### PR TITLE
Update translation files

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -45,6 +45,7 @@ hr
 hu
 hy
 id
+ie
 is
 it
 ja

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,8 +1,23 @@
 # List of source files containing translatable strings.
 # Please keep this file sorted alphabetically.
 panels/applications/cc-applications-panel.c
+panels/applications/cc-applications-panel.h
 panels/applications/cc-applications-panel.ui
+panels/applications/cc-applications-row.c
+panels/applications/cc-applications-row.h
+panels/applications/cc-applications-row.ui
+panels/applications/cc-info-row.c
+panels/applications/cc-info-row.h
+panels/applications/cc-info-row.ui
+panels/applications/cc-snap-row.c
+panels/applications/cc-snap-row.h
+panels/applications/cc-snap-row.ui
+panels/applications/cc-toggle-row.c
+panels/applications/cc-toggle-row.h
+panels/applications/cc-toggle-row.ui
 panels/applications/gnome-applications-panel.desktop.in.in
+panels/applications/search.c
+panels/applications/search.h
 panels/background/bg-colors-source.c
 panels/background/cc-background-chooser.c
 panels/background/cc-background-chooser.ui
@@ -32,12 +47,16 @@ panels/common/cc-time-editor.ui
 panels/common/cc-time-entry.c
 panels/common/cc-util.c
 panels/common/hostname-helper.c
-panels/connectivity/cc-connectivity-panel.ui
-panels/connectivity/gnome-connectivity-panel.desktop.in.in
 panels/datetime/cc-datetime-panel.c
+panels/datetime/cc-datetime-panel.h
 panels/datetime/cc-datetime-panel.ui
+panels/datetime/cc-timezone-map.c
+panels/datetime/cc-timezone-map.h
+panels/datetime/date-endian.h
 panels/datetime/gnome-datetime-panel.desktop.in.in
 panels/datetime/org.gnome.controlcenter.datetime.policy.in
+panels/datetime/tz.c
+panels/datetime/tz.h
 panels/default-apps/cc-default-apps-panel.ui
 panels/default-apps/gnome-default-apps-panel.desktop.in.in
 panels/diagnostics/cc-diagnostics-panel.c
@@ -86,8 +105,13 @@ panels/location/cc-location-panel.ui
 panels/location/gnome-location-panel.desktop.in.in
 panels/microphone/cc-microphone-panel.ui
 panels/microphone/gnome-microphone-panel.desktop.in.in
+panels/mouse/cc-mouse-caps-helper.c
+panels/mouse/cc-mouse-caps-helper.h
+panels/mouse/cc-mouse-panel.c
+panels/mouse/cc-mouse-panel.h
 panels/mouse/cc-mouse-panel.ui
 panels/mouse/cc-mouse-test.c
+panels/mouse/cc-mouse-test.h
 panels/mouse/cc-mouse-test.ui
 panels/mouse/gnome-mouse-panel.desktop.in.in
 panels/multitasking/cc-multitasking-panel.ui
@@ -284,6 +308,10 @@ panels/wacom/cc-wacom-stylus-page.ui
 panels/wacom/cc-wacom-tool.c
 panels/wacom/gnome-wacom-panel.desktop.in.in
 panels/wacom/gsd-wacom-key-shortcut-button.c
+panels/windows/cc-windows-panel.c
+panels/windows/cc-windows-panel.h
+panels/windows/cc-windows-panel.ui
+panels/windows/gnome-windows-panel.desktop.in.in
 panels/wwan/cc-wwan-apn-dialog.c
 panels/wwan/cc-wwan-apn-dialog.ui
 panels/wwan/cc-wwan-data.c

--- a/po/ab.po
+++ b/po/ab.po
@@ -1,8 +1,7 @@
 msgid ""
 msgstr ""
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-07-22 06:47+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "Last-Translator: Нанба Наала <naala-nanba@rambler.ru>\n"
 "Language-Team: Abkhazian <daniel.abzakh@gmail.com>\n"
 "Language: ab\n"
@@ -10,121 +9,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#: panels/applications/cc-applications-panel.c:790
-msgid "System Bus"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:790
-#: panels/applications/cc-applications-panel.c:792
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:810
-msgid "Full access"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:792
-msgid "Session Bus"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:796
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:796
-msgid "Full access to /dev"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:800
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:800
-msgid "Has network access"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:807
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Home"
-
-#: panels/applications/cc-applications-panel.c:807
-#: panels/applications/cc-applications-panel.c:812
-msgid "Read-only"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:810
-#: panels/applications/cc-applications-panel.c:812
-msgid "File System"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:816
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:816
-msgid "Can change settings"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:818
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1154
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] ""
-msgstr[1] ""
-
-#: panels/applications/cc-applications-panel.c:1161
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> ахархәара аиуоит анаҩстәи афаилқәа рыхкқәеи азхьарԥшқәеи раартразы."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1213
-#, c-format
-msgid "%s of disk space used"
-msgstr ""
+"X-DamnedLies-Scope: partial\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1377
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
-msgstr ""
+msgstr "Аԥшькәа"
 
 #: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
-msgstr ""
+msgstr "Аԥшьқәа ыҟаӡам"
 
 #: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr ""
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
-msgstr ""
+msgstr "Аартра"
 
 #: panels/applications/cc-applications-panel.ui:94
 msgid "View Details"
-msgstr ""
+msgstr "Аԥкаарақәа"
 
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
@@ -135,31 +43,20 @@ msgstr ""
 #: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
-msgstr ""
+msgstr "Аҧшаара"
 
 #: panels/applications/cc-applications-panel.ui:113
 #: panels/applications/cc-applications-panel.ui:120
 msgid "Receive system searches and send results."
-msgstr ""
+msgstr "Асистемаҟны аԥшаара алҵшәақәа риура, насгьы урҭ рышьҭра"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr ""
 
@@ -170,144 +67,152 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.ui:127
 msgid "Show system notifications."
-msgstr ""
+msgstr "Асистематә цҳамҭақәа рырбара. "
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
-msgstr ""
+msgid "Run in Background"
+msgstr "Аусуратә ишәа адыԥшылахә ада"
 
 #: panels/applications/cc-applications-panel.ui:134
 msgid "Allow activity when the app is closed."
-msgstr ""
+msgstr "Активра азин аҭара, аԥшьы анарку."
 
 #: panels/applications/cc-applications-panel.ui:140
-msgid "Change Wallpaper"
+msgid "Screenshots"
 msgstr ""
 
 #: panels/applications/cc-applications-panel.ui:141
-msgid "Change the desktop wallpaper."
-msgstr ""
+msgid "Take pictures of the screen at any time."
+msgstr "Иаразнактәи аекран аҭыхра ианакәзаалак аҟаҵара"
 
 #: panels/applications/cc-applications-panel.ui:147
-#: panels/applications/cc-applications-panel.ui:154
-msgid "Sounds"
-msgstr ""
+msgid "Change Wallpaper"
+msgstr "Адыԥшылахә аԥсахра"
 
 #: panels/applications/cc-applications-panel.ui:148
-#: panels/applications/cc-applications-panel.ui:155
-msgid "Reproduce sounds."
-msgstr ""
+msgid "Change the desktop wallpaper."
+msgstr "Аусуратә ишәа адыԥшылахә аԥсахра"
 
+#: panels/applications/cc-applications-panel.ui:154
 #: panels/applications/cc-applications-panel.ui:161
-msgid "Inhibit Shortcuts"
-msgstr ""
+msgid "Sounds"
+msgstr "Абжьқәа"
 
+#: panels/applications/cc-applications-panel.ui:155
 #: panels/applications/cc-applications-panel.ui:162
-msgid "Block standard keyboard shortcuts."
-msgstr ""
+msgid "Reproduce sounds."
+msgstr "Абжьқәа рҿакра"
 
 #: panels/applications/cc-applications-panel.ui:168
-#: panels/applications/cc-applications-panel.ui:175
-#: panels/camera/gnome-camera-panel.desktop.in.in:3
-msgid "Camera"
-msgstr ""
+msgid "Inhibit Shortcuts"
+msgstr "Арыдқәа реилаҵа рақәиҭымтәра"
 
 #: panels/applications/cc-applications-panel.ui:169
-#: panels/applications/cc-applications-panel.ui:176
-msgid "Take pictures with the camera."
-msgstr ""
+msgid "Block standard keyboard shortcuts."
+msgstr "Арыдқәа истандарту реицааира аанкылара"
 
+#: panels/applications/cc-applications-panel.ui:175
 #: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Акамера"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Акамера ацхыраарала аҭыхымҭақәа рыҟаҵара"
+
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
-msgstr ""
+msgstr "Амикрофон"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
-msgstr ""
+msgstr "Амикрофон ацхыраарала абжьы анҵара"
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
-msgstr ""
+msgstr "Шәахьыҟоу аҭыԥ асервисқаә"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
-msgstr ""
+msgstr "Аиҿартәыра ҭыԥс аҟазаара аазырԥшуа адыррақәа рахь анеира"
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
-msgstr ""
+msgstr "Иҭазоу азинқәа"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
-msgstr ""
+msgstr "Аԥшьы иаҭаху асистема ахь анеира"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "Афаилқәеи &amp; азхьарԥшқәеи реидгыла"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
-msgstr ""
+msgstr "Аҵәахырҭа"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:108
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
-msgstr ""
+msgstr "Алҵшәақәа ԥшааӡам"
 
-#: panels/applications/cc-applications-panel.ui:304
+#: panels/applications/cc-applications-panel.ui:311
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
 #: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "Афаилқәеи азхьарԥшқәеи реидгыла"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
-msgstr ""
+msgstr "Аҧшьы"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Зегьы</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr ""
 
@@ -315,72 +220,8 @@ msgstr ""
 msgid "Control various application permissions and settings"
 msgstr ""
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
-msgstr ""
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr ""
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:209
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr ""
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr ""
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr ""
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Аусуратә ишәа адыԥшылахә ада"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
 msgstr ""
 
 #: panels/background/cc-background-panel.ui:9
@@ -388,9 +229,13 @@ msgid "Style"
 msgstr ""
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
-msgstr ""
+msgstr "default:mm"
 
 #: panels/background/cc-background-panel.ui:79
 msgid "Dark"
@@ -398,7 +243,7 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:98
 msgid "Background"
-msgstr ""
+msgstr "Ақәыԥшылара"
 
 #: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
@@ -412,7 +257,6 @@ msgstr "Аԥшра"
 msgid "Change your background image or the UI colors"
 msgstr ""
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -425,7 +269,7 @@ msgstr ""
 #: panels/universal-access/cc-cursor-blinking-dialog.ui:15
 #: panels/universal-access/cc-repeat-keys-dialog.ui:15
 msgid "Enable"
-msgstr ""
+msgstr "Иаҿакуп"
 
 #: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
@@ -463,9 +307,7 @@ msgstr "Аппараттә авиарежим аҿакуп"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -473,7 +315,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr ""
@@ -502,236 +343,49 @@ msgstr ""
 msgid "Protect your pictures"
 msgstr ""
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
-msgstr ""
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr ""
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr ""
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr ""
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr ""
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr ""
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr ""
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr ""
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr ""
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
 msgstr ""
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr ""
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Аԥыхра"
+
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
-msgstr ""
+msgstr "_Алагара"
 
 #. This resumes the calibration process
 #: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
-msgstr ""
+msgstr "_Ацҵара"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
-msgstr ""
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr ""
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr ""
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr ""
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr ""
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr ""
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr ""
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr ""
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr ""
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr ""
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr ""
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr ""
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr ""
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr ""
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Афаилқәа зегьы"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr ""
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr ""
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr ""
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr ""
+msgstr "_Ихиоуп"
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -854,23 +508,20 @@ msgstr ""
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
-msgstr ""
+msgstr "_Афаил аимпорт азура"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
-msgstr ""
+msgstr "_Ацҵара"
 
 #: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr ""
 
@@ -880,7 +531,7 @@ msgstr ""
 
 #: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
-msgstr ""
+msgstr "_Ахархәаҩцәа зегь рзы ашьақәыргылара"
 
 #: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
 #: panels/color/cc-color-panel.ui:484
@@ -889,11 +540,11 @@ msgstr ""
 
 #: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
-msgstr ""
+msgstr "_Аҿакра"
 
 #: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
-msgstr ""
+msgstr "_Аҷыдахәра ацҵара"
 
 #: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
@@ -971,7 +622,7 @@ msgstr ""
 
 #: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
-msgstr ""
+msgstr "30 минуҭ"
 
 #: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
@@ -980,7 +631,7 @@ msgstr ""
 
 #: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
-msgstr ""
+msgstr "15 минуҭ"
 
 #: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
@@ -1002,82 +653,6 @@ msgstr ""
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr ""
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr ""
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr ""
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr ""
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr ""
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr ""
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr ""
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr ""
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr ""
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr ""
@@ -1087,13 +662,8 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
-msgstr ""
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
 msgstr ""
 
 #: panels/common/cc-language-chooser.ui:5
@@ -1102,19 +672,14 @@ msgstr ""
 
 #: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
-msgstr ""
+msgstr "_Алхра"
 
 #: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr ""
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
-msgstr ""
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
 msgstr ""
 
 #: panels/common/cc-permission-infobar.ui:42
@@ -1145,175 +710,30 @@ msgstr ""
 msgid "Decrement Minute"
 msgstr ""
 
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr ""
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Иацы"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%-d %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] ""
-msgstr[1] ""
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] ""
-msgstr[1] ""
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr ""
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr ""
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr ""
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr ""
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr ""
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr ""
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr ""
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr ""
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr ""
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%-d %B %Y, %l∶%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%-d %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr ""
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr ""
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr ""
-
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
-msgstr ""
+msgstr "Аамҭарбеи  аамҭеи"
 
 #: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
-msgstr ""
+msgstr "Ашықәс"
 
 #: panels/datetime/cc-datetime-panel.ui:66
 msgid "Month"
-msgstr ""
+msgstr "Амз"
 
 #: panels/datetime/cc-datetime-panel.ui:71
 msgid "January"
-msgstr ""
+msgstr "Ажьырныҳәа"
 
 #: panels/datetime/cc-datetime-panel.ui:72
 msgid "February"
-msgstr ""
+msgstr "Жәабран"
 
 #: panels/datetime/cc-datetime-panel.ui:73
 msgid "March"
-msgstr ""
+msgstr "Хәажәкыра"
 
 #: panels/datetime/cc-datetime-panel.ui:74
 msgid "April"
@@ -1321,15 +741,15 @@ msgstr "Мшаԥымза"
 
 #: panels/datetime/cc-datetime-panel.ui:75
 msgid "May"
-msgstr ""
+msgstr "Лаҵара"
 
 #: panels/datetime/cc-datetime-panel.ui:76
 msgid "June"
-msgstr ""
+msgstr "Рашәара"
 
 #: panels/datetime/cc-datetime-panel.ui:77
 msgid "July"
-msgstr ""
+msgstr "Ԥхынгәы"
 
 #: panels/datetime/cc-datetime-panel.ui:78
 msgid "August"
@@ -1337,23 +757,23 @@ msgstr "Нанҳәа"
 
 #: panels/datetime/cc-datetime-panel.ui:79
 msgid "September"
-msgstr ""
+msgstr "Цәыббра"
 
 #: panels/datetime/cc-datetime-panel.ui:80
 msgid "October"
-msgstr ""
+msgstr "Жьҭаара"
 
 #: panels/datetime/cc-datetime-panel.ui:81
 msgid "November"
-msgstr ""
+msgstr "Абҵара"
 
 #: panels/datetime/cc-datetime-panel.ui:82
 msgid "December"
-msgstr ""
+msgstr "Ԥхынҷкәын"
 
 #: panels/datetime/cc-datetime-panel.ui:92
 msgid "Day"
-msgstr ""
+msgstr "Амш"
 
 #: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
@@ -1361,7 +781,7 @@ msgstr ""
 
 #: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
-msgstr ""
+msgstr "Ақалақь аҟны аԥшаара"
 
 #: panels/datetime/cc-datetime-panel.ui:164
 msgid "Automatic _Date &amp; Time"
@@ -1373,7 +793,7 @@ msgstr ""
 
 #: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
-msgstr ""
+msgstr "Аамҭарбеи  _аамҭеи"
 
 #: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
@@ -1383,15 +803,11 @@ msgstr "Автоматикла _ асааҭзона ашьақәыргылара
 msgid "Requires location services enabled and internet access"
 msgstr ""
 
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
-#: panels/location/cc-location-panel.ui:9 panels/lock/cc-lock-panel.ui:39
-#: panels/lock/cc-lock-panel.ui:75 panels/lock/cc-lock-panel.ui:95
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Иаҿакуп"
 
@@ -1399,15 +815,42 @@ msgstr "Иаҿакуп"
 msgid "Time Z_one"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "_Аужьра:"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Аамҭарба"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+msgid "Seconds"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Амзар"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Ахатә номер"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr ""
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr ""
@@ -1422,7 +865,7 @@ msgstr ""
 
 #: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
-msgstr ""
+msgstr "_Аинтернет"
 
 #: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
@@ -1430,7 +873,7 @@ msgstr ""
 
 #: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
-msgstr ""
+msgstr "_Амзар"
 
 #: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
@@ -1443,27 +886,18 @@ msgstr "_Авидео"
 #: panels/default-apps/cc-default-apps-panel.ui:134
 #: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
-msgstr ""
+msgstr "_Аҧшранҵа"
 
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
 msgid "Default Applications"
-msgstr ""
+msgstr "Аҧшьқәа ишыҟоу еиҧш"
 
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
 msgid "Configure Default Applications"
-msgstr ""
+msgstr "Аҧшьқәа ишыҟоу еиҧш рырхиара"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
-msgstr ""
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
 msgstr ""
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
@@ -1476,55 +910,20 @@ msgstr "_Автоматикатә цҳамҭа агхақәа ирызкны"
 
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
 msgid "Diagnostics"
-msgstr ""
+msgstr "Адиагностика"
 
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
 msgid "Report your problems"
 msgstr ""
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
-msgstr ""
-
-#: panels/display/cc-display-panel.c:516
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Иаҿакуп"
-
-#: panels/display/cc-display-panel.c:518 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr ""
-
-#: panels/display/cc-display-panel.c:955
-msgid "Apply Changes?"
-msgstr ""
-
-#: panels/display/cc-display-panel.c:960
-msgid "Changes Cannot be Applied"
-msgstr ""
-
-#: panels/display/cc-display-panel.c:962
-msgid "This could be due to hardware limitations."
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
-msgstr ""
+msgstr "_Ахархәара"
 
 #: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
 #: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
@@ -1535,7 +934,7 @@ msgstr ""
 #: panels/wacom/cc-wacom-stylus-page.ui:136
 #: panels/wwan/cc-wwan-apn-dialog.ui:21
 msgid "Back"
-msgstr ""
+msgstr "Шьҭахьҟа"
 
 #: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
@@ -1548,11 +947,11 @@ msgstr ""
 #. 'Join' as in 'Join displays'
 #: panels/display/cc-display-panel.ui:120
 msgid "Join"
-msgstr ""
+msgstr "Аҽадҵара"
 
 #: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
-msgstr ""
+msgstr "Асаркьа"
 
 #: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
@@ -1560,39 +959,14 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
-msgstr ""
+msgstr "Ихадоу адисплеи"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
 #: panels/display/cc-display-panel.ui:177
 #: panels/display/cc-display-panel.ui:228
 #: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr ""
+msgstr "Уахынлатәи алашара"
 
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
@@ -1618,6 +992,16 @@ msgctxt "display setting"
 msgid "Scale"
 msgstr ""
 
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
 msgstr ""
@@ -1631,7 +1015,7 @@ msgstr ""
 #. Inhibit the redshift functionality until the next day starts
 #: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
-msgstr " Аамҭала уаҵәынӡа иаҿыхуп"
+msgstr "Аамҭала уаҵәынӡа иаҿыхуп"
 
 #. This cancels the redshift inhibit.
 #: panels/display/cc-night-light-page.ui:72
@@ -1646,7 +1030,7 @@ msgstr ""
 
 #: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
-msgstr ""
+msgstr "Аихшанҵа"
 
 #: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
@@ -1698,7 +1082,7 @@ msgstr ""
 
 #: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
-msgstr ""
+msgstr "Аԥштәытә шоура"
 
 #: panels/display/gnome-display-panel.desktop.in.in:3
 msgid "Displays"
@@ -1708,71 +1092,10 @@ msgstr ""
 msgid "Choose how to use connected monitors and projectors"
 msgstr ""
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:106
-msgid "Secure Boot is Active"
-msgstr "Ишәарҭадароу аҭагалара активуп"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:76
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:82
-msgid "Secure Boot Has Problems"
-msgstr ""
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:86
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:89
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:92
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-panel.c:118
-msgid "Secure Boot is Turned Off"
-msgstr ""
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:102
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:105
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
 msgstr ""
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
@@ -1788,434 +1111,38 @@ msgstr ""
 "Иацҵаны аинформациа шәоурц азы амаруга аԥҵаҩы ,мамзар ИТ -ацхыраара амаҵзура "
 "шәрыдҵаала."
 
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:70
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-panel.c:433
-msgid "No Protection"
-msgstr "Хьчарада"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:99
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:111
-#: panels/firmware-security/cc-firmware-security-dialog.ui:80
-#: panels/firmware-security/cc-firmware-security-panel.c:440
-msgid "Minimal Protection"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:112
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:127
-#: panels/firmware-security/cc-firmware-security-dialog.ui:94
-#: panels/firmware-security/cc-firmware-security-panel.c:447
-msgid "Basic Protection"
-msgstr "Абазатә ҽацәыхьчара"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:128
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:146
-#: panels/firmware-security/cc-firmware-security-dialog.ui:108
-#: panels/firmware-security/cc-firmware-security-panel.c:454
-msgid "Extended Protection"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:147
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:156
-msgid "Error: unable to determine HSI level."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:157
-msgid "Error: unable to determine Incorrect HSI level."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:241
-msgid "Minimal Security Protections"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:246
-msgid "Basic Security Protections"
-msgstr "Абазатә ашәарҭадаратә уснагӡатәқәа"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:251
-msgid "Extended Security Protections"
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
 msgid "Security Level"
 msgstr ""
 
-#: panels/firmware-security/cc-firmware-security-panel.c:107
-msgid "Protected against malicious software when the device starts."
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
 msgstr ""
 
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot has Problems"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
 msgstr ""
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Some protection when the device is started."
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
 msgstr ""
 
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "No protection when the device is started."
-msgstr "Аиҿыртәара аҿакраан хьчарада"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:434
-msgid "Highly exposed to security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:441
-msgid "Limited protection against simple security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:448
-msgid "Protected against common security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:455
-#: panels/firmware-security/cc-firmware-security-panel.c:462
-msgid "Protected against a wide range of security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:461
-msgid "Comprehensive Protection"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.ui:138
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr ""
 
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:38
-msgid "SPI write"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Ашәарҭадара"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
 msgstr ""
 
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:40
-msgid "SPI lock"
-msgstr ""
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "SPI BIOS region"
-msgstr ""
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:44
-msgid "SPI BIOS Descriptor"
-msgstr ""
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:46
-msgid "Pre-boot DMA protection is"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:48
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:51
-msgid "Intel BootGuard verified boot"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:54
-msgid "Intel BootGuard ACM protected"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Intel BootGuard error policy"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * OTP = one time programmable
-#: panels/firmware-security/cc-firmware-security-utils.c:60
-msgid "Intel BootGuard OTP fuse"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:63
-msgid "Intel CET"
-msgstr "Intel CET"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:66
-msgid "Intel CET Active"
-msgstr "Intel CET иактивуп"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:70
-msgid "Encrypted RAM"
-msgstr ""
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:73
-msgid "IOMMU device protection"
-msgstr ""
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:75
-msgid "Kernel lockdown"
-msgstr ""
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:77
-msgid "Kernel tainted"
-msgstr ""
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:79
-msgid "Linux swap"
-msgstr ""
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:81
-msgid "Suspend-to-ram"
-msgstr ""
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:83
-msgid "Suspend-to-idle"
-msgstr ""
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "UEFI platform key"
-msgstr ""
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:87
-msgid "Secure boot"
-msgstr "Ишәарҭадароу аҭагалара"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:89
-msgid "All TPM PCRs are"
-msgstr ""
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "TPM PCR0 reconstruction"
-msgstr ""
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:93
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:95
-msgid "MEI manufacturing mode"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the
-#. * "override" is the physical PIN that can be driven to
-#. * logic high -- luckily it is probably not accessible to
-#. * end users on consumer boards
-#: panels/firmware-security/cc-firmware-security-utils.c:100
-msgid "MEI override"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "MEI version"
-msgstr "Аверсиа MEI"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:104
-msgid "Firmware updates"
-msgstr ""
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:106
-msgid "Firmware attestation"
-msgstr "Аҭаӡахра аттестациа азура"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:108
-msgid "fwupd plugins"
-msgstr ""
-
-#. TRANSLATORS: Title: Direct Connect Interface (DCI) allows
-#. * debugging of Intel processors using the USB3 port
-#: panels/firmware-security/cc-firmware-security-utils.c:111
-#: panels/firmware-security/cc-firmware-security-utils.c:112
-msgid "Intel DCI debugger"
-msgstr ""
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:114
-msgid "Pre-boot DMA protection"
-msgstr ""
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:116
-msgid "Supported CPU"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:150
-msgid "IOMMU device protection enabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:156
-msgid "IOMMU device protection disabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:176
-msgid "Kernel is no longer tainted"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:182
-msgid "Kernel is tainted"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:188
-msgid "Kernel lockdown disabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:194
-msgid "Kernel lockdown enabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:200
-msgid "Pre-boot DMA protection is disabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Pre-boot DMA protection is enabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:212
-msgid "Secure Boot disabled"
-msgstr "Ишәарҭадароу аҭагалара аҿыхуп"
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:218
-msgid "Secure Boot enabled"
-msgstr "Ишәарҭадароу аҭагалара аҿакуп"
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:224
-msgid "All TPM PCRs are valid"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:230
-msgid "All TPM PCRs are now valid"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:236
-msgid "A TPM PCR is now an invalid value"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "TPM PCR0 reconstruction is invalid"
-msgstr ""
-
-#: panels/info-overview/cc-info-overview-panel.c:296
-#: panels/info-overview/cc-info-overview-panel.c:320
-#: panels/info-overview/cc-info-overview-panel.c:366
-#: panels/info-overview/cc-info-overview-panel.c:396
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr ""
-
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:328
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr ""
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:343
-#, c-format
-msgid "64-bit"
-msgstr ""
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:346
-#, c-format
-msgid "32-bit"
-msgstr ""
-
-#: panels/info-overview/cc-info-overview-panel.c:605
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:609
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:611
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr ""
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:689
-msgid "Not Available"
-msgstr ""
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
 msgstr ""
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
@@ -2237,7 +1164,7 @@ msgstr ""
 
 #: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
-msgstr ""
+msgstr "Аграфика"
 
 #: panels/info-overview/cc-info-overview-panel.ui:82
 msgid "Disk Capacity"
@@ -2252,62 +1179,62 @@ msgstr ""
 msgid "OS Name"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Аверсиа GNOME"
 
 #. translators: this is a placeholder while the GNOME version is being fetched
-#: panels/info-overview/cc-info-overview-panel.ui:116
+#: panels/info-overview/cc-info-overview-panel.ui:125
 msgid "Loading…"
-msgstr ""
+msgstr "Аҭагалара..."
 
-#: panels/info-overview/cc-info-overview-panel.ui:124
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:132
-msgid "Virtualization"
-msgstr ""
-
 #: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Авиртуалра"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:165
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:181
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:187
+#: panels/info-overview/cc-info-overview-panel.ui:196
 msgid "Device name"
-msgstr ""
+msgstr "Аиҿартәыра ахьӡ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:201
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
-msgstr ""
+msgstr "_Ахьӡԥсахра"
 
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
 msgid "About"
-msgstr ""
+msgstr "Аԥшьы иазкны"
 
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr ""
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2383,6 +1310,12 @@ msgstr ""
 msgid "Launch help browser"
 msgstr ""
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Архиарақәа"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr ""
@@ -2404,13 +1337,13 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr ""
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr ""
 
 #: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
-msgstr ""
+msgstr "Асеанс ахырқәшара"
 
 #: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
@@ -2419,7 +1352,7 @@ msgstr ""
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
 msgid "Accessibility"
-msgstr ""
+msgstr "Ахархәара аманшәалара"
 
 #: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
@@ -2427,11 +1360,11 @@ msgstr "Аизҳара  аҿакра, мамзар аҿыхра"
 
 #: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
-msgstr ""
+msgstr "Ардура"
 
 #: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
-msgstr ""
+msgstr "Архәҷра"
 
 #: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
@@ -2453,15 +1386,6 @@ msgstr ""
 msgid "High contrast on or off"
 msgstr "Иҳараку аиҿагылара аҿакра, мамзар аҿыхра"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr ""
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr ""
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr ""
@@ -2476,7 +1400,7 @@ msgstr ""
 
 #: panels/keyboard/cc-input-row.ui:20
 msgid "Options"
-msgstr ""
+msgstr "Ахышәарақәа"
 
 #: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
@@ -2488,103 +1412,14 @@ msgstr ""
 
 #: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
-msgstr ""
+msgstr "Ахышәарақәа"
 
 #: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr ""
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
 msgstr ""
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
@@ -2593,7 +1428,7 @@ msgstr ""
 
 #: panels/keyboard/cc-keyboard-panel.ui:18
 msgid "Includes keyboard layouts and input methods."
-msgstr ""
+msgstr "Иаҿанакуеит арыдыркыра аихшареи аҭагалара аметодқәеи."
 
 #: panels/keyboard/cc-keyboard-panel.ui:28
 msgid "Input Source Switching"
@@ -2607,50 +1442,28 @@ msgstr ""
 msgid "Switch input sources _individually for each window"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "Арыдқәа реилаҵа"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] ""
-msgstr[1] ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
 msgstr ""
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
@@ -2689,47 +1502,19 @@ msgstr ""
 msgid "No keyboard shortcut found"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr ""
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
-msgstr ""
+msgstr "_Аныхра"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
 msgid "Re_place"
-msgstr ""
+msgstr "Аԥса_хра"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
-msgstr ""
+msgstr "_Ашьақәыргылара"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
@@ -2741,7 +1526,7 @@ msgstr ""
 #: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
-msgstr ""
+msgstr "Ахьӡ"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
@@ -2757,15 +1542,19 @@ msgstr ""
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
-msgstr ""
+msgstr "Мап"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr ""
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
-msgstr ""
+msgstr "Арыдыркыра"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
 msgid ""
@@ -2773,7 +1562,6 @@ msgid ""
 "and input sources"
 msgstr ""
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2806,172 +1594,8 @@ msgstr ""
 msgid "Protect your location information"
 msgstr ""
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
-msgstr ""
-"Автоматикла аекран аусура амҩакра шәара шәаарӡа акомпиутер ахь анеира "
-"ԥнарҟәҟәоит"
-
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "Автоматикла _аекран аусура аанкылара"
-
-#: panels/lock/cc-lock-panel.ui:49
-msgid "Automatic _Screen Lock Delay"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:50
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:68
-msgid "Show _Notifications on Lock Screen"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:86
-msgid "Forbid new _USB devices"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:87
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr ""
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr ""
-
-#. Translators: Search terms to find the Lock panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-msgid "screen;lock;private;privacy;"
 msgstr ""
 
 #: panels/microphone/cc-microphone-panel.ui:23
@@ -2999,7 +1623,6 @@ msgstr ""
 msgid "Protect your conversations"
 msgstr ""
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
@@ -3011,7 +1634,7 @@ msgstr ""
 #: panels/mouse/cc-mouse-panel.ui:23
 #: panels/multitasking/cc-multitasking-panel.ui:9
 msgid "General"
-msgstr ""
+msgstr "Зегьы ирзаку"
 
 #: panels/mouse/cc-mouse-panel.ui:26
 msgid "Primary Button"
@@ -3023,86 +1646,137 @@ msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
-msgstr ""
+msgstr "Армарахь"
 
 #: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Арӷьарахь"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Аҭыӡҭыԥ"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Иаҿакуп"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
-msgstr ""
+msgstr "Акьыснырратә панель"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
 msgstr ""
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
 msgstr ""
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
@@ -3114,14 +1788,13 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:15
 msgid "_Hot Corner"
-msgstr ""
+msgstr "_Ицоу акьаҿ"
 
 #: panels/multitasking/cc-multitasking-panel.ui:16
 msgid "Touch the top-left corner to open the Activities Overview."
@@ -3158,7 +1831,7 @@ msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:108
 msgid "_Number of Workspaces"
-msgstr ""
+msgstr "_ Аишәақәа рхыҧхьаӡара"
 
 #: panels/multitasking/cc-multitasking-panel.ui:124
 msgid "Multi-Monitor"
@@ -3178,11 +1851,11 @@ msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:190
 msgid "Include applications from all _workspaces"
-msgstr ""
+msgstr "Аишәақәа зегьы рҟынтәи аԥшьқәа рҿакра"
 
 #: panels/multitasking/cc-multitasking-panel.ui:204
 msgid "Include applications from the _current workspace only"
-msgstr ""
+msgstr "Иҟоу аишәа _заҵәык аҟынтәи аԥшьы аҿакра"
 
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
 msgid "Multitasking"
@@ -3192,26 +1865,16 @@ msgstr ""
 msgid "Manage preferences for productivity and multitasking"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
-msgstr ""
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
 msgstr ""
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr ""
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:56
-#: panels/network/connection-editor/net-connection-editor.c:586
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
@@ -3219,61 +1882,20 @@ msgstr "VPN"
 msgid "Add connection"
 msgstr ""
 
-#: panels/network/cc-network-panel.ui:73
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr ""
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr ""
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
-msgstr ""
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr ""
+msgstr "Ахышәарақәа...."
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3300,13 +1922,13 @@ msgstr ""
 #. Translators: This is a password needed for printing.
 #: panels/network/cc-wifi-hotspot-dialog.ui:75
 #: panels/printers/new-printer-dialog.ui:338
-#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:391
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
 #: panels/user-accounts/cc-add-user-dialog.ui:364
 #: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
-msgstr ""
+msgstr "Ажәамаӡа"
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
@@ -3318,21 +1940,7 @@ msgstr "Ажәамаӡа автоматикла агенерациа азура"
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
-msgstr ""
-
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr ""
+msgstr "_Аҿакра"
 
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
@@ -3376,88 +1984,15 @@ msgstr ""
 
 #: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
+msgstr "NetworkManager аус арузароуп"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr ""
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Ашәарҭадара 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Ашәарҭадара"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr ""
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr ""
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3467,220 +2002,60 @@ msgid_plural "%i days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr ""
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Аҭыӡҭыԥ IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Аҭыӡҭыԥ IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP-Аҭыӡҭыԥ"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "Автоматикала"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr ""
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
-msgstr ""
+msgstr "Асигнал амчра"
 
 #: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
-msgstr ""
+msgstr "Адыррақәа рышьҭра аццакыра"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Ашәарҭадара"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Аҭыӡҭыԥ IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Аҭыӡҭыԥ IPv6"
 
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Аппараттә ҭыӡҭыԥ"
 
 #: panels/network/connection-editor/details-page.ui:142
 msgid "Supported Frequencies"
-msgstr ""
+msgstr "Адкылара змоу  аҵыс-ҵысра"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
-msgstr ""
+msgstr "Ахырхарҭа ишыҟоу еиԥш"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
-msgstr ""
+msgstr "Аҵыхәтәантәи ахархәара"
 
 #: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
-msgstr ""
+msgstr "Автоматла аҽаҿакра"
 
 #: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
-msgstr ""
+msgstr "Егьырҭ ахархәаҩцәа рзы анеишьа маншәаланы аҟаҵара"
 
 #: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
@@ -3694,7 +2069,7 @@ msgstr ""
 #: panels/network/connection-editor/ethernet-page.ui:21
 #: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
-msgstr ""
+msgstr "_Ахьӡ"
 
 #: panels/network/connection-editor/ethernet-page.ui:42
 #: panels/network/connection-editor/wifi-page.ui:51
@@ -3729,7 +2104,7 @@ msgstr ""
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Напыла"
 
@@ -3773,9 +2148,8 @@ msgstr ""
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Автоматикала"
 
@@ -3787,7 +2161,7 @@ msgstr "Автоматикалатәи DNS"
 #: panels/network/connection-editor/ip4-page.ui:192
 #: panels/network/connection-editor/ip6-page.ui:202
 msgid "DNS server address(es)"
-msgstr "DNS асервис аҭыӡҭыԥ "
+msgstr "DNS асервис аҭыӡҭыԥ"
 
 #: panels/network/connection-editor/ip4-page.ui:200
 #: panels/network/connection-editor/ip6-page.ui:210
@@ -3828,82 +2202,9 @@ msgstr "Автоматикалатәи DHCP мацара"
 msgid "Prefix"
 msgstr ""
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr ""
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Ашәарҭадара"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr ""
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3917,94 +2218,35 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr ""
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr ""
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr ""
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr ""
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr ""
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "Иацы"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr ""
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
-msgstr ""
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1047
-msgid "Known Wi-Fi Networks"
-msgstr ""
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1079
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1235
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1238
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Иҭелдоу аиҿартәыра анеира аҭыԥ арежим аднакылаӡом"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
 msgstr ""
 
 #: panels/network/network-bluetooth.ui:11
@@ -4023,7 +2265,11 @@ msgstr "IMEI"
 
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
-msgstr ""
+msgstr "Адгалаҩ"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-Аҭыӡҭыԥ"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4047,7 +2293,7 @@ msgstr ""
 
 #: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
-msgstr ""
+msgstr "_Аиқәҳәаларҭақәа рызхьамҧшра"
 
 #: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
@@ -4102,294 +2348,11 @@ msgstr ""
 
 #: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
-msgstr ""
+msgstr "Wi-Fi анеирҭа ҭыԥ аҿакра"
 
 #: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr ""
+msgstr "_Еилкаау  Wi-Fi аҳақәа"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4413,7 +2376,7 @@ msgstr "Зхаҭареилкаау"
 
 #: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
-msgstr ""
+msgstr "Ииааланы насгьы гәҵәыла"
 
 #: panels/network/wireless-security/eap-method-fast.ui:46
 #: panels/network/wireless-security/eap-method-peap.ui:49
@@ -4423,7 +2386,7 @@ msgstr "И_хьӡыдоу ахаҭареилкаара"
 
 #: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
-msgstr ""
+msgstr "_Афаил PAC"
 
 #: panels/network/wireless-security/eap-method-fast.ui:79
 msgid "Choose a PAC file"
@@ -4439,19 +2402,11 @@ msgstr ""
 msgid "Allow automatic PAC pro_visioning"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr ""
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
-msgstr ""
+msgstr "_Ахархәаҩ ихьӡ"
 
 #: panels/network/wireless-security/eap-method-leap.ui:23
 #: panels/network/wireless-security/eap-method-simple.ui:23
@@ -4461,7 +2416,7 @@ msgstr ""
 #: panels/sharing/cc-sharing-panel.ui:152
 #: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
-msgstr ""
+msgstr "_Ажәамаӡа"
 
 #: panels/network/wireless-security/eap-method-leap.ui:44
 #: panels/network/wireless-security/eap-method-simple.ui:61
@@ -4470,15 +2425,6 @@ msgstr ""
 #: panels/network/wireless-security/ws-sae.ui:45
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
 msgstr ""
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
@@ -4502,7 +2448,6 @@ msgid "C_A certificate"
 msgstr ""
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4518,58 +2463,6 @@ msgstr ""
 msgid "PEAP _version"
 msgstr "_Аверсиа PEAP"
 
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr ""
-
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr ""
@@ -4584,15 +2477,6 @@ msgstr ""
 
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
 msgstr ""
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
@@ -4614,16 +2498,17 @@ msgstr "CHAP"
 #: panels/network/wireless-security/eap-method-ttls.ui:68
 #: panels/user-accounts/data/join-dialog.ui:90
 msgid "_Domain"
-msgstr ""
-
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr ""
+msgstr "_Адомен"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4651,55 +2536,9 @@ msgstr ""
 msgid "Au_thentication"
 msgstr "А_хаҭареилкаара"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr ""
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr ""
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr ""
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr ""
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
 msgstr ""
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
@@ -4724,18 +2563,7 @@ msgstr ""
 
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
+msgstr "_Аиндекс WEP"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4778,7 +2606,7 @@ msgstr ""
 
 #: panels/notifications/cc-notifications-panel.ui:10
 msgid "_Do Not Disturb"
-msgstr ""
+msgstr "_Ауадаҩра  аламҵара"
 
 #: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
@@ -4788,26 +2616,8 @@ msgstr ""
 msgid "Control which notifications are displayed and what they show"
 msgstr ""
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
-msgstr ""
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr ""
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr ""
-
-#: panels/online-accounts/cc-online-accounts-panel.c:691
-msgid "Error removing account"
 msgstr ""
 
 #. Translators: This is the button which allows undoing the removal of the printer.
@@ -4832,17 +2642,6 @@ msgstr ""
 msgid "Add an account"
 msgstr ""
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr ""
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr ""
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr ""
@@ -4851,18 +2650,10 @@ msgstr ""
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-msgstr ""
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
 msgstr ""
 
 #: panels/power/cc-battery-row.c:83
@@ -4879,13 +2670,6 @@ msgid_plural "%i hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4897,184 +2681,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Иҭелдоу аҳәынаԥ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Иҭелдоу арыдыркыра"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr ""
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Абатареиа"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr ""
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Абатареиа"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Автоматикалатәи аԥшаара арежим"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr ""
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5136,6 +2742,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr ""
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Абатареиа"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr ""
@@ -5166,7 +2781,7 @@ msgstr ""
 
 #: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
-msgstr ""
+msgstr "_Аекран аҿакра"
 
 #: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
@@ -5178,7 +2793,7 @@ msgstr "Автоматикла аенергиа аиқәырхара"
 
 #: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
-msgstr ""
+msgstr "Иаҿанакуеит афымцеиқәырхара арежим, аиҵаҵа тәаны ианыҟоу"
 
 #: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
@@ -5213,33 +2828,6 @@ msgstr ""
 msgid "Delay"
 msgstr ""
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr ""
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr ""
@@ -5248,32 +2836,10 @@ msgstr ""
 msgid "View your battery status and change power saving settings"
 msgstr ""
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
-msgstr ""
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr ""
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr ""
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr ""
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
 msgstr ""
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
@@ -5284,7 +2850,6 @@ msgstr ""
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -5292,8 +2857,6 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr ""
 
@@ -5303,7 +2866,7 @@ msgstr ""
 #: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
-msgstr ""
+msgstr "_Аужьра:"
 
 #. Translators: No printers were detected
 #: panels/printers/new-printer-dialog.ui:197
@@ -5330,28 +2893,7 @@ msgstr ""
 #: panels/user-accounts/cc-add-user-dialog.ui:343
 #: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
-msgstr ""
-
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
+msgstr "Ахархәаҩ ихьӡ"
 
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
@@ -5361,9 +2903,7 @@ msgstr ""
 msgid "Location"
 msgstr "Аҭыӡҭыԥ"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr ""
 
@@ -5377,7 +2917,7 @@ msgstr ""
 
 #: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
-msgstr ""
+msgstr "Адыррақәа рбаза аҟынтә алхра..."
 
 #: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
@@ -5391,140 +2931,20 @@ msgstr ""
 msgid "Loading drivers database…"
 msgstr ""
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Аԥыхры"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
-msgstr ""
+msgstr "Алхра"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr ""
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr ""
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr ""
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pause"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr ""
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr ""
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr ""
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr ""
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr ""
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr ""
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr ""
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr ""
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr ""
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] ""
 msgstr[1] ""
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr ""
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr ""
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5552,206 +2972,11 @@ msgstr "_Ахаҭара ашьақәыргылара"
 msgid "No Active Printer Jobs"
 msgstr ""
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr ""
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr ""
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr ""
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr ""
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr ""
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Аҭыӡҭыԥ:%s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Аҭыӡҭыԥ:%s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr ""
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr ""
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr ""
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr ""
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr ""
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr ""
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr ""
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr ""
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr ""
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr ""
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr ""
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr ""
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr ""
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr ""
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Автоматикла алхра"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Заанаҵтәи араӡарада"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr ""
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr ""
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5759,118 +2984,9 @@ msgid_plural "%u Jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr ""
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr ""
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr ""
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr ""
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr ""
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr ""
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Ақьаад нҵәеит"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr ""
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr ""
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr ""
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr ""
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr ""
-
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
-msgstr ""
+msgstr "Акьыҧхьра ахышәарақәа"
 
 #: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
@@ -5890,6 +3006,10 @@ msgstr ""
 msgid "Remove Printer"
 msgstr ""
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -5907,30 +3027,28 @@ msgstr ""
 #. Translators: This is the button which restarts the printer.
 #: panels/printers/printer-entry.ui:306
 msgid "Restart"
-msgstr ""
+msgstr "Ханатә алагара"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr ""
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr ""
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:171
-msgid "Add a Printer…"
-msgstr ""
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
 msgstr ""
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr ""
@@ -5945,7 +3063,7 @@ msgstr ""
 
 #: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
-msgstr ""
+msgstr "Аформатқәа зегьы"
 
 #: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
@@ -5957,17 +3075,7 @@ msgstr ""
 
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
-msgstr ""
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr ""
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr ""
+msgstr "Акьыԥхьра ахәаԥшра"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5975,7 +3083,7 @@ msgstr "Аамҭарба"
 
 #: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
-msgstr ""
+msgstr "Аамҭарбеи  аамҭеи"
 
 #: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
@@ -6003,20 +3111,24 @@ msgid ""
 "used for numbers, dates, and currencies."
 msgstr ""
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr ""
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
-msgstr ""
+msgstr "_Абызшәа"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr ""
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr ""
 
@@ -6028,98 +3140,8 @@ msgstr ""
 msgid "Select your display language and formats"
 msgstr ""
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr ""
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
 msgstr ""
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
@@ -6128,11 +3150,11 @@ msgstr ""
 
 #: panels/removable-media/cc-removable-media-panel.ui:52
 msgid "CD _audio"
-msgstr ""
+msgstr "_Икомпакту абжьытә санҭыр"
 
 #: panels/removable-media/cc-removable-media-panel.ui:67
 msgid "_DVD video"
-msgstr ""
+msgstr "_Авидео-DVD"
 
 #: panels/removable-media/cc-removable-media-panel.ui:102
 msgid "_Music player"
@@ -6156,7 +3178,7 @@ msgstr ""
 
 #: panels/removable-media/cc-removable-media-panel.ui:259
 msgid "_Action:"
-msgstr ""
+msgstr "_Аҟаҵара:"
 
 #: panels/removable-media/cc-removable-media-panel.ui:278
 msgid "_Type:"
@@ -6170,20 +3192,81 @@ msgstr ""
 msgid "Configure Removable Media settings"
 msgstr ""
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Аекаран аусура аанкылара"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Автоматикла аекран аусура амҩакра шәара шәаарӡа акомпиутер ахь анеира "
+"ԥнарҟәҟәоит"
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Автоматикла _аекран аусура аанкылара"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6198,23 +3281,19 @@ msgstr ""
 
 #: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
-msgstr ""
+msgstr "Аҭыԥқәа"
 
 #: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
-msgstr ""
+msgstr "Агәылаҵақәа"
 
 #: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
-msgstr ""
+msgstr "Егьырҭгьы"
 
 #: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
-msgstr ""
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr ""
+msgstr "Ҭыԥс шәахьыҟоу ацҵара"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -6222,7 +3301,7 @@ msgstr ""
 
 #: panels/search/cc-search-panel.ui:11
 msgid "Include application-provided search results."
-msgstr ""
+msgstr "Аԥшьы ишәыднагала аԥшаара алҵшәақәа рҿакра,"
 
 #: panels/search/cc-search-panel.ui:23
 msgid "Folders which are searched by system applications."
@@ -6241,88 +3320,13 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr ""
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
 msgstr ""
 
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Аҳа аҿы"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Аиҿартәыра аҭыӡҭыԥ акопиа ахыхуп"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr ""
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6396,10 +3400,10 @@ msgstr ""
 
 #: panels/sharing/cc-sharing-panel.ui:318
 #: panels/sharing/cc-sharing-panel.ui:345
-#: panels/sharing/cc-sharing-panel.ui:379
-#: panels/sharing/cc-sharing-panel.ui:405
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
 msgid "Copy"
-msgstr ""
+msgstr "Ахкьыҧхьаара"
 
 #: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
@@ -6417,37 +3421,36 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:420
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:449
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:450
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
 "identical."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:482
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:504
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:517
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
-msgstr ""
+msgstr "Аҭаӡқәа "
 
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
 msgstr ""
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6462,20 +3465,20 @@ msgstr ""
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 
-#: panels/sound/cc-alert-chooser.c:152
-msgid "Custom"
-msgstr ""
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Drip"
+msgid "Click"
 msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Glass"
-msgstr ""
+msgid "String"
+msgstr "Ацәаҳәа"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Sonar"
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
 msgstr ""
 
 #: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
@@ -6492,11 +3495,6 @@ msgstr ""
 
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
-msgstr ""
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
 msgstr ""
 
 #: panels/sound/cc-output-test-dialog.ui:131
@@ -6529,7 +3527,7 @@ msgstr ""
 
 #: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
-msgstr ""
+msgstr "Архиара"
 
 #: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
@@ -6545,15 +3543,10 @@ msgstr ""
 
 #: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
-msgstr ""
+msgstr "Амҽхак"
 
 #: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
-msgstr ""
-
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
 msgstr ""
 
 #: panels/sound/cc-volume-slider.ui:22
@@ -6562,86 +3555,15 @@ msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
-msgstr ""
+msgstr "_Абжьы"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:4
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr ""
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Ахаҭара шьақәыргылоуп:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr ""
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
 msgstr ""
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
@@ -6662,7 +3584,7 @@ msgstr ""
 
 #: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
-msgstr ""
+msgstr "Аҭагылазаашьа:"
 
 #: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
@@ -6676,50 +3598,6 @@ msgstr ""
 msgid "Forget Device"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr ""
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr ""
@@ -6730,6 +3608,10 @@ msgstr ""
 
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
@@ -6748,7 +3630,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr ""
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr ""
@@ -6764,7 +3645,7 @@ msgstr ""
 #: panels/universal-access/cc-cursor-blinking-dialog.ui:65
 #: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
-msgstr ""
+msgstr "Аццакра"
 
 #: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
@@ -6869,7 +3750,7 @@ msgstr ""
 
 #: panels/universal-access/cc-typing-dialog.ui:41
 msgid "_Sticky Keys"
-msgstr ""
+msgstr "_Иҷабуа  арыдқәа"
 
 #: panels/universal-access/cc-typing-dialog.ui:51
 msgid "Treats a sequence of modifier keys as a key combination"
@@ -6885,7 +3766,7 @@ msgstr ""
 
 #: panels/universal-access/cc-typing-dialog.ui:96
 msgid "S_low Keys"
-msgstr ""
+msgstr "_Имыццакуа арыдқәа"
 
 #: panels/universal-access/cc-typing-dialog.ui:106
 msgid "Puts a delay between when a key is pressed and when it is accepted"
@@ -6946,41 +3827,7 @@ msgstr ""
 
 #: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
-msgstr ""
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] ""
-msgstr[1] ""
+msgstr "Арыдқәа рыцхыраарала иҷыдоу алшарақәа рҿакра мамзар рҿыхра"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6996,7 +3843,7 @@ msgstr ""
 
 #: panels/universal-access/cc-ua-panel.ui:46
 msgid "_Large Text"
-msgstr ""
+msgstr "_Ишәпоу атекст"
 
 #: panels/universal-access/cc-ua-panel.ui:58
 msgid "Enable A_nimations"
@@ -7012,7 +3859,7 @@ msgstr ""
 
 #: panels/universal-access/cc-ua-panel.ui:83
 msgid "_Sound Keys"
-msgstr ""
+msgstr "_ Арыд ақәыӷәӷәараан абжьы аргара"
 
 #: panels/universal-access/cc-ua-panel.ui:84
 msgid "Beep when Num Lock or Caps Lock are turned on or off."
@@ -7025,7 +3872,7 @@ msgstr ""
 #: panels/universal-access/cc-ua-panel.ui:116
 #: panels/universal-access/cc-zoom-options-dialog.ui:82
 msgid "_Zoom"
-msgstr ""
+msgstr "_Амасштаб:"
 
 #: panels/universal-access/cc-ua-panel.ui:138
 msgid "Hearing"
@@ -7096,31 +3943,6 @@ msgstr ""
 msgid "Flash the entire _window"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr ""
-
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr ""
@@ -7143,7 +3965,7 @@ msgstr ""
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
-msgstr ""
+msgstr "Амасштабркра  ахышәарақәа "
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
@@ -7191,7 +4013,7 @@ msgstr ""
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
-msgstr ""
+msgstr "_Ашәпара:"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
@@ -7205,12 +4027,12 @@ msgstr ""
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
-msgstr ""
+msgstr "_Аура"
 
 #. The color of the accessibility crosshair
 #: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
-msgstr ""
+msgstr "_Аҧштәы:"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
@@ -7230,7 +4052,7 @@ msgstr ""
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
-msgstr ""
+msgstr "_Аиҿагылара:"
 
 #. The contrast scale goes from Color to None (grayscale)
 #: panels/universal-access/cc-zoom-options-dialog.ui:515
@@ -7276,121 +4098,12 @@ msgstr ""
 msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
 "audio;typing;animations;"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr ""
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr ""
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr ""
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr ""
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
 msgstr ""
 
 #: panels/usage/cc-usage-panel.ui:9
@@ -7440,11 +4153,11 @@ msgstr ""
 
 #: panels/usage/cc-usage-panel.ui:115
 msgid "_Empty Trash…"
-msgstr ""
+msgstr "_Акаҵкәыр арыцқьара…"
 
 #: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
-msgstr ""
+msgstr "_Аамҭалатәи афаилқәа рныхра"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
@@ -7454,57 +4167,9 @@ msgstr ""
 msgid "Don't leave traces"
 msgstr ""
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
 msgstr ""
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
@@ -7556,13 +4221,9 @@ msgid ""
 "resources on the internet."
 msgstr ""
 
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr ""
-
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
-msgstr ""
+msgstr "Афаила алшәха..."
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:8
 msgid "Fingerprint Manager"
@@ -7574,7 +4235,7 @@ msgstr ""
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
-msgstr ""
+msgstr "_Мап"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
@@ -7619,394 +4280,50 @@ msgstr ""
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
-msgstr ""
+msgstr "_Ашьҭақәа рныхра"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr ""
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr ""
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr ""
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr ""
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr ""
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr ""
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr ""
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr ""
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr ""
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr ""
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s- аҳасабрбатә нҵамҭа активра"
-
-#: panels/user-accounts/cc-login-history-dialog.ui:24
+#: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
-msgstr ""
+msgstr "Аԥхьатәи"
 
-#: panels/user-accounts/cc-login-history-dialog.ui:34
+#: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Ԥхьаҟа"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr ""
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr ""
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr ""
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Ажәамаӡақәа еиқәшәаӡом"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:187
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
-msgstr ""
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr ""
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr ""
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr ""
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr ""
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Зхаҭара шьақәыргылоу"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
 msgstr ""
 
 #: panels/user-accounts/cc-user-panel.ui:23
@@ -8024,7 +4341,7 @@ msgstr ""
 
 #: panels/user-accounts/cc-user-panel.ui:79
 msgid "Close"
-msgstr ""
+msgstr "Аркра"
 
 #: panels/user-accounts/cc-user-panel.ui:120
 msgid "Edit avatar"
@@ -8032,17 +4349,16 @@ msgstr ""
 
 #: panels/user-accounts/cc-user-panel.ui:152
 msgid "Full name"
-msgstr ""
+msgstr "Ихарҭәаау ахьӡ"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
-msgstr ""
+msgstr "Аредакциа азура"
 
 #. FIXME
 #: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
-msgstr ""
+msgstr "_Ашьаҭа  ала аҭалара"
 
 #: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
@@ -8097,7 +4413,6 @@ msgstr ""
 msgid "Add or remove users and change your password"
 msgstr ""
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8107,7 +4422,7 @@ msgstr ""
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
 #: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
-msgstr ""
+msgstr "_Аҭагалара"
 
 #: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
@@ -8136,171 +4451,8 @@ msgstr ""
 msgid "Authentication is required to change user data"
 msgstr ""
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr ""
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr ""
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:40
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr ""
 
@@ -8316,7 +4468,7 @@ msgstr ""
 
 #: panels/wacom/button-mapping.ui:66
 msgid "_Close"
-msgstr ""
+msgstr "_Аркра"
 
 #: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
@@ -8328,46 +4480,9 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr ""
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr ""
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr ""
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr ""
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr ""
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
 #: panels/wacom/cc-wacom-page.ui:16
@@ -8464,22 +4579,6 @@ msgstr ""
 msgid "Forward"
 msgstr "Ԥхьаҟа"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr ""
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr ""
@@ -8488,181 +4587,126 @@ msgstr ""
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+msgid "Windows Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
 msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr ""
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Аиқәырхара"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
 
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Агха:</b> Архиарақәа рыԥсахразы анеира мап ацәкуп"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Агха:</b> Амобилтә маруга   агха "
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr ""
-
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
-msgstr ""
+msgstr "Амодем аԥкаарақәа"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:16
 msgid "Modem Status"
-msgstr ""
+msgstr "Амодем аҭагылазаашьа"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:25
 msgid "Carrier"
-msgstr ""
+msgstr "Аоператор"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:49
 msgid "Network Type"
-msgstr ""
+msgstr "Аҳа ахкы"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:97
 msgid "Network Status"
-msgstr ""
+msgstr "Аҳа астатус"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:122
 msgid "Own Number"
-msgstr ""
+msgstr "Ахатә номер"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:151
 msgid "Device Details"
+msgstr "Аиҿартәыра иазкны адыррақәа"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
 msgstr ""
 
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr ""
+msgstr "Аҭаӡахырсҭа аверсиа"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8678,173 +4722,65 @@ msgid_plural "You have %u tries left"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr ""
-
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
-msgstr ""
+msgstr "SIM ыҟаӡам"
 
 #: panels/wwan/cc-wwan-device-page.ui:19
 msgid "Insert a SIM card to use this modem"
-msgstr ""
+msgstr "Ари амодем шәхы иашәырхәарц азы SIM карта ҭашәыргыл"
 
 #: panels/wwan/cc-wwan-device-page.ui:33
 msgid "SIM Locked"
-msgstr ""
+msgstr "SIM аанкылоуп"
 
 #: panels/wwan/cc-wwan-device-page.ui:77
 msgid "_Mobile Data"
-msgstr ""
+msgstr "_Амобилтә дыррақәа"
 
 #: panels/wwan/cc-wwan-device-page.ui:78
 msgid "Access data using mobile network"
-msgstr ""
+msgstr "Амобилтә ҳа шәхы иархәаны адыррақәа рахь анеира"
 
 #: panels/wwan/cc-wwan-device-page.ui:88
 msgid "_Data Roaming"
-msgstr ""
+msgstr "_Адыррақәа рроуминг"
 
 #: panels/wwan/cc-wwan-device-page.ui:89
 msgid "Use mobile data when roaming"
-msgstr ""
+msgstr "Шәхы иашәырхәа амобилтә дыррақәа ароуминг аҟны"
 
 #: panels/wwan/cc-wwan-device-page.ui:115
 msgid "_Network Mode"
-msgstr ""
+msgstr "_Аҳа арежим"
 
 #: panels/wwan/cc-wwan-device-page.ui:122
 msgid "N_etwork"
-msgstr ""
+msgstr "_Аҳа"
 
 #: panels/wwan/cc-wwan-device-page.ui:132
 msgid "Advanced"
-msgstr ""
+msgstr "Аҧкаақәа"
 
 #: panels/wwan/cc-wwan-device-page.ui:146
 msgid "_Access Point Names"
-msgstr ""
+msgstr "_ Анеира аҭыҧ ахьӡқәа"
 
 #: panels/wwan/cc-wwan-device-page.ui:155
 msgid "_SIM Lock"
-msgstr ""
+msgstr "_SIM амҩакра"
 
 #: panels/wwan/cc-wwan-device-page.ui:156
 msgid "Lock SIM with PIN"
-msgstr ""
+msgstr "SIM  карта аужьра PIN ала"
 
 #: panels/wwan/cc-wwan-device-page.ui:165
 msgid "M_odem Details"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr ""
+msgstr "Амодем_ аԥкаарақәа"
 
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
-msgstr ""
+msgstr "Аҳа арежим"
 
 #: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
@@ -8852,20 +4788,15 @@ msgstr "_Автоматикла"
 
 #: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
-msgstr ""
+msgstr "Аҳа алшәха"
 
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
+msgstr "Апроваидерқәа рыхьӡынҵа арҿыцра"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
-msgstr ""
+msgstr "Амобилтә ҳа азин аҭара"
 
 #: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
@@ -8873,7 +4804,7 @@ msgstr "Арнаалагақәа WWAN ԥшаам"
 
 #: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
-msgstr ""
+msgstr "Агәра шәга ишшәымоу аиҿартәыра иҭеилдоу аҳакәа рахь анеиразы"
 
 #: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
@@ -8881,19 +4812,19 @@ msgstr "Иҭелдоу аҳақәа аҿыххоит авиарежим анаҿ
 
 #: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
-msgstr ""
+msgstr "_Авиарежим"
 
 #: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
-msgstr ""
+msgstr "Адыррақәа реиԥшьра"
 
 #: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
-msgstr ""
+msgstr "SIM карта Аинтернет аҭаларазы"
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
 msgid "SIM Lock"
-msgstr ""
+msgstr "SIM амҩкра"
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
 msgid "_Next"
@@ -8901,88 +4832,59 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
-msgstr ""
+msgstr "_ ПИН -кодла SIM амҩакра"
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
-msgstr ""
+msgstr "ПИН-код аҧсахра"
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
-msgstr ""
+msgstr "Иҭажәгал уажәтәи ПИН-код, SIM карта амҩакразы архиарақәа рыҧсахразы"
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:3
 msgid "Mobile Network"
-msgstr ""
+msgstr "Амобилтә ҳа"
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:4
 msgid "Configure Telephony and mobile data connections"
-msgstr ""
+msgstr "Амобилтә дыррақәа рзы ателефониеи аимадарақәеи рырхиара"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
-msgstr ""
+msgstr "абларҭатә;амобильник;амобилтә;амобилтә;wwan;ателефониа;аҭел;sim;сим;"
 
 #: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
-msgstr ""
+msgstr "Аусуратә ишәа GNOME архиаразы амаруга"
 
 #: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
-msgstr ""
+msgstr "Архиарақәа- хадаразлоу интерфеисуп шәсистема архиаразы"
 
 #: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "The GNOME Project"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr ""
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Аинформациа змоу арежим аҿакра"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr ""
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr ""
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr ""
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr ""
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
-msgstr ""
+msgstr "Архиарақәа ркатегориа"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
-msgstr ""
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
 msgstr ""
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
-msgstr ""
+msgstr "Архиарақәа зегьы"
 
 #: shell/cc-window.ui:54
 msgid "Primary Menu"
-msgstr ""
+msgstr "Ихадоу амениу"
 
 #: shell/cc-window.ui:152
 msgid "Warning: Development Version"
-msgstr ""
+msgstr "Агәҽанҵара: аԥҵаразы аверсиа"
 
 #: shell/cc-window.ui:153
 msgid ""
@@ -8993,7 +4895,7 @@ msgstr ""
 
 #: shell/cc-window.ui:164
 msgid "Help"
-msgstr ""
+msgstr "Аилыркаа"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -9025,42 +4927,42 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr ""
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
-msgstr ""
+msgstr "Архиарақәа;Ахышәарақәа;"
 
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
-msgstr ""
+msgstr "Аҵыхәтәантәи архиарақәа рпанель ахаҭарбага аатоит"
 
 #: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
 "The identifier for the last Settings panel to be opened. Unrecognised values "
 "will be ignored and the first panel in the list selected."
 msgstr ""
+"Аҵыхәтәантәи архиарақәа рпанель ахаҭарбага аатоит.Еилкаам аҵакқәа зхьаҧшрада "
+"иаанхоит, иагьалххоит ахьӡынҵаҟны раҧхьаӡатәи апанель."
 
 #: shell/org.gnome.Settings.gschema.xml:13
 msgid "Show warning when running a development build of Settings"
-msgstr ""
+msgstr "Аԥшьы Архиарақәа аԥҵарақәа рзы аус арураан  агәҽанҵара арбара"
 
 #: shell/org.gnome.Settings.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
-msgstr ""
+msgstr "Аԥҵаразы аизгарақәа раан иаҭахума агәҽанҵара арбара"
 
 #: shell/org.gnome.Settings.gschema.xml:20
 msgid "Initial state of the window"
-msgstr ""
+msgstr "Аԥенџьыр аԥхьатәи аҭагылазаашьа"
 
 #: shell/org.gnome.Settings.gschema.xml:21
 msgid ""
 "A tuple containing the initial width, height and maximized state of the "
 "application window."
 msgstr ""
+"Аԥшьы аԥенџьыр аԥхьатәи аҭбаареи, аҳаракреи,еиҵыху аҭагылазаашьа змоу анҵамҭа"
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9068,8 +4970,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u ҭыҵрак"
 msgstr[1] "%u ҭыҵрак"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9077,6 +4977,735 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u аҭалара"
 msgstr[1] "%u аҭаларақәа"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr ""
+#~ msgid "System Bus"
+#~ msgstr "Асистематә ҭелцаха"
+
+#~ msgid "Full access"
+#~ msgstr "Инаӡоу анеира"
+
+#~ msgid "Session Bus"
+#~ msgstr "Асеанс аҭелцаха"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Инаӡоу анеира к /dev ахь"
+
+#~ msgid "Has network access"
+#~ msgstr "Аҳа ахь анеира азин амоуп"
+
+#~ msgid "Home"
+#~ msgstr "Home"
+
+#~ msgid "Read-only"
+#~ msgstr "Аԥхьара заҵәык азы"
+
+#~ msgid "File System"
+#~ msgstr "Афаилтә система"
+
+#~ msgid "Can change settings"
+#~ msgstr "Аиҿкаарақәа аԥсахлар ҟалоит"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> ахархәара аиуоит анаҩстәи афаилқәа рыхкқәеи азхьарԥшқәеи "
+#~ "раартразы."
+
+#~ msgid "_Open"
+#~ msgstr "_Аартра"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Аусуратә ишәа адыԥшылахә ада"
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Аԥштәытә ҷыдахә алшәха"
+
+#~ msgid "_Import"
+#~ msgstr "_Аиагара"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Иаднакыло аҷыдахәра ICC"
+
+#~ msgid "All files"
+#~ msgstr "Афаилқәа зегьы"
+
+#~ msgid "Today"
+#~ msgstr "Иахьа"
+
+#~ msgid "Yesterday"
+#~ msgstr "Иацы"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-d %b %Y"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%-d %B %Y, %l∶%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%-d %B %Y, %R"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#~ msgid "On"
+#~ msgstr "Иаҿакуп"
+
+#~ msgid "Off"
+#~ msgstr "Иаҿыхуп"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Аҧсахрақәа ахархәара рыҭатәума?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Аҧсахрақәа ахархәара рызрыҭахаӡом"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Ишәарҭадароу аҭагалара активуп"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Ашәарҭадара"
+
+#~ msgid "Security Level 1"
+#~ msgstr "Ашәарҭадара"
+
+#~ msgid "Security Level 2"
+#~ msgstr "Ашәарҭадара"
+
+#~ msgid "Security Level 3"
+#~ msgstr "Ашәарҭадара"
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Ишәарҭадароу аҭагалара активуп"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Аиҿыртәара аҿакраан хьчарада"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Аҭаӡахра аттестациа азура"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Аҭаӡахра аттестациа азура"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Аҭаӡахра аттестациа азура"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Хьчарада"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET иактивуп"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Хьчарада"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Ишәарҭадароу аҭагалара"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Аҭаӡахра аттестациа азура"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Аҭаӡахра аттестациа азура"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Аҭаӡахра аттестациа азура"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Хьчарада"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Аҭаӡахра аттестациа азура"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Аҭаӡахра аттестациа азура"
+
+#~ msgid "Valid"
+#~ msgstr "Иҵабыргуп"
+
+#~ msgid "Not Valid"
+#~ msgstr "Иҵабыргӡам"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Иаҿакуп"
+
+#~ msgid "Locked"
+#~ msgstr "Иаанкылоуп"
+
+#~ msgid "Not Locked"
+#~ msgstr "Иаанкылаӡам"
+
+#~ msgid "Encrypted"
+#~ msgstr "Ишифрркуп"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Ишифрркӡам"
+
+#~ msgid "Tainted"
+#~ msgstr "Иҧхасҭоуп"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Иҧхасҭатәӡам"
+
+#~ msgid "Found"
+#~ msgstr "Иҧшаау"
+
+#~ msgid "Not Found"
+#~ msgstr "Арнаалагақәа Bluetooth ԥшаам"
+
+#~ msgid "Supported"
+#~ msgstr "Иаднакылоит"
+
+#~ msgid "Unknown"
+#~ msgstr "Еилкаам"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-битк"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-битк"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager аус арузароуп."
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Ихьчам аҳа (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Ихьчоу аҳа (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Ихьчоу аҳа (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Ихьчоу аҳа (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Ихьчоу аҳа"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Анаплакы"
+
+#~ msgid "Never"
+#~ msgstr "Ахаан"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Мб/с (%1.1f ГГц)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Мб/с"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 ГГц / 5 ГГц"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 ГГц"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 ГГц"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Аимадара ахаршҭра"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Аимадара аҷыдахәра аныхра"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN аныхра"
+
+#~ msgid "Details"
+#~ msgstr "Аԥкаарақәа"
+
+#~ msgid "automatic"
+#~ msgstr "Автоматикала"
+
+#~ msgid "Delete Address"
+#~ msgstr "Аҭыӡҭыԥ аныхра"
+
+#~ msgid "Delete Route"
+#~ msgstr "Ахырхарҭа аныхра"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Адинамикатә WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "Аперсонатә WPA и WPA2"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Акорпоративтә WPA и WPA2"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "Персональный WPA3"
+
+#~ msgid "_Replace"
+#~ msgstr "_Аҧсахра"
+
+#~ msgid "yesterday"
+#~ msgstr "Иацы"
+
+#~ msgid "_Forget"
+#~ msgstr "_Ахашҭра"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Иҭелдоу аиҿартәыра анеира аҭыԥ арежим аднакылаӡом"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Аҳа аҭаҩразы аамҭа нҵәеит"
+
+#~ msgid "Select a file"
+#~ msgstr "Афаил алхра"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Wi-Fi Ажәамаӡа  ыҟаӡам."
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Иҭелдоу аҳәынаԥ"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Иҭелдоу арыдыркыра"
+
+#~ msgid "Computer"
+#~ msgstr "Акомпиутер"
+
+#~ msgid "Batteries"
+#~ msgstr "Абатареиа"
+
+#~ msgid "Nothing"
+#~ msgstr "Иҭацәу аобиект"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Автоматикалатәи аԥшаара арежим"
+
+#~ msgid "Landscape"
+#~ msgstr "Аҭыҧсахьатә"
+
+#~ msgid "Resume"
+#~ msgstr "аиҭашьақәыргылара"
+
+#~ msgid "Pause"
+#~ msgstr "Pause"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Аҭыӡҭыԥ:%s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Аҭыӡҭыԥ:%s"
+
+#~ msgid "Auto Select"
+#~ msgstr "Автоматикла алхра"
+
+#~ msgid "Printer Default"
+#~ msgstr "Ахышәарақәа  ишыҟоу еиҧш"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Заанаҵтәи араӡарада"
+
+#~ msgid "Out of paper"
+#~ msgstr "Ақьаад нҵәеит"
+
+#~ msgid "Open folder"
+#~ msgstr "Аҭаӡ аартра"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "Select Location"
+#~ msgstr "Ааҭгыларҭа алхра"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "Device address copied"
+#~ msgstr "Аиҿартәыра аҭыӡҭыԥ акопиа ахыхуп"
+
+#~ msgid "Custom"
+#~ msgstr "Ахархәаратә"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Ахаҭара шьақәыргылоуп:"
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr " Thunderbolt адкылара аҿыхуп BIOS аҟны."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Аамҭалатәи афаилқәа рныхра"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Иацҵаны асахьақәа рыҧшаара"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Арымарахьтәи анацәарбага"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s- аҳасабрбатә нҵамҭа активра"
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Афаилқәа рныхра"
+
+#~ msgid "_Delete"
+#~ msgstr "_Аныхра"
+
+#~ msgid "Logged in"
+#~ msgstr "Зхаҭара шьақәыргылоу"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Еилкаам агха"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Агха:</b> Архиарақәа рыԥсахразы анеира мап ацәкуп"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Агха:</b> Амобилтә маруга   агха"
+
+#~ msgid "Not Registered"
+#~ msgstr "Дҭагалаӡам"
+
+#~ msgid "Registered"
+#~ msgstr "Дҭагалоуп"
+
+#~ msgid "Roaming"
+#~ msgstr "Ароуминг"
+
+#~ msgid "Denied"
+#~ msgstr "Мап ацәкуп"
+
+#~ msgid "2G Only"
+#~ msgstr " 2G амацара"
+
+#~ msgid "3G Only"
+#~ msgstr " 3G амацара"
+
+#~ msgid "4G Only"
+#~ msgstr " 4G амацара"
+
+#~ msgid "5G Only"
+#~ msgstr " 5G амацара"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (Еиӷьуп)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (Еиӷьуп), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (Еиӷьуп), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (Еиӷьуп), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Еиӷьуп)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Еиӷьуп), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Еиӷьуп), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (Еиӷьуп)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (Еиӷьуп), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (Еиӷьуп), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (Еиӷьуп)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (Еиӷьуп), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (Еиӷьуп), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (Еиӷьуп)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (Еиӷьуп), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (Еиӷьуп), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Еиӷьуп)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Еиӷьуп), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Еиӷьуп)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Еиӷьуп), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Еиӷьуп)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Еиӷьуп), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (Еиӷьуп)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (Еиӷьуп), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Еиӷьуп)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (Еиӷьуп), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (Еиӷьуп)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (Еиӷьуп), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "SIM-карта аужьра"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Ҳшәыҳәоит, иҭажәгал PIN код SIM карта %d азы"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Иҭажәгал PIN шә-SIM карта аужьразы "
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Ҳшәыҳәоит, акод PUK  SIM %d азы адгалара ҟашәҵа"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Иҭажәгал акод PUK шә- SIM карта аужьразы"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Иҭагалоуп ииашам акод"
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK шьақәгылазароуп 8 хыԥхьаӡарак рыла"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Иҭажәгал ихыцу код PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN акод шьақәгылазароуп 4 инаркны 8 хфԥхьаӡарак рыла"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Аужьра..."
+
+#~ msgid "Phone failure"
+#~ msgstr "Ателефон шьақәҟьеит"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Атефон аҿакӡам"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Аоперациа зиндоуп"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM-карта ҭаргылаӡам"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Иаҭахуп SIM апин код"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Иаҭахуп SIM PUK-акод"
+
+#~ msgid "SIM failure"
+#~ msgstr " SIM карта мап ацәкуп"
+
+#~ msgid "SIM busy"
+#~ msgstr " SIM карта нкылоуп"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Акод иашаӡам"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Иаҭахуп SIM PIN2-акод"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Иаҭахуп SIM PUK2-акод"
+
+#~ msgid "Not found"
+#~ msgstr "Иԥшааӡам"
+
+#~ msgid "No network service"
+#~ msgstr "Аҳатә сервис ыҟаӡам"
+
+#~ msgid "Network timeout"
+#~ msgstr "Аҳа атаим -аут"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS амаҵзцрақәа зиндоуп"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Ари аҭыԥ аҟны ароуминг азин амаӡам"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "GPRSиарбам агха"
+
+#~ msgid "No Error"
+#~ msgstr "Агхақәа ыҟаӡам"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Аҟаҵара аԥыхуп"
+
+#~ msgid "Access denied"
+#~ msgstr "Анеира мап ацәкуп"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Еилкаам агха"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Аԥшьы аверсиа арбара"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Аинформативтә режим аҿакра"
+
+#~ msgid "Search for the string"
+#~ msgstr "Ацәаҳәа аҧшаара"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Апанельқәа ирыхьыӡхар зылшо ахьӡқәа цәырганы аҭыҵра"
+
+#~ msgid "Panel to display"
+#~ msgstr "Аарҧшразы аҵакыра"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[АПАНЕЛЬ][АҴАҴӶӘЫ...]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Иманшәалоу апанельқәа:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Асистематә бжьқәа"

--- a/po/ab.po~
+++ b/po/ab.po~
@@ -1,0 +1,9296 @@
+msgid ""
+msgstr ""
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-12-13 06:55+0000\n"
+"Last-Translator: Нанба Наала <naala-nanba@rambler.ru>\n"
+"Language-Team: Abkhazian <daniel.abzakh@gmail.com>\n"
+"Language: ab\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-DamnedLies-Scope: partial\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Асистематә ҭелцаха"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Инаӡоу анеира"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Асеанс аҭелцаха"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Инаӡоу анеира к /dev ахь"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Аҳа ахь анеира азин амоуп"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Home"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Аԥхьара заҵәык азы"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Афаилтә система"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Архиарақәа"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Аиҿкаарақәа аԥсахлар ҟалоит"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> ахархәара аиуоит анаҩстәи афаилқәа рыхкқәеи азхьарԥшқәеи раартразы."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr ""
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Аԥшькәа"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Аԥшьқәа ыҟаӡам"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Аартра"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Аԥкаарақәа"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Аҧшаара"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Асистемаҟны аԥшаара алҵшәақәа риура, насгьы урҭ рышьҭра"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Асистематә цҳамҭақәа рырбара. "
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Аусуратә ишәа адыԥшылахә ада"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Активра азин аҭара, аԥшьы анарку."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Иаразнактәи аекран аҭыхра ианакәзаалак аҟаҵара"
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Адыԥшылахә аԥсахра"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Аусуратә ишәа адыԥшылахә аԥсахра"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Абжьқәа"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Абжьқәа рҿакра"
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Арыдқәа реилаҵа рақәиҭымтәра"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Арыдқәа истандарту реицааира аанкылара"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Акамера"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Акамера ацхыраарала аҭыхымҭақәа рыҟаҵара"
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Амикрофон"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Амикрофон ацхыраарала абжьы анҵара"
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Шәахьыҟоу аҭыԥ асервисқаә"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Аиҿартәыра ҭыԥс аҟазаара аазырԥшуа адыррақәа рахь анеира"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Иҭазоу азинқәа"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Аԥшьы иаҭаху асистема ахь анеира"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Афаилқәеи &amp; азхьарԥшқәеи реидгыла"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Аҵәахырҭа"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Алҵшәақәа ԥшааӡам"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Афаилқәеи азхьарԥшқәеи реидгыла"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Аҧшьы"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Зегьы</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr ""
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Аԥыхра"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Аартра"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr ""
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Аусуратә ишәа адыԥшылахә ада"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "default:mm"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Ақәыԥшылара"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Аԥшра"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Иаҿакуп"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Арнаалагақәа Bluetooth ԥшаам"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Арнаалага Bluetooth аҿыхуп"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Авиарежим аҿакуп"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Аппараттә авиарежим аҿакуп"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr ""
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr ""
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr ""
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr ""
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr ""
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr ""
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr ""
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr ""
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Алагара"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Ацҵара"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Ихиоуп"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr ""
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr ""
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr ""
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr ""
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr ""
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr ""
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr ""
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr ""
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr ""
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr ""
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Аԥштәытә ҷыдахә алшәха"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Аиагара"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Иаднакыло аҷыдахәра ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Афаилқәа зегьы"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr ""
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Аиқәырхара"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Афаил аимпорт азура"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Ацҵара"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Ахархәаҩцәа зегь рзы ашьақәыргылара"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Аҿакра"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Аҷыдахәра ацҵара"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (ишкәакәоу LED-арлашара)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 минуҭ"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 минуҭ"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr ""
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr ""
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr ""
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr ""
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr ""
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr ""
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr ""
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr ""
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Алхра"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Аамҭа"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Иахьа"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Иацы"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%-d %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr ""
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr ""
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr ""
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr ""
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr ""
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr ""
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr ""
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%-d %B %Y, %l∶%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%-d %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr ""
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr ""
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Аамҭарбеи  аамҭеи"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Ашықәс"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Амз"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Ажьырныҳәа"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Жәабран"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Хәажәкыра"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Мшаԥымза"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Лаҵара"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Рашәара"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Ԥхынгәы"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Нанҳәа"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Цәыббра"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Жьҭаара"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Абҵара"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Ԥхынҷкәын"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Амш"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Ақалақь аҟны аԥшаара"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Автоматикла _аамҭеи арыцхәи рышьақәыргылара"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Аамҭарбеи  _аамҭеи"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Автоматикла _ асааҭзона ашьақәыргылара"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Иаҿакуп"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Аинтернет"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Амзар"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Авидео"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Аҧшранҵа"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Аҧшьқәа ишыҟоу еиҧш"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Аҧшьқәа ишыҟоу еиҧш рырхиара"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Автоматикатә цҳамҭа агхақәа ирызкны"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Адиагностика"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Иаҿакуп"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Иаҿыхуп"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Аҧсахрақәа ахархәара рыҭатәума?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Аҧсахрақәа ахархәара рызрыҭахаӡом"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Ахархәара"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Шьҭахьҟа"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Аҽадҵара"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Асаркьа"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Ихадоу адисплеи"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Уахынлатәи алашара"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Аамҭала уаҵәынӡа иаҿыхуп"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Аихшанҵа"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Аамҭа"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr ""
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Аԥштәытә шоура"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Ишәарҭадароу аҭагалара активуп"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr ""
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr ""
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Ишәарҭадароу аҭагалара аԥхасҭа ҟазҵо апрограмматә еиқәыршәарақәа рҭагалара "
+"ԥнарҟәҟәоит аиҿартәыраадәықәҵараан.\n"
+"\n"
+"Иацҵаны аинформациа шәоурц азы амаруга аԥҵаҩы ,мамзар ИТ -ацхыраара амаҵзура "
+"шәрыдҵаала."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr ""
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Ашәарҭадара"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Ашәарҭадара"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Ашәарҭадара"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Ашәарҭадара"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr ""
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Ишәарҭадароу аҭагалара активуп"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Аиҿыртәара аҿакраан хьчарада"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Аҭаӡахра аттестациа азура"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Аҭаӡахра аттестациа азура"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Аҭаӡахра аттестациа азура"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr ""
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Хьчарада"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET иактивуп"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr ""
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Хьчарада"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr ""
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr ""
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr ""
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr ""
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr ""
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr ""
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Ишәарҭадароу аҭагалара"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr ""
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr ""
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Аҭаӡахра аттестациа азура"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Аҭаӡахра аттестациа азура"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Аҭаӡахра аттестациа азура"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr ""
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Хьчарада"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Аҭаӡахра аттестациа азура"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Аҭаӡахра аттестациа азура"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr ""
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Иҵабыргуп"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Иҵабыргӡам"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Иаҿакуп"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Иаанкылоуп"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Иаанкылаӡам"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Ишифрркуп"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Ишифрркӡам"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Иҧхасҭоуп"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Иҧхасҭатәӡам"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Иҧшаау"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Арнаалагақәа Bluetooth ԥшаам"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Иаднакылоит"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Ашәарҭадара"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Еилкаам"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-битк"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-битк"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr ""
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Аграфика"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr ""
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Аверсиа GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Аҭагалара..."
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Авиртуалра"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Аиҿартәыра ахьӡ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Ахьӡԥсахра"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Аԥшьы иазкны"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Асеанс ахырқәшара"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Ахархәара аманшәалара"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Аизҳара  аҿакра, мамзар аҿыхра"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Ардура"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Архәҷра"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr " Аекран аҟынтә аԥхьара  аҿакра, мамзар аҿыхра"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Аекрантә рыдыркыра аҿакра, мамзар аҿыхра"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Иҳараку аиҿагылара аҿакра, мамзар аҿыхра"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Ахышәарақәа"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Ахышәарақәа"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Иаҿанакуеит арыдыркыра аихшареи аҭагалара аметодқәеи."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Арыдқәа реилаҵа"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Аԥыхры"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Аныхра"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Аԥса_хра"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Ашьақәыргылара"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Ахьӡ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Мап"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Арыдыркыра"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Зегьы ирзаку"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Армарахь"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Арӷьарахь"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr ""
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Акьыснырратә панель"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Ицоу акьаҿ"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_иактиву аекран аҳәаақәа"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Автоматикла аишәақәа анаԥхгара рыҭара"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Иҭацәу аишәқәа автоматикла ррыцқьара"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_ Аишәақәа рхыҧхьаӡара"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Аишәақәа зегьы рҟынтәи аԥшьқәа рҿакра"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Иҟоу аишәа _заҵәык аҟынтәи аԥшьы аҿакра"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager аус арузароуп."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Ихьчам аҳа (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Ихьчоу аҳа (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Ихьчоу аҳа (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Ихьчоу аҳа (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Ихьчоу аҳа"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Ахышәарақәа...."
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr ""
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Ажәамаӡа"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Ажәамаӡа автоматикла агенерациа азура"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Аҿакра"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Авиарежим"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Арнаалагақәа Wi-Fi  ԥшаам"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Авиарежим аҿакуп"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager аус арузароуп"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Ашәарҭадара 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Ашәарҭадара"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr ""
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Анаплакы"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Ахаан"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Мб/с (%1.1f ГГц)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Мб/с"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 ГГц / 5 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Аҭыӡҭыԥ IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Аҭыӡҭыԥ IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-Аҭыӡҭыԥ"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Аимадара ахаршҭра"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Аимадара аҷыдахәра аныхра"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "VPN аныхра"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Аԥкаарақәа"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "Автоматикала"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Аҭыӡҭыԥ аныхра"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Ахырхарҭа аныхра"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Адинамикатә WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "Аперсонатә WPA и WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "Акорпоративтә WPA и WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "Персональный WPA3"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Асигнал амчра"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Адыррақәа рышьҭра аццакыра"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Аппараттә ҭыӡҭыԥ"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Адкылара змоу  аҵыс-ҵысра"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Ахырхарҭа ишыҟоу еиԥш"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Аҵыхәтәантәи ахархәара"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Автоматла аҽаҿакра"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Егьырҭ ахархәаҩцәа рзы анеишьа маншәаланы аҟаҵара"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Ахьӡ"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "МАС -А_ҭыӡҭыԥ"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "баит"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Автоматикалатәи (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Напыла"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Аҭыӡҭыԥқәа"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Аҭыӡҭыԥ"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Автоматикала"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Автоматикалатәи DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS асервис аҭыӡҭыԥ"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Автоматикатә хырхарҭақәа"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Автоматикалатәи DHCP мацара"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_Ашәарҭадара"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Аҧсахра"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr ""
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr ""
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "Иацы"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr ""
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Ахашҭра"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr ""
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Иҭелдоу аиҿартәыра анеира аҭыԥ арежим аднакылаӡом"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Иаҿакуп"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Адгалаҩ"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Аиқәҳәаларҭақәа рызхьамҧшра"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL _ автоматикатә архиарақәа ртәы"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr ""
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr ""
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Иҵегь ахышәарақәа..."
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi анеирҭа ҭыԥ аҿакра"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Еилкаау  Wi-Fi аҳақәа"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Аҳа аҭаҩразы аамҭа нҵәеит"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Ихьӡыдоу"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Зхаҭареилкаау"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ииааланы насгьы гәҵәыла"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "И_хьӡыдоу ахаҭареилкаара"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Афаил PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Ахархәаҩ ихьӡ"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Ажәамаӡа"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Аверсиа 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Аверсиа 2"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Аверсиа PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 ( EAP ада)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Адомен"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "А_хаҭареилкаара"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Афаил алхра"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr ""
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr ""
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Wi-Fi Ажәамаӡа  ыҟаӡам."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Open System"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "_Аиндекс WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr ""
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Ауадаҩра  аламҵара"
+
+#. Translators: Whether to show notifications on the lock screen
+#: panels/notifications/cc-notifications-panel.ui:17
+#: panels/screen/cc-screen-panel.ui:69
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr ""
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Архынҳәра"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr ""
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Иҭелдоу аҳәынаԥ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Иҭелдоу арыдыркыра"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Акомпиутер"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr ""
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Абатареиа"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Абатареиа"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Иҭацәу аобиект"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Автоматикалатәи аԥшаара арежим"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Алашара автоматикла аиҽкаара"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Аекран аҿакра"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Автоматикла аенергиа аиқәырхара"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Иаҿанакуеит афымцеиқәырхара арежим, аиҵаҵа тәаны ианыҟоу"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Автоматикалатәи аԥшаара арежим"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Автоматикалатәи аԥшаара арежим"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr ""
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr ""
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr ""
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Аужьра:"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Ахархәаҩ ихьӡ"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Аҭыӡҭыԥ"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Адыррақәа рбаза аҟынтә алхра..."
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Алхра"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr ""
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Аҭыҧсахьатә"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr ""
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "аиҭашьақәыргылара"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pause"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr ""
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr ""
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr ""
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr ""
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr ""
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr ""
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr ""
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr ""
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr ""
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr ""
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "А_хаҭареилкаара"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Ахаҭара ашьақәыргылара"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr ""
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr ""
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr ""
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr ""
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr ""
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Аҭыӡҭыԥ:%s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Аҭыӡҭыԥ:%s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr ""
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr ""
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr ""
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr ""
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr ""
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr ""
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr ""
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr ""
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr ""
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr ""
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr ""
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr ""
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr ""
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Автоматикла алхра"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Ахышәарақәа  ишыҟоу еиҧш"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Заанаҵтәи араӡарада"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr ""
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr ""
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr ""
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr ""
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr ""
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr ""
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Ақьаад нҵәеит"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr ""
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr ""
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr ""
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Акьыҧхьра ахышәарақәа"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr ""
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Ханатә алагара"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Аформатқәа зегьы"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Акьыԥхьра ахәаԥшра"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr ""
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Аамҭарба"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Аамҭарбеи  аамҭеи"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Ақьаад"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Абызшәа"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Аҭаӡ аартра"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr ""
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Икомпакту абжьытә санҭыр"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_Авидео-DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Аҟаҵара:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Аекаран аусура аанкылара"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Автоматикла аекран аусура амҩакра шәара шәаарӡа акомпиутер ахь анеира "
+"ԥнарҟәҟәоит"
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Автоматикла _аекран аусура аанкылара"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr ""
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Ааҭгыларҭа алхра"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Аҭыԥқәа"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Агәылаҵақәа"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Егьырҭгьы"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Ҭыԥс шәахьыҟоу ацҵара"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Аԥшьы ишәыднагала аԥшаара алҵшәақәа рҿакра,"
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Аҳа аҿы"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Аиҿартәыра аҭыӡҭыԥ акопиа ахыхуп"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Ахкьыҧхьаара"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Иалцоу аусуратә ишәа аҭыӡҭыԥ"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Ахаҭареилкаара"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Аҭаӡқәа "
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Ахархәаратә"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Ацәаҳәа"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Абаланс"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Аҭыҵра"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Архиара"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Аҭалара"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Амҽхак"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr ""
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr ""
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "_Абжьы"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr ""
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Ахаҭара шьақәыргылоуп:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr ""
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Аҭагылазаашьа:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr " Thunderbolt адкылара аҿыхуп BIOS аҟны."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Аццакра"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Арыдқәа автоматла реиҭаҟаҵара"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Иҷабуа  арыдқәа"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Имыццакуа арыдқәа"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Арыдқәа рыцхыраарала иҷыдоу алшарақәа рҿакра мамзар рҿыхра"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Ишәпоу атекст"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_ Арыд ақәыӷәӷәараан абжьы аргара"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Амасштаб:"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Арыдқәа автоматла реиҭаҟаҵара"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Хыхьтәи абжара"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Амасштабркра  ахышәарақәа "
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Ашәпара:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Аура"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Аҧштәы:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Ашкәакәа аиқәаҵәа аҟны:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Аиҿагылара:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Аамҭалатәи афаилқәа рныхра"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr ""
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr ""
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr ""
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Акаҵкәыр автоматикла _арыцқьара"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Автоматикла иаамҭалатәу _афаилқә рныхра"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Акаҵкәыр арыцқьара…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Аамҭалатәи афаилқәа рныхра"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Ажәамаӡақәа еиқәшәаӡом"
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Анаԥхгаҩы"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Анаԥхгаҩцәа ирылшоит егьырҭ ахархәаҩцәа рныхреи рацҵареи, насгьы ахархәаҩцәа "
+"зегьы рзы архиарақәа рыԥсахра.  Анаԥхгаҩцәа рахь аҭаацәаратә хылаԥшра "
+"ахархәара заиуӡом."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Иацҵаны асахьақәа рыҧшаара"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Афаила алшәха..."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Мап"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Ааи"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Ашьҭақәа рныхра"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "_Арымарахьтәи анацәарбага"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr ""
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr ""
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr ""
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr ""
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr ""
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s- аҳасабрбатә нҵамҭа активра"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Аԥхьатәи"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Ԥхьаҟа"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Афаилқәа рныхра"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Аныхра"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Зхаҭара шьақәыргылоу"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Аркра"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Ихарҭәаау ахьӡ"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Аредакциа азура"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Ашьаҭа  ала аҭалара"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Автоматикла а_ҭалара"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "аҳасабрбатә нҵамҭа активра"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Анаԥхгаҩы"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Анаԥхгаҩцәа ирылшоит егьырҭ ахархәаҩцәа рныхреи рацҵареи, насгьы ахархәаҩцәа "
+"зегьы рзы архиарақәа рыԥсахра"
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Аҭагалара"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Еилкаам агха"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Аркра"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Ԥхьаҟа"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Агха:</b> Архиарақәа рыԥсахразы анеира мап ацәкуп"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Агха:</b> Амобилтә маруга   агха"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Дҭагалаӡам"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Дҭагалоуп"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Ароуминг"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Мап ацәкуп"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Амодем аԥкаарақәа"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Амодем аҭагылазаашьа"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Аоператор"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Аҳа ахкы"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Аҳа астатус"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Ахатә номер"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Аиҿартәыра иазкны адыррақәа"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Аҭаӡахырсҭа аверсиа"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr " 2G амацара"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr " 3G амацара"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr " 4G амацара"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr " 5G амацара"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (Еиӷьуп), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (Еиӷьуп), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (Еиӷьуп), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Еиӷьуп), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Еиӷьуп), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (Еиӷьуп), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (Еиӷьуп), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (Еиӷьуп), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (Еиӷьуп), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (Еиӷьуп), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (Еиӷьуп), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (Еиӷьуп), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (Еиӷьуп), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (Еиӷьуп), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (Еиӷьуп), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (Еиӷьуп), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (Еиӷьуп)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (Еиӷьуп), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "SIM-карта аужьра"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Ҳшәыҳәоит, иҭажәгал PIN код SIM карта %d азы"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Иҭажәгал PIN шә-SIM карта аужьразы "
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Ҳшәыҳәоит, акод PUK  SIM %d азы адгалара ҟашәҵа"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Иҭажәгал акод PUK шә- SIM карта аужьразы"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Иҭагалоуп ииашам акод"
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK шьақәгылазароуп 8 хыԥхьаӡарак рыла"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Иҭажәгал ихыцу код PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN акод шьақәгылазароуп 4 инаркны 8 хфԥхьаӡарак рыла"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Аужьра..."
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "SIM ыҟаӡам"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Ари амодем шәхы иашәырхәарц азы SIM карта ҭашәыргыл"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM аанкылоуп"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Амобилтә дыррақәа"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Амобилтә ҳа шәхы иархәаны адыррақәа рахь анеира"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Адыррақәа рроуминг"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Шәхы иашәырхәа амобилтә дыррақәа ароуминг аҟны"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Аҳа арежим"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Аҳа"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Аҧкаақәа"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_ Анеира аҭыҧ ахьӡқәа"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM амҩакра"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "SIM  карта аужьра PIN ала"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Амодем_ аԥкаарақәа"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Ателефон шьақәҟьеит"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Атефон аҿакӡам"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Аоперациа зиндоуп"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM-карта ҭаргылаӡам"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Иаҭахуп SIM апин код"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Иаҭахуп SIM PUK-акод"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr " SIM карта мап ацәкуп"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr " SIM карта нкылоуп"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Акод иашаӡам"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Иаҭахуп SIM PIN2-акод"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Иаҭахуп SIM PUK2-акод"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Иԥшааӡам"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Аҳатә сервис ыҟаӡам"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Аҳа атаим -аут"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS амаҵзцрақәа зиндоуп"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Ари аҭыԥ аҟны ароуминг азин амаӡам"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "GPRSиарбам агха"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Агхақәа ыҟаӡам"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Аҟаҵара аԥыхуп"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Анеира мап ацәкуп"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Еилкаам агха"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Аҳа арежим"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Автоматикла"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Аҳа алшәха"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Апроваидерқәа рыхьӡынҵа арҿыцра"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Амобилтә ҳа азин аҭара"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Арнаалагақәа WWAN ԥшаам"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Агәра шәга ишшәымоу аиҿартәыра иҭеилдоу аҳакәа рахь анеиразы"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Иҭелдоу аҳақәа аҿыххоит авиарежим анаҿаку"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Авиарежим"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Адыррақәа реиԥшьра"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM карта Аинтернет аҭаларазы"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM амҩкра"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_ ПИН -кодла SIM амҩакра"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "ПИН-код аҧсахра"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Иҭажәгал уажәтәи ПИН-код, SIM карта амҩакразы архиарақәа рыҧсахразы"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Амобилтә ҳа"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Амобилтә дыррақәа рзы ателефониеи аимадарақәеи рырхиара"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "абларҭатә;амобильник;амобилтә;амобилтә;wwan;ателефониа;аҭел;sim;сим;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Аусуратә ишәа GNOME архиаразы амаруга"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Архиарақәа- хадаразлоу интерфеисуп шәсистема архиаразы"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "The GNOME Project"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Аԥшьы аверсиа арбара"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Аинформативтә режим аҿакра"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Ацәаҳәа аҧшаара"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Апанельқәа ирыхьыӡхар зылшо ахьӡқәа цәырганы аҭыҵра"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Аарҧшразы аҵакыра"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[АПАНЕЛЬ][АҴАҴӶӘЫ...]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Архиарақәа ркатегориа"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Иманшәалоу апанельқәа:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Архиарақәа зегьы"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Ихадоу амениу"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Агәҽанҵара: аԥҵаразы аверсиа"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Аилыркаа"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr ""
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Архиарақәа;Ахышәарақәа;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Аҵыхәтәантәи архиарақәа рпанель ахаҭарбага аатоит"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Аҵыхәтәантәи архиарақәа рпанель ахаҭарбага аатоит.Еилкаам аҵакқәа зхьаҧшрада "
+"иаанхоит, иагьалххоит ахьӡынҵаҟны раҧхьаӡатәи апанель."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Аԥшьы Архиарақәа аԥҵарақәа рзы аус арураан  агәҽанҵара арбара"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "Аԥҵаразы аизгарақәа раан иаҭахума агәҽанҵара арбара"
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Аԥенџьыр аԥхьатәи аҭагылазаашьа"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Аԥшьы аԥенџьыр аԥхьатәи аҭбаареи, аҳаракреи,еиҵыху аҭагылазаашьа змоу анҵамҭа"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u ҭыҵрак"
+msgstr[1] "%u ҭыҵрак"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u аҭалара"
+msgstr[1] "%u аҭаларақәа"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Асистематә бжьқәа"

--- a/po/af.po
+++ b/po/af.po
@@ -8,9 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center 2.6-branch\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2019-01-10 14:17+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2018-02-06 17:56+0200\n"
 "Last-Translator: Pieter Schalk Schoeman <pieter@sonbesie.co.za>\n"
 "Language-Team: Afrikaans <pieter@sonbesie.co.za>\n"
@@ -22,195 +21,330 @@ msgstr ""
 "X-Generator: Poedit 2.0.3\n"
 "X-Project-Style: gnome\n"
 
-#: panels/background/background.ui:49
-msgid "_Background"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Toepassings"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Geen toepassings gevind nie"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Verskaf PPD-lêer…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Open"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_Bekyk besonderhede"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Soek"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Gedeaktiveer"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "Ke_nnisgewings"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Wys ke_nnisgewings"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "_Agtergrond"
 
-#. This refers to a slideshow background
-#: panels/background/background.ui:99 panels/background/background.ui:212
-msgid "Changes throughout the day"
-msgstr "Verander regdeur die dag"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
 
-#. To translators: This is a noun, not a verb
-#: panels/background/background.ui:162
-msgid "_Lock Screen"
-msgstr "Ges_lote skerm"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Skermskote"
 
-#: panels/background/background.ui:268
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Teël"
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
 
-#: panels/background/background.ui:272
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Zoem"
-
-#: panels/background/background.ui:276
-msgctxt "background, style"
-msgid "Center"
-msgstr "Sentreer"
-
-#: panels/background/background.ui:280
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Skaleer"
-
-#: panels/background/background.ui:284
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Opvul"
-
-#: panels/background/background.ui:288
-msgctxt "background, style"
-msgid "Span"
-msgstr "Span"
-
-#: panels/background/cc-background-chooser-dialog.c:424
-msgid "Wallpapers"
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
 msgstr "Muurpapier"
 
-#: panels/background/cc-background-chooser-dialog.c:433
-msgid "Colors"
-msgstr "Kleure"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
-#. translators: This is the title of the wallpaper chooser dialog.
-#: panels/background/cc-background-chooser-dialog.c:468
-msgid "Select Background"
-msgstr "Kies Agtergrond"
-
-#: panels/background/cc-background-chooser-dialog.c:496
-msgid "Pictures"
-msgstr "Prente"
-
-#. translators: No pictures were found
-#: panels/background/cc-background-chooser-dialog.c:528
-msgid "No Pictures Found"
-msgstr "Geen prente gevind nie"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: panels/background/cc-background-chooser-dialog.c:545
-#: panels/search/cc-search-locations-dialog.c:302
-msgid "Home"
-msgstr "Tuis"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: panels/background/cc-background-chooser-dialog.c:555
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "Voeg prente by die %s-gids dan sal hulle hier verskyn"
-
-#: panels/background/cc-background-chooser-dialog.c:560
-#: panels/color/cc-color-panel.c:225 panels/color/cc-color-panel.c:963
-#: panels/color/color-calibrate.ui:25 panels/color/color.ui:657
-#: panels/common/language-chooser.ui:23 panels/display/cc-display-panel.c:2597
-#: panels/network/connection-editor/connection-editor.ui:15
-#: panels/network/connection-editor/vpn-helpers.c:181
-#: panels/network/connection-editor/vpn-helpers.c:310
-#: panels/network/net-device-wifi.c:1411 panels/network/net-device-wifi.c:1491
-#: panels/network/net-device-wifi.c:1736 panels/network/network-wifi.ui:24
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:331
-#: panels/privacy/cc-privacy-panel.c:1053 panels/region/format-chooser.ui:25
-#: panels/region/input-chooser.ui:13
-#: panels/search/cc-search-locations-dialog.c:642
-#: panels/sharing/cc-sharing-panel.c:384
-#: panels/user-accounts/data/account-dialog.ui:28
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/user-accounts/data/password-dialog.ui:21
-#: panels/user-accounts/um-fingerprint-dialog.c:261
-#: panels/user-accounts/um-photo-dialog.c:103
-#: panels/user-accounts/um-photo-dialog.c:230
-#: panels/user-accounts/um-user-panel.c:634
-#: panels/user-accounts/um-user-panel.c:652
-msgid "_Cancel"
-msgstr "_Kanselleer"
-
-#: panels/background/cc-background-chooser-dialog.c:561
-msgid "_Select"
-msgstr "_Kies"
-
-#: panels/background/cc-background-item.c:192
-msgid "multiple sizes"
-msgstr "veelvuldige groottes"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:196
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:321
-msgid "No Desktop Background"
-msgstr "Geen werkskermagtergrond"
-
-#: panels/background/cc-background-panel.c:291
-msgid "Current background"
-msgstr "Huidige agtergrond"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 #, fuzzy
-#| msgid "_Background"
+msgid "Sounds"
+msgstr "Klank"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Stel Kortpad"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Geen sleutelbord kortpad gevind nie"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s-kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "Mikrofoonvolume"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Liggingdienste"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Ingeboude webkamera"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Geen resultate gevind nie"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Probeer 'n ander soektog"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Skermtipe"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Skakelspoed"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+#, fuzzy
+msgid "Reset"
+msgstr "Herstel"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Toepassings"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>E-pos</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Pen"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Verstek"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
 msgid "Background"
 msgstr "_Agtergrond"
 
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "Voeg 'n drukker by…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "Frankryk"
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Verander die agtergrondbeeld na 'n muurpapier of foto"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/background/gnome-background-panel.desktop.in.in:7
-msgid "preferences-desktop-wallpaper"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
 
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Muurpapier;Skerm;Werkskerm;"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "_Aktiveer"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:265
-msgid "Turn Off Airplane Mode"
-msgstr "Skakel vlugmodus af"
-
-#: panels/bluetooth/cc-bluetooth-panel.c:330
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Geen Bluetooth-hardeware gevind nie"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:330
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Prop 'n passtuk in om Bluetooth te gebruik."
 
-#: panels/bluetooth/cc-bluetooth-panel.c:331
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth is afgeskakel"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:331
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Skakel aan om toestelle te koppel en lêers oor te dra."
 
-#: panels/bluetooth/cc-bluetooth-panel.c:332
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "Vlugmodus is aan"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:332
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth word gedeaktiveer tydens vlugmodus."
 
-#: panels/bluetooth/cc-bluetooth-panel.c:333
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Skakel vlugmodus af"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
 msgstr "Hardewarevlugmodus is aan"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:333
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Skakel die vlugmodusskakelaar af om Bluetooth te aktiveer."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/network/network.ui:101 panels/printers/pp-new-printer-dialog.c:1816
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -218,359 +352,90 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Skakel Bluetooth aan en af en koppel toestelle"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:6
-#, fuzzy
-#| msgid "Bluetooth"
-msgid "bluetooth"
-msgstr "Bluetooth"
-
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "deel;deling;bluetooth;obex;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Plaas die kalibreertoestel oor die vierkant en druk \"Begin\""
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "Bluetooth is afgeskakel"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Geen toepassing wat tans oudio speel of opneem nie."
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"Skuif die kalibreertoestel na die kalibreerposisie en druk \"Gaan voort\""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-"Skuif die kalibreertoestel na die oppervlakposisie en druk \"Gaan voort\""
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "Vou die skootrekenaar toe"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Blaai vir meer beelde"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "'n Interne fout het voorgekom waarvan daar nie herstel kon word nie."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "Nodige gereedskap vir kalibrering is nie geïnstalleer nie."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "Die profiel kon nie gegenereer word nie."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "Die doel-witpunt was nie bereikbaar nie."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "Voltooid!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "Kalibrering het misluk!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "Verwyder gerus die kalibreertoestel."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"Moenie die werking van die kalibreertoestel steur terwyl dit besig is nie"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Skootrekenaar se skerm"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Ingeboude webkamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s-monitor"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s-skandeerder"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s-kamera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s-drukker"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s-webkamera"
-
-#: panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Aktiveer kleurbestuur vir %s"
-
-#: panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Wys kleurprofiele vir %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:323
-msgid "Not calibrated"
-msgstr "Nie gekalibreer nie"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:141
-msgid "Default: "
-msgstr "Verstek: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:149
-msgid "Colorspace: "
-msgstr "Kleurruimte: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:156
-msgid "Test profile: "
-msgstr "Toetsprofiel: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:223
-msgid "Select ICC Profile File"
-msgstr "Kies lêer met ICC-profiel"
-
-#: panels/color/cc-color-panel.c:226
-msgid "_Import"
-msgstr "_Intrek"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:237
-msgid "Supported ICC profiles"
-msgstr "Ondersteunde ICC-profiele"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:244
-#: panels/network/wireless-security/eap-method-fast.c:417
-msgid "All files"
-msgstr "Alle lêers"
-
-#: panels/color/cc-color-panel.c:583
-msgid "Screen"
-msgstr "Skerm"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:908
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Kon nie die lêer oplaai nie: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:922
-msgid "The profile has been uploaded to:"
-msgstr "Die profiel is opgelaai na:"
-
-#: panels/color/cc-color-panel.c:924
-msgid "Write down this URL."
-msgstr "Skryf hierdie URL neer."
-
-#: panels/color/cc-color-panel.c:925
-msgid "Restart this computer and boot your normal operating system."
-msgstr "Herbegin die rekenaar en begin die normale bedryfstelsel."
-
-#: panels/color/cc-color-panel.c:926
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-"Tik die URL in die webblaaier om die profiel af te laai en te installeer."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:960
-msgid "Save Profile"
-msgstr "Stoor profiel"
-
-#: panels/color/cc-color-panel.c:964
-#: panels/network/connection-editor/vpn-helpers.c:311
-msgid "_Save"
-msgstr "_Stoor"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1325
-msgid "Create a color profile for the selected device"
-msgstr "Skep 'n kleurprofiel vir die gekose toestel"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1340 panels/color/cc-color-panel.c:1364
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Die meetinstrument is nie bespeur nie. Maak seker dit is aangeskakel en "
-"korrek ingeprop."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1374
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Die meetinstrument kan nie drukkerprofiele opstel nie."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1385
-msgid "The device type is not currently supported."
-msgstr "Die toesteltipe word nie tans ondersteun nie."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "Standaardruimte"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "Toetsprofiel"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Outomaties"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Lae kwaliteit"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Medium kwaliteit"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Hoë kwaliteit"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Verstek RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Verstek CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Verstek grys"
-
-#: panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "Kalibreerdata soos wat verskaffer in fabriek verskaf"
-
-#: panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Volskermkorrigering van skerm is nie moontlik met dié profiel nie"
-
-#: panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "Dié profiel is dalk nie meer akkuraat is nie"
-
-#: panels/color/color-calibrate.ui:7
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Skermkalibrering"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Kanselleer"
+
 #. This starts the calibration process
-#: panels/color/color-calibrate.ui:40
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "_Begin"
 
 #. This resumes the calibration process
-#: panels/color/color-calibrate.ui:54
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "He_rvat"
 
 #. This button returns the user back to the color control panel
-#: panels/color/color-calibrate.ui:67 panels/common/language-chooser.ui:12
-#: panels/region/format-chooser.ui:14
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Klaar"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: panels/color/color.ui:6 panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Skermkalibrering"
 
-#: panels/color/color.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibreerkwaliteit"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -580,42 +445,42 @@ msgstr ""
 "skerm. Hoe meer tyd geneem word vir kalibrering hoe beter is die kwaliteit "
 "van die kleurprofiel."
 
-#: panels/color/color.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "Die rekenaar kan nie gebruik word tydens kalibrering nie."
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/color.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Kwaliteit"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/color.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Tyd ongeveer"
 
-#: panels/color/color.ui:121
-msgid "Calibration Quality"
-msgstr "Kalibreerkwaliteit"
-
-#: panels/color/color.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Kies die sensortoestel om te gebruik vir kalibrering."
-
-#: panels/color/color.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Kalibreertoestel"
 
-#: panels/color/color.ui:189
-msgid "Select the type of display that is connected."
-msgstr "Kies die tipe skerm wat ingeprop is."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Kies die sensortoestel om te gebruik vir kalibrering."
 
-#: panels/color/color.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Skermtipe"
 
-#: panels/color/color.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Kies die tipe skerm wat ingeprop is."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profiel se witpunt"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -623,11 +488,11 @@ msgstr ""
 "Selekteer 'n skerm teiken witpunt. Meeste skerms moet gekalibreer word na 'n "
 "D65 verligting."
 
-#: panels/color/color.ui:278
-msgid "Profile Whitepoint"
-msgstr "Profiel se witpunt"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Skermhelderheid"
 
-#: panels/color/color.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -635,7 +500,7 @@ msgstr ""
 "Stel die skerm se helderheid soos u dit tipies gebruik. Kleurbestuur sal "
 "akkuraatste wees by die helderheidsvlak."
 
-#: panels/color/color.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -643,11 +508,11 @@ msgstr ""
 "Of u kan die helderheidsvlak gebruik wat met een van die ander profiele vir "
 "dié toestel gebruik word."
 
-#: panels/color/color.ui:318
-msgid "Display Brightness"
-msgstr "Skermhelderheid"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profielnaam"
 
-#: panels/color/color.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -655,64 +520,41 @@ msgstr ""
 "Mens kan 'n kleurprofiel op verskillende rekenaars gebruik, of selfs "
 "profiele skep vir verskillende tipes beligting."
 
-#: panels/color/color.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Profielnaam:"
 
-#: panels/color/color.ui:377
-msgid "Profile Name"
-msgstr "Profielnaam"
-
-#: panels/color/color.ui:392
-msgid "Profile successfully created!"
-msgstr "Profiel is suksesvol geskep!"
-
-#: panels/color/color.ui:443
-msgid "Copy profile"
-msgstr "Kopieer profiel"
-
-#: panels/color/color.ui:456
-msgid "Requires writable media"
-msgstr "Skryfbare media is nodig"
-
-#: panels/color/color.ui:519
-msgid "Upload profile"
-msgstr "Laai profiel op"
-
-#: panels/color/color.ui:532
-msgid "Requires Internet connection"
-msgstr "Internetverbinding is nodig"
-
-#: panels/color/color.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"Raadpleeg gerus hierdie instruksies oor hoe om die profiel te gebruik op <a "
-"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> en <a href="
-"\"windows\">Microsoft Windows</a>."
-
-#: panels/color/color.ui:607 panels/user-accounts/um-fingerprint-dialog.c:720
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Opsomming"
 
-#: panels/color/color.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profiel is suksesvol geskep!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopieer profiel"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Skryfbare media is nodig"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Raadpleeg gerus hierdie instruksies oor hoe om die profiel te gebruik op <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> en <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "Voeg profiel by"
 
-#: panels/color/color.ui:643
-msgid "_Import File…"
-msgstr "_Voer lêer in…"
-
-#: panels/color/color.ui:672
-#: panels/network/connection-editor/net-connection-editor.c:519
-#: panels/printers/new-printer-dialog.ui:80 panels/region/input-chooser.ui:22
-#: panels/user-accounts/data/account-dialog.ui:47
-msgid "_Add"
-msgstr "_Voeg by"
-
-#: panels/color/color.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
@@ -720,141 +562,151 @@ msgstr ""
 "Probleme teëgekom. Die profiel gaan dalk nie werk nie. <a href=\"\">Wys "
 "besonderhede.</a>"
 
-#: panels/color/color.ui:807
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Voer lêer in…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Voeg by"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Elke toestel benodig 'n kleurprofiel wat op datum is om sy kleur te bestuur."
 
-#: panels/color/color.ui:829
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Meer inligting"
 
-#: panels/color/color.ui:834
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Meer oor kleurbestuur"
 
-#: panels/color/color.ui:882
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "_Stel vir alle gebruikers"
 
-#: panels/color/color.ui:886 panels/color/color.ui:901
-#: panels/color/color.ui:902
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Stel dié profiel vir alle gebruikers op dié rekenaar"
 
-#: panels/color/color.ui:897
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "_Aktiveer"
 
-#: panels/color/color.ui:928
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "_Voeg profiel by"
 
-#: panels/color/color.ui:941
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "_Kalibreer…"
 
-#: panels/color/color.ui:945
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Kalibreer die toestel"
 
-#: panels/color/color.ui:956
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "Ve_rwyder 'n profiel"
 
-#: panels/color/color.ui:969
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "_Bekyk besonderhede"
 
-#: panels/color/color.ui:1005
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "Kan nie enige toestelle bespeur waarvoor kleur bestuur kan word nie"
 
-#: panels/color/color.ui:1047
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/color.ui:1052
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/color.ui:1057
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: panels/color/color.ui:1062
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Projektor"
 
-#: panels/color/color.ui:1067
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plasma"
 
-#: panels/color/color.ui:1072
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL-agterlig)"
 
-#: panels/color/color.ui:1077
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED-agterlig)"
 
-#: panels/color/color.ui:1082
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (wit LED-agterlig)"
 
-#: panels/color/color.ui:1087
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Wye spektrum LCD (CCFL-agterlig)"
 
-#: panels/color/color.ui:1092
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Wye spektrum LCD (RGB LED-agterlig)"
 
-#: panels/color/color.ui:1109
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Hoog"
 
-#: panels/color/color.ui:1110
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 minute"
 
-#: panels/color/color.ui:1114
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Medium"
 
-#: panels/color/color.ui:1115 panels/power/power.ui:25
-#: panels/privacy/privacy.ui:38
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 minute"
 
-#: panels/color/color.ui:1119
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Laag"
 
-#: panels/color/color.ui:1120 panels/power/power.ui:13 panels/power/power.ui:95
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 minute"
 
-#: panels/color/color.ui:1142
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Ingebou in die skerm"
 
-#: panels/color/color.ui:1146
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (drukwerk en publisering)"
 
-#: panels/color/color.ui:1150
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/color.ui:1154
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (fotografie en grafika)"
 
-#: panels/color/color.ui:1158
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
@@ -867,235 +719,203 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Kalibreer die kleur van toestelle, bv. skerms, kameras of drukkers"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/color/gnome-color-panel.desktop.in.in:7
-#, fuzzy
-#| msgid "Preferences"
-msgid "preferences-color"
-msgstr "Voorkeure"
-
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "kleur;ICC;profiel;kalibreer;drukker;skerm;"
 
-#: panels/common/cc-common-language.c:323
-msgid "Other…"
-msgstr "Ander…"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Kies 'n taal"
 
-#: panels/common/cc-language-chooser.c:124
-#: panels/region/cc-format-chooser.c:269 panels/region/cc-input-chooser.c:169
-msgid "More…"
-msgstr "Meer…"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Kies"
 
-#: panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Geen tale gevind nie"
 
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:106
-msgid "Today"
-msgstr "Vandag"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Meer…"
 
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "Yesterday"
-msgstr "Gister"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "_Ontsluit"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: panels/common/language-chooser.ui:5
-msgid "Language"
-msgstr "Taal"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "Vergroot:"
 
-#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
-#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
-msgid "Day"
-msgstr "Dag"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Tyd"
 
-#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
-#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
-msgid "Month"
-msgstr "Maand"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
-#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
-msgid "Year"
-msgstr "Jaar"
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "Verklein:"
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:333
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:338
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:503
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:530
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:537
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:542
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:547
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:552
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/datetime.ui:22
-msgid "January"
-msgstr "Januarie"
-
-#: panels/datetime/datetime.ui:25
-msgid "February"
-msgstr "Februarie"
-
-#: panels/datetime/datetime.ui:28
-msgid "March"
-msgstr "Maart"
-
-#: panels/datetime/datetime.ui:31
-msgid "April"
-msgstr "April"
-
-#: panels/datetime/datetime.ui:34
-msgid "May"
-msgstr "Mei"
-
-#: panels/datetime/datetime.ui:37
-msgid "June"
-msgstr "Junie"
-
-#: panels/datetime/datetime.ui:40
-msgid "July"
-msgstr "Julie"
-
-#: panels/datetime/datetime.ui:43
-msgid "August"
-msgstr "Augustus"
-
-#: panels/datetime/datetime.ui:46
-msgid "September"
-msgstr "September"
-
-#: panels/datetime/datetime.ui:49
-msgid "October"
-msgstr "Oktober"
-
-#: panels/datetime/datetime.ui:52
-msgid "November"
-msgstr "November"
-
-#: panels/datetime/datetime.ui:55
-msgid "December"
-msgstr "Desember"
-
-#: panels/datetime/datetime.ui:61
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Datum en tyd"
 
-#: panels/datetime/datetime.ui:106
-msgid "Hour"
-msgstr "Uur"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Jaar"
 
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: panels/datetime/datetime.ui:121
-msgid "∶"
-msgstr "∶"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Maand"
 
-#: panels/datetime/datetime.ui:143
-msgid "Minute"
-msgstr "Minuut"
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januarie"
 
-#: panels/datetime/datetime.ui:208
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februarie"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Maart"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mei"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Junie"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Julie"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Augustus"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Desember"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dag"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Tydsone"
 
-#: panels/datetime/datetime.ui:228
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Soek vir 'n stad"
 
-#: panels/datetime/datetime.ui:304
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "Outomatiese _datum en tyd"
 
-#: panels/datetime/datetime.ui:319 panels/datetime/datetime.ui:397
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Internet toegang is nodig"
 
-#: panels/datetime/datetime.ui:382
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Datum en _tyd"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Outomatiese tyd_sone"
 
-#: panels/datetime/datetime.ui:454
-msgid "Date & _Time"
-msgstr "Datum en _tyd"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "Internet toegang is nodig"
 
-#: panels/datetime/datetime.ui:502
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Geaktiveer"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Tyds_one"
 
-#: panels/datetime/datetime.ui:570
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Kloksgewys"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Tyd_formaat"
 
-#: panels/datetime/datetime.ui:588
-msgid "24-hour"
-msgstr "24-uur"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/datetime.ui:589
-msgid "AM / PM"
-msgstr "VM / NM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datums"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "Sekondêr"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalender"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Getalle"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Verander die datum en tyd, asook tydsone"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/datetime/gnome-datetime-panel.desktop.in.in:7
-msgid "preferences-system-time"
-msgstr ""
-
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "horlosie;tydsone;ligging;"
@@ -1108,144 +928,173 @@ msgstr "Verander instellings vir datum en tyd"
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Om datum of tyd verstellings te maak moet jy eers aanteken."
 
-#: panels/display/cc-display-panel.c:732
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Landskap"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
 
-#: panels/display/cc-display-panel.c:735
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Portret Regs"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Pos"
 
-#: panels/display/cc-display-panel.c:738
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Portret Links"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalender"
 
-#: panels/display/cc-display-panel.c:741
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Landskap (omgedraai)"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usiek"
 
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/display/cc-display-panel.c:808
-#: panels/printers/pp-options-dialog.c:558
-msgid "Orientation"
-msgstr "Oriëntasie"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
 
-#: panels/display/cc-display-panel.c:873 panels/display/cc-display-panel.c:1676
-#: panels/printers/pp-options-dialog.c:87
-msgid "Resolution"
-msgstr "Resolusie"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Foto's"
 
-#: panels/display/cc-display-panel.c:961
-msgid "Refresh Rate"
-msgstr "Verfristempo"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Verstektoepassings"
 
-#: panels/display/cc-display-panel.c:1098
-msgid "Scale"
-msgstr "Skaleer"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Stel verstektoepassings in"
 
-#: panels/display/cc-display-panel.c:1151
-msgid "Adjust for TV"
-msgstr "Verstel vir televisie"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "verstek;toepassing;voorkeur;media;"
 
-#: panels/display/cc-display-panel.c:1413
-msgid "Primary Display"
-msgstr "Primêre skerm"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Probleemrapportering"
 
-#: panels/display/cc-display-panel.c:1442
-msgid "Display Arrangement"
-msgstr "Skerm uitleg"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Outom_atiese probleemrapportering"
 
-#: panels/display/cc-display-panel.c:1443
-msgid ""
-"Drag displays to match your setup. The top bar is placed on the primary "
-"display."
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
 msgstr ""
-"Trek die skerms om te lyk soos jou werklike skerm uitleg. Die balk bo aan "
-"die skerm word slegs vertoon op die primere skerm."
 
-#: panels/display/cc-display-panel.c:1866
-msgid "Display Mode"
-msgstr "Skermmodus"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: panels/display/cc-display-panel.c:1882
-msgid "Join Displays"
-msgstr "Koppel skerms"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
 
-#: panels/display/cc-display-panel.c:1885
-msgid "Mirror"
-msgstr "Dupliseer"
-
-#: panels/display/cc-display-panel.c:1888
-msgid "Single Display"
-msgstr "Enkel skerm"
-
-#: panels/display/cc-display-panel.c:2593
-msgid "Apply Changes?"
-msgstr "Pas veranderinge toe?"
-
-#: panels/display/cc-display-panel.c:2607
-#: panels/network/connection-editor/connection-editor.ui:24
-#: panels/network/network-wifi.ui:38
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "P_as toe"
 
-#: panels/display/cc-display-panel.c:2982
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Terug"
 
-#. TRANSLATORS: the state of the night light setting
-#: panels/display/cc-display-panel.c:3198
-#: panels/notifications/cc-notifications-panel.c:292
-#: panels/power/cc-power-panel.c:1994 panels/power/cc-power-panel.c:2001
-#: panels/privacy/cc-privacy-panel.c:190 panels/privacy/cc-privacy-panel.c:257
-#: panels/universal-access/cc-ua-panel.c:333
-#: panels/universal-access/cc-ua-panel.c:714
-#: panels/universal-access/cc-ua-panel.c:727
-#: panels/universal-access/cc-ua-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:910
-msgid "On"
-msgstr "Aan"
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Bluetooth is gedeaktiveer"
 
-#: panels/display/cc-display-panel.c:3198 panels/network/net-proxy.c:54
-#: panels/notifications/cc-notifications-panel.c:292
-#: panels/power/cc-power-panel.c:1988 panels/power/cc-power-panel.c:1999
-#: panels/privacy/cc-privacy-panel.c:190 panels/privacy/cc-privacy-panel.c:257
-#: panels/universal-access/cc-ua-panel.c:333
-#: panels/universal-access/cc-ua-panel.c:714
-#: panels/universal-access/cc-ua-panel.c:727
-#: panels/universal-access/cc-ua-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:910 panels/universal-access/uap.ui:334
-#: panels/universal-access/uap.ui:380 panels/universal-access/uap.ui:426
-#: panels/universal-access/uap.ui:532 panels/universal-access/uap.ui:685
-#: panels/universal-access/uap.ui:731 panels/universal-access/uap.ui:777
-#: panels/universal-access/uap.ui:929
-msgid "Off"
-msgstr "Af"
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Enkel skerm"
 
-#: panels/display/cc-display-panel.c:3219
-msgid "_Night Light"
-msgstr "_Naglig"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
 
-#: panels/display/cc-display-panel.c:3284
-msgid "Could not get screen information"
-msgstr "Kon nie skerminligting kry nie"
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Dupliseer"
 
-#. This cancels the redshift inhibit.
-#: panels/display/display.ui:71
-msgid "Restart Filter"
-msgstr "Herbegin filter"
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Primêre skerm"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Naglig"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Oriëntasie"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolusie"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Verfristempo"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Verstel vir televisie"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skaleer"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Natuurlike rol"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Naglig"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/display.ui:103
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Tydelik gestop tot die volgende dag"
 
-#: panels/display/display.ui:144
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Herbegin filter"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1253,53 +1102,65 @@ msgstr ""
 "Naglig maak die skermkleur warmer. Dit kan help om oog stremming en "
 "slapeloosheid te voorkom."
 
-#. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/display.ui:171 panels/display/display.ui:567
-msgid "Night Light"
-msgstr "Naglig"
-
-#: panels/display/display.ui:187
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Skeduleer"
 
-#: panels/display/display.ui:215
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Sonsondergang tot Sonsopkoms"
 
-#: panels/display/display.ui:229
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:56 panels/network/network-proxy.ui:113
-#: panels/network/network-wifi.ui:777 panels/network/network-wifi.ui:1054
-#: panels/privacy/cc-privacy-panel.c:217
-msgid "Manual"
-msgstr "Handmatig"
+#: panels/display/cc-night-light-page.ui:141
+#, fuzzy
+msgid "Manual Schedule"
+msgstr "Skeduleer"
 
-#: panels/display/display.ui:268
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Tye"
+
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Van"
 
-#: panels/display/display.ui:309 panels/display/display.ui:430
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Uur"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuut"
+
 #. This is the short form for the time period in the morning
-#: panels/display/display.ui:343 panels/display/display.ui:464
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "VM"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/display.ui:359 panels/display/display.ui:480
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "NM"
 
-#: panels/display/display.ui:528
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Tot"
 
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
 #: panels/display/gnome-display-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "Dis­plays"
 msgid "Displays"
 msgstr "Skerms"
 
@@ -1307,12 +1168,6 @@ msgstr "Skerms"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Kies hoe om ingepropte monitors en projektors te gebruik"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/display/gnome-display-panel.desktop.in.in:7
-msgid "preferences-desktop-display"
-msgstr ""
-
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1321,308 +1176,175 @@ msgstr ""
 "paneel;projektor;xrandr;skerm;resolusie;verfris;monitor;nag;lig;blou;"
 "rooiverskuiwing;kleur;sonsondergang;sonsopkoms;"
 
-#. TRANSLATORS: AP type
-#: panels/info/cc-info-overview-panel.c:374
-#: panels/info/cc-info-overview-panel.c:457 panels/network/panel-common.c:123
-msgid "Unknown"
-msgstr "Onbekend"
-
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info/cc-info-overview-panel.c:465
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; Bou ID: %s"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info/cc-info-overview-panel.c:482
-#, c-format
-msgid "64-bit"
-msgstr "64-bis"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info/cc-info-overview-panel.c:485
-#, c-format
-msgid "32-bit"
-msgstr "32-bis"
-
-#: panels/info/cc-info-overview-panel.c:775
-#, c-format
-msgid "Version %s"
-msgstr "Weergawe %s"
-
-#: panels/info/cc-info-removable-media-panel.c:298
-msgid "Ask what to do"
-msgstr "Vra wat om te doen"
-
-#: panels/info/cc-info-removable-media-panel.c:302
-msgid "Do nothing"
-msgstr "Doen niks"
-
-#: panels/info/cc-info-removable-media-panel.c:306
-msgid "Open folder"
-msgstr "Open gids"
-
-#: panels/info/cc-info-removable-media-panel.c:391
-msgid "Other Media"
-msgstr "Ander media"
-
-#: panels/info/cc-info-removable-media-panel.c:424
-msgid "Select an application for audio CDs"
-msgstr "Kies 'n toepassing vir oudio-CD's"
-
-#: panels/info/cc-info-removable-media-panel.c:425
-msgid "Select an application for video DVDs"
-msgstr "Kies 'n toepassing vir video-DVD's"
-
-#: panels/info/cc-info-removable-media-panel.c:426
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Kies 'n toepassing om uit te voer wanneer 'n musiekspeler ingeprop word"
-
-#: panels/info/cc-info-removable-media-panel.c:427
-msgid "Select an application to run when a camera is connected"
-msgstr "Kies 'n toepassing om uit te voer wanneer 'n kamera ingeprop word"
-
-#: panels/info/cc-info-removable-media-panel.c:428
-msgid "Select an application for software CDs"
-msgstr "Kies 'n toepassing vir sagteware-CD's"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/info/cc-info-removable-media-panel.c:440
-msgid "audio DVD"
-msgstr "oudio-DVD"
-
-#: panels/info/cc-info-removable-media-panel.c:441
-msgid "blank Blu-ray disc"
-msgstr "skoon Blu-Ray-skyf"
-
-#: panels/info/cc-info-removable-media-panel.c:442
-msgid "blank CD disc"
-msgstr "skoon CD-skyf"
-
-#: panels/info/cc-info-removable-media-panel.c:443
-msgid "blank DVD disc"
-msgstr "skoon DVD-skyf"
-
-#: panels/info/cc-info-removable-media-panel.c:444
-msgid "blank HD DVD disc"
-msgstr "skoon HD-DVD-skyf"
-
-#: panels/info/cc-info-removable-media-panel.c:445
-msgid "Blu-ray video disc"
-msgstr "Blu-ray-videoskyf"
-
-#: panels/info/cc-info-removable-media-panel.c:446
-msgid "e-book reader"
-msgstr "e-boekleser"
-
-#: panels/info/cc-info-removable-media-panel.c:447
-msgid "HD DVD video disc"
-msgstr "HD-DVD-videoskyf"
-
-#: panels/info/cc-info-removable-media-panel.c:448
-msgid "Picture CD"
-msgstr "Prente-CD"
-
-#: panels/info/cc-info-removable-media-panel.c:449
-msgid "Super Video CD"
-msgstr "Super Video-CD"
-
-#: panels/info/cc-info-removable-media-panel.c:450
-msgid "Video CD"
-msgstr "Video-CD"
-
-#: panels/info/cc-info-removable-media-panel.c:451
-msgid "Windows software"
-msgstr "Windows-sagteware"
-
-#: panels/info/gnome-default-apps-panel.desktop.in.in:3
-msgid "Default Applications"
-msgstr "Verstektoepassings"
-
-#: panels/info/gnome-default-apps-panel.desktop.in.in:4
-msgid "Configure Default Applications"
-msgstr "Stel verstektoepassings in"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info/gnome-default-apps-panel.desktop.in.in:7
-msgid "starred"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
 msgstr ""
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/info/gnome-default-apps-panel.desktop.in.in:19
-msgid "default;application;preferred;media;"
-msgstr "verstek;toepassing;voorkeur;media;"
-
-#: panels/info/gnome-info-overview-panel.desktop.in.in:3
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
 #, fuzzy
-#| msgid "/_About"
-msgid "About"
-msgstr "/_Aangaande"
+msgid "Security Level"
+msgstr "Sekuriteitsleutel"
 
-#: panels/info/gnome-info-overview-panel.desktop.in.in:4
-msgid "View information about your system"
-msgstr "Vertoon inligting oor die stelsel"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Inkvlak"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info/gnome-info-overview-panel.desktop.in.in:7
-msgid "help-about"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Inkvlak"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Inkvlak"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+#, fuzzy
+msgid "No Events"
+msgstr "Gebeurtenis"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Sekuriteit"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
 msgstr ""
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
-#: panels/info/gnome-info-overview-panel.desktop.in.in:23
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
 msgstr ""
-"toestel;stelsel;inligting;geheue;verwerker;weergawe;verstek;toepassing;"
-"voorkeur;cd;dvd;usb;klank;video;skyf;verwyderbaar;media;outoloop;"
+"skerm;sluit;diagnose;privaat;onlangs;voorlopig;tmp;indeks;naam;netwerk;"
+"identiteit;"
 
-#: panels/info/gnome-removable-media-panel.desktop.in.in:3
-msgid "Removable Media"
-msgstr "Verwyderbare media"
-
-#: panels/info/gnome-removable-media-panel.desktop.in.in:4
-msgid "Configure Removable Media settings"
-msgstr "Verander verwyderbare media instellings"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info/gnome-removable-media-panel.desktop.in.in:7
-msgid "media-removable"
-msgstr ""
-
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/info/gnome-removable-media-panel.desktop.in.in:19
-msgid ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
-"removable;media;autorun;"
-msgstr ""
-"toestel;stelsel;verstek;toepassing;voorkeur;cd;dvd;usb;klank;video;skyf;"
-"verwyderbaar;media;outoloop;"
-
-#: panels/info/info-default-apps.ui:31
-msgid "_Web"
-msgstr "_Web"
-
-#: panels/info/info-default-apps.ui:43
-msgid "_Mail"
-msgstr "_Pos"
-
-#: panels/info/info-default-apps.ui:59
-msgid "_Calendar"
-msgstr "_Kalender"
-
-#: panels/info/info-default-apps.ui:75
-msgid "M_usic"
-msgstr "M_usiek"
-
-#: panels/info/info-default-apps.ui:91
-msgid "_Video"
-msgstr "_Video"
-
-#: panels/info/info-default-apps.ui:162 panels/info/info-removable-media.ui:161
-msgid "_Photos"
-msgstr "_Foto's"
-
-#: panels/info/info-overview.ui:58
-msgid "Device name"
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
 msgstr "Toestelnaam"
 
-#: panels/info/info-overview.ui:74
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Hardewareadres"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "Geheue"
 
-#: panels/info/info-overview.ui:90
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "Verwerker"
 
-#: panels/info/info-overview.ui:106
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "Grafika"
 
-#. To translators: this field contains the distro name and version
-#: panels/info/info-overview.ui:121
-msgid "OS name"
-msgstr "Bedryfstelsel naam"
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
 
-#. To translators: this field contains the distro type
-#: panels/info/info-overview.ui:137
-msgid "OS type"
-msgstr "Tipe bedryfstelsel"
-
-#: panels/info/info-overview.ui:153
-msgid "Virtualization"
-msgstr "Virtualisering"
-
-#: panels/info/info-overview.ui:169
-msgid "Disk"
-msgstr "Skyf"
-
-#: panels/info/info-overview.ui:274
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "Bereken tans…"
 
-#: panels/info/info-overview.ui:314
-msgid "Check for updates"
-msgstr "Kontroleer vir bywerkings"
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Naam"
 
-#: panels/info/info-removable-media.ui:43
-msgid "Select how media should be handled"
-msgstr "Kies hoe die media hanteer moet word"
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; Bou ID: %s"
 
-#: panels/info/info-removable-media.ui:74
-msgid "CD _audio"
-msgstr "CD-_oudio"
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Tipe"
 
-#: panels/info/info-removable-media.ui:91
-msgid "_DVD video"
-msgstr "_DVD-video"
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME-terminaal"
 
-#: panels/info/info-removable-media.ui:132
-msgid "_Music player"
-msgstr "_Musiekspeler"
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Laai tans keuses…"
 
-#: panels/info/info-removable-media.ui:190
-msgid "_Software"
-msgstr "_Sagteware"
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows-sagteware"
 
-#: panels/info/info-removable-media.ui:228
-msgid "_Other Media…"
-msgstr "_Ander media…"
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisering"
 
-#: panels/info/info-removable-media.ui:272
-msgid "_Never prompt or start programs on media insertion"
-msgstr "As media ingedruk word, moet _nooit programme begin of vra daaroor nie"
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Sagtewaregebruik"
 
-#: panels/info/info-removable-media.ui:331
-msgid "Select how other media should be handled"
-msgstr "Kies hoe ander media hanteer moet word"
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Verwyder toestel"
 
-#: panels/info/info-removable-media.ui:370
-msgid "_Action:"
-msgstr "_Aksie:"
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
 
-#: panels/info/info-removable-media.ui:393
-msgid "_Type:"
-msgstr "_Tipe:"
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Toestelnaam"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Hernoem..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Aangaande"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Vertoon inligting oor die stelsel"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"toestel;stelsel;inligting;geheue;verwerker;weergawe;verstek;toepassing;"
+"voorkeur;cd;dvd;usb;klank;video;skyf;verwyderbaar;media;outoloop;"
 
 #: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "Klank en media"
 
 #: panels/keyboard/00-multimedia.xml.in:4
-msgid "Volume mute"
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Volume uit"
 
 #: panels/keyboard/00-multimedia.xml.in:6
@@ -1634,34 +1356,40 @@ msgid "Volume up"
 msgstr "Volume harder"
 
 #: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "Mikrofoonvolume"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Lanseer mediaspeler"
 
-#: panels/keyboard/00-multimedia.xml.in:12
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Speel (of speel/wag)"
 
-#: panels/keyboard/00-multimedia.xml.in:14
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Laat wag terugspeel"
 
-#: panels/keyboard/00-multimedia.xml.in:16
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Stop terugspeel"
 
-#: panels/keyboard/00-multimedia.xml.in:18
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Vorige snit"
 
-#: panels/keyboard/00-multimedia.xml.in:20
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Volgende snit"
 
-#: panels/keyboard/00-multimedia.xml.in:22
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Uitskiet"
 
-#: panels/keyboard/01-input-sources.xml.in:4 panels/universal-access/uap.ui:576
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Tik"
 
@@ -1681,9 +1409,9 @@ msgstr "Lanseerders"
 msgid "Launch help browser"
 msgstr "Laat loop hulpblaaier"
 
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:222
-#: shell/cc-window.c:760 shell/gnome-control-center.desktop.in.in:3
-#: shell/window.ui:125
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "Instellings"
 
@@ -1704,43 +1432,11 @@ msgid "Home folder"
 msgstr "Tuisgids"
 
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/window.ui:157
+msgctxt "keybinding"
 msgid "Search"
 msgstr "Soek"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "Skermskote"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "Stoor 'n skermskoot na $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Stoor 'n skermskoot van 'n venster na $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Stoor 'n skermskoot van 'n area na $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "Kopieer 'n skermskoot na die knipbord"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Kopieer 'n skermskoot van 'n venster na die knipbord"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Kopieer 'n skermskoot van 'n area na die knipbord"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "Neem 'n kort skermvideo op"
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Stelsel"
 
@@ -1754,8 +1450,9 @@ msgstr "Sluit skerm"
 
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
-msgid "Universal Access"
-msgstr "Universele toegang"
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Toeganklikheid..."
 
 #: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
@@ -1789,117 +1486,198 @@ msgstr "Verklein teks"
 msgid "High contrast on or off"
 msgstr "Skakel hoë kontras aan of af"
 
-#: panels/keyboard/cc-keyboard-manager.c:506
-#: panels/keyboard/cc-keyboard-manager.c:514
-#: panels/keyboard/cc-keyboard-manager.c:822
-msgid "Custom Shortcuts"
-msgstr "Pasgemaakte kortpaaie"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Voeg 'n toevoerbron by"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: panels/keyboard/cc-keyboard-option.c:263
-#: panels/keyboard/cc-keyboard-option.c:382
-#: panels/keyboard/keyboard-shortcuts.c:435
-#: panels/keyboard/shortcut-editor.ui:96 panels/network/network-proxy.ui:123
-#: panels/network/network-wifi.ui:782 panels/network/network-wifi.ui:1059
-#: panels/user-accounts/um-fingerprint-dialog.c:211
-#: subprojects/gvc/gvc-mixer-control.c:1866
-msgid "Disabled"
-msgstr "Gedeaktiveer"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Toevoermetodes kan nie gebruik word op die aanmeldskerm nie"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: panels/keyboard/cc-keyboard-option.c:341
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Geen toevoerbronne gekies nie"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Keuses"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Skuif op"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Skuif af"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Voorkeure"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "XKB-sleutelbord-uitleg"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr "Verwyder"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Toevoerbronne"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Keuses vir toevoerbronne"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Gebruik die _selfde bron vir alle vensters"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "_Laat verskillende uitlegte in elke venster toe"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "Sleutel vir alternatiewe karakters"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: panels/keyboard/cc-keyboard-option.c:350
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "Saamstelsleutel"
 
-#: panels/keyboard/cc-keyboard-option.c:355
-msgid "Modifiers-only switch to next source"
-msgstr "Wysigers verander slegs na volgende bron"
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Sleutelbordkortpaaie"
 
-#: panels/keyboard/cc-keyboard-panel.c:181
-msgid "Reset All Shortcuts?"
-msgstr "Skrap alle kortpaaie?"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Pasgemaakte kortpaaie"
 
-#: panels/keyboard/cc-keyboard-panel.c:184
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Stel alles terug…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Herstel alle kortpaaie na hul oorspronklike sleutelbindinge"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Afdeling"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Kortpad"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Voeg kortpad by"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Voeg 'n pasgemaakte kortpad by"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"Die herstel van alle kortpaaie mag jou pasgemaakte kortpaaie affekteer. Die "
-"aksie kan nie ongedaan gemaak word nie."
 
-#: panels/keyboard/cc-keyboard-panel.c:188
-#: panels/keyboard/shortcut-editor.ui:346
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-msgid "Cancel"
-msgstr "Kanselleer"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Voeg kortpad by"
 
-#: panels/keyboard/cc-keyboard-panel.c:189
-msgid "Reset All"
-msgstr "Herstel alles"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Geen sleutelbord kortpad gevind nie"
 
-#: panels/keyboard/cc-keyboard-panel.c:281
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "Verwyder"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "Vervang"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+#, fuzzy
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Druk Esc om te kanselleer of Backspace om die sleutelbordkortpaaie te "
+"herstel."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Naam"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Opdrag"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Kortpad"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Nuwe Kortpad…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Geen"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Herstel die kortpad na sy oorspronklike waarde"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:413
-#, c-format
-msgid ""
-"%s is already being used for <b>%s</b>. If you replace it, %s will be "
-"disabled"
-msgstr ""
-"%s word klaar gebruik deur <b>%s</b>. Indien jy dit vervang sal, %s "
-"gedeaktiveer word"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:583
-msgid "Set Custom Shortcut"
-msgstr "Stel 'n pasgemaakte kortpad"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:583
-msgid "Set Shortcut"
-msgstr "Stel Kortpad"
-
-#. Setup the top label
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:592
-#, c-format
-msgid "Enter new shortcut to change <b>%s</b>."
-msgstr "Voeg 'n nuwe kortpad by om <b>%s</b> te verander."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:1019
-msgid "Add Custom Shortcut"
-msgstr "Voeg 'n pasgemaakte kortpad by"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "He_rstel na verstek"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "Key­board"
 msgid "Keyboard"
 msgstr "Sleutelbord"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr "Vertoon en verander sleutelbordkortpaaie en stel tikvoorkeure"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:7
-msgid "input-keyboard"
-msgstr ""
-
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -1907,82 +1685,234 @@ msgstr ""
 "kortpad;werkspasie;venster;verander;grootte;zoem;kontras;invoer;bron;sluit;"
 "volume;"
 
-#: panels/keyboard/gnome-keyboard-panel.ui:67 panels/region/input-options.ui:68
-#: shell/cc-application.c:255
-msgid "Keyboard Shortcuts"
-msgstr "Sleutelbordkortpaaie"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "Liggingdienste"
 
-#: panels/keyboard/gnome-keyboard-panel.ui:77
-msgid "Reset All…"
-msgstr "Stel alles terug…"
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Geen toepassing wat tans oudio speel of opneem nie."
 
-#: panels/keyboard/gnome-keyboard-panel.ui:78
-msgid "Reset all shortcuts to their default keybindings"
-msgstr "Herstel alle kortpaaie na hul oorspronklike sleutelbindinge"
-
-#: panels/keyboard/gnome-keyboard-panel.ui:164
-msgid "No keyboard shortcut found"
-msgstr "Geen sleutelbord kortpad gevind nie"
-
-#: panels/keyboard/gnome-keyboard-panel.ui:175 shell/panel-list.ui:206
-msgid "Try a different search"
-msgstr "Probeer 'n ander soektog"
-
-#: panels/keyboard/shortcut-editor.ui:68 panels/keyboard/shortcut-editor.ui:318
-msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
-"Druk Esc om te kanselleer of Backspace om die sleutelbordkortpaaie te "
-"herstel."
 
-#: panels/keyboard/shortcut-editor.ui:156 panels/printers/details-dialog.ui:38
-#: panels/sound/gvc-mixer-dialog.c:1480
-#: panels/sound/gvc-sound-theme-chooser.c:554
-msgid "Name"
-msgstr "Naam"
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:168
-msgid "Command"
-msgstr "Opdrag"
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:180
-msgid "Shortcut"
-msgstr "Kortpad"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:259
-msgid "Set Shortcut…"
-msgstr "Nuwe Kortpad…"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Mikrofoonvolume"
 
-#: panels/keyboard/shortcut-editor.ui:272 panels/network/network-wifi.ui:594
-msgid "None"
-msgstr "Geen"
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Geen toepassings gevind nie"
 
-#: panels/keyboard/shortcut-editor.ui:303
-msgid "Enter the new shortcut"
-msgstr "Voer 'n nuwe kortpad in"
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:357
-msgid "Remove"
-msgstr "Verwyder"
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:367
-msgid "Add"
-msgstr "Voeg by"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:382
-msgid "Replace"
-msgstr "Vervang"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:395
-msgid "Set"
-msgstr "Kies"
-
-#: panels/mouse/cc-mouse-panel.c:82 panels/wacom/cc-wacom-panel.c:402
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Toet_s die instellings"
 
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Algemeen"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primêre knoppie"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Stel die volgorde van fisiese knoppies op muise en raakblaaie."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Links"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Regs"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Soekliggings"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Muis"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "Muisspoed"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Rol af"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "Rol skuif die inhoud, nie die aansig nie."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Rol skuif die inhoud, nie die aansig nie."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Versnelling:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktief"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Raakblad"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "Raakblad se spoed"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "Raak om te klik"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Raak om te klik"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Deaktiveer tydens _tik"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Raakblad (relatief)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Rol op die rand"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Rol links"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Albei kante"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Probeer klik, dubbelklik, rol"
+
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "Mouse & Touch­pad"
 msgid "Mouse & Touchpad"
 msgstr "Muis en Raakblad"
 
@@ -1993,676 +1923,454 @@ msgstr ""
 "Verander sensitiwiteit van die muis of raakblad en kies regs- of "
 "linkerhandigheid"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/mouse/gnome-mouse-panel.desktop.in.in:7
-msgid "input-mouse"
-msgstr ""
-
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "raakblad;wyser;klik;kliek;raak;dubbel;knoppie;rolbal;rol;"
 
-#: panels/mouse/gnome-mouse-properties.ui:45
-msgid "General"
-msgstr "Algemeen"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:83
-msgid "Primary Button"
-msgstr "Primêre knoppie"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:102
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "Stel die volgorde van fisiese knoppies op muise en raakblaaie."
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:131
-msgid "Left"
-msgstr "Links"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:141
-msgid "Right"
-msgstr "Regs"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Kleurruimte: "
 
-#: panels/mouse/gnome-mouse-properties.ui:177
-msgid "Mouse"
-msgstr "Muis"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:216
-msgid "Mouse Speed"
-msgstr "Muisspoed"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "_Maak asblik outomaties leeg"
 
-#: panels/mouse/gnome-mouse-properties.ui:238
-#: panels/mouse/gnome-mouse-properties.ui:543
-msgid "Double-click timeout"
-msgstr "Dubbelklik-uitteltyd"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/gnome-mouse-properties.ui:275
-#: panels/mouse/gnome-mouse-properties.ui:451
-msgid "Natural Scrolling"
-msgstr "Natuurlike rol"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:291
-#: panels/mouse/gnome-mouse-properties.ui:467
-msgid "Scrolling moves the content, not the view."
-msgstr "Rol skuif die inhoud, nie die aansig nie."
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:341
-#: panels/mouse/gnome-mouse-properties.ui:386
-msgid "Touchpad"
-msgstr "Raakblad"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "%s-monitor"
 
-#: panels/mouse/gnome-mouse-properties.ui:522
-msgid "Touchpad Speed"
-msgstr "Raakblad se spoed"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Sleep om die primêre vertoonarea te verander."
 
-#: panels/mouse/gnome-mouse-properties.ui:581
-msgid "Tap to Click"
-msgstr "Raak om te klik"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:634
-msgid "Two-finger Scrolling"
-msgstr "Rol met twee vingers"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Toepassings gedefinieer"
 
-#: panels/mouse/gnome-mouse-properties.ui:687
-msgid "Edge Scrolling"
-msgstr "Rol op die rand"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:130 panels/mouse/gnome-mouse-test.ui:23
-msgid "Try clicking, double clicking, scrolling"
-msgstr "Probeer klik, dubbelklik, rol"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "Vyf kliks, GEGL tyd!"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "Dubbelklik, primêre knoppie"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "Enkelklik, primêre knoppie"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "Dubbelklik, middelknoppie"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Toestelle"
 
-#: panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "Enkelklik, middelknoppie"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "Dubbelklik, sekondêre knoppie"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Voeg nuwe verbinding by"
 
-#: panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "Enkelklik, sekondêre knoppie"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nie opgestel nie"
 
-#. add proxy to device list
-#: panels/network/cc-network-panel.c:582
-msgid "Network proxy"
-msgstr "Netwerkinstaner"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Gekoppel"
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/cc-network-panel.c:718 panels/network/net-vpn.c:170
-#: panels/network/net-vpn.c:299
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Keuses…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%s VPN"
-msgstr "%s-VPN"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#: panels/network/cc-network-panel.c:782 panels/network/wifi.ui:282
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Skakel 'n Wi-Fi-kuberkol aan?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Netwerknaam"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Wagwoord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Groepwagwoord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Kies 'n gegenereerde wagwoord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Skakel aan"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Vlugmodus"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Deaktiveer Wi-Fi, Bluetooth en mobiele breëband"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Geen Wi-Fi passtukke gevind nie"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Versker dat die Wi-Fi-passtuk ingeprop en angeskakel is"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Vlugmodus"
+
+#: panels/network/cc-wifi-panel.ui:165
+#, fuzzy
+msgid "Turn off to use Wi-Fi"
+msgstr "Skakel die Wi-Fi af om krag te spaar."
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi-Kuberkol"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Skakel Wi-Fi-kuberkol aan…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Sigbare netwerke"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager moet loop"
+
+#: panels/network/cc-wifi-panel.ui:303
 msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr "Oeps! Iets het foutgeloop. Kontak die sagtewareverskaffer."
 
-#: panels/network/cc-network-panel.c:788
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager moet loop."
-
-#: panels/network/cc-wifi-panel.c:213
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:1769
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/connection-editor/8021x-security-page.ui:26
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x-_sekuriteit"
 
-#: panels/network/connection-editor/8021x-security-page.ui:73
-#: panels/network/connection-editor/security-page.ui:72
-#: panels/wacom/wacom-stylus-page.ui:108
-msgid "page 1"
-msgstr "bladsy 1"
-
-#: panels/network/connection-editor/8021x-security-page.ui:224
-#: panels/network/connection-editor/security-page.ui:223
-#: panels/network/wireless-security/eap-method-fast.ui:50
-#: panels/network/wireless-security/eap-method-peap.ui:48
-#: panels/network/wireless-security/eap-method-ttls.ui:31
-msgid "Anony_mous identity"
-msgstr "Anonie_me identiteit"
-
-#: panels/network/connection-editor/8021x-security-page.ui:238
-#: panels/network/connection-editor/security-page.ui:237
-msgid "Inner _authentication"
-msgstr "Binne _verifikasie"
-
-#: panels/network/connection-editor/8021x-security-page.ui:281
-#: panels/network/connection-editor/security-page.ui:280
-#: panels/wacom/wacom-stylus-page.ui:426
-msgid "page 2"
-msgstr "bladsy 2"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:101
-#: panels/network/connection-editor/ce-page-security.c:445
-#: panels/network/connection-editor/details-page.ui:86
-#: panels/network/network-wifi.ui:239
-msgid "Security"
-msgstr "Sekuriteit"
-
-#: panels/network/connection-editor/ce-page.c:481
-msgid "automatic"
-msgstr "outomaties"
-
-#: panels/network/connection-editor/ce-page.c:521
-#, c-format
-msgid "Profile %d"
-msgstr "Profiel %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:56
-#: panels/network/net-device-wifi.c:235 panels/network/net-device-wifi.c:468
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:60
-#: panels/network/net-device-wifi.c:239 panels/network/net-device-wifi.c:473
-#: panels/network/network-wifi.ui:593
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:64
-#: panels/network/net-device-wifi.c:243
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:69
-#: panels/network/net-device-wifi.c:248
-msgid "Enterprise"
-msgstr "Onderneming"
-
-#: panels/network/connection-editor/ce-page-details.c:74
-#: panels/network/net-device-wifi.c:253 panels/network/net-device-wifi.c:458
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Geen"
-
-#: panels/network/connection-editor/ce-page-details.c:95
-#: panels/power/power.ui:99
-msgid "Never"
-msgstr "Nooit"
-
-#: panels/network/connection-editor/ce-page-details.c:110
-#: panels/network/net-device-ethernet.c:121
-#: panels/network/net-device-wifi.c:567
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i dag gelede"
 msgstr[1] "%i dae gelede"
 
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:225
-#: panels/network/net-device-ethernet.c:50 panels/network/net-device-wifi.c:646
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mg/s"
-
-#: panels/network/connection-editor/ce-page-details.c:251
-#: panels/network/net-device-wifi.c:675
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Geen"
-
-#: panels/network/connection-editor/ce-page-details.c:253
-#: panels/network/net-device-wifi.c:677
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Swak"
-
-#: panels/network/connection-editor/ce-page-details.c:255
-#: panels/network/net-device-wifi.c:679
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Redelik"
-
-#: panels/network/connection-editor/ce-page-details.c:257
-#: panels/network/net-device-wifi.c:681
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Goed"
-
-#: panels/network/connection-editor/ce-page-details.c:259
-#: panels/network/net-device-wifi.c:683
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Uitstekend"
-
-#: panels/network/connection-editor/ce-page-details.c:302
-msgid "Forget Connection"
-msgstr "Vergeet verbinding"
-
-#: panels/network/connection-editor/ce-page-details.c:304
-msgid "Remove Connection Profile"
-msgstr "Verwyder verbindingprofiel"
-
-#: panels/network/connection-editor/ce-page-details.c:306
-msgid "Remove VPN"
-msgstr "Verwyder VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-#: panels/network/network-wifi.ui:1456 shell/cc-window.c:214
-#: shell/panel-list.ui:103
-msgid "Details"
-msgstr "Besonderhede"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:174
-#: panels/network/connection-editor/ce-page-vpn.c:188
-#: panels/network/connection-editor/ce-page-wifi.c:194
-#: panels/network/network-wifi.ui:1460
-msgid "Identity"
-msgstr "Identiteit"
-
-#: panels/network/connection-editor/ce-page-ip4.c:251
-#: panels/network/connection-editor/ce-page-ip6.c:230
-msgid "Delete Address"
-msgstr "Skrap adres"
-
-#: panels/network/connection-editor/ce-page-ip4.c:422
-#: panels/network/connection-editor/ce-page-ip6.c:390
-msgid "Delete Route"
-msgstr "Skrap roete"
-
-#: panels/network/connection-editor/ce-page-ip4.c:896
-#: panels/network/network-wifi.ui:1464
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:828
-#: panels/network/network-wifi.ui:1468
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:245
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Geen"
-
-#: panels/network/connection-editor/ce-page-security.c:268
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bis-sleutel (Heks of ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:278
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bis wagwoordfrase"
-
-#: panels/network/connection-editor/ce-page-security.c:291
-#: panels/network/wireless-security/wireless-security.c:465
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:304
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dinamiese WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:318
-msgid "WPA & WPA2 Personal"
-msgstr "WPA en WPA2 (persoonlik)"
-
-#: panels/network/connection-editor/ce-page-security.c:332
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA en WPA2 (onderneming)"
-
-#: panels/network/connection-editor/details-page.ui:18
-#: panels/network/network-wifi.ui:174
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Seinsterkte"
 
-#: panels/network/connection-editor/details-page.ui:52
-#: panels/network/network-wifi.ui:207
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Skakelspoed"
 
-#: panels/network/connection-editor/details-page.ui:104
-#: panels/network/net-device-ethernet.c:154 panels/network/network-wifi.ui:256
-#: panels/network/panel-common.c:644
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sekuriteit"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4-adres"
 
-#: panels/network/connection-editor/details-page.ui:122
-#: panels/network/net-device-ethernet.c:155
-#: panels/network/net-device-ethernet.c:159
-#: panels/network/network-mobile.ui:189 panels/network/network-wifi.ui:273
-#: panels/network/panel-common.c:645
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6-adres"
 
-#: panels/network/connection-editor/details-page.ui:140
-#: panels/network/net-device-ethernet.c:162 panels/network/network-wifi.ui:290
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Hardewareadres"
 
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Ondersteunde ICC-profiele"
+
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/network-mobile.ui:206 panels/network/network-wifi.ui:307
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Verstekroete"
 
-#: panels/network/connection-editor/details-page.ui:177
-#: panels/network/connection-editor/ip4-page.ui:197
-#: panels/network/connection-editor/ip6-page.ui:211
-#: panels/network/net-device-ethernet.c:168
-#: panels/network/network-mobile.ui:224 panels/network/network-wifi.ui:325
-#: panels/network/network-wifi.ui:832 panels/network/network-wifi.ui:1109
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: panels/network/connection-editor/details-page.ui:195
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Laas gebruik"
 
-#: panels/network/connection-editor/details-page.ui:324
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "Koppel _outomaties"
 
-#: panels/network/connection-editor/details-page.ui:343
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Maak beskikbaar aan _ander gebruikers"
 
-#: panels/network/connection-editor/details-page.ui:376
-msgid "Restrict background data usage"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:386
-msgid "Appropriate for connections that have data charges or limits."
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:16
-#: panels/network/connection-editor/ethernet-page.ui:39
-#: panels/network/connection-editor/ip4-page.ui:209
-#: panels/network/connection-editor/ip4-page.ui:277
-#: panels/network/connection-editor/ip6-page.ui:42
-#: panels/network/connection-editor/ip6-page.ui:223
-#: panels/network/connection-editor/ip6-page.ui:291
-#: panels/network/net-proxy.c:58 panels/network/network-proxy.ui:103
-#: panels/network/wireless-security/eap-method-peap.ui:22
-#: panels/privacy/cc-privacy-panel.c:217
-msgid "Automatic"
-msgstr "Outomaties"
-
-#: panels/network/connection-editor/ethernet-page.ui:19
-msgid "Twisted Pair (TP)"
-msgstr "Gedraaide draadpaar (TP)"
-
-#: panels/network/connection-editor/ethernet-page.ui:22
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Aanhangsel Eenheid Koppelvlak (AEK)"
-
-#: panels/network/connection-editor/ethernet-page.ui:25
-msgid "BNC"
-msgstr "BNC"
-
-#: panels/network/connection-editor/ethernet-page.ui:28
-msgid "Media Independent Interface (MII)"
-msgstr "Media Onafhankilike Koppelvlak (MOK)"
-
-#: panels/network/connection-editor/ethernet-page.ui:42
-msgid "10 Mb/s"
-msgstr "10 Mg/s"
-
-#: panels/network/connection-editor/ethernet-page.ui:45
-msgid "100 Mb/s"
-msgstr "100 Mg/s"
-
-#: panels/network/connection-editor/ethernet-page.ui:48
-msgid "1 Gb/s"
-msgstr "1 Gg/s"
-
-#: panels/network/connection-editor/ethernet-page.ui:51
-msgid "10 Gb/s"
-msgstr "10 Gg/s"
-
-#: panels/network/connection-editor/ethernet-page.ui:71
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Naam"
 
-#: panels/network/connection-editor/ethernet-page.ui:100
-#: panels/network/connection-editor/wifi-page.ui:68
-#: panels/network/network-wifi.ui:1261
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "_MAC-adres"
 
-#: panels/network/connection-editor/ethernet-page.ui:146
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: panels/network/connection-editor/ethernet-page.ui:163
-#: panels/network/connection-editor/wifi-page.ui:98
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "_Gekloonde adres"
 
-#: panels/network/connection-editor/ethernet-page.ui:178
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "grepe"
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "IPv_4 Metode"
 
-#: panels/network/connection-editor/ip4-page.ui:42
-#: panels/network/network-wifi.ui:778 panels/network/network-wifi.ui:1055
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "Outomaties (DHCP)"
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "Skakel slegs plaaslik"
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Handmatig"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "Deaktiveer"
 
-#: panels/network/connection-editor/ip4-page.ui:111
-#: panels/network/connection-editor/ip6-page.ui:125
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "Gedeel met ander rekenaars"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "Adresse"
 
-#: panels/network/connection-editor/ip4-page.ui:129
-#: panels/network/connection-editor/ip4-page.ui:313
-#: panels/network/connection-editor/ip6-page.ui:143
-#: panels/network/connection-editor/ip6-page.ui:327
-#: panels/printers/details-dialog.ui:87
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Adres"
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Netmasker"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Deurgang"
 
-#: panels/network/connection-editor/ip4-page.ui:220
-#: panels/network/connection-editor/ip6-page.ui:234
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Outomaties"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "Outomatiese DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:244
-#: panels/network/connection-editor/ip6-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Verdeel IP adresse met kommas"
 
-#: panels/network/connection-editor/ip4-page.ui:265
-#: panels/network/connection-editor/ip6-page.ui:279
-#: panels/network/network-wifi.ui:877 panels/network/network-wifi.ui:1154
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Roetes"
 
-#: panels/network/connection-editor/ip4-page.ui:288
-#: panels/network/connection-editor/ip6-page.ui:302
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Outomatiese roetes"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:354
-#: panels/network/connection-editor/ip6-page.ui:368
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Mates"
 
-#: panels/network/connection-editor/ip4-page.ui:384
-#: panels/network/connection-editor/ip6-page.ui:398
-#: panels/network/network-wifi.ui:933 panels/network/network-wifi.ui:1210
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Gebruik hierdie verbinding _slegs vir hulpbronne op sy netwerk"
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "IPv_6 Metode"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "Outomaties, slegs DHCP"
 
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Voorvoegsel"
 
-#: panels/network/connection-editor/net-connection-editor.c:273
-msgid "Unable to open connection editor"
-msgstr "Kan nie verbindingredigeerder open nie"
-
-#: panels/network/connection-editor/net-connection-editor.c:291
-msgid "New Profile"
-msgstr "Nuwe profiel"
-
-#: panels/network/connection-editor/net-connection-editor.c:603
-#: panels/network/network.ui:142
-msgid "VPN"
-msgstr "VPN"
-
-#: panels/network/connection-editor/net-connection-editor.c:751
-msgid "Import from file…"
-msgstr "Voer vanaf lêer in…"
-
-#: panels/network/connection-editor/net-connection-editor.c:785
-msgid "Add VPN"
-msgstr "Voeg 'n VPN by"
-
-#: panels/network/connection-editor/security-page.ui:26
-#: panels/network/network-wifi.ui:529
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_ekuriteit"
 
-#: panels/network/connection-editor/vpn-helpers.c:141
-msgid "Cannot import VPN connection"
-msgstr "Kan nie VPN-verbinding invoer nie"
-
-#: panels/network/connection-editor/vpn-helpers.c:143
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Die lêer \"%s\" kon nie gelees word nie of die inligting vir VPN-verbinding "
-"word nie herken nie.\n"
-"\n"
-"Fout: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:178
-msgid "Select file to import"
-msgstr "Kies lêer om in te voer"
-
-#: panels/network/connection-editor/vpn-helpers.c:182
-#: panels/printers/pp-details-dialog.c:332
-#: panels/sharing/cc-sharing-panel.c:385
-#: panels/user-accounts/um-photo-dialog.c:231
-msgid "_Open"
-msgstr "_Open"
-
-#: panels/network/connection-editor/vpn-helpers.c:230
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "'n Lêer genaamd \"%s\" bestaan reeds."
-
-#: panels/network/connection-editor/vpn-helpers.c:232
-msgid "_Replace"
-msgstr "Ve_rvang"
-
-#: panels/network/connection-editor/vpn-helpers.c:234
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Wil u %s vervang met die VPN-verbinding wat u nou stoor?"
-
-#: panels/network/connection-editor/vpn-helpers.c:270
-msgid "Cannot export VPN connection"
-msgstr "Kan nie VPN-verbinding uitvoer nie"
-
-#: panels/network/connection-editor/vpn-helpers.c:272
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Die VPN-verbinding \"%s\" kon nie uitgevoer word na %s nie.\n"
-"\n"
-"Fout: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:307
-msgid "Export VPN connection"
-msgstr "Voer VPN-verbinding uit"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(Fout: kan nie VPN-verbindingredigeerder laai nie)"
 
-#: panels/network/connection-editor/wifi-page.ui:20
-#: panels/network/network-wifi.ui:497
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
-#: panels/network/network-wifi.ui:513
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
 
-#: panels/network/connection-editor/wifi-page.ui:53
-#: panels/network/network-wifi.ui:562
-msgid "My Home Network"
-msgstr "Huisnetwerk"
-
 #: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:241
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "Netwerk"
 
@@ -2670,996 +2378,327 @@ msgstr "Netwerk"
 msgid "Control how you connect to the Internet"
 msgstr "Bepaal hoe om te koppel aan die internet"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/network/gnome-network-panel.desktop.in.in:7
-msgid "network-workgroup"
-msgstr ""
-
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"DNS;"
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "netwerk;draadloos;Wi-Fi;IP;LAN;instaanbediener;WAN;breëband;modem;bluetooth;"
 "vpn;brug;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Bepaal hoe om te koppel aan Wi-Fi verbindings"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/network/gnome-wifi-panel.desktop.in.in:7
-#, fuzzy
-#| msgid "Network;Wireless;IP;LAN;"
-msgid "network-wireless"
-msgstr "Network;Wireless;IP;LAN;netwerk;draadloos;"
-
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
-msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "netwerk;draadloos;Wi-Fi;wifi;LAN;breeband;DNS;"
 
-#: panels/network/net-device-ethernet.c:107
-#: panels/network/net-device-wifi.c:553
-msgid "never"
-msgstr "nog nooit"
-
-#: panels/network/net-device-ethernet.c:117
-#: panels/network/net-device-wifi.c:563
-msgid "today"
-msgstr "vandag"
-
-#: panels/network/net-device-ethernet.c:119
-#: panels/network/net-device-wifi.c:565
-msgid "yesterday"
-msgstr "gister"
-
-#: panels/network/net-device-ethernet.c:157
-#: panels/network/network-mobile.ui:172 panels/network/panel-common.c:647
-#: panels/network/panel-common.c:649
-msgid "IP Address"
-msgstr "IP-adres"
-
-#: panels/network/net-device-ethernet.c:173 panels/network/network-wifi.ui:342
-msgid "Last used"
-msgstr "Laas gebruik"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:276
-#: panels/network/network-ethernet.ui:19 panels/network/network-simple.ui:39
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Draad"
 
-#: panels/network/net-device-ethernet.c:344
-#: panels/network/net-device-wifi.c:1895 panels/network/network-ethernet.ui:120
-#: panels/network/network-mobile.ui:394 panels/network/network-simple.ui:75
-#: panels/network/network-vpn.ui:79
-msgid "Options…"
-msgstr "Keuses…"
-
-#: panels/network/net-device-mobile.c:238
-msgid "Add new connection"
-msgstr "Voeg nuwe verbinding by"
-
-#: panels/network/net-device-wifi.c:1368
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "Deur die kuberkol aan te skakel, sal u ontkoppel van <b>%s</b>."
-
-#: panels/network/net-device-wifi.c:1372
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"Dis nie moontlik om deur die draadloos internettoegang te kry terwyl die "
-"kuberkol aktief is nie."
-
-#: panels/network/net-device-wifi.c:1379
-msgid "Turn On Wi-Fi Hotspot?"
-msgstr "Skakel 'n Wi-Fi-kuberkol aan?"
-
-#: panels/network/net-device-wifi.c:1401
-msgid ""
-"Wi-Fi hotspots are usually used to share an additional Internet connection "
-"over Wi-Fi."
-msgstr ""
-"'n Wi-Fi kuberkol word gewoonlik gebruik om 'n addisionele internet "
-"verbinding oor Wi-Fi te deel."
-
-#: panels/network/net-device-wifi.c:1412
-msgid "_Turn On"
-msgstr "_Skakel aan"
-
-#: panels/network/net-device-wifi.c:1489
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Stop kuberkol en ontkoppel alle gebruikers?"
-
-#: panels/network/net-device-wifi.c:1492
-msgid "_Stop Hotspot"
-msgstr "_Stop kuberkol"
-
-#: panels/network/net-device-wifi.c:1592
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Stelselbeleid verbied die gebruik van 'n kuberkol"
-
-#: panels/network/net-device-wifi.c:1595
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Draadlose toestel het nie steun vir kuberkolmodus nie"
-
-#: panels/network/net-device-wifi.c:1733
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Netwerkbesonderhede vir die gekose netwerke sal verloor word, insluitend "
-"wagwoorde en enige eie opstelling."
-
-#: panels/network/net-device-wifi.c:1737 panels/network/network-wifi.ui:1362
-msgid "_Forget"
-msgstr "_Vergeet"
-
-#: panels/network/net-device-wifi.c:2046 panels/network/net-device-wifi.c:2053
-msgid "Known Wi-Fi Networks"
-msgstr "Bekende Wi-Fi netwerke"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:2086
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Vergeet"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:102
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Outomatiese opspoor van webinstaanbedieners word gebruik wanneer 'n "
-"opstelling-URL nie verskaf word nie."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:110
-msgid "This is not recommended for untrusted public networks."
-msgstr "Dié word nié aanbeveel vir onvertroude openbare netwerke nie."
-
-#: panels/network/network-mobile.ui:30
-msgid "IMEI"
-msgstr "IMEI"
-
-#: panels/network/network-mobile.ui:48
-msgid "Provider"
-msgstr "Verskaffer"
-
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:92
-msgid "Network Proxy"
-msgstr "Netwerkinstaner"
-
-#: panels/network/network-proxy.ui:173
-msgid "_HTTP Proxy"
-msgstr "_HTTP-instaanbediener"
-
-#: panels/network/network-proxy.ui:192
-msgid "H_TTPS Proxy"
-msgstr "H_TTPS-instaanbediener"
-
-#: panels/network/network-proxy.ui:211
-msgid "_FTP Proxy"
-msgstr "_FTP-instaanbediener"
-
-#: panels/network/network-proxy.ui:230
-msgid "_Socks Host"
-msgstr "_Socks-gasheer"
-
-#: panels/network/network-proxy.ui:249
-msgid "_Ignore Hosts"
-msgstr "_Ignoreer gashere"
-
-#: panels/network/network-proxy.ui:287
-msgid "HTTP proxy port"
-msgstr "HTTP-instaanpoort"
-
-#: panels/network/network-proxy.ui:364
-msgid "HTTPS proxy port"
-msgstr "HTTPS-instaanpoort"
-
-#: panels/network/network-proxy.ui:385
-msgid "FTP proxy port"
-msgstr "FTP-instaanpoort"
-
-#: panels/network/network-proxy.ui:406
-msgid "Socks proxy port"
-msgstr "SOCKS-instaanpoort"
-
-#: panels/network/network-proxy.ui:435
-msgid "_Configuration URL"
-msgstr "_Konfigurasie-URL"
-
-#: panels/network/network-simple.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Skakel toestel af"
 
-#: panels/network/network.ui:194
-msgid "Not set up"
-msgstr "Nie opgestel nie"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Aktief"
 
-#: panels/network/network-vpn.ui:56
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Verskaffer"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adres"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Netwerkinstaner"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP-instaanbediener"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS-instaanbediener"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP-instaanbediener"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks-gasheer"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignoreer gashere"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP-instaanpoort"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS-instaanpoort"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP-instaanpoort"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "SOCKS-instaanpoort"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Konfigurasie-URL"
+
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "Skakel VPN-verbinding af"
 
-#: panels/network/network-wifi.ui:127
-msgid "Automatic _Connect"
-msgstr "Outomatiese _koppeling"
-
-#: panels/network/network-wifi.ui:474
-msgid "details"
-msgstr "besonderhede"
-
-#: panels/network/network-wifi.ui:545
-#: panels/network/wireless-security/eap-method-leap.ui:40
-#: panels/network/wireless-security/eap-method-simple.ui:40
-#: panels/network/wireless-security/ws-leap.ui:40
-#: panels/network/wireless-security/ws-wpa-psk.ui:22
-#: panels/sharing/sharing.ui:351
-#: panels/user-accounts/data/account-dialog.ui:300
-#: panels/user-accounts/data/account-dialog.ui:525
-#: panels/user-accounts/data/user-accounts-dialog.ui:205
-msgid "_Password"
-msgstr "_Wagwoord"
-
-#: panels/network/network-wifi.ui:622
-msgid "Show P_assword"
-msgstr "Wys w_agwoord"
-
-#: panels/network/network-wifi.ui:652
-msgid "Make available to other users"
-msgstr "Maak beskikbaar aan ander gebruikers"
-
-#: panels/network/network-wifi.ui:680
-msgid "identity"
-msgstr "identiteit"
-
-#: panels/network/network-wifi.ui:714
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: panels/network/network-wifi.ui:755 panels/network/network-wifi.ui:1032
-msgid "_Addresses"
-msgstr "_Adresse"
-
-#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
-msgid "Automatic (DHCP) addresses only"
-msgstr "Slegs outomatiese (DHCP-) adresse"
-
-#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
-msgid "Link-local only"
-msgstr "Skakel slegs plaaslik"
-
-#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
-msgid "Shared with other computers"
-msgstr "Gedeel met ander rekenaars"
-
-#: panels/network/network-wifi.ui:917 panels/network/network-wifi.ui:1194
-msgid "_Ignore automatically obtained routes"
-msgstr "_Ignoreer roetes wat outomaties verkry is"
-
-#: panels/network/network-wifi.ui:960
-msgid "ipv4"
-msgstr "ipv4"
-
-#: panels/network/network-wifi.ui:991
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: panels/network/network-wifi.ui:1237
-msgid "ipv6"
-msgstr "ipv6"
-
-#: panels/network/network-wifi.ui:1277
-msgid "_Cloned MAC Address"
-msgstr "_Gekloonde MAC-adres"
-
-#: panels/network/network-wifi.ui:1327
-msgid "hardware"
-msgstr "hardeware"
-
-#: panels/network/network-wifi.ui:1346
-msgid "_Reset"
-msgstr "Stel te_rug"
-
-#: panels/network/network-wifi.ui:1382
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"Stel die instellings vir dié verbinding terug, maar onthou dit as 'n "
-"voorkeurverbinding."
-
-#: panels/network/network-wifi.ui:1399
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"Verwyder alle besonderhede wat met dié netwerk te doen het en moenie weer "
-"outomaties daaraan probeer koppel nie."
-
-#: panels/network/network-wifi.ui:1419
-msgid "reset"
-msgstr "herstel"
-
-#: panels/network/network-wifi.ui:1472
-msgid "Hardware"
-msgstr "Hardeware"
-
-#: panels/network/network-wifi.ui:1476
-msgctxt "tab"
-msgid "Reset"
-msgstr "Herstel"
-
-#: panels/network/network-wifi.ui:1537
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi-Kuberkol"
-
-#: panels/network/network-wifi.ui:1554
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Skakel af om aan 'n Wi-Fi-netwerk te koppel"
-
-#: panels/network/network-wifi.ui:1603
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Netwerknaam"
 
-#: panels/network/network-wifi.ui:1621
-msgid "Connected Devices"
-msgstr "Gekoppelde toestelle"
-
-#: panels/network/network-wifi.ui:1639
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Sekuriteitstipe"
 
-#: panels/network/network-wifi.ui:1702
+#: panels/network/network-wifi.ui:46
 #, fuzzy
-#| msgid "Password"
-msgctxt "Wi-Fi passkey"
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Wagwoord"
 
-#: panels/network/network-wifi.ui:1799
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Skakel Wi-Fi af"
 
-#: panels/network/network-wifi.ui:1831
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Laai tans keuses…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Koppel aan 'n versteekte netwerk…"
 
-#: panels/network/network-wifi.ui:1841
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Skakel Wi-Fi-kuberkol aan…"
 
-#: panels/network/network-wifi.ui:1851
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Bekende Wi-Fi Netwerke"
 
-#: panels/network/wifi.ui:40
-msgid "No Wi-Fi Adapter Found"
-msgstr "Geen Wi-Fi passtukke gevind nie"
-
-#: panels/network/wifi.ui:52
-msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
-msgstr "Versker dat die Wi-Fi-passtuk ingeprop en angeskakel is"
-
-#: panels/network/wifi.ui:127
-msgid "Airplane Mode"
-msgstr "Vlugmodus"
-
-#: panels/network/wifi.ui:142
-msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
-msgstr "Deaktiveer Wi-Fi, Bluetooth en mobiele breëband"
-
-#: panels/network/wifi.ui:192
-msgid "Visible Networks"
-msgstr "Sigbare netwerke"
-
-#: panels/network/wifi.ui:271
-msgid "NetworkManager needs to be running"
-msgstr "NetworkManager moet loop"
-
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:127
-msgid "Ad-hoc"
-msgstr "Ad hoc"
-
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:131
-msgid "Infrastructure"
-msgstr "Infrastruktuur"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:147 panels/network/panel-common.c:201
-msgid "Status unknown"
-msgstr "Status onbekend"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:151
-msgid "Unmanaged"
-msgstr "Nie bestuur nie"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:155
-msgid "Unavailable"
-msgstr "Nie beskikbaar nie"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:165 panels/network/panel-common.c:207
-msgid "Connecting"
-msgstr "Koppel tans"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:169 panels/network/panel-common.c:211
-msgid "Authentication required"
-msgstr "Verifikasie word vereis"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:173 panels/network/panel-common.c:215
-msgid "Connected"
-msgstr "Gekoppel"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:177
-msgid "Disconnecting"
-msgstr "Ontkoppel tans"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:181 panels/network/panel-common.c:219
-msgid "Connection failed"
-msgstr "Koppeling het misluk"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:185 panels/network/panel-common.c:227
-msgid "Status unknown (missing)"
-msgstr "Status onbekend (ontbreek)"
-
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:223
-msgid "Not connected"
-msgstr "Nie gekoppel nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "Configuration failed"
-msgstr "Opstelling het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252
-msgid "IP configuration failed"
-msgstr "IP-opstelling het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "IP configuration expired"
-msgstr "IP-opstelling het verval"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:260
-msgid "Secrets were required, but not provided"
-msgstr "Geheime was nodig, maar is nie verskaf nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:264
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x supplicant ontkoppel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:268
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x supplicant konfigurasie het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:272
-msgid "802.1x supplicant failed"
-msgstr "802.1x supplicant het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:276
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant het te lank geneem om te verifieer"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:280
-msgid "PPP service failed to start"
-msgstr "PPP-diens kon nie begin nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:284
-msgid "PPP service disconnected"
-msgstr "PPP-diens het ontkoppel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:288
-msgid "PPP failed"
-msgstr "PPP het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:292
-msgid "DHCP client failed to start"
-msgstr "DHCP-kliënt kon nie begin nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:296
-msgid "DHCP client error"
-msgstr "DHCP-kliëntfout"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:300
-msgid "DHCP client failed"
-msgstr "DHCP-kliënt het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:304
-msgid "Shared connection service failed to start"
-msgstr "Gedeelde verbinding diens kon nie begin nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:308
-msgid "Shared connection service failed"
-msgstr "Gedeelde verbinding diens het gebreek"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:312
-msgid "AutoIP service failed to start"
-msgstr "AutoIP diens kon nie begin nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:316
-msgid "AutoIP service error"
-msgstr "AutoIP diens fout"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:320
-msgid "AutoIP service failed"
-msgstr "AutoIP diens het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:324
-msgid "Line busy"
-msgstr "Lyn beset"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:328
-msgid "No dial tone"
-msgstr "Geen luitoon nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:332
-msgid "No carrier could be established"
-msgstr "Geen draer kon vasgestel word nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:336
-msgid "Dialing request timed out"
-msgstr "Inbelversoek het uitgetel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:340
-msgid "Dialing attempt failed"
-msgstr "Inbelpoging het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:344
-msgid "Modem initialization failed"
-msgstr "Inisialisering van modem het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:348
-msgid "Failed to select the specified APN"
-msgstr "Kon nie die gespesifiseerde APN kies nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:352
-msgid "Not searching for networks"
-msgstr "Soek nie tans vir netwerke nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:356
-msgid "Network registration denied"
-msgstr "Netwerkregistrasie geweier"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:360
-msgid "Network registration timed out"
-msgstr "Netwerkregistrasie het uitgetel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:364
-msgid "Failed to register with the requested network"
-msgstr "Kon nie registreer met die aangevraagde netwerk nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:368
-msgid "PIN check failed"
-msgstr "PIN-kontrole het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:372
-msgid "Firmware for the device may be missing"
-msgstr "Fermware vir die toestel ontbreek moontlik"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:376
-msgid "Connection disappeared"
-msgstr "Verbinding het verdwyn"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:380
-msgid "Existing connection was assumed"
-msgstr "Het aangeneem daar is 'n bestaande verbinding"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:384
-msgid "Modem not found"
-msgstr "Modem nie gevind nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:388
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth-koppeling het misluk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:392
-msgid "SIM Card not inserted"
-msgstr "SIM-kaart nie in nie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:396
-msgid "SIM Pin required"
-msgstr "SIM-PIN benodig"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:400
-msgid "SIM Puk required"
-msgstr "SIM-PUK benodig"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:404
-msgid "SIM wrong"
-msgstr "SIM verkeerd"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:408
-msgid "Connection dependency failed"
-msgstr "Koppeling se afhanklikheid het misluk"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:433
-msgid "Firmware missing"
-msgstr "Fermware ontbreek"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:437
-msgid "Cable unplugged"
-msgstr "Kabel uitgeprop"
-
-#: panels/network/wireless-security/eap-method.c:69
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "ongedefinieerde fout in 802.1X sekuriteit (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:245
-msgid "no file selected"
-msgstr "geen lêer is geselekteer nie"
-
-#: panels/network/wireless-security/eap-method.c:276
-msgid "unspecified error validating eap-method file"
-msgstr ""
-"ongespesifiseerde fout ondervind terwyl eap-metode lêer gevalideer word"
-
-#: panels/network/wireless-security/eap-method.c:451
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER-, PEM-, of PKCS#12- private sleutels (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:454
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER- of PEM-sertifikate (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:72
-msgid "missing EAP-FAST PAC file"
-msgstr "vermiste EAP-FAST PAC lêer"
-
-#: panels/network/wireless-security/eap-method-fast.c:268
-#: panels/network/wireless-security/eap-method-peap.c:302
-#: panels/network/wireless-security/eap-method-ttls.c:351
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: panels/network/wireless-security/eap-method-fast.c:283
-#: panels/network/wireless-security/eap-method-peap.c:272
-#: panels/network/wireless-security/eap-method-ttls.c:289
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: panels/network/wireless-security/eap-method-fast.c:406
-msgid "Choose a PAC file"
-msgstr "Kies 'n PAC-lêer"
-
-#: panels/network/wireless-security/eap-method-fast.c:413
-msgid "PAC files (*.pac)"
-msgstr "PAC-lêers (*.pac)"
-
-#: panels/network/wireless-security/eap-method-fast.ui:22
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "Anoniem"
 
-#: panels/network/wireless-security/eap-method-fast.ui:25
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "Geverifieer"
 
-#: panels/network/wireless-security/eap-method-fast.ui:28
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "Altwee"
 
-#: panels/network/wireless-security/eap-method-fast.ui:76
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anonie_me identiteit"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "PAC-_lêer"
 
-#: panels/network/wireless-security/eap-method-fast.ui:122
-#: panels/network/wireless-security/eap-method-peap.ui:146
-#: panels/network/wireless-security/eap-method-ttls.ui:97
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Kies 'n PAC-lêer"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "_Binne verifiëring"
 
-#: panels/network/wireless-security/eap-method-fast.ui:156
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Laat outomatiese PAC voorsiening toe"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "vermisde EAP-LEAP gebruikersnaam"
-
-#: panels/network/wireless-security/eap-method-leap.c:74
-msgid "missing EAP-LEAP password"
-msgstr "vermisde EAP-LEAP wagwoord"
-
-#: panels/network/wireless-security/eap-method-leap.ui:26
-#: panels/network/wireless-security/eap-method-simple.ui:26
-#: panels/network/wireless-security/ws-leap.ui:26
-#: panels/user-accounts/data/account-dialog.ui:142
-#: panels/user-accounts/data/account-dialog.ui:505
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "Gebr_uikernaam"
 
-#: panels/network/wireless-security/eap-method-leap.ui:68
-#: panels/network/wireless-security/eap-method-simple.ui:85
-#: panels/network/wireless-security/eap-method-tls.ui:164
-#: panels/network/wireless-security/ws-leap.ui:68
-#: panels/network/wireless-security/ws-wpa-psk.ui:76
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Wagwoord"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Wys wagwoord"
 
-#: panels/network/wireless-security/eap-method-peap.c:63
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "ongeldige EAP-PEAP CA sertifikaat: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:68
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "ongeldige EAP-PEAP CA sertifikaat: geen sertifikaat is verskaf nie"
-
-#: panels/network/wireless-security/eap-method-peap.c:287
-#: panels/network/wireless-security/eap-method-ttls.c:336
-#: panels/network/wireless-security/wireless-security.c:441
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: panels/network/wireless-security/eap-method-peap.c:381
-#: panels/network/wireless-security/eap-method-tls.c:492
-#: panels/network/wireless-security/eap-method-ttls.c:430
-msgid "Choose a Certificate Authority certificate"
-msgstr "Kies 'n sertifikaat vir die sertifikaatowerheid"
-
-#: panels/network/wireless-security/eap-method-peap.ui:25
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "Weergawe 0"
 
-#: panels/network/wireless-security/eap-method-peap.ui:28
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "Weergawe 1"
 
-#: panels/network/wireless-security/eap-method-peap.ui:74
-#: panels/network/wireless-security/eap-method-tls.ui:75
-#: panels/network/wireless-security/eap-method-ttls.ui:57
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "S_O-sertifikaat"
 
-#: panels/network/wireless-security/eap-method-peap.ui:96
-#: panels/network/wireless-security/eap-method-tls.ui:97
-#: panels/network/wireless-security/eap-method-ttls.ui:79
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Kies 'n sertifikaat vir die sertifikaatowerheid"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "Geen CA sertifikaat word _benodig nie"
 
-#: panels/network/wireless-security/eap-method-peap.ui:114
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP-_weergawe"
 
-#: panels/network/wireless-security/eap-method-simple.c:74
-msgid "missing EAP username"
-msgstr "vermisde EAP gebruikersnaam"
-
-#: panels/network/wireless-security/eap-method-simple.c:87
-msgid "missing EAP password"
-msgstr "EAP wagwoord nie teenwoordig nie"
-
-#: panels/network/wireless-security/eap-method-tls.c:68
-msgid "missing EAP-TLS identity"
-msgstr "vermisde EAP-TLS identiteit"
-
-#: panels/network/wireless-security/eap-method-tls.c:77
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "ongeldige EAP-TLS CA sertifikaat: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:84
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "ongeldige EAP-TLS CA sertifikaat: geen sertifikaat is verskaf nie"
-
-#: panels/network/wireless-security/eap-method-tls.c:100
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "ongeldige EAP-TLS privaat-sleutel: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:110
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "ongeldige EAP-TLS gebruikers-sertifikaat: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:307
-msgid "Unencrypted private keys are insecure"
-msgstr "Ongeënkripteerde privaatsleutels is onveilig"
-
-#: panels/network/wireless-security/eap-method-tls.c:310
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Die gekose privaatsleutel word klaarblyklik nie met 'n wagwoord beskerm nie. "
-"Dit kan dalk toelaat dat u sekuriteitsinligting gesteel word.  Kies asb. 'n "
-"wagwoordbeskermde privaatsleutel.\n"
-"\n"
-"('n Privaatsleutel kan d.m.v. openssl met 'n wagwoord beskerm word)"
-
-#: panels/network/wireless-security/eap-method-tls.c:486
-msgid "Choose your personal certificate"
-msgstr "Kies u persoonlike sertifikaat"
-
-#: panels/network/wireless-security/eap-method-tls.c:498
-msgid "Choose your private key"
-msgstr "Kies u privaatsleutel"
-
-#: panels/network/wireless-security/eap-method-tls.ui:24
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "I_dentiteit"
 
-#: panels/network/wireless-security/eap-method-tls.ui:50
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "Gebr_uikersertifikaat"
 
-#: panels/network/wireless-security/eap-method-tls.ui:115
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "Privaats_leutel"
 
-#: panels/network/wireless-security/eap-method-tls.ui:140
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Wagwoord vir _privaatsleutel"
 
-#: panels/network/wireless-security/eap-method-ttls.c:63
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "ongeldige EAP-TTLS CA sertifikaat: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:68
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "ongeldige EAP-TTLS CA sertifikaat: geen sertifikaat is verskaf nie"
-
-#: panels/network/wireless-security/eap-method-ttls.c:259
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: panels/network/wireless-security/eap-method-ttls.c:274
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.c:305
+#: panels/network/wireless-security/eap-method-ttls.ui:25
 msgid "MSCHAPv2 (no EAP)"
 msgstr "MSCHAPv2 (geen EAP)"
 
-#: panels/network/wireless-security/eap-method-ttls.c:321
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/wireless-security.c:87
-msgid "Unknown error validating 802.1X security"
-msgstr "Onbekende fout ervaar tydens die verifikasie van 802.1X sekuriteit"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domein"
 
-#: panels/network/wireless-security/wireless-security.c:453
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: panels/network/wireless-security/wireless-security.c:477
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
 msgid "PWD"
 msgstr "PWD"
 
-#: panels/network/wireless-security/wireless-security.c:488
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: panels/network/wireless-security/wireless-security.c:499
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "Getonnelde TLS"
 
-#: panels/network/wireless-security/wireless-security.c:510
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "Beskermde EAP (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:39
-#: panels/network/wireless-security/ws-wep-key.ui:115
-#: panels/network/wireless-security/ws-wpa-eap.ui:33
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Verifiëring"
 
-#: panels/network/wireless-security/ws-leap.c:63
-msgid "missing leap-username"
-msgstr "vermisde leap-gebruikersnaam"
-
-#: panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr "leap-wagwoord nie teenwoordig nie"
-
-#: panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr "geen wep-kode verskaf nie"
-
-#: panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"ongeldige wep-kode: 'n kode met 'n lengte van %zu mag slegs hex-getalle bevat"
-
-#: panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"ongeldige wep-kode: 'n kode met 'n lengte van %zu mag slegs ascii karakters "
-"bevat"
-
-#: panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"ongeldige wep-kode: verkeerde kode lengte %zu 'n Kode moet 'n lengte van "
-"5/13 (ascii) of 10/26 (hex) hê"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "ongeldige wep-kode: wagwoord mag nie leeg wees nie"
-
-#: panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "ongeldige wep-kode: wagwoord moet korter as 64 karakters wees"
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipe"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -3673,53 +2712,36 @@ msgstr "Oop stelsel"
 msgid "Shared Key"
 msgstr "Gedeelde sleutel"
 
-#: panels/network/wireless-security/ws-wep-key.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "S_leutel"
 
-#: panels/network/wireless-security/ws-wep-key.ui:94
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "_Wys sleutel"
 
-#: panels/network/wireless-security/ws-wep-key.ui:152
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP inde_ks"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"ongeldige wpa-psk: ongeldige kode lengte %zu. Moet [8,63] grepe of 64 hex "
-"nommers wees"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "ongeldige wpa-psk: kan nie kode met 64 grepe as hex verstaan nie"
-
-#: panels/network/wireless-security/ws-wpa-psk.ui:50
-msgid "_Type"
-msgstr "_Tipe"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/edit-dialog.ui:64
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "Ke_nnisgewings"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/edit-dialog.ui:116
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "_Klankkennisgewings"
 
-#: panels/notifications/edit-dialog.ui:172
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "Kennisgewing_baniere"
 
-#: panels/notifications/edit-dialog.ui:188
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
@@ -3728,85 +2750,64 @@ msgstr ""
 "baniere gedeaktiveer word."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/edit-dialog.ui:253
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "Wys _boodskapinhoud in baniere"
 
-#: panels/notifications/edit-dialog.ui:304
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "_Kennisgewings op geslote skerm"
 
-#: panels/notifications/edit-dialog.ui:355
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "Wys _boodskapinhoud op geslote skerm"
 
-#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
-#, fuzzy
-#| msgctxt "notifications"
-#| msgid "_Notifications"
-msgid "Notifications"
-msgstr "Ke_nnisgewings"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Kennisgewings op geslote skerm"
 
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "Beheer watter kennisgewings wys en wat hulle bevat"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/notifications/gnome-notifications-panel.desktop.in.in:7
-#, fuzzy
-#| msgid "Preferences;Settings;"
-msgid "preferences-system-notifications"
-msgstr "voorkeure;instelling;opstelling;"
-
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "kennisgewings;banier;boodskap;"
 
-#: panels/notifications/notifications.ui:84
-msgid "Notification _Popups"
-msgstr "Kennisgewing_baniere"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Ontdoen"
 
-#: panels/notifications/notifications.ui:134
-msgid "_Lock Screen Notifications"
-msgstr "_Kennisgewings op geslote skerm"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Binne _verifikasie"
 
-#. List of applications.
-#: panels/notifications/notifications.ui:180 panels/privacy/privacy.ui:875
-#: panels/sound/gvc-mixer-dialog.c:1768
-msgid "Applications"
-msgstr "Toepassings"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Koppel aan jou data in die wolk"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:149
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Ander"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Geen internet verbinding. Koppel aan die internet om aanlyn rekeninge by te "
+"voeg"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:615
-#, c-format
-msgid "%s Account"
-msgstr "%s Rekening"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:910
-msgid "Error removing account"
-msgstr "Kon nie rekening verwyder nie"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:975
-#, c-format
-msgid "<b>%s</b> removed"
-msgstr "<b>%s</b> verwyder"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Voeg 'n rekening by"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "On­line Accounts"
 msgid "Online Accounts"
 msgstr "Aanlynrekeninge"
 
@@ -3814,15 +2815,6 @@ msgstr "Aanlynrekeninge"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Koppel met aanlynrekeninge en kies waarvoor hulle gebruik moet word"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:7
-msgid "goa-panel"
-msgstr ""
-
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -3831,305 +2823,197 @@ msgstr ""
 "google;facebook;twitter;yahoo;web;aanlyn;klets;kalender;pos;kontak;owncloud;"
 "kerberos;IMAP;SMTP;pocket;readitlater;"
 
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
-msgid "Undo"
-msgstr "Ontdoen"
-
-#: panels/online-accounts/online-accounts.ui:125
-msgid "Connect to your data in the cloud"
-msgstr "Koppel aan jou data in die wolk"
-
-#: panels/online-accounts/online-accounts.ui:137
-msgid "No internet connection — connect to set up new online accounts"
-msgstr ""
-"Geen internet verbinding. Koppel aan die internet om aanlyn rekeninge by te "
-"voeg"
-
-#: panels/online-accounts/online-accounts.ui:159
-msgid "Add an account"
-msgstr "Voeg 'n rekening by"
-
-#: panels/online-accounts/online-accounts.ui:264
-msgid "Remove Account"
-msgstr "Verwyder rekening"
-
-#: panels/power/cc-power-panel.c:253
-msgid "Unknown time"
-msgstr "Onbekende tyd"
-
-#: panels/power/cc-power-panel.c:259
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i minuut"
 msgstr[1] "%i minute"
 
-#: panels/power/cc-power-panel.c:271
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i uur"
 msgstr[1] "%i ure"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-power-panel.c:279
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: panels/power/cc-power-panel.c:280
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "uur"
 msgstr[1] "ure"
 
-#: panels/power/cc-power-panel.c:281
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuut"
 msgstr[1] "minute"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:300
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s tot volgelaai"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minute"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:307
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Waarskuwing: %s oor"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 minute"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:312
-#, c-format
-msgid "%s remaining"
-msgstr "%s oor"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 minute"
 
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:317 panels/power/cc-power-panel.c:345
-msgid "Fully charged"
-msgstr "Volgelaai"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minute"
 
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:321 panels/power/cc-power-panel.c:349
-msgid "Empty"
-msgstr "Pap"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minute"
 
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:336
-msgid "Charging"
-msgstr "Laai tans"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 uur"
 
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:341
-msgid "Discharging"
-msgstr "Ontlaai tans"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minute"
 
-#: panels/power/cc-power-panel.c:464
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Hoof"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minute"
 
-#: panels/power/cc-power-panel.c:466
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Ekstra"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minute"
 
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:537
-msgid "Wireless mouse"
-msgstr "Draadlose muis"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 ure"
 
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:540
-msgid "Wireless keyboard"
-msgstr "Draadlose sleutelbord"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:543
-msgid "Uninterruptible power supply"
-msgstr "Ononderbreekbare kragbron"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:546
-msgid "Personal digital assistant"
-msgstr "Persoonlike digitale assistent"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:549
-msgid "Cellphone"
-msgstr "Selfoon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:552
-msgid "Media player"
-msgstr "Mediaspeler"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:555 panels/wacom/cc-wacom-panel.c:793
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:558
-msgid "Computer"
-msgstr "Rekenaar"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:561
-msgid "Gaming input device"
-msgstr ""
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-power-panel.c:564 panels/power/cc-power-panel.c:804
-#: panels/power/cc-power-panel.c:2380
+#: panels/power/cc-power-panel.ui:58
 msgid "Battery"
 msgstr "Battery"
 
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:618
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Laai tans"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:625
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Versigtig"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:630
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Amper pap"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:635
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Goed"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:640
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Volgelaai"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:644
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Pap"
-
-#: panels/power/cc-power-panel.c:802
-msgid "Batteries"
-msgstr "Batterye"
-
-#: panels/power/cc-power-panel.c:1242
-msgid "When _idle"
-msgstr "Indien _ongebruik"
-
-#: panels/power/cc-power-panel.c:1696
-msgid "Power Saving"
-msgstr "Kragbesparing"
-
-#: panels/power/cc-power-panel.c:1727
-msgid "_Screen brightness"
-msgstr "_Skermhelderheid"
-
-#: panels/power/cc-power-panel.c:1746
-msgid "Automatic brightness"
-msgstr "Outomatiese helderheid"
-
-#: panels/power/cc-power-panel.c:1766
-msgid "_Keyboard brightness"
-msgstr "S_leutelbordhelderheid"
-
-#: panels/power/cc-power-panel.c:1776
-msgid "_Dim screen when inactive"
-msgstr "Ver_dof skerm wanneer onaktief"
-
-#: panels/power/cc-power-panel.c:1801
-msgid "_Blank screen"
-msgstr "_Wys swart skerm"
-
-#: panels/power/cc-power-panel.c:1838
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: panels/power/cc-power-panel.c:1843
-msgid "Turn off Wi-Fi to save power."
-msgstr "Skakel die Wi-Fi af om krag te spaar."
-
-#: panels/power/cc-power-panel.c:1868
-msgid "_Mobile broadband"
-msgstr "S_elfoonbreëband"
-
-#: panels/power/cc-power-panel.c:1873
-msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
-msgstr ""
-"Skakel selfoonbreëbandtoestelle (3G, 4G, LTE, ens.) af om krag te spaar."
-
-#: panels/power/cc-power-panel.c:1926
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: panels/power/cc-power-panel.c:1931
-#, fuzzy
-#| msgid "Turn off Wi-Fi to save power."
-msgid "Turn off Bluetooth to save power."
-msgstr "Skakel die Wi-Fi af om krag te spaar."
-
-#: panels/power/cc-power-panel.c:1990
-msgid "When on battery power"
-msgstr "Terwyl op batterykrag"
-
-#: panels/power/cc-power-panel.c:1992
-msgid "When plugged in"
-msgstr "Terwyl ingeprop"
-
-#: panels/power/cc-power-panel.c:2087
-msgid "Suspend"
-msgstr "Sluimer"
-
-#: panels/power/cc-power-panel.c:2088
-msgid "Power Off"
-msgstr "Skakel af"
-
-#: panels/power/cc-power-panel.c:2089
-msgid "Hibernate"
-msgstr "Hiberneer"
-
-#: panels/power/cc-power-panel.c:2090
-msgid "Nothing"
-msgstr "Doen niks"
-
-#. Frame header
-#: panels/power/cc-power-panel.c:2204
-msgid "Suspend & Power Button"
-msgstr "Sluimer en kragknoppie"
-
-#: panels/power/cc-power-panel.c:2243
-msgid "_Automatic suspend"
-msgstr "_Outomatiese sluimer"
-
-#: panels/power/cc-power-panel.c:2244
-msgid "Automatic suspend"
-msgstr "Outomatiese sluimer"
-
-#: panels/power/cc-power-panel.c:2311
-msgid "_When the Power Button is pressed"
-msgstr "_Wanneer die kragknoppie gedruk word"
-
-#: panels/power/cc-power-panel.c:2430 shell/cc-window.c:218
-#: shell/panel-list.ui:45
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
 msgid "Devices"
 msgstr "Toestelle"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Skakel af"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Kragbesparing"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Outomatiese helderheid"
+
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Instellings vir skermhelderheid in skermsluiting"
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Skerm"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Ske_rmleser"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Outom_atiese probleemrapportering"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Outomatiese sluimer"
+
+#: panels/power/cc-power-panel.ui:175
+#, fuzzy
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Laat die rekenaar sluimer indien onaktief:"
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Onderste knoppie"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Outomatiese sluimer"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Ingepr_op"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Op _batterykrag"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Wagtyd"
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4139,177 +3023,17 @@ msgstr "Krag"
 msgid "View your battery status and change power saving settings"
 msgstr "Bekyk batterystatus en verander instellings vir kragbesparing"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/power/gnome-power-panel.desktop.in.in:7
-msgid "gnome-power-manager"
-msgstr ""
-
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "krag;slaap;sluimer;hiberneer;battery;helderheid;verdof;blanko;monitor;DPMS;"
 "onaktief;"
 
-#: panels/power/power.ui:17
-#, fuzzy
-#| msgid "2 minutes"
-msgid "20 minutes"
-msgstr "2 minute"
-
-#: panels/power/power.ui:21
-#, fuzzy
-#| msgid "5 minutes"
-msgid "25 minutes"
-msgstr "5 minute"
-
-#: panels/power/power.ui:29
-msgid "45 minutes"
-msgstr "45 minute"
-
-#: panels/power/power.ui:33 panels/privacy/privacy.ui:42
-#: panels/privacy/privacy.ui:56
-msgid "1 hour"
-msgstr "1 uur"
-
-#: panels/power/power.ui:37
-msgid "80 minutes"
-msgstr "80 minute"
-
-#: panels/power/power.ui:41
-msgid "90 minutes"
-msgstr "90 minute"
-
-#: panels/power/power.ui:45
-msgid "100 minutes"
-msgstr "100 minute"
-
-#: panels/power/power.ui:49
-msgid "2 hours"
-msgstr "2 ure"
-
-#: panels/power/power.ui:63 panels/privacy/privacy.ui:22
-msgid "1 minute"
-msgstr "1 minuut"
-
-#: panels/power/power.ui:67 panels/privacy/privacy.ui:26
-msgid "2 minutes"
-msgstr "2 minute"
-
-#: panels/power/power.ui:71 panels/privacy/privacy.ui:30
-msgid "3 minutes"
-msgstr "3 minute"
-
-#: panels/power/power.ui:75
-msgid "4 minutes"
-msgstr "4 minute"
-
-#: panels/power/power.ui:79 panels/privacy/privacy.ui:34
-msgid "5 minutes"
-msgstr "5 minute"
-
-#: panels/power/power.ui:83
-msgid "8 minutes"
-msgstr "8 minute"
-
-#: panels/power/power.ui:87
-msgid "10 minutes"
-msgstr "10 minute"
-
-#: panels/power/power.ui:91
-msgid "12 minutes"
-msgstr "12 minute"
-
-#: panels/power/power.ui:155
-msgid "Automatic Suspend"
-msgstr "Outomatiese sluimer"
-
-#: panels/power/power.ui:180
-msgid "_Plugged In"
-msgstr "Ingepr_op"
-
-#: panels/power/power.ui:196
-msgid "On _Battery Power"
-msgstr "Op _batterykrag"
-
-#: panels/power/power.ui:241 panels/power/power.ui:301
-#: panels/universal-access/uap.ui:1501
-msgid "Delay"
-msgstr "Wagtyd"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "Verifieer"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:361
-msgid "Username"
-msgstr "Gebruikernaam"
-
-#. Translators: This is a password needed for printing.
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:382
-#: panels/user-accounts/data/account-dialog.ui:240
-msgid "Password"
-msgstr "Wagwoord"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:336
-msgid "Authentication Required"
-msgstr "Verifikasie benodig"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:808
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Die drukker \"%s\" is verwyder"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:1053
-msgid "Failed to add new printer."
-msgstr "Kon nie nuwe drukker byvoeg nie."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1390
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Kon nie die gebruikerkoppelvlak laai nie: %s"
-
-#: panels/printers/details-dialog.ui:63 panels/printers/printer-entry.ui:223
-msgid "Location"
-msgstr "Ligging"
-
-#. Translators: Name of column showing printer drivers
-#: panels/printers/details-dialog.ui:111
-#: panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "Aandrywer"
-
-#: panels/printers/details-dialog.ui:147
-msgid "Searching for preferred drivers…"
-msgstr "Soek tans vir voorkeurdrywers…"
-
-#: panels/printers/details-dialog.ui:169
-msgid "Search for Drivers"
-msgstr "Soek vir 'n drywerprogramatuur"
-
-#: panels/printers/details-dialog.ui:177
-msgid "Select from Database…"
-msgstr "Kies uit 'n databasis…"
-
-#: panels/printers/details-dialog.ui:185
-msgid "Install PPD File…"
-msgstr "Verskaf PPD-lêer…"
-
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "Prin­ters"
 msgid "Printers"
 msgstr "Drukkers"
 
@@ -4317,1186 +3041,646 @@ msgstr "Drukkers"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Voeg drukkers by, bekyk druktake en kies hoe om te druk"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/printers/gnome-printers-panel.desktop.in.in:7
-#, fuzzy
-#| msgid "No printers"
-msgid "printer"
-msgstr "Geen drukkers nie"
-
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "drukker;tou;druk;papier;ink;toner;"
 
-#. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/jobs-dialog.ui:44
-#, fuzzy
-#| msgid "_Domain"
-msgid "Domain"
-msgstr "_Domein"
-
-#. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/jobs-dialog.ui:123
-#, fuzzy
-#| msgid "Authenticate"
-msgid "A_uthenticate"
-msgstr "Verifieer"
-
-#. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/jobs-dialog.ui:163
-msgid "Clear All"
-msgstr "Verwyder almal"
-
-#. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/jobs-dialog.ui:225
-#, fuzzy
-#| msgid "Authenticate"
-msgid "_Authenticate"
-msgstr "Verifieer"
-
-#. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/jobs-dialog.ui:354
-msgid "No Active Printer Jobs"
-msgstr "Geen aktiewe druktake nie"
-
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:384
-#: panels/printers/pp-new-printer-dialog.c:456
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Voeg drukker by"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Ontsluit"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:210
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Geen drukkers gevind nie"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:283
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Tik 'n netwerkadres of soek vir 'n drukker"
 
-#: panels/printers/new-printer-dialog.ui:352
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Verifikasie benodig"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Voer u gebruikernaam en wagwoord in om beskikbare drukkers op bediener te "
 "sien."
 
-#. Translators: This button triggers the printing of a test page.
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/options-dialog.ui:22 panels/printers/pp-options-dialog.c:893
-msgid "Test Page"
-msgstr "Toetsbladsy"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Gebruikernaam"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:135
-#: panels/printers/pp-details-dialog.c:435
-#, c-format
-msgid "%s Details"
-msgstr "%s Besonderhede"
-
-#: panels/printers/pp-details-dialog.c:184
-msgid "No suitable driver found"
-msgstr "Geen gepaste drywer gevind nie"
-
-#: panels/printers/pp-details-dialog.c:328
-msgid "Select PPD File"
-msgstr "Kies PPD-lêer"
-
-#: panels/printers/pp-details-dialog.c:337
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"PostScript-drukkerbeskrywings (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Ligging"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Aandrywer"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Soek tans vir voorkeurdrywers…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Soek vir 'n drywerprogramatuur"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Kies uit 'n databasis…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Verskaf PPD-lêer…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "Kies 'n drukkerdrywer"
 
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/um-photo-dialog.c:105
-msgid "Select"
-msgstr "Kies"
-
-#: panels/printers/ppd-selection-dialog.ui:73
+#: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "Laai tans drywerdatabasis…"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:539
-msgid "JetDirect Printer"
-msgstr "JetDirect-drukker"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Kanselleer"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:795
-msgid "LPD Printer"
-msgstr "LPD-drukker"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Kies"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "Een kant"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "Lang kant (standaard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:70
-#: panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "Kort kant (swaai om)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "Portret"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "Landskap"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "Omgekeerde landskap"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "Omgekeerde portret"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-jobs-dialog.c:234
-msgctxt "print job"
-msgid "Pending"
-msgstr "Hangend"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-jobs-dialog.c:240
-msgctxt "print job"
-msgid "Paused"
-msgstr "Wagtend"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-jobs-dialog.c:245
-#, fuzzy
-#| msgid "Authentication required"
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Verifikasie word vereis"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-jobs-dialog.c:250
-msgctxt "print job"
-msgid "Processing"
-msgstr "Verwerk tans"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-jobs-dialog.c:254
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Gestop"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-jobs-dialog.c:258
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Gekanselleer"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-jobs-dialog.c:262
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Gestaak"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-jobs-dialog.c:266
-msgctxt "print job"
-msgid "Completed"
-msgstr "Voltooid"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:390
+#: panels/printers/pp-jobs-dialog.c:318
 #, fuzzy, c-format
-#| msgid "Server requires authentication"
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "Bediener nodig verifikasie"
 msgstr[1] "Bediener nodig verifikasie"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:620
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - Aktiewe Take"
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "_Domein"
 
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:625
-#, fuzzy, c-format
-#| msgid "Enter username and password to view printers on %s."
-msgid "Enter credentials to print from %s."
-msgstr ""
-"Voer u gebruikersnaam en wagwoord in om beskikbare drukkers op %s te sien."
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "Verifieer"
 
-#: panels/printers/pp-new-printer-dialog.c:402
-msgid "Unlock Print Server"
-msgstr "Sluit die druk bediener oop"
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Verwyder almal"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:406
-#, c-format
-msgid "Unlock %s."
-msgstr "Ontsluit %s."
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Verifieer"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:411
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Voer u gebruikersnaam en wagwoord in om beskikbare drukkers op %s te sien."
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Geen aktiewe druktake nie"
 
-#: panels/printers/pp-new-printer-dialog.c:876
-msgid "Searching for Printers"
-msgstr "Soek tans vir drukkers"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1799
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1804
-msgid "Serial Port"
-msgstr "Seriepoort"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1811
-msgid "Parallel Port"
-msgstr "Parallelle poort"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1853
-#, c-format
-msgid "Location: %s"
-msgstr "Ligging: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1858
-#, c-format
-msgid "Address: %s"
-msgstr "Adres: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1887
-msgid "Server requires authentication"
-msgstr "Bediener nodig verifikasie"
-
-#: panels/printers/pp-options-dialog.c:83
-msgid "Two Sided"
-msgstr "Albei kante"
-
-#: panels/printers/pp-options-dialog.c:84
-msgid "Paper Type"
-msgstr "Papiertipe"
-
-#: panels/printers/pp-options-dialog.c:85
-msgid "Paper Source"
-msgstr "Papierbron"
-
-#: panels/printers/pp-options-dialog.c:86
-msgid "Output Tray"
-msgstr "Afvoerrakkie"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript-voor-filtrering"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:534
-msgid "Pages per side"
-msgstr "Bladsye per kant"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:546
-msgid "Two-sided"
-msgstr "Albei kante"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Algemeen"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Bladsyopstelling"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Installeerbare keuses"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Taak"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Beeldkwaliteit"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Kleur"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Afwerking"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:676
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Gevorderd"
-
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:908
-msgid "Test page"
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
 msgstr "Toetsbladsy"
 
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:76
-#: panels/printers/pp-ppd-option-widget.c:78
-#: panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "Kies outomaties"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:80
-#: panels/printers/pp-ppd-option-widget.c:82
-#: panels/printers/pp-ppd-option-widget.c:84
-#: panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "Drukker se verstek"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "Bed slegs GhostScript-lettertipes in"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "Skakel om na PS-vlak 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "Skakel om na PS-vlak 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "Geen filtrering vooraf nie"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "Vervaardiger"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:598 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr "Geen aktiewe take"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:603
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u Taak"
 msgstr[1] "%u Take"
 
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:766
-msgid "Low on toner"
-msgstr "Poeierink is min"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:768
-msgid "Out of toner"
-msgstr "Poeierink is op"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:771
-msgid "Low on developer"
-msgstr "Ontwikkelingvloeistof is min"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:774
-msgid "Out of developer"
-msgstr "Ontwikkelingvloeistof is op"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:776
-msgid "Low on a marker supply"
-msgstr "Merkervoorraad is laag"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:778
-msgid "Out of a marker supply"
-msgstr "Merkervoorraad is klaar"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:780
-msgid "Open cover"
-msgstr "Open deksel"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:782
-msgid "Open door"
-msgstr "Oop deur"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:784
-msgid "Low on paper"
-msgstr "Papier is min"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:786
-msgid "Out of paper"
-msgstr "Papier is op"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:788
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Vanlyn"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:790
-#: panels/printers/pp-printer-entry.c:920
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Gestop"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:792
-msgid "Waste receptacle almost full"
-msgstr "Afvalhouer byna vol"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:794
-msgid "Waste receptacle full"
-msgstr "Afvalhouer vol"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:796
-msgid "The optical photo conductor is near end of life"
-msgstr "Die optiese fotogeleier is naby die einde van sy funksionele lewe"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:798
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Die optiese fotogeleier werk nie meer nie"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:906
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Gereed"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:911
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Aanvaar nie take nie"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:916
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Verwerk tans"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:940
-msgid "Clean print heads"
-msgstr "Maak drukkoppe skoon"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "Drukker Instellings"
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "Drukker Besonderhede"
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "Gebruik as verstek drukker"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "Maak drukkoppe skoon"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Verwyder drukker"
 
-#: panels/printers/printer-entry.ui:193
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Geen aktiewe take"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Inkvlak"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:312
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Herbegin die toestel as die probleem opgelos is."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:319
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Herbegin"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:20
-msgid "Add…"
-msgstr "Voeg by…"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Voeg 'n drukker by…"
 
-#: panels/printers/printers.ui:186
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Voeg 'n drukker by…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Geen drukkers nie"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:200
-msgid "Add a Printer…"
-msgstr "Voeg 'n drukker by…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:232
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Jammer! Die stelsel se drukdiens blyk\n"
 "nie beskikbaar te wees nie."
 
-#: panels/privacy/cc-privacy-panel.c:387 panels/privacy/privacy.ui:280
-msgid "Screen Lock"
-msgstr "Skermslot"
-
-#: panels/privacy/cc-privacy-panel.c:438
-msgid "In use"
-msgstr "In gebruik"
-
-#: panels/privacy/cc-privacy-panel.c:443
-msgctxt "Location services status"
-msgid "On"
-msgstr "Aan"
-
-#: panels/privacy/cc-privacy-panel.c:444
-msgctxt "Location services status"
-msgid "Off"
-msgstr "Af"
-
-#: panels/privacy/cc-privacy-panel.c:823 panels/privacy/privacy.ui:745
-msgid "Location Services"
-msgstr "Liggingdienste"
-
-#: panels/privacy/cc-privacy-panel.c:946 panels/privacy/privacy.ui:127
-msgid "Usage & History"
-msgstr "Gebruik en geskiedenis"
-
-#: panels/privacy/cc-privacy-panel.c:1075
-msgid "Empty all items from Trash?"
-msgstr "Skrap alle items uit die asblik?"
-
-#: panels/privacy/cc-privacy-panel.c:1076
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Alle items in die asblik sal permanent geskrap word."
-
-#: panels/privacy/cc-privacy-panel.c:1077
-msgid "_Empty Trash"
-msgstr "Maak _asblik leeg"
-
-#: panels/privacy/cc-privacy-panel.c:1100
-msgid "Delete all the temporary files?"
-msgstr "Skrap alle tydelike lêers?"
-
-#: panels/privacy/cc-privacy-panel.c:1101
-msgid "All the temporary files will be permanently deleted."
-msgstr "Al die tydelike lêers sal permanent geskrap word."
-
-#: panels/privacy/cc-privacy-panel.c:1102
-msgid "_Purge Temporary Files"
-msgstr "Vee tydelike lêers _permanent uit"
-
-#: panels/privacy/cc-privacy-panel.c:1124 panels/privacy/privacy.ui:432
-msgid "Purge Trash & Temporary Files"
-msgstr "Permanente uitvee en tydelike lêers"
-
-#: panels/privacy/cc-privacy-panel.c:1164 panels/privacy/privacy.ui:637
-msgid "Software Usage"
-msgstr "Sagtewaregebruik"
-
-#: panels/privacy/cc-privacy-panel.c:1205 panels/privacy/privacy.ui:959
-msgid "Problem Reporting"
-msgstr "Probleemrapportering"
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: panels/privacy/cc-privacy-panel.c:1219
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-"Verslae oor tegniese probleme help ons om %s te verbeter. Verslae word "
-"anoniem gestuur en word gesuiwer van persoonlike data."
-
-#: panels/privacy/cc-privacy-panel.c:1231 panels/privacy/privacy.ui:719
-msgid "Privacy Policy"
-msgstr "Privaatheidbeleid"
-
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:3
-msgid "Privacy"
-msgstr "Privaatheid"
-
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
-msgid "Protect your personal information and control what others might see"
-msgstr "Beskerm persoonlike inligting en bepaal wat anders moontlik kan sien"
-
-#. FIXME
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:8
-msgid "preferences-system-privacy"
-msgstr ""
-
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"skerm;sluit;diagnose;privaat;onlangs;voorlopig;tmp;indeks;naam;netwerk;"
-"identiteit;"
-
-#: panels/privacy/privacy.ui:14
-msgid "Screen Turns Off"
-msgstr "Skerm afskakel"
-
-#: panels/privacy/privacy.ui:18
-msgid "30 seconds"
-msgstr "30 sekondes"
-
-#: panels/privacy/privacy.ui:60 panels/privacy/privacy.ui:106
-msgid "1 day"
-msgstr "1 dag"
-
-#: panels/privacy/privacy.ui:64
-msgid "2 days"
-msgstr "2 dae"
-
-#: panels/privacy/privacy.ui:68
-msgid "3 days"
-msgstr "3 dae"
-
-#: panels/privacy/privacy.ui:72
-msgid "4 days"
-msgstr "4 dae"
-
-#: panels/privacy/privacy.ui:76
-msgid "5 days"
-msgstr "5 dae"
-
-#: panels/privacy/privacy.ui:80
-msgid "6 days"
-msgstr "6 dae"
-
-#: panels/privacy/privacy.ui:84 panels/privacy/privacy.ui:110
-msgid "7 days"
-msgstr "7 dae"
-
-#: panels/privacy/privacy.ui:88
-msgid "14 days"
-msgstr "14 dae"
-
-#: panels/privacy/privacy.ui:92 panels/privacy/privacy.ui:114
-msgid "30 days"
-msgstr "30 dae"
-
-#: panels/privacy/privacy.ui:118
-msgid "Forever"
-msgstr "Permanent"
-
-#: panels/privacy/privacy.ui:148
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"Deur geskiedenis te onthou, kan dinge makliker weer gevind word. Hierdie "
-"items word nooit oor die netwerk gedeel nie."
-
-#: panels/privacy/privacy.ui:176
-msgid "_Recently Used"
-msgstr "_Onlangs gebruik"
-
-#: panels/privacy/privacy.ui:207
-msgid "Retain _History"
-msgstr "Behou _geskiedenis"
-
-#: panels/privacy/privacy.ui:247
-msgid "Cl_ear Recent History"
-msgstr "_Maak onlangse geskiedenis skoon"
-
-#: panels/privacy/privacy.ui:301
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "Die skermslot beskerm u privaatheid wanneer u weg is."
-
-#: panels/privacy/privacy.ui:328
-msgid "Automatic Screen _Lock"
-msgstr "_Outomatiese skermslot"
-
-#: panels/privacy/privacy.ui:362
-msgid "Lock screen _after blank for"
-msgstr "S_luit skerm ná"
-
-#: panels/privacy/privacy.ui:394
-msgid "Show _Notifications"
-msgstr "Wys ke_nnisgewings"
-
-#: panels/privacy/privacy.ui:454
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"Maak outomaties die asblik en tydelike lêers permanent skoon om die rekenaar "
-"vry te hou van onnodige sensitiewe inligting."
-
-#: panels/privacy/privacy.ui:483
-msgid "Automatically empty _Trash"
-msgstr "_Maak asblik outomaties leeg"
-
-#: panels/privacy/privacy.ui:515
-msgid "Automatically purge Temporary _Files"
-msgstr "_Vee tydelike lêers outomaties permanent uit"
-
-#: panels/privacy/privacy.ui:546
-msgid "Purge _After"
-msgstr "Vee permament uit n_a"
-
-#: panels/privacy/privacy.ui:590
-msgid "_Empty Trash…"
-msgstr "Maak _asblik leeg…"
-
-#: panels/privacy/privacy.ui:606
-msgid "_Purge Temporary Files…"
-msgstr "Vee tydelike lêers _permanent uit…"
-
-#: panels/privacy/privacy.ui:654
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"Inligting wat u stuur oor watter sagteware u gebruik, help ons om meer "
-"akkurate voorstelle te maak. Dit help ook om ons sagteware te verbeter.\n"
-"\n"
-"Al die inligting wat ons versamel word anoniem gemaak, en ons sal nooit u "
-"data deel met derde partye nie."
-
-#: panels/privacy/privacy.ui:681
-msgid "_Send software usage statistics"
-msgstr "_Stuur statistiek oor sagtewaregebruik"
-
-#: panels/privacy/privacy.ui:764
-msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"Liggingdienste laat programme toe om jou ligging te weet. Die gebruik van Wi-"
-"Fi en mobiele breëband verhoog akkuraatheid."
-
-#: panels/privacy/privacy.ui:778
-msgid ""
-"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
-msgstr ""
-
-#: panels/privacy/privacy.ui:828
-msgid "_Location Services"
-msgstr "_Liggingdienste"
-
-#: panels/privacy/privacy.ui:1026
-msgid "_Automatic Problem Reporting"
-msgstr "Outom_atiese probleemrapportering"
-
-#: panels/region/cc-format-chooser.c:118
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Brits"
-
-#: panels/region/cc-format-chooser.c:120
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metriek"
-
-#: panels/region/cc-format-chooser.c:285
-msgid "No regions found"
-msgstr "Geen streke gevind nie"
-
-#: panels/region/cc-input-chooser.c:182
-msgid "No input sources found"
-msgstr "Geen toevoerbronne gevind nie"
-
-#: panels/region/cc-input-chooser.c:1012
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Ander"
-
-#: panels/region/cc-region-panel.c:881
-msgid "No input source selected"
-msgstr "Geen toevoerbronne gekies nie"
-
-#: panels/region/cc-region-panel.c:1773
-msgid "Login _Screen"
-msgstr "Aanmeld_skerm"
-
-#: panels/region/format-chooser.ui:7
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formate"
 
-#: panels/region/format-chooser.ui:120
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Soekliggings"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Algemene take"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Formate"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "Geen resultate gevind nie"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Voorskou"
 
-#: panels/region/format-chooser.ui:137
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Datums"
 
-#: panels/region/format-chooser.ui:168
-msgid "Times"
-msgstr "Tye"
-
-#: panels/region/format-chooser.ui:199
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "Datum en Tyd"
 
-#: panels/region/format-chooser.ui:230
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Getalle"
 
-#: panels/region/format-chooser.ui:247
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Mates"
 
-#: panels/region/format-chooser.ui:264
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Papier"
 
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Installeer tale..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Jou rekening"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Taal"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr "_Formate"
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Aanmeld_skerm"
+
 #: panels/region/gnome-region-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "Re­gion & Lan­guage"
 msgid "Region & Language"
 msgstr "Streek en Taal"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr "Kies die vertoontaal, formate, sleutelborduitlegte en toevoerbronne"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/region/gnome-region-panel.desktop.in.in:7
-msgid "preferences-desktop-locale"
-msgstr ""
-
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "taal;uitleg;sleutelbord;toevoer;"
 
-#: panels/region/input-chooser.ui:5
-msgid "Add an Input Source"
-msgstr "Voeg 'n toevoerbron by"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Kies hoe die media hanteer moet word"
 
-#: panels/region/input-chooser.ui:76
-msgid "Input methods can’t be used on the login screen"
-msgstr "Toevoermetodes kan nie gebruik word op die aanmeldskerm nie"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD-_oudio"
 
-#: panels/region/input-options.ui:7
-msgid "Input Source Options"
-msgstr "Keuses vir toevoerbronne"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD-video"
 
-#: panels/region/input-options.ui:27
-msgid "Use the _same source for all windows"
-msgstr "Gebruik die _selfde bron vir alle vensters"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Musiekspeler"
 
-#: panels/region/input-options.ui:45
-msgid "Allow _different sources for each window"
-msgstr "_Laat verskillende uitlegte in elke venster toe"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Sagteware"
 
-#: panels/region/input-options.ui:85
-msgid "Switch to previous source"
-msgstr "Skakel na vorige bron"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Ander media…"
 
-#: panels/region/input-options.ui:102
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Spasie"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "As media ingedruk word, moet _nooit programme begin of vra daaroor nie"
 
-#: panels/region/input-options.ui:116
-msgid "Switch to next source"
-msgstr "Skakel na volgende bron"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Kies hoe ander media hanteer moet word"
 
-#: panels/region/input-options.ui:133
-msgid "Super+Space"
-msgstr "Super+Spasie"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Aksie:"
 
-#: panels/region/input-options.ui:147
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "Verander gerus dié kortpaaie in sleutelbordinstellings"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipe:"
 
-#: panels/region/input-options.ui:164
-msgid "Alternative switch to next source"
-msgstr "Alternatiewe skakelaar na volgende bron"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Verwyderbare media"
 
-#: panels/region/input-options.ui:181
-msgid "Left+Right Alt"
-msgstr "Linker+Regter Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Verander verwyderbare media instellings"
 
-#: panels/region/region.ui:67
-#: panels/user-accounts/data/user-accounts-dialog.ui:348
-msgid "_Language"
-msgstr "_Taal"
-
-#: panels/region/region.ui:85
-msgid "English (United Kingdom)"
-msgstr "Engels (Verenigde Koninkryk)"
-
-#: panels/region/region.ui:112
-msgid "Restart the session for changes to take effect"
-msgstr "Die sessie moet herbegin word sodat veranderinge kan neerslag vind"
-
-#: panels/region/region.ui:134
-msgid "Restart…"
-msgstr "Herbegin…"
-
-#: panels/region/region.ui:169
-msgid "_Formats"
-msgstr "_Formate"
-
-#: panels/region/region.ui:187
-msgid "United Kingdom"
-msgstr "Verenigde Koninkryk"
-
-#: panels/region/region.ui:229
-msgid "Input Sources"
-msgstr "Toevoerbronne"
-
-#: panels/region/region.ui:245
-msgid "_Options"
-msgstr "_Keuses"
-
-#: panels/region/region.ui:311
-msgid "Add input source"
-msgstr "Voeg toevoerbron by"
-
-#: panels/region/region.ui:336
-msgid "Remove input source"
-msgstr "Verwyder toevoerbron"
-
-#: panels/region/region.ui:386
-msgid "Move input source up"
-msgstr "Skuif toevoerbron op"
-
-#: panels/region/region.ui:411
-msgid "Move input source down"
-msgstr "Skuif toevoerbron af"
-
-#: panels/region/region.ui:461
-msgid "Configure input source"
-msgstr "Stel toevoerbron op"
-
-#: panels/region/region.ui:486
-msgid "Show input source keyboard layout"
-msgstr "Wys sleutelborduitleg van toevoerbron"
-
-#: panels/region/region.ui:530
-msgid "Login settings are used by all users when logging into the system"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"Aanmeldinstellings word deur alle gebruikers gebruik wanneer hulle by die "
-"stelsel aanmeld"
+"toestel;stelsel;verstek;toepassing;voorkeur;cd;dvd;usb;klank;video;skyf;"
+"verwyderbaar;media;outoloop;"
 
-#: panels/search/cc-search-locations-dialog.c:639
-msgid "Select Location"
-msgstr "Kies ligging"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Skermslot"
 
-#: panels/search/cc-search-locations-dialog.c:643
-msgid "_OK"
-msgstr "_OK"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
 
-#: panels/search/cc-search-panel.c:178
-msgid "No applications found"
-msgstr "Geen toepassings gevind nie"
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "_Wys swart skerm"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Outomatiese skermslot"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Outomatiese skermslot"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Wys ke_nnisgewings"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Ges_lote skerm"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Privaatheid"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skerm"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Klankinstellings"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Soekliggings"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Plekke"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Boekmerke"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Ander"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Ligging"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Toepassings"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "_Soek volgens adres"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "Kies watter programme soekresultate wys in die Aktiwiteitoorsig"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/search/gnome-search-panel.desktop.in.in:7
-msgid "preferences-system-search"
-msgstr ""
-
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "soek;vind;indeks;versteek;privaatheid;resultate;"
 
-#: panels/search/search-locations-dialog.ui:9
-msgid "Search Locations"
-msgstr "Soekliggings"
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Netwerke"
 
-#: panels/search/search-locations-dialog.ui:43
-msgid "Places"
-msgstr "Plekke"
-
-#: panels/search/search-locations-dialog.ui:73
-msgid "Bookmarks"
-msgstr "Boekmerke"
-
-#: panels/search/search-locations-dialog.ui:130
-msgid "Other"
-msgstr "Ander"
-
-#: panels/search/search.ui:66
-msgid "Move Up"
-msgstr "Skuif op"
-
-#: panels/search/search.ui:83
-msgid "Move Down"
-msgstr "Skuif af"
-
-#: panels/search/search.ui:119
-msgid "Preferences"
-msgstr "Voorkeure"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:305
-msgid "No networks selected for sharing"
-msgstr "Geen netwerke gekies vir deling nie"
-
-#: panels/sharing/cc-sharing-panel.c:275
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Aan"
-
-#: panels/sharing/cc-sharing-panel.c:277 panels/sharing/cc-sharing-panel.c:304
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Af"
-
-#: panels/sharing/cc-sharing-panel.c:307
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Geaktiveer"
-
-#: panels/sharing/cc-sharing-panel.c:310
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktief"
-
-#: panels/sharing/cc-sharing-panel.c:381
-msgid "Choose a Folder"
-msgstr "Kies 'n gids"
-
-#: panels/sharing/cc-sharing-panel.c:693
-#, fuzzy, c-format
-#| msgid ""
-#| "Personal File Sharing allows you to share your Public folder with others "
-#| "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr ""
-"Persoonlike lêerdeling maak dit moontlik om die Publiek-gids te deel met "
-"ander op die huidige netwerk m.b.v: <a href=\"dav://%s\">dav://%s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:695
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"Wanneer afgeleë toegang geaktiveer is kan afgeleë gebruikers koppel met die "
-"Secure Shell-opdrag:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:697
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"Laat afgeleë gebruikers toe om die skerm te sien of te beheer deur te koppel "
-"aan: <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:809
-msgid "Copy"
-msgstr "Kopieer"
-
-#: panels/sharing/cc-sharing-panel.c:1236
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Deling"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Rekenaarnaam"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Lêerdeling"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Werkarea"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Mediadeling"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "A_fgeleë aanmelding"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Lêerdeling"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Ve_reis wagwoord"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Afgeleë aanmelding"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Werkarea"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Aktiveer of deaktiveer afgeleë aanmelding"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "L_aat eksterne beheer toe"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
+msgstr "_Laat verbindings toe om die skerm te beheer"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Nie gekoppel nie"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopieer"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Skrap adres"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Verifiëring"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Gebruikernaam"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Besig om fingerafdrukke in te skryf"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Mediadeling"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Deel musiek, foto's en video's oor die netwerk."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Gidse"
 
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
 msgstr "Kies wat om te deel met ander"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/sharing/gnome-sharing-panel.desktop.in.in:7
-msgid "preferences-system-sharing"
-msgstr ""
-
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -5504,10 +3688,6 @@ msgid ""
 msgstr ""
 "deel;deling;ssh;gasheer;naam;afgeleë;werkskerm;media;klank;video;prente;"
 "fotos;flieks;bediener;"
-
-#: panels/sharing/networks.ui:19
-msgid "Networks"
-msgstr "Netwerke"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
@@ -5517,868 +3697,802 @@ msgstr "Aktiveer of deaktiveer afgeleë aanmelding"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Verifikasie is nodig om afgeleë aanmelding aan of af te skakel"
 
-#: panels/sharing/sharing.ui:46
-msgid "_Computer Name"
-msgstr "_Rekenaarnaam"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
 
-#: panels/sharing/sharing.ui:104
-msgid "_File Sharing"
-msgstr "_Lêerdeling"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Deling"
 
-#: panels/sharing/sharing.ui:147
-msgid "_Screen Sharing"
-msgstr "_Skermdeling"
-
-#: panels/sharing/sharing.ui:190
-msgid "_Media Sharing"
-msgstr "_Mediadeling"
-
-#: panels/sharing/sharing.ui:233
-msgid "_Remote Login"
-msgstr "A_fgeleë aanmelding"
-
-#: panels/sharing/sharing.ui:272
-msgid "Some services are disabled because of no network access."
-msgstr "Sommige dienste is gedeaktiveer weens 'n gebrek aan netwerktoegang."
-
-#: panels/sharing/sharing.ui:286 panels/sharing/sharing.ui:413
-msgid "File Sharing"
-msgstr "Lêerdeling"
-
-#: panels/sharing/sharing.ui:333
-msgid "_Require Password"
-msgstr "Ve_reis wagwoord"
-
-#: panels/sharing/sharing.ui:424 panels/sharing/sharing.ui:496
-msgid "Remote Login"
-msgstr "Afgeleë aanmelding"
-
-#: panels/sharing/sharing.ui:519 panels/sharing/sharing.ui:765
-msgid "Screen Sharing"
-msgstr "Skermdeling"
-
-#: panels/sharing/sharing.ui:577
-msgid "_Allow connections to control the screen"
-msgstr "_Laat verbindings toe om die skerm te beheer"
-
-#: panels/sharing/sharing.ui:622
-msgid "_Password:"
-msgstr "_Wagwoord:"
-
-#: panels/sharing/sharing.ui:652
-msgid "_Show Password"
-msgstr "Wy_s wagwoord"
-
-#: panels/sharing/sharing.ui:683
-msgid "Access Options"
-msgstr "Toegangskeuses"
-
-#: panels/sharing/sharing.ui:697
-msgid "_New connections must ask for access"
-msgstr "_Nuwe verbindings moet vra vir toegang"
-
-#: panels/sharing/sharing.ui:715
-msgid "_Require a password"
-msgstr "Ve_reis 'n wagwoord"
-
-#: panels/sharing/sharing.ui:776 panels/sharing/sharing.ui:870
-msgid "Media Sharing"
-msgstr "Mediadeling"
-
-#: panels/sharing/sharing.ui:809
-msgid "Share music, photos and videos over the network."
-msgstr "Deel musiek, foto's en video's oor die netwerk."
-
-#: panels/sharing/sharing.ui:824
-msgid "Folders"
-msgstr "Gidse"
-
-#: panels/sound/data/gnome-sound-panel.desktop.in.in:3
-msgid "Sound"
-msgstr "Klank"
-
-#: panels/sound/data/gnome-sound-panel.desktop.in.in:4
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "Verander klankvolume, toevoer, afvoer en kennisgewingklanke"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/sound/data/gnome-sound-panel.desktop.in.in:7
-msgid "multimedia-volume-control"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/sound/data/gnome-sound-panel.desktop.in.in:20
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "kaart;mikrofoon;volume;doof;balans;bluetooth;kopstuk;klank;"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:6
-msgid "Bark"
-msgstr "Blaf"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Balans:"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:12
-msgid "Drip"
-msgstr "Drup"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "Doo_f:"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:18
-msgid "Glass"
-msgstr "Glas"
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:24
-msgid "Sonar"
-msgstr "Sonar"
-
-#: panels/sound/gvc-balance-bar.c:104
-msgctxt "balance"
-msgid "Left"
-msgstr "Links"
-
-#: panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Right"
-msgstr "Regs"
-
-#: panels/sound/gvc-balance-bar.c:108
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Agter"
 
-#: panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Voor"
 
-#: panels/sound/gvc-balance-bar.c:112
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Minimum"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Maksimum"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Stelselklanke"
 
-#: panels/sound/gvc-balance-bar.c:288
-msgid "_Balance:"
-msgstr "_Balans:"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "W_aarskuwingvolume:"
 
-#: panels/sound/gvc-balance-bar.c:291
-msgid "_Fade:"
-msgstr "Doo_f:"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Volume uit"
 
-#: panels/sound/gvc-balance-bar.c:294
-msgid "_Subwoofer:"
-msgstr "_Basluidspreker:"
-
-#: panels/sound/gvc-channel-bar.c:610 panels/sound/gvc-channel-bar.c:619
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: panels/sound/gvc-channel-bar.c:614
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Onversterk"
-
-#: panels/sound/gvc-combo-box.c:166 panels/sound/gvc-mixer-dialog.c:253
-#: panels/sound/gvc-mixer-dialog.c:520
-msgid "_Profile:"
-msgstr "_Profiel:"
-
-#: panels/sound/gvc-mixer-dialog.c:255
-msgid "_Test Speakers"
-msgstr "_Toets luidsprekers"
-
-#: panels/sound/gvc-mixer-dialog.c:424
-msgid "Peak detect"
-msgstr "Spitsbespeuring"
-
-#: panels/sound/gvc-mixer-dialog.c:1499
-msgid "Device"
-msgstr "Toestel"
-
-#: panels/sound/gvc-mixer-dialog.c:1562
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "Luidsprekertoets vir %s"
-
-#: panels/sound/gvc-mixer-dialog.c:1617
-msgid "_Output volume:"
-msgstr "_Afvoervolume:"
-
-#: panels/sound/gvc-mixer-dialog.c:1631
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Afvoer"
 
-#: panels/sound/gvc-mixer-dialog.c:1636
-msgid "C_hoose a device for sound output:"
-msgstr "_Kies 'n toestel vir klankafvoer:"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "_Afvoervolume:"
 
-#: panels/sound/gvc-mixer-dialog.c:1658
-msgid "Settings for the selected device:"
-msgstr "Instellings vir die gekose toestel:"
-
-#: panels/sound/gvc-mixer-dialog.c:1669
-msgid "Input"
-msgstr "Toevoer"
-
-#: panels/sound/gvc-mixer-dialog.c:1676
-msgid "_Input volume:"
-msgstr "_Toevoervolume:"
-
-#: panels/sound/gvc-mixer-dialog.c:1697
-msgid "Input level:"
-msgstr "Toevoervlak:"
-
-#: panels/sound/gvc-mixer-dialog.c:1723
-msgid "C_hoose a device for sound input:"
-msgstr "_Kies 'n toestel vir klanktoevoer:"
-
-#: panels/sound/gvc-mixer-dialog.c:1747
-msgid "Sound Effects"
-msgstr "Klankeffekte"
-
-#: panels/sound/gvc-mixer-dialog.c:1754
-msgid "_Alert volume:"
-msgstr "W_aarskuwingvolume:"
-
-#: panels/sound/gvc-mixer-dialog.c:1775
-msgid "No application is currently playing or recording audio."
-msgstr "Geen toepassing wat tans oudio speel of opneem nie."
-
-#: panels/sound/gvc-sound-theme-chooser.c:187
-msgid "Built-in"
-msgstr "Ingebou"
-
-#: panels/sound/gvc-sound-theme-chooser.c:446
-#: panels/sound/gvc-sound-theme-chooser.c:458
-#: panels/sound/gvc-sound-theme-chooser.c:470
-msgid "Sound Preferences"
-msgstr "Klankvoorkeure"
-
-#: panels/sound/gvc-sound-theme-chooser.c:449
-#: panels/sound/gvc-sound-theme-chooser.c:460
-#: panels/sound/gvc-sound-theme-chooser.c:472
-msgid "Testing event sound"
-msgstr "Toets tans gebeurtenisklank"
-
-#: panels/sound/gvc-sound-theme-chooser.c:544
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "Verstek"
-
-#: panels/sound/gvc-sound-theme-chooser.c:545
-msgid "From theme"
-msgstr "Vanaf tema"
-
-#: panels/sound/gvc-sound-theme-chooser.c:720
-msgid "C_hoose an alert sound:"
-msgstr "_Kies 'n waarskuwingklank:"
-
-#: panels/sound/gvc-speaker-test.c:229
-msgid "Stop"
-msgstr "Stop"
-
-#: panels/sound/gvc-speaker-test.c:229 panels/sound/gvc-speaker-test.c:341
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Toets"
 
-#: panels/sound/gvc-speaker-test.c:237
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "_Konfigurasie-URL"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Basluidspreker"
 
-#: panels/sound/sound-theme-file-utils.c:288
-msgid "Custom"
-msgstr "Doelgemaak"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Toevoer"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:353
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Verstek"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Toevoervlak:"
 
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Medium"
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Volume harder"
 
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Groot"
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "W_aarskuwingvolume:"
 
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Groter"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Doof uit"
 
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Grootste"
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Klank"
 
-#: panels/universal-access/cc-ua-panel.c:369
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d beeldpunt"
-msgstr[1] "%d beeldpunte"
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Verander klankvolume, toevoer, afvoer en kennisgewingklanke"
 
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "Maak sien, hoor, tik, wys en klik makliker"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:7
-msgid "preferences-desktop-accessibility"
-msgstr ""
-
-#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "kaart;mikrofoon;volume;doof;balans;bluetooth;kopstuk;klank;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Ke_nnisgewings"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Naam:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"sleutelbord;muis;a11y;toeganklikheid;kontras;zoem;skerm;leser;teks;"
-"lettertipe;grootte;accessx;kleefsleutels;stadige;sleutels;bons;dubbel;klik;"
-"vertraag;help;herhaal;flikker;"
 
-#: panels/universal-access/uap.ui:89
-msgid "_Always Show Universal Access Menu"
-msgstr "Wys _altyd die kieslys vir universele toegang"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: panels/universal-access/uap.ui:131
-msgid "Seeing"
-msgstr "Sien"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "Outomatiese _koppeling"
 
-#: panels/universal-access/uap.ui:177
-msgid "_High Contrast"
-msgstr "_Hoë kontras"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Verwyder toestel"
 
-#: panels/universal-access/uap.ui:224
-msgid "_Large Text"
-msgstr "_Groot teks"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: panels/universal-access/uap.ui:269
-msgid "C_ursor Size"
-msgstr "_Wysergrootte"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Kon nie koppel aan die %s-domein nie: %s"
 
-#: panels/universal-access/uap.ui:316
-#: panels/universal-access/zoom-options.ui:98
-msgid "_Zoom"
-msgstr "_Zoem"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Universele toegang"
 
-#: panels/universal-access/uap.ui:362
-msgid "Screen _Reader"
-msgstr "Ske_rmleser"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: panels/universal-access/uap.ui:408 panels/universal-access/uap.ui:1237
-msgid "_Sound Keys"
-msgstr "Klank_sleutels"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Kry tans toestelle..."
 
-#: panels/universal-access/uap.ui:470
-msgid "Hearing"
-msgstr "Hoor"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: panels/universal-access/uap.ui:514 panels/universal-access/uap.ui:1340
-msgid "_Visual Alerts"
-msgstr "_Visuele waarskuwings"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
 
-#: panels/universal-access/uap.ui:622
-msgid "Screen _Keyboard"
-msgstr "S_kermsleutelbord"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: panels/universal-access/uap.ui:667
-msgid "R_epeat Keys"
-msgstr "H_erhaalsleutels"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: panels/universal-access/uap.ui:713
-msgid "Cursor _Blinking"
-msgstr "Wyser _flikker"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Wyser flikker"
 
-#: panels/universal-access/uap.ui:759
-msgid "_Typing Assist (AccessX)"
-msgstr "_Tik-assistent (AccessX)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Wyser flikker in teksvelde."
 
-#: panels/universal-access/uap.ui:820
-msgid "Pointing & Clicking"
-msgstr "Wys en klik"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Spoed"
 
-#: panels/universal-access/uap.ui:866
-msgid "_Mouse Keys"
-msgstr "_Muissleutels"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Wyser se flikkerspoed"
 
-#: panels/universal-access/uap.ui:911
-msgid "_Click Assist"
-msgstr "_Klik-assistent"
-
-#: panels/universal-access/uap.ui:957
-msgid "_Double-Click Delay"
-msgstr "Wagtyd vir _dubbelklik"
-
-#: panels/universal-access/uap.ui:977
-msgid "Double-Click Delay"
-msgstr "Wagtyd vir dubbelklik"
-
-#: panels/universal-access/uap.ui:1042
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr "Wysergrootte"
 
-#: panels/universal-access/uap.ui:1069
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 "Muis grootte kan gekombineer word met die zoem funksie om dit makliker te "
 "maak om te sien."
 
-#: panels/universal-access/uap.ui:1105
-msgid "Screen Reader"
-msgstr "Skermleser"
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Klik-assistent"
 
-#: panels/universal-access/uap.ui:1122
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "Die skermleser lees die vertoonde teks soos die fokus verskuif."
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Ge_simuleerder sekondêre klik"
 
-#: panels/universal-access/uap.ui:1155
-msgid "_Screen Reader"
-msgstr "_Skermleser"
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Doen 'n sekondêre klik deur die primêre knoppie in te hou"
 
-#: panels/universal-access/uap.ui:1194
-msgid "Sound Keys"
-msgstr "Klanksleutels"
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Wagtyd _voor aanvaarding:"
 
-#: panels/universal-access/uap.ui:1212
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "Biep wanneer Caps- of NumLock aan of af geskakel word."
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kort"
 
-#: panels/universal-access/uap.ui:1282
-msgid "Visual Alerts"
-msgstr "Visuele waarskuwings"
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Sekondêre klikwagtyd"
 
-#: panels/universal-access/uap.ui:1286
-msgid "_Test flash"
-msgstr "_Toets flits"
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lank"
 
-#: panels/universal-access/uap.ui:1315
-msgid "Use a visual indication when an alert sound occurs."
-msgstr ""
-"Gebruik 'n visuele aanduiding wanneer 'n waarskuwingklank gespeel word."
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Swee_fklik"
 
-#: panels/universal-access/uap.ui:1366
-msgid "Flash the _window title"
-msgstr "Flits die _venstertitel"
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Registreer 'n klik wanneer die muiswyser sweef"
 
-#: panels/universal-access/uap.ui:1384
-msgid "Flash the entire _screen"
-msgstr "Flits die _hele skerm"
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "V_ertraging:"
 
-#: panels/universal-access/uap.ui:1429
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lank"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Bewegingsdrempel:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Klein"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Groot"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
 msgid "Repeat Keys"
 msgstr "Herhaalsleutels"
 
-#: panels/universal-access/uap.ui:1459
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Sleuteldrukke herhaal wanneer sleutel ingehou word."
 
-#: panels/universal-access/uap.ui:1539
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Wagtyd vir herhaalsleutels"
 
-#: panels/universal-access/uap.ui:1587 panels/universal-access/uap.ui:1722
-msgid "Speed"
-msgstr "Spoed"
-
-#: panels/universal-access/uap.ui:1626
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Herhaalsleutelspoed"
 
-#: panels/universal-access/uap.ui:1650
-msgid "Cursor Blinking"
-msgstr "Wyser flikker"
-
-#: panels/universal-access/uap.ui:1680
-msgid "Cursor blinks in text fields."
-msgstr "Wyser flikker in teksvelde."
-
-#: panels/universal-access/uap.ui:1759
-msgid "Cursor blinking speed"
-msgstr "Wyser se flikkerspoed"
-
-#: panels/universal-access/uap.ui:1795
+#: panels/universal-access/cc-typing-dialog.ui:4
 msgid "Typing Assist"
 msgstr "Tik-assistent"
 
-#: panels/universal-access/uap.ui:1834
+#: panels/universal-access/cc-typing-dialog.ui:41
 msgid "_Sticky Keys"
 msgstr "_Kleefsleutels"
 
-#: panels/universal-access/uap.ui:1851
+#: panels/universal-access/cc-typing-dialog.ui:51
 msgid "Treats a sequence of modifier keys as a key combination"
 msgstr "Hanteer opeenvolgende wysigersleutels as 'n sleutelkombinasie"
 
-#: panels/universal-access/uap.ui:1875
+#: panels/universal-access/cc-typing-dialog.ui:63
 msgid "_Disable if two keys are pressed together"
 msgstr "_Deaktiveer indien twee sleutels gelyktydig gedruk word"
 
-#: panels/universal-access/uap.ui:1893
+#: panels/universal-access/cc-typing-dialog.ui:71
 msgid "Beep when a _modifier key is pressed"
 msgstr "Biep wanneer 'n _wysigsleutel gedruk word"
 
-#: panels/universal-access/uap.ui:1941
+#: panels/universal-access/cc-typing-dialog.ui:96
 msgid "S_low Keys"
 msgstr "Stadige s_leutels"
 
-#: panels/universal-access/uap.ui:1958
+#: panels/universal-access/cc-typing-dialog.ui:106
 msgid "Puts a delay between when a key is pressed and when it is accepted"
 msgstr ""
 "Wag 'n rukkie tussen wanneer 'n sleutel gedruk word en wanneer dit aanvaar "
 "word"
 
-#: panels/universal-access/uap.ui:1991 panels/universal-access/uap.ui:2204
-#: panels/universal-access/uap.ui:2541
-msgid "A_cceptance delay:"
-msgstr "Wagtyd _voor aanvaarding:"
-
-#: panels/universal-access/uap.ui:2013
+#: panels/universal-access/cc-typing-dialog.ui:135
 msgctxt "slow keys delay"
 msgid "Short"
 msgstr "Kort"
 
-#: panels/universal-access/uap.ui:2032
+#: panels/universal-access/cc-typing-dialog.ui:147
 msgid "Slow keys typing delay"
 msgstr "Stadige sleutels se tikwagtyd"
 
-#: panels/universal-access/uap.ui:2047
+#: panels/universal-access/cc-typing-dialog.ui:154
 msgctxt "slow keys delay"
 msgid "Long"
 msgstr "Lank"
 
-#: panels/universal-access/uap.ui:2074
+#: panels/universal-access/cc-typing-dialog.ui:166
 msgid "Beep when a key is pr_essed"
 msgstr "Bi_ep as 'n sleutel gedruk word"
 
-#: panels/universal-access/uap.ui:2091
+#: panels/universal-access/cc-typing-dialog.ui:173
 msgid "Beep when a key is _accepted"
 msgstr "Biep as 'n sleutel _aanvaar word"
 
-#: panels/universal-access/uap.ui:2108 panels/universal-access/uap.ui:2287
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
 msgid "Beep when a key is _rejected"
 msgstr "Biep as 'n sleutel ve_rwerp word"
 
-#: panels/universal-access/uap.ui:2154
+#: panels/universal-access/cc-typing-dialog.ui:203
 msgid "_Bounce Keys"
 msgstr "_Bonssleutels"
 
-#: panels/universal-access/uap.ui:2171
+#: panels/universal-access/cc-typing-dialog.ui:213
 msgid "Ignores fast duplicate keypresses"
 msgstr "Ignoreer duplikaatsleutels kort na mekaar"
 
-#: panels/universal-access/uap.ui:2226
+#: panels/universal-access/cc-typing-dialog.ui:242
 msgctxt "bounce keys delay"
 msgid "Short"
 msgstr "Kort"
 
-#: panels/universal-access/uap.ui:2245
+#: panels/universal-access/cc-typing-dialog.ui:254
 msgid "Bounce keys typing delay"
 msgstr "Bonssleutels se tikwagtyd"
 
-#: panels/universal-access/uap.ui:2260
+#: panels/universal-access/cc-typing-dialog.ui:261
 msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Lank"
 
-#: panels/universal-access/uap.ui:2373
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "_Aktiveer met sleutelbord"
 
-#: panels/universal-access/uap.ui:2390
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Skakel toeganklikheidfunksies aan en af met die sleutelbord"
 
-#: panels/universal-access/uap.ui:2454
-msgid "Click Assist"
-msgstr "Klik-assistent"
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Wys _altyd die kieslys vir universele toegang"
 
-#: panels/universal-access/uap.ui:2490
-msgid "_Simulated Secondary Click"
-msgstr "Ge_simuleerder sekondêre klik"
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Sien"
 
-#: panels/universal-access/uap.ui:2508
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "Doen 'n sekondêre klik deur die primêre knoppie in te hou"
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Hoë kontras"
 
-#: panels/universal-access/uap.ui:2562
-msgctxt "secondary click"
-msgid "Short"
-msgstr "Kort"
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Groot teks"
 
-#: panels/universal-access/uap.ui:2581
-msgid "Secondary click delay"
-msgstr "Sekondêre klikwagtyd"
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
 
-#: panels/universal-access/uap.ui:2596
-msgctxt "secondary click delay"
-msgid "Long"
-msgstr "Lank"
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Ske_rmleser"
 
-#: panels/universal-access/uap.ui:2653
-msgid "_Hover Click"
-msgstr "Swee_fklik"
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Die skermleser lees die vertoonde teks soos die fokus verskuif."
 
-#: panels/universal-access/uap.ui:2671
-msgid "Trigger a click when the pointer hovers"
-msgstr "Registreer 'n klik wanneer die muiswyser sweef"
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Klank_sleutels"
 
-#: panels/universal-access/uap.ui:2704
-msgid "D_elay:"
-msgstr "V_ertraging:"
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Biep wanneer Caps- of NumLock aan of af geskakel word."
 
-#: panels/universal-access/uap.ui:2726
-msgctxt "dwell click delay"
-msgid "Short"
-msgstr "Kort"
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "_Wysergrootte"
 
-#: panels/universal-access/uap.ui:2757
-msgctxt "dwell click delay"
-msgid "Long"
-msgstr "Lank"
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zoem"
 
-#: panels/universal-access/uap.ui:2793
-msgid "Motion _threshold:"
-msgstr "_Bewegingsdrempel:"
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Hoor"
 
-#: panels/universal-access/uap.ui:2815
-msgctxt "dwell click threshold"
-msgid "Small"
-msgstr "Klein"
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Visuele waarskuwings"
 
-#: panels/universal-access/uap.ui:2846
-msgctxt "dwell click threshold"
-msgid "Large"
-msgstr "Groot"
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "S_kermsleutelbord"
 
-#: panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
-msgid "Short"
-msgstr "Kort"
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "H_erhaalsleutels"
 
-#: panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼-skerm"
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Wyser _flikker"
 
-#: panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½-skerm"
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Tik-assistent (AccessX)"
 
-#: panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾-skerm"
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Wys en klik"
 
-#: panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
-msgid "Long"
-msgstr "Lank"
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Muissleutels"
 
-#: panels/universal-access/zoom-options.ui:48
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "<b>Vind Wyser</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Klik-assistent"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Wagtyd vir _dubbelklik"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Wagtyd vir dubbelklik"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Visuele waarskuwings"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Toets flits"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+"Gebruik 'n visuele aanduiding wanneer 'n waarskuwingklank gespeel word."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Flits die _hele skerm"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Flits die _hele skerm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "Volskerm"
 
-#: panels/universal-access/zoom-options.ui:53
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "Boonste helfte"
 
-#: panels/universal-access/zoom-options.ui:58
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "Onderste helfte"
 
-#: panels/universal-access/zoom-options.ui:63
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "Linkerhelfte"
 
-#: panels/universal-access/zoom-options.ui:68
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "Regterhelfte"
 
-#: panels/universal-access/zoom-options.ui:77
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "Zoemkeuses"
 
-#: panels/universal-access/zoom-options.ui:186
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
 msgstr "_Vergroting:"
 
-#: panels/universal-access/zoom-options.ui:250
-msgid "_Follow mouse cursor"
-msgstr "_Volg die muiswyser"
-
-#: panels/universal-access/zoom-options.ui:270
-msgid "_Screen part:"
-msgstr "_Skermgedeelte:"
-
-#: panels/universal-access/zoom-options.ui:332
-msgid "Magnifier _extends outside of screen"
-msgstr "V_ergrootglas gaan verby die skerm"
-
-#: panels/universal-access/zoom-options.ui:351
-msgid "_Keep magnifier cursor centered"
-msgstr "_Hou vergrootglas se wyser in die middel"
-
-#: panels/universal-access/zoom-options.ui:370
-msgid "Magnifier cursor _pushes contents around"
-msgstr "Vergrootglas se wyser s_kuif die inhoud rond"
-
-#: panels/universal-access/zoom-options.ui:389
-msgid "Magnifier cursor moves with _contents"
-msgstr "Vergrootglas se wyser skuif saam met i_nhoud"
-
-#: panels/universal-access/zoom-options.ui:423
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "Vergrootglas se ligging:"
 
-#: panels/universal-access/zoom-options.ui:444
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Volg die muiswyser"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Skermgedeelte:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "V_ergrootglas gaan verby die skerm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Hou vergrootglas se wyser in die middel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Vergrootglas se wyser s_kuif die inhoud rond"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Vergrootglas se wyser skuif saam met i_nhoud"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Vergrootglas"
 
-#: panels/universal-access/zoom-options.ui:490
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Kruisdraadjies:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "B_o-oor die muiswyser"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
 msgstr "_Dikte:"
 
-#: panels/universal-access/zoom-options.ui:516
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "Dun"
 
-#: panels/universal-access/zoom-options.ui:548
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Dik"
 
-#: panels/universal-access/zoom-options.ui:574
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
 msgstr "_Lengte:"
 
 #. The color of the accessibility crosshair
-#: panels/universal-access/zoom-options.ui:626
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
 msgstr "K_leur:"
 
-#: panels/universal-access/zoom-options.ui:690
-msgid "_Crosshairs:"
-msgstr "_Kruisdraadjies:"
-
-#: panels/universal-access/zoom-options.ui:741
-msgid "_Overlaps mouse cursor"
-msgstr "B_o-oor die muiswyser"
-
-#: panels/universal-access/zoom-options.ui:779
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "Kruisdraadjies"
 
-#: panels/universal-access/zoom-options.ui:827
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Klankeffekte:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
 msgstr "_Wit op swart:"
 
-#: panels/universal-access/zoom-options.ui:850
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
 msgstr "_Helderheid:"
 
-#: panels/universal-access/zoom-options.ui:874
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
 msgstr "_Kontras:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/zoom-options.ui:897
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
 msgid "Co_lor"
 msgstr "K_leur"
 
-#: panels/universal-access/zoom-options.ui:925
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Geen"
 
-#: panels/universal-access/zoom-options.ui:957
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Vol"
 
-#: panels/universal-access/zoom-options.ui:1023
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Donker"
 
-#: panels/universal-access/zoom-options.ui:1056
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Helder"
 
-#: panels/universal-access/zoom-options.ui:1087
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Laag"
 
-#: panels/universal-access/zoom-options.ui:1120
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Hoog"
 
-#: panels/universal-access/zoom-options.ui:1156
-msgid "Color Effects:"
-msgstr "Klankeffekte:"
-
-#: panels/universal-access/zoom-options.ui:1181
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "Kleureffekte"
 
-#: panels/user-accounts/data/account-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Maak sien, hoor, tik, wys en klik makliker"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"sleutelbord;muis;a11y;toeganklikheid;kontras;zoem;skerm;leser;teks;"
+"lettertipe;grootte;accessx;kleefsleutels;stadige;sleutels;bons;dubbel;klik;"
+"vertraag;help;herhaal;flikker;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Geskiedenis"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "Geskiedenis"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "_Maak onlangse geskiedenis skoon"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "Permanente uitvee en tydelike lêers"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "_Maak asblik outomaties leeg"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "_Vee tydelike lêers outomaties permanent uit"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "_Maak asblik outomaties leeg"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Maak _asblik leeg…"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "Vee tydelike lêers _permanent uit…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "Skuif na asblik"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Voeg gebruiker by"
 
-#: panels/user-accounts/data/account-dialog.ui:171
-msgid "_Full Name"
-msgstr "_Volle naam"
-
-#: panels/user-accounts/data/account-dialog.ui:197
-#: panels/user-accounts/data/user-accounts-dialog.ui:146
-msgid "Standard"
-msgstr "Standaard"
-
-#: panels/user-accounts/data/account-dialog.ui:207
-#: panels/user-accounts/data/user-accounts-dialog.ui:155
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "Administrateur"
 
-#: panels/user-accounts/data/account-dialog.ui:223
-#: panels/user-accounts/data/user-accounts-dialog.ui:173
-msgid "Account _Type"
-msgstr "Rekening_tipe"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: panels/user-accounts/data/account-dialog.ui:260
-msgid "Allow user to set a password when they next _login"
-msgstr "_Laat gebruiker toe om 'n wagwoord in te stel met volgende aanmelding"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Laat gebruiker toe om 'n wagwoord in te stel met volgende aanmelding"
 
-#: panels/user-accounts/data/account-dialog.ui:274
-msgid "Set a password _now"
-msgstr "Stel 'n wagwoord _nou in"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Stel 'n wagwoord nou in"
 
-#: panels/user-accounts/data/account-dialog.ui:387
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "_Bevestig"
 
-#: panels/user-accounts/data/account-dialog.ui:463
-#: panels/user-accounts/data/account-dialog.ui:667
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_Onderneming-aanmelding"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Jy is vanlyn af"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -6388,120 +4502,237 @@ msgstr ""
 "gebruikerrekening op dié toestel gebruik kan word. U kan ook die rekening "
 "gebruik om toegang tot maatskapy hulpbronne op die internet te kry."
 
-#: panels/user-accounts/data/account-dialog.ui:485
-#: panels/user-accounts/data/join-dialog.ui:116
-msgid "_Domain"
-msgstr "_Domein"
-
-#: panels/user-accounts/data/account-dialog.ui:707
-msgid "You are Offline"
-msgstr "Jy is vanlyn af"
-
-#: panels/user-accounts/data/account-dialog.ui:726
-msgid "You must be online in order to add enterprise users."
-msgstr "Jy moet aanlyn wees om onderneming-gebruikers by te voeg."
-
-#: panels/user-accounts/data/account-dialog.ui:760
-msgid "_Enterprise Login"
-msgstr "_Onderneming-aanmelding"
-
-#: panels/user-accounts/data/account-fingerprint.ui:12
-msgid "Left thumb"
-msgstr "Linkerduim"
-
-#: panels/user-accounts/data/account-fingerprint.ui:15
-msgid "Left middle finger"
-msgstr "Linkermiddelvinger"
-
-#: panels/user-accounts/data/account-fingerprint.ui:18
-msgid "Left ring finger"
-msgstr "Linkerringvinger"
-
-#: panels/user-accounts/data/account-fingerprint.ui:21
-msgid "Left little finger"
-msgstr "Linkerpinkie"
-
-#: panels/user-accounts/data/account-fingerprint.ui:24
-msgid "Right thumb"
-msgstr "Regterduim"
-
-#: panels/user-accounts/data/account-fingerprint.ui:27
-msgid "Right middle finger"
-msgstr "Regtermiddelvinger"
-
-#: panels/user-accounts/data/account-fingerprint.ui:30
-msgid "Right ring finger"
-msgstr "Regterringvinger"
-
-#: panels/user-accounts/data/account-fingerprint.ui:33
-msgid "Right little finger"
-msgstr "Regterpinkie"
-
-#: panels/user-accounts/data/account-fingerprint.ui:39
-#: panels/user-accounts/um-fingerprint-dialog.c:677
-msgid "Enable Fingerprint Login"
-msgstr "Aktiveer aanmelding met vingerafdruk"
-
-#: panels/user-accounts/data/account-fingerprint.ui:89
-msgid "_Right index finger"
-msgstr "_Regterwysvinger"
-
-#: panels/user-accounts/data/account-fingerprint.ui:105
-msgid "_Left index finger"
-msgstr "_Linkerwysvinger"
-
-#: panels/user-accounts/data/account-fingerprint.ui:126
-msgid "_Other finger:"
-msgstr "_Ander vinger:"
-
-#: panels/user-accounts/data/account-fingerprint.ui:262
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"U vingerafdruk is suksesvol gestoor. U behoort nou te kan aanmeld m.b.v. die "
-"vingerafdrukleser."
-
-#: panels/user-accounts/data/avatar-chooser.ui:27
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 #, fuzzy
-#| msgid "Take a photo…"
-msgid "Take a Picture…"
-msgstr "Neem 'n foto…"
-
-#: panels/user-accounts/data/avatar-chooser.ui:34
-#, fuzzy
-#| msgid "Select PPD File"
 msgid "Select a File…"
 msgstr "Kies PPD-lêer"
 
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Aanmelding met vingera_fdruk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Aanmelding met vingera_fdruk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Nee"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Wil u die geregistreerde vingerafdrukke skrap sodat aanmelding met "
+"vingerafdrukke gedeaktiveer is?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Geen drukkers bespeur nie."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Aanmelding met vingera_fdruk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Aanmelding met vingera_fdruk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "_Kies 'n toestel om in te stel:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Aanmelding met vingera_fdruk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Skrap vingerafdrukke"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Aanmelding met vingera_fdruk"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Vorige snit"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Verander wagwoord"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Ver_ander"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Huidige _wagwoord"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Nuwe wagwoord"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "_Bevestig wagwoord"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Die wagwoorde stem nie ooreen nie."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Laat gebruiker toe om 'n wagwoord in te stel met volgende aanmelding"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Stel 'n wagwoord nou in"
+
+#: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Gebruikers"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Die sessie moet herbegin word sodat veranderinge kan neerslag vind"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Herbegin nou"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Sluit"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Volle naam"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "Redigeer..."
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Aanmelding met vingera_fdruk"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "O_utomatiese aanmelding"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "%s — Rekening Aktiwiteit"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Administrateur"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Kontroles"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Verwyder gebruiker…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Ander vinger:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "_Voeg gebruiker by…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Geen drukkers gevind nie"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "Skep 'n gebruikerrekening"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "Voeg by of skrap gebruikers en verander u wagwoord"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:7
-msgid "system-users"
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "aanmeld;naam;vingerafdruk;embleem;gesig;wagwoord;"
-
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Inskryf"
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Aanmelding as domein se administrateur"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6512,87 +4743,13 @@ msgstr ""
 "domein gekoppel wees. Laat u netwerkadministrateur\n"
 "hul domeinwagwoord hier invul."
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "Administrateur_naam"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Administrateurwagwoord"
-
-#: panels/user-accounts/data/password-dialog.ui:7
-msgid "Change Password"
-msgstr "Verander wagwoord"
-
-#: panels/user-accounts/data/password-dialog.ui:38
-msgid "Ch_ange"
-msgstr "Ver_ander"
-
-#: panels/user-accounts/data/password-dialog.ui:142
-msgid "_Verify New Password"
-msgstr "Be_vestig nuwe wagwoord"
-
-#: panels/user-accounts/data/password-dialog.ui:159
-msgid "_New Password"
-msgstr "_Nuwe wagwoord"
-
-#: panels/user-accounts/data/password-dialog.ui:208
-msgid "Current _Password"
-msgstr "Huidige _wagwoord"
-
-#: panels/user-accounts/data/password-dialog.ui:243
-msgid "Allow user to change their password on next login"
-msgstr "Laat gebruiker toe om 'n wagwoord in te stel met volgende aanmelding"
-
-#: panels/user-accounts/data/password-dialog.ui:256
-msgid "Set a password now"
-msgstr "Stel 'n wagwoord nou in"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:20
-msgid "_Add User…"
-msgstr "_Voeg gebruiker by…"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:69
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "Die sessie moet herbegin word sodat veranderinge kan neerslag vind"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:77
-msgid "Restart Now"
-msgstr "Herbegin nou"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:244
-msgid "A_utomatic Login"
-msgstr "O_utomatiese aanmelding"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:285
-msgid "_Fingerprint Login"
-msgstr "Aanmelding met vingera_fdruk"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:311
-#: panels/user-accounts/data/user-accounts-dialog.ui:324
-msgid "User Icon"
-msgstr "Gebruikerikoon"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:387
-msgid "Last Login"
-msgstr "Laas aangemeld"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:434
-msgid "Remove User…"
-msgstr "Verwyder gebruiker…"
-
-#. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/data/user-accounts-dialog.ui:466
-#, fuzzy
-#| msgid "No Printers Found"
-msgid "No Users Found"
-msgstr "Geen drukkers gevind nie"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:476
-#, fuzzy
-#| msgid "Create a user account"
-msgid "Unlock to add a user account."
-msgstr "Skep 'n gebruikerrekening"
 
 #: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
@@ -6602,589 +4759,16 @@ msgstr "Bestuur gebruikerrekeninge"
 msgid "Authentication is required to change user data"
 msgstr "Verifikasie is nodig om gebruikersdata te verander"
 
-#: panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Die nuwe wagwoord moet verskil van die oue."
-
-#: panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Probeer om sommige letters en syfers te verander."
-
-#: panels/user-accounts/pw-utils.c:85 panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Probeer om die wagwoord nog meer te verander."
-
-#: panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "'n Wagwoord wat nie die gebruikernaam bevat nie sal sterker wees."
-
-#: panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Vermy die gebruik van u naam in die wagwoord."
-
-#: panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Vermy sommige van die woorde in die wagwoord."
-
-#: panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Vermy eerder algemene woorde."
-
-#: panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Probeer om nie bestaande woorde te skommel nie."
-
-#: panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Probeer om meer syfers te gebruik."
-
-#: panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Probeer om meer hoofletters te gebruik."
-
-#: panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Probeer om meer kleinletters te gebruik."
-
-#: panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Probeer om meer karakters soos leestekens te gebruik."
-
-#: panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Probeer om 'n mengsel van letters, syfers en leestekens te gebruik."
-
-#: panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Probeer om nie die selfde karakter te herhaal nie."
-
-#: panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Probeer om nie die selfde tipe karakter te herhaal nie: meng eerder letters, "
-"syfers en leestekens."
-
-#: panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Bly eerder weg van patrone soos 1234 of abcd."
-
-#: panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Die wagwoord moet langer wees. Probeer om 'n mengsel van letters, syfers en "
-"leestekens te gebruik."
-
-#: panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Meng hoof- en kleinletters en gebruik 'n syfer of twee."
-
-# Notes:
-# Add Note
-#
-# Context:
-# Password hint
-#: panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Goeie wagwoord! Meer letters, syfers en leestekens sal dit selfs nog sterker "
-"maak."
-
-#: panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "Verifikasie het misluk"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "Die nuwe wagwoord is te kort"
-
-#: panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "Die nuwe wagwoord is te eenvoudig"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Die ou en nuwe wagwoorde is te soortgelyk"
-
-#: panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Die nuwe wagwoord is reeds onlangs gebruik."
-
-#: panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Die nuwe wagwoord moet syfers of spesiale karakters bevat"
-
-#: panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Die ou en nuwe wagwoorde is die selfde"
-
-#: panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Jou wagwoord het verander sedert jy aanvanklik geverifieer is!"
-
-#: panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Die nuwe wagwoord bevat nie genoeg verskillende karakters nie"
-
-#: panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "Onbekende fout"
-
-#: panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "Moet pas by die webadres van die rekeningverskaffer."
-
-#: panels/user-accounts/um-account-dialog.c:229
-msgid "Failed to add account"
-msgstr "Kon nie 'n rekening byvoeg nie"
-
-#: panels/user-accounts/um-account-dialog.c:462
-msgid "Passwords do not match."
-msgstr "Wagwoorde stem nie ooreen nie."
-
-#: panels/user-accounts/um-account-dialog.c:717
-#: panels/user-accounts/um-account-dialog.c:763
-#: panels/user-accounts/um-account-dialog.c:784
-msgid "Failed to register account"
-msgstr "Kon nie rekening registreer nie"
-
-#: panels/user-accounts/um-account-dialog.c:907
-msgid "No supported way to authenticate with this domain"
-msgstr "Geen ondersteunde manier om met hierdie domein te verifieer nie"
-
-#: panels/user-accounts/um-account-dialog.c:980
-msgid "Failed to join domain"
-msgstr "Kon nie by domein aansluit nie"
-
-#: panels/user-accounts/um-account-dialog.c:1041
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Daardie gebruikernaam het nie gewerk nie.\n"
-"Probeer gerus weer."
-
-#: panels/user-accounts/um-account-dialog.c:1048
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Daardie wagwoord het nie gewerk nie.\n"
-"Probeer gerus weer."
-
-#: panels/user-accounts/um-account-dialog.c:1056
-msgid "Failed to log into domain"
-msgstr "Kon nie by domein aanmeld nie"
-
-#: panels/user-accounts/um-account-dialog.c:1114
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Kon nie die domein vind nie. Is dit reg gespel?"
-
-#: panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Gewoon"
-
-#: panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "Administrateur"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"U mag nie toegang kry tot die toestel nie. Kontak die stelseladministrateur."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "Die toestel is reeds in gebruik."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr "'n Interne fout het voorgekom."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Enabled"
-msgstr "Geaktiveer"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:260
-msgid "Delete registered fingerprints?"
-msgstr "Skrap geregistreerde vingerafdrukke?"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:264
-msgid "_Delete Fingerprints"
-msgstr "_Skrap vingerafdrukke"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:270
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"Wil u die geregistreerde vingerafdrukke skrap sodat aanmelding met "
-"vingerafdrukke gedeaktiveer is?"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:440
-msgid "Done!"
-msgstr "Klaar!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:501
-#: panels/user-accounts/um-fingerprint-dialog.c:543
-#, c-format
-msgid "Could not access “%s” device"
-msgstr "Kon nie toegang tot die toestel \"%s\" kry nie"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:584
-#, c-format
-msgid "Could not start finger capture on “%s” device"
-msgstr "Kon nie vingeropname op \"%s\" begin nie"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:628
-msgid "Could not access any fingerprint readers"
-msgstr "Kon nie toegang kry tot enige vingerafdruklesers nie"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:629
-msgid "Please contact your system administrator for help."
-msgstr "Kontak u stelseladministrateur vir hulp."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: panels/user-accounts/um-fingerprint-dialog.c:711
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the “%s” device."
-msgstr ""
-"Om aanmelding met vingerafdruk te aktiveer moet u een van u vingerafdrukke "
-"stoor met die toestel \"%s\"."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:718
-msgid "Selecting finger"
-msgstr "Kies 'n vinger"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:719
-msgid "Enrolling fingerprints"
-msgstr "Besig om fingerafdrukke in te skryf"
-
-#: panels/user-accounts/um-history-dialog.c:70
-msgid "This Week"
-msgstr "Dié week"
-
-#: panels/user-accounts/um-history-dialog.c:73
-msgid "Last Week"
-msgstr "Verlede week"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/um-history-dialog.c:79
-#: panels/user-accounts/um-history-dialog.c:83
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/um-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/um-history-dialog.c:93
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/um-history-dialog.c:177
-#: panels/user-accounts/um-user-panel.c:766
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/um-history-dialog.c:180
-#: panels/user-accounts/um-user-panel.c:770
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/um-history-dialog.c:250
-msgid "Session Ended"
-msgstr "Sessie is begin"
-
-#: panels/user-accounts/um-history-dialog.c:256
-msgid "Session Started"
-msgstr "Sessie is beëindig"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/um-history-dialog.c:299
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Rekening Aktiwiteit"
-
-#: panels/user-accounts/um-password-dialog.c:144
-msgid "Please choose another password."
-msgstr "Kies asseblief 'n ander wagwoord."
-
-#: panels/user-accounts/um-password-dialog.c:153
-msgid "Please type your current password again."
-msgstr "Tik asseblief die huidige wagwoord weer."
-
-#: panels/user-accounts/um-password-dialog.c:159
-msgid "Password could not be changed"
-msgstr "Wagwoord kon nie verander word nie"
-
-#: panels/user-accounts/um-password-dialog.c:285
-msgid "The passwords do not match."
-msgstr "Die wagwoorde stem nie ooreen nie."
-
-#: panels/user-accounts/um-photo-dialog.c:227
-msgid "Browse for more pictures"
-msgstr "Blaai vir meer beelde"
-
-#: panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "Kan nie outomaties by 'n domein van dié soort aansluit nie"
-
-#: panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "Geen domein of gebied gevind nie"
-
-#: panels/user-accounts/um-realm-manager.c:815
-#: panels/user-accounts/um-realm-manager.c:829
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Kan nie as %s by die %s-domein aanmeld nie"
-
-#: panels/user-accounts/um-realm-manager.c:821
-msgid "Invalid password, please try again"
-msgstr "Verkeerde wagwoord. Probeer gerus weer"
-
-#: panels/user-accounts/um-realm-manager.c:834
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Kon nie koppel aan die %s-domein nie: %s"
-
-#: panels/user-accounts/um-user-panel.c:200
-msgid "Your account"
-msgstr "Jou rekening"
-
-#: panels/user-accounts/um-user-panel.c:380
-msgid "Failed to delete user"
-msgstr "Kon nie gebruiker skrap nie"
-
-#: panels/user-accounts/um-user-panel.c:438
-#: panels/user-accounts/um-user-panel.c:497
-#: panels/user-accounts/um-user-panel.c:549
-msgid "Failed to revoke remotely managed user"
-msgstr "Kon nie afstand bestuurde gebruiker skrap nie"
-
-#: panels/user-accounts/um-user-panel.c:603
-msgid "You cannot delete your own account."
-msgstr "U kan nie u eie rekening skrap nie."
-
-#: panels/user-accounts/um-user-panel.c:612
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s is steeds aangemeld"
-
-#: panels/user-accounts/um-user-panel.c:616
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Om 'n gebruiker te skrap terwyl hy aangemeld is, kan die stelsel in 'n "
-"inkonsekwente toestand laat."
-
-#: panels/user-accounts/um-user-panel.c:625
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Wil u %s se lêers behou?"
-
-#: panels/user-accounts/um-user-panel.c:629
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Dit is moontlik om die tuisgids, pos-spool-gids en tydelike lêers te hou "
-"wanneer 'n gebruiker se rekening geskrap word."
-
-#: panels/user-accounts/um-user-panel.c:632
-msgid "_Delete Files"
-msgstr "_Skrap lêers"
-
-#: panels/user-accounts/um-user-panel.c:633
-msgid "_Keep Files"
-msgstr "_Hou lêers"
-
-#: panels/user-accounts/um-user-panel.c:647
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Is u seker u wil %s se afstand bestuurde rekeneing skrap?"
-
-#: panels/user-accounts/um-user-panel.c:651
-msgid "_Delete"
-msgstr "_Skrap"
-
-#: panels/user-accounts/um-user-panel.c:701
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Rekening gedeaktiveer"
-
-#: panels/user-accounts/um-user-panel.c:709
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Moet by volgende aanmelding gestel word"
-
-#: panels/user-accounts/um-user-panel.c:712
-msgctxt "Password mode"
-msgid "None"
-msgstr "Geen"
-
-#: panels/user-accounts/um-user-panel.c:759
-msgid "Logged in"
-msgstr "Aangemeld"
-
-#: panels/user-accounts/um-user-panel.c:1106
-msgid "Failed to contact the accounts service"
-msgstr "Kon nie die rekeningediens kontak nie"
-
-#: panels/user-accounts/um-user-panel.c:1108
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Maak asb. seker dat die AccountService korrek geïnstalleer en geaktiveer is."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/um-user-panel.c:1140
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Om veranderinge te maak,\n"
-"klik eers die *-ikoon"
-
-#: panels/user-accounts/um-user-panel.c:1180
-msgid "Create a user account"
-msgstr "Skep 'n gebruikerrekening"
-
-#: panels/user-accounts/um-user-panel.c:1191
-#: panels/user-accounts/um-user-panel.c:1370
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Om 'n gebruikerrekening te skep,\n"
-"klik eers die *-ikoon"
-
-#: panels/user-accounts/um-user-panel.c:1201
-msgid "Delete the selected user account"
-msgstr "Skrap die gekose gebruikerrekening"
-
-#: panels/user-accounts/um-user-panel.c:1213
-#: panels/user-accounts/um-user-panel.c:1375
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Om die gekose gebruikerrekening te skrap,\n"
-"klik eers die *-ikoon"
-
-#: panels/user-accounts/um-utils.c:496
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Jammer maar die gebruikersnaam is nie meer beskikbaar nie. Probeer gerus 'n "
-"ander een."
-
-#: panels/user-accounts/um-utils.c:499
-#, c-format
-msgid "The username is too long."
-msgstr "Die gebruikernaam is te lank."
-
-#: panels/user-accounts/um-utils.c:502
-msgid "The username cannot start with a “-”."
-msgstr "'n Gebruikernaam kan nie begin met 'n \"-\" nie."
-
-#: panels/user-accounts/um-utils.c:505
-msgid ""
-"The username should only consist of upper and lower case letters from a-z, "
-"digits and the following characters: . - _"
-msgstr ""
-"Die gebruikernaam moet slegs bestaan uit hoof- en kleinletters (a-z), syfers "
-"en enige van die karakters '.', '-' en '_'"
-
-#: panels/user-accounts/um-utils.c:509
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr ""
-"Hierdie gaan gebruik word as tuisgidsnaam en kan nie verander word nie."
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Koppel knoppies"
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:547
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "_Sluit"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Koppel knoppies aan funksies"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -7192,7 +4776,11 @@ msgstr ""
 "Om 'n kortpad te wysig, kies die \"Stuur sleutel\" -aksie, druk die "
 "sleutelbordkortpad en hou die nuwe sleutels in of druk Backspace om te vee."
 
-#: panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Sluit"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -7200,68 +4788,121 @@ msgstr ""
 "Raak asseblief aan die teikenmerkers soos dit verskyn om die tablet te "
 "kalibreer."
 
-#: panels/wacom/calibrator/calibrator-gui.c:87
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "Mis-klik bespeur, herbegin…"
 
-#: panels/wacom/cc-wacom-button-row.c:266
-#, c-format
-msgid "Button %d"
-msgstr "Knoppie %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "Skep virtuele toestel"
 
-#: panels/wacom/cc-wacom-button-row.h:53
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Toepassings gedefinieer"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tablet"
 
-#: panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Stuur sleutel"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Ruil Monitor"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Linkshandige oriëntasie"
 
-#: panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Wys hulp op die skerm"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:260
-msgid "Output:"
-msgstr "Afvoer:"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Koppel aan Skerm…"
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:272
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Behou beeldverhouding (breedbeeld)"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Aspekverhouding"
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:283
-msgid "Map to single monitor"
-msgstr "Koppel aan 'n enkele skerm"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:86
-#, c-format
-msgid "%d of %d"
-msgstr "%d van %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Kalibreer…"
 
-#: panels/wacom/cc-wacom-page.c:544
-msgid "Display Mapping"
-msgstr "Vertoon koppelings"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Geen tablet bespeur nie"
 
-#: panels/wacom/cc-wacom-panel.c:790 panels/wacom/wacom-stylus-page.ui:127
-msgid "Stylus"
-msgstr "Pen"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Prop die Wacom-tablet in en skakel dit aan"
 
-#: panels/wacom/cc-wacom-stylus-page.c:362
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Punt druk gevoel"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Sag"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Ferm"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Knoppie"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Knoppie"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Knoppie"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Uitveër druk gevoel"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Uitveër druk gevoel"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Middel muisklik"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Regter muisklik"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Vorentoe"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:198
 msgid "Wacom Tablet"
 msgstr "Wacom-tablet"
 
@@ -7270,199 +4911,351 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Stel knoppiekoppelings en pas pengevoeligheid vir grafiese tablette aan"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/wacom/gnome-wacom-panel.desktop.in.in:7
-msgid "input-tablet"
-msgstr ""
-
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "tablet;wacom;pen;uitveër;muis;"
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "Tablet (absoluut)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Uitleg"
 
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
-msgstr "Raakblad (relatief)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "Tabletvoorkeure"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "_Hulp"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:123
-msgid "No tablet detected"
-msgstr "Geen tablet bespeur nie"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:139
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Prop die Wacom-tablet in en skakel dit aan"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:159
-msgid "Bluetooth Settings"
-msgstr "Bluetooth-instellings"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:231
-msgid "Map to Monitor…"
-msgstr "Koppel aan Skerm…"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:247
-msgid "Map Buttons…"
-msgstr "Koppel knoppies…"
-
-#: panels/wacom/gnome-wacom-properties.ui:263
-msgid "Calibrate…"
-msgstr "Kalibreer…"
-
-#: panels/wacom/gnome-wacom-properties.ui:284
-msgid "Adjust display resolution"
-msgstr "Verander die resolusie van die skerm"
-
-#: panels/wacom/gnome-wacom-properties.ui:300
-msgid "Adjust mouse settings"
-msgstr "Verstel muisinstellings"
-
-#: panels/wacom/gnome-wacom-properties.ui:328
-msgid "Tracking Mode"
-msgstr "Opspoormodus"
-
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Left-Handed Orientation"
-msgstr "Linkshandige oriëntasie"
-
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "Nuwe kortpad…"
-
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "Middel muisklik"
-
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "Regter muisklik"
-
-#: panels/wacom/wacom-stylus-page.ui:37
-msgid "Back"
-msgstr "Terug"
-
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "Vorentoe"
-
-#: panels/wacom/wacom-stylus-page.ui:77
-msgid "No stylus found"
-msgstr "Geen pen gevind nie"
-
-#: panels/wacom/wacom-stylus-page.ui:91
-msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr "Beweeg jou pen naby aan die tablet om dit in te stel"
-
-#: panels/wacom/wacom-stylus-page.ui:167
-msgid "Eraser Pressure Feel"
-msgstr "Uitveër druk gevoel"
-
-#: panels/wacom/wacom-stylus-page.ui:188 panels/wacom/wacom-stylus-page.ui:348
-msgid "Soft"
-msgstr "Sag"
-
-#: panels/wacom/wacom-stylus-page.ui:218 panels/wacom/wacom-stylus-page.ui:378
-msgid "Firm"
-msgstr "Ferm"
-
-#: panels/wacom/wacom-stylus-page.ui:241
-msgid "Top Button"
-msgstr "Boonste knoppie"
-
-#: panels/wacom/wacom-stylus-page.ui:270
-msgid "Lower Button"
-msgstr "Onderste knoppie"
-
-#: panels/wacom/wacom-stylus-page.ui:299
+#: panels/windows/cc-windows-panel.ui:82
 #, fuzzy
-#| msgid "Lower Button"
-msgid "Lowest Button"
-msgstr "Onderste knoppie"
+msgid "Resize with Secondary Click"
+msgstr "Ge_simuleerder sekondêre klik"
 
-#: panels/wacom/wacom-stylus-page.ui:328
-msgid "Tip Pressure Feel"
-msgstr "Punt druk gevoel"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Vensters"
 
-#: panels/wacom/wacom-stylus-page.ui:440
-msgid "page 3"
-msgstr "bladsy 3"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Control Center"
-msgstr "GNOME-beheersentrum"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Poeierink is min"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
-msgid "Utilities to configure the GNOME desktop"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Sekondêr"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Vensters"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Toegangskeuses"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Voeg by"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Stoor"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Tema _besonderhede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_Netwerktyd"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Netwerke"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Getalle"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Tema _besonderhede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Vervaardiger"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Fermware ontbreek"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "Vasgesluit"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "S_elfoonbreëband"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_Netwerktyd"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Netwerk"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Gevorderd"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Toegangskeuses"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Sluit vas"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Tema _besonderhede"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Netwerknaam"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Outomaties"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Huisnetwerk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Huisnetwerk"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Geen Wi-Fi passtukke gevind nie"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Versker dat die Wi-Fi-passtuk ingeprop en angeskakel is"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Bluetooth word gedeaktiveer tydens vlugmodus."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Skakel vlugmodus af"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Vergeet verbinding"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM-kaart nie in nie"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Sluit vas"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Ver_ander"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Huisnetwerk"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "Verander verwyderbare media instellings"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+#, fuzzy
+msgid "Utility to configure the GNOME desktop"
 msgstr "Nutsgoed om die GNOME-werkarea op te stel"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
-msgid ""
-"The control center is GNOME’s main interface for configuration of various "
-"aspects of your desktop."
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
 msgstr ""
-"Die beheersentrum is GNOME se plek vir die opstelling van verskeie aspekte "
-"van die werkskerm."
 
-#: shell/cc-application.c:47
-msgid "Display version number"
-msgstr "Wys weergawenommer"
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
 
-#: shell/cc-application.c:48
-msgid "Enable verbose mode"
-msgstr "Aktiveer spraaksame modus"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
 
-#: shell/cc-application.c:49
-msgid "Show the overview"
-msgstr "Wys die oorsig"
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "Privaatheid"
 
-#: shell/cc-application.c:50
-msgid "Search for the string"
-msgstr "Soek na die string"
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Alle instellings"
 
-#: shell/cc-application.c:51
-msgid "List possible panel names and exit"
-msgstr "Druk 'n lys van moontlike panneelname en sluit af"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Primêr"
 
-#: shell/cc-application.c:52
-msgid "Panel to display"
-msgstr "Paneel om te wys"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: shell/cc-application.c:52
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEEL] [ARGUMENT…]"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: shell/cc-application.c:117
-msgid "Available panels:"
-msgstr "Beskikbaar panele:"
-
-#: shell/cc-application.c:256
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Hulp"
-
-#: shell/cc-application.c:257
-msgid "Quit"
-msgstr "Sluit af"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: shell/gnome-control-center.desktop.in.in:5
-msgid "gnome-control-center"
-msgstr ""
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "voorkeure;instelling;opstelling;"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -7474,7 +5267,7 @@ msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Sluit af"
 
-#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "Soek"
@@ -7484,21 +5277,20 @@ msgctxt "shortcut window"
 msgid "Panels"
 msgstr "Panele"
 
-#: shell/help-overlay.ui:40
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
 msgctxt "shortcut window"
-msgid "Go back to the overview"
+msgid "Go back to previous panel"
 msgstr "Terug na die oorsig"
 
-#: shell/help-overlay.ui:53
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Kanselleer soektog"
 
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: shell/hostname-helper.c:189
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Kuberkol"
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "voorkeure;instelling;opstelling;"
 
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
@@ -7510,35 +5302,2692 @@ msgid ""
 "will be ignored and the first panel in the list selected."
 msgstr ""
 
-#: shell/panel-list.ui:195
-msgid "No results found"
-msgstr "Geen resultate gevind nie"
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
 
-#: shell/window.ui:141
-msgid "All Settings"
-msgstr "Alle instellings"
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1873
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u afvoer"
 msgstr[1] "%u afvoere"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1883
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u toevoer"
 msgstr[1] "%u toevoere"
 
-#: subprojects/gvc/gvc-mixer-control.c:2738
-msgid "System Sounds"
-msgstr "Stelselklanke"
+#~ msgid "_Background"
+#~ msgstr "_Agtergrond"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Verander regdeur die dag"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Teël"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zoem"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Sentreer"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Skaleer"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Opvul"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Span"
+
+#~ msgid "Colors"
+#~ msgstr "Kleure"
+
+#~ msgid "Select Background"
+#~ msgstr "Kies Agtergrond"
+
+#~ msgid "Pictures"
+#~ msgstr "Prente"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Geen prente gevind nie"
+
+#~ msgid "Home"
+#~ msgstr "Tuis"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Voeg prente by die %s-gids dan sal hulle hier verskyn"
+
+#~ msgid "multiple sizes"
+#~ msgstr "veelvuldige groottes"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Geen werkskermagtergrond"
+
+#~ msgid "Current background"
+#~ msgstr "Huidige agtergrond"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Muurpapier;Skerm;Werkskerm;"
+
+#, fuzzy
+#~| msgid "Bluetooth"
+#~ msgid "bluetooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Plaas die kalibreertoestel oor die vierkant en druk \"Begin\""
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Skuif die kalibreertoestel na die kalibreerposisie en druk \"Gaan voort\""
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Skuif die kalibreertoestel na die oppervlakposisie en druk \"Gaan voort\""
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Vou die skootrekenaar toe"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr ""
+#~ "'n Interne fout het voorgekom waarvan daar nie herstel kon word nie."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Nodige gereedskap vir kalibrering is nie geïnstalleer nie."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Die profiel kon nie gegenereer word nie."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Die doel-witpunt was nie bereikbaar nie."
+
+#~ msgid "Complete!"
+#~ msgstr "Voltooid!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrering het misluk!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Verwyder gerus die kalibreertoestel."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr ""
+#~ "Moenie die werking van die kalibreertoestel steur terwyl dit besig is nie"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Skootrekenaar se skerm"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s-skandeerder"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s-drukker"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s-webkamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Aktiveer kleurbestuur vir %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Wys kleurprofiele vir %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nie gekalibreer nie"
+
+#~ msgid "Default: "
+#~ msgstr "Verstek: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Toetsprofiel: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Kies lêer met ICC-profiel"
+
+#~ msgid "_Import"
+#~ msgstr "_Intrek"
+
+#~ msgid "All files"
+#~ msgstr "Alle lêers"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Kon nie die lêer oplaai nie: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Die profiel is opgelaai na:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Skryf hierdie URL neer."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Herbegin die rekenaar en begin die normale bedryfstelsel."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Tik die URL in die webblaaier om die profiel af te laai en te installeer."
+
+#~ msgid "Save Profile"
+#~ msgstr "Stoor profiel"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Skep 'n kleurprofiel vir die gekose toestel"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Die meetinstrument is nie bespeur nie. Maak seker dit is aangeskakel en "
+#~ "korrek ingeprop."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Die meetinstrument kan nie drukkerprofiele opstel nie."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Die toesteltipe word nie tans ondersteun nie."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standaardruimte"
+
+#~ msgid "Test Profile"
+#~ msgstr "Toetsprofiel"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Outomaties"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Lae kwaliteit"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Medium kwaliteit"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Hoë kwaliteit"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Verstek RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Verstek CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Verstek grys"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Kalibreerdata soos wat verskaffer in fabriek verskaf"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Volskermkorrigering van skerm is nie moontlik met dié profiel nie"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Dié profiel is dalk nie meer akkuraat is nie"
+
+#~ msgid "Upload profile"
+#~ msgstr "Laai profiel op"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Internetverbinding is nodig"
+
+#, fuzzy
+#~| msgid "Preferences"
+#~ msgid "preferences-color"
+#~ msgstr "Voorkeure"
+
+#~ msgid "Other…"
+#~ msgstr "Ander…"
+
+#~ msgid "Today"
+#~ msgstr "Vandag"
+
+#~ msgid "Yesterday"
+#~ msgstr "Gister"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#~ msgid "Language"
+#~ msgstr "Taal"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "24-hour"
+#~ msgstr "24-uur"
+
+#~ msgid "AM / PM"
+#~ msgstr "VM / NM"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Landskap"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portret Regs"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portret Links"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Landskap (omgedraai)"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Skerm uitleg"
+
+#~ msgid ""
+#~ "Drag displays to match your setup. The top bar is placed on the primary "
+#~ "display."
+#~ msgstr ""
+#~ "Trek die skerms om te lyk soos jou werklike skerm uitleg. Die balk bo aan "
+#~ "die skerm word slegs vertoon op die primere skerm."
+
+#~ msgid "Display Mode"
+#~ msgstr "Skermmodus"
+
+#~ msgid "Join Displays"
+#~ msgstr "Koppel skerms"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Pas veranderinge toe?"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "On"
+#~ msgstr "Aan"
+
+#~ msgid "Off"
+#~ msgstr "Af"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Naglig"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Kon nie skerminligting kry nie"
+
+#~ msgid "Unknown"
+#~ msgstr "Onbekend"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bis"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bis"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "Weergawe %s"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Vra wat om te doen"
+
+#~ msgid "Do nothing"
+#~ msgstr "Doen niks"
+
+#~ msgid "Open folder"
+#~ msgstr "Open gids"
+
+#~ msgid "Other Media"
+#~ msgstr "Ander media"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Kies 'n toepassing vir oudio-CD's"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Kies 'n toepassing vir video-DVD's"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Kies 'n toepassing om uit te voer wanneer 'n musiekspeler ingeprop word"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Kies 'n toepassing om uit te voer wanneer 'n kamera ingeprop word"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Kies 'n toepassing vir sagteware-CD's"
+
+#~ msgid "audio DVD"
+#~ msgstr "oudio-DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "skoon Blu-Ray-skyf"
+
+#~ msgid "blank CD disc"
+#~ msgstr "skoon CD-skyf"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "skoon DVD-skyf"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "skoon HD-DVD-skyf"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray-videoskyf"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-boekleser"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD-DVD-videoskyf"
+
+#~ msgid "Picture CD"
+#~ msgstr "Prente-CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video-CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video-CD"
+
+#~ msgid "OS name"
+#~ msgstr "Bedryfstelsel naam"
+
+#~ msgid "OS type"
+#~ msgstr "Tipe bedryfstelsel"
+
+#~ msgid "Disk"
+#~ msgstr "Skyf"
+
+#~ msgid "Check for updates"
+#~ msgstr "Kontroleer vir bywerkings"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Stoor 'n skermskoot na $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Stoor 'n skermskoot van 'n venster na $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Stoor 'n skermskoot van 'n area na $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopieer 'n skermskoot na die knipbord"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopieer 'n skermskoot van 'n venster na die knipbord"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopieer 'n skermskoot van 'n area na die knipbord"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Neem 'n kort skermvideo op"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Wysigers verander slegs na volgende bron"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Skrap alle kortpaaie?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Die herstel van alle kortpaaie mag jou pasgemaakte kortpaaie affekteer. "
+#~ "Die aksie kan nie ongedaan gemaak word nie."
+
+#~ msgid "Reset All"
+#~ msgstr "Herstel alles"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for <b>%s</b>. If you replace it, %s will be "
+#~ "disabled"
+#~ msgstr ""
+#~ "%s word klaar gebruik deur <b>%s</b>. Indien jy dit vervang sal, %s "
+#~ "gedeaktiveer word"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Stel 'n pasgemaakte kortpad"
+
+#, c-format
+#~ msgid "Enter new shortcut to change <b>%s</b>."
+#~ msgstr "Voeg 'n nuwe kortpad by om <b>%s</b> te verander."
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Voer 'n nuwe kortpad in"
+
+#~ msgid "Set"
+#~ msgstr "Kies"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Dubbelklik-uitteltyd"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Rol met twee vingers"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Vyf kliks, GEGL tyd!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dubbelklik, primêre knoppie"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Enkelklik, primêre knoppie"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dubbelklik, middelknoppie"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Enkelklik, middelknoppie"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dubbelklik, sekondêre knoppie"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Enkelklik, sekondêre knoppie"
+
+#~ msgid "Network proxy"
+#~ msgstr "Netwerkinstaner"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s-VPN"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager moet loop."
+
+#~ msgid "page 1"
+#~ msgstr "bladsy 1"
+
+#~ msgid "page 2"
+#~ msgstr "bladsy 2"
+
+#~ msgid "automatic"
+#~ msgstr "outomaties"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profiel %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Onderneming"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgid "Never"
+#~ msgstr "Nooit"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mg/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Swak"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Redelik"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Goed"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Uitstekend"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Verwyder verbindingprofiel"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Verwyder VPN"
+
+#~ msgid "Details"
+#~ msgstr "Besonderhede"
+
+#~ msgid "Identity"
+#~ msgstr "Identiteit"
+
+#~ msgid "Delete Route"
+#~ msgstr "Skrap roete"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bis-sleutel (Heks of ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bis wagwoordfrase"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dinamiese WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA en WPA2 (persoonlik)"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA en WPA2 (onderneming)"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Gedraaide draadpaar (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Aanhangsel Eenheid Koppelvlak (AEK)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Onafhankilike Koppelvlak (MOK)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mg/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mg/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gg/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gg/s"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Kan nie verbindingredigeerder open nie"
+
+#~ msgid "New Profile"
+#~ msgstr "Nuwe profiel"
+
+#~ msgid "Import from file…"
+#~ msgstr "Voer vanaf lêer in…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Voeg 'n VPN by"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Kan nie VPN-verbinding invoer nie"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Die lêer \"%s\" kon nie gelees word nie of die inligting vir VPN-"
+#~ "verbinding word nie herken nie.\n"
+#~ "\n"
+#~ "Fout: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Kies lêer om in te voer"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "'n Lêer genaamd \"%s\" bestaan reeds."
+
+#~ msgid "_Replace"
+#~ msgstr "Ve_rvang"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Wil u %s vervang met die VPN-verbinding wat u nou stoor?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Kan nie VPN-verbinding uitvoer nie"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Die VPN-verbinding \"%s\" kon nie uitgevoer word na %s nie.\n"
+#~ "\n"
+#~ "Fout: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Voer VPN-verbinding uit"
+
+#, fuzzy
+#~| msgid "Network;Wireless;IP;LAN;"
+#~ msgid "network-wireless"
+#~ msgstr "Network;Wireless;IP;LAN;netwerk;draadloos;"
+
+#~ msgid "never"
+#~ msgstr "nog nooit"
+
+#~ msgid "today"
+#~ msgstr "vandag"
+
+#~ msgid "yesterday"
+#~ msgstr "gister"
+
+#~ msgid "Last used"
+#~ msgstr "Laas gebruik"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Deur die kuberkol aan te skakel, sal u ontkoppel van <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Dis nie moontlik om deur die draadloos internettoegang te kry terwyl die "
+#~ "kuberkol aktief is nie."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "'n Wi-Fi kuberkol word gewoonlik gebruik om 'n addisionele internet "
+#~ "verbinding oor Wi-Fi te deel."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Stop kuberkol en ontkoppel alle gebruikers?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Stop kuberkol"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Stelselbeleid verbied die gebruik van 'n kuberkol"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Draadlose toestel het nie steun vir kuberkolmodus nie"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Netwerkbesonderhede vir die gekose netwerke sal verloor word, insluitend "
+#~ "wagwoorde en enige eie opstelling."
+
+#~ msgid "_Forget"
+#~ msgstr "_Vergeet"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Bekende Wi-Fi netwerke"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Vergeet"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Outomatiese opspoor van webinstaanbedieners word gebruik wanneer 'n "
+#~ "opstelling-URL nie verskaf word nie."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Dié word nié aanbeveel vir onvertroude openbare netwerke nie."
+
+#~ msgid "details"
+#~ msgstr "besonderhede"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Wys w_agwoord"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Maak beskikbaar aan ander gebruikers"
+
+#~ msgid "identity"
+#~ msgstr "identiteit"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adresse"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Slegs outomatiese (DHCP-) adresse"
+
+#~ msgid "Link-local only"
+#~ msgstr "Skakel slegs plaaslik"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignoreer roetes wat outomaties verkry is"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Gekloonde MAC-adres"
+
+#~ msgid "hardware"
+#~ msgstr "hardeware"
+
+#~ msgid "_Reset"
+#~ msgstr "Stel te_rug"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Stel die instellings vir dié verbinding terug, maar onthou dit as 'n "
+#~ "voorkeurverbinding."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Verwyder alle besonderhede wat met dié netwerk te doen het en moenie weer "
+#~ "outomaties daaraan probeer koppel nie."
+
+#~ msgid "reset"
+#~ msgstr "herstel"
+
+#~ msgid "Hardware"
+#~ msgstr "Hardeware"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Skakel af om aan 'n Wi-Fi-netwerk te koppel"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Gekoppelde toestelle"
+
+#, fuzzy
+#~| msgid "Password"
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Wagwoord"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastruktuur"
+
+#~ msgid "Status unknown"
+#~ msgstr "Status onbekend"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Nie bestuur nie"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nie beskikbaar nie"
+
+#~ msgid "Connecting"
+#~ msgstr "Koppel tans"
+
+#~ msgid "Authentication required"
+#~ msgstr "Verifikasie word vereis"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Ontkoppel tans"
+
+#~ msgid "Connection failed"
+#~ msgstr "Koppeling het misluk"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Status onbekend (ontbreek)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Opstelling het misluk"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP-opstelling het misluk"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP-opstelling het verval"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Geheime was nodig, maar is nie verskaf nie"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x supplicant ontkoppel"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x supplicant konfigurasie het misluk"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x supplicant het misluk"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant het te lank geneem om te verifieer"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP-diens kon nie begin nie"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP-diens het ontkoppel"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP het misluk"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP-kliënt kon nie begin nie"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP-kliëntfout"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-kliënt het misluk"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Gedeelde verbinding diens kon nie begin nie"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Gedeelde verbinding diens het gebreek"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP diens kon nie begin nie"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP diens fout"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP diens het misluk"
+
+#~ msgid "Line busy"
+#~ msgstr "Lyn beset"
+
+#~ msgid "No dial tone"
+#~ msgstr "Geen luitoon nie"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Geen draer kon vasgestel word nie"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Inbelversoek het uitgetel"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Inbelpoging het misluk"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Inisialisering van modem het misluk"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Kon nie die gespesifiseerde APN kies nie"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Soek nie tans vir netwerke nie"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Netwerkregistrasie geweier"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Netwerkregistrasie het uitgetel"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Kon nie registreer met die aangevraagde netwerk nie"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN-kontrole het misluk"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Fermware vir die toestel ontbreek moontlik"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Verbinding het verdwyn"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Het aangeneem daar is 'n bestaande verbinding"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem nie gevind nie"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth-koppeling het misluk"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM-PIN benodig"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM-PUK benodig"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM verkeerd"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Koppeling se afhanklikheid het misluk"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel uitgeprop"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "ongedefinieerde fout in 802.1X sekuriteit (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "geen lêer is geselekteer nie"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr ""
+#~ "ongespesifiseerde fout ondervind terwyl eap-metode lêer gevalideer word"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr ""
+#~ "DER-, PEM-, of PKCS#12- private sleutels (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER- of PEM-sertifikate (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "vermiste EAP-FAST PAC lêer"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC-lêers (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "vermisde EAP-LEAP gebruikersnaam"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "vermisde EAP-LEAP wagwoord"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "ongeldige EAP-PEAP CA sertifikaat: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "ongeldige EAP-PEAP CA sertifikaat: geen sertifikaat is verskaf nie"
+
+#~ msgid "missing EAP username"
+#~ msgstr "vermisde EAP gebruikersnaam"
+
+#~ msgid "missing EAP password"
+#~ msgstr "EAP wagwoord nie teenwoordig nie"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "vermisde EAP-TLS identiteit"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "ongeldige EAP-TLS CA sertifikaat: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "ongeldige EAP-TLS CA sertifikaat: geen sertifikaat is verskaf nie"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "ongeldige EAP-TLS privaat-sleutel: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "ongeldige EAP-TLS gebruikers-sertifikaat: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Ongeënkripteerde privaatsleutels is onveilig"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Die gekose privaatsleutel word klaarblyklik nie met 'n wagwoord beskerm "
+#~ "nie. Dit kan dalk toelaat dat u sekuriteitsinligting gesteel word.  Kies "
+#~ "asb. 'n wagwoordbeskermde privaatsleutel.\n"
+#~ "\n"
+#~ "('n Privaatsleutel kan d.m.v. openssl met 'n wagwoord beskerm word)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Kies u persoonlike sertifikaat"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Kies u privaatsleutel"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "ongeldige EAP-TTLS CA sertifikaat: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "ongeldige EAP-TTLS CA sertifikaat: geen sertifikaat is verskaf nie"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Onbekende fout ervaar tydens die verifikasie van 802.1X sekuriteit"
+
+#~ msgid "missing leap-username"
+#~ msgstr "vermisde leap-gebruikersnaam"
+
+#~ msgid "missing leap-password"
+#~ msgstr "leap-wagwoord nie teenwoordig nie"
+
+#~ msgid "missing wep-key"
+#~ msgstr "geen wep-kode verskaf nie"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "ongeldige wep-kode: 'n kode met 'n lengte van %zu mag slegs hex-getalle "
+#~ "bevat"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "ongeldige wep-kode: 'n kode met 'n lengte van %zu mag slegs ascii "
+#~ "karakters bevat"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "ongeldige wep-kode: verkeerde kode lengte %zu 'n Kode moet 'n lengte van "
+#~ "5/13 (ascii) of 10/26 (hex) hê"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "ongeldige wep-kode: wagwoord mag nie leeg wees nie"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "ongeldige wep-kode: wagwoord moet korter as 64 karakters wees"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "ongeldige wpa-psk: ongeldige kode lengte %zu. Moet [8,63] grepe of 64 hex "
+#~ "nommers wees"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "ongeldige wpa-psk: kan nie kode met 64 grepe as hex verstaan nie"
+
+#, fuzzy
+#~| msgid "Preferences;Settings;"
+#~ msgid "preferences-system-notifications"
+#~ msgstr "voorkeure;instelling;opstelling;"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Kennisgewing_baniere"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Ander"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s Rekening"
+
+#~ msgid "Error removing account"
+#~ msgstr "Kon nie rekening verwyder nie"
+
+#, c-format
+#~ msgid "<b>%s</b> removed"
+#~ msgstr "<b>%s</b> verwyder"
+
+#~ msgid "Remove Account"
+#~ msgstr "Verwyder rekening"
+
+#~ msgid "Unknown time"
+#~ msgstr "Onbekende tyd"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s tot volgelaai"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Waarskuwing: %s oor"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s oor"
+
+#~ msgid "Fully charged"
+#~ msgstr "Volgelaai"
+
+#~ msgid "Empty"
+#~ msgstr "Pap"
+
+#~ msgid "Charging"
+#~ msgstr "Laai tans"
+
+#~ msgid "Discharging"
+#~ msgstr "Ontlaai tans"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Hoof"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Ekstra"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Draadlose muis"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Draadlose sleutelbord"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Ononderbreekbare kragbron"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Persoonlike digitale assistent"
+
+#~ msgid "Cellphone"
+#~ msgstr "Selfoon"
+
+#~ msgid "Media player"
+#~ msgstr "Mediaspeler"
+
+#~ msgid "Computer"
+#~ msgstr "Rekenaar"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Laai tans"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Versigtig"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Amper pap"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Goed"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Volgelaai"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Pap"
+
+#~ msgid "Batteries"
+#~ msgstr "Batterye"
+
+#~ msgid "When _idle"
+#~ msgstr "Indien _ongebruik"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "_Skermhelderheid"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "S_leutelbordhelderheid"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "Ver_dof skerm wanneer onaktief"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+#~ msgstr ""
+#~ "Skakel selfoonbreëbandtoestelle (3G, 4G, LTE, ens.) af om krag te spaar."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#, fuzzy
+#~| msgid "Turn off Wi-Fi to save power."
+#~ msgid "Turn off Bluetooth to save power."
+#~ msgstr "Skakel die Wi-Fi af om krag te spaar."
+
+#~ msgid "When on battery power"
+#~ msgstr "Terwyl op batterykrag"
+
+#~ msgid "When plugged in"
+#~ msgstr "Terwyl ingeprop"
+
+#~ msgid "Suspend"
+#~ msgstr "Sluimer"
+
+#~ msgid "Power Off"
+#~ msgstr "Skakel af"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hiberneer"
+
+#~ msgid "Nothing"
+#~ msgstr "Doen niks"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Sluimer en kragknoppie"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Outomatiese sluimer"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Outomatiese sluimer"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Wanneer die kragknoppie gedruk word"
+
+#~ msgid "1 minute"
+#~ msgstr "1 minuut"
+
+#~ msgid "2 minutes"
+#~ msgstr "2 minute"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 minute"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 minute"
+
+#~ msgid "5 minutes"
+#~ msgstr "5 minute"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 minute"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 minute"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 minute"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Verifieer"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Die drukker \"%s\" is verwyder"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Kon nie nuwe drukker byvoeg nie."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Kon nie die gebruikerkoppelvlak laai nie: %s"
+
+#, fuzzy
+#~| msgid "No printers"
+#~ msgid "printer"
+#~ msgstr "Geen drukkers nie"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s Besonderhede"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Geen gepaste drywer gevind nie"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Kies PPD-lêer"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript-drukkerbeskrywings (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect-drukker"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD-drukker"
+
+#~ msgid "One Sided"
+#~ msgstr "Een kant"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Lang kant (standaard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kort kant (swaai om)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portret"
+
+#~ msgid "Landscape"
+#~ msgstr "Landskap"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Omgekeerde landskap"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Omgekeerde portret"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Hangend"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Wagtend"
+
+#, fuzzy
+#~| msgid "Authentication required"
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Verifikasie word vereis"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Verwerk tans"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Gestop"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Gekanselleer"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Gestaak"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Voltooid"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - Aktiewe Take"
+
+#, fuzzy, c-format
+#~| msgid "Enter username and password to view printers on %s."
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr ""
+#~ "Voer u gebruikersnaam en wagwoord in om beskikbare drukkers op %s te sien."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Sluit die druk bediener oop"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Ontsluit %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Voer u gebruikersnaam en wagwoord in om beskikbare drukkers op %s te sien."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Soek tans vir drukkers"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Seriepoort"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Parallelle poort"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Ligging: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adres: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Bediener nodig verifikasie"
+
+#~ msgid "Two Sided"
+#~ msgstr "Albei kante"
+
+#~ msgid "Paper Type"
+#~ msgstr "Papiertipe"
+
+#~ msgid "Paper Source"
+#~ msgstr "Papierbron"
+
+#~ msgid "Output Tray"
+#~ msgstr "Afvoerrakkie"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript-voor-filtrering"
+
+#~ msgid "Pages per side"
+#~ msgstr "Bladsye per kant"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Algemeen"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Bladsyopstelling"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Installeerbare keuses"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Taak"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Beeldkwaliteit"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Kleur"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Afwerking"
+
+#~ msgid "Test page"
+#~ msgstr "Toetsbladsy"
+
+#~ msgid "Auto Select"
+#~ msgstr "Kies outomaties"
+
+#~ msgid "Printer Default"
+#~ msgstr "Drukker se verstek"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Bed slegs GhostScript-lettertipes in"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Skakel om na PS-vlak 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Skakel om na PS-vlak 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Geen filtrering vooraf nie"
+
+#~ msgid "Out of toner"
+#~ msgstr "Poeierink is op"
+
+#~ msgid "Low on developer"
+#~ msgstr "Ontwikkelingvloeistof is min"
+
+#~ msgid "Out of developer"
+#~ msgstr "Ontwikkelingvloeistof is op"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Merkervoorraad is laag"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Merkervoorraad is klaar"
+
+#~ msgid "Open cover"
+#~ msgstr "Open deksel"
+
+#~ msgid "Open door"
+#~ msgstr "Oop deur"
+
+#~ msgid "Low on paper"
+#~ msgstr "Papier is min"
+
+#~ msgid "Out of paper"
+#~ msgstr "Papier is op"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Vanlyn"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Gestop"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Afvalhouer byna vol"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Afvalhouer vol"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Die optiese fotogeleier is naby die einde van sy funksionele lewe"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Die optiese fotogeleier werk nie meer nie"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Gereed"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Aanvaar nie take nie"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Verwerk tans"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Maak drukkoppe skoon"
+
+#~ msgid "Add…"
+#~ msgstr "Voeg by…"
+
+#~ msgid "In use"
+#~ msgstr "In gebruik"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Aan"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Af"
+
+#~ msgid "Usage & History"
+#~ msgstr "Gebruik en geskiedenis"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Skrap alle items uit die asblik?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Alle items in die asblik sal permanent geskrap word."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Maak _asblik leeg"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Skrap alle tydelike lêers?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Al die tydelike lêers sal permanent geskrap word."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Vee tydelike lêers _permanent uit"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Verslae oor tegniese probleme help ons om %s te verbeter. Verslae word "
+#~ "anoniem gestuur en word gesuiwer van persoonlike data."
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Privaatheidbeleid"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Beskerm persoonlike inligting en bepaal wat anders moontlik kan sien"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "Skerm afskakel"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 sekondes"
+
+#~ msgid "1 day"
+#~ msgstr "1 dag"
+
+#~ msgid "2 days"
+#~ msgstr "2 dae"
+
+#~ msgid "3 days"
+#~ msgstr "3 dae"
+
+#~ msgid "4 days"
+#~ msgstr "4 dae"
+
+#~ msgid "5 days"
+#~ msgstr "5 dae"
+
+#~ msgid "6 days"
+#~ msgstr "6 dae"
+
+#~ msgid "7 days"
+#~ msgstr "7 dae"
+
+#~ msgid "14 days"
+#~ msgstr "14 dae"
+
+#~ msgid "30 days"
+#~ msgstr "30 dae"
+
+#~ msgid "Forever"
+#~ msgstr "Permanent"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Deur geskiedenis te onthou, kan dinge makliker weer gevind word. Hierdie "
+#~ "items word nooit oor die netwerk gedeel nie."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Onlangs gebruik"
+
+#~ msgid "Retain _History"
+#~ msgstr "Behou _geskiedenis"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Die skermslot beskerm u privaatheid wanneer u weg is."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "S_luit skerm ná"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Maak outomaties die asblik en tydelike lêers permanent skoon om die "
+#~ "rekenaar vry te hou van onnodige sensitiewe inligting."
+
+#~ msgid "Purge _After"
+#~ msgstr "Vee permament uit n_a"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Inligting wat u stuur oor watter sagteware u gebruik, help ons om meer "
+#~ "akkurate voorstelle te maak. Dit help ook om ons sagteware te verbeter.\n"
+#~ "\n"
+#~ "Al die inligting wat ons versamel word anoniem gemaak, en ons sal nooit u "
+#~ "data deel met derde partye nie."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Stuur statistiek oor sagtewaregebruik"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Liggingdienste laat programme toe om jou ligging te weet. Die gebruik van "
+#~ "Wi-Fi en mobiele breëband verhoog akkuraatheid."
+
+#~ msgid "_Location Services"
+#~ msgstr "_Liggingdienste"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Brits"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metriek"
+
+#~ msgid "No regions found"
+#~ msgstr "Geen streke gevind nie"
+
+#~ msgid "No input sources found"
+#~ msgstr "Geen toevoerbronne gevind nie"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Ander"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Skakel na vorige bron"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Spasie"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Skakel na volgende bron"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Spasie"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "Verander gerus dié kortpaaie in sleutelbordinstellings"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Alternatiewe skakelaar na volgende bron"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Linker+Regter Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Engels (Verenigde Koninkryk)"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Die sessie moet herbegin word sodat veranderinge kan neerslag vind"
+
+#~ msgid "Restart…"
+#~ msgstr "Herbegin…"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Verenigde Koninkryk"
+
+#~ msgid "_Options"
+#~ msgstr "_Keuses"
+
+#~ msgid "Add input source"
+#~ msgstr "Voeg toevoerbron by"
+
+#~ msgid "Remove input source"
+#~ msgstr "Verwyder toevoerbron"
+
+#~ msgid "Move input source up"
+#~ msgstr "Skuif toevoerbron op"
+
+#~ msgid "Move input source down"
+#~ msgstr "Skuif toevoerbron af"
+
+#~ msgid "Configure input source"
+#~ msgstr "Stel toevoerbron op"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Wys sleutelborduitleg van toevoerbron"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Aanmeldinstellings word deur alle gebruikers gebruik wanneer hulle by die "
+#~ "stelsel aanmeld"
+
+#~ msgid "Select Location"
+#~ msgstr "Kies ligging"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Geen netwerke gekies vir deling nie"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Aan"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Af"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Geaktiveer"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Kies 'n gids"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "Personal File Sharing allows you to share your Public folder with others "
+#~| "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "Persoonlike lêerdeling maak dit moontlik om die Publiek-gids te deel met "
+#~ "ander op die huidige netwerk m.b.v: <a href=\"dav://%s\">dav://%s</a>"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "Wanneer afgeleë toegang geaktiveer is kan afgeleë gebruikers koppel met "
+#~ "die Secure Shell-opdrag:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "Laat afgeleë gebruikers toe om die skerm te sien of te beheer deur te "
+#~ "koppel aan: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Skermdeling"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Sommige dienste is gedeaktiveer weens 'n gebrek aan netwerktoegang."
+
+#~ msgid "Screen Sharing"
+#~ msgstr "Skermdeling"
+
+#~ msgid "_Password:"
+#~ msgstr "_Wagwoord:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Wy_s wagwoord"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Nuwe verbindings moet vra vir toegang"
+
+#~ msgid "_Require a password"
+#~ msgstr "Ve_reis 'n wagwoord"
+
+#~ msgid "Bark"
+#~ msgstr "Blaf"
+
+#~ msgid "Drip"
+#~ msgstr "Drup"
+
+#~ msgid "Glass"
+#~ msgstr "Glas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Links"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Regs"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimum"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maksimum"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Basluidspreker:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Onversterk"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profiel:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Toets luidsprekers"
+
+#~ msgid "Peak detect"
+#~ msgstr "Spitsbespeuring"
+
+#~ msgid "Device"
+#~ msgstr "Toestel"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Luidsprekertoets vir %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Kies 'n toestel vir klankafvoer:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Instellings vir die gekose toestel:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Toevoervolume:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Kies 'n toestel vir klanktoevoer:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Klankeffekte"
+
+#~ msgid "Built-in"
+#~ msgstr "Ingebou"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Klankvoorkeure"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Toets tans gebeurtenisklank"
+
+#~ msgid "From theme"
+#~ msgstr "Vanaf tema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Kies 'n waarskuwingklank:"
+
+#~ msgid "Stop"
+#~ msgstr "Stop"
+
+#~ msgid "Custom"
+#~ msgstr "Doelgemaak"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Verstek"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Medium"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Groot"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Groter"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Grootste"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d beeldpunt"
+#~ msgstr[1] "%d beeldpunte"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Skermleser"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Skermleser"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Klanksleutels"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Flits die _venstertitel"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kort"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼-skerm"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½-skerm"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾-skerm"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Lank"
+
+#~ msgid "Standard"
+#~ msgstr "Standaard"
+
+#~ msgid "Account _Type"
+#~ msgstr "Rekening_tipe"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "_Laat gebruiker toe om 'n wagwoord in te stel met volgende aanmelding"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Stel 'n wagwoord _nou in"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Jy moet aanlyn wees om onderneming-gebruikers by te voeg."
+
+#~ msgid "Left thumb"
+#~ msgstr "Linkerduim"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Linkermiddelvinger"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Linkerringvinger"
+
+#~ msgid "Left little finger"
+#~ msgstr "Linkerpinkie"
+
+#~ msgid "Right thumb"
+#~ msgstr "Regterduim"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Regtermiddelvinger"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Regterringvinger"
+
+#~ msgid "Right little finger"
+#~ msgstr "Regterpinkie"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Aktiveer aanmelding met vingerafdruk"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Regterwysvinger"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Linkerwysvinger"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "U vingerafdruk is suksesvol gestoor. U behoort nou te kan aanmeld m.b.v. "
+#~ "die vingerafdrukleser."
+
+#, fuzzy
+#~| msgid "Take a photo…"
+#~ msgid "Take a Picture…"
+#~ msgstr "Neem 'n foto…"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "aanmeld;naam;vingerafdruk;embleem;gesig;wagwoord;"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "Be_vestig nuwe wagwoord"
+
+#~ msgid "User Icon"
+#~ msgstr "Gebruikerikoon"
+
+#~ msgid "Last Login"
+#~ msgstr "Laas aangemeld"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Die nuwe wagwoord moet verskil van die oue."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Probeer om sommige letters en syfers te verander."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Probeer om die wagwoord nog meer te verander."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "'n Wagwoord wat nie die gebruikernaam bevat nie sal sterker wees."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Vermy die gebruik van u naam in die wagwoord."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Vermy sommige van die woorde in die wagwoord."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Vermy eerder algemene woorde."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Probeer om nie bestaande woorde te skommel nie."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Probeer om meer syfers te gebruik."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Probeer om meer hoofletters te gebruik."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Probeer om meer kleinletters te gebruik."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Probeer om meer karakters soos leestekens te gebruik."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Probeer om 'n mengsel van letters, syfers en leestekens te gebruik."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Probeer om nie die selfde karakter te herhaal nie."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Probeer om nie die selfde tipe karakter te herhaal nie: meng eerder "
+#~ "letters, syfers en leestekens."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Bly eerder weg van patrone soos 1234 of abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Die wagwoord moet langer wees. Probeer om 'n mengsel van letters, syfers "
+#~ "en leestekens te gebruik."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Meng hoof- en kleinletters en gebruik 'n syfer of twee."
+
+# Notes:
+# Add Note
+#
+# Context:
+# Password hint
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Goeie wagwoord! Meer letters, syfers en leestekens sal dit selfs nog "
+#~ "sterker maak."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Verifikasie het misluk"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Die nuwe wagwoord is te kort"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Die nuwe wagwoord is te eenvoudig"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Die ou en nuwe wagwoorde is te soortgelyk"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Die nuwe wagwoord is reeds onlangs gebruik."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Die nuwe wagwoord moet syfers of spesiale karakters bevat"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Die ou en nuwe wagwoorde is die selfde"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Jou wagwoord het verander sedert jy aanvanklik geverifieer is!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Die nuwe wagwoord bevat nie genoeg verskillende karakters nie"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Onbekende fout"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Moet pas by die webadres van die rekeningverskaffer."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Kon nie 'n rekening byvoeg nie"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Wagwoorde stem nie ooreen nie."
+
+#~ msgid "Failed to register account"
+#~ msgstr "Kon nie rekening registreer nie"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Geen ondersteunde manier om met hierdie domein te verifieer nie"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Kon nie by domein aansluit nie"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Daardie gebruikernaam het nie gewerk nie.\n"
+#~ "Probeer gerus weer."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Daardie wagwoord het nie gewerk nie.\n"
+#~ "Probeer gerus weer."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Kon nie by domein aanmeld nie"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Kon nie die domein vind nie. Is dit reg gespel?"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Gewoon"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrateur"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "U mag nie toegang kry tot die toestel nie. Kontak die "
+#~ "stelseladministrateur."
+
+#~ msgid "The device is already in use."
+#~ msgstr "Die toestel is reeds in gebruik."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "'n Interne fout het voorgekom."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Skrap geregistreerde vingerafdrukke?"
+
+#~ msgid "Done!"
+#~ msgstr "Klaar!"
+
+#, c-format
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Kon nie toegang tot die toestel \"%s\" kry nie"
+
+#, c-format
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Kon nie vingeropname op \"%s\" begin nie"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Kon nie toegang kry tot enige vingerafdruklesers nie"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Kontak u stelseladministrateur vir hulp."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Om aanmelding met vingerafdruk te aktiveer moet u een van u "
+#~ "vingerafdrukke stoor met die toestel \"%s\"."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Kies 'n vinger"
+
+#~ msgid "This Week"
+#~ msgstr "Dié week"
+
+#~ msgid "Last Week"
+#~ msgstr "Verlede week"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sessie is begin"
+
+#~ msgid "Session Started"
+#~ msgstr "Sessie is beëindig"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Kies asseblief 'n ander wagwoord."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Tik asseblief die huidige wagwoord weer."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Wagwoord kon nie verander word nie"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Kan nie outomaties by 'n domein van dié soort aansluit nie"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "Geen domein of gebied gevind nie"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Kan nie as %s by die %s-domein aanmeld nie"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Verkeerde wagwoord. Probeer gerus weer"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Kon nie gebruiker skrap nie"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Kon nie afstand bestuurde gebruiker skrap nie"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "U kan nie u eie rekening skrap nie."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s is steeds aangemeld"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Om 'n gebruiker te skrap terwyl hy aangemeld is, kan die stelsel in 'n "
+#~ "inkonsekwente toestand laat."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Wil u %s se lêers behou?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Dit is moontlik om die tuisgids, pos-spool-gids en tydelike lêers te hou "
+#~ "wanneer 'n gebruiker se rekening geskrap word."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Skrap lêers"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Hou lêers"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Is u seker u wil %s se afstand bestuurde rekeneing skrap?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Skrap"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Rekening gedeaktiveer"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Moet by volgende aanmelding gestel word"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgid "Logged in"
+#~ msgstr "Aangemeld"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Kon nie die rekeningediens kontak nie"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Maak asb. seker dat die AccountService korrek geïnstalleer en geaktiveer "
+#~ "is."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Om veranderinge te maak,\n"
+#~ "klik eers die *-ikoon"
+
+#~ msgid "Create a user account"
+#~ msgstr "Skep 'n gebruikerrekening"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Om 'n gebruikerrekening te skep,\n"
+#~ "klik eers die *-ikoon"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Skrap die gekose gebruikerrekening"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Om die gekose gebruikerrekening te skrap,\n"
+#~ "klik eers die *-ikoon"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Jammer maar die gebruikersnaam is nie meer beskikbaar nie. Probeer gerus "
+#~ "'n ander een."
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "Die gebruikernaam is te lank."
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "'n Gebruikernaam kan nie begin met 'n \"-\" nie."
+
+#~ msgid ""
+#~ "The username should only consist of upper and lower case letters from a-"
+#~ "z, digits and the following characters: . - _"
+#~ msgstr ""
+#~ "Die gebruikernaam moet slegs bestaan uit hoof- en kleinletters (a-z), "
+#~ "syfers en enige van die karakters '.', '-' en '_'"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Hierdie gaan gebruik word as tuisgidsnaam en kan nie verander word nie."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Knoppie %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Stuur sleutel"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Ruil Monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Wys hulp op die skerm"
+
+#~ msgid "Output:"
+#~ msgstr "Afvoer:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Behou beeldverhouding (breedbeeld)"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Koppel aan 'n enkele skerm"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d van %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Vertoon koppelings"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (absoluut)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Tabletvoorkeure"
+
+#~ msgid "_Help"
+#~ msgstr "_Hulp"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth-instellings"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Koppel knoppies…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Verander die resolusie van die skerm"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Verstel muisinstellings"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Opspoormodus"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nuwe kortpad…"
+
+#~ msgid "No stylus found"
+#~ msgstr "Geen pen gevind nie"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Beweeg jou pen naby aan die tablet om dit in te stel"
+
+#~ msgid "Top Button"
+#~ msgstr "Boonste knoppie"
+
+#, fuzzy
+#~| msgid "Lower Button"
+#~ msgid "Lowest Button"
+#~ msgstr "Onderste knoppie"
+
+#~ msgid "page 3"
+#~ msgstr "bladsy 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME-beheersentrum"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Die beheersentrum is GNOME se plek vir die opstelling van verskeie "
+#~ "aspekte van die werkskerm."
+
+#~ msgid "Display version number"
+#~ msgstr "Wys weergawenommer"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Aktiveer spraaksame modus"
+
+#~ msgid "Show the overview"
+#~ msgstr "Wys die oorsig"
+
+#~ msgid "Search for the string"
+#~ msgstr "Soek na die string"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Druk 'n lys van moontlike panneelname en sluit af"
+
+#~ msgid "Panel to display"
+#~ msgstr "Paneel om te wys"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Beskikbaar panele:"
+
+#~ msgid "Quit"
+#~ msgstr "Sluit af"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Kuberkol"
 
 #~ msgid "Back­ground"
 #~ msgstr "Agtergrond"
@@ -7548,9 +7997,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Co­lor"
 #~ msgstr "Kleur"
-
-#~ msgid "Section"
-#~ msgstr "Afdeling"
 
 #~ msgid "Overview"
 #~ msgstr "Oorsig"
@@ -7566,10 +8012,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Remo­vable Media"
 #~ msgstr "Verwyderbare media"
-
-#~ msgctxt "keybinding"
-#~ msgid "Search"
-#~ msgstr "Soek"
 
 #~ msgid "Net­work"
 #~ msgstr "Netwerk"
@@ -7619,12 +8061,6 @@ msgstr "Stelselklanke"
 #~ msgid "Mirrored"
 #~ msgstr "Gedupliseer"
 
-#~ msgid "Primary"
-#~ msgstr "Primêr"
-
-#~ msgid "Secondary"
-#~ msgstr "Sekondêr"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Rangskik gekombineerde vertone"
 
@@ -7642,9 +8078,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Size"
 #~ msgstr "Grootte"
-
-#~ msgid "Aspect Ratio"
-#~ msgstr "Aspekverhouding"
 
 #~ msgid "Show the top bar and Activities Overview on this display"
 #~ msgstr "Wys die boonste balk en Aktiwiteitoorsig op dié vertoon"
@@ -7679,14 +8112,8 @@ msgstr "Stelselklanke"
 #~ msgid "Shortcut;Repeat;Blink;"
 #~ msgstr "Shortcut;Repeat;Blink;kortpad;herhaal;flikker;"
 
-#~ msgid "_Name:"
-#~ msgstr "_Naam:"
-
 #~ msgid "C_ommand:"
 #~ msgstr "_Opdrag:"
-
-#~ msgid "Add Shortcut"
-#~ msgstr "Voeg kortpad by"
 
 #~ msgid ""
 #~ "To edit a shortcut, click the row and hold down the new keys or press "
@@ -7809,9 +8236,6 @@ msgstr "Stelselklanke"
 #~ "As u 'n internetverbinding het buiten vir 'n draadlose een, kan u 'n "
 #~ "draadlose toegangsarea opstel om die verbinding te deel met ander."
 
-#~ msgid "History"
-#~ msgstr "Geskiedenis"
-
 #~ msgid "Proxy"
 #~ msgstr "Instaanbediener"
 
@@ -7833,17 +8257,11 @@ msgstr "Stelselklanke"
 #~ msgid "Add Device"
 #~ msgstr "Voeg toestel by"
 
-#~ msgid "Remove Device"
-#~ msgstr "Verwyder toestel"
-
 #~ msgid "VPN Type"
 #~ msgstr "VPN-Tipe"
 
 #~ msgid "Group Name"
 #~ msgstr "Groepnaam"
-
-#~ msgid "Group Password"
-#~ msgstr "Groepwagwoord"
 
 #~ msgid "_Use as Hotspot…"
 #~ msgstr "Gebr_uik as toegangsarea…"
@@ -7874,9 +8292,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Don't _warn me again"
 #~ msgstr "Moenie my _weer waarsku nie"
-
-#~ msgid "No"
-#~ msgstr "Nee"
 
 #~ msgid "Yes"
 #~ msgstr "Ja"
@@ -7965,12 +8380,6 @@ msgstr "Stelselklanke"
 #~ msgid "Add a New Printer"
 #~ msgstr "Voeg drukker by"
 
-#~ msgid "No printers detected."
-#~ msgstr "Geen drukkers bespeur nie."
-
-#~ msgid "Loading options…"
-#~ msgstr "Laai tans keuses…"
-
 #~ msgid "Supply"
 #~ msgstr "Voorraad"
 
@@ -7998,9 +8407,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Personal File Sharing"
 #~ msgstr "Persoonlike lêerdeling"
-
-#~ msgid "_Allow Remote Control"
-#~ msgstr "L_aat eksterne beheer toe"
 
 #~ msgid "_Verify"
 #~ msgstr "Be_vestig"
@@ -8088,17 +8494,8 @@ msgstr "Stelselklanke"
 #~ msgid "Scroll Up"
 #~ msgstr "Rol op"
 
-#~ msgid "Scroll Down"
-#~ msgstr "Rol af"
-
-#~ msgid "Scroll Left"
-#~ msgstr "Rol links"
-
 #~ msgid "Scroll Right"
 #~ msgstr "Rol regs"
-
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "Bluetooth is gedeaktiveer"
 
 #~ msgid "Done"
 #~ msgstr "Klaar"
@@ -8108,9 +8505,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Germany"
 #~ msgstr "Duitsland"
-
-#~ msgid "France"
-#~ msgstr "Frankryk"
 
 #~ msgid "Spain"
 #~ msgstr "Spanje"
@@ -8184,15 +8578,9 @@ msgstr "Stelselklanke"
 #~ msgid "Fast"
 #~ msgstr "Vinnig"
 
-#~ msgid "Disable while _typing"
-#~ msgstr "Deaktiveer tydens _tik"
-
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr ""
 #~ "Die stelsel se netwerkdienste is nie versoenbaar met dié weergawe nie."
-
-#~ msgid "Security key"
-#~ msgstr "Sekuriteitsleutel"
 
 #~ msgctxt "notifications"
 #~ msgid "Show Popup Banners"
@@ -8214,14 +8602,8 @@ msgstr "Stelselklanke"
 #~ msgid "When battery power is _critical"
 #~ msgstr "Wanneer batterykrag _krities min is"
 
-#~ msgid "Power off"
-#~ msgstr "Skakel af"
-
 #~ msgid "No printers available"
 #~ msgstr "Geen drukkers beskikbaar nie"
-
-#~ msgid "Close"
-#~ msgstr "Sluit"
 
 #~ msgid "Resume Printing"
 #~ msgstr "Sit drukwerk voort"
@@ -8242,17 +8624,11 @@ msgstr "Stelselklanke"
 #~ msgid "Job State"
 #~ msgstr "Taakstatus"
 
-#~ msgid "Time"
-#~ msgstr "Tyd"
-
 #~ msgid "Add New Printer"
 #~ msgstr "Voeg nuwe drukker by"
 
 #~ msgid "Sorry"
 #~ msgstr "Jammer"
-
-#~ msgid "Options"
-#~ msgstr "Keuses"
 
 #~ msgid ""
 #~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
@@ -8290,23 +8666,14 @@ msgstr "Stelselklanke"
 #~ "%s\n"
 #~ "Laat loop '%s --help' om 'n volledige lys opdraglynkeuses te sien.\n"
 
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
-
 #~ msgid "Set Up New Device"
 #~ msgstr "Stel nuwe toestel op"
 
 #~ msgid "Paired"
 #~ msgstr "Opgepaar"
 
-#~ msgid "Type"
-#~ msgstr "Tipe"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "Muis- en raakbladinstellings"
-
-#~ msgid "Sound Settings"
-#~ msgstr "Klankinstellings"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "Sleutelbordinstellings"
@@ -8463,9 +8830,6 @@ msgstr "Stelselklanke"
 #~ msgid "Unspecified"
 #~ msgstr "Nie gespesifiseer nie"
 
-#~ msgid "Select a language"
-#~ msgstr "Kies 'n taal"
-
 #~ msgid "AM/PM"
 #~ msgstr "v.m./n.m."
 
@@ -8486,9 +8850,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "_City:"
 #~ msgstr "_Stad:"
-
-#~ msgid "_Network Time"
-#~ msgstr "_Netwerktyd"
 
 #~ msgid "_Region:"
 #~ msgstr "St_reek:"
@@ -8511,17 +8872,11 @@ msgstr "Stelselklanke"
 #~ msgid "Normal"
 #~ msgstr "Normaal"
 
-#~ msgid "Clockwise"
-#~ msgstr "Kloksgewys"
-
 #~ msgid "180 Degrees"
 #~ msgstr "180 grade"
 
 #~ msgid "%d x %d"
 #~ msgstr "%d x %d"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "Sleep om die primêre vertoonarea te verander."
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -8636,12 +8991,6 @@ msgstr "Stelselklanke"
 #~ msgid "_Add..."
 #~ msgstr "_Voeg by..."
 
-#~ msgid "_Search by Address"
-#~ msgstr "_Soek volgens adres"
-
-#~ msgid "Getting devices..."
-#~ msgstr "Kry tans toestelle..."
-
 #~ msgctxt "printer type"
 #~ msgid "Local"
 #~ msgstr "Plaaslik"
@@ -8675,9 +9024,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Examples"
 #~ msgstr "Voorbeelde"
-
-#~ msgid "Install languages..."
-#~ msgstr "Installeer tale..."
 
 #~ msgid "Layouts"
 #~ msgstr "Uitlegte"
@@ -8727,9 +9073,6 @@ msgstr "Stelselklanke"
 #~ msgstr ""
 #~ "Die aanmeldskerm, stelselrekeninge en nuwe gebruikerrekeninge gebruik die "
 #~ "stelselwye instellings vir streek en taal."
-
-#~ msgid "Layout"
-#~ msgstr "Uitleg"
 
 #~ msgid "A_cceleration:"
 #~ msgstr "_Versnelling:"
@@ -8805,9 +9148,6 @@ msgstr "Stelselklanke"
 #~ msgid "Color management settings"
 #~ msgstr "Kleurbestuurinstellings"
 
-#~ msgid "Create virtual device"
-#~ msgstr "Skep virtuele toestel"
-
 #~ msgid "%i year"
 #~ msgid_plural "%i years"
 #~ msgstr[0] "%i jaar"
@@ -8856,17 +9196,11 @@ msgstr "Stelselklanke"
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "Brightness;Lock;Dim;Blank;Monitor;helderheid;sluit;verdof;"
 
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "Instellings vir skermhelderheid in skermsluiting"
-
 #~ msgid "Don't lock when at home"
 #~ msgstr "Moenie sluit indien tuis nie"
 
 #~ msgid "Locations..."
 #~ msgstr "Liggings..."
-
-#~ msgid "Lock"
-#~ msgstr "Sluit vas"
 
 #~ msgid "_Dim screen to save power"
 #~ msgstr "Ver_dof skerm om krag te spaar"
@@ -8885,15 +9219,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Sound Output Volume"
 #~ msgstr "Klank se afvoervolume"
-
-#~ msgid "Microphone Volume"
-#~ msgstr "Mikrofoonvolume"
-
-#~ msgid "Mute"
-#~ msgstr "Doof uit"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "_Kies 'n toestel om in te stel:"
 
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "Kon nie klankvoorkeure begin nie: %s"
@@ -9035,14 +9360,8 @@ msgstr "Stelselklanke"
 #~ msgid "Dasher"
 #~ msgstr "Dasher"
 
-#~ msgid "Decrease size:"
-#~ msgstr "Verklein:"
-
 #~ msgid "Display a textual description of speech and sounds"
 #~ msgstr "Wys 'n tekstuele beskrywing van spraak en klanke"
-
-#~ msgid "Increase size:"
-#~ msgstr "Vergroot:"
 
 #~ msgid "Nomon"
 #~ msgstr "Nomon"
@@ -9136,12 +9455,6 @@ msgstr "Stelselklanke"
 #~ msgid "_Account Type"
 #~ msgstr "_Rekeningtipe"
 
-#~ msgid "C_onfirm password"
-#~ msgstr "_Bevestig wagwoord"
-
-#~ msgid "Choose a generated password"
-#~ msgstr "Kies 'n gegenereerde wagwoord"
-
 #~ msgid "Disable this account"
 #~ msgstr "Deaktiveer dié rekening"
 
@@ -9213,9 +9526,6 @@ msgstr "Stelselklanke"
 #~ "URL vanwaar meer werskermtemas gekry kan word. As dit op 'n leë string "
 #~ "gestel word, sal dit nie verskyn nie."
 
-#~ msgid "Locked"
-#~ msgstr "Vasgesluit"
-
 #~ msgid ""
 #~ "Dialog is unlocked.\n"
 #~ "Click to prevent further changes"
@@ -9270,14 +9580,8 @@ msgstr "Stelselklanke"
 #~ msgid "Use default layout in new windows"
 #~ msgstr "Gebruik die verstekuitleg in nuwe vensters"
 
-#~ msgid "_Acceleration:"
-#~ msgstr "_Versnelling:"
-
 #~ msgid "On AC power:"
 #~ msgstr "Op muurkrag:"
-
-#~ msgid "Put the computer to sleep when inactive:"
-#~ msgstr "Laat die rekenaar sluimer indien onaktief:"
 
 #~ msgid "When the sleep button is pressed:"
 #~ msgstr "Wanneer die sluimerknoppie gedruk word:"
@@ -9361,9 +9665,6 @@ msgstr "Stelselklanke"
 #~ "Regtermiddelvinger\n"
 #~ "Regterringvinger\n"
 #~ "Regterpinkie"
-
-#~ msgid "<b>Email</b>"
-#~ msgstr "<b>E-pos</b>"
 
 #~ msgid "<b>Home</b>"
 #~ msgstr "<b>Tuis</b>"
@@ -9626,9 +9927,6 @@ msgstr "Stelselklanke"
 #~ msgstr ""
 #~ "Verandering van die wysertema tree in werking by die volgende aanmelding."
 
-#~ msgid "Controls"
-#~ msgstr "Kontroles"
-
 #~ msgid "Customize Theme"
 #~ msgstr "Doelgemaakte tema"
 
@@ -9739,9 +10037,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
-
-#~ msgid "_Reset to Defaults"
-#~ msgstr "He_rstel na verstek"
 
 #~ msgid "_Selected items:"
 #~ msgstr "Ge_selekteerde items:"
@@ -10066,9 +10361,6 @@ msgstr "Stelselklanke"
 #~ msgid "GNOME Magnifier without Screen Reader"
 #~ msgstr "GNOME-vergrootglas sonder skermleser"
 
-#~ msgid "GNOME Terminal"
-#~ msgstr "GNOME-terminaal"
-
 #~ msgid "Gnopernicus"
 #~ msgstr "Gnopernicus"
 
@@ -10150,9 +10442,6 @@ msgstr "Stelselklanke"
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "Sylpheed-Claws"
 
-#~ msgid "Thunderbird"
-#~ msgstr "Thunderbird"
-
 #~ msgid "Totem Movie Player"
 #~ msgstr "Totem-filmspeler"
 
@@ -10191,9 +10480,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
 #~ msgstr "Kon nie org.gnome.SettingsDaemon.XRANDR kry nie"
-
-#~ msgid "Desktop"
-#~ msgstr "Werkarea"
 
 #, fuzzy
 #~ msgid "Error unsetting accelerator in configuration database: %s"
@@ -10329,9 +10615,6 @@ msgstr "Stelselklanke"
 #~ msgid "<b>Dwell Click</b>"
 #~ msgstr "<b>Dubbelkiek Uitteltyd </b>"
 
-#~ msgid "<b>Locate Pointer</b>"
-#~ msgstr "<b>Vind Wyser</b>"
-
 #~ msgid "<b>Mouse Orientation</b>"
 #~ msgstr "<b>Muisoriëntasie</b>"
 
@@ -10430,9 +10713,6 @@ msgstr "Stelselklanke"
 #~ msgid "Set your window properties"
 #~ msgstr "Stel die venster-eienskappe"
 
-#~ msgid "Windows"
-#~ msgstr "Vensters"
-
 #~ msgid "<b>Start %s</b>"
 #~ msgstr "<b>Begin %s</b>"
 
@@ -10472,14 +10752,8 @@ msgstr "Stelselklanke"
 #~ msgid "<b>Open</b>"
 #~ msgstr "<b>Open</b>"
 
-#~ msgid "Rename..."
-#~ msgstr "Hernoem..."
-
 #~ msgid "Send To..."
 #~ msgstr "Stuur aan..."
-
-#~ msgid "Move to Trash"
-#~ msgstr "Skuif na asblik"
 
 #~ msgid "If you delete an item, it is permanently lost."
 #~ msgstr "As u 'n item skrap, sal dit permanent verlore wees."
@@ -10521,9 +10795,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Groups"
 #~ msgstr "Groepe"
-
-#~ msgid "Common Tasks"
-#~ msgstr "Algemene take"
 
 #~ msgid "Close the control-center when a task is activated"
 #~ msgstr "Sluit die beheersentrum wanneer 'n taak geaktiveer is"
@@ -10852,9 +11123,6 @@ msgstr "Stelselklanke"
 #~ msgid "Default Web Browser"
 #~ msgstr "Verstek Webblaaier"
 
-#~ msgid "Edit..."
-#~ msgstr "Redigeer..."
-
 #, fuzzy
 #~ msgid "Run in a _terminal"
 #~ msgstr "Loop in _Terminaal"
@@ -10948,9 +11216,6 @@ msgstr "Stelselklanke"
 #, fuzzy
 #~ msgid "..."
 #~ msgstr "Voeg by..."
-
-#~ msgid "_Accessibility..."
-#~ msgstr "_Toeganklikheid..."
 
 #~ msgid "The default cursor that ships with X"
 #~ msgstr "Die verstekwyser wat saam met X vaar"
@@ -11059,9 +11324,6 @@ msgstr "Stelselklanke"
 
 #~ msgid "Short _description:"
 #~ msgstr "Kort _beskrywing:"
-
-#~ msgid "Theme _Details"
-#~ msgstr "Tema _besonderhede"
 
 #~ msgid "This theme does not suggest any particular font or background."
 #~ msgstr ""
@@ -11295,9 +11557,6 @@ msgstr "Stelselklanke"
 #~ msgid "The file %s is not a valid wav file"
 #~ msgstr "Die lêer %s is nie 'n geldige wav-lêer nie"
 
-#~ msgid "Event"
-#~ msgstr "Gebeurtenis"
-
 #~ msgid "Sound _file:"
 #~ msgstr "Klank _lêer:"
 
@@ -11404,10 +11663,6 @@ msgstr "Stelselklanke"
 #~ "Keyboard settings in gconf will be overridden from the system ASAP "
 #~ "(deprecated)"
 #~ msgstr "XKB-instellings in gconf sal oorheers vanaf die stelsel ASAP"
-
-#, fuzzy
-#~ msgid "keyboard layout"
-#~ msgstr "XKB-sleutelbord-uitleg"
 
 #, fuzzy
 #~ msgid "keyboard model"

--- a/po/af.po~
+++ b/po/af.po~
@@ -1,0 +1,11476 @@
+# Afrikaans translation of gnome-control-center.
+# Copyright (C) 2004 Zuza Software Foundation
+# This file is distributed under the same license as the gnome-control-center package.
+# Zuza Software Foundation <info@translate.org.za>, 2004
+# F Wolff <friedel@translate.org.za>, 2009, 2011, 2013, 2014, 2016.
+# Pieter Schoeman <pieter@sonbesie.co.za>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center 2.6-branch\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2019-01-10 14:17+0000\n"
+"PO-Revision-Date: 2018-02-06 17:56+0200\n"
+"Last-Translator: Pieter Schalk Schoeman <pieter@sonbesie.co.za>\n"
+"Language-Team: Afrikaans <pieter@sonbesie.co.za>\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.3\n"
+"X-Project-Style: gnome\n"
+
+#: panels/background/background.ui:49
+msgid "_Background"
+msgstr "_Agtergrond"
+
+#. This refers to a slideshow background
+#: panels/background/background.ui:99 panels/background/background.ui:212
+msgid "Changes throughout the day"
+msgstr "Verander regdeur die dag"
+
+#. To translators: This is a noun, not a verb
+#: panels/background/background.ui:162
+msgid "_Lock Screen"
+msgstr "Ges_lote skerm"
+
+#: panels/background/background.ui:268
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Teël"
+
+#: panels/background/background.ui:272
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Zoem"
+
+#: panels/background/background.ui:276
+msgctxt "background, style"
+msgid "Center"
+msgstr "Sentreer"
+
+#: panels/background/background.ui:280
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Skaleer"
+
+#: panels/background/background.ui:284
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Opvul"
+
+#: panels/background/background.ui:288
+msgctxt "background, style"
+msgid "Span"
+msgstr "Span"
+
+#: panels/background/cc-background-chooser-dialog.c:424
+msgid "Wallpapers"
+msgstr "Muurpapier"
+
+#: panels/background/cc-background-chooser-dialog.c:433
+msgid "Colors"
+msgstr "Kleure"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: panels/background/cc-background-chooser-dialog.c:468
+msgid "Select Background"
+msgstr "Kies Agtergrond"
+
+#: panels/background/cc-background-chooser-dialog.c:496
+msgid "Pictures"
+msgstr "Prente"
+
+#. translators: No pictures were found
+#: panels/background/cc-background-chooser-dialog.c:528
+msgid "No Pictures Found"
+msgstr "Geen prente gevind nie"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: panels/background/cc-background-chooser-dialog.c:545
+#: panels/search/cc-search-locations-dialog.c:302
+msgid "Home"
+msgstr "Tuis"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: panels/background/cc-background-chooser-dialog.c:555
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "Voeg prente by die %s-gids dan sal hulle hier verskyn"
+
+#: panels/background/cc-background-chooser-dialog.c:560
+#: panels/color/cc-color-panel.c:225 panels/color/cc-color-panel.c:963
+#: panels/color/color-calibrate.ui:25 panels/color/color.ui:657
+#: panels/common/language-chooser.ui:23 panels/display/cc-display-panel.c:2597
+#: panels/network/connection-editor/connection-editor.ui:15
+#: panels/network/connection-editor/vpn-helpers.c:181
+#: panels/network/connection-editor/vpn-helpers.c:310
+#: panels/network/net-device-wifi.c:1411 panels/network/net-device-wifi.c:1491
+#: panels/network/net-device-wifi.c:1736 panels/network/network-wifi.ui:24
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:331
+#: panels/privacy/cc-privacy-panel.c:1053 panels/region/format-chooser.ui:25
+#: panels/region/input-chooser.ui:13
+#: panels/search/cc-search-locations-dialog.c:642
+#: panels/sharing/cc-sharing-panel.c:384
+#: panels/user-accounts/data/account-dialog.ui:28
+#: panels/user-accounts/data/join-dialog.ui:20
+#: panels/user-accounts/data/password-dialog.ui:21
+#: panels/user-accounts/um-fingerprint-dialog.c:261
+#: panels/user-accounts/um-photo-dialog.c:103
+#: panels/user-accounts/um-photo-dialog.c:230
+#: panels/user-accounts/um-user-panel.c:634
+#: panels/user-accounts/um-user-panel.c:652
+msgid "_Cancel"
+msgstr "_Kanselleer"
+
+#: panels/background/cc-background-chooser-dialog.c:561
+msgid "_Select"
+msgstr "_Kies"
+
+#: panels/background/cc-background-item.c:192
+msgid "multiple sizes"
+msgstr "veelvuldige groottes"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:196
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:321
+msgid "No Desktop Background"
+msgstr "Geen werkskermagtergrond"
+
+#: panels/background/cc-background-panel.c:291
+msgid "Current background"
+msgstr "Huidige agtergrond"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "_Background"
+msgid "Background"
+msgstr "_Agtergrond"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Verander die agtergrondbeeld na 'n muurpapier of foto"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/background/gnome-background-panel.desktop.in.in:7
+msgid "preferences-desktop-wallpaper"
+msgstr ""
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Muurpapier;Skerm;Werkskerm;"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:265
+msgid "Turn Off Airplane Mode"
+msgstr "Skakel vlugmodus af"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:330
+msgid "No Bluetooth Found"
+msgstr "Geen Bluetooth-hardeware gevind nie"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:330
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Prop 'n passtuk in om Bluetooth te gebruik."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:331
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth is afgeskakel"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:331
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Skakel aan om toestelle te koppel en lêers oor te dra."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:332
+msgid "Airplane Mode is on"
+msgstr "Vlugmodus is aan"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:332
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth word gedeaktiveer tydens vlugmodus."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:333
+msgid "Hardware Airplane Mode is on"
+msgstr "Hardewarevlugmodus is aan"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:333
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Skakel die vlugmodusskakelaar af om Bluetooth te aktiveer."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/network/network.ui:101 panels/printers/pp-new-printer-dialog.c:1816
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Skakel Bluetooth aan en af en koppel toestelle"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:6
+#, fuzzy
+#| msgid "Bluetooth"
+msgid "bluetooth"
+msgstr "Bluetooth"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "deel;deling;bluetooth;obex;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Plaas die kalibreertoestel oor die vierkant en druk \"Begin\""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Skuif die kalibreertoestel na die kalibreerposisie en druk \"Gaan voort\""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Skuif die kalibreertoestel na die oppervlakposisie en druk \"Gaan voort\""
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "Vou die skootrekenaar toe"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "'n Interne fout het voorgekom waarvan daar nie herstel kon word nie."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "Nodige gereedskap vir kalibrering is nie geïnstalleer nie."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "Die profiel kon nie gegenereer word nie."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "Die doel-witpunt was nie bereikbaar nie."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "Voltooid!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "Kalibrering het misluk!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "Verwyder gerus die kalibreertoestel."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr ""
+"Moenie die werking van die kalibreertoestel steur terwyl dit besig is nie"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Skootrekenaar se skerm"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Ingeboude webkamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s-monitor"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s-skandeerder"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s-kamera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s-drukker"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s-webkamera"
+
+#: panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Aktiveer kleurbestuur vir %s"
+
+#: panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Wys kleurprofiele vir %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:323
+msgid "Not calibrated"
+msgstr "Nie gekalibreer nie"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:141
+msgid "Default: "
+msgstr "Verstek: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:149
+msgid "Colorspace: "
+msgstr "Kleurruimte: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:156
+msgid "Test profile: "
+msgstr "Toetsprofiel: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:223
+msgid "Select ICC Profile File"
+msgstr "Kies lêer met ICC-profiel"
+
+#: panels/color/cc-color-panel.c:226
+msgid "_Import"
+msgstr "_Intrek"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:237
+msgid "Supported ICC profiles"
+msgstr "Ondersteunde ICC-profiele"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:244
+#: panels/network/wireless-security/eap-method-fast.c:417
+msgid "All files"
+msgstr "Alle lêers"
+
+#: panels/color/cc-color-panel.c:583
+msgid "Screen"
+msgstr "Skerm"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:908
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Kon nie die lêer oplaai nie: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:922
+msgid "The profile has been uploaded to:"
+msgstr "Die profiel is opgelaai na:"
+
+#: panels/color/cc-color-panel.c:924
+msgid "Write down this URL."
+msgstr "Skryf hierdie URL neer."
+
+#: panels/color/cc-color-panel.c:925
+msgid "Restart this computer and boot your normal operating system."
+msgstr "Herbegin die rekenaar en begin die normale bedryfstelsel."
+
+#: panels/color/cc-color-panel.c:926
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+"Tik die URL in die webblaaier om die profiel af te laai en te installeer."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:960
+msgid "Save Profile"
+msgstr "Stoor profiel"
+
+#: panels/color/cc-color-panel.c:964
+#: panels/network/connection-editor/vpn-helpers.c:311
+msgid "_Save"
+msgstr "_Stoor"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1325
+msgid "Create a color profile for the selected device"
+msgstr "Skep 'n kleurprofiel vir die gekose toestel"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1340 panels/color/cc-color-panel.c:1364
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Die meetinstrument is nie bespeur nie. Maak seker dit is aangeskakel en "
+"korrek ingeprop."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1374
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Die meetinstrument kan nie drukkerprofiele opstel nie."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1385
+msgid "The device type is not currently supported."
+msgstr "Die toesteltipe word nie tans ondersteun nie."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "Standaardruimte"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "Toetsprofiel"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Outomaties"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Lae kwaliteit"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Medium kwaliteit"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Hoë kwaliteit"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Verstek RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Verstek CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Verstek grys"
+
+#: panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "Kalibreerdata soos wat verskaffer in fabriek verskaf"
+
+#: panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Volskermkorrigering van skerm is nie moontlik met dié profiel nie"
+
+#: panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "Dié profiel is dalk nie meer akkuraat is nie"
+
+#: panels/color/color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr "Skermkalibrering"
+
+#. This starts the calibration process
+#: panels/color/color-calibrate.ui:40
+msgid "_Start"
+msgstr "_Begin"
+
+#. This resumes the calibration process
+#: panels/color/color-calibrate.ui:54
+msgid "_Resume"
+msgstr "He_rvat"
+
+#. This button returns the user back to the color control panel
+#: panels/color/color-calibrate.ui:67 panels/common/language-chooser.ui:12
+#: panels/region/format-chooser.ui:14
+msgid "_Done"
+msgstr "_Klaar"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: panels/color/color.ui:6 panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "Skermkalibrering"
+
+#: panels/color/color.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrering verskaf 'n profiel wat gebruik kan word vir kleurbestuur op die "
+"skerm. Hoe meer tyd geneem word vir kalibrering hoe beter is die kwaliteit "
+"van die kleurprofiel."
+
+#: panels/color/color.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Die rekenaar kan nie gebruik word tydens kalibrering nie."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/color.ui:58
+msgid "Quality"
+msgstr "Kwaliteit"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/color.ui:75
+msgid "Approximate Time"
+msgstr "Tyd ongeveer"
+
+#: panels/color/color.ui:121
+msgid "Calibration Quality"
+msgstr "Kalibreerkwaliteit"
+
+#: panels/color/color.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Kies die sensortoestel om te gebruik vir kalibrering."
+
+#: panels/color/color.ui:174
+msgid "Calibration Device"
+msgstr "Kalibreertoestel"
+
+#: panels/color/color.ui:189
+msgid "Select the type of display that is connected."
+msgstr "Kies die tipe skerm wat ingeprop is."
+
+#: panels/color/color.ui:226
+msgid "Display Type"
+msgstr "Skermtipe"
+
+#: panels/color/color.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Selekteer 'n skerm teiken witpunt. Meeste skerms moet gekalibreer word na 'n "
+"D65 verligting."
+
+#: panels/color/color.ui:278
+msgid "Profile Whitepoint"
+msgstr "Profiel se witpunt"
+
+#: panels/color/color.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Stel die skerm se helderheid soos u dit tipies gebruik. Kleurbestuur sal "
+"akkuraatste wees by die helderheidsvlak."
+
+#: panels/color/color.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Of u kan die helderheidsvlak gebruik wat met een van die ander profiele vir "
+"dié toestel gebruik word."
+
+#: panels/color/color.ui:318
+msgid "Display Brightness"
+msgstr "Skermhelderheid"
+
+#: panels/color/color.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Mens kan 'n kleurprofiel op verskillende rekenaars gebruik, of selfs "
+"profiele skep vir verskillende tipes beligting."
+
+#: panels/color/color.ui:348
+msgid "Profile Name:"
+msgstr "Profielnaam:"
+
+#: panels/color/color.ui:377
+msgid "Profile Name"
+msgstr "Profielnaam"
+
+#: panels/color/color.ui:392
+msgid "Profile successfully created!"
+msgstr "Profiel is suksesvol geskep!"
+
+#: panels/color/color.ui:443
+msgid "Copy profile"
+msgstr "Kopieer profiel"
+
+#: panels/color/color.ui:456
+msgid "Requires writable media"
+msgstr "Skryfbare media is nodig"
+
+#: panels/color/color.ui:519
+msgid "Upload profile"
+msgstr "Laai profiel op"
+
+#: panels/color/color.ui:532
+msgid "Requires Internet connection"
+msgstr "Internetverbinding is nodig"
+
+#: panels/color/color.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Raadpleeg gerus hierdie instruksies oor hoe om die profiel te gebruik op <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> en <a href="
+"\"windows\">Microsoft Windows</a>."
+
+#: panels/color/color.ui:607 panels/user-accounts/um-fingerprint-dialog.c:720
+msgid "Summary"
+msgstr "Opsomming"
+
+#: panels/color/color.ui:621
+msgid "Add Profile"
+msgstr "Voeg profiel by"
+
+#: panels/color/color.ui:643
+msgid "_Import File…"
+msgstr "_Voer lêer in…"
+
+#: panels/color/color.ui:672
+#: panels/network/connection-editor/net-connection-editor.c:519
+#: panels/printers/new-printer-dialog.ui:80 panels/region/input-chooser.ui:22
+#: panels/user-accounts/data/account-dialog.ui:47
+msgid "_Add"
+msgstr "_Voeg by"
+
+#: panels/color/color.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Probleme teëgekom. Die profiel gaan dalk nie werk nie. <a href=\"\">Wys "
+"besonderhede.</a>"
+
+#: panels/color/color.ui:807
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Elke toestel benodig 'n kleurprofiel wat op datum is om sy kleur te bestuur."
+
+#: panels/color/color.ui:829
+msgid "Learn more"
+msgstr "Meer inligting"
+
+#: panels/color/color.ui:834
+msgid "Learn more about color management"
+msgstr "Meer oor kleurbestuur"
+
+#: panels/color/color.ui:882
+msgid "_Set for all users"
+msgstr "_Stel vir alle gebruikers"
+
+#: panels/color/color.ui:886 panels/color/color.ui:901
+#: panels/color/color.ui:902
+msgid "Set this profile for all users on this computer"
+msgstr "Stel dié profiel vir alle gebruikers op dié rekenaar"
+
+#: panels/color/color.ui:897
+msgid "_Enable"
+msgstr "_Aktiveer"
+
+#: panels/color/color.ui:928
+msgid "_Add profile"
+msgstr "_Voeg profiel by"
+
+#: panels/color/color.ui:941
+msgid "_Calibrate…"
+msgstr "_Kalibreer…"
+
+#: panels/color/color.ui:945
+msgid "Calibrate the device"
+msgstr "Kalibreer die toestel"
+
+#: panels/color/color.ui:956
+msgid "_Remove profile"
+msgstr "Ve_rwyder 'n profiel"
+
+#: panels/color/color.ui:969
+msgid "_View details"
+msgstr "_Bekyk besonderhede"
+
+#: panels/color/color.ui:1005
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Kan nie enige toestelle bespeur waarvoor kleur bestuur kan word nie"
+
+#: panels/color/color.ui:1047
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/color.ui:1052
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/color.ui:1057
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/color.ui:1062
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/color.ui:1067
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/color.ui:1072
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL-agterlig)"
+
+#: panels/color/color.ui:1077
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED-agterlig)"
+
+#: panels/color/color.ui:1082
+msgid "LCD (white LED backlight)"
+msgstr "LCD (wit LED-agterlig)"
+
+#: panels/color/color.ui:1087
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Wye spektrum LCD (CCFL-agterlig)"
+
+#: panels/color/color.ui:1092
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Wye spektrum LCD (RGB LED-agterlig)"
+
+#: panels/color/color.ui:1109
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Hoog"
+
+#: panels/color/color.ui:1110
+msgid "40 minutes"
+msgstr "40 minute"
+
+#: panels/color/color.ui:1114
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Medium"
+
+#: panels/color/color.ui:1115 panels/power/power.ui:25
+#: panels/privacy/privacy.ui:38
+msgid "30 minutes"
+msgstr "30 minute"
+
+#: panels/color/color.ui:1119
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Laag"
+
+#: panels/color/color.ui:1120 panels/power/power.ui:13 panels/power/power.ui:95
+msgid "15 minutes"
+msgstr "15 minute"
+
+#: panels/color/color.ui:1142
+msgid "Native to display"
+msgstr "Ingebou in die skerm"
+
+#: panels/color/color.ui:1146
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (drukwerk en publisering)"
+
+#: panels/color/color.ui:1150
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/color.ui:1154
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografie en grafika)"
+
+#: panels/color/color.ui:1158
+msgid "D75"
+msgstr "D75"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Kleur"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Kalibreer die kleur van toestelle, bv. skerms, kameras of drukkers"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/color/gnome-color-panel.desktop.in.in:7
+#, fuzzy
+#| msgid "Preferences"
+msgid "preferences-color"
+msgstr "Voorkeure"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "kleur;ICC;profiel;kalibreer;drukker;skerm;"
+
+#: panels/common/cc-common-language.c:323
+msgid "Other…"
+msgstr "Ander…"
+
+#: panels/common/cc-language-chooser.c:124
+#: panels/region/cc-format-chooser.c:269 panels/region/cc-input-chooser.c:169
+msgid "More…"
+msgstr "Meer…"
+
+#: panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "Geen tale gevind nie"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:106
+msgid "Today"
+msgstr "Vandag"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "Yesterday"
+msgstr "Gister"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#: panels/common/language-chooser.ui:5
+msgid "Language"
+msgstr "Taal"
+
+#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
+#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
+msgid "Day"
+msgstr "Dag"
+
+#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
+#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
+msgid "Month"
+msgstr "Maand"
+
+#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
+#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
+msgid "Year"
+msgstr "Jaar"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:333
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:338
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:503
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:530
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:537
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:542
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:547
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:552
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/datetime.ui:22
+msgid "January"
+msgstr "Januarie"
+
+#: panels/datetime/datetime.ui:25
+msgid "February"
+msgstr "Februarie"
+
+#: panels/datetime/datetime.ui:28
+msgid "March"
+msgstr "Maart"
+
+#: panels/datetime/datetime.ui:31
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/datetime.ui:34
+msgid "May"
+msgstr "Mei"
+
+#: panels/datetime/datetime.ui:37
+msgid "June"
+msgstr "Junie"
+
+#: panels/datetime/datetime.ui:40
+msgid "July"
+msgstr "Julie"
+
+#: panels/datetime/datetime.ui:43
+msgid "August"
+msgstr "Augustus"
+
+#: panels/datetime/datetime.ui:46
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/datetime.ui:49
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/datetime.ui:52
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/datetime.ui:55
+msgid "December"
+msgstr "Desember"
+
+#: panels/datetime/datetime.ui:61
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Datum en tyd"
+
+#: panels/datetime/datetime.ui:106
+msgid "Hour"
+msgstr "Uur"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: panels/datetime/datetime.ui:121
+msgid "∶"
+msgstr "∶"
+
+#: panels/datetime/datetime.ui:143
+msgid "Minute"
+msgstr "Minuut"
+
+#: panels/datetime/datetime.ui:208
+msgid "Time Zone"
+msgstr "Tydsone"
+
+#: panels/datetime/datetime.ui:228
+msgid "Search for a city"
+msgstr "Soek vir 'n stad"
+
+#: panels/datetime/datetime.ui:304
+msgid "Automatic _Date & Time"
+msgstr "Outomatiese _datum en tyd"
+
+#: panels/datetime/datetime.ui:319 panels/datetime/datetime.ui:397
+msgid "Requires internet access"
+msgstr "Internet toegang is nodig"
+
+#: panels/datetime/datetime.ui:382
+msgid "Automatic Time _Zone"
+msgstr "Outomatiese tyd_sone"
+
+#: panels/datetime/datetime.ui:454
+msgid "Date & _Time"
+msgstr "Datum en _tyd"
+
+#: panels/datetime/datetime.ui:502
+msgid "Time Z_one"
+msgstr "Tyds_one"
+
+#: panels/datetime/datetime.ui:570
+msgid "Time _Format"
+msgstr "Tyd_formaat"
+
+#: panels/datetime/datetime.ui:588
+msgid "24-hour"
+msgstr "24-uur"
+
+#: panels/datetime/datetime.ui:589
+msgid "AM / PM"
+msgstr "VM / NM"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Verander die datum en tyd, asook tydsone"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:7
+msgid "preferences-system-time"
+msgstr ""
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "horlosie;tydsone;ligging;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Verander instellings vir datum en tyd"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Om datum of tyd verstellings te maak moet jy eers aanteken."
+
+#: panels/display/cc-display-panel.c:732
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Landskap"
+
+#: panels/display/cc-display-panel.c:735
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portret Regs"
+
+#: panels/display/cc-display-panel.c:738
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portret Links"
+
+#: panels/display/cc-display-panel.c:741
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Landskap (omgedraai)"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/display/cc-display-panel.c:808
+#: panels/printers/pp-options-dialog.c:558
+msgid "Orientation"
+msgstr "Oriëntasie"
+
+#: panels/display/cc-display-panel.c:873 panels/display/cc-display-panel.c:1676
+#: panels/printers/pp-options-dialog.c:87
+msgid "Resolution"
+msgstr "Resolusie"
+
+#: panels/display/cc-display-panel.c:961
+msgid "Refresh Rate"
+msgstr "Verfristempo"
+
+#: panels/display/cc-display-panel.c:1098
+msgid "Scale"
+msgstr "Skaleer"
+
+#: panels/display/cc-display-panel.c:1151
+msgid "Adjust for TV"
+msgstr "Verstel vir televisie"
+
+#: panels/display/cc-display-panel.c:1413
+msgid "Primary Display"
+msgstr "Primêre skerm"
+
+#: panels/display/cc-display-panel.c:1442
+msgid "Display Arrangement"
+msgstr "Skerm uitleg"
+
+#: panels/display/cc-display-panel.c:1443
+msgid ""
+"Drag displays to match your setup. The top bar is placed on the primary "
+"display."
+msgstr ""
+"Trek die skerms om te lyk soos jou werklike skerm uitleg. Die balk bo aan "
+"die skerm word slegs vertoon op die primere skerm."
+
+#: panels/display/cc-display-panel.c:1866
+msgid "Display Mode"
+msgstr "Skermmodus"
+
+#: panels/display/cc-display-panel.c:1882
+msgid "Join Displays"
+msgstr "Koppel skerms"
+
+#: panels/display/cc-display-panel.c:1885
+msgid "Mirror"
+msgstr "Dupliseer"
+
+#: panels/display/cc-display-panel.c:1888
+msgid "Single Display"
+msgstr "Enkel skerm"
+
+#: panels/display/cc-display-panel.c:2593
+msgid "Apply Changes?"
+msgstr "Pas veranderinge toe?"
+
+#: panels/display/cc-display-panel.c:2607
+#: panels/network/connection-editor/connection-editor.ui:24
+#: panels/network/network-wifi.ui:38
+msgid "_Apply"
+msgstr "P_as toe"
+
+#: panels/display/cc-display-panel.c:2982
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#. TRANSLATORS: the state of the night light setting
+#: panels/display/cc-display-panel.c:3198
+#: panels/notifications/cc-notifications-panel.c:292
+#: panels/power/cc-power-panel.c:1994 panels/power/cc-power-panel.c:2001
+#: panels/privacy/cc-privacy-panel.c:190 panels/privacy/cc-privacy-panel.c:257
+#: panels/universal-access/cc-ua-panel.c:333
+#: panels/universal-access/cc-ua-panel.c:714
+#: panels/universal-access/cc-ua-panel.c:727
+#: panels/universal-access/cc-ua-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:910
+msgid "On"
+msgstr "Aan"
+
+#: panels/display/cc-display-panel.c:3198 panels/network/net-proxy.c:54
+#: panels/notifications/cc-notifications-panel.c:292
+#: panels/power/cc-power-panel.c:1988 panels/power/cc-power-panel.c:1999
+#: panels/privacy/cc-privacy-panel.c:190 panels/privacy/cc-privacy-panel.c:257
+#: panels/universal-access/cc-ua-panel.c:333
+#: panels/universal-access/cc-ua-panel.c:714
+#: panels/universal-access/cc-ua-panel.c:727
+#: panels/universal-access/cc-ua-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:910 panels/universal-access/uap.ui:334
+#: panels/universal-access/uap.ui:380 panels/universal-access/uap.ui:426
+#: panels/universal-access/uap.ui:532 panels/universal-access/uap.ui:685
+#: panels/universal-access/uap.ui:731 panels/universal-access/uap.ui:777
+#: panels/universal-access/uap.ui:929
+msgid "Off"
+msgstr "Af"
+
+#: panels/display/cc-display-panel.c:3219
+msgid "_Night Light"
+msgstr "_Naglig"
+
+#: panels/display/cc-display-panel.c:3284
+msgid "Could not get screen information"
+msgstr "Kon nie skerminligting kry nie"
+
+#. This cancels the redshift inhibit.
+#: panels/display/display.ui:71
+msgid "Restart Filter"
+msgstr "Herbegin filter"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/display.ui:103
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Tydelik gestop tot die volgende dag"
+
+#: panels/display/display.ui:144
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Naglig maak die skermkleur warmer. Dit kan help om oog stremming en "
+"slapeloosheid te voorkom."
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/display.ui:171 panels/display/display.ui:567
+msgid "Night Light"
+msgstr "Naglig"
+
+#: panels/display/display.ui:187
+msgid "Schedule"
+msgstr "Skeduleer"
+
+#: panels/display/display.ui:215
+msgid "Sunset to Sunrise"
+msgstr "Sonsondergang tot Sonsopkoms"
+
+#: panels/display/display.ui:229
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:56 panels/network/network-proxy.ui:113
+#: panels/network/network-wifi.ui:777 panels/network/network-wifi.ui:1054
+#: panels/privacy/cc-privacy-panel.c:217
+msgid "Manual"
+msgstr "Handmatig"
+
+#: panels/display/display.ui:268
+msgid "From"
+msgstr "Van"
+
+#: panels/display/display.ui:309 panels/display/display.ui:430
+msgid ":"
+msgstr ":"
+
+#. This is the short form for the time period in the morning
+#: panels/display/display.ui:343 panels/display/display.ui:464
+msgid "AM"
+msgstr "VM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/display.ui:359 panels/display/display.ui:480
+msgid "PM"
+msgstr "NM"
+
+#: panels/display/display.ui:528
+msgid "To"
+msgstr "Tot"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "Dis­plays"
+msgid "Displays"
+msgstr "Skerms"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Kies hoe om ingepropte monitors en projektors te gebruik"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/display/gnome-display-panel.desktop.in.in:7
+msgid "preferences-desktop-display"
+msgstr ""
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"paneel;projektor;xrandr;skerm;resolusie;verfris;monitor;nag;lig;blou;"
+"rooiverskuiwing;kleur;sonsondergang;sonsopkoms;"
+
+#. TRANSLATORS: AP type
+#: panels/info/cc-info-overview-panel.c:374
+#: panels/info/cc-info-overview-panel.c:457 panels/network/panel-common.c:123
+msgid "Unknown"
+msgstr "Onbekend"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info/cc-info-overview-panel.c:465
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; Bou ID: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info/cc-info-overview-panel.c:482
+#, c-format
+msgid "64-bit"
+msgstr "64-bis"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info/cc-info-overview-panel.c:485
+#, c-format
+msgid "32-bit"
+msgstr "32-bis"
+
+#: panels/info/cc-info-overview-panel.c:775
+#, c-format
+msgid "Version %s"
+msgstr "Weergawe %s"
+
+#: panels/info/cc-info-removable-media-panel.c:298
+msgid "Ask what to do"
+msgstr "Vra wat om te doen"
+
+#: panels/info/cc-info-removable-media-panel.c:302
+msgid "Do nothing"
+msgstr "Doen niks"
+
+#: panels/info/cc-info-removable-media-panel.c:306
+msgid "Open folder"
+msgstr "Open gids"
+
+#: panels/info/cc-info-removable-media-panel.c:391
+msgid "Other Media"
+msgstr "Ander media"
+
+#: panels/info/cc-info-removable-media-panel.c:424
+msgid "Select an application for audio CDs"
+msgstr "Kies 'n toepassing vir oudio-CD's"
+
+#: panels/info/cc-info-removable-media-panel.c:425
+msgid "Select an application for video DVDs"
+msgstr "Kies 'n toepassing vir video-DVD's"
+
+#: panels/info/cc-info-removable-media-panel.c:426
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Kies 'n toepassing om uit te voer wanneer 'n musiekspeler ingeprop word"
+
+#: panels/info/cc-info-removable-media-panel.c:427
+msgid "Select an application to run when a camera is connected"
+msgstr "Kies 'n toepassing om uit te voer wanneer 'n kamera ingeprop word"
+
+#: panels/info/cc-info-removable-media-panel.c:428
+msgid "Select an application for software CDs"
+msgstr "Kies 'n toepassing vir sagteware-CD's"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/info/cc-info-removable-media-panel.c:440
+msgid "audio DVD"
+msgstr "oudio-DVD"
+
+#: panels/info/cc-info-removable-media-panel.c:441
+msgid "blank Blu-ray disc"
+msgstr "skoon Blu-Ray-skyf"
+
+#: panels/info/cc-info-removable-media-panel.c:442
+msgid "blank CD disc"
+msgstr "skoon CD-skyf"
+
+#: panels/info/cc-info-removable-media-panel.c:443
+msgid "blank DVD disc"
+msgstr "skoon DVD-skyf"
+
+#: panels/info/cc-info-removable-media-panel.c:444
+msgid "blank HD DVD disc"
+msgstr "skoon HD-DVD-skyf"
+
+#: panels/info/cc-info-removable-media-panel.c:445
+msgid "Blu-ray video disc"
+msgstr "Blu-ray-videoskyf"
+
+#: panels/info/cc-info-removable-media-panel.c:446
+msgid "e-book reader"
+msgstr "e-boekleser"
+
+#: panels/info/cc-info-removable-media-panel.c:447
+msgid "HD DVD video disc"
+msgstr "HD-DVD-videoskyf"
+
+#: panels/info/cc-info-removable-media-panel.c:448
+msgid "Picture CD"
+msgstr "Prente-CD"
+
+#: panels/info/cc-info-removable-media-panel.c:449
+msgid "Super Video CD"
+msgstr "Super Video-CD"
+
+#: panels/info/cc-info-removable-media-panel.c:450
+msgid "Video CD"
+msgstr "Video-CD"
+
+#: panels/info/cc-info-removable-media-panel.c:451
+msgid "Windows software"
+msgstr "Windows-sagteware"
+
+#: panels/info/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Verstektoepassings"
+
+#: panels/info/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Stel verstektoepassings in"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info/gnome-default-apps-panel.desktop.in.in:7
+msgid "starred"
+msgstr ""
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/info/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "verstek;toepassing;voorkeur;media;"
+
+#: panels/info/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "/_About"
+msgid "About"
+msgstr "/_Aangaande"
+
+#: panels/info/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Vertoon inligting oor die stelsel"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info/gnome-info-overview-panel.desktop.in.in:7
+msgid "help-about"
+msgstr ""
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"toestel;stelsel;inligting;geheue;verwerker;weergawe;verstek;toepassing;"
+"voorkeur;cd;dvd;usb;klank;video;skyf;verwyderbaar;media;outoloop;"
+
+#: panels/info/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Verwyderbare media"
+
+#: panels/info/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Verander verwyderbare media instellings"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info/gnome-removable-media-panel.desktop.in.in:7
+msgid "media-removable"
+msgstr ""
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/info/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"toestel;stelsel;verstek;toepassing;voorkeur;cd;dvd;usb;klank;video;skyf;"
+"verwyderbaar;media;outoloop;"
+
+#: panels/info/info-default-apps.ui:31
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/info/info-default-apps.ui:43
+msgid "_Mail"
+msgstr "_Pos"
+
+#: panels/info/info-default-apps.ui:59
+msgid "_Calendar"
+msgstr "_Kalender"
+
+#: panels/info/info-default-apps.ui:75
+msgid "M_usic"
+msgstr "M_usiek"
+
+#: panels/info/info-default-apps.ui:91
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/info/info-default-apps.ui:162 panels/info/info-removable-media.ui:161
+msgid "_Photos"
+msgstr "_Foto's"
+
+#: panels/info/info-overview.ui:58
+msgid "Device name"
+msgstr "Toestelnaam"
+
+#: panels/info/info-overview.ui:74
+msgid "Memory"
+msgstr "Geheue"
+
+#: panels/info/info-overview.ui:90
+msgid "Processor"
+msgstr "Verwerker"
+
+#: panels/info/info-overview.ui:106
+msgid "Graphics"
+msgstr "Grafika"
+
+#. To translators: this field contains the distro name and version
+#: panels/info/info-overview.ui:121
+msgid "OS name"
+msgstr "Bedryfstelsel naam"
+
+#. To translators: this field contains the distro type
+#: panels/info/info-overview.ui:137
+msgid "OS type"
+msgstr "Tipe bedryfstelsel"
+
+#: panels/info/info-overview.ui:153
+msgid "Virtualization"
+msgstr "Virtualisering"
+
+#: panels/info/info-overview.ui:169
+msgid "Disk"
+msgstr "Skyf"
+
+#: panels/info/info-overview.ui:274
+msgid "Calculating…"
+msgstr "Bereken tans…"
+
+#: panels/info/info-overview.ui:314
+msgid "Check for updates"
+msgstr "Kontroleer vir bywerkings"
+
+#: panels/info/info-removable-media.ui:43
+msgid "Select how media should be handled"
+msgstr "Kies hoe die media hanteer moet word"
+
+#: panels/info/info-removable-media.ui:74
+msgid "CD _audio"
+msgstr "CD-_oudio"
+
+#: panels/info/info-removable-media.ui:91
+msgid "_DVD video"
+msgstr "_DVD-video"
+
+#: panels/info/info-removable-media.ui:132
+msgid "_Music player"
+msgstr "_Musiekspeler"
+
+#: panels/info/info-removable-media.ui:190
+msgid "_Software"
+msgstr "_Sagteware"
+
+#: panels/info/info-removable-media.ui:228
+msgid "_Other Media…"
+msgstr "_Ander media…"
+
+#: panels/info/info-removable-media.ui:272
+msgid "_Never prompt or start programs on media insertion"
+msgstr "As media ingedruk word, moet _nooit programme begin of vra daaroor nie"
+
+#: panels/info/info-removable-media.ui:331
+msgid "Select how other media should be handled"
+msgstr "Kies hoe ander media hanteer moet word"
+
+#: panels/info/info-removable-media.ui:370
+msgid "_Action:"
+msgstr "_Aksie:"
+
+#: panels/info/info-removable-media.ui:393
+msgid "_Type:"
+msgstr "_Tipe:"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Klank en media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute"
+msgstr "Volume uit"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Volume sagter"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Volume harder"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Launch media player"
+msgstr "Lanseer mediaspeler"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Play (or play/pause)"
+msgstr "Speel (of speel/wag)"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Pause playback"
+msgstr "Laat wag terugspeel"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Stop playback"
+msgstr "Stop terugspeel"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Previous track"
+msgstr "Vorige snit"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Next track"
+msgstr "Volgende snit"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Eject"
+msgstr "Uitskiet"
+
+#: panels/keyboard/01-input-sources.xml.in:4 panels/universal-access/uap.ui:576
+msgid "Typing"
+msgstr "Tik"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Skakel na volgende toevoerbron"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Skakel na vorige toevoerbron"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lanseerders"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Laat loop hulpblaaier"
+
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:222
+#: shell/cc-window.c:760 shell/gnome-control-center.desktop.in.in:3
+#: shell/window.ui:125
+msgid "Settings"
+msgstr "Instellings"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Lanseer sakrekenaar"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Lanseer e-poskliënt"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Lanseer webblaaier"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Tuisgids"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/window.ui:157
+msgid "Search"
+msgstr "Soek"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "Skermskote"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr "Stoor 'n skermskoot na $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Stoor 'n skermskoot van 'n venster na $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Stoor 'n skermskoot van 'n area na $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "Kopieer 'n skermskoot na die knipbord"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Kopieer 'n skermskoot van 'n venster na die knipbord"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Kopieer 'n skermskoot van 'n area na die knipbord"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr "Neem 'n kort skermvideo op"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Stelsel"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Meld af"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Sluit skerm"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Universal Access"
+msgstr "Universele toegang"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Skakel zoem aan of af"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zoem in"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Zoem uit"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Skakel skermleser aan of af"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Skakel sleutelbord op die skerm aan of af"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Vergroot teks"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Verklein teks"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Skakel hoë kontras aan of af"
+
+#: panels/keyboard/cc-keyboard-manager.c:506
+#: panels/keyboard/cc-keyboard-manager.c:514
+#: panels/keyboard/cc-keyboard-manager.c:822
+msgid "Custom Shortcuts"
+msgstr "Pasgemaakte kortpaaie"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: panels/keyboard/cc-keyboard-option.c:263
+#: panels/keyboard/cc-keyboard-option.c:382
+#: panels/keyboard/keyboard-shortcuts.c:435
+#: panels/keyboard/shortcut-editor.ui:96 panels/network/network-proxy.ui:123
+#: panels/network/network-wifi.ui:782 panels/network/network-wifi.ui:1059
+#: panels/user-accounts/um-fingerprint-dialog.c:211
+#: subprojects/gvc/gvc-mixer-control.c:1866
+msgid "Disabled"
+msgstr "Gedeaktiveer"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: panels/keyboard/cc-keyboard-option.c:341
+msgid "Alternative Characters Key"
+msgstr "Sleutel vir alternatiewe karakters"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: panels/keyboard/cc-keyboard-option.c:350
+msgid "Compose Key"
+msgstr "Saamstelsleutel"
+
+#: panels/keyboard/cc-keyboard-option.c:355
+msgid "Modifiers-only switch to next source"
+msgstr "Wysigers verander slegs na volgende bron"
+
+#: panels/keyboard/cc-keyboard-panel.c:181
+msgid "Reset All Shortcuts?"
+msgstr "Skrap alle kortpaaie?"
+
+#: panels/keyboard/cc-keyboard-panel.c:184
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Die herstel van alle kortpaaie mag jou pasgemaakte kortpaaie affekteer. Die "
+"aksie kan nie ongedaan gemaak word nie."
+
+#: panels/keyboard/cc-keyboard-panel.c:188
+#: panels/keyboard/shortcut-editor.ui:346
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+msgid "Cancel"
+msgstr "Kanselleer"
+
+#: panels/keyboard/cc-keyboard-panel.c:189
+msgid "Reset All"
+msgstr "Herstel alles"
+
+#: panels/keyboard/cc-keyboard-panel.c:281
+msgid "Reset the shortcut to its default value"
+msgstr "Herstel die kortpad na sy oorspronklike waarde"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:413
+#, c-format
+msgid ""
+"%s is already being used for <b>%s</b>. If you replace it, %s will be "
+"disabled"
+msgstr ""
+"%s word klaar gebruik deur <b>%s</b>. Indien jy dit vervang sal, %s "
+"gedeaktiveer word"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:583
+msgid "Set Custom Shortcut"
+msgstr "Stel 'n pasgemaakte kortpad"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:583
+msgid "Set Shortcut"
+msgstr "Stel Kortpad"
+
+#. Setup the top label
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:592
+#, c-format
+msgid "Enter new shortcut to change <b>%s</b>."
+msgstr "Voeg 'n nuwe kortpad by om <b>%s</b> te verander."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:1019
+msgid "Add Custom Shortcut"
+msgstr "Voeg 'n pasgemaakte kortpad by"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "Key­board"
+msgid "Keyboard"
+msgstr "Sleutelbord"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "Vertoon en verander sleutelbordkortpaaie en stel tikvoorkeure"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:7
+msgid "input-keyboard"
+msgstr ""
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"kortpad;werkspasie;venster;verander;grootte;zoem;kontras;invoer;bron;sluit;"
+"volume;"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:67 panels/region/input-options.ui:68
+#: shell/cc-application.c:255
+msgid "Keyboard Shortcuts"
+msgstr "Sleutelbordkortpaaie"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:77
+msgid "Reset All…"
+msgstr "Stel alles terug…"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:78
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Herstel alle kortpaaie na hul oorspronklike sleutelbindinge"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:164
+msgid "No keyboard shortcut found"
+msgstr "Geen sleutelbord kortpad gevind nie"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:175 shell/panel-list.ui:206
+msgid "Try a different search"
+msgstr "Probeer 'n ander soektog"
+
+#: panels/keyboard/shortcut-editor.ui:68 panels/keyboard/shortcut-editor.ui:318
+msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
+msgstr ""
+"Druk Esc om te kanselleer of Backspace om die sleutelbordkortpaaie te "
+"herstel."
+
+#: panels/keyboard/shortcut-editor.ui:156 panels/printers/details-dialog.ui:38
+#: panels/sound/gvc-mixer-dialog.c:1480
+#: panels/sound/gvc-sound-theme-chooser.c:554
+msgid "Name"
+msgstr "Naam"
+
+#: panels/keyboard/shortcut-editor.ui:168
+msgid "Command"
+msgstr "Opdrag"
+
+#: panels/keyboard/shortcut-editor.ui:180
+msgid "Shortcut"
+msgstr "Kortpad"
+
+#: panels/keyboard/shortcut-editor.ui:259
+msgid "Set Shortcut…"
+msgstr "Nuwe Kortpad…"
+
+#: panels/keyboard/shortcut-editor.ui:272 panels/network/network-wifi.ui:594
+msgid "None"
+msgstr "Geen"
+
+#: panels/keyboard/shortcut-editor.ui:303
+msgid "Enter the new shortcut"
+msgstr "Voer 'n nuwe kortpad in"
+
+#: panels/keyboard/shortcut-editor.ui:357
+msgid "Remove"
+msgstr "Verwyder"
+
+#: panels/keyboard/shortcut-editor.ui:367
+msgid "Add"
+msgstr "Voeg by"
+
+#: panels/keyboard/shortcut-editor.ui:382
+msgid "Replace"
+msgstr "Vervang"
+
+#: panels/keyboard/shortcut-editor.ui:395
+msgid "Set"
+msgstr "Kies"
+
+#: panels/mouse/cc-mouse-panel.c:82 panels/wacom/cc-wacom-panel.c:402
+msgid "Test Your _Settings"
+msgstr "Toet_s die instellings"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "Mouse & Touch­pad"
+msgid "Mouse & Touchpad"
+msgstr "Muis en Raakblad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Verander sensitiwiteit van die muis of raakblad en kies regs- of "
+"linkerhandigheid"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:7
+msgid "input-mouse"
+msgstr ""
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "raakblad;wyser;klik;kliek;raak;dubbel;knoppie;rolbal;rol;"
+
+#: panels/mouse/gnome-mouse-properties.ui:45
+msgid "General"
+msgstr "Algemeen"
+
+#: panels/mouse/gnome-mouse-properties.ui:83
+msgid "Primary Button"
+msgstr "Primêre knoppie"
+
+#: panels/mouse/gnome-mouse-properties.ui:102
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Stel die volgorde van fisiese knoppies op muise en raakblaaie."
+
+#: panels/mouse/gnome-mouse-properties.ui:131
+msgid "Left"
+msgstr "Links"
+
+#: panels/mouse/gnome-mouse-properties.ui:141
+msgid "Right"
+msgstr "Regs"
+
+#: panels/mouse/gnome-mouse-properties.ui:177
+msgid "Mouse"
+msgstr "Muis"
+
+#: panels/mouse/gnome-mouse-properties.ui:216
+msgid "Mouse Speed"
+msgstr "Muisspoed"
+
+#: panels/mouse/gnome-mouse-properties.ui:238
+#: panels/mouse/gnome-mouse-properties.ui:543
+msgid "Double-click timeout"
+msgstr "Dubbelklik-uitteltyd"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/gnome-mouse-properties.ui:275
+#: panels/mouse/gnome-mouse-properties.ui:451
+msgid "Natural Scrolling"
+msgstr "Natuurlike rol"
+
+#: panels/mouse/gnome-mouse-properties.ui:291
+#: panels/mouse/gnome-mouse-properties.ui:467
+msgid "Scrolling moves the content, not the view."
+msgstr "Rol skuif die inhoud, nie die aansig nie."
+
+#: panels/mouse/gnome-mouse-properties.ui:341
+#: panels/mouse/gnome-mouse-properties.ui:386
+msgid "Touchpad"
+msgstr "Raakblad"
+
+#: panels/mouse/gnome-mouse-properties.ui:522
+msgid "Touchpad Speed"
+msgstr "Raakblad se spoed"
+
+#: panels/mouse/gnome-mouse-properties.ui:581
+msgid "Tap to Click"
+msgstr "Raak om te klik"
+
+#: panels/mouse/gnome-mouse-properties.ui:634
+msgid "Two-finger Scrolling"
+msgstr "Rol met twee vingers"
+
+#: panels/mouse/gnome-mouse-properties.ui:687
+msgid "Edge Scrolling"
+msgstr "Rol op die rand"
+
+#: panels/mouse/gnome-mouse-test.c:130 panels/mouse/gnome-mouse-test.ui:23
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Probeer klik, dubbelklik, rol"
+
+#: panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "Vyf kliks, GEGL tyd!"
+
+#: panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "Dubbelklik, primêre knoppie"
+
+#: panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "Enkelklik, primêre knoppie"
+
+#: panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "Dubbelklik, middelknoppie"
+
+#: panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "Enkelklik, middelknoppie"
+
+#: panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "Dubbelklik, sekondêre knoppie"
+
+#: panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "Enkelklik, sekondêre knoppie"
+
+#. add proxy to device list
+#: panels/network/cc-network-panel.c:582
+msgid "Network proxy"
+msgstr "Netwerkinstaner"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/cc-network-panel.c:718 panels/network/net-vpn.c:170
+#: panels/network/net-vpn.c:299
+#, c-format
+msgid "%s VPN"
+msgstr "%s-VPN"
+
+#: panels/network/cc-network-panel.c:782 panels/network/wifi.ui:282
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Oeps! Iets het foutgeloop. Kontak die sagtewareverskaffer."
+
+#: panels/network/cc-network-panel.c:788
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager moet loop."
+
+#: panels/network/cc-wifi-panel.c:213
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:1769
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/connection-editor/8021x-security-page.ui:26
+msgid "802.1x _Security"
+msgstr "802.1x-_sekuriteit"
+
+#: panels/network/connection-editor/8021x-security-page.ui:73
+#: panels/network/connection-editor/security-page.ui:72
+#: panels/wacom/wacom-stylus-page.ui:108
+msgid "page 1"
+msgstr "bladsy 1"
+
+#: panels/network/connection-editor/8021x-security-page.ui:224
+#: panels/network/connection-editor/security-page.ui:223
+#: panels/network/wireless-security/eap-method-fast.ui:50
+#: panels/network/wireless-security/eap-method-peap.ui:48
+#: panels/network/wireless-security/eap-method-ttls.ui:31
+msgid "Anony_mous identity"
+msgstr "Anonie_me identiteit"
+
+#: panels/network/connection-editor/8021x-security-page.ui:238
+#: panels/network/connection-editor/security-page.ui:237
+msgid "Inner _authentication"
+msgstr "Binne _verifikasie"
+
+#: panels/network/connection-editor/8021x-security-page.ui:281
+#: panels/network/connection-editor/security-page.ui:280
+#: panels/wacom/wacom-stylus-page.ui:426
+msgid "page 2"
+msgstr "bladsy 2"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:101
+#: panels/network/connection-editor/ce-page-security.c:445
+#: panels/network/connection-editor/details-page.ui:86
+#: panels/network/network-wifi.ui:239
+msgid "Security"
+msgstr "Sekuriteit"
+
+#: panels/network/connection-editor/ce-page.c:481
+msgid "automatic"
+msgstr "outomaties"
+
+#: panels/network/connection-editor/ce-page.c:521
+#, c-format
+msgid "Profile %d"
+msgstr "Profiel %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:56
+#: panels/network/net-device-wifi.c:235 panels/network/net-device-wifi.c:468
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:60
+#: panels/network/net-device-wifi.c:239 panels/network/net-device-wifi.c:473
+#: panels/network/network-wifi.ui:593
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:64
+#: panels/network/net-device-wifi.c:243
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:69
+#: panels/network/net-device-wifi.c:248
+msgid "Enterprise"
+msgstr "Onderneming"
+
+#: panels/network/connection-editor/ce-page-details.c:74
+#: panels/network/net-device-wifi.c:253 panels/network/net-device-wifi.c:458
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Geen"
+
+#: panels/network/connection-editor/ce-page-details.c:95
+#: panels/power/power.ui:99
+msgid "Never"
+msgstr "Nooit"
+
+#: panels/network/connection-editor/ce-page-details.c:110
+#: panels/network/net-device-ethernet.c:121
+#: panels/network/net-device-wifi.c:567
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i dag gelede"
+msgstr[1] "%i dae gelede"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:225
+#: panels/network/net-device-ethernet.c:50 panels/network/net-device-wifi.c:646
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mg/s"
+
+#: panels/network/connection-editor/ce-page-details.c:251
+#: panels/network/net-device-wifi.c:675
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Geen"
+
+#: panels/network/connection-editor/ce-page-details.c:253
+#: panels/network/net-device-wifi.c:677
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Swak"
+
+#: panels/network/connection-editor/ce-page-details.c:255
+#: panels/network/net-device-wifi.c:679
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Redelik"
+
+#: panels/network/connection-editor/ce-page-details.c:257
+#: panels/network/net-device-wifi.c:681
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Goed"
+
+#: panels/network/connection-editor/ce-page-details.c:259
+#: panels/network/net-device-wifi.c:683
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Uitstekend"
+
+#: panels/network/connection-editor/ce-page-details.c:302
+msgid "Forget Connection"
+msgstr "Vergeet verbinding"
+
+#: panels/network/connection-editor/ce-page-details.c:304
+msgid "Remove Connection Profile"
+msgstr "Verwyder verbindingprofiel"
+
+#: panels/network/connection-editor/ce-page-details.c:306
+msgid "Remove VPN"
+msgstr "Verwyder VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+#: panels/network/network-wifi.ui:1456 shell/cc-window.c:214
+#: shell/panel-list.ui:103
+msgid "Details"
+msgstr "Besonderhede"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:174
+#: panels/network/connection-editor/ce-page-vpn.c:188
+#: panels/network/connection-editor/ce-page-wifi.c:194
+#: panels/network/network-wifi.ui:1460
+msgid "Identity"
+msgstr "Identiteit"
+
+#: panels/network/connection-editor/ce-page-ip4.c:251
+#: panels/network/connection-editor/ce-page-ip6.c:230
+msgid "Delete Address"
+msgstr "Skrap adres"
+
+#: panels/network/connection-editor/ce-page-ip4.c:422
+#: panels/network/connection-editor/ce-page-ip6.c:390
+msgid "Delete Route"
+msgstr "Skrap roete"
+
+#: panels/network/connection-editor/ce-page-ip4.c:896
+#: panels/network/network-wifi.ui:1464
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:828
+#: panels/network/network-wifi.ui:1468
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:245
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Geen"
+
+#: panels/network/connection-editor/ce-page-security.c:268
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bis-sleutel (Heks of ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:278
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bis wagwoordfrase"
+
+#: panels/network/connection-editor/ce-page-security.c:291
+#: panels/network/wireless-security/wireless-security.c:465
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:304
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dinamiese WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:318
+msgid "WPA & WPA2 Personal"
+msgstr "WPA en WPA2 (persoonlik)"
+
+#: panels/network/connection-editor/ce-page-security.c:332
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA en WPA2 (onderneming)"
+
+#: panels/network/connection-editor/details-page.ui:18
+#: panels/network/network-wifi.ui:174
+msgid "Signal Strength"
+msgstr "Seinsterkte"
+
+#: panels/network/connection-editor/details-page.ui:52
+#: panels/network/network-wifi.ui:207
+msgid "Link speed"
+msgstr "Skakelspoed"
+
+#: panels/network/connection-editor/details-page.ui:104
+#: panels/network/net-device-ethernet.c:154 panels/network/network-wifi.ui:256
+#: panels/network/panel-common.c:644
+msgid "IPv4 Address"
+msgstr "IPv4-adres"
+
+#: panels/network/connection-editor/details-page.ui:122
+#: panels/network/net-device-ethernet.c:155
+#: panels/network/net-device-ethernet.c:159
+#: panels/network/network-mobile.ui:189 panels/network/network-wifi.ui:273
+#: panels/network/panel-common.c:645
+msgid "IPv6 Address"
+msgstr "IPv6-adres"
+
+#: panels/network/connection-editor/details-page.ui:140
+#: panels/network/net-device-ethernet.c:162 panels/network/network-wifi.ui:290
+msgid "Hardware Address"
+msgstr "Hardewareadres"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/network-mobile.ui:206 panels/network/network-wifi.ui:307
+msgid "Default Route"
+msgstr "Verstekroete"
+
+#: panels/network/connection-editor/details-page.ui:177
+#: panels/network/connection-editor/ip4-page.ui:197
+#: panels/network/connection-editor/ip6-page.ui:211
+#: panels/network/net-device-ethernet.c:168
+#: panels/network/network-mobile.ui:224 panels/network/network-wifi.ui:325
+#: panels/network/network-wifi.ui:832 panels/network/network-wifi.ui:1109
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:195
+msgid "Last Used"
+msgstr "Laas gebruik"
+
+#: panels/network/connection-editor/details-page.ui:324
+msgid "Connect _automatically"
+msgstr "Koppel _outomaties"
+
+#: panels/network/connection-editor/details-page.ui:343
+msgid "Make available to _other users"
+msgstr "Maak beskikbaar aan _ander gebruikers"
+
+#: panels/network/connection-editor/details-page.ui:376
+msgid "Restrict background data usage"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:386
+msgid "Appropriate for connections that have data charges or limits."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:16
+#: panels/network/connection-editor/ethernet-page.ui:39
+#: panels/network/connection-editor/ip4-page.ui:209
+#: panels/network/connection-editor/ip4-page.ui:277
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:291
+#: panels/network/net-proxy.c:58 panels/network/network-proxy.ui:103
+#: panels/network/wireless-security/eap-method-peap.ui:22
+#: panels/privacy/cc-privacy-panel.c:217
+msgid "Automatic"
+msgstr "Outomaties"
+
+#: panels/network/connection-editor/ethernet-page.ui:19
+msgid "Twisted Pair (TP)"
+msgstr "Gedraaide draadpaar (TP)"
+
+#: panels/network/connection-editor/ethernet-page.ui:22
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Aanhangsel Eenheid Koppelvlak (AEK)"
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+msgid "BNC"
+msgstr "BNC"
+
+#: panels/network/connection-editor/ethernet-page.ui:28
+msgid "Media Independent Interface (MII)"
+msgstr "Media Onafhankilike Koppelvlak (MOK)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+msgid "10 Mb/s"
+msgstr "10 Mg/s"
+
+#: panels/network/connection-editor/ethernet-page.ui:45
+msgid "100 Mb/s"
+msgstr "100 Mg/s"
+
+#: panels/network/connection-editor/ethernet-page.ui:48
+msgid "1 Gb/s"
+msgstr "1 Gg/s"
+
+#: panels/network/connection-editor/ethernet-page.ui:51
+msgid "10 Gb/s"
+msgstr "10 Gg/s"
+
+#: panels/network/connection-editor/ethernet-page.ui:71
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "_Naam"
+
+#: panels/network/connection-editor/ethernet-page.ui:100
+#: panels/network/connection-editor/wifi-page.ui:68
+#: panels/network/network-wifi.ui:1261
+msgid "_MAC Address"
+msgstr "_MAC-adres"
+
+#: panels/network/connection-editor/ethernet-page.ui:146
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:163
+#: panels/network/connection-editor/wifi-page.ui:98
+msgid "_Cloned Address"
+msgstr "_Gekloonde adres"
+
+#: panels/network/connection-editor/ethernet-page.ui:178
+msgid "bytes"
+msgstr "grepe"
+
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr "IPv_4 Metode"
+
+#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/network-wifi.ui:778 panels/network/network-wifi.ui:1055
+msgid "Automatic (DHCP)"
+msgstr "Outomaties (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr "Skakel slegs plaaslik"
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr "Deaktiveer"
+
+#: panels/network/connection-editor/ip4-page.ui:111
+#: panels/network/connection-editor/ip6-page.ui:125
+msgid "Addresses"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ip4-page.ui:129
+#: panels/network/connection-editor/ip4-page.ui:313
+#: panels/network/connection-editor/ip6-page.ui:143
+#: panels/network/connection-editor/ip6-page.ui:327
+#: panels/printers/details-dialog.ui:87
+msgid "Address"
+msgstr "Adres"
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+msgid "Netmask"
+msgstr "Netmasker"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Gateway"
+msgstr "Deurgang"
+
+#: panels/network/connection-editor/ip4-page.ui:220
+#: panels/network/connection-editor/ip6-page.ui:234
+msgid "Automatic DNS"
+msgstr "Outomatiese DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:244
+#: panels/network/connection-editor/ip6-page.ui:258
+msgid "Separate IP addresses with commas"
+msgstr "Verdeel IP adresse met kommas"
+
+#: panels/network/connection-editor/ip4-page.ui:265
+#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/network-wifi.ui:877 panels/network/network-wifi.ui:1154
+msgid "Routes"
+msgstr "Roetes"
+
+#: panels/network/connection-editor/ip4-page.ui:288
+#: panels/network/connection-editor/ip6-page.ui:302
+msgid "Automatic Routes"
+msgstr "Outomatiese roetes"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:354
+#: panels/network/connection-editor/ip6-page.ui:368
+msgid "Metric"
+msgstr "Mates"
+
+#: panels/network/connection-editor/ip4-page.ui:384
+#: panels/network/connection-editor/ip6-page.ui:398
+#: panels/network/network-wifi.ui:933 panels/network/network-wifi.ui:1210
+msgid "Use this connection _only for resources on its network"
+msgstr "Gebruik hierdie verbinding _slegs vir hulpbronne op sy netwerk"
+
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr "IPv_6 Metode"
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr "Outomaties, slegs DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+msgid "Prefix"
+msgstr "Voorvoegsel"
+
+#: panels/network/connection-editor/net-connection-editor.c:273
+msgid "Unable to open connection editor"
+msgstr "Kan nie verbindingredigeerder open nie"
+
+#: panels/network/connection-editor/net-connection-editor.c:291
+msgid "New Profile"
+msgstr "Nuwe profiel"
+
+#: panels/network/connection-editor/net-connection-editor.c:603
+#: panels/network/network.ui:142
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/connection-editor/net-connection-editor.c:751
+msgid "Import from file…"
+msgstr "Voer vanaf lêer in…"
+
+#: panels/network/connection-editor/net-connection-editor.c:785
+msgid "Add VPN"
+msgstr "Voeg 'n VPN by"
+
+#: panels/network/connection-editor/security-page.ui:26
+#: panels/network/network-wifi.ui:529
+msgid "S_ecurity"
+msgstr "S_ekuriteit"
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+msgid "Cannot import VPN connection"
+msgstr "Kan nie VPN-verbinding invoer nie"
+
+#: panels/network/connection-editor/vpn-helpers.c:143
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Die lêer \"%s\" kon nie gelees word nie of die inligting vir VPN-verbinding "
+"word nie herken nie.\n"
+"\n"
+"Fout: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:178
+msgid "Select file to import"
+msgstr "Kies lêer om in te voer"
+
+#: panels/network/connection-editor/vpn-helpers.c:182
+#: panels/printers/pp-details-dialog.c:332
+#: panels/sharing/cc-sharing-panel.c:385
+#: panels/user-accounts/um-photo-dialog.c:231
+msgid "_Open"
+msgstr "_Open"
+
+#: panels/network/connection-editor/vpn-helpers.c:230
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "'n Lêer genaamd \"%s\" bestaan reeds."
+
+#: panels/network/connection-editor/vpn-helpers.c:232
+msgid "_Replace"
+msgstr "Ve_rvang"
+
+#: panels/network/connection-editor/vpn-helpers.c:234
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Wil u %s vervang met die VPN-verbinding wat u nou stoor?"
+
+#: panels/network/connection-editor/vpn-helpers.c:270
+msgid "Cannot export VPN connection"
+msgstr "Kan nie VPN-verbinding uitvoer nie"
+
+#: panels/network/connection-editor/vpn-helpers.c:272
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Die VPN-verbinding \"%s\" kon nie uitgevoer word na %s nie.\n"
+"\n"
+"Fout: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:307
+msgid "Export VPN connection"
+msgstr "Voer VPN-verbinding uit"
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Fout: kan nie VPN-verbindingredigeerder laai nie)"
+
+#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/network-wifi.ui:497
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/network-wifi.ui:513
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/connection-editor/wifi-page.ui:53
+#: panels/network/network-wifi.ui:562
+msgid "My Home Network"
+msgstr "Huisnetwerk"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:241
+msgid "Network"
+msgstr "Netwerk"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Bepaal hoe om te koppel aan die internet"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/network/gnome-network-panel.desktop.in.in:7
+msgid "network-workgroup"
+msgstr ""
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;"
+msgstr ""
+"netwerk;draadloos;Wi-Fi;IP;LAN;instaanbediener;WAN;breëband;modem;bluetooth;"
+"vpn;brug;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Bepaal hoe om te koppel aan Wi-Fi verbindings"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/network/gnome-wifi-panel.desktop.in.in:7
+#, fuzzy
+#| msgid "Network;Wireless;IP;LAN;"
+msgid "network-wireless"
+msgstr "Network;Wireless;IP;LAN;netwerk;draadloos;"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+msgstr "netwerk;draadloos;Wi-Fi;wifi;LAN;breeband;DNS;"
+
+#: panels/network/net-device-ethernet.c:107
+#: panels/network/net-device-wifi.c:553
+msgid "never"
+msgstr "nog nooit"
+
+#: panels/network/net-device-ethernet.c:117
+#: panels/network/net-device-wifi.c:563
+msgid "today"
+msgstr "vandag"
+
+#: panels/network/net-device-ethernet.c:119
+#: panels/network/net-device-wifi.c:565
+msgid "yesterday"
+msgstr "gister"
+
+#: panels/network/net-device-ethernet.c:157
+#: panels/network/network-mobile.ui:172 panels/network/panel-common.c:647
+#: panels/network/panel-common.c:649
+msgid "IP Address"
+msgstr "IP-adres"
+
+#: panels/network/net-device-ethernet.c:173 panels/network/network-wifi.ui:342
+msgid "Last used"
+msgstr "Laas gebruik"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:276
+#: panels/network/network-ethernet.ui:19 panels/network/network-simple.ui:39
+msgid "Wired"
+msgstr "Draad"
+
+#: panels/network/net-device-ethernet.c:344
+#: panels/network/net-device-wifi.c:1895 panels/network/network-ethernet.ui:120
+#: panels/network/network-mobile.ui:394 panels/network/network-simple.ui:75
+#: panels/network/network-vpn.ui:79
+msgid "Options…"
+msgstr "Keuses…"
+
+#: panels/network/net-device-mobile.c:238
+msgid "Add new connection"
+msgstr "Voeg nuwe verbinding by"
+
+#: panels/network/net-device-wifi.c:1368
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "Deur die kuberkol aan te skakel, sal u ontkoppel van <b>%s</b>."
+
+#: panels/network/net-device-wifi.c:1372
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"Dis nie moontlik om deur die draadloos internettoegang te kry terwyl die "
+"kuberkol aktief is nie."
+
+#: panels/network/net-device-wifi.c:1379
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Skakel 'n Wi-Fi-kuberkol aan?"
+
+#: panels/network/net-device-wifi.c:1401
+msgid ""
+"Wi-Fi hotspots are usually used to share an additional Internet connection "
+"over Wi-Fi."
+msgstr ""
+"'n Wi-Fi kuberkol word gewoonlik gebruik om 'n addisionele internet "
+"verbinding oor Wi-Fi te deel."
+
+#: panels/network/net-device-wifi.c:1412
+msgid "_Turn On"
+msgstr "_Skakel aan"
+
+#: panels/network/net-device-wifi.c:1489
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Stop kuberkol en ontkoppel alle gebruikers?"
+
+#: panels/network/net-device-wifi.c:1492
+msgid "_Stop Hotspot"
+msgstr "_Stop kuberkol"
+
+#: panels/network/net-device-wifi.c:1592
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Stelselbeleid verbied die gebruik van 'n kuberkol"
+
+#: panels/network/net-device-wifi.c:1595
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Draadlose toestel het nie steun vir kuberkolmodus nie"
+
+#: panels/network/net-device-wifi.c:1733
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Netwerkbesonderhede vir die gekose netwerke sal verloor word, insluitend "
+"wagwoorde en enige eie opstelling."
+
+#: panels/network/net-device-wifi.c:1737 panels/network/network-wifi.ui:1362
+msgid "_Forget"
+msgstr "_Vergeet"
+
+#: panels/network/net-device-wifi.c:2046 panels/network/net-device-wifi.c:2053
+msgid "Known Wi-Fi Networks"
+msgstr "Bekende Wi-Fi netwerke"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:2086
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Vergeet"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:102
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Outomatiese opspoor van webinstaanbedieners word gebruik wanneer 'n "
+"opstelling-URL nie verskaf word nie."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:110
+msgid "This is not recommended for untrusted public networks."
+msgstr "Dié word nié aanbeveel vir onvertroude openbare netwerke nie."
+
+#: panels/network/network-mobile.ui:30
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:48
+msgid "Provider"
+msgstr "Verskaffer"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:92
+msgid "Network Proxy"
+msgstr "Netwerkinstaner"
+
+#: panels/network/network-proxy.ui:173
+msgid "_HTTP Proxy"
+msgstr "_HTTP-instaanbediener"
+
+#: panels/network/network-proxy.ui:192
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS-instaanbediener"
+
+#: panels/network/network-proxy.ui:211
+msgid "_FTP Proxy"
+msgstr "_FTP-instaanbediener"
+
+#: panels/network/network-proxy.ui:230
+msgid "_Socks Host"
+msgstr "_Socks-gasheer"
+
+#: panels/network/network-proxy.ui:249
+msgid "_Ignore Hosts"
+msgstr "_Ignoreer gashere"
+
+#: panels/network/network-proxy.ui:287
+msgid "HTTP proxy port"
+msgstr "HTTP-instaanpoort"
+
+#: panels/network/network-proxy.ui:364
+msgid "HTTPS proxy port"
+msgstr "HTTPS-instaanpoort"
+
+#: panels/network/network-proxy.ui:385
+msgid "FTP proxy port"
+msgstr "FTP-instaanpoort"
+
+#: panels/network/network-proxy.ui:406
+msgid "Socks proxy port"
+msgstr "SOCKS-instaanpoort"
+
+#: panels/network/network-proxy.ui:435
+msgid "_Configuration URL"
+msgstr "_Konfigurasie-URL"
+
+#: panels/network/network-simple.ui:50
+msgid "Turn device off"
+msgstr "Skakel toestel af"
+
+#: panels/network/network.ui:194
+msgid "Not set up"
+msgstr "Nie opgestel nie"
+
+#: panels/network/network-vpn.ui:56
+msgid "Turn VPN connection off"
+msgstr "Skakel VPN-verbinding af"
+
+#: panels/network/network-wifi.ui:127
+msgid "Automatic _Connect"
+msgstr "Outomatiese _koppeling"
+
+#: panels/network/network-wifi.ui:474
+msgid "details"
+msgstr "besonderhede"
+
+#: panels/network/network-wifi.ui:545
+#: panels/network/wireless-security/eap-method-leap.ui:40
+#: panels/network/wireless-security/eap-method-simple.ui:40
+#: panels/network/wireless-security/ws-leap.ui:40
+#: panels/network/wireless-security/ws-wpa-psk.ui:22
+#: panels/sharing/sharing.ui:351
+#: panels/user-accounts/data/account-dialog.ui:300
+#: panels/user-accounts/data/account-dialog.ui:525
+#: panels/user-accounts/data/user-accounts-dialog.ui:205
+msgid "_Password"
+msgstr "_Wagwoord"
+
+#: panels/network/network-wifi.ui:622
+msgid "Show P_assword"
+msgstr "Wys w_agwoord"
+
+#: panels/network/network-wifi.ui:652
+msgid "Make available to other users"
+msgstr "Maak beskikbaar aan ander gebruikers"
+
+#: panels/network/network-wifi.ui:680
+msgid "identity"
+msgstr "identiteit"
+
+#: panels/network/network-wifi.ui:714
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: panels/network/network-wifi.ui:755 panels/network/network-wifi.ui:1032
+msgid "_Addresses"
+msgstr "_Adresse"
+
+#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
+msgid "Automatic (DHCP) addresses only"
+msgstr "Slegs outomatiese (DHCP-) adresse"
+
+#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
+msgid "Link-local only"
+msgstr "Skakel slegs plaaslik"
+
+#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
+msgid "Shared with other computers"
+msgstr "Gedeel met ander rekenaars"
+
+#: panels/network/network-wifi.ui:917 panels/network/network-wifi.ui:1194
+msgid "_Ignore automatically obtained routes"
+msgstr "_Ignoreer roetes wat outomaties verkry is"
+
+#: panels/network/network-wifi.ui:960
+msgid "ipv4"
+msgstr "ipv4"
+
+#: panels/network/network-wifi.ui:991
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: panels/network/network-wifi.ui:1237
+msgid "ipv6"
+msgstr "ipv6"
+
+#: panels/network/network-wifi.ui:1277
+msgid "_Cloned MAC Address"
+msgstr "_Gekloonde MAC-adres"
+
+#: panels/network/network-wifi.ui:1327
+msgid "hardware"
+msgstr "hardeware"
+
+#: panels/network/network-wifi.ui:1346
+msgid "_Reset"
+msgstr "Stel te_rug"
+
+#: panels/network/network-wifi.ui:1382
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"Stel die instellings vir dié verbinding terug, maar onthou dit as 'n "
+"voorkeurverbinding."
+
+#: panels/network/network-wifi.ui:1399
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"Verwyder alle besonderhede wat met dié netwerk te doen het en moenie weer "
+"outomaties daaraan probeer koppel nie."
+
+#: panels/network/network-wifi.ui:1419
+msgid "reset"
+msgstr "herstel"
+
+#: panels/network/network-wifi.ui:1472
+msgid "Hardware"
+msgstr "Hardeware"
+
+#: panels/network/network-wifi.ui:1476
+msgctxt "tab"
+msgid "Reset"
+msgstr "Herstel"
+
+#: panels/network/network-wifi.ui:1537
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi-Kuberkol"
+
+#: panels/network/network-wifi.ui:1554
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Skakel af om aan 'n Wi-Fi-netwerk te koppel"
+
+#: panels/network/network-wifi.ui:1603
+msgid "Network Name"
+msgstr "Netwerknaam"
+
+#: panels/network/network-wifi.ui:1621
+msgid "Connected Devices"
+msgstr "Gekoppelde toestelle"
+
+#: panels/network/network-wifi.ui:1639
+msgid "Security type"
+msgstr "Sekuriteitstipe"
+
+#: panels/network/network-wifi.ui:1702
+#, fuzzy
+#| msgid "Password"
+msgctxt "Wi-Fi passkey"
+msgid "Password"
+msgstr "Wagwoord"
+
+#: panels/network/network-wifi.ui:1799
+msgid "Turn Wi-Fi off"
+msgstr "Skakel Wi-Fi af"
+
+#: panels/network/network-wifi.ui:1831
+msgid "_Connect to Hidden Network…"
+msgstr "_Koppel aan 'n versteekte netwerk…"
+
+#: panels/network/network-wifi.ui:1841
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Skakel Wi-Fi-kuberkol aan…"
+
+#: panels/network/network-wifi.ui:1851
+msgid "_Known Wi-Fi Networks"
+msgstr "_Bekende Wi-Fi Netwerke"
+
+#: panels/network/wifi.ui:40
+msgid "No Wi-Fi Adapter Found"
+msgstr "Geen Wi-Fi passtukke gevind nie"
+
+#: panels/network/wifi.ui:52
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Versker dat die Wi-Fi-passtuk ingeprop en angeskakel is"
+
+#: panels/network/wifi.ui:127
+msgid "Airplane Mode"
+msgstr "Vlugmodus"
+
+#: panels/network/wifi.ui:142
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Deaktiveer Wi-Fi, Bluetooth en mobiele breëband"
+
+#: panels/network/wifi.ui:192
+msgid "Visible Networks"
+msgstr "Sigbare netwerke"
+
+#: panels/network/wifi.ui:271
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager moet loop"
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:127
+msgid "Ad-hoc"
+msgstr "Ad hoc"
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:131
+msgid "Infrastructure"
+msgstr "Infrastruktuur"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:147 panels/network/panel-common.c:201
+msgid "Status unknown"
+msgstr "Status onbekend"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:151
+msgid "Unmanaged"
+msgstr "Nie bestuur nie"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:155
+msgid "Unavailable"
+msgstr "Nie beskikbaar nie"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:165 panels/network/panel-common.c:207
+msgid "Connecting"
+msgstr "Koppel tans"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:169 panels/network/panel-common.c:211
+msgid "Authentication required"
+msgstr "Verifikasie word vereis"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:173 panels/network/panel-common.c:215
+msgid "Connected"
+msgstr "Gekoppel"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:177
+msgid "Disconnecting"
+msgstr "Ontkoppel tans"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:181 panels/network/panel-common.c:219
+msgid "Connection failed"
+msgstr "Koppeling het misluk"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:185 panels/network/panel-common.c:227
+msgid "Status unknown (missing)"
+msgstr "Status onbekend (ontbreek)"
+
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:223
+msgid "Not connected"
+msgstr "Nie gekoppel nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "Configuration failed"
+msgstr "Opstelling het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252
+msgid "IP configuration failed"
+msgstr "IP-opstelling het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "IP configuration expired"
+msgstr "IP-opstelling het verval"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:260
+msgid "Secrets were required, but not provided"
+msgstr "Geheime was nodig, maar is nie verskaf nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:264
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x supplicant ontkoppel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:268
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x supplicant konfigurasie het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:272
+msgid "802.1x supplicant failed"
+msgstr "802.1x supplicant het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:276
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant het te lank geneem om te verifieer"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:280
+msgid "PPP service failed to start"
+msgstr "PPP-diens kon nie begin nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:284
+msgid "PPP service disconnected"
+msgstr "PPP-diens het ontkoppel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:288
+msgid "PPP failed"
+msgstr "PPP het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:292
+msgid "DHCP client failed to start"
+msgstr "DHCP-kliënt kon nie begin nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:296
+msgid "DHCP client error"
+msgstr "DHCP-kliëntfout"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:300
+msgid "DHCP client failed"
+msgstr "DHCP-kliënt het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:304
+msgid "Shared connection service failed to start"
+msgstr "Gedeelde verbinding diens kon nie begin nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:308
+msgid "Shared connection service failed"
+msgstr "Gedeelde verbinding diens het gebreek"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:312
+msgid "AutoIP service failed to start"
+msgstr "AutoIP diens kon nie begin nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:316
+msgid "AutoIP service error"
+msgstr "AutoIP diens fout"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:320
+msgid "AutoIP service failed"
+msgstr "AutoIP diens het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:324
+msgid "Line busy"
+msgstr "Lyn beset"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:328
+msgid "No dial tone"
+msgstr "Geen luitoon nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:332
+msgid "No carrier could be established"
+msgstr "Geen draer kon vasgestel word nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:336
+msgid "Dialing request timed out"
+msgstr "Inbelversoek het uitgetel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:340
+msgid "Dialing attempt failed"
+msgstr "Inbelpoging het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:344
+msgid "Modem initialization failed"
+msgstr "Inisialisering van modem het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:348
+msgid "Failed to select the specified APN"
+msgstr "Kon nie die gespesifiseerde APN kies nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:352
+msgid "Not searching for networks"
+msgstr "Soek nie tans vir netwerke nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:356
+msgid "Network registration denied"
+msgstr "Netwerkregistrasie geweier"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:360
+msgid "Network registration timed out"
+msgstr "Netwerkregistrasie het uitgetel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:364
+msgid "Failed to register with the requested network"
+msgstr "Kon nie registreer met die aangevraagde netwerk nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:368
+msgid "PIN check failed"
+msgstr "PIN-kontrole het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:372
+msgid "Firmware for the device may be missing"
+msgstr "Fermware vir die toestel ontbreek moontlik"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:376
+msgid "Connection disappeared"
+msgstr "Verbinding het verdwyn"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:380
+msgid "Existing connection was assumed"
+msgstr "Het aangeneem daar is 'n bestaande verbinding"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:384
+msgid "Modem not found"
+msgstr "Modem nie gevind nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:388
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth-koppeling het misluk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:392
+msgid "SIM Card not inserted"
+msgstr "SIM-kaart nie in nie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:396
+msgid "SIM Pin required"
+msgstr "SIM-PIN benodig"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:400
+msgid "SIM Puk required"
+msgstr "SIM-PUK benodig"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:404
+msgid "SIM wrong"
+msgstr "SIM verkeerd"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:408
+msgid "Connection dependency failed"
+msgstr "Koppeling se afhanklikheid het misluk"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:433
+msgid "Firmware missing"
+msgstr "Fermware ontbreek"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:437
+msgid "Cable unplugged"
+msgstr "Kabel uitgeprop"
+
+#: panels/network/wireless-security/eap-method.c:69
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "ongedefinieerde fout in 802.1X sekuriteit (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:245
+msgid "no file selected"
+msgstr "geen lêer is geselekteer nie"
+
+#: panels/network/wireless-security/eap-method.c:276
+msgid "unspecified error validating eap-method file"
+msgstr ""
+"ongespesifiseerde fout ondervind terwyl eap-metode lêer gevalideer word"
+
+#: panels/network/wireless-security/eap-method.c:451
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "DER-, PEM-, of PKCS#12- private sleutels (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:454
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER- of PEM-sertifikate (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:72
+msgid "missing EAP-FAST PAC file"
+msgstr "vermiste EAP-FAST PAC lêer"
+
+#: panels/network/wireless-security/eap-method-fast.c:268
+#: panels/network/wireless-security/eap-method-peap.c:302
+#: panels/network/wireless-security/eap-method-ttls.c:351
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.c:283
+#: panels/network/wireless-security/eap-method-peap.c:272
+#: panels/network/wireless-security/eap-method-ttls.c:289
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.c:406
+msgid "Choose a PAC file"
+msgstr "Kies 'n PAC-lêer"
+
+#: panels/network/wireless-security/eap-method-fast.c:413
+msgid "PAC files (*.pac)"
+msgstr "PAC-lêers (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:22
+msgid "Anonymous"
+msgstr "Anoniem"
+
+#: panels/network/wireless-security/eap-method-fast.ui:25
+msgid "Authenticated"
+msgstr "Geverifieer"
+
+#: panels/network/wireless-security/eap-method-fast.ui:28
+msgid "Both"
+msgstr "Altwee"
+
+#: panels/network/wireless-security/eap-method-fast.ui:76
+msgid "PAC _file"
+msgstr "PAC-_lêer"
+
+#: panels/network/wireless-security/eap-method-fast.ui:122
+#: panels/network/wireless-security/eap-method-peap.ui:146
+#: panels/network/wireless-security/eap-method-ttls.ui:97
+msgid "_Inner authentication"
+msgstr "_Binne verifiëring"
+
+#: panels/network/wireless-security/eap-method-fast.ui:156
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Laat outomatiese PAC voorsiening toe"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "vermisde EAP-LEAP gebruikersnaam"
+
+#: panels/network/wireless-security/eap-method-leap.c:74
+msgid "missing EAP-LEAP password"
+msgstr "vermisde EAP-LEAP wagwoord"
+
+#: panels/network/wireless-security/eap-method-leap.ui:26
+#: panels/network/wireless-security/eap-method-simple.ui:26
+#: panels/network/wireless-security/ws-leap.ui:26
+#: panels/user-accounts/data/account-dialog.ui:142
+#: panels/user-accounts/data/account-dialog.ui:505
+msgid "_Username"
+msgstr "Gebr_uikernaam"
+
+#: panels/network/wireless-security/eap-method-leap.ui:68
+#: panels/network/wireless-security/eap-method-simple.ui:85
+#: panels/network/wireless-security/eap-method-tls.ui:164
+#: panels/network/wireless-security/ws-leap.ui:68
+#: panels/network/wireless-security/ws-wpa-psk.ui:76
+msgid "Sho_w password"
+msgstr "_Wys wagwoord"
+
+#: panels/network/wireless-security/eap-method-peap.c:63
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "ongeldige EAP-PEAP CA sertifikaat: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:68
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "ongeldige EAP-PEAP CA sertifikaat: geen sertifikaat is verskaf nie"
+
+#: panels/network/wireless-security/eap-method-peap.c:287
+#: panels/network/wireless-security/eap-method-ttls.c:336
+#: panels/network/wireless-security/wireless-security.c:441
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.c:381
+#: panels/network/wireless-security/eap-method-tls.c:492
+#: panels/network/wireless-security/eap-method-ttls.c:430
+msgid "Choose a Certificate Authority certificate"
+msgstr "Kies 'n sertifikaat vir die sertifikaatowerheid"
+
+#: panels/network/wireless-security/eap-method-peap.ui:25
+msgid "Version 0"
+msgstr "Weergawe 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:28
+msgid "Version 1"
+msgstr "Weergawe 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:74
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:57
+msgid "C_A certificate"
+msgstr "S_O-sertifikaat"
+
+#: panels/network/wireless-security/eap-method-peap.ui:96
+#: panels/network/wireless-security/eap-method-tls.ui:97
+#: panels/network/wireless-security/eap-method-ttls.ui:79
+msgid "No CA certificate is _required"
+msgstr "Geen CA sertifikaat word _benodig nie"
+
+#: panels/network/wireless-security/eap-method-peap.ui:114
+msgid "PEAP _version"
+msgstr "PEAP-_weergawe"
+
+#: panels/network/wireless-security/eap-method-simple.c:74
+msgid "missing EAP username"
+msgstr "vermisde EAP gebruikersnaam"
+
+#: panels/network/wireless-security/eap-method-simple.c:87
+msgid "missing EAP password"
+msgstr "EAP wagwoord nie teenwoordig nie"
+
+#: panels/network/wireless-security/eap-method-tls.c:68
+msgid "missing EAP-TLS identity"
+msgstr "vermisde EAP-TLS identiteit"
+
+#: panels/network/wireless-security/eap-method-tls.c:77
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "ongeldige EAP-TLS CA sertifikaat: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:84
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "ongeldige EAP-TLS CA sertifikaat: geen sertifikaat is verskaf nie"
+
+#: panels/network/wireless-security/eap-method-tls.c:100
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "ongeldige EAP-TLS privaat-sleutel: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:110
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "ongeldige EAP-TLS gebruikers-sertifikaat: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:307
+msgid "Unencrypted private keys are insecure"
+msgstr "Ongeënkripteerde privaatsleutels is onveilig"
+
+#: panels/network/wireless-security/eap-method-tls.c:310
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Die gekose privaatsleutel word klaarblyklik nie met 'n wagwoord beskerm nie. "
+"Dit kan dalk toelaat dat u sekuriteitsinligting gesteel word.  Kies asb. 'n "
+"wagwoordbeskermde privaatsleutel.\n"
+"\n"
+"('n Privaatsleutel kan d.m.v. openssl met 'n wagwoord beskerm word)"
+
+#: panels/network/wireless-security/eap-method-tls.c:486
+msgid "Choose your personal certificate"
+msgstr "Kies u persoonlike sertifikaat"
+
+#: panels/network/wireless-security/eap-method-tls.c:498
+msgid "Choose your private key"
+msgstr "Kies u privaatsleutel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:24
+msgid "I_dentity"
+msgstr "I_dentiteit"
+
+#: panels/network/wireless-security/eap-method-tls.ui:50
+msgid "_User certificate"
+msgstr "Gebr_uikersertifikaat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:115
+msgid "Private _key"
+msgstr "Privaats_leutel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:140
+msgid "_Private key password"
+msgstr "Wagwoord vir _privaatsleutel"
+
+#: panels/network/wireless-security/eap-method-ttls.c:63
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "ongeldige EAP-TTLS CA sertifikaat: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:68
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "ongeldige EAP-TTLS CA sertifikaat: geen sertifikaat is verskaf nie"
+
+#: panels/network/wireless-security/eap-method-ttls.c:259
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.c:274
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.c:305
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (geen EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.c:321
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/wireless-security.c:87
+msgid "Unknown error validating 802.1X security"
+msgstr "Onbekende fout ervaar tydens die verifikasie van 802.1X sekuriteit"
+
+#: panels/network/wireless-security/wireless-security.c:453
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/wireless-security.c:477
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/wireless-security.c:488
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/wireless-security.c:499
+msgid "Tunneled TLS"
+msgstr "Getonnelde TLS"
+
+#: panels/network/wireless-security/wireless-security.c:510
+msgid "Protected EAP (PEAP)"
+msgstr "Beskermde EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:39
+#: panels/network/wireless-security/ws-wep-key.ui:115
+#: panels/network/wireless-security/ws-wpa-eap.ui:33
+msgid "Au_thentication"
+msgstr "Verifiëring"
+
+#: panels/network/wireless-security/ws-leap.c:63
+msgid "missing leap-username"
+msgstr "vermisde leap-gebruikersnaam"
+
+#: panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr "leap-wagwoord nie teenwoordig nie"
+
+#: panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr "geen wep-kode verskaf nie"
+
+#: panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"ongeldige wep-kode: 'n kode met 'n lengte van %zu mag slegs hex-getalle bevat"
+
+#: panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"ongeldige wep-kode: 'n kode met 'n lengte van %zu mag slegs ascii karakters "
+"bevat"
+
+#: panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"ongeldige wep-kode: verkeerde kode lengte %zu 'n Kode moet 'n lengte van "
+"5/13 (ascii) of 10/26 (hex) hê"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "ongeldige wep-kode: wagwoord mag nie leeg wees nie"
+
+#: panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "ongeldige wep-kode: wagwoord moet korter as 64 karakters wees"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (verstek)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Oop stelsel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Gedeelde sleutel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:56
+msgid "_Key"
+msgstr "S_leutel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:94
+msgid "Sho_w key"
+msgstr "_Wys sleutel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:152
+msgid "WEP inde_x"
+msgstr "WEP inde_ks"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"ongeldige wpa-psk: ongeldige kode lengte %zu. Moet [8,63] grepe of 64 hex "
+"nommers wees"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "ongeldige wpa-psk: kan nie kode met 64 grepe as hex verstaan nie"
+
+#: panels/network/wireless-security/ws-wpa-psk.ui:50
+msgid "_Type"
+msgstr "_Tipe"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/edit-dialog.ui:64
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Ke_nnisgewings"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/edit-dialog.ui:116
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Klankkennisgewings"
+
+#: panels/notifications/edit-dialog.ui:172
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Kennisgewing_baniere"
+
+#: panels/notifications/edit-dialog.ui:188
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Kennisgewings sal aanhou om in die kenisgewing lys vertoon te word as "
+"baniere gedeaktiveer word."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/edit-dialog.ui:253
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Wys _boodskapinhoud in baniere"
+
+#: panels/notifications/edit-dialog.ui:304
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Kennisgewings op geslote skerm"
+
+#: panels/notifications/edit-dialog.ui:355
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Wys _boodskapinhoud op geslote skerm"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+#| msgctxt "notifications"
+#| msgid "_Notifications"
+msgid "Notifications"
+msgstr "Ke_nnisgewings"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Beheer watter kennisgewings wys en wat hulle bevat"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:7
+#, fuzzy
+#| msgid "Preferences;Settings;"
+msgid "preferences-system-notifications"
+msgstr "voorkeure;instelling;opstelling;"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "kennisgewings;banier;boodskap;"
+
+#: panels/notifications/notifications.ui:84
+msgid "Notification _Popups"
+msgstr "Kennisgewing_baniere"
+
+#: panels/notifications/notifications.ui:134
+msgid "_Lock Screen Notifications"
+msgstr "_Kennisgewings op geslote skerm"
+
+#. List of applications.
+#: panels/notifications/notifications.ui:180 panels/privacy/privacy.ui:875
+#: panels/sound/gvc-mixer-dialog.c:1768
+msgid "Applications"
+msgstr "Toepassings"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:149
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Ander"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:615
+#, c-format
+msgid "%s Account"
+msgstr "%s Rekening"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:910
+msgid "Error removing account"
+msgstr "Kon nie rekening verwyder nie"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:975
+#, c-format
+msgid "<b>%s</b> removed"
+msgstr "<b>%s</b> verwyder"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "On­line Accounts"
+msgid "Online Accounts"
+msgstr "Aanlynrekeninge"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Koppel met aanlynrekeninge en kies waarvoor hulle gebruik moet word"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:7
+msgid "goa-panel"
+msgstr ""
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"google;facebook;twitter;yahoo;web;aanlyn;klets;kalender;pos;kontak;owncloud;"
+"kerberos;IMAP;SMTP;pocket;readitlater;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
+msgid "Undo"
+msgstr "Ontdoen"
+
+#: panels/online-accounts/online-accounts.ui:125
+msgid "Connect to your data in the cloud"
+msgstr "Koppel aan jou data in die wolk"
+
+#: panels/online-accounts/online-accounts.ui:137
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Geen internet verbinding. Koppel aan die internet om aanlyn rekeninge by te "
+"voeg"
+
+#: panels/online-accounts/online-accounts.ui:159
+msgid "Add an account"
+msgstr "Voeg 'n rekening by"
+
+#: panels/online-accounts/online-accounts.ui:264
+msgid "Remove Account"
+msgstr "Verwyder rekening"
+
+#: panels/power/cc-power-panel.c:253
+msgid "Unknown time"
+msgstr "Onbekende tyd"
+
+#: panels/power/cc-power-panel.c:259
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuut"
+msgstr[1] "%i minute"
+
+#: panels/power/cc-power-panel.c:271
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i uur"
+msgstr[1] "%i ure"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-power-panel.c:279
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-power-panel.c:280
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "uur"
+msgstr[1] "ure"
+
+#: panels/power/cc-power-panel.c:281
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuut"
+msgstr[1] "minute"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:300
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s tot volgelaai"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:307
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Waarskuwing: %s oor"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:312
+#, c-format
+msgid "%s remaining"
+msgstr "%s oor"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:317 panels/power/cc-power-panel.c:345
+msgid "Fully charged"
+msgstr "Volgelaai"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:321 panels/power/cc-power-panel.c:349
+msgid "Empty"
+msgstr "Pap"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:336
+msgid "Charging"
+msgstr "Laai tans"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:341
+msgid "Discharging"
+msgstr "Ontlaai tans"
+
+#: panels/power/cc-power-panel.c:464
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Hoof"
+
+#: panels/power/cc-power-panel.c:466
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Ekstra"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:537
+msgid "Wireless mouse"
+msgstr "Draadlose muis"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:540
+msgid "Wireless keyboard"
+msgstr "Draadlose sleutelbord"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:543
+msgid "Uninterruptible power supply"
+msgstr "Ononderbreekbare kragbron"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:546
+msgid "Personal digital assistant"
+msgstr "Persoonlike digitale assistent"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:549
+msgid "Cellphone"
+msgstr "Selfoon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:552
+msgid "Media player"
+msgstr "Mediaspeler"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:555 panels/wacom/cc-wacom-panel.c:793
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:558
+msgid "Computer"
+msgstr "Rekenaar"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:561
+msgid "Gaming input device"
+msgstr ""
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-power-panel.c:564 panels/power/cc-power-panel.c:804
+#: panels/power/cc-power-panel.c:2380
+msgid "Battery"
+msgstr "Battery"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:618
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Laai tans"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:625
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Versigtig"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:630
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Amper pap"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:635
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Goed"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:640
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Volgelaai"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:644
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Pap"
+
+#: panels/power/cc-power-panel.c:802
+msgid "Batteries"
+msgstr "Batterye"
+
+#: panels/power/cc-power-panel.c:1242
+msgid "When _idle"
+msgstr "Indien _ongebruik"
+
+#: panels/power/cc-power-panel.c:1696
+msgid "Power Saving"
+msgstr "Kragbesparing"
+
+#: panels/power/cc-power-panel.c:1727
+msgid "_Screen brightness"
+msgstr "_Skermhelderheid"
+
+#: panels/power/cc-power-panel.c:1746
+msgid "Automatic brightness"
+msgstr "Outomatiese helderheid"
+
+#: panels/power/cc-power-panel.c:1766
+msgid "_Keyboard brightness"
+msgstr "S_leutelbordhelderheid"
+
+#: panels/power/cc-power-panel.c:1776
+msgid "_Dim screen when inactive"
+msgstr "Ver_dof skerm wanneer onaktief"
+
+#: panels/power/cc-power-panel.c:1801
+msgid "_Blank screen"
+msgstr "_Wys swart skerm"
+
+#: panels/power/cc-power-panel.c:1838
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: panels/power/cc-power-panel.c:1843
+msgid "Turn off Wi-Fi to save power."
+msgstr "Skakel die Wi-Fi af om krag te spaar."
+
+#: panels/power/cc-power-panel.c:1868
+msgid "_Mobile broadband"
+msgstr "S_elfoonbreëband"
+
+#: panels/power/cc-power-panel.c:1873
+msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+msgstr ""
+"Skakel selfoonbreëbandtoestelle (3G, 4G, LTE, ens.) af om krag te spaar."
+
+#: panels/power/cc-power-panel.c:1926
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: panels/power/cc-power-panel.c:1931
+#, fuzzy
+#| msgid "Turn off Wi-Fi to save power."
+msgid "Turn off Bluetooth to save power."
+msgstr "Skakel die Wi-Fi af om krag te spaar."
+
+#: panels/power/cc-power-panel.c:1990
+msgid "When on battery power"
+msgstr "Terwyl op batterykrag"
+
+#: panels/power/cc-power-panel.c:1992
+msgid "When plugged in"
+msgstr "Terwyl ingeprop"
+
+#: panels/power/cc-power-panel.c:2087
+msgid "Suspend"
+msgstr "Sluimer"
+
+#: panels/power/cc-power-panel.c:2088
+msgid "Power Off"
+msgstr "Skakel af"
+
+#: panels/power/cc-power-panel.c:2089
+msgid "Hibernate"
+msgstr "Hiberneer"
+
+#: panels/power/cc-power-panel.c:2090
+msgid "Nothing"
+msgstr "Doen niks"
+
+#. Frame header
+#: panels/power/cc-power-panel.c:2204
+msgid "Suspend & Power Button"
+msgstr "Sluimer en kragknoppie"
+
+#: panels/power/cc-power-panel.c:2243
+msgid "_Automatic suspend"
+msgstr "_Outomatiese sluimer"
+
+#: panels/power/cc-power-panel.c:2244
+msgid "Automatic suspend"
+msgstr "Outomatiese sluimer"
+
+#: panels/power/cc-power-panel.c:2311
+msgid "_When the Power Button is pressed"
+msgstr "_Wanneer die kragknoppie gedruk word"
+
+#: panels/power/cc-power-panel.c:2430 shell/cc-window.c:218
+#: shell/panel-list.ui:45
+msgid "Devices"
+msgstr "Toestelle"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Krag"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Bekyk batterystatus en verander instellings vir kragbesparing"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/power/gnome-power-panel.desktop.in.in:7
+msgid "gnome-power-manager"
+msgstr ""
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"krag;slaap;sluimer;hiberneer;battery;helderheid;verdof;blanko;monitor;DPMS;"
+"onaktief;"
+
+#: panels/power/power.ui:17
+#, fuzzy
+#| msgid "2 minutes"
+msgid "20 minutes"
+msgstr "2 minute"
+
+#: panels/power/power.ui:21
+#, fuzzy
+#| msgid "5 minutes"
+msgid "25 minutes"
+msgstr "5 minute"
+
+#: panels/power/power.ui:29
+msgid "45 minutes"
+msgstr "45 minute"
+
+#: panels/power/power.ui:33 panels/privacy/privacy.ui:42
+#: panels/privacy/privacy.ui:56
+msgid "1 hour"
+msgstr "1 uur"
+
+#: panels/power/power.ui:37
+msgid "80 minutes"
+msgstr "80 minute"
+
+#: panels/power/power.ui:41
+msgid "90 minutes"
+msgstr "90 minute"
+
+#: panels/power/power.ui:45
+msgid "100 minutes"
+msgstr "100 minute"
+
+#: panels/power/power.ui:49
+msgid "2 hours"
+msgstr "2 ure"
+
+#: panels/power/power.ui:63 panels/privacy/privacy.ui:22
+msgid "1 minute"
+msgstr "1 minuut"
+
+#: panels/power/power.ui:67 panels/privacy/privacy.ui:26
+msgid "2 minutes"
+msgstr "2 minute"
+
+#: panels/power/power.ui:71 panels/privacy/privacy.ui:30
+msgid "3 minutes"
+msgstr "3 minute"
+
+#: panels/power/power.ui:75
+msgid "4 minutes"
+msgstr "4 minute"
+
+#: panels/power/power.ui:79 panels/privacy/privacy.ui:34
+msgid "5 minutes"
+msgstr "5 minute"
+
+#: panels/power/power.ui:83
+msgid "8 minutes"
+msgstr "8 minute"
+
+#: panels/power/power.ui:87
+msgid "10 minutes"
+msgstr "10 minute"
+
+#: panels/power/power.ui:91
+msgid "12 minutes"
+msgstr "12 minute"
+
+#: panels/power/power.ui:155
+msgid "Automatic Suspend"
+msgstr "Outomatiese sluimer"
+
+#: panels/power/power.ui:180
+msgid "_Plugged In"
+msgstr "Ingepr_op"
+
+#: panels/power/power.ui:196
+msgid "On _Battery Power"
+msgstr "Op _batterykrag"
+
+#: panels/power/power.ui:241 panels/power/power.ui:301
+#: panels/universal-access/uap.ui:1501
+msgid "Delay"
+msgstr "Wagtyd"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "Verifieer"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:361
+msgid "Username"
+msgstr "Gebruikernaam"
+
+#. Translators: This is a password needed for printing.
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:382
+#: panels/user-accounts/data/account-dialog.ui:240
+msgid "Password"
+msgstr "Wagwoord"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:336
+msgid "Authentication Required"
+msgstr "Verifikasie benodig"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:808
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Die drukker \"%s\" is verwyder"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:1053
+msgid "Failed to add new printer."
+msgstr "Kon nie nuwe drukker byvoeg nie."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1390
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Kon nie die gebruikerkoppelvlak laai nie: %s"
+
+#: panels/printers/details-dialog.ui:63 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "Ligging"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/details-dialog.ui:111
+#: panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Aandrywer"
+
+#: panels/printers/details-dialog.ui:147
+msgid "Searching for preferred drivers…"
+msgstr "Soek tans vir voorkeurdrywers…"
+
+#: panels/printers/details-dialog.ui:169
+msgid "Search for Drivers"
+msgstr "Soek vir 'n drywerprogramatuur"
+
+#: panels/printers/details-dialog.ui:177
+msgid "Select from Database…"
+msgstr "Kies uit 'n databasis…"
+
+#: panels/printers/details-dialog.ui:185
+msgid "Install PPD File…"
+msgstr "Verskaf PPD-lêer…"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "Prin­ters"
+msgid "Printers"
+msgstr "Drukkers"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Voeg drukkers by, bekyk druktake en kies hoe om te druk"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/printers/gnome-printers-panel.desktop.in.in:7
+#, fuzzy
+#| msgid "No printers"
+msgid "printer"
+msgstr "Geen drukkers nie"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "drukker;tou;druk;papier;ink;toner;"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/jobs-dialog.ui:44
+#, fuzzy
+#| msgid "_Domain"
+msgid "Domain"
+msgstr "_Domein"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/jobs-dialog.ui:123
+#, fuzzy
+#| msgid "Authenticate"
+msgid "A_uthenticate"
+msgstr "Verifieer"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/jobs-dialog.ui:163
+msgid "Clear All"
+msgstr "Verwyder almal"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/jobs-dialog.ui:225
+#, fuzzy
+#| msgid "Authenticate"
+msgid "_Authenticate"
+msgstr "Verifieer"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/jobs-dialog.ui:354
+msgid "No Active Printer Jobs"
+msgstr "Geen aktiewe druktake nie"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:384
+#: panels/printers/pp-new-printer-dialog.c:456
+msgid "Add Printer"
+msgstr "Voeg drukker by"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+msgid "_Unlock"
+msgstr "_Ontsluit"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:210
+msgid "No Printers Found"
+msgstr "Geen drukkers gevind nie"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:283
+msgid "Enter a network address or search for a printer"
+msgstr "Tik 'n netwerkadres of soek vir 'n drukker"
+
+#: panels/printers/new-printer-dialog.ui:352
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Voer u gebruikernaam en wagwoord in om beskikbare drukkers op bediener te "
+"sien."
+
+#. Translators: This button triggers the printing of a test page.
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/options-dialog.ui:22 panels/printers/pp-options-dialog.c:893
+msgid "Test Page"
+msgstr "Toetsbladsy"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:135
+#: panels/printers/pp-details-dialog.c:435
+#, c-format
+msgid "%s Details"
+msgstr "%s Besonderhede"
+
+#: panels/printers/pp-details-dialog.c:184
+msgid "No suitable driver found"
+msgstr "Geen gepaste drywer gevind nie"
+
+#: panels/printers/pp-details-dialog.c:328
+msgid "Select PPD File"
+msgstr "Kies PPD-lêer"
+
+#: panels/printers/pp-details-dialog.c:337
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript-drukkerbeskrywings (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr "Kies 'n drukkerdrywer"
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/um-photo-dialog.c:105
+msgid "Select"
+msgstr "Kies"
+
+#: panels/printers/ppd-selection-dialog.ui:73
+msgid "Loading drivers database…"
+msgstr "Laai tans drywerdatabasis…"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:539
+msgid "JetDirect Printer"
+msgstr "JetDirect-drukker"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:795
+msgid "LPD Printer"
+msgstr "LPD-drukker"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "Een kant"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "Lang kant (standaard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:70
+#: panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "Kort kant (swaai om)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "Portret"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "Landskap"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "Omgekeerde landskap"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "Omgekeerde portret"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-jobs-dialog.c:234
+msgctxt "print job"
+msgid "Pending"
+msgstr "Hangend"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-jobs-dialog.c:240
+msgctxt "print job"
+msgid "Paused"
+msgstr "Wagtend"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-jobs-dialog.c:245
+#, fuzzy
+#| msgid "Authentication required"
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Verifikasie word vereis"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-jobs-dialog.c:250
+msgctxt "print job"
+msgid "Processing"
+msgstr "Verwerk tans"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-jobs-dialog.c:254
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Gestop"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-jobs-dialog.c:258
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Gekanselleer"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-jobs-dialog.c:262
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Gestaak"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-jobs-dialog.c:266
+msgctxt "print job"
+msgid "Completed"
+msgstr "Voltooid"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:390
+#, fuzzy, c-format
+#| msgid "Server requires authentication"
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "Bediener nodig verifikasie"
+msgstr[1] "Bediener nodig verifikasie"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:620
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - Aktiewe Take"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:625
+#, fuzzy, c-format
+#| msgid "Enter username and password to view printers on %s."
+msgid "Enter credentials to print from %s."
+msgstr ""
+"Voer u gebruikersnaam en wagwoord in om beskikbare drukkers op %s te sien."
+
+#: panels/printers/pp-new-printer-dialog.c:402
+msgid "Unlock Print Server"
+msgstr "Sluit die druk bediener oop"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:406
+#, c-format
+msgid "Unlock %s."
+msgstr "Ontsluit %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:411
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Voer u gebruikersnaam en wagwoord in om beskikbare drukkers op %s te sien."
+
+#: panels/printers/pp-new-printer-dialog.c:876
+msgid "Searching for Printers"
+msgstr "Soek tans vir drukkers"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1799
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1804
+msgid "Serial Port"
+msgstr "Seriepoort"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1811
+msgid "Parallel Port"
+msgstr "Parallelle poort"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1853
+#, c-format
+msgid "Location: %s"
+msgstr "Ligging: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1858
+#, c-format
+msgid "Address: %s"
+msgstr "Adres: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1887
+msgid "Server requires authentication"
+msgstr "Bediener nodig verifikasie"
+
+#: panels/printers/pp-options-dialog.c:83
+msgid "Two Sided"
+msgstr "Albei kante"
+
+#: panels/printers/pp-options-dialog.c:84
+msgid "Paper Type"
+msgstr "Papiertipe"
+
+#: panels/printers/pp-options-dialog.c:85
+msgid "Paper Source"
+msgstr "Papierbron"
+
+#: panels/printers/pp-options-dialog.c:86
+msgid "Output Tray"
+msgstr "Afvoerrakkie"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript-voor-filtrering"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:534
+msgid "Pages per side"
+msgstr "Bladsye per kant"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:546
+msgid "Two-sided"
+msgstr "Albei kante"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Algemeen"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Bladsyopstelling"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Installeerbare keuses"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Taak"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Beeldkwaliteit"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Kleur"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Afwerking"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:676
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Gevorderd"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:908
+msgid "Test page"
+msgstr "Toetsbladsy"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:76
+#: panels/printers/pp-ppd-option-widget.c:78
+#: panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "Kies outomaties"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:80
+#: panels/printers/pp-ppd-option-widget.c:82
+#: panels/printers/pp-ppd-option-widget.c:84
+#: panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "Drukker se verstek"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "Bed slegs GhostScript-lettertipes in"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "Skakel om na PS-vlak 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "Skakel om na PS-vlak 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "Geen filtrering vooraf nie"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "Vervaardiger"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:598 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr "Geen aktiewe take"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:603
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u Taak"
+msgstr[1] "%u Take"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:766
+msgid "Low on toner"
+msgstr "Poeierink is min"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:768
+msgid "Out of toner"
+msgstr "Poeierink is op"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:771
+msgid "Low on developer"
+msgstr "Ontwikkelingvloeistof is min"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:774
+msgid "Out of developer"
+msgstr "Ontwikkelingvloeistof is op"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:776
+msgid "Low on a marker supply"
+msgstr "Merkervoorraad is laag"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:778
+msgid "Out of a marker supply"
+msgstr "Merkervoorraad is klaar"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:780
+msgid "Open cover"
+msgstr "Open deksel"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:782
+msgid "Open door"
+msgstr "Oop deur"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:784
+msgid "Low on paper"
+msgstr "Papier is min"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:786
+msgid "Out of paper"
+msgstr "Papier is op"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:788
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Vanlyn"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:790
+#: panels/printers/pp-printer-entry.c:920
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Gestop"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:792
+msgid "Waste receptacle almost full"
+msgstr "Afvalhouer byna vol"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:794
+msgid "Waste receptacle full"
+msgstr "Afvalhouer vol"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:796
+msgid "The optical photo conductor is near end of life"
+msgstr "Die optiese fotogeleier is naby die einde van sy funksionele lewe"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:798
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Die optiese fotogeleier werk nie meer nie"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:906
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Gereed"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:911
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Aanvaar nie take nie"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:916
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Verwerk tans"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:940
+msgid "Clean print heads"
+msgstr "Maak drukkoppe skoon"
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr "Drukker Instellings"
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr "Drukker Besonderhede"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr "Gebruik as verstek drukker"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr "Maak drukkoppe skoon"
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "Verwyder drukker"
+
+#: panels/printers/printer-entry.ui:193
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr "Inkvlak"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:312
+msgid "Please restart when the problem is resolved."
+msgstr "Herbegin die toestel as die probleem opgelos is."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:319
+msgid "Restart"
+msgstr "Herbegin"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:20
+msgid "Add…"
+msgstr "Voeg by…"
+
+#: panels/printers/printers.ui:186
+msgid "No printers"
+msgstr "Geen drukkers nie"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:200
+msgid "Add a Printer…"
+msgstr "Voeg 'n drukker by…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:232
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"Jammer! Die stelsel se drukdiens blyk\n"
+"nie beskikbaar te wees nie."
+
+#: panels/privacy/cc-privacy-panel.c:387 panels/privacy/privacy.ui:280
+msgid "Screen Lock"
+msgstr "Skermslot"
+
+#: panels/privacy/cc-privacy-panel.c:438
+msgid "In use"
+msgstr "In gebruik"
+
+#: panels/privacy/cc-privacy-panel.c:443
+msgctxt "Location services status"
+msgid "On"
+msgstr "Aan"
+
+#: panels/privacy/cc-privacy-panel.c:444
+msgctxt "Location services status"
+msgid "Off"
+msgstr "Af"
+
+#: panels/privacy/cc-privacy-panel.c:823 panels/privacy/privacy.ui:745
+msgid "Location Services"
+msgstr "Liggingdienste"
+
+#: panels/privacy/cc-privacy-panel.c:946 panels/privacy/privacy.ui:127
+msgid "Usage & History"
+msgstr "Gebruik en geskiedenis"
+
+#: panels/privacy/cc-privacy-panel.c:1075
+msgid "Empty all items from Trash?"
+msgstr "Skrap alle items uit die asblik?"
+
+#: panels/privacy/cc-privacy-panel.c:1076
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Alle items in die asblik sal permanent geskrap word."
+
+#: panels/privacy/cc-privacy-panel.c:1077
+msgid "_Empty Trash"
+msgstr "Maak _asblik leeg"
+
+#: panels/privacy/cc-privacy-panel.c:1100
+msgid "Delete all the temporary files?"
+msgstr "Skrap alle tydelike lêers?"
+
+#: panels/privacy/cc-privacy-panel.c:1101
+msgid "All the temporary files will be permanently deleted."
+msgstr "Al die tydelike lêers sal permanent geskrap word."
+
+#: panels/privacy/cc-privacy-panel.c:1102
+msgid "_Purge Temporary Files"
+msgstr "Vee tydelike lêers _permanent uit"
+
+#: panels/privacy/cc-privacy-panel.c:1124 panels/privacy/privacy.ui:432
+msgid "Purge Trash & Temporary Files"
+msgstr "Permanente uitvee en tydelike lêers"
+
+#: panels/privacy/cc-privacy-panel.c:1164 panels/privacy/privacy.ui:637
+msgid "Software Usage"
+msgstr "Sagtewaregebruik"
+
+#: panels/privacy/cc-privacy-panel.c:1205 panels/privacy/privacy.ui:959
+msgid "Problem Reporting"
+msgstr "Probleemrapportering"
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: panels/privacy/cc-privacy-panel.c:1219
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+"Verslae oor tegniese probleme help ons om %s te verbeter. Verslae word "
+"anoniem gestuur en word gesuiwer van persoonlike data."
+
+#: panels/privacy/cc-privacy-panel.c:1231 panels/privacy/privacy.ui:719
+msgid "Privacy Policy"
+msgstr "Privaatheidbeleid"
+
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:3
+msgid "Privacy"
+msgstr "Privaatheid"
+
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
+msgid "Protect your personal information and control what others might see"
+msgstr "Beskerm persoonlike inligting en bepaal wat anders moontlik kan sien"
+
+#. FIXME
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:8
+msgid "preferences-system-privacy"
+msgstr ""
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"skerm;sluit;diagnose;privaat;onlangs;voorlopig;tmp;indeks;naam;netwerk;"
+"identiteit;"
+
+#: panels/privacy/privacy.ui:14
+msgid "Screen Turns Off"
+msgstr "Skerm afskakel"
+
+#: panels/privacy/privacy.ui:18
+msgid "30 seconds"
+msgstr "30 sekondes"
+
+#: panels/privacy/privacy.ui:60 panels/privacy/privacy.ui:106
+msgid "1 day"
+msgstr "1 dag"
+
+#: panels/privacy/privacy.ui:64
+msgid "2 days"
+msgstr "2 dae"
+
+#: panels/privacy/privacy.ui:68
+msgid "3 days"
+msgstr "3 dae"
+
+#: panels/privacy/privacy.ui:72
+msgid "4 days"
+msgstr "4 dae"
+
+#: panels/privacy/privacy.ui:76
+msgid "5 days"
+msgstr "5 dae"
+
+#: panels/privacy/privacy.ui:80
+msgid "6 days"
+msgstr "6 dae"
+
+#: panels/privacy/privacy.ui:84 panels/privacy/privacy.ui:110
+msgid "7 days"
+msgstr "7 dae"
+
+#: panels/privacy/privacy.ui:88
+msgid "14 days"
+msgstr "14 dae"
+
+#: panels/privacy/privacy.ui:92 panels/privacy/privacy.ui:114
+msgid "30 days"
+msgstr "30 dae"
+
+#: panels/privacy/privacy.ui:118
+msgid "Forever"
+msgstr "Permanent"
+
+#: panels/privacy/privacy.ui:148
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"Deur geskiedenis te onthou, kan dinge makliker weer gevind word. Hierdie "
+"items word nooit oor die netwerk gedeel nie."
+
+#: panels/privacy/privacy.ui:176
+msgid "_Recently Used"
+msgstr "_Onlangs gebruik"
+
+#: panels/privacy/privacy.ui:207
+msgid "Retain _History"
+msgstr "Behou _geskiedenis"
+
+#: panels/privacy/privacy.ui:247
+msgid "Cl_ear Recent History"
+msgstr "_Maak onlangse geskiedenis skoon"
+
+#: panels/privacy/privacy.ui:301
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "Die skermslot beskerm u privaatheid wanneer u weg is."
+
+#: panels/privacy/privacy.ui:328
+msgid "Automatic Screen _Lock"
+msgstr "_Outomatiese skermslot"
+
+#: panels/privacy/privacy.ui:362
+msgid "Lock screen _after blank for"
+msgstr "S_luit skerm ná"
+
+#: panels/privacy/privacy.ui:394
+msgid "Show _Notifications"
+msgstr "Wys ke_nnisgewings"
+
+#: panels/privacy/privacy.ui:454
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"Maak outomaties die asblik en tydelike lêers permanent skoon om die rekenaar "
+"vry te hou van onnodige sensitiewe inligting."
+
+#: panels/privacy/privacy.ui:483
+msgid "Automatically empty _Trash"
+msgstr "_Maak asblik outomaties leeg"
+
+#: panels/privacy/privacy.ui:515
+msgid "Automatically purge Temporary _Files"
+msgstr "_Vee tydelike lêers outomaties permanent uit"
+
+#: panels/privacy/privacy.ui:546
+msgid "Purge _After"
+msgstr "Vee permament uit n_a"
+
+#: panels/privacy/privacy.ui:590
+msgid "_Empty Trash…"
+msgstr "Maak _asblik leeg…"
+
+#: panels/privacy/privacy.ui:606
+msgid "_Purge Temporary Files…"
+msgstr "Vee tydelike lêers _permanent uit…"
+
+#: panels/privacy/privacy.ui:654
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"Inligting wat u stuur oor watter sagteware u gebruik, help ons om meer "
+"akkurate voorstelle te maak. Dit help ook om ons sagteware te verbeter.\n"
+"\n"
+"Al die inligting wat ons versamel word anoniem gemaak, en ons sal nooit u "
+"data deel met derde partye nie."
+
+#: panels/privacy/privacy.ui:681
+msgid "_Send software usage statistics"
+msgstr "_Stuur statistiek oor sagtewaregebruik"
+
+#: panels/privacy/privacy.ui:764
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"Liggingdienste laat programme toe om jou ligging te weet. Die gebruik van Wi-"
+"Fi en mobiele breëband verhoog akkuraatheid."
+
+#: panels/privacy/privacy.ui:778
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+
+#: panels/privacy/privacy.ui:828
+msgid "_Location Services"
+msgstr "_Liggingdienste"
+
+#: panels/privacy/privacy.ui:1026
+msgid "_Automatic Problem Reporting"
+msgstr "Outom_atiese probleemrapportering"
+
+#: panels/region/cc-format-chooser.c:118
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Brits"
+
+#: panels/region/cc-format-chooser.c:120
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metriek"
+
+#: panels/region/cc-format-chooser.c:285
+msgid "No regions found"
+msgstr "Geen streke gevind nie"
+
+#: panels/region/cc-input-chooser.c:182
+msgid "No input sources found"
+msgstr "Geen toevoerbronne gevind nie"
+
+#: panels/region/cc-input-chooser.c:1012
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Ander"
+
+#: panels/region/cc-region-panel.c:881
+msgid "No input source selected"
+msgstr "Geen toevoerbronne gekies nie"
+
+#: panels/region/cc-region-panel.c:1773
+msgid "Login _Screen"
+msgstr "Aanmeld_skerm"
+
+#: panels/region/format-chooser.ui:7
+msgid "Formats"
+msgstr "Formate"
+
+#: panels/region/format-chooser.ui:120
+msgid "Preview"
+msgstr "Voorskou"
+
+#: panels/region/format-chooser.ui:137
+msgid "Dates"
+msgstr "Datums"
+
+#: panels/region/format-chooser.ui:168
+msgid "Times"
+msgstr "Tye"
+
+#: panels/region/format-chooser.ui:199
+msgid "Dates & Times"
+msgstr "Datum en Tyd"
+
+#: panels/region/format-chooser.ui:230
+msgid "Numbers"
+msgstr "Getalle"
+
+#: panels/region/format-chooser.ui:247
+msgid "Measurement"
+msgstr "Mates"
+
+#: panels/region/format-chooser.ui:264
+msgid "Paper"
+msgstr "Papier"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "Re­gion & Lan­guage"
+msgid "Region & Language"
+msgstr "Streek en Taal"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr "Kies die vertoontaal, formate, sleutelborduitlegte en toevoerbronne"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/region/gnome-region-panel.desktop.in.in:7
+msgid "preferences-desktop-locale"
+msgstr ""
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "taal;uitleg;sleutelbord;toevoer;"
+
+#: panels/region/input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Voeg 'n toevoerbron by"
+
+#: panels/region/input-chooser.ui:76
+msgid "Input methods can’t be used on the login screen"
+msgstr "Toevoermetodes kan nie gebruik word op die aanmeldskerm nie"
+
+#: panels/region/input-options.ui:7
+msgid "Input Source Options"
+msgstr "Keuses vir toevoerbronne"
+
+#: panels/region/input-options.ui:27
+msgid "Use the _same source for all windows"
+msgstr "Gebruik die _selfde bron vir alle vensters"
+
+#: panels/region/input-options.ui:45
+msgid "Allow _different sources for each window"
+msgstr "_Laat verskillende uitlegte in elke venster toe"
+
+#: panels/region/input-options.ui:85
+msgid "Switch to previous source"
+msgstr "Skakel na vorige bron"
+
+#: panels/region/input-options.ui:102
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Spasie"
+
+#: panels/region/input-options.ui:116
+msgid "Switch to next source"
+msgstr "Skakel na volgende bron"
+
+#: panels/region/input-options.ui:133
+msgid "Super+Space"
+msgstr "Super+Spasie"
+
+#: panels/region/input-options.ui:147
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "Verander gerus dié kortpaaie in sleutelbordinstellings"
+
+#: panels/region/input-options.ui:164
+msgid "Alternative switch to next source"
+msgstr "Alternatiewe skakelaar na volgende bron"
+
+#: panels/region/input-options.ui:181
+msgid "Left+Right Alt"
+msgstr "Linker+Regter Alt"
+
+#: panels/region/region.ui:67
+#: panels/user-accounts/data/user-accounts-dialog.ui:348
+msgid "_Language"
+msgstr "_Taal"
+
+#: panels/region/region.ui:85
+msgid "English (United Kingdom)"
+msgstr "Engels (Verenigde Koninkryk)"
+
+#: panels/region/region.ui:112
+msgid "Restart the session for changes to take effect"
+msgstr "Die sessie moet herbegin word sodat veranderinge kan neerslag vind"
+
+#: panels/region/region.ui:134
+msgid "Restart…"
+msgstr "Herbegin…"
+
+#: panels/region/region.ui:169
+msgid "_Formats"
+msgstr "_Formate"
+
+#: panels/region/region.ui:187
+msgid "United Kingdom"
+msgstr "Verenigde Koninkryk"
+
+#: panels/region/region.ui:229
+msgid "Input Sources"
+msgstr "Toevoerbronne"
+
+#: panels/region/region.ui:245
+msgid "_Options"
+msgstr "_Keuses"
+
+#: panels/region/region.ui:311
+msgid "Add input source"
+msgstr "Voeg toevoerbron by"
+
+#: panels/region/region.ui:336
+msgid "Remove input source"
+msgstr "Verwyder toevoerbron"
+
+#: panels/region/region.ui:386
+msgid "Move input source up"
+msgstr "Skuif toevoerbron op"
+
+#: panels/region/region.ui:411
+msgid "Move input source down"
+msgstr "Skuif toevoerbron af"
+
+#: panels/region/region.ui:461
+msgid "Configure input source"
+msgstr "Stel toevoerbron op"
+
+#: panels/region/region.ui:486
+msgid "Show input source keyboard layout"
+msgstr "Wys sleutelborduitleg van toevoerbron"
+
+#: panels/region/region.ui:530
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"Aanmeldinstellings word deur alle gebruikers gebruik wanneer hulle by die "
+"stelsel aanmeld"
+
+#: panels/search/cc-search-locations-dialog.c:639
+msgid "Select Location"
+msgstr "Kies ligging"
+
+#: panels/search/cc-search-locations-dialog.c:643
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-panel.c:178
+msgid "No applications found"
+msgstr "Geen toepassings gevind nie"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "Kies watter programme soekresultate wys in die Aktiwiteitoorsig"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/search/gnome-search-panel.desktop.in.in:7
+msgid "preferences-system-search"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "soek;vind;indeks;versteek;privaatheid;resultate;"
+
+#: panels/search/search-locations-dialog.ui:9
+msgid "Search Locations"
+msgstr "Soekliggings"
+
+#: panels/search/search-locations-dialog.ui:43
+msgid "Places"
+msgstr "Plekke"
+
+#: panels/search/search-locations-dialog.ui:73
+msgid "Bookmarks"
+msgstr "Boekmerke"
+
+#: panels/search/search-locations-dialog.ui:130
+msgid "Other"
+msgstr "Ander"
+
+#: panels/search/search.ui:66
+msgid "Move Up"
+msgstr "Skuif op"
+
+#: panels/search/search.ui:83
+msgid "Move Down"
+msgstr "Skuif af"
+
+#: panels/search/search.ui:119
+msgid "Preferences"
+msgstr "Voorkeure"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:305
+msgid "No networks selected for sharing"
+msgstr "Geen netwerke gekies vir deling nie"
+
+#: panels/sharing/cc-sharing-panel.c:275
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Aan"
+
+#: panels/sharing/cc-sharing-panel.c:277 panels/sharing/cc-sharing-panel.c:304
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Af"
+
+#: panels/sharing/cc-sharing-panel.c:307
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Geaktiveer"
+
+#: panels/sharing/cc-sharing-panel.c:310
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktief"
+
+#: panels/sharing/cc-sharing-panel.c:381
+msgid "Choose a Folder"
+msgstr "Kies 'n gids"
+
+#: panels/sharing/cc-sharing-panel.c:693
+#, fuzzy, c-format
+#| msgid ""
+#| "Personal File Sharing allows you to share your Public folder with others "
+#| "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"Persoonlike lêerdeling maak dit moontlik om die Publiek-gids te deel met "
+"ander op die huidige netwerk m.b.v: <a href=\"dav://%s\">dav://%s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:695
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"Wanneer afgeleë toegang geaktiveer is kan afgeleë gebruikers koppel met die "
+"Secure Shell-opdrag:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:697
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"Laat afgeleë gebruikers toe om die skerm te sien of te beheer deur te koppel "
+"aan: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:809
+msgid "Copy"
+msgstr "Kopieer"
+
+#: panels/sharing/cc-sharing-panel.c:1236
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Deling"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Kies wat om te deel met ander"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:7
+msgid "preferences-system-sharing"
+msgstr ""
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"deel;deling;ssh;gasheer;naam;afgeleë;werkskerm;media;klank;video;prente;"
+"fotos;flieks;bediener;"
+
+#: panels/sharing/networks.ui:19
+msgid "Networks"
+msgstr "Netwerke"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Aktiveer of deaktiveer afgeleë aanmelding"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Verifikasie is nodig om afgeleë aanmelding aan of af te skakel"
+
+#: panels/sharing/sharing.ui:46
+msgid "_Computer Name"
+msgstr "_Rekenaarnaam"
+
+#: panels/sharing/sharing.ui:104
+msgid "_File Sharing"
+msgstr "_Lêerdeling"
+
+#: panels/sharing/sharing.ui:147
+msgid "_Screen Sharing"
+msgstr "_Skermdeling"
+
+#: panels/sharing/sharing.ui:190
+msgid "_Media Sharing"
+msgstr "_Mediadeling"
+
+#: panels/sharing/sharing.ui:233
+msgid "_Remote Login"
+msgstr "A_fgeleë aanmelding"
+
+#: panels/sharing/sharing.ui:272
+msgid "Some services are disabled because of no network access."
+msgstr "Sommige dienste is gedeaktiveer weens 'n gebrek aan netwerktoegang."
+
+#: panels/sharing/sharing.ui:286 panels/sharing/sharing.ui:413
+msgid "File Sharing"
+msgstr "Lêerdeling"
+
+#: panels/sharing/sharing.ui:333
+msgid "_Require Password"
+msgstr "Ve_reis wagwoord"
+
+#: panels/sharing/sharing.ui:424 panels/sharing/sharing.ui:496
+msgid "Remote Login"
+msgstr "Afgeleë aanmelding"
+
+#: panels/sharing/sharing.ui:519 panels/sharing/sharing.ui:765
+msgid "Screen Sharing"
+msgstr "Skermdeling"
+
+#: panels/sharing/sharing.ui:577
+msgid "_Allow connections to control the screen"
+msgstr "_Laat verbindings toe om die skerm te beheer"
+
+#: panels/sharing/sharing.ui:622
+msgid "_Password:"
+msgstr "_Wagwoord:"
+
+#: panels/sharing/sharing.ui:652
+msgid "_Show Password"
+msgstr "Wy_s wagwoord"
+
+#: panels/sharing/sharing.ui:683
+msgid "Access Options"
+msgstr "Toegangskeuses"
+
+#: panels/sharing/sharing.ui:697
+msgid "_New connections must ask for access"
+msgstr "_Nuwe verbindings moet vra vir toegang"
+
+#: panels/sharing/sharing.ui:715
+msgid "_Require a password"
+msgstr "Ve_reis 'n wagwoord"
+
+#: panels/sharing/sharing.ui:776 panels/sharing/sharing.ui:870
+msgid "Media Sharing"
+msgstr "Mediadeling"
+
+#: panels/sharing/sharing.ui:809
+msgid "Share music, photos and videos over the network."
+msgstr "Deel musiek, foto's en video's oor die netwerk."
+
+#: panels/sharing/sharing.ui:824
+msgid "Folders"
+msgstr "Gidse"
+
+#: panels/sound/data/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Klank"
+
+#: panels/sound/data/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Verander klankvolume, toevoer, afvoer en kennisgewingklanke"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/sound/data/gnome-sound-panel.desktop.in.in:7
+msgid "multimedia-volume-control"
+msgstr ""
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/data/gnome-sound-panel.desktop.in.in:20
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "kaart;mikrofoon;volume;doof;balans;bluetooth;kopstuk;klank;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:6
+msgid "Bark"
+msgstr "Blaf"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:12
+msgid "Drip"
+msgstr "Drup"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:18
+msgid "Glass"
+msgstr "Glas"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:24
+msgid "Sonar"
+msgstr "Sonar"
+
+#: panels/sound/gvc-balance-bar.c:104
+msgctxt "balance"
+msgid "Left"
+msgstr "Links"
+
+#: panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Right"
+msgstr "Regs"
+
+#: panels/sound/gvc-balance-bar.c:108
+msgctxt "balance"
+msgid "Rear"
+msgstr "Agter"
+
+#: panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Front"
+msgstr "Voor"
+
+#: panels/sound/gvc-balance-bar.c:112
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Minimum"
+
+#: panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Maksimum"
+
+#: panels/sound/gvc-balance-bar.c:288
+msgid "_Balance:"
+msgstr "_Balans:"
+
+#: panels/sound/gvc-balance-bar.c:291
+msgid "_Fade:"
+msgstr "Doo_f:"
+
+#: panels/sound/gvc-balance-bar.c:294
+msgid "_Subwoofer:"
+msgstr "_Basluidspreker:"
+
+#: panels/sound/gvc-channel-bar.c:610 panels/sound/gvc-channel-bar.c:619
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gvc-channel-bar.c:614
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Onversterk"
+
+#: panels/sound/gvc-combo-box.c:166 panels/sound/gvc-mixer-dialog.c:253
+#: panels/sound/gvc-mixer-dialog.c:520
+msgid "_Profile:"
+msgstr "_Profiel:"
+
+#: panels/sound/gvc-mixer-dialog.c:255
+msgid "_Test Speakers"
+msgstr "_Toets luidsprekers"
+
+#: panels/sound/gvc-mixer-dialog.c:424
+msgid "Peak detect"
+msgstr "Spitsbespeuring"
+
+#: panels/sound/gvc-mixer-dialog.c:1499
+msgid "Device"
+msgstr "Toestel"
+
+#: panels/sound/gvc-mixer-dialog.c:1562
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "Luidsprekertoets vir %s"
+
+#: panels/sound/gvc-mixer-dialog.c:1617
+msgid "_Output volume:"
+msgstr "_Afvoervolume:"
+
+#: panels/sound/gvc-mixer-dialog.c:1631
+msgid "Output"
+msgstr "Afvoer"
+
+#: panels/sound/gvc-mixer-dialog.c:1636
+msgid "C_hoose a device for sound output:"
+msgstr "_Kies 'n toestel vir klankafvoer:"
+
+#: panels/sound/gvc-mixer-dialog.c:1658
+msgid "Settings for the selected device:"
+msgstr "Instellings vir die gekose toestel:"
+
+#: panels/sound/gvc-mixer-dialog.c:1669
+msgid "Input"
+msgstr "Toevoer"
+
+#: panels/sound/gvc-mixer-dialog.c:1676
+msgid "_Input volume:"
+msgstr "_Toevoervolume:"
+
+#: panels/sound/gvc-mixer-dialog.c:1697
+msgid "Input level:"
+msgstr "Toevoervlak:"
+
+#: panels/sound/gvc-mixer-dialog.c:1723
+msgid "C_hoose a device for sound input:"
+msgstr "_Kies 'n toestel vir klanktoevoer:"
+
+#: panels/sound/gvc-mixer-dialog.c:1747
+msgid "Sound Effects"
+msgstr "Klankeffekte"
+
+#: panels/sound/gvc-mixer-dialog.c:1754
+msgid "_Alert volume:"
+msgstr "W_aarskuwingvolume:"
+
+#: panels/sound/gvc-mixer-dialog.c:1775
+msgid "No application is currently playing or recording audio."
+msgstr "Geen toepassing wat tans oudio speel of opneem nie."
+
+#: panels/sound/gvc-sound-theme-chooser.c:187
+msgid "Built-in"
+msgstr "Ingebou"
+
+#: panels/sound/gvc-sound-theme-chooser.c:446
+#: panels/sound/gvc-sound-theme-chooser.c:458
+#: panels/sound/gvc-sound-theme-chooser.c:470
+msgid "Sound Preferences"
+msgstr "Klankvoorkeure"
+
+#: panels/sound/gvc-sound-theme-chooser.c:449
+#: panels/sound/gvc-sound-theme-chooser.c:460
+#: panels/sound/gvc-sound-theme-chooser.c:472
+msgid "Testing event sound"
+msgstr "Toets tans gebeurtenisklank"
+
+#: panels/sound/gvc-sound-theme-chooser.c:544
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "Verstek"
+
+#: panels/sound/gvc-sound-theme-chooser.c:545
+msgid "From theme"
+msgstr "Vanaf tema"
+
+#: panels/sound/gvc-sound-theme-chooser.c:720
+msgid "C_hoose an alert sound:"
+msgstr "_Kies 'n waarskuwingklank:"
+
+#: panels/sound/gvc-speaker-test.c:229
+msgid "Stop"
+msgstr "Stop"
+
+#: panels/sound/gvc-speaker-test.c:229 panels/sound/gvc-speaker-test.c:341
+msgid "Test"
+msgstr "Toets"
+
+#: panels/sound/gvc-speaker-test.c:237
+msgid "Subwoofer"
+msgstr "Basluidspreker"
+
+#: panels/sound/sound-theme-file-utils.c:288
+msgid "Custom"
+msgstr "Doelgemaak"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:353
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Verstek"
+
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Medium"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Groot"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Groter"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Grootste"
+
+#: panels/universal-access/cc-ua-panel.c:369
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d beeldpunt"
+msgstr[1] "%d beeldpunte"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Maak sien, hoor, tik, wys en klik makliker"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:7
+msgid "preferences-desktop-accessibility"
+msgstr ""
+
+#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+msgstr ""
+"sleutelbord;muis;a11y;toeganklikheid;kontras;zoem;skerm;leser;teks;"
+"lettertipe;grootte;accessx;kleefsleutels;stadige;sleutels;bons;dubbel;klik;"
+"vertraag;help;herhaal;flikker;"
+
+#: panels/universal-access/uap.ui:89
+msgid "_Always Show Universal Access Menu"
+msgstr "Wys _altyd die kieslys vir universele toegang"
+
+#: panels/universal-access/uap.ui:131
+msgid "Seeing"
+msgstr "Sien"
+
+#: panels/universal-access/uap.ui:177
+msgid "_High Contrast"
+msgstr "_Hoë kontras"
+
+#: panels/universal-access/uap.ui:224
+msgid "_Large Text"
+msgstr "_Groot teks"
+
+#: panels/universal-access/uap.ui:269
+msgid "C_ursor Size"
+msgstr "_Wysergrootte"
+
+#: panels/universal-access/uap.ui:316
+#: panels/universal-access/zoom-options.ui:98
+msgid "_Zoom"
+msgstr "_Zoem"
+
+#: panels/universal-access/uap.ui:362
+msgid "Screen _Reader"
+msgstr "Ske_rmleser"
+
+#: panels/universal-access/uap.ui:408 panels/universal-access/uap.ui:1237
+msgid "_Sound Keys"
+msgstr "Klank_sleutels"
+
+#: panels/universal-access/uap.ui:470
+msgid "Hearing"
+msgstr "Hoor"
+
+#: panels/universal-access/uap.ui:514 panels/universal-access/uap.ui:1340
+msgid "_Visual Alerts"
+msgstr "_Visuele waarskuwings"
+
+#: panels/universal-access/uap.ui:622
+msgid "Screen _Keyboard"
+msgstr "S_kermsleutelbord"
+
+#: panels/universal-access/uap.ui:667
+msgid "R_epeat Keys"
+msgstr "H_erhaalsleutels"
+
+#: panels/universal-access/uap.ui:713
+msgid "Cursor _Blinking"
+msgstr "Wyser _flikker"
+
+#: panels/universal-access/uap.ui:759
+msgid "_Typing Assist (AccessX)"
+msgstr "_Tik-assistent (AccessX)"
+
+#: panels/universal-access/uap.ui:820
+msgid "Pointing & Clicking"
+msgstr "Wys en klik"
+
+#: panels/universal-access/uap.ui:866
+msgid "_Mouse Keys"
+msgstr "_Muissleutels"
+
+#: panels/universal-access/uap.ui:911
+msgid "_Click Assist"
+msgstr "_Klik-assistent"
+
+#: panels/universal-access/uap.ui:957
+msgid "_Double-Click Delay"
+msgstr "Wagtyd vir _dubbelklik"
+
+#: panels/universal-access/uap.ui:977
+msgid "Double-Click Delay"
+msgstr "Wagtyd vir dubbelklik"
+
+#: panels/universal-access/uap.ui:1042
+msgid "Cursor Size"
+msgstr "Wysergrootte"
+
+#: panels/universal-access/uap.ui:1069
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Muis grootte kan gekombineer word met die zoem funksie om dit makliker te "
+"maak om te sien."
+
+#: panels/universal-access/uap.ui:1105
+msgid "Screen Reader"
+msgstr "Skermleser"
+
+#: panels/universal-access/uap.ui:1122
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Die skermleser lees die vertoonde teks soos die fokus verskuif."
+
+#: panels/universal-access/uap.ui:1155
+msgid "_Screen Reader"
+msgstr "_Skermleser"
+
+#: panels/universal-access/uap.ui:1194
+msgid "Sound Keys"
+msgstr "Klanksleutels"
+
+#: panels/universal-access/uap.ui:1212
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Biep wanneer Caps- of NumLock aan of af geskakel word."
+
+#: panels/universal-access/uap.ui:1282
+msgid "Visual Alerts"
+msgstr "Visuele waarskuwings"
+
+#: panels/universal-access/uap.ui:1286
+msgid "_Test flash"
+msgstr "_Toets flits"
+
+#: panels/universal-access/uap.ui:1315
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+"Gebruik 'n visuele aanduiding wanneer 'n waarskuwingklank gespeel word."
+
+#: panels/universal-access/uap.ui:1366
+msgid "Flash the _window title"
+msgstr "Flits die _venstertitel"
+
+#: panels/universal-access/uap.ui:1384
+msgid "Flash the entire _screen"
+msgstr "Flits die _hele skerm"
+
+#: panels/universal-access/uap.ui:1429
+msgid "Repeat Keys"
+msgstr "Herhaalsleutels"
+
+#: panels/universal-access/uap.ui:1459
+msgid "Key presses repeat when key is held down."
+msgstr "Sleuteldrukke herhaal wanneer sleutel ingehou word."
+
+#: panels/universal-access/uap.ui:1539
+msgid "Repeat keys delay"
+msgstr "Wagtyd vir herhaalsleutels"
+
+#: panels/universal-access/uap.ui:1587 panels/universal-access/uap.ui:1722
+msgid "Speed"
+msgstr "Spoed"
+
+#: panels/universal-access/uap.ui:1626
+msgid "Repeat keys speed"
+msgstr "Herhaalsleutelspoed"
+
+#: panels/universal-access/uap.ui:1650
+msgid "Cursor Blinking"
+msgstr "Wyser flikker"
+
+#: panels/universal-access/uap.ui:1680
+msgid "Cursor blinks in text fields."
+msgstr "Wyser flikker in teksvelde."
+
+#: panels/universal-access/uap.ui:1759
+msgid "Cursor blinking speed"
+msgstr "Wyser se flikkerspoed"
+
+#: panels/universal-access/uap.ui:1795
+msgid "Typing Assist"
+msgstr "Tik-assistent"
+
+#: panels/universal-access/uap.ui:1834
+msgid "_Sticky Keys"
+msgstr "_Kleefsleutels"
+
+#: panels/universal-access/uap.ui:1851
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Hanteer opeenvolgende wysigersleutels as 'n sleutelkombinasie"
+
+#: panels/universal-access/uap.ui:1875
+msgid "_Disable if two keys are pressed together"
+msgstr "_Deaktiveer indien twee sleutels gelyktydig gedruk word"
+
+#: panels/universal-access/uap.ui:1893
+msgid "Beep when a _modifier key is pressed"
+msgstr "Biep wanneer 'n _wysigsleutel gedruk word"
+
+#: panels/universal-access/uap.ui:1941
+msgid "S_low Keys"
+msgstr "Stadige s_leutels"
+
+#: panels/universal-access/uap.ui:1958
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Wag 'n rukkie tussen wanneer 'n sleutel gedruk word en wanneer dit aanvaar "
+"word"
+
+#: panels/universal-access/uap.ui:1991 panels/universal-access/uap.ui:2204
+#: panels/universal-access/uap.ui:2541
+msgid "A_cceptance delay:"
+msgstr "Wagtyd _voor aanvaarding:"
+
+#: panels/universal-access/uap.ui:2013
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/uap.ui:2032
+msgid "Slow keys typing delay"
+msgstr "Stadige sleutels se tikwagtyd"
+
+#: panels/universal-access/uap.ui:2047
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lank"
+
+#: panels/universal-access/uap.ui:2074
+msgid "Beep when a key is pr_essed"
+msgstr "Bi_ep as 'n sleutel gedruk word"
+
+#: panels/universal-access/uap.ui:2091
+msgid "Beep when a key is _accepted"
+msgstr "Biep as 'n sleutel _aanvaar word"
+
+#: panels/universal-access/uap.ui:2108 panels/universal-access/uap.ui:2287
+msgid "Beep when a key is _rejected"
+msgstr "Biep as 'n sleutel ve_rwerp word"
+
+#: panels/universal-access/uap.ui:2154
+msgid "_Bounce Keys"
+msgstr "_Bonssleutels"
+
+#: panels/universal-access/uap.ui:2171
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignoreer duplikaatsleutels kort na mekaar"
+
+#: panels/universal-access/uap.ui:2226
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/uap.ui:2245
+msgid "Bounce keys typing delay"
+msgstr "Bonssleutels se tikwagtyd"
+
+#: panels/universal-access/uap.ui:2260
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lank"
+
+#: panels/universal-access/uap.ui:2373
+msgid "_Enable by Keyboard"
+msgstr "_Aktiveer met sleutelbord"
+
+#: panels/universal-access/uap.ui:2390
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Skakel toeganklikheidfunksies aan en af met die sleutelbord"
+
+#: panels/universal-access/uap.ui:2454
+msgid "Click Assist"
+msgstr "Klik-assistent"
+
+#: panels/universal-access/uap.ui:2490
+msgid "_Simulated Secondary Click"
+msgstr "Ge_simuleerder sekondêre klik"
+
+#: panels/universal-access/uap.ui:2508
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Doen 'n sekondêre klik deur die primêre knoppie in te hou"
+
+#: panels/universal-access/uap.ui:2562
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/uap.ui:2581
+msgid "Secondary click delay"
+msgstr "Sekondêre klikwagtyd"
+
+#: panels/universal-access/uap.ui:2596
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lank"
+
+#: panels/universal-access/uap.ui:2653
+msgid "_Hover Click"
+msgstr "Swee_fklik"
+
+#: panels/universal-access/uap.ui:2671
+msgid "Trigger a click when the pointer hovers"
+msgstr "Registreer 'n klik wanneer die muiswyser sweef"
+
+#: panels/universal-access/uap.ui:2704
+msgid "D_elay:"
+msgstr "V_ertraging:"
+
+#: panels/universal-access/uap.ui:2726
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/uap.ui:2757
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lank"
+
+#: panels/universal-access/uap.ui:2793
+msgid "Motion _threshold:"
+msgstr "_Bewegingsdrempel:"
+
+#: panels/universal-access/uap.ui:2815
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Klein"
+
+#: panels/universal-access/uap.ui:2846
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Groot"
+
+#: panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼-skerm"
+
+#: panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½-skerm"
+
+#: panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾-skerm"
+
+#: panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "Lank"
+
+#: panels/universal-access/zoom-options.ui:48
+msgid "Full Screen"
+msgstr "Volskerm"
+
+#: panels/universal-access/zoom-options.ui:53
+msgid "Top Half"
+msgstr "Boonste helfte"
+
+#: panels/universal-access/zoom-options.ui:58
+msgid "Bottom Half"
+msgstr "Onderste helfte"
+
+#: panels/universal-access/zoom-options.ui:63
+msgid "Left Half"
+msgstr "Linkerhelfte"
+
+#: panels/universal-access/zoom-options.ui:68
+msgid "Right Half"
+msgstr "Regterhelfte"
+
+#: panels/universal-access/zoom-options.ui:77
+msgid "Zoom Options"
+msgstr "Zoemkeuses"
+
+#: panels/universal-access/zoom-options.ui:186
+msgid "_Magnification:"
+msgstr "_Vergroting:"
+
+#: panels/universal-access/zoom-options.ui:250
+msgid "_Follow mouse cursor"
+msgstr "_Volg die muiswyser"
+
+#: panels/universal-access/zoom-options.ui:270
+msgid "_Screen part:"
+msgstr "_Skermgedeelte:"
+
+#: panels/universal-access/zoom-options.ui:332
+msgid "Magnifier _extends outside of screen"
+msgstr "V_ergrootglas gaan verby die skerm"
+
+#: panels/universal-access/zoom-options.ui:351
+msgid "_Keep magnifier cursor centered"
+msgstr "_Hou vergrootglas se wyser in die middel"
+
+#: panels/universal-access/zoom-options.ui:370
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Vergrootglas se wyser s_kuif die inhoud rond"
+
+#: panels/universal-access/zoom-options.ui:389
+msgid "Magnifier cursor moves with _contents"
+msgstr "Vergrootglas se wyser skuif saam met i_nhoud"
+
+#: panels/universal-access/zoom-options.ui:423
+msgid "Magnifier Position:"
+msgstr "Vergrootglas se ligging:"
+
+#: panels/universal-access/zoom-options.ui:444
+msgid "Magnifier"
+msgstr "Vergrootglas"
+
+#: panels/universal-access/zoom-options.ui:490
+msgid "_Thickness:"
+msgstr "_Dikte:"
+
+#: panels/universal-access/zoom-options.ui:516
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Dun"
+
+#: panels/universal-access/zoom-options.ui:548
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Dik"
+
+#: panels/universal-access/zoom-options.ui:574
+msgid "_Length:"
+msgstr "_Lengte:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/zoom-options.ui:626
+msgid "Co_lor:"
+msgstr "K_leur:"
+
+#: panels/universal-access/zoom-options.ui:690
+msgid "_Crosshairs:"
+msgstr "_Kruisdraadjies:"
+
+#: panels/universal-access/zoom-options.ui:741
+msgid "_Overlaps mouse cursor"
+msgstr "B_o-oor die muiswyser"
+
+#: panels/universal-access/zoom-options.ui:779
+msgid "Crosshairs"
+msgstr "Kruisdraadjies"
+
+#: panels/universal-access/zoom-options.ui:827
+msgid "_White on black:"
+msgstr "_Wit op swart:"
+
+#: panels/universal-access/zoom-options.ui:850
+msgid "_Brightness:"
+msgstr "_Helderheid:"
+
+#: panels/universal-access/zoom-options.ui:874
+msgid "_Contrast:"
+msgstr "_Kontras:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/zoom-options.ui:897
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "K_leur"
+
+#: panels/universal-access/zoom-options.ui:925
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Geen"
+
+#: panels/universal-access/zoom-options.ui:957
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Vol"
+
+#: panels/universal-access/zoom-options.ui:1023
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Donker"
+
+#: panels/universal-access/zoom-options.ui:1056
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Helder"
+
+#: panels/universal-access/zoom-options.ui:1087
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Laag"
+
+#: panels/universal-access/zoom-options.ui:1120
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Hoog"
+
+#: panels/universal-access/zoom-options.ui:1156
+msgid "Color Effects:"
+msgstr "Klankeffekte:"
+
+#: panels/universal-access/zoom-options.ui:1181
+msgid "Color Effects"
+msgstr "Kleureffekte"
+
+#: panels/user-accounts/data/account-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "Voeg gebruiker by"
+
+#: panels/user-accounts/data/account-dialog.ui:171
+msgid "_Full Name"
+msgstr "_Volle naam"
+
+#: panels/user-accounts/data/account-dialog.ui:197
+#: panels/user-accounts/data/user-accounts-dialog.ui:146
+msgid "Standard"
+msgstr "Standaard"
+
+#: panels/user-accounts/data/account-dialog.ui:207
+#: panels/user-accounts/data/user-accounts-dialog.ui:155
+msgid "Administrator"
+msgstr "Administrateur"
+
+#: panels/user-accounts/data/account-dialog.ui:223
+#: panels/user-accounts/data/user-accounts-dialog.ui:173
+msgid "Account _Type"
+msgstr "Rekening_tipe"
+
+#: panels/user-accounts/data/account-dialog.ui:260
+msgid "Allow user to set a password when they next _login"
+msgstr "_Laat gebruiker toe om 'n wagwoord in te stel met volgende aanmelding"
+
+#: panels/user-accounts/data/account-dialog.ui:274
+msgid "Set a password _now"
+msgstr "Stel 'n wagwoord _nou in"
+
+#: panels/user-accounts/data/account-dialog.ui:387
+msgid "_Confirm"
+msgstr "_Bevestig"
+
+#: panels/user-accounts/data/account-dialog.ui:463
+#: panels/user-accounts/data/account-dialog.ui:667
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Onderneming-aanmelding maak dat 'n bestaande, sentraal bestuurde "
+"gebruikerrekening op dié toestel gebruik kan word. U kan ook die rekening "
+"gebruik om toegang tot maatskapy hulpbronne op die internet te kry."
+
+#: panels/user-accounts/data/account-dialog.ui:485
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "_Domein"
+
+#: panels/user-accounts/data/account-dialog.ui:707
+msgid "You are Offline"
+msgstr "Jy is vanlyn af"
+
+#: panels/user-accounts/data/account-dialog.ui:726
+msgid "You must be online in order to add enterprise users."
+msgstr "Jy moet aanlyn wees om onderneming-gebruikers by te voeg."
+
+#: panels/user-accounts/data/account-dialog.ui:760
+msgid "_Enterprise Login"
+msgstr "_Onderneming-aanmelding"
+
+#: panels/user-accounts/data/account-fingerprint.ui:12
+msgid "Left thumb"
+msgstr "Linkerduim"
+
+#: panels/user-accounts/data/account-fingerprint.ui:15
+msgid "Left middle finger"
+msgstr "Linkermiddelvinger"
+
+#: panels/user-accounts/data/account-fingerprint.ui:18
+msgid "Left ring finger"
+msgstr "Linkerringvinger"
+
+#: panels/user-accounts/data/account-fingerprint.ui:21
+msgid "Left little finger"
+msgstr "Linkerpinkie"
+
+#: panels/user-accounts/data/account-fingerprint.ui:24
+msgid "Right thumb"
+msgstr "Regterduim"
+
+#: panels/user-accounts/data/account-fingerprint.ui:27
+msgid "Right middle finger"
+msgstr "Regtermiddelvinger"
+
+#: panels/user-accounts/data/account-fingerprint.ui:30
+msgid "Right ring finger"
+msgstr "Regterringvinger"
+
+#: panels/user-accounts/data/account-fingerprint.ui:33
+msgid "Right little finger"
+msgstr "Regterpinkie"
+
+#: panels/user-accounts/data/account-fingerprint.ui:39
+#: panels/user-accounts/um-fingerprint-dialog.c:677
+msgid "Enable Fingerprint Login"
+msgstr "Aktiveer aanmelding met vingerafdruk"
+
+#: panels/user-accounts/data/account-fingerprint.ui:89
+msgid "_Right index finger"
+msgstr "_Regterwysvinger"
+
+#: panels/user-accounts/data/account-fingerprint.ui:105
+msgid "_Left index finger"
+msgstr "_Linkerwysvinger"
+
+#: panels/user-accounts/data/account-fingerprint.ui:126
+msgid "_Other finger:"
+msgstr "_Ander vinger:"
+
+#: panels/user-accounts/data/account-fingerprint.ui:262
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"U vingerafdruk is suksesvol gestoor. U behoort nou te kan aanmeld m.b.v. die "
+"vingerafdrukleser."
+
+#: panels/user-accounts/data/avatar-chooser.ui:27
+#, fuzzy
+#| msgid "Take a photo…"
+msgid "Take a Picture…"
+msgstr "Neem 'n foto…"
+
+#: panels/user-accounts/data/avatar-chooser.ui:34
+#, fuzzy
+#| msgid "Select PPD File"
+msgid "Select a File…"
+msgstr "Kies PPD-lêer"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Gebruikers"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Voeg by of skrap gebruikers en verander u wagwoord"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:7
+msgid "system-users"
+msgstr ""
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "aanmeld;naam;vingerafdruk;embleem;gesig;wagwoord;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr "_Inskryf"
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "Aanmelding as domein se administrateur"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Om die maatskappy se aanmeldstelsel te kan gebruik, moet hierdie rekenaar "
+"aan die\n"
+"domein gekoppel wees. Laat u netwerkadministrateur\n"
+"hul domeinwagwoord hier invul."
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "Administrateur_naam"
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "Administrateurwagwoord"
+
+#: panels/user-accounts/data/password-dialog.ui:7
+msgid "Change Password"
+msgstr "Verander wagwoord"
+
+#: panels/user-accounts/data/password-dialog.ui:38
+msgid "Ch_ange"
+msgstr "Ver_ander"
+
+#: panels/user-accounts/data/password-dialog.ui:142
+msgid "_Verify New Password"
+msgstr "Be_vestig nuwe wagwoord"
+
+#: panels/user-accounts/data/password-dialog.ui:159
+msgid "_New Password"
+msgstr "_Nuwe wagwoord"
+
+#: panels/user-accounts/data/password-dialog.ui:208
+msgid "Current _Password"
+msgstr "Huidige _wagwoord"
+
+#: panels/user-accounts/data/password-dialog.ui:243
+msgid "Allow user to change their password on next login"
+msgstr "Laat gebruiker toe om 'n wagwoord in te stel met volgende aanmelding"
+
+#: panels/user-accounts/data/password-dialog.ui:256
+msgid "Set a password now"
+msgstr "Stel 'n wagwoord nou in"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:20
+msgid "_Add User…"
+msgstr "_Voeg gebruiker by…"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:69
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Die sessie moet herbegin word sodat veranderinge kan neerslag vind"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:77
+msgid "Restart Now"
+msgstr "Herbegin nou"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:244
+msgid "A_utomatic Login"
+msgstr "O_utomatiese aanmelding"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:285
+msgid "_Fingerprint Login"
+msgstr "Aanmelding met vingera_fdruk"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:311
+#: panels/user-accounts/data/user-accounts-dialog.ui:324
+msgid "User Icon"
+msgstr "Gebruikerikoon"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:387
+msgid "Last Login"
+msgstr "Laas aangemeld"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:434
+msgid "Remove User…"
+msgstr "Verwyder gebruiker…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/data/user-accounts-dialog.ui:466
+#, fuzzy
+#| msgid "No Printers Found"
+msgid "No Users Found"
+msgstr "Geen drukkers gevind nie"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:476
+#, fuzzy
+#| msgid "Create a user account"
+msgid "Unlock to add a user account."
+msgstr "Skep 'n gebruikerrekening"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Bestuur gebruikerrekeninge"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Verifikasie is nodig om gebruikersdata te verander"
+
+#: panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Die nuwe wagwoord moet verskil van die oue."
+
+#: panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Probeer om sommige letters en syfers te verander."
+
+#: panels/user-accounts/pw-utils.c:85 panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Probeer om die wagwoord nog meer te verander."
+
+#: panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "'n Wagwoord wat nie die gebruikernaam bevat nie sal sterker wees."
+
+#: panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Vermy die gebruik van u naam in die wagwoord."
+
+#: panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Vermy sommige van die woorde in die wagwoord."
+
+#: panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Vermy eerder algemene woorde."
+
+#: panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Probeer om nie bestaande woorde te skommel nie."
+
+#: panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Probeer om meer syfers te gebruik."
+
+#: panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Probeer om meer hoofletters te gebruik."
+
+#: panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Probeer om meer kleinletters te gebruik."
+
+#: panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Probeer om meer karakters soos leestekens te gebruik."
+
+#: panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Probeer om 'n mengsel van letters, syfers en leestekens te gebruik."
+
+#: panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Probeer om nie die selfde karakter te herhaal nie."
+
+#: panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Probeer om nie die selfde tipe karakter te herhaal nie: meng eerder letters, "
+"syfers en leestekens."
+
+#: panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Bly eerder weg van patrone soos 1234 of abcd."
+
+#: panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Die wagwoord moet langer wees. Probeer om 'n mengsel van letters, syfers en "
+"leestekens te gebruik."
+
+#: panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Meng hoof- en kleinletters en gebruik 'n syfer of twee."
+
+# Notes:
+# Add Note
+#
+# Context:
+# Password hint
+#: panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Goeie wagwoord! Meer letters, syfers en leestekens sal dit selfs nog sterker "
+"maak."
+
+#: panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "Verifikasie het misluk"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "Die nuwe wagwoord is te kort"
+
+#: panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "Die nuwe wagwoord is te eenvoudig"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Die ou en nuwe wagwoorde is te soortgelyk"
+
+#: panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Die nuwe wagwoord is reeds onlangs gebruik."
+
+#: panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Die nuwe wagwoord moet syfers of spesiale karakters bevat"
+
+#: panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Die ou en nuwe wagwoorde is die selfde"
+
+#: panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Jou wagwoord het verander sedert jy aanvanklik geverifieer is!"
+
+#: panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Die nuwe wagwoord bevat nie genoeg verskillende karakters nie"
+
+#: panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "Onbekende fout"
+
+#: panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "Moet pas by die webadres van die rekeningverskaffer."
+
+#: panels/user-accounts/um-account-dialog.c:229
+msgid "Failed to add account"
+msgstr "Kon nie 'n rekening byvoeg nie"
+
+#: panels/user-accounts/um-account-dialog.c:462
+msgid "Passwords do not match."
+msgstr "Wagwoorde stem nie ooreen nie."
+
+#: panels/user-accounts/um-account-dialog.c:717
+#: panels/user-accounts/um-account-dialog.c:763
+#: panels/user-accounts/um-account-dialog.c:784
+msgid "Failed to register account"
+msgstr "Kon nie rekening registreer nie"
+
+#: panels/user-accounts/um-account-dialog.c:907
+msgid "No supported way to authenticate with this domain"
+msgstr "Geen ondersteunde manier om met hierdie domein te verifieer nie"
+
+#: panels/user-accounts/um-account-dialog.c:980
+msgid "Failed to join domain"
+msgstr "Kon nie by domein aansluit nie"
+
+#: panels/user-accounts/um-account-dialog.c:1041
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Daardie gebruikernaam het nie gewerk nie.\n"
+"Probeer gerus weer."
+
+#: panels/user-accounts/um-account-dialog.c:1048
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Daardie wagwoord het nie gewerk nie.\n"
+"Probeer gerus weer."
+
+#: panels/user-accounts/um-account-dialog.c:1056
+msgid "Failed to log into domain"
+msgstr "Kon nie by domein aanmeld nie"
+
+#: panels/user-accounts/um-account-dialog.c:1114
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Kon nie die domein vind nie. Is dit reg gespel?"
+
+#: panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Gewoon"
+
+#: panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Administrateur"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"U mag nie toegang kry tot die toestel nie. Kontak die stelseladministrateur."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "Die toestel is reeds in gebruik."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr "'n Interne fout het voorgekom."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Enabled"
+msgstr "Geaktiveer"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:260
+msgid "Delete registered fingerprints?"
+msgstr "Skrap geregistreerde vingerafdrukke?"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:264
+msgid "_Delete Fingerprints"
+msgstr "_Skrap vingerafdrukke"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:270
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Wil u die geregistreerde vingerafdrukke skrap sodat aanmelding met "
+"vingerafdrukke gedeaktiveer is?"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:440
+msgid "Done!"
+msgstr "Klaar!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:501
+#: panels/user-accounts/um-fingerprint-dialog.c:543
+#, c-format
+msgid "Could not access “%s” device"
+msgstr "Kon nie toegang tot die toestel \"%s\" kry nie"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:584
+#, c-format
+msgid "Could not start finger capture on “%s” device"
+msgstr "Kon nie vingeropname op \"%s\" begin nie"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:628
+msgid "Could not access any fingerprint readers"
+msgstr "Kon nie toegang kry tot enige vingerafdruklesers nie"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:629
+msgid "Please contact your system administrator for help."
+msgstr "Kontak u stelseladministrateur vir hulp."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: panels/user-accounts/um-fingerprint-dialog.c:711
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the “%s” device."
+msgstr ""
+"Om aanmelding met vingerafdruk te aktiveer moet u een van u vingerafdrukke "
+"stoor met die toestel \"%s\"."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:718
+msgid "Selecting finger"
+msgstr "Kies 'n vinger"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:719
+msgid "Enrolling fingerprints"
+msgstr "Besig om fingerafdrukke in te skryf"
+
+#: panels/user-accounts/um-history-dialog.c:70
+msgid "This Week"
+msgstr "Dié week"
+
+#: panels/user-accounts/um-history-dialog.c:73
+msgid "Last Week"
+msgstr "Verlede week"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/um-history-dialog.c:79
+#: panels/user-accounts/um-history-dialog.c:83
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/um-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/um-history-dialog.c:93
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/um-history-dialog.c:177
+#: panels/user-accounts/um-user-panel.c:766
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/um-history-dialog.c:180
+#: panels/user-accounts/um-user-panel.c:770
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/um-history-dialog.c:250
+msgid "Session Ended"
+msgstr "Sessie is begin"
+
+#: panels/user-accounts/um-history-dialog.c:256
+msgid "Session Started"
+msgstr "Sessie is beëindig"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/um-history-dialog.c:299
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Rekening Aktiwiteit"
+
+#: panels/user-accounts/um-password-dialog.c:144
+msgid "Please choose another password."
+msgstr "Kies asseblief 'n ander wagwoord."
+
+#: panels/user-accounts/um-password-dialog.c:153
+msgid "Please type your current password again."
+msgstr "Tik asseblief die huidige wagwoord weer."
+
+#: panels/user-accounts/um-password-dialog.c:159
+msgid "Password could not be changed"
+msgstr "Wagwoord kon nie verander word nie"
+
+#: panels/user-accounts/um-password-dialog.c:285
+msgid "The passwords do not match."
+msgstr "Die wagwoorde stem nie ooreen nie."
+
+#: panels/user-accounts/um-photo-dialog.c:227
+msgid "Browse for more pictures"
+msgstr "Blaai vir meer beelde"
+
+#: panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "Kan nie outomaties by 'n domein van dié soort aansluit nie"
+
+#: panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "Geen domein of gebied gevind nie"
+
+#: panels/user-accounts/um-realm-manager.c:815
+#: panels/user-accounts/um-realm-manager.c:829
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Kan nie as %s by die %s-domein aanmeld nie"
+
+#: panels/user-accounts/um-realm-manager.c:821
+msgid "Invalid password, please try again"
+msgstr "Verkeerde wagwoord. Probeer gerus weer"
+
+#: panels/user-accounts/um-realm-manager.c:834
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Kon nie koppel aan die %s-domein nie: %s"
+
+#: panels/user-accounts/um-user-panel.c:200
+msgid "Your account"
+msgstr "Jou rekening"
+
+#: panels/user-accounts/um-user-panel.c:380
+msgid "Failed to delete user"
+msgstr "Kon nie gebruiker skrap nie"
+
+#: panels/user-accounts/um-user-panel.c:438
+#: panels/user-accounts/um-user-panel.c:497
+#: panels/user-accounts/um-user-panel.c:549
+msgid "Failed to revoke remotely managed user"
+msgstr "Kon nie afstand bestuurde gebruiker skrap nie"
+
+#: panels/user-accounts/um-user-panel.c:603
+msgid "You cannot delete your own account."
+msgstr "U kan nie u eie rekening skrap nie."
+
+#: panels/user-accounts/um-user-panel.c:612
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s is steeds aangemeld"
+
+#: panels/user-accounts/um-user-panel.c:616
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Om 'n gebruiker te skrap terwyl hy aangemeld is, kan die stelsel in 'n "
+"inkonsekwente toestand laat."
+
+#: panels/user-accounts/um-user-panel.c:625
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Wil u %s se lêers behou?"
+
+#: panels/user-accounts/um-user-panel.c:629
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Dit is moontlik om die tuisgids, pos-spool-gids en tydelike lêers te hou "
+"wanneer 'n gebruiker se rekening geskrap word."
+
+#: panels/user-accounts/um-user-panel.c:632
+msgid "_Delete Files"
+msgstr "_Skrap lêers"
+
+#: panels/user-accounts/um-user-panel.c:633
+msgid "_Keep Files"
+msgstr "_Hou lêers"
+
+#: panels/user-accounts/um-user-panel.c:647
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Is u seker u wil %s se afstand bestuurde rekeneing skrap?"
+
+#: panels/user-accounts/um-user-panel.c:651
+msgid "_Delete"
+msgstr "_Skrap"
+
+#: panels/user-accounts/um-user-panel.c:701
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Rekening gedeaktiveer"
+
+#: panels/user-accounts/um-user-panel.c:709
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Moet by volgende aanmelding gestel word"
+
+#: panels/user-accounts/um-user-panel.c:712
+msgctxt "Password mode"
+msgid "None"
+msgstr "Geen"
+
+#: panels/user-accounts/um-user-panel.c:759
+msgid "Logged in"
+msgstr "Aangemeld"
+
+#: panels/user-accounts/um-user-panel.c:1106
+msgid "Failed to contact the accounts service"
+msgstr "Kon nie die rekeningediens kontak nie"
+
+#: panels/user-accounts/um-user-panel.c:1108
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Maak asb. seker dat die AccountService korrek geïnstalleer en geaktiveer is."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/um-user-panel.c:1140
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Om veranderinge te maak,\n"
+"klik eers die *-ikoon"
+
+#: panels/user-accounts/um-user-panel.c:1180
+msgid "Create a user account"
+msgstr "Skep 'n gebruikerrekening"
+
+#: panels/user-accounts/um-user-panel.c:1191
+#: panels/user-accounts/um-user-panel.c:1370
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Om 'n gebruikerrekening te skep,\n"
+"klik eers die *-ikoon"
+
+#: panels/user-accounts/um-user-panel.c:1201
+msgid "Delete the selected user account"
+msgstr "Skrap die gekose gebruikerrekening"
+
+#: panels/user-accounts/um-user-panel.c:1213
+#: panels/user-accounts/um-user-panel.c:1375
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Om die gekose gebruikerrekening te skrap,\n"
+"klik eers die *-ikoon"
+
+#: panels/user-accounts/um-utils.c:496
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Jammer maar die gebruikersnaam is nie meer beskikbaar nie. Probeer gerus 'n "
+"ander een."
+
+#: panels/user-accounts/um-utils.c:499
+#, c-format
+msgid "The username is too long."
+msgstr "Die gebruikernaam is te lank."
+
+#: panels/user-accounts/um-utils.c:502
+msgid "The username cannot start with a “-”."
+msgstr "'n Gebruikernaam kan nie begin met 'n \"-\" nie."
+
+#: panels/user-accounts/um-utils.c:505
+msgid ""
+"The username should only consist of upper and lower case letters from a-z, "
+"digits and the following characters: . - _"
+msgstr ""
+"Die gebruikernaam moet slegs bestaan uit hoof- en kleinletters (a-z), syfers "
+"en enige van die karakters '.', '-' en '_'"
+
+#: panels/user-accounts/um-utils.c:509
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr ""
+"Hierdie gaan gebruik word as tuisgidsnaam en kan nie verander word nie."
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr "Koppel knoppies"
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:547
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "_Sluit"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr "Koppel knoppies aan funksies"
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Om 'n kortpad te wysig, kies die \"Stuur sleutel\" -aksie, druk die "
+"sleutelbordkortpad en hou die nuwe sleutels in of druk Backspace om te vee."
+
+#: panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Raak asseblief aan die teikenmerkers soos dit verskyn om die tablet te "
+"kalibreer."
+
+#: panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting…"
+msgstr "Mis-klik bespeur, herbegin…"
+
+#: panels/wacom/cc-wacom-button-row.c:266
+#, c-format
+msgid "Button %d"
+msgstr "Knoppie %d"
+
+#: panels/wacom/cc-wacom-button-row.h:53
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Toepassings gedefinieer"
+
+#: panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Stuur sleutel"
+
+#: panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Ruil Monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Wys hulp op die skerm"
+
+#: panels/wacom/cc-wacom-mapping-panel.c:260
+msgid "Output:"
+msgstr "Afvoer:"
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:272
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Behou beeldverhouding (breedbeeld)"
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:283
+msgid "Map to single monitor"
+msgstr "Koppel aan 'n enkele skerm"
+
+#: panels/wacom/cc-wacom-nav-button.c:86
+#, c-format
+msgid "%d of %d"
+msgstr "%d van %d"
+
+#: panels/wacom/cc-wacom-page.c:544
+msgid "Display Mapping"
+msgstr "Vertoon koppelings"
+
+#: panels/wacom/cc-wacom-panel.c:790 panels/wacom/wacom-stylus-page.ui:127
+msgid "Stylus"
+msgstr "Pen"
+
+#: panels/wacom/cc-wacom-stylus-page.c:362
+msgid "Button"
+msgstr "Knoppie"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:198
+msgid "Wacom Tablet"
+msgstr "Wacom-tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Stel knoppiekoppelings en pas pengevoeligheid vir grafiese tablette aan"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:7
+msgid "input-tablet"
+msgstr ""
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "tablet;wacom;pen;uitveër;muis;"
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr "Tablet (absoluut)"
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr "Raakblad (relatief)"
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr "Tabletvoorkeure"
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "_Hulp"
+
+#: panels/wacom/gnome-wacom-properties.ui:123
+msgid "No tablet detected"
+msgstr "Geen tablet bespeur nie"
+
+#: panels/wacom/gnome-wacom-properties.ui:139
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Prop die Wacom-tablet in en skakel dit aan"
+
+#: panels/wacom/gnome-wacom-properties.ui:159
+msgid "Bluetooth Settings"
+msgstr "Bluetooth-instellings"
+
+#: panels/wacom/gnome-wacom-properties.ui:231
+msgid "Map to Monitor…"
+msgstr "Koppel aan Skerm…"
+
+#: panels/wacom/gnome-wacom-properties.ui:247
+msgid "Map Buttons…"
+msgstr "Koppel knoppies…"
+
+#: panels/wacom/gnome-wacom-properties.ui:263
+msgid "Calibrate…"
+msgstr "Kalibreer…"
+
+#: panels/wacom/gnome-wacom-properties.ui:284
+msgid "Adjust display resolution"
+msgstr "Verander die resolusie van die skerm"
+
+#: panels/wacom/gnome-wacom-properties.ui:300
+msgid "Adjust mouse settings"
+msgstr "Verstel muisinstellings"
+
+#: panels/wacom/gnome-wacom-properties.ui:328
+msgid "Tracking Mode"
+msgstr "Opspoormodus"
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Left-Handed Orientation"
+msgstr "Linkshandige oriëntasie"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "Nuwe kortpad…"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr "Middel muisklik"
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr "Regter muisklik"
+
+#: panels/wacom/wacom-stylus-page.ui:37
+msgid "Back"
+msgstr "Terug"
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "Vorentoe"
+
+#: panels/wacom/wacom-stylus-page.ui:77
+msgid "No stylus found"
+msgstr "Geen pen gevind nie"
+
+#: panels/wacom/wacom-stylus-page.ui:91
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr "Beweeg jou pen naby aan die tablet om dit in te stel"
+
+#: panels/wacom/wacom-stylus-page.ui:167
+msgid "Eraser Pressure Feel"
+msgstr "Uitveër druk gevoel"
+
+#: panels/wacom/wacom-stylus-page.ui:188 panels/wacom/wacom-stylus-page.ui:348
+msgid "Soft"
+msgstr "Sag"
+
+#: panels/wacom/wacom-stylus-page.ui:218 panels/wacom/wacom-stylus-page.ui:378
+msgid "Firm"
+msgstr "Ferm"
+
+#: panels/wacom/wacom-stylus-page.ui:241
+msgid "Top Button"
+msgstr "Boonste knoppie"
+
+#: panels/wacom/wacom-stylus-page.ui:270
+msgid "Lower Button"
+msgstr "Onderste knoppie"
+
+#: panels/wacom/wacom-stylus-page.ui:299
+#, fuzzy
+#| msgid "Lower Button"
+msgid "Lowest Button"
+msgstr "Onderste knoppie"
+
+#: panels/wacom/wacom-stylus-page.ui:328
+msgid "Tip Pressure Feel"
+msgstr "Punt druk gevoel"
+
+#: panels/wacom/wacom-stylus-page.ui:440
+msgid "page 3"
+msgstr "bladsy 3"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+msgid "GNOME Control Center"
+msgstr "GNOME-beheersentrum"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utilities to configure the GNOME desktop"
+msgstr "Nutsgoed om die GNOME-werkarea op te stel"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid ""
+"The control center is GNOME’s main interface for configuration of various "
+"aspects of your desktop."
+msgstr ""
+"Die beheersentrum is GNOME se plek vir die opstelling van verskeie aspekte "
+"van die werkskerm."
+
+#: shell/cc-application.c:47
+msgid "Display version number"
+msgstr "Wys weergawenommer"
+
+#: shell/cc-application.c:48
+msgid "Enable verbose mode"
+msgstr "Aktiveer spraaksame modus"
+
+#: shell/cc-application.c:49
+msgid "Show the overview"
+msgstr "Wys die oorsig"
+
+#: shell/cc-application.c:50
+msgid "Search for the string"
+msgstr "Soek na die string"
+
+#: shell/cc-application.c:51
+msgid "List possible panel names and exit"
+msgstr "Druk 'n lys van moontlike panneelname en sluit af"
+
+#: shell/cc-application.c:52
+msgid "Panel to display"
+msgstr "Paneel om te wys"
+
+#: shell/cc-application.c:52
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEEL] [ARGUMENT…]"
+
+#: shell/cc-application.c:117
+msgid "Available panels:"
+msgstr "Beskikbaar panele:"
+
+#: shell/cc-application.c:256
+msgid "Help"
+msgstr "Hulp"
+
+#: shell/cc-application.c:257
+msgid "Quit"
+msgstr "Sluit af"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: shell/gnome-control-center.desktop.in.in:5
+msgid "gnome-control-center"
+msgstr ""
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "voorkeure;instelling;opstelling;"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Algemeen"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Sluit af"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Soek"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panele"
+
+#: shell/help-overlay.ui:40
+msgctxt "shortcut window"
+msgid "Go back to the overview"
+msgstr "Terug na die oorsig"
+
+#: shell/help-overlay.ui:53
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Kanselleer soektog"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: shell/hostname-helper.c:189
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Kuberkol"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/panel-list.ui:195
+msgid "No results found"
+msgstr "Geen resultate gevind nie"
+
+#: shell/window.ui:141
+msgid "All Settings"
+msgstr "Alle instellings"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1873
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u afvoer"
+msgstr[1] "%u afvoere"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1883
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u toevoer"
+msgstr[1] "%u toevoere"
+
+#: subprojects/gvc/gvc-mixer-control.c:2738
+msgid "System Sounds"
+msgstr "Stelselklanke"
+
+#~ msgid "Back­ground"
+#~ msgstr "Agtergrond"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Kleur"
+
+#~ msgid "Section"
+#~ msgstr "Afdeling"
+
+#~ msgid "Overview"
+#~ msgstr "Oorsig"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Verstektoepassings"
+
+#~ msgid "Ab­out"
+#~ msgstr "Aangaande"
+
+#~ msgid "De­tails"
+#~ msgstr "Besonderhede"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Verwyderbare media"
+
+#~ msgctxt "keybinding"
+#~ msgid "Search"
+#~ msgstr "Soek"
+
+#~ msgid "Net­work"
+#~ msgstr "Netwerk"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Kennisgewings"
+
+#~ msgid "Po­wer"
+#~ msgstr "Krag"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Privaatheid"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Deling"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Universele toegang"
+
+#~ msgid "Disable image"
+#~ msgstr "Deaktiveer beeld"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Blaai vir meer prente…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Gebruik deur %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wacom-Tablet"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Persoonlik"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardeware"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Stelsel"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Skerm toegevou"
+
+#~ msgid "Mirrored"
+#~ msgstr "Gedupliseer"
+
+#~ msgid "Primary"
+#~ msgstr "Primêr"
+
+#~ msgid "Secondary"
+#~ msgstr "Sekondêr"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Rangskik gekombineerde vertone"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Sleep vertone om te herrangskik"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Draai 90° antikloksgewys"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Draai 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Draai 90° kloksgewys"
+
+#~ msgid "Size"
+#~ msgstr "Grootte"
+
+#~ msgid "Aspect Ratio"
+#~ msgstr "Aspekverhouding"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Wys die boonste balk en Aktiwiteitoorsig op dié vertoon"
+
+#~ msgid "Presentation"
+#~ msgstr "Voorlegging"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Wys slegs skyfievertonings en media"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Wys die bestaande aansig op altwee vertoone"
+
+#~ msgid "Turn Off"
+#~ msgstr "Skakel af"
+
+#~ msgid "Don't use this display"
+#~ msgstr "Moenie hierdie vertoon gebruik nie"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "R_angskik gekombineerde vertone"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bis"
+
+#~ msgid "Base system"
+#~ msgstr "Onderliggende stelsel"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;kortpad;herhaal;flikker;"
+
+#~ msgid "_Name:"
+#~ msgstr "_Naam:"
+
+#~ msgid "C_ommand:"
+#~ msgstr "_Opdrag:"
+
+#~ msgid "Add Shortcut"
+#~ msgstr "Voeg kortpad by"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Om 'n kortpad te verander, klik op die ry en tik die nuwe "
+#~ "sleutelkombinasie, of druk Backspace om skoon te maak."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Onbekende aksie>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Die kortpad \"%s\" kan nie gebruik word nie omdat dit dan onmoontlik sal "
+#~ "wees om met dié sleutel te tik.\n"
+#~ "Probeer eerder met 'n knoppie soos Control, Alt of Shift op die selfde "
+#~ "tyd."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Die kortpad \"%s\" word reeds gebruik vir\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "As u die kortpad hertoeken aan \"%s\" sal die \"%s\"-kortpad gedeaktiveer "
+#~ "word."
+
+#~ msgid "_Reassign"
+#~ msgstr "He_rtoeken"
+
+#, fuzzy
+#~| msgid ""
+#~| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~| "disabled."
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "As u die kortpad hertoeken aan \"%s\" sal die \"%s\"-kortpad gedeaktiveer "
+#~ "word."
+
+#~ msgid "_Assign"
+#~ msgstr "_Ken toe"
+
+#~ msgid "Server"
+#~ msgstr "Bediener"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Skrap DNS-bediener"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Maak beskikbaar aan ander gebr_uikers"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Brandmuur_sone"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Verstek"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Die sone bepaal die vertrouensvlak van die verbinding"
+
+#~ msgid "Bond"
+#~ msgstr "Saambind"
+
+#~ msgid "Team"
+#~ msgstr "Span"
+
+#~ msgid "Bridge"
+#~ msgstr "Brug"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Kon nie VPN-inproppe laai nie"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Voeg netwerkverbinding by"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Stel die instellings, insluitend wagwoorde, vir dié netwerk terug, maar "
+#~ "onthou dit as 'n voorkeurnetwerk"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Verwyder alle besonderhede wat met dié netwerk te doen het en moenie weer "
+#~ "outomaties probeer koppel nie"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Saambindslawe"
+
+#~ msgid "(none)"
+#~ msgstr "(geen)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Brugslawe"
+
+#~ msgid "Team slaves"
+#~ msgstr "Spanslawe"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "As u 'n internetverbinding het buiten vir 'n draadlose een, kan u 'n "
+#~ "draadlose toegangsarea opstel om die verbinding te deel met ander."
+
+#~ msgid "History"
+#~ msgstr "Geskiedenis"
+
+#~ msgid "Proxy"
+#~ msgstr "Instaanbediener"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Voeg profiel by…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Handmatig"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Outomaties"
+
+#~ msgid "Add Device"
+#~ msgstr "Voeg toestel by"
+
+#~ msgid "Remove Device"
+#~ msgstr "Verwyder toestel"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN-Tipe"
+
+#~ msgid "Group Name"
+#~ msgstr "Groepnaam"
+
+#~ msgid "Group Password"
+#~ msgstr "Groepwagwoord"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "Gebr_uik as toegangsarea…"
+
+#~ msgid "_History"
+#~ msgstr "_Geskiedenis"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Geen sertifikaatowerheid se sertifikaat is gekies nie"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Deur nie 'n sertifikaatowerheid (CA) se sertifikaat te gebruik nie kan "
+#~ "lei tot onveilige, skelm Wi-Fi-netwerkverbindings.  Wil u 'n sertifikaat "
+#~ "van 'n sertifikaatowerheid kies?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignoreer"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Kies SO-sertifikaat"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Vra tel_kens vir dié wagwoord"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Moenie my _weer waarsku nie"
+
+#~ msgid "No"
+#~ msgstr "Nee"
+
+#~ msgid "Yes"
+#~ msgstr "Ja"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Kennisgewing_baniere"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Kennisgewing_baniere"
+
+#~ msgid "Add Account"
+#~ msgstr "Voeg rekening by"
+
+#~ msgid "Mail"
+#~ msgstr "Pos"
+
+#~ msgid "Contacts"
+#~ msgstr "Kontakte"
+
+#~ msgid "Chat"
+#~ msgstr "Gesels"
+
+#~ msgid "Resources"
+#~ msgstr "Hulpbronne"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Fout met aanmeld met die rekening"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Aanmeldinligting het verstryk."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Meld aan om dié rekening te aktiveer."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Meld aan"
+
+#~ msgid "Error creating account"
+#~ msgstr "Kon nie rekening skep nie"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Wil u definitief die rekening skrap?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Die rekening op die bediener sal nié verwyder word nie."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Geen aanlynrekeninge opgetel nie"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Deur 'n rekening by te voeg, kan programme dit gebruik om dokumente, pos, "
+#~ "kontakte, kalender, gesels, ens. te bekom."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Word tans ingestel"
+
+#~ msgid "Toner Level"
+#~ msgstr "Poeierinkvlak"
+
+#~ msgid "Supply Level"
+#~ msgstr "Voorraadvlak"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Word tans geïnstalleer"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktief"
+#~ msgstr[1] "%u aktief"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Voeg drukker by"
+
+#~ msgid "No printers detected."
+#~ msgstr "Geen drukkers bespeur nie."
+
+#~ msgid "Loading options…"
+#~ msgstr "Laai tans keuses…"
+
+#~ msgid "Supply"
+#~ msgstr "Voorraad"
+
+#~ msgid "_Default printer"
+#~ msgstr "_Verstekdrukker"
+
+#~ msgid "Jobs"
+#~ msgstr "Take"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Wys _take"
+
+#~ msgid "label"
+#~ msgstr "etiket"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Druk _toetsbladsy"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Om u geografiese ligging mee te bepaal"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Ander"
+
+#~ msgid "Personal File Sharing"
+#~ msgstr "Persoonlike lêerdeling"
+
+#~ msgid "_Allow Remote Control"
+#~ msgstr "L_aat eksterne beheer toe"
+
+#~ msgid "_Verify"
+#~ msgstr "Be_vestig"
+
+#~ msgid "Login History"
+#~ msgstr "Aanmeldgeskiedenis"
+
+#~ msgid "Add User Account"
+#~ msgstr "Voeg gebruikerrekening by"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Probeer om meer letters, syfers en simbole by te voeg."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Sterkte: Baie swak"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Sterkte: Swak"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Sterkte: Medium"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Sterkte: Goed"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Sterkte: Baie goed"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Ander rekeninge"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "'n Gebruiker met gebruikernaam '%s' bestaan reeds."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Op"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Af"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#, fuzzy
+#~| msgid "Left ring finger"
+#~ msgid "Left Ring"
+#~ msgstr "Linkerringvinger"
+
+#, fuzzy
+#~| msgid "Right ring finger"
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Regterringvinger"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Linkerknoppie #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Regterknoppie #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Boonste knoppie #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Onderste knoppie #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Geen aksie"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Linker muisklik"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Rol op"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Rol af"
+
+#~ msgid "Scroll Left"
+#~ msgstr "Rol links"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Rol regs"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "Bluetooth is gedeaktiveer"
+
+#~ msgid "Done"
+#~ msgstr "Klaar"
+
+#~ msgid "United States"
+#~ msgstr "Verenigde State"
+
+#~ msgid "Germany"
+#~ msgstr "Duitsland"
+
+#~ msgid "France"
+#~ msgstr "Frankryk"
+
+#~ msgid "Spain"
+#~ msgstr "Spanje"
+
+#~ msgid "China"
+#~ msgstr "Sjina"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Tyd_sone"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Vertraging:"
+
+#~ msgid "_Speed:"
+#~ msgstr "_Spoed:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Kort"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Stadig"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Lank"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Vinnig"
+
+#~ msgid "S_peed:"
+#~ msgstr "S_poed:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Toets instellings"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Stadig"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Vinnig"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Links"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Regs"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Wyserspoed"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Stadig"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Vinnig"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Stadig"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Vinnig"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Deaktiveer tydens _tik"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr ""
+#~ "Die stelsel se netwerkdienste is nie versoenbaar met dié weergawe nie."
+
+#~ msgid "Security key"
+#~ msgstr "Sekuriteitsleutel"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Wys opspringbaniere"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Wys in geslote skerm"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Wys opspringbaniere"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "Wys in geslote skerm"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Skakel draadlose toestelle af"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Wanneer batterykrag _krities min is"
+
+#~ msgid "Power off"
+#~ msgstr "Skakel af"
+
+#~ msgid "No printers available"
+#~ msgstr "Geen drukkers beskikbaar nie"
+
+#~ msgid "Close"
+#~ msgstr "Sluit"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Sit drukwerk voort"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Laat drukwerk wag"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Tik 'n drukker se adres, of teks om resultate te verfyn"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Gehou"
+
+#~ msgid "Job Title"
+#~ msgstr "Taaktitel"
+
+#~ msgid "Job State"
+#~ msgstr "Taakstatus"
+
+#~ msgid "Time"
+#~ msgstr "Tyd"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Voeg nuwe drukker by"
+
+#~ msgid "Sorry"
+#~ msgstr "Jammer"
+
+#~ msgid "Options"
+#~ msgstr "Keuses"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Bluetooth-deling maak dit moontlik om lêers te deel met ander Bluetooth-"
+#~ "toestelle"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Ontvang slegs vanaf vertroude toestelle"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Stoor ontvangde lêers na Afgelaai-gids"
+
+#~ msgid "Password:"
+#~ msgstr "Wagwoord:"
+
+#~ msgid "Zoom"
+#~ msgstr "Zoem"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Kleur"
+
+#~ msgid "Show help options"
+#~ msgstr "Wys hulpkeuses"
+
+#~ msgid "- Settings"
+#~ msgstr "- Instellings"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Laat loop '%s --help' om 'n volledige lys opdraglynkeuses te sien.\n"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Stel nuwe toestel op"
+
+#~ msgid "Paired"
+#~ msgstr "Opgepaar"
+
+#~ msgid "Type"
+#~ msgstr "Tipe"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Muis- en raakbladinstellings"
+
+#~ msgid "Sound Settings"
+#~ msgstr "Klankinstellings"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Sleutelbordinstellings"
+
+#~ msgid "Send Files…"
+#~ msgstr "Stuur lêers…"
+
+#~ msgid "Visibility"
+#~ msgstr "Sigbaarheid"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Sigbaarheid van “%s”"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Verwyder '%s' uit die lys van toestelle?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "As die toestel verwyder word, sal dit weer opgestel moet word voor die "
+#~ "volgende gebruik."
+
+#~ msgid "Device type:"
+#~ msgstr "Toesteltipe:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Vervaardiger:"
+
+#~ msgid "Model:"
+#~ msgstr "Model:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Beeldlêers kan na hierdie venster gesleep word om die bostaande velde "
+#~ "outomaties te voltooi."
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "Wys die primêre vertoon ook op dié skerm"
+
+#~ msgid "Combine"
+#~ msgstr "Kombineer"
+
+#~ msgid "Don't use the display"
+#~ msgstr "Moenie die vertoon gebruik nie"
+
+#~ msgid "Install Updates"
+#~ msgstr "Installeer bywerkings"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Stelsel op datum"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Muisvoorkeure"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Kies die koppelvlak om vir die nuwe diens te gebruik"
+
+#~ msgid "C_reate…"
+#~ msgstr "Kalib_reer…"
+
+#~ msgid "_Interface"
+#~ msgstr "_Koppelvlak"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Soek vir netwerkdrukkers of verfyn resultate"
+
+#~ msgid "_Default"
+#~ msgstr "_Verstek"
+
+#~ msgid "Immediately"
+#~ msgstr "Onmiddellik"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Deel die Publiek-gids"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Deel slegs met vertroude toestelle"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Deel media op dié netwerk"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Gedeelde gidse"
+
+#~ msgid "column"
+#~ msgstr "kolom"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Verwyder gids"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Deel Public-gids op dié netwerk"
+
+#~| msgid "Remove profile"
+#~ msgid "Remote View"
+#~ msgstr "Afgeleë besigtiging"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Laat alle verbindings toe"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Verander tans foto vir:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "Kies 'n prent wat gaan wys by die aanmeldskerm vir dié rekening."
+
+#~ msgid "Gallery"
+#~ msgstr "Galery"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Neem 'n foto"
+
+#~ msgid "Browse"
+#~ msgstr "Blaai"
+
+#~ msgid "Photograph"
+#~ msgstr "Foto"
+
+#~ msgid "Account Information"
+#~ msgstr "Rekeninginligting"
+
+#~ msgid "Change the background"
+#~ msgstr "Verander die agtergrond instellings"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "Voeg muurpapier by"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "Verwyder muurpapier"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Horisontale helling"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Vertikale helling"
+
+#~ msgid "Solid Color"
+#~ msgstr "Soliede kleur"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "Kleure en gradiënte"
+
+#~ msgid "Select a region"
+#~ msgstr "Kies 'n streek"
+
+#~ msgid "Unspecified"
+#~ msgstr "Nie gespesifiseer nie"
+
+#~ msgid "Select a language"
+#~ msgstr "Kies 'n taal"
+
+#~ msgid "AM/PM"
+#~ msgstr "v.m./n.m."
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Stel die tyd een uur vorentoe."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Stel die tyd een uur terug."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Stel die tyd een minuut vorentoe."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Stel die tyd een minuut terug."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Wissel tussen v.m. en n.m."
+
+#~ msgid "_City:"
+#~ msgstr "_Stad:"
+
+#~ msgid "_Network Time"
+#~ msgstr "_Netwerktyd"
+
+#~ msgid "_Region:"
+#~ msgstr "St_reek:"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Voorkeurepaneel vir datum en tyd"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Let wel: kan resolusiekeuses beperk"
+
+#~ msgid "R_otation:"
+#~ msgstr "R_otasie:"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "_Bespeur vertoonareas"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Dupliseer vertoonareas"
+
+#~ msgid "Normal"
+#~ msgstr "Normaal"
+
+#~ msgid "Clockwise"
+#~ msgstr "Kloksgewys"
+
+#~ msgid "180 Degrees"
+#~ msgstr "180 grade"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "Sleep om die primêre vertoonarea te verander."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Kies 'n monitor om sy eienskappe te verander; sleep om sy plasing te "
+#~ "verander."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %k:%M"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Kon nie die monitoropstelling stoor nie"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr ""
+#~ "Kon nie die sessiebus kry tydens toepassing van die vertoonopstelling nie"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "Onbekende model"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr ""
+#~ "Die volgende aanmelding sal probeer om die standaardervaring te lewer."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "Die volgende aanmelding sal terugval op die modus bedoel vir nie-"
+#~ "ondersteunde grafikahardeware."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Terugval"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "Standaard"
+
+#~ msgid "System Info"
+#~ msgstr "Stelselinligting"
+
+#~ msgid "System Information"
+#~ msgstr "Stelselinligting"
+
+#~ msgid "Experience"
+#~ msgstr "Ervaring"
+
+#, fuzzy
+#~| msgid "Forced Fallback Mode"
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "Terugvalmodus afgedwing"
+
+#~ msgid "Magnifier zoom out"
+#~ msgstr "Minder vergroting"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "Wissel kontras"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "Wissel vergroting"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "Wissel skermleser"
+
+#~ msgid "Accelerator key"
+#~ msgstr "Snelsleutel"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Snelsleutel-wysigers"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Snelsleutelkode"
+
+#~ msgid "Accel Mode"
+#~ msgstr "Versnelmodus"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Die tipe versneller."
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Te veel kortpaaie"
+
+#~ msgid "Action"
+#~ msgstr "Aksie"
+
+#~ msgid "Layout Settings"
+#~ msgstr "Uitlegopstelling"
+
+#~ msgid "Acti_on:"
+#~ msgstr "Aksi_e:"
+
+#~ msgid "_Photos:"
+#~ msgstr "_Foto's:"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "cd;dvd;usb;audio;video;disc;oudio;skyf;"
+
+#~ msgid "_Log In"
+#~ msgstr "_Meld aan"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "Om 'n nuwe rekening by te voeg, kies eers die rekeningtipe"
+
+#~ msgid "_Add..."
+#~ msgstr "_Voeg by..."
+
+#~ msgid "_Search by Address"
+#~ msgstr "_Soek volgens adres"
+
+#~ msgid "Getting devices..."
+#~ msgstr "Kry tans toestelle..."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "Plaaslik"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "Netwerk"
+
+#~ msgid "Device types"
+#~ msgstr "Toesteltipes"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "Outomatiese opstelling"
+
+#~ msgid "_Back"
+#~ msgstr "_Terug"
+
+#~ msgid "_Show"
+#~ msgstr "_Wys"
+
+#~ msgid "Keyboard Layout Options"
+#~ msgstr "Keuses oor sleutelborduitleg"
+
+#, fuzzy
+#~| msgid "Mouse Settings"
+#~ msgid "Copy Settings..."
+#~ msgstr "Muisinstellings"
+
+#~ msgid "Currency"
+#~ msgstr "Geldeenheid"
+
+#~ msgid "Examples"
+#~ msgstr "Voorbeelde"
+
+#~ msgid "Install languages..."
+#~ msgstr "Installeer tale..."
+
+#~ msgid "Layouts"
+#~ msgstr "Uitlegte"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "Nuwe vensters gebruik die verstekuitleg"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "Nuwe vensters gebruik die vorige venster se uitleg"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Vervang die huidige instellings vir sleutelborduitleg\n"
+#~ "met die verstekinstellings"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "Herstel na _verstekwaardes"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Kies 'n vertoontaal (verandering sal wys by die volgende aanmelding)"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "Kies 'n streek (verandering sal wys by die volgende aanmelding)"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "Die aanmeldskerm, stelselrekeninge en nuwe gebruikerrekeninge gebruik die "
+#~ "stelselwye instellings vir streek en taal. Stel gerus die stelsel "
+#~ "dieselfde as u instellings."
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "Bekyk en wysig keuses vir die sleutelborduitleg"
+
+#~ msgid "_Options..."
+#~ msgstr "_Keuses..."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "Die aanmeldskerm, stelselrekeninge en nuwe gebruikerrekeninge gebruik die "
+#~ "stelselwye instellings vir streek en taal."
+
+#~ msgid "Layout"
+#~ msgstr "Uitleg"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "_Versnelling:"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "Sleep en los"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "Aktiveer _muisklik m.b.v. raakblad"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Wys die p_osisie van die wyser as Control gedruk word"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "Dr_empel:"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "Om die instellings te toets, probeer om te dubbelklik op die gesig."
+
+#~ msgid "_Disabled"
+#~ msgstr "Ge_deaktiveer"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Linkshandig"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_Regshandig"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Sensitiwiteit:"
+
+#~ msgid "_Timeout:"
+#~ msgstr "Uittel_tyd:"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Stel jou muis- en raakbladvoorkeure in"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "Ander..."
+
+#, fuzzy
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "Ontkoppel van %s en skep 'n nuwe ......"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "Hierdie is die enigste koppeling aan die internet."
+
+#~ msgid "Create..."
+#~ msgstr "Skep..."
+
+#~ msgid "Subnet Mask"
+#~ msgstr "Subnetmasker"
+
+#~ msgid "_Network Name"
+#~ msgstr "_Netwerknaam"
+
+#~ msgid "Power management settings"
+#~ msgstr "Kragbestuurinstellings"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s tot leeg (%.0lf%%)"
+
+#~ msgid "Ask me"
+#~ msgstr "Vra my"
+
+#~ msgid "Don't suspend"
+#~ msgstr "Moenie sluimer nie"
+
+#~ msgid "Shutdown"
+#~ msgstr "Skakel af"
+
+#~ msgid "Color management settings"
+#~ msgstr "Kleurbestuurinstellings"
+
+#~ msgid "Create virtual device"
+#~ msgstr "Skep virtuele toestel"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i jaar"
+#~ msgstr[1] "%i jare"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i maand"
+#~ msgstr[1] "%i maande"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i week"
+#~ msgstr[1] "%i weke"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "Minder as 'n week"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "Die toestel se kleur word nie bestuur nie."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "Dié toestel het nie 'n profiel wat geskik is vir volskerm-"
+#~ "kleurkorrigering nie."
+
+#~ msgid "Not specified"
+#~ msgstr "Nie gespesifiseer nie"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "Geen toestelle bespeur wat kleurbestuur ondersteun nie"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "Voeg 'n virtuele toestel by"
+
+#~ msgid "Available Profiles"
+#~ msgstr "Beskikbare profiele"
+
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr ""
+#~ "Slegs profiele wat versoenbaar is met die toestel sal bo gelys word."
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Brightness;Lock;Dim;Blank;Monitor;helderheid;sluit;verdof;"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "Instellings vir skermhelderheid in skermsluiting"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "Moenie sluit indien tuis nie"
+
+#~ msgid "Locations..."
+#~ msgstr "Liggings..."
+
+#~ msgid "Lock"
+#~ msgstr "Sluit vas"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "Ver_dof skerm om krag te spaar"
+
+#~ msgid "_Turn off after:"
+#~ msgstr "Skakel a_f ná:"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Aktiveer ontfoutkode"
+
+#~ msgid "Version of this application"
+#~ msgstr "Weergawe van hierdie toepassing"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME miniprogram vir volumebeheer"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Klank se afvoervolume"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "Mikrofoonvolume"
+
+#~ msgid "Mute"
+#~ msgstr "Doof uit"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "_Kies 'n toestel om in te stel:"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "Kon nie klankvoorkeure begin nie: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "_Doof uit"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "_Klankvoorkeure"
+
+#~ msgid "Muted"
+#~ msgstr "Uitgedoof"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Wys volumebeheer vir die werkskerm"
+
+#~ msgid "No shortcut set"
+#~ msgstr "Geen kortpad ingestel nie"
+
+#~ msgid "Key"
+#~ msgstr "Sleutel"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf-sleutel waar dié eienskap-redigeerder aangeheg is"
+
+#~ msgid "Callback"
+#~ msgstr "Terug-bel"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Reik dié terug-bel uit wanneer die waarde met sleutel geassosieer verander"
+
+#~ msgid "Change set"
+#~ msgstr "Verander stel"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf-veranderingstel wat data bevat moet aangestuur word na die gconf-"
+#~ "kliënt tydens toepassing"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Omskakeling na dingesie terug-bel"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Terug-bel moet uitgereik word wanneer data omgeskakel moet word vanaf "
+#~ "Gconf na dingesie"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Omskakeling vanaf dingesie terug-bel"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Terugbel moet uitgereik word wanneer data omgeskakel moet word na GConf "
+#~ "vanaf die dingesie"
+
+#~ msgid "UI Control"
+#~ msgstr "UI-kontrole"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Voorwerp wat die eienskap beheer (gewoonlik a dingesie)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Eienskap-redigeerder voorwerp data"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Doelgemaakte data vereis deur die spesifieke eienskap-redigeerder"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Eienskap-redigeerder data besig om terugbel vry te stel"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Terugbel moet uitgereik word wanneer die eienskap-redigeerder voorwerp "
+#~ "data vrygestel gaan word"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Kon nie die lêer '%s' vind nie.\n"
+#~ "\n"
+#~ "Maak asb. seker dat dit bestaan, en probeer weer of kies 'n ander "
+#~ "agtergrondprent."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Weet nie hoe om lêer '%s' te open nie.\n"
+#~ "Miskien is dit 'n tipe beeld wat nog nie ondersteun word nie.\n"
+#~ "\n"
+#~ "Kies liewer 'n ander prent."
+
+#~ msgid "Please select an image."
+#~ msgstr "Kies asb. 'n beeld."
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Voorkeure vir universele toegang"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "Wagtyd _voor aanvaarding:"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Biep wanneer 'n sleutel"
+
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~ msgid "Change contrast:"
+#~ msgstr "Verander kontras:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Beheer die muiswyser d.m.v. die syfersleutels"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Beheer die muiswyser d.m.v. die videokamera."
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Decrease size:"
+#~ msgstr "Verklein:"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Wys 'n tekstuele beskrywing van spraak en klanke"
+
+#~ msgid "Increase size:"
+#~ msgstr "Vergroot:"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Sleutelbord op die skerm"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "Options..."
+#~ msgstr "Keuses..."
+
+#~ msgid "Type here to test settings"
+#~ msgstr "Tik om instellings te toets"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Videomuis"
+
+#~ msgid "_Text size:"
+#~ msgstr "_Teksgrootte:"
+
+#~ msgid "accepted"
+#~ msgstr "aanvaar word"
+
+#~ msgid "pressed"
+#~ msgstr "gedruk word"
+
+#~ msgid "rejected"
+#~ msgstr "verwerp word"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Hoog/Invers"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Normaal"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "Vergroting"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Large"
+#~ msgstr "Groot"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Normaal"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Small"
+#~ msgstr "Klein"
+
+#~ msgid "More choices..."
+#~ msgstr "Meer keuses..."
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "U moet 'n nuwe wagwoord intik"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "U moet die wagwoord bevestig"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "U moet die huidige wagwoord intik"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "Die huidige wagwoord is verkeerd"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Te kort"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Redelik"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Blaai vir meer prente..."
+
+#~ msgid "This user does not exist."
+#~ msgstr "Dié gebruiker bestaan nie."
+
+#~ msgid "Create a user"
+#~ msgstr "Skep 'n gebruiker"
+
+#~ msgid "Cr_eate"
+#~ msgstr "Sk_ep"
+
+#~ msgid "_Account Type"
+#~ msgstr "_Rekeningtipe"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "_Bevestig wagwoord"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "Kies 'n gegenereerde wagwoord"
+
+#~ msgid "Disable this account"
+#~ msgstr "Deaktiveer dié rekening"
+
+#~ msgid "Fair"
+#~ msgstr "Redelik"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Hoe om 'n sterk wagwoord te kies"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Meld aan sonder 'n wagwoord"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "Dié wenk word dalk vertoon by die aanmeldskerm.  Dit sal sigbaar wees vir "
+#~ "alle gebruikers van dié stelsel.  <b>Moenie</b> die wagwoord hier gebruik "
+#~ "nie."
+
+#~ msgid "_Hint"
+#~ msgstr "_Wenk"
+
+#~ msgid "Account _type"
+#~ msgstr "Rekening_tipe"
+
+#~ msgid "Calibrate..."
+#~ msgstr "Kalibreer…"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Stel die Wacom-tabletvoorkeure in"
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Wacom-tekentablet"
+
+#~ msgid "- System Settings"
+#~ msgstr "- Stelselinstellings"
+
+#~ msgid "System Settings"
+#~ msgstr "Stelselinstellings"
+
+#~ msgid "Current network location"
+#~ msgstr "Huidige netwerkligging"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "URL vir meer agtergronde"
+
+#~ msgid "More themes URL"
+#~ msgstr "URL vir meer temas"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "Stel hierdie op die huidige liggingnaam. Dit word gebruik om die regte "
+#~ "instelling vir die instaanbediener te bepaal."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "URL vanwaar meer werskermagtergronde gekry kan word. As dit op 'n leë "
+#~ "string gestel word, sal dit nie verskyn nie."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "URL vanwaar meer werskermtemas gekry kan word. As dit op 'n leë string "
+#~ "gestel word, sal dit nie verskyn nie."
+
+#~ msgid "Locked"
+#~ msgstr "Vasgesluit"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "Dialoog is ontsluit.\n"
+#~ "Klik om verdere veranderinge te voorkom"
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "Dialoog is vasgesluit.\n"
+#~ "Klik om veranderinge te maak"
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "Stelselbeleid voorkom veranderinge.\n"
+#~ "Kontak u stelseladministrateur"
+
+#~ msgid "24-Hour Time"
+#~ msgstr "24-uur-tyd"
+
+#~ msgid "Upside-down"
+#~ msgstr "Onderstebo"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f KG"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f MG"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f GG"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TG"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PG"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EG"
+
+#~ msgid "Photos"
+#~ msgstr "Foto's"
+
+#~ msgid "Updates Available"
+#~ msgstr "Opdaterings beskikbaar"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "Gebruik die verstekuitleg in nuwe vensters"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "_Versnelling:"
+
+#~ msgid "On AC power:"
+#~ msgstr "Op muurkrag:"
+
+#~ msgid "Put the computer to sleep when inactive:"
+#~ msgstr "Laat die rekenaar sluimer indien onaktief:"
+
+#~ msgid "When the sleep button is pressed:"
+#~ msgstr "Wanneer die sluimerknoppie gedruk word:"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr ""
+#~ "Keyboard;Mouse;a11y;Accessibility;sleutelbord;toetsbord;toeganklikheid;"
+
+#~| msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">Hoog/Invers</span>"
+
+#~| msgctxt "universal access, contrast"
+#~| msgid "<span size=\"x-large\">High</span>"
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">Hoog</span>"
+
+#~| msgctxt "universal access, contrast"
+#~| msgid "<span size=\"x-large\">Low</span>"
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">Laag</span>"
+
+#~| msgctxt "universal access, contrast"
+#~| msgid "<span size=\"x-large\">Normal</span>"
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">Normaal</span>"
+
+#~ msgid "An error has occured during a maintenance command."
+#~ msgstr "'n Fout het voorgekom tydens 'n onderhoudopdrag."
+
+#, fuzzy
+#~ msgid "The type of alert"
+#~ msgstr "Die tipe versneller."
+
+#~ msgid "Show more _details"
+#~ msgstr "Wys meer beson_derhede"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "Plaas u linkerduim op %s"
+
+#~ msgid "No Image"
+#~ msgstr "Geen beeld"
+
+#~ msgid "Images"
+#~ msgstr "Beelde"
+
+#~ msgid "All Files"
+#~ msgstr "Alle lêers"
+
+#~ msgid "About %s"
+#~ msgstr "Aangaande %s"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "Aktiveer aanmelding met _vingerafdruk..."
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "Deaktiveer aanmelding met _vingerafdruk..."
+
+#~ msgid "Place finger on reader"
+#~ msgstr "Plaas u vinger op die leser"
+
+#~ msgid ""
+#~ "Left thumb\n"
+#~ "Left middle finger\n"
+#~ "Left ring finger\n"
+#~ "Left little finger\n"
+#~ "Right thumb\n"
+#~ "Right middle finger\n"
+#~ "Right ring finger\n"
+#~ "Right little finger"
+#~ msgstr ""
+#~ "Linkerduim\n"
+#~ "Linkermiddelvinger\n"
+#~ "Linkerringvinger\n"
+#~ "Linkerpinkie\n"
+#~ "Regterduim\n"
+#~ "Regtermiddelvinger\n"
+#~ "Regterringvinger\n"
+#~ "Regterpinkie"
+
+#~ msgid "<b>Email</b>"
+#~ msgstr "<b>E-pos</b>"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Tuis</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Kitsboodskappe</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Werk</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Telefoon</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Web</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Werk</b>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "M_aatskappy:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Verander wagwoo_rd..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "S_tad:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "La_nd:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "Tuis:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "Pos_bus:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "Pos_bus:"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "Tik asb. weer u wagwoord in die <b>Wagwoord (weer)</b>-veld."
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Deelstaat/provinsie:"
+
+#~ msgid "Web _log:"
+#~ msgstr "Webjoernaa_l:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "Wer_k:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "Werk_faks:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "ZIP/Poskode:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Tuisblad:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Tuis:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "Deel_staat/provinsie:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Werk:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "_ZIP/Poskode:"
+
+#~ msgid "System error: %s."
+#~ msgstr "Stelselfout: %s."
+
+#~ msgid "A system error has occurred"
+#~ msgstr "'n Stelselfout het voorgekom"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "Klik <b>Verander wagwoord</b> om u wagwoord te verander."
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "Tik asb. u wagwoord in die <b>Nuwe wagwoord</b>-veld."
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>Helpende tegnologieë</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>Voorkeure</b>"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "Toeganklike aanmeldin_g"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Voorkeure vir helpende tegnologieë"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "Veranderinge aan helpende tegnologieë sal eers by die volgende aanmelding "
+#~ "in werking tree."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Sluit en _meld af"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Spring na die venster vir voorkeurtoepassings"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "Spring na die venster vir toeganklike aanmelding"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "Spring na venster vir sleutelbord-toegangklikheid"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Spring na venster vir muistoegangklikheid"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Aktiveer helpende tegnologieë"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "_Muistoeganklikheid"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "_Voorkeurtoepassings"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "Helpende Tegnologieë"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr ""
+#~ "Kies watter toeganklikheidseienskappe by aanmelding geaktiveer moet word"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Lettertipe mag dalk te groot wees"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Die geselekteerde lettertipe is %d punt groot en mag dit moeilik maak om "
+#~ "die rekenaar effektief te gebruik.  Gebruik eerder 'n grootte kleiner as "
+#~ "%d."
+#~ msgstr[1] ""
+#~ "Die geselekteerde lettertipe is %d punte groot, en mag dit moeilik maak "
+#~ "om die rekenaar effektief te gebruik.  Gebruik eerder 'n grootte kleiner "
+#~ "as %d."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Die geselekteerde lettertipe is %d punt groot en mag dit moeilik maak om "
+#~ "die rekenaar effektief te gebruik.  Gebruik eerder 'n kleiner grootte "
+#~ "lettertipe."
+#~ msgstr[1] ""
+#~ "Die geselekteerde lettertipe is %d punte groot, en mag dit moeilik maak "
+#~ "om die rekenaar effektief te gebruik.  Gebruik eerder 'n kleiner grootte "
+#~ "lettertipe."
+
+#~ msgid "Use selected font"
+#~ msgstr "Gebruik gekose lettertipe"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Gee die lêernaam van die tema om te installeer"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "Gee die naam van die bladsy om te wys (theme|background|fonts|interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[MUURPAPIER...]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "Hierdie tema sal nie lyk soos dit bedoel is nie omdat die benodigde GTK+-"
+#~ "tema-enjin '%s' nie geïnstalleer is nie."
+
+#~ msgid "Apply Background"
+#~ msgstr "Pas agtergrond toe"
+
+#~ msgid "Apply Font"
+#~ msgstr "Pas lettertipe toe"
+
+#, fuzzy
+#~ msgid "Revert Font"
+#~ msgstr "_Verwyder"
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "Die huidige tema stel 'n agtergrond en 'n skriftipe voor."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "Die huidige tema stel 'n agtergrond."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "Die huidige tema stel 'n skriftipe voor."
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>Kl_eure</b>"
+
+#~ msgid "<b>Hinting</b>"
+#~ msgstr "<b>Belyning met rooster</b>"
+
+#~ msgid "<b>Menus and Toolbars</b>"
+#~ msgstr "<b>Kieslyste en nutsbalke</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Voorskou</b>"
+
+#~ msgid "<b>Rendering</b>"
+#~ msgstr "<b>Verbeelding</b>"
+
+#~ msgid "<b>Smoothing</b>"
+#~ msgstr "<b>Gelykmaking</b>:"
+
+#~ msgid "<b>Subpixel Order</b>"
+#~ msgstr "<b>Subpixel-orde</b>"
+
+#~ msgid "<b>_Desktop Background</b>"
+#~ msgstr "<b>_Werkarea se agtergrond</b>"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Beste _vorms"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "D_oelmaak..."
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr ""
+#~ "Verandering van die wysertema tree in werking by die volgende aanmelding."
+
+#~ msgid "Controls"
+#~ msgstr "Kontroles"
+
+#~ msgid "Customize Theme"
+#~ msgstr "Doelgemaakte tema"
+
+#~ msgid "D_etails..."
+#~ msgstr "D_etail..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "_Werkarealettertipe:"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "Detail van lettertipeverbeelding"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Gr_ysskaal"
+
+#~ msgid "Icons"
+#~ msgstr "Ikone"
+
+#~ msgid "N_one"
+#~ msgstr "G_een"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Open 'n dialoog om die kleur te spesifiseer"
+
+#~ msgid "R_esolution:"
+#~ msgstr "R_esolusie:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "Stoor tema as..."
+
+#~ msgid "Save _As..."
+#~ msgstr "Stoor _as..."
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "Soliede kleur\n"
+#~ "Horisontale gradiënt\n"
+#~ "Vertikale gradiënt"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sub_pixel (LCD's)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Sub_pixel gelykmakend (LCDs)"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "Teks onder items\n"
+#~ "Teks langs items\n"
+#~ "Slegs ikone\n"
+#~ "Slegs teks"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "Die huidige tema vir kontroles ondersteun nie kleurskemas nie."
+
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "Geteëld\n"
+#~ "Zoem\n"
+#~ "Gesentreer\n"
+#~ "Op skaal\n"
+#~ "Volskerm"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Etikette vir nutsbalk_knoppies:"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "_Beskrywing:"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Dokumentlettertipe:"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "R_edigeerbare kortpadsleutels vir kieslyste"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_Vastewydtelettertipe:"
+
+#~ msgid "_Medium"
+#~ msgstr "_Medium"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Monochroom"
+
+#~ msgid "_New"
+#~ msgstr "_Nuwe"
+
+#~ msgid "_None"
+#~ msgstr "_Geen"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "He_rstel na verstek"
+
+#~ msgid "_Selected items:"
+#~ msgstr "Ge_selekteerde items:"
+
+#~ msgid "_Size:"
+#~ msgstr "_Grootte:"
+
+#~ msgid "_Slight"
+#~ msgstr "_Effens"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "_Nutswenke:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Venstertitellettertipe:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Vensters:"
+
+#~ msgid "dots per inch"
+#~ msgstr "kolle per duim"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Pasmaak die voorkoms van die werkarea"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Installeer temapakkette vir verskillende dele van die werkarea"
+
+#~ msgid "Theme Installer"
+#~ msgstr "Tema-installeerder"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "GNOME-temapakket"
+
+#~ msgid "Slide Show"
+#~ msgstr "Skyfievertoning"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s by %d %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s by %d %s\n"
+#~ "Gids: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "Kan nie tema installeer nie"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "Die %s-hulper is nie geïnstalleer nie."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "Daar was 'n probleem met die uitpak van die tema."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "Daar was 'n fout met die installasie van die gekose lêer"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" blyk nie 'n geldige tema te wees nie."
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" blyk nie 'n geldige tema te wees nie. Dit is dalk 'n tema-enjin "
+#~ "wat gebou moet word."
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "Installasie van die tema \"%s\" het misluk."
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "Die tema \"%s\" is geïnstalleer."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "Wil u die nou toepas of die huidige tema behou?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Behou huidige tema"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Pas nuwe tema toe"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME-tema \"%s\" korrek geïnstalleer"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "Nuwe temas is suksesvol geïnstalleer."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Geen temalêer-ligging gespesifiseer om te installeer nie"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Onvoldoende regte om die tema te installeer in:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "Kies tema"
+
+#~ msgid "Theme Packages"
+#~ msgstr "Tema-pakkette"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Temanaam moet aanwesig wees"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Die tema bestaan reeds. Wil u dit vervang?"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Wil u hierdie tema skrap?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "Kon nie tema-enjin installeer nie"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Kan nie die instellingsbestuurder van 'gnome-settings-daemon' laai nie.\n"
+#~ "Sonder die GNOME-instellingsbestuurder wat loop, sal sommige voorkeure "
+#~ "nie in werking tree nie. Dit kan dui op 'n probleem met Bonobo, of 'n nie-"
+#~ "GNOME (bv. KDE) instellingsbestuurder mag reeds aktief wees en in konflik "
+#~ "wees met die GNOME-instellingsbestuurder."
+
+#, fuzzy
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Kan nie C-miniprogram voorraadikoon '%s' oplaai nie\n"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Daar was 'n fout met die vertoning van hulp: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Kopieer tans lêer %u van %u"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "Kopieer tans '%s'"
+
+#~ msgid "From URI"
+#~ msgstr "Vanaf URI"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI plaas tans oor van"
+
+#~ msgid "To URI"
+#~ msgstr "Na URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI plaas tans oor na"
+
+#~ msgid "Fraction completed"
+#~ msgstr "Fraksie voltooi"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Fraksie van oorplasing tans voltooi"
+
+#~ msgid "Current URI index"
+#~ msgstr "Huidige URI-indeks"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Huidige URI-indeks - begin by 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "Totale URI's"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Totale aantal URI's"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "Die lêer '%s' bestaan reeds. Wil u dit oorskryf?"
+
+#~ msgid "_Skip"
+#~ msgstr "_Slaan oor"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "Oorskryf _almal"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Verstekwyser - Huidig"
+
+#~ msgid "White Pointer"
+#~ msgstr "Wit wyser"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Wit wyser - Huidig"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Groot wyser - Huidig"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Groot wit wyser - Huidig"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Hierdie tema sal nie lyk soos dit bedoel is nie omdat die benodigde GTK+-"
+#~ "tema '%s' nie geïnstalleer is nie."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "Hierdie tema sal nie lyk soos dit bedoel is nie omdat die benodigde "
+#~ "vensterbestuurder-tema '%s' nie geïnstalleer is nie."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Hierdie tema sal nie lyk soos dit bedoel is nie omdat die benodigde ikoon-"
+#~ "tema '%s' nie geïnstalleer is nie."
+
+#~ msgid "Preferred Applications"
+#~ msgstr "Voorkeurtoepassings"
+
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Fout met stoor van opstelling: %s"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "Gee die naam van die bladsy om te wys (internet|multimedia|system|a11y)"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>Beeldkyker</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>Kitsboodskappe</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>Posleser</b>"
+
+#, fuzzy
+#~ msgid "<b>Mobility</b>"
+#~ msgstr "<b>Ondersteuning</b>"
+
+#~ msgid "<b>Multimedia Player</b>"
+#~ msgstr "<b>Multimediaspeler</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Terminaal-emuleerder</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Teksredigeerder</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Videospeler</b>"
+
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b>Visueel</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Webblaaier</b>"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Op_drag:"
+
+#, fuzzy
+#~ msgid "E_xecute flag:"
+#~ msgstr "E_xec Flag:"
+
+#~ msgid "Internet"
+#~ msgstr "Internet"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Open skakel in nuwe _oortjie"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Open skakel in nuwe _venster"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Open skakel met webblaaier se verste_k"
+
+#~ msgid "Run at st_art"
+#~ msgstr "Voer uit aan b_egin"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Loop in t_erminaal"
+
+#~ msgid "_Run at start"
+#~ msgstr "Voer uit aan _begin"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee-musiekspeler"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debien se \"sensible-browser\""
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian terminaal-emuleerder"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Epiphany-webblaaier"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution-posprogram"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "GNOME-vergrootglas sonder skermleser"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "GNOME-terminaal"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus met Vergrootglas"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape-pos"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "GNOME-vergrootglas sonder skermleser"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Linux-skermleser met Vergrootglas"
+
+#~ msgid "Listen"
+#~ msgstr "Listen"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla-pos"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "Orca met Vergrootglas"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox-musiekspeler"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey-pos"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Thunderbird"
+#~ msgstr "Thunderbird"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem-filmspeler"
+
+#~ msgid "<b>Panel icon</b>"
+#~ msgstr "<b>Paneelikoon</b>"
+
+#~ msgid "<i>Drag the monitors to set their place</i>"
+#~ msgstr "<i>Sleep die monitors om hulle plekke te stel</i>"
+
+#, fuzzy
+#~ msgid "Display Preferences"
+#~ msgstr "Werkarea agtergrond-voorkeure"
+
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "Normaal\n"
+#~ "Links\n"
+#~ "Regs\n"
+#~ "Onderstebo\n"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Verander skermresolusie"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "<b>Monitor: %s</b>"
+#~ msgstr "<b>Monitor: %s</b>"
+
+#~ msgid "Could not apply the selected configuration"
+#~ msgstr "Kon nie die gekose opstelling toepas nie"
+
+#~ msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+#~ msgstr "Kon nie org.gnome.SettingsDaemon.XRANDR kry nie"
+
+#~ msgid "Desktop"
+#~ msgstr "Werkarea"
+
+#, fuzzy
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr ""
+#~ "Fout met uitwerkingstelling van versnel in konfigurasie databasis: %s\n"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Wys kortpadsleutel toe aan opdragte"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Pas net die instellings toe en stop (slegs aanpasbaarheid; nou gehanteer "
+#~ "deur daemoon)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Laai die bladsy met die tikonderbreking-instellings wat wys"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Laai die bladsy met die toeganklikheidsinstellings wat wys"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- GNOME se sleutelbordvoorkeure"
+
+#~ msgid "<b>Bounce Keys</b>"
+#~ msgstr "<b>Bonssleutels</b>"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>Algemeen</b>"
+
+#~ msgid "<b>Slow Keys</b>"
+#~ msgstr "<b>Stadige sleutels</b>"
+
+#~ msgid "<b>Sticky Keys</b>"
+#~ msgstr "<b>Taai sleutels</b>"
+
+#~ msgid "<b>Visual cues for sounds</b>"
+#~ msgstr "<b>Visuele aanduiding van klanke</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Vinnig</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Lank</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Kort</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Stadig</i></small>"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Laa_t uitstel van onderbrekings toe"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Oudioterugv_oer..."
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Biep as sleutel ver_werp word"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Maak seker of onderbrekings uitgestel mag word"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Kies 'n sleutelbordmodel"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Tydsduur van die onderbreking wanneer nie getik mag word nie"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Tydsduur van werk voordat onderbreking afgedwing word"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Oudioterugvoer vir sleutelbordtoeganklikheid"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Sleutelbordvoorkeure"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Sleutelbord _model:"
+
+#~ msgid "Layout _Options..."
+#~ msgstr "Uitleg se _keuses..."
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Sluit skerm na 'n sekere tydsduur om herhaalde sleutelbordgebruik-"
+#~ "beserings te help voorkom"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Onderbrekingsinterval duur:"
+
+#~ msgid "_Country:"
+#~ msgstr "_Land:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "S_luit skerm om tikonderbreking af te dwing"
+
+#~ msgid "_Models:"
+#~ msgstr "_Modelle:"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_Aanvaar slegs sleutels wat lank ingehou word"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Uitgesoekte uitlegte:"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Simuleer gelyktydige sleutels"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variante:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_Verskaffers:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Werkinterval duur:"
+
+#, fuzzy
+#~ msgid "gesture|Disabled"
+#~ msgstr "Buite werking gestel"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "Gee die naam van die bladsy om te wys (general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- GNOME se muiisvoorkeure"
+
+#, fuzzy
+#~ msgid "<b>Dwell Click</b>"
+#~ msgstr "<b>Dubbelkiek Uitteltyd </b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Vind Wyser</b>"
+
+#~ msgid "<b>Mouse Orientation</b>"
+#~ msgstr "<b>Muisoriëntasie</b>"
+
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i>Hoog</i></small>"
+
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i>Groot</i></small>"
+
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>Laag</i></small>"
+
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i>Klein</i></small>"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Kies die kliktipe _vooraf"
+
+#~ msgid "D_rag click:"
+#~ msgstr "S_leepklik:"
+
+#~ msgid "_Single click:"
+#~ msgstr "_Enkelklik:"
+
+#~ msgid "Location already exists"
+#~ msgstr "Ligging bestaan reeds"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Stel jou voorkeure in vir netwerkinstaanbedieners"
+
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>Lys van geïgnoreerde adresse</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_Selfdoen instaankonfigurasie</b>"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP-instaanbesonderhede"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Netwerkinstaan-voorkeure"
+
+#~ msgid "U_sername:"
+#~ msgstr "_Gebruikernaam:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Veilige HTTP-instaan:"
+
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "Gebr_uik dieselfde instaanbediener vir alle protokolle"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "Kan nie die voorkeuretoepassing vir die vensterbestuurder laai nie"
+
+#~ msgid "C_ontrol"
+#~ msgstr "C_ontrol"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_iper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "S_uper (of \"Windows-embleem\")"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Bewegingsleutel</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Titelbalkaksie</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Vensterseleksie</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Om 'n venster te skuif, druk-en-hou hierdie sleutel en gryp dan die "
+#~ "venster:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Venster-voorkeure"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Dubbelkliek titelbalk om hierdie aksie uit te voer:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Interval voor oplig:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Lig geselekteerde vensters op na interval"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Kies vensters wanneer die muis oor hulle beweeg"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Stel die venster-eienskappe"
+
+#~ msgid "Windows"
+#~ msgstr "Vensters"
+
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>Begin %s</b>"
+
+#~ msgid "Upgrade"
+#~ msgstr "Gradeer op"
+
+#~ msgid "Uninstall"
+#~ msgstr "Oninstalleer"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "Voeg by gunstelinge"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Verwyder uit beginprogramme"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Voeg by beginprogramme"
+
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>Geen passendes gevind nie.</b> </span><span>\n"
+#~ "\n"
+#~ " Die filter \"<b>%s</b>\" pas nie enige items nie.</span>"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "Nuwe sigblad"
+
+#~ msgid "New Document"
+#~ msgstr "Nuwe dokument"
+
+#~ msgid "Documents"
+#~ msgstr "Dokumente"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Open</b>"
+
+#~ msgid "Rename..."
+#~ msgstr "Hernoem..."
+
+#~ msgid "Send To..."
+#~ msgstr "Stuur aan..."
+
+#~ msgid "Move to Trash"
+#~ msgstr "Skuif na asblik"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "As u 'n item skrap, sal dit permanent verlore wees."
+
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>Open met \"%s\"</b>"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "Open in lêerbestuurder"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Vandag %k:%M"
+
+#~ msgid "Find Now"
+#~ msgstr "Vind nou"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Open %s</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "Verwyder uit stelselitems"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "Vensterbestuurder \"%s\" het nie 'n konfigurasie-nutsgoed geregistreer "
+#~ "nie\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "Maksimeer vertikaal"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Maksimeer horisontaal"
+
+#~ msgid "Roll up"
+#~ msgstr "Rol op"
+
+#~ msgid "Groups"
+#~ msgstr "Groepe"
+
+#~ msgid "Common Tasks"
+#~ msgstr "Algemene take"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Sluit die beheersentrum wanneer 'n taak geaktiveer is"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Die GNOME-konfigurasieprogram"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_Vertraag onderbreking"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Neem 'n breuk"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d minuut voor volgende onderbreking"
+#~ msgstr[1] "%d minute voor volgende onderbreking"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Minder as een minuut tot volgende onderbreking"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Kan nie die eienskapdialoog vir tikonderbrekings open nie weens die "
+#~ "volgende fout: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Geskryf deur Richard Hult <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Versierings bygevoeg deur Anders Carlsson"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "'n Herinnering aan 'n rekenaarbreuk."
+
+#~ msgid "translator-credits"
+#~ msgstr "Friedel Wolff"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Moenie toets of die kennisgewingarea bestaan nie"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Die tikmonitor gebruik die kennisgewingarea om inligting te vertoon. Dit "
+#~ "lyk asof daar nie 'n kennisgewingarea op die paneel is nie. Om dit by te "
+#~ "voeg, klik regs op die paneel, kies 'Voeg by paneel', kies "
+#~ "'kennisgewingarea' en klik 'Voeg by'."
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "Indien waar, sal OpenType-lettertipe geduimnaelskets wees."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Indien waar, sal PCF-lettertipe geduimnaelskets wees."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "Indien waar, sal TrueType-lettertipe geduimnaelskets wees."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Indien waar, sal Type1-lettertipe geduimnaelskets wees."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Stel hierdie sleutel in op die opdrag wat gebruik word om 'n "
+#~ "duimnaelskets te skep vir OpenType-lettertipes."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Stel hierdie sleutel in op die opdrag wat gebruik word om 'n "
+#~ "duimnaelskets te skep vir PCF-lettertipes."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Stel hierdie sleutel in op die opdrag wat gebruik word om 'n "
+#~ "duimnaelskets te skep vir TrueType-lettertipes."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Stel hierdie sleutel in op die opdrag wat gebruik word om 'n "
+#~ "duimnaelskets te skep vir Type1-lettertipes."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Duimnaelsketsopdrag vir OpenType-lettertipes"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Duimnaelsketsopdrag vir PCF-lettertipes"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Duimnaelsketsopdrag vir TrueType-lettertipes"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Duimnaelsketsopdrag vir Type1-lettertipes"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Om OpenType-lettertipes te duimnaelskets of nie"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Om PCF-lettertipes te duimnaelskets of nie"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Om TrueType-lettertipes te duimnaelskets of nie"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Om Type1-lettertipes te duimnaelskets of nie"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Coetzer én 'n kwêvoëltjie beïndruk a capella. 0123456789"
+
+#~ msgid "Copyright:"
+#~ msgstr "Kopiereg:"
+
+#~ msgid "Description:"
+#~ msgstr "Beskrywing:"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "gebruik: %s lettertipelêer\n"
+
+#~ msgid "Font Viewer"
+#~ msgstr "Lettertipe-bekyker"
+
+#~ msgid "Preview fonts"
+#~ msgstr "Kry 'n voorskou van lettertipes"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Voorskouteks (verstek: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEKS"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Lettergrootte (verstek: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "GROOTTE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "LETTERTIPELÊER AFVOERLÊER"
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "_Wagwoord:"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Laai hierdie helpende tegnologieë elke keer wanneer jy aanmeld:"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "Helpende Tegnologie Ondersteuning"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr ""
+#~ "Aktiveer ondersteuning vir GNOME helpende tegnologieë tydens aanmelding"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Geen Helpende Tegnologie beskikbaar op jou stelsel nie.  Die 'gok'-pakket "
+#~ "moet geïnstalleer word ten einde aan-skerm sleutelbord ondersteuning te "
+#~ "kry, en die 'gnopernicus'-pakket moet geïnstalleer word vir skermlees- en "
+#~ "vergrotingsvermoë."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Nie alle beskikbare helpende tegnologieë is op jou stelsel geïnstalleer "
+#~ "nie.Die 'gok'-pakket moet geïnstalleer word ten einde op-skerm "
+#~ "sleutelbord ondersteuning te kry."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+#~ msgstr ""
+#~ "Nie alle beskikbare helpende tegnologieë is op jou stelsel geïnstalleer "
+#~ "nie.  Die 'gnopernicus'-pakket moet geïnstalleer word vir skermlees- en "
+#~ "vergrotingsvermoë."
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "Daar was 'n fout met die laat loop van die muisvoorkeurdialoog: %s"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Kan nie AccessX-stellings intrek uit lêer '%s' nie"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Trek Kenmerk-instellingslêer in"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Stel jou sleutelbord-toeganklikheidsvoorkeure in"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Die blyk asof hierdie stelsel nie die XKB-uitbreiding het nie.  Die "
+#~ "sleutelbord-toeganklikheidskenmerke sal nie daarsonder werk nie."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Aktiveer _Muissleutels</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>Aktiveer _Herhaalsleutels</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Kenmerke</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Wisselsleutels</b>"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr ""
+#~ "Biep wanneer 'n LED aangeskakel word, en twee bieps wanneer een "
+#~ "afgeskakel word."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Vertraging tussen sleuteldruk en wyser be_weging:"
+
+#~ msgid "E_nable Toggle Keys"
+#~ msgstr "A_ktiveer Wisselsleutels"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Ignoreer alle opvolgende druk van DIESELFDE sleutel indien dit binne 'n "
+#~ "gebruiker se gekose tydperiode gebeur."
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Ma_ksimum wyserspoed:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Muis _Voorkeure..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Aanvaar slegs sleutels nadat hulle gedruk is en vir 'n gebruiker-"
+#~ "aanpasbare tydsduur ingehou is."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Voer veelvuldige en gelyktydige sleuteldruk-bewerkings uit deur die "
+#~ "wysigersleutels in volgorde te druk."
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Tyd om te ver_snel na maksimum spoed:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Verander die numeriese-sleutelbordjie na 'n muiskontrole-bordjie."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Versper indien ongebruik vir:"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Trek Kenmerk-instellings in..."
+
+#~ msgid "characters/second"
+#~ msgstr "karakters/sekonde"
+
+#~ msgid "milliseconds"
+#~ msgstr "millisekondes"
+
+#~ msgid "pixels/second"
+#~ msgstr "pixels/sekonde"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Voeg Muurpapier by"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Pas net instellings toe en stop"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Herstel en stoor argaïese-instellings"
+
+#~ msgid "Epiphany"
+#~ msgstr "Epiphany"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M Text Browser"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Lynx Text Browser"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Links Text Browser"
+
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "Spesifiseer asb. 'n naam en 'n opdrag vir hierdie redigeerder."
+
+#, fuzzy
+#~ msgid "C_ustom:"
+#~ msgstr "Doelgemaak"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Doelgemaakte Redigeerder-eienskappe"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "Verstek Posleser"
+
+#~ msgid "Default Terminal"
+#~ msgstr "Verstek Terminaal"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "Verstek Teksredigeerder"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "Verstek Webblaaier"
+
+#~ msgid "Edit..."
+#~ msgstr "Redigeer..."
+
+#, fuzzy
+#~ msgid "Run in a _terminal"
+#~ msgstr "Loop in _Terminaal"
+
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "Kies die vensterbestuurder wat jy wil hê.  Jy sal toepas moet druk, die "
+#~ "towerstaf moet swaai, en 'n towerdans moet uitvoer sodat dit kan werk."
+
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "Verstaan _Netscape-afstandbeheer"
+
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr ""
+#~ "Gebruik hierdie _redigeerder om tekslêers te open in die lêerbestuurder"
+
+#~ msgid "Window Manager"
+#~ msgstr "Vensterbestuurder"
+
+#~ msgid "_Properties..."
+#~ msgstr "_Eienskappe..."
+
+#, fuzzy
+#~ msgid "_Select:"
+#~ msgstr "_Kies"
+
+#~ msgid "Screen Resolution"
+#~ msgstr "Skermresolusie"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Skermresolusie-voorkeure"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Maak verstek vir hierdie rekenaar slegs (%s)"
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Toets die nuwe instellings. As jy nie binne %d sekonde reageer nie, sal "
+#~ "die vorige instellings herstel word. "
+#~ msgstr[1] ""
+#~ "Toets die nuwe instellings. As jy nie binne %d sekondes reageer nie sal "
+#~ "die vorige instellings herstel word."
+
+#, fuzzy
+#~ msgid "Keep Resolution"
+#~ msgstr "_Behou resolusie"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Behou resolusie"
+
+#, fuzzy
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "Die X-bediener ondersteun nie die XRandR-uitbreiding nie.  Looptyd-"
+#~ "resolusie veranderinge na die vertoongrootte is nie beskikbaar nie."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Die XRandR-uitbreiding weergawe is onversoenbaar met hierdie program. "
+#~ "Looptyd-veranderinge aan die vertoongrootte is nie beskikbaar nie."
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Kies lettertipes vir die werkarea"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "Gaan _na lettertipe-vouer"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "_Terminaal-lettertipe:"
+
+#~ msgid "Window Management"
+#~ msgstr "Vensterbestuur"
+
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "Fout met instelling van nuwe versnel-konfigurasie databasis: %s\n"
+
+#~ msgid "There was an error launching the keyboard capplet : %s"
+#~ msgstr "Daar was 'n fout met die oopmaak van die sleutelbordkapalet : %s"
+
+#, fuzzy
+#~ msgid "..."
+#~ msgstr "Voeg by..."
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Toeganklikheid..."
+
+#~ msgid "The default cursor that ships with X"
+#~ msgstr "Die verstekwyser wat saam met X vaar"
+
+#~ msgid "The default cursor inverted"
+#~ msgstr "Die verstekwyser omgekeer"
+
+#~ msgid "Large Cursor"
+#~ msgstr "Grootwyser"
+
+#~ msgid "Large version of normal cursor"
+#~ msgstr "Groot weergawe van normale wyser"
+
+#~ msgid "Large version of white cursor"
+#~ msgstr "Groot weergawe van witwyser"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Vinnig</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Hoog</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Groot</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Laag</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Stadig</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Klein</i>"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Merk die _wyser wanneer jy Ctrl druk"
+
+#~ msgid "Motion"
+#~ msgstr "Beweging"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "Advanced Configuration"
+#~ msgstr "Outokonfigurasie _URL:"
+
+#~ msgid "E_nable sound server startup"
+#~ msgstr "A_ktiveer klankbediener laaier"
+
+#~ msgid "_Sound an audible bell"
+#~ msgstr "_Lui 'n hoorbare klokkie"
+
+#~ msgid "_Sounds for events"
+#~ msgstr "_Klank vir gebeurtenisse"
+
+#~ msgid "_Visual feedback:"
+#~ msgstr "_Visuele terugvoer:"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Geen temas kon gevind word op jou stelsel nie.  Dit beteken waarskynlik "
+#~ "dat jou \"Theme Preferences\" dialoog verkeerd geïnstalleer was, of jy "
+#~ "het nog nie die \"gnome-themes\" pakket geïnstalleer nie."
+
+#, fuzzy
+#~ msgid "The file format is invalid"
+#~ msgstr "Die lêer %s is nie 'n geldige wav-lêer nie"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Die gespesifiseerde temalêer-lokaliteit is ongeldig"
+
+#, fuzzy
+#~ msgid "The file format is invalid."
+#~ msgstr "Die lêer %s is nie 'n geldige wav-lêer nie"
+
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s is die pad waar die temalêers geïnstalleer sal word. Dit kan nie "
+#~ "gekies word as die bronlokalitiet nie"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "Jy kan hierdie tema stoor deur die Save Theme-knoppie te druk."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "Die verstektemas skemas kon nie op jou stelsel gevind word nie.  Dit "
+#~ "beteken dat jy heel moontlik nie metacity geïnstalleer het nie, of dat "
+#~ "jou gconf inkorrek gekonfigureer is."
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr ""
+#~ "Nuwe temas kan ook geïnstalleer word deur hulle in die venster in te "
+#~ "sleep."
+
+#~ msgid "Save Theme"
+#~ msgstr "Stoor Tema"
+
+#~ msgid "Short _description:"
+#~ msgstr "Kort _beskrywing:"
+
+#~ msgid "Theme _Details"
+#~ msgstr "Tema _besonderhede"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr ""
+#~ "Hierdie tema stel geen spesifieke lettertipe of agtergrond voor nie."
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Hierdie tema stel 'n lettertipe en 'n agtergrond voor:"
+
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "_Gaan na Temavouer"
+
+#~ msgid "_Theme name:"
+#~ msgstr "_Tema naam:"
+
+#~ msgid "theme selection tree"
+#~ msgstr "tema seleksie-boom"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr ""
+#~ "Doelmaak die voorkoms van die nutsbalke en kieslysbalke in toepassings"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Gedrag en Voorkoms</b>"
+
+#~ msgid "Icons only"
+#~ msgstr "Ikone alleenlik"
+
+#~ msgid "Text below icons"
+#~ msgstr "Teks onder ikone"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Teks langs ikone"
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "_Verwyderbare nutsbalke"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Jy het pas die Shift-sleutel vir 8 sekondes gedruk.  Dit is die kortpad "
+#~ "vir die Stadige-sleuteleienskap wat die manier waarop jou sleutelbord "
+#~ "werk, affekteer."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Wil jy die Stadige-sleutels aktiveer?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Wil jy die Stadige-sleutels deaktiveer?"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Jy het pas die Shift-sleutel 5 keer namekaar gedruk.  Dit is die kortpad "
+#~ "vir die Taai-sleutels eienskap wat die manier waarop jou sleutelbord "
+#~ "werk, affekteer."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "Jy het pas twee sleutels gelyktydig gedruk, of die Shift-sleutel 5 keer "
+#~ "namekaar gedruk.  Dit skakel die Taai-sleutels eienskap af wat die manier "
+#~ "waarop jou sleutelbord werk, affekteer."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Wil Taai-sleutels aktiveer?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Wil jy die Taai-sleutels deaktiveer?"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Kan nie die gids \"%s\" skep nie.\n"
+#~ "Dit word benodig vir die verandering van wysers."
+
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "Sleutelbinding (%s) se funksie word herhaalde male gedefinieer\n"
+
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "Sleutelbinding  (%s) se binding word herhaalde male gedefinieer\n"
+
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Sleutelbinding (%s) is onvolledig\n"
+
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Sleutelbinding (%s) is ongeldig\n"
+
+#~ msgid "It seems that another application already has access to key '%d'."
+#~ msgstr ""
+#~ "Dit blyk asof 'n ander toepassing reeds toegang het tot sleutel '%d'."
+
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Fout terwyl probeer is om (%s)\n"
+#~ " te laat loopwat gekoppel is aan sleutel (%s)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Fout tydens aktivering van XKB-konfigurasie.\n"
+#~ "Moontlik interne X-bediener probleem.\n"
+#~ "\n"
+#~ "X-bedienerweergawe-data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "Indien jy hierdie situasie as 'n vlooi aanmeld, sluit asb. in:\n"
+#~ "- Die resultate van <b>xprop -stam | grep XKB</b>\n"
+#~ "- Die resultate van <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/"
+#~ "xkb</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "Jy gebruik XFree 4.3.0.\n"
+#~ "Daar is bekende probleme met die komplekse XKB-konfigurasies.\n"
+#~ "Probeer om 'n eenvoudiger konfigurasie of gebruik van 'n nuwer weergawe "
+#~ "van XFree sagteware."
+
+#, fuzzy
+#~ msgid "Do _not show this warning again"
+#~ msgstr "_Moenie weer hierdie boodskap wys nie"
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Kon nie opdrag uitvoer nie: %s\n"
+#~ "Verifieer dat hierdie opdrag bestaan."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Kon nie die masjien in slaap stel nie.\n"
+#~ "Verifieer dat die masjien korrek gekonfigureer is."
+
+#~ msgid "Permissions on the file %s are broken\n"
+#~ msgstr "Toestemmings op die lêer %s is verbreek\n"
+
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Daar was 'n probleem met die laai van die skermskut:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Skermskut funksionaliteit sal nie in hierdie sessie werk nie."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Moenie weer hierdie boodskap wys nie"
+
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "Kon nie klanklêer %s laai as voorbeeld %s nie"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Kan nie gebruiker se tuisgids vasstel nie"
+
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "GConf-sleutel %s is ingestel na tipe %s maar sy verwagte tipe was %s\n"
+
+#, fuzzy
+#~ msgid "Do _not show this warning again."
+#~ msgstr "_Moenie weer hierdie boodskap wys nie"
+
+#, fuzzy
+#~ msgid "_Loaded files:"
+#~ msgstr "Model"
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Tipe van bg_applier: BG_APPLIER_ROOT vir stamvenster of "
+#~ "BG_APPLIER_PREVIEW vir voorskou"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Wydte indien toepasser 'n voorskou is: Verstek na 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Voorskou Hoogte"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Hoogte indien toepasser 'n voorskou is: Verstek na 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Skerm waarop BGApplier moet teken"
+
+#, fuzzy
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Daar was 'n fout met die vertoning van hulp: %s"
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package\n"
+#~ "for a set of default sounds."
+#~ msgstr ""
+#~ "Die klanklêer vir hierdie gebeurtenis bestaan nie.\n"
+#~ "Jy mag dalk gnome-audio-pakket\n"
+#~ " wil installeer vir 'n stel van verstek klanke."
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "Die lêer %s is nie 'n geldige wav-lêer nie"
+
+#~ msgid "Event"
+#~ msgstr "Gebeurtenis"
+
+#~ msgid "Sound _file:"
+#~ msgstr "Klank _lêer:"
+
+#~ msgid "_Play"
+#~ msgstr "_Speel"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "Indien waar, sal die MIME-hanteerders vir teks/gewoon en teks/* "
+#~ "gesinkroniseer gehou word"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Sinkroniseer teks/gewoon en tekst/* hanteerders"
+
+#~ msgid "Brightness down"
+#~ msgstr "Helderheid-af"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Helderheid-af se kortpad."
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Helderheid-op se kortpad."
+
+#~ msgid "E-mail"
+#~ msgstr "E-pos"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "E-pos se kortpad."
+
+#, fuzzy
+#~ msgid "Home folder's shortcut."
+#~ msgstr "My Tuisvouer se kortpad."
+
+#, fuzzy
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Maak Hulpblaaier se kortpad oop."
+
+#, fuzzy
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Maak Webblaaier se kortpad oop."
+
+#, fuzzy
+#~ msgid "Log out's shortcut."
+#~ msgstr "Afmeld se kortpad."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Volgende snit-sleutel se kortpad."
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Wag-sleutel se kortpad."
+
+#, fuzzy
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Speel (of Speel/Wag) sleutel se kortpad."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Vorige snit-sleutel se kortpad."
+
+#~ msgid "Sleep"
+#~ msgstr "Slaap"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Slaap se kortpad."
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Stop terugspeel-sleutel se kortpad."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Volume sagter se kortpad."
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Volume uit se kortpad"
+
+#~ msgid "Volume step"
+#~ msgstr "Volume trap"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Volume trap as 'n persentasie van die volume."
+
+#, fuzzy
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr ""
+#~ "Vertoon 'n dialoog wanneer daar foute is met die loop van XScreenSaver"
+
+#, fuzzy
+#~ msgid "Run screensaver at login"
+#~ msgstr "Laat XScreenSaver loop by aanmelding"
+
+#, fuzzy
+#~ msgid "Start screensaver"
+#~ msgstr "Laai XScreenSaver"
+
+#, fuzzy
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Sleutelbord _model:"
+
+#, fuzzy
+#~ msgid "Keyboard model"
+#~ msgstr "Sleutelbord _model:"
+
+#, fuzzy
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr "XKB-instellings in gconf sal oorheers vanaf die stelsel ASAP"
+
+#, fuzzy
+#~ msgid "keyboard layout"
+#~ msgstr "XKB-sleutelbord-uitleg"
+
+#, fuzzy
+#~ msgid "keyboard model"
+#~ msgstr "XKB-sleutelbord-model"
+
+#~ msgid "Break reminder"
+#~ msgstr "Onderbreking herinnering"
+
+#~ msgid "The typing monitor is already running."
+#~ msgstr "Die tikmonitor loop reeds."
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Moet _nie lettertipe toepas nie"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Die tema wat jy gekies het wil 'n nuwe letter hê. 'n Voorskou van die "
+#~ "lettertipe word hieronder vertoon."
+
+#~ msgid "Themes"
+#~ msgstr "Temas"
+
+#~ msgid "Description"
+#~ msgstr "Beskrywing"
+
+#~ msgid "Window border theme"
+#~ msgstr "Vensteromlysting-tema"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#, fuzzy
+#~ msgid "Sets the default theme"
+#~ msgstr "Terugstel na ver_stek"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "Indien waar, sal geïnstalleerde temas geduimnaelskets wees."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "Indien waar, sal die temas geduimnaelskets wees."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Stel hierdie sleutel in op die opdrag wat gebruik word om duimnaelsketse "
+#~ "te skep vir geïnstalleerde temas."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "Stel hierdie sleutel in op die opdrag wat gebruik word om duimnaelsketse "
+#~ "te skep vir temas."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Duimnaelsketsopdrag vir geïnstalleerde temas"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Duimnaelsketsopdrag vir temas"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Om geïnstalleerde temas te duimnaelskets of nie"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Om temas te duimnaelskets of nie"

--- a/po/am.po
+++ b/po/am.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2003-02-03 10:16+EDT\n"
 "Last-Translator: Ge'ez Frontier Foundation <locales@geez.org>\n"
 "Language-Team: Amharic <locales@geez.org>\n"
@@ -17,3411 +17,5796 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-#, fuzzy
-msgid "Alert Type"
-msgstr "የፋይል ዓይነት ጨምር"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-#, fuzzy
-msgid "Alert Buttons"
-msgstr "ቁልፎች"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-#, fuzzy
-msgid "Show more _details"
-msgstr "የጭብት ዝርዝሮች"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-#, fuzzy
-msgid "About Me"
-msgstr "ስለ... (_A)"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:554
-#, fuzzy
-msgid "Select Image"
-msgstr "አጥፉ"
-
-#: ../capplets/about-me/gnome-about-me.c:556
-#, fuzzy
-msgid "No Image"
-msgstr "ምስሎች"
-
-#: ../capplets/about-me/gnome-about-me.c:706
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:727
-msgid "Unable to open address book"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:739
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:770
-#: ../capplets/about-me/gnome-about-me.c:772
-#, fuzzy, c-format
-msgid "About %s"
-msgstr "ስለ... (_A)"
-
-#: ../capplets/about-me/gnome-about-me-password.c:101
-#: ../capplets/about-me/gnome-about-me-password.c:479
-msgid "Old password is incorrect, please retype it"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:112
-msgid "System error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:113
-msgid "Could not run /usr/bin/passwd"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:114
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:117
-msgid "Unexpected error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:315
-msgid "Password is too short"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:318
-#: ../capplets/about-me/gnome-about-me-password.c:321
-msgid "Password is too simple"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:324
-msgid "Old and new passwords are too similar"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:328
-msgid "Old and new password are the same"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:406
-#, fuzzy
-msgid "Please type the passwords."
-msgstr "ሚስጢራዊ _ቃል፦"
-
-#: ../capplets/about-me/gnome-about-me-password.c:414
-msgid "Please type the password again, it is wrong."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:417
-msgid "Click on Change Password to change the password."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/font/font-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-#, fuzzy
-msgid "    "
-msgstr "      "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-#, fuzzy
-msgid "<b>Email</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-#, fuzzy
-msgid "<b>Home</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-#, fuzzy
-msgid "<b>Instant Messaging</b>"
-msgstr "የተለመደው ጭብጥ\n"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-#, fuzzy
-msgid "<b>Job</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-#, fuzzy
-msgid "<b>Telephone</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-#, fuzzy
-msgid "<b>Web</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-#, fuzzy
-msgid "<b>Work</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-#, fuzzy
-msgid "A_ddress:"
-msgstr "ጨምር፦ (_A)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-#, fuzzy
-msgid "Address"
-msgstr "ጨምር፦ (_A)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-#, fuzzy
-msgid "C_ity:"
-msgstr "ዓይነት፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-#, fuzzy
-msgid "C_ompany:"
-msgstr "_ትእዛዝ፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-#, fuzzy
-msgid "Cale_ndar:"
-msgstr "ምድብ፦ (_G)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-#, fuzzy
-msgid "Change Passwo_rd..."
-msgstr "ሚስጢራዊ _ቃል፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-#, fuzzy
-msgid "Change Password"
-msgstr "ሚስጢራዊ _ቃል፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-#, fuzzy
-msgid "Ci_ty:"
-msgstr "ዓይነት፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-#, fuzzy
-msgid "Co_untry:"
-msgstr "Control"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-#, fuzzy
-msgid "Contact"
-msgstr "ይዞታዎች... (_C)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-#, fuzzy
-msgid "Cou_ntry:"
-msgstr "Control"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-#, fuzzy
-msgid "Hom_e:"
-msgstr "ስም፦ (_N)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-#, fuzzy
-msgid "Old pa_ssword:"
-msgstr "ሚስጢራዊ _ቃል፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P.O. _box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P._O. box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-#, fuzzy
-msgid "Personal Info"
-msgstr "የተርሚናል የፊደል ቅርጽ፦ (_T)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "State/Pro_vince:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#, fuzzy
-msgid "User name:"
-msgstr "የተጠቃሚ _ስም፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Web _log:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-#, fuzzy
-msgid "Wor_k:"
-msgstr "_ቀለም፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-#, fuzzy
-msgid "Work _fax:"
-msgstr "_ቀለም፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Zip/_Postal code:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-#, fuzzy
-msgid "_Address:"
-msgstr "ጨምር፦ (_A)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-#, fuzzy
-msgid "_Home page:"
-msgstr "የ_ጭብጥ ስም፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-#, fuzzy
-msgid "_Home:"
-msgstr "ስም፦ (_N)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-#, fuzzy
-msgid "_Manager:"
-msgstr "መስኮቱን መቆጣጠሪያ፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-#, fuzzy
-msgid "_Mobile:"
-msgstr "_ፋይል"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-#, fuzzy
-msgid "_New password:"
-msgstr "ሚስጢራዊ _ቃል፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-#, fuzzy
-msgid "_Profession:"
-msgstr "_መግለጫ፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-#, fuzzy
-msgid "_Retype new password:"
-msgstr "ሚስጢራዊ _ቃል፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-#, fuzzy
-msgid "_Title:"
-msgstr "_ፋይል"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-#, fuzzy
-msgid "_Work:"
-msgstr "_ቀለም፦"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Zip/Postal code:"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Applications</b>"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-#, fuzzy
-msgid "<b>Support</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-#, fuzzy
-msgid "Assistive Technology Preferences"
-msgstr "የመስኮት ምርጫዎች"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-#, fuzzy
-msgid "_Screenreader"
-msgstr "እስክሪን"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/main.c:60
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
-msgid "Import Feature Settings File"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
-msgid "_Import"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "የፊደል ሠሌዳ"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-#: ../capplets/theme-switcher/theme-install.glade.h:1
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-#, fuzzy
-msgid "<b>Features</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "ቀላል"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "አጣራዎች"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "S_peed:"
-msgstr "_ፍጥነት፦"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Type to test settings:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-msgid "milliseconds"
-msgstr "ሚሊሴኮንዶች"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr ""
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:885
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "ሴኮንዶች"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-msgid "Change your Desktop Background settings"
-msgstr ""
-
-#: ../capplets/background/background.desktop.in.in.h:2
-#, fuzzy
-msgid "Desktop Background"
-msgstr "መደብ"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-#, fuzzy
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "ሜኑና ቱልባር ምርጫዎች"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-#, fuzzy
-msgid "<b>_Desktop Colors</b>"
-msgstr "ሜኑና ቱልባር ምርጫዎች"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-#, fuzzy
-msgid "Desktop Background Preferences"
-msgstr "የመደቡ ምርጫዎች"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-#, fuzzy
-msgid "_Style:"
-msgstr "ዓይነት፦"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-capplet.c:1042
-#: ../capplets/background/gnome-wp-capplet.c:1060
-#, fuzzy
-msgid "Centered"
-msgstr "_መሀከል"
-
-#: ../capplets/background/gnome-wp-capplet.c:1068
-#: ../capplets/background/gnome-wp-capplet.c:1085
-#, fuzzy
-msgid "Fill Screen"
-msgstr "እስክሪን"
-
-#: ../capplets/background/gnome-wp-capplet.c:1093
-#: ../capplets/background/gnome-wp-capplet.c:1110
-#, fuzzy
-msgid "Scaled"
-msgstr "_የተመዘነ"
-
-#: ../capplets/background/gnome-wp-capplet.c:1118
-#: ../capplets/background/gnome-wp-capplet.c:1135
-#, fuzzy
-msgid "Tiled"
-msgstr "_ፋይል"
-
-#: ../capplets/background/gnome-wp-capplet.c:1159
-#: ../capplets/background/gnome-wp-capplet.c:1168
-#, fuzzy
-msgid "Solid Color"
-msgstr "ቀጣይ ቀለም"
-
-#: ../capplets/background/gnome-wp-capplet.c:1176
-#: ../capplets/background/gnome-wp-capplet.c:1185
-msgid "Horizontal Gradient"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-capplet.c:1193
-#: ../capplets/background/gnome-wp-capplet.c:1202
-msgid "Vertical Gradient"
-msgstr ""
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1251
-msgid "Add Wallpaper"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-item.c:292
-#: ../capplets/background/gnome-wp-item.c:294
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/common/activate-settings-daemon.c:18
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-
-#: ../capplets/common/capplet-stock-icons.c:94
-#, c-format
-msgid "Unable to load capplet stock icon '%s'\n"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/default-applications/gnome-default-applications-properties.c:765
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1021
-#: ../capplets/sound/sound-properties-capplet.c:244
-msgid "Retrieve and store legacy settings"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %i of %i"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr "ከ URI"
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr "ወደ URI"
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:345
-#, fuzzy
-msgid "From:"
-msgstr "ከ፦ %s"
-
-#: ../capplets/common/file-transfer-dialog.c:349
-#, fuzzy
-msgid "To:"
-msgstr "ሁለት"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "ቁልፍ"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1598
-#, fuzzy
-msgid "_Select"
-msgstr "አጥፉ"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
-#, fuzzy
-msgid "Debian Sensible Browser"
-msgstr "የነበረው የዌብ መቃኛ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
-msgid "Epiphany"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
-msgid "Galeon"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
-msgid "Encompass"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
-msgid "Firebird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
-msgid "Firefox"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
-msgid "Mozilla"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
-msgid "Netscape Communicator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
-msgid "Konqueror"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
-#, fuzzy
-msgid "W3M Text Browser"
-msgstr "የዌብ መቃኛ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
-#, fuzzy
-msgid "Lynx Text Browser"
-msgstr "የዌብ መቃኛ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
-#, fuzzy
-msgid "Links Text Browser"
-msgstr "የዌብ መቃኛ"
-
-#. The code in gnome-default-applications-properties.c makes sure
-#. * there is only one (the first entry in this list) Evolution entry
-#. * in the list shown to the user
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
-#, fuzzy
-msgid "Evolution Mail Reader"
-msgstr "የተለመደው የመረጃ መቃኛ፦ (_U)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
-msgid "Balsa"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
-msgid "KMail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
-msgid "Thunderbird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
-msgid "Mozilla Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
-msgid "Mutt"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
-#, fuzzy
-msgid "Debian Terminal Emulator"
-msgstr "የነበረው ተርሚናል"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
-#, fuzzy
-msgid "GNOME Terminal"
-msgstr "ተርሚናል"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
-#, fuzzy
-msgid "Standard XTerminal"
-msgstr "በተርሚናል ውስጥ ጀምር (_E)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
-msgid "NXterm"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
-msgid "RXVT"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
-#, fuzzy
-msgid "aterm"
-msgstr "ምድብ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
-#, fuzzy
-msgid "ETerm"
-msgstr "ተርሚናል"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.c:123
-msgid "Please specify a name and a command for this editor."
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "Add..."
-msgstr "ጨምር..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-#, fuzzy
-msgid "C_ustom"
-msgstr "_የተለየ፦"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "C_ustom:"
-msgstr "_የተለየ፦"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "Can open _URIs"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "Can open multiple _files"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "Co_mmand:"
-msgstr "_ትእዛዝ፦"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "Custom Editor Properties"
-msgstr "የተለመደው የጽሑፍ ማቀናጃ ምርጫዎች"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-#, fuzzy
-msgid "Default Mail Reader"
-msgstr "የነበረው መስኮቱን መቆጣጠሪያ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "Default Terminal"
-msgstr "የነበረው ተርሚናል"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Default Text Editor"
-msgstr "የነበረው የጽሑፍ ማቀናጃ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "Default Web Browser"
-msgstr "የነበረው የዌብ መቃኛ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Default Window Manager"
-msgstr "የነበረው መስኮቱን መቆጣጠሪያ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Delete"
-msgstr "አጥፉ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "E_xec Flag:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Edit..."
-msgstr "አስተካክል..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Mail Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-#, fuzzy
-msgid "Run in a _terminal"
-msgstr "በተርሚናሉ ውስጥ አስኪድ (_T)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-#, fuzzy
-msgid "Run in a t_erminal"
-msgstr "በተርሚናሉ ውስጥ አስኪድ (_T)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid ""
-"Select the window manager you want.  You will need to hit apply, wave the "
-"magic wand, and do a magic dance for it to work."
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Terminal"
-msgstr "ተርሚናል"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Text Editor"
-msgstr "የጽሑፍ ማቀናጃ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Understands _Netscape Remote Control"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "Use this _editor to open text files in the file manager"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "Web Browser"
-msgstr "የዌብ መቃኛ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
-msgid "Window Manager"
-msgstr "መስኮቱን መቆጣጠሪያ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
-#, fuzzy
-msgid "_Command:"
-msgstr "_ትእዛዝ፦"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
-msgid "_Name:"
-msgstr "ስም፦ (_N)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
-msgid "_Properties..."
-msgstr "ምርጫዎች... (_P)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
-#, fuzzy
-msgid "_Select:"
-msgstr "አጥፉ"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr ""
-
-#: ../capplets/display/main.c:448
-#, fuzzy
-msgid "_Resolution:"
-msgstr "_መግለጫ፦"
-
-#: ../capplets/display/main.c:467
-msgid "Re_fresh rate:"
-msgstr ""
-
-#: ../capplets/display/main.c:488
-#, fuzzy
-msgid "Default Settings"
-msgstr "የነበረው ተርሚናል"
-
-#: ../capplets/display/main.c:490
-#, fuzzy, c-format
-msgid "Screen %d Settings\n"
-msgstr "ጠለቅ ምርጫዎች"
-
-#: ../capplets/display/main.c:516
-#, fuzzy
-msgid "Screen Resolution Preferences"
-msgstr "የድምፅ ምርጫዎች"
-
-#: ../capplets/display/main.c:553
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr ""
-
-#: ../capplets/display/main.c:571
-#, fuzzy
-msgid "Options"
-msgstr "ትግባሮች"
-
-#: ../capplets/display/main.c:592
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/display/main.c:638
-#, fuzzy
-msgid "Keep Resolution"
-msgstr "_መግለጫ፦"
-
-#: ../capplets/display/main.c:642
-msgid "Do you want to keep this resolution?"
-msgstr ""
-
-#: ../capplets/display/main.c:667
-msgid "Use _previous resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:667
-msgid "_Keep resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:818
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-
-#: ../capplets/display/main.c:826
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "የፊደል ቅርጽ"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:2
-msgid "<b>Font Rendering</b>"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:3
-#, fuzzy
-msgid "<b>Hinting</b>:"
-msgstr "የተለመደው ጭብጥ\n"
-
-#: ../capplets/font/font-properties.glade.h:4
-#, fuzzy
-msgid "<b>Smoothing</b>:"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/font/font-properties.glade.h:5
-#, fuzzy
-msgid "<b>Subpixel order</b>:"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best _shapes"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "Best co_ntrast"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:8
-#, fuzzy
-msgid "D_etails..."
-msgstr "_ዝርዝሮች..."
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "የፊደል ቅርጽ ምርጫዎች"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:11
-#, fuzzy
-msgid "Go _to font folder"
-msgstr "ወደ የጭብጥ ዶሴ _ሂድ"
-
-#: ../capplets/font/font-properties.glade.h:12
-#, fuzzy
-msgid "Gra_yscale"
-msgstr "ግራጫማ (_R)"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "(ም_ንም)"
-
-#: ../capplets/font/font-properties.glade.h:14
-#, fuzzy
-msgid "R_esolution:"
-msgstr "_መግለጫ፦"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
 msgstr "_የመጠቀሚያ ፕሮግራሞች የፊደል ቅርጽ፦"
 
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr "_BGR"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "_የመጠቀሚያ ፕሮግራሞች የፊደል ቅርጽ፦"
 
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Desktop font:"
-msgstr "_ሠሌዳ የፊደል ቅርጽ፦"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "ጭብጥን _አስገባ..."
 
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Full"
-msgstr "ሙሉ (_F)"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_ክፈት"
 
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Medium"
-msgstr "መሀከለኛ (_M)"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "የጭብት ዝርዝሮች"
 
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Monochrome"
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
 msgstr ""
 
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_None"
-msgstr "_ምንም"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_RGB"
-msgstr "RGB"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_Slight"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Terminal font:"
-msgstr "የተርሚናል የፊደል ቅርጽ፦ (_T)"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "የመስኮት አርእስት የፊደል ቅርጽ፦ (_W)"
-
-#: ../capplets/font/font-properties.glade.h:30
-msgid "dots per inch"
-msgstr ""
-
-#: ../capplets/font/main.c:488
-msgid "Font may be too large"
-msgstr ""
-
-#: ../capplets/font/main.c:492
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/font/main.c:505
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:197
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "የተበላሸ"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:545
-msgid "<Unknown Action>"
-msgstr "<ያልታወቀ ትግባር>"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_ቦታ፦"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:566
-msgid "Desktop"
-msgstr "ሠሌዳ"
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr ""
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:567
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "መደብ"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "እስክሪን"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
 msgstr "ድምፅ"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:571
-msgid "Window Management"
-msgstr "የመስኮት ጉባኤ"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:668
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:700
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:750
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:857
-msgid "Action"
-msgstr "ትግባር"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:881
-msgid "Shortcut"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
 msgstr "አቋራጭ"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
 msgstr "የፊደል ሠሌዳው አቋራጭ"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
 msgstr ""
 
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
 #, fuzzy
-msgid "Unknown"
+msgid "File Types"
+msgstr "የፋይል ዓይነት ጨምር"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
 msgstr ""
-"<b>ያልታወቀ ጠቋሚ</b>\n"
-"%s"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
-msgid "Layout"
-msgstr "እቅድ"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
 
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "_የመጠቀሚያ ፕሮግራሞች የፊደል ቅርጽ፦"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "ዓይነት፦"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 #, fuzzy
 msgid "Default"
 msgstr "የነበረው የዌብ መቃኛ"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 #, fuzzy
-msgid "Models"
-msgstr "ሞዴል"
+msgid "Background"
+msgstr "መደብ"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:106
-#, c-format
-msgid "There was an error launching the keyboard capplet : %s"
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:240
-#: ../capplets/sound/sound-properties-capplet.c:242
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
 #, fuzzy
-msgid "..."
+msgid "_Add"
 msgstr "ጨምር..."
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
 #, fuzzy
-msgid "<b>Cursor Blinking</b>"
-msgstr "የተለመደው ጭብጥ\n"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-#, fuzzy
-msgid "<b>Repeat Keys</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>ቶሎ</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>ረጅም</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>አጭር</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>ዝግታ</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_vailable layouts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "All_ow postponing of breaks"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Check if breaks are allowed to be postponed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-#, fuzzy
-msgid "Choose A Keyboard Model"
-msgstr "የፊደል ሠሌዳ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Choose A Layout"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Duration of the break when typing is disallowed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of work before forcing a break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Key presses _repeat when key is held down"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Keyboard Preferences"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-#, fuzzy
-msgid "Keyboard _model:"
-msgstr "የፊደል ሠሌዳ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-#, fuzzy
-msgid "Layout Options"
-msgstr "የሥዕል ምርጫዎችን፦"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-#, fuzzy
-msgid "Layouts"
-msgstr "እቅድ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Microsoft Natural Keyboard"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-#, fuzzy
-msgid "Preview:"
-msgstr "ቅድመ ዕይታ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Reset To De_faults"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Separate _group for each window"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Typing Break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "_Accessibility..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-#, fuzzy
-msgid "_Add..."
-msgstr "ጨምር..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Break interval lasts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Delay:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-#, fuzzy
-msgid "_Models:"
+msgid "_Add profile"
 msgstr "ሞዴል"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Selected layouts:"
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Speed:"
-msgstr "_ፍጥነት፦"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Work interval lasts:"
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "minutes"
-msgstr ""
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:559
+#: panels/color/cc-color-panel.ui:511
 #, fuzzy
-msgid "Unknown Cursor"
-msgstr ""
-"<b>ያልታወቀ ጠቋሚ</b>\n"
-"%s"
+msgid "_Remove profile"
+msgstr "አስወግድ (_R)"
 
-#: ../capplets/mouse/gnome-mouse-properties.c:761
+#: panels/color/cc-color-panel.ui:517
 #, fuzzy
-msgid "Default Cursor"
-msgstr "የነበረው የዌብ መቃኛ"
+msgid "_View details"
+msgstr "_ዝርዝሮች"
 
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Cursor - Current"
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-msgid "The default cursor that ships with X"
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-msgid "White Cursor"
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Cursor - Current"
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-msgid "The default cursor inverted"
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-msgid "Large Cursor"
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Cursor - Current"
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-msgid "Large version of normal cursor"
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-msgid "Large White Cursor - Current"
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Cursor"
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-msgid "Large version of white cursor"
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:975
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:635
 #, fuzzy
-msgid "Cursor Theme"
-msgstr "የተለመደው ጭብጥ"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Mouse Orientation</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-#, fuzzy
-msgid "<b>Speed</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>ከፍ ያለ</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>ትልቅ</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>ዝቅ ያለ</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>ዝግታ</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>ትንሽ</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "ቁልፎች"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
-#, fuzzy
-msgid "Cursor Size:"
-msgstr "የተለመደው ጭብጥ"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Cursors"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-#, fuzzy
-msgid "Large"
-msgstr "የመመሪያ ገጾች"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-#, fuzzy
+msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "መሀከለኛ (_M)"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Motion"
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Mouse Preferences"
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
 #, fuzzy
-msgid "Small"
+msgid "Color"
+msgstr "ቀጣይ ቀለም"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "አጥፉ"
+
+#: panels/common/cc-language-chooser.ui:13
+#, fuzzy
+msgid "_Select"
+msgstr "አጥፉ"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "አቋራጭ"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "የተበላሸ"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "ሴኮንዶች"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "ምድብ፦ (_G)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "ምድብ፦ (_G)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "የነበረው ተርሚናል"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "_የመጠቀሚያ ፕሮግራሞች የፊደል ቅርጽ፦"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_መግለጫ፦"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
 msgstr "_የተመዘነ"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr ""
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your network proxy preferences"
-msgstr "ሜኑና ቱልባር ምርጫዎች"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>D_irect internet connection</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-#, fuzzy
-msgid "Advanced Configuration"
-msgstr "ጠለቅ ምርጫዎች"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-#, fuzzy
-msgid "Network Proxy Preferences"
-msgstr "የመደቡ ምርጫዎች"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "ፖርት፦"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "Proxy Configuration"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-#, fuzzy
-msgid "U_sername:"
-msgstr "የተጠቃሚ _ስም፦"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_ዝርዝሮች"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "ሚስጢራዊ _ቃል፦"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr ""
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr ""
-
-#: ../capplets/sound/sound-properties-capplet.c:271
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Sound Preferences"
-msgstr "የድምፅ ምርጫዎች"
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "E_nable sound server startup"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "Flash _entire screen"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "Flash _window titlebar"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "General"
-msgstr "አጠቃላይ"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "Sound Events"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "System Bell"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "_Sound an audible bell"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "_Sounds for events"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "_Visual feedback:"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:347
+#: panels/display/cc-night-light-page.ui:33
 msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:227
-msgid "This theme is not in a supported format."
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:244
-msgid "Failed to create temporary directory"
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:264
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:282
-#: ../capplets/theme-switcher/gnome-theme-installer.c:319
-#: ../capplets/theme-switcher/gnome-theme-installer.c:399
-msgid "Installation Failed"
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:302
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "ከ፦ %s"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr ""
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "ሁለት"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:340
-#, c-format
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:343
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:346
-#, c-format
-msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:349
-#, c-format
-msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:357
-msgid "The theme is an engine. You need to compile the theme."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:374
-msgid "The file format is invalid"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:468
-msgid "No theme file location specified to install"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:485
-msgid "The theme file location specified to install is invalid"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:505
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:526
-msgid "The file format is invalid."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:553
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:607
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "Custom theme"
-msgstr "የተለመደው ጭብጥ"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:72
-msgid "Theme name must be present"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:104
-msgid "The theme already exists. Would you like to replace it?"
-msgstr ""
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr ""
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "ጭብጥ"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-install.glade.h:3
-msgid "Theme Installation"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-install.glade.h:4
-msgid "_Install"
-msgstr "_አስገባ"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:5
-msgid "_Location:"
-msgstr "_ቦታ፦"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Apply _Background"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Apply _Font"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Controls"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "Icons"
-msgstr "ምልክቶች"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "New themes can also be installed by dragging them into the window."
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-#, fuzzy
-msgid "Save Theme"
-msgstr "ጭብጥን _አስቀምጥ"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-msgid "Select theme for the desktop"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-#, fuzzy
-msgid "Short _description:"
-msgstr "የአጭር _መግለጫ"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "Theme Details"
-msgstr "የጭብት ዝርዝሮች"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "Theme Preferences"
-msgstr "የጭብት ምርጫዎች"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-#, fuzzy
-msgid "Theme _Details"
-msgstr "የጭብት ዝርዝሮች"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-msgid "This theme does not suggest any particular font or background."
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-msgid "This theme suggests a background:"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-msgid "This theme suggests a font and a background:"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-msgid "This theme suggests a font:"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "Window Border"
-msgstr "የመስኮት ወሰን"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-#, fuzzy
-msgid "_Go To Theme Folder"
-msgstr "ወደ የጭብጥ ዶሴ _ሂድ"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-#, fuzzy
-msgid "_Install Theme..."
-msgstr "ጭብጥን _አስገባ..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-#, fuzzy
-msgid "_Revert"
-msgstr "አስወግድ (_R)"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-#, fuzzy
-msgid "_Save Theme..."
-msgstr "ጭብጥን _አስቀምጥ"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-msgid "_Theme name:"
-msgstr "የ_ጭብጥ ስም፦"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:24
-msgid "theme selection tree"
-msgstr ""
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
-msgstr ""
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "ሜኑዎች እና ቱልባሮች"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
-msgstr ""
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<i>ቶሎ</i>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "_ቁረጥ"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-#, fuzzy
-msgid "Icons only"
-msgstr "ምልክቶችን ብቻ"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "ሜኑና ቱልባር ምርጫዎች"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "አዲስ ፋይል"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "ፋይል ክፈት"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "ፋይልን አስቀምጥ"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr ""
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-#, fuzzy
-msgid "Text below icons"
-msgstr "ጽሑፍ ከምልክቶቹ ስር"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-#, fuzzy
-msgid "Text beside icons"
-msgstr "ጽሑፍ ከምልክቶቹ ጐን"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-#, fuzzy
-msgid "Text only"
-msgstr "ጽሑፉን ብቻ"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
-#, fuzzy
-msgid "Toolbar _button labels:"
-msgstr "የቁልፍ መለያዎች፦"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_ቅጂ"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
-msgstr ""
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
-msgstr "_አስተካክል"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
-msgstr ""
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "_ፋይል"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_አዲስ"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
-msgstr "_ክፈት"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "_ለጥፍ"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "አትም"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "_ውጣ"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "_አስቀምጥ"
-
-#: ../capplets/windows/gnome-window-properties.c:386
-#, c-format
-msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
 "\n"
-"%s"
+"For more information, contact the hardware manufacturer or IT support."
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.c:644
-msgid "Control"
-msgstr "Control"
-
-#: ../capplets/windows/gnome-window-properties.c:649
-msgid "Alt"
-msgstr "Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:655
-msgid "Hyper"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.c:662
-msgid "Super (or \"Windows logo\")"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.c:669
-msgid "Meta"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.glade.h:1
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
 #, fuzzy
-msgid "<b>Movement Key</b>"
-msgstr "<i>ቶሎ</i>"
+msgid "OS Name"
+msgstr "ስም፦"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.glade.h:3
+#: panels/info-overview/cc-info-overview-panel.ui:115
 #, fuzzy
-msgid "<b>Window Selection</b>"
-msgstr "የተለመደው ጭብጥ\n"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To _move a window, press-and-hold this key then grab the window:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "የመስኮት ምርጫዎች"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr ""
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-#, fuzzy
-msgid "Set your window properties"
-msgstr "የመስኮት ምርጫዎች"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "መስኮቶች"
-
-#: ../control-center/control-center-categories.c:257
-#, fuzzy
-msgid "Others"
-msgstr "አጣራዎች"
-
-#: ../control-center/control-center.c:42
-#, fuzzy
-msgid "Desktop Preferences"
-msgstr "ሜኑና ቱልባር ምርጫዎች"
-
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr ""
-
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr ""
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr ""
-
-#: ../gnome-settings-daemon/factory.c:36
-msgid "Could not initialize Bonobo"
-msgstr "bonobo ማስጀመር አልቻልኩም!"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
-msgid "Slow Keys Alert"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
-msgid "Do you want to activate Slow Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
-msgid "Do you want to deactivate Slow Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Sticky Keys Alert"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
-msgid "Do you want to activate Sticky Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:107
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
-#, c-format
-msgid "It seems that another application already has access to key '%d'."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
-#, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
-msgid "Do _not show this warning again"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
-msgid ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
-#, fuzzy
-msgid "Use X settings"
-msgstr "ጠለቅ ምርጫዎች"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
-msgid "Use GNOME settings"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
-#, c-format
-msgid "Permissions on the file %s are broken\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
-msgid "_Do not show this message again"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:129
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
-msgid "Cannot determine user's home directory"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-#, fuzzy
-msgid "A_vailable files:"
-msgstr "የሥዕል ምርጫዎችን፦"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-msgid "Do _not show this warning again."
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-#, fuzzy
-msgid "_Loaded files:"
-msgstr "ሞዴል"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr ""
-
-#: ../libbackground/applier.c:255
-msgid "Type"
+msgid "OS Type"
 msgstr "ዓይነት"
 
-#: ../libbackground/applier.c:256
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "ተርሚናል"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "መስኮቶች"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
 msgstr ""
 
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "የ_ጭብጥ ስም፦"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "የተጠቃሚ _ስም፦"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "ስለ... (_A)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
 msgstr ""
 
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr ""
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr ""
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr ""
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "እስክሪን"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr ""
-
-#: ../libgswitchit/gswitchit_config.c:1035
-#, c-format
-msgid "There was an error loading an image: %s"
-msgstr ""
-
-#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
-msgid "The sound file for this event does not exist."
-msgstr ""
-
-#: ../libsounds/sound-view.c:149
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package\n"
-"for a set of default sounds."
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 
-#: ../libsounds/sound-view.c:224
-#, c-format
-msgid "The file %s is not a valid wav file"
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
 msgstr ""
 
-#: ../libsounds/sound-view.c:289
-msgid "Event"
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
 msgstr ""
 
-#: ../libsounds/sound-view.c:298
-#, fuzzy
-msgid "Sound File"
-msgstr "ድምፅ"
-
-#: ../libsounds/sound-view.c:314
-#, fuzzy
-msgid "_Sounds:"
-msgstr "ድምፆች (_S)"
-
-#: ../libsounds/sound-view.c:328
-msgid "Sound _file:"
-msgstr ""
-
-#: ../libsounds/sound-view.c:332
-msgid "Select Sound File"
-msgstr ""
-
-#: ../libsounds/sound-view.c:356
-msgid "_Play"
-msgstr "አጫውት (_P)"
-
-#: ../libsounds/sound-view.c:366
-msgid "_Remove"
-msgstr "አስወግድ (_R)"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "መተልቅ"
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "ማውጣት"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "Brightness down"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "Brightness down's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Brightness up"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Brightness up's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "E-mail"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "E-mail's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Eject"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-#, fuzzy
-msgid "Eject's shortcut."
-msgstr "የሠሌዳው አቋራጭ፦ (_D)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-#, fuzzy
-msgid "Home folder"
-msgstr "ወደ የጭብጥ ዶሴ _ሂድ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-#, fuzzy
-msgid "Home folder's shortcut."
-msgstr "አቋራጭ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-#, fuzzy
-msgid "Launch help browser"
-msgstr "የመረጃ መቃኛ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-#, fuzzy
-msgid "Launch help browser's shortcut."
-msgstr "የመረጃ መቃኛ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-#, fuzzy
-msgid "Launch web browser"
-msgstr "የዌብ መቃኛ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-#, fuzzy
-msgid "Launch web browser's shortcut."
-msgstr "የዌብ መቃኛ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-#, fuzzy
-msgid "Lock screen"
-msgstr "እስክሪን"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-#, fuzzy
-msgid "Lock screen's shortcut."
-msgstr "አቋራጭ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-#, fuzzy
-msgid "Log out"
-msgstr "እቅድ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-#, fuzzy
-msgid "Log out's shortcut."
-msgstr "የሠሌዳው አቋራጭ፦ (_D)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Next track key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-#, fuzzy
-msgid "Pause"
-msgstr "_ለጥፍ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-msgid "Pause key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Play (or play/pause)"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Play (or play/pause) key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Previous track key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
-msgid "Search"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-#, fuzzy
-msgid "Search's shortcut."
-msgstr "አቋራጭ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Skip to next track"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Skip to previous track"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-#, fuzzy
-msgid "Sleep"
-msgstr "ፍጥነት"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-#, fuzzy
-msgid "Sleep's shortcut."
-msgstr "አቋራጭ"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Stop playback key"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Stop playback key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume down's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-msgid "Volume mute"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume mute's shortcut"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
-msgid "Volume step"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-msgid "Volume step as percentage of volume."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+#: panels/keyboard/00-multimedia.xml.in:8
 #, fuzzy
 msgid "Volume up"
 msgstr "ማውጣት"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
-msgid "Volume up's shortcut."
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
-msgid "Display a dialog when there are errors running the screensaver"
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-msgid "Run screensaver at login"
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
 #, fuzzy
-msgid "Start screensaver"
+msgid "Launchers"
+msgstr "የዌብ መቃኛ"
+
+#: panels/keyboard/01-launchers.xml.in:4
+#, fuzzy
+msgid "Launch help browser"
+msgstr "የመረጃ መቃኛ"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "የነበረው ተርሚናል"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+#, fuzzy
+msgid "Launch web browser"
+msgstr "የዌብ መቃኛ"
+
+#: panels/keyboard/01-launchers.xml.in:14
+#, fuzzy
+msgid "Home folder"
+msgstr "ወደ የጭብጥ ዶሴ _ሂድ"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:4
+#, fuzzy
+msgid "Log out"
+msgstr "እቅድ"
+
+#: panels/keyboard/01-system.xml.in:6
+#, fuzzy
+msgid "Lock screen"
 msgstr "እስክሪን"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:8
 #, fuzzy
-msgid "Keyboard Update Handlers"
-msgstr "የፊደል ሠሌዳ"
+msgid "Zoom out"
+msgstr "እቅድ"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
 #, fuzzy
-msgid "Keyboard layout"
-msgstr "የፊደል ሠሌዳው አቋራጭ"
+msgid "Options"
+msgstr "ትግባሮች"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
 #, fuzzy
-msgid "Keyboard model"
-msgstr "የፊደል ሠሌዳ"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
-#, fuzzy
-msgid "Keyboard options"
-msgstr "የፊደል ሠሌዳው አቋራጭ"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
-#, fuzzy
-msgid "keyboard layout"
-msgstr "የፊደል ሠሌዳው አቋራጭ"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
-#, fuzzy
-msgid "keyboard model"
-msgstr "የፊደል ሠሌዳ"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "modmap file list"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:212
-msgid "_Postpone break"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:259
-msgid "Take a break!"
-msgstr ""
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:141
-#, fuzzy
-msgid "/_Preferences"
+msgid "Preferences"
 msgstr "የፊደል ቅርጽ ምርጫዎች"
 
-#: ../typing-break/drwright.c:142
+#: panels/keyboard/cc-input-row.ui:48
 #, fuzzy
-msgid "/_About"
-msgstr "ስለ... (_A)"
+msgid "View Keyboard Layout"
+msgstr "የፊደል ሠሌዳው አቋራጭ"
 
-#: ../typing-break/drwright.c:144
-msgid "/_Take a Break"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "አስወግድ (_R)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
 msgstr ""
 
-#: ../typing-break/drwright.c:495
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "የፊደል ሠሌዳው አቋራጭ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "ትግባር"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "አቋራጭ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "አቋራጭ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "አቋራጭ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "የፊደል ሠሌዳው አቋራጭ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "አስወግድ (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "ስም፦"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "_ትእዛዝ፦"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "አቋራጭ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "አቋራጭ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_ምንም"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "የፊደል ሠሌዳ"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "የነበረው ተርሚናል"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "አጠቃላይ"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_ቦታ፦"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_የመጠቀሚያ ፕሮግራሞች የፊደል ቅርጽ፦"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "አጣራዎች"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "ትግባር"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "ትግባሮች"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../typing-break/drwright.c:499
-msgid "Less than one minute until the next break"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
 msgstr ""
 
-#: ../typing-break/drwright.c:587
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr ""
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "ጨምር፦ (_A)"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "ጨምር፦ (_A)"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "ጨምር፦ (_A)"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "የነበረው የዌብ መቃኛ"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: ../typing-break/drwright.c:635
-msgid "About GNOME Typing Monitor"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "ስም፦ (_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "ጨምር፦ (_A)"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
 msgstr ""
 
-#: ../typing-break/drwright.c:659
-msgid "A computer break reminder."
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "ጨምር፦ (_A)"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
 msgstr ""
 
-#: ../typing-break/drwright.c:660
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
 msgstr ""
 
-#: ../typing-break/drwright.c:661
-msgid "Eye candy added by Anders Carlsson"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
 msgstr ""
 
-#: ../typing-break/drwright.c:837
-msgid "Break reminder"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
 msgstr ""
 
-#: ../typing-break/main.c:93
-msgid "The typing monitor is already running."
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
 msgstr ""
 
-#: ../typing-break/main.c:106
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "የተበላሸ"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "ጨምር፦ (_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+#, fuzzy
+msgid "Address"
+msgstr "ጨምር፦ (_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "ትግባር"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "ጨምር፦ (_A)"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "ጠለቅ ምርጫዎች"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr ""
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "የፊደል ሠሌዳው አቋራጭ"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "የተጠቃሚ _ስም፦"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "ዝርያ፦"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "ዝርያ፦"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr ""
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "ዓይነት"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "የነበረው የዌብ መቃኛ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "ፋይል ክፈት"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_ቦታ፦"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "ድምፅ"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
 msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "The quick brown fox jumps over the lazy dog. 0123456789"
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:276
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "አቋራጭ"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "አቋራጭ"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "እስክሪን"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "እስክሪን"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "አትም"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "የተጠቃሚ _ስም፦"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "_ቦታ፦"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "አጥፉ"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "ትግባሮች"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "የጭብት ዝርዝሮች"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "ሞዴል"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "ቅድመ ዕይታ"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "እስክሪን"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "ትግባር"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "ዓይነት፦"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "እስክሪን"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "እስክሪን"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "እስክሪን"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "እስክሪን"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "ጠለቅ ምርጫዎች"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "የፊደል ሠሌዳው አቋራጭ"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "አጣራዎች"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "_ቦታ፦"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_የመጠቀሚያ ፕሮግራሞች የፊደል ቅርጽ፦"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "አቋራጭ"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "ሠሌዳ"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "አስወግድ (_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "ሠሌዳ"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Control"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_ቅጂ"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "ትግባር"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "የተጠቃሚ _ስም፦"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "ማውጣት"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "ጠለቅ ምርጫዎች"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "ቁልፎች"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ድምፅ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "ስም፦"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "ዓይነት፦"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "ዓይነት፦"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "መጠን፦"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "ዝርያ፦"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "የቅጂው መብት፦"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "መግለጫ፦"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:408
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "የተለመደው ጭብጥ\n"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_ፍጥነት፦"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "የተለመደው ጭብጥ\n"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "የተለመደው ጭብጥ"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "አቋራጭ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "አቋራጭ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "_የተመዘነ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "የመመሪያ ገጾች"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<i>ቶሎ</i>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "አቋራጭ"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "አቋራጭ"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "የመመሪያ ገጾች"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "እስክሪን"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "ድምፆች (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "የተለመደው ጭብጥ"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "የፊደል ሠሌዳ"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<i>ቶሎ</i>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "የተለመደው ጭብጥ\n"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "_ቦታ፦"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "እስክሪን"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "ትግባሮች"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_ቦታ፦"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "እስክሪን"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "ይዞታዎች... (_C)"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_ምንም"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "ሙሉ (_F)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "አጥፉ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "መስኮቱን መቆጣጠሪያ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_ምንም"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "ቅድመ ዕይታ"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_አስተካክል"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "አጣራዎች"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "ቁልፎች"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "ቁልፎች"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ቁልፎች"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ቁልፎች"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "እቅድ"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "_መሀከል"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "መስኮቶች"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "መስኮቶች"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "ጨምር..."
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_አስቀምጥ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "የጭብት ዝርዝሮች"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "የፋይል ዓይነት ጨምር"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "የጭብት ዝርዝሮች"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid "usage: %s fontfile\n"
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
-msgid "Sets the default application font"
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_ፋይል"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "የጭብት ዝርዝሮች"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "የነበረው ተርሚናል"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
 msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#: shell/cc-window.ui:164
+msgid "Help"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "አጠቃላይ"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_ውጣ"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr ""
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "የፊደል ቅርጽ ምርጫዎች"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
-msgid "GNOME Font Viewer"
-msgstr ""
-
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-msgstr ""
-
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr ""
-
-#: ../vfs-methods/themus/apply-font.glade.h:4
+#: shell/org.gnome.Settings.gschema.xml:14
 msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
+"Whether Settings should show a warning when running a development build."
 msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-#, fuzzy
-msgid "_Apply font"
-msgstr "_የመጠቀሚያ ፕሮግራሞች የፊደል ቅርጽ፦"
-
-#: ../vfs-methods/themus/theme-method.c:520
-#, fuzzy
-msgid "Themes"
-msgstr "ጭብጥ"
-
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "መግለጫ"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-#, fuzzy
-msgid "Control theme"
-msgstr "የተለመደው ጭብጥ"
-
-#: ../vfs-methods/themus/themus-properties-view.c:139
-#, fuzzy
-msgid "Window border theme"
-msgstr "የመስኮት ወሰን"
-
-#: ../vfs-methods/themus/themus-properties-view.c:145
-#, fuzzy
-msgid "Icon theme"
-msgstr "የተለመደው ጭብጥ"
-
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
 msgstr ""
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-#, fuzzy
-msgid "Apply theme"
-msgstr "ጭብጥን _አስገባ..."
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-msgid "Sets the default theme"
-msgstr ""
-
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr ""
-
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr ""
-
-#: ../vfs-methods/themus/themus.schemas.in.h:3
+#: shell/org.gnome.Settings.gschema.xml:21
 msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
-msgstr ""
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr ""
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr ""
+#, fuzzy
+#~ msgid "Show more _details"
+#~ msgstr "የጭብት ዝርዝሮች"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr ""
+#, fuzzy
+#~ msgid "About Me"
+#~ msgstr "ስለ... (_A)"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr ""
+#, fuzzy
+#~ msgid "No Image"
+#~ msgstr "ምስሎች"
 
-msgid "Show help options"
-msgstr ""
+#, fuzzy, c-format
+#~ msgid "About %s"
+#~ msgstr "ስለ... (_A)"
+
+#, fuzzy
+#~ msgid "Please type the passwords."
+#~ msgstr "ሚስጢራዊ _ቃል፦"
+
+#, fuzzy
+#~ msgid "    "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "<b>Home</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#, fuzzy
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "የተለመደው ጭብጥ\n"
+
+#, fuzzy
+#~ msgid "<b>Job</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#, fuzzy
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#, fuzzy
+#~ msgid "<b>Web</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#, fuzzy
+#~ msgid "<b>Work</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#, fuzzy
+#~ msgid "A_ddress:"
+#~ msgstr "ጨምር፦ (_A)"
+
+#, fuzzy
+#~ msgid "C_ity:"
+#~ msgstr "ዓይነት፦"
+
+#, fuzzy
+#~ msgid "C_ompany:"
+#~ msgstr "_ትእዛዝ፦"
+
+#, fuzzy
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "ሚስጢራዊ _ቃል፦"
+
+#, fuzzy
+#~ msgid "Ci_ty:"
+#~ msgstr "ዓይነት፦"
+
+#, fuzzy
+#~ msgid "Co_untry:"
+#~ msgstr "Control"
+
+#, fuzzy
+#~ msgid "Cou_ntry:"
+#~ msgstr "Control"
+
+#, fuzzy
+#~ msgid "Hom_e:"
+#~ msgstr "ስም፦ (_N)"
+
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "ሚስጢራዊ _ቃል፦"
+
+#, fuzzy
+#~ msgid "Personal Info"
+#~ msgstr "የተርሚናል የፊደል ቅርጽ፦ (_T)"
+
+#, fuzzy
+#~ msgid "Wor_k:"
+#~ msgstr "_ቀለም፦"
+
+#, fuzzy
+#~ msgid "Work _fax:"
+#~ msgstr "_ቀለም፦"
+
+#, fuzzy
+#~ msgid "_Home page:"
+#~ msgstr "የ_ጭብጥ ስም፦"
+
+#, fuzzy
+#~ msgid "_Home:"
+#~ msgstr "ስም፦ (_N)"
+
+#, fuzzy
+#~ msgid "_Manager:"
+#~ msgstr "መስኮቱን መቆጣጠሪያ፦"
+
+#, fuzzy
+#~ msgid "_Profession:"
+#~ msgstr "_መግለጫ፦"
+
+#, fuzzy
+#~ msgid "_Title:"
+#~ msgstr "_ፋይል"
+
+#, fuzzy
+#~ msgid "_Work:"
+#~ msgstr "_ቀለም፦"
+
+#, fuzzy
+#~ msgid "<b>Support</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#, fuzzy
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "የመስኮት ምርጫዎች"
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#, fuzzy
+#~ msgid "<b>Features</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#~ msgid "Basic"
+#~ msgstr "ቀላል"
+
+#~ msgid "Filters"
+#~ msgstr "አጣራዎች"
+
+#~ msgid "S_peed:"
+#~ msgstr "_ፍጥነት፦"
+
+#~ msgid "milliseconds"
+#~ msgstr "ሚሊሴኮንዶች"
+
+#, fuzzy
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#, fuzzy
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#, fuzzy
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "የመደቡ ምርጫዎች"
+
+#, fuzzy
+#~ msgid "_Style:"
+#~ msgstr "ዓይነት፦"
+
+#, fuzzy
+#~ msgid "Tiled"
+#~ msgstr "_ፋይል"
+
+#~ msgid "From URI"
+#~ msgstr "ከ URI"
+
+#~ msgid "To URI"
+#~ msgstr "ወደ URI"
+
+#~ msgid "Key"
+#~ msgstr "ቁልፍ"
+
+#, fuzzy
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "የነበረው የዌብ መቃኛ"
+
+#, fuzzy
+#~ msgid "W3M Text Browser"
+#~ msgstr "የዌብ መቃኛ"
+
+#, fuzzy
+#~ msgid "Lynx Text Browser"
+#~ msgstr "የዌብ መቃኛ"
+
+#, fuzzy
+#~ msgid "Links Text Browser"
+#~ msgstr "የዌብ መቃኛ"
+
+#, fuzzy
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "የተለመደው የመረጃ መቃኛ፦ (_U)"
+
+#, fuzzy
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "የነበረው ተርሚናል"
+
+#, fuzzy
+#~ msgid "Standard XTerminal"
+#~ msgstr "በተርሚናል ውስጥ ጀምር (_E)"
+
+#, fuzzy
+#~ msgid "aterm"
+#~ msgstr "ምድብ"
+
+#, fuzzy
+#~ msgid "ETerm"
+#~ msgstr "ተርሚናል"
+
+#, fuzzy
+#~ msgid "C_ustom"
+#~ msgstr "_የተለየ፦"
+
+#~ msgid "C_ustom:"
+#~ msgstr "_የተለየ፦"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "_ትእዛዝ፦"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "የተለመደው የጽሑፍ ማቀናጃ ምርጫዎች"
+
+#, fuzzy
+#~ msgid "Default Mail Reader"
+#~ msgstr "የነበረው መስኮቱን መቆጣጠሪያ"
+
+#~ msgid "Default Terminal"
+#~ msgstr "የነበረው ተርሚናል"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "የነበረው የጽሑፍ ማቀናጃ"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "የነበረው የዌብ መቃኛ"
+
+#~ msgid "Default Window Manager"
+#~ msgstr "የነበረው መስኮቱን መቆጣጠሪያ"
+
+#~ msgid "Delete"
+#~ msgstr "አጥፉ"
+
+#~ msgid "Edit..."
+#~ msgstr "አስተካክል..."
+
+#, fuzzy
+#~ msgid "Run in a _terminal"
+#~ msgstr "በተርሚናሉ ውስጥ አስኪድ (_T)"
+
+#, fuzzy
+#~ msgid "Run in a t_erminal"
+#~ msgstr "በተርሚናሉ ውስጥ አስኪድ (_T)"
+
+#~ msgid "Terminal"
+#~ msgstr "ተርሚናል"
+
+#~ msgid "Text Editor"
+#~ msgstr "የጽሑፍ ማቀናጃ"
+
+#~ msgid "Web Browser"
+#~ msgstr "የዌብ መቃኛ"
+
+#~ msgid "_Properties..."
+#~ msgstr "ምርጫዎች... (_P)"
+
+#, fuzzy
+#~ msgid "_Select:"
+#~ msgstr "አጥፉ"
+
+#, fuzzy
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "የድምፅ ምርጫዎች"
+
+#, fuzzy
+#~ msgid "Keep Resolution"
+#~ msgstr "_መግለጫ፦"
+
+#~ msgid "Font"
+#~ msgstr "የፊደል ቅርጽ"
+
+#, fuzzy
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "የተለመደው ጭብጥ\n"
+
+#, fuzzy
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<i>ቶሎ</i>"
+
+#, fuzzy
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<i>ቶሎ</i>"
+
+#, fuzzy
+#~ msgid "D_etails..."
+#~ msgstr "_ዝርዝሮች..."
+
+#~ msgid "Font Preferences"
+#~ msgstr "የፊደል ቅርጽ ምርጫዎች"
+
+#, fuzzy
+#~ msgid "Go _to font folder"
+#~ msgstr "ወደ የጭብጥ ዶሴ _ሂድ"
+
+#, fuzzy
+#~ msgid "Gra_yscale"
+#~ msgstr "ግራጫማ (_R)"
+
+#~ msgid "N_one"
+#~ msgstr "(ም_ንም)"
+
+#, fuzzy
+#~ msgid "R_esolution:"
+#~ msgstr "_መግለጫ፦"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Desktop font:"
+#~ msgstr "_ሠሌዳ የፊደል ቅርጽ፦"
+
+#~ msgid "_Medium"
+#~ msgstr "መሀከለኛ (_M)"
+
+#~ msgid "_RGB"
+#~ msgstr "RGB"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "የተርሚናል የፊደል ቅርጽ፦ (_T)"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "የመስኮት አርእስት የፊደል ቅርጽ፦ (_W)"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<ያልታወቀ ትግባር>"
+
+#~ msgid "Window Management"
+#~ msgstr "የመስኮት ጉባኤ"
+
+#, fuzzy
+#~ msgid "Unknown"
+#~ msgstr ""
+#~ "<b>ያልታወቀ ጠቋሚ</b>\n"
+#~ "%s"
+
+#, fuzzy
+#~ msgid "..."
+#~ msgstr "ጨምር..."
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>ቶሎ</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>ረጅም</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>አጭር</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>ዝግታ</i></small>"
+
+#, fuzzy
+#~ msgid "Choose A Keyboard Model"
+#~ msgstr "የፊደል ሠሌዳ"
+
+#, fuzzy
+#~ msgid "Keyboard _model:"
+#~ msgstr "የፊደል ሠሌዳ"
+
+#, fuzzy
+#~ msgid "Layout Options"
+#~ msgstr "የሥዕል ምርጫዎችን፦"
+
+#, fuzzy
+#~ msgid "Layouts"
+#~ msgstr "እቅድ"
+
+#, fuzzy
+#~ msgid "_Models:"
+#~ msgstr "ሞዴል"
+
+#, fuzzy
+#~ msgid "Unknown Cursor"
+#~ msgstr ""
+#~ "<b>ያልታወቀ ጠቋሚ</b>\n"
+#~ "%s"
+
+#, fuzzy
+#~ msgid "Default Cursor"
+#~ msgstr "የነበረው የዌብ መቃኛ"
+
+#, fuzzy
+#~ msgid "Cursor Theme"
+#~ msgstr "የተለመደው ጭብጥ"
+
+#, fuzzy
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>ከፍ ያለ</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>ትልቅ</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>ዝቅ ያለ</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>ዝግታ</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>ትንሽ</i>"
+
+#, fuzzy
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "የመደቡ ምርጫዎች"
+
+#~ msgid "Port:"
+#~ msgstr "ፖርት፦"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "የድምፅ ምርጫዎች"
+
+#~ msgid "Custom theme"
+#~ msgstr "የተለመደው ጭብጥ"
+
+#~ msgid "Theme"
+#~ msgstr "ጭብጥ"
+
+#~ msgid "_Install"
+#~ msgstr "_አስገባ"
+
+#~ msgid "Icons"
+#~ msgstr "ምልክቶች"
+
+#, fuzzy
+#~ msgid "Save Theme"
+#~ msgstr "ጭብጥን _አስቀምጥ"
+
+#, fuzzy
+#~ msgid "Short _description:"
+#~ msgstr "የአጭር _መግለጫ"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "የጭብት ምርጫዎች"
+
+#, fuzzy
+#~ msgid "Theme _Details"
+#~ msgstr "የጭብት ዝርዝሮች"
+
+#~ msgid "Window Border"
+#~ msgstr "የመስኮት ወሰን"
+
+#, fuzzy
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "ወደ የጭብጥ ዶሴ _ሂድ"
+
+#, fuzzy
+#~ msgid "_Revert"
+#~ msgstr "አስወግድ (_R)"
+
+#, fuzzy
+#~ msgid "_Save Theme..."
+#~ msgstr "ጭብጥን _አስቀምጥ"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "ሜኑዎች እና ቱልባሮች"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#~ msgid "C_ut"
+#~ msgstr "_ቁረጥ"
+
+#, fuzzy
+#~ msgid "Icons only"
+#~ msgstr "ምልክቶችን ብቻ"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#~ msgid "New File"
+#~ msgstr "አዲስ ፋይል"
+
+#~ msgid "Save File"
+#~ msgstr "ፋይልን አስቀምጥ"
+
+#, fuzzy
+#~ msgid "Text below icons"
+#~ msgstr "ጽሑፍ ከምልክቶቹ ስር"
+
+#, fuzzy
+#~ msgid "Text beside icons"
+#~ msgstr "ጽሑፍ ከምልክቶቹ ጐን"
+
+#, fuzzy
+#~ msgid "Text only"
+#~ msgstr "ጽሑፉን ብቻ"
+
+#, fuzzy
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "የቁልፍ መለያዎች፦"
+
+#~ msgid "_File"
+#~ msgstr "_ፋይል"
+
+#~ msgid "_New"
+#~ msgstr "_አዲስ"
+
+#~ msgid "_Paste"
+#~ msgstr "_ለጥፍ"
+
+#~ msgid "Alt"
+#~ msgstr "Alt"
+
+#, fuzzy
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<i>ቶሎ</i>"
+
+#, fuzzy
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "የተለመደው ጭብጥ\n"
+
+#~ msgid "Window Preferences"
+#~ msgstr "የመስኮት ምርጫዎች"
+
+#, fuzzy
+#~ msgid "Set your window properties"
+#~ msgstr "የመስኮት ምርጫዎች"
+
+#, fuzzy
+#~ msgid "Desktop Preferences"
+#~ msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "bonobo ማስጀመር አልቻልኩም!"
+
+#, fuzzy
+#~ msgid "Use X settings"
+#~ msgstr "ጠለቅ ምርጫዎች"
+
+#, fuzzy
+#~ msgid "A_vailable files:"
+#~ msgstr "የሥዕል ምርጫዎችን፦"
+
+#~ msgid "_Play"
+#~ msgstr "አጫውት (_P)"
+
+#~ msgid "Maximize"
+#~ msgstr "መተልቅ"
+
+#~ msgid "Roll up"
+#~ msgstr "ማውጣት"
+
+#, fuzzy
+#~ msgid "Eject's shortcut."
+#~ msgstr "የሠሌዳው አቋራጭ፦ (_D)"
+
+#, fuzzy
+#~ msgid "Home folder's shortcut."
+#~ msgstr "አቋራጭ"
+
+#, fuzzy
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "የመረጃ መቃኛ"
+
+#, fuzzy
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "የዌብ መቃኛ"
+
+#, fuzzy
+#~ msgid "Log out's shortcut."
+#~ msgstr "የሠሌዳው አቋራጭ፦ (_D)"
+
+#, fuzzy
+#~ msgid "Pause"
+#~ msgstr "_ለጥፍ"
+
+#, fuzzy
+#~ msgid "Sleep"
+#~ msgstr "ፍጥነት"
+
+#, fuzzy
+#~ msgid "Sleep's shortcut."
+#~ msgstr "አቋራጭ"
+
+#, fuzzy
+#~ msgid "Start screensaver"
+#~ msgstr "እስክሪን"
+
+#, fuzzy
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "የፊደል ሠሌዳ"
+
+#, fuzzy
+#~ msgid "Keyboard model"
+#~ msgstr "የፊደል ሠሌዳ"
+
+#, fuzzy
+#~ msgid "keyboard layout"
+#~ msgstr "የፊደል ሠሌዳው አቋራጭ"
+
+#, fuzzy
+#~ msgid "keyboard model"
+#~ msgstr "የፊደል ሠሌዳ"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "The quick brown fox jumps over the lazy dog. 0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "መጠን፦"
+
+#~ msgid "Copyright:"
+#~ msgstr "የቅጂው መብት፦"
+
+#~ msgid "Description:"
+#~ msgstr "መግለጫ፦"
+
+#, fuzzy
+#~ msgid "Themes"
+#~ msgstr "ጭብጥ"
+
+#~ msgid "Description"
+#~ msgstr "መግለጫ"
+
+#, fuzzy
+#~ msgid "Control theme"
+#~ msgstr "የተለመደው ጭብጥ"
+
+#, fuzzy
+#~ msgid "Window border theme"
+#~ msgstr "የመስኮት ወሰን"
+
+#, fuzzy
+#~ msgid "Icon theme"
+#~ msgstr "የተለመደው ጭብጥ"
+
+#, fuzzy
+#~ msgid "Apply theme"
+#~ msgstr "ጭብጥን _አስገባ..."

--- a/po/am.po~
+++ b/po/am.po~
@@ -1,0 +1,3427 @@
+# Translations into the Amharic Language.
+# Copyright (C) 2002 Free Software Foundation, Inc.
+# This file is distributed under the same license as the GNOME Control Center package.
+# Ge'ez Frontier Foundation <locales@geez.org>, 2002.
+#
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"PO-Revision-Date: 2003-02-03 10:16+EDT\n"
+"Last-Translator: Ge'ez Frontier Foundation <locales@geez.org>\n"
+"Language-Team: Amharic <locales@geez.org>\n"
+"Language: am\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+#, fuzzy
+msgid "Alert Type"
+msgstr "የፋይል ዓይነት ጨምር"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+#, fuzzy
+msgid "Alert Buttons"
+msgstr "ቁልፎች"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+#, fuzzy
+msgid "Show more _details"
+msgstr "የጭብት ዝርዝሮች"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+#, fuzzy
+msgid "About Me"
+msgstr "ስለ... (_A)"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:554
+#, fuzzy
+msgid "Select Image"
+msgstr "አጥፉ"
+
+#: ../capplets/about-me/gnome-about-me.c:556
+#, fuzzy
+msgid "No Image"
+msgstr "ምስሎች"
+
+#: ../capplets/about-me/gnome-about-me.c:706
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:727
+msgid "Unable to open address book"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:739
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:770
+#: ../capplets/about-me/gnome-about-me.c:772
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "ስለ... (_A)"
+
+#: ../capplets/about-me/gnome-about-me-password.c:101
+#: ../capplets/about-me/gnome-about-me-password.c:479
+msgid "Old password is incorrect, please retype it"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:112
+msgid "System error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:113
+msgid "Could not run /usr/bin/passwd"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:114
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:117
+msgid "Unexpected error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:315
+msgid "Password is too short"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:318
+#: ../capplets/about-me/gnome-about-me-password.c:321
+msgid "Password is too simple"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:324
+msgid "Old and new passwords are too similar"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:328
+msgid "Old and new password are the same"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:406
+#, fuzzy
+msgid "Please type the passwords."
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: ../capplets/about-me/gnome-about-me-password.c:414
+msgid "Please type the password again, it is wrong."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:417
+msgid "Click on Change Password to change the password."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/font/font-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+#, fuzzy
+msgid "    "
+msgstr "      "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+#, fuzzy
+msgid "<b>Email</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+#, fuzzy
+msgid "<b>Home</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+#, fuzzy
+msgid "<b>Instant Messaging</b>"
+msgstr "የተለመደው ጭብጥ\n"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+#, fuzzy
+msgid "<b>Job</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+#, fuzzy
+msgid "<b>Telephone</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+#, fuzzy
+msgid "<b>Web</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+#, fuzzy
+msgid "<b>Work</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+#, fuzzy
+msgid "A_ddress:"
+msgstr "ጨምር፦ (_A)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+#, fuzzy
+msgid "Address"
+msgstr "ጨምር፦ (_A)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+#, fuzzy
+msgid "C_ity:"
+msgstr "ዓይነት፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+#, fuzzy
+msgid "C_ompany:"
+msgstr "_ትእዛዝ፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+#, fuzzy
+msgid "Cale_ndar:"
+msgstr "ምድብ፦ (_G)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+#, fuzzy
+msgid "Change Passwo_rd..."
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+#, fuzzy
+msgid "Change Password"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+#, fuzzy
+msgid "Ci_ty:"
+msgstr "ዓይነት፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+#, fuzzy
+msgid "Co_untry:"
+msgstr "Control"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+#, fuzzy
+msgid "Contact"
+msgstr "ይዞታዎች... (_C)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+#, fuzzy
+msgid "Cou_ntry:"
+msgstr "Control"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+#, fuzzy
+msgid "Hom_e:"
+msgstr "ስም፦ (_N)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+#, fuzzy
+msgid "Old pa_ssword:"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P.O. _box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P._O. box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+#, fuzzy
+msgid "Personal Info"
+msgstr "የተርሚናል የፊደል ቅርጽ፦ (_T)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "State/Pro_vince:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#, fuzzy
+msgid "User name:"
+msgstr "የተጠቃሚ _ስም፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Web _log:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+#, fuzzy
+msgid "Wor_k:"
+msgstr "_ቀለም፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+#, fuzzy
+msgid "Work _fax:"
+msgstr "_ቀለም፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Zip/_Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+#, fuzzy
+msgid "_Address:"
+msgstr "ጨምር፦ (_A)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+#, fuzzy
+msgid "_Home page:"
+msgstr "የ_ጭብጥ ስም፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+#, fuzzy
+msgid "_Home:"
+msgstr "ስም፦ (_N)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+#, fuzzy
+msgid "_Manager:"
+msgstr "መስኮቱን መቆጣጠሪያ፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+#, fuzzy
+msgid "_Mobile:"
+msgstr "_ፋይል"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+#, fuzzy
+msgid "_New password:"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+#, fuzzy
+msgid "_Profession:"
+msgstr "_መግለጫ፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+#, fuzzy
+msgid "_Retype new password:"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+#, fuzzy
+msgid "_Title:"
+msgstr "_ፋይል"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+#, fuzzy
+msgid "_Work:"
+msgstr "_ቀለም፦"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Zip/Postal code:"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Applications</b>"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+#, fuzzy
+msgid "<b>Support</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+#, fuzzy
+msgid "Assistive Technology Preferences"
+msgstr "የመስኮት ምርጫዎች"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+#, fuzzy
+msgid "_Screenreader"
+msgstr "እስክሪን"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
+msgid "Import Feature Settings File"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
+msgid "_Import"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "የፊደል ሠሌዳ"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+#: ../capplets/theme-switcher/theme-install.glade.h:1
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+#, fuzzy
+msgid "<b>Features</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "ቀላል"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "አጣራዎች"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "S_peed:"
+msgstr "_ፍጥነት፦"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Type to test settings:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+msgid "milliseconds"
+msgstr "ሚሊሴኮንዶች"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr ""
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:885
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "ሴኮንዶች"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+msgid "Change your Desktop Background settings"
+msgstr ""
+
+#: ../capplets/background/background.desktop.in.in.h:2
+#, fuzzy
+msgid "Desktop Background"
+msgstr "መደብ"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+#, fuzzy
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+#, fuzzy
+msgid "<b>_Desktop Colors</b>"
+msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+#, fuzzy
+msgid "Desktop Background Preferences"
+msgstr "የመደቡ ምርጫዎች"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+#, fuzzy
+msgid "_Style:"
+msgstr "ዓይነት፦"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-capplet.c:1042
+#: ../capplets/background/gnome-wp-capplet.c:1060
+#, fuzzy
+msgid "Centered"
+msgstr "_መሀከል"
+
+#: ../capplets/background/gnome-wp-capplet.c:1068
+#: ../capplets/background/gnome-wp-capplet.c:1085
+#, fuzzy
+msgid "Fill Screen"
+msgstr "እስክሪን"
+
+#: ../capplets/background/gnome-wp-capplet.c:1093
+#: ../capplets/background/gnome-wp-capplet.c:1110
+#, fuzzy
+msgid "Scaled"
+msgstr "_የተመዘነ"
+
+#: ../capplets/background/gnome-wp-capplet.c:1118
+#: ../capplets/background/gnome-wp-capplet.c:1135
+#, fuzzy
+msgid "Tiled"
+msgstr "_ፋይል"
+
+#: ../capplets/background/gnome-wp-capplet.c:1159
+#: ../capplets/background/gnome-wp-capplet.c:1168
+#, fuzzy
+msgid "Solid Color"
+msgstr "ቀጣይ ቀለም"
+
+#: ../capplets/background/gnome-wp-capplet.c:1176
+#: ../capplets/background/gnome-wp-capplet.c:1185
+msgid "Horizontal Gradient"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-capplet.c:1193
+#: ../capplets/background/gnome-wp-capplet.c:1202
+msgid "Vertical Gradient"
+msgstr ""
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1251
+msgid "Add Wallpaper"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-item.c:292
+#: ../capplets/background/gnome-wp-item.c:294
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/common/activate-settings-daemon.c:18
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+
+#: ../capplets/common/capplet-stock-icons.c:94
+#, c-format
+msgid "Unable to load capplet stock icon '%s'\n"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/default-applications/gnome-default-applications-properties.c:765
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1021
+#: ../capplets/sound/sound-properties-capplet.c:244
+msgid "Retrieve and store legacy settings"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %i of %i"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr "ከ URI"
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr "ወደ URI"
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:345
+#, fuzzy
+msgid "From:"
+msgstr "ከ፦ %s"
+
+#: ../capplets/common/file-transfer-dialog.c:349
+#, fuzzy
+msgid "To:"
+msgstr "ሁለት"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "ቁልፍ"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1598
+#, fuzzy
+msgid "_Select"
+msgstr "አጥፉ"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+#, fuzzy
+msgid "Debian Sensible Browser"
+msgstr "የነበረው የዌብ መቃኛ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
+msgid "Epiphany"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
+msgid "Galeon"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
+msgid "Encompass"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+msgid "Firebird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
+msgid "Firefox"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
+msgid "Mozilla"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
+msgid "Netscape Communicator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
+msgid "Konqueror"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
+#, fuzzy
+msgid "W3M Text Browser"
+msgstr "የዌብ መቃኛ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
+#, fuzzy
+msgid "Lynx Text Browser"
+msgstr "የዌብ መቃኛ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
+#, fuzzy
+msgid "Links Text Browser"
+msgstr "የዌብ መቃኛ"
+
+#. The code in gnome-default-applications-properties.c makes sure
+#. * there is only one (the first entry in this list) Evolution entry
+#. * in the list shown to the user
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
+#, fuzzy
+msgid "Evolution Mail Reader"
+msgstr "የተለመደው የመረጃ መቃኛ፦ (_U)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
+msgid "Balsa"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
+msgid "KMail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
+msgid "Thunderbird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
+msgid "Mozilla Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
+msgid "Mutt"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
+#, fuzzy
+msgid "Debian Terminal Emulator"
+msgstr "የነበረው ተርሚናል"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
+#, fuzzy
+msgid "GNOME Terminal"
+msgstr "ተርሚናል"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
+#, fuzzy
+msgid "Standard XTerminal"
+msgstr "በተርሚናል ውስጥ ጀምር (_E)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
+msgid "NXterm"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
+msgid "RXVT"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
+#, fuzzy
+msgid "aterm"
+msgstr "ምድብ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
+#, fuzzy
+msgid "ETerm"
+msgstr "ተርሚናል"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.c:123
+msgid "Please specify a name and a command for this editor."
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "Add..."
+msgstr "ጨምር..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+#, fuzzy
+msgid "C_ustom"
+msgstr "_የተለየ፦"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "C_ustom:"
+msgstr "_የተለየ፦"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "Can open _URIs"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "Can open multiple _files"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "Co_mmand:"
+msgstr "_ትእዛዝ፦"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "Custom Editor Properties"
+msgstr "የተለመደው የጽሑፍ ማቀናጃ ምርጫዎች"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+#, fuzzy
+msgid "Default Mail Reader"
+msgstr "የነበረው መስኮቱን መቆጣጠሪያ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "Default Terminal"
+msgstr "የነበረው ተርሚናል"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Default Text Editor"
+msgstr "የነበረው የጽሑፍ ማቀናጃ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "Default Web Browser"
+msgstr "የነበረው የዌብ መቃኛ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Default Window Manager"
+msgstr "የነበረው መስኮቱን መቆጣጠሪያ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Delete"
+msgstr "አጥፉ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "E_xec Flag:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Edit..."
+msgstr "አስተካክል..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Mail Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+#, fuzzy
+msgid "Run in a _terminal"
+msgstr "በተርሚናሉ ውስጥ አስኪድ (_T)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+#, fuzzy
+msgid "Run in a t_erminal"
+msgstr "በተርሚናሉ ውስጥ አስኪድ (_T)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid ""
+"Select the window manager you want.  You will need to hit apply, wave the "
+"magic wand, and do a magic dance for it to work."
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Terminal"
+msgstr "ተርሚናል"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Text Editor"
+msgstr "የጽሑፍ ማቀናጃ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Understands _Netscape Remote Control"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "Use this _editor to open text files in the file manager"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "Web Browser"
+msgstr "የዌብ መቃኛ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
+msgid "Window Manager"
+msgstr "መስኮቱን መቆጣጠሪያ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
+#, fuzzy
+msgid "_Command:"
+msgstr "_ትእዛዝ፦"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
+msgid "_Name:"
+msgstr "ስም፦ (_N)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
+msgid "_Properties..."
+msgstr "ምርጫዎች... (_P)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
+#, fuzzy
+msgid "_Select:"
+msgstr "አጥፉ"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: ../capplets/display/main.c:448
+#, fuzzy
+msgid "_Resolution:"
+msgstr "_መግለጫ፦"
+
+#: ../capplets/display/main.c:467
+msgid "Re_fresh rate:"
+msgstr ""
+
+#: ../capplets/display/main.c:488
+#, fuzzy
+msgid "Default Settings"
+msgstr "የነበረው ተርሚናል"
+
+#: ../capplets/display/main.c:490
+#, fuzzy, c-format
+msgid "Screen %d Settings\n"
+msgstr "ጠለቅ ምርጫዎች"
+
+#: ../capplets/display/main.c:516
+#, fuzzy
+msgid "Screen Resolution Preferences"
+msgstr "የድምፅ ምርጫዎች"
+
+#: ../capplets/display/main.c:553
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr ""
+
+#: ../capplets/display/main.c:571
+#, fuzzy
+msgid "Options"
+msgstr "ትግባሮች"
+
+#: ../capplets/display/main.c:592
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/display/main.c:638
+#, fuzzy
+msgid "Keep Resolution"
+msgstr "_መግለጫ፦"
+
+#: ../capplets/display/main.c:642
+msgid "Do you want to keep this resolution?"
+msgstr ""
+
+#: ../capplets/display/main.c:667
+msgid "Use _previous resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:667
+msgid "_Keep resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:818
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+
+#: ../capplets/display/main.c:826
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "የፊደል ቅርጽ"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:2
+msgid "<b>Font Rendering</b>"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:3
+#, fuzzy
+msgid "<b>Hinting</b>:"
+msgstr "የተለመደው ጭብጥ\n"
+
+#: ../capplets/font/font-properties.glade.h:4
+#, fuzzy
+msgid "<b>Smoothing</b>:"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/font/font-properties.glade.h:5
+#, fuzzy
+msgid "<b>Subpixel order</b>:"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best _shapes"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "Best co_ntrast"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:8
+#, fuzzy
+msgid "D_etails..."
+msgstr "_ዝርዝሮች..."
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "የፊደል ቅርጽ ምርጫዎች"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:11
+#, fuzzy
+msgid "Go _to font folder"
+msgstr "ወደ የጭብጥ ዶሴ _ሂድ"
+
+#: ../capplets/font/font-properties.glade.h:12
+#, fuzzy
+msgid "Gra_yscale"
+msgstr "ግራጫማ (_R)"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "(ም_ንም)"
+
+#: ../capplets/font/font-properties.glade.h:14
+#, fuzzy
+msgid "R_esolution:"
+msgstr "_መግለጫ፦"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "_የመጠቀሚያ ፕሮግራሞች የፊደል ቅርጽ፦"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Desktop font:"
+msgstr "_ሠሌዳ የፊደል ቅርጽ፦"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Full"
+msgstr "ሙሉ (_F)"
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Medium"
+msgstr "መሀከለኛ (_M)"
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Monochrome"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_None"
+msgstr "_ምንም"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_RGB"
+msgstr "RGB"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_Slight"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Terminal font:"
+msgstr "የተርሚናል የፊደል ቅርጽ፦ (_T)"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "የመስኮት አርእስት የፊደል ቅርጽ፦ (_W)"
+
+#: ../capplets/font/font-properties.glade.h:30
+msgid "dots per inch"
+msgstr ""
+
+#: ../capplets/font/main.c:488
+msgid "Font may be too large"
+msgstr ""
+
+#: ../capplets/font/main.c:492
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/font/main.c:505
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:197
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+msgid "Disabled"
+msgstr "የተበላሸ"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:545
+msgid "<Unknown Action>"
+msgstr "<ያልታወቀ ትግባር>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:566
+msgid "Desktop"
+msgstr "ሠሌዳ"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:567
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "ድምፅ"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:571
+msgid "Window Management"
+msgstr "የመስኮት ጉባኤ"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:668
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:700
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:750
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:857
+msgid "Action"
+msgstr "ትግባር"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:881
+msgid "Shortcut"
+msgstr "አቋራጭ"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "የፊደል ሠሌዳው አቋራጭ"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+#, fuzzy
+msgid "Unknown"
+msgstr ""
+"<b>ያልታወቀ ጠቋሚ</b>\n"
+"%s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+msgid "Layout"
+msgstr "እቅድ"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#, fuzzy
+msgid "Default"
+msgstr "የነበረው የዌብ መቃኛ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+#, fuzzy
+msgid "Models"
+msgstr "ሞዴል"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:106
+#, c-format
+msgid "There was an error launching the keyboard capplet : %s"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:240
+#: ../capplets/sound/sound-properties-capplet.c:242
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+#, fuzzy
+msgid "..."
+msgstr "ጨምር..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+#, fuzzy
+msgid "<b>Cursor Blinking</b>"
+msgstr "የተለመደው ጭብጥ\n"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+#, fuzzy
+msgid "<b>Repeat Keys</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>ቶሎ</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>ረጅም</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>አጭር</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>ዝግታ</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_vailable layouts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "All_ow postponing of breaks"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Check if breaks are allowed to be postponed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+#, fuzzy
+msgid "Choose A Keyboard Model"
+msgstr "የፊደል ሠሌዳ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Choose A Layout"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Duration of the break when typing is disallowed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of work before forcing a break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Key presses _repeat when key is held down"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Keyboard Preferences"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+#, fuzzy
+msgid "Keyboard _model:"
+msgstr "የፊደል ሠሌዳ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+#, fuzzy
+msgid "Layout Options"
+msgstr "የሥዕል ምርጫዎችን፦"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+#, fuzzy
+msgid "Layouts"
+msgstr "እቅድ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Microsoft Natural Keyboard"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+#, fuzzy
+msgid "Preview:"
+msgstr "ቅድመ ዕይታ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Reset To De_faults"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Separate _group for each window"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Typing Break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "_Accessibility..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#, fuzzy
+msgid "_Add..."
+msgstr "ጨምር..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Break interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Delay:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#, fuzzy
+msgid "_Models:"
+msgstr "ሞዴል"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Selected layouts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Speed:"
+msgstr "_ፍጥነት፦"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Work interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "minutes"
+msgstr ""
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:559
+#, fuzzy
+msgid "Unknown Cursor"
+msgstr ""
+"<b>ያልታወቀ ጠቋሚ</b>\n"
+"%s"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+#, fuzzy
+msgid "Default Cursor"
+msgstr "የነበረው የዌብ መቃኛ"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+msgid "The default cursor that ships with X"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+msgid "White Cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+msgid "The default cursor inverted"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+msgid "Large Cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+msgid "Large version of normal cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+msgid "Large White Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+msgid "Large version of white cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:975
+#, fuzzy
+msgid "Cursor Theme"
+msgstr "የተለመደው ጭብጥ"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Mouse Orientation</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+#, fuzzy
+msgid "<b>Speed</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>ከፍ ያለ</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>ትልቅ</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>ዝቅ ያለ</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>ዝግታ</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>ትንሽ</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "ቁልፎች"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#, fuzzy
+msgid "Cursor Size:"
+msgstr "የተለመደው ጭብጥ"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Cursors"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+#, fuzzy
+msgid "Large"
+msgstr "የመመሪያ ገጾች"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+#, fuzzy
+msgid "Medium"
+msgstr "መሀከለኛ (_M)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Motion"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Mouse Preferences"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#, fuzzy
+msgid "Small"
+msgstr "_የተመዘነ"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr ""
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your network proxy preferences"
+msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>D_irect internet connection</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+#, fuzzy
+msgid "Advanced Configuration"
+msgstr "ጠለቅ ምርጫዎች"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+#, fuzzy
+msgid "Network Proxy Preferences"
+msgstr "የመደቡ ምርጫዎች"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "ፖርት፦"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "Proxy Configuration"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+#, fuzzy
+msgid "U_sername:"
+msgstr "የተጠቃሚ _ስም፦"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_ዝርዝሮች"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "ሚስጢራዊ _ቃል፦"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr ""
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr ""
+
+#: ../capplets/sound/sound-properties-capplet.c:271
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Sound Preferences"
+msgstr "የድምፅ ምርጫዎች"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "E_nable sound server startup"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "Flash _entire screen"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "Flash _window titlebar"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "General"
+msgstr "አጠቃላይ"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "Sound Events"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "System Bell"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "_Sound an audible bell"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "_Sounds for events"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "_Visual feedback:"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:347
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:227
+msgid "This theme is not in a supported format."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:244
+msgid "Failed to create temporary directory"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:264
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:282
+#: ../capplets/theme-switcher/gnome-theme-installer.c:319
+#: ../capplets/theme-switcher/gnome-theme-installer.c:399
+msgid "Installation Failed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:302
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:340
+#, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:343
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:346
+#, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:349
+#, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:357
+msgid "The theme is an engine. You need to compile the theme."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:374
+msgid "The file format is invalid"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:468
+msgid "No theme file location specified to install"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:485
+msgid "The theme file location specified to install is invalid"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:505
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:526
+msgid "The file format is invalid."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:553
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:607
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "Custom theme"
+msgstr "የተለመደው ጭብጥ"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:72
+msgid "Theme name must be present"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:104
+msgid "The theme already exists. Would you like to replace it?"
+msgstr ""
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr ""
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "ጭብጥ"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-install.glade.h:3
+msgid "Theme Installation"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-install.glade.h:4
+msgid "_Install"
+msgstr "_አስገባ"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:5
+msgid "_Location:"
+msgstr "_ቦታ፦"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Apply _Background"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Apply _Font"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Controls"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "Icons"
+msgstr "ምልክቶች"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "New themes can also be installed by dragging them into the window."
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+#, fuzzy
+msgid "Save Theme"
+msgstr "ጭብጥን _አስቀምጥ"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+msgid "Select theme for the desktop"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+#, fuzzy
+msgid "Short _description:"
+msgstr "የአጭር _መግለጫ"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "Theme Details"
+msgstr "የጭብት ዝርዝሮች"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "Theme Preferences"
+msgstr "የጭብት ምርጫዎች"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+#, fuzzy
+msgid "Theme _Details"
+msgstr "የጭብት ዝርዝሮች"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+msgid "This theme does not suggest any particular font or background."
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+msgid "This theme suggests a background:"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+msgid "This theme suggests a font and a background:"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+msgid "This theme suggests a font:"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "Window Border"
+msgstr "የመስኮት ወሰን"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+#, fuzzy
+msgid "_Go To Theme Folder"
+msgstr "ወደ የጭብጥ ዶሴ _ሂድ"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+#, fuzzy
+msgid "_Install Theme..."
+msgstr "ጭብጥን _አስገባ..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+#, fuzzy
+msgid "_Revert"
+msgstr "አስወግድ (_R)"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+#, fuzzy
+msgid "_Save Theme..."
+msgstr "ጭብጥን _አስቀምጥ"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+msgid "_Theme name:"
+msgstr "የ_ጭብጥ ስም፦"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:24
+msgid "theme selection tree"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "ሜኑዎች እና ቱልባሮች"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+#, fuzzy
+msgid "<b>Preview</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "_ቁረጥ"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+#, fuzzy
+msgid "Icons only"
+msgstr "ምልክቶችን ብቻ"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "አዲስ ፋይል"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "ፋይል ክፈት"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "ፋይልን አስቀምጥ"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+#, fuzzy
+msgid "Text below icons"
+msgstr "ጽሑፍ ከምልክቶቹ ስር"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+#, fuzzy
+msgid "Text beside icons"
+msgstr "ጽሑፍ ከምልክቶቹ ጐን"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+#, fuzzy
+msgid "Text only"
+msgstr "ጽሑፉን ብቻ"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+#, fuzzy
+msgid "Toolbar _button labels:"
+msgstr "የቁልፍ መለያዎች፦"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_ቅጂ"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_አስተካክል"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "_ፋይል"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_አዲስ"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "_ክፈት"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "_ለጥፍ"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "አትም"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "_ውጣ"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "_አስቀምጥ"
+
+#: ../capplets/windows/gnome-window-properties.c:386
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:644
+msgid "Control"
+msgstr "Control"
+
+#: ../capplets/windows/gnome-window-properties.c:649
+msgid "Alt"
+msgstr "Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:655
+msgid "Hyper"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:662
+msgid "Super (or \"Windows logo\")"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:669
+msgid "Meta"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+#, fuzzy
+msgid "<b>Movement Key</b>"
+msgstr "<i>ቶሎ</i>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+#, fuzzy
+msgid "<b>Window Selection</b>"
+msgstr "የተለመደው ጭብጥ\n"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To _move a window, press-and-hold this key then grab the window:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "የመስኮት ምርጫዎች"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr ""
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+#, fuzzy
+msgid "Set your window properties"
+msgstr "የመስኮት ምርጫዎች"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "መስኮቶች"
+
+#: ../control-center/control-center-categories.c:257
+#, fuzzy
+msgid "Others"
+msgstr "አጣራዎች"
+
+#: ../control-center/control-center.c:42
+#, fuzzy
+msgid "Desktop Preferences"
+msgstr "ሜኑና ቱልባር ምርጫዎች"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr ""
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr ""
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr ""
+
+#: ../gnome-settings-daemon/factory.c:36
+msgid "Could not initialize Bonobo"
+msgstr "bonobo ማስጀመር አልቻልኩም!"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
+msgid "Slow Keys Alert"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
+msgid "Do you want to activate Slow Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
+msgid "Do you want to deactivate Slow Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Sticky Keys Alert"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
+msgid "Do you want to activate Sticky Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:107
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
+#, c-format
+msgid "It seems that another application already has access to key '%d'."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
+#, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
+msgid "Do _not show this warning again"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
+msgid ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
+#, fuzzy
+msgid "Use X settings"
+msgstr "ጠለቅ ምርጫዎች"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
+msgid "Use GNOME settings"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
+#, c-format
+msgid "Permissions on the file %s are broken\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
+msgid "_Do not show this message again"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:129
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
+msgid "Cannot determine user's home directory"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+#, fuzzy
+msgid "A_vailable files:"
+msgstr "የሥዕል ምርጫዎችን፦"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+msgid "Do _not show this warning again."
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+#, fuzzy
+msgid "_Loaded files:"
+msgstr "ሞዴል"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr ""
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "ዓይነት"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr ""
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr ""
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr ""
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr ""
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "እስክሪን"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr ""
+
+#: ../libgswitchit/gswitchit_config.c:1035
+#, c-format
+msgid "There was an error loading an image: %s"
+msgstr ""
+
+#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
+msgid "The sound file for this event does not exist."
+msgstr ""
+
+#: ../libsounds/sound-view.c:149
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package\n"
+"for a set of default sounds."
+msgstr ""
+
+#: ../libsounds/sound-view.c:224
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr ""
+
+#: ../libsounds/sound-view.c:289
+msgid "Event"
+msgstr ""
+
+#: ../libsounds/sound-view.c:298
+#, fuzzy
+msgid "Sound File"
+msgstr "ድምፅ"
+
+#: ../libsounds/sound-view.c:314
+#, fuzzy
+msgid "_Sounds:"
+msgstr "ድምፆች (_S)"
+
+#: ../libsounds/sound-view.c:328
+msgid "Sound _file:"
+msgstr ""
+
+#: ../libsounds/sound-view.c:332
+msgid "Select Sound File"
+msgstr ""
+
+#: ../libsounds/sound-view.c:356
+msgid "_Play"
+msgstr "አጫውት (_P)"
+
+#: ../libsounds/sound-view.c:366
+msgid "_Remove"
+msgstr "አስወግድ (_R)"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "መተልቅ"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "ማውጣት"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "Brightness down"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "Brightness down's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Brightness up"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Brightness up's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "E-mail"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "E-mail's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Eject"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+#, fuzzy
+msgid "Eject's shortcut."
+msgstr "የሠሌዳው አቋራጭ፦ (_D)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+#, fuzzy
+msgid "Home folder"
+msgstr "ወደ የጭብጥ ዶሴ _ሂድ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+#, fuzzy
+msgid "Home folder's shortcut."
+msgstr "አቋራጭ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+#, fuzzy
+msgid "Launch help browser"
+msgstr "የመረጃ መቃኛ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+#, fuzzy
+msgid "Launch help browser's shortcut."
+msgstr "የመረጃ መቃኛ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+#, fuzzy
+msgid "Launch web browser"
+msgstr "የዌብ መቃኛ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+#, fuzzy
+msgid "Launch web browser's shortcut."
+msgstr "የዌብ መቃኛ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+#, fuzzy
+msgid "Lock screen"
+msgstr "እስክሪን"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+#, fuzzy
+msgid "Lock screen's shortcut."
+msgstr "አቋራጭ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+#, fuzzy
+msgid "Log out"
+msgstr "እቅድ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+#, fuzzy
+msgid "Log out's shortcut."
+msgstr "የሠሌዳው አቋራጭ፦ (_D)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Next track key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+#, fuzzy
+msgid "Pause"
+msgstr "_ለጥፍ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Pause key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Play (or play/pause) key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Previous track key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Search"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+#, fuzzy
+msgid "Search's shortcut."
+msgstr "አቋራጭ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Skip to next track"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Skip to previous track"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+#, fuzzy
+msgid "Sleep"
+msgstr "ፍጥነት"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+#, fuzzy
+msgid "Sleep's shortcut."
+msgstr "አቋራጭ"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Stop playback key"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Stop playback key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume down"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume down's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume mute"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume mute's shortcut"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+msgid "Volume step"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+msgid "Volume step as percentage of volume."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+#, fuzzy
+msgid "Volume up"
+msgstr "ማውጣት"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
+msgid "Volume up's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+msgid "Run screensaver at login"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#, fuzzy
+msgid "Start screensaver"
+msgstr "እስክሪን"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+#, fuzzy
+msgid "Keyboard Update Handlers"
+msgstr "የፊደል ሠሌዳ"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#, fuzzy
+msgid "Keyboard layout"
+msgstr "የፊደል ሠሌዳው አቋራጭ"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#, fuzzy
+msgid "Keyboard model"
+msgstr "የፊደል ሠሌዳ"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+#, fuzzy
+msgid "Keyboard options"
+msgstr "የፊደል ሠሌዳው አቋራጭ"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+#, fuzzy
+msgid "keyboard layout"
+msgstr "የፊደል ሠሌዳው አቋራጭ"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+#, fuzzy
+msgid "keyboard model"
+msgstr "የፊደል ሠሌዳ"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "modmap file list"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:212
+msgid "_Postpone break"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:259
+msgid "Take a break!"
+msgstr ""
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:141
+#, fuzzy
+msgid "/_Preferences"
+msgstr "የፊደል ቅርጽ ምርጫዎች"
+
+#: ../typing-break/drwright.c:142
+#, fuzzy
+msgid "/_About"
+msgstr "ስለ... (_A)"
+
+#: ../typing-break/drwright.c:144
+msgid "/_Take a Break"
+msgstr ""
+
+#: ../typing-break/drwright.c:495
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../typing-break/drwright.c:499
+msgid "Less than one minute until the next break"
+msgstr ""
+
+#: ../typing-break/drwright.c:587
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+
+#: ../typing-break/drwright.c:635
+msgid "About GNOME Typing Monitor"
+msgstr ""
+
+#: ../typing-break/drwright.c:659
+msgid "A computer break reminder."
+msgstr ""
+
+#: ../typing-break/drwright.c:660
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr ""
+
+#: ../typing-break/drwright.c:661
+msgid "Eye candy added by Anders Carlsson"
+msgstr ""
+
+#: ../typing-break/drwright.c:837
+msgid "Break reminder"
+msgstr ""
+
+#: ../typing-break/main.c:93
+msgid "The typing monitor is already running."
+msgstr ""
+
+#: ../typing-break/main.c:106
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "The quick brown fox jumps over the lazy dog. 0123456789"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "ስም፦"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "ዓይነት፦"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "ዓይነት፦"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "መጠን፦"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "ዝርያ፦"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "የቅጂው መብት፦"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "መግለጫ፦"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+msgid "Sets the default application font"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+msgid "GNOME Font Viewer"
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+#, fuzzy
+msgid "_Apply font"
+msgstr "_የመጠቀሚያ ፕሮግራሞች የፊደል ቅርጽ፦"
+
+#: ../vfs-methods/themus/theme-method.c:520
+#, fuzzy
+msgid "Themes"
+msgstr "ጭብጥ"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "መግለጫ"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+#, fuzzy
+msgid "Control theme"
+msgstr "የተለመደው ጭብጥ"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+#, fuzzy
+msgid "Window border theme"
+msgstr "የመስኮት ወሰን"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+#, fuzzy
+msgid "Icon theme"
+msgstr "የተለመደው ጭብጥ"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr ""
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+#, fuzzy
+msgid "Apply theme"
+msgstr "ጭብጥን _አስገባ..."
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+msgid "Sets the default theme"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr ""
+
+msgid "Show help options"
+msgstr ""

--- a/po/an.po
+++ b/po/an.po
@@ -7,9 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2015-06-14 06:46+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2015-06-14 11:37+0200\n"
 "Last-Translator: Daniel <entaltoaragon@gmail.com>\n"
 "Language-Team: Aragonés <softaragones@googlegroups.com>\n"
@@ -21,519 +20,420 @@ msgstr ""
 "X-Generator: Pootle 2.5.1.1\n"
 "X-POOTLE-MTIME: 1434278245.000000\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicacions"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "No s'han trobau aplicacions"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Ubrir"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Veyer os detalles"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Buscar"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Desactivau"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificacions"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Amostrar AS _notificacions"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Fondo"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Capturas de pantalla"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Fondos d'escritorio"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Son"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Alcorces"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Alcorces de teclau"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "Camara %s"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "Servicios d'_ubicación"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Camara web integrada"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "No s'han trobau rechions"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Mena de pantalla"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Velocidat de connexión"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Reiniciar"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Aplicacions"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Stylus"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Predeterminau"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Fondo"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "Cambea a lo luengo d'o diya"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "_Adhibir un perfil…"
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "Lock Screen"
-msgstr "Blocar a pantalla"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Mosaico"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Ampliación"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "Centrar"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Escalar"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Replenar"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "Expandir"
-
-#: ../panels/background/cc-background-chooser-dialog.c:437
-msgid "Wallpapers"
-msgstr "Fondos d'escritorio"
-
-#: ../panels/background/cc-background-chooser-dialog.c:446
-msgid "Colors"
-msgstr "Colors"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:483
-msgid "Select Background"
-msgstr "Seleccionar un fondo"
-
-#: ../panels/background/cc-background-chooser-dialog.c:511
-msgid "Pictures"
-msgstr "Imachens"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:543
-msgid "No Pictures Found"
-msgstr "No s'han trobau imachens"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:561
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "Domicilio"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:573
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "Puetz adhibir imachens a la tuya carpeta %s y s'amostrarán aquí alto"
-
-#: ../panels/background/cc-background-chooser-dialog.c:580
-#: ../panels/color/cc-color-panel.c:225 ../panels/color/cc-color-panel.c:963
-#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1594
-#: ../panels/display/cc-display-panel.c:2056
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1247
-#: ../panels/network/net-device-wifi.c:1440
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/cc-printers-panel.c:1940
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:568
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-#: ../panels/user-accounts/um-photo-dialog.c:94
-#: ../panels/user-accounts/um-photo-dialog.c:217
-#: ../panels/user-accounts/um-user-panel.c:708
-#: ../panels/user-accounts/um-user-panel.c:726
-msgid "_Cancel"
-msgstr "_Cancelar"
-
-#: ../panels/background/cc-background-chooser-dialog.c:581
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:96
-msgid "Select"
-msgstr "Seleccionar"
-
-#: ../panels/background/cc-background-item.c:203
-msgid "multiple sizes"
-msgstr "grandarias multiples"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:207
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:333
-msgid "No Desktop Background"
-msgstr "Sin fondo d'escritorio"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "Fondo actual"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Cambiar a imachen de fondo d'escritorio por un tapiz u una foto"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Fondo d'escritorio;Pantalla;Escritorio;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "O Bluetooth ye desactivau"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Activar"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "No s'han trobau adaptadors Bluetooth"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Compartición por Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "Modo a_vión"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "O Bluetooth ye fisicament desactivau"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1637
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "Modo a_vión"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Modo a_vión"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Activar y desactivar o Bluetooth y connectar os tuyos dispositivos"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "Mete o dispositivo de calibración en o quadrau y preta 'prencipiar'"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
-msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
-"Mueve o tuyo dispositivo de calibración t'a posición de calibración y preta "
-"'continar'"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr "Mueve o dispositivo de calibración t'a superficie y preta 'continar'"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "Zarra la tapa d'o portatil"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "S'ha produciu una error interna que no s'ha puesto recuperar."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "As ferramientas necesarias ta la calibración no son instaladas."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "No s'ha puesto chenerar o perfil."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "No s'ha puesto obtener o punto blanco de l'obchectivo."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "Completau!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "Ha fallau a calibración!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "Puetz sacar o dispositivo de calibración."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "No interrumpas o dispositivo de calibración mientras siga en progreso"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Pantalla d'o portatil"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Camara web integrada"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Escáner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Camara %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Impresora %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Camara web %s"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Activar a chestión de color ta %s"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Amostrar os perfils de color ta %s"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:323
-msgid "Not calibrated"
-msgstr "Sin calibrar"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:141
-msgid "Default: "
-msgstr "Predeterminau: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:149
-msgid "Colorspace: "
-msgstr "Espacio de color: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:156
-msgid "Test profile: "
-msgstr "Perfil de preba: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:223
-msgid "Select ICC Profile File"
-msgstr "Seleccionar o fichero de perfil ICC"
-
-#: ../panels/color/cc-color-panel.c:226
-msgid "_Import"
-msgstr "_Importar"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:237
-msgid "Supported ICC profiles"
-msgstr "Perfils ICC suportaus"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:244
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "Totz os fichers"
-
-#: ../panels/color/cc-color-panel.c:583
-msgid "Screen"
-msgstr "Pantalla"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:908
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Ha fallau en puyar o fichero: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:922
-msgid "The profile has been uploaded to:"
-msgstr "O perfil s'ha puyau ta:"
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Write down this URL."
-msgstr "Anota ista URL."
-
-#: ../panels/color/cc-color-panel.c:925
-msgid "Restart this computer and boot your normal operating system."
-msgstr "Reinicia l'equipo y ranqa o tuyo sistema operativo normal."
-
-#: ../panels/color/cc-color-panel.c:926
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "Escribe a URL en o tuyo navegador pa descargar y instalar o perfil."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:960
-msgid "Save Profile"
-msgstr "Alzar o perfil"
-
-#: ../panels/color/cc-color-panel.c:964
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "_Alzar"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1324
-msgid "Create a color profile for the selected device"
-msgstr "Creyar un perfil de color ta lo dispositivo seleccionau"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
 msgstr ""
-"No s'ha detectau l'instrumento de medida. Compreba que ye enchegau y "
-"connectau correctament."
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1373
-msgid "The measuring instrument does not support printer profiling."
-msgstr "L'instrumento de medida no suporta perfilau d'impresoras."
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Actualment garra aplicación ye reproducindo u gravando son."
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1384
-msgid "The device type is not currently supported."
-msgstr "A mena de dispositivo no ye suportada actualment."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "Espacio estándar"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "Perfil de preba"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatico"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Calidat baixa"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Calidat meya"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Calidat alta"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB predeterminau"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK predeterminau"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Griso predeterminau"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "O furnidor suministra os datos de calibración de fabrica"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"No se puet fer a correcciónde pantalla en pantalla completa con iste perfil"
 
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "Iste perfil ya no ye preciso"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Examinar ta mirar mas imachens"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibración de pantalla"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1476
-msgid "Cancel"
-msgstr "Cancelar"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancelar"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "Prencipiar"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "Reprener"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "Feito"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Feito"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Calibración d'a pantalla"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Calidat d'a calibración"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -543,42 +443,42 @@ msgstr ""
 "color d'a tuya pantalla. Contra más tiempo pierdas en achustar a "
 "calibración, millor será la calidat d'o perfil de color."
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "No podrás emplegar o tuyo ordinador mientras se faiga la calibración."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Calidat d'a imachen"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Tiempo aproximau"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "Calidat d'a calibración"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Selecciona o sensor que quiers emplegar ta la calibración."
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Dispositivo de calibración"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "Selecciona la mena de pantalla que ye connectada."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Selecciona o sensor que quiers emplegar ta la calibración."
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Mena de pantalla"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Selecciona la mena de pantalla que ye connectada."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Puntero blanco d'o perfil"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -586,11 +486,11 @@ msgstr ""
 "Selecciona o punto blanco de l'obchectivo en a pantalla. A mayoría d'as "
 "pantallas deben estar calibradas con un iluminant D65."
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "Puntero blanco d'o perfil"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Brilo d'a pantalla"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -598,7 +498,7 @@ msgstr ""
 "Por favor, configura o brilo d'a pantalla como siga normal ta tu. "
 "L'administración d'o color será más precisa en iste libel de brilo."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -606,11 +506,11 @@ msgstr ""
 "Alternativament, puetz usar o libel de brilo usau con un d'os atros perfils "
 "ta iste dispositivo."
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "Brilo d'a pantalla"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nombre d'o perfil"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -618,35 +518,27 @@ msgstr ""
 "Puetz usar un perfil de color en diferents ordinadors, o mesmo creyar "
 "perfils ta diferents condicions de luz."
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Nombre d'o perfil:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "Nombre d'o perfil"
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Resumen"
 
-#: ../panels/color/color.ui.h:21
+#: panels/color/cc-color-panel.ui:259
 msgid "Profile successfully created!"
 msgstr "O perfil ha estau creyau satisfactoriament!"
 
-#: ../panels/color/color.ui.h:22
+#: panels/color/cc-color-panel.ui:290
 msgid "Copy profile"
 msgstr "Copiar o perfil"
 
-#: ../panels/color/color.ui.h:23
+#: panels/color/cc-color-panel.ui:296
 msgid "Requires writable media"
 msgstr "Requier un meyo escribible"
 
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "Puyar o perfil"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "Requerir una connexión a internet"
-
-#: ../panels/color/color.ui.h:26
+#: panels/color/cc-color-panel.ui:313
 msgid ""
 "You may find these instructions on how to use the profile on <a "
 "href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
@@ -656,25 +548,12 @@ msgstr ""
 "href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> y <a "
 "href=\"windows\">Microsoft Windows</a>."
 
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:729
-msgid "Summary"
-msgstr "Resumen"
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Adhibir un perfil"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "Importar un fichero…"
-
-#: ../panels/color/color.ui.h:30
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1477
-msgid "_Add"
-msgstr "_Adhibir"
-
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
@@ -682,3007 +561,2286 @@ msgstr ""
 "S'han trobau problemas. O perfil puet no funcionar correctament. <a "
 "href=\"\">Amostrar os detalles.</a>"
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "Importar un fichero…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Adhibir"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Cada dispositivo ameneste un perfil de color actualizau ta poder chestionar "
 "a color."
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Aprender mas"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Aprende mas sobre a chestión d'a color"
 
-#: ../panels/color/color.ui.h:35
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "Establir ta totz os usuarios"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Establir iste perfil ta totz os usuarios d'iste equipo"
 
-#: ../panels/color/color.ui.h:37
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "Activar"
 
-#: ../panels/color/color.ui.h:38
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "Adhibir un perfil"
 
-#: ../panels/color/color.ui.h:39 ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "Calibrar…"
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Calibrar o dispositivo"
 
-#: ../panels/color/color.ui.h:41
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "Sacar o perfil"
 
-#: ../panels/color/color.ui.h:42
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "Veyer os detalles"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "No s'han detectau dispositivos que se puedan chestionar por color"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Prochector"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plasma"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL retroiluminau)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED retroiluminau)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (LED blanco retroiluminau)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Gama LCD amplo (CCFL retroiluminau)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Gama LCD amplo (RGB LED retroiluminau)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Alta"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 menutos"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Meya"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:2
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 menutos"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Baixa"
 
-#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:1
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 menutos"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Nativo d'a pantalla"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Impresions y publicacions)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Fotografía y graficos)"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Color"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 "Calibrar a color d'os tuyos dispositivos, como pantallas, camaras u "
 "impresoras"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Color;ICC;Perfil;Calibrau;Impresora;Pantalla;"
 
-#: ../panels/common/cc-common-language.c:323
-msgid "Other…"
-msgstr "Unatro…"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Idioma"
 
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:270
-#: ../panels/region/cc-input-chooser.c:167
-msgid "More…"
-msgstr "Mas…"
+#: panels/common/cc-language-chooser.ui:13
+#, fuzzy
+msgid "_Select"
+msgstr "Seleccionar"
 
-#: ../panels/common/cc-language-chooser.c:139
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "No s'han trobau idiomas"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "Idioma"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Mas…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "_Feito"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%d/%b/%Y, %I:%M"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%d/%b/%Y, %H:%M"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Hora"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%H:%M"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "Chinero"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "Febrero"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "Marzo"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "Abril"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "Mayo"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "Chunio"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "Chulio"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "Agosto"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "Setiembre"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "Octubre"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "Noviembre"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "Aviento"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Calendata y hora"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "Hora"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "Menuto"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "Diya"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "Mes"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "Anyo"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mes"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Chinero"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Febrero"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Marzo"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Abril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mayo"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Chunio"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Chulio"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Agosto"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Setiembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Octubre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Noviembre"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Aviento"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Diya"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Zona horaria"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Mirar por una ciudat"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "Calen_data y hora automatica"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Requier acceso a internet"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Calenda_ta y hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "_Zona horaria automatica"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "Date & _Time"
-msgstr "Calenda_ta y hora"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "Requier acceso a internet"
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
-msgstr "_Zona horaria"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Activada"
 
-#: ../panels/datetime/datetime.ui.h:28
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "Zona horaria"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Formato d'a hora"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24 horas"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "AM/PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Calendatas"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "Secundario"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calandario"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Numeros"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Cambiar a calendata y a hora, incluindo a zona horaria"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Reloch;Zona horaria;Ubicación;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "Cambiar a configuración d'a hora y a calendata d'o sistema"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr ""
 "Ta cambiar a configuración d'a calendata u d'a hora, debes autenticar-te."
 
-#: ../panels/display/cc-display-panel.c:579
-msgid "Lid Closed"
-msgstr "Tapa zarrada"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
 
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:582
-msgid "Mirrored"
-msgstr "En espiello"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "Co_rreo"
 
-#: ../panels/display/cc-display-panel.c:584
-#: ../panels/display/cc-display-panel.c:2228
-msgid "Primary"
-msgstr "Primario"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calandario"
 
-#: ../panels/display/cc-display-panel.c:586
-#: ../panels/notifications/cc-notifications-panel.c:257
-#: ../panels/power/cc-power-panel.c:1834 ../panels/power/cc-power-panel.c:1845
-#: ../panels/privacy/cc-privacy-panel.c:155
-#: ../panels/privacy/cc-privacy-panel.c:222
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "Amortau"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Mosica"
 
-#: ../panels/display/cc-display-panel.c:589
-msgid "Secondary"
-msgstr "Secundario"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
 
-#. Title of displays dialog when multiple monitors are present.
-#: ../panels/display/cc-display-panel.c:1591
-msgid "Arrange Combined Displays"
-msgstr "Ordenar as pantallas combinadas"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotos"
 
-#: ../panels/display/cc-display-panel.c:1595
-#: ../panels/display/cc-display-panel.c:2057
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr "_Aplicar"
-
-#: ../panels/display/cc-display-panel.c:1619
-msgid "Drag displays to rearrange them"
-msgstr "Arrocegar as pantallas ta reordenar-las"
-
-#: ../panels/display/cc-display-panel.c:2106
-msgid "Rotate counterclockwise by 90°"
-msgstr "Rotar 90° en sentiu antihorario"
-
-#: ../panels/display/cc-display-panel.c:2124
-msgid "Rotate by 180°"
-msgstr "Rotar 180°"
-
-#: ../panels/display/cc-display-panel.c:2142
-msgid "Rotate clockwise by 90°"
-msgstr "Rotar 90° en sentiu antihorario"
-
-#: ../panels/display/cc-display-panel.c:2163
-msgid "Size"
-msgstr "Grandaria"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2176
-msgid "Aspect Ratio"
-msgstr "Proporción d'aspecto"
-
-#: ../panels/display/cc-display-panel.c:2198
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "Resolución"
-
-#: ../panels/display/cc-display-panel.c:2229
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "Amostrar a barra superior y l'anvista de actividatz en ista pantalla"
-
-#: ../panels/display/cc-display-panel.c:2235
-msgid "Secondary Display"
-msgstr "Pantalla secundaria"
-
-#: ../panels/display/cc-display-panel.c:2236
-msgid "Join this display with another to create an extra workspace"
-msgstr ""
-"Unir ista pantalla con unatra ta creyar un espacio de treballo adicional"
-
-#: ../panels/display/cc-display-panel.c:2243
-msgid "Presentation"
-msgstr "Presentación"
-
-#: ../panels/display/cc-display-panel.c:2244
-msgid "Show slideshows and media only"
-msgstr "Amostrar nomás as diapositivas y a multimedia"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2249
-msgid "Mirror"
-msgstr "Espiello"
-
-#: ../panels/display/cc-display-panel.c:2250
-msgid "Show your existing view on both displays"
-msgstr "Amostrar a tuya anvista existent en todas dos pantallas"
-
-#: ../panels/display/cc-display-panel.c:2256
-msgid "Turn Off"
-msgstr "Desenchegar"
-
-#: ../panels/display/cc-display-panel.c:2257
-msgid "Don't use this display"
-msgstr "No usar ista pantalla"
-
-#: ../panels/display/cc-display-panel.c:2560
-msgid "Could not get screen information"
-msgstr "No s'ha puesto obtener a información d'a pantalla"
-
-#: ../panels/display/cc-display-panel.c:2591
-msgid "_Arrange Combined Displays"
-msgstr "Ordenar as p_antallas combinadas"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "Pantallas"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr "Trigar cómo usar as pantallas y os prochectors connectaus"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "Panel;Prochector;xranrd;Pantalla;Resolución;refrescar;Monitor;"
-
-#: ../panels/info/cc-info-panel.c:385
-msgid "Wayland"
-msgstr "Wayland"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:388 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "Desconoixiu"
-
-#: ../panels/info/cc-info-panel.c:473
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d bits"
-
-#: ../panels/info/cc-info-panel.c:475
-#, c-format
-msgid "%d-bit"
-msgstr "%d bits"
-
-#: ../panels/info/cc-info-panel.c:1155
-msgid "Ask what to do"
-msgstr "Preguntar qué fer"
-
-#: ../panels/info/cc-info-panel.c:1159
-msgid "Do nothing"
-msgstr "No fer cosa"
-
-#: ../panels/info/cc-info-panel.c:1163
-msgid "Open folder"
-msgstr "Ubrir una carpeta"
-
-#: ../panels/info/cc-info-panel.c:1254
-msgid "Other Media"
-msgstr "Atros suportes"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for audio CDs"
-msgstr "Seleccionar una aplicación ta CD de son"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application for video DVDs"
-msgstr "Seleccionar una aplicación ta DVD de video"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Seleccionar una aplicación que executar quan se connecta un reproductor de "
-"mosica"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application to run when a camera is connected"
-msgstr "Seleccionar una aplicación que executar quan se connecta una camera"
-
-#: ../panels/info/cc-info-panel.c:1289
-msgid "Select an application for software CDs"
-msgstr "Seleccionar una aplicación ta CD de software"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1301
-msgid "audio DVD"
-msgstr "DVD de son"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank Blu-ray disc"
-msgstr "Disco Blu-ray virchen"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank CD disc"
-msgstr "CD virchen"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank DVD disc"
-msgstr "DVD virchen"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "blank HD DVD disc"
-msgstr "Disco HD DVD virchen"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "Blu-ray video disc"
-msgstr "Disco Blu-ray de video"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "e-book reader"
-msgstr "Lector de libros electronicos"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "HD DVD video disc"
-msgstr "Disco HD DVD de video"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Picture CD"
-msgstr "CD d'imachens"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Super Video CD"
-msgstr "CD de super video"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Video CD"
-msgstr "CD de video"
-
-#: ../panels/info/cc-info-panel.c:1312
-msgid "Windows software"
-msgstr "Software de Windows"
-
-#: ../panels/info/cc-info-panel.c:1435
-#: ../panels/keyboard/keyboard-shortcuts.c:1947
-msgid "Section"
-msgstr "Sección"
-
-#: ../panels/info/cc-info-panel.c:1444 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "Anvista cheneral"
-
-#: ../panels/info/cc-info-panel.c:1450 ../panels/info/info.ui.h:21
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
 msgid "Default Applications"
 msgstr "Aplicacions predeterminadas"
 
-#: ../panels/info/cc-info-panel.c:1455 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "Suportes extraíbles"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Aplicacions predeterminadas"
 
-#: ../panels/info/cc-info-panel.c:1480
-#, c-format
-msgid "Version %s"
-msgstr "Versión %s"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:46
-msgid "Details"
-msgstr "Detalles"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Informar d'una error"
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Informar d'un problema _automaticament"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Aplicar"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Dezaga"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "O Bluetooth ye desactivau"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "grandarias multiples"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Espiello"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Pantalla secundaria"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "Aniello dreito"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientación"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolución"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Escalar"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "No bi ha impresoras disponibles"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Reiniciar-ne agora"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Horas"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hora"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Menuto"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Pantallas"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Trigar cómo usar as pantallas y os prochectors connectaus"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Panel;Prochector;xranrd;Pantalla;Resolución;refrescar;Monitor;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Clau de seguranza"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Libel de tinta"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Libel de tinta"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Libel de tinta"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Seguranza"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"pantalla;bloqueyo;dianostico;error;privau;recient;temporal;tmp;indiz;nombre;"
+"ret;identidat;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Nombre d'o dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Adreza fisica"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memoria"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesador"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Graficos"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calculando…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Nombre"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Mena de VPN"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Versión 0"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Cargando as opcions…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Software de Windows"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualización"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Emplego d'o software"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Sacar o dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nombre d'o dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Nombre d'_usuario"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr "Veyer información sobre o tuyo sistema"
 
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "dispositivo;sistema;información;memoria;procesador;versión;predeterminau;"
 "aplicación;alternativo;preferiu;cd;dvd;usb;son;video;disco;extraíble;meyo;"
 "autoexecutar;"
 
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "Seleccionar cómo s'han de maniar atros suportes"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "_Acción:"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "_Mena:"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "Nombre d'o dispositivo"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "Memoria"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "Procesador"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "Sistema base"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "Disco"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "Calculando…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "Graficos"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "Virtualización"
-
-#: ../panels/info/info.ui.h:13
-msgid "Check for updates"
-msgstr "Comprebar si bi ha actualizacions"
-
-#: ../panels/info/info.ui.h:15
-msgid "_Web"
-msgstr "_Web"
-
-#: ../panels/info/info.ui.h:16
-msgid "_Mail"
-msgstr "Co_rreo"
-
-#: ../panels/info/info.ui.h:17
-msgid "_Calendar"
-msgstr "_Calandario"
-
-#: ../panels/info/info.ui.h:18
-msgid "M_usic"
-msgstr "_Mosica"
-
-#: ../panels/info/info.ui.h:19
-msgid "_Video"
-msgstr "_Video"
-
-#: ../panels/info/info.ui.h:20
-msgid "_Photos"
-msgstr "_Fotos"
-
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "Seleccionar cómo s'han de maniar os suportes"
-
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "CD de _son"
-
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "_DVD de video"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "Reproductor de _mosica"
-
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "_Software"
-
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "_Atros suportes…"
-
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr "_Nunca no preguntar ni encetar programas en introducir suportes"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "Son y meyos"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Silenciar"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Baixar o volumen"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Puyar o volumen"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Lanzar o reproductor multimeya"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Reproducir (u reproducir/pausar)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Pausar a reproducción"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Aturar a reproducción"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Pista anterior"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Pista siguient"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Fer fuera"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Escritura"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "Cambiar a la siguient fuent de dentrada"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "Cambiar a l'anterior fuent de dentrada"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "Lanzadors"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Lanzar o visor d'aduya"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1605
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "Configuración"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Lanzar a calculadera"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "Lanzar o client de correu"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "Lanzar o navegador web"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "Carpeta presonal"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "Mirar"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "Capturas de pantalla"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "Alzar una captura de pantalla en $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Alzar la captura d'una finestra en $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Alzar a captura de pantalla d'un aria en $PICTURES"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "Copiar una captura de pantalla en o portafuellas"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Copiar una captura de pantalla d'una finestra en o portafuellas"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Copiar una captura de pantalla d'un aria en o portafuellas"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "Fer una grabación curta d'o escritorio"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "Zarrar a sesión"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "Bloqueyar a pantalla"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "Acceso universal"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "Activar u desactivar l'ampliación"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "Enamplar"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "Reducir"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "Activar u desactivar o lector de pantalla"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "Activar u desactivar o teclau en pantalla"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "Agrandir a mida d'o texto"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "Achiquir a mida d'o texto"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "Alto contraste activau u desactivau"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1219
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-msgid "Disabled"
-msgstr "Desactivau"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Adhibir una fuent de dentrada"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+"Os metodos de dentrada no se pueden usar en a pantalla d'inicio de sesión"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "No s'ha seleccionau garra fuent de dentrada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opcions"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Puyar"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Baixar"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Alcorces de teclau"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Sacar"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Fuents de dentrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Opcions d'as fuents de dentrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Usar a _mesma fuent ta todas as finestras"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "Premitir _diferents fuents ta cada finestra"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "Tecla de caracters alternativos"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "Tecla de composición"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "Solament os modificadors cambean a la fuent siguient"
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Alcorces de teclau"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Alcorces presonalizaus"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sección"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Alcorces"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Adhibir l'alcorce"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Alcorces presonalizaus"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Adhibir l'alcorce"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Alcorces de teclau"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Sacar"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "Substitui_r"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nombre"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "C_omando:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+#, fuzzy
+msgid "Shortcut"
+msgstr "Alcorces"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Nuevo alcorce de teclau…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Denguna"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Teclau"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
 "Veyer y cambiar os alcorces d'o teclau y establir as tuyas preferencias de "
 "escritura"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Alcorce;Repetir;Parpaguiar;"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "Alcorce presonalizau"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "_Nombre:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "C_omando:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "Repetición de teclas"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "As pulsacions de teclas se _repiten quan a tecla se mantién preta"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "_Retardo:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "Ve_locidad:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "Curto"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "Lenta"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "Velocidat de repetición d'as teclas"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "Largo"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "Rapida"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "Parpagueo d'o cursor"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "O cursor pa_rpadia en os campos de texto"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "Ve_locidad:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "Velocidat de parpagueo d'o cursor"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
-msgid "Input Sources"
-msgstr "Fuents de dentrada"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "Adhibir l'alcorce"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "Sacar l'alcorce"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
-"Ta editar un alcorce nuevo preta en a ringlera y mantién pretas as teclas "
-"nuevas, u preta Retroceso ta eliminar-lo."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
-msgid "Shortcuts"
-msgstr "Alcorces"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "Servicios d'_ubicación"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:632
-#: ../panels/keyboard/keyboard-shortcuts.c:640
-msgid "Custom Shortcuts"
-msgstr "Alcorces presonalizaus"
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Actualment garra aplicación ye reproducindo u gravando son."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:857
-msgid "<Unknown Action>"
-msgstr "<Acción desconoixida>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1358
-#, c-format
+#: panels/location/cc-location-panel.ui:38
 msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
-"No se puet usar l'alcorce de teclau \"%s\" porque se fería imposible "
-"escribir usando ista tecla.\n"
-"Por favor, intenta-lo con una tecla como Control, Alt u Mayús. a lo mesmo "
-"tiempo."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1388
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
 msgstr ""
-"L'alcorce \"%s\" ya se ye usando ta\n"
-"\"%s\""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1393
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "Si reasignas l'alcorce a \"%s\" se desactivará l'alcorce \"%s\"."
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1399
-msgid "_Reassign"
-msgstr "_Reasignar"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1440
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
 msgstr ""
-"L'alcorce \"%s\" tien un alcorce \"%s\" asociau. Quiers establir-lo "
-"automaticament ta \"%s\"?"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1450
-#, c-format
-msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"\"%s\" ye actualment asociau con \"%s\", iste alcorce se desactivará si "
-"continas."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1457
-msgid "_Assign"
-msgstr "_Asignar"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "S'amorta la pantalla"
 
-#: ../panels/mouse/cc-mouse-panel.c:94
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "No s'han trobau aplicacions"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "_Prebar a tuya configuración"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-msgid "Test Your Settings"
-msgstr "Prebar as tuya preferencias"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Cheneral"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "_Botón primario"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Cucho"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Dreito"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Buscar ubicacions"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Ratet"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "_Teclas d'o ratet"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Desplazar enta baixo"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "O cursor d'o manificador se mueve con o conteniu"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "activo"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Metodo"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "To_car ta pretar"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "To_car ta pretar"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Desactivar a imachen"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relativo)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Desplazar enta la dreita"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Desplazar enta la cucha"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dos caras"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Preba a pretar una vegada, dos vegadas, desplazar-te"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "Ratet y touchpad"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 "Cambiar a sensibilidat d'o tuyo ratet u lo tuyo touchpad y configurar-los ta "
 "cuchos u diestros"
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Trackpad;Puntero;Click;Tap;Dople;Botón;Trackball;Desplazamiento;"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "Cheneral"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "Lenta"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "Tiempo d'aspera d'o dople clic"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "Rapida"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "_Dople clic"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Espacio de color: "
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "_Botón primario"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "_Cucho"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "Vuedar automa_ticament a papelera"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "_Dreito"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "Ratet"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "_Velocidat d'o puntero"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "Lenta"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Monitor %s"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "Rapida"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "Touchpad"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "Lenta"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Aplicacions"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "Rapida"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Tap to _click"
-msgstr "To_car ta pretar"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Two _finger scroll"
-msgstr "Despla_zamiento con dos didos"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
-msgid "_Natural scrolling"
-msgstr "Desplazamiento _natural"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "Preba a pretar una vegada, dos vegadas, desplazar-te"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "Cinco clics, ye tiempo de GEGL!"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Dispositivos"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "Dople clic, botón primario"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "Un clic, botón primario"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Adhibir una nueva connexión"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "Dople clic, botón meyo"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "Un clic, botón meyo"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Connectau"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "Dople clic, botón secundario"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opcions…"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "Un clic, botón secundario"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:358
-msgid "Air_plane Mode"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Punto d'acceso inalambrico"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nombre d'o ret"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Clau"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Clau d'a colla"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Clau _actual"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Enchegar"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
 msgstr "Modo a_vión"
 
-#: ../panels/network/cc-network-panel.c:967
-msgid "Network proxy"
-msgstr "Proxy d'o ret"
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "VPN %s"
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "No s'han trobau imachens"
 
-#: ../panels/network/cc-network-panel.c:1300
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Modo a_vión"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Punto d'acceso inalambrico"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Usar-ne como un punto d'acceso…"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Retz"
+
+#: panels/network/cc-wifi-panel.ui:297
+#, fuzzy
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager ha d'estar en execución."
+
+#: panels/network/cc-wifi-panel.ui:303
 msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr "Bella cosa ha fallau. Contacte con o fabricant d'o software."
 
-#: ../panels/network/cc-network-panel.c:1306
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager ha d'estar en execución."
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Seguranza 802.1x"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "pachina 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "Identidat anoni_ma"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:5
-msgid "Inner _authentication"
-msgstr "Autenticación i_nterna"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:6
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "pachina 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:469
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "Seguranza"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "automatico"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:218
-#: ../panels/network/net-device-wifi.c:382
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:222
-#: ../panels/network/net-device-wifi.c:387
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:226
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:231
-msgid "Enterprise"
-msgstr "Interpresa"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:236
-#: ../panels/network/net-device-wifi.c:372
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Denguna"
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:17
-msgid "Never"
-msgstr "Nunca"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:815
-msgid "Today"
-msgstr "Hue"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:818
-msgid "Yesterday"
-msgstr "Ahiere"
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:476
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "fa %i diya"
 msgstr[1] "fa %i diyas"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:533
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Denguna"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Feble"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Acceptar"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:568
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Buena"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:570
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excelent"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:262
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "Identidat"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "Adreza"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "Mascara de ret"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:2
-msgid "Gateway"
-msgstr "Puerta de vinclo"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "Eliminar l'adreza"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "Adhibir"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "Servidor"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "Eliminar o servidor DNS"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "Metrica"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "Eliminar a ruta"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP)"
-msgstr "Automatico (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:26
-#: ../panels/privacy/cc-privacy-panel.c:182
-msgid "Manual"
-msgstr "Manual"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "Nomás vinclo local"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:967
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "Prefixo"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:182
-msgid "Automatic"
-msgstr "Automatico"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "Automatico, nomás DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:937
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:51
-msgid "Reset"
-msgstr "Reiniciar"
-
-#: ../panels/network/connection-editor/ce-page-security.c:253
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Denguna"
-
-#: ../panels/network/connection-editor/ce-page-security.c:276
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Clau WEP 40/128 bits (Hexadecimal u ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:286
-msgid "WEP 128-bit Passphrase"
-msgstr "Clau WEP de 128 bits"
-
-#: ../panels/network/connection-editor/ce-page-security.c:299
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:312
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinamica (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:326
-msgid "WPA & WPA2 Personal"
-msgstr "WPA y WPA2 personal"
-
-#: ../panels/network/connection-editor/ce-page-security.c:340
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA y WPA2 Interpresa"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Fortidura d'o sinyal"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Velocidat de connexión"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:157
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguranza"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "Adreza IPv4"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:158
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "Adreza IPv6"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:165
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Adreza fisica"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:169
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Perfils ICC suportaus"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Ruta predeterminada"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Usada por zaguera vegada"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "Par trenau (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Interficie d'unidat d'acoplamiento (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "Interficie independient de meyos (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mbps"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mbps"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gbps"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gbps"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "_Nombre"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
-msgid "_MAC Address"
-msgstr "Adreza _MAC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "M_TU"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "Adreza _clonada"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "bytes"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "Fer-ne disponible ta _atros usuarios"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "Connectar-ne _automaticament"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-msgid "Firewall _Zone"
-msgstr "Zona d'o tallafuegos"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:113
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "Predeterminada"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "A zona define o libel de confianza d'a connexión"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
-msgstr "_Adrezas"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "DNS automatico"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Routes"
-msgstr "Rutas"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "Rutas automaticas"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:34
-msgid "Use this connection _only for resources on its network"
-msgstr "Usar ista c_onnexion nomás ta os recursos en o tuyo ret"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "No s'ha puesto ubrir l'editor de connexions"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "Nuevo perfil"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "Bond"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "Equipo"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "Puente"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "No s'han puesto cargar os complementos de VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "Importar dende un fichero…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "Adhibir una connexión de ret"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "_Reiniciar"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1441
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "_Ixuplidar"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"Restablir a configuración ta iste ret, incluindo as claus, pero remerar-lo "
-"como un ret preferiu"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"Sacar totz os detalles relativos a iste ret y no tornar a intentar connectar-"
-"se automaticament"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
-msgid "S_ecurity"
-msgstr "S_eguranza"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "No se puet importar a connexión VPN"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"No s'ha puesto leyer o fichero '%s' u no contién información de connexión "
-"VPN que se pueda reconoixer\n"
-"\n"
-"Error: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "Selecciona lo fichero que quiers importar"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1941
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "_Open"
-msgstr "_Ubrir"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "Ya existe un fichero clamau \"%s\"."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "Substitui_r"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Quiers substituir %s con a connexión VPN que yes alzando?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "No se puet exportar a connexión VPN"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"No s'ha puesto exportar a connexión VPN '%s' ta %s.\n"
-"\n"
-"Error: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-msgid "Export VPN connection"
-msgstr "Exportar a connexión VPN"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(Error: no s'ha puesto cargar l'editor de connexions VPN)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "_SSID"
-msgstr "_SSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
-msgid "_BSSID"
-msgstr "_BSSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "O mío ret privau"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Fer-ne disponible ta _atros usuarios"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nombre"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Adreza _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Adreza _clonada"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "_Metodo"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatico (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Nomás vinclo local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Desactivau"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "Compartiu con atros ordinadors"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_Adrezas"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adreza"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Mascara de ret"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Puerta de vinclo"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Automatico"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automatico"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rutas"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Rutas automaticas"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "Metrica"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Usar ista c_onnexion nomás ta os recursos en o tuyo ret"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "_Metodo"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatico, nomás DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefixo"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_eguranza"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Error: no s'ha puesto cargar l'editor de connexions VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "Ret"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+#: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controlar cómo se connecta ta Internet"
 
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Ret;Inalambrica;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Banda ampla;Modem;Bluetooth;VPN;"
 "WLAN;Puente;Enlaz;DNS;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "Asociar esclaus"
-
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(garra)"
-
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "Puentear esclaus"
-
-#: ../panels/network/net-device-ethernet.c:110
-#: ../panels/network/net-device-wifi.c:462
-msgid "never"
-msgstr "Nunca"
-
-#: ../panels/network/net-device-ethernet.c:120
-#: ../panels/network/net-device-wifi.c:472
-msgid "today"
-msgstr "Hue"
-
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:474
-msgid "yesterday"
-msgstr "Ayere"
-
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "Adreza IP"
-
-#: ../panels/network/net-device-ethernet.c:176
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "Usada por zaguera vegada"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:286
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "Cableyau"
-
-#: ../panels/network/net-device-ethernet.c:354
-#: ../panels/network/net-device-wifi.c:1599
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8 ../panels/network/network-vpn.ui.h:7
-msgid "Options…"
-msgstr "Opcions…"
-
-#: ../panels/network/net-device-ethernet.c:472
-#, c-format
-msgid "Profile %d"
-msgstr "Perfil %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "Adhibir una nueva connexión"
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr "Esclaus de l'equipo"
-
-#: ../panels/network/net-device-wifi.c:1154
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-"Si tiens unatra connexión ta Internet antiparti d'a inalambrica, puetz "
-"configurar un punto d'acceso inalambrico ta compartir a tuya connexión ta "
-"Internet con atros."
-
-#: ../panels/network/net-device-wifi.c:1158
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "Cambiar a lo punto d'acceso inalambrico te desconnectará de <b>%s</b>."
-
-#: ../panels/network/net-device-wifi.c:1162
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"No ye posible accedir a Internet usando a connexión inalambrica mientras o "
-"punto d'acceso ye activau."
-
-#: ../panels/network/net-device-wifi.c:1245
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Aturar o punto d'acceso y desconnectar a los usuarios?"
-
-#: ../panels/network/net-device-wifi.c:1248
-msgid "_Stop Hotspot"
-msgstr "_Aturar punto d'acceso"
-
-#: ../panels/network/net-device-wifi.c:1305
-msgid "System policy prohibits use as a Hotspot"
-msgstr "A politica d'o sistema prohibe usar-lo como punto d'acceso"
-
-#: ../panels/network/net-device-wifi.c:1308
-msgid "Wireless device does not support Hotspot mode"
-msgstr "O dispositivo inalambrico no suporta o modo de punto d'acceso"
-
-#: ../panels/network/net-device-wifi.c:1437
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Se perderán os detalles d'os retz seleccionaus, incluindo a clau y "
-"qualsiquier configuración presonalizada."
-
-#: ../panels/network/net-device-wifi.c:1752
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "Historia"
-
-#: ../panels/network/net-device-wifi.c:1756
-#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
-#: ../panels/wacom/cc-wacom-page.c:525
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "_Close"
-msgstr "_Zarrar"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1764
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Ixuplidar"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"S'usa l'autodiscubrimiento d'o proxy web quan no se proporciona una URL de "
-"configuración."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "No se recomienda ta retz publicos en as qualas no se confida."
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "Proxy"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "_Adhibir un perfil…"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "Furnidor"
-
-#: ../panels/network/network-proxy.ui.h:1
-msgctxt "proxy method"
-msgid "None"
-msgstr "Dengún"
-
-#: ../panels/network/network-proxy.ui.h:2
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "Manual"
-
-#: ../panels/network/network-proxy.ui.h:3
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "Automatico"
-
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
-msgstr "_Metodo"
-
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "URL de _configuración"
-
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "Proxy ta _HTTP"
-
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "Proxy ta H_TTPS"
-
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "Proxy ta _FTP"
-
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "_Servidor socks"
-
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "_Ignorar os anfitrions"
-
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "Puerto ta proxy HTTP"
-
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "Puerto ta proxy HTTPS"
-
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "Puerto ta proxy FTP"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "Puerto ta proxy Socks"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "Amortar o dispositivo"
-
-#: ../panels/network/network.ui.h:1
-msgid "Add Device"
-msgstr "Adhibir un dispositivo"
-
-#: ../panels/network/network.ui.h:2
-msgid "Remove Device"
-msgstr "Sacar o dispositivo"
-
-#: ../panels/network/network-vpn.ui.h:1
-msgid "VPN Type"
-msgstr "Mena de VPN"
-
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Group Name"
-msgstr "Nombre d'a colla"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Password"
-msgstr "Clau d'a colla"
-
-#: ../panels/network/network-vpn.ui.h:5
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "Nombre d'usuario"
-
-#: ../panels/network/network-vpn.ui.h:6
-msgid "Turn VPN connection off"
-msgstr "Zarrar a connexión VPN"
-
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "_Connexión automatica"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "Detalles"
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "_Clau"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "Denguna"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "Amostrar a _clau"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr "Fer-ne disponible ta la resta d'usuarios"
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "Identidat"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr "Nomás adrezas automaticas (DHCP)"
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr "Nomás o vinclo local"
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr "Compartiu con atros ordinadors"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr "_Ignorar as rotas obtenidas automaticament"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr "Adreza MAC _clonada"
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr "hardware"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"Restablir a configuración d'ista connexión a las suyas valors "
-"predeterminadas, pero recordar-la como una connexión favorita."
-
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"Sacar totz os detalles relativos a iste ret y no tornar a intentar connectar-"
-"se automaticament a ella."
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "Reiniciar"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "Hardware"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr "Punto d'acceso inalambrico"
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Turn On"
-msgstr "_Enchegar"
-
-#: ../panels/network/network-wifi.ui.h:54
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Turn Wi-Fi off"
-msgstr "Amortar o Wi-Fi"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controlar cómo se connecta ta Internet"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_Use as Hotspot…"
-msgstr "_Usar-ne como un punto d'acceso…"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Ret;Inalambrica;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Banda ampla;Modem;Bluetooth;VPN;"
+"WLAN;Puente;Enlaz;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "_Connect to Hidden Network…"
-msgstr "_Connectar-se a un ret amagau…"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Cableyau"
 
-#: ../panels/network/network-wifi.ui.h:58
-msgid "_History"
-msgstr "_Historico"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Amortar o dispositivo"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Amortar ta connectar-se a un ret inalambrico"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "activo"
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Furnidor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adreza IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Proxy d'o ret"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy ta _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy ta H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy ta _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Servidor socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorar os anfitrions"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Puerto ta proxy HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Puerto ta proxy HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Puerto ta proxy FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Puerto ta proxy Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuración"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Zarrar a connexión VPN"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Nombre d'o ret"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Connected Devices"
-msgstr "Dispositivos connectaus"
-
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Menade seguranza"
 
-#: ../panels/network/network-wifi.ui.h:63
-msgid "Security key"
-msgstr "Clau de seguranza"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Clau"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Amortar o Wi-Fi"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "Infrastructura"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Cargando as opcions…"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "Estau desconoixiu"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Connectar-se a un ret amagau…"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "Sin chestionar"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Punto d'acceso inalambrico"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "No disponible"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "Connectando"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "S'ameneste autenticación"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "Connectau"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "Desconnectando"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "A connexión ha fallau"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "Estau desconoixiu (ausent)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "No connectau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "Ha fallau a configuración"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "Ha fallau a configuración IP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "A configuración IP ha expirau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "S'amenesten secretos, pero no s'han proporcionau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "O suplicant de 802.1x ye desconnectau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "Ha fallau a configuración d'o suplicant de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "Ha fallau o suplicant de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "O suplicant de 802.1x ha tardau muito tiempo en autenticar-se"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "S'ha produciu una error en encetar o servicio de PPP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "Servicio PPP desconnectau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "O PPP ha fallau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "O client DHCP ha fallau en encetar-se"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "S'ha produciu una error en o client DHCP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "Ha fallau o client DHCP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "S'ha produciu una error en encetar o servicio de connexión compartida"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "Ha fallau o servicio de connexión compartida"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "S'ha produciu una error en encetar o servicio d'IP automatica"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "S'ha produciu una error d'o servicio d'IP automatica"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "O servicio d'IP automatica ha fallau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "Linia ocupada"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "No bi ha ton de gritada"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "No s'ha puesto establir o portador"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "Ha expirau lo tiempo de solicitut d'a gritada"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "Intento de gritada falliu"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "Ha fallau a inicialización d'o modem"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "S'ha produciu una error en seleccionar o APN especificau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "No se son mirando retz"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "Rechistro d'o ret denegau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "Ha expirau o tiempo de rechistro d'o ret"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "S'ha produciu una error en rechistrar-se con o ret solicitau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "Ha fallau a comprebación d'o PIN"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "Ye posible que falte o firmware d'o dispositivo"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "A connexión ha desapareixiu"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "S'ha asumiu una connexión existent"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "No s'ha trobau lo modem"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "Ha fallau a connexión Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "A tarcheta SIM no ye ficada"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "S'ameneste o PIN d'a SIM"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "S'ameneste o PUK d'a SIM"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "SIM erronia"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "O dispositivo InfiniBand no suporta o modo connectau"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "Ha fallau a dependencia d'a connexión"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "falta o firmware"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "Cable desconnectau"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "No s'ha trigau dengún certificau de autoridat certificadera"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"No usar un certificau de autoridat certificadera (CA) puet dar puesto a "
-"connexions inseguras a retz inalambricos promiscuos.  Quiers trigar un "
-"certificau d'autoridat certificadera?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "Inorar"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "Triga un certificau d'autoridat certificadera"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "Claus privadas DER, PEM, u PKCS#12 (*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Certificaus DER u PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-msgid "Choose a PAC file"
-msgstr "Trigar un fichero PAC"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "Fichers PAC (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "Fichero _PAC"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "Autenticación _interna"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "Pro_visión PAC"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "Anonimo"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "Autenticau"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "Totz dos"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identidat anoni_ma"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "Fichero _PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Trigar un fichero PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autenticación _interna"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Pro_visión PAC"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "Nombre d'_usuario"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Clau"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Amostrar a clau"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate"
-msgstr "Triga un certificau d'autoridat certificadera"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "Versión 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "Versión 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "Certificau C_A"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Triga un certificau d'autoridat certificadera"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "S'ameneste autenticación"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versión PEAP"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "_Preguntar ista clau cada vegada"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "As claus privadas sin zifrar son inseguras"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"A clau privada seleccionada no pareix estar protechida por una clau.  Isto "
-"podría permitir que as tuyas credencials de seguranza se comprometesen.  "
-"Selecciona una clau privada protechida por clau.\n"
-"\n"
-"(Puetz protecher a tuya clau privada con una clau con openssl)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-msgid "Choose your personal certificate"
-msgstr "Triga lo tuyo certificau presonal"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-msgid "Choose your private key"
-msgstr "Triga la tuya clau privada"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "I_dentidat"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "Certificau de l'_usuario"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "Clau pri_vada"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "clau de clau pri_vada"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "No al_vertir-me de nuevo"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Dominio"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "No"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "Sí"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "TLS a traviés d'un túnel"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "EAP protechiu (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Au_tenticación"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (Predeterminau)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "Sistema ubierto"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "Clau compartida"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "_Clau"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "_Amostrar a clau"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "In_diz WEP"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Mena"
 
-#: ../panels/notifications/cc-notifications-panel.c:257
-#: ../panels/power/cc-power-panel.c:1840 ../panels/power/cc-power-panel.c:1847
-#: ../panels/privacy/cc-privacy-panel.c:155
-#: ../panels/privacy/cc-privacy-panel.c:222
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "Encendiu"
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Predeterminau)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistema ubierto"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Clau compartida"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Clau"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Amostrar a clau"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "In_diz WEP"
 
 #. This is the per application switch for message tray usage.
-#: ../panels/notifications/edit-dialog.ui.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "Notificacions"
 
 #. This is the setting to configure sounds associated with notifications.
-#: ../panels/notifications/edit-dialog.ui.h:4
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "Alertas de son"
 
-#: ../panels/notifications/edit-dialog.ui.h:5
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Notification Banners"
-msgstr "Banners de notificación"
-
-#. Banners here refers to message tray notifications in the middle of the screen.
-#: ../panels/notifications/edit-dialog.ui.h:7
-msgctxt "notifications"
-msgid "Show Message Content in Banners"
-msgstr "Amostrar o conteniu d'o mensache en os banners"
-
-#: ../panels/notifications/edit-dialog.ui.h:8
-msgctxt "notifications"
-msgid "Lock Screen Notifications"
-msgstr "Notificacions d'a pantalla de bloqueyo"
-
-#: ../panels/notifications/edit-dialog.ui.h:9
-msgctxt "notifications"
-msgid "Show Message Content on Lock Screen"
-msgstr "Amostrar o conteniu d'o mensache en a pantalla de bloqueyo"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "Notificacions"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Amostrar o conteniu d'o mensache en os banners"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notificacions d'a pantalla de bloqueyo"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Amostrar o conteniu d'o mensache en a pantalla de bloqueyo"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Notificacions d'a pantalla de bloqueyo"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controlar qué notificacions s'amuestran"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "notificacions;anuncio;mensache;servilla;emerchent;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Notification Banners"
-msgstr "Banners de notificación"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Lock Screen Notifications"
-msgstr "Notificacions d'a pantalla de bloqueyo"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Autenticación i_nterna"
 
-#. List of applications.
-#: ../panels/notifications/notifications.ui.h:4
-#: ../panels/sound/gvc-mixer-dialog.c:1781
-msgid "Applications"
-msgstr "Aplicacions"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Atra"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:290
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
-msgstr "Adhibir una cuenta"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Adhibir una cuenta en linia"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:329
-msgid "Mail"
-msgstr "Correu"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:335
-msgid "Contacts"
-msgstr "Contactos"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:341
-msgid "Chat"
-msgstr "Chat"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:347
-msgid "Resources"
-msgstr "Recursos"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:422
-msgid "Error logging into the account"
-msgstr "S'ha produciu una error en encetar a sesión en a cuenta"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:492
-msgid "Credentials have expired."
-msgstr "As credencials han caducau."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:496
-msgid "Sign in to enable this account."
-msgstr "Encieta la sesión ta activar ista cuenta."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:501
-msgid "_Sign In"
-msgstr "Encetar a _sesión"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:748
-msgid "Error creating account"
-msgstr "S'ha produciu una error en creyar a cuenta"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:808
-msgid "Error removing account"
-msgstr "S'ha produciu una error en sacar a cuenta"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:844
-msgid "Are you sure you want to remove the account?"
-msgstr "Yes seguro que quiers sacar a cuenta?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:846
-msgid "This will not remove the account on the server."
-msgstr "Isto no sacará la cuenta en o servidor."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:847
-msgid "_Remove"
-msgstr "_Sacar"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Cuentas en linia"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Connectar-se a las tuyas cuentas en linia y decidir ta qué usar-las"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -3690,2353 +2848,1967 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Ret;En linia;Chat;Calandario;Correu;Contacto;"
 "ownCloud;Kerberos;IMAP;SMTP;Pocha;Leyer-loDimpués;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "No bi ha cuentas en linia configuradas"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "Sacar a cuenta"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "Adhibir una cuenta en linia"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"adhibir una cuenta premite que as tuyas aplicacions accedeixcan a "
-"documentos, correu-y, contactos, calandario, chat y mas."
-
-#: ../panels/power/cc-power-panel.c:200
-msgid "Unknown time"
-msgstr "Tiempo desconoixiu"
-
-#: ../panels/power/cc-power-panel.c:206
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i menuto"
 msgstr[1] "%i menutos"
 
-#: ../panels/power/cc-power-panel.c:218
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i hora"
 msgstr[1] "%i horas"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:226
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:227
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hora"
 msgstr[1] "horas"
 
-#: ../panels/power/cc-power-panel.c:228
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "menuto"
 msgstr[1] "menutos"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:247
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s dica que se cargue de raso"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 menutos"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:254
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Alvertencia: quedan %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 menutos"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:259
-#, c-format
-msgid "%s remaining"
-msgstr "%s restant"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 menutos"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:264 ../panels/power/cc-power-panel.c:292
-msgid "Fully charged"
-msgstr "Cargada de raso"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 menutos"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:268 ../panels/power/cc-power-panel.c:296
-msgid "Empty"
-msgstr "Vueda"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 menutos"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:283
-msgid "Charging"
-msgstr "Cargando"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hora"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:288
-msgid "Discharging"
-msgstr "Descargando"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 menutos"
 
-#: ../panels/power/cc-power-panel.c:411
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Prencipal"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 menutos"
 
-#: ../panels/power/cc-power-panel.c:413
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Adicional"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 menutos"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:484
-msgid "Wireless mouse"
-msgstr "Ratet inalambrico"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 horas"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:487
-msgid "Wireless keyboard"
-msgstr "Teclau inalambrico"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:490
-msgid "Uninterruptible power supply"
-msgstr "Fuent d'alimentación no interrumpible"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:493
-msgid "Personal digital assistant"
-msgstr "Asistent dichital presonal"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:496
-msgid "Cellphone"
-msgstr "Telefono mobil"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:499
-msgid "Media player"
-msgstr "Reproductor multimeya"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:502
-msgid "Tablet"
-msgstr "Tableta"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:505
-msgid "Computer"
-msgstr "Ordinador"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:508 ../panels/power/cc-power-panel.c:748
-#: ../panels/power/cc-power-panel.c:2095
+#: panels/power/cc-power-panel.ui:58
 msgid "Battery"
 msgstr "Bateria"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Cargando"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:569
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Alvertencia"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:574
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Baixa"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:579
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Buena"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:584
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Cargada de raso"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:588
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Vueda"
-
-#: ../panels/power/cc-power-panel.c:746
-msgid "Batteries"
-msgstr "Baterías"
-
-#: ../panels/power/cc-power-panel.c:1167
-msgid "When _idle"
-msgstr "Quan siga _inactivo"
-
-#: ../panels/power/cc-power-panel.c:1547
-msgid "Power Saving"
-msgstr "Cabido d'enerchía"
-
-#: ../panels/power/cc-power-panel.c:1582
-msgid "_Screen brightness"
-msgstr "_Brilo d'a pantalla"
-
-#: ../panels/power/cc-power-panel.c:1601
-#| msgid "Automatic Routes"
-msgid "Automatic brightness"
-msgstr "Brilo automatico"
-
-#: ../panels/power/cc-power-panel.c:1621
-msgid "_Keyboard brightness"
-msgstr "Brilo d'o _teclau"
-
-#: ../panels/power/cc-power-panel.c:1631
-msgid "_Dim screen when inactive"
-msgstr "_Enfoscar a pantalla quan siga inactiva"
-
-#: ../panels/power/cc-power-panel.c:1656
-msgid "_Blank screen"
-msgstr "_Amortar a pantalla"
-
-#: ../panels/power/cc-power-panel.c:1693
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: ../panels/power/cc-power-panel.c:1698
-msgid "Wireless devices require extra power"
-msgstr "Os dispositivos inalámbricos requieren enerchía adicional"
-
-#: ../panels/power/cc-power-panel.c:1723
-msgid "_Mobile broadband"
-msgstr "Banda ampla _mobil"
-
-#: ../panels/power/cc-power-panel.c:1728
-msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
-msgstr ""
-"Os dispositivos de banda ampla mobil (3G, 4G, WiMax, etc.) requieren "
-"enerchía adicional"
-
-#: ../panels/power/cc-power-panel.c:1780
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: ../panels/power/cc-power-panel.c:1836
-msgid "When on battery power"
-msgstr "En modo batería"
-
-#: ../panels/power/cc-power-panel.c:1838
-msgid "When plugged in"
-msgstr "Quan ye connectau a o ret"
-
-#: ../panels/power/cc-power-panel.c:1955
-msgid "Suspend & Power Off"
-msgstr "Suspender y amortar"
-
-#: ../panels/power/cc-power-panel.c:1995
-msgid "_Automatic suspend"
-msgstr "Suspender _automaticament"
-
-#: ../panels/power/cc-power-panel.c:2149
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
 msgid "Devices"
 msgstr "Dispositivos"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Amortar"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Cabido d'enerchía"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Brilo automatico"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Pantalla"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Lecto_r de pantalla"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Informar d'un problema _automaticament"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Suspender automaticament"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Botón inferior"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Suspender automaticament"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Enchufau"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Usando a _batería"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Retardo"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Enerchía"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+#: panels/power/gnome-power-panel.desktop.in.in:4
 msgid "View your battery status and change power saving settings"
 msgstr ""
 "Veyer o estau d'a batería y cambiar a configuración d'estalbio d'enerchía"
 
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "Enerchía;Adormir;Suspender;Hibernar;Batería;Brilo;Amortar;Monitor;DPMS;"
 "inactivo;"
 
-#: ../panels/power/power.ui.h:3
-msgid "45 minutes"
-msgstr "45 menutos"
-
-#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
-msgid "1 hour"
-msgstr "1 hora"
-
-#: ../panels/power/power.ui.h:5
-msgid "80 minutes"
-msgstr "80 menutos"
-
-#: ../panels/power/power.ui.h:6
-msgid "90 minutes"
-msgstr "90 menutos"
-
-#: ../panels/power/power.ui.h:7
-msgid "100 minutes"
-msgstr "100 menutos"
-
-#: ../panels/power/power.ui.h:8
-msgid "2 hours"
-msgstr "2 horas"
-
-#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 menuto"
-
-#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 menutos"
-
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 menutos"
-
-#: ../panels/power/power.ui.h:12
-msgid "4 minutes"
-msgstr "4 menutos"
-
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 menutos"
-
-#: ../panels/power/power.ui.h:14
-msgid "8 minutes"
-msgstr "8 menutos"
-
-#: ../panels/power/power.ui.h:15
-msgid "10 minutes"
-msgstr "10 menutos"
-
-#: ../panels/power/power.ui.h:16
-msgid "12 minutes"
-msgstr "12 menutos"
-
-#: ../panels/power/power.ui.h:18
-msgid "Automatic Suspend"
-msgstr "Suspender automaticament"
-
-#: ../panels/power/power.ui.h:19
-msgid "_Plugged In"
-msgstr "_Enchufau"
-
-#: ../panels/power/power.ui.h:20
-msgid "On _Battery Power"
-msgstr "Usando a _batería"
-
-#: ../panels/power/power.ui.h:21
-msgid "Delay"
-msgstr "Retardo"
-
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "Autenticar-se"
-
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "Clau"
-
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "Se requier autenticación"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:588
-msgid "Low on toner"
-msgstr "Tóner baixo"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Out of toner"
-msgstr "Sin tóner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:593
-msgid "Low on developer"
-msgstr "Libel de revelador baixo"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:596
-msgid "Out of developer"
-msgstr "Sin revelador"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Low on a marker supply"
-msgstr "Marcador baixo"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Out of a marker supply"
-msgstr "Sin marcador"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Open cover"
-msgstr "Ubrir a cubierta"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open door"
-msgstr "Ubrir a puerta"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Low on paper"
-msgstr "Libel de paper baixo"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Out of paper"
-msgstr "Sin paper"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:610
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Desconnectada"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:612
-#: ../panels/printers/cc-printers-panel.c:803
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Aturada"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:614
-msgid "Waste receptacle almost full"
-msgstr "Recipient de residuos quasi pleno"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle full"
-msgstr "Recipient de residuos pleno"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "The optical photo conductor is near end of life"
-msgstr "O conductor optico ye amán d'a final d'a vida d'ell"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is no longer functioning"
-msgstr "O conductor optico ya no funciona"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:730
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "Configurando"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:789
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Parada"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:794
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "No acceptar treballos"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:799
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Procesando"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:919
-msgid "Toner Level"
-msgstr "Libel d'o tóner"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Ink Level"
-msgstr "Libel de tinta"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Supply Level"
-msgstr "Libel d'o suministro"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:943
-msgctxt "printer state"
-msgid "Installing"
-msgstr "Instalando"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1119
-msgid "No printers available"
-msgstr "No bi ha impresoras disponibles"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1429
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u activo"
-msgstr[1] "%u activos"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1770
-msgid "Failed to add new printer."
-msgstr "S'ha produciu una error en adhibir una impresora nueva."
-
-#: ../panels/printers/cc-printers-panel.c:1937
-msgid "Select PPD File"
-msgstr "Seleccionar un fichero PPD"
-
-#: ../panels/printers/cc-printers-panel.c:1946
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Fichers de descripción d'impresora PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD."
-"gz, *.PPD.GZ)"
-
-#: ../panels/printers/cc-printers-panel.c:2253
-msgid "No suitable driver found"
-msgstr "No s'ha trobau dengún controlador adequau"
-
-#: ../panels/printers/cc-printers-panel.c:2324
-msgid "Searching for preferred drivers…"
-msgstr "Buscando os controladors preferius…"
-
-#: ../panels/printers/cc-printers-panel.c:2345
-msgid "Select from database…"
-msgstr "Seleccionar dende a base de datos…"
-
-#: ../panels/printers/cc-printers-panel.c:2354
-msgid "Provide PPD File…"
-msgstr "Proporcionar un fichero PPD…"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2505
-#: ../panels/printers/cc-printers-panel.c:2528
-msgid "Test page"
-msgstr "Pachina de preba"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2942
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "No s'ha puesto cargar a IU: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "Impresoras"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Adhibir impresoras, veyer os treballos d'a impresora y decidir quál quiers "
 "imprentar"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Impresora;Coda;Imprentar;Paper;Tinta;Tóner;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "Treballos activos"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "Zarrar"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "Reprener a impresión"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "Pausar a impresión"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "Cancelar o treballo d'impresión"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "Adhibir una impresora nueva"
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr "Adhibir a impresora"
 
 #. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "A_uthenticate"
-msgstr "A_utenticar-se"
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "No s'ha detectau garra impresora."
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "No s'han trobau imachens"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Introduzca una adreza de ret u busque una impresora"
 
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "Cargando as opcions…"
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Se requier autenticación"
 
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "Seleccionar o controlador d'a impresora"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "Cargando as bases de datos de controladors…"
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-msgid "JetDirect Printer"
-msgstr "Impresora JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-msgid "LPD Printer"
-msgstr "Impresora LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "Una cara"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "Marguin larga (estandar)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "Marguin curta (chirar)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "Vertical"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "Apaisau"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "Apaisau invertiu"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "Vertical invertiu"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "Pendient"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "Reteniu"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "Procesando"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Aturau"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Cancelau"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Abortau"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Completau"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "Titol d'o treballo"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "Estau d'o treballo"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "Hora"
-
-#: ../panels/printers/pp-jobs-dialog.c:451
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s treballos activos"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1620
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1625
-msgid "Serial Port"
-msgstr "Puerto serie"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1632
-msgid "Parallel Port"
-msgstr "Puerto paralelo"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1688
-#, c-format
-msgid "Location: %s"
-msgstr "Ubicación: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1693
-#, c-format
-msgid "Address: %s"
-msgstr "Adreza: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1717
-msgid "Server requires authentication"
-msgstr "O servidor amenista d'autenticación"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "Dos caras"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "Mena de paper"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "Fuent de paper"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "Servilla de salida"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "Prefiltrau GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:533
-msgid "Pages per side"
-msgstr "Pachinas por cara"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:545
-msgid "Two-sided"
-msgstr "Dos caras"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:557
-msgid "Orientation"
-msgstr "Orientación"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Cheneral"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Configuración de pachina"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opcions instalables"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Treballo"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Calidat d'a imachen"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Color"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Rematando"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:675
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Abanzau"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "Seleccionar automaticament"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "Impresora predeterminada"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "Nomás empotrar as fuents GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "Convertir ta PS de libel 1"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "Convertir ta PS de libel 2"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "Sin prefiltrau"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "Fabricant"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "Controlador"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Introduz o tuyo nombre d'usuario y a tuya clau ta veyer as impresoras "
 "disponibles en %s."
 
-#: ../panels/printers/printers.ui.h:1
-msgid "Add Printer"
-msgstr "Adhibir a impresora"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nombre d'usuario"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "Sacar a impresora"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "Suministro"
-
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Ubicación"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default printer"
-msgstr "Impresora pre_determinada"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Controlador"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "Treballos"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Buscando os controladors preferius…"
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "Amostrar os _treballos"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "Mirar por una ciudat"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "Seleccionar dende a base de datos…"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Proporcionar un fichero PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Seleccionar o controlador d'a impresora"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "Cargando as bases de datos de controladors…"
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Seleccionar"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "O servidor amenista d'autenticación"
+msgstr[1] "O servidor amenista d'autenticación"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "_Dominio"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utenticar-se"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Autenticar-se"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s treballos activos"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Pachina de preba"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Opcions d'inicio de sesión"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Impresora predeterminada"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Impresora predeterminada"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "Cancelar o treballo d'impresión"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Sacar a impresora"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Treballos activos"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Modelo"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "Etiqueta"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Libel de tinta"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "Seye establindo o nuevo controlador…"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "Pachina 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "Impren_tar a pachina de preba"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "_Opcions"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "Reiniciar-ne agora"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "Adhibir una impresora nueva"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Adhibir a impresora"
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Impresoras"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "O servicio d'o sistema d'impresión\n"
 "pareix no estar disponible."
 
-#: ../panels/privacy/cc-privacy-panel.c:352 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "Bloqueyo de pantalla"
-
-#: ../panels/privacy/cc-privacy-panel.c:462 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "Uso y historico"
-
-#: ../panels/privacy/cc-privacy-panel.c:587
-msgid "Empty all items from Trash?"
-msgstr "Vuedar totz os elementos d'a papelera?"
-
-#: ../panels/privacy/cc-privacy-panel.c:588
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Totz os elementos d'a papelera serán esborraus permanentment."
-
-#: ../panels/privacy/cc-privacy-panel.c:589 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "_Vuedar a papelera"
-
-#: ../panels/privacy/cc-privacy-panel.c:612
-msgid "Delete all the temporary files?"
-msgstr "Esborrar totz os ficheros temporals?"
-
-#: ../panels/privacy/cc-privacy-panel.c:613
-msgid "All the temporary files will be permanently deleted."
-msgstr "Totz os fichers temporals serán esborraus permanentment."
-
-#: ../panels/privacy/cc-privacy-panel.c:614 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "_Limpiar os fichers temporals"
-
-#: ../panels/privacy/cc-privacy-panel.c:636 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "Vuedar a papelera y os fichers temporals"
-
-#: ../panels/privacy/cc-privacy-panel.c:676 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr "Emplego d'o software"
-
-#: ../panels/privacy/cc-privacy-panel.c:717 ../panels/privacy/privacy.ui.h:44
-msgid "Problem Reporting"
-msgstr "Informar d'una error"
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: ../panels/privacy/cc-privacy-panel.c:731
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-"Ninviar informes de problemas tecnicos aduya a amillorar %s. Los informes se "
-"ninvian anonimament y no contienen datos personals."
-
-#: ../panels/privacy/cc-privacy-panel.c:743 ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "Politica deprivacidat"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "Privacidat"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-"Protecher a tuya información presonal y controlar qué pueden veyer atros"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"pantalla;bloqueyo;dianostico;error;privau;recient;temporal;tmp;indiz;nombre;"
-"ret;identidat;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "S'amorta la pantalla"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 segundos"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 diya"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 diyas"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 diyas"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 diyas"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 diyas"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 diyas"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 diyas"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 diyas"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 diyas"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "Perén"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"Remerar o tuyo historico fa que siga mas sencillo buscar as cosetas de "
-"nuevo. Istos elementos nunca no se comparten en o ret."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "Usaus _recientment"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "Remerar l'_historico"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "Limpiar l'historico r_ecient"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "A pantalla de bloqueyo proteche a tuya privacidat quan yes ausent."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "_Bloqueyo de pantalla automatico"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "B_loqueyar a pantalla dimpués de"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "Amostrar AS _notificacions"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"Limpiar automaticament os fichers temporals y d'a Papelera ta aduyar-te a "
-"mantener o tuyo equipo libre d'información sensible."
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "Vuedar automa_ticament a papelera"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "Li_mpiar os fichers temporals automaticament"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "Limpiar _dimpués de"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our software."
-"\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"Ninviando-nos información arredol de qué software fas servir nos aduya "
-"furnir-te recomendacions con mas precisión. Tamién nos aduya a amillorar o "
-"nuestro software.\n"
-"\n"
-"Toda la información que replegamos ye feita anonyma, y nunca no "
-"compartiremos os tuyos datos con tercers."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "_Ninviar estatisticas d'emplego d'o software"
-
-#: ../panels/privacy/privacy.ui.h:42
-msgid "_Location Services"
-msgstr "Servicios d'_ubicación"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "S'usa tadeterminar atuya localización cheografica"
-
-#: ../panels/privacy/privacy.ui.h:45
-msgid "_Automatic Problem Reporting"
-msgstr "Informar d'un problema _automaticament"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrico"
-
-#: ../panels/region/cc-format-chooser.c:286
-msgid "No regions found"
-msgstr "No s'han trobau rechions"
-
-#: ../panels/region/cc-input-chooser.c:180
-msgid "No input sources found"
-msgstr "No s'han trobau fuents de dentrada"
-
-#: ../panels/region/cc-input-chooser.c:1085
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Atra"
-
-#: ../panels/region/cc-region-panel.c:247
-#: ../panels/user-accounts/um-user-panel.c:1071
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "Cal reiniciar a sesión ta que s'apliquen os cambeos"
-
-#: ../panels/region/cc-region-panel.c:251
-#: ../panels/user-accounts/um-user-panel.c:1075
-msgid "Restart Now"
-msgstr "Reiniciar-ne agora"
-
-#: ../panels/region/cc-region-panel.c:876
-msgid "No input source selected"
-msgstr "No s'ha seleccionau garra fuent de dentrada"
-
-#: ../panels/region/cc-region-panel.c:1796
-msgid "Login Screen"
-msgstr "Pantalla d'inicio de sesión"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formatos"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Buscar ubicacions"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Anvista previa"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Calendatas"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "Horas"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Calendata y hora"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Numeros"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Mesura"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Paper"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "A mía cuenta"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Idioma"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "Pantalla d'inicio de sesión"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Rechión y idioma"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr ""
 "Selecciona o tuyo idioma, formatos, distribucions de teclau y fuents de "
 "dentrada"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Distribución;Teclau;Dentrada;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "Adhibir una fuent de dentrada"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Seleccionar cómo s'han de maniar os suportes"
 
-#: ../panels/region/input-chooser.ui.h:4
-msgid "Input methods can't be used on the login screen"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD de _son"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD de video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Reproductor de _mosica"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Atros suportes…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nunca no preguntar ni encetar programas en introducir suportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Seleccionar cómo s'han de maniar atros suportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Acción:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Mena:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Suportes extraíbles"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Suportes extraíbles"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"Os metodos de dentrada no se pueden usar en a pantalla d'inicio de sesión"
+"dispositivo;sistema;información;memoria;procesador;versión;predeterminau;"
+"aplicación;alternativo;preferiu;cd;dvd;usb;son;video;disco;extraíble;meyo;"
+"autoexecutar;"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "Opcions d'as fuents de dentrada"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Bloqueyo de pantalla"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Use the _same source for all windows"
-msgstr "Usar a _mesma fuent ta todas as finestras"
-
-#: ../panels/region/input-options.ui.h:4
-msgid "Allow _different sources for each window"
-msgstr "Premitir _diferents fuents ta cada finestra"
-
-#: ../panels/region/input-options.ui.h:5
-msgid "Keyboard Shortcuts"
-msgstr "Alcorces de teclau"
-
-#: ../panels/region/input-options.ui.h:6
-msgid "Switch to previous source"
-msgstr "Cambiar a la fuent anterior"
-
-#: ../panels/region/input-options.ui.h:7
-msgid "Super+Shift+Space"
-msgstr "Súper+Mayús+Espacio"
-
-#: ../panels/region/input-options.ui.h:8
-msgid "Switch to next source"
-msgstr "Cambiar a la fuent siguient"
-
-#: ../panels/region/input-options.ui.h:9
-msgid "Super+Space"
-msgstr "Super+Space"
-
-#: ../panels/region/input-options.ui.h:10
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "Puetz cambiar istos alcorces en a configuración d'o teclau"
-
-#: ../panels/region/input-options.ui.h:11
-msgid "Alternative switch to next source"
-msgstr "Cambeo alternativo a la fuent siguient"
-
-#: ../panels/region/input-options.ui.h:12
-msgid "Left+Right Alt"
-msgstr "Cucha + Alt dreita"
-
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "Anglés (Reino Uniu)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "Reino Uniu"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "Opcions"
-
-#: ../panels/region/region.ui.h:7
-msgid "Add input source"
-msgstr "Adhibir fuent de dentrada"
-
-#: ../panels/region/region.ui.h:8
-msgid "Remove input source"
-msgstr "Sacar fuent de dentrada"
-
-#: ../panels/region/region.ui.h:9
-msgid "Move input source up"
-msgstr "Puyar a fuent de dentrada"
-
-#: ../panels/region/region.ui.h:10
-msgid "Move input source down"
-msgstr "Baixar a fuent de dentrada"
-
-#: ../panels/region/region.ui.h:11
-msgid "Configure input source"
-msgstr "Configurar fuent de dentrada"
-
-#: ../panels/region/region.ui.h:12
-msgid "Show input source keyboard layout"
-msgstr "Amostrar a distribución d'o teclau d'a fuent de dentrada"
-
-#: ../panels/region/region.ui.h:13
-msgid "Login settings are used by all users when logging into the system"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
 msgstr ""
-"A configuración d'inicio de sesión la usan totz os usuarios quan encietan a "
-"sesión en o sistema"
 
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "_Amortar a pantalla"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Bloqueyo de pantalla automatico"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Bloqueyo de pantalla automatico"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Amostrar AS _notificacions"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Blocar a pantalla"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Privacidat"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantalla"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Compartición d'a pantalla"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Buscar ubicacions"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
 msgid "Places"
 msgstr "Puestos"
 
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
 msgid "Bookmarks"
 msgstr "Marcapachinas"
 
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Atra"
 
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "Seleccionar una ubicación"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Ubicación"
 
-#: ../panels/search/cc-search-locations-dialog.c:682
-msgid "_OK"
-msgstr "_Acceptar"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Aplicacions"
 
-#: ../panels/search/cc-search-panel.c:177
-msgid "No applications found"
-msgstr "No s'han trobau aplicacions"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "Buscar"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Buscar ubicacions"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 "Controlar qué aplicacions amuestran resultaus de busca en l'anvista de "
 "actividatz"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "buscar;busca;indiz;amagar;privacidat;resultaus;"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr "Buscar ubicacions"
-
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "Puyar"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "Baixar"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Encendiu"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Amortau"
-
-#: ../panels/sharing/cc-sharing-panel.c:304
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Activau"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-msgctxt "service is active"
-msgid "Active"
-msgstr "activo"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "Triga una carpeta"
-
-#: ../panels/sharing/cc-sharing-panel.c:917
-msgid "Copy"
-msgstr "Copiar"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-msgid "Sharing"
-msgstr "Compartir"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr "Controla qué quiers compartir con atros"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
-msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
-msgstr ""
-"compartir;compartición;ssh;equipo;remoto;escritorio:bluetooth;obex;multimeya;"
-"son:video;imachens;fotos;cintas;servidor;renderizau;"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "Activar u desactivar l'inicio de sesión remota"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr ""
-"Se requier autenticación ta activar u desactivar l'inicio de sesión remota"
-
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:303
-msgid "No networks selected for sharing"
-msgstr "No bi ha retz seleccionaus ta compartir"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Retz"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "Compartición por Bluetooth"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Compartir"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-"A compartición por Bluetooth te permite compartir fichers con atros "
-"dispositivos con o Bluetooth activau"
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "Recibir nomás dende dispositivos de confianza"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "Alzar os fichers recibius en a carpeta de descargas"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "Nombre de l'ordinador"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "Compartición de fichers presonals"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "Compartición d'a pantalla"
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
 msgstr "Compartición multimeya"
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "Encieto de sesión remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Compartir"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "Solicitar a clau"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "Encieto de sesión remoto"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "S'han desactivau qualques servicios porque no bi ha acceso a lo ret."
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Encieto de sesión remoto"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
-"A compartición de fichers presonals te permite compartir a tuya carpeta "
-"Publica con atros en o tuyo ret actual usando: <a href=\"dav://%s\">dav://"
-"%s</a>"
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr "Solicitar a clau"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Activar u desactivar l'inicio de sesión remota"
 
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"Premitir a os usuarios remotos connectar-se usando o comando de shell "
-"segura:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a "
-"href=\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"Premitir a os usuarios remotos veyer u controlar a tuya pantalla connectando-"
-"se ta: <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "Activar o control remoto"
 
-#: ../panels/sharing/sharing.ui.h:21
-msgid "Password:"
-msgstr "Clau:"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "Amostrar a clau"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "No connectau"
 
-#: ../panels/sharing/sharing.ui.h:23
-msgid "Access Options"
-msgstr "Opcions d'acceso"
-
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "As nuevas connexions deben preguntar por l'acceso"
-
-#: ../panels/sharing/sharing.ui.h:25
-msgid "Require a password"
-msgstr "Solicitar a clau"
-
-#: ../panels/sharing/sharing.ui.h:26
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
-"Media sharing allows you to share music, photos and videos over the network."
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copiar"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Eliminar l'adreza"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Au_tenticación"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Nombre d'usuario"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Rechistrando as ditaladas"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Compartición multimeya"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+#, fuzzy
+msgid "Share music, photos and videos over the network."
 msgstr ""
 "A compartición de meyos le permite compartir mosica, fotos y videos por meyo "
 "d'o ret."
 
-#: ../panels/sharing/sharing.ui.h:27
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Carpetas"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "Son"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controla qué quiers compartir con atros"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "Cambiar o volumen de dentrada y salida de son y as alertas sonoras"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 msgstr ""
-"tarcheta;microfono;volumen;esvaneixer;balanz;bluetooth;cascos;auriculars;son;"
+"compartir;compartición;ssh;equipo;remoto;escritorio:bluetooth;obex;multimeya;"
+"son:video;imachens;fotos;cintas;servidor;renderizau;"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "Ladriu"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Activar u desactivar l'inicio de sesión remota"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "Goteyo"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Se requier autenticación ta activar u desactivar l'inicio de sesión remota"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "Vaso"
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "Sonar"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Compartir"
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "Cucho"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "Dreito"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Balanz:"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Esvaneiximiento:"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Trasero"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Frontal"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Minimo"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Maximo"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "_Balanz:"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "_Esvaneiximiento:"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "_Subwoofer:"
-
-#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:615
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Sin amplificar"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
-#: ../panels/sound/gvc-mixer-dialog.c:515
-msgid "_Profile:"
-msgstr "_Perfil:"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u salida"
-msgstr[1] "%u salidas"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u dentrada"
-msgstr[1] "%u dentradas"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "Sons d'o sistema"
 
-#: ../panels/sound/gvc-mixer-dialog.c:251
-msgid "_Test Speakers"
-msgstr "_Prebar os altavoces"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Volumen de _alerta:"
 
-#: ../panels/sound/gvc-mixer-dialog.c:420
-msgid "Peak detect"
-msgstr "Detección de picos"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Silenciar"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1493
-#: ../panels/sound/gvc-sound-theme-chooser.c:564
-msgid "Name"
-msgstr "Nombre"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1512
-msgid "Device"
-msgstr "Dispositivo"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1575
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "Preba d'altavoces ta %s"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1631
-msgid "_Output volume:"
-msgstr "Volumen de sali_da:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1645
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Salida"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1650
-msgid "C_hoose a device for sound output:"
-msgstr "_Trigar un dispositivo ta la salida de son:"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Volumen de sali_da:"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1672
-msgid "Settings for the selected device:"
-msgstr "Configuración ta lo dispositivo seleccionau:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1683
-msgid "Input"
-msgstr "Dentrada"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1690
-msgid "_Input volume:"
-msgstr "Volumen de _dentrada:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "Input level:"
-msgstr "Libel de dentrada:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1737
-msgid "C_hoose a device for sound input:"
-msgstr "_Trigar un dispositivo ta la dentrada de son:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1761
-msgid "Sound Effects"
-msgstr "Efectos de son"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1768
-msgid "_Alert volume:"
-msgstr "Volumen de _alerta:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1785
-msgid "No application is currently playing or recording audio."
-msgstr "Actualment garra aplicación ye reproducindo u gravando son."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "Integrau"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "Preferencias de son"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "Comprebando o son d'evento"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:554
-msgid "Default"
-msgstr "Predeterminau"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:555
-msgid "From theme"
-msgstr "D'o tema"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:740
-msgid "C_hoose an alert sound:"
-msgstr "_Trigar un son d'alerta:"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "Aturar"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Prebar"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "URL de _configuración"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "Presonalizau"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Dentrada"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "Fer mas sencillo de veyer, escuitar, escribir y apuntar y pretar"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Libel de dentrada:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Puyar o volumen"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Volumen de _alerta:"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Son"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Cambiar o volumen de dentrada y salida de son y as alertas sonoras"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
-"Teclau;Ratet;a11y;Accesibilidat;Contraste;Zoom;Pantalla;Lector;texto;fuent;"
-"Grandaria;AccessX;Persistents;Teclas;Lentas;Refuso;Ratet;"
+"tarcheta;microfono;volumen;esvaneixer;balanz;bluetooth;cascos;auriculars;son;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "_Amostrar siempre o menú d'acceso universal"
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "Visión"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Notificacions"
 
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "_Alto contraste"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Nombre:"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "Texto _gran"
-
-#: ../panels/universal-access/uap.ui.h:5
-msgid "_Zoom"
-msgstr "_Zoom"
-
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr "Lecto_r de pantalla"
-
-#: ../panels/universal-access/uap.ui.h:8
-msgid "_Sound Keys"
-msgstr "Teclas de_son"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "Audición"
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
-msgstr "Alertas _visuals"
-
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Screen _Keyboard"
-msgstr "_Teclau en pantalla"
-
-#: ../panels/universal-access/uap.ui.h:13
-msgid "_Typing Assist (AccessX)"
-msgstr "Asis_tent d'Escritura (AccessX)"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Pointing & Clicking"
-msgstr "Apuntar y pretar"
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "_Mouse Keys"
-msgstr "_Teclas d'o ratet"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "Asistent de _clic"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "Lector de pantalla"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "O lector de pantalla leye o texto amostrau en que vas movendo lo foco."
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Screen Reader"
-msgstr "_Lector de pantalla"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Sound Keys"
-msgstr "Teclas de son"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "Chuflar quan o Bloq. Num. u lo Bloq. Mayús. sigan enchegaus."
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "Alertas visuals"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "_Prebar os destellos"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "Usar una indicación visual quan ocurra una alerta de son."
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Flash the _window title"
-msgstr "Destello d'a barra de titol d'a _finestra"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Flash the entire _screen"
-msgstr "De_stello d'a pantalla completa"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Typing Assist"
-msgstr "Asistent d'Escritura"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "_Sticky Keys"
-msgstr "Tecla_s persistents"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"Tracta una seqüencia de teclas modificaderas como una combinación de teclas"
 
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "_Desactivar-ne si se pretan dos teclas a la vegada"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifier key is pressed"
-msgstr "Pitar en pretar una tecla _modificadera"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "_Connexión automatica"
 
-#: ../panels/universal-access/uap.ui.h:32
-msgid "S_low Keys"
-msgstr "Teclas _lentas"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Sacar o dispositivo"
 
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "Introduz un retardo en pretar una tecla y quan ista s'accepta"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "R_etardo d'acceptación:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "No s'ha puesto connectar a lo dominio %s: %s"
 
-#: ../panels/universal-access/uap.ui.h:35
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Curto"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Acceso universal"
 
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "Retardo d'as teclas lentas en escribir"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:37
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Luengo"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Adhibir un dispositivo"
 
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Beep when a key is pr_essed"
-msgstr "Chuflar _en que se preta una tecla"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Beep when a key is _accepted"
-msgstr "Chuflar en que s'_accepta una tecla"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "Chuflar en _refusar una tecla"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:41
-msgid "_Bounce Keys"
-msgstr "_Refuso de teclas"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "Inorar as pulsacions duplicadas rapidas"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Parpagueo d'o cursor"
 
-#: ../panels/universal-access/uap.ui.h:43
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Curto"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "O cursor pa_rpadia en os campos de texto"
 
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "Retardo de pulsación d'o refuso de teclas"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "Ve_locidad:"
 
-#: ../panels/universal-access/uap.ui.h:45
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Luengo"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Velocidat de parpagueo d'o cursor"
 
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Enable by Keyboard"
-msgstr "Activar-ne por t_eclau"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Velocidat de parpagueo d'o cursor"
 
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "Activar as caracteristicas d'accesibilidat usando o teclau"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "Asistent de clic"
 
-#: ../panels/universal-access/uap.ui.h:49
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "Clic secundario _simulau"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "Disparar un clic secundario en mantener pretau o botón primario"
 
-#: ../panels/universal-access/uap.ui.h:51
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "R_etardo d'acceptación:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Curto"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "Retardo d'o clic secundario"
 
-#: ../panels/universal-access/uap.ui.h:53
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Luengo"
 
-#: ../panels/universal-access/uap.ui.h:54
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "Clic en pasar p_or dencima"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "Disparar un clic en posicionar o puntero"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "R_etardo:"
 
-#: ../panels/universal-access/uap.ui.h:57
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Curto"
 
-#: ../panels/universal-access/uap.ui.h:58
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Luengo"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "Branquil de _movimiento:"
 
-#: ../panels/universal-access/uap.ui.h:60
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Chicot"
 
-#: ../panels/universal-access/uap.ui.h:61
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Gran"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetición de teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "As pulsacions de teclas se _repiten quan a tecla se mantién preta"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Velocidat de repetición d'as teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocidat de repetición d'as teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Asistent d'Escritura"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Tecla_s persistents"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Tracta una seqüencia de teclas modificaderas como una combinación de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desactivar-ne si se pretan dos teclas a la vegada"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pitar en pretar una tecla _modificadera"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Teclas _lentas"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introduz un retardo en pretar una tecla y quan ista s'accepta"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
-msgstr "Curta"
+msgstr "Curto"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ de pantalla"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Retardo d'as teclas lentas en escribir"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ pantalla"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ de pantalla"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
-msgstr "Larga"
+msgstr "Luengo"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Chuflar _en que se preta una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Chuflar en que s'_accepta una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Chuflar en _refusar una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Refuso de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Inorar as pulsacions duplicadas rapidas"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Retardo de pulsación d'o refuso de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Luengo"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Activar-ne por t_eclau"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Activar as caracteristicas d'accesibilidat usando o teclau"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Amostrar siempre o menú d'acceso universal"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Visión"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Alto contraste"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Texto _gran"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Lecto_r de pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "O lector de pantalla leye o texto amostrau en que vas movendo lo foco."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Teclas de_son"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Chuflar quan o Bloq. Num. u lo Bloq. Mayús. sigan enchegaus."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Velocidat de parpagueo d'o cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audición"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Alertas _visuals"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Teclau en pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Repetición de teclas"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Parpagueo d'o cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Asis_tent d'Escritura (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Apuntar y pretar"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Teclas d'o ratet"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Sacar a impresora"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Asistent de _clic"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "_Dople clic"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "_Dople clic"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alertas visuals"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Prebar os destellos"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Usar una indicación visual quan ocurra una alerta de son."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "De_stello d'a pantalla completa"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "De_stello d'a pantalla completa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "Pantalla completa"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "Metat superior"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "Metat inferior"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "Metat cucha"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "Metat dreita"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "Opcions d'ampliación"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "Ampliación"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "Magnificación:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "Siguir a lo cursor d'o ratet"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "Parti d'a pantalla:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "O manificador s'extiende difuera d'a pantalla"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "Mantener centrau o cursor d'o manificador"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "O cursor d'o manificador empenta o conteniu ta l'arredol d'ell"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "O cursor d'o manificador se mueve con o conteniu"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "Posición d'o manificador:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Siguir a lo cursor d'o ratet"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Parti d'a pantalla:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "O manificador s'extiende difuera d'a pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "Mantener centrau o cursor d'o manificador"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "O cursor d'o manificador empenta o conteniu ta l'arredol d'ell"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "O cursor d'o manificador se mueve con o conteniu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Manificador"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "Cruces:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "Solapa lo cursor d'o ratet"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "Grosor:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "Fino"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Recio"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "Longaria:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "Color:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "Cruces:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "Solapa lo cursor d'o ratet"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "Cruces"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efectos de color:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "Blanco sobre negro:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "Brilo:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "Contraste:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "Color"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Denguna"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Completa"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Baixo"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Alto"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Baixo"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Alto"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "Efectos de color:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "Efectos de color"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Estandar"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Fer mas sencillo de veyer, escuitar, escribir y apuntar y pretar"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Teclau;Ratet;a11y;Accesibilidat;Contraste;Zoom;Pantalla;Lector;texto;fuent;"
+"Grandaria;AccessX;Persistents;Teclas;Lentas;Refuso;Ratet;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Historia"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "Historia"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "Limpiar l'historico r_ecient"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "Vuedar a papelera y os fichers temporals"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "Vuedar automa_ticament a papelera"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Li_mpiar os fichers temporals automaticament"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "Vuedar automa_ticament a papelera"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "_Vuedar a papelera"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Limpiar os fichers temporals"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Adhibir un usuario"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
 msgid "Administrator"
 msgstr "Administrador"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Full Name"
-msgstr "Nombre _completo"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "_mena de cuenta"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to set a password when they next login"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
 msgstr "Permitir a l'usuario trigar una clau en o siguient inicio de sesión"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
 msgstr "Establir una clau agora"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "_Verificar"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "Configurando"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Encieto de s_esión corporativo"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Desconnectada"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
 "L'encieto de sesión corporativo permite que se faiga servir una cuenta "
 "d'usuario chestionada de traza centralizada en iste dispositivo."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "_Dominio"
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Seleccionar un fichero PPD"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Encieto de sesión con a _ditalada"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Encieto de sesión con a _ditalada"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "No"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
 msgstr ""
-"Conecta-te ta adhibir\n"
-"cuentas d'encieto de sesión corporativo."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "Encieto de s_esión corporativo"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Quiers eliminar as tuyas ditaladas rechistradas y asinas desactivar l'inicio "
+"de sesión con a ditalada?"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1466
-msgid "Add User"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "No s'ha detectau garra impresora."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Encieto de sesión con a _ditalada"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Encieto de sesión con a _ditalada"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Encieto de sesión con a _ditalada"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Eliminar as ditaladas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Encieto de sesión con a _ditalada"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Pista anterior"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Cambiar a clau"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Cam_biar"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Clau _actual"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Clau _nueva"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Cambiar a clau"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "As claus no coinciden."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "Permitir a l'usuario trigar una clau en o siguient inicio de sesión"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Establir una clau agora"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Usuarios"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Cal reiniciar a sesión ta que s'apliquen os cambeos"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Reiniciar-ne agora"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Zarrar"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Nombre _completo"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Encieto de sesión con a _ditalada"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Encieto de sesión automatico"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "_mena de cuenta"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Administrador"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Sacar una cuenta d'usuario"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Atro dido:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
 msgstr "Adhibir un usuario"
 
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "No s'han trobau imachens"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "Creyar una cuenta d'usuario"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Adhibir u sacar usuarios y cambiar as claus d'ells"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Unir"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Encieto de sesión de l'administrador d'o dominio"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6046,767 +4818,46 @@ msgstr ""
 "formar parti d'un dominio. Pide a l'administrador d'o tuyo\n"
 "sistema que escriba aquí a clau d'o dominio."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "_Nombre de l'administrador"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Clau d'administrador"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "Dedo gordo cucho"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "Dido meyo cucho"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "Dido aniello cucho"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "Dido currín cucho"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "Dido gran dreito"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "Dido meyo dreito"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "Dido aniello dreito"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "Dido currín dreito"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:686
-msgid "Enable Fingerprint Login"
-msgstr "Activar l'inicio de sesión con a ditalada"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "Dido indiz _dreito"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "Dido indiz _cucho"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "_Atro dido:"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"A tuya ditalada s'alzó correctament. Agora habrías de poder encetar a sesión "
-"en usando o tuyo lector de ditaladas."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "Usuarios"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr "Adhibir u sacar usuarios y cambiar as claus d'ells"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "inicio de sesión;nombre;ditalada;avatar;logo;cara;clau;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "Historico d'inicio de sesión"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr "Cambiar a clau"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "Cam_biar"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "_Verificar a Clau nueva"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "Clau _nueva"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "Clau _actual"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "Adhibir una cuenta d'usuario"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "Sacar una cuenta d'usuario"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "Opcions d'inicio de sesión"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "_Encieto de sesión automatico"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "Encieto de sesión con a _ditalada"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "Icono d'usuario"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "_Idioma"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "Zaguer inicio de sesión"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "Chestionar as cuentas d'usuario"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "Se requier autenticación ta cambiar os datos de l'usuario"
 
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "A nueva clau debe estar diferent de l'antiga."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Preba cambiando bellas letras y numeros."
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Preba a cambiar a clau una mica más."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Una clau sin o tuyo nombre d'usuario será mas rebusta."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Preba a privar usar o tuyo nombre en a clau."
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Preba a privar bellas d'as parolas incluidas en a clau."
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Preba a privar as parolas comuns."
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Preba a privar reordenar as parolas existents."
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Preba a emplegar mas numeros."
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Preba a emplegar mas letras mayusclas."
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Preba a emplegar mas letras minusclas."
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Preba a emplegar mas caracters especials, como puntuación."
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-"Preba a fer servir una mezcla de letras, numeros y simbolos depuntuación."
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Preba a privar repetir o mesmo caracter."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Preba a privar repetir a mesma mena de caracter: Cal mezclar letras, numeros "
-"y simbolos de puntuación."
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Preba a privar as seqüencias como 1234 u abc."
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "Preba a adhibir mas letras, numeros y simbolos."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr "Mezcla letras mayusclas y minusclas y emplega un numero u dos."
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-"Clau buena. Preba a adhibir mas letras, numeros y simbolos de puntuación ta "
-"fer-la mas rebusta."
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "Fortidura: Feble"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "Fortidura: Baixa"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "Fortidura: Meya"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "Fortidura: Buena"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "Fortidura: Alta"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "Ha fallau l'autenticación"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "A nueva clau ye masiau curta"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "A nueva clau ye masiau simpla"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "A antiga clau y a nueva son masiau semellants"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "A nueva clau ya s'ha usau recientment."
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "A nueva clau debe contener caracters numericos u especials"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "A nueva clau y l'antiga son a mesma"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "S'ha cambiau a tuya clau dende que t'autentiqués inicialment!"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "A nueva clau no contién suficients caracters diferents"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "Error desconoixida"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "Cal que coincida con l'adreza web d'o tuyo furnidor d'a cuenta."
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "S'ha produciu una error en adhibir a cuenta"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-msgid "Passwords do not match."
-msgstr "As claus no coinciden."
-
-#: ../panels/user-accounts/um-account-dialog.c:733
-#: ../panels/user-accounts/um-account-dialog.c:779
-#: ../panels/user-accounts/um-account-dialog.c:800
-msgid "Failed to register account"
-msgstr "S'ha produciu una error en rechistrar a cuenta"
-
-#: ../panels/user-accounts/um-account-dialog.c:923
-msgid "No supported way to authenticate with this domain"
-msgstr "No bi ha una traza suportada d'autenticar-se con iste dominio"
-
-#: ../panels/user-accounts/um-account-dialog.c:982
-msgid "Failed to join domain"
-msgstr "S'ha produciu una error en unir-se a lo dominio"
-
-#: ../panels/user-accounts/um-account-dialog.c:1043
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"Ixe nombre d'encieto de sesión no ha marchau.\n"
-"Intenta-lo de nuevas."
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"Ixa clau d'encieto de sesión no ha marchau.\n"
-"Intenta-lo de nuevas."
-
-#: ../panels/user-accounts/um-account-dialog.c:1058
-msgid "Failed to log into domain"
-msgstr "S'ha produciu una error en encetar a sesión en o dominio"
-
-#: ../panels/user-accounts/um-account-dialog.c:1116
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "No s'ha puesto trobar o dominio. ¿En ye bien escrito?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:138
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"No te ye premitiu accedir a lo dispositivo. Contacta con l'administrador d'o "
-"tuyo sistema."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:140
-msgid "The device is already in use."
-msgstr "O dispositivo ya ye en uso."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid "An internal error occurred."
-msgstr "S'ha produciu una error interna."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Enabled"
-msgstr "Activada"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr "Eliminar as ditaladas rechistradas?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
-msgstr "_Eliminar as ditaladas"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"Quiers eliminar as tuyas ditaladas rechistradas y asinas desactivar l'inicio "
-"de sesión con a ditalada?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:443
-msgid "Done!"
-msgstr "Feito!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:504
-#: ../panels/user-accounts/um-fingerprint-dialog.c:546
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "No s'ha puesto accedir a lo dispositivo '%s'"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:587
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "No s'ha puesto encetar a captura de dido en o dispositivo '%s'"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:637
-msgid "Could not access any fingerprint readers"
-msgstr "No s'ha puesto accedir a dengún lector de ditaladas"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:638
-msgid "Please contact your system administrator for help."
-msgstr "Contacta con l'administrador d'o tuyo sistema ta obtener aduya."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:720
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"Ta activar l'inicio de sesión con a ditalada debes alzar una d'as tuyas "
-"ditaladas usando lo dispositivo '%s'."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:727
-msgid "Selecting finger"
-msgstr "Seleccionando lo dido"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:728
-msgid "Enrolling fingerprints"
-msgstr "Rechistrando as ditaladas"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "Ista semana"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "A zaguera semana"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e de %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:844
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:848
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "Sesión rematada"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "Sesión encetada"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "Triga unatra clau."
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "Escribe de nuevas a tuya clau actual."
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "No s'ha puesto cambiar a clau"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-msgid "The passwords do not match."
-msgstr "As claus no coinciden."
-
-#: ../panels/user-accounts/um-photo-dialog.c:214
-msgid "Browse for more pictures"
-msgstr "Examinar ta mirar mas imachens"
-
-#: ../panels/user-accounts/um-photo-dialog.c:448
-msgid "Disable image"
-msgstr "Desactivar a imachen"
-
-#: ../panels/user-accounts/um-photo-dialog.c:466
-msgid "Take a photo…"
-msgstr "Prener una foto…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:484
-msgid "Browse for more pictures…"
-msgstr "Examinar ta mirar mas imachens…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:708
-#, c-format
-msgid "Used by %s"
-msgstr "Usada por %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "No se puet unir automaticament ta ista mena de dominio"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "No existe o dominio u no s'ha trobau o reino"
-
-#: ../panels/user-accounts/um-realm-manager.c:815
-#: ../panels/user-accounts/um-realm-manager.c:829
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "No se puet encetar a sesión como %s en o dominio %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:821
-msgid "Invalid password, please try again"
-msgstr "A clau no ye valida, intenta-lo de nuevo"
-
-#: ../panels/user-accounts/um-realm-manager.c:834
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "No s'ha puesto connectar a lo dominio %s: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:240
-msgid "Other Accounts"
-msgstr "Atras cuentas"
-
-#: ../panels/user-accounts/um-user-panel.c:450
-msgid "Failed to delete user"
-msgstr "S'ha produciu una error en eliminar l'usuario"
-
-#: ../panels/user-accounts/um-user-panel.c:510
-#: ../panels/user-accounts/um-user-panel.c:569
-#: ../panels/user-accounts/um-user-panel.c:621
-msgid "Failed to revoke remotely managed user"
-msgstr "S'ha produciu una error en eliminar l'usuario maniau remotament"
-
-#: ../panels/user-accounts/um-user-panel.c:677
-msgid "You cannot delete your own account."
-msgstr "No puetz eliminar a tuya propia cuenta."
-
-#: ../panels/user-accounts/um-user-panel.c:686
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s agún no ye rechistrau en o sistema"
-
-#: ../panels/user-accounts/um-user-panel.c:690
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Eliminar un usuario entre que ye rechistrau en o sistema puede deixar lo "
-"sistema en un estau inconsistent."
-
-#: ../panels/user-accounts/um-user-panel.c:699
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "Quiers mantener os fichers de %s?"
-
-#: ../panels/user-accounts/um-user-panel.c:703
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Ye posible mantener a carpeta presonal, a ringlera d'o correu y os fichers "
-"temporals en eliminar una cuenta d'usuario."
-
-#: ../panels/user-accounts/um-user-panel.c:706
-msgid "_Delete Files"
-msgstr "_Eliminar os fichers"
-
-#: ../panels/user-accounts/um-user-panel.c:707
-msgid "_Keep Files"
-msgstr "_Mantener os fichers"
-
-#: ../panels/user-accounts/um-user-panel.c:721
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s's account?"
-msgstr "Yes seguro que quiers sacar a cuenta %s maniada remotament?"
-
-#: ../panels/user-accounts/um-user-panel.c:725
-msgid "_Delete"
-msgstr "_Eliminar"
-
-#: ../panels/user-accounts/um-user-panel.c:777
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Cuenta desactivada"
-
-#: ../panels/user-accounts/um-user-panel.c:785
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Ta configurar-ne en o siguient inicio de sesión"
-
-#: ../panels/user-accounts/um-user-panel.c:788
-msgctxt "Password mode"
-msgid "None"
-msgstr "Dengún"
-
-#: ../panels/user-accounts/um-user-panel.c:837
-msgid "Logged in"
-msgstr "Sesión encetada"
-
-#: ../panels/user-accounts/um-user-panel.c:1274
-msgid "Failed to contact the accounts service"
-msgstr "S'ha produciu una error a lo contactar con o servicio de cuentas"
-
-#: ../panels/user-accounts/um-user-panel.c:1276
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Asegura-te que o servicio de cuentas ye instalau y activau."
-
-#: ../panels/user-accounts/um-user-panel.c:1317
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Ta realizar os cambeos\n"
-"preta en primeras l'icono *"
-
-#: ../panels/user-accounts/um-user-panel.c:1355
-msgid "Create a user account"
-msgstr "Creyar una cuenta d'usuario"
-
-#: ../panels/user-accounts/um-user-panel.c:1366
-#: ../panels/user-accounts/um-user-panel.c:1678
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Ta creyar un usuario\n"
-"preta en primeras l'icono *"
-
-#: ../panels/user-accounts/um-user-panel.c:1376
-msgid "Delete the selected user account"
-msgstr "Eliminar a cuenta d'usuario seleccionadapreta en primeras l'icono *"
-
-#: ../panels/user-accounts/um-user-panel.c:1388
-#: ../panels/user-accounts/um-user-panel.c:1683
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Ta eliminar a cuenta d'usuario seleccionada\n"
-"preta en primeras l'icono *"
-
-#: ../panels/user-accounts/um-user-panel.c:1592
-msgid "My Account"
-msgstr "A mía cuenta"
-
-#: ../panels/user-accounts/um-utils.c:563
-#, c-format
-msgid "A user with the username '%s' already exists."
-msgstr "Ya existe un usuario con nombre d'usuario '%s'."
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-msgid "The username is too long."
-msgstr "O nombre d'usuario ye masiau largo."
-
-#: ../panels/user-accounts/um-utils.c:570
-msgid "The username cannot start with a '-'."
-msgstr "O nombre d'usuario no puet prencipiar por '-'."
-
-#: ../panels/user-accounts/um-utils.c:573
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"O nombre d'usuario debe consistir nomás de letras mayusclas y minusclas de "
-"l'a-dica la z, dichitos y belún d'os caracters '.', '-' y '_'."
-
-#: ../panels/user-accounts/um-utils.c:577
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-"Isto s'emplegará pa nombrar a tuya carpeta personal y no se puet cambiar."
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:823
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e, %Y"
-msgstr "%e de %b %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Mapear os botons"
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Mapear botons a funcions"
 
-#: ../panels/wacom/button-mapping.ui.h:4
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 "Ta editar un alcorce, triga l'acción \"Ninviar o clic de teclas\", preta "
 "l'alcorce d'o teclau y mantién pretas as teclas nuevas u preta o Retroceso "
 "ta esborrar-lo."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Zarrar"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -6814,386 +4865,3291 @@ msgstr ""
 "Preta as marcas d'obchectivo en que amaneixen en a pantalla ta calibrar a "
 "tableta."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "Clic erronio detectau, se ye reiniciando…"
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "Alto"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "Abaixo"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tableta"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "Dengún"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Ninviar a pulsación de tecla"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Orientación ta zurdos"
 
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Cambiar o monitor"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Amostrar l'aduya en a pantalla"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapa que monitorizar…"
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "Salida:"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Proporción d'aspecto"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Mantener a relación d'aspecto (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "Mapear una sola pantalla"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Calibrar…"
 
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d de %d"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "No s'ha detectau garra tableta"
 
-#: ../panels/wacom/cc-wacom-page.c:522
-msgid "Display Mapping"
-msgstr "Amostrar o mapeo"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Conecta u enchega a tuya tableta Wacom"
 
-#: ../panels/wacom/cc-wacom-stylus-page.c:377
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensibilidat de presión d'o lapiz"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Suau"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Botón"
 
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botón"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botón"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilidat de presión d'o borrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Sensibilidat de presión d'o borrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Pulsación d'o botón meyo d'o ratet"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Pulsación d'o botón dreito d'o ratet"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Avant"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tableta Wacom"
 
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Establir o mapiau de botons y achustar a sensibilidat d'o lapiz ta tabletas "
 "graficas"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tableta;Wacom;Stylus;Borrador;Rato;"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "Tableta (absoluto)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "Touchpad (relativo)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "Preferencias d'a tableta"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Help"
-msgstr "_Aduya"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "No tablet detected"
-msgstr "No s'ha detectau garra tableta"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Conecta u enchega a tuya tableta Wacom"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Bluetooth Settings"
-msgstr "Configuración d'o Bluetooth"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map to Monitor…"
-msgstr "Mapa que monitorizar…"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Map Buttons…"
-msgstr "Mapear os botons…"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Clic secundario _simulau"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust display resolution"
-msgstr "Achustar a resolución d'a pantalla"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Software de Windows"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Adjust mouse settings"
-msgstr "Achustar as opcions d'o ratet"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Tracking Mode"
-msgstr "Modo de seguimiento"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Tóner baixo"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:16
-msgid "Left-Handed Orientation"
-msgstr "Orientación ta zurdos"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Secundario"
 
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1028
-msgid "Left Ring"
-msgstr "Aniello cucho"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Software de Windows"
 
-#: ../panels/wacom/gsd-wacom-device.c:1039
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Opcions d'acceso"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Adhibir"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Alzar"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Detalles"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Nombre d'o ret"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Retz"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Numeros"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Veyer os detalles"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricant"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "falta o firmware"
+
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid "Left Ring Mode #%d"
-msgstr "Modo de l'aniello cucho nº %d"
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
 
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1059
-msgid "Right Ring"
-msgstr "Aniello dreito"
-
-#: ../panels/wacom/gsd-wacom-device.c:1070
+#: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
-msgid "Right Ring Mode #%d"
-msgstr "Modo de l'aniello dreito nº %d"
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
 
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1112
-msgid "Left Touchstrip"
-msgstr "Banda tactil cucha"
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
 
-#: ../panels/wacom/gsd-wacom-device.c:1123
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "Modo d'a banda tactil cucha nº %d"
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
 
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1143
-msgid "Right Touchstrip"
-msgstr "Banda tactil dreita"
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
 
-#: ../panels/wacom/gsd-wacom-device.c:1154
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "Modo d'a banda tactil dreita nº %d"
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "Banda ampla _mobil"
 
-#: ../panels/wacom/gsd-wacom-device.c:1180
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "Modo de cambeo de l'aniello tactil cucho"
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
 
-#: ../panels/wacom/gsd-wacom-device.c:1182
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "Modo de cambeo de l'aniello tactil dreito"
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
 
-#: ../panels/wacom/gsd-wacom-device.c:1185
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "Modo de cambeo d'a banda tactil cucha"
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
 
-#: ../panels/wacom/gsd-wacom-device.c:1187
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "Modo de cambeo d'a banda tactil dreita"
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Nombre d'o ret"
 
-#: ../panels/wacom/gsd-wacom-device.c:1192
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "Modo de cambeo nº %d"
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Ret"
 
-#: ../panels/wacom/gsd-wacom-device.c:1300
-#, c-format
-msgid "Left Button #%d"
-msgstr "Botón cucho nº %d"
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Abanzau"
 
-#: ../panels/wacom/gsd-wacom-device.c:1303
-#, c-format
-msgid "Right Button #%d"
-msgstr "Botón dreito nº %d"
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Opcions d'acceso"
 
-#: ../panels/wacom/gsd-wacom-device.c:1306
-#, c-format
-msgid "Top Button #%d"
-msgstr "Botón superior nº %d"
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Bloqueyo de pantalla"
 
-#: ../panels/wacom/gsd-wacom-device.c:1309
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "Botón inferior nº %d"
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
 
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "Nuevo alcorce de teclau…"
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Detalles"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "Sin acción"
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Nombre d'o ret"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "Pulsación d'o botón cucho d'o ratet"
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Automatico"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "Pulsación d'o botón meyo d'o ratet"
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "O mío ret privau"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "Pulsación d'o botón dreito d'o ratet"
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "Desplazar enta alto"
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "O mío ret privau"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "Desplazar enta baixo"
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "No s'han trobau adaptadors Bluetooth"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "Desplazar enta la cucha"
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "Desplazar enta la dreita"
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "Dezaga"
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Modo a_vión"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "Avant"
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Connectando"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "Stylus"
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "A tarcheta SIM no ye ficada"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "Sensibilidat de presión d'o borrador"
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Bloqueyo de pantalla"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "Suau"
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "Firme"
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "Botón superior"
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Cam_biar"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "Botón inferior"
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
-msgid "Tip Pressure Feel"
-msgstr "Sensibilidat de presión d'o lapiz"
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "O mío ret privau"
 
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
-msgid "GNOME Control Center"
-msgstr "Centro de control de GNOME"
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
 
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
-msgid "Utilities to configure the GNOME desktop"
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+#, fuzzy
+msgid "Utility to configure the GNOME desktop"
 msgstr "Utilidatz ta configurar o escritorio GNOME"
 
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
-msgid ""
-"The control center is GNOME's main interface for configuration of various "
-"aspects of your desktop."
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
 msgstr ""
-"O centro de control ye a interficie prencipal de GNOME ta la configuración "
-"de diversos aspectos d'o suyo escritorio."
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "Activar o modo detallau"
-
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "Amostrar a visión cheneral"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "Mirar a cadena"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "Listar totz os nombres de panels posibles y salir"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "Amostrar as opcions d'aduya"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "Panel ta amostrar"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENTO…]"
-
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- Configuración"
-
-#: ../shell/cc-application.c:163
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
 msgstr ""
-"%s\n"
-"Executar '%s --help' ta veyer una lista completa d'as opcions de comando "
-"disponibles.\n"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "Panels disponibles:"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "Seye establindo o nuevo controlador…"
 
-#: ../shell/cc-application.c:326
-msgid "Help"
-msgstr "Aduya"
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "Privacidat"
 
-#: ../shell/cc-application.c:327
-msgid "Quit"
-msgstr "Salir"
-
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1494
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Todas as configuracions"
 
-#. Add categories
-#: ../shell/cc-window.c:880
-msgctxt "category"
-msgid "Personal"
-msgstr "Presonal"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Primario"
 
-#: ../shell/cc-window.c:881
-msgctxt "category"
-msgid "Hardware"
-msgstr "Hardware"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:882
-msgctxt "category"
-msgid "System"
-msgstr "Sistema"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Aduya"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Cheneral"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Salir"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Buscar"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Cambiar a la fuent anterior"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Cancelau"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferencias;Configuración;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u salida"
+msgstr[1] "%u salidas"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u dentrada"
+msgstr[1] "%u dentradas"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Cambea a lo luengo d'o diya"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Mosaico"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Ampliación"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrar"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Replenar"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Expandir"
+
+#~ msgid "Colors"
+#~ msgstr "Colors"
+
+#~ msgid "Select Background"
+#~ msgstr "Seleccionar un fondo"
+
+#~ msgid "Pictures"
+#~ msgstr "Imachens"
+
+#~ msgid "Home"
+#~ msgstr "Domicilio"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Puetz adhibir imachens a la tuya carpeta %s y s'amostrarán aquí alto"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Sin fondo d'escritorio"
+
+#~ msgid "Current background"
+#~ msgstr "Fondo actual"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Fondo d'escritorio;Pantalla;Escritorio;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "Mete o dispositivo de calibración en o quadrau y preta 'prencipiar'"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr ""
+#~ "Mueve o tuyo dispositivo de calibración t'a posición de calibración y "
+#~ "preta 'continar'"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr ""
+#~ "Mueve o dispositivo de calibración t'a superficie y preta 'continar'"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Zarra la tapa d'o portatil"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "S'ha produciu una error interna que no s'ha puesto recuperar."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "As ferramientas necesarias ta la calibración no son instaladas."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "No s'ha puesto chenerar o perfil."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "No s'ha puesto obtener o punto blanco de l'obchectivo."
+
+#~ msgid "Complete!"
+#~ msgstr "Completau!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Ha fallau a calibración!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Puetz sacar o dispositivo de calibración."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr ""
+#~ "No interrumpas o dispositivo de calibración mientras siga en progreso"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Pantalla d'o portatil"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Escáner %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Impresora %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Camara web %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Activar a chestión de color ta %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Amostrar os perfils de color ta %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Sin calibrar"
+
+#~ msgid "Default: "
+#~ msgstr "Predeterminau: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Perfil de preba: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Seleccionar o fichero de perfil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importar"
+
+#~ msgid "All files"
+#~ msgstr "Totz os fichers"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Ha fallau en puyar o fichero: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "O perfil s'ha puyau ta:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Anota ista URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Reinicia l'equipo y ranqa o tuyo sistema operativo normal."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Escribe a URL en o tuyo navegador pa descargar y instalar o perfil."
+
+#~ msgid "Save Profile"
+#~ msgstr "Alzar o perfil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Creyar un perfil de color ta lo dispositivo seleccionau"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "No s'ha detectau l'instrumento de medida. Compreba que ye enchegau y "
+#~ "connectau correctament."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "L'instrumento de medida no suporta perfilau d'impresoras."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "A mena de dispositivo no ye suportada actualment."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espacio estándar"
+
+#~ msgid "Test Profile"
+#~ msgstr "Perfil de preba"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatico"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Calidat baixa"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Calidat meya"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Calidat alta"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB predeterminau"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK predeterminau"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Griso predeterminau"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "O furnidor suministra os datos de calibración de fabrica"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "No se puet fer a correcciónde pantalla en pantalla completa con iste "
+#~ "perfil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Iste perfil ya no ye preciso"
+
+#~ msgid "Done"
+#~ msgstr "Feito"
+
+#~ msgid "Upload profile"
+#~ msgstr "Puyar o perfil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Requerir una connexión a internet"
+
+#~ msgid "Other…"
+#~ msgstr "Unatro…"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%d/%b/%Y, %I:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%d/%b/%Y, %H:%M"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%H:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "_Zona horaria"
+
+#~ msgid "24-hour"
+#~ msgstr "24 horas"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM/PM"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Tapa zarrada"
+
+#~ msgid "Mirrored"
+#~ msgstr "En espiello"
+
+#~ msgid "Off"
+#~ msgstr "Amortau"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Ordenar as pantallas combinadas"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Arrocegar as pantallas ta reordenar-las"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Rotar 90° en sentiu antihorario"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Rotar 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Rotar 90° en sentiu antihorario"
+
+#~ msgid "Size"
+#~ msgstr "Grandaria"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr ""
+#~ "Amostrar a barra superior y l'anvista de actividatz en ista pantalla"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Unir ista pantalla con unatra ta creyar un espacio de treballo adicional"
+
+#~ msgid "Presentation"
+#~ msgstr "Presentación"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Amostrar nomás as diapositivas y a multimedia"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Amostrar a tuya anvista existent en todas dos pantallas"
+
+#~ msgid "Turn Off"
+#~ msgstr "Desenchegar"
+
+#~ msgid "Don't use this display"
+#~ msgstr "No usar ista pantalla"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "No s'ha puesto obtener a información d'a pantalla"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "Ordenar as p_antallas combinadas"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "Unknown"
+#~ msgstr "Desconoixiu"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d bits"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d bits"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Preguntar qué fer"
+
+#~ msgid "Do nothing"
+#~ msgstr "No fer cosa"
+
+#~ msgid "Open folder"
+#~ msgstr "Ubrir una carpeta"
+
+#~ msgid "Other Media"
+#~ msgstr "Atros suportes"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Seleccionar una aplicación ta CD de son"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Seleccionar una aplicación ta DVD de video"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Seleccionar una aplicación que executar quan se connecta un reproductor "
+#~ "de mosica"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Seleccionar una aplicación que executar quan se connecta una camera"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Seleccionar una aplicación ta CD de software"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD de son"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Disco Blu-ray virchen"
+
+#~ msgid "blank CD disc"
+#~ msgstr "CD virchen"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "DVD virchen"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Disco HD DVD virchen"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disco Blu-ray de video"
+
+#~ msgid "e-book reader"
+#~ msgstr "Lector de libros electronicos"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disco HD DVD de video"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD d'imachens"
+
+#~ msgid "Super Video CD"
+#~ msgstr "CD de super video"
+
+#~ msgid "Video CD"
+#~ msgstr "CD de video"
+
+#~ msgid "Overview"
+#~ msgstr "Anvista cheneral"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "Versión %s"
+
+#~ msgid "Base system"
+#~ msgstr "Sistema base"
+
+#~ msgid "Disk"
+#~ msgstr "Disco"
+
+#~ msgid "Check for updates"
+#~ msgstr "Comprebar si bi ha actualizacions"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Alzar una captura de pantalla en $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Alzar la captura d'una finestra en $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Alzar a captura de pantalla d'un aria en $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copiar una captura de pantalla en o portafuellas"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copiar una captura de pantalla d'una finestra en o portafuellas"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copiar una captura de pantalla d'un aria en o portafuellas"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Fer una grabación curta d'o escritorio"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Solament os modificadors cambean a la fuent siguient"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Alcorce;Repetir;Parpaguiar;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Alcorce presonalizau"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Retardo:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Curto"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Largo"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapida"
+
+#~ msgid "S_peed:"
+#~ msgstr "Ve_locidad:"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Sacar l'alcorce"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Ta editar un alcorce nuevo preta en a ringlera y mantién pretas as teclas "
+#~ "nuevas, u preta Retroceso ta eliminar-lo."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Acción desconoixida>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "No se puet usar l'alcorce de teclau \"%s\" porque se fería imposible "
+#~ "escribir usando ista tecla.\n"
+#~ "Por favor, intenta-lo con una tecla como Control, Alt u Mayús. a lo mesmo "
+#~ "tiempo."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "L'alcorce \"%s\" ya se ye usando ta\n"
+#~ "\"%s\""
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "Si reasignas l'alcorce a \"%s\" se desactivará l'alcorce \"%s\"."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Reasignar"
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "L'alcorce \"%s\" tien un alcorce \"%s\" asociau. Quiers establir-lo "
+#~ "automaticament ta \"%s\"?"
+
+#, c-format
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" ye actualment asociau con \"%s\", iste alcorce se desactivará si "
+#~ "continas."
+
+#~ msgid "_Assign"
+#~ msgstr "_Asignar"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Prebar as tuya preferencias"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Tiempo d'aspera d'o dople clic"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapida"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Cucho"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Dreito"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Velocidat d'o puntero"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapida"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapida"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "Despla_zamiento con dos didos"
+
+#~ msgid "_Natural scrolling"
+#~ msgstr "Desplazamiento _natural"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinco clics, ye tiempo de GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dople clic, botón primario"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Un clic, botón primario"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dople clic, botón meyo"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Un clic, botón meyo"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dople clic, botón secundario"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Un clic, botón secundario"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "page 1"
+#~ msgstr "pachina 1"
+
+#~ msgid "page 2"
+#~ msgstr "pachina 2"
+
+#~ msgid "automatic"
+#~ msgstr "automatico"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Interpresa"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Denguna"
+
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#~ msgid "Today"
+#~ msgstr "Hue"
+
+#~ msgid "Yesterday"
+#~ msgstr "Ahiere"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Denguna"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Feble"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Acceptar"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Buena"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excelent"
+
+#~ msgid "Identity"
+#~ msgstr "Identidat"
+
+#~ msgid "Server"
+#~ msgstr "Servidor"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Eliminar o servidor DNS"
+
+#~ msgid "Delete Route"
+#~ msgstr "Eliminar a ruta"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Denguna"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Clau WEP 40/128 bits (Hexadecimal u ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Clau WEP de 128 bits"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinamica (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA y WPA2 personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA y WPA2 Interpresa"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Par trenau (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Interficie d'unidat d'acoplamiento (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Interficie independient de meyos (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mbps"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mbps"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gbps"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gbps"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Fer-ne disponible ta _atros usuarios"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Zona d'o tallafuegos"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Predeterminada"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "A zona define o libel de confianza d'a connexión"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "No s'ha puesto ubrir l'editor de connexions"
+
+#~ msgid "New Profile"
+#~ msgstr "Nuevo perfil"
+
+#~ msgid "Bond"
+#~ msgstr "Bond"
+
+#~ msgid "Team"
+#~ msgstr "Equipo"
+
+#~ msgid "Bridge"
+#~ msgstr "Puente"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "No s'han puesto cargar os complementos de VPN"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importar dende un fichero…"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Adhibir una connexión de ret"
+
+#~ msgid "_Reset"
+#~ msgstr "_Reiniciar"
+
+#~ msgid "_Forget"
+#~ msgstr "_Ixuplidar"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Restablir a configuración ta iste ret, incluindo as claus, pero remerar-"
+#~ "lo como un ret preferiu"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Sacar totz os detalles relativos a iste ret y no tornar a intentar "
+#~ "connectar-se automaticament"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "No se puet importar a connexión VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "No s'ha puesto leyer o fichero '%s' u no contién información de connexión "
+#~ "VPN que se pueda reconoixer\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Selecciona lo fichero que quiers importar"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "Ya existe un fichero clamau \"%s\"."
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Quiers substituir %s con a connexión VPN que yes alzando?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "No se puet exportar a connexión VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "No s'ha puesto exportar a connexión VPN '%s' ta %s.\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportar a connexión VPN"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Asociar esclaus"
+
+#~ msgid "(none)"
+#~ msgstr "(garra)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Puentear esclaus"
+
+#~ msgid "never"
+#~ msgstr "Nunca"
+
+#~ msgid "today"
+#~ msgstr "Hue"
+
+#~ msgid "yesterday"
+#~ msgstr "Ayere"
+
+#~ msgid "Last used"
+#~ msgstr "Usada por zaguera vegada"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Perfil %d"
+
+#~ msgid "Team slaves"
+#~ msgstr "Esclaus de l'equipo"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Si tiens unatra connexión ta Internet antiparti d'a inalambrica, puetz "
+#~ "configurar un punto d'acceso inalambrico ta compartir a tuya connexión ta "
+#~ "Internet con atros."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Cambiar a lo punto d'acceso inalambrico te desconnectará de <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "No ye posible accedir a Internet usando a connexión inalambrica mientras "
+#~ "o punto d'acceso ye activau."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Aturar o punto d'acceso y desconnectar a los usuarios?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Aturar punto d'acceso"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "A politica d'o sistema prohibe usar-lo como punto d'acceso"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "O dispositivo inalambrico no suporta o modo de punto d'acceso"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Se perderán os detalles d'os retz seleccionaus, incluindo a clau y "
+#~ "qualsiquier configuración presonalizada."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Ixuplidar"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "S'usa l'autodiscubrimiento d'o proxy web quan no se proporciona una URL "
+#~ "de configuración."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "No se recomienda ta retz publicos en as qualas no se confida."
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Dengún"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manual"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatico"
+
+#~ msgid "Group Name"
+#~ msgstr "Nombre d'a colla"
+
+#~ msgid "details"
+#~ msgstr "Detalles"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Amostrar a _clau"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Fer-ne disponible ta la resta d'usuarios"
+
+#~ msgid "identity"
+#~ msgstr "Identidat"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Nomás adrezas automaticas (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Nomás o vinclo local"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignorar as rotas obtenidas automaticament"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Adreza MAC _clonada"
+
+#~ msgid "hardware"
+#~ msgstr "hardware"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Restablir a configuración d'ista connexión a las suyas valors "
+#~ "predeterminadas, pero recordar-la como una connexión favorita."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Sacar totz os detalles relativos a iste ret y no tornar a intentar "
+#~ "connectar-se automaticament a ella."
+
+#~ msgid "reset"
+#~ msgstr "Reiniciar"
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgid "_History"
+#~ msgstr "_Historico"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Amortar ta connectar-se a un ret inalambrico"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Dispositivos connectaus"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastructura"
+
+#~ msgid "Status unknown"
+#~ msgstr "Estau desconoixiu"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Sin chestionar"
+
+#~ msgid "Unavailable"
+#~ msgstr "No disponible"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Desconnectando"
+
+#~ msgid "Connection failed"
+#~ msgstr "A connexión ha fallau"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Estau desconoixiu (ausent)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Ha fallau a configuración"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Ha fallau a configuración IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "A configuración IP ha expirau"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "S'amenesten secretos, pero no s'han proporcionau"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "O suplicant de 802.1x ye desconnectau"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Ha fallau a configuración d'o suplicant de 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Ha fallau o suplicant de 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "O suplicant de 802.1x ha tardau muito tiempo en autenticar-se"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "S'ha produciu una error en encetar o servicio de PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Servicio PPP desconnectau"
+
+#~ msgid "PPP failed"
+#~ msgstr "O PPP ha fallau"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "O client DHCP ha fallau en encetar-se"
+
+#~ msgid "DHCP client error"
+#~ msgstr "S'ha produciu una error en o client DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Ha fallau o client DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr ""
+#~ "S'ha produciu una error en encetar o servicio de connexión compartida"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Ha fallau o servicio de connexión compartida"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "S'ha produciu una error en encetar o servicio d'IP automatica"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "S'ha produciu una error d'o servicio d'IP automatica"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "O servicio d'IP automatica ha fallau"
+
+#~ msgid "Line busy"
+#~ msgstr "Linia ocupada"
+
+#~ msgid "No dial tone"
+#~ msgstr "No bi ha ton de gritada"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "No s'ha puesto establir o portador"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Ha expirau lo tiempo de solicitut d'a gritada"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Intento de gritada falliu"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Ha fallau a inicialización d'o modem"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "S'ha produciu una error en seleccionar o APN especificau"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "No se son mirando retz"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Rechistro d'o ret denegau"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Ha expirau o tiempo de rechistro d'o ret"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "S'ha produciu una error en rechistrar-se con o ret solicitau"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Ha fallau a comprebación d'o PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Ye posible que falte o firmware d'o dispositivo"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "A connexión ha desapareixiu"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "S'ha asumiu una connexión existent"
+
+#~ msgid "Modem not found"
+#~ msgstr "No s'ha trobau lo modem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Ha fallau a connexión Bluetooth"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "S'ameneste o PIN d'a SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "S'ameneste o PUK d'a SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM erronia"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "O dispositivo InfiniBand no suporta o modo connectau"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Ha fallau a dependencia d'a connexión"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cable desconnectau"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "No s'ha trigau dengún certificau de autoridat certificadera"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "No usar un certificau de autoridat certificadera (CA) puet dar puesto a "
+#~ "connexions inseguras a retz inalambricos promiscuos.  Quiers trigar un "
+#~ "certificau d'autoridat certificadera?"
+
+#~ msgid "Ignore"
+#~ msgstr "Inorar"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Triga un certificau d'autoridat certificadera"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "Claus privadas DER, PEM, u PKCS#12 (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificaus DER u PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Fichers PAC (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "_Preguntar ista clau cada vegada"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "As claus privadas sin zifrar son inseguras"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "A clau privada seleccionada no pareix estar protechida por una clau.  "
+#~ "Isto podría permitir que as tuyas credencials de seguranza se "
+#~ "comprometesen.  Selecciona una clau privada protechida por clau.\n"
+#~ "\n"
+#~ "(Puetz protecher a tuya clau privada con una clau con openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Triga lo tuyo certificau presonal"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Triga la tuya clau privada"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "No al_vertir-me de nuevo"
+
+#~ msgid "Yes"
+#~ msgstr "Sí"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "On"
+#~ msgstr "Encendiu"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification Banners"
+#~ msgstr "Banners de notificación"
+
+#~ msgid "Notification Banners"
+#~ msgstr "Banners de notificación"
+
+#~ msgid "Add Account"
+#~ msgstr "Adhibir una cuenta"
+
+#~ msgid "Mail"
+#~ msgstr "Correu"
+
+#~ msgid "Contacts"
+#~ msgstr "Contactos"
+
+#~ msgid "Chat"
+#~ msgstr "Chat"
+
+#~ msgid "Resources"
+#~ msgstr "Recursos"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "S'ha produciu una error en encetar a sesión en a cuenta"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "As credencials han caducau."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Encieta la sesión ta activar ista cuenta."
+
+#~ msgid "_Sign In"
+#~ msgstr "Encetar a _sesión"
+
+#~ msgid "Error creating account"
+#~ msgstr "S'ha produciu una error en creyar a cuenta"
+
+#~ msgid "Error removing account"
+#~ msgstr "S'ha produciu una error en sacar a cuenta"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Yes seguro que quiers sacar a cuenta?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Isto no sacará la cuenta en o servidor."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "No bi ha cuentas en linia configuradas"
+
+#~ msgid "Remove Account"
+#~ msgstr "Sacar a cuenta"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "adhibir una cuenta premite que as tuyas aplicacions accedeixcan a "
+#~ "documentos, correu-y, contactos, calandario, chat y mas."
+
+#~ msgid "Unknown time"
+#~ msgstr "Tiempo desconoixiu"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s dica que se cargue de raso"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Alvertencia: quedan %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s restant"
+
+#~ msgid "Fully charged"
+#~ msgstr "Cargada de raso"
+
+#~ msgid "Empty"
+#~ msgstr "Vueda"
+
+#~ msgid "Charging"
+#~ msgstr "Cargando"
+
+#~ msgid "Discharging"
+#~ msgstr "Descargando"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Prencipal"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Adicional"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Ratet inalambrico"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Teclau inalambrico"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Fuent d'alimentación no interrumpible"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Asistent dichital presonal"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telefono mobil"
+
+#~ msgid "Media player"
+#~ msgstr "Reproductor multimeya"
+
+#~ msgid "Computer"
+#~ msgstr "Ordinador"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Cargando"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Alvertencia"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Baixa"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Buena"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Cargada de raso"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Vueda"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterías"
+
+#~ msgid "When _idle"
+#~ msgstr "Quan siga _inactivo"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "_Brilo d'a pantalla"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "Brilo d'o _teclau"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "_Enfoscar a pantalla quan siga inactiva"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Os dispositivos inalámbricos requieren enerchía adicional"
+
+#~ msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
+#~ msgstr ""
+#~ "Os dispositivos de banda ampla mobil (3G, 4G, WiMax, etc.) requieren "
+#~ "enerchía adicional"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "When on battery power"
+#~ msgstr "En modo batería"
+
+#~ msgid "When plugged in"
+#~ msgstr "Quan ye connectau a o ret"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "Suspender y amortar"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "Suspender _automaticament"
+
+#~ msgid "1 minute"
+#~ msgstr "1 menuto"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 menutos"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 menutos"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 menutos"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 menutos"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 menutos"
+
+#~ msgid "Out of toner"
+#~ msgstr "Sin tóner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Libel de revelador baixo"
+
+#~ msgid "Out of developer"
+#~ msgstr "Sin revelador"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Marcador baixo"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Sin marcador"
+
+#~ msgid "Open cover"
+#~ msgstr "Ubrir a cubierta"
+
+#~ msgid "Open door"
+#~ msgstr "Ubrir a puerta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Libel de paper baixo"
+
+#~ msgid "Out of paper"
+#~ msgstr "Sin paper"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Aturada"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Recipient de residuos quasi pleno"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Recipient de residuos pleno"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "O conductor optico ye amán d'a final d'a vida d'ell"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "O conductor optico ya no funciona"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Parada"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "No acceptar treballos"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Procesando"
+
+#~ msgid "Toner Level"
+#~ msgstr "Libel d'o tóner"
+
+#~ msgid "Supply Level"
+#~ msgstr "Libel d'o suministro"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Instalando"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u activo"
+#~ msgstr[1] "%u activos"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "S'ha produciu una error en adhibir una impresora nueva."
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Fichers de descripción d'impresora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
+#~ "PPD.gz, *.PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "No s'ha trobau dengún controlador adequau"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "No s'ha puesto cargar a IU: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Reprener a impresión"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Pausar a impresión"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Adhibir una impresora nueva"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Impresora JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Impresora LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Una cara"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Marguin larga (estandar)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Marguin curta (chirar)"
+
+#~ msgid "Portrait"
+#~ msgstr "Vertical"
+
+#~ msgid "Landscape"
+#~ msgstr "Apaisau"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Apaisau invertiu"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Vertical invertiu"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Pendient"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Reteniu"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Procesando"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Aturau"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Abortau"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Completau"
+
+#~ msgid "Job Title"
+#~ msgstr "Titol d'o treballo"
+
+#~ msgid "Job State"
+#~ msgstr "Estau d'o treballo"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Puerto serie"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Puerto paralelo"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Ubicación: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adreza: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dos caras"
+
+#~ msgid "Paper Type"
+#~ msgstr "Mena de paper"
+
+#~ msgid "Paper Source"
+#~ msgstr "Fuent de paper"
+
+#~ msgid "Output Tray"
+#~ msgstr "Servilla de salida"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Prefiltrau GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Pachinas por cara"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Cheneral"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Configuración de pachina"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opcions instalables"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Treballo"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Calidat d'a imachen"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Rematando"
+
+#~ msgid "Auto Select"
+#~ msgstr "Seleccionar automaticament"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Nomás empotrar as fuents GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Convertir ta PS de libel 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Convertir ta PS de libel 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Sin prefiltrau"
+
+#~ msgid "Supply"
+#~ msgstr "Suministro"
+
+#~ msgid "_Default printer"
+#~ msgstr "Impresora pre_determinada"
+
+#~ msgid "Jobs"
+#~ msgstr "Treballos"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Amostrar os _treballos"
+
+#~ msgid "label"
+#~ msgstr "Etiqueta"
+
+#~ msgid "page 3"
+#~ msgstr "Pachina 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Impren_tar a pachina de preba"
+
+#~ msgid "_Options"
+#~ msgstr "_Opcions"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Adhibir una impresora nueva"
+
+#~ msgid "Usage & History"
+#~ msgstr "Uso y historico"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Vuedar totz os elementos d'a papelera?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Totz os elementos d'a papelera serán esborraus permanentment."
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Esborrar totz os ficheros temporals?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Totz os fichers temporals serán esborraus permanentment."
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Ninviar informes de problemas tecnicos aduya a amillorar %s. Los informes "
+#~ "se ninvian anonimament y no contienen datos personals."
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Politica deprivacidat"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Protecher a tuya información presonal y controlar qué pueden veyer atros"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 segundos"
+
+#~ msgid "1 day"
+#~ msgstr "1 diya"
+
+#~ msgid "2 days"
+#~ msgstr "2 diyas"
+
+#~ msgid "3 days"
+#~ msgstr "3 diyas"
+
+#~ msgid "4 days"
+#~ msgstr "4 diyas"
+
+#~ msgid "5 days"
+#~ msgstr "5 diyas"
+
+#~ msgid "6 days"
+#~ msgstr "6 diyas"
+
+#~ msgid "7 days"
+#~ msgstr "7 diyas"
+
+#~ msgid "14 days"
+#~ msgstr "14 diyas"
+
+#~ msgid "30 days"
+#~ msgstr "30 diyas"
+
+#~ msgid "Forever"
+#~ msgstr "Perén"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Remerar o tuyo historico fa que siga mas sencillo buscar as cosetas de "
+#~ "nuevo. Istos elementos nunca no se comparten en o ret."
+
+#~ msgid "_Recently Used"
+#~ msgstr "Usaus _recientment"
+
+#~ msgid "Retain _History"
+#~ msgstr "Remerar l'_historico"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "A pantalla de bloqueyo proteche a tuya privacidat quan yes ausent."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "B_loqueyar a pantalla dimpués de"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Limpiar automaticament os fichers temporals y d'a Papelera ta aduyar-te a "
+#~ "mantener o tuyo equipo libre d'información sensible."
+
+#~ msgid "Purge _After"
+#~ msgstr "Limpiar _dimpués de"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Ninviando-nos información arredol de qué software fas servir nos aduya "
+#~ "furnir-te recomendacions con mas precisión. Tamién nos aduya a amillorar "
+#~ "o nuestro software.\n"
+#~ "\n"
+#~ "Toda la información que replegamos ye feita anonyma, y nunca no "
+#~ "compartiremos os tuyos datos con tercers."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Ninviar estatisticas d'emplego d'o software"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "S'usa tadeterminar atuya localización cheografica"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrico"
+
+#~ msgid "No input sources found"
+#~ msgstr "No s'han trobau fuents de dentrada"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Atra"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Súper+Mayús+Espacio"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Cambiar a la fuent siguient"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "Puetz cambiar istos alcorces en a configuración d'o teclau"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Cambeo alternativo a la fuent siguient"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Cucha + Alt dreita"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Anglés (Reino Uniu)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Reino Uniu"
+
+#~ msgid "Add input source"
+#~ msgstr "Adhibir fuent de dentrada"
+
+#~ msgid "Remove input source"
+#~ msgstr "Sacar fuent de dentrada"
+
+#~ msgid "Move input source up"
+#~ msgstr "Puyar a fuent de dentrada"
+
+#~ msgid "Move input source down"
+#~ msgstr "Baixar a fuent de dentrada"
+
+#~ msgid "Configure input source"
+#~ msgstr "Configurar fuent de dentrada"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Amostrar a distribución d'o teclau d'a fuent de dentrada"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "A configuración d'inicio de sesión la usan totz os usuarios quan encietan "
+#~ "a sesión en o sistema"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Atra"
+
+#~ msgid "Select Location"
+#~ msgstr "Seleccionar una ubicación"
+
+#~ msgid "_OK"
+#~ msgstr "_Acceptar"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Encendiu"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Amortau"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Activau"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Triga una carpeta"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "No bi ha retz seleccionaus ta compartir"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "A compartición por Bluetooth te permite compartir fichers con atros "
+#~ "dispositivos con o Bluetooth activau"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Recibir nomás dende dispositivos de confianza"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Alzar os fichers recibius en a carpeta de descargas"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "S'han desactivau qualques servicios porque no bi ha acceso a lo ret."
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "A compartición de fichers presonals te permite compartir a tuya carpeta "
+#~ "Publica con atros en o tuyo ret actual usando: <a href=\"dav://%s\">dav://"
+#~ "%s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "Premitir a os usuarios remotos connectar-se usando o comando de shell "
+#~ "segura:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "Premitir a os usuarios remotos veyer u controlar a tuya pantalla "
+#~ "connectando-se ta: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "Password:"
+#~ msgstr "Clau:"
+
+#~ msgid "Show Password"
+#~ msgstr "Amostrar a clau"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "As nuevas connexions deben preguntar por l'acceso"
+
+#~ msgid "Require a password"
+#~ msgstr "Solicitar a clau"
+
+#~ msgid "Bark"
+#~ msgstr "Ladriu"
+
+#~ msgid "Drip"
+#~ msgstr "Goteyo"
+
+#~ msgid "Glass"
+#~ msgstr "Vaso"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimo"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maximo"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Sin amplificar"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Perfil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Prebar os altavoces"
+
+#~ msgid "Peak detect"
+#~ msgstr "Detección de picos"
+
+#~ msgid "Device"
+#~ msgstr "Dispositivo"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Preba d'altavoces ta %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Trigar un dispositivo ta la salida de son:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Configuración ta lo dispositivo seleccionau:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Volumen de _dentrada:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Trigar un dispositivo ta la dentrada de son:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Efectos de son"
+
+#~ msgid "Built-in"
+#~ msgstr "Integrau"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferencias de son"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Comprebando o son d'evento"
+
+#~ msgid "From theme"
+#~ msgstr "D'o tema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Trigar un son d'alerta:"
+
+#~ msgid "Stop"
+#~ msgstr "Aturar"
+
+#~ msgid "Custom"
+#~ msgstr "Presonalizau"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Lector de pantalla"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Lector de pantalla"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Teclas de son"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Destello d'a barra de titol d'a _finestra"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Curta"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Larga"
+
+#~ msgid "Zoom"
+#~ msgstr "Ampliación"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Estandar"
+
+#~ msgid "_Verify"
+#~ msgstr "_Verificar"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "Conecta-te ta adhibir\n"
+#~ "cuentas d'encieto de sesión corporativo."
+
+#~ msgid "Left thumb"
+#~ msgstr "Dedo gordo cucho"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Dido meyo cucho"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Dido aniello cucho"
+
+#~ msgid "Left little finger"
+#~ msgstr "Dido currín cucho"
+
+#~ msgid "Right thumb"
+#~ msgstr "Dido gran dreito"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Dido meyo dreito"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Dido aniello dreito"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dido currín dreito"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Activar l'inicio de sesión con a ditalada"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Dido indiz _dreito"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Dido indiz _cucho"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "A tuya ditalada s'alzó correctament. Agora habrías de poder encetar a "
+#~ "sesión en usando o tuyo lector de ditaladas."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "inicio de sesión;nombre;ditalada;avatar;logo;cara;clau;"
+
+#~ msgid "Login History"
+#~ msgstr "Historico d'inicio de sesión"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Verificar a Clau nueva"
+
+#~ msgid "Add User Account"
+#~ msgstr "Adhibir una cuenta d'usuario"
+
+#~ msgid "User Icon"
+#~ msgstr "Icono d'usuario"
+
+#~ msgid "Last Login"
+#~ msgstr "Zaguer inicio de sesión"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "A nueva clau debe estar diferent de l'antiga."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Preba cambiando bellas letras y numeros."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Preba a cambiar a clau una mica más."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Una clau sin o tuyo nombre d'usuario será mas rebusta."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Preba a privar usar o tuyo nombre en a clau."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Preba a privar bellas d'as parolas incluidas en a clau."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Preba a privar as parolas comuns."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Preba a privar reordenar as parolas existents."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Preba a emplegar mas numeros."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Preba a emplegar mas letras mayusclas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Preba a emplegar mas letras minusclas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Preba a emplegar mas caracters especials, como puntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Preba a fer servir una mezcla de letras, numeros y simbolos depuntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Preba a privar repetir o mesmo caracter."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Preba a privar repetir a mesma mena de caracter: Cal mezclar letras, "
+#~ "numeros y simbolos de puntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Preba a privar as seqüencias como 1234 u abc."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Preba a adhibir mas letras, numeros y simbolos."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr "Mezcla letras mayusclas y minusclas y emplega un numero u dos."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr ""
+#~ "Clau buena. Preba a adhibir mas letras, numeros y simbolos de puntuación "
+#~ "ta fer-la mas rebusta."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Fortidura: Feble"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Fortidura: Baixa"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Fortidura: Meya"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Fortidura: Buena"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Fortidura: Alta"
+
+#~ msgid "Authentication failed"
+#~ msgstr "Ha fallau l'autenticación"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "A nueva clau ye masiau curta"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "A nueva clau ye masiau simpla"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "A antiga clau y a nueva son masiau semellants"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "A nueva clau ya s'ha usau recientment."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "A nueva clau debe contener caracters numericos u especials"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "A nueva clau y l'antiga son a mesma"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "S'ha cambiau a tuya clau dende que t'autentiqués inicialment!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "A nueva clau no contién suficients caracters diferents"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Error desconoixida"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "Cal que coincida con l'adreza web d'o tuyo furnidor d'a cuenta."
+
+#~ msgid "Failed to add account"
+#~ msgstr "S'ha produciu una error en adhibir a cuenta"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "As claus no coinciden."
+
+#~ msgid "Failed to register account"
+#~ msgstr "S'ha produciu una error en rechistrar a cuenta"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "No bi ha una traza suportada d'autenticar-se con iste dominio"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "S'ha produciu una error en unir-se a lo dominio"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ixe nombre d'encieto de sesión no ha marchau.\n"
+#~ "Intenta-lo de nuevas."
+
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ixa clau d'encieto de sesión no ha marchau.\n"
+#~ "Intenta-lo de nuevas."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "S'ha produciu una error en encetar a sesión en o dominio"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "No s'ha puesto trobar o dominio. ¿En ye bien escrito?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "No te ye premitiu accedir a lo dispositivo. Contacta con l'administrador "
+#~ "d'o tuyo sistema."
+
+#~ msgid "The device is already in use."
+#~ msgstr "O dispositivo ya ye en uso."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "S'ha produciu una error interna."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Eliminar as ditaladas rechistradas?"
+
+#~ msgid "Done!"
+#~ msgstr "Feito!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "No s'ha puesto accedir a lo dispositivo '%s'"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "No s'ha puesto encetar a captura de dido en o dispositivo '%s'"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "No s'ha puesto accedir a dengún lector de ditaladas"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Contacta con l'administrador d'o tuyo sistema ta obtener aduya."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "Ta activar l'inicio de sesión con a ditalada debes alzar una d'as tuyas "
+#~ "ditaladas usando lo dispositivo '%s'."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Seleccionando lo dido"
+
+#~ msgid "This Week"
+#~ msgstr "Ista semana"
+
+#~ msgid "Last Week"
+#~ msgstr "A zaguera semana"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sesión rematada"
+
+#~ msgid "Session Started"
+#~ msgstr "Sesión encetada"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Triga unatra clau."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Escribe de nuevas a tuya clau actual."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "No s'ha puesto cambiar a clau"
+
+#~ msgid "Take a photo…"
+#~ msgstr "Prener una foto…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Examinar ta mirar mas imachens…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "Usada por %s"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "No se puet unir automaticament ta ista mena de dominio"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "No existe o dominio u no s'ha trobau o reino"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "No se puet encetar a sesión como %s en o dominio %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "A clau no ye valida, intenta-lo de nuevo"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Atras cuentas"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "S'ha produciu una error en eliminar l'usuario"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "S'ha produciu una error en eliminar l'usuario maniau remotament"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "No puetz eliminar a tuya propia cuenta."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s agún no ye rechistrau en o sistema"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Eliminar un usuario entre que ye rechistrau en o sistema puede deixar lo "
+#~ "sistema en un estau inconsistent."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "Quiers mantener os fichers de %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Ye posible mantener a carpeta presonal, a ringlera d'o correu y os "
+#~ "fichers temporals en eliminar una cuenta d'usuario."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Eliminar os fichers"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Mantener os fichers"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s's account?"
+#~ msgstr "Yes seguro que quiers sacar a cuenta %s maniada remotament?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Eliminar"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Cuenta desactivada"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Ta configurar-ne en o siguient inicio de sesión"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Dengún"
+
+#~ msgid "Logged in"
+#~ msgstr "Sesión encetada"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "S'ha produciu una error a lo contactar con o servicio de cuentas"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Asegura-te que o servicio de cuentas ye instalau y activau."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Ta realizar os cambeos\n"
+#~ "preta en primeras l'icono *"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Ta creyar un usuario\n"
+#~ "preta en primeras l'icono *"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Eliminar a cuenta d'usuario seleccionadapreta en primeras l'icono *"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Ta eliminar a cuenta d'usuario seleccionada\n"
+#~ "preta en primeras l'icono *"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Ya existe un usuario con nombre d'usuario '%s'."
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "O nombre d'usuario ye masiau largo."
+
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "O nombre d'usuario no puet prencipiar por '-'."
+
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "O nombre d'usuario debe consistir nomás de letras mayusclas y minusclas "
+#~ "de l'a-dica la z, dichitos y belún d'os caracters '.', '-' y '_'."
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr ""
+#~ "Isto s'emplegará pa nombrar a tuya carpeta personal y no se puet cambiar."
+
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Alto"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Abaixo"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Dengún"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Ninviar a pulsación de tecla"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Cambiar o monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Amostrar l'aduya en a pantalla"
+
+#~ msgid "Output:"
+#~ msgstr "Salida:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Mantener a relación d'aspecto (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapear una sola pantalla"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Amostrar o mapeo"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tableta (absoluto)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferencias d'a tableta"
+
+#~ msgid "_Help"
+#~ msgstr "_Aduya"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Configuración d'o Bluetooth"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Mapear os botons…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Achustar a resolución d'a pantalla"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Achustar as opcions d'o ratet"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Modo de seguimiento"
+
+#~ msgid "Left Ring"
+#~ msgstr "Aniello cucho"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Modo de l'aniello cucho nº %d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Modo de l'aniello dreito nº %d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Banda tactil cucha"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Modo d'a banda tactil cucha nº %d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Banda tactil dreita"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Modo d'a banda tactil dreita nº %d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Modo de cambeo de l'aniello tactil cucho"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Modo de cambeo de l'aniello tactil dreito"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Modo de cambeo d'a banda tactil cucha"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Modo de cambeo d'a banda tactil dreita"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Modo de cambeo nº %d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "Botón cucho nº %d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "Botón dreito nº %d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "Botón superior nº %d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Botón inferior nº %d"
+
+#~ msgid "No Action"
+#~ msgstr "Sin acción"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Pulsación d'o botón cucho d'o ratet"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Desplazar enta alto"
+
+#~ msgid "Top Button"
+#~ msgstr "Botón superior"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Centro de control de GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME's main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "O centro de control ye a interficie prencipal de GNOME ta la "
+#~ "configuración de diversos aspectos d'o suyo escritorio."
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Activar o modo detallau"
+
+#~ msgid "Show the overview"
+#~ msgstr "Amostrar a visión cheneral"
+
+#~ msgid "Search for the string"
+#~ msgstr "Mirar a cadena"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Listar totz os nombres de panels posibles y salir"
+
+#~ msgid "Show help options"
+#~ msgstr "Amostrar as opcions d'aduya"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel ta amostrar"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENTO…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- Configuración"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Executar '%s --help' ta veyer una lista completa d'as opcions de comando "
+#~ "disponibles.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "Panels disponibles:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Presonal"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistema"
 
 #~ msgid "When battery power is _critical"
 #~ msgstr "_Quan a carga ye criticament baixa"
@@ -7203,6 +8159,3 @@ msgstr "Preferencias;Configuración;"
 
 #~ msgid "Hibernate"
 #~ msgstr "Hibernar"
-
-#~ msgid "Power off"
-#~ msgstr "Amortar"

--- a/po/an.po~
+++ b/po/an.po~
@@ -1,0 +1,7208 @@
+# Aragonese translation for gnome-control-center.
+# Copyright (C) 2013 gnome-control-center's COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center package.
+# Jorge Pérez Pérez <jorgtum@gmail.com>, 2013.
+# Daniel Martinez <entaltoaragon@gmail.com>, 2014, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2015-06-14 06:46+0000\n"
+"PO-Revision-Date: 2015-06-14 11:37+0200\n"
+"Last-Translator: Daniel <entaltoaragon@gmail.com>\n"
+"Language-Team: Aragonés <softaragones@googlegroups.com>\n"
+"Language: an\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.5.1.1\n"
+"X-POOTLE-MTIME: 1434278245.000000\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "Fondo"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "Cambea a lo luengo d'o diya"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "Lock Screen"
+msgstr "Blocar a pantalla"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Mosaico"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Ampliación"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "Centrar"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Escalar"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Replenar"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "Expandir"
+
+#: ../panels/background/cc-background-chooser-dialog.c:437
+msgid "Wallpapers"
+msgstr "Fondos d'escritorio"
+
+#: ../panels/background/cc-background-chooser-dialog.c:446
+msgid "Colors"
+msgstr "Colors"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:483
+msgid "Select Background"
+msgstr "Seleccionar un fondo"
+
+#: ../panels/background/cc-background-chooser-dialog.c:511
+msgid "Pictures"
+msgstr "Imachens"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:543
+msgid "No Pictures Found"
+msgstr "No s'han trobau imachens"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:561
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "Domicilio"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:573
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "Puetz adhibir imachens a la tuya carpeta %s y s'amostrarán aquí alto"
+
+#: ../panels/background/cc-background-chooser-dialog.c:580
+#: ../panels/color/cc-color-panel.c:225 ../panels/color/cc-color-panel.c:963
+#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1594
+#: ../panels/display/cc-display-panel.c:2056
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1247
+#: ../panels/network/net-device-wifi.c:1440
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/cc-printers-panel.c:1940
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:568
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+#: ../panels/user-accounts/um-photo-dialog.c:94
+#: ../panels/user-accounts/um-photo-dialog.c:217
+#: ../panels/user-accounts/um-user-panel.c:708
+#: ../panels/user-accounts/um-user-panel.c:726
+msgid "_Cancel"
+msgstr "_Cancelar"
+
+#: ../panels/background/cc-background-chooser-dialog.c:581
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:96
+msgid "Select"
+msgstr "Seleccionar"
+
+#: ../panels/background/cc-background-item.c:203
+msgid "multiple sizes"
+msgstr "grandarias multiples"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:207
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:333
+msgid "No Desktop Background"
+msgstr "Sin fondo d'escritorio"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "Fondo actual"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Cambiar a imachen de fondo d'escritorio por un tapiz u una foto"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Fondo d'escritorio;Pantalla;Escritorio;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "O Bluetooth ye desactivau"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "No s'han trobau adaptadors Bluetooth"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "O Bluetooth ye fisicament desactivau"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1637
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Activar y desactivar o Bluetooth y connectar os tuyos dispositivos"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "Mete o dispositivo de calibración en o quadrau y preta 'prencipiar'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+"Mueve o tuyo dispositivo de calibración t'a posición de calibración y preta "
+"'continar'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr "Mueve o dispositivo de calibración t'a superficie y preta 'continar'"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "Zarra la tapa d'o portatil"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "S'ha produciu una error interna que no s'ha puesto recuperar."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "As ferramientas necesarias ta la calibración no son instaladas."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "No s'ha puesto chenerar o perfil."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "No s'ha puesto obtener o punto blanco de l'obchectivo."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "Completau!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "Ha fallau a calibración!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "Puetz sacar o dispositivo de calibración."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "No interrumpas o dispositivo de calibración mientras siga en progreso"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Pantalla d'o portatil"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Camara web integrada"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Escáner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Camara %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Impresora %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Camara web %s"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Activar a chestión de color ta %s"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Amostrar os perfils de color ta %s"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:323
+msgid "Not calibrated"
+msgstr "Sin calibrar"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:141
+msgid "Default: "
+msgstr "Predeterminau: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:149
+msgid "Colorspace: "
+msgstr "Espacio de color: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:156
+msgid "Test profile: "
+msgstr "Perfil de preba: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:223
+msgid "Select ICC Profile File"
+msgstr "Seleccionar o fichero de perfil ICC"
+
+#: ../panels/color/cc-color-panel.c:226
+msgid "_Import"
+msgstr "_Importar"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:237
+msgid "Supported ICC profiles"
+msgstr "Perfils ICC suportaus"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:244
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "Totz os fichers"
+
+#: ../panels/color/cc-color-panel.c:583
+msgid "Screen"
+msgstr "Pantalla"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:908
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Ha fallau en puyar o fichero: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:922
+msgid "The profile has been uploaded to:"
+msgstr "O perfil s'ha puyau ta:"
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Write down this URL."
+msgstr "Anota ista URL."
+
+#: ../panels/color/cc-color-panel.c:925
+msgid "Restart this computer and boot your normal operating system."
+msgstr "Reinicia l'equipo y ranqa o tuyo sistema operativo normal."
+
+#: ../panels/color/cc-color-panel.c:926
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "Escribe a URL en o tuyo navegador pa descargar y instalar o perfil."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:960
+msgid "Save Profile"
+msgstr "Alzar o perfil"
+
+#: ../panels/color/cc-color-panel.c:964
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "_Alzar"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1324
+msgid "Create a color profile for the selected device"
+msgstr "Creyar un perfil de color ta lo dispositivo seleccionau"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"No s'ha detectau l'instrumento de medida. Compreba que ye enchegau y "
+"connectau correctament."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1373
+msgid "The measuring instrument does not support printer profiling."
+msgstr "L'instrumento de medida no suporta perfilau d'impresoras."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1384
+msgid "The device type is not currently supported."
+msgstr "A mena de dispositivo no ye suportada actualment."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "Espacio estándar"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "Perfil de preba"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatico"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Calidat baixa"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Calidat meya"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Calidat alta"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB predeterminau"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK predeterminau"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Griso predeterminau"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "O furnidor suministra os datos de calibración de fabrica"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+"No se puet fer a correcciónde pantalla en pantalla completa con iste perfil"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "Iste perfil ya no ye preciso"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "Calibración de pantalla"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1476
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "Prencipiar"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "Reprener"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "Feito"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "Calibración d'a pantalla"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"A calibración puet producir un perfil que puetz emplegar ta chestionar a "
+"color d'a tuya pantalla. Contra más tiempo pierdas en achustar a "
+"calibración, millor será la calidat d'o perfil de color."
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "No podrás emplegar o tuyo ordinador mientras se faiga la calibración."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "Calidat d'a imachen"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "Tiempo aproximau"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "Calidat d'a calibración"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Selecciona o sensor que quiers emplegar ta la calibración."
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "Dispositivo de calibración"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "Selecciona la mena de pantalla que ye connectada."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "Mena de pantalla"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Selecciona o punto blanco de l'obchectivo en a pantalla. A mayoría d'as "
+"pantallas deben estar calibradas con un iluminant D65."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "Puntero blanco d'o perfil"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Por favor, configura o brilo d'a pantalla como siga normal ta tu. "
+"L'administración d'o color será más precisa en iste libel de brilo."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativament, puetz usar o libel de brilo usau con un d'os atros perfils "
+"ta iste dispositivo."
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "Brilo d'a pantalla"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Puetz usar un perfil de color en diferents ordinadors, o mesmo creyar "
+"perfils ta diferents condicions de luz."
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "Nombre d'o perfil:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "Nombre d'o perfil"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "O perfil ha estau creyau satisfactoriament!"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "Copiar o perfil"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "Requier un meyo escribible"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "Puyar o perfil"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "Requerir una connexión a internet"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Puetz trobar instruccions utils sobre cómo usar o perfil en sistemas <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> y <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:729
+msgid "Summary"
+msgstr "Resumen"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "Importar un fichero…"
+
+#: ../panels/color/color.ui.h:30
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1477
+msgid "_Add"
+msgstr "_Adhibir"
+
+#: ../panels/color/color.ui.h:31
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"S'han trobau problemas. O perfil puet no funcionar correctament. <a "
+"href=\"\">Amostrar os detalles.</a>"
+
+#: ../panels/color/color.ui.h:32
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Cada dispositivo ameneste un perfil de color actualizau ta poder chestionar "
+"a color."
+
+#: ../panels/color/color.ui.h:33
+msgid "Learn more"
+msgstr "Aprender mas"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more about color management"
+msgstr "Aprende mas sobre a chestión d'a color"
+
+#: ../panels/color/color.ui.h:35
+msgid "Set for all users"
+msgstr "Establir ta totz os usuarios"
+
+#: ../panels/color/color.ui.h:36
+msgid "Set this profile for all users on this computer"
+msgstr "Establir iste perfil ta totz os usuarios d'iste equipo"
+
+#: ../panels/color/color.ui.h:37
+msgid "Enable"
+msgstr "Activar"
+
+#: ../panels/color/color.ui.h:38
+msgid "Add profile"
+msgstr "Adhibir un perfil"
+
+#: ../panels/color/color.ui.h:39 ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Calibrate…"
+msgstr "Calibrar…"
+
+#: ../panels/color/color.ui.h:40
+msgid "Calibrate the device"
+msgstr "Calibrar o dispositivo"
+
+#: ../panels/color/color.ui.h:41
+msgid "Remove profile"
+msgstr "Sacar o perfil"
+
+#: ../panels/color/color.ui.h:42
+msgid "View details"
+msgstr "Veyer os detalles"
+
+#: ../panels/color/color.ui.h:43
+msgid "Unable to detect any devices that can be color managed"
+msgstr "No s'han detectau dispositivos que se puedan chestionar por color"
+
+#: ../panels/color/color.ui.h:44
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:45
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:46
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:47
+msgid "Projector"
+msgstr "Prochector"
+
+#: ../panels/color/color.ui.h:48
+msgid "Plasma"
+msgstr "Plasma"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL retroiluminau)"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED retroiluminau)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (white LED backlight)"
+msgstr "LCD (LED blanco retroiluminau)"
+
+#: ../panels/color/color.ui.h:52
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Gama LCD amplo (CCFL retroiluminau)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Gama LCD amplo (RGB LED retroiluminau)"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alta"
+
+#: ../panels/color/color.ui.h:55
+msgid "40 minutes"
+msgstr "40 menutos"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Meya"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:2
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 menutos"
+
+#: ../panels/color/color.ui.h:58
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Baixa"
+
+#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:1
+msgid "15 minutes"
+msgstr "15 menutos"
+
+#: ../panels/color/color.ui.h:60
+msgid "Native to display"
+msgstr "Nativo d'a pantalla"
+
+#: ../panels/color/color.ui.h:61
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Impresions y publicacions)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:63
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografía y graficos)"
+
+#: ../panels/color/color.ui.h:64
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "Color"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibrar a color d'os tuyos dispositivos, como pantallas, camaras u "
+"impresoras"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Perfil;Calibrau;Impresora;Pantalla;"
+
+#: ../panels/common/cc-common-language.c:323
+msgid "Other…"
+msgstr "Unatro…"
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:270
+#: ../panels/region/cc-input-chooser.c:167
+msgid "More…"
+msgstr "Mas…"
+
+#: ../panels/common/cc-language-chooser.c:139
+msgid "No languages found"
+msgstr "No s'han trobau idiomas"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "Idioma"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "_Feito"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%d/%b/%Y, %I:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%d/%b/%Y, %H:%M"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%H:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "Chinero"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "Febrero"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "Marzo"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "Abril"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "Mayo"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "Chunio"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "Chulio"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "Agosto"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "Setiembre"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "Octubre"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "Noviembre"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "Aviento"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "Calendata y hora"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "Hora"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "Menuto"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "Diya"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "Mes"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "Anyo"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Time Zone"
+msgstr "Zona horaria"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Search for a city"
+msgstr "Mirar por una ciudat"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Automatic _Date & Time"
+msgstr "Calen_data y hora automatica"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr "Requier acceso a internet"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Automatic Time _Zone"
+msgstr "_Zona horaria automatica"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "Date & _Time"
+msgstr "Calenda_ta y hora"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr "_Zona horaria"
+
+#: ../panels/datetime/datetime.ui.h:28
+msgid "Time _Format"
+msgstr "_Formato d'a hora"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24 horas"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "AM/PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "Cambiar a calendata y a hora, incluindo a zona horaria"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "Reloch;Zona horaria;Ubicación;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "Cambiar a configuración d'a hora y a calendata d'o sistema"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Ta cambiar a configuración d'a calendata u d'a hora, debes autenticar-te."
+
+#: ../panels/display/cc-display-panel.c:579
+msgid "Lid Closed"
+msgstr "Tapa zarrada"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:582
+msgid "Mirrored"
+msgstr "En espiello"
+
+#: ../panels/display/cc-display-panel.c:584
+#: ../panels/display/cc-display-panel.c:2228
+msgid "Primary"
+msgstr "Primario"
+
+#: ../panels/display/cc-display-panel.c:586
+#: ../panels/notifications/cc-notifications-panel.c:257
+#: ../panels/power/cc-power-panel.c:1834 ../panels/power/cc-power-panel.c:1845
+#: ../panels/privacy/cc-privacy-panel.c:155
+#: ../panels/privacy/cc-privacy-panel.c:222
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "Amortau"
+
+#: ../panels/display/cc-display-panel.c:589
+msgid "Secondary"
+msgstr "Secundario"
+
+#. Title of displays dialog when multiple monitors are present.
+#: ../panels/display/cc-display-panel.c:1591
+msgid "Arrange Combined Displays"
+msgstr "Ordenar as pantallas combinadas"
+
+#: ../panels/display/cc-display-panel.c:1595
+#: ../panels/display/cc-display-panel.c:2057
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "_Aplicar"
+
+#: ../panels/display/cc-display-panel.c:1619
+msgid "Drag displays to rearrange them"
+msgstr "Arrocegar as pantallas ta reordenar-las"
+
+#: ../panels/display/cc-display-panel.c:2106
+msgid "Rotate counterclockwise by 90°"
+msgstr "Rotar 90° en sentiu antihorario"
+
+#: ../panels/display/cc-display-panel.c:2124
+msgid "Rotate by 180°"
+msgstr "Rotar 180°"
+
+#: ../panels/display/cc-display-panel.c:2142
+msgid "Rotate clockwise by 90°"
+msgstr "Rotar 90° en sentiu antihorario"
+
+#: ../panels/display/cc-display-panel.c:2163
+msgid "Size"
+msgstr "Grandaria"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2176
+msgid "Aspect Ratio"
+msgstr "Proporción d'aspecto"
+
+#: ../panels/display/cc-display-panel.c:2198
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "Resolución"
+
+#: ../panels/display/cc-display-panel.c:2229
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "Amostrar a barra superior y l'anvista de actividatz en ista pantalla"
+
+#: ../panels/display/cc-display-panel.c:2235
+msgid "Secondary Display"
+msgstr "Pantalla secundaria"
+
+#: ../panels/display/cc-display-panel.c:2236
+msgid "Join this display with another to create an extra workspace"
+msgstr ""
+"Unir ista pantalla con unatra ta creyar un espacio de treballo adicional"
+
+#: ../panels/display/cc-display-panel.c:2243
+msgid "Presentation"
+msgstr "Presentación"
+
+#: ../panels/display/cc-display-panel.c:2244
+msgid "Show slideshows and media only"
+msgstr "Amostrar nomás as diapositivas y a multimedia"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2249
+msgid "Mirror"
+msgstr "Espiello"
+
+#: ../panels/display/cc-display-panel.c:2250
+msgid "Show your existing view on both displays"
+msgstr "Amostrar a tuya anvista existent en todas dos pantallas"
+
+#: ../panels/display/cc-display-panel.c:2256
+msgid "Turn Off"
+msgstr "Desenchegar"
+
+#: ../panels/display/cc-display-panel.c:2257
+msgid "Don't use this display"
+msgstr "No usar ista pantalla"
+
+#: ../panels/display/cc-display-panel.c:2560
+msgid "Could not get screen information"
+msgstr "No s'ha puesto obtener a información d'a pantalla"
+
+#: ../panels/display/cc-display-panel.c:2591
+msgid "_Arrange Combined Displays"
+msgstr "Ordenar as p_antallas combinadas"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "Pantallas"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Trigar cómo usar as pantallas y os prochectors connectaus"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "Panel;Prochector;xranrd;Pantalla;Resolución;refrescar;Monitor;"
+
+#: ../panels/info/cc-info-panel.c:385
+msgid "Wayland"
+msgstr "Wayland"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:388 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "Desconoixiu"
+
+#: ../panels/info/cc-info-panel.c:473
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d bits"
+
+#: ../panels/info/cc-info-panel.c:475
+#, c-format
+msgid "%d-bit"
+msgstr "%d bits"
+
+#: ../panels/info/cc-info-panel.c:1155
+msgid "Ask what to do"
+msgstr "Preguntar qué fer"
+
+#: ../panels/info/cc-info-panel.c:1159
+msgid "Do nothing"
+msgstr "No fer cosa"
+
+#: ../panels/info/cc-info-panel.c:1163
+msgid "Open folder"
+msgstr "Ubrir una carpeta"
+
+#: ../panels/info/cc-info-panel.c:1254
+msgid "Other Media"
+msgstr "Atros suportes"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for audio CDs"
+msgstr "Seleccionar una aplicación ta CD de son"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application for video DVDs"
+msgstr "Seleccionar una aplicación ta DVD de video"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Seleccionar una aplicación que executar quan se connecta un reproductor de "
+"mosica"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application to run when a camera is connected"
+msgstr "Seleccionar una aplicación que executar quan se connecta una camera"
+
+#: ../panels/info/cc-info-panel.c:1289
+msgid "Select an application for software CDs"
+msgstr "Seleccionar una aplicación ta CD de software"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1301
+msgid "audio DVD"
+msgstr "DVD de son"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank Blu-ray disc"
+msgstr "Disco Blu-ray virchen"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank CD disc"
+msgstr "CD virchen"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank DVD disc"
+msgstr "DVD virchen"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "blank HD DVD disc"
+msgstr "Disco HD DVD virchen"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "Blu-ray video disc"
+msgstr "Disco Blu-ray de video"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "e-book reader"
+msgstr "Lector de libros electronicos"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "HD DVD video disc"
+msgstr "Disco HD DVD de video"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Picture CD"
+msgstr "CD d'imachens"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Super Video CD"
+msgstr "CD de super video"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Video CD"
+msgstr "CD de video"
+
+#: ../panels/info/cc-info-panel.c:1312
+msgid "Windows software"
+msgstr "Software de Windows"
+
+#: ../panels/info/cc-info-panel.c:1435
+#: ../panels/keyboard/keyboard-shortcuts.c:1947
+msgid "Section"
+msgstr "Sección"
+
+#: ../panels/info/cc-info-panel.c:1444 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "Anvista cheneral"
+
+#: ../panels/info/cc-info-panel.c:1450 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "Aplicacions predeterminadas"
+
+#: ../panels/info/cc-info-panel.c:1455 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "Suportes extraíbles"
+
+#: ../panels/info/cc-info-panel.c:1480
+#, c-format
+msgid "Version %s"
+msgstr "Versión %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:46
+msgid "Details"
+msgstr "Detalles"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "Veyer información sobre o tuyo sistema"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;información;memoria;procesador;versión;predeterminau;"
+"aplicación;alternativo;preferiu;cd;dvd;usb;son;video;disco;extraíble;meyo;"
+"autoexecutar;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "Seleccionar cómo s'han de maniar atros suportes"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "_Acción:"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "_Mena:"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "Nombre d'o dispositivo"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "Memoria"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "Procesador"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "Sistema base"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "Disco"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "Calculando…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "Graficos"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "Virtualización"
+
+#: ../panels/info/info.ui.h:13
+msgid "Check for updates"
+msgstr "Comprebar si bi ha actualizacions"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "_Web"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "Co_rreo"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "_Calandario"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "_Mosica"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "_Video"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "_Fotos"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "Seleccionar cómo s'han de maniar os suportes"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "CD de _son"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "_DVD de video"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "Reproductor de _mosica"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "_Software"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "_Atros suportes…"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nunca no preguntar ni encetar programas en introducir suportes"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "Son y meyos"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "Silenciar"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "Baixar o volumen"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "Puyar o volumen"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "Lanzar o reproductor multimeya"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "Reproducir (u reproducir/pausar)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "Pausar a reproducción"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "Aturar a reproducción"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "Pista anterior"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "Pista siguient"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "Fer fuera"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "Escritura"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "Cambiar a la siguient fuent de dentrada"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "Cambiar a l'anterior fuent de dentrada"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "Lanzadors"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "Lanzar o visor d'aduya"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1605
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "Configuración"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "Lanzar a calculadera"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "Lanzar o client de correu"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "Lanzar o navegador web"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "Carpeta presonal"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Mirar"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "Capturas de pantalla"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "Alzar una captura de pantalla en $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Alzar la captura d'una finestra en $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Alzar a captura de pantalla d'un aria en $PICTURES"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "Copiar una captura de pantalla en o portafuellas"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Copiar una captura de pantalla d'una finestra en o portafuellas"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Copiar una captura de pantalla d'un aria en o portafuellas"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "Fer una grabación curta d'o escritorio"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "Sistema"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Zarrar a sesión"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "Bloqueyar a pantalla"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "Acceso universal"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "Activar u desactivar l'ampliación"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "Enamplar"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "Reducir"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "Activar u desactivar o lector de pantalla"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "Activar u desactivar o teclau en pantalla"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "Agrandir a mida d'o texto"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "Achiquir a mida d'o texto"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "Alto contraste activau u desactivau"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1219
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+msgid "Disabled"
+msgstr "Desactivau"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "Tecla de caracters alternativos"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "Tecla de composición"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "Solament os modificadors cambean a la fuent siguient"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Teclau"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"Veyer y cambiar os alcorces d'o teclau y establir as tuyas preferencias de "
+"escritura"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Alcorce;Repetir;Parpaguiar;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "Alcorce presonalizau"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "_Nombre:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "C_omando:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "Repetición de teclas"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "As pulsacions de teclas se _repiten quan a tecla se mantién preta"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "_Retardo:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "Ve_locidad:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "Curto"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "Lenta"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "Velocidat de repetición d'as teclas"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "Largo"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "Rapida"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "Parpagueo d'o cursor"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "O cursor pa_rpadia en os campos de texto"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "Ve_locidad:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "Velocidat de parpagueo d'o cursor"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "Fuents de dentrada"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "Adhibir l'alcorce"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "Sacar l'alcorce"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"Ta editar un alcorce nuevo preta en a ringlera y mantién pretas as teclas "
+"nuevas, u preta Retroceso ta eliminar-lo."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "Alcorces"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:632
+#: ../panels/keyboard/keyboard-shortcuts.c:640
+msgid "Custom Shortcuts"
+msgstr "Alcorces presonalizaus"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:857
+msgid "<Unknown Action>"
+msgstr "<Acción desconoixida>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1358
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"No se puet usar l'alcorce de teclau \"%s\" porque se fería imposible "
+"escribir usando ista tecla.\n"
+"Por favor, intenta-lo con una tecla como Control, Alt u Mayús. a lo mesmo "
+"tiempo."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1388
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"L'alcorce \"%s\" ya se ye usando ta\n"
+"\"%s\""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1393
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "Si reasignas l'alcorce a \"%s\" se desactivará l'alcorce \"%s\"."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1399
+msgid "_Reassign"
+msgstr "_Reasignar"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1440
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"L'alcorce \"%s\" tien un alcorce \"%s\" asociau. Quiers establir-lo "
+"automaticament ta \"%s\"?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1450
+#, c-format
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"\"%s\" ye actualment asociau con \"%s\", iste alcorce se desactivará si "
+"continas."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1457
+msgid "_Assign"
+msgstr "_Asignar"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "_Prebar a tuya configuración"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+msgid "Test Your Settings"
+msgstr "Prebar as tuya preferencias"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "Ratet y touchpad"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Cambiar a sensibilidat d'o tuyo ratet u lo tuyo touchpad y configurar-los ta "
+"cuchos u diestros"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Puntero;Click;Tap;Dople;Botón;Trackball;Desplazamiento;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "Cheneral"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "Lenta"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "Tiempo d'aspera d'o dople clic"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "Rapida"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "_Dople clic"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "_Botón primario"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "_Cucho"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "_Dreito"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "Ratet"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "_Velocidat d'o puntero"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "Lenta"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "Rapida"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "Lenta"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "Rapida"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Tap to _click"
+msgstr "To_car ta pretar"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Two _finger scroll"
+msgstr "Despla_zamiento con dos didos"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+msgid "_Natural scrolling"
+msgstr "Desplazamiento _natural"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Preba a pretar una vegada, dos vegadas, desplazar-te"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "Cinco clics, ye tiempo de GEGL!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "Dople clic, botón primario"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "Un clic, botón primario"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "Dople clic, botón meyo"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "Un clic, botón meyo"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "Dople clic, botón secundario"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "Un clic, botón secundario"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:358
+msgid "Air_plane Mode"
+msgstr "Modo a_vión"
+
+#: ../panels/network/cc-network-panel.c:967
+msgid "Network proxy"
+msgstr "Proxy d'o ret"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "VPN %s"
+
+#: ../panels/network/cc-network-panel.c:1300
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Bella cosa ha fallau. Contacte con o fabricant d'o software."
+
+#: ../panels/network/cc-network-panel.c:1306
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager ha d'estar en execución."
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "_Seguranza 802.1x"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "pachina 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "Identidat anoni_ma"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:5
+msgid "Inner _authentication"
+msgstr "Autenticación i_nterna"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:6
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "pachina 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:469
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "Seguranza"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "automatico"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:218
+#: ../panels/network/net-device-wifi.c:382
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:222
+#: ../panels/network/net-device-wifi.c:387
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:226
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:231
+msgid "Enterprise"
+msgstr "Interpresa"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:236
+#: ../panels/network/net-device-wifi.c:372
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Denguna"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:17
+msgid "Never"
+msgstr "Nunca"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:815
+msgid "Today"
+msgstr "Hue"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:818
+msgid "Yesterday"
+msgstr "Ahiere"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:476
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "fa %i diya"
+msgstr[1] "fa %i diyas"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:533
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Denguna"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Feble"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Acceptar"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:568
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Buena"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:570
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excelent"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:262
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "Identidat"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "Adreza"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "Mascara de ret"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:2
+msgid "Gateway"
+msgstr "Puerta de vinclo"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "Eliminar l'adreza"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "Adhibir"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "Servidor"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "Eliminar o servidor DNS"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "Metrica"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "Eliminar a ruta"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "Automatico (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:26
+#: ../panels/privacy/cc-privacy-panel.c:182
+msgid "Manual"
+msgstr "Manual"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "Nomás vinclo local"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:967
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "Prefixo"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:182
+msgid "Automatic"
+msgstr "Automatico"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "Automatico, nomás DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:937
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:51
+msgid "Reset"
+msgstr "Reiniciar"
+
+#: ../panels/network/connection-editor/ce-page-security.c:253
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Denguna"
+
+#: ../panels/network/connection-editor/ce-page-security.c:276
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Clau WEP 40/128 bits (Hexadecimal u ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:286
+msgid "WEP 128-bit Passphrase"
+msgstr "Clau WEP de 128 bits"
+
+#: ../panels/network/connection-editor/ce-page-security.c:299
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:312
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinamica (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:326
+msgid "WPA & WPA2 Personal"
+msgstr "WPA y WPA2 personal"
+
+#: ../panels/network/connection-editor/ce-page-security.c:340
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA y WPA2 Interpresa"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr "Fortidura d'o sinyal"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "Velocidat de connexión"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:157
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "Adreza IPv4"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:158
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "Adreza IPv6"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:165
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "Adreza fisica"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:169
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "Ruta predeterminada"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "Usada por zaguera vegada"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "Par trenau (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Interficie d'unidat d'acoplamiento (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "Interficie independient de meyos (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mbps"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mbps"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gbps"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gbps"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "_Nombre"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "Adreza _MAC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "Adreza _clonada"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "bytes"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "Fer-ne disponible ta _atros usuarios"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "Connectar-ne _automaticament"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+msgid "Firewall _Zone"
+msgstr "Zona d'o tallafuegos"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:113
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "Predeterminada"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "A zona define o libel de confianza d'a connexión"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "_Adrezas"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "DNS automatico"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "Rutas"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "Rutas automaticas"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr "Usar ista c_onnexion nomás ta os recursos en o tuyo ret"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "No s'ha puesto ubrir l'editor de connexions"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "Nuevo perfil"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "Bond"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "Equipo"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "Puente"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "No s'han puesto cargar os complementos de VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "Importar dende un fichero…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "Adhibir una connexión de ret"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "_Reiniciar"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1441
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "_Ixuplidar"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"Restablir a configuración ta iste ret, incluindo as claus, pero remerar-lo "
+"como un ret preferiu"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"Sacar totz os detalles relativos a iste ret y no tornar a intentar connectar-"
+"se automaticament"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "S_eguranza"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "No se puet importar a connexión VPN"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"No s'ha puesto leyer o fichero '%s' u no contién información de connexión "
+"VPN que se pueda reconoixer\n"
+"\n"
+"Error: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "Selecciona lo fichero que quiers importar"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1941
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "_Open"
+msgstr "_Ubrir"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "Ya existe un fichero clamau \"%s\"."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "Substitui_r"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Quiers substituir %s con a connexión VPN que yes alzando?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "No se puet exportar a connexión VPN"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"No s'ha puesto exportar a connexión VPN '%s' ta %s.\n"
+"\n"
+"Error: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+msgid "Export VPN connection"
+msgstr "Exportar a connexión VPN"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Error: no s'ha puesto cargar l'editor de connexions VPN)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "O mío ret privau"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "Fer-ne disponible ta _atros usuarios"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "Ret"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "Controlar cómo se connecta ta Internet"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"Ret;Inalambrica;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Banda ampla;Modem;Bluetooth;VPN;"
+"WLAN;Puente;Enlaz;DNS;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "Asociar esclaus"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(garra)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "Puentear esclaus"
+
+#: ../panels/network/net-device-ethernet.c:110
+#: ../panels/network/net-device-wifi.c:462
+msgid "never"
+msgstr "Nunca"
+
+#: ../panels/network/net-device-ethernet.c:120
+#: ../panels/network/net-device-wifi.c:472
+msgid "today"
+msgstr "Hue"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:474
+msgid "yesterday"
+msgstr "Ayere"
+
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "Adreza IP"
+
+#: ../panels/network/net-device-ethernet.c:176
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "Usada por zaguera vegada"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:286
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "Cableyau"
+
+#: ../panels/network/net-device-ethernet.c:354
+#: ../panels/network/net-device-wifi.c:1599
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8 ../panels/network/network-vpn.ui.h:7
+msgid "Options…"
+msgstr "Opcions…"
+
+#: ../panels/network/net-device-ethernet.c:472
+#, c-format
+msgid "Profile %d"
+msgstr "Perfil %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "Adhibir una nueva connexión"
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr "Esclaus de l'equipo"
+
+#: ../panels/network/net-device-wifi.c:1154
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"Si tiens unatra connexión ta Internet antiparti d'a inalambrica, puetz "
+"configurar un punto d'acceso inalambrico ta compartir a tuya connexión ta "
+"Internet con atros."
+
+#: ../panels/network/net-device-wifi.c:1158
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "Cambiar a lo punto d'acceso inalambrico te desconnectará de <b>%s</b>."
+
+#: ../panels/network/net-device-wifi.c:1162
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"No ye posible accedir a Internet usando a connexión inalambrica mientras o "
+"punto d'acceso ye activau."
+
+#: ../panels/network/net-device-wifi.c:1245
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Aturar o punto d'acceso y desconnectar a los usuarios?"
+
+#: ../panels/network/net-device-wifi.c:1248
+msgid "_Stop Hotspot"
+msgstr "_Aturar punto d'acceso"
+
+#: ../panels/network/net-device-wifi.c:1305
+msgid "System policy prohibits use as a Hotspot"
+msgstr "A politica d'o sistema prohibe usar-lo como punto d'acceso"
+
+#: ../panels/network/net-device-wifi.c:1308
+msgid "Wireless device does not support Hotspot mode"
+msgstr "O dispositivo inalambrico no suporta o modo de punto d'acceso"
+
+#: ../panels/network/net-device-wifi.c:1437
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Se perderán os detalles d'os retz seleccionaus, incluindo a clau y "
+"qualsiquier configuración presonalizada."
+
+#: ../panels/network/net-device-wifi.c:1752
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "Historia"
+
+#: ../panels/network/net-device-wifi.c:1756
+#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
+#: ../panels/wacom/cc-wacom-page.c:525
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "_Close"
+msgstr "_Zarrar"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1764
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Ixuplidar"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"S'usa l'autodiscubrimiento d'o proxy web quan no se proporciona una URL de "
+"configuración."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "No se recomienda ta retz publicos en as qualas no se confida."
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "Proxy"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "_Adhibir un perfil…"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "Furnidor"
+
+#: ../panels/network/network-proxy.ui.h:1
+msgctxt "proxy method"
+msgid "None"
+msgstr "Dengún"
+
+#: ../panels/network/network-proxy.ui.h:2
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "Manual"
+
+#: ../panels/network/network-proxy.ui.h:3
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "Automatico"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "_Metodo"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "URL de _configuración"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "Proxy ta _HTTP"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "Proxy ta H_TTPS"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "Proxy ta _FTP"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "_Servidor socks"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "_Ignorar os anfitrions"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "Puerto ta proxy HTTP"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "Puerto ta proxy HTTPS"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "Puerto ta proxy FTP"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "Puerto ta proxy Socks"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "Amortar o dispositivo"
+
+#: ../panels/network/network.ui.h:1
+msgid "Add Device"
+msgstr "Adhibir un dispositivo"
+
+#: ../panels/network/network.ui.h:2
+msgid "Remove Device"
+msgstr "Sacar o dispositivo"
+
+#: ../panels/network/network-vpn.ui.h:1
+msgid "VPN Type"
+msgstr "Mena de VPN"
+
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Group Name"
+msgstr "Nombre d'a colla"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Password"
+msgstr "Clau d'a colla"
+
+#: ../panels/network/network-vpn.ui.h:5
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "Nombre d'usuario"
+
+#: ../panels/network/network-vpn.ui.h:6
+msgid "Turn VPN connection off"
+msgstr "Zarrar a connexión VPN"
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "_Connexión automatica"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "Detalles"
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "_Clau"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "Denguna"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "Amostrar a _clau"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr "Fer-ne disponible ta la resta d'usuarios"
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "Identidat"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr "Nomás adrezas automaticas (DHCP)"
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr "Nomás o vinclo local"
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr "Compartiu con atros ordinadors"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr "_Ignorar as rotas obtenidas automaticament"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr "Adreza MAC _clonada"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr "hardware"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"Restablir a configuración d'ista connexión a las suyas valors "
+"predeterminadas, pero recordar-la como una connexión favorita."
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"Sacar totz os detalles relativos a iste ret y no tornar a intentar connectar-"
+"se automaticament a ella."
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "Reiniciar"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "Hardware"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr "Punto d'acceso inalambrico"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Turn On"
+msgstr "_Enchegar"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Turn Wi-Fi off"
+msgstr "Amortar o Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_Use as Hotspot…"
+msgstr "_Usar-ne como un punto d'acceso…"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "_Connect to Hidden Network…"
+msgstr "_Connectar-se a un ret amagau…"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "_History"
+msgstr "_Historico"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Amortar ta connectar-se a un ret inalambrico"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Network Name"
+msgstr "Nombre d'o ret"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Connected Devices"
+msgstr "Dispositivos connectaus"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "Security type"
+msgstr "Menade seguranza"
+
+#: ../panels/network/network-wifi.ui.h:63
+msgid "Security key"
+msgstr "Clau de seguranza"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "Infrastructura"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "Estau desconoixiu"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "Sin chestionar"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "No disponible"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "Connectando"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "S'ameneste autenticación"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "Connectau"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "Desconnectando"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "A connexión ha fallau"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "Estau desconoixiu (ausent)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "No connectau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "Ha fallau a configuración"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "Ha fallau a configuración IP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "A configuración IP ha expirau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "S'amenesten secretos, pero no s'han proporcionau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "O suplicant de 802.1x ye desconnectau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "Ha fallau a configuración d'o suplicant de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "Ha fallau o suplicant de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "O suplicant de 802.1x ha tardau muito tiempo en autenticar-se"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "S'ha produciu una error en encetar o servicio de PPP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "Servicio PPP desconnectau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "O PPP ha fallau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "O client DHCP ha fallau en encetar-se"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "S'ha produciu una error en o client DHCP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "Ha fallau o client DHCP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "S'ha produciu una error en encetar o servicio de connexión compartida"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "Ha fallau o servicio de connexión compartida"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "S'ha produciu una error en encetar o servicio d'IP automatica"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "S'ha produciu una error d'o servicio d'IP automatica"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "O servicio d'IP automatica ha fallau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "Linia ocupada"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "No bi ha ton de gritada"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "No s'ha puesto establir o portador"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "Ha expirau lo tiempo de solicitut d'a gritada"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "Intento de gritada falliu"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "Ha fallau a inicialización d'o modem"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "S'ha produciu una error en seleccionar o APN especificau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "No se son mirando retz"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "Rechistro d'o ret denegau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "Ha expirau o tiempo de rechistro d'o ret"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "S'ha produciu una error en rechistrar-se con o ret solicitau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "Ha fallau a comprebación d'o PIN"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "Ye posible que falte o firmware d'o dispositivo"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "A connexión ha desapareixiu"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "S'ha asumiu una connexión existent"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "No s'ha trobau lo modem"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "Ha fallau a connexión Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "A tarcheta SIM no ye ficada"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "S'ameneste o PIN d'a SIM"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "S'ameneste o PUK d'a SIM"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "SIM erronia"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "O dispositivo InfiniBand no suporta o modo connectau"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "Ha fallau a dependencia d'a connexión"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "falta o firmware"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "Cable desconnectau"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "No s'ha trigau dengún certificau de autoridat certificadera"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"No usar un certificau de autoridat certificadera (CA) puet dar puesto a "
+"connexions inseguras a retz inalambricos promiscuos.  Quiers trigar un "
+"certificau d'autoridat certificadera?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "Inorar"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "Triga un certificau d'autoridat certificadera"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "Claus privadas DER, PEM, u PKCS#12 (*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "Certificaus DER u PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+msgid "Choose a PAC file"
+msgstr "Trigar un fichero PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "Fichers PAC (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "Fichero _PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "Autenticación _interna"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "Pro_visión PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "Anonimo"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "Autenticau"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "Totz dos"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "Nombre d'_usuario"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "_Amostrar a clau"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate"
+msgstr "Triga un certificau d'autoridat certificadera"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "Versión 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "Versión 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "Certificau C_A"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "_Versión PEAP"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "_Preguntar ista clau cada vegada"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "As claus privadas sin zifrar son inseguras"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"A clau privada seleccionada no pareix estar protechida por una clau.  Isto "
+"podría permitir que as tuyas credencials de seguranza se comprometesen.  "
+"Selecciona una clau privada protechida por clau.\n"
+"\n"
+"(Puetz protecher a tuya clau privada con una clau con openssl)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+msgid "Choose your personal certificate"
+msgstr "Triga lo tuyo certificau presonal"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+msgid "Choose your private key"
+msgstr "Triga la tuya clau privada"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "I_dentidat"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "Certificau de l'_usuario"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "Clau pri_vada"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "clau de clau pri_vada"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "No al_vertir-me de nuevo"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "No"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "Sí"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "TLS a traviés d'un túnel"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "EAP protechiu (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "Au_tenticación"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (Predeterminau)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "Sistema ubierto"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "Clau compartida"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "_Clau"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "_Amostrar a clau"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "In_diz WEP"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "_Mena"
+
+#: ../panels/notifications/cc-notifications-panel.c:257
+#: ../panels/power/cc-power-panel.c:1840 ../panels/power/cc-power-panel.c:1847
+#: ../panels/privacy/cc-privacy-panel.c:155
+#: ../panels/privacy/cc-privacy-panel.c:222
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "Encendiu"
+
+#. This is the per application switch for message tray usage.
+#: ../panels/notifications/edit-dialog.ui.h:2
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "Notificacions"
+
+#. This is the setting to configure sounds associated with notifications.
+#: ../panels/notifications/edit-dialog.ui.h:4
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "Alertas de son"
+
+#: ../panels/notifications/edit-dialog.ui.h:5
+msgctxt "notifications"
+msgid "Notification Banners"
+msgstr "Banners de notificación"
+
+#. Banners here refers to message tray notifications in the middle of the screen.
+#: ../panels/notifications/edit-dialog.ui.h:7
+msgctxt "notifications"
+msgid "Show Message Content in Banners"
+msgstr "Amostrar o conteniu d'o mensache en os banners"
+
+#: ../panels/notifications/edit-dialog.ui.h:8
+msgctxt "notifications"
+msgid "Lock Screen Notifications"
+msgstr "Notificacions d'a pantalla de bloqueyo"
+
+#: ../panels/notifications/edit-dialog.ui.h:9
+msgctxt "notifications"
+msgid "Show Message Content on Lock Screen"
+msgstr "Amostrar o conteniu d'o mensache en a pantalla de bloqueyo"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "Notificacions"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controlar qué notificacions s'amuestran"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "notificacions;anuncio;mensache;servilla;emerchent;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Notification Banners"
+msgstr "Banners de notificación"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Lock Screen Notifications"
+msgstr "Notificacions d'a pantalla de bloqueyo"
+
+#. List of applications.
+#: ../panels/notifications/notifications.ui.h:4
+#: ../panels/sound/gvc-mixer-dialog.c:1781
+msgid "Applications"
+msgstr "Aplicacions"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Atra"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:290
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "Adhibir una cuenta"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:329
+msgid "Mail"
+msgstr "Correu"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:335
+msgid "Contacts"
+msgstr "Contactos"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:341
+msgid "Chat"
+msgstr "Chat"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:347
+msgid "Resources"
+msgstr "Recursos"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:422
+msgid "Error logging into the account"
+msgstr "S'ha produciu una error en encetar a sesión en a cuenta"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:492
+msgid "Credentials have expired."
+msgstr "As credencials han caducau."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:496
+msgid "Sign in to enable this account."
+msgstr "Encieta la sesión ta activar ista cuenta."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:501
+msgid "_Sign In"
+msgstr "Encetar a _sesión"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:748
+msgid "Error creating account"
+msgstr "S'ha produciu una error en creyar a cuenta"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:808
+msgid "Error removing account"
+msgstr "S'ha produciu una error en sacar a cuenta"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:844
+msgid "Are you sure you want to remove the account?"
+msgstr "Yes seguro que quiers sacar a cuenta?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:846
+msgid "This will not remove the account on the server."
+msgstr "Isto no sacará la cuenta en o servidor."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:847
+msgid "_Remove"
+msgstr "_Sacar"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "Cuentas en linia"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Connectar-se a las tuyas cuentas en linia y decidir ta qué usar-las"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Ret;En linia;Chat;Calandario;Correu;Contacto;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocha;Leyer-loDimpués;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "No bi ha cuentas en linia configuradas"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "Sacar a cuenta"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "Adhibir una cuenta en linia"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"adhibir una cuenta premite que as tuyas aplicacions accedeixcan a "
+"documentos, correu-y, contactos, calandario, chat y mas."
+
+#: ../panels/power/cc-power-panel.c:200
+msgid "Unknown time"
+msgstr "Tiempo desconoixiu"
+
+#: ../panels/power/cc-power-panel.c:206
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i menuto"
+msgstr[1] "%i menutos"
+
+#: ../panels/power/cc-power-panel.c:218
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hora"
+msgstr[1] "%i horas"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:226
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:227
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hora"
+msgstr[1] "horas"
+
+#: ../panels/power/cc-power-panel.c:228
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "menuto"
+msgstr[1] "menutos"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:247
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s dica que se cargue de raso"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:254
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Alvertencia: quedan %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:259
+#, c-format
+msgid "%s remaining"
+msgstr "%s restant"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:264 ../panels/power/cc-power-panel.c:292
+msgid "Fully charged"
+msgstr "Cargada de raso"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:268 ../panels/power/cc-power-panel.c:296
+msgid "Empty"
+msgstr "Vueda"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:283
+msgid "Charging"
+msgstr "Cargando"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:288
+msgid "Discharging"
+msgstr "Descargando"
+
+#: ../panels/power/cc-power-panel.c:411
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Prencipal"
+
+#: ../panels/power/cc-power-panel.c:413
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Adicional"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:484
+msgid "Wireless mouse"
+msgstr "Ratet inalambrico"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:487
+msgid "Wireless keyboard"
+msgstr "Teclau inalambrico"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:490
+msgid "Uninterruptible power supply"
+msgstr "Fuent d'alimentación no interrumpible"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:493
+msgid "Personal digital assistant"
+msgstr "Asistent dichital presonal"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:496
+msgid "Cellphone"
+msgstr "Telefono mobil"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:499
+msgid "Media player"
+msgstr "Reproductor multimeya"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:502
+msgid "Tablet"
+msgstr "Tableta"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:505
+msgid "Computer"
+msgstr "Ordinador"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:508 ../panels/power/cc-power-panel.c:748
+#: ../panels/power/cc-power-panel.c:2095
+msgid "Battery"
+msgstr "Bateria"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Cargando"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:569
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Alvertencia"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:574
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Baixa"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:579
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Buena"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:584
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Cargada de raso"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:588
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Vueda"
+
+#: ../panels/power/cc-power-panel.c:746
+msgid "Batteries"
+msgstr "Baterías"
+
+#: ../panels/power/cc-power-panel.c:1167
+msgid "When _idle"
+msgstr "Quan siga _inactivo"
+
+#: ../panels/power/cc-power-panel.c:1547
+msgid "Power Saving"
+msgstr "Cabido d'enerchía"
+
+#: ../panels/power/cc-power-panel.c:1582
+msgid "_Screen brightness"
+msgstr "_Brilo d'a pantalla"
+
+#: ../panels/power/cc-power-panel.c:1601
+#| msgid "Automatic Routes"
+msgid "Automatic brightness"
+msgstr "Brilo automatico"
+
+#: ../panels/power/cc-power-panel.c:1621
+msgid "_Keyboard brightness"
+msgstr "Brilo d'o _teclau"
+
+#: ../panels/power/cc-power-panel.c:1631
+msgid "_Dim screen when inactive"
+msgstr "_Enfoscar a pantalla quan siga inactiva"
+
+#: ../panels/power/cc-power-panel.c:1656
+msgid "_Blank screen"
+msgstr "_Amortar a pantalla"
+
+#: ../panels/power/cc-power-panel.c:1693
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: ../panels/power/cc-power-panel.c:1698
+msgid "Wireless devices require extra power"
+msgstr "Os dispositivos inalámbricos requieren enerchía adicional"
+
+#: ../panels/power/cc-power-panel.c:1723
+msgid "_Mobile broadband"
+msgstr "Banda ampla _mobil"
+
+#: ../panels/power/cc-power-panel.c:1728
+msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
+msgstr ""
+"Os dispositivos de banda ampla mobil (3G, 4G, WiMax, etc.) requieren "
+"enerchía adicional"
+
+#: ../panels/power/cc-power-panel.c:1780
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: ../panels/power/cc-power-panel.c:1836
+msgid "When on battery power"
+msgstr "En modo batería"
+
+#: ../panels/power/cc-power-panel.c:1838
+msgid "When plugged in"
+msgstr "Quan ye connectau a o ret"
+
+#: ../panels/power/cc-power-panel.c:1955
+msgid "Suspend & Power Off"
+msgstr "Suspender y amortar"
+
+#: ../panels/power/cc-power-panel.c:1995
+msgid "_Automatic suspend"
+msgstr "Suspender _automaticament"
+
+#: ../panels/power/cc-power-panel.c:2149
+msgid "Devices"
+msgstr "Dispositivos"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "Enerchía"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Veyer o estau d'a batería y cambiar a configuración d'estalbio d'enerchía"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"Enerchía;Adormir;Suspender;Hibernar;Batería;Brilo;Amortar;Monitor;DPMS;"
+"inactivo;"
+
+#: ../panels/power/power.ui.h:3
+msgid "45 minutes"
+msgstr "45 menutos"
+
+#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 hora"
+
+#: ../panels/power/power.ui.h:5
+msgid "80 minutes"
+msgstr "80 menutos"
+
+#: ../panels/power/power.ui.h:6
+msgid "90 minutes"
+msgstr "90 menutos"
+
+#: ../panels/power/power.ui.h:7
+msgid "100 minutes"
+msgstr "100 menutos"
+
+#: ../panels/power/power.ui.h:8
+msgid "2 hours"
+msgstr "2 horas"
+
+#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 menuto"
+
+#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 menutos"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 menutos"
+
+#: ../panels/power/power.ui.h:12
+msgid "4 minutes"
+msgstr "4 menutos"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 menutos"
+
+#: ../panels/power/power.ui.h:14
+msgid "8 minutes"
+msgstr "8 menutos"
+
+#: ../panels/power/power.ui.h:15
+msgid "10 minutes"
+msgstr "10 menutos"
+
+#: ../panels/power/power.ui.h:16
+msgid "12 minutes"
+msgstr "12 menutos"
+
+#: ../panels/power/power.ui.h:18
+msgid "Automatic Suspend"
+msgstr "Suspender automaticament"
+
+#: ../panels/power/power.ui.h:19
+msgid "_Plugged In"
+msgstr "_Enchufau"
+
+#: ../panels/power/power.ui.h:20
+msgid "On _Battery Power"
+msgstr "Usando a _batería"
+
+#: ../panels/power/power.ui.h:21
+msgid "Delay"
+msgstr "Retardo"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "Autenticar-se"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "Clau"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "Se requier autenticación"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:588
+msgid "Low on toner"
+msgstr "Tóner baixo"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Out of toner"
+msgstr "Sin tóner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:593
+msgid "Low on developer"
+msgstr "Libel de revelador baixo"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:596
+msgid "Out of developer"
+msgstr "Sin revelador"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Low on a marker supply"
+msgstr "Marcador baixo"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Out of a marker supply"
+msgstr "Sin marcador"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Open cover"
+msgstr "Ubrir a cubierta"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open door"
+msgstr "Ubrir a puerta"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Low on paper"
+msgstr "Libel de paper baixo"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Out of paper"
+msgstr "Sin paper"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:610
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Desconnectada"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:612
+#: ../panels/printers/cc-printers-panel.c:803
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Aturada"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:614
+msgid "Waste receptacle almost full"
+msgstr "Recipient de residuos quasi pleno"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle full"
+msgstr "Recipient de residuos pleno"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "The optical photo conductor is near end of life"
+msgstr "O conductor optico ye amán d'a final d'a vida d'ell"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is no longer functioning"
+msgstr "O conductor optico ya no funciona"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:730
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "Configurando"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:789
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Parada"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:794
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "No acceptar treballos"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:799
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Procesando"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:919
+msgid "Toner Level"
+msgstr "Libel d'o tóner"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Ink Level"
+msgstr "Libel de tinta"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Supply Level"
+msgstr "Libel d'o suministro"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:943
+msgctxt "printer state"
+msgid "Installing"
+msgstr "Instalando"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1119
+msgid "No printers available"
+msgstr "No bi ha impresoras disponibles"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1429
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u activo"
+msgstr[1] "%u activos"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1770
+msgid "Failed to add new printer."
+msgstr "S'ha produciu una error en adhibir una impresora nueva."
+
+#: ../panels/printers/cc-printers-panel.c:1937
+msgid "Select PPD File"
+msgstr "Seleccionar un fichero PPD"
+
+#: ../panels/printers/cc-printers-panel.c:1946
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Fichers de descripción d'impresora PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+"gz, *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2253
+msgid "No suitable driver found"
+msgstr "No s'ha trobau dengún controlador adequau"
+
+#: ../panels/printers/cc-printers-panel.c:2324
+msgid "Searching for preferred drivers…"
+msgstr "Buscando os controladors preferius…"
+
+#: ../panels/printers/cc-printers-panel.c:2345
+msgid "Select from database…"
+msgstr "Seleccionar dende a base de datos…"
+
+#: ../panels/printers/cc-printers-panel.c:2354
+msgid "Provide PPD File…"
+msgstr "Proporcionar un fichero PPD…"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2505
+#: ../panels/printers/cc-printers-panel.c:2528
+msgid "Test page"
+msgstr "Pachina de preba"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2942
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "No s'ha puesto cargar a IU: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "Impresoras"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Adhibir impresoras, veyer os treballos d'a impresora y decidir quál quiers "
+"imprentar"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Impresora;Coda;Imprentar;Paper;Tinta;Tóner;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "Treballos activos"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "Zarrar"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "Reprener a impresión"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "Pausar a impresión"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "Cancelar o treballo d'impresión"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "Adhibir una impresora nueva"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "A_uthenticate"
+msgstr "A_utenticar-se"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "No s'ha detectau garra impresora."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter a network address or search for a printer"
+msgstr "Introduzca una adreza de ret u busque una impresora"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "Cargando as opcions…"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "Seleccionar o controlador d'a impresora"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "Cargando as bases de datos de controladors…"
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+msgid "JetDirect Printer"
+msgstr "Impresora JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+msgid "LPD Printer"
+msgstr "Impresora LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "Una cara"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "Marguin larga (estandar)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "Marguin curta (chirar)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "Vertical"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "Apaisau"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "Apaisau invertiu"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "Vertical invertiu"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "Pendient"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "Reteniu"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "Procesando"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Aturau"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Cancelau"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Abortau"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "Completau"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "Titol d'o treballo"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "Estau d'o treballo"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "Hora"
+
+#: ../panels/printers/pp-jobs-dialog.c:451
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s treballos activos"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1620
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1625
+msgid "Serial Port"
+msgstr "Puerto serie"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1632
+msgid "Parallel Port"
+msgstr "Puerto paralelo"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+#, c-format
+msgid "Location: %s"
+msgstr "Ubicación: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1693
+#, c-format
+msgid "Address: %s"
+msgstr "Adreza: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1717
+msgid "Server requires authentication"
+msgstr "O servidor amenista d'autenticación"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "Dos caras"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "Mena de paper"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "Fuent de paper"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "Servilla de salida"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "Prefiltrau GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:533
+msgid "Pages per side"
+msgstr "Pachinas por cara"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:545
+msgid "Two-sided"
+msgstr "Dos caras"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:557
+msgid "Orientation"
+msgstr "Orientación"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Cheneral"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Configuración de pachina"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opcions instalables"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Treballo"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Calidat d'a imachen"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Color"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Rematando"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:675
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Abanzau"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "Seleccionar automaticament"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "Impresora predeterminada"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "Nomás empotrar as fuents GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "Convertir ta PS de libel 1"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "Convertir ta PS de libel 2"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "Sin prefiltrau"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "Fabricant"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Controlador"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"Introduz o tuyo nombre d'usuario y a tuya clau ta veyer as impresoras "
+"disponibles en %s."
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "Adhibir a impresora"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "Sacar a impresora"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "Suministro"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "Ubicación"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default printer"
+msgstr "Impresora pre_determinada"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "Treballos"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "Amostrar os _treballos"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "Modelo"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "Etiqueta"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "Seye establindo o nuevo controlador…"
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "Pachina 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "Impren_tar a pachina de preba"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "_Opcions"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "Adhibir una impresora nueva"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"O servicio d'o sistema d'impresión\n"
+"pareix no estar disponible."
+
+#: ../panels/privacy/cc-privacy-panel.c:352 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "Bloqueyo de pantalla"
+
+#: ../panels/privacy/cc-privacy-panel.c:462 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "Uso y historico"
+
+#: ../panels/privacy/cc-privacy-panel.c:587
+msgid "Empty all items from Trash?"
+msgstr "Vuedar totz os elementos d'a papelera?"
+
+#: ../panels/privacy/cc-privacy-panel.c:588
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Totz os elementos d'a papelera serán esborraus permanentment."
+
+#: ../panels/privacy/cc-privacy-panel.c:589 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "_Vuedar a papelera"
+
+#: ../panels/privacy/cc-privacy-panel.c:612
+msgid "Delete all the temporary files?"
+msgstr "Esborrar totz os ficheros temporals?"
+
+#: ../panels/privacy/cc-privacy-panel.c:613
+msgid "All the temporary files will be permanently deleted."
+msgstr "Totz os fichers temporals serán esborraus permanentment."
+
+#: ../panels/privacy/cc-privacy-panel.c:614 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "_Limpiar os fichers temporals"
+
+#: ../panels/privacy/cc-privacy-panel.c:636 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "Vuedar a papelera y os fichers temporals"
+
+#: ../panels/privacy/cc-privacy-panel.c:676 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr "Emplego d'o software"
+
+#: ../panels/privacy/cc-privacy-panel.c:717 ../panels/privacy/privacy.ui.h:44
+msgid "Problem Reporting"
+msgstr "Informar d'una error"
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: ../panels/privacy/cc-privacy-panel.c:731
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+"Ninviar informes de problemas tecnicos aduya a amillorar %s. Los informes se "
+"ninvian anonimament y no contienen datos personals."
+
+#: ../panels/privacy/cc-privacy-panel.c:743 ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "Politica deprivacidat"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "Privacidat"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+"Protecher a tuya información presonal y controlar qué pueden veyer atros"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"pantalla;bloqueyo;dianostico;error;privau;recient;temporal;tmp;indiz;nombre;"
+"ret;identidat;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "S'amorta la pantalla"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 segundos"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 diya"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 diyas"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 diyas"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 diyas"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 diyas"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 diyas"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 diyas"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 diyas"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 diyas"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "Perén"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"Remerar o tuyo historico fa que siga mas sencillo buscar as cosetas de "
+"nuevo. Istos elementos nunca no se comparten en o ret."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "Usaus _recientment"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "Remerar l'_historico"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "Limpiar l'historico r_ecient"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "A pantalla de bloqueyo proteche a tuya privacidat quan yes ausent."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "_Bloqueyo de pantalla automatico"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "B_loqueyar a pantalla dimpués de"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "Amostrar AS _notificacions"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"Limpiar automaticament os fichers temporals y d'a Papelera ta aduyar-te a "
+"mantener o tuyo equipo libre d'información sensible."
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "Vuedar automa_ticament a papelera"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "Li_mpiar os fichers temporals automaticament"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "Limpiar _dimpués de"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our software."
+"\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"Ninviando-nos información arredol de qué software fas servir nos aduya "
+"furnir-te recomendacions con mas precisión. Tamién nos aduya a amillorar o "
+"nuestro software.\n"
+"\n"
+"Toda la información que replegamos ye feita anonyma, y nunca no "
+"compartiremos os tuyos datos con tercers."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "_Ninviar estatisticas d'emplego d'o software"
+
+#: ../panels/privacy/privacy.ui.h:42
+msgid "_Location Services"
+msgstr "Servicios d'_ubicación"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "S'usa tadeterminar atuya localización cheografica"
+
+#: ../panels/privacy/privacy.ui.h:45
+msgid "_Automatic Problem Reporting"
+msgstr "Informar d'un problema _automaticament"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrico"
+
+#: ../panels/region/cc-format-chooser.c:286
+msgid "No regions found"
+msgstr "No s'han trobau rechions"
+
+#: ../panels/region/cc-input-chooser.c:180
+msgid "No input sources found"
+msgstr "No s'han trobau fuents de dentrada"
+
+#: ../panels/region/cc-input-chooser.c:1085
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Atra"
+
+#: ../panels/region/cc-region-panel.c:247
+#: ../panels/user-accounts/um-user-panel.c:1071
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Cal reiniciar a sesión ta que s'apliquen os cambeos"
+
+#: ../panels/region/cc-region-panel.c:251
+#: ../panels/user-accounts/um-user-panel.c:1075
+msgid "Restart Now"
+msgstr "Reiniciar-ne agora"
+
+#: ../panels/region/cc-region-panel.c:876
+msgid "No input source selected"
+msgstr "No s'ha seleccionau garra fuent de dentrada"
+
+#: ../panels/region/cc-region-panel.c:1796
+msgid "Login Screen"
+msgstr "Pantalla d'inicio de sesión"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "Formatos"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "Anvista previa"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "Calendatas"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "Horas"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "Numeros"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "Mesura"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "Paper"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "Rechión y idioma"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"Selecciona o tuyo idioma, formatos, distribucions de teclau y fuents de "
+"dentrada"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Idioma;Distribución;Teclau;Dentrada;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "Adhibir una fuent de dentrada"
+
+#: ../panels/region/input-chooser.ui.h:4
+msgid "Input methods can't be used on the login screen"
+msgstr ""
+"Os metodos de dentrada no se pueden usar en a pantalla d'inicio de sesión"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "Opcions d'as fuents de dentrada"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Use the _same source for all windows"
+msgstr "Usar a _mesma fuent ta todas as finestras"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Allow _different sources for each window"
+msgstr "Premitir _diferents fuents ta cada finestra"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Keyboard Shortcuts"
+msgstr "Alcorces de teclau"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Switch to previous source"
+msgstr "Cambiar a la fuent anterior"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Super+Shift+Space"
+msgstr "Súper+Mayús+Espacio"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Switch to next source"
+msgstr "Cambiar a la fuent siguient"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "Puetz cambiar istos alcorces en a configuración d'o teclau"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Alternative switch to next source"
+msgstr "Cambeo alternativo a la fuent siguient"
+
+#: ../panels/region/input-options.ui.h:12
+msgid "Left+Right Alt"
+msgstr "Cucha + Alt dreita"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "Anglés (Reino Uniu)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "Reino Uniu"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "Opcions"
+
+#: ../panels/region/region.ui.h:7
+msgid "Add input source"
+msgstr "Adhibir fuent de dentrada"
+
+#: ../panels/region/region.ui.h:8
+msgid "Remove input source"
+msgstr "Sacar fuent de dentrada"
+
+#: ../panels/region/region.ui.h:9
+msgid "Move input source up"
+msgstr "Puyar a fuent de dentrada"
+
+#: ../panels/region/region.ui.h:10
+msgid "Move input source down"
+msgstr "Baixar a fuent de dentrada"
+
+#: ../panels/region/region.ui.h:11
+msgid "Configure input source"
+msgstr "Configurar fuent de dentrada"
+
+#: ../panels/region/region.ui.h:12
+msgid "Show input source keyboard layout"
+msgstr "Amostrar a distribución d'o teclau d'a fuent de dentrada"
+
+#: ../panels/region/region.ui.h:13
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"A configuración d'inicio de sesión la usan totz os usuarios quan encietan a "
+"sesión en o sistema"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr "Puestos"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "Marcapachinas"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr "Atra"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "Seleccionar una ubicación"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+msgid "_OK"
+msgstr "_Acceptar"
+
+#: ../panels/search/cc-search-panel.c:177
+msgid "No applications found"
+msgstr "No s'han trobau aplicacions"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "Buscar"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controlar qué aplicacions amuestran resultaus de busca en l'anvista de "
+"actividatz"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "buscar;busca;indiz;amagar;privacidat;resultaus;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "Buscar ubicacions"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "Puyar"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "Baixar"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Encendiu"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Amortau"
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Activau"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+msgctxt "service is active"
+msgid "Active"
+msgstr "activo"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "Triga una carpeta"
+
+#: ../panels/sharing/cc-sharing-panel.c:917
+msgid "Copy"
+msgstr "Copiar"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "Compartir"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "Controla qué quiers compartir con atros"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"compartir;compartición;ssh;equipo;remoto;escritorio:bluetooth;obex;multimeya;"
+"son:video;imachens;fotos;cintas;servidor;renderizau;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "Activar u desactivar l'inicio de sesión remota"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Se requier autenticación ta activar u desactivar l'inicio de sesión remota"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:303
+msgid "No networks selected for sharing"
+msgstr "No bi ha retz seleccionaus ta compartir"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "Retz"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "Compartición por Bluetooth"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"A compartición por Bluetooth te permite compartir fichers con atros "
+"dispositivos con o Bluetooth activau"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "Recibir nomás dende dispositivos de confianza"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "Alzar os fichers recibius en a carpeta de descargas"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "Nombre de l'ordinador"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "Compartición de fichers presonals"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "Compartición d'a pantalla"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "Compartición multimeya"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "Encieto de sesión remoto"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "S'han desactivau qualques servicios porque no bi ha acceso a lo ret."
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"A compartición de fichers presonals te permite compartir a tuya carpeta "
+"Publica con atros en o tuyo ret actual usando: <a href=\"dav://%s\">dav://"
+"%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr "Solicitar a clau"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"Premitir a os usuarios remotos connectar-se usando o comando de shell "
+"segura:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a "
+"href=\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"Premitir a os usuarios remotos veyer u controlar a tuya pantalla connectando-"
+"se ta: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Allow Remote Control"
+msgstr "Activar o control remoto"
+
+#: ../panels/sharing/sharing.ui.h:21
+msgid "Password:"
+msgstr "Clau:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "Amostrar a clau"
+
+#: ../panels/sharing/sharing.ui.h:23
+msgid "Access Options"
+msgstr "Opcions d'acceso"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "As nuevas connexions deben preguntar por l'acceso"
+
+#: ../panels/sharing/sharing.ui.h:25
+msgid "Require a password"
+msgstr "Solicitar a clau"
+
+#: ../panels/sharing/sharing.ui.h:26
+msgid ""
+"Media sharing allows you to share music, photos and videos over the network."
+msgstr ""
+"A compartición de meyos le permite compartir mosica, fotos y videos por meyo "
+"d'o ret."
+
+#: ../panels/sharing/sharing.ui.h:27
+msgid "Folders"
+msgstr "Carpetas"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "Son"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Cambiar o volumen de dentrada y salida de son y as alertas sonoras"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr ""
+"tarcheta;microfono;volumen;esvaneixer;balanz;bluetooth;cascos;auriculars;son;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "Ladriu"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "Goteyo"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "Vaso"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "Sonar"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "Cucho"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "Dreito"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "Trasero"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "Frontal"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Minimo"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Maximo"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "_Balanz:"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "_Esvaneiximiento:"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "_Subwoofer:"
+
+#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:615
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Sin amplificar"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
+#: ../panels/sound/gvc-mixer-dialog.c:515
+msgid "_Profile:"
+msgstr "_Perfil:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u salida"
+msgstr[1] "%u salidas"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u dentrada"
+msgstr[1] "%u dentradas"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "Sons d'o sistema"
+
+#: ../panels/sound/gvc-mixer-dialog.c:251
+msgid "_Test Speakers"
+msgstr "_Prebar os altavoces"
+
+#: ../panels/sound/gvc-mixer-dialog.c:420
+msgid "Peak detect"
+msgstr "Detección de picos"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1493
+#: ../panels/sound/gvc-sound-theme-chooser.c:564
+msgid "Name"
+msgstr "Nombre"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1512
+msgid "Device"
+msgstr "Dispositivo"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1575
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "Preba d'altavoces ta %s"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1631
+msgid "_Output volume:"
+msgstr "Volumen de sali_da:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1645
+msgid "Output"
+msgstr "Salida"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1650
+msgid "C_hoose a device for sound output:"
+msgstr "_Trigar un dispositivo ta la salida de son:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1672
+msgid "Settings for the selected device:"
+msgstr "Configuración ta lo dispositivo seleccionau:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1683
+msgid "Input"
+msgstr "Dentrada"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1690
+msgid "_Input volume:"
+msgstr "Volumen de _dentrada:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "Input level:"
+msgstr "Libel de dentrada:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1737
+msgid "C_hoose a device for sound input:"
+msgstr "_Trigar un dispositivo ta la dentrada de son:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1761
+msgid "Sound Effects"
+msgstr "Efectos de son"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1768
+msgid "_Alert volume:"
+msgstr "Volumen de _alerta:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1785
+msgid "No application is currently playing or recording audio."
+msgstr "Actualment garra aplicación ye reproducindo u gravando son."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "Integrau"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "Preferencias de son"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "Comprebando o son d'evento"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:554
+msgid "Default"
+msgstr "Predeterminau"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:555
+msgid "From theme"
+msgstr "D'o tema"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:740
+msgid "C_hoose an alert sound:"
+msgstr "_Trigar un son d'alerta:"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "Aturar"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "Prebar"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "Presonalizau"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Fer mas sencillo de veyer, escuitar, escribir y apuntar y pretar"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"Teclau;Ratet;a11y;Accesibilidat;Contraste;Zoom;Pantalla;Lector;texto;fuent;"
+"Grandaria;AccessX;Persistents;Teclas;Lentas;Refuso;Ratet;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "_Amostrar siempre o menú d'acceso universal"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "Visión"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "_Alto contraste"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "Texto _gran"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr "Lecto_r de pantalla"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "_Sound Keys"
+msgstr "Teclas de_son"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "Audición"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr "Alertas _visuals"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Screen _Keyboard"
+msgstr "_Teclau en pantalla"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "_Typing Assist (AccessX)"
+msgstr "Asis_tent d'Escritura (AccessX)"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Pointing & Clicking"
+msgstr "Apuntar y pretar"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "_Mouse Keys"
+msgstr "_Teclas d'o ratet"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "Asistent de _clic"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "Lector de pantalla"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "O lector de pantalla leye o texto amostrau en que vas movendo lo foco."
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Screen Reader"
+msgstr "_Lector de pantalla"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Sound Keys"
+msgstr "Teclas de son"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "Chuflar quan o Bloq. Num. u lo Bloq. Mayús. sigan enchegaus."
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "Alertas visuals"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "_Prebar os destellos"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Usar una indicación visual quan ocurra una alerta de son."
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Flash the _window title"
+msgstr "Destello d'a barra de titol d'a _finestra"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Flash the entire _screen"
+msgstr "De_stello d'a pantalla completa"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Typing Assist"
+msgstr "Asistent d'Escritura"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "_Sticky Keys"
+msgstr "Tecla_s persistents"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Tracta una seqüencia de teclas modificaderas como una combinación de teclas"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desactivar-ne si se pretan dos teclas a la vegada"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pitar en pretar una tecla _modificadera"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "S_low Keys"
+msgstr "Teclas _lentas"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introduz un retardo en pretar una tecla y quan ista s'accepta"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "R_etardo d'acceptación:"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curto"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "Retardo d'as teclas lentas en escribir"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Luengo"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Beep when a key is pr_essed"
+msgstr "Chuflar _en que se preta una tecla"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Beep when a key is _accepted"
+msgstr "Chuflar en que s'_accepta una tecla"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "Chuflar en _refusar una tecla"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "_Bounce Keys"
+msgstr "_Refuso de teclas"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "Inorar as pulsacions duplicadas rapidas"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curto"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "Retardo de pulsación d'o refuso de teclas"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Luengo"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Enable by Keyboard"
+msgstr "Activar-ne por t_eclau"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Activar as caracteristicas d'accesibilidat usando o teclau"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "Asistent de clic"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "_Simulated Secondary Click"
+msgstr "Clic secundario _simulau"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Disparar un clic secundario en mantener pretau o botón primario"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curto"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "Retardo d'o clic secundario"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Luengo"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "_Hover Click"
+msgstr "Clic en pasar p_or dencima"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "Disparar un clic en posicionar o puntero"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "R_etardo:"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curto"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Luengo"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "Branquil de _movimiento:"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Chicot"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Gran"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "Curta"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ de pantalla"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ pantalla"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ de pantalla"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "Larga"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "Pantalla completa"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "Metat superior"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "Metat inferior"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "Metat cucha"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "Metat dreita"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "Opcions d'ampliación"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "Ampliación"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "Magnificación:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "Siguir a lo cursor d'o ratet"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "Parti d'a pantalla:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "O manificador s'extiende difuera d'a pantalla"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "Mantener centrau o cursor d'o manificador"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "O cursor d'o manificador empenta o conteniu ta l'arredol d'ell"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "O cursor d'o manificador se mueve con o conteniu"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "Posición d'o manificador:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "Manificador"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "Grosor:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Fino"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Recio"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "Longaria:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "Color:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "Cruces:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "Solapa lo cursor d'o ratet"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "Cruces"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "Blanco sobre negro:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "Brilo:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "Contraste:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "Color"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Denguna"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Completa"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Baixo"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alto"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Baixo"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alto"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "Efectos de color:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "Efectos de color"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Estandar"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Administrador"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Full Name"
+msgstr "Nombre _completo"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "_mena de cuenta"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to set a password when they next login"
+msgstr "Permitir a l'usuario trigar una clau en o siguient inicio de sesión"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "Establir una clau agora"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "_Verificar"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"L'encieto de sesión corporativo permite que se faiga servir una cuenta "
+"d'usuario chestionada de traza centralizada en iste dispositivo."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "_Dominio"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"Conecta-te ta adhibir\n"
+"cuentas d'encieto de sesión corporativo."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "Encieto de s_esión corporativo"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1466
+msgid "Add User"
+msgstr "Adhibir un usuario"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "_Unir"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "Encieto de sesión de l'administrador d'o dominio"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Ta usar inicios de sesión corporativos, iste equipo ameneste\n"
+"formar parti d'un dominio. Pide a l'administrador d'o tuyo\n"
+"sistema que escriba aquí a clau d'o dominio."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "_Nombre de l'administrador"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "Clau d'administrador"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "Dedo gordo cucho"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "Dido meyo cucho"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "Dido aniello cucho"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "Dido currín cucho"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "Dido gran dreito"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "Dido meyo dreito"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "Dido aniello dreito"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "Dido currín dreito"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:686
+msgid "Enable Fingerprint Login"
+msgstr "Activar l'inicio de sesión con a ditalada"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "Dido indiz _dreito"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "Dido indiz _cucho"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "_Atro dido:"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"A tuya ditalada s'alzó correctament. Agora habrías de poder encetar a sesión "
+"en usando o tuyo lector de ditaladas."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "Usuarios"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "Adhibir u sacar usuarios y cambiar as claus d'ells"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "inicio de sesión;nombre;ditalada;avatar;logo;cara;clau;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "Historico d'inicio de sesión"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr "Cambiar a clau"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "Cam_biar"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "_Verificar a Clau nueva"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "Clau _nueva"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "Clau _actual"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "Adhibir una cuenta d'usuario"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "Sacar una cuenta d'usuario"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "Opcions d'inicio de sesión"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "_Encieto de sesión automatico"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "Encieto de sesión con a _ditalada"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "Icono d'usuario"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "_Idioma"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "Zaguer inicio de sesión"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "Chestionar as cuentas d'usuario"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "Se requier autenticación ta cambiar os datos de l'usuario"
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "A nueva clau debe estar diferent de l'antiga."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Preba cambiando bellas letras y numeros."
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Preba a cambiar a clau una mica más."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Una clau sin o tuyo nombre d'usuario será mas rebusta."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Preba a privar usar o tuyo nombre en a clau."
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Preba a privar bellas d'as parolas incluidas en a clau."
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Preba a privar as parolas comuns."
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Preba a privar reordenar as parolas existents."
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Preba a emplegar mas numeros."
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Preba a emplegar mas letras mayusclas."
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Preba a emplegar mas letras minusclas."
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Preba a emplegar mas caracters especials, como puntuación."
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+"Preba a fer servir una mezcla de letras, numeros y simbolos depuntuación."
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Preba a privar repetir o mesmo caracter."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Preba a privar repetir a mesma mena de caracter: Cal mezclar letras, numeros "
+"y simbolos de puntuación."
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Preba a privar as seqüencias como 1234 u abc."
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "Preba a adhibir mas letras, numeros y simbolos."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr "Mezcla letras mayusclas y minusclas y emplega un numero u dos."
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+"Clau buena. Preba a adhibir mas letras, numeros y simbolos de puntuación ta "
+"fer-la mas rebusta."
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "Fortidura: Feble"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "Fortidura: Baixa"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "Fortidura: Meya"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "Fortidura: Buena"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "Fortidura: Alta"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "Ha fallau l'autenticación"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "A nueva clau ye masiau curta"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "A nueva clau ye masiau simpla"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "A antiga clau y a nueva son masiau semellants"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "A nueva clau ya s'ha usau recientment."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "A nueva clau debe contener caracters numericos u especials"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "A nueva clau y l'antiga son a mesma"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "S'ha cambiau a tuya clau dende que t'autentiqués inicialment!"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "A nueva clau no contién suficients caracters diferents"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "Error desconoixida"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "Cal que coincida con l'adreza web d'o tuyo furnidor d'a cuenta."
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "S'ha produciu una error en adhibir a cuenta"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+msgid "Passwords do not match."
+msgstr "As claus no coinciden."
+
+#: ../panels/user-accounts/um-account-dialog.c:733
+#: ../panels/user-accounts/um-account-dialog.c:779
+#: ../panels/user-accounts/um-account-dialog.c:800
+msgid "Failed to register account"
+msgstr "S'ha produciu una error en rechistrar a cuenta"
+
+#: ../panels/user-accounts/um-account-dialog.c:923
+msgid "No supported way to authenticate with this domain"
+msgstr "No bi ha una traza suportada d'autenticar-se con iste dominio"
+
+#: ../panels/user-accounts/um-account-dialog.c:982
+msgid "Failed to join domain"
+msgstr "S'ha produciu una error en unir-se a lo dominio"
+
+#: ../panels/user-accounts/um-account-dialog.c:1043
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"Ixe nombre d'encieto de sesión no ha marchau.\n"
+"Intenta-lo de nuevas."
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"Ixa clau d'encieto de sesión no ha marchau.\n"
+"Intenta-lo de nuevas."
+
+#: ../panels/user-accounts/um-account-dialog.c:1058
+msgid "Failed to log into domain"
+msgstr "S'ha produciu una error en encetar a sesión en o dominio"
+
+#: ../panels/user-accounts/um-account-dialog.c:1116
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "No s'ha puesto trobar o dominio. ¿En ye bien escrito?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:138
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"No te ye premitiu accedir a lo dispositivo. Contacta con l'administrador d'o "
+"tuyo sistema."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:140
+msgid "The device is already in use."
+msgstr "O dispositivo ya ye en uso."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid "An internal error occurred."
+msgstr "S'ha produciu una error interna."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Enabled"
+msgstr "Activada"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr "Eliminar as ditaladas rechistradas?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr "_Eliminar as ditaladas"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Quiers eliminar as tuyas ditaladas rechistradas y asinas desactivar l'inicio "
+"de sesión con a ditalada?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:443
+msgid "Done!"
+msgstr "Feito!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:504
+#: ../panels/user-accounts/um-fingerprint-dialog.c:546
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "No s'ha puesto accedir a lo dispositivo '%s'"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:587
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "No s'ha puesto encetar a captura de dido en o dispositivo '%s'"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:637
+msgid "Could not access any fingerprint readers"
+msgstr "No s'ha puesto accedir a dengún lector de ditaladas"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:638
+msgid "Please contact your system administrator for help."
+msgstr "Contacta con l'administrador d'o tuyo sistema ta obtener aduya."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:720
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"Ta activar l'inicio de sesión con a ditalada debes alzar una d'as tuyas "
+"ditaladas usando lo dispositivo '%s'."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:727
+msgid "Selecting finger"
+msgstr "Seleccionando lo dido"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:728
+msgid "Enrolling fingerprints"
+msgstr "Rechistrando as ditaladas"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "Ista semana"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "A zaguera semana"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e de %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:844
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:848
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "Sesión rematada"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "Sesión encetada"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "Triga unatra clau."
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "Escribe de nuevas a tuya clau actual."
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "No s'ha puesto cambiar a clau"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "The passwords do not match."
+msgstr "As claus no coinciden."
+
+#: ../panels/user-accounts/um-photo-dialog.c:214
+msgid "Browse for more pictures"
+msgstr "Examinar ta mirar mas imachens"
+
+#: ../panels/user-accounts/um-photo-dialog.c:448
+msgid "Disable image"
+msgstr "Desactivar a imachen"
+
+#: ../panels/user-accounts/um-photo-dialog.c:466
+msgid "Take a photo…"
+msgstr "Prener una foto…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:484
+msgid "Browse for more pictures…"
+msgstr "Examinar ta mirar mas imachens…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:708
+#, c-format
+msgid "Used by %s"
+msgstr "Usada por %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "No se puet unir automaticament ta ista mena de dominio"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "No existe o dominio u no s'ha trobau o reino"
+
+#: ../panels/user-accounts/um-realm-manager.c:815
+#: ../panels/user-accounts/um-realm-manager.c:829
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "No se puet encetar a sesión como %s en o dominio %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:821
+msgid "Invalid password, please try again"
+msgstr "A clau no ye valida, intenta-lo de nuevo"
+
+#: ../panels/user-accounts/um-realm-manager.c:834
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "No s'ha puesto connectar a lo dominio %s: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:240
+msgid "Other Accounts"
+msgstr "Atras cuentas"
+
+#: ../panels/user-accounts/um-user-panel.c:450
+msgid "Failed to delete user"
+msgstr "S'ha produciu una error en eliminar l'usuario"
+
+#: ../panels/user-accounts/um-user-panel.c:510
+#: ../panels/user-accounts/um-user-panel.c:569
+#: ../panels/user-accounts/um-user-panel.c:621
+msgid "Failed to revoke remotely managed user"
+msgstr "S'ha produciu una error en eliminar l'usuario maniau remotament"
+
+#: ../panels/user-accounts/um-user-panel.c:677
+msgid "You cannot delete your own account."
+msgstr "No puetz eliminar a tuya propia cuenta."
+
+#: ../panels/user-accounts/um-user-panel.c:686
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s agún no ye rechistrau en o sistema"
+
+#: ../panels/user-accounts/um-user-panel.c:690
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Eliminar un usuario entre que ye rechistrau en o sistema puede deixar lo "
+"sistema en un estau inconsistent."
+
+#: ../panels/user-accounts/um-user-panel.c:699
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "Quiers mantener os fichers de %s?"
+
+#: ../panels/user-accounts/um-user-panel.c:703
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Ye posible mantener a carpeta presonal, a ringlera d'o correu y os fichers "
+"temporals en eliminar una cuenta d'usuario."
+
+#: ../panels/user-accounts/um-user-panel.c:706
+msgid "_Delete Files"
+msgstr "_Eliminar os fichers"
+
+#: ../panels/user-accounts/um-user-panel.c:707
+msgid "_Keep Files"
+msgstr "_Mantener os fichers"
+
+#: ../panels/user-accounts/um-user-panel.c:721
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s's account?"
+msgstr "Yes seguro que quiers sacar a cuenta %s maniada remotament?"
+
+#: ../panels/user-accounts/um-user-panel.c:725
+msgid "_Delete"
+msgstr "_Eliminar"
+
+#: ../panels/user-accounts/um-user-panel.c:777
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Cuenta desactivada"
+
+#: ../panels/user-accounts/um-user-panel.c:785
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Ta configurar-ne en o siguient inicio de sesión"
+
+#: ../panels/user-accounts/um-user-panel.c:788
+msgctxt "Password mode"
+msgid "None"
+msgstr "Dengún"
+
+#: ../panels/user-accounts/um-user-panel.c:837
+msgid "Logged in"
+msgstr "Sesión encetada"
+
+#: ../panels/user-accounts/um-user-panel.c:1274
+msgid "Failed to contact the accounts service"
+msgstr "S'ha produciu una error a lo contactar con o servicio de cuentas"
+
+#: ../panels/user-accounts/um-user-panel.c:1276
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Asegura-te que o servicio de cuentas ye instalau y activau."
+
+#: ../panels/user-accounts/um-user-panel.c:1317
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Ta realizar os cambeos\n"
+"preta en primeras l'icono *"
+
+#: ../panels/user-accounts/um-user-panel.c:1355
+msgid "Create a user account"
+msgstr "Creyar una cuenta d'usuario"
+
+#: ../panels/user-accounts/um-user-panel.c:1366
+#: ../panels/user-accounts/um-user-panel.c:1678
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Ta creyar un usuario\n"
+"preta en primeras l'icono *"
+
+#: ../panels/user-accounts/um-user-panel.c:1376
+msgid "Delete the selected user account"
+msgstr "Eliminar a cuenta d'usuario seleccionadapreta en primeras l'icono *"
+
+#: ../panels/user-accounts/um-user-panel.c:1388
+#: ../panels/user-accounts/um-user-panel.c:1683
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Ta eliminar a cuenta d'usuario seleccionada\n"
+"preta en primeras l'icono *"
+
+#: ../panels/user-accounts/um-user-panel.c:1592
+msgid "My Account"
+msgstr "A mía cuenta"
+
+#: ../panels/user-accounts/um-utils.c:563
+#, c-format
+msgid "A user with the username '%s' already exists."
+msgstr "Ya existe un usuario con nombre d'usuario '%s'."
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+msgid "The username is too long."
+msgstr "O nombre d'usuario ye masiau largo."
+
+#: ../panels/user-accounts/um-utils.c:570
+msgid "The username cannot start with a '-'."
+msgstr "O nombre d'usuario no puet prencipiar por '-'."
+
+#: ../panels/user-accounts/um-utils.c:573
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"O nombre d'usuario debe consistir nomás de letras mayusclas y minusclas de "
+"l'a-dica la z, dichitos y belún d'os caracters '.', '-' y '_'."
+
+#: ../panels/user-accounts/um-utils.c:577
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+"Isto s'emplegará pa nombrar a tuya carpeta personal y no se puet cambiar."
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:823
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e, %Y"
+msgstr "%e de %b %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "Mapear os botons"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr "Mapear botons a funcions"
+
+#: ../panels/wacom/button-mapping.ui.h:4
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Ta editar un alcorce, triga l'acción \"Ninviar o clic de teclas\", preta "
+"l'alcorce d'o teclau y mantién pretas as teclas nuevas u preta o Retroceso "
+"ta esborrar-lo."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Preta as marcas d'obchectivo en que amaneixen en a pantalla ta calibrar a "
+"tableta."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "Clic erronio detectau, se ye reiniciando…"
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "Alto"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "Abaixo"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "Dengún"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Ninviar a pulsación de tecla"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Cambiar o monitor"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Amostrar l'aduya en a pantalla"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "Salida:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Mantener a relación d'aspecto (letterbox):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "Mapear una sola pantalla"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d de %d"
+
+#: ../panels/wacom/cc-wacom-page.c:522
+msgid "Display Mapping"
+msgstr "Amostrar o mapeo"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:377
+msgid "Button"
+msgstr "Botón"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Wacom Tablet"
+msgstr "Tableta Wacom"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Establir o mapiau de botons y achustar a sensibilidat d'o lapiz ta tabletas "
+"graficas"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tableta;Wacom;Stylus;Borrador;Rato;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "Tableta (absoluto)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "Touchpad (relativo)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "Preferencias d'a tableta"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Help"
+msgstr "_Aduya"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "No tablet detected"
+msgstr "No s'ha detectau garra tableta"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Conecta u enchega a tuya tableta Wacom"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Bluetooth Settings"
+msgstr "Configuración d'o Bluetooth"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map to Monitor…"
+msgstr "Mapa que monitorizar…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Map Buttons…"
+msgstr "Mapear os botons…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust display resolution"
+msgstr "Achustar a resolución d'a pantalla"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Adjust mouse settings"
+msgstr "Achustar as opcions d'o ratet"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Tracking Mode"
+msgstr "Modo de seguimiento"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:16
+msgid "Left-Handed Orientation"
+msgstr "Orientación ta zurdos"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1028
+msgid "Left Ring"
+msgstr "Aniello cucho"
+
+#: ../panels/wacom/gsd-wacom-device.c:1039
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "Modo de l'aniello cucho nº %d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1059
+msgid "Right Ring"
+msgstr "Aniello dreito"
+
+#: ../panels/wacom/gsd-wacom-device.c:1070
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "Modo de l'aniello dreito nº %d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1112
+msgid "Left Touchstrip"
+msgstr "Banda tactil cucha"
+
+#: ../panels/wacom/gsd-wacom-device.c:1123
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "Modo d'a banda tactil cucha nº %d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1143
+msgid "Right Touchstrip"
+msgstr "Banda tactil dreita"
+
+#: ../panels/wacom/gsd-wacom-device.c:1154
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "Modo d'a banda tactil dreita nº %d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1180
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "Modo de cambeo de l'aniello tactil cucho"
+
+#: ../panels/wacom/gsd-wacom-device.c:1182
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "Modo de cambeo de l'aniello tactil dreito"
+
+#: ../panels/wacom/gsd-wacom-device.c:1185
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "Modo de cambeo d'a banda tactil cucha"
+
+#: ../panels/wacom/gsd-wacom-device.c:1187
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "Modo de cambeo d'a banda tactil dreita"
+
+#: ../panels/wacom/gsd-wacom-device.c:1192
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "Modo de cambeo nº %d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1300
+#, c-format
+msgid "Left Button #%d"
+msgstr "Botón cucho nº %d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1303
+#, c-format
+msgid "Right Button #%d"
+msgstr "Botón dreito nº %d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1306
+#, c-format
+msgid "Top Button #%d"
+msgstr "Botón superior nº %d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1309
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "Botón inferior nº %d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "Nuevo alcorce de teclau…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "Sin acción"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "Pulsación d'o botón cucho d'o ratet"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "Pulsación d'o botón meyo d'o ratet"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "Pulsación d'o botón dreito d'o ratet"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "Desplazar enta alto"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "Desplazar enta baixo"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "Desplazar enta la cucha"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "Desplazar enta la dreita"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "Dezaga"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "Avant"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "Stylus"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilidat de presión d'o borrador"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "Suau"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "Firme"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "Botón superior"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "Botón inferior"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "Sensibilidat de presión d'o lapiz"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
+msgid "GNOME Control Center"
+msgstr "Centro de control de GNOME"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
+msgid "Utilities to configure the GNOME desktop"
+msgstr "Utilidatz ta configurar o escritorio GNOME"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
+msgid ""
+"The control center is GNOME's main interface for configuration of various "
+"aspects of your desktop."
+msgstr ""
+"O centro de control ye a interficie prencipal de GNOME ta la configuración "
+"de diversos aspectos d'o suyo escritorio."
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "Activar o modo detallau"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "Amostrar a visión cheneral"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "Mirar a cadena"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "Listar totz os nombres de panels posibles y salir"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "Amostrar as opcions d'aduya"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "Panel ta amostrar"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENTO…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- Configuración"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"Executar '%s --help' ta veyer una lista completa d'as opcions de comando "
+"disponibles.\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "Panels disponibles:"
+
+#: ../shell/cc-application.c:326
+msgid "Help"
+msgstr "Aduya"
+
+#: ../shell/cc-application.c:327
+msgid "Quit"
+msgstr "Salir"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1494
+msgid "All Settings"
+msgstr "Todas as configuracions"
+
+#. Add categories
+#: ../shell/cc-window.c:880
+msgctxt "category"
+msgid "Personal"
+msgstr "Presonal"
+
+#: ../shell/cc-window.c:881
+msgctxt "category"
+msgid "Hardware"
+msgstr "Hardware"
+
+#: ../shell/cc-window.c:882
+msgctxt "category"
+msgid "System"
+msgstr "Sistema"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "Preferencias;Configuración;"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "_Quan a carga ye criticament baixa"
+
+#~ msgid "Power Off"
+#~ msgstr "Amortar"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernar"
+
+#~ msgid "Power off"
+#~ msgstr "Amortar"

--- a/po/ar.po
+++ b/po/ar.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-17 16:07+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2019-03-17 17:07+0200\n"
 "Last-Translator: Khaled Hosny <khaledhosny@eglug.org>\n"
 "Language-Team: Arabic <doc@arabeyes.org>\n"
@@ -27,299 +27,219 @@ msgstr ""
 "X-Generator: Virtaal 0.7.1\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:558
-msgid "System Bus"
-msgstr "ناقل النظام"
-
-#: panels/applications/cc-applications-panel.c:558
-#: panels/applications/cc-applications-panel.c:560
-#: panels/applications/cc-applications-panel.c:576
-#: panels/applications/cc-applications-panel.c:581
-msgid "Full access"
-msgstr "وصول كامل"
-
-#: panels/applications/cc-applications-panel.c:560
-msgid "Session Bus"
-msgstr "ناقل الجلسة"
-
-#: panels/applications/cc-applications-panel.c:565
-#: panels/power/cc-power-panel.c:2528 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525 shell/cc-panel-list.ui:45
-#: shell/cc-window.c:251
-msgid "Devices"
-msgstr "الأجهزة"
-
-#: panels/applications/cc-applications-panel.c:565
-msgid "Full access to /dev"
-msgstr "وصول كامل إلى /dev"
-
-#: panels/applications/cc-applications-panel.c:570
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:241
-msgid "Network"
-msgstr "الشبكة"
-
-#: panels/applications/cc-applications-panel.c:570
-msgid "Has network access"
-msgstr "له وصول إلى الشبكة"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: panels/applications/cc-applications-panel.c:576
-#: panels/applications/cc-applications-panel.c:578
-#: panels/background/cc-background-chooser-dialog.c:536
-#: panels/search/cc-search-locations-dialog.c:286
-msgid "Home"
-msgstr "البداية"
-
-#: panels/applications/cc-applications-panel.c:578
-#: panels/applications/cc-applications-panel.c:583
-msgid "Read-only"
-msgstr "قراءة فقط"
-
-#: panels/applications/cc-applications-panel.c:581
-#: panels/applications/cc-applications-panel.c:583
-msgid "File System"
-msgstr "نظام الملفات"
-
-#: panels/applications/cc-applications-panel.c:588
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:255
-#: shell/cc-window.c:867 shell/cc-window.ui:116
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr "الإعدادات"
-
-#: panels/applications/cc-applications-panel.c:588
-msgid "Can change settings"
-msgstr "يستطيع تغيير الإعدادات"
-
-#: panels/applications/cc-applications-panel.c:593
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"الصلاحيات التالية مبنية في %s، ولا يمكن تغييرها. إذا كنت قلقا من هذا "
-"الصلاحيات، فربما تود إزالة التطبيق."
-
-#: panels/applications/cc-applications-panel.c:735
-msgid "Web Links"
-msgstr "روابط الوب"
-
-#: panels/applications/cc-applications-panel.c:745
-msgid "Git Links"
-msgstr "روابط Git"
-
-#: panels/applications/cc-applications-panel.c:751
-#, c-format
-msgid "%s Links"
-msgstr "روابط %s"
-
-#: panels/applications/cc-applications-panel.c:759
-#: panels/applications/cc-applications-panel.c:795
-msgid "Unset"
-msgstr "أزل"
-
-#: panels/applications/cc-applications-panel.c:850
-msgid "Links"
-msgstr "روابط"
-
-#: panels/applications/cc-applications-panel.c:858
-msgid "Hypertext Files"
-msgstr "ملفات النص التشعبي"
-
-#: panels/applications/cc-applications-panel.c:872
-msgid "Text Files"
-msgstr "ملفات النصوص"
-
-#: panels/applications/cc-applications-panel.c:886
-msgid "Image Files"
-msgstr "ملفات الصور"
-
-#: panels/applications/cc-applications-panel.c:902
-msgid "Font Files"
-msgstr "ملفات الخطوط"
-
-#: panels/applications/cc-applications-panel.c:963
-msgid "Archive Files"
-msgstr "الملفات المضغوطة"
-
-#: panels/applications/cc-applications-panel.c:983
-msgid "Package Files"
-msgstr "ملفات الحزم"
-
-#: panels/applications/cc-applications-panel.c:1006
-msgid "Audio Files"
-msgstr "ملفات الصوت"
-
-#: panels/applications/cc-applications-panel.c:1023
-msgid "Video Files"
-msgstr "ملفات الفديو"
-
-#: panels/applications/cc-applications-panel.c:1031
-msgid "Other Files"
-msgstr "ملفات أخرى"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1353
-#: panels/applications/cc-applications-panel.ui:406
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:167
-#: panels/privacy/cc-privacy-panel.ui:1085
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr "التطبيقات"
 
-#: panels/applications/cc-applications-panel.ui:45
+#: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
 msgstr "لا تطبيقات"
 
-#: panels/applications/cc-applications-panel.ui:59
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr "ثبّت البعض…"
 
-#: panels/applications/cc-applications-panel.ui:99
-msgid "Permissions & Access"
-msgstr "الصلاحيات والوصول"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "ا_فتح"
 
-#: panels/applications/cc-applications-panel.ui:111
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-"البيانات والخدمات التي طلب هذا التطبيق الوصول إليها والصلاحيات التي يحتاجها."
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "اعرض ال_تفاصيل"
 
-#: panels/applications/cc-applications-panel.ui:126
-#: panels/applications/cc-applications-panel.ui:132
-#: panels/privacy/cc-privacy-panel.c:908 panels/privacy/cc-privacy-panel.ui:745
-msgid "Camera"
-msgstr "كمرة"
-
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:237
-#: panels/applications/cc-applications-panel.ui:255
-#: panels/keyboard/cc-keyboard-option.c:259
-#: panels/keyboard/cc-keyboard-option.c:378
-#: panels/keyboard/keyboard-shortcuts.c:425
-#: panels/keyboard/shortcut-editor.ui:96 panels/network/network-proxy.ui:123
-#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
-#: panels/user-accounts/um-fingerprint-dialog.c:211
-#: subprojects/gvc/gvc-mixer-control.c:1864
-msgid "Disabled"
-msgstr "معطّل"
-
-#: panels/applications/cc-applications-panel.ui:138
-#: panels/applications/cc-applications-panel.ui:144
-#: panels/privacy/cc-privacy-panel.c:941 panels/privacy/cc-privacy-panel.ui:850
-msgid "Microphone"
-msgstr "ميكروفون"
-
-#: panels/applications/cc-applications-panel.ui:150
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/privacy/cc-privacy-panel.c:850 panels/privacy/cc-privacy-panel.ui:955
-msgid "Location Services"
-msgstr "خدمات التموضع"
-
-#: panels/applications/cc-applications-panel.ui:162
-#: panels/applications/cc-applications-panel.ui:422
-msgid "Built-in Permissions"
-msgstr "الصلاحيات المدمجة"
-
-#: panels/applications/cc-applications-panel.ui:163
-msgid "Cannot be changed"
-msgstr "لا يمكن تغييرها"
-
-#: panels/applications/cc-applications-panel.ui:180
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-"يمكن مراجعة صلاحيات التطبيق كل على حدة في إعدادات <a href=\"privacy\""
-">الخصوصية</a>."
-
-#: panels/applications/cc-applications-panel.ui:204
-msgid "Integration"
-msgstr "التكامل"
-
-#: panels/applications/cc-applications-panel.ui:216
-msgid "System features used by this application."
-msgstr "خصائص النظام التي يستخدمها هذا التّطبيق."
-
-#: panels/applications/cc-applications-panel.ui:230
-#: panels/applications/cc-applications-panel.ui:236
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:146
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "البحث"
 
-#: panels/applications/cc-applications-panel.ui:242
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "معطّل"
+
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr "التنبيهات"
 
-#: panels/applications/cc-applications-panel.ui:248
-#: panels/applications/cc-applications-panel.ui:254
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "أظهر ال_تنبيهات"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "الخلفية"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "لقطات الشاشة"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "خلفيات"
+
+#: panels/applications/cc-applications-panel.ui:148
+#, fuzzy
+msgid "Change the desktop wallpaper."
+msgstr "preferences-desktop-wallpaper"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "الصوت"
 
-#: panels/applications/cc-applications-panel.ui:287
-msgid "Default Handlers"
-msgstr "المناولات المبدئية"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:299
-msgid "Types of files and links that this application opens."
-msgstr "أنواع الملفات والروابط التي يفتحها هذا التطبيق."
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "الاختصارات"
 
-#: panels/applications/cc-applications-panel.ui:315
-msgid "Reset"
-msgstr "صفّر"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "لم يُعثر على أي اختصارات للوحة المفاتيح"
 
-#: panels/applications/cc-applications-panel.ui:351
-msgid "Usage"
-msgstr "الاستخدام"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "كمرة"
 
-#: panels/applications/cc-applications-panel.ui:363
-msgid "How much resources this application is using."
-msgstr "ما مقدار الموارد التي يستخدمها هذا التطبيق."
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:378
-#: panels/applications/cc-applications-panel.ui:458
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "ميكروفون"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "خدمات التموضع"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "الصلاحيات المدمجة"
+
+#: panels/applications/cc-applications-panel.ui:223
+#, fuzzy
+msgid "System access that is required by the app"
+msgstr "خصائص النظام التي يستخدمها هذا التّطبيق."
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "مساحة التخزين"
 
-#: panels/applications/cc-applications-panel.ui:413
-msgid "Open in Software"
-msgstr "افتح في «البرمجيات»"
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "لا نتائج"
 
-#: panels/applications/cc-applications-panel.ui:475
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "جرب بحثًا آخر"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "نظام الملفات"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "سرعة الوصلة"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "صفّر"
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr "ما المساحة التي يستخدمها هذا التطبيق هو والبيانات التي يخزنها."
 
-#: panels/applications/cc-applications-panel.ui:484
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "تطبيق"
 
-#: panels/applications/cc-applications-panel.ui:490
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "البيانات"
 
-#: panels/applications/cc-applications-panel.ui:496
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "الخبيئة"
 
-#: panels/applications/cc-applications-panel.ui:502
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>المجموع</b>"
 
-#: panels/applications/cc-applications-panel.ui:519
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "امسح الخبيئة…"
 
@@ -327,199 +247,101 @@ msgstr "امسح الخبيئة…"
 msgid "Control various application permissions and settings"
 msgstr "تحكم في مختلف صلاحيات وإعدادات التطبيقات"
 
-#. FIXME
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/applications/gnome-applications-panel.desktop.in.in:8
-msgid "application-x-executable"
-msgstr "application-x-executable"
-
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "تطبيق;صلاحيات;إعداد;application;flatpak;permission;setting;"
 
-#: panels/background/background.ui:49
-msgid "_Background"
-msgstr "ال_خلفية"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "القلم"
 
-#. This refers to a slideshow background
-#: panels/background/background.ui:99 panels/background/background.ui:212
-msgid "Changes throughout the day"
-msgstr "تتغير خلال اليوم"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "المبدئي"
 
-#. To translators: This is a noun, not a verb
-#: panels/background/background.ui:162
-msgid "_Lock Screen"
-msgstr "أو_صد الشاشة"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#: panels/background/background.ui:268
-msgctxt "background, style"
-msgid "Tile"
-msgstr "مبلّطة"
-
-#: panels/background/background.ui:272
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "مُقرَّبة"
-
-#: panels/background/background.ui:276
-msgctxt "background, style"
-msgid "Center"
-msgstr "موسَّطة"
-
-#: panels/background/background.ui:280
-msgctxt "background, style"
-msgid "Scale"
-msgstr "محجّمة"
-
-#: panels/background/background.ui:284
-msgctxt "background, style"
-msgid "Fill"
-msgstr "مملوءة"
-
-#: panels/background/background.ui:288
-msgctxt "background, style"
-msgid "Span"
-msgstr "موسّعة"
-
-#: panels/background/cc-background-chooser-dialog.c:412
-msgid "Wallpapers"
-msgstr "خلفيات"
-
-#: panels/background/cc-background-chooser-dialog.c:423
-msgid "Colors"
-msgstr "ألوان"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: panels/background/cc-background-chooser-dialog.c:455
-msgid "Select Background"
-msgstr "اختر خلفية"
-
-#: panels/background/cc-background-chooser-dialog.c:484
-msgid "Pictures"
-msgstr "صور"
-
-#. translators: No pictures were found
-#: panels/background/cc-background-chooser-dialog.c:519
-msgid "No Pictures Found"
-msgstr "لم يُعثر على أي صور"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: panels/background/cc-background-chooser-dialog.c:546
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "يمكنك إضافة الصور إلى مجلد %s و ستظهر هنا"
-
-#: panels/background/cc-background-chooser-dialog.c:550
-#: panels/color/cc-color-panel.c:241 panels/color/cc-color-panel.c:894
-#: panels/color/cc-color-panel.ui:657 panels/color/color-calibrate.ui:25
-#: panels/common/cc-language-chooser.ui:24
-#: panels/display/cc-display-panel.c:877
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:181
-#: panels/network/connection-editor/vpn-helpers.c:310
-#: panels/network/net-device-wifi.c:1200 panels/network/net-device-wifi.c:1280
-#: panels/network/net-device-wifi.c:1474 panels/network/network-wifi.ui:24
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:313
-#: panels/privacy/cc-privacy-panel.c:1137 panels/region/cc-format-chooser.ui:24
-#: panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:607
-#: panels/sharing/cc-sharing-panel.c:427
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:106
-#: panels/user-accounts/cc-avatar-chooser.c:234
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:640
-#: panels/user-accounts/cc-user-panel.c:658
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/user-accounts/um-fingerprint-dialog.c:261
-msgid "_Cancel"
-msgstr "أ_لغِ"
-
-#: panels/background/cc-background-chooser-dialog.c:551
-#: panels/common/cc-language-chooser.ui:12
-msgid "_Select"
-msgstr "ا_ختر"
-
-#: panels/background/cc-background-item.c:191
-msgid "multiple sizes"
-msgstr "مقاسات متعددة"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:195
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:320
-msgid "No Desktop Background"
-msgstr "لا خلفية لسطح المكتب"
-
-#: panels/background/cc-background-panel.c:291
-msgid "Current background"
-msgstr "الخلفية الحالية"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "الخلفية"
 
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "أضِف طابعة…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "فرنسا"
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "غيّر صورة الخلفية"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/background/gnome-background-panel.desktop.in.in:7
-msgid "preferences-desktop-wallpaper"
-msgstr "preferences-desktop-wallpaper"
-
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "خلفية;شاشة;سطح المكتب;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.c:309
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "_فعّل"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "لم يعثر على بلوتوث"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:310
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "وصل جهاز بلوتوث خارجي لاستخدامه"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:313
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "بلوتوث مغلق"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:314
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "شغله للاتصال بالأجهزة و استقبال الملفات."
 
-#: panels/bluetooth/cc-bluetooth-panel.c:317
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "وضع ال_طائرة مفعّل"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:318
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "بلوتوث معطّل لأن وضع الطائرة مفعّل."
 
-#: panels/bluetooth/cc-bluetooth-panel.c:321
-msgid "Hardware Airplane Mode is on"
-msgstr "وضع الطائرة مفعّل من العتاد"
-
-#: panels/bluetooth/cc-bluetooth-panel.c:322
-msgid "Turn off the Airplane mode switch to enable Bluetooth."
-msgstr "عطّل وضع الطائرة لتفعيل بلوتوث."
-
-#: panels/bluetooth/cc-bluetooth-panel.c:324
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "أوقف وضع الطائرة"
 
-#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "وضع الطائرة مفعّل من العتاد"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "عطّل وضع الطائرة لتفعيل بلوتوث."
+
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/network/cc-network-panel.ui:101
-#: panels/printers/pp-new-printer-dialog.c:1697
 msgid "Bluetooth"
 msgstr "بلوتوث"
 
@@ -527,251 +349,93 @@ msgstr "بلوتوث"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "شغّل أو أغلق بلوتوث لتوصيل جهازك بالأجهزة الأخرى"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:6
-msgid "bluetooth"
-msgstr "bluetooth"
-
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;مشاركة;شارك;بلوتوث;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:348
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "ضع جهاز المعايرة على المربع ثم اضغط ”ابدأ“"
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "بلوتوث مغلق"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:354
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "لا تطبيقات تشغل أو تسجل صوتا حاليا."
+
+#: panels/camera/cc-camera-panel.ui:39
+#, fuzzy
 msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "انقل جهاز المعايرة إلى موضع المعايرة ثم اضغط ”واصل“"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"استخدام الكمرة يتيح للتطبيقات التقاط الصور والفيديو. تعطيل الكمرة قد يتسبب "
+"في ألا تعمل بعض التطبيقات كما يجب."
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:360
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "انقل جهاز المعايرة إلى موضع السطح ثم اضغط ”واصل“"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:366
-msgid "Shut the laptop lid"
-msgstr "أعلق غطاء الحاسوب"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "تصفّح لمزيد من الصور"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:397
-msgid "An internal error occurred that could not be recovered."
-msgstr "حصل عطل داخلي تعذّر التعافي منه."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:402
-msgid "Tools required for calibration are not installed."
-msgstr "الأدوات المطلوبة للمعايرة غير مُثبّتة."
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "معايرة جهاز العرض"
 
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:408
-msgid "The profile could not be generated."
-msgstr "تعذّر توليد الإعدادات."
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "أ_لغِ"
 
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:414
-msgid "The target whitepoint was not obtainable."
-msgstr "لا يمكن الحصول على النقطة البيضاء المحددة"
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "اب_دأ"
 
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:453
-msgid "Complete!"
-msgstr "تم"
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "اس_تئنف"
 
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:461
-msgid "Calibration failed!"
-msgstr "فشلت المعايرة"
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_تمّ"
 
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:468
-msgid "You can remove the calibration device."
-msgstr "يمكنك رفع جهاز المعايرة"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:537
-msgid "Do not disturb the calibration device while in progress"
-msgstr "لا تُقاطع جهاز المعايرة أثناء عمله"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "شاشة حاسوب محمول"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "كمرة وب مدمجة"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "شاشة %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "ماسحة %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "كمرة %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "طابعة %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "كمرة وب %s"
-
-#: panels/color/cc-color-device.c:91
-#, c-format
-msgid "Enable color management for %s"
-msgstr "فعّل إدارة ألوان %s"
-
-#: panels/color/cc-color-device.c:94
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "أظهر تشكيلات ألوان %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:303
-msgid "Not calibrated"
-msgstr "غير مُعايَر"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:170
-msgid "Default: "
-msgstr "المبدئي: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:178
-msgid "Colorspace: "
-msgstr "نطاق الألوان: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:185
-msgid "Test profile: "
-msgstr "ملف إعداد للاختبار: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:239
-msgid "Select ICC Profile File"
-msgstr "اختر ملف إعداد ICC"
-
-#: panels/color/cc-color-panel.c:242
-msgid "_Import"
-msgstr "ا_ستورد"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:253
-msgid "Supported ICC profiles"
-msgstr "تشكيلات ICC المدعومة"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:260
-#: panels/network/wireless-security/eap-method-fast.c:417
-msgid "All files"
-msgstr "كلّ الملفات"
-
-#: panels/color/cc-color-panel.c:555
-msgid "Screen"
-msgstr "شاشة"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:847
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "فشل رفع الملف: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:859
-msgid "The profile has been uploaded to:"
-msgstr "رُفع الإعداد إلى:"
-
-#: panels/color/cc-color-panel.c:861
-msgid "Write down this URL."
-msgstr "اكتب هذا المسار في ورقة."
-
-#: panels/color/cc-color-panel.c:862
-msgid "Restart this computer and boot your normal operating system."
-msgstr "أعد تشغيل الحاسوب و أقلع نظام التشغيل المعتاد."
-
-#: panels/color/cc-color-panel.c:863
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "اكتب المسار في المتصفح و نزّل الإعداد."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:891
-msgid "Save Profile"
-msgstr "احفظ الإعداد"
-
-#: panels/color/cc-color-panel.c:895
-#: panels/network/connection-editor/vpn-helpers.c:311
-msgid "_Save"
-msgstr "ا_حفظ"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1209
-msgid "Create a color profile for the selected device"
-msgstr "أنشئ إعداد لون للجهاز المختار"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1224 panels/color/cc-color-panel.c:1248
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "لم تُكتشف أداة القياس. رجاءً تأكد من تشغيلها وتوصيلها بشكل صحيح."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1258
-msgid "The measuring instrument does not support printer profiling."
-msgstr "أداة القياس لا تدعم تشكيل الطابعة."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1269
-msgid "The device type is not currently supported."
-msgstr "نوع الجهاز غير مدعوم حاليًا."
-
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:47
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "معايرة الشاشة"
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "جودة المعايرة"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -780,68 +444,68 @@ msgstr ""
 "ستنتج المعايرة إعدادات يمكنك استخدامها للتحكم في ألوان شاشتك. كلما قضيت وقتا "
 "أطول في المعايرة كلما كانت جودة الإعدادات الناتجة أفضل."
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "لم تستطيع استخدام حاسوبك أثناء المعايرة."
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "الجودة"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "الوقت التقريبي"
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr "جودة المعايرة"
-
-#: panels/color/cc-color-panel.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr "اختر الجهاز المستشعر الذي تريد استخدامه في المعايرة."
-
-#: panels/color/cc-color-panel.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "جهاز المعايرة"
 
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
-msgstr "اختر نوع جهاز العرض المُوصّل."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "اختر الجهاز المستشعر الذي تريد استخدامه في المعايرة."
 
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "نوع جهاز العرض"
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "اختر نوع جهاز العرض المُوصّل."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
-msgstr ""
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "سطوع جهاز العرض"
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr "سطوع جهاز العرض"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "اسم الإعداد"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -849,302 +513,193 @@ msgstr ""
 "يمكنك استخدام تشكيلات ألوان مستقلة على الحواسيب المختلفة، أو حتى تشكيلات "
 "مستقلة لدرجات الإضاءة المختلفة."
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "اسم الإعداد:"
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "اسم الإعداد"
-
-#: panels/color/cc-color-panel.ui:392
-msgid "Profile successfully created!"
-msgstr "تم إنشاء الإعداد"
-
-#: panels/color/cc-color-panel.ui:443
-msgid "Copy profile"
-msgstr "انسخ الإعداد"
-
-#: panels/color/cc-color-panel.ui:456
-msgid "Requires writable media"
-msgstr "يحتاج وسائط قابلة للكتابة"
-
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr "ارفع الإعداد"
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr "يحتاج اتصالًا بالإنترنت"
-
-#: panels/color/cc-color-panel.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"قد ترغب بالاطلاع على تعليمات استخدام إعدادات الألوان على <a href=\"linux"
-"\">جنوم\\لينكس</a> و <a href=\"osx\">أبل ماك</a> و <a href=\"windows"
-"\">ميكروسوفت وندوز</a>."
-
-#: panels/color/cc-color-panel.ui:607
-#: panels/user-accounts/um-fingerprint-dialog.c:720
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "ملخّص"
 
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "تم إنشاء الإعداد"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "انسخ الإعداد"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "يحتاج وسائط قابلة للكتابة"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"قد ترغب بالاطلاع على تعليمات استخدام إعدادات الألوان على <a "
+"href=\"linux\">جنوم\\لينكس</a> و <a href=\"osx\">أبل ماك</a> و <a "
+"href=\"windows\">ميكروسوفت وندوز</a>."
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "أضف إعدادًا"
 
-#: panels/color/cc-color-panel.ui:643
-msgid "_Import File…"
-msgstr "ا_ستورد ملفًا…"
-
-#: panels/color/cc-color-panel.ui:672
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/region/cc-input-chooser.ui:20
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr "أ_ضف"
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
 "وجدت مشاكل ولن يعمل ملف الإعداد كما يجب. <a href=\"\">أظهر التفاصيل.</a>"
 
-#: panels/color/cc-color-panel.ui:790
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "ا_ستورد ملفًا…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "أ_ضف"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "كل جهاز يحتاج إلى ملفات إعدادات ألوان مُحدّثة ليكون مُدار الألوان."
 
-#: panels/color/cc-color-panel.ui:812
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "اعرف المزيد"
 
-#: panels/color/cc-color-panel.ui:817
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "اعرف المزيد عن إدارة الألوان"
 
-#: panels/color/cc-color-panel.ui:865
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "ا_ضبط لجميع المستخدمين"
 
-#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
-#: panels/color/cc-color-panel.ui:885
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "اضبط هذا الإعداد لكل المستخدمين على هذا الحاسوب"
 
-#: panels/color/cc-color-panel.ui:880
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "_فعّل"
 
-#: panels/color/cc-color-panel.ui:911
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "أ_ضف إعدادًا"
 
-#: panels/color/cc-color-panel.ui:924
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "_عاير…"
 
-#: panels/color/cc-color-panel.ui:928
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "عاير الجهاز"
 
-#: panels/color/cc-color-panel.ui:939
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "أزل الإع_داد"
 
-#: panels/color/cc-color-panel.ui:952
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "اعرض ال_تفاصيل"
 
-#: panels/color/cc-color-panel.ui:988
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "تعذّر اكتشاف الأجهزة التي يمكن التحكم بألوانها"
 
-#: panels/color/cc-color-panel.ui:1032
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "شاشة كريستال سائل"
 
-#: panels/color/cc-color-panel.ui:1037
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/cc-color-panel.ui:1042
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "شاشة عادية"
 
-#: panels/color/cc-color-panel.ui:1047
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "جهاز عرض الشرائح"
 
-#: panels/color/cc-color-panel.ui:1052
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "شاشة بلازما"
 
-#: panels/color/cc-color-panel.ui:1057
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1062
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1067
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1072
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1077
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1094
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "عالية"
 
-#: panels/color/cc-color-panel.ui:1095
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 دقيقة"
 
-#: panels/color/cc-color-panel.ui:1099
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "متوسطة"
 
-#: panels/color/cc-color-panel.ui:1100
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 دقيقة"
 
-#: panels/color/cc-color-panel.ui:1104
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "منخفضة"
 
-#: panels/color/cc-color-panel.ui:1105
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 دقيقة"
 
-#: panels/color/cc-color-panel.ui:1127
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "الأصلي لجهاز العرض"
 
-#: panels/color/cc-color-panel.ui:1131
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "‏D50 (الطباعة و النشر)"
 
-#: panels/color/cc-color-panel.ui:1135
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/cc-color-panel.ui:1139
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "‏D65 (التصوير و الرسوميات)"
 
-#: panels/color/cc-color-panel.ui:1143
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:100
-msgid "Standard Space"
-msgstr "النطاق المعياري"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:106
-msgid "Test Profile"
-msgstr "اختبر الإعداد"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:114
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "تلقائي"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:124
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "جودة منخفضة"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:129
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "جودة متوسطة"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:136
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "جودة عالية"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:153
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "ح‌خ‌ز المبدئي"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:160
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "زق‌ص‌س المبدئي"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:167
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "الرمادي المبدئي"
-
-#: panels/color/cc-color-profile.c:190
-msgid "Vendor supplied factory calibration data"
-msgstr "بيانات معايرة المصنع من منتج الجهاز"
-
-#: panels/color/cc-color-profile.c:199
-msgid "Full-screen display correction not possible with this profile"
-msgstr "تصحيح عرض ملء الشاشة غير ممكن مع هذا الإعداد"
-
-#: panels/color/cc-color-profile.c:221
-msgid "This profile may no longer be accurate"
-msgstr "هذا الإعداد ربما لم يعد دقيقا"
-
-#: panels/color/color-calibrate.ui:7
-msgid "Display Calibration"
-msgstr "معايرة جهاز العرض"
-
-#. This starts the calibration process
-#: panels/color/color-calibrate.ui:40
-msgid "_Start"
-msgstr "اب_دأ"
-
-#. This resumes the calibration process
-#: panels/color/color-calibrate.ui:54
-msgid "_Resume"
-msgstr "اس_تئنف"
-
-#. This button returns the user back to the color control panel
-#: panels/color/color-calibrate.ui:67 panels/region/cc-format-chooser.ui:13
-msgid "_Done"
-msgstr "_تمّ"
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1155,247 +710,200 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "عاير ألوان أجهزتك، مثل أجهزة العرض و الكمرات و الطابعات"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/color/gnome-color-panel.desktop.in.in:7
-msgid "preferences-color"
-msgstr "preferences-color"
-
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "لون;ألوان;إعداد;تشكيل;معايرة;طابعة;شاشة;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "آخر…"
-
-#: panels/common/cc-language-chooser.c:125
-#: panels/region/cc-format-chooser.c:268 panels/region/cc-input-chooser.c:178
-msgid "More…"
-msgstr "المزيد…"
-
-#: panels/common/cc-language-chooser.c:142
-msgid "No languages found"
-msgstr "لا يوجد أي لغات"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
 msgstr "اختر لغة"
 
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:106
-msgid "Today"
-msgstr "اليوم"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "ا_ختر"
 
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "Yesterday"
-msgstr "الأمس"
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "لا يوجد أي لغات"
 
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %B"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "المزيد…"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %B، %Y"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "نقطة بث"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "ا_فتح"
 
-#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
-#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
-msgid "Day"
-msgstr "اليوم"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
-#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
-msgid "Month"
-msgstr "الشهر"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "كبّر الحجم:"
 
-#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
-#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
-msgid "Year"
-msgstr "السنة"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "الوقت"
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:332
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y، %l:%M %p"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:337
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y، %R"
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "قلل الحجم:"
 
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:502
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s، %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:529
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:536
-msgid "UTC%:::z"
-msgstr "جرينتش%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:541
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:546
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:551
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:26
-msgid "January"
-msgstr "يناير"
-
-#: panels/datetime/cc-datetime-panel.ui:29
-msgid "February"
-msgstr "فبراير"
-
-#: panels/datetime/cc-datetime-panel.ui:32
-msgid "March"
-msgstr "مارس"
-
-#: panels/datetime/cc-datetime-panel.ui:35
-msgid "April"
-msgstr "أبريل"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "May"
-msgstr "مايو"
-
-#: panels/datetime/cc-datetime-panel.ui:41
-msgid "June"
-msgstr "يونيو"
-
-#: panels/datetime/cc-datetime-panel.ui:44
-msgid "July"
-msgstr "يوليو"
-
-#: panels/datetime/cc-datetime-panel.ui:47
-msgid "August"
-msgstr "أغسطس"
-
-#: panels/datetime/cc-datetime-panel.ui:50
-msgid "September"
-msgstr "سبتمبر"
-
-#: panels/datetime/cc-datetime-panel.ui:53
-msgid "October"
-msgstr "أكتوبر"
-
-#: panels/datetime/cc-datetime-panel.ui:56
-msgid "November"
-msgstr "نوفمبر"
-
-#: panels/datetime/cc-datetime-panel.ui:59
-msgid "December"
-msgstr "ديسمبر"
-
-#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "التاريخ والوقت"
 
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "السنة"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "الشهر"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "يناير"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "فبراير"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "مارس"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "أبريل"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "مايو"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "يونيو"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "يوليو"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "أغسطس"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "سبتمبر"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "أكتوبر"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "نوفمبر"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ديسمبر"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "اليوم"
+
 #: panels/datetime/cc-datetime-panel.ui:113
-#: panels/display/cc-night-light-dialog.ui:245
-#: panels/display/cc-night-light-dialog.ui:352
-msgid "Hour"
-msgstr "ساعة"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: panels/datetime/cc-datetime-panel.ui:128
-msgid "∶"
-msgstr ":"
-
-#: panels/datetime/cc-datetime-panel.ui:152
-#: panels/display/cc-night-light-dialog.ui:273
-#: panels/display/cc-night-light-dialog.ui:380
-msgid "Minute"
-msgstr "دقيقة"
-
-#: panels/datetime/cc-datetime-panel.ui:219
 msgid "Time Zone"
 msgstr "المنطقة الزمنية"
 
-#: panels/datetime/cc-datetime-panel.ui:240
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "ابحث عن مدينة"
 
-#: panels/datetime/cc-datetime-panel.ui:313
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "_تاريخ و وقت تلقائييْن"
 
-#: panels/datetime/cc-datetime-panel.ui:314
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "يتطلب اتصالًا بالإنترنت"
 
-#: panels/datetime/cc-datetime-panel.ui:334
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "التاريخ و الو_قت"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "من_طقة زمنية تلقائية"
 
-#: panels/datetime/cc-datetime-panel.ui:335
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "يتطلب تفعيل خدمات الموضع الجغرافي واتصالًا بالإنترنت"
 
-#: panels/datetime/cc-datetime-panel.ui:350
-msgid "Date & _Time"
-msgstr "التاريخ و الو_قت"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "مفعّل"
 
-#: panels/datetime/cc-datetime-panel.ui:366
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "المن_طقة الزمنية"
 
-#: panels/datetime/cc-datetime-panel.ui:405
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "مع عقارب الساعة"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "تن_سيق الوقت"
 
-#: panels/datetime/cc-datetime-panel.ui:414
-msgid "24-hour"
-msgstr "24-ساعة"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:415
-msgid "AM / PM"
-msgstr "ص \\ م"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "التّواريخ"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "أقل من ثانية"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "التقويم"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "الأرقام"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "غيّر الوقت والتاريخ، بما فيها المنطقة الزمنية"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/datetime/gnome-datetime-panel.desktop.in.in:7
-msgid "preferences-system-time"
-msgstr "preferences-system-time"
-
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "ساعة;توقيت;منطقة زمنية;منطقة;"
@@ -1408,153 +916,171 @@ msgstr "غيّر إعدادات الوقت والتاريخ للنظام"
 msgid "To change time or date settings, you need to authenticate."
 msgstr "لتغيير إعدادات الوقت والتاريخ، تحتاج للاستيثاق."
 
-#: panels/display/cc-display-panel.c:888
-#: panels/network/connection-editor/connection-editor.ui:27
-#: panels/network/network-wifi.ui:38
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "ال_وب"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "ال_بريد"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "الت_قويم"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "ال_صوتيات"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "ال_فيديو"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "ال_صور"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "التطبيقات المبدئية"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "اضبط التطبيقات المبدئية"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "مبدئي;تطبيق;مفضل;وسائط;"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "الإبلاغ عن المشاكل"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "الإبلاغ التل_قائي عن المشاكل"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_طبّق"
 
-#: panels/display/cc-display-panel.c:909
-msgid "Apply Changes?"
-msgstr "أتريد تطبيق التغييرات؟"
-
-#: panels/display/cc-display-panel.c:914
-msgid "Changes Cannot be Applied"
-msgstr "تعذّر تطبيق التغييرات"
-
-#: panels/display/cc-display-panel.c:915
-msgid "This could be due to hardware limitations."
-msgstr "قد يكون هذا بسبب قصور في العتاد."
-
-#. TRANSLATORS: the state of the night light setting
-#: panels/display/cc-display-panel.c:1088
-#: panels/notifications/cc-notifications-panel.c:270
-#: panels/power/cc-power-panel.c:2111 panels/power/cc-power-panel.c:2118
-#: panels/privacy/cc-privacy-panel.c:212 panels/privacy/cc-privacy-panel.c:289
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:841
-#: panels/universal-access/cc-ua-panel.c:854
-#: panels/universal-access/cc-ua-panel.c:866
-#: panels/universal-access/cc-ua-panel.c:1031
-msgid "On"
-msgstr "مفعّل"
-
-#: panels/display/cc-display-panel.c:1088 panels/network/net-proxy.c:54
-#: panels/notifications/cc-notifications-panel.c:270
-#: panels/power/cc-power-panel.c:2105 panels/power/cc-power-panel.c:2116
-#: panels/privacy/cc-privacy-panel.c:212 panels/privacy/cc-privacy-panel.c:289
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:841
-#: panels/universal-access/cc-ua-panel.c:854
-#: panels/universal-access/cc-ua-panel.c:866
-#: panels/universal-access/cc-ua-panel.c:1031
-#: panels/universal-access/cc-ua-panel.ui:338
-#: panels/universal-access/cc-ua-panel.ui:384
-#: panels/universal-access/cc-ua-panel.ui:430
-#: panels/universal-access/cc-ua-panel.ui:536
-#: panels/universal-access/cc-ua-panel.ui:689
-#: panels/universal-access/cc-ua-panel.ui:735
-#: panels/universal-access/cc-ua-panel.ui:781
-#: panels/universal-access/cc-ua-panel.ui:933
-msgid "Off"
-msgstr "معطّل"
-
-#: panels/display/cc-display-panel.ui:81
-msgid "Single Display"
-msgstr "شاشة مفردة"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "إلى الخلف"
 
 #: panels/display/cc-display-panel.ui:100
-#: panels/display/cc-display-panel.ui:305
-msgid "Join Displays"
-msgstr "ضم الشاشات"
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "بلوتوث معطّل"
 
-#: panels/display/cc-display-panel.ui:118
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "شاشة مفردة"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "طابق"
 
-#: panels/display/cc-display-panel.ui:143
-msgid "Display Mode"
-msgstr "نمط العرض"
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
 
-#: panels/display/cc-display-panel.ui:235
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
-msgstr "اسحب الشاشات لتطابق ترتيبها في الطبيعة. اختر الشاشة لتغيير إعداداتها."
-
-#: panels/display/cc-display-panel.ui:242
-msgid "Display Arrangement"
-msgstr "ترتيب الشاشات"
-
-#: panels/display/cc-display-panel.ui:424
-msgid "Display Configuration"
-msgstr "إعدادات الشاشة"
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "الشاشة الرئيسية"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:451
-#: panels/display/cc-display-panel.ui:469
-#: panels/display/cc-night-light-dialog.ui:505
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "الإضاءة الليلية"
 
-#: panels/display/cc-display-settings.c:108
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "عرضيّ"
-
-#: panels/display/cc-display-settings.c:111
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "طوليّ يمين"
-
-#: panels/display/cc-display-settings.c:114
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "طوليّ يسار"
-
-#: panels/display/cc-display-settings.c:117
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "عرضيّ (مقلوب)"
-
-#: panels/display/cc-display-settings.c:191
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf هرتز"
-
-#: panels/display/cc-display-settings.ui:15
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "الاتجاه"
 
-#: panels/display/cc-display-settings.ui:24
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "الميز"
 
-#: panels/display/cc-display-settings.ui:33
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "تردد التحديث"
 
-#: panels/display/cc-display-settings.ui:42
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "اضبط للتلفاز"
 
-#: panels/display/cc-display-settings.ui:59
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
 msgid "Scale"
 msgstr "المقياس"
 
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-dialog.ui:46
-msgid "Restart Filter"
-msgstr "أعِد تشغيل المُرشّح"
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "تمرير طبيعي"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "الإضاءة الليلية"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-dialog.ui:79
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "عطّل مؤقتًا حتى الغد"
 
-#: panels/display/cc-night-light-dialog.ui:106
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "أعِد تشغيل المُرشّح"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1562,53 +1088,60 @@ msgstr ""
 "تجعل الإضاءة الليلية ألوان الشاشة أدفأ. يساعد هذا على تفادي إجهاد العين "
 "و الأرق."
 
-#: panels/display/cc-night-light-dialog.ui:127
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "الجدول"
 
-#: panels/display/cc-night-light-dialog.ui:148
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "من الغروب للشروق"
 
-#: panels/display/cc-night-light-dialog.ui:164
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:56 panels/network/network-proxy.ui:113
-#: panels/network/network-wifi.ui:776 panels/network/network-wifi.ui:1053
-#: panels/privacy/cc-privacy-panel.c:239
-msgid "Manual"
-msgstr "يدويًا"
+#: panels/display/cc-night-light-page.ui:141
+#, fuzzy
+msgid "Manual Schedule"
+msgstr "الجدول"
 
-#: panels/display/cc-night-light-dialog.ui:180
-msgid "_Off"
-msgstr "مع_طّل"
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "الوقت"
 
-#: panels/display/cc-night-light-dialog.ui:216
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "من"
 
-#: panels/display/cc-night-light-dialog.ui:254
-#: panels/display/cc-night-light-dialog.ui:361
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "ساعة"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "دقيقة"
+
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-dialog.ui:284
-#: panels/display/cc-night-light-dialog.ui:391
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "ص"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-dialog.ui:300
-#: panels/display/cc-night-light-dialog.ui:407
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "م"
 
-#: panels/display/cc-night-light-dialog.ui:449
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "إلى"
 
-#: panels/display/cc-night-light-dialog.ui:470
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "حرارة اللون"
 
@@ -1620,320 +1153,177 @@ msgstr "الشاشات"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "اختر كيف تستخدم الشاشات و أجهزة عرض الشرائح"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/display/gnome-display-panel.desktop.in.in:7
-msgid "preferences-desktop-display"
-msgstr "preferences-desktop-display"
-
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
 msgstr "لوحة;عرض;شاشة;ميز;ليل;إضاءة;شروق;غروب;لون;"
 
-#: panels/info/cc-info-default-apps-panel.ui:31
-msgid "_Web"
-msgstr "ال_وب"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#: panels/info/cc-info-default-apps-panel.ui:43
-msgid "_Mail"
-msgstr "ال_بريد"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "مفتاح الأمن"
 
-#: panels/info/cc-info-default-apps-panel.ui:59
-msgid "_Calendar"
-msgstr "الت_قويم"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "مستوى الحبر"
 
-#: panels/info/cc-info-default-apps-panel.ui:75
-msgid "M_usic"
-msgstr "ال_صوتيات"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "مستوى الحبر"
 
-#: panels/info/cc-info-default-apps-panel.ui:91
-msgid "_Video"
-msgstr "ال_فيديو"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "مستوى الحبر"
 
-#: panels/info/cc-info-default-apps-panel.ui:162
-#: panels/info/cc-info-removable-media-panel.ui:161
-msgid "_Photos"
-msgstr "ال_صور"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#. TRANSLATORS: AP type
-#: panels/info/cc-info-overview-panel.c:369
-#: panels/info/cc-info-overview-panel.c:452
-#: panels/info/cc-info-overview-panel.c:497
-#: panels/info/cc-info-overview-panel.c:527 panels/network/panel-common.c:123
-msgid "Unknown"
-msgstr "غير معروف"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "الأمن"
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info/cc-info-overview-panel.c:460
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s؛ معرف البناء: %s"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
 
-#. translators: This is the type of architecture for the OS
-#: panels/info/cc-info-overview-panel.c:477
-#, c-format
-msgid "64-bit"
-msgstr "٦٤ بتة"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr "شاشة;قفل;تشخيص;تحطم;خاص;حديث;مؤقت;شبكة;هوية;"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info/cc-info-overview-panel.c:480
-#, c-format
-msgid "32-bit"
-msgstr "٣٢ بتة"
-
-#: panels/info/cc-info-overview-panel.c:710
-#, c-format
-msgid "Version %s"
-msgstr "الإصدارة %s"
-
-#: panels/info/cc-info-overview-panel.ui:70
-msgid "Device name"
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
 msgstr "اسم الجهاز"
 
-#: panels/info/cc-info-overview-panel.ui:86
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "عنوان العتاد"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "الذاكرة"
 
-#: panels/info/cc-info-overview-panel.ui:102
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "المعالج"
 
-#: panels/info/cc-info-overview-panel.ui:118
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "الرسوميات"
 
-#. To translators: this field contains the distro name and version
-#: panels/info/cc-info-overview-panel.ui:133
-msgid "OS name"
-msgstr "اسم نظام التشغيل"
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
 
-#. To translators: this field contains the distro type
-#: panels/info/cc-info-overview-panel.ui:149
-msgid "OS type"
-msgstr "نوع نظام التشغيل"
-
-#: panels/info/cc-info-overview-panel.ui:165
-msgid "Virtualization"
-msgstr "المحاكاة"
-
-#: panels/info/cc-info-overview-panel.ui:181
-msgid "Disk"
-msgstr "القرص"
-
-#: panels/info/cc-info-overview-panel.ui:293
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "يحسب…"
 
-#: panels/info/cc-info-overview-panel.ui:333
-msgid "Check for updates"
-msgstr "التمس التحديثات"
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "الاسم"
 
-#: panels/info/cc-info-removable-media-panel.c:296
-msgid "Ask what to do"
-msgstr "اسأل ما الذي يجب فعله"
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s؛ معرف البناء: %s"
 
-#: panels/info/cc-info-removable-media-panel.c:300
-msgid "Do nothing"
-msgstr "لا تفعل شيئا"
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "النوع"
 
-#: panels/info/cc-info-removable-media-panel.c:304
-msgid "Open folder"
-msgstr "افتح المجلّد"
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "طرفية جنوم"
 
-#: panels/info/cc-info-removable-media-panel.c:389
-msgid "Other Media"
-msgstr "وسائط أخرى"
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "يُحمّل الخيارات…"
 
-#: panels/info/cc-info-removable-media-panel.c:422
-msgid "Select an application for audio CDs"
-msgstr "اختر تطبيقا لاسطوانات الصوت"
-
-#: panels/info/cc-info-removable-media-panel.c:423
-msgid "Select an application for video DVDs"
-msgstr "اختر تطبيقا لاسطوانات الفديو"
-
-#: panels/info/cc-info-removable-media-panel.c:424
-msgid "Select an application to run when a music player is connected"
-msgstr "اختر تطبيقا لتشغيله عند توصيل مشغّل موسيقى"
-
-#: panels/info/cc-info-removable-media-panel.c:425
-msgid "Select an application to run when a camera is connected"
-msgstr "اختر تطبيقا لتشغيله عند توصيل كمرة"
-
-#: panels/info/cc-info-removable-media-panel.c:426
-msgid "Select an application for software CDs"
-msgstr "اختر تطبيقا لاسطوانات البرامج"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/info/cc-info-removable-media-panel.c:438
-msgid "audio DVD"
-msgstr "دي‌ڤي‌دي صوتي"
-
-#: panels/info/cc-info-removable-media-panel.c:439
-msgid "blank Blu-ray disc"
-msgstr "قرص Blu-Ray فارغ"
-
-#: panels/info/cc-info-removable-media-panel.c:440
-msgid "blank CD disc"
-msgstr "اسطوانة فارغة"
-
-#: panels/info/cc-info-removable-media-panel.c:441
-msgid "blank DVD disc"
-msgstr "قرص دي‌ڤي‌دي فارغ"
-
-#: panels/info/cc-info-removable-media-panel.c:442
-msgid "blank HD DVD disc"
-msgstr "قرص دي‌ڤي‌دي إتش‌دي فارغ"
-
-#: panels/info/cc-info-removable-media-panel.c:443
-msgid "Blu-ray video disc"
-msgstr "قرص Blu-Ray فديو فارغ"
-
-#: panels/info/cc-info-removable-media-panel.c:444
-msgid "e-book reader"
-msgstr "قارئ كتب إلكتروني"
-
-#: panels/info/cc-info-removable-media-panel.c:445
-msgid "HD DVD video disc"
-msgstr "قرص دي‌ڤي‌دي إتش‌دي فديو فارغ"
-
-#: panels/info/cc-info-removable-media-panel.c:446
-msgid "Picture CD"
-msgstr "اسطوانة صور"
-
-#: panels/info/cc-info-removable-media-panel.c:447
-msgid "Super Video CD"
-msgstr "اسطوانة فديو فائقة"
-
-#: panels/info/cc-info-removable-media-panel.c:448
-msgid "Video CD"
-msgstr "اسطوانة فديو"
-
-#: panels/info/cc-info-removable-media-panel.c:449
-msgid "Windows software"
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
 msgstr "برمجيات وندوز"
 
-#: panels/info/cc-info-removable-media-panel.ui:43
-msgid "Select how media should be handled"
-msgstr "اختر كيفية التعامل مع الوسائط"
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "المحاكاة"
 
-#: panels/info/cc-info-removable-media-panel.ui:74
-msgid "CD _audio"
-msgstr "قرص _صوتي"
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "استخدام البرمجيات"
 
-#: panels/info/cc-info-removable-media-panel.ui:91
-msgid "_DVD video"
-msgstr "_دي‌ڤي‌دي فيديو"
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "أزِل جهازا"
 
-#: panels/info/cc-info-removable-media-panel.ui:132
-msgid "_Music player"
-msgstr "مشغّل _موسيقى"
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
 
-#: panels/info/cc-info-removable-media-panel.ui:190
-msgid "_Software"
-msgstr "بر_مجيات"
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "اسم الجهاز"
 
-#: panels/info/cc-info-removable-media-panel.ui:228
-msgid "_Other Media…"
-msgstr "و_سائط أخرى…"
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "ا_سم المستخدم"
 
-#: panels/info/cc-info-removable-media-panel.ui:272
-msgid "_Never prompt or start programs on media insertion"
-msgstr "لا _تسأل أو تبدأ البرامج عند إدخال الوسائط"
-
-#: panels/info/cc-info-removable-media-panel.ui:331
-msgid "Select how other media should be handled"
-msgstr "اختر كيفية التعامل مع الوسائط الأخرى"
-
-#: panels/info/cc-info-removable-media-panel.ui:370
-msgid "_Action:"
-msgstr "الإ_جراء:"
-
-#: panels/info/cc-info-removable-media-panel.ui:393
-msgid "_Type:"
-msgstr "ال_نوع:"
-
-#: panels/info/gnome-default-apps-panel.desktop.in.in:3
-msgid "Default Applications"
-msgstr "التطبيقات المبدئية"
-
-#: panels/info/gnome-default-apps-panel.desktop.in.in:4
-msgid "Configure Default Applications"
-msgstr "اضبط التطبيقات المبدئية"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info/gnome-default-apps-panel.desktop.in.in:7
-msgid "starred"
-msgstr "starred"
-
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/info/gnome-default-apps-panel.desktop.in.in:19
-msgid "default;application;preferred;media;"
-msgstr "مبدئي;تطبيق;مفضل;وسائط;"
-
-#: panels/info/gnome-info-overview-panel.desktop.in.in:3
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
 msgid "About"
 msgstr "عنْ"
 
-#: panels/info/gnome-info-overview-panel.desktop.in.in:4
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr "اعرض معلومات عن نظامك"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info/gnome-info-overview-panel.desktop.in.in:7
-msgid "help-about"
-msgstr "help-about"
-
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
-#: panels/info/gnome-info-overview-panel.desktop.in.in:23
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "جهاز;نظام;معلومات;ذاكرة;معالج;إصدارة;تطبيق;مبدئي;مفضل;قرص مضغوط;دي في دي;يو "
 "اس بي;صوت;فيديو;قرص;قابل للفصل;وسائط;تشغيل تلقائي;"
-
-#: panels/info/gnome-removable-media-panel.desktop.in.in:3
-msgid "Removable Media"
-msgstr "الوسائط المنفصلة"
-
-#: panels/info/gnome-removable-media-panel.desktop.in.in:4
-msgid "Configure Removable Media settings"
-msgstr "اضبط إعدادات الوسائط المنفصلة"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info/gnome-removable-media-panel.desktop.in.in:7
-msgid "media-removable"
-msgstr "media-removable"
-
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/info/gnome-removable-media-panel.desktop.in.in:19
-msgid ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
-"removable;media;autorun;"
-msgstr ""
-"جهاز;نظام;تطبيق;مبدئي;مفضل;قرص مضغوط;دي في دي;يو اس بي;صوت;فيديو;قرص;قابل "
-"للفصل;وسائط;تشغيل تلقائي;"
 
 #: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "الصوت والوسائط"
 
 #: panels/keyboard/00-multimedia.xml.in:4
-msgid "Volume mute"
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "أصمِت الصوت"
 
 #: panels/keyboard/00-multimedia.xml.in:6
@@ -1945,35 +1335,40 @@ msgid "Volume up"
 msgstr "ارفع الصوت"
 
 #: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "ميكروفون"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "ابدأ مشغل الوسائط"
 
-#: panels/keyboard/00-multimedia.xml.in:12
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "شغّل (أو شغّل\\ألبِث)"
 
-#: panels/keyboard/00-multimedia.xml.in:14
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "ألبِث التشغيل"
 
-#: panels/keyboard/00-multimedia.xml.in:16
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "أوقف التشغيل"
 
-#: panels/keyboard/00-multimedia.xml.in:18
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "المقطوعة السابقة"
 
-#: panels/keyboard/00-multimedia.xml.in:20
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "المقطوعة التالية"
 
-#: panels/keyboard/00-multimedia.xml.in:22
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "أخرِج"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:580
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "الكتابة"
 
@@ -1992,6 +1387,12 @@ msgstr "مشغلات التطبيقات"
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "شغّل متصفّح المساعدة"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "الإعدادات"
 
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -2014,39 +1415,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "ابحث"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "لقطات الشاشة"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "احفظ لقطة شاشة في مجلد $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "احفظ لقطة شاشة لنافذة في مجلد $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "احفظ لقطة شاشة لمنطقة في مجلد $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "انسخ اللقطة إلى الحافظة"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "انسخ لقطة النافذة إلى الحافظة"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "انسخ لقطة المنطقة المحددة إلى الحافظة"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "سجّل تسجيل شاشة قصير"
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "النظام"
 
@@ -2060,8 +1429,9 @@ msgstr "أوصد الشاشة"
 
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
-msgid "Universal Access"
-msgstr "الإتاحة"
+#, fuzzy
+msgid "Accessibility"
+msgstr "الظهور"
 
 #: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
@@ -2095,171 +1465,427 @@ msgstr "صغّر النص"
 msgid "High contrast on or off"
 msgstr "شغّل أو عطّل التباين العال"
 
-#: panels/keyboard/cc-keyboard-manager.c:501
-#: panels/keyboard/cc-keyboard-manager.c:509
-#: panels/keyboard/cc-keyboard-manager.c:809
-msgid "Custom Shortcuts"
-msgstr "اختصارات مخصصة"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "أضف مصْدَر إدخال"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: panels/keyboard/cc-keyboard-option.c:337
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "لا يمكن استخدام مصادر الإدخال في شاشة الولوج"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "لم تحدد أي مصادر إدخال"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "الخيارات"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "انقل لأعلى"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "انقل لأسفل"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "التفضيلات"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "اعرض وعدّل خيارات تخطيط لوحة المفاتيح"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr "أزل"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "مصادر الإدخال"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+#, fuzzy
+msgid "Includes keyboard layouts and input methods."
+msgstr "اختر تخطيط لوحة المفاتيح وطرق الإدخال"
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "خيارات مصْدَر الإدخال"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "استخدم _نفس المصدر لكل النوافذ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "ا_سمح بمصدر مختلف لكل نافذة"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "مفتاح الحروف البديلة"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: panels/keyboard/cc-keyboard-option.c:346
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "مفتاح التركيب"
 
-#: panels/keyboard/cc-keyboard-option.c:351
-#, fuzzy
-msgid "Modifiers-only switch to next source"
-msgstr "تحول إلى المصدر التالي"
-
-#: panels/keyboard/cc-keyboard-panel.c:179
-msgid "Reset All Shortcuts?"
-msgstr "أتريد تصفير كل الاختصارات؟"
-
-#: panels/keyboard/cc-keyboard-panel.c:182
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"تصفير الاختصارات قد يؤثر على اختصاراتك المخصوصة. لا يمكن التراجع عن هذا."
-
-#: panels/keyboard/cc-keyboard-panel.c:186
-#: panels/keyboard/shortcut-editor.ui:346
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-msgid "Cancel"
-msgstr "ألغِ"
-
-#: panels/keyboard/cc-keyboard-panel.c:187
-msgid "Reset All"
-msgstr "صفّر الكل"
-
-#: panels/keyboard/cc-keyboard-panel.c:283
-msgid "Reset the shortcut to its default value"
-msgstr "أعِد الاختصار إلى قيمته المبدئية"
-
-#: panels/keyboard/cc-keyboard-panel.ui:67 panels/region/cc-region-panel.ui:395
-#: shell/cc-window.ui:279
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "اختصارات لوحة المفاتيح"
 
-#: panels/keyboard/cc-keyboard-panel.ui:77
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "اختصارات مخصصة"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
 msgstr "صفّر الكل…"
 
-#: panels/keyboard/cc-keyboard-panel.ui:78
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "أعِد كل الاختصارات إلى قيمها المبدئية"
 
-#: panels/keyboard/cc-keyboard-panel.ui:164
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "القسم"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "الاختصارات"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "أضف اختصارًا"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "أضف اختصارًا مخصصًا"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "أضف اختصارًا"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "لم يُعثر على أي اختصارات للوحة المفاتيح"
 
-#: panels/keyboard/cc-keyboard-panel.ui:175 shell/cc-panel-list.ui:206
-msgid "Try a different search"
-msgstr "جرب بحثًا آخر"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "أ_زل"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:411
-#, c-format
-msgid ""
-"%s is already being used for <b>%s</b>. If you replace it, %s will be "
-"disabled"
-msgstr "الاختصار %s مستخدم حاليا من أجل <b>%s</b>. إذا استبدلته، فيُعطّل %s."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "استبدل"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
-msgid "Set Custom Shortcut"
-msgstr "حدد اختصارًا مخصصًا"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
-msgid "Set Shortcut"
-msgstr "حدد اختصارًا"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+#, fuzzy
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "اضغط Esc أو إلغاء أو Backspace لإعادة اختصار لوحة المفاتيح لأصله."
 
-#. Setup the top label
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:590
-#, c-format
-msgid "Enter new shortcut to change <b>%s</b>."
-msgstr "أدخل اختصارًا جديدًا لتغيير <b>%s</b>."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "الاسم"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:1017
-msgid "Add Custom Shortcut"
-msgstr "أضف اختصارًا مخصصًا"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "الأمر"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "الاختصار"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "حدد اختصارًا…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "لا شيء"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "أعِد الاختصار إلى قيمته المبدئية"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "ا_ستعد المبدئيات"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "لوحة المفاتيح"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr "اعرض و غيّر اختصارات لوحة المفاتيح و اضبط خيارات الكتابة"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:7
-msgid "input-keyboard"
-msgstr "input-keyboard"
-
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr "اختصار;منطقة عمل;نافذة;تحجيم;تقريب;تباين;إدخال;مصدر;قفل;"
 
-#: panels/keyboard/shortcut-editor.ui:68 panels/keyboard/shortcut-editor.ui:318
-msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "اضغط Esc أو إلغاء أو Backspace لإعادة اختصار لوحة المفاتيح لأصله."
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "خدمات التموضع"
 
-#: panels/keyboard/shortcut-editor.ui:156 panels/printers/details-dialog.ui:38
-msgid "Name"
-msgstr "الاسم"
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "لا تطبيقات تشغل أو تسجل صوتا حاليا."
 
-#: panels/keyboard/shortcut-editor.ui:168
-msgid "Command"
-msgstr "الأمر"
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:180
-msgid "Shortcut"
-msgstr "الاختصار"
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:259
-msgid "Set Shortcut…"
-msgstr "حدد اختصارًا…"
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:272 panels/network/network-wifi.ui:593
-msgid "None"
-msgstr "لا شيء"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:303
-msgid "Enter the new shortcut"
-msgstr "أدخِل اختصارًا جديدًا"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "تطفأ الشاشة"
 
-#: panels/keyboard/shortcut-editor.ui:357
-msgid "Remove"
-msgstr "أزل"
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "لا يوجد أي تطبيقات"
 
-#: panels/keyboard/shortcut-editor.ui:367
-msgid "Add"
-msgstr "أضف"
+#: panels/microphone/cc-microphone-panel.ui:37
+#, fuzzy
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"استخدام الميكروفون يتيح للتطبيقات تسجيل الصوت. تعطيل الميكروفون قد يتسبب في "
+"ألا تعمل بعض التطبيقات كما يجب."
 
-#: panels/keyboard/shortcut-editor.ui:382
-msgid "Replace"
-msgstr "استبدل"
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:395
-msgid "Set"
-msgstr "حدد"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.c:80 panels/wacom/cc-wacom-panel.c:463
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "اختبر إ_عداداتك"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "عام"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "الزر الأساسي"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "حدد ترتيب الأزرار على الفأرة و لوحة اللمس."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "يسار"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "يمين"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "أماكن البحث"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "الفأرة"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "سرعة الفأرة"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "تمرير للأسفل"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "التمرير يحرك المحتوى و ليس المنظور."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "التمرير يحرك المحتوى و ليس المنظور."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "ال_تسارع:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "نشِط"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "لوحة اللمس"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "سرعة لوحة اللمس"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "النقر بالإصبع"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "النقر بالإصبع"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_عطّل أثناء الكتابة"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "لوحة لمس (نسبي)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "التمرير عند الحافة"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "تمرير لليسار"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "على الوجهين"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "جرب النقر والنقر المزدوج والتمرير"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2270,285 +1896,229 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "غيّر حساسية الشاشة و لوح اللمس و اختر اليد اليمنى أم اليسرى"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/mouse/gnome-mouse-panel.desktop.in.in:7
-msgid "input-mouse"
-msgstr "input-mouse"
-
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "فأرة;مؤشر;نقر;مزدوج;زر;لمس;"
 
-#: panels/mouse/gnome-mouse-properties.ui:50
-msgid "General"
-msgstr "عام"
-
-#: panels/mouse/gnome-mouse-properties.ui:88
-msgid "Primary Button"
-msgstr "الزر الأساسي"
-
-#: panels/mouse/gnome-mouse-properties.ui:107
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "حدد ترتيب الأزرار على الفأرة و لوحة اللمس."
-
-#: panels/mouse/gnome-mouse-properties.ui:136
-#: panels/sound/cc-balance-slider.ui:13
-msgid "Left"
-msgstr "يسار"
-
-#: panels/mouse/gnome-mouse-properties.ui:146
-#: panels/sound/cc-balance-slider.ui:15
-msgid "Right"
-msgstr "يمين"
-
-#: panels/mouse/gnome-mouse-properties.ui:182
-msgid "Mouse"
-msgstr "الفأرة"
-
-#: panels/mouse/gnome-mouse-properties.ui:221
-msgid "Mouse Speed"
-msgstr "سرعة الفأرة"
-
-#: panels/mouse/gnome-mouse-properties.ui:243
-#: panels/mouse/gnome-mouse-properties.ui:535
-msgid "Double-click timeout"
-msgstr "مهلة النقر المزدوج"
-
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/gnome-mouse-properties.ui:280
-#: panels/mouse/gnome-mouse-properties.ui:443
-msgid "Natural Scrolling"
-msgstr "تمرير طبيعي"
-
-#: panels/mouse/gnome-mouse-properties.ui:296
-#: panels/mouse/gnome-mouse-properties.ui:459
-msgid "Scrolling moves the content, not the view."
-msgstr "التمرير يحرك المحتوى و ليس المنظور."
-
-#: panels/mouse/gnome-mouse-properties.ui:346
-#: panels/mouse/gnome-mouse-properties.ui:391
-msgid "Touchpad"
-msgstr "لوحة اللمس"
-
-#: panels/mouse/gnome-mouse-properties.ui:514
-msgid "Touchpad Speed"
-msgstr "سرعة لوحة اللمس"
-
-#: panels/mouse/gnome-mouse-properties.ui:573
-msgid "Tap to Click"
-msgstr "النقر بالإصبع"
-
-#: panels/mouse/gnome-mouse-properties.ui:625
-msgid "Two-finger Scrolling"
-msgstr "اللف بأصبعين"
-
-#: panels/mouse/gnome-mouse-properties.ui:678
-msgid "Edge Scrolling"
-msgstr "التمرير عند الحافة"
-
-#: panels/mouse/gnome-mouse-test.c:132 panels/mouse/gnome-mouse-test.ui:25
-msgid "Try clicking, double clicking, scrolling"
-msgstr "جرب النقر والنقر المزدوج والتمرير"
-
-#: panels/mouse/gnome-mouse-test.c:137
-msgid "Five clicks, GEGL time!"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
 msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:142
-msgid "Double click, primary button"
-msgstr "نقرة مزدوجة، الزر الأساسي"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:142
-msgid "Single click, primary button"
-msgstr "نقرة مفردة، الزر الأساسي"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:145
-msgid "Double click, middle button"
-msgstr "نقرة مزدوجة، الزر الأوسط"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:145
-msgid "Single click, middle button"
-msgstr "نقرة مفردة، الزر الأوسط"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "نطاق الألوان: "
 
-#: panels/mouse/gnome-mouse-test.c:148
-msgid "Double click, secondary button"
-msgstr "نقرة مزدوجة، الزر الثانوي"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:148
-msgid "Single click, secondary button"
-msgstr "نقرة مفردة، الزر الثانوي"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "أفرغ ال_مهملات تلقائيا"
 
-#. add proxy to device list
-#: panels/network/cc-network-panel.c:583
-msgid "Network proxy"
-msgstr "وسيط الشبكة"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/cc-network-panel.c:719 panels/network/net-vpn.c:167
-#: panels/network/net-vpn.c:295
-#, c-format
-msgid "%s VPN"
-msgstr "‏VPN %s"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: panels/network/cc-network-panel.c:783 panels/network/cc-wifi-panel.ui:304
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "نأسف، حدث عطل ما. من فضلك اتصل بالدعم الفني."
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: panels/network/cc-network-panel.c:789
-msgid "NetworkManager needs to be running."
-msgstr "يجب أن يكون NetworkManager شغّالًا."
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "الشاشة"
 
-#: panels/network/cc-network-panel.ui:142
-#: panels/network/connection-editor/net-connection-editor.c:581
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "اسحب لتغيير جهاز العرض المبدئي."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "التطبيقات المُعرّفة"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ملفات أخرى"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "‏VPN"
 
-#: panels/network/cc-network-panel.ui:194
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "أضف اتصالًا جديدا"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "غير مُعَد"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:189
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "متّصل"
 
-#: panels/network/cc-wifi-connection-row.ui:36
-msgid "Connection/SSID"
-msgstr "الاتصال/SSID"
-
-#: panels/network/cc-wifi-connection-row.ui:73
-#: panels/network/net-device-ethernet.c:359
-#: panels/network/network-ethernet.ui:120 panels/network/network-mobile.ui:394
-#: panels/network/network-simple.ui:75 panels/network/network-vpn.ui:79
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "الخيارات…"
 
-#: panels/network/cc-wifi-panel.c:281
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:1738
-msgid "Wi-Fi"
-msgstr "واي فاي"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
 
-#: panels/network/cc-wifi-panel.ui:56
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "أتريد تشغيل نقطة بث واي فاي؟"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "اسم الشبكة"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "كلمة السر"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "ولِّد كلمة سر"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "ولِّد كلمة سر"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_شغّل"
+
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "وضع الطائرة"
 
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "يعطل واي فاي و بلوتوث و إنترنت المحمول"
 
-#: panels/network/cc-wifi-panel.ui:141
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "لم يُعثر على محوّل واي فاي"
 
-#: panels/network/cc-wifi-panel.ui:153
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "تأكد من أن محوّل واي فاي متصل و يعمل"
 
-#: panels/network/cc-wifi-panel.ui:188
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "وضع الطائرة مُفعّل"
 
-#: panels/network/cc-wifi-panel.ui:200
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "عطله لاستخدام واي فاي"
 
-#: panels/network/cc-wifi-panel.ui:226
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "نقطة بث واي فاي"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "شغّل نقطة بث واي فاي…"
+
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "الشبكات المرئية"
 
-#: panels/network/cc-wifi-panel.ui:293
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "يجب أن يكون NetworkManager شغّالًا"
 
-#: panels/network/connection-editor/8021x-security-page.ui:26
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "نأسف، حدث عطل ما. من فضلك اتصل بالدعم الفني."
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "أ_من 802.1x"
 
-#: panels/network/connection-editor/8021x-security-page.ui:73
-#: panels/network/connection-editor/security-page.ui:72
-msgid "page 1"
-msgstr "صفحة 1"
-
-#: panels/network/connection-editor/8021x-security-page.ui:224
-#: panels/network/connection-editor/security-page.ui:223
-#: panels/network/wireless-security/eap-method-fast.ui:50
-#: panels/network/wireless-security/eap-method-peap.ui:48
-#: panels/network/wireless-security/eap-method-ttls.ui:31
-msgid "Anony_mous identity"
-msgstr "_هوية مجهولة"
-
-#: panels/network/connection-editor/8021x-security-page.ui:238
-#: panels/network/connection-editor/security-page.ui:237
-msgid "Inner _authentication"
-msgstr "الاستيثاق ال_داخلي"
-
-#: panels/network/connection-editor/8021x-security-page.ui:281
-#: panels/network/connection-editor/security-page.ui:280
-msgid "page 2"
-msgstr "صفحة 2"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:101
-#: panels/network/connection-editor/ce-page-security.c:445
-#: panels/network/connection-editor/details-page.ui:86
-#: panels/network/network-wifi.ui:239
-msgid "Security"
-msgstr "الأمن"
-
-#: panels/network/connection-editor/ce-page.c:481
-msgid "automatic"
-msgstr "تلقائي"
-
-#: panels/network/connection-editor/ce-page.c:521
-#, c-format
-msgid "Profile %d"
-msgstr "إعداد %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:56
-#: panels/network/net-device-wifi.c:123 panels/network/net-device-wifi.c:299
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:60
-#: panels/network/net-device-wifi.c:127 panels/network/net-device-wifi.c:304
-#: panels/network/network-wifi.ui:592
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:64
-#: panels/network/net-device-wifi.c:131
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:69
-#: panels/network/net-device-wifi.c:136
-msgid "Enterprise"
-msgstr "مؤسسة"
-
-#: panels/network/connection-editor/ce-page-details.c:74
-#: panels/network/net-device-wifi.c:141 panels/network/net-device-wifi.c:289
-msgctxt "Wifi security"
-msgid "None"
-msgstr "بدون"
-
-#: panels/network/connection-editor/ce-page-details.c:95
-msgid "Never"
-msgstr "أبدًا"
-
-#: panels/network/connection-editor/ce-page-details.c:110
-#: panels/network/net-device-ethernet.c:137
-#: panels/network/net-device-wifi.c:398
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
@@ -2559,1358 +2129,553 @@ msgstr[3] "منذ %i أيام"
 msgstr[4] "منذ %i يوما"
 msgstr[5] "منذ %i يوم"
 
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:228
-#: panels/network/net-device-ethernet.c:66 panels/network/net-device-wifi.c:476
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d م.بايت\\ث"
-
-#: panels/network/connection-editor/ce-page-details.c:249
-#: panels/network/net-device-wifi.c:505
-msgctxt "Signal strength"
-msgid "None"
-msgstr "لا إشارة"
-
-#: panels/network/connection-editor/ce-page-details.c:251
-#: panels/network/net-device-wifi.c:507
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "ضعيفة"
-
-#: panels/network/connection-editor/ce-page-details.c:253
-#: panels/network/net-device-wifi.c:509
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "معقولة"
-
-#: panels/network/connection-editor/ce-page-details.c:255
-#: panels/network/net-device-wifi.c:511
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "جيّدة"
-
-#: panels/network/connection-editor/ce-page-details.c:257
-#: panels/network/net-device-wifi.c:513
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "ممتازة"
-
-#: panels/network/connection-editor/ce-page-details.c:300
-msgid "Forget Connection"
-msgstr " انس الاتصال"
-
-#: panels/network/connection-editor/ce-page-details.c:302
-msgid "Remove Connection Profile"
-msgstr "أزل إعدادات الاتصال"
-
-#: panels/network/connection-editor/ce-page-details.c:304
-msgid "Remove VPN"
-msgstr "أزل VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:332
-#: panels/network/network-wifi.ui:1433 shell/cc-panel-list.ui:103
-#: shell/cc-window.c:247
-msgid "Details"
-msgstr "تفاصيل"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:174
-#: panels/network/connection-editor/ce-page-vpn.c:188
-#: panels/network/connection-editor/ce-page-wifi.c:194
-#: panels/network/network-wifi.ui:1437
-msgid "Identity"
-msgstr "الهوية"
-
-#: panels/network/connection-editor/ce-page-ip4.c:251
-#: panels/network/connection-editor/ce-page-ip6.c:230
-msgid "Delete Address"
-msgstr "احذف العنوان"
-
-#: panels/network/connection-editor/ce-page-ip4.c:422
-#: panels/network/connection-editor/ce-page-ip6.c:390
-msgid "Delete Route"
-msgstr "احذق السبيل"
-
-#: panels/network/connection-editor/ce-page-ip4.c:896
-#: panels/network/network-wifi.ui:1441
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:828
-#: panels/network/network-wifi.ui:1445
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:245
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "لا شيء"
-
-#: panels/network/connection-editor/ce-page-security.c:268
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:278
-msgid "WEP 128-bit Passphrase"
-msgstr "عبارة سر WEP‏ 128-بتة"
-
-#: panels/network/connection-editor/ce-page-security.c:291
-#: panels/network/wireless-security/wireless-security.c:465
-msgid "LEAP"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:304
-msgid "Dynamic WEP (802.1x)"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:318
-msgid "WPA & WPA2 Personal"
-msgstr "‏WPA و WPA2 شخصي"
-
-#: panels/network/connection-editor/ce-page-security.c:332
-msgid "WPA & WPA2 Enterprise"
-msgstr "‏WPA و WPA2 للمؤسسات"
-
-#: panels/network/connection-editor/details-page.ui:18
-#: panels/network/network-wifi.ui:174
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "قوّة الإشارة"
 
-#: panels/network/connection-editor/details-page.ui:52
-#: panels/network/network-wifi.ui:207
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "سرعة الوصلة"
 
-#: panels/network/connection-editor/details-page.ui:104
-#: panels/network/net-device-ethernet.c:170 panels/network/network-wifi.ui:256
-#: panels/network/panel-common.c:644
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "الأمن"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "عنوان IPv4"
 
-#: panels/network/connection-editor/details-page.ui:122
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-ethernet.c:175
-#: panels/network/network-mobile.ui:189 panels/network/network-wifi.ui:273
-#: panels/network/panel-common.c:645
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "عنوان IPv6"
 
-#: panels/network/connection-editor/details-page.ui:140
-#: panels/network/net-device-ethernet.c:178 panels/network/network-wifi.ui:290
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "عنوان العتاد"
 
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "تشكيلات ICC المدعومة"
+
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:182
-#: panels/network/network-mobile.ui:206 panels/network/network-wifi.ui:307
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "السبيل المبدئي"
 
-#: panels/network/connection-editor/details-page.ui:177
-#: panels/network/connection-editor/ip4-page.ui:197
-#: panels/network/connection-editor/ip6-page.ui:211
-#: panels/network/net-device-ethernet.c:184
-#: panels/network/network-mobile.ui:224 panels/network/network-wifi.ui:325
-#: panels/network/network-wifi.ui:831 panels/network/network-wifi.ui:1108
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: panels/network/connection-editor/details-page.ui:195
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "آخر استخدام"
 
-#: panels/network/connection-editor/details-page.ui:324
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "اتصل _تلقائيا"
 
-#: panels/network/connection-editor/details-page.ui:343
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "اجعله م_تاحا للمستخدمين الآخرين"
 
-#: panels/network/connection-editor/details-page.ui:376
-msgid "Restrict background data usage"
-msgstr "قلل استخدام البيانات في الخلفية"
-
-#: panels/network/connection-editor/details-page.ui:386
-msgid "Appropriate for connections that have data charges or limits."
-msgstr "مناسب للاتصالات التي تحاسب على الاستهلاك أو لها تعليق."
-
-#: panels/network/connection-editor/ethernet-page.ui:16
-#: panels/network/connection-editor/ethernet-page.ui:39
-#: panels/network/connection-editor/ip4-page.ui:209
-#: panels/network/connection-editor/ip4-page.ui:277
-#: panels/network/connection-editor/ip6-page.ui:42
-#: panels/network/connection-editor/ip6-page.ui:223
-#: panels/network/connection-editor/ip6-page.ui:291
-#: panels/network/net-proxy.c:58 panels/network/network-proxy.ui:103
-#: panels/network/wireless-security/eap-method-peap.ui:22
-#: panels/privacy/cc-privacy-panel.c:239
-msgid "Automatic"
-msgstr "تلقائي"
-
-#: panels/network/connection-editor/ethernet-page.ui:19
-msgid "Twisted Pair (TP)"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:22
-msgid "Attachment Unit Interface (AUI)"
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:25
-msgid "BNC"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:28
-msgid "Media Independent Interface (MII)"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:42
-msgid "10 Mb/s"
-msgstr "10 م.بايت\\ث"
-
-#: panels/network/connection-editor/ethernet-page.ui:45
-msgid "100 Mb/s"
-msgstr "100 م.بايت\\ث"
-
-#: panels/network/connection-editor/ethernet-page.ui:48
-msgid "1 Gb/s"
-msgstr "1 ج.بايت/ث"
-
-#: panels/network/connection-editor/ethernet-page.ui:51
-msgid "10 Gb/s"
-msgstr "10 ج.بايت/ث"
-
-#: panels/network/connection-editor/ethernet-page.ui:71
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "الا_سم"
 
-#: panels/network/connection-editor/ethernet-page.ui:100
-#: panels/network/connection-editor/wifi-page.ui:67
-#: panels/network/network-wifi.ui:1260
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "عنوان _MAC"
 
-#: panels/network/connection-editor/ethernet-page.ui:146
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:163
-#: panels/network/connection-editor/wifi-page.ui:97
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "عنوان IP"
 
-#: panels/network/connection-editor/ethernet-page.ui:178
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "بايت"
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "طريقة IPv_4"
 
-#: panels/network/connection-editor/ip4-page.ui:42
-#: panels/network/network-wifi.ui:777 panels/network/network-wifi.ui:1054
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "تلقائي (DHCP)"
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "يدويًا"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "عطّل"
 
-#: panels/network/connection-editor/ip4-page.ui:111
-#: panels/network/connection-editor/ip6-page.ui:125
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "مشتركة مع حواسيب أخرى"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "العناوين"
 
-#: panels/network/connection-editor/ip4-page.ui:129
-#: panels/network/connection-editor/ip4-page.ui:313
-#: panels/network/connection-editor/ip6-page.ui:143
-#: panels/network/connection-editor/ip6-page.ui:327
-#: panels/printers/details-dialog.ui:89
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "العنوان"
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "قناع الشّبكة"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "البوّابة"
 
-#: panels/network/connection-editor/ip4-page.ui:220
-#: panels/network/connection-editor/ip6-page.ui:234
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "تلقائي"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "‏DNS تلقائي"
 
-#: panels/network/connection-editor/ip4-page.ui:244
-#: panels/network/connection-editor/ip6-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "عناوين إنترنت مفصولة بفاصلة"
 
-#: panels/network/connection-editor/ip4-page.ui:265
-#: panels/network/connection-editor/ip6-page.ui:279
-#: panels/network/network-wifi.ui:876 panels/network/network-wifi.ui:1153
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "الطُرق"
 
-#: panels/network/connection-editor/ip4-page.ui:288
-#: panels/network/connection-editor/ip6-page.ui:302
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "سُبُل تلقائية"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:354
-#: panels/network/connection-editor/ip6-page.ui:368
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "المعيار"
 
-#: panels/network/connection-editor/ip4-page.ui:384
-#: panels/network/connection-editor/ip6-page.ui:398
-#: panels/network/network-wifi.ui:932 panels/network/network-wifi.ui:1209
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "استخدم هذا الاتصال _فقط إذا كان الهدف على شبكته"
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "طريقة IPv_6"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "تلقائي، DHCP فقط"
 
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "السابقة"
 
-#: panels/network/connection-editor/net-connection-editor.c:261
-msgid "Unable to open connection editor"
-msgstr "تعذّر فتح محرر الاتصالات"
-
-#: panels/network/connection-editor/net-connection-editor.c:279
-msgid "New Profile"
-msgstr "إعداد جديد"
-
-#: panels/network/connection-editor/net-connection-editor.c:727
-msgid "Import from file…"
-msgstr "استورد من ملف…"
-
-#: panels/network/connection-editor/net-connection-editor.c:759
-msgid "Add VPN"
-msgstr "أضف VPN"
-
-#: panels/network/connection-editor/security-page.ui:26
-#: panels/network/network-wifi.ui:529
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "الأ_من"
 
-#: panels/network/connection-editor/vpn-helpers.c:141
-msgid "Cannot import VPN connection"
-msgstr "تعذّر استيراد اتصال VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:143
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:178
-msgid "Select file to import"
-msgstr "اختر ملفا لاستيراده"
-
-#: panels/network/connection-editor/vpn-helpers.c:182
-#: panels/printers/pp-details-dialog.c:314
-#: panels/sharing/cc-sharing-panel.c:428
-#: panels/user-accounts/cc-avatar-chooser.c:235
-msgid "_Open"
-msgstr "ا_فتح"
-
-#: panels/network/connection-editor/vpn-helpers.c:230
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "يوجد فعلا ملف بالاسم ”%s“."
-
-#: panels/network/connection-editor/vpn-helpers.c:232
-msgid "_Replace"
-msgstr "ا_ستبدل"
-
-#: panels/network/connection-editor/vpn-helpers.c:234
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "هل تريد استبدال %s باتصال VPN الذي تحفظه؟"
-
-#: panels/network/connection-editor/vpn-helpers.c:270
-msgid "Cannot export VPN connection"
-msgstr "تعذّر تصدير اتصال VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:272
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:307
-msgid "Export VPN connection"
-msgstr "صدّر اتصال VPN"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(عطل: تعذّر تحميل محرر اتصالات VPN)"
 
-#: panels/network/connection-editor/wifi-page.ui:20
-#: panels/network/network-wifi.ui:497
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr ""
 
-#: panels/network/connection-editor/wifi-page.ui:36
-#: panels/network/network-wifi.ui:513
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "الشبكة"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "تحكم في اتصالك بالإنترنت"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/network/gnome-network-panel.desktop.in.in:7
-msgid "network-workgroup"
-msgstr "network-workgroup"
-
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"DNS;"
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "شبكة;لاسلكي;واي فاي;بلوتوث;محمول;وسيط;شبكة محلية;مودم;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "واي فاي"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "تحكم في اتصالك بشبكات واي فاي"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/network/gnome-wifi-panel.desktop.in.in:7
-msgid "network-wireless"
-msgstr "network-wireless"
-
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
-msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "شبكة;لاسلكي;واي فاي;بلوتوث;محمول;وسيط;شبكة محلية;مودم;"
 
-#: panels/network/net-device-ethernet.c:123
-#: panels/network/net-device-wifi.c:384
-msgid "never"
-msgstr "أبدًا"
-
-#: panels/network/net-device-ethernet.c:133
-#: panels/network/net-device-wifi.c:394
-msgid "today"
-msgstr "اليوم"
-
-#: panels/network/net-device-ethernet.c:135
-#: panels/network/net-device-wifi.c:396
-msgid "yesterday"
-msgstr "الأمس"
-
-#: panels/network/net-device-ethernet.c:173
-#: panels/network/network-mobile.ui:172 panels/network/panel-common.c:647
-#: panels/network/panel-common.c:649
-msgid "IP Address"
-msgstr "عنوان IP"
-
-#: panels/network/net-device-ethernet.c:189 panels/network/network-wifi.ui:342
-msgid "Last used"
-msgstr "آخر استخدام"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:291
-#: panels/network/network-ethernet.ui:19 panels/network/network-simple.ui:39
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "سلكية"
 
-#: panels/network/net-device-mobile.c:236
-msgid "Add new connection"
-msgstr "أضف اتصالًا جديدا"
-
-#: panels/network/net-device-wifi.c:1157
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "تشغيل نقطة بث اللاسلكي ستفصلك عن <b>%s</b>."
-
-#: panels/network/net-device-wifi.c:1161
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"لا يمكن استخدام الاتصال اللاسلكي للوصول إلى الإنترنت عند تفعيل نقطة البث."
-
-#: panels/network/net-device-wifi.c:1168
-msgid "Turn On Wi-Fi Hotspot?"
-msgstr "أتريد تشغيل نقطة بث واي فاي؟"
-
-#: panels/network/net-device-wifi.c:1190
-msgid ""
-"Wi-Fi hotspots are usually used to share an additional Internet connection "
-"over Wi-Fi."
-msgstr "تستخدم نقاط بث واي فاي عادة لمشاركة اتصال إنترنت إضافي عبر واي فاي."
-
-#: panels/network/net-device-wifi.c:1201
-msgid "_Turn On"
-msgstr "_شغّل"
-
-#: panels/network/net-device-wifi.c:1278
-msgid "Stop hotspot and disconnect any users?"
-msgstr "إيقاف نقطة البث وقطع الاتصال عن أي مستخدمين؟"
-
-#: panels/network/net-device-wifi.c:1281
-msgid "_Stop Hotspot"
-msgstr "أو_قف نقطة البث"
-
-#: panels/network/net-device-wifi.c:1337
-msgid "System policy prohibits use as a Hotspot"
-msgstr "تمنع سياسة النظام استخدامه نقطة بث"
-
-#: panels/network/net-device-wifi.c:1340
-msgid "Wireless device does not support Hotspot mode"
-msgstr "لا يدعم جهاز اللاسلكي وضع نقطة البث"
-
-#: panels/network/net-device-wifi.c:1471
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr "ستُفقد تفاصيل الشبكة، بما في ذلك كلمات السر وأي إعدادات مُخصصة."
-
-#: panels/network/net-device-wifi.c:1475 panels/network/network-wifi.ui:1350
-msgid "_Forget"
-msgstr "ان_سَ"
-
-#: panels/network/net-device-wifi.c:1638 panels/network/net-device-wifi.c:1645
-msgid "Known Wi-Fi Networks"
-msgstr "شبكات واي فاي المعروفة"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1682
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "إن_س"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:102
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "يستخدم الاكتشاف التلقائي للوسيط في حال لم يُعطَ مسار للإعداد."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:110
-msgid "This is not recommended for untrusted public networks."
-msgstr "لا يُنصَح بهذا مع الشبكات العامة غير الموثوقة."
-
-#: panels/network/network-mobile.ui:30
-msgid "IMEI"
-msgstr "IMEI"
-
-#: panels/network/network-mobile.ui:48
-msgid "Provider"
-msgstr "مقدم الخدمة"
-
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:92
-msgid "Network Proxy"
-msgstr "وسيط الشبكة"
-
-#: panels/network/network-proxy.ui:173
-msgid "_HTTP Proxy"
-msgstr "وسيط _HTTP"
-
-#: panels/network/network-proxy.ui:192
-msgid "H_TTPS Proxy"
-msgstr "وسيط H_TTPS"
-
-#: panels/network/network-proxy.ui:211
-msgid "_FTP Proxy"
-msgstr "وسيط _FTP"
-
-#: panels/network/network-proxy.ui:230
-msgid "_Socks Host"
-msgstr "مستضيف _Socks"
-
-#: panels/network/network-proxy.ui:249
-msgid "_Ignore Hosts"
-msgstr "_تجاهل المستضيفين"
-
-#: panels/network/network-proxy.ui:287
-msgid "HTTP proxy port"
-msgstr "منفذ وسيط HTTP"
-
-#: panels/network/network-proxy.ui:364
-msgid "HTTPS proxy port"
-msgstr "منفذ وسيط HTTPS"
-
-#: panels/network/network-proxy.ui:385
-msgid "FTP proxy port"
-msgstr "منفذ وسيط FTP"
-
-#: panels/network/network-proxy.ui:406
-msgid "Socks proxy port"
-msgstr "منفذ وسيط Socks"
-
-#: panels/network/network-proxy.ui:435
-msgid "_Configuration URL"
-msgstr "م_سار الإعداد"
-
-#: panels/network/network-simple.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "أغلق الجهاز"
 
-#: panels/network/network-vpn.ui:56
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "نشِط"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "مقدم الخدمة"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "عنوان IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "وسيط الشبكة"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "وسيط _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "وسيط H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "وسيط _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "مستضيف _Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_تجاهل المستضيفين"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "منفذ وسيط HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "منفذ وسيط HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "منفذ وسيط FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "منفذ وسيط Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "م_سار الإعداد"
+
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "أوقف اتصال VPN"
 
-#: panels/network/network-wifi.ui:127
-msgid "Automatic _Connect"
-msgstr "اتّ_صل تلقائيا"
-
-#: panels/network/network-wifi.ui:474
-msgid "details"
-msgstr "التفاصيل"
-
-#: panels/network/network-wifi.ui:545
-#: panels/network/wireless-security/eap-method-leap.ui:40
-#: panels/network/wireless-security/eap-method-simple.ui:40
-#: panels/network/wireless-security/ws-leap.ui:40
-#: panels/network/wireless-security/ws-wpa-psk.ui:22
-#: panels/sharing/cc-sharing-panel.ui:357
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:214
-msgid "_Password"
-msgstr "كلمة ال_سر"
-
-#: panels/network/network-wifi.ui:621
-msgid "Show P_assword"
-msgstr "أ_ظهر كلمة السر"
-
-#: panels/network/network-wifi.ui:651
-msgid "Make available to other users"
-msgstr "اجعله متاحا للمستخدمين الآخرين"
-
-#: panels/network/network-wifi.ui:679
-msgid "identity"
-msgstr "الهوية"
-
-#: panels/network/network-wifi.ui:713
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: panels/network/network-wifi.ui:754 panels/network/network-wifi.ui:1031
-msgid "_Addresses"
-msgstr "ال_عنوان"
-
-#: panels/network/network-wifi.ui:778 panels/network/network-wifi.ui:1055
-msgid "Automatic (DHCP) addresses only"
-msgstr "عناوين (DHCP) تلقائية فقط"
-
-#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
-msgid "Link-local only"
-msgstr ""
-
-#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
-msgid "Shared with other computers"
-msgstr "مشتركة مع حواسيب أخرى"
-
-#: panels/network/network-wifi.ui:916 panels/network/network-wifi.ui:1193
-msgid "_Ignore automatically obtained routes"
-msgstr "_تجاهل السُبُل المُضافة آليًا"
-
-#: panels/network/network-wifi.ui:959
-msgid "ipv4"
-msgstr "ipv4"
-
-#: panels/network/network-wifi.ui:990
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: panels/network/network-wifi.ui:1236
-msgid "ipv6"
-msgstr "ipv6"
-
-#: panels/network/network-wifi.ui:1276
-msgid "_Cloned MAC Address"
-msgstr "عنوان MAC _منسوخ"
-
-#: panels/network/network-wifi.ui:1334
-msgid "_Reset"
-msgstr "_صفّر"
-
-#: panels/network/network-wifi.ui:1370
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"صفّر كل إعدادات هذا الاتصال لقيمها المبدئية و لكن تذكّر أنها الاتصال المُفضّل."
-
-#: panels/network/network-wifi.ui:1387
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr "احذف كل التفاصيل المتعلقة بهذه الشبكة و لا تحاول الاتصال بها تلقائيا."
-
-#: panels/network/network-wifi.ui:1449
-msgid "Hardware"
-msgstr "العتاد"
-
-#: panels/network/network-wifi.ui:1453
-msgctxt "tab"
-msgid "Reset"
-msgstr "صفّر"
-
-#: panels/network/network-wifi.ui:1505
-msgid "Wi-Fi Hotspot"
-msgstr "نقطة بث واي فاي"
-
-#: panels/network/network-wifi.ui:1523
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "أطفئ للاتصال بشبكة واي فاي"
-
-#: panels/network/network-wifi.ui:1572
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "اسم الشبكة"
 
-#: panels/network/network-wifi.ui:1590
-msgid "Connected Devices"
-msgstr "الأجهزة الموصّلة"
-
-#: panels/network/network-wifi.ui:1608
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "نوع الأمن"
 
-#: panels/network/network-wifi.ui:1671
-msgctxt "Wi-Fi passkey"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "كلمة السر"
 
-#: panels/network/network-wifi.ui:1768
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "أغلق واي فاي"
 
-#: panels/network/network-wifi.ui:1800
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "يُحمّل الخيارات…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "اتّ_صل بشبكة مخفية…"
 
-#: panels/network/network-wifi.ui:1810
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "شغّل نقطة بث واي فاي…"
 
-#: panels/network/network-wifi.ui:1820
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_شبكات واي فاي المعروفة"
 
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:127
-msgid "Ad-hoc"
-msgstr "لا مركزية"
-
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:131
-msgid "Infrastructure"
-msgstr "مركزية"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:147 panels/network/panel-common.c:201
-msgid "Status unknown"
-msgstr "الحالة غير معروفة"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:151
-msgid "Unmanaged"
-msgstr "غير مُدار"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:155
-msgid "Unavailable"
-msgstr "غير متاح"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:165 panels/network/panel-common.c:207
-msgid "Connecting"
-msgstr "يتّصل"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:169 panels/network/panel-common.c:211
-msgid "Authentication required"
-msgstr "الاستيثاق مطلوب"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:173 panels/network/panel-common.c:215
-msgid "Connected"
-msgstr "متّصل"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:177
-msgid "Disconnecting"
-msgstr "يقطع الاتصال"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:181 panels/network/panel-common.c:219
-msgid "Connection failed"
-msgstr "فشل الاتصال"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:185 panels/network/panel-common.c:227
-msgid "Status unknown (missing)"
-msgstr "الحالة غير معروفة (مفقودة)"
-
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:223
-msgid "Not connected"
-msgstr "غير متّصِل"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "Configuration failed"
-msgstr "فشل الإعداد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252
-msgid "IP configuration failed"
-msgstr "فشل إعداد رقم الإنترنت (IP)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "IP configuration expired"
-msgstr "انتهت صلاحية إعداد رقم الإنترنت (IP)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:260
-msgid "Secrets were required, but not provided"
-msgstr "الأسرار مطلوبة لكن لم تُعطَ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:264
-msgid "802.1x supplicant disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:268
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:272
-msgid "802.1x supplicant failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:276
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:280
-msgid "PPP service failed to start"
-msgstr "فشل بدء خدمة PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:284
-msgid "PPP service disconnected"
-msgstr "فصلت خدمة PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:288
-msgid "PPP failed"
-msgstr "فشل PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:292
-msgid "DHCP client failed to start"
-msgstr "فشل بدء عميل DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:296
-msgid "DHCP client error"
-msgstr "خطأ من عميل DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:300
-msgid "DHCP client failed"
-msgstr "فشل عميل DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:304
-msgid "Shared connection service failed to start"
-msgstr "فشل بدء خدمة الاتصال المشترك"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:308
-msgid "Shared connection service failed"
-msgstr "فشلت خدمة الاتصال المشترك"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:312
-msgid "AutoIP service failed to start"
-msgstr "فشل بدء خدمة AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:316
-msgid "AutoIP service error"
-msgstr "عطل في خدمة AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:320
-msgid "AutoIP service failed"
-msgstr "فشلت خدمة AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:324
-msgid "Line busy"
-msgstr "الخط مشغول"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:328
-msgid "No dial tone"
-msgstr "الخط مقطوع"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:332
-msgid "No carrier could be established"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:336
-msgid "Dialing request timed out"
-msgstr "انتهت مهلة الاتصال الهاتفي"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:340
-msgid "Dialing attempt failed"
-msgstr "فشل الاتصال الهاتفي"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:344
-msgid "Modem initialization failed"
-msgstr "فشلت تهيئة المودم"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:348
-msgid "Failed to select the specified APN"
-msgstr "تعذّر اختيار APN المحدد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:352
-msgid "Not searching for networks"
-msgstr "لن يبحث عن شبكة"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:356
-msgid "Network registration denied"
-msgstr "رُفض تسجيل الشبكة"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:360
-msgid "Network registration timed out"
-msgstr "انتهت مهلة تسجيل الشبكة"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:364
-msgid "Failed to register with the requested network"
-msgstr "فشل تسجيل الشبكة المطلوبة"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:368
-msgid "PIN check failed"
-msgstr "فضل فحص PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:372
-msgid "Firmware for the device may be missing"
-msgstr "البرمجيات المضمنة التي يحتاجها الجهاز غير متاحة"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:376
-msgid "Connection disappeared"
-msgstr "اختفى الاتصال"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:380
-msgid "Existing connection was assumed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:384
-msgid "Modem not found"
-msgstr "المودم غير موجود"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:388
-msgid "Bluetooth connection failed"
-msgstr "فشل اتصال بلوتوث"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:392
-msgid "SIM Card not inserted"
-msgstr "لم تُدرج شريحة الهاتف"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:396
-msgid "SIM Pin required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:400
-msgid "SIM Puk required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:404
-msgid "SIM wrong"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:408
-msgid "Connection dependency failed"
-msgstr "فشلت اعتمادية الاتصال"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:433
-msgid "Firmware missing"
-msgstr "البرمجية المغروسة غير متاحة"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:437
-msgid "Cable unplugged"
-msgstr "الكبل مفصول"
-
-#: panels/network/wireless-security/eap-method.c:69
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:245
-msgid "no file selected"
-msgstr "لم تحدد أي ملف"
-
-#: panels/network/wireless-security/eap-method.c:276
-msgid "unspecified error validating eap-method file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:451
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:454
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:72
-msgid "missing EAP-FAST PAC file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:268
-#: panels/network/wireless-security/eap-method-peap.c:302
-#: panels/network/wireless-security/eap-method-ttls.c:351
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.c:283
-#: panels/network/wireless-security/eap-method-peap.c:272
-#: panels/network/wireless-security/eap-method-ttls.c:289
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.c:406
-msgid "Choose a PAC file"
-msgstr "اختر ملف PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:413
-msgid "PAC files (*.pac)"
-msgstr "ملفات PAC‏ (*.pac)"
-
-#: panels/network/wireless-security/eap-method-fast.ui:22
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "مجهول"
 
-#: panels/network/wireless-security/eap-method-fast.ui:25
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "مستوثَق"
 
-#: panels/network/wireless-security/eap-method-fast.ui:28
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "كلاهما"
 
-#: panels/network/wireless-security/eap-method-fast.ui:76
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_هوية مجهولة"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "_ملفات PAC"
 
-#: panels/network/wireless-security/eap-method-fast.ui:122
-#: panels/network/wireless-security/eap-method-peap.ui:146
-#: panels/network/wireless-security/eap-method-ttls.ui:97
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "اختر ملف PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "الاستيثاق ال_داخلي"
 
-#: panels/network/wireless-security/eap-method-fast.ui:156
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.c:74
-msgid "missing EAP-LEAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.ui:26
-#: panels/network/wireless-security/eap-method-simple.ui:26
-#: panels/network/wireless-security/ws-leap.ui:26
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "ا_سم المستخدم"
 
-#: panels/network/wireless-security/eap-method-leap.ui:68
-#: panels/network/wireless-security/eap-method-simple.ui:85
-#: panels/network/wireless-security/eap-method-tls.ui:164
-#: panels/network/wireless-security/ws-leap.ui:68
-#: panels/network/wireless-security/ws-wpa-psk.ui:76
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "كلمة ال_سر"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "أظهر _كلمة السر"
 
-#: panels/network/wireless-security/eap-method-peap.c:63
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:68
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:287
-#: panels/network/wireless-security/eap-method-ttls.c:336
-#: panels/network/wireless-security/wireless-security.c:441
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-peap.c:381
-#: panels/network/wireless-security/eap-method-tls.c:492
-#: panels/network/wireless-security/eap-method-ttls.c:430
-msgid "Choose a Certificate Authority certificate"
-msgstr "اختر شهادة \"سلطة شهادات\""
-
-#: panels/network/wireless-security/eap-method-peap.ui:25
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "الإصدارة 0"
 
-#: panels/network/wireless-security/eap-method-peap.ui:28
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "الإصدارة 1"
 
-#: panels/network/wireless-security/eap-method-peap.ui:74
-#: panels/network/wireless-security/eap-method-tls.ui:75
-#: panels/network/wireless-security/eap-method-ttls.ui:57
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "شهادة _سُلْطة استيثاق"
 
-#: panels/network/wireless-security/eap-method-peap.ui:96
-#: panels/network/wireless-security/eap-method-tls.ui:97
-#: panels/network/wireless-security/eap-method-ttls.ui:79
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "اختر شهادة \"سلطة شهادات\""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "غير مطلوب أي _شهادة من سلطة شهادات"
 
-#: panels/network/wireless-security/eap-method-peap.ui:114
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "إ_صدارة PEAP:"
 
-#: panels/network/wireless-security/eap-method-simple.c:74
-msgid "missing EAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-simple.c:87
-msgid "missing EAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:68
-msgid "missing EAP-TLS identity"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:77
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:84
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:100
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:110
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:307
-msgid "Unencrypted private keys are insecure"
-msgstr "المفاتيح السرية غير المُعمّاة ليست آمنة"
-
-#: panels/network/wireless-security/eap-method-tls.c:310
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"المفتاح السري المحدد ليس محميًا بكلمة سر.  قد يتسبب هذا في تقويض اعتمادات "
-"الأمان. رجاء اختر مفتاحًا محميًا بكلمة سر.\n"
-"\n"
-"(يمكنك حماية مفتاحك بكلمة سر باستخدام openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:486
-msgid "Choose your personal certificate"
-msgstr "اختر شهادتك الشخصية"
-
-#: panels/network/wireless-security/eap-method-tls.c:498
-msgid "Choose your private key"
-msgstr "اختر مفتاحك السري"
-
-#: panels/network/wireless-security/eap-method-tls.ui:24
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "ا_لهوية"
 
-#: panels/network/wireless-security/eap-method-tls.ui:50
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "شهادة المست_خدم"
 
-#: panels/network/wireless-security/eap-method-tls.ui:115
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "المفتاح ال_سري"
 
-#: panels/network/wireless-security/eap-method-tls.ui:140
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "كل_مة سر المفتاح السري"
 
-#: panels/network/wireless-security/eap-method-ttls.c:63
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:68
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:259
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: panels/network/wireless-security/eap-method-ttls.c:274
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.c:305
+#: panels/network/wireless-security/eap-method-ttls.ui:25
 msgid "MSCHAPv2 (no EAP)"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-ttls.c:321
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/wireless-security.c:87
-msgid "Unknown error validating 802.1X security"
-msgstr ""
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "الن_طاق"
 
-#: panels/network/wireless-security/wireless-security.c:453
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: panels/network/wireless-security/wireless-security.c:477
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
 msgid "PWD"
 msgstr ""
 
-#: panels/network/wireless-security/wireless-security.c:488
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr ""
 
-#: panels/network/wireless-security/wireless-security.c:499
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "‏TLS عبر نفق"
 
-#: panels/network/wireless-security/wireless-security.c:510
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "‏EAP ‏(PEAP) محمي"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:39
-#: panels/network/wireless-security/ws-wep-key.ui:115
-#: panels/network/wireless-security/ws-wpa-eap.ui:33
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "الا_ستيثاق"
 
-#: panels/network/wireless-security/ws-leap.c:63
-msgid "missing leap-username"
-msgstr ""
-
-#: panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "ال_نوع"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -3924,77 +2689,62 @@ msgstr "نظام مفتوح"
 msgid "Shared Key"
 msgstr "مفتاح مشترك"
 
-#: panels/network/wireless-security/ws-wep-key.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "الم_فتاح"
 
-#: panels/network/wireless-security/ws-wep-key.ui:94
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "أظهر ال_مفتاح"
 
-#: panels/network/wireless-security/ws-wep-key.ui:152
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "_فهرس WEP"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.ui:50
-msgid "_Type"
-msgstr "ال_نوع"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:61
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "ال_تنبيهات"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:113
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "التنبيهات ال_صوتية"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:169
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "_نوافذ التنبيهات المنبثقة"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:185
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
 msgstr "ستظل التنبيهات ظاهرة في قائمة التنبيهات عند تعطيل النوافذ المنبثقة."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:250
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "أ_ظهر محتوى الرسائل في نوافذ منبثقة"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:301
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "تنبيهات شاشة ال_قفل"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:352
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "أظهر محتوى الر_سالة في شاشة القفل"
 
-#: panels/notifications/cc-notifications-panel.ui:70
-msgid "Notification _Popups"
-msgstr "_نوافذ التنبيهات المنبثقة"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
 
-#: panels/notifications/cc-notifications-panel.ui:121
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr "تنبيهات شاشة ال_قفل"
 
@@ -4002,39 +2752,32 @@ msgstr "تنبيهات شاشة ال_قفل"
 msgid "Control which notifications are displayed and what they show"
 msgstr "تحكم في أي التنبيهات تُعرض و ماذا تعرِض"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/notifications/gnome-notifications-panel.desktop.in.in:7
-msgid "preferences-system-notifications"
-msgstr "preferences-system-notifications"
-
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "تنبيهات;لوحة;رسالة;منبثق;"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:150
-msgctxt "Online Account"
-msgid "Other"
-msgstr "أخرى"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "تراجع"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:621
-#, c-format
-msgid "%s Account"
-msgstr "حساب %s"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "أدِر التنبيهات"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:918
-msgid "Error removing account"
-msgstr "خطأ أثناء إزالة الحساب"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "اتصل ببياناتك في السحاب"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:983
-#, c-format
-msgid "<b>%s</b> removed"
-msgstr "أزيل <b>%s</b>"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "لا اتصال بالإنترنت — اتصل لإعداد حساب إنترنت جديد"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "أضف حسابا"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4044,47 +2787,13 @@ msgstr "حسابات الإنترنت"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "اتصل بحساباتك على الإنترنت و اختر ما الذي تستخدمه منهم"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:7
-msgid "goa-panel"
-msgstr "goa-panel"
-
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr "جوجل;جووجل;فيسبوك;تويتر;ياهو;وب;ويب;محادثة;تقويم;بريد;اتصال;"
 
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
-msgid "Undo"
-msgstr "تراجع"
-
-#: panels/online-accounts/online-accounts.ui:96
-msgid "Connect to your data in the cloud"
-msgstr "اتصل ببياناتك في السحاب"
-
-#: panels/online-accounts/online-accounts.ui:111
-msgid "No internet connection — connect to set up new online accounts"
-msgstr "لا اتصال بالإنترنت — اتصل لإعداد حساب إنترنت جديد"
-
-#: panels/online-accounts/online-accounts.ui:136
-msgid "Add an account"
-msgstr "أضف حسابا"
-
-#: panels/online-accounts/online-accounts.ui:243
-msgid "Remove Account"
-msgstr "أزِل الحساب"
-
-#: panels/power/cc-power-panel.c:260
-msgid "Unknown time"
-msgstr "وقت غير معروف"
-
-#: panels/power/cc-power-panel.c:266
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
@@ -4095,7 +2804,7 @@ msgstr[3] "%i دقائق"
 msgstr[4] "%i دقيقة"
 msgstr[5] "%i دقيقة"
 
-#: panels/power/cc-power-panel.c:278
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
@@ -4106,14 +2815,7 @@ msgstr[3] "%i ساعات"
 msgstr[4] "%i ساعة"
 msgstr[5] "%i ساعة"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-power-panel.c:286
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: panels/power/cc-power-panel.c:287
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ساعة"
@@ -4123,7 +2825,7 @@ msgstr[3] "ساعات"
 msgstr[4] "ساعة"
 msgstr[5] "ساعة"
 
-#: panels/power/cc-power-panel.c:288
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "دقيقة"
@@ -4133,429 +2835,159 @@ msgstr[3] "دقائق"
 msgstr[4] "دقيقة"
 msgstr[5] "دقيقة"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:306
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s حتى يكتمل الشحن"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:313
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "تحذير: بقي %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:318
-#, c-format
-msgid "%s remaining"
-msgstr "بقي %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:323 panels/power/cc-power-panel.c:353
-msgid "Fully charged"
-msgstr "مشحونة بالكامل"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:327 panels/power/cc-power-panel.c:357
-msgid "Not charging"
-msgstr "لا تشحن"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:331 panels/power/cc-power-panel.c:361
-msgid "Empty"
-msgstr "فارغة"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:344
-msgid "Charging"
-msgstr "يشحن"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:349
-msgid "Discharging"
-msgstr "تُفرّغ"
-
-#: panels/power/cc-power-panel.c:479
-msgctxt "Battery name"
-msgid "Main"
-msgstr "الأساسية"
-
-#: panels/power/cc-power-panel.c:481
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "إضافية"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:559
-msgid "Wireless mouse"
-msgstr "فأرة لا سلكية"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:562
-msgid "Wireless keyboard"
-msgstr "لوحة مفاتيح لا سلكية"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:565
-msgid "Uninterruptible power supply"
-msgstr "مزود طاقة غير منقطعة"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:568
-msgid "Personal digital assistant"
-msgstr "مساعد رقمي شخصي PDA"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:571
-msgid "Cellphone"
-msgstr "هاتف خليوي"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:574
-msgid "Media player"
-msgstr "مشغل وسائط"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:577 panels/wacom/cc-wacom-panel.c:848
-msgid "Tablet"
-msgstr "لوحي"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:580
-msgid "Computer"
-msgstr "حاسوب"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:583
-msgid "Gaming input device"
-msgstr "جهاز إدخال ألعاب"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-power-panel.c:586 panels/power/cc-power-panel.c:847
-#: panels/power/cc-power-panel.c:2481
-msgid "Battery"
-msgstr "بطارية"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:646
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "تشحن"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:653
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "إنتباه"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:658
-msgctxt "Battery power"
-msgid "Low"
-msgstr "منخفضة"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:663
-msgctxt "Battery power"
-msgid "Good"
-msgstr "جيّدة"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:668
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "مشحونة بالكامل"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:672
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "فارغة"
-
-#: panels/power/cc-power-panel.c:845
-msgid "Batteries"
-msgstr "البطاريات"
-
-#: panels/power/cc-power-panel.c:1206
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "أقل من ساعة"
-msgstr[1] "ساعة واحدة"
-msgstr[2] "ساعتين"
-msgstr[3] "%d ساعات"
-msgstr[4] "%d ساعة"
-msgstr[5] "%d ساعة"
-
-#: panels/power/cc-power-panel.c:1208
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "أقل من دقيقة"
-msgstr[1] "دقيقة واحدة"
-msgstr[2] "دقيقتين"
-msgstr[3] "%d دقائق"
-msgstr[4] "%d دقيقة"
-msgstr[5] "%d دقيقة"
-
-#: panels/power/cc-power-panel.c:1211
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "أقل من ثانية"
-msgstr[1] "ثانية واحدة"
-msgstr[2] "ثانيتين"
-msgstr[3] "%d ثوان"
-msgstr[4] "%d ثانية"
-msgstr[5] "%d ثانية"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/power/cc-power-panel.c:1216
-#, c-format
-msgctxt "time"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 2 minutes 12 seconds
-#: panels/power/cc-power-panel.c:1219
-#, c-format
-msgctxt "time"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 0 seconds
-#: panels/power/cc-power-panel.c:1225
-msgid "0 seconds"
-msgstr "أقل من ثانية"
-
-#: panels/power/cc-power-panel.c:1322
-msgid "When _idle"
-msgstr "عند عدم الا_ستخدام"
-
-#: panels/power/cc-power-panel.c:1779
-msgid "Power Saving"
-msgstr "حفظ الطاقة"
-
-#: panels/power/cc-power-panel.c:1811
-msgid "_Screen brightness"
-msgstr "س_طوع الشاشة"
-
-#: panels/power/cc-power-panel.c:1833
-msgid "Automatic brightness"
-msgstr "سطوع تلقائي"
-
-#: panels/power/cc-power-panel.c:1855
-msgid "_Keyboard brightness"
-msgstr "سطوع _لوحة المفاتيح"
-
-#: panels/power/cc-power-panel.c:1868
-msgid "_Dim screen when inactive"
-msgstr "أ_خفض ضوء الشاشة عند الخمول"
-
-#: panels/power/cc-power-panel.c:1897
-msgid "_Blank screen"
-msgstr "شاشة _فارغة"
-
-#: panels/power/cc-power-panel.c:1939
-msgid "_Wi-Fi"
-msgstr "واي فاي"
-
-#: panels/power/cc-power-panel.c:1945
-msgid "Wi-Fi can be turned off to save power."
-msgstr "يمكن تعطيل واي فاي لتوفير الطاقة."
-
-#: panels/power/cc-power-panel.c:1975
-msgid "_Mobile broadband"
-msgstr "شبكة هاتف م_حمول"
-
-#: panels/power/cc-power-panel.c:1981
-msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
-msgstr "يمكن تعطل شبكات الهاتف المحمول (٣ج، ٤ج، واي‌ماك، إلخ.) لتوفير الطاقة."
-
-#: panels/power/cc-power-panel.c:2045
-msgid "_Bluetooth"
-msgstr "بلو_توث"
-
-#: panels/power/cc-power-panel.c:2051
-msgid "Bluetooth can be turned off to save power."
-msgstr "يمكن تعطيل بلوتوث لتوفير الطاقة."
-
-#: panels/power/cc-power-panel.c:2107
-msgid "When on battery power"
-msgstr "عندما تكون على طاقة البطارية"
-
-#: panels/power/cc-power-panel.c:2109
-msgid "When plugged in"
-msgstr "عند توصيل الكبل"
-
-#: panels/power/cc-power-panel.c:2203
-msgid "Suspend"
-msgstr "علِّق"
-
-#: panels/power/cc-power-panel.c:2204
-msgid "Power Off"
-msgstr "أطفئ"
-
-#: panels/power/cc-power-panel.c:2205
-msgid "Hibernate"
-msgstr "أسبِت"
-
-#: panels/power/cc-power-panel.c:2206
-msgid "Nothing"
-msgstr "لا تفعل شيئا"
-
-#. Frame header
-#: panels/power/cc-power-panel.c:2306
-msgid "Suspend & Power Button"
-msgstr "التعليق و زر الطاقة"
-
-#: panels/power/cc-power-panel.c:2348
-msgid "_Automatic suspend"
-msgstr "ت_عليق تلقائي"
-
-#: panels/power/cc-power-panel.c:2350
-msgid "Automatic suspend"
-msgstr "تعليق تلقائي"
-
-#: panels/power/cc-power-panel.c:2416
-msgid "_When the Power Button is pressed"
-msgstr "عند _ضغط زر الطاقة"
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "١٥ دقيقة"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "٢٠ دقيقة"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "٢٥ دقيقة"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "٣٠ دقيقة"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "٤٥ دقيقة"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "ساعة واحدة"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "٨٠ دقيقة"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "٩٠ دقيقة"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "١٠٠ دقيقة"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "ساعتين"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:63
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "دقيقة واحدة"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "بطارية"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:67
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "دقيقتين"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "الأجهزة"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:71
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "٣ دقائق"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "أطفئ التشغيل"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:75
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "٤ دقائق"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:79
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "٥ دقائق"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "حفظ الطاقة"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:83
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "٨ دقائق"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "سطوع تلقائي"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:87
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "١٠ دقائق"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "إعدادات سطوع وقفل الشاشة"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:91
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "١٢ دقيقة"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "شاشة"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:95
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "١٥ دقيقة"
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:99
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "أبدًا"
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "قار_ئ الشاشة"
 
-#: panels/power/cc-power-panel.ui:167
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "الإبلاغ التل_قائي عن المشاكل"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "تعليق تلقائي"
+
+#: panels/power/cc-power-panel.ui:175
+#, fuzzy
+msgid "Pauses the computer after a period of inactivity."
+msgstr "ضع الحاسوب لينام عندما لا يكون نشطا:"
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "الزر السفلي"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "تعليق تلقائي"
 
-#: panels/power/cc-power-panel.ui:192
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_موصّل بمقبس الكهرباء"
 
-#: panels/power/cc-power-panel.ui:208
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "على _طاقة البطارية"
 
-#: panels/power/cc-power-panel.ui:253 panels/power/cc-power-panel.ui:313
-#: panels/universal-access/cc-ua-panel.ui:1507
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "التأخير"
 
@@ -4567,85 +2999,12 @@ msgstr "الطاقة"
 msgid "View your battery status and change power saving settings"
 msgstr "اعرض حالة البطارية و غيّر إعدادات توفير الطاقة"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/power/gnome-power-panel.desktop.in.in:7
-msgid "gnome-power-manager"
-msgstr "gnome-power-manager"
-
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr "طاقة;سبات;تعليق;بطارية;إضاءة;شاشة;إسبات;"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "استوثق"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:362
-msgid "Username"
-msgstr "اسم المستخدم"
-
-#. Translators: This is a password needed for printing.
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:383
-#: panels/user-accounts/cc-add-user-dialog.ui:249
-msgid "Password"
-msgstr "كلمة السر"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:337
-msgid "Authentication Required"
-msgstr "الاستيثاق مطلوب"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:715
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "أزيلت الطابعة ”%s“"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:938
-msgid "Failed to add new printer."
-msgstr "تعذّر إضافة طابعة جديدة."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1242
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "تعذّر تحميل الواجهة: %s"
-
-#: panels/printers/details-dialog.ui:64 panels/printers/printer-entry.ui:223
-msgid "Location"
-msgstr "المكان"
-
-#. Translators: Name of column showing printer drivers
-#: panels/printers/details-dialog.ui:114
-#: panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "المُشغّل"
-
-#: panels/printers/details-dialog.ui:152
-msgid "Searching for preferred drivers…"
-msgstr "يبحث عن المُشغّلات المُفضّلة…"
-
-#: panels/printers/details-dialog.ui:174
-msgid "Search for Drivers"
-msgstr "ابحث عن المشغلات"
-
-#: panels/printers/details-dialog.ui:182
-msgid "Select from Database…"
-msgstr "اختر من قاعدة بيانات…"
-
-#: panels/printers/details-dialog.ui:190
-msgid "Install PPD File…"
-msgstr "ثبّت ملف PPD…"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4655,208 +3014,97 @@ msgstr "الطابعات"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "أضف الطابعات و اعرض مهام الطباعة و اختر ما الذي تطبعه"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/printers/gnome-printers-panel.desktop.in.in:7
-msgid "printer"
-msgstr "printer"
-
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "طابعة;طباعة;طبع;ورق;حبر;"
 
-#. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/jobs-dialog.ui:44
-msgid "Domain"
-msgstr "النطاق"
-
-#. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/jobs-dialog.ui:123
-msgid "A_uthenticate"
-msgstr "اس_توثق"
-
-#. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/jobs-dialog.ui:163
-msgid "Clear All"
-msgstr "امسح الكل"
-
-#. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/jobs-dialog.ui:225
-msgid "_Authenticate"
-msgstr "ا_ستوثق"
-
-#. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/jobs-dialog.ui:354
-msgid "No Active Printer Jobs"
-msgstr "لا مهام طابعة نشطة"
-
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:363
-#: panels/printers/pp-new-printer-dialog.c:427
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "أضِف طابعة"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "ا_فتح"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "لم يُعثر على أي طابعات"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "أدخل عنوان شبكة للبحث عن الطابعة"
 
-#: panels/printers/new-printer-dialog.ui:353
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "الاستيثاق مطلوب"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "أدخل اسم المستخدم و كلمة السر لعرض الطابعات المتوفرة على خادوم الطباعة."
 
-#. Translators: This button triggers the printing of a test page.
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/options-dialog.ui:22 panels/printers/pp-options-dialog.c:907
-msgid "Test Page"
-msgstr "صفحة اختبار"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "اسم المستخدم"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:133
-#: panels/printers/pp-details-dialog.c:417
-#, c-format
-msgid "%s Details"
-msgstr "تفاصيل %s"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
 
-#: panels/printers/pp-details-dialog.c:180
-msgid "No suitable driver found"
-msgstr "لم يعثر على أي طابعة مناسبة"
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "المكان"
 
-#: panels/printers/pp-details-dialog.c:310
-msgid "Select PPD File"
-msgstr "اختر ملف PPD"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "المُشغّل"
 
-#: panels/printers/pp-details-dialog.c:319
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr "ملفت وصف طابعة بوست‌سكربت (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "يبحث عن المُشغّلات المُفضّلة…"
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "ابحث عن المشغلات"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "اختر من قاعدة بيانات…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "ثبّت ملف PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "اختر مُشغّل الطابعة"
 
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:108
-msgid "Select"
-msgstr "اختر"
-
-#: panels/printers/ppd-selection-dialog.ui:73
+#: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "يُحمّل قاعدة بيانات المشغلات…"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:472
-msgid "JetDirect Printer"
-msgstr "طابعة JetDirect"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "ألغِ"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:707
-msgid "LPD Printer"
-msgstr "طابعة LPD"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "اختر"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:65
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "على وجه واحد"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:67
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "الحافة الطويلة (قياسي)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:69
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "الحافة القصيرة (ملفوف)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:71
-msgid "Portrait"
-msgstr "طوليّ"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:73
-msgid "Landscape"
-msgstr "عرضيّ"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:75
-msgid "Reverse landscape"
-msgstr "عرضيّ مقلوب"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:77
-msgid "Reverse portrait"
-msgstr "طوليّ مقلوب"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-jobs-dialog.c:234
-msgctxt "print job"
-msgid "Pending"
-msgstr "منتظرة"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-jobs-dialog.c:240
-msgctxt "print job"
-msgid "Paused"
-msgstr "مُلبثة"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-jobs-dialog.c:245
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "الاستيثاق مطلوب"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-jobs-dialog.c:250
-msgctxt "print job"
-msgid "Processing"
-msgstr "تُعالَج"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-jobs-dialog.c:254
-msgctxt "print job"
-msgid "Stopped"
-msgstr "متوقفة"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-jobs-dialog.c:258
-msgctxt "print job"
-msgid "Canceled"
-msgstr "ملغاة"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-jobs-dialog.c:262
-msgctxt "print job"
-msgid "Aborted"
-msgstr "مُجهضَة"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-jobs-dialog.c:266
-msgctxt "print job"
-msgid "Completed"
-msgstr "مُنجزَة"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:390
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
@@ -4867,212 +3115,38 @@ msgstr[3] "تتطلب %u مهمات الاستيثاق"
 msgstr[4] "تتطلب %u مهمة الاستيثاق"
 msgstr[5] "تتطلب %u مهمة الاستيثاق"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:613
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — المهام النشطة"
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "النطاق"
 
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:617
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "أدخل اسم المستخدم و كلمة السر للطباعة من %s."
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "اس_توثق"
 
-#: panels/printers/pp-new-printer-dialog.c:380
-msgid "Unlock Print Server"
-msgstr "افتح خادوم الطباعة"
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "امسح الكل"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:384
-#, c-format
-msgid "Unlock %s."
-msgstr "افتح %s."
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "ا_ستوثق"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:388
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "أدخل اسم المستخدم و كلمة السر لعرض الطابعات المتوفرة على %s."
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "لا مهام طابعة نشطة"
 
-#: panels/printers/pp-new-printer-dialog.c:838
-msgid "Searching for Printers"
-msgstr "البحث عن الطابعات"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1680
-msgid "USB"
-msgstr "يو‌إس‌بي"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1685
-msgid "Serial Port"
-msgstr "منفذ تسلسلي"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1692
-msgid "Parallel Port"
-msgstr "منفذ متواز"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1734
-#, c-format
-msgid "Location: %s"
-msgstr "المكان: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-msgid "Address: %s"
-msgstr "العنوان: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1766
-msgid "Server requires authentication"
-msgstr "يتطلب الخادوم الاستيثاق"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Two Sided"
-msgstr "على الوجهين"
-
-#: panels/printers/pp-options-dialog.c:91
-msgid "Paper Type"
-msgstr "نوع الورق"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "Paper Source"
-msgstr "مصدر الورق"
-
-#: panels/printers/pp-options-dialog.c:93
-msgid "Output Tray"
-msgstr "رف الخارج"
-
-#: panels/printers/pp-options-dialog.c:94
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "الميز"
-
-#: panels/printers/pp-options-dialog.c:95
-msgid "GhostScript pre-filtering"
-msgstr "ترشيح مسبق في غوست‌سكربت"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:548
-msgid "Pages per side"
-msgstr "الصفحات في كل وجه"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:560
-msgid "Two-sided"
-msgstr "على الوجهين"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:572
-msgid "Orientation"
-msgstr "الاتجاه"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "عام"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "إعداد الصفحة"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:675
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "الخيارات القابلة للتثبيت"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:678
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "المهام"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:681
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "جودة الصورة"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:684
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "الألوان"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:687
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "الإنهاء"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:690
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "متقدم"
-
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:920
-msgid "Test page"
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
 msgstr "صفحة اختبار"
 
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "اختيار تلقائي"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "مبدئي الطابعة"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "ادمج خطوط غوست‌سكربت فقط"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "حوّل إلى بوست‌سكربت المستوى 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "حوّل إلى بوست‌سكربت المستوى 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "لا ترشيح مسبق"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "المُصنِّع"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:606 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr "لا مهام نشطة"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:611
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
@@ -5083,912 +3157,499 @@ msgstr[3] "%u مهمات"
 msgstr[4] "%u مهمة"
 msgstr[5] "%u مهمة"
 
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:766
-msgid "Low on toner"
-msgstr "الحبر قليل"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:768
-msgid "Out of toner"
-msgstr "نفد الحبر"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:771
-msgid "Low on developer"
-msgstr "المُحمِّض قليل"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:774
-msgid "Out of developer"
-msgstr "نفد المُحمِّض"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:776
-msgid "Low on a marker supply"
-msgstr "اللون قليل"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:778
-msgid "Out of a marker supply"
-msgstr "نفد اللون"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:780
-msgid "Open cover"
-msgstr "الغطاء مفتوح"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:782
-msgid "Open door"
-msgstr "الباب مفنوح"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:784
-msgid "Low on paper"
-msgstr "الورق قليل"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:786
-msgid "Out of paper"
-msgstr "نفد الورق"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:788
-msgctxt "printer state"
-msgid "Offline"
-msgstr "غير متصلة"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:790
-#: panels/printers/pp-printer-entry.c:918
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "متوقفة"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:792
-msgid "Waste receptacle almost full"
-msgstr "حاوية النفايات على وشك الامتلاء"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:794
-msgid "Waste receptacle full"
-msgstr "حاوية النفايات ممتلئة"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:796
-msgid "The optical photo conductor is near end of life"
-msgstr "قاربت صلاحية المقاوم الضوئي على الانتهاء"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:798
-msgid "The optical photo conductor is no longer functioning"
-msgstr "لم يعد المقاوم الضوئي يعمل"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:904
-msgctxt "printer state"
-msgid "Ready"
-msgstr "جاهزة"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:909
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "لا تقبل المهام"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:914
-msgctxt "printer state"
-msgid "Processing"
-msgstr "تُعالِج"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:938
-msgid "Clean print heads"
-msgstr "نظف رؤوس الطباعة"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "خيارات الطابعة"
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "تفاصيل الطابعة"
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "استخدم الطابعة مبدئيًا"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "نظف رؤوس الطابعة"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "أزِل طابعة"
 
-#: panels/printers/printer-entry.ui:193
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "لا مهام نشطة"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "الطراز"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "مستوى الحبر"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:312
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "رجاء أعد التشغيل بعد حل المشكلة."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:319
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "أعِد التشغيل"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:20
-msgid "Add…"
-msgstr "أضف…"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "أضِف طابعة…"
 
-#: panels/printers/printers.ui:186
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "أضِف طابعة…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "لا طابعات"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:200
-msgid "Add a Printer…"
-msgstr "أضِف طابعة…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:232
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "آسف، يبدو أن خدمة الطباعة\n"
 "في النظام غير متاحة."
 
-#: panels/privacy/cc-privacy-panel.c:423 panels/privacy/cc-privacy-panel.ui:280
-msgid "Screen Lock"
-msgstr "قفل الشاشة"
-
-#: panels/privacy/cc-privacy-panel.c:467
-msgid "In use"
-msgstr "قيد الاستعمال"
-
-#: panels/privacy/cc-privacy-panel.c:472
-msgctxt "Location services status"
-msgid "On"
-msgstr "مشغلة"
-
-#: panels/privacy/cc-privacy-panel.c:473
-msgctxt "Location services status"
-msgid "Off"
-msgstr "مغلقة"
-
-#: panels/privacy/cc-privacy-panel.c:895
-msgctxt "Camera status"
-msgid "Off"
-msgstr "معطّل"
-
-#: panels/privacy/cc-privacy-panel.c:897
-msgctxt "Camera status"
-msgid "On"
-msgstr "مفعّل"
-
-#: panels/privacy/cc-privacy-panel.c:928
-msgctxt "Microphone status"
-msgid "Off"
-msgstr "معطّل"
-
-#: panels/privacy/cc-privacy-panel.c:930
-msgctxt "Microphone status"
-msgid "On"
-msgstr "مفعّل"
-
-#: panels/privacy/cc-privacy-panel.c:1036
-#: panels/privacy/cc-privacy-panel.ui:127
-msgid "Usage & History"
-msgstr "الاستخدام والتأريخ"
-
-#: panels/privacy/cc-privacy-panel.c:1157
-msgid "Empty all items from Trash?"
-msgstr "أأحذف كل العناصر من المهملات؟"
-
-#: panels/privacy/cc-privacy-panel.c:1158
-msgid "All items in the Trash will be permanently deleted."
-msgstr "ستحذف نهائيا كل العناصر الموجودة في المهملات."
-
-#: panels/privacy/cc-privacy-panel.c:1159
-msgid "_Empty Trash"
-msgstr "أ_فرغ المهملات"
-
-#: panels/privacy/cc-privacy-panel.c:1180
-msgid "Delete all the temporary files?"
-msgstr "أأحذف كل الملفات المؤقتة؟"
-
-#: panels/privacy/cc-privacy-panel.c:1181
-msgid "All the temporary files will be permanently deleted."
-msgstr "ستُحذف كل الملفات المؤقتة نهائيًا."
-
-#: panels/privacy/cc-privacy-panel.c:1182
-msgid "_Purge Temporary Files"
-msgstr "ت_خلّص من الملفات المؤقتة"
-
-#: panels/privacy/cc-privacy-panel.c:1204
-#: panels/privacy/cc-privacy-panel.ui:432
-msgid "Purge Trash & Temporary Files"
-msgstr "أفرغ المهملات والملفات المؤقتة"
-
-#: panels/privacy/cc-privacy-panel.c:1237
-#: panels/privacy/cc-privacy-panel.ui:637
-msgid "Software Usage"
-msgstr "استخدام البرمجيات"
-
-#: panels/privacy/cc-privacy-panel.c:1276
-#: panels/privacy/cc-privacy-panel.ui:1169
-msgid "Problem Reporting"
-msgstr "الإبلاغ عن المشاكل"
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: panels/privacy/cc-privacy-panel.c:1288
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-"الإبلاغ عن المشاكل التقنية يساعدنا على تحسين %s. ترسل البلاغات مُجهّلة بدون أي "
-"معلومات شخصية."
-
-#: panels/privacy/cc-privacy-panel.c:1300
-#: panels/privacy/cc-privacy-panel.ui:719
-msgid "Privacy Policy"
-msgstr "سياسة الخصوصية"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:14
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "تطفأ الشاشة"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:18
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "٣٠ ثانية"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:22
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "دقيقة واحدة"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:26
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "دقيقتين"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:30
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "٣ دقائق"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:34
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "٥ دقائق"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:38
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "٣٠ دقيقة"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:42
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "ساعة واحدة"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:56
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "ساعة واحدة"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:60
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "يوم واحد"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:64
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "يومين"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:68
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "٣ أيام"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:72
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "٤ أيام"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:76
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "٥ أيام"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:80
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "٦ أيام"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:84
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "٧ أيام"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:88
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "١٤ يومًا"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:92
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "٣٠ يومًا"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/privacy/cc-privacy-panel.ui:106
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "يوم واحد"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/privacy/cc-privacy-panel.ui:110
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "٧ أيام"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/privacy/cc-privacy-panel.ui:114
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "٣٠ يومًا"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/privacy/cc-privacy-panel.ui:118
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "إلى الأبد"
-
-#: panels/privacy/cc-privacy-panel.ui:148
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"تذكر التأريخ يسهل الوصول إلى الأشياء في ما بعد. لا تُشارك هذه العناصر أبدا "
-"عبر الشبكة."
-
-#: panels/privacy/cc-privacy-panel.ui:176
-msgid "_Recently Used"
-msgstr "مستخدمة مؤ_خرا"
-
-#: panels/privacy/cc-privacy-panel.ui:207
-msgid "Retain _History"
-msgstr "احتف_ظ بالتأريخ"
-
-#: panels/privacy/cc-privacy-panel.ui:247
-msgid "Cl_ear Recent History"
-msgstr "امسح التأريخ ال_حالي"
-
-#: panels/privacy/cc-privacy-panel.ui:301
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "قفل الشاشة يحفظ خصوصيتك حين تبتعد عن حاسوبك."
-
-#: panels/privacy/cc-privacy-panel.ui:328
-msgid "Automatic Screen _Lock"
-msgstr "إي_صاد تلقائي للشاشة"
-
-#: panels/privacy/cc-privacy-panel.ui:362
-msgid "Lock screen _after blank for"
-msgstr "أ_وصِد الشاشة بعد إطفائها لمدة"
-
-#: panels/privacy/cc-privacy-panel.ui:394
-msgid "Show _Notifications"
-msgstr "أظهر ال_تنبيهات"
-
-#: panels/privacy/cc-privacy-panel.ui:454
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"تخلص من المهملات والملفات المؤقتة تلقائيا للمحافظة على خلو حاسوبك من "
-"المعلومات الحساسة."
-
-#: panels/privacy/cc-privacy-panel.ui:483
-msgid "Automatically empty _Trash"
-msgstr "أفرغ ال_مهملات تلقائيا"
-
-#: panels/privacy/cc-privacy-panel.ui:515
-msgid "Automatically purge Temporary _Files"
-msgstr "تخلّص من الملفات المؤ_قتة تلقائيا"
-
-#: panels/privacy/cc-privacy-panel.ui:546
-msgid "Purge _After"
-msgstr "أفرف ب_عد"
-
-#: panels/privacy/cc-privacy-panel.ui:590
-msgid "_Empty Trash…"
-msgstr "أ_فرغ المهملات…"
-
-#: panels/privacy/cc-privacy-panel.ui:606
-msgid "_Purge Temporary Files…"
-msgstr "ت_خلّص من الملفات المؤقتة…"
-
-#: panels/privacy/cc-privacy-panel.ui:654
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"إرسال معلومات لنا عن البرمجيات التي تستخدمها يساعدنا على إمدادك بتوصيات أدق، "
-"كما يساعدنا أيضًا على تسحين برمجياتنا.\n"
-"\n"
-"كل المعلومات التي نجمعها مُجهّلة و لن نشاركها أبدًا مع أي طرف ثالث."
-
-#: panels/privacy/cc-privacy-panel.ui:681
-msgid "_Send software usage statistics"
-msgstr "أر_سل إحصائيات استخدام البرمجيات"
-
-#: panels/privacy/cc-privacy-panel.ui:764
-msgid ""
-"Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
-msgstr ""
-"استخدام الكمرة يتيح للتطبيقات التقاط الصور والفيديو. تعطيل الكمرة قد يتسبب "
-"في ألا تعمل بعض التطبيقات كما يجب."
-
-#: panels/privacy/cc-privacy-panel.ui:812
-msgid "_Camera"
-msgstr "_كمرة"
-
-#: panels/privacy/cc-privacy-panel.ui:869
-msgid ""
-"Use of the microphone allows applications to capture sounds. Disabling the "
-"microphone may cause some applications to not function properly."
-msgstr ""
-"استخدام الميكروفون يتيح للتطبيقات تسجيل الصوت. تعطيل الميكروفون قد يتسبب في "
-"ألا تعمل بعض التطبيقات كما يجب."
-
-#: panels/privacy/cc-privacy-panel.ui:917
-msgid "_Microphone"
-msgstr "_ميكروفون"
-
-#: panels/privacy/cc-privacy-panel.ui:974
-msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"تسمح خدمات التموضع للتطبيقات بمعرفة مكانك. استخدام الشبكات اللاسلكية "
-"و الهاتف المحمول يزيد من دقة هذه الخدمات."
-
-#: panels/privacy/cc-privacy-panel.ui:988
-msgid ""
-"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
-msgstr ""
-"يستخدم خدمة تموضع موزيلا: <a href='https://location.services.mozilla.com/"
-"privacy'>سياسة الخصوصية</a>"
-
-#: panels/privacy/cc-privacy-panel.ui:1038
-msgid "_Location Services"
-msgstr "خدمات ال_تموضع"
-
-#: panels/privacy/cc-privacy-panel.ui:1236
-msgid "_Automatic Problem Reporting"
-msgstr "الإبلاغ التل_قائي عن المشاكل"
-
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:3
-msgid "Privacy"
-msgstr "الخصوصية"
-
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
-msgid "Protect your personal information and control what others might see"
-msgstr "احمِ بياناتك الشخصية و تحكم في ما يمكن للآخرين الاطلاع عليه منها"
-
-#. FIXME
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:8
-msgid "preferences-system-privacy"
-msgstr "preferences-system-privacy"
-
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr "شاشة;قفل;تشخيص;تحطم;خاص;حديث;مؤقت;شبكة;هوية;"
-
-#: panels/region/cc-format-chooser.c:114
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "إمبراطوري"
-
-#: panels/region/cc-format-chooser.c:116
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "متري"
-
-#: panels/region/cc-format-chooser.c:286
-msgid "No regions found"
-msgstr "لا يوجد أي مناطق"
-
-#: panels/region/cc-format-chooser.ui:7
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "النُسق"
 
-#: panels/region/cc-format-chooser.ui:106
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "أماكن البحث"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "النُسق"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "النُسق"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "إعدادات البحث"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "معاينة"
 
-#: panels/region/cc-format-chooser.ui:123
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "التّواريخ"
 
-#: panels/region/cc-format-chooser.ui:154
-msgid "Times"
-msgstr "الوقت"
-
-#: panels/region/cc-format-chooser.ui:185
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "التاريخ و الوقت"
 
-#: panels/region/cc-format-chooser.ui:216
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "الأرقام"
 
-#: panels/region/cc-format-chooser.ui:233
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "القياس"
 
-#: panels/region/cc-format-chooser.ui:250
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "الورق"
 
-#: panels/region/cc-input-chooser.c:193
-msgid "No input sources found"
-msgstr "لا يوجد أي مصادر إدخال"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#: panels/region/cc-input-chooser.c:948
-msgctxt "Input Source"
-msgid "Other"
-msgstr "أخرى"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-#: panels/region/cc-input-chooser.ui:5
-msgid "Add an Input Source"
-msgstr "أضف مصْدَر إدخال"
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#: panels/region/cc-input-chooser.ui:77
-msgid "Input methods can’t be used on the login screen"
-msgstr "لا يمكن استخدام مصادر الإدخال في شاشة الولوج"
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "ثبّت اللغات..."
 
-#: panels/region/cc-region-panel.c:1505
-msgid "Login _Screen"
-msgstr "شاشة الو_لوج"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "حسابك"
 
-#: panels/region/cc-region-panel.ui:64
-#: panels/user-accounts/cc-user-panel.ui:362
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "الل_غة"
 
-#: panels/region/cc-region-panel.ui:99
-msgid "Restart the session for changes to take effect"
-msgstr "يجب إعادة تشغيل الجلسة لتطبيق التغييرات"
-
-#: panels/region/cc-region-panel.ui:114
-msgid "Restart…"
-msgstr "أعِد التشغيل…"
-
-#: panels/region/cc-region-panel.ui:147
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "ال_نُسق"
 
-#: panels/region/cc-region-panel.ui:195
-msgid "Input Sources"
-msgstr "مصادر الإدخال"
-
-#: panels/region/cc-region-panel.ui:209
-msgid "Choose keyboard layouts or input methods."
-msgstr "اختر تخطيط لوحة المفاتيح وطرق الإدخال"
-
-#: panels/region/cc-region-panel.ui:266
-msgid "No input source selected"
-msgstr "لم تحدد أي مصادر إدخال"
-
-#: panels/region/cc-region-panel.ui:300
-msgid "Login settings are used by all users when logging into the system"
-msgstr "يستخدم إعدادات الولوج كل المستخدمين أثناء الولوج إلى النظام"
-
-#: panels/region/cc-region-panel.ui:338
-msgid "Input Source Options"
-msgstr "خيارات مصْدَر الإدخال"
-
-#: panels/region/cc-region-panel.ui:353
-msgid "Use the _same source for all windows"
-msgstr "استخدم _نفس المصدر لكل النوافذ"
-
-#: panels/region/cc-region-panel.ui:371
-msgid "Allow _different sources for each window"
-msgstr "ا_سمح بمصدر مختلف لكل نافذة"
-
-#: panels/region/cc-region-panel.ui:413
-msgid "Previous source"
-msgstr "المصدر السابق"
-
-#: panels/region/cc-region-panel.ui:431
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
-
-#: panels/region/cc-region-panel.ui:446
-msgid "Next source"
-msgstr "المصدر التالي"
-
-#: panels/region/cc-region-panel.ui:464
-msgid "Super+Space"
-msgstr "Super+Space"
-
-#: panels/region/cc-region-panel.ui:479
-msgid "Left+Right Alt"
-msgstr "Left+Right Alt"
-
-#: panels/region/cc-region-panel.ui:495
-msgid "These keyboard shortcuts can be changed in the keyboard settings"
-msgstr "يمكن تغيير هذه الاختصارات من إعدادات لوحة المفاتيح"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "شاشة الو_لوج"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "المنطقة و اللغة"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
-msgstr "اختر لغة العرض و التنسيق و تخطيط لوحة المفاتيح و مصادر الإدخال"
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "اختر لغة العرض"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/region/gnome-region-panel.desktop.in.in:7
-msgid "preferences-desktop-locale"
-msgstr "preferences-desktop-locale"
-
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "اللغة;التخطيط;مفاتيح;"
 
-#: panels/search/cc-search-locations-dialog.c:604
-msgid "Select Location"
-msgstr "اختر مكانًا"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "اختر كيفية التعامل مع الوسائط"
 
-#: panels/search/cc-search-locations-dialog.c:608
-msgid "_OK"
-msgstr "_نعم"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "قرص _صوتي"
 
-#: panels/search/cc-search-panel.c:175
-msgid "No applications found"
-msgstr "لا يوجد أي تطبيقات"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_دي‌ڤي‌دي فيديو"
 
-#: panels/search/cc-search-panel.ui:52
-msgid "Move Up"
-msgstr "انقل لأعلى"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "مشغّل _موسيقى"
 
-#: panels/search/cc-search-panel.ui:69
-msgid "Move Down"
-msgstr "انقل لأسفل"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "بر_مجيات"
 
-#: panels/search/cc-search-panel.ui:105
-msgid "Preferences"
-msgstr "التفضيلات"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "و_سائط أخرى…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "لا _تسأل أو تبدأ البرامج عند إدخال الوسائط"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "اختر كيفية التعامل مع الوسائط الأخرى"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "الإ_جراء:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "ال_نوع:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "الوسائط المنفصلة"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "اضبط إعدادات الوسائط المنفصلة"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"جهاز;نظام;تطبيق;مبدئي;مفضل;قرص مضغوط;دي في دي;يو اس بي;صوت;فيديو;قرص;قابل "
+"للفصل;وسائط;تشغيل تلقائي;"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "قفل الشاشة"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "شاشة _فارغة"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "إي_صاد تلقائي للشاشة"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "إي_صاد تلقائي للشاشة"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "أظهر ال_تنبيهات عندما يكون موصدًا"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "أوصِد الشاشة ب_عد"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "الخصوصية"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "شاشة"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "إعدادات الصوت"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "أماكن البحث"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "الأماكن"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "العلامات"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "أخرى"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "المكان"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "تطبيق"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "إعدادات البحث"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "تحكم في التطبيقات التي ستُعرض نتائج البحث منها في منظور الأنشطة"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/search/gnome-search-panel.desktop.in.in:7
-msgid "preferences-system-search"
-msgstr "preferences-system-search"
-
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "بحث;إخفاء;نتائج;خصوصية;"
 
-#: panels/search/search-locations-dialog.ui:9
-msgid "Search Locations"
-msgstr "أماكن البحث"
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "الشبكات"
 
-#: panels/search/search-locations-dialog.ui:43
-msgid "Places"
-msgstr "الأماكن"
-
-#: panels/search/search-locations-dialog.ui:73
-msgid "Bookmarks"
-msgstr "العلامات"
-
-#: panels/search/search-locations-dialog.ui:130
-msgid "Other"
-msgstr "أخرى"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:307
-msgid "No networks selected for sharing"
-msgstr "لم تختر أي شبكة لمشاركتها"
-
-#: panels/sharing/cc-sharing-panel.c:319
-msgctxt "service is enabled"
-msgid "On"
-msgstr "مفعّل"
-
-#: panels/sharing/cc-sharing-panel.c:321 panels/sharing/cc-sharing-panel.c:348
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "معطّل"
-
-#: panels/sharing/cc-sharing-panel.c:351
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "مفعّل"
-
-#: panels/sharing/cc-sharing-panel.c:354
-msgctxt "service is active"
-msgid "Active"
-msgstr "نشِط"
-
-#: panels/sharing/cc-sharing-panel.c:424
-msgid "Choose a Folder"
-msgstr "اختر مجلّدًا"
-
-#: panels/sharing/cc-sharing-panel.c:724
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr ""
-"تتيح لك ”مشاركة الملفات“ مشاركة المجلد العام مع الآخرين على الشبكة الحالية "
-"باستخدام: <a href=\"dav://%s\">‪dav://%s‬</a>"
-
-#: panels/sharing/cc-sharing-panel.c:726
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"عند تفعيل بالولوج عن بعد، يمكن للمستخدمين الولوج عن بعد باستخدام أمر الصدفة "
-"الآمنة:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:728
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"مشاركة الشاشة تسمح للمستخدمين عن بعد بالتحكم في شاشتك باستخدام: <a href="
-"\"vnc://%s\">‪vnc://%s‬</a>"
-
-#: panels/sharing/cc-sharing-panel.c:832
-msgid "Copy"
-msgstr "انسخ"
-
-#: panels/sharing/cc-sharing-panel.c:1285
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "المشاركة"
 
-#: panels/sharing/cc-sharing-panel.ui:50
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr "ا_سم الحاسوب"
 
-#: panels/sharing/cc-sharing-panel.ui:108
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr "م_شاركة الملفات"
 
-#: panels/sharing/cc-sharing-panel.ui:151
-msgid "_Screen Sharing"
-msgstr "مشار_كة الشاشة"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "سطح المكتب"
 
-#: panels/sharing/cc-sharing-panel.ui:194
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr "مشاركة الوسائ_ط"
 
-#: panels/sharing/cc-sharing-panel.ui:237
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr "الولوج عن ب_عد"
 
-#: panels/sharing/cc-sharing-panel.ui:276
-msgid "Some services are disabled because of no network access."
-msgstr "بعض الأجهزة معطل لتعذّر الوصول الشبكي."
-
-#: panels/sharing/cc-sharing-panel.ui:292
-#: panels/sharing/cc-sharing-panel.ui:419
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr "مشاركة الملفات"
 
-#: panels/sharing/cc-sharing-panel.ui:339
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr "ا_طلب كلمة سر"
 
-#: panels/sharing/cc-sharing-panel.ui:430
-#: panels/sharing/cc-sharing-panel.ui:502
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "الولوج عن بعد"
 
-#: panels/sharing/cc-sharing-panel.ui:525
-#: panels/sharing/cc-sharing-panel.ui:771
-msgid "Screen Sharing"
-msgstr "مشاركة الشاشة"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "سطح المكتب"
 
-#: panels/sharing/cc-sharing-panel.ui:583
-msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "فعّل أو عطّل الولوج عن بعد"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "اسمح بالتحكم عن بع_د"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
 msgstr "ا_سمح للاتصالات بالتحكم في الشاشة"
 
-#: panels/sharing/cc-sharing-panel.ui:628
-msgid "_Password:"
-msgstr "كلمة ال_سر:"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "غير متّصِل"
 
-#: panels/sharing/cc-sharing-panel.ui:658
-msgid "_Show Password"
-msgstr "أ_ظهر كلمة السر"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:689
-msgid "Access Options"
-msgstr "خيارات النفاذ"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "انسخ"
 
-#: panels/sharing/cc-sharing-panel.ui:703
-msgid "_New connections must ask for access"
-msgstr "يجب على الاتصالات الجديدة أن ت_طلب النفاذ"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "احذف العنوان"
 
-#: panels/sharing/cc-sharing-panel.ui:721
-msgid "_Require a password"
-msgstr "ا_طلب كلمة سر"
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "الا_ستيثاق"
 
-#: panels/sharing/cc-sharing-panel.ui:782
-#: panels/sharing/cc-sharing-panel.ui:876
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "اسم المستخدم"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "يسجّل البصمات"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "مشاركة الوسائط"
 
-#: panels/sharing/cc-sharing-panel.ui:815
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "شارك الموسيقى و الصور و الڤديو مع الآخرين على الشبكة."
 
-#: panels/sharing/cc-sharing-panel.ui:830
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "المجلدات"
 
@@ -5996,21 +3657,11 @@ msgstr "المجلدات"
 msgid "Control what you want to share with others"
 msgstr "تحكم في ما تريد مشاركته مع الآخرين"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/sharing/gnome-sharing-panel.desktop.in.in:7
-msgid "preferences-system-sharing"
-msgstr "preferences-system-sharing"
-
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
 "movies;server;renderer;"
 msgstr "مشاركة;شارك;اسم;مكتب;بعيد;بلوتوث;صوت;صورة;وسائط;"
-
-#: panels/sharing/networks.ui:19
-msgid "Networks"
-msgstr "الشبكات"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
@@ -6020,99 +3671,96 @@ msgstr "فعّل أو عطّل الولوج عن بعد"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "الاستيثاق مطلوب لتفعيل أو تعطيل الولوج عن بعد"
 
-#: panels/sound/cc-alert-chooser.c:151
-msgid "Custom"
-msgstr "مخصص"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "فلِكَر"
 
-#: panels/sound/cc-alert-chooser.ui:12 panels/sound/cc-alert-selector.ui:9
-msgid "Bark"
-msgstr "نباح"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "المشاركة"
 
-#: panels/sound/cc-alert-chooser.ui:19 panels/sound/cc-alert-selector.ui:15
-msgid "Drip"
-msgstr "قطرات"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:26 panels/sound/cc-alert-selector.ui:21
-msgid "Glass"
-msgstr "زجاج"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:33 panels/sound/cc-alert-selector.ui:27
-msgid "Sonar"
-msgstr "سونار"
-
-#: panels/sound/cc-fade-slider.ui:13
-msgid "Rear"
-msgstr "الخلفية"
-
-#: panels/sound/cc-fade-slider.ui:15
-msgid "Front"
-msgstr "المقدمة"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "يختبر %s"
-
-#: panels/sound/cc-output-test-dialog.ui:127
-msgid "Click a speaker to test"
-msgstr "انقر على السماعة لاختبارها"
-
-#: panels/sound/cc-sound-panel.ui:29
-msgid "System Volume"
-msgstr "شدة صوت النظام"
-
-#: panels/sound/cc-sound-panel.ui:45
-msgid "Volume Levels"
-msgstr "مستويات الصوت"
-
-#: panels/sound/cc-sound-panel.ui:67
-msgid "Output"
-msgstr "المَخْرَج"
-
-#: panels/sound/cc-sound-panel.ui:94
-msgid "Output Device"
-msgstr "جهاز إخراج"
-
-#: panels/sound/cc-sound-panel.ui:117
-msgid "Test"
-msgstr "اختبِر"
-
-#: panels/sound/cc-sound-panel.ui:148 panels/sound/cc-sound-panel.ui:325
-msgid "Configuration"
-msgstr "الإعدادات"
-
-#: panels/sound/cc-sound-panel.ui:181
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 msgid "Balance"
 msgstr "التوازن"
 
-#: panels/sound/cc-sound-panel.ui:208
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 msgid "Fade"
 msgstr "التلاشي"
 
-#: panels/sound/cc-sound-panel.ui:235
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "الخلفية"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "المقدمة"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "انقر على السماعة لاختبارها"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "شدة صوت النظام"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "شدة صوت النظام"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "مستويات الصوت"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "المَخْرَج"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "جهاز إخراج"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "اختبِر"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "الإعدادات"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "سماعات كبيرة"
 
-#: panels/sound/cc-sound-panel.ui:257
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "المَدخَل"
 
-#: panels/sound/cc-sound-panel.ui:284
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "جهاز إدخال"
 
-#: panels/sound/cc-sound-panel.ui:358
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "شدة الصوت"
 
-#: panels/sound/cc-sound-panel.ui:380
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "صوت التنبيه"
 
-#: panels/sound/cc-volume-slider.c:178
-msgctxt "volume"
-msgid "100%"
-msgstr "١٠٠٪"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "أصمِت"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6122,87 +3770,13 @@ msgstr "الصوت"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "غيّر شدة الصوت و أصوات التنبيهات"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/sound/gnome-sound-panel.desktop.in.in:7
-msgid "multimedia-volume-control"
-msgstr "multimedia-volume-control"
-
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr "بطاقة;ميكروفون;صوت;شدة;توازن;بلوتوث;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "غير متّصل"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "يتّصل"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "متّصل"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "عطل في التخويل"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "يخوّل"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "وظيفية مقللة"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "متّصل ومخوّل"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "غير معروف"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr "مخوّل في:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-msgid "Connected at:"
-msgstr "متّصل في:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-msgid "Enrolled at:"
-msgstr "سجّل في:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-msgid "Failed to authorize device: "
-msgstr "فشل تخويل الجهاز:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-msgid "Failed to forget device: "
-msgstr "فشل نسيان الجهاز:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
@@ -6213,84 +3787,55 @@ msgstr[3] "لا يعتمد على %u أجهزة أخرى"
 msgstr[4] "لا يعتمد على %u جهازًا آخر"
 msgstr[5] "لا يعتمد على %u جهاز آخر"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "أدِر التنبيهات"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "الاسم:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "الحالة:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "خوّل واتصل"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "انس الجهاز"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "عُطل"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "مخوّل"
-
-#: panels/thunderbolt/cc-bolt-panel.c:176
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.c:469
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:513
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:517
+#: panels/thunderbolt/cc-bolt-panel.ui:103
 #, fuzzy
-msgid "Thunderbolt security level could not be determined."
-msgstr "تعذّر توليد الإعدادات."
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "تعذّر الاتصال بالنطاق %s:‏ %s"
 
-#: panels/thunderbolt/cc-bolt-panel.c:622
-#, fuzzy, c-format
-msgid "Error switching direct mode: %s"
-msgstr "عطل في تحديد مُرسِل البريد المبدئي: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:246
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "وصول مباشرة"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 #, fuzzy
 msgid "Pending Devices"
 msgstr "يجلب الأجهزة..."
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr ""
 
@@ -6302,652 +3847,608 @@ msgstr ""
 msgid "Manage Thunderbolt devices"
 msgstr ""
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:7
-msgid "thunderbolt"
-msgstr ""
-
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
-msgid "Thunderbolt;"
+msgid "Thunderbolt;privacy;"
 msgstr ""
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:498
-msgctxt "cursor size"
-msgid "Default"
-msgstr "المبدئي"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "وميض المؤشر"
 
-#: panels/universal-access/cc-ua-panel.c:501
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "متوسط"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "ومضات المؤشر في حقول النصوص."
 
-#: panels/universal-access/cc-ua-panel.c:504
-msgctxt "cursor size"
-msgid "Large"
-msgstr "كبير"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "السرعة"
 
-#: panels/universal-access/cc-ua-panel.c:507
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "أكبر"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "سرعة ومضات المؤشر"
 
-#: panels/universal-access/cc-ua-panel.c:510
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "الأكبر"
-
-#: panels/universal-access/cc-ua-panel.c:514
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d بكسل"
-msgstr[1] "%d بكسل"
-msgstr[2] "%d بكسل"
-msgstr[3] "%d بكسل"
-msgstr[4] "%d بكسل"
-msgstr[5] "%d بكسل"
-
-#: panels/universal-access/cc-ua-panel.ui:93
-msgid "_Always Show Universal Access Menu"
-msgstr "اعرض قائمة الإتاحة _دائمًا"
-
-#: panels/universal-access/cc-ua-panel.ui:135
-msgid "Seeing"
-msgstr "النظر"
-
-#: panels/universal-access/cc-ua-panel.ui:181
-msgid "_High Contrast"
-msgstr "تباين _عال"
-
-#: panels/universal-access/cc-ua-panel.ui:228
-msgid "_Large Text"
-msgstr "نص _كبير"
-
-#: panels/universal-access/cc-ua-panel.ui:273
-msgid "C_ursor Size"
-msgstr "حجم المؤ_شر"
-
-#: panels/universal-access/cc-ua-panel.ui:320
-#: panels/universal-access/zoom-options.ui:99
-msgid "_Zoom"
-msgstr "ال_تقريب"
-
-#: panels/universal-access/cc-ua-panel.ui:366
-msgid "Screen _Reader"
-msgstr "قار_ئ الشاشة"
-
-#: panels/universal-access/cc-ua-panel.ui:412
-#: panels/universal-access/cc-ua-panel.ui:1243
-msgid "_Sound Keys"
-msgstr "مفاتيح الصو_ت"
-
-#: panels/universal-access/cc-ua-panel.ui:474
-msgid "Hearing"
-msgstr "السمع"
-
-#: panels/universal-access/cc-ua-panel.ui:518
-#: panels/universal-access/cc-ua-panel.ui:1346
-msgid "_Visual Alerts"
-msgstr "تنبيهات ب_صرية"
-
-#: panels/universal-access/cc-ua-panel.ui:626
-msgid "Screen _Keyboard"
-msgstr "لوحة م_فاتيح على الشاشة"
-
-#: panels/universal-access/cc-ua-panel.ui:671
-msgid "R_epeat Keys"
-msgstr "_تكرار المفاتيح"
-
-#: panels/universal-access/cc-ua-panel.ui:717
-msgid "Cursor _Blinking"
-msgstr "وميض ال_مؤشر"
-
-#: panels/universal-access/cc-ua-panel.ui:763
-msgid "_Typing Assist (AccessX)"
-msgstr "م_ساعدة الكتابة"
-
-#: panels/universal-access/cc-ua-panel.ui:824
-msgid "Pointing & Clicking"
-msgstr "التأشير و النقر"
-
-#: panels/universal-access/cc-ua-panel.ui:870
-msgid "_Mouse Keys"
-msgstr "مفاتيح ال_فأرة"
-
-#: panels/universal-access/cc-ua-panel.ui:915
-msgid "_Click Assist"
-msgstr "مساعدة الن_قر"
-
-#: panels/universal-access/cc-ua-panel.ui:961
-msgid "_Double-Click Delay"
-msgstr "مهلة الن_قر المزدوج"
-
-#: panels/universal-access/cc-ua-panel.ui:981
-msgid "Double-Click Delay"
-msgstr "مهلة النقر المزدوج"
-
-#: panels/universal-access/cc-ua-panel.ui:1048
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr "حجم المؤشر"
 
-#: panels/universal-access/cc-ua-panel.ui:1075
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr "يمكن تغيير حجم المؤشر مع مستوى التقريب لتسهيل رؤية المؤشر."
 
-#: panels/universal-access/cc-ua-panel.ui:1111
-msgid "Screen Reader"
-msgstr "قارئ الشاشة"
-
-#: panels/universal-access/cc-ua-panel.ui:1128
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "يقرأ قارئ الشاشة النص أثناء تحريكك للبؤرة."
-
-#: panels/universal-access/cc-ua-panel.ui:1161
-msgid "_Screen Reader"
-msgstr "قارئ ال_شاشة"
-
-#: panels/universal-access/cc-ua-panel.ui:1200
-msgid "Sound Keys"
-msgstr "مفاتيح الصوت"
-
-#: panels/universal-access/cc-ua-panel.ui:1218
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "أصدر صفيرًا عند تفعيل أو تعطيل قفل الأرقام أو الحروف الكبيرة."
-
-#: panels/universal-access/cc-ua-panel.ui:1288
-msgid "Visual Alerts"
-msgstr "التنبيهات البصرية"
-
-#: panels/universal-access/cc-ua-panel.ui:1292
-msgid "_Test flash"
-msgstr "ا_ختبر الوميض"
-
-#: panels/universal-access/cc-ua-panel.ui:1321
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "أظهر مؤشرًا بصريًا عند حدوث تنبيه صوتي."
-
-#: panels/universal-access/cc-ua-panel.ui:1372
-msgid "Flash the _window title"
-msgstr "أومض _عنوان النافذة"
-
-#: panels/universal-access/cc-ua-panel.ui:1390
-msgid "Flash the entire _screen"
-msgstr "أومض _كل الشاشة"
-
-#: panels/universal-access/cc-ua-panel.ui:1435
-msgid "Repeat Keys"
-msgstr "تكرار المفاتيح"
-
-#: panels/universal-access/cc-ua-panel.ui:1465
-msgid "Key presses repeat when key is held down."
-msgstr "تكرار نقر المفتاح عند الضغط عليه."
-
-#: panels/universal-access/cc-ua-panel.ui:1545
-msgid "Repeat keys delay"
-msgstr "مهلة تكرار المفاتيح"
-
-#: panels/universal-access/cc-ua-panel.ui:1593
-#: panels/universal-access/cc-ua-panel.ui:1728
-msgid "Speed"
-msgstr "السرعة"
-
-#: panels/universal-access/cc-ua-panel.ui:1632
-msgid "Repeat keys speed"
-msgstr "سرعة تكرار المفاتيح"
-
-#: panels/universal-access/cc-ua-panel.ui:1656
-msgid "Cursor Blinking"
-msgstr "وميض المؤشر"
-
-#: panels/universal-access/cc-ua-panel.ui:1686
-msgid "Cursor blinks in text fields."
-msgstr "ومضات المؤشر في حقول النصوص."
-
-#: panels/universal-access/cc-ua-panel.ui:1765
-msgid "Cursor blinking speed"
-msgstr "سرعة ومضات المؤشر"
-
-#: panels/universal-access/cc-ua-panel.ui:1801
-msgid "Typing Assist"
-msgstr "مساعدة الكتابة"
-
-#: panels/universal-access/cc-ua-panel.ui:1840
-msgid "_Sticky Keys"
-msgstr "مفاتيح لا_صقة"
-
-#: panels/universal-access/cc-ua-panel.ui:1857
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "تعتبر تتابعا من المفاتيح المُغيِّرة كما لو كان اختصارا"
-
-#: panels/universal-access/cc-ua-panel.ui:1881
-msgid "_Disable if two keys are pressed together"
-msgstr "_عطِّل إذا ضُغط مفتاحان في آن واحد"
-
-#: panels/universal-access/cc-ua-panel.ui:1899
-msgid "Beep when a _modifier key is pressed"
-msgstr "صفّر عند ضغط مفاتيح الم_غيّرات"
-
-#: panels/universal-access/cc-ua-panel.ui:1947
-msgid "S_low Keys"
-msgstr "مفاتيح ب_طيئة"
-
-#: panels/universal-access/cc-ua-panel.ui:1964
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "تضع تأخيرا بين ضغط المفتاح وقبوله"
-
-#: panels/universal-access/cc-ua-panel.ui:1997
-#: panels/universal-access/cc-ua-panel.ui:2210
-#: panels/universal-access/cc-ua-panel.ui:2547
-msgid "A_cceptance delay:"
-msgstr "تأخير ال_قبول:"
-
-#: panels/universal-access/cc-ua-panel.ui:2019
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "قصير"
-
-#: panels/universal-access/cc-ua-panel.ui:2038
-msgid "Slow keys typing delay"
-msgstr "تأخير الكتابة للمفاتيح البطيئة"
-
-#: panels/universal-access/cc-ua-panel.ui:2053
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "طويل"
-
-#: panels/universal-access/cc-ua-panel.ui:2080
-msgid "Beep when a key is pr_essed"
-msgstr "صفّر عند ض_غط مفتاح"
-
-#: panels/universal-access/cc-ua-panel.ui:2097
-msgid "Beep when a key is _accepted"
-msgstr "صفّر عند _قُبول مفتاح"
-
-#: panels/universal-access/cc-ua-panel.ui:2114
-#: panels/universal-access/cc-ua-panel.ui:2293
-msgid "Beep when a key is _rejected"
-msgstr "صفّر إذا _رُفض مفتاح"
-
-#: panels/universal-access/cc-ua-panel.ui:2160
-msgid "_Bounce Keys"
-msgstr "مفاتيح _قافزة"
-
-#: panels/universal-access/cc-ua-panel.ui:2177
-msgid "Ignores fast duplicate keypresses"
-msgstr "تجاهل الضغطات المكررة السريعة للمفاتيح"
-
-#: panels/universal-access/cc-ua-panel.ui:2232
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "قصير"
-
-#: panels/universal-access/cc-ua-panel.ui:2251
-msgid "Bounce keys typing delay"
-msgstr "تأخير الكتابة للمفاتيح القافزة"
-
-#: panels/universal-access/cc-ua-panel.ui:2266
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "طويل"
-
-#: panels/universal-access/cc-ua-panel.ui:2379
-msgid "_Enable by Keyboard"
-msgstr "فعّل من _لوحة المفاتيح"
-
-#: panels/universal-access/cc-ua-panel.ui:2396
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "فعّل أو عطّل خصائص الإتاحة باستخدام لوحة المفاتيح"
-
-#: panels/universal-access/cc-ua-panel.ui:2460
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "مساعدة النقر"
 
-#: panels/universal-access/cc-ua-panel.ui:2496
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "م_حاكاة النقر الثانوي"
 
-#: panels/universal-access/cc-ua-panel.ui:2514
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "ابتدئ نقرة ثانوية عن طريق الاستمرار بضغط الزر الأولي"
 
-#: panels/universal-access/cc-ua-panel.ui:2568
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "تأخير ال_قبول:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "قصير"
 
-#: panels/universal-access/cc-ua-panel.ui:2587
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "تأخير النقر الثانوي"
 
-#: panels/universal-access/cc-ua-panel.ui:2602
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "طويل"
 
-#: panels/universal-access/cc-ua-panel.ui:2659
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "النقر ال_سلبي"
 
-#: panels/universal-access/cc-ua-panel.ui:2677
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "ابتدئ نقرة عند حومان المؤشر"
 
-#: panels/universal-access/cc-ua-panel.ui:2710
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "ال_تأخير:"
 
-#: panels/universal-access/cc-ua-panel.ui:2732
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "قصير"
 
-#: panels/universal-access/cc-ua-panel.ui:2763
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "طويل"
 
-#: panels/universal-access/cc-ua-panel.ui:2799
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "عتبة الحر_كة:"
 
-#: panels/universal-access/cc-ua-panel.ui:2821
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "صغير"
 
-#: panels/universal-access/cc-ua-panel.ui:2852
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "كبير"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "تكرار المفاتيح"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "تكرار نقر المفتاح عند الضغط عليه."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "مهلة تكرار المفاتيح"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "سرعة تكرار المفاتيح"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "مساعدة الكتابة"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "مفاتيح لا_صقة"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "تعتبر تتابعا من المفاتيح المُغيِّرة كما لو كان اختصارا"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_عطِّل إذا ضُغط مفتاحان في آن واحد"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "صفّر عند ضغط مفاتيح الم_غيّرات"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "مفاتيح ب_طيئة"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "تضع تأخيرا بين ضغط المفتاح وقبوله"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "قصير"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "تأخير الكتابة للمفاتيح البطيئة"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "طويل"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "صفّر عند ض_غط مفتاح"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "صفّر عند _قُبول مفتاح"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "صفّر إذا _رُفض مفتاح"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "مفاتيح _قافزة"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "تجاهل الضغطات المكررة السريعة للمفاتيح"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "قصير"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "تأخير الكتابة للمفاتيح القافزة"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "طويل"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "فعّل من _لوحة المفاتيح"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "فعّل أو عطّل خصائص الإتاحة باستخدام لوحة المفاتيح"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "اعرض قائمة الإتاحة _دائمًا"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "النظر"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "تباين _عال"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "نص _كبير"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+#, fuzzy
+msgid "Enable A_nimations"
+msgstr "أدِر التنبيهات"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "قار_ئ الشاشة"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "يقرأ قارئ الشاشة النص أثناء تحريكك للبؤرة."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "مفاتيح الصو_ت"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "أصدر صفيرًا عند تفعيل أو تعطيل قفل الأرقام أو الحروف الكبيرة."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "حجم المؤ_شر"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "ال_تقريب"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "السمع"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "تنبيهات ب_صرية"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "لوحة م_فاتيح على الشاشة"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_تكرار المفاتيح"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "وميض ال_مؤشر"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "م_ساعدة الكتابة"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "التأشير و النقر"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "مفاتيح ال_فأرة"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "حدد موقع المؤشر"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "مساعدة الن_قر"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "مهلة الن_قر المزدوج"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "مهلة النقر المزدوج"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "التنبيهات البصرية"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "ا_ختبر الوميض"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "أظهر مؤشرًا بصريًا عند حدوث تنبيه صوتي."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "أومض _كل الشاشة"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "أومض _كل الشاشة"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "ملء الشاشة"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "النصف العلوي"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "النصف السفلي"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "النصف الأيسر"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "النصف الأيمن"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "خيارات التقريب"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "ال_تكبير:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "موضع المُكبِّرة:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "يتبع مؤشر ال_فأرة"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "جزء من ال_شاشة:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "المكبرة تمتد ل_خارج الشاشة"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "أبق مؤشر المكبرة متمركزًا"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "مؤشر المكبرة يحرك الم_حتوى"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "مؤشر المكبرة يتحرك مع المح_توى"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "المكبّرة"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "م_حاور الهدف:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "يغطي على مؤ_شر الفأرة"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "ال_سماكة:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "نحيف"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "سميك"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "ال_طول:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "اللو_ن:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "محاور الهدف"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "المؤثرات اللونية:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "أبيض على أ_سود:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "ال_سطوع:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "ال_تباين:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "اللو_ن"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "لا شيء"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "كامل"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "منخفض"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "عال"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "منخفض"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "عال"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "المؤثرات اللونية"
 
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "اجعل الرؤية و السماع و الكتابة و المؤشر أسهل"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:7
-msgid "preferences-desktop-accessibility"
-msgstr "preferences-desktop-accessibility"
-
-#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
-"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
-"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"لوحة المفاتيح;الفأرة;الإتاحة;التباين;التقريب;التكبير;قارئ "
-"الشاشة;النص;الخط;الحجم;مفاتيح ملتصقة;مفاتيح بطيئة;مفاتيح قافزة;مفاتيح الفأرة;"
+"لوحة المفاتيح;الفأرة;الإتاحة;التباين;التقريب;التكبير;قارئ الشاشة;النص;الخط;"
+"الحجم;مفاتيح ملتصقة;مفاتيح بطيئة;مفاتيح قافزة;مفاتيح الفأرة;"
 
-#: panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "Short"
-msgstr "قصيرة"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "التأريخ"
 
-#: panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ الشاشة"
-
-#: panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ الشاشة"
-
-#: panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ الشاشة"
-
-#: panels/universal-access/zoom-options.c:338
-msgctxt "Distance"
-msgid "Long"
-msgstr "طويلة"
-
-#: panels/universal-access/zoom-options.ui:48
-msgid "Full Screen"
-msgstr "ملء الشاشة"
-
-#: panels/universal-access/zoom-options.ui:53
-msgid "Top Half"
-msgstr "النصف العلوي"
-
-#: panels/universal-access/zoom-options.ui:58
-msgid "Bottom Half"
-msgstr "النصف السفلي"
-
-#: panels/universal-access/zoom-options.ui:63
-msgid "Left Half"
-msgstr "النصف الأيسر"
-
-#: panels/universal-access/zoom-options.ui:68
-msgid "Right Half"
-msgstr "النصف الأيمن"
-
-#: panels/universal-access/zoom-options.ui:78
-msgid "Zoom Options"
-msgstr "خيارات التقريب"
-
-#: panels/universal-access/zoom-options.ui:185
-msgid "_Magnification:"
-msgstr "ال_تكبير:"
-
-#: panels/universal-access/zoom-options.ui:249
-msgid "_Follow mouse cursor"
-msgstr "يتبع مؤشر ال_فأرة"
-
-#: panels/universal-access/zoom-options.ui:269
-msgid "_Screen part:"
-msgstr "جزء من ال_شاشة:"
-
-#: panels/universal-access/zoom-options.ui:331
-msgid "Magnifier _extends outside of screen"
-msgstr "المكبرة تمتد ل_خارج الشاشة"
-
-#: panels/universal-access/zoom-options.ui:350
-msgid "_Keep magnifier cursor centered"
-msgstr "أبق مؤشر المكبرة متمركزًا"
-
-#: panels/universal-access/zoom-options.ui:369
-msgid "Magnifier cursor _pushes contents around"
-msgstr "مؤشر المكبرة يحرك الم_حتوى"
-
-#: panels/universal-access/zoom-options.ui:388
-msgid "Magnifier cursor moves with _contents"
-msgstr "مؤشر المكبرة يتحرك مع المح_توى"
-
-#: panels/universal-access/zoom-options.ui:422
-msgid "Magnifier Position:"
-msgstr "موضع المُكبِّرة:"
-
-#: panels/universal-access/zoom-options.ui:443
-msgid "Magnifier"
-msgstr "المكبّرة"
-
-#: panels/universal-access/zoom-options.ui:490
-msgid "_Thickness:"
-msgstr "ال_سماكة:"
-
-#: panels/universal-access/zoom-options.ui:516
-msgctxt "universal access, thickness"
-msgid "Thin"
-msgstr "نحيف"
-
-#: panels/universal-access/zoom-options.ui:548
-msgctxt "universal access, thickness"
-msgid "Thick"
-msgstr "سميك"
-
-#: panels/universal-access/zoom-options.ui:574
-msgid "_Length:"
-msgstr "ال_طول:"
-
-#. The color of the accessibility crosshair
-#: panels/universal-access/zoom-options.ui:623
-msgid "Co_lor:"
-msgstr "اللو_ن:"
-
-#: panels/universal-access/zoom-options.ui:687
-msgid "_Crosshairs:"
-msgstr "م_حاور الهدف:"
-
-#: panels/universal-access/zoom-options.ui:735
-msgid "_Overlaps mouse cursor"
-msgstr "يغطي على مؤ_شر الفأرة"
-
-#: panels/universal-access/zoom-options.ui:773
-msgid "Crosshairs"
-msgstr "محاور الهدف"
-
-#: panels/universal-access/zoom-options.ui:822
-msgid "_White on black:"
-msgstr "أبيض على أ_سود:"
-
-#: panels/universal-access/zoom-options.ui:842
-msgid "_Brightness:"
-msgstr "ال_سطوع:"
-
-#: panels/universal-access/zoom-options.ui:863
-msgid "_Contrast:"
-msgstr "ال_تباين:"
-
-#. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/zoom-options.ui:883
-msgctxt "universal access, contrast"
-msgid "Co_lor"
-msgstr "اللو_ن"
-
-#: panels/universal-access/zoom-options.ui:908
-msgctxt "universal access, color"
-msgid "None"
-msgstr "لا شيء"
-
-#: panels/universal-access/zoom-options.ui:940
-msgctxt "universal access, color"
-msgid "Full"
-msgstr "كامل"
-
-#: panels/universal-access/zoom-options.ui:1003
-msgctxt "universal access, brightness"
-msgid "Low"
-msgstr "منخفض"
-
-#: panels/universal-access/zoom-options.ui:1036
-msgctxt "universal access, brightness"
-msgid "High"
-msgstr "عال"
-
-#: panels/universal-access/zoom-options.ui:1067
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "منخفض"
-
-#: panels/universal-access/zoom-options.ui:1100
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "عال"
-
-#: panels/universal-access/zoom-options.ui:1136
-msgid "Color Effects:"
-msgstr "المؤثرات اللونية:"
-
-#: panels/universal-access/zoom-options.ui:1161
-msgid "Color Effects"
-msgstr "المؤثرات اللونية"
-
-#: panels/user-accounts/cc-add-user-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "يجب أن تطابق عنوان الوب لمُزود الولوج."
-
-#: panels/user-accounts/cc-add-user-dialog.c:204
-msgid "Failed to add account"
-msgstr "فشلت إضافة الحساب"
-
-#: panels/user-accounts/cc-add-user-dialog.c:652
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "لا تتطابق كلمتا السر."
-
-#: panels/user-accounts/cc-add-user-dialog.c:874
-#: panels/user-accounts/cc-add-user-dialog.c:920
-#: panels/user-accounts/cc-add-user-dialog.c:941
-msgid "Failed to register account"
-msgstr "فشل تسجيل المستخدم"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1064
-msgid "No supported way to authenticate with this domain"
-msgstr "لا توجد طريقة مدعومة للاستيثاق مع هذا النطاق"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1137
-msgid "Failed to join domain"
-msgstr "فشل الانضمام إلى النطاق"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1198
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"اسم الولوج لم يعمل.\n"
-"من فضلك أعد المحاولة"
 
-#: panels/user-accounts/cc-add-user-dialog.c:1205
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "التأريخ"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "امسح التأريخ ال_حالي"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "أفرغ المهملات والملفات المؤقتة"
+
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
-"That login password didn’t work.\n"
-"Please try again."
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
 msgstr ""
-"كلمة سر الولوج لم تعمل.\n"
-"من فضلك أعد المحاولة"
 
-#: panels/user-accounts/cc-add-user-dialog.c:1213
-msgid "Failed to log into domain"
-msgstr "فشل الولوج إلى النطاق"
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "أفرغ ال_مهملات تلقائيا"
 
-#: panels/user-accounts/cc-add-user-dialog.c:1271
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "تعذّر العثور على النطاق. هل أخطأت في كتابته؟"
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "تخلّص من الملفات المؤ_قتة تلقائيا"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "أفرغ ال_مهملات تلقائيا"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "أ_فرغ المهملات…"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "ت_خلّص من الملفات المؤقتة…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "أضف مستخدما"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr "الاسم بال_كامل"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-#: panels/user-accounts/cc-user-panel.ui:151
-msgid "Standard"
-msgstr "عادي"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:216
-#: panels/user-accounts/cc-user-panel.ui:161
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "إداري"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-#: panels/user-accounts/cc-user-panel.ui:179
-msgid "Account _Type"
-msgstr "_نوع الحساب"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-msgid "Allow user to set a password when they next _login"
-msgstr "اسمح للمستخدم بوضع كلمة سر عند الولوج ال_تالي"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "اسمح للمستخدم بتغيير كلمة السر عند الولوج التالي"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
-msgid "Set a password _now"
-msgstr "_ضع كلمة سر الآن"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "ضع كلمة سر الآن"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "أ_كّد"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "ولوج ال_مؤسسات"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "لست متّصلا"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -6956,412 +4457,231 @@ msgstr ""
 "ولوج المؤسسات يسمح باستخدام حساب مستخدم مدار مركزيًا على هذا الجهاز. يمكنك "
 "أيضًا استخدام هذا الحساب للوصول إلى موارد الشركة على الإنترنت."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
-msgid "_Domain"
-msgstr "الن_طاق"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:732
-msgid "You are Offline"
-msgstr "لست متّصلا"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-msgid "You must be online in order to add enterprise users."
-msgstr "يجب أن تكون متصلا لإضافة حسابات ولوج مؤسسات."
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "ولوج ال_مؤسسات"
-
-#: panels/user-accounts/cc-avatar-chooser.c:231
-msgid "Browse for more pictures"
-msgstr "تصفّح لمزيد من الصور"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:27
-msgid "Take a Picture…"
-msgstr "التقط صورة…"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:34
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "اختر ملفًا…"
 
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "هذا الأسبوع"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "الولوج بال_بصمة"
 
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "الولوج بال_بصمة"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "لا"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "أتريد حذف بصماتك المسجلة بحيث يُعطل الولوج بالبصمة؟"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "جهاز إدخال ألعاب"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "الولوج بال_بصمة"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "الولوج بال_بصمة"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "ا_ختر جهازا لإعداده:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "الولوج بال_بصمة"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "ا_حذف البصمات"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "الولوج بال_بصمة"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
 msgstr "الأسبوع الماضي"
 
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %B"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "الأسبوع القادم"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %B، %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:770
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:774
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s، %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr "انتهت الجلسة"
-
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr "بدأت الجلسة"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
-msgstr "‏%s – نشاط الحساب"
-
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr "رجاء اختر كلمة سر أخرى."
-
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
-msgstr "رجاء أعد كتابة كلمة السر الحالية."
-
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
-msgstr "تعذّر تغيير كلمة السر"
-
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "غيّر كلمة السر"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "_غيّر"
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr "أ_كّد كلمة السر الجديدة"
-
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr "ك_لمة السر الجديدة"
-
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "كلمة السر ال_حالية"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "ك_لمة السر الجديدة"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "أ_كّد كلمة السر"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "لا تتطابق كلمتا السر."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "اسمح للمستخدم بتغيير كلمة السر عند الولوج التالي"
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "ضع كلمة سر الآن"
 
-#: panels/user-accounts/cc-realm-manager.c:307
-msgid "Cannot automatically join this type of domain"
-msgstr "لا يمكن الانضمام تلقائيا إلى هذا النوع من النطاقات"
-
-#: panels/user-accounts/cc-realm-manager.c:310
-msgid "No such domain or realm found"
-msgstr "لم يعثر على هذا النطاق أو المجال"
-
-#: panels/user-accounts/cc-realm-manager.c:732
-#: panels/user-accounts/cc-realm-manager.c:746
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "تعذّر الولوج باسم %s في النطاق %s"
-
-#: panels/user-accounts/cc-realm-manager.c:738
-msgid "Invalid password, please try again"
-msgstr "كلمة سر خطأ؛ من فضلك أعد المحاولة"
-
-#: panels/user-accounts/cc-realm-manager.c:751
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "تعذّر الاتصال بالنطاق %s:‏ %s"
-
-#: panels/user-accounts/cc-user-panel.c:213
-msgid "Your account"
-msgstr "حسابك"
-
-#: panels/user-accounts/cc-user-panel.c:388
-msgid "Failed to delete user"
-msgstr "فشل حذف المستخدم"
-
-#: panels/user-accounts/cc-user-panel.c:446
-#: panels/user-accounts/cc-user-panel.c:505
-#: panels/user-accounts/cc-user-panel.c:557
-msgid "Failed to revoke remotely managed user"
-msgstr "فشل إبطال المستخدم المتحكم فيه عن بعد"
-
-#: panels/user-accounts/cc-user-panel.c:609
-msgid "You cannot delete your own account."
-msgstr "لا يمكنك حذف حسابك أنت."
-
-#: panels/user-accounts/cc-user-panel.c:618
-#, c-format
-msgid "%s is still logged in"
-msgstr "ما يزال %s والجا"
-
-#: panels/user-accounts/cc-user-panel.c:622
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "حذف مستخدم أثناء ولوجه قد يترك النظام في حالة غير مستقرة."
-
-#: panels/user-accounts/cc-user-panel.c:631
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "أتريد إبقاء ملفات %s؟"
-
-#: panels/user-accounts/cc-user-panel.c:635
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"من الممكن الإبقاء على مجلد المنزل وخزانة البريد والملفات المؤقتة عند حذف "
-"حساب مستخدم."
-
-#: panels/user-accounts/cc-user-panel.c:638
-msgid "_Delete Files"
-msgstr "ا_حذف الملفات"
-
-#: panels/user-accounts/cc-user-panel.c:639
-msgid "_Keep Files"
-msgstr "أ_بقِ الملفات"
-
-#: panels/user-accounts/cc-user-panel.c:653
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "أمتأكد أنك تريد إبطال حساب %s المتحكم فيه عن بعد؟"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgid "_Delete"
-msgstr "ا_حذف"
-
-#: panels/user-accounts/cc-user-panel.c:707
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "الحساب معطّل"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "لتوضع مع الولوج التالي"
-
-#: panels/user-accounts/cc-user-panel.c:718
-msgctxt "Password mode"
-msgid "None"
-msgstr "بدون"
-
-#: panels/user-accounts/cc-user-panel.c:763
-msgid "Logged in"
-msgstr "والِج"
-
-#: panels/user-accounts/cc-user-panel.c:1093
-msgid "Failed to contact the accounts service"
-msgstr "فشل الاتصال بخدمة الحسابات"
-
-#: panels/user-accounts/cc-user-panel.c:1095
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "رجاء تأكّد من أن AccountService مثبّتة ومفعّلة."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1127
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"انقر على أيقونة *\n"
-"لعمل أي تغييرات"
-
-#: panels/user-accounts/cc-user-panel.c:1200
-msgid "Create a user account"
-msgstr "أنشئ حساب مستخدِم"
-
-#: panels/user-accounts/cc-user-panel.c:1211
-#: panels/user-accounts/cc-user-panel.c:1339
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"لإنشاء حساب مستخدِم،\n"
-"انقر أولًا على أيقونة *"
-
-#: panels/user-accounts/cc-user-panel.c:1220
-msgid "Delete the selected user account"
-msgstr "احذف حساب المستخدِم المختار"
-
-#: panels/user-accounts/cc-user-panel.c:1232
-#: panels/user-accounts/cc-user-panel.c:1343
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"لحذف حساب المستخدم المختار،\n"
-"انقر أولًا على أيقونة *"
-
-#: panels/user-accounts/cc-user-panel.ui:18
-msgid "_Add User…"
-msgstr "أ_ضف مستخدمًا…"
-
-#: panels/user-accounts/cc-user-panel.ui:70
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "يجب إعادة تشغيل الجلسة لتطبيق التغييرات"
-
-#: panels/user-accounts/cc-user-panel.ui:78
-msgid "Restart Now"
-msgstr "أعِد التشغيل الآن"
-
-#: panels/user-accounts/cc-user-panel.ui:254
-msgid "A_utomatic Login"
-msgstr "الولوج الت_لقائي"
-
-#: panels/user-accounts/cc-user-panel.ui:296
-msgid "_Fingerprint Login"
-msgstr "الولوج بال_بصمة"
-
-#: panels/user-accounts/cc-user-panel.ui:322
-#: panels/user-accounts/cc-user-panel.ui:338
-msgid "User Icon"
-msgstr "أيقونة المستخدم"
-
-#: panels/user-accounts/cc-user-panel.ui:402
-msgid "Last Login"
-msgstr "آخر ولوج"
-
-#: panels/user-accounts/cc-user-panel.ui:451
-msgid "Remove User…"
-msgstr "أزِل المستخدِم…"
-
-#. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:484
-msgid "No Users Found"
-msgstr "لم يُعثر على أي مستخدمين"
-
-#: panels/user-accounts/cc-user-panel.ui:494
-msgid "Unlock to add a user account."
-msgstr "افتح لإضافة حساب مستخدِم."
-
-#: panels/user-accounts/data/account-fingerprint.ui:12
-msgid "Left thumb"
-msgstr "الإبهام الأيسر"
-
-#: panels/user-accounts/data/account-fingerprint.ui:15
-msgid "Left middle finger"
-msgstr "الوسطى اليسرى"
-
-#: panels/user-accounts/data/account-fingerprint.ui:18
-msgid "Left ring finger"
-msgstr "البنصر الأيسر"
-
-#: panels/user-accounts/data/account-fingerprint.ui:21
-msgid "Left little finger"
-msgstr "الخنصر الأيسر"
-
-#: panels/user-accounts/data/account-fingerprint.ui:24
-msgid "Right thumb"
-msgstr "الإبهام الأيمن"
-
-#: panels/user-accounts/data/account-fingerprint.ui:27
-msgid "Right middle finger"
-msgstr "الوسطى اليمنى"
-
-#: panels/user-accounts/data/account-fingerprint.ui:30
-msgid "Right ring finger"
-msgstr "البنصر الأيمن"
-
-#: panels/user-accounts/data/account-fingerprint.ui:33
-msgid "Right little finger"
-msgstr "الخنصر الأيمن"
-
-#: panels/user-accounts/data/account-fingerprint.ui:39
-#: panels/user-accounts/um-fingerprint-dialog.c:677
-msgid "Enable Fingerprint Login"
-msgstr "فعّل الولوج بالبصمة"
-
-#: panels/user-accounts/data/account-fingerprint.ui:89
-msgid "_Right index finger"
-msgstr "السبابة الي_منى"
-
-#: panels/user-accounts/data/account-fingerprint.ui:105
-msgid "_Left index finger"
-msgstr "السبابة الي_سرى"
-
-#: panels/user-accounts/data/account-fingerprint.ui:126
-msgid "_Other finger:"
-msgstr "أصبع آخ_ر:"
-
-#: panels/user-accounts/data/account-fingerprint.ui:262
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr "حُفظت بصمتك بنجاح. تستطيع الآن الولوج ببصمة أصبعك."
-
+#: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "المستخدمين"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "يجب إعادة تشغيل الجلسة لتطبيق التغييرات"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "أعِد التشغيل الآن"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "أغلق"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "الاسم بال_كامل"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "حرِّر"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "الولوج بال_بصمة"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "الولوج الت_لقائي"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "‏%s – نشاط الحساب"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "إداري"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "أزِل المستخدِم…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "ملفات أخرى"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "أ_ضف مستخدمًا…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "لم يُعثر على أي مستخدمين"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "افتح لإضافة حساب مستخدِم."
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "أضف أو احذف مستخدمين و غيّر كلمة السر"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:7
-msgid "system-users"
-msgstr "system-users"
-
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "ولوج;اسم;بصمة;أيقونة;شعار;وجه;كلمة سر;"
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_سجّل"
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "ولوج مدير النطاق"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -7370,11 +4690,11 @@ msgstr ""
 "تحتاج أن تكون مسجّلا في النطاق لاستخدام ولوج المؤسسات على هذا الحاسوب.\n"
 "من فضلك اطلب من مدير الشبكة أن يكتب كلمة سر النطاق هنا."
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "ا_سم المدير"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "كلمة سر المدير"
 
@@ -7386,279 +4706,16 @@ msgstr "أدِر حسابات المستخدمين"
 msgid "Authentication is required to change user data"
 msgstr "الاستيثاق مطلوب لتغيير بيانات المستخدم"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "لا تحتوي كلمة السر الجديدة على حروف مختلفة كفاية."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "حاول تغيير بعض الحروف و الأرقان."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "حاول تغيير كلمة السر أكثر قليلًا."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "كلمة السر أقوى بدون اسم المستخدم."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "حاول تفادي وضع اسم المستخدم في كلمة السر."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "حاول تفادي بعض الكلمات المستخدمة في كلمة السر."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "حاول تفادي الكلمات الشائعة."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "حاول تفادي تغيير ترتيب كلمات معروفة."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "حاول استخدام أرقام أكثر."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "حاول استخدام حروف كبيرة أكثر."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "حاول استخدام حروف صغيرة أكثر."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "حاول استخدام علامات خاصة أكثر، مثل علامات الترقيم."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "حاول استخدام خليط من الحروف و الأرقام و علامات الترقيم."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "حاول تفادي تكرار نفس الحرف."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"حاول تفادي تكرار نفس النوع من الحروف: عليك الخلط بين الحروف و الأرقام "
-"و علامات الترقيم."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "حاول تفادي تتابعات مثل 1234 أو abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"على كلمة السر أن تكون أطول. حاول استخدام خليط من الحروف و الأرقام و علامات "
-"الترقيم."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "اخلط الحروف الكبيرة مع الصغيرة و استخدم رقمًا أو اثنين."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"إضافة المزيد من الحروف و الأرقام و علامات الترقيم ستجعل كلمة السر أقوى."
-
-#: panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "فشل الاستيثاق"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "كلمة السّر الجديدة قصيرة جدًا"
-
-#: panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "كلمة السر الجديدة بسيطة جدا"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "كلمتا السر القديمة والجديدة متشابهتان جدا"
-
-#: panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "كلمة السر الجديدة سبق استخدامها مؤخرا."
-
-#: panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "يجب أن تحتوي كلمة السر الجديدة على محارف خاصة أو أرقام"
-
-#: panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "كلمتا السر القديمة و الجديدة متطابقتان"
-
-#: panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "تغيِّرت كلمة السر بعد الاستيثاق!"
-
-#: panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "لا تحتوي كلمة السر الجديدة على حروف مختلفة كفاية"
-
-#: panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "عطل غير معروف"
-
-#: panels/user-accounts/user-utils.c:430
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "اسم المستخدم هذا غير متاح. جرب اسمًا آخر."
-
-#: panels/user-accounts/user-utils.c:433
-#, c-format
-msgid "The username is too long."
-msgstr "اسم المستخدم طويل جدا."
-
-#: panels/user-accounts/user-utils.c:436
-msgid "The username cannot start with a “-”."
-msgstr "لا يمكن أن يبدأ اسم المستخدم بعلامة ”-“."
-
-#: panels/user-accounts/user-utils.c:439
-msgid ""
-"The username should only consist of upper and lower case letters from a-z, "
-"digits and the following characters: . - _"
-msgstr ""
-"يجب أن لا يتعدى اسم المستخدم الحروف الإنجليزية الكبيرة و الصغيرة من a-z، "
-"و الأرقام و أي من الحروف '.' و '-' و '_'."
-
-#: panels/user-accounts/user-utils.c:443
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr "سيُستخدم هذا لتسمية مجلد المنزل ولا يمكن تغييره."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr "لست مخولا بالوصول إلى الجهاز. تكلم مع مدير النظام."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "الجهاز مستخدم بالفعل."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr "حصل عطل داخلي."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Enabled"
-msgstr "مفعّل"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:260
-msgid "Delete registered fingerprints?"
-msgstr "أأحذف البصمات المسجّلة؟"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:264
-msgid "_Delete Fingerprints"
-msgstr "ا_حذف البصمات"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:270
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr "أتريد حذف بصماتك المسجلة بحيث يُعطل الولوج بالبصمة؟"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:440
-msgid "Done!"
-msgstr "تم!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:501
-#: panels/user-accounts/um-fingerprint-dialog.c:543
-#, c-format
-msgid "Could not access “%s” device"
-msgstr "تعذر الوصول إلى الجهاز ”%s“"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:584
-#, c-format
-msgid "Could not start finger capture on “%s” device"
-msgstr "تعذّر بدء التقاط الأصابع على الجهاز ”%s“"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:628
-msgid "Could not access any fingerprint readers"
-msgstr "تعذّر الوصول إلى أي قارئ بصمة"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:629
-msgid "Please contact your system administrator for help."
-msgstr "من فضلك راجع مدير النظام للمساعدة."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: panels/user-accounts/um-fingerprint-dialog.c:711
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the “%s” device."
-msgstr "لتفعيل الولوج بالبصمة، ستحتاج لحفظ إحدى بصماتك باستخدام الجهاز ”%s“."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:718
-msgid "Selecting finger"
-msgstr "اصبع الاختيار"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:719
-msgid "Enrolling fingerprints"
-msgstr "يسجّل البصمات"
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "تعيين أزرار"
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:533
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "أ_غلق"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "تعيين وظائف للأزرار"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -7666,74 +4723,131 @@ msgstr ""
 "لتعديل مفتاح اختصار، اختر ”أرسل ضغطة الزر“ ثم اضغط على الأزرار الجديدة أو "
 "اضغط مفتاح التّراجع لمسحها."
 
-#: panels/wacom/calibrator/calibrator.ui:60
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "أ_غلق"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr "رجاءً انقر علامات الهدف الظاهرة على الشاشة لمعايرة اللوح."
 
-#: panels/wacom/calibrator/calibrator.ui:77
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "اكتُشفت نقرة خاطئة، يعيد بدء العملية…"
 
-#: panels/wacom/cc-wacom-button-row.c:253
-#, c-format
-msgid "Button %d"
-msgstr "زر %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "أنشئ جهاز افتراضي"
 
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "التطبيقات المُعرّفة"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "لوحي"
 
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "أرسل ضغطة الزر"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "بدّل الشاشة"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "اتجاه لليد اليسرى"
 
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "أظهر مساعدة على الشاشة"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:256
-msgid "Output:"
-msgstr "المَخْرَج:"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "تعيين شاشة عرض…"
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:268
-msgid "Keep aspect ratio (letterbox):"
-msgstr "حافظ على نسبة العرض:"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "نسبة العرض"
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:279
-msgid "Map to single monitor"
-msgstr "عيّن في شاشة واحدة"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
-msgstr "%d من %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "عاير…"
 
-#: panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "اعرض المخطط"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "لم يكتشف أي لوح"
 
-#: panels/wacom/cc-wacom-panel.c:845 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
-msgstr "القلم"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "رجاءً وصّل أو شغّل لوح واكوم"
 
-#: panels/wacom/cc-wacom-stylus-page.c:355
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "الشعور بضغط السن"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "ناعم"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "قاس"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "زر"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "زر"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "زر"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "الشعور بضغط الممحاة"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "الشعور بضغط الممحاة"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "نقرة بزر الفأرة الأوسط"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "نقرة بزر الفأرة الأيمن"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "إلى الأمام"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr "لوح واكوم"
 
@@ -7741,210 +4855,363 @@ msgstr "لوح واكوم"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "اضبط استخدام أزرار و حساسية قلم ألواح الرسوميات"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/wacom/gnome-wacom-panel.desktop.in.in:7
-msgid "input-tablet"
-msgstr "input-tablet"
-
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "لوحة;واكوم;قلم;ممحاة;فأرة;"
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "لوح (مطلق)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "التخطيط"
 
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
-msgstr "لوحة لمس (نسبي)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "تفضيلات اللوح"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "م_ساعدة"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
-msgstr "لم يكتشف أي لوح"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "رجاءً وصّل أو شغّل لوح واكوم"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
-msgstr "إعدادات بلوتوث"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
-msgstr "نمط التتبع"
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "موسَّطة"
 
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
-msgstr "اتجاه لليد اليسرى"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "م_حاكاة النقر الثانوي"
 
-#: panels/wacom/gnome-wacom-properties.ui:296
-msgid "Map to Monitor…"
-msgstr "تعيين شاشة عرض…"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "برمجيات وندوز"
 
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
-msgstr "تعيين أزرار…"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
-msgstr "عاير…"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "الحبر قليل"
 
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
-msgstr "اضبط إعدادات الفأرة"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "الثانوي"
 
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
-msgstr "اضبط ميز الشاشة"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "برمجيات وندوز"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr "اختصار جديد…"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "المبدئي"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "نقرة بزر الفأرة الأوسط"
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "خيارات النفاذ"
 
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "نقرة بزر الفأرة الأيمن"
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "أضف"
 
-#: panels/wacom/wacom-stylus-page.ui:37
-msgid "Back"
-msgstr "إلى الخلف"
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "ا_حفظ"
 
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "إلى الأمام"
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "‏VPN"
 
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
-msgstr "لم يُعثر على أي قلم"
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "تفاصيل"
 
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr "رجاء انقل قلمك قرب اللوح لإعداده"
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+msgid "Modem Status"
+msgstr "الحالة:"
 
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
-msgstr "الشعور بضغط الممحاة"
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:340
-msgid "Soft"
-msgstr "ناعم"
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "وقت ال_شبكة"
 
-#: panels/wacom/wacom-stylus-page.ui:210 panels/wacom/wacom-stylus-page.ui:370
-msgid "Firm"
-msgstr "قاس"
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "إعدادات الشّبكة"
 
-#: panels/wacom/wacom-stylus-page.ui:233
-msgid "Top Button"
-msgstr "الزر العلوي"
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "الأرقام"
 
-#: panels/wacom/wacom-stylus-page.ui:262
-msgid "Lower Button"
-msgstr "الزر السفلي"
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "أنواع الأجهزة"
 
-#: panels/wacom/wacom-stylus-page.ui:291
-msgid "Lowest Button"
-msgstr "الزر الأسفل"
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "المُصنِّع"
 
-#: panels/wacom/wacom-stylus-page.ui:320
-msgid "Tip Pressure Feel"
-msgstr "الشعور بضغط السن"
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "البرمجية المغروسة غير متاحة"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Settings"
-msgstr "إعدادات جنوم"
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "مُوصد"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "شبكة هاتف م_حمول"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "وقت ال_شبكة"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "الشبكة"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "متقدم"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "خيارات النفاذ"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "أوصِد"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "تفاصيل %s"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "اسم الشبكة"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "تلقائي"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "شبكتي المنزلية"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "شبكتي المنزلية"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "لم يُعثر على محوّل واي فاي"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "تأكد من أن محوّل واي فاي متصل و يعمل"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "بلوتوث معطّل لأن وضع الطائرة مفعّل."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "أوقف وضع الطائرة"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr " انس الاتصال"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "لم تُدرج شريحة الهاتف"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "أوصِد"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "_غيّر"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "شبكتي المنزلية"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "اضبط إعدادات الوسائط المنفصلة"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
 msgstr "أدوات لضبط سطح مكتب جنوم"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr ""
 
-#: shell/cc-application.c:58
-msgid "Display version number"
-msgstr "اعرض الإصدارة"
-
-#: shell/cc-application.c:59
-msgid "Enable verbose mode"
-msgstr "فعّل الطور المسهِب"
-
-#: shell/cc-application.c:60
-msgid "Search for the string"
-msgstr "ابحث عن نصّ"
-
-#: shell/cc-application.c:61
-msgid "List possible panel names and exit"
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
 msgstr ""
 
-#: shell/cc-application.c:62
-msgid "Panel to display"
-msgstr "لوحة لعرضها"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "يُعدّ المُشغّل الجديد…"
 
-#: shell/cc-application.c:62
-msgid "[PANEL] [ARGUMENT…]"
-msgstr ""
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "الخصوصية"
 
-#: shell/cc-panel-list.ui:195
-msgid "No results found"
-msgstr "لا نتائج"
-
-#: shell/cc-panel-loader.c:279
-msgid "Available panels:"
-msgstr "اللوحات المتوفرة:"
-
-#: shell/cc-window.ui:131
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "كل الإعدادات"
 
-#: shell/cc-window.ui:169
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr "القائمة الرئيسية"
 
-#: shell/cc-window.ui:271
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr "تحذير: الإصدارة التطويرية"
 
-#: shell/cc-window.ui:272
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
 "issues. "
 msgstr ""
-"هذه الإصدارة من تطبيق الإعدادات مخصصة للتطوير. قد تواجه مشاكل في سلوك النظام،"
-" أو تتعرض لفقد البيانات، أو أي مشاكل أخرى غير متوقعة."
+"هذه الإصدارة من تطبيق الإعدادات مخصصة للتطوير. قد تواجه مشاكل في سلوك "
+"النظام، أو تتعرض لفقد البيانات، أو أي مشاكل أخرى غير متوقعة."
 
-#: shell/cc-window.ui:283
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "مساعدة"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: shell/gnome-control-center.desktop.in.in:5
-msgid "org.gnome.Settings"
-msgstr "org.gnome.Settings"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "تفضيلات;إعدادات;"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -7956,7 +5223,7 @@ msgctxt "shortcut window"
 msgid "Quit"
 msgstr "أنهِ"
 
-#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "ابحث"
@@ -7966,15 +5233,19 @@ msgctxt "shortcut window"
 msgid "Panels"
 msgstr "اللوحات"
 
-#: shell/help-overlay.ui:40
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
 msgstr "ارجع للشاشة السابقة"
 
-#: shell/help-overlay.ui:53
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "ألغِ البحث"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "تفضيلات;إعدادات;"
 
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
@@ -7995,9 +5266,17 @@ msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1871
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
@@ -8008,9 +5287,7 @@ msgstr[3] "%u مَخْارِج"
 msgstr[4] "%u مَخْرَجًا"
 msgstr[5] "%u مَخْرَج"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1881
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
@@ -8021,24 +5298,2706 @@ msgstr[3] "%u مَداخِل"
 msgstr[4] "%u مَدْخَلًا"
 msgstr[5] "%u مَدْخَل"
 
-#: subprojects/gvc/gvc-mixer-control.c:2736
-msgid "System Sounds"
-msgstr "أصوات النظام"
+#~ msgid "System Bus"
+#~ msgstr "ناقل النظام"
+
+#~ msgid "Full access"
+#~ msgstr "وصول كامل"
+
+#~ msgid "Session Bus"
+#~ msgstr "ناقل الجلسة"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "وصول كامل إلى /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "له وصول إلى الشبكة"
+
+#~ msgid "Home"
+#~ msgstr "البداية"
+
+#~ msgid "Read-only"
+#~ msgstr "قراءة فقط"
+
+#~ msgid "Can change settings"
+#~ msgstr "يستطيع تغيير الإعدادات"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "الصلاحيات التالية مبنية في %s، ولا يمكن تغييرها. إذا كنت قلقا من هذا "
+#~ "الصلاحيات، فربما تود إزالة التطبيق."
+
+#~ msgid "Web Links"
+#~ msgstr "روابط الوب"
+
+#~ msgid "Git Links"
+#~ msgstr "روابط Git"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "روابط %s"
+
+#~ msgid "Unset"
+#~ msgstr "أزل"
+
+#~ msgid "Links"
+#~ msgstr "روابط"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "ملفات النص التشعبي"
+
+#~ msgid "Text Files"
+#~ msgstr "ملفات النصوص"
+
+#~ msgid "Image Files"
+#~ msgstr "ملفات الصور"
+
+#~ msgid "Font Files"
+#~ msgstr "ملفات الخطوط"
+
+#~ msgid "Archive Files"
+#~ msgstr "الملفات المضغوطة"
+
+#~ msgid "Package Files"
+#~ msgstr "ملفات الحزم"
+
+#~ msgid "Audio Files"
+#~ msgstr "ملفات الصوت"
+
+#~ msgid "Video Files"
+#~ msgstr "ملفات الفديو"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "الصلاحيات والوصول"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "البيانات والخدمات التي طلب هذا التطبيق الوصول إليها والصلاحيات التي "
+#~ "يحتاجها."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "لا يمكن تغييرها"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "يمكن مراجعة صلاحيات التطبيق كل على حدة في إعدادات <a "
+#~ "href=\"privacy\">الخصوصية</a>."
+
+#~ msgid "Integration"
+#~ msgstr "التكامل"
+
+#~ msgid "Default Handlers"
+#~ msgstr "المناولات المبدئية"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "أنواع الملفات والروابط التي يفتحها هذا التطبيق."
+
+#~ msgid "Usage"
+#~ msgstr "الاستخدام"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "ما مقدار الموارد التي يستخدمها هذا التطبيق."
+
+#~ msgid "Open in Software"
+#~ msgstr "افتح في «البرمجيات»"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "_Background"
+#~ msgstr "ال_خلفية"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "تتغير خلال اليوم"
+
+#~ msgid "_Lock Screen"
+#~ msgstr "أو_صد الشاشة"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "مبلّطة"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "مُقرَّبة"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "موسَّطة"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "محجّمة"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "مملوءة"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "موسّعة"
+
+#~ msgid "Colors"
+#~ msgstr "ألوان"
+
+#~ msgid "Select Background"
+#~ msgstr "اختر خلفية"
+
+#~ msgid "Pictures"
+#~ msgstr "صور"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "لم يُعثر على أي صور"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "يمكنك إضافة الصور إلى مجلد %s و ستظهر هنا"
+
+#~ msgid "multiple sizes"
+#~ msgstr "مقاسات متعددة"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "لا خلفية لسطح المكتب"
+
+#~ msgid "Current background"
+#~ msgstr "الخلفية الحالية"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "خلفية;شاشة;سطح المكتب;"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "ضع جهاز المعايرة على المربع ثم اضغط ”ابدأ“"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "انقل جهاز المعايرة إلى موضع المعايرة ثم اضغط ”واصل“"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "انقل جهاز المعايرة إلى موضع السطح ثم اضغط ”واصل“"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "أعلق غطاء الحاسوب"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "حصل عطل داخلي تعذّر التعافي منه."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "الأدوات المطلوبة للمعايرة غير مُثبّتة."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "تعذّر توليد الإعدادات."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "لا يمكن الحصول على النقطة البيضاء المحددة"
+
+#~ msgid "Complete!"
+#~ msgstr "تم"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "فشلت المعايرة"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "يمكنك رفع جهاز المعايرة"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "لا تُقاطع جهاز المعايرة أثناء عمله"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "شاشة حاسوب محمول"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "كمرة وب مدمجة"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "شاشة %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "ماسحة %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "كمرة %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "طابعة %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "كمرة وب %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "فعّل إدارة ألوان %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "أظهر تشكيلات ألوان %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "غير مُعايَر"
+
+#~ msgid "Default: "
+#~ msgstr "المبدئي: "
+
+#~ msgid "Test profile: "
+#~ msgstr "ملف إعداد للاختبار: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "اختر ملف إعداد ICC"
+
+#~ msgid "_Import"
+#~ msgstr "ا_ستورد"
+
+#~ msgid "All files"
+#~ msgstr "كلّ الملفات"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "فشل رفع الملف: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "رُفع الإعداد إلى:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "اكتب هذا المسار في ورقة."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "أعد تشغيل الحاسوب و أقلع نظام التشغيل المعتاد."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "اكتب المسار في المتصفح و نزّل الإعداد."
+
+#~ msgid "Save Profile"
+#~ msgstr "احفظ الإعداد"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "أنشئ إعداد لون للجهاز المختار"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr "لم تُكتشف أداة القياس. رجاءً تأكد من تشغيلها وتوصيلها بشكل صحيح."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "أداة القياس لا تدعم تشكيل الطابعة."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "نوع الجهاز غير مدعوم حاليًا."
+
+#~ msgid "Upload profile"
+#~ msgstr "ارفع الإعداد"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "يحتاج اتصالًا بالإنترنت"
+
+#~ msgid "Standard Space"
+#~ msgstr "النطاق المعياري"
+
+#~ msgid "Test Profile"
+#~ msgstr "اختبر الإعداد"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "تلقائي"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "جودة منخفضة"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "جودة متوسطة"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "جودة عالية"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "ح‌خ‌ز المبدئي"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "زق‌ص‌س المبدئي"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "الرمادي المبدئي"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "بيانات معايرة المصنع من منتج الجهاز"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "تصحيح عرض ملء الشاشة غير ممكن مع هذا الإعداد"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "هذا الإعداد ربما لم يعد دقيقا"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "Other…"
+#~ msgstr "آخر…"
+
+#~ msgid "Today"
+#~ msgstr "اليوم"
+
+#~ msgid "Yesterday"
+#~ msgstr "الأمس"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %B"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %B، %Y"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "نقطة بث"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y، %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y، %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s، %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "جرينتش%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr ":"
+
+#~ msgid "24-hour"
+#~ msgstr "24-ساعة"
+
+#~ msgid "AM / PM"
+#~ msgstr "ص \\ م"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "أتريد تطبيق التغييرات؟"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "تعذّر تطبيق التغييرات"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "قد يكون هذا بسبب قصور في العتاد."
+
+#~ msgid "On"
+#~ msgstr "مفعّل"
+
+#~ msgid "Off"
+#~ msgstr "معطّل"
+
+#~ msgid "Join Displays"
+#~ msgstr "ضم الشاشات"
+
+#~ msgid "Display Mode"
+#~ msgstr "نمط العرض"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "اسحب الشاشات لتطابق ترتيبها في الطبيعة. اختر الشاشة لتغيير إعداداتها."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "ترتيب الشاشات"
+
+#~ msgid "Display Configuration"
+#~ msgstr "إعدادات الشاشة"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "عرضيّ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "طوليّ يمين"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "طوليّ يسار"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "عرضيّ (مقلوب)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf هرتز"
+
+#~ msgid "_Off"
+#~ msgstr "مع_طّل"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "Unknown"
+#~ msgstr "غير معروف"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "٦٤ بتة"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "٣٢ بتة"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "الإصدارة %s"
+
+#~ msgid "OS name"
+#~ msgstr "اسم نظام التشغيل"
+
+#~ msgid "OS type"
+#~ msgstr "نوع نظام التشغيل"
+
+#~ msgid "Disk"
+#~ msgstr "القرص"
+
+#~ msgid "Check for updates"
+#~ msgstr "التمس التحديثات"
+
+#~ msgid "Ask what to do"
+#~ msgstr "اسأل ما الذي يجب فعله"
+
+#~ msgid "Do nothing"
+#~ msgstr "لا تفعل شيئا"
+
+#~ msgid "Open folder"
+#~ msgstr "افتح المجلّد"
+
+#~ msgid "Other Media"
+#~ msgstr "وسائط أخرى"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "اختر تطبيقا لاسطوانات الصوت"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "اختر تطبيقا لاسطوانات الفديو"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "اختر تطبيقا لتشغيله عند توصيل مشغّل موسيقى"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "اختر تطبيقا لتشغيله عند توصيل كمرة"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "اختر تطبيقا لاسطوانات البرامج"
+
+#~ msgid "audio DVD"
+#~ msgstr "دي‌ڤي‌دي صوتي"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "قرص Blu-Ray فارغ"
+
+#~ msgid "blank CD disc"
+#~ msgstr "اسطوانة فارغة"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "قرص دي‌ڤي‌دي فارغ"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "قرص دي‌ڤي‌دي إتش‌دي فارغ"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "قرص Blu-Ray فديو فارغ"
+
+#~ msgid "e-book reader"
+#~ msgstr "قارئ كتب إلكتروني"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "قرص دي‌ڤي‌دي إتش‌دي فديو فارغ"
+
+#~ msgid "Picture CD"
+#~ msgstr "اسطوانة صور"
+
+#~ msgid "Super Video CD"
+#~ msgstr "اسطوانة فديو فائقة"
+
+#~ msgid "Video CD"
+#~ msgstr "اسطوانة فديو"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "احفظ لقطة شاشة في مجلد $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "احفظ لقطة شاشة لنافذة في مجلد $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "احفظ لقطة شاشة لمنطقة في مجلد $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "انسخ اللقطة إلى الحافظة"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "انسخ لقطة النافذة إلى الحافظة"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "انسخ لقطة المنطقة المحددة إلى الحافظة"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "سجّل تسجيل شاشة قصير"
+
+#~ msgid "Universal Access"
+#~ msgstr "الإتاحة"
+
+#, fuzzy
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "تحول إلى المصدر التالي"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "أتريد تصفير كل الاختصارات؟"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "تصفير الاختصارات قد يؤثر على اختصاراتك المخصوصة. لا يمكن التراجع عن هذا."
+
+#~ msgid "Reset All"
+#~ msgstr "صفّر الكل"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for <b>%s</b>. If you replace it, %s will be "
+#~ "disabled"
+#~ msgstr "الاختصار %s مستخدم حاليا من أجل <b>%s</b>. إذا استبدلته، فيُعطّل %s."
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "حدد اختصارًا مخصصًا"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "حدد اختصارًا"
+
+#, c-format
+#~ msgid "Enter new shortcut to change <b>%s</b>."
+#~ msgstr "أدخل اختصارًا جديدًا لتغيير <b>%s</b>."
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "أدخِل اختصارًا جديدًا"
+
+#~ msgid "Set"
+#~ msgstr "حدد"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "مهلة النقر المزدوج"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "اللف بأصبعين"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "نقرة مزدوجة، الزر الأساسي"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "نقرة مفردة، الزر الأساسي"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "نقرة مزدوجة، الزر الأوسط"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "نقرة مفردة، الزر الأوسط"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "نقرة مزدوجة، الزر الثانوي"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "نقرة مفردة، الزر الثانوي"
+
+#~ msgid "Network proxy"
+#~ msgstr "وسيط الشبكة"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "‏VPN %s"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "يجب أن يكون NetworkManager شغّالًا."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "الاتصال/SSID"
+
+#~ msgid "page 1"
+#~ msgstr "صفحة 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "الاستيثاق ال_داخلي"
+
+#~ msgid "page 2"
+#~ msgstr "صفحة 2"
+
+#~ msgid "automatic"
+#~ msgstr "تلقائي"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "إعداد %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "مؤسسة"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "بدون"
+
+#~ msgid "Never"
+#~ msgstr "أبدًا"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d م.بايت\\ث"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "لا إشارة"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "ضعيفة"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "معقولة"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "جيّدة"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "ممتازة"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "أزل إعدادات الاتصال"
+
+#~ msgid "Remove VPN"
+#~ msgstr "أزل VPN"
+
+#~ msgid "Identity"
+#~ msgstr "الهوية"
+
+#~ msgid "Delete Route"
+#~ msgstr "احذق السبيل"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "لا شيء"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "عبارة سر WEP‏ 128-بتة"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "‏WPA و WPA2 شخصي"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "‏WPA و WPA2 للمؤسسات"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "قلل استخدام البيانات في الخلفية"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "مناسب للاتصالات التي تحاسب على الاستهلاك أو لها تعليق."
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 م.بايت\\ث"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 م.بايت\\ث"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 ج.بايت/ث"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 ج.بايت/ث"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "تعذّر فتح محرر الاتصالات"
+
+#~ msgid "New Profile"
+#~ msgstr "إعداد جديد"
+
+#~ msgid "Import from file…"
+#~ msgstr "استورد من ملف…"
+
+#~ msgid "Add VPN"
+#~ msgstr "أضف VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "تعذّر استيراد اتصال VPN"
+
+#~ msgid "Select file to import"
+#~ msgstr "اختر ملفا لاستيراده"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "يوجد فعلا ملف بالاسم ”%s“."
+
+#~ msgid "_Replace"
+#~ msgstr "ا_ستبدل"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "هل تريد استبدال %s باتصال VPN الذي تحفظه؟"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "تعذّر تصدير اتصال VPN"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "صدّر اتصال VPN"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "never"
+#~ msgstr "أبدًا"
+
+#~ msgid "today"
+#~ msgstr "اليوم"
+
+#~ msgid "yesterday"
+#~ msgstr "الأمس"
+
+#~ msgid "Last used"
+#~ msgstr "آخر استخدام"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "تشغيل نقطة بث اللاسلكي ستفصلك عن <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "لا يمكن استخدام الاتصال اللاسلكي للوصول إلى الإنترنت عند تفعيل نقطة البث."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr "تستخدم نقاط بث واي فاي عادة لمشاركة اتصال إنترنت إضافي عبر واي فاي."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "إيقاف نقطة البث وقطع الاتصال عن أي مستخدمين؟"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "أو_قف نقطة البث"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "تمنع سياسة النظام استخدامه نقطة بث"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "لا يدعم جهاز اللاسلكي وضع نقطة البث"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr "ستُفقد تفاصيل الشبكة، بما في ذلك كلمات السر وأي إعدادات مُخصصة."
+
+#~ msgid "_Forget"
+#~ msgstr "ان_سَ"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "شبكات واي فاي المعروفة"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "إن_س"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "يستخدم الاكتشاف التلقائي للوسيط في حال لم يُعطَ مسار للإعداد."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "لا يُنصَح بهذا مع الشبكات العامة غير الموثوقة."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "اتّ_صل تلقائيا"
+
+#~ msgid "details"
+#~ msgstr "التفاصيل"
+
+#~ msgid "Show P_assword"
+#~ msgstr "أ_ظهر كلمة السر"
+
+#~ msgid "Make available to other users"
+#~ msgstr "اجعله متاحا للمستخدمين الآخرين"
+
+#~ msgid "identity"
+#~ msgstr "الهوية"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "ال_عنوان"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "عناوين (DHCP) تلقائية فقط"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_تجاهل السُبُل المُضافة آليًا"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "عنوان MAC _منسوخ"
+
+#~ msgid "_Reset"
+#~ msgstr "_صفّر"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "صفّر كل إعدادات هذا الاتصال لقيمها المبدئية و لكن تذكّر أنها الاتصال المُفضّل."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "احذف كل التفاصيل المتعلقة بهذه الشبكة و لا تحاول الاتصال بها تلقائيا."
+
+#~ msgid "Hardware"
+#~ msgstr "العتاد"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "صفّر"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "أطفئ للاتصال بشبكة واي فاي"
+
+#~ msgid "Connected Devices"
+#~ msgstr "الأجهزة الموصّلة"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "كلمة السر"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "لا مركزية"
+
+#~ msgid "Infrastructure"
+#~ msgstr "مركزية"
+
+#~ msgid "Status unknown"
+#~ msgstr "الحالة غير معروفة"
+
+#~ msgid "Unmanaged"
+#~ msgstr "غير مُدار"
+
+#~ msgid "Unavailable"
+#~ msgstr "غير متاح"
+
+#~ msgid "Connecting"
+#~ msgstr "يتّصل"
+
+#~ msgid "Authentication required"
+#~ msgstr "الاستيثاق مطلوب"
+
+#~ msgid "Disconnecting"
+#~ msgstr "يقطع الاتصال"
+
+#~ msgid "Connection failed"
+#~ msgstr "فشل الاتصال"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "الحالة غير معروفة (مفقودة)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "فشل الإعداد"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "فشل إعداد رقم الإنترنت (IP)"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "انتهت صلاحية إعداد رقم الإنترنت (IP)"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "الأسرار مطلوبة لكن لم تُعطَ"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "فشل بدء خدمة PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "فصلت خدمة PPP"
+
+#~ msgid "PPP failed"
+#~ msgstr "فشل PPP"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "فشل بدء عميل DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "خطأ من عميل DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "فشل عميل DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "فشل بدء خدمة الاتصال المشترك"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "فشلت خدمة الاتصال المشترك"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "فشل بدء خدمة AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "عطل في خدمة AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "فشلت خدمة AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "الخط مشغول"
+
+#~ msgid "No dial tone"
+#~ msgstr "الخط مقطوع"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "انتهت مهلة الاتصال الهاتفي"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "فشل الاتصال الهاتفي"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "فشلت تهيئة المودم"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "تعذّر اختيار APN المحدد"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "لن يبحث عن شبكة"
+
+#~ msgid "Network registration denied"
+#~ msgstr "رُفض تسجيل الشبكة"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "انتهت مهلة تسجيل الشبكة"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "فشل تسجيل الشبكة المطلوبة"
+
+#~ msgid "PIN check failed"
+#~ msgstr "فضل فحص PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "البرمجيات المضمنة التي يحتاجها الجهاز غير متاحة"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "اختفى الاتصال"
+
+#~ msgid "Modem not found"
+#~ msgstr "المودم غير موجود"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "فشل اتصال بلوتوث"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "فشلت اعتمادية الاتصال"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "الكبل مفصول"
+
+#~ msgid "no file selected"
+#~ msgstr "لم تحدد أي ملف"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "ملفات PAC‏ (*.pac)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "المفاتيح السرية غير المُعمّاة ليست آمنة"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "المفتاح السري المحدد ليس محميًا بكلمة سر.  قد يتسبب هذا في تقويض اعتمادات "
+#~ "الأمان. رجاء اختر مفتاحًا محميًا بكلمة سر.\n"
+#~ "\n"
+#~ "(يمكنك حماية مفتاحك بكلمة سر باستخدام openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "اختر شهادتك الشخصية"
+
+#~ msgid "Choose your private key"
+#~ msgstr "اختر مفتاحك السري"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_نوافذ التنبيهات المنبثقة"
+
+#~ msgid "preferences-system-notifications"
+#~ msgstr "preferences-system-notifications"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "أخرى"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "حساب %s"
+
+#~ msgid "Error removing account"
+#~ msgstr "خطأ أثناء إزالة الحساب"
+
+#, c-format
+#~ msgid "<b>%s</b> removed"
+#~ msgstr "أزيل <b>%s</b>"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "Remove Account"
+#~ msgstr "أزِل الحساب"
+
+#~ msgid "Unknown time"
+#~ msgstr "وقت غير معروف"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s حتى يكتمل الشحن"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "تحذير: بقي %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "بقي %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "مشحونة بالكامل"
+
+#~ msgid "Not charging"
+#~ msgstr "لا تشحن"
+
+#~ msgid "Empty"
+#~ msgstr "فارغة"
+
+#~ msgid "Charging"
+#~ msgstr "يشحن"
+
+#~ msgid "Discharging"
+#~ msgstr "تُفرّغ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "الأساسية"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "إضافية"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "فأرة لا سلكية"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "لوحة مفاتيح لا سلكية"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "مزود طاقة غير منقطعة"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "مساعد رقمي شخصي PDA"
+
+#~ msgid "Cellphone"
+#~ msgstr "هاتف خليوي"
+
+#~ msgid "Media player"
+#~ msgstr "مشغل وسائط"
+
+#~ msgid "Computer"
+#~ msgstr "حاسوب"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "تشحن"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "إنتباه"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "منخفضة"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "جيّدة"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "مشحونة بالكامل"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "فارغة"
+
+#~ msgid "Batteries"
+#~ msgstr "البطاريات"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "أقل من ساعة"
+#~ msgstr[1] "ساعة واحدة"
+#~ msgstr[2] "ساعتين"
+#~ msgstr[3] "%d ساعات"
+#~ msgstr[4] "%d ساعة"
+#~ msgstr[5] "%d ساعة"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "أقل من دقيقة"
+#~ msgstr[1] "دقيقة واحدة"
+#~ msgstr[2] "دقيقتين"
+#~ msgstr[3] "%d دقائق"
+#~ msgstr[4] "%d دقيقة"
+#~ msgstr[5] "%d دقيقة"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "أقل من ثانية"
+#~ msgstr[1] "ثانية واحدة"
+#~ msgstr[2] "ثانيتين"
+#~ msgstr[3] "%d ثوان"
+#~ msgstr[4] "%d ثانية"
+#~ msgstr[5] "%d ثانية"
+
+#, c-format
+#~ msgctxt "time"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "time"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#~ msgid "When _idle"
+#~ msgstr "عند عدم الا_ستخدام"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "س_طوع الشاشة"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "سطوع _لوحة المفاتيح"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "أ_خفض ضوء الشاشة عند الخمول"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "واي فاي"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "يمكن تعطيل واي فاي لتوفير الطاقة."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "يمكن تعطل شبكات الهاتف المحمول (٣ج، ٤ج، واي‌ماك، إلخ.) لتوفير الطاقة."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "بلو_توث"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "يمكن تعطيل بلوتوث لتوفير الطاقة."
+
+#~ msgid "When on battery power"
+#~ msgstr "عندما تكون على طاقة البطارية"
+
+#~ msgid "When plugged in"
+#~ msgstr "عند توصيل الكبل"
+
+#~ msgid "Suspend"
+#~ msgstr "علِّق"
+
+#~ msgid "Power Off"
+#~ msgstr "أطفئ"
+
+#~ msgid "Hibernate"
+#~ msgstr "أسبِت"
+
+#~ msgid "Nothing"
+#~ msgstr "لا تفعل شيئا"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "التعليق و زر الطاقة"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "ت_عليق تلقائي"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "تعليق تلقائي"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "عند _ضغط زر الطاقة"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "دقيقة واحدة"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "دقيقتين"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "٣ دقائق"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "٤ دقائق"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "٥ دقائق"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "٨ دقائق"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "١٠ دقائق"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "١٢ دقيقة"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "١٥ دقيقة"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "أبدًا"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "استوثق"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "أزيلت الطابعة ”%s“"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "تعذّر إضافة طابعة جديدة."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "تعذّر تحميل الواجهة: %s"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "لم يعثر على أي طابعة مناسبة"
+
+#~ msgid "Select PPD File"
+#~ msgstr "اختر ملف PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "ملفت وصف طابعة بوست‌سكربت (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "طابعة JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "طابعة LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "على وجه واحد"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "الحافة الطويلة (قياسي)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "الحافة القصيرة (ملفوف)"
+
+#~ msgid "Portrait"
+#~ msgstr "طوليّ"
+
+#~ msgid "Landscape"
+#~ msgstr "عرضيّ"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "عرضيّ مقلوب"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "طوليّ مقلوب"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "منتظرة"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "مُلبثة"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "الاستيثاق مطلوب"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "تُعالَج"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "متوقفة"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "ملغاة"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "مُجهضَة"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "مُنجزَة"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — المهام النشطة"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "أدخل اسم المستخدم و كلمة السر للطباعة من %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "افتح خادوم الطباعة"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "افتح %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "أدخل اسم المستخدم و كلمة السر لعرض الطابعات المتوفرة على %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "البحث عن الطابعات"
+
+#~ msgid "USB"
+#~ msgstr "يو‌إس‌بي"
+
+#~ msgid "Serial Port"
+#~ msgstr "منفذ تسلسلي"
+
+#~ msgid "Parallel Port"
+#~ msgstr "منفذ متواز"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "المكان: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "العنوان: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "يتطلب الخادوم الاستيثاق"
+
+#~ msgid "Two Sided"
+#~ msgstr "على الوجهين"
+
+#~ msgid "Paper Type"
+#~ msgstr "نوع الورق"
+
+#~ msgid "Paper Source"
+#~ msgstr "مصدر الورق"
+
+#~ msgid "Output Tray"
+#~ msgstr "رف الخارج"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "الميز"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "ترشيح مسبق في غوست‌سكربت"
+
+#~ msgid "Pages per side"
+#~ msgstr "الصفحات في كل وجه"
+
+#~ msgid "Orientation"
+#~ msgstr "الاتجاه"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "عام"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "إعداد الصفحة"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "الخيارات القابلة للتثبيت"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "المهام"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "جودة الصورة"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "الألوان"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "الإنهاء"
+
+#~ msgid "Test page"
+#~ msgstr "صفحة اختبار"
+
+#~ msgid "Auto Select"
+#~ msgstr "اختيار تلقائي"
+
+#~ msgid "Printer Default"
+#~ msgstr "مبدئي الطابعة"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "ادمج خطوط غوست‌سكربت فقط"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "حوّل إلى بوست‌سكربت المستوى 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "حوّل إلى بوست‌سكربت المستوى 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "لا ترشيح مسبق"
+
+#~ msgid "Out of toner"
+#~ msgstr "نفد الحبر"
+
+#~ msgid "Low on developer"
+#~ msgstr "المُحمِّض قليل"
+
+#~ msgid "Out of developer"
+#~ msgstr "نفد المُحمِّض"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "اللون قليل"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "نفد اللون"
+
+#~ msgid "Open cover"
+#~ msgstr "الغطاء مفتوح"
+
+#~ msgid "Open door"
+#~ msgstr "الباب مفنوح"
+
+#~ msgid "Low on paper"
+#~ msgstr "الورق قليل"
+
+#~ msgid "Out of paper"
+#~ msgstr "نفد الورق"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "غير متصلة"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "متوقفة"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "حاوية النفايات على وشك الامتلاء"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "حاوية النفايات ممتلئة"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "قاربت صلاحية المقاوم الضوئي على الانتهاء"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "لم يعد المقاوم الضوئي يعمل"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "جاهزة"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "لا تقبل المهام"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "تُعالِج"
+
+#~ msgid "Clean print heads"
+#~ msgstr "نظف رؤوس الطباعة"
+
+#~ msgid "Add…"
+#~ msgstr "أضف…"
+
+#~ msgid "In use"
+#~ msgstr "قيد الاستعمال"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "مشغلة"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "مغلقة"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "معطّل"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "مفعّل"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "معطّل"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "مفعّل"
+
+#~ msgid "Usage & History"
+#~ msgstr "الاستخدام والتأريخ"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "أأحذف كل العناصر من المهملات؟"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "ستحذف نهائيا كل العناصر الموجودة في المهملات."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "أ_فرغ المهملات"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "أأحذف كل الملفات المؤقتة؟"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "ستُحذف كل الملفات المؤقتة نهائيًا."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "ت_خلّص من الملفات المؤقتة"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "الإبلاغ عن المشاكل التقنية يساعدنا على تحسين %s. ترسل البلاغات مُجهّلة بدون "
+#~ "أي معلومات شخصية."
+
+#~ msgid "Privacy Policy"
+#~ msgstr "سياسة الخصوصية"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "٣٠ ثانية"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "دقيقة واحدة"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "دقيقتين"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "٣ دقائق"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "٥ دقائق"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "٣٠ دقيقة"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "ساعة واحدة"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "ساعة واحدة"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "يوم واحد"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "يومين"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "٣ أيام"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "٤ أيام"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "٥ أيام"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "٦ أيام"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "٧ أيام"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "١٤ يومًا"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "٣٠ يومًا"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "يوم واحد"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "٧ أيام"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "٣٠ يومًا"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "إلى الأبد"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "تذكر التأريخ يسهل الوصول إلى الأشياء في ما بعد. لا تُشارك هذه العناصر أبدا "
+#~ "عبر الشبكة."
+
+#~ msgid "_Recently Used"
+#~ msgstr "مستخدمة مؤ_خرا"
+
+#~ msgid "Retain _History"
+#~ msgstr "احتف_ظ بالتأريخ"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "قفل الشاشة يحفظ خصوصيتك حين تبتعد عن حاسوبك."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "أ_وصِد الشاشة بعد إطفائها لمدة"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "تخلص من المهملات والملفات المؤقتة تلقائيا للمحافظة على خلو حاسوبك من "
+#~ "المعلومات الحساسة."
+
+#~ msgid "Purge _After"
+#~ msgstr "أفرف ب_عد"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "إرسال معلومات لنا عن البرمجيات التي تستخدمها يساعدنا على إمدادك بتوصيات "
+#~ "أدق، كما يساعدنا أيضًا على تسحين برمجياتنا.\n"
+#~ "\n"
+#~ "كل المعلومات التي نجمعها مُجهّلة و لن نشاركها أبدًا مع أي طرف ثالث."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "أر_سل إحصائيات استخدام البرمجيات"
+
+#~ msgid "_Camera"
+#~ msgstr "_كمرة"
+
+#~ msgid "_Microphone"
+#~ msgstr "_ميكروفون"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "تسمح خدمات التموضع للتطبيقات بمعرفة مكانك. استخدام الشبكات اللاسلكية "
+#~ "و الهاتف المحمول يزيد من دقة هذه الخدمات."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "يستخدم خدمة تموضع موزيلا: <a href='https://location.services.mozilla.com/"
+#~ "privacy'>سياسة الخصوصية</a>"
+
+#~ msgid "_Location Services"
+#~ msgstr "خدمات ال_تموضع"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "احمِ بياناتك الشخصية و تحكم في ما يمكن للآخرين الاطلاع عليه منها"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "إمبراطوري"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "متري"
+
+#~ msgid "No regions found"
+#~ msgstr "لا يوجد أي مناطق"
+
+#~ msgid "No input sources found"
+#~ msgstr "لا يوجد أي مصادر إدخال"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "أخرى"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "يجب إعادة تشغيل الجلسة لتطبيق التغييرات"
+
+#~ msgid "Restart…"
+#~ msgstr "أعِد التشغيل…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "يستخدم إعدادات الولوج كل المستخدمين أثناء الولوج إلى النظام"
+
+#~ msgid "Previous source"
+#~ msgstr "المصدر السابق"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "المصدر التالي"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Left+Right Alt"
+
+#~ msgid "These keyboard shortcuts can be changed in the keyboard settings"
+#~ msgstr "يمكن تغيير هذه الاختصارات من إعدادات لوحة المفاتيح"
+
+#~ msgid ""
+#~ "Select your display language, formats, keyboard layouts and input sources"
+#~ msgstr "اختر لغة العرض و التنسيق و تخطيط لوحة المفاتيح و مصادر الإدخال"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Select Location"
+#~ msgstr "اختر مكانًا"
+
+#~ msgid "_OK"
+#~ msgstr "_نعم"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "لم تختر أي شبكة لمشاركتها"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "مفعّل"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "معطّل"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "مفعّل"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "اختر مجلّدًا"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "تتيح لك ”مشاركة الملفات“ مشاركة المجلد العام مع الآخرين على الشبكة "
+#~ "الحالية باستخدام: <a href=\"dav://%s\">‪dav://%s‬</a>"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "عند تفعيل بالولوج عن بعد، يمكن للمستخدمين الولوج عن بعد باستخدام أمر "
+#~ "الصدفة الآمنة:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "مشاركة الشاشة تسمح للمستخدمين عن بعد بالتحكم في شاشتك باستخدام: <a "
+#~ "href=\"vnc://%s\">‪vnc://%s‬</a>"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "مشار_كة الشاشة"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "بعض الأجهزة معطل لتعذّر الوصول الشبكي."
+
+#~ msgid "Screen Sharing"
+#~ msgstr "مشاركة الشاشة"
+
+#~ msgid "_Password:"
+#~ msgstr "كلمة ال_سر:"
+
+#~ msgid "_Show Password"
+#~ msgstr "أ_ظهر كلمة السر"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "يجب على الاتصالات الجديدة أن ت_طلب النفاذ"
+
+#~ msgid "_Require a password"
+#~ msgstr "ا_طلب كلمة سر"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "Custom"
+#~ msgstr "مخصص"
+
+#~ msgid "Bark"
+#~ msgstr "نباح"
+
+#~ msgid "Drip"
+#~ msgstr "قطرات"
+
+#~ msgid "Glass"
+#~ msgstr "زجاج"
+
+#~ msgid "Sonar"
+#~ msgstr "سونار"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "يختبر %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "١٠٠٪"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "غير متّصل"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "يتّصل"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "متّصل"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "عطل في التخويل"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "يخوّل"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "وظيفية مقللة"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "متّصل ومخوّل"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "غير معروف"
+
+#~ msgid "Authorized at:"
+#~ msgstr "مخوّل في:"
+
+#~ msgid "Connected at:"
+#~ msgstr "متّصل في:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "سجّل في:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "فشل تخويل الجهاز:"
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "فشل نسيان الجهاز:"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "عُطل"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "مخوّل"
+
+#, fuzzy
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "تعذّر توليد الإعدادات."
+
+#, fuzzy, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "عطل في تحديد مُرسِل البريد المبدئي: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "المبدئي"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "متوسط"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "كبير"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "أكبر"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "الأكبر"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d بكسل"
+#~ msgstr[1] "%d بكسل"
+#~ msgstr[2] "%d بكسل"
+#~ msgstr[3] "%d بكسل"
+#~ msgstr[4] "%d بكسل"
+#~ msgstr[5] "%d بكسل"
+
+#~ msgid "Screen Reader"
+#~ msgstr "قارئ الشاشة"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "قارئ ال_شاشة"
+
+#~ msgid "Sound Keys"
+#~ msgstr "مفاتيح الصوت"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "أومض _عنوان النافذة"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "قصيرة"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ الشاشة"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ الشاشة"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ الشاشة"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "طويلة"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "يجب أن تطابق عنوان الوب لمُزود الولوج."
+
+#~ msgid "Failed to add account"
+#~ msgstr "فشلت إضافة الحساب"
+
+#~ msgid "Failed to register account"
+#~ msgstr "فشل تسجيل المستخدم"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "لا توجد طريقة مدعومة للاستيثاق مع هذا النطاق"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "فشل الانضمام إلى النطاق"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "اسم الولوج لم يعمل.\n"
+#~ "من فضلك أعد المحاولة"
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "كلمة سر الولوج لم تعمل.\n"
+#~ "من فضلك أعد المحاولة"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "فشل الولوج إلى النطاق"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "تعذّر العثور على النطاق. هل أخطأت في كتابته؟"
+
+#~ msgid "Standard"
+#~ msgstr "عادي"
+
+#~ msgid "Account _Type"
+#~ msgstr "_نوع الحساب"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "اسمح للمستخدم بوضع كلمة سر عند الولوج ال_تالي"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_ضع كلمة سر الآن"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "يجب أن تكون متصلا لإضافة حسابات ولوج مؤسسات."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "التقط صورة…"
+
+#~ msgid "This Week"
+#~ msgstr "هذا الأسبوع"
+
+#~ msgid "Last Week"
+#~ msgstr "الأسبوع الماضي"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %B"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %B، %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s، %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "انتهت الجلسة"
+
+#~ msgid "Session Started"
+#~ msgstr "بدأت الجلسة"
+
+#~ msgid "Please choose another password."
+#~ msgstr "رجاء اختر كلمة سر أخرى."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "رجاء أعد كتابة كلمة السر الحالية."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "تعذّر تغيير كلمة السر"
+
+#~ msgid "_Confirm New Password"
+#~ msgstr "أ_كّد كلمة السر الجديدة"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "لا يمكن الانضمام تلقائيا إلى هذا النوع من النطاقات"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "لم يعثر على هذا النطاق أو المجال"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "تعذّر الولوج باسم %s في النطاق %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "كلمة سر خطأ؛ من فضلك أعد المحاولة"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "فشل حذف المستخدم"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "فشل إبطال المستخدم المتحكم فيه عن بعد"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "لا يمكنك حذف حسابك أنت."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "ما يزال %s والجا"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "حذف مستخدم أثناء ولوجه قد يترك النظام في حالة غير مستقرة."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "أتريد إبقاء ملفات %s؟"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "من الممكن الإبقاء على مجلد المنزل وخزانة البريد والملفات المؤقتة عند حذف "
+#~ "حساب مستخدم."
+
+#~ msgid "_Delete Files"
+#~ msgstr "ا_حذف الملفات"
+
+#~ msgid "_Keep Files"
+#~ msgstr "أ_بقِ الملفات"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "أمتأكد أنك تريد إبطال حساب %s المتحكم فيه عن بعد؟"
+
+#~ msgid "_Delete"
+#~ msgstr "ا_حذف"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "الحساب معطّل"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "لتوضع مع الولوج التالي"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "بدون"
+
+#~ msgid "Logged in"
+#~ msgstr "والِج"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "فشل الاتصال بخدمة الحسابات"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "رجاء تأكّد من أن AccountService مثبّتة ومفعّلة."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "انقر على أيقونة *\n"
+#~ "لعمل أي تغييرات"
+
+#~ msgid "Create a user account"
+#~ msgstr "أنشئ حساب مستخدِم"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "لإنشاء حساب مستخدِم،\n"
+#~ "انقر أولًا على أيقونة *"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "احذف حساب المستخدِم المختار"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "لحذف حساب المستخدم المختار،\n"
+#~ "انقر أولًا على أيقونة *"
+
+#~ msgid "User Icon"
+#~ msgstr "أيقونة المستخدم"
+
+#~ msgid "Last Login"
+#~ msgstr "آخر ولوج"
+
+#~ msgid "Left thumb"
+#~ msgstr "الإبهام الأيسر"
+
+#~ msgid "Left middle finger"
+#~ msgstr "الوسطى اليسرى"
+
+#~ msgid "Left ring finger"
+#~ msgstr "البنصر الأيسر"
+
+#~ msgid "Left little finger"
+#~ msgstr "الخنصر الأيسر"
+
+#~ msgid "Right thumb"
+#~ msgstr "الإبهام الأيمن"
+
+#~ msgid "Right middle finger"
+#~ msgstr "الوسطى اليمنى"
+
+#~ msgid "Right ring finger"
+#~ msgstr "البنصر الأيمن"
+
+#~ msgid "Right little finger"
+#~ msgstr "الخنصر الأيمن"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "فعّل الولوج بالبصمة"
+
+#~ msgid "_Right index finger"
+#~ msgstr "السبابة الي_منى"
+
+#~ msgid "_Left index finger"
+#~ msgstr "السبابة الي_سرى"
+
+#~ msgid "_Other finger:"
+#~ msgstr "أصبع آخ_ر:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr "حُفظت بصمتك بنجاح. تستطيع الآن الولوج ببصمة أصبعك."
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "ولوج;اسم;بصمة;أيقونة;شعار;وجه;كلمة سر;"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "لا تحتوي كلمة السر الجديدة على حروف مختلفة كفاية."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "حاول تغيير بعض الحروف و الأرقان."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "حاول تغيير كلمة السر أكثر قليلًا."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "كلمة السر أقوى بدون اسم المستخدم."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "حاول تفادي وضع اسم المستخدم في كلمة السر."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "حاول تفادي بعض الكلمات المستخدمة في كلمة السر."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "حاول تفادي الكلمات الشائعة."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "حاول تفادي تغيير ترتيب كلمات معروفة."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "حاول استخدام أرقام أكثر."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "حاول استخدام حروف كبيرة أكثر."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "حاول استخدام حروف صغيرة أكثر."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "حاول استخدام علامات خاصة أكثر، مثل علامات الترقيم."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "حاول استخدام خليط من الحروف و الأرقام و علامات الترقيم."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "حاول تفادي تكرار نفس الحرف."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "حاول تفادي تكرار نفس النوع من الحروف: عليك الخلط بين الحروف و الأرقام "
+#~ "و علامات الترقيم."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "حاول تفادي تتابعات مثل 1234 أو abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "على كلمة السر أن تكون أطول. حاول استخدام خليط من الحروف و الأرقام "
+#~ "و علامات الترقيم."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "اخلط الحروف الكبيرة مع الصغيرة و استخدم رقمًا أو اثنين."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "إضافة المزيد من الحروف و الأرقام و علامات الترقيم ستجعل كلمة السر أقوى."
+
+#~ msgid "Authentication failed"
+#~ msgstr "فشل الاستيثاق"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "كلمة السّر الجديدة قصيرة جدًا"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "كلمة السر الجديدة بسيطة جدا"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "كلمتا السر القديمة والجديدة متشابهتان جدا"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "كلمة السر الجديدة سبق استخدامها مؤخرا."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "يجب أن تحتوي كلمة السر الجديدة على محارف خاصة أو أرقام"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "كلمتا السر القديمة و الجديدة متطابقتان"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "تغيِّرت كلمة السر بعد الاستيثاق!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "لا تحتوي كلمة السر الجديدة على حروف مختلفة كفاية"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "عطل غير معروف"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "اسم المستخدم هذا غير متاح. جرب اسمًا آخر."
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "اسم المستخدم طويل جدا."
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "لا يمكن أن يبدأ اسم المستخدم بعلامة ”-“."
+
+#~ msgid ""
+#~ "The username should only consist of upper and lower case letters from a-"
+#~ "z, digits and the following characters: . - _"
+#~ msgstr ""
+#~ "يجب أن لا يتعدى اسم المستخدم الحروف الإنجليزية الكبيرة و الصغيرة من a-z، "
+#~ "و الأرقام و أي من الحروف '.' و '-' و '_'."
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "سيُستخدم هذا لتسمية مجلد المنزل ولا يمكن تغييره."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "لست مخولا بالوصول إلى الجهاز. تكلم مع مدير النظام."
+
+#~ msgid "The device is already in use."
+#~ msgstr "الجهاز مستخدم بالفعل."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "حصل عطل داخلي."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "أأحذف البصمات المسجّلة؟"
+
+#~ msgid "Done!"
+#~ msgstr "تم!"
+
+#, c-format
+#~ msgid "Could not access “%s” device"
+#~ msgstr "تعذر الوصول إلى الجهاز ”%s“"
+
+#, c-format
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "تعذّر بدء التقاط الأصابع على الجهاز ”%s“"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "تعذّر الوصول إلى أي قارئ بصمة"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "من فضلك راجع مدير النظام للمساعدة."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "لتفعيل الولوج بالبصمة، ستحتاج لحفظ إحدى بصماتك باستخدام الجهاز ”%s“."
+
+#~ msgid "Selecting finger"
+#~ msgstr "اصبع الاختيار"
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "زر %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "أرسل ضغطة الزر"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "بدّل الشاشة"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "أظهر مساعدة على الشاشة"
+
+#~ msgid "Output:"
+#~ msgstr "المَخْرَج:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "حافظ على نسبة العرض:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "عيّن في شاشة واحدة"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d من %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "اعرض المخطط"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "لوح (مطلق)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "تفضيلات اللوح"
+
+#~ msgid "_Help"
+#~ msgstr "م_ساعدة"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "إعدادات بلوتوث"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "نمط التتبع"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "تعيين أزرار…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "اضبط إعدادات الفأرة"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "اضبط ميز الشاشة"
+
+#~ msgid "New shortcut…"
+#~ msgstr "اختصار جديد…"
+
+#~ msgid "No stylus found"
+#~ msgstr "لم يُعثر على أي قلم"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "رجاء انقل قلمك قرب اللوح لإعداده"
+
+#~ msgid "Top Button"
+#~ msgstr "الزر العلوي"
+
+#~ msgid "Lowest Button"
+#~ msgstr "الزر الأسفل"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "إعدادات جنوم"
+
+#~ msgid "Display version number"
+#~ msgstr "اعرض الإصدارة"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "فعّل الطور المسهِب"
+
+#~ msgid "Search for the string"
+#~ msgstr "ابحث عن نصّ"
+
+#~ msgid "Panel to display"
+#~ msgstr "لوحة لعرضها"
+
+#~ msgid "Available panels:"
+#~ msgstr "اللوحات المتوفرة:"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "System Sounds"
+#~ msgstr "أصوات النظام"
 
 #~ msgid "Language"
 #~ msgstr "اللغة"
-
-#~ msgid "Primary Display"
-#~ msgstr "الشاشة الرئيسية"
 
 #~ msgid "_Night Light"
 #~ msgstr "الإ_ضاءة الليلية"
 
 #~ msgid "Could not get screen information"
 #~ msgstr "تعذّرت معرفة معلومات الشاشة"
-
-#~ msgid "My Home Network"
-#~ msgstr "شبكتي المنزلية"
 
 #~ msgid "hardware"
 #~ msgstr "العتاد"
@@ -8135,9 +8094,6 @@ msgstr "أصوات النظام"
 #~ msgid "Sound Effects"
 #~ msgstr "المؤثرات الصوتية"
 
-#~ msgid "No application is currently playing or recording audio."
-#~ msgstr "لا تطبيقات تشغل أو تسجل صوتا حاليا."
-
 #~ msgid "Built-in"
 #~ msgstr "مدمج"
 
@@ -8195,9 +8151,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Co­lor"
 #~ msgstr "الألوان"
-
-#~ msgid "Section"
-#~ msgstr "القسم"
 
 #~ msgid "Overview"
 #~ msgstr "عام"
@@ -8262,9 +8215,6 @@ msgstr "أصوات النظام"
 #~ msgid "Mirrored"
 #~ msgstr "متطابقة"
 
-#~ msgid "Secondary"
-#~ msgstr "الثانوي"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "رتب الشاشات المركبة"
 
@@ -8288,9 +8238,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Size"
 #~ msgstr "الحجم"
-
-#~ msgid "Aspect Ratio"
-#~ msgstr "نسبة العرض"
 
 #~ msgid "Show the top bar and Activities Overview on this display"
 #~ msgstr "اعرض الشريط العلوي و تجميعة الأنشطة على هذه الشاشة"
@@ -8344,9 +8291,6 @@ msgstr "أصوات النظام"
 #~ "إذا كان لديك اتصال بالإنترنت غير الاتصال اللاسلكي فيمكنك إعداد نقطة بث "
 #~ "لمشاركة اتصالك بالإنترنت مع الآخرين."
 
-#~ msgid "History"
-#~ msgstr "التأريخ"
-
 #~ msgid "Proxy"
 #~ msgstr "الوسيط"
 
@@ -8382,9 +8326,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "_History"
 #~ msgstr "ال_تأريخ"
-
-#~ msgid "Loading options…"
-#~ msgstr "يُحمّل الخيارات…"
 
 #~ msgid "%s %d-bit (Build ID: %s)"
 #~ msgstr "‏%s ‏%d-بتة (معرف البناء: %s)"
@@ -8447,9 +8388,6 @@ msgstr "أصوات النظام"
 #~ msgid "Wayland"
 #~ msgstr "وايلاند"
 
-#~ msgid "Edit"
-#~ msgstr "حرِّر"
-
 #~ msgctxt "notifications"
 #~ msgid "Notification _Banners"
 #~ msgstr "أ_شرطة التنبيهات"
@@ -8462,10 +8400,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Mail"
 #~ msgstr "البريد"
-
-#~| msgid "_Calendar"
-#~ msgid "Calendar"
-#~ msgstr "التقويم"
 
 #~ msgid "Contacts"
 #~ msgstr "المتراسلين"
@@ -8481,9 +8415,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "هذا لن يزيل الحساب على الخادوم."
-
-#~ msgid "_Remove"
-#~ msgstr "أ_زل"
 
 #~ msgid "No online accounts configured"
 #~ msgstr "لم تُعد أي حسابات إنترنت"
@@ -8539,9 +8470,6 @@ msgstr "أصوات النظام"
 #~ msgid "label"
 #~ msgstr "العنوان"
 
-#~ msgid "Setting new driver…"
-#~ msgstr "يُعدّ المُشغّل الجديد…"
-
 #~ msgid "Print _Test Page"
 #~ msgstr "اطبع صفحة ا_ختبار"
 
@@ -8576,17 +8504,8 @@ msgstr "أصوات النظام"
 #~ msgid "Scroll Up"
 #~ msgstr "تمرير للأعلى"
 
-#~ msgid "Scroll Down"
-#~ msgstr "تمرير للأسفل"
-
-#~ msgid "Scroll Left"
-#~ msgstr "تمرير لليسار"
-
 #~ msgid "Scroll Right"
 #~ msgstr "تمرير لليمين"
-
-#~ msgid "Add Shortcut"
-#~ msgstr "أضف اختصارًا"
 
 #~ msgid "Remove Shortcut"
 #~ msgstr "أزِل اختصارًا"
@@ -8689,9 +8608,6 @@ msgstr "أصوات النظام"
 #~ msgid "Don't _warn me again"
 #~ msgstr "لا _تنبهني ثانيةً"
 
-#~ msgid "No"
-#~ msgstr "لا"
-
 #~ msgid "Yes"
 #~ msgstr "نعم"
 
@@ -8713,9 +8629,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Personal File Sharing"
 #~ msgstr "مشاركة الملفات الشخصية"
-
-#~ msgid "_Allow Remote Control"
-#~ msgstr "اسمح بالتحكم عن بع_د"
 
 #~ msgid "_Verify"
 #~ msgstr "أ_كّد"
@@ -8763,9 +8676,6 @@ msgstr "أصوات النظام"
 #~ msgid "S_peed:"
 #~ msgstr "ال_سرعة:"
 
-#~ msgid "Shortcuts"
-#~ msgstr "الاختصارات"
-
 #~ msgid "Test Your Settings"
 #~ msgstr "اختبر إعداداتك"
 
@@ -8807,9 +8717,6 @@ msgstr "أصوات النظام"
 #~ msgid "No printers available"
 #~ msgstr "لا تتوفر أي طابعات"
 
-#~ msgid "Close"
-#~ msgstr "أغلق"
-
 #~ msgid "Resume Printing"
 #~ msgstr "تابع الطباعة"
 
@@ -8829,17 +8736,11 @@ msgstr "أصوات النظام"
 #~ msgid "Job State"
 #~ msgstr "حالة المهمة"
 
-#~ msgid "Time"
-#~ msgstr "الوقت"
-
 #~ msgid "Add New Printer"
 #~ msgstr "أضِف طابعة جديدة"
 
 #~ msgid "Used to determine your geographical location"
 #~ msgstr "تستخدم لتحديد موقعك الجغرافي"
-
-#~ msgid "Options"
-#~ msgstr "الخيارات"
 
 #~ msgid "Password:"
 #~ msgstr "كلمة السر:"
@@ -8851,20 +8752,11 @@ msgstr "أصوات النظام"
 #~ msgid "Color"
 #~ msgstr "اللون"
 
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "بلوتوث معطّل"
-
-#~ msgid "Security key"
-#~ msgstr "مفتاح الأمن"
-
 #~ msgid "Wireless devices require extra power"
 #~ msgstr "يحتاج الجهاز اللاسلكي طاقة إضافية"
 
 #~ msgid "When battery power is _critical"
 #~ msgstr "عندما تكون الطاقة من_خفضة جدا"
-
-#~ msgid "Power off"
-#~ msgstr "أطفئ التشغيل"
 
 #~ msgid ""
 #~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
@@ -8895,17 +8787,11 @@ msgstr "أصوات النظام"
 #~ msgid "Germany"
 #~ msgstr "ألمانيا"
 
-#~ msgid "France"
-#~ msgstr "فرنسا"
-
 #~ msgid "Spain"
 #~ msgstr "إسبانيا"
 
 #~ msgid "China"
 #~ msgstr "الصّين"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "_عطّل أثناء الكتابة"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "لا تتوافق خدمات الشبكة في النظام مع هذه الإصدارة."
@@ -8951,32 +8837,20 @@ msgstr "أصوات النظام"
 #~ msgid "Share Public Folder On This Network"
 #~ msgstr "شارك المجلد العام على هذه الشبكة"
 
-#~ msgid "Flickr"
-#~ msgstr "فلِكَر"
-
 #~ msgid "Set Up New Device"
 #~ msgstr "إعداد جهاز جديد"
 
 #~ msgid "Paired"
 #~ msgstr "مقترن"
 
-#~ msgid "Type"
-#~ msgstr "النوع"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "إعدادات الفأرة ولوحة اللمس"
-
-#~ msgid "Sound Settings"
-#~ msgstr "إعدادات الصوت"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "إعدادات لوحة المفاتيح"
 
 #~ msgid "Send Files…"
 #~ msgstr "أرسل ملفات…"
-
-#~ msgid "Visibility"
-#~ msgstr "الظهور"
 
 #~ msgid "Visibility of “%s”"
 #~ msgstr "ظهور ”%s“"
@@ -9086,9 +8960,6 @@ msgstr "أصوات النظام"
 #~ msgid "_City:"
 #~ msgstr "الم_دينة:"
 
-#~ msgid "_Network Time"
-#~ msgstr "وقت ال_شبكة"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "قدّم الوقت ساعة واحدة."
 
@@ -9109,18 +8980,8 @@ msgstr "أصوات النظام"
 #~ msgstr "طبيعي"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "مع عقارب الساعة"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 درجة"
-
-#~ msgid "Monitor"
-#~ msgstr "الشاشة"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "اسحب لتغيير جهاز العرض المبدئي."
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -9171,9 +9032,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "_Stealth Mode"
 #~ msgstr "وضع الت_خفي"
-
-#~ msgid "_Confirm Password"
-#~ msgstr "أ_كّد كلمة السر"
 
 #~ msgid "_Login Name"
 #~ msgstr "اسم ال_ولوج"
@@ -9316,12 +9174,6 @@ msgstr "أصوات النظام"
 #~ msgid "C_ontinue"
 #~ msgstr "_تابع"
 
-#~ msgid "Previous Week"
-#~ msgstr "الأسبوع الماضي"
-
-#~ msgid "Next Week"
-#~ msgstr "الأسبوع القادم"
-
 #~ msgid "Next week"
 #~ msgstr "الأسبوع القادم"
 
@@ -9333,9 +9185,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Enable this account"
 #~ msgstr "فعّل هذا الحساب"
-
-#~ msgid "Generate a password"
-#~ msgstr "ولِّد كلمة سر"
 
 #~ msgid "_Action"
 #~ msgstr "الإ_جراء"
@@ -9431,14 +9280,8 @@ msgstr "أصوات النظام"
 #~ msgid "Set your mouse and touchpad preferences"
 #~ msgstr "اضبط تفضيلات الفأرة ولوحة اللمس"
 
-#~ msgid "Network settings"
-#~ msgstr "إعدادات الشّبكة"
-
 #~ msgid "_Options…"
 #~ msgstr "ال_خيارات…"
-
-#~ msgid "Manage notifications"
-#~ msgstr "أدِر التنبيهات"
 
 #~ msgid "Expired credentials. Please log in again."
 #~ msgstr "بيانات اعتماد مُنتهية. رجاءً لُج مجددا."
@@ -9466,9 +9309,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Don't retain history"
 #~ msgstr "لا تحتفظ بالتأريخ"
-
-#~ msgid "Lock Screen _After"
-#~ msgstr "أوصِد الشاشة ب_عد"
 
 #~ msgid "Change your region and language settings"
 #~ msgstr "غيّر إعدادات المنطقة واللغة"
@@ -9500,9 +9340,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Region and Language"
 #~ msgstr "المنطقة واللغة"
-
-#~ msgid "Select a display language"
-#~ msgstr "اختر لغة العرض"
 
 #~ msgid "Add Language"
 #~ msgstr "أضِف لغة"
@@ -9543,9 +9380,6 @@ msgstr "أصوات النظام"
 #~ msgid "System settings"
 #~ msgstr "إعدادات النظام"
 
-#~ msgid "Search settings"
-#~ msgstr "إعدادات البحث"
-
 #~ msgid "Universal Access Preferences"
 #~ msgstr "تفضيلات الإتاحة"
 
@@ -9564,9 +9398,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Set your Wacom tablet preferences"
 #~ msgstr "إعداد تفضيلات لوح واكوم"
-
-#~ msgid "Create virtual device"
-#~ msgstr "أنشئ جهاز افتراضي"
 
 #~ msgid "%i year"
 #~ msgid_plural "%i years"
@@ -9620,9 +9451,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Add a virtual device"
 #~ msgstr "اضف جهازًا افتراضيًا"
-
-#~ msgid "Remove a device"
-#~ msgstr "أزِل جهازا"
 
 #~ msgid "Unspecified"
 #~ msgstr "غير محدّد"
@@ -9684,9 +9512,6 @@ msgstr "أصوات النظام"
 #~ msgid "Brightness & Lock"
 #~ msgstr "السطوع والقفل"
 
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "إعدادات سطوع وقفل الشاشة"
-
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "سطوع;قفل;فارغ;شاشة;"
 
@@ -9701,12 +9526,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Locations…"
 #~ msgstr "المكان…"
-
-#~ msgid "Show _notifications when locked"
-#~ msgstr "أظهر ال_تنبيهات عندما يكون موصدًا"
-
-#~ msgid "Lock"
-#~ msgstr "أوصِد"
 
 #~ msgid "No user with the name '%s' exists."
 #~ msgstr "اسم المستخدم '%s' موجود بالفعل."
@@ -9814,9 +9633,6 @@ msgstr "أصوات النظام"
 #~ msgid "Remove Language"
 #~ msgstr "أزِل لغة"
 
-#~ msgid "Install languages..."
-#~ msgstr "ثبّت اللغات..."
-
 #~ msgid "Locations..."
 #~ msgstr "الأماكن..."
 
@@ -9897,9 +9713,6 @@ msgstr "أصوات النظام"
 #~ msgid "Network"
 #~ msgstr "على الشبكة"
 
-#~ msgid "Device types"
-#~ msgstr "أنواع الأجهزة"
-
 #~ msgid "Automatic configuration"
 #~ msgstr "إعداد تلقائي"
 
@@ -9923,9 +9736,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Caribou"
 #~ msgstr "كاريبو"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "ا_ختر جهازا لإعداده:"
 
 #~ msgid "Add wallpaper"
 #~ msgstr "أضف خلفية"
@@ -9959,9 +9769,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "Sh_ow position of pointer when the Control key is pressed"
 #~ msgstr "أ_ظهر موقع الفأرة عند ضغط مفتاح Ctrl"
-
-#~ msgid "A_cceleration:"
-#~ msgstr "ال_تسارع:"
 
 #~ msgid "_Sensitivity:"
 #~ msgstr "الح_ساسية:"
@@ -10060,12 +9867,6 @@ msgstr "أصوات النظام"
 #~ msgid "New windows use the previous window's layout"
 #~ msgstr "النوافذ الجديدة تستخدم تخطيط النافذة السابقة"
 
-#~ msgid "View and edit keyboard layout options"
-#~ msgstr "اعرض وعدّل خيارات تخطيط لوحة المفاتيح"
-
-#~ msgid "Reset to De_faults"
-#~ msgstr "ا_ستعد المبدئيات"
-
 #~ msgid ""
 #~ "Replace the current keyboard layout settings with the\n"
 #~ "default settings"
@@ -10076,20 +9877,11 @@ msgstr "أصوات النظام"
 #~ msgid "Layouts"
 #~ msgstr "التخطيطات"
 
-#~ msgid "Layout"
-#~ msgstr "التخطيط"
-
 #~ msgid "Change contrast:"
 #~ msgstr "غيّر التباين:"
 
 #~ msgid "_Text size:"
 #~ msgstr "حجم ال_نص:"
-
-#~ msgid "Increase size:"
-#~ msgstr "كبّر الحجم:"
-
-#~ msgid "Decrease size:"
-#~ msgstr "قلل الحجم:"
 
 #~ msgctxt "universal access, seeing"
 #~ msgid "Zoom"
@@ -10257,10 +10049,6 @@ msgstr "أصوات النظام"
 #~ msgstr "رجاء اختر صورة."
 
 #, fuzzy
-#~ msgid "Centered"
-#~ msgstr "موسَّطة"
-
-#, fuzzy
 #~ msgid "Show"
 #~ msgstr "أ_ظهر"
 
@@ -10279,9 +10067,6 @@ msgstr "أصوات النظام"
 #, fuzzy
 #~ msgid "_Turn off after:"
 #~ msgstr "أ_طفئ بعد:"
-
-#~ msgid "Mute"
-#~ msgstr "أصمِت"
 
 #~ msgid "Current network location"
 #~ msgstr "مكان الشبكة الحالي"
@@ -10308,9 +10093,6 @@ msgstr "أصوات النظام"
 #~ "URL for where to get more desktop themes. If set to an empty string the "
 #~ "link will not appear."
 #~ msgstr "مسار لجلب المزيد من سمات سطح المكتب. إذا ترك فارغا لن يظهر."
-
-#~ msgid "Locked"
-#~ msgstr "مُوصد"
 
 #~ msgid ""
 #~ "Dialog is unlocked.\n"
@@ -10378,9 +10160,6 @@ msgstr "أصوات النظام"
 #~ msgid "On AC power:"
 #~ msgstr "على الطاقة الاعتيادية:"
 
-#~ msgid "Put the computer to sleep when inactive:"
-#~ msgstr "ضع الحاسوب لينام عندما لا يكون نشطا:"
-
 #~ msgid "When the sleep button is pressed:"
 #~ msgstr "عند ضغط زر الإسبات:"
 
@@ -10404,9 +10183,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "DSL"
 #~ msgstr "DSL"
-
-#~ msgid "Locate Pointer"
-#~ msgstr "حدد موقع المؤشر"
 
 #~ msgid "16"
 #~ msgstr "16"
@@ -10608,9 +10384,6 @@ msgstr "أصوات النظام"
 #~ msgid "_Type to test settings:"
 #~ msgstr "ا_كتب لاختبار الإعدادات:"
 
-#~ msgid "Desktop"
-#~ msgstr "سطح المكتب"
-
 #~ msgid "Choose type of click _beforehand"
 #~ msgstr "اختر نوع النقر م_سبقًا"
 
@@ -10704,9 +10477,6 @@ msgstr "أصوات النظام"
 
 #~ msgid "GNOME OnScreen Keyboard"
 #~ msgstr "لوحة مفاتيح جنوم على الشاشة"
-
-#~ msgid "GNOME Terminal"
-#~ msgstr "طرفية جنوم"
 
 #~ msgid "Gnopernicus"
 #~ msgstr "جنوبرنيكوس"

--- a/po/ar.po~
+++ b/po/ar.po~
@@ -1,0 +1,10757 @@
+# translation of gnome-control-center to Arabic
+# This file is under the same license as the gnome-control-center package.
+# Copyright (C) Listed translators
+# Sayed Jaffer Al-Mosawi <mosawi@arabeyes.org>, 2002.
+# Isam Bayazidi <bayazidi@arabeyes.org>, 2002.
+# Arafat Medini <lumina@silverpen.de>, 2003.
+# Abdulaziz Al-Arfaj <alarfaj0@yahoo.com>, 2004.
+# Anas Husseini <linux.anas@gmail.com>, 2007.
+# Djihed Afifi <djihed@gmail.com>, 2006.
+# Khaled Hosny <khaledhosny@eglug.org>, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019.
+# Abderrahim Kitouni <a.kitouni@gmail.com>, 2011, 2012.
+# Ibrahim Saed <ibraheem5000@gmail.com>, 2012.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-03-17 16:07+0200\n"
+"PO-Revision-Date: 2019-03-17 17:07+0200\n"
+"Last-Translator: Khaled Hosny <khaledhosny@eglug.org>\n"
+"Language-Team: Arabic <doc@arabeyes.org>\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
+"X-Generator: Virtaal 0.7.1\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:558
+msgid "System Bus"
+msgstr "ناقل النظام"
+
+#: panels/applications/cc-applications-panel.c:558
+#: panels/applications/cc-applications-panel.c:560
+#: panels/applications/cc-applications-panel.c:576
+#: panels/applications/cc-applications-panel.c:581
+msgid "Full access"
+msgstr "وصول كامل"
+
+#: panels/applications/cc-applications-panel.c:560
+msgid "Session Bus"
+msgstr "ناقل الجلسة"
+
+#: panels/applications/cc-applications-panel.c:565
+#: panels/power/cc-power-panel.c:2528 panels/thunderbolt/cc-bolt-panel.ui:466
+#: panels/thunderbolt/cc-bolt-panel.ui:525 shell/cc-panel-list.ui:45
+#: shell/cc-window.c:251
+msgid "Devices"
+msgstr "الأجهزة"
+
+#: panels/applications/cc-applications-panel.c:565
+msgid "Full access to /dev"
+msgstr "وصول كامل إلى /dev"
+
+#: panels/applications/cc-applications-panel.c:570
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:241
+msgid "Network"
+msgstr "الشبكة"
+
+#: panels/applications/cc-applications-panel.c:570
+msgid "Has network access"
+msgstr "له وصول إلى الشبكة"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: panels/applications/cc-applications-panel.c:576
+#: panels/applications/cc-applications-panel.c:578
+#: panels/background/cc-background-chooser-dialog.c:536
+#: panels/search/cc-search-locations-dialog.c:286
+msgid "Home"
+msgstr "البداية"
+
+#: panels/applications/cc-applications-panel.c:578
+#: panels/applications/cc-applications-panel.c:583
+msgid "Read-only"
+msgstr "قراءة فقط"
+
+#: panels/applications/cc-applications-panel.c:581
+#: panels/applications/cc-applications-panel.c:583
+msgid "File System"
+msgstr "نظام الملفات"
+
+#: panels/applications/cc-applications-panel.c:588
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:255
+#: shell/cc-window.c:867 shell/cc-window.ui:116
+#: shell/gnome-control-center.desktop.in.in:3
+msgid "Settings"
+msgstr "الإعدادات"
+
+#: panels/applications/cc-applications-panel.c:588
+msgid "Can change settings"
+msgstr "يستطيع تغيير الإعدادات"
+
+#: panels/applications/cc-applications-panel.c:593
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"الصلاحيات التالية مبنية في %s، ولا يمكن تغييرها. إذا كنت قلقا من هذا "
+"الصلاحيات، فربما تود إزالة التطبيق."
+
+#: panels/applications/cc-applications-panel.c:735
+msgid "Web Links"
+msgstr "روابط الوب"
+
+#: panels/applications/cc-applications-panel.c:745
+msgid "Git Links"
+msgstr "روابط Git"
+
+#: panels/applications/cc-applications-panel.c:751
+#, c-format
+msgid "%s Links"
+msgstr "روابط %s"
+
+#: panels/applications/cc-applications-panel.c:759
+#: panels/applications/cc-applications-panel.c:795
+msgid "Unset"
+msgstr "أزل"
+
+#: panels/applications/cc-applications-panel.c:850
+msgid "Links"
+msgstr "روابط"
+
+#: panels/applications/cc-applications-panel.c:858
+msgid "Hypertext Files"
+msgstr "ملفات النص التشعبي"
+
+#: panels/applications/cc-applications-panel.c:872
+msgid "Text Files"
+msgstr "ملفات النصوص"
+
+#: panels/applications/cc-applications-panel.c:886
+msgid "Image Files"
+msgstr "ملفات الصور"
+
+#: panels/applications/cc-applications-panel.c:902
+msgid "Font Files"
+msgstr "ملفات الخطوط"
+
+#: panels/applications/cc-applications-panel.c:963
+msgid "Archive Files"
+msgstr "الملفات المضغوطة"
+
+#: panels/applications/cc-applications-panel.c:983
+msgid "Package Files"
+msgstr "ملفات الحزم"
+
+#: panels/applications/cc-applications-panel.c:1006
+msgid "Audio Files"
+msgstr "ملفات الصوت"
+
+#: panels/applications/cc-applications-panel.c:1023
+msgid "Video Files"
+msgstr "ملفات الفديو"
+
+#: panels/applications/cc-applications-panel.c:1031
+msgid "Other Files"
+msgstr "ملفات أخرى"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1353
+#: panels/applications/cc-applications-panel.ui:406
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:167
+#: panels/privacy/cc-privacy-panel.ui:1085
+msgid "Applications"
+msgstr "التطبيقات"
+
+#: panels/applications/cc-applications-panel.ui:45
+msgid "No applications"
+msgstr "لا تطبيقات"
+
+#: panels/applications/cc-applications-panel.ui:59
+msgid "Install some…"
+msgstr "ثبّت البعض…"
+
+#: panels/applications/cc-applications-panel.ui:99
+msgid "Permissions & Access"
+msgstr "الصلاحيات والوصول"
+
+#: panels/applications/cc-applications-panel.ui:111
+msgid ""
+"Data and services that this app has asked for access to and permissions that "
+"it requires."
+msgstr ""
+"البيانات والخدمات التي طلب هذا التطبيق الوصول إليها والصلاحيات التي يحتاجها."
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/applications/cc-applications-panel.ui:132
+#: panels/privacy/cc-privacy-panel.c:908 panels/privacy/cc-privacy-panel.ui:745
+msgid "Camera"
+msgstr "كمرة"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:133
+#: panels/applications/cc-applications-panel.ui:145
+#: panels/applications/cc-applications-panel.ui:157
+#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:255
+#: panels/keyboard/cc-keyboard-option.c:259
+#: panels/keyboard/cc-keyboard-option.c:378
+#: panels/keyboard/keyboard-shortcuts.c:425
+#: panels/keyboard/shortcut-editor.ui:96 panels/network/network-proxy.ui:123
+#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
+#: panels/user-accounts/um-fingerprint-dialog.c:211
+#: subprojects/gvc/gvc-mixer-control.c:1864
+msgid "Disabled"
+msgstr "معطّل"
+
+#: panels/applications/cc-applications-panel.ui:138
+#: panels/applications/cc-applications-panel.ui:144
+#: panels/privacy/cc-privacy-panel.c:941 panels/privacy/cc-privacy-panel.ui:850
+msgid "Microphone"
+msgstr "ميكروفون"
+
+#: panels/applications/cc-applications-panel.ui:150
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/privacy/cc-privacy-panel.c:850 panels/privacy/cc-privacy-panel.ui:955
+msgid "Location Services"
+msgstr "خدمات التموضع"
+
+#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:422
+msgid "Built-in Permissions"
+msgstr "الصلاحيات المدمجة"
+
+#: panels/applications/cc-applications-panel.ui:163
+msgid "Cannot be changed"
+msgstr "لا يمكن تغييرها"
+
+#: panels/applications/cc-applications-panel.ui:180
+msgid ""
+"Individual permissions for applications can be reviewed in the <a href="
+"\"privacy\">Privacy</a> Settings."
+msgstr ""
+"يمكن مراجعة صلاحيات التطبيق كل على حدة في إعدادات <a href=\"privacy\""
+">الخصوصية</a>."
+
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Integration"
+msgstr "التكامل"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System features used by this application."
+msgstr "خصائص النظام التي يستخدمها هذا التّطبيق."
+
+#: panels/applications/cc-applications-panel.ui:230
+#: panels/applications/cc-applications-panel.ui:236
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:146
+msgid "Search"
+msgstr "البحث"
+
+#: panels/applications/cc-applications-panel.ui:242
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "التنبيهات"
+
+#: panels/applications/cc-applications-panel.ui:248
+#: panels/applications/cc-applications-panel.ui:254
+msgid "Sounds"
+msgstr "الصوت"
+
+#: panels/applications/cc-applications-panel.ui:287
+msgid "Default Handlers"
+msgstr "المناولات المبدئية"
+
+#: panels/applications/cc-applications-panel.ui:299
+msgid "Types of files and links that this application opens."
+msgstr "أنواع الملفات والروابط التي يفتحها هذا التطبيق."
+
+#: panels/applications/cc-applications-panel.ui:315
+msgid "Reset"
+msgstr "صفّر"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "Usage"
+msgstr "الاستخدام"
+
+#: panels/applications/cc-applications-panel.ui:363
+msgid "How much resources this application is using."
+msgstr "ما مقدار الموارد التي يستخدمها هذا التطبيق."
+
+#: panels/applications/cc-applications-panel.ui:378
+#: panels/applications/cc-applications-panel.ui:458
+msgid "Storage"
+msgstr "مساحة التخزين"
+
+#: panels/applications/cc-applications-panel.ui:413
+msgid "Open in Software"
+msgstr "افتح في «البرمجيات»"
+
+#: panels/applications/cc-applications-panel.ui:475
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "ما المساحة التي يستخدمها هذا التطبيق هو والبيانات التي يخزنها."
+
+#: panels/applications/cc-applications-panel.ui:484
+msgid "Application"
+msgstr "تطبيق"
+
+#: panels/applications/cc-applications-panel.ui:490
+msgid "Data"
+msgstr "البيانات"
+
+#: panels/applications/cc-applications-panel.ui:496
+msgid "Cache"
+msgstr "الخبيئة"
+
+#: panels/applications/cc-applications-panel.ui:502
+msgid "<b>Total</b>"
+msgstr "<b>المجموع</b>"
+
+#: panels/applications/cc-applications-panel.ui:519
+msgid "Clear Cache…"
+msgstr "امسح الخبيئة…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "تحكم في مختلف صلاحيات وإعدادات التطبيقات"
+
+#. FIXME
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/applications/gnome-applications-panel.desktop.in.in:8
+msgid "application-x-executable"
+msgstr "application-x-executable"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "تطبيق;صلاحيات;إعداد;application;flatpak;permission;setting;"
+
+#: panels/background/background.ui:49
+msgid "_Background"
+msgstr "ال_خلفية"
+
+#. This refers to a slideshow background
+#: panels/background/background.ui:99 panels/background/background.ui:212
+msgid "Changes throughout the day"
+msgstr "تتغير خلال اليوم"
+
+#. To translators: This is a noun, not a verb
+#: panels/background/background.ui:162
+msgid "_Lock Screen"
+msgstr "أو_صد الشاشة"
+
+#: panels/background/background.ui:268
+msgctxt "background, style"
+msgid "Tile"
+msgstr "مبلّطة"
+
+#: panels/background/background.ui:272
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "مُقرَّبة"
+
+#: panels/background/background.ui:276
+msgctxt "background, style"
+msgid "Center"
+msgstr "موسَّطة"
+
+#: panels/background/background.ui:280
+msgctxt "background, style"
+msgid "Scale"
+msgstr "محجّمة"
+
+#: panels/background/background.ui:284
+msgctxt "background, style"
+msgid "Fill"
+msgstr "مملوءة"
+
+#: panels/background/background.ui:288
+msgctxt "background, style"
+msgid "Span"
+msgstr "موسّعة"
+
+#: panels/background/cc-background-chooser-dialog.c:412
+msgid "Wallpapers"
+msgstr "خلفيات"
+
+#: panels/background/cc-background-chooser-dialog.c:423
+msgid "Colors"
+msgstr "ألوان"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: panels/background/cc-background-chooser-dialog.c:455
+msgid "Select Background"
+msgstr "اختر خلفية"
+
+#: panels/background/cc-background-chooser-dialog.c:484
+msgid "Pictures"
+msgstr "صور"
+
+#. translators: No pictures were found
+#: panels/background/cc-background-chooser-dialog.c:519
+msgid "No Pictures Found"
+msgstr "لم يُعثر على أي صور"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: panels/background/cc-background-chooser-dialog.c:546
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "يمكنك إضافة الصور إلى مجلد %s و ستظهر هنا"
+
+#: panels/background/cc-background-chooser-dialog.c:550
+#: panels/color/cc-color-panel.c:241 panels/color/cc-color-panel.c:894
+#: panels/color/cc-color-panel.ui:657 panels/color/color-calibrate.ui:25
+#: panels/common/cc-language-chooser.ui:24
+#: panels/display/cc-display-panel.c:877
+#: panels/network/connection-editor/connection-editor.ui:17
+#: panels/network/connection-editor/vpn-helpers.c:181
+#: panels/network/connection-editor/vpn-helpers.c:310
+#: panels/network/net-device-wifi.c:1200 panels/network/net-device-wifi.c:1280
+#: panels/network/net-device-wifi.c:1474 panels/network/network-wifi.ui:24
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:313
+#: panels/privacy/cc-privacy-panel.c:1137 panels/region/cc-format-chooser.ui:24
+#: panels/region/cc-input-chooser.ui:11
+#: panels/search/cc-search-locations-dialog.c:607
+#: panels/sharing/cc-sharing-panel.c:427
+#: panels/user-accounts/cc-add-user-dialog.ui:28
+#: panels/user-accounts/cc-avatar-chooser.c:106
+#: panels/user-accounts/cc-avatar-chooser.c:234
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:640
+#: panels/user-accounts/cc-user-panel.c:658
+#: panels/user-accounts/data/join-dialog.ui:20
+#: panels/user-accounts/um-fingerprint-dialog.c:261
+msgid "_Cancel"
+msgstr "أ_لغِ"
+
+#: panels/background/cc-background-chooser-dialog.c:551
+#: panels/common/cc-language-chooser.ui:12
+msgid "_Select"
+msgstr "ا_ختر"
+
+#: panels/background/cc-background-item.c:191
+msgid "multiple sizes"
+msgstr "مقاسات متعددة"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:195
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:320
+msgid "No Desktop Background"
+msgstr "لا خلفية لسطح المكتب"
+
+#: panels/background/cc-background-panel.c:291
+msgid "Current background"
+msgstr "الخلفية الحالية"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "الخلفية"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr "غيّر صورة الخلفية"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/background/gnome-background-panel.desktop.in.in:7
+msgid "preferences-desktop-wallpaper"
+msgstr "preferences-desktop-wallpaper"
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "خلفية;شاشة;سطح المكتب;"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:309
+msgid "No Bluetooth Found"
+msgstr "لم يعثر على بلوتوث"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:310
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "وصل جهاز بلوتوث خارجي لاستخدامه"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:313
+msgid "Bluetooth Turned Off"
+msgstr "بلوتوث مغلق"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:314
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "شغله للاتصال بالأجهزة و استقبال الملفات."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:317
+msgid "Airplane Mode is on"
+msgstr "وضع ال_طائرة مفعّل"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:318
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "بلوتوث معطّل لأن وضع الطائرة مفعّل."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:321
+msgid "Hardware Airplane Mode is on"
+msgstr "وضع الطائرة مفعّل من العتاد"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:322
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "عطّل وضع الطائرة لتفعيل بلوتوث."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:324
+msgid "Turn Off Airplane Mode"
+msgstr "أوقف وضع الطائرة"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/network/cc-network-panel.ui:101
+#: panels/printers/pp-new-printer-dialog.c:1697
+msgid "Bluetooth"
+msgstr "بلوتوث"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "شغّل أو أغلق بلوتوث لتوصيل جهازك بالأجهزة الأخرى"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:6
+msgid "bluetooth"
+msgstr "bluetooth"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;مشاركة;شارك;بلوتوث;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:348
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "ضع جهاز المعايرة على المربع ثم اضغط ”ابدأ“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:354
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "انقل جهاز المعايرة إلى موضع المعايرة ثم اضغط ”واصل“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:360
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "انقل جهاز المعايرة إلى موضع السطح ثم اضغط ”واصل“"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:366
+msgid "Shut the laptop lid"
+msgstr "أعلق غطاء الحاسوب"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:397
+msgid "An internal error occurred that could not be recovered."
+msgstr "حصل عطل داخلي تعذّر التعافي منه."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:402
+msgid "Tools required for calibration are not installed."
+msgstr "الأدوات المطلوبة للمعايرة غير مُثبّتة."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:408
+msgid "The profile could not be generated."
+msgstr "تعذّر توليد الإعدادات."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:414
+msgid "The target whitepoint was not obtainable."
+msgstr "لا يمكن الحصول على النقطة البيضاء المحددة"
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:453
+msgid "Complete!"
+msgstr "تم"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:461
+msgid "Calibration failed!"
+msgstr "فشلت المعايرة"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:468
+msgid "You can remove the calibration device."
+msgstr "يمكنك رفع جهاز المعايرة"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:537
+msgid "Do not disturb the calibration device while in progress"
+msgstr "لا تُقاطع جهاز المعايرة أثناء عمله"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "شاشة حاسوب محمول"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "كمرة وب مدمجة"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "شاشة %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "ماسحة %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "كمرة %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "طابعة %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "كمرة وب %s"
+
+#: panels/color/cc-color-device.c:91
+#, c-format
+msgid "Enable color management for %s"
+msgstr "فعّل إدارة ألوان %s"
+
+#: panels/color/cc-color-device.c:94
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "أظهر تشكيلات ألوان %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:303
+msgid "Not calibrated"
+msgstr "غير مُعايَر"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:170
+msgid "Default: "
+msgstr "المبدئي: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:178
+msgid "Colorspace: "
+msgstr "نطاق الألوان: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:185
+msgid "Test profile: "
+msgstr "ملف إعداد للاختبار: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:239
+msgid "Select ICC Profile File"
+msgstr "اختر ملف إعداد ICC"
+
+#: panels/color/cc-color-panel.c:242
+msgid "_Import"
+msgstr "ا_ستورد"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:253
+msgid "Supported ICC profiles"
+msgstr "تشكيلات ICC المدعومة"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:260
+#: panels/network/wireless-security/eap-method-fast.c:417
+msgid "All files"
+msgstr "كلّ الملفات"
+
+#: panels/color/cc-color-panel.c:555
+msgid "Screen"
+msgstr "شاشة"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:847
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "فشل رفع الملف: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:859
+msgid "The profile has been uploaded to:"
+msgstr "رُفع الإعداد إلى:"
+
+#: panels/color/cc-color-panel.c:861
+msgid "Write down this URL."
+msgstr "اكتب هذا المسار في ورقة."
+
+#: panels/color/cc-color-panel.c:862
+msgid "Restart this computer and boot your normal operating system."
+msgstr "أعد تشغيل الحاسوب و أقلع نظام التشغيل المعتاد."
+
+#: panels/color/cc-color-panel.c:863
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "اكتب المسار في المتصفح و نزّل الإعداد."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:891
+msgid "Save Profile"
+msgstr "احفظ الإعداد"
+
+#: panels/color/cc-color-panel.c:895
+#: panels/network/connection-editor/vpn-helpers.c:311
+msgid "_Save"
+msgstr "ا_حفظ"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1209
+msgid "Create a color profile for the selected device"
+msgstr "أنشئ إعداد لون للجهاز المختار"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1224 panels/color/cc-color-panel.c:1248
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "لم تُكتشف أداة القياس. رجاءً تأكد من تشغيلها وتوصيلها بشكل صحيح."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1258
+msgid "The measuring instrument does not support printer profiling."
+msgstr "أداة القياس لا تدعم تشكيل الطابعة."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1269
+msgid "The device type is not currently supported."
+msgstr "نوع الجهاز غير مدعوم حاليًا."
+
+#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:47
+msgid "Screen Calibration"
+msgstr "معايرة الشاشة"
+
+#: panels/color/cc-color-panel.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"ستنتج المعايرة إعدادات يمكنك استخدامها للتحكم في ألوان شاشتك. كلما قضيت وقتا "
+"أطول في المعايرة كلما كانت جودة الإعدادات الناتجة أفضل."
+
+#: panels/color/cc-color-panel.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "لم تستطيع استخدام حاسوبك أثناء المعايرة."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:58
+msgid "Quality"
+msgstr "الجودة"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:75
+msgid "Approximate Time"
+msgstr "الوقت التقريبي"
+
+#: panels/color/cc-color-panel.ui:121
+msgid "Calibration Quality"
+msgstr "جودة المعايرة"
+
+#: panels/color/cc-color-panel.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr "اختر الجهاز المستشعر الذي تريد استخدامه في المعايرة."
+
+#: panels/color/cc-color-panel.ui:174
+msgid "Calibration Device"
+msgstr "جهاز المعايرة"
+
+#: panels/color/cc-color-panel.ui:189
+msgid "Select the type of display that is connected."
+msgstr "اختر نوع جهاز العرض المُوصّل."
+
+#: panels/color/cc-color-panel.ui:226
+msgid "Display Type"
+msgstr "نوع جهاز العرض"
+
+#: panels/color/cc-color-panel.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:278
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:318
+msgid "Display Brightness"
+msgstr "سطوع جهاز العرض"
+
+#: panels/color/cc-color-panel.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"يمكنك استخدام تشكيلات ألوان مستقلة على الحواسيب المختلفة، أو حتى تشكيلات "
+"مستقلة لدرجات الإضاءة المختلفة."
+
+#: panels/color/cc-color-panel.ui:348
+msgid "Profile Name:"
+msgstr "اسم الإعداد:"
+
+#: panels/color/cc-color-panel.ui:377
+msgid "Profile Name"
+msgstr "اسم الإعداد"
+
+#: panels/color/cc-color-panel.ui:392
+msgid "Profile successfully created!"
+msgstr "تم إنشاء الإعداد"
+
+#: panels/color/cc-color-panel.ui:443
+msgid "Copy profile"
+msgstr "انسخ الإعداد"
+
+#: panels/color/cc-color-panel.ui:456
+msgid "Requires writable media"
+msgstr "يحتاج وسائط قابلة للكتابة"
+
+#: panels/color/cc-color-panel.ui:519
+msgid "Upload profile"
+msgstr "ارفع الإعداد"
+
+#: panels/color/cc-color-panel.ui:532
+msgid "Requires Internet connection"
+msgstr "يحتاج اتصالًا بالإنترنت"
+
+#: panels/color/cc-color-panel.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"قد ترغب بالاطلاع على تعليمات استخدام إعدادات الألوان على <a href=\"linux"
+"\">جنوم\\لينكس</a> و <a href=\"osx\">أبل ماك</a> و <a href=\"windows"
+"\">ميكروسوفت وندوز</a>."
+
+#: panels/color/cc-color-panel.ui:607
+#: panels/user-accounts/um-fingerprint-dialog.c:720
+msgid "Summary"
+msgstr "ملخّص"
+
+#: panels/color/cc-color-panel.ui:621
+msgid "Add Profile"
+msgstr "أضف إعدادًا"
+
+#: panels/color/cc-color-panel.ui:643
+msgid "_Import File…"
+msgstr "ا_ستورد ملفًا…"
+
+#: panels/color/cc-color-panel.ui:672
+#: panels/network/connection-editor/net-connection-editor.c:497
+#: panels/printers/new-printer-dialog.ui:80
+#: panels/region/cc-input-chooser.ui:20
+#: panels/user-accounts/cc-add-user-dialog.ui:47
+msgid "_Add"
+msgstr "أ_ضف"
+
+#: panels/color/cc-color-panel.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"وجدت مشاكل ولن يعمل ملف الإعداد كما يجب. <a href=\"\">أظهر التفاصيل.</a>"
+
+#: panels/color/cc-color-panel.ui:790
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "كل جهاز يحتاج إلى ملفات إعدادات ألوان مُحدّثة ليكون مُدار الألوان."
+
+#: panels/color/cc-color-panel.ui:812
+msgid "Learn more"
+msgstr "اعرف المزيد"
+
+#: panels/color/cc-color-panel.ui:817
+msgid "Learn more about color management"
+msgstr "اعرف المزيد عن إدارة الألوان"
+
+#: panels/color/cc-color-panel.ui:865
+msgid "_Set for all users"
+msgstr "ا_ضبط لجميع المستخدمين"
+
+#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
+#: panels/color/cc-color-panel.ui:885
+msgid "Set this profile for all users on this computer"
+msgstr "اضبط هذا الإعداد لكل المستخدمين على هذا الحاسوب"
+
+#: panels/color/cc-color-panel.ui:880
+msgid "_Enable"
+msgstr "_فعّل"
+
+#: panels/color/cc-color-panel.ui:911
+msgid "_Add profile"
+msgstr "أ_ضف إعدادًا"
+
+#: panels/color/cc-color-panel.ui:924
+msgid "_Calibrate…"
+msgstr "_عاير…"
+
+#: panels/color/cc-color-panel.ui:928
+msgid "Calibrate the device"
+msgstr "عاير الجهاز"
+
+#: panels/color/cc-color-panel.ui:939
+msgid "_Remove profile"
+msgstr "أزل الإع_داد"
+
+#: panels/color/cc-color-panel.ui:952
+msgid "_View details"
+msgstr "اعرض ال_تفاصيل"
+
+#: panels/color/cc-color-panel.ui:988
+msgid "Unable to detect any devices that can be color managed"
+msgstr "تعذّر اكتشاف الأجهزة التي يمكن التحكم بألوانها"
+
+#: panels/color/cc-color-panel.ui:1032
+msgid "LCD"
+msgstr "شاشة كريستال سائل"
+
+#: panels/color/cc-color-panel.ui:1037
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:1042
+msgid "CRT"
+msgstr "شاشة عادية"
+
+#: panels/color/cc-color-panel.ui:1047
+msgid "Projector"
+msgstr "جهاز عرض الشرائح"
+
+#: panels/color/cc-color-panel.ui:1052
+msgid "Plasma"
+msgstr "شاشة بلازما"
+
+#: panels/color/cc-color-panel.ui:1057
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1062
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1067
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1072
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1077
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1094
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "عالية"
+
+#: panels/color/cc-color-panel.ui:1095
+msgid "40 minutes"
+msgstr "40 دقيقة"
+
+#: panels/color/cc-color-panel.ui:1099
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "متوسطة"
+
+#: panels/color/cc-color-panel.ui:1100
+msgid "30 minutes"
+msgstr "30 دقيقة"
+
+#: panels/color/cc-color-panel.ui:1104
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "منخفضة"
+
+#: panels/color/cc-color-panel.ui:1105
+msgid "15 minutes"
+msgstr "15 دقيقة"
+
+#: panels/color/cc-color-panel.ui:1127
+msgid "Native to display"
+msgstr "الأصلي لجهاز العرض"
+
+#: panels/color/cc-color-panel.ui:1131
+msgid "D50 (Printing and publishing)"
+msgstr "‏D50 (الطباعة و النشر)"
+
+#: panels/color/cc-color-panel.ui:1135
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:1139
+msgid "D65 (Photography and graphics)"
+msgstr "‏D65 (التصوير و الرسوميات)"
+
+#: panels/color/cc-color-panel.ui:1143
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:100
+msgid "Standard Space"
+msgstr "النطاق المعياري"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:106
+msgid "Test Profile"
+msgstr "اختبر الإعداد"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:114
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "تلقائي"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:124
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "جودة منخفضة"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:129
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "جودة متوسطة"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:136
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "جودة عالية"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:153
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "ح‌خ‌ز المبدئي"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:160
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "زق‌ص‌س المبدئي"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:167
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "الرمادي المبدئي"
+
+#: panels/color/cc-color-profile.c:190
+msgid "Vendor supplied factory calibration data"
+msgstr "بيانات معايرة المصنع من منتج الجهاز"
+
+#: panels/color/cc-color-profile.c:199
+msgid "Full-screen display correction not possible with this profile"
+msgstr "تصحيح عرض ملء الشاشة غير ممكن مع هذا الإعداد"
+
+#: panels/color/cc-color-profile.c:221
+msgid "This profile may no longer be accurate"
+msgstr "هذا الإعداد ربما لم يعد دقيقا"
+
+#: panels/color/color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr "معايرة جهاز العرض"
+
+#. This starts the calibration process
+#: panels/color/color-calibrate.ui:40
+msgid "_Start"
+msgstr "اب_دأ"
+
+#. This resumes the calibration process
+#: panels/color/color-calibrate.ui:54
+msgid "_Resume"
+msgstr "اس_تئنف"
+
+#. This button returns the user back to the color control panel
+#: panels/color/color-calibrate.ui:67 panels/region/cc-format-chooser.ui:13
+msgid "_Done"
+msgstr "_تمّ"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "الألوان"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "عاير ألوان أجهزتك، مثل أجهزة العرض و الكمرات و الطابعات"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/color/gnome-color-panel.desktop.in.in:7
+msgid "preferences-color"
+msgstr "preferences-color"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "لون;ألوان;إعداد;تشكيل;معايرة;طابعة;شاشة;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "آخر…"
+
+#: panels/common/cc-language-chooser.c:125
+#: panels/region/cc-format-chooser.c:268 panels/region/cc-input-chooser.c:178
+msgid "More…"
+msgstr "المزيد…"
+
+#: panels/common/cc-language-chooser.c:142
+msgid "No languages found"
+msgstr "لا يوجد أي لغات"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "اختر لغة"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:106
+msgid "Today"
+msgstr "اليوم"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "Yesterday"
+msgstr "الأمس"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %B"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %B، %Y"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "نقطة بث"
+
+#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
+#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
+msgid "Day"
+msgstr "اليوم"
+
+#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
+#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
+msgid "Month"
+msgstr "الشهر"
+
+#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
+#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
+msgid "Year"
+msgstr "السنة"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:332
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y، %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:337
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y، %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:502
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s، %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:529
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:536
+msgid "UTC%:::z"
+msgstr "جرينتش%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:541
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:546
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:551
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:26
+msgid "January"
+msgstr "يناير"
+
+#: panels/datetime/cc-datetime-panel.ui:29
+msgid "February"
+msgstr "فبراير"
+
+#: panels/datetime/cc-datetime-panel.ui:32
+msgid "March"
+msgstr "مارس"
+
+#: panels/datetime/cc-datetime-panel.ui:35
+msgid "April"
+msgstr "أبريل"
+
+#: panels/datetime/cc-datetime-panel.ui:38
+msgid "May"
+msgstr "مايو"
+
+#: panels/datetime/cc-datetime-panel.ui:41
+msgid "June"
+msgstr "يونيو"
+
+#: panels/datetime/cc-datetime-panel.ui:44
+msgid "July"
+msgstr "يوليو"
+
+#: panels/datetime/cc-datetime-panel.ui:47
+msgid "August"
+msgstr "أغسطس"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "September"
+msgstr "سبتمبر"
+
+#: panels/datetime/cc-datetime-panel.ui:53
+msgid "October"
+msgstr "أكتوبر"
+
+#: panels/datetime/cc-datetime-panel.ui:56
+msgid "November"
+msgstr "نوفمبر"
+
+#: panels/datetime/cc-datetime-panel.ui:59
+msgid "December"
+msgstr "ديسمبر"
+
+#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "التاريخ والوقت"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#: panels/display/cc-night-light-dialog.ui:245
+#: panels/display/cc-night-light-dialog.ui:352
+msgid "Hour"
+msgstr "ساعة"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: panels/datetime/cc-datetime-panel.ui:128
+msgid "∶"
+msgstr ":"
+
+#: panels/datetime/cc-datetime-panel.ui:152
+#: panels/display/cc-night-light-dialog.ui:273
+#: panels/display/cc-night-light-dialog.ui:380
+msgid "Minute"
+msgstr "دقيقة"
+
+#: panels/datetime/cc-datetime-panel.ui:219
+msgid "Time Zone"
+msgstr "المنطقة الزمنية"
+
+#: panels/datetime/cc-datetime-panel.ui:240
+msgid "Search for a city"
+msgstr "ابحث عن مدينة"
+
+#: panels/datetime/cc-datetime-panel.ui:313
+msgid "Automatic _Date & Time"
+msgstr "_تاريخ و وقت تلقائييْن"
+
+#: panels/datetime/cc-datetime-panel.ui:314
+msgid "Requires internet access"
+msgstr "يتطلب اتصالًا بالإنترنت"
+
+#: panels/datetime/cc-datetime-panel.ui:334
+msgid "Automatic Time _Zone"
+msgstr "من_طقة زمنية تلقائية"
+
+#: panels/datetime/cc-datetime-panel.ui:335
+msgid "Requires location services enabled and internet access"
+msgstr "يتطلب تفعيل خدمات الموضع الجغرافي واتصالًا بالإنترنت"
+
+#: panels/datetime/cc-datetime-panel.ui:350
+msgid "Date & _Time"
+msgstr "التاريخ و الو_قت"
+
+#: panels/datetime/cc-datetime-panel.ui:366
+msgid "Time Z_one"
+msgstr "المن_طقة الزمنية"
+
+#: panels/datetime/cc-datetime-panel.ui:405
+msgid "Time _Format"
+msgstr "تن_سيق الوقت"
+
+#: panels/datetime/cc-datetime-panel.ui:414
+msgid "24-hour"
+msgstr "24-ساعة"
+
+#: panels/datetime/cc-datetime-panel.ui:415
+msgid "AM / PM"
+msgstr "ص \\ م"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "غيّر الوقت والتاريخ، بما فيها المنطقة الزمنية"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:7
+msgid "preferences-system-time"
+msgstr "preferences-system-time"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "ساعة;توقيت;منطقة زمنية;منطقة;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "غيّر إعدادات الوقت والتاريخ للنظام"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "لتغيير إعدادات الوقت والتاريخ، تحتاج للاستيثاق."
+
+#: panels/display/cc-display-panel.c:888
+#: panels/network/connection-editor/connection-editor.ui:27
+#: panels/network/network-wifi.ui:38
+msgid "_Apply"
+msgstr "_طبّق"
+
+#: panels/display/cc-display-panel.c:909
+msgid "Apply Changes?"
+msgstr "أتريد تطبيق التغييرات؟"
+
+#: panels/display/cc-display-panel.c:914
+msgid "Changes Cannot be Applied"
+msgstr "تعذّر تطبيق التغييرات"
+
+#: panels/display/cc-display-panel.c:915
+msgid "This could be due to hardware limitations."
+msgstr "قد يكون هذا بسبب قصور في العتاد."
+
+#. TRANSLATORS: the state of the night light setting
+#: panels/display/cc-display-panel.c:1088
+#: panels/notifications/cc-notifications-panel.c:270
+#: panels/power/cc-power-panel.c:2111 panels/power/cc-power-panel.c:2118
+#: panels/privacy/cc-privacy-panel.c:212 panels/privacy/cc-privacy-panel.c:289
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:841
+#: panels/universal-access/cc-ua-panel.c:854
+#: panels/universal-access/cc-ua-panel.c:866
+#: panels/universal-access/cc-ua-panel.c:1031
+msgid "On"
+msgstr "مفعّل"
+
+#: panels/display/cc-display-panel.c:1088 panels/network/net-proxy.c:54
+#: panels/notifications/cc-notifications-panel.c:270
+#: panels/power/cc-power-panel.c:2105 panels/power/cc-power-panel.c:2116
+#: panels/privacy/cc-privacy-panel.c:212 panels/privacy/cc-privacy-panel.c:289
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:841
+#: panels/universal-access/cc-ua-panel.c:854
+#: panels/universal-access/cc-ua-panel.c:866
+#: panels/universal-access/cc-ua-panel.c:1031
+#: panels/universal-access/cc-ua-panel.ui:338
+#: panels/universal-access/cc-ua-panel.ui:384
+#: panels/universal-access/cc-ua-panel.ui:430
+#: panels/universal-access/cc-ua-panel.ui:536
+#: panels/universal-access/cc-ua-panel.ui:689
+#: panels/universal-access/cc-ua-panel.ui:735
+#: panels/universal-access/cc-ua-panel.ui:781
+#: panels/universal-access/cc-ua-panel.ui:933
+msgid "Off"
+msgstr "معطّل"
+
+#: panels/display/cc-display-panel.ui:81
+msgid "Single Display"
+msgstr "شاشة مفردة"
+
+#: panels/display/cc-display-panel.ui:100
+#: panels/display/cc-display-panel.ui:305
+msgid "Join Displays"
+msgstr "ضم الشاشات"
+
+#: panels/display/cc-display-panel.ui:118
+msgid "Mirror"
+msgstr "طابق"
+
+#: panels/display/cc-display-panel.ui:143
+msgid "Display Mode"
+msgstr "نمط العرض"
+
+#: panels/display/cc-display-panel.ui:235
+msgid ""
+"Drag displays to match your physical display setup. Select a display to "
+"change its settings."
+msgstr "اسحب الشاشات لتطابق ترتيبها في الطبيعة. اختر الشاشة لتغيير إعداداتها."
+
+#: panels/display/cc-display-panel.ui:242
+msgid "Display Arrangement"
+msgstr "ترتيب الشاشات"
+
+#: panels/display/cc-display-panel.ui:424
+msgid "Display Configuration"
+msgstr "إعدادات الشاشة"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:451
+#: panels/display/cc-display-panel.ui:469
+#: panels/display/cc-night-light-dialog.ui:505
+msgid "Night Light"
+msgstr "الإضاءة الليلية"
+
+#: panels/display/cc-display-settings.c:108
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "عرضيّ"
+
+#: panels/display/cc-display-settings.c:111
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "طوليّ يمين"
+
+#: panels/display/cc-display-settings.c:114
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "طوليّ يسار"
+
+#: panels/display/cc-display-settings.c:117
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "عرضيّ (مقلوب)"
+
+#: panels/display/cc-display-settings.c:191
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf هرتز"
+
+#: panels/display/cc-display-settings.ui:15
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "الاتجاه"
+
+#: panels/display/cc-display-settings.ui:24
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "الميز"
+
+#: panels/display/cc-display-settings.ui:33
+msgid "Refresh Rate"
+msgstr "تردد التحديث"
+
+#: panels/display/cc-display-settings.ui:42
+msgid "Adjust for TV"
+msgstr "اضبط للتلفاز"
+
+#: panels/display/cc-display-settings.ui:59
+msgid "Scale"
+msgstr "المقياس"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-dialog.ui:46
+msgid "Restart Filter"
+msgstr "أعِد تشغيل المُرشّح"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-dialog.ui:79
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "عطّل مؤقتًا حتى الغد"
+
+#: panels/display/cc-night-light-dialog.ui:106
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"تجعل الإضاءة الليلية ألوان الشاشة أدفأ. يساعد هذا على تفادي إجهاد العين "
+"و الأرق."
+
+#: panels/display/cc-night-light-dialog.ui:127
+msgid "Schedule"
+msgstr "الجدول"
+
+#: panels/display/cc-night-light-dialog.ui:148
+msgid "Sunset to Sunrise"
+msgstr "من الغروب للشروق"
+
+#: panels/display/cc-night-light-dialog.ui:164
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:56 panels/network/network-proxy.ui:113
+#: panels/network/network-wifi.ui:776 panels/network/network-wifi.ui:1053
+#: panels/privacy/cc-privacy-panel.c:239
+msgid "Manual"
+msgstr "يدويًا"
+
+#: panels/display/cc-night-light-dialog.ui:180
+msgid "_Off"
+msgstr "مع_طّل"
+
+#: panels/display/cc-night-light-dialog.ui:216
+msgid "From"
+msgstr "من"
+
+#: panels/display/cc-night-light-dialog.ui:254
+#: panels/display/cc-night-light-dialog.ui:361
+msgid ":"
+msgstr ":"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-dialog.ui:284
+#: panels/display/cc-night-light-dialog.ui:391
+msgid "AM"
+msgstr "ص"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-dialog.ui:300
+#: panels/display/cc-night-light-dialog.ui:407
+msgid "PM"
+msgstr "م"
+
+#: panels/display/cc-night-light-dialog.ui:449
+msgid "To"
+msgstr "إلى"
+
+#: panels/display/cc-night-light-dialog.ui:470
+msgid "Color Temperature"
+msgstr "حرارة اللون"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "الشاشات"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "اختر كيف تستخدم الشاشات و أجهزة عرض الشرائح"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/display/gnome-display-panel.desktop.in.in:7
+msgid "preferences-desktop-display"
+msgstr "preferences-desktop-display"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "لوحة;عرض;شاشة;ميز;ليل;إضاءة;شروق;غروب;لون;"
+
+#: panels/info/cc-info-default-apps-panel.ui:31
+msgid "_Web"
+msgstr "ال_وب"
+
+#: panels/info/cc-info-default-apps-panel.ui:43
+msgid "_Mail"
+msgstr "ال_بريد"
+
+#: panels/info/cc-info-default-apps-panel.ui:59
+msgid "_Calendar"
+msgstr "الت_قويم"
+
+#: panels/info/cc-info-default-apps-panel.ui:75
+msgid "M_usic"
+msgstr "ال_صوتيات"
+
+#: panels/info/cc-info-default-apps-panel.ui:91
+msgid "_Video"
+msgstr "ال_فيديو"
+
+#: panels/info/cc-info-default-apps-panel.ui:162
+#: panels/info/cc-info-removable-media-panel.ui:161
+msgid "_Photos"
+msgstr "ال_صور"
+
+#. TRANSLATORS: AP type
+#: panels/info/cc-info-overview-panel.c:369
+#: panels/info/cc-info-overview-panel.c:452
+#: panels/info/cc-info-overview-panel.c:497
+#: panels/info/cc-info-overview-panel.c:527 panels/network/panel-common.c:123
+msgid "Unknown"
+msgstr "غير معروف"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info/cc-info-overview-panel.c:460
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s؛ معرف البناء: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info/cc-info-overview-panel.c:477
+#, c-format
+msgid "64-bit"
+msgstr "٦٤ بتة"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info/cc-info-overview-panel.c:480
+#, c-format
+msgid "32-bit"
+msgstr "٣٢ بتة"
+
+#: panels/info/cc-info-overview-panel.c:710
+#, c-format
+msgid "Version %s"
+msgstr "الإصدارة %s"
+
+#: panels/info/cc-info-overview-panel.ui:70
+msgid "Device name"
+msgstr "اسم الجهاز"
+
+#: panels/info/cc-info-overview-panel.ui:86
+msgid "Memory"
+msgstr "الذاكرة"
+
+#: panels/info/cc-info-overview-panel.ui:102
+msgid "Processor"
+msgstr "المعالج"
+
+#: panels/info/cc-info-overview-panel.ui:118
+msgid "Graphics"
+msgstr "الرسوميات"
+
+#. To translators: this field contains the distro name and version
+#: panels/info/cc-info-overview-panel.ui:133
+msgid "OS name"
+msgstr "اسم نظام التشغيل"
+
+#. To translators: this field contains the distro type
+#: panels/info/cc-info-overview-panel.ui:149
+msgid "OS type"
+msgstr "نوع نظام التشغيل"
+
+#: panels/info/cc-info-overview-panel.ui:165
+msgid "Virtualization"
+msgstr "المحاكاة"
+
+#: panels/info/cc-info-overview-panel.ui:181
+msgid "Disk"
+msgstr "القرص"
+
+#: panels/info/cc-info-overview-panel.ui:293
+msgid "Calculating…"
+msgstr "يحسب…"
+
+#: panels/info/cc-info-overview-panel.ui:333
+msgid "Check for updates"
+msgstr "التمس التحديثات"
+
+#: panels/info/cc-info-removable-media-panel.c:296
+msgid "Ask what to do"
+msgstr "اسأل ما الذي يجب فعله"
+
+#: panels/info/cc-info-removable-media-panel.c:300
+msgid "Do nothing"
+msgstr "لا تفعل شيئا"
+
+#: panels/info/cc-info-removable-media-panel.c:304
+msgid "Open folder"
+msgstr "افتح المجلّد"
+
+#: panels/info/cc-info-removable-media-panel.c:389
+msgid "Other Media"
+msgstr "وسائط أخرى"
+
+#: panels/info/cc-info-removable-media-panel.c:422
+msgid "Select an application for audio CDs"
+msgstr "اختر تطبيقا لاسطوانات الصوت"
+
+#: panels/info/cc-info-removable-media-panel.c:423
+msgid "Select an application for video DVDs"
+msgstr "اختر تطبيقا لاسطوانات الفديو"
+
+#: panels/info/cc-info-removable-media-panel.c:424
+msgid "Select an application to run when a music player is connected"
+msgstr "اختر تطبيقا لتشغيله عند توصيل مشغّل موسيقى"
+
+#: panels/info/cc-info-removable-media-panel.c:425
+msgid "Select an application to run when a camera is connected"
+msgstr "اختر تطبيقا لتشغيله عند توصيل كمرة"
+
+#: panels/info/cc-info-removable-media-panel.c:426
+msgid "Select an application for software CDs"
+msgstr "اختر تطبيقا لاسطوانات البرامج"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/info/cc-info-removable-media-panel.c:438
+msgid "audio DVD"
+msgstr "دي‌ڤي‌دي صوتي"
+
+#: panels/info/cc-info-removable-media-panel.c:439
+msgid "blank Blu-ray disc"
+msgstr "قرص Blu-Ray فارغ"
+
+#: panels/info/cc-info-removable-media-panel.c:440
+msgid "blank CD disc"
+msgstr "اسطوانة فارغة"
+
+#: panels/info/cc-info-removable-media-panel.c:441
+msgid "blank DVD disc"
+msgstr "قرص دي‌ڤي‌دي فارغ"
+
+#: panels/info/cc-info-removable-media-panel.c:442
+msgid "blank HD DVD disc"
+msgstr "قرص دي‌ڤي‌دي إتش‌دي فارغ"
+
+#: panels/info/cc-info-removable-media-panel.c:443
+msgid "Blu-ray video disc"
+msgstr "قرص Blu-Ray فديو فارغ"
+
+#: panels/info/cc-info-removable-media-panel.c:444
+msgid "e-book reader"
+msgstr "قارئ كتب إلكتروني"
+
+#: panels/info/cc-info-removable-media-panel.c:445
+msgid "HD DVD video disc"
+msgstr "قرص دي‌ڤي‌دي إتش‌دي فديو فارغ"
+
+#: panels/info/cc-info-removable-media-panel.c:446
+msgid "Picture CD"
+msgstr "اسطوانة صور"
+
+#: panels/info/cc-info-removable-media-panel.c:447
+msgid "Super Video CD"
+msgstr "اسطوانة فديو فائقة"
+
+#: panels/info/cc-info-removable-media-panel.c:448
+msgid "Video CD"
+msgstr "اسطوانة فديو"
+
+#: panels/info/cc-info-removable-media-panel.c:449
+msgid "Windows software"
+msgstr "برمجيات وندوز"
+
+#: panels/info/cc-info-removable-media-panel.ui:43
+msgid "Select how media should be handled"
+msgstr "اختر كيفية التعامل مع الوسائط"
+
+#: panels/info/cc-info-removable-media-panel.ui:74
+msgid "CD _audio"
+msgstr "قرص _صوتي"
+
+#: panels/info/cc-info-removable-media-panel.ui:91
+msgid "_DVD video"
+msgstr "_دي‌ڤي‌دي فيديو"
+
+#: panels/info/cc-info-removable-media-panel.ui:132
+msgid "_Music player"
+msgstr "مشغّل _موسيقى"
+
+#: panels/info/cc-info-removable-media-panel.ui:190
+msgid "_Software"
+msgstr "بر_مجيات"
+
+#: panels/info/cc-info-removable-media-panel.ui:228
+msgid "_Other Media…"
+msgstr "و_سائط أخرى…"
+
+#: panels/info/cc-info-removable-media-panel.ui:272
+msgid "_Never prompt or start programs on media insertion"
+msgstr "لا _تسأل أو تبدأ البرامج عند إدخال الوسائط"
+
+#: panels/info/cc-info-removable-media-panel.ui:331
+msgid "Select how other media should be handled"
+msgstr "اختر كيفية التعامل مع الوسائط الأخرى"
+
+#: panels/info/cc-info-removable-media-panel.ui:370
+msgid "_Action:"
+msgstr "الإ_جراء:"
+
+#: panels/info/cc-info-removable-media-panel.ui:393
+msgid "_Type:"
+msgstr "ال_نوع:"
+
+#: panels/info/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "التطبيقات المبدئية"
+
+#: panels/info/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "اضبط التطبيقات المبدئية"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info/gnome-default-apps-panel.desktop.in.in:7
+msgid "starred"
+msgstr "starred"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/info/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "مبدئي;تطبيق;مفضل;وسائط;"
+
+#: panels/info/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "عنْ"
+
+#: panels/info/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "اعرض معلومات عن نظامك"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info/gnome-info-overview-panel.desktop.in.in:7
+msgid "help-about"
+msgstr "help-about"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"جهاز;نظام;معلومات;ذاكرة;معالج;إصدارة;تطبيق;مبدئي;مفضل;قرص مضغوط;دي في دي;يو "
+"اس بي;صوت;فيديو;قرص;قابل للفصل;وسائط;تشغيل تلقائي;"
+
+#: panels/info/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "الوسائط المنفصلة"
+
+#: panels/info/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "اضبط إعدادات الوسائط المنفصلة"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info/gnome-removable-media-panel.desktop.in.in:7
+msgid "media-removable"
+msgstr "media-removable"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/info/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"جهاز;نظام;تطبيق;مبدئي;مفضل;قرص مضغوط;دي في دي;يو اس بي;صوت;فيديو;قرص;قابل "
+"للفصل;وسائط;تشغيل تلقائي;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "الصوت والوسائط"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute"
+msgstr "أصمِت الصوت"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "اخفض الصوت"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "ارفع الصوت"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Launch media player"
+msgstr "ابدأ مشغل الوسائط"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Play (or play/pause)"
+msgstr "شغّل (أو شغّل\\ألبِث)"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Pause playback"
+msgstr "ألبِث التشغيل"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Stop playback"
+msgstr "أوقف التشغيل"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Previous track"
+msgstr "المقطوعة السابقة"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Next track"
+msgstr "المقطوعة التالية"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Eject"
+msgstr "أخرِج"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:580
+msgid "Typing"
+msgstr "الكتابة"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "تحول إلى مصدر الإدخال التالي"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "تحول إلى مصدر الإدخال السابق"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "مشغلات التطبيقات"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "شغّل متصفّح المساعدة"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "شغّل الحاسبة"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "شغّل عميل البريد الإلكتروني"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "شغّل متصفّح الوِب"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "مجلّد المنزل"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ابحث"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "لقطات الشاشة"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr "احفظ لقطة شاشة في مجلد $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "احفظ لقطة شاشة لنافذة في مجلد $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "احفظ لقطة شاشة لمنطقة في مجلد $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "انسخ اللقطة إلى الحافظة"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "انسخ لقطة النافذة إلى الحافظة"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "انسخ لقطة المنطقة المحددة إلى الحافظة"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr "سجّل تسجيل شاشة قصير"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "النظام"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "اخرج"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "أوصد الشاشة"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Universal Access"
+msgstr "الإتاحة"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "شغِّل أو عطِّل التقريب"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "قرّب"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "بعّد"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "شغِّل أو عطِّل قارئ الشاشة"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "شغّل أو عطّل لوحة المفاتيح على الشاشة"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "كبّر النص"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "صغّر النص"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "شغّل أو عطّل التباين العال"
+
+#: panels/keyboard/cc-keyboard-manager.c:501
+#: panels/keyboard/cc-keyboard-manager.c:509
+#: panels/keyboard/cc-keyboard-manager.c:809
+msgid "Custom Shortcuts"
+msgstr "اختصارات مخصصة"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: panels/keyboard/cc-keyboard-option.c:337
+msgid "Alternative Characters Key"
+msgstr "مفتاح الحروف البديلة"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: panels/keyboard/cc-keyboard-option.c:346
+msgid "Compose Key"
+msgstr "مفتاح التركيب"
+
+#: panels/keyboard/cc-keyboard-option.c:351
+#, fuzzy
+msgid "Modifiers-only switch to next source"
+msgstr "تحول إلى المصدر التالي"
+
+#: panels/keyboard/cc-keyboard-panel.c:179
+msgid "Reset All Shortcuts?"
+msgstr "أتريد تصفير كل الاختصارات؟"
+
+#: panels/keyboard/cc-keyboard-panel.c:182
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"تصفير الاختصارات قد يؤثر على اختصاراتك المخصوصة. لا يمكن التراجع عن هذا."
+
+#: panels/keyboard/cc-keyboard-panel.c:186
+#: panels/keyboard/shortcut-editor.ui:346
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+msgid "Cancel"
+msgstr "ألغِ"
+
+#: panels/keyboard/cc-keyboard-panel.c:187
+msgid "Reset All"
+msgstr "صفّر الكل"
+
+#: panels/keyboard/cc-keyboard-panel.c:283
+msgid "Reset the shortcut to its default value"
+msgstr "أعِد الاختصار إلى قيمته المبدئية"
+
+#: panels/keyboard/cc-keyboard-panel.ui:67 panels/region/cc-region-panel.ui:395
+#: shell/cc-window.ui:279
+msgid "Keyboard Shortcuts"
+msgstr "اختصارات لوحة المفاتيح"
+
+#: panels/keyboard/cc-keyboard-panel.ui:77
+msgid "Reset All…"
+msgstr "صفّر الكل…"
+
+#: panels/keyboard/cc-keyboard-panel.ui:78
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "أعِد كل الاختصارات إلى قيمها المبدئية"
+
+#: panels/keyboard/cc-keyboard-panel.ui:164
+msgid "No keyboard shortcut found"
+msgstr "لم يُعثر على أي اختصارات للوحة المفاتيح"
+
+#: panels/keyboard/cc-keyboard-panel.ui:175 shell/cc-panel-list.ui:206
+msgid "Try a different search"
+msgstr "جرب بحثًا آخر"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:411
+#, c-format
+msgid ""
+"%s is already being used for <b>%s</b>. If you replace it, %s will be "
+"disabled"
+msgstr "الاختصار %s مستخدم حاليا من أجل <b>%s</b>. إذا استبدلته، فيُعطّل %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+msgid "Set Custom Shortcut"
+msgstr "حدد اختصارًا مخصصًا"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+msgid "Set Shortcut"
+msgstr "حدد اختصارًا"
+
+#. Setup the top label
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:590
+#, c-format
+msgid "Enter new shortcut to change <b>%s</b>."
+msgstr "أدخل اختصارًا جديدًا لتغيير <b>%s</b>."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:1017
+msgid "Add Custom Shortcut"
+msgstr "أضف اختصارًا مخصصًا"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "لوحة المفاتيح"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "اعرض و غيّر اختصارات لوحة المفاتيح و اضبط خيارات الكتابة"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:7
+msgid "input-keyboard"
+msgstr "input-keyboard"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr "اختصار;منطقة عمل;نافذة;تحجيم;تقريب;تباين;إدخال;مصدر;قفل;"
+
+#: panels/keyboard/shortcut-editor.ui:68 panels/keyboard/shortcut-editor.ui:318
+msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
+msgstr "اضغط Esc أو إلغاء أو Backspace لإعادة اختصار لوحة المفاتيح لأصله."
+
+#: panels/keyboard/shortcut-editor.ui:156 panels/printers/details-dialog.ui:38
+msgid "Name"
+msgstr "الاسم"
+
+#: panels/keyboard/shortcut-editor.ui:168
+msgid "Command"
+msgstr "الأمر"
+
+#: panels/keyboard/shortcut-editor.ui:180
+msgid "Shortcut"
+msgstr "الاختصار"
+
+#: panels/keyboard/shortcut-editor.ui:259
+msgid "Set Shortcut…"
+msgstr "حدد اختصارًا…"
+
+#: panels/keyboard/shortcut-editor.ui:272 panels/network/network-wifi.ui:593
+msgid "None"
+msgstr "لا شيء"
+
+#: panels/keyboard/shortcut-editor.ui:303
+msgid "Enter the new shortcut"
+msgstr "أدخِل اختصارًا جديدًا"
+
+#: panels/keyboard/shortcut-editor.ui:357
+msgid "Remove"
+msgstr "أزل"
+
+#: panels/keyboard/shortcut-editor.ui:367
+msgid "Add"
+msgstr "أضف"
+
+#: panels/keyboard/shortcut-editor.ui:382
+msgid "Replace"
+msgstr "استبدل"
+
+#: panels/keyboard/shortcut-editor.ui:395
+msgid "Set"
+msgstr "حدد"
+
+#: panels/mouse/cc-mouse-panel.c:80 panels/wacom/cc-wacom-panel.c:463
+msgid "Test Your _Settings"
+msgstr "اختبر إ_عداداتك"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "الفأرة و لوحة اللمس"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "غيّر حساسية الشاشة و لوح اللمس و اختر اليد اليمنى أم اليسرى"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:7
+msgid "input-mouse"
+msgstr "input-mouse"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "فأرة;مؤشر;نقر;مزدوج;زر;لمس;"
+
+#: panels/mouse/gnome-mouse-properties.ui:50
+msgid "General"
+msgstr "عام"
+
+#: panels/mouse/gnome-mouse-properties.ui:88
+msgid "Primary Button"
+msgstr "الزر الأساسي"
+
+#: panels/mouse/gnome-mouse-properties.ui:107
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "حدد ترتيب الأزرار على الفأرة و لوحة اللمس."
+
+#: panels/mouse/gnome-mouse-properties.ui:136
+#: panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "يسار"
+
+#: panels/mouse/gnome-mouse-properties.ui:146
+#: panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "يمين"
+
+#: panels/mouse/gnome-mouse-properties.ui:182
+msgid "Mouse"
+msgstr "الفأرة"
+
+#: panels/mouse/gnome-mouse-properties.ui:221
+msgid "Mouse Speed"
+msgstr "سرعة الفأرة"
+
+#: panels/mouse/gnome-mouse-properties.ui:243
+#: panels/mouse/gnome-mouse-properties.ui:535
+msgid "Double-click timeout"
+msgstr "مهلة النقر المزدوج"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/gnome-mouse-properties.ui:280
+#: panels/mouse/gnome-mouse-properties.ui:443
+msgid "Natural Scrolling"
+msgstr "تمرير طبيعي"
+
+#: panels/mouse/gnome-mouse-properties.ui:296
+#: panels/mouse/gnome-mouse-properties.ui:459
+msgid "Scrolling moves the content, not the view."
+msgstr "التمرير يحرك المحتوى و ليس المنظور."
+
+#: panels/mouse/gnome-mouse-properties.ui:346
+#: panels/mouse/gnome-mouse-properties.ui:391
+msgid "Touchpad"
+msgstr "لوحة اللمس"
+
+#: panels/mouse/gnome-mouse-properties.ui:514
+msgid "Touchpad Speed"
+msgstr "سرعة لوحة اللمس"
+
+#: panels/mouse/gnome-mouse-properties.ui:573
+msgid "Tap to Click"
+msgstr "النقر بالإصبع"
+
+#: panels/mouse/gnome-mouse-properties.ui:625
+msgid "Two-finger Scrolling"
+msgstr "اللف بأصبعين"
+
+#: panels/mouse/gnome-mouse-properties.ui:678
+msgid "Edge Scrolling"
+msgstr "التمرير عند الحافة"
+
+#: panels/mouse/gnome-mouse-test.c:132 panels/mouse/gnome-mouse-test.ui:25
+msgid "Try clicking, double clicking, scrolling"
+msgstr "جرب النقر والنقر المزدوج والتمرير"
+
+#: panels/mouse/gnome-mouse-test.c:137
+msgid "Five clicks, GEGL time!"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-test.c:142
+msgid "Double click, primary button"
+msgstr "نقرة مزدوجة، الزر الأساسي"
+
+#: panels/mouse/gnome-mouse-test.c:142
+msgid "Single click, primary button"
+msgstr "نقرة مفردة، الزر الأساسي"
+
+#: panels/mouse/gnome-mouse-test.c:145
+msgid "Double click, middle button"
+msgstr "نقرة مزدوجة، الزر الأوسط"
+
+#: panels/mouse/gnome-mouse-test.c:145
+msgid "Single click, middle button"
+msgstr "نقرة مفردة، الزر الأوسط"
+
+#: panels/mouse/gnome-mouse-test.c:148
+msgid "Double click, secondary button"
+msgstr "نقرة مزدوجة، الزر الثانوي"
+
+#: panels/mouse/gnome-mouse-test.c:148
+msgid "Single click, secondary button"
+msgstr "نقرة مفردة، الزر الثانوي"
+
+#. add proxy to device list
+#: panels/network/cc-network-panel.c:583
+msgid "Network proxy"
+msgstr "وسيط الشبكة"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/cc-network-panel.c:719 panels/network/net-vpn.c:167
+#: panels/network/net-vpn.c:295
+#, c-format
+msgid "%s VPN"
+msgstr "‏VPN %s"
+
+#: panels/network/cc-network-panel.c:783 panels/network/cc-wifi-panel.ui:304
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "نأسف، حدث عطل ما. من فضلك اتصل بالدعم الفني."
+
+#: panels/network/cc-network-panel.c:789
+msgid "NetworkManager needs to be running."
+msgstr "يجب أن يكون NetworkManager شغّالًا."
+
+#: panels/network/cc-network-panel.ui:142
+#: panels/network/connection-editor/net-connection-editor.c:581
+msgid "VPN"
+msgstr "‏VPN"
+
+#: panels/network/cc-network-panel.ui:194
+msgid "Not set up"
+msgstr "غير مُعَد"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:189
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.ui:36
+msgid "Connection/SSID"
+msgstr "الاتصال/SSID"
+
+#: panels/network/cc-wifi-connection-row.ui:73
+#: panels/network/net-device-ethernet.c:359
+#: panels/network/network-ethernet.ui:120 panels/network/network-mobile.ui:394
+#: panels/network/network-simple.ui:75 panels/network/network-vpn.ui:79
+msgid "Options…"
+msgstr "الخيارات…"
+
+#: panels/network/cc-wifi-panel.c:281
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:1738
+msgid "Wi-Fi"
+msgstr "واي فاي"
+
+#: panels/network/cc-wifi-panel.ui:56
+msgid "Airplane Mode"
+msgstr "وضع الطائرة"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "يعطل واي فاي و بلوتوث و إنترنت المحمول"
+
+#: panels/network/cc-wifi-panel.ui:141
+msgid "No Wi-Fi Adapter Found"
+msgstr "لم يُعثر على محوّل واي فاي"
+
+#: panels/network/cc-wifi-panel.ui:153
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "تأكد من أن محوّل واي فاي متصل و يعمل"
+
+#: panels/network/cc-wifi-panel.ui:188
+msgid "Airplane Mode On"
+msgstr "وضع الطائرة مُفعّل"
+
+#: panels/network/cc-wifi-panel.ui:200
+msgid "Turn off to use Wi-Fi"
+msgstr "عطله لاستخدام واي فاي"
+
+#: panels/network/cc-wifi-panel.ui:226
+msgid "Visible Networks"
+msgstr "الشبكات المرئية"
+
+#: panels/network/cc-wifi-panel.ui:293
+msgid "NetworkManager needs to be running"
+msgstr "يجب أن يكون NetworkManager شغّالًا"
+
+#: panels/network/connection-editor/8021x-security-page.ui:26
+msgid "802.1x _Security"
+msgstr "أ_من 802.1x"
+
+#: panels/network/connection-editor/8021x-security-page.ui:73
+#: panels/network/connection-editor/security-page.ui:72
+msgid "page 1"
+msgstr "صفحة 1"
+
+#: panels/network/connection-editor/8021x-security-page.ui:224
+#: panels/network/connection-editor/security-page.ui:223
+#: panels/network/wireless-security/eap-method-fast.ui:50
+#: panels/network/wireless-security/eap-method-peap.ui:48
+#: panels/network/wireless-security/eap-method-ttls.ui:31
+msgid "Anony_mous identity"
+msgstr "_هوية مجهولة"
+
+#: panels/network/connection-editor/8021x-security-page.ui:238
+#: panels/network/connection-editor/security-page.ui:237
+msgid "Inner _authentication"
+msgstr "الاستيثاق ال_داخلي"
+
+#: panels/network/connection-editor/8021x-security-page.ui:281
+#: panels/network/connection-editor/security-page.ui:280
+msgid "page 2"
+msgstr "صفحة 2"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:101
+#: panels/network/connection-editor/ce-page-security.c:445
+#: panels/network/connection-editor/details-page.ui:86
+#: panels/network/network-wifi.ui:239
+msgid "Security"
+msgstr "الأمن"
+
+#: panels/network/connection-editor/ce-page.c:481
+msgid "automatic"
+msgstr "تلقائي"
+
+#: panels/network/connection-editor/ce-page.c:521
+#, c-format
+msgid "Profile %d"
+msgstr "إعداد %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:56
+#: panels/network/net-device-wifi.c:123 panels/network/net-device-wifi.c:299
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:60
+#: panels/network/net-device-wifi.c:127 panels/network/net-device-wifi.c:304
+#: panels/network/network-wifi.ui:592
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:64
+#: panels/network/net-device-wifi.c:131
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:69
+#: panels/network/net-device-wifi.c:136
+msgid "Enterprise"
+msgstr "مؤسسة"
+
+#: panels/network/connection-editor/ce-page-details.c:74
+#: panels/network/net-device-wifi.c:141 panels/network/net-device-wifi.c:289
+msgctxt "Wifi security"
+msgid "None"
+msgstr "بدون"
+
+#: panels/network/connection-editor/ce-page-details.c:95
+msgid "Never"
+msgstr "أبدًا"
+
+#: panels/network/connection-editor/ce-page-details.c:110
+#: panels/network/net-device-ethernet.c:137
+#: panels/network/net-device-wifi.c:398
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "منذ أقل من يوم"
+msgstr[1] "منذ يوم واحد"
+msgstr[2] "منذ يومين"
+msgstr[3] "منذ %i أيام"
+msgstr[4] "منذ %i يوما"
+msgstr[5] "منذ %i يوم"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:228
+#: panels/network/net-device-ethernet.c:66 panels/network/net-device-wifi.c:476
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d م.بايت\\ث"
+
+#: panels/network/connection-editor/ce-page-details.c:249
+#: panels/network/net-device-wifi.c:505
+msgctxt "Signal strength"
+msgid "None"
+msgstr "لا إشارة"
+
+#: panels/network/connection-editor/ce-page-details.c:251
+#: panels/network/net-device-wifi.c:507
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "ضعيفة"
+
+#: panels/network/connection-editor/ce-page-details.c:253
+#: panels/network/net-device-wifi.c:509
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "معقولة"
+
+#: panels/network/connection-editor/ce-page-details.c:255
+#: panels/network/net-device-wifi.c:511
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "جيّدة"
+
+#: panels/network/connection-editor/ce-page-details.c:257
+#: panels/network/net-device-wifi.c:513
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "ممتازة"
+
+#: panels/network/connection-editor/ce-page-details.c:300
+msgid "Forget Connection"
+msgstr " انس الاتصال"
+
+#: panels/network/connection-editor/ce-page-details.c:302
+msgid "Remove Connection Profile"
+msgstr "أزل إعدادات الاتصال"
+
+#: panels/network/connection-editor/ce-page-details.c:304
+msgid "Remove VPN"
+msgstr "أزل VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:332
+#: panels/network/network-wifi.ui:1433 shell/cc-panel-list.ui:103
+#: shell/cc-window.c:247
+msgid "Details"
+msgstr "تفاصيل"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:174
+#: panels/network/connection-editor/ce-page-vpn.c:188
+#: panels/network/connection-editor/ce-page-wifi.c:194
+#: panels/network/network-wifi.ui:1437
+msgid "Identity"
+msgstr "الهوية"
+
+#: panels/network/connection-editor/ce-page-ip4.c:251
+#: panels/network/connection-editor/ce-page-ip6.c:230
+msgid "Delete Address"
+msgstr "احذف العنوان"
+
+#: panels/network/connection-editor/ce-page-ip4.c:422
+#: panels/network/connection-editor/ce-page-ip6.c:390
+msgid "Delete Route"
+msgstr "احذق السبيل"
+
+#: panels/network/connection-editor/ce-page-ip4.c:896
+#: panels/network/network-wifi.ui:1441
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:828
+#: panels/network/network-wifi.ui:1445
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:245
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "لا شيء"
+
+#: panels/network/connection-editor/ce-page-security.c:268
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:278
+msgid "WEP 128-bit Passphrase"
+msgstr "عبارة سر WEP‏ 128-بتة"
+
+#: panels/network/connection-editor/ce-page-security.c:291
+#: panels/network/wireless-security/wireless-security.c:465
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:304
+msgid "Dynamic WEP (802.1x)"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:318
+msgid "WPA & WPA2 Personal"
+msgstr "‏WPA و WPA2 شخصي"
+
+#: panels/network/connection-editor/ce-page-security.c:332
+msgid "WPA & WPA2 Enterprise"
+msgstr "‏WPA و WPA2 للمؤسسات"
+
+#: panels/network/connection-editor/details-page.ui:18
+#: panels/network/network-wifi.ui:174
+msgid "Signal Strength"
+msgstr "قوّة الإشارة"
+
+#: panels/network/connection-editor/details-page.ui:52
+#: panels/network/network-wifi.ui:207
+msgid "Link speed"
+msgstr "سرعة الوصلة"
+
+#: panels/network/connection-editor/details-page.ui:104
+#: panels/network/net-device-ethernet.c:170 panels/network/network-wifi.ui:256
+#: panels/network/panel-common.c:644
+msgid "IPv4 Address"
+msgstr "عنوان IPv4"
+
+#: panels/network/connection-editor/details-page.ui:122
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-ethernet.c:175
+#: panels/network/network-mobile.ui:189 panels/network/network-wifi.ui:273
+#: panels/network/panel-common.c:645
+msgid "IPv6 Address"
+msgstr "عنوان IPv6"
+
+#: panels/network/connection-editor/details-page.ui:140
+#: panels/network/net-device-ethernet.c:178 panels/network/network-wifi.ui:290
+msgid "Hardware Address"
+msgstr "عنوان العتاد"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:182
+#: panels/network/network-mobile.ui:206 panels/network/network-wifi.ui:307
+msgid "Default Route"
+msgstr "السبيل المبدئي"
+
+#: panels/network/connection-editor/details-page.ui:177
+#: panels/network/connection-editor/ip4-page.ui:197
+#: panels/network/connection-editor/ip6-page.ui:211
+#: panels/network/net-device-ethernet.c:184
+#: panels/network/network-mobile.ui:224 panels/network/network-wifi.ui:325
+#: panels/network/network-wifi.ui:831 panels/network/network-wifi.ui:1108
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:195
+msgid "Last Used"
+msgstr "آخر استخدام"
+
+#: panels/network/connection-editor/details-page.ui:324
+msgid "Connect _automatically"
+msgstr "اتصل _تلقائيا"
+
+#: panels/network/connection-editor/details-page.ui:343
+msgid "Make available to _other users"
+msgstr "اجعله م_تاحا للمستخدمين الآخرين"
+
+#: panels/network/connection-editor/details-page.ui:376
+msgid "Restrict background data usage"
+msgstr "قلل استخدام البيانات في الخلفية"
+
+#: panels/network/connection-editor/details-page.ui:386
+msgid "Appropriate for connections that have data charges or limits."
+msgstr "مناسب للاتصالات التي تحاسب على الاستهلاك أو لها تعليق."
+
+#: panels/network/connection-editor/ethernet-page.ui:16
+#: panels/network/connection-editor/ethernet-page.ui:39
+#: panels/network/connection-editor/ip4-page.ui:209
+#: panels/network/connection-editor/ip4-page.ui:277
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:291
+#: panels/network/net-proxy.c:58 panels/network/network-proxy.ui:103
+#: panels/network/wireless-security/eap-method-peap.ui:22
+#: panels/privacy/cc-privacy-panel.c:239
+msgid "Automatic"
+msgstr "تلقائي"
+
+#: panels/network/connection-editor/ethernet-page.ui:19
+msgid "Twisted Pair (TP)"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:22
+msgid "Attachment Unit Interface (AUI)"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+msgid "BNC"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:28
+msgid "Media Independent Interface (MII)"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+msgid "10 Mb/s"
+msgstr "10 م.بايت\\ث"
+
+#: panels/network/connection-editor/ethernet-page.ui:45
+msgid "100 Mb/s"
+msgstr "100 م.بايت\\ث"
+
+#: panels/network/connection-editor/ethernet-page.ui:48
+msgid "1 Gb/s"
+msgstr "1 ج.بايت/ث"
+
+#: panels/network/connection-editor/ethernet-page.ui:51
+msgid "10 Gb/s"
+msgstr "10 ج.بايت/ث"
+
+#: panels/network/connection-editor/ethernet-page.ui:71
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "الا_سم"
+
+#: panels/network/connection-editor/ethernet-page.ui:100
+#: panels/network/connection-editor/wifi-page.ui:67
+#: panels/network/network-wifi.ui:1260
+msgid "_MAC Address"
+msgstr "عنوان _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:146
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:163
+#: panels/network/connection-editor/wifi-page.ui:97
+msgid "_Cloned Address"
+msgstr "عنوان IP"
+
+#: panels/network/connection-editor/ethernet-page.ui:178
+msgid "bytes"
+msgstr "بايت"
+
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr "طريقة IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/network-wifi.ui:777 panels/network/network-wifi.ui:1054
+msgid "Automatic (DHCP)"
+msgstr "تلقائي (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr "عطّل"
+
+#: panels/network/connection-editor/ip4-page.ui:111
+#: panels/network/connection-editor/ip6-page.ui:125
+msgid "Addresses"
+msgstr "العناوين"
+
+#: panels/network/connection-editor/ip4-page.ui:129
+#: panels/network/connection-editor/ip4-page.ui:313
+#: panels/network/connection-editor/ip6-page.ui:143
+#: panels/network/connection-editor/ip6-page.ui:327
+#: panels/printers/details-dialog.ui:89
+msgid "Address"
+msgstr "العنوان"
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+msgid "Netmask"
+msgstr "قناع الشّبكة"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Gateway"
+msgstr "البوّابة"
+
+#: panels/network/connection-editor/ip4-page.ui:220
+#: panels/network/connection-editor/ip6-page.ui:234
+msgid "Automatic DNS"
+msgstr "‏DNS تلقائي"
+
+#: panels/network/connection-editor/ip4-page.ui:244
+#: panels/network/connection-editor/ip6-page.ui:258
+msgid "Separate IP addresses with commas"
+msgstr "عناوين إنترنت مفصولة بفاصلة"
+
+#: panels/network/connection-editor/ip4-page.ui:265
+#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/network-wifi.ui:876 panels/network/network-wifi.ui:1153
+msgid "Routes"
+msgstr "الطُرق"
+
+#: panels/network/connection-editor/ip4-page.ui:288
+#: panels/network/connection-editor/ip6-page.ui:302
+msgid "Automatic Routes"
+msgstr "سُبُل تلقائية"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:354
+#: panels/network/connection-editor/ip6-page.ui:368
+msgid "Metric"
+msgstr "المعيار"
+
+#: panels/network/connection-editor/ip4-page.ui:384
+#: panels/network/connection-editor/ip6-page.ui:398
+#: panels/network/network-wifi.ui:932 panels/network/network-wifi.ui:1209
+msgid "Use this connection _only for resources on its network"
+msgstr "استخدم هذا الاتصال _فقط إذا كان الهدف على شبكته"
+
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr "طريقة IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr "تلقائي، DHCP فقط"
+
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+msgid "Prefix"
+msgstr "السابقة"
+
+#: panels/network/connection-editor/net-connection-editor.c:261
+msgid "Unable to open connection editor"
+msgstr "تعذّر فتح محرر الاتصالات"
+
+#: panels/network/connection-editor/net-connection-editor.c:279
+msgid "New Profile"
+msgstr "إعداد جديد"
+
+#: panels/network/connection-editor/net-connection-editor.c:727
+msgid "Import from file…"
+msgstr "استورد من ملف…"
+
+#: panels/network/connection-editor/net-connection-editor.c:759
+msgid "Add VPN"
+msgstr "أضف VPN"
+
+#: panels/network/connection-editor/security-page.ui:26
+#: panels/network/network-wifi.ui:529
+msgid "S_ecurity"
+msgstr "الأ_من"
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+msgid "Cannot import VPN connection"
+msgstr "تعذّر استيراد اتصال VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:143
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:178
+msgid "Select file to import"
+msgstr "اختر ملفا لاستيراده"
+
+#: panels/network/connection-editor/vpn-helpers.c:182
+#: panels/printers/pp-details-dialog.c:314
+#: panels/sharing/cc-sharing-panel.c:428
+#: panels/user-accounts/cc-avatar-chooser.c:235
+msgid "_Open"
+msgstr "ا_فتح"
+
+#: panels/network/connection-editor/vpn-helpers.c:230
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "يوجد فعلا ملف بالاسم ”%s“."
+
+#: panels/network/connection-editor/vpn-helpers.c:232
+msgid "_Replace"
+msgstr "ا_ستبدل"
+
+#: panels/network/connection-editor/vpn-helpers.c:234
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "هل تريد استبدال %s باتصال VPN الذي تحفظه؟"
+
+#: panels/network/connection-editor/vpn-helpers.c:270
+msgid "Cannot export VPN connection"
+msgstr "تعذّر تصدير اتصال VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:272
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:307
+msgid "Export VPN connection"
+msgstr "صدّر اتصال VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(عطل: تعذّر تحميل محرر اتصالات VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/network-wifi.ui:497
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/network-wifi.ui:513
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "تحكم في اتصالك بالإنترنت"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/network/gnome-network-panel.desktop.in.in:7
+msgid "network-workgroup"
+msgstr "network-workgroup"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;"
+msgstr "شبكة;لاسلكي;واي فاي;بلوتوث;محمول;وسيط;شبكة محلية;مودم;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "تحكم في اتصالك بشبكات واي فاي"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/network/gnome-wifi-panel.desktop.in.in:7
+msgid "network-wireless"
+msgstr "network-wireless"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+msgstr "شبكة;لاسلكي;واي فاي;بلوتوث;محمول;وسيط;شبكة محلية;مودم;"
+
+#: panels/network/net-device-ethernet.c:123
+#: panels/network/net-device-wifi.c:384
+msgid "never"
+msgstr "أبدًا"
+
+#: panels/network/net-device-ethernet.c:133
+#: panels/network/net-device-wifi.c:394
+msgid "today"
+msgstr "اليوم"
+
+#: panels/network/net-device-ethernet.c:135
+#: panels/network/net-device-wifi.c:396
+msgid "yesterday"
+msgstr "الأمس"
+
+#: panels/network/net-device-ethernet.c:173
+#: panels/network/network-mobile.ui:172 panels/network/panel-common.c:647
+#: panels/network/panel-common.c:649
+msgid "IP Address"
+msgstr "عنوان IP"
+
+#: panels/network/net-device-ethernet.c:189 panels/network/network-wifi.ui:342
+msgid "Last used"
+msgstr "آخر استخدام"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:291
+#: panels/network/network-ethernet.ui:19 panels/network/network-simple.ui:39
+msgid "Wired"
+msgstr "سلكية"
+
+#: panels/network/net-device-mobile.c:236
+msgid "Add new connection"
+msgstr "أضف اتصالًا جديدا"
+
+#: panels/network/net-device-wifi.c:1157
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "تشغيل نقطة بث اللاسلكي ستفصلك عن <b>%s</b>."
+
+#: panels/network/net-device-wifi.c:1161
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"لا يمكن استخدام الاتصال اللاسلكي للوصول إلى الإنترنت عند تفعيل نقطة البث."
+
+#: panels/network/net-device-wifi.c:1168
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "أتريد تشغيل نقطة بث واي فاي؟"
+
+#: panels/network/net-device-wifi.c:1190
+msgid ""
+"Wi-Fi hotspots are usually used to share an additional Internet connection "
+"over Wi-Fi."
+msgstr "تستخدم نقاط بث واي فاي عادة لمشاركة اتصال إنترنت إضافي عبر واي فاي."
+
+#: panels/network/net-device-wifi.c:1201
+msgid "_Turn On"
+msgstr "_شغّل"
+
+#: panels/network/net-device-wifi.c:1278
+msgid "Stop hotspot and disconnect any users?"
+msgstr "إيقاف نقطة البث وقطع الاتصال عن أي مستخدمين؟"
+
+#: panels/network/net-device-wifi.c:1281
+msgid "_Stop Hotspot"
+msgstr "أو_قف نقطة البث"
+
+#: panels/network/net-device-wifi.c:1337
+msgid "System policy prohibits use as a Hotspot"
+msgstr "تمنع سياسة النظام استخدامه نقطة بث"
+
+#: panels/network/net-device-wifi.c:1340
+msgid "Wireless device does not support Hotspot mode"
+msgstr "لا يدعم جهاز اللاسلكي وضع نقطة البث"
+
+#: panels/network/net-device-wifi.c:1471
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr "ستُفقد تفاصيل الشبكة، بما في ذلك كلمات السر وأي إعدادات مُخصصة."
+
+#: panels/network/net-device-wifi.c:1475 panels/network/network-wifi.ui:1350
+msgid "_Forget"
+msgstr "ان_سَ"
+
+#: panels/network/net-device-wifi.c:1638 panels/network/net-device-wifi.c:1645
+msgid "Known Wi-Fi Networks"
+msgstr "شبكات واي فاي المعروفة"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1682
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "إن_س"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:102
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "يستخدم الاكتشاف التلقائي للوسيط في حال لم يُعطَ مسار للإعداد."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:110
+msgid "This is not recommended for untrusted public networks."
+msgstr "لا يُنصَح بهذا مع الشبكات العامة غير الموثوقة."
+
+#: panels/network/network-mobile.ui:30
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:48
+msgid "Provider"
+msgstr "مقدم الخدمة"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:92
+msgid "Network Proxy"
+msgstr "وسيط الشبكة"
+
+#: panels/network/network-proxy.ui:173
+msgid "_HTTP Proxy"
+msgstr "وسيط _HTTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "H_TTPS Proxy"
+msgstr "وسيط H_TTPS"
+
+#: panels/network/network-proxy.ui:211
+msgid "_FTP Proxy"
+msgstr "وسيط _FTP"
+
+#: panels/network/network-proxy.ui:230
+msgid "_Socks Host"
+msgstr "مستضيف _Socks"
+
+#: panels/network/network-proxy.ui:249
+msgid "_Ignore Hosts"
+msgstr "_تجاهل المستضيفين"
+
+#: panels/network/network-proxy.ui:287
+msgid "HTTP proxy port"
+msgstr "منفذ وسيط HTTP"
+
+#: panels/network/network-proxy.ui:364
+msgid "HTTPS proxy port"
+msgstr "منفذ وسيط HTTPS"
+
+#: panels/network/network-proxy.ui:385
+msgid "FTP proxy port"
+msgstr "منفذ وسيط FTP"
+
+#: panels/network/network-proxy.ui:406
+msgid "Socks proxy port"
+msgstr "منفذ وسيط Socks"
+
+#: panels/network/network-proxy.ui:435
+msgid "_Configuration URL"
+msgstr "م_سار الإعداد"
+
+#: panels/network/network-simple.ui:50
+msgid "Turn device off"
+msgstr "أغلق الجهاز"
+
+#: panels/network/network-vpn.ui:56
+msgid "Turn VPN connection off"
+msgstr "أوقف اتصال VPN"
+
+#: panels/network/network-wifi.ui:127
+msgid "Automatic _Connect"
+msgstr "اتّ_صل تلقائيا"
+
+#: panels/network/network-wifi.ui:474
+msgid "details"
+msgstr "التفاصيل"
+
+#: panels/network/network-wifi.ui:545
+#: panels/network/wireless-security/eap-method-leap.ui:40
+#: panels/network/wireless-security/eap-method-simple.ui:40
+#: panels/network/wireless-security/ws-leap.ui:40
+#: panels/network/wireless-security/ws-wpa-psk.ui:22
+#: panels/sharing/cc-sharing-panel.ui:357
+#: panels/user-accounts/cc-add-user-dialog.ui:310
+#: panels/user-accounts/cc-add-user-dialog.ui:547
+#: panels/user-accounts/cc-user-panel.ui:214
+msgid "_Password"
+msgstr "كلمة ال_سر"
+
+#: panels/network/network-wifi.ui:621
+msgid "Show P_assword"
+msgstr "أ_ظهر كلمة السر"
+
+#: panels/network/network-wifi.ui:651
+msgid "Make available to other users"
+msgstr "اجعله متاحا للمستخدمين الآخرين"
+
+#: panels/network/network-wifi.ui:679
+msgid "identity"
+msgstr "الهوية"
+
+#: panels/network/network-wifi.ui:713
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: panels/network/network-wifi.ui:754 panels/network/network-wifi.ui:1031
+msgid "_Addresses"
+msgstr "ال_عنوان"
+
+#: panels/network/network-wifi.ui:778 panels/network/network-wifi.ui:1055
+msgid "Automatic (DHCP) addresses only"
+msgstr "عناوين (DHCP) تلقائية فقط"
+
+#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
+msgid "Link-local only"
+msgstr ""
+
+#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
+msgid "Shared with other computers"
+msgstr "مشتركة مع حواسيب أخرى"
+
+#: panels/network/network-wifi.ui:916 panels/network/network-wifi.ui:1193
+msgid "_Ignore automatically obtained routes"
+msgstr "_تجاهل السُبُل المُضافة آليًا"
+
+#: panels/network/network-wifi.ui:959
+msgid "ipv4"
+msgstr "ipv4"
+
+#: panels/network/network-wifi.ui:990
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: panels/network/network-wifi.ui:1236
+msgid "ipv6"
+msgstr "ipv6"
+
+#: panels/network/network-wifi.ui:1276
+msgid "_Cloned MAC Address"
+msgstr "عنوان MAC _منسوخ"
+
+#: panels/network/network-wifi.ui:1334
+msgid "_Reset"
+msgstr "_صفّر"
+
+#: panels/network/network-wifi.ui:1370
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"صفّر كل إعدادات هذا الاتصال لقيمها المبدئية و لكن تذكّر أنها الاتصال المُفضّل."
+
+#: panels/network/network-wifi.ui:1387
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr "احذف كل التفاصيل المتعلقة بهذه الشبكة و لا تحاول الاتصال بها تلقائيا."
+
+#: panels/network/network-wifi.ui:1449
+msgid "Hardware"
+msgstr "العتاد"
+
+#: panels/network/network-wifi.ui:1453
+msgctxt "tab"
+msgid "Reset"
+msgstr "صفّر"
+
+#: panels/network/network-wifi.ui:1505
+msgid "Wi-Fi Hotspot"
+msgstr "نقطة بث واي فاي"
+
+#: panels/network/network-wifi.ui:1523
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "أطفئ للاتصال بشبكة واي فاي"
+
+#: panels/network/network-wifi.ui:1572
+msgid "Network Name"
+msgstr "اسم الشبكة"
+
+#: panels/network/network-wifi.ui:1590
+msgid "Connected Devices"
+msgstr "الأجهزة الموصّلة"
+
+#: panels/network/network-wifi.ui:1608
+msgid "Security type"
+msgstr "نوع الأمن"
+
+#: panels/network/network-wifi.ui:1671
+msgctxt "Wi-Fi passkey"
+msgid "Password"
+msgstr "كلمة السر"
+
+#: panels/network/network-wifi.ui:1768
+msgid "Turn Wi-Fi off"
+msgstr "أغلق واي فاي"
+
+#: panels/network/network-wifi.ui:1800
+msgid "_Connect to Hidden Network…"
+msgstr "اتّ_صل بشبكة مخفية…"
+
+#: panels/network/network-wifi.ui:1810
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "شغّل نقطة بث واي فاي…"
+
+#: panels/network/network-wifi.ui:1820
+msgid "_Known Wi-Fi Networks"
+msgstr "_شبكات واي فاي المعروفة"
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:127
+msgid "Ad-hoc"
+msgstr "لا مركزية"
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:131
+msgid "Infrastructure"
+msgstr "مركزية"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:147 panels/network/panel-common.c:201
+msgid "Status unknown"
+msgstr "الحالة غير معروفة"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:151
+msgid "Unmanaged"
+msgstr "غير مُدار"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:155
+msgid "Unavailable"
+msgstr "غير متاح"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:165 panels/network/panel-common.c:207
+msgid "Connecting"
+msgstr "يتّصل"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:169 panels/network/panel-common.c:211
+msgid "Authentication required"
+msgstr "الاستيثاق مطلوب"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:173 panels/network/panel-common.c:215
+msgid "Connected"
+msgstr "متّصل"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:177
+msgid "Disconnecting"
+msgstr "يقطع الاتصال"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:181 panels/network/panel-common.c:219
+msgid "Connection failed"
+msgstr "فشل الاتصال"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:185 panels/network/panel-common.c:227
+msgid "Status unknown (missing)"
+msgstr "الحالة غير معروفة (مفقودة)"
+
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:223
+msgid "Not connected"
+msgstr "غير متّصِل"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "Configuration failed"
+msgstr "فشل الإعداد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252
+msgid "IP configuration failed"
+msgstr "فشل إعداد رقم الإنترنت (IP)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "IP configuration expired"
+msgstr "انتهت صلاحية إعداد رقم الإنترنت (IP)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:260
+msgid "Secrets were required, but not provided"
+msgstr "الأسرار مطلوبة لكن لم تُعطَ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:264
+msgid "802.1x supplicant disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:268
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:272
+msgid "802.1x supplicant failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:276
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:280
+msgid "PPP service failed to start"
+msgstr "فشل بدء خدمة PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:284
+msgid "PPP service disconnected"
+msgstr "فصلت خدمة PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:288
+msgid "PPP failed"
+msgstr "فشل PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:292
+msgid "DHCP client failed to start"
+msgstr "فشل بدء عميل DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:296
+msgid "DHCP client error"
+msgstr "خطأ من عميل DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:300
+msgid "DHCP client failed"
+msgstr "فشل عميل DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:304
+msgid "Shared connection service failed to start"
+msgstr "فشل بدء خدمة الاتصال المشترك"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:308
+msgid "Shared connection service failed"
+msgstr "فشلت خدمة الاتصال المشترك"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:312
+msgid "AutoIP service failed to start"
+msgstr "فشل بدء خدمة AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:316
+msgid "AutoIP service error"
+msgstr "عطل في خدمة AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:320
+msgid "AutoIP service failed"
+msgstr "فشلت خدمة AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:324
+msgid "Line busy"
+msgstr "الخط مشغول"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:328
+msgid "No dial tone"
+msgstr "الخط مقطوع"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:332
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:336
+msgid "Dialing request timed out"
+msgstr "انتهت مهلة الاتصال الهاتفي"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:340
+msgid "Dialing attempt failed"
+msgstr "فشل الاتصال الهاتفي"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:344
+msgid "Modem initialization failed"
+msgstr "فشلت تهيئة المودم"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:348
+msgid "Failed to select the specified APN"
+msgstr "تعذّر اختيار APN المحدد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:352
+msgid "Not searching for networks"
+msgstr "لن يبحث عن شبكة"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:356
+msgid "Network registration denied"
+msgstr "رُفض تسجيل الشبكة"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:360
+msgid "Network registration timed out"
+msgstr "انتهت مهلة تسجيل الشبكة"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:364
+msgid "Failed to register with the requested network"
+msgstr "فشل تسجيل الشبكة المطلوبة"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:368
+msgid "PIN check failed"
+msgstr "فضل فحص PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:372
+msgid "Firmware for the device may be missing"
+msgstr "البرمجيات المضمنة التي يحتاجها الجهاز غير متاحة"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:376
+msgid "Connection disappeared"
+msgstr "اختفى الاتصال"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:380
+msgid "Existing connection was assumed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:384
+msgid "Modem not found"
+msgstr "المودم غير موجود"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:388
+msgid "Bluetooth connection failed"
+msgstr "فشل اتصال بلوتوث"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:392
+msgid "SIM Card not inserted"
+msgstr "لم تُدرج شريحة الهاتف"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:396
+msgid "SIM Pin required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:400
+msgid "SIM Puk required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:404
+msgid "SIM wrong"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:408
+msgid "Connection dependency failed"
+msgstr "فشلت اعتمادية الاتصال"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:433
+msgid "Firmware missing"
+msgstr "البرمجية المغروسة غير متاحة"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:437
+msgid "Cable unplugged"
+msgstr "الكبل مفصول"
+
+#: panels/network/wireless-security/eap-method.c:69
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:245
+msgid "no file selected"
+msgstr "لم تحدد أي ملف"
+
+#: panels/network/wireless-security/eap-method.c:276
+msgid "unspecified error validating eap-method file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:451
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:454
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:72
+msgid "missing EAP-FAST PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:268
+#: panels/network/wireless-security/eap-method-peap.c:302
+#: panels/network/wireless-security/eap-method-ttls.c:351
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:283
+#: panels/network/wireless-security/eap-method-peap.c:272
+#: panels/network/wireless-security/eap-method-ttls.c:289
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:406
+msgid "Choose a PAC file"
+msgstr "اختر ملف PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:413
+msgid "PAC files (*.pac)"
+msgstr "ملفات PAC‏ (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:22
+msgid "Anonymous"
+msgstr "مجهول"
+
+#: panels/network/wireless-security/eap-method-fast.ui:25
+msgid "Authenticated"
+msgstr "مستوثَق"
+
+#: panels/network/wireless-security/eap-method-fast.ui:28
+msgid "Both"
+msgstr "كلاهما"
+
+#: panels/network/wireless-security/eap-method-fast.ui:76
+msgid "PAC _file"
+msgstr "_ملفات PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:122
+#: panels/network/wireless-security/eap-method-peap.ui:146
+#: panels/network/wireless-security/eap-method-ttls.ui:97
+msgid "_Inner authentication"
+msgstr "الاستيثاق ال_داخلي"
+
+#: panels/network/wireless-security/eap-method-fast.ui:156
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:74
+msgid "missing EAP-LEAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:26
+#: panels/network/wireless-security/eap-method-simple.ui:26
+#: panels/network/wireless-security/ws-leap.ui:26
+#: panels/user-accounts/cc-add-user-dialog.ui:146
+#: panels/user-accounts/cc-add-user-dialog.ui:527
+msgid "_Username"
+msgstr "ا_سم المستخدم"
+
+#: panels/network/wireless-security/eap-method-leap.ui:68
+#: panels/network/wireless-security/eap-method-simple.ui:85
+#: panels/network/wireless-security/eap-method-tls.ui:164
+#: panels/network/wireless-security/ws-leap.ui:68
+#: panels/network/wireless-security/ws-wpa-psk.ui:76
+msgid "Sho_w password"
+msgstr "أظهر _كلمة السر"
+
+#: panels/network/wireless-security/eap-method-peap.c:63
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:68
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:287
+#: panels/network/wireless-security/eap-method-ttls.c:336
+#: panels/network/wireless-security/wireless-security.c:441
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:381
+#: panels/network/wireless-security/eap-method-tls.c:492
+#: panels/network/wireless-security/eap-method-ttls.c:430
+msgid "Choose a Certificate Authority certificate"
+msgstr "اختر شهادة \"سلطة شهادات\""
+
+#: panels/network/wireless-security/eap-method-peap.ui:25
+msgid "Version 0"
+msgstr "الإصدارة 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:28
+msgid "Version 1"
+msgstr "الإصدارة 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:74
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:57
+msgid "C_A certificate"
+msgstr "شهادة _سُلْطة استيثاق"
+
+#: panels/network/wireless-security/eap-method-peap.ui:96
+#: panels/network/wireless-security/eap-method-tls.ui:97
+#: panels/network/wireless-security/eap-method-ttls.ui:79
+msgid "No CA certificate is _required"
+msgstr "غير مطلوب أي _شهادة من سلطة شهادات"
+
+#: panels/network/wireless-security/eap-method-peap.ui:114
+msgid "PEAP _version"
+msgstr "إ_صدارة PEAP:"
+
+#: panels/network/wireless-security/eap-method-simple.c:74
+msgid "missing EAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-simple.c:87
+msgid "missing EAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:68
+msgid "missing EAP-TLS identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:77
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:84
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:100
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:110
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:307
+msgid "Unencrypted private keys are insecure"
+msgstr "المفاتيح السرية غير المُعمّاة ليست آمنة"
+
+#: panels/network/wireless-security/eap-method-tls.c:310
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"المفتاح السري المحدد ليس محميًا بكلمة سر.  قد يتسبب هذا في تقويض اعتمادات "
+"الأمان. رجاء اختر مفتاحًا محميًا بكلمة سر.\n"
+"\n"
+"(يمكنك حماية مفتاحك بكلمة سر باستخدام openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:486
+msgid "Choose your personal certificate"
+msgstr "اختر شهادتك الشخصية"
+
+#: panels/network/wireless-security/eap-method-tls.c:498
+msgid "Choose your private key"
+msgstr "اختر مفتاحك السري"
+
+#: panels/network/wireless-security/eap-method-tls.ui:24
+msgid "I_dentity"
+msgstr "ا_لهوية"
+
+#: panels/network/wireless-security/eap-method-tls.ui:50
+msgid "_User certificate"
+msgstr "شهادة المست_خدم"
+
+#: panels/network/wireless-security/eap-method-tls.ui:115
+msgid "Private _key"
+msgstr "المفتاح ال_سري"
+
+#: panels/network/wireless-security/eap-method-tls.ui:140
+msgid "_Private key password"
+msgstr "كل_مة سر المفتاح السري"
+
+#: panels/network/wireless-security/eap-method-ttls.c:63
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:68
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:259
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.c:274
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.c:305
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:321
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/wireless-security.c:87
+msgid "Unknown error validating 802.1X security"
+msgstr ""
+
+#: panels/network/wireless-security/wireless-security.c:453
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/wireless-security.c:477
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/wireless-security.c:488
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/wireless-security.c:499
+msgid "Tunneled TLS"
+msgstr "‏TLS عبر نفق"
+
+#: panels/network/wireless-security/wireless-security.c:510
+msgid "Protected EAP (PEAP)"
+msgstr "‏EAP ‏(PEAP) محمي"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:39
+#: panels/network/wireless-security/ws-wep-key.ui:115
+#: panels/network/wireless-security/ws-wpa-eap.ui:33
+msgid "Au_thentication"
+msgstr "الا_ستيثاق"
+
+#: panels/network/wireless-security/ws-leap.c:63
+msgid "missing leap-username"
+msgstr ""
+
+#: panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "١ (المبدئي)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "نظام مفتوح"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "مفتاح مشترك"
+
+#: panels/network/wireless-security/ws-wep-key.ui:56
+msgid "_Key"
+msgstr "الم_فتاح"
+
+#: panels/network/wireless-security/ws-wep-key.ui:94
+msgid "Sho_w key"
+msgstr "أظهر ال_مفتاح"
+
+#: panels/network/wireless-security/ws-wep-key.ui:152
+msgid "WEP inde_x"
+msgstr "_فهرس WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.ui:50
+msgid "_Type"
+msgstr "ال_نوع"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:61
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "ال_تنبيهات"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:113
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "التنبيهات ال_صوتية"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:169
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_نوافذ التنبيهات المنبثقة"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:185
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr "ستظل التنبيهات ظاهرة في قائمة التنبيهات عند تعطيل النوافذ المنبثقة."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:250
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "أ_ظهر محتوى الرسائل في نوافذ منبثقة"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:301
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "تنبيهات شاشة ال_قفل"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:352
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "أظهر محتوى الر_سالة في شاشة القفل"
+
+#: panels/notifications/cc-notifications-panel.ui:70
+msgid "Notification _Popups"
+msgstr "_نوافذ التنبيهات المنبثقة"
+
+#: panels/notifications/cc-notifications-panel.ui:121
+msgid "_Lock Screen Notifications"
+msgstr "تنبيهات شاشة ال_قفل"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "تحكم في أي التنبيهات تُعرض و ماذا تعرِض"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:7
+msgid "preferences-system-notifications"
+msgstr "preferences-system-notifications"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "تنبيهات;لوحة;رسالة;منبثق;"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:150
+msgctxt "Online Account"
+msgid "Other"
+msgstr "أخرى"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:621
+#, c-format
+msgid "%s Account"
+msgstr "حساب %s"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:918
+msgid "Error removing account"
+msgstr "خطأ أثناء إزالة الحساب"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:983
+#, c-format
+msgid "<b>%s</b> removed"
+msgstr "أزيل <b>%s</b>"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "حسابات الإنترنت"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "اتصل بحساباتك على الإنترنت و اختر ما الذي تستخدمه منهم"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:7
+msgid "goa-panel"
+msgstr "goa-panel"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr "جوجل;جووجل;فيسبوك;تويتر;ياهو;وب;ويب;محادثة;تقويم;بريد;اتصال;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
+msgid "Undo"
+msgstr "تراجع"
+
+#: panels/online-accounts/online-accounts.ui:96
+msgid "Connect to your data in the cloud"
+msgstr "اتصل ببياناتك في السحاب"
+
+#: panels/online-accounts/online-accounts.ui:111
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "لا اتصال بالإنترنت — اتصل لإعداد حساب إنترنت جديد"
+
+#: panels/online-accounts/online-accounts.ui:136
+msgid "Add an account"
+msgstr "أضف حسابا"
+
+#: panels/online-accounts/online-accounts.ui:243
+msgid "Remove Account"
+msgstr "أزِل الحساب"
+
+#: panels/power/cc-power-panel.c:260
+msgid "Unknown time"
+msgstr "وقت غير معروف"
+
+#: panels/power/cc-power-panel.c:266
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "أقل من دقيقة"
+msgstr[1] "دقيقة واحدة"
+msgstr[2] "دقيقتين"
+msgstr[3] "%i دقائق"
+msgstr[4] "%i دقيقة"
+msgstr[5] "%i دقيقة"
+
+#: panels/power/cc-power-panel.c:278
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "أقل من ساعة"
+msgstr[1] "ساعة واحدة"
+msgstr[2] "ساعتين"
+msgstr[3] "%i ساعات"
+msgstr[4] "%i ساعة"
+msgstr[5] "%i ساعة"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-power-panel.c:286
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-power-panel.c:287
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ساعة"
+msgstr[1] "ساعة"
+msgstr[2] "ساعتين"
+msgstr[3] "ساعات"
+msgstr[4] "ساعة"
+msgstr[5] "ساعة"
+
+#: panels/power/cc-power-panel.c:288
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "دقيقة"
+msgstr[1] "دقيقة"
+msgstr[2] "دقيقتين"
+msgstr[3] "دقائق"
+msgstr[4] "دقيقة"
+msgstr[5] "دقيقة"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:306
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s حتى يكتمل الشحن"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:313
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "تحذير: بقي %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:318
+#, c-format
+msgid "%s remaining"
+msgstr "بقي %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:323 panels/power/cc-power-panel.c:353
+msgid "Fully charged"
+msgstr "مشحونة بالكامل"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:327 panels/power/cc-power-panel.c:357
+msgid "Not charging"
+msgstr "لا تشحن"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:331 panels/power/cc-power-panel.c:361
+msgid "Empty"
+msgstr "فارغة"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:344
+msgid "Charging"
+msgstr "يشحن"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:349
+msgid "Discharging"
+msgstr "تُفرّغ"
+
+#: panels/power/cc-power-panel.c:479
+msgctxt "Battery name"
+msgid "Main"
+msgstr "الأساسية"
+
+#: panels/power/cc-power-panel.c:481
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "إضافية"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:559
+msgid "Wireless mouse"
+msgstr "فأرة لا سلكية"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:562
+msgid "Wireless keyboard"
+msgstr "لوحة مفاتيح لا سلكية"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:565
+msgid "Uninterruptible power supply"
+msgstr "مزود طاقة غير منقطعة"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:568
+msgid "Personal digital assistant"
+msgstr "مساعد رقمي شخصي PDA"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:571
+msgid "Cellphone"
+msgstr "هاتف خليوي"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:574
+msgid "Media player"
+msgstr "مشغل وسائط"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:577 panels/wacom/cc-wacom-panel.c:848
+msgid "Tablet"
+msgstr "لوحي"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:580
+msgid "Computer"
+msgstr "حاسوب"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:583
+msgid "Gaming input device"
+msgstr "جهاز إدخال ألعاب"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-power-panel.c:586 panels/power/cc-power-panel.c:847
+#: panels/power/cc-power-panel.c:2481
+msgid "Battery"
+msgstr "بطارية"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:646
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "تشحن"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:653
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "إنتباه"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:658
+msgctxt "Battery power"
+msgid "Low"
+msgstr "منخفضة"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:663
+msgctxt "Battery power"
+msgid "Good"
+msgstr "جيّدة"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:668
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "مشحونة بالكامل"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:672
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "فارغة"
+
+#: panels/power/cc-power-panel.c:845
+msgid "Batteries"
+msgstr "البطاريات"
+
+#: panels/power/cc-power-panel.c:1206
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "أقل من ساعة"
+msgstr[1] "ساعة واحدة"
+msgstr[2] "ساعتين"
+msgstr[3] "%d ساعات"
+msgstr[4] "%d ساعة"
+msgstr[5] "%d ساعة"
+
+#: panels/power/cc-power-panel.c:1208
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "أقل من دقيقة"
+msgstr[1] "دقيقة واحدة"
+msgstr[2] "دقيقتين"
+msgstr[3] "%d دقائق"
+msgstr[4] "%d دقيقة"
+msgstr[5] "%d دقيقة"
+
+#: panels/power/cc-power-panel.c:1211
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "أقل من ثانية"
+msgstr[1] "ثانية واحدة"
+msgstr[2] "ثانيتين"
+msgstr[3] "%d ثوان"
+msgstr[4] "%d ثانية"
+msgstr[5] "%d ثانية"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/power/cc-power-panel.c:1216
+#, c-format
+msgctxt "time"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 2 minutes 12 seconds
+#: panels/power/cc-power-panel.c:1219
+#, c-format
+msgctxt "time"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 0 seconds
+#: panels/power/cc-power-panel.c:1225
+msgid "0 seconds"
+msgstr "أقل من ثانية"
+
+#: panels/power/cc-power-panel.c:1322
+msgid "When _idle"
+msgstr "عند عدم الا_ستخدام"
+
+#: panels/power/cc-power-panel.c:1779
+msgid "Power Saving"
+msgstr "حفظ الطاقة"
+
+#: panels/power/cc-power-panel.c:1811
+msgid "_Screen brightness"
+msgstr "س_طوع الشاشة"
+
+#: panels/power/cc-power-panel.c:1833
+msgid "Automatic brightness"
+msgstr "سطوع تلقائي"
+
+#: panels/power/cc-power-panel.c:1855
+msgid "_Keyboard brightness"
+msgstr "سطوع _لوحة المفاتيح"
+
+#: panels/power/cc-power-panel.c:1868
+msgid "_Dim screen when inactive"
+msgstr "أ_خفض ضوء الشاشة عند الخمول"
+
+#: panels/power/cc-power-panel.c:1897
+msgid "_Blank screen"
+msgstr "شاشة _فارغة"
+
+#: panels/power/cc-power-panel.c:1939
+msgid "_Wi-Fi"
+msgstr "واي فاي"
+
+#: panels/power/cc-power-panel.c:1945
+msgid "Wi-Fi can be turned off to save power."
+msgstr "يمكن تعطيل واي فاي لتوفير الطاقة."
+
+#: panels/power/cc-power-panel.c:1975
+msgid "_Mobile broadband"
+msgstr "شبكة هاتف م_حمول"
+
+#: panels/power/cc-power-panel.c:1981
+msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+msgstr "يمكن تعطل شبكات الهاتف المحمول (٣ج، ٤ج، واي‌ماك، إلخ.) لتوفير الطاقة."
+
+#: panels/power/cc-power-panel.c:2045
+msgid "_Bluetooth"
+msgstr "بلو_توث"
+
+#: panels/power/cc-power-panel.c:2051
+msgid "Bluetooth can be turned off to save power."
+msgstr "يمكن تعطيل بلوتوث لتوفير الطاقة."
+
+#: panels/power/cc-power-panel.c:2107
+msgid "When on battery power"
+msgstr "عندما تكون على طاقة البطارية"
+
+#: panels/power/cc-power-panel.c:2109
+msgid "When plugged in"
+msgstr "عند توصيل الكبل"
+
+#: panels/power/cc-power-panel.c:2203
+msgid "Suspend"
+msgstr "علِّق"
+
+#: panels/power/cc-power-panel.c:2204
+msgid "Power Off"
+msgstr "أطفئ"
+
+#: panels/power/cc-power-panel.c:2205
+msgid "Hibernate"
+msgstr "أسبِت"
+
+#: panels/power/cc-power-panel.c:2206
+msgid "Nothing"
+msgstr "لا تفعل شيئا"
+
+#. Frame header
+#: panels/power/cc-power-panel.c:2306
+msgid "Suspend & Power Button"
+msgstr "التعليق و زر الطاقة"
+
+#: panels/power/cc-power-panel.c:2348
+msgid "_Automatic suspend"
+msgstr "ت_عليق تلقائي"
+
+#: panels/power/cc-power-panel.c:2350
+msgid "Automatic suspend"
+msgstr "تعليق تلقائي"
+
+#: panels/power/cc-power-panel.c:2416
+msgid "_When the Power Button is pressed"
+msgstr "عند _ضغط زر الطاقة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:13
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "١٥ دقيقة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:17
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "٢٠ دقيقة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:21
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "٢٥ دقيقة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:25
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "٣٠ دقيقة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:29
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "٤٥ دقيقة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:33
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "ساعة واحدة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:37
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "٨٠ دقيقة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:41
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "٩٠ دقيقة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:45
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "١٠٠ دقيقة"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:49
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "ساعتين"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:63
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "دقيقة واحدة"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:67
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "دقيقتين"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:71
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "٣ دقائق"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:75
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "٤ دقائق"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:79
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "٥ دقائق"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:83
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "٨ دقائق"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:87
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "١٠ دقائق"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:91
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "١٢ دقيقة"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:95
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "١٥ دقيقة"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:99
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "أبدًا"
+
+#: panels/power/cc-power-panel.ui:167
+msgid "Automatic Suspend"
+msgstr "تعليق تلقائي"
+
+#: panels/power/cc-power-panel.ui:192
+msgid "_Plugged In"
+msgstr "_موصّل بمقبس الكهرباء"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "On _Battery Power"
+msgstr "على _طاقة البطارية"
+
+#: panels/power/cc-power-panel.ui:253 panels/power/cc-power-panel.ui:313
+#: panels/universal-access/cc-ua-panel.ui:1507
+msgid "Delay"
+msgstr "التأخير"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "الطاقة"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "اعرض حالة البطارية و غيّر إعدادات توفير الطاقة"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/power/gnome-power-panel.desktop.in.in:7
+msgid "gnome-power-manager"
+msgstr "gnome-power-manager"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr "طاقة;سبات;تعليق;بطارية;إضاءة;شاشة;إسبات;"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "استوثق"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:362
+msgid "Username"
+msgstr "اسم المستخدم"
+
+#. Translators: This is a password needed for printing.
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:383
+#: panels/user-accounts/cc-add-user-dialog.ui:249
+msgid "Password"
+msgstr "كلمة السر"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:337
+msgid "Authentication Required"
+msgstr "الاستيثاق مطلوب"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:715
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "أزيلت الطابعة ”%s“"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:938
+msgid "Failed to add new printer."
+msgstr "تعذّر إضافة طابعة جديدة."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1242
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "تعذّر تحميل الواجهة: %s"
+
+#: panels/printers/details-dialog.ui:64 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "المكان"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/details-dialog.ui:114
+#: panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "المُشغّل"
+
+#: panels/printers/details-dialog.ui:152
+msgid "Searching for preferred drivers…"
+msgstr "يبحث عن المُشغّلات المُفضّلة…"
+
+#: panels/printers/details-dialog.ui:174
+msgid "Search for Drivers"
+msgstr "ابحث عن المشغلات"
+
+#: panels/printers/details-dialog.ui:182
+msgid "Select from Database…"
+msgstr "اختر من قاعدة بيانات…"
+
+#: panels/printers/details-dialog.ui:190
+msgid "Install PPD File…"
+msgstr "ثبّت ملف PPD…"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "الطابعات"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "أضف الطابعات و اعرض مهام الطباعة و اختر ما الذي تطبعه"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/printers/gnome-printers-panel.desktop.in.in:7
+msgid "printer"
+msgstr "printer"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "طابعة;طباعة;طبع;ورق;حبر;"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/jobs-dialog.ui:44
+msgid "Domain"
+msgstr "النطاق"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/jobs-dialog.ui:123
+msgid "A_uthenticate"
+msgstr "اس_توثق"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/jobs-dialog.ui:163
+msgid "Clear All"
+msgstr "امسح الكل"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/jobs-dialog.ui:225
+msgid "_Authenticate"
+msgstr "ا_ستوثق"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/jobs-dialog.ui:354
+msgid "No Active Printer Jobs"
+msgstr "لا مهام طابعة نشطة"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:363
+#: panels/printers/pp-new-printer-dialog.c:427
+msgid "Add Printer"
+msgstr "أضِف طابعة"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+msgid "_Unlock"
+msgstr "ا_فتح"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:211
+msgid "No Printers Found"
+msgstr "لم يُعثر على أي طابعات"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:284
+msgid "Enter a network address or search for a printer"
+msgstr "أدخل عنوان شبكة للبحث عن الطابعة"
+
+#: panels/printers/new-printer-dialog.ui:353
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"أدخل اسم المستخدم و كلمة السر لعرض الطابعات المتوفرة على خادوم الطباعة."
+
+#. Translators: This button triggers the printing of a test page.
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/options-dialog.ui:22 panels/printers/pp-options-dialog.c:907
+msgid "Test Page"
+msgstr "صفحة اختبار"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:133
+#: panels/printers/pp-details-dialog.c:417
+#, c-format
+msgid "%s Details"
+msgstr "تفاصيل %s"
+
+#: panels/printers/pp-details-dialog.c:180
+msgid "No suitable driver found"
+msgstr "لم يعثر على أي طابعة مناسبة"
+
+#: panels/printers/pp-details-dialog.c:310
+msgid "Select PPD File"
+msgstr "اختر ملف PPD"
+
+#: panels/printers/pp-details-dialog.c:319
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr "ملفت وصف طابعة بوست‌سكربت (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr "اختر مُشغّل الطابعة"
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/cc-avatar-chooser.c:108
+msgid "Select"
+msgstr "اختر"
+
+#: panels/printers/ppd-selection-dialog.ui:73
+msgid "Loading drivers database…"
+msgstr "يُحمّل قاعدة بيانات المشغلات…"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:472
+msgid "JetDirect Printer"
+msgstr "طابعة JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:707
+msgid "LPD Printer"
+msgstr "طابعة LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:65
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "على وجه واحد"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:67
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "الحافة الطويلة (قياسي)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:69
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "الحافة القصيرة (ملفوف)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:71
+msgid "Portrait"
+msgstr "طوليّ"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:73
+msgid "Landscape"
+msgstr "عرضيّ"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:75
+msgid "Reverse landscape"
+msgstr "عرضيّ مقلوب"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:77
+msgid "Reverse portrait"
+msgstr "طوليّ مقلوب"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-jobs-dialog.c:234
+msgctxt "print job"
+msgid "Pending"
+msgstr "منتظرة"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-jobs-dialog.c:240
+msgctxt "print job"
+msgid "Paused"
+msgstr "مُلبثة"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-jobs-dialog.c:245
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "الاستيثاق مطلوب"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-jobs-dialog.c:250
+msgctxt "print job"
+msgid "Processing"
+msgstr "تُعالَج"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-jobs-dialog.c:254
+msgctxt "print job"
+msgid "Stopped"
+msgstr "متوقفة"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-jobs-dialog.c:258
+msgctxt "print job"
+msgid "Canceled"
+msgstr "ملغاة"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-jobs-dialog.c:262
+msgctxt "print job"
+msgid "Aborted"
+msgstr "مُجهضَة"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-jobs-dialog.c:266
+msgctxt "print job"
+msgid "Completed"
+msgstr "مُنجزَة"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:390
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "تتطلب المهمة الاستيثاق"
+msgstr[1] "تتطلب المهمة الاستيثاق"
+msgstr[2] "تتطلب المهمتان الاستيثاق"
+msgstr[3] "تتطلب %u مهمات الاستيثاق"
+msgstr[4] "تتطلب %u مهمة الاستيثاق"
+msgstr[5] "تتطلب %u مهمة الاستيثاق"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:613
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — المهام النشطة"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:617
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "أدخل اسم المستخدم و كلمة السر للطباعة من %s."
+
+#: panels/printers/pp-new-printer-dialog.c:380
+msgid "Unlock Print Server"
+msgstr "افتح خادوم الطباعة"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:384
+#, c-format
+msgid "Unlock %s."
+msgstr "افتح %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:388
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "أدخل اسم المستخدم و كلمة السر لعرض الطابعات المتوفرة على %s."
+
+#: panels/printers/pp-new-printer-dialog.c:838
+msgid "Searching for Printers"
+msgstr "البحث عن الطابعات"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1680
+msgid "USB"
+msgstr "يو‌إس‌بي"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1685
+msgid "Serial Port"
+msgstr "منفذ تسلسلي"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1692
+msgid "Parallel Port"
+msgstr "منفذ متواز"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1734
+#, c-format
+msgid "Location: %s"
+msgstr "المكان: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+msgid "Address: %s"
+msgstr "العنوان: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1766
+msgid "Server requires authentication"
+msgstr "يتطلب الخادوم الاستيثاق"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Two Sided"
+msgstr "على الوجهين"
+
+#: panels/printers/pp-options-dialog.c:91
+msgid "Paper Type"
+msgstr "نوع الورق"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "Paper Source"
+msgstr "مصدر الورق"
+
+#: panels/printers/pp-options-dialog.c:93
+msgid "Output Tray"
+msgstr "رف الخارج"
+
+#: panels/printers/pp-options-dialog.c:94
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "الميز"
+
+#: panels/printers/pp-options-dialog.c:95
+msgid "GhostScript pre-filtering"
+msgstr "ترشيح مسبق في غوست‌سكربت"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:548
+msgid "Pages per side"
+msgstr "الصفحات في كل وجه"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:560
+msgid "Two-sided"
+msgstr "على الوجهين"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:572
+msgid "Orientation"
+msgstr "الاتجاه"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "عام"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "إعداد الصفحة"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:675
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "الخيارات القابلة للتثبيت"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:678
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "المهام"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:681
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "جودة الصورة"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:684
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "الألوان"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:687
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "الإنهاء"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:690
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "متقدم"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:920
+msgid "Test page"
+msgstr "صفحة اختبار"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "اختيار تلقائي"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "مبدئي الطابعة"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "ادمج خطوط غوست‌سكربت فقط"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "حوّل إلى بوست‌سكربت المستوى 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "حوّل إلى بوست‌سكربت المستوى 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "لا ترشيح مسبق"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "المُصنِّع"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:606 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr "لا مهام نشطة"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:611
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "لا مهام"
+msgstr[1] "مهمة"
+msgstr[2] "مهمتين"
+msgstr[3] "%u مهمات"
+msgstr[4] "%u مهمة"
+msgstr[5] "%u مهمة"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:766
+msgid "Low on toner"
+msgstr "الحبر قليل"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:768
+msgid "Out of toner"
+msgstr "نفد الحبر"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:771
+msgid "Low on developer"
+msgstr "المُحمِّض قليل"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:774
+msgid "Out of developer"
+msgstr "نفد المُحمِّض"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:776
+msgid "Low on a marker supply"
+msgstr "اللون قليل"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:778
+msgid "Out of a marker supply"
+msgstr "نفد اللون"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:780
+msgid "Open cover"
+msgstr "الغطاء مفتوح"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:782
+msgid "Open door"
+msgstr "الباب مفنوح"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:784
+msgid "Low on paper"
+msgstr "الورق قليل"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:786
+msgid "Out of paper"
+msgstr "نفد الورق"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:788
+msgctxt "printer state"
+msgid "Offline"
+msgstr "غير متصلة"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:790
+#: panels/printers/pp-printer-entry.c:918
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "متوقفة"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:792
+msgid "Waste receptacle almost full"
+msgstr "حاوية النفايات على وشك الامتلاء"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:794
+msgid "Waste receptacle full"
+msgstr "حاوية النفايات ممتلئة"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:796
+msgid "The optical photo conductor is near end of life"
+msgstr "قاربت صلاحية المقاوم الضوئي على الانتهاء"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:798
+msgid "The optical photo conductor is no longer functioning"
+msgstr "لم يعد المقاوم الضوئي يعمل"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:904
+msgctxt "printer state"
+msgid "Ready"
+msgstr "جاهزة"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:909
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "لا تقبل المهام"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:914
+msgctxt "printer state"
+msgid "Processing"
+msgstr "تُعالِج"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:938
+msgid "Clean print heads"
+msgstr "نظف رؤوس الطباعة"
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr "خيارات الطابعة"
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr "تفاصيل الطابعة"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr "استخدم الطابعة مبدئيًا"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr "نظف رؤوس الطابعة"
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "أزِل طابعة"
+
+#: panels/printers/printer-entry.ui:193
+msgid "Model"
+msgstr "الطراز"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr "مستوى الحبر"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:312
+msgid "Please restart when the problem is resolved."
+msgstr "رجاء أعد التشغيل بعد حل المشكلة."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:319
+msgid "Restart"
+msgstr "أعِد التشغيل"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:20
+msgid "Add…"
+msgstr "أضف…"
+
+#: panels/printers/printers.ui:186
+msgid "No printers"
+msgstr "لا طابعات"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:200
+msgid "Add a Printer…"
+msgstr "أضِف طابعة…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:232
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"آسف، يبدو أن خدمة الطباعة\n"
+"في النظام غير متاحة."
+
+#: panels/privacy/cc-privacy-panel.c:423 panels/privacy/cc-privacy-panel.ui:280
+msgid "Screen Lock"
+msgstr "قفل الشاشة"
+
+#: panels/privacy/cc-privacy-panel.c:467
+msgid "In use"
+msgstr "قيد الاستعمال"
+
+#: panels/privacy/cc-privacy-panel.c:472
+msgctxt "Location services status"
+msgid "On"
+msgstr "مشغلة"
+
+#: panels/privacy/cc-privacy-panel.c:473
+msgctxt "Location services status"
+msgid "Off"
+msgstr "مغلقة"
+
+#: panels/privacy/cc-privacy-panel.c:895
+msgctxt "Camera status"
+msgid "Off"
+msgstr "معطّل"
+
+#: panels/privacy/cc-privacy-panel.c:897
+msgctxt "Camera status"
+msgid "On"
+msgstr "مفعّل"
+
+#: panels/privacy/cc-privacy-panel.c:928
+msgctxt "Microphone status"
+msgid "Off"
+msgstr "معطّل"
+
+#: panels/privacy/cc-privacy-panel.c:930
+msgctxt "Microphone status"
+msgid "On"
+msgstr "مفعّل"
+
+#: panels/privacy/cc-privacy-panel.c:1036
+#: panels/privacy/cc-privacy-panel.ui:127
+msgid "Usage & History"
+msgstr "الاستخدام والتأريخ"
+
+#: panels/privacy/cc-privacy-panel.c:1157
+msgid "Empty all items from Trash?"
+msgstr "أأحذف كل العناصر من المهملات؟"
+
+#: panels/privacy/cc-privacy-panel.c:1158
+msgid "All items in the Trash will be permanently deleted."
+msgstr "ستحذف نهائيا كل العناصر الموجودة في المهملات."
+
+#: panels/privacy/cc-privacy-panel.c:1159
+msgid "_Empty Trash"
+msgstr "أ_فرغ المهملات"
+
+#: panels/privacy/cc-privacy-panel.c:1180
+msgid "Delete all the temporary files?"
+msgstr "أأحذف كل الملفات المؤقتة؟"
+
+#: panels/privacy/cc-privacy-panel.c:1181
+msgid "All the temporary files will be permanently deleted."
+msgstr "ستُحذف كل الملفات المؤقتة نهائيًا."
+
+#: panels/privacy/cc-privacy-panel.c:1182
+msgid "_Purge Temporary Files"
+msgstr "ت_خلّص من الملفات المؤقتة"
+
+#: panels/privacy/cc-privacy-panel.c:1204
+#: panels/privacy/cc-privacy-panel.ui:432
+msgid "Purge Trash & Temporary Files"
+msgstr "أفرغ المهملات والملفات المؤقتة"
+
+#: panels/privacy/cc-privacy-panel.c:1237
+#: panels/privacy/cc-privacy-panel.ui:637
+msgid "Software Usage"
+msgstr "استخدام البرمجيات"
+
+#: panels/privacy/cc-privacy-panel.c:1276
+#: panels/privacy/cc-privacy-panel.ui:1169
+msgid "Problem Reporting"
+msgstr "الإبلاغ عن المشاكل"
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: panels/privacy/cc-privacy-panel.c:1288
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+"الإبلاغ عن المشاكل التقنية يساعدنا على تحسين %s. ترسل البلاغات مُجهّلة بدون أي "
+"معلومات شخصية."
+
+#: panels/privacy/cc-privacy-panel.c:1300
+#: panels/privacy/cc-privacy-panel.ui:719
+msgid "Privacy Policy"
+msgstr "سياسة الخصوصية"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:14
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "تطفأ الشاشة"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:18
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "٣٠ ثانية"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:22
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "دقيقة واحدة"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:26
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "دقيقتين"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:30
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "٣ دقائق"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:34
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "٥ دقائق"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:38
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "٣٠ دقيقة"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:42
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "ساعة واحدة"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:56
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "ساعة واحدة"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:60
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "يوم واحد"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:64
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "يومين"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:68
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "٣ أيام"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:72
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "٤ أيام"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:76
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "٥ أيام"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:80
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "٦ أيام"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:84
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "٧ أيام"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:88
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "١٤ يومًا"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:92
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "٣٠ يومًا"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/privacy/cc-privacy-panel.ui:106
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "يوم واحد"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/privacy/cc-privacy-panel.ui:110
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "٧ أيام"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/privacy/cc-privacy-panel.ui:114
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "٣٠ يومًا"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/privacy/cc-privacy-panel.ui:118
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "إلى الأبد"
+
+#: panels/privacy/cc-privacy-panel.ui:148
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"تذكر التأريخ يسهل الوصول إلى الأشياء في ما بعد. لا تُشارك هذه العناصر أبدا "
+"عبر الشبكة."
+
+#: panels/privacy/cc-privacy-panel.ui:176
+msgid "_Recently Used"
+msgstr "مستخدمة مؤ_خرا"
+
+#: panels/privacy/cc-privacy-panel.ui:207
+msgid "Retain _History"
+msgstr "احتف_ظ بالتأريخ"
+
+#: panels/privacy/cc-privacy-panel.ui:247
+msgid "Cl_ear Recent History"
+msgstr "امسح التأريخ ال_حالي"
+
+#: panels/privacy/cc-privacy-panel.ui:301
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "قفل الشاشة يحفظ خصوصيتك حين تبتعد عن حاسوبك."
+
+#: panels/privacy/cc-privacy-panel.ui:328
+msgid "Automatic Screen _Lock"
+msgstr "إي_صاد تلقائي للشاشة"
+
+#: panels/privacy/cc-privacy-panel.ui:362
+msgid "Lock screen _after blank for"
+msgstr "أ_وصِد الشاشة بعد إطفائها لمدة"
+
+#: panels/privacy/cc-privacy-panel.ui:394
+msgid "Show _Notifications"
+msgstr "أظهر ال_تنبيهات"
+
+#: panels/privacy/cc-privacy-panel.ui:454
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"تخلص من المهملات والملفات المؤقتة تلقائيا للمحافظة على خلو حاسوبك من "
+"المعلومات الحساسة."
+
+#: panels/privacy/cc-privacy-panel.ui:483
+msgid "Automatically empty _Trash"
+msgstr "أفرغ ال_مهملات تلقائيا"
+
+#: panels/privacy/cc-privacy-panel.ui:515
+msgid "Automatically purge Temporary _Files"
+msgstr "تخلّص من الملفات المؤ_قتة تلقائيا"
+
+#: panels/privacy/cc-privacy-panel.ui:546
+msgid "Purge _After"
+msgstr "أفرف ب_عد"
+
+#: panels/privacy/cc-privacy-panel.ui:590
+msgid "_Empty Trash…"
+msgstr "أ_فرغ المهملات…"
+
+#: panels/privacy/cc-privacy-panel.ui:606
+msgid "_Purge Temporary Files…"
+msgstr "ت_خلّص من الملفات المؤقتة…"
+
+#: panels/privacy/cc-privacy-panel.ui:654
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"إرسال معلومات لنا عن البرمجيات التي تستخدمها يساعدنا على إمدادك بتوصيات أدق، "
+"كما يساعدنا أيضًا على تسحين برمجياتنا.\n"
+"\n"
+"كل المعلومات التي نجمعها مُجهّلة و لن نشاركها أبدًا مع أي طرف ثالث."
+
+#: panels/privacy/cc-privacy-panel.ui:681
+msgid "_Send software usage statistics"
+msgstr "أر_سل إحصائيات استخدام البرمجيات"
+
+#: panels/privacy/cc-privacy-panel.ui:764
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly."
+msgstr ""
+"استخدام الكمرة يتيح للتطبيقات التقاط الصور والفيديو. تعطيل الكمرة قد يتسبب "
+"في ألا تعمل بعض التطبيقات كما يجب."
+
+#: panels/privacy/cc-privacy-panel.ui:812
+msgid "_Camera"
+msgstr "_كمرة"
+
+#: panels/privacy/cc-privacy-panel.ui:869
+msgid ""
+"Use of the microphone allows applications to capture sounds. Disabling the "
+"microphone may cause some applications to not function properly."
+msgstr ""
+"استخدام الميكروفون يتيح للتطبيقات تسجيل الصوت. تعطيل الميكروفون قد يتسبب في "
+"ألا تعمل بعض التطبيقات كما يجب."
+
+#: panels/privacy/cc-privacy-panel.ui:917
+msgid "_Microphone"
+msgstr "_ميكروفون"
+
+#: panels/privacy/cc-privacy-panel.ui:974
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"تسمح خدمات التموضع للتطبيقات بمعرفة مكانك. استخدام الشبكات اللاسلكية "
+"و الهاتف المحمول يزيد من دقة هذه الخدمات."
+
+#: panels/privacy/cc-privacy-panel.ui:988
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+"يستخدم خدمة تموضع موزيلا: <a href='https://location.services.mozilla.com/"
+"privacy'>سياسة الخصوصية</a>"
+
+#: panels/privacy/cc-privacy-panel.ui:1038
+msgid "_Location Services"
+msgstr "خدمات ال_تموضع"
+
+#: panels/privacy/cc-privacy-panel.ui:1236
+msgid "_Automatic Problem Reporting"
+msgstr "الإبلاغ التل_قائي عن المشاكل"
+
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:3
+msgid "Privacy"
+msgstr "الخصوصية"
+
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
+msgid "Protect your personal information and control what others might see"
+msgstr "احمِ بياناتك الشخصية و تحكم في ما يمكن للآخرين الاطلاع عليه منها"
+
+#. FIXME
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:8
+msgid "preferences-system-privacy"
+msgstr "preferences-system-privacy"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr "شاشة;قفل;تشخيص;تحطم;خاص;حديث;مؤقت;شبكة;هوية;"
+
+#: panels/region/cc-format-chooser.c:114
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "إمبراطوري"
+
+#: panels/region/cc-format-chooser.c:116
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "متري"
+
+#: panels/region/cc-format-chooser.c:286
+msgid "No regions found"
+msgstr "لا يوجد أي مناطق"
+
+#: panels/region/cc-format-chooser.ui:7
+msgid "Formats"
+msgstr "النُسق"
+
+#: panels/region/cc-format-chooser.ui:106
+msgid "Preview"
+msgstr "معاينة"
+
+#: panels/region/cc-format-chooser.ui:123
+msgid "Dates"
+msgstr "التّواريخ"
+
+#: panels/region/cc-format-chooser.ui:154
+msgid "Times"
+msgstr "الوقت"
+
+#: panels/region/cc-format-chooser.ui:185
+msgid "Dates & Times"
+msgstr "التاريخ و الوقت"
+
+#: panels/region/cc-format-chooser.ui:216
+msgid "Numbers"
+msgstr "الأرقام"
+
+#: panels/region/cc-format-chooser.ui:233
+msgid "Measurement"
+msgstr "القياس"
+
+#: panels/region/cc-format-chooser.ui:250
+msgid "Paper"
+msgstr "الورق"
+
+#: panels/region/cc-input-chooser.c:193
+msgid "No input sources found"
+msgstr "لا يوجد أي مصادر إدخال"
+
+#: panels/region/cc-input-chooser.c:948
+msgctxt "Input Source"
+msgid "Other"
+msgstr "أخرى"
+
+#: panels/region/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "أضف مصْدَر إدخال"
+
+#: panels/region/cc-input-chooser.ui:77
+msgid "Input methods can’t be used on the login screen"
+msgstr "لا يمكن استخدام مصادر الإدخال في شاشة الولوج"
+
+#: panels/region/cc-region-panel.c:1505
+msgid "Login _Screen"
+msgstr "شاشة الو_لوج"
+
+#: panels/region/cc-region-panel.ui:64
+#: panels/user-accounts/cc-user-panel.ui:362
+msgid "_Language"
+msgstr "الل_غة"
+
+#: panels/region/cc-region-panel.ui:99
+msgid "Restart the session for changes to take effect"
+msgstr "يجب إعادة تشغيل الجلسة لتطبيق التغييرات"
+
+#: panels/region/cc-region-panel.ui:114
+msgid "Restart…"
+msgstr "أعِد التشغيل…"
+
+#: panels/region/cc-region-panel.ui:147
+msgid "_Formats"
+msgstr "ال_نُسق"
+
+#: panels/region/cc-region-panel.ui:195
+msgid "Input Sources"
+msgstr "مصادر الإدخال"
+
+#: panels/region/cc-region-panel.ui:209
+msgid "Choose keyboard layouts or input methods."
+msgstr "اختر تخطيط لوحة المفاتيح وطرق الإدخال"
+
+#: panels/region/cc-region-panel.ui:266
+msgid "No input source selected"
+msgstr "لم تحدد أي مصادر إدخال"
+
+#: panels/region/cc-region-panel.ui:300
+msgid "Login settings are used by all users when logging into the system"
+msgstr "يستخدم إعدادات الولوج كل المستخدمين أثناء الولوج إلى النظام"
+
+#: panels/region/cc-region-panel.ui:338
+msgid "Input Source Options"
+msgstr "خيارات مصْدَر الإدخال"
+
+#: panels/region/cc-region-panel.ui:353
+msgid "Use the _same source for all windows"
+msgstr "استخدم _نفس المصدر لكل النوافذ"
+
+#: panels/region/cc-region-panel.ui:371
+msgid "Allow _different sources for each window"
+msgstr "ا_سمح بمصدر مختلف لكل نافذة"
+
+#: panels/region/cc-region-panel.ui:413
+msgid "Previous source"
+msgstr "المصدر السابق"
+
+#: panels/region/cc-region-panel.ui:431
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: panels/region/cc-region-panel.ui:446
+msgid "Next source"
+msgstr "المصدر التالي"
+
+#: panels/region/cc-region-panel.ui:464
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: panels/region/cc-region-panel.ui:479
+msgid "Left+Right Alt"
+msgstr "Left+Right Alt"
+
+#: panels/region/cc-region-panel.ui:495
+msgid "These keyboard shortcuts can be changed in the keyboard settings"
+msgstr "يمكن تغيير هذه الاختصارات من إعدادات لوحة المفاتيح"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "المنطقة و اللغة"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr "اختر لغة العرض و التنسيق و تخطيط لوحة المفاتيح و مصادر الإدخال"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/region/gnome-region-panel.desktop.in.in:7
+msgid "preferences-desktop-locale"
+msgstr "preferences-desktop-locale"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "اللغة;التخطيط;مفاتيح;"
+
+#: panels/search/cc-search-locations-dialog.c:604
+msgid "Select Location"
+msgstr "اختر مكانًا"
+
+#: panels/search/cc-search-locations-dialog.c:608
+msgid "_OK"
+msgstr "_نعم"
+
+#: panels/search/cc-search-panel.c:175
+msgid "No applications found"
+msgstr "لا يوجد أي تطبيقات"
+
+#: panels/search/cc-search-panel.ui:52
+msgid "Move Up"
+msgstr "انقل لأعلى"
+
+#: panels/search/cc-search-panel.ui:69
+msgid "Move Down"
+msgstr "انقل لأسفل"
+
+#: panels/search/cc-search-panel.ui:105
+msgid "Preferences"
+msgstr "التفضيلات"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "تحكم في التطبيقات التي ستُعرض نتائج البحث منها في منظور الأنشطة"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/search/gnome-search-panel.desktop.in.in:7
+msgid "preferences-system-search"
+msgstr "preferences-system-search"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "بحث;إخفاء;نتائج;خصوصية;"
+
+#: panels/search/search-locations-dialog.ui:9
+msgid "Search Locations"
+msgstr "أماكن البحث"
+
+#: panels/search/search-locations-dialog.ui:43
+msgid "Places"
+msgstr "الأماكن"
+
+#: panels/search/search-locations-dialog.ui:73
+msgid "Bookmarks"
+msgstr "العلامات"
+
+#: panels/search/search-locations-dialog.ui:130
+msgid "Other"
+msgstr "أخرى"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:307
+msgid "No networks selected for sharing"
+msgstr "لم تختر أي شبكة لمشاركتها"
+
+#: panels/sharing/cc-sharing-panel.c:319
+msgctxt "service is enabled"
+msgid "On"
+msgstr "مفعّل"
+
+#: panels/sharing/cc-sharing-panel.c:321 panels/sharing/cc-sharing-panel.c:348
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "معطّل"
+
+#: panels/sharing/cc-sharing-panel.c:351
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "مفعّل"
+
+#: panels/sharing/cc-sharing-panel.c:354
+msgctxt "service is active"
+msgid "Active"
+msgstr "نشِط"
+
+#: panels/sharing/cc-sharing-panel.c:424
+msgid "Choose a Folder"
+msgstr "اختر مجلّدًا"
+
+#: panels/sharing/cc-sharing-panel.c:724
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"تتيح لك ”مشاركة الملفات“ مشاركة المجلد العام مع الآخرين على الشبكة الحالية "
+"باستخدام: <a href=\"dav://%s\">‪dav://%s‬</a>"
+
+#: panels/sharing/cc-sharing-panel.c:726
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"عند تفعيل بالولوج عن بعد، يمكن للمستخدمين الولوج عن بعد باستخدام أمر الصدفة "
+"الآمنة:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:728
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"مشاركة الشاشة تسمح للمستخدمين عن بعد بالتحكم في شاشتك باستخدام: <a href="
+"\"vnc://%s\">‪vnc://%s‬</a>"
+
+#: panels/sharing/cc-sharing-panel.c:832
+msgid "Copy"
+msgstr "انسخ"
+
+#: panels/sharing/cc-sharing-panel.c:1285
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "المشاركة"
+
+#: panels/sharing/cc-sharing-panel.ui:50
+msgid "_Computer Name"
+msgstr "ا_سم الحاسوب"
+
+#: panels/sharing/cc-sharing-panel.ui:108
+msgid "_File Sharing"
+msgstr "م_شاركة الملفات"
+
+#: panels/sharing/cc-sharing-panel.ui:151
+msgid "_Screen Sharing"
+msgstr "مشار_كة الشاشة"
+
+#: panels/sharing/cc-sharing-panel.ui:194
+msgid "_Media Sharing"
+msgstr "مشاركة الوسائ_ط"
+
+#: panels/sharing/cc-sharing-panel.ui:237
+msgid "_Remote Login"
+msgstr "الولوج عن ب_عد"
+
+#: panels/sharing/cc-sharing-panel.ui:276
+msgid "Some services are disabled because of no network access."
+msgstr "بعض الأجهزة معطل لتعذّر الوصول الشبكي."
+
+#: panels/sharing/cc-sharing-panel.ui:292
+#: panels/sharing/cc-sharing-panel.ui:419
+msgid "File Sharing"
+msgstr "مشاركة الملفات"
+
+#: panels/sharing/cc-sharing-panel.ui:339
+msgid "_Require Password"
+msgstr "ا_طلب كلمة سر"
+
+#: panels/sharing/cc-sharing-panel.ui:430
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Remote Login"
+msgstr "الولوج عن بعد"
+
+#: panels/sharing/cc-sharing-panel.ui:525
+#: panels/sharing/cc-sharing-panel.ui:771
+msgid "Screen Sharing"
+msgstr "مشاركة الشاشة"
+
+#: panels/sharing/cc-sharing-panel.ui:583
+msgid "_Allow connections to control the screen"
+msgstr "ا_سمح للاتصالات بالتحكم في الشاشة"
+
+#: panels/sharing/cc-sharing-panel.ui:628
+msgid "_Password:"
+msgstr "كلمة ال_سر:"
+
+#: panels/sharing/cc-sharing-panel.ui:658
+msgid "_Show Password"
+msgstr "أ_ظهر كلمة السر"
+
+#: panels/sharing/cc-sharing-panel.ui:689
+msgid "Access Options"
+msgstr "خيارات النفاذ"
+
+#: panels/sharing/cc-sharing-panel.ui:703
+msgid "_New connections must ask for access"
+msgstr "يجب على الاتصالات الجديدة أن ت_طلب النفاذ"
+
+#: panels/sharing/cc-sharing-panel.ui:721
+msgid "_Require a password"
+msgstr "ا_طلب كلمة سر"
+
+#: panels/sharing/cc-sharing-panel.ui:782
+#: panels/sharing/cc-sharing-panel.ui:876
+msgid "Media Sharing"
+msgstr "مشاركة الوسائط"
+
+#: panels/sharing/cc-sharing-panel.ui:815
+msgid "Share music, photos and videos over the network."
+msgstr "شارك الموسيقى و الصور و الڤديو مع الآخرين على الشبكة."
+
+#: panels/sharing/cc-sharing-panel.ui:830
+msgid "Folders"
+msgstr "المجلدات"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "تحكم في ما تريد مشاركته مع الآخرين"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:7
+msgid "preferences-system-sharing"
+msgstr "preferences-system-sharing"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr "مشاركة;شارك;اسم;مكتب;بعيد;بلوتوث;صوت;صورة;وسائط;"
+
+#: panels/sharing/networks.ui:19
+msgid "Networks"
+msgstr "الشبكات"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "فعّل أو عطّل الولوج عن بعد"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "الاستيثاق مطلوب لتفعيل أو تعطيل الولوج عن بعد"
+
+#: panels/sound/cc-alert-chooser.c:151
+msgid "Custom"
+msgstr "مخصص"
+
+#: panels/sound/cc-alert-chooser.ui:12 panels/sound/cc-alert-selector.ui:9
+msgid "Bark"
+msgstr "نباح"
+
+#: panels/sound/cc-alert-chooser.ui:19 panels/sound/cc-alert-selector.ui:15
+msgid "Drip"
+msgstr "قطرات"
+
+#: panels/sound/cc-alert-chooser.ui:26 panels/sound/cc-alert-selector.ui:21
+msgid "Glass"
+msgstr "زجاج"
+
+#: panels/sound/cc-alert-chooser.ui:33 panels/sound/cc-alert-selector.ui:27
+msgid "Sonar"
+msgstr "سونار"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "الخلفية"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "المقدمة"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "يختبر %s"
+
+#: panels/sound/cc-output-test-dialog.ui:127
+msgid "Click a speaker to test"
+msgstr "انقر على السماعة لاختبارها"
+
+#: panels/sound/cc-sound-panel.ui:29
+msgid "System Volume"
+msgstr "شدة صوت النظام"
+
+#: panels/sound/cc-sound-panel.ui:45
+msgid "Volume Levels"
+msgstr "مستويات الصوت"
+
+#: panels/sound/cc-sound-panel.ui:67
+msgid "Output"
+msgstr "المَخْرَج"
+
+#: panels/sound/cc-sound-panel.ui:94
+msgid "Output Device"
+msgstr "جهاز إخراج"
+
+#: panels/sound/cc-sound-panel.ui:117
+msgid "Test"
+msgstr "اختبِر"
+
+#: panels/sound/cc-sound-panel.ui:148 panels/sound/cc-sound-panel.ui:325
+msgid "Configuration"
+msgstr "الإعدادات"
+
+#: panels/sound/cc-sound-panel.ui:181
+msgid "Balance"
+msgstr "التوازن"
+
+#: panels/sound/cc-sound-panel.ui:208
+msgid "Fade"
+msgstr "التلاشي"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Subwoofer"
+msgstr "سماعات كبيرة"
+
+#: panels/sound/cc-sound-panel.ui:257
+msgid "Input"
+msgstr "المَدخَل"
+
+#: panels/sound/cc-sound-panel.ui:284
+msgid "Input Device"
+msgstr "جهاز إدخال"
+
+#: panels/sound/cc-sound-panel.ui:358
+msgid "Volume"
+msgstr "شدة الصوت"
+
+#: panels/sound/cc-sound-panel.ui:380
+msgid "Alert Sound"
+msgstr "صوت التنبيه"
+
+#: panels/sound/cc-volume-slider.c:178
+msgctxt "volume"
+msgid "100%"
+msgstr "١٠٠٪"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "الصوت"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "غيّر شدة الصوت و أصوات التنبيهات"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/sound/gnome-sound-panel.desktop.in.in:7
+msgid "multimedia-volume-control"
+msgstr "multimedia-volume-control"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "بطاقة;ميكروفون;صوت;شدة;توازن;بلوتوث;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:94
+#: panels/thunderbolt/cc-bolt-device-entry.c:125
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "غير متّصل"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:97
+#: panels/thunderbolt/cc-bolt-device-entry.c:128
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "يتّصل"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:100
+#: panels/thunderbolt/cc-bolt-device-entry.c:132
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "متّصل"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:103
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "عطل في التخويل"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:106
+#: panels/thunderbolt/cc-bolt-device-entry.c:138
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "يخوّل"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "وظيفية مقللة"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:115
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "متّصل ومخوّل"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:121
+#: panels/thunderbolt/cc-bolt-device-entry.c:152
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "غير معروف"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:177
+msgid "Authorized at:"
+msgstr "مخوّل في:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:183
+msgid "Connected at:"
+msgstr "متّصل في:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:190
+msgid "Enrolled at:"
+msgstr "سجّل في:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:264
+msgid "Failed to authorize device: "
+msgstr "فشل تخويل الجهاز:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:333
+msgid "Failed to forget device: "
+msgstr "فشل نسيان الجهاز:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "لا يعتمد على أجهزة أخرى"
+msgstr[1] "يعتمد على جهاز آخر"
+msgstr[2] "يعتمد على جهازين آخر"
+msgstr[3] "لا يعتمد على %u أجهزة أخرى"
+msgstr[4] "لا يعتمد على %u جهازًا آخر"
+msgstr[5] "لا يعتمد على %u جهاز آخر"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+msgid "Name:"
+msgstr "الاسم:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "Status:"
+msgstr "الحالة:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+msgid "Authorize and Connect"
+msgstr "خوّل واتصل"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+msgid "Forget Device"
+msgstr "انس الجهاز"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:135
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "عُطل"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:146
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "مخوّل"
+
+#: panels/thunderbolt/cc-bolt-panel.c:176
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:469
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:513
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:517
+#, fuzzy
+msgid "Thunderbolt security level could not be determined."
+msgstr "تعذّر توليد الإعدادات."
+
+#: panels/thunderbolt/cc-bolt-panel.c:622
+#, fuzzy, c-format
+msgid "Error switching direct mode: %s"
+msgstr "عطل في تحديد مُرسِل البريد المبدئي: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:143
+msgid "No Thunderbolt support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:246
+msgid "Direct Access"
+msgstr "وصول مباشرة"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:269
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:289
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:397
+#, fuzzy
+msgid "Pending Devices"
+msgstr "يجلب الأجهزة..."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:535
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:7
+msgid "thunderbolt"
+msgstr ""
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;"
+msgstr ""
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:498
+msgctxt "cursor size"
+msgid "Default"
+msgstr "المبدئي"
+
+#: panels/universal-access/cc-ua-panel.c:501
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "متوسط"
+
+#: panels/universal-access/cc-ua-panel.c:504
+msgctxt "cursor size"
+msgid "Large"
+msgstr "كبير"
+
+#: panels/universal-access/cc-ua-panel.c:507
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "أكبر"
+
+#: panels/universal-access/cc-ua-panel.c:510
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "الأكبر"
+
+#: panels/universal-access/cc-ua-panel.c:514
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d بكسل"
+msgstr[1] "%d بكسل"
+msgstr[2] "%d بكسل"
+msgstr[3] "%d بكسل"
+msgstr[4] "%d بكسل"
+msgstr[5] "%d بكسل"
+
+#: panels/universal-access/cc-ua-panel.ui:93
+msgid "_Always Show Universal Access Menu"
+msgstr "اعرض قائمة الإتاحة _دائمًا"
+
+#: panels/universal-access/cc-ua-panel.ui:135
+msgid "Seeing"
+msgstr "النظر"
+
+#: panels/universal-access/cc-ua-panel.ui:181
+msgid "_High Contrast"
+msgstr "تباين _عال"
+
+#: panels/universal-access/cc-ua-panel.ui:228
+msgid "_Large Text"
+msgstr "نص _كبير"
+
+#: panels/universal-access/cc-ua-panel.ui:273
+msgid "C_ursor Size"
+msgstr "حجم المؤ_شر"
+
+#: panels/universal-access/cc-ua-panel.ui:320
+#: panels/universal-access/zoom-options.ui:99
+msgid "_Zoom"
+msgstr "ال_تقريب"
+
+#: panels/universal-access/cc-ua-panel.ui:366
+msgid "Screen _Reader"
+msgstr "قار_ئ الشاشة"
+
+#: panels/universal-access/cc-ua-panel.ui:412
+#: panels/universal-access/cc-ua-panel.ui:1243
+msgid "_Sound Keys"
+msgstr "مفاتيح الصو_ت"
+
+#: panels/universal-access/cc-ua-panel.ui:474
+msgid "Hearing"
+msgstr "السمع"
+
+#: panels/universal-access/cc-ua-panel.ui:518
+#: panels/universal-access/cc-ua-panel.ui:1346
+msgid "_Visual Alerts"
+msgstr "تنبيهات ب_صرية"
+
+#: panels/universal-access/cc-ua-panel.ui:626
+msgid "Screen _Keyboard"
+msgstr "لوحة م_فاتيح على الشاشة"
+
+#: panels/universal-access/cc-ua-panel.ui:671
+msgid "R_epeat Keys"
+msgstr "_تكرار المفاتيح"
+
+#: panels/universal-access/cc-ua-panel.ui:717
+msgid "Cursor _Blinking"
+msgstr "وميض ال_مؤشر"
+
+#: panels/universal-access/cc-ua-panel.ui:763
+msgid "_Typing Assist (AccessX)"
+msgstr "م_ساعدة الكتابة"
+
+#: panels/universal-access/cc-ua-panel.ui:824
+msgid "Pointing & Clicking"
+msgstr "التأشير و النقر"
+
+#: panels/universal-access/cc-ua-panel.ui:870
+msgid "_Mouse Keys"
+msgstr "مفاتيح ال_فأرة"
+
+#: panels/universal-access/cc-ua-panel.ui:915
+msgid "_Click Assist"
+msgstr "مساعدة الن_قر"
+
+#: panels/universal-access/cc-ua-panel.ui:961
+msgid "_Double-Click Delay"
+msgstr "مهلة الن_قر المزدوج"
+
+#: panels/universal-access/cc-ua-panel.ui:981
+msgid "Double-Click Delay"
+msgstr "مهلة النقر المزدوج"
+
+#: panels/universal-access/cc-ua-panel.ui:1048
+msgid "Cursor Size"
+msgstr "حجم المؤشر"
+
+#: panels/universal-access/cc-ua-panel.ui:1075
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "يمكن تغيير حجم المؤشر مع مستوى التقريب لتسهيل رؤية المؤشر."
+
+#: panels/universal-access/cc-ua-panel.ui:1111
+msgid "Screen Reader"
+msgstr "قارئ الشاشة"
+
+#: panels/universal-access/cc-ua-panel.ui:1128
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "يقرأ قارئ الشاشة النص أثناء تحريكك للبؤرة."
+
+#: panels/universal-access/cc-ua-panel.ui:1161
+msgid "_Screen Reader"
+msgstr "قارئ ال_شاشة"
+
+#: panels/universal-access/cc-ua-panel.ui:1200
+msgid "Sound Keys"
+msgstr "مفاتيح الصوت"
+
+#: panels/universal-access/cc-ua-panel.ui:1218
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "أصدر صفيرًا عند تفعيل أو تعطيل قفل الأرقام أو الحروف الكبيرة."
+
+#: panels/universal-access/cc-ua-panel.ui:1288
+msgid "Visual Alerts"
+msgstr "التنبيهات البصرية"
+
+#: panels/universal-access/cc-ua-panel.ui:1292
+msgid "_Test flash"
+msgstr "ا_ختبر الوميض"
+
+#: panels/universal-access/cc-ua-panel.ui:1321
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "أظهر مؤشرًا بصريًا عند حدوث تنبيه صوتي."
+
+#: panels/universal-access/cc-ua-panel.ui:1372
+msgid "Flash the _window title"
+msgstr "أومض _عنوان النافذة"
+
+#: panels/universal-access/cc-ua-panel.ui:1390
+msgid "Flash the entire _screen"
+msgstr "أومض _كل الشاشة"
+
+#: panels/universal-access/cc-ua-panel.ui:1435
+msgid "Repeat Keys"
+msgstr "تكرار المفاتيح"
+
+#: panels/universal-access/cc-ua-panel.ui:1465
+msgid "Key presses repeat when key is held down."
+msgstr "تكرار نقر المفتاح عند الضغط عليه."
+
+#: panels/universal-access/cc-ua-panel.ui:1545
+msgid "Repeat keys delay"
+msgstr "مهلة تكرار المفاتيح"
+
+#: panels/universal-access/cc-ua-panel.ui:1593
+#: panels/universal-access/cc-ua-panel.ui:1728
+msgid "Speed"
+msgstr "السرعة"
+
+#: panels/universal-access/cc-ua-panel.ui:1632
+msgid "Repeat keys speed"
+msgstr "سرعة تكرار المفاتيح"
+
+#: panels/universal-access/cc-ua-panel.ui:1656
+msgid "Cursor Blinking"
+msgstr "وميض المؤشر"
+
+#: panels/universal-access/cc-ua-panel.ui:1686
+msgid "Cursor blinks in text fields."
+msgstr "ومضات المؤشر في حقول النصوص."
+
+#: panels/universal-access/cc-ua-panel.ui:1765
+msgid "Cursor blinking speed"
+msgstr "سرعة ومضات المؤشر"
+
+#: panels/universal-access/cc-ua-panel.ui:1801
+msgid "Typing Assist"
+msgstr "مساعدة الكتابة"
+
+#: panels/universal-access/cc-ua-panel.ui:1840
+msgid "_Sticky Keys"
+msgstr "مفاتيح لا_صقة"
+
+#: panels/universal-access/cc-ua-panel.ui:1857
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "تعتبر تتابعا من المفاتيح المُغيِّرة كما لو كان اختصارا"
+
+#: panels/universal-access/cc-ua-panel.ui:1881
+msgid "_Disable if two keys are pressed together"
+msgstr "_عطِّل إذا ضُغط مفتاحان في آن واحد"
+
+#: panels/universal-access/cc-ua-panel.ui:1899
+msgid "Beep when a _modifier key is pressed"
+msgstr "صفّر عند ضغط مفاتيح الم_غيّرات"
+
+#: panels/universal-access/cc-ua-panel.ui:1947
+msgid "S_low Keys"
+msgstr "مفاتيح ب_طيئة"
+
+#: panels/universal-access/cc-ua-panel.ui:1964
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "تضع تأخيرا بين ضغط المفتاح وقبوله"
+
+#: panels/universal-access/cc-ua-panel.ui:1997
+#: panels/universal-access/cc-ua-panel.ui:2210
+#: panels/universal-access/cc-ua-panel.ui:2547
+msgid "A_cceptance delay:"
+msgstr "تأخير ال_قبول:"
+
+#: panels/universal-access/cc-ua-panel.ui:2019
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "قصير"
+
+#: panels/universal-access/cc-ua-panel.ui:2038
+msgid "Slow keys typing delay"
+msgstr "تأخير الكتابة للمفاتيح البطيئة"
+
+#: panels/universal-access/cc-ua-panel.ui:2053
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "طويل"
+
+#: panels/universal-access/cc-ua-panel.ui:2080
+msgid "Beep when a key is pr_essed"
+msgstr "صفّر عند ض_غط مفتاح"
+
+#: panels/universal-access/cc-ua-panel.ui:2097
+msgid "Beep when a key is _accepted"
+msgstr "صفّر عند _قُبول مفتاح"
+
+#: panels/universal-access/cc-ua-panel.ui:2114
+#: panels/universal-access/cc-ua-panel.ui:2293
+msgid "Beep when a key is _rejected"
+msgstr "صفّر إذا _رُفض مفتاح"
+
+#: panels/universal-access/cc-ua-panel.ui:2160
+msgid "_Bounce Keys"
+msgstr "مفاتيح _قافزة"
+
+#: panels/universal-access/cc-ua-panel.ui:2177
+msgid "Ignores fast duplicate keypresses"
+msgstr "تجاهل الضغطات المكررة السريعة للمفاتيح"
+
+#: panels/universal-access/cc-ua-panel.ui:2232
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "قصير"
+
+#: panels/universal-access/cc-ua-panel.ui:2251
+msgid "Bounce keys typing delay"
+msgstr "تأخير الكتابة للمفاتيح القافزة"
+
+#: panels/universal-access/cc-ua-panel.ui:2266
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "طويل"
+
+#: panels/universal-access/cc-ua-panel.ui:2379
+msgid "_Enable by Keyboard"
+msgstr "فعّل من _لوحة المفاتيح"
+
+#: panels/universal-access/cc-ua-panel.ui:2396
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "فعّل أو عطّل خصائص الإتاحة باستخدام لوحة المفاتيح"
+
+#: panels/universal-access/cc-ua-panel.ui:2460
+msgid "Click Assist"
+msgstr "مساعدة النقر"
+
+#: panels/universal-access/cc-ua-panel.ui:2496
+msgid "_Simulated Secondary Click"
+msgstr "م_حاكاة النقر الثانوي"
+
+#: panels/universal-access/cc-ua-panel.ui:2514
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "ابتدئ نقرة ثانوية عن طريق الاستمرار بضغط الزر الأولي"
+
+#: panels/universal-access/cc-ua-panel.ui:2568
+msgctxt "secondary click"
+msgid "Short"
+msgstr "قصير"
+
+#: panels/universal-access/cc-ua-panel.ui:2587
+msgid "Secondary click delay"
+msgstr "تأخير النقر الثانوي"
+
+#: panels/universal-access/cc-ua-panel.ui:2602
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "طويل"
+
+#: panels/universal-access/cc-ua-panel.ui:2659
+msgid "_Hover Click"
+msgstr "النقر ال_سلبي"
+
+#: panels/universal-access/cc-ua-panel.ui:2677
+msgid "Trigger a click when the pointer hovers"
+msgstr "ابتدئ نقرة عند حومان المؤشر"
+
+#: panels/universal-access/cc-ua-panel.ui:2710
+msgid "D_elay:"
+msgstr "ال_تأخير:"
+
+#: panels/universal-access/cc-ua-panel.ui:2732
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "قصير"
+
+#: panels/universal-access/cc-ua-panel.ui:2763
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "طويل"
+
+#: panels/universal-access/cc-ua-panel.ui:2799
+msgid "Motion _threshold:"
+msgstr "عتبة الحر_كة:"
+
+#: panels/universal-access/cc-ua-panel.ui:2821
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "صغير"
+
+#: panels/universal-access/cc-ua-panel.ui:2852
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "كبير"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "اجعل الرؤية و السماع و الكتابة و المؤشر أسهل"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:7
+msgid "preferences-desktop-accessibility"
+msgstr "preferences-desktop-accessibility"
+
+#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
+"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
+"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+msgstr ""
+"لوحة المفاتيح;الفأرة;الإتاحة;التباين;التقريب;التكبير;قارئ "
+"الشاشة;النص;الخط;الحجم;مفاتيح ملتصقة;مفاتيح بطيئة;مفاتيح قافزة;مفاتيح الفأرة;"
+
+#: panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "Short"
+msgstr "قصيرة"
+
+#: panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ الشاشة"
+
+#: panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ الشاشة"
+
+#: panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ الشاشة"
+
+#: panels/universal-access/zoom-options.c:338
+msgctxt "Distance"
+msgid "Long"
+msgstr "طويلة"
+
+#: panels/universal-access/zoom-options.ui:48
+msgid "Full Screen"
+msgstr "ملء الشاشة"
+
+#: panels/universal-access/zoom-options.ui:53
+msgid "Top Half"
+msgstr "النصف العلوي"
+
+#: panels/universal-access/zoom-options.ui:58
+msgid "Bottom Half"
+msgstr "النصف السفلي"
+
+#: panels/universal-access/zoom-options.ui:63
+msgid "Left Half"
+msgstr "النصف الأيسر"
+
+#: panels/universal-access/zoom-options.ui:68
+msgid "Right Half"
+msgstr "النصف الأيمن"
+
+#: panels/universal-access/zoom-options.ui:78
+msgid "Zoom Options"
+msgstr "خيارات التقريب"
+
+#: panels/universal-access/zoom-options.ui:185
+msgid "_Magnification:"
+msgstr "ال_تكبير:"
+
+#: panels/universal-access/zoom-options.ui:249
+msgid "_Follow mouse cursor"
+msgstr "يتبع مؤشر ال_فأرة"
+
+#: panels/universal-access/zoom-options.ui:269
+msgid "_Screen part:"
+msgstr "جزء من ال_شاشة:"
+
+#: panels/universal-access/zoom-options.ui:331
+msgid "Magnifier _extends outside of screen"
+msgstr "المكبرة تمتد ل_خارج الشاشة"
+
+#: panels/universal-access/zoom-options.ui:350
+msgid "_Keep magnifier cursor centered"
+msgstr "أبق مؤشر المكبرة متمركزًا"
+
+#: panels/universal-access/zoom-options.ui:369
+msgid "Magnifier cursor _pushes contents around"
+msgstr "مؤشر المكبرة يحرك الم_حتوى"
+
+#: panels/universal-access/zoom-options.ui:388
+msgid "Magnifier cursor moves with _contents"
+msgstr "مؤشر المكبرة يتحرك مع المح_توى"
+
+#: panels/universal-access/zoom-options.ui:422
+msgid "Magnifier Position:"
+msgstr "موضع المُكبِّرة:"
+
+#: panels/universal-access/zoom-options.ui:443
+msgid "Magnifier"
+msgstr "المكبّرة"
+
+#: panels/universal-access/zoom-options.ui:490
+msgid "_Thickness:"
+msgstr "ال_سماكة:"
+
+#: panels/universal-access/zoom-options.ui:516
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "نحيف"
+
+#: panels/universal-access/zoom-options.ui:548
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "سميك"
+
+#: panels/universal-access/zoom-options.ui:574
+msgid "_Length:"
+msgstr "ال_طول:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/zoom-options.ui:623
+msgid "Co_lor:"
+msgstr "اللو_ن:"
+
+#: panels/universal-access/zoom-options.ui:687
+msgid "_Crosshairs:"
+msgstr "م_حاور الهدف:"
+
+#: panels/universal-access/zoom-options.ui:735
+msgid "_Overlaps mouse cursor"
+msgstr "يغطي على مؤ_شر الفأرة"
+
+#: panels/universal-access/zoom-options.ui:773
+msgid "Crosshairs"
+msgstr "محاور الهدف"
+
+#: panels/universal-access/zoom-options.ui:822
+msgid "_White on black:"
+msgstr "أبيض على أ_سود:"
+
+#: panels/universal-access/zoom-options.ui:842
+msgid "_Brightness:"
+msgstr "ال_سطوع:"
+
+#: panels/universal-access/zoom-options.ui:863
+msgid "_Contrast:"
+msgstr "ال_تباين:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/zoom-options.ui:883
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "اللو_ن"
+
+#: panels/universal-access/zoom-options.ui:908
+msgctxt "universal access, color"
+msgid "None"
+msgstr "لا شيء"
+
+#: panels/universal-access/zoom-options.ui:940
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "كامل"
+
+#: panels/universal-access/zoom-options.ui:1003
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "منخفض"
+
+#: panels/universal-access/zoom-options.ui:1036
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "عال"
+
+#: panels/universal-access/zoom-options.ui:1067
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "منخفض"
+
+#: panels/universal-access/zoom-options.ui:1100
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "عال"
+
+#: panels/universal-access/zoom-options.ui:1136
+msgid "Color Effects:"
+msgstr "المؤثرات اللونية:"
+
+#: panels/universal-access/zoom-options.ui:1161
+msgid "Color Effects"
+msgstr "المؤثرات اللونية"
+
+#: panels/user-accounts/cc-add-user-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "يجب أن تطابق عنوان الوب لمُزود الولوج."
+
+#: panels/user-accounts/cc-add-user-dialog.c:204
+msgid "Failed to add account"
+msgstr "فشلت إضافة الحساب"
+
+#: panels/user-accounts/cc-add-user-dialog.c:652
+#: panels/user-accounts/cc-password-dialog.c:261
+msgid "The passwords do not match."
+msgstr "لا تتطابق كلمتا السر."
+
+#: panels/user-accounts/cc-add-user-dialog.c:874
+#: panels/user-accounts/cc-add-user-dialog.c:920
+#: panels/user-accounts/cc-add-user-dialog.c:941
+msgid "Failed to register account"
+msgstr "فشل تسجيل المستخدم"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1064
+msgid "No supported way to authenticate with this domain"
+msgstr "لا توجد طريقة مدعومة للاستيثاق مع هذا النطاق"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1137
+msgid "Failed to join domain"
+msgstr "فشل الانضمام إلى النطاق"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1198
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"اسم الولوج لم يعمل.\n"
+"من فضلك أعد المحاولة"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1205
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"كلمة سر الولوج لم تعمل.\n"
+"من فضلك أعد المحاولة"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1213
+msgid "Failed to log into domain"
+msgstr "فشل الولوج إلى النطاق"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1271
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "تعذّر العثور على النطاق. هل أخطأت في كتابته؟"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "أضف مستخدما"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:180
+msgid "_Full Name"
+msgstr "الاسم بال_كامل"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:206
+#: panels/user-accounts/cc-user-panel.ui:151
+msgid "Standard"
+msgstr "عادي"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-user-panel.ui:161
+msgid "Administrator"
+msgstr "إداري"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:232
+#: panels/user-accounts/cc-user-panel.ui:179
+msgid "Account _Type"
+msgstr "_نوع الحساب"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:269
+msgid "Allow user to set a password when they next _login"
+msgstr "اسمح للمستخدم بوضع كلمة سر عند الولوج ال_تالي"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:283
+msgid "Set a password _now"
+msgstr "_ضع كلمة سر الآن"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:405
+msgid "_Confirm"
+msgstr "أ_كّد"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:485
+#: panels/user-accounts/cc-add-user-dialog.ui:692
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"ولوج المؤسسات يسمح باستخدام حساب مستخدم مدار مركزيًا على هذا الجهاز. يمكنك "
+"أيضًا استخدام هذا الحساب للوصول إلى موارد الشركة على الإنترنت."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:507
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "الن_طاق"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:732
+msgid "You are Offline"
+msgstr "لست متّصلا"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:751
+msgid "You must be online in order to add enterprise users."
+msgstr "يجب أن تكون متصلا لإضافة حسابات ولوج مؤسسات."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:782
+msgid "_Enterprise Login"
+msgstr "ولوج ال_مؤسسات"
+
+#: panels/user-accounts/cc-avatar-chooser.c:231
+msgid "Browse for more pictures"
+msgstr "تصفّح لمزيد من الصور"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:27
+msgid "Take a Picture…"
+msgstr "التقط صورة…"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:34
+msgid "Select a File…"
+msgstr "اختر ملفًا…"
+
+#: panels/user-accounts/cc-login-history-dialog.c:69
+msgid "This Week"
+msgstr "هذا الأسبوع"
+
+#: panels/user-accounts/cc-login-history-dialog.c:72
+msgid "Last Week"
+msgstr "الأسبوع الماضي"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:82
+#: panels/user-accounts/cc-login-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %B"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:91
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %B، %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:96
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:173
+#: panels/user-accounts/cc-user-panel.c:770
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:176
+#: panels/user-accounts/cc-user-panel.c:774
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s، %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:243
+msgid "Session Ended"
+msgstr "انتهت الجلسة"
+
+#: panels/user-accounts/cc-login-history-dialog.c:249
+msgid "Session Started"
+msgstr "بدأت الجلسة"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:343
+#, c-format
+msgid "%s — Account Activity"
+msgstr "‏%s – نشاط الحساب"
+
+#: panels/user-accounts/cc-password-dialog.c:125
+msgid "Please choose another password."
+msgstr "رجاء اختر كلمة سر أخرى."
+
+#: panels/user-accounts/cc-password-dialog.c:134
+msgid "Please type your current password again."
+msgstr "رجاء أعد كتابة كلمة السر الحالية."
+
+#: panels/user-accounts/cc-password-dialog.c:140
+msgid "Password could not be changed"
+msgstr "تعذّر تغيير كلمة السر"
+
+#: panels/user-accounts/cc-password-dialog.ui:7
+msgid "Change Password"
+msgstr "غيّر كلمة السر"
+
+#: panels/user-accounts/cc-password-dialog.ui:37
+msgid "Ch_ange"
+msgstr "_غيّر"
+
+#: panels/user-accounts/cc-password-dialog.ui:145
+msgid "_Confirm New Password"
+msgstr "أ_كّد كلمة السر الجديدة"
+
+#: panels/user-accounts/cc-password-dialog.ui:162
+msgid "_New Password"
+msgstr "ك_لمة السر الجديدة"
+
+#: panels/user-accounts/cc-password-dialog.ui:216
+msgid "Current _Password"
+msgstr "كلمة السر ال_حالية"
+
+#: panels/user-accounts/cc-password-dialog.ui:254
+msgid "Allow user to change their password on next login"
+msgstr "اسمح للمستخدم بتغيير كلمة السر عند الولوج التالي"
+
+#: panels/user-accounts/cc-password-dialog.ui:267
+msgid "Set a password now"
+msgstr "ضع كلمة سر الآن"
+
+#: panels/user-accounts/cc-realm-manager.c:307
+msgid "Cannot automatically join this type of domain"
+msgstr "لا يمكن الانضمام تلقائيا إلى هذا النوع من النطاقات"
+
+#: panels/user-accounts/cc-realm-manager.c:310
+msgid "No such domain or realm found"
+msgstr "لم يعثر على هذا النطاق أو المجال"
+
+#: panels/user-accounts/cc-realm-manager.c:732
+#: panels/user-accounts/cc-realm-manager.c:746
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "تعذّر الولوج باسم %s في النطاق %s"
+
+#: panels/user-accounts/cc-realm-manager.c:738
+msgid "Invalid password, please try again"
+msgstr "كلمة سر خطأ؛ من فضلك أعد المحاولة"
+
+#: panels/user-accounts/cc-realm-manager.c:751
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "تعذّر الاتصال بالنطاق %s:‏ %s"
+
+#: panels/user-accounts/cc-user-panel.c:213
+msgid "Your account"
+msgstr "حسابك"
+
+#: panels/user-accounts/cc-user-panel.c:388
+msgid "Failed to delete user"
+msgstr "فشل حذف المستخدم"
+
+#: panels/user-accounts/cc-user-panel.c:446
+#: panels/user-accounts/cc-user-panel.c:505
+#: panels/user-accounts/cc-user-panel.c:557
+msgid "Failed to revoke remotely managed user"
+msgstr "فشل إبطال المستخدم المتحكم فيه عن بعد"
+
+#: panels/user-accounts/cc-user-panel.c:609
+msgid "You cannot delete your own account."
+msgstr "لا يمكنك حذف حسابك أنت."
+
+#: panels/user-accounts/cc-user-panel.c:618
+#, c-format
+msgid "%s is still logged in"
+msgstr "ما يزال %s والجا"
+
+#: panels/user-accounts/cc-user-panel.c:622
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "حذف مستخدم أثناء ولوجه قد يترك النظام في حالة غير مستقرة."
+
+#: panels/user-accounts/cc-user-panel.c:631
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "أتريد إبقاء ملفات %s؟"
+
+#: panels/user-accounts/cc-user-panel.c:635
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"من الممكن الإبقاء على مجلد المنزل وخزانة البريد والملفات المؤقتة عند حذف "
+"حساب مستخدم."
+
+#: panels/user-accounts/cc-user-panel.c:638
+msgid "_Delete Files"
+msgstr "ا_حذف الملفات"
+
+#: panels/user-accounts/cc-user-panel.c:639
+msgid "_Keep Files"
+msgstr "أ_بقِ الملفات"
+
+#: panels/user-accounts/cc-user-panel.c:653
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "أمتأكد أنك تريد إبطال حساب %s المتحكم فيه عن بعد؟"
+
+#: panels/user-accounts/cc-user-panel.c:657
+msgid "_Delete"
+msgstr "ا_حذف"
+
+#: panels/user-accounts/cc-user-panel.c:707
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "الحساب معطّل"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "لتوضع مع الولوج التالي"
+
+#: panels/user-accounts/cc-user-panel.c:718
+msgctxt "Password mode"
+msgid "None"
+msgstr "بدون"
+
+#: panels/user-accounts/cc-user-panel.c:763
+msgid "Logged in"
+msgstr "والِج"
+
+#: panels/user-accounts/cc-user-panel.c:1093
+msgid "Failed to contact the accounts service"
+msgstr "فشل الاتصال بخدمة الحسابات"
+
+#: panels/user-accounts/cc-user-panel.c:1095
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "رجاء تأكّد من أن AccountService مثبّتة ومفعّلة."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/cc-user-panel.c:1127
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"انقر على أيقونة *\n"
+"لعمل أي تغييرات"
+
+#: panels/user-accounts/cc-user-panel.c:1200
+msgid "Create a user account"
+msgstr "أنشئ حساب مستخدِم"
+
+#: panels/user-accounts/cc-user-panel.c:1211
+#: panels/user-accounts/cc-user-panel.c:1339
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"لإنشاء حساب مستخدِم،\n"
+"انقر أولًا على أيقونة *"
+
+#: panels/user-accounts/cc-user-panel.c:1220
+msgid "Delete the selected user account"
+msgstr "احذف حساب المستخدِم المختار"
+
+#: panels/user-accounts/cc-user-panel.c:1232
+#: panels/user-accounts/cc-user-panel.c:1343
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"لحذف حساب المستخدم المختار،\n"
+"انقر أولًا على أيقونة *"
+
+#: panels/user-accounts/cc-user-panel.ui:18
+msgid "_Add User…"
+msgstr "أ_ضف مستخدمًا…"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "يجب إعادة تشغيل الجلسة لتطبيق التغييرات"
+
+#: panels/user-accounts/cc-user-panel.ui:78
+msgid "Restart Now"
+msgstr "أعِد التشغيل الآن"
+
+#: panels/user-accounts/cc-user-panel.ui:254
+msgid "A_utomatic Login"
+msgstr "الولوج الت_لقائي"
+
+#: panels/user-accounts/cc-user-panel.ui:296
+msgid "_Fingerprint Login"
+msgstr "الولوج بال_بصمة"
+
+#: panels/user-accounts/cc-user-panel.ui:322
+#: panels/user-accounts/cc-user-panel.ui:338
+msgid "User Icon"
+msgstr "أيقونة المستخدم"
+
+#: panels/user-accounts/cc-user-panel.ui:402
+msgid "Last Login"
+msgstr "آخر ولوج"
+
+#: panels/user-accounts/cc-user-panel.ui:451
+msgid "Remove User…"
+msgstr "أزِل المستخدِم…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:484
+msgid "No Users Found"
+msgstr "لم يُعثر على أي مستخدمين"
+
+#: panels/user-accounts/cc-user-panel.ui:494
+msgid "Unlock to add a user account."
+msgstr "افتح لإضافة حساب مستخدِم."
+
+#: panels/user-accounts/data/account-fingerprint.ui:12
+msgid "Left thumb"
+msgstr "الإبهام الأيسر"
+
+#: panels/user-accounts/data/account-fingerprint.ui:15
+msgid "Left middle finger"
+msgstr "الوسطى اليسرى"
+
+#: panels/user-accounts/data/account-fingerprint.ui:18
+msgid "Left ring finger"
+msgstr "البنصر الأيسر"
+
+#: panels/user-accounts/data/account-fingerprint.ui:21
+msgid "Left little finger"
+msgstr "الخنصر الأيسر"
+
+#: panels/user-accounts/data/account-fingerprint.ui:24
+msgid "Right thumb"
+msgstr "الإبهام الأيمن"
+
+#: panels/user-accounts/data/account-fingerprint.ui:27
+msgid "Right middle finger"
+msgstr "الوسطى اليمنى"
+
+#: panels/user-accounts/data/account-fingerprint.ui:30
+msgid "Right ring finger"
+msgstr "البنصر الأيمن"
+
+#: panels/user-accounts/data/account-fingerprint.ui:33
+msgid "Right little finger"
+msgstr "الخنصر الأيمن"
+
+#: panels/user-accounts/data/account-fingerprint.ui:39
+#: panels/user-accounts/um-fingerprint-dialog.c:677
+msgid "Enable Fingerprint Login"
+msgstr "فعّل الولوج بالبصمة"
+
+#: panels/user-accounts/data/account-fingerprint.ui:89
+msgid "_Right index finger"
+msgstr "السبابة الي_منى"
+
+#: panels/user-accounts/data/account-fingerprint.ui:105
+msgid "_Left index finger"
+msgstr "السبابة الي_سرى"
+
+#: panels/user-accounts/data/account-fingerprint.ui:126
+msgid "_Other finger:"
+msgstr "أصبع آخ_ر:"
+
+#: panels/user-accounts/data/account-fingerprint.ui:262
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr "حُفظت بصمتك بنجاح. تستطيع الآن الولوج ببصمة أصبعك."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "المستخدمين"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "أضف أو احذف مستخدمين و غيّر كلمة السر"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:7
+msgid "system-users"
+msgstr "system-users"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "ولوج;اسم;بصمة;أيقونة;شعار;وجه;كلمة سر;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr "_سجّل"
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "ولوج مدير النطاق"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"تحتاج أن تكون مسجّلا في النطاق لاستخدام ولوج المؤسسات على هذا الحاسوب.\n"
+"من فضلك اطلب من مدير الشبكة أن يكتب كلمة سر النطاق هنا."
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "ا_سم المدير"
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "كلمة سر المدير"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "أدِر حسابات المستخدمين"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "الاستيثاق مطلوب لتغيير بيانات المستخدم"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "لا تحتوي كلمة السر الجديدة على حروف مختلفة كفاية."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "حاول تغيير بعض الحروف و الأرقان."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "حاول تغيير كلمة السر أكثر قليلًا."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "كلمة السر أقوى بدون اسم المستخدم."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "حاول تفادي وضع اسم المستخدم في كلمة السر."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "حاول تفادي بعض الكلمات المستخدمة في كلمة السر."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "حاول تفادي الكلمات الشائعة."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "حاول تفادي تغيير ترتيب كلمات معروفة."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "حاول استخدام أرقام أكثر."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "حاول استخدام حروف كبيرة أكثر."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "حاول استخدام حروف صغيرة أكثر."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "حاول استخدام علامات خاصة أكثر، مثل علامات الترقيم."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "حاول استخدام خليط من الحروف و الأرقام و علامات الترقيم."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "حاول تفادي تكرار نفس الحرف."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"حاول تفادي تكرار نفس النوع من الحروف: عليك الخلط بين الحروف و الأرقام "
+"و علامات الترقيم."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "حاول تفادي تتابعات مثل 1234 أو abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"على كلمة السر أن تكون أطول. حاول استخدام خليط من الحروف و الأرقام و علامات "
+"الترقيم."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "اخلط الحروف الكبيرة مع الصغيرة و استخدم رقمًا أو اثنين."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"إضافة المزيد من الحروف و الأرقام و علامات الترقيم ستجعل كلمة السر أقوى."
+
+#: panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "فشل الاستيثاق"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "كلمة السّر الجديدة قصيرة جدًا"
+
+#: panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "كلمة السر الجديدة بسيطة جدا"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "كلمتا السر القديمة والجديدة متشابهتان جدا"
+
+#: panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "كلمة السر الجديدة سبق استخدامها مؤخرا."
+
+#: panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "يجب أن تحتوي كلمة السر الجديدة على محارف خاصة أو أرقام"
+
+#: panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "كلمتا السر القديمة و الجديدة متطابقتان"
+
+#: panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "تغيِّرت كلمة السر بعد الاستيثاق!"
+
+#: panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "لا تحتوي كلمة السر الجديدة على حروف مختلفة كفاية"
+
+#: panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "عطل غير معروف"
+
+#: panels/user-accounts/user-utils.c:430
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "اسم المستخدم هذا غير متاح. جرب اسمًا آخر."
+
+#: panels/user-accounts/user-utils.c:433
+#, c-format
+msgid "The username is too long."
+msgstr "اسم المستخدم طويل جدا."
+
+#: panels/user-accounts/user-utils.c:436
+msgid "The username cannot start with a “-”."
+msgstr "لا يمكن أن يبدأ اسم المستخدم بعلامة ”-“."
+
+#: panels/user-accounts/user-utils.c:439
+msgid ""
+"The username should only consist of upper and lower case letters from a-z, "
+"digits and the following characters: . - _"
+msgstr ""
+"يجب أن لا يتعدى اسم المستخدم الحروف الإنجليزية الكبيرة و الصغيرة من a-z، "
+"و الأرقام و أي من الحروف '.' و '-' و '_'."
+
+#: panels/user-accounts/user-utils.c:443
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr "سيُستخدم هذا لتسمية مجلد المنزل ولا يمكن تغييره."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr "لست مخولا بالوصول إلى الجهاز. تكلم مع مدير النظام."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "الجهاز مستخدم بالفعل."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr "حصل عطل داخلي."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Enabled"
+msgstr "مفعّل"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:260
+msgid "Delete registered fingerprints?"
+msgstr "أأحذف البصمات المسجّلة؟"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:264
+msgid "_Delete Fingerprints"
+msgstr "ا_حذف البصمات"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:270
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "أتريد حذف بصماتك المسجلة بحيث يُعطل الولوج بالبصمة؟"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:440
+msgid "Done!"
+msgstr "تم!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:501
+#: panels/user-accounts/um-fingerprint-dialog.c:543
+#, c-format
+msgid "Could not access “%s” device"
+msgstr "تعذر الوصول إلى الجهاز ”%s“"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:584
+#, c-format
+msgid "Could not start finger capture on “%s” device"
+msgstr "تعذّر بدء التقاط الأصابع على الجهاز ”%s“"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:628
+msgid "Could not access any fingerprint readers"
+msgstr "تعذّر الوصول إلى أي قارئ بصمة"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:629
+msgid "Please contact your system administrator for help."
+msgstr "من فضلك راجع مدير النظام للمساعدة."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: panels/user-accounts/um-fingerprint-dialog.c:711
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the “%s” device."
+msgstr "لتفعيل الولوج بالبصمة، ستحتاج لحفظ إحدى بصماتك باستخدام الجهاز ”%s“."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:718
+msgid "Selecting finger"
+msgstr "اصبع الاختيار"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:719
+msgid "Enrolling fingerprints"
+msgstr "يسجّل البصمات"
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr "تعيين أزرار"
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:533
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "أ_غلق"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr "تعيين وظائف للأزرار"
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"لتعديل مفتاح اختصار، اختر ”أرسل ضغطة الزر“ ثم اضغط على الأزرار الجديدة أو "
+"اضغط مفتاح التّراجع لمسحها."
+
+#: panels/wacom/calibrator/calibrator.ui:60
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "رجاءً انقر علامات الهدف الظاهرة على الشاشة لمعايرة اللوح."
+
+#: panels/wacom/calibrator/calibrator.ui:77
+msgid "Mis-click detected, restarting…"
+msgstr "اكتُشفت نقرة خاطئة، يعيد بدء العملية…"
+
+#: panels/wacom/cc-wacom-button-row.c:253
+#, c-format
+msgid "Button %d"
+msgstr "زر %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "التطبيقات المُعرّفة"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "أرسل ضغطة الزر"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "بدّل الشاشة"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "أظهر مساعدة على الشاشة"
+
+#: panels/wacom/cc-wacom-mapping-panel.c:256
+msgid "Output:"
+msgstr "المَخْرَج:"
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:268
+msgid "Keep aspect ratio (letterbox):"
+msgstr "حافظ على نسبة العرض:"
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:279
+msgid "Map to single monitor"
+msgstr "عيّن في شاشة واحدة"
+
+#: panels/wacom/cc-wacom-nav-button.c:84
+#, c-format
+msgid "%d of %d"
+msgstr "%d من %d"
+
+#: panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "اعرض المخطط"
+
+#: panels/wacom/cc-wacom-panel.c:845 panels/wacom/wacom-stylus-page.ui:119
+msgid "Stylus"
+msgstr "القلم"
+
+#: panels/wacom/cc-wacom-stylus-page.c:355
+msgid "Button"
+msgstr "زر"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:200
+msgid "Wacom Tablet"
+msgstr "لوح واكوم"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "اضبط استخدام أزرار و حساسية قلم ألواح الرسوميات"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:7
+msgid "input-tablet"
+msgstr "input-tablet"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "لوحة;واكوم;قلم;ممحاة;فأرة;"
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr "لوح (مطلق)"
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr "لوحة لمس (نسبي)"
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr "تفضيلات اللوح"
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "م_ساعدة"
+
+#: panels/wacom/gnome-wacom-properties.ui:125
+msgid "No tablet detected"
+msgstr "لم يكتشف أي لوح"
+
+#: panels/wacom/gnome-wacom-properties.ui:141
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "رجاءً وصّل أو شغّل لوح واكوم"
+
+#: panels/wacom/gnome-wacom-properties.ui:161
+msgid "Bluetooth Settings"
+msgstr "إعدادات بلوتوث"
+
+#: panels/wacom/gnome-wacom-properties.ui:238
+msgid "Tracking Mode"
+msgstr "نمط التتبع"
+
+#: panels/wacom/gnome-wacom-properties.ui:266
+msgid "Left-Handed Orientation"
+msgstr "اتجاه لليد اليسرى"
+
+#: panels/wacom/gnome-wacom-properties.ui:296
+msgid "Map to Monitor…"
+msgstr "تعيين شاشة عرض…"
+
+#: panels/wacom/gnome-wacom-properties.ui:309
+msgid "Map Buttons…"
+msgstr "تعيين أزرار…"
+
+#: panels/wacom/gnome-wacom-properties.ui:322
+msgid "Calibrate…"
+msgstr "عاير…"
+
+#: panels/wacom/gnome-wacom-properties.ui:340
+msgid "Adjust mouse settings"
+msgstr "اضبط إعدادات الفأرة"
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Adjust display resolution"
+msgstr "اضبط ميز الشاشة"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
+msgid "New shortcut…"
+msgstr "اختصار جديد…"
+
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "المبدئي"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr "نقرة بزر الفأرة الأوسط"
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr "نقرة بزر الفأرة الأيمن"
+
+#: panels/wacom/wacom-stylus-page.ui:37
+msgid "Back"
+msgstr "إلى الخلف"
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "إلى الأمام"
+
+#: panels/wacom/wacom-stylus-page.ui:79
+msgid "No stylus found"
+msgstr "لم يُعثر على أي قلم"
+
+#: panels/wacom/wacom-stylus-page.ui:93
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr "رجاء انقل قلمك قرب اللوح لإعداده"
+
+#: panels/wacom/wacom-stylus-page.ui:159
+msgid "Eraser Pressure Feel"
+msgstr "الشعور بضغط الممحاة"
+
+#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:340
+msgid "Soft"
+msgstr "ناعم"
+
+#: panels/wacom/wacom-stylus-page.ui:210 panels/wacom/wacom-stylus-page.ui:370
+msgid "Firm"
+msgstr "قاس"
+
+#: panels/wacom/wacom-stylus-page.ui:233
+msgid "Top Button"
+msgstr "الزر العلوي"
+
+#: panels/wacom/wacom-stylus-page.ui:262
+msgid "Lower Button"
+msgstr "الزر السفلي"
+
+#: panels/wacom/wacom-stylus-page.ui:291
+msgid "Lowest Button"
+msgstr "الزر الأسفل"
+
+#: panels/wacom/wacom-stylus-page.ui:320
+msgid "Tip Pressure Feel"
+msgstr "الشعور بضغط السن"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+msgid "GNOME Settings"
+msgstr "إعدادات جنوم"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "أدوات لضبط سطح مكتب جنوم"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/cc-application.c:58
+msgid "Display version number"
+msgstr "اعرض الإصدارة"
+
+#: shell/cc-application.c:59
+msgid "Enable verbose mode"
+msgstr "فعّل الطور المسهِب"
+
+#: shell/cc-application.c:60
+msgid "Search for the string"
+msgstr "ابحث عن نصّ"
+
+#: shell/cc-application.c:61
+msgid "List possible panel names and exit"
+msgstr ""
+
+#: shell/cc-application.c:62
+msgid "Panel to display"
+msgstr "لوحة لعرضها"
+
+#: shell/cc-application.c:62
+msgid "[PANEL] [ARGUMENT…]"
+msgstr ""
+
+#: shell/cc-panel-list.ui:195
+msgid "No results found"
+msgstr "لا نتائج"
+
+#: shell/cc-panel-loader.c:279
+msgid "Available panels:"
+msgstr "اللوحات المتوفرة:"
+
+#: shell/cc-window.ui:131
+msgid "All Settings"
+msgstr "كل الإعدادات"
+
+#: shell/cc-window.ui:169
+msgid "Primary Menu"
+msgstr "القائمة الرئيسية"
+
+#: shell/cc-window.ui:271
+msgid "Warning: Development Version"
+msgstr "تحذير: الإصدارة التطويرية"
+
+#: shell/cc-window.ui:272
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"هذه الإصدارة من تطبيق الإعدادات مخصصة للتطوير. قد تواجه مشاكل في سلوك النظام،"
+" أو تتعرض لفقد البيانات، أو أي مشاكل أخرى غير متوقعة."
+
+#: shell/cc-window.ui:283
+msgid "Help"
+msgstr "مساعدة"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: shell/gnome-control-center.desktop.in.in:5
+msgid "org.gnome.Settings"
+msgstr "org.gnome.Settings"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "تفضيلات;إعدادات;"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "عام"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "أنهِ"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "ابحث"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "اللوحات"
+
+#: shell/help-overlay.ui:40
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "ارجع للشاشة السابقة"
+
+#: shell/help-overlay.ui:53
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "ألغِ البحث"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1871
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "لا مَخْرَج"
+msgstr[1] "مَخْرَج واحد"
+msgstr[2] "مَخْرَجين"
+msgstr[3] "%u مَخْارِج"
+msgstr[4] "%u مَخْرَجًا"
+msgstr[5] "%u مَخْرَج"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1881
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "لا مَدْخَل"
+msgstr[1] "مَدْخَل واحد"
+msgstr[2] "مَدْخَلين"
+msgstr[3] "%u مَداخِل"
+msgstr[4] "%u مَدْخَلًا"
+msgstr[5] "%u مَدْخَل"
+
+#: subprojects/gvc/gvc-mixer-control.c:2736
+msgid "System Sounds"
+msgstr "أصوات النظام"
+
+#~ msgid "Language"
+#~ msgstr "اللغة"
+
+#~ msgid "Primary Display"
+#~ msgstr "الشاشة الرئيسية"
+
+#~ msgid "_Night Light"
+#~ msgstr "الإ_ضاءة الليلية"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "تعذّرت معرفة معلومات الشاشة"
+
+#~ msgid "My Home Network"
+#~ msgstr "شبكتي المنزلية"
+
+#~ msgid "hardware"
+#~ msgstr "العتاد"
+
+#~ msgid "reset"
+#~ msgstr "صفّر"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "تحول إلى المصدر السابق"
+
+#~ msgid "Switch to next source"
+#~ msgstr "تحول إلى المصدر التالي"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "تحول إلى المصدر التالي البديل"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "إنجليزي (المملكة المتحدة)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "المملكة المتحدة"
+
+#~ msgid "_Options"
+#~ msgstr "ال_خيارات"
+
+#~ msgid "Add input source"
+#~ msgstr "أضف مصْدَر إدخال"
+
+#~ msgid "Remove input source"
+#~ msgstr "احذف مصْدَر الإدخال"
+
+#~ msgid "Move input source up"
+#~ msgstr "انقل مصْدَر الإدخال لأعلى"
+
+#~ msgid "Move input source down"
+#~ msgstr "انقل مصْدَر الإدخال لأسفل"
+
+#~ msgid "Configure input source"
+#~ msgstr "اضبط مصْدَر الإدخال"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "أظهر تخطيط لوحة مفاتيح مصْدَر الإدخال"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "يسار"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "يمين"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "أدنى"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "أقصى"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_سماعات كبيرة:"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "غير مكبّر"
+
+#~ msgid "_Profile:"
+#~ msgstr "ال_طور:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "ا_ختبر السماعات"
+
+#~ msgid "Peak detect"
+#~ msgstr "التعرف على الذروة"
+
+#~ msgid "Device"
+#~ msgstr "الجهاز"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "اختبار سماعات %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "اخ_تر جهاز إخراج الصوت:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "إعدادات الجهاز المختار:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "شدة صوت المَ_دْخَل:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "اخ_تر جهاز إدخال الصوت:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "المؤثرات الصوتية"
+
+#~ msgid "No application is currently playing or recording audio."
+#~ msgstr "لا تطبيقات تشغل أو تسجل صوتا حاليا."
+
+#~ msgid "Built-in"
+#~ msgstr "مدمج"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "تفضيلات الصوت"
+
+#~ msgid "Testing event sound"
+#~ msgstr "يختبر صوت الحدث"
+
+#~ msgid "From theme"
+#~ msgstr "من السمة"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "اختر صوت تنبي_ه:"
+
+#~ msgid "Stop"
+#~ msgstr "أوقِف"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "أ_كّد كلمة السر الجديدة"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "لا تتطابق كلمتا السر."
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "عادي"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "إداري"
+
+#~ msgid "page 3"
+#~ msgstr "صفحة 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "مركز تحكم جنوم"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr "مركز التحكم هو واجهة جنوم الرئيسة لضبط مختلف خصائص حاسوبك."
+
+#~ msgid "Show the overview"
+#~ msgstr "اعرض الملخص"
+
+#~ msgid "Quit"
+#~ msgstr "أنهِ"
+
+#~ msgid "Back­ground"
+#~ msgstr "الخلفية"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "بلوتوث"
+
+#~ msgid "Co­lor"
+#~ msgstr "الألوان"
+
+#~ msgid "Section"
+#~ msgstr "القسم"
+
+#~ msgid "Overview"
+#~ msgstr "عام"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "التطبيقات المبدئية"
+
+#~ msgid "Ab­out"
+#~ msgstr "عن"
+
+#~ msgid "De­tails"
+#~ msgstr "التفاصيل"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "الوسائط المنفصلة"
+
+#~ msgid "Net­work"
+#~ msgstr "الشبكة"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "التنبيهات"
+
+#~ msgid "Po­wer"
+#~ msgstr "الطاقة"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "الخصوصية"
+
+#~ msgid "Sha­ring"
+#~ msgstr "المشاركة"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "الإتاحة"
+
+#~ msgid "Disable image"
+#~ msgstr "عطّل الصورة"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "تصفّح لمزيد من الصور…"
+
+#~ msgid "Used by %s"
+#~ msgstr "يستخدمها %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "لوح واكوم"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "شخصي"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "العتاد"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "النظام"
+
+#~ msgid "Lid Closed"
+#~ msgstr "الغطاء مغلق"
+
+#~ msgid "Mirrored"
+#~ msgstr "متطابقة"
+
+#~ msgid "Secondary"
+#~ msgstr "الثانوي"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "رتب الشاشات المركبة"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "اسحب الشاشات لترتيبها"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d هرتز (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d هرتز"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "أدِر ٩٠° عكس عقارب الساعة"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "أدِر ١٨٠°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "أدِر ٩٠° باتجاه عقارب الساعة"
+
+#~ msgid "Size"
+#~ msgstr "الحجم"
+
+#~ msgid "Aspect Ratio"
+#~ msgstr "نسبة العرض"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "اعرض الشريط العلوي و تجميعة الأنشطة على هذه الشاشة"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "ضم هذه الشاشة على شاشة أخرى لإنشاء مساحة عمل إضافية"
+
+#~ msgid "Presentation"
+#~ msgstr "العروض التقديمة"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "اعرض عروض الشرائح و الوسائط فقط"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "اعرض المنظور الخالي على الشاشتين"
+
+#~ msgid "Turn Off"
+#~ msgstr "أطفئ"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "لا تستخدم هذه الشاشة"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "ر_تب الشاشات المركبة"
+
+#~ msgid "Server"
+#~ msgstr "الخادوم"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "احذف خادوك DNS"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "اجعله م_تاحا للمستخدمين الآخرين"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "صفّر إعدادات هذه الشبكة بما فيها كلمات السر، لكن تذكر كونها الشبكة المُفضّلة"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "احذف كل التفاصيل المتعلقة بهذه الشبكة و لا تحاول الاتصال بها تلقائيا"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "إذا كان لديك اتصال بالإنترنت غير الاتصال اللاسلكي فيمكنك إعداد نقطة بث "
+#~ "لمشاركة اتصالك بالإنترنت مع الآخرين."
+
+#~ msgid "History"
+#~ msgstr "التأريخ"
+
+#~ msgid "Proxy"
+#~ msgstr "الوسيط"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "أضف إ_عدادًا…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "لا شيء"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "يدوي"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "تلقائي"
+
+#~ msgid "Add Device"
+#~ msgstr "أضف جهازًا"
+
+#~ msgid "VPN Type"
+#~ msgstr "نوع VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "اسم المجموعة"
+
+#~ msgid "Group Password"
+#~ msgstr "كلمة سر المجموعة"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "ا_ستخدم كنقطة بث…"
+
+#~ msgid "_History"
+#~ msgstr "ال_تأريخ"
+
+#~ msgid "Loading options…"
+#~ msgstr "يُحمّل الخيارات…"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "‏%s ‏%d-بتة (معرف البناء: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "‏%s‏ %d بتة"
+
+#~ msgid "Base system"
+#~ msgstr "النظام الأساسي"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "اختصار;تكرار;وميض;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "اضغط Esc للإلغاء."
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_طبقة الجدار الناري"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "المبدئية"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "تحدد الطبقة مستوى الثقة في الاتصال"
+
+#~ msgid "2"
+#~ msgstr "٢"
+
+#~ msgid "3"
+#~ msgstr "٣"
+
+#~ msgid "4"
+#~ msgstr "٤"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "حاول إضافة حروف و أرقام و رموز أكثر."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "القوّة: ضعيفة"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "القوّة: منخفضة"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "القوّة: متوسطة"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "القوّة: جيدة"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "القوّة: قوية"
+
+#~ msgid "Wayland"
+#~ msgstr "وايلاند"
+
+#~ msgid "Edit"
+#~ msgstr "حرِّر"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "أ_شرطة التنبيهات"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "أشر_طة التنبيهات"
+
+#~ msgid "Add Account"
+#~ msgstr "أضف حسابا"
+
+#~ msgid "Mail"
+#~ msgstr "البريد"
+
+#~| msgid "_Calendar"
+#~ msgid "Calendar"
+#~ msgstr "التقويم"
+
+#~ msgid "Contacts"
+#~ msgstr "المتراسلين"
+
+#~ msgid "Chat"
+#~ msgstr "الدردشة"
+
+#~ msgid "Error creating account"
+#~ msgstr "خطأ أثناء إنشاء الحساب"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "أمتأكد أنك تريد إزالة الحساب؟"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "هذا لن يزيل الحساب على الخادوم."
+
+#~ msgid "_Remove"
+#~ msgstr "أ_زل"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "لم تُعد أي حسابات إنترنت"
+
+#~ msgid "Add an online account"
+#~ msgstr "أضِف حساب إنترنت"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "إضافة حساب تتيح للتطبيقات استخدامه للوصول إلى المستندات، والبريد، "
+#~ "والمتراسلين، والتقويم، والدردشة، وغيرها."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "تُضبط"
+
+#~ msgid "Toner Level"
+#~ msgstr "مستوى الحبر"
+
+#~ msgid "Supply Level"
+#~ msgstr "مستوى المداد"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "تُثبّت"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "لا مهام نشطة"
+#~ msgstr[1] "%u نشطة"
+#~ msgstr[2] "%u نشطتين"
+#~ msgstr[3] "%u نشطة"
+#~ msgstr[4] "%u نشطة"
+#~ msgstr[5] "%u نشطة"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "أضِف طابعة جديدة"
+
+#~ msgid "No printers detected."
+#~ msgstr "لم تُكتشف أي طابعة."
+
+#~ msgid "Supply"
+#~ msgstr "المداد"
+
+#~ msgid "Jobs"
+#~ msgstr "المهام"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "أظهر ال_مهام"
+
+#~ msgid "label"
+#~ msgstr "العنوان"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "يُعدّ المُشغّل الجديد…"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "اطبع صفحة ا_ختبار"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "الحسابات الأخرى"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "أعلى"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "أسفل"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "لا شيء"
+
+#~ msgid "Left Ring"
+#~ msgstr "البنصر الأيسر"
+
+#~ msgid "No Action"
+#~ msgstr "دون إجراء"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "نقرة بزر الفأرة الأيسر"
+
+#~ msgid "Scroll Up"
+#~ msgstr "تمرير للأعلى"
+
+#~ msgid "Scroll Down"
+#~ msgstr "تمرير للأسفل"
+
+#~ msgid "Scroll Left"
+#~ msgstr "تمرير لليسار"
+
+#~ msgid "Scroll Right"
+#~ msgstr "تمرير لليمين"
+
+#~ msgid "Add Shortcut"
+#~ msgstr "أضف اختصارًا"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "أزِل اختصارًا"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "لتعديل مفتاح اختصار، انقر على السّطر ثم اضغط على الأزرار الجديدة أو اضغط "
+#~ "مفتاح التّراجع لمسحها."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<إجراء غير معروف>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "الاختصار \"%s\" لا يمكن استخدامه لأن الطباعة بهذا المفتاح ستصبح متعذرة.\n"
+#~ "حاول رجاءً استخدام مفتاح مع Ctrl أو Alt أو Shift في نفس الوقت."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "الاختصار \"%s\" مستخدم في:\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "إذا أعدت تعيين الاختصار \"%s\" فسيُعطّل الاختصار \"%s\"."
+
+#~ msgid "_Reassign"
+#~ msgstr "أعِد ال_تعيين"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "الاختصار \"%s\" مرتبط بالاختصار \"%s\". هل تريد ضبطه تلقائيا إلى \"%s\"؟"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "الاختصار \"%s\" مرتبط حاليًا بالاختصار \"%s\"، سيُعطّل الاختصار إذا أكملت."
+
+#~ msgid "_Assign"
+#~ msgstr "ا_ضبط"
+
+#~ msgid "Team"
+#~ msgstr "فريق"
+
+#~ msgid "Bridge"
+#~ msgstr "جسر"
+
+#~ msgid "VLAN"
+#~ msgstr "شبكة محلية ظاهرية"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "تعذّر تحميل ملحقات VPN"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "أضف اتصالًا شبكيّا"
+
+#~ msgid "Bond slaves"
+#~ msgstr "أجهزة تابعة للربط"
+
+#~ msgid "(none)"
+#~ msgstr "(لا شيء)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "تابعي الجسر"
+
+#~ msgid "Team slaves"
+#~ msgstr "تابعي الفريق"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "لم تُختر أي شهادة سُلْطة استيثاق"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "عدم استخدام شهادة أمنيّة من جهة معتمدة قد يتسبّب باتصالات لا سلكية غير آمنة "
+#~ "واحتيالية. هل تريد اختيار شهادة أمنية من جهة معتمدة؟"
+
+#~ msgid "Ignore"
+#~ msgstr "تجاهل"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "اختر شهادة سُلْطة استيثاق"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "ا_طلب كلمة السر هذه في كل مرة"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "لا _تنبهني ثانيةً"
+
+#~ msgid "No"
+#~ msgstr "لا"
+
+#~ msgid "Yes"
+#~ msgstr "نعم"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "خطأ عند الولوج إلى الحساب"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "انتهت صلاحية بيانات الاستيثاق."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "ادخل لتفعيل هذا الحساب."
+
+#~ msgid "_Sign In"
+#~ msgstr "اد_خل"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "أخرى"
+
+#~ msgid "Personal File Sharing"
+#~ msgstr "مشاركة الملفات الشخصية"
+
+#~ msgid "_Allow Remote Control"
+#~ msgstr "اسمح بالتحكم عن بع_د"
+
+#~ msgid "_Verify"
+#~ msgstr "أ_كّد"
+
+#~ msgid "Login History"
+#~ msgstr "تأريخ الولوج"
+
+#~ msgid "Add User Account"
+#~ msgstr "أضِف حساب مستخدِم"
+
+#~ msgid "Login Options"
+#~ msgstr "خيارات الولوج"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "اسم المستخدم '%s' موجود بالفعل."
+
+#~ msgid "Done"
+#~ msgstr "تمّ"
+
+#~ msgid "Time _Zone"
+#~ msgstr "المن_طقة الزمنية"
+
+#~ msgid "_Delay:"
+#~ msgstr "ال_تأخير:"
+
+#~ msgid "_Speed:"
+#~ msgstr "ال_سرعة:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "قصير"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "بطيء"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "طويل"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "سريع"
+
+#~ msgid "S_peed:"
+#~ msgstr "ال_سرعة:"
+
+#~ msgid "Shortcuts"
+#~ msgstr "الاختصارات"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "اختبر إعداداتك"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "بطيء"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "سريع"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "الأي_سر"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "الأي_من"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "سرعة المؤ_شر"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "بطيء"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "سريع"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "بطيء"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "سريع"
+
+#~ msgid "No printers available"
+#~ msgstr "لا تتوفر أي طابعات"
+
+#~ msgid "Close"
+#~ msgstr "أغلق"
+
+#~ msgid "Resume Printing"
+#~ msgstr "تابع الطباعة"
+
+#~ msgid "Pause Printing"
+#~ msgstr "ألبِث الطباعة"
+
+#~ msgid "Cancel Print Job"
+#~ msgstr "ألغِ مهمة الطباعة"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "مُعلَّقة"
+
+#~ msgid "Job Title"
+#~ msgstr "عنوان المهمة"
+
+#~ msgid "Job State"
+#~ msgstr "حالة المهمة"
+
+#~ msgid "Time"
+#~ msgstr "الوقت"
+
+#~ msgid "Add New Printer"
+#~ msgstr "أضِف طابعة جديدة"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "تستخدم لتحديد موقعك الجغرافي"
+
+#~ msgid "Options"
+#~ msgstr "الخيارات"
+
+#~ msgid "Password:"
+#~ msgstr "كلمة السر:"
+
+#~ msgid "Zoom"
+#~ msgstr "التقريب"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "اللون"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "بلوتوث معطّل"
+
+#~ msgid "Security key"
+#~ msgstr "مفتاح الأمن"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "يحتاج الجهاز اللاسلكي طاقة إضافية"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "عندما تكون الطاقة من_خفضة جدا"
+
+#~ msgid "Power off"
+#~ msgstr "أطفئ التشغيل"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "تتيح لك مشاركة بلوتوث مشاركة الملفات مع الأجهزة الأخرى التي تحتوي على "
+#~ "بلوتوث"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "استلم من الأجهزة الموثوق بها فقط"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "احفظ الملفات المستلمة في مجلد التنزيلات"
+
+#~ msgid "Show help options"
+#~ msgstr "اعرض خيارات المساعدة"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "شغّل '%s --help' لترى قائمة كاملة بخيارات سطر الأوامر المتاحة.\n"
+
+#~ msgid "United States"
+#~ msgstr "الولايات المتّحدة"
+
+#~ msgid "Germany"
+#~ msgstr "ألمانيا"
+
+#~ msgid "France"
+#~ msgstr "فرنسا"
+
+#~ msgid "Spain"
+#~ msgstr "إسبانيا"
+
+#~ msgid "China"
+#~ msgstr "الصّين"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "_عطّل أثناء الكتابة"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "لا تتوافق خدمات الشبكة في النظام مع هذه الإصدارة."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "أظهر لوحات منبثقة"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "أظهر في شاشة القفل"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "أظهر لوحات منبثقة"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "أظهر في شاشة القفل"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "أطفئ الأجهزة اللاسلكية"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "أدخل عنوان طابعًا أو نصًا لترشيح النتائج"
+
+#~ msgid "Immediately"
+#~ msgstr "حالًا"
+
+#~ msgid "Sorry"
+#~ msgstr "آسف"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "شارك الوسائط على هذه الشبكة"
+
+#~ msgid "Shared Folders"
+#~ msgstr "المجلدات المُشاركة"
+
+#~ msgid "column"
+#~ msgstr "عمود"
+
+#~ msgid "Remove Folder"
+#~ msgstr "أزِل المجلد"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "شارك المجلد العام على هذه الشبكة"
+
+#~ msgid "Flickr"
+#~ msgstr "فلِكَر"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "إعداد جهاز جديد"
+
+#~ msgid "Paired"
+#~ msgstr "مقترن"
+
+#~ msgid "Type"
+#~ msgstr "النوع"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "إعدادات الفأرة ولوحة اللمس"
+
+#~ msgid "Sound Settings"
+#~ msgstr "إعدادات الصوت"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "إعدادات لوحة المفاتيح"
+
+#~ msgid "Send Files…"
+#~ msgstr "أرسل ملفات…"
+
+#~ msgid "Visibility"
+#~ msgstr "الظهور"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "ظهور ”%s“"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "أأزيل '%s' من قائمة الأجهزة؟"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr "إذا أزلت الجهاز، فستحتاج لإعداده مرة أخرى قبل استخدامه مجددا."
+
+#~ msgid "Install Updates"
+#~ msgstr "ثبّت التّحديثات"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "النظام مُحدّث"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "ابحث عن طابعات على الشبكة أو رشّح النتائج"
+
+#~ msgid "_Default"
+#~ msgstr "الم_بدئية"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "لا شيء"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "شارك المجلد العام"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "شارك مع الأجهزة الموثوق بها فقط"
+
+#~ msgid "Remote View"
+#~ msgstr "العرض عن بعد"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "اسم بكل الاتصالات"
+
+#~ msgid "Device type:"
+#~ msgstr "نوع الجهاز:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "المُصنّع:"
+
+#~ msgid "Model:"
+#~ msgstr "الطراز:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "يمكن سحب ملفات الصور على هذه النافذة لإكمال الحقول أعلاه آليًا."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "بدّل بين صباحا و مساءا."
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "اعرض المنظور الأساسي على هذه الشاشة أيضًا"
+
+#~ msgid "Combine"
+#~ msgstr "ركّب"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "ضم على الشاشة الأساسية لإنشاء مساحة إضافية"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "تفضيلات الفأرة"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "اختر الواجهة التي ستُستخدم للخدمة الجديدة"
+
+#~ msgid "C_reate…"
+#~ msgstr "أن_شئ…"
+
+#~ msgid "_Interface"
+#~ msgstr "الوا_جهة"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "قدرة استيعاب البطارية المُقدّرة: %s"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "تغيير صورة:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "اختر صورة هذا الحساب في شاشة الولوج."
+
+#~ msgid "Gallery"
+#~ msgstr "المعرض"
+
+#~ msgid "Take a photograph"
+#~ msgstr "التقط صورة"
+
+#~ msgid "Browse"
+#~ msgstr "تصفّح"
+
+#~ msgid "Photograph"
+#~ msgstr "صورة"
+
+#~ msgid "Account Information"
+#~ msgstr "معلومات الحساب"
+
+#~ msgid "_Region:"
+#~ msgstr "الم_نطقة:"
+
+#~ msgid "_City:"
+#~ msgstr "الم_دينة:"
+
+#~ msgid "_Network Time"
+#~ msgstr "وقت ال_شبكة"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "قدّم الوقت ساعة واحدة."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "أخّر الوقت ساعة واحدة."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "قدّم الوقت دقيقة واحدة."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "أخّر الوقت دقيقة واحدة."
+
+#~ msgid "AM/PM"
+#~ msgstr "ص\\م"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "طبيعي"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "مع عقارب الساعة"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 درجة"
+
+#~ msgid "Monitor"
+#~ msgstr "الشاشة"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "اسحب لتغيير جهاز العرض المبدئي."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "اختر شاشة لتغيير خصائصها، واسحبها لتغيير ترتيبها."
+
+#~ msgid "%a %R"
+#~ msgstr "‏%a ‏%R"
+
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "فشل تطبيق الإعداد: %s"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "تعذّر حفظ إعدادات الشاشة"
+
+#~ msgid "_Resolution"
+#~ msgstr "ال_ميز"
+
+#~ msgid "R_otation"
+#~ msgstr "ال_دوران"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "ا_نسخ الشاشات"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "ملاحظة: قد يقلل من خيارات الميز"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "اكتشف ال_شاشات"
+
+#~ msgid "Hidden"
+#~ msgstr "خفي"
+
+#~ msgid "Visible"
+#~ msgstr "مرئي"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "الاسم والظهور"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "تحكم في كيفية ظهورك على الشاشة والشبكة."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "أظهر ا_سمك بالكامل في الشريط العلوي"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "أظهر اسمك بالكامل في شاشة ال_قفل"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "وضع الت_خفي"
+
+#~ msgid "_Confirm Password"
+#~ msgstr "أ_كّد كلمة السر"
+
+#~ msgid "_Login Name"
+#~ msgstr "اسم ال_ولوج"
+
+#~ msgid "Login _Password"
+#~ msgstr "كلمة _سر الولوج"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "لا تتطابق كلمتا السر"
+
+#, fuzzy
+#~ msgid "Domain not found."
+#~ msgstr "المودم غير موجود"
+
+#~ msgid "Export"
+#~ msgstr "صدِّر"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "بطيئة"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "سريعة"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "يلت_صق المحتوى بالإصابع"
+
+#~ msgid "_Mobile Broadband"
+#~ msgstr "شبكة هاتف م_حمول"
+
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "لا شيء"
+
+#~ msgid "No shortcut set"
+#~ msgstr "لم يُحدد أي اختصار"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "عادي"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "عال\\معكوس"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "لوحة مفاتيح على الشاشة"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "عادي"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "صفّر عند ضغط مفتاح الحروف العالية وقفل الأرقام"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "شغِّل أو عطِّل:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "تكبير"
+
+#~ msgid "Zoom in:"
+#~ msgstr "قرّب:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "بعّد:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "كتابة الأصوات على الشاشة"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "اعرض وصفا نصيا للكلام والصوت"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "لوحة مفاتيح على الشاشة"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "قصير"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "طويل"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "صفّر إذا كان المفتاح"
+
+#~ msgid "pressed"
+#~ msgstr "ضُغِطَ"
+
+#~ msgid "accepted"
+#~ msgstr "قُبِلَ"
+
+#~ msgid "rejected"
+#~ msgstr "رُفِضَ"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "تأخير ال_قبول:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "تحكم في المؤشر باستخدام لوحة المفاتيح"
+
+#~ msgid "Video Mouse"
+#~ msgstr "فأرة الفديو"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "تحكم في المؤشر باستخدام كمرة فديو."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "صغير"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "كبير"
+
+#~ msgid "_Local Account"
+#~ msgstr "حساب _محلي"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "تلميحة: نطاق مؤسسة أو اسم مجال"
+
+#~ msgid "C_ontinue"
+#~ msgstr "_تابع"
+
+#~ msgid "Previous Week"
+#~ msgstr "الأسبوع الماضي"
+
+#~ msgid "Next Week"
+#~ msgstr "الأسبوع القادم"
+
+#~ msgid "Next week"
+#~ msgstr "الأسبوع القادم"
+
+#~ msgid "Log in without a password"
+#~ msgstr "لُج دون كلمة سر"
+
+#~ msgid "Disable this account"
+#~ msgstr "عطّل هذا الحساب"
+
+#~ msgid "Enable this account"
+#~ msgstr "فعّل هذا الحساب"
+
+#~ msgid "Generate a password"
+#~ msgstr "ولِّد كلمة سر"
+
+#~ msgid "_Action"
+#~ msgstr "الإ_جراء"
+
+#~ msgid "_Show password"
+#~ msgstr "أ_ظهر كلمة السر"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "كيف تضع كلمة سر قوية"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "قصيرة جدا"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "ليست جيدة كفاية"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "ضعيفة"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "معقولة"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "جيّدة"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "قوية"
+
+#~ msgid "_Generate a password"
+#~ msgstr "ولِّد _كلمة سر"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "عليك إدخال كلمة سر جديدة"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "كلمة السّر الجديدة ليست قوية كفاية"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "عليك تأكيد كلمة السر"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "عليك إدخال كلمة السر الحالية"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "كلمة السر الحالية خطأ"
+
+#~ msgid "Switch Modes"
+#~ msgstr "بدّل الأنماط"
+
+#~ msgid "Action"
+#~ msgstr "الإجراء"
+
+#~ msgid "Change the background"
+#~ msgstr "غيّر الخلفية"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "بلوتوث"
+
+#~ msgid "Color management settings"
+#~ msgstr "إعدادات إدارة الألوان"
+
+#~ msgid "British English"
+#~ msgstr "الإنجليزية البريطانية"
+
+#~ msgid "Spanish"
+#~ msgstr "الإسبانية"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "الصينية (المبسطة)"
+
+#~ msgid "Select a region"
+#~ msgstr "اختر منطقة"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "لوحة تفضيلات التاريخ والوقت"
+
+#~ msgid "System Information"
+#~ msgstr "معلومات النظام"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "غيّر إعدادات لوحة المفاتيح"
+
+#~ msgid "Layout Settings"
+#~ msgstr "إعدادات التخطيط"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "اضبط تفضيلات الفأرة ولوحة اللمس"
+
+#~ msgid "Network settings"
+#~ msgstr "إعدادات الشّبكة"
+
+#~ msgid "_Options…"
+#~ msgstr "ال_خيارات…"
+
+#~ msgid "Manage notifications"
+#~ msgstr "أدِر التنبيهات"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "بيانات اعتماد مُنتهية. رجاءً لُج مجددا."
+
+#~ msgid "_Log In"
+#~ msgstr "لُ_ج"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "أدِر حسابات الإنترنت"
+
+#~ msgid "_Mark As Inactive After"
+#~ msgstr "اعتبرها خاملة ب_عد"
+
+#~ msgid "Power management settings"
+#~ msgstr "إعدادات إدارة الطاقة"
+
+#~ msgid "Manufacturers"
+#~ msgstr "المُصنّعين"
+
+#~ msgid "Drivers"
+#~ msgstr "المُشغّلات"
+
+#~ msgid "Privacy settings"
+#~ msgstr "إعدادات الخصوصية"
+
+#~ msgid "Don't retain history"
+#~ msgstr "لا تحتفظ بالتأريخ"
+
+#~ msgid "Lock Screen _After"
+#~ msgstr "أوصِد الشاشة ب_عد"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "غيّر إعدادات المنطقة واللغة"
+
+#~ msgid "Select an input source"
+#~ msgstr "اختر مصْدَر إدخال"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "شاشة الولوج، وحسابات النظام، وحسابات المستخدمين الجُدد تستخدم إعدادات "
+#~ "مُستوى-النظام بالنسبة للمنطقة وإعدادات اللغة."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "شاشة الولوج، وحسابات النظام، وحسابات المستخدمين الجُدد تستخدم إعدادات "
+#~ "مُستوى-النظام بالنسبة للمنطقة وإعدادات اللغة. يمكنك تغيير إعدادات النظام "
+#~ "لتطابق إعداداتك."
+
+#~ msgid "Copy Settings"
+#~ msgstr "انسخ الإعدادات"
+
+#~ msgid "Copy Settings…"
+#~ msgstr "انسخ الإعدادات…"
+
+#~ msgid "Region and Language"
+#~ msgstr "المنطقة واللغة"
+
+#~ msgid "Select a display language"
+#~ msgstr "اختر لغة العرض"
+
+#~ msgid "Add Language"
+#~ msgstr "أضِف لغة"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "اختر منطقة (ستُتطبّق التغييرات مع الولوج التالي)"
+
+#~ msgid "Add Region"
+#~ msgstr "أضِف منطقة"
+
+#~ msgid "Remove Region"
+#~ msgstr "أزِل منطقة"
+
+#~ msgid "Currency"
+#~ msgstr "العملة"
+
+#~ msgid "Examples"
+#~ msgstr "أمثلة"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "اختر لوحة المفاتيح أو غيرها من مصادر الإدخال"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "إعدادات الاختصار"
+
+#~ msgid "Input source:"
+#~ msgstr "مصدر الإدخال:"
+
+#~ msgid "Format:"
+#~ msgstr "النُسق:"
+
+#~ msgid "Your settings"
+#~ msgstr "إعداداتك"
+
+#~ msgid "System settings"
+#~ msgstr "إعدادات النظام"
+
+#~ msgid "Search settings"
+#~ msgstr "إعدادات البحث"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "تفضيلات الإتاحة"
+
+#~ msgid "_Hint"
+#~ msgstr "ال_تلميح"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "قد تُعرض هذه التلميحة في شاشة الولوج، وستظهر لكل مستخدمي النظام.  <b>لا</"
+#~ "b> تضع كلمة السر هنا."
+
+#~ msgid "Fair"
+#~ msgstr "معقولة"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "إعداد تفضيلات لوح واكوم"
+
+#~ msgid "Create virtual device"
+#~ msgstr "أنشئ جهاز افتراضي"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "أقلّ من سنة"
+#~ msgstr[1] "سنة واحدة"
+#~ msgstr[2] "سنتين"
+#~ msgstr[3] "%i سنوات"
+#~ msgstr[4] "%i سنة"
+#~ msgstr[5] "%i سنة"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "أقلّ من شهر"
+#~ msgstr[1] "شهر واحد"
+#~ msgstr[2] "شهرين"
+#~ msgstr[3] "%i شهور"
+#~ msgstr[4] "%i شهرا"
+#~ msgstr[5] "%i شهر"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "أقلّ من أسبوع"
+#~ msgstr[1] "أسبوع واحد"
+#~ msgstr[2] "أسبوعين"
+#~ msgstr[3] "%i أسابيع"
+#~ msgstr[4] "%i أسبوعا"
+#~ msgstr[5] "%i أسبوع"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "أقلّ من أسبوع"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "الجهاز ليس مُدار الألوان."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "هذا الجهاز يستخدم بيانات التصنيع المعايرة."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "ليس لهذا الجهاز إعداد مناسب لتصحيح ألون كامل الشاشة."
+
+#~ msgid "Not specified"
+#~ msgstr "غير محدّد"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "لم يُعثر على جهاز يدعم إدارة الألوان"
+
+#~ msgid "Add device"
+#~ msgstr "أضف جهازًا"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "اضف جهازًا افتراضيًا"
+
+#~ msgid "Remove a device"
+#~ msgstr "أزِل جهازا"
+
+#~ msgid "Unspecified"
+#~ msgstr "غير محدّد"
+
+#~ msgid "Out of range"
+#~ msgstr "خارج المدى"
+
+#~ msgid "_Disconnect"
+#~ msgstr "ا_قطع الاتصال"
+
+#~ msgid "_Connect"
+#~ msgstr "اتّ_صل"
+
+#~ msgid "_Settings…"
+#~ msgstr "الإ_عدادات…"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "تحذير انخفاض البطارية، تبقى %s"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "استخدام طاقة البطارية - تبقى %s"
+
+#~ msgid "Using battery power"
+#~ msgstr "استخدام طاقة البطارية"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "يشحن - اكتمل الشحن"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "استخدام مزود الطاقة الغير منقطعة - تبقى %s"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "تحذير انخفاض مزود الطاقة الغير منقطعة"
+
+#~ msgid "Using UPS power"
+#~ msgstr "استخدام طاقة مزود الطاقة الغير منقطعة"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "بطاريتك الثانوية مكتملة الشحن"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "بطاريتك الثانوية فارغة"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "تشحن - مكتملة الشحن"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr "فائدة: يؤثّر <a href=\"screen\">سطوع الشاشة</a> على استهلاك الطاقة"
+
+#~ msgid "Don't suspend"
+#~ msgstr "لا تعلِّق"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "علِّق عند الخمول لـ"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "السطوع والقفل"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "إعدادات سطوع وقفل الشاشة"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "سطوع;قفل;فارغ;شاشة;"
+
+#~ msgid "Screen turns off"
+#~ msgstr "إطفاء الشاشة"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "أخفِت ضوء ال_شاشة لتوفير الطاقة"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "لا توصد عندما أكون في البيت"
+
+#~ msgid "Locations…"
+#~ msgstr "المكان…"
+
+#~ msgid "Show _notifications when locked"
+#~ msgstr "أظهر ال_تنبيهات عندما يكون موصدًا"
+
+#~ msgid "Lock"
+#~ msgstr "أوصِد"
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "اسم المستخدم '%s' موجود بالفعل."
+
+#~ msgid "This user does not exist."
+#~ msgstr "المستخدم غير موجود."
+
+#~ msgid "Browse Files..."
+#~ msgstr "تصفح الملفات..."
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "التشكيلات المتوفرة لشاشات العرض"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "التشكيلات المتوفرة للماسحات الضوئية"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "التشكيلات المتوفرة للطابعات"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "التشكيلات المتوفرة للكاميرات"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "التشكيلات المتوفرة لكاميرات الوِب"
+
+#~ msgid "English"
+#~ msgstr "الإنجليزية"
+
+#~ msgid "German"
+#~ msgstr "الألمانية"
+
+#~ msgid "French"
+#~ msgstr "الفرنسيّة"
+
+#~ msgid "Russian"
+#~ msgstr "الروسية"
+
+#~ msgid "Arabic"
+#~ msgstr "العربية"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "طِراز غير معروف"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "الولوج التالي سيحاول استخدام الواجهة الاعتيادية."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "الولوج التالي سيستخدم النمط الاحتياطي والذي سيستخدم الواجهة التقليدية "
+#~ "المخصصة لعتاد الرسوميات غير المدعوم."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "احتياطية"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "اعتيادية"
+
+#~ msgid "_Other Media..."
+#~ msgstr "وسائط أ_خرى..."
+
+#~ msgid "Experience"
+#~ msgstr "الواجهة"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "أرغم النمط الا_حتياطي"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "الشبكة;لاسلكي;عنوان أي بي;بروتوكول الإنترنت;الشبكة المحلية;الوسيط"
+
+#~ msgid "_Options..."
+#~ msgstr "ال_خيارات..."
+
+#~ msgid "C_reate..."
+#~ msgstr "أ_نشئ..."
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "نقطة اتصال لا سلكية"
+
+#~ msgid "Wireless"
+#~ msgstr "لاسلكية"
+
+#~ msgid "Mesh"
+#~ msgstr "عُرَوِيّة"
+
+#~ msgid "_Show"
+#~ msgstr "أ_ظهر"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "انسخ الإعدادات..."
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr "اختر لغة العرض (ستُتطبّق التغييرات مع الولوج التالي)"
+
+#~ msgid "Remove Language"
+#~ msgstr "أزِل لغة"
+
+#~ msgid "Install languages..."
+#~ msgstr "ثبّت اللغات..."
+
+#~ msgid "Locations..."
+#~ msgstr "الأماكن..."
+
+#~ msgid "Enable debugging code"
+#~ msgstr "فعلّ كود التنقيح"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — بريمج التحكم في شدة الصوت"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "اعرض التحكم في شدة الصوت"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "شدة مَخْرَج الصوت"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "فشل بدء تفضيلات الصوت: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "أص_مت"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "_تفضيلات الصوت"
+
+#~ msgid "Muted"
+#~ msgstr "مُصمَت"
+
+#~ msgid "Options..."
+#~ msgstr "الخيارات..."
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "اللون"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "بلا"
+
+#~ msgid "User Accounts"
+#~ msgstr "حسابات المستخدمين"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "تصفّح لمزيد من الصور..."
+
+#~ msgid "Map Buttons..."
+#~ msgstr "تعيين أزرار..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "عايِر..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- إعدادات النظام"
+
+#~ msgid "System Settings"
+#~ msgstr "إعدادات النظام"
+
+#~ msgid "Security Key"
+#~ msgstr "مفتاح الأمن"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "قناع الشبكة الفرعية"
+
+#~ msgid "_Search by Address"
+#~ msgstr "ا_بحث حسب العنوان"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "لا يعمل FirewallD. يحتاج اكتشاف طابعة الشبكة إلى تفعيل خدمات mdns و ipp و "
+#~ "ipp-client و samba-client في الجدار الناري."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "محلية"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "على الشبكة"
+
+#~ msgid "Device types"
+#~ msgstr "أنواع الأجهزة"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "إعداد تلقائي"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "يفتح الجدار الناري لاتصالات mDNS"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "يفتح الجدار الناري لاتصالات Samba"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "يفتح الجدار الناري لاتصالات IPP"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "لاختبار إعدادات النقر المزدوج، جرّب النقر المزدوج على الوجه."
+
+#~ msgid "Dasher"
+#~ msgstr "داشر"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "Caribou"
+#~ msgstr "كاريبو"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "ا_ختر جهازا لإعداده:"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "أضف خلفية"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "أزل الخلفية"
+
+#~ msgid "Swap colors"
+#~ msgstr "بدّل الألوان"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "تدرج أفقي"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "تدرج رأسي"
+
+#~ msgid "Solid Color"
+#~ msgstr "لون سادة"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "ألوان وتدرجات"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "التقط صورة للشاشة"
+
+#~ msgid "_Right-handed"
+#~ msgstr "فأرة لليد الي_منى"
+
+#~ msgid "_Left-handed"
+#~ msgstr "فأرة لليد اليسر_ى"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "أ_ظهر موقع الفأرة عند ضغط مفتاح Ctrl"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "ال_تسارع:"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "الح_ساسية:"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "السحب والإفلات"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "ال_عتبة:"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "اسحب العتبة"
+
+#~ msgid "_Timeout:"
+#~ msgstr "ا_لمهلة:"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "فعّل _نقرات الفأرة في لوحة اللمس"
+
+#~ msgid "_Disabled"
+#~ msgstr "مع_طّل"
+
+#~ msgid "Account _type"
+#~ msgstr "_نوع الحساب"
+
+#~ msgid "Acti_on:"
+#~ msgstr "الإ_جراء:"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "أخرى..."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "إنشاء نقطة اتصال على أي حال؟"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "قطع الاتصال بـ %s وأنشئ نقطة اتصال جديدة؟"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "هذا اتصالك الوحيد بالإنترنت."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "أنشئ _نقطة اتصال"
+
+#~ msgid "_Network Name"
+#~ msgstr "اسم ال_شبكة"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "أو_قف نقطة الاتصال..."
+
+#~ msgid "_Back"
+#~ msgstr "ا_رجع"
+
+#~ msgid "Allowed users"
+#~ msgstr "المستخدمين المسموح لهم"
+
+#~ msgid "Disable VPN"
+#~ msgstr "عطّل VPN"
+
+#~ msgid "HTTP Port"
+#~ msgstr "منفذ HTTP"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "منفذ HTTPS"
+
+#~ msgid "FTP Port"
+#~ msgstr "منفذ FTP"
+
+#~ msgid "Select an account"
+#~ msgstr "اختر حسابًا"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "لإضافة حساب جديد، اختر أولًا نوع الحساب"
+
+#~ msgid "_Add..."
+#~ msgstr "أ_ضِف…"
+
+#~ msgid "Tip:"
+#~ msgstr "تلميح:"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "تؤثر في كمية الطاقة المستهلكة"
+
+#~ msgid "Add Layout"
+#~ msgstr "أضِف تخطيطا"
+
+#~ msgid "Remove Layout"
+#~ msgstr "أزِل تخطيطا"
+
+#~ msgid "Preview Layout"
+#~ msgstr "معاينة التخطيط"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "النوافذ الجديدة تستخدم التخطيط المبدئي"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "النوافذ الجديدة تستخدم تخطيط النافذة السابقة"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "اعرض وعدّل خيارات تخطيط لوحة المفاتيح"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "ا_ستعد المبدئيات"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "غيّر إعدادات لوحة المفاتيح الحالية إلى\n"
+#~ "الإعدادات المبدئية"
+
+#~ msgid "Layouts"
+#~ msgstr "التخطيطات"
+
+#~ msgid "Layout"
+#~ msgstr "التخطيط"
+
+#~ msgid "Change contrast:"
+#~ msgstr "غيّر التباين:"
+
+#~ msgid "_Text size:"
+#~ msgstr "حجم ال_نص:"
+
+#~ msgid "Increase size:"
+#~ msgstr "كبّر الحجم:"
+
+#~ msgid "Decrease size:"
+#~ msgstr "قلل الحجم:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "التقريب"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "اكتب هنا لاختبار الإعدادات"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 الشاشة"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 الشاشة"
+
+#~ msgid "Create new account"
+#~ msgstr "أنشئ حسابا جديدا"
+
+#~ msgid "_Account Type"
+#~ msgstr "_نوع الحساب"
+
+#~ msgid "Cr_eate"
+#~ msgstr "أ_نشئ"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "اختر كلمة سر مُوَلّدة"
+
+#~ msgid "More choices..."
+#~ msgstr "المزيد من الخيارات…"
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "لوح رسوميات Wacom"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "تعذرت معرفة الجلسة أثناء تطبيق تضبيطات العرض"
+
+#~ msgid "System Info"
+#~ msgstr "معلومات النظام"
+
+#~ msgid "_Photos:"
+#~ msgstr "_صور:"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "بدّل التباين"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "بدّل المكبرة"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "بدّل قارئ الشاشة"
+
+#~ msgid "Accelerator key"
+#~ msgstr "مفتاح اختصار"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "مُغيِّرات مفاتيح الاختصار"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "رمز مفتاح الاختصار"
+
+#~ msgid "Accel Mode"
+#~ msgstr "نسق الاختصار"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "نوع مفتاح الاختصار."
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "الكثير من الاختصارات المخصصة"
+
+#~ msgid "Battery discharging"
+#~ msgstr "البطارية تُستخدم"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s حتى تُشحن (%.0lf%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s حتى تفرغ (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% مشحون"
+
+#~ msgid "Ask me"
+#~ msgstr "اسألني"
+
+#~ msgid "Shutdown"
+#~ msgstr "أطفئ"
+
+#~ msgid "Key"
+#~ msgstr "المفتاح"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "مفتاح GConf الذي يتبعه محرّر الخاصية هذا."
+
+#~ msgid "Callback"
+#~ msgstr "اتصال معاكس"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "فعّل هذا الاتصال المعاكس إثر تغيير قيمة بالمفتاح"
+
+#~ msgid "Change set"
+#~ msgstr "مجموعة التغييرات"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "مجموعة تغييرات GConf المحتوية على بيانات سترسل إلى عميل gconf عند التطبيق"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "تحويل إلى نداء معاكس للودجة"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "الاتصال المعاكس الذي يتم تفعيله لتحويل البيانات من GConf للودجة"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "تحويل من النداء المعاكس للودجة"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "الاتصال المعاكس الذي يتم تفعيله لتحويل البيانات من الودجة إلى GConf"
+
+#~ msgid "UI Control"
+#~ msgstr "كائن واجهة المستخدم"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "الكائن الذي يتحكم في الخاصية (عادة ودجة)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "بيانات كائن محرّر الخاصيات"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "البيانات المعرفة المطلوبة من محرّر الخاصية المحدّد"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "الاتصال المعاكس المفرغ لمحرر الخاصيات من بياناته"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "الاتصال المعاكس الذي يتم تفعيله عند تحرير بيانات جسم محرّر الخاصيات"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "تعذّر إيجاد الملف '%s'.\n"
+#~ "\n"
+#~ "رجاء تأكد من وجوده وأعد المحاولة مرّة اخرى، أو اختر صورةَ خلفية مغايرة."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "لا أعرف كيف أفتح الملف '%s'.\n"
+#~ "قد يكون نوع الصورة غير مدعوم الآن.\n"
+#~ "\n"
+#~ "رجاء اختر صورة أخرى."
+
+#~ msgid "Please select an image."
+#~ msgstr "رجاء اختر صورة."
+
+#, fuzzy
+#~ msgid "Centered"
+#~ msgstr "موسَّطة"
+
+#, fuzzy
+#~ msgid "Show"
+#~ msgstr "أ_ظهر"
+
+#~ msgid "Create a user"
+#~ msgstr "أنشئ مستخدما"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "الوسائط والتشغيل التلقائي"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "اضبط تفضيلات الوسائط والتشغيل التلقائي"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "اسطوانة;قرص;صوت;صورة;فديو;"
+
+#, fuzzy
+#~ msgid "_Turn off after:"
+#~ msgstr "أ_طفئ بعد:"
+
+#~ msgid "Mute"
+#~ msgstr "أصمِت"
+
+#~ msgid "Current network location"
+#~ msgstr "مكان الشبكة الحالي"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "مسار جلب المزيد من الخلفيات"
+
+#~ msgid "More themes URL"
+#~ msgstr "مسار جلب المزيد من السمات"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "يحدد هذا اسما لمكانك الحالي. يستخدم هذا لتحديد إعدادات وسيط الشبكة "
+#~ "المناسبة."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr "مسار لجلب المزيد من خلفيات سطح المكتب. إذا ترك فارغا لن يظهر."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr "مسار لجلب المزيد من سمات سطح المكتب. إذا ترك فارغا لن يظهر."
+
+#~ msgid "Locked"
+#~ msgstr "مُوصد"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "المربع الحواري غير مُوصَد.\n"
+#~ "انقر لمنع أي تغييرات"
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "المربع الحواري مُوصَد.\n"
+#~ "انقر للسماح بالتغييرات"
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "تمنع سياسة النظام التعديلات.\n"
+#~ "راجع مدير النظام."
+
+#~ msgid "24-Hour Time"
+#~ msgstr "توقيت 24 ساعة"
+
+#~ msgid "Upside-down"
+#~ msgstr "رأسا على عقب"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f ك.بايت"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f م.بايت"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f ج.بايت"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f ت.بايت"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f ب.بايت"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f إ.بايت"
+
+#~ msgid "Photos"
+#~ msgstr "الصور"
+
+#~ msgid "Updates Available"
+#~ msgstr "يوجد تحديثات"
+
+#~ msgid "Web"
+#~ msgstr "الوب"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "استخدم التخطيط المبدئي في النوافذ الجديدة"
+
+#~ msgid "Use previous window's layout in new windows"
+#~ msgstr "استخدم تخطيط النافذة السابقة في النوافذ الجديدة"
+
+#~ msgid "On AC power:"
+#~ msgstr "على الطاقة الاعتيادية:"
+
+#~ msgid "Put the computer to sleep when inactive:"
+#~ msgstr "ضع الحاسوب لينام عندما لا يكون نشطا:"
+
+#~ msgid "When the sleep button is pressed:"
+#~ msgstr "عند ضغط زر الإسبات:"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "لوحة;مفاتيح;فأرة;إتاحة;"
+
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">عال\\معكوس</span>"
+
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">عال</span>"
+
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">منخفض</span>"
+
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">عادي</span>"
+
+#~ msgid "An error has occured during a maintenance command."
+#~ msgstr "حدث عطل أثناء تنفيذ أمر الصيانة."
+
+#~ msgid "DSL"
+#~ msgstr "DSL"
+
+#~ msgid "Locate Pointer"
+#~ msgstr "حدد موقع المؤشر"
+
+#~ msgid "16"
+#~ msgstr "16"
+
+#~ msgid "2010"
+#~ msgstr "2010"
+
+#~ msgid "Info"
+#~ msgstr "معلومات"
+
+#~ msgid "Set the system proxy settings"
+#~ msgstr "اضبط إعدادات وسيط الشبكة"
+
+#~ msgid "Virtual private network"
+#~ msgstr "شبكة خاصة افتراضية"
+
+#~ msgid "The running NetworkManager version is not compatible (too new)."
+#~ msgstr "نسخة NetworkManager التي تعمل غير متوافقة (حديثة جدا)"
+
+#~ msgid "The running NetworkManager version is not compatible (too old)."
+#~ msgstr "نسخة NetworkManager التي تعمل غير متوافقة (قديمة جدا)"
+
+#~ msgid "IP Address:"
+#~ msgstr "عنوان IP:"
+
+#~ msgid "Preparing"
+#~ msgstr "يُجهّز"
+
+#~ msgctxt "Account type"
+#~ msgid "Supervised"
+#~ msgstr "تحت الإشراف"
+
+#~ msgid "Supervised"
+#~ msgstr "تحت الإشراف"
+
+#~ msgid "Secure HTTP Proxy:"
+#~ msgstr "وسيط HTTP الآمن:"
+
+#~ msgid "Chipset"
+#~ msgstr "البطاقة"
+
+#~ msgid "LowContrast"
+#~ msgstr "تباين منخفض"
+
+#~ msgid "Use an alternative form of text input"
+#~ msgstr "استخدم صورة بديلة من الإدخال النصّي"
+
+#~ msgid "Language:"
+#~ msgstr "اللغة:"
+
+#~ msgid "Ctrl+Alt+0"
+#~ msgstr "Ctrl+Alt+0"
+
+#~ msgid "Ctrl+Alt+4"
+#~ msgstr "Ctrl+Alt+4"
+
+#~ msgid "Ctrl+Alt+8"
+#~ msgstr "Ctrl+Alt+8"
+
+#~ msgid "Ctrl+Alt+="
+#~ msgstr "Ctrl+Alt+="
+
+#~ msgid "Shift+Ctrl+Alt+-"
+#~ msgstr "Shift+Ctrl+Alt+-"
+
+#~ msgid "Shift+Ctrl+Alt+="
+#~ msgstr "Shift+Ctrl+Alt+="
+
+#~ msgid "%i kb/s"
+#~ msgstr "%i ك.بايت\\ث"
+
+#~ msgid "Graphics:"
+#~ msgstr "الرسوميات:"
+
+#, fuzzy
+#~ msgid "Always use fallback:"
+#~ msgstr "استخدم الاحتياط دائما:"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "خطأ عند إلغاء ضبط مفتاح الاختصار في قاعدة بيانات الإعدادات: %s"
+
+#~ msgid "More Info"
+#~ msgstr "المزيد من المعلومات"
+
+#~ msgctxt "printer state"
+#~ msgid "Idle"
+#~ msgstr "ساكنة"
+
+#~ msgid "By _country"
+#~ msgstr "بالب_لد"
+
+#~ msgid "By _language"
+#~ msgstr "بالل_غة"
+
+#~ msgid "_Country:"
+#~ msgstr "الب_لد:"
+
+#~ msgid "_Variants:"
+#~ msgstr "ال_تنويعات:"
+
+#~ msgid "Upside Down"
+#~ msgstr "رأسا على عقب"
+
+#~ msgid "Description:"
+#~ msgstr "الوصف:"
+
+#~ msgid "Hold"
+#~ msgstr "علّق"
+
+#~ msgid "Queue"
+#~ msgstr "الطابور"
+
+#~ msgid "Release"
+#~ msgstr "أطلِق"
+
+#~ msgid "Show / hide printer's jobs"
+#~ msgstr "أظهر أو أخفِ مهام الطابعة"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "_طراز لوحة المفاتيح:"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "انقل تخطيط لوحة المفاتيح المحدد إلى أعلى"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "اطبع رسما لتخطيط لوحة المفاتيح المحدد"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "احذف تخطيط لوحة المفاتيح المحدد من القائمة"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "اختر تخطيط لوحة مفاتيح ليُضاف إلى القائمة"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "اختر طراز لوحة المفاتيح"
+
+#~ msgid "_Models:"
+#~ msgstr "ال_طرُز:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "ال_مُنتِج:"
+
+#~ msgid "Vendors"
+#~ msgstr "المُنتِج"
+
+#~ msgid "Battery power and inactive for:"
+#~ msgstr "البطارية غير نشطة منذ:"
+
+#~ msgid "Put the computer to sleep when on:"
+#~ msgstr "ضع الحاسوب لينام عندما يعمل على:"
+
+#~ msgid "Restrictions:"
+#~ msgstr "القيود:"
+
+#~ msgid ""
+#~ "A guest account will allow anyone to temporarily log in to this computer "
+#~ "without a password.  For security, remote logins to this account are not "
+#~ "allowed.\n"
+#~ "\n"
+#~ "                    <b>When the guest user logs out, all files and data "
+#~ "associated with the account will be deleted.</b>"
+#~ msgstr ""
+#~ "سيتيح حساب الضيف لأي كان أن يلج مؤقتا إلى هذا الحاسوب بدون كلمة سر. "
+#~ "للأمان، سن يُسمح لهذا الحساب بالولوج عن بعد.\n"
+#~ "\n"
+#~ "                    <b>عندما يخرج المستخدم الضيف فستحذف كل الملفات "
+#~ "والبيانات المتعلقة بهذا الحساب.</b>"
+
+#~ msgid "Accounts"
+#~ msgstr "الحسابات"
+
+#~ msgid "Address Book Card:"
+#~ msgstr "بطاقة دفتر العناوين:"
+
+#~ msgid "Allow guests to log in to this computer"
+#~ msgstr "اسمح للضيوف بالولوج إلى هذا الحاسوب"
+
+#~ msgid "E-mail address:"
+#~ msgstr "عنوان البريد الإلكتروني:"
+
+#~ msgid "Show Shutdown, Suspend and Restart actions"
+#~ msgstr "أظهر إجراءات الإطفاء والتعليق وإعادة التشغيل"
+
+#~ msgid "Show list of users"
+#~ msgstr "أظهر قائمة المستخدمين"
+
+#~ msgid "Show password hints"
+#~ msgstr "أظهر تلميحات كلمات السر"
+
+#~ msgid "2 GB"
+#~ msgstr "2 ج.بايت"
+
+#~ msgid "80 GB (4 GB free)"
+#~ msgstr "80 ج.بايت (4 ج.بايت خالية)"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "يمكن ال_تحكم في المؤشر باستخدام لوحة المفاتيح"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "ا_كتب لاختبار الإعدادات:"
+
+#~ msgid "Desktop"
+#~ msgstr "سطح المكتب"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "اختر نوع النقر م_سبقًا"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "اختر نو_ع النقر بحركات الفأرة"
+
+#~ msgid "D_rag click:"
+#~ msgstr "نقر ال_سحب:"
+
+#~ msgid "Dwell Click"
+#~ msgstr "النقر السلبي"
+
+#~ msgid "Show click type _window"
+#~ msgstr "أظ_هر نافذة نوع النقر"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr "يمكنك أيضًا استخدام بريمج النقر السلبي لاختيار نوع النقر."
+
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "ابتد_ئ بالنقر عند توقف حركة المؤشر"
+
+#~ msgid "_Single click:"
+#~ msgstr "نقرة م_فردة:"
+
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr "يسبب النقر ال_ثانوي عن طريق الاستمرار بضغط الزر الأولي"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "التطبيقات المفضّلة"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "ابدأ تقنية الإعانة المرئية المفضلة"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "الإعانة المرئية"
+
+#~ msgid "Error setting default browser: %s"
+#~ msgstr "عطل في تحديد المتصفح المبدئي: %s"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "سيتم تبديل كل مصادفات %s بالرابط الحقيقي"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "الأ_مر:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "شا_رة التنفيذ:"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "المرسال الفوري"
+
+#~ msgid "Mail Reader"
+#~ msgstr "قارئ البريد"
+
+#~ msgid "Mobility"
+#~ msgstr "الحركيّة"
+
+#~ msgid "Run at st_art"
+#~ msgstr "شغّ_ل عند البدء"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "شغّل في _طرفية"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "محاكي الطرفية"
+
+#~ msgid "Text Editor"
+#~ msgstr "محرّر النصوص"
+
+#~ msgid "Visual"
+#~ msgstr "مرئي"
+
+#~ msgid "Web Browser"
+#~ msgstr "متصفّح الوِب"
+
+#~ msgid "_Run at start"
+#~ msgstr "_شغل عند البدء"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "مشغل موسيقى بانشي"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "محاكي طرفية دبيان"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "مكبّر جنوم بدون قارئ الشاشة"
+
+#~ msgid "GNOME OnScreen Keyboard"
+#~ msgstr "لوحة مفاتيح جنوم على الشاشة"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "طرفية جنوم"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "جنوبرنيكوس"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "جنوبرنيكوس مع المكبّر"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "مكبّر كدي بدون قارئ الشاشة"
+
+#~ msgid "Konsole"
+#~ msgstr "كونسول"
+
+#~ msgid "Linux Screen Reader"
+#~ msgstr "قارئ شاشة لينكس"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "قارئ شاشة لينكس مع المكبّر"
+
+#~ msgid "Listen"
+#~ msgstr "استمع"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "مشغل الموسيقى موين"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Orca"
+#~ msgstr "أوركا"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "أوركا مع المكبّر"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "مشغل الموسيقى أنغام"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "طرفيّة X القياسيّة"
+
+#~ msgid "Terminator"
+#~ msgstr "Terminator"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "مشغل الأفلام توتم"

--- a/po/as.po
+++ b/po/as.po
@@ -9,9 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: as\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-08-20 06:31+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-08-20 13:00+0530\n"
 "Last-Translator: Nilamdyuti Goswami <ngoswami@redhat.com>\n"
 "Language-Team: Assamese <kde-i18n-doc@kde.org>\n"
@@ -22,559 +21,467 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!=1)\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "এপ্লিকেচনসমূহ"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "কোনো এপ্লিকেচন পোৱা নগল"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "ইনস্টল কৰা হয়েছে"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "খোলক (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "বিৱৰণসমূহ দৰ্শন কৰক"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "বিচাৰক"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "নিষ্ক্ৰীয়"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "অধিসূচনাসমূহ"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "অধিসূচনাসমূহ দেখুৱাওক (_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "পটভূমি"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "স্ক্ৰিনশ্বটসমূহ"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "ৱালপেপাৰসমূহ"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "শব্দ"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "চৰ্টকাটসমূহ"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "কিবৰ্ড চৰ্টকাটসমূহ"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s কেমেৰা"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "মাইক্ৰোফোন ভলিউম"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "অবস্থান সেৱাসমূহ (_L)"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "বিল্ট-ইন ৱেবকেম"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "কোনো অঞ্চল পোৱা নগল"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "প্ৰদৰ্শনৰ ধৰণ"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "সংযোগৰ গতী"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "পুনৰসংহতি কৰক"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "এপ্লিকেচনসমূহ"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>ঈ-মেইল</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "বিন্যাস:(_S)"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "অবিকল্পিত"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "পটভূমি"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "দিনটোত কৰা পৰিবৰ্তনসমূহ"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "আলেখ্য যোগ কৰক (_A)…"
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "Lock Screen"
-msgstr "পৰ্দা লক কৰক"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "ফ্ৰাঞ্চ"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "টাইল"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "জুম"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "কেন্দ্ৰ"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "স্কেইল"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "পূৰ্ণ কৰক"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "বিস্তাৰ"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:442
-msgid "Select Background"
-msgstr "পটভূমি বাছক"
-
-#: ../panels/background/cc-background-chooser-dialog.c:463
-msgid "Wallpapers"
-msgstr "ৱালপেপাৰসমূহ"
-
-#: ../panels/background/cc-background-chooser-dialog.c:472
-msgid "Pictures"
-msgstr "ছবিসমূহ"
-
-#: ../panels/background/cc-background-chooser-dialog.c:481
-msgid "Colors"
-msgstr "ৰঙবোৰ"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:540
-msgid "No Pictures Found"
-msgstr "কোনো ছবি পোৱা নগল"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:558
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "গৃহ"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:570
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "আপুনি আপোনাৰ %s ফোল্ডাৰলৈ ছবি যোগ কৰিব পাৰিব আৰু সিহত ইয়াত দেখা যাব"
-
-#: ../panels/background/cc-background-chooser-dialog.c:592
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1537
-#: ../panels/display/cc-display-panel.c:1976
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1240
-#: ../panels/network/net-device-wifi.c:1448
-#: ../panels/printers/cc-printers-panel.c:1947
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-#: ../panels/user-accounts/um-photo-dialog.c:95
-#: ../panels/user-accounts/um-photo-dialog.c:222
-#: ../panels/user-accounts/um-user-panel.c:513
-msgid "_Cancel"
-msgstr "বাতিল কৰক (_C)"
-
-#: ../panels/background/cc-background-chooser-dialog.c:593
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:97
-msgid "Select"
-msgstr "বাছক"
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "একাধিক মাপ"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "কোনো ডেস্কটপ পটভূমি নাই"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "বৰ্তমান পটভূমী"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "আপোনাৰ পটভূমি ছবিক এটা ৱালপেপাৰ অথবা ফ'টোলে পৰিবৰ্তন কৰক"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "ৱালপেপাৰ;পৰ্দা;ডেস্কটপ;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "ব্লুটুথ অসামৰ্থবান"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "সামৰ্থবান কৰক"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "কোনো ব্লু-টুথ এডাপ্টাৰ পোৱা নগল"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "ব্লুটুথ অংশীদাৰী"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "বিমান অৱস্থা (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "ব্লু-টুথ হাৰ্ডৱেৰ চুইচ দ্বাৰা অসামৰ্থবান"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1688
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "বিমান অৱস্থা (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "বিমান অৱস্থা (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "ব্লুটুথ"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "ব্লুটুথ অন বা অফ কৰক আৰু আপোনাৰ ডিভাইচসমূহ সংযোগ কৰক"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "আপোনাৰ মানাংকন ডিভাইচক বৰ্গৰ ওপৰত ৰাখি 'আৰম্ভ কৰক' টিপক"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
-msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
-msgstr "আপোনাৰ মানাংকন ডিভাইচক মানাংকন অৱস্থানত ৰাখি 'অব্যাহত ৰাখক' টিপক"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr "আপোনাৰ মানাংকন ডিভাইচক পৃষ্ঠ অৱস্থানত ৰাখি 'অব্যাহত ৰাখক' টিপক"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "লেপটপ লিড বন্ধ কৰক"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "এটা অভ্যন্তৰীক ত্ৰুটি দেখা দিছে যাক উদ্ধাৰ কৰিব নোৱাৰি।"
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "মানাংকনৰ বাবে প্ৰয়োজনীয় সঁজুলিসমূহ ইনস্টল্ড নাই।"
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "আলেখ্য সৃজন কৰিব পৰা নগল।"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "লক্ষ্য বগাবিন্দু অপ্ৰাপ্য আছিল।"
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "সম্পূৰ্ণ!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "মানাংকন ব্যৰ্থ হল!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "আপুনি মানাংকন ডিভাইচ আতৰাব পাৰে।"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "প্ৰগতিশীল অৱস্থাত মানাংকন ডিভাইচক অসুবিধা নিদিব"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "লেপটপৰ পৰ্দা"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "বিল্ট-ইন ৱেবকেম"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s মনিটৰ"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s স্কেনাৰ"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s কেমেৰা"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s প্ৰিন্টাৰ"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s ৱেবকেম"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s ৰ বাবে ৰঙ ব্যৱস্থাপনা সামৰ্থবান কৰক"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s ৰ বাবে ৰঙৰ আলেখ্যসমূহ দেখুৱাওক"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-msgid "Not calibrated"
-msgstr "মানাংকিত নহয়"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "অবিকল্পিত: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "ৰঙস্থান: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "আলেখ্য পৰীক্ষা কৰক: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "ICC আলেখ্য ফাইল বাছক"
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "ইমপোৰ্ট কৰক (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "সমৰ্থিত ICC আলেখ্যসমূহ"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "সৰ্বধৰণৰ ফাইল"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "পৰ্দা"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "ফাইল আপল'ড কৰিবলে ব্যৰ্থ: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "আলেখ্যক চিহ্নিত স্থানলৈ আপল'ড কৰা হৈছে:"
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "এই URL লিখি ৰাখক।"
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
-"এই কমপিউটাৰ পুনৰাম্ভ কৰক আৰু আপোনাৰ স্বাভাৱিক অপাৰেটিং চিস্টেম বুট কৰক।"
 
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "আলেখ্যক ডাউনল'ড কৰি ইনস্টল কৰিবলে URL ক আপোনাৰ ব্ৰাউছাৰত টাইপ কৰক।"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "আলেখ্য সংৰক্ষণ কৰক"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "সংৰক্ষণ (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "নিৰ্বাচিত ডিভাইচৰ বাবে এটা ৰঙ আলেখ্য সৃষ্টি কৰক"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
 msgstr ""
-"মাপ লোৱা ডিভাইচ চিনাক্ত কৰা হোৱা নাই। অনুগ্ৰহ কৰি নিৰীক্ষণ কৰক ই চলি আছে আৰু "
-"সঠিকভাৱে সংযুক্ত।"
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "মাপ লোৱা ডিভাইচয় প্ৰিন্টাৰ আলেখ্যকৰণ সমৰ্থন নকৰে।"
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "কোনো এপ্লিকেচনে বৰ্তমানে অডিঅ' বজোৱা বা ৰেকৰ্ড কৰা নাই।"
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "ডিভাইচ ধৰণ বৰ্তমানে সমৰ্থিত নহয়।"
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "প্ৰামাণিক স্থান"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "পৰীক্ষামূলক আলেখ্য"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "অধিক ছবিৰ বাবে ব্ৰাউছ কৰক"
 
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "স্বচালিত"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "নিম্ন গুণ"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "মধ্যম গুণ"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "উচ্চ গুণ"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "অবিকল্পিত RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "অবিকল্পিত CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "অবিকল্পিত ধূসৰ"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "বিক্ৰেতা দ্বাৰা প্ৰদান কৰা কলঘৰ মানাংকিত তথ্য"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "এই আলেখ্যৰ সৈতে সম্পূৰ্ণ-পৰ্দা প্ৰদৰ্শন শুদ্ধ কৰা সম্ভব নহয়"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "এই আলেখ্য আৰু সঠিক নহব পাৰে"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "মানাংকন প্ৰদৰ্শন কৰক"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr "বাতিল কৰক"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "বাতিল কৰক (_C)"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "আৰম্ভ কৰক"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "অব্যাহত ৰাখক"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "কৰা হল"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "কৰা হল (_D)"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "পৰ্দা মানাংকন"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "মানাংকনৰ গুণ"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"মানাংকনে এটা আলেখ্য উৎপন্ন কৰিব যি আপুনি আপোনাৰ পৰ্দাৰ ৰঙ ব্যৱস্থাপনা কৰাৰ "
-"বাবে "
+"মানাংকনে এটা আলেখ্য উৎপন্ন কৰিব যি আপুনি আপোনাৰ পৰ্দাৰ ৰঙ ব্যৱস্থাপনা কৰাৰ বাবে "
 "ব্যৱহাৰ কৰিব পাৰিব। মানাংকনত যিমান অধিক সময় ব্যয় হব, ৰঙৰ আলেখ্য তিমান ভাল হব।"
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "মানাংকন হৈ থাকোতে আপুনি আপোনাৰ কমপিউটাৰ ব্যৱহাৰ কৰিব সক্ষম নহব।"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "গুণ"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "আনুমানিক সময়"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "মানাংকনৰ গুণ"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "মানাংকনৰ বাবে ব্যৱহাৰ কৰিব বিচৰা সংবেদনশীল ডিভাইচ বাছক।"
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "মানাংকন ডিভাইচ"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "সংযুক্ত থকা প্ৰদৰ্শনৰ ধৰণ বাছক।"
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "মানাংকনৰ বাবে ব্যৱহাৰ কৰিব বিচৰা সংবেদনশীল ডিভাইচ বাছক।"
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "প্ৰদৰ্শনৰ ধৰণ"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "সংযুক্ত থকা প্ৰদৰ্শনৰ ধৰণ বাছক।"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "আলেখ্য বগাবিন্দু"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -582,33 +489,31 @@ msgstr ""
 "এটা প্ৰদৰ্শন লক্ষ্য বগা বিন্দু বাছক। বেছিৰভাগ প্ৰদৰ্শনক এটা D65 illuminant লে "
 "মানাংকন কৰিব লাগিব।"
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "আলেখ্য বগাবিন্দু"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "প্ৰদৰ্শনৰ উজ্জ্বলতা"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"অনুগ্ৰহ কৰি আপোনাৰ বাবে অনুকূলিত এটা উজ্জ্বলতালে প্ৰদৰ্শন সংহতি কৰক। ৰঙ "
-"ব্যৱস্থাপনা এই "
+"অনুগ্ৰহ কৰি আপোনাৰ বাবে অনুকূলিত এটা উজ্জ্বলতালে প্ৰদৰ্শন সংহতি কৰক। ৰঙ ব্যৱস্থাপনা এই "
 "উজ্জ্বলতা স্তৰত সঠিক হব।"
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
-"বিকল্পভাৱে, আপুনি এই ডিভাইচৰ বাবে অন্য আলেখ্যসমূহৰ এটাৰ সৈতে ব্যৱহাৰ কৰা "
-"উজ্জ্বলতা "
+"বিকল্পভাৱে, আপুনি এই ডিভাইচৰ বাবে অন্য আলেখ্যসমূহৰ এটাৰ সৈতে ব্যৱহাৰ কৰা উজ্জ্বলতা "
 "স্তৰ ব্যৱহাৰ কৰিব পাৰিব।"
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "প্ৰদৰ্শনৰ উজ্জ্বলতা"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "আলেখ্যৰ নাম"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -616,3079 +521,2331 @@ msgstr ""
 "আপুনি বিভিন্ন কমপিউটাৰসমূহত এটা ৰঙৰ আলেখ্য ব্যৱহাৰ কৰিব পাৰিব, অথবা বিভিন্ন "
 "উজ্জ্বলতা স্তৰৰ বাবে আলেখ্যসমূহ সৃষ্টি কৰিব পাৰিব।"
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "আলেখ্যৰ নাম:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "আলেখ্যৰ নাম"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "আলেখ্য সফলভাৱে সৃষ্টি কৰা হৈছে!"
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "আলেখ্য কপি কৰক"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "লিখিব পৰা মাধ্যমৰ প্ৰয়োজন"
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "আলেখ্য আপল'ড কৰক"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "ইন্টাৰনেট সংযোগৰ প্ৰয়োজন"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"আলেখ্য কেনেকৈ ব্যৱহাৰ কৰিব লাগিব তাৰ বিষয়ে নিৰ্দেশসমূহ আপুনি <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> আৰু <a href=\"windows"
-"\">Microsoft Windows</a> চিস্টেমসমূহত পাব।"
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "সাৰাংশ"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "ফাইল ইমপোৰ্ট কৰক…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "আলেখ্য সফলভাৱে সৃষ্টি কৰা হৈছে!"
 
-#: ../panels/color/color.ui.h:29
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "আলেখ্য কপি কৰক"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "লিখিব পৰা মাধ্যমৰ প্ৰয়োজন"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"আলেখ্য কেনেকৈ ব্যৱহাৰ কৰিব লাগিব তাৰ বিষয়ে নিৰ্দেশসমূহ আপুনি <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> আৰু <a "
+"href=\"windows\">Microsoft Windows</a> চিস্টেমসমূহত পাব।"
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "আলেখ্য যোগ কৰক"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"সমস্যা দেখা দিছে। আলেখ্য সঠিকভাৱে কাম নকৰিব পাৰে। <a href=\"\">বিৱৰণ "
-"দেখুৱাওক।</"
+"সমস্যা দেখা দিছে। আলেখ্য সঠিকভাৱে কাম নকৰিব পাৰে। <a href=\"\">বিৱৰণ দেখুৱাওক।</"
 "a>"
 
-#: ../panels/color/color.ui.h:30
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "ফাইল ইমপোৰ্ট কৰক…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "যোগ কৰক (_A)"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
-"প্ৰতিটো ডিভাইচ ব্যৱস্থাপনা কৰিবলে এটা বৰ্তমান তাৰিখলে উন্নত এটা ৰঙ আলেখ্যৰ "
-"প্ৰয়োজন।"
+"প্ৰতিটো ডিভাইচ ব্যৱস্থাপনা কৰিবলে এটা বৰ্তমান তাৰিখলে উন্নত এটা ৰঙ আলেখ্যৰ প্ৰয়োজন।"
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "অধিক জানক"
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "ৰঙ ব্যৱস্থাপনাৰ বিষয়ে অধিক জানক"
 
-#: ../panels/color/color.ui.h:33
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "সকলো ব্যৱহাৰকাৰীৰ বাবে সংহত"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "এই কমপিউটাৰৰ সকলো ব্যৱহাৰকাৰীৰ বাবে এই আলেখ্য সংহতি কৰক"
 
-#: ../panels/color/color.ui.h:35
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "সামৰ্থবান কৰক"
 
-#: ../panels/color/color.ui.h:36
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "আলেখ্য যোগ কৰক"
 
-#: ../panels/color/color.ui.h:37
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "মানাংকন কৰক…"
 
-#: ../panels/color/color.ui.h:38
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "ডিভাইচ মানাংকন কৰক"
 
-#: ../panels/color/color.ui.h:39
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "আলেখ্য আতৰাওক"
 
-#: ../panels/color/color.ui.h:40
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "বিৱৰণসমূহ দৰ্শন কৰক"
 
-#: ../panels/color/color.ui.h:41
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "ৰঙ ব্যৱস্থাপনা কৰিব পৰা কোনো ডিভাইচ চিনাক্ত কৰিবলে অক্ষম"
 
-#: ../panels/color/color.ui.h:42
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "প্ৰক্ষেপক"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "প্লাজমা"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL বেকলাইট)"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED বেকলাইট)"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (বগা LED বেকলাইট)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "বিস্তাৰিত gamut LCD (CCFL বেকলাইট)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "বিস্তাৰিত gamut LCD (RGB LED বেকলাইট)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "উচ্চ"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "৪০ মিনিট"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "মধ্যম"
 
-#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "৩০ মিনিট"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "নিম্ন"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "১৫ মিনিট"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "প্ৰদৰ্শন কৰিবলে স্থানীয়"
 
-#: ../panels/color/color.ui.h:59
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (প্ৰিন্টিং আৰু প্ৰকাশন)"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (ফ'টোগ্ৰাফি আৰু গ্ৰাফিক্স)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "ৰঙ"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
-"আপোনাৰ ডিভাইচসমূহৰ ৰঙ মানাংকন কৰক, যেনে প্ৰদৰ্শনসমূহ, কেমেৰাসমূহ অথবা "
-"প্ৰিন্টাৰসমূহ"
+"আপোনাৰ ডিভাইচসমূহৰ ৰঙ মানাংকন কৰক, যেনে প্ৰদৰ্শনসমূহ, কেমেৰাসমূহ অথবা প্ৰিন্টাৰসমূহ"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "ৰঙ;ICC;আলেখ্য;মানাংকন;প্ৰিন্টাৰ;প্ৰদৰ্শন;"
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:684
-msgid "United States"
-msgstr "মাৰ্কিণ যুক্তৰাষ্ট্ৰ"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "এটা ভাষা বাছক"
 
-#: ../panels/common/cc-common-language.c:685
-msgid "Germany"
-msgstr "জাৰ্মানী"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "নিৰ্বাচন কৰক (_S)"
 
-#: ../panels/common/cc-common-language.c:686
-msgid "France"
-msgstr "ফ্ৰাঞ্চ"
-
-#: ../panels/common/cc-common-language.c:687
-msgid "Spain"
-msgstr "স্পেইন"
-
-#: ../panels/common/cc-common-language.c:688
-msgid "China"
-msgstr "চীন"
-
-#: ../panels/common/cc-common-language.c:758
-msgid "Other…"
-msgstr "অন্য…"
-
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr "অধিক…"
-
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "কোনো ভাষা পোৱা নগল"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "ভাষা"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "অধিক…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "কৰা হল (_D)"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "আকাৰ বৃদ্ধি কৰক:"
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "সময়"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "আকাৰ সৰু কৰক:"
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "জানুৱাৰী"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "ফেব্ৰুৱাৰী"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "মাৰ্চ"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "এপ্ৰিল"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "মে"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "জুন"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "জুলাই"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "আগষ্ট"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "চেপ্তেম্বৰ"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "অক্টোবৰ"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "নভেম্বৰ"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "ডিচেম্বৰ"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "তাৰিখ &সময়"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "ঘন্টা"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "মিনিট"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "দিন"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "মাহ"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "বছৰ"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "মাহ"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "জানুৱাৰী"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ফেব্ৰুৱাৰী"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "মাৰ্চ"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "এপ্ৰিল"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "মে"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "জুন"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "জুলাই"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "আগষ্ট"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "চেপ্তেম্বৰ"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "অক্টোবৰ"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "নভেম্বৰ"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ডিচেম্বৰ"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "দিন"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "সময় অঞ্চল"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "এটা শহৰৰ বাবে সন্ধান কৰক"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "স্বচালিত তাৰিখ আৰু সময় (_D)"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "ইন্টাৰনেট সংযোগৰ প্ৰয়োজন"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "তাৰিখ আৰু সময় (_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "স্বচালিত সময় অঞ্চল (_Z)"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "Date & _Time"
-msgstr "তাৰিখ আৰু সময় (_T)"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "ইন্টাৰনেট সংযোগৰ প্ৰয়োজন"
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
-msgstr "সময় অঞ্চল (_Z)"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "সামৰ্থবান"
 
-#: ../panels/datetime/datetime.ui.h:28
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "সময় অঞ্চল"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ঘড়িৰ দিশত"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "সময় বিন্যাস (_F)"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "২৪-ঘন্টা"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "তাৰিখসমূহ"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "দ্বিতীয়"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "কেলেন্ডাৰ (_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "নম্বৰসমূহ"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "তাৰিখ আৰু সময় পৰিবৰ্তন কৰক, সময় অঞ্চল অন্তৰ্ভুক্ত কৰাকৈ"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "ঘড়ি;সময়অঞ্চল;অৱস্থান;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "চিস্টেম সময় আৰু তাৰিখ সংহতিসমূহ পৰিবৰ্তন কৰক"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "সময় আৰু তাৰিখ সংহতিসমূহ পৰিবৰ্তন কৰিবলে, আপুনি প্ৰমাণীত হব লাগিব।"
 
-#: ../panels/display/cc-display-panel.c:487
-msgid "Lid Closed"
-msgstr "লিড বন্ধ"
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-msgid "Mirrored"
-msgstr "মিৰৰড্"
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2145
-msgid "Primary"
-msgstr "প্ৰাথমিক"
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "অফ"
-
-#: ../panels/display/cc-display-panel.c:497
-msgid "Secondary"
-msgstr "দ্বিতীয়"
-
-#: ../panels/display/cc-display-panel.c:1533
-msgid "Arrange Combined Displays"
-msgstr "সংযুক্ত প্ৰদৰ্শনসমূহ সঁজাওক"
-
-#: ../panels/display/cc-display-panel.c:1539
-#: ../panels/display/cc-display-panel.c:1979
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-msgid "_Apply"
-msgstr "প্ৰয়োগ কৰক (_A)"
-
-#: ../panels/display/cc-display-panel.c:1560
-msgid "Drag displays to rearrange them"
-msgstr "প্ৰদৰ্শনসমূহক পুনৰ সংঘঠিত কৰিবলৈ সিহতক সঁজাওক"
-
-#: ../panels/display/cc-display-panel.c:2081
-msgid "Size"
-msgstr "আকাৰ"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2094
-msgid "Aspect Ratio"
-msgstr "অনুপাত হাৰ"
-
-#: ../panels/display/cc-display-panel.c:2115
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "বিভেদন"
-
-#: ../panels/display/cc-display-panel.c:2146
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "এই প্ৰদৰ্শনত ওপৰ বাৰ আৰু কাৰ্য্যসমূহ অভাৰভিউ দেখুৱাওক"
-
-#: ../panels/display/cc-display-panel.c:2152
-msgid "Secondary Display"
-msgstr "দ্বিতীয় প্ৰদৰ্শন"
-
-#: ../panels/display/cc-display-panel.c:2153
-msgid "Join this display with another to create an extra workspace"
-msgstr "এটা অতিৰিক্ত কৰ্মস্থান সৃষ্টি কৰিবলৈ এই প্ৰদৰ্শনক অন্যৰ সৈতে লগ লগাওক"
-
-#: ../panels/display/cc-display-panel.c:2160
-msgid "Presentation"
-msgstr "পৰিৱেশন"
-
-#: ../panels/display/cc-display-panel.c:2161
-msgid "Show slideshows and media only"
-msgstr "কেৱল স্লাইডশ্ব আৰু মাধ্যম দেখুৱাওক"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2166
-msgid "Mirror"
-msgstr "মিৰৰ"
-
-#: ../panels/display/cc-display-panel.c:2167
-msgid "Show your existing view on both displays"
-msgstr "দুয়োটা প্ৰদৰ্শনত আপোনাৰ স্থায়ী দৰ্শন দেখুৱাওক"
-
-#: ../panels/display/cc-display-panel.c:2173
-msgid "Turn Off"
-msgstr "বন্ধ কৰক"
-
-#: ../panels/display/cc-display-panel.c:2174
-msgid "Don't use this display"
-msgstr "এই প্ৰদৰ্শন ব্যৱহাৰ নকৰিব"
-
-#: ../panels/display/cc-display-panel.c:2383
-msgid "Could not get screen information"
-msgstr "পৰ্দা পৰিবৰ্তন প্ৰাপ্ত কৰিবলৈ ব্যৰ্থ"
-
-#: ../panels/display/cc-display-panel.c:2414
-msgid "_Arrange Combined Displays"
-msgstr "সংযুক্ত প্ৰদৰ্শনসমূহ সঁজাওক (_A)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "প্ৰদৰ্শনসমূহ"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr "সংযুক্ত মনিটৰসমূহ আৰু প্ৰক্ষেপকসমূহ কিধৰণে ব্যৱহাৰ কৰিব বাছক"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr "Wayland"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "অজ্ঞাত"
-
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-bit"
-
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr "%d-bit"
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr "কি কৰা হব সোধক"
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr "একো নকৰিব"
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr "ফোল্ডাৰ খোলক"
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr "অন্য মাধ্যম"
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr "অডিঅ' CDসমূহৰ বাবে এটা এপ্লিকেচন বাছক"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr "ভিডিঅ' DVDসমূহৰ বাবে এটা এপ্লিকেচন বাছক"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr "যেতিয়া এটা সংগীত প্লেয়াৰ সংযুক্ত থাকে চলাবলে এটা এপ্লিকেচন বাছক"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr "যেতিয়া এটা কেমেৰা সংযুক্ত তেতিয়া চলিবলে এটা এপ্লিকেচন বাছক"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr "চফ্টৱেৰ CDসমূহৰ বাবে এটা এপ্লিকেচন বাছক"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr "অডিঅ' DVD"
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr "ৰিক্ত Blu-ray ডিস্ক"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr "ৰিক্ত CD ডিস্ক"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr "ৰিক্ত DVD ডিস্ক"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr "ৰিক্ত HD DVD ডিস্ক"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr "Blu-ray ভিডিঅ' ডিস্ক"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr "e-book ৰিডাৰ"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr "HD DVD ভিডিঅ' ডিস্ক"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr "ছবি CD"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr "চুপাৰ ভিডিঅ' CD"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr "ভিডিঅ' CD"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr "Windows চফ্টৱেৰ"
-
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1917
-msgid "Section"
-msgstr "অংশ"
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "অভাৰভিউ"
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr "অবিকল্পিত এপ্লিকেচনসমূহ"
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "আতৰাব পৰা মাধ্যম"
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr "সংস্কৰণ %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:44
-msgid "Details"
-msgstr "বিৱৰণসমূহ"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr "আপোনাৰ চিস্টেমৰ বিষয়ে তথ্য চাওক"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"ডিভাইচ;চিস্টেম;তথ্য;মেমৰি;প্ৰচেছৰ;সংস্কৰণ;অবিকল্পিত;এপ্লিকেচন;পছন্দ;cd;dvd;usb"
-";"
-"অডিঅ';ভিডিঅ';ডিস্ক;আতৰাব পৰা;মাধ্যম;স্বচলন;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "মাধ্যম কেনেধৰণে নিয়ন্ত্ৰণ কৰা হব বাছক"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "কাৰ্য্য (_A):"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "ধৰণ (_T):"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "ডিভাইচ নাম"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "মেমৰি"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "প্ৰচেছৰ"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "ভিত্তি চিস্টেম"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "ডিস্ক"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "গণনা কৰা হৈ আছে…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "গ্ৰাফিক্স"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "ভাৰছুৱেলাইজেষণ"
-
-#: ../panels/info/info.ui.h:13
-msgid "Check for updates"
-msgstr "আপডেইসমূহৰ বাবে নিৰীক্ষণ কৰক"
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "ৱেব (_W)"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "মেইল (_M)"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "কেলেন্ডাৰ (_C)"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "সংগীত (_u)"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "ভিডিঅ' (_V)"
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "ছবিসমূহ (_P)"
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "মাধ্যম কেনেধৰণে নিয়ন্ত্ৰণ কৰা হব বাছক"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "অবিকল্পিত এপ্লিকেচনসমূহ"
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "CD অডিঅ' (_a)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "অবিকল্পিত এপ্লিকেচনসমূহ"
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "DVD ভিডিঅ' (_D)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "সংগীত প্লেয়াৰ (_M)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "চফ্টৱেৰ (_S)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "অন্য মাধ্যম (_O)…"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr "মাধ্যম সুমুৱাত কেতিয়াও প্ৰগ্ৰামসমূহ প্ৰমপ্ট অথবা আৰম্ভ নকৰিব (_N)"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "প্ৰয়োগ কৰক (_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "পিছলৈ"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "ব্লুটুথ অসামৰ্থবান"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "প্ৰদৰ্শনসমূহ চিনাক্ত কৰক (_D)"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "মিৰৰ"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "দ্বিতীয় প্ৰদৰ্শন"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "সোঁ ৰিং"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "দিশনিৰ্ণয়"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "বিভেদন"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "সতেজ কৰাৰ হাৰ"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "স্কেইল"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "আংশিক সম্পন্ন"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "কোনো প্ৰিন্টাৰ উপলব্ধ নাই"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "এতিয়া পুনৰাম্ভ কৰক"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "সময়বোৰ"
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "URI ৰ পৰা"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "ঘন্টা"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "মিনিট"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "প্ৰদৰ্শনসমূহ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "সংযুক্ত মনিটৰসমূহ আৰু প্ৰক্ষেপকসমূহ কিধৰণে ব্যৱহাৰ কৰিব বাছক"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "সুৰক্ষা কি'"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "কালীৰ স্তৰ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "কালীৰ স্তৰ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "কালীৰ স্তৰ"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "সুৰক্ষা"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ডিভাইচ নাম"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "হাৰ্ডৱেৰ ঠিকনা"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "মেমৰি"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "প্ৰচেছৰ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "গ্ৰাফিক্স"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "গণনা কৰা হৈ আছে…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "নাম"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "ধৰণ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME Terminal"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "বিকল্পসমূহ ল'ড কৰা হৈছে…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows চফ্টৱেৰ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "ভাৰছুৱেলাইজেষণ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "চফ্টৱেৰৰ ব্যৱহাৰ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "ডিভাইচ আতৰাওক"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ডিভাইচ নাম"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "নাম পৰিবৰ্তন..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/বিষয়ে (_A)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "আপোনাৰ চিস্টেমৰ বিষয়ে তথ্য চাওক"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ডিভাইচ;চিস্টেম;তথ্য;মেমৰি;প্ৰচেছৰ;সংস্কৰণ;অবিকল্পিত;এপ্লিকেচন;পছন্দ;cd;dvd;usb;"
+"অডিঅ';ভিডিঅ';ডিস্ক;আতৰাব পৰা;মাধ্যম;স্বচলন;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "শব্দ আৰু মাধ্যম"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "ভলিউম মৌণ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "ভলিউম কম"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "ভলিউম বৃদ্ধি"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "মাইক্ৰোফোন ভলিউম"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "মিডিয়া প্লেয়াৰ আৰম্ভ কৰক"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "চলাওক (অথবা চলাওক/ৰখাওক)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "প্লেবেক ৰখাওক"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "প্লেবেক ৰখাওক"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "পূৰ্বৱৰ্তী ট্ৰেক"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "পৰৱৰ্তী ট্ৰেক"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "উলাওক"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "টাইপিং"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "পৰৱৰ্তী ইনপুট উৎসলে যাওক"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "পূৰ্বৱৰ্তী ইনপুট উৎসলে যাওক"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "আৰম্ভকসমূহ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "সহায় ব্ৰাউছাৰ আৰম্ভ কৰক"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "সংহতিসমূহ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "গণক আৰম্ভ কৰক"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "ই-মেইল ক্লাএন্ট আৰম্ভ কৰক"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "ৱেব ব্ৰাউছাৰ আৰম্ভ কৰক"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "ঘৰ ফোল্ডাৰ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "সন্ধান কৰক"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "স্ক্ৰিনশ্বটসমূহ"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "এটা স্ক্ৰিনশ্বটক $PICTURES সংৰক্ষণ কৰক"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "এটা উইন্ডোৰ স্ক্ৰিনশ্বটক $PICTURES ত সংৰক্ষণ কৰক"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "এটা স্থানৰ স্ক্ৰিনশ্বটক $PICTURES ত সংৰক্ষণ কৰক"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "এটা স্ক্ৰিনশ্বটক ক্লিপবৰ্ডলে কপি কৰক"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "এটা উইন্ডোৰ স্ক্ৰিনশ্বটক ক্লিপবৰ্ডলে কপি কৰক"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "এটা স্থানৰ স্ক্ৰিনশ্বটক ক্লিপবৰ্ডলে কপি কৰক"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "এটা সৰু স্ক্ৰিনকাস্ট ৰেকৰ্ড কৰক"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "চিস্টেম"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "লগ আউট কৰক"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "পৰ্দা লক কৰক"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "সাৰ্বভৈমক অভিগম"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "মাউস ব্যবহাৰৰ সহায়ক প্ৰযুক্তি (_M)"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "জুম অন বা অফ কৰক"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "ডাঙৰ কৰি দেখুৱাওক"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "সৰু কৰি দেখুৱাওক"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "স্ক্ৰিন ৰিডাৰ অন বা অফ কৰক"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "অন-স্ক্ৰিন কিবৰ্ড অন অথবা অফ কৰক"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "লিখনি আকাৰ ডাঙৰ কৰক"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "লিখনি আকাৰ সৰু কৰক"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "উচ্চ কন্ট্ৰাস্ট অন বা অফ কৰক"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1217
-#: ../panels/network/network-wifi.ui.h:29
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-#: ../panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Disabled"
-msgstr "নিষ্ক্ৰীয়"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "এটা ইনপুট উৎস যোগ কৰক"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "বৈকল্পিক আখৰসমূহ চাবি"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "ইনপুট পদ্ধতিসমূহ লগিন পৰ্দাত ব্যৱহাৰ কৰিব নোৱাৰি"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "কি' ৰচনা কৰক"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "কোনো ইনপুট উৎস নিৰ্বাচন কৰা হোৱা নাই"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "পৰিবৰ্তক-কেৱল পৰৱৰ্তী উৎসলে যাওক"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "বিকল্পসমূহ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "কিবৰ্ড"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "উপৰলে স্থানান্তৰ কৰক"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr ""
-"কিবৰ্ড চৰ্টকাটসমূহ দৰ্শন কৰক আৰু পৰিবৰ্তন কৰক আৰু আপোনাৰ টাইপিং পছন্দসমূহ "
-"সংহতি কৰক"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "তললে স্থানান্তৰ কৰক"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "চৰ্টকাট;পুনৰাবৃত্তি;পিৰিকিয়া;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "পছন্দসমূহ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "স্বনিৰ্ধাৰিত চৰ্টকাট"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "কিবৰ্ড বিন্যাস দেখুৱাওক"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
-msgstr "যোগ কৰক (_A)"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "আতৰাওক (_R)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "নাম :(_N)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "কমান্ড:(_o)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "পুনৰাবৃত্তিৰ-কি"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "কি টিপি ৰাখিলে অনবৰত লিখা হ'ব (_r)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "বিলম্ব (_D):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "গতি (_S):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "সৰু"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "লেহেম"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "কি পুনৰাবৃত্তিৰ হাৰ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "দীঘল"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "দ্ৰুত"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "কাৰ্চাৰৰ পিৰিকিয়া"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "আখৰৰ ক্ষেত্ৰত কাৰ্চাৰ পিৰিকিয়া (_b)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "গতি (_p):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "কাৰ্চাৰৰ পিৰিকিয়া গতি"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "ইনপুট উৎসসমূহ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "চৰ্টকাট যোগ কৰক"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "চৰ্টকাট আতৰাওক"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"এটা চৰ্টকাট সম্পাদন কৰিবলে, শাৰীত ক্লিক কৰক আৰু নতুন কিসমূহ ধৰি ৰাখক অথবা "
-"পৰিষ্কাৰ "
-"কৰিবলে Backspace টিপক।"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "ইনপুট উৎস বিকল্পসমূহ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "সকলো উইন্ডোৰ বাবে একেটা উৎস ব্যৱহাৰ কৰক (_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "প্ৰতিটো উইন্ডোৰ বাবে ভিন্ন উৎসৰ অনুমতি দিয়ক (_d)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "বৈকল্পিক আখৰসমূহ চাবি"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "কি' ৰচনা কৰক"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "কিবৰ্ড চৰ্টকাটসমূহ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "স্বনিৰ্ধাৰিত চৰ্টকাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "অংশ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "চৰ্টকাটসমূহ"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:634
-#: ../panels/keyboard/keyboard-shortcuts.c:642
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "চৰ্টকাট যোগ কৰক"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "স্বনিৰ্ধাৰিত চৰ্টকাট"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:859
-msgid "<Unknown Action>"
-msgstr "<Unknown Action>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1356
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"চৰ্টকাট-কি হিচাপে \"%s\" ব্যবহাৰ কৰা নাযাব কাৰণ ইয়াৰ ফলস্বৰূপ এই কি ব্যবহাৰ "
-"কৰি "
-"একো টাইপ কৰা নাযাব।\n"
-"অনুগ্ৰহ কৰি Control, Alt বা Shift কিৰ একত্ৰিক ব্যবহাৰৰ প্ৰচেষ্টা কৰক।"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1386
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "চৰ্টকাট যোগ কৰক"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "কিবৰ্ড চৰ্টকাটসমূহ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "আতৰাওক (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "প্ৰতিস্থাপন কৰক (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"চৰ্টকাট \"%s\" বৰ্তমানে\n"
-" \"%s\"ৰ বাবে ব্যবহৃত হৈছে"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1391
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "\"%s\" ত চৰ্টকাট স্থাপন কৰা হ'লে, \"%s\" চৰ্টকাটটো নিষ্ক্ৰিয় কৰা হ'ব।"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1397
-msgid "_Reassign"
-msgstr "পুনৰ ধাৰ্য্য (_R)"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1429
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"\"%s\" চৰ্টকাটৰ সৈতে এটা সংলঘ্ন \"%s\" চৰ্টকাট আছে। আপুনি ইয়াক স্বচালিতভাৱে "
-"\"%s"
-"\" লৈ সংহতি কৰিব খোজে নে?"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1435
-#, c-format
-msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "নাম"
+
+#
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "কমান্ড:(_C)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "চৰ্টকাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "নতুন চৰ্টকাট…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "শূণ্য"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
 msgstr ""
-"\"%s\" বৰ্তমানে \"%s\" ৰ সৈতে সংলঘ্ন, এই চৰ্টকাট অসামৰ্থবান কৰা হ'ব যদি আপুনি "
-"আগবাঢ়ে।"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1441
-msgid "_Assign"
-msgstr "ধাৰ্য্য কৰক (_A)"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "অবিকল্পিত মান আকৌ স্থাপন কৰক(_R)"
 
-#: ../panels/mouse/cc-mouse-panel.c:94
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "কিবৰ্ড"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"কিবৰ্ড চৰ্টকাটসমূহ দৰ্শন কৰক আৰু পৰিবৰ্তন কৰক আৰু আপোনাৰ টাইপিং পছন্দসমূহ সংহতি কৰক"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "অবস্থান সেৱাসমূহ (_L)"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "কোনো এপ্লিকেচনে বৰ্তমানে অডিঅ' বজোৱা বা ৰেকৰ্ড কৰা নাই।"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "মাইক্ৰোফোন ভলিউম"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "কোনো এপ্লিকেচন পোৱা নগল"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "আপোনাৰ সংহতিসমূহ পৰীক্ষা কৰক (_S)"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-msgid "Test Your Settings"
-msgstr "আপোনাৰ সংহতিসমূহ পৰীক্ষা কৰক"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "সাধাৰণ"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "প্ৰাথমিক বুটাম (_b)"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "বাওঁ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "সোঁ"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "প্ৰিন্টাৰ বিকল্পসমূহ"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "মাউছ"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "মাউছ সংহতিসমূহ"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "তললে স্ক্ৰল কৰক"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "মেগ্নিফায়াৰ কাৰ্চাৰ সমলসমূহৰ সৈতে গমন কৰে"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "গতিবৃদ্ধি (_A):"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "সক্ৰিয়"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "টাচ-প্যাড"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "টাচ-প্যাড"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "পদ্ধতি (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "ক্লিক কৰিবলে টেপ কৰক (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "ক্লিক কৰিবলে টেপ কৰক (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "টাইপ কৰাৰ সময়ত অসামৰ্থবান কৰক (_t)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "টাচপেড (প্ৰাসংগিক)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "স্ক্রোল ব্যবস্থা"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "বাঁওফালে স্ক্ৰল কৰক"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "দুই -ফলিয়া"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ক্লিক, দুবাৰ ক্লিক, স্ক্ৰল কৰি চাওক"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "মাউছ & টাচপেড"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 "আপোনাৰ মাউছ অথবা টাচপেডৰ সংবেদনশীলতা পৰিবৰ্তন কৰক আৰু সোঁ অথবা বাঁও হাত বাছক"
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "ট্ৰেকপেড;পোইন্টাৰ;ক্লিক;টেপ;দুবাৰ;বুটাম;ট্ৰেকবল;স্ক্ৰল;"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "সাধাৰণ"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "লেহেম"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "দুবাৰ-ক্লিক সময়অন্ত"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "দ্ৰুত"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "দুবাৰ-ক্লিক (_D)"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "ৰঙস্থান: "
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "প্ৰাথমিক বুটাম (_b)"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "বাওঁ (_L)"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "আবৰ্জনা স্বচালিতভাৱে খালি কৰক (_T)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "সোঁ (_R)"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "মাউছ"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "পোইন্টাৰৰ গতি (_P)"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "লেহেম"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "মনিটৰ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "দ্ৰুত"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "প্ৰাথমিক প্ৰদৰ্শন সলনি কৰিবলে টানি আনক।"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "টাচ-প্যাড"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "লেহেম"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "এপ্লিকেচনসমূহ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "দ্ৰুত"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
-msgstr "টাইপ কৰাৰ সময়ত অসামৰ্থবান কৰক (_t)"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
-msgstr "ক্লিক কৰিবলে টেপ কৰক (_c)"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
-msgstr "দুটা আঙুলি বিশিষ্ট স্ক্রোলিং (_f)"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "_Natural scrolling"
-msgstr "স্বাভাৱিক স্ক্রোলিং (_N)"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "ক্লিক, দুবাৰ ক্লিক, স্ক্ৰল কৰি চাওক"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ডিভাইচ"
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "পাঁচবাৰ ক্লিক, GEGL সময়!"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "দুবাৰ ক্লিক, প্ৰাথমিক বুটাম"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "নতুন সংযোগ যোগ কৰক"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "এবাৰ ক্লিক, প্ৰাথমিক বুটাম"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "দুবাৰ ক্লিক, মাজৰ বুটাম"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "সংযুক্ত"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "এবাৰ ক্লিক, মাজৰ বুটাম"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "বিকল্পসমূহ…"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "দুবাৰ ক্লিক, দ্বিতীয় বুটাম"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "এবাৰ ক্লিক, দ্বিতীয় বুটাম"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi হটস্পট"
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:366
-msgid "Air_plane Mode"
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "নেটৱৰ্কৰ নাম"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "পাছৱৰ্ড"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "এটা পাছৱৰ্ড সৃজন কৰক"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "এটা পাছৱৰ্ড সৃজন কৰক"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "আৰম্ভ কৰক (_T)"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
 msgstr "বিমান অৱস্থা (_p)"
 
-#: ../panels/network/cc-network-panel.c:965
-msgid "Network proxy"
-msgstr "নেটৱৰ্ক প্ৰক্সি"
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "কোনো ছবি পোৱা নগল"
 
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1289
-msgid "The system network services are not compatible with this version."
-msgstr "চিস্টেম নেটৱৰ্ক সেৱাসমূহ এই সংস্কৰণৰ সৈতে সংগত নহয়।"
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "বিমান অৱস্থা (_p)"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi হটস্পট"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "হটস্পট হিচাপে ব্যৱহাৰ কৰক (_U)…"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "নেটৱৰ্কসমূহ"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x সুৰক্ষা (_S)"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "পৃষ্ঠা ১"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "বেনামী পৰিচয় (_m)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "অভ্যন্তৰীক প্ৰমাণীকৰণ (_a)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "পৃষ্ঠা ২"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:4
-msgid "Security"
-msgstr "সুৰক্ষা"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "স্বচালিত"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:217
-#: ../panels/network/net-device-wifi.c:378
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:221
-#: ../panels/network/net-device-wifi.c:383
-#: ../panels/network/network-wifi.ui.h:17
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:225
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:230
-msgid "Enterprise"
-msgstr "এন্টাৰপ্ৰাইজ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:235
-#: ../panels/network/net-device-wifi.c:368
-msgctxt "Wifi security"
-msgid "None"
-msgstr "কোনো নহয়"
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "কেতিয়াও নহয়"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:819
-msgid "Today"
-msgstr "আজি"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:822
-msgid "Yesterday"
-msgstr "যোৱাকালি"
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:472
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i দিন আগত"
 msgstr[1] "%i দিন আগত"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:529
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:558
-msgctxt "Signal strength"
-msgid "None"
-msgstr "কোনো নহয়"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:560
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "দুৰ্বল"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ঠিক আছে"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "ভাল"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "উত্তম"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:45
-msgid "Identity"
-msgstr "পৰিচয়"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "ঠিকনা"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "নেটমাস্ক"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "গেইটৱে"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "ঠিকনা মচি পেলাওক"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "যোগ কৰক"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "চাৰ্ভাৰ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "DNS চাৰ্ভাৰ মচি পেলাওক"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "মেট্ৰিক"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "পথ মচি পেলাওক"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:25
-msgid "Automatic (DHCP)"
-msgstr "স্বচালিত (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:24
-msgid "Manual"
-msgstr "হস্তচালিত"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "কেৱল স্থানীয়-সংযোগ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:46
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "উপসৰ্গ"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "স্বচালিত"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "স্বচালিত, কেৱল DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:47
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:49
-msgid "Reset"
-msgstr "পুনৰসংহতি কৰক"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "কোনো নহয়"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit কি (Hex অথবা ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-বিট পাচফ্ৰেইছ"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "চলমান WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 ব্যক্তিগত"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 এন্টাৰপ্ৰাইজ"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:2
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "সংকেতৰ শক্তি"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:3
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "সংযোগৰ গতী"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "সুৰক্ষা"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 ঠিকনা"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 ঠিকনা"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:7
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "হাৰ্ডৱেৰ ঠিকনা"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:8
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "সমৰ্থিত ICC আলেখ্যসমূহ"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "অবিকল্পিত পথ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "সৰ্বশেষ ব্যৱহৃত"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "টুইস্টেড পেয়াৰ (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "এটাচমেন্ট একক আন্তঃপৃষ্ঠ (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "মাধ্যম মুক্ত আন্তঃপৃষ্ঠ (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "নাম (_N)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:36
-msgid "_MAC Address"
-msgstr "MAC ঠিকনা (_M)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "MTU (_T)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "ক্লৌন্ড ঠিকনা (_C)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "বাইটসমূহ"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "অন্য ব্যৱহাৰকাৰীসকলৰ বাবে উপলব্ধ কৰক (_u)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "স্বচালিতভাৱে সংযোগ কৰক (_a)"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "ফায়াৰৱাল অঞ্চল (_Z)"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "অবিকল্পিত"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "অঞ্চলে সংযোগৰ ভৰষা স্তৰৰ বিৱৰণ দিয়ে"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:22
-msgid "IPv_4"
-msgstr "IPv4 (_4)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:23
-msgid "_Addresses"
-msgstr "ঠিকনাসমূহ (_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "স্বচালিত DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Routes"
-msgstr "পথসমূহ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "স্বচালিত পথসমূহ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Use this connection _only for resources on its network"
-msgstr "এই সংযোগক কেৱল ইয়াৰ নেটৱৰ্কত থকা সম্পদৰ বাবে ব্যৱহাৰ কৰক (_o)"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:34
-msgid "IPv_6"
-msgstr "IPv6 (_6)"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "সংযোগ সম্পাদক খোলিবলে অক্ষম"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "নতুন আলেখ্য"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "বান্ধনী"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "দল"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "ব্ৰিজ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "VPN প্লাগিনসমূহ ল'ড কৰিব পৰা নগল"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "ফাইলৰ পৰা ইমপোৰ্ট কৰক…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "নেটৱৰ্ক সংযোগ যোগ কৰক"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Reset"
-msgstr "পুনৰ সংহতি কৰক (_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1449
-#: ../panels/network/network-wifi.ui.h:40
-msgid "_Forget"
-msgstr "পাহৰি যাওক (_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"এই নেটৱৰ্কৰ বাবে সংহতিসমূহ পুনৰ সংহতি কৰক, পাছৱৰ্ডসমূহ অন্তৰ্ভুক্ত কৰাকৈ, "
-"কিন্তু ইয়াক "
-"এটা পছন্দৰ নেটৱৰ্ক হিচাপে মনত ৰাখক"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"এই নেটৱৰ্কৰ সৈতে প্ৰসংগ কৰা সকলো বিৱৰণ আতৰাওক আৰু স্বচালিতভাৱে সংযোগ কৰাৰ "
-"চেষ্টা "
-"নকৰিব"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "S_ecurity"
-msgstr "সুৰক্ষা (_e)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "VPN সংযোগ ইমপোৰ্ট কৰিব নোৱাৰি"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"ফাইল '%s' পঢ়িব পৰা নাযায় অথবা পৰিচিত VPN সংযোগ তথ্য অন্তৰ্ভুক্ত নকৰে\n"
-"\n"
-"ত্ৰুটি: %s।"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "ইমপোৰ্ট কৰিবলে ফাইল বাছক"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1948
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:223
-msgid "_Open"
-msgstr "খোলক (_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "'\"%s\" নামৰ এটা ফাইল ইতিমধ্যে অস্তিত্ববান।"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "প্ৰতিস্থাপন কৰক (_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-"আপুনি %s ক আপুনি সংৰক্ষণ কৰি থকা VPN সংযোগৰ সৈতে প্ৰতিস্থাপন কৰিব বিচাৰে নে?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "VPN সংযোগ এক্সপোৰ্ট কৰিব নোৱাৰি"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN সংযোগ '%s' ক %s লে এক্সপোৰ্ট কৰিব নোৱাৰি।\n"
-"\n"
-"ত্ৰুটি: %s।"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-msgid "Export VPN connection"
-msgstr "VPN সংযোগ এক্সপোৰ্ট কৰক"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(ত্ৰুটি: VPN সংযোগ সম্পাদক ল'ড কৰিবলে অক্ষম)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:12
-msgid "_SSID"
-msgstr "SSID (_S)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:13
-msgid "_BSSID"
-msgstr "BSSID (_B)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:16
-msgid "My Home Network"
-msgstr "মোৰ ঘৰ নেটৱৰ্ক"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "অন্য ব্যৱহাৰকাৰীসকলৰ বাবে উপলব্ধ কৰাওক (_o)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "নেটৱৰ্ক"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Control how you connect to the Internet"
-msgstr "ইন্টাৰনেটৰ সৈতে কেনেকৈ সংযোগ কৰিব নিয়ন্ত্ৰণ কৰক"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
-"নেটৱৰ্ক;বেতাঁৰ;Wi-Fi;Wifi;IP;LAN;প্ৰক্সি;WAN;ব্ৰডবেণ্ড;মডেম;ব্লুটুথ;vpn;vlan;b"
-"ridge;"
-"বান্ধনী;DNS;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "বণ্ড স্লেইভসমূহ"
-
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(কোনো নহয়)"
-
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "ব্ৰিজ স্লেইভসমূহ"
-
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:458
-msgid "never"
-msgstr "কেতিয়াও নহয়"
-
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:468
-msgid "today"
-msgstr "আজি"
-
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:470
-msgid "yesterday"
-msgstr "যোৱাকালী"
-
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP ঠিকনা"
-
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:10
-msgid "Last used"
-msgstr "সৰ্বশেষ ব্যৱহৃত"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "তাঁৰযুক্ত"
-
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1604
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "বিকল্পসমূহ…"
-
-#: ../panels/network/net-device-ethernet.c:474
-#, c-format
-msgid "Profile %d"
-msgstr "আলেখ্য %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "নতুন সংযোগ যোগ কৰক"
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr "দলৰ স্লেইভবোৰ"
-
-#: ../panels/network/net-device-wifi.c:1153
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
-"যদি আপোনাৰ ইন্টাৰনেটলে বেতাঁৰৰ বাহিৰে অন্য সংযোগ উপলব্ধ আছে, আপুনি ইয়াক অন্যৰ "
-"সৈতে "
-"অংশীদাৰী কৰিবলে এটা বেতাঁৰ হটস্পট সংস্থাপন কৰিব পাৰে।"
 
-#: ../panels/network/net-device-wifi.c:1157
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "বেতাঁৰ হটস্পট আৰম্ভ কৰিলে আপুনি <b>%s</b> ৰ পৰা বিচ্ছিন্নিত হব।"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "নাম (_N)"
 
-#: ../panels/network/net-device-wifi.c:1161
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"হটস্পট সক্ৰিয় থকা অৱস্থাত আপোনাৰ বেতাঁৰৰ সহায়ত ইন্টাৰনেট অভিগম কৰাটো সম্ভব "
-"নহয়।"
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC ঠিকনা (_M)"
 
-#: ../panels/network/net-device-wifi.c:1238
-msgid "Stop hotspot and disconnect any users?"
-msgstr "হটস্পট বন্ধ কৰি কোনো ব্যৱহাৰকাৰী বিচ্ছিন্ন কৰিব নে?"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "MTU (_T)"
 
-#: ../panels/network/net-device-wifi.c:1241
-msgid "_Stop Hotspot"
-msgstr "হটস্পট বন্ধ কৰক (_S)"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "ক্লৌন্ড ঠিকনা (_C)"
 
-#: ../panels/network/net-device-wifi.c:1313
-msgid "System policy prohibits use as a Hotspot"
-msgstr "চিস্টেমৰ নীতিয়ে হটস্পট হিচাপে ব্যৱহাৰ নিষিদ্ধ কৰে"
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "বাইটসমূহ"
 
-#: ../panels/network/net-device-wifi.c:1316
-msgid "Wireless device does not support Hotspot mode"
-msgstr "বেতাঁৰ ডিভাইচে হটস্পট অৱস্থা সমৰ্থন নকৰে"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "পদ্ধতি (_M)"
 
-#: ../panels/network/net-device-wifi.c:1445
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"নিৰ্বাচিত নেটৱৰ্কসমূহৰ বাবে নেটৱৰ্ক বিৱৰণসমূহ, লগতে পাছৱৰ্ডসমূহ আৰু কোনো "
-"স্বনিৰ্বাচিত "
-"সংৰূপ হেৰাই যাব।"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "স্বচালিত (DHCP)"
 
-#: ../panels/network/net-device-wifi.c:1753
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "ইতিহাস"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "কেৱল স্থানীয়-সংযোগ"
 
-#: ../panels/network/net-device-wifi.c:1757
-#: ../panels/wacom/cc-wacom-page.c:533
-msgid "_Close"
-msgstr "বন্ধ কৰক (_C)"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1765
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "পাহৰি যাওক (_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "যেতিয়া এটা সংৰূপ URL প্ৰদান কৰা নহয় ৱেব প্ৰক্সি স্বখোজ ব্যৱহাৰ কৰা হয়।"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "ই ভৰষাহিন ৰাজহুৱা নেটৱৰ্কসমূহৰ বাবে উপদেশিত নহয়।"
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "প্ৰক্সি"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "আলেখ্য যোগ কৰক (_A)…"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "প্ৰদানকাৰী"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "কোনো নহয়"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "হস্তচালিত"
 
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "নিষ্ক্ৰীয়"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "অন্য কমপিউটাৰৰ সৈতে অংশীদাৰী কৰা আছে"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "ঠিকনাসমূহ (_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ঠিকনা"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "নেটমাস্ক"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "গেইটৱে"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "স্বচালিত"
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "স্বচালিত DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "পথসমূহ"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "স্বচালিত পথসমূহ"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "মেট্ৰিক"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "এই সংযোগক কেৱল ইয়াৰ নেটৱৰ্কত থকা সম্পদৰ বাবে ব্যৱহাৰ কৰক (_o)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
 msgstr "পদ্ধতি (_M)"
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "সংৰূপ URL (_C)"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "স্বচালিত, কেৱল DHCP"
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "HTTP প্ৰক্সি (_H)"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "উপসৰ্গ"
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "HTTP প্ৰক্সি (_T)"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "সুৰক্ষা (_e)"
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "FTP প্ৰক্সি (_F)"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ত্ৰুটি: VPN সংযোগ সম্পাদক ল'ড কৰিবলে অক্ষম)"
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "চক্স হস্ট (_S)"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "SSID (_S)"
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "হস্টসমূহ উপেক্ষা কৰক (_I)"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "BSSID (_B)"
 
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "HTTP প্ৰক্সি পোৰ্ট"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "নেটৱৰ্ক"
 
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "HTTP প্ৰক্সি পোৰ্ট"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "ইন্টাৰনেটৰ সৈতে কেনেকৈ সংযোগ কৰিব নিয়ন্ত্ৰণ কৰক"
 
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "FTP প্ৰক্সি পোৰ্ট"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "চক্স প্ৰক্সি পোৰ্ট"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "ডিভাইচ বন্ধ কৰক"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "ডিভাইচ যোগ কৰক"
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "ডিভাইচ আতৰাওক"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN ধৰণ"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "দলৰ নাম"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "দল পাছৱৰ্ড"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "ব্যৱহাৰকাৰীনাম"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr "VPN সংযোগ বন্ধ কৰক"
-
-#: ../panels/network/network-wifi.ui.h:1
-msgid "Automatic _Connect"
-msgstr "স্বচালিত সংযোগ (_C)"
-
-#: ../panels/network/network-wifi.ui.h:11
-msgid "details"
-msgstr "বিৱৰণসমূহ"
-
-#: ../panels/network/network-wifi.ui.h:15
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "পাছৱৰ্ড (_P)"
-
-#: ../panels/network/network-wifi.ui.h:18
-msgid "None"
-msgstr "শূণ্য"
-
-#: ../panels/network/network-wifi.ui.h:19
-msgid "Show P_assword"
-msgstr "পাছৱৰ্ড দেখুৱাওক (_a)"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "Make available to other users"
-msgstr "অন্য ব্যৱহাৰকাৰীসকলৰ বাবে উপলব্ধ কৰাওক"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "identity"
-msgstr "পৰিচয়"
-
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Automatic (DHCP) addresses only"
-msgstr "কেৱল স্বচালিত (DHCP) ঠিকনাসমূহ"
-
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Link-local only"
-msgstr "কেৱল স্থানীয়-সংযোগ"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Shared with other computers"
-msgstr "অন্য কমপিউটাৰৰ সৈতে অংশীদাৰী কৰা আছে"
-
-#: ../panels/network/network-wifi.ui.h:31
-msgid "_Ignore automatically obtained routes"
-msgstr "স্বচালিতভাৱে প্ৰাপ্ত পথসমূহ উপেক্ষা কৰক (_I)"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "_Cloned MAC Address"
-msgstr "ক্লৌন্ড MAC ঠিকনা (_C)"
-
-#: ../panels/network/network-wifi.ui.h:38
-msgid "hardware"
-msgstr "হাৰ্ডৱেৰ"
-
-#: ../panels/network/network-wifi.ui.h:41
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
-"এই সংযোগৰ বাবে সংহতিসমূহক তাৰ অবিকল্পিতলে পুনৰসংহতি কৰক, কিন্তু এটা পছন্দৰ "
-"সংযোগ "
-"হিচাপে মনত ৰাখক।"
+"নেটৱৰ্ক;বেতাঁৰ;Wi-Fi;Wifi;IP;LAN;প্ৰক্সি;WAN;ব্ৰডবেণ্ড;মডেম;ব্লুটুথ;vpn;vlan;bridge;"
+"বান্ধনী;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:42
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"এই নেটৱৰ্কৰ সৈতে প্ৰসংগ কৰা সকলো বিৱৰণ আতৰাওক আৰু স্বচালিতভাৱে ইয়াৰ সৈতে "
-"সংযোগ "
-"কৰাৰ চেষ্টা নকৰিব।"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid "reset"
-msgstr "পুনৰসংহতি কৰক"
-
-#: ../panels/network/network-wifi.ui.h:48
-msgid "Hardware"
-msgstr "হাৰ্ডৱেৰ"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi হটস্পট"
-
-#: ../panels/network/network-wifi.ui.h:51
-msgid "_Turn On"
-msgstr "আৰম্ভ কৰক (_T)"
-
-#: ../panels/network/network-wifi.ui.h:52
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:53
-msgid "Turn Wi-Fi off"
-msgstr "Wi-Fi অন বা অফ কৰক"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "ইন্টাৰনেটৰ সৈতে কেনেকৈ সংযোগ কৰিব নিয়ন্ত্ৰণ কৰক"
 
-#: ../panels/network/network-wifi.ui.h:54
-msgid "_Use as Hotspot…"
-msgstr "হটস্পট হিচাপে ব্যৱহাৰ কৰক (_U)…"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"নেটৱৰ্ক;বেতাঁৰ;Wi-Fi;Wifi;IP;LAN;প্ৰক্সি;WAN;ব্ৰডবেণ্ড;মডেম;ব্লুটুথ;vpn;vlan;bridge;"
+"বান্ধনী;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "_Connect to Hidden Network…"
-msgstr "লুকুৱা নেটৱৰ্কৰ সৈতে সংযোগ কৰক (_C)…"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "তাঁৰযুক্ত"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_History"
-msgstr "ইতিহাস (_H)"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "ডিভাইচ বন্ধ কৰক"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "এটা Wi-Fi নেটৱৰ্কৰ সৈতে সংযোগ কৰিবলে বন্ধ কৰক"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "সক্ৰিয়"
 
-#: ../panels/network/network-wifi.ui.h:58
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "প্ৰদানকাৰী"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP ঠিকনা"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "নেটৱৰ্ক প্ৰক্সি"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "HTTP প্ৰক্সি (_H)"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTP প্ৰক্সি (_T)"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "FTP প্ৰক্সি (_F)"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "চক্স হস্ট (_S)"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "হস্টসমূহ উপেক্ষা কৰক (_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP প্ৰক্সি পোৰ্ট"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTP প্ৰক্সি পোৰ্ট"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP প্ৰক্সি পোৰ্ট"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "চক্স প্ৰক্সি পোৰ্ট"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "সংৰূপ URL (_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN সংযোগ বন্ধ কৰক"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "নেটৱৰ্কৰ নাম"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Connected Devices"
-msgstr "সংযুক্ত ডিভাইচসমূহ"
-
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "সুৰক্ষা ধৰণ"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Security key"
-msgstr "সুৰক্ষা কি'"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "পাছৱৰ্ড"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "এড-হক"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi অন বা অফ কৰক"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "আন্তঃগাঁথনি"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "বিকল্পসমূহ ল'ড কৰা হৈছে…"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "অৱস্থা অজ্ঞাত"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "লুকুৱা নেটৱৰ্কৰ সৈতে সংযোগ কৰক (_C)…"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "অব্যৱস্থাপিত"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi হটস্পট"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "উপলব্ধ নাই"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "সংযোগ স্থাপন কৰা হৈছে..."
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "প্ৰমাণীকৰণৰ প্ৰয়োজন"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "সংযুক্ত"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "বিচ্ছিন্ন কৰা হৈ আছে"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "সংযোগ ব্যৰ্থ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "অৱস্থা অজ্ঞাত (সন্ধানহিন)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "সংযোগ বিহীন"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "সংৰূপ ব্যৰ্থ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "IP সংৰূপ ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "IP সংৰূপৰ অৱসান ঘটিল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "গোপনসমূহৰ প্ৰয়োজন আছিল, কিন্তু প্ৰদান কৰা হোৱা নাছিল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x সাপ্লিকেণ্ট বিচ্ছিন্নিত"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x সাপ্লিকেণ্ট সংৰূপ ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1x সাপ্লিকেণ্ট ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x সাপ্লিকেণ্ট প্ৰমাণীত হবলে বহু সময় ললে"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "PPP সেৱা আৰম্ভ হবলে ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "PPP সেৱা বিচ্ছিন্নিত হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "DHCP ক্লাএন্ট আৰম্ভ হবলে ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP ক্লাএন্ট ত্ৰুটি"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP ক্লাএন্ট ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "অংশীদাৰী সংযোগ সেৱা আৰম্ভ হবলে ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "অংশীদাৰী সংযোগ সেৱা ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "AutoIP সেৱা আৰম্ভ হবলে ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "AutoIP সেৱা ত্ৰুটি"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "AutoIP সেৱা ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "লাইন ব্যস্ত"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "কোনো ডায়েল শব্দ নাই"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "কোনো বাহক স্থাপন কৰিব পৰা নগল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "ডায়লিং অনুৰোধৰ সময় অন্ত হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "ডায়লিং চেষ্টা ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "মডেম আৰম্ভকৰণ ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "ধাৰ্য্যত APN নিৰ্বাচন কৰিবলে ব্যৰ্থ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "নেটৱৰ্কসমূহ সন্ধান কৰা হোৱা নাই"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "নেটৱৰ্ক ৰেজিষ্ট্ৰেষণ নাকচ কৰা হৈছে"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "নেটৱৰ্ক ৰেজিষ্ট্ৰেষণৰ সময় অন্ত হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "অনুৰোধ কৰা নেটৱৰ্কৰ সৈতে ৰেজিস্টাৰ কৰিবলে ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "PIN নিৰীক্ষণ ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "ডিভাইচৰ বাবে ফাৰ্মৱেৰ সন্ধানহিন হব পাৰে"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "সংযোগ নোহোৱা হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "স্থায়ী সংযোগ ধাৰনা কৰা হৈছিল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "মডেম পোৱা নগল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "ব্লুটুথ সংযোগ ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "SIM কাৰ্ড সুমুৱা হোৱা নাই"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "SIM ৰ Pin ৰ প্ৰয়োজন"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "SIM ৰ Puk ৰ প্ৰয়োজন"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "SIM ভুল"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "InfiniBand ডিভাইচে সংযুক্ত অৱস্থা সমৰ্থন নকৰে"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "সংযোগ নিৰ্ভৰতা ব্যৰ্থ হল"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "ফাৰ্মৱেৰ সন্ধানহীন"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "কেবুল আনপ্লাগ্গড"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "কোনো প্ৰমাণপত্ৰ কতৃপক্ষৰ প্ৰমাণপত্ৰ নিৰ্ব্বাচন কৰা নহয়"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"প্ৰমাণপত্ৰ কতৃপক্ষ (CA) প্ৰমাণপত্ৰ ব্যৱহাৰ নকৰিলে সুৰক্ষাবিহীন, বিপদজনক Wi-Fi "
-"নেটৱৰ্কৰ "
-"সৈতে সংযোগ স্থাপন কৰা হ'ব পাৰে। আপুনি এটা প্ৰমাণপত্ৰ কতৃপক্ষ প্ৰমাণপত্ৰ "
-"নিৰ্বাচন কৰিব "
-"বিচাৰে নেকি?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "উপেক্ষা কৰক"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "CA প্ৰমাণপত্ৰ বাছক"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, অথবা PKCS#12 ব্যক্তিগত কি'সমূহ (*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER অথবা PEM প্ৰমাণপত্ৰসমূহ (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-msgid "Choose a PAC file"
-msgstr "এটা PAC ফাইল বাছক"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC ফাইলসমূহ (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC ফাইল (_f)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "অভ্যন্তৰীক প্ৰমাণীকৰণ (_I)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "PAC যোগান (_v)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "বেনামী"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "প্ৰমাণীত"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "দুয়ো"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "বেনামী পৰিচয় (_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC ফাইল (_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "এটা PAC ফাইল বাছক"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "অভ্যন্তৰীক প্ৰমাণীকৰণ (_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC যোগান (_v)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "ব্যৱহাৰকাৰীনাম (_U)"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "পাছৱৰ্ড (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "পাছৱৰ্ড দেখুৱাওক (_w)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate"
-msgstr "এটা প্ৰমাণপত্ৰ কতৃপক্ষ প্ৰমাণপত্ৰ বাছক"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "সংস্কৰণ ০"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "সংস্কৰণ ১"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "CA প্ৰমাণপত্ৰ (_A)"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "এটা প্ৰমাণপত্ৰ কতৃপক্ষ প্ৰমাণপত্ৰ বাছক"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "প্ৰমাণীকৰণৰ প্ৰয়োজন"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP সংস্কৰণ (_v)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "প্ৰতিবাৰ এই পাছৱৰ্ড বিচাৰিব (_k)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "আনইনক্ৰিপ্টেড ব্যক্তিগত কি'সমূহ অসুৰক্ষিত"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"নিৰ্বাচিত ব্যক্তিগত কি' এটা পাছৱৰ্ড দ্বাৰা সুৰক্ষিত যেন নালাগে। ইয়াৰ বাবে "
-"আপোনাৰ "
-"সুৰক্ষা তথ্যসমূহ আপোচ হব পাৰে। অনুগ্ৰহ কৰি এটা পাছৱৰ্ড-সুৰক্ষিত ব্যক্তিগত কি' "
-"বাছক।\n"
-"\n"
-"(আপুনি openssl ৰ সৈতে আপোনাৰ ব্যক্তিগত কি' পাছৱৰ্ড-সুৰক্ষিত কৰিব পাৰিব)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-msgid "Choose your personal certificate"
-msgstr "আপোনাৰ ব্যক্তিগত প্ৰমাণপত্ৰ বাছক"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-msgid "Choose your private key"
-msgstr "আপোনাৰ ব্যক্তিগত কি' বাছক"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "পৰিচয় (_d)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "ব্যৱহাৰকাৰী প্ৰমাণপত্ৰ (_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "ব্যক্তিগত কি' (_k)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "ব্যক্তিগত কি' পাছৱৰ্ড (_P)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "মোক আকৌ সতৰ্ক নকৰিব (_w)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "ডমেইন (_D)"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "নহয়"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "হয়"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "টানেল্ড TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "সুৰক্ষিত EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "প্ৰমাণীকৰণ (_t)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "১ (অবিকল্পিত)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "২"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "৩"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "৪"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "খোলা চিস্টেম"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "অংশীদাৰী কৰা কি'"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "কি' (_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "কি' দেখুৱাওক (_w)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP সূচী (_x)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "ধৰণ (_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "১ (অবিকল্পিত)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "খোলা চিস্টেম"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "অংশীদাৰী কৰা কি'"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "কি' (_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "কি' দেখুৱাওক (_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP সূচী (_x)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "অধিসূচনাসমূহ"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "শব্দ সতৰ্কবাৰ্তাসমূহ"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "পপআপ বেনাৰসমূহ দেখুৱাওক"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "বেনাৰসমূহত বিৱৰণসমূহ দেখুৱাওক"
-
-#: ../panels/notifications/cc-edit-dialog.c:43
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "পৰ্দা লক কৰাত দৰ্শন কৰক"
-
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "পৰ্দা লক কৰাত বিৱৰণসমূহ দেখুৱাওক"
-
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "অন "
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "অধিসূচনাসমূহ"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "অধিসূচনাসমূহ"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "পৰ্দা লক কৰাত বিৱৰণসমূহ দেখুৱাওক"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "অধিসূচনাসমূহ"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "কোনবোৰ অধিসূচনা প্ৰদৰ্শন কৰা হব আৰু সিহতে কি দেখুৱাব নিয়ন্ত্ৰণ কৰক"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifications;Banner;Message;Tray;Popup;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "পপআপ বেনাৰসমূহ দেখুৱাওক"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "পৰ্দা লক কৰাত দেখুৱাওক"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "অধিসূচনাসমূহ ব্যৱস্থাপনা কৰক"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-msgctxt "Online Account"
-msgid "Other"
-msgstr "অন্য"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "একাওন্ট যোগ কৰক"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
-msgstr "মেইল"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr "পৰিচয়সমূহ"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "চেট"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "সম্পদসমূহ"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "একাওন্টলে লগিন কৰোতে ত্ৰুটি"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "তথ্যসমূহৰ অৱসান ঘটিছে।"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr "এই একাওন্ট সামৰ্থবান কৰিবলে ছাইন ইন কৰক।"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr "ছাইন ইন কৰক (_S)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "একাওন্ট সৃষ্টি কৰোতে ত্ৰুটি"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "একাওন্ট আতৰাওতে ত্ৰুটি"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "আপুনি নিশ্চিত নে আপুনি একাওন্ট আতৰাব বিচাৰে?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "ই চাৰ্ভাৰত একাওন্টক আতৰাই নিদিয়ে।"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "আতৰাওক (_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "অনলাইন একাওন্টসমূহ"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "আপোনাৰ অনলাইন একাওন্টসমূহৰ সৈতে সংযোগ কৰক আৰু সিহতক কিহৰ বাবে ব্যৱহাৰ কৰিব "
 "নিৰ্ধাৰণ কৰক"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -3696,2321 +2853,1967 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "সংৰূপিত কোনো অনলাইন একাওন্ট নাই"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "একাওন্ট আতৰাওক"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "এটা অনলাইন একাওন্ট যোগ কৰক"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"এটা একাওন্টে যোগ কৰিলে আপোনাৰ এপ্লিকেচনে ইয়াক দস্তাবেজসমূহ, মেইল, পৰিচয়সমূহ, "
-"কেলেন্ডাৰ, চেট আৰু অধিকৰ বাবে অভিগম কৰিবলে অনুমতি প্ৰাপ্ত কৰে।"
-
-#: ../panels/power/cc-power-panel.c:183
-msgid "Unknown time"
-msgstr "অজ্ঞাত সময়"
-
-#: ../panels/power/cc-power-panel.c:189
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i মিনিট"
 msgstr[1] "%i মিনিট"
 
-#: ../panels/power/cc-power-panel.c:201
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i ঘন্টা"
 msgstr[1] "%i ঘন্টা"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:209
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ঘন্টা"
 msgstr[1] "ঘন্টা"
 
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "মিনিট"
 msgstr[1] "মিনিট"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:230
-#, c-format
-msgid "%s until fully charged"
-msgstr "সম্পূৰ্ণ চাৰ্জ হবলে %s অৱশিষ্ট"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "১৫ মিনিট"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:237
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "সাৱধান: %s অৱশিষ্ট"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "২ মিনিট"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:242
-#, c-format
-msgid "%s remaining"
-msgstr "%s অৱশিষ্ট"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "৫ মিনিট"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
-msgid "Fully charged"
-msgstr "সম্পূৰ্ণ চাৰ্জ হৈছে"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "৩০ মিনিট"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
-msgid "Empty"
-msgstr "ৰিক্ত"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Charging"
-msgstr "চাৰ্জ কৰা হৈ আছে"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:271
-msgid "Discharging"
-msgstr "চাৰ্জ শেষ হৈ আছে"
-
-#: ../panels/power/cc-power-panel.c:396
-msgctxt "Battery name"
-msgid "Main"
-msgstr "মূখ্য"
-
-#: ../panels/power/cc-power-panel.c:398
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "অতিৰিক্ত"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:470
-msgid "Wireless mouse"
-msgstr "বেতাঁৰ মাউছ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:473
-msgid "Wireless keyboard"
-msgstr "বেতাঁৰ কিবৰ্ড"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:476
-msgid "Uninterruptible power supply"
-msgstr "ব্যাঘাতহিন শক্তিৰ যোগান"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Personal digital assistant"
-msgstr "ব্যক্তিগত অঙ্কীয় সহায়ক"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Cellphone"
-msgstr "চেলফোন"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Media player"
-msgstr "মিডিয়া প্লেয়াৰ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Tablet"
-msgstr "টেবলেট"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Computer"
-msgstr "কমপিউটাৰ"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
-#: ../panels/power/cc-power-panel.c:2019
-msgid "Battery"
-msgstr "বেটাৰি"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "চাৰ্জ কৰা হৈ আছে"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "সাৱধানী"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Low"
-msgstr "নিম্ন"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Good"
-msgstr "ভাল"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "সম্পূৰ্ণ চাৰ্জ হৈছে"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "ৰিক্ত"
-
-#: ../panels/power/cc-power-panel.c:715
-msgid "Batteries"
-msgstr "বেটাৰিসমূহ"
-
-#: ../panels/power/cc-power-panel.c:1117
-msgid "When _idle"
-msgstr "যেতিয়া অলস (_i)"
-
-#: ../panels/power/cc-power-panel.c:1445
-msgid "Power Saving"
-msgstr "শক্তি সংৰক্ষণ কৰা"
-
-#: ../panels/power/cc-power-panel.c:1473
-msgid "_Screen brightness"
-msgstr "পৰ্দাৰ উজ্জ্বলতা (_S)"
-
-#: ../panels/power/cc-power-panel.c:1479
-msgid "_Keyboard brightness"
-msgstr "কিবৰ্ডৰ উজ্জ্বলতা (_K)"
-
-#: ../panels/power/cc-power-panel.c:1489
-msgid "_Dim screen when inactive"
-msgstr "যেতিয়া নিষ্ক্ৰিয় তেতিয়া পৰ্দা স্লান কৰিব (_D)"
-
-#: ../panels/power/cc-power-panel.c:1514
-msgid "_Blank screen"
-msgstr "ৰিক্ত পৰ্দা (_B)"
-
-#: ../panels/power/cc-power-panel.c:1551
-msgid "_Wi-Fi"
-msgstr "Wi-Fi (_W)"
-
-#: ../panels/power/cc-power-panel.c:1556
-msgid "Turns off wireless devices"
-msgstr "বেতাঁৰ ডিভাইচসমূহ বন্ধ কৰে"
-
-#: ../panels/power/cc-power-panel.c:1581
-msgid "_Mobile broadband"
-msgstr "মবাইল ব্ৰডবেণ্ড (_M)"
-
-#: ../panels/power/cc-power-panel.c:1586
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "মবাইল ব্ৰডবেণ্ড (3G, 4G, WiMax, ইত্যাদি) ডিভাইচসমূহ বন্ধ কৰে"
-
-#: ../panels/power/cc-power-panel.c:1635
-msgid "_Bluetooth"
-msgstr "ব্লুটুথ (_B)"
-
-#: ../panels/power/cc-power-panel.c:1686
-msgid "When on battery power"
-msgstr "যেতিয়া বেটাৰি শক্তিত চলি থাকে"
-
-#: ../panels/power/cc-power-panel.c:1688
-msgid "When plugged in"
-msgstr "যেতিয়া প্লাগ ইন কৰা আছে"
-
-#: ../panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Off"
-msgstr "স্থগিত কৰি বন্ধ কৰক"
-
-#: ../panels/power/cc-power-panel.c:1851
-msgid "_Automatic suspend"
-msgstr "স্বচালিতভাৱে স্থগিত কৰা (_A)"
-
-#: ../panels/power/cc-power-panel.c:1875
-msgid "When battery power is _critical"
-msgstr "যেতিয়া বেটাৰি শক্তি মাৰাত্মকভাৱে কম (_c)"
-
-#: ../panels/power/cc-power-panel.c:1930
-msgid "Power Off"
-msgstr "বন্ধ কৰক"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Devices"
-msgstr "ডিভাইচ"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "শক্তি"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr "আপোনাৰ বেটাৰিৰ অৱস্থা চাওক আৰু শক্তি সংৰক্ষণ সংহতিসমূহ পৰিবৰ্তন কৰক"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "হাইবাৰনেইট"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "পাৱাৰ অফ"
-
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "৪৫ মিনিট"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "১ ঘন্টা"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "৮০ মিনিট"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "৯০ মিনিট"
 
-#: ../panels/power/power.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "১০০ মিনিট"
 
-#: ../panels/power/power.ui.h:10
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "২ ঘন্টা"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "১ মিনিট"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "বেটাৰি"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "২ মিনিট"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ডিভাইচ"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "৩ মিনিট"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "পাৱাৰ অফ"
 
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "৪ মিনিট"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "৫ মিনিট"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "শক্তি সংৰক্ষণ কৰা"
 
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "৮ মিনিট"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "পৰ্দাৰ উজ্জ্বলতা (_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "১০ মিনিট"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "পৰ্দাৰ উজ্জ্বলতা আৰু লক সংহতিসমূহ"
 
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "১২ মিনিট"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "পৰ্দা"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "পৰ্দা ৰিডাৰ (_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "স্বচালিত পথসমূহ"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "স্বচালিতভাৱে স্থগিত কৰা"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "তলৰ বুটাম"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "স্বচালিতভাৱে স্থগিত কৰা"
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "যেতিয়া প্লাগ ইন কৰা থাকে (_P)"
 
-#: ../panels/power/power.ui.h:22
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "বেটাৰি শক্তিত চলি আছে (_B)"
 
-#: ../panels/power/power.ui.h:23
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "বিলম্ব"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "প্ৰমাণীত কৰক"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "শক্তি"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "পাছৱৰ্ড"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "আপোনাৰ বেটাৰিৰ অৱস্থা চাওক আৰু শক্তি সংৰক্ষণ সংহতিসমূহ পৰিবৰ্তন কৰক"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "প্ৰমাণীকৰণৰ প্ৰয়োজন"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr "টনাৰ কম"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr "টনাৰ শেষ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr "উন্নয়নকাৰী কম"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr "উন্নয়নকাৰী নাই"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr "এটা মাৰ্কাৰ যোগানত কম"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr "এটা মাৰ্কাৰ যোগান শেষ"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr "প্ৰচ্ছেদ খোলক"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr "দৰ্জা খোলক"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr "কাগজ কম"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr "কাগজ শেষ"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr "অফলাইন"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "বন্ধ কৰা হল"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr "আবৰ্জনা গ্ৰাহক প্ৰায় ভৰ্তি"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr "আবৰ্জনা গ্ৰাহক পূৰ্ণ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr "অপ্টিকেল ফ'টো পৰিবাহক জীৱনৰ শেষ পৰ্যায়ত আছে"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr "অপ্টিকেল ফ'টো পৰিবাহক কাৰ্য্য কৰা নাই"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "সংৰূপণ কৰা হৈছে"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr "প্ৰস্তুত"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "কাৰ্য্যসমূহ গ্ৰহণ নকৰে"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr "প্ৰক্ৰিয়াকৰণ কৰা হৈছে"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Toner Level"
-msgstr "টনাৰ স্তৰ"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Ink Level"
-msgstr "কালীৰ স্তৰ"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:928
-msgid "Supply Level"
-msgstr "যোগান স্তৰ"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:946
-msgctxt "printer state"
-msgid "Installing"
-msgstr "ইনস্টল কৰা হৈছে"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1123
-msgid "No printers available"
-msgstr "কোনো প্ৰিন্টাৰ উপলব্ধ নাই"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1433
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u সক্ৰিয়"
-msgstr[1] "%u সক্ৰিয়"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1777
-msgid "Failed to add new printer."
-msgstr "নতুন প্ৰিন্টাৰ যোগ কৰিবলে ব্যৰ্থ।"
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid "Select PPD File"
-msgstr "PPD ফাইল বাছক"
-
-#: ../panels/printers/cc-printers-panel.c:1953
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
-"পস্টস্ক্ৰিপ্ট প্ৰিন্টাৰ বিৱৰণ ফাইলসমূহ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 
-#: ../panels/printers/cc-printers-panel.c:2258
-msgid "No suitable driver found"
-msgstr "কোনো উপযুক্ত ড্ৰাইভাৰ পোৱা নগল"
-
-#: ../panels/printers/cc-printers-panel.c:2327
-msgid "Searching for preferred drivers…"
-msgstr "পছন্দৰ ড্ৰাইভাৰসমূহৰ বাবে সন্ধান কৰা হৈছে…"
-
-#: ../panels/printers/cc-printers-panel.c:2342
-msgid "Select from database…"
-msgstr "ডাটাবেইচৰ পৰা বাছক…"
-
-#: ../panels/printers/cc-printers-panel.c:2351
-msgid "Provide PPD File…"
-msgstr "PPD ফাইল প্ৰদান কৰক…"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2502
-#: ../panels/printers/cc-printers-panel.c:2525
-msgid "Test page"
-msgstr "পৰীক্ষা পৃষ্ঠা"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2933
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui ল'ড কৰিব নোৱাৰি: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "প্ৰিন্টাৰসমূহ"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
-"প্ৰিন্টাৰসমূহ যোগ কৰক, প্ৰিন্টাৰ কাৰ্য্যসমূহ চাওক আৰু আপুনি কেনেধৰণে প্ৰিন্ট "
-"কৰিব বিচাৰে "
+"প্ৰিন্টাৰসমূহ যোগ কৰক, প্ৰিন্টাৰ কাৰ্য্যসমূহ চাওক আৰু আপুনি কেনেধৰণে প্ৰিন্ট কৰিব বিচাৰে "
 "নিৰ্ধাৰণ কৰক"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "প্ৰিন্টাৰ;শাৰী;প্ৰিন্ট;কাগজ;কালী;টনাৰ;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "সক্ৰিয় কাৰ্য্যসমূহ"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "বন্ধ কৰক"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "প্ৰিন্টিং চলাই নিয়ক"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "প্ৰিন্টিং ৰখাওক"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "প্ৰিন্ট কাৰ্য্য বাতিল কৰক"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "এটা নতুন প্ৰিন্টাৰ যোগ কৰক"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "A_uthenticate"
-msgstr "প্ৰমাণীত কৰক (_u)"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "কোনো প্ৰিন্টাৰ চিনাক্ত কৰা হোৱা নাই।"
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-msgid "Enter address of a printer or a text to filter results"
-msgstr "ফলাফলসমূহ ফিল্টাৰ কৰিবলৈ এটা প্ৰিন্টাৰৰ ঠিকনা অথবা এটা লিখনি সুমুৱাওক"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "বিকল্পসমূহ ল'ড কৰা হৈছে…"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "প্ৰিন্টাৰ ড্ৰাইভাৰ বাছক"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "ড্ৰাইভাৰসমূহ ডাটাবেইচ ল'ড কৰা হৈছে..."
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-msgid "JetDirect Printer"
-msgstr "JetDirect প্ৰিন্টাৰ"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-msgid "LPD Printer"
-msgstr "LPD প্ৰিন্টাৰ"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "এক-ফলিয়া"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "দীঘল প্ৰান্ত (প্ৰামাণিক)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "চুটি প্ৰান্ত (লুটিৱাওক)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "পট্ৰেইট"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "লেণ্ডস্কেইপ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "উলোটা লেণ্ডস্কেইপ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "উলোটা পোট্ৰেইট"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "বাকি আছে"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "ধৰি ৰখা আছে"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "প্ৰক্ৰিয়াকৰণ কৰা হৈছে"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "বন্ধ কৰা হল"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "বাতিল কৰা হল"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "বাদ দিয়া হল"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "সম্পন্ন"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "কাৰ্য্য শীৰ্ষক"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "কাৰ্য্য অৱস্থা"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "সময়"
-
-#: ../panels/printers/pp-jobs-dialog.c:495
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s সক্ৰিয় কাৰ্য্যসমূহ"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Serial Port"
-msgstr "ক্ৰমিক পৰ্ট"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1683
-msgid "Parallel Port"
-msgstr "সমান্তৰাল পৰ্ট"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-msgid "Location: %s"
-msgstr "অবস্থান: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1744
-#, c-format
-msgid "Address: %s"
-msgstr "ঠিকনা: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1768
-msgid "Server requires authentication"
-msgstr "চাৰ্ভাৰৰ প্ৰমাণীকৰণৰ প্ৰয়োজন"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "দুই -ফলিয়া"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "পাতৰ ধৰণ"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "পাতৰ উৎস"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "আউটপুট ট্ৰে"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript পূৰ্ব-পৰিস্ৰাৱন"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:531
-msgid "Pages per side"
-msgstr "প্ৰতি ফাল পৃষ্ঠাসমূহ"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:543
-msgid "Two-sided"
-msgstr "দুই -ফলিয়া"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:555
-msgid "Orientation"
-msgstr "দিশনিৰ্ণয়"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:652
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "সাধাৰণ"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "পৃষ্ঠাৰ সংস্থাপন"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "ইনস্টল কৰিব পৰা বিকল্পসমূহ"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "কাৰ্য্য"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "ছবিৰ গুণ"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "ৰঙ"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "শেষ কৰা হৈছে"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "উন্নত"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "স্বনিৰ্বাচন"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "অবিকল্পিত প্ৰিন্টাৰ"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "কেৱল GhostScript ফন্টসমূহ অন্তৰভুক্ত কৰক"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "PS স্তৰ ১ লে পৰিবৰ্তন কৰক"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "PS স্তৰ ২ লে পৰিবৰ্তন কৰক"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "কোনো পূৰ্ব-পৰিস্ৰাৱন নাই"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "উৎপাদক"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "ড্ৰাইভাৰ"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-"%s ত উপলব্ধ প্ৰিন্টাৰসমূহ চাবলে আপোনাৰ ব্যৱহাৰকাৰীনাম আৰু পাছৱৰ্ড সুমুৱাওক।"
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "প্ৰিন্টাৰ যোগ কৰক"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "প্ৰিন্টাৰ আতৰাওক"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "যোগান দিয়ক"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "কোনো ছবি পোৱা নগল"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "প্ৰমাণীকৰণৰ প্ৰয়োজন"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr "%s ত উপলব্ধ প্ৰিন্টাৰসমূহ চাবলে আপোনাৰ ব্যৱহাৰকাৰীনাম আৰু পাছৱৰ্ড সুমুৱাওক।"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ব্যৱহাৰকাৰীনাম"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "অবস্থান"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default printer"
-msgstr "অবিকল্পিত প্ৰিন্টাৰ (_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "ড্ৰাইভাৰ"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "কাৰ্য্যসমূহ"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "পছন্দৰ ড্ৰাইভাৰসমূহৰ বাবে সন্ধান কৰা হৈছে…"
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "কাৰ্য্যসমূহ দেখুৱাওক (_J)"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "এটা শহৰৰ বাবে সন্ধান কৰক"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "ডাটাবেইচৰ পৰা বাছক…"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "PPD ফাইল প্ৰদান কৰক…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "প্ৰিন্টাৰ ড্ৰাইভাৰ বাছক"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "ড্ৰাইভাৰসমূহ ডাটাবেইচ ল'ড কৰা হৈছে..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "বাতিল কৰক"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "বাছক"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "চাৰ্ভাৰৰ প্ৰমাণীকৰণৰ প্ৰয়োজন"
+msgstr[1] "চাৰ্ভাৰৰ প্ৰমাণীকৰণৰ প্ৰয়োজন"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "ডমেইন (_D)"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "প্ৰমাণীত কৰক (_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "প্ৰমাণীত কৰক"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s সক্ৰিয় কাৰ্য্যসমূহ"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "পৰীক্ষা পৃষ্ঠা"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "প্ৰিন্টাৰ বিকল্পসমূহ"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "অবিকল্পিত প্ৰিন্টাৰ"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "অবিকল্পিত প্ৰিন্টাৰ"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "প্ৰিন্ট কাৰ্য্য বাতিল কৰক"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "প্ৰিন্টাৰ আতৰাওক"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "সক্ৰিয় কাৰ্য্যসমূহ"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "আৰ্হি"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "লেবেল"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "কালীৰ স্তৰ"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "নতুন ড্ৰাইভাৰ সংস্থাপন কৰা হৈছে…"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "পৃষ্ঠা ৩"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "পৰীক্ষা পৃষ্ঠা প্ৰিন্ট কৰক (_T)"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "বিকল্পসমূহ (_O)"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "এতিয়া পুনৰাম্ভ কৰক"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "নতুন প্ৰিন্টাৰ যোগ কৰক"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "প্ৰিন্টাৰ যোগ কৰক"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "প্ৰিন্টাৰ সংহতিসমূহ সলনি কৰক"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "প্ৰিন্টাৰসমূহ"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "ক্ষমা কৰিব! চিস্টেম প্ৰিন্টিং সেৱা\n"
 "উপলব্ধ নাই যেন লাগিছে।"
 
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "পৰ্দাৰ লক"
-
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "ব্যৱহাৰ আৰু ইতিহাস"
-
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
-msgstr "আবৰ্জনাৰ পৰা সকলো বস্তু আতৰাব নে?"
-
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
-msgstr "আবৰ্জনাৰ সকলো বস্তু স্থায়ীভাৱে মচি পেলোৱা হব।"
-
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "আবৰ্জনা খালি কৰক (_E)"
-
-#: ../panels/privacy/cc-privacy-panel.c:512
-msgid "Delete all the temporary files?"
-msgstr "সকলো অস্থায়ী ফাইল মচি পেলাব নে?"
-
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
-msgstr "সকলো অস্থায়ী ফাইল স্থায়ীভাৱে মচি পেলোৱা হব।"
-
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "অস্থায়ী ফাইলসমূহ শোধন কৰক (_P)"
-
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "আবৰ্জনা শোধন আৰু অস্থায়ী ফাইলসমূহ"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr "চফ্টৱেৰৰ ব্যৱহাৰ"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "গোপনীয়তা"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr "আপোনাৰ ব্যক্তিগত তথ্য সুৰক্ষিত কৰক আৰু অন্যয় কি চাব পাৰে নিয়ন্ত্ৰণ কৰক"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "পৰ্দা বন্ধ হয়"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "৩০ ছেকেণ্ড"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "১ দিন"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "২ দিন"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "৩ দিন"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "৪ দিন"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "৫ দিন"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "৬ দিন"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "৭ দিন"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "১৪ দিন"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "৩০ দিন"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "চিৰকাল"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"আপোনাৰ ইতিহাস মনত ৰাখিলে বস্তুবোৰ আকৌ বিচাৰোতে সহজ হয়। এই বস্তুবোৰ নেটৱৰ্কৰে "
-"কেতিয়াও অংশীদাৰী কৰা নহয়।"
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "শেহতীয়াভাৱে ব্যৱহৃত (_R)"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "ইতিহাস অব্যাহত ৰাখক (_H)"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "শেহতীয়া ইতিহাস পৰিষ্কাৰ কৰক (_e)"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "যেতিয়া আপুনি আতৰ হয় পৰ্দা লকে আপোনাৰ গোপনীয়তা সুৰক্ষিত ৰাখে।"
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "স্বচালিত পৰ্দা লক (_L)"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "উল্লেখিত সময় খালি থকাৰ পিছত পৰ্দা লক কৰিব (_A)"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "অধিসূচনাসমূহ দেখুৱাওক (_N)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"আপোনাৰ কমপিউটাৰক অপ্ৰয়োজনীয় সংবেদ্য তথ্যৰ পৰা মুক্ত ৰাখিবলে আবৰ্জনা আৰু "
-"অস্থায়ী "
-"ফাইলসমূহ স্বচালিতভাৱে শোধন কৰক।"
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "আবৰ্জনা স্বচালিতভাৱে খালি কৰক (_T)"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "অস্থায়ী ফাইলসমূহ স্বচালিতভাৱে শোধন কৰক (_F)"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "উল্লেখিত সময়ৰ পিছত শোধন কৰক (_A)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"আপুনি কি চফ্টৱেৰ ব্যৱহাৰ কৰে তাৰ বিষয়ে তথ্য পঠালে আমাক অধিক সঠিক উপদেশ প্ৰদান "
-"কৰাত সহায় কৰে। ই লগতে আমাৰ চফ্টৱেৰ উন্নত কৰাত সহায় কৰে।\n"
-"\n"
-"আমি সংগ্ৰহ কৰা সকলো তথ্যক বেনামী কৰা হয়, আৰু আমি আপোনাৰ তথ্য কেতিয়াও তৃতীয় "
-"দলৰ "
-"সৈতে অংশীদাৰী নকৰো।"
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "চফ্টৱেৰ ব্যৱহাৰৰ পৰিসংখ্যা পঠাওক (_S)"
-
-#: ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "গোপনীয়তা নীতি"
-
-#: ../panels/privacy/privacy.ui.h:42
-msgid "_Location Services"
-msgstr "অবস্থান সেৱাসমূহ (_L)"
-
-#: ../panels/privacy/privacy.ui.h:43
-#| msgid "Allows applications to determine your geographical location"
-msgid "Used to determine your geographical location"
-msgstr "আপোনাৰ ভৌগলিক অৱস্থান নিৰ্ধাৰণ কৰাৰ বাবে ব্যৱহাৰ কৰা হয়"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ইম্পেৰিয়েল"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "মেট্ৰিক"
-
-#: ../panels/region/cc-format-chooser.c:284
-msgid "No regions found"
-msgstr "কোনো অঞ্চল পোৱা নগল"
-
-#: ../panels/region/cc-input-chooser.c:179
-msgid "No input sources found"
-msgstr "কোনো ইনপুট উৎস পোৱা নগল"
-
-#: ../panels/region/cc-input-chooser.c:1076
-msgctxt "Input Source"
-msgid "Other"
-msgstr "অন্য"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:896
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "পৰিবৰ্তনসমূহ প্ৰভাৱশালী হবলে আপোনাৰ অধিবেশন পুনৰাম্ভ কৰিব লাগিব"
-
-#: ../panels/region/cc-region-panel.c:240
-#: ../panels/user-accounts/um-user-panel.c:897
-msgid "Restart Now"
-msgstr "এতিয়া পুনৰাম্ভ কৰক"
-
-#: ../panels/region/cc-region-panel.c:858
-msgid "No input source selected"
-msgstr "কোনো ইনপুট উৎস নিৰ্বাচন কৰা হোৱা নাই"
-
-#: ../panels/region/cc-region-panel.c:1088
-msgid "Sorry"
-msgstr "ক্ষমা কৰিব"
-
-#: ../panels/region/cc-region-panel.c:1090
-msgid "Input methods can't be used on the login screen"
-msgstr "ইনপুট পদ্ধতিসমূহ লগিন পৰ্দাত ব্যৱহাৰ কৰিব নোৱাৰি"
-
-#: ../panels/region/cc-region-panel.c:1727
-msgid "Login Screen"
-msgstr "লগিন পৰ্দা"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "বিন্যাসসমূহ"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "অবস্থানসমূহ সন্ধান কৰক"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "সাধাৰণ কৰ্ম"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "বিন্যাসসমূহ"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "সংহতিসমূহ সন্ধান কৰক"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "পূর্ব প্ৰদর্শন"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "তাৰিখসমূহ"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "সময়বোৰ"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "তাৰিখ &সময়"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "নম্বৰসমূহ"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "মাপ"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "পাত"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "ভাষাসমূহ ইনস্টল কৰক..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "মোৰ একাওন্ট"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "ভাষা (_L)"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "বিন্যাসসমূহ"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "লগিন পৰ্দা"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "অঞ্চল & ভাষা"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
-msgstr ""
-"আপোনাৰ প্ৰদৰ্শন ভাষা, বিন্যাসসমূহ, কিবৰ্ড বিন্যাসসমূহ আৰু ইনপুট উৎসসমূহ বাছক"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "এটা প্ৰদৰ্শনৰ ভাষা বাছক"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "এটা ইনপুট উৎস যোগ কৰক"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "মাধ্যম কেনেধৰণে নিয়ন্ত্ৰণ কৰা হব বাছক"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "ইনপুট উৎস বিকল্পসমূহ"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD অডিঅ' (_a)"
 
-#: ../panels/region/input-options.ui.h:2
-msgid "Use the _same source for all windows"
-msgstr "সকলো উইন্ডোৰ বাবে একেটা উৎস ব্যৱহাৰ কৰক (_s)"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "DVD ভিডিঅ' (_D)"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Allow _different sources for each window"
-msgstr "প্ৰতিটো উইন্ডোৰ বাবে ভিন্ন উৎসৰ অনুমতি দিয়ক (_d)"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "সংগীত প্লেয়াৰ (_M)"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Keyboard Shortcuts"
-msgstr "কিবৰ্ড চৰ্টকাটসমূহ"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "চফ্টৱেৰ (_S)"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Switch to previous source"
-msgstr "পূৰ্বৱৰ্তী উৎসলে যাওক"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "অন্য মাধ্যম (_O)…"
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "মাধ্যম সুমুৱাত কেতিয়াও প্ৰগ্ৰামসমূহ প্ৰমপ্ট অথবা আৰম্ভ নকৰিব (_N)"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Switch to next source"
-msgstr "পৰৱৰ্তী উৎসলে যাওক"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "মাধ্যম কেনেধৰণে নিয়ন্ত্ৰণ কৰা হব বাছক"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Super+Space"
-msgstr "Super+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "কাৰ্য্য (_A):"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "আপুনি এই চৰ্টকাটসমূহ কিবৰ্ড সংহতিসমূহত পৰিবৰ্তন কৰিব পাৰিব"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "ধৰণ (_T):"
 
-#: ../panels/region/input-options.ui.h:10
-msgid "Alternative switch to next source"
-msgstr "পৰৱৰ্তী উৎসলে বৈকল্পিক চুইচ"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "আতৰাব পৰা মাধ্যম"
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Left+Right Alt"
-msgstr "Left+Right Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "ব্লুটুথ সংহতিসমূহ সংৰূপণ কৰক"
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "ইংৰাজী (ইংলেণ্ড)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "সংযুক্তৰাজ্য"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "বিকল্পসমূহ"
-
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"চিস্টেমত লগিন কৰোতে লগিন সংহতিসমূহ সকলো ব্যৱহাৰকাৰী দ্বাৰা ব্যৱহাৰ কৰা হয়"
+"ডিভাইচ;চিস্টেম;তথ্য;মেমৰি;প্ৰচেছৰ;সংস্কৰণ;অবিকল্পিত;এপ্লিকেচন;পছন্দ;cd;dvd;usb;"
+"অডিঅ';ভিডিঅ';ডিস্ক;আতৰাব পৰা;মাধ্যম;স্বচলন;"
 
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "পৰ্দাৰ লক"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "ৰিক্ত পৰ্দা (_B)"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "স্বচালিত পৰ্দা লক (_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "স্বচালিত পৰ্দা লক (_L)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "পৰ্দা লক কৰাত বিৱৰণসমূহ দেখুৱাওক"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "পৰ্দা লক কৰক"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "গোপনীয়তা"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "পৰ্দা"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "শব্দ সংহতিসমূহ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "অবস্থানসমূহ সন্ধান কৰক"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
 msgid "Places"
 msgstr "স্থানবোৰ"
 
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
 msgid "Bookmarks"
 msgstr "পত্ৰচিহ্নসমূহ"
 
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "অন্য"
 
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "অবস্থান বাছক"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "অবস্থান"
 
-#: ../panels/search/cc-search-locations-dialog.c:682
-msgid "_OK"
-msgstr "ঠিক আছে (_O)"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "এপ্লিকেচনসমূহ"
 
-#: ../panels/search/cc-search-panel.c:176
-msgid "No applications found"
-msgstr "কোনো এপ্লিকেচন পোৱা নগল"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "বিচাৰক"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "সংহতিসমূহ সন্ধান কৰক"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "কোনবোৰ এপ্লিকেচনে কাৰ্য্যসমূহ অভাৰভিউত ফলাফলসমূহ দেখুৱায় নিয়ন্ত্ৰণ কৰক"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Search;Find;Index;Hide;Privacy;Results;"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr "অবস্থানসমূহ সন্ধান কৰক"
-
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "উপৰলে স্থানান্তৰ কৰক"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "তললে স্থানান্তৰ কৰক"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "পছন্দসমূহ"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "অন"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "অফ"
-
-#: ../panels/sharing/cc-sharing-panel.c:304
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "সামৰ্থবান"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-msgctxt "service is active"
-msgid "Active"
-msgstr "সক্ৰিয়"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "এটা ফোল্ডাৰ বাছক"
-
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "কপি কৰক"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-msgid "Sharing"
-msgstr "অংশীদাৰী কৰা"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr "আপুনি অন্যৰ লগত কি অংশীদাৰী কৰিব বিচাৰে নিয়ন্ত্ৰণ কৰক"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
-msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
-msgstr ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "দূৰৱৰ্তী লগিন সামৰ্থবান অথবা অসামৰ্থবান কৰক"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "দূৰৱৰ্তী লগিন সামৰ্থবান অথবা অসামৰ্থবান কৰিবলে প্ৰমাণীকৰণৰ প্ৰয়োজন"
-
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:299
-msgid "No networks selected for sharing"
-msgstr "অংশীদাৰী কৰিবলে কোনো নেটৱৰ্ক নিৰ্বাচন কৰা হোৱা নাই"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "নেটৱৰ্কসমূহ"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "ব্লুটুথ অংশীদাৰী"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "অংশীদাৰী কৰা"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-"ব্লুটুথ অংশীদাৰীয়ে আপোনাক অন্য ব্লুটুথ সামৰ্থবান ডিভাইচসমূহৰ সৈতে ফাইলসমূহ "
-"অংশীদাৰী "
-"কৰাৰ অনুমতি দিয়ে"
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "কেৱল ভৰষাবান ডিভাইচসমূহৰ পৰা গ্ৰহণ কৰক"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "গ্ৰহণ কৰা ফাইলসমূহ ডাউনল'ডসমূহ ফোল্ডাৰত সংৰক্ষণ কৰক"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "কমপিউটাৰৰ নাম"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "ব্যক্তিগত ফাইল অংশীদাৰী"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "পৰ্দা অংশীদাৰী"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "ডেস্কটপ"
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
 msgstr "মাধ্যমৰ অংশীদাৰী"
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "দূৰৱৰ্তী লগিন"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "অংশীদাৰী কৰা"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "পাছৱৰ্ডৰ প্ৰয়োজন"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "দূৰৱৰ্তী লগিন"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "কোনো নেটৱৰ্ক অভিগম নথকা বাবে কিছুমান সেৱা অসামৰ্থবান কৰা আছে।"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "ডেস্কটপ"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
-"ব্যক্তিগত ফাইল অংশীদাৰীয়ে আপোনাক আপোনাৰ বৰ্তমান নেটৱৰ্কত <a href=\"dav://%s"
-"\">dav://%s</a> ব্যৱহাৰ কৰি আপোনাৰ ৰাজহুৱা ফোল্ডাৰক অন্যৰ সৈতে অংশীদাৰী কৰাৰ "
-"অনুমতি দিয়ে"
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr "পাছৱৰ্ডৰ প্ৰয়োজন"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "দূৰৱৰ্তী লগিন সামৰ্থবান অথবা অসামৰ্থবান কৰক"
 
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"Secure Shell কমান্ড ব্যৱহাৰ কৰি দূৰৱৰ্তী ব্যৱহাৰকাৰীসকলৰ সৈতে সংযোগ কৰাৰ "
-"অনুমতি "
-"দিয়ক:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"দূৰৱৰ্তী ব্যৱহাৰকাৰীসকলক <a href=\"vnc://%s\">vnc://%s</a> ৰ সৈতে সংযোগ কৰি "
-"আপোনাৰ পৰ্দা দৰ্শন অথবা নিয়ন্ত্ৰণ কৰাৰ অনুমতি দিয়ক"
-
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "দূৰৱৰ্তী নিয়ন্ত্ৰণৰ অনুমতি দিয়ক"
 
-#: ../panels/sharing/sharing.ui.h:21
-msgid "Password:"
-msgstr "পাছৱৰ্ড:"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "পাছৱৰ্ড দেখুৱাওক"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "সংযোগ বিহীন"
 
-#: ../panels/sharing/sharing.ui.h:23
-msgid "Access Options"
-msgstr "অভিগমৰ বিকল্পসমূহ"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "নতুন সংযোগসমূহে অভিগমৰ বাবে সোধিব লাগিব"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "কপি কৰক"
 
-#: ../panels/sharing/sharing.ui.h:25
-msgid "Require a password"
-msgstr "এটা পাছৱৰ্ডৰ প্ৰয়োজন"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "ঠিকনা মচি পেলাওক"
 
-#: ../panels/sharing/sharing.ui.h:26
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "প্ৰমাণীকৰণ (_t)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ব্যৱহাৰকাৰীনাম"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "আঙ্গুলিৰ ছাপসমূহ এনৰোল কৰা"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "মাধ্যমৰ অংশীদাৰী"
+
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "নেটৱৰ্কৰে সংগীত, ফ'টোসমূহ আৰু ভিডিঅ'সমূহ অংশীদাৰী কৰক।"
 
-#: ../panels/sharing/sharing.ui.h:27
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "ফোল্ডাৰসমূহ"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "শব্দ"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "আপুনি অন্যৰ লগত কি অংশীদাৰী কৰিব বিচাৰে নিয়ন্ত্ৰণ কৰক"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 msgstr ""
-"শব্দৰ স্তৰসমূহ, ইনপুটসমূহ, আউটপুটসমূহ, আৰু সতৰ্কতা শব্দসমূহ পৰিবৰ্তন কৰক"
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "কাৰ্ড;মাইক্ৰোফোন;ভলিউম;স্লান;ভাৰসাম্য;ব্লুটুথ;হেডচেট;অডিঅ;"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "দূৰৱৰ্তী লগিন সামৰ্থবান অথবা অসামৰ্থবান কৰক"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "বাৰ্ক"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "দূৰৱৰ্তী লগিন সামৰ্থবান অথবা অসামৰ্থবান কৰিবলে প্ৰমাণীকৰণৰ প্ৰয়োজন"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "ড্ৰিপ"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "কাঁচ"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "অংশীদাৰী কৰা"
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "Sonar"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "বাওঁ"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "সোঁ"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "ভাৰসাম্য (_B):"
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "স্লান (_F):"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "পিছফাল"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "আগফাল"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "নূন্যতম"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "সৰ্বাধিক"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "ভাৰসাম্য (_B):"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "স্লান (_F):"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "চাব্ওফাৰ (_S):"
-
-#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
-msgctxt "volume"
-msgid "100%"
-msgstr "১০০%"
-
-#: ../panels/sound/gvc-channel-bar.c:616
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "অবৃদ্ধিত"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "আলেখ্য (_P):"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u আউটপুট"
-msgstr[1] "%u আউটপুটসমূহ"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u ইনপুট"
-msgstr[1] "%u ইনপুটসমূহ"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "চিস্টেমৰ শব্দসমূহ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "স্পিকাৰসমূহ পৰীক্ষা কৰক (_T)"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "সতৰ্ক ভলিউম (_A):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "শীৰ্ষ চিনাক্তকৰণ"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "ভলিউম মৌণ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1509
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "নাম"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1528
-msgid "Device"
-msgstr "ডিভাইচ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1591
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s ৰ বাবে স্পিকাৰ পৰীক্ষা"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1649
-msgid "_Output volume:"
-msgstr "আউটপুট ভলিউম (_O):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1663
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "আউটপুট"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1668
-msgid "C_hoose a device for sound output:"
-msgstr "শব্দ আউটপুটৰ বাবে এটা ডিভাইচ বাছক (_h):"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "আউটপুট ভলিউম (_O):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1693
-msgid "Settings for the selected device:"
-msgstr "নিৰ্বাচিত ডিভাইচৰ বাবে সংহতিসমূহ:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "Input"
-msgstr "ইনপুট"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "_Input volume:"
-msgstr "ইনপুট ভলিউম (_I):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1734
-msgid "Input level:"
-msgstr "ইনপুট স্তৰ:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1762
-msgid "C_hoose a device for sound input:"
-msgstr "শব্দ ইনপুটৰ বাবে এটা ডিভাইচ বাছক (_h):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "Sound Effects"
-msgstr "শব্দ প্ৰভাৱসমূহ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-msgid "_Alert volume:"
-msgstr "সতৰ্ক ভলিউম (_A):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1809
-msgid "Applications"
-msgstr "এপ্লিকেচনসমূহ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1813
-msgid "No application is currently playing or recording audio."
-msgstr "কোনো এপ্লিকেচনে বৰ্তমানে অডিঅ' বজোৱা বা ৰেকৰ্ড কৰা নাই।"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "বিল্ট-ইন"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "শব্দ পছন্দসমূহ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "ঘটনা শব্দ পৰীক্ষা কৰা"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "অবিকল্পিত"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "থীমৰ পৰা"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:769
-msgid "C_hoose an alert sound:"
-msgstr "এটা সতৰ্কৰ শব্দ বাছক (_h):"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "বন্ধ কৰক"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "পৰীক্ষা"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "সংৰূপ URL (_C)"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "চাব্ওফাৰ"
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "স্বনিৰ্বাচিত"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "ইনপুট"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "চোৱা, শুনা, টাইপ কৰা, পোইন্ট আৰু ক্লিক কৰাটো সহজ কৰক"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "ইনপুট স্তৰ:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "ভলিউম বৃদ্ধি"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "সতৰ্ক ভলিউম (_A):"
+
+#: panels/sound/cc-volume-slider.ui:22
+#, fuzzy
+msgid "Mute"
+msgstr "মৌণ কৰক (_M)"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "শব্দ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "শব্দৰ স্তৰসমূহ, ইনপুটসমূহ, আউটপুটসমূহ, আৰু সতৰ্কতা শব্দসমূহ পৰিবৰ্তন কৰক"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "কাৰ্ড;মাইক্ৰোফোন;ভলিউম;স্লান;ভাৰসাম্য;ব্লুটুথ;হেডচেট;অডিঅ;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "অধিসূচনাসমূহ ব্যৱস্থাপনা কৰক"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "নাম :(_N)"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"কিবৰ্ড;মাউছ;a11y;অভিগম্যতা;কনট্ৰাস্ট;জুম;পৰ্দা;ৰিডাৰ;লিখনি;ফন্ট;আকাৰ;AccessX;স"
-"্টিকি; "
-"কিসমূহ;লেহেম;বাউন্স;মাউছ;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "সাৰ্বভৈমক অভিগম মেনু সদায় দেখুৱাব (_A)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "দেখা"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "স্বচালিত সংযোগ (_C)"
 
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "উচ্চ কন্ট্ৰাস্ট (_H)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "ডিভাইচ আতৰাওক"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "ডাঙৰ লিখনি (_L)"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:5
-msgid "_Zoom"
-msgstr "জুম (_Z)"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s ডমেইনলে সংযোগ কৰিব নোৱাৰি: %s"
 
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr "পৰ্দা ৰিডাৰ (_R)"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "সাৰ্বভৈমক অভিগম"
 
-#: ../panels/universal-access/uap.ui.h:8
-msgid "_Sound Keys"
-msgstr "শব্দ কি'সমূহ (_S)"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "শুনা"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "ডিভাইচসমূহ প্ৰাপ্ত কৰা হৈ আছে..."
 
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
-msgstr "চক্ষ সতৰ্কবাৰ্তাসমূহ (_V)"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Screen _Keyboard"
-msgstr "পৰ্দা কিবৰ্ড (_K)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
 
-#: ../panels/universal-access/uap.ui.h:13
-msgid "_Typing Assist (AccessX)"
-msgstr "টাইপিং সহায়ক (AccessX) (_T)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Pointing & Clicking"
-msgstr "পোইন্টিং আৰু ক্লিকিং"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:15
-msgid "_Mouse Keys"
-msgstr "মাউছ কি'সমূহ (_M)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "কাৰ্চাৰৰ পিৰিকিয়া"
 
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "সহায়ত ক্লিক কৰক (_C)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "আখৰৰ ক্ষেত্ৰত কাৰ্চাৰ পিৰিকিয়া (_b)"
 
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "পৰ্দা ৰিডাৰ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "গতি (_S):"
 
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "স্ক্ৰিন ৰিডাৰে প্ৰদৰ্শিত লিখনি পঢ়ে যেতিয়া আপুনি ফকাচ আতৰায়।"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "কাৰ্চাৰৰ পিৰিকিয়া গতি"
 
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Screen Reader"
-msgstr "পৰ্দা ৰিডাৰ (_S)"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "কাৰ্চাৰৰ পিৰিকিয়া গতি"
 
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Sound Keys"
-msgstr "শব্দ কি'সমূহ"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "Num Lock অথবা Caps Lock অন থকা অৱস্থাত বিপ কৰিব।"
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "চক্ষ সতৰ্কবাৰ্তাসমূহ"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "ফ্লেশ পৰীক্ষা কৰক (_T)"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "এটা সতৰ্ক শব্দ হওতে এটা চক্ষ ইংগিত ব্যৱহাৰ কৰিব।"
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Flash the _window title"
-msgstr "উইন্ডো শীৰ্ষক ফ্লেশ কৰক (_w)"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Flash the entire _screen"
-msgstr "সম্পূৰ্ণ পৰ্দা ফ্লেশ কৰক (_s)"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Typing Assist"
-msgstr "টাইপিং সহায়"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "_Sticky Keys"
-msgstr "স্টিকি কি'সমূহ (_S)"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "পৰিৱৰ্তক কিসমূহৰ এটা ক্ৰমক এটা কি সংযুক্তি হিচাপে ব্যৱহাৰ কৰে"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "অসামৰ্থবান কৰিব যদি দুটা কি একেলগে টিপা হয় (_D)"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifer key is pressed"
-msgstr "এটা পৰিৱৰ্তক কি টিপোতে বিপ কৰিব (_m)"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "S_low Keys"
-msgstr "ধীৰ গতিৰ কি'সমূহ (_l)"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "এটা বিলম্ব দিয়ে যেতিয়া এটা কি টিপা হয় আৰু গ্ৰহণ কৰা হয়"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "গ্ৰহণ বিলম্ব (_c):"
-
-#: ../panels/universal-access/uap.ui.h:35
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "সৰু"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "লেহেম কিসমূহৰ টাইপিং বিলম্ব"
-
-#: ../panels/universal-access/uap.ui.h:37
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "দীঘল"
-
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Beep when a key is pr_essed"
-msgstr "এটা কি' টিপোতে বিপ কৰিব (_e)"
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Beep when a key is _accepted"
-msgstr "এটা কি' গ্ৰহণ কৰিলে বিপ কৰিব (_a)"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "এটা কি নাকচ হওতে বিপ কৰিব (_r)"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "_Bounce Keys"
-msgstr "বাউন্স কি'সমূহ (_B)"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "দ্ৰুত প্ৰতিলিপিত কিটিপা উপেক্ষা কৰে"
-
-#: ../panels/universal-access/uap.ui.h:43
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "সৰু"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "বাউন্স কিসমূহ টাইপিং বিলম্ব"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "দীঘল"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Enable by Keyboard"
-msgstr "কিবৰ্ড দ্বাৰা সামৰ্থবান কৰা (_E)"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "কিবৰ্ড ব্যৱহাৰ কৰি অভিগম্যতা বৈশিষ্টসমূহ অন অথবা অফ কৰক"
-
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "সহায় ক্লিক কৰক"
 
-#: ../panels/universal-access/uap.ui.h:49
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "কৃত্ৰিম দ্বিতীয় ক্লিক (_S)"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "প্ৰাথমিক বুটাম টিপি ৰাখি এটা দ্বিতীয় ক্লিক কৰক"
 
-#: ../panels/universal-access/uap.ui.h:51
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "গ্ৰহণ বিলম্ব (_c):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "সৰু"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "দ্বিতীয় ক্লিক বিলম্ব"
 
-#: ../panels/universal-access/uap.ui.h:53
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "দীঘল"
 
-#: ../panels/universal-access/uap.ui.h:54
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "হভাৰ ক্লিক (_H)"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "পোইন্টাৰ হভাৰ হওতে এটা ক্লিক কৰক"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "বিলম্ব (_e):"
 
-#: ../panels/universal-access/uap.ui.h:57
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "সৰু"
 
-#: ../panels/universal-access/uap.ui.h:58
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "দীঘল"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "চলন ডেউৰী (_t):"
 
-#: ../panels/universal-access/uap.ui.h:60
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "সৰু"
 
-#: ../panels/universal-access/uap.ui.h:61
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "ডাঙৰ"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "পুনৰাবৃত্তিৰ-কি"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "কি টিপি ৰাখিলে অনবৰত লিখা হ'ব (_r)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "কি পুনৰাবৃত্তিৰ হাৰ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "কি পুনৰাবৃত্তিৰ হাৰ"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "টাইপিং সহায়"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "স্টিকি কি'সমূহ (_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "পৰিৱৰ্তক কিসমূহৰ এটা ক্ৰমক এটা কি সংযুক্তি হিচাপে ব্যৱহাৰ কৰে"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "অসামৰ্থবান কৰিব যদি দুটা কি একেলগে টিপা হয় (_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "এটা পৰিৱৰ্তক কি টিপোতে বিপ কৰিব (_m)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "ধীৰ গতিৰ কি'সমূহ (_l)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "এটা বিলম্ব দিয়ে যেতিয়া এটা কি টিপা হয় আৰু গ্ৰহণ কৰা হয়"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "সৰু"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ পৰ্দা"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "লেহেম কিসমূহৰ টাইপিং বিলম্ব"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ পৰ্দা"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ পৰ্দা"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "দীঘল"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "এটা কি' টিপোতে বিপ কৰিব (_e)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "এটা কি' গ্ৰহণ কৰিলে বিপ কৰিব (_a)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "এটা কি নাকচ হওতে বিপ কৰিব (_r)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "বাউন্স কি'সমূহ (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "দ্ৰুত প্ৰতিলিপিত কিটিপা উপেক্ষা কৰে"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "সৰু"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "বাউন্স কিসমূহ টাইপিং বিলম্ব"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "দীঘল"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "কিবৰ্ড দ্বাৰা সামৰ্থবান কৰা (_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "কিবৰ্ড ব্যৱহাৰ কৰি অভিগম্যতা বৈশিষ্টসমূহ অন অথবা অফ কৰক"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "সাৰ্বভৈমক অভিগম মেনু সদায় দেখুৱাব (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "দেখা"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "উচ্চ কন্ট্ৰাস্ট (_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "ডাঙৰ লিখনি (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+#, fuzzy
+msgid "Enable A_nimations"
+msgstr "অধিসূচনাসমূহ ব্যৱস্থাপনা কৰক"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "পৰ্দা ৰিডাৰ (_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "স্ক্ৰিন ৰিডাৰে প্ৰদৰ্শিত লিখনি পঢ়ে যেতিয়া আপুনি ফকাচ আতৰায়।"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "শব্দ কি'সমূহ (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num Lock অথবা Caps Lock অন থকা অৱস্থাত বিপ কৰিব।"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "কাৰ্চাৰৰ পিৰিকিয়া গতি"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "জুম (_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "শুনা"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "চক্ষ সতৰ্কবাৰ্তাসমূহ (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "পৰ্দা কিবৰ্ড (_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "পুনৰাবৃত্তিৰ-কি"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "কাৰ্চাৰৰ পিৰিকিয়া"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "টাইপিং সহায়ক (AccessX) (_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "পোইন্টিং আৰু ক্লিকিং"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "মাউছ কি'সমূহ (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "বগা পইন্টাৰ"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "সহায়ত ক্লিক কৰক (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "দুবাৰ-ক্লিক (_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "দুবাৰ ক্লিকৰ সময়সীমা"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "চক্ষ সতৰ্কবাৰ্তাসমূহ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "ফ্লেশ পৰীক্ষা কৰক (_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "এটা সতৰ্ক শব্দ হওতে এটা চক্ষ ইংগিত ব্যৱহাৰ কৰিব।"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "সম্পূৰ্ণ পৰ্দা ফ্লেশ কৰক (_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "সম্পূৰ্ণ পৰ্দা ফ্লেশ কৰক (_s)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "পূৰ্ণ পৰ্দা"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "উপৰ অৰ্দ্ধাংশ"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "তলৰ অৰ্দ্ধাংশ"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "বাওঁ অৰ্দ্ধাংশ"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "সোঁ অৰ্দ্ধাংশ"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "জুম বিকল্পসমূহ"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "ডাঙৰ কৰি দেখুৱাওক"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "ডাঙৰ কৰা:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "মাউছ কাৰ্চাৰ অনুসৰণ কৰক"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "পৰ্দাৰ অংশ:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "ডাঙৰ কৰাটো পৰ্দাৰ বাহিৰ প্ৰসাৰিত হয়"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "মেগ্নিফায়াৰ কাৰ্চাৰ কেন্দ্ৰত ৰাখক"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "মেগ্নিফায়াৰ কাৰ্চাৰে সমলসমূহক ঠেলা মাৰে"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "মেগ্নিফায়াৰ কাৰ্চাৰ সমলসমূহৰ সৈতে গমন কৰে"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "মেগ্নিফায়াৰ অৱস্থান:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "মাউছ কাৰ্চাৰ অনুসৰণ কৰক"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "পৰ্দাৰ অংশ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "ডাঙৰ কৰাটো পৰ্দাৰ বাহিৰ প্ৰসাৰিত হয়"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "মেগ্নিফায়াৰ কাৰ্চাৰ কেন্দ্ৰত ৰাখক"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "মেগ্নিফায়াৰ কাৰ্চাৰে সমলসমূহক ঠেলা মাৰে"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "মেগ্নিফায়াৰ কাৰ্চাৰ সমলসমূহৰ সৈতে গমন কৰে"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "মেগ্নিফায়াৰ"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "ক্ৰসহেয়াৰসমূহ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "মাউছ কাৰ্চাৰক অভিব্যপন কৰে"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "ডাঠ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "পাতল"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "শকত"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "দৈৰ্ঘ্য:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "ৰঙ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "ক্ৰসহেয়াৰসমূহ:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "মাউছ কাৰ্চাৰক অভিব্যপন কৰে"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "ক্ৰসহেয়াৰসমূহ"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "ৰঙৰ প্ৰভাৱসমূহ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "কলাত বগা:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "উজ্জ্বলতা:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "কনট্ৰাস্ট:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "ৰঙ"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "কোনো নহয়"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "সম্পূৰ্ণ"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "নিম্ন"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "উচ্চ"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "নিম্ন"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "উচ্চ"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "ৰঙৰ প্ৰভাৱসমূহ:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "ৰঙৰ প্ৰভাৱসমূহ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "প্ৰামাণিক"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "চোৱা, শুনা, টাইপ কৰা, পোইন্ট আৰু ক্লিক কৰাটো সহজ কৰক"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "প্ৰশাসক"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Full Name"
-msgstr "সম্পূৰ্ণ নাম (_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "একাওন্টৰ ধৰণ (_T)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to set a password when they next login"
-msgstr "ব্যৱহাৰকাৰীক পৰৱৰ্তী লগিনত এটা পাছৱৰ্ড সংহতি কৰাৰ অনুমতি দিয়ক"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "এটা নতুন পাছৱৰ্ড এতিয়া সংহতি কৰক"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "সতা সত্য নিৰূপণ কৰক (_V)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"এন্টাৰপ্ৰাইজ লগিনে এটা স্থায়ী কেন্দ্ৰীয়ভাৱে ব্যৱস্থিত ব্যৱহাৰকাৰী একাওন্টক এই "
-"ডিভাইচত "
-"ব্যৱহাৰ কৰাৰ অনুমতি দিয়ে।"
+"কিবৰ্ড;মাউছ;a11y;অভিগম্যতা;কনট্ৰাস্ট;জুম;পৰ্দা;ৰিডাৰ;লিখনি;ফন্ট;আকাৰ;AccessX;স্টিকি; "
+"কিসমূহ;লেহেম;বাউন্স;মাউছ;"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "ডমেইন (_D)"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ইতিহাস"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"এন্টাৰপ্ৰাইজ লগিন একাউন্টসমূহ\n"
-"যোগ কৰিবলৈ অনলাইন যাওক।"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "এন্টাৰপ্ৰাইজ লগিন (_E)"
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "ইতিহাস"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "শেহতীয়া ইতিহাস পৰিষ্কাৰ কৰক (_e)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "আবৰ্জনা শোধন আৰু অস্থায়ী ফাইলসমূহ"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "আবৰ্জনা স্বচালিতভাৱে খালি কৰক (_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "অস্থায়ী ফাইলসমূহ স্বচালিতভাৱে শোধন কৰক (_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "আবৰ্জনা স্বচালিতভাৱে খালি কৰক (_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "আবৰ্জনা খালি কৰক (_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "অস্থায়ী ফাইলসমূহ শোধন কৰক (_P)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "আবৰ্জনাৰ বাকসলৈ স্থানান্তৰ"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "ব্যৱহাৰকাৰী যোগ কৰক"
 
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "প্ৰশাসক"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "ব্যৱহাৰকাৰীক পৰৱৰ্তী লগিনত এটা পাছৱৰ্ড সংহতি কৰাৰ অনুমতি দিয়ক"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "এটা নতুন পাছৱৰ্ড এতিয়া সংহতি কৰক"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "সংৰূপণ কৰা হৈছে"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "এন্টাৰপ্ৰাইজ লগিন (_E)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "অফলাইন"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"এন্টাৰপ্ৰাইজ লগিনে এটা স্থায়ী কেন্দ্ৰীয়ভাৱে ব্যৱস্থিত ব্যৱহাৰকাৰী একাওন্টক এই ডিভাইচত "
+"ব্যৱহাৰ কৰাৰ অনুমতি দিয়ে।"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PPD ফাইল বাছক"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "আঙ্গুলিৰ ছাপ লগিন (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "আঙ্গুলিৰ ছাপ লগিন (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "নহয়"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"আঙ্গুলিৰ ছাপ লগিন ব্যবস্থা নিষ্ক্ৰিয় কৰাৰ উদ্দেশ্যে নিবন্ধিত আঙ্গুলিৰ ছাপসমূহ আঁতৰুৱা হ'ব "
+"নেকি ?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "কোনো প্ৰিন্টাৰ চিনাক্ত কৰা হোৱা নাই।"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "আঙ্গুলিৰ ছাপ লগিন (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "আঙ্গুলিৰ ছাপ লগিন (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "সংৰূপণ কৰিবলে এটা ডিভাইচ বাছক (_h):"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "আঙ্গুলিৰ ছাপ লগিন (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "আঙ্গুলিৰ ছাপ আঁতৰাওক (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "আঙ্গুলিৰ ছাপ লগিন (_F)"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "পূৰ্বৱৰ্তী সপ্তাহ"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "অহা সপ্তাহ"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "পাছৱৰ্ড পৰিবৰ্তন কৰক"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "পৰিবৰ্তন কৰক (_a)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "বৰ্তমান পাছৱৰ্ড (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "নতুন পাছৱৰ্ড (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "পাছৱৰ্ড সুনিশ্চিত কৰক (_o)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "পাছৱৰ্ডসমূহ মিল নাখায়।"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "ব্যৱহাৰকাৰীক পৰৱৰ্তী লগিনত এটা পাছৱৰ্ড সংহতি কৰাৰ অনুমতি দিয়ক"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "এটা নতুন পাছৱৰ্ড এতিয়া সংহতি কৰক"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "ব্যৱহাৰকাৰীসকল"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "পৰিবৰ্তনসমূহ প্ৰভাৱশালী হবলে আপোনাৰ অধিবেশন পুনৰাম্ভ কৰিব লাগিব"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "এতিয়া পুনৰাম্ভ কৰক"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "বন্ধ কৰক"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "সম্পূৰ্ণ নাম (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "আঙ্গুলিৰ ছাপ লগিন (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "স্বচালিত লগিন (_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "একাওন্টৰ ধৰণ (_t)"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "প্ৰশাসক"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "নিয়ন্ত্ৰণ"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "অবিকল্পিত এপ্লিকেচন ফন্টৰ ব্যৱহাৰ নিৰ্ধাৰণ কৰে"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "ব্যৱহাৰকাৰী একাওন্ট আতৰাওক"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "অন্য আঙুলি (_O):"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "ব্যৱহাৰকাৰী যোগ কৰক"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "কোনো ছবি পোৱা নগল"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "এজন ব্যৱহাৰকাৰীৰ একাওন্ট সৃষ্টি কৰক"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "ব্যৱহাৰকাৰীসকল যোগ কৰক বা আতৰাওক আৰু আপোনাৰ পাছৱৰ্ড পৰিবৰ্তন কৰক"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "এনৰল কৰক (_E)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "ডমেইন প্ৰশাসকৰ লগিন"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6020,1128 +4823,3346 @@ msgstr ""
 "এনৰোল কৰিব লাগিব। অনুগ্ৰহ কৰি আপোনাৰ নেটৱৰ্ক প্ৰশাসকসমূহক\n"
 "তেওলোকৰ ডমেইন পাছৱৰ্ড ইয়াত টাইপ কৰিব দিব।"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "প্ৰশাসকৰ নাম (_N)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "প্ৰশাসকৰ পাছৱৰ্ড"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "বাঁওহাতৰ বৃদ্ধাঙ্গুলি"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "বাঁওহাতৰ মধ্যমা"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "বাঁওহাতৰ অনামিকা"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "বাঁওহাতৰ কনিষ্ঠা"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "সোঁহাতৰ বৃদ্ধাঙ্গুলি"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "সোঁহাতৰ মধ্যমা"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "সোঁহাতৰ অনামিকা"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "সোঁহাতৰ কনিষ্ঠা"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:697
-msgid "Enable Fingerprint Login"
-msgstr "আঙ্গুলিৰ ছাপ লগিন সক্ৰিয় কৰক"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "সোঁ সূচক আঙুলি (_R)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "বাওঁ সূচক আঙুলি (_L)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "অন্য আঙুলি (_O):"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"সাফল্যেৰ সৈতে আপোনাৰ আঙ্গুলিৰ ছাপ সংৰক্ষিত হৈছে। আঙ্গুলিৰ ছাপ পাঠৰ ব্যবস্থা "
-"(ৰিডাৰ) "
-"সহযোগে আপুনি এতিয়া লগিন কৰিবলৈ সক্ষম হ'ব।"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "ব্যৱহাৰকাৰীসকল"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr "ব্যৱহাৰকাৰীসকল যোগ কৰক বা আতৰাওক আৰু আপোনাৰ পাছৱৰ্ড পৰিবৰ্তন কৰক"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "লগিন;নাম;আঙ্গুলিৰ ছাপ;অৱতাৰ;লগো;মূখ;পাছৱৰ্ড;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "লগিনৰ ইতিহাস"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr "পাছৱৰ্ড পৰিবৰ্তন কৰক"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "পৰিবৰ্তন কৰক (_a)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "নতুন পাছৱৰ্ড সতা সত্য নিৰূপণ কৰক (_V)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "নতুন পাছৱৰ্ড (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "বৰ্তমান পাছৱৰ্ড (_P)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "ব্যৱহাৰকাৰী একাওন্ট যোগ কৰক"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "ব্যৱহাৰকাৰী একাওন্ট আতৰাওক"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "লগিন বিকল্পসমূহ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "স্বচালিত লগিন (_u)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "আঙ্গুলিৰ ছাপ লগিন (_F)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "ব্যৱহাৰকাৰী আইকন"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "ভাষা (_L)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "সৰ্বশেষ লগিন"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "ব্যৱহাৰকাৰী একাওন্টসমূহ ব্যৱস্থাপনা কৰক"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "ব্যৱহাৰকাৰী তথ্য পৰিবৰ্তন কৰিবলে প্ৰমাণীকৰণৰ প্ৰয়োজন"
 
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "নতুন পাছৱৰ্ড পুৰনি পাছৱৰ্ডৰ পৰা ভিন্ন হব লাগিব।"
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "কিছুমান আখৰ আৰু সংখ্যা পৰিবৰ্তন কৰি চাওক।"
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "পাছৱৰ্ডটো আৰু অলপ পৰিবৰ্তন কৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "আপোনাৰ ব্যৱহাৰকাৰী নাম নথকা এটা পাছৱৰ্ড অধিক শক্তিশালী হব।"
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "পাছৱৰ্ডত আপোনাৰ নাম ব্যৱহাৰ নকৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "পাছৱৰ্ডত ব্যৱহৃত কিছুমান শব্দ ব্যৱহাৰ নকৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "সাধাৰণ শব্দবোৰ বাদ দিয়াৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "স্থায়ী শব্দবোৰ পুনৰ ব্যৱস্থিত নকৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "অধিক সংখ্যা ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "অধিক ওপৰফলা আখৰ ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "অধিক তলৰফলা আখৰ ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "অধিক বিশেষ আখৰ, যেনে বিৰাম চিহ্ন ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "আখৰ, সংখ্যা আৰু বিৰাম চিহ্নৰ এটা সংমিশ্ৰণ ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "একেটা আখৰ পুনৰাবৃত্তি নকৰাৰ চেষ্টা কৰিব।"
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"একেধৰণ আখৰ পুনৰাবৃত্তি নকৰাৰ চেষ্টা কৰিব: আপুনি আখৰ, সংখ্যা আৰু বিৰাম চিহ্ন "
-"সংমিশ্ৰণ "
-"কৰিব লাগিব।"
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "ক্ৰম যেনে 1234 অথবা abcd বাদ দিয়াৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "অধিক আখৰ, সংখ্যা আৰু চিহ্ন যোগ কৰাৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr "ওপৰফলা আৰু তলৰফলা সংমিশ্ৰণ কৰক আৰু এটা বা দুটা সংখ্যা ব্যৱহাৰ কৰক।"
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-"ভাল পাছৱৰ্ড! অধিক আখৰ, সংখ্যা আৰু বিৰাম চিহ্ন যোগ কৰিলে ই আৰু অধিক শক্তিশালী "
-"হব।"
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "শক্তি: দূৰ্বল"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "শক্তি: কম"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "শক্তি: মধ্যম"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "শক্তি: ভাল"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "শক্তি: প্ৰবল"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "প্ৰমাণীকৰণ ব্যৰ্থ হল"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "নতুন পাছৱৰ্ড অতি সৰু"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "নতুন পাছৱৰ্ড অতি সাধাৰণ"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "পুৰনি আৰু নতুন পাছৱৰ্ড অত্যন্ত সদৃশ"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "নতুন পাছৱৰ্ড ইতিমধ্যে শেহতীয়াকৈ ব্যৱহাৰ কৰা হৈছে।"
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "নতুন পাছৱৰ্ড সাংখ্যিক অথবা বিশেষ আখৰসমূহ অন্তৰ্ভুক্ত কৰিব লাগিব"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "পুৰনি আৰু নতুন পাছৱৰ্ড একে"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "আপোনাৰ পাছৱৰ্ড আপুনি আৰম্ভণিত প্ৰমাণিত কৰাৰ পিছত পৰিবৰ্তন হৈছে!"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "নতুন পাছৱাৰ্ডে পৰ্যাপ্ত ভিন্ন আখৰ অন্তৰ্ভুক্ত নকৰে"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "অজ্ঞাত ত্ৰুটি"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "আপোনাৰ একাওন্ট প্ৰদানকাৰীৰ ৱেব ঠিকনাৰ সৈতে মিল খাব লাগিব।"
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "একাওন্ট যোগ কৰিবলে ব্যৰ্থ হল"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-msgid "Passwords do not match."
-msgstr "পাছৱৰ্ডসমূহ মিল নাখায়।"
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr "একাওন্ট ৰেজিস্টাৰ কৰিবলে ব্যৰ্থ হল"
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr "এই ডমেইনৰ সৈতে প্ৰমাণীত কৰিবলে কোনো সমৰ্থিত পদ্ধতি নাই"
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr "ডমেইনত অংশগ্ৰহণ কৰিবলে ব্যৰ্থ হল"
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"সেই লগিন নাম কাম নকৰিলে।\n"
-"অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"সেই লগিন পাছৱৰ্ড কাম নকৰিলে।\n"
-"অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক।"
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr "ডমেইনত লগিন কৰিবলে ব্যৰ্থ হল"
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "ডমেইন সন্ধান কৰিবলৈ অক্ষম। হয়তো আপুনি ইয়াক ভুলকৈ বানান কৰিছে?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:137
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"আপুনি এই ডিভাইচ ব্যবহাৰ কৰিবলৈ অনুমোদিত নহয়। অনুগ্ৰহ কৰি প্ৰণালী প্ৰশাসকৰ "
-"সৈতে "
-"যোগাযোগ কৰক।"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
-msgid "The device is already in use."
-msgstr "ডিভাইচ বৰ্তমানে ব্যবহৃত হৈছে।"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "An internal error occurred."
-msgstr "এটা অভ্যন্তৰীক ত্ৰুটি দেখা দিছে।"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:217
-#: ../panels/user-accounts/um-fingerprint-dialog.c:218
-msgid "Enabled"
-msgstr "সামৰ্থবান"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:266
-msgid "Delete registered fingerprints?"
-msgstr "নিবন্ধিত আঙ্গুলিৰ ছাপ আঁতৰুৱা হ'ব নেকি ?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:270
-msgid "_Delete Fingerprints"
-msgstr "আঙ্গুলিৰ ছাপ আঁতৰাওক (_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:276
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"আঙ্গুলিৰ ছাপ লগিন ব্যবস্থা নিষ্ক্ৰিয় কৰাৰ উদ্দেশ্যে নিবন্ধিত আঙ্গুলিৰ ছাপসমূহ "
-"আঁতৰুৱা হ'ব "
-"নেকি ?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:452
-msgid "Done!"
-msgstr "সমাপ্ত!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:513
-#: ../panels/user-accounts/um-fingerprint-dialog.c:555
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' ডিভাইচ ব্যবহাৰ কৰিবলৈ ব্যৰ্থ"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:596
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "'%s' ডিভাইচত আঙ্গুলিৰ ছাপ প্ৰাপ্ত কৰিবলৈ ব্যৰ্থ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:647
-msgid "Could not access any fingerprint readers"
-msgstr "কোনো আঙ্গুলিৰ ছাপ ৰিডাৰ অভিগম কৰিব নোৱাৰি"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:648
-msgid "Please contact your system administrator for help."
-msgstr "অনুগ্ৰহ কৰি সহায়তাৰ বাবে আপোনাৰ চিস্টেম প্ৰশাসকৰ সৈতে যোগাযোগ কৰক।"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:731
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"আঙ্গুলিৰ ছাপ লগিন ব্যবস্থা সামৰ্থবান কৰাৰ বাবে, '%s' সহযোগে অন্তত এটা "
-"আঙ্গুলিৰ ছাপ "
-"সংৰক্ষণ কৰা আবশ্যক।"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:738
-msgid "Selecting finger"
-msgstr "আঙুলি নিৰ্বাচন কৰা"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:739
-msgid "Enrolling fingerprints"
-msgstr "আঙ্গুলিৰ ছাপসমূহ এনৰোল কৰা"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "এই সপ্তাহ"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "যোৱা সপ্তাহ"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:631
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:635
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "অধিবেশন সমাপ্ত হল"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "অধিবেশন আৰম্ভ হল"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "অনুগ্ৰহ কৰি অন্য পাছৱৰ্ড বাছক।"
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "অনুগ্ৰহ কৰি আপোনাৰ বৰ্তমান পাছৱৰ্ড পুনৰ টাইপ কৰক।"
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "পাছৱৰ্ড সলনি কৰিব পৰা নগল"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-msgid "The passwords do not match."
-msgstr "পাছৱৰ্ডসমূহ মিল নাখায়।"
-
-#: ../panels/user-accounts/um-photo-dialog.c:219
-msgid "Browse for more pictures"
-msgstr "অধিক ছবিৰ বাবে ব্ৰাউছ কৰক"
-
-#: ../panels/user-accounts/um-photo-dialog.c:453
-msgid "Disable image"
-msgstr "ছবি অসামৰ্থবান কৰক"
-
-#: ../panels/user-accounts/um-photo-dialog.c:471
-msgid "Take a photo…"
-msgstr "এটা ফ'টো লওক…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:489
-msgid "Browse for more pictures…"
-msgstr "অধিক ছবিৰ বাবে ব্ৰাউছ কৰক…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:713
-#, c-format
-msgid "Used by %s"
-msgstr "%s দ্বাৰা ব্যৱহৃত"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "এই ধৰণৰ ডমেইনত স্বচালিতভাৱে অংশগ্ৰহণ কৰিব নোৱাৰি"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "এনেধৰণৰ কোনো ডমেইন অথবা ৰাজত্ব পোৱা নগল"
-
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s ডমেইনত %s হিচাপে লগিন কৰিব নোৱাৰি"
-
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
-msgstr "অবৈধ পাছৱৰ্ড, অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক"
-
-#: ../panels/user-accounts/um-realm-manager.c:832
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "%s ডমেইনলে সংযোগ কৰিব নোৱাৰি: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:198
-msgid "Other Accounts"
-msgstr "অন্য একাওন্টসমূহ"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "Failed to delete user"
-msgstr "ব্যৱহাৰকাৰী মচি পেলাবলে ব্যৰ্থ"
-
-#: ../panels/user-accounts/um-user-panel.c:482
-msgid "You cannot delete your own account."
-msgstr "আপুনি আপোনাৰ একাওন্ট মচিব নোৱাৰিব।"
-
-#: ../panels/user-accounts/um-user-panel.c:491
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s এতিয়াও লগিন অৱস্থাত আছে"
-
-#: ../panels/user-accounts/um-user-panel.c:495
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"এজন ব্যৱহাৰকাৰীক লগিন অৱস্থাত মচি পেলালে চিস্টেম এটা অস্থিৰ অৱস্থাত যাব পাৰে।"
-
-#: ../panels/user-accounts/um-user-panel.c:504
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "আপুনি %s ৰ ফাইলসমূহ ৰাখিব বিচাৰে নে?"
-
-#: ../panels/user-accounts/um-user-panel.c:508
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"এজন ব্যৱহাৰকাৰীৰ একাওন্ট মচোতে ঘৰ ডাইৰেকটৰি, মেইল স্পুল আৰু অস্থায়ী ফাইলসমূহ "
-"ৰখাটো "
-"সম্ভব।"
-
-#: ../panels/user-accounts/um-user-panel.c:511
-msgid "_Delete Files"
-msgstr "ফাইলসমূহ মচি পেলাওক (_D)"
-
-#: ../panels/user-accounts/um-user-panel.c:512
-msgid "_Keep Files"
-msgstr "ফাইলসমূহ ৰাখক (_K)"
-
-#: ../panels/user-accounts/um-user-panel.c:564
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "একাওন্ট অসামৰ্থবান"
-
-#: ../panels/user-accounts/um-user-panel.c:572
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "পৰৱৰ্তী লগিনত সংহতি কৰিব লগিয়া"
-
-#: ../panels/user-accounts/um-user-panel.c:575
-msgctxt "Password mode"
-msgid "None"
-msgstr "কোনো নহয়"
-
-#: ../panels/user-accounts/um-user-panel.c:624
-msgid "Logged in"
-msgstr "লগিন ইন কৰা আছে"
-
-#: ../panels/user-accounts/um-user-panel.c:1072
-msgid "Failed to contact the accounts service"
-msgstr "একাওন্ট সেৱাৰ সৈতে সংযোগ কৰিবলে ব্যৰ্থ"
-
-#: ../panels/user-accounts/um-user-panel.c:1074
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"অনুগ্ৰহ কৰি AccountService ইনস্টল আৰু সামৰ্থবান আছে বুলি সুনিশ্চিত কৰক।"
-
-#: ../panels/user-accounts/um-user-panel.c:1115
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"পৰিবৰ্তনসমূহ কৰিবলে,\n"
-"* আইকন প্ৰথমতে ক্লিক কৰক"
-
-#: ../panels/user-accounts/um-user-panel.c:1153
-msgid "Create a user account"
-msgstr "এজন ব্যৱহাৰকাৰীৰ একাওন্ট সৃষ্টি কৰক"
-
-#: ../panels/user-accounts/um-user-panel.c:1164
-#: ../panels/user-accounts/um-user-panel.c:1453
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"এজন ব্যৱহাৰকাৰী সৃষ্টি কৰিবলে,\n"
-"* আইকন প্ৰথমতে ক্লিক কৰক"
-
-#: ../panels/user-accounts/um-user-panel.c:1174
-msgid "Delete the selected user account"
-msgstr "নিৰ্বাচিত ব্যৱহাৰকাৰী একাওন্ট মচি পেলাওক"
-
-#: ../panels/user-accounts/um-user-panel.c:1186
-#: ../panels/user-accounts/um-user-panel.c:1458
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"নিৰ্বাচিত ব্যৱহাৰকাৰী একাওন্ট মচিবলে,\n"
-"* আইকন প্ৰথমতে ক্লিক কৰক"
-
-#: ../panels/user-accounts/um-user-panel.c:1368
-msgid "My Account"
-msgstr "মোৰ একাওন্ট"
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-msgid "A user with the username '%s' already exists."
-msgstr "'%s' ব্যৱহাৰকাৰীনামৰ সৈতে এজন ব্যৱহাৰকাৰী ইতিমধ্যে অস্তিত্ববান।"
-
-#: ../panels/user-accounts/um-utils.c:571
-#, c-format
-msgid "The username is too long."
-msgstr "ব্যৱহাৰকাৰীনাম অতি দীঘল।"
-
-#: ../panels/user-accounts/um-utils.c:574
-msgid "The username cannot start with a '-'."
-msgstr "ব্যৱহাৰকাৰীনাম '-' ৰ সৈতে আৰম্ভ হব নোৱাৰিব।"
-
-#: ../panels/user-accounts/um-utils.c:577
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"ব্যৱহাৰকাৰীনামত কেৱল a-z ডিজিটৰ পৰা তলৰ আৰু ওপৰ ফলা আখৰ আৰু আখৰসমূহ '.', '-' "
-"আৰু "
-"'_' ৰ পৰা যিকোনো আখৰ থাকিব পাৰিব।"
-
-#: ../panels/user-accounts/um-utils.c:581
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-"ইয়াক আপোনাৰ ঘৰ ফোল্ডাৰ নামকৰণৰ বাবে ব্যৱহাৰ কৰা হব আৰু ইয়াক পৰিবৰ্তন কৰিব "
-"নোৱাৰি।"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:831
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "বুটামসমূহ মেপ কৰক"
 
-#: ../panels/wacom/button-mapping.ui.h:2
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "বুটামসমূহক ফলনসমূহলে মেপ কৰক"
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"এটা চৰ্টকাট সম্পাদন কৰিবলে, \"কিস্ট্ৰৌক পঠাওক\" বুটাম বাছক, কিবৰ্ড চৰ্টকাট "
-"বুটাম "
+"এটা চৰ্টকাট সম্পাদন কৰিবলে, \"কিস্ট্ৰৌক পঠাওক\" বুটাম বাছক, কিবৰ্ড চৰ্টকাট বুটাম "
 "টিপক আৰু নতুন কি'সমূহ টিপি ধৰক অথবা পৰিষ্কাৰ কৰিবলৈ Backspace টিপক।"
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "বন্ধ কৰক (_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
-"টেবলেট মানাংকন কৰিবলে লক্ষ্য চিহ্নকসমূহক সিহত পৰ্দাত উপস্থিত হোৱা নিচিনা টেপ "
-"কৰক।"
+"টেবলেট মানাংকন কৰিবলে লক্ষ্য চিহ্নকসমূহক সিহত পৰ্দাত উপস্থিত হোৱা নিচিনা টেপ কৰক।"
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "ভুল-ক্লিক চিনাক্ত কৰা হৈছে, পুনৰাম্ভ কৰা হৈছে..."
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "ওপৰ"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "ভাৰছুৱেল ডিভাইচ সৃষ্টি কৰক"
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "তল"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "টেবলেট"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "কোনো নহয়"
-
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "কি'স্ট্ৰৌক পঠাওক"
-
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "চুইচ পৰ্যবেক্ষক"
-
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "অন-স্ক্ৰিন সহায় দেখুৱাওক"
-
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "আউটপুট:"
-
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "এস্পেক্ট অনুপাত ৰাখক (লেটাৰবাকচ):"
-
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "এটা মনিটৰলে মেপ কৰক"
-
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d, %d ৰ"
-
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "প্ৰদৰ্শন মেপিং"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
-msgstr "বুটাম"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr "Wacom টেবলেট"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
-"বুটাম মেপিংসমূহ চাওক আৰু গ্ৰাফিক্স টেবলেটসমূহৰ বাবে স্টাইলাচ সংবেদনশীলতা "
-"নিয়ন্ত্ৰণ কৰক"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "টেবলেট;Wacom;স্টাইলাচ;ইৰেজাৰ;মাউছ;"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "বাঁও-হাতৰ দিশ"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "টেবলেট (প্ৰকৃত)"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "টাচপেড (প্ৰাসংগিক)"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "মনিটৰলে মেপ কৰক…"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "টেবলেট পছন্দসমূহ"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "অনুপাত হাৰ"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "মানাংকন কৰক…"
+
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "কোনো টেবলেট চিনাক্ত কৰা হোৱা নাই"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "অনুগ্ৰহ কৰি আপোনাৰ Wacom টেবলেট প্লাগ ইন অথবা অন কৰক"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr "ব্লুটুথ সংহতিসমূহ"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Map to Monitor…"
-msgstr "মনিটৰলে মেপ কৰক…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map Buttons…"
-msgstr "বুটামসমূহ মেপ কৰক…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr "প্ৰদৰ্শন বিভেদন সজাওক"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust mouse settings"
-msgstr "মাউছ সংহতিসমূহ ব্যৱস্থাপনা কৰক"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Tracking Mode"
-msgstr "অনুকৰণ অৱস্থা"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Left-Handed Orientation"
-msgstr "বাঁও-হাতৰ দিশ"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-msgid "Left Ring"
-msgstr "বাঁও ৰিং"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "বাঁও ৰিং অৱস্থা #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-msgid "Right Ring"
-msgstr "সোঁ ৰিং"
-
-#: ../panels/wacom/gsd-wacom-device.c:1104
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "সোঁ ৰিং অৱস্থা #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-msgid "Left Touchstrip"
-msgstr "বাঁও Touchstrip"
-
-#: ../panels/wacom/gsd-wacom-device.c:1157
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "বাঁও Touchstrip অৱস্থা #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-msgid "Right Touchstrip"
-msgstr "সোঁ Touchstrip"
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "সোঁ Touchstrip অৱস্থা #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1214
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "বাঁও Touchring অৱস্থা চুইচ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1216
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "সোঁ Touchring অৱস্থা চুইচ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1219
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "বাঁও Touchstrip অৱস্থা চুইচ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1221
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "সোঁ Touchstrip অৱস্থা চুইচ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1226
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "অৱস্থা চুইচ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1334
-#, c-format
-msgid "Left Button #%d"
-msgstr "বাঁও বুটাম #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1337
-#, c-format
-msgid "Right Button #%d"
-msgstr "সোঁ বুটাম #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1340
-#, c-format
-msgid "Top Button #%d"
-msgstr "উপৰ বুটাম #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1343
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "তলৰ বুটাম #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "নতুন চৰ্টকাট…"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "কোনো কাৰ্য্য নহয়"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "বাঁও মাউছ বুটাম ক্লিক"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "মাজৰ মাউছ বুটাম ক্লিক"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "সোঁ মাউছ বুটাম ক্লিক"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "উপৰলে সক্ৰল কৰক"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "তললে স্ক্ৰল কৰক"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "বাঁওফালে স্ক্ৰল কৰক"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "সোঁফালে স্ক্ৰল কৰক"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "পিছলৈ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "আগলৈ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "স্টাইলাচ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "ইৰেচাৰ চাপ অনুভৱ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "কোমল"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "কঠিন"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "উপৰ বুটাম"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "তলৰ বুটাম"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "আগ চাপ অনুভৱ"
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "ভাৰবৌচ অৱস্থা সামৰ্থবান কৰক"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "কোমল"
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "অভাৰভিউ দেখুৱাওক"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "স্ট্ৰিংৰ বাবে সন্ধান কৰক"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "সম্ভাব্য পেনেল নামসমূহ তালিকাভুক্ত কৰি প্ৰস্থান কৰক"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "সহায়তা বিকল্প প্ৰদৰ্শন কৰা হ'ব"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "প্ৰদৰ্শন কৰিবলে পেনেল"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- সংহতিসমূহ"
-
-#: ../shell/cc-application.c:163
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-"%s\n"
-"উপলব্ধ কমান্ড শাৰী বিকল্পসমূহৰ এটা সম্পূৰ্ণ তালিকা চাবলে '%s --help' চাওক।\n"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "উপলব্ধ পেনেলসমূহ:"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "কঠিন"
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "সহায়"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "বুটাম"
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "প্ৰস্থান কৰক"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "বুটাম"
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "বুটাম"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "ইৰেচাৰ চাপ অনুভৱ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "ইৰেচাৰ চাপ অনুভৱ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "মাজৰ মাউছ বুটাম ক্লিক"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "সোঁ মাউছ বুটাম ক্লিক"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "আগলৈ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom টেবলেট"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"বুটাম মেপিংসমূহ চাওক আৰু গ্ৰাফিক্স টেবলেটসমূহৰ বাবে স্টাইলাচ সংবেদনশীলতা নিয়ন্ত্ৰণ কৰক"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "টেবলেট;Wacom;স্টাইলাচ;ইৰেজাৰ;মাউছ;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "পৰিকল্পনা"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "ঊৰ্ধ্বতন সংযোগক্ষেত্ৰ"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "কৃত্ৰিম দ্বিতীয় ক্লিক (_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "সংযোগক্ষেত্ৰ"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "সমাপ্ত কৰিবলৈ ঠিক আছে টিপক"
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "টনাৰ কম"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "দ্বিতীয়"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "সংযোগক্ষেত্ৰ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "অভিগমৰ বিকল্পসমূহ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "যোগ কৰক"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "সংৰক্ষণ (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "বিৱৰণসমূহ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "নেটৱৰ্ক সময় (_N)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "নেটৱৰ্ক সংহতিসমূহ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "নম্বৰসমূহ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "ডিভাই ধৰণসমূহ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "উৎপাদক"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "ফাৰ্মৱেৰ সন্ধানহীন"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "মবাইল ব্ৰডবেণ্ড (_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "নেটৱৰ্ক সময় (_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "নেটৱৰ্ক"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "উন্নত"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "অভিগমৰ বিকল্পসমূহ"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "লক"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "বিৱৰণসমূহ"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "নেটৱৰ্কৰ নাম"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "স্বচালিত"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "মোৰ ঘৰ নেটৱৰ্ক"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "মোৰ ঘৰ নেটৱৰ্ক"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "কোনো ব্লু-টুথ এডাপ্টাৰ পোৱা নগল"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "বিমান অৱস্থা (_p)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "সংযোগ"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM কাৰ্ড সুমুৱা হোৱা নাই"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "লক"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "পৰিবৰ্তন কৰক (_a)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "মোৰ ঘৰ নেটৱৰ্ক"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "নতুন ড্ৰাইভাৰ সংস্থাপন কৰা হৈছে…"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "গোপনীয়তা"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "সকলো সংহতি"
 
-#. Add categories
-#: ../shell/cc-window.c:876
-msgctxt "category"
-msgid "Personal"
-msgstr "ব্যক্তিগত"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "প্ৰাথমিক"
 
-#: ../shell/cc-window.c:877
-msgctxt "category"
-msgid "Hardware"
-msgstr "হাৰ্ডৱেৰ"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:878
-msgctxt "category"
-msgid "System"
-msgstr "চিস্টেম"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "সহায়"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "সাধাৰণ"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "প্ৰস্থান কৰক"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "বিচাৰক"
+
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "প্যানেলেৰ আইকন"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "পূৰ্বৱৰ্তী উৎসলে যাওক"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "বাতিল কৰা হল"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u আউটপুট"
+msgstr[1] "%u আউটপুটসমূহ"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ইনপুট"
+msgstr[1] "%u ইনপুটসমূহ"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "দিনটোত কৰা পৰিবৰ্তনসমূহ"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "টাইল"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "জুম"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "কেন্দ্ৰ"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "পূৰ্ণ কৰক"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "বিস্তাৰ"
+
+#~ msgid "Select Background"
+#~ msgstr "পটভূমি বাছক"
+
+#~ msgid "Pictures"
+#~ msgstr "ছবিসমূহ"
+
+#~ msgid "Colors"
+#~ msgstr "ৰঙবোৰ"
+
+#~ msgid "Home"
+#~ msgstr "গৃহ"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "আপুনি আপোনাৰ %s ফোল্ডাৰলৈ ছবি যোগ কৰিব পাৰিব আৰু সিহত ইয়াত দেখা যাব"
+
+#~ msgid "multiple sizes"
+#~ msgstr "একাধিক মাপ"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "কোনো ডেস্কটপ পটভূমি নাই"
+
+#~ msgid "Current background"
+#~ msgstr "বৰ্তমান পটভূমী"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "ৱালপেপাৰ;পৰ্দা;ডেস্কটপ;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "আপোনাৰ মানাংকন ডিভাইচক বৰ্গৰ ওপৰত ৰাখি 'আৰম্ভ কৰক' টিপক"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "আপোনাৰ মানাংকন ডিভাইচক মানাংকন অৱস্থানত ৰাখি 'অব্যাহত ৰাখক' টিপক"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "আপোনাৰ মানাংকন ডিভাইচক পৃষ্ঠ অৱস্থানত ৰাখি 'অব্যাহত ৰাখক' টিপক"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "লেপটপ লিড বন্ধ কৰক"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "এটা অভ্যন্তৰীক ত্ৰুটি দেখা দিছে যাক উদ্ধাৰ কৰিব নোৱাৰি।"
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "মানাংকনৰ বাবে প্ৰয়োজনীয় সঁজুলিসমূহ ইনস্টল্ড নাই।"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "আলেখ্য সৃজন কৰিব পৰা নগল।"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "লক্ষ্য বগাবিন্দু অপ্ৰাপ্য আছিল।"
+
+#~ msgid "Complete!"
+#~ msgstr "সম্পূৰ্ণ!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "মানাংকন ব্যৰ্থ হল!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "আপুনি মানাংকন ডিভাইচ আতৰাব পাৰে।"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "প্ৰগতিশীল অৱস্থাত মানাংকন ডিভাইচক অসুবিধা নিদিব"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "লেপটপৰ পৰ্দা"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s মনিটৰ"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s স্কেনাৰ"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s প্ৰিন্টাৰ"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s ৱেবকেম"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s ৰ বাবে ৰঙ ব্যৱস্থাপনা সামৰ্থবান কৰক"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s ৰ বাবে ৰঙৰ আলেখ্যসমূহ দেখুৱাওক"
+
+#~ msgid "Not calibrated"
+#~ msgstr "মানাংকিত নহয়"
+
+#~ msgid "Default: "
+#~ msgstr "অবিকল্পিত: "
+
+#~ msgid "Test profile: "
+#~ msgstr "আলেখ্য পৰীক্ষা কৰক: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC আলেখ্য ফাইল বাছক"
+
+#~ msgid "_Import"
+#~ msgstr "ইমপোৰ্ট কৰক (_I)"
+
+#~ msgid "All files"
+#~ msgstr "সৰ্বধৰণৰ ফাইল"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "ফাইল আপল'ড কৰিবলে ব্যৰ্থ: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "আলেখ্যক চিহ্নিত স্থানলৈ আপল'ড কৰা হৈছে:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "এই URL লিখি ৰাখক।"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "এই কমপিউটাৰ পুনৰাম্ভ কৰক আৰু আপোনাৰ স্বাভাৱিক অপাৰেটিং চিস্টেম বুট কৰক।"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "আলেখ্যক ডাউনল'ড কৰি ইনস্টল কৰিবলে URL ক আপোনাৰ ব্ৰাউছাৰত টাইপ কৰক।"
+
+#~ msgid "Save Profile"
+#~ msgstr "আলেখ্য সংৰক্ষণ কৰক"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "নিৰ্বাচিত ডিভাইচৰ বাবে এটা ৰঙ আলেখ্য সৃষ্টি কৰক"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "মাপ লোৱা ডিভাইচ চিনাক্ত কৰা হোৱা নাই। অনুগ্ৰহ কৰি নিৰীক্ষণ কৰক ই চলি আছে আৰু "
+#~ "সঠিকভাৱে সংযুক্ত।"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "মাপ লোৱা ডিভাইচয় প্ৰিন্টাৰ আলেখ্যকৰণ সমৰ্থন নকৰে।"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "ডিভাইচ ধৰণ বৰ্তমানে সমৰ্থিত নহয়।"
+
+#~ msgid "Standard Space"
+#~ msgstr "প্ৰামাণিক স্থান"
+
+#~ msgid "Test Profile"
+#~ msgstr "পৰীক্ষামূলক আলেখ্য"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "স্বচালিত"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "নিম্ন গুণ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "মধ্যম গুণ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "উচ্চ গুণ"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "অবিকল্পিত RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "অবিকল্পিত CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "অবিকল্পিত ধূসৰ"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "বিক্ৰেতা দ্বাৰা প্ৰদান কৰা কলঘৰ মানাংকিত তথ্য"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "এই আলেখ্যৰ সৈতে সম্পূৰ্ণ-পৰ্দা প্ৰদৰ্শন শুদ্ধ কৰা সম্ভব নহয়"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "এই আলেখ্য আৰু সঠিক নহব পাৰে"
+
+#~ msgid "Done"
+#~ msgstr "কৰা হল"
+
+#~ msgid "Upload profile"
+#~ msgstr "আলেখ্য আপল'ড কৰক"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "ইন্টাৰনেট সংযোগৰ প্ৰয়োজন"
+
+#~ msgid "United States"
+#~ msgstr "মাৰ্কিণ যুক্তৰাষ্ট্ৰ"
+
+#~ msgid "Germany"
+#~ msgstr "জাৰ্মানী"
+
+#~ msgid "Spain"
+#~ msgstr "স্পেইন"
+
+#~ msgid "China"
+#~ msgstr "চীন"
+
+#~ msgid "Other…"
+#~ msgstr "অন্য…"
+
+#~ msgid "Language"
+#~ msgstr "ভাষা"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "সময় অঞ্চল (_Z)"
+
+#~ msgid "24-hour"
+#~ msgstr "২৪-ঘন্টা"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "Lid Closed"
+#~ msgstr "লিড বন্ধ"
+
+#~ msgid "Mirrored"
+#~ msgstr "মিৰৰড্"
+
+#~ msgid "Off"
+#~ msgstr "অফ"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "সংযুক্ত প্ৰদৰ্শনসমূহ সঁজাওক"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "প্ৰদৰ্শনসমূহক পুনৰ সংঘঠিত কৰিবলৈ সিহতক সঁজাওক"
+
+#~ msgid "Size"
+#~ msgstr "আকাৰ"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "এই প্ৰদৰ্শনত ওপৰ বাৰ আৰু কাৰ্য্যসমূহ অভাৰভিউ দেখুৱাওক"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "এটা অতিৰিক্ত কৰ্মস্থান সৃষ্টি কৰিবলৈ এই প্ৰদৰ্শনক অন্যৰ সৈতে লগ লগাওক"
+
+#~ msgid "Presentation"
+#~ msgstr "পৰিৱেশন"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "কেৱল স্লাইডশ্ব আৰু মাধ্যম দেখুৱাওক"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "দুয়োটা প্ৰদৰ্শনত আপোনাৰ স্থায়ী দৰ্শন দেখুৱাওক"
+
+#~ msgid "Turn Off"
+#~ msgstr "বন্ধ কৰক"
+
+#~ msgid "Don't use this display"
+#~ msgstr "এই প্ৰদৰ্শন ব্যৱহাৰ নকৰিব"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "পৰ্দা পৰিবৰ্তন প্ৰাপ্ত কৰিবলৈ ব্যৰ্থ"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "সংযুক্ত প্ৰদৰ্শনসমূহ সঁজাওক (_A)"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "Unknown"
+#~ msgstr "অজ্ঞাত"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-bit"
+
+#~ msgid "Ask what to do"
+#~ msgstr "কি কৰা হব সোধক"
+
+#~ msgid "Do nothing"
+#~ msgstr "একো নকৰিব"
+
+#~ msgid "Open folder"
+#~ msgstr "ফোল্ডাৰ খোলক"
+
+#~ msgid "Other Media"
+#~ msgstr "অন্য মাধ্যম"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "অডিঅ' CDসমূহৰ বাবে এটা এপ্লিকেচন বাছক"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "ভিডিঅ' DVDসমূহৰ বাবে এটা এপ্লিকেচন বাছক"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "যেতিয়া এটা সংগীত প্লেয়াৰ সংযুক্ত থাকে চলাবলে এটা এপ্লিকেচন বাছক"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "যেতিয়া এটা কেমেৰা সংযুক্ত তেতিয়া চলিবলে এটা এপ্লিকেচন বাছক"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "চফ্টৱেৰ CDসমূহৰ বাবে এটা এপ্লিকেচন বাছক"
+
+#~ msgid "audio DVD"
+#~ msgstr "অডিঅ' DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "ৰিক্ত Blu-ray ডিস্ক"
+
+#~ msgid "blank CD disc"
+#~ msgstr "ৰিক্ত CD ডিস্ক"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "ৰিক্ত DVD ডিস্ক"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "ৰিক্ত HD DVD ডিস্ক"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray ভিডিঅ' ডিস্ক"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-book ৰিডাৰ"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD ভিডিঅ' ডিস্ক"
+
+#~ msgid "Picture CD"
+#~ msgstr "ছবি CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "চুপাৰ ভিডিঅ' CD"
+
+#~ msgid "Video CD"
+#~ msgstr "ভিডিঅ' CD"
+
+#~ msgid "Overview"
+#~ msgstr "অভাৰভিউ"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "সংস্কৰণ %s"
+
+#~ msgid "Base system"
+#~ msgstr "ভিত্তি চিস্টেম"
+
+#~ msgid "Disk"
+#~ msgstr "ডিস্ক"
+
+#~ msgid "Check for updates"
+#~ msgstr "আপডেইসমূহৰ বাবে নিৰীক্ষণ কৰক"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "এটা স্ক্ৰিনশ্বটক $PICTURES সংৰক্ষণ কৰক"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "এটা উইন্ডোৰ স্ক্ৰিনশ্বটক $PICTURES ত সংৰক্ষণ কৰক"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "এটা স্থানৰ স্ক্ৰিনশ্বটক $PICTURES ত সংৰক্ষণ কৰক"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "এটা স্ক্ৰিনশ্বটক ক্লিপবৰ্ডলে কপি কৰক"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "এটা উইন্ডোৰ স্ক্ৰিনশ্বটক ক্লিপবৰ্ডলে কপি কৰক"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "এটা স্থানৰ স্ক্ৰিনশ্বটক ক্লিপবৰ্ডলে কপি কৰক"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "এটা সৰু স্ক্ৰিনকাস্ট ৰেকৰ্ড কৰক"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "পৰিবৰ্তক-কেৱল পৰৱৰ্তী উৎসলে যাওক"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "চৰ্টকাট;পুনৰাবৃত্তি;পিৰিকিয়া;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "স্বনিৰ্ধাৰিত চৰ্টকাট"
+
+#~ msgid "C_ommand:"
+#~ msgstr "কমান্ড:(_o)"
+
+#~ msgid "_Delay:"
+#~ msgstr "বিলম্ব (_D):"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "সৰু"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "লেহেম"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "দীঘল"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্ৰুত"
+
+#~ msgid "S_peed:"
+#~ msgstr "গতি (_p):"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "চৰ্টকাট আতৰাওক"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "এটা চৰ্টকাট সম্পাদন কৰিবলে, শাৰীত ক্লিক কৰক আৰু নতুন কিসমূহ ধৰি ৰাখক অথবা "
+#~ "পৰিষ্কাৰ কৰিবলে Backspace টিপক।"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Unknown Action>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "চৰ্টকাট-কি হিচাপে \"%s\" ব্যবহাৰ কৰা নাযাব কাৰণ ইয়াৰ ফলস্বৰূপ এই কি ব্যবহাৰ "
+#~ "কৰি একো টাইপ কৰা নাযাব।\n"
+#~ "অনুগ্ৰহ কৰি Control, Alt বা Shift কিৰ একত্ৰিক ব্যবহাৰৰ প্ৰচেষ্টা কৰক।"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "চৰ্টকাট \"%s\" বৰ্তমানে\n"
+#~ " \"%s\"ৰ বাবে ব্যবহৃত হৈছে"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "\"%s\" ত চৰ্টকাট স্থাপন কৰা হ'লে, \"%s\" চৰ্টকাটটো নিষ্ক্ৰিয় কৰা হ'ব।"
+
+#~ msgid "_Reassign"
+#~ msgstr "পুনৰ ধাৰ্য্য (_R)"
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" চৰ্টকাটৰ সৈতে এটা সংলঘ্ন \"%s\" চৰ্টকাট আছে। আপুনি ইয়াক স্বচালিতভাৱে "
+#~ "\"%s\" লৈ সংহতি কৰিব খোজে নে?"
+
+#, c-format
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" বৰ্তমানে \"%s\" ৰ সৈতে সংলঘ্ন, এই চৰ্টকাট অসামৰ্থবান কৰা হ'ব যদি আপুনি "
+#~ "আগবাঢ়ে।"
+
+#~ msgid "_Assign"
+#~ msgstr "ধাৰ্য্য কৰক (_A)"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "আপোনাৰ সংহতিসমূহ পৰীক্ষা কৰক"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "লেহেম"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "দুবাৰ-ক্লিক সময়অন্ত"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্ৰুত"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "বাওঁ (_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "সোঁ (_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "পোইন্টাৰৰ গতি (_P)"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "লেহেম"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্ৰুত"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "লেহেম"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্ৰুত"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "দুটা আঙুলি বিশিষ্ট স্ক্রোলিং (_f)"
+
+#~ msgid "_Natural scrolling"
+#~ msgstr "স্বাভাৱিক স্ক্রোলিং (_N)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "পাঁচবাৰ ক্লিক, GEGL সময়!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "দুবাৰ ক্লিক, প্ৰাথমিক বুটাম"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "এবাৰ ক্লিক, প্ৰাথমিক বুটাম"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "দুবাৰ ক্লিক, মাজৰ বুটাম"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "এবাৰ ক্লিক, মাজৰ বুটাম"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "দুবাৰ ক্লিক, দ্বিতীয় বুটাম"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "এবাৰ ক্লিক, দ্বিতীয় বুটাম"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "চিস্টেম নেটৱৰ্ক সেৱাসমূহ এই সংস্কৰণৰ সৈতে সংগত নহয়।"
+
+#~ msgid "page 1"
+#~ msgstr "পৃষ্ঠা ১"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "অভ্যন্তৰীক প্ৰমাণীকৰণ (_a)"
+
+#~ msgid "page 2"
+#~ msgstr "পৃষ্ঠা ২"
+
+#~ msgid "automatic"
+#~ msgstr "স্বচালিত"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "এন্টাৰপ্ৰাইজ"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "কোনো নহয়"
+
+#~ msgid "Never"
+#~ msgstr "কেতিয়াও নহয়"
+
+#~ msgid "Today"
+#~ msgstr "আজি"
+
+#~ msgid "Yesterday"
+#~ msgstr "যোৱাকালি"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "কোনো নহয়"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "দুৰ্বল"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ঠিক আছে"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "ভাল"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "উত্তম"
+
+#~ msgid "Identity"
+#~ msgstr "পৰিচয়"
+
+#~ msgid "Server"
+#~ msgstr "চাৰ্ভাৰ"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS চাৰ্ভাৰ মচি পেলাওক"
+
+#~ msgid "Delete Route"
+#~ msgstr "পথ মচি পেলাওক"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "কোনো নহয়"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit কি (Hex অথবা ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-বিট পাচফ্ৰেইছ"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "চলমান WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 ব্যক্তিগত"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 এন্টাৰপ্ৰাইজ"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "টুইস্টেড পেয়াৰ (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "এটাচমেন্ট একক আন্তঃপৃষ্ঠ (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "মাধ্যম মুক্ত আন্তঃপৃষ্ঠ (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "অন্য ব্যৱহাৰকাৰীসকলৰ বাবে উপলব্ধ কৰক (_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "ফায়াৰৱাল অঞ্চল (_Z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "অবিকল্পিত"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "অঞ্চলে সংযোগৰ ভৰষা স্তৰৰ বিৱৰণ দিয়ে"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv4 (_4)"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv6 (_6)"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "সংযোগ সম্পাদক খোলিবলে অক্ষম"
+
+#~ msgid "New Profile"
+#~ msgstr "নতুন আলেখ্য"
+
+#~ msgid "Bond"
+#~ msgstr "বান্ধনী"
+
+#~ msgid "Team"
+#~ msgstr "দল"
+
+#~ msgid "Bridge"
+#~ msgstr "ব্ৰিজ"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN প্লাগিনসমূহ ল'ড কৰিব পৰা নগল"
+
+#~ msgid "Import from file…"
+#~ msgstr "ফাইলৰ পৰা ইমপোৰ্ট কৰক…"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "নেটৱৰ্ক সংযোগ যোগ কৰক"
+
+#~ msgid "_Reset"
+#~ msgstr "পুনৰ সংহতি কৰক (_R)"
+
+#~ msgid "_Forget"
+#~ msgstr "পাহৰি যাওক (_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "এই নেটৱৰ্কৰ বাবে সংহতিসমূহ পুনৰ সংহতি কৰক, পাছৱৰ্ডসমূহ অন্তৰ্ভুক্ত কৰাকৈ, কিন্তু "
+#~ "ইয়াক এটা পছন্দৰ নেটৱৰ্ক হিচাপে মনত ৰাখক"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "এই নেটৱৰ্কৰ সৈতে প্ৰসংগ কৰা সকলো বিৱৰণ আতৰাওক আৰু স্বচালিতভাৱে সংযোগ কৰাৰ "
+#~ "চেষ্টা নকৰিব"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN সংযোগ ইমপোৰ্ট কৰিব নোৱাৰি"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "ফাইল '%s' পঢ়িব পৰা নাযায় অথবা পৰিচিত VPN সংযোগ তথ্য অন্তৰ্ভুক্ত নকৰে\n"
+#~ "\n"
+#~ "ত্ৰুটি: %s।"
+
+#~ msgid "Select file to import"
+#~ msgstr "ইমপোৰ্ট কৰিবলে ফাইল বাছক"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "'\"%s\" নামৰ এটা ফাইল ইতিমধ্যে অস্তিত্ববান।"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "আপুনি %s ক আপুনি সংৰক্ষণ কৰি থকা VPN সংযোগৰ সৈতে প্ৰতিস্থাপন কৰিব বিচাৰে নে?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN সংযোগ এক্সপোৰ্ট কৰিব নোৱাৰি"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN সংযোগ '%s' ক %s লে এক্সপোৰ্ট কৰিব নোৱাৰি।\n"
+#~ "\n"
+#~ "ত্ৰুটি: %s।"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN সংযোগ এক্সপোৰ্ট কৰক"
+
+#~ msgid "Bond slaves"
+#~ msgstr "বণ্ড স্লেইভসমূহ"
+
+#~ msgid "(none)"
+#~ msgstr "(কোনো নহয়)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "ব্ৰিজ স্লেইভসমূহ"
+
+#~ msgid "never"
+#~ msgstr "কেতিয়াও নহয়"
+
+#~ msgid "today"
+#~ msgstr "আজি"
+
+#~ msgid "yesterday"
+#~ msgstr "যোৱাকালী"
+
+#~ msgid "Last used"
+#~ msgstr "সৰ্বশেষ ব্যৱহৃত"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "আলেখ্য %d"
+
+#~ msgid "Team slaves"
+#~ msgstr "দলৰ স্লেইভবোৰ"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "যদি আপোনাৰ ইন্টাৰনেটলে বেতাঁৰৰ বাহিৰে অন্য সংযোগ উপলব্ধ আছে, আপুনি ইয়াক অন্যৰ "
+#~ "সৈতে অংশীদাৰী কৰিবলে এটা বেতাঁৰ হটস্পট সংস্থাপন কৰিব পাৰে।"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "বেতাঁৰ হটস্পট আৰম্ভ কৰিলে আপুনি <b>%s</b> ৰ পৰা বিচ্ছিন্নিত হব।"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "হটস্পট সক্ৰিয় থকা অৱস্থাত আপোনাৰ বেতাঁৰৰ সহায়ত ইন্টাৰনেট অভিগম কৰাটো সম্ভব নহয়।"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "হটস্পট বন্ধ কৰি কোনো ব্যৱহাৰকাৰী বিচ্ছিন্ন কৰিব নে?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "হটস্পট বন্ধ কৰক (_S)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "চিস্টেমৰ নীতিয়ে হটস্পট হিচাপে ব্যৱহাৰ নিষিদ্ধ কৰে"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "বেতাঁৰ ডিভাইচে হটস্পট অৱস্থা সমৰ্থন নকৰে"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "নিৰ্বাচিত নেটৱৰ্কসমূহৰ বাবে নেটৱৰ্ক বিৱৰণসমূহ, লগতে পাছৱৰ্ডসমূহ আৰু কোনো "
+#~ "স্বনিৰ্বাচিত সংৰূপ হেৰাই যাব।"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "পাহৰি যাওক (_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "যেতিয়া এটা সংৰূপ URL প্ৰদান কৰা নহয় ৱেব প্ৰক্সি স্বখোজ ব্যৱহাৰ কৰা হয়।"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "ই ভৰষাহিন ৰাজহুৱা নেটৱৰ্কসমূহৰ বাবে উপদেশিত নহয়।"
+
+#~ msgid "Proxy"
+#~ msgstr "প্ৰক্সি"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "কোনো নহয়"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "হস্তচালিত"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "স্বচালিত"
+
+#~ msgid "Add Device"
+#~ msgstr "ডিভাইচ যোগ কৰক"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN ধৰণ"
+
+#~ msgid "Group Name"
+#~ msgstr "দলৰ নাম"
+
+#~ msgid "Group Password"
+#~ msgstr "দল পাছৱৰ্ড"
+
+#~ msgid "details"
+#~ msgstr "বিৱৰণসমূহ"
+
+#~ msgid "Show P_assword"
+#~ msgstr "পাছৱৰ্ড দেখুৱাওক (_a)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "অন্য ব্যৱহাৰকাৰীসকলৰ বাবে উপলব্ধ কৰাওক"
+
+#~ msgid "identity"
+#~ msgstr "পৰিচয়"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "কেৱল স্বচালিত (DHCP) ঠিকনাসমূহ"
+
+#~ msgid "Link-local only"
+#~ msgstr "কেৱল স্থানীয়-সংযোগ"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "স্বচালিতভাৱে প্ৰাপ্ত পথসমূহ উপেক্ষা কৰক (_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "ক্লৌন্ড MAC ঠিকনা (_C)"
+
+#~ msgid "hardware"
+#~ msgstr "হাৰ্ডৱেৰ"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "এই সংযোগৰ বাবে সংহতিসমূহক তাৰ অবিকল্পিতলে পুনৰসংহতি কৰক, কিন্তু এটা পছন্দৰ "
+#~ "সংযোগ হিচাপে মনত ৰাখক।"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "এই নেটৱৰ্কৰ সৈতে প্ৰসংগ কৰা সকলো বিৱৰণ আতৰাওক আৰু স্বচালিতভাৱে ইয়াৰ সৈতে "
+#~ "সংযোগ কৰাৰ চেষ্টা নকৰিব।"
+
+#~ msgid "reset"
+#~ msgstr "পুনৰসংহতি কৰক"
+
+#~ msgid "Hardware"
+#~ msgstr "হাৰ্ডৱেৰ"
+
+#~ msgid "_History"
+#~ msgstr "ইতিহাস (_H)"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "এটা Wi-Fi নেটৱৰ্কৰ সৈতে সংযোগ কৰিবলে বন্ধ কৰক"
+
+#~ msgid "Connected Devices"
+#~ msgstr "সংযুক্ত ডিভাইচসমূহ"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "এড-হক"
+
+#~ msgid "Infrastructure"
+#~ msgstr "আন্তঃগাঁথনি"
+
+#~ msgid "Status unknown"
+#~ msgstr "অৱস্থা অজ্ঞাত"
+
+#~ msgid "Unmanaged"
+#~ msgstr "অব্যৱস্থাপিত"
+
+#~ msgid "Unavailable"
+#~ msgstr "উপলব্ধ নাই"
+
+#~ msgid "Connecting"
+#~ msgstr "সংযোগ স্থাপন কৰা হৈছে..."
+
+#~ msgid "Disconnecting"
+#~ msgstr "বিচ্ছিন্ন কৰা হৈ আছে"
+
+#~ msgid "Connection failed"
+#~ msgstr "সংযোগ ব্যৰ্থ"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "অৱস্থা অজ্ঞাত (সন্ধানহিন)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "সংৰূপ ব্যৰ্থ"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP সংৰূপ ব্যৰ্থ হল"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP সংৰূপৰ অৱসান ঘটিল"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "গোপনসমূহৰ প্ৰয়োজন আছিল, কিন্তু প্ৰদান কৰা হোৱা নাছিল"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x সাপ্লিকেণ্ট বিচ্ছিন্নিত"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x সাপ্লিকেণ্ট সংৰূপ ব্যৰ্থ হল"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x সাপ্লিকেণ্ট ব্যৰ্থ হল"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x সাপ্লিকেণ্ট প্ৰমাণীত হবলে বহু সময় ললে"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP সেৱা আৰম্ভ হবলে ব্যৰ্থ হল"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP সেৱা বিচ্ছিন্নিত হল"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP ব্যৰ্থ হল"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP ক্লাএন্ট আৰম্ভ হবলে ব্যৰ্থ হল"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP ক্লাএন্ট ত্ৰুটি"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP ক্লাএন্ট ব্যৰ্থ হল"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "অংশীদাৰী সংযোগ সেৱা আৰম্ভ হবলে ব্যৰ্থ হল"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "অংশীদাৰী সংযোগ সেৱা ব্যৰ্থ হল"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP সেৱা আৰম্ভ হবলে ব্যৰ্থ হল"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP সেৱা ত্ৰুটি"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP সেৱা ব্যৰ্থ হল"
+
+#~ msgid "Line busy"
+#~ msgstr "লাইন ব্যস্ত"
+
+#~ msgid "No dial tone"
+#~ msgstr "কোনো ডায়েল শব্দ নাই"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "কোনো বাহক স্থাপন কৰিব পৰা নগল"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "ডায়লিং অনুৰোধৰ সময় অন্ত হল"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "ডায়লিং চেষ্টা ব্যৰ্থ হল"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "মডেম আৰম্ভকৰণ ব্যৰ্থ হল"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "ধাৰ্য্যত APN নিৰ্বাচন কৰিবলে ব্যৰ্থ"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "নেটৱৰ্কসমূহ সন্ধান কৰা হোৱা নাই"
+
+#~ msgid "Network registration denied"
+#~ msgstr "নেটৱৰ্ক ৰেজিষ্ট্ৰেষণ নাকচ কৰা হৈছে"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "নেটৱৰ্ক ৰেজিষ্ট্ৰেষণৰ সময় অন্ত হল"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "অনুৰোধ কৰা নেটৱৰ্কৰ সৈতে ৰেজিস্টাৰ কৰিবলে ব্যৰ্থ হল"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN নিৰীক্ষণ ব্যৰ্থ হল"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "ডিভাইচৰ বাবে ফাৰ্মৱেৰ সন্ধানহিন হব পাৰে"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "সংযোগ নোহোৱা হল"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "স্থায়ী সংযোগ ধাৰনা কৰা হৈছিল"
+
+#~ msgid "Modem not found"
+#~ msgstr "মডেম পোৱা নগল"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ব্লুটুথ সংযোগ ব্যৰ্থ হল"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM ৰ Pin ৰ প্ৰয়োজন"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM ৰ Puk ৰ প্ৰয়োজন"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM ভুল"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand ডিভাইচে সংযুক্ত অৱস্থা সমৰ্থন নকৰে"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "সংযোগ নিৰ্ভৰতা ব্যৰ্থ হল"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "কেবুল আনপ্লাগ্গড"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "কোনো প্ৰমাণপত্ৰ কতৃপক্ষৰ প্ৰমাণপত্ৰ নিৰ্ব্বাচন কৰা নহয়"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "প্ৰমাণপত্ৰ কতৃপক্ষ (CA) প্ৰমাণপত্ৰ ব্যৱহাৰ নকৰিলে সুৰক্ষাবিহীন, বিপদজনক Wi-Fi "
+#~ "নেটৱৰ্কৰ সৈতে সংযোগ স্থাপন কৰা হ'ব পাৰে। আপুনি এটা প্ৰমাণপত্ৰ কতৃপক্ষ প্ৰমাণপত্ৰ "
+#~ "নিৰ্বাচন কৰিব বিচাৰে নেকি?"
+
+#~ msgid "Ignore"
+#~ msgstr "উপেক্ষা কৰক"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA প্ৰমাণপত্ৰ বাছক"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, অথবা PKCS#12 ব্যক্তিগত কি'সমূহ (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER অথবা PEM প্ৰমাণপত্ৰসমূহ (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ফাইলসমূহ (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "প্ৰতিবাৰ এই পাছৱৰ্ড বিচাৰিব (_k)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "আনইনক্ৰিপ্টেড ব্যক্তিগত কি'সমূহ অসুৰক্ষিত"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "নিৰ্বাচিত ব্যক্তিগত কি' এটা পাছৱৰ্ড দ্বাৰা সুৰক্ষিত যেন নালাগে। ইয়াৰ বাবে আপোনাৰ "
+#~ "সুৰক্ষা তথ্যসমূহ আপোচ হব পাৰে। অনুগ্ৰহ কৰি এটা পাছৱৰ্ড-সুৰক্ষিত ব্যক্তিগত কি' বাছক।\n"
+#~ "\n"
+#~ "(আপুনি openssl ৰ সৈতে আপোনাৰ ব্যক্তিগত কি' পাছৱৰ্ড-সুৰক্ষিত কৰিব পাৰিব)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "আপোনাৰ ব্যক্তিগত প্ৰমাণপত্ৰ বাছক"
+
+#~ msgid "Choose your private key"
+#~ msgstr "আপোনাৰ ব্যক্তিগত কি' বাছক"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "মোক আকৌ সতৰ্ক নকৰিব (_w)"
+
+#~ msgid "Yes"
+#~ msgstr "হয়"
+
+#~ msgid "2"
+#~ msgstr "২"
+
+#~ msgid "3"
+#~ msgstr "৩"
+
+#~ msgid "4"
+#~ msgstr "৪"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "পপআপ বেনাৰসমূহ দেখুৱাওক"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "বেনাৰসমূহত বিৱৰণসমূহ দেখুৱাওক"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "পৰ্দা লক কৰাত দৰ্শন কৰক"
+
+#~ msgid "On"
+#~ msgstr "অন "
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "পপআপ বেনাৰসমূহ দেখুৱাওক"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "পৰ্দা লক কৰাত দেখুৱাওক"
+
+#~ msgid "Add Account"
+#~ msgstr "একাওন্ট যোগ কৰক"
+
+#~ msgid "Mail"
+#~ msgstr "মেইল"
+
+#~ msgid "Contacts"
+#~ msgstr "পৰিচয়সমূহ"
+
+#~ msgid "Chat"
+#~ msgstr "চেট"
+
+#~ msgid "Resources"
+#~ msgstr "সম্পদসমূহ"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "একাওন্টলে লগিন কৰোতে ত্ৰুটি"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "তথ্যসমূহৰ অৱসান ঘটিছে।"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "এই একাওন্ট সামৰ্থবান কৰিবলে ছাইন ইন কৰক।"
+
+#~ msgid "_Sign In"
+#~ msgstr "ছাইন ইন কৰক (_S)"
+
+#~ msgid "Error creating account"
+#~ msgstr "একাওন্ট সৃষ্টি কৰোতে ত্ৰুটি"
+
+#~ msgid "Error removing account"
+#~ msgstr "একাওন্ট আতৰাওতে ত্ৰুটি"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "আপুনি নিশ্চিত নে আপুনি একাওন্ট আতৰাব বিচাৰে?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "ই চাৰ্ভাৰত একাওন্টক আতৰাই নিদিয়ে।"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "সংৰূপিত কোনো অনলাইন একাওন্ট নাই"
+
+#~ msgid "Remove Account"
+#~ msgstr "একাওন্ট আতৰাওক"
+
+#~ msgid "Add an online account"
+#~ msgstr "এটা অনলাইন একাওন্ট যোগ কৰক"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "এটা একাওন্টে যোগ কৰিলে আপোনাৰ এপ্লিকেচনে ইয়াক দস্তাবেজসমূহ, মেইল, পৰিচয়সমূহ, "
+#~ "কেলেন্ডাৰ, চেট আৰু অধিকৰ বাবে অভিগম কৰিবলে অনুমতি প্ৰাপ্ত কৰে।"
+
+#~ msgid "Unknown time"
+#~ msgstr "অজ্ঞাত সময়"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "সম্পূৰ্ণ চাৰ্জ হবলে %s অৱশিষ্ট"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "সাৱধান: %s অৱশিষ্ট"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s অৱশিষ্ট"
+
+#~ msgid "Fully charged"
+#~ msgstr "সম্পূৰ্ণ চাৰ্জ হৈছে"
+
+#~ msgid "Empty"
+#~ msgstr "ৰিক্ত"
+
+#~ msgid "Charging"
+#~ msgstr "চাৰ্জ কৰা হৈ আছে"
+
+#~ msgid "Discharging"
+#~ msgstr "চাৰ্জ শেষ হৈ আছে"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "মূখ্য"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "অতিৰিক্ত"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "বেতাঁৰ মাউছ"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "বেতাঁৰ কিবৰ্ড"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "ব্যাঘাতহিন শক্তিৰ যোগান"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "ব্যক্তিগত অঙ্কীয় সহায়ক"
+
+#~ msgid "Cellphone"
+#~ msgstr "চেলফোন"
+
+#~ msgid "Media player"
+#~ msgstr "মিডিয়া প্লেয়াৰ"
+
+#~ msgid "Computer"
+#~ msgstr "কমপিউটাৰ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "চাৰ্জ কৰা হৈ আছে"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "সাৱধানী"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "নিম্ন"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "ভাল"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "সম্পূৰ্ণ চাৰ্জ হৈছে"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "ৰিক্ত"
+
+#~ msgid "Batteries"
+#~ msgstr "বেটাৰিসমূহ"
+
+#~ msgid "When _idle"
+#~ msgstr "যেতিয়া অলস (_i)"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "কিবৰ্ডৰ উজ্জ্বলতা (_K)"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "যেতিয়া নিষ্ক্ৰিয় তেতিয়া পৰ্দা স্লান কৰিব (_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "Wi-Fi (_W)"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "বেতাঁৰ ডিভাইচসমূহ বন্ধ কৰে"
+
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "মবাইল ব্ৰডবেণ্ড (3G, 4G, WiMax, ইত্যাদি) ডিভাইচসমূহ বন্ধ কৰে"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "ব্লুটুথ (_B)"
+
+#~ msgid "When on battery power"
+#~ msgstr "যেতিয়া বেটাৰি শক্তিত চলি থাকে"
+
+#~ msgid "When plugged in"
+#~ msgstr "যেতিয়া প্লাগ ইন কৰা আছে"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "স্থগিত কৰি বন্ধ কৰক"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "স্বচালিতভাৱে স্থগিত কৰা (_A)"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "যেতিয়া বেটাৰি শক্তি মাৰাত্মকভাৱে কম (_c)"
+
+#~ msgid "Power Off"
+#~ msgstr "বন্ধ কৰক"
+
+#~ msgid "Hibernate"
+#~ msgstr "হাইবাৰনেইট"
+
+#~ msgid "1 minute"
+#~ msgstr "১ মিনিট"
+
+#~ msgid "3 minutes"
+#~ msgstr "৩ মিনিট"
+
+#~ msgid "4 minutes"
+#~ msgstr "৪ মিনিট"
+
+#~ msgid "8 minutes"
+#~ msgstr "৮ মিনিট"
+
+#~ msgid "10 minutes"
+#~ msgstr "১০ মিনিট"
+
+#~ msgid "12 minutes"
+#~ msgstr "১২ মিনিট"
+
+#~ msgid "Out of toner"
+#~ msgstr "টনাৰ শেষ"
+
+#~ msgid "Low on developer"
+#~ msgstr "উন্নয়নকাৰী কম"
+
+#~ msgid "Out of developer"
+#~ msgstr "উন্নয়নকাৰী নাই"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "এটা মাৰ্কাৰ যোগানত কম"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "এটা মাৰ্কাৰ যোগান শেষ"
+
+#~ msgid "Open cover"
+#~ msgstr "প্ৰচ্ছেদ খোলক"
+
+#~ msgid "Open door"
+#~ msgstr "দৰ্জা খোলক"
+
+#~ msgid "Low on paper"
+#~ msgstr "কাগজ কম"
+
+#~ msgid "Out of paper"
+#~ msgstr "কাগজ শেষ"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "বন্ধ কৰা হল"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "আবৰ্জনা গ্ৰাহক প্ৰায় ভৰ্তি"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "আবৰ্জনা গ্ৰাহক পূৰ্ণ"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "অপ্টিকেল ফ'টো পৰিবাহক জীৱনৰ শেষ পৰ্যায়ত আছে"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "অপ্টিকেল ফ'টো পৰিবাহক কাৰ্য্য কৰা নাই"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "প্ৰস্তুত"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "কাৰ্য্যসমূহ গ্ৰহণ নকৰে"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "প্ৰক্ৰিয়াকৰণ কৰা হৈছে"
+
+#~ msgid "Toner Level"
+#~ msgstr "টনাৰ স্তৰ"
+
+#~ msgid "Supply Level"
+#~ msgstr "যোগান স্তৰ"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "ইনস্টল কৰা হৈছে"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u সক্ৰিয়"
+#~ msgstr[1] "%u সক্ৰিয়"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "নতুন প্ৰিন্টাৰ যোগ কৰিবলে ব্যৰ্থ।"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "পস্টস্ক্ৰিপ্ট প্ৰিন্টাৰ বিৱৰণ ফাইলসমূহ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+#~ "GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "কোনো উপযুক্ত ড্ৰাইভাৰ পোৱা নগল"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui ল'ড কৰিব নোৱাৰি: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "প্ৰিন্টিং চলাই নিয়ক"
+
+#~ msgid "Pause Printing"
+#~ msgstr "প্ৰিন্টিং ৰখাওক"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "এটা নতুন প্ৰিন্টাৰ যোগ কৰক"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "ফলাফলসমূহ ফিল্টাৰ কৰিবলৈ এটা প্ৰিন্টাৰৰ ঠিকনা অথবা এটা লিখনি সুমুৱাওক"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect প্ৰিন্টাৰ"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD প্ৰিন্টাৰ"
+
+#~ msgid "One Sided"
+#~ msgstr "এক-ফলিয়া"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "দীঘল প্ৰান্ত (প্ৰামাণিক)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "চুটি প্ৰান্ত (লুটিৱাওক)"
+
+#~ msgid "Portrait"
+#~ msgstr "পট্ৰেইট"
+
+#~ msgid "Landscape"
+#~ msgstr "লেণ্ডস্কেইপ"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "উলোটা লেণ্ডস্কেইপ"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "উলোটা পোট্ৰেইট"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "বাকি আছে"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "ধৰি ৰখা আছে"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "প্ৰক্ৰিয়াকৰণ কৰা হৈছে"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "বন্ধ কৰা হল"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "বাদ দিয়া হল"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "সম্পন্ন"
+
+#~ msgid "Job Title"
+#~ msgstr "কাৰ্য্য শীৰ্ষক"
+
+#~ msgid "Job State"
+#~ msgstr "কাৰ্য্য অৱস্থা"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "ক্ৰমিক পৰ্ট"
+
+#~ msgid "Parallel Port"
+#~ msgstr "সমান্তৰাল পৰ্ট"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "অবস্থান: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "ঠিকনা: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "দুই -ফলিয়া"
+
+#~ msgid "Paper Type"
+#~ msgstr "পাতৰ ধৰণ"
+
+#~ msgid "Paper Source"
+#~ msgstr "পাতৰ উৎস"
+
+#~ msgid "Output Tray"
+#~ msgstr "আউটপুট ট্ৰে"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript পূৰ্ব-পৰিস্ৰাৱন"
+
+#~ msgid "Pages per side"
+#~ msgstr "প্ৰতি ফাল পৃষ্ঠাসমূহ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "সাধাৰণ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "পৃষ্ঠাৰ সংস্থাপন"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "ইনস্টল কৰিব পৰা বিকল্পসমূহ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "কাৰ্য্য"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "ছবিৰ গুণ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "ৰঙ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "শেষ কৰা হৈছে"
+
+#~ msgid "Auto Select"
+#~ msgstr "স্বনিৰ্বাচন"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "কেৱল GhostScript ফন্টসমূহ অন্তৰভুক্ত কৰক"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS স্তৰ ১ লে পৰিবৰ্তন কৰক"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS স্তৰ ২ লে পৰিবৰ্তন কৰক"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "কোনো পূৰ্ব-পৰিস্ৰাৱন নাই"
+
+#~ msgid "Supply"
+#~ msgstr "যোগান দিয়ক"
+
+#~ msgid "_Default printer"
+#~ msgstr "অবিকল্পিত প্ৰিন্টাৰ (_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "কাৰ্য্যসমূহ"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "কাৰ্য্যসমূহ দেখুৱাওক (_J)"
+
+#~ msgid "label"
+#~ msgstr "লেবেল"
+
+#~ msgid "page 3"
+#~ msgstr "পৃষ্ঠা ৩"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "পৰীক্ষা পৃষ্ঠা প্ৰিন্ট কৰক (_T)"
+
+#~ msgid "_Options"
+#~ msgstr "বিকল্পসমূহ (_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "নতুন প্ৰিন্টাৰ যোগ কৰক"
+
+#~ msgid "Usage & History"
+#~ msgstr "ব্যৱহাৰ আৰু ইতিহাস"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "আবৰ্জনাৰ পৰা সকলো বস্তু আতৰাব নে?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "আবৰ্জনাৰ সকলো বস্তু স্থায়ীভাৱে মচি পেলোৱা হব।"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "সকলো অস্থায়ী ফাইল মচি পেলাব নে?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "সকলো অস্থায়ী ফাইল স্থায়ীভাৱে মচি পেলোৱা হব।"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "আপোনাৰ ব্যক্তিগত তথ্য সুৰক্ষিত কৰক আৰু অন্যয় কি চাব পাৰে নিয়ন্ত্ৰণ কৰক"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "পৰ্দা বন্ধ হয়"
+
+#~ msgid "30 seconds"
+#~ msgstr "৩০ ছেকেণ্ড"
+
+#~ msgid "1 day"
+#~ msgstr "১ দিন"
+
+#~ msgid "2 days"
+#~ msgstr "২ দিন"
+
+#~ msgid "3 days"
+#~ msgstr "৩ দিন"
+
+#~ msgid "4 days"
+#~ msgstr "৪ দিন"
+
+#~ msgid "5 days"
+#~ msgstr "৫ দিন"
+
+#~ msgid "6 days"
+#~ msgstr "৬ দিন"
+
+#~ msgid "7 days"
+#~ msgstr "৭ দিন"
+
+#~ msgid "14 days"
+#~ msgstr "১৪ দিন"
+
+#~ msgid "30 days"
+#~ msgstr "৩০ দিন"
+
+#~ msgid "Forever"
+#~ msgstr "চিৰকাল"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "আপোনাৰ ইতিহাস মনত ৰাখিলে বস্তুবোৰ আকৌ বিচাৰোতে সহজ হয়। এই বস্তুবোৰ নেটৱৰ্কৰে "
+#~ "কেতিয়াও অংশীদাৰী কৰা নহয়।"
+
+#~ msgid "_Recently Used"
+#~ msgstr "শেহতীয়াভাৱে ব্যৱহৃত (_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "ইতিহাস অব্যাহত ৰাখক (_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "যেতিয়া আপুনি আতৰ হয় পৰ্দা লকে আপোনাৰ গোপনীয়তা সুৰক্ষিত ৰাখে।"
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "উল্লেখিত সময় খালি থকাৰ পিছত পৰ্দা লক কৰিব (_A)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "আপোনাৰ কমপিউটাৰক অপ্ৰয়োজনীয় সংবেদ্য তথ্যৰ পৰা মুক্ত ৰাখিবলে আবৰ্জনা আৰু অস্থায়ী "
+#~ "ফাইলসমূহ স্বচালিতভাৱে শোধন কৰক।"
+
+#~ msgid "Purge _After"
+#~ msgstr "উল্লেখিত সময়ৰ পিছত শোধন কৰক (_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "আপুনি কি চফ্টৱেৰ ব্যৱহাৰ কৰে তাৰ বিষয়ে তথ্য পঠালে আমাক অধিক সঠিক উপদেশ প্ৰদান "
+#~ "কৰাত সহায় কৰে। ই লগতে আমাৰ চফ্টৱেৰ উন্নত কৰাত সহায় কৰে।\n"
+#~ "\n"
+#~ "আমি সংগ্ৰহ কৰা সকলো তথ্যক বেনামী কৰা হয়, আৰু আমি আপোনাৰ তথ্য কেতিয়াও তৃতীয় দলৰ "
+#~ "সৈতে অংশীদাৰী নকৰো।"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "চফ্টৱেৰ ব্যৱহাৰৰ পৰিসংখ্যা পঠাওক (_S)"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "গোপনীয়তা নীতি"
+
+#~| msgid "Allows applications to determine your geographical location"
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "আপোনাৰ ভৌগলিক অৱস্থান নিৰ্ধাৰণ কৰাৰ বাবে ব্যৱহাৰ কৰা হয়"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ইম্পেৰিয়েল"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "মেট্ৰিক"
+
+#~ msgid "No input sources found"
+#~ msgstr "কোনো ইনপুট উৎস পোৱা নগল"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "অন্য"
+
+#~ msgid "Sorry"
+#~ msgstr "ক্ষমা কৰিব"
+
+#~ msgid ""
+#~ "Select your display language, formats, keyboard layouts and input sources"
+#~ msgstr "আপোনাৰ প্ৰদৰ্শন ভাষা, বিন্যাসসমূহ, কিবৰ্ড বিন্যাসসমূহ আৰু ইনপুট উৎসসমূহ বাছক"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "পৰৱৰ্তী উৎসলে যাওক"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "আপুনি এই চৰ্টকাটসমূহ কিবৰ্ড সংহতিসমূহত পৰিবৰ্তন কৰিব পাৰিব"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "পৰৱৰ্তী উৎসলে বৈকল্পিক চুইচ"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Left+Right Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "ইংৰাজী (ইংলেণ্ড)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "সংযুক্তৰাজ্য"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "চিস্টেমত লগিন কৰোতে লগিন সংহতিসমূহ সকলো ব্যৱহাৰকাৰী দ্বাৰা ব্যৱহাৰ কৰা হয়"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "অন্য"
+
+#~ msgid "Select Location"
+#~ msgstr "অবস্থান বাছক"
+
+#~ msgid "_OK"
+#~ msgstr "ঠিক আছে (_O)"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "অন"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "অফ"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "সামৰ্থবান"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "এটা ফোল্ডাৰ বাছক"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "অংশীদাৰী কৰিবলে কোনো নেটৱৰ্ক নিৰ্বাচন কৰা হোৱা নাই"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "ব্লুটুথ অংশীদাৰীয়ে আপোনাক অন্য ব্লুটুথ সামৰ্থবান ডিভাইচসমূহৰ সৈতে ফাইলসমূহ অংশীদাৰী "
+#~ "কৰাৰ অনুমতি দিয়ে"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "কেৱল ভৰষাবান ডিভাইচসমূহৰ পৰা গ্ৰহণ কৰক"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "গ্ৰহণ কৰা ফাইলসমূহ ডাউনল'ডসমূহ ফোল্ডাৰত সংৰক্ষণ কৰক"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "পৰ্দা অংশীদাৰী"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "কোনো নেটৱৰ্ক অভিগম নথকা বাবে কিছুমান সেৱা অসামৰ্থবান কৰা আছে।"
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "ব্যক্তিগত ফাইল অংশীদাৰীয়ে আপোনাক আপোনাৰ বৰ্তমান নেটৱৰ্কত <a href=\"dav://"
+#~ "%s\">dav://%s</a> ব্যৱহাৰ কৰি আপোনাৰ ৰাজহুৱা ফোল্ডাৰক অন্যৰ সৈতে অংশীদাৰী "
+#~ "কৰাৰ অনুমতি দিয়ে"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "Secure Shell কমান্ড ব্যৱহাৰ কৰি দূৰৱৰ্তী ব্যৱহাৰকাৰীসকলৰ সৈতে সংযোগ কৰাৰ অনুমতি "
+#~ "দিয়ক:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "দূৰৱৰ্তী ব্যৱহাৰকাৰীসকলক <a href=\"vnc://%s\">vnc://%s</a> ৰ সৈতে সংযোগ কৰি "
+#~ "আপোনাৰ পৰ্দা দৰ্শন অথবা নিয়ন্ত্ৰণ কৰাৰ অনুমতি দিয়ক"
+
+#~ msgid "Password:"
+#~ msgstr "পাছৱৰ্ড:"
+
+#~ msgid "Show Password"
+#~ msgstr "পাছৱৰ্ড দেখুৱাওক"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "নতুন সংযোগসমূহে অভিগমৰ বাবে সোধিব লাগিব"
+
+#~ msgid "Require a password"
+#~ msgstr "এটা পাছৱৰ্ডৰ প্ৰয়োজন"
+
+#~ msgid "Bark"
+#~ msgstr "বাৰ্ক"
+
+#~ msgid "Drip"
+#~ msgstr "ড্ৰিপ"
+
+#~ msgid "Glass"
+#~ msgstr "কাঁচ"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "নূন্যতম"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "সৰ্বাধিক"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "চাব্ওফাৰ (_S):"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "১০০%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "অবৃদ্ধিত"
+
+#~ msgid "_Profile:"
+#~ msgstr "আলেখ্য (_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "স্পিকাৰসমূহ পৰীক্ষা কৰক (_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "শীৰ্ষ চিনাক্তকৰণ"
+
+#~ msgid "Device"
+#~ msgstr "ডিভাইচ"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s ৰ বাবে স্পিকাৰ পৰীক্ষা"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "শব্দ আউটপুটৰ বাবে এটা ডিভাইচ বাছক (_h):"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "নিৰ্বাচিত ডিভাইচৰ বাবে সংহতিসমূহ:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "ইনপুট ভলিউম (_I):"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "শব্দ ইনপুটৰ বাবে এটা ডিভাইচ বাছক (_h):"
+
+#~ msgid "Sound Effects"
+#~ msgstr "শব্দ প্ৰভাৱসমূহ"
+
+#~ msgid "Built-in"
+#~ msgstr "বিল্ট-ইন"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "শব্দ পছন্দসমূহ"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ঘটনা শব্দ পৰীক্ষা কৰা"
+
+#~ msgid "From theme"
+#~ msgstr "থীমৰ পৰা"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "এটা সতৰ্কৰ শব্দ বাছক (_h):"
+
+#~ msgid "Stop"
+#~ msgstr "বন্ধ কৰক"
+
+#~ msgid "Custom"
+#~ msgstr "স্বনিৰ্বাচিত"
+
+#~ msgid "Screen Reader"
+#~ msgstr "পৰ্দা ৰিডাৰ"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "পৰ্দা ৰিডাৰ (_S)"
+
+#~ msgid "Sound Keys"
+#~ msgstr "শব্দ কি'সমূহ"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "উইন্ডো শীৰ্ষক ফ্লেশ কৰক (_w)"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "সৰু"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ পৰ্দা"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ পৰ্দা"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ পৰ্দা"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "দীঘল"
+
+#~ msgid "Zoom"
+#~ msgstr "ডাঙৰ কৰি দেখুৱাওক"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "ৰঙ"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "প্ৰামাণিক"
+
+#~ msgid "Account _Type"
+#~ msgstr "একাওন্টৰ ধৰণ (_T)"
+
+#~ msgid "_Verify"
+#~ msgstr "সতা সত্য নিৰূপণ কৰক (_V)"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "এন্টাৰপ্ৰাইজ লগিন একাউন্টসমূহ\n"
+#~ "যোগ কৰিবলৈ অনলাইন যাওক।"
+
+#~ msgid "Left thumb"
+#~ msgstr "বাঁওহাতৰ বৃদ্ধাঙ্গুলি"
+
+#~ msgid "Left middle finger"
+#~ msgstr "বাঁওহাতৰ মধ্যমা"
+
+#~ msgid "Left ring finger"
+#~ msgstr "বাঁওহাতৰ অনামিকা"
+
+#~ msgid "Left little finger"
+#~ msgstr "বাঁওহাতৰ কনিষ্ঠা"
+
+#~ msgid "Right thumb"
+#~ msgstr "সোঁহাতৰ বৃদ্ধাঙ্গুলি"
+
+#~ msgid "Right middle finger"
+#~ msgstr "সোঁহাতৰ মধ্যমা"
+
+#~ msgid "Right ring finger"
+#~ msgstr "সোঁহাতৰ অনামিকা"
+
+#~ msgid "Right little finger"
+#~ msgstr "সোঁহাতৰ কনিষ্ঠা"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "আঙ্গুলিৰ ছাপ লগিন সক্ৰিয় কৰক"
+
+#~ msgid "_Right index finger"
+#~ msgstr "সোঁ সূচক আঙুলি (_R)"
+
+#~ msgid "_Left index finger"
+#~ msgstr "বাওঁ সূচক আঙুলি (_L)"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "সাফল্যেৰ সৈতে আপোনাৰ আঙ্গুলিৰ ছাপ সংৰক্ষিত হৈছে। আঙ্গুলিৰ ছাপ পাঠৰ ব্যবস্থা "
+#~ "(ৰিডাৰ) সহযোগে আপুনি এতিয়া লগিন কৰিবলৈ সক্ষম হ'ব।"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "লগিন;নাম;আঙ্গুলিৰ ছাপ;অৱতাৰ;লগো;মূখ;পাছৱৰ্ড;"
+
+#~ msgid "Login History"
+#~ msgstr "লগিনৰ ইতিহাস"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "নতুন পাছৱৰ্ড সতা সত্য নিৰূপণ কৰক (_V)"
+
+#~ msgid "Add User Account"
+#~ msgstr "ব্যৱহাৰকাৰী একাওন্ট যোগ কৰক"
+
+#~ msgid "Login Options"
+#~ msgstr "লগিন বিকল্পসমূহ"
+
+#~ msgid "User Icon"
+#~ msgstr "ব্যৱহাৰকাৰী আইকন"
+
+#~ msgid "Last Login"
+#~ msgstr "সৰ্বশেষ লগিন"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "নতুন পাছৱৰ্ড পুৰনি পাছৱৰ্ডৰ পৰা ভিন্ন হব লাগিব।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "কিছুমান আখৰ আৰু সংখ্যা পৰিবৰ্তন কৰি চাওক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "পাছৱৰ্ডটো আৰু অলপ পৰিবৰ্তন কৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "আপোনাৰ ব্যৱহাৰকাৰী নাম নথকা এটা পাছৱৰ্ড অধিক শক্তিশালী হব।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "পাছৱৰ্ডত আপোনাৰ নাম ব্যৱহাৰ নকৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "পাছৱৰ্ডত ব্যৱহৃত কিছুমান শব্দ ব্যৱহাৰ নকৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "সাধাৰণ শব্দবোৰ বাদ দিয়াৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "স্থায়ী শব্দবোৰ পুনৰ ব্যৱস্থিত নকৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "অধিক সংখ্যা ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "অধিক ওপৰফলা আখৰ ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "অধিক তলৰফলা আখৰ ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "অধিক বিশেষ আখৰ, যেনে বিৰাম চিহ্ন ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "আখৰ, সংখ্যা আৰু বিৰাম চিহ্নৰ এটা সংমিশ্ৰণ ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "একেটা আখৰ পুনৰাবৃত্তি নকৰাৰ চেষ্টা কৰিব।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "একেধৰণ আখৰ পুনৰাবৃত্তি নকৰাৰ চেষ্টা কৰিব: আপুনি আখৰ, সংখ্যা আৰু বিৰাম চিহ্ন "
+#~ "সংমিশ্ৰণ কৰিব লাগিব।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "ক্ৰম যেনে 1234 অথবা abcd বাদ দিয়াৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "অধিক আখৰ, সংখ্যা আৰু চিহ্ন যোগ কৰাৰ চেষ্টা কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr "ওপৰফলা আৰু তলৰফলা সংমিশ্ৰণ কৰক আৰু এটা বা দুটা সংখ্যা ব্যৱহাৰ কৰক।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr ""
+#~ "ভাল পাছৱৰ্ড! অধিক আখৰ, সংখ্যা আৰু বিৰাম চিহ্ন যোগ কৰিলে ই আৰু অধিক শক্তিশালী হব।"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "শক্তি: দূৰ্বল"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "শক্তি: কম"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "শক্তি: মধ্যম"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "শক্তি: ভাল"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "শক্তি: প্ৰবল"
+
+#~ msgid "Authentication failed"
+#~ msgstr "প্ৰমাণীকৰণ ব্যৰ্থ হল"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "নতুন পাছৱৰ্ড অতি সৰু"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "নতুন পাছৱৰ্ড অতি সাধাৰণ"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "পুৰনি আৰু নতুন পাছৱৰ্ড অত্যন্ত সদৃশ"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "নতুন পাছৱৰ্ড ইতিমধ্যে শেহতীয়াকৈ ব্যৱহাৰ কৰা হৈছে।"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "নতুন পাছৱৰ্ড সাংখ্যিক অথবা বিশেষ আখৰসমূহ অন্তৰ্ভুক্ত কৰিব লাগিব"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "পুৰনি আৰু নতুন পাছৱৰ্ড একে"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "আপোনাৰ পাছৱৰ্ড আপুনি আৰম্ভণিত প্ৰমাণিত কৰাৰ পিছত পৰিবৰ্তন হৈছে!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "নতুন পাছৱাৰ্ডে পৰ্যাপ্ত ভিন্ন আখৰ অন্তৰ্ভুক্ত নকৰে"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "অজ্ঞাত ত্ৰুটি"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "আপোনাৰ একাওন্ট প্ৰদানকাৰীৰ ৱেব ঠিকনাৰ সৈতে মিল খাব লাগিব।"
+
+#~ msgid "Failed to add account"
+#~ msgstr "একাওন্ট যোগ কৰিবলে ব্যৰ্থ হল"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "পাছৱৰ্ডসমূহ মিল নাখায়।"
+
+#~ msgid "Failed to register account"
+#~ msgstr "একাওন্ট ৰেজিস্টাৰ কৰিবলে ব্যৰ্থ হল"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "এই ডমেইনৰ সৈতে প্ৰমাণীত কৰিবলে কোনো সমৰ্থিত পদ্ধতি নাই"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "ডমেইনত অংশগ্ৰহণ কৰিবলে ব্যৰ্থ হল"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "সেই লগিন নাম কাম নকৰিলে।\n"
+#~ "অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক।"
+
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "সেই লগিন পাছৱৰ্ড কাম নকৰিলে।\n"
+#~ "অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক।"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "ডমেইনত লগিন কৰিবলে ব্যৰ্থ হল"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "ডমেইন সন্ধান কৰিবলৈ অক্ষম। হয়তো আপুনি ইয়াক ভুলকৈ বানান কৰিছে?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "আপুনি এই ডিভাইচ ব্যবহাৰ কৰিবলৈ অনুমোদিত নহয়। অনুগ্ৰহ কৰি প্ৰণালী প্ৰশাসকৰ সৈতে "
+#~ "যোগাযোগ কৰক।"
+
+#~ msgid "The device is already in use."
+#~ msgstr "ডিভাইচ বৰ্তমানে ব্যবহৃত হৈছে।"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "এটা অভ্যন্তৰীক ত্ৰুটি দেখা দিছে।"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "নিবন্ধিত আঙ্গুলিৰ ছাপ আঁতৰুৱা হ'ব নেকি ?"
+
+#~ msgid "Done!"
+#~ msgstr "সমাপ্ত!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' ডিভাইচ ব্যবহাৰ কৰিবলৈ ব্যৰ্থ"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' ডিভাইচত আঙ্গুলিৰ ছাপ প্ৰাপ্ত কৰিবলৈ ব্যৰ্থ"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "কোনো আঙ্গুলিৰ ছাপ ৰিডাৰ অভিগম কৰিব নোৱাৰি"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "অনুগ্ৰহ কৰি সহায়তাৰ বাবে আপোনাৰ চিস্টেম প্ৰশাসকৰ সৈতে যোগাযোগ কৰক।"
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "আঙ্গুলিৰ ছাপ লগিন ব্যবস্থা সামৰ্থবান কৰাৰ বাবে, '%s' সহযোগে অন্তত এটা আঙ্গুলিৰ "
+#~ "ছাপ সংৰক্ষণ কৰা আবশ্যক।"
+
+#~ msgid "Selecting finger"
+#~ msgstr "আঙুলি নিৰ্বাচন কৰা"
+
+#~ msgid "This Week"
+#~ msgstr "এই সপ্তাহ"
+
+#~ msgid "Last Week"
+#~ msgstr "যোৱা সপ্তাহ"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "অধিবেশন সমাপ্ত হল"
+
+#~ msgid "Session Started"
+#~ msgstr "অধিবেশন আৰম্ভ হল"
+
+#~ msgid "Please choose another password."
+#~ msgstr "অনুগ্ৰহ কৰি অন্য পাছৱৰ্ড বাছক।"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "অনুগ্ৰহ কৰি আপোনাৰ বৰ্তমান পাছৱৰ্ড পুনৰ টাইপ কৰক।"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "পাছৱৰ্ড সলনি কৰিব পৰা নগল"
+
+#~ msgid "Disable image"
+#~ msgstr "ছবি অসামৰ্থবান কৰক"
+
+#~ msgid "Take a photo…"
+#~ msgstr "এটা ফ'টো লওক…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "অধিক ছবিৰ বাবে ব্ৰাউছ কৰক…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s দ্বাৰা ব্যৱহৃত"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "এই ধৰণৰ ডমেইনত স্বচালিতভাৱে অংশগ্ৰহণ কৰিব নোৱাৰি"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "এনেধৰণৰ কোনো ডমেইন অথবা ৰাজত্ব পোৱা নগল"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s ডমেইনত %s হিচাপে লগিন কৰিব নোৱাৰি"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "অবৈধ পাছৱৰ্ড, অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক"
+
+#~ msgid "Other Accounts"
+#~ msgstr "অন্য একাওন্টসমূহ"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ব্যৱহাৰকাৰী মচি পেলাবলে ব্যৰ্থ"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "আপুনি আপোনাৰ একাওন্ট মচিব নোৱাৰিব।"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s এতিয়াও লগিন অৱস্থাত আছে"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "এজন ব্যৱহাৰকাৰীক লগিন অৱস্থাত মচি পেলালে চিস্টেম এটা অস্থিৰ অৱস্থাত যাব পাৰে।"
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "আপুনি %s ৰ ফাইলসমূহ ৰাখিব বিচাৰে নে?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "এজন ব্যৱহাৰকাৰীৰ একাওন্ট মচোতে ঘৰ ডাইৰেকটৰি, মেইল স্পুল আৰু অস্থায়ী ফাইলসমূহ "
+#~ "ৰখাটো সম্ভব।"
+
+#~ msgid "_Delete Files"
+#~ msgstr "ফাইলসমূহ মচি পেলাওক (_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "ফাইলসমূহ ৰাখক (_K)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "একাওন্ট অসামৰ্থবান"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "পৰৱৰ্তী লগিনত সংহতি কৰিব লগিয়া"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "কোনো নহয়"
+
+#~ msgid "Logged in"
+#~ msgstr "লগিন ইন কৰা আছে"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "একাওন্ট সেৱাৰ সৈতে সংযোগ কৰিবলে ব্যৰ্থ"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "অনুগ্ৰহ কৰি AccountService ইনস্টল আৰু সামৰ্থবান আছে বুলি সুনিশ্চিত কৰক।"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "পৰিবৰ্তনসমূহ কৰিবলে,\n"
+#~ "* আইকন প্ৰথমতে ক্লিক কৰক"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "এজন ব্যৱহাৰকাৰী সৃষ্টি কৰিবলে,\n"
+#~ "* আইকন প্ৰথমতে ক্লিক কৰক"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "নিৰ্বাচিত ব্যৱহাৰকাৰী একাওন্ট মচি পেলাওক"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "নিৰ্বাচিত ব্যৱহাৰকাৰী একাওন্ট মচিবলে,\n"
+#~ "* আইকন প্ৰথমতে ক্লিক কৰক"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "'%s' ব্যৱহাৰকাৰীনামৰ সৈতে এজন ব্যৱহাৰকাৰী ইতিমধ্যে অস্তিত্ববান।"
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "ব্যৱহাৰকাৰীনাম অতি দীঘল।"
+
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "ব্যৱহাৰকাৰীনাম '-' ৰ সৈতে আৰম্ভ হব নোৱাৰিব।"
+
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "ব্যৱহাৰকাৰীনামত কেৱল a-z ডিজিটৰ পৰা তলৰ আৰু ওপৰ ফলা আখৰ আৰু আখৰসমূহ '.', '-' "
+#~ "আৰু '_' ৰ পৰা যিকোনো আখৰ থাকিব পাৰিব।"
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr ""
+#~ "ইয়াক আপোনাৰ ঘৰ ফোল্ডাৰ নামকৰণৰ বাবে ব্যৱহাৰ কৰা হব আৰু ইয়াক পৰিবৰ্তন কৰিব "
+#~ "নোৱাৰি।"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "ওপৰ"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "তল"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "কোনো নহয়"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "কি'স্ট্ৰৌক পঠাওক"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "চুইচ পৰ্যবেক্ষক"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "অন-স্ক্ৰিন সহায় দেখুৱাওক"
+
+#~ msgid "Output:"
+#~ msgstr "আউটপুট:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "এস্পেক্ট অনুপাত ৰাখক (লেটাৰবাকচ):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "এটা মনিটৰলে মেপ কৰক"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d, %d ৰ"
+
+#~ msgid "Display Mapping"
+#~ msgstr "প্ৰদৰ্শন মেপিং"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "টেবলেট (প্ৰকৃত)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "টেবলেট পছন্দসমূহ"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ব্লুটুথ সংহতিসমূহ"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "বুটামসমূহ মেপ কৰক…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "প্ৰদৰ্শন বিভেদন সজাওক"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "মাউছ সংহতিসমূহ ব্যৱস্থাপনা কৰক"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "অনুকৰণ অৱস্থা"
+
+#~ msgid "Left Ring"
+#~ msgstr "বাঁও ৰিং"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "বাঁও ৰিং অৱস্থা #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "সোঁ ৰিং অৱস্থা #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "বাঁও Touchstrip"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "বাঁও Touchstrip অৱস্থা #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "সোঁ Touchstrip"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "সোঁ Touchstrip অৱস্থা #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "বাঁও Touchring অৱস্থা চুইচ"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "সোঁ Touchring অৱস্থা চুইচ"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "বাঁও Touchstrip অৱস্থা চুইচ"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "সোঁ Touchstrip অৱস্থা চুইচ"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "অৱস্থা চুইচ #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "বাঁও বুটাম #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "সোঁ বুটাম #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "উপৰ বুটাম #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "তলৰ বুটাম #%d"
+
+#~ msgid "No Action"
+#~ msgstr "কোনো কাৰ্য্য নহয়"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "বাঁও মাউছ বুটাম ক্লিক"
+
+#~ msgid "Scroll Up"
+#~ msgstr "উপৰলে সক্ৰল কৰক"
+
+#~ msgid "Scroll Right"
+#~ msgstr "সোঁফালে স্ক্ৰল কৰক"
+
+#~ msgid "Stylus"
+#~ msgstr "স্টাইলাচ"
+
+#~ msgid "Top Button"
+#~ msgstr "উপৰ বুটাম"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "ভাৰবৌচ অৱস্থা সামৰ্থবান কৰক"
+
+#~ msgid "Show the overview"
+#~ msgstr "অভাৰভিউ দেখুৱাওক"
+
+#~ msgid "Search for the string"
+#~ msgstr "স্ট্ৰিংৰ বাবে সন্ধান কৰক"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "সম্ভাব্য পেনেল নামসমূহ তালিকাভুক্ত কৰি প্ৰস্থান কৰক"
+
+#~ msgid "Show help options"
+#~ msgstr "সহায়তা বিকল্প প্ৰদৰ্শন কৰা হ'ব"
+
+#~ msgid "Panel to display"
+#~ msgstr "প্ৰদৰ্শন কৰিবলে পেনেল"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- সংহতিসমূহ"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "উপলব্ধ কমান্ড শাৰী বিকল্পসমূহৰ এটা সম্পূৰ্ণ তালিকা চাবলে '%s --help' চাওক।\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "উপলব্ধ পেনেলসমূহ:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "ব্যক্তিগত"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "হাৰ্ডৱেৰ"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "চিস্টেম"
 
 #~ msgid "Install Updates"
 #~ msgstr "আপডেইটসমূহ ইনস্টল কৰক"
@@ -7182,20 +8203,11 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Set Up New Device"
 #~ msgstr "নতুন ডিভাইচ সংস্থাপন কৰক"
 
-#~ msgid "Connection"
-#~ msgstr "সংযোগ"
-
 #~ msgid "Paired"
 #~ msgstr "সংযুক্ত"
 
-#~ msgid "Type"
-#~ msgstr "ধৰণ"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "মাউচ আৰু টাচপেড সংহতিসমূহ"
-
-#~ msgid "Sound Settings"
-#~ msgstr "শব্দ সংহতিসমূহ"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "কিবৰ্ড সংহতিসমূহ"
@@ -7246,9 +8258,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Don't use the display"
 #~ msgstr "প্ৰদৰ্শন ব্যৱহাৰ নকৰিব"
-
-#~ msgid "Refresh Rate"
-#~ msgstr "সতেজ কৰাৰ হাৰ"
 
 #~ msgid "Mouse Preferences"
 #~ msgstr "মাউছ সম্পৰ্কিত পছন্দ"
@@ -7357,12 +8366,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "_City:"
 #~ msgstr "চহৰ (_C):"
 
-#~ msgid "_Network Time"
-#~ msgstr "নেটৱৰ্ক সময় (_N)"
-
-#~ msgid ":"
-#~ msgstr ":"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "সময়ক এক ঘন্টা আগত সংহতি কৰক।"
 
@@ -7390,18 +8393,8 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgstr "ঘড়িৰউলোটাদিশত"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "ঘড়িৰ দিশত"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "১৮০ ডিগ্ৰিসমূহ"
-
-#~ msgid "Monitor"
-#~ msgstr "মনিটৰ"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "প্ৰাথমিক প্ৰদৰ্শন সলনি কৰিবলে টানি আনক।"
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -7433,9 +8426,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "টোকা: বিভেদন বিকল্পসমূহ সীমিত কৰিব পাৰে"
-
-#~ msgid "_Detect Displays"
-#~ msgstr "প্ৰদৰ্শনসমূহ চিনাক্ত কৰক (_D)"
 
 #~ msgid "C_ontent sticks to fingers"
 #~ msgstr "আঙুলিলৈ সমল স্টিক (_o)"
@@ -7563,12 +8553,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Large"
 #~ msgstr "ডাঙৰ"
 
-#~ msgid "Mouse Settings"
-#~ msgstr "মাউছ সংহতিসমূহ"
-
-#~ msgid "Add account"
-#~ msgstr "একাওন্ট যোগ কৰক"
-
 #~ msgid "_Local Account"
 #~ msgstr "স্থানীয় একাওন্ট (_L)"
 
@@ -7581,12 +8565,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "C_ontinue"
 #~ msgstr "চলাই থাকক (_o)"
 
-#~ msgid "Previous Week"
-#~ msgstr "পূৰ্বৱৰ্তী সপ্তাহ"
-
-#~ msgid "Next Week"
-#~ msgstr "অহা সপ্তাহ"
-
 #~ msgid "Next week"
 #~ msgstr "অহা সপ্তাহ"
 
@@ -7598,12 +8576,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Enable this account"
 #~ msgstr "এই একাওন্ট সামৰ্থবান কৰক"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "পাছৱৰ্ড সুনিশ্চিত কৰক (_o)"
-
-#~ msgid "Generate a password"
-#~ msgstr "এটা পাছৱৰ্ড সৃজন কৰক"
 
 #~ msgid "_Action"
 #~ msgstr "কাৰ্য্য (_A)"
@@ -7726,9 +8698,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Change the background"
 #~ msgstr "পটভূমী পৰিবৰ্তন কৰক"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "ব্লুটুথ সংহতিসমূহ সংৰূপণ কৰক"
-
 #~ msgctxt "Power"
 #~ msgid "Bluetooth"
 #~ msgstr "ব্লুটুথ"
@@ -7751,12 +8720,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Unspecified"
 #~ msgstr "অধাৰ্য্যত"
 
-#~ msgid "Select a language"
-#~ msgstr "এটা ভাষা বাছক"
-
-#~ msgid "_Select"
-#~ msgstr "নিৰ্বাচন কৰক (_S)"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "তাৰিখ আৰু সময় পছন্দসমূহ পেনেল"
 
@@ -7771,9 +8734,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Set your mouse and touchpad preferences"
 #~ msgstr "আপোনাৰ মাউছ আৰু টাচপেড পছন্দসমূহ সংহতি কৰক"
-
-#~ msgid "Network settings"
-#~ msgstr "নেটৱৰ্ক সংহতিসমূহ"
 
 #~ msgid "Out of range"
 #~ msgstr "বিস্তাৰৰ বাহিৰ"
@@ -7796,9 +8756,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Carrier/link changed"
 #~ msgstr "বাহক/সংযোগ পৰিবৰ্তন হল"
 
-#~ msgid "Manage notifications"
-#~ msgstr "অধিসূচনাসমূহ ব্যৱস্থাপনা কৰক"
-
 #~ msgid "Expired credentials. Please log in again."
 #~ msgstr "অৱসিত তথ্যসমূহ। অনুগ্ৰহ কৰি পুনৰ লগিন কৰক।"
 
@@ -7813,9 +8770,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Power management settings"
 #~ msgstr "শক্তি ব্যৱস্থাপনা সংহতিসমূহ"
-
-#~ msgid "Change printer settings"
-#~ msgstr "প্ৰিন্টাৰ সংহতিসমূহ সলনি কৰক"
 
 #~ msgid "Manufacturers"
 #~ msgstr "নিৰ্মাতাসকল"
@@ -7860,9 +8814,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Region and Language"
 #~ msgstr "অঞ্চল আৰু ভাষা"
 
-#~ msgid "Select a display language"
-#~ msgstr "এটা প্ৰদৰ্শনৰ ভাষা বাছক"
-
 #~ msgid "Add Language"
 #~ msgstr "ভাষা যোগ কৰক"
 
@@ -7890,9 +8841,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Move Input Source Up"
 #~ msgstr "ইনপুট উৎসক উপৰত স্থানান্তৰ কৰক"
 
-#~ msgid "Show Keyboard Layout"
-#~ msgstr "কিবৰ্ড বিন্যাস দেখুৱাওক"
-
 #~ msgid "Ctrl+Alt+Space"
 #~ msgstr "Ctrl+Alt+Space"
 
@@ -7913,9 +8861,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "System settings"
 #~ msgstr "চিস্টেম সংহতিসমূহ"
-
-#~ msgid "Search settings"
-#~ msgstr "সংহতিসমূহ সন্ধান কৰক"
 
 #~ msgid "<b>Remote Login</b>"
 #~ msgstr "<b>দূৰৱৰ্তী লগিন</b>"
@@ -7991,9 +8936,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Browse Files..."
 #~ msgstr "ফাইলসমূহ ব্ৰাউছ কৰক..."
-
-#~ msgid "Create virtual device"
-#~ msgstr "ভাৰছুৱেল ডিভাইচ সৃষ্টি কৰক"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "প্ৰদৰ্শনৰ বাবে উপলব্ধ আলেখ্যসমূহ"
@@ -8139,14 +9081,8 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgstr ""
 #~ "এটা প্ৰদৰ্শন ভাষা বাছক (পৰিবৰ্তন আপুনি পৰৱৰ্তী বাৰ লগিন কৰোতে প্ৰয়োগ কৰা হব)"
 
-#~ msgid "Install languages..."
-#~ msgstr "ভাষাসমূহ ইনস্টল কৰক..."
-
 #~ msgid "Brightness & Lock"
 #~ msgstr "উজ্জ্বলতা & লক"
-
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "পৰ্দাৰ উজ্জ্বলতা আৰু লক সংহতিসমূহ"
 
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "উজ্জ্বলতা;লক;স্লান;ৰিক্ত;মনিটৰ;"
@@ -8162,9 +9098,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Locations..."
 #~ msgstr "অবস্থানসমূহ..."
-
-#~ msgid "Lock"
-#~ msgstr "লক"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "ডিবাগিং ক'ড সামৰ্থবান কৰক"
@@ -8184,14 +9117,8 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Sound Output Volume"
 #~ msgstr "শব্দ আউটপুট ভলিউম"
 
-#~ msgid "Microphone Volume"
-#~ msgstr "মাইক্ৰোফোন ভলিউম"
-
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "শব্দ পছন্দসমূহ আৰম্ভ কৰিবলে ব্যৰ্থ হল: %s"
-
-#~ msgid "_Mute"
-#~ msgstr "মৌণ কৰক (_M)"
 
 #~ msgid "_Sound Preferences"
 #~ msgstr "শব্দ পছন্দসমূহ (_S)"
@@ -8261,9 +9188,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "_Search by Address"
 #~ msgstr "ঠিকনাৰ সহায়ত সন্ধান কৰক (_S)"
 
-#~ msgid "Getting devices..."
-#~ msgstr "ডিভাইচসমূহ প্ৰাপ্ত কৰা হৈ আছে..."
-
 #~ msgid ""
 #~ "FirewallD is not running. Network printer detection needs services mdns, "
 #~ "ipp, ipp-client and samba-client enabled on firewall."
@@ -8278,9 +9202,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgctxt "printer type"
 #~ msgid "Network"
 #~ msgstr "নেটৱৰ্ক"
-
-#~ msgid "Device types"
-#~ msgstr "ডিভাই ধৰণসমূহ"
 
 #~ msgid "Automatic configuration"
 #~ msgstr "স্বচালিত সংৰূপ"
@@ -8327,9 +9248,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Take a screenshot"
 #~ msgstr "এটা স্ক্ৰিনশ্বট লওক"
 
-#~ msgid "Shortcut"
-#~ msgstr "চৰ্টকাট"
-
 #~ msgid "_Right-handed"
 #~ msgstr "সোঁহাতৰ (_R)"
 
@@ -8362,32 +9280,17 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Drag Threshold"
 #~ msgstr "টান্ ডেউৰী"
 
-#~ msgid "Double-Click Timeout"
-#~ msgstr "দুবাৰ ক্লিকৰ সময়সীমা"
-
 #~ msgid "_Timeout:"
 #~ msgstr "সময়অন্ত: (_T)"
 
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "টাচপেডৰ সৈতে মাউছ ক্লিকসমূহ সামৰ্থবান কৰক (_m)"
 
-#~ msgid "Scrolling"
-#~ msgstr "স্ক্রোল ব্যবস্থা"
-
 #~ msgid "_Disabled"
 #~ msgstr "নিষ্ক্ৰিয় (_D)"
 
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "সংৰূপণ কৰিবলে এটা ডিভাইচ বাছক (_h):"
-
-#~ msgid "Account _type"
-#~ msgstr "একাওন্টৰ ধৰণ (_t)"
-
 #~ msgid "_Back"
 #~ msgstr "পিছলৈ যাওক (_B)"
-
-#~ msgid "Printer Options"
-#~ msgstr "প্ৰিন্টাৰ বিকল্পসমূহ"
 
 #~ msgid "Allowed users"
 #~ msgstr "অনুমোদিত ব্যৱহাৰকাৰীসমূহ"
@@ -8478,20 +9381,11 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Layouts"
 #~ msgstr "পৰিকল্পনাসমূহ"
 
-#~ msgid "Layout"
-#~ msgstr "পৰিকল্পনা"
-
 #~ msgid "Change contrast:"
 #~ msgstr "কনট্ৰাস্ট পৰিবৰ্তন কৰক:"
 
 #~ msgid "_Text size:"
 #~ msgstr "লিখনি আকাৰ (_T):"
-
-#~ msgid "Increase size:"
-#~ msgstr "আকাৰ বৃদ্ধি কৰক:"
-
-#~ msgid "Decrease size:"
-#~ msgstr "আকাৰ সৰু কৰক:"
 
 #~ msgctxt "universal access, seeing"
 #~ msgid "Display"
@@ -8836,9 +9730,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "_Keyboard Accessibility"
 #~ msgstr "কি ফলকৰ সহায়ক প্ৰযুক্ত (_K)"
 
-#~ msgid "_Mouse Accessibility"
-#~ msgstr "মাউস ব্যবহাৰৰ সহায়ক প্ৰযুক্তি (_M)"
-
 #~ msgid "_Preferred Applications"
 #~ msgstr "পছন্দৰ এপ্লিকেচন (_P)"
 
@@ -8956,9 +9847,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Changing your cursor theme takes effect the next time you log in."
 #~ msgstr "ইয়াৰ পিছৰ বাৰ লগিন কৰোঁতে আপোনাৰ কাৰ্ছৰৰ থিম সলনি কৰা প্ৰযোজ্য হয়।"
 
-#~ msgid "Controls"
-#~ msgstr "নিয়ন্ত্ৰণ"
-
 #~ msgid "Customize Theme"
 #~ msgstr "স্বনিৰ্ধাৰিত থিম"
 
@@ -9068,9 +9956,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "অবিকল্পিত মান আকৌ স্থাপন কৰক(_R)"
-
 #~ msgid "_Selected items:"
 #~ msgstr "নিৰ্বাচিত বস্তু: (_S)"
 
@@ -9079,9 +9964,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "_Slight"
 #~ msgstr "স্বল্প (_S)"
-
-#~ msgid "_Style:"
-#~ msgstr "বিন্যাস:(_S)"
 
 #~ msgid "_Tooltips:"
 #~ msgstr "টুল-টিপ: (_T)"
@@ -9231,14 +10113,8 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Copying file: %u of %u"
 #~ msgstr "ফাইল নকল কৰা হৈছে: %u, %u ৰ"
 
-#~ msgid "Parent Window"
-#~ msgstr "ঊৰ্ধ্বতন সংযোগক্ষেত্ৰ"
-
 #~ msgid "Parent window of the dialog"
 #~ msgstr "বৰ্তমান সম্বাদৰ ঊৰ্ধ্বতন সংযোগক্ষেত্ৰ"
-
-#~ msgid "From URI"
-#~ msgstr "URI ৰ পৰা"
 
 #~ msgid "URI currently transferring from"
 #~ msgstr "যি URI ৰ পৰা বৰ্তমানে স্থানান্তৰিত হৈছে"
@@ -9248,9 +10124,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "URI currently transferring to"
 #~ msgstr "যি URI লৈ বৰ্তমানে স্থানান্তৰিত হৈছে"
-
-#~ msgid "Fraction completed"
-#~ msgstr "আংশিক সম্পন্ন"
 
 #~ msgid "Fraction of transfer currently completed"
 #~ msgstr "স্থানান্তৰিত ভগ্নাংশ তথ্যৰ পৰিমাণ"
@@ -9358,9 +10231,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Default Pointer - Current"
 #~ msgstr "অবিকল্পিত পইন্টাৰ - বৰ্তমানৰ"
-
-#~ msgid "White Pointer"
-#~ msgstr "বগা পইন্টাৰ"
 
 #~ msgid "White Pointer - Current"
 #~ msgstr "বগা পইন্টাৰ - বৰ্তমানৰ"
@@ -9493,9 +10363,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "GNOME Magnifier without Screen Reader"
 #~ msgstr "GNOME বিবৰ্ধক পৰ্দা পঢ়া ডিভাইচ নোহোৱাকৈ"
 
-#~ msgid "GNOME Terminal"
-#~ msgstr "GNOME Terminal"
-
 #~ msgid "Gnopernicus"
 #~ msgstr "Gnopernicus"
 
@@ -9574,9 +10441,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "Sylpheed-Claws"
 
-#~ msgid "Thunderbird"
-#~ msgstr "Thunderbird"
-
 #~ msgid "Totem Movie Player"
 #~ msgstr "Totem চলচ্চিত্ৰ বাদন ব্যৱস্থা"
 
@@ -9589,10 +10453,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Include _panel"
 #~ msgstr "পেনেল অন্তৰ্ভুক্ত কৰা হ'ব (_p)"
-
-#~| msgid "<b>Panel icon</b>"
-#~ msgid "Panel icon"
-#~ msgstr "প্যানেলেৰ আইকন"
 
 #~| msgid "Upside Down"
 #~ msgid "Upside-down"
@@ -9616,9 +10476,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Could not get session bus while applying display configuration"
 #~ msgstr "প্ৰদৰ্শন সংৰূপ প্ৰয়োগ কৰাৰ সময় সেশান বাস পাওয়া নাযায়"
-
-#~ msgid "Desktop"
-#~ msgstr "ডেস্কটপ"
 
 #~ msgid "Accelerator key"
 #~ msgstr "বেগবৰ্দ্ধক কি"
@@ -9771,9 +10628,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ "You can also use the Dwell Click panel applet to choose the click type."
 #~ msgstr "ক্লিকৰ ধৰন নির্বাচনেৰ জন্য Dwell Click প্যানেল অ্যাপ্লেট ব্যবহাৰ কৰা যাবে।"
 
-#~ msgid "_Acceleration:"
-#~ msgstr "গতিবৃদ্ধি (_A):"
-
 #~ msgid "_Single click:"
 #~ msgstr "এবাৰ টিপক (_S):"
 
@@ -9854,9 +10708,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Set your window properties"
 #~ msgstr "সংযোগক্ষেত্ৰৰ বৈশিষ্ট্য নিৰ্ধাৰণ কৰক"
 
-#~ msgid "Windows"
-#~ msgstr "সংযোগক্ষেত্ৰ"
-
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr "সংযোগক্ষেত্ৰ পৰিচালক \"%s\" কোনো বিন্যাস প্ৰক্ৰিয়া নিবন্ধন কৰা নাই\n"
 
@@ -9871,9 +10722,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Groups"
 #~ msgstr "দল"
-
-#~ msgid "Common Tasks"
-#~ msgstr "সাধাৰণ কৰ্ম"
 
 #~ msgid "Close the control-center when a task is activated"
 #~ msgstr "Close the control-center when a task is activated"
@@ -10053,10 +10901,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "Description:"
 #~ msgstr "বিৱৰণ:"
 
-#~| msgid "Install"
-#~ msgid "Installed"
-#~ msgstr "ইনস্টল কৰা হয়েছে"
-
 #~ msgid "usage: %s fontfile\n"
 #~ msgstr "ব্যৱহাৰবিধি: %s ফন্ট ফাইল\n"
 
@@ -10113,12 +10957,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "<b>Open</b>"
 #~ msgstr "<b>খোলক</b>"
 
-#~ msgid "Rename..."
-#~ msgstr "নাম পৰিবৰ্তন..."
-
-#~ msgid "Move to Trash"
-#~ msgstr "আবৰ্জনাৰ বাকসলৈ স্থানান্তৰ"
-
 #~ msgid "If you delete an item, it is permanently lost."
 #~ msgstr "If you delete an item, it is permanently lost."
 
@@ -10168,9 +11006,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ "সোঁহাতৰ মধ্যমা\n"
 #~ "সোঁহাতৰ অনামিকা\n"
 #~ "সোঁহাতৰ কনিষ্ঠা"
-
-#~ msgid "<b>Email</b>"
-#~ msgstr "<b>ঈ-মেইল</b>"
 
 #~ msgid "<b>Job</b>"
 #~ msgstr "<b>কৰ্মস্থল</b>"
@@ -10296,14 +11131,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
 #~ "\n"
 #~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
-
-#~ msgid "/_About"
-#~ msgstr "/বিষয়ে (_A)"
-
-#
-#~| msgid "C_ommand:"
-#~ msgid "_Command:"
-#~ msgstr "কমান্ড:(_C)"
 
 #~ msgid "Enable support for GNOME assistive technologies at login"
 #~ msgstr "লগিনৰ সময়ত GNOME ৰ সহায়ক প্ৰযুক্তি আৰম্ভ কৰক"
@@ -10436,9 +11263,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 #~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
 #~ msgstr "<span weight=\"bold\" size=\"x-large\">পৰীক্ষণ...</span>"
 
-#~ msgid "Click OK to finish."
-#~ msgstr "সমাপ্ত কৰিবলৈ ঠিক আছে টিপক"
-
 #~ msgid "E_nable software sound mixing (ESD)"
 #~ msgstr "E_nable software sound mixing (ESD)"
 
@@ -10454,9 +11278,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "Sou_nd capture:"
 #~ msgstr "Sou_nd capture:"
-
-#~ msgid "Sounds"
-#~ msgstr "শব্দ"
 
 #~ msgid "System Beep"
 #~ msgstr "চিস্টেমৰ বীপ ধ্বনি"
@@ -10522,9 +11343,6 @@ msgstr "পছন্দসমূহ;সংহতিসমূহ;"
 
 #~ msgid "The file %s is not a valid wav file"
 #~ msgstr "%s ফাইল কোনো বৈধ Wav ফাইল নহয়"
-
-#~ msgid "Sets the default application font"
-#~ msgstr "অবিকল্পিত এপ্লিকেচন ফন্টৰ ব্যৱহাৰ নিৰ্ধাৰণ কৰে"
 
 #~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
 #~ msgstr ""

--- a/po/as.po~
+++ b/po/as.po~
@@ -1,0 +1,10586 @@
+# translation of as.po to Assamese
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Amitakhya Phukan <amitakhya@svn.gnome.org>, 2008.
+# Amitakhya Phukan <aphukan@redhat.com>, 2008.
+# Amitakhya Phukan <aphukan@fedoraproject.org>, 2009.
+# Nilamdyuti Goswami <ngoswami@redhat.com>, 2012, 2013, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: as\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-08-20 06:31+0000\n"
+"PO-Revision-Date: 2014-08-20 13:00+0530\n"
+"Last-Translator: Nilamdyuti Goswami <ngoswami@redhat.com>\n"
+"Language-Team: Assamese <kde-i18n-doc@kde.org>\n"
+"Language: as\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1)\n"
+"X-Generator: Lokalize 1.5\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "পটভূমি"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "দিনটোত কৰা পৰিবৰ্তনসমূহ"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "Lock Screen"
+msgstr "পৰ্দা লক কৰক"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "টাইল"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "জুম"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "কেন্দ্ৰ"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "স্কেইল"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "পূৰ্ণ কৰক"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "বিস্তাৰ"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:442
+msgid "Select Background"
+msgstr "পটভূমি বাছক"
+
+#: ../panels/background/cc-background-chooser-dialog.c:463
+msgid "Wallpapers"
+msgstr "ৱালপেপাৰসমূহ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:472
+msgid "Pictures"
+msgstr "ছবিসমূহ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:481
+msgid "Colors"
+msgstr "ৰঙবোৰ"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:540
+msgid "No Pictures Found"
+msgstr "কোনো ছবি পোৱা নগল"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:558
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "গৃহ"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:570
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "আপুনি আপোনাৰ %s ফোল্ডাৰলৈ ছবি যোগ কৰিব পাৰিব আৰু সিহত ইয়াত দেখা যাব"
+
+#: ../panels/background/cc-background-chooser-dialog.c:592
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1537
+#: ../panels/display/cc-display-panel.c:1976
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1240
+#: ../panels/network/net-device-wifi.c:1448
+#: ../panels/printers/cc-printers-panel.c:1947
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+#: ../panels/user-accounts/um-photo-dialog.c:95
+#: ../panels/user-accounts/um-photo-dialog.c:222
+#: ../panels/user-accounts/um-user-panel.c:513
+msgid "_Cancel"
+msgstr "বাতিল কৰক (_C)"
+
+#: ../panels/background/cc-background-chooser-dialog.c:593
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:97
+msgid "Select"
+msgstr "বাছক"
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "একাধিক মাপ"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "কোনো ডেস্কটপ পটভূমি নাই"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "বৰ্তমান পটভূমী"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "আপোনাৰ পটভূমি ছবিক এটা ৱালপেপাৰ অথবা ফ'টোলে পৰিবৰ্তন কৰক"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "ৱালপেপাৰ;পৰ্দা;ডেস্কটপ;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "ব্লুটুথ অসামৰ্থবান"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "কোনো ব্লু-টুথ এডাপ্টাৰ পোৱা নগল"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "ব্লু-টুথ হাৰ্ডৱেৰ চুইচ দ্বাৰা অসামৰ্থবান"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+msgid "Bluetooth"
+msgstr "ব্লুটুথ"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "ব্লুটুথ অন বা অফ কৰক আৰু আপোনাৰ ডিভাইচসমূহ সংযোগ কৰক"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "আপোনাৰ মানাংকন ডিভাইচক বৰ্গৰ ওপৰত ৰাখি 'আৰম্ভ কৰক' টিপক"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr "আপোনাৰ মানাংকন ডিভাইচক মানাংকন অৱস্থানত ৰাখি 'অব্যাহত ৰাখক' টিপক"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr "আপোনাৰ মানাংকন ডিভাইচক পৃষ্ঠ অৱস্থানত ৰাখি 'অব্যাহত ৰাখক' টিপক"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "লেপটপ লিড বন্ধ কৰক"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "এটা অভ্যন্তৰীক ত্ৰুটি দেখা দিছে যাক উদ্ধাৰ কৰিব নোৱাৰি।"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "মানাংকনৰ বাবে প্ৰয়োজনীয় সঁজুলিসমূহ ইনস্টল্ড নাই।"
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "আলেখ্য সৃজন কৰিব পৰা নগল।"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "লক্ষ্য বগাবিন্দু অপ্ৰাপ্য আছিল।"
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "সম্পূৰ্ণ!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "মানাংকন ব্যৰ্থ হল!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "আপুনি মানাংকন ডিভাইচ আতৰাব পাৰে।"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "প্ৰগতিশীল অৱস্থাত মানাংকন ডিভাইচক অসুবিধা নিদিব"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "লেপটপৰ পৰ্দা"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "বিল্ট-ইন ৱেবকেম"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s মনিটৰ"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s স্কেনাৰ"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s কেমেৰা"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s প্ৰিন্টাৰ"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s ৱেবকেম"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s ৰ বাবে ৰঙ ব্যৱস্থাপনা সামৰ্থবান কৰক"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s ৰ বাবে ৰঙৰ আলেখ্যসমূহ দেখুৱাওক"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+msgid "Not calibrated"
+msgstr "মানাংকিত নহয়"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "অবিকল্পিত: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "ৰঙস্থান: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "আলেখ্য পৰীক্ষা কৰক: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "ICC আলেখ্য ফাইল বাছক"
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "ইমপোৰ্ট কৰক (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "সমৰ্থিত ICC আলেখ্যসমূহ"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "সৰ্বধৰণৰ ফাইল"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "পৰ্দা"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "ফাইল আপল'ড কৰিবলে ব্যৰ্থ: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "আলেখ্যক চিহ্নিত স্থানলৈ আপল'ড কৰা হৈছে:"
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "এই URL লিখি ৰাখক।"
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+"এই কমপিউটাৰ পুনৰাম্ভ কৰক আৰু আপোনাৰ স্বাভাৱিক অপাৰেটিং চিস্টেম বুট কৰক।"
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "আলেখ্যক ডাউনল'ড কৰি ইনস্টল কৰিবলে URL ক আপোনাৰ ব্ৰাউছাৰত টাইপ কৰক।"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "আলেখ্য সংৰক্ষণ কৰক"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "সংৰক্ষণ (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "নিৰ্বাচিত ডিভাইচৰ বাবে এটা ৰঙ আলেখ্য সৃষ্টি কৰক"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"মাপ লোৱা ডিভাইচ চিনাক্ত কৰা হোৱা নাই। অনুগ্ৰহ কৰি নিৰীক্ষণ কৰক ই চলি আছে আৰু "
+"সঠিকভাৱে সংযুক্ত।"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "মাপ লোৱা ডিভাইচয় প্ৰিন্টাৰ আলেখ্যকৰণ সমৰ্থন নকৰে।"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "ডিভাইচ ধৰণ বৰ্তমানে সমৰ্থিত নহয়।"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "প্ৰামাণিক স্থান"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "পৰীক্ষামূলক আলেখ্য"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "স্বচালিত"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "নিম্ন গুণ"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "মধ্যম গুণ"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "উচ্চ গুণ"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "অবিকল্পিত RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "অবিকল্পিত CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "অবিকল্পিত ধূসৰ"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "বিক্ৰেতা দ্বাৰা প্ৰদান কৰা কলঘৰ মানাংকিত তথ্য"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "এই আলেখ্যৰ সৈতে সম্পূৰ্ণ-পৰ্দা প্ৰদৰ্শন শুদ্ধ কৰা সম্ভব নহয়"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "এই আলেখ্য আৰু সঠিক নহব পাৰে"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "মানাংকন প্ৰদৰ্শন কৰক"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr "বাতিল কৰক"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "আৰম্ভ কৰক"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "অব্যাহত ৰাখক"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "কৰা হল"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "পৰ্দা মানাংকন"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"মানাংকনে এটা আলেখ্য উৎপন্ন কৰিব যি আপুনি আপোনাৰ পৰ্দাৰ ৰঙ ব্যৱস্থাপনা কৰাৰ "
+"বাবে "
+"ব্যৱহাৰ কৰিব পাৰিব। মানাংকনত যিমান অধিক সময় ব্যয় হব, ৰঙৰ আলেখ্য তিমান ভাল হব।"
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "মানাংকন হৈ থাকোতে আপুনি আপোনাৰ কমপিউটাৰ ব্যৱহাৰ কৰিব সক্ষম নহব।"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "গুণ"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "আনুমানিক সময়"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "মানাংকনৰ গুণ"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "মানাংকনৰ বাবে ব্যৱহাৰ কৰিব বিচৰা সংবেদনশীল ডিভাইচ বাছক।"
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "মানাংকন ডিভাইচ"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "সংযুক্ত থকা প্ৰদৰ্শনৰ ধৰণ বাছক।"
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "প্ৰদৰ্শনৰ ধৰণ"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"এটা প্ৰদৰ্শন লক্ষ্য বগা বিন্দু বাছক। বেছিৰভাগ প্ৰদৰ্শনক এটা D65 illuminant লে "
+"মানাংকন কৰিব লাগিব।"
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "আলেখ্য বগাবিন্দু"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"অনুগ্ৰহ কৰি আপোনাৰ বাবে অনুকূলিত এটা উজ্জ্বলতালে প্ৰদৰ্শন সংহতি কৰক। ৰঙ "
+"ব্যৱস্থাপনা এই "
+"উজ্জ্বলতা স্তৰত সঠিক হব।"
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"বিকল্পভাৱে, আপুনি এই ডিভাইচৰ বাবে অন্য আলেখ্যসমূহৰ এটাৰ সৈতে ব্যৱহাৰ কৰা "
+"উজ্জ্বলতা "
+"স্তৰ ব্যৱহাৰ কৰিব পাৰিব।"
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "প্ৰদৰ্শনৰ উজ্জ্বলতা"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"আপুনি বিভিন্ন কমপিউটাৰসমূহত এটা ৰঙৰ আলেখ্য ব্যৱহাৰ কৰিব পাৰিব, অথবা বিভিন্ন "
+"উজ্জ্বলতা স্তৰৰ বাবে আলেখ্যসমূহ সৃষ্টি কৰিব পাৰিব।"
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "আলেখ্যৰ নাম:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "আলেখ্যৰ নাম"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "আলেখ্য সফলভাৱে সৃষ্টি কৰা হৈছে!"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "আলেখ্য কপি কৰক"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "লিখিব পৰা মাধ্যমৰ প্ৰয়োজন"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "আলেখ্য আপল'ড কৰক"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "ইন্টাৰনেট সংযোগৰ প্ৰয়োজন"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"আলেখ্য কেনেকৈ ব্যৱহাৰ কৰিব লাগিব তাৰ বিষয়ে নিৰ্দেশসমূহ আপুনি <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> আৰু <a href=\"windows"
+"\">Microsoft Windows</a> চিস্টেমসমূহত পাব।"
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+msgid "Summary"
+msgstr "সাৰাংশ"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "ফাইল ইমপোৰ্ট কৰক…"
+
+#: ../panels/color/color.ui.h:29
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"সমস্যা দেখা দিছে। আলেখ্য সঠিকভাৱে কাম নকৰিব পাৰে। <a href=\"\">বিৱৰণ "
+"দেখুৱাওক।</"
+"a>"
+
+#: ../panels/color/color.ui.h:30
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"প্ৰতিটো ডিভাইচ ব্যৱস্থাপনা কৰিবলে এটা বৰ্তমান তাৰিখলে উন্নত এটা ৰঙ আলেখ্যৰ "
+"প্ৰয়োজন।"
+
+#: ../panels/color/color.ui.h:31
+msgid "Learn more"
+msgstr "অধিক জানক"
+
+#: ../panels/color/color.ui.h:32
+msgid "Learn more about color management"
+msgstr "ৰঙ ব্যৱস্থাপনাৰ বিষয়ে অধিক জানক"
+
+#: ../panels/color/color.ui.h:33
+msgid "Set for all users"
+msgstr "সকলো ব্যৱহাৰকাৰীৰ বাবে সংহত"
+
+#: ../panels/color/color.ui.h:34
+msgid "Set this profile for all users on this computer"
+msgstr "এই কমপিউটাৰৰ সকলো ব্যৱহাৰকাৰীৰ বাবে এই আলেখ্য সংহতি কৰক"
+
+#: ../panels/color/color.ui.h:35
+msgid "Enable"
+msgstr "সামৰ্থবান কৰক"
+
+#: ../panels/color/color.ui.h:36
+msgid "Add profile"
+msgstr "আলেখ্য যোগ কৰক"
+
+#: ../panels/color/color.ui.h:37
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate…"
+msgstr "মানাংকন কৰক…"
+
+#: ../panels/color/color.ui.h:38
+msgid "Calibrate the device"
+msgstr "ডিভাইচ মানাংকন কৰক"
+
+#: ../panels/color/color.ui.h:39
+msgid "Remove profile"
+msgstr "আলেখ্য আতৰাওক"
+
+#: ../panels/color/color.ui.h:40
+msgid "View details"
+msgstr "বিৱৰণসমূহ দৰ্শন কৰক"
+
+#: ../panels/color/color.ui.h:41
+msgid "Unable to detect any devices that can be color managed"
+msgstr "ৰঙ ব্যৱস্থাপনা কৰিব পৰা কোনো ডিভাইচ চিনাক্ত কৰিবলে অক্ষম"
+
+#: ../panels/color/color.ui.h:42
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:43
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:44
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:45
+msgid "Projector"
+msgstr "প্ৰক্ষেপক"
+
+#: ../panels/color/color.ui.h:46
+msgid "Plasma"
+msgstr "প্লাজমা"
+
+#: ../panels/color/color.ui.h:47
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL বেকলাইট)"
+
+#: ../panels/color/color.ui.h:48
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED বেকলাইট)"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (white LED backlight)"
+msgstr "LCD (বগা LED বেকলাইট)"
+
+#: ../panels/color/color.ui.h:50
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "বিস্তাৰিত gamut LCD (CCFL বেকলাইট)"
+
+#: ../panels/color/color.ui.h:51
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "বিস্তাৰিত gamut LCD (RGB LED বেকলাইট)"
+
+#: ../panels/color/color.ui.h:52
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "উচ্চ"
+
+#: ../panels/color/color.ui.h:53
+msgid "40 minutes"
+msgstr "৪০ মিনিট"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "মধ্যম"
+
+#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "৩০ মিনিট"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "নিম্ন"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "১৫ মিনিট"
+
+#: ../panels/color/color.ui.h:58
+msgid "Native to display"
+msgstr "প্ৰদৰ্শন কৰিবলে স্থানীয়"
+
+#: ../panels/color/color.ui.h:59
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (প্ৰিন্টিং আৰু প্ৰকাশন)"
+
+#: ../panels/color/color.ui.h:60
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:61
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (ফ'টোগ্ৰাফি আৰু গ্ৰাফিক্স)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "ৰঙ"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"আপোনাৰ ডিভাইচসমূহৰ ৰঙ মানাংকন কৰক, যেনে প্ৰদৰ্শনসমূহ, কেমেৰাসমূহ অথবা "
+"প্ৰিন্টাৰসমূহ"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "ৰঙ;ICC;আলেখ্য;মানাংকন;প্ৰিন্টাৰ;প্ৰদৰ্শন;"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:684
+msgid "United States"
+msgstr "মাৰ্কিণ যুক্তৰাষ্ট্ৰ"
+
+#: ../panels/common/cc-common-language.c:685
+msgid "Germany"
+msgstr "জাৰ্মানী"
+
+#: ../panels/common/cc-common-language.c:686
+msgid "France"
+msgstr "ফ্ৰাঞ্চ"
+
+#: ../panels/common/cc-common-language.c:687
+msgid "Spain"
+msgstr "স্পেইন"
+
+#: ../panels/common/cc-common-language.c:688
+msgid "China"
+msgstr "চীন"
+
+#: ../panels/common/cc-common-language.c:758
+msgid "Other…"
+msgstr "অন্য…"
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr "অধিক…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "কোনো ভাষা পোৱা নগল"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "ভাষা"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "কৰা হল (_D)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "জানুৱাৰী"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "ফেব্ৰুৱাৰী"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "মাৰ্চ"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "এপ্ৰিল"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "মে"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "জুন"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "জুলাই"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "আগষ্ট"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "চেপ্তেম্বৰ"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "অক্টোবৰ"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "নভেম্বৰ"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "ডিচেম্বৰ"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "তাৰিখ &সময়"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "ঘন্টা"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "মিনিট"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "দিন"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "মাহ"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "বছৰ"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Time Zone"
+msgstr "সময় অঞ্চল"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Search for a city"
+msgstr "এটা শহৰৰ বাবে সন্ধান কৰক"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Automatic _Date & Time"
+msgstr "স্বচালিত তাৰিখ আৰু সময় (_D)"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr "ইন্টাৰনেট সংযোগৰ প্ৰয়োজন"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Automatic Time _Zone"
+msgstr "স্বচালিত সময় অঞ্চল (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "Date & _Time"
+msgstr "তাৰিখ আৰু সময় (_T)"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr "সময় অঞ্চল (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:28
+msgid "Time _Format"
+msgstr "সময় বিন্যাস (_F)"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "২৪-ঘন্টা"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "তাৰিখ আৰু সময় পৰিবৰ্তন কৰক, সময় অঞ্চল অন্তৰ্ভুক্ত কৰাকৈ"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "ঘড়ি;সময়অঞ্চল;অৱস্থান;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "চিস্টেম সময় আৰু তাৰিখ সংহতিসমূহ পৰিবৰ্তন কৰক"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "সময় আৰু তাৰিখ সংহতিসমূহ পৰিবৰ্তন কৰিবলে, আপুনি প্ৰমাণীত হব লাগিব।"
+
+#: ../panels/display/cc-display-panel.c:487
+msgid "Lid Closed"
+msgstr "লিড বন্ধ"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+msgid "Mirrored"
+msgstr "মিৰৰড্"
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2145
+msgid "Primary"
+msgstr "প্ৰাথমিক"
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "অফ"
+
+#: ../panels/display/cc-display-panel.c:497
+msgid "Secondary"
+msgstr "দ্বিতীয়"
+
+#: ../panels/display/cc-display-panel.c:1533
+msgid "Arrange Combined Displays"
+msgstr "সংযুক্ত প্ৰদৰ্শনসমূহ সঁজাওক"
+
+#: ../panels/display/cc-display-panel.c:1539
+#: ../panels/display/cc-display-panel.c:1979
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+msgid "_Apply"
+msgstr "প্ৰয়োগ কৰক (_A)"
+
+#: ../panels/display/cc-display-panel.c:1560
+msgid "Drag displays to rearrange them"
+msgstr "প্ৰদৰ্শনসমূহক পুনৰ সংঘঠিত কৰিবলৈ সিহতক সঁজাওক"
+
+#: ../panels/display/cc-display-panel.c:2081
+msgid "Size"
+msgstr "আকাৰ"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2094
+msgid "Aspect Ratio"
+msgstr "অনুপাত হাৰ"
+
+#: ../panels/display/cc-display-panel.c:2115
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "বিভেদন"
+
+#: ../panels/display/cc-display-panel.c:2146
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "এই প্ৰদৰ্শনত ওপৰ বাৰ আৰু কাৰ্য্যসমূহ অভাৰভিউ দেখুৱাওক"
+
+#: ../panels/display/cc-display-panel.c:2152
+msgid "Secondary Display"
+msgstr "দ্বিতীয় প্ৰদৰ্শন"
+
+#: ../panels/display/cc-display-panel.c:2153
+msgid "Join this display with another to create an extra workspace"
+msgstr "এটা অতিৰিক্ত কৰ্মস্থান সৃষ্টি কৰিবলৈ এই প্ৰদৰ্শনক অন্যৰ সৈতে লগ লগাওক"
+
+#: ../panels/display/cc-display-panel.c:2160
+msgid "Presentation"
+msgstr "পৰিৱেশন"
+
+#: ../panels/display/cc-display-panel.c:2161
+msgid "Show slideshows and media only"
+msgstr "কেৱল স্লাইডশ্ব আৰু মাধ্যম দেখুৱাওক"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2166
+msgid "Mirror"
+msgstr "মিৰৰ"
+
+#: ../panels/display/cc-display-panel.c:2167
+msgid "Show your existing view on both displays"
+msgstr "দুয়োটা প্ৰদৰ্শনত আপোনাৰ স্থায়ী দৰ্শন দেখুৱাওক"
+
+#: ../panels/display/cc-display-panel.c:2173
+msgid "Turn Off"
+msgstr "বন্ধ কৰক"
+
+#: ../panels/display/cc-display-panel.c:2174
+msgid "Don't use this display"
+msgstr "এই প্ৰদৰ্শন ব্যৱহাৰ নকৰিব"
+
+#: ../panels/display/cc-display-panel.c:2383
+msgid "Could not get screen information"
+msgstr "পৰ্দা পৰিবৰ্তন প্ৰাপ্ত কৰিবলৈ ব্যৰ্থ"
+
+#: ../panels/display/cc-display-panel.c:2414
+msgid "_Arrange Combined Displays"
+msgstr "সংযুক্ত প্ৰদৰ্শনসমূহ সঁজাওক (_A)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "প্ৰদৰ্শনসমূহ"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr "সংযুক্ত মনিটৰসমূহ আৰু প্ৰক্ষেপকসমূহ কিধৰণে ব্যৱহাৰ কৰিব বাছক"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr "Wayland"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "অজ্ঞাত"
+
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-bit"
+
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr "%d-bit"
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr "কি কৰা হব সোধক"
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr "একো নকৰিব"
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr "ফোল্ডাৰ খোলক"
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr "অন্য মাধ্যম"
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr "অডিঅ' CDসমূহৰ বাবে এটা এপ্লিকেচন বাছক"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr "ভিডিঅ' DVDসমূহৰ বাবে এটা এপ্লিকেচন বাছক"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr "যেতিয়া এটা সংগীত প্লেয়াৰ সংযুক্ত থাকে চলাবলে এটা এপ্লিকেচন বাছক"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr "যেতিয়া এটা কেমেৰা সংযুক্ত তেতিয়া চলিবলে এটা এপ্লিকেচন বাছক"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr "চফ্টৱেৰ CDসমূহৰ বাবে এটা এপ্লিকেচন বাছক"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr "অডিঅ' DVD"
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr "ৰিক্ত Blu-ray ডিস্ক"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr "ৰিক্ত CD ডিস্ক"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr "ৰিক্ত DVD ডিস্ক"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr "ৰিক্ত HD DVD ডিস্ক"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr "Blu-ray ভিডিঅ' ডিস্ক"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr "e-book ৰিডাৰ"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr "HD DVD ভিডিঅ' ডিস্ক"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr "ছবি CD"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr "চুপাৰ ভিডিঅ' CD"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr "ভিডিঅ' CD"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr "Windows চফ্টৱেৰ"
+
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1917
+msgid "Section"
+msgstr "অংশ"
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "অভাৰভিউ"
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "অবিকল্পিত এপ্লিকেচনসমূহ"
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "আতৰাব পৰা মাধ্যম"
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr "সংস্কৰণ %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:44
+msgid "Details"
+msgstr "বিৱৰণসমূহ"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "আপোনাৰ চিস্টেমৰ বিষয়ে তথ্য চাওক"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ডিভাইচ;চিস্টেম;তথ্য;মেমৰি;প্ৰচেছৰ;সংস্কৰণ;অবিকল্পিত;এপ্লিকেচন;পছন্দ;cd;dvd;usb"
+";"
+"অডিঅ';ভিডিঅ';ডিস্ক;আতৰাব পৰা;মাধ্যম;স্বচলন;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "মাধ্যম কেনেধৰণে নিয়ন্ত্ৰণ কৰা হব বাছক"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "কাৰ্য্য (_A):"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "ধৰণ (_T):"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "ডিভাইচ নাম"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "মেমৰি"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "প্ৰচেছৰ"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "ভিত্তি চিস্টেম"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "ডিস্ক"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "গণনা কৰা হৈ আছে…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "গ্ৰাফিক্স"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "ভাৰছুৱেলাইজেষণ"
+
+#: ../panels/info/info.ui.h:13
+msgid "Check for updates"
+msgstr "আপডেইসমূহৰ বাবে নিৰীক্ষণ কৰক"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "ৱেব (_W)"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "মেইল (_M)"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "কেলেন্ডাৰ (_C)"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "সংগীত (_u)"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "ভিডিঅ' (_V)"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "ছবিসমূহ (_P)"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "মাধ্যম কেনেধৰণে নিয়ন্ত্ৰণ কৰা হব বাছক"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "CD অডিঅ' (_a)"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "DVD ভিডিঅ' (_D)"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "সংগীত প্লেয়াৰ (_M)"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "চফ্টৱেৰ (_S)"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "অন্য মাধ্যম (_O)…"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr "মাধ্যম সুমুৱাত কেতিয়াও প্ৰগ্ৰামসমূহ প্ৰমপ্ট অথবা আৰম্ভ নকৰিব (_N)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "শব্দ আৰু মাধ্যম"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "ভলিউম মৌণ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "ভলিউম কম"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "ভলিউম বৃদ্ধি"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "মিডিয়া প্লেয়াৰ আৰম্ভ কৰক"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "চলাওক (অথবা চলাওক/ৰখাওক)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "প্লেবেক ৰখাওক"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "প্লেবেক ৰখাওক"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "পূৰ্বৱৰ্তী ট্ৰেক"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "পৰৱৰ্তী ট্ৰেক"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "উলাওক"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "টাইপিং"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "পৰৱৰ্তী ইনপুট উৎসলে যাওক"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "পূৰ্বৱৰ্তী ইনপুট উৎসলে যাওক"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "আৰম্ভকসমূহ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "সহায় ব্ৰাউছাৰ আৰম্ভ কৰক"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "সংহতিসমূহ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "গণক আৰম্ভ কৰক"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "ই-মেইল ক্লাএন্ট আৰম্ভ কৰক"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "ৱেব ব্ৰাউছাৰ আৰম্ভ কৰক"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "ঘৰ ফোল্ডাৰ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "সন্ধান কৰক"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "স্ক্ৰিনশ্বটসমূহ"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "এটা স্ক্ৰিনশ্বটক $PICTURES সংৰক্ষণ কৰক"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "এটা উইন্ডোৰ স্ক্ৰিনশ্বটক $PICTURES ত সংৰক্ষণ কৰক"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "এটা স্থানৰ স্ক্ৰিনশ্বটক $PICTURES ত সংৰক্ষণ কৰক"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "এটা স্ক্ৰিনশ্বটক ক্লিপবৰ্ডলে কপি কৰক"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "এটা উইন্ডোৰ স্ক্ৰিনশ্বটক ক্লিপবৰ্ডলে কপি কৰক"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "এটা স্থানৰ স্ক্ৰিনশ্বটক ক্লিপবৰ্ডলে কপি কৰক"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "এটা সৰু স্ক্ৰিনকাস্ট ৰেকৰ্ড কৰক"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "চিস্টেম"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "লগ আউট কৰক"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "পৰ্দা লক কৰক"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "সাৰ্বভৈমক অভিগম"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "জুম অন বা অফ কৰক"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "ডাঙৰ কৰি দেখুৱাওক"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "সৰু কৰি দেখুৱাওক"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "স্ক্ৰিন ৰিডাৰ অন বা অফ কৰক"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "অন-স্ক্ৰিন কিবৰ্ড অন অথবা অফ কৰক"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "লিখনি আকাৰ ডাঙৰ কৰক"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "লিখনি আকাৰ সৰু কৰক"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "উচ্চ কন্ট্ৰাস্ট অন বা অফ কৰক"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1217
+#: ../panels/network/network-wifi.ui.h:29
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+#: ../panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Disabled"
+msgstr "নিষ্ক্ৰীয়"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "বৈকল্পিক আখৰসমূহ চাবি"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "কি' ৰচনা কৰক"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "পৰিবৰ্তক-কেৱল পৰৱৰ্তী উৎসলে যাওক"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "কিবৰ্ড"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"কিবৰ্ড চৰ্টকাটসমূহ দৰ্শন কৰক আৰু পৰিবৰ্তন কৰক আৰু আপোনাৰ টাইপিং পছন্দসমূহ "
+"সংহতি কৰক"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "চৰ্টকাট;পুনৰাবৃত্তি;পিৰিকিয়া;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "স্বনিৰ্ধাৰিত চৰ্টকাট"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr "যোগ কৰক (_A)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "নাম :(_N)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "কমান্ড:(_o)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "পুনৰাবৃত্তিৰ-কি"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "কি টিপি ৰাখিলে অনবৰত লিখা হ'ব (_r)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "বিলম্ব (_D):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "গতি (_S):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "সৰু"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "লেহেম"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "কি পুনৰাবৃত্তিৰ হাৰ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "দীঘল"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "দ্ৰুত"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "কাৰ্চাৰৰ পিৰিকিয়া"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "আখৰৰ ক্ষেত্ৰত কাৰ্চাৰ পিৰিকিয়া (_b)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "গতি (_p):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "কাৰ্চাৰৰ পিৰিকিয়া গতি"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "ইনপুট উৎসসমূহ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "চৰ্টকাট যোগ কৰক"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "চৰ্টকাট আতৰাওক"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"এটা চৰ্টকাট সম্পাদন কৰিবলে, শাৰীত ক্লিক কৰক আৰু নতুন কিসমূহ ধৰি ৰাখক অথবা "
+"পৰিষ্কাৰ "
+"কৰিবলে Backspace টিপক।"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "চৰ্টকাটসমূহ"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:634
+#: ../panels/keyboard/keyboard-shortcuts.c:642
+msgid "Custom Shortcuts"
+msgstr "স্বনিৰ্ধাৰিত চৰ্টকাট"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:859
+msgid "<Unknown Action>"
+msgstr "<Unknown Action>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1356
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"চৰ্টকাট-কি হিচাপে \"%s\" ব্যবহাৰ কৰা নাযাব কাৰণ ইয়াৰ ফলস্বৰূপ এই কি ব্যবহাৰ "
+"কৰি "
+"একো টাইপ কৰা নাযাব।\n"
+"অনুগ্ৰহ কৰি Control, Alt বা Shift কিৰ একত্ৰিক ব্যবহাৰৰ প্ৰচেষ্টা কৰক।"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1386
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"চৰ্টকাট \"%s\" বৰ্তমানে\n"
+" \"%s\"ৰ বাবে ব্যবহৃত হৈছে"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1391
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "\"%s\" ত চৰ্টকাট স্থাপন কৰা হ'লে, \"%s\" চৰ্টকাটটো নিষ্ক্ৰিয় কৰা হ'ব।"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1397
+msgid "_Reassign"
+msgstr "পুনৰ ধাৰ্য্য (_R)"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1429
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"\"%s\" চৰ্টকাটৰ সৈতে এটা সংলঘ্ন \"%s\" চৰ্টকাট আছে। আপুনি ইয়াক স্বচালিতভাৱে "
+"\"%s"
+"\" লৈ সংহতি কৰিব খোজে নে?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1435
+#, c-format
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"\"%s\" বৰ্তমানে \"%s\" ৰ সৈতে সংলঘ্ন, এই চৰ্টকাট অসামৰ্থবান কৰা হ'ব যদি আপুনি "
+"আগবাঢ়ে।"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1441
+msgid "_Assign"
+msgstr "ধাৰ্য্য কৰক (_A)"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "আপোনাৰ সংহতিসমূহ পৰীক্ষা কৰক (_S)"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+msgid "Test Your Settings"
+msgstr "আপোনাৰ সংহতিসমূহ পৰীক্ষা কৰক"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "মাউছ & টাচপেড"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"আপোনাৰ মাউছ অথবা টাচপেডৰ সংবেদনশীলতা পৰিবৰ্তন কৰক আৰু সোঁ অথবা বাঁও হাত বাছক"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ট্ৰেকপেড;পোইন্টাৰ;ক্লিক;টেপ;দুবাৰ;বুটাম;ট্ৰেকবল;স্ক্ৰল;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "সাধাৰণ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "লেহেম"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "দুবাৰ-ক্লিক সময়অন্ত"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "দ্ৰুত"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "দুবাৰ-ক্লিক (_D)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "প্ৰাথমিক বুটাম (_b)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "বাওঁ (_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "সোঁ (_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "মাউছ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "পোইন্টাৰৰ গতি (_P)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "লেহেম"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "দ্ৰুত"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "টাচ-প্যাড"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "লেহেম"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "দ্ৰুত"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr "টাইপ কৰাৰ সময়ত অসামৰ্থবান কৰক (_t)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr "ক্লিক কৰিবলে টেপ কৰক (_c)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr "দুটা আঙুলি বিশিষ্ট স্ক্রোলিং (_f)"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "_Natural scrolling"
+msgstr "স্বাভাৱিক স্ক্রোলিং (_N)"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ক্লিক, দুবাৰ ক্লিক, স্ক্ৰল কৰি চাওক"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "পাঁচবাৰ ক্লিক, GEGL সময়!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "দুবাৰ ক্লিক, প্ৰাথমিক বুটাম"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "এবাৰ ক্লিক, প্ৰাথমিক বুটাম"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "দুবাৰ ক্লিক, মাজৰ বুটাম"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "এবাৰ ক্লিক, মাজৰ বুটাম"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "দুবাৰ ক্লিক, দ্বিতীয় বুটাম"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "এবাৰ ক্লিক, দ্বিতীয় বুটাম"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:366
+msgid "Air_plane Mode"
+msgstr "বিমান অৱস্থা (_p)"
+
+#: ../panels/network/cc-network-panel.c:965
+msgid "Network proxy"
+msgstr "নেটৱৰ্ক প্ৰক্সি"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1289
+msgid "The system network services are not compatible with this version."
+msgstr "চিস্টেম নেটৱৰ্ক সেৱাসমূহ এই সংস্কৰণৰ সৈতে সংগত নহয়।"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x সুৰক্ষা (_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "পৃষ্ঠা ১"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "বেনামী পৰিচয় (_m)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "অভ্যন্তৰীক প্ৰমাণীকৰণ (_a)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "পৃষ্ঠা ২"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Security"
+msgstr "সুৰক্ষা"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "স্বচালিত"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:217
+#: ../panels/network/net-device-wifi.c:378
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:221
+#: ../panels/network/net-device-wifi.c:383
+#: ../panels/network/network-wifi.ui.h:17
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:225
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:230
+msgid "Enterprise"
+msgstr "এন্টাৰপ্ৰাইজ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:235
+#: ../panels/network/net-device-wifi.c:368
+msgctxt "Wifi security"
+msgid "None"
+msgstr "কোনো নহয়"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "কেতিয়াও নহয়"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:819
+msgid "Today"
+msgstr "আজি"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:822
+msgid "Yesterday"
+msgstr "যোৱাকালি"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:472
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i দিন আগত"
+msgstr[1] "%i দিন আগত"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:529
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:558
+msgctxt "Signal strength"
+msgid "None"
+msgstr "কোনো নহয়"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:560
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "দুৰ্বল"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ঠিক আছে"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "ভাল"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "উত্তম"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:45
+msgid "Identity"
+msgstr "পৰিচয়"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "ঠিকনা"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "নেটমাস্ক"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "গেইটৱে"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "ঠিকনা মচি পেলাওক"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "যোগ কৰক"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "চাৰ্ভাৰ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "DNS চাৰ্ভাৰ মচি পেলাওক"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "মেট্ৰিক"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "পথ মচি পেলাওক"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:25
+msgid "Automatic (DHCP)"
+msgstr "স্বচালিত (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:24
+msgid "Manual"
+msgstr "হস্তচালিত"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "কেৱল স্থানীয়-সংযোগ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:46
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "উপসৰ্গ"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "স্বচালিত"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "স্বচালিত, কেৱল DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:47
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:49
+msgid "Reset"
+msgstr "পুনৰসংহতি কৰক"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "কোনো নহয়"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit কি (Hex অথবা ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-বিট পাচফ্ৰেইছ"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "চলমান WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 ব্যক্তিগত"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 এন্টাৰপ্ৰাইজ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:2
+msgid "Signal Strength"
+msgstr "সংকেতৰ শক্তি"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Link speed"
+msgstr "সংযোগৰ গতী"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 ঠিকনা"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 ঠিকনা"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:7
+msgid "Hardware Address"
+msgstr "হাৰ্ডৱেৰ ঠিকনা"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:8
+msgid "Default Route"
+msgstr "অবিকল্পিত পথ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:9
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "সৰ্বশেষ ব্যৱহৃত"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "টুইস্টেড পেয়াৰ (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "এটাচমেন্ট একক আন্তঃপৃষ্ঠ (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "মাধ্যম মুক্ত আন্তঃপৃষ্ঠ (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "নাম (_N)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:36
+msgid "_MAC Address"
+msgstr "MAC ঠিকনা (_M)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "MTU (_T)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "ক্লৌন্ড ঠিকনা (_C)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "বাইটসমূহ"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "অন্য ব্যৱহাৰকাৰীসকলৰ বাবে উপলব্ধ কৰক (_u)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "স্বচালিতভাৱে সংযোগ কৰক (_a)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "ফায়াৰৱাল অঞ্চল (_Z)"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "অবিকল্পিত"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "অঞ্চলে সংযোগৰ ভৰষা স্তৰৰ বিৱৰণ দিয়ে"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:22
+msgid "IPv_4"
+msgstr "IPv4 (_4)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:23
+msgid "_Addresses"
+msgstr "ঠিকনাসমূহ (_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "স্বচালিত DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Routes"
+msgstr "পথসমূহ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "স্বচালিত পথসমূহ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Use this connection _only for resources on its network"
+msgstr "এই সংযোগক কেৱল ইয়াৰ নেটৱৰ্কত থকা সম্পদৰ বাবে ব্যৱহাৰ কৰক (_o)"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:34
+msgid "IPv_6"
+msgstr "IPv6 (_6)"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "সংযোগ সম্পাদক খোলিবলে অক্ষম"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "নতুন আলেখ্য"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "বান্ধনী"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "দল"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "ব্ৰিজ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "VPN প্লাগিনসমূহ ল'ড কৰিব পৰা নগল"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "ফাইলৰ পৰা ইমপোৰ্ট কৰক…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "নেটৱৰ্ক সংযোগ যোগ কৰক"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Reset"
+msgstr "পুনৰ সংহতি কৰক (_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1449
+#: ../panels/network/network-wifi.ui.h:40
+msgid "_Forget"
+msgstr "পাহৰি যাওক (_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"এই নেটৱৰ্কৰ বাবে সংহতিসমূহ পুনৰ সংহতি কৰক, পাছৱৰ্ডসমূহ অন্তৰ্ভুক্ত কৰাকৈ, "
+"কিন্তু ইয়াক "
+"এটা পছন্দৰ নেটৱৰ্ক হিচাপে মনত ৰাখক"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"এই নেটৱৰ্কৰ সৈতে প্ৰসংগ কৰা সকলো বিৱৰণ আতৰাওক আৰু স্বচালিতভাৱে সংযোগ কৰাৰ "
+"চেষ্টা "
+"নকৰিব"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "S_ecurity"
+msgstr "সুৰক্ষা (_e)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "VPN সংযোগ ইমপোৰ্ট কৰিব নোৱাৰি"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"ফাইল '%s' পঢ়িব পৰা নাযায় অথবা পৰিচিত VPN সংযোগ তথ্য অন্তৰ্ভুক্ত নকৰে\n"
+"\n"
+"ত্ৰুটি: %s।"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "ইমপোৰ্ট কৰিবলে ফাইল বাছক"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1948
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:223
+msgid "_Open"
+msgstr "খোলক (_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "'\"%s\" নামৰ এটা ফাইল ইতিমধ্যে অস্তিত্ববান।"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "প্ৰতিস্থাপন কৰক (_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+"আপুনি %s ক আপুনি সংৰক্ষণ কৰি থকা VPN সংযোগৰ সৈতে প্ৰতিস্থাপন কৰিব বিচাৰে নে?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "VPN সংযোগ এক্সপোৰ্ট কৰিব নোৱাৰি"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN সংযোগ '%s' ক %s লে এক্সপোৰ্ট কৰিব নোৱাৰি।\n"
+"\n"
+"ত্ৰুটি: %s।"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+msgid "Export VPN connection"
+msgstr "VPN সংযোগ এক্সপোৰ্ট কৰক"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ত্ৰুটি: VPN সংযোগ সম্পাদক ল'ড কৰিবলে অক্ষম)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:12
+msgid "_SSID"
+msgstr "SSID (_S)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:13
+msgid "_BSSID"
+msgstr "BSSID (_B)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:16
+msgid "My Home Network"
+msgstr "মোৰ ঘৰ নেটৱৰ্ক"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "অন্য ব্যৱহাৰকাৰীসকলৰ বাবে উপলব্ধ কৰাওক (_o)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "নেটৱৰ্ক"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "ইন্টাৰনেটৰ সৈতে কেনেকৈ সংযোগ কৰিব নিয়ন্ত্ৰণ কৰক"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"নেটৱৰ্ক;বেতাঁৰ;Wi-Fi;Wifi;IP;LAN;প্ৰক্সি;WAN;ব্ৰডবেণ্ড;মডেম;ব্লুটুথ;vpn;vlan;b"
+"ridge;"
+"বান্ধনী;DNS;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "বণ্ড স্লেইভসমূহ"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(কোনো নহয়)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "ব্ৰিজ স্লেইভসমূহ"
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:458
+msgid "never"
+msgstr "কেতিয়াও নহয়"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:468
+msgid "today"
+msgstr "আজি"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:470
+msgid "yesterday"
+msgstr "যোৱাকালী"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP ঠিকনা"
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Last used"
+msgstr "সৰ্বশেষ ব্যৱহৃত"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "তাঁৰযুক্ত"
+
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1604
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "বিকল্পসমূহ…"
+
+#: ../panels/network/net-device-ethernet.c:474
+#, c-format
+msgid "Profile %d"
+msgstr "আলেখ্য %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "নতুন সংযোগ যোগ কৰক"
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr "দলৰ স্লেইভবোৰ"
+
+#: ../panels/network/net-device-wifi.c:1153
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"যদি আপোনাৰ ইন্টাৰনেটলে বেতাঁৰৰ বাহিৰে অন্য সংযোগ উপলব্ধ আছে, আপুনি ইয়াক অন্যৰ "
+"সৈতে "
+"অংশীদাৰী কৰিবলে এটা বেতাঁৰ হটস্পট সংস্থাপন কৰিব পাৰে।"
+
+#: ../panels/network/net-device-wifi.c:1157
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "বেতাঁৰ হটস্পট আৰম্ভ কৰিলে আপুনি <b>%s</b> ৰ পৰা বিচ্ছিন্নিত হব।"
+
+#: ../panels/network/net-device-wifi.c:1161
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"হটস্পট সক্ৰিয় থকা অৱস্থাত আপোনাৰ বেতাঁৰৰ সহায়ত ইন্টাৰনেট অভিগম কৰাটো সম্ভব "
+"নহয়।"
+
+#: ../panels/network/net-device-wifi.c:1238
+msgid "Stop hotspot and disconnect any users?"
+msgstr "হটস্পট বন্ধ কৰি কোনো ব্যৱহাৰকাৰী বিচ্ছিন্ন কৰিব নে?"
+
+#: ../panels/network/net-device-wifi.c:1241
+msgid "_Stop Hotspot"
+msgstr "হটস্পট বন্ধ কৰক (_S)"
+
+#: ../panels/network/net-device-wifi.c:1313
+msgid "System policy prohibits use as a Hotspot"
+msgstr "চিস্টেমৰ নীতিয়ে হটস্পট হিচাপে ব্যৱহাৰ নিষিদ্ধ কৰে"
+
+#: ../panels/network/net-device-wifi.c:1316
+msgid "Wireless device does not support Hotspot mode"
+msgstr "বেতাঁৰ ডিভাইচে হটস্পট অৱস্থা সমৰ্থন নকৰে"
+
+#: ../panels/network/net-device-wifi.c:1445
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"নিৰ্বাচিত নেটৱৰ্কসমূহৰ বাবে নেটৱৰ্ক বিৱৰণসমূহ, লগতে পাছৱৰ্ডসমূহ আৰু কোনো "
+"স্বনিৰ্বাচিত "
+"সংৰূপ হেৰাই যাব।"
+
+#: ../panels/network/net-device-wifi.c:1753
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "ইতিহাস"
+
+#: ../panels/network/net-device-wifi.c:1757
+#: ../panels/wacom/cc-wacom-page.c:533
+msgid "_Close"
+msgstr "বন্ধ কৰক (_C)"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1765
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "পাহৰি যাওক (_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "যেতিয়া এটা সংৰূপ URL প্ৰদান কৰা নহয় ৱেব প্ৰক্সি স্বখোজ ব্যৱহাৰ কৰা হয়।"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "ই ভৰষাহিন ৰাজহুৱা নেটৱৰ্কসমূহৰ বাবে উপদেশিত নহয়।"
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "প্ৰক্সি"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "আলেখ্য যোগ কৰক (_A)…"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "প্ৰদানকাৰী"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "কোনো নহয়"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "হস্তচালিত"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "স্বচালিত"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "পদ্ধতি (_M)"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "সংৰূপ URL (_C)"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "HTTP প্ৰক্সি (_H)"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "HTTP প্ৰক্সি (_T)"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "FTP প্ৰক্সি (_F)"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "চক্স হস্ট (_S)"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "হস্টসমূহ উপেক্ষা কৰক (_I)"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "HTTP প্ৰক্সি পোৰ্ট"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "HTTP প্ৰক্সি পোৰ্ট"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "FTP প্ৰক্সি পোৰ্ট"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "চক্স প্ৰক্সি পোৰ্ট"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "ডিভাইচ বন্ধ কৰক"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "ডিভাইচ যোগ কৰক"
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "ডিভাইচ আতৰাওক"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN ধৰণ"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "দলৰ নাম"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "দল পাছৱৰ্ড"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "ব্যৱহাৰকাৰীনাম"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "VPN সংযোগ বন্ধ কৰক"
+
+#: ../panels/network/network-wifi.ui.h:1
+msgid "Automatic _Connect"
+msgstr "স্বচালিত সংযোগ (_C)"
+
+#: ../panels/network/network-wifi.ui.h:11
+msgid "details"
+msgstr "বিৱৰণসমূহ"
+
+#: ../panels/network/network-wifi.ui.h:15
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "পাছৱৰ্ড (_P)"
+
+#: ../panels/network/network-wifi.ui.h:18
+msgid "None"
+msgstr "শূণ্য"
+
+#: ../panels/network/network-wifi.ui.h:19
+msgid "Show P_assword"
+msgstr "পাছৱৰ্ড দেখুৱাওক (_a)"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "Make available to other users"
+msgstr "অন্য ব্যৱহাৰকাৰীসকলৰ বাবে উপলব্ধ কৰাওক"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "identity"
+msgstr "পৰিচয়"
+
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Automatic (DHCP) addresses only"
+msgstr "কেৱল স্বচালিত (DHCP) ঠিকনাসমূহ"
+
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Link-local only"
+msgstr "কেৱল স্থানীয়-সংযোগ"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Shared with other computers"
+msgstr "অন্য কমপিউটাৰৰ সৈতে অংশীদাৰী কৰা আছে"
+
+#: ../panels/network/network-wifi.ui.h:31
+msgid "_Ignore automatically obtained routes"
+msgstr "স্বচালিতভাৱে প্ৰাপ্ত পথসমূহ উপেক্ষা কৰক (_I)"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "_Cloned MAC Address"
+msgstr "ক্লৌন্ড MAC ঠিকনা (_C)"
+
+#: ../panels/network/network-wifi.ui.h:38
+msgid "hardware"
+msgstr "হাৰ্ডৱেৰ"
+
+#: ../panels/network/network-wifi.ui.h:41
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"এই সংযোগৰ বাবে সংহতিসমূহক তাৰ অবিকল্পিতলে পুনৰসংহতি কৰক, কিন্তু এটা পছন্দৰ "
+"সংযোগ "
+"হিচাপে মনত ৰাখক।"
+
+#: ../panels/network/network-wifi.ui.h:42
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"এই নেটৱৰ্কৰ সৈতে প্ৰসংগ কৰা সকলো বিৱৰণ আতৰাওক আৰু স্বচালিতভাৱে ইয়াৰ সৈতে "
+"সংযোগ "
+"কৰাৰ চেষ্টা নকৰিব।"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid "reset"
+msgstr "পুনৰসংহতি কৰক"
+
+#: ../panels/network/network-wifi.ui.h:48
+msgid "Hardware"
+msgstr "হাৰ্ডৱেৰ"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi হটস্পট"
+
+#: ../panels/network/network-wifi.ui.h:51
+msgid "_Turn On"
+msgstr "আৰম্ভ কৰক (_T)"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi অন বা অফ কৰক"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "_Use as Hotspot…"
+msgstr "হটস্পট হিচাপে ব্যৱহাৰ কৰক (_U)…"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "_Connect to Hidden Network…"
+msgstr "লুকুৱা নেটৱৰ্কৰ সৈতে সংযোগ কৰক (_C)…"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_History"
+msgstr "ইতিহাস (_H)"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "এটা Wi-Fi নেটৱৰ্কৰ সৈতে সংযোগ কৰিবলে বন্ধ কৰক"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "Network Name"
+msgstr "নেটৱৰ্কৰ নাম"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Connected Devices"
+msgstr "সংযুক্ত ডিভাইচসমূহ"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Security type"
+msgstr "সুৰক্ষা ধৰণ"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Security key"
+msgstr "সুৰক্ষা কি'"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "এড-হক"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "আন্তঃগাঁথনি"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "অৱস্থা অজ্ঞাত"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "অব্যৱস্থাপিত"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "উপলব্ধ নাই"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "সংযোগ স্থাপন কৰা হৈছে..."
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "প্ৰমাণীকৰণৰ প্ৰয়োজন"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "সংযুক্ত"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "বিচ্ছিন্ন কৰা হৈ আছে"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "সংযোগ ব্যৰ্থ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "অৱস্থা অজ্ঞাত (সন্ধানহিন)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "সংযোগ বিহীন"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "সংৰূপ ব্যৰ্থ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "IP সংৰূপ ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "IP সংৰূপৰ অৱসান ঘটিল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "গোপনসমূহৰ প্ৰয়োজন আছিল, কিন্তু প্ৰদান কৰা হোৱা নাছিল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x সাপ্লিকেণ্ট বিচ্ছিন্নিত"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x সাপ্লিকেণ্ট সংৰূপ ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1x সাপ্লিকেণ্ট ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x সাপ্লিকেণ্ট প্ৰমাণীত হবলে বহু সময় ললে"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "PPP সেৱা আৰম্ভ হবলে ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "PPP সেৱা বিচ্ছিন্নিত হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "DHCP ক্লাএন্ট আৰম্ভ হবলে ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP ক্লাএন্ট ত্ৰুটি"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP ক্লাএন্ট ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "অংশীদাৰী সংযোগ সেৱা আৰম্ভ হবলে ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "অংশীদাৰী সংযোগ সেৱা ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "AutoIP সেৱা আৰম্ভ হবলে ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "AutoIP সেৱা ত্ৰুটি"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "AutoIP সেৱা ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "লাইন ব্যস্ত"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "কোনো ডায়েল শব্দ নাই"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "কোনো বাহক স্থাপন কৰিব পৰা নগল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "ডায়লিং অনুৰোধৰ সময় অন্ত হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "ডায়লিং চেষ্টা ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "মডেম আৰম্ভকৰণ ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "ধাৰ্য্যত APN নিৰ্বাচন কৰিবলে ব্যৰ্থ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "নেটৱৰ্কসমূহ সন্ধান কৰা হোৱা নাই"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "নেটৱৰ্ক ৰেজিষ্ট্ৰেষণ নাকচ কৰা হৈছে"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "নেটৱৰ্ক ৰেজিষ্ট্ৰেষণৰ সময় অন্ত হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "অনুৰোধ কৰা নেটৱৰ্কৰ সৈতে ৰেজিস্টাৰ কৰিবলে ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "PIN নিৰীক্ষণ ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "ডিভাইচৰ বাবে ফাৰ্মৱেৰ সন্ধানহিন হব পাৰে"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "সংযোগ নোহোৱা হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "স্থায়ী সংযোগ ধাৰনা কৰা হৈছিল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "মডেম পোৱা নগল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "ব্লুটুথ সংযোগ ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "SIM কাৰ্ড সুমুৱা হোৱা নাই"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "SIM ৰ Pin ৰ প্ৰয়োজন"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "SIM ৰ Puk ৰ প্ৰয়োজন"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "SIM ভুল"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "InfiniBand ডিভাইচে সংযুক্ত অৱস্থা সমৰ্থন নকৰে"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "সংযোগ নিৰ্ভৰতা ব্যৰ্থ হল"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "ফাৰ্মৱেৰ সন্ধানহীন"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "কেবুল আনপ্লাগ্গড"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "কোনো প্ৰমাণপত্ৰ কতৃপক্ষৰ প্ৰমাণপত্ৰ নিৰ্ব্বাচন কৰা নহয়"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"প্ৰমাণপত্ৰ কতৃপক্ষ (CA) প্ৰমাণপত্ৰ ব্যৱহাৰ নকৰিলে সুৰক্ষাবিহীন, বিপদজনক Wi-Fi "
+"নেটৱৰ্কৰ "
+"সৈতে সংযোগ স্থাপন কৰা হ'ব পাৰে। আপুনি এটা প্ৰমাণপত্ৰ কতৃপক্ষ প্ৰমাণপত্ৰ "
+"নিৰ্বাচন কৰিব "
+"বিচাৰে নেকি?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "উপেক্ষা কৰক"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "CA প্ৰমাণপত্ৰ বাছক"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, অথবা PKCS#12 ব্যক্তিগত কি'সমূহ (*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER অথবা PEM প্ৰমাণপত্ৰসমূহ (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+msgid "Choose a PAC file"
+msgstr "এটা PAC ফাইল বাছক"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC ফাইলসমূহ (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC ফাইল (_f)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "অভ্যন্তৰীক প্ৰমাণীকৰণ (_I)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "PAC যোগান (_v)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "বেনামী"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "প্ৰমাণীত"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "দুয়ো"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "ব্যৱহাৰকাৰীনাম (_U)"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "পাছৱৰ্ড দেখুৱাওক (_w)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate"
+msgstr "এটা প্ৰমাণপত্ৰ কতৃপক্ষ প্ৰমাণপত্ৰ বাছক"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "সংস্কৰণ ০"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "সংস্কৰণ ১"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "CA প্ৰমাণপত্ৰ (_A)"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP সংস্কৰণ (_v)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "প্ৰতিবাৰ এই পাছৱৰ্ড বিচাৰিব (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "আনইনক্ৰিপ্টেড ব্যক্তিগত কি'সমূহ অসুৰক্ষিত"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"নিৰ্বাচিত ব্যক্তিগত কি' এটা পাছৱৰ্ড দ্বাৰা সুৰক্ষিত যেন নালাগে। ইয়াৰ বাবে "
+"আপোনাৰ "
+"সুৰক্ষা তথ্যসমূহ আপোচ হব পাৰে। অনুগ্ৰহ কৰি এটা পাছৱৰ্ড-সুৰক্ষিত ব্যক্তিগত কি' "
+"বাছক।\n"
+"\n"
+"(আপুনি openssl ৰ সৈতে আপোনাৰ ব্যক্তিগত কি' পাছৱৰ্ড-সুৰক্ষিত কৰিব পাৰিব)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+msgid "Choose your personal certificate"
+msgstr "আপোনাৰ ব্যক্তিগত প্ৰমাণপত্ৰ বাছক"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+msgid "Choose your private key"
+msgstr "আপোনাৰ ব্যক্তিগত কি' বাছক"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "পৰিচয় (_d)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "ব্যৱহাৰকাৰী প্ৰমাণপত্ৰ (_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "ব্যক্তিগত কি' (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "ব্যক্তিগত কি' পাছৱৰ্ড (_P)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "মোক আকৌ সতৰ্ক নকৰিব (_w)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "নহয়"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "হয়"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "টানেল্ড TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "সুৰক্ষিত EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "প্ৰমাণীকৰণ (_t)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "১ (অবিকল্পিত)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "২"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "৩"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "৪"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "খোলা চিস্টেম"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "অংশীদাৰী কৰা কি'"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "কি' (_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "কি' দেখুৱাওক (_w)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP সূচী (_x)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "ধৰণ (_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "অধিসূচনাসমূহ"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "শব্দ সতৰ্কবাৰ্তাসমূহ"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "পপআপ বেনাৰসমূহ দেখুৱাওক"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "বেনাৰসমূহত বিৱৰণসমূহ দেখুৱাওক"
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "পৰ্দা লক কৰাত দৰ্শন কৰক"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "পৰ্দা লক কৰাত বিৱৰণসমূহ দেখুৱাওক"
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "অন "
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "অধিসূচনাসমূহ"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr "কোনবোৰ অধিসূচনা প্ৰদৰ্শন কৰা হব আৰু সিহতে কি দেখুৱাব নিয়ন্ত্ৰণ কৰক"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Banner;Message;Tray;Popup;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "পপআপ বেনাৰসমূহ দেখুৱাওক"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "পৰ্দা লক কৰাত দেখুৱাওক"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+msgctxt "Online Account"
+msgid "Other"
+msgstr "অন্য"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "একাওন্ট যোগ কৰক"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr "মেইল"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr "পৰিচয়সমূহ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "চেট"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "সম্পদসমূহ"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "একাওন্টলে লগিন কৰোতে ত্ৰুটি"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "তথ্যসমূহৰ অৱসান ঘটিছে।"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr "এই একাওন্ট সামৰ্থবান কৰিবলে ছাইন ইন কৰক।"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr "ছাইন ইন কৰক (_S)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "একাওন্ট সৃষ্টি কৰোতে ত্ৰুটি"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "একাওন্ট আতৰাওতে ত্ৰুটি"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "আপুনি নিশ্চিত নে আপুনি একাওন্ট আতৰাব বিচাৰে?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "ই চাৰ্ভাৰত একাওন্টক আতৰাই নিদিয়ে।"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "আতৰাওক (_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "অনলাইন একাওন্টসমূহ"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"আপোনাৰ অনলাইন একাওন্টসমূহৰ সৈতে সংযোগ কৰক আৰু সিহতক কিহৰ বাবে ব্যৱহাৰ কৰিব "
+"নিৰ্ধাৰণ কৰক"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "সংৰূপিত কোনো অনলাইন একাওন্ট নাই"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "একাওন্ট আতৰাওক"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "এটা অনলাইন একাওন্ট যোগ কৰক"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"এটা একাওন্টে যোগ কৰিলে আপোনাৰ এপ্লিকেচনে ইয়াক দস্তাবেজসমূহ, মেইল, পৰিচয়সমূহ, "
+"কেলেন্ডাৰ, চেট আৰু অধিকৰ বাবে অভিগম কৰিবলে অনুমতি প্ৰাপ্ত কৰে।"
+
+#: ../panels/power/cc-power-panel.c:183
+msgid "Unknown time"
+msgstr "অজ্ঞাত সময়"
+
+#: ../panels/power/cc-power-panel.c:189
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i মিনিট"
+msgstr[1] "%i মিনিট"
+
+#: ../panels/power/cc-power-panel.c:201
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ঘন্টা"
+msgstr[1] "%i ঘন্টা"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:209
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:210
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ঘন্টা"
+msgstr[1] "ঘন্টা"
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "মিনিট"
+msgstr[1] "মিনিট"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:230
+#, c-format
+msgid "%s until fully charged"
+msgstr "সম্পূৰ্ণ চাৰ্জ হবলে %s অৱশিষ্ট"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:237
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "সাৱধান: %s অৱশিষ্ট"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:242
+#, c-format
+msgid "%s remaining"
+msgstr "%s অৱশিষ্ট"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
+msgid "Fully charged"
+msgstr "সম্পূৰ্ণ চাৰ্জ হৈছে"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
+msgid "Empty"
+msgstr "ৰিক্ত"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Charging"
+msgstr "চাৰ্জ কৰা হৈ আছে"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:271
+msgid "Discharging"
+msgstr "চাৰ্জ শেষ হৈ আছে"
+
+#: ../panels/power/cc-power-panel.c:396
+msgctxt "Battery name"
+msgid "Main"
+msgstr "মূখ্য"
+
+#: ../panels/power/cc-power-panel.c:398
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "অতিৰিক্ত"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:470
+msgid "Wireless mouse"
+msgstr "বেতাঁৰ মাউছ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:473
+msgid "Wireless keyboard"
+msgstr "বেতাঁৰ কিবৰ্ড"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:476
+msgid "Uninterruptible power supply"
+msgstr "ব্যাঘাতহিন শক্তিৰ যোগান"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Personal digital assistant"
+msgstr "ব্যক্তিগত অঙ্কীয় সহায়ক"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Cellphone"
+msgstr "চেলফোন"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Media player"
+msgstr "মিডিয়া প্লেয়াৰ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Tablet"
+msgstr "টেবলেট"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Computer"
+msgstr "কমপিউটাৰ"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
+#: ../panels/power/cc-power-panel.c:2019
+msgid "Battery"
+msgstr "বেটাৰি"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "চাৰ্জ কৰা হৈ আছে"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "সাৱধানী"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Low"
+msgstr "নিম্ন"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Good"
+msgstr "ভাল"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "সম্পূৰ্ণ চাৰ্জ হৈছে"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "ৰিক্ত"
+
+#: ../panels/power/cc-power-panel.c:715
+msgid "Batteries"
+msgstr "বেটাৰিসমূহ"
+
+#: ../panels/power/cc-power-panel.c:1117
+msgid "When _idle"
+msgstr "যেতিয়া অলস (_i)"
+
+#: ../panels/power/cc-power-panel.c:1445
+msgid "Power Saving"
+msgstr "শক্তি সংৰক্ষণ কৰা"
+
+#: ../panels/power/cc-power-panel.c:1473
+msgid "_Screen brightness"
+msgstr "পৰ্দাৰ উজ্জ্বলতা (_S)"
+
+#: ../panels/power/cc-power-panel.c:1479
+msgid "_Keyboard brightness"
+msgstr "কিবৰ্ডৰ উজ্জ্বলতা (_K)"
+
+#: ../panels/power/cc-power-panel.c:1489
+msgid "_Dim screen when inactive"
+msgstr "যেতিয়া নিষ্ক্ৰিয় তেতিয়া পৰ্দা স্লান কৰিব (_D)"
+
+#: ../panels/power/cc-power-panel.c:1514
+msgid "_Blank screen"
+msgstr "ৰিক্ত পৰ্দা (_B)"
+
+#: ../panels/power/cc-power-panel.c:1551
+msgid "_Wi-Fi"
+msgstr "Wi-Fi (_W)"
+
+#: ../panels/power/cc-power-panel.c:1556
+msgid "Turns off wireless devices"
+msgstr "বেতাঁৰ ডিভাইচসমূহ বন্ধ কৰে"
+
+#: ../panels/power/cc-power-panel.c:1581
+msgid "_Mobile broadband"
+msgstr "মবাইল ব্ৰডবেণ্ড (_M)"
+
+#: ../panels/power/cc-power-panel.c:1586
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "মবাইল ব্ৰডবেণ্ড (3G, 4G, WiMax, ইত্যাদি) ডিভাইচসমূহ বন্ধ কৰে"
+
+#: ../panels/power/cc-power-panel.c:1635
+msgid "_Bluetooth"
+msgstr "ব্লুটুথ (_B)"
+
+#: ../panels/power/cc-power-panel.c:1686
+msgid "When on battery power"
+msgstr "যেতিয়া বেটাৰি শক্তিত চলি থাকে"
+
+#: ../panels/power/cc-power-panel.c:1688
+msgid "When plugged in"
+msgstr "যেতিয়া প্লাগ ইন কৰা আছে"
+
+#: ../panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Off"
+msgstr "স্থগিত কৰি বন্ধ কৰক"
+
+#: ../panels/power/cc-power-panel.c:1851
+msgid "_Automatic suspend"
+msgstr "স্বচালিতভাৱে স্থগিত কৰা (_A)"
+
+#: ../panels/power/cc-power-panel.c:1875
+msgid "When battery power is _critical"
+msgstr "যেতিয়া বেটাৰি শক্তি মাৰাত্মকভাৱে কম (_c)"
+
+#: ../panels/power/cc-power-panel.c:1930
+msgid "Power Off"
+msgstr "বন্ধ কৰক"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Devices"
+msgstr "ডিভাইচ"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "শক্তি"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr "আপোনাৰ বেটাৰিৰ অৱস্থা চাওক আৰু শক্তি সংৰক্ষণ সংহতিসমূহ পৰিবৰ্তন কৰক"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "হাইবাৰনেইট"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "পাৱাৰ অফ"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "৪৫ মিনিট"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "১ ঘন্টা"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "৮০ মিনিট"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "৯০ মিনিট"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "১০০ মিনিট"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "২ ঘন্টা"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "১ মিনিট"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "২ মিনিট"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "৩ মিনিট"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "৪ মিনিট"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "৫ মিনিট"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "৮ মিনিট"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "১০ মিনিট"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "১২ মিনিট"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "স্বচালিতভাৱে স্থগিত কৰা"
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr "যেতিয়া প্লাগ ইন কৰা থাকে (_P)"
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr "বেটাৰি শক্তিত চলি আছে (_B)"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "বিলম্ব"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "প্ৰমাণীত কৰক"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "পাছৱৰ্ড"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "প্ৰমাণীকৰণৰ প্ৰয়োজন"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr "টনাৰ কম"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr "টনাৰ শেষ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr "উন্নয়নকাৰী কম"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr "উন্নয়নকাৰী নাই"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr "এটা মাৰ্কাৰ যোগানত কম"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr "এটা মাৰ্কাৰ যোগান শেষ"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr "প্ৰচ্ছেদ খোলক"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr "দৰ্জা খোলক"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr "কাগজ কম"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr "কাগজ শেষ"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr "অফলাইন"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "বন্ধ কৰা হল"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr "আবৰ্জনা গ্ৰাহক প্ৰায় ভৰ্তি"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr "আবৰ্জনা গ্ৰাহক পূৰ্ণ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr "অপ্টিকেল ফ'টো পৰিবাহক জীৱনৰ শেষ পৰ্যায়ত আছে"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr "অপ্টিকেল ফ'টো পৰিবাহক কাৰ্য্য কৰা নাই"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "সংৰূপণ কৰা হৈছে"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr "প্ৰস্তুত"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "কাৰ্য্যসমূহ গ্ৰহণ নকৰে"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr "প্ৰক্ৰিয়াকৰণ কৰা হৈছে"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Toner Level"
+msgstr "টনাৰ স্তৰ"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Ink Level"
+msgstr "কালীৰ স্তৰ"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:928
+msgid "Supply Level"
+msgstr "যোগান স্তৰ"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:946
+msgctxt "printer state"
+msgid "Installing"
+msgstr "ইনস্টল কৰা হৈছে"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1123
+msgid "No printers available"
+msgstr "কোনো প্ৰিন্টাৰ উপলব্ধ নাই"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1433
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u সক্ৰিয়"
+msgstr[1] "%u সক্ৰিয়"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1777
+msgid "Failed to add new printer."
+msgstr "নতুন প্ৰিন্টাৰ যোগ কৰিবলে ব্যৰ্থ।"
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid "Select PPD File"
+msgstr "PPD ফাইল বাছক"
+
+#: ../panels/printers/cc-printers-panel.c:1953
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"পস্টস্ক্ৰিপ্ট প্ৰিন্টাৰ বিৱৰণ ফাইলসমূহ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2258
+msgid "No suitable driver found"
+msgstr "কোনো উপযুক্ত ড্ৰাইভাৰ পোৱা নগল"
+
+#: ../panels/printers/cc-printers-panel.c:2327
+msgid "Searching for preferred drivers…"
+msgstr "পছন্দৰ ড্ৰাইভাৰসমূহৰ বাবে সন্ধান কৰা হৈছে…"
+
+#: ../panels/printers/cc-printers-panel.c:2342
+msgid "Select from database…"
+msgstr "ডাটাবেইচৰ পৰা বাছক…"
+
+#: ../panels/printers/cc-printers-panel.c:2351
+msgid "Provide PPD File…"
+msgstr "PPD ফাইল প্ৰদান কৰক…"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2502
+#: ../panels/printers/cc-printers-panel.c:2525
+msgid "Test page"
+msgstr "পৰীক্ষা পৃষ্ঠা"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2933
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui ল'ড কৰিব নোৱাৰি: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "প্ৰিন্টাৰসমূহ"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"প্ৰিন্টাৰসমূহ যোগ কৰক, প্ৰিন্টাৰ কাৰ্য্যসমূহ চাওক আৰু আপুনি কেনেধৰণে প্ৰিন্ট "
+"কৰিব বিচাৰে "
+"নিৰ্ধাৰণ কৰক"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "প্ৰিন্টাৰ;শাৰী;প্ৰিন্ট;কাগজ;কালী;টনাৰ;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "সক্ৰিয় কাৰ্য্যসমূহ"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "বন্ধ কৰক"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "প্ৰিন্টিং চলাই নিয়ক"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "প্ৰিন্টিং ৰখাওক"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "প্ৰিন্ট কাৰ্য্য বাতিল কৰক"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "এটা নতুন প্ৰিন্টাৰ যোগ কৰক"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "A_uthenticate"
+msgstr "প্ৰমাণীত কৰক (_u)"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "কোনো প্ৰিন্টাৰ চিনাক্ত কৰা হোৱা নাই।"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter address of a printer or a text to filter results"
+msgstr "ফলাফলসমূহ ফিল্টাৰ কৰিবলৈ এটা প্ৰিন্টাৰৰ ঠিকনা অথবা এটা লিখনি সুমুৱাওক"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "বিকল্পসমূহ ল'ড কৰা হৈছে…"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "প্ৰিন্টাৰ ড্ৰাইভাৰ বাছক"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "ড্ৰাইভাৰসমূহ ডাটাবেইচ ল'ড কৰা হৈছে..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+msgid "JetDirect Printer"
+msgstr "JetDirect প্ৰিন্টাৰ"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+msgid "LPD Printer"
+msgstr "LPD প্ৰিন্টাৰ"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "এক-ফলিয়া"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "দীঘল প্ৰান্ত (প্ৰামাণিক)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "চুটি প্ৰান্ত (লুটিৱাওক)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "পট্ৰেইট"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "লেণ্ডস্কেইপ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "উলোটা লেণ্ডস্কেইপ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "উলোটা পোট্ৰেইট"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "বাকি আছে"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "ধৰি ৰখা আছে"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "প্ৰক্ৰিয়াকৰণ কৰা হৈছে"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "বন্ধ কৰা হল"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "বাতিল কৰা হল"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "বাদ দিয়া হল"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "সম্পন্ন"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "কাৰ্য্য শীৰ্ষক"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "কাৰ্য্য অৱস্থা"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "সময়"
+
+#: ../panels/printers/pp-jobs-dialog.c:495
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s সক্ৰিয় কাৰ্য্যসমূহ"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Serial Port"
+msgstr "ক্ৰমিক পৰ্ট"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1683
+msgid "Parallel Port"
+msgstr "সমান্তৰাল পৰ্ট"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+msgid "Location: %s"
+msgstr "অবস্থান: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1744
+#, c-format
+msgid "Address: %s"
+msgstr "ঠিকনা: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1768
+msgid "Server requires authentication"
+msgstr "চাৰ্ভাৰৰ প্ৰমাণীকৰণৰ প্ৰয়োজন"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "দুই -ফলিয়া"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "পাতৰ ধৰণ"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "পাতৰ উৎস"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "আউটপুট ট্ৰে"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript পূৰ্ব-পৰিস্ৰাৱন"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:531
+msgid "Pages per side"
+msgstr "প্ৰতি ফাল পৃষ্ঠাসমূহ"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:543
+msgid "Two-sided"
+msgstr "দুই -ফলিয়া"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:555
+msgid "Orientation"
+msgstr "দিশনিৰ্ণয়"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:652
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "সাধাৰণ"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "পৃষ্ঠাৰ সংস্থাপন"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "ইনস্টল কৰিব পৰা বিকল্পসমূহ"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "কাৰ্য্য"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "ছবিৰ গুণ"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "ৰঙ"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "শেষ কৰা হৈছে"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "উন্নত"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "স্বনিৰ্বাচন"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "অবিকল্পিত প্ৰিন্টাৰ"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "কেৱল GhostScript ফন্টসমূহ অন্তৰভুক্ত কৰক"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "PS স্তৰ ১ লে পৰিবৰ্তন কৰক"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "PS স্তৰ ২ লে পৰিবৰ্তন কৰক"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "কোনো পূৰ্ব-পৰিস্ৰাৱন নাই"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "উৎপাদক"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "ড্ৰাইভাৰ"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"%s ত উপলব্ধ প্ৰিন্টাৰসমূহ চাবলে আপোনাৰ ব্যৱহাৰকাৰীনাম আৰু পাছৱৰ্ড সুমুৱাওক।"
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "প্ৰিন্টাৰ যোগ কৰক"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "প্ৰিন্টাৰ আতৰাওক"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "যোগান দিয়ক"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "অবস্থান"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default printer"
+msgstr "অবিকল্পিত প্ৰিন্টাৰ (_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "কাৰ্য্যসমূহ"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "কাৰ্য্যসমূহ দেখুৱাওক (_J)"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "আৰ্হি"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "লেবেল"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "নতুন ড্ৰাইভাৰ সংস্থাপন কৰা হৈছে…"
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "পৃষ্ঠা ৩"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "পৰীক্ষা পৃষ্ঠা প্ৰিন্ট কৰক (_T)"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "বিকল্পসমূহ (_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "নতুন প্ৰিন্টাৰ যোগ কৰক"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"ক্ষমা কৰিব! চিস্টেম প্ৰিন্টিং সেৱা\n"
+"উপলব্ধ নাই যেন লাগিছে।"
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "পৰ্দাৰ লক"
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "ব্যৱহাৰ আৰু ইতিহাস"
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr "আবৰ্জনাৰ পৰা সকলো বস্তু আতৰাব নে?"
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr "আবৰ্জনাৰ সকলো বস্তু স্থায়ীভাৱে মচি পেলোৱা হব।"
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "আবৰ্জনা খালি কৰক (_E)"
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+msgid "Delete all the temporary files?"
+msgstr "সকলো অস্থায়ী ফাইল মচি পেলাব নে?"
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr "সকলো অস্থায়ী ফাইল স্থায়ীভাৱে মচি পেলোৱা হব।"
+
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "অস্থায়ী ফাইলসমূহ শোধন কৰক (_P)"
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "আবৰ্জনা শোধন আৰু অস্থায়ী ফাইলসমূহ"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr "চফ্টৱেৰৰ ব্যৱহাৰ"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "গোপনীয়তা"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr "আপোনাৰ ব্যক্তিগত তথ্য সুৰক্ষিত কৰক আৰু অন্যয় কি চাব পাৰে নিয়ন্ত্ৰণ কৰক"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "পৰ্দা বন্ধ হয়"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "৩০ ছেকেণ্ড"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "১ দিন"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "২ দিন"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "৩ দিন"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "৪ দিন"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "৫ দিন"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "৬ দিন"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "৭ দিন"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "১৪ দিন"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "৩০ দিন"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "চিৰকাল"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"আপোনাৰ ইতিহাস মনত ৰাখিলে বস্তুবোৰ আকৌ বিচাৰোতে সহজ হয়। এই বস্তুবোৰ নেটৱৰ্কৰে "
+"কেতিয়াও অংশীদাৰী কৰা নহয়।"
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "শেহতীয়াভাৱে ব্যৱহৃত (_R)"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "ইতিহাস অব্যাহত ৰাখক (_H)"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "শেহতীয়া ইতিহাস পৰিষ্কাৰ কৰক (_e)"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "যেতিয়া আপুনি আতৰ হয় পৰ্দা লকে আপোনাৰ গোপনীয়তা সুৰক্ষিত ৰাখে।"
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "স্বচালিত পৰ্দা লক (_L)"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "উল্লেখিত সময় খালি থকাৰ পিছত পৰ্দা লক কৰিব (_A)"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "অধিসূচনাসমূহ দেখুৱাওক (_N)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"আপোনাৰ কমপিউটাৰক অপ্ৰয়োজনীয় সংবেদ্য তথ্যৰ পৰা মুক্ত ৰাখিবলে আবৰ্জনা আৰু "
+"অস্থায়ী "
+"ফাইলসমূহ স্বচালিতভাৱে শোধন কৰক।"
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "আবৰ্জনা স্বচালিতভাৱে খালি কৰক (_T)"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "অস্থায়ী ফাইলসমূহ স্বচালিতভাৱে শোধন কৰক (_F)"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "উল্লেখিত সময়ৰ পিছত শোধন কৰক (_A)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"আপুনি কি চফ্টৱেৰ ব্যৱহাৰ কৰে তাৰ বিষয়ে তথ্য পঠালে আমাক অধিক সঠিক উপদেশ প্ৰদান "
+"কৰাত সহায় কৰে। ই লগতে আমাৰ চফ্টৱেৰ উন্নত কৰাত সহায় কৰে।\n"
+"\n"
+"আমি সংগ্ৰহ কৰা সকলো তথ্যক বেনামী কৰা হয়, আৰু আমি আপোনাৰ তথ্য কেতিয়াও তৃতীয় "
+"দলৰ "
+"সৈতে অংশীদাৰী নকৰো।"
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "চফ্টৱেৰ ব্যৱহাৰৰ পৰিসংখ্যা পঠাওক (_S)"
+
+#: ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "গোপনীয়তা নীতি"
+
+#: ../panels/privacy/privacy.ui.h:42
+msgid "_Location Services"
+msgstr "অবস্থান সেৱাসমূহ (_L)"
+
+#: ../panels/privacy/privacy.ui.h:43
+#| msgid "Allows applications to determine your geographical location"
+msgid "Used to determine your geographical location"
+msgstr "আপোনাৰ ভৌগলিক অৱস্থান নিৰ্ধাৰণ কৰাৰ বাবে ব্যৱহাৰ কৰা হয়"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ইম্পেৰিয়েল"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "মেট্ৰিক"
+
+#: ../panels/region/cc-format-chooser.c:284
+msgid "No regions found"
+msgstr "কোনো অঞ্চল পোৱা নগল"
+
+#: ../panels/region/cc-input-chooser.c:179
+msgid "No input sources found"
+msgstr "কোনো ইনপুট উৎস পোৱা নগল"
+
+#: ../panels/region/cc-input-chooser.c:1076
+msgctxt "Input Source"
+msgid "Other"
+msgstr "অন্য"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:896
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "পৰিবৰ্তনসমূহ প্ৰভাৱশালী হবলে আপোনাৰ অধিবেশন পুনৰাম্ভ কৰিব লাগিব"
+
+#: ../panels/region/cc-region-panel.c:240
+#: ../panels/user-accounts/um-user-panel.c:897
+msgid "Restart Now"
+msgstr "এতিয়া পুনৰাম্ভ কৰক"
+
+#: ../panels/region/cc-region-panel.c:858
+msgid "No input source selected"
+msgstr "কোনো ইনপুট উৎস নিৰ্বাচন কৰা হোৱা নাই"
+
+#: ../panels/region/cc-region-panel.c:1088
+msgid "Sorry"
+msgstr "ক্ষমা কৰিব"
+
+#: ../panels/region/cc-region-panel.c:1090
+msgid "Input methods can't be used on the login screen"
+msgstr "ইনপুট পদ্ধতিসমূহ লগিন পৰ্দাত ব্যৱহাৰ কৰিব নোৱাৰি"
+
+#: ../panels/region/cc-region-panel.c:1727
+msgid "Login Screen"
+msgstr "লগিন পৰ্দা"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "বিন্যাসসমূহ"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "পূর্ব প্ৰদর্শন"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "তাৰিখসমূহ"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "সময়বোৰ"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "নম্বৰসমূহ"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "মাপ"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "পাত"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "অঞ্চল & ভাষা"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"আপোনাৰ প্ৰদৰ্শন ভাষা, বিন্যাসসমূহ, কিবৰ্ড বিন্যাসসমূহ আৰু ইনপুট উৎসসমূহ বাছক"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "এটা ইনপুট উৎস যোগ কৰক"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "ইনপুট উৎস বিকল্পসমূহ"
+
+#: ../panels/region/input-options.ui.h:2
+msgid "Use the _same source for all windows"
+msgstr "সকলো উইন্ডোৰ বাবে একেটা উৎস ব্যৱহাৰ কৰক (_s)"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Allow _different sources for each window"
+msgstr "প্ৰতিটো উইন্ডোৰ বাবে ভিন্ন উৎসৰ অনুমতি দিয়ক (_d)"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Keyboard Shortcuts"
+msgstr "কিবৰ্ড চৰ্টকাটসমূহ"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Switch to previous source"
+msgstr "পূৰ্বৱৰ্তী উৎসলে যাওক"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Switch to next source"
+msgstr "পৰৱৰ্তী উৎসলে যাওক"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "আপুনি এই চৰ্টকাটসমূহ কিবৰ্ড সংহতিসমূহত পৰিবৰ্তন কৰিব পাৰিব"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "Alternative switch to next source"
+msgstr "পৰৱৰ্তী উৎসলে বৈকল্পিক চুইচ"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Left+Right Alt"
+msgstr "Left+Right Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "ইংৰাজী (ইংলেণ্ড)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "সংযুক্তৰাজ্য"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "বিকল্পসমূহ"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"চিস্টেমত লগিন কৰোতে লগিন সংহতিসমূহ সকলো ব্যৱহাৰকাৰী দ্বাৰা ব্যৱহাৰ কৰা হয়"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr "স্থানবোৰ"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "পত্ৰচিহ্নসমূহ"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr "অন্য"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "অবস্থান বাছক"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+msgid "_OK"
+msgstr "ঠিক আছে (_O)"
+
+#: ../panels/search/cc-search-panel.c:176
+msgid "No applications found"
+msgstr "কোনো এপ্লিকেচন পোৱা নগল"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "বিচাৰক"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "কোনবোৰ এপ্লিকেচনে কাৰ্য্যসমূহ অভাৰভিউত ফলাফলসমূহ দেখুৱায় নিয়ন্ত্ৰণ কৰক"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "অবস্থানসমূহ সন্ধান কৰক"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "উপৰলে স্থানান্তৰ কৰক"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "তললে স্থানান্তৰ কৰক"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "পছন্দসমূহ"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "অন"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "অফ"
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "সামৰ্থবান"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+msgctxt "service is active"
+msgid "Active"
+msgstr "সক্ৰিয়"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "এটা ফোল্ডাৰ বাছক"
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "কপি কৰক"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "অংশীদাৰী কৰা"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "আপুনি অন্যৰ লগত কি অংশীদাৰী কৰিব বিচাৰে নিয়ন্ত্ৰণ কৰক"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "দূৰৱৰ্তী লগিন সামৰ্থবান অথবা অসামৰ্থবান কৰক"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "দূৰৱৰ্তী লগিন সামৰ্থবান অথবা অসামৰ্থবান কৰিবলে প্ৰমাণীকৰণৰ প্ৰয়োজন"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:299
+msgid "No networks selected for sharing"
+msgstr "অংশীদাৰী কৰিবলে কোনো নেটৱৰ্ক নিৰ্বাচন কৰা হোৱা নাই"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "নেটৱৰ্কসমূহ"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "ব্লুটুথ অংশীদাৰী"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"ব্লুটুথ অংশীদাৰীয়ে আপোনাক অন্য ব্লুটুথ সামৰ্থবান ডিভাইচসমূহৰ সৈতে ফাইলসমূহ "
+"অংশীদাৰী "
+"কৰাৰ অনুমতি দিয়ে"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "কেৱল ভৰষাবান ডিভাইচসমূহৰ পৰা গ্ৰহণ কৰক"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "গ্ৰহণ কৰা ফাইলসমূহ ডাউনল'ডসমূহ ফোল্ডাৰত সংৰক্ষণ কৰক"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "কমপিউটাৰৰ নাম"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "ব্যক্তিগত ফাইল অংশীদাৰী"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "পৰ্দা অংশীদাৰী"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "মাধ্যমৰ অংশীদাৰী"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "দূৰৱৰ্তী লগিন"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "কোনো নেটৱৰ্ক অভিগম নথকা বাবে কিছুমান সেৱা অসামৰ্থবান কৰা আছে।"
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"ব্যক্তিগত ফাইল অংশীদাৰীয়ে আপোনাক আপোনাৰ বৰ্তমান নেটৱৰ্কত <a href=\"dav://%s"
+"\">dav://%s</a> ব্যৱহাৰ কৰি আপোনাৰ ৰাজহুৱা ফোল্ডাৰক অন্যৰ সৈতে অংশীদাৰী কৰাৰ "
+"অনুমতি দিয়ে"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr "পাছৱৰ্ডৰ প্ৰয়োজন"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"Secure Shell কমান্ড ব্যৱহাৰ কৰি দূৰৱৰ্তী ব্যৱহাৰকাৰীসকলৰ সৈতে সংযোগ কৰাৰ "
+"অনুমতি "
+"দিয়ক:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"দূৰৱৰ্তী ব্যৱহাৰকাৰীসকলক <a href=\"vnc://%s\">vnc://%s</a> ৰ সৈতে সংযোগ কৰি "
+"আপোনাৰ পৰ্দা দৰ্শন অথবা নিয়ন্ত্ৰণ কৰাৰ অনুমতি দিয়ক"
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Allow Remote Control"
+msgstr "দূৰৱৰ্তী নিয়ন্ত্ৰণৰ অনুমতি দিয়ক"
+
+#: ../panels/sharing/sharing.ui.h:21
+msgid "Password:"
+msgstr "পাছৱৰ্ড:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "পাছৱৰ্ড দেখুৱাওক"
+
+#: ../panels/sharing/sharing.ui.h:23
+msgid "Access Options"
+msgstr "অভিগমৰ বিকল্পসমূহ"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "নতুন সংযোগসমূহে অভিগমৰ বাবে সোধিব লাগিব"
+
+#: ../panels/sharing/sharing.ui.h:25
+msgid "Require a password"
+msgstr "এটা পাছৱৰ্ডৰ প্ৰয়োজন"
+
+#: ../panels/sharing/sharing.ui.h:26
+msgid "Share music, photos and videos over the network."
+msgstr "নেটৱৰ্কৰে সংগীত, ফ'টোসমূহ আৰু ভিডিঅ'সমূহ অংশীদাৰী কৰক।"
+
+#: ../panels/sharing/sharing.ui.h:27
+msgid "Folders"
+msgstr "ফোল্ডাৰসমূহ"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "শব্দ"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"শব্দৰ স্তৰসমূহ, ইনপুটসমূহ, আউটপুটসমূহ, আৰু সতৰ্কতা শব্দসমূহ পৰিবৰ্তন কৰক"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "কাৰ্ড;মাইক্ৰোফোন;ভলিউম;স্লান;ভাৰসাম্য;ব্লুটুথ;হেডচেট;অডিঅ;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "বাৰ্ক"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "ড্ৰিপ"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "কাঁচ"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "Sonar"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "বাওঁ"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "সোঁ"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "পিছফাল"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "আগফাল"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "নূন্যতম"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "সৰ্বাধিক"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "ভাৰসাম্য (_B):"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "স্লান (_F):"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "চাব্ওফাৰ (_S):"
+
+#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
+msgctxt "volume"
+msgid "100%"
+msgstr "১০০%"
+
+#: ../panels/sound/gvc-channel-bar.c:616
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "অবৃদ্ধিত"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "আলেখ্য (_P):"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u আউটপুট"
+msgstr[1] "%u আউটপুটসমূহ"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ইনপুট"
+msgstr[1] "%u ইনপুটসমূহ"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "চিস্টেমৰ শব্দসমূহ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "স্পিকাৰসমূহ পৰীক্ষা কৰক (_T)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "শীৰ্ষ চিনাক্তকৰণ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1509
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "নাম"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1528
+msgid "Device"
+msgstr "ডিভাইচ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1591
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s ৰ বাবে স্পিকাৰ পৰীক্ষা"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1649
+msgid "_Output volume:"
+msgstr "আউটপুট ভলিউম (_O):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "Output"
+msgstr "আউটপুট"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1668
+msgid "C_hoose a device for sound output:"
+msgstr "শব্দ আউটপুটৰ বাবে এটা ডিভাইচ বাছক (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1693
+msgid "Settings for the selected device:"
+msgstr "নিৰ্বাচিত ডিভাইচৰ বাবে সংহতিসমূহ:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "Input"
+msgstr "ইনপুট"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "_Input volume:"
+msgstr "ইনপুট ভলিউম (_I):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1734
+msgid "Input level:"
+msgstr "ইনপুট স্তৰ:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1762
+msgid "C_hoose a device for sound input:"
+msgstr "শব্দ ইনপুটৰ বাবে এটা ডিভাইচ বাছক (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "Sound Effects"
+msgstr "শব্দ প্ৰভাৱসমূহ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+msgid "_Alert volume:"
+msgstr "সতৰ্ক ভলিউম (_A):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1809
+msgid "Applications"
+msgstr "এপ্লিকেচনসমূহ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1813
+msgid "No application is currently playing or recording audio."
+msgstr "কোনো এপ্লিকেচনে বৰ্তমানে অডিঅ' বজোৱা বা ৰেকৰ্ড কৰা নাই।"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "বিল্ট-ইন"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "শব্দ পছন্দসমূহ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "ঘটনা শব্দ পৰীক্ষা কৰা"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "অবিকল্পিত"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "থীমৰ পৰা"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:769
+msgid "C_hoose an alert sound:"
+msgstr "এটা সতৰ্কৰ শব্দ বাছক (_h):"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "বন্ধ কৰক"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "পৰীক্ষা"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "চাব্ওফাৰ"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "স্বনিৰ্বাচিত"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "চোৱা, শুনা, টাইপ কৰা, পোইন্ট আৰু ক্লিক কৰাটো সহজ কৰক"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"কিবৰ্ড;মাউছ;a11y;অভিগম্যতা;কনট্ৰাস্ট;জুম;পৰ্দা;ৰিডাৰ;লিখনি;ফন্ট;আকাৰ;AccessX;স"
+"্টিকি; "
+"কিসমূহ;লেহেম;বাউন্স;মাউছ;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "সাৰ্বভৈমক অভিগম মেনু সদায় দেখুৱাব (_A)"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "দেখা"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "উচ্চ কন্ট্ৰাস্ট (_H)"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "ডাঙৰ লিখনি (_L)"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "_Zoom"
+msgstr "জুম (_Z)"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr "পৰ্দা ৰিডাৰ (_R)"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "_Sound Keys"
+msgstr "শব্দ কি'সমূহ (_S)"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "শুনা"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr "চক্ষ সতৰ্কবাৰ্তাসমূহ (_V)"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Screen _Keyboard"
+msgstr "পৰ্দা কিবৰ্ড (_K)"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "_Typing Assist (AccessX)"
+msgstr "টাইপিং সহায়ক (AccessX) (_T)"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Pointing & Clicking"
+msgstr "পোইন্টিং আৰু ক্লিকিং"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "_Mouse Keys"
+msgstr "মাউছ কি'সমূহ (_M)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "সহায়ত ক্লিক কৰক (_C)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "পৰ্দা ৰিডাৰ"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "স্ক্ৰিন ৰিডাৰে প্ৰদৰ্শিত লিখনি পঢ়ে যেতিয়া আপুনি ফকাচ আতৰায়।"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Screen Reader"
+msgstr "পৰ্দা ৰিডাৰ (_S)"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Sound Keys"
+msgstr "শব্দ কি'সমূহ"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "Num Lock অথবা Caps Lock অন থকা অৱস্থাত বিপ কৰিব।"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "চক্ষ সতৰ্কবাৰ্তাসমূহ"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "ফ্লেশ পৰীক্ষা কৰক (_T)"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "এটা সতৰ্ক শব্দ হওতে এটা চক্ষ ইংগিত ব্যৱহাৰ কৰিব।"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Flash the _window title"
+msgstr "উইন্ডো শীৰ্ষক ফ্লেশ কৰক (_w)"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Flash the entire _screen"
+msgstr "সম্পূৰ্ণ পৰ্দা ফ্লেশ কৰক (_s)"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Typing Assist"
+msgstr "টাইপিং সহায়"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "_Sticky Keys"
+msgstr "স্টিকি কি'সমূহ (_S)"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "পৰিৱৰ্তক কিসমূহৰ এটা ক্ৰমক এটা কি সংযুক্তি হিচাপে ব্যৱহাৰ কৰে"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "অসামৰ্থবান কৰিব যদি দুটা কি একেলগে টিপা হয় (_D)"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifer key is pressed"
+msgstr "এটা পৰিৱৰ্তক কি টিপোতে বিপ কৰিব (_m)"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "S_low Keys"
+msgstr "ধীৰ গতিৰ কি'সমূহ (_l)"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "এটা বিলম্ব দিয়ে যেতিয়া এটা কি টিপা হয় আৰু গ্ৰহণ কৰা হয়"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "গ্ৰহণ বিলম্ব (_c):"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "সৰু"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "লেহেম কিসমূহৰ টাইপিং বিলম্ব"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "দীঘল"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Beep when a key is pr_essed"
+msgstr "এটা কি' টিপোতে বিপ কৰিব (_e)"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Beep when a key is _accepted"
+msgstr "এটা কি' গ্ৰহণ কৰিলে বিপ কৰিব (_a)"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "এটা কি নাকচ হওতে বিপ কৰিব (_r)"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "_Bounce Keys"
+msgstr "বাউন্স কি'সমূহ (_B)"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "দ্ৰুত প্ৰতিলিপিত কিটিপা উপেক্ষা কৰে"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "সৰু"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "বাউন্স কিসমূহ টাইপিং বিলম্ব"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "দীঘল"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Enable by Keyboard"
+msgstr "কিবৰ্ড দ্বাৰা সামৰ্থবান কৰা (_E)"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "কিবৰ্ড ব্যৱহাৰ কৰি অভিগম্যতা বৈশিষ্টসমূহ অন অথবা অফ কৰক"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "সহায় ক্লিক কৰক"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "_Simulated Secondary Click"
+msgstr "কৃত্ৰিম দ্বিতীয় ক্লিক (_S)"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "প্ৰাথমিক বুটাম টিপি ৰাখি এটা দ্বিতীয় ক্লিক কৰক"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "secondary click"
+msgid "Short"
+msgstr "সৰু"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "দ্বিতীয় ক্লিক বিলম্ব"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "দীঘল"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "_Hover Click"
+msgstr "হভাৰ ক্লিক (_H)"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "পোইন্টাৰ হভাৰ হওতে এটা ক্লিক কৰক"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "বিলম্ব (_e):"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "সৰু"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "দীঘল"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "চলন ডেউৰী (_t):"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "সৰু"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "ডাঙৰ"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "সৰু"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ পৰ্দা"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ পৰ্দা"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ পৰ্দা"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "দীঘল"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "পূৰ্ণ পৰ্দা"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "উপৰ অৰ্দ্ধাংশ"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "তলৰ অৰ্দ্ধাংশ"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "বাওঁ অৰ্দ্ধাংশ"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "সোঁ অৰ্দ্ধাংশ"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "জুম বিকল্পসমূহ"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "ডাঙৰ কৰি দেখুৱাওক"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "ডাঙৰ কৰা:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "মাউছ কাৰ্চাৰ অনুসৰণ কৰক"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "পৰ্দাৰ অংশ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "ডাঙৰ কৰাটো পৰ্দাৰ বাহিৰ প্ৰসাৰিত হয়"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "মেগ্নিফায়াৰ কাৰ্চাৰ কেন্দ্ৰত ৰাখক"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "মেগ্নিফায়াৰ কাৰ্চাৰে সমলসমূহক ঠেলা মাৰে"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "মেগ্নিফায়াৰ কাৰ্চাৰ সমলসমূহৰ সৈতে গমন কৰে"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "মেগ্নিফায়াৰ অৱস্থান:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "মেগ্নিফায়াৰ"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "ডাঠ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "পাতল"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "শকত"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "দৈৰ্ঘ্য:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "ৰঙ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "ক্ৰসহেয়াৰসমূহ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "মাউছ কাৰ্চাৰক অভিব্যপন কৰে"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "ক্ৰসহেয়াৰসমূহ"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "কলাত বগা:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "উজ্জ্বলতা:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "কনট্ৰাস্ট:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "ৰঙ"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "কোনো নহয়"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "সম্পূৰ্ণ"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "নিম্ন"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "উচ্চ"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "নিম্ন"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "উচ্চ"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "ৰঙৰ প্ৰভাৱসমূহ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "ৰঙৰ প্ৰভাৱসমূহ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "প্ৰামাণিক"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "প্ৰশাসক"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Full Name"
+msgstr "সম্পূৰ্ণ নাম (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "একাওন্টৰ ধৰণ (_T)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to set a password when they next login"
+msgstr "ব্যৱহাৰকাৰীক পৰৱৰ্তী লগিনত এটা পাছৱৰ্ড সংহতি কৰাৰ অনুমতি দিয়ক"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "এটা নতুন পাছৱৰ্ড এতিয়া সংহতি কৰক"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "সতা সত্য নিৰূপণ কৰক (_V)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"এন্টাৰপ্ৰাইজ লগিনে এটা স্থায়ী কেন্দ্ৰীয়ভাৱে ব্যৱস্থিত ব্যৱহাৰকাৰী একাওন্টক এই "
+"ডিভাইচত "
+"ব্যৱহাৰ কৰাৰ অনুমতি দিয়ে।"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "ডমেইন (_D)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"এন্টাৰপ্ৰাইজ লগিন একাউন্টসমূহ\n"
+"যোগ কৰিবলৈ অনলাইন যাওক।"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "এন্টাৰপ্ৰাইজ লগিন (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "ব্যৱহাৰকাৰী যোগ কৰক"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "এনৰল কৰক (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "ডমেইন প্ৰশাসকৰ লগিন"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"এন্টাৰপ্ৰাইজ লগিনসমূহ ব্যৱহাৰ কৰিবলে, এই কমপিউটাৰক ডমেইনত\n"
+"এনৰোল কৰিব লাগিব। অনুগ্ৰহ কৰি আপোনাৰ নেটৱৰ্ক প্ৰশাসকসমূহক\n"
+"তেওলোকৰ ডমেইন পাছৱৰ্ড ইয়াত টাইপ কৰিব দিব।"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "প্ৰশাসকৰ নাম (_N)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "প্ৰশাসকৰ পাছৱৰ্ড"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "বাঁওহাতৰ বৃদ্ধাঙ্গুলি"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "বাঁওহাতৰ মধ্যমা"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "বাঁওহাতৰ অনামিকা"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "বাঁওহাতৰ কনিষ্ঠা"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "সোঁহাতৰ বৃদ্ধাঙ্গুলি"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "সোঁহাতৰ মধ্যমা"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "সোঁহাতৰ অনামিকা"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "সোঁহাতৰ কনিষ্ঠা"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:697
+msgid "Enable Fingerprint Login"
+msgstr "আঙ্গুলিৰ ছাপ লগিন সক্ৰিয় কৰক"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "সোঁ সূচক আঙুলি (_R)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "বাওঁ সূচক আঙুলি (_L)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "অন্য আঙুলি (_O):"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"সাফল্যেৰ সৈতে আপোনাৰ আঙ্গুলিৰ ছাপ সংৰক্ষিত হৈছে। আঙ্গুলিৰ ছাপ পাঠৰ ব্যবস্থা "
+"(ৰিডাৰ) "
+"সহযোগে আপুনি এতিয়া লগিন কৰিবলৈ সক্ষম হ'ব।"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "ব্যৱহাৰকাৰীসকল"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "ব্যৱহাৰকাৰীসকল যোগ কৰক বা আতৰাওক আৰু আপোনাৰ পাছৱৰ্ড পৰিবৰ্তন কৰক"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "লগিন;নাম;আঙ্গুলিৰ ছাপ;অৱতাৰ;লগো;মূখ;পাছৱৰ্ড;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "লগিনৰ ইতিহাস"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr "পাছৱৰ্ড পৰিবৰ্তন কৰক"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "পৰিবৰ্তন কৰক (_a)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "নতুন পাছৱৰ্ড সতা সত্য নিৰূপণ কৰক (_V)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "নতুন পাছৱৰ্ড (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "বৰ্তমান পাছৱৰ্ড (_P)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "ব্যৱহাৰকাৰী একাওন্ট যোগ কৰক"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "ব্যৱহাৰকাৰী একাওন্ট আতৰাওক"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "লগিন বিকল্পসমূহ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "স্বচালিত লগিন (_u)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "আঙ্গুলিৰ ছাপ লগিন (_F)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "ব্যৱহাৰকাৰী আইকন"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "ভাষা (_L)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "সৰ্বশেষ লগিন"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "ব্যৱহাৰকাৰী একাওন্টসমূহ ব্যৱস্থাপনা কৰক"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "ব্যৱহাৰকাৰী তথ্য পৰিবৰ্তন কৰিবলে প্ৰমাণীকৰণৰ প্ৰয়োজন"
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "নতুন পাছৱৰ্ড পুৰনি পাছৱৰ্ডৰ পৰা ভিন্ন হব লাগিব।"
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "কিছুমান আখৰ আৰু সংখ্যা পৰিবৰ্তন কৰি চাওক।"
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "পাছৱৰ্ডটো আৰু অলপ পৰিবৰ্তন কৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "আপোনাৰ ব্যৱহাৰকাৰী নাম নথকা এটা পাছৱৰ্ড অধিক শক্তিশালী হব।"
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "পাছৱৰ্ডত আপোনাৰ নাম ব্যৱহাৰ নকৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "পাছৱৰ্ডত ব্যৱহৃত কিছুমান শব্দ ব্যৱহাৰ নকৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "সাধাৰণ শব্দবোৰ বাদ দিয়াৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "স্থায়ী শব্দবোৰ পুনৰ ব্যৱস্থিত নকৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "অধিক সংখ্যা ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "অধিক ওপৰফলা আখৰ ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "অধিক তলৰফলা আখৰ ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "অধিক বিশেষ আখৰ, যেনে বিৰাম চিহ্ন ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "আখৰ, সংখ্যা আৰু বিৰাম চিহ্নৰ এটা সংমিশ্ৰণ ব্যৱহাৰ কৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "একেটা আখৰ পুনৰাবৃত্তি নকৰাৰ চেষ্টা কৰিব।"
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"একেধৰণ আখৰ পুনৰাবৃত্তি নকৰাৰ চেষ্টা কৰিব: আপুনি আখৰ, সংখ্যা আৰু বিৰাম চিহ্ন "
+"সংমিশ্ৰণ "
+"কৰিব লাগিব।"
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "ক্ৰম যেনে 1234 অথবা abcd বাদ দিয়াৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "অধিক আখৰ, সংখ্যা আৰু চিহ্ন যোগ কৰাৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr "ওপৰফলা আৰু তলৰফলা সংমিশ্ৰণ কৰক আৰু এটা বা দুটা সংখ্যা ব্যৱহাৰ কৰক।"
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+"ভাল পাছৱৰ্ড! অধিক আখৰ, সংখ্যা আৰু বিৰাম চিহ্ন যোগ কৰিলে ই আৰু অধিক শক্তিশালী "
+"হব।"
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "শক্তি: দূৰ্বল"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "শক্তি: কম"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "শক্তি: মধ্যম"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "শক্তি: ভাল"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "শক্তি: প্ৰবল"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "প্ৰমাণীকৰণ ব্যৰ্থ হল"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "নতুন পাছৱৰ্ড অতি সৰু"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "নতুন পাছৱৰ্ড অতি সাধাৰণ"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "পুৰনি আৰু নতুন পাছৱৰ্ড অত্যন্ত সদৃশ"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "নতুন পাছৱৰ্ড ইতিমধ্যে শেহতীয়াকৈ ব্যৱহাৰ কৰা হৈছে।"
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "নতুন পাছৱৰ্ড সাংখ্যিক অথবা বিশেষ আখৰসমূহ অন্তৰ্ভুক্ত কৰিব লাগিব"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "পুৰনি আৰু নতুন পাছৱৰ্ড একে"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "আপোনাৰ পাছৱৰ্ড আপুনি আৰম্ভণিত প্ৰমাণিত কৰাৰ পিছত পৰিবৰ্তন হৈছে!"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "নতুন পাছৱাৰ্ডে পৰ্যাপ্ত ভিন্ন আখৰ অন্তৰ্ভুক্ত নকৰে"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "অজ্ঞাত ত্ৰুটি"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "আপোনাৰ একাওন্ট প্ৰদানকাৰীৰ ৱেব ঠিকনাৰ সৈতে মিল খাব লাগিব।"
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "একাওন্ট যোগ কৰিবলে ব্যৰ্থ হল"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+msgid "Passwords do not match."
+msgstr "পাছৱৰ্ডসমূহ মিল নাখায়।"
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr "একাওন্ট ৰেজিস্টাৰ কৰিবলে ব্যৰ্থ হল"
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr "এই ডমেইনৰ সৈতে প্ৰমাণীত কৰিবলে কোনো সমৰ্থিত পদ্ধতি নাই"
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr "ডমেইনত অংশগ্ৰহণ কৰিবলে ব্যৰ্থ হল"
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"সেই লগিন নাম কাম নকৰিলে।\n"
+"অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"সেই লগিন পাছৱৰ্ড কাম নকৰিলে।\n"
+"অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক।"
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr "ডমেইনত লগিন কৰিবলে ব্যৰ্থ হল"
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "ডমেইন সন্ধান কৰিবলৈ অক্ষম। হয়তো আপুনি ইয়াক ভুলকৈ বানান কৰিছে?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:137
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"আপুনি এই ডিভাইচ ব্যবহাৰ কৰিবলৈ অনুমোদিত নহয়। অনুগ্ৰহ কৰি প্ৰণালী প্ৰশাসকৰ "
+"সৈতে "
+"যোগাযোগ কৰক।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid "The device is already in use."
+msgstr "ডিভাইচ বৰ্তমানে ব্যবহৃত হৈছে।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "An internal error occurred."
+msgstr "এটা অভ্যন্তৰীক ত্ৰুটি দেখা দিছে।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:217
+#: ../panels/user-accounts/um-fingerprint-dialog.c:218
+msgid "Enabled"
+msgstr "সামৰ্থবান"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:266
+msgid "Delete registered fingerprints?"
+msgstr "নিবন্ধিত আঙ্গুলিৰ ছাপ আঁতৰুৱা হ'ব নেকি ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:270
+msgid "_Delete Fingerprints"
+msgstr "আঙ্গুলিৰ ছাপ আঁতৰাওক (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:276
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"আঙ্গুলিৰ ছাপ লগিন ব্যবস্থা নিষ্ক্ৰিয় কৰাৰ উদ্দেশ্যে নিবন্ধিত আঙ্গুলিৰ ছাপসমূহ "
+"আঁতৰুৱা হ'ব "
+"নেকি ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:452
+msgid "Done!"
+msgstr "সমাপ্ত!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:513
+#: ../panels/user-accounts/um-fingerprint-dialog.c:555
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' ডিভাইচ ব্যবহাৰ কৰিবলৈ ব্যৰ্থ"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:596
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "'%s' ডিভাইচত আঙ্গুলিৰ ছাপ প্ৰাপ্ত কৰিবলৈ ব্যৰ্থ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:647
+msgid "Could not access any fingerprint readers"
+msgstr "কোনো আঙ্গুলিৰ ছাপ ৰিডাৰ অভিগম কৰিব নোৱাৰি"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:648
+msgid "Please contact your system administrator for help."
+msgstr "অনুগ্ৰহ কৰি সহায়তাৰ বাবে আপোনাৰ চিস্টেম প্ৰশাসকৰ সৈতে যোগাযোগ কৰক।"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:731
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"আঙ্গুলিৰ ছাপ লগিন ব্যবস্থা সামৰ্থবান কৰাৰ বাবে, '%s' সহযোগে অন্তত এটা "
+"আঙ্গুলিৰ ছাপ "
+"সংৰক্ষণ কৰা আবশ্যক।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:738
+msgid "Selecting finger"
+msgstr "আঙুলি নিৰ্বাচন কৰা"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:739
+msgid "Enrolling fingerprints"
+msgstr "আঙ্গুলিৰ ছাপসমূহ এনৰোল কৰা"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "এই সপ্তাহ"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "যোৱা সপ্তাহ"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:631
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "অধিবেশন সমাপ্ত হল"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "অধিবেশন আৰম্ভ হল"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "অনুগ্ৰহ কৰি অন্য পাছৱৰ্ড বাছক।"
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "অনুগ্ৰহ কৰি আপোনাৰ বৰ্তমান পাছৱৰ্ড পুনৰ টাইপ কৰক।"
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "পাছৱৰ্ড সলনি কৰিব পৰা নগল"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "The passwords do not match."
+msgstr "পাছৱৰ্ডসমূহ মিল নাখায়।"
+
+#: ../panels/user-accounts/um-photo-dialog.c:219
+msgid "Browse for more pictures"
+msgstr "অধিক ছবিৰ বাবে ব্ৰাউছ কৰক"
+
+#: ../panels/user-accounts/um-photo-dialog.c:453
+msgid "Disable image"
+msgstr "ছবি অসামৰ্থবান কৰক"
+
+#: ../panels/user-accounts/um-photo-dialog.c:471
+msgid "Take a photo…"
+msgstr "এটা ফ'টো লওক…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:489
+msgid "Browse for more pictures…"
+msgstr "অধিক ছবিৰ বাবে ব্ৰাউছ কৰক…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:713
+#, c-format
+msgid "Used by %s"
+msgstr "%s দ্বাৰা ব্যৱহৃত"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "এই ধৰণৰ ডমেইনত স্বচালিতভাৱে অংশগ্ৰহণ কৰিব নোৱাৰি"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "এনেধৰণৰ কোনো ডমেইন অথবা ৰাজত্ব পোৱা নগল"
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s ডমেইনত %s হিচাপে লগিন কৰিব নোৱাৰি"
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr "অবৈধ পাছৱৰ্ড, অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক"
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "%s ডমেইনলে সংযোগ কৰিব নোৱাৰি: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:198
+msgid "Other Accounts"
+msgstr "অন্য একাওন্টসমূহ"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "Failed to delete user"
+msgstr "ব্যৱহাৰকাৰী মচি পেলাবলে ব্যৰ্থ"
+
+#: ../panels/user-accounts/um-user-panel.c:482
+msgid "You cannot delete your own account."
+msgstr "আপুনি আপোনাৰ একাওন্ট মচিব নোৱাৰিব।"
+
+#: ../panels/user-accounts/um-user-panel.c:491
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s এতিয়াও লগিন অৱস্থাত আছে"
+
+#: ../panels/user-accounts/um-user-panel.c:495
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"এজন ব্যৱহাৰকাৰীক লগিন অৱস্থাত মচি পেলালে চিস্টেম এটা অস্থিৰ অৱস্থাত যাব পাৰে।"
+
+#: ../panels/user-accounts/um-user-panel.c:504
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "আপুনি %s ৰ ফাইলসমূহ ৰাখিব বিচাৰে নে?"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"এজন ব্যৱহাৰকাৰীৰ একাওন্ট মচোতে ঘৰ ডাইৰেকটৰি, মেইল স্পুল আৰু অস্থায়ী ফাইলসমূহ "
+"ৰখাটো "
+"সম্ভব।"
+
+#: ../panels/user-accounts/um-user-panel.c:511
+msgid "_Delete Files"
+msgstr "ফাইলসমূহ মচি পেলাওক (_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:512
+msgid "_Keep Files"
+msgstr "ফাইলসমূহ ৰাখক (_K)"
+
+#: ../panels/user-accounts/um-user-panel.c:564
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "একাওন্ট অসামৰ্থবান"
+
+#: ../panels/user-accounts/um-user-panel.c:572
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "পৰৱৰ্তী লগিনত সংহতি কৰিব লগিয়া"
+
+#: ../panels/user-accounts/um-user-panel.c:575
+msgctxt "Password mode"
+msgid "None"
+msgstr "কোনো নহয়"
+
+#: ../panels/user-accounts/um-user-panel.c:624
+msgid "Logged in"
+msgstr "লগিন ইন কৰা আছে"
+
+#: ../panels/user-accounts/um-user-panel.c:1072
+msgid "Failed to contact the accounts service"
+msgstr "একাওন্ট সেৱাৰ সৈতে সংযোগ কৰিবলে ব্যৰ্থ"
+
+#: ../panels/user-accounts/um-user-panel.c:1074
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"অনুগ্ৰহ কৰি AccountService ইনস্টল আৰু সামৰ্থবান আছে বুলি সুনিশ্চিত কৰক।"
+
+#: ../panels/user-accounts/um-user-panel.c:1115
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"পৰিবৰ্তনসমূহ কৰিবলে,\n"
+"* আইকন প্ৰথমতে ক্লিক কৰক"
+
+#: ../panels/user-accounts/um-user-panel.c:1153
+msgid "Create a user account"
+msgstr "এজন ব্যৱহাৰকাৰীৰ একাওন্ট সৃষ্টি কৰক"
+
+#: ../panels/user-accounts/um-user-panel.c:1164
+#: ../panels/user-accounts/um-user-panel.c:1453
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"এজন ব্যৱহাৰকাৰী সৃষ্টি কৰিবলে,\n"
+"* আইকন প্ৰথমতে ক্লিক কৰক"
+
+#: ../panels/user-accounts/um-user-panel.c:1174
+msgid "Delete the selected user account"
+msgstr "নিৰ্বাচিত ব্যৱহাৰকাৰী একাওন্ট মচি পেলাওক"
+
+#: ../panels/user-accounts/um-user-panel.c:1186
+#: ../panels/user-accounts/um-user-panel.c:1458
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"নিৰ্বাচিত ব্যৱহাৰকাৰী একাওন্ট মচিবলে,\n"
+"* আইকন প্ৰথমতে ক্লিক কৰক"
+
+#: ../panels/user-accounts/um-user-panel.c:1368
+msgid "My Account"
+msgstr "মোৰ একাওন্ট"
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+msgid "A user with the username '%s' already exists."
+msgstr "'%s' ব্যৱহাৰকাৰীনামৰ সৈতে এজন ব্যৱহাৰকাৰী ইতিমধ্যে অস্তিত্ববান।"
+
+#: ../panels/user-accounts/um-utils.c:571
+#, c-format
+msgid "The username is too long."
+msgstr "ব্যৱহাৰকাৰীনাম অতি দীঘল।"
+
+#: ../panels/user-accounts/um-utils.c:574
+msgid "The username cannot start with a '-'."
+msgstr "ব্যৱহাৰকাৰীনাম '-' ৰ সৈতে আৰম্ভ হব নোৱাৰিব।"
+
+#: ../panels/user-accounts/um-utils.c:577
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"ব্যৱহাৰকাৰীনামত কেৱল a-z ডিজিটৰ পৰা তলৰ আৰু ওপৰ ফলা আখৰ আৰু আখৰসমূহ '.', '-' "
+"আৰু "
+"'_' ৰ পৰা যিকোনো আখৰ থাকিব পাৰিব।"
+
+#: ../panels/user-accounts/um-utils.c:581
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+"ইয়াক আপোনাৰ ঘৰ ফোল্ডাৰ নামকৰণৰ বাবে ব্যৱহাৰ কৰা হব আৰু ইয়াক পৰিবৰ্তন কৰিব "
+"নোৱাৰি।"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:831
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "বুটামসমূহ মেপ কৰক"
+
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr "বুটামসমূহক ফলনসমূহলে মেপ কৰক"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"এটা চৰ্টকাট সম্পাদন কৰিবলে, \"কিস্ট্ৰৌক পঠাওক\" বুটাম বাছক, কিবৰ্ড চৰ্টকাট "
+"বুটাম "
+"টিপক আৰু নতুন কি'সমূহ টিপি ধৰক অথবা পৰিষ্কাৰ কৰিবলৈ Backspace টিপক।"
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"টেবলেট মানাংকন কৰিবলে লক্ষ্য চিহ্নকসমূহক সিহত পৰ্দাত উপস্থিত হোৱা নিচিনা টেপ "
+"কৰক।"
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "ভুল-ক্লিক চিনাক্ত কৰা হৈছে, পুনৰাম্ভ কৰা হৈছে..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "ওপৰ"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "তল"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "কোনো নহয়"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "কি'স্ট্ৰৌক পঠাওক"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "চুইচ পৰ্যবেক্ষক"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "অন-স্ক্ৰিন সহায় দেখুৱাওক"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "আউটপুট:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "এস্পেক্ট অনুপাত ৰাখক (লেটাৰবাকচ):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "এটা মনিটৰলে মেপ কৰক"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d, %d ৰ"
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "প্ৰদৰ্শন মেপিং"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "বুটাম"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr "Wacom টেবলেট"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"বুটাম মেপিংসমূহ চাওক আৰু গ্ৰাফিক্স টেবলেটসমূহৰ বাবে স্টাইলাচ সংবেদনশীলতা "
+"নিয়ন্ত্ৰণ কৰক"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "টেবলেট;Wacom;স্টাইলাচ;ইৰেজাৰ;মাউছ;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "টেবলেট (প্ৰকৃত)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "টাচপেড (প্ৰাসংগিক)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "টেবলেট পছন্দসমূহ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr "কোনো টেবলেট চিনাক্ত কৰা হোৱা নাই"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "অনুগ্ৰহ কৰি আপোনাৰ Wacom টেবলেট প্লাগ ইন অথবা অন কৰক"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr "ব্লুটুথ সংহতিসমূহ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Map to Monitor…"
+msgstr "মনিটৰলে মেপ কৰক…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map Buttons…"
+msgstr "বুটামসমূহ মেপ কৰক…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr "প্ৰদৰ্শন বিভেদন সজাওক"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust mouse settings"
+msgstr "মাউছ সংহতিসমূহ ব্যৱস্থাপনা কৰক"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Tracking Mode"
+msgstr "অনুকৰণ অৱস্থা"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Left-Handed Orientation"
+msgstr "বাঁও-হাতৰ দিশ"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+msgid "Left Ring"
+msgstr "বাঁও ৰিং"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "বাঁও ৰিং অৱস্থা #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+msgid "Right Ring"
+msgstr "সোঁ ৰিং"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "সোঁ ৰিং অৱস্থা #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+msgid "Left Touchstrip"
+msgstr "বাঁও Touchstrip"
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "বাঁও Touchstrip অৱস্থা #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+msgid "Right Touchstrip"
+msgstr "সোঁ Touchstrip"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "সোঁ Touchstrip অৱস্থা #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "বাঁও Touchring অৱস্থা চুইচ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "সোঁ Touchring অৱস্থা চুইচ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "বাঁও Touchstrip অৱস্থা চুইচ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "সোঁ Touchstrip অৱস্থা চুইচ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "অৱস্থা চুইচ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr "বাঁও বুটাম #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr "সোঁ বুটাম #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr "উপৰ বুটাম #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "তলৰ বুটাম #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "নতুন চৰ্টকাট…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "কোনো কাৰ্য্য নহয়"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "বাঁও মাউছ বুটাম ক্লিক"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "মাজৰ মাউছ বুটাম ক্লিক"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "সোঁ মাউছ বুটাম ক্লিক"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "উপৰলে সক্ৰল কৰক"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "তললে স্ক্ৰল কৰক"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "বাঁওফালে স্ক্ৰল কৰক"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "সোঁফালে স্ক্ৰল কৰক"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "পিছলৈ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "আগলৈ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "স্টাইলাচ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "ইৰেচাৰ চাপ অনুভৱ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "কোমল"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "কঠিন"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "উপৰ বুটাম"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "তলৰ বুটাম"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "আগ চাপ অনুভৱ"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "ভাৰবৌচ অৱস্থা সামৰ্থবান কৰক"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "অভাৰভিউ দেখুৱাওক"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "স্ট্ৰিংৰ বাবে সন্ধান কৰক"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "সম্ভাব্য পেনেল নামসমূহ তালিকাভুক্ত কৰি প্ৰস্থান কৰক"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "সহায়তা বিকল্প প্ৰদৰ্শন কৰা হ'ব"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "প্ৰদৰ্শন কৰিবলে পেনেল"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- সংহতিসমূহ"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"উপলব্ধ কমান্ড শাৰী বিকল্পসমূহৰ এটা সম্পূৰ্ণ তালিকা চাবলে '%s --help' চাওক।\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "উপলব্ধ পেনেলসমূহ:"
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "সহায়"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "প্ৰস্থান কৰক"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+msgid "All Settings"
+msgstr "সকলো সংহতি"
+
+#. Add categories
+#: ../shell/cc-window.c:876
+msgctxt "category"
+msgid "Personal"
+msgstr "ব্যক্তিগত"
+
+#: ../shell/cc-window.c:877
+msgctxt "category"
+msgid "Hardware"
+msgstr "হাৰ্ডৱেৰ"
+
+#: ../shell/cc-window.c:878
+msgctxt "category"
+msgid "System"
+msgstr "চিস্টেম"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "পছন্দসমূহ;সংহতিসমূহ;"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Install Updates"
+#~ msgstr "আপডেইটসমূহ ইনস্টল কৰক"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "চিস্টেম বৰ্তমান-তাৰিখলে-উন্নত"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "নেটৱৰ্ক প্ৰিন্টাৰৰ বাবে সন্ধান কৰক অথবা ফলাফল ফিল্টাৰ কৰক"
+
+#~ msgid "Immediately"
+#~ msgstr "তৎক্ষনাত"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "এই নেটৱৰ্কত মাধ্যম অংশীদাৰী কৰক"
+
+#~ msgid "Shared Folders"
+#~ msgstr "অংশীদাৰী কৰা ফোল্ডাৰসমূহ"
+
+#~ msgid "column"
+#~ msgstr "স্তম্ভ"
+
+#~ msgid "Remove Folder"
+#~ msgstr "ফোল্ডাৰ আতৰাওক"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "এই নেটৱৰ্কত ৰাজহুৱা ফোল্ডাৰ অংশীদাৰী কৰক"
+
+#~ msgid "Remote View"
+#~ msgstr "দূৰৱৰ্তী দৰ্শন"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "সকলো সংযোগৰ অনুমতি দিয়ক"
+
+#~ msgid "_Default"
+#~ msgstr "অবিকল্পিত (_D)"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "নতুন ডিভাইচ সংস্থাপন কৰক"
+
+#~ msgid "Connection"
+#~ msgstr "সংযোগ"
+
+#~ msgid "Paired"
+#~ msgstr "সংযুক্ত"
+
+#~ msgid "Type"
+#~ msgstr "ধৰণ"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "মাউচ আৰু টাচপেড সংহতিসমূহ"
+
+#~ msgid "Sound Settings"
+#~ msgstr "শব্দ সংহতিসমূহ"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "কিবৰ্ড সংহতিসমূহ"
+
+#~ msgid "Send Files…"
+#~ msgstr "ফাইলসমূহ পঠাওক…"
+
+#~ msgid "Visibility"
+#~ msgstr "দৃশ্যমানতা"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” ৰ দৃশ্যমানতা"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "'%s' ক ডিভাইচসমূহৰ তালিকাৰ পৰা আতৰাব নে?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "যদি আপুনি ডিভাইচ আতৰায়, আপুনি ইয়াক পৰৱৰ্তী ব্যৱহাৰৰ আগত আকৌ সংস্থাপন কৰিব "
+#~ "লাগিব।"
+
+#~ msgid "Device type:"
+#~ msgstr "ডিভাইচৰ ধৰণ:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "উৎপাদক:"
+
+#~ msgid "Model:"
+#~ msgstr "আৰ্হি:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "উপৰোক্ত ক্ষেত্ৰসমূহ স্বচালিতভাৱে-সম্পূৰ্ণ কৰিবলে ছবি ফাইলসমূহক এই উইন্ডোত টানি আনিব "
+#~ "পাৰি।"
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "আপোনাৰ প্ৰাথমিক প্ৰদৰ্শনক এই পৰ্দাত দেখুৱাওক"
+
+#~ msgid "Combine"
+#~ msgstr "সংমিশ্ৰণ কৰক"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "এটা অতিৰিক্ত স্থান সৃষ্টি কৰিবলৈ প্ৰাথমিক প্ৰদৰ্শনৰ সৈতে সংযুক্ত কৰক"
+
+#~ msgid "Don't use the display"
+#~ msgstr "প্ৰদৰ্শন ব্যৱহাৰ নকৰিব"
+
+#~ msgid "Refresh Rate"
+#~ msgstr "সতেজ কৰাৰ হাৰ"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "মাউছ সম্পৰ্কিত পছন্দ"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "নতুন সেৱাৰ বাবে ব্যৱহাৰ কৰিবলে আন্তঃপৃষ্ঠ বাছক"
+
+#~ msgid "C_reate…"
+#~ msgstr "সৃষ্টি কৰক (_r)…"
+
+#~ msgid "_Interface"
+#~ msgstr "আন্তঃপৃষ্ঠ (_I)"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "কোনো নহয়"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "ৰাজহুৱা ফোল্ডাৰ অংশীদাৰী কৰক"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "কেৱল ভৰষাবান ডিভাইচসমূহৰ সৈতে অংশীদাৰী কৰক"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "ছবি পৰিবৰ্তন কৰা হৈ আছে:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "এই একাওন্টৰ বাবে লগিন পৰ্দাত দেখাব লগিয়া এটা ছবি বাছক।"
+
+#~ msgid "Gallery"
+#~ msgstr "গেলাৰী"
+
+#~ msgid "Take a photograph"
+#~ msgstr "এটা ছবি লওক"
+
+#~ msgid "Browse"
+#~ msgstr "ব্ৰাউছাৰ"
+
+#~ msgid "Photograph"
+#~ msgstr "ছবি"
+
+#~ msgid "Account Information"
+#~ msgstr "একাওন্ট তথ্য"
+
+#~ msgid "Left Shift"
+#~ msgstr "Left Shift"
+
+#~ msgid "Left Alt"
+#~ msgstr "Left Alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "Left Ctrl"
+
+#~ msgid "Right Shift"
+#~ msgstr "Right Shift"
+
+#~ msgid "Right Alt"
+#~ msgstr "Right Alt"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Right Ctrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Left Alt+Shift"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Right Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Left Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Right Ctrl+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Left+Right Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Left+Right Ctrl"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "Caps"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "_Region:"
+#~ msgstr "অঞ্চল (_R):"
+
+#~ msgid "_City:"
+#~ msgstr "চহৰ (_C):"
+
+#~ msgid "_Network Time"
+#~ msgstr "নেটৱৰ্ক সময় (_N)"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "সময়ক এক ঘন্টা আগত সংহতি কৰক।"
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "সময়ক এক ঘন্টা পিছত সংহতি কৰক।"
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "সময়ক এক মিনিট আগত সংহতি কৰক।"
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "সময়ক এক মিনিট পিছত সংহতি কৰক।"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM আৰু PM ৰ মাজত পৰিবৰ্তন কৰক।"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "স্বাভাৱিক"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "ঘড়িৰউলোটাদিশত"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "ঘড়িৰ দিশত"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "১৮০ ডিগ্ৰিসমূহ"
+
+#~ msgid "Monitor"
+#~ msgstr "মনিটৰ"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "প্ৰাথমিক প্ৰদৰ্শন সলনি কৰিবলে টানি আনক।"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "এটা মনিটৰৰ বৈশিষ্টসমূহ সলনি কৰিবলে তাক নিৰ্বাচন কৰক; তাৰ স্থাপনা পুনৰ সজাবলে "
+#~ "টানক।"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "সংৰূপ প্ৰয়োগ কৰিবলে ব্যৰ্থ: %s"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "মনিটৰ সংৰূপ সংৰক্ষণ কৰিবলৈ ব্যৰ্থ"
+
+#~ msgid "_Resolution"
+#~ msgstr "বিভেদন (_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "ঘূৰ্ণন (_o)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "আইনা প্ৰদৰ্শনসমূহ (_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "টোকা: বিভেদন বিকল্পসমূহ সীমিত কৰিব পাৰে"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "প্ৰদৰ্শনসমূহ চিনাক্ত কৰক (_D)"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "আঙুলিলৈ সমল স্টিক (_o)"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "আনুমানিক বেটাৰি ক্ষমতা: %s"
+
+#~ msgid "Hidden"
+#~ msgstr "গুপ্ত"
+
+#~ msgid "Visible"
+#~ msgstr "দৃশ্যমান"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "নাম আৰু দৃশ্যমানতা"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "আপুনি কিধৰণে পৰ্দা আৰু নেটৱৰ্কত উপস্থিত হয় নিয়ন্ত্ৰণ কৰক।"
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "ওপৰৰ বাৰত সম্পূৰ্ণ নাম প্ৰদৰ্শন কৰক (_f)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "পৰ্দা লক কৰাত সম্পূৰ্ণ নাম প্ৰদৰ্শন কৰক (_l)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "গোপন অৱস্থা (_S)"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "স্বাভাবিক"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "উচ্চ/উলোটা"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "পৰ্দাত কিবৰ্ড"
+
+#~ msgid "OnBoard"
+#~ msgstr "পৰ্দাত"
+
+#~ msgid "75%"
+#~ msgstr "৭৫%"
+
+#~ msgid "100%"
+#~ msgstr "১০০%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "স্বাভাৱিক"
+
+#~ msgid "125%"
+#~ msgstr "১২৫%"
+
+#~ msgid "150%"
+#~ msgstr "১৫০%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "ডাঙৰ"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Caps আৰু Num Lock ত বিপ কৰিব"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "অন বা অফ কৰক:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "জুম"
+
+#~ msgid "Zoom in:"
+#~ msgstr "ডাঙৰ কৰি দেখুৱাওক:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "সৰু কৰি দেখুৱাওক:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "বন্ধ শীৰোণামা"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "কথা আৰু শব্দৰ এটা লিখিত বিৱৰণ প্ৰদৰ্শন কৰক"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "পৰ্দাৰ কিবৰ্ড"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "সৰু"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "দীঘল"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "বিপ কৰিব যেতিয়া এটা কি"
+
+#~ msgid "pressed"
+#~ msgstr "টিপা হল"
+
+#~ msgid "accepted"
+#~ msgstr "গ্ৰহণ কৰা হল"
+
+#~ msgid "rejected"
+#~ msgstr "নাকচ কৰা হল"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "গ্ৰহণ বিলম্ব (_e):"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "কিপেড ব্যৱহাৰ কৰি পোইন্টাৰ নিয়ন্ত্ৰণ কৰক"
+
+#~ msgid "Video Mouse"
+#~ msgstr "ভিডিঅ' মাউছ"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "ভিডিঅ' কেমেৰা ব্যৱহাৰ কৰি পোইন্টাৰ নিয়ন্ত্ৰণ কৰক।"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "সৰু"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "ডাঙৰ"
+
+#~ msgid "Mouse Settings"
+#~ msgstr "মাউছ সংহতিসমূহ"
+
+#~ msgid "Add account"
+#~ msgstr "একাওন্ট যোগ কৰক"
+
+#~ msgid "_Local Account"
+#~ msgstr "স্থানীয় একাওন্ট (_L)"
+
+#~ msgid "_Login Name"
+#~ msgstr "লগিন নাম (_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "সহায়: এন্টাৰপ্ৰাইজ ডমেইন অথবা ৰাজত্বৰ নাম"
+
+#~ msgid "C_ontinue"
+#~ msgstr "চলাই থাকক (_o)"
+
+#~ msgid "Previous Week"
+#~ msgstr "পূৰ্বৱৰ্তী সপ্তাহ"
+
+#~ msgid "Next Week"
+#~ msgstr "অহা সপ্তাহ"
+
+#~ msgid "Next week"
+#~ msgstr "অহা সপ্তাহ"
+
+#~ msgid "Log in without a password"
+#~ msgstr "এটা পাছৱৰ্ড নহোৱাকৈ লগিন কৰক"
+
+#~ msgid "Disable this account"
+#~ msgstr "এই একাওন্ট অসামৰ্থবান কৰক"
+
+#~ msgid "Enable this account"
+#~ msgstr "এই একাওন্ট সামৰ্থবান কৰক"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "পাছৱৰ্ড সুনিশ্চিত কৰক (_o)"
+
+#~ msgid "Generate a password"
+#~ msgstr "এটা পাছৱৰ্ড সৃজন কৰক"
+
+#~ msgid "_Action"
+#~ msgstr "কাৰ্য্য (_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "পাছৱৰ্ড দেখুৱাওক (_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "এটা শক্তিশালী পাছৱৰ্ড কেনেধৰণে নিৰ্বাচন কৰা হব"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "অতি সৰু"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "পৰ্যাপ্ত ভাল নহয়"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "দুৰ্বল"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "নিৰপেক্ষ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "ভাল"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "শক্তিশালী"
+
+#~ msgid "_Generate a password"
+#~ msgstr "এটা পাছৱৰ্ড সৃজন কৰক (_G)"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "আপুনি এটা পাছৱৰ্ড সুমুৱাব লাগিব"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "নতুন পাছৱৰ্ড পৰ্যাপ্তভাৱে শক্তিশালী নহয়"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "আপুনি পাছৱৰ্ড সুনিশ্চিত কৰিব লাগিব"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "আপুনি আপোনাৰ বৰ্তমান পাছৱৰ্ড সুমুৱাব লাগিব"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "বৰ্তমান পাছৱৰ্ড সঠিক নহয়"
+
+#~ msgid "Wrong password"
+#~ msgstr "ভুল পাছৱৰ্ড"
+
+#~ msgid "Switch Modes"
+#~ msgstr "চুইচ অৱস্থাসমূহ"
+
+#~ msgid "Action"
+#~ msgstr "কাৰ্য্য"
+
+#~ msgid "Export"
+#~ msgstr "এক্সপোৰ্ট কৰক"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "লেহেম"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্ৰুত"
+
+#~ msgid "blablabla"
+#~ msgstr "blablabla"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "ঠিকনাৰ\n"
+#~ "অংশ\n"
+#~ "ইয়াত\n"
+#~ "আহিব"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "অংশ\n"
+#~ "ইয়াত\n"
+#~ "আহিব"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "পথসমূহৰ\n"
+#~ "অংশ\n"
+#~ "ইয়াত\n"
+#~ "আহিব"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "_Options…"
+#~ msgstr "বিকল্পসমূহ (_O)…"
+
+#~| msgid "None"
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "কোনো নহয়"
+
+#~ msgid "Change the background"
+#~ msgstr "পটভূমী পৰিবৰ্তন কৰক"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "ব্লুটুথ সংহতিসমূহ সংৰূপণ কৰক"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "ব্লুটুথ"
+
+#~ msgid "Color management settings"
+#~ msgstr "ৰঙ ব্যৱস্থাপনা সংহতিসমূহ"
+
+#~ msgid "British English"
+#~ msgstr "ব্ৰিটিচ ইংৰাজী"
+
+#~ msgid "Spanish"
+#~ msgstr "স্পেনিচ"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "চীনা (সৰলীকৃত)"
+
+#~ msgid "Select a region"
+#~ msgstr "এটা অঞ্চল বাছক"
+
+#~ msgid "Unspecified"
+#~ msgstr "অধাৰ্য্যত"
+
+#~ msgid "Select a language"
+#~ msgstr "এটা ভাষা বাছক"
+
+#~ msgid "_Select"
+#~ msgstr "নিৰ্বাচন কৰক (_S)"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "তাৰিখ আৰু সময় পছন্দসমূহ পেনেল"
+
+#~ msgid "System Information"
+#~ msgstr "চিস্টেম তথ্য"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "কিবৰ্ড সংহতিসমূহ পৰিবৰ্তন কৰক"
+
+#~ msgid "Layout Settings"
+#~ msgstr "বিন্যাস সংহতিসমূহ"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "আপোনাৰ মাউছ আৰু টাচপেড পছন্দসমূহ সংহতি কৰক"
+
+#~ msgid "Network settings"
+#~ msgstr "নেটৱৰ্ক সংহতিসমূহ"
+
+#~ msgid "Out of range"
+#~ msgstr "বিস্তাৰৰ বাহিৰ"
+
+#~ msgid "_Configure…"
+#~ msgstr "সংৰূপণ কৰক (_C)…"
+
+#~ msgid "_Disconnect"
+#~ msgstr "বিচ্ছিন্ন কৰক (_D)"
+
+#~ msgid "_Connect"
+#~ msgstr "সংযোগ কৰক (_C)"
+
+#~ msgid "_Settings…"
+#~ msgstr "সংহতিসমূহ (_S)…"
+
+#~ msgid "Disconnected"
+#~ msgstr "বিচ্ছিন্নিত"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "বাহক/সংযোগ পৰিবৰ্তন হল"
+
+#~ msgid "Manage notifications"
+#~ msgstr "অধিসূচনাসমূহ ব্যৱস্থাপনা কৰক"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "অৱসিত তথ্যসমূহ। অনুগ্ৰহ কৰি পুনৰ লগিন কৰক।"
+
+#~ msgid "_Log In"
+#~ msgstr "লগ ইন কৰক (_L)"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "অনলাইন একাওন্টসমূহ ব্যৱস্থাপনা কৰক"
+
+#~ msgid "Mark As Inactive After"
+#~ msgstr "চিহ্নিত সময়ৰ পিছত নিষ্ক্ৰিয় হিচাপে চিহ্নিত কৰিব"
+
+#~ msgid "Power management settings"
+#~ msgstr "শক্তি ব্যৱস্থাপনা সংহতিসমূহ"
+
+#~ msgid "Change printer settings"
+#~ msgstr "প্ৰিন্টাৰ সংহতিসমূহ সলনি কৰক"
+
+#~ msgid "Manufacturers"
+#~ msgstr "নিৰ্মাতাসকল"
+
+#~ msgid "Drivers"
+#~ msgstr "ড্ৰাইভাৰসমূহ"
+
+#~ msgid "Privacy settings"
+#~ msgstr "গোপনীয়তা সংহতিসমূহ"
+
+#~ msgid "Don't retain history"
+#~ msgstr "ইতিহাস অব্যাহত নাৰাখিব"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "আপোনাৰ অঞ্চল আৰু ভাষা সংহতিসমূহ সলনি কৰক"
+
+#~ msgid "Select an input source"
+#~ msgstr "এটা ইনপুট উৎস বাছক"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "লগিন পৰ্দা, চিস্টেম একাওন্টসমূহ আৰু নতুন ব্যৱহাৰকাৰী একাওন্টসমূহে চিস্টেম-বিস্তৃত "
+#~ "অঞ্চল আৰু ভাষা সংহতিসমূহ ব্যৱহাৰ কৰে।"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "লগিন পৰ্দা, চিস্টেম একাওন্টসমূহ আৰু নতুন ব্যৱহাৰকাৰী একাওন্টসমূহে চিস্টেম-বিস্তৃত "
+#~ "অঞ্চল আৰু ভাষা সংহতিসমূহ ব্যৱহাৰ কৰে। আপুনি আপোনাৰ সংহতিসমূহৰ সৈতে মিল খাবলে "
+#~ "চিস্টেম সংহতিসমূহ পৰিবৰ্তন কৰিব পাৰে।"
+
+#~ msgid "Copy Settings"
+#~ msgstr "সংহতিসমূহ কপি কৰক"
+
+#~ msgid "Copy Settings…"
+#~ msgstr "সংহতিসমূহ কপি কৰক…"
+
+#~ msgid "Region and Language"
+#~ msgstr "অঞ্চল আৰু ভাষা"
+
+#~ msgid "Select a display language"
+#~ msgstr "এটা প্ৰদৰ্শনৰ ভাষা বাছক"
+
+#~ msgid "Add Language"
+#~ msgstr "ভাষা যোগ কৰক"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "এটা অঞ্চল বাছক (পৰিবৰ্তন আপুনি পৰৱৰ্তী বাৰ লগিন কৰতে প্ৰয়োগ কৰা হব)"
+
+#~ msgid "Add Region"
+#~ msgstr "অঞ্চল যোগ কৰক"
+
+#~ msgid "Remove Region"
+#~ msgstr "অঞ্চল আতৰাওক"
+
+#~ msgid "Currency"
+#~ msgstr "টকা"
+
+#~ msgid "Examples"
+#~ msgstr "উদাহৰণসমূহ"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "কিবৰ্ডসমূহ অথবা অন্য ইনপুট উৎসসমূহ বাছক"
+
+#~ msgid "Remove Input Source"
+#~ msgstr "ইনপুট উৎস আতৰাওক"
+
+#~ msgid "Move Input Source Up"
+#~ msgstr "ইনপুট উৎসক উপৰত স্থানান্তৰ কৰক"
+
+#~ msgid "Show Keyboard Layout"
+#~ msgstr "কিবৰ্ড বিন্যাস দেখুৱাওক"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "চৰ্টকাট সংহতিসমূহ"
+
+#~ msgid "Display language:"
+#~ msgstr "ভাষা প্ৰদৰ্শন কৰক:"
+
+#~ msgid "Input source:"
+#~ msgstr "ইনপুট উৎস:"
+
+#~ msgid "Format:"
+#~ msgstr "বিন্যাস:"
+
+#~ msgid "Your settings"
+#~ msgstr "আপোনাৰ সংহতিসমূহ"
+
+#~ msgid "System settings"
+#~ msgstr "চিস্টেম সংহতিসমূহ"
+
+#~ msgid "Search settings"
+#~ msgstr "সংহতিসমূহ সন্ধান কৰক"
+
+#~ msgid "<b>Remote Login</b>"
+#~ msgstr "<b>দূৰৱৰ্তী লগিন</b>"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "সাৰ্বভৈমক অভিগম পছন্দসমূহ"
+
+#~ msgid "_Hint"
+#~ msgstr "আভাস (_H)"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "এই আভাস লগিন পৰ্দাত দেখুৱা হব পাৰে। ই চিস্টেমৰ সকলো ব্যৱহাৰকাৰীৰ বাবে দৃশ্যমান "
+#~ "থাকিব। পাছৱৰ্ড ইয়াত অন্তৰ্ভুক্ত <b>নকৰিব</b>।"
+
+#~ msgid "Fair"
+#~ msgstr "নিৰপেক্ষ"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "আপোনাৰ Wacom টেব্লেট পছন্দসমূহ সংহতি কৰক"
+
+#~ msgid "Control Center"
+#~ msgstr "নিয়ন্ত্ৰণ কেন্দ্ৰ"
+
+#~ msgid "1"
+#~ msgstr "১"
+
+#~ msgid "8"
+#~ msgstr "৮"
+
+#~ msgid "5"
+#~ msgstr "৫"
+
+#~ msgid "0"
+#~ msgstr "০"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i বছৰ"
+#~ msgstr[1] "%i বছৰ"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i মাহ"
+#~ msgstr[1] "%i মাহ"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i সপ্তাহ"
+#~ msgstr[1] "%i সপ্তাহ"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "১ সপ্তাহতকে কম"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "এই ডিভাইচ ৰঙ ব্যৱস্থাপিত নহয়।"
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "এই ডিভাইচে নিৰ্মিত মানাংকিত তথ্য ব্যৱহাৰ কৰি আছে।"
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "এই ডিভাইচৰ সম্পূৰ্ণ পৰ্দা ৰঙ সঠিকৰণৰ বাবে উপযোগী এটা আলেখ্য নাই।"
+
+#~ msgid "Not specified"
+#~ msgstr "ধাৰ্য্যত নহয়"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "ৰঙ ব্যৱস্থাপনা সমৰ্থন কৰা কোনো ডিভাইচ চিনাক্ত কৰা হোৱা নাই"
+
+#~ msgid "Browse Files..."
+#~ msgstr "ফাইলসমূহ ব্ৰাউছ কৰক..."
+
+#~ msgid "Create virtual device"
+#~ msgstr "ভাৰছুৱেল ডিভাইচ সৃষ্টি কৰক"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "প্ৰদৰ্শনৰ বাবে উপলব্ধ আলেখ্যসমূহ"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "স্কেনাৰসমূহৰ বাবে উপলব্ধ আলেখ্যসমূহ"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "প্ৰিন্টাৰসমূহৰ বাবে উপলব্ধ আলেখ্যসমূহ"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "কেমেৰাসমূহৰ বাবে উপলব্ধ আলেখ্যসমূহ"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "ৱেবকেমসমূহৰ বাবে উপলব্ধ আলেখ্যসমূহ"
+
+#~ msgid "Add device"
+#~ msgstr "ডিভাইচ যোগ কৰক"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "এটা ভাৰছুৱেল ডিভাইচ যোগ কৰক"
+
+#~ msgid "Remove a device"
+#~ msgstr "এটা ডিভাইচ আতৰাওক"
+
+#~ msgid "English"
+#~ msgstr "ইংৰাজী"
+
+#~ msgid "German"
+#~ msgstr "জাৰ্মান"
+
+#~ msgid "French"
+#~ msgstr "ফৰাচী"
+
+#~ msgid "Russian"
+#~ msgstr "ৰাছিয়ান"
+
+#~ msgid "Arabic"
+#~ msgstr "আৰবী"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "অজ্ঞাত আৰ্হি"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "পৰৱৰ্তী লগিনে প্ৰামাণিক অনুভৱ ব্যৱহাৰ কৰাৰ চেষ্টা কৰিব।"
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr "পৰৱৰ্তী লগিনে অসমৰ্থিত গ্ৰাফিক্স হাৰ্ডৱেৰৰ বাবে ফলবেক অৱস্থা ব্যৱহাৰ কৰিব।"
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "ফলবেক"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "প্ৰামাণিক"
+
+#~ msgid "OS type"
+#~ msgstr "OS ধৰণ"
+
+#~ msgid "_Other Media..."
+#~ msgstr "অন্য মাধ্যম (_O)..."
+
+#~ msgid "Experience"
+#~ msgstr "অনুভৱ"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "বলৱৎ ফলবেক অৱস্থা (_F)"
+
+#~ msgid "_Options..."
+#~ msgstr "বিকল্পসমূহ (_O)..."
+
+#~ msgid "C_reate..."
+#~ msgstr "সৃষ্টি কৰক (_r)..."
+
+#~ msgid "_Settings..."
+#~ msgstr "সংহতিসমূহ (_S)..."
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "সাৱধান বেটাৰি কম আছে, %s অৱশিষ্ট"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "বেটাৰি শক্তি ব্যৱহাৰ কৰা হৈছে - %s অৱশিষ্ট"
+
+#~ msgid "Using battery power"
+#~ msgstr "বেটাৰি শক্তি ব্যৱহাৰ কৰা হৈছে"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "চাৰ্জ কৰা হৈ আছে - সম্পূৰ্ণ চাৰ্জ হল"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "UPS শক্তি ব্যৱহাৰ কৰা হৈছে - %s অৱশিষ্ট"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "সাৱধান কম UPS"
+
+#~ msgid "Using UPS power"
+#~ msgstr "UPS শক্তি ব্যৱহাৰ কৰা হৈছে"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "আপোনাৰ দ্বিতীয় বেটাৰি সম্পূৰ্ণভাৱে চাৰ্জ কৰা হল"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "আপোনাৰ দ্বিতীয় বেটাৰি ৰিক্ত"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "চাৰ্জ কৰা হৈ আছে - সম্পূৰ্ণ চাৰ্জ হল"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "সহায়: <a href=\"screen\">পৰ্দাৰ উজ্জ্বলতা</a> কিমান শক্তি ব্যৱহাৰ কৰা হৈছে তাৰ "
+#~ "ওপৰত প্ৰভাৱ পেলায়"
+
+#~ msgid "Don't suspend"
+#~ msgstr "বাতিল নকৰিব"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "ৰখোৱা হৈছে"
+
+#~ msgid "_Show"
+#~ msgstr "দেখুৱাওক (_S)"
+
+#~ msgid "Choose an input source"
+#~ msgstr "এটা ইনপুট উৎস বাছক"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "সংহতিসমূহ কপি কৰক..."
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "এটা প্ৰদৰ্শন ভাষা বাছক (পৰিবৰ্তন আপুনি পৰৱৰ্তী বাৰ লগিন কৰোতে প্ৰয়োগ কৰা হব)"
+
+#~ msgid "Install languages..."
+#~ msgstr "ভাষাসমূহ ইনস্টল কৰক..."
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "উজ্জ্বলতা & লক"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "পৰ্দাৰ উজ্জ্বলতা আৰু লক সংহতিসমূহ"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "উজ্জ্বলতা;লক;স্লান;ৰিক্ত;মনিটৰ;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "শক্তি সংৰক্ষণ কৰিবলে পৰ্দা স্লান কৰক (_D)"
+
+#~ msgid "_Turn screen off when inactive for:"
+#~ msgstr "পৰ্দা বন্ধ কৰিব যেতিয়া নিষ্ক্ৰিয় (_T):"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "ঘৰত থাকোতে লক নকৰিব"
+
+#~ msgid "Locations..."
+#~ msgstr "অবস্থানসমূহ..."
+
+#~ msgid "Lock"
+#~ msgstr "লক"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "ডিবাগিং ক'ড সামৰ্থবান কৰক"
+
+#~ msgid "Version of this application"
+#~ msgstr "এই এপ্লিকেচনৰ সংস্কৰণ"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME ভলিউম নিয়ন্ত্ৰণ এপ্লেট"
+
+#~ msgid "Volume Control"
+#~ msgstr "ভলিউমৰ নিয়ন্ত্ৰণ"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "ডেস্কটপ ভলিউমৰ নিয়ন্ত্ৰণ দেখুৱাওক"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "শব্দ আউটপুট ভলিউম"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "মাইক্ৰোফোন ভলিউম"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "শব্দ পছন্দসমূহ আৰম্ভ কৰিবলে ব্যৰ্থ হল: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "মৌণ কৰক (_M)"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "শব্দ পছন্দসমূহ (_S)"
+
+#~ msgid "Muted"
+#~ msgstr "মৌণ কৰা আছে"
+
+#~ msgid "Options..."
+#~ msgstr "বিকল্পসমূহ..."
+
+#~ msgid "User Accounts"
+#~ msgstr "ব্যৱহাৰকাৰী একাওন্টসমূহ"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "অধিক ছবিৰ বাবে ব্ৰাউছ কৰক..."
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "'%s' নামৰ কোনো ব্যৱহাৰকাৰীৰ অস্তিত্ব নাই।"
+
+#~ msgid "This user does not exist."
+#~ msgstr "এইজন ব্যৱহাৰকাৰী অস্তিত্ববান নহয়।"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "বুটামসমূহ মেপ কৰক..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "মানাংকন কৰক..."
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "নেটৱৰ্ক;বেতাঁৰ;IP;LAN;প্ৰক্সি;"
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "বেতাঁৰ হটস্পট"
+
+#~ msgid "Wireless"
+#~ msgstr "বেতাঁৰ"
+
+#~ msgid "Mesh"
+#~ msgstr "মেশ"
+
+#~ msgid "Remove Language"
+#~ msgstr "ভাষা আতৰাওক"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "ৰঙ"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "কোনো নহয়"
+
+#~ msgid "- System Settings"
+#~ msgstr "- চিস্টেম সংহতিসমূহ"
+
+#~ msgid "System Settings"
+#~ msgstr "চিস্টেম সংহতিসমূহ"
+
+#~ msgid "Security Key"
+#~ msgstr "সুৰক্ষা কি"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "চাবনেট মাস্ক"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "আপোনাৰ সংহতিসমূহ পৰীক্ষা কৰিবলে, মুখত দুবাৰ-ক্লিক কৰাৰ চেষ্টা কৰক"
+
+#~ msgid "_Search by Address"
+#~ msgstr "ঠিকনাৰ সহায়ত সন্ধান কৰক (_S)"
+
+#~ msgid "Getting devices..."
+#~ msgstr "ডিভাইচসমূহ প্ৰাপ্ত কৰা হৈ আছে..."
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD চলি থকা নাই। নেটৱৰ্ক প্ৰিন্টাৰ চিনাক্তকৰণৰ বাবে সেৱাসমূহ mdns, ipp, "
+#~ "ipp-client আৰু samba-client ফায়াৰৱালত সামৰ্থবান থাকিব লাগিব।"
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "স্থানীয়"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "নেটৱৰ্ক"
+
+#~ msgid "Device types"
+#~ msgstr "ডিভাই ধৰণসমূহ"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "স্বচালিত সংৰূপ"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "mDNS সংযোগসমূহৰ বাবে ফায়াৰৱাল খোলা হৈ আছে"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Samba সংযোগসমূহৰ বাবে ফায়াৰৱাল খোলা হৈ আছে"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "IPP সংযোগসমূহৰ বাবে ফায়াৰৱাল খোলা হৈ আছে"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "ৱালপেপাৰ যোগ কৰক"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "ৱালপেপাৰ আতৰাওক"
+
+#~ msgid "Swap colors"
+#~ msgstr "ৰঙ পৰিবৰ্তন কৰক"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "আনুভূমিক গ্ৰেডিয়েন্ট"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "উলম্ব গ্ৰেডিয়েন্ট"
+
+#~ msgid "Solid Color"
+#~ msgstr "ডাঠ ৰঙ"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "ৰঙসমূহ & গ্ৰেডিয়েন্টসমূহ"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "এটা স্ক্ৰিনশ্বট লওক"
+
+#~ msgid "Shortcut"
+#~ msgstr "চৰ্টকাট"
+
+#~ msgid "_Right-handed"
+#~ msgstr "সোঁহাতৰ (_R)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "বাওঁহাতৰ (_L)"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Control কি টিপোতে পোইন্টাৰৰ অৱস্থান দেখুৱাওক (_o)"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "ত্বৰণ (_c):"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "সংবেদনশীলতা (_S):"
+
+#~ msgctxt "Mouse sensitivity"
+#~ msgid "Low"
+#~ msgstr "নিম্ন"
+
+#~ msgctxt "Mouse sensitivity"
+#~ msgid "High"
+#~ msgstr "উচ্চ"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "ড্ৰেগ আৰু ড্ৰপ"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "ডেউৰী (_e):"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "টান্ ডেউৰী"
+
+#~ msgid "Double-Click Timeout"
+#~ msgstr "দুবাৰ ক্লিকৰ সময়সীমা"
+
+#~ msgid "_Timeout:"
+#~ msgstr "সময়অন্ত: (_T)"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "টাচপেডৰ সৈতে মাউছ ক্লিকসমূহ সামৰ্থবান কৰক (_m)"
+
+#~ msgid "Scrolling"
+#~ msgstr "স্ক্রোল ব্যবস্থা"
+
+#~ msgid "_Disabled"
+#~ msgstr "নিষ্ক্ৰিয় (_D)"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "সংৰূপণ কৰিবলে এটা ডিভাইচ বাছক (_h):"
+
+#~ msgid "Account _type"
+#~ msgstr "একাওন্টৰ ধৰণ (_t)"
+
+#~ msgid "_Back"
+#~ msgstr "পিছলৈ যাওক (_B)"
+
+#~ msgid "Printer Options"
+#~ msgstr "প্ৰিন্টাৰ বিকল্পসমূহ"
+
+#~ msgid "Allowed users"
+#~ msgstr "অনুমোদিত ব্যৱহাৰকাৰীসমূহ"
+
+#~ msgid "Acti_on:"
+#~ msgstr "কাৰ্য্য (_o):"
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "তথাপিও হটস্পট সৃষ্টি কৰিব নে?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "%s ৰ পৰা বিচ্ছিন্ন কৰি এটা নতুন হটস্পট সৃষ্টি কৰিব নে?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "ই ইন্টাৰনেটলে আপোনাৰ একমাত্ৰ সংযোগ।"
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "হটস্পট সৃষ্টি কৰক (_H)"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "অন্য..."
+
+#~ msgid "_Network Name"
+#~ msgstr "নেটৱৰ্কৰ নাম (_N)"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "হটস্পট বন্ধ কৰক (_S)..."
+
+#~ msgid "Disable VPN"
+#~ msgstr "VPN অসামৰ্থবান কৰক"
+
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP পোৰ্ট"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "HTTPS পোৰ্ট"
+
+#~ msgid "FTP Port"
+#~ msgstr "FTP পোৰ্ট"
+
+#~ msgid "Select an account"
+#~ msgstr "এটা একাওন্ট বাছক"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "এটা নতুন একাওন্ট যোগ কৰিবলে, প্ৰথমতে একাওন্ট ধৰণ নিৰ্বাচন কৰক"
+
+#~ msgid "_Add..."
+#~ msgstr "যোগ কৰক...(_A)"
+
+#~ msgid "Tip:"
+#~ msgstr "সহায়:"
+
+#~ msgid "Brightness Settings"
+#~ msgstr "উজ্জ্বলতা সংহতিসমূহ"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "কিমান শক্তি ব্যৱহাৰ কৰা হৈছে প্ৰভাৱ পেলায়"
+
+#~ msgid "Add Layout"
+#~ msgstr "বিন্যাস যোগ কৰক"
+
+#~ msgid "Remove Layout"
+#~ msgstr "বিন্যাস আতৰাওক"
+
+#~ msgid "Preview Layout"
+#~ msgstr "বিন্যাস পূৰ্বদৰ্শন কৰক"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "নতুন উইন্ডোসমূহে অবিকল্পিত বিন্যাস ব্যৱহাৰ কৰে"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "নতুন উইন্ডোসমূহে পূৰ্বৱৰ্তী উইন্ডোৰ বিন্যাস ব্যৱহাৰ কৰে"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "কিবৰ্ড বিন্যাস বিকল্পসমূহ দৰ্শন আৰু সম্পাদন কৰক"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "অবিকল্পিত মান আকৌ স্থাপন কৰক (_f)"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "বৰ্তমান কিবৰ্ড বিন্যাস সংহতিসমূহক অবিকল্পিত সংহতিসমূহৰ সৈতে\n"
+#~ "প্ৰতিস্থাপন কৰক"
+
+#~ msgid "Layouts"
+#~ msgstr "পৰিকল্পনাসমূহ"
+
+#~ msgid "Layout"
+#~ msgstr "পৰিকল্পনা"
+
+#~ msgid "Change contrast:"
+#~ msgstr "কনট্ৰাস্ট পৰিবৰ্তন কৰক:"
+
+#~ msgid "_Text size:"
+#~ msgstr "লিখনি আকাৰ (_T):"
+
+#~ msgid "Increase size:"
+#~ msgstr "আকাৰ বৃদ্ধি কৰক:"
+
+#~ msgid "Decrease size:"
+#~ msgstr "আকাৰ সৰু কৰক:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "প্ৰদৰ্শন কৰক"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "জুম"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "সংহতিসমূহ পৰীক্ষা কৰিবলে ইয়াত লিখক"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "১/২ পৰ্দা"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "৩/৪ পৰ্দা"
+
+#~ msgid "Create new account"
+#~ msgstr "নতুন একাওন্ট সৃষ্টি কৰক"
+
+#~ msgid "_Account Type"
+#~ msgstr "একাওন্ট ধৰণ (_A)"
+
+#~ msgid "Cr_eate"
+#~ msgstr "সৃষ্টি কৰক (_e)"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "এটা সৃজন কৰা পাছৱৰ্ড বাছক"
+
+#~ msgid "More choices..."
+#~ msgstr "অধিক পছন্দসমূহ..."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Wacom গ্ৰাফিক্স টেবলেট"
+
+#~| msgid "Create New Location"
+#~ msgid "Current network location"
+#~ msgstr "নেটওয়ার্কেৰ বর্তমান অবস্থান"
+
+#~ msgid "More themes URL"
+#~ msgstr "অতিৰিক্ত থিম প্ৰাপ্ত কৰাৰ URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "বর্তমান অবস্থানেৰ নাম হিসাবে এটি ধার্য কৰা হয়। নেটওয়ার্ক প্ৰক্সিৰ যথাযত সংৰূপ "
+#~ "চিনাক্ত কৰাৰ জন্য এটি প্ৰয়োগ কৰা হয়।"
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "ডেস্কটপৰ জন্য পটভূমিৰ অতিৰিক্ত ছবি প্ৰাপ্ত কৰাৰ URL। এই ক্ষেত্ৰে একটি ফাঁকা পংক্তি "
+#~ "চিহ্নিত হলে লিংক প্ৰদর্শন কৰা হব না।"
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "ডেস্কটপৰ জন্য অতিৰিক্ত থিম প্ৰাপ্ত কৰাৰ URL। এই ক্ষেত্ৰে একটি ফাঁকা পংক্তি চিহ্নিত "
+#~ "হলে লিংক প্ৰদর্শন কৰা হব না।"
+
+#~ msgid "Image/label border"
+#~ msgstr "ছবি/লেবেলৰ প্ৰান্তৰেখা"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "সতৰ্কবাৰ্তা প্ৰদৰ্শনকাৰী সম্বাদ বক্সৰ লেবেল আৰু ছবিৰ প্ৰান্তৰেখাৰ প্ৰস্থ"
+
+#~ msgid "The type of alert"
+#~ msgstr "সতৰ্কবাৰ্তাৰ ধৰণ"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "সতৰ্কবাৰ্তাৰ সম্বাদ-বক্সত প্ৰদৰ্শিত বুটাম"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "%sত বাওঁহাতৰ বুঢ়া আঙ্গুলি ৰাখক"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "%sৰ ওপৰত বাওঁহাতৰ বুঢ়া আঙ্গুলি চোৱাইপ কৰক"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "%sত বাওঁহাতৰ তৰ্জনি ৰাখক"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "%sৰ ওপৰত বাওঁহাতৰ তৰ্জনি চোৱাইপ কৰক"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "%sত বাওঁহাতৰ মধ্যমা ৰাখক"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "%sৰ ওপৰত বাওঁহাতৰ মধ্যমা চোৱাইপ কৰক"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "%sত বাওঁহাতৰ অনামিকা ৰাখক"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "%sৰ ওপৰত বাওঁহাতৰ অনামিকা চোৱাইপ কৰক"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "%sত বাওঁহাতৰ কনিষ্টা ৰাখক"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "%sৰ ওপৰত বাওঁহাতৰ কনিষ্টা চোৱাইপ কৰক"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "%sত সোঁ হাতৰ বুঢ়া আঙ্গুলি ৰাখক"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "%sৰ ওপৰত সোঁ হাতৰ বুঢ়া আঙ্গুলি চোৱাইপ কৰক"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "%sত সোঁ হাতৰ তৰ্জনি ৰাখক"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "%sত সোঁ হাতৰ তৰ্জনি চোৱাইপ কৰক"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "%sত সোঁ হাতৰ মধ্যমা ৰাখক"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "%sৰ ওপৰত সোঁ হাতৰ মধ্যমা চোৱাইপ কৰক"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "%sত সোঁ হাতৰ অনামিকা ৰাখক"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "%sৰ ওপৰত সোঁ হাতৰ অনামিকা চোৱাইপ কৰক"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "%sত সোঁ হাতৰ কনিষ্টা ৰাখক"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "%sৰ ওপৰত সোঁ হাতৰ কনিষ্টা চোৱাইপ কৰক"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "ৰিডাৰৰ ওপৰত আপোনাৰ আঙ্গুলি পকঃ ৰাখক"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "পকঃ আপোনাৰ আঙ্গুলি চোৱাইপ কৰক"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "অত্যন্ত কম সময় চোৱাইপ কৰা হৈছে, পকঃ প্ৰচেষ্টা কৰক"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "আঙ্গুলি কেন্দ্ৰত স্থাপিত নাছিল, পকঃ চোৱাইপ কৰাৰ চেষ্টা কৰক"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "আঙ্গুলি আঁতৰাই লওক আৰু পকঃ সেইটো ৰাখি চোৱাইপ কৰাৰ প্ৰচেষ্টা কৰক"
+
+#~ msgid "No Image"
+#~ msgstr "কোনো ছবি নাই"
+
+#~ msgid "Images"
+#~ msgstr "ছবি"
+
+#~ msgid "All Files"
+#~ msgstr "সৰ্বধৰণৰ ফাইল"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "ঠিকনা বহি তথ্য সংগ্ৰহৰ সময়ত এটা সমস্যা ‍হৈছে।\n"
+#~ "ব্যৱহৃত আচাৰ বিধি ইভলিউছন তথ্য সেৱকে বুজি নাপায়"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "ঠিকনা বহি খোলা নাযায়"
+
+#~ msgid "About %s"
+#~ msgstr "%s ৰ বিষয়ে"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "কোম্পানি (_o):"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "পাছৱৰ্ড পৰিবৰ্তন... (_r)"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "ছহৰ (_t):"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "দেশ (_n):"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "আঙ্গুলিৰ ছাপ লগিন নিষ্ক্ৰিয় কৰক...(_F)"
+
+#~| msgid "Small"
+#~ msgid "Email"
+#~ msgstr "ই-মেইল"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "আঙ্গুলিৰ ছাপ লগিন সক্ৰিয় কৰক...(_F)"
+
+#~ msgid "Hom_e:"
+#~ msgstr "গৃহ:(_e)"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~| msgid "<b>Instant Messaging</b>"
+#~ msgid "Instant Messaging"
+#~ msgstr "ইনস্ট্যান্ট বার্তালাপ"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _box:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. box:"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "ৰাজ্য/প্ৰদেশ (_v):"
+
+#~ msgid "Web _log:"
+#~ msgstr "ৱেব লগ (_l):"
+
+#~ msgid "Wor_k:"
+#~ msgstr "কাৰ্য্যালয় (_k):"
+
+#~| msgid "Wor_k:"
+#~ msgid "Work"
+#~ msgstr "কাজ"
+
+#~ msgid "Work _fax:"
+#~ msgstr "কাৰ্য্যালয়ৰ ফেক্স (_f):"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "জিপ/পোচ্‌টেল কোড (_P):"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "ঘৰৰ পৃষ্ঠা: (_H)"
+
+#~ msgid "_Home:"
+#~ msgstr "ঘৰ: (_H)"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "ৰাষ্ট্ৰ/প্ৰদেশ (_S):"
+
+#~ msgid "_Work:"
+#~ msgstr "কাৰ্য্য (_W):"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "জিপ/পোচ্‌টেল কোড (_Z):"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "ৰিডাৰৰ ওপৰত আঙ্গুলি চোৱাইপ কৰক"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "ৰিডাৰৰ ওপৰত আঙ্গুলি ৰাখক"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "চাইল্ড অপ্ৰত্যাশিতৰূপে বন্ধ হৈছে"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO চেনেল বন্ধ কৰোঁতে ব্যৰ্থ: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO চেনেল বন্ধ কৰোঁতে ব্যৰ্থ: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "চিস্টেম সমস্যা: %s।"
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%s আৰম্ভ কৰোঁতে ব্যৰ্থ: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "বেকএন্ড আৰম্ভ কৰা নাযায়"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "চিস্টেম সমস্যা ‍হৈছে"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "পাছৱৰ্ড পৰিবৰ্তনৰ বাবে <b>পাছৱৰ্ড পৰিবৰ্তন</b> টিপক।"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "অনুগ্ৰহ কৰি <b>নতুন পাছৱৰ্ড আকৌ লিখক</b> শীৰ্ষক ক্ষেত্ৰত পাছৱৰ্ড আকৌ লিখক।"
+
+#~| msgid "Change password"
+#~ msgid "Change your password"
+#~ msgstr "পাসওয়ার্ড পৰিবর্তন কৰুন"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "পাছৱৰ্ড পৰিবৰ্তনৰ বাবে নিম্নলিখিত ক্ষেত্ৰত নিজৰ বৰ্তমান পাছৱৰ্ড লিখক আৰু "
+#~ "<b>অনুমোদন</b> টিপক।\n"
+#~ "অনুমোদিত হ'লে, নতুন পাছৱৰ্ড লিখক, সুনিশ্চিত কৰাৰ বাবে পুনঃ পাছৱৰ্ড লিখি, "
+#~ "<b>পাছৱৰ্ড পৰিবৰ্তন</b> টিপক।"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "ব্যৱহাৰযোগ্য লগিন (_g)"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "সহায়ক প্ৰযুক্তি"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "সহায়ক প্ৰযুক্তি বিষয়ক পছন্দ"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr "আকৌ লগিন নকৰালৈকে সহায়ক প্ৰযুক্তি এই পৰিবৰ্তনসমূহ প্ৰয়োগ কৰা ন'হ'ব।"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "বন্ধ কৰি প্ৰস্থান কৰক (_L)"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "পছন্দৰ এপ্লিকেচনৰ সম্বাদলৈ যাওক"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "ব্যৱহাৰযোগ্য লগিন সম্বাদেলৈ যাওক"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "কি ফলকৰ সহায়ক প্ৰযুক্তি সম্বাদেলৈ যাওক"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "মাউস সহায়ক প্ৰযুক্তি ডায়লগে এগিয়ে চলুন"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "সহায়ক প্ৰযুক্তি ব্যৱহাৰ কৰক (_E)"
+
+#~ msgid "_Keyboard Accessibility"
+#~ msgstr "কি ফলকৰ সহায়ক প্ৰযুক্ত (_K)"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "মাউস ব্যবহাৰৰ সহায়ক প্ৰযুক্তি (_M)"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "পছন্দৰ এপ্লিকেচন (_P)"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr ""
+#~ "লগিন কৰাৰ সময়, বিশেষ ব্যবহাৰৰ কোনো ব্যবস্থাসমূহ সক্ৰিয় কৰা হ'ব সেইটো নিৰ্বাচন "
+#~ "কৰক"
+
+#~ msgid "Font may be too large"
+#~ msgstr "ফন্ট সম্ভৱতঃ বৰ ডাঙৰ"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "নিৰ্ব্বাচত ফন্ট %d পইন্ট ডাঙৰ, আৰু কম্পিউটাৰ ব্যৱহাৰ কৰিবলৈ সহজ ন'হ'বও পাৰে। "
+#~ "আপুনি %d ত কৈ সৰু আকাৰ বাচি লোৱাৰ উপদেশ দিওঁ।"
+#~ msgstr[1] ""
+#~ "নিৰ্ব্বাচত ফন্ট %d পইন্ট ডাঙৰ, আৰু কম্পিউটাৰ ব্যৱহাৰ কৰিবলৈ সহজ ন'হ'বও পাৰে। "
+#~ "আপুনি %d ত কৈ সৰু আকাৰ বাচি লোৱাৰ উপদেশ দিওঁ।"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "বাচি লোৱা ফন্টৰ আকাৰ %d; কিন্তু ইমান ডাঙৰ আকাৰৰ ফন্ট বাচি ল'লে কম্পিউটাৰত "
+#~ "ব্যৱহাৰ কৰা কঠিন হ'ব। সেইবাবে আপোনাক আৰু সৰু আকাৰৰ ফন্ট বাচি লোৱাৰ বাবে উপদেশ "
+#~ "দিয়া হৈছে।"
+#~ msgstr[1] ""
+#~ "বাচি লোৱা ফন্টৰ আকাৰ %d; কিন্তু ইমান ডাঙৰ আকাৰৰ ফন্ট বাচি ল'লে কম্পিউটাৰত "
+#~ "ব্যৱহাৰ কৰা কঠিন হ'ব। সেইবাবে আপোনাক আৰু সৰু আকাৰৰ ফন্ট বাচি লোৱাৰ বাবে উপদেশ "
+#~ "দিয়া হৈছে।"
+
+#~ msgid "Use previous font"
+#~ msgstr "পূৰ্ববৰ্তী ফন্ট ব্যৱহাৰ কৰা হ'ব"
+
+#~ msgid "Use selected font"
+#~ msgstr "নিৰ্বাচিত ফন্ট ব্যৱহাৰ কৰা হ'ব"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "সংস্থাপন কৰাৰ বাবে কোনো থিম ফাইলৰ নাম উল্লেখ কৰক"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr "প্ৰদৰ্শন কৰিব লগা পৃষ্ঠাৰ নাম দিয়ক (theme|background|fonts|interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "আবশ্যক GTK+ থিম ইঞ্জিন '%s' ইনস্টল না থাকাৰ ফলস্বৰূপ চিহ্নিত থিমটি সঠিকৰূপে "
+#~ "প্ৰদৰ্শিত নহব।"
+
+#~ msgid "Apply Background"
+#~ msgstr "পটভূমি প্ৰয়োগ কৰক"
+
+#~ msgid "Apply Font"
+#~ msgstr "ফন্ট প্ৰয়োগ কৰক"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "এই থিমেৰ ক্ষেত্ৰত প্ৰস্তাবিত পটভূমি আৰু ফন্ট উপস্থিত ৰয়েছে। ওপৰতন্তু, সৰ্বশেষ "
+#~ "প্ৰস্তাবিত ফন্ট নাকচ কৰা যাবে।"
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "এই থিমেৰ ক্ষেত্ৰত প্ৰস্তাবিত পটভূমি উপস্থিত ৰয়েছে। ওপৰতন্তু, সৰ্বশেষ প্ৰস্তাবিত ফন্ট "
+#~ "নাকচ কৰা যাবে।"
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "এই থিমে পটভূমি আৰু ফন্টৰ প্ৰস্তাব দিছে।"
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "এই থিমেৰ ক্ষেত্ৰত প্ৰস্তাবিত ফন্ট উপস্থিত ৰয়েছে। ওপৰতন্তু, সৰ্বশেষ প্ৰস্তাবিত ফন্ট "
+#~ "নাকচ কৰা যাবে।"
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "এই থিমে পটভূমিৰ প্ৰস্তাব দিছে।"
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "সৰ্বশেষ প্ৰয়োগ কৰা প্ৰস্থাবিত ফন্টেৰ নিৰ্বাচন নাকচ কৰা যাবে।"
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "এই থিমে ফন্টৰ প্ৰস্তাব দিছে।"
+
+#~ msgid "Best _shapes"
+#~ msgstr "সৰ্বোত্তম আকাৰ (_s)"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Best co_ntrast"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "স্বনিৰ্ধাৰিত...(_u)"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "ইয়াৰ পিছৰ বাৰ লগিন কৰোঁতে আপোনাৰ কাৰ্ছৰৰ থিম সলনি কৰা প্ৰযোজ্য হয়।"
+
+#~ msgid "Controls"
+#~ msgstr "নিয়ন্ত্ৰণ"
+
+#~ msgid "Customize Theme"
+#~ msgstr "স্বনিৰ্ধাৰিত থিম"
+
+#~ msgid "D_etails..."
+#~ msgstr "বিৱৰণ...(_e)"
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "ডেস্কটপত ব্যৱহৃত ফন্ট (_k):"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "ফন্ট ৰেন্ডাৰিঙৰ বিৱৰণ"
+
+#~| msgid "Save _background image"
+#~ msgid "Get more backgrounds online"
+#~ msgstr "পটভূমিৰ অতিৰিক্ত ছবি অন-লাইন প্ৰাপ্ত কৰুন"
+
+#~ msgid "Get more themes online"
+#~ msgstr "অতিৰিক্ত থিম অন-লাইন প্ৰাপ্ত কৰুন"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "গ্ৰেস্কেল(_y)"
+
+#~| msgid "<b>Hinting</b>"
+#~ msgid "Hinting"
+#~ msgstr "হিন্টিং"
+
+#~ msgid "Icons"
+#~ msgstr "আইকন"
+
+#~| msgid "Icons"
+#~ msgid "Icons only"
+#~ msgstr "শুধুমাত্ৰ আইকন"
+
+#~| msgid "<b>Menus and Toolbars</b>"
+#~ msgid "Menus and Toolbars"
+#~ msgstr "মেনু ও টুলবাৰ"
+
+#~ msgid "N_one"
+#~ msgstr "শূণ্য (_o)"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "ৰং নিৰ্ধাৰণৰ বাবে এটা সম্বাদ খোলক"
+
+#~ msgid "R_esolution:"
+#~ msgstr "বিশ্লেষণ: (_e)"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "নতুন ৰূপত থিম সংৰক্ষণ..."
+
+#~ msgid "Save _As..."
+#~ msgstr "নতুন নামে সংৰক্ষণ কৰক (_A)..."
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "তালিকাত আইকন প্ৰদৰ্শন কৰক (_i)"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "ছাবপিক্সেল (LCD) (_p)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "ছাবপিক্সেল স্মুদিং (LCD) (_p)"
+
+#~| msgid "<b>Subpixel Order</b>"
+#~ msgid "Subpixel Order"
+#~ msgstr "সাবপিক্সেলেৰ ধাৰা"
+
+#~ msgid "Text below items"
+#~ msgstr "বস্তুৰ নীচে লেখা স্থাপন"
+
+#~| msgid "_Selected items:"
+#~ msgid "Text beside items"
+#~ msgstr "বস্তুৰ পাশে লেখা স্থাপন"
+
+#~| msgid "Test Sound"
+#~ msgid "Text only"
+#~ msgstr "শুধুমাত্ৰ টেক্সট"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "বৰ্ত্তমানৰ নিয়ন্ত্ৰণৰ থিমে ৰংৰ স্কীমৰ সমৰ্থন নকৰি।"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "টুলবাৰৰ বুটামৰ লেবেল: (_b)"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "বিৱৰণ: (_D)"
+
+#~ msgid "_Document font:"
+#~ msgstr "আলেখ্যনত ব্যৱহৃত ফন্ট (_D):"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "সম্পাদনযোগ্য তালিকাৰ চৰ্টকাট কি (_E)"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "নিৰ্দিষ্ট প্ৰস্থবিশিষ্ট ফন্ট (_F):"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Monochrome"
+
+#~ msgid "_None"
+#~ msgstr "শূণ্য (_N)"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "অবিকল্পিত মান আকৌ স্থাপন কৰক(_R)"
+
+#~ msgid "_Selected items:"
+#~ msgstr "নিৰ্বাচিত বস্তু: (_S)"
+
+#~ msgid "_Size:"
+#~ msgstr "মাপ:(_S)"
+
+#~ msgid "_Slight"
+#~ msgstr "স্বল্প (_S)"
+
+#~ msgid "_Style:"
+#~ msgstr "বিন্যাস:(_S)"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "টুল-টিপ: (_T)"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "সংযোগক্ষেত্ৰৰ শিৰোনামত ব্যৱহৃত ফন্ট (_W):"
+
+#~ msgid "_Windows:"
+#~ msgstr "সংযোগক্ষেত্ৰ: (_W)"
+
+#~ msgid "dots per inch"
+#~ msgstr "প্ৰতি ইঞ্চিত ডটৰ সংখ্যা"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "ডেস্কটপৰ প্ৰদৰ্শনৰ পছন্দ নিৰ্ধাৰণ কৰক"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "ডেস্কটপৰ বিভিন্ন অংশৰ বাবে থিমৰ সৰঞ্জাম সংস্থাপন কৰক"
+
+#~ msgid "Theme Installer"
+#~ msgstr "থিম সংস্থাপক"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Gnome থিম সৰঞ্জাম"
+
+#~ msgid "Slide Show"
+#~ msgstr "চ্‌লাইড শ্বো"
+
+#~| msgid "Images"
+#~ msgid "Image"
+#~ msgstr "ছবি"
+
+#~| msgid ""
+#~| "<b>%s</b>\n"
+#~| "%s, %d %s by %d %s\n"
+#~| "Folder: %s"
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "ফোল্ডাৰ: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "থিম সংস্থাপন কৰিব নোৱাৰি"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s সৰঞ্জাম সংস্থাপিত নাই।"
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "থিম উদ্ধাৰ কৰোঁতে সমস্যা।"
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "নিৰ্বাচিত ফাইল সংস্থাপন কৰোঁতে ভুল"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" এটা বৈধ থিম নহয় যেন লাগিছে।"
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" এটা বৈধ থিম নহয় যেন লাগিছে। আপুনি সঙ্কলন কৰিব লগা এটা থিমৰ কলঘৰ হ'ব "
+#~ "পাৰে।"
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "থিম \"%s\" ৰ সংস্থাপন বিফল।"
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "\"%s\" থিম সংস্থাপন কৰা ‍হৈছে।"
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "আপুনি এতিয়া প্ৰযোজ্য কৰিব খোজে, নে আপোনাৰ বৰ্ত্তমানৰ থিম ৰাখিব বিচাৰে ?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "বৰ্তমান থিম অপৰিবৰ্তিত ৰখা হ'ব"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "নতুন থিম প্ৰয়োগ কৰা হ'ব"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME থিম %s সঠিকৰূপে সংস্থাপিত"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "নতন থিমসমূহ সফলভাবে সংস্থাপন কৰা হৈছে।"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "সংস্থাপন কৰাৰ বাবে কোনো থিম ফাইলৰ অৱস্থান উল্লেখ কৰা নহয়"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "থিমটে ইয়াত সংস্থাপন কৰাৰ বাবে প্ৰয়োজনীয় অনুমতি নাই:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "থিম বাচক"
+
+#~ msgid "Theme Packages"
+#~ msgstr "থিম সৰঞ্জাম"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "থিমৰ নাম থাকিবই লাগিব"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "থিমটো ইতিমধ্যেই আছে। আপুনি এইটোক প্ৰতিস্থাপন কৰিব বিচাৰে নেকি ?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "আঁতৰাই নতুন কৰি লিখক(_O)"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "আপুনি এই থিমটো আঁতৰাবলৈ ইচ্ছুক ?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "থিম ইঞ্জিন ইনস্টল কৰা নাযায়"
+
+#~| msgid ""
+#~| "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~| "Without the GNOME settings manager running, some preferences may not "
+#~| "take effect. This could indicate a problem with Bonobo, or a non-GNOME "
+#~| "(e.g. KDE) settings manager may already be active and conflicting with "
+#~| "the GNOME settings manager."
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "'gnome-settings-daemon' নামক বৈশিষ্ট্য পৰিচালনব্যবস্থা আৰম্ভ কৰতে ব্যর্থ।\n"
+#~ "GNOME settings manager না চললে একো বৈশিষ্ট্য কার্যকৰ হব না। সম্ভবত DBusৰ কোনো "
+#~ "সমস্যাৰ কাৰণে এটি হয়েছে অথবা GNOME-ভিন্ন অন্য কোনো বৈশিষ্ট্য পৰিচালনব্যবস্থা "
+#~ "বর্তমানে চলছে এবং ইয়াৰ ফলস্বৰূপ GNOME settings managerৰ সাথে দ্বন্দ্ব সৃষ্টি হচ্ছে।"
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "স্টক আইকন '%s' তোলা নাযায়\n"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "সাহায্যকাৰী তথ্য দেখুৱাওঁতে সমস্যা ‍হৈছে: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "ফাইল নকল কৰা হৈছে: %u, %u ৰ"
+
+#~ msgid "Parent Window"
+#~ msgstr "ঊৰ্ধ্বতন সংযোগক্ষেত্ৰ"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "বৰ্তমান সম্বাদৰ ঊৰ্ধ্বতন সংযোগক্ষেত্ৰ"
+
+#~ msgid "From URI"
+#~ msgstr "URI ৰ পৰা"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "যি URI ৰ পৰা বৰ্তমানে স্থানান্তৰিত হৈছে"
+
+#~ msgid "To URI"
+#~ msgstr "এই URI লৈ"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "যি URI লৈ বৰ্তমানে স্থানান্তৰিত হৈছে"
+
+#~ msgid "Fraction completed"
+#~ msgstr "আংশিক সম্পন্ন"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "স্থানান্তৰিত ভগ্নাংশ তথ্যৰ পৰিমাণ"
+
+#~ msgid "Current URI index"
+#~ msgstr "বৰ্তমান URI সূচি"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "বৰ্তমান URI সূচি - আৰম্ভ ‍হৈছে ১ৰ পৰা"
+
+#~ msgid "Total URIs"
+#~ msgstr "সৰ্বমোঠ URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "সৰ্বমোঠ URI সংখ্যা"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr ""
+#~ "'%s' ফাইলটি বৰ্তমানে উপস্থিত ৰয়েছে। আপুনি কি এটিকে প্ৰতিস্থাপন কৰিবলৈ চান?"
+
+#
+#~ msgid "_Skip"
+#~ msgstr "উপেক্ষা কৰা হ'ব (_S)"
+
+#
+#~ msgid "Overwrite _All"
+#~ msgstr "সমস্ত নতুন কৰি লিখা হ'ব (_A)"
+
+#~ msgid "Key"
+#~ msgstr "কি"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "গুণ সম্পাদক যি GConf কিৰ সৈতে যুক্ত আছে"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "কিৰ সৈতে সংস্লিষ্ট মান পৰিবৰ্তিত হ'লে এই কলবেক ব্যৱহাৰ কৰক"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "প্ৰযোজ্য কৰোঁতে gconf গ্ৰাহকলৈ তথ্য থকা GConf ৰ সলনি কৰা গোষ্ঠি আগবঢ়োৱা যাব"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "উইজেট কলবেকলৈ ৰূপান্তৰ"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "তথ্যক GConf ৰ পৰা উইজেটলৈ ৰূপান্তৰৰ সময়ত যি কলবেক ব্যৱহৃত হ'ব"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "উইজেট কলবেকৰ পৰা ৰূপান্তৰ"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "তথ্যক উইজেটৰ পৰা GConf লৈ ৰূপান্তৰৰ সময়ত যি কলবেক ব্যৱহৃত হ'ব"
+
+#~ msgid "UI Control"
+#~ msgstr "UI নিয়ন্ত্ৰণ"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "বৈশিষ্ট্য নিৰ্ধাৰণী বস্তু (সাধাৰণতে এইটো এটা উইজেট)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "বৈশিষ্ট্য নিৰ্ধাৰণী সম্পাদকৰ বস্তুবিষয়ক তথ্য"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "বৈশিষ্ট্য নিৰ্ধাৰণী সম্পাদকৰ প্ৰয়োজনীয় স্বনিৰ্বাচিত তথ্য"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "বৈশিষ্ট্য নিৰ্ধাৰণী সম্পাদকৰ তথ্য কলবেকৰ ওপৰৰ পৰা নিয়ন্ত্ৰণ প্ৰত্যাহাৰ কৰিছে"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "বৈশিষ্ট্য নিৰ্ধাৰণী সম্পাদকৰ বস্তুবিষয়ক তথ্যৰ ওপৰৰ পৰা নিয়ন্ত্ৰণ প্ৰত্যাহাৰৰ সময়তযি "
+#~ "কলবেক ব্যৱহৃত হ'ব"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "'%s' নামক ফাইল পাৱা নাযায়।\n"
+#~ "\n"
+#~ "অনুগ্ৰহ কৰি নিশ্চিত কৰক যি ফাইল আছে আৰু তাৰ পিছত আৰু এবাৰ চেষ্টা কৰক, বা পটভূমিৰ "
+#~ "বাবে অন্য কোনো ছবি বাচক।"
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' ফাইল পঢ়িব নোৱাৰি।\n"
+#~ "সম্ভৱতঃ এইটো এটা অসমৰ্থিত ছবিৰ ধৰণ।\n"
+#~ "\n"
+#~ "অনুগ্ৰহ কৰি অন্য এটা ছবি বাচক।"
+
+#~ msgid "Please select an image."
+#~ msgstr "অনুগ্ৰহ কৰি এটা ছবি বাচক।"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "অবিকল্পিত পইন্টাৰ - বৰ্তমানৰ"
+
+#~ msgid "White Pointer"
+#~ msgstr "বগা পইন্টাৰ"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "বগা পইন্টাৰ - বৰ্তমানৰ"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "ডাঙৰ পইন্টাৰ - বৰ্তমানৰ"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "ডাঙৰ বগা পইন্টাৰ - বৰ্তমানৰ"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "আবশ্যক GTK+ থিম '%s' ইনস্টল না থাকাৰ ফলস্বৰূপ চিহ্নিত থিমটি সঠিকৰূপে প্ৰদৰ্শিত "
+#~ "হ'ব না।"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "আবশ্যক উইন্ডো পৰিচালন ব্যবস্থাৰ থিম '%s' ইনস্টল না থাকাৰ ফলস্বৰূপ চিহ্নিত থিমটি "
+#~ "সঠিকৰূপে প্ৰদৰ্শিত নহব।"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "আবশ্যক আইকন থিম '%s' ইনস্টল না থাকাৰ ফলস্বৰূপ চিহ্নিত থিমটি সঠিকৰূপে প্ৰদৰ্শিত "
+#~ "হ'ব না।"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "পছন্দৰ এপ্লিকেচন"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "পছন্দৰ প্ৰদৰ্শনত সহায়ক প্ৰযুক্তিগত এপ্লিকেশনসমূহ আৰম্ভ কৰা হ'ব"
+
+#
+#~ msgid "Visual Assistance"
+#~ msgstr "দৃশ্যমান চিস্টেম বীপ (_V)"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "মূল সংযোগক্ষেত্ৰ তোলা নাযায়"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr "প্ৰদৰ্শনযোগ্য পৃষ্ঠাৰ নাম উল্লেখ কৰক (internet|multimedia|system|a11y)"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "%s ৰ সকলোকে প্ৰকৃত সংযোগ দ্বাৰা প্ৰতিস্থাপিত কৰা হ'ব"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "কমান্ড (_m):"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "এক্সিকিউট ফ্লেগ (_x):"
+
+#~| msgid "<b>Image Viewer</b>"
+#~ msgid "Image Viewer"
+#~ msgstr "ছবি প্ৰদর্শন ব্যবস্থা"
+
+#~| msgid "<b>Instant Messenger</b>"
+#~ msgid "Instant Messenger"
+#~ msgstr "তাৎ‍ক্ষণিক মেসেঞ্জাৰ"
+
+#~ msgid "Internet"
+#~ msgstr "ইন্টাৰনেট"
+
+#~| msgid "<b>Mail Reader</b>"
+#~ msgid "Mail Reader"
+#~ msgstr "মেইল পাঠৰ ব্যবস্থা"
+
+#~| msgid "<b>Mobility</b>"
+#~ msgid "Mobility"
+#~ msgstr "চলাচল"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "নতুন টেবত সংযোগ খোলক (_t)"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "নতুন সংযোগক্ষেত্ৰত সংযোগ খোলক (_w)"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "সংযোগ খোলাৰ বাবে ৱেব চৰকৰ অবিকল্পিত ব্যৱহাৰ কৰক (_d)"
+
+#~ msgid "Run at st_art"
+#~ msgstr "আৰম্ভত সঞ্চালিত হ'ব (_a)"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "টাৰ্মিনালত সঞ্চালন (_e)"
+
+#~| msgid "<b>Terminal Emulator</b>"
+#~ msgid "Terminal Emulator"
+#~ msgstr "টার্মিন্যাল এমুলেটৰ"
+
+#~| msgid "<b>Text Editor</b>"
+#~ msgid "Text Editor"
+#~ msgstr "টেক্সট এডিটাৰ"
+
+#~ msgid "_Run at start"
+#~ msgstr "সঞ্চালন কৰক"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee সংগীত বাদন ব্যৱস্থা"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian Sensible Browser"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian Terminal Emulator"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution Mail Reader"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "GNOME বিবৰ্ধক পৰ্দা পঢ়া ডিভাইচ নোহোৱাকৈ"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "GNOME Terminal"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape মেইল"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "KDE পৰ্দা"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "বিবৰ্ধক সহ Linux Screen Reader"
+
+#~ msgid "Listen"
+#~ msgstr "শুনক"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox সংগীত বাদন ব্যৱস্থা"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey মেইল"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Thunderbird"
+#~ msgstr "Thunderbird"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem চলচ্চিত্ৰ বাদন ব্যৱস্থা"
+
+#~ msgid "Display Preferences"
+#~ msgstr "প্ৰদৰ্শন সম্পৰ্কিত পছন্দ"
+
+#~| msgid "<i>Drag the monitors to set their place</i>"
+#~ msgid "Drag the monitors to set their place"
+#~ msgstr "মনিটৰেৰ অবস্থান নির্ধাৰণেৰ জন্য সেগুলিকে টেনে আনুন"
+
+#~ msgid "Include _panel"
+#~ msgstr "পেনেল অন্তৰ্ভুক্ত কৰা হ'ব (_p)"
+
+#~| msgid "<b>Panel icon</b>"
+#~ msgid "Panel icon"
+#~ msgstr "প্যানেলেৰ আইকন"
+
+#~| msgid "Upside Down"
+#~ msgid "Upside-down"
+#~ msgstr "উলটো"
+
+#~ msgid "_Detect Monitors"
+#~ msgstr "মনিটৰ চিনাক্তকৰণ (_D)"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "পৰ্দাৰ বিশ্লেষণ পৰিবৰ্তন কৰক"
+
+#~ msgid "Upside Down"
+#~ msgstr "উলোটা"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~| msgid "<b>Monitor: %s</b>"
+#~ msgid "Monitor: %s"
+#~ msgstr "মনিটৰ: %s"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "প্ৰদৰ্শন সংৰূপ প্ৰয়োগ কৰাৰ সময় সেশান বাস পাওয়া নাযায়"
+
+#~ msgid "Desktop"
+#~ msgstr "ডেস্কটপ"
+
+#~ msgid "Accelerator key"
+#~ msgstr "বেগবৰ্দ্ধক কি"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "বেগবৰ্দ্ধক পৰিবৰ্তক"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "বেগবৰ্দ্ধক কিৰ কোড"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "বেগবৰ্দ্ধক কিৰ ধৰণ।"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "নতুন চৰ্টকাট সংৰক্ষণে সমস্যা"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "সংৰূপ ডাটাবেসেত একসেলেৰেটৰৰ মান বাতিল কৰিবলৈ ত্ৰুটি: %s"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "অত্যাধিক স্বনিৰ্ধাৰিত চৰ্টকাট"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "বিভিন্ন কমান্ডৰ বাবে চৰ্টকাট নিৰ্ধাৰণ কৰক"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "পছন্দসমূহক কাৰ্যকৰ কৰি প্ৰস্থান কৰক (অকল সঙ্গতিৰ বাবে; এতিয়া ডেমনৰ দ্বাৰা "
+#~ "নিয়ন্ত্ৰিত)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "পৃষ্ঠাটিৰ প্ৰদৰ্শন আৰম্ভ কৰাৰ সময়ত টাইপিং বিৰতিৰ বৈশিষ্ট্য দেখাওক"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Start the page with the accessibility settings showing"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- GNOME Keyboard পছন্দ"
+
+#~ msgid "Beep when _accessibility features are turned on or off"
+#~ msgstr "অভিগমৰ গুণ আৰম্ভ বা বন্ধ কৰিলে বিপ কৰা হ'ব (_a)"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "কি গ্ৰহণ নকৰিলে বিপ কৰক (_r)"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "কি-বোৰ্ডেৰ বিশেষ ব্যবহাৰৰ অডিও প্ৰতিক্ৰিয়া"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "সতৰ্কধ্বনিৰ বাবে ভিসুয়্যাল প্ৰতিক্ৰিয়া প্ৰদৰ্শন কৰা হ'ব (_v)"
+
+#~| msgid "<b>Visual cues for sounds</b>"
+#~ msgid "Visual cues for sounds"
+#~ msgstr "শব্দেৰ জন্য প্ৰদর্শিত ছবি"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "বিৰতি বাতিলকৰণ অনুমোদন কৰক (_o)"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "অডিও প্ৰতিক্ৰিয়া...(_F)"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "বিৰতি বাতিল কৰা যায় নে নহয় তাকে পৰীক্ষা কৰক"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "অনুমতি থকা টাইপিং বিৰতিৰ দৈৰ্ঘ্য"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "যি সময় কাৰ্য্য কৰাৰ পিছত বিৰতি দিয়া হ'ব"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "কি ফলকৰ মডেল (_):"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "অনবৰত কিবৰ্ড ব্যৱহাৰৰ পৰা হোৱা দৈহিক ক্ষতি প্ৰতিৰোধ কৰাৰ বাবে স্ক্ৰিন বন্ধ কৰা "
+#~ "হ'ব"
+
+#~ msgid "Separate _layout for each window"
+#~ msgstr "প্ৰতিটো সংযোগক্ষেত্ৰৰ বাবে পৃথক বিন্যাস (_l)"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "বিৰতিৰ দৈৰ্ঘ্য (_B):"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "টাইপেত বাধ্যতামূলক বিৰতি ধাৰ্য কৰাৰ বাবে পৰ্দা লক কৰা হ'ব (_L)"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_Only accept long keypresses"
+
+#
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Simulate simultanous keypresses"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "কাৰ্য্য চলাকালীন বিৰতিৰ দৈৰ্ঘ্য (_W):"
+
+#~ msgid "Preview:"
+#~ msgstr "পূৰ্বপ্ৰদৰ্শন:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variants:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "যি কোনো এটা কিবৰ্ড মডেল বাচক"
+
+#~ msgid "_Vendors:"
+#~ msgstr "বিক্ৰেতা: (_V)"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "কিবৰ্ড সম্পৰ্কিত পছন্দ নিৰ্ধাৰণ কৰক"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "বাওঁফাললৈ যাওক"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "সোঁফাললৈ যাওক"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "ওপৰলৈ যাওক"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "নিষ্ক্ৰীয়"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "প্ৰদৰ্শনযোগ্য পৃষ্ঠাৰ নাম উল্লেখ কৰক (general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- GNOME মাউস পছন্দ"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Choose type of click _beforehand"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "Choose type of click with mo_use gestures"
+
+#~ msgid "D_rag click:"
+#~ msgstr "D_rag click:"
+
+#~ msgid "Show click type _window"
+#~ msgstr "Show click type _window"
+
+#~| msgid ""
+#~| "<i>You can also use the Dwell Click panel applet to choose the click "
+#~| "type.</i>"
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr "ক্লিকৰ ধৰন নির্বাচনেৰ জন্য Dwell Click প্যানেল অ্যাপ্লেট ব্যবহাৰ কৰা যাবে।"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "গতিবৃদ্ধি (_A):"
+
+#~ msgid "_Single click:"
+#~ msgstr "এবাৰ টিপক (_S):"
+
+#~ msgid "Location already exists"
+#~ msgstr "অবস্থান বৰ্তমানে উপস্থিত"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "নেটৱৰ্ক নিযুক্তক সম্পৰ্কিত পছন্দ নিৰ্ধাৰণ কৰক"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>স্বহস্তে নিযুক্তক বিন্যাস (_M)</b>"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP নিযুক্তক বিৱৰণ"
+
+#~| msgid "Ignored Hosts"
+#~ msgid "Ignore Host List"
+#~ msgstr "উপেক্ষিত হোস্টেৰ তালিকা"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "নেটৱৰ্ক নিযুক্তক সম্পৰ্কিত পছন্দ"
+
+#~ msgid "The location already exists."
+#~ msgstr "অবস্থান বৰ্তমানে উপস্থিত।"
+
+#~ msgid "U_sername:"
+#~ msgstr "ব্যৱহাৰকৰোঁতাৰ-নাম (_s):"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "নিৰাপদ HTTP নিযুক্তক: (_S)"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "Cannot start the preferences application for your window manager"
+
+#~ msgid "C_ontrol"
+#~ msgstr "নিয়ন্ত্ৰণ (_o)"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "হাইপাৰ (_y)"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "ছুপাৰ (বা \"সংযোগক্ষেত্ৰৰ লোগো\") (_u)"
+
+#~| msgid "<b>Movement Key</b>"
+#~ msgid "Movement Key"
+#~ msgstr "বিচলনেৰ-কি"
+
+#~| msgid "<b>Titlebar Action</b>"
+#~ msgid "Titlebar Action"
+#~ msgstr "শিরোনামেৰ-বাৰ কর্ম"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "সংযোগক্ষেত্ৰ স্থানান্তৰ কৰোঁতে এই কি টিপি সংযোগক্ষেত্ৰৰ অৱস্থান পৰিবৰ্তন কৰক:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "সংযোগক্ষেত্ৰ পছন্দ"
+
+#~| msgid "<b>Window Selection</b>"
+#~ msgid "Window Selection"
+#~ msgstr "উইন্ডো নির্বাচন"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "এই কাৰ্য্য কৰাৰ বাবে টাইটেলবাৰত দুবাৰ টিপক (_D):"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "যি সময়ৰ পিছত সংযোগক্ষেত্ৰ ডাঙৰ কৰা হ'ব (_I):"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "বাচি লোৱা সংযোগক্ষেত্ৰসমূহক এটা নিৰ্দিষ্ট সময়ৰ পিছত ডাঙৰ কৰা হ'ব (_R)"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "কোনো সংযোগক্ষেত্ৰৰ ওপৰত মাউছ অৱস্থান কৰিলে সেইটো সক্ৰিয় হ'ব (_S)"
+
+#~ msgid "Set your window properties"
+#~ msgstr "সংযোগক্ষেত্ৰৰ বৈশিষ্ট্য নিৰ্ধাৰণ কৰক"
+
+#~ msgid "Windows"
+#~ msgstr "সংযোগক্ষেত্ৰ"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "সংযোগক্ষেত্ৰ পৰিচালক \"%s\" কোনো বিন্যাস প্ৰক্ৰিয়া নিবন্ধন কৰা নাই\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "উলম্ব দিশায় সৰ্বোচ্চ মাপ নিৰ্ধাৰণ"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "অনুভূমিক দিশায় সৰ্বোচ্চ মাপ নিৰ্ধাৰণ"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "আৰম্ভ আড়াল কৰা হব (শেল প্ৰি-লোড কৰাৰ সময় সুবিধাজনক)"
+
+#~ msgid "Groups"
+#~ msgstr "দল"
+
+#~ msgid "Common Tasks"
+#~ msgstr "সাধাৰণ কৰ্ম"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Close the control-center when a task is activated"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "Exit shell on add or remove action performed"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Exit shell on help action performed"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Exit shell on start action performed"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "Exit shell on upgrade or uninstall action performed"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "সাহায্য কৰ্ম সঞ্চালিত হ'লে শেল বন্ধ কৰা হ'ব কি না সেইটো নিৰ্দেশ কৰা হয় ।"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "আৰম্ভেৰ কৰ্ম সঞ্চালিত হ'লে শেল বন্ধ কৰা হ'ব কি না সেইটো নিৰ্দেশ কৰা হয়।"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "যোগ অথবা অপসাৰণ কৰ্ম সঞ্চালিত হ'লে শেল বন্ধ কৰা হ'ব কি না সেইটো নিৰ্দেশ কৰা "
+#~ "হয়।"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "আপগ্ৰেড অথবা আন-ইনস্টল কৰ্ম সঞ্চালিত হ'লে শেল বন্ধ কৰা হ'ব কি না সেইটো নিৰ্দেশ "
+#~ "কৰা হয়।"
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "কৰ্মৰ নাম আৰু সংশ্লিষ্ট .desktop ফাইল"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[থিম সলনি কৰক;gtk-theme-selector.desktop,পছন্দৰ এপ্লিকেচন নিৰ্ধাৰিত কৰক;"
+#~ "default-applications.desktop,মূদ্ৰক যোগ কৰক;gnome-cups-manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "মান true (সত্য) হ'লে, কোনো \"সাধাৰণ কৰ্ম\" সক্ৰিয় কৰা হ'লে control-center "
+#~ "বন্ধ কৰা হ'ব।"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME বিন্যাস প্ৰক্ৰিয়া"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_Postpone Break"
+
+#~| msgid "/_Take a Break"
+#~ msgid "_Take a Break"
+#~ msgstr "বিৰতি নিন (_T)"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "পৰবৰ্তী বিৰতি %d মিনিটৰ পিছত"
+#~ msgstr[1] "পৰবৰ্তী বিৰতি %d মিনিটৰ পিছত"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "পৰবৰ্তী বিৰতিলৈ আৰু এক মিনিটতকৈ কম"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "নিম্নোক্ত সমস্যাৰ কাৰণে টাইপিং বিৰতিৰ বৈশিষ্টাসূচক সম্বাদটিক চলোৱা ন'গ'ল: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Richard Hult <richard@imendio.com> ৰ দ্বাৰা লিখা হৈছে"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "অপ্ৰয়োজনীয় সকলো ৰংচং যোগ কৰিছে Anders Carlsson"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "বিৰতি স্মৰণ কৰি দিয়াৰ এটা কম্পিউটাৰ প্ৰোগ্ৰাম।"
+
+#~ msgid "translator-credits"
+#~ msgstr "অমিতাক্ষ ফুকন (aphukan@fedoraproject.org)"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Don't check whether the notification area exists"
+
+#~ msgid "Typing Monitor"
+#~ msgstr "Typing Monitor"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "তথ্য প্ৰদৰ্শনৰ বাবে টাইপিং মনিটৰটি বিজ্ঞপ্তিস্থলকে ব্যৱহাৰ কৰি। মনে হৈছে আপোনাৰ "
+#~ "পেনেলে কোনো বিজ্ঞপ্তিস্থল নাই। এইটো যোগ কৰোঁতে চাইলে পেনেলে মাউচেৰ সোঁ বুটাম "
+#~ "ক্লিক কৰি 'পেনেলে যোগ কৰক' বাচি নিয়ে 'বিজ্ঞপ্তিস্থল' নিৰ্বাচন কৰক আৰু তাৰপৰ "
+#~ "'যোগ' এ টিপক।"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "সত্য হ'লে OpenType ফন্টক থাম্বনেইল কৰা হ'ব।"
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "সত্য হ'লে PCF ফন্টকে থাম্বনেইল কৰা হ'ব।"
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "সত্য হ'লে TrueType ফন্টকে থাম্বনেইল কৰা হ'ব।"
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "সত্য হ'লে Type1 ফন্টকে থাম্বনেইল কৰা হ'ব।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "OpenType ফন্টৰ থাম্বনেইল নিৰ্মাণৰ কমান্ড চলোৱাৰ বাবে এই কিক নিৰ্ধাৰণ কৰক।"
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "PCF ফন্টৰ থাম্বনেইল নিৰ্মাণৰ কমান্ড চলোৱাৰ বাবে এই কিক নিৰ্ধাৰণ কৰক।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "TrueType ফন্টৰ থাম্বনেইল নিৰ্মাণৰ কমান্ড চলোৱাৰ বাবে এই কিক নিৰ্ধাৰণ কৰক।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "Type1 ফন্টৰ থাম্বনেইল নিৰ্মাণৰ কমান্ড চলোৱাৰ বাবে এই কিক নিৰ্ধাৰণ কৰক।"
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "OpenType ফন্টৰ থাম্বনেইল কমান্ড"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "PCF ফন্টৰ থাম্বনেইল কমান্ড"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "TrueType ফন্টৰ থাম্বনেইল কমান্ড"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Type1 ফন্টৰ থাম্বনেইল কমান্ড"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "OpenType ফন্টৰ থাম্বনেইল কৰা হ'ব নে নহয়"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCF ফন্টৰ থাম্বনেইল কৰা হ'ব নে নহয়"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "TrueType ফন্টৰ থাম্বনেইল কৰা হ'ব নে নহয়"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Type1 ফন্টৰ থাম্বনেইল কৰা হ'ব নে নহয়"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "The quick brown fox jumps over the lazy dog. 0123456789"
+
+#~ msgid "Copyright:"
+#~ msgstr "স্বত্বাধিকাৰ:"
+
+#~ msgid "Description:"
+#~ msgstr "বিৱৰণ:"
+
+#~| msgid "Install"
+#~ msgid "Installed"
+#~ msgstr "ইনস্টল কৰা হয়েছে"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "ব্যৱহাৰবিধি: %s ফন্ট ফাইল\n"
+
+#~| msgid "Install"
+#~ msgid "I_nstall Font"
+#~ msgstr "ফন্ট ইনস্টল কৰুন (_n)"
+
+#~ msgid "Font Viewer"
+#~ msgstr "Font Viewer"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Text to thumbnail (default: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Font size (default: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "আকাৰ"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "চিহ্নিত ফিল্টাৰ \"%s\" অনুযায়ী কোনো বস্তু পাওয়া যায়নি।"
+
+#~ msgid "Upgrade"
+#~ msgstr "উন্নহয়ন কৰক"
+
+#~ msgid "Uninstall"
+#~ msgstr "সংস্থাপন নকৰিব"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "নিজৰ পছন্দলৈ যোগ কৰক"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "প্ৰাৰম্ভিক প্ৰোগ্ৰাম তালিকাৰ পৰা আঁতৰাওঁক"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "প্ৰাৰম্ভিক প্ৰোগ্ৰাম তালিকাত যোগ কৰক"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "নতুন স্প্ৰেড-শিট"
+
+#~ msgid "New Document"
+#~ msgstr "নতুন আলেখ্যন"
+
+#
+#~ msgid "Documents"
+#~ msgstr "ডকুমেন্ট"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>খোলক</b>"
+
+#~ msgid "Rename..."
+#~ msgstr "নাম পৰিবৰ্তন..."
+
+#~ msgid "Move to Trash"
+#~ msgstr "আবৰ্জনাৰ বাকসলৈ স্থানান্তৰ"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "If you delete an item, it is permanently lost."
+
+#~| msgid "<b>Open with \"%s\"</b>"
+#~ msgid "Open with \"%s\""
+#~ msgstr "\"%s\" সহযোগে খুলুন"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "ফাইল পৰিচালন ব্যৱস্থাত খোলক"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "আজি %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "যোৱাকালি %l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "এতিয়া বিচাৰক"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s খোলক</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "চিস্টেম"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "অজ্ঞাত লগিন ID, সম্ভৱতঃ ব্যৱহাৰকৰোঁতা-বিষয়ক তথ্যভঁৰালত ভুল"
+
+#~ msgid ""
+#~ "Left thumb\n"
+#~ "Left middle finger\n"
+#~ "Left ring finger\n"
+#~ "Left little finger\n"
+#~ "Right thumb\n"
+#~ "Right middle finger\n"
+#~ "Right ring finger\n"
+#~ "Right little finger"
+#~ msgstr ""
+#~ "বাওঁহাতৰ বুঢ়া আঙ্গুলি\n"
+#~ "বাওঁহাতৰ মধ্যমা\n"
+#~ "বাওঁহাতৰ অনামিকা\n"
+#~ "বাওঁহাতৰ কনিষ্ঠা\n"
+#~ "সোঁহাতৰ বুঢ়া আঙ্গুলি\n"
+#~ "সোঁহাতৰ মধ্যমা\n"
+#~ "সোঁহাতৰ অনামিকা\n"
+#~ "সোঁহাতৰ কনিষ্ঠা"
+
+#~ msgid "<b>Email</b>"
+#~ msgstr "<b>ঈ-মেইল</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>কৰ্মস্থল</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>ৱেব</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>কৰ্ম</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">পাছৱৰ্ড পৰিবৰ্তন</span>"
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>সহায়ক প্ৰযুক্তি</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>পছন্দ</b>"
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>ৰং (_o)</b>"
+
+#~ msgid "<b>_Desktop Background</b>"
+#~ msgstr "<b>ডেস্কটপৰ পটভূমি (_D)</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "কাটক (_u)"
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "ডাঠ ৰং\n"
+#~ "অনুভূমিক ঢাল\n"
+#~ "লম্বীয় ঢাল"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "বস্তুৰ তলত আখৰ\n"
+#~ "বস্তুৰ লগত আখৰ\n"
+#~ "অকল আইকণ\n"
+#~ "অকল আখৰ"
+
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "টাইলযুক্ত\n"
+#~ "বড় মাপে প্ৰদৰ্শন\n"
+#~ "কেন্দ্ৰস্থিত\n"
+#~ "মাপ অনুসাৰে\n"
+#~ "সম্পূৰ্ণ পৰ্দায় প্ৰদৰ্শন"
+
+#~ msgid "_New"
+#~ msgstr "নতুন (_N)"
+
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b> ভিছুৱেল</b>"
+
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "স্বাভাবিক\n"
+#~ "বাওঁফালে\n"
+#~ "সোঁফালে\n"
+#~ "উলোটা\n"
+
+#~ msgid "Could not apply the selected configuration"
+#~ msgstr "নিৰ্বাচিত সংৰূপ প্ৰয়োগ কৰা নাযায়"
+
+#~ msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+#~ msgstr "org.gnome.SettingsDaemon.XRANDR প্ৰাপ্ত কৰিবলৈ ব্যৰ্থ"
+
+#~ msgid "<b>Bounce Keys</b>"
+#~ msgstr "<b>Bounce Keys</b>"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b> সাধাৰণ</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>দ্ৰুত</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>দীৰ্ঘ</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>সৰু</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>লাহে</i></small>"
+
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i> উচ্চ</i></small>"
+
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i> ডাঙৰ</i></small>"
+
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>নিম্ন</i></small>"
+
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i> সৰু</i></small>"
+
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>অগ্ৰাহ্য কৰিব লগা গৃহস্থৰ তালিকা</b>"
+
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+
+#~ msgid "/_About"
+#~ msgstr "/বিষয়ে (_A)"
+
+#
+#~| msgid "C_ommand:"
+#~ msgid "_Command:"
+#~ msgstr "কমান্ড:(_C)"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "লগিনৰ সময়ত GNOME ৰ সহায়ক প্ৰযুক্তি আৰম্ভ কৰক"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>ৱালপেপাৰ (_W)</b>"
+
+#~ msgid ""
+#~ "Centered\n"
+#~ "Fill screen\n"
+#~ "Scaled\n"
+#~ "Zoom\n"
+#~ "Tiled"
+#~ msgstr ""
+#~ "মাজত\n"
+#~ "পৰ্দ্দা ভৰাই দিয়ক\n"
+#~ "স্কেল্ড\n"
+#~ "ডাঙৰ কৰক\n"
+#~ "টাইল্ড"
+
+#~ msgid "Go _to Fonts Folder"
+#~ msgstr "ফন্ট ফোল্ডাৰলৈ যাওক (_t)"
+
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "থিম ফাইলসমূহ %s পথত সংস্থাপন কৰা হ'ব। ইয়াক উৎসৰ স্থান হিচাপে নিৰ্বাচন কৰা "
+#~ "নোৱাৰি"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "বৈশিষ্টেবলী কাৰ্যকৰ কৰি প্ৰোগ্ৰামৰ পৰা প্ৰস্থান কৰক"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "পূৰ্বে ব্যৱহৃত মানসমূহ উদ্ধাৰ কৰি সংৰক্ষণ কৰক"
+
+#~ msgid "Autostart the preferred AT"
+#~ msgstr "স্বয়ংক্ৰিয় প্ৰাৰম্ভকৰণ"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "স্ক্ৰিন বিশ্লেষণ শক্তি সম্পৰ্কিত পছন্দ"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "অকল এই কম্পিউটাৰৰ (%s) বাবে অবিকল্পিত নিৰ্ধাৰণ কৰা হ'ব (_M)"
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "নতুন বৈশিষ্ট্যসমূহ পৰীক্ষা কৰা হৈছে। আপুনি যদি %d ছেকেণ্ডত কোনো উত্তৰ নিদিয়ে "
+#~ "তেন্তে পূৰণি মানসমূহকেই আকৌ ব্যৱহাৰ কৰা হ'ব।"
+#~ msgstr[1] ""
+#~ "নতুন বৈশিষ্ট্যসমূহ পৰীক্ষা কৰা হৈছে। আপুনি যদি %d ছেকেণ্ডত কোনো উত্তৰ নিদিয়ে "
+#~ "তেন্তে পূৰণি মানসমূহকেই আকৌ ব্যৱহাৰ কৰা হ'ব।"
+
+#~ msgid "Keep Resolution"
+#~ msgstr "এই বিশ্লেষণ শক্তি ব্যৱহাৰ কৰক"
+
+#~ msgid "Use _Previous Resolution"
+#~ msgstr "আগৰ বিশ্লেষণ শক্তি (_P)"
+
+#~ msgid "_Keep Resolution"
+#~ msgstr "বিশ্লেষণ শক্তি ৰাখক (_K)"
+
+#~ msgid ""
+#~ "The X server does not support the XRandR extension. Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "The X server does not support the XRandR extension. Runtime resolution "
+#~ "changes to the display size are not available."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "এই প্ৰোগ্ৰামটোৰ সৈতে XRandR সম্প্ৰসাৰণৰ এই সংস্কৰণটোৰ অমিল। প্ৰদৰ্শনৰ আকাৰৰ বাবে "
+#~ "ৰাণটাইম সলনি পোৱা নাযায়।"
+
+#~ msgid "New accelerator..."
+#~ msgstr "নতুন বেগবৰ্দ্ধক..."
+
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "বিন্যাস তথ্যভঁৰালৰ বাবে নতুন বেগবৰ্দ্ধক কি স্থাপনত সমস্যা ‍হৈছে: %s\n"
+
+#~ msgid "Keyboard Accessibility Notifications"
+#~ msgstr "কিবৰ্ড সহায়ক প্ৰযুক্তি"
+
+#~ msgid "_Layouts:"
+#~ msgstr "বিন্যাস: (_L)"
+
+#~ msgid "   "
+#~ msgstr "   "
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "উন্নত বিন্যাস"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - Advanced Linux Sound Architecture"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART Sound Daemon"
+
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ESD - Enlightened Sound Daemon"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - Open Sound System"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "PulseAudio Sound Server"
+
+#~ msgid "Silence"
+#~ msgstr "নিঃশব্দ"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>অডিও কনফাৰেন্স সুবিধা</b>"
+
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>অবিকল্পিত Mixer Tracks</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>সংগীত আৰু ছায়াছবি</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>শব্দ ঘটনা</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">পৰীক্ষণ...</span>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "সমাপ্ত কৰিবলৈ ঠিক আছে টিপক"
+
+#~ msgid "E_nable software sound mixing (ESD)"
+#~ msgstr "E_nable software sound mixing (ESD)"
+
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+#~ msgstr ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+
+#~ msgid "So_und playback:"
+#~ msgstr "So_und playback:"
+
+#~ msgid "Sou_nd capture:"
+#~ msgstr "Sou_nd capture:"
+
+#~ msgid "Sounds"
+#~ msgstr "শব্দ"
+
+#~ msgid "System Beep"
+#~ msgstr "চিস্টেমৰ বীপ ধ্বনি"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "Testing Pipeline"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "চিস্টেমৰ বীপ ধ্বনি সক্ৰিয় কৰক (_E)"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "চিস্টেম শব্দ বজাওক (_P)"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "_Sound playback:"
+
+#~ msgid "Unexpected attribute '%s' for element '%s'"
+#~ msgstr "অপ্ৰত্যাশিত গুণ '%s' পদাৰ্থ '%s' ৰ বাবে"
+
+#~ msgid "Attribute '%s' of element '%s' not found"
+#~ msgstr "গুণ '%s', পদাৰ্থ '%s' ৰ পোৱা ন'গ'ল"
+
+#~ msgid "Unexpected tag '%s', tag '%s' expected"
+#~ msgstr "অপ্ৰত্যাশিত টেগ '%s', টেগ '%s' ৰ আশা কৰা হ'ল"
+
+#~ msgid "Unexpected tag '%s' inside '%s'"
+#~ msgstr "অপ্ৰত্যাশিত টেগ '%s' '%s' ৰ ভিতৰত"
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "No valid bookmark file found in data dirs"
+
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "No bookmark found for URI '%s'"
+
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "No MIME type defined in the bookmark for URI '%s'"
+
+#~ msgid "No private flag has been defined in bookmark for URI '%s'"
+#~ msgstr "No private flag has been defined in bookmark for URI '%s'"
+
+#~ msgid "No groups set in bookmark for URI '%s'"
+#~ msgstr "No groups set in bookmark for URI '%s'"
+
+#~ msgid "No application with name '%s' registered a bookmark for '%s'"
+#~ msgstr "No application with name '%s' registered a bookmark for '%s'"
+
+#~ msgid "Boing"
+#~ msgstr "Boing"
+
+#~ msgid "Beep"
+#~ msgstr "বিপ"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "এই ঘটনাৰ বাবে কোনো শব্দ নিৰ্ধাৰণ কৰা নাই।"
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "এই ঘটনাৰ বাবে শব্দৰ ফাইল নাই।\n"
+#~ "অবিকল্পিত শব্দৰ ছেট ব্যৱহাৰ কৰিবলৈ GNOME-অ'ডিও সৰঞ্জাম সংস্থাপন কৰিব পাৰে।"
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "%s ফাইল কোনো বৈধ Wav ফাইল নহয়"
+
+#~ msgid "Sets the default application font"
+#~ msgstr "অবিকল্পিত এপ্লিকেচন ফন্টৰ ব্যৱহাৰ নিৰ্ধাৰণ কৰে"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">নতুন ফন্ট সক্ৰিয় কৰা হ'ব ?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "ফন্ট সক্ৰিয় নকৰিব (_n)"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "আপুনি যি থিম পছন্দ কৰিছে সেইটো এটা নতুন ফন্টক ব্যৱহাৰ কৰে। সেই ফন্টৰ এটা "
+#~ "প্ৰাকদৰ্শন তলত দেখুৱা হৈছে।"
+
+#~ msgid "Description"
+#~ msgstr "বিৱৰণ"
+
+#~ msgid "Control theme"
+#~ msgstr "নিয়ন্ত্ৰণ থিম"
+
+#~ msgid "Window border theme"
+#~ msgstr "সংযোগক্ষেত্ৰ সীমাৰ থিম"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "সত্য হ'লে সংস্থাপন কৰা থিমক থাম্বনেইল কৰা হ'ব।"
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "সত্য হ'লে থিমক থাম্বনেইল কৰা হ'ব।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "সংস্থাপনকৃত থিমৰ থাম্বনেইল নিৰ্মাণৰ কমান্ড চলোৱাৰ বাবে এই কিক নিৰ্ধাৰণ কৰক।"
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr "থিমৰ থাম্বনেইল নিৰ্মাণৰ কমান্ড চলোৱাৰ বাবে এই কিক নিৰ্ধাৰণ কৰক।"
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "সংস্থাপনকৃত থিম থাম্বনেইল কৰাৰ কমান্ড"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "থিম থাম্বনেইল কৰাৰ কমান্ড"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "সংস্থাপন কৰা থিম থাম্বনেইল কৰা হ'ব নে নহয়"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "থিম থাম্বনেইল কৰা হ'ব নে নহয়"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "কখগঘঙচছজ"
+
+#~ msgid "[FILE]"
+#~ msgstr "[FILE]"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "অবিকল্পিত থিম নিৰ্ধাৰণ কৰক"

--- a/po/ast.po
+++ b/po/ast.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: control-center-2.0\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2011-10-23 12:52+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2011-10-23 19:59+0100\n"
 "Last-Translator: ivarela <ivarela@softastur.org>\n"
 "Language-Team: Softastur <alministradores@softastur.org>\n"
@@ -24,4441 +24,7516 @@ msgstr ""
 "X-Launchpad-Export-Date: 2011-10-23 16:28+0000\n"
 "X-Generator: Launchpad (build 14170)\n"
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
-msgid "Background"
-msgstr "Fondu de pantalla"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change the background"
-msgstr "Cambia'l fondu"
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Fondu d'escritoriu;Pantalla;Escritoriu;"
-
-#: ../panels/background/background.ui.h:1
-msgid "Add wallpaper"
-msgstr "Amestar fondu d'escritoriu"
-
-#: ../panels/background/background.ui.h:2
-msgid "Center"
-msgstr "Centru"
-
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:4
-msgid "Changes throughout the day"
-msgstr "Camuda a lo llargo'l día"
-
-#: ../panels/background/background.ui.h:5
-msgid "Fill"
-msgstr "Rellenu"
-
-#: ../panels/background/background.ui.h:6
-msgid "Remove wallpaper"
-msgstr "Quitar fondu"
-
-#: ../panels/background/background.ui.h:7
-msgid "Scale"
-msgstr "Escala"
-
-#: ../panels/background/background.ui.h:8
-msgid "Span"
-msgstr "Espander"
-
-#: ../panels/background/background.ui.h:9
-msgid "Tile"
-msgstr "Mosaicu"
-
-#: ../panels/background/background.ui.h:10
-msgid "Zoom"
-msgstr "Zoom"
-
-#: ../panels/background/bg-colors-source.c:46
-msgid "Horizontal Gradient"
-msgstr "Dilíu Horizontal"
-
-#: ../panels/background/bg-colors-source.c:47
-msgid "Vertical Gradient"
-msgstr "Dilíu Vertical"
-
-#: ../panels/background/bg-colors-source.c:48
-msgid "Solid Color"
-msgstr "Color Sólido"
-
-#: ../panels/background/cc-background-panel.c:1001
-#: ../panels/user-accounts/um-photo-dialog.c:217
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
-msgid "Browse for more pictures"
-msgstr "Restolar pa buscar más imáxenes"
-
-#: ../panels/background/cc-background-panel.c:1093
-msgid "Current background"
-msgstr "Fondu actual"
-
-#: ../panels/background/cc-background-panel.c:1203
-msgid "Wallpapers"
-msgstr "Fondos d'escritoriu"
-
-#: ../panels/background/cc-background-panel.c:1210
-msgid "Pictures Folder"
-msgstr "Carpeta d'imáxenes"
-
-#: ../panels/background/cc-background-panel.c:1217
-msgid "Colors & Gradients"
-msgstr "Colores y dilíos"
-
-#: ../panels/background/cc-background-panel.c:1225
-msgid "Flickr"
-msgstr "Flickr"
-
-#: ../panels/background/cc-background-item.c:148
-msgid "multiple sizes"
-msgstr "tamaños múltiples"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:152
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:281
-msgid "No Desktop Background"
-msgstr "Ensin fondu d'escritoriu"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:281
-msgid "Yes"
-msgstr "Sí"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:281
-msgid "No"
-msgstr "Non"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:393
-msgid "Bluetooth is disabled"
-msgstr "El Bluetooth ta desactiváu"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:398
-msgid "Bluetooth is disabled by hardware switch"
-msgstr "El Bluetooth ta físicamente desactiváu"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:402
-msgid "No Bluetooth adapters found"
-msgstr "Nun s'atoparon adautadores de Bluetooth"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:535
-msgid "Visibility"
-msgstr "Visibilidá"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:539
-#, c-format
-msgid "Visibility of “%s”"
-msgstr "Visibilidá de “%s”"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:583
-#, c-format
-msgid "Remove '%s' from the list of devices?"
-msgstr "Desaniciar '%s' de la llista de preseos?"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:585
-msgid "If you remove the device, you will have to set it up again before next use."
-msgstr "Si quites el preséu, tendrás de configuralu otra vegada enantes d'usalu nuevamente"
-
-#: ../panels/bluetooth/bluetooth.ui.h:1
-msgid "Address"
-msgstr "Direición/es"
-
-#: ../panels/bluetooth/bluetooth.ui.h:2
-msgid "Browse Files..."
-msgstr "Restolar por ficheros…"
-
-#: ../panels/bluetooth/bluetooth.ui.h:3
-msgid "Connection"
-msgstr "Conexón"
-
-#: ../panels/bluetooth/bluetooth.ui.h:4
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Keyboard Settings"
-msgstr "Axustes del tecláu"
-
-#: ../panels/bluetooth/bluetooth.ui.h:5
-msgid "Mouse and Touchpad Settings"
-msgstr "Axustes del Mur y «touchpad»"
-
-#: ../panels/bluetooth/bluetooth.ui.h:6
-msgid "Paired"
-msgstr "Emparexáu"
-
-#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
-#: ../panels/bluetooth/bluetooth.ui.h:8
-msgctxt "Power"
-msgid "Bluetooth"
-msgstr "Bluetooth"
-
-#: ../panels/bluetooth/bluetooth.ui.h:9
-msgid "Send Files..."
-msgstr "Unviar ficheros..."
-
-#: ../panels/bluetooth/bluetooth.ui.h:10
-#: ../panels/universal-access/uap.ui.h:60
-msgid "Sound Settings"
-msgstr "Axustes de soníu"
-
-#: ../panels/bluetooth/bluetooth.ui.h:11
-msgid "Type"
-msgstr "Triba"
-
-#. TRANSLATORS: device type
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
-#: ../panels/network/panel-common.c:99
-msgid "Bluetooth"
-msgstr "Bluetooth"
-
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
-msgid "Configure Bluetooth settings"
-msgstr "Configurar axustes de Bluetooth"
-
-#. Add some common languages first
-#: ../panels/common/cc-common-language.c:513
-msgid "English"
-msgstr "Inglés"
-
-#: ../panels/common/cc-common-language.c:515
-msgid "British English"
-msgstr "Inglés Británicu"
-
-#: ../panels/common/cc-common-language.c:517
-msgid "German"
-msgstr "Alemán"
-
-#: ../panels/common/cc-common-language.c:519
-msgid "French"
-msgstr "Francés"
-
-#: ../panels/common/cc-common-language.c:521
-msgid "Spanish"
-msgstr "Español"
-
-#: ../panels/common/cc-common-language.c:523
-msgid "Chinese (simplified)"
-msgstr "Chinu (Simplificáu)"
-
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:552
-msgid "United States"
-msgstr "Estaos Xuníos"
-
-#: ../panels/common/cc-common-language.c:553
-msgid "Germany"
-msgstr "Alemaña"
-
-#: ../panels/common/cc-common-language.c:554
-msgid "France"
-msgstr "Francia"
-
-#: ../panels/common/cc-common-language.c:555
-msgid "Spain"
-msgstr "Spain"
-
-#: ../panels/common/cc-common-language.c:556
-msgid "China"
-msgstr "China"
-
-#: ../panels/common/cc-language-chooser.c:119
-msgid "Other..."
-msgstr "Otru..."
-
-#: ../panels/common/cc-language-chooser.c:290
-msgid "Select a region"
-msgstr "Esbilla una rexón"
-
-#: ../panels/common/gdm-languages.c:774
-msgid "Unspecified"
-msgstr "Ensin especificar"
-
-#: ../panels/common/language-chooser.ui.h:1
-msgid "Select a language"
-msgstr "Esbilla una llingua"
-
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/printers/new-printer-dialog.ui.h:4
-#: ../panels/user-accounts/um-user-panel.c:448
-msgid "_Cancel"
-msgstr "_Encaboxar"
-
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/universal-access/gconf-property-editor.c:1609
-msgid "_Select"
-msgstr "_Seleicionar"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "24-hour"
-msgstr "24 hores"
-
-#. Translator: this is the separator between hours and minutes, like in HH:MM
-#: ../panels/datetime/datetime.ui.h:3
-msgid ":"
-msgstr ":"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "AM/PM"
-msgstr "AM/PM"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "April"
-msgstr "abril"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "August"
-msgstr "agostu"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "Day"
-msgstr "Día"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "December"
-msgstr "avientu"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "February"
-msgstr "febreru"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "January"
-msgstr "xineru"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "July"
-msgstr "xunetu"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "June"
-msgstr "xunu"
-
-#: ../panels/datetime/datetime.ui.h:13
-msgid "March"
-msgstr "marzu"
-
-#: ../panels/datetime/datetime.ui.h:14
-msgid "May"
-msgstr "mayu"
-
-#: ../panels/datetime/datetime.ui.h:15
-msgid "Month"
-msgstr "Mes"
-
-#: ../panels/datetime/datetime.ui.h:16
-msgid "November"
-msgstr "payares"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "October"
-msgstr "ochobre"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "September"
-msgstr "septiembre"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Set the time one hour ahead."
-msgstr "Axustar la hora una hora p'alantre."
-
-#: ../panels/datetime/datetime.ui.h:20
-msgid "Set the time one hour back."
-msgstr "Axustar la hora una hora p'atrás."
-
-#: ../panels/datetime/datetime.ui.h:21
-msgid "Set the time one minute ahead."
-msgstr "Axustar la hora un minutu p'alantre."
-
-#: ../panels/datetime/datetime.ui.h:22
-msgid "Set the time one minute back."
-msgstr "Axustar la hora un minutu p'atrás."
-
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Switch between AM and PM."
-msgstr "Alternar entre AM y PM"
-
-#: ../panels/datetime/datetime.ui.h:24
-msgid "Year"
-msgstr "Añu"
-
-#: ../panels/datetime/datetime.ui.h:25
-msgid "_City:"
-msgstr "_Ciudá:"
-
-#: ../panels/datetime/datetime.ui.h:26
-msgid "_Network Time"
-msgstr "_Hora de rede"
-
-#: ../panels/datetime/datetime.ui.h:27
-msgid "_Region:"
-msgstr "_Rexón:"
-
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Clock;Timezone;Location;"
-msgstr "Reló;Estaya horaria;Allugamientu;"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
-msgid "Date and Time"
-msgstr "Data y hora"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
-msgid "Date and Time preferences panel"
-msgstr "Panel de preferencies de la data y hora"
-
-#: ../panels/display/display-capplet.ui.h:1
-#: ../panels/display/cc-display-panel.c:641
-msgid "Monitor"
-msgstr "Monitor"
-
-#: ../panels/display/display-capplet.ui.h:2
-msgid "Note: may limit resolution options"
-msgstr "Nota: puedes llendar les opciones de resolución"
-
-#: ../panels/display/display-capplet.ui.h:3
-msgid "R_otation:"
-msgstr "R_otación:"
-
-#: ../panels/display/display-capplet.ui.h:4
-msgid "_Detect Displays"
-msgstr "_Deteutar pantalles"
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:6
-msgid "_Mirror displays"
-msgstr "_Espeyar pantalles"
-
-#: ../panels/display/display-capplet.ui.h:7
-msgid "_Resolution:"
-msgstr "_Resolución:"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Change resolution and position of monitors and projectors"
-msgstr "Camudar la resolución y posición de los monitores y proyeutores"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Displays"
-msgstr "Pantalles"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr "Panel;Proyeutor;xranrd;Pantalla;Resolución;Anovar;"
-
-#: ../panels/display/cc-display-panel.c:477
-msgctxt "display panel, rotation"
-msgid "Normal"
-msgstr "Normal"
-
-#: ../panels/display/cc-display-panel.c:478
-msgctxt "display panel, rotation"
-msgid "Counterclockwise"
-msgstr "Antihorariu"
-
-#: ../panels/display/cc-display-panel.c:479
-msgctxt "display panel, rotation"
-msgid "Clockwise"
-msgstr "Horariu"
-
-#: ../panels/display/cc-display-panel.c:480
-msgctxt "display panel, rotation"
-msgid "180 Degrees"
-msgstr "180 graos"
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../panels/display/cc-display-panel.c:617
-msgid "Mirror Displays"
-msgstr "Espeyar pantalles"
-
-#: ../panels/display/cc-display-panel.c:747
-#, c-format
-msgid "%d x %d (%s)"
-msgstr "%d x %d (%s)"
-
-#: ../panels/display/cc-display-panel.c:749
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#: ../panels/display/cc-display-panel.c:1656
-msgid "Drag to change primary display."
-msgstr "Arrastrar pa camudar la pantalla principal."
-
-#: ../panels/display/cc-display-panel.c:1714
-msgid "Select a monitor to change its properties; drag it to rearrange its placement."
-msgstr "Esbillar un monitor pa cambiar les sos propiedaes; arrastralu reubícalu."
-
-#: ../panels/display/cc-display-panel.c:2102
-msgid "%a %R"
-msgstr "%a %R"
-
-#: ../panels/display/cc-display-panel.c:2104
-msgid "%a %l:%M %p"
-msgstr "%a %H:%M"
-
-#: ../panels/display/cc-display-panel.c:2350
-msgid "Could not save the monitor configuration"
-msgstr "Nun pudo guardase la configuración del monitor"
-
-#: ../panels/display/cc-display-panel.c:2375
-msgid "Could not get session bus while applying display configuration"
-msgstr "Nun pudo algamase el bus de sesión al aplicar la configuración de pantalla"
-
-#: ../panels/display/cc-display-panel.c:2420
-msgid "Could not detect displays"
-msgstr "Nun pudieron detectase pantalles"
-
-#: ../panels/display/cc-display-panel.c:2614
-msgid "Could not get screen information"
-msgstr "Nun pudo algamase información de pantalla"
-
-#. Translators: VESA is an techncial acronym, don't translate it.
-#: ../panels/info/cc-info-panel.c:402
-#, c-format
-msgid "VESA: %s"
-msgstr "VESA: %s"
-
-#. TRANSLATORS: device type
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:426
-#: ../panels/network/panel-common.c:79
-#: ../panels/network/panel-common.c:158
-msgid "Unknown"
-msgstr "Desconocíu"
-
-#. translators: This is the type of architecture, for example:
-#. * "64-bit" or "32-bit"
-#: ../panels/info/cc-info-panel.c:587
-#, c-format
-msgid "%d-bit"
-msgstr "%d-bit"
-
-#: ../panels/info/cc-info-panel.c:744
-msgid "Unknown model"
-msgstr "Modelu desconocíu"
-
-#: ../panels/info/cc-info-panel.c:827
-msgid "The next login will attempt to use the standard experience."
-msgstr "El siguiente arranque de sesión intentará usar la decoración estándar."
-
-#: ../panels/info/cc-info-panel.c:829
-msgid "The next login will use the fallback mode intended for unsupported graphics hardware."
-msgstr "El siguiente arranque de sesión usará el mou alternativu, pensáu pa hardware de gráficos non soportáu."
-
-#. translators: The hardware is not able to run GNOME 3's
-#. * shell, so we use the GNOME "Fallback" session
-#: ../panels/info/cc-info-panel.c:871
-msgctxt "Experience"
-msgid "Fallback"
-msgstr "Reserva"
-
-#. translators: The hardware is able to run GNOME 3's
-#. * shell, also called "Standard" experience
-#: ../panels/info/cc-info-panel.c:877
-msgctxt "Experience"
-msgid "Standard"
-msgstr "Estándar"
-
-#: ../panels/info/cc-info-panel.c:1200
-msgid "Ask what to do"
-msgstr "Entrugar qué facer"
-
-#: ../panels/info/cc-info-panel.c:1204
-msgid "Do nothing"
-msgstr "Nun facer nada"
-
-#: ../panels/info/cc-info-panel.c:1208
-msgid "Open folder"
-msgstr "Abrir carpeta"
-
-#: ../panels/info/cc-info-panel.c:1319
-msgid "Select an application for audio CDs"
-msgstr "Escoyer una aplicación pa CD de soníu"
-
-#: ../panels/info/cc-info-panel.c:1320
-msgid "Select an application for video DVDs"
-msgstr "Escoyer una aplicación pa DVD de videu"
-
-#: ../panels/info/cc-info-panel.c:1321
-msgid "Select an application to run when a music player is connected"
-msgstr "Escoyer una aplicación pa executar cuando se coneuta un reproductor de música"
-
-#: ../panels/info/cc-info-panel.c:1322
-msgid "Select an application to run when a camera is connected"
-msgstr "Esbillar una aplicación qu'executar cuando se coneuta una cámara"
-
-#: ../panels/info/cc-info-panel.c:1323
-msgid "Select an application for software CDs"
-msgstr "Esbillar una aplicación pa CD de software"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1335
-msgid "audio DVD"
-msgstr "DVD de soníu"
-
-#: ../panels/info/cc-info-panel.c:1336
-msgid "blank Blu-ray disc"
-msgstr "discu Blu-ray virxe"
-
-#: ../panels/info/cc-info-panel.c:1337
-msgid "blank CD disc"
-msgstr "discu CD virxe"
-
-#: ../panels/info/cc-info-panel.c:1338
-msgid "blank DVD disc"
-msgstr "DVD virxe"
-
-#: ../panels/info/cc-info-panel.c:1339
-msgid "blank HD DVD disc"
-msgstr "discu HD DVD virxe"
-
-#: ../panels/info/cc-info-panel.c:1340
-msgid "Blu-ray video disc"
-msgstr "Discu Blu-ray de videu"
-
-#: ../panels/info/cc-info-panel.c:1341
-msgid "e-book reader"
-msgstr "llector de llibros electrónicos"
-
-#: ../panels/info/cc-info-panel.c:1342
-msgid "HD DVD video disc"
-msgstr "Discu HD DVD de videu"
-
-#: ../panels/info/cc-info-panel.c:1343
-msgid "Picture CD"
-msgstr "Discu d'imáxenes Picture CD"
-
-#: ../panels/info/cc-info-panel.c:1344
-msgid "Super Video CD"
-msgstr "CD de Super Videu"
-
-#: ../panels/info/cc-info-panel.c:1345
-msgid "Video CD"
-msgstr "CD de videu"
-
-#: ../panels/info/cc-info-panel.c:1474
-#: ../panels/keyboard/keyboard-shortcuts.c:1802
-msgid "Section"
-msgstr "Estaya"
-
-#: ../panels/info/cc-info-panel.c:1483
-#: ../panels/info/info.ui.h:15
-msgid "Overview"
-msgstr "Vista xeneral"
-
-#: ../panels/info/cc-info-panel.c:1489
-#: ../panels/info/info.ui.h:4
-msgid "Default Applications"
-msgstr "Aplicaciones predeterminaes"
-
-#: ../panels/info/cc-info-panel.c:1494
-#: ../panels/info/info.ui.h:17
-msgid "Removable Media"
-msgstr "Medios Estrayibles"
-
-#: ../panels/info/cc-info-panel.c:1499
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "Gráficos."
-
-#: ../panels/info/cc-info-panel.c:1700
-#, c-format
-msgid "Version %s"
-msgstr "Versión %s"
-
-#: ../panels/info/cc-info-panel.c:1750
-msgid "Install Updates"
-msgstr "Instalar Anovamientos"
-
-#: ../panels/info/cc-info-panel.c:1754
-msgid "System Up-To-Date"
-msgstr "Anovar el sistema"
-
-#: ../panels/info/cc-info-panel.c:1758
-msgid "Checking for Updates"
-msgstr "Comprobando anovamientos"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-msgid "System Info"
-msgstr "Información del sistema"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "System Information"
-msgstr "Información del sistema"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid "device;system;information;memory;processor;version;default;application;fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr "peséu;sistema;información;memoria;procesador;versión;predetermináu;aplicación;alternativu;preferíu;cd;dvd;usb;audio;videu;discu;estrayible;mediu;autoexecutar;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Acti_on:"
-msgstr "Aici_ón:"
-
-#: ../panels/info/info.ui.h:2
-msgid "CD _audio:"
-msgstr "CD de _soníu:"
-
-#: ../panels/info/info.ui.h:3
-msgid "Calculating..."
-msgstr "Calculando…"
-
-#: ../panels/info/info.ui.h:5
-msgid "Device name"
-msgstr "Nome del preséu"
-
-#: ../panels/info/info.ui.h:6
-msgid "Disk"
-msgstr "Discu"
-
-#: ../panels/info/info.ui.h:7
-msgid "Driver"
-msgstr "Controlador"
-
-#: ../panels/info/info.ui.h:8
-msgid "Experience"
-msgstr "Esperiencia"
-
-#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
-#: ../panels/info/info.ui.h:10
-msgid "Forced _Fallback Mode"
-msgstr "_Forzar mou alternativu"
-
-#: ../panels/info/info.ui.h:12
-msgid "M_usic"
-msgstr "_Música"
-
-#: ../panels/info/info.ui.h:13
-msgid "Memory"
-msgstr "Memoria"
-
-#: ../panels/info/info.ui.h:14
-msgid "OS type"
-msgstr "Triba de SO"
-
-#: ../panels/info/info.ui.h:16
-msgid "Processor"
-msgstr "Procesador"
-
-#: ../panels/info/info.ui.h:18
-msgid "Select how media should be handled"
-msgstr "Escoyer cómo hai que remanar los soportes"
-
-#: ../panels/info/info.ui.h:19
-msgid "Select how other media should be handled"
-msgstr "Escoyer cómo hai que remanar otros soportes"
-
-#: ../panels/info/info.ui.h:20
-msgid "_Calendar"
-msgstr "_Calendariu"
-
-#: ../panels/info/info.ui.h:21
-msgid "_DVD video:"
-msgstr "_DVD de videu:"
-
-#: ../panels/info/info.ui.h:22
-msgid "_Mail"
-msgstr "_Corréu"
-
-#: ../panels/info/info.ui.h:23
-msgid "_Music player:"
-msgstr "Reproductor de _música:"
-
-#: ../panels/info/info.ui.h:24
-msgid "_Never prompt or start programs on media insertion"
-msgstr "_Enxamás entrugar nin arrancar programes al introducir soportes"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Other Media..."
-msgstr "_Otros soportes…"
-
-#: ../panels/info/info.ui.h:26
-msgid "_Photos"
-msgstr "_Semeyes"
-
-#: ../panels/info/info.ui.h:27
-msgid "_Photos:"
-msgstr "_Semeyes:"
-
-#: ../panels/info/info.ui.h:28
-msgid "_Software:"
-msgstr "_Software:"
-
-#: ../panels/info/info.ui.h:29
-msgid "_Type:"
-msgstr "_Triba:"
-
-#: ../panels/info/info.ui.h:30
-msgid "_Video"
-msgstr "_Videu"
-
-#: ../panels/info/info.ui.h:31
-msgid "_Web"
-msgstr "_Web"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
-msgid "Eject"
-msgstr "Espulsar"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Launch media player"
-msgstr "Llanzar el reproductor multimedia"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
-msgid "Next track"
-msgstr "Pista siguiente"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
-msgid "Pause playback"
-msgstr "Posar la reproducción"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
-msgid "Play (or play/pause)"
-msgstr "Reproducir (o reproducir/posar)"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
-msgid "Previous track"
-msgstr "Pista anterior"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
-msgid "Sound and Media"
-msgstr "Soníu y medios"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
-msgid "Stop playback"
-msgstr "Parar la reproducción"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
-msgid "Volume down"
-msgstr "Baxar volume"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
-msgid "Volume mute"
-msgstr "Silenciar"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
-msgid "Volume up"
-msgstr "Xubir volume"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:1
-msgid "Home folder"
-msgstr "Carpeta personal"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:2
-msgid "Launch calculator"
-msgstr "Llanzar la calculadora"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:3
-msgid "Launch email client"
-msgstr "Llanzar el veceru de corréu-e"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:4
-msgid "Launch help browser"
-msgstr "Llanzar el visor d'ayuda"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:5
-msgid "Launch web browser"
-msgstr "Llanzar restolador web"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:6
-msgid "Launchers"
-msgstr "Llanzadores"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicaciones"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Aplicaciones"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Instalada"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "Abrir puerta"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Ver detalles"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Guetar"
 
-#: ../panels/keyboard/01-system.xml.in.h:1
-msgid "Lock screen"
-msgstr "Candar la pantalla"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
 
-#: ../panels/keyboard/01-system.xml.in.h:2
-msgid "Log out"
-msgstr "Colar"
-
-#: ../panels/keyboard/01-system.xml.in.h:3
-#: ../panels/region/gnome-region-panel.ui.h:24
-msgid "System"
-msgstr "Sistema"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-msgid "Decrease text size"
-msgstr "Menguar el tamañu del testu:"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
-msgid "Increase text size"
-msgstr "Aumentar el tamañu del testu:"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
-msgid "Magnifier zoom in"
-msgstr "Ampliación del magnificador"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
-msgid "Magnifier zoom out"
-msgstr "Reducción del magnificador"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
-msgid "Toggle contrast"
-msgstr "Cambiar contraste"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
-msgid "Toggle magnifier"
-msgstr "Conmutar l'ampliador"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
-msgid "Toggle on-screen keyboard"
-msgstr "Conmutar el tecláu de pantalla"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
-msgid "Toggle screen reader"
-msgstr "Conmutar el llector de pantalla"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
-msgid "Universal Access"
-msgstr "Accesu universal"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr "Combinación nueva..."
-
-#: ../panels/keyboard/eggcellrendererkeys.c:164
-#: ../panels/keyboard/eggcellrendererkeys.c:165
-msgid "Accelerator key"
-msgstr "Tecla Aceleradora"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:174
-#: ../panels/keyboard/eggcellrendererkeys.c:175
-msgid "Accelerator modifiers"
-msgstr "Modificadores del Acelerador"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:183
-#: ../panels/keyboard/eggcellrendererkeys.c:184
-msgid "Accelerator keycode"
-msgstr "Códigu de tecla de la combinación"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:194
-msgid "Accel Mode"
-msgstr "Mou de la combinación"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:195
-msgid "The type of accelerator."
-msgstr "El tipu d'acelerador."
-
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/eggcellrendererkeys.c:243
-#: ../panels/keyboard/keyboard-shortcuts.c:1191
-#: ../panels/sound/gvc-mixer-control.c:1086
-#: ../panels/user-accounts/um-fingerprint-dialog.c:177
-#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Deshabilitáu"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Change keyboard settings"
-msgstr "Camudar la configuración del tecláu"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "Magnificador"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "Keyboard"
-msgstr "Tecláu"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Información del sistema"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Atayu;Repetir;Parpaguiar;"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Fondu de pantalla"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:646
-#: ../panels/keyboard/keyboard-shortcuts.c:654
-#: ../panels/keyboard/keyboard-shortcuts.c:966
-#: ../panels/keyboard/keyboard-shortcuts.c:1564
-#: ../panels/keyboard/keyboard-shortcuts.c:1568
-msgid "Custom Shortcuts"
-msgstr "Combinación personalizada"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:814
-msgid "<Unknown Action>"
-msgstr "<Aición desconocida>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1217
-msgid "Error saving the new shortcut"
-msgstr "Error al guardar l'atayu nuevu"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1350
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
-"Nun pue usase la combinación de tecles «%s» porque fadríase enforma abegoso escribir usando esta tecla.\n"
-"Por favor, téntelo con una tecla como Control, Alt o Mayús. al mesmu tiempu."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1380
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Pantalla"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
 msgstr ""
-"La combinación «%s» yá ta usándose pa\n"
-"«%s»"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1385
-#, c-format
-msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "Si reasigna la combinación a «%s» desactivaráse la combinación «%s»."
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Fondos d'escritoriu"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1391
-msgid "_Reassign"
-msgstr "_Reasignar"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1503
-msgid "Too many custom shortcuts"
-msgstr "Demasiaos atayos personalizaos"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Soníu"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1855
-msgid "Action"
-msgstr "Aición"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1878
-msgid "Shortcut"
-msgstr "Atayu"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "C_ommand:"
-msgstr "C_omandu:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "Cursor Blinking"
-msgstr "Parpaguéu del cursor"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "Cursor _blinks in text fields"
-msgstr "El cursor pa_rpaguea nos campos de testu"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "Cursor blink speed"
-msgstr "Velocidá de parpaguéu del cursor"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "Custom Shortcut"
-msgstr "Combinación personalizada"
-
-#. fast acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "Fast"
-msgstr "Rápidu"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "Les pulsaciones de tecles _repítense cuando la tecla se caltién calcada"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "Layout Settings"
-msgstr "Configuración del formatu"
-
-#. long delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-#: ../panels/universal-access/uap.ui.h:38
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Long"
-msgstr "Llargu"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgid "Repeat Keys"
-msgstr "Repetir tecles"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "Velocidá de repetición de les tecles"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgid "S_peed:"
-msgstr "Veloci_dá:"
-
-#. short delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-#: ../panels/mouse/gnome-mouse-properties.ui.h:24
-#: ../panels/universal-access/uap.ui.h:54
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Short"
-msgstr "Curtiu"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Shortcuts"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
 msgstr "Atayos"
 
-#. slow acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-#: ../panels/mouse/gnome-mouse-properties.ui.h:26
-msgid "Slow"
-msgstr "Lentu"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "To edit a shortcut, click the row and hold down the new keys or press Backspace to clear."
-msgstr "Pa editar un atayu nuevu calca na filera y caltén primíes les tecles nueves, o calca Retrocesu pa desaniciar."
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-#: ../panels/universal-access/uap.ui.h:67
-msgid "Typing"
-msgstr "Escribiendo"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-msgid "_Delay:"
-msgstr "_Retrasu:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-msgid "_Name:"
-msgstr "_Nome:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "_Speed:"
-msgstr "_Velocidá:"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:305
-msgid "Error logging into the account"
-msgstr "Fallua al arrancar la sesión na cuenta"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:351
-msgid "Expired credentials. Please log in again."
-msgstr "Les credenciales gandieron. Arranca sesión otra vuelta."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:354
-msgid "_Log In"
-msgstr "_Arrancar sesión"
-
-#. translators: This is the title of the "Add Account" dialogue.
-#. * The title is not visible when using GNOME Shell
-#: ../panels/online-accounts/cc-online-accounts-panel.c:461
-msgid "Add Account"
-msgstr "Amestar cuenta"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:466
-msgid "To add a new account, first select the account type"
-msgstr "P'amestar una cuenta nueva, escueyi primero la triba de cuenta"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:469
-msgid "Account Type:"
-msgstr "Triba de cuenta:"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Add..."
-msgstr "_Amestar..."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:555
-msgid "Error creating account"
-msgstr "Fallu al criar la cuenta"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:589
-msgid "Error removing account"
-msgstr "Fallu al desaniciar la cuenta"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:625
-msgid "Are you sure you want to remove the account?"
-msgstr "¿Tas seguru de que quies desaniciar la cuenta?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:627
-msgid "This will not remove the account on the server."
-msgstr "Esto nun desanicia la cuenta nel sirvidor"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:628
-msgid "_Remove"
-msgstr "_Desaniciar"
-
-#. Translators: those are keywords for the online-accounts control-center panel
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
-msgstr "Google;Facebook;Twitter;Yahoo;Web;En llinia;Chat;Calendariu;Corréu-e;Contautu;"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
-msgid "Manage online accounts"
-msgstr "Xestionar cuentes en llinia"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-msgid "Online Accounts"
-msgstr "Cuentes en llinia"
-
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "Select an account"
-msgstr "Escueyi una cuenta"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:520
-msgid "Low on toner"
-msgstr "Tóner baxo"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:522
-msgid "Out of toner"
-msgstr "Ensin tóner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:525
-msgid "Low on developer"
-msgstr "Nivel de revelador baxo"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:528
-msgid "Out of developer"
-msgstr "Ensin revelador"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:530
-msgid "Low on a marker supply"
-msgstr "Marcador baxo"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:532
-msgid "Out of a marker supply"
-msgstr "Ensin marcador"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:534
-msgid "Open cover"
-msgstr "Abrir cubierta"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:536
-msgid "Open door"
-msgstr "Abrir puerta"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:538
-msgid "Low on paper"
-msgstr "Nivel de papel baxo"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:540
-msgid "Out of paper"
-msgstr "Ensin papel"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:542
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Ensin conexón"
-
-#. Translators: Someone has paused the Printer
-#: ../panels/printers/cc-printers-panel.c:544
-msgctxt "printer state"
-msgid "Paused"
-msgstr "Posáu"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:546
-msgid "Waste receptacle almost full"
-msgstr "Recipiente de residuos casi enllenu"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:548
-msgid "Waste receptacle full"
-msgstr "Receptáculu de residuos enllenu"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:550
-msgid "The optical photo conductor is near end of life"
-msgstr "El conductor ópticu ta cerca del final de la so vida"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:552
-msgid "The optical photo conductor is no longer functioning"
-msgstr "El conductor ópticu yá nun funciona"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:724
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Sollerte"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:728
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Procesando"
-
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Paráu"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:851
-msgid "Toner Level"
-msgstr "Nivel de tóner"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:854
-msgid "Ink Level"
-msgstr "Nivel de tinta"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:857
-msgid "Supply Level"
-msgstr "Nivel del suministru"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:872
-#: ../panels/printers/cc-printers-panel.c:1258
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u activu"
-msgstr[1] "%u activos"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:977
-msgid "No printers available"
-msgstr "Nun hai imprentadores disponibles"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/cc-printers-panel.c:1301
-msgctxt "print job"
-msgid "Pending"
-msgstr "N'espera"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/cc-printers-panel.c:1305
-msgctxt "print job"
-msgid "Held"
-msgstr "Reteníu"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/cc-printers-panel.c:1309
-msgctxt "print job"
-msgid "Processing"
-msgstr "Procesando"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/cc-printers-panel.c:1313
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Paráu"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/cc-printers-panel.c:1317
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Encaboxáu"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/cc-printers-panel.c:1321
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Torgáu"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/cc-printers-panel.c:1325
-msgctxt "print job"
-msgid "Completed"
-msgstr "Completáu"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/cc-printers-panel.c:1408
-msgid "Job Title"
-msgstr "Títulu del Trabayu"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/cc-printers-panel.c:1417
-msgid "Job State"
-msgstr "Estáu del trabayu"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/cc-printers-panel.c:1423
-msgid "Time"
-msgstr "Tiempu"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:2019
-msgid "Failed to add new printer."
-msgstr "Falló al amestar una imprentadora nueva."
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2223
-#: ../panels/printers/cc-printers-panel.c:2237
-msgid "Test page"
-msgstr "Páxina de prueba"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2484
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Nun se pudo cargar la IU: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
-msgid "Change printer settings"
-msgstr "Cambiar la configuración de la imprentadora"
-
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
-msgid "Printer;Queue;Print;Paper;Ink;Toner;"
-msgstr "Imprentadora;Cola;Imprentar;Papel;Tinta;Tóner;"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
-#: ../panels/printers/pp-new-printer-dialog.c:148
-msgid "Printers"
-msgstr "Imprentadores"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "A_ddress:"
-msgstr "D_ireicion/es:"
-
-#: ../panels/printers/new-printer-dialog.ui.h:2
-msgid "Add a New Printer"
-msgstr "Amestar una imprentadora nueva"
-
-#: ../panels/printers/new-printer-dialog.ui.h:3
-msgid "_Add"
-msgstr "_Amestar"
-
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "_Search by Address"
-msgstr "Gu_etar por direición"
-
-#: ../panels/printers/pp-new-printer-dialog.c:654
-msgid "Getting devices..."
-msgstr "Obteniendo dispositivos…"
-
-#. Translators: No localy connected printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1230
-msgid "No local printers found"
-msgstr "Nun s'atoparon imprentadores llocales"
-
-#. Translators: No network printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1243
-msgid "No network printers found"
-msgstr "Nun s'atoparon imprentadores de rede"
-
-#: ../panels/printers/pp-new-printer-dialog.c:1335
-msgid "FirewallD is not running. Network printer detection needs services mdns, ipp, ipp-client and samba-client enabled on firewall."
-msgstr "FirewallD nun ta n'execución. La deteición d'imprentadores de rede necesita que los servicios  mdns, ipp, ipp-client y samba-client tean activaos nel tornafueos."
-
-#. Translators: Column of devices which can be installed
-#: ../panels/printers/pp-new-printer-dialog.c:1363
-#: ../panels/printers/pp-new-printer-dialog.c:1368
-msgid "Devices"
-msgstr "Preseos"
-
-#. Translators: Local means local printers
-#: ../panels/printers/pp-new-printer-dialog.c:1393
-msgctxt "printer type"
-msgid "Local"
-msgstr "Llocal"
-
-#. Translators: Network means network printers
-#: ../panels/printers/pp-new-printer-dialog.c:1395
-msgctxt "printer type"
-msgid "Network"
-msgstr "Rede"
-
-#. Translators: Device types column (network or local)
-#: ../panels/printers/pp-new-printer-dialog.c:1436
-msgid "Device types"
-msgstr "Tribes de dispositivos"
-
-#. Translators: Name of job which makes printer to autoconfigure itself
-#: ../panels/printers/pp-new-printer-dialog.c:1737
-msgid "Automatic configuration"
-msgstr "Configuración automática"
-
-#: ../panels/printers/pp-new-printer-dialog.c:1818
-msgid "Opening firewall for mDNS connections"
-msgstr "Abrir el tornafueos pa conexones mDNS"
-
-#: ../panels/printers/pp-new-printer-dialog.c:1827
-msgid "Opening firewall for Samba connections"
-msgstr "Abrir el tornafueos pa conexones Samba"
-
-#: ../panels/printers/pp-new-printer-dialog.c:1836
-msgid "Opening firewall for IPP connections"
-msgstr "Abrir el tornafueos pa conexones IPP"
-
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:2
-msgid "Active Print Jobs"
-msgstr "Trabayos d'imprentación activos"
-
-#. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:4
-msgid "Add New Printer"
-msgstr "Amestar imprentadora nueva"
-
-#: ../panels/printers/printers.ui.h:5
-msgid "Allowed users"
-msgstr "Usuarios permitíos"
-
-#: ../panels/printers/printers.ui.h:6
-#: ../panels/network/cc-network-panel.c:1990
-#: ../panels/network/cc-network-panel.c:1993
-#: ../panels/network/network.ui.h:11
-msgid "IP Address"
-msgstr "Direición IP"
-
-#: ../panels/printers/printers.ui.h:7
-msgid "Jobs"
-msgstr "Trabayos"
-
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:9
-msgid "Location"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Atayos del Tecláu"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "Cámara"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "Volume del micrófonu"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
 msgstr "Allugamientu"
 
-#: ../panels/printers/printers.ui.h:10
-msgid "Model"
-msgstr "Modelu"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:12
-msgid "Print _Test Page"
-msgstr "Impren_tar páxina de preba"
-
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:14
-msgid "Printer Options"
-msgstr "Opciones d'Imprentación"
-
-#. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:16
-msgid ""
-"Sorry! The system printing service\n"
-"doesn't seem to be available."
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
 msgstr ""
-"El serviciu del sistema d'imprentación\n"
-"paez nun tar disponible."
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:19
-msgid "Supply"
-msgstr "Suministru"
-
-#. Translators: Switch back to printer's info tab
-#: ../panels/printers/printers.ui.h:21
-msgid "_Back"
-msgstr "_Atrás"
-
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:23
-msgid "_Default"
-msgstr "_Predetermináu"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:25
-msgid "_Options"
-msgstr "Opciones"
-
-#. Tanslators: Switch to tab containing printer's jobs
-#: ../panels/printers/printers.ui.h:27
-msgid "_Show"
-msgstr "_Amosar"
-
-#: ../panels/region/gnome-region-panel-formats.c:142
-msgid "Imperial"
-msgstr "Imperial"
-
-#: ../panels/region/gnome-region-panel-formats.c:144
-msgid "Metric"
-msgstr "Métricu"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
-msgid "Choose a Layout"
-msgstr "Escueyi una distribución"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
-msgid "Preview"
-msgstr "Vista previa"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
-msgid "Select an input source to add"
-msgstr "Esbillar una fonte d'entrada qu'amestar"
-
-#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
-msgid "Keyboard Layout Options"
-msgstr "Opciones de distribución del tecláu"
-
-#: ../panels/region/gnome-region-panel.ui.h:1
-msgid "Allow different layouts for individual windows"
-msgstr "Permitir diferentes distribuciones pa cada ventana"
-
-#: ../panels/region/gnome-region-panel.ui.h:2
-#: ../panels/region/gnome-region-panel-system.c:406
-msgid "Copy Settings..."
-msgstr "Copiar configuración..."
-
-#: ../panels/region/gnome-region-panel.ui.h:3
-msgid "Currency"
-msgstr "Divises"
-
-#: ../panels/region/gnome-region-panel.ui.h:4
-msgid "Dates"
-msgstr "Dates"
-
-#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
-#: ../panels/region/gnome-region-panel.ui.h:6
-msgid "Display language:"
-msgstr "Amosar llingua:"
-
-#: ../panels/region/gnome-region-panel.ui.h:7
-msgid "Examples"
-msgstr "Exemplos"
-
-#: ../panels/region/gnome-region-panel.ui.h:8
-msgid "Format:"
-msgstr "Formatu:"
-
-#: ../panels/region/gnome-region-panel.ui.h:9
-msgid "Formats"
-msgstr "Formatos"
-
-#: ../panels/region/gnome-region-panel.ui.h:10
-msgid "Input source:"
-msgstr "Fonte d'entrada:"
-
-#: ../panels/region/gnome-region-panel.ui.h:11
-msgid "Install languages..."
-msgstr "Instalar llingües…"
-
-#: ../panels/region/gnome-region-panel.ui.h:12
-msgid "Language"
-msgstr "Llinguax"
-
-#: ../panels/region/gnome-region-panel.ui.h:13
-msgid "Layouts"
-msgstr "Distribuciones"
-
-#: ../panels/region/gnome-region-panel.ui.h:14
-msgid "Measurement"
-msgstr "Midida"
-
-#: ../panels/region/gnome-region-panel.ui.h:15
-msgid "New windows use the default layout"
-msgstr "Les ventanes nueves usen la distribución predeterminada"
-
-#: ../panels/region/gnome-region-panel.ui.h:16
-msgid "New windows use the previous window's layout"
-msgstr "Les ventanes nueves usen la distribución de la ventana activa"
-
-#: ../panels/region/gnome-region-panel.ui.h:17
-msgid "Numbers"
-msgstr "Númberos"
-
-#: ../panels/region/gnome-region-panel.ui.h:18
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-msgid "Region and Language"
-msgstr "Rexón y llingua"
-
-#: ../panels/region/gnome-region-panel.ui.h:19
-msgid ""
-"Replace the current keyboard layout settings with the\n"
-"default settings"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
 msgstr ""
-"Trocar la configuración actual de tecláu pola\n"
-"configuración por defeutu"
 
-#: ../panels/region/gnome-region-panel.ui.h:21
-msgid "Reset to De_faults"
-msgstr "Restablecer valores _predeterminaos"
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:22
-msgid "Select a display language (change will be applied next time you log in)"
-msgstr "Esbilla una llingua p'amosar (el cambéu va aplicase la próxima vegada qu'anicies sesión)"
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:23
-msgid "Select a region (change will be applied the next time you log in)"
-msgstr "Esbilla una rexón (el cambéu va aplicase la próxima vegada qu'anicies sesión)"
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:25
-msgid "System settings"
-msgstr "Axustes del sistema"
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Nun s'atoparon imprentadores llocales"
 
-#: ../panels/region/gnome-region-panel.ui.h:26
-#: ../panels/region/gnome-region-panel-system.c:400
-msgid "The login screen, system accounts and new user accounts use the system-wide Region and Language settings. You may change the system settings to match yours."
-msgstr "La pantalla d'aniciu de sesión, les cuentes de sistema y les nueves cuentes d'usuariu usen los axustes de rexón y llingua. Pues camudar los axustes del sistema pa que correspuendan a les tuyes."
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:27
-msgid "Times"
-msgstr "Vegaes"
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:28
-msgid "Use the same layout for all windows"
-msgstr "Usar la mesma distribución pa toles ventanes"
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Tipu d'Avisu"
 
-#: ../panels/region/gnome-region-panel.ui.h:29
-msgid "View and edit keyboard layout options"
-msgstr "Ver y editar les opciones de distribución de tecláu"
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:30
-msgid "Your settings"
-msgstr "Los tos axustes"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Resetear"
 
-#: ../panels/region/gnome-region-panel.ui.h:31
-msgid "_Options..."
-msgstr "_Opciones..."
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
 
-#: ../panels/region/gnome-region-panel-system.c:395
-msgid "The login screen, system accounts and new user accounts use the system-wide Region and Language settings."
-msgstr "La pantalla d'aniciu de sesión, les cuentes de sistema y les nueves cuentes d'usuariu usen los axustes de rexón y llingua."
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Aplicaciones"
 
-#: ../panels/region/gnome-region-panel-system.c:403
-msgid "Copy Settings"
-msgstr "Copiar axustes"
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel-xkblt.c:210
-msgid "Layout"
-msgstr "Disposición"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel-xkbot.c:229
-#: ../panels/sound/gvc-sound-theme-chooser.c:586
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Tema</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Estilu:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Predetermináu"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
-msgid "Change your region and language settings"
-msgstr "Cambiar los axustes de rexón y llingua"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
-msgid "Language;Layout;Keyboard;"
-msgstr "Llingua;Distribución;Tecláu;"
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Fondu de pantalla"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "A_cceleration:"
-msgstr "A_celeración:"
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "Disable _touchpad while typing"
-msgstr "_Desactivar el touchpad al escribir"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aspeutu"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-Click Timeout"
-msgstr "Retardu del duble clic"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Double-click timeout"
-msgstr "Retardu del duble clic"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "Drag Threshold"
-msgstr "Umbral d'arrastre"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "Activáu"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Drag and Drop"
-msgstr "Arrastrar y llantar"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
+msgstr "Nun s'atoparon adautadores de Bluetooth"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Enable _mouse clicks with touchpad"
-msgstr "Activar pul_saciones del mur col touchpad"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "Enable h_orizontal scrolling"
-msgstr "Activar desplazamientu _horizontal"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "General"
-msgstr "Xeneral"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
 
-#. high sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "Mou a_vión"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "El Bluetooth ta físicamente desactiváu"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "Mou a_vión"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Mou a_vión"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Denguna aplicación ta reproduciendo o grabando soníu anguaño."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Restolar pa buscar más imáxenes"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+#, fuzzy
+msgid "Display Calibration"
+msgstr "Calibración"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Encaboxar"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
+msgstr "Entamar %s"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "¡Fecho!"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Calibración"
+
+#: panels/color/cc-color-panel.ui:12
+#, fuzzy
+msgid "Calibration Quality"
+msgstr "Calibración"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+#, fuzzy
+msgid "Calibration Device"
+msgstr "Calibración"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "Pantalla"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Punteru Blancu Grande"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Brillu"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "nome de ficheru"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "_Perfil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Resume"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Ensin perfil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Amestar perfil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Importar"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Amestar"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Cada preséu necesita un perfil de color anováu pa poder xestionar el color."
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr "Deprendi más"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Deprendi más sobre la xestión de color"
+
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
+msgstr "Afitar pa tolos usuarios"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+#, fuzzy
+msgid "Set this profile for all users on this computer"
+msgstr "Configurar esti preséu pa tolos usuarios d'esti equipu"
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "Activáu"
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "Amestar perfil"
+
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
+msgstr "Calibrar…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibrar el preséu"
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "Desaniciar perfil"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "Ver detalles"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+#, fuzzy
+msgid "Projector"
+msgstr "Co_neutor:"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+#, fuzzy
+msgctxt "Calibration quality"
 msgid "High"
 msgstr "Altu"
 
-#. large threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Large"
-msgstr "Grande"
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "10 minutos"
 
-#. low sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "_Mediu"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#: panels/color/cc-color-panel.ui:640
+#, fuzzy
+msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Baxu"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "5 minutos"
+
+#: panels/color/cc-color-panel.ui:663
+#, fuzzy
+msgid "Native to display"
+msgstr "Panel a amosar"
+
+#: panels/color/cc-color-panel.ui:667
+#, fuzzy
+msgid "D50 (Printing and publishing)"
+msgstr "Apuntar y calcar"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+#, fuzzy
+msgid "D75"
+msgstr "75%"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Color"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Perfil;Calibráu;Imprentadora;Pantalla;"
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Esbilla una llingua"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Seleicionar"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Nun s'atoparon imprentadores llocales"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "Desbloquiar"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "Aumentar tamañu:"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Tiempu"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "Amenorgar tamañu:"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+#, fuzzy
+msgid "Date & Time"
+msgstr "Data y hora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Añu"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mes"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "xineru"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "febreru"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "marzu"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "abril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "mayu"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "xunu"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "xunetu"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "agostu"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "septiembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ochobre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "payares"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "avientu"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Día"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#, fuzzy
+msgid "Time Zone"
+msgstr "Tiempu"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Data y hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "_Aniciu automáticu de sesión"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Activáu"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desbloquiar"
+
+#: panels/datetime/cc-datetime-panel.ui:246
+#, fuzzy
+msgid "Time _Format"
+msgstr "Formatu:"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dates"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "segundos"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calendariu"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Númberos"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Reló;Estaya horaria;Allugamientu;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Cambiar los axustes de rexón y llingua"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Corréu"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendariu"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Música"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Videu"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Semeyes"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicaciones predeterminaes"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Aplicaciones predeterminaes"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+#, fuzzy
+msgid "Problem Reporting"
+msgstr "Proporcional"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Suministru"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Atrás"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "El Bluetooth ta desactiváu"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Espeyar pantalles"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+#, fuzzy
+msgid "Mirror"
+msgstr "Mirror Screens"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Espeyar pantalles"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientación del mur"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Resolución:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Frecuencia de _refrescu:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Escala"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Fracción completada"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Nun hai imprentadores disponibles"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Filtru"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Vegaes"
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "De URI"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "minutu"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Pantalles"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+#, fuzzy
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Camudar la resolución y posición de los monitores y proyeutores"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Panel;Proyeutor;xranrd;Pantalla;Resolución;Anovar;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Clave de seguridá"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Nivel de tinta"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Nivel de tinta"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Nivel de tinta"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Seguridá"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Nome del preséu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Direición física"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memoria"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesador"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Gráficos."
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+#, fuzzy
+msgid "Calculating…"
+msgstr "Calculando…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Nome"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Triba"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Terminal GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Ventanes"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+#, fuzzy
+msgid "Virtualization"
+msgstr "Calibración"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Instalar Anovamientos"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Desaniciar un preséu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nome del preséu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Renomar..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "Tocante a %s"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"peséu;sistema;información;memoria;procesador;versión;predetermináu;"
+"aplicación;alternativu;preferíu;cd;dvd;usb;audio;videu;discu;estrayible;"
+"mediu;autoexecutar;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Soníu y medios"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Silenciar"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Baxar volume"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Xubir volume"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "Volume del micrófonu"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Llanzar el reproductor multimedia"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Reproducir (o reproducir/posar)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Posar la reproducción"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Parar la reproducción"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Pista anterior"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Pista siguiente"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Espulsar"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Escribiendo"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Esbillar una fonte d'entrada qu'amestar"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Llanzadores"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Llanzar el visor d'ayuda"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Copiar axustes"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Llanzar la calculadora"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Llanzar el veceru de corréu-e"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Llanzar restolador web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Carpeta personal"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Guetar"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Colar"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Candar la pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Accesibilidá del Mur"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+#, fuzzy
+msgid "Turn zoom on or off"
+msgstr "Activar o desactivar:"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "Acercar:"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Allonxar:"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+#, fuzzy
+msgid "Turn screen reader on or off"
+msgstr "Activar o desactivar:"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "Conmutar el tecláu de pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Aumentar el tamañu del testu:"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Menguar el tamañu del testu:"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+#, fuzzy
+msgid "Add an Input Source"
+msgstr "Fonte d'entrada:"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+#, fuzzy
+msgid "No input source selected"
+msgstr "Esbillar una fonte d'entrada qu'amestar"
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "Opciones"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+#, fuzzy
+msgid "Move Up"
+msgstr "M_over Arriba"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+#, fuzzy
+msgid "Move Down"
+msgstr "_Mover Abaxo"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferencies"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Distribución del tecláu"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Desaniciar"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "Fonte d'entrada:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Fonte d'entrada:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "Usar la mesma distribución pa toles ventanes"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Tecles del Mur"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Atayos del Tecláu"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Combinación personalizada"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Estaya"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Atayos"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Atayu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Combinación personalizada"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Atayu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Atayos del Tecláu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Desaniciar"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nome"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "C_omandu:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Atayu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Atayu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Dengún"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_Restablecer valores predeterminaos"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tecláu"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Denguna aplicación ta reproduciendo o grabando soníu anguaño."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Configura la to información personal"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Volume del micrófonu"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Denguna aplicación ta reproduciendo o grabando soníu anguaño."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Los tos axustes"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Xeneral"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "Botón inferior"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Esquierda"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Derecha"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Opciones d'Imprentación"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mur"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "Mouse Preferences"
-msgstr "Preferencies del Mur"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:21
-msgid "Pointer Speed"
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
 msgstr "Velocidá del mur"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:22
-msgid "Scrolling"
-msgstr "Desplazamientu"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Desplazar abaxo"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:23
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr "Amosar la posición del punteru al calcar la tecla Control"
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+#, fuzzy
+msgid "Traditional"
+msgstr "Proporcional"
 
-#. small threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:28
-#: ../panels/universal-access/uap.ui.h:59
-msgid "Small"
-msgstr "Pequeñu"
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:29
-msgid "Thr_eshold:"
-msgstr "_Umbral:"
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:30
-msgid "To test your settings, try to double-click on the face."
-msgstr "Pa probar la configuración prueba a calcar dos vegaes sobre la cara."
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:31
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Aceleración:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:32
-msgid "Two-_finger scrolling"
-msgstr "_Desplazamientu con dos deos"
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Touchpad"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:33
-msgid "_Disabled"
-msgstr "_Desactiváu"
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Métodu"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:34
-msgid "_Edge scrolling"
-msgstr "_Berbesu de desplazamientu"
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:35
-msgid "_Left-handed"
-msgstr "_Maniegu"
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:36
-msgid "_Right-handed"
-msgstr "_Diestru"
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:37
-msgid "_Sensitivity:"
-msgstr "_Sensibilidá:"
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "Pulsación al pasar per encima"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:38
-msgid "_Timeout:"
-msgstr "_Tiempu d'espera:"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse and Touchpad"
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_Desactivar el touchpad al escribir"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (rellativu)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "Desplazamientu"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Desplazar a la izquierda"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
 msgstr "Mur y «touchpad»"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Set your mouse and touchpad preferences"
-msgstr "Configura les preferencies de mur y touchpad"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+#, fuzzy
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "trackpad;punteru;calcar;doble;mur;trackball;"
 
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/cc-network-panel.c:269
-msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "Úsase'l autodescubrimientu del proxy web cuando nun s'apurre un URL de configuración."
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/cc-network-panel.c:277
-msgid "This is not recommended for untrusted public networks."
-msgstr "Nun s'encamienta l'usu pa redes públiques nes que nun se confía."
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#. TRANSLATORS: this is when the access point is not listed
-#. * in the dropdown (or hidden) and the user has to select
-#. * another entry manually
-#: ../panels/network/cc-network-panel.c:949
-msgctxt "Wireless access point"
-msgid "Other..."
-msgstr "Otru ..."
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/cc-network-panel.c:1107
-#: ../panels/network/cc-network-panel.c:1514
-msgid "WEP"
-msgstr "WEP"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:1111
-#: ../panels/network/cc-network-panel.c:1518
-msgid "WPA"
-msgstr "WPA"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Espaciu de color:"
 
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:1115
-msgid "WPA2"
-msgstr "WPA2"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/cc-network-panel.c:1120
-msgid "Enterprise"
-msgstr "Empresa"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
 
-#. TRANSLATORS: this no (!) WiFi security
-#: ../panels/network/cc-network-panel.c:1126
-#: ../panels/network/cc-network-panel.c:1509
-#: ../panels/universal-access/uap.ui.h:43
-#: ../panels/universal-access/zoom-options.ui.h:16
-msgid "None"
-msgstr "Dengún"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#: ../panels/network/cc-network-panel.c:1577
-msgid "Hotspot"
-msgstr "Hotspot"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#. Translators: network device speed
-#: ../panels/network/cc-network-panel.c:1643
-#: ../panels/network/cc-network-panel.c:1731
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: ../panels/network/cc-network-panel.c:1986
-#: ../panels/network/network.ui.h:12
-msgid "IPv4 Address"
-msgstr "Direición IPv4"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Monitor"
 
-#: ../panels/network/cc-network-panel.c:1987
-#: ../panels/network/network.ui.h:13
-msgid "IPv6 Address"
-msgstr "Direición IPv6"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Arrastrar pa camudar la pantalla principal."
 
-#: ../panels/network/cc-network-panel.c:2040
-#: ../panels/network/cc-network-panel.c:2413
-#, c-format
-msgid "%s VPN"
-msgstr "VPN «%s»"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/network/cc-network-panel.c:2148
-msgid "Proxy"
-msgstr "Proxy"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Fonte de Progr_ama:"
 
-#: ../panels/network/cc-network-panel.c:2222
-msgid "Network proxy"
-msgstr "Proxy de rede"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:2480
-msgid "The system network services are not compatible with this version."
-msgstr "Los servicios de rede del sistema nun son compatibles con esta versión."
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: ../panels/network/cc-network-panel.c:3095
-msgid "Not connected to the internet."
-msgstr "Non coneutáu a Internet."
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#: ../panels/network/cc-network-panel.c:3096
-msgid "Create the hotspot anyway?"
-msgstr "¿Crear el «hotspot» de toes formes?"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#: ../panels/network/cc-network-panel.c:3114
-#, c-format
-msgid "Disconnect from %s and create a new hotspot?"
-msgstr "¿Desconeutase de %s y crear un «hotspot» nuevu?"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: ../panels/network/cc-network-panel.c:3117
-msgid "This is your only connection to the internet."
-msgstr "Esta ye la única conexón a Internet."
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Preseos"
 
-#: ../panels/network/cc-network-panel.c:3135
-msgid "Create _Hotspot"
-msgstr "Crear «_hotspot»"
-
-#: ../panels/network/cc-network-panel.c:3195
-msgid "Stop hotspot and disconnect any users?"
-msgstr "¿Detener el «hotspot» y desconeutar a los usuarios?"
-
-#: ../panels/network/cc-network-panel.c:3198
-msgid "_Stop Hotspot"
-msgstr "_Detener «hotspot»"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-msgid "Network"
-msgstr "Rede"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Network settings"
-msgstr "Configuración de la rede"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid "Network;Wireless;IP;LAN;"
-msgstr "rede;inalámbrica;ip;lan;"
-
-#: ../panels/network/network.ui.h:1
-msgid "Air_plane Mode"
-msgstr "Mou a_vión"
-
-#: ../panels/network/network.ui.h:2
-msgid "Create..."
-msgstr "Crear…"
-
-#: ../panels/network/network.ui.h:3
-msgid "DNS"
-msgstr "DNS"
-
-#: ../panels/network/network.ui.h:4
-msgid "Default Route"
-msgstr "Ruta predeterminada"
-
-#: ../panels/network/network.ui.h:5
-msgid "Gateway"
-msgstr "Puerta d'enllaz"
-
-#: ../panels/network/network.ui.h:6
-msgid "Group Name"
-msgstr "Nome de grupu"
-
-#: ../panels/network/network.ui.h:7
-msgid "Group Password"
-msgstr "Contraseña del grupu"
-
-#: ../panels/network/network.ui.h:8
-msgid "H_TTPS Proxy"
-msgstr "Proxy pa H_TTPS"
-
-#: ../panels/network/network.ui.h:9
-msgid "Hardware Address"
-msgstr "Direición física"
-
-#: ../panels/network/network.ui.h:10
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network.ui.h:14
-msgid "Interface"
-msgstr "Interface"
-
-#: ../panels/network/network.ui.h:15
-msgid "Network Name"
-msgstr "Nome de rede"
-
-#: ../panels/network/network.ui.h:16
-msgid "Provider"
-msgstr "Fornidor"
-
-#: ../panels/network/network.ui.h:17
-msgid "Security"
-msgstr "Seguridá"
-
-#: ../panels/network/network.ui.h:18
-msgid "Security Key"
-msgstr "Clave de seguridá"
-
-#: ../panels/network/network.ui.h:19
-msgid "Select the interface to use for the new service"
-msgstr "Esbillar la interfaz qu'usar pal serviciu nuevu"
-
-#: ../panels/network/network.ui.h:20
-msgid "Speed"
-msgstr "Velocidá"
-
-#: ../panels/network/network.ui.h:21
-msgid "Subnet Mask"
-msgstr "Mázcara de subrede"
-
-#: ../panels/network/network.ui.h:22
-msgid "Unlock"
-msgstr "Desbloquiar"
-
-#: ../panels/network/network.ui.h:23
-msgid "Username"
-msgstr "Nome d'usuariu/a"
-
-#: ../panels/network/network.ui.h:24
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: ../panels/network/network.ui.h:25
-msgid "VPN Type"
-msgstr "Tipu de VPN"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Conexón"
 
-#: ../panels/network/network.ui.h:26
-msgid "_Configuration URL"
-msgstr "URL de _configuración"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#: ../panels/network/network.ui.h:27
-msgid "_Configure..."
-msgstr "_Configurar..."
-
-#: ../panels/network/network.ui.h:28
-msgid "_FTP Proxy"
-msgstr "Proxy pa _FTP"
-
-#: ../panels/network/network.ui.h:29
-msgid "_HTTP Proxy"
-msgstr "Proxy pa _HTTP"
-
-#: ../panels/network/network.ui.h:30
-msgid "_Method"
-msgstr "_Métodu"
-
-#: ../panels/network/network.ui.h:31
-msgid "_Network Name"
-msgstr "_Nome de rede"
-
-#: ../panels/network/network.ui.h:32
-msgid "_Socks Host"
-msgstr "_Sirvidor socks"
-
-#: ../panels/network/network.ui.h:33
-msgid "_Stop Hotspot..."
-msgstr "_Detener «hotspot»…"
-
-#: ../panels/network/network.ui.h:34
-msgid "_Use as Hotspot..."
-msgstr "_Usar como «hotspot»…"
-
-#: ../panels/network/network.ui.h:35
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "Automáticu"
-
-#: ../panels/network/network.ui.h:36
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "Manual"
-
-#: ../panels/network/network.ui.h:37
-msgctxt "proxy method"
-msgid "None"
-msgstr "Dengún"
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:83
-msgid "Wired"
-msgstr "Cableada"
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:87
-msgid "Wireless"
-msgstr "Inalámbrica"
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:94
-msgid "Mobile broadband"
-msgstr "Banda ancha móvil"
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:103
-msgid "Mesh"
-msgstr "Malla"
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:162
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:166
-msgid "Infrastructure"
-msgstr "Infraestructura"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:190
-#: ../panels/network/panel-common.c:251
-msgid "Status unknown"
-msgstr "Estáu desconocíu"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:194
-msgid "Unmanaged"
-msgstr "Non xestionada"
-
-#: ../panels/network/panel-common.c:199
-msgid "Firmware missing"
-msgstr "falta'l «firmware»"
-
-#: ../panels/network/panel-common.c:202
-msgid "Cable unplugged"
-msgstr "Cable desconeutáu"
-
-#: ../panels/network/panel-common.c:204
-msgid "Unavailable"
-msgstr "Non disponible"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:208
-msgid "Disconnected"
-msgstr "Desconectáu"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:215
-#: ../panels/network/panel-common.c:257
-msgid "Connecting"
-msgstr "Coneutando"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:219
-#: ../panels/network/panel-common.c:261
-msgid "Authentication required"
-msgstr "Necesítase autenticación"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223
-#: ../panels/network/panel-common.c:265
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Coneutáu"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:227
-msgid "Disconnecting"
-msgstr "Desconeutando"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Opciones"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:231
-#: ../panels/network/panel-common.c:269
-msgid "Connection failed"
-msgstr "Falló la conexón"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:235
-#: ../panels/network/panel-common.c:277
-msgid "Status unknown (missing)"
-msgstr "Estáu desconocíu (ausente)"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
 
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:273
-msgid "Not connected"
-msgstr "Non coneutáu"
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "Enerxía"
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nome de rede"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Power management settings"
-msgstr "Axustes de Xestión d'enerxía"
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "C_ontraseña"
 
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid "Power;Sleep;Suspend;Hibernate;Battery;"
-msgstr "Enerxía;Durmir;Suspender;Ivernar;Batería;"
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Contraseña del grupu"
 
-#: ../panels/power/cc-power-panel.c:160
-msgid "Unknown time"
-msgstr "Tiempu desconocíu"
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Escoyer una contraseña xenerada"
 
-#: ../panels/power/cc-power-panel.c:166
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Mou a_vión"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nun s'atoparon adautadores de Bluetooth"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Mou a_vión"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Rede"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+#, fuzzy
+msgid "802.1x _Security"
+msgstr "Seguridá"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Velocidá de parpaguéu del cursor"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguridá"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Direición IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Direición IPv6"
+
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr "Direición física"
+
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Perfiles ICC sofitaos"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Ruta predeterminada"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Nome:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Direición:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Direición:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "_Métodu"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+#, fuzzy
+msgid "Automatic (DHCP)"
+msgstr "Automáticu"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+#, fuzzy
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Deshabilitáu"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Direición/es"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Direición/es"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Puerta d'enllaz"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "Automáticu"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+#, fuzzy
+msgid "Automatic DNS"
+msgstr "Automáticu"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "minutos"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+#, fuzzy
+msgid "Automatic Routes"
+msgstr "Automáticu"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Métricu"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "_Métodu"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+#, fuzzy
+msgid "Automatic, DHCP only"
+msgstr "_Aniciu automáticu de sesión"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+#, fuzzy
+msgid "S_ecurity"
+msgstr "Seguridá"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rede"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to the Internet"
+msgstr "Non coneutáu a Internet."
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Cableada"
+
+#: panels/network/network-bluetooth.ui:11
+#, fuzzy
+msgid "Turn device off"
+msgstr "Activar o desactivar:"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "%u activu"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Fornidor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Direición IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy de Rede"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy pa _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy pa H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy pa _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Sirvidor socks"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "Hosts inoraos"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "Proxy H_TTP:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "Proxy pa H_TTPS"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "Proxy _FTP:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuración"
+
+#: panels/network/network-vpn.ui:11
+#, fuzzy
+msgid "Turn VPN connection off"
+msgstr "Activar o desactivar:"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nome de rede"
+
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Clave de seguridá"
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "C_ontraseña"
+
+#: panels/network/network-wifi.ui:90
+#, fuzzy
+msgid "Turn Wi-Fi off"
+msgstr "Activar o desactivar:"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Amosar opciones d'aida"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "¡Reconocíu!"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "Tolos ficheros"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Utiliza autenticación</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nome d'_usuariu"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "C_ontraseña"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Amosar contraseña"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Versión %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Versión %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_Autenticar"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Necesítase autenticación"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "Volve_r a escribir la nueva contraseña:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+#, fuzzy
+msgid "PAP"
+msgstr "WPA"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_Autenticar"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "_Triba:"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Predetermináu"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Sistema de Ficheros"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Magnificador"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Efeutos de soníu"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "B_loquiar pantalla dempués de:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "B_loquiar pantalla dempués de:"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "_Desaniciar allugamientu"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Amestar cuenta"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Cuentes en llinia"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+#, fuzzy
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;En llinia;Chat;Calendariu;Corréu-e;"
+"Contautu;"
+
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i minutu"
 msgstr[1] "%i minutos"
 
-#: ../panels/power/cc-power-panel.c:178
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i hora"
 msgstr[1] "%i hores"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:186
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:187
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hora"
 msgstr[1] "hores"
 
-#: ../panels/power/cc-power-panel.c:188
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minutu"
 msgstr[1] "minutos"
 
-#: ../panels/power/cc-power-panel.c:265
-msgid "Battery charging"
-msgstr "La batería ta cargándose"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "5 minutos"
 
-#: ../panels/power/cc-power-panel.c:268
-msgid "Battery discharging"
-msgstr "La batería ta descargándose"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 minutos"
 
-#: ../panels/power/cc-power-panel.c:279
-msgid "UPS charging"
-msgstr "SAI cargándose"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 minutos"
 
-#: ../panels/power/cc-power-panel.c:282
-msgid "UPS discharging"
-msgstr "SAI descargándose"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:300
-#, c-format
-msgid "%s until charged (%.0lf%%)"
-msgstr "%s hasta cargase (%.0lf%%)"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:306
-#, c-format
-msgid "%s until empty (%.0lf%%)"
-msgstr "%s hasta descargase (%.0lf%%)"
-
-#. TRANSLATORS: %1 is a percentage value. Note: this string is only
-#. * used when we don't have a time value
-#: ../panels/power/cc-power-panel.c:314
-#, c-format
-msgid "%.0lf%% charged"
-msgstr "%.0lf%% cargáu"
-
-#: ../panels/power/power.ui.h:1
-#: ../panels/screen/screen.ui.h:1
-msgid "1 hour"
-msgstr "1 hora"
-
-#: ../panels/power/power.ui.h:2
-#: ../panels/screen/screen.ui.h:3
-msgid "10 minutes"
-msgstr "10 minutos"
-
-#: ../panels/power/power.ui.h:3
-#: ../panels/screen/screen.ui.h:6
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 minutos"
 
-#: ../panels/power/power.ui.h:4
-#: ../panels/screen/screen.ui.h:8
-msgid "5 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
 msgstr "5 minutos"
 
-#: ../panels/power/power.ui.h:5
-msgid "Don't suspend"
-msgstr "Non suspender"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hora"
 
-#: ../panels/power/power.ui.h:6
-msgid "Hibernate"
-msgstr "Ivernar"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "10 minutos"
 
-#: ../panels/power/power.ui.h:7
-msgid "On battery power"
-msgstr "Cuando tea con batería"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "10 minutos"
 
-#: ../panels/power/power.ui.h:8
-msgid "Power off"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "10 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "1 hora"
+
+#: panels/power/cc-power-panel.ui:58
+#, fuzzy
+msgid "Battery"
+msgstr "La batería ta cargándose"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Preseos"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
 msgstr "Apagar"
 
-#: ../panels/power/power.ui.h:9
-msgid "Suspend when inactive for:"
-msgstr "Suspender cuando tea inactivu por:"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:10
-msgid "When plugged in"
-msgstr "Cuando tea coneutáu"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Opciones d'Imprentación"
 
-#: ../panels/power/power.ui.h:11
-msgid "When power is _critically low:"
-msgstr "_Cuando la carga tea críticamente baxa:"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Configuración automática"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
-#: ../panels/color/color.ui.h:8
-msgid "Color"
-msgstr "Color"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Brillu y axustes de bloquéu de la pantalla"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Color management settings"
-msgstr "Axustes de xestión de color"
-
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
-msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
-msgstr "Color;ICC;Perfil;Calibráu;Imprentadora;Pantalla;"
-
-#. TRANSLATORS: this is where the user can click and import a profile
-#: ../panels/color/cc-color-panel.c:106
-msgid "Other profile…"
-msgstr "Otru perfil…"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:119
-msgid "Default: "
-msgstr "Predetermináu:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:126
-msgid "Colorspace: "
-msgstr "Espaciu de color:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:132
-msgid "Test profile: "
-msgstr "Perfil de color:"
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:185
-#: ../panels/color/color.ui.h:19
-msgid "Set for all users"
-msgstr "Afitar pa tolos usuarios"
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:192
-msgid "Create virtual device"
-msgstr "Crear un preséu virtual"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:227
-msgid "Select ICC Profile File"
-msgstr "Esbillar ficheru de perfil ICC"
-
-#: ../panels/color/cc-color-panel.c:230
-msgid "_Import"
-msgstr "_Importar"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:241
-msgid "Supported ICC profiles"
-msgstr "Perfiles ICC sofitaos"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:248
-msgid "All files"
-msgstr "Tolos ficheros"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:504
-msgid "Available Profiles for Displays"
-msgstr "Perfiles disponibles pa pantalles"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:508
-msgid "Available Profiles for Scanners"
-msgstr "Perfiles disponibles pa escáneres"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:512
-msgid "Available Profiles for Printers"
-msgstr "Perfiles disponibles pa imprentadores"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:516
-msgid "Available Profiles for Cameras"
-msgstr "Perfiles disponibles pa cámares"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:520
-msgid "Available Profiles for Webcams"
-msgstr "Perfiles disponibles pa webcams"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#. * where the device type is not recognised
-#. Profiles that can be added to the device
-#: ../panels/color/cc-color-panel.c:525
-#: ../panels/color/color.ui.h:5
-msgid "Available Profiles"
-msgstr "Perfiles disponibles"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:794
-#: ../panels/sound/gvc-mixer-dialog.c:1515
-msgid "Device"
-msgstr "Preséu"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:829
-msgid "Calibration"
-msgstr "Calibración"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:861
-msgid "Create a color profile for the selected device"
-msgstr "Crear un perfil de color pal preséu esbilláu"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:875
-#: ../panels/color/cc-color-panel.c:899
-msgid "The measuring instrument is not detected. Please check it is turned on and correctly connected."
-msgstr "Nun se deteutó l'instrumentu de midida. Comprueba que tea encesu y correutamente coneutáu."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:908
-msgid "The measuring instrument does not support printer profiling."
-msgstr "L'instrumentu de midida nun sofita perfiláu d'imprentadores."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:919
-msgid "The device type is not currently supported."
-msgstr "El tipu de preséu nun ta sofitáu anguaño."
-
-#. TRANSLATORS: this is when an auto-added profile cannot be removed
-#: ../panels/color/cc-color-panel.c:992
-msgid "Cannot remove automatically added profile"
-msgstr "Nun pue desaniciase automáticamente'l perfil amestáu"
-
-#. TRANSLATORS: this is when there is no profile for the device
-#: ../panels/color/cc-color-panel.c:1327
-msgid "No profile"
-msgstr "Ensin perfil"
-
-#: ../panels/color/cc-color-panel.c:1358
-#, c-format
-msgid "%i year"
-msgid_plural "%i years"
-msgstr[0] "%i añu"
-msgstr[1] "%i años"
-
-#: ../panels/color/cc-color-panel.c:1369
-#, c-format
-msgid "%i month"
-msgid_plural "%i months"
-msgstr[0] "%i mes"
-msgstr[1] "%i meses"
-
-#: ../panels/color/cc-color-panel.c:1380
-#, c-format
-msgid "%i week"
-msgid_plural "%i weeks"
-msgstr[0] "%i selmana"
-msgstr[1] "%i selmanes"
-
-#. fallback
-#: ../panels/color/cc-color-panel.c:1387
-#, c-format
-msgid "Less than 1 week"
-msgstr "Menos d'una selmana"
-
-#: ../panels/color/cc-color-panel.c:1449
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB predetermináu"
-
-#: ../panels/color/cc-color-panel.c:1454
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK predetermináu"
-
-#: ../panels/color/cc-color-panel.c:1459
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Buxu predetermináu"
-
-#: ../panels/color/cc-color-panel.c:1577
-#: ../panels/color/cc-color-panel.c:1609
-#: ../panels/color/cc-color-panel.c:1620
-#: ../panels/color/cc-color-panel.c:1631
-msgid "Uncalibrated"
-msgstr "Ensin calibrar"
-
-#: ../panels/color/cc-color-panel.c:1580
-msgid "This device is not color managed."
-msgstr "Esti preséu nun tien xestión de color."
-
-#: ../panels/color/cc-color-panel.c:1612
-msgid "This device is using manufacturing calibrated data."
-msgstr "Esti preséu ta usando los datos de calibración de fabricación."
-
-#: ../panels/color/cc-color-panel.c:1623
-msgid "This device does not have a profile suitable for whole-screen color correction."
-msgstr "Esti preséu nun tien un perfil aptu pa correición de color en tola pantalla."
-
-#: ../panels/color/cc-color-panel.c:1656
-msgid "This device has an old profile that may no longer be accurate."
-msgstr "Esti preséu tien un perfil antiguu que pue nun ser precisu."
-
-#. TRANSLATORS: this is when the calibration profile age is not
-#. * specified as it has been autogenerated from the hardware
-#: ../panels/color/cc-color-panel.c:1684
-msgid "Not specified"
-msgstr "Ensin especificar"
-
-#. add the 'No devices detected' entry
-#: ../panels/color/cc-color-panel.c:1868
-msgid "No devices supporting color management detected"
-msgstr "Nun hai preseos deteutaos que sofiten la xestión de color"
-
-#: ../panels/color/cc-color-panel.c:2097
-msgctxt "Device kind"
-msgid "Display"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
 msgstr "Pantalla"
 
-#: ../panels/color/cc-color-panel.c:2099
-msgctxt "Device kind"
-msgid "Scanner"
-msgstr "Escáner"
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
 
-#: ../panels/color/cc-color-panel.c:2101
-msgctxt "Device kind"
-msgid "Printer"
-msgstr "Imprentadora"
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Pantalla"
 
-#: ../panels/color/cc-color-panel.c:2103
-msgctxt "Device kind"
-msgid "Camera"
-msgstr "Cámara"
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
 
-#: ../panels/color/cc-color-panel.c:2105
-msgctxt "Device kind"
-msgid "Webcam"
-msgstr "Cámara web"
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
 
-#: ../panels/color/color.ui.h:1
-msgid "Add a virtual device"
-msgstr "Amestar un preséu virtual"
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
 
-#: ../panels/color/color.ui.h:2
-msgid "Add device"
-msgstr "Amestar preséu"
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Automáticu"
 
-#: ../panels/color/color.ui.h:3
-msgid "Add profile"
-msgstr "Amestar perfil"
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
 
-#: ../panels/color/color.ui.h:6
-msgid "Calibrate the device"
-msgstr "Calibrar el preséu"
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Botón inferior"
 
-#: ../panels/color/color.ui.h:7
-msgid "Calibrate…"
-msgstr "Calibrar…"
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
 
-#: ../panels/color/color.ui.h:9
-msgid "Delete device"
-msgstr "Desaniciar preséu"
+#: panels/power/cc-power-panel.ui:244
+#, fuzzy
+msgid "Automatic Suspend"
+msgstr "Automáticu"
 
-#: ../panels/color/color.ui.h:10
-msgid "Device type:"
-msgstr "Triba de preséu:"
+#: panels/power/cc-power-panel.ui:267
+#, fuzzy
+msgid "_Plugged In"
+msgstr "Cuando tea coneutáu"
 
-#: ../panels/color/color.ui.h:11
-msgid "Each device needs an up to date color profile to be color managed."
-msgstr "Cada preséu necesita un perfil de color anováu pa poder xestionar el color."
+#: panels/power/cc-power-panel.ui:279
+#, fuzzy
+msgid "On _Battery Power"
+msgstr "Cuando tea con batería"
 
-#: ../panels/color/color.ui.h:12
-msgid "Image files can be dragged on this window to auto-complete the above fields."
-msgstr "Puen arrastrase ficheros d'imaxe nesta ventana p'autocompletar los campos superiores."
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Retrasu:"
 
-#: ../panels/color/color.ui.h:13
-msgid "Learn more"
-msgstr "Deprendi más"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Enerxía"
 
-#: ../panels/color/color.ui.h:14
-msgid "Learn more about color management"
-msgstr "Deprendi más sobre la xestión de color"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
 
-#: ../panels/color/color.ui.h:15
-msgid "Manufacturer:"
-msgstr "Fabricante:"
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "Enerxía;Durmir;Suspender;Ivernar;Batería;"
 
-#: ../panels/color/color.ui.h:16
-msgid "Model:"
-msgstr "Modelu:"
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Imprentadores"
 
-#: ../panels/color/color.ui.h:17
-msgid "Remove a device"
-msgstr "Desaniciar un preséu"
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
 
-#: ../panels/color/color.ui.h:18
-msgid "Remove profile"
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Imprentadora;Cola;Imprentar;Papel;Tinta;Tóner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "Amestar imprentadora nueva"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "Desbloquiar"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Nun s'atoparon imprentadores llocales"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Necesítase autenticación"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nome d'usuariu/a"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Allugamientu"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Controlador"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "Gu_etar por direición"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Falló la instalación"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "Seleicionando deu"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Encaboxar"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Seleicionar"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_Autenticar"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autenticar"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "Trabayos d'imprentación activos"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Páxina de prueba"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Opciones d'Imprentación"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Opciones d'Imprentación"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "_Restablecer valores predeterminaos"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
 msgstr "Desaniciar perfil"
 
-#: ../panels/color/color.ui.h:20
-msgid "Set this device for all users on this computer"
-msgstr "Configurar esti preséu pa tolos usuarios d'esti equipu"
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Trabayos d'imprentación activos"
 
-#: ../panels/color/color.ui.h:21
-msgid "View details"
-msgstr "Ver detalles"
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modelu"
 
-#. Translators: those are keywords for the brightness and lock control-center panel
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
-msgid "Brightness;Lock;Dim;Blank;Monitor;"
-msgstr "Brillu;Bloquiar;Escurecer;Illuminar;Pantalla;"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nivel de tinta"
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Tea xuru de que la miniaplicación ta instalada correchamente"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "_Executar al entamu"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Amestar imprentadora nueva"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Cambiar la configuración de la imprentadora"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Imprentadores"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+#, fuzzy
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"El serviciu del sistema d'imprentación\n"
+"paez nun tar disponible."
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Xeres comunes"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Vista previa"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Dates"
+
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Data y hora"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Númberos"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Midida"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Instalar llingües…"
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "La mio cuenta"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Llingua"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Candar la pantalla"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+#, fuzzy
+msgid "Region & Language"
+msgstr "Rexón y llingua"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+#, fuzzy
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Llingua;Distribución;Tecláu;"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Escoyer cómo hai que remanar los soportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+#, fuzzy
+msgid "CD _audio"
+msgstr "CD de _soníu:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+#, fuzzy
+msgid "_DVD video"
+msgstr "_DVD de videu:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "Reproductor de _música:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+#, fuzzy
+msgid "_Software"
+msgstr "_Software:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+#, fuzzy
+msgid "_Other Media…"
+msgstr "_Otros soportes…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Enxamás entrugar nin arrancar programes al introducir soportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Escoyer cómo hai que remanar otros soportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "_Aición"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Triba:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Medios Estrayibles"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Configurar axustes de Bluetooth"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"peséu;sistema;información;memoria;procesador;versión;predetermináu;"
+"aplicación;alternativu;preferíu;cd;dvd;usb;audio;videu;discu;estrayible;"
+"mediu;autoexecutar;"
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Pantalla"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+#, fuzzy
+msgid "Automatic Screen _Lock"
+msgstr "_Aniciu automáticu de sesión"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Candar la pantalla"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Pantalla"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
 msgid "Screen"
 msgstr "Pantalla"
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
-msgid "Screen brightness and lock settings"
-msgstr "Brillu y axustes de bloquéu de la pantalla"
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Axustes de soníu"
 
-#: ../panels/screen/screen.ui.h:2
-msgid "1 minute"
-msgstr "1 minutu"
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:4
-msgid "2 minutes"
-msgstr "2 minutos"
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Allugamientu"
 
-#: ../panels/screen/screen.ui.h:5
-msgid "3 minutes"
-msgstr "3 minutos"
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:7
-msgid "30 seconds"
-msgstr "30 segundos"
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:9
-msgid "Brightness"
-msgstr "Brillu"
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
 
-#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
-#: ../panels/screen/screen.ui.h:11
-msgid "Don't lock when at home"
-msgstr "Nun bloquiar cuando tea en casa"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Otru"
 
-#: ../panels/screen/screen.ui.h:12
-msgid "Locations..."
-msgstr "Llocalizaciones…"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Allugamientu"
 
-#: ../panels/screen/screen.ui.h:13
-msgid "Lock"
-msgstr "Bloquiar"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Aplicaciones"
 
-#: ../panels/screen/screen.ui.h:14
-msgid "Screen turns off"
-msgstr "que la pantalla s'apague"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:15
-msgid "_Dim screen to save power"
-msgstr "_Escurecer la pantalla p'aforrar enerxía"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:16
-msgid "_Lock screen after:"
-msgstr "B_loquiar pantalla dempués de:"
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Gu_etar por direición"
 
-#: ../panels/screen/screen.ui.h:17
-msgid "_Turn screen off when inactive for:"
-msgstr "S_uspender cuando tea inactivu por:"
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
-#: ../panels/sound/applet-main.c:49
-msgid "Enable debugging code"
-msgstr "Activar códigu de depuración"
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
 
-#: ../panels/sound/applet-main.c:50
-msgid "Version of this application"
-msgstr "Versión d'esta aplicación"
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
 
-#: ../panels/sound/applet-main.c:62
-msgid " — GNOME Volume Control Applet"
-msgstr " — Miniaplicación de control de volume de GNOME"
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Rede"
 
-#: ../panels/sound/gvc-applet.c:270
-#: ../panels/sound/gvc-mixer-dialog.c:1767
-msgid "Output"
-msgstr "Salida"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+#, fuzzy
+msgid "Sharing"
+msgstr "Audición"
 
-#: ../panels/sound/gvc-applet.c:272
-msgid "Sound Output Volume"
-msgstr "Volume de la salida de soníu"
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
 
-#: ../panels/sound/gvc-applet.c:276
-#: ../panels/sound/gvc-mixer-dialog.c:1807
-msgid "Input"
-msgstr "Entrada"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Audición"
 
-#: ../panels/sound/gvc-applet.c:278
-msgid "Microphone Volume"
-msgstr "Volume del micrófonu"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Escritoriu"
 
-#: ../panels/sound/gvc-balance-bar.c:111
-msgctxt "balance"
-msgid "Left"
-msgstr "Esquierda"
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:112
-msgctxt "balance"
-msgid "Right"
-msgstr "Derecha"
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Aniciu automáticu de sesión"
 
-#: ../panels/sound/gvc-balance-bar.c:115
-msgctxt "balance"
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Audición"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "C_ontraseña"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+#, fuzzy
+msgid "Remote Login"
+msgstr "Desaniciar perfil"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Escritoriu"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Control de volume"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Non coneutáu"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Autenticar"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Nome d'usuariu:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Rexistrando buelgues dixitales"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "Soportes y autoexecución"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+#, fuzzy
+msgid "Enable or disable remote login"
+msgstr "Activar desplazamientu _horizontal"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+#, fuzzy
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Ye necesario autentificase pa instalar configuraciones multi-monitor pa "
+"tolos usuarios"
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Audición"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Balance:"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Esvanecimientu:"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Traseru"
 
-#: ../panels/sound/gvc-balance-bar.c:116
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Frontal"
 
-#: ../panels/sound/gvc-balance-bar.c:119
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Mínimu"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:120
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Máximu"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Sones del Sistema"
 
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Balance:"
-msgstr "_Balance:"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Volume d'a_lerta"
 
-#: ../panels/sound/gvc-balance-bar.c:298
-msgid "_Fade:"
-msgstr "_Esvanecimientu:"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Silenciar"
 
-#: ../panels/sound/gvc-balance-bar.c:301
-msgid "_Subwoofer:"
-msgstr "_Subwoofer:"
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Salida"
 
-#: ../panels/sound/gvc-channel-bar.c:603
-#: ../panels/sound/gvc-channel-bar.c:612
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Volume de _salida"
 
-#: ../panels/sound/gvc-channel-bar.c:607
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Ensin amplificar"
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Prebar"
 
-#: ../panels/sound/gvc-combo-box.c:167
-#: ../panels/sound/gvc-mixer-dialog.c:1621
-msgid "_Profile:"
-msgstr "_Perfil:"
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "URL de _configuración"
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1093
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Entrada"
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Nivel d'entrada:"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Xubir volume"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Botones d'Avisu"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Silenciar"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Soníu"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Camudar el volume del soníu y los eventos de soníu"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"tarxeta;micrófonu;volume;esvanecer;balance;altavoz;bluetooth;cascos;"
+"auriculares;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, fuzzy, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Desaniciar preséu"
+msgstr[1] "Desaniciar preséu"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Magnificador"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nome:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Preséu"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Accesu universal"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Obteniendo dispositivos…"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Parpaguéu del cursor"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "El cursor pa_rpaguea nos campos de testu"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocidá"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Velocidá de parpaguéu del cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Velocidá de parpaguéu del cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Pulsación secundaria simulada"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Disparar una pulsación secundaria al caltener primíu'l botón primariu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "R_etardu d'aceutación:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curtiu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Retardu pulsación secundaria"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Llargu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "Pulsación al pasar per encima"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Aniciar una pulsación al posicionar el punteru"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "A_llanciu:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curtiu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Llargu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Umbral de _movimientu:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Pequeñu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetir tecles"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr ""
+"Les pulsaciones de tecles _repítense cuando la tecla se caltién calcada"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Velocidá de repetición de les tecles"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocidá de repetición de les tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Asistente de tecleáu"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Tecles pegañoses"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Trata una secuencia de tecles modificadores como una combinación de tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desactivar si se calquen dos tecles al empar"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pitar al calcar un _modificador"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Tecles lentes"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introduz un allanciu al calcar una tecla y cuando esta s'aceuta"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curtiu"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Retardu de les tecles lentes al escribir"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Llargu"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Pitar al cal_car una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Pitar cuando la tecla s'_aceute"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Pitar al _refugar una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Tecles de rebote"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Inorar pulsaciones duplicaes rápides"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curtiu"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Retrasu de pulsación del refugu de tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Llargu"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Ac_tivar les carauterístiques d'accesibilidá dende'l tecláu"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Acesibilidá _Tecláu"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Visión"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "_Contraste:"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Grande"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Llector de pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Tecles de rebote"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Pitar cuando s'activen o desactiven les característiques d'_accesibilidá"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Velocidá de parpaguéu del cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audición"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Alertes visuales"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Tecláu en pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Repetir tecles"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Parpaguéu del cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
+msgstr "Asistente de tecleáu"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Apuntar y calcar"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Tecles del Mur"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Llocalizar el punteru"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "Retardu del duble clic"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "Retardu del duble clic"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alertes visuales"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Probar destellos"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+#, fuzzy
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Usar una indicación visual cuando heba una alerta de soníu"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Destellu de la pantalla completa"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Destellu de la pantalla completa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Pantalla completa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Metada superior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Metada inferior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Metada esquierda"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Metada Derecha"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Opciones de zoom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "Magnificador"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "Ampliación del magnificador"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Usuarios permitíos"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Llector de pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "Ampliación del magnificador"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "Cruces"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
+msgstr "Grosor"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+#, fuzzy
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Finu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+#, fuzzy
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Gruesu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
+msgstr "Llonxitú"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Cruces"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "Efeutos de soníu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Brillu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contraste:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Dengún"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "C_ompletu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Baxu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Altu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Baxu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Altu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "Efeutos de soníu"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Tecláu;Mur;a11y;Accesibilidá;Contraste;Zoom;Llector de pantalla;testu;fonte;"
+"tamañu;AccessX;Tecles persistentes;Tecles lentes;Refugu de tecles;Tecles del "
+"mur"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Sistema de Ficheros"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Desaniciar ficheros"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "Mover a la papelera"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "Alministrador"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Escoyer una contraseña nel siguiente aniciu de sesión"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Afitar agora una contraseña"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "_Configurar..."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Empresa"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Ensin conexón"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Esbilla una llingua"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Aniciu de sesión con _buelga"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Aniciu de sesión con _buelga"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Non"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"¿Quies desaniciar les tos buelgues rexistraes y asina desactivar l'entamu de "
+"sesión con buelga?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Aniciu de sesión con _buelga"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Aniciu de sesión con _buelga"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Aniciu de sesión con _buelga"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "_Esbillar un preséu pa configurar:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Aniciu de sesión con _buelga"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Desaniciar buelgues"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Aniciu de sesión con _buelga"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Pista anterior"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Camudar la Contraseña"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Cam_biar"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Contraseña _actual"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Contraseña _nueva"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "C_onfirmar contraseña"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Les contraseñes nun concasen"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "Escoyer una contraseña nel siguiente aniciu de sesión"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Afitar agora una contraseña"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Users"
+msgstr "Nome d'usuariu/a"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Nome _completu"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Aniciu de sesión con _buelga"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Aniciu automáticu de sesión"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "_Triba de cuenta"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Alministrador"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Controles"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Abrir cola aplicación predeterminada"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Quitar fondu"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Otru deu:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+#, fuzzy
+msgid "Add or remove users and change your password"
+msgstr "Amestar o quitar usuarios"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+#, fuzzy
+msgid "Domain Administrator Login"
+msgstr "Alministrador"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+#, fuzzy
+msgid "Administrator _Name"
+msgstr "Alministrador"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+#, fuzzy
+msgid "Administrator Password"
+msgstr "Alministrador"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+#, fuzzy
+msgid "Manage user accounts"
+msgstr "Xestionar cuentes en llinia"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+#, fuzzy
+msgid "Authentication is required to change user data"
+msgstr "Necesítase autenticación"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Botón superior"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Pa editar un atayu nuevu calca na filera y caltén primíes les tecles nueves, "
+"o calca Retrocesu pa desaniciar."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "Crear un preséu virtual"
+
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tableta (completa)"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Orientación pa maniegos:"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Calibrar…"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Tableta non deteutada"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Enchufa o prende la to tableta Wacom"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensibilidá de presión del llápiz"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Blandu"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Botón superior"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botón superior"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botón superior"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilidá de presión de borrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Sensibilidá de presión de borrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Pulsación del botón central del mur"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Pulsación del botón derechu del mur"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Alantre"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tableta Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Llápiz;Borrador;Mur;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Disposición"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Ventana raíz"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Pulsación secundaria simulada"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Ventanes"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Tóner baxo"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Retardu pulsación secundaria"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Ventanes"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Lo_gin accesible"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "_Amestar"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Detalles"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_Hora de rede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Configuración de la rede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Númberos"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Tribes de dispositivos"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+#, fuzzy
+msgid "Manufacturer"
+msgstr "Fabricante:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "falta'l «firmware»"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Móvil:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_Hora de rede"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Rede"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Encaboxáu"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Bloquiar"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Detalles"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Nome de rede"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Automáticu"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Rede"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Nun s'atoparon adautadores de Bluetooth"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Mou a_vión"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Conexón"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Bloquiar"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Cam_biar"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Rede"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "_Toles configuraciones"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Ayuda"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Xeneral"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Guetar"
+
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Iconu de panel"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Encaboxáu"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "Preferencies"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u salida"
 msgstr[1] "%u salides"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1103
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u entrada"
 msgstr[1] "%u entraes"
 
-#: ../panels/sound/gvc-mixer-control.c:1401
-msgid "System Sounds"
-msgstr "Sones del Sistema"
+#~ msgid "Change the background"
+#~ msgstr "Cambia'l fondu"
 
-#: ../panels/sound/gvc-mixer-dialog.c:323
-#: ../panels/sound/gvc-mixer-dialog.c:634
-msgid "Co_nnector:"
-msgstr "Co_neutor:"
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Fondu d'escritoriu;Pantalla;Escritoriu;"
 
-#: ../panels/sound/gvc-mixer-dialog.c:540
-msgid "Peak detect"
-msgstr "Deteutar picos"
+#~ msgid "Add wallpaper"
+#~ msgstr "Amestar fondu d'escritoriu"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1496
-#: ../panels/sound/gvc-mixer-dialog.c:1709
-#: ../panels/sound/gvc-sound-theme-chooser.c:596
-msgid "Name"
-msgstr "Nome"
+#~ msgid "Center"
+#~ msgstr "Centru"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1563
+#~ msgid "Changes throughout the day"
+#~ msgstr "Camuda a lo llargo'l día"
+
+#~ msgid "Fill"
+#~ msgstr "Rellenu"
+
+#~ msgid "Span"
+#~ msgstr "Espander"
+
+#~ msgid "Tile"
+#~ msgstr "Mosaicu"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Dilíu Horizontal"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Dilíu Vertical"
+
+#~ msgid "Solid Color"
+#~ msgstr "Color Sólido"
+
+#~ msgid "Current background"
+#~ msgstr "Fondu actual"
+
+#~ msgid "Pictures Folder"
+#~ msgstr "Carpeta d'imáxenes"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "Colores y dilíos"
+
+#~ msgid "multiple sizes"
+#~ msgstr "tamaños múltiples"
+
 #, c-format
-msgid "Speaker Testing for %s"
-msgstr "Comprobación d'altavoces pa %s"
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1622
-msgid "_Test Speakers"
-msgstr "_Probar los altavoces"
+#~ msgid "No Desktop Background"
+#~ msgstr "Ensin fondu d'escritoriu"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1753
-msgid "_Output volume:"
-msgstr "Volume de _salida"
+#~ msgid "Yes"
+#~ msgstr "Sí"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1772
-msgid "C_hoose a device for sound output:"
-msgstr "_Esbillar un preséu pa la salida de soníu"
+#~ msgid "Visibility"
+#~ msgstr "Visibilidá"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-#: ../panels/sound/gvc-mixer-dialog.c:1925
-msgid "Settings for the selected device:"
-msgstr "Axustes pal preséu seleicionáu:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1814
-msgid "_Input volume:"
-msgstr "Volume d'e_ntrada"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1837
-msgid "Input level:"
-msgstr "Nivel d'entrada:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1865
-msgid "C_hoose a device for sound input:"
-msgstr "_Esbillar un preséu pa la entrada de soníu"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1892
-msgid "Hardware"
-msgstr "Hardware"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1897
-msgid "C_hoose a device to configure:"
-msgstr "_Esbillar un preséu pa configurar:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1936
-msgid "Sound Effects"
-msgstr "Efeutos de soníu"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1943
-msgid "_Alert volume:"
-msgstr "Volume d'a_lerta"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1956
-msgid "Applications"
-msgstr "Aplicaciones"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1960
-msgid "No application is currently playing or recording audio."
-msgstr "Denguna aplicación ta reproduciendo o grabando soníu anguaño."
-
-#: ../panels/sound/gvc-speaker-test.c:221
-msgid "Stop"
-msgstr "Detener"
-
-#: ../panels/sound/gvc-speaker-test.c:221
-#: ../panels/sound/gvc-speaker-test.c:333
-msgid "Test"
-msgstr "Prebar"
-
-#: ../panels/sound/gvc-speaker-test.c:229
-msgid "Subwoofer"
-msgstr "Subwoofer"
-
-#: ../panels/sound/gvc-stream-status-icon.c:235
 #, c-format
-msgid "Failed to start Sound Preferences: %s"
-msgstr "Falló al aniciar les Preferencies de Soníu: %s"
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Visibilidá de “%s”"
 
-#: ../panels/sound/gvc-stream-status-icon.c:261
-msgid "_Mute"
-msgstr "_Silenciar"
-
-#: ../panels/sound/gvc-stream-status-icon.c:270
-msgid "_Sound Preferences"
-msgstr "_Preferencies de Soníu"
-
-#: ../panels/sound/gvc-stream-status-icon.c:415
-msgid "Muted"
-msgstr "Silenciáu"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:190
-msgid "Built-in"
-msgstr "Built-in"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:456
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Sound Preferences"
-msgstr "Preferencies de Soníu"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:459
-#: ../panels/sound/gvc-sound-theme-chooser.c:470
-#: ../panels/sound/gvc-sound-theme-chooser.c:482
-msgid "Testing event sound"
-msgstr "Comprobando'l soníu d'eventu"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:587
-msgid "From theme"
-msgstr "Del tema"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:782
-msgid "C_hoose an alert sound:"
-msgstr "_Esbillar un soníu d'alerta:"
-
-#: ../panels/sound/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr "Personalizáu"
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
-msgid "Show desktop volume control"
-msgstr "Amosar el control de volume de l'escritoriu"
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
-msgid "Volume Control"
-msgstr "Control de volume"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
-msgstr "tarxeta;micrófonu;volume;esvanecer;balance;altavoz;bluetooth;cascos;auriculares;"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
-msgid "Change sound volume and sound events"
-msgstr "Camudar el volume del soníu y los eventos de soníu"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Sound"
-msgstr "Soníu"
-
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "Lladríu"
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "Gotiar"
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "Cristal"
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "Sónar"
-
-#: ../panels/universal-access/cc-ua-panel.c:505
-#: ../panels/universal-access/cc-ua-panel.c:510
-msgid "No shortcut set"
-msgstr "Nun esiste dengún atayu configuráu"
-
-#: ../panels/universal-access/gconf-property-editor.c:134
-msgid "Key"
-msgstr "Clave"
-
-#: ../panels/universal-access/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr "Clave de gconf a la que ta asociáu esti editor de propiedaes"
-
-#: ../panels/universal-access/gconf-property-editor.c:141
-msgid "Callback"
-msgstr "Retornu de llamada"
-
-#: ../panels/universal-access/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Emitir este retornu de llamada cuando camude'l valor asociáu cola clave"
-
-#: ../panels/universal-access/gconf-property-editor.c:147
-msgid "Change set"
-msgstr "Conxuntu de cambeos"
-
-#: ../panels/universal-access/gconf-property-editor.c:148
-msgid "GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr "Conxuntu de cambeos de gconf que contién datos que deben remitise al veceru de gconf cuando s'apliquen"
-
-#: ../panels/universal-access/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr "Conversión a retornu de llamada del widget"
-
-#: ../panels/universal-access/gconf-property-editor.c:154
-msgid "Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "Retornu de llamada qu'hai d'emitir cuando se vayan a convertir datos de gconf al widget"
-
-#: ../panels/universal-access/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr "Conversión dende'l retornu de llamada del widget"
-
-#: ../panels/universal-access/gconf-property-editor.c:160
-msgid "Callback to be issued when data are to be converted to GConf from the widget"
-msgstr "Retornu de llamada que tien d'emitise cuando vayan a convertise datos del widget a gconf"
-
-#: ../panels/universal-access/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "Control UI"
-
-#: ../panels/universal-access/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr "Oxetu que remana la propiedá (xeneralmente, un widget)"
-
-#: ../panels/universal-access/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr "Datos d'oxetu del editor de propiedaes"
-
-#: ../panels/universal-access/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr "Datos personalizaos requeríos pol editor de propiedaes específicu"
-
-#: ../panels/universal-access/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr "Retornu de llamada de lliberación de datos del editor de propiedaes"
-
-#: ../panels/universal-access/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr "Retornu de llamada que tien d'emitise cuando vayan a lliberase datos d'oxetu del editor de propiedaes"
-
-#: ../panels/universal-access/gconf-property-editor.c:1474
 #, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background picture."
-msgstr ""
-"Nun pudo alcontrase'l ficheru «%s».\n"
-"\n"
-"Compruebe si esiste y torne a tentalo o escueya una imaxe de fondu distinta."
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Desaniciar '%s' de la llista de preseos?"
 
-#: ../panels/universal-access/gconf-property-editor.c:1482
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Si quites el preséu, tendrás de configuralu otra vegada enantes d'usalu "
+#~ "nuevamente"
+
+#~ msgid "Browse Files..."
+#~ msgstr "Restolar por ficheros…"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Axustes del tecláu"
+
+#~ msgid "Mouse and Touchpad Settings"
+#~ msgstr "Axustes del Mur y «touchpad»"
+
+#~ msgid "Paired"
+#~ msgstr "Emparexáu"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Send Files..."
+#~ msgstr "Unviar ficheros..."
+
+#~ msgid "English"
+#~ msgstr "Inglés"
+
+#~ msgid "British English"
+#~ msgstr "Inglés Británicu"
+
+#~ msgid "German"
+#~ msgstr "Alemán"
+
+#~ msgid "French"
+#~ msgstr "Francés"
+
+#~ msgid "Spanish"
+#~ msgstr "Español"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chinu (Simplificáu)"
+
+#~ msgid "United States"
+#~ msgstr "Estaos Xuníos"
+
+#~ msgid "Germany"
+#~ msgstr "Alemaña"
+
+#~ msgid "France"
+#~ msgstr "Francia"
+
+#~ msgid "Spain"
+#~ msgstr "Spain"
+
+#~ msgid "China"
+#~ msgstr "China"
+
+#~ msgid "Other..."
+#~ msgstr "Otru..."
+
+#~ msgid "Select a region"
+#~ msgstr "Esbilla una rexón"
+
+#~ msgid "Unspecified"
+#~ msgstr "Ensin especificar"
+
+#~ msgid "24-hour"
+#~ msgstr "24 hores"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Axustar la hora una hora p'alantre."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Axustar la hora una hora p'atrás."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Axustar la hora un minutu p'alantre."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Axustar la hora un minutu p'atrás."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Alternar entre AM y PM"
+
+#~ msgid "_City:"
+#~ msgstr "_Ciudá:"
+
+#~ msgid "_Region:"
+#~ msgstr "_Rexón:"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Panel de preferencies de la data y hora"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Nota: puedes llendar les opciones de resolución"
+
+#~ msgid "R_otation:"
+#~ msgstr "R_otación:"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "_Deteutar pantalles"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Espeyar pantalles"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "Antihorariu"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Horariu"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 graos"
+
 #, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Nun ye dable abrir el ficheru «%s».\n"
-"Pue que se trate d'un tipu d'imaxe qu'entá nun s'almite.\n"
-"\n"
-"Seleicione una imaxe distinta."
+#~ msgid "%d x %d (%s)"
+#~ msgstr "%d x %d (%s)"
 
-#: ../panels/universal-access/gconf-property-editor.c:1604
-msgid "Please select an image."
-msgstr "Por favor seleicione una imaxe."
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
 
-#: ../panels/universal-access/zoom-options.c:156
-msgid "1/4 Screen"
-msgstr "1/4 Pantalla"
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Esbillar un monitor pa cambiar les sos propiedaes; arrastralu reubícalu."
 
-#: ../panels/universal-access/zoom-options.c:157
-msgid "1/2 Screen"
-msgstr "1/2 Pantalla"
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
 
-#: ../panels/universal-access/zoom-options.c:158
-msgid "3/4 Screen"
-msgstr "3/4 Pantalla"
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %H:%M"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys"
-msgstr "Tecláu;Mur;a11y;Accesibilidá;Contraste;Zoom;Llector de pantalla;testu;fonte;tamañu;AccessX;Tecles persistentes;Tecles lentes;Refugu de tecles;Tecles del mur"
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Nun pudo guardase la configuración del monitor"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
-msgid "Universal Access Preferences"
-msgstr "Preferencies d'accesu universal"
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr ""
+#~ "Nun pudo algamase el bus de sesión al aplicar la configuración de pantalla"
 
-#: ../panels/universal-access/uap.ui.h:2
+#~ msgid "Could not detect displays"
+#~ msgstr "Nun pudieron detectase pantalles"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Nun pudo algamase información de pantalla"
+
+#, c-format
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown"
+#~ msgstr "Desconocíu"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-bit"
+
+#~ msgid "Unknown model"
+#~ msgstr "Modelu desconocíu"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr ""
+#~ "El siguiente arranque de sesión intentará usar la decoración estándar."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "El siguiente arranque de sesión usará el mou alternativu, pensáu pa "
+#~ "hardware de gráficos non soportáu."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Reserva"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "Estándar"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Entrugar qué facer"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nun facer nada"
+
+#~ msgid "Open folder"
+#~ msgstr "Abrir carpeta"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Escoyer una aplicación pa CD de soníu"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Escoyer una aplicación pa DVD de videu"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Escoyer una aplicación pa executar cuando se coneuta un reproductor de "
+#~ "música"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Esbillar una aplicación qu'executar cuando se coneuta una cámara"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Esbillar una aplicación pa CD de software"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD de soníu"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "discu Blu-ray virxe"
+
+#~ msgid "blank CD disc"
+#~ msgstr "discu CD virxe"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "DVD virxe"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "discu HD DVD virxe"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Discu Blu-ray de videu"
+
+#~ msgid "e-book reader"
+#~ msgstr "llector de llibros electrónicos"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Discu HD DVD de videu"
+
+#~ msgid "Picture CD"
+#~ msgstr "Discu d'imáxenes Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "CD de Super Videu"
+
+#~ msgid "Video CD"
+#~ msgstr "CD de videu"
+
+#~ msgid "Overview"
+#~ msgstr "Vista xeneral"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Anovar el sistema"
+
+#~ msgid "Checking for Updates"
+#~ msgstr "Comprobando anovamientos"
+
+#~ msgid "System Info"
+#~ msgstr "Información del sistema"
+
+#~ msgid "Acti_on:"
+#~ msgstr "Aici_ón:"
+
+#~ msgid "Disk"
+#~ msgstr "Discu"
+
+#~ msgid "Experience"
+#~ msgstr "Esperiencia"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "_Forzar mou alternativu"
+
+#~ msgid "OS type"
+#~ msgstr "Triba de SO"
+
+#~ msgid "_Photos:"
+#~ msgstr "_Semeyes:"
+
+#~ msgid "Magnifier zoom out"
+#~ msgstr "Reducción del magnificador"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "Cambiar contraste"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "Conmutar l'ampliador"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "Conmutar el llector de pantalla"
+
+#~ msgid "New shortcut..."
+#~ msgstr "Combinación nueva..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Tecla Aceleradora"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Modificadores del Acelerador"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Códigu de tecla de la combinación"
+
+#~ msgid "Accel Mode"
+#~ msgstr "Mou de la combinación"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "El tipu d'acelerador."
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "Camudar la configuración del tecláu"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Atayu;Repetir;Parpaguiar;"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Aición desconocida>"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "Error al guardar l'atayu nuevu"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Nun pue usase la combinación de tecles «%s» porque fadríase enforma "
+#~ "abegoso escribir usando esta tecla.\n"
+#~ "Por favor, téntelo con una tecla como Control, Alt o Mayús. al mesmu "
+#~ "tiempu."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "La combinación «%s» yá ta usándose pa\n"
+#~ "«%s»"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Si reasigna la combinación a «%s» desactivaráse la combinación «%s»."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Reasignar"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Demasiaos atayos personalizaos"
+
+#~ msgid "Action"
+#~ msgstr "Aición"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Combinación personalizada"
+
+#~ msgid "Fast"
+#~ msgstr "Rápidu"
+
+#~ msgid "Layout Settings"
+#~ msgstr "Configuración del formatu"
+
+#~ msgid "S_peed:"
+#~ msgstr "Veloci_dá:"
+
+#~ msgid "Slow"
+#~ msgstr "Lentu"
+
+#~ msgid "_Speed:"
+#~ msgstr "_Velocidá:"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Fallua al arrancar la sesión na cuenta"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "Les credenciales gandieron. Arranca sesión otra vuelta."
+
+#~ msgid "_Log In"
+#~ msgstr "_Arrancar sesión"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "P'amestar una cuenta nueva, escueyi primero la triba de cuenta"
+
+#~ msgid "Account Type:"
+#~ msgstr "Triba de cuenta:"
+
+#~ msgid "_Add..."
+#~ msgstr "_Amestar..."
+
+#~ msgid "Error creating account"
+#~ msgstr "Fallu al criar la cuenta"
+
+#~ msgid "Error removing account"
+#~ msgstr "Fallu al desaniciar la cuenta"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "¿Tas seguru de que quies desaniciar la cuenta?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Esto nun desanicia la cuenta nel sirvidor"
+
+#~ msgid "Select an account"
+#~ msgstr "Escueyi una cuenta"
+
+#~ msgid "Out of toner"
+#~ msgstr "Ensin tóner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Nivel de revelador baxo"
+
+#~ msgid "Out of developer"
+#~ msgstr "Ensin revelador"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Marcador baxo"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Ensin marcador"
+
+#~ msgid "Open cover"
+#~ msgstr "Abrir cubierta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Nivel de papel baxo"
+
+#~ msgid "Out of paper"
+#~ msgstr "Ensin papel"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "Posáu"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Recipiente de residuos casi enllenu"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Receptáculu de residuos enllenu"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "El conductor ópticu ta cerca del final de la so vida"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "El conductor ópticu yá nun funciona"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Sollerte"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Procesando"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Paráu"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nivel de tóner"
+
+#~ msgid "Supply Level"
+#~ msgstr "Nivel del suministru"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "N'espera"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Reteníu"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Procesando"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Paráu"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Torgáu"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Completáu"
+
+#~ msgid "Job Title"
+#~ msgstr "Títulu del Trabayu"
+
+#~ msgid "Job State"
+#~ msgstr "Estáu del trabayu"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Falló al amestar una imprentadora nueva."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Nun se pudo cargar la IU: %s"
+
+#~ msgid "A_ddress:"
+#~ msgstr "D_ireicion/es:"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Amestar una imprentadora nueva"
+
+#~ msgid "No network printers found"
+#~ msgstr "Nun s'atoparon imprentadores de rede"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD nun ta n'execución. La deteición d'imprentadores de rede "
+#~ "necesita que los servicios  mdns, ipp, ipp-client y samba-client tean "
+#~ "activaos nel tornafueos."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "Llocal"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "Rede"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "Abrir el tornafueos pa conexones mDNS"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Abrir el tornafueos pa conexones Samba"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "Abrir el tornafueos pa conexones IPP"
+
+#~ msgid "Jobs"
+#~ msgstr "Trabayos"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Impren_tar páxina de preba"
+
+#~ msgid "_Back"
+#~ msgstr "_Atrás"
+
+#~ msgid "_Default"
+#~ msgstr "_Predetermináu"
+
+#~ msgid "_Show"
+#~ msgstr "_Amosar"
+
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Escueyi una distribución"
+
+#~ msgid "Keyboard Layout Options"
+#~ msgstr "Opciones de distribución del tecláu"
+
+#~ msgid "Allow different layouts for individual windows"
+#~ msgstr "Permitir diferentes distribuciones pa cada ventana"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "Copiar configuración..."
+
+#~ msgid "Currency"
+#~ msgstr "Divises"
+
+#~ msgid "Display language:"
+#~ msgstr "Amosar llingua:"
+
+#~ msgid "Examples"
+#~ msgstr "Exemplos"
+
+#~ msgid "Language"
+#~ msgstr "Llinguax"
+
+#~ msgid "Layouts"
+#~ msgstr "Distribuciones"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "Les ventanes nueves usen la distribución predeterminada"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "Les ventanes nueves usen la distribución de la ventana activa"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Trocar la configuración actual de tecláu pola\n"
+#~ "configuración por defeutu"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "Restablecer valores _predeterminaos"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Esbilla una llingua p'amosar (el cambéu va aplicase la próxima vegada "
+#~ "qu'anicies sesión)"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr ""
+#~ "Esbilla una rexón (el cambéu va aplicase la próxima vegada qu'anicies "
+#~ "sesión)"
+
+#~ msgid "System settings"
+#~ msgstr "Axustes del sistema"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "La pantalla d'aniciu de sesión, les cuentes de sistema y les nueves "
+#~ "cuentes d'usuariu usen los axustes de rexón y llingua. Pues camudar los "
+#~ "axustes del sistema pa que correspuendan a les tuyes."
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "Ver y editar les opciones de distribución de tecláu"
+
+#~ msgid "_Options..."
+#~ msgstr "_Opciones..."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "La pantalla d'aniciu de sesión, les cuentes de sistema y les nueves "
+#~ "cuentes d'usuariu usen los axustes de rexón y llingua."
+
+#~ msgid "A_cceleration:"
+#~ msgstr "A_celeración:"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Retardu del duble clic"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "Umbral d'arrastre"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "Arrastrar y llantar"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "Activar pul_saciones del mur col touchpad"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Preferencies del Mur"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Amosar la posición del punteru al calcar la tecla Control"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "_Umbral:"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr ""
+#~ "Pa probar la configuración prueba a calcar dos vegaes sobre la cara."
+
+#~ msgid "Two-_finger scrolling"
+#~ msgstr "_Desplazamientu con dos deos"
+
+#~ msgid "_Disabled"
+#~ msgstr "_Desactiváu"
+
+#~ msgid "_Edge scrolling"
+#~ msgstr "_Berbesu de desplazamientu"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Maniegu"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_Diestru"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Sensibilidá:"
+
+#~ msgid "_Timeout:"
+#~ msgstr "_Tiempu d'espera:"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Configura les preferencies de mur y touchpad"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Úsase'l autodescubrimientu del proxy web cuando nun s'apurre un URL de "
+#~ "configuración."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Nun s'encamienta l'usu pa redes públiques nes que nun se confía."
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "Otru ..."
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "VPN «%s»"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "Network proxy"
+#~ msgstr "Proxy de rede"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr ""
+#~ "Los servicios de rede del sistema nun son compatibles con esta versión."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "¿Crear el «hotspot» de toes formes?"
+
+#, c-format
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "¿Desconeutase de %s y crear un «hotspot» nuevu?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "Esta ye la única conexón a Internet."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "Crear «_hotspot»"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "¿Detener el «hotspot» y desconeutar a los usuarios?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Detener «hotspot»"
+
+#~ msgid "Network;Wireless;IP;LAN;"
+#~ msgstr "rede;inalámbrica;ip;lan;"
+
+#~ msgid "Create..."
+#~ msgstr "Crear…"
+
+#~ msgid "Group Name"
+#~ msgstr "Nome de grupu"
+
+#~ msgid "Interface"
+#~ msgstr "Interface"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Esbillar la interfaz qu'usar pal serviciu nuevu"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "Mázcara de subrede"
+
+#~ msgid "VPN Type"
+#~ msgstr "Tipu de VPN"
+
+#~ msgid "_Network Name"
+#~ msgstr "_Nome de rede"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "_Detener «hotspot»…"
+
+#~ msgid "_Use as Hotspot..."
+#~ msgstr "_Usar como «hotspot»…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Dengún"
+
+#~ msgid "Wireless"
+#~ msgstr "Inalámbrica"
+
+#~ msgid "Mobile broadband"
+#~ msgstr "Banda ancha móvil"
+
+#~ msgid "Mesh"
+#~ msgstr "Malla"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infraestructura"
+
+#~ msgid "Status unknown"
+#~ msgstr "Estáu desconocíu"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Non xestionada"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cable desconeutáu"
+
+#~ msgid "Unavailable"
+#~ msgstr "Non disponible"
+
+#~ msgid "Disconnected"
+#~ msgstr "Desconectáu"
+
+#~ msgid "Connecting"
+#~ msgstr "Coneutando"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Desconeutando"
+
+#~ msgid "Connection failed"
+#~ msgstr "Falló la conexón"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Estáu desconocíu (ausente)"
+
+#~ msgid "Power management settings"
+#~ msgstr "Axustes de Xestión d'enerxía"
+
+#~ msgid "Unknown time"
+#~ msgstr "Tiempu desconocíu"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#~ msgid "Battery discharging"
+#~ msgstr "La batería ta descargándose"
+
+#~ msgid "UPS charging"
+#~ msgstr "SAI cargándose"
+
+#~ msgid "UPS discharging"
+#~ msgstr "SAI descargándose"
+
+#, c-format
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s hasta cargase (%.0lf%%)"
+
+#, c-format
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s hasta descargase (%.0lf%%)"
+
+#, c-format
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% cargáu"
+
+#~ msgid "Don't suspend"
+#~ msgstr "Non suspender"
+
+#~ msgid "Hibernate"
+#~ msgstr "Ivernar"
+
+#~ msgid "Suspend when inactive for:"
+#~ msgstr "Suspender cuando tea inactivu por:"
+
+#~ msgid "When power is _critically low:"
+#~ msgstr "_Cuando la carga tea críticamente baxa:"
+
+#~ msgid "Color management settings"
+#~ msgstr "Axustes de xestión de color"
+
+#~ msgid "Other profile…"
+#~ msgstr "Otru perfil…"
+
+#~ msgid "Default: "
+#~ msgstr "Predetermináu:"
+
+#~ msgid "Test profile: "
+#~ msgstr "Perfil de color:"
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Esbillar ficheru de perfil ICC"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Perfiles disponibles pa pantalles"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Perfiles disponibles pa escáneres"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Perfiles disponibles pa imprentadores"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Perfiles disponibles pa cámares"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Perfiles disponibles pa webcams"
+
+#~ msgid "Available Profiles"
+#~ msgstr "Perfiles disponibles"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Crear un perfil de color pal preséu esbilláu"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Nun se deteutó l'instrumentu de midida. Comprueba que tea encesu y "
+#~ "correutamente coneutáu."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "L'instrumentu de midida nun sofita perfiláu d'imprentadores."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "El tipu de preséu nun ta sofitáu anguaño."
+
+#~ msgid "Cannot remove automatically added profile"
+#~ msgstr "Nun pue desaniciase automáticamente'l perfil amestáu"
+
+#, c-format
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i añu"
+#~ msgstr[1] "%i años"
+
+#, c-format
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i mes"
+#~ msgstr[1] "%i meses"
+
+#, c-format
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i selmana"
+#~ msgstr[1] "%i selmanes"
+
+#, c-format
+#~ msgid "Less than 1 week"
+#~ msgstr "Menos d'una selmana"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB predetermináu"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK predetermináu"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Buxu predetermináu"
+
+#~ msgid "Uncalibrated"
+#~ msgstr "Ensin calibrar"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "Esti preséu nun tien xestión de color."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "Esti preséu ta usando los datos de calibración de fabricación."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "Esti preséu nun tien un perfil aptu pa correición de color en tola "
+#~ "pantalla."
+
+#~ msgid "This device has an old profile that may no longer be accurate."
+#~ msgstr "Esti preséu tien un perfil antiguu que pue nun ser precisu."
+
+#~ msgid "Not specified"
+#~ msgstr "Ensin especificar"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "Nun hai preseos deteutaos que sofiten la xestión de color"
+
+#~ msgctxt "Device kind"
+#~ msgid "Scanner"
+#~ msgstr "Escáner"
+
+#~ msgctxt "Device kind"
+#~ msgid "Printer"
+#~ msgstr "Imprentadora"
+
+#~ msgctxt "Device kind"
+#~ msgid "Webcam"
+#~ msgstr "Cámara web"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "Amestar un preséu virtual"
+
+#~ msgid "Add device"
+#~ msgstr "Amestar preséu"
+
+#~ msgid "Device type:"
+#~ msgstr "Triba de preséu:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Puen arrastrase ficheros d'imaxe nesta ventana p'autocompletar los campos "
+#~ "superiores."
+
+#~ msgid "Model:"
+#~ msgstr "Modelu:"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Brillu;Bloquiar;Escurecer;Illuminar;Pantalla;"
+
+#~ msgid "1 minute"
+#~ msgstr "1 minutu"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 minutos"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 segundos"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "Nun bloquiar cuando tea en casa"
+
+#~ msgid "Locations..."
+#~ msgstr "Llocalizaciones…"
+
+#~ msgid "Screen turns off"
+#~ msgstr "que la pantalla s'apague"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "_Escurecer la pantalla p'aforrar enerxía"
+
+#~ msgid "_Turn screen off when inactive for:"
+#~ msgstr "S_uspender cuando tea inactivu por:"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Activar códigu de depuración"
+
+#~ msgid "Version of this application"
+#~ msgstr "Versión d'esta aplicación"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — Miniaplicación de control de volume de GNOME"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Volume de la salida de soníu"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Mínimu"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Máximu"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Ensin amplificar"
+
+#~ msgid "Peak detect"
+#~ msgstr "Deteutar picos"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Comprobación d'altavoces pa %s"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Probar los altavoces"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Esbillar un preséu pa la salida de soníu"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Axustes pal preséu seleicionáu:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Volume d'e_ntrada"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Esbillar un preséu pa la entrada de soníu"
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgid "Stop"
+#~ msgstr "Detener"
+
+#, c-format
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "Falló al aniciar les Preferencies de Soníu: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "_Silenciar"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "_Preferencies de Soníu"
+
+#~ msgid "Muted"
+#~ msgstr "Silenciáu"
+
+#~ msgid "Built-in"
+#~ msgstr "Built-in"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferencies de Soníu"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Comprobando'l soníu d'eventu"
+
+#~ msgid "From theme"
+#~ msgstr "Del tema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Esbillar un soníu d'alerta:"
+
+#~ msgid "Custom"
+#~ msgstr "Personalizáu"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Amosar el control de volume de l'escritoriu"
+
+#~ msgid "Bark"
+#~ msgstr "Lladríu"
+
+#~ msgid "Drip"
+#~ msgstr "Gotiar"
+
+#~ msgid "Glass"
+#~ msgstr "Cristal"
+
+#~ msgid "Sonar"
+#~ msgstr "Sónar"
+
+#~ msgid "No shortcut set"
+#~ msgstr "Nun esiste dengún atayu configuráu"
+
+#~ msgid "Key"
+#~ msgstr "Clave"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Clave de gconf a la que ta asociáu esti editor de propiedaes"
+
+#~ msgid "Callback"
+#~ msgstr "Retornu de llamada"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Emitir este retornu de llamada cuando camude'l valor asociáu cola clave"
+
+#~ msgid "Change set"
+#~ msgstr "Conxuntu de cambeos"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Conxuntu de cambeos de gconf que contién datos que deben remitise al "
+#~ "veceru de gconf cuando s'apliquen"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Conversión a retornu de llamada del widget"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Retornu de llamada qu'hai d'emitir cuando se vayan a convertir datos de "
+#~ "gconf al widget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Conversión dende'l retornu de llamada del widget"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Retornu de llamada que tien d'emitise cuando vayan a convertise datos del "
+#~ "widget a gconf"
+
+#~ msgid "UI Control"
+#~ msgstr "Control UI"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Oxetu que remana la propiedá (xeneralmente, un widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Datos d'oxetu del editor de propiedaes"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Datos personalizaos requeríos pol editor de propiedaes específicu"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Retornu de llamada de lliberación de datos del editor de propiedaes"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Retornu de llamada que tien d'emitise cuando vayan a lliberase datos "
+#~ "d'oxetu del editor de propiedaes"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Nun pudo alcontrase'l ficheru «%s».\n"
+#~ "\n"
+#~ "Compruebe si esiste y torne a tentalo o escueya una imaxe de fondu "
+#~ "distinta."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Nun ye dable abrir el ficheru «%s».\n"
+#~ "Pue que se trate d'un tipu d'imaxe qu'entá nun s'almite.\n"
+#~ "\n"
+#~ "Seleicione una imaxe distinta."
+
+#~ msgid "Please select an image."
+#~ msgstr "Por favor seleicione una imaxe."
+
+#~ msgid "1/4 Screen"
+#~ msgstr "1/4 Pantalla"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 Pantalla"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 Pantalla"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Preferencies d'accesu universal"
+
 #, no-c-format
-msgid "100%"
-msgstr "100%"
+#~ msgid "100%"
+#~ msgstr "100%"
 
-#: ../panels/universal-access/uap.ui.h:4
 #, no-c-format
-msgid "125%"
-msgstr "125%"
+#~ msgid "125%"
+#~ msgstr "125%"
 
-#: ../panels/universal-access/uap.ui.h:6
 #, no-c-format
-msgid "150%"
-msgstr "150%"
-
-#: ../panels/universal-access/uap.ui.h:8
-#, no-c-format
-msgid "75%"
-msgstr "75%"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "A_cceptance delay:"
-msgstr "R_etardu d'aceutación:"
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "Acc_eptance delay:"
-msgstr "Ret_ardu d'aceutación:"
-
-#: ../panels/universal-access/uap.ui.h:11
-msgid "Beep when Caps and Num Lock are used"
-msgstr "Pitar al usar Bloq. Númb. y Bloq. Mayús."
-
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Beep when a _modifer key is pressed"
-msgstr "Pitar al calcar una tecla _modificadora"
-
-#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Beep when a key is"
-msgstr "Pitar cuando la tecla ye"
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "Beep when a key is _rejected"
-msgstr "Pitar al _refugar una tecla"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "Bounce Keys"
-msgstr "Tecles de rebote"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Bounce keys typing delay"
-msgstr "Retrasu de pulsación del refugu de tecles"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "Caribou"
-msgstr "Caribou"
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "Change contrast:"
-msgstr "Cambiar contraste:"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Closed Captioning"
-msgstr "GOP zarráu"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Control the pointer using the keypad"
-msgstr "Remanar el punteru usando'l tecláu numbéricu"
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Control the pointer using the video camera."
-msgstr "Remanar el punteru usando la cámara de videu."
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "D_elay:"
-msgstr "A_llanciu:"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Dasher"
-msgstr "Dasher"
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Decrease size:"
-msgstr "Amenorgar tamañu:"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Display a textual description of speech and sounds"
-msgstr "Amosar una descripción testual de la voz y los soníos"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Flash the entire screen"
-msgstr "Destellu de la pantalla completa"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "Flash the window title"
-msgstr "Destellu de la barra de títulu de la ventana"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "GOK"
-msgstr "GOK"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "Hearing"
-msgstr "Audición"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Hover Click"
-msgstr "Pulsación al pasar per encima"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Ignores fast duplicate keypresses"
-msgstr "Inorar pulsaciones duplicaes rápides"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Increase size:"
-msgstr "Aumentar tamañu:"
+#~ msgid "150%"
+#~ msgstr "150%"
 
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Motion _threshold:"
-msgstr "Umbral de _movimientu:"
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "Ret_ardu d'aceutación:"
 
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Mouse Keys"
-msgstr "Tecles del Mur"
+#~ msgid "Beep when Caps and Num Lock are used"
+#~ msgstr "Pitar al usar Bloq. Númb. y Bloq. Mayús."
 
-#: ../panels/universal-access/uap.ui.h:41
-msgid "Mouse Settings"
-msgstr "Configuración del mur"
+#~ msgid "Beep when a _modifer key is pressed"
+#~ msgstr "Pitar al calcar una tecla _modificadora"
 
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Nomon"
-msgstr "Nomon"
+#~ msgid "Beep when a key is"
+#~ msgstr "Pitar cuando la tecla ye"
 
-#: ../panels/universal-access/uap.ui.h:44
-msgid "On screen keyboard"
-msgstr "Tecláu en pantalla"
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
 
-#: ../panels/universal-access/uap.ui.h:45
-msgid "OnBoard"
-msgstr "EnPantalla"
+#~ msgid "Change contrast:"
+#~ msgstr "Cambiar contraste:"
 
-#: ../panels/universal-access/uap.ui.h:46
-msgid "Options..."
-msgstr "Opciones…"
+#~ msgid "Closed Captioning"
+#~ msgstr "GOP zarráu"
 
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Pointing and Clicking"
-msgstr "Apuntar y calcar"
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Remanar el punteru usando'l tecláu numbéricu"
 
-#: ../panels/universal-access/uap.ui.h:48
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "Introduz un allanciu al calcar una tecla y cuando esta s'aceuta"
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Remanar el punteru usando la cámara de videu."
 
-#: ../panels/universal-access/uap.ui.h:49
-msgid "Screen Reader"
-msgstr "Llector de pantalla"
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
 
-#: ../panels/universal-access/uap.ui.h:50
-msgid "Screen keyboard"
-msgstr "Tecláu en pantalla"
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Amosar una descripción testual de la voz y los soníos"
 
-#: ../panels/universal-access/uap.ui.h:51
-msgid "Secondary click delay"
-msgstr "Retardu pulsación secundaria"
+#~ msgid "Flash the window title"
+#~ msgstr "Destellu de la barra de títulu de la ventana"
 
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Seeing"
-msgstr "Visión"
-
-#: ../panels/universal-access/uap.ui.h:55
-msgid "Simulated Secondary Click"
-msgstr "Pulsación secundaria simulada"
-
-#: ../panels/universal-access/uap.ui.h:56
-msgid "Slow Keys"
-msgstr "Tecles lentes"
-
-#: ../panels/universal-access/uap.ui.h:57
-msgid "Slow keys typing delay"
-msgstr "Retardu de les tecles lentes al escribir"
-
-#: ../panels/universal-access/uap.ui.h:61
-msgid "Sticky Keys"
-msgstr "Tecles pegañoses"
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "Trata una secuencia de tecles modificadores como una combinación de tecles"
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "Trigger a click when the pointer hovers"
-msgstr "Aniciar una pulsación al posicionar el punteru"
-
-#: ../panels/universal-access/uap.ui.h:64
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "Disparar una pulsación secundaria al caltener primíu'l botón primariu"
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "Turn on or off:"
-msgstr "Activar o desactivar:"
-
-#: ../panels/universal-access/uap.ui.h:66
-msgid "Type here to test settings"
-msgstr "Teclear equí pa probar la configuración"
-
-#: ../panels/universal-access/uap.ui.h:68
-msgid "Typing Assistant"
-msgstr "Asistente de tecleáu"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Use a visual indication when an alert sound occurs"
-msgstr "Usar una indicación visual cuando heba una alerta de soníu"
-
-#: ../panels/universal-access/uap.ui.h:70
-msgid "Video Mouse"
-msgstr "Mur de videu"
-
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Visual Alerts"
-msgstr "Alertes visuales"
-
-#: ../panels/universal-access/uap.ui.h:72
-msgid "Zoom in:"
-msgstr "Acercar:"
-
-#: ../panels/universal-access/uap.ui.h:73
-msgid "Zoom out:"
-msgstr "Allonxar:"
-
-#: ../panels/universal-access/uap.ui.h:74
-msgid "_Contrast:"
-msgstr "_Contraste:"
-
-#: ../panels/universal-access/uap.ui.h:75
-msgid "_Disable if two keys are pressed together"
-msgstr "_Desactivar si se calquen dos tecles al empar"
-
-#: ../panels/universal-access/uap.ui.h:76
-msgid "_Test flash"
-msgstr "_Probar destellos"
-
-#: ../panels/universal-access/uap.ui.h:77
-msgid "_Text size:"
-msgstr "_Tamañu del testu:"
-
-#: ../panels/universal-access/uap.ui.h:78
-msgid "_Turn on accessibility features from the keyboard"
-msgstr "Ac_tivar les carauterístiques d'accesibilidá dende'l tecláu"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:80
-msgid "accepted"
-msgstr "aceutada"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:82
-msgid "pressed"
-msgstr "primida"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:84
-msgid "rejected"
-msgstr "refugada"
-
-#: ../panels/universal-access/uap.ui.h:85
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "Altu"
-
-#: ../panels/universal-access/uap.ui.h:86
-msgctxt "universal access, contrast"
-msgid "High/Inverse"
-msgstr "Altu/invertíu"
-
-#: ../panels/universal-access/uap.ui.h:87
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "Baxu"
-
-#: ../panels/universal-access/uap.ui.h:88
-msgctxt "universal access, contrast"
-msgid "Normal"
-msgstr "Normal"
-
-#. Translators: this refers to theme contrast and font size
-#: ../panels/universal-access/uap.ui.h:90
-msgctxt "universal access, seeing"
-msgid "Display"
-msgstr "Amosar"
-
-#. Translators: this refers to screen magnifier
-#: ../panels/universal-access/uap.ui.h:92
-msgctxt "universal access, seeing"
-msgid "Zoom"
-msgstr "Acercar"
-
-#: ../panels/universal-access/uap.ui.h:93
-msgctxt "universal access, text size"
-msgid "Large"
-msgstr "Grande"
-
-#: ../panels/universal-access/uap.ui.h:94
-msgctxt "universal access, text size"
-msgid "Larger"
-msgstr "Más _grande"
-
-#: ../panels/universal-access/uap.ui.h:95
-msgctxt "universal access, text size"
-msgid "Normal"
-msgstr "Normal"
-
-#: ../panels/universal-access/uap.ui.h:96
-msgctxt "universal access, text size"
-msgid "Small"
-msgstr "Pequeñu"
-
-#: ../panels/universal-access/zoom-options.ui.h:1
-msgid "Always"
-msgstr "Siempre"
-
-#: ../panels/universal-access/zoom-options.ui.h:2
-msgid "Bottom Half"
-msgstr "Metada inferior"
-
-#: ../panels/universal-access/zoom-options.ui.h:3
-msgid "Centered"
-msgstr "Centráu"
-
-#: ../panels/universal-access/zoom-options.ui.h:4
-msgid "Color and Opacity"
-msgstr "Color y opacidá"
-
-#: ../panels/universal-access/zoom-options.ui.h:5
-msgid "Crosshairs"
-msgstr "Cruces"
-
-#: ../panels/universal-access/zoom-options.ui.h:6
-msgid "Full Screen"
-msgstr "Pantalla completa"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Image moves with the mouse pointer"
-msgstr "La imaxe muévese col punteru del mur"
-
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Image scrolls at screen edges"
-msgstr "La imaxe eslízase nos berbesos de la pantalla"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Left Half"
-msgstr "Metada esquierda"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Length"
-msgstr "Llonxitú"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnification"
-msgstr "Magnificador"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
-msgid "Moveable lens - magnified view follows mouse movements"
-msgstr "Llentes movibles: la vista magnificada sigue los movimientos del mur"
-
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Position of magnified view on screen"
-msgstr "Posición de la vista magnificada na pantalla"
-
-#: ../panels/universal-access/zoom-options.ui.h:18
-msgid "Proportional"
-msgstr "Proporcional"
-
-#: ../panels/universal-access/zoom-options.ui.h:19
-msgid "Push"
-msgstr "Push"
-
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Right Half"
-msgstr "Metada Derecha"
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Show"
-msgstr "Amosar"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Show crosshairs intersection"
-msgstr "Amosar la interseición de les cruces"
-
-#. long delay
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "Thick"
-msgstr "Gruesu"
-
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Thickness"
-msgstr "Grosor"
-
-#. short delay
-#: ../panels/universal-access/zoom-options.ui.h:29
-msgid "Thin"
-msgstr "Finu"
-
-#: ../panels/universal-access/zoom-options.ui.h:30
-msgid "To keep the pointer centered"
-msgstr "Caltener el punteru centráu"
-
-#: ../panels/universal-access/zoom-options.ui.h:31
-msgid "To keep the pointer visible"
-msgstr "Caltener el punteru visible"
-
-#: ../panels/universal-access/zoom-options.ui.h:32
-msgid "Top Half"
-msgstr "Metada superior"
-
-#: ../panels/universal-access/zoom-options.ui.h:33
-msgid "Zoom Options"
-msgstr "Opciones de zoom"
-
-#: ../panels/user-accounts/run-passwd.c:426
-msgid "Authentication failed"
-msgstr "Falló l'autenticación"
-
-#: ../panels/user-accounts/run-passwd.c:506
-#: ../panels/user-accounts/um-password-dialog.c:375
+#~ msgid "GOK"
+#~ msgstr "GOK"
+
+#~ msgid "Mouse Settings"
+#~ msgstr "Configuración del mur"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Tecláu en pantalla"
+
+#~ msgid "OnBoard"
+#~ msgstr "EnPantalla"
+
+#~ msgid "Options..."
+#~ msgstr "Opciones…"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "Teclear equí pa probar la configuración"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Mur de videu"
+
+#~ msgid "_Text size:"
+#~ msgstr "_Tamañu del testu:"
+
+#~ msgid "accepted"
+#~ msgstr "aceutada"
+
+#~ msgid "pressed"
+#~ msgstr "primida"
+
+#~ msgid "rejected"
+#~ msgstr "refugada"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Altu/invertíu"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "Amosar"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "Acercar"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Large"
+#~ msgstr "Grande"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "Más _grande"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Small"
+#~ msgstr "Pequeñu"
+
+#~ msgid "Always"
+#~ msgstr "Siempre"
+
+#~ msgid "Centered"
+#~ msgstr "Centráu"
+
+#~ msgid "Color and Opacity"
+#~ msgstr "Color y opacidá"
+
+#~ msgid "Image moves with the mouse pointer"
+#~ msgstr "La imaxe muévese col punteru del mur"
+
+#~ msgid "Image scrolls at screen edges"
+#~ msgstr "La imaxe eslízase nos berbesos de la pantalla"
+
+#~ msgid "Moveable lens - magnified view follows mouse movements"
+#~ msgstr ""
+#~ "Llentes movibles: la vista magnificada sigue los movimientos del mur"
+
+#~ msgid "Position of magnified view on screen"
+#~ msgstr "Posición de la vista magnificada na pantalla"
+
+#~ msgid "Push"
+#~ msgstr "Push"
+
+#~ msgid "Show"
+#~ msgstr "Amosar"
+
+#~ msgid "Show crosshairs intersection"
+#~ msgstr "Amosar la interseición de les cruces"
+
+#~ msgid "To keep the pointer centered"
+#~ msgstr "Caltener el punteru centráu"
+
+#~ msgid "To keep the pointer visible"
+#~ msgstr "Caltener el punteru visible"
+
+#~ msgid "Authentication failed"
+#~ msgstr "Falló l'autenticación"
+
 #, c-format
-msgid "The new password is too short"
-msgstr "La contraseña nueva ye enforma curtia"
+#~ msgid "The new password is too short"
+#~ msgstr "La contraseña nueva ye enforma curtia"
 
-#: ../panels/user-accounts/run-passwd.c:512
 #, c-format
-msgid "The new password is too simple"
-msgstr "La contraseña nueva ye enforma cenciella."
+#~ msgid "The new password is too simple"
+#~ msgstr "La contraseña nueva ye enforma cenciella."
 
-#: ../panels/user-accounts/run-passwd.c:518
 #, c-format
-msgid "The old and new passwords are too similar"
-msgstr "La contraseña antigua y la nueva son abondo asemeyaes"
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "La contraseña antigua y la nueva son abondo asemeyaes"
 
-#: ../panels/user-accounts/run-passwd.c:521
 #, c-format
-msgid "The new password has already been used recently."
-msgstr "La contraseña nueva yá s'usara recientemente."
+#~ msgid "The new password has already been used recently."
+#~ msgstr "La contraseña nueva yá s'usara recientemente."
 
-#: ../panels/user-accounts/run-passwd.c:524
 #, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "La contraseña nueva tien de tener carauteres numbéricos o especiales"
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr ""
+#~ "La contraseña nueva tien de tener carauteres numbéricos o especiales"
 
-#: ../panels/user-accounts/run-passwd.c:528
 #, c-format
-msgid "The old and new passwords are the same"
-msgstr "La contraseña nueva y l'antigua son la mesma"
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "La contraseña nueva y l'antigua son la mesma"
 
-#: ../panels/user-accounts/run-passwd.c:532
 #, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Camudóse la contraseña dende que t'autenticaste inicialmente."
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Camudóse la contraseña dende que t'autenticaste inicialmente."
 
-#: ../panels/user-accounts/run-passwd.c:536
 #, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "La contraseña nueva nun contién suficientes caráuteres diferentes"
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "La contraseña nueva nun contién suficientes caráuteres diferentes"
 
-#: ../panels/user-accounts/run-passwd.c:540
 #, c-format
-msgid "Unknown error"
-msgstr "Fallu desconocíu"
+#~ msgid "Unknown error"
+#~ msgstr "Fallu desconocíu"
 
-#: ../panels/user-accounts/um-account-dialog.c:73
-msgid "Failed to create user"
-msgstr "Falló al crear l'usuariu"
+#~ msgid "Failed to create user"
+#~ msgstr "Falló al crear l'usuariu"
 
-#: ../panels/user-accounts/um-account-type.c:35
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Estándar"
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Estándar"
 
-#: ../panels/user-accounts/um-account-type.c:37
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "Alministrador"
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Nun tienes permisu pa entrar nel preséu. Contauta col alministrador del "
+#~ "to sistema."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:107
-msgid "You are not allowed to access the device. Contact your system administrator."
-msgstr "Nun tienes permisu pa entrar nel preséu. Contauta col alministrador del to sistema."
+#~ msgid "The device is already in use."
+#~ msgstr "El preséu yá se ta usando"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:109
-msgid "The device is already in use."
-msgstr "El preséu yá se ta usando"
+#~ msgid "An internal error occurred."
+#~ msgstr "Hebo un fallu internu."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:111
-msgid "An internal error occurred."
-msgstr "Hebo un fallu internu."
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "¿Desaniciar les buelgues rexistraes?"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:181
-#: ../panels/user-accounts/um-fingerprint-dialog.c:182
-msgid "Enabled"
-msgstr "Activáu"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:224
-msgid "Delete registered fingerprints?"
-msgstr "¿Desaniciar les buelgues rexistraes?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:228
-msgid "_Delete Fingerprints"
-msgstr "_Desaniciar buelgues"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:235
-msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
-msgstr "¿Quies desaniciar les tos buelgues rexistraes y asina desactivar l'entamu de sesión con buelga?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:363
-msgid "Done!"
-msgstr "¡Fecho!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:410
-#: ../panels/user-accounts/um-fingerprint-dialog.c:432
 #, c-format
-msgid "Could not access '%s' device"
-msgstr "Nun se fue a acceder al preséu «%s»"
+#~ msgid "Could not access '%s' device"
+#~ msgstr "Nun se fue a acceder al preséu «%s»"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:481
 #, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "Nun pudo arrancase la captura dixital nel preséu «%s»"
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "Nun pudo arrancase la captura dixital nel preséu «%s»"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:533
-msgid "Could not access any fingerprint readers"
-msgstr "Nun se pudo acceder a denguna llectura de buelgues"
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Nun se pudo acceder a denguna llectura de buelgues"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:534
-msgid "Please contact your system administrator for help."
-msgstr "Contauta col alministrador del to sistema pa que t'aíde"
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Contauta col alministrador del to sistema pa que t'aíde"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:571
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Enable Fingerprint Login"
-msgstr "Activar l'entamu de sesión con buelga"
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Activar l'entamu de sesión con buelga"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:605
 #, c-format
-msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
-msgstr "P'activar l'aniciu de sesión con buelga dixital, tienes de guardar una buelga emplegando'l preséu '%s'."
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "P'activar l'aniciu de sesión con buelga dixital, tienes de guardar una "
+#~ "buelga emplegando'l preséu '%s'."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:612
-msgid "Selecting finger"
-msgstr "Seleicionando deu"
+#~ msgid "More choices..."
+#~ msgstr "Más opciones…"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:613
-msgid "Enrolling fingerprints"
-msgstr "Rexistrando buelgues dixitales"
+#~ msgid "Please choose another password."
+#~ msgstr "Escueyi otra contraseña."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:614
-msgid "Summary"
-msgstr "Resume"
+#~ msgid "Please type your current password again."
+#~ msgstr "Escribi otra vuelta la contraseña actual."
 
-#: ../panels/user-accounts/um-password-dialog.c:179
-msgid "More choices..."
-msgstr "Más opciones…"
+#~ msgid "Password could not be changed"
+#~ msgstr "Nun pudo camudase la contraseña"
 
-#: ../panels/user-accounts/um-password-dialog.c:285
-msgid "Please choose another password."
-msgstr "Escueyi otra contraseña."
+#~ msgid "You need to enter a new password"
+#~ msgstr "Tienes d'introducir una contraseña"
 
-#: ../panels/user-accounts/um-password-dialog.c:294
-msgid "Please type your current password again."
-msgstr "Escribi otra vuelta la contraseña actual."
+#~ msgid "You need to confirm the password"
+#~ msgstr "Tienes de confirmar la contraseña"
 
-#: ../panels/user-accounts/um-password-dialog.c:300
-msgid "Password could not be changed"
-msgstr "Nun pudo camudase la contraseña"
+#~ msgid "You need to enter your current password"
+#~ msgstr "Tienes d'introducir la contraseña actual"
 
-#: ../panels/user-accounts/um-password-dialog.c:372
-msgid "You need to enter a new password"
-msgstr "Tienes d'introducir una contraseña"
+#~ msgid "The current password is not correct"
+#~ msgstr "La contraseña actual nun ye correuta"
 
-#: ../panels/user-accounts/um-password-dialog.c:381
-msgid "You need to confirm the password"
-msgstr "Tienes de confirmar la contraseña"
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Enforma curtia"
 
-#: ../panels/user-accounts/um-password-dialog.c:384
-msgid "The passwords do not match"
-msgstr "Les contraseñes nun concasen"
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Feble"
 
-#: ../panels/user-accounts/um-password-dialog.c:390
-msgid "You need to enter your current password"
-msgstr "Tienes d'introducir la contraseña actual"
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Regular"
 
-#: ../panels/user-accounts/um-password-dialog.c:393
-msgid "The current password is not correct"
-msgstr "La contraseña actual nun ye correuta"
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Bona"
 
-#: ../panels/user-accounts/um-password-dialog.c:466
-#: ../panels/user-accounts/um-password-dialog.c:693
-msgctxt "Password strength"
-msgid "Too short"
-msgstr "Enforma curtia"
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Fuerte"
 
-#: ../panels/user-accounts/um-password-dialog.c:469
-#: ../panels/user-accounts/um-password-dialog.c:694
-msgctxt "Password strength"
-msgid "Weak"
-msgstr "Feble"
+#~ msgid "Passwords do not match"
+#~ msgstr "Les contraseñes nun concasen"
 
-#: ../panels/user-accounts/um-password-dialog.c:471
-#: ../panels/user-accounts/um-password-dialog.c:695
-msgctxt "Password strength"
-msgid "Fair"
-msgstr "Regular"
+#~ msgid "Wrong password"
+#~ msgstr "Contraseña incorreuta"
 
-#: ../panels/user-accounts/um-password-dialog.c:473
-#: ../panels/user-accounts/um-password-dialog.c:696
-msgctxt "Password strength"
-msgid "Good"
-msgstr "Bona"
+#~ msgid "Disable image"
+#~ msgstr "Desactivar imaxe"
 
-#: ../panels/user-accounts/um-password-dialog.c:475
-#: ../panels/user-accounts/um-password-dialog.c:697
-msgctxt "Password strength"
-msgid "Strong"
-msgstr "Fuerte"
+#~ msgid "Take a photo..."
+#~ msgstr "Tomar una semeya…"
 
-#: ../panels/user-accounts/um-password-dialog.c:514
-msgid "Passwords do not match"
-msgstr "Les contraseñes nun concasen"
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Restolar por más imáxenes…"
 
-#: ../panels/user-accounts/um-password-dialog.c:540
-msgid "Wrong password"
-msgstr "Contraseña incorreuta"
-
-#: ../panels/user-accounts/um-photo-dialog.c:97
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-msgid "Select"
-msgstr "Seleicionar"
-
-#: ../panels/user-accounts/um-photo-dialog.c:445
-msgid "Disable image"
-msgstr "Desactivar imaxe"
-
-#: ../panels/user-accounts/um-photo-dialog.c:463
-msgid "Take a photo..."
-msgstr "Tomar una semeya…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:481
-msgid "Browse for more pictures..."
-msgstr "Restolar por más imáxenes…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:706
 #, c-format
-msgid "Used by %s"
-msgstr "Usada por %s"
+#~ msgid "Used by %s"
+#~ msgstr "Usada por %s"
 
-#: ../panels/user-accounts/um-user-manager.c:450
 #, c-format
-msgid "A user with name '%s' already exists."
-msgstr "Yá hai otru usuariu con el nome «%s»."
+#~ msgid "A user with name '%s' already exists."
+#~ msgstr "Yá hai otru usuariu con el nome «%s»."
 
-#: ../panels/user-accounts/um-user-manager.c:546
-msgid "This user does not exist."
-msgstr "Esti usuariu nun esiste."
+#~ msgid "This user does not exist."
+#~ msgstr "Esti usuariu nun esiste."
 
-#: ../panels/user-accounts/um-user-panel.c:357
-msgid "Failed to delete user"
-msgstr "Falló al desaniciar l'usuariu"
+#~ msgid "Failed to delete user"
+#~ msgstr "Falló al desaniciar l'usuariu"
 
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "You cannot delete your own account."
-msgstr "Nun pues desaniciar la to propia cuenta."
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nun pues desaniciar la to propia cuenta."
 
-#: ../panels/user-accounts/um-user-panel.c:426
 #, c-format
-msgid "%s is still logged in"
-msgstr "%s aínda ta rexistráu nel sistema"
+#~ msgid "%s is still logged in"
+#~ msgstr "%s aínda ta rexistráu nel sistema"
 
-#: ../panels/user-accounts/um-user-panel.c:430
-msgid "Deleting a user while they are logged in can leave the system in an inconsistent state."
-msgstr "Desaniciar a un usuariu mentanto ta coneutáu nel sistema pue dexar al sistema nun estáu inconsistente."
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Desaniciar a un usuariu mentanto ta coneutáu nel sistema pue dexar al "
+#~ "sistema nun estáu inconsistente."
 
-#: ../panels/user-accounts/um-user-panel.c:439
 #, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "¿Quies caltener los ficheros de %s?"
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "¿Quies caltener los ficheros de %s?"
 
-#: ../panels/user-accounts/um-user-panel.c:443
-msgid "It is possible to keep the home directory, mail spool and temporary files around when deleting a user account."
-msgstr "Ye dable caltener la carpeta personal, el «spool» del corréu y los ficheros temporales al desaniciar una cuenta d'usuariu."
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Ye dable caltener la carpeta personal, el «spool» del corréu y los "
+#~ "ficheros temporales al desaniciar una cuenta d'usuariu."
 
-#: ../panels/user-accounts/um-user-panel.c:446
-msgid "_Delete Files"
-msgstr "_Desaniciar ficheros"
+#~ msgid "_Keep Files"
+#~ msgstr "_Caltener ficheros"
 
-#: ../panels/user-accounts/um-user-panel.c:447
-msgid "_Keep Files"
-msgstr "_Caltener ficheros"
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Cuenta desactivada"
 
-#: ../panels/user-accounts/um-user-panel.c:499
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Cuenta desactivada"
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Pa configurar nel siguiente aniciu de sesión"
 
-#: ../panels/user-accounts/um-user-panel.c:507
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Pa configurar nel siguiente aniciu de sesión"
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Dengún"
 
-#: ../panels/user-accounts/um-user-panel.c:510
-msgctxt "Password mode"
-msgid "None"
-msgstr "Dengún"
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Falló al contautar col serviciu de cuentes"
 
-#: ../panels/user-accounts/um-user-panel.c:845
-msgid "Failed to contact the accounts service"
-msgstr "Falló al contautar col serviciu de cuentes"
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Asegúrate de que'l serviciu de cuentes ta instaláu y activáu."
 
-#: ../panels/user-accounts/um-user-panel.c:847
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Asegúrate de que'l serviciu de cuentes ta instaláu y activáu."
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pa facer los cambeos\n"
+#~ "calca primero l'iconu *"
 
-#: ../panels/user-accounts/um-user-panel.c:887
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Pa facer los cambeos\n"
-"calca primero l'iconu *"
+#~ msgid "Create a user"
+#~ msgstr "Crear un usuariu"
 
-#: ../panels/user-accounts/um-user-panel.c:925
-msgid "Create a user"
-msgstr "Crear un usuariu"
+#~ msgid ""
+#~ "To create a user,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pa crear un usuariu\n"
+#~ "calca primero l'iconu *"
 
-#: ../panels/user-accounts/um-user-panel.c:936
-#: ../panels/user-accounts/um-user-panel.c:1225
-msgid ""
-"To create a user,\n"
-"click the * icon first"
-msgstr ""
-"Pa crear un usuariu\n"
-"calca primero l'iconu *"
+#~ msgid "Delete the selected user"
+#~ msgstr "Desaniciar l'usuariu esbilláu"
 
-#: ../panels/user-accounts/um-user-panel.c:945
-msgid "Delete the selected user"
-msgstr "Desaniciar l'usuariu esbilláu"
+#~ msgid ""
+#~ "To delete the selected user,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pa desaniciar l'usuariu esbilláu\n"
+#~ "calca primero l'iconu *"
 
-#: ../panels/user-accounts/um-user-panel.c:957
-#: ../panels/user-accounts/um-user-panel.c:1230
-msgid ""
-"To delete the selected user,\n"
-"click the * icon first"
-msgstr ""
-"Pa desaniciar l'usuariu esbilláu\n"
-"calca primero l'iconu *"
+#~ msgid "Other Accounts"
+#~ msgstr "Otres cuentes"
 
-#: ../panels/user-accounts/um-user-panel.c:1134
-msgid "My Account"
-msgstr "La mio cuenta"
-
-#: ../panels/user-accounts/um-user-panel.c:1144
-msgid "Other Accounts"
-msgstr "Otres cuentes"
-
-#: ../panels/user-accounts/um-utils.c:512
 #, c-format
-msgid "A user with the username '%s' already exists"
-msgstr "Yá esiste un nome d'usuariu col nome «%s»"
+#~ msgid "A user with the username '%s' already exists"
+#~ msgstr "Yá esiste un nome d'usuariu col nome «%s»"
 
-#: ../panels/user-accounts/um-utils.c:516
 #, c-format
-msgid "The username is too long"
-msgstr "El nome d'usuariu ye enforma llargu"
-
-#: ../panels/user-accounts/um-utils.c:519
-msgid "The username cannot start with a '-'"
-msgstr "El nome d'usuariu nun pue entamar por «-»"
-
-#: ../panels/user-accounts/um-utils.c:522
-msgid ""
-"The username must only consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-"El nome d'usuariu tien de contener:\n"
-" ➣ lletres del alfabetu inglés\n"
-" ➣ díxitos\n"
-" ➣ cualquiera de los caráuteres «.», «-» y «_»"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Add or remove users"
-msgstr "Amestar o quitar usuarios"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "aniciu;sesión;nome;buelga;avatar;logu;cara;contraseña;"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "User Accounts"
-msgstr "Cuentes d'usuariu"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-msgid "Cr_eate"
-msgstr "Cr_ear"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "Create new account"
-msgstr "Crear una cuenta nueva"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "_Account Type"
-msgstr "_Triba de cuenta"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "_Full name"
-msgstr "Nome _completu"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-msgid "_Username"
-msgstr "Nome d'_usuariu"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "C_onfirm password"
-msgstr "C_onfirmar contraseña"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-msgid "Ch_ange"
-msgstr "Cam_biar"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Changing password for"
-msgstr "Cambiando la contraseña pa"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "Choose a generated password"
-msgstr "Escoyer una contraseña xenerada"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Choose password at next login"
-msgstr "Escoyer una contraseña nel siguiente aniciu de sesión"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _password"
-msgstr "Contraseña _actual"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Disable this account"
-msgstr "Desactivar esta cuenta"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Enable this account"
-msgstr "Activar esta cuenta"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-msgid "Fair"
-msgstr "Regular"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-msgid "How to choose a strong password"
-msgstr "Cómo escoyer una contraseña fuerte"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-msgid "Log in without a password"
-msgstr "Aniciar sesión ensin contraseña"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-msgid "Set a password now"
-msgstr "Afitar agora una contraseña"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid "This hint may be displayed at the login screen.  It will be visible to all users of this system.  Do <b>not</b> include the password here."
-msgstr "Esti conseyu pue amosase na pantalla d'aniciu. Va ser visible pa tolos usuarios d'esti sistema. <b>Nun</b> incluyas equí la to contraseña."
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-msgid "_Action"
-msgstr "_Aición"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:15
-msgid "_Hint"
-msgstr "C_onseyu"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:16
-msgid "_New password"
-msgstr "Contraseña _nueva"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:17
-msgid "_Show password"
-msgstr "_Amosar contraseña"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-msgid "Browse"
-msgstr "Restolar"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-msgid "Cancel"
-msgstr "Encaboxar"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-msgid "Changing photo for:"
-msgstr "Cambiando la semeya pa:"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-msgid "Choose a picture that will be shown at the login screen for this account."
-msgstr "Escueyi la imaxe que s'amosará na pantalla d'aniciu de sesión pa esta cuenta."
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-msgid "Gallery"
-msgstr "Galería"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr "Semeya"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-msgid "Take a photograph"
-msgstr "Facer una semeya"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-msgid "A_utomatic Login"
-msgstr "_Aniciu automáticu de sesión"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-msgid "Account Information"
-msgstr "Información de Cuenta"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Account _type"
-msgstr "_Triba de cuenta"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "Opciones d'aniciu de sesión"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Fingerprint Login"
-msgstr "Aniciu de sesión con _buelga"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "_Language"
-msgstr "_Llingua"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Password"
-msgstr "C_ontraseña"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left little finger"
-msgstr "Moñín esquierdu"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left middle finger"
-msgstr "Deu mediu esquierdu"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left ring finger"
-msgstr "Deu anular esquierdu"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Left thumb"
-msgstr "Pulgar esquierdu"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right little finger"
-msgstr "Moñín drechu"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right middle finger"
-msgstr "Deu mediu drechu"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right ring finger"
-msgstr "Deu anular drechu"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-msgid "Right thumb"
-msgstr "Pulgar drechu"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
-msgstr "La to buelga dixital guardóse correutamente. Agora deberíes poder aniciar sesión emplegando'l llector de buelgues dixital."
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "Deu índiz _izquierdu"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "_Otru deu:"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid "_Right index finger"
-msgstr "_Deu índiz derechu"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Back"
-msgstr "Atrás"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Bluetooth Settings"
-msgstr "Preferencies de Bluetooth"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Calibrate..."
-msgstr "Calibrar..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "Eraser Pressure Feel"
-msgstr "Sensibilidá de presión de borrador"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Firm"
-msgstr "Firme"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Forward"
-msgstr "Alantre"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Left Mouse Button Click"
-msgstr "Pulsación del botón izquierdu del mur"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Left-Handed Orientation:"
-msgstr "Orientación pa maniegos:"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Lower Button"
-msgstr "Botón inferior"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Middle Mouse Button Click"
-msgstr "Pulsación del botón central del mur"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "No Action"
-msgstr "Denguna aición"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "No tablet detected"
-msgstr "Tableta non deteutada"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Enchufa o prende la to tableta Wacom"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Right Mouse Button Click"
-msgstr "Pulsación del botón derechu del mur"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Scroll Down"
-msgstr "Desplazar abaxo"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:16
-msgid "Scroll Left"
-msgstr "Desplazar a la izquierda"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:17
-msgid "Scroll Right"
-msgstr "Desplazar a la derecha"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:18
-msgid "Scroll Up"
-msgstr "Mover arriba"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:19
-msgid "Soft"
-msgstr "Blandu"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:20
-msgid "Stylus"
-msgstr "Stylus"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:21
-msgid "Tablet (absolute)"
-msgstr "Tableta (completa)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:22
-msgid "Tablet Preferences"
-msgstr "Preferencies de tableta"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:23
-msgid "Tip Pressure Feel"
-msgstr "Sensibilidá de presión del llápiz"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:24
-msgid "Top Button"
-msgstr "Botón superior"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:25
-msgid "Touchpad (relative)"
-msgstr "Touchpad (rellativu)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:26
-msgid "Tracking Mode"
-msgstr "Mou de rastréu"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:27
-msgid "Wacom Tablet"
-msgstr "Tableta Wacom"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-msgid "Set your Wacom tablet preferences"
-msgstr "Afita les preferencies de la to tableta Wacom"
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "Tablet;Wacom;Llápiz;Borrador;Mur;"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Wacom Graphics Tablet"
-msgstr "Tableta gráfica Wacom"
-
-#: ../shell/control-center.c:54
-msgid "Enable verbose mode"
-msgstr "Activar el mou detalláu"
-
-#: ../shell/control-center.c:55
-msgid "Show the overview"
-msgstr "Amosar la visión xeneral"
-
-#: ../shell/control-center.c:56
-#: ../shell/control-center.c:57
-#: ../shell/control-center.c:58
-msgid "Show help options"
-msgstr "Amosar opciones d'aida"
-
-#: ../shell/control-center.c:59
-msgid "Panel to display"
-msgstr "Panel a amosar"
-
-#: ../shell/control-center.c:81
-msgid "- System Settings"
-msgstr "- Axustes del sistema"
-
-#: ../shell/control-center.c:89
+#~ msgid "The username is too long"
+#~ msgstr "El nome d'usuariu ye enforma llargu"
+
+#~ msgid "The username cannot start with a '-'"
+#~ msgstr "El nome d'usuariu nun pue entamar por «-»"
+
+#~ msgid ""
+#~ "The username must only consist of:\n"
+#~ " ➣ letters from the English alphabet\n"
+#~ " ➣ digits\n"
+#~ " ➣ any of the characters '.', '-' and '_'"
+#~ msgstr ""
+#~ "El nome d'usuariu tien de contener:\n"
+#~ " ➣ lletres del alfabetu inglés\n"
+#~ " ➣ díxitos\n"
+#~ " ➣ cualquiera de los caráuteres «.», «-» y «_»"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "aniciu;sesión;nome;buelga;avatar;logu;cara;contraseña;"
+
+#~ msgid "User Accounts"
+#~ msgstr "Cuentes d'usuariu"
+
+#~ msgid "Cr_eate"
+#~ msgstr "Cr_ear"
+
+#~ msgid "Create new account"
+#~ msgstr "Crear una cuenta nueva"
+
+#~ msgid "_Account Type"
+#~ msgstr "_Triba de cuenta"
+
+#~ msgid "Changing password for"
+#~ msgstr "Cambiando la contraseña pa"
+
+#~ msgid "Disable this account"
+#~ msgstr "Desactivar esta cuenta"
+
+#~ msgid "Enable this account"
+#~ msgstr "Activar esta cuenta"
+
+#~ msgid "Fair"
+#~ msgstr "Regular"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Cómo escoyer una contraseña fuerte"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Aniciar sesión ensin contraseña"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "Esti conseyu pue amosase na pantalla d'aniciu. Va ser visible pa tolos "
+#~ "usuarios d'esti sistema. <b>Nun</b> incluyas equí la to contraseña."
+
+#~ msgid "_Hint"
+#~ msgstr "C_onseyu"
+
+#~ msgid "Browse"
+#~ msgstr "Restolar"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Cambiando la semeya pa:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Escueyi la imaxe que s'amosará na pantalla d'aniciu de sesión pa esta "
+#~ "cuenta."
+
+#~ msgid "Gallery"
+#~ msgstr "Galería"
+
+#~ msgid "Photograph"
+#~ msgstr "Semeya"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Facer una semeya"
+
+#~ msgid "Account Information"
+#~ msgstr "Información de Cuenta"
+
+#~ msgid "Login Options"
+#~ msgstr "Opciones d'aniciu de sesión"
+
+#~ msgid "Left little finger"
+#~ msgstr "Moñín esquierdu"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Deu mediu esquierdu"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Deu anular esquierdu"
+
+#~ msgid "Left thumb"
+#~ msgstr "Pulgar esquierdu"
+
+#~ msgid "Right little finger"
+#~ msgstr "Moñín drechu"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Deu mediu drechu"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Deu anular drechu"
+
+#~ msgid "Right thumb"
+#~ msgstr "Pulgar drechu"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "La to buelga dixital guardóse correutamente. Agora deberíes poder aniciar "
+#~ "sesión emplegando'l llector de buelgues dixital."
+
+#~ msgid "_Left index finger"
+#~ msgstr "Deu índiz _izquierdu"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Deu índiz derechu"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Preferencies de Bluetooth"
+
+#~ msgid "Calibrate..."
+#~ msgstr "Calibrar..."
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Pulsación del botón izquierdu del mur"
+
+#~ msgid "No Action"
+#~ msgstr "Denguna aición"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Desplazar a la derecha"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Mover arriba"
+
+#~ msgid "Stylus"
+#~ msgstr "Stylus"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferencies de tableta"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Mou de rastréu"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Afita les preferencies de la to tableta Wacom"
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Tableta gráfica Wacom"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Activar el mou detalláu"
+
+#~ msgid "Show the overview"
+#~ msgstr "Amosar la visión xeneral"
+
+#~ msgid "- System Settings"
+#~ msgstr "- Axustes del sistema"
+
 #, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
-msgstr ""
-"%s\n"
-"Executar '%s --help' pa ver una llista completa de les opciones de comandu disponibles.\n"
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Executar '%s --help' pa ver una llista completa de les opciones de "
+#~ "comandu disponibles.\n"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:1
-#: ../shell/shell.ui.h:1
-msgid "System Settings"
-msgstr "Preferencies del sistema"
+#~ msgid "System Settings"
+#~ msgstr "Preferencies del sistema"
 
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Centru de control"
+#~ msgid "Control Center"
+#~ msgstr "Centru de control"
 
-#~ msgid "Appearance"
-#~ msgstr "Aspeutu"
 #~ msgid "<b>Background</b>"
 #~ msgstr "<b>Fondu</b>"
-#~ msgid "<b>Theme</b>"
-#~ msgstr "<b>Tema</b>"
+
 #~ msgid "Theme to be used for the UI"
 #~ msgstr "Tema usáu na interfaz d'usuariu"
-#~ msgid "Media and Autorun"
-#~ msgstr "Soportes y autoexecución"
+
 #~ msgid "Configure media and autorun preferences"
 #~ msgstr "Configurar los soportes y preferencies d'autoexecución"
+
 #~ msgid "cd;dvd;usb;audio;video;disc;"
 #~ msgstr "cd;dvd;usb;soníu;videu;discu;"
-#~ msgid "Keyboard Layout"
-#~ msgstr "Distribución del tecláu"
+
 #~ msgid "Apply system wide"
 #~ msgstr "Aplicar en tol sistema"
+
 #~ msgid "Ask me"
 #~ msgstr "Entrúgame"
+
 #~ msgid "Shutdown"
 #~ msgstr "Apagar"
+
 #~ msgid "Suspend"
 #~ msgstr "Suspender"
+
 #~ msgid "When the lid is closed:"
 #~ msgstr "Cuando la cubierta tea zarrada"
+
 #~ msgid ""
 #~ "Only profiles that are compatible with the device will be listed above."
 #~ msgstr "Debaxo namái van llistase perfiles compatibles col preséu."
+
 #~ msgid "Never"
 #~ msgstr "Enxamás"
+
 #~ msgid "_Turn off after:"
 #~ msgstr "_Apagar dempués de:"
-#~ msgid "Mute"
-#~ msgstr "Silenciar"
-#~ msgid "_All Settings"
-#~ msgstr "_Toles configuraciones"
+
 #~ msgid ""
 #~ "To edit a shortcut key, click on the corresponding row and type a new key "
 #~ "combination, or press backspace to clear."
 #~ msgstr ""
 #~ "Pa editar una combinación nueva calque na filera correspondiente y teclee "
 #~ "una combinación de tecles nueva, o calque Retrocesu pa desaniciala."
-#~ msgid "Reset"
-#~ msgstr "Resetear"
+
 #~ msgid "Apply System-Wide..."
 #~ msgstr "Aplica a tol sistema..."
+
 #~ msgid "Off"
 #~ msgstr "Apagáu"
+
 #~ msgid "Error unsetting accelerator in configuration database: %s"
 #~ msgstr ""
 #~ "Fallu al desaniciar una combinación de tecles na base de datos de "
 #~ "configuración: %s"
-#~ msgid "Mirror Screens"
-#~ msgstr "Mirror Screens"
+
 #~ msgid "Could not install theme engine"
 #~ msgstr "Nun pudo instalase'l motor del tema"
+
 #~ msgid "Install"
 #~ msgstr "Instalar"
+
 #~ msgid "Maximize Horizontally"
 #~ msgstr "Maximizar horizontalmente"
+
 #~ msgid "Maximize Vertically"
 #~ msgstr "Maximizar verticalmente"
+
 #~ msgid "Documents"
 #~ msgstr "Documentos"
-#~ msgid "Ignored Hosts"
-#~ msgstr "Hosts inoraos"
+
 #~ msgid "Specify the name of the page to show (general|accessibility)"
 #~ msgstr "Especifique'l nome de la páxina p'amosar (general|accessibility)"
+
 #~ msgid "_Simulate simultaneous keypresses"
 #~ msgstr "_Simular pulsaciones de múltiples tecles"
+
 #~ msgid "_Pointer can be controlled using the keypad"
 #~ msgstr "Permitir remanar el _punteru usando'l tecláu numbéricu"
+
 #~ msgid "_Lock screen to enforce typing break"
 #~ msgstr "B_loquiar la pantalla pa forciar un descansu d'escritura"
+
 #~ msgid "_Language:"
 #~ msgstr "_Llingua:"
+
 #~ msgid "_Country:"
 #~ msgstr "_País:"
+
 #~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
 #~ msgstr ""
 #~ "Permitir conmutar les carauterístiques d'_accesibilidá dende "
 #~ "combinaciones de tecles"
+
 #~ msgid "Keyboard Accessibility Audio Feedback"
 #~ msgstr "Comentarios sobro los soníos d'accesibilidá del tecláu"
+
 #~ msgid "By _language"
 #~ msgstr "Por _llingua"
+
 #~ msgid "By _country"
 #~ msgstr "Por _país"
+
 #~ msgid "Audio _Feedback..."
 #~ msgstr "Co_mentarios sobro'l soníu..."
+
 #~ msgid ""
 #~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
 #~ msgstr ""
 #~ "Especifique'l nome de la páxina p'amosar (internet|multimedia|system|a11y)"
+
 #~ msgid "Overwrite _All"
 #~ msgstr "Sobroscribir _too"
+
 #~ msgid "_Skip"
 #~ msgstr "_Saltar"
+
 #~ msgid "File '%s' already exists. Do you want to overwrite it?"
 #~ msgstr "El ficheru «%s» yá esiste. ¿Quier sobroscribilu?"
+
 #~ msgid "The last applied font suggestion can be reverted."
 #~ msgstr "Pue revertise la cabera suxerencia de tipografía aplicada."
+
 #~ msgid ""
 #~ "This theme will not look as intended because the required GTK+ theme "
 #~ "engine '%s' is not installed."
 #~ msgstr ""
 #~ "Esti tema nun s'amosará como se pretende porque'l motor de temes GTK+ "
 #~ "necesariu «%s» nun ta instaláu."
-#~ msgid "_Mouse Accessibility"
-#~ msgstr "_Accesibilidá del Mur"
+
 #~ msgid "Jump to the Mouse Accessibility dialog"
 #~ msgstr "Saltar al diálogu d'Accesibilidá del mur"
+
 #~ msgid "- GNOME Mouse Preferences"
 #~ msgstr "- GNOME Preferencies del Mur"
+
 #~ msgid "S_uper (or \"Windows logo\")"
 #~ msgstr "_Super (o «Logu de Windows»)"
+
 #~ msgid "Show click type _window"
 #~ msgstr "Amosar la _ventana del tipu de pulsación"
+
 #~ msgid "Cannot install theme"
 #~ msgstr "Nun pue instalase'l tema"
+
 #~ msgid "Ci_ty:"
 #~ msgstr "Ci_udá:"
+
 #~ msgid "Could not shutdown backend_stdout IO channel: %s"
 #~ msgstr "Nun ye dable apagar el canal de E/S backend_stdout: %s"
+
 #~ msgid "gesture|Move down"
 #~ msgstr "Mover abaxo"
+
 #~ msgid "Open in File Manager"
 #~ msgstr "Abrir nel alministrador de ficheros"
+
 #~ msgid "Web _log:"
 #~ msgstr "Rexistr_u Web:"
+
 #~ msgid ""
 #~ "Insufficient permissions to install the theme in:\n"
 #~ "%s"
 #~ msgstr ""
 #~ "Permisos insuficientes pa instalar el tema en:\n"
 #~ "%s"
+
 #~ msgid ""
 #~ "The task name to be displayed in the control-center followed by a \";\" "
 #~ "separator then the filename of an associated .desktop file to launch for "
@@ -4467,258 +7542,328 @@ msgstr "Centru de control"
 #~ "El nome de la xera que despliegar nel centru de control siguíu por un "
 #~ "separtador «;» y llueu el nome d'un ficheru .desktop asociáu que llanzar "
 #~ "pa esa xera."
-#~ msgid "User name:"
-#~ msgstr "Nome d'usuariu:"
+
 #~ msgid "Save Theme As..."
 #~ msgstr "Guardar tema como…"
+
 #~ msgid "Typing Monitor"
 #~ msgstr "Monitor de tecléu"
-#~ msgid "Fraction completed"
-#~ msgstr "Fracción completada"
+
 #~ msgid ""
 #~ "Your password has been changed since you initially authenticated! Please "
 #~ "re-authenticate."
 #~ msgstr ""
 #~ "La to clave foi camudada dende la to identificación inicial! Por favor re-"
 #~ "identificate."
+
 #~ msgid "Pointer"
 #~ msgstr "Punteru"
+
 #~ msgid "Parent window of the dialog"
 #~ msgstr "Ventana raigón del diálogu"
+
 #~ msgid "Unable to launch backend"
 #~ msgstr "Nun ye dable llanzar el backend"
+
 #~ msgid "_Selected items:"
 #~ msgstr "Elementos _seleicionaos:"
-#~ msgid "Open with Default Application"
-#~ msgstr "Abrir cola aplicación predeterminada"
+
 #~ msgid "_VRGB"
 #~ msgstr "_VRGB"
+
 #~ msgid "White Pointer"
 #~ msgstr "Punteru Blancu"
+
 #~ msgid "Current URI index"
 #~ msgstr "Índiz URI actual"
+
 #~ msgid "Sub_pixel (LCDs)"
 #~ msgstr "Sub_pixel (LCDs)"
+
 #~ msgid "Are you sure you want to permanently delete \"%s\"?"
 #~ msgstr "¿Daveres quier esaniciar pa siempres «%s»?"
+
 #~ msgid "The old and new passwords are too similar."
 #~ msgstr "La contraseña nueva y la vieya son abondo asemeyaes"
+
 #~ msgid "Today %l:%M %p"
 #~ msgstr "Güei %H:%M"
+
 #~ msgid "Multimedia"
 #~ msgstr "Multimedia"
+
 #~ msgid "Changing your cursor theme takes effect the next time you log in."
 #~ msgstr ""
 #~ "El cambéu del tema de cursor nun fadrá efeutu hasta que salga y anicie "
 #~ "sesión de nuevu."
+
 #~ msgid "<b>_Automatic proxy configuration</b>"
 #~ msgstr "<b>Configuración _Automática del proxy</b>"
+
 #~ msgid "Window Preferences"
 #~ msgstr "Preferencies de Ventana"
+
 #~ msgid "Jump to the Accessible Login dialog"
 #~ msgstr "Dir al diálogu d'Entrada Acesible"
+
 #~ msgid "Exit shell on add or remove action performed"
 #~ msgstr ""
 #~ "Abandona la consola cuando se tien fecho una aición d'amestáu o desaniciu"
+
 #~ msgid "Font Rendering Details"
 #~ msgstr "Detalles de Procesamientu de Fontes"
-#~ msgid "Please make sure that the applet is properly installed"
-#~ msgstr "Tea xuru de que la miniaplicación ta instalada correchamente"
+
 #~ msgid "Start the page with the typing break settings showing"
 #~ msgstr ""
 #~ "Aniciar la páxina amosando la configuración del descansu d'escritura"
+
 #~ msgid "gesture|Move right"
 #~ msgstr "Mover a la drecha"
+
 #~ msgid "Run in t_erminal"
 #~ msgstr "Executar nel t_erminal"
+
 #~ msgid "_Password dialogs as normal windows"
 #~ msgstr "Diálogos de _Clave como una ventana normal"
+
 #~ msgid "Totem Movie Player"
 #~ msgstr "Reproductor de películes Totem"
+
 #~ msgid "KDE Magnifier without Screen Reader"
 #~ msgstr "Magnificador de KDE ensin llector de pantalla"
+
 #~ msgid "R_esolution:"
 #~ msgstr "R_esolución:"
+
 #~ msgid "The password is too short."
 #~ msgstr "La contraseña ye mui curtia"
+
 #~ msgid "%b %d %l:%M %p"
 #~ msgstr "%d %b %l:%M %p"
-#~ msgid "<b>_Use authentication</b>"
-#~ msgstr "<b>_Utiliza autenticación</b>"
+
 #~ msgid "URI currently transferring to"
 #~ msgstr "URI ta tresfiriendo a"
+
 #~ msgid "The two passwords are not equal."
 #~ msgstr "Les dos claves nun son iguales."
+
 #~ msgid "Current URI index - starts from 1"
 #~ msgstr "Índiz URI actual - entama dende 1"
+
 #~ msgid "<b>Open %s</b>"
 #~ msgstr "<b>Abrir %s</b>"
+
 #~ msgid "Linux Screen Reader with Magnifier"
 #~ msgstr "Llector de pantalla de Linux con magnificador"
+
 #~ msgid "Could not shutdown backend_stdin IO channel: %s"
 #~ msgstr "Nun ye dable apagar el canal de E/S backend_stdin: %s"
-#~ msgid "_Reset to Defaults"
-#~ msgstr "_Restablecer valores predeterminaos"
-#~ msgid "From URI"
-#~ msgstr "De URI"
+
 #~ msgid "C_ompany:"
 #~ msgstr "C_ompañía:"
+
 #~ msgid "There was a problem while extracting the theme."
 #~ msgstr "Hebo un fallu al estrayer el tema."
-#~ msgid "H_TTP proxy:"
-#~ msgstr "Proxy H_TTP:"
+
 #~ msgid "_Password:"
 #~ msgstr "_Contraseña:"
+
 #~ msgid "Assistive Technologies"
 #~ msgstr "Teunoloxíes d'asistencia"
+
 #~ msgid "Change Passwo_rd..."
 #~ msgstr "Camudar Cont_raseña..."
+
 #~ msgid "Eye candy added by Anders Carlsson"
 #~ msgstr "Vistosidá amestada por Anders Carlsson"
-#~ msgid "Beep when a _modifier key is pressed"
-#~ msgstr "Pitar al calcar un _modificador"
+
 #~ msgid "?"
 #~ msgstr "?"
+
 #~ msgid "Linux Screen Reader"
 #~ msgstr "Llector de pantalla de Linux"
+
 #~ msgid "_Install..."
 #~ msgstr "_Instalar…"
+
 #~ msgid "_Home:"
 #~ msgstr "_Domiciliu:"
+
 #~ msgid "Beep when a _toggle key is pressed"
 #~ msgstr "Pitar al calcar una _tecla conmutable"
+
 #~ msgid "A computer break reminder."
 #~ msgstr "Un recordatoriu pa los descansos frente a la computadora."
+
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr ""
 #~ "El xestor de ventanes «%s» nun rexistró una ferramienta de configuración\n"
+
 #~ msgid "gesture|Move left"
 #~ msgstr "Mover a la esquierda"
+
 #~ msgid "Duration of the break when typing is disallowed"
 #~ msgstr "Duración del descansu cuando la escritura nun ta permitía"
+
 #~ msgid "dots per inch"
 #~ msgstr "puntos por pulgada"
+
 #~ msgid "Muine Music Player"
 #~ msgstr "Reproductor de música Muine"
+
 #~ msgid "Network Proxy Preferences"
 #~ msgstr "Preferencies del Proxy de Rede"
+
 #~ msgid ""
 #~ "Specify the name of the page to show (theme|background|fonts|interface)"
 #~ msgstr ""
 #~ "Especifique'l nome de la páxina p'amosar (theme|background|fonts|"
 #~ "interface)"
+
 #~ msgid "_Secure HTTP proxy:"
 #~ msgstr "Proxy HTTP _Seguru:"
+
 #~ msgid "Default Pointer"
 #~ msgstr "Punteru Predetermináu"
+
 #~ msgid "Add Wallpaper"
 #~ msgstr "Amestar Fondu d'Escritoriu"
+
 #~ msgid "Remove from Startup Programs"
 #~ msgstr "Desaniciar de los programes d'entamu"
+
 #~ msgid "_Motion threshold:"
 #~ msgstr "Umbral de _movimientu:"
+
 #~ msgid "Find Now"
 #~ msgstr "Guetar agora"
+
 #~ msgid "P._O. box:"
 #~ msgstr "Apartáu de C_orreos:"
+
 #~ msgid "Autoconfiguration _URL:"
 #~ msgstr "_URL d'Autoconfiguración:"
+
 #~ msgid "Select Image"
 #~ msgstr "Esbillar Imaxe"
+
 #~ msgid "P.O. _box:"
 #~ msgstr "Apartáu de C_orreos:"
-#~ msgid "_FTP proxy:"
-#~ msgstr "Proxy _FTP:"
-#~ msgid "GNOME Terminal"
-#~ msgstr "Terminal GNOME"
+
 #~ msgid "Gnome Theme Package"
 #~ msgstr "Paquete de tema GNOME"
+
 #~ msgid "Terminator"
 #~ msgstr "Terminator"
+
 #~ msgid "Hom_e:"
 #~ msgstr "_Domiciliu:"
+
 #~ msgid "Unable to open address book"
 #~ msgstr "Incapaz d'abrir la llibreta de direiciones"
+
 #~ msgid "Keyboard _model:"
 #~ msgstr "_Modelu de tecláu:"
-#~ msgid "Alert Type"
-#~ msgstr "Tipu d'Avisu"
+
 #~ msgid "Keep Current Theme"
 #~ msgstr "Caltener el tema actual"
+
 #~ msgid "Check if breaks are allowed to be postponed"
 #~ msgstr "Comprobar si se permite posponer los descansos"
+
 #~ msgid "If you delete an item, it is permanently lost."
 #~ msgstr "Si desanicia un elementu, piérdese pa siempres."
+
 #~ msgid "Full Name"
 #~ msgstr "Nome Completu"
+
 #~ msgid "Installs themes packages for various parts of the desktop"
 #~ msgstr "Instala paquetes de temes pa delles partes del escritoriu"
+
 #~ msgid "pixel"
 #~ msgid_plural "pixels"
 #~ msgstr[0] "píxel"
 #~ msgstr[1] "píxeles"
-#~ msgid "Controls"
-#~ msgstr "Controles"
+
 #~ msgid "_Slight"
 #~ msgstr "Le_ve"
+
 #~ msgid "Task names and associated .desktop files"
 #~ msgstr "Nomes de xeres y ficheros .desktop asociaos"
-#~ msgid "Change password"
-#~ msgstr "Camudar la Contraseña"
+
 #~ msgid "gesture|Move up"
 #~ msgstr "Mover arriba"
+
 #~ msgid "All %s occurrences will be replaced with actual link"
 #~ msgstr "Toles apariciones de %s reemplazaránse pol enllaz actual"
+
 #~ msgid "%d minute until the next break"
 #~ msgid_plural "%d minutes until the next break"
 #~ msgstr[0] "%d minutu hasta'l so siguiente descansu"
 #~ msgstr[1] "%d minutos hasta'l so siguiente descansu"
+
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
+
 #~ msgid "Duration of work before forcing a break"
 #~ msgstr "Duración del trabayu enantes de forciar un descansu"
+
 #~ msgid "The password is too simple."
 #~ msgstr "La contraseña ye mui cenciella"
+
 #~ msgid "Written by Richard Hult <richard@imendio.com>"
 #~ msgstr "Escritu por Richard Hult <richard@imendio.com>"
+
 #~ msgid "Default Pointer - Current"
 #~ msgstr "Punteru Predetermináu - Actual"
+
 #~ msgid "Jump to Preferred Applications dialog"
 #~ msgstr "Dir al diálogu d'Aplicaciones Preferíes"
+
 #~ msgid "Groups"
 #~ msgstr "Grupos"
+
 #~ msgid "Add to Favorites"
 #~ msgstr "Amestar a favoritos"
+
 #~ msgid "Image/label border"
 #~ msgstr "Berbesu semeya/etiqueta"
+
 #~ msgid "Select your photo"
 #~ msgstr "Escueye la to semeya"
+
 #~ msgid ""
 #~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
 #~ "which you need to compile."
 #~ msgstr ""
 #~ "«%s» nun paez ser un tema válidu. Pue ser un motor de temes que tien de "
 #~ "compilar."
+
 #~ msgid ""
 #~ "Indicates whether to close the shell when an add or remove action is "
 #~ "performed."
 #~ msgstr ""
 #~ "Conseña si hai de zarrar la consola cuando se tien executao una aición "
 #~ "d'amestáu o desaniciu."
+
 #~ msgid "C_ustomize..."
 #~ msgstr "Pe_rsonalizar..."
+
 #~ msgid "A_IM/iChat:"
 #~ msgstr "A_IM/iChat:"
+
 #~ msgid "GNOME OnScreen Keyboard"
 #~ msgstr "Tecláu en pantalla de GNOME"
+
 #~ msgid "Icons"
 #~ msgstr "Iconos"
+
 #~ msgid "_Initiate click when stopping pointer movement"
 #~ msgstr "_Aniciar la pulsación cuando se pare'l movimientu del punteru"
+
 #~ msgid "S_ocks host:"
 #~ msgstr "S_ock host:"
-#~ msgid "_Run at start"
-#~ msgstr "_Executar al entamu"
+
 #~ msgid ""
 #~ "The typing monitor uses the notification area to display information. You "
 #~ "don't seem to have a notification area on your panel. You can add it by "
@@ -4729,50 +7874,64 @@ msgstr "Centru de control"
 #~ "Paez que vusté nun tien l'área de notificación nel so panel. Pue amestala "
 #~ "calcando col botón drechu sobro'l panel y seleicionando «Amestar al "
 #~ "panel...», seleicionando «Área de notificación» y calcando en «Amestar»."
+
 #~ msgid "URI currently transferring from"
 #~ msgstr "URI ta tresfiriendo de"
+
 #~ msgid "_Title:"
 #~ msgstr "_Títulu:"
-#~ msgid "Parent Window"
-#~ msgstr "Ventana raíz"
+
 #~ msgid "Models"
 #~ msgstr "Modelos"
+
 #~ msgid "Large White Pointer - Current"
 #~ msgstr "Punteru Blancu Grande - Actual"
+
 #~ msgid "All Files"
 #~ msgstr "Tolos Ficheros"
-#~ msgid "Windows"
-#~ msgstr "Ventanes"
+
 #~ msgid "_State/Province:"
 #~ msgstr "E_stáu/Provincia:"
+
 #~ msgid "_Document font:"
 #~ msgstr "Fonte de _documentu:"
+
 #~ msgid "_None"
 #~ msgstr "_Dengún"
+
 #~ msgid "Current _password:"
 #~ msgstr "Contraseña _actual:"
+
 #~ msgid "D_rag click:"
 #~ msgstr "Pulsación d'a_rrastre:"
+
 #~ msgid "_New password:"
 #~ msgstr "_Nueva contraseña:"
+
 #~ msgid "Unable to launch %s: %s"
 #~ msgstr "Nun pue llanzase %s: %s"
+
 #~ msgid "Minimize"
 #~ msgstr "Minimizar"
+
 #~ msgid "_Raise selected windows after an interval"
 #~ msgstr "_Elevar les ventanes seleicionaes tres d'un intervalu"
+
 #~ msgid "Close the control-center when a task is activated"
 #~ msgstr "Zarra'l centru de control cuando s'activa una xera"
+
 #~ msgid "Banshee Music Player"
 #~ msgstr "Reproductor de música Banshee"
+
 #~ msgid "The old and new passwords are the same."
 #~ msgstr "La contraseña vieya y la nueva son la mesma"
+
 #~ msgid "Slide Show"
 #~ msgstr "Amosar diapositives"
+
 #~ msgid "Copying '%s'"
 #~ msgstr "Copiando '%s'"
-#~ msgid "_Acceleration:"
-#~ msgstr "_Aceleración:"
+
 #~ msgid ""
 #~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
 #~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
@@ -4780,186 +7939,237 @@ msgstr "Centru de control"
 #~ "[Camudar el tema;gtk-theme-selector.desktop,Afitar les aplicaciones "
 #~ "preferíes;default-applications.desktop,Amestar imprentadora;gnome-cups-"
 #~ "manager.desktop]"
+
 #~ msgid "<b>Di_rect internet connection</b>"
 #~ msgstr "<b>Conexón Di_reuta a Internet</b>"
+
 #~ msgid "Orca with Magnifier"
 #~ msgstr "Orca con magnificador"
-#~ msgid "Beep when a key is pr_essed"
-#~ msgstr "Pitar al cal_car una tecla"
+
 #~ msgid "Show more _details"
 #~ msgstr "Amosar más _detalles"
+
 #~ msgid "Upgrade"
 #~ msgstr "Actualizar"
+
 #~ msgid "ETerm"
 #~ msgstr "ETerm"
+
 #~ msgid "HTTP Proxy Details"
 #~ msgstr "Detalles Proxy HTTP"
+
 #~ msgid "The GNOME configuration tool"
 #~ msgstr "Ferramienta de configuración de GNOME"
+
 #~ msgid "Large Pointer - Current"
 #~ msgstr "Punteru Grande - Actual"
+
 #~ msgid ""
 #~ "Unable to bring up the typing break properties dialog with the following "
 #~ "error: %s"
 #~ msgstr ""
 #~ "Nun pue amosase'l diálogu de les propiedaes del descansu d'escritura pol "
 #~ "siguiente fallu: %s"
+
 #~ msgid "%d Hz"
 #~ msgstr "%d Hz"
+
 #~ msgid "Remove from Favorites"
 #~ msgstr "Desaniciar de favoritos"
+
 #~ msgid "C_ity:"
 #~ msgstr "C_iudá:"
+
 #~ msgid "%l:%M %p"
 #~ msgstr "%H:%M"
+
 #~ msgid "Add to Startup Programs"
 #~ msgstr "Amestar a los programes d'entamu"
+
 #~ msgid "_Size:"
 #~ msgstr "_Tamañu:"
+
 #~ msgid "Customize Theme"
 #~ msgstr "Personalizar tema"
-#~ msgid "Beep when key is _accepted"
-#~ msgstr "Pitar cuando la tecla s'_aceute"
+
 #~ msgid "[WALLPAPER...]"
 #~ msgstr "[Tapiz…]"
+
 #~ msgid "Cale_ndar:"
 #~ msgstr "Cale_ndariu:"
-#~ msgid "Authenticated!"
-#~ msgstr "¡Reconocíu!"
+
 #~ msgid "Rhythmbox Music Player"
 #~ msgstr "Reproductor de música Rhythmbox"
+
 #~ msgid "NXterm"
 #~ msgstr "NXterm"
+
 #~ msgid "_Use the same proxy for all protocols"
 #~ msgstr "_Usar el mesmu proxy pa tolos protocolos"
+
 #~ msgid "Text"
 #~ msgstr "Testu"
+
 #~ msgid "Personal Info"
 #~ msgstr "Información Personal"
+
 #~ msgid "There was an error installing the selected file"
 #~ msgstr "Hebo un fallu al instalar el ficheru seleicionáu"
+
 #~ msgid "_Monochrome"
 #~ msgstr "_Monocromu"
+
 #~ msgid "_Preferred Applications"
 #~ msgstr "Aplicaciones _Preferíes"
+
 #~ msgid "Wor_k:"
 #~ msgstr "Traba_yu:"
+
 #~ msgid "Child exited unexpectedly"
 #~ msgstr "El fíu salió inesperadamente"
+
 #~ msgid "Don't check whether the notification area exists"
 #~ msgstr "Nun comprobar si esiste l'área de notificación"
+
 #~ msgid "VB_GR"
 #~ msgstr "VB_GR"
+
 #~ msgid "Unable to load stock icon '%s'\n"
 #~ msgstr "Nun pue cargase l'iconu de fábrica «%s»\n"
+
 #~ msgid "The current controls theme does not support color schemes."
 #~ msgstr "El tema actual de controles nun tien sofitu pa esquemes de colores."
-#~ msgid "seconds"
-#~ msgstr "segundos"
-#~ msgid "Large White Pointer"
-#~ msgstr "Punteru Blancu Grande"
+
 #~ msgid "Assistive Technologies Preferences"
 #~ msgstr "Preferencies de les teunoloxíes d'asistencia"
+
 #~ msgid "<b>_Manual proxy configuration</b>"
 #~ msgstr "<b>Configuración _Manual del proxy</b>"
-#~ msgid "Beep when _accessibility features are turned on or off"
-#~ msgstr ""
-#~ "Pitar cuando s'activen o desactiven les característiques d'_accesibilidá"
+
 #~ msgid "_Input boxes:"
 #~ msgstr "Caxes d'_entrada:"
+
 #~ msgid "_Window title font:"
 #~ msgstr "Fonte de títulu de _Ventana:"
-#~ msgid "_Mobile:"
-#~ msgstr "_Móvil:"
-#~ msgid "About %s"
-#~ msgstr "Tocante a %s"
+
 #~ msgid "Preferred Applications"
 #~ msgstr "Programes Preferíos"
-#~ msgid "_Medium"
-#~ msgstr "_Mediu"
+
 #~ msgid "Maximize"
 #~ msgstr "Maximizar"
+
 #~ msgid "Home"
 #~ msgstr "Entamu"
+
 #~ msgid "Appearance Preferences"
 #~ msgstr "Preferencies d'aspeutu"
+
 #~ msgid "_Break interval lasts:"
 #~ msgstr "D_uración del intervalu de descansu:"
+
 #~ msgid "Theme name must be present"
 #~ msgstr "El nome del tema tien de tar presente"
+
 #~ msgid "The theme \"%s\" has been installed."
 #~ msgstr "Instalóse'l tema «%s»."
+
 #~ msgid "Images"
 #~ msgstr "Imaxes"
-#~ msgid "_Application font:"
-#~ msgstr "Fonte de Progr_ama:"
+
 #~ msgid "_Postpone Break"
 #~ msgstr "_Posponer el descansu"
+
 #~ msgid "_Select windows when the mouse moves over them"
 #~ msgstr "_Seleicionar ventanes cuando'l mur se mueve sobro elles"
+
 #~ msgid "Upside Down"
 #~ msgstr "Boca abaxo"
+
 #~ msgid "Theme cannot be deleted"
 #~ msgstr "Nun pue desaniciase'l tema"
+
 #~ msgid "RXVT"
 #~ msgstr "RXVT"
+
 #~ msgid "U_sername:"
 #~ msgstr "_Usuariu:"
+
 #~ msgid "Roll up"
 #~ msgstr "Endolcar"
+
 #~ msgid "Gnopernicus"
 #~ msgstr "Gnopernicus"
+
 #~ msgid "Checking password..."
 #~ msgstr "Comprobando contraseña..."
+
 #~ msgid "Beep when key is _rejected"
 #~ msgstr "Pitar si se _refuga la tecla"
+
 #~ msgid "System error: %s."
 #~ msgstr "Error del sistema: %s."
+
 #~ msgid "Your password has been changed."
 #~ msgstr "La to clave foi camudada."
+
 #~ msgid "_Enable assistive technologies"
 #~ msgstr "Habilitar t_eunoloxíes d'asistencia"
+
 #~ msgid "Contact"
 #~ msgstr "Contautu"
+
 #~ msgid "_Vendors:"
 #~ msgstr "_Fabricantes:"
+
 #~ msgid "Jump to the Keyboard Accessibility dialog"
 #~ msgstr "Dir al diálogu de l'acesibilidá del tecláu"
+
 #~ msgid "State/Pro_vince:"
 #~ msgstr "Estáu/Pro_vincia:"
+
 #~ msgid "Copying files"
 #~ msgstr "Copiando ficheros"
+
 #~ msgid "Co_mmand:"
 #~ msgstr "Co_mandu:"
+
 #~ msgid "A_ssistant:"
 #~ msgstr "A_sistente:"
+
 #~ msgid "New themes have been successfully installed."
 #~ msgstr "Los nuevos temes instaláronse con ésitu."
+
 #~ msgid "_Description:"
 #~ msgstr "_Descripción:"
+
 #~ msgid "Konsole"
 #~ msgstr "Konsole"
+
 #~ msgid "Run at st_art"
 #~ msgstr "Exe_cutar al entamu"
-#~ msgid "Alert Buttons"
-#~ msgstr "Botones d'Avisu"
+
 #~ msgid "M_SN:"
 #~ msgstr "M_SN:"
+
 #~ msgid "Width of border around the label and image in the alert dialog"
 #~ msgstr ""
 #~ "Anchu al rodiu del berbesu de la etiqueta y semeya nel diálogu d'avisu"
+
 #~ msgid "White Pointer - Current"
 #~ msgstr "Punteru Blancu - Actual"
+
 #~ msgid "Best co_ntrast"
 #~ msgstr "Meyor co_ntraste"
+
 #~ msgid "page"
 #~ msgstr "páxina"
-#~ msgid "_Address:"
-#~ msgstr "_Direición:"
+
 #~ msgid "Internet"
 #~ msgstr "Internet"
+
 #~ msgid "That password was incorrect."
 #~ msgstr "La contraseña foi incorreuta."
+
 #~ msgid ""
 #~ "There was an error while trying to get the addressbook information\n"
 #~ "Evolution Data Server can't handle the protocol"
@@ -4967,484 +8177,631 @@ msgstr "Centru de control"
 #~ "Hebo un error intentando garrar la información de la llibreta de "
 #~ "direiciones\n"
 #~ "Servidor de Datos d'Evolution nun pudo afitar el protocolu"
+
 #~ msgid "Cannot start the preferences application for your window manager"
 #~ msgstr ""
 #~ "Nun se pue aniciar l'aplicación de preferencies pal so xestor de ventanes"
+
 #~ msgid "To URI"
 #~ msgstr "A URI"
+
 #~ msgid "_Ignore fast duplicate keypresses"
 #~ msgstr "_Inorar pulsaciones duplicaes rápides"
+
 #~ msgid "_Tooltips:"
 #~ msgstr "_Conseyos:"
-#~ msgid "File System"
-#~ msgstr "Sistema de Ficheros"
+
 #~ msgid "Apply New Theme"
 #~ msgstr "Aplicar el nuevu tema"
+
 #~ msgid "Window Border"
 #~ msgstr "Llende de la Ventana"
-#~ msgid "Network Proxy"
-#~ msgstr "Proxy de Rede"
+
 #~ msgid "Preview:"
 #~ msgstr "Vista previa:"
+
 #~ msgid "_Double-click titlebar to perform this action:"
 #~ msgstr "_Doble-click na barra de títulu pa facer esta aición:"
+
 #~ msgid "The current theme suggests a background."
 #~ msgstr "El tema actual suxer un tapiz."
+
 #~ msgid "Beep when a key is reje_cted"
 #~ msgstr "Pitar si se refu_ga la tecla"
+
 #~ msgid "Orca"
 #~ msgstr "Orca"
+
 #~ msgid "\"%s\" does not appear to be a valid theme."
 #~ msgstr "«%s» nun paez ser un tema válidu."
+
 #~ msgid "_Single click:"
 #~ msgstr "Pulsación _cenciella:"
+
 #~ msgid "Best _shapes"
 #~ msgstr "Meyores forme_s"
+
 #~ msgid "Proxy Configuration"
 #~ msgstr "Configuración del Proxy"
+
 #~ msgid "All_ow postponing of breaks"
 #~ msgstr "Permitir p_osponer los descansos"
+
 #~ msgid "_Windows:"
 #~ msgstr "_Ventanes:"
+
 #~ msgid "_Work:"
 #~ msgstr "_Trabayu:"
+
 #~ msgid "Disa_ble sticky keys if two keys are pressed together"
 #~ msgstr ""
 #~ "_Desactivar les tecles persistentes si se calquen dos tecles al empar"
-#~ msgid "Common Tasks"
-#~ msgstr "Xeres comunes"
+
 #~ msgid "Vendors"
 #~ msgstr "Fabricantes"
-#~ msgid "Rename..."
-#~ msgstr "Renomar..."
+
 #~ msgid "Standard XTerminal"
 #~ msgstr "XTerminal Estándar"
+
 #~ msgid "_Work interval lasts:"
 #~ msgstr "D_uración del intervalu de trabayu:"
+
 #~ msgid "_Trigger secondary click by holding down the primary button"
 #~ msgstr ""
 #~ "D_isparar la pulsación secundaria al caltener pulsáu el botón primariu"
+
 #~ msgid "GNOME Magnifier without Screen Reader"
 #~ msgstr "Magnificador de GNOME ensin llector de pantalla"
+
 #~ msgid ""
 #~ "if true, the control-center will close when a \"Common Task\" is "
 #~ "activated."
 #~ msgstr ""
 #~ "Si ye braero, el centru de control zarrarase cuando s'active una «Xera "
 #~ "común»."
+
 #~ msgid "Cou_ntry:"
 #~ msgstr "P_aís:"
+
 #~ msgid "D_ouble click:"
 #~ msgstr "Pulsación d_uble:"
+
 #~ msgid "Theme Installer"
 #~ msgstr "Instalador de temes"
+
 #~ msgid "Visual Assistance"
 #~ msgstr "Asistencia visual"
+
 #~ msgid "Open a dialog to specify the color"
 #~ msgstr "Abrir un diálogu pa especificar el color"
-#~ msgid "Move to Trash"
-#~ msgstr "Mover a la papelera"
+
 #~ msgid "_Yahoo:"
 #~ msgstr "_Yahoo:"
-#~ msgid "filename"
-#~ msgstr "nome de ficheru"
+
 #~ msgid "Take a break!"
 #~ msgstr "¡Asele un pocu!"
+
 #~ msgid "aterm"
 #~ msgstr "aterm"
+
 #~ msgid "_Interval before raising:"
 #~ msgstr "_Intervalu enantes d'elevar:"
+
 #~ msgid "Work _fax:"
 #~ msgstr "_Fax del trabayu:"
+
 #~ msgid "<b>Open</b>"
 #~ msgstr "<b>Abrir</b>"
+
 #~ msgid "Save _background image"
 #~ msgstr "Guardar imaxe de _fondu"
+
 #~ msgid "key not found [%s]\n"
 #~ msgstr "tecla non alcontrada [%s]\n"
+
 #~ msgid "Co_untry:"
 #~ msgstr "P_aís:"
+
 #~ msgid "Could not load the main interface"
 #~ msgstr "Nun fue a cargar la interfaz principal"
+
 #~ msgid "_Models:"
 #~ msgstr "_Modelos:"
-#~ msgid "minutes"
-#~ msgstr "minutos"
+
 #~ msgid "Colors"
 #~ msgstr "Colores"
+
 #~ msgid "New Document"
 #~ msgstr "Documentu nuevu"
+
 #~ msgid "The %s utility is not installed."
 #~ msgstr "La utilidá %s nun ta instalada."
+
 #~ msgid "Yesterday %l:%M %p"
 #~ msgstr "Ayeri %H:%M"
+
 #~ msgid "Theme Packages"
 #~ msgstr "Paquetes de temes"
+
 #~ msgid "_Only accept long keypresses"
 #~ msgstr "N_amái aceutar tecles calcaes durante ciertu tiempu"
-#~ msgid "Keyboard Shortcuts"
-#~ msgstr "Atayos del Tecláu"
+
 #~ msgid "About Me"
 #~ msgstr "Tocante a min"
+
 #~ msgid "Large Pointer"
 #~ msgstr "Punteru Grande"
-#~ msgid "Desktop"
-#~ msgstr "Escritoriu"
+
 #~ msgid "Apply Background"
 #~ msgstr "Aplicar tapiz"
+
 #~ msgid "Copying file: %u of %u"
 #~ msgstr "Copiando ficheru: %u de %u"
+
 #~ msgid "Installation for theme \"%s\" failed."
 #~ msgstr "La instalación del tema «%s» falló."
+
 #~ msgid "A system error has occurred"
 #~ msgstr "Hebo un fallu del sistema"
+
 #~ msgid "GNOME Theme %s correctly installed"
 #~ msgstr "El tema de GNOME %s instalóse correchamente"
+
 #~ msgid "N_one"
 #~ msgstr "D_engún"
+
 #~ msgid "E_xecute flag:"
 #~ msgstr "Etiqueta d'e_xecución:"
+
 #~ msgid "Delete"
 #~ msgstr "Desaniciar"
+
 #~ msgid "Start the page with the accessibility settings showing"
 #~ msgstr "Aniciar la páxina amosando la configuración d'accesibilidá"
+
 #~ msgid "Fonts"
 #~ msgstr "Fontes"
+
 #~ msgid "_Overwrite"
 #~ msgstr "_Sobroscribir"
+
 #~ msgid "The type of alert"
 #~ msgstr "El tipu d'alerta"
+
 #~ msgid "D_etails..."
 #~ msgstr "D_etalles..."
+
 #~ msgid "_Manager:"
 #~ msgstr "Al_ministrador:"
+
 #~ msgid "Less than one minute until the next break"
 #~ msgstr "Menos d'un minutu hasta'l siguiente descansu"
+
 #~ msgid "Gra_yscale"
 #~ msgstr "Escala de b_uxos"
+
 #~ msgid "Remove from System Items"
 #~ msgstr "Desaniciar d'elementos de sistema"
+
 #~ msgid "To move a window, press-and-hold this key then grab the window:"
 #~ msgstr ""
 #~ "Pa mover una ventana, caltenga calcada esta tecla y llueu arrastre la "
 #~ "ventana:"
+
 #~ msgid "_Profession:"
 #~ msgstr "_Profesión:"
-#~ msgid "Other"
-#~ msgstr "Otru"
+
 #~ msgid "The buttons shown in the alert dialog"
 #~ msgstr "Los botones que s'amuesen nel diálogu d'alerta"
+
 #~ msgid "Keyboard Preferences"
 #~ msgstr "Preferencies del tecláu"
+
 #~ msgid "%b %d %Y"
 #~ msgstr "%d %b %Y"
+
 #~ msgid "gesture|Disabled"
 #~ msgstr "Desactiváu"
+
 #~ msgid ""
 #~ "Indicates whether to close the shell when a start action is performed."
 #~ msgstr ""
 #~ "Conseña si hai de zarrar la consola cuando se tien executao una aición "
 #~ "d'aniciu."
+
 #~ msgid "_Department:"
 #~ msgstr "_Departamentu:"
+
 #~ msgid "Total number of URIs"
 #~ msgstr "Númberu total d'URIs"
+
 #~ msgid "_Meta"
 #~ msgstr "_Meta"
+
 #~ msgid "_Alt"
 #~ msgstr "_Alt"
+
 #~ msgid ""
 #~ "Just apply settings and quit (compatibility only; now handled by daemon)"
 #~ msgstr ""
 #~ "Namái aplicar la configuración y salir (namái por compatibilidad; remanáu "
 #~ "agora por un degorriu)"
+
 #~ msgid "H_yper"
 #~ msgstr "_Hiper"
+
 #~ msgid "Fraction of transfer currently completed"
 #~ msgstr "Fraición de tresferencia actual completa"
+
 #~ msgid "Close and _Log Out"
 #~ msgstr "Zarrar y _Salir"
+
 #~ msgid "Uninstall"
 #~ msgstr "Desinstalar"
-#~ msgid "_Full"
-#~ msgstr "C_ompletu"
+
 #~ msgid "Typing Break"
 #~ msgstr "Descansu d'escritura"
+
 #~ msgid "Exit shell on start action performed"
 #~ msgstr "Abandona la consola cuando se tien fecho una aición d'aniciu"
+
 #~ msgid "New Spreadsheet"
 #~ msgstr "Fueya de cálculu nueva"
+
 #~ msgid "_BGR"
 #~ msgstr "_BGR"
+
 #~ msgid "- GNOME Keyboard Preferences"
 #~ msgstr "- Preferencies del tecláu de GNOME"
+
 #~ msgid "Total URIs"
 #~ msgstr "URIs Totales"
+
 #~ msgid "Gnopernicus with Magnifier"
 #~ msgstr "Gnopernicus con magnificador"
+
 #~ msgid "Port:"
 #~ msgstr "Puertu:"
+
 #~ msgid "_Variants:"
 #~ msgstr "_Variantes:"
+
 #~ msgid "_Style:"
 #~ msgstr "E_stilu:"
+
 #~ msgid "IC_Q:"
 #~ msgstr "IC_Q:"
+
 #~ msgid "No Image"
 #~ msgstr "Nun hai Imaxe"
+
 #~ msgid "Change pa_ssword"
 #~ msgstr "Camudar la Contraseña"
-#~ msgid "_Authenticate"
-#~ msgstr "_Autenticar"
+
 #~ msgid "_Home page:"
 #~ msgstr "Pá_xina d'entamu:"
-#~ msgid "_Retype new password:"
-#~ msgstr "Volve_r a escribir la nueva contraseña:"
+
 #~ msgid "Save _As..."
 #~ msgstr "Guardar _como…"
+
 #~ msgid "Enable _Fingerprint Login..."
 #~ msgstr "Activar l'entamu sesión con _Buelga"
+
 #~ msgid "Disable _Fingerprint Login..."
 #~ msgstr "Desactivar l'entamu sesión con _Buelga"
+
 #~ msgid "An internal error occured"
 #~ msgstr "Hebo un fallu internu"
+
 #~ msgid "Select finger"
 #~ msgstr "Escoyer deu"
+
 #~ msgid "New Location..."
 #~ msgstr "Allugamientu nuevu..."
+
 #~ msgid "Location already exists"
 #~ msgstr "L'allugamientu yá existe"
+
 #~ msgid "Location:"
 #~ msgstr "Allugamientu"
+
 #~ msgid "The location already exists."
 #~ msgstr "L'allugamientu yá existe."
+
 #~ msgid "C_reate"
 #~ msgstr "C_rear"
+
 #~ msgid "Create New Location"
 #~ msgstr "Crear un allugamientu nuevu"
+
 #~ msgid "If set to true, then OpenType fonts will be thumbnailed."
 #~ msgstr ""
 #~ "Si ta afitao a «true», entós les tipografíes OpenType miniaturizaránse."
+
 #~ msgid "If set to true, then PCF fonts will be thumbnailed."
 #~ msgstr "Si ta afitao a «true», entós les tipografíes PFC miniaturizaránse."
+
 #~ msgid "If set to true, then TrueType fonts will be thumbnailed."
 #~ msgstr ""
 #~ "Si ta afitao a «true», entós les tipografíes TrueType miniaturizaránse."
+
 #~ msgid "If set to true, then Type1 fonts will be thumbnailed."
 #~ msgstr ""
 #~ "Si ta afitao a «true», entós les tipografíes Type1 miniaturizaránse."
-#~ msgid "_Details"
-#~ msgstr "_Detalles"
+
 #~ msgid "_Location name:"
 #~ msgstr "N_ome d'allugamientu:"
+
 #~ msgid ""
 #~ "Set this key to the command used to create thumbnails for Type1 fonts."
 #~ msgstr ""
 #~ "Pon nesta clave la orde qu'hai d'usar pa crear miniatures de les "
 #~ "tipografíes Type1."
+
 #~ msgid "Whether to thumbnail Type1 fonts"
 #~ msgstr "Conseña si hai de miniaturizar les tipografíes Type1"
+
 #~ msgid "Whether to thumbnail TrueType fonts"
 #~ msgstr "Conseña si hai de miniaturizar les tipografíes TrueType"
+
 #~ msgid "Whether to thumbnail PCF fonts"
 #~ msgstr "Conseña si hai de miniaturizar les tipografíes PCF"
+
 #~ msgid "Whether to thumbnail OpenType fonts"
 #~ msgstr "Conseña si hai de miniaturizar les tipografíes OpenType"
+
 #~ msgid "Thumbnail command for Type1 fonts"
 #~ msgstr "Comandu pa miniaturizar les tipografíes Type1"
+
 #~ msgid "Thumbnail command for TrueType fonts"
 #~ msgstr "Comandu pa miniaturizar les tipografíes TrueType"
+
 #~ msgid "Thumbnail command for PCF fonts"
 #~ msgstr "Comandu pa miniaturizar les tipografíes PCF"
+
 #~ msgid "Thumbnail command for OpenType fonts"
 #~ msgstr "Comandu pa miniaturizar les tipografíes OpenType"
+
 #~ msgid "Version:"
 #~ msgstr "Versión:"
+
 #~ msgid "Copyright:"
 #~ msgstr "Copyright:"
+
 #~ msgid "Description:"
 #~ msgstr "Descripción:"
+
 #~ msgid "usage: %s fontfile\n"
 #~ msgstr "usu: %s ficheru de tipografíes\n"
-#~ msgid "Name:"
-#~ msgstr "Nome:"
-#~ msgid "Style:"
-#~ msgstr "Estilu:"
+
 #~ msgid "Size:"
 #~ msgstr "Tamañu:"
+
 #~ msgid "Font Viewer"
 #~ msgstr "Visor de tipografíes"
+
 #~ msgid "Preview fonts"
 #~ msgstr "Vista previa de les tipografíes"
+
 #~ msgid "Text to thumbnail (default: Aa)"
 #~ msgstr "Testu a miniaturizar (predetermináu: Aa)"
+
 #~ msgid "Error parsing arguments: %s\n"
 #~ msgstr "Fallu al analizar los argumentos: %s\n"
+
 #~ msgid "TEXT"
 #~ msgstr "TESTU"
+
 #~ msgid "FONT-FILE OUTPUT-FILE"
 #~ msgstr "FICHERU-DE-TIPOGRAFÍA ARCHIVU-DE-SALIDA"
+
 #~ msgid "SIZE"
 #~ msgstr "TAMAÑU"
+
 #~ msgid "Place finger on reader"
 #~ msgstr "Pon el deu nel llector"
+
 #~ msgid "Swipe finger on reader"
 #~ msgstr "Pasa'l deu penriba'l llector"
+
 #~ msgid "Other finger: "
 #~ msgstr "Otru deu: "
+
 #~ msgid "Right index finger"
 #~ msgstr "Furabollos drechu"
+
 #~ msgid "Listen"
 #~ msgstr "Sentir"
-#~ msgid "_Delete Location"
-#~ msgstr "_Desaniciar allugamientu"
+
 #~ msgid "On"
 #~ msgstr "Encesu"
+
 #~ msgid "Flash entire _screen"
 #~ msgstr "Destellu de la pantalla _completa"
+
 #~ msgid "Flash _window titlebar"
 #~ msgstr "Destellu de la barra de títulu de la _ventana"
+
 #~ msgid "Show _visual feedback for the alert sound"
 #~ msgstr "Amosar rempuesta _visual pa les alertes de soníu"
+
 #~ msgid "Include _panel"
 #~ msgstr "Incluyir pa_nel"
+
 #~ msgid ""
 #~ "Changes to enable assistive technologies will not take effect until your "
 #~ "next log in."
 #~ msgstr ""
 #~ "Los cambeos p'activar les teunoloxíes d'asistencia nun tendrán efeutu "
 #~ "fasta que salga ya anicie sesión nuevamente."
+
 #~ msgid "Could not load user interface file: %s"
 #~ msgstr "Nun pudo cargase'l ficheru d'interfaz d'usuariu: %s"
+
 #~ msgid "Text beside items"
 #~ msgstr "Testu al delláu de los elementos"
+
 #~ msgid "Text below items"
 #~ msgstr "Testu baxo los elementos"
+
 #~ msgid "Solid color"
 #~ msgstr "Color sólidu"
+
 #~ msgid "Icons only"
 #~ msgstr "Namái iconos"
+
 #~ msgid "Horizontal gradient"
 #~ msgstr "Dilíu horizontal"
+
 #~ msgid "Upside-down"
 #~ msgstr "Al revés"
+
 #~ msgid "_Take a Break"
 #~ msgstr "_Tomar un descansu"
+
 #~ msgid "Vertical gradient"
 #~ msgstr "Dilíu Vertical"
+
 #~ msgid "Text only"
 #~ msgstr "Namái testu"
+
 #~ msgid "Telephone"
 #~ msgstr "Teléfonu"
+
 #~ msgid "Web"
 #~ msgstr "Web"
+
 #~ msgid "Email"
 #~ msgstr "Corréu-e"
+
 #~ msgid "Instant Messaging"
 #~ msgstr "Mensaxería nel Intre"
+
 #~ msgid "Work"
 #~ msgstr "Trabayu"
+
 #~ msgid "Job"
 #~ msgstr "Trabayu"
+
 #~ msgid "Change your password"
 #~ msgstr "Cambiar la to contraseña"
+
 #~ msgid "Hinting"
 #~ msgstr "Suxiriendo"
-#~ msgid "Preferences"
-#~ msgstr "Preferencies"
+
 #~ msgid "Image Viewer"
 #~ msgstr "Visor d'imáxenes"
+
 #~ msgid "Smoothing"
 #~ msgstr "Suavizáu"
+
 #~ msgid "Subpixel Order"
 #~ msgstr "Orde subpixel"
+
 #~ msgid "Instant Messenger"
 #~ msgstr "Mensaxería nel intre"
+
 #~ msgid "Terminal Emulator"
 #~ msgstr "Emulador de terminal"
+
 #~ msgid "Multimedia Player"
 #~ msgstr "Reproductor multimedia"
+
 #~ msgid "Mobility"
 #~ msgstr "Mobilidá"
+
 #~ msgid "Mail Reader"
 #~ msgstr "Llector de corréu"
+
 #~ msgid "Visual"
 #~ msgstr "Visual"
+
 #~ msgid "Video Player"
 #~ msgstr "Reproductor de vídeu"
-#~ msgid "Panel icon"
-#~ msgstr "Iconu de panel"
+
 #~ msgid "Web Browser"
 #~ msgstr "Restolador web"
+
 #~ msgid "Text Editor"
 #~ msgstr "Editor de Testu"
+
 #~ msgid "Dwell Click"
 #~ msgstr "Pulsación al posase"
+
 #~ msgid "Visual cues for sounds"
 #~ msgstr "Indicadores visuales pa soníos"
-#~ msgid "Mouse Orientation"
-#~ msgstr "Orientación del mur"
-#~ msgid "Locate Pointer"
-#~ msgstr "Llocalizar el punteru"
+
 #~ msgid "Titlebar Action"
 #~ msgstr "Aición de barra de titulu"
-#~ msgid "Install Failed"
-#~ msgstr "Falló la instalación"
+
 #~ msgid "Window Selection"
 #~ msgstr "Seleición de ventana"
+
 #~ msgid "Movement Key"
 #~ msgstr "Tecla de movimientu"
+
 #~ msgid "I_nstall Font"
 #~ msgstr "I_nstalar Fonte"
+
 #~ msgid ""
 #~ "You can also use the Dwell Click panel applet to choose the click type."
 #~ msgstr ""
 #~ "Tamién puedes usar la miniaplicación Dwell Click pa escoyer la triba "
 #~ "pulsación."
+
 #~ msgid "The new password must contain numeric or special character(s)."
 #~ msgstr "La nueva clave tien de contener númberos o carauteres especiales."
-#~ msgid "Accessible Lo_gin"
-#~ msgstr "Lo_gin accesible"
-#~ msgid "_Keyboard Accessibility"
-#~ msgstr "Acesibilidá _Tecláu"
+
 #~ msgid "Ignore Host List"
 #~ msgstr "Inorar llista d'Agospiadores"
-#~ msgid "Start %s"
-#~ msgstr "Entamar %s"
+
 #~ msgid "Open with \"%s\""
 #~ msgstr "Abrir con \"%s\""
+
 #~ msgid "Monitor: %s"
 #~ msgstr "Monitor: %s"
+
 #~ msgid "Hide on start (useful to preload the shell)"
 #~ msgstr "Anubrir nel entamu (afayadizo pa precargar la consola)"
+
 #~ msgid "Your filter \"%s\" does not match any items."
 #~ msgstr "El to filtru «%s» nun concasa con oxetu dalu"
+
 #~ msgid "Left index finger"
 #~ msgstr "Furabollos esquierdu"
+
 #~ msgid "Get more themes online"
 #~ msgstr "Obtener más temes en llinia"
+
 #~ msgid "Image"
 #~ msgstr "Imaxe"
+
 #~ msgid "Current network location"
 #~ msgstr "Allugamientu de la rede actual"
+
 #~ msgid ""
 #~ "URL for where to get more desktop backgrounds. If set to an empty string "
 #~ "the link will not appear."
 #~ msgstr ""
 #~ "URL na qu'obtener más fondos pal escritoriu. Si s'afita a una cadena "
 #~ "balera, l'enllaz nun apaez."
+
 #~ msgid "More themes URL"
 #~ msgstr "URL pa más temes"
+
 #~ msgid "More backgrounds URL"
 #~ msgstr "URL pa más fondos"
+
 #~ msgid "Get more backgrounds online"
 #~ msgstr "Obtener más fondos en llinia"
+
 #~ msgid ""
 #~ "URL for where to get more desktop themes. If set to an empty string the "
 #~ "link will not appear."
 #~ msgstr ""
 #~ "URL na qu'obtener más temes pal escritoriu. Si s'afita a una cadena "
 #~ "balera, l'enllaz nun apaez."
+
 #~ msgid ""
 #~ "<b>%s</b>\n"
 #~ "%s, %s\n"
@@ -5453,6 +8810,7 @@ msgstr "Centru de control"
 #~ "<b>%s</b>\n"
 #~ "%s, %s\n"
 #~ "Carpeta: %s"
+
 #~ msgid ""
 #~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
 #~ "Without the GNOME settings manager running, some preferences may not take "
@@ -5466,12 +8824,13 @@ msgstr "Centru de control"
 #~ "preferencies nun furrulen. Esto puede ser el síntoma d'un problema con "
 #~ "DBus o qu'un xestor de configuración que nun ye de GNOME (por exemplu "
 #~ "KDE) yá tea activu y engarriáu col xestor de configuración de GNOME."
-#~ msgid "Installed"
-#~ msgstr "Instalada"
+
 #~ msgid "Image missing"
 #~ msgstr "Falta la imaxe"
+
 #~ msgid "Stretch"
 #~ msgstr "Estiramientu"
+
 #~ msgid ""
 #~ "<b>%s</b>\n"
 #~ "%s\n"
@@ -5480,135 +8839,176 @@ msgstr "Centru de control"
 #~ "<b>%s</b>\n"
 #~ "%s\n"
 #~ "Carpeta: %s"
-#~ msgid "Move _Down"
-#~ msgstr "_Mover Abaxo"
-#~ msgid "Move _Up"
-#~ msgstr "M_over Arriba"
+
 #~ msgid "New windows u_se active window's layout"
 #~ msgstr "Les ventanes nueves u_sen la distribución de la ventana activa"
+
 #~ msgid "_Separate layout for each window"
 #~ msgstr "Separtar la _distribución pa cada ventana"
+
 #~ msgid "Sa_me image in all monitors"
 #~ msgstr "La _mesma imaxe en tolos monitores"
+
 #~ msgid "_Detect monitors"
 #~ msgstr "_Deteutar monitores"
+
 #~ msgid "_Show monitors in panel"
 #~ msgstr "_Amosar pantalles nel panel"
+
 #~ msgid "Change resolution and position of monitors"
 #~ msgstr "Camudar la resolución y posición de los monitores"
+
 #~ msgid "Monitor Preferences"
 #~ msgstr "Preferencies del monitor"
+
 #~ msgid "Monitors"
 #~ msgstr "Pantalles"
+
 #~ msgid "Customize the look of the desktop"
 #~ msgstr "Personaliza l'aspeutu del escritoriu"
+
 #~ msgid "Assign shortcut keys to commands"
 #~ msgstr "Da-y una combinación de tecles a comandos"
+
 #~ msgid "Set your keyboard preferences"
 #~ msgstr "Afitar les preferencies de tecláu"
+
 #~ msgid "Set your network proxy preferences"
 #~ msgstr "Afitar les preferencies de proxy de rede"
+
 #~ msgid "Set your window properties"
 #~ msgstr "Afitar les propiedaes de les ventanes"
+
 #~ msgid "Set your mouse preferences"
 #~ msgstr "Afitar les preferencies del mur"
+
 #~ msgid "Choose which accessibility features to enable when you log in"
 #~ msgstr ""
 #~ "Escueyi qué carauterístiques d'accesibilidá activar al aniciar sesión"
+
 #~ msgid "Choose a Keyboard Model"
 #~ msgstr "Escueyi un modelu de tecláu"
+
 #~ msgid "Choose type of click _beforehand"
 #~ msgstr "Escueyi'l tipu de pulsación d'an_temanu"
+
 #~ msgid "Select your default applications"
 #~ msgstr "Escueyi los tos programes predeterminaos"
+
 #~ msgid "Choose type of click with mo_use gestures"
 #~ msgstr "Escueyi'l tipu de pulsación con _xestos del mur"
+
 #~ msgid "Font size (default: 64)"
 #~ msgstr "Tamañu de la fonte (predetermináu: 64)"
+
 #~ msgid "Des_ktop font:"
 #~ msgstr "Fonte pal _escritoriu:"
+
 #~ msgid "_Fixed width font:"
 #~ msgstr "Fonte d'anchor _fixu:"
+
 #~ msgid ""
 #~ "The current theme suggests a font. Also, the last applied font suggestion "
 #~ "can be reverted."
 #~ msgstr ""
 #~ "El tema actual suxer una fonte. Arriendes, pue revertise la cabera "
 #~ "suxerencia de fonte aplicada."
+
 #~ msgid ""
 #~ "The current theme suggests a background. Also, the last applied font "
 #~ "suggestion can be reverted."
 #~ msgstr ""
 #~ "El tema actual suxer un tapiz. Arriendes, pue revertise la cabera "
 #~ "suxerencia de fonte aplicada."
+
 #~ msgid "The current theme suggests a background and a font."
 #~ msgstr "El tema actual suxer un tapiz y una fonte."
+
 #~ msgid "Specify the filename of a theme to install"
 #~ msgstr "Especifica'l nome de ficheru del tema a instalar"
+
 #~ msgid "Theme"
 #~ msgstr "Temes"
+
 #~ msgid "The current theme suggests a font."
 #~ msgstr "El tema actual suxer una fonte."
+
 #~ msgid "Would you like to apply it now, or keep your current theme?"
 #~ msgstr "¿Quies aplicalu agora, o caltener el so tema actual?"
+
 #~ msgid "No theme file location specified to install"
 #~ msgstr ""
 #~ "Nun s'especificó dengún allugamientu del ficheru del tema pa instalar"
+
 #~ msgid ""
 #~ "This theme will not look as intended because the required icon theme '%s' "
 #~ "is not installed."
 #~ msgstr ""
 #~ "Esti tema nun va amosase como se pretende porque'l el tema d'iconos "
 #~ "necesariu «%s» nun ta instaláu."
+
 #~ msgid ""
 #~ "This theme will not look as intended because the required window manager "
 #~ "theme '%s' is not installed."
 #~ msgstr ""
 #~ "Esti tema nun va amosase como se pretende porque'l el tema del xestor de "
 #~ "ventanes necesariu «%s» nun ta instaláu."
+
 #~ msgid ""
 #~ "This theme will not look as intended because the required GTK+ theme '%s' "
 #~ "is not installed."
 #~ msgstr ""
 #~ "Esti tema nun va amosase como se pretende porque'l el tema GTK+ necesariu "
 #~ "«%s» nun ta instaláu."
+
 #~ msgid "Would you like to delete this theme?"
 #~ msgstr "¿Quies desaniciar esti tema?"
+
 #~ msgid "Select Theme"
 #~ msgstr "Esbilla un tema"
+
 #~ msgid "The theme already exists. Would you like to replace it?"
 #~ msgstr "Yá esiste'l tema. ¿Prestaríate trocalu?"
+
 #~ msgid ""
 #~ "The current theme suggests a button layout. Also, the last button layout "
 #~ "suggestion can be reverted."
 #~ msgstr ""
 #~ "El tema actual suxer un diseñu de botón. Arriendes, la cabera suxerencia "
 #~ "de disposición de los botones puede revertise."
+
 #~ msgid ""
 #~ "The current theme suggests a font and a button layout. Also, the last "
 #~ "applied button_layout suggestion can be reverted."
 #~ msgstr ""
 #~ "El tema actual suxer un fondu, y un diseñu de botón. Arriendes, la cabera "
 #~ "suxerencia de disposición de los botones aplicada, puede revertise."
+
 #~ msgid "Revert Button Layout"
 #~ msgstr "Revertir diseñu de botón"
+
 #~ msgid ""
 #~ "Do you want to apply these settings system-wide, so that they are also "
 #~ "used for package installation and other system services?"
 #~ msgstr ""
 #~ "¿Quies aplicar estes opciones a tol sistema pa que s'usen tamién na "
 #~ "instalación de paquetes y otros servicios del sistema?"
+
 #~ msgid "%d %s by %d %s"
 #~ msgstr "%d %s por %d %s"
+
 #~ msgid "Click <b>Change password</b> to change your password."
 #~ msgstr "Caca en <b>Camudar Contraseña</b> pa camudar la contraseña."
+
 #~ msgid "Please type your password in the <b>New password</b> field."
 #~ msgstr "Teclea la contraseña nel campu <b>Contraseña nueva</b>."
+
 #~ msgid ""
 #~ "Please type your password again in the <b>Retype new password</b> field."
 #~ msgstr ""
 #~ "Por favor, teclea la contraseña otra vegada nel campu <b>Reescribi la "
 #~ "nueva contraseña</b>."
+
 #~ msgid ""
 #~ "To change your password, enter your current password in the field below "
 #~ "and click <b>Authenticate</b>.\n"
@@ -5619,8 +9019,10 @@ msgstr "Centru de control"
 #~ "calca <b>Autentificar</b>.\n"
 #~ "Dempués de que seyas autentificáu, introduz la to nueva clave, "
 #~ "reintroduciéndola pa verificala y calca <b>Camudar clave</b>."
+
 #~ msgid "Font may be too large"
 #~ msgstr "La fonte seique seya enforma grande"
+
 #~ msgid ""
 #~ "The font selected is %d point large, and may make it difficult to "
 #~ "effectively use the computer.  It is recommended that you select a size "
@@ -5635,6 +9037,7 @@ msgstr "Centru de control"
 #~ msgstr[1] ""
 #~ "La fonte seleicionada ye %d puntos de grande, y pue facer abegoso l'usu "
 #~ "del equipu. Encamiéntase que seleicione un tamañu menor de %d."
+
 #~ msgid ""
 #~ "The font selected is %d point large, and may make it difficult to "
 #~ "effectively use the computer.  It is recommended that you select a "
@@ -5649,61 +9052,89 @@ msgstr "Centru de control"
 #~ msgstr[1] ""
 #~ "La fonte seleicionada ye %d puntos de grande, y pue facer abegoso l'usu "
 #~ "del equipu. Encamiéntase que seleicione un tamañu menor."
+
 #~ msgid "Use previous font"
 #~ msgstr "Usar la fonte anterior"
+
 #~ msgid "Use selected font"
 #~ msgstr "Usar la fonte seleicionada"
+
 #~ msgid "Apply Font"
 #~ msgstr "Aplicar fonte"
+
 #~ msgid "Revert Font"
 #~ msgstr "Revertir la fonte"
+
 #~ msgid "ZIP/_Postal code:"
 #~ msgstr "Códigu Postal:"
+
 #~ msgid "_GroupWise:"
 #~ msgstr "_Groupwise:"
+
 #~ msgid "_XMPP:"
 #~ msgstr "_XMPP:"
+
 #~ msgid "_ZIP/Postal code:"
 #~ msgstr "Códigu _Postal:"
+
 #~ msgid "Make Default"
 #~ msgstr "Facer Predetermináu"
+
 #~ msgid "The monitor configuration has been saved"
 #~ msgstr "Guardóse la configuración del monitor"
+
 #~ msgid "This configuration will be used the next time someone logs in."
 #~ msgstr ""
 #~ "Esta configuración va usase la próxima vegada que daquién se rexistre."
+
 #~ msgid "Could not set the default configuration for monitors"
 #~ msgstr "Nun pudo afitase la configuración predefinía pa los monitores"
+
 #~ msgid "List of keyboard layouts selected for usage"
 #~ msgstr "Llista de distribuciones teclaos seleicionaos pa usar"
+
 #~ msgid "Move the selected keyboard layout down in the list"
 #~ msgstr "Mover la distribución de tecláu seleicionada p'abaxo na llista"
+
 #~ msgid "Move the selected keyboard layout up in the list"
 #~ msgstr "Mover la distribución de tecláu seleicionada p'arriba na llista"
+
 #~ msgid "Print a diagram of the selected keyboard layout"
 #~ msgstr "Imprentar una diagrama de la distribución de tecláu selecionada"
+
 #~ msgid "Remove the selected keyboard layout from the list"
 #~ msgstr "Esborrar la distribución de tecláu selecionada de la llista"
+
 #~ msgid "Select a keyboard layout to be added to the list"
 #~ msgstr "Seleicionar una distribución de tecláu p'amestala a la llista"
+
 #~ msgid "Take a break now (next in %dm)"
 #~ msgstr "Descansar agora (prósimu en %dm)"
+
 #~ msgid "Take a break now (next in less than one minute)"
 #~ msgstr "Descansar agora (prósimu en menos d'un minutu)"
+
 #~ msgid "Changes to visual system bell take effect immediately."
 #~ msgstr "Los cambeos na campana visual del sistema van facer efeutu darréu."
+
 #~ msgid "Enable _visual system bell"
 #~ msgstr "Activar campana _visual del sistema"
+
 #~ msgid "%s must be a regular file\n"
 #~ msgstr "%s tien de ser un ficheru regular\n"
+
 #~ msgid "PKEXEC_UID must be set to an integer value"
 #~ msgstr "PKEXEC_UID tien de conseñase como un valor enteru"
+
 #~ msgid "%s must be owned by you\n"
 #~ msgstr "has de ser el propietariu de %s\n"
+
 #~ msgid "Could not get information for %s: %s\n"
 #~ msgstr "Nun pudo alcontrase información de %s: %s\n"
+
 #~ msgid "Could not open %s: %s\n"
 #~ msgstr "Nun pudo abrise %s: %s\n"
+
 #~ msgid ""
 #~ "Usage: %s SOURCE_FILE DEST_NAME\n"
 #~ "\n"
@@ -5730,84 +9161,101 @@ msgstr "Centru de control"
 #~ "NOME_DEST - nome relativu del ficheru instaláu.  Esti va ponese nel\n"
 #~ "            direutoriu de sistema pa les configuraciones RANDR,\n"
 #~ "            de manera que'l resultáu típicu va ser %s/NOME_DEST\n"
+
 #~ msgid "The source filename must be absolute"
 #~ msgstr "El nome del ficheru orixe tien de ser absolutu"
+
 #~ msgid "This program can only be used by the root user"
 #~ msgstr "Esti programa namái pue usalu'l superusuariu"
+
 #~ msgctxt "Home folder"
 #~ msgid "Home"
 #~ msgstr "Direutoriu Personal"
+
 #~ msgid "_Show..."
 #~ msgstr "_Amosar..."
+
 #~ msgid "Remove from recent menu"
 #~ msgstr "Desaniciar del menú de recientes"
+
 #~ msgid "Purge all the recent items"
 #~ msgstr "Purgar tolos elementos recientes"
-#~ msgid ""
-#~ "Authentication is required to install multi-monitor settings for all users"
-#~ msgstr ""
-#~ "Ye necesario autentificase pa instalar configuraciones multi-monitor pa "
-#~ "tolos usuarios"
+
 #~ msgid "%s must not have any directory components\n"
 #~ msgstr "%s nun pue tener dengún componente de direutoriu\n"
+
 #~ msgid "Could not open %s/%s: %s\n"
 #~ msgstr "Nun pudo abrise %s/%s: %s\n"
+
 #~ msgid "%s must be a directory\n"
 #~ msgstr "%s tien de ser un direutoriu\n"
+
 #~ msgid "Could not rename %s to %s: %s\n"
 #~ msgstr "Nun se pudo renomar %s a %s: %s\n"
+
 #~ msgid "This program must only be run through pkexec(1)"
 #~ msgstr "Esti programa namái pue executase per aciu de pkexec(1)"
+
 #~ msgid "- GNOME Default Applications"
 #~ msgstr "- Aplicaciones GNOME predeterminaes"
+
 #~ msgid "Install multi-monitor settings for the whole system"
 #~ msgstr "Instalar configuraciones multi-monitor pa tol sistema"
+
 #~ msgid ""
 #~ "To test your double-click settings, try to double-click on the light bulb."
 #~ msgstr ""
 #~ "Pa probar les configuraciones del duble clic, intenta facer duble clic "
 #~ "nel focu"
+
 #~ msgid ""
 #~ "Set this key to the command used to create thumbnails for OpenType fonts."
 #~ msgstr ""
 #~ "Pon nesta clave la orde qu'hai d'usar pa crear miniatures de les "
 #~ "tipografíes OpenType."
+
 #~ msgid ""
 #~ "Set this key to the command used to create thumbnails for TrueType fonts."
 #~ msgstr ""
 #~ "Pon nesta clave la orde qu'hai d'usar pa crear miniatures de les "
 #~ "tipografíes TrueType."
+
 #~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
 #~ msgstr ""
 #~ "Pon nesta clave la orde qu'hai d'usar pa crear miniatures de les "
 #~ "tipografíes PCF."
+
 #~ msgid "Failed to create temporary directory"
 #~ msgstr "Falló al crear la carpeta temporal"
+
 #~ msgid ""
 #~ "Lock screen after a certain duration to help prevent repetitive keyboard "
 #~ "use injuries"
 #~ msgstr ""
 #~ "Bloquia la pantalla dempués d'un ciertu intervalu p'ayudar a prevenir les "
 #~ "lesiones pol usu repetitivu del tecláu"
+
 #~ msgid ""
 #~ "Indicates whether to close the shell when a help action is performed."
 #~ msgstr ""
 #~ "Conseña si hai de zarrar la consola cuando se tien executao una aición "
 #~ "d'ayuda."
+
 #~ msgid "Exit shell on help action performed"
 #~ msgstr "Abandona la consola cuando se tien fecho una aición d'ayuda"
-#~ msgid "Help"
-#~ msgstr "Ayuda"
+
 #~ msgid "There was an error displaying help: %s"
 #~ msgstr "Hebo un fallu al amosar l'ayuda: %s"
-#~ msgid "Set your personal information"
-#~ msgstr "Configura la to información personal"
+
 #~ msgid "Error setting default browser: %s"
 #~ msgstr "Fallu na configuración del restolador predetermináu: %s"
+
 #~ msgid "Error setting default mailer: %s"
 #~ msgstr "Fallu na configuración del veceru de corréu: %s"
+
 #~ msgid "Start the preferred visual assistive technology"
 #~ msgstr "Aniciar la teunoloxía d'asistencia visual preferida"
+
 #~ msgid ""
 #~ "The current theme suggests a background, a font and a button layout. "
 #~ "Also, the last applied font and button layout suggestion can be reverted."
@@ -5815,6 +9263,7 @@ msgstr "Centru de control"
 #~ "El tema actual suxer un fondu, una fonte y un diseñu de botón. Arriendes, "
 #~ "la cabera suxerencia de fonte y de disposición de los botones aplicada, "
 #~ "pue revertise."
+
 #~ msgid ""
 #~ "The current theme suggests a background and a button layout. Also, the "
 #~ "last applied font and button layout suggestion can be reverted."
@@ -5822,6 +9271,7 @@ msgstr "Centru de control"
 #~ "El tema actual suxer un fondu, y un diseñu de botón. Arriendes, la cabera "
 #~ "suxerencia de fonte y de disposición de los botones aplicada, pue "
 #~ "revertise."
+
 #~ msgid ""
 #~ "The current theme suggests a background, a font and a button layout. "
 #~ "Also, the last applied button layout suggestion can be reverted."
@@ -5829,38 +9279,42 @@ msgstr "Centru de control"
 #~ "El tema actual suxer un fondu, una fonte y un diseñu de botón. Arriendes, "
 #~ "la cabera suxerencia de disposición de los botones aplicada, pue "
 #~ "revertise."
+
 #~ msgid ""
 #~ "Set this to your current location name. This is used to determine the "
 #~ "appropriate network proxy configuration."
 #~ msgstr ""
 #~ "Afítalo al nome del to allugamientu actual. Úsase pa determinar la "
 #~ "configuración afayadiza del proxy de rede"
+
 #~ msgid ""
 #~ "The current theme suggests a background and a font. Also, the last "
 #~ "applied font suggestion can be reverted."
 #~ msgstr ""
 #~ "El tema actual suxer un tapiz y una fonte. Arriendes, pue revertise la "
 #~ "cabera suxerencia de fonte aplicada."
+
 #~ msgid "Exit shell on upgrade or uninstall action performed"
 #~ msgstr ""
 #~ "Abandona la consola cuando se tien fecho una aición d'anovamientu o "
 #~ "desinstalación"
+
 #~ msgid ""
 #~ "Indicates whether to close the shell when an upgrade or uninstall action "
 #~ "is performed."
 #~ msgstr ""
 #~ "Conseña si hai de zarrar la consola cuando se tien executao una aición "
 #~ "d'anovamientu o desinstalación."
-#~ msgid "Re_fresh rate:"
-#~ msgstr "Frecuencia de _refrescu:"
-#~ msgid "Filter"
-#~ msgstr "Filtru"
+
 #~ msgid "_Type to test settings:"
 #~ msgstr "_Escribi pa comprobar la configuración:"
+
 #~ msgid "Rendering"
 #~ msgstr "Renderizáu"
+
 #~ msgid "Sub_pixel smoothing (LCDs)"
 #~ msgstr "Suavizáu de sub_pixel (LCDs)"
+
 #~ msgid "translator-credits"
 #~ msgstr ""
 #~ "Launchpad Contributions:\n"
@@ -5871,4 +9325,3 @@ msgstr "Centru de control"
 #~ "  Rodrigo Toraño Valle https://launchpad.net/~rodrigo-torval\n"
 #~ "  Xandru Martino https://launchpad.net/~xandru-martino\n"
 #~ "  Xuacu Saturio https://launchpad.net/~xuacusk8"
-

--- a/po/ast.po~
+++ b/po/ast.po~
@@ -1,0 +1,5874 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# translation of control-center-2.0.po to Asturian
+# Asturian translation for control-center
+# Copyright (c) 2007 Rosetta Contributors and Canonical Ltd 2007
+# This file is distributed under the same license as the control-center package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2007.
+# Xose S. Puente <xspuente@gmail.com>, 2007.
+# Xandru Armesto <xandru@softastur.org>, 2010, 2011.
+msgid ""
+msgstr ""
+"Project-Id-Version: control-center-2.0\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2011-10-23 12:52+0000\n"
+"PO-Revision-Date: 2011-10-23 19:59+0100\n"
+"Last-Translator: ivarela <ivarela@softastur.org>\n"
+"Language-Team: Softastur <alministradores@softastur.org>\n"
+"Language: ast\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2011-10-23 16:28+0000\n"
+"X-Generator: Launchpad (build 14170)\n"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "Fondu de pantalla"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change the background"
+msgstr "Cambia'l fondu"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Fondu d'escritoriu;Pantalla;Escritoriu;"
+
+#: ../panels/background/background.ui.h:1
+msgid "Add wallpaper"
+msgstr "Amestar fondu d'escritoriu"
+
+#: ../panels/background/background.ui.h:2
+msgid "Center"
+msgstr "Centru"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:4
+msgid "Changes throughout the day"
+msgstr "Camuda a lo llargo'l día"
+
+#: ../panels/background/background.ui.h:5
+msgid "Fill"
+msgstr "Rellenu"
+
+#: ../panels/background/background.ui.h:6
+msgid "Remove wallpaper"
+msgstr "Quitar fondu"
+
+#: ../panels/background/background.ui.h:7
+msgid "Scale"
+msgstr "Escala"
+
+#: ../panels/background/background.ui.h:8
+msgid "Span"
+msgstr "Espander"
+
+#: ../panels/background/background.ui.h:9
+msgid "Tile"
+msgstr "Mosaicu"
+
+#: ../panels/background/background.ui.h:10
+msgid "Zoom"
+msgstr "Zoom"
+
+#: ../panels/background/bg-colors-source.c:46
+msgid "Horizontal Gradient"
+msgstr "Dilíu Horizontal"
+
+#: ../panels/background/bg-colors-source.c:47
+msgid "Vertical Gradient"
+msgstr "Dilíu Vertical"
+
+#: ../panels/background/bg-colors-source.c:48
+msgid "Solid Color"
+msgstr "Color Sólido"
+
+#: ../panels/background/cc-background-panel.c:1001
+#: ../panels/user-accounts/um-photo-dialog.c:217
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+msgid "Browse for more pictures"
+msgstr "Restolar pa buscar más imáxenes"
+
+#: ../panels/background/cc-background-panel.c:1093
+msgid "Current background"
+msgstr "Fondu actual"
+
+#: ../panels/background/cc-background-panel.c:1203
+msgid "Wallpapers"
+msgstr "Fondos d'escritoriu"
+
+#: ../panels/background/cc-background-panel.c:1210
+msgid "Pictures Folder"
+msgstr "Carpeta d'imáxenes"
+
+#: ../panels/background/cc-background-panel.c:1217
+msgid "Colors & Gradients"
+msgstr "Colores y dilíos"
+
+#: ../panels/background/cc-background-panel.c:1225
+msgid "Flickr"
+msgstr "Flickr"
+
+#: ../panels/background/cc-background-item.c:148
+msgid "multiple sizes"
+msgstr "tamaños múltiples"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:152
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:281
+msgid "No Desktop Background"
+msgstr "Ensin fondu d'escritoriu"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:281
+msgid "Yes"
+msgstr "Sí"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:281
+msgid "No"
+msgstr "Non"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:393
+msgid "Bluetooth is disabled"
+msgstr "El Bluetooth ta desactiváu"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:398
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "El Bluetooth ta físicamente desactiváu"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:402
+msgid "No Bluetooth adapters found"
+msgstr "Nun s'atoparon adautadores de Bluetooth"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:535
+msgid "Visibility"
+msgstr "Visibilidá"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:539
+#, c-format
+msgid "Visibility of “%s”"
+msgstr "Visibilidá de “%s”"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:583
+#, c-format
+msgid "Remove '%s' from the list of devices?"
+msgstr "Desaniciar '%s' de la llista de preseos?"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:585
+msgid "If you remove the device, you will have to set it up again before next use."
+msgstr "Si quites el preséu, tendrás de configuralu otra vegada enantes d'usalu nuevamente"
+
+#: ../panels/bluetooth/bluetooth.ui.h:1
+msgid "Address"
+msgstr "Direición/es"
+
+#: ../panels/bluetooth/bluetooth.ui.h:2
+msgid "Browse Files..."
+msgstr "Restolar por ficheros…"
+
+#: ../panels/bluetooth/bluetooth.ui.h:3
+msgid "Connection"
+msgstr "Conexón"
+
+#: ../panels/bluetooth/bluetooth.ui.h:4
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Keyboard Settings"
+msgstr "Axustes del tecláu"
+
+#: ../panels/bluetooth/bluetooth.ui.h:5
+msgid "Mouse and Touchpad Settings"
+msgstr "Axustes del Mur y «touchpad»"
+
+#: ../panels/bluetooth/bluetooth.ui.h:6
+msgid "Paired"
+msgstr "Emparexáu"
+
+#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
+#: ../panels/bluetooth/bluetooth.ui.h:8
+msgctxt "Power"
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/bluetooth.ui.h:9
+msgid "Send Files..."
+msgstr "Unviar ficheros..."
+
+#: ../panels/bluetooth/bluetooth.ui.h:10
+#: ../panels/universal-access/uap.ui.h:60
+msgid "Sound Settings"
+msgstr "Axustes de soníu"
+
+#: ../panels/bluetooth/bluetooth.ui.h:11
+msgid "Type"
+msgstr "Triba"
+
+#. TRANSLATORS: device type
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
+#: ../panels/network/panel-common.c:99
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
+msgid "Configure Bluetooth settings"
+msgstr "Configurar axustes de Bluetooth"
+
+#. Add some common languages first
+#: ../panels/common/cc-common-language.c:513
+msgid "English"
+msgstr "Inglés"
+
+#: ../panels/common/cc-common-language.c:515
+msgid "British English"
+msgstr "Inglés Británicu"
+
+#: ../panels/common/cc-common-language.c:517
+msgid "German"
+msgstr "Alemán"
+
+#: ../panels/common/cc-common-language.c:519
+msgid "French"
+msgstr "Francés"
+
+#: ../panels/common/cc-common-language.c:521
+msgid "Spanish"
+msgstr "Español"
+
+#: ../panels/common/cc-common-language.c:523
+msgid "Chinese (simplified)"
+msgstr "Chinu (Simplificáu)"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:552
+msgid "United States"
+msgstr "Estaos Xuníos"
+
+#: ../panels/common/cc-common-language.c:553
+msgid "Germany"
+msgstr "Alemaña"
+
+#: ../panels/common/cc-common-language.c:554
+msgid "France"
+msgstr "Francia"
+
+#: ../panels/common/cc-common-language.c:555
+msgid "Spain"
+msgstr "Spain"
+
+#: ../panels/common/cc-common-language.c:556
+msgid "China"
+msgstr "China"
+
+#: ../panels/common/cc-language-chooser.c:119
+msgid "Other..."
+msgstr "Otru..."
+
+#: ../panels/common/cc-language-chooser.c:290
+msgid "Select a region"
+msgstr "Esbilla una rexón"
+
+#: ../panels/common/gdm-languages.c:774
+msgid "Unspecified"
+msgstr "Ensin especificar"
+
+#: ../panels/common/language-chooser.ui.h:1
+msgid "Select a language"
+msgstr "Esbilla una llingua"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/printers/new-printer-dialog.ui.h:4
+#: ../panels/user-accounts/um-user-panel.c:448
+msgid "_Cancel"
+msgstr "_Encaboxar"
+
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/universal-access/gconf-property-editor.c:1609
+msgid "_Select"
+msgstr "_Seleicionar"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "24-hour"
+msgstr "24 hores"
+
+#. Translator: this is the separator between hours and minutes, like in HH:MM
+#: ../panels/datetime/datetime.ui.h:3
+msgid ":"
+msgstr ":"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "AM/PM"
+msgstr "AM/PM"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "April"
+msgstr "abril"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "August"
+msgstr "agostu"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "Day"
+msgstr "Día"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "December"
+msgstr "avientu"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "February"
+msgstr "febreru"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "January"
+msgstr "xineru"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "July"
+msgstr "xunetu"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "June"
+msgstr "xunu"
+
+#: ../panels/datetime/datetime.ui.h:13
+msgid "March"
+msgstr "marzu"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "May"
+msgstr "mayu"
+
+#: ../panels/datetime/datetime.ui.h:15
+msgid "Month"
+msgstr "Mes"
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "November"
+msgstr "payares"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "October"
+msgstr "ochobre"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "September"
+msgstr "septiembre"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Set the time one hour ahead."
+msgstr "Axustar la hora una hora p'alantre."
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Set the time one hour back."
+msgstr "Axustar la hora una hora p'atrás."
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Set the time one minute ahead."
+msgstr "Axustar la hora un minutu p'alantre."
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Set the time one minute back."
+msgstr "Axustar la hora un minutu p'atrás."
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Switch between AM and PM."
+msgstr "Alternar entre AM y PM"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Year"
+msgstr "Añu"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "_City:"
+msgstr "_Ciudá:"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "_Network Time"
+msgstr "_Hora de rede"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "_Region:"
+msgstr "_Rexón:"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Clock;Timezone;Location;"
+msgstr "Reló;Estaya horaria;Allugamientu;"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+msgid "Date and Time"
+msgstr "Data y hora"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Date and Time preferences panel"
+msgstr "Panel de preferencies de la data y hora"
+
+#: ../panels/display/display-capplet.ui.h:1
+#: ../panels/display/cc-display-panel.c:641
+msgid "Monitor"
+msgstr "Monitor"
+
+#: ../panels/display/display-capplet.ui.h:2
+msgid "Note: may limit resolution options"
+msgstr "Nota: puedes llendar les opciones de resolución"
+
+#: ../panels/display/display-capplet.ui.h:3
+msgid "R_otation:"
+msgstr "R_otación:"
+
+#: ../panels/display/display-capplet.ui.h:4
+msgid "_Detect Displays"
+msgstr "_Deteutar pantalles"
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:6
+msgid "_Mirror displays"
+msgstr "_Espeyar pantalles"
+
+#: ../panels/display/display-capplet.ui.h:7
+msgid "_Resolution:"
+msgstr "_Resolución:"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Change resolution and position of monitors and projectors"
+msgstr "Camudar la resolución y posición de los monitores y proyeutores"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Displays"
+msgstr "Pantalles"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr "Panel;Proyeutor;xranrd;Pantalla;Resolución;Anovar;"
+
+#: ../panels/display/cc-display-panel.c:477
+msgctxt "display panel, rotation"
+msgid "Normal"
+msgstr "Normal"
+
+#: ../panels/display/cc-display-panel.c:478
+msgctxt "display panel, rotation"
+msgid "Counterclockwise"
+msgstr "Antihorariu"
+
+#: ../panels/display/cc-display-panel.c:479
+msgctxt "display panel, rotation"
+msgid "Clockwise"
+msgstr "Horariu"
+
+#: ../panels/display/cc-display-panel.c:480
+msgctxt "display panel, rotation"
+msgid "180 Degrees"
+msgstr "180 graos"
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../panels/display/cc-display-panel.c:617
+msgid "Mirror Displays"
+msgstr "Espeyar pantalles"
+
+#: ../panels/display/cc-display-panel.c:747
+#, c-format
+msgid "%d x %d (%s)"
+msgstr "%d x %d (%s)"
+
+#: ../panels/display/cc-display-panel.c:749
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#: ../panels/display/cc-display-panel.c:1656
+msgid "Drag to change primary display."
+msgstr "Arrastrar pa camudar la pantalla principal."
+
+#: ../panels/display/cc-display-panel.c:1714
+msgid "Select a monitor to change its properties; drag it to rearrange its placement."
+msgstr "Esbillar un monitor pa cambiar les sos propiedaes; arrastralu reubícalu."
+
+#: ../panels/display/cc-display-panel.c:2102
+msgid "%a %R"
+msgstr "%a %R"
+
+#: ../panels/display/cc-display-panel.c:2104
+msgid "%a %l:%M %p"
+msgstr "%a %H:%M"
+
+#: ../panels/display/cc-display-panel.c:2350
+msgid "Could not save the monitor configuration"
+msgstr "Nun pudo guardase la configuración del monitor"
+
+#: ../panels/display/cc-display-panel.c:2375
+msgid "Could not get session bus while applying display configuration"
+msgstr "Nun pudo algamase el bus de sesión al aplicar la configuración de pantalla"
+
+#: ../panels/display/cc-display-panel.c:2420
+msgid "Could not detect displays"
+msgstr "Nun pudieron detectase pantalles"
+
+#: ../panels/display/cc-display-panel.c:2614
+msgid "Could not get screen information"
+msgstr "Nun pudo algamase información de pantalla"
+
+#. Translators: VESA is an techncial acronym, don't translate it.
+#: ../panels/info/cc-info-panel.c:402
+#, c-format
+msgid "VESA: %s"
+msgstr "VESA: %s"
+
+#. TRANSLATORS: device type
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:426
+#: ../panels/network/panel-common.c:79
+#: ../panels/network/panel-common.c:158
+msgid "Unknown"
+msgstr "Desconocíu"
+
+#. translators: This is the type of architecture, for example:
+#. * "64-bit" or "32-bit"
+#: ../panels/info/cc-info-panel.c:587
+#, c-format
+msgid "%d-bit"
+msgstr "%d-bit"
+
+#: ../panels/info/cc-info-panel.c:744
+msgid "Unknown model"
+msgstr "Modelu desconocíu"
+
+#: ../panels/info/cc-info-panel.c:827
+msgid "The next login will attempt to use the standard experience."
+msgstr "El siguiente arranque de sesión intentará usar la decoración estándar."
+
+#: ../panels/info/cc-info-panel.c:829
+msgid "The next login will use the fallback mode intended for unsupported graphics hardware."
+msgstr "El siguiente arranque de sesión usará el mou alternativu, pensáu pa hardware de gráficos non soportáu."
+
+#. translators: The hardware is not able to run GNOME 3's
+#. * shell, so we use the GNOME "Fallback" session
+#: ../panels/info/cc-info-panel.c:871
+msgctxt "Experience"
+msgid "Fallback"
+msgstr "Reserva"
+
+#. translators: The hardware is able to run GNOME 3's
+#. * shell, also called "Standard" experience
+#: ../panels/info/cc-info-panel.c:877
+msgctxt "Experience"
+msgid "Standard"
+msgstr "Estándar"
+
+#: ../panels/info/cc-info-panel.c:1200
+msgid "Ask what to do"
+msgstr "Entrugar qué facer"
+
+#: ../panels/info/cc-info-panel.c:1204
+msgid "Do nothing"
+msgstr "Nun facer nada"
+
+#: ../panels/info/cc-info-panel.c:1208
+msgid "Open folder"
+msgstr "Abrir carpeta"
+
+#: ../panels/info/cc-info-panel.c:1319
+msgid "Select an application for audio CDs"
+msgstr "Escoyer una aplicación pa CD de soníu"
+
+#: ../panels/info/cc-info-panel.c:1320
+msgid "Select an application for video DVDs"
+msgstr "Escoyer una aplicación pa DVD de videu"
+
+#: ../panels/info/cc-info-panel.c:1321
+msgid "Select an application to run when a music player is connected"
+msgstr "Escoyer una aplicación pa executar cuando se coneuta un reproductor de música"
+
+#: ../panels/info/cc-info-panel.c:1322
+msgid "Select an application to run when a camera is connected"
+msgstr "Esbillar una aplicación qu'executar cuando se coneuta una cámara"
+
+#: ../panels/info/cc-info-panel.c:1323
+msgid "Select an application for software CDs"
+msgstr "Esbillar una aplicación pa CD de software"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1335
+msgid "audio DVD"
+msgstr "DVD de soníu"
+
+#: ../panels/info/cc-info-panel.c:1336
+msgid "blank Blu-ray disc"
+msgstr "discu Blu-ray virxe"
+
+#: ../panels/info/cc-info-panel.c:1337
+msgid "blank CD disc"
+msgstr "discu CD virxe"
+
+#: ../panels/info/cc-info-panel.c:1338
+msgid "blank DVD disc"
+msgstr "DVD virxe"
+
+#: ../panels/info/cc-info-panel.c:1339
+msgid "blank HD DVD disc"
+msgstr "discu HD DVD virxe"
+
+#: ../panels/info/cc-info-panel.c:1340
+msgid "Blu-ray video disc"
+msgstr "Discu Blu-ray de videu"
+
+#: ../panels/info/cc-info-panel.c:1341
+msgid "e-book reader"
+msgstr "llector de llibros electrónicos"
+
+#: ../panels/info/cc-info-panel.c:1342
+msgid "HD DVD video disc"
+msgstr "Discu HD DVD de videu"
+
+#: ../panels/info/cc-info-panel.c:1343
+msgid "Picture CD"
+msgstr "Discu d'imáxenes Picture CD"
+
+#: ../panels/info/cc-info-panel.c:1344
+msgid "Super Video CD"
+msgstr "CD de Super Videu"
+
+#: ../panels/info/cc-info-panel.c:1345
+msgid "Video CD"
+msgstr "CD de videu"
+
+#: ../panels/info/cc-info-panel.c:1474
+#: ../panels/keyboard/keyboard-shortcuts.c:1802
+msgid "Section"
+msgstr "Estaya"
+
+#: ../panels/info/cc-info-panel.c:1483
+#: ../panels/info/info.ui.h:15
+msgid "Overview"
+msgstr "Vista xeneral"
+
+#: ../panels/info/cc-info-panel.c:1489
+#: ../panels/info/info.ui.h:4
+msgid "Default Applications"
+msgstr "Aplicaciones predeterminaes"
+
+#: ../panels/info/cc-info-panel.c:1494
+#: ../panels/info/info.ui.h:17
+msgid "Removable Media"
+msgstr "Medios Estrayibles"
+
+#: ../panels/info/cc-info-panel.c:1499
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "Gráficos."
+
+#: ../panels/info/cc-info-panel.c:1700
+#, c-format
+msgid "Version %s"
+msgstr "Versión %s"
+
+#: ../panels/info/cc-info-panel.c:1750
+msgid "Install Updates"
+msgstr "Instalar Anovamientos"
+
+#: ../panels/info/cc-info-panel.c:1754
+msgid "System Up-To-Date"
+msgstr "Anovar el sistema"
+
+#: ../panels/info/cc-info-panel.c:1758
+msgid "Checking for Updates"
+msgstr "Comprobando anovamientos"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+msgid "System Info"
+msgstr "Información del sistema"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "System Information"
+msgstr "Información del sistema"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid "device;system;information;memory;processor;version;default;application;fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr "peséu;sistema;información;memoria;procesador;versión;predetermináu;aplicación;alternativu;preferíu;cd;dvd;usb;audio;videu;discu;estrayible;mediu;autoexecutar;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Acti_on:"
+msgstr "Aici_ón:"
+
+#: ../panels/info/info.ui.h:2
+msgid "CD _audio:"
+msgstr "CD de _soníu:"
+
+#: ../panels/info/info.ui.h:3
+msgid "Calculating..."
+msgstr "Calculando…"
+
+#: ../panels/info/info.ui.h:5
+msgid "Device name"
+msgstr "Nome del preséu"
+
+#: ../panels/info/info.ui.h:6
+msgid "Disk"
+msgstr "Discu"
+
+#: ../panels/info/info.ui.h:7
+msgid "Driver"
+msgstr "Controlador"
+
+#: ../panels/info/info.ui.h:8
+msgid "Experience"
+msgstr "Esperiencia"
+
+#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
+#: ../panels/info/info.ui.h:10
+msgid "Forced _Fallback Mode"
+msgstr "_Forzar mou alternativu"
+
+#: ../panels/info/info.ui.h:12
+msgid "M_usic"
+msgstr "_Música"
+
+#: ../panels/info/info.ui.h:13
+msgid "Memory"
+msgstr "Memoria"
+
+#: ../panels/info/info.ui.h:14
+msgid "OS type"
+msgstr "Triba de SO"
+
+#: ../panels/info/info.ui.h:16
+msgid "Processor"
+msgstr "Procesador"
+
+#: ../panels/info/info.ui.h:18
+msgid "Select how media should be handled"
+msgstr "Escoyer cómo hai que remanar los soportes"
+
+#: ../panels/info/info.ui.h:19
+msgid "Select how other media should be handled"
+msgstr "Escoyer cómo hai que remanar otros soportes"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Calendar"
+msgstr "_Calendariu"
+
+#: ../panels/info/info.ui.h:21
+msgid "_DVD video:"
+msgstr "_DVD de videu:"
+
+#: ../panels/info/info.ui.h:22
+msgid "_Mail"
+msgstr "_Corréu"
+
+#: ../panels/info/info.ui.h:23
+msgid "_Music player:"
+msgstr "Reproductor de _música:"
+
+#: ../panels/info/info.ui.h:24
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Enxamás entrugar nin arrancar programes al introducir soportes"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Other Media..."
+msgstr "_Otros soportes…"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Photos"
+msgstr "_Semeyes"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Photos:"
+msgstr "_Semeyes:"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Software:"
+msgstr "_Software:"
+
+#: ../panels/info/info.ui.h:29
+msgid "_Type:"
+msgstr "_Triba:"
+
+#: ../panels/info/info.ui.h:30
+msgid "_Video"
+msgstr "_Videu"
+
+#: ../panels/info/info.ui.h:31
+msgid "_Web"
+msgstr "_Web"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Eject"
+msgstr "Espulsar"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Launch media player"
+msgstr "Llanzar el reproductor multimedia"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Next track"
+msgstr "Pista siguiente"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Pause playback"
+msgstr "Posar la reproducción"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Play (or play/pause)"
+msgstr "Reproducir (o reproducir/posar)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Previous track"
+msgstr "Pista anterior"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Sound and Media"
+msgstr "Soníu y medios"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "Parar la reproducción"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Volume down"
+msgstr "Baxar volume"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Volume mute"
+msgstr "Silenciar"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Volume up"
+msgstr "Xubir volume"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Home folder"
+msgstr "Carpeta personal"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch calculator"
+msgstr "Llanzar la calculadora"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3
+msgid "Launch email client"
+msgstr "Llanzar el veceru de corréu-e"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch help browser"
+msgstr "Llanzar el visor d'ayuda"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch web browser"
+msgstr "Llanzar restolador web"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launchers"
+msgstr "Llanzadores"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Search"
+msgstr "Guetar"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "Lock screen"
+msgstr "Candar la pantalla"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Colar"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+#: ../panels/region/gnome-region-panel.ui.h:24
+msgid "System"
+msgstr "Sistema"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+msgid "Decrease text size"
+msgstr "Menguar el tamañu del testu:"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Increase text size"
+msgstr "Aumentar el tamañu del testu:"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Magnifier zoom in"
+msgstr "Ampliación del magnificador"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Magnifier zoom out"
+msgstr "Reducción del magnificador"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Toggle contrast"
+msgstr "Cambiar contraste"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Toggle magnifier"
+msgstr "Conmutar l'ampliador"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Toggle on-screen keyboard"
+msgstr "Conmutar el tecláu de pantalla"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Toggle screen reader"
+msgstr "Conmutar el llector de pantalla"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
+msgid "Universal Access"
+msgstr "Accesu universal"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr "Combinación nueva..."
+
+#: ../panels/keyboard/eggcellrendererkeys.c:164
+#: ../panels/keyboard/eggcellrendererkeys.c:165
+msgid "Accelerator key"
+msgstr "Tecla Aceleradora"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:174
+#: ../panels/keyboard/eggcellrendererkeys.c:175
+msgid "Accelerator modifiers"
+msgstr "Modificadores del Acelerador"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:183
+#: ../panels/keyboard/eggcellrendererkeys.c:184
+msgid "Accelerator keycode"
+msgstr "Códigu de tecla de la combinación"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:194
+msgid "Accel Mode"
+msgstr "Mou de la combinación"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:195
+msgid "The type of accelerator."
+msgstr "El tipu d'acelerador."
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/eggcellrendererkeys.c:243
+#: ../panels/keyboard/keyboard-shortcuts.c:1191
+#: ../panels/sound/gvc-mixer-control.c:1086
+#: ../panels/user-accounts/um-fingerprint-dialog.c:177
+#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+msgid "Disabled"
+msgstr "Deshabilitáu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Change keyboard settings"
+msgstr "Camudar la configuración del tecláu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "Keyboard"
+msgstr "Tecláu"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Atayu;Repetir;Parpaguiar;"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:646
+#: ../panels/keyboard/keyboard-shortcuts.c:654
+#: ../panels/keyboard/keyboard-shortcuts.c:966
+#: ../panels/keyboard/keyboard-shortcuts.c:1564
+#: ../panels/keyboard/keyboard-shortcuts.c:1568
+msgid "Custom Shortcuts"
+msgstr "Combinación personalizada"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:814
+msgid "<Unknown Action>"
+msgstr "<Aición desconocida>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1217
+msgid "Error saving the new shortcut"
+msgstr "Error al guardar l'atayu nuevu"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1350
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"Nun pue usase la combinación de tecles «%s» porque fadríase enforma abegoso escribir usando esta tecla.\n"
+"Por favor, téntelo con una tecla como Control, Alt o Mayús. al mesmu tiempu."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1380
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"La combinación «%s» yá ta usándose pa\n"
+"«%s»"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1385
+#, c-format
+msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "Si reasigna la combinación a «%s» desactivaráse la combinación «%s»."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1391
+msgid "_Reassign"
+msgstr "_Reasignar"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1503
+msgid "Too many custom shortcuts"
+msgstr "Demasiaos atayos personalizaos"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1855
+msgid "Action"
+msgstr "Aición"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1878
+msgid "Shortcut"
+msgstr "Atayu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "C_ommand:"
+msgstr "C_omandu:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "Cursor Blinking"
+msgstr "Parpaguéu del cursor"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "Cursor _blinks in text fields"
+msgstr "El cursor pa_rpaguea nos campos de testu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "Cursor blink speed"
+msgstr "Velocidá de parpaguéu del cursor"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "Custom Shortcut"
+msgstr "Combinación personalizada"
+
+#. fast acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "Fast"
+msgstr "Rápidu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "Les pulsaciones de tecles _repítense cuando la tecla se caltién calcada"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "Layout Settings"
+msgstr "Configuración del formatu"
+
+#. long delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+#: ../panels/universal-access/uap.ui.h:38
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Long"
+msgstr "Llargu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgid "Repeat Keys"
+msgstr "Repetir tecles"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "Velocidá de repetición de les tecles"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgid "S_peed:"
+msgstr "Veloci_dá:"
+
+#. short delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+#: ../panels/mouse/gnome-mouse-properties.ui.h:24
+#: ../panels/universal-access/uap.ui.h:54
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Short"
+msgstr "Curtiu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Shortcuts"
+msgstr "Atayos"
+
+#. slow acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+#: ../panels/mouse/gnome-mouse-properties.ui.h:26
+msgid "Slow"
+msgstr "Lentu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "To edit a shortcut, click the row and hold down the new keys or press Backspace to clear."
+msgstr "Pa editar un atayu nuevu calca na filera y caltén primíes les tecles nueves, o calca Retrocesu pa desaniciar."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+#: ../panels/universal-access/uap.ui.h:67
+msgid "Typing"
+msgstr "Escribiendo"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+msgid "_Delay:"
+msgstr "_Retrasu:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+msgid "_Name:"
+msgstr "_Nome:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "_Speed:"
+msgstr "_Velocidá:"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:305
+msgid "Error logging into the account"
+msgstr "Fallua al arrancar la sesión na cuenta"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:351
+msgid "Expired credentials. Please log in again."
+msgstr "Les credenciales gandieron. Arranca sesión otra vuelta."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:354
+msgid "_Log In"
+msgstr "_Arrancar sesión"
+
+#. translators: This is the title of the "Add Account" dialogue.
+#. * The title is not visible when using GNOME Shell
+#: ../panels/online-accounts/cc-online-accounts-panel.c:461
+msgid "Add Account"
+msgstr "Amestar cuenta"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:466
+msgid "To add a new account, first select the account type"
+msgstr "P'amestar una cuenta nueva, escueyi primero la triba de cuenta"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:469
+msgid "Account Type:"
+msgstr "Triba de cuenta:"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Add..."
+msgstr "_Amestar..."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:555
+msgid "Error creating account"
+msgstr "Fallu al criar la cuenta"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:589
+msgid "Error removing account"
+msgstr "Fallu al desaniciar la cuenta"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:625
+msgid "Are you sure you want to remove the account?"
+msgstr "¿Tas seguru de que quies desaniciar la cuenta?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:627
+msgid "This will not remove the account on the server."
+msgstr "Esto nun desanicia la cuenta nel sirvidor"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:628
+msgid "_Remove"
+msgstr "_Desaniciar"
+
+#. Translators: those are keywords for the online-accounts control-center panel
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+msgstr "Google;Facebook;Twitter;Yahoo;Web;En llinia;Chat;Calendariu;Corréu-e;Contautu;"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
+msgid "Manage online accounts"
+msgstr "Xestionar cuentes en llinia"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid "Online Accounts"
+msgstr "Cuentes en llinia"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "Select an account"
+msgstr "Escueyi una cuenta"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:520
+msgid "Low on toner"
+msgstr "Tóner baxo"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:522
+msgid "Out of toner"
+msgstr "Ensin tóner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:525
+msgid "Low on developer"
+msgstr "Nivel de revelador baxo"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:528
+msgid "Out of developer"
+msgstr "Ensin revelador"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:530
+msgid "Low on a marker supply"
+msgstr "Marcador baxo"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:532
+msgid "Out of a marker supply"
+msgstr "Ensin marcador"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:534
+msgid "Open cover"
+msgstr "Abrir cubierta"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:536
+msgid "Open door"
+msgstr "Abrir puerta"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:538
+msgid "Low on paper"
+msgstr "Nivel de papel baxo"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:540
+msgid "Out of paper"
+msgstr "Ensin papel"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:542
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Ensin conexón"
+
+#. Translators: Someone has paused the Printer
+#: ../panels/printers/cc-printers-panel.c:544
+msgctxt "printer state"
+msgid "Paused"
+msgstr "Posáu"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:546
+msgid "Waste receptacle almost full"
+msgstr "Recipiente de residuos casi enllenu"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:548
+msgid "Waste receptacle full"
+msgstr "Receptáculu de residuos enllenu"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:550
+msgid "The optical photo conductor is near end of life"
+msgstr "El conductor ópticu ta cerca del final de la so vida"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:552
+msgid "The optical photo conductor is no longer functioning"
+msgstr "El conductor ópticu yá nun funciona"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:724
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Sollerte"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:728
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Procesando"
+
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Paráu"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:851
+msgid "Toner Level"
+msgstr "Nivel de tóner"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:854
+msgid "Ink Level"
+msgstr "Nivel de tinta"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:857
+msgid "Supply Level"
+msgstr "Nivel del suministru"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:872
+#: ../panels/printers/cc-printers-panel.c:1258
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u activu"
+msgstr[1] "%u activos"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:977
+msgid "No printers available"
+msgstr "Nun hai imprentadores disponibles"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/cc-printers-panel.c:1301
+msgctxt "print job"
+msgid "Pending"
+msgstr "N'espera"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/cc-printers-panel.c:1305
+msgctxt "print job"
+msgid "Held"
+msgstr "Reteníu"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/cc-printers-panel.c:1309
+msgctxt "print job"
+msgid "Processing"
+msgstr "Procesando"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/cc-printers-panel.c:1313
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Paráu"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/cc-printers-panel.c:1317
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Encaboxáu"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/cc-printers-panel.c:1321
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Torgáu"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/cc-printers-panel.c:1325
+msgctxt "print job"
+msgid "Completed"
+msgstr "Completáu"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/cc-printers-panel.c:1408
+msgid "Job Title"
+msgstr "Títulu del Trabayu"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/cc-printers-panel.c:1417
+msgid "Job State"
+msgstr "Estáu del trabayu"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/cc-printers-panel.c:1423
+msgid "Time"
+msgstr "Tiempu"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:2019
+msgid "Failed to add new printer."
+msgstr "Falló al amestar una imprentadora nueva."
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2223
+#: ../panels/printers/cc-printers-panel.c:2237
+msgid "Test page"
+msgstr "Páxina de prueba"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2484
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Nun se pudo cargar la IU: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Change printer settings"
+msgstr "Cambiar la configuración de la imprentadora"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Imprentadora;Cola;Imprentar;Papel;Tinta;Tóner;"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: ../panels/printers/pp-new-printer-dialog.c:148
+msgid "Printers"
+msgstr "Imprentadores"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "A_ddress:"
+msgstr "D_ireicion/es:"
+
+#: ../panels/printers/new-printer-dialog.ui.h:2
+msgid "Add a New Printer"
+msgstr "Amestar una imprentadora nueva"
+
+#: ../panels/printers/new-printer-dialog.ui.h:3
+msgid "_Add"
+msgstr "_Amestar"
+
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "_Search by Address"
+msgstr "Gu_etar por direición"
+
+#: ../panels/printers/pp-new-printer-dialog.c:654
+msgid "Getting devices..."
+msgstr "Obteniendo dispositivos…"
+
+#. Translators: No localy connected printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1230
+msgid "No local printers found"
+msgstr "Nun s'atoparon imprentadores llocales"
+
+#. Translators: No network printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1243
+msgid "No network printers found"
+msgstr "Nun s'atoparon imprentadores de rede"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1335
+msgid "FirewallD is not running. Network printer detection needs services mdns, ipp, ipp-client and samba-client enabled on firewall."
+msgstr "FirewallD nun ta n'execución. La deteición d'imprentadores de rede necesita que los servicios  mdns, ipp, ipp-client y samba-client tean activaos nel tornafueos."
+
+#. Translators: Column of devices which can be installed
+#: ../panels/printers/pp-new-printer-dialog.c:1363
+#: ../panels/printers/pp-new-printer-dialog.c:1368
+msgid "Devices"
+msgstr "Preseos"
+
+#. Translators: Local means local printers
+#: ../panels/printers/pp-new-printer-dialog.c:1393
+msgctxt "printer type"
+msgid "Local"
+msgstr "Llocal"
+
+#. Translators: Network means network printers
+#: ../panels/printers/pp-new-printer-dialog.c:1395
+msgctxt "printer type"
+msgid "Network"
+msgstr "Rede"
+
+#. Translators: Device types column (network or local)
+#: ../panels/printers/pp-new-printer-dialog.c:1436
+msgid "Device types"
+msgstr "Tribes de dispositivos"
+
+#. Translators: Name of job which makes printer to autoconfigure itself
+#: ../panels/printers/pp-new-printer-dialog.c:1737
+msgid "Automatic configuration"
+msgstr "Configuración automática"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1818
+msgid "Opening firewall for mDNS connections"
+msgstr "Abrir el tornafueos pa conexones mDNS"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1827
+msgid "Opening firewall for Samba connections"
+msgstr "Abrir el tornafueos pa conexones Samba"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1836
+msgid "Opening firewall for IPP connections"
+msgstr "Abrir el tornafueos pa conexones IPP"
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:2
+msgid "Active Print Jobs"
+msgstr "Trabayos d'imprentación activos"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:4
+msgid "Add New Printer"
+msgstr "Amestar imprentadora nueva"
+
+#: ../panels/printers/printers.ui.h:5
+msgid "Allowed users"
+msgstr "Usuarios permitíos"
+
+#: ../panels/printers/printers.ui.h:6
+#: ../panels/network/cc-network-panel.c:1990
+#: ../panels/network/cc-network-panel.c:1993
+#: ../panels/network/network.ui.h:11
+msgid "IP Address"
+msgstr "Direición IP"
+
+#: ../panels/printers/printers.ui.h:7
+msgid "Jobs"
+msgstr "Trabayos"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:9
+msgid "Location"
+msgstr "Allugamientu"
+
+#: ../panels/printers/printers.ui.h:10
+msgid "Model"
+msgstr "Modelu"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:12
+msgid "Print _Test Page"
+msgstr "Impren_tar páxina de preba"
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:14
+msgid "Printer Options"
+msgstr "Opciones d'Imprentación"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:16
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"El serviciu del sistema d'imprentación\n"
+"paez nun tar disponible."
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:19
+msgid "Supply"
+msgstr "Suministru"
+
+#. Translators: Switch back to printer's info tab
+#: ../panels/printers/printers.ui.h:21
+msgid "_Back"
+msgstr "_Atrás"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:23
+msgid "_Default"
+msgstr "_Predetermináu"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:25
+msgid "_Options"
+msgstr "Opciones"
+
+#. Tanslators: Switch to tab containing printer's jobs
+#: ../panels/printers/printers.ui.h:27
+msgid "_Show"
+msgstr "_Amosar"
+
+#: ../panels/region/gnome-region-panel-formats.c:142
+msgid "Imperial"
+msgstr "Imperial"
+
+#: ../panels/region/gnome-region-panel-formats.c:144
+msgid "Metric"
+msgstr "Métricu"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
+msgid "Choose a Layout"
+msgstr "Escueyi una distribución"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
+msgid "Preview"
+msgstr "Vista previa"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
+msgid "Select an input source to add"
+msgstr "Esbillar una fonte d'entrada qu'amestar"
+
+#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
+msgid "Keyboard Layout Options"
+msgstr "Opciones de distribución del tecláu"
+
+#: ../panels/region/gnome-region-panel.ui.h:1
+msgid "Allow different layouts for individual windows"
+msgstr "Permitir diferentes distribuciones pa cada ventana"
+
+#: ../panels/region/gnome-region-panel.ui.h:2
+#: ../panels/region/gnome-region-panel-system.c:406
+msgid "Copy Settings..."
+msgstr "Copiar configuración..."
+
+#: ../panels/region/gnome-region-panel.ui.h:3
+msgid "Currency"
+msgstr "Divises"
+
+#: ../panels/region/gnome-region-panel.ui.h:4
+msgid "Dates"
+msgstr "Dates"
+
+#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
+#: ../panels/region/gnome-region-panel.ui.h:6
+msgid "Display language:"
+msgstr "Amosar llingua:"
+
+#: ../panels/region/gnome-region-panel.ui.h:7
+msgid "Examples"
+msgstr "Exemplos"
+
+#: ../panels/region/gnome-region-panel.ui.h:8
+msgid "Format:"
+msgstr "Formatu:"
+
+#: ../panels/region/gnome-region-panel.ui.h:9
+msgid "Formats"
+msgstr "Formatos"
+
+#: ../panels/region/gnome-region-panel.ui.h:10
+msgid "Input source:"
+msgstr "Fonte d'entrada:"
+
+#: ../panels/region/gnome-region-panel.ui.h:11
+msgid "Install languages..."
+msgstr "Instalar llingües…"
+
+#: ../panels/region/gnome-region-panel.ui.h:12
+msgid "Language"
+msgstr "Llinguax"
+
+#: ../panels/region/gnome-region-panel.ui.h:13
+msgid "Layouts"
+msgstr "Distribuciones"
+
+#: ../panels/region/gnome-region-panel.ui.h:14
+msgid "Measurement"
+msgstr "Midida"
+
+#: ../panels/region/gnome-region-panel.ui.h:15
+msgid "New windows use the default layout"
+msgstr "Les ventanes nueves usen la distribución predeterminada"
+
+#: ../panels/region/gnome-region-panel.ui.h:16
+msgid "New windows use the previous window's layout"
+msgstr "Les ventanes nueves usen la distribución de la ventana activa"
+
+#: ../panels/region/gnome-region-panel.ui.h:17
+msgid "Numbers"
+msgstr "Númberos"
+
+#: ../panels/region/gnome-region-panel.ui.h:18
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Region and Language"
+msgstr "Rexón y llingua"
+
+#: ../panels/region/gnome-region-panel.ui.h:19
+msgid ""
+"Replace the current keyboard layout settings with the\n"
+"default settings"
+msgstr ""
+"Trocar la configuración actual de tecláu pola\n"
+"configuración por defeutu"
+
+#: ../panels/region/gnome-region-panel.ui.h:21
+msgid "Reset to De_faults"
+msgstr "Restablecer valores _predeterminaos"
+
+#: ../panels/region/gnome-region-panel.ui.h:22
+msgid "Select a display language (change will be applied next time you log in)"
+msgstr "Esbilla una llingua p'amosar (el cambéu va aplicase la próxima vegada qu'anicies sesión)"
+
+#: ../panels/region/gnome-region-panel.ui.h:23
+msgid "Select a region (change will be applied the next time you log in)"
+msgstr "Esbilla una rexón (el cambéu va aplicase la próxima vegada qu'anicies sesión)"
+
+#: ../panels/region/gnome-region-panel.ui.h:25
+msgid "System settings"
+msgstr "Axustes del sistema"
+
+#: ../panels/region/gnome-region-panel.ui.h:26
+#: ../panels/region/gnome-region-panel-system.c:400
+msgid "The login screen, system accounts and new user accounts use the system-wide Region and Language settings. You may change the system settings to match yours."
+msgstr "La pantalla d'aniciu de sesión, les cuentes de sistema y les nueves cuentes d'usuariu usen los axustes de rexón y llingua. Pues camudar los axustes del sistema pa que correspuendan a les tuyes."
+
+#: ../panels/region/gnome-region-panel.ui.h:27
+msgid "Times"
+msgstr "Vegaes"
+
+#: ../panels/region/gnome-region-panel.ui.h:28
+msgid "Use the same layout for all windows"
+msgstr "Usar la mesma distribución pa toles ventanes"
+
+#: ../panels/region/gnome-region-panel.ui.h:29
+msgid "View and edit keyboard layout options"
+msgstr "Ver y editar les opciones de distribución de tecláu"
+
+#: ../panels/region/gnome-region-panel.ui.h:30
+msgid "Your settings"
+msgstr "Los tos axustes"
+
+#: ../panels/region/gnome-region-panel.ui.h:31
+msgid "_Options..."
+msgstr "_Opciones..."
+
+#: ../panels/region/gnome-region-panel-system.c:395
+msgid "The login screen, system accounts and new user accounts use the system-wide Region and Language settings."
+msgstr "La pantalla d'aniciu de sesión, les cuentes de sistema y les nueves cuentes d'usuariu usen los axustes de rexón y llingua."
+
+#: ../panels/region/gnome-region-panel-system.c:403
+msgid "Copy Settings"
+msgstr "Copiar axustes"
+
+#: ../panels/region/gnome-region-panel-xkblt.c:210
+msgid "Layout"
+msgstr "Disposición"
+
+#: ../panels/region/gnome-region-panel-xkbot.c:229
+#: ../panels/sound/gvc-sound-theme-chooser.c:586
+msgid "Default"
+msgstr "Predetermináu"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Change your region and language settings"
+msgstr "Cambiar los axustes de rexón y llingua"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
+msgid "Language;Layout;Keyboard;"
+msgstr "Llingua;Distribución;Tecláu;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "A_cceleration:"
+msgstr "A_celeración:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "Disable _touchpad while typing"
+msgstr "_Desactivar el touchpad al escribir"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-Click Timeout"
+msgstr "Retardu del duble clic"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Double-click timeout"
+msgstr "Retardu del duble clic"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "Drag Threshold"
+msgstr "Umbral d'arrastre"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Drag and Drop"
+msgstr "Arrastrar y llantar"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Enable _mouse clicks with touchpad"
+msgstr "Activar pul_saciones del mur col touchpad"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "Enable h_orizontal scrolling"
+msgstr "Activar desplazamientu _horizontal"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "General"
+msgstr "Xeneral"
+
+#. high sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "High"
+msgstr "Altu"
+
+#. large threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Large"
+msgstr "Grande"
+
+#. low sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Low"
+msgstr "Baxu"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+msgid "Mouse"
+msgstr "Mur"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "Mouse Preferences"
+msgstr "Preferencies del Mur"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:21
+msgid "Pointer Speed"
+msgstr "Velocidá del mur"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:22
+msgid "Scrolling"
+msgstr "Desplazamientu"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:23
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr "Amosar la posición del punteru al calcar la tecla Control"
+
+#. small threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:28
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Small"
+msgstr "Pequeñu"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:29
+msgid "Thr_eshold:"
+msgstr "_Umbral:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:30
+msgid "To test your settings, try to double-click on the face."
+msgstr "Pa probar la configuración prueba a calcar dos vegaes sobre la cara."
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:31
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:32
+msgid "Two-_finger scrolling"
+msgstr "_Desplazamientu con dos deos"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:33
+msgid "_Disabled"
+msgstr "_Desactiváu"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:34
+msgid "_Edge scrolling"
+msgstr "_Berbesu de desplazamientu"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:35
+msgid "_Left-handed"
+msgstr "_Maniegu"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:36
+msgid "_Right-handed"
+msgstr "_Diestru"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:37
+msgid "_Sensitivity:"
+msgstr "_Sensibilidá:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:38
+msgid "_Timeout:"
+msgstr "_Tiempu d'espera:"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse and Touchpad"
+msgstr "Mur y «touchpad»"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Set your mouse and touchpad preferences"
+msgstr "Configura les preferencies de mur y touchpad"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr "trackpad;punteru;calcar;doble;mur;trackball;"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/cc-network-panel.c:269
+msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "Úsase'l autodescubrimientu del proxy web cuando nun s'apurre un URL de configuración."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/cc-network-panel.c:277
+msgid "This is not recommended for untrusted public networks."
+msgstr "Nun s'encamienta l'usu pa redes públiques nes que nun se confía."
+
+#. TRANSLATORS: this is when the access point is not listed
+#. * in the dropdown (or hidden) and the user has to select
+#. * another entry manually
+#: ../panels/network/cc-network-panel.c:949
+msgctxt "Wireless access point"
+msgid "Other..."
+msgstr "Otru ..."
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/cc-network-panel.c:1107
+#: ../panels/network/cc-network-panel.c:1514
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:1111
+#: ../panels/network/cc-network-panel.c:1518
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:1115
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/cc-network-panel.c:1120
+msgid "Enterprise"
+msgstr "Empresa"
+
+#. TRANSLATORS: this no (!) WiFi security
+#: ../panels/network/cc-network-panel.c:1126
+#: ../panels/network/cc-network-panel.c:1509
+#: ../panels/universal-access/uap.ui.h:43
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "None"
+msgstr "Dengún"
+
+#: ../panels/network/cc-network-panel.c:1577
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#. Translators: network device speed
+#: ../panels/network/cc-network-panel.c:1643
+#: ../panels/network/cc-network-panel.c:1731
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/cc-network-panel.c:1986
+#: ../panels/network/network.ui.h:12
+msgid "IPv4 Address"
+msgstr "Direición IPv4"
+
+#: ../panels/network/cc-network-panel.c:1987
+#: ../panels/network/network.ui.h:13
+msgid "IPv6 Address"
+msgstr "Direición IPv6"
+
+#: ../panels/network/cc-network-panel.c:2040
+#: ../panels/network/cc-network-panel.c:2413
+#, c-format
+msgid "%s VPN"
+msgstr "VPN «%s»"
+
+#: ../panels/network/cc-network-panel.c:2148
+msgid "Proxy"
+msgstr "Proxy"
+
+#: ../panels/network/cc-network-panel.c:2222
+msgid "Network proxy"
+msgstr "Proxy de rede"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:2480
+msgid "The system network services are not compatible with this version."
+msgstr "Los servicios de rede del sistema nun son compatibles con esta versión."
+
+#: ../panels/network/cc-network-panel.c:3095
+msgid "Not connected to the internet."
+msgstr "Non coneutáu a Internet."
+
+#: ../panels/network/cc-network-panel.c:3096
+msgid "Create the hotspot anyway?"
+msgstr "¿Crear el «hotspot» de toes formes?"
+
+#: ../panels/network/cc-network-panel.c:3114
+#, c-format
+msgid "Disconnect from %s and create a new hotspot?"
+msgstr "¿Desconeutase de %s y crear un «hotspot» nuevu?"
+
+#: ../panels/network/cc-network-panel.c:3117
+msgid "This is your only connection to the internet."
+msgstr "Esta ye la única conexón a Internet."
+
+#: ../panels/network/cc-network-panel.c:3135
+msgid "Create _Hotspot"
+msgstr "Crear «_hotspot»"
+
+#: ../panels/network/cc-network-panel.c:3195
+msgid "Stop hotspot and disconnect any users?"
+msgstr "¿Detener el «hotspot» y desconeutar a los usuarios?"
+
+#: ../panels/network/cc-network-panel.c:3198
+msgid "_Stop Hotspot"
+msgstr "_Detener «hotspot»"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+msgid "Network"
+msgstr "Rede"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Network settings"
+msgstr "Configuración de la rede"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid "Network;Wireless;IP;LAN;"
+msgstr "rede;inalámbrica;ip;lan;"
+
+#: ../panels/network/network.ui.h:1
+msgid "Air_plane Mode"
+msgstr "Mou a_vión"
+
+#: ../panels/network/network.ui.h:2
+msgid "Create..."
+msgstr "Crear…"
+
+#: ../panels/network/network.ui.h:3
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/network.ui.h:4
+msgid "Default Route"
+msgstr "Ruta predeterminada"
+
+#: ../panels/network/network.ui.h:5
+msgid "Gateway"
+msgstr "Puerta d'enllaz"
+
+#: ../panels/network/network.ui.h:6
+msgid "Group Name"
+msgstr "Nome de grupu"
+
+#: ../panels/network/network.ui.h:7
+msgid "Group Password"
+msgstr "Contraseña del grupu"
+
+#: ../panels/network/network.ui.h:8
+msgid "H_TTPS Proxy"
+msgstr "Proxy pa H_TTPS"
+
+#: ../panels/network/network.ui.h:9
+msgid "Hardware Address"
+msgstr "Direición física"
+
+#: ../panels/network/network.ui.h:10
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network.ui.h:14
+msgid "Interface"
+msgstr "Interface"
+
+#: ../panels/network/network.ui.h:15
+msgid "Network Name"
+msgstr "Nome de rede"
+
+#: ../panels/network/network.ui.h:16
+msgid "Provider"
+msgstr "Fornidor"
+
+#: ../panels/network/network.ui.h:17
+msgid "Security"
+msgstr "Seguridá"
+
+#: ../panels/network/network.ui.h:18
+msgid "Security Key"
+msgstr "Clave de seguridá"
+
+#: ../panels/network/network.ui.h:19
+msgid "Select the interface to use for the new service"
+msgstr "Esbillar la interfaz qu'usar pal serviciu nuevu"
+
+#: ../panels/network/network.ui.h:20
+msgid "Speed"
+msgstr "Velocidá"
+
+#: ../panels/network/network.ui.h:21
+msgid "Subnet Mask"
+msgstr "Mázcara de subrede"
+
+#: ../panels/network/network.ui.h:22
+msgid "Unlock"
+msgstr "Desbloquiar"
+
+#: ../panels/network/network.ui.h:23
+msgid "Username"
+msgstr "Nome d'usuariu/a"
+
+#: ../panels/network/network.ui.h:24
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/network.ui.h:25
+msgid "VPN Type"
+msgstr "Tipu de VPN"
+
+#: ../panels/network/network.ui.h:26
+msgid "_Configuration URL"
+msgstr "URL de _configuración"
+
+#: ../panels/network/network.ui.h:27
+msgid "_Configure..."
+msgstr "_Configurar..."
+
+#: ../panels/network/network.ui.h:28
+msgid "_FTP Proxy"
+msgstr "Proxy pa _FTP"
+
+#: ../panels/network/network.ui.h:29
+msgid "_HTTP Proxy"
+msgstr "Proxy pa _HTTP"
+
+#: ../panels/network/network.ui.h:30
+msgid "_Method"
+msgstr "_Métodu"
+
+#: ../panels/network/network.ui.h:31
+msgid "_Network Name"
+msgstr "_Nome de rede"
+
+#: ../panels/network/network.ui.h:32
+msgid "_Socks Host"
+msgstr "_Sirvidor socks"
+
+#: ../panels/network/network.ui.h:33
+msgid "_Stop Hotspot..."
+msgstr "_Detener «hotspot»…"
+
+#: ../panels/network/network.ui.h:34
+msgid "_Use as Hotspot..."
+msgstr "_Usar como «hotspot»…"
+
+#: ../panels/network/network.ui.h:35
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "Automáticu"
+
+#: ../panels/network/network.ui.h:36
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "Manual"
+
+#: ../panels/network/network.ui.h:37
+msgctxt "proxy method"
+msgid "None"
+msgstr "Dengún"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:83
+msgid "Wired"
+msgstr "Cableada"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:87
+msgid "Wireless"
+msgstr "Inalámbrica"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:94
+msgid "Mobile broadband"
+msgstr "Banda ancha móvil"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:103
+msgid "Mesh"
+msgstr "Malla"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:162
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:166
+msgid "Infrastructure"
+msgstr "Infraestructura"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:190
+#: ../panels/network/panel-common.c:251
+msgid "Status unknown"
+msgstr "Estáu desconocíu"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:194
+msgid "Unmanaged"
+msgstr "Non xestionada"
+
+#: ../panels/network/panel-common.c:199
+msgid "Firmware missing"
+msgstr "falta'l «firmware»"
+
+#: ../panels/network/panel-common.c:202
+msgid "Cable unplugged"
+msgstr "Cable desconeutáu"
+
+#: ../panels/network/panel-common.c:204
+msgid "Unavailable"
+msgstr "Non disponible"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:208
+msgid "Disconnected"
+msgstr "Desconectáu"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:215
+#: ../panels/network/panel-common.c:257
+msgid "Connecting"
+msgstr "Coneutando"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:219
+#: ../panels/network/panel-common.c:261
+msgid "Authentication required"
+msgstr "Necesítase autenticación"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223
+#: ../panels/network/panel-common.c:265
+msgid "Connected"
+msgstr "Coneutáu"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:227
+msgid "Disconnecting"
+msgstr "Desconeutando"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:231
+#: ../panels/network/panel-common.c:269
+msgid "Connection failed"
+msgstr "Falló la conexón"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:235
+#: ../panels/network/panel-common.c:277
+msgid "Status unknown (missing)"
+msgstr "Estáu desconocíu (ausente)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:273
+msgid "Not connected"
+msgstr "Non coneutáu"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "Enerxía"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Power management settings"
+msgstr "Axustes de Xestión d'enerxía"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+msgstr "Enerxía;Durmir;Suspender;Ivernar;Batería;"
+
+#: ../panels/power/cc-power-panel.c:160
+msgid "Unknown time"
+msgstr "Tiempu desconocíu"
+
+#: ../panels/power/cc-power-panel.c:166
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minutu"
+msgstr[1] "%i minutos"
+
+#: ../panels/power/cc-power-panel.c:178
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hora"
+msgstr[1] "%i hores"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:186
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:187
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hora"
+msgstr[1] "hores"
+
+#: ../panels/power/cc-power-panel.c:188
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minutu"
+msgstr[1] "minutos"
+
+#: ../panels/power/cc-power-panel.c:265
+msgid "Battery charging"
+msgstr "La batería ta cargándose"
+
+#: ../panels/power/cc-power-panel.c:268
+msgid "Battery discharging"
+msgstr "La batería ta descargándose"
+
+#: ../panels/power/cc-power-panel.c:279
+msgid "UPS charging"
+msgstr "SAI cargándose"
+
+#: ../panels/power/cc-power-panel.c:282
+msgid "UPS discharging"
+msgstr "SAI descargándose"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:300
+#, c-format
+msgid "%s until charged (%.0lf%%)"
+msgstr "%s hasta cargase (%.0lf%%)"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:306
+#, c-format
+msgid "%s until empty (%.0lf%%)"
+msgstr "%s hasta descargase (%.0lf%%)"
+
+#. TRANSLATORS: %1 is a percentage value. Note: this string is only
+#. * used when we don't have a time value
+#: ../panels/power/cc-power-panel.c:314
+#, c-format
+msgid "%.0lf%% charged"
+msgstr "%.0lf%% cargáu"
+
+#: ../panels/power/power.ui.h:1
+#: ../panels/screen/screen.ui.h:1
+msgid "1 hour"
+msgstr "1 hora"
+
+#: ../panels/power/power.ui.h:2
+#: ../panels/screen/screen.ui.h:3
+msgid "10 minutes"
+msgstr "10 minutos"
+
+#: ../panels/power/power.ui.h:3
+#: ../panels/screen/screen.ui.h:6
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#: ../panels/power/power.ui.h:4
+#: ../panels/screen/screen.ui.h:8
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#: ../panels/power/power.ui.h:5
+msgid "Don't suspend"
+msgstr "Non suspender"
+
+#: ../panels/power/power.ui.h:6
+msgid "Hibernate"
+msgstr "Ivernar"
+
+#: ../panels/power/power.ui.h:7
+msgid "On battery power"
+msgstr "Cuando tea con batería"
+
+#: ../panels/power/power.ui.h:8
+msgid "Power off"
+msgstr "Apagar"
+
+#: ../panels/power/power.ui.h:9
+msgid "Suspend when inactive for:"
+msgstr "Suspender cuando tea inactivu por:"
+
+#: ../panels/power/power.ui.h:10
+msgid "When plugged in"
+msgstr "Cuando tea coneutáu"
+
+#: ../panels/power/power.ui.h:11
+msgid "When power is _critically low:"
+msgstr "_Cuando la carga tea críticamente baxa:"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: ../panels/color/color.ui.h:8
+msgid "Color"
+msgstr "Color"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Color management settings"
+msgstr "Axustes de xestión de color"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Perfil;Calibráu;Imprentadora;Pantalla;"
+
+#. TRANSLATORS: this is where the user can click and import a profile
+#: ../panels/color/cc-color-panel.c:106
+msgid "Other profile…"
+msgstr "Otru perfil…"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:119
+msgid "Default: "
+msgstr "Predetermináu:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:126
+msgid "Colorspace: "
+msgstr "Espaciu de color:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:132
+msgid "Test profile: "
+msgstr "Perfil de color:"
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:185
+#: ../panels/color/color.ui.h:19
+msgid "Set for all users"
+msgstr "Afitar pa tolos usuarios"
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:192
+msgid "Create virtual device"
+msgstr "Crear un preséu virtual"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:227
+msgid "Select ICC Profile File"
+msgstr "Esbillar ficheru de perfil ICC"
+
+#: ../panels/color/cc-color-panel.c:230
+msgid "_Import"
+msgstr "_Importar"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:241
+msgid "Supported ICC profiles"
+msgstr "Perfiles ICC sofitaos"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:248
+msgid "All files"
+msgstr "Tolos ficheros"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:504
+msgid "Available Profiles for Displays"
+msgstr "Perfiles disponibles pa pantalles"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:508
+msgid "Available Profiles for Scanners"
+msgstr "Perfiles disponibles pa escáneres"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:512
+msgid "Available Profiles for Printers"
+msgstr "Perfiles disponibles pa imprentadores"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:516
+msgid "Available Profiles for Cameras"
+msgstr "Perfiles disponibles pa cámares"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:520
+msgid "Available Profiles for Webcams"
+msgstr "Perfiles disponibles pa webcams"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#. * where the device type is not recognised
+#. Profiles that can be added to the device
+#: ../panels/color/cc-color-panel.c:525
+#: ../panels/color/color.ui.h:5
+msgid "Available Profiles"
+msgstr "Perfiles disponibles"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:794
+#: ../panels/sound/gvc-mixer-dialog.c:1515
+msgid "Device"
+msgstr "Preséu"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:829
+msgid "Calibration"
+msgstr "Calibración"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:861
+msgid "Create a color profile for the selected device"
+msgstr "Crear un perfil de color pal preséu esbilláu"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:875
+#: ../panels/color/cc-color-panel.c:899
+msgid "The measuring instrument is not detected. Please check it is turned on and correctly connected."
+msgstr "Nun se deteutó l'instrumentu de midida. Comprueba que tea encesu y correutamente coneutáu."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:908
+msgid "The measuring instrument does not support printer profiling."
+msgstr "L'instrumentu de midida nun sofita perfiláu d'imprentadores."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:919
+msgid "The device type is not currently supported."
+msgstr "El tipu de preséu nun ta sofitáu anguaño."
+
+#. TRANSLATORS: this is when an auto-added profile cannot be removed
+#: ../panels/color/cc-color-panel.c:992
+msgid "Cannot remove automatically added profile"
+msgstr "Nun pue desaniciase automáticamente'l perfil amestáu"
+
+#. TRANSLATORS: this is when there is no profile for the device
+#: ../panels/color/cc-color-panel.c:1327
+msgid "No profile"
+msgstr "Ensin perfil"
+
+#: ../panels/color/cc-color-panel.c:1358
+#, c-format
+msgid "%i year"
+msgid_plural "%i years"
+msgstr[0] "%i añu"
+msgstr[1] "%i años"
+
+#: ../panels/color/cc-color-panel.c:1369
+#, c-format
+msgid "%i month"
+msgid_plural "%i months"
+msgstr[0] "%i mes"
+msgstr[1] "%i meses"
+
+#: ../panels/color/cc-color-panel.c:1380
+#, c-format
+msgid "%i week"
+msgid_plural "%i weeks"
+msgstr[0] "%i selmana"
+msgstr[1] "%i selmanes"
+
+#. fallback
+#: ../panels/color/cc-color-panel.c:1387
+#, c-format
+msgid "Less than 1 week"
+msgstr "Menos d'una selmana"
+
+#: ../panels/color/cc-color-panel.c:1449
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB predetermináu"
+
+#: ../panels/color/cc-color-panel.c:1454
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK predetermináu"
+
+#: ../panels/color/cc-color-panel.c:1459
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Buxu predetermináu"
+
+#: ../panels/color/cc-color-panel.c:1577
+#: ../panels/color/cc-color-panel.c:1609
+#: ../panels/color/cc-color-panel.c:1620
+#: ../panels/color/cc-color-panel.c:1631
+msgid "Uncalibrated"
+msgstr "Ensin calibrar"
+
+#: ../panels/color/cc-color-panel.c:1580
+msgid "This device is not color managed."
+msgstr "Esti preséu nun tien xestión de color."
+
+#: ../panels/color/cc-color-panel.c:1612
+msgid "This device is using manufacturing calibrated data."
+msgstr "Esti preséu ta usando los datos de calibración de fabricación."
+
+#: ../panels/color/cc-color-panel.c:1623
+msgid "This device does not have a profile suitable for whole-screen color correction."
+msgstr "Esti preséu nun tien un perfil aptu pa correición de color en tola pantalla."
+
+#: ../panels/color/cc-color-panel.c:1656
+msgid "This device has an old profile that may no longer be accurate."
+msgstr "Esti preséu tien un perfil antiguu que pue nun ser precisu."
+
+#. TRANSLATORS: this is when the calibration profile age is not
+#. * specified as it has been autogenerated from the hardware
+#: ../panels/color/cc-color-panel.c:1684
+msgid "Not specified"
+msgstr "Ensin especificar"
+
+#. add the 'No devices detected' entry
+#: ../panels/color/cc-color-panel.c:1868
+msgid "No devices supporting color management detected"
+msgstr "Nun hai preseos deteutaos que sofiten la xestión de color"
+
+#: ../panels/color/cc-color-panel.c:2097
+msgctxt "Device kind"
+msgid "Display"
+msgstr "Pantalla"
+
+#: ../panels/color/cc-color-panel.c:2099
+msgctxt "Device kind"
+msgid "Scanner"
+msgstr "Escáner"
+
+#: ../panels/color/cc-color-panel.c:2101
+msgctxt "Device kind"
+msgid "Printer"
+msgstr "Imprentadora"
+
+#: ../panels/color/cc-color-panel.c:2103
+msgctxt "Device kind"
+msgid "Camera"
+msgstr "Cámara"
+
+#: ../panels/color/cc-color-panel.c:2105
+msgctxt "Device kind"
+msgid "Webcam"
+msgstr "Cámara web"
+
+#: ../panels/color/color.ui.h:1
+msgid "Add a virtual device"
+msgstr "Amestar un preséu virtual"
+
+#: ../panels/color/color.ui.h:2
+msgid "Add device"
+msgstr "Amestar preséu"
+
+#: ../panels/color/color.ui.h:3
+msgid "Add profile"
+msgstr "Amestar perfil"
+
+#: ../panels/color/color.ui.h:6
+msgid "Calibrate the device"
+msgstr "Calibrar el preséu"
+
+#: ../panels/color/color.ui.h:7
+msgid "Calibrate…"
+msgstr "Calibrar…"
+
+#: ../panels/color/color.ui.h:9
+msgid "Delete device"
+msgstr "Desaniciar preséu"
+
+#: ../panels/color/color.ui.h:10
+msgid "Device type:"
+msgstr "Triba de preséu:"
+
+#: ../panels/color/color.ui.h:11
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "Cada preséu necesita un perfil de color anováu pa poder xestionar el color."
+
+#: ../panels/color/color.ui.h:12
+msgid "Image files can be dragged on this window to auto-complete the above fields."
+msgstr "Puen arrastrase ficheros d'imaxe nesta ventana p'autocompletar los campos superiores."
+
+#: ../panels/color/color.ui.h:13
+msgid "Learn more"
+msgstr "Deprendi más"
+
+#: ../panels/color/color.ui.h:14
+msgid "Learn more about color management"
+msgstr "Deprendi más sobre la xestión de color"
+
+#: ../panels/color/color.ui.h:15
+msgid "Manufacturer:"
+msgstr "Fabricante:"
+
+#: ../panels/color/color.ui.h:16
+msgid "Model:"
+msgstr "Modelu:"
+
+#: ../panels/color/color.ui.h:17
+msgid "Remove a device"
+msgstr "Desaniciar un preséu"
+
+#: ../panels/color/color.ui.h:18
+msgid "Remove profile"
+msgstr "Desaniciar perfil"
+
+#: ../panels/color/color.ui.h:20
+msgid "Set this device for all users on this computer"
+msgstr "Configurar esti preséu pa tolos usuarios d'esti equipu"
+
+#: ../panels/color/color.ui.h:21
+msgid "View details"
+msgstr "Ver detalles"
+
+#. Translators: those are keywords for the brightness and lock control-center panel
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
+msgid "Brightness;Lock;Dim;Blank;Monitor;"
+msgstr "Brillu;Bloquiar;Escurecer;Illuminar;Pantalla;"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
+msgid "Screen"
+msgstr "Pantalla"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
+msgid "Screen brightness and lock settings"
+msgstr "Brillu y axustes de bloquéu de la pantalla"
+
+#: ../panels/screen/screen.ui.h:2
+msgid "1 minute"
+msgstr "1 minutu"
+
+#: ../panels/screen/screen.ui.h:4
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#: ../panels/screen/screen.ui.h:5
+msgid "3 minutes"
+msgstr "3 minutos"
+
+#: ../panels/screen/screen.ui.h:7
+msgid "30 seconds"
+msgstr "30 segundos"
+
+#: ../panels/screen/screen.ui.h:9
+msgid "Brightness"
+msgstr "Brillu"
+
+#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
+#: ../panels/screen/screen.ui.h:11
+msgid "Don't lock when at home"
+msgstr "Nun bloquiar cuando tea en casa"
+
+#: ../panels/screen/screen.ui.h:12
+msgid "Locations..."
+msgstr "Llocalizaciones…"
+
+#: ../panels/screen/screen.ui.h:13
+msgid "Lock"
+msgstr "Bloquiar"
+
+#: ../panels/screen/screen.ui.h:14
+msgid "Screen turns off"
+msgstr "que la pantalla s'apague"
+
+#: ../panels/screen/screen.ui.h:15
+msgid "_Dim screen to save power"
+msgstr "_Escurecer la pantalla p'aforrar enerxía"
+
+#: ../panels/screen/screen.ui.h:16
+msgid "_Lock screen after:"
+msgstr "B_loquiar pantalla dempués de:"
+
+#: ../panels/screen/screen.ui.h:17
+msgid "_Turn screen off when inactive for:"
+msgstr "S_uspender cuando tea inactivu por:"
+
+#: ../panels/sound/applet-main.c:49
+msgid "Enable debugging code"
+msgstr "Activar códigu de depuración"
+
+#: ../panels/sound/applet-main.c:50
+msgid "Version of this application"
+msgstr "Versión d'esta aplicación"
+
+#: ../panels/sound/applet-main.c:62
+msgid " — GNOME Volume Control Applet"
+msgstr " — Miniaplicación de control de volume de GNOME"
+
+#: ../panels/sound/gvc-applet.c:270
+#: ../panels/sound/gvc-mixer-dialog.c:1767
+msgid "Output"
+msgstr "Salida"
+
+#: ../panels/sound/gvc-applet.c:272
+msgid "Sound Output Volume"
+msgstr "Volume de la salida de soníu"
+
+#: ../panels/sound/gvc-applet.c:276
+#: ../panels/sound/gvc-mixer-dialog.c:1807
+msgid "Input"
+msgstr "Entrada"
+
+#: ../panels/sound/gvc-applet.c:278
+msgid "Microphone Volume"
+msgstr "Volume del micrófonu"
+
+#: ../panels/sound/gvc-balance-bar.c:111
+msgctxt "balance"
+msgid "Left"
+msgstr "Esquierda"
+
+#: ../panels/sound/gvc-balance-bar.c:112
+msgctxt "balance"
+msgid "Right"
+msgstr "Derecha"
+
+#: ../panels/sound/gvc-balance-bar.c:115
+msgctxt "balance"
+msgid "Rear"
+msgstr "Traseru"
+
+#: ../panels/sound/gvc-balance-bar.c:116
+msgctxt "balance"
+msgid "Front"
+msgstr "Frontal"
+
+#: ../panels/sound/gvc-balance-bar.c:119
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Mínimu"
+
+#: ../panels/sound/gvc-balance-bar.c:120
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Máximu"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Balance:"
+msgstr "_Balance:"
+
+#: ../panels/sound/gvc-balance-bar.c:298
+msgid "_Fade:"
+msgstr "_Esvanecimientu:"
+
+#: ../panels/sound/gvc-balance-bar.c:301
+msgid "_Subwoofer:"
+msgstr "_Subwoofer:"
+
+#: ../panels/sound/gvc-channel-bar.c:603
+#: ../panels/sound/gvc-channel-bar.c:612
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:607
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Ensin amplificar"
+
+#: ../panels/sound/gvc-combo-box.c:167
+#: ../panels/sound/gvc-mixer-dialog.c:1621
+msgid "_Profile:"
+msgstr "_Perfil:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1093
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u salida"
+msgstr[1] "%u salides"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1103
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrada"
+msgstr[1] "%u entraes"
+
+#: ../panels/sound/gvc-mixer-control.c:1401
+msgid "System Sounds"
+msgstr "Sones del Sistema"
+
+#: ../panels/sound/gvc-mixer-dialog.c:323
+#: ../panels/sound/gvc-mixer-dialog.c:634
+msgid "Co_nnector:"
+msgstr "Co_neutor:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:540
+msgid "Peak detect"
+msgstr "Deteutar picos"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1496
+#: ../panels/sound/gvc-mixer-dialog.c:1709
+#: ../panels/sound/gvc-sound-theme-chooser.c:596
+msgid "Name"
+msgstr "Nome"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1563
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "Comprobación d'altavoces pa %s"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1622
+msgid "_Test Speakers"
+msgstr "_Probar los altavoces"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1753
+msgid "_Output volume:"
+msgstr "Volume de _salida"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1772
+msgid "C_hoose a device for sound output:"
+msgstr "_Esbillar un preséu pa la salida de soníu"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+#: ../panels/sound/gvc-mixer-dialog.c:1925
+msgid "Settings for the selected device:"
+msgstr "Axustes pal preséu seleicionáu:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1814
+msgid "_Input volume:"
+msgstr "Volume d'e_ntrada"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1837
+msgid "Input level:"
+msgstr "Nivel d'entrada:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1865
+msgid "C_hoose a device for sound input:"
+msgstr "_Esbillar un preséu pa la entrada de soníu"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1892
+msgid "Hardware"
+msgstr "Hardware"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1897
+msgid "C_hoose a device to configure:"
+msgstr "_Esbillar un preséu pa configurar:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1936
+msgid "Sound Effects"
+msgstr "Efeutos de soníu"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1943
+msgid "_Alert volume:"
+msgstr "Volume d'a_lerta"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1956
+msgid "Applications"
+msgstr "Aplicaciones"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1960
+msgid "No application is currently playing or recording audio."
+msgstr "Denguna aplicación ta reproduciendo o grabando soníu anguaño."
+
+#: ../panels/sound/gvc-speaker-test.c:221
+msgid "Stop"
+msgstr "Detener"
+
+#: ../panels/sound/gvc-speaker-test.c:221
+#: ../panels/sound/gvc-speaker-test.c:333
+msgid "Test"
+msgstr "Prebar"
+
+#: ../panels/sound/gvc-speaker-test.c:229
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: ../panels/sound/gvc-stream-status-icon.c:235
+#, c-format
+msgid "Failed to start Sound Preferences: %s"
+msgstr "Falló al aniciar les Preferencies de Soníu: %s"
+
+#: ../panels/sound/gvc-stream-status-icon.c:261
+msgid "_Mute"
+msgstr "_Silenciar"
+
+#: ../panels/sound/gvc-stream-status-icon.c:270
+msgid "_Sound Preferences"
+msgstr "_Preferencies de Soníu"
+
+#: ../panels/sound/gvc-stream-status-icon.c:415
+msgid "Muted"
+msgstr "Silenciáu"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:190
+msgid "Built-in"
+msgstr "Built-in"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:456
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Sound Preferences"
+msgstr "Preferencies de Soníu"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:459
+#: ../panels/sound/gvc-sound-theme-chooser.c:470
+#: ../panels/sound/gvc-sound-theme-chooser.c:482
+msgid "Testing event sound"
+msgstr "Comprobando'l soníu d'eventu"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:587
+msgid "From theme"
+msgstr "Del tema"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:782
+msgid "C_hoose an alert sound:"
+msgstr "_Esbillar un soníu d'alerta:"
+
+#: ../panels/sound/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr "Personalizáu"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
+msgid "Show desktop volume control"
+msgstr "Amosar el control de volume de l'escritoriu"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
+msgid "Volume Control"
+msgstr "Control de volume"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+msgstr "tarxeta;micrófonu;volume;esvanecer;balance;altavoz;bluetooth;cascos;auriculares;"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
+msgid "Change sound volume and sound events"
+msgstr "Camudar el volume del soníu y los eventos de soníu"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Sound"
+msgstr "Soníu"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "Lladríu"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "Gotiar"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "Cristal"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "Sónar"
+
+#: ../panels/universal-access/cc-ua-panel.c:505
+#: ../panels/universal-access/cc-ua-panel.c:510
+msgid "No shortcut set"
+msgstr "Nun esiste dengún atayu configuráu"
+
+#: ../panels/universal-access/gconf-property-editor.c:134
+msgid "Key"
+msgstr "Clave"
+
+#: ../panels/universal-access/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr "Clave de gconf a la que ta asociáu esti editor de propiedaes"
+
+#: ../panels/universal-access/gconf-property-editor.c:141
+msgid "Callback"
+msgstr "Retornu de llamada"
+
+#: ../panels/universal-access/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Emitir este retornu de llamada cuando camude'l valor asociáu cola clave"
+
+#: ../panels/universal-access/gconf-property-editor.c:147
+msgid "Change set"
+msgstr "Conxuntu de cambeos"
+
+#: ../panels/universal-access/gconf-property-editor.c:148
+msgid "GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr "Conxuntu de cambeos de gconf que contién datos que deben remitise al veceru de gconf cuando s'apliquen"
+
+#: ../panels/universal-access/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr "Conversión a retornu de llamada del widget"
+
+#: ../panels/universal-access/gconf-property-editor.c:154
+msgid "Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "Retornu de llamada qu'hai d'emitir cuando se vayan a convertir datos de gconf al widget"
+
+#: ../panels/universal-access/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr "Conversión dende'l retornu de llamada del widget"
+
+#: ../panels/universal-access/gconf-property-editor.c:160
+msgid "Callback to be issued when data are to be converted to GConf from the widget"
+msgstr "Retornu de llamada que tien d'emitise cuando vayan a convertise datos del widget a gconf"
+
+#: ../panels/universal-access/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "Control UI"
+
+#: ../panels/universal-access/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr "Oxetu que remana la propiedá (xeneralmente, un widget)"
+
+#: ../panels/universal-access/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr "Datos d'oxetu del editor de propiedaes"
+
+#: ../panels/universal-access/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr "Datos personalizaos requeríos pol editor de propiedaes específicu"
+
+#: ../panels/universal-access/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr "Retornu de llamada de lliberación de datos del editor de propiedaes"
+
+#: ../panels/universal-access/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr "Retornu de llamada que tien d'emitise cuando vayan a lliberase datos d'oxetu del editor de propiedaes"
+
+#: ../panels/universal-access/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background picture."
+msgstr ""
+"Nun pudo alcontrase'l ficheru «%s».\n"
+"\n"
+"Compruebe si esiste y torne a tentalo o escueya una imaxe de fondu distinta."
+
+#: ../panels/universal-access/gconf-property-editor.c:1482
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Nun ye dable abrir el ficheru «%s».\n"
+"Pue que se trate d'un tipu d'imaxe qu'entá nun s'almite.\n"
+"\n"
+"Seleicione una imaxe distinta."
+
+#: ../panels/universal-access/gconf-property-editor.c:1604
+msgid "Please select an image."
+msgstr "Por favor seleicione una imaxe."
+
+#: ../panels/universal-access/zoom-options.c:156
+msgid "1/4 Screen"
+msgstr "1/4 Pantalla"
+
+#: ../panels/universal-access/zoom-options.c:157
+msgid "1/2 Screen"
+msgstr "1/2 Pantalla"
+
+#: ../panels/universal-access/zoom-options.c:158
+msgid "3/4 Screen"
+msgstr "3/4 Pantalla"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys"
+msgstr "Tecláu;Mur;a11y;Accesibilidá;Contraste;Zoom;Llector de pantalla;testu;fonte;tamañu;AccessX;Tecles persistentes;Tecles lentes;Refugu de tecles;Tecles del mur"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid "Universal Access Preferences"
+msgstr "Preferencies d'accesu universal"
+
+#: ../panels/universal-access/uap.ui.h:2
+#, no-c-format
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/universal-access/uap.ui.h:4
+#, no-c-format
+msgid "125%"
+msgstr "125%"
+
+#: ../panels/universal-access/uap.ui.h:6
+#, no-c-format
+msgid "150%"
+msgstr "150%"
+
+#: ../panels/universal-access/uap.ui.h:8
+#, no-c-format
+msgid "75%"
+msgstr "75%"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "A_cceptance delay:"
+msgstr "R_etardu d'aceutación:"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "Acc_eptance delay:"
+msgstr "Ret_ardu d'aceutación:"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Beep when Caps and Num Lock are used"
+msgstr "Pitar al usar Bloq. Númb. y Bloq. Mayús."
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Beep when a _modifer key is pressed"
+msgstr "Pitar al calcar una tecla _modificadora"
+
+#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Beep when a key is"
+msgstr "Pitar cuando la tecla ye"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "Beep when a key is _rejected"
+msgstr "Pitar al _refugar una tecla"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "Bounce Keys"
+msgstr "Tecles de rebote"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Bounce keys typing delay"
+msgstr "Retrasu de pulsación del refugu de tecles"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "Caribou"
+msgstr "Caribou"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "Change contrast:"
+msgstr "Cambiar contraste:"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Closed Captioning"
+msgstr "GOP zarráu"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Control the pointer using the keypad"
+msgstr "Remanar el punteru usando'l tecláu numbéricu"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Control the pointer using the video camera."
+msgstr "Remanar el punteru usando la cámara de videu."
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "D_elay:"
+msgstr "A_llanciu:"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Dasher"
+msgstr "Dasher"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Decrease size:"
+msgstr "Amenorgar tamañu:"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Display a textual description of speech and sounds"
+msgstr "Amosar una descripción testual de la voz y los soníos"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Flash the entire screen"
+msgstr "Destellu de la pantalla completa"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Flash the window title"
+msgstr "Destellu de la barra de títulu de la ventana"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "GOK"
+msgstr "GOK"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "Hearing"
+msgstr "Audición"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Hover Click"
+msgstr "Pulsación al pasar per encima"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Ignores fast duplicate keypresses"
+msgstr "Inorar pulsaciones duplicaes rápides"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Increase size:"
+msgstr "Aumentar tamañu:"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Motion _threshold:"
+msgstr "Umbral de _movimientu:"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Mouse Keys"
+msgstr "Tecles del Mur"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "Mouse Settings"
+msgstr "Configuración del mur"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Nomon"
+msgstr "Nomon"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "On screen keyboard"
+msgstr "Tecláu en pantalla"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "OnBoard"
+msgstr "EnPantalla"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "Options..."
+msgstr "Opciones…"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Pointing and Clicking"
+msgstr "Apuntar y calcar"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introduz un allanciu al calcar una tecla y cuando esta s'aceuta"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Screen Reader"
+msgstr "Llector de pantalla"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Screen keyboard"
+msgstr "Tecláu en pantalla"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgid "Secondary click delay"
+msgstr "Retardu pulsación secundaria"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Seeing"
+msgstr "Visión"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Simulated Secondary Click"
+msgstr "Pulsación secundaria simulada"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "Slow Keys"
+msgstr "Tecles lentes"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgid "Slow keys typing delay"
+msgstr "Retardu de les tecles lentes al escribir"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgid "Sticky Keys"
+msgstr "Tecles pegañoses"
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Trata una secuencia de tecles modificadores como una combinación de tecles"
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Trigger a click when the pointer hovers"
+msgstr "Aniciar una pulsación al posicionar el punteru"
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Disparar una pulsación secundaria al caltener primíu'l botón primariu"
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Turn on or off:"
+msgstr "Activar o desactivar:"
+
+#: ../panels/universal-access/uap.ui.h:66
+msgid "Type here to test settings"
+msgstr "Teclear equí pa probar la configuración"
+
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Typing Assistant"
+msgstr "Asistente de tecleáu"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Use a visual indication when an alert sound occurs"
+msgstr "Usar una indicación visual cuando heba una alerta de soníu"
+
+#: ../panels/universal-access/uap.ui.h:70
+msgid "Video Mouse"
+msgstr "Mur de videu"
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Visual Alerts"
+msgstr "Alertes visuales"
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "Zoom in:"
+msgstr "Acercar:"
+
+#: ../panels/universal-access/uap.ui.h:73
+msgid "Zoom out:"
+msgstr "Allonxar:"
+
+#: ../panels/universal-access/uap.ui.h:74
+msgid "_Contrast:"
+msgstr "_Contraste:"
+
+#: ../panels/universal-access/uap.ui.h:75
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desactivar si se calquen dos tecles al empar"
+
+#: ../panels/universal-access/uap.ui.h:76
+msgid "_Test flash"
+msgstr "_Probar destellos"
+
+#: ../panels/universal-access/uap.ui.h:77
+msgid "_Text size:"
+msgstr "_Tamañu del testu:"
+
+#: ../panels/universal-access/uap.ui.h:78
+msgid "_Turn on accessibility features from the keyboard"
+msgstr "Ac_tivar les carauterístiques d'accesibilidá dende'l tecláu"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:80
+msgid "accepted"
+msgstr "aceutada"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:82
+msgid "pressed"
+msgstr "primida"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:84
+msgid "rejected"
+msgstr "refugada"
+
+#: ../panels/universal-access/uap.ui.h:85
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Altu"
+
+#: ../panels/universal-access/uap.ui.h:86
+msgctxt "universal access, contrast"
+msgid "High/Inverse"
+msgstr "Altu/invertíu"
+
+#: ../panels/universal-access/uap.ui.h:87
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Baxu"
+
+#: ../panels/universal-access/uap.ui.h:88
+msgctxt "universal access, contrast"
+msgid "Normal"
+msgstr "Normal"
+
+#. Translators: this refers to theme contrast and font size
+#: ../panels/universal-access/uap.ui.h:90
+msgctxt "universal access, seeing"
+msgid "Display"
+msgstr "Amosar"
+
+#. Translators: this refers to screen magnifier
+#: ../panels/universal-access/uap.ui.h:92
+msgctxt "universal access, seeing"
+msgid "Zoom"
+msgstr "Acercar"
+
+#: ../panels/universal-access/uap.ui.h:93
+msgctxt "universal access, text size"
+msgid "Large"
+msgstr "Grande"
+
+#: ../panels/universal-access/uap.ui.h:94
+msgctxt "universal access, text size"
+msgid "Larger"
+msgstr "Más _grande"
+
+#: ../panels/universal-access/uap.ui.h:95
+msgctxt "universal access, text size"
+msgid "Normal"
+msgstr "Normal"
+
+#: ../panels/universal-access/uap.ui.h:96
+msgctxt "universal access, text size"
+msgid "Small"
+msgstr "Pequeñu"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Always"
+msgstr "Siempre"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Bottom Half"
+msgstr "Metada inferior"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Centered"
+msgstr "Centráu"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Color and Opacity"
+msgstr "Color y opacidá"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Crosshairs"
+msgstr "Cruces"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Full Screen"
+msgstr "Pantalla completa"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Image moves with the mouse pointer"
+msgstr "La imaxe muévese col punteru del mur"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Image scrolls at screen edges"
+msgstr "La imaxe eslízase nos berbesos de la pantalla"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Left Half"
+msgstr "Metada esquierda"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Length"
+msgstr "Llonxitú"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnification"
+msgstr "Magnificador"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Moveable lens - magnified view follows mouse movements"
+msgstr "Llentes movibles: la vista magnificada sigue los movimientos del mur"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Position of magnified view on screen"
+msgstr "Posición de la vista magnificada na pantalla"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgid "Proportional"
+msgstr "Proporcional"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgid "Push"
+msgstr "Push"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Right Half"
+msgstr "Metada Derecha"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Show"
+msgstr "Amosar"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Show crosshairs intersection"
+msgstr "Amosar la interseición de les cruces"
+
+#. long delay
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "Thick"
+msgstr "Gruesu"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Thickness"
+msgstr "Grosor"
+
+#. short delay
+#: ../panels/universal-access/zoom-options.ui.h:29
+msgid "Thin"
+msgstr "Finu"
+
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgid "To keep the pointer centered"
+msgstr "Caltener el punteru centráu"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgid "To keep the pointer visible"
+msgstr "Caltener el punteru visible"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgid "Top Half"
+msgstr "Metada superior"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgid "Zoom Options"
+msgstr "Opciones de zoom"
+
+#: ../panels/user-accounts/run-passwd.c:426
+msgid "Authentication failed"
+msgstr "Falló l'autenticación"
+
+#: ../panels/user-accounts/run-passwd.c:506
+#: ../panels/user-accounts/um-password-dialog.c:375
+#, c-format
+msgid "The new password is too short"
+msgstr "La contraseña nueva ye enforma curtia"
+
+#: ../panels/user-accounts/run-passwd.c:512
+#, c-format
+msgid "The new password is too simple"
+msgstr "La contraseña nueva ye enforma cenciella."
+
+#: ../panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "La contraseña antigua y la nueva son abondo asemeyaes"
+
+#: ../panels/user-accounts/run-passwd.c:521
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "La contraseña nueva yá s'usara recientemente."
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "La contraseña nueva tien de tener carauteres numbéricos o especiales"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "La contraseña nueva y l'antigua son la mesma"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Camudóse la contraseña dende que t'autenticaste inicialmente."
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "La contraseña nueva nun contién suficientes caráuteres diferentes"
+
+#: ../panels/user-accounts/run-passwd.c:540
+#, c-format
+msgid "Unknown error"
+msgstr "Fallu desconocíu"
+
+#: ../panels/user-accounts/um-account-dialog.c:73
+msgid "Failed to create user"
+msgstr "Falló al crear l'usuariu"
+
+#: ../panels/user-accounts/um-account-type.c:35
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Estándar"
+
+#: ../panels/user-accounts/um-account-type.c:37
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Alministrador"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:107
+msgid "You are not allowed to access the device. Contact your system administrator."
+msgstr "Nun tienes permisu pa entrar nel preséu. Contauta col alministrador del to sistema."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:109
+msgid "The device is already in use."
+msgstr "El preséu yá se ta usando"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:111
+msgid "An internal error occurred."
+msgstr "Hebo un fallu internu."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:181
+#: ../panels/user-accounts/um-fingerprint-dialog.c:182
+msgid "Enabled"
+msgstr "Activáu"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:224
+msgid "Delete registered fingerprints?"
+msgstr "¿Desaniciar les buelgues rexistraes?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:228
+msgid "_Delete Fingerprints"
+msgstr "_Desaniciar buelgues"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:235
+msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
+msgstr "¿Quies desaniciar les tos buelgues rexistraes y asina desactivar l'entamu de sesión con buelga?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:363
+msgid "Done!"
+msgstr "¡Fecho!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:410
+#: ../panels/user-accounts/um-fingerprint-dialog.c:432
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "Nun se fue a acceder al preséu «%s»"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:481
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "Nun pudo arrancase la captura dixital nel preséu «%s»"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:533
+msgid "Could not access any fingerprint readers"
+msgstr "Nun se pudo acceder a denguna llectura de buelgues"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:534
+msgid "Please contact your system administrator for help."
+msgstr "Contauta col alministrador del to sistema pa que t'aíde"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:571
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Enable Fingerprint Login"
+msgstr "Activar l'entamu de sesión con buelga"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:605
+#, c-format
+msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
+msgstr "P'activar l'aniciu de sesión con buelga dixital, tienes de guardar una buelga emplegando'l preséu '%s'."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:612
+msgid "Selecting finger"
+msgstr "Seleicionando deu"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:613
+msgid "Enrolling fingerprints"
+msgstr "Rexistrando buelgues dixitales"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:614
+msgid "Summary"
+msgstr "Resume"
+
+#: ../panels/user-accounts/um-password-dialog.c:179
+msgid "More choices..."
+msgstr "Más opciones…"
+
+#: ../panels/user-accounts/um-password-dialog.c:285
+msgid "Please choose another password."
+msgstr "Escueyi otra contraseña."
+
+#: ../panels/user-accounts/um-password-dialog.c:294
+msgid "Please type your current password again."
+msgstr "Escribi otra vuelta la contraseña actual."
+
+#: ../panels/user-accounts/um-password-dialog.c:300
+msgid "Password could not be changed"
+msgstr "Nun pudo camudase la contraseña"
+
+#: ../panels/user-accounts/um-password-dialog.c:372
+msgid "You need to enter a new password"
+msgstr "Tienes d'introducir una contraseña"
+
+#: ../panels/user-accounts/um-password-dialog.c:381
+msgid "You need to confirm the password"
+msgstr "Tienes de confirmar la contraseña"
+
+#: ../panels/user-accounts/um-password-dialog.c:384
+msgid "The passwords do not match"
+msgstr "Les contraseñes nun concasen"
+
+#: ../panels/user-accounts/um-password-dialog.c:390
+msgid "You need to enter your current password"
+msgstr "Tienes d'introducir la contraseña actual"
+
+#: ../panels/user-accounts/um-password-dialog.c:393
+msgid "The current password is not correct"
+msgstr "La contraseña actual nun ye correuta"
+
+#: ../panels/user-accounts/um-password-dialog.c:466
+#: ../panels/user-accounts/um-password-dialog.c:693
+msgctxt "Password strength"
+msgid "Too short"
+msgstr "Enforma curtia"
+
+#: ../panels/user-accounts/um-password-dialog.c:469
+#: ../panels/user-accounts/um-password-dialog.c:694
+msgctxt "Password strength"
+msgid "Weak"
+msgstr "Feble"
+
+#: ../panels/user-accounts/um-password-dialog.c:471
+#: ../panels/user-accounts/um-password-dialog.c:695
+msgctxt "Password strength"
+msgid "Fair"
+msgstr "Regular"
+
+#: ../panels/user-accounts/um-password-dialog.c:473
+#: ../panels/user-accounts/um-password-dialog.c:696
+msgctxt "Password strength"
+msgid "Good"
+msgstr "Bona"
+
+#: ../panels/user-accounts/um-password-dialog.c:475
+#: ../panels/user-accounts/um-password-dialog.c:697
+msgctxt "Password strength"
+msgid "Strong"
+msgstr "Fuerte"
+
+#: ../panels/user-accounts/um-password-dialog.c:514
+msgid "Passwords do not match"
+msgstr "Les contraseñes nun concasen"
+
+#: ../panels/user-accounts/um-password-dialog.c:540
+msgid "Wrong password"
+msgstr "Contraseña incorreuta"
+
+#: ../panels/user-accounts/um-photo-dialog.c:97
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+msgid "Select"
+msgstr "Seleicionar"
+
+#: ../panels/user-accounts/um-photo-dialog.c:445
+msgid "Disable image"
+msgstr "Desactivar imaxe"
+
+#: ../panels/user-accounts/um-photo-dialog.c:463
+msgid "Take a photo..."
+msgstr "Tomar una semeya…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:481
+msgid "Browse for more pictures..."
+msgstr "Restolar por más imáxenes…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:706
+#, c-format
+msgid "Used by %s"
+msgstr "Usada por %s"
+
+#: ../panels/user-accounts/um-user-manager.c:450
+#, c-format
+msgid "A user with name '%s' already exists."
+msgstr "Yá hai otru usuariu con el nome «%s»."
+
+#: ../panels/user-accounts/um-user-manager.c:546
+msgid "This user does not exist."
+msgstr "Esti usuariu nun esiste."
+
+#: ../panels/user-accounts/um-user-panel.c:357
+msgid "Failed to delete user"
+msgstr "Falló al desaniciar l'usuariu"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "You cannot delete your own account."
+msgstr "Nun pues desaniciar la to propia cuenta."
+
+#: ../panels/user-accounts/um-user-panel.c:426
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s aínda ta rexistráu nel sistema"
+
+#: ../panels/user-accounts/um-user-panel.c:430
+msgid "Deleting a user while they are logged in can leave the system in an inconsistent state."
+msgstr "Desaniciar a un usuariu mentanto ta coneutáu nel sistema pue dexar al sistema nun estáu inconsistente."
+
+#: ../panels/user-accounts/um-user-panel.c:439
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "¿Quies caltener los ficheros de %s?"
+
+#: ../panels/user-accounts/um-user-panel.c:443
+msgid "It is possible to keep the home directory, mail spool and temporary files around when deleting a user account."
+msgstr "Ye dable caltener la carpeta personal, el «spool» del corréu y los ficheros temporales al desaniciar una cuenta d'usuariu."
+
+#: ../panels/user-accounts/um-user-panel.c:446
+msgid "_Delete Files"
+msgstr "_Desaniciar ficheros"
+
+#: ../panels/user-accounts/um-user-panel.c:447
+msgid "_Keep Files"
+msgstr "_Caltener ficheros"
+
+#: ../panels/user-accounts/um-user-panel.c:499
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Cuenta desactivada"
+
+#: ../panels/user-accounts/um-user-panel.c:507
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Pa configurar nel siguiente aniciu de sesión"
+
+#: ../panels/user-accounts/um-user-panel.c:510
+msgctxt "Password mode"
+msgid "None"
+msgstr "Dengún"
+
+#: ../panels/user-accounts/um-user-panel.c:845
+msgid "Failed to contact the accounts service"
+msgstr "Falló al contautar col serviciu de cuentes"
+
+#: ../panels/user-accounts/um-user-panel.c:847
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Asegúrate de que'l serviciu de cuentes ta instaláu y activáu."
+
+#: ../panels/user-accounts/um-user-panel.c:887
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Pa facer los cambeos\n"
+"calca primero l'iconu *"
+
+#: ../panels/user-accounts/um-user-panel.c:925
+msgid "Create a user"
+msgstr "Crear un usuariu"
+
+#: ../panels/user-accounts/um-user-panel.c:936
+#: ../panels/user-accounts/um-user-panel.c:1225
+msgid ""
+"To create a user,\n"
+"click the * icon first"
+msgstr ""
+"Pa crear un usuariu\n"
+"calca primero l'iconu *"
+
+#: ../panels/user-accounts/um-user-panel.c:945
+msgid "Delete the selected user"
+msgstr "Desaniciar l'usuariu esbilláu"
+
+#: ../panels/user-accounts/um-user-panel.c:957
+#: ../panels/user-accounts/um-user-panel.c:1230
+msgid ""
+"To delete the selected user,\n"
+"click the * icon first"
+msgstr ""
+"Pa desaniciar l'usuariu esbilláu\n"
+"calca primero l'iconu *"
+
+#: ../panels/user-accounts/um-user-panel.c:1134
+msgid "My Account"
+msgstr "La mio cuenta"
+
+#: ../panels/user-accounts/um-user-panel.c:1144
+msgid "Other Accounts"
+msgstr "Otres cuentes"
+
+#: ../panels/user-accounts/um-utils.c:512
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr "Yá esiste un nome d'usuariu col nome «%s»"
+
+#: ../panels/user-accounts/um-utils.c:516
+#, c-format
+msgid "The username is too long"
+msgstr "El nome d'usuariu ye enforma llargu"
+
+#: ../panels/user-accounts/um-utils.c:519
+msgid "The username cannot start with a '-'"
+msgstr "El nome d'usuariu nun pue entamar por «-»"
+
+#: ../panels/user-accounts/um-utils.c:522
+msgid ""
+"The username must only consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr ""
+"El nome d'usuariu tien de contener:\n"
+" ➣ lletres del alfabetu inglés\n"
+" ➣ díxitos\n"
+" ➣ cualquiera de los caráuteres «.», «-» y «_»"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Add or remove users"
+msgstr "Amestar o quitar usuarios"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "aniciu;sesión;nome;buelga;avatar;logu;cara;contraseña;"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "User Accounts"
+msgstr "Cuentes d'usuariu"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "Cr_eate"
+msgstr "Cr_ear"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "Create new account"
+msgstr "Crear una cuenta nueva"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "_Account Type"
+msgstr "_Triba de cuenta"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "_Full name"
+msgstr "Nome _completu"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+msgid "_Username"
+msgstr "Nome d'_usuariu"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "C_onfirm password"
+msgstr "C_onfirmar contraseña"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+msgid "Ch_ange"
+msgstr "Cam_biar"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Changing password for"
+msgstr "Cambiando la contraseña pa"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "Choose a generated password"
+msgstr "Escoyer una contraseña xenerada"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Choose password at next login"
+msgstr "Escoyer una contraseña nel siguiente aniciu de sesión"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _password"
+msgstr "Contraseña _actual"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Disable this account"
+msgstr "Desactivar esta cuenta"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Enable this account"
+msgstr "Activar esta cuenta"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+msgid "Fair"
+msgstr "Regular"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+msgid "How to choose a strong password"
+msgstr "Cómo escoyer una contraseña fuerte"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+msgid "Log in without a password"
+msgstr "Aniciar sesión ensin contraseña"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+msgid "Set a password now"
+msgstr "Afitar agora una contraseña"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid "This hint may be displayed at the login screen.  It will be visible to all users of this system.  Do <b>not</b> include the password here."
+msgstr "Esti conseyu pue amosase na pantalla d'aniciu. Va ser visible pa tolos usuarios d'esti sistema. <b>Nun</b> incluyas equí la to contraseña."
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+msgid "_Action"
+msgstr "_Aición"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:15
+msgid "_Hint"
+msgstr "C_onseyu"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:16
+msgid "_New password"
+msgstr "Contraseña _nueva"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:17
+msgid "_Show password"
+msgstr "_Amosar contraseña"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+msgid "Browse"
+msgstr "Restolar"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+msgid "Cancel"
+msgstr "Encaboxar"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+msgid "Changing photo for:"
+msgstr "Cambiando la semeya pa:"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+msgid "Choose a picture that will be shown at the login screen for this account."
+msgstr "Escueyi la imaxe que s'amosará na pantalla d'aniciu de sesión pa esta cuenta."
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+msgid "Gallery"
+msgstr "Galería"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr "Semeya"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+msgid "Take a photograph"
+msgstr "Facer una semeya"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+msgid "A_utomatic Login"
+msgstr "_Aniciu automáticu de sesión"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+msgid "Account Information"
+msgstr "Información de Cuenta"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Account _type"
+msgstr "_Triba de cuenta"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "Opciones d'aniciu de sesión"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Fingerprint Login"
+msgstr "Aniciu de sesión con _buelga"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "_Language"
+msgstr "_Llingua"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Password"
+msgstr "C_ontraseña"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left little finger"
+msgstr "Moñín esquierdu"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left middle finger"
+msgstr "Deu mediu esquierdu"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left ring finger"
+msgstr "Deu anular esquierdu"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Left thumb"
+msgstr "Pulgar esquierdu"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right little finger"
+msgstr "Moñín drechu"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right middle finger"
+msgstr "Deu mediu drechu"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right ring finger"
+msgstr "Deu anular drechu"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+msgid "Right thumb"
+msgstr "Pulgar drechu"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
+msgstr "La to buelga dixital guardóse correutamente. Agora deberíes poder aniciar sesión emplegando'l llector de buelgues dixital."
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "Deu índiz _izquierdu"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "_Otru deu:"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid "_Right index finger"
+msgstr "_Deu índiz derechu"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Back"
+msgstr "Atrás"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Bluetooth Settings"
+msgstr "Preferencies de Bluetooth"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Calibrate..."
+msgstr "Calibrar..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilidá de presión de borrador"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Firm"
+msgstr "Firme"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Forward"
+msgstr "Alantre"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Left Mouse Button Click"
+msgstr "Pulsación del botón izquierdu del mur"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Left-Handed Orientation:"
+msgstr "Orientación pa maniegos:"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Lower Button"
+msgstr "Botón inferior"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Middle Mouse Button Click"
+msgstr "Pulsación del botón central del mur"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "No Action"
+msgstr "Denguna aición"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "No tablet detected"
+msgstr "Tableta non deteutada"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Enchufa o prende la to tableta Wacom"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Right Mouse Button Click"
+msgstr "Pulsación del botón derechu del mur"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Scroll Down"
+msgstr "Desplazar abaxo"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:16
+msgid "Scroll Left"
+msgstr "Desplazar a la izquierda"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:17
+msgid "Scroll Right"
+msgstr "Desplazar a la derecha"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:18
+msgid "Scroll Up"
+msgstr "Mover arriba"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:19
+msgid "Soft"
+msgstr "Blandu"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:20
+msgid "Stylus"
+msgstr "Stylus"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:21
+msgid "Tablet (absolute)"
+msgstr "Tableta (completa)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:22
+msgid "Tablet Preferences"
+msgstr "Preferencies de tableta"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:23
+msgid "Tip Pressure Feel"
+msgstr "Sensibilidá de presión del llápiz"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:24
+msgid "Top Button"
+msgstr "Botón superior"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:25
+msgid "Touchpad (relative)"
+msgstr "Touchpad (rellativu)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:26
+msgid "Tracking Mode"
+msgstr "Mou de rastréu"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:27
+msgid "Wacom Tablet"
+msgstr "Tableta Wacom"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+msgid "Set your Wacom tablet preferences"
+msgstr "Afita les preferencies de la to tableta Wacom"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Llápiz;Borrador;Mur;"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Wacom Graphics Tablet"
+msgstr "Tableta gráfica Wacom"
+
+#: ../shell/control-center.c:54
+msgid "Enable verbose mode"
+msgstr "Activar el mou detalláu"
+
+#: ../shell/control-center.c:55
+msgid "Show the overview"
+msgstr "Amosar la visión xeneral"
+
+#: ../shell/control-center.c:56
+#: ../shell/control-center.c:57
+#: ../shell/control-center.c:58
+msgid "Show help options"
+msgstr "Amosar opciones d'aida"
+
+#: ../shell/control-center.c:59
+msgid "Panel to display"
+msgstr "Panel a amosar"
+
+#: ../shell/control-center.c:81
+msgid "- System Settings"
+msgstr "- Axustes del sistema"
+
+#: ../shell/control-center.c:89
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"Executar '%s --help' pa ver una llista completa de les opciones de comandu disponibles.\n"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: ../shell/shell.ui.h:1
+msgid "System Settings"
+msgstr "Preferencies del sistema"
+
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Centru de control"
+
+#~ msgid "Appearance"
+#~ msgstr "Aspeutu"
+#~ msgid "<b>Background</b>"
+#~ msgstr "<b>Fondu</b>"
+#~ msgid "<b>Theme</b>"
+#~ msgstr "<b>Tema</b>"
+#~ msgid "Theme to be used for the UI"
+#~ msgstr "Tema usáu na interfaz d'usuariu"
+#~ msgid "Media and Autorun"
+#~ msgstr "Soportes y autoexecución"
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "Configurar los soportes y preferencies d'autoexecución"
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "cd;dvd;usb;soníu;videu;discu;"
+#~ msgid "Keyboard Layout"
+#~ msgstr "Distribución del tecláu"
+#~ msgid "Apply system wide"
+#~ msgstr "Aplicar en tol sistema"
+#~ msgid "Ask me"
+#~ msgstr "Entrúgame"
+#~ msgid "Shutdown"
+#~ msgstr "Apagar"
+#~ msgid "Suspend"
+#~ msgstr "Suspender"
+#~ msgid "When the lid is closed:"
+#~ msgstr "Cuando la cubierta tea zarrada"
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr "Debaxo namái van llistase perfiles compatibles col preséu."
+#~ msgid "Never"
+#~ msgstr "Enxamás"
+#~ msgid "_Turn off after:"
+#~ msgstr "_Apagar dempués de:"
+#~ msgid "Mute"
+#~ msgstr "Silenciar"
+#~ msgid "_All Settings"
+#~ msgstr "_Toles configuraciones"
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new key "
+#~ "combination, or press backspace to clear."
+#~ msgstr ""
+#~ "Pa editar una combinación nueva calque na filera correspondiente y teclee "
+#~ "una combinación de tecles nueva, o calque Retrocesu pa desaniciala."
+#~ msgid "Reset"
+#~ msgstr "Resetear"
+#~ msgid "Apply System-Wide..."
+#~ msgstr "Aplica a tol sistema..."
+#~ msgid "Off"
+#~ msgstr "Apagáu"
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr ""
+#~ "Fallu al desaniciar una combinación de tecles na base de datos de "
+#~ "configuración: %s"
+#~ msgid "Mirror Screens"
+#~ msgstr "Mirror Screens"
+#~ msgid "Could not install theme engine"
+#~ msgstr "Nun pudo instalase'l motor del tema"
+#~ msgid "Install"
+#~ msgstr "Instalar"
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Maximizar horizontalmente"
+#~ msgid "Maximize Vertically"
+#~ msgstr "Maximizar verticalmente"
+#~ msgid "Documents"
+#~ msgstr "Documentos"
+#~ msgid "Ignored Hosts"
+#~ msgstr "Hosts inoraos"
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "Especifique'l nome de la páxina p'amosar (general|accessibility)"
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Simular pulsaciones de múltiples tecles"
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "Permitir remanar el _punteru usando'l tecláu numbéricu"
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "B_loquiar la pantalla pa forciar un descansu d'escritura"
+#~ msgid "_Language:"
+#~ msgstr "_Llingua:"
+#~ msgid "_Country:"
+#~ msgstr "_País:"
+#~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#~ msgstr ""
+#~ "Permitir conmutar les carauterístiques d'_accesibilidá dende "
+#~ "combinaciones de tecles"
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Comentarios sobro los soníos d'accesibilidá del tecláu"
+#~ msgid "By _language"
+#~ msgstr "Por _llingua"
+#~ msgid "By _country"
+#~ msgstr "Por _país"
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Co_mentarios sobro'l soníu..."
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "Especifique'l nome de la páxina p'amosar (internet|multimedia|system|a11y)"
+#~ msgid "Overwrite _All"
+#~ msgstr "Sobroscribir _too"
+#~ msgid "_Skip"
+#~ msgstr "_Saltar"
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "El ficheru «%s» yá esiste. ¿Quier sobroscribilu?"
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "Pue revertise la cabera suxerencia de tipografía aplicada."
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "Esti tema nun s'amosará como se pretende porque'l motor de temes GTK+ "
+#~ "necesariu «%s» nun ta instaláu."
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "_Accesibilidá del Mur"
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Saltar al diálogu d'Accesibilidá del mur"
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- GNOME Preferencies del Mur"
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "_Super (o «Logu de Windows»)"
+#~ msgid "Show click type _window"
+#~ msgstr "Amosar la _ventana del tipu de pulsación"
+#~ msgid "Cannot install theme"
+#~ msgstr "Nun pue instalase'l tema"
+#~ msgid "Ci_ty:"
+#~ msgstr "Ci_udá:"
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "Nun ye dable apagar el canal de E/S backend_stdout: %s"
+#~ msgid "gesture|Move down"
+#~ msgstr "Mover abaxo"
+#~ msgid "Open in File Manager"
+#~ msgstr "Abrir nel alministrador de ficheros"
+#~ msgid "Web _log:"
+#~ msgstr "Rexistr_u Web:"
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Permisos insuficientes pa instalar el tema en:\n"
+#~ "%s"
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "El nome de la xera que despliegar nel centru de control siguíu por un "
+#~ "separtador «;» y llueu el nome d'un ficheru .desktop asociáu que llanzar "
+#~ "pa esa xera."
+#~ msgid "User name:"
+#~ msgstr "Nome d'usuariu:"
+#~ msgid "Save Theme As..."
+#~ msgstr "Guardar tema como…"
+#~ msgid "Typing Monitor"
+#~ msgstr "Monitor de tecléu"
+#~ msgid "Fraction completed"
+#~ msgstr "Fracción completada"
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr ""
+#~ "La to clave foi camudada dende la to identificación inicial! Por favor re-"
+#~ "identificate."
+#~ msgid "Pointer"
+#~ msgstr "Punteru"
+#~ msgid "Parent window of the dialog"
+#~ msgstr "Ventana raigón del diálogu"
+#~ msgid "Unable to launch backend"
+#~ msgstr "Nun ye dable llanzar el backend"
+#~ msgid "_Selected items:"
+#~ msgstr "Elementos _seleicionaos:"
+#~ msgid "Open with Default Application"
+#~ msgstr "Abrir cola aplicación predeterminada"
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+#~ msgid "White Pointer"
+#~ msgstr "Punteru Blancu"
+#~ msgid "Current URI index"
+#~ msgstr "Índiz URI actual"
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sub_pixel (LCDs)"
+#~ msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgstr "¿Daveres quier esaniciar pa siempres «%s»?"
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "La contraseña nueva y la vieya son abondo asemeyaes"
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Güei %H:%M"
+#~ msgid "Multimedia"
+#~ msgstr "Multimedia"
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr ""
+#~ "El cambéu del tema de cursor nun fadrá efeutu hasta que salga y anicie "
+#~ "sesión de nuevu."
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>Configuración _Automática del proxy</b>"
+#~ msgid "Window Preferences"
+#~ msgstr "Preferencies de Ventana"
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "Dir al diálogu d'Entrada Acesible"
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr ""
+#~ "Abandona la consola cuando se tien fecho una aición d'amestáu o desaniciu"
+#~ msgid "Font Rendering Details"
+#~ msgstr "Detalles de Procesamientu de Fontes"
+#~ msgid "Please make sure that the applet is properly installed"
+#~ msgstr "Tea xuru de que la miniaplicación ta instalada correchamente"
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr ""
+#~ "Aniciar la páxina amosando la configuración del descansu d'escritura"
+#~ msgid "gesture|Move right"
+#~ msgstr "Mover a la drecha"
+#~ msgid "Run in t_erminal"
+#~ msgstr "Executar nel t_erminal"
+#~ msgid "_Password dialogs as normal windows"
+#~ msgstr "Diálogos de _Clave como una ventana normal"
+#~ msgid "Totem Movie Player"
+#~ msgstr "Reproductor de películes Totem"
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "Magnificador de KDE ensin llector de pantalla"
+#~ msgid "R_esolution:"
+#~ msgstr "R_esolución:"
+#~ msgid "The password is too short."
+#~ msgstr "La contraseña ye mui curtia"
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%d %b %l:%M %p"
+#~ msgid "<b>_Use authentication</b>"
+#~ msgstr "<b>_Utiliza autenticación</b>"
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI ta tresfiriendo a"
+#~ msgid "The two passwords are not equal."
+#~ msgstr "Les dos claves nun son iguales."
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Índiz URI actual - entama dende 1"
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Abrir %s</b>"
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Llector de pantalla de Linux con magnificador"
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "Nun ye dable apagar el canal de E/S backend_stdin: %s"
+#~ msgid "_Reset to Defaults"
+#~ msgstr "_Restablecer valores predeterminaos"
+#~ msgid "From URI"
+#~ msgstr "De URI"
+#~ msgid "C_ompany:"
+#~ msgstr "C_ompañía:"
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "Hebo un fallu al estrayer el tema."
+#~ msgid "H_TTP proxy:"
+#~ msgstr "Proxy H_TTP:"
+#~ msgid "_Password:"
+#~ msgstr "_Contraseña:"
+#~ msgid "Assistive Technologies"
+#~ msgstr "Teunoloxíes d'asistencia"
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Camudar Cont_raseña..."
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Vistosidá amestada por Anders Carlsson"
+#~ msgid "Beep when a _modifier key is pressed"
+#~ msgstr "Pitar al calcar un _modificador"
+#~ msgid "?"
+#~ msgstr "?"
+#~ msgid "Linux Screen Reader"
+#~ msgstr "Llector de pantalla de Linux"
+#~ msgid "_Install..."
+#~ msgstr "_Instalar…"
+#~ msgid "_Home:"
+#~ msgstr "_Domiciliu:"
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "Pitar al calcar una _tecla conmutable"
+#~ msgid "A computer break reminder."
+#~ msgstr "Un recordatoriu pa los descansos frente a la computadora."
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "El xestor de ventanes «%s» nun rexistró una ferramienta de configuración\n"
+#~ msgid "gesture|Move left"
+#~ msgstr "Mover a la esquierda"
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Duración del descansu cuando la escritura nun ta permitía"
+#~ msgid "dots per inch"
+#~ msgstr "puntos por pulgada"
+#~ msgid "Muine Music Player"
+#~ msgstr "Reproductor de música Muine"
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Preferencies del Proxy de Rede"
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "Especifique'l nome de la páxina p'amosar (theme|background|fonts|"
+#~ "interface)"
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "Proxy HTTP _Seguru:"
+#~ msgid "Default Pointer"
+#~ msgstr "Punteru Predetermináu"
+#~ msgid "Add Wallpaper"
+#~ msgstr "Amestar Fondu d'Escritoriu"
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Desaniciar de los programes d'entamu"
+#~ msgid "_Motion threshold:"
+#~ msgstr "Umbral de _movimientu:"
+#~ msgid "Find Now"
+#~ msgstr "Guetar agora"
+#~ msgid "P._O. box:"
+#~ msgstr "Apartáu de C_orreos:"
+#~ msgid "Autoconfiguration _URL:"
+#~ msgstr "_URL d'Autoconfiguración:"
+#~ msgid "Select Image"
+#~ msgstr "Esbillar Imaxe"
+#~ msgid "P.O. _box:"
+#~ msgstr "Apartáu de C_orreos:"
+#~ msgid "_FTP proxy:"
+#~ msgstr "Proxy _FTP:"
+#~ msgid "GNOME Terminal"
+#~ msgstr "Terminal GNOME"
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Paquete de tema GNOME"
+#~ msgid "Terminator"
+#~ msgstr "Terminator"
+#~ msgid "Hom_e:"
+#~ msgstr "_Domiciliu:"
+#~ msgid "Unable to open address book"
+#~ msgstr "Incapaz d'abrir la llibreta de direiciones"
+#~ msgid "Keyboard _model:"
+#~ msgstr "_Modelu de tecláu:"
+#~ msgid "Alert Type"
+#~ msgstr "Tipu d'Avisu"
+#~ msgid "Keep Current Theme"
+#~ msgstr "Caltener el tema actual"
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Comprobar si se permite posponer los descansos"
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "Si desanicia un elementu, piérdese pa siempres."
+#~ msgid "Full Name"
+#~ msgstr "Nome Completu"
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Instala paquetes de temes pa delles partes del escritoriu"
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "píxel"
+#~ msgstr[1] "píxeles"
+#~ msgid "Controls"
+#~ msgstr "Controles"
+#~ msgid "_Slight"
+#~ msgstr "Le_ve"
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "Nomes de xeres y ficheros .desktop asociaos"
+#~ msgid "Change password"
+#~ msgstr "Camudar la Contraseña"
+#~ msgid "gesture|Move up"
+#~ msgstr "Mover arriba"
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Toles apariciones de %s reemplazaránse pol enllaz actual"
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d minutu hasta'l so siguiente descansu"
+#~ msgstr[1] "%d minutos hasta'l so siguiente descansu"
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Duración del trabayu enantes de forciar un descansu"
+#~ msgid "The password is too simple."
+#~ msgstr "La contraseña ye mui cenciella"
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Escritu por Richard Hult <richard@imendio.com>"
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Punteru Predetermináu - Actual"
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Dir al diálogu d'Aplicaciones Preferíes"
+#~ msgid "Groups"
+#~ msgstr "Grupos"
+#~ msgid "Add to Favorites"
+#~ msgstr "Amestar a favoritos"
+#~ msgid "Image/label border"
+#~ msgstr "Berbesu semeya/etiqueta"
+#~ msgid "Select your photo"
+#~ msgstr "Escueye la to semeya"
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "«%s» nun paez ser un tema válidu. Pue ser un motor de temes que tien de "
+#~ "compilar."
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "Conseña si hai de zarrar la consola cuando se tien executao una aición "
+#~ "d'amestáu o desaniciu."
+#~ msgid "C_ustomize..."
+#~ msgstr "Pe_rsonalizar..."
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+#~ msgid "GNOME OnScreen Keyboard"
+#~ msgstr "Tecláu en pantalla de GNOME"
+#~ msgid "Icons"
+#~ msgstr "Iconos"
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "_Aniciar la pulsación cuando se pare'l movimientu del punteru"
+#~ msgid "S_ocks host:"
+#~ msgstr "S_ock host:"
+#~ msgid "_Run at start"
+#~ msgstr "_Executar al entamu"
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "El monitor de tecléu usa l'área de notificación p'amosar información. "
+#~ "Paez que vusté nun tien l'área de notificación nel so panel. Pue amestala "
+#~ "calcando col botón drechu sobro'l panel y seleicionando «Amestar al "
+#~ "panel...», seleicionando «Área de notificación» y calcando en «Amestar»."
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI ta tresfiriendo de"
+#~ msgid "_Title:"
+#~ msgstr "_Títulu:"
+#~ msgid "Parent Window"
+#~ msgstr "Ventana raíz"
+#~ msgid "Models"
+#~ msgstr "Modelos"
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Punteru Blancu Grande - Actual"
+#~ msgid "All Files"
+#~ msgstr "Tolos Ficheros"
+#~ msgid "Windows"
+#~ msgstr "Ventanes"
+#~ msgid "_State/Province:"
+#~ msgstr "E_stáu/Provincia:"
+#~ msgid "_Document font:"
+#~ msgstr "Fonte de _documentu:"
+#~ msgid "_None"
+#~ msgstr "_Dengún"
+#~ msgid "Current _password:"
+#~ msgstr "Contraseña _actual:"
+#~ msgid "D_rag click:"
+#~ msgstr "Pulsación d'a_rrastre:"
+#~ msgid "_New password:"
+#~ msgstr "_Nueva contraseña:"
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "Nun pue llanzase %s: %s"
+#~ msgid "Minimize"
+#~ msgstr "Minimizar"
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Elevar les ventanes seleicionaes tres d'un intervalu"
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Zarra'l centru de control cuando s'activa una xera"
+#~ msgid "Banshee Music Player"
+#~ msgstr "Reproductor de música Banshee"
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "La contraseña vieya y la nueva son la mesma"
+#~ msgid "Slide Show"
+#~ msgstr "Amosar diapositives"
+#~ msgid "Copying '%s'"
+#~ msgstr "Copiando '%s'"
+#~ msgid "_Acceleration:"
+#~ msgstr "_Aceleración:"
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[Camudar el tema;gtk-theme-selector.desktop,Afitar les aplicaciones "
+#~ "preferíes;default-applications.desktop,Amestar imprentadora;gnome-cups-"
+#~ "manager.desktop]"
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Conexón Di_reuta a Internet</b>"
+#~ msgid "Orca with Magnifier"
+#~ msgstr "Orca con magnificador"
+#~ msgid "Beep when a key is pr_essed"
+#~ msgstr "Pitar al cal_car una tecla"
+#~ msgid "Show more _details"
+#~ msgstr "Amosar más _detalles"
+#~ msgid "Upgrade"
+#~ msgstr "Actualizar"
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Detalles Proxy HTTP"
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Ferramienta de configuración de GNOME"
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Punteru Grande - Actual"
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Nun pue amosase'l diálogu de les propiedaes del descansu d'escritura pol "
+#~ "siguiente fallu: %s"
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+#~ msgid "Remove from Favorites"
+#~ msgstr "Desaniciar de favoritos"
+#~ msgid "C_ity:"
+#~ msgstr "C_iudá:"
+#~ msgid "%l:%M %p"
+#~ msgstr "%H:%M"
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Amestar a los programes d'entamu"
+#~ msgid "_Size:"
+#~ msgstr "_Tamañu:"
+#~ msgid "Customize Theme"
+#~ msgstr "Personalizar tema"
+#~ msgid "Beep when key is _accepted"
+#~ msgstr "Pitar cuando la tecla s'_aceute"
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[Tapiz…]"
+#~ msgid "Cale_ndar:"
+#~ msgstr "Cale_ndariu:"
+#~ msgid "Authenticated!"
+#~ msgstr "¡Reconocíu!"
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Reproductor de música Rhythmbox"
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "_Usar el mesmu proxy pa tolos protocolos"
+#~ msgid "Text"
+#~ msgstr "Testu"
+#~ msgid "Personal Info"
+#~ msgstr "Información Personal"
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "Hebo un fallu al instalar el ficheru seleicionáu"
+#~ msgid "_Monochrome"
+#~ msgstr "_Monocromu"
+#~ msgid "_Preferred Applications"
+#~ msgstr "Aplicaciones _Preferíes"
+#~ msgid "Wor_k:"
+#~ msgstr "Traba_yu:"
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "El fíu salió inesperadamente"
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Nun comprobar si esiste l'área de notificación"
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Nun pue cargase l'iconu de fábrica «%s»\n"
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "El tema actual de controles nun tien sofitu pa esquemes de colores."
+#~ msgid "seconds"
+#~ msgstr "segundos"
+#~ msgid "Large White Pointer"
+#~ msgstr "Punteru Blancu Grande"
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Preferencies de les teunoloxíes d'asistencia"
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Configuración _Manual del proxy</b>"
+#~ msgid "Beep when _accessibility features are turned on or off"
+#~ msgstr ""
+#~ "Pitar cuando s'activen o desactiven les característiques d'_accesibilidá"
+#~ msgid "_Input boxes:"
+#~ msgstr "Caxes d'_entrada:"
+#~ msgid "_Window title font:"
+#~ msgstr "Fonte de títulu de _Ventana:"
+#~ msgid "_Mobile:"
+#~ msgstr "_Móvil:"
+#~ msgid "About %s"
+#~ msgstr "Tocante a %s"
+#~ msgid "Preferred Applications"
+#~ msgstr "Programes Preferíos"
+#~ msgid "_Medium"
+#~ msgstr "_Mediu"
+#~ msgid "Maximize"
+#~ msgstr "Maximizar"
+#~ msgid "Home"
+#~ msgstr "Entamu"
+#~ msgid "Appearance Preferences"
+#~ msgstr "Preferencies d'aspeutu"
+#~ msgid "_Break interval lasts:"
+#~ msgstr "D_uración del intervalu de descansu:"
+#~ msgid "Theme name must be present"
+#~ msgstr "El nome del tema tien de tar presente"
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "Instalóse'l tema «%s»."
+#~ msgid "Images"
+#~ msgstr "Imaxes"
+#~ msgid "_Application font:"
+#~ msgstr "Fonte de Progr_ama:"
+#~ msgid "_Postpone Break"
+#~ msgstr "_Posponer el descansu"
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Seleicionar ventanes cuando'l mur se mueve sobro elles"
+#~ msgid "Upside Down"
+#~ msgstr "Boca abaxo"
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "Nun pue desaniciase'l tema"
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+#~ msgid "U_sername:"
+#~ msgstr "_Usuariu:"
+#~ msgid "Roll up"
+#~ msgstr "Endolcar"
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+#~ msgid "Checking password..."
+#~ msgstr "Comprobando contraseña..."
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Pitar si se _refuga la tecla"
+#~ msgid "System error: %s."
+#~ msgstr "Error del sistema: %s."
+#~ msgid "Your password has been changed."
+#~ msgstr "La to clave foi camudada."
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "Habilitar t_eunoloxíes d'asistencia"
+#~ msgid "Contact"
+#~ msgstr "Contautu"
+#~ msgid "_Vendors:"
+#~ msgstr "_Fabricantes:"
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "Dir al diálogu de l'acesibilidá del tecláu"
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Estáu/Pro_vincia:"
+#~ msgid "Copying files"
+#~ msgstr "Copiando ficheros"
+#~ msgid "Co_mmand:"
+#~ msgstr "Co_mandu:"
+#~ msgid "A_ssistant:"
+#~ msgstr "A_sistente:"
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "Los nuevos temes instaláronse con ésitu."
+#~ msgid "_Description:"
+#~ msgstr "_Descripción:"
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+#~ msgid "Run at st_art"
+#~ msgstr "Exe_cutar al entamu"
+#~ msgid "Alert Buttons"
+#~ msgstr "Botones d'Avisu"
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr ""
+#~ "Anchu al rodiu del berbesu de la etiqueta y semeya nel diálogu d'avisu"
+#~ msgid "White Pointer - Current"
+#~ msgstr "Punteru Blancu - Actual"
+#~ msgid "Best co_ntrast"
+#~ msgstr "Meyor co_ntraste"
+#~ msgid "page"
+#~ msgstr "páxina"
+#~ msgid "_Address:"
+#~ msgstr "_Direición:"
+#~ msgid "Internet"
+#~ msgstr "Internet"
+#~ msgid "That password was incorrect."
+#~ msgstr "La contraseña foi incorreuta."
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Hebo un error intentando garrar la información de la llibreta de "
+#~ "direiciones\n"
+#~ "Servidor de Datos d'Evolution nun pudo afitar el protocolu"
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr ""
+#~ "Nun se pue aniciar l'aplicación de preferencies pal so xestor de ventanes"
+#~ msgid "To URI"
+#~ msgstr "A URI"
+#~ msgid "_Ignore fast duplicate keypresses"
+#~ msgstr "_Inorar pulsaciones duplicaes rápides"
+#~ msgid "_Tooltips:"
+#~ msgstr "_Conseyos:"
+#~ msgid "File System"
+#~ msgstr "Sistema de Ficheros"
+#~ msgid "Apply New Theme"
+#~ msgstr "Aplicar el nuevu tema"
+#~ msgid "Window Border"
+#~ msgstr "Llende de la Ventana"
+#~ msgid "Network Proxy"
+#~ msgstr "Proxy de Rede"
+#~ msgid "Preview:"
+#~ msgstr "Vista previa:"
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Doble-click na barra de títulu pa facer esta aición:"
+#~ msgid "The current theme suggests a background."
+#~ msgstr "El tema actual suxer un tapiz."
+#~ msgid "Beep when a key is reje_cted"
+#~ msgstr "Pitar si se refu_ga la tecla"
+#~ msgid "Orca"
+#~ msgstr "Orca"
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "«%s» nun paez ser un tema válidu."
+#~ msgid "_Single click:"
+#~ msgstr "Pulsación _cenciella:"
+#~ msgid "Best _shapes"
+#~ msgstr "Meyores forme_s"
+#~ msgid "Proxy Configuration"
+#~ msgstr "Configuración del Proxy"
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Permitir p_osponer los descansos"
+#~ msgid "_Windows:"
+#~ msgstr "_Ventanes:"
+#~ msgid "_Work:"
+#~ msgstr "_Trabayu:"
+#~ msgid "Disa_ble sticky keys if two keys are pressed together"
+#~ msgstr ""
+#~ "_Desactivar les tecles persistentes si se calquen dos tecles al empar"
+#~ msgid "Common Tasks"
+#~ msgstr "Xeres comunes"
+#~ msgid "Vendors"
+#~ msgstr "Fabricantes"
+#~ msgid "Rename..."
+#~ msgstr "Renomar..."
+#~ msgid "Standard XTerminal"
+#~ msgstr "XTerminal Estándar"
+#~ msgid "_Work interval lasts:"
+#~ msgstr "D_uración del intervalu de trabayu:"
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr ""
+#~ "D_isparar la pulsación secundaria al caltener pulsáu el botón primariu"
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "Magnificador de GNOME ensin llector de pantalla"
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "Si ye braero, el centru de control zarrarase cuando s'active una «Xera "
+#~ "común»."
+#~ msgid "Cou_ntry:"
+#~ msgstr "P_aís:"
+#~ msgid "D_ouble click:"
+#~ msgstr "Pulsación d_uble:"
+#~ msgid "Theme Installer"
+#~ msgstr "Instalador de temes"
+#~ msgid "Visual Assistance"
+#~ msgstr "Asistencia visual"
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Abrir un diálogu pa especificar el color"
+#~ msgid "Move to Trash"
+#~ msgstr "Mover a la papelera"
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+#~ msgid "filename"
+#~ msgstr "nome de ficheru"
+#~ msgid "Take a break!"
+#~ msgstr "¡Asele un pocu!"
+#~ msgid "aterm"
+#~ msgstr "aterm"
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Intervalu enantes d'elevar:"
+#~ msgid "Work _fax:"
+#~ msgstr "_Fax del trabayu:"
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Abrir</b>"
+#~ msgid "Save _background image"
+#~ msgstr "Guardar imaxe de _fondu"
+#~ msgid "key not found [%s]\n"
+#~ msgstr "tecla non alcontrada [%s]\n"
+#~ msgid "Co_untry:"
+#~ msgstr "P_aís:"
+#~ msgid "Could not load the main interface"
+#~ msgstr "Nun fue a cargar la interfaz principal"
+#~ msgid "_Models:"
+#~ msgstr "_Modelos:"
+#~ msgid "minutes"
+#~ msgstr "minutos"
+#~ msgid "Colors"
+#~ msgstr "Colores"
+#~ msgid "New Document"
+#~ msgstr "Documentu nuevu"
+#~ msgid "The %s utility is not installed."
+#~ msgstr "La utilidá %s nun ta instalada."
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "Ayeri %H:%M"
+#~ msgid "Theme Packages"
+#~ msgstr "Paquetes de temes"
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "N_amái aceutar tecles calcaes durante ciertu tiempu"
+#~ msgid "Keyboard Shortcuts"
+#~ msgstr "Atayos del Tecláu"
+#~ msgid "About Me"
+#~ msgstr "Tocante a min"
+#~ msgid "Large Pointer"
+#~ msgstr "Punteru Grande"
+#~ msgid "Desktop"
+#~ msgstr "Escritoriu"
+#~ msgid "Apply Background"
+#~ msgstr "Aplicar tapiz"
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Copiando ficheru: %u de %u"
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "La instalación del tema «%s» falló."
+#~ msgid "A system error has occurred"
+#~ msgstr "Hebo un fallu del sistema"
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "El tema de GNOME %s instalóse correchamente"
+#~ msgid "N_one"
+#~ msgstr "D_engún"
+#~ msgid "E_xecute flag:"
+#~ msgstr "Etiqueta d'e_xecución:"
+#~ msgid "Delete"
+#~ msgstr "Desaniciar"
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Aniciar la páxina amosando la configuración d'accesibilidá"
+#~ msgid "Fonts"
+#~ msgstr "Fontes"
+#~ msgid "_Overwrite"
+#~ msgstr "_Sobroscribir"
+#~ msgid "The type of alert"
+#~ msgstr "El tipu d'alerta"
+#~ msgid "D_etails..."
+#~ msgstr "D_etalles..."
+#~ msgid "_Manager:"
+#~ msgstr "Al_ministrador:"
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Menos d'un minutu hasta'l siguiente descansu"
+#~ msgid "Gra_yscale"
+#~ msgstr "Escala de b_uxos"
+#~ msgid "Remove from System Items"
+#~ msgstr "Desaniciar d'elementos de sistema"
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Pa mover una ventana, caltenga calcada esta tecla y llueu arrastre la "
+#~ "ventana:"
+#~ msgid "_Profession:"
+#~ msgstr "_Profesión:"
+#~ msgid "Other"
+#~ msgstr "Otru"
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Los botones que s'amuesen nel diálogu d'alerta"
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Preferencies del tecláu"
+#~ msgid "%b %d %Y"
+#~ msgstr "%d %b %Y"
+#~ msgid "gesture|Disabled"
+#~ msgstr "Desactiváu"
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr ""
+#~ "Conseña si hai de zarrar la consola cuando se tien executao una aición "
+#~ "d'aniciu."
+#~ msgid "_Department:"
+#~ msgstr "_Departamentu:"
+#~ msgid "Total number of URIs"
+#~ msgstr "Númberu total d'URIs"
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Namái aplicar la configuración y salir (namái por compatibilidad; remanáu "
+#~ "agora por un degorriu)"
+#~ msgid "H_yper"
+#~ msgstr "_Hiper"
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Fraición de tresferencia actual completa"
+#~ msgid "Close and _Log Out"
+#~ msgstr "Zarrar y _Salir"
+#~ msgid "Uninstall"
+#~ msgstr "Desinstalar"
+#~ msgid "_Full"
+#~ msgstr "C_ompletu"
+#~ msgid "Typing Break"
+#~ msgstr "Descansu d'escritura"
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Abandona la consola cuando se tien fecho una aición d'aniciu"
+#~ msgid "New Spreadsheet"
+#~ msgstr "Fueya de cálculu nueva"
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- Preferencies del tecláu de GNOME"
+#~ msgid "Total URIs"
+#~ msgstr "URIs Totales"
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus con magnificador"
+#~ msgid "Port:"
+#~ msgstr "Puertu:"
+#~ msgid "_Variants:"
+#~ msgstr "_Variantes:"
+#~ msgid "_Style:"
+#~ msgstr "E_stilu:"
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+#~ msgid "No Image"
+#~ msgstr "Nun hai Imaxe"
+#~ msgid "Change pa_ssword"
+#~ msgstr "Camudar la Contraseña"
+#~ msgid "_Authenticate"
+#~ msgstr "_Autenticar"
+#~ msgid "_Home page:"
+#~ msgstr "Pá_xina d'entamu:"
+#~ msgid "_Retype new password:"
+#~ msgstr "Volve_r a escribir la nueva contraseña:"
+#~ msgid "Save _As..."
+#~ msgstr "Guardar _como…"
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "Activar l'entamu sesión con _Buelga"
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "Desactivar l'entamu sesión con _Buelga"
+#~ msgid "An internal error occured"
+#~ msgstr "Hebo un fallu internu"
+#~ msgid "Select finger"
+#~ msgstr "Escoyer deu"
+#~ msgid "New Location..."
+#~ msgstr "Allugamientu nuevu..."
+#~ msgid "Location already exists"
+#~ msgstr "L'allugamientu yá existe"
+#~ msgid "Location:"
+#~ msgstr "Allugamientu"
+#~ msgid "The location already exists."
+#~ msgstr "L'allugamientu yá existe."
+#~ msgid "C_reate"
+#~ msgstr "C_rear"
+#~ msgid "Create New Location"
+#~ msgstr "Crear un allugamientu nuevu"
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Si ta afitao a «true», entós les tipografíes OpenType miniaturizaránse."
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Si ta afitao a «true», entós les tipografíes PFC miniaturizaránse."
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Si ta afitao a «true», entós les tipografíes TrueType miniaturizaránse."
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Si ta afitao a «true», entós les tipografíes Type1 miniaturizaránse."
+#~ msgid "_Details"
+#~ msgstr "_Detalles"
+#~ msgid "_Location name:"
+#~ msgstr "N_ome d'allugamientu:"
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Pon nesta clave la orde qu'hai d'usar pa crear miniatures de les "
+#~ "tipografíes Type1."
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Conseña si hai de miniaturizar les tipografíes Type1"
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Conseña si hai de miniaturizar les tipografíes TrueType"
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Conseña si hai de miniaturizar les tipografíes PCF"
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Conseña si hai de miniaturizar les tipografíes OpenType"
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Comandu pa miniaturizar les tipografíes Type1"
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Comandu pa miniaturizar les tipografíes TrueType"
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Comandu pa miniaturizar les tipografíes PCF"
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Comandu pa miniaturizar les tipografíes OpenType"
+#~ msgid "Version:"
+#~ msgstr "Versión:"
+#~ msgid "Copyright:"
+#~ msgstr "Copyright:"
+#~ msgid "Description:"
+#~ msgstr "Descripción:"
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "usu: %s ficheru de tipografíes\n"
+#~ msgid "Name:"
+#~ msgstr "Nome:"
+#~ msgid "Style:"
+#~ msgstr "Estilu:"
+#~ msgid "Size:"
+#~ msgstr "Tamañu:"
+#~ msgid "Font Viewer"
+#~ msgstr "Visor de tipografíes"
+#~ msgid "Preview fonts"
+#~ msgstr "Vista previa de les tipografíes"
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Testu a miniaturizar (predetermináu: Aa)"
+#~ msgid "Error parsing arguments: %s\n"
+#~ msgstr "Fallu al analizar los argumentos: %s\n"
+#~ msgid "TEXT"
+#~ msgstr "TESTU"
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FICHERU-DE-TIPOGRAFÍA ARCHIVU-DE-SALIDA"
+#~ msgid "SIZE"
+#~ msgstr "TAMAÑU"
+#~ msgid "Place finger on reader"
+#~ msgstr "Pon el deu nel llector"
+#~ msgid "Swipe finger on reader"
+#~ msgstr "Pasa'l deu penriba'l llector"
+#~ msgid "Other finger: "
+#~ msgstr "Otru deu: "
+#~ msgid "Right index finger"
+#~ msgstr "Furabollos drechu"
+#~ msgid "Listen"
+#~ msgstr "Sentir"
+#~ msgid "_Delete Location"
+#~ msgstr "_Desaniciar allugamientu"
+#~ msgid "On"
+#~ msgstr "Encesu"
+#~ msgid "Flash entire _screen"
+#~ msgstr "Destellu de la pantalla _completa"
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Destellu de la barra de títulu de la _ventana"
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "Amosar rempuesta _visual pa les alertes de soníu"
+#~ msgid "Include _panel"
+#~ msgstr "Incluyir pa_nel"
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "Los cambeos p'activar les teunoloxíes d'asistencia nun tendrán efeutu "
+#~ "fasta que salga ya anicie sesión nuevamente."
+#~ msgid "Could not load user interface file: %s"
+#~ msgstr "Nun pudo cargase'l ficheru d'interfaz d'usuariu: %s"
+#~ msgid "Text beside items"
+#~ msgstr "Testu al delláu de los elementos"
+#~ msgid "Text below items"
+#~ msgstr "Testu baxo los elementos"
+#~ msgid "Solid color"
+#~ msgstr "Color sólidu"
+#~ msgid "Icons only"
+#~ msgstr "Namái iconos"
+#~ msgid "Horizontal gradient"
+#~ msgstr "Dilíu horizontal"
+#~ msgid "Upside-down"
+#~ msgstr "Al revés"
+#~ msgid "_Take a Break"
+#~ msgstr "_Tomar un descansu"
+#~ msgid "Vertical gradient"
+#~ msgstr "Dilíu Vertical"
+#~ msgid "Text only"
+#~ msgstr "Namái testu"
+#~ msgid "Telephone"
+#~ msgstr "Teléfonu"
+#~ msgid "Web"
+#~ msgstr "Web"
+#~ msgid "Email"
+#~ msgstr "Corréu-e"
+#~ msgid "Instant Messaging"
+#~ msgstr "Mensaxería nel Intre"
+#~ msgid "Work"
+#~ msgstr "Trabayu"
+#~ msgid "Job"
+#~ msgstr "Trabayu"
+#~ msgid "Change your password"
+#~ msgstr "Cambiar la to contraseña"
+#~ msgid "Hinting"
+#~ msgstr "Suxiriendo"
+#~ msgid "Preferences"
+#~ msgstr "Preferencies"
+#~ msgid "Image Viewer"
+#~ msgstr "Visor d'imáxenes"
+#~ msgid "Smoothing"
+#~ msgstr "Suavizáu"
+#~ msgid "Subpixel Order"
+#~ msgstr "Orde subpixel"
+#~ msgid "Instant Messenger"
+#~ msgstr "Mensaxería nel intre"
+#~ msgid "Terminal Emulator"
+#~ msgstr "Emulador de terminal"
+#~ msgid "Multimedia Player"
+#~ msgstr "Reproductor multimedia"
+#~ msgid "Mobility"
+#~ msgstr "Mobilidá"
+#~ msgid "Mail Reader"
+#~ msgstr "Llector de corréu"
+#~ msgid "Visual"
+#~ msgstr "Visual"
+#~ msgid "Video Player"
+#~ msgstr "Reproductor de vídeu"
+#~ msgid "Panel icon"
+#~ msgstr "Iconu de panel"
+#~ msgid "Web Browser"
+#~ msgstr "Restolador web"
+#~ msgid "Text Editor"
+#~ msgstr "Editor de Testu"
+#~ msgid "Dwell Click"
+#~ msgstr "Pulsación al posase"
+#~ msgid "Visual cues for sounds"
+#~ msgstr "Indicadores visuales pa soníos"
+#~ msgid "Mouse Orientation"
+#~ msgstr "Orientación del mur"
+#~ msgid "Locate Pointer"
+#~ msgstr "Llocalizar el punteru"
+#~ msgid "Titlebar Action"
+#~ msgstr "Aición de barra de titulu"
+#~ msgid "Install Failed"
+#~ msgstr "Falló la instalación"
+#~ msgid "Window Selection"
+#~ msgstr "Seleición de ventana"
+#~ msgid "Movement Key"
+#~ msgstr "Tecla de movimientu"
+#~ msgid "I_nstall Font"
+#~ msgstr "I_nstalar Fonte"
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr ""
+#~ "Tamién puedes usar la miniaplicación Dwell Click pa escoyer la triba "
+#~ "pulsación."
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "La nueva clave tien de contener númberos o carauteres especiales."
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "Lo_gin accesible"
+#~ msgid "_Keyboard Accessibility"
+#~ msgstr "Acesibilidá _Tecláu"
+#~ msgid "Ignore Host List"
+#~ msgstr "Inorar llista d'Agospiadores"
+#~ msgid "Start %s"
+#~ msgstr "Entamar %s"
+#~ msgid "Open with \"%s\""
+#~ msgstr "Abrir con \"%s\""
+#~ msgid "Monitor: %s"
+#~ msgstr "Monitor: %s"
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "Anubrir nel entamu (afayadizo pa precargar la consola)"
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "El to filtru «%s» nun concasa con oxetu dalu"
+#~ msgid "Left index finger"
+#~ msgstr "Furabollos esquierdu"
+#~ msgid "Get more themes online"
+#~ msgstr "Obtener más temes en llinia"
+#~ msgid "Image"
+#~ msgstr "Imaxe"
+#~ msgid "Current network location"
+#~ msgstr "Allugamientu de la rede actual"
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "URL na qu'obtener más fondos pal escritoriu. Si s'afita a una cadena "
+#~ "balera, l'enllaz nun apaez."
+#~ msgid "More themes URL"
+#~ msgstr "URL pa más temes"
+#~ msgid "More backgrounds URL"
+#~ msgstr "URL pa más fondos"
+#~ msgid "Get more backgrounds online"
+#~ msgstr "Obtener más fondos en llinia"
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "URL na qu'obtener más temes pal escritoriu. Si s'afita a una cadena "
+#~ "balera, l'enllaz nun apaez."
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Carpeta: %s"
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Nun se puede arrancar el xestor de configuración «gnome-settings-"
+#~ "daemon».\n"
+#~ "Si'l xestor de configuración de GNOME nun se ta executando, seique delles "
+#~ "preferencies nun furrulen. Esto puede ser el síntoma d'un problema con "
+#~ "DBus o qu'un xestor de configuración que nun ye de GNOME (por exemplu "
+#~ "KDE) yá tea activu y engarriáu col xestor de configuración de GNOME."
+#~ msgid "Installed"
+#~ msgstr "Instalada"
+#~ msgid "Image missing"
+#~ msgstr "Falta la imaxe"
+#~ msgid "Stretch"
+#~ msgstr "Estiramientu"
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Carpeta: %s"
+#~ msgid "Move _Down"
+#~ msgstr "_Mover Abaxo"
+#~ msgid "Move _Up"
+#~ msgstr "M_over Arriba"
+#~ msgid "New windows u_se active window's layout"
+#~ msgstr "Les ventanes nueves u_sen la distribución de la ventana activa"
+#~ msgid "_Separate layout for each window"
+#~ msgstr "Separtar la _distribución pa cada ventana"
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "La _mesma imaxe en tolos monitores"
+#~ msgid "_Detect monitors"
+#~ msgstr "_Deteutar monitores"
+#~ msgid "_Show monitors in panel"
+#~ msgstr "_Amosar pantalles nel panel"
+#~ msgid "Change resolution and position of monitors"
+#~ msgstr "Camudar la resolución y posición de los monitores"
+#~ msgid "Monitor Preferences"
+#~ msgstr "Preferencies del monitor"
+#~ msgid "Monitors"
+#~ msgstr "Pantalles"
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Personaliza l'aspeutu del escritoriu"
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Da-y una combinación de tecles a comandos"
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Afitar les preferencies de tecláu"
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Afitar les preferencies de proxy de rede"
+#~ msgid "Set your window properties"
+#~ msgstr "Afitar les propiedaes de les ventanes"
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Afitar les preferencies del mur"
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr ""
+#~ "Escueyi qué carauterístiques d'accesibilidá activar al aniciar sesión"
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Escueyi un modelu de tecláu"
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Escueyi'l tipu de pulsación d'an_temanu"
+#~ msgid "Select your default applications"
+#~ msgstr "Escueyi los tos programes predeterminaos"
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "Escueyi'l tipu de pulsación con _xestos del mur"
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Tamañu de la fonte (predetermináu: 64)"
+#~ msgid "Des_ktop font:"
+#~ msgstr "Fonte pal _escritoriu:"
+#~ msgid "_Fixed width font:"
+#~ msgstr "Fonte d'anchor _fixu:"
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "El tema actual suxer una fonte. Arriendes, pue revertise la cabera "
+#~ "suxerencia de fonte aplicada."
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "El tema actual suxer un tapiz. Arriendes, pue revertise la cabera "
+#~ "suxerencia de fonte aplicada."
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "El tema actual suxer un tapiz y una fonte."
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Especifica'l nome de ficheru del tema a instalar"
+#~ msgid "Theme"
+#~ msgstr "Temes"
+#~ msgid "The current theme suggests a font."
+#~ msgstr "El tema actual suxer una fonte."
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "¿Quies aplicalu agora, o caltener el so tema actual?"
+#~ msgid "No theme file location specified to install"
+#~ msgstr ""
+#~ "Nun s'especificó dengún allugamientu del ficheru del tema pa instalar"
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Esti tema nun va amosase como se pretende porque'l el tema d'iconos "
+#~ "necesariu «%s» nun ta instaláu."
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "Esti tema nun va amosase como se pretende porque'l el tema del xestor de "
+#~ "ventanes necesariu «%s» nun ta instaláu."
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Esti tema nun va amosase como se pretende porque'l el tema GTK+ necesariu "
+#~ "«%s» nun ta instaláu."
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "¿Quies desaniciar esti tema?"
+#~ msgid "Select Theme"
+#~ msgstr "Esbilla un tema"
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Yá esiste'l tema. ¿Prestaríate trocalu?"
+#~ msgid ""
+#~ "The current theme suggests a button layout. Also, the last button layout "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "El tema actual suxer un diseñu de botón. Arriendes, la cabera suxerencia "
+#~ "de disposición de los botones puede revertise."
+#~ msgid ""
+#~ "The current theme suggests a font and a button layout. Also, the last "
+#~ "applied button_layout suggestion can be reverted."
+#~ msgstr ""
+#~ "El tema actual suxer un fondu, y un diseñu de botón. Arriendes, la cabera "
+#~ "suxerencia de disposición de los botones aplicada, puede revertise."
+#~ msgid "Revert Button Layout"
+#~ msgstr "Revertir diseñu de botón"
+#~ msgid ""
+#~ "Do you want to apply these settings system-wide, so that they are also "
+#~ "used for package installation and other system services?"
+#~ msgstr ""
+#~ "¿Quies aplicar estes opciones a tol sistema pa que s'usen tamién na "
+#~ "instalación de paquetes y otros servicios del sistema?"
+#~ msgid "%d %s by %d %s"
+#~ msgstr "%d %s por %d %s"
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "Caca en <b>Camudar Contraseña</b> pa camudar la contraseña."
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "Teclea la contraseña nel campu <b>Contraseña nueva</b>."
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "Por favor, teclea la contraseña otra vegada nel campu <b>Reescribi la "
+#~ "nueva contraseña</b>."
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "Pa camudar la to clave, introduz la to clave actual nel campu d'abaxo y "
+#~ "calca <b>Autentificar</b>.\n"
+#~ "Dempués de que seyas autentificáu, introduz la to nueva clave, "
+#~ "reintroduciéndola pa verificala y calca <b>Camudar clave</b>."
+#~ msgid "Font may be too large"
+#~ msgstr "La fonte seique seya enforma grande"
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "La fonte seleicionada ye %d puntu de grande, y pue facer abegoso l'usu "
+#~ "del equipu. Encamiéntase que seleicione un tamañu menor de %d."
+#~ msgstr[1] ""
+#~ "La fonte seleicionada ye %d puntos de grande, y pue facer abegoso l'usu "
+#~ "del equipu. Encamiéntase que seleicione un tamañu menor de %d."
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "La fonte seleicionada ye %d puntu de grande, y pue facer abegoso l'usu "
+#~ "del equipu. Encamiéntase que seleicione un tamañu menor."
+#~ msgstr[1] ""
+#~ "La fonte seleicionada ye %d puntos de grande, y pue facer abegoso l'usu "
+#~ "del equipu. Encamiéntase que seleicione un tamañu menor."
+#~ msgid "Use previous font"
+#~ msgstr "Usar la fonte anterior"
+#~ msgid "Use selected font"
+#~ msgstr "Usar la fonte seleicionada"
+#~ msgid "Apply Font"
+#~ msgstr "Aplicar fonte"
+#~ msgid "Revert Font"
+#~ msgstr "Revertir la fonte"
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "Códigu Postal:"
+#~ msgid "_GroupWise:"
+#~ msgstr "_Groupwise:"
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "Códigu _Postal:"
+#~ msgid "Make Default"
+#~ msgstr "Facer Predetermináu"
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "Guardóse la configuración del monitor"
+#~ msgid "This configuration will be used the next time someone logs in."
+#~ msgstr ""
+#~ "Esta configuración va usase la próxima vegada que daquién se rexistre."
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "Nun pudo afitase la configuración predefinía pa los monitores"
+#~ msgid "List of keyboard layouts selected for usage"
+#~ msgstr "Llista de distribuciones teclaos seleicionaos pa usar"
+#~ msgid "Move the selected keyboard layout down in the list"
+#~ msgstr "Mover la distribución de tecláu seleicionada p'abaxo na llista"
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "Mover la distribución de tecláu seleicionada p'arriba na llista"
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "Imprentar una diagrama de la distribución de tecláu selecionada"
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "Esborrar la distribución de tecláu selecionada de la llista"
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "Seleicionar una distribución de tecláu p'amestala a la llista"
+#~ msgid "Take a break now (next in %dm)"
+#~ msgstr "Descansar agora (prósimu en %dm)"
+#~ msgid "Take a break now (next in less than one minute)"
+#~ msgstr "Descansar agora (prósimu en menos d'un minutu)"
+#~ msgid "Changes to visual system bell take effect immediately."
+#~ msgstr "Los cambeos na campana visual del sistema van facer efeutu darréu."
+#~ msgid "Enable _visual system bell"
+#~ msgstr "Activar campana _visual del sistema"
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s tien de ser un ficheru regular\n"
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "PKEXEC_UID tien de conseñase como un valor enteru"
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "has de ser el propietariu de %s\n"
+#~ msgid "Could not get information for %s: %s\n"
+#~ msgstr "Nun pudo alcontrase información de %s: %s\n"
+#~ msgid "Could not open %s: %s\n"
+#~ msgstr "Nun pudo abrise %s: %s\n"
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "Usu: %s FICHERU_ORIX NOME_DEST\n"
+#~ "\n"
+#~ "Esti programa instala un perfil RANDR pa configuraciones multi-monitor\n"
+#~ "nun llugar pal sistema ensembre.  El perfil resultante s'usará cuando\n"
+#~ "el plug-in RANDR s'execute con gnome-settings-daemon.\n"
+#~ "\n"
+#~ "FICHERU_ORIX - un camín completu, de vezu /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "NOME_DEST - nome relativu del ficheru instaláu.  Esti va ponese nel\n"
+#~ "            direutoriu de sistema pa les configuraciones RANDR,\n"
+#~ "            de manera que'l resultáu típicu va ser %s/NOME_DEST\n"
+#~ msgid "The source filename must be absolute"
+#~ msgstr "El nome del ficheru orixe tien de ser absolutu"
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "Esti programa namái pue usalu'l superusuariu"
+#~ msgctxt "Home folder"
+#~ msgid "Home"
+#~ msgstr "Direutoriu Personal"
+#~ msgid "_Show..."
+#~ msgstr "_Amosar..."
+#~ msgid "Remove from recent menu"
+#~ msgstr "Desaniciar del menú de recientes"
+#~ msgid "Purge all the recent items"
+#~ msgstr "Purgar tolos elementos recientes"
+#~ msgid ""
+#~ "Authentication is required to install multi-monitor settings for all users"
+#~ msgstr ""
+#~ "Ye necesario autentificase pa instalar configuraciones multi-monitor pa "
+#~ "tolos usuarios"
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s nun pue tener dengún componente de direutoriu\n"
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "Nun pudo abrise %s/%s: %s\n"
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s tien de ser un direutoriu\n"
+#~ msgid "Could not rename %s to %s: %s\n"
+#~ msgstr "Nun se pudo renomar %s a %s: %s\n"
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "Esti programa namái pue executase per aciu de pkexec(1)"
+#~ msgid "- GNOME Default Applications"
+#~ msgstr "- Aplicaciones GNOME predeterminaes"
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "Instalar configuraciones multi-monitor pa tol sistema"
+#~ msgid ""
+#~ "To test your double-click settings, try to double-click on the light bulb."
+#~ msgstr ""
+#~ "Pa probar les configuraciones del duble clic, intenta facer duble clic "
+#~ "nel focu"
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Pon nesta clave la orde qu'hai d'usar pa crear miniatures de les "
+#~ "tipografíes OpenType."
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Pon nesta clave la orde qu'hai d'usar pa crear miniatures de les "
+#~ "tipografíes TrueType."
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Pon nesta clave la orde qu'hai d'usar pa crear miniatures de les "
+#~ "tipografíes PCF."
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Falló al crear la carpeta temporal"
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Bloquia la pantalla dempués d'un ciertu intervalu p'ayudar a prevenir les "
+#~ "lesiones pol usu repetitivu del tecláu"
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr ""
+#~ "Conseña si hai de zarrar la consola cuando se tien executao una aición "
+#~ "d'ayuda."
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Abandona la consola cuando se tien fecho una aición d'ayuda"
+#~ msgid "Help"
+#~ msgstr "Ayuda"
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Hebo un fallu al amosar l'ayuda: %s"
+#~ msgid "Set your personal information"
+#~ msgstr "Configura la to información personal"
+#~ msgid "Error setting default browser: %s"
+#~ msgstr "Fallu na configuración del restolador predetermináu: %s"
+#~ msgid "Error setting default mailer: %s"
+#~ msgstr "Fallu na configuración del veceru de corréu: %s"
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "Aniciar la teunoloxía d'asistencia visual preferida"
+#~ msgid ""
+#~ "The current theme suggests a background, a font and a button layout. "
+#~ "Also, the last applied font and button layout suggestion can be reverted."
+#~ msgstr ""
+#~ "El tema actual suxer un fondu, una fonte y un diseñu de botón. Arriendes, "
+#~ "la cabera suxerencia de fonte y de disposición de los botones aplicada, "
+#~ "pue revertise."
+#~ msgid ""
+#~ "The current theme suggests a background and a button layout. Also, the "
+#~ "last applied font and button layout suggestion can be reverted."
+#~ msgstr ""
+#~ "El tema actual suxer un fondu, y un diseñu de botón. Arriendes, la cabera "
+#~ "suxerencia de fonte y de disposición de los botones aplicada, pue "
+#~ "revertise."
+#~ msgid ""
+#~ "The current theme suggests a background, a font and a button layout. "
+#~ "Also, the last applied button layout suggestion can be reverted."
+#~ msgstr ""
+#~ "El tema actual suxer un fondu, una fonte y un diseñu de botón. Arriendes, "
+#~ "la cabera suxerencia de disposición de los botones aplicada, pue "
+#~ "revertise."
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "Afítalo al nome del to allugamientu actual. Úsase pa determinar la "
+#~ "configuración afayadiza del proxy de rede"
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "El tema actual suxer un tapiz y una fonte. Arriendes, pue revertise la "
+#~ "cabera suxerencia de fonte aplicada."
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr ""
+#~ "Abandona la consola cuando se tien fecho una aición d'anovamientu o "
+#~ "desinstalación"
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "Conseña si hai de zarrar la consola cuando se tien executao una aición "
+#~ "d'anovamientu o desinstalación."
+#~ msgid "Re_fresh rate:"
+#~ msgstr "Frecuencia de _refrescu:"
+#~ msgid "Filter"
+#~ msgstr "Filtru"
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Escribi pa comprobar la configuración:"
+#~ msgid "Rendering"
+#~ msgstr "Renderizáu"
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Suavizáu de sub_pixel (LCDs)"
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "Launchpad Contributions:\n"
+#~ "  Costales https://launchpad.net/~costales\n"
+#~ "  Esbardu https://launchpad.net/~esguil\n"
+#~ "  Iñigo Varela https://launchpad.net/~ivarela\n"
+#~ "  Mikel González https://launchpad.net/~mikelglez\n"
+#~ "  Rodrigo Toraño Valle https://launchpad.net/~rodrigo-torval\n"
+#~ "  Xandru Martino https://launchpad.net/~xandru-martino\n"
+#~ "  Xuacu Saturio https://launchpad.net/~xuacusk8"
+

--- a/po/az.po
+++ b/po/az.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.HEAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2004-09-04 19:45+0300\n"
 "Last-Translator: Mətin Əmirov <metin@karegen.com>\n"
 "Language-Team: Azerbaijani <translation-team-az@lists.sourceforge.net>\n"
@@ -21,3474 +21,7127 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: KBabel 1.3.1\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
 #, fuzzy
-msgid "Alert Type"
-msgstr "Fayl Növünü Əlavə Et"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-#, fuzzy
-msgid "The type of alert"
-msgstr "Sürə'tləndirici növü."
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-#, fuzzy
-msgid "Alert Buttons"
-msgstr "Düymələr"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-#, fuzzy
-msgid "Show more _details"
-msgstr "Örtük _Təfərruatları"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-#, fuzzy
-msgid "About Me"
-msgstr "_Haqqında"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your personal information"
-msgstr "MIME növü mə'lumatı"
-
-#: ../capplets/about-me/gnome-about-me.c:554
-#, fuzzy
-msgid "Select Image"
-msgstr "_Seç"
-
-#: ../capplets/about-me/gnome-about-me.c:556
-#, fuzzy
-msgid "No Image"
-msgstr "Rəsmlər"
-
-#: ../capplets/about-me/gnome-about-me.c:706
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:727
-msgid "Unable to open address book"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:739
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:770
-#: ../capplets/about-me/gnome-about-me.c:772
-#, fuzzy, c-format
-msgid "About %s"
-msgstr "_Haqqında"
-
-#: ../capplets/about-me/gnome-about-me-password.c:101
-#: ../capplets/about-me/gnome-about-me-password.c:479
-msgid "Old password is incorrect, please retype it"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:112
-msgid "System error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:113
-msgid "Could not run /usr/bin/passwd"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:114
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:117
-msgid "Unexpected error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:315
-msgid "Password is too short"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:318
-#: ../capplets/about-me/gnome-about-me-password.c:321
-msgid "Password is too simple"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:324
-msgid "Old and new passwords are too similar"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:328
-msgid "Old and new password are the same"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:406
-#, fuzzy
-msgid "Please type the passwords."
-msgstr "_Şifrə:"
-
-#: ../capplets/about-me/gnome-about-me-password.c:414
-msgid "Please type the password again, it is wrong."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:417
-msgid "Click on Change Password to change the password."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/font/font-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-msgid "    "
-msgstr "    "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-#, fuzzy
-msgid "<b>Email</b>"
-msgstr "<i>Kiçik</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-#, fuzzy
-msgid "<b>Home</b>"
-msgstr "<b>Sür'ət</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-#, fuzzy
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Yazı Növü Görünüşü</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-#, fuzzy
-msgid "<b>Job</b>"
-msgstr "<b>Dəstək</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-#, fuzzy
-msgid "<b>Telephone</b>"
-msgstr "<b>Açma Düymələri</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-#, fuzzy
-msgid "<b>Web</b>"
-msgstr "<b>Sür'ət</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-#, fuzzy
-msgid "<b>Work</b>"
-msgstr "<b>Dəstək</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-#, fuzzy
-msgid "A_ddress:"
-msgstr "Ə_lavə Et:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-#, fuzzy
-msgid "Address"
-msgstr "_basılanda"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-#, fuzzy
-msgid "C_ity:"
-msgstr "_Tərz:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-#, fuzzy
-msgid "C_ompany:"
-msgstr "Ə_mr:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-#, fuzzy
-msgid "Cale_ndar:"
-msgstr "Kate_qoriya:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-#, fuzzy
-msgid "Change Passwo_rd..."
-msgstr "Dəstəni Dəyişdir"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-#, fuzzy
-msgid "Change Password"
-msgstr "Dəstəni Dəyişdir"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-#, fuzzy
-msgid "Ci_ty:"
-msgstr "_Tərz:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-#, fuzzy
-msgid "Co_untry:"
-msgstr "Control"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-#, fuzzy
-msgid "Contact"
-msgstr "_Məzmun"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-#, fuzzy
-msgid "Cou_ntry:"
-msgstr "Control"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-#, fuzzy
-msgid "Hom_e:"
-msgstr "_Ad:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-#, fuzzy
-msgid "Old pa_ssword:"
-msgstr "_Şifrə:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P.O. _box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P._O. box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-#, fuzzy
-msgid "Personal Info"
-msgstr "_Terminal yazı növü:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "State/Pro_vince:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#, fuzzy
-msgid "User name:"
-msgstr "_İstifadəçi Adı:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Web _log:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "Wor_k:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid "Work _fax:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Zip/_Postal code:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-#, fuzzy
-msgid "_Address:"
-msgstr "Ə_lavə Et:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-#, fuzzy
-msgid "_Home page:"
-msgstr "Örtük _adı:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-#, fuzzy
-msgid "_Home:"
-msgstr "_Ad:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-#, fuzzy
-msgid "_Manager:"
-msgstr "_Böyüdücü"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-#, fuzzy
-msgid "_Mobile:"
-msgstr "_Fayl"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-#, fuzzy
-msgid "_New password:"
-msgstr "_Şifrə:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-#, fuzzy
-msgid "_Profession:"
-msgstr "Buraxılış:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-#, fuzzy
-msgid "_Retype new password:"
-msgstr "_Şifrə:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-#, fuzzy
-msgid "_Title:"
-msgstr "_Tərz:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Work:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Zip/Postal code:"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Applications</b>"
+msgid "Applications"
 msgstr "<b>Proqramlar</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Support</b>"
-msgstr "<b>Dəstək</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-"<small><i><b>Qeyd:</b> Bu qurğudakı dəyişikliklər bir sonrakı girişinizə "
-"qədər fəal olmayacaqdır.</i></small>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technology Preferences"
-msgstr "Yardımçı Texnologiya Seçimləri"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr "_Bağla və İclası Sonlandır"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr "Bu yardımçı texnologiyaları hər girişdə başlat:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr "_Yardımçı texnologiyaları fəallaşdır"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr "_Böyüdücü"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr "_Ekran üstü klaviatura"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Screenreader"
-msgstr "_Ekran oxuyucusu"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr "Yardımçı Texnologiya Dəstəyi"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr "Girişdə GNOME yardımçı texnologiya dəstəyini fəallaşdır"
-
-#: ../capplets/accessibility/at-properties/main.c:60
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Sisteminizdə heç bir yardımçı texnologiya mövcud deyil. Ekran üstü "
-"klaviatura dəstəyi almaq üçün 'gok' paketi, ekran oxuma və yaxınlaşdırma "
-"bacarıqları üçün isə 'gnopernicus' paketi qurulu olmalıdır."
-
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-"Sisteminizdə bütün yardımçı texnologiyalar mövcud deyil. Ekran üstü "
-"klaviatura dəstəyi almaq üçün 'gok' paketi qurulu olmalıdır."
-
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Sisteminizdə bütün yardımçı texnologiyalar mövcud deyil.  Ekran oxuma və "
-"yaxınlaşdırma bacarıqları üçün 'gnopernicus' paketi qurulu olmalıdır."
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr "Siçan qurğuları pəncərəsi başlarkən xəta yarandı: %s"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr "'%s' faylından AccessX qurğuları idxal edilə bilmədi"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
-msgid "Import Feature Settings File"
-msgstr "Xassə Qurğuları Faylını İdxal Et"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
-msgid "_Import"
-msgstr "_İdxal Et"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Klaviatura"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr "Klaviatura yetişmə qabiliyyəti qurğularınızı seçin"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-"Bu sistem üstündə XKB uzantısı qurulu deyil. Klaviatura yetişmə qabiliyyəti "
-"xassəsi onsuz işləməyəcək."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-#: ../capplets/theme-switcher/theme-install.glade.h:1
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "<b>_Eyni Düymələri Fəallaşdır</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "<b>Y_avaş Düymələri Fəallaşdır</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "<b>_Siçan Düymələrini Fəallaşdır</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "<b>_Düymələrin Təkrarlanmasını Fəallaşdır</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "<b>_Yapışqan Düymələri Fəallaşdır</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-msgid "<b>Features</b>"
-msgstr "<b>Xüsusiyyətlər</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr "<b>Açma Düymələri</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "Əsas"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr "Düymə rədd ediləndə _səs çıxart"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
-msgstr "_Xassələr klaviaturadan açılıb bağlananda səs çıxart"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
-msgstr "_Dəyişdirici basılanda səs çıxart"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr ""
-"Açma düyməsi fəal seçiləndə bir dəfə, qeyri-fəal seçiləndə isə iki dəfə səs "
-"çıxart."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr "Səs çıxartma vəziyyəti:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr "_Gecikmə:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr "Düymənin basılması ilə oxun hərəkəti arasındakı _gecikmə"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr "İki düymə eyni anda basılanda qeyri-fəallaşdır"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr "Açma _Düymələrini Fəallaşdır"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Filtrlər"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr "Bu vaxt içindəki cüt düymə basışlarını _ləğv et:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-"İstifadəçinin seçdiyi vaxt aralığı içində EYNİ düymənin ardıcıl basışlarını "
-"rədd et."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr "Klaviatura Yetişmə Qabiliyyəti Qurğuları (AccessX)"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr "Ma_ksimal ox sür'əti:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr "Siçan Düymələri"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr "Siçan _Qurğuları..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-"Yalnız istifadəçinin istədiyi bir müddət boyunca basılı tutulan düymələri "
-"qəbul et."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-"Dəyişdirici düymələri ardıcıl basaraq birdən çox ardıcıl düymə basma "
-"əməliyyatını həyata keçirin."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "S_peed:"
-msgstr "_Sür'ət:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr "Maksimal sür'ətə çıxma _vaxtı:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr "Ədəd düymələri sahəsini siçan idarə vasitəsinə döndərin."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr "_Bu vaxt içinə işlədilməzsə qeyri-fəallaşdır:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr "Klaviatura yetişmə qabiliyyətini _fəallaşdır"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr "_Qurğu Faylını İdxal Et..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr "_Yalnız bu vaxt müddətincə basılı tutulan düymələri qəbul et:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Type to test settings:"
-msgstr "Qurğuları sınama _taxtası:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr "_qəbul ediləndə"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr "_basılanda"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr "_rədd ediləndə"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr "hərf/saniyə"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-msgid "milliseconds"
-msgstr "millisaniyə"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr "piksel/saniyə"
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:885
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "saniyə"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-msgid "Change your Desktop Background settings"
-msgstr "Masa Üstü Arxa Plan Qurğunuzu Dəyişdirin"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-msgid "Desktop Background"
-msgstr "Masa Üstü Arxa Planı"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "<b>Masa Üstü _Divar Kağızı</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-msgid "<b>_Desktop Colors</b>"
-msgstr "<b>_Masa Üstü Rəngləri</b> "
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-msgid "Desktop Background Preferences"
-msgstr "Masa Üstü Arxa Planı Seçimləri"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr "Divar Kağızı Ə_lavə Et"
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-msgid "_Style:"
-msgstr "_Tərz:"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Yardımın göstərilməsi sırasında xəta oldu: %s"
-
-#: ../capplets/background/gnome-wp-capplet.c:1042
-#: ../capplets/background/gnome-wp-capplet.c:1060
-msgid "Centered"
-msgstr "Ortalanmış"
-
-#: ../capplets/background/gnome-wp-capplet.c:1068
-#: ../capplets/background/gnome-wp-capplet.c:1085
-msgid "Fill Screen"
-msgstr "Ekranı Doldur"
-
-#: ../capplets/background/gnome-wp-capplet.c:1093
-#: ../capplets/background/gnome-wp-capplet.c:1110
-msgid "Scaled"
-msgstr "Miqyaslandırılmış"
-
-#: ../capplets/background/gnome-wp-capplet.c:1118
-#: ../capplets/background/gnome-wp-capplet.c:1135
-msgid "Tiled"
-msgstr "Döşənmiş"
-
-#: ../capplets/background/gnome-wp-capplet.c:1159
-#: ../capplets/background/gnome-wp-capplet.c:1168
-msgid "Solid Color"
-msgstr "Tək Rəng"
-
-#: ../capplets/background/gnome-wp-capplet.c:1176
-#: ../capplets/background/gnome-wp-capplet.c:1185
-msgid "Horizontal Gradient"
-msgstr "Üfüqi Qradient"
-
-#: ../capplets/background/gnome-wp-capplet.c:1193
-#: ../capplets/background/gnome-wp-capplet.c:1202
-msgid "Vertical Gradient"
-msgstr "Şaquli Qradient"
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1251
-msgid "Add Wallpaper"
-msgstr "Divar Kağızı Əlavə Et"
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr "Divar Kağızı İşlətmə"
-
-#: ../capplets/background/gnome-wp-item.c:292
-#: ../capplets/background/gnome-wp-item.c:294
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/common/activate-settings-daemon.c:18
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"Qurğu idarəçisi 'gnome-settings-daemon' başladıla bilmədi.\n"
-"Gnome qurğu idarəçisi işləməzsə, bə'zi seçimlər fəal olmaya bilər. Buna, "
-"Bonobodakı bir problem, ya da Gnome qurğu idarəçisi ilə toqquşan diqər "
-"tə'minatlar səbəb ola bilər."
-
-#: ../capplets/common/capplet-stock-icons.c:94
-#, c-format
-msgid "Unable to load capplet stock icon '%s'\n"
-msgstr "Kapplet timsalı '%s' yüklənə bilmədi\n"
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr "Təkcə qurğuları əlavə et və çıx"
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/default-applications/gnome-default-applications-properties.c:765
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1021
-#: ../capplets/sound/sound-properties-capplet.c:244
-msgid "Retrieve and store legacy settings"
-msgstr "Miras qurğularını al və saxla"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %i of %i"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr "URI-dən"
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr "Hazırda transferin hansı URI'dən edildiyi"
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr "URI-yə"
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr "Hazırda transferin hansı URI'yə edildiyi"
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr "Hissə bitdi"
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr "Transferin hissəsi hazırda bitdi"
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr "Hazırkı URI indexi"
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr "Hasırkı URI indeksi - 1'dən başlayır"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr "Toplam URI"
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr "Toplam URI miqdarı"
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:345
+#: panels/applications/cc-applications-panel.ui:31
 #, fuzzy
-msgid "From:"
-msgstr "%s-dən"
-
-#: ../capplets/common/file-transfer-dialog.c:349
-#, fuzzy
-msgid "To:"
-msgstr "%s-yə"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr "Bağlanılır..."
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Açar"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr "Bu üstünlük editorunun ilişdirildiyi GConf açarı"
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr "Geri axtarma"
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Açar ilə əlaqələndirilmiş qiymət dəyişəndə bu geri çağırışı yay"
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr "Dəstəni Dəyişdir"
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"Tətbiq ediləndə gconf alıcısına istiqamətləndiriləcək mə'lumatı daxil edən "
-"GConf Dəyişmə dəsti"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr "Widget geri çağırışına çeviriş"
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "Mə'lumat GConf'dan widget'ə dönüşdürüləndə yaradılacaq geri çağırış"
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr "Widget geri çağırışından çeviriş"
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr "Mə'lumat widget'dən GConf'a dönüşdürüləcəksə yaradılacaq geri çağırış"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr "UI İdarəsi"
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr "Üstünlüyü idarə edən cism (normal halda pəncərəcik)"
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr "Xassə editoru obyekt verilənləri"
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr "Spesifik xassə editoru tərəfindən xüsusi mə'lumat məcburi qılınıb"
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr "Geri çağırışı boşaldan xassə editoru mə'lumatı"
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr "Xassə editoru mə'lumatı boşaldılanda yaradılacaq geri çağırış"
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"'%s' faylı tapıla bilmədi.\n"
-"\n"
-"Xahiş edirik, onun mövcud olduğundan əmin olun və yenidən sınayın, ya da "
-"başqa arxa plan rəsmi seçin."
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"'%s' faylın necə açılacağı bilinmir.\n"
-"Deyəsən, o hələ dəstəklənməyən bir rəsm növüdür.\n"
-"\n"
-"Xahiş edirik, onun yerinə başqa rəsm seçin."
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr "Xahiş edirik, bir rəsm seçin."
-
-#: ../capplets/common/gconf-property-editor.c:1598
-msgid "_Select"
-msgstr "_Seç"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
+msgid "No applications"
 msgstr "Ön Qurğulu Proqramlar"
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Ön qurğulu proqramlarınızı seçin"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+#: panels/applications/cc-applications-panel.ui:34
 #, fuzzy
-msgid "Debian Sensible Browser"
-msgstr "Ön Qurğulu Veb Səyyahı"
+msgid "Install some…"
+msgstr "Ö_rtük Qur..."
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
-msgid "Epiphany"
-msgstr "Epiphany"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
-msgid "Encompass"
-msgstr "Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+#: panels/applications/cc-applications-panel.ui:84
 #, fuzzy
-msgid "Firebird"
-msgstr "Firebird/FireFox"
+msgid "Open"
+msgstr "_Aç"
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
-msgid "Firefox"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Örtük Təfərruatları"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Axtar"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
-#, fuzzy
-msgid "Mozilla"
-msgstr "Mozilla Mail"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
-msgid "Netscape Communicator"
-msgstr "Netscape Communicator"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
-msgid "W3M Text Browser"
-msgstr "W3M Mətn Səyyahı"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
-msgid "Lynx Text Browser"
-msgstr "Lynx Mətn Səyyahı"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
-msgid "Links Text Browser"
-msgstr "Links Mətn Səyyahı"
-
-#. The code in gnome-default-applications-properties.c makes sure
-#. * there is only one (the first entry in this list) Evolution entry
-#. * in the list shown to the user
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
-msgid "Evolution Mail Reader"
-msgstr "Evolution Poçt Oxuyucusu"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
-msgid "KMail"
-msgstr "KMail"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
-msgid "Thunderbird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
-msgid "Mozilla Mail"
-msgstr "Mozilla Mail"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
-#, fuzzy
-msgid "Debian Terminal Emulator"
-msgstr "Ön Qurğulu Terminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
-#, fuzzy
-msgid "GNOME Terminal"
-msgstr "Terminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
-msgid "Standard XTerminal"
-msgstr "Standart XTerminalı"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
-#, fuzzy
-msgid "aterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.c:123
-msgid "Please specify a name and a command for this editor."
-msgstr "Xahiş edirik, bu editor üçün bir ad və əmr girin."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "Add..."
-msgstr "Əlavə Et..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-#, fuzzy
-msgid "C_ustom"
-msgstr "Hazırkı"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-#, fuzzy
-msgid "C_ustom:"
-msgstr "Hazırkı"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "Can open _URIs"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-#, fuzzy
-msgid "Can open multiple _files"
-msgstr "Bu tə'minat _birdən çox faylları aça bilmir"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "Co_mmand:"
-msgstr "Ə_mr:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "Custom Editor Properties"
-msgstr "Xüsusi Editor Xassələri"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "Default Mail Reader"
-msgstr "Ön Qurğulu Poçt Oxuyucusu"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "Default Terminal"
-msgstr "Ön Qurğulu Terminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Default Text Editor"
-msgstr "Ön Qurğulu Mətn Editoru"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "Default Web Browser"
-msgstr "Ön Qurğulu Veb Səyyahı"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Default Window Manager"
-msgstr "Ön Qurğulu Pəncərə İdarəçisi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Delete"
-msgstr "Sil"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "E_xec Flag:"
-msgstr "İşə Salma _Bayrağı:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Edit..."
-msgstr "Düzəlt..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Mail Reader"
-msgstr "Poçt Oxuyucusu"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-#, fuzzy
-msgid "Run in a _terminal"
-msgstr "_Terminalda İcra Et"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-#, fuzzy
-msgid "Run in a t_erminal"
-msgstr "_Terminalda İcra Et"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid ""
-"Select the window manager you want.  You will need to hit apply, wave the "
-"magic wand, and do a magic dance for it to work."
-msgstr ""
-"İstədiyiniz pəncərə idarəçisini seçin. Bunun işləməsi üçün tətbiq et "
-"düyməsinə basdıqdan sonra, sehirli çubuğu oynadıb sehirli sözlər deməlisiniz."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Terminal"
-msgstr "Terminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Text Editor"
-msgstr "Mətn Editoru"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Understands _Netscape Remote Control"
-msgstr "_Netscape Uzaq İdarəsini Başa Düşür"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "Use this _editor to open text files in the file manager"
-msgstr "Fayl idarəçisində mətn fayllarını açmaq üçün bu _editoru istifadə et"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "Web Browser"
-msgstr "Veb Səyyahı"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
-msgid "Window Manager"
-msgstr "Pəncərə İdarəçisi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
-#, fuzzy
-msgid "_Command:"
-msgstr "Ə_mr:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
-msgid "_Name:"
-msgstr "_Ad:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
-msgid "_Properties..."
-msgstr "_Xüsusiyyətlər..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
-#, fuzzy
-msgid "_Select:"
-msgstr "_Seç"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Ekran həlleciliyini dəyişdir"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Ekran Həllediciliyi"
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/main.c:448
-msgid "_Resolution:"
-msgstr "_Həlledicilik:"
-
-#: ../capplets/display/main.c:467
-msgid "Re_fresh rate:"
-msgstr "_Yeniləmə sıxlığı:"
-
-#: ../capplets/display/main.c:488
-msgid "Default Settings"
-msgstr "Ön Qurğular"
-
-#: ../capplets/display/main.c:490
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr "Ekran %d Qurğuları\n"
-
-#: ../capplets/display/main.c:516
-msgid "Screen Resolution Preferences"
-msgstr "Ekran Həllediciliy Seçimləri"
-
-#: ../capplets/display/main.c:553
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "Sadəcə olaraq bu _kompüter (%s) üçün ön qurğulu qəbul et"
-
-#: ../capplets/display/main.c:571
-msgid "Options"
-msgstr "Seçimlər"
-
-#: ../capplets/display/main.c:592
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"Yeni qurğular sınanır. Əgər %d saniyə ərzində cavab verməsəniz qurğular "
-"bərpa ediləcəkdir."
-msgstr[1] ""
-"Yeni qurğular sınanır. Əgər %d saniyə ərzində cavab verməsəniz qurğular "
-"bərpa ediləcəkdir."
-
-#: ../capplets/display/main.c:638
-msgid "Keep Resolution"
-msgstr "Həllediciliyi Qeyd Et"
-
-#: ../capplets/display/main.c:642
-msgid "Do you want to keep this resolution?"
-msgstr "Bu həlledilirliyi saxlamaq istəyirsiniz?"
-
-#: ../capplets/display/main.c:667
-msgid "Use _previous resolution"
-msgstr "Ə_vvəlki həlledilirliyi istifadə et"
-
-#: ../capplets/display/main.c:667
-msgid "_Keep resolution"
-msgstr "Həlledilirliyi _qeyd et"
-
-#: ../capplets/display/main.c:818
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"Xverici XRandR uzantısını dəstəkləmir. Canlı həlledicilik dəyişmələri "
-"təəssüf ki mövcud deyil."
-
-#: ../capplets/display/main.c:826
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"XRandR buraxılışı bu proqram ilə uyğun gəlmir. Canlı həlledilirlik "
-"dəyişmələri təəssüf ki mövcud deyil."
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Yazı Növü"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr "Masa üstü yazı növlərini seçin"
-
-#: ../capplets/font/font-properties.glade.h:2
-msgid "<b>Font Rendering</b>"
-msgstr "<b>Yazı Növü Görünüşü</b>"
-
-#: ../capplets/font/font-properties.glade.h:3
-msgid "<b>Hinting</b>:"
-msgstr "<b>Zərifləndirmə</b>:"
-
-#: ../capplets/font/font-properties.glade.h:4
-msgid "<b>Smoothing</b>:"
-msgstr "<b>Yumuşaltma</b>:"
-
-#: ../capplets/font/font-properties.glade.h:5
-msgid "<b>Subpixel order</b>:"
-msgstr "<b>Sabpiksel ardıcıllığı</b>:"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best _shapes"
-msgstr "Optimal şə_killər"
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "Best co_ntrast"
-msgstr "Optimal ko_ntrast"
-
-#: ../capplets/font/font-properties.glade.h:8
-msgid "D_etails..."
-msgstr "_Təfərruatlar..."
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "Yazı Növü Qurğuları"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr "Yazı Növü Görünüş Təfərruatları"
-
-#: ../capplets/font/font-properties.glade.h:11
-msgid "Go _to font folder"
-msgstr "_Yazı növü qovluğuna get"
-
-#: ../capplets/font/font-properties.glade.h:12
-msgid "Gra_yscale"
-msgstr "_Ağ-qara"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "Yo_xdur"
-
-#: ../capplets/font/font-properties.glade.h:14
-msgid "R_esolution:"
-msgstr "_Həlledilirlik:"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr "Sab_piksel (LCD-lər)"
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "Sab_piksel yumuşaldılması (LCD-lər)"
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
-msgstr "_Proqram yazı növü:"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Desktop font:"
-msgstr "_Masa üstü yazı növü:"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Full"
-msgstr "_Tam"
-
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Medium"
-msgstr "_Orta"
-
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Monochrome"
-msgstr "_Monoxrom"
-
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_None"
-msgstr "_Yoxdur"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_Slight"
-msgstr "_Zərif"
-
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Terminal font:"
-msgstr "_Terminal yazı növü:"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "_Pəncərə başlığının yazı növü:"
-
-#: ../capplets/font/font-properties.glade.h:30
-msgid "dots per inch"
-msgstr "inç başına nöqtə"
-
-#: ../capplets/font/main.c:488
-msgid "Font may be too large"
-msgstr "Yazı növü çox geniş ola bilər"
-
-#: ../capplets/font/main.c:492
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
-"işlətmənizə mane ola bilər.  Məsləhət edirik ki %d böyüklüyündən daha kiçik "
-"böyüklük seçəsiniz."
-msgstr[1] ""
-"Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
-"işlətmənizə mane ola bilər.  Məsləhət edirik ki %d böyüklüyündən daha kiçik "
-"böyüklük seçəsiniz."
-
-#: ../capplets/font/main.c:505
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
-"işlətmənizə mane ola bilər.  Məsləhət edirik ki daha kiçik .böyüklük "
-"seçəsiniz."
-msgstr[1] ""
-"Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
-"işlətmənizə mane ola bilər.  Məsləhət edirik ki daha kiçik .böyüklük "
-"seçəsiniz."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "Yeni sürətləndirici..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Sürə'tləndirici düymə"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Sürə'tləndirici dəyişdiriciləri"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Sür'ətləndirici düymə kodu"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Sürə'tləndirmə Modu"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Sürə'tləndirici növü."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:197
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Bağlı"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:545
-msgid "<Unknown Action>"
-msgstr "<Namə'lum Gedişat>"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_Mövqe:"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:566
-msgid "Desktop"
-msgstr "Masa Üstü"
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr ""
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:567
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "_Arxa Planı Tətbiq Et"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Ekran"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Divar Kağızı İşlətmə"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
 msgstr "Səs"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:571
-msgid "Window Management"
-msgstr "Pəncərə İdarəsi"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:668
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
-"\"%s\" qısa yolu hazırda bu gedişat üçün istifadə edilir:\n"
-" \"%s\"\n"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:700
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr "Qurğu mə'lumat bazasında yeni sür'ətləndirici tə'yin etmə xətası: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:750
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr "Qurğu mə'lumat bazasından sür'ətləndirici silmə xətası: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:857
-msgid "Action"
-msgstr "Gedişat"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:881
-msgid "Shortcut"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
 msgstr "Qısa Yol"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
 msgstr "Klaviatura Qısa Yolları"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
 msgstr ""
-"Qısa yolu dəyişdirmək üçün uyğun sətirə tıqlayıb yeni sürətləndiricini "
-"yazın, ya da silmək üçün backspace düyməsinə basın."
 
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Əmrlərə qısa yol düymələri tə'yin edin"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
-msgid "Unknown"
-msgstr "Naməlum"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
-msgid "Layout"
-msgstr "Düzülüş"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Fayl Növünü Əlavə Et"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "_Proqram yazı növü:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<i>Kiçik</i>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Tərz:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 #, fuzzy
 msgid "Default"
 msgstr "Ön Qurğulu Kursor"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
-msgid "Models"
-msgstr "Modellər"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:106
-#, c-format
-msgid "There was an error launching the keyboard capplet : %s"
-msgstr "Klaviatura kappleti başlarkən xəta yarandı : %s"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
-msgstr "_Yetişmə Qabiliyyəti"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:240
-#: ../capplets/sound/sound-properties-capplet.c:242
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr "Yalnızca qurğuları tətbiq et və çıx"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
-msgstr "Səhifəyə başlarkən yazma fasiləsi qurğularını göstər"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "..."
-msgstr "..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>Yanıb Sönən Ox</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Təkrarlanan Düymələr</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<b>Fasilə verməyə məcbur etmək üçün ekranı _qıfılla</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Sür'ətli</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Uzun</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Qısa</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Yavaş</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_vailable layouts:"
-msgstr "_Mövcud düzülüşlər:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "All_ow postponing of breaks"
-msgstr "Fasilələrin _gecikdirilməsinə icazə ver"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Fasilələrin tə'xirə salma icazələrinin olduğunu yoxlayın"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-#, fuzzy
-msgid "Choose A Keyboard Model"
-msgstr "Klaviatura modelini seç"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-#, fuzzy
-msgid "Choose A Layout"
-msgstr "_Bağla və İclası Sonlandır"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
-msgstr "Mətn qutuları və sahələrində ox _yanıb sönsün"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Duration of the break when typing is disallowed"
-msgstr "Yazma qadağan ikən fasilənin sürəkliyi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of work before forcing a break"
-msgstr "Fasiləyə məcbur etmədən əvvəlki iş sürəkliyi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Key presses _repeat when key is held down"
-msgstr "Düymə basılı tutulanda hərflər təkrarlansın"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Keyboard Preferences"
-msgstr "Klaviatura Qurğuları"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Keyboard _model:"
-msgstr "Klaviatura _modeli:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Layout Options"
-msgstr "Düzülüş Seçimləri"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Layouts"
-msgstr "Düzülüşlər"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-"Sürəkli klaviatura istifadəsindən meydana gələn zədələnmələrdən qorunmaq "
-"üçün müəyyən bir vaxt sonra ekranı qıfılla"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Microsoft Natural Keyboard"
-msgstr "Microsoft Natural Keyboard"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-#, fuzzy
-msgid "Preview:"
-msgstr "Ön _Nümayiş"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-#, fuzzy
-msgid "Reset To De_faults"
-msgstr "Ön _qurğulara sıfırla"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Separate _group for each window"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Typing Break"
-msgstr "Yazma Fasiləsi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "_Accessibility..."
-msgstr "_Yetişmə Qabiliyyəti..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#: panels/background/cc-background-panel.ui:98
 #, fuzzy
-msgid "_Add..."
+msgid "Background"
+msgstr "_Arxa Planı Tətbiq Et"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Ekran Həllediciliyi"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Parlaqlığı artır"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_İdxal Et"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
 msgstr "Əlavə Et..."
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Break interval lasts:"
-msgstr "_Fasilənin sürəkliyi:"
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Delay:"
-msgstr "_Gecikmə:"
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
 #, fuzzy
-msgid "_Models:"
+msgid "_Add profile"
 msgstr "_Modellər"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Selected layouts:"
-msgstr "_Seçili düzülüşlər:"
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Speed:"
-msgstr "_Sür'ət:"
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Work interval lasts:"
-msgstr "_İşin sürəkliyi:"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "_Sil"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "minutes"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Ətraflı"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
 msgstr "dəqiqə"
 
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Klaviatura seçimlərinizi seçin"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:559
-msgid "Unknown Cursor"
-msgstr "Namə'lum Kursor"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:761
-msgid "Default Cursor"
-msgstr "Ön Qurğulu Kursor"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Cursor - Current"
-msgstr "Ön Qurğulu Kursor - Hazırkı"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-msgid "The default cursor that ships with X"
-msgstr "X ilə birlikdə gələn ön qurğulu kursor"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-msgid "White Cursor"
-msgstr "Ağ Kursor"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Cursor - Current"
-msgstr "Ağ Kursor - Hazırkı"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-msgid "The default cursor inverted"
-msgstr "Ön qurğulu kursorun çevrilmiş vəziyyəti"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-msgid "Large Cursor"
-msgstr "Geniş Kursor"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Cursor - Current"
-msgstr "Geniş Kursor - Hazırkı"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-msgid "Large version of normal cursor"
-msgstr "Ön qurğulu kursorun geniş forması"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-msgid "Large White Cursor - Current"
-msgstr "Geniş Ağ Kursor - Hazırkı"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Cursor"
-msgstr "Geniş Ağ Kursor"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-msgid "Large version of white cursor"
-msgstr "Ağ kursorun geniş forması"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:975
-msgid "Cursor Theme"
-msgstr "Kursor Örtüyü"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr "<b>Cüt Tıqlama Gecikməsi </b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Daşı və Burax</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Oxun Yerinin Göstərilməsi</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>Siçan İstiqaməti</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Speed</b>"
-msgstr "<b>Sür'ət</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>Sür'ətli</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>Yüksək</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>Böyük</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>Alçaq</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>Yavaş</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>Kiçik</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Düymələr"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#: panels/color/cc-color-panel.ui:635
 #, fuzzy
-msgid "Cursor Size:"
-msgstr "Kursor Böyüklüyü"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Cursors"
-msgstr "Kursorlar"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr "Ctrl düyməsinə basıldığında _oxun yerini göstər"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-#, fuzzy
-msgid "Large"
-msgstr "_Geniş"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-#, fuzzy
+msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "_Orta"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Motion"
-msgstr "Hərəkət"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Mouse Preferences"
-msgstr "Siçan Seçimləri"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#: panels/color/cc-color-panel.ui:636
 #, fuzzy
-msgid "Small"
-msgstr "_Kiçik"
+msgid "30 minutes"
+msgstr "dəqiqə"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
-msgstr "_Sür'ətləndirmə:"
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
-msgstr "_Solaxay üçün siçan"
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "dəqiqə"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr "_Həssasiyyət:"
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr "_Aralıq:"
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Tək Rəng"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "_Seç"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Seç"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
 msgstr "_Gecikmə:"
 
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Siçan"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Siçanınızın qurğularını seçin"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Şəbəkə Vəkil Vericisi"
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
 #, fuzzy
-msgid "Set your network proxy preferences"
-msgstr "Şəbəkə vəkil qurğuları"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-#, fuzzy
-msgid "<b>D_irect internet connection</b>"
-msgstr "<b>_Birbaşa internet bağlantısı</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>_Avtomatik vəkil quraşdırılması</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>Ə_l ilə vəkil quraşdırılması</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Təsdiqləmə işlət</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-#, fuzzy
-msgid "Advanced Configuration"
-msgstr "Avtomatik quraşdırma _URL-si:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr "Avtomatik quraşdırma _URL-si:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "HTTP Vəkil Təfərruatları"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "H_TTP vəkil vericisi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-#, fuzzy
-msgid "Network Proxy Preferences"
-msgstr "Şəbəkə vəkil qurğuları"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Qapı:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-#, fuzzy
-msgid "Proxy Configuration"
-msgstr "Şəbəkə Proksisi Quraşdırması"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr "S_ocks qovşağı:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "U_sername:"
-msgstr "_İstifadəçi Adı:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_Ətraflı"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr "_FTP vəkil vericisi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "_Şifrə:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr "_E'tibarlı HTTP vəkil vericisi:"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Səsi fəallaşdır və hadisələrlə səsləri əlaqələndir"
-
-#: ../capplets/sound/sound-properties-capplet.c:271
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Sound Preferences"
-msgstr "Səs Qurğuları"
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "E_nable sound server startup"
-msgstr "Başlanğıcda səs vericisini _fəallaşdır"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "Flash _entire screen"
-msgstr "_Bütün ekranı parlat"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "Flash _window titlebar"
-msgstr "_Pəncərənin başlıq çubuğunu parlat"
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "General"
-msgstr "Ümumi"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "Sound Events"
-msgstr "Səsli Hadisələr"
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "System Bell"
-msgstr "Sistem Bildirişi"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "_Sound an audible bell"
-msgstr "_Səs çıxart"
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "_Sounds for events"
-msgstr "Hadisələr üçün _səsli bildirişləri işlət"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "_Visual feedback:"
-msgstr "_Əyani bildiriş işlət:"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:347
-msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
-msgstr ""
-"Sisteminizdə heş örtük tapıla bilmədi. Bu \"Örtük Qurğuları\" dialoqunun "
-"düzgün quraşdırılmadığına dəlalət edir, ya da \"gnome-themes\" paketini "
-"qurmamışsınız."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:227
-msgid "This theme is not in a supported format."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:244
-msgid "Failed to create temporary directory"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:264
-msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:282
-#: ../capplets/theme-switcher/gnome-theme-installer.c:319
-#: ../capplets/theme-switcher/gnome-theme-installer.c:399
-#, fuzzy
-msgid "Installation Failed"
-msgstr "Örtük Qurulması"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:302
-msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:340
-#, c-format
-msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:343
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:346
-#, c-format
-msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:349
-#, c-format
-msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:357
-msgid "The theme is an engine. You need to compile the theme."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:374
-#, fuzzy
-msgid "The file format is invalid"
-msgstr "%s faylı hökmlü wav faylı deyil"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:468
-msgid "No theme file location specified to install"
-msgstr "Qurulacaq örtük faylı mövqeyi bildirilmədi"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:485
-msgid "The theme file location specified to install is invalid"
-msgstr "Qurulacaq örtük faylının mövqeyi hökmsüzdür"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:505
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:526
-#, fuzzy
-msgid "The file format is invalid."
-msgstr "%s faylı hökmlü wav faylı deyil"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:553
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-"%s mövqeyinə örtük faylları qurulacaqdır ona görə də mənbə qovluğu olaraq bu "
-"qovluq seçilə bilməz"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:607
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "Custom theme"
-msgstr "Xüsusi örtük"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr "Bu örtüyü Örtüyü Qeyd Et düyməsinə basaraq qeyd edə bilərsiniz."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr ""
-"Sisteminizdə ön qurğulu örtük sxemləri tapıla bilmədi. Bu metacity paketinin "
-"qurulmadığına ya da gconf'un səhv qurğulandığına dəlalət edir."
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:72
-msgid "Theme name must be present"
-msgstr "Örtük adı mövcud olmalıdır"
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:104
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Örtük onsuzda mövcuddur. Onu əvəz etmək istəyirsiniz?"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr "Masa üstünün müxtə'lif yerləri üçün örtüklər seç"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "Örtük"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Örtük Qur</span>"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:3
-msgid "Theme Installation"
-msgstr "Örtük Qurulması"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:4
-msgid "_Install"
-msgstr "_Qur"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:5
-msgid "_Location:"
-msgstr "_Mövqe:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Örtüyü Diskə Qeyd Et</span>"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Apply _Background"
-msgstr "_Arxa Planı Tətbiq Et"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Apply _Font"
-msgstr "_Yazı Növünü Tətbiq Et"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Controls"
-msgstr "Pəncərə görünüşü"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "Icons"
-msgstr "Timsallar"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "New themes can also be installed by dragging them into the window."
-msgstr ""
-"Yeni örtükləri bu pəncərənin üstünə daşıyıb buraxaraq da qura bilərsiniz."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-msgid "Save Theme"
-msgstr "Örtüyü Qeyd Et"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-msgid "Select theme for the desktop"
-msgstr "Masa üstü örtüyünü seçin"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-msgid "Short _description:"
-msgstr "_Qısa izahat:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "Theme Details"
-msgstr "Örtük Təfərruatları"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "Theme Preferences"
-msgstr "Örtük Seçimləri"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-msgid "Theme _Details"
-msgstr "Örtük _Təfərruatları"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-msgid "This theme does not suggest any particular font or background."
-msgstr ""
-"Bu örtüyün məsləhər etdiyi xüsusi bir yazı növü ya da arxa plan yoxdur."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-msgid "This theme suggests a background:"
-msgstr "Bu örtük arxa plan məsləhət edir:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-msgid "This theme suggests a font and a background:"
-msgstr "Bu örtük yazı növü və arxa plan məsləhət edir:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-msgid "This theme suggests a font:"
-msgstr "Bu örtük yazı növü məsləhət edir:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "Window Border"
-msgstr "Pəncərə Kənarı"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-msgid "_Go To Theme Folder"
-msgstr "Örtük Qovluğuna _Get"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-msgid "_Install Theme..."
-msgstr "Ö_rtük Qur..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-msgid "_Revert"
-msgstr "_Geri Al"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-msgid "_Save Theme..."
-msgstr "Örtüyü _Qeyd Et..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-msgid "_Theme name:"
-msgstr "Örtük _adı:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:24
-msgid "theme selection tree"
-msgstr "örtük seçki budağı"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
-msgstr "Proqramlardakı vasitə və menyu çubuqlarının görünüşünü xüsusiləşdir"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "Menyular və Vasitə Çubuqları"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
-msgstr "<b>Davranış və Görünüş</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-msgid "<b>Preview</b>"
-msgstr "<b>Nümayiş</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "Kə_s"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-msgid "Icons only"
-msgstr "Təkcə timsallar"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "Menyu və Vasitə Çubuğu Seçimləri"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "Yeni Fayl"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Fayl Aç"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Faylı Qeyd Et"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr "Menyularda _timsalları göstər"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-msgid "Text below icons"
-msgstr "Mətn timsalların altında"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-msgid "Text beside icons"
-msgstr "Mətn timsalların yanında"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-msgid "Text only"
-msgstr "Təkcə mətn"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
-#, fuzzy
-msgid "Toolbar _button labels:"
-msgstr "Vasitə çubuğu _düymələrinin görünüşü: "
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_Köçür"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
-msgstr "_Vasitə çubuqları ayırıla bilsin"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
-msgstr "_Düzəlt"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
-msgstr ""
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "_Fayl"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_Yeni"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
-msgstr "_Aç"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "_Yapışdır"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "Ç_ap Et"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "Çı_x"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "_Qeyd Et"
-
-#: ../capplets/windows/gnome-window-properties.c:386
-#, c-format
-msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
-msgstr ""
-"<b>Pəncərə idarəçiniz üçün qurğu tə'minatı başladıla bilmir</b>\n"
-"\n"
-"%s"
-
-#: ../capplets/windows/gnome-window-properties.c:644
-msgid "Control"
-msgstr "Control"
-
-#: ../capplets/windows/gnome-window-properties.c:649
-msgid "Alt"
-msgstr "Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:655
-msgid "Hyper"
-msgstr "Hyper"
-
-#: ../capplets/windows/gnome-window-properties.c:662
-msgid "Super (or \"Windows logo\")"
-msgstr "Windows"
-
-#: ../capplets/windows/gnome-window-properties.c:669
-msgid "Meta"
-msgstr "Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Hərəkət Düyməsi</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>Etiket Çubuğu Gedişatı</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Pəncərə Seçkisi</b>:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To _move a window, press-and-hold this key then grab the window:"
-msgstr ""
-"Pəncərəni _daşımaq üçün bu düyməni basılı tutaraq pəncərəni hərəkət etdirin:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Pəncərə Seçimləri"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_Başlıq çubuğuna cüt tıqlandığında bu gedişatı yerinə gətir:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "_Qabağa gətirmədən əvvəlki vaxt:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_Seçili pəncərələri müəyyən bir vaxt sonra qabağa gətir"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Siçanın oxu pəncərələrin üstünə gələndə onları seç"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-#, fuzzy
-msgid "Set your window properties"
-msgstr "Pəncərə Xassələri"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "Pəncələr"
-
-#: ../control-center/control-center-categories.c:257
-msgid "Others"
-msgstr "Digərləri"
-
-#: ../control-center/control-center.c:42
-#, fuzzy
-msgid "Desktop Preferences"
-msgstr "Masa Üstü Arxa Planı Seçimləri"
-
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr "GNOME İdarə Mərkəzi"
-
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "GNOME quraşdırma avadanlığı"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "Səs"
-
-#: ../gnome-settings-daemon/factory.c:36
-msgid "Could not initialize Bonobo"
-msgstr "Bonobo başladıla bilmir"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
-msgid "Slow Keys Alert"
-msgstr "Yavaş Düymələr Xəbərdarlığı"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-msgstr ""
-"Az öncə Shift düyməsinə basıb 8 saniyə saxladınız.  Bu Yavaş Düymələr "
-"xassəsini fəallaşdırar, bu da klaviaturanızın işləmə tərzini dəyişdirər."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
-msgid "Do you want to activate Slow Keys?"
-msgstr "Yavaş Düymələri fəallaşdırmaq istəyirsiniz?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
-msgid "Do you want to deactivate Slow Keys?"
-msgstr "Yavaş Düymələri qeyri-fəallaşdırmaq istəyirsiniz?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Sticky Keys Alert"
-msgstr "Yapışqan Düymələr Xəbərdarlığı"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-"Az öncə Shift düyməsinə arxa arxaya 5 dəfə basdınız.  Bu Yapışqan Düymələr "
-"xassəsini fəallaşdırar, bu da klaviaturanızın işləmə tərzini dəyişdirər."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-"Az öncə iki düyməyə bərabər ya da Shift düyməsinə arxa arxaya 5 dəfə "
-"basdınız.  Bu Yapışqan Düymələr xassəsini fəallaşdırar, bu da "
-"klaviaturanızın işləmə tərzini dəyişdirər."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
-msgid "Do you want to activate Sticky Keys?"
-msgstr "Yapışqan Düymələri fəallaşdırmaq istəyirsiniz?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr "Yapışqan Düymələri qeyri-fəallaşdırmaq istəyirsiniz?"
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:107
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-"\"%s\" qovluğu yaradıla bilmir.\n"
-"Bu kursorların dəyişdirilə bilməsi üçün məcburidir."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr "(%s) düymə bağının gedişatı birdən çox dəfə tə'yin edilib\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr "(%s) düymə bağının bağı birdən çox dəfə tə'yin edilib\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr "(%s) düymə bağı tamamlanmayıb\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr "(%s) düymə bağı hökmsüzdür\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
-#, c-format
-msgid "It seems that another application already has access to key '%d'."
-msgstr "Görünən odur ki, '%d' düyməsinə başqa bir tə'minat bağ qurub."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr "(%s) düymə bağı hazırda istifadədədir\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-"(%2$s) düyməsinə bağlı olan\n"
-"(%1$s) icra edilməyə çalışırkən xəta yarandı"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
-#, fuzzy, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-"XKB qurğularını fəallaşdırma xətası.\n"
-"Deyəsən daxili X vericisi problemidir.\n"
-"\n"
-"X vericisi mə'lumatı:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"Əgər bu vəziyyəti xəta olaraq raport etmək istəsəniz:\n"
-"- <b>xprop -root | grep XKB</b> əmrinin nəticəsini və\n"
-"- <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/xkb</b>\n"
-"   əmrinin nəticəsini də yollayın."
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
-#, fuzzy
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-"Siz XFree 4.3.0 buraxılışını işlədirsiniz.\n"
-"Qarışıq XKB qurğuları ilə əlaqəli bə'zi problemlər vardır.\n"
-"XFree tə'minatının daha yeni buraxılışını endirməyə çalışın."
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
-#, fuzzy
-msgid "Do _not show this warning again"
-msgstr "_Bu ismarışı bir də göstərmə"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
-msgid ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
-msgstr ""
-"X sisteminin klaviatura quruluşu hazırkı GNOME klaviatura quruluşundan "
-"fərqlidir. Hansı dəstəni işlətmək istəyirsiniz?"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
-msgid "Use X settings"
-msgstr "X qurğularını işlət"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
-msgid "Use GNOME settings"
-msgstr "GNOME Qurğularını İşlət"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
-msgstr ""
-"Əmr icra edilə bilmədi: %s\n"
-"Bu əmrin mövcud olduğunu yoxlayın."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-"Sistem yuxu vəziyyətinə keçirilə bilmədi.\n"
-"Sistemin düzgün quraşdırıldığını yoxlayın."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
-#, c-format
-msgid "Permissions on the file %s are broken\n"
-msgstr "%s faylının səlahiyyətləri hökmsüzdür\n"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-"Glade faylı yüklənə biləmdi.\n"
-"Bu demonun düzgün qurulduğunu yoxlayın."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-"Ekran qoruyucu başladılırkən bir xəta yarandı:\n"
-"\n"
-"%s\n"
-"\n"
-"Bu iclas üçün ekran qoruyucu xassəsi fəal olmayacaq."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
-msgid "_Do not show this message again"
-msgstr "_Bu ismarışı bir də göstərmə"
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:129
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr "%2$s şablonu olaraq %1$s səs faylı yüklənə bilmədi"
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
-msgid "Cannot determine user's home directory"
-msgstr "İstifadəçinin ev cərgəsi müəyyən edilə bilmir"
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr "%s GConf açarı %s seçilib ancaq %s cüründə olması gözlənilirdi\n"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-#, fuzzy
-msgid "A_vailable files:"
-msgstr "_Mövcud düzülüşlər:"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-#, fuzzy
-msgid "Do _not show this warning again."
-msgstr "_Bu ismarışı bir də göstərmə"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-#, fuzzy
-msgid "_Loaded files:"
-msgstr "_Modellər"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr "Signal borusu yaradıla bilmədi."
-
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "Növ"
-
-#: ../libbackground/applier.c:256
-msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-msgstr ""
-"bg_applier növü: Kök pəncərəsi üçün BG_APPLIER_ROOT və ya nümayiş üçün "
-"BG_APPLIER_PREVIEW"
-
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr "Nümayiş Eni"
-
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr "Tətbiq edici bir nümayiş isə eni: Ön qurğulusu 64."
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr "Nümayiş Hündürlüyü"
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr "Tətbiq edici bir nümayiş isə hündürlüyü: Ön qurğulusu 48."
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Ekran"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr "BGApplier'in göstəriləcəyi ekran"
-
-#: ../libgswitchit/gswitchit_config.c:1035
-#, fuzzy, c-format
-msgid "There was an error loading an image: %s"
-msgstr "Yardımın göstərilməsi sırasında xəta oldu: %s"
-
-#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
-msgid "The sound file for this event does not exist."
-msgstr "Bu səbəb üçün ayrılmış səs faylı yoxdur."
-
-#: ../libsounds/sound-view.c:149
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package\n"
-"for a set of default sounds."
-msgstr ""
-"Bu səbəb üçün seçilmiş səs faylı yoxdur.\n"
-"Bəlkə də ön qurğulu səslər üçün gnome-audio paketini\n"
-" qurmamısınız."
-
-#: ../libsounds/sound-view.c:224
-#, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "%s faylı hökmlü wav faylı deyil"
-
-#: ../libsounds/sound-view.c:289
-msgid "Event"
-msgstr "Hadisə"
-
-#: ../libsounds/sound-view.c:298
-msgid "Sound File"
-msgstr "Səs Faylı"
-
-#: ../libsounds/sound-view.c:314
-msgid "_Sounds:"
-msgstr "_Səslər:"
-
-#: ../libsounds/sound-view.c:328
-msgid "Sound _file:"
-msgstr "Səs _faylı:"
-
-#: ../libsounds/sound-view.c:332
-msgid "Select Sound File"
-msgstr "Səs Faylını Seç"
-
-#: ../libsounds/sound-view.c:356
-msgid "_Play"
-msgstr "Ç_al"
-
-#: ../libsounds/sound-view.c:366
-msgid "_Remove"
-msgstr "_Sil"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "\"%s\" pəncərə idarəçisi quraşdırma vasitəsini tanımadı\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Böyüt"
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Yuxarı Bur"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr ""
-"Seşilidirsə, text/plain və text/* üçün tutucular sync içində saxlanacaq"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr "Sync text/plain və text/* tutucuları"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "Brightness down"
-msgstr "Parlaqlığı azalt"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "Brightness down's shortcut."
-msgstr "Parlaqlığı azaltma qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Brightness up"
-msgstr "Parlaqlığı artır"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Brightness up's shortcut."
-msgstr "Parlaqlığı artırma qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "E-mail"
-msgstr "E-poçt"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "E-mail's shortcut."
-msgstr "E-poçt qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Eject"
-msgstr "Çıxart"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-msgid "Eject's shortcut."
-msgstr "Çıxartma əməliyyatı üçün qısa yol."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-msgid "Home folder"
-msgstr "Ev qovluğu"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-msgid "Home folder's shortcut."
-msgstr "Ev qovluğunun qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-msgid "Launch help browser"
-msgstr "Yardım aəyyahını başlat"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-msgid "Launch help browser's shortcut."
-msgstr "Yardım səyyahını başlatma qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-msgid "Launch web browser"
-msgstr "Veb səyyahını başlat"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-msgid "Launch web browser's shortcut."
-msgstr "Veb səyyahını başlatma qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-msgid "Lock screen"
-msgstr "Ekranı qıfılla"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-msgid "Lock screen's shortcut."
-msgstr "Ekranı qıfıllama qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-msgid "Log out"
-msgstr "İclası sonlandır"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-msgid "Log out's shortcut."
-msgstr "İclası sonlandırma qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Next track key's shortcut."
-msgstr "Növbəti mahnı üçün qısa yol."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Pause"
-msgstr "Fasilə ver"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-msgid "Pause key's shortcut."
-msgstr "Fasilə vermək üçün qısa yol."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Play (or play/pause)"
-msgstr "Çal (ya da çal/fasilə ver)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Play (or play/pause) key's shortcut."
-msgstr "Çal (ya da çal/fasilə ver) düyməsinin qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Previous track key's shortcut."
-msgstr "Əvvəlki mahnı üçün qısa yol."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
-msgid "Search"
+msgid "March"
 msgstr "Axtar"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-msgid "Search's shortcut."
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "_Gecikmə:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
 msgstr "Axtarış üçün qısa yol."
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Skip to next track"
-msgstr "Nüvbəti mahnıya keç"
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Skip to previous track"
-msgstr "Əvvəlki mahnıya keç"
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-msgid "Sleep"
-msgstr "Yuxu vəziyyətinə sal"
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-msgid "Sleep's shortcut."
-msgstr "Yuxu vəziyyətinə salma qısa yolu"
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Stop playback key"
-msgstr "Çalğını dayandırma düyməsi"
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Stop playback key's shortcut."
-msgstr "Çalğını dayandırma düyməsinin qısa yolu."
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Bağlı"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "saniyə"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Kate_qoriya:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Masa Üstü Arxa Plan Qurğunuzu Dəyişdirin"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Kate_qoriya:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Ön Qurğulu Proqramlar"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Ön qurğulu proqramlarınızı seçin"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Yazı növünü _tətbiq et"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<b>Siçan İstiqaməti</b>"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Həlledicilik:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "_Yeniləmə sıxlığı:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Miqyaslandırılmış"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Hissə bitdi"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "%s-dən"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "dəqiqə"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "%s-yə"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+#, fuzzy
+msgid "No Events"
+msgstr "Səsli Hadisələr"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Ad:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Növ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Terminal"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Pəncələr"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Örtük _adı:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_İstifadəçi Adı:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Haqqında"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Səsi bağla"
+
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Səsi azalt"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume down's shortcut."
-msgstr "Səsi azaltma qısa yolu"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-msgid "Volume mute"
-msgstr "Səsi bağla"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume mute's shortcut"
-msgstr "Səsi bağlama qısa yolu"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
-msgid "Volume step"
-msgstr "Səs addımı"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-msgid "Volume step as percentage of volume."
-msgstr "Səs həcmi faizi olaraq səs addımı."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Səsi artır"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
-msgid "Volume up's shortcut."
-msgstr "Səsi artırma qısa yolu."
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
-#, fuzzy
-msgid "Display a dialog when there are errors running the screensaver"
-msgstr "XScreenSaver işlərkən yaranan xətaları dialoq qutusunda göstər"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-#, fuzzy
-msgid "Run screensaver at login"
-msgstr "Girişdə XScreenSaver-i işə sal"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
-msgstr "Başlanğıc Xətalarını Göstər"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
-#, fuzzy
-msgid "Start screensaver"
-msgstr "XScreenSaver-i Başlat"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Çal (ya da çal/fasilə ver)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:18
 #, fuzzy
-msgid "Keyboard Update Handlers"
-msgstr "Klaviatura _modeli:"
+msgid "Stop playback"
+msgstr "Çalğını dayandırma düyməsi"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:20
 #, fuzzy
-msgid "Keyboard layout"
-msgstr "XKB klaviatura düzülüşü"
+msgid "Previous track"
+msgstr "Əvvəlki mahnıya keç"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:22
 #, fuzzy
-msgid "Keyboard model"
-msgstr "Klaviatura _modeli:"
+msgid "Next track"
+msgstr "Nüvbəti mahnıya keç"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Çıxart"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 #, fuzzy
-msgid "Keyboard options"
-msgstr "Klaviatura Qısa Yolları"
+msgid "Typing"
+msgstr "Yazma Fasiləsi"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+#: panels/keyboard/01-input-sources.xml.in:8
 #, fuzzy
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
-msgstr "Gconf-dakı XKB qurğuları tezliklə sisteminkilərlə əvəz ediləcəkdir"
+msgid "Switch to next input source"
+msgstr "Nüvbəti mahnıya keç"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Əvvəlki mahnıya keç"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Veb səyyahını başlat"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Yardım aəyyahını başlat"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Ön Qurğular"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
-msgstr ""
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Veb səyyahını başlat"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr ""
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Ev qovluğu"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+#: panels/keyboard/01-launchers.xml.in:16
 #, fuzzy
-msgid "keyboard layout"
-msgstr "XKB klaviatura düzülüşü"
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Axtar"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 #, fuzzy
-msgid "keyboard model"
-msgstr "XKB klaviatura modeli"
+msgid "System"
+msgstr "Sistem Bildirişi"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "modmap file list"
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "İclası sonlandır"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Ekranı qıfılla"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Yetişmə Qabiliyyəti"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
 msgstr ""
 
-#: ../typing-break/drw-break-window.c:212
-msgid "_Postpone break"
-msgstr "Fasiləni _tə'xirə sal"
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
 
-#: ../typing-break/drw-break-window.c:259
-msgid "Take a break!"
-msgstr "Fasilə ver!"
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "İclası sonlandır"
 
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:141
-msgid "/_Preferences"
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "_Ekran üstü klaviatura"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Seçimlər"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
 msgstr "/_Seçimlər"
 
-#: ../typing-break/drwright.c:142
-msgid "/_About"
-msgstr "/_Haqqında"
-
-#: ../typing-break/drwright.c:144
-msgid "/_Take a Break"
-msgstr "/_Fasilə Ver"
-
-#: ../typing-break/drwright.c:495
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "Növbəti fasiləyə %d dəqiqə qalıb"
-msgstr[1] "Növbəti fasiləyə %d dəqiqə qalıb"
-
-#: ../typing-break/drwright.c:499
-msgid "Less than one minute until the next break"
-msgstr "Növbəti fasiləyə bir dəqiqədən az qalıb"
-
-#: ../typing-break/drwright.c:587
-#, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
-msgstr "Yazma fasiləsi xassələri dialoqu göstərilə bilmədi. Xəta: %s"
-
-#: ../typing-break/drwright.c:635
-msgid "About GNOME Typing Monitor"
-msgstr "GNOME Yazma İzləyicisi Haqqında"
-
-#: ../typing-break/drwright.c:659
-msgid "A computer break reminder."
-msgstr "Kopüter fasiləsini yada salan tə'minat."
-
-#: ../typing-break/drwright.c:660
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
-msgstr "Richard Hult &lt;richard@imendio.com&gt; tərəfindən yazılıb"
-
-#: ../typing-break/drwright.c:661
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Qrafika Anders Carlsson tərəfindən əlavə edilib"
-
-#: ../typing-break/drwright.c:837
-msgid "Break reminder"
-msgstr "Fasilə yada salıcı"
-
-#: ../typing-break/main.c:93
-msgid "The typing monitor is already running."
-msgstr "Yazma izləyicisi onsuzda fəaliyyətdədir."
-
-#: ../typing-break/main.c:106
+#: panels/keyboard/cc-input-row.ui:48
 #, fuzzy
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+msgid "View Keyboard Layout"
+msgstr "XKB klaviatura düzülüşü"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Sil"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
 msgstr ""
-"Yazma izləyicisi mə'lumatı göstərmək üçün bildiriş sahəsini istifadə edir. "
-"Panelinizdə bildiriş sahəsi appleti mövcud deyil. Onu əlavə etmək üçün "
-"panelinizə sağ tıqlayıb 'Panelə Əlavə Et -> Tə'minatlar -> Bildiriş sahəsi' "
-"menyusunu seçin."
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "Sən! Bu gün Azərbaycan üçün nə etdin? 0123456789"
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:276
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Siçan Düymələri"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Klaviatura Qısa Yolları"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Gedişat"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Qısa Yol"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Qısa Yol"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Qısa Yol"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Klaviatura Qısa Yolları"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Sil"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Ad:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Ə_mr:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Qısa Yol"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Qısa Yol"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_Yoxdur"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Ön _qurğulara sıfırla"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klaviatura"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "MIME növü mə'lumatı"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Ön Qurğular"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Ümumi"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "_Zərif"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_Mövqe:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Siçan"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Siçan Düymələri"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Sür'ətləndirmə:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Sür'ətləndirmə:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_Proqram yazı növü:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Digərləri"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Gedişat"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Bağlanılır..."
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Seçimlər"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Şifrə:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Dəstəni Dəyişdir"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Sürə'tləndirmə Modu"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "_basılanda"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "_basılanda"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "_basılanda"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Ön Qurğulu Kursor"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Ad:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "Ə_lavə Et:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "Ə_lavə Et:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Bağlı"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_basılanda"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+#, fuzzy
+msgid "Address"
+msgstr "_basılanda"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "dəqiqə"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Gedişat"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "_basılanda"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "H_TTP vəkil vericisi:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "H_TTP vəkil vericisi:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP vəkil vericisi:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "S_ocks qovşağı:"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "H_TTP vəkil vericisi:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "H_TTP vəkil vericisi:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP vəkil vericisi:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Avtomatik quraşdırma _URL-si:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Şifrə:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Klaviatura Qısa Yolları"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Təsdiqləmə işlət</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "_İstifadəçi Adı:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Şifrə:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Şifrə:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Buraxılış:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Buraxılış:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Şifrə:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "<b>_Təsdiqləmə işlət</b>"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Növ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Ön Qurğulu Kursor"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Fayl Aç"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Mövqe:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Səs _faylı:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Ekranı qıfıllama qısa yolu."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Ekranı qıfıllama qısa yolu."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Təsdiqləmə işlət</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "dəqiqə"
+msgstr[1] "dəqiqə"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "dəqiqə"
+msgstr[1] "dəqiqə"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "dəqiqə"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "dəqiqə"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "dəqiqə"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "dəqiqə"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "dəqiqə"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "dəqiqə"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "dəqiqə"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "dəqiqə"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Sürə'tləndirmə Modu"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Ekranı Doldur"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Ekran"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Gecikmə:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "Ç_ap Et"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "_İstifadəçi Adı:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "_Mövqe:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Örtük Qurulması"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Seç"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Seçimlər"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Yazı Növü Görünüş Təfərruatları"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Ön _qurğulara sıfırla"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Modellər"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Ön _Nümayiş"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Ekranı Doldur"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Gedişat"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Növ:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Ekran"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Ekranı qıfılla"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Ekran"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Ekran %d Qurğuları\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Klaviatura Qısa Yolları"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Digərləri"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "_Mövqe:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_Proqram yazı növü:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Axtarış üçün qısa yol."
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Masa Üstü"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Sil"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Şifrə:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Masa Üstü"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "UI İdarəsi"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Köçür"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<b>_Təsdiqləmə işlət</b>"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "_İstifadəçi Adı:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Sistem Bildirişi"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Səsi bağla"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Şəbəkə Proksisi Quraşdırması"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Səs"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Düymələr"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Səs"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Ad:"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "Tərz:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "Növ:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "Böyüklük:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "Buraxılış:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "Müəllif hüququ:"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "İzahat:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:408
-#, c-format
-msgid "usage: %s fontfile\n"
-msgstr "istifadə qaydası: %s yazı növü faylı\n"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
-msgstr "Proqram Yazı Növü Olaraq Tə'yin Et"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 #, fuzzy
-msgid "Sets the default application font"
+msgid "Cursor Blinking"
+msgstr "<b>Yanıb Sönən Ox</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Mətn qutuları və sahələrində ox _yanıb sönsün"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Sür'ət:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "<b>Yanıb Sönən Ox</b>"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Kursor Böyüklüyü"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Qısa Yol"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Gecikmə:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Qısa Yol"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Aralıq:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "_Kiçik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "_Geniş"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Təkrarlanan Düymələr</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Düymə basılı tutulanda hərflər təkrarlansın"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Yapışqan Düymələr Xəbərdarlığı"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "İki düymə eyni anda basılanda qeyri-fəallaşdır"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "_Dəyişdirici basılanda səs çıxart"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Yavaş Düymələr Xəbərdarlığı"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Qısa Yol"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "_Dəyişdirici basılanda səs çıxart"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Səs çıxartma vəziyyəti:"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Düymə rədd ediləndə _səs çıxart"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Siçan Düymələri"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Bu vaxt içindəki cüt düymə basışlarını _ləğv et:"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Qısa Yol"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Yetişmə Qabiliyyəti"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "_Geniş"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "_Ekran oxuyucusu"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "_Səslər:"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Kursor Böyüklüyü"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "_Ekran üstü klaviatura"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Təkrarlanan Düymələr</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Yanıb Sönən Ox</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Siçan Düymələri"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "<b>Oxun Yerinin Göstərilməsi</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<b>Cüt Tıqlama Gecikməsi </b>"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "_Bütün ekranı parlat"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "_Bütün ekranı parlat"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Ekranı Doldur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Seçimlər"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_Böyüdücü"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "_Böyüdücü"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "_Ekran oxuyucusu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "_Böyüdücü"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Parlaqlığı artır"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "_Məzmun"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Yoxdur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Tam"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Şifrə:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Səs Faylını Seç"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Pəncərə İdarəçisi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Yoxdur"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Ön _Nümayiş"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Dəstəni Dəyişdir"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Dəstəni Dəyişdir"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Dəstəni Dəyişdir"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Şifrə:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Dəstəni Dəyişdir"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Şifrə:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_Düzəlt"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Pəncərə görünüşü"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
 msgstr "Ön qurğulu proqramlarınızı seçin"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "Seçilirsə, OpenType yazı növlərinin ön nümayişləri göstəriləcək."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "Seçilirsə, PCF yazı növlərinin ön nümayişləri göstəriləcək."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "Seçilirsə, TrueType yazı növlərinin ön nümayişləri göstəriləcək."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "Seçilirsə, Type1 yazı növlərinin ön nümayişləri göstəriləcək."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
 msgstr ""
-"Bu düyməni OpenType yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən "
-"əmrə bağlayın."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr ""
-"Bu düyməni PCF yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən əmrə "
-"bağlayın."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr ""
-"Bu düyməni TrueType yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən "
-"əmrə bağlayın."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr ""
-"Bu düyməni Type1 yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən "
-"əmrə bağlayın."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "OpenType yazı növlərinin ön nümayiş əmri"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "PCF yazı növlərinin ön nümayiş əmri"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "TrueType yazı növlərinin ön nümayiş əmri"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Type1 yazı növlərinin ön nümayiş əmri"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "OpenType yazı növlərinin ön nümayişlərinin göstərilməsi"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "PCF yazı növlərinin ön nümayişlərinin göstərilməsi"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "TrueType yazı növlərinin ön nümayişlərinin göstərilməsi"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "Type1 yazı növlərinin ön nümayişlərinin göstərilməsi"
-
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+#: panels/user-accounts/cc-user-panel.ui:347
 #, fuzzy
-msgid "GNOME Font Viewer"
-msgstr "GNOME İdarə Mərkəzi"
+msgid "Other Users"
+msgstr "Digərləri"
 
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
 msgstr ""
-"<span weight=\"bold\" size=\"larger\">Yeni yazı növü tətbiq edilsin?</span>"
 
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr "Yazı növünü tətbiq et_mə"
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:4
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"Seçdiyiniz örtük yeni yazı növü təklif edir. Yazı növünün nümayişi "
-"aşağıdadır."
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-msgid "_Apply font"
-msgstr "Yazı növünü _tətbiq et"
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
 
-#: ../vfs-methods/themus/theme-method.c:520
-msgid "Themes"
-msgstr "Örtüklər"
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
 
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "İzahat"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
-msgstr "Sınama örtüyü"
-
-#: ../vfs-methods/themus/themus-properties-view.c:139
-msgid "Window border theme"
-msgstr "Pəncərə kənarı örtüyü"
-
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
-msgstr "Timsal örtüyü"
-
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
-msgstr "ABCDEFG"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-#, fuzzy
-msgid "Apply theme"
-msgstr "Yazı növünü _tətbiq et"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-#, fuzzy
-msgid "Sets the default theme"
-msgstr "Ön _qurğulara sıfırla"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr "True isə, quraşdırılmış örtüklərin nümaişləri göstəriləcək."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr "True isə, örtüklərin nümaişləri göstəriləcək."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:3
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
-"Bu düyməni quraşdırılmış örtüklərin nümaişləri göstərmək üçün işlədilən əmrə "
-"bağlayın."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
 msgstr ""
-"Bu düyməni örtüklərin nümaişləri göstərmək üçün işlədilən əmrə bağlayın."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr "Quraşdırılmış örtüklərin nümaişləri göstərmək üçün işlədilən əmr"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr "Örtüklərin nümaişləri göstərmək üçün işlədilən əmr"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr "Quraşdırılmış örtüklərin nümaişlərinin göstərilməsi"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr "Örtüklərin nümaişlərinin göstərilməsi"
-
-msgid "Show help options"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
 msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Düymələr"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Düymələr"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Düymələr"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Düymələr"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Düzülüş"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Ortalanmış"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Pəncələr"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Pəncələr"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Əlavə Et..."
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Qeyd Et"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Örtük Təfərruatları"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Örtük Təfərruatları"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Fayl"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Örtük Təfərruatları"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Açma _Düymələrini Fəallaşdır"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Bağlanılır..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Dəstəni Dəyişdir"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Ön Qurğular"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Ümumi"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Çı_x"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Axtar"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Əvvəlki mahnıya keç"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Seçimlər"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#, fuzzy
+#~ msgid "The type of alert"
+#~ msgstr "Sürə'tləndirici növü."
+
+#, fuzzy
+#~ msgid "Show more _details"
+#~ msgstr "Örtük _Təfərruatları"
+
+#, fuzzy
+#~ msgid "About Me"
+#~ msgstr "_Haqqında"
+
+#, fuzzy
+#~ msgid "No Image"
+#~ msgstr "Rəsmlər"
+
+#, fuzzy, c-format
+#~ msgid "About %s"
+#~ msgstr "_Haqqında"
+
+#, fuzzy
+#~ msgid "Please type the passwords."
+#~ msgstr "_Şifrə:"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#, fuzzy
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Sür'ət</b>"
+
+#, fuzzy
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Yazı Növü Görünüşü</b>"
+
+#, fuzzy
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Dəstək</b>"
+
+#, fuzzy
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Açma Düymələri</b>"
+
+#, fuzzy
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Sür'ət</b>"
+
+#, fuzzy
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Dəstək</b>"
+
+#, fuzzy
+#~ msgid "A_ddress:"
+#~ msgstr "Ə_lavə Et:"
+
+#, fuzzy
+#~ msgid "C_ity:"
+#~ msgstr "_Tərz:"
+
+#, fuzzy
+#~ msgid "C_ompany:"
+#~ msgstr "Ə_mr:"
+
+#, fuzzy
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Dəstəni Dəyişdir"
+
+#, fuzzy
+#~ msgid "Ci_ty:"
+#~ msgstr "_Tərz:"
+
+#, fuzzy
+#~ msgid "Co_untry:"
+#~ msgstr "Control"
+
+#, fuzzy
+#~ msgid "Cou_ntry:"
+#~ msgstr "Control"
+
+#, fuzzy
+#~ msgid "Hom_e:"
+#~ msgstr "_Ad:"
+
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "_Şifrə:"
+
+#, fuzzy
+#~ msgid "Personal Info"
+#~ msgstr "_Terminal yazı növü:"
+
+#, fuzzy
+#~ msgid "_Home page:"
+#~ msgstr "Örtük _adı:"
+
+#, fuzzy
+#~ msgid "_Home:"
+#~ msgstr "_Ad:"
+
+#, fuzzy
+#~ msgid "_Manager:"
+#~ msgstr "_Böyüdücü"
+
+#, fuzzy
+#~ msgid "_Profession:"
+#~ msgstr "Buraxılış:"
+
+#, fuzzy
+#~ msgid "_Title:"
+#~ msgstr "_Tərz:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Dəstək</b>"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>Qeyd:</b> Bu qurğudakı dəyişikliklər bir sonrakı girişinizə "
+#~ "qədər fəal olmayacaqdır.</i></small>"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Yardımçı Texnologiya Seçimləri"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "_Bağla və İclası Sonlandır"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Bu yardımçı texnologiyaları hər girişdə başlat:"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Yardımçı texnologiyaları fəallaşdır"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "Yardımçı Texnologiya Dəstəyi"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "Girişdə GNOME yardımçı texnologiya dəstəyini fəallaşdır"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Sisteminizdə heç bir yardımçı texnologiya mövcud deyil. Ekran üstü "
+#~ "klaviatura dəstəyi almaq üçün 'gok' paketi, ekran oxuma və yaxınlaşdırma "
+#~ "bacarıqları üçün isə 'gnopernicus' paketi qurulu olmalıdır."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Sisteminizdə bütün yardımçı texnologiyalar mövcud deyil. Ekran üstü "
+#~ "klaviatura dəstəyi almaq üçün 'gok' paketi qurulu olmalıdır."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+#~ msgstr ""
+#~ "Sisteminizdə bütün yardımçı texnologiyalar mövcud deyil.  Ekran oxuma və "
+#~ "yaxınlaşdırma bacarıqları üçün 'gnopernicus' paketi qurulu olmalıdır."
+
+#, c-format
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "Siçan qurğuları pəncərəsi başlarkən xəta yarandı: %s"
+
+#, c-format
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "'%s' faylından AccessX qurğuları idxal edilə bilmədi"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Xassə Qurğuları Faylını İdxal Et"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Klaviatura yetişmə qabiliyyəti qurğularınızı seçin"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Bu sistem üstündə XKB uzantısı qurulu deyil. Klaviatura yetişmə "
+#~ "qabiliyyəti xassəsi onsuz işləməyəcək."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>_Eyni Düymələri Fəallaşdır</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>Y_avaş Düymələri Fəallaşdır</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>_Siçan Düymələrini Fəallaşdır</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>_Düymələrin Təkrarlanmasını Fəallaşdır</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>_Yapışqan Düymələri Fəallaşdır</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Xüsusiyyətlər</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Açma Düymələri</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Əsas"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr "_Xassələr klaviaturadan açılıb bağlananda səs çıxart"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr ""
+#~ "Açma düyməsi fəal seçiləndə bir dəfə, qeyri-fəal seçiləndə isə iki dəfə "
+#~ "səs çıxart."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Düymənin basılması ilə oxun hərəkəti arasındakı _gecikmə"
+
+#~ msgid "Filters"
+#~ msgstr "Filtrlər"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "İstifadəçinin seçdiyi vaxt aralığı içində EYNİ düymənin ardıcıl "
+#~ "basışlarını rədd et."
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Klaviatura Yetişmə Qabiliyyəti Qurğuları (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Ma_ksimal ox sür'əti:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Siçan _Qurğuları..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Yalnız istifadəçinin istədiyi bir müddət boyunca basılı tutulan düymələri "
+#~ "qəbul et."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Dəyişdirici düymələri ardıcıl basaraq birdən çox ardıcıl düymə basma "
+#~ "əməliyyatını həyata keçirin."
+
+#~ msgid "S_peed:"
+#~ msgstr "_Sür'ət:"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Maksimal sür'ətə çıxma _vaxtı:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Ədəd düymələri sahəsini siçan idarə vasitəsinə döndərin."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Bu vaxt içinə işlədilməzsə qeyri-fəallaşdır:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "Klaviatura yetişmə qabiliyyətini _fəallaşdır"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Qurğu Faylını İdxal Et..."
+
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "_Yalnız bu vaxt müddətincə basılı tutulan düymələri qəbul et:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "Qurğuları sınama _taxtası:"
+
+#~ msgid "_accepted"
+#~ msgstr "_qəbul ediləndə"
+
+#~ msgid "_pressed"
+#~ msgstr "_basılanda"
+
+#~ msgid "_rejected"
+#~ msgstr "_rədd ediləndə"
+
+#~ msgid "characters/second"
+#~ msgstr "hərf/saniyə"
+
+#~ msgid "milliseconds"
+#~ msgstr "millisaniyə"
+
+#~ msgid "pixels/second"
+#~ msgstr "piksel/saniyə"
+
+#~ msgid "Desktop Background"
+#~ msgstr "Masa Üstü Arxa Planı"
+
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>Masa Üstü _Divar Kağızı</b>"
+
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>_Masa Üstü Rəngləri</b> "
+
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Masa Üstü Arxa Planı Seçimləri"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "Divar Kağızı Ə_lavə Et"
+
+#~ msgid "_Style:"
+#~ msgstr "_Tərz:"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Yardımın göstərilməsi sırasında xəta oldu: %s"
+
+#~ msgid "Tiled"
+#~ msgstr "Döşənmiş"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Üfüqi Qradient"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Şaquli Qradient"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Divar Kağızı Əlavə Et"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Qurğu idarəçisi 'gnome-settings-daemon' başladıla bilmədi.\n"
+#~ "Gnome qurğu idarəçisi işləməzsə, bə'zi seçimlər fəal olmaya bilər. Buna, "
+#~ "Bonobodakı bir problem, ya da Gnome qurğu idarəçisi ilə toqquşan diqər "
+#~ "tə'minatlar səbəb ola bilər."
+
+#, c-format
+#~ msgid "Unable to load capplet stock icon '%s'\n"
+#~ msgstr "Kapplet timsalı '%s' yüklənə bilmədi\n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Təkcə qurğuları əlavə et və çıx"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Miras qurğularını al və saxla"
+
+#~ msgid "From URI"
+#~ msgstr "URI-dən"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "Hazırda transferin hansı URI'dən edildiyi"
+
+#~ msgid "To URI"
+#~ msgstr "URI-yə"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "Hazırda transferin hansı URI'yə edildiyi"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Transferin hissəsi hazırda bitdi"
+
+#~ msgid "Current URI index"
+#~ msgstr "Hazırkı URI indexi"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Hasırkı URI indeksi - 1'dən başlayır"
+
+#~ msgid "Total URIs"
+#~ msgstr "Toplam URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Toplam URI miqdarı"
+
+#~ msgid "Key"
+#~ msgstr "Açar"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Bu üstünlük editorunun ilişdirildiyi GConf açarı"
+
+#~ msgid "Callback"
+#~ msgstr "Geri axtarma"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Açar ilə əlaqələndirilmiş qiymət dəyişəndə bu geri çağırışı yay"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Tətbiq ediləndə gconf alıcısına istiqamətləndiriləcək mə'lumatı daxil "
+#~ "edən GConf Dəyişmə dəsti"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Widget geri çağırışına çeviriş"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "Mə'lumat GConf'dan widget'ə dönüşdürüləndə yaradılacaq geri çağırış"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Widget geri çağırışından çeviriş"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Mə'lumat widget'dən GConf'a dönüşdürüləcəksə yaradılacaq geri çağırış"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Üstünlüyü idarə edən cism (normal halda pəncərəcik)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Xassə editoru obyekt verilənləri"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Spesifik xassə editoru tərəfindən xüsusi mə'lumat məcburi qılınıb"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Geri çağırışı boşaldan xassə editoru mə'lumatı"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "Xassə editoru mə'lumatı boşaldılanda yaradılacaq geri çağırış"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "'%s' faylı tapıla bilmədi.\n"
+#~ "\n"
+#~ "Xahiş edirik, onun mövcud olduğundan əmin olun və yenidən sınayın, ya da "
+#~ "başqa arxa plan rəsmi seçin."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' faylın necə açılacağı bilinmir.\n"
+#~ "Deyəsən, o hələ dəstəklənməyən bir rəsm növüdür.\n"
+#~ "\n"
+#~ "Xahiş edirik, onun yerinə başqa rəsm seçin."
+
+#~ msgid "Please select an image."
+#~ msgstr "Xahiş edirik, bir rəsm seçin."
+
+#, fuzzy
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Ön Qurğulu Veb Səyyahı"
+
+#~ msgid "Epiphany"
+#~ msgstr "Epiphany"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#, fuzzy
+#~ msgid "Firebird"
+#~ msgstr "Firebird/FireFox"
+
+#, fuzzy
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M Mətn Səyyahı"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Lynx Mətn Səyyahı"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Links Mətn Səyyahı"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution Poçt Oxuyucusu"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#, fuzzy
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Ön Qurğulu Terminal"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Standart XTerminalı"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#, fuzzy
+#~ msgid "aterm"
+#~ msgstr "NXterm"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "Xahiş edirik, bu editor üçün bir ad və əmr girin."
+
+#, fuzzy
+#~ msgid "C_ustom"
+#~ msgstr "Hazırkı"
+
+#, fuzzy
+#~ msgid "C_ustom:"
+#~ msgstr "Hazırkı"
+
+#, fuzzy
+#~ msgid "Can open multiple _files"
+#~ msgstr "Bu tə'minat _birdən çox faylları aça bilmir"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Ə_mr:"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Xüsusi Editor Xassələri"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "Ön Qurğulu Poçt Oxuyucusu"
+
+#~ msgid "Default Terminal"
+#~ msgstr "Ön Qurğulu Terminal"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "Ön Qurğulu Mətn Editoru"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "Ön Qurğulu Veb Səyyahı"
+
+#~ msgid "Default Window Manager"
+#~ msgstr "Ön Qurğulu Pəncərə İdarəçisi"
+
+#~ msgid "Delete"
+#~ msgstr "Sil"
+
+#~ msgid "E_xec Flag:"
+#~ msgstr "İşə Salma _Bayrağı:"
+
+#~ msgid "Edit..."
+#~ msgstr "Düzəlt..."
+
+#~ msgid "Mail Reader"
+#~ msgstr "Poçt Oxuyucusu"
+
+#, fuzzy
+#~ msgid "Run in a _terminal"
+#~ msgstr "_Terminalda İcra Et"
+
+#, fuzzy
+#~ msgid "Run in a t_erminal"
+#~ msgstr "_Terminalda İcra Et"
+
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "İstədiyiniz pəncərə idarəçisini seçin. Bunun işləməsi üçün tətbiq et "
+#~ "düyməsinə basdıqdan sonra, sehirli çubuğu oynadıb sehirli sözlər "
+#~ "deməlisiniz."
+
+#~ msgid "Terminal"
+#~ msgstr "Terminal"
+
+#~ msgid "Text Editor"
+#~ msgstr "Mətn Editoru"
+
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "_Netscape Uzaq İdarəsini Başa Düşür"
+
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr ""
+#~ "Fayl idarəçisində mətn fayllarını açmaq üçün bu _editoru istifadə et"
+
+#~ msgid "Web Browser"
+#~ msgstr "Veb Səyyahı"
+
+#~ msgid "_Properties..."
+#~ msgstr "_Xüsusiyyətlər..."
+
+#, fuzzy
+#~ msgid "_Select:"
+#~ msgstr "_Seç"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Ekran həlleciliyini dəyişdir"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Ekran Həllediciliy Seçimləri"
+
+#, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "Sadəcə olaraq bu _kompüter (%s) üçün ön qurğulu qəbul et"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Yeni qurğular sınanır. Əgər %d saniyə ərzində cavab verməsəniz qurğular "
+#~ "bərpa ediləcəkdir."
+#~ msgstr[1] ""
+#~ "Yeni qurğular sınanır. Əgər %d saniyə ərzində cavab verməsəniz qurğular "
+#~ "bərpa ediləcəkdir."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Həllediciliyi Qeyd Et"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Bu həlledilirliyi saxlamaq istəyirsiniz?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "Ə_vvəlki həlledilirliyi istifadə et"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "Həlledilirliyi _qeyd et"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "Xverici XRandR uzantısını dəstəkləmir. Canlı həlledicilik dəyişmələri "
+#~ "təəssüf ki mövcud deyil."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "XRandR buraxılışı bu proqram ilə uyğun gəlmir. Canlı həlledilirlik "
+#~ "dəyişmələri təəssüf ki mövcud deyil."
+
+#~ msgid "Font"
+#~ msgstr "Yazı Növü"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Masa üstü yazı növlərini seçin"
+
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<b>Yazı Növü Görünüşü</b>"
+
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<b>Zərifləndirmə</b>:"
+
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<b>Yumuşaltma</b>:"
+
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<b>Sabpiksel ardıcıllığı</b>:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Optimal şə_killər"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Optimal ko_ntrast"
+
+#~ msgid "D_etails..."
+#~ msgstr "_Təfərruatlar..."
+
+#~ msgid "Font Preferences"
+#~ msgstr "Yazı Növü Qurğuları"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "_Yazı növü qovluğuna get"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "_Ağ-qara"
+
+#~ msgid "N_one"
+#~ msgstr "Yo_xdur"
+
+#~ msgid "R_esolution:"
+#~ msgstr "_Həlledilirlik:"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sab_piksel (LCD-lər)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Sab_piksel yumuşaldılması (LCD-lər)"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Desktop font:"
+#~ msgstr "_Masa üstü yazı növü:"
+
+#~ msgid "_Medium"
+#~ msgstr "_Orta"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Monoxrom"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "_Terminal yazı növü:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Pəncərə başlığının yazı növü:"
+
+#~ msgid "dots per inch"
+#~ msgstr "inç başına nöqtə"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Yazı növü çox geniş ola bilər"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
+#~ "işlətmənizə mane ola bilər.  Məsləhət edirik ki %d böyüklüyündən daha "
+#~ "kiçik böyüklük seçəsiniz."
+#~ msgstr[1] ""
+#~ "Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
+#~ "işlətmənizə mane ola bilər.  Məsləhət edirik ki %d böyüklüyündən daha "
+#~ "kiçik böyüklük seçəsiniz."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
+#~ "işlətmənizə mane ola bilər.  Məsləhət edirik ki daha kiçik .böyüklük "
+#~ "seçəsiniz."
+#~ msgstr[1] ""
+#~ "Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
+#~ "işlətmənizə mane ola bilər.  Məsləhət edirik ki daha kiçik .böyüklük "
+#~ "seçəsiniz."
+
+#~ msgid "New accelerator..."
+#~ msgstr "Yeni sürətləndirici..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Sürə'tləndirici düymə"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Sürə'tləndirici dəyişdiriciləri"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Sür'ətləndirici düymə kodu"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Sürə'tləndirici növü."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Namə'lum Gedişat>"
+
+#~ msgid "Window Management"
+#~ msgstr "Pəncərə İdarəsi"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "\"%s\" qısa yolu hazırda bu gedişat üçün istifadə edilir:\n"
+#~ " \"%s\"\n"
+
+#, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Qurğu mə'lumat bazasında yeni sür'ətləndirici tə'yin etmə xətası: %s\n"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "Qurğu mə'lumat bazasından sür'ətləndirici silmə xətası: %s\n"
+
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "Qısa yolu dəyişdirmək üçün uyğun sətirə tıqlayıb yeni sürətləndiricini "
+#~ "yazın, ya da silmək üçün backspace düyməsinə basın."
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Əmrlərə qısa yol düymələri tə'yin edin"
+
+#~ msgid "Unknown"
+#~ msgstr "Naməlum"
+
+#, c-format
+#~ msgid "There was an error launching the keyboard capplet : %s"
+#~ msgstr "Klaviatura kappleti başlarkən xəta yarandı : %s"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "Yalnızca qurğuları tətbiq et və çıx"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Səhifəyə başlarkən yazma fasiləsi qurğularını göstər"
+
+#~ msgid "..."
+#~ msgstr "..."
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>Fasilə verməyə məcbur etmək üçün ekranı _qıfılla</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Sür'ətli</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Uzun</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Qısa</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Yavaş</i></small>"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "_Mövcud düzülüşlər:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Fasilələrin _gecikdirilməsinə icazə ver"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Fasilələrin tə'xirə salma icazələrinin olduğunu yoxlayın"
+
+#, fuzzy
+#~ msgid "Choose A Keyboard Model"
+#~ msgstr "Klaviatura modelini seç"
+
+#, fuzzy
+#~ msgid "Choose A Layout"
+#~ msgstr "_Bağla və İclası Sonlandır"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Yazma qadağan ikən fasilənin sürəkliyi"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Fasiləyə məcbur etmədən əvvəlki iş sürəkliyi"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Klaviatura Qurğuları"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Klaviatura _modeli:"
+
+#~ msgid "Layout Options"
+#~ msgstr "Düzülüş Seçimləri"
+
+#~ msgid "Layouts"
+#~ msgstr "Düzülüşlər"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Sürəkli klaviatura istifadəsindən meydana gələn zədələnmələrdən qorunmaq "
+#~ "üçün müəyyən bir vaxt sonra ekranı qıfılla"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Microsoft Natural Keyboard"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Yetişmə Qabiliyyəti..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Fasilənin sürəkliyi:"
+
+#, fuzzy
+#~ msgid "_Models:"
+#~ msgstr "_Modellər"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Seçili düzülüşlər:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_İşin sürəkliyi:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Klaviatura seçimlərinizi seçin"
+
+#~ msgid "Unknown Cursor"
+#~ msgstr "Namə'lum Kursor"
+
+#~ msgid "Default Cursor"
+#~ msgstr "Ön Qurğulu Kursor"
+
+#~ msgid "Default Cursor - Current"
+#~ msgstr "Ön Qurğulu Kursor - Hazırkı"
+
+#~ msgid "The default cursor that ships with X"
+#~ msgstr "X ilə birlikdə gələn ön qurğulu kursor"
+
+#~ msgid "White Cursor"
+#~ msgstr "Ağ Kursor"
+
+#~ msgid "White Cursor - Current"
+#~ msgstr "Ağ Kursor - Hazırkı"
+
+#~ msgid "The default cursor inverted"
+#~ msgstr "Ön qurğulu kursorun çevrilmiş vəziyyəti"
+
+#~ msgid "Large Cursor"
+#~ msgstr "Geniş Kursor"
+
+#~ msgid "Large Cursor - Current"
+#~ msgstr "Geniş Kursor - Hazırkı"
+
+#~ msgid "Large version of normal cursor"
+#~ msgstr "Ön qurğulu kursorun geniş forması"
+
+#~ msgid "Large White Cursor - Current"
+#~ msgstr "Geniş Ağ Kursor - Hazırkı"
+
+#~ msgid "Large White Cursor"
+#~ msgstr "Geniş Ağ Kursor"
+
+#~ msgid "Large version of white cursor"
+#~ msgstr "Ağ kursorun geniş forması"
+
+#~ msgid "Cursor Theme"
+#~ msgstr "Kursor Örtüyü"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Daşı və Burax</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Sür'ət</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Sür'ətli</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Yüksək</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Böyük</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Alçaq</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Yavaş</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Kiçik</i>"
+
+#~ msgid "Cursors"
+#~ msgstr "Kursorlar"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Ctrl düyməsinə basıldığında _oxun yerini göstər"
+
+#~ msgid "Motion"
+#~ msgstr "Hərəkət"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Siçan Seçimləri"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Solaxay üçün siçan"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Həssasiyyət:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Siçanınızın qurğularını seçin"
+
+#, fuzzy
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Şəbəkə vəkil qurğuları"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "<b>D_irect internet connection</b>"
+#~ msgstr "<b>_Birbaşa internet bağlantısı</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>_Avtomatik vəkil quraşdırılması</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Ə_l ilə vəkil quraşdırılması</b>"
+
+#, fuzzy
+#~ msgid "Advanced Configuration"
+#~ msgstr "Avtomatik quraşdırma _URL-si:"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP Vəkil Təfərruatları"
+
+#, fuzzy
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Şəbəkə vəkil qurğuları"
+
+#~ msgid "Port:"
+#~ msgstr "Qapı:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_E'tibarlı HTTP vəkil vericisi:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Səsi fəallaşdır və hadisələrlə səsləri əlaqələndir"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Səs Qurğuları"
+
+#~ msgid "E_nable sound server startup"
+#~ msgstr "Başlanğıcda səs vericisini _fəallaşdır"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "_Pəncərənin başlıq çubuğunu parlat"
+
+#~ msgid "_Sound an audible bell"
+#~ msgstr "_Səs çıxart"
+
+#~ msgid "_Sounds for events"
+#~ msgstr "Hadisələr üçün _səsli bildirişləri işlət"
+
+#~ msgid "_Visual feedback:"
+#~ msgstr "_Əyani bildiriş işlət:"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Sisteminizdə heş örtük tapıla bilmədi. Bu \"Örtük Qurğuları\" dialoqunun "
+#~ "düzgün quraşdırılmadığına dəlalət edir, ya da \"gnome-themes\" paketini "
+#~ "qurmamışsınız."
+
+#, fuzzy
+#~ msgid "The file format is invalid"
+#~ msgstr "%s faylı hökmlü wav faylı deyil"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Qurulacaq örtük faylı mövqeyi bildirilmədi"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Qurulacaq örtük faylının mövqeyi hökmsüzdür"
+
+#, fuzzy
+#~ msgid "The file format is invalid."
+#~ msgstr "%s faylı hökmlü wav faylı deyil"
+
+#, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s mövqeyinə örtük faylları qurulacaqdır ona görə də mənbə qovluğu olaraq "
+#~ "bu qovluq seçilə bilməz"
+
+#~ msgid "Custom theme"
+#~ msgstr "Xüsusi örtük"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "Bu örtüyü Örtüyü Qeyd Et düyməsinə basaraq qeyd edə bilərsiniz."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "Sisteminizdə ön qurğulu örtük sxemləri tapıla bilmədi. Bu metacity "
+#~ "paketinin qurulmadığına ya da gconf'un səhv qurğulandığına dəlalət edir."
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Örtük adı mövcud olmalıdır"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Örtük onsuzda mövcuddur. Onu əvəz etmək istəyirsiniz?"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Masa üstünün müxtə'lif yerləri üçün örtüklər seç"
+
+#~ msgid "Theme"
+#~ msgstr "Örtük"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Örtük Qur</span>"
+
+#~ msgid "Theme Installation"
+#~ msgstr "Örtük Qurulması"
+
+#~ msgid "_Install"
+#~ msgstr "_Qur"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Örtüyü Diskə Qeyd Et</span>"
+
+#~ msgid "Apply _Font"
+#~ msgstr "_Yazı Növünü Tətbiq Et"
+
+#~ msgid "Icons"
+#~ msgstr "Timsallar"
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr ""
+#~ "Yeni örtükləri bu pəncərənin üstünə daşıyıb buraxaraq da qura bilərsiniz."
+
+#~ msgid "Save Theme"
+#~ msgstr "Örtüyü Qeyd Et"
+
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Masa üstü örtüyünü seçin"
+
+#~ msgid "Short _description:"
+#~ msgstr "_Qısa izahat:"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "Örtük Seçimləri"
+
+#~ msgid "Theme _Details"
+#~ msgstr "Örtük _Təfərruatları"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr ""
+#~ "Bu örtüyün məsləhər etdiyi xüsusi bir yazı növü ya da arxa plan yoxdur."
+
+#~ msgid "This theme suggests a background:"
+#~ msgstr "Bu örtük arxa plan məsləhət edir:"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Bu örtük yazı növü və arxa plan məsləhət edir:"
+
+#~ msgid "This theme suggests a font:"
+#~ msgstr "Bu örtük yazı növü məsləhət edir:"
+
+#~ msgid "Window Border"
+#~ msgstr "Pəncərə Kənarı"
+
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "Örtük Qovluğuna _Get"
+
+#~ msgid "_Revert"
+#~ msgstr "_Geri Al"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "Örtüyü _Qeyd Et..."
+
+#~ msgid "theme selection tree"
+#~ msgstr "örtük seçki budağı"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "Proqramlardakı vasitə və menyu çubuqlarının görünüşünü xüsusiləşdir"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Menyular və Vasitə Çubuqları"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Davranış və Görünüş</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Nümayiş</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "Kə_s"
+
+#~ msgid "Icons only"
+#~ msgstr "Təkcə timsallar"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Menyu və Vasitə Çubuğu Seçimləri"
+
+#~ msgid "New File"
+#~ msgstr "Yeni Fayl"
+
+#~ msgid "Save File"
+#~ msgstr "Faylı Qeyd Et"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Menyularda _timsalları göstər"
+
+#~ msgid "Text below icons"
+#~ msgstr "Mətn timsalların altında"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Mətn timsalların yanında"
+
+#~ msgid "Text only"
+#~ msgstr "Təkcə mətn"
+
+#, fuzzy
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Vasitə çubuğu _düymələrinin görünüşü: "
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "_Vasitə çubuqları ayırıla bilsin"
+
+#~ msgid "_File"
+#~ msgstr "_Fayl"
+
+#~ msgid "_New"
+#~ msgstr "_Yeni"
+
+#~ msgid "_Paste"
+#~ msgstr "_Yapışdır"
+
+#, c-format
+#~ msgid ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "<b>Pəncərə idarəçiniz üçün qurğu tə'minatı başladıla bilmir</b>\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "Control"
+#~ msgstr "Control"
+
+#~ msgid "Alt"
+#~ msgstr "Alt"
+
+#~ msgid "Hyper"
+#~ msgstr "Hyper"
+
+#~ msgid "Super (or \"Windows logo\")"
+#~ msgstr "Windows"
+
+#~ msgid "Meta"
+#~ msgstr "Meta"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Hərəkət Düyməsi</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Etiket Çubuğu Gedişatı</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Pəncərə Seçkisi</b>:"
+
+#~ msgid "To _move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Pəncərəni _daşımaq üçün bu düyməni basılı tutaraq pəncərəni hərəkət "
+#~ "etdirin:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Pəncərə Seçimləri"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Başlıq çubuğuna cüt tıqlandığında bu gedişatı yerinə gətir:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Qabağa gətirmədən əvvəlki vaxt:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Seçili pəncərələri müəyyən bir vaxt sonra qabağa gətir"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Siçanın oxu pəncərələrin üstünə gələndə onları seç"
+
+#, fuzzy
+#~ msgid "Set your window properties"
+#~ msgstr "Pəncərə Xassələri"
+
+#, fuzzy
+#~ msgid "Desktop Preferences"
+#~ msgstr "Masa Üstü Arxa Planı Seçimləri"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME İdarə Mərkəzi"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME quraşdırma avadanlığı"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "Bonobo başladıla bilmir"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Az öncə Shift düyməsinə basıb 8 saniyə saxladınız.  Bu Yavaş Düymələr "
+#~ "xassəsini fəallaşdırar, bu da klaviaturanızın işləmə tərzini dəyişdirər."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Yavaş Düymələri fəallaşdırmaq istəyirsiniz?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Yavaş Düymələri qeyri-fəallaşdırmaq istəyirsiniz?"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Az öncə Shift düyməsinə arxa arxaya 5 dəfə basdınız.  Bu Yapışqan "
+#~ "Düymələr xassəsini fəallaşdırar, bu da klaviaturanızın işləmə tərzini "
+#~ "dəyişdirər."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "Az öncə iki düyməyə bərabər ya da Shift düyməsinə arxa arxaya 5 dəfə "
+#~ "basdınız.  Bu Yapışqan Düymələr xassəsini fəallaşdırar, bu da "
+#~ "klaviaturanızın işləmə tərzini dəyişdirər."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Yapışqan Düymələri fəallaşdırmaq istəyirsiniz?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Yapışqan Düymələri qeyri-fəallaşdırmaq istəyirsiniz?"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "\"%s\" qovluğu yaradıla bilmir.\n"
+#~ "Bu kursorların dəyişdirilə bilməsi üçün məcburidir."
+
+#, c-format
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "(%s) düymə bağının gedişatı birdən çox dəfə tə'yin edilib\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "(%s) düymə bağının bağı birdən çox dəfə tə'yin edilib\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "(%s) düymə bağı tamamlanmayıb\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "(%s) düymə bağı hökmsüzdür\n"
+
+#, c-format
+#~ msgid "It seems that another application already has access to key '%d'."
+#~ msgstr "Görünən odur ki, '%d' düyməsinə başqa bir tə'minat bağ qurub."
+
+#, c-format
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "(%s) düymə bağı hazırda istifadədədir\n"
+
+#, c-format
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "(%2$s) düyməsinə bağlı olan\n"
+#~ "(%1$s) icra edilməyə çalışırkən xəta yarandı"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "XKB qurğularını fəallaşdırma xətası.\n"
+#~ "Deyəsən daxili X vericisi problemidir.\n"
+#~ "\n"
+#~ "X vericisi mə'lumatı:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "Əgər bu vəziyyəti xəta olaraq raport etmək istəsəniz:\n"
+#~ "- <b>xprop -root | grep XKB</b> əmrinin nəticəsini və\n"
+#~ "- <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/xkb</b>\n"
+#~ "   əmrinin nəticəsini də yollayın."
+
+#, fuzzy
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "Siz XFree 4.3.0 buraxılışını işlədirsiniz.\n"
+#~ "Qarışıq XKB qurğuları ilə əlaqəli bə'zi problemlər vardır.\n"
+#~ "XFree tə'minatının daha yeni buraxılışını endirməyə çalışın."
+
+#, fuzzy
+#~ msgid "Do _not show this warning again"
+#~ msgstr "_Bu ismarışı bir də göstərmə"
+
+#~ msgid ""
+#~ "The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.  Which set would you like to use?"
+#~ msgstr ""
+#~ "X sisteminin klaviatura quruluşu hazırkı GNOME klaviatura quruluşundan "
+#~ "fərqlidir. Hansı dəstəni işlətmək istəyirsiniz?"
+
+#~ msgid "Use X settings"
+#~ msgstr "X qurğularını işlət"
+
+#~ msgid "Use GNOME settings"
+#~ msgstr "GNOME Qurğularını İşlət"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Əmr icra edilə bilmədi: %s\n"
+#~ "Bu əmrin mövcud olduğunu yoxlayın."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Sistem yuxu vəziyyətinə keçirilə bilmədi.\n"
+#~ "Sistemin düzgün quraşdırıldığını yoxlayın."
+
+#, c-format
+#~ msgid "Permissions on the file %s are broken\n"
+#~ msgstr "%s faylının səlahiyyətləri hökmsüzdür\n"
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "Glade faylı yüklənə biləmdi.\n"
+#~ "Bu demonun düzgün qurulduğunu yoxlayın."
+
+#, c-format
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Ekran qoruyucu başladılırkən bir xəta yarandı:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Bu iclas üçün ekran qoruyucu xassəsi fəal olmayacaq."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Bu ismarışı bir də göstərmə"
+
+#, c-format
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "%2$s şablonu olaraq %1$s səs faylı yüklənə bilmədi"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "İstifadəçinin ev cərgəsi müəyyən edilə bilmir"
+
+#, c-format
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr "%s GConf açarı %s seçilib ancaq %s cüründə olması gözlənilirdi\n"
+
+#, fuzzy
+#~ msgid "A_vailable files:"
+#~ msgstr "_Mövcud düzülüşlər:"
+
+#, fuzzy
+#~ msgid "Do _not show this warning again."
+#~ msgstr "_Bu ismarışı bir də göstərmə"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "Signal borusu yaradıla bilmədi."
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "bg_applier növü: Kök pəncərəsi üçün BG_APPLIER_ROOT və ya nümayiş üçün "
+#~ "BG_APPLIER_PREVIEW"
+
+#~ msgid "Preview Width"
+#~ msgstr "Nümayiş Eni"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Tətbiq edici bir nümayiş isə eni: Ön qurğulusu 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Nümayiş Hündürlüyü"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Tətbiq edici bir nümayiş isə hündürlüyü: Ön qurğulusu 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "BGApplier'in göstəriləcəyi ekran"
+
+#, fuzzy, c-format
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Yardımın göstərilməsi sırasında xəta oldu: %s"
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Bu səbəb üçün ayrılmış səs faylı yoxdur."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package\n"
+#~ "for a set of default sounds."
+#~ msgstr ""
+#~ "Bu səbəb üçün seçilmiş səs faylı yoxdur.\n"
+#~ "Bəlkə də ön qurğulu səslər üçün gnome-audio paketini\n"
+#~ " qurmamısınız."
+
+#, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "%s faylı hökmlü wav faylı deyil"
+
+#~ msgid "Event"
+#~ msgstr "Hadisə"
+
+#~ msgid "Sound File"
+#~ msgstr "Səs Faylı"
+
+#~ msgid "_Play"
+#~ msgstr "Ç_al"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "\"%s\" pəncərə idarəçisi quraşdırma vasitəsini tanımadı\n"
+
+#~ msgid "Maximize"
+#~ msgstr "Böyüt"
+
+#~ msgid "Roll up"
+#~ msgstr "Yuxarı Bur"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "Seşilidirsə, text/plain və text/* üçün tutucular sync içində saxlanacaq"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Sync text/plain və text/* tutucuları"
+
+#~ msgid "Brightness down"
+#~ msgstr "Parlaqlığı azalt"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Parlaqlığı azaltma qısa yolu."
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Parlaqlığı artırma qısa yolu."
+
+#~ msgid "E-mail"
+#~ msgstr "E-poçt"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "E-poçt qısa yolu."
+
+#~ msgid "Eject's shortcut."
+#~ msgstr "Çıxartma əməliyyatı üçün qısa yol."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Ev qovluğunun qısa yolu."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Yardım səyyahını başlatma qısa yolu."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Veb səyyahını başlatma qısa yolu."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "İclası sonlandırma qısa yolu."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Növbəti mahnı üçün qısa yol."
+
+#~ msgid "Pause"
+#~ msgstr "Fasilə ver"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Fasilə vermək üçün qısa yol."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Çal (ya da çal/fasilə ver) düyməsinin qısa yolu."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Əvvəlki mahnı üçün qısa yol."
+
+#~ msgid "Sleep"
+#~ msgstr "Yuxu vəziyyətinə sal"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Yuxu vəziyyətinə salma qısa yolu"
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Çalğını dayandırma düyməsinin qısa yolu."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Səsi azaltma qısa yolu"
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Səsi bağlama qısa yolu"
+
+#~ msgid "Volume step"
+#~ msgstr "Səs addımı"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Səs həcmi faizi olaraq səs addımı."
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Səsi artırma qısa yolu."
+
+#, fuzzy
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "XScreenSaver işlərkən yaranan xətaları dialoq qutusunda göstər"
+
+#, fuzzy
+#~ msgid "Run screensaver at login"
+#~ msgstr "Girişdə XScreenSaver-i işə sal"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Başlanğıc Xətalarını Göstər"
+
+#, fuzzy
+#~ msgid "Start screensaver"
+#~ msgstr "XScreenSaver-i Başlat"
+
+#, fuzzy
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Klaviatura _modeli:"
+
+#, fuzzy
+#~ msgid "Keyboard model"
+#~ msgstr "Klaviatura _modeli:"
+
+#, fuzzy
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr "Gconf-dakı XKB qurğuları tezliklə sisteminkilərlə əvəz ediləcəkdir"
+
+#, fuzzy
+#~ msgid "keyboard layout"
+#~ msgstr "XKB klaviatura düzülüşü"
+
+#, fuzzy
+#~ msgid "keyboard model"
+#~ msgstr "XKB klaviatura modeli"
+
+#~ msgid "_Postpone break"
+#~ msgstr "Fasiləni _tə'xirə sal"
+
+#~ msgid "Take a break!"
+#~ msgstr "Fasilə ver!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Fasilə Ver"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "Növbəti fasiləyə %d dəqiqə qalıb"
+#~ msgstr[1] "Növbəti fasiləyə %d dəqiqə qalıb"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Növbəti fasiləyə bir dəqiqədən az qalıb"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr "Yazma fasiləsi xassələri dialoqu göstərilə bilmədi. Xəta: %s"
+
+#~ msgid "About GNOME Typing Monitor"
+#~ msgstr "GNOME Yazma İzləyicisi Haqqında"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Kopüter fasiləsini yada salan tə'minat."
+
+#~ msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgstr "Richard Hult &lt;richard@imendio.com&gt; tərəfindən yazılıb"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Qrafika Anders Carlsson tərəfindən əlavə edilib"
+
+#~ msgid "Break reminder"
+#~ msgstr "Fasilə yada salıcı"
+
+#~ msgid "The typing monitor is already running."
+#~ msgstr "Yazma izləyicisi onsuzda fəaliyyətdədir."
+
+#, fuzzy
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Yazma izləyicisi mə'lumatı göstərmək üçün bildiriş sahəsini istifadə "
+#~ "edir. Panelinizdə bildiriş sahəsi appleti mövcud deyil. Onu əlavə etmək "
+#~ "üçün panelinizə sağ tıqlayıb 'Panelə Əlavə Et -> Tə'minatlar -> Bildiriş "
+#~ "sahəsi' menyusunu seçin."
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Sən! Bu gün Azərbaycan üçün nə etdin? 0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Böyüklük:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Müəllif hüququ:"
+
+#~ msgid "Description:"
+#~ msgstr "İzahat:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "istifadə qaydası: %s yazı növü faylı\n"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Proqram Yazı Növü Olaraq Tə'yin Et"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "Seçilirsə, OpenType yazı növlərinin ön nümayişləri göstəriləcək."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Seçilirsə, PCF yazı növlərinin ön nümayişləri göstəriləcək."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "Seçilirsə, TrueType yazı növlərinin ön nümayişləri göstəriləcək."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Seçilirsə, Type1 yazı növlərinin ön nümayişləri göstəriləcək."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Bu düyməni OpenType yazı növlərinin ön nümayişlərini yaratmaq üçün "
+#~ "işlədilən əmrə bağlayın."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Bu düyməni PCF yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən "
+#~ "əmrə bağlayın."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Bu düyməni TrueType yazı növlərinin ön nümayişlərini yaratmaq üçün "
+#~ "işlədilən əmrə bağlayın."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Bu düyməni Type1 yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən "
+#~ "əmrə bağlayın."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "OpenType yazı növlərinin ön nümayiş əmri"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "PCF yazı növlərinin ön nümayiş əmri"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "TrueType yazı növlərinin ön nümayiş əmri"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Type1 yazı növlərinin ön nümayiş əmri"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "OpenType yazı növlərinin ön nümayişlərinin göstərilməsi"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCF yazı növlərinin ön nümayişlərinin göstərilməsi"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "TrueType yazı növlərinin ön nümayişlərinin göstərilməsi"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Type1 yazı növlərinin ön nümayişlərinin göstərilməsi"
+
+#, fuzzy
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "GNOME İdarə Mərkəzi"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">Yeni yazı növü tətbiq edilsin?</"
+#~ "span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Yazı növünü tətbiq et_mə"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Seçdiyiniz örtük yeni yazı növü təklif edir. Yazı növünün nümayişi "
+#~ "aşağıdadır."
+
+#~ msgid "Themes"
+#~ msgstr "Örtüklər"
+
+#~ msgid "Description"
+#~ msgstr "İzahat"
+
+#~ msgid "Control theme"
+#~ msgstr "Sınama örtüyü"
+
+#~ msgid "Window border theme"
+#~ msgstr "Pəncərə kənarı örtüyü"
+
+#~ msgid "Icon theme"
+#~ msgstr "Timsal örtüyü"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#, fuzzy
+#~ msgid "Apply theme"
+#~ msgstr "Yazı növünü _tətbiq et"
+
+#, fuzzy
+#~ msgid "Sets the default theme"
+#~ msgstr "Ön _qurğulara sıfırla"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "True isə, quraşdırılmış örtüklərin nümaişləri göstəriləcək."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "True isə, örtüklərin nümaişləri göstəriləcək."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Bu düyməni quraşdırılmış örtüklərin nümaişləri göstərmək üçün işlədilən "
+#~ "əmrə bağlayın."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "Bu düyməni örtüklərin nümaişləri göstərmək üçün işlədilən əmrə bağlayın."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Quraşdırılmış örtüklərin nümaişləri göstərmək üçün işlədilən əmr"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Örtüklərin nümaişləri göstərmək üçün işlədilən əmr"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Quraşdırılmış örtüklərin nümaişlərinin göstərilməsi"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Örtüklərin nümaişlərinin göstərilməsi"

--- a/po/az.po~
+++ b/po/az.po~
@@ -1,0 +1,3494 @@
+# translation of gnome-control-center.HEAD.az.po to Azerbaijani
+# translation of gnome-control-center.HEAD.po to Azerbaijani
+# translation of gnome-control-center.HEAD.az.po to Azerbaijani Turkish
+# Copyright (C) 1998,1999,2003, 2004 Free Software Foundation, Inc.
+# Mətin Əmirov <metin@karegen.com>, 2003, 2004.
+# Metin Amiroff <metin@karegen.com>, 2004.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.HEAD\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"PO-Revision-Date: 2004-09-04 19:45+0300\n"
+"Last-Translator: Mətin Əmirov <metin@karegen.com>\n"
+"Language-Team: Azerbaijani <translation-team-az@lists.sourceforge.net>\n"
+"Language: az\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"net>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: KBabel 1.3.1\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+#, fuzzy
+msgid "Alert Type"
+msgstr "Fayl Növünü Əlavə Et"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+#, fuzzy
+msgid "The type of alert"
+msgstr "Sürə'tləndirici növü."
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+#, fuzzy
+msgid "Alert Buttons"
+msgstr "Düymələr"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+#, fuzzy
+msgid "Show more _details"
+msgstr "Örtük _Təfərruatları"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+#, fuzzy
+msgid "About Me"
+msgstr "_Haqqında"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your personal information"
+msgstr "MIME növü mə'lumatı"
+
+#: ../capplets/about-me/gnome-about-me.c:554
+#, fuzzy
+msgid "Select Image"
+msgstr "_Seç"
+
+#: ../capplets/about-me/gnome-about-me.c:556
+#, fuzzy
+msgid "No Image"
+msgstr "Rəsmlər"
+
+#: ../capplets/about-me/gnome-about-me.c:706
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:727
+msgid "Unable to open address book"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:739
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:770
+#: ../capplets/about-me/gnome-about-me.c:772
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "_Haqqında"
+
+#: ../capplets/about-me/gnome-about-me-password.c:101
+#: ../capplets/about-me/gnome-about-me-password.c:479
+msgid "Old password is incorrect, please retype it"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:112
+msgid "System error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:113
+msgid "Could not run /usr/bin/passwd"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:114
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:117
+msgid "Unexpected error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:315
+msgid "Password is too short"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:318
+#: ../capplets/about-me/gnome-about-me-password.c:321
+msgid "Password is too simple"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:324
+msgid "Old and new passwords are too similar"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:328
+msgid "Old and new password are the same"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:406
+#, fuzzy
+msgid "Please type the passwords."
+msgstr "_Şifrə:"
+
+#: ../capplets/about-me/gnome-about-me-password.c:414
+msgid "Please type the password again, it is wrong."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:417
+msgid "Click on Change Password to change the password."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/font/font-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+msgid "    "
+msgstr "    "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+#, fuzzy
+msgid "<b>Email</b>"
+msgstr "<i>Kiçik</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+#, fuzzy
+msgid "<b>Home</b>"
+msgstr "<b>Sür'ət</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+#, fuzzy
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Yazı Növü Görünüşü</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+#, fuzzy
+msgid "<b>Job</b>"
+msgstr "<b>Dəstək</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+#, fuzzy
+msgid "<b>Telephone</b>"
+msgstr "<b>Açma Düymələri</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+#, fuzzy
+msgid "<b>Web</b>"
+msgstr "<b>Sür'ət</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+#, fuzzy
+msgid "<b>Work</b>"
+msgstr "<b>Dəstək</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+#, fuzzy
+msgid "A_ddress:"
+msgstr "Ə_lavə Et:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+#, fuzzy
+msgid "Address"
+msgstr "_basılanda"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+#, fuzzy
+msgid "C_ity:"
+msgstr "_Tərz:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+#, fuzzy
+msgid "C_ompany:"
+msgstr "Ə_mr:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+#, fuzzy
+msgid "Cale_ndar:"
+msgstr "Kate_qoriya:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+#, fuzzy
+msgid "Change Passwo_rd..."
+msgstr "Dəstəni Dəyişdir"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+#, fuzzy
+msgid "Change Password"
+msgstr "Dəstəni Dəyişdir"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+#, fuzzy
+msgid "Ci_ty:"
+msgstr "_Tərz:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+#, fuzzy
+msgid "Co_untry:"
+msgstr "Control"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+#, fuzzy
+msgid "Contact"
+msgstr "_Məzmun"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+#, fuzzy
+msgid "Cou_ntry:"
+msgstr "Control"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+#, fuzzy
+msgid "Hom_e:"
+msgstr "_Ad:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+#, fuzzy
+msgid "Old pa_ssword:"
+msgstr "_Şifrə:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P.O. _box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P._O. box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+#, fuzzy
+msgid "Personal Info"
+msgstr "_Terminal yazı növü:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "State/Pro_vince:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#, fuzzy
+msgid "User name:"
+msgstr "_İstifadəçi Adı:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Web _log:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "Wor_k:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid "Work _fax:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Zip/_Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+#, fuzzy
+msgid "_Address:"
+msgstr "Ə_lavə Et:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+#, fuzzy
+msgid "_Home page:"
+msgstr "Örtük _adı:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+#, fuzzy
+msgid "_Home:"
+msgstr "_Ad:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+#, fuzzy
+msgid "_Manager:"
+msgstr "_Böyüdücü"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+#, fuzzy
+msgid "_Mobile:"
+msgstr "_Fayl"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+#, fuzzy
+msgid "_New password:"
+msgstr "_Şifrə:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+#, fuzzy
+msgid "_Profession:"
+msgstr "Buraxılış:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+#, fuzzy
+msgid "_Retype new password:"
+msgstr "_Şifrə:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+#, fuzzy
+msgid "_Title:"
+msgstr "_Tərz:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Work:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Zip/Postal code:"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Applications</b>"
+msgstr "<b>Proqramlar</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Support</b>"
+msgstr "<b>Dəstək</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+"<small><i><b>Qeyd:</b> Bu qurğudakı dəyişikliklər bir sonrakı girişinizə "
+"qədər fəal olmayacaqdır.</i></small>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technology Preferences"
+msgstr "Yardımçı Texnologiya Seçimləri"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr "_Bağla və İclası Sonlandır"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr "Bu yardımçı texnologiyaları hər girişdə başlat:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr "_Yardımçı texnologiyaları fəallaşdır"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr "_Böyüdücü"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr "_Ekran üstü klaviatura"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Screenreader"
+msgstr "_Ekran oxuyucusu"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr "Yardımçı Texnologiya Dəstəyi"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr "Girişdə GNOME yardımçı texnologiya dəstəyini fəallaşdır"
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Sisteminizdə heç bir yardımçı texnologiya mövcud deyil. Ekran üstü "
+"klaviatura dəstəyi almaq üçün 'gok' paketi, ekran oxuma və yaxınlaşdırma "
+"bacarıqları üçün isə 'gnopernicus' paketi qurulu olmalıdır."
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+"Sisteminizdə bütün yardımçı texnologiyalar mövcud deyil. Ekran üstü "
+"klaviatura dəstəyi almaq üçün 'gok' paketi qurulu olmalıdır."
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Sisteminizdə bütün yardımçı texnologiyalar mövcud deyil.  Ekran oxuma və "
+"yaxınlaşdırma bacarıqları üçün 'gnopernicus' paketi qurulu olmalıdır."
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr "Siçan qurğuları pəncərəsi başlarkən xəta yarandı: %s"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr "'%s' faylından AccessX qurğuları idxal edilə bilmədi"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
+msgid "Import Feature Settings File"
+msgstr "Xassə Qurğuları Faylını İdxal Et"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
+msgid "_Import"
+msgstr "_İdxal Et"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Klaviatura"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr "Klaviatura yetişmə qabiliyyəti qurğularınızı seçin"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+"Bu sistem üstündə XKB uzantısı qurulu deyil. Klaviatura yetişmə qabiliyyəti "
+"xassəsi onsuz işləməyəcək."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+#: ../capplets/theme-switcher/theme-install.glade.h:1
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "<b>_Eyni Düymələri Fəallaşdır</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "<b>Y_avaş Düymələri Fəallaşdır</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "<b>_Siçan Düymələrini Fəallaşdır</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "<b>_Düymələrin Təkrarlanmasını Fəallaşdır</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "<b>_Yapışqan Düymələri Fəallaşdır</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+msgid "<b>Features</b>"
+msgstr "<b>Xüsusiyyətlər</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr "<b>Açma Düymələri</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "Əsas"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr "Düymə rədd ediləndə _səs çıxart"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr "_Xassələr klaviaturadan açılıb bağlananda səs çıxart"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr "_Dəyişdirici basılanda səs çıxart"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr ""
+"Açma düyməsi fəal seçiləndə bir dəfə, qeyri-fəal seçiləndə isə iki dəfə səs "
+"çıxart."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr "Səs çıxartma vəziyyəti:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr "_Gecikmə:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr "Düymənin basılması ilə oxun hərəkəti arasındakı _gecikmə"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr "İki düymə eyni anda basılanda qeyri-fəallaşdır"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr "Açma _Düymələrini Fəallaşdır"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Filtrlər"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr "Bu vaxt içindəki cüt düymə basışlarını _ləğv et:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+"İstifadəçinin seçdiyi vaxt aralığı içində EYNİ düymənin ardıcıl basışlarını "
+"rədd et."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr "Klaviatura Yetişmə Qabiliyyəti Qurğuları (AccessX)"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr "Ma_ksimal ox sür'əti:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr "Siçan Düymələri"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr "Siçan _Qurğuları..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+"Yalnız istifadəçinin istədiyi bir müddət boyunca basılı tutulan düymələri "
+"qəbul et."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+"Dəyişdirici düymələri ardıcıl basaraq birdən çox ardıcıl düymə basma "
+"əməliyyatını həyata keçirin."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "S_peed:"
+msgstr "_Sür'ət:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr "Maksimal sür'ətə çıxma _vaxtı:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr "Ədəd düymələri sahəsini siçan idarə vasitəsinə döndərin."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr "_Bu vaxt içinə işlədilməzsə qeyri-fəallaşdır:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr "Klaviatura yetişmə qabiliyyətini _fəallaşdır"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr "_Qurğu Faylını İdxal Et..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr "_Yalnız bu vaxt müddətincə basılı tutulan düymələri qəbul et:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Type to test settings:"
+msgstr "Qurğuları sınama _taxtası:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr "_qəbul ediləndə"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr "_basılanda"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr "_rədd ediləndə"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr "hərf/saniyə"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+msgid "milliseconds"
+msgstr "millisaniyə"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr "piksel/saniyə"
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:885
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "saniyə"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+msgid "Change your Desktop Background settings"
+msgstr "Masa Üstü Arxa Plan Qurğunuzu Dəyişdirin"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+msgid "Desktop Background"
+msgstr "Masa Üstü Arxa Planı"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "<b>Masa Üstü _Divar Kağızı</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+msgid "<b>_Desktop Colors</b>"
+msgstr "<b>_Masa Üstü Rəngləri</b> "
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+msgid "Desktop Background Preferences"
+msgstr "Masa Üstü Arxa Planı Seçimləri"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr "Divar Kağızı Ə_lavə Et"
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+msgid "_Style:"
+msgstr "_Tərz:"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Yardımın göstərilməsi sırasında xəta oldu: %s"
+
+#: ../capplets/background/gnome-wp-capplet.c:1042
+#: ../capplets/background/gnome-wp-capplet.c:1060
+msgid "Centered"
+msgstr "Ortalanmış"
+
+#: ../capplets/background/gnome-wp-capplet.c:1068
+#: ../capplets/background/gnome-wp-capplet.c:1085
+msgid "Fill Screen"
+msgstr "Ekranı Doldur"
+
+#: ../capplets/background/gnome-wp-capplet.c:1093
+#: ../capplets/background/gnome-wp-capplet.c:1110
+msgid "Scaled"
+msgstr "Miqyaslandırılmış"
+
+#: ../capplets/background/gnome-wp-capplet.c:1118
+#: ../capplets/background/gnome-wp-capplet.c:1135
+msgid "Tiled"
+msgstr "Döşənmiş"
+
+#: ../capplets/background/gnome-wp-capplet.c:1159
+#: ../capplets/background/gnome-wp-capplet.c:1168
+msgid "Solid Color"
+msgstr "Tək Rəng"
+
+#: ../capplets/background/gnome-wp-capplet.c:1176
+#: ../capplets/background/gnome-wp-capplet.c:1185
+msgid "Horizontal Gradient"
+msgstr "Üfüqi Qradient"
+
+#: ../capplets/background/gnome-wp-capplet.c:1193
+#: ../capplets/background/gnome-wp-capplet.c:1202
+msgid "Vertical Gradient"
+msgstr "Şaquli Qradient"
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1251
+msgid "Add Wallpaper"
+msgstr "Divar Kağızı Əlavə Et"
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr "Divar Kağızı İşlətmə"
+
+#: ../capplets/background/gnome-wp-item.c:292
+#: ../capplets/background/gnome-wp-item.c:294
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/common/activate-settings-daemon.c:18
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"Qurğu idarəçisi 'gnome-settings-daemon' başladıla bilmədi.\n"
+"Gnome qurğu idarəçisi işləməzsə, bə'zi seçimlər fəal olmaya bilər. Buna, "
+"Bonobodakı bir problem, ya da Gnome qurğu idarəçisi ilə toqquşan diqər "
+"tə'minatlar səbəb ola bilər."
+
+#: ../capplets/common/capplet-stock-icons.c:94
+#, c-format
+msgid "Unable to load capplet stock icon '%s'\n"
+msgstr "Kapplet timsalı '%s' yüklənə bilmədi\n"
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr "Təkcə qurğuları əlavə et və çıx"
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/default-applications/gnome-default-applications-properties.c:765
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1021
+#: ../capplets/sound/sound-properties-capplet.c:244
+msgid "Retrieve and store legacy settings"
+msgstr "Miras qurğularını al və saxla"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %i of %i"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr "URI-dən"
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr "Hazırda transferin hansı URI'dən edildiyi"
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr "URI-yə"
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr "Hazırda transferin hansı URI'yə edildiyi"
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr "Hissə bitdi"
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr "Transferin hissəsi hazırda bitdi"
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr "Hazırkı URI indexi"
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr "Hasırkı URI indeksi - 1'dən başlayır"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr "Toplam URI"
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr "Toplam URI miqdarı"
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:345
+#, fuzzy
+msgid "From:"
+msgstr "%s-dən"
+
+#: ../capplets/common/file-transfer-dialog.c:349
+#, fuzzy
+msgid "To:"
+msgstr "%s-yə"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr "Bağlanılır..."
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Açar"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr "Bu üstünlük editorunun ilişdirildiyi GConf açarı"
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr "Geri axtarma"
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Açar ilə əlaqələndirilmiş qiymət dəyişəndə bu geri çağırışı yay"
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr "Dəstəni Dəyişdir"
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"Tətbiq ediləndə gconf alıcısına istiqamətləndiriləcək mə'lumatı daxil edən "
+"GConf Dəyişmə dəsti"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr "Widget geri çağırışına çeviriş"
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "Mə'lumat GConf'dan widget'ə dönüşdürüləndə yaradılacaq geri çağırış"
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr "Widget geri çağırışından çeviriş"
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr "Mə'lumat widget'dən GConf'a dönüşdürüləcəksə yaradılacaq geri çağırış"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr "UI İdarəsi"
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr "Üstünlüyü idarə edən cism (normal halda pəncərəcik)"
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr "Xassə editoru obyekt verilənləri"
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr "Spesifik xassə editoru tərəfindən xüsusi mə'lumat məcburi qılınıb"
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr "Geri çağırışı boşaldan xassə editoru mə'lumatı"
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr "Xassə editoru mə'lumatı boşaldılanda yaradılacaq geri çağırış"
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"'%s' faylı tapıla bilmədi.\n"
+"\n"
+"Xahiş edirik, onun mövcud olduğundan əmin olun və yenidən sınayın, ya da "
+"başqa arxa plan rəsmi seçin."
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"'%s' faylın necə açılacağı bilinmir.\n"
+"Deyəsən, o hələ dəstəklənməyən bir rəsm növüdür.\n"
+"\n"
+"Xahiş edirik, onun yerinə başqa rəsm seçin."
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr "Xahiş edirik, bir rəsm seçin."
+
+#: ../capplets/common/gconf-property-editor.c:1598
+msgid "_Select"
+msgstr "_Seç"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr "Ön Qurğulu Proqramlar"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Ön qurğulu proqramlarınızı seçin"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+#, fuzzy
+msgid "Debian Sensible Browser"
+msgstr "Ön Qurğulu Veb Səyyahı"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
+msgid "Epiphany"
+msgstr "Epiphany"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
+msgid "Encompass"
+msgstr "Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+#, fuzzy
+msgid "Firebird"
+msgstr "Firebird/FireFox"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
+msgid "Firefox"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
+#, fuzzy
+msgid "Mozilla"
+msgstr "Mozilla Mail"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
+msgid "Netscape Communicator"
+msgstr "Netscape Communicator"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
+msgid "W3M Text Browser"
+msgstr "W3M Mətn Səyyahı"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
+msgid "Lynx Text Browser"
+msgstr "Lynx Mətn Səyyahı"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
+msgid "Links Text Browser"
+msgstr "Links Mətn Səyyahı"
+
+#. The code in gnome-default-applications-properties.c makes sure
+#. * there is only one (the first entry in this list) Evolution entry
+#. * in the list shown to the user
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
+msgid "Evolution Mail Reader"
+msgstr "Evolution Poçt Oxuyucusu"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
+msgid "Thunderbird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
+msgid "Mozilla Mail"
+msgstr "Mozilla Mail"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
+#, fuzzy
+msgid "Debian Terminal Emulator"
+msgstr "Ön Qurğulu Terminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
+#, fuzzy
+msgid "GNOME Terminal"
+msgstr "Terminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
+msgid "Standard XTerminal"
+msgstr "Standart XTerminalı"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
+#, fuzzy
+msgid "aterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.c:123
+msgid "Please specify a name and a command for this editor."
+msgstr "Xahiş edirik, bu editor üçün bir ad və əmr girin."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "Add..."
+msgstr "Əlavə Et..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+#, fuzzy
+msgid "C_ustom"
+msgstr "Hazırkı"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+#, fuzzy
+msgid "C_ustom:"
+msgstr "Hazırkı"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "Can open _URIs"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+#, fuzzy
+msgid "Can open multiple _files"
+msgstr "Bu tə'minat _birdən çox faylları aça bilmir"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "Co_mmand:"
+msgstr "Ə_mr:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "Custom Editor Properties"
+msgstr "Xüsusi Editor Xassələri"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "Default Mail Reader"
+msgstr "Ön Qurğulu Poçt Oxuyucusu"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "Default Terminal"
+msgstr "Ön Qurğulu Terminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Default Text Editor"
+msgstr "Ön Qurğulu Mətn Editoru"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "Default Web Browser"
+msgstr "Ön Qurğulu Veb Səyyahı"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Default Window Manager"
+msgstr "Ön Qurğulu Pəncərə İdarəçisi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Delete"
+msgstr "Sil"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "E_xec Flag:"
+msgstr "İşə Salma _Bayrağı:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Edit..."
+msgstr "Düzəlt..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Mail Reader"
+msgstr "Poçt Oxuyucusu"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+#, fuzzy
+msgid "Run in a _terminal"
+msgstr "_Terminalda İcra Et"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+#, fuzzy
+msgid "Run in a t_erminal"
+msgstr "_Terminalda İcra Et"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid ""
+"Select the window manager you want.  You will need to hit apply, wave the "
+"magic wand, and do a magic dance for it to work."
+msgstr ""
+"İstədiyiniz pəncərə idarəçisini seçin. Bunun işləməsi üçün tətbiq et "
+"düyməsinə basdıqdan sonra, sehirli çubuğu oynadıb sehirli sözlər deməlisiniz."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Terminal"
+msgstr "Terminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Text Editor"
+msgstr "Mətn Editoru"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Understands _Netscape Remote Control"
+msgstr "_Netscape Uzaq İdarəsini Başa Düşür"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "Use this _editor to open text files in the file manager"
+msgstr "Fayl idarəçisində mətn fayllarını açmaq üçün bu _editoru istifadə et"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "Web Browser"
+msgstr "Veb Səyyahı"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
+msgid "Window Manager"
+msgstr "Pəncərə İdarəçisi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
+#, fuzzy
+msgid "_Command:"
+msgstr "Ə_mr:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
+msgid "_Name:"
+msgstr "_Ad:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
+msgid "_Properties..."
+msgstr "_Xüsusiyyətlər..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
+#, fuzzy
+msgid "_Select:"
+msgstr "_Seç"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Ekran həlleciliyini dəyişdir"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Ekran Həllediciliyi"
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/main.c:448
+msgid "_Resolution:"
+msgstr "_Həlledicilik:"
+
+#: ../capplets/display/main.c:467
+msgid "Re_fresh rate:"
+msgstr "_Yeniləmə sıxlığı:"
+
+#: ../capplets/display/main.c:488
+msgid "Default Settings"
+msgstr "Ön Qurğular"
+
+#: ../capplets/display/main.c:490
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr "Ekran %d Qurğuları\n"
+
+#: ../capplets/display/main.c:516
+msgid "Screen Resolution Preferences"
+msgstr "Ekran Həllediciliy Seçimləri"
+
+#: ../capplets/display/main.c:553
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "Sadəcə olaraq bu _kompüter (%s) üçün ön qurğulu qəbul et"
+
+#: ../capplets/display/main.c:571
+msgid "Options"
+msgstr "Seçimlər"
+
+#: ../capplets/display/main.c:592
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"Yeni qurğular sınanır. Əgər %d saniyə ərzində cavab verməsəniz qurğular "
+"bərpa ediləcəkdir."
+msgstr[1] ""
+"Yeni qurğular sınanır. Əgər %d saniyə ərzində cavab verməsəniz qurğular "
+"bərpa ediləcəkdir."
+
+#: ../capplets/display/main.c:638
+msgid "Keep Resolution"
+msgstr "Həllediciliyi Qeyd Et"
+
+#: ../capplets/display/main.c:642
+msgid "Do you want to keep this resolution?"
+msgstr "Bu həlledilirliyi saxlamaq istəyirsiniz?"
+
+#: ../capplets/display/main.c:667
+msgid "Use _previous resolution"
+msgstr "Ə_vvəlki həlledilirliyi istifadə et"
+
+#: ../capplets/display/main.c:667
+msgid "_Keep resolution"
+msgstr "Həlledilirliyi _qeyd et"
+
+#: ../capplets/display/main.c:818
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"Xverici XRandR uzantısını dəstəkləmir. Canlı həlledicilik dəyişmələri "
+"təəssüf ki mövcud deyil."
+
+#: ../capplets/display/main.c:826
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"XRandR buraxılışı bu proqram ilə uyğun gəlmir. Canlı həlledilirlik "
+"dəyişmələri təəssüf ki mövcud deyil."
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Yazı Növü"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr "Masa üstü yazı növlərini seçin"
+
+#: ../capplets/font/font-properties.glade.h:2
+msgid "<b>Font Rendering</b>"
+msgstr "<b>Yazı Növü Görünüşü</b>"
+
+#: ../capplets/font/font-properties.glade.h:3
+msgid "<b>Hinting</b>:"
+msgstr "<b>Zərifləndirmə</b>:"
+
+#: ../capplets/font/font-properties.glade.h:4
+msgid "<b>Smoothing</b>:"
+msgstr "<b>Yumuşaltma</b>:"
+
+#: ../capplets/font/font-properties.glade.h:5
+msgid "<b>Subpixel order</b>:"
+msgstr "<b>Sabpiksel ardıcıllığı</b>:"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best _shapes"
+msgstr "Optimal şə_killər"
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "Best co_ntrast"
+msgstr "Optimal ko_ntrast"
+
+#: ../capplets/font/font-properties.glade.h:8
+msgid "D_etails..."
+msgstr "_Təfərruatlar..."
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "Yazı Növü Qurğuları"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr "Yazı Növü Görünüş Təfərruatları"
+
+#: ../capplets/font/font-properties.glade.h:11
+msgid "Go _to font folder"
+msgstr "_Yazı növü qovluğuna get"
+
+#: ../capplets/font/font-properties.glade.h:12
+msgid "Gra_yscale"
+msgstr "_Ağ-qara"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "Yo_xdur"
+
+#: ../capplets/font/font-properties.glade.h:14
+msgid "R_esolution:"
+msgstr "_Həlledilirlik:"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr "Sab_piksel (LCD-lər)"
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "Sab_piksel yumuşaldılması (LCD-lər)"
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "_Proqram yazı növü:"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Desktop font:"
+msgstr "_Masa üstü yazı növü:"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Full"
+msgstr "_Tam"
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Medium"
+msgstr "_Orta"
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Monochrome"
+msgstr "_Monoxrom"
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_None"
+msgstr "_Yoxdur"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_Slight"
+msgstr "_Zərif"
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Terminal font:"
+msgstr "_Terminal yazı növü:"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "_Pəncərə başlığının yazı növü:"
+
+#: ../capplets/font/font-properties.glade.h:30
+msgid "dots per inch"
+msgstr "inç başına nöqtə"
+
+#: ../capplets/font/main.c:488
+msgid "Font may be too large"
+msgstr "Yazı növü çox geniş ola bilər"
+
+#: ../capplets/font/main.c:492
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
+"işlətmənizə mane ola bilər.  Məsləhət edirik ki %d böyüklüyündən daha kiçik "
+"böyüklük seçəsiniz."
+msgstr[1] ""
+"Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
+"işlətmənizə mane ola bilər.  Məsləhət edirik ki %d böyüklüyündən daha kiçik "
+"böyüklük seçəsiniz."
+
+#: ../capplets/font/main.c:505
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
+"işlətmənizə mane ola bilər.  Məsləhət edirik ki daha kiçik .böyüklük "
+"seçəsiniz."
+msgstr[1] ""
+"Seçilən yazı növü %d nöqtə genişdir, ona görə də kompüteri effektivolaraq "
+"işlətmənizə mane ola bilər.  Məsləhət edirik ki daha kiçik .böyüklük "
+"seçəsiniz."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "Yeni sürətləndirici..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Sürə'tləndirici düymə"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Sürə'tləndirici dəyişdiriciləri"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Sür'ətləndirici düymə kodu"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Sürə'tləndirmə Modu"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Sürə'tləndirici növü."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:197
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+msgid "Disabled"
+msgstr "Bağlı"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:545
+msgid "<Unknown Action>"
+msgstr "<Namə'lum Gedişat>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:566
+msgid "Desktop"
+msgstr "Masa Üstü"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:567
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Səs"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:571
+msgid "Window Management"
+msgstr "Pəncərə İdarəsi"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:668
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+"\"%s\" qısa yolu hazırda bu gedişat üçün istifadə edilir:\n"
+" \"%s\"\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:700
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr "Qurğu mə'lumat bazasında yeni sür'ətləndirici tə'yin etmə xətası: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:750
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr "Qurğu mə'lumat bazasından sür'ətləndirici silmə xətası: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:857
+msgid "Action"
+msgstr "Gedişat"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:881
+msgid "Shortcut"
+msgstr "Qısa Yol"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Klaviatura Qısa Yolları"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"Qısa yolu dəyişdirmək üçün uyğun sətirə tıqlayıb yeni sürətləndiricini "
+"yazın, ya da silmək üçün backspace düyməsinə basın."
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Əmrlərə qısa yol düymələri tə'yin edin"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+msgid "Unknown"
+msgstr "Naməlum"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+msgid "Layout"
+msgstr "Düzülüş"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#, fuzzy
+msgid "Default"
+msgstr "Ön Qurğulu Kursor"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+msgid "Models"
+msgstr "Modellər"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:106
+#, c-format
+msgid "There was an error launching the keyboard capplet : %s"
+msgstr "Klaviatura kappleti başlarkən xəta yarandı : %s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr "_Yetişmə Qabiliyyəti"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:240
+#: ../capplets/sound/sound-properties-capplet.c:242
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr "Yalnızca qurğuları tətbiq et və çıx"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr "Səhifəyə başlarkən yazma fasiləsi qurğularını göstər"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "..."
+msgstr "..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Yanıb Sönən Ox</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Təkrarlanan Düymələr</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<b>Fasilə verməyə məcbur etmək üçün ekranı _qıfılla</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Sür'ətli</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Uzun</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Qısa</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Yavaş</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_vailable layouts:"
+msgstr "_Mövcud düzülüşlər:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "All_ow postponing of breaks"
+msgstr "Fasilələrin _gecikdirilməsinə icazə ver"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Fasilələrin tə'xirə salma icazələrinin olduğunu yoxlayın"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+#, fuzzy
+msgid "Choose A Keyboard Model"
+msgstr "Klaviatura modelini seç"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+#, fuzzy
+msgid "Choose A Layout"
+msgstr "_Bağla və İclası Sonlandır"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr "Mətn qutuları və sahələrində ox _yanıb sönsün"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Duration of the break when typing is disallowed"
+msgstr "Yazma qadağan ikən fasilənin sürəkliyi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of work before forcing a break"
+msgstr "Fasiləyə məcbur etmədən əvvəlki iş sürəkliyi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Key presses _repeat when key is held down"
+msgstr "Düymə basılı tutulanda hərflər təkrarlansın"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Keyboard Preferences"
+msgstr "Klaviatura Qurğuları"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Keyboard _model:"
+msgstr "Klaviatura _modeli:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Layout Options"
+msgstr "Düzülüş Seçimləri"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Layouts"
+msgstr "Düzülüşlər"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Sürəkli klaviatura istifadəsindən meydana gələn zədələnmələrdən qorunmaq "
+"üçün müəyyən bir vaxt sonra ekranı qıfılla"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Microsoft Natural Keyboard"
+msgstr "Microsoft Natural Keyboard"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+#, fuzzy
+msgid "Preview:"
+msgstr "Ön _Nümayiş"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+#, fuzzy
+msgid "Reset To De_faults"
+msgstr "Ön _qurğulara sıfırla"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Separate _group for each window"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Typing Break"
+msgstr "Yazma Fasiləsi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "_Accessibility..."
+msgstr "_Yetişmə Qabiliyyəti..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#, fuzzy
+msgid "_Add..."
+msgstr "Əlavə Et..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Break interval lasts:"
+msgstr "_Fasilənin sürəkliyi:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Delay:"
+msgstr "_Gecikmə:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#, fuzzy
+msgid "_Models:"
+msgstr "_Modellər"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Selected layouts:"
+msgstr "_Seçili düzülüşlər:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Speed:"
+msgstr "_Sür'ət:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Work interval lasts:"
+msgstr "_İşin sürəkliyi:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "minutes"
+msgstr "dəqiqə"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Klaviatura seçimlərinizi seçin"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:559
+msgid "Unknown Cursor"
+msgstr "Namə'lum Kursor"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+msgid "Default Cursor"
+msgstr "Ön Qurğulu Kursor"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Cursor - Current"
+msgstr "Ön Qurğulu Kursor - Hazırkı"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+msgid "The default cursor that ships with X"
+msgstr "X ilə birlikdə gələn ön qurğulu kursor"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+msgid "White Cursor"
+msgstr "Ağ Kursor"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Cursor - Current"
+msgstr "Ağ Kursor - Hazırkı"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+msgid "The default cursor inverted"
+msgstr "Ön qurğulu kursorun çevrilmiş vəziyyəti"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+msgid "Large Cursor"
+msgstr "Geniş Kursor"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Cursor - Current"
+msgstr "Geniş Kursor - Hazırkı"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+msgid "Large version of normal cursor"
+msgstr "Ön qurğulu kursorun geniş forması"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+msgid "Large White Cursor - Current"
+msgstr "Geniş Ağ Kursor - Hazırkı"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Cursor"
+msgstr "Geniş Ağ Kursor"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+msgid "Large version of white cursor"
+msgstr "Ağ kursorun geniş forması"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:975
+msgid "Cursor Theme"
+msgstr "Kursor Örtüyü"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr "<b>Cüt Tıqlama Gecikməsi </b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Daşı və Burax</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Oxun Yerinin Göstərilməsi</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>Siçan İstiqaməti</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Speed</b>"
+msgstr "<b>Sür'ət</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>Sür'ətli</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>Yüksək</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>Böyük</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>Alçaq</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>Yavaş</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>Kiçik</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Düymələr"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#, fuzzy
+msgid "Cursor Size:"
+msgstr "Kursor Böyüklüyü"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Cursors"
+msgstr "Kursorlar"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr "Ctrl düyməsinə basıldığında _oxun yerini göstər"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+#, fuzzy
+msgid "Large"
+msgstr "_Geniş"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+#, fuzzy
+msgid "Medium"
+msgstr "_Orta"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Motion"
+msgstr "Hərəkət"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Mouse Preferences"
+msgstr "Siçan Seçimləri"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#, fuzzy
+msgid "Small"
+msgstr "_Kiçik"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr "_Sür'ətləndirmə:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr "_Solaxay üçün siçan"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr "_Həssasiyyət:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr "_Aralıq:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr "_Gecikmə:"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Siçan"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Siçanınızın qurğularını seçin"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Şəbəkə Vəkil Vericisi"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your network proxy preferences"
+msgstr "Şəbəkə vəkil qurğuları"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+#, fuzzy
+msgid "<b>D_irect internet connection</b>"
+msgstr "<b>_Birbaşa internet bağlantısı</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>_Avtomatik vəkil quraşdırılması</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>Ə_l ilə vəkil quraşdırılması</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Təsdiqləmə işlət</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+#, fuzzy
+msgid "Advanced Configuration"
+msgstr "Avtomatik quraşdırma _URL-si:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr "Avtomatik quraşdırma _URL-si:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "HTTP Vəkil Təfərruatları"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "H_TTP vəkil vericisi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+#, fuzzy
+msgid "Network Proxy Preferences"
+msgstr "Şəbəkə vəkil qurğuları"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Qapı:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+#, fuzzy
+msgid "Proxy Configuration"
+msgstr "Şəbəkə Proksisi Quraşdırması"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr "S_ocks qovşağı:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "U_sername:"
+msgstr "_İstifadəçi Adı:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_Ətraflı"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr "_FTP vəkil vericisi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "_Şifrə:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr "_E'tibarlı HTTP vəkil vericisi:"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Səsi fəallaşdır və hadisələrlə səsləri əlaqələndir"
+
+#: ../capplets/sound/sound-properties-capplet.c:271
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Sound Preferences"
+msgstr "Səs Qurğuları"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "E_nable sound server startup"
+msgstr "Başlanğıcda səs vericisini _fəallaşdır"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "Flash _entire screen"
+msgstr "_Bütün ekranı parlat"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "Flash _window titlebar"
+msgstr "_Pəncərənin başlıq çubuğunu parlat"
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "General"
+msgstr "Ümumi"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "Sound Events"
+msgstr "Səsli Hadisələr"
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "System Bell"
+msgstr "Sistem Bildirişi"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "_Sound an audible bell"
+msgstr "_Səs çıxart"
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "_Sounds for events"
+msgstr "Hadisələr üçün _səsli bildirişləri işlət"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "_Visual feedback:"
+msgstr "_Əyani bildiriş işlət:"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:347
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+"Sisteminizdə heş örtük tapıla bilmədi. Bu \"Örtük Qurğuları\" dialoqunun "
+"düzgün quraşdırılmadığına dəlalət edir, ya da \"gnome-themes\" paketini "
+"qurmamışsınız."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:227
+msgid "This theme is not in a supported format."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:244
+msgid "Failed to create temporary directory"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:264
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:282
+#: ../capplets/theme-switcher/gnome-theme-installer.c:319
+#: ../capplets/theme-switcher/gnome-theme-installer.c:399
+#, fuzzy
+msgid "Installation Failed"
+msgstr "Örtük Qurulması"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:302
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:340
+#, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:343
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:346
+#, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:349
+#, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:357
+msgid "The theme is an engine. You need to compile the theme."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:374
+#, fuzzy
+msgid "The file format is invalid"
+msgstr "%s faylı hökmlü wav faylı deyil"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:468
+msgid "No theme file location specified to install"
+msgstr "Qurulacaq örtük faylı mövqeyi bildirilmədi"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:485
+msgid "The theme file location specified to install is invalid"
+msgstr "Qurulacaq örtük faylının mövqeyi hökmsüzdür"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:505
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:526
+#, fuzzy
+msgid "The file format is invalid."
+msgstr "%s faylı hökmlü wav faylı deyil"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:553
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+"%s mövqeyinə örtük faylları qurulacaqdır ona görə də mənbə qovluğu olaraq bu "
+"qovluq seçilə bilməz"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:607
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "Custom theme"
+msgstr "Xüsusi örtük"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr "Bu örtüyü Örtüyü Qeyd Et düyməsinə basaraq qeyd edə bilərsiniz."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+"Sisteminizdə ön qurğulu örtük sxemləri tapıla bilmədi. Bu metacity paketinin "
+"qurulmadığına ya da gconf'un səhv qurğulandığına dəlalət edir."
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:72
+msgid "Theme name must be present"
+msgstr "Örtük adı mövcud olmalıdır"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:104
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Örtük onsuzda mövcuddur. Onu əvəz etmək istəyirsiniz?"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr "Masa üstünün müxtə'lif yerləri üçün örtüklər seç"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "Örtük"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Örtük Qur</span>"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:3
+msgid "Theme Installation"
+msgstr "Örtük Qurulması"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:4
+msgid "_Install"
+msgstr "_Qur"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:5
+msgid "_Location:"
+msgstr "_Mövqe:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Örtüyü Diskə Qeyd Et</span>"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Apply _Background"
+msgstr "_Arxa Planı Tətbiq Et"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Apply _Font"
+msgstr "_Yazı Növünü Tətbiq Et"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Controls"
+msgstr "Pəncərə görünüşü"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "Icons"
+msgstr "Timsallar"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "New themes can also be installed by dragging them into the window."
+msgstr ""
+"Yeni örtükləri bu pəncərənin üstünə daşıyıb buraxaraq da qura bilərsiniz."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+msgid "Save Theme"
+msgstr "Örtüyü Qeyd Et"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+msgid "Select theme for the desktop"
+msgstr "Masa üstü örtüyünü seçin"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+msgid "Short _description:"
+msgstr "_Qısa izahat:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "Theme Details"
+msgstr "Örtük Təfərruatları"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "Theme Preferences"
+msgstr "Örtük Seçimləri"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+msgid "Theme _Details"
+msgstr "Örtük _Təfərruatları"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+msgid "This theme does not suggest any particular font or background."
+msgstr ""
+"Bu örtüyün məsləhər etdiyi xüsusi bir yazı növü ya da arxa plan yoxdur."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+msgid "This theme suggests a background:"
+msgstr "Bu örtük arxa plan məsləhət edir:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+msgid "This theme suggests a font and a background:"
+msgstr "Bu örtük yazı növü və arxa plan məsləhət edir:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+msgid "This theme suggests a font:"
+msgstr "Bu örtük yazı növü məsləhət edir:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "Window Border"
+msgstr "Pəncərə Kənarı"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+msgid "_Go To Theme Folder"
+msgstr "Örtük Qovluğuna _Get"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+msgid "_Install Theme..."
+msgstr "Ö_rtük Qur..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+msgid "_Revert"
+msgstr "_Geri Al"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+msgid "_Save Theme..."
+msgstr "Örtüyü _Qeyd Et..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+msgid "_Theme name:"
+msgstr "Örtük _adı:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:24
+msgid "theme selection tree"
+msgstr "örtük seçki budağı"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr "Proqramlardakı vasitə və menyu çubuqlarının görünüşünü xüsusiləşdir"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "Menyular və Vasitə Çubuqları"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr "<b>Davranış və Görünüş</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+msgid "<b>Preview</b>"
+msgstr "<b>Nümayiş</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "Kə_s"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+msgid "Icons only"
+msgstr "Təkcə timsallar"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "Menyu və Vasitə Çubuğu Seçimləri"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "Yeni Fayl"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Fayl Aç"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Faylı Qeyd Et"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr "Menyularda _timsalları göstər"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+msgid "Text below icons"
+msgstr "Mətn timsalların altında"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+msgid "Text beside icons"
+msgstr "Mətn timsalların yanında"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+msgid "Text only"
+msgstr "Təkcə mətn"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+#, fuzzy
+msgid "Toolbar _button labels:"
+msgstr "Vasitə çubuğu _düymələrinin görünüşü: "
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_Köçür"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr "_Vasitə çubuqları ayırıla bilsin"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_Düzəlt"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "_Fayl"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_Yeni"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "_Aç"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "_Yapışdır"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "Ç_ap Et"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "Çı_x"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "_Qeyd Et"
+
+#: ../capplets/windows/gnome-window-properties.c:386
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+"<b>Pəncərə idarəçiniz üçün qurğu tə'minatı başladıla bilmir</b>\n"
+"\n"
+"%s"
+
+#: ../capplets/windows/gnome-window-properties.c:644
+msgid "Control"
+msgstr "Control"
+
+#: ../capplets/windows/gnome-window-properties.c:649
+msgid "Alt"
+msgstr "Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:655
+msgid "Hyper"
+msgstr "Hyper"
+
+#: ../capplets/windows/gnome-window-properties.c:662
+msgid "Super (or \"Windows logo\")"
+msgstr "Windows"
+
+#: ../capplets/windows/gnome-window-properties.c:669
+msgid "Meta"
+msgstr "Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Hərəkət Düyməsi</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>Etiket Çubuğu Gedişatı</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Pəncərə Seçkisi</b>:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To _move a window, press-and-hold this key then grab the window:"
+msgstr ""
+"Pəncərəni _daşımaq üçün bu düyməni basılı tutaraq pəncərəni hərəkət etdirin:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Pəncərə Seçimləri"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_Başlıq çubuğuna cüt tıqlandığında bu gedişatı yerinə gətir:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "_Qabağa gətirmədən əvvəlki vaxt:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_Seçili pəncərələri müəyyən bir vaxt sonra qabağa gətir"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Siçanın oxu pəncərələrin üstünə gələndə onları seç"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+#, fuzzy
+msgid "Set your window properties"
+msgstr "Pəncərə Xassələri"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Pəncələr"
+
+#: ../control-center/control-center-categories.c:257
+msgid "Others"
+msgstr "Digərləri"
+
+#: ../control-center/control-center.c:42
+#, fuzzy
+msgid "Desktop Preferences"
+msgstr "Masa Üstü Arxa Planı Seçimləri"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr "GNOME İdarə Mərkəzi"
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "GNOME quraşdırma avadanlığı"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "Səs"
+
+#: ../gnome-settings-daemon/factory.c:36
+msgid "Could not initialize Bonobo"
+msgstr "Bonobo başladıla bilmir"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
+msgid "Slow Keys Alert"
+msgstr "Yavaş Düymələr Xəbərdarlığı"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Az öncə Shift düyməsinə basıb 8 saniyə saxladınız.  Bu Yavaş Düymələr "
+"xassəsini fəallaşdırar, bu da klaviaturanızın işləmə tərzini dəyişdirər."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
+msgid "Do you want to activate Slow Keys?"
+msgstr "Yavaş Düymələri fəallaşdırmaq istəyirsiniz?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
+msgid "Do you want to deactivate Slow Keys?"
+msgstr "Yavaş Düymələri qeyri-fəallaşdırmaq istəyirsiniz?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Sticky Keys Alert"
+msgstr "Yapışqan Düymələr Xəbərdarlığı"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Az öncə Shift düyməsinə arxa arxaya 5 dəfə basdınız.  Bu Yapışqan Düymələr "
+"xassəsini fəallaşdırar, bu da klaviaturanızın işləmə tərzini dəyişdirər."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+"Az öncə iki düyməyə bərabər ya da Shift düyməsinə arxa arxaya 5 dəfə "
+"basdınız.  Bu Yapışqan Düymələr xassəsini fəallaşdırar, bu da "
+"klaviaturanızın işləmə tərzini dəyişdirər."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
+msgid "Do you want to activate Sticky Keys?"
+msgstr "Yapışqan Düymələri fəallaşdırmaq istəyirsiniz?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr "Yapışqan Düymələri qeyri-fəallaşdırmaq istəyirsiniz?"
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:107
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+"\"%s\" qovluğu yaradıla bilmir.\n"
+"Bu kursorların dəyişdirilə bilməsi üçün məcburidir."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr "(%s) düymə bağının gedişatı birdən çox dəfə tə'yin edilib\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr "(%s) düymə bağının bağı birdən çox dəfə tə'yin edilib\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr "(%s) düymə bağı tamamlanmayıb\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr "(%s) düymə bağı hökmsüzdür\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
+#, c-format
+msgid "It seems that another application already has access to key '%d'."
+msgstr "Görünən odur ki, '%d' düyməsinə başqa bir tə'minat bağ qurub."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr "(%s) düymə bağı hazırda istifadədədir\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+"(%2$s) düyməsinə bağlı olan\n"
+"(%1$s) icra edilməyə çalışırkən xəta yarandı"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
+#, fuzzy, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+"XKB qurğularını fəallaşdırma xətası.\n"
+"Deyəsən daxili X vericisi problemidir.\n"
+"\n"
+"X vericisi mə'lumatı:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"Əgər bu vəziyyəti xəta olaraq raport etmək istəsəniz:\n"
+"- <b>xprop -root | grep XKB</b> əmrinin nəticəsini və\n"
+"- <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/xkb</b>\n"
+"   əmrinin nəticəsini də yollayın."
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+#, fuzzy
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+"Siz XFree 4.3.0 buraxılışını işlədirsiniz.\n"
+"Qarışıq XKB qurğuları ilə əlaqəli bə'zi problemlər vardır.\n"
+"XFree tə'minatının daha yeni buraxılışını endirməyə çalışın."
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
+#, fuzzy
+msgid "Do _not show this warning again"
+msgstr "_Bu ismarışı bir də göstərmə"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
+msgid ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+msgstr ""
+"X sisteminin klaviatura quruluşu hazırkı GNOME klaviatura quruluşundan "
+"fərqlidir. Hansı dəstəni işlətmək istəyirsiniz?"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
+msgid "Use X settings"
+msgstr "X qurğularını işlət"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
+msgid "Use GNOME settings"
+msgstr "GNOME Qurğularını İşlət"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+"Əmr icra edilə bilmədi: %s\n"
+"Bu əmrin mövcud olduğunu yoxlayın."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+"Sistem yuxu vəziyyətinə keçirilə bilmədi.\n"
+"Sistemin düzgün quraşdırıldığını yoxlayın."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
+#, c-format
+msgid "Permissions on the file %s are broken\n"
+msgstr "%s faylının səlahiyyətləri hökmsüzdür\n"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+"Glade faylı yüklənə biləmdi.\n"
+"Bu demonun düzgün qurulduğunu yoxlayın."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+"Ekran qoruyucu başladılırkən bir xəta yarandı:\n"
+"\n"
+"%s\n"
+"\n"
+"Bu iclas üçün ekran qoruyucu xassəsi fəal olmayacaq."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
+msgid "_Do not show this message again"
+msgstr "_Bu ismarışı bir də göstərmə"
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:129
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr "%2$s şablonu olaraq %1$s səs faylı yüklənə bilmədi"
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
+msgid "Cannot determine user's home directory"
+msgstr "İstifadəçinin ev cərgəsi müəyyən edilə bilmir"
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr "%s GConf açarı %s seçilib ancaq %s cüründə olması gözlənilirdi\n"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+#, fuzzy
+msgid "A_vailable files:"
+msgstr "_Mövcud düzülüşlər:"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+#, fuzzy
+msgid "Do _not show this warning again."
+msgstr "_Bu ismarışı bir də göstərmə"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+#, fuzzy
+msgid "_Loaded files:"
+msgstr "_Modellər"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr "Signal borusu yaradıla bilmədi."
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Növ"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+"bg_applier növü: Kök pəncərəsi üçün BG_APPLIER_ROOT və ya nümayiş üçün "
+"BG_APPLIER_PREVIEW"
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr "Nümayiş Eni"
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr "Tətbiq edici bir nümayiş isə eni: Ön qurğulusu 64."
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr "Nümayiş Hündürlüyü"
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr "Tətbiq edici bir nümayiş isə hündürlüyü: Ön qurğulusu 48."
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Ekran"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr "BGApplier'in göstəriləcəyi ekran"
+
+#: ../libgswitchit/gswitchit_config.c:1035
+#, fuzzy, c-format
+msgid "There was an error loading an image: %s"
+msgstr "Yardımın göstərilməsi sırasında xəta oldu: %s"
+
+#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
+msgid "The sound file for this event does not exist."
+msgstr "Bu səbəb üçün ayrılmış səs faylı yoxdur."
+
+#: ../libsounds/sound-view.c:149
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package\n"
+"for a set of default sounds."
+msgstr ""
+"Bu səbəb üçün seçilmiş səs faylı yoxdur.\n"
+"Bəlkə də ön qurğulu səslər üçün gnome-audio paketini\n"
+" qurmamısınız."
+
+#: ../libsounds/sound-view.c:224
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "%s faylı hökmlü wav faylı deyil"
+
+#: ../libsounds/sound-view.c:289
+msgid "Event"
+msgstr "Hadisə"
+
+#: ../libsounds/sound-view.c:298
+msgid "Sound File"
+msgstr "Səs Faylı"
+
+#: ../libsounds/sound-view.c:314
+msgid "_Sounds:"
+msgstr "_Səslər:"
+
+#: ../libsounds/sound-view.c:328
+msgid "Sound _file:"
+msgstr "Səs _faylı:"
+
+#: ../libsounds/sound-view.c:332
+msgid "Select Sound File"
+msgstr "Səs Faylını Seç"
+
+#: ../libsounds/sound-view.c:356
+msgid "_Play"
+msgstr "Ç_al"
+
+#: ../libsounds/sound-view.c:366
+msgid "_Remove"
+msgstr "_Sil"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "\"%s\" pəncərə idarəçisi quraşdırma vasitəsini tanımadı\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Böyüt"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Yuxarı Bur"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr ""
+"Seşilidirsə, text/plain və text/* üçün tutucular sync içində saxlanacaq"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr "Sync text/plain və text/* tutucuları"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "Brightness down"
+msgstr "Parlaqlığı azalt"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "Brightness down's shortcut."
+msgstr "Parlaqlığı azaltma qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Brightness up"
+msgstr "Parlaqlığı artır"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Brightness up's shortcut."
+msgstr "Parlaqlığı artırma qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "E-mail"
+msgstr "E-poçt"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "E-mail's shortcut."
+msgstr "E-poçt qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Eject"
+msgstr "Çıxart"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+msgid "Eject's shortcut."
+msgstr "Çıxartma əməliyyatı üçün qısa yol."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+msgid "Home folder"
+msgstr "Ev qovluğu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+msgid "Home folder's shortcut."
+msgstr "Ev qovluğunun qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+msgid "Launch help browser"
+msgstr "Yardım aəyyahını başlat"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+msgid "Launch help browser's shortcut."
+msgstr "Yardım səyyahını başlatma qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+msgid "Launch web browser"
+msgstr "Veb səyyahını başlat"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+msgid "Launch web browser's shortcut."
+msgstr "Veb səyyahını başlatma qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+msgid "Lock screen"
+msgstr "Ekranı qıfılla"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+msgid "Lock screen's shortcut."
+msgstr "Ekranı qıfıllama qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+msgid "Log out"
+msgstr "İclası sonlandır"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+msgid "Log out's shortcut."
+msgstr "İclası sonlandırma qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Next track key's shortcut."
+msgstr "Növbəti mahnı üçün qısa yol."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Pause"
+msgstr "Fasilə ver"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Pause key's shortcut."
+msgstr "Fasilə vermək üçün qısa yol."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Play (or play/pause)"
+msgstr "Çal (ya da çal/fasilə ver)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Play (or play/pause) key's shortcut."
+msgstr "Çal (ya da çal/fasilə ver) düyməsinin qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Previous track key's shortcut."
+msgstr "Əvvəlki mahnı üçün qısa yol."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Search"
+msgstr "Axtar"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+msgid "Search's shortcut."
+msgstr "Axtarış üçün qısa yol."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Skip to next track"
+msgstr "Nüvbəti mahnıya keç"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Skip to previous track"
+msgstr "Əvvəlki mahnıya keç"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Sleep"
+msgstr "Yuxu vəziyyətinə sal"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+msgid "Sleep's shortcut."
+msgstr "Yuxu vəziyyətinə salma qısa yolu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Stop playback key"
+msgstr "Çalğını dayandırma düyməsi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Stop playback key's shortcut."
+msgstr "Çalğını dayandırma düyməsinin qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume down"
+msgstr "Səsi azalt"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume down's shortcut."
+msgstr "Səsi azaltma qısa yolu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume mute"
+msgstr "Səsi bağla"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume mute's shortcut"
+msgstr "Səsi bağlama qısa yolu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+msgid "Volume step"
+msgstr "Səs addımı"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+msgid "Volume step as percentage of volume."
+msgstr "Səs həcmi faizi olaraq səs addımı."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+msgid "Volume up"
+msgstr "Səsi artır"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
+msgid "Volume up's shortcut."
+msgstr "Səsi artırma qısa yolu."
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+#, fuzzy
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr "XScreenSaver işlərkən yaranan xətaları dialoq qutusunda göstər"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+#, fuzzy
+msgid "Run screensaver at login"
+msgstr "Girişdə XScreenSaver-i işə sal"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr "Başlanğıc Xətalarını Göstər"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#, fuzzy
+msgid "Start screensaver"
+msgstr "XScreenSaver-i Başlat"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+#, fuzzy
+msgid "Keyboard Update Handlers"
+msgstr "Klaviatura _modeli:"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#, fuzzy
+msgid "Keyboard layout"
+msgstr "XKB klaviatura düzülüşü"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#, fuzzy
+msgid "Keyboard model"
+msgstr "Klaviatura _modeli:"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+#, fuzzy
+msgid "Keyboard options"
+msgstr "Klaviatura Qısa Yolları"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+#, fuzzy
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr "Gconf-dakı XKB qurğuları tezliklə sisteminkilərlə əvəz ediləcəkdir"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+#, fuzzy
+msgid "keyboard layout"
+msgstr "XKB klaviatura düzülüşü"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+#, fuzzy
+msgid "keyboard model"
+msgstr "XKB klaviatura modeli"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "modmap file list"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:212
+msgid "_Postpone break"
+msgstr "Fasiləni _tə'xirə sal"
+
+#: ../typing-break/drw-break-window.c:259
+msgid "Take a break!"
+msgstr "Fasilə ver!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:141
+msgid "/_Preferences"
+msgstr "/_Seçimlər"
+
+#: ../typing-break/drwright.c:142
+msgid "/_About"
+msgstr "/_Haqqında"
+
+#: ../typing-break/drwright.c:144
+msgid "/_Take a Break"
+msgstr "/_Fasilə Ver"
+
+#: ../typing-break/drwright.c:495
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "Növbəti fasiləyə %d dəqiqə qalıb"
+msgstr[1] "Növbəti fasiləyə %d dəqiqə qalıb"
+
+#: ../typing-break/drwright.c:499
+msgid "Less than one minute until the next break"
+msgstr "Növbəti fasiləyə bir dəqiqədən az qalıb"
+
+#: ../typing-break/drwright.c:587
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr "Yazma fasiləsi xassələri dialoqu göstərilə bilmədi. Xəta: %s"
+
+#: ../typing-break/drwright.c:635
+msgid "About GNOME Typing Monitor"
+msgstr "GNOME Yazma İzləyicisi Haqqında"
+
+#: ../typing-break/drwright.c:659
+msgid "A computer break reminder."
+msgstr "Kopüter fasiləsini yada salan tə'minat."
+
+#: ../typing-break/drwright.c:660
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr "Richard Hult &lt;richard@imendio.com&gt; tərəfindən yazılıb"
+
+#: ../typing-break/drwright.c:661
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Qrafika Anders Carlsson tərəfindən əlavə edilib"
+
+#: ../typing-break/drwright.c:837
+msgid "Break reminder"
+msgstr "Fasilə yada salıcı"
+
+#: ../typing-break/main.c:93
+msgid "The typing monitor is already running."
+msgstr "Yazma izləyicisi onsuzda fəaliyyətdədir."
+
+#: ../typing-break/main.c:106
+#, fuzzy
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Yazma izləyicisi mə'lumatı göstərmək üçün bildiriş sahəsini istifadə edir. "
+"Panelinizdə bildiriş sahəsi appleti mövcud deyil. Onu əlavə etmək üçün "
+"panelinizə sağ tıqlayıb 'Panelə Əlavə Et -> Tə'minatlar -> Bildiriş sahəsi' "
+"menyusunu seçin."
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "Sən! Bu gün Azərbaycan üçün nə etdin? 0123456789"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "Ad:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "Tərz:"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "Növ:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "Böyüklük:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "Buraxılış:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "Müəllif hüququ:"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "İzahat:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "istifadə qaydası: %s yazı növü faylı\n"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr "Proqram Yazı Növü Olaraq Tə'yin Et"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+#, fuzzy
+msgid "Sets the default application font"
+msgstr "Ön qurğulu proqramlarınızı seçin"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "Seçilirsə, OpenType yazı növlərinin ön nümayişləri göstəriləcək."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "Seçilirsə, PCF yazı növlərinin ön nümayişləri göstəriləcək."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "Seçilirsə, TrueType yazı növlərinin ön nümayişləri göstəriləcək."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "Seçilirsə, Type1 yazı növlərinin ön nümayişləri göstəriləcək."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"Bu düyməni OpenType yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən "
+"əmrə bağlayın."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+"Bu düyməni PCF yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən əmrə "
+"bağlayın."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"Bu düyməni TrueType yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən "
+"əmrə bağlayın."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"Bu düyməni Type1 yazı növlərinin ön nümayişlərini yaratmaq üçün işlədilən "
+"əmrə bağlayın."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "OpenType yazı növlərinin ön nümayiş əmri"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "PCF yazı növlərinin ön nümayiş əmri"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "TrueType yazı növlərinin ön nümayiş əmri"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Type1 yazı növlərinin ön nümayiş əmri"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "OpenType yazı növlərinin ön nümayişlərinin göstərilməsi"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "PCF yazı növlərinin ön nümayişlərinin göstərilməsi"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "TrueType yazı növlərinin ön nümayişlərinin göstərilməsi"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "Type1 yazı növlərinin ön nümayişlərinin göstərilməsi"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+#, fuzzy
+msgid "GNOME Font Viewer"
+msgstr "GNOME İdarə Mərkəzi"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr ""
+"<span weight=\"bold\" size=\"larger\">Yeni yazı növü tətbiq edilsin?</span>"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr "Yazı növünü tətbiq et_mə"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"Seçdiyiniz örtük yeni yazı növü təklif edir. Yazı növünün nümayişi "
+"aşağıdadır."
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+msgid "_Apply font"
+msgstr "Yazı növünü _tətbiq et"
+
+#: ../vfs-methods/themus/theme-method.c:520
+msgid "Themes"
+msgstr "Örtüklər"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "İzahat"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr "Sınama örtüyü"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+msgid "Window border theme"
+msgstr "Pəncərə kənarı örtüyü"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr "Timsal örtüyü"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr "ABCDEFG"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+#, fuzzy
+msgid "Apply theme"
+msgstr "Yazı növünü _tətbiq et"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+#, fuzzy
+msgid "Sets the default theme"
+msgstr "Ön _qurğulara sıfırla"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr "True isə, quraşdırılmış örtüklərin nümaişləri göstəriləcək."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr "True isə, örtüklərin nümaişləri göstəriləcək."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+"Bu düyməni quraşdırılmış örtüklərin nümaişləri göstərmək üçün işlədilən əmrə "
+"bağlayın."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+"Bu düyməni örtüklərin nümaişləri göstərmək üçün işlədilən əmrə bağlayın."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr "Quraşdırılmış örtüklərin nümaişləri göstərmək üçün işlədilən əmr"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr "Örtüklərin nümaişləri göstərmək üçün işlədilən əmr"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr "Quraşdırılmış örtüklərin nümaişlərinin göstərilməsi"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr "Örtüklərin nümaişlərinin göstərilməsi"
+
+msgid "Show help options"
+msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -7,333 +7,223 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2021-09-07 09:53+0000\n"
-"PO-Revision-Date: 2021-09-08 01:31+0300\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-11-24 18:42+0300\n"
 "Last-Translator: Launchpad translators\n"
 "Language-Team: Belarusian <i18n-bel-gnome@googlegroups.com>\n"
 "Language: be\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Launchpad-Export-Date: 2020-05-05 21:37+0000\n"
-"X-Generator: Poedit 3.0\n"
+"X-Generator: Poedit 3.2\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:823
-msgid "System Bus"
-msgstr "Сістэмная шына"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-#: panels/applications/cc-applications-panel.c:838
-#: panels/applications/cc-applications-panel.c:843
-msgid "Full access"
-msgstr "Поўны доступ"
-
-#: panels/applications/cc-applications-panel.c:825
-msgid "Session Bus"
-msgstr "Шына сеанса"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/power/cc-power-panel.ui:85 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525
-msgid "Devices"
-msgstr "Прылады"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Full access to /dev"
-msgstr "Поўны доступ да /dev"
-
-#: panels/applications/cc-applications-panel.c:833
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:288 panels/wwan/cc-wwan-device-page.ui:114
-#: panels/wwan/cc-wwan-network-dialog.ui:4
-msgid "Network"
-msgstr "Сетка"
-
-#: panels/applications/cc-applications-panel.c:833
-msgid "Has network access"
-msgstr "Мае доступ да сеткі"
-
-#: panels/applications/cc-applications-panel.c:838
-#: panels/applications/cc-applications-panel.c:840
-#: panels/search/cc-search-locations-dialog.c:362
-msgid "Home"
-msgstr "Хатняя папка"
-
-#: panels/applications/cc-applications-panel.c:840
-#: panels/applications/cc-applications-panel.c:845
-msgid "Read-only"
-msgstr "Толькі для чытання"
-
-#: panels/applications/cc-applications-panel.c:843
-#: panels/applications/cc-applications-panel.c:845
-msgid "File System"
-msgstr "Файлавая сістэма"
-
-#: panels/applications/cc-applications-panel.c:849
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:279
-#: shell/cc-window.c:938 shell/cc-window.ui:121
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr "Налады"
-
-#: panels/applications/cc-applications-panel.c:849
-msgid "Can change settings"
-msgstr "Можа змяняць налады"
-
-#: panels/applications/cc-applications-panel.c:851
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s мае наступныя ўбудаваныя дазволы, іх немагчыма змяніць. Калі гэтыя "
-"дазволы вас непакояць, падумайце ці не варта выдаліць праграму."
-
-#: panels/applications/cc-applications-panel.c:1024
-msgid "Web Links"
-msgstr "Вэб-спасылкі"
-
-#: panels/applications/cc-applications-panel.c:1034
-msgid "Git Links"
-msgstr "Спасылкі Git"
-
-#: panels/applications/cc-applications-panel.c:1040
-#, c-format
-msgid "%s Links"
-msgstr "Спасылкі %s"
-
-#: panels/applications/cc-applications-panel.c:1048
-#: panels/applications/cc-applications-panel.c:1084
-msgid "Unset"
-msgstr "Зняць"
-
-#: panels/applications/cc-applications-panel.c:1139
-msgid "Links"
-msgstr "Спасылкі"
-
-#: panels/applications/cc-applications-panel.c:1147
-msgid "Hypertext Files"
-msgstr "Гіпертэкставыя файлы"
-
-#: panels/applications/cc-applications-panel.c:1161
-msgid "Text Files"
-msgstr "Тэкставыя файлы"
-
-#: panels/applications/cc-applications-panel.c:1175
-msgid "Image Files"
-msgstr "Файлы відарысаў"
-
-#: panels/applications/cc-applications-panel.c:1191
-msgid "Font Files"
-msgstr "Файлы шрыфтоў"
-
-#: panels/applications/cc-applications-panel.c:1252
-msgid "Archive Files"
-msgstr "Файлы архіваў"
-
-#: panels/applications/cc-applications-panel.c:1272
-msgid "Package Files"
-msgstr "Файлы пакетаў"
-
-#: panels/applications/cc-applications-panel.c:1295
-msgid "Audio Files"
-msgstr "Аўдыяфайлы"
-
-#: panels/applications/cc-applications-panel.c:1312
-msgid "Video Files"
-msgstr "Відэафайлы"
-
-#: panels/applications/cc-applications-panel.c:1320
-msgid "Other Files"
-msgstr "Іншыя файлы"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1660
-#: panels/applications/cc-applications-panel.ui:416
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:70
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr "Праграмы"
 
-#: panels/applications/cc-applications-panel.ui:43
+#: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
 msgstr "Няма праграм"
 
-#: panels/applications/cc-applications-panel.ui:57
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr "Усталяваць…"
 
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
+msgstr "Адкрыць"
+
 #: panels/applications/cc-applications-panel.ui:94
-msgid "Permissions & Access"
-msgstr "Дазволы і доступ"
+msgid "View Details"
+msgstr "Паказаць падрабязнасці"
 
-#: panels/applications/cc-applications-panel.ui:106
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-"Даныя і сэрвісы, да якіх праграма запытала доступ і патрэбныя ёй дазволы."
-
-#: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:127
-#: panels/camera/gnome-camera-panel.desktop.in.in:3
-msgid "Camera"
-msgstr "Камера"
-
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:128
-#: panels/applications/cc-applications-panel.ui:140
-#: panels/applications/cc-applications-panel.ui:152
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:262
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:85
-#: panels/keyboard/cc-xkb-modifier-dialog.c:353
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:129
-#: panels/user-accounts/cc-user-panel.c:848
-#: panels/user-accounts/cc-user-panel.c:938
-#: panels/wwan/cc-wwan-device-page.c:445
-#: subprojects/gvc/gvc-mixer-control.c:1900
-msgid "Disabled"
-msgstr "Адключана"
-
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:139
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
-msgid "Microphone"
-msgstr "Мікрафон"
-
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:151
-#: panels/location/gnome-location-panel.desktop.in.in:3
-msgid "Location Services"
-msgstr "Сэрвісы месцазнаходжання"
-
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:500
-msgid "Built-in Permissions"
-msgstr "Убудаваныя дазволы"
-
-#: panels/applications/cc-applications-panel.ui:158
-msgid "Cannot be changed"
-msgstr "Немагчыма змяніць"
-
-#: panels/applications/cc-applications-panel.ui:175
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-"Асобныя дазволы для праграм можна пераглядзець у раздзеле налад <a href="
-"\"privacy\">Прыватнасць</a>."
-
-#: panels/applications/cc-applications-panel.ui:199
-msgid "Integration"
-msgstr "Інтэграцыя"
-
-#: panels/applications/cc-applications-panel.ui:211
-msgid "System features used by this application."
-msgstr "Сістэмныя функцыі, якія выкарыстоўвае гэтая праграма."
-
-#: panels/applications/cc-applications-panel.ui:225
-#: panels/applications/cc-applications-panel.ui:231
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:151
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Пошук"
 
-#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Атрымліваць пошукавых запытаў сістэмы і адпраўляць вынікі."
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Адключана"
+
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr "Апавяшчэнні"
 
-#: panels/applications/cc-applications-panel.ui:243
-msgid "Run in background"
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Паказваць сістэмныя апавяшчэнні."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
 msgstr "Запуск у фонавым рэжыме"
 
-#: panels/applications/cc-applications-panel.ui:249
-msgid "Set Desktop Background"
-msgstr "Задаць фон працоўнага стала"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Дазволіць актыўнасць, калі праграма закрыта."
 
-#: panels/applications/cc-applications-panel.ui:255
-#: panels/applications/cc-applications-panel.ui:261
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Здымкі экрана"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Рабіць здымкі экрана ў любы часы."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Змяненне шпалер"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Змяняць шпалеры працоўнага стала."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Гукі"
 
-#: panels/applications/cc-applications-panel.ui:267
-msgid "Inhibit system keyboard shortcuts"
-msgstr "Спалучэнні клавіш"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Прайграванне гуку."
 
-#: panels/applications/cc-applications-panel.ui:300
-msgid "Default Handlers"
-msgstr "Прадвызначаныя апрацоўшчыкі"
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Забараняць спалучэнні клавіш"
 
-#: panels/applications/cc-applications-panel.ui:312
-msgid "Types of files and links that this application opens."
-msgstr "Тыпы файлаў і спасылак, якія адкрывае гэтая праграма."
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Блакіраваць стандартныя спалучэнні клавіш."
 
-#: panels/applications/cc-applications-panel.ui:328
-msgid "Reset"
-msgstr "Скінуць"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Камера"
 
-#: panels/applications/cc-applications-panel.ui:364
-msgid "Usage"
-msgstr "Выкарыстанне"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Рабіць здымкі праз камеру."
 
-#: panels/applications/cc-applications-panel.ui:376
-msgid "How much resources this application is using."
-msgstr "Колькі рэсурсаў выкарыстоўвае гэтая праграма."
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Мікрафон"
 
-#: panels/applications/cc-applications-panel.ui:391
-#: panels/applications/cc-applications-panel.ui:537
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Запісваць гук праз мікрафон."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Сэрвісы месцазнаходжання"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Доступ да звестак пра месцазнаходжанне прылады."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Убудаваныя дазволы"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Доступ да сістэмы, які запатрабавала праграма"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Суаднясенні файлаў і спасылак"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Сховішча"
 
-#: panels/applications/cc-applications-panel.ui:424
-msgid "Open in Software"
-msgstr "Адкрыць у Software"
-
-#: panels/applications/cc-applications-panel.ui:474 shell/cc-panel-list.ui:121
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Нічога не знойдзена"
 
-#: panels/applications/cc-applications-panel.ui:485
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:177
-#: shell/cc-panel-list.ui:132
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
-msgstr "Паспрабуйце пашукаць іншае"
+msgstr "Паспрабуйце змяніць пошукавы запыт"
 
-#: panels/applications/cc-applications-panel.ui:555
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Суаднясенні файлаў і спасылак"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Тыпы файлаў"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Тыпы спасылак"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Скінуць"
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr "Колькі месца на дыску займае гэтая праграма разам з данымі і кэшам."
 
-#: panels/applications/cc-applications-panel.ui:564
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Праграма"
 
-#: panels/applications/cc-applications-panel.ui:570
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Даныя"
 
-#: panels/applications/cc-applications-panel.ui:576
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Кэш"
 
-#: panels/applications/cc-applications-panel.ui:582
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Усяго</b>"
 
-#: panels/applications/cc-applications-panel.ui:599
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Ачысціць кэш…"
 
@@ -341,135 +231,94 @@ msgstr "Ачысціць кэш…"
 msgid "Control various application permissions and settings"
 msgstr "Кіраванне разнастайнымі дазволамі і наладамі праграмы"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "праграма;flatpak;дазвол;налада;параметр;"
 
-#: panels/background/cc-background-chooser.c:344
-msgid "Select a picture"
-msgstr "Выберыце выяву"
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Стыль"
 
-#: panels/background/cc-background-chooser.c:347
-#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:238
-#: panels/color/cc-color-panel.c:886 panels/color/cc-color-panel.ui:657
-#: panels/common/cc-language-chooser.ui:25
-#: panels/display/cc-display-panel.c:1006
-#: panels/info-overview/cc-info-overview-panel.ui:243
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:122
-#: panels/network/cc-wifi-panel.c:866
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:176
-#: panels/network/connection-editor/vpn-helpers.c:299
-#: panels/network/net-device-wifi.c:854
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:235
-#: panels/region/cc-format-chooser.ui:28
-#: panels/search/cc-search-locations-dialog.c:639
-#: panels/sharing/cc-sharing-panel.c:396 panels/usage/cc-usage-panel.c:133
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:105
-#: panels/user-accounts/cc-avatar-chooser.c:228
-#: panels/user-accounts/cc-fingerprint-dialog.ui:36
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:638
-#: panels/user-accounts/cc-user-panel.c:656
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/wwan/cc-wwan-mode-dialog.ui:35
-#: panels/wwan/cc-wwan-network-dialog.ui:166
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:297
-msgid "_Cancel"
-msgstr "_Скасаваць"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Стандартны"
 
-#: panels/background/cc-background-chooser.c:348
-#: panels/network/connection-editor/vpn-helpers.c:177
-#: panels/printers/pp-details-dialog.c:236
-#: panels/sharing/cc-sharing-panel.c:397
-#: panels/user-accounts/cc-avatar-chooser.c:229
-msgid "_Open"
-msgstr "_Адкрыць"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Цёмны"
 
-#: panels/background/cc-background-item.c:140
-msgid "multiple sizes"
-msgstr "некалькі памераў"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:144
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:282
-msgid "No Desktop Background"
-msgstr "Без фону працоўнага стала"
-
-#: panels/background/cc-background-panel.c:110
-msgid "Current background"
-msgstr "Цяперашні фон"
-
-#: panels/background/cc-background-panel.ui:55
-msgid "Add Picture…"
-msgstr "Дадаць выяву…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Дзейнасць"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Фон"
 
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Дадаць выяву…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Выгляд"
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
-msgstr "Змяніць фонавы відарыс на шпалеры або фота"
+msgid "Change your background image or the UI colors"
+msgstr "Змяніць фонавую выяву або колеры інтэрфейсу карыстальніка"
 
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Wallpaper;абрус;фон;экран;працоўны стол;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Фон;шпалеры;экран;стыль;светлы;цёмны;выгляд;тэма;працоўны стол;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Уключыць"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Bluetooth не знойдзены"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Каб карыстацца Bluetooth, падключыце адаптар."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:69
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth выключаны"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:80
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Уключыце, каб злучаць прылады і прымаць файлы."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:107
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
 msgstr "Рэжым палёту ўключаны"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:118
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth выключаны ў рэжыме палёту."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:124
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Выключыць рэжым палёту"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:154
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
 msgstr "Апаратны рэжым палёту ўключаны"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:165
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Выключыце рэжым палёту, каб уключыць Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1392
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -477,32 +326,31 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Уключэнне ці выключэнне Bluetooth і злучэнне з прыладамі"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;апублікаваць;абагуліць;супольны;агульны;bluetooth;obex;блютуз;"
 
-#: panels/camera/cc-camera-panel.ui:34
-msgid "Camera is turned off"
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
 msgstr "Камера выключана"
 
-#: panels/camera/cc-camera-panel.ui:43
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Няма праграм, якія могуць здымаць фота або відэа."
 
-#: panels/camera/cc-camera-panel.ui:75
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 "Выкарыстанне камеры дазваляе праграмам здымаць фота і відэа. Адключэнне "
-"камеры можа прывесці да няправільнай працы некаторых праграм."
+"камеры можа прывесці да няправільнай працы некаторых праграм.\n"
+"\n"
+"Дазволіць пералічаным ніжэй праграмам выкарыстоўваць камеру."
 
-#: panels/camera/cc-camera-panel.ui:85
-msgid "Allow the applications below to use your camera."
-msgstr "Дазволіць праграмам ніжэй выкарыстоўваць камеру."
-
-#: panels/camera/cc-camera-panel.ui:105
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Няма праграм, якія запыталі доступ да камеры"
 
@@ -510,283 +358,61 @@ msgstr "Няма праграм, якія запыталі доступ да к�
 msgid "Protect your pictures"
 msgstr "Абараніце свае фота"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"экран;блакіраванне;блакіроўка;блакаванне;дыягностыка;аварыя;збой;прыватны;"
-"нядаўні;апошні;часовы;назва;імя;сетка;сеціва;ідэнтыфікацыя;ідэнтычнасць;"
-"асоба;"
+"камера;фота;відэа;вэб-камера;прыватнасць;асабістыя;канфідэнцыяльнасць;"
+"блакіраванне;блакаванне;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Змясціце калібравальную прыладу на квадрат і націсніце «Пачаць»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Перамясціце калібравальную прыладу ў абазначанае месца і націсніце "
-"«Працягнуць»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Перамясціце калібравальную прыладу на абазначаную паверхню і націсніце "
-"«Працягнуць»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Закрыйце вечка ноўтбука"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Узнікла непапраўная ўнутраная памылка."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Не ўсталяваны інструменты для каліброўкі.."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Не ўдалося стварыць профіль."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Мэтавы пункт белага не атрыманы."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Выканана!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Не ўдалося выканаць каліброўку!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Можна прыбраць калібравальную прыладу."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Падчас працы не чапайце калібравальную прыладу"
-
-#: panels/color/cc-color-calibrate.ui:7
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Каліброўка дысплэя"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Скасаваць"
+
 #. This starts the calibration process
-#: panels/color/cc-color-calibrate.ui:40
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "_Пачаць"
 
 #. This resumes the calibration process
-#: panels/color/cc-color-calibrate.ui:54
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "_Узнавіць"
 
 #. This button returns the user back to the color control panel
-#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
-#: panels/user-accounts/cc-fingerprint-dialog.ui:73
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Гатова"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Экран ноўтбука"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Убудаваная вэб-камера"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Манітор %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Сканер %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Камера %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Прынтар %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Вэб-камера %s"
-
-#: panels/color/cc-color-device.c:90
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Уключыць кіраванне колерамі для %s"
-
-#: panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Паказаць колеравыя профілі для %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Не адкалібраваны"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:167
-msgid "Default: "
-msgstr "Прадвызначаны: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:175
-msgid "Colorspace: "
-msgstr "Колеравая прастора: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:182
-msgid "Test profile: "
-msgstr "Тэставы профіль: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:236
-msgid "Select ICC Profile File"
-msgstr "Выберыце файл профілю ICC"
-
-#: panels/color/cc-color-panel.c:239
-msgid "_Import"
-msgstr "І_мпартаваць"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:250
-msgid "Supported ICC profiles"
-msgstr "Вядомыя профілі ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:257
-#: panels/network/wireless-security/eap-method-fast.c:356
-msgid "All files"
-msgstr "Усе файлы"
-
-#: panels/color/cc-color-panel.c:549
-msgid "Screen"
-msgstr "Экран"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:839
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Не ўдалося запампаваць файл на сервер: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:851
-msgid "The profile has been uploaded to:"
-msgstr "Профіль запампаваны на:"
-
-#: panels/color/cc-color-panel.c:853
-msgid "Write down this URL."
-msgstr "Запішыце гэты URL-адрас."
-
-#: panels/color/cc-color-panel.c:854
-msgid "Restart this computer and boot your normal operating system."
-msgstr ""
-"Перазапусціце камп'ютар і загрузіце вашу звычайную аперацыйную сістэму."
-
-#: panels/color/cc-color-panel.c:855
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-"Увядзіце гэты URL-адрас у сваім браўзеры, каб спампаваць і ўсталяваць "
-"профіль."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:883
-msgid "Save Profile"
-msgstr "Захаваць профіль"
-
-#: panels/color/cc-color-panel.c:887
-#: panels/network/connection-editor/vpn-helpers.c:300
-#: panels/wwan/cc-wwan-apn-dialog.ui:64
-msgid "_Save"
-msgstr "_Захаваць"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1196
-msgid "Create a color profile for the selected device"
-msgstr "Стварыць колеравы профіль для вылучанай прылады"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1211 panels/color/cc-color-panel.c:1235
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Вымяральны інструмент не знойдзены. Праверце, што ён уключаны і правільна "
-"падлучаны."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1245
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Вымяральны інструмент не падтрымлівае прафілявання прынтараў."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1256
-msgid "The device type is not currently supported."
-msgstr "Гэты тып прылад зараз не падтрымліваецца."
-
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Каліброўка экрана"
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Якасць каліброўкі"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -796,42 +422,42 @@ msgstr ""
 "колерамі экрана. Чым болей часу выдаткавана на калібраванне, тым лепш якасць "
 "колеравага профілю."
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "Падчас калібравання вы не зможаце карыстацца камп'ютарам."
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Якасць"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Прыблізны час"
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr "Якасць каліброўкі"
-
-#: panels/color/cc-color-panel.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Выберыце вымяральную прыладу для каліброўкі."
-
-#: panels/color/cc-color-panel.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Калібравальная прылада"
 
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
-msgstr "Выберыце тып падлучанага дысплэя."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Выберыце вымяральную прыладу для каліброўкі."
 
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Тып дысплэя"
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Выберыце тып падлучанага дысплэя."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Профіль пункта белага"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -839,11 +465,11 @@ msgstr ""
 "Выберыце для дысплэя мэтавы пункт белага. Большасць дысплэяў калібруецца "
 "адносна крыніцы святла D65."
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
-msgstr "Профіль пункта белага"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Яркасць дысплэя"
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -851,7 +477,7 @@ msgstr ""
 "Задайце звыклую для вас яркасць дысплэя. Кіраванне колерамі будзе найбольш "
 "дакладным для гэтага ўзроўні яркасці."
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -859,11 +485,11 @@ msgstr ""
 "Таксама, вы можаце выкарыстаць узровень яркасці з іншага профілю для гэтай "
 "прылады."
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr "Яркасць дысплэя"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Назва профілю"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -871,285 +497,195 @@ msgstr ""
 "Колеравы профіль можа быць выкарыстаны на розных камп'ютарах. Таксама вы "
 "можаце стварыць розныя профілі для рознага асвятлення."
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Назва профілю:"
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "Назва профілю"
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Зводка"
 
-#: panels/color/cc-color-panel.ui:392
+#: panels/color/cc-color-panel.ui:259
 msgid "Profile successfully created!"
 msgstr "Профіль створаны!"
 
-#: panels/color/cc-color-panel.ui:443
+#: panels/color/cc-color-panel.ui:290
 msgid "Copy profile"
 msgstr "Скапіраваць профіль"
 
-#: panels/color/cc-color-panel.ui:456
+#: panels/color/cc-color-panel.ui:296
 msgid "Requires writable media"
 msgstr "Патрабуецца носьбіт з магчымасцю запісу"
 
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr "Запампаваць профіль"
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr "Патрабуецца інтэрнэт-злучэнне"
-
-#: panels/color/cc-color-panel.ui:591
+#: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Вам могуць прыдацца наступныя інструкцыі аб тым, як можна выкарыстаць гэты "
 "профіль на сістэмах <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple "
 "OS X</a> і <a href=\"windows\">Microsoft Windows</a>."
 
-#: panels/color/cc-color-panel.ui:607
-msgid "Summary"
-msgstr "Зводка"
-
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "Дадаць профіль"
 
-#: panels/color/cc-color-panel.ui:643
-msgid "_Import File…"
-msgstr "_Імпартаваць файл…"
-
-#: panels/color/cc-color-panel.ui:672 panels/keyboard/cc-input-chooser.ui:20
-#: panels/network/connection-editor/net-connection-editor.c:504
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr "_Дадаць"
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Выяўлены праблемы. Профіль можа працаваць няправільна. <a href="
-"\"\">Падрабязнасці.</a>"
+"Выяўлены праблемы. Профіль можа працаваць няправільна. <a "
+"href=\"\">Падрабязнасці.</a>"
 
-#: panels/color/cc-color-panel.ui:788
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Імпартаваць файл…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Дадаць"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Каб кіраваць колерамі, кожнай прыладзе трэба абнавіць колеравы профіль."
 
-#. translators: Text used in link to privacy policy
-#: panels/color/cc-color-panel.ui:810
-#: panels/diagnostics/cc-diagnostics-panel.c:144
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Даведацца больш"
 
-#: panels/color/cc-color-panel.ui:815
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Даведацца больш пра кіраванне колерам"
 
-#: panels/color/cc-color-panel.ui:863
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "_Устанавіць для ўсіх карыстальнікаў"
 
-#: panels/color/cc-color-panel.ui:867 panels/color/cc-color-panel.ui:882
-#: panels/color/cc-color-panel.ui:883
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Устанавіць гэты профіль для ўсіх карыстальнікаў гэтага камп'ютара"
 
-#: panels/color/cc-color-panel.ui:878
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "_Уключыць"
 
-#: panels/color/cc-color-panel.ui:909
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "_Дадаць профіль"
 
-#: panels/color/cc-color-panel.ui:922
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "_Адкалібраваць…"
 
-#: panels/color/cc-color-panel.ui:926
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Адкалібраваць прыладу"
 
-#: panels/color/cc-color-panel.ui:937
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "_Выдаліць профіль"
 
-#: panels/color/cc-color-panel.ui:950
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "_Паказаць падрабязнасці"
 
-#: panels/color/cc-color-panel.ui:986
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "Не ўдалося выявіць прылады, якія могуць кіраваць колерам"
 
-#: panels/color/cc-color-panel.ui:1030
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/cc-color-panel.ui:1035
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/cc-color-panel.ui:1040
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: panels/color/cc-color-panel.ui:1045
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Праектар"
 
-#: panels/color/cc-color-panel.ui:1050
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Плазма"
 
-#: panels/color/cc-color-panel.ui:1055
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (падсветка CCFL)"
 
-#: panels/color/cc-color-panel.ui:1060
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (падсветка RGB LED)"
 
-#: panels/color/cc-color-panel.ui:1065
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (белая падсветка LED)"
 
-#: panels/color/cc-color-panel.ui:1070
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Wide gamut LCD (падсветка CCFL)"
 
-#: panels/color/cc-color-panel.ui:1075
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Wide gamut LCD (падсветка RGB LED)"
 
-#: panels/color/cc-color-panel.ui:1092
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Высокая"
 
-#: panels/color/cc-color-panel.ui:1093
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 хвілін"
 
-#: panels/color/cc-color-panel.ui:1097
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Сярэдняя"
 
-#: panels/color/cc-color-panel.ui:1098
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 хвілін"
 
-#: panels/color/cc-color-panel.ui:1102
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Нізкая"
 
-#: panels/color/cc-color-panel.ui:1103
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 хвілін"
 
-#: panels/color/cc-color-panel.ui:1125
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Родная для гэтага дысплэя"
 
-#: panels/color/cc-color-panel.ui:1129
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (друк і кнігавыдавецтва)"
 
-#: panels/color/cc-color-panel.ui:1133
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/cc-color-panel.ui:1137
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (фатаграфія і графіка)"
 
-#: panels/color/cc-color-panel.ui:1141
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Стандартная прастора"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Праверачны профіль"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Аўтаматычны"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Нізкая якасць"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Сярэдняя якасць"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Высокая якасць"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Прадвызначаны RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Прадвызначаны CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Прадвызначаны шэры"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Калібравальныя даныя ад вытворцы"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Поўнаэкранная рэжым карэкцыі дысплэя з гэтым профілем немагчымы"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Гэты профіль ужо можа быць недакладным"
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1160,16 +696,11 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Калібраванне колераў прылад: дысплэяў, камер або прынтараў"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Calibrate;Колер;ICC;Колеравы;Профіль;Калібраванне;Каліброўка;Прынтар;Друк;"
 "Манітор;Экран;Дысплэй;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Іншая…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1179,309 +710,184 @@ msgstr "Выбраць мову"
 msgid "_Select"
 msgstr "_Выбраць"
 
-#: panels/common/cc-language-chooser.ui:69
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Мовы не знойдзены"
 
-#: panels/common/cc-language-chooser.ui:82
-#: panels/keyboard/cc-input-chooser.c:178
+#: panels/common/cc-language-chooser.ui:69
 msgid "More…"
 msgstr "Яшчэ…"
 
-#: panels/common/cc-permission-infobar.c:107
-msgid "Unlock to Change Settings"
-msgstr "Разблакіруйце, каб змяняць налады"
-
-#: panels/common/cc-permission-infobar.ui:20
-msgid "Unlock…"
-msgstr "Разблакіраваць…"
-
-#: panels/common/cc-permission-infobar.ui:56
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "Каб змяніць некаторыя налады, спачатку іх трэба разблакіраваць."
 
-#: panels/common/cc-time-editor.ui:33
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Разблакіраваць…"
+
+#: panels/common/cc-time-editor.ui:25
 msgid "Increment Hour"
 msgstr "Прыбавіць гадзіну"
 
-#: panels/common/cc-time-editor.ui:65
+#: panels/common/cc-time-editor.ui:53
 msgid "Increment Minute"
 msgstr "Прыбавіць хвіліну"
 
-#: panels/common/cc-time-editor.ui:80
+#: panels/common/cc-time-editor.ui:73
 msgid "Time"
 msgstr "Час"
 
-#: panels/common/cc-time-editor.ui:113
+#: panels/common/cc-time-editor.ui:94
 msgid "Decrement Hour"
 msgstr "Адняць гадзіну"
 
-#: panels/common/cc-time-editor.ui:145
+#: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Адняць хвіліну"
 
-#: panels/common/cc-time-entry.c:219
-msgid "_Copy"
-msgstr "_Капіяваць"
-
-#: panels/common/cc-time-entry.c:225
-msgid "Select _All"
-msgstr "Выбраць ус_е"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Сёння"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Учора"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%-d %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%-d %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d гадзіна"
-msgstr[1] "%d гадзіны"
-msgstr[2] "%d гадзін"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:973
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d хвіліна"
-msgstr[1] "%d хвіліны"
-msgstr[2] "%d хвілін"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d секунда"
-msgstr[1] "%d секунды"
-msgstr[2] "%d секунд"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 секунд"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Хот-спот"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:262
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:267
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:449
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:476
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:483
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:488
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:493
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:498
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "January"
-msgstr "Студзень"
-
-#: panels/datetime/cc-datetime-panel.ui:46
-msgid "February"
-msgstr "Люты"
-
-#: panels/datetime/cc-datetime-panel.ui:54
-msgid "March"
-msgstr "Сакавік"
-
-#: panels/datetime/cc-datetime-panel.ui:62
-msgid "April"
-msgstr "Красавік"
-
-#: panels/datetime/cc-datetime-panel.ui:70
-msgid "May"
-msgstr "Май"
-
-#: panels/datetime/cc-datetime-panel.ui:78
-msgid "June"
-msgstr "Чэрвень"
-
-#: panels/datetime/cc-datetime-panel.ui:86
-msgid "July"
-msgstr "Ліпень"
-
-#: panels/datetime/cc-datetime-panel.ui:94
-msgid "August"
-msgstr "Жнівень"
-
-#: panels/datetime/cc-datetime-panel.ui:102
-msgid "September"
-msgstr "Верасень"
-
-#: panels/datetime/cc-datetime-panel.ui:110
-msgid "October"
-msgstr "Кастрычнік"
-
-#: panels/datetime/cc-datetime-panel.ui:118
-msgid "November"
-msgstr "Лістапад"
-
-#: panels/datetime/cc-datetime-panel.ui:126
-msgid "December"
-msgstr "Снежань"
-
-#: panels/datetime/cc-datetime-panel.ui:136
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Дата і час"
 
-#: panels/datetime/cc-datetime-panel.ui:187
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "Год"
 
-#: panels/datetime/cc-datetime-panel.ui:220
+#: panels/datetime/cc-datetime-panel.ui:66
 msgid "Month"
 msgstr "Месяц"
 
-#: panels/datetime/cc-datetime-panel.ui:257
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Студзень"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Люты"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Сакавік"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Красавік"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Май"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Чэрвень"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Ліпень"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Жнівень"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Верасень"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Кастрычнік"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Лістапад"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Снежань"
+
+#: panels/datetime/cc-datetime-panel.ui:92
 msgid "Day"
 msgstr "Дзень"
 
-#: panels/datetime/cc-datetime-panel.ui:286
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Часавы пояс"
 
-#: panels/datetime/cc-datetime-panel.ui:307
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Пошук горада"
 
-#: panels/datetime/cc-datetime-panel.ui:375
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
 msgstr "_Аўтаматычнае вызначэнне даты і часу"
 
-#: panels/datetime/cc-datetime-panel.ui:376
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Патрабуецца доступ да інтэрнэту"
 
-#: panels/datetime/cc-datetime-panel.ui:396
-msgid "Date & _Time"
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
 msgstr "Дата і _час"
 
-#: panels/datetime/cc-datetime-panel.ui:430
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Аўтаматычнае _вызначэнне часавага пояса"
 
-#: panels/datetime/cc-datetime-panel.ui:431
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "Патрабуецца ўключэнне сэрвісаў месцазнаходжання і доступ да інтэрнэту"
 
-#: panels/datetime/cc-datetime-panel.ui:446
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Уключана"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Часавы п_ояс"
 
-#: panels/datetime/cc-datetime-panel.ui:481
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Разблакіраваць"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Фармат часу"
 
-#: panels/datetime/cc-datetime-panel.ui:490
-msgid "24-hour"
-msgstr "24 гадзіны"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:491
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Дата"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 секунд"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Каляндар"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Лікі"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Змяненне даты і часу, у тым ліку часавага пояса"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Гадзіннік;Часавы пояс;Месцазнаходжанне;Месца;"
@@ -1494,28 +900,28 @@ msgstr "Змяненне налад сістэмнага часу і даты"
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Каб змяніць час або дату, трэба прайсці праверку сапраўднасці."
 
-#: panels/default-apps/cc-default-apps-panel.ui:31
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "І_нтэрнэт"
 
-#: panels/default-apps/cc-default-apps-panel.ui:43
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "_Пошта"
 
-#: panels/default-apps/cc-default-apps-panel.ui:59
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "_Каляндар"
 
-#: panels/default-apps/cc-default-apps-panel.ui:75
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "_Музыка"
 
-#: panels/default-apps/cc-default-apps-panel.ui:91
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "_Відэа"
 
-#: panels/default-apps/cc-default-apps-panel.ui:162
-#: panels/removable-media/cc-removable-media-panel.ui:162
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "_Фота"
 
@@ -1527,26 +933,15 @@ msgstr "Прадвызначаныя праграмы"
 msgid "Configure Default Applications"
 msgstr "Канфігураваць прадвызначаныя праграмы"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "прадвызначаны;перадвызначаны;па змаўчанні;праграма;перавагі;медыя;"
 
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:146
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Справаздачы пра тэхнічныя праблемы дапамагаюць нам удасканальваць % s. Усе "
-"справаздачы адпраўляюцца ананімна і не змяшчаюць персанальных дадзеных. % s"
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:28
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
 msgstr "Справаздачы аб праблемах"
 
-#: panels/diagnostics/cc-diagnostics-panel.ui:65
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
 msgid "_Automatic Problem Reporting"
 msgstr "_Аўтаматычныя справаздачы аб праблемах"
 
@@ -1558,160 +953,116 @@ msgstr "Дыягностыка"
 msgid "Report your problems"
 msgstr "Паведаміць аб праблеме"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"экран;блакіраванне;заблакіраваць;дыягностыка;аварыя;прыватны;нядаўні;часовы;"
-"назва;імя;сетка;сеціва;ідэнтыфікацыя;асоба;прыватнасць;"
+msgid "diagnostics;crash;"
+msgstr "дыягностыка;збой;"
 
-#: panels/display/cc-display-panel.c:1017
-#: panels/network/connection-editor/connection-editor.ui:27
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Ужыць"
 
-#: panels/display/cc-display-panel.c:1038
-msgid "Apply Changes?"
-msgstr "Ужыць змены?"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Назад"
 
-#: panels/display/cc-display-panel.c:1043
-msgid "Changes Cannot be Applied"
-msgstr "Немагчыма ўжыць змены"
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Налады дысплэя адключаны"
 
-#: panels/display/cc-display-panel.c:1044
-msgid "This could be due to hardware limitations."
-msgstr "Магчыма, гэта з-за апаратных абмежаванняў."
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Некалькі дысплэяў"
 
-#: panels/display/cc-display-panel.ui:89
-msgid "Single Display"
-msgstr "Адзін дысплэй"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Аб'яднаць"
 
-#: panels/display/cc-display-panel.ui:108
-#: panels/display/cc-display-panel.ui:310
-msgid "Join Displays"
-msgstr "Аб'яднаць дысплэі"
-
-#: panels/display/cc-display-panel.ui:126
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Адлюстраванне"
 
-#: panels/display/cc-display-panel.ui:151
-msgid "Display Mode"
-msgstr "Рэжым манітора"
-
-#: panels/display/cc-display-panel.ui:220
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Змяшчае верхнюю панэль і меню Дзейнасць"
 
-#: panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Асноўны дысплэй"
 
-#: panels/display/cc-display-panel.ui:243
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
-msgstr ""
-"Перацягніце дысплэі адпаведна з іх рэальным размяшчэннем. Выберыце дысплэй, "
-"каб змяніць яго налады."
-
-#: panels/display/cc-display-panel.ui:250
-msgid "Display Arrangement"
-msgstr "Упарадкаванне дысплэяў"
-
-#: panels/display/cc-display-panel.ui:374
-msgid "Active Display"
-msgstr "Актыўны дысплэй"
-
-#: panels/display/cc-display-panel.ui:421
-msgid "Display Configuration"
-msgstr "Канфігурацыя дысплэя"
-
-#: panels/display/cc-display-panel.ui:440
-#: panels/display/gnome-display-panel.desktop.in.in:3
-msgid "Displays"
-msgstr "Дысплэі"
-
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:451
-#: panels/display/cc-night-light-page.ui:111
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Начное святло"
 
-#: panels/display/cc-display-settings.c:107
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Альбомная"
-
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Кніжная (на правы бок)"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Кніжная (на левы бок)"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Альбомная (перавернутая)"
-
-#: panels/display/cc-display-settings.c:190
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Гц"
-
-#: panels/display/cc-display-settings.ui:15
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Арыентацыя"
 
-#: panels/display/cc-display-settings.ui:24
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Раздзяляльнасць"
 
-#: panels/display/cc-display-settings.ui:33
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Частата абнаўлення"
 
-#: panels/display/cc-display-settings.ui:42
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Падстроіць для ТБ"
 
-#: panels/display/cc-display-settings.ui:59
-#: panels/display/cc-display-settings.ui:76
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Маштабаванне"
 
-#: panels/display/cc-night-light-page.c:627
-msgid "More Warm"
-msgstr "Больш цёплая"
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Натуральная прагортка"
 
-#: panels/display/cc-night-light-page.c:639
-msgid "Less Warm"
-msgstr "Менш цёплая"
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:28
-msgid "Restart Filter"
-msgstr "Перазапусціць фільтр"
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Начное святло недаступна"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Гэта можа адбывацца з-за выкарыстанага графічнага драйвера або выкарыстання "
+"аддаленага працоўнага стала"
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:61
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Часова адключана да заўтра"
 
-#: panels/display/cc-night-light-page.ui:88
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Перазапусціць фільтр"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1719,67 +1070,70 @@ msgstr ""
 "Начное святло робіць колеры на экране цяплейшымі. Гэта можа дапамагчы ад "
 "стамлення вачэй і бяссонніцы."
 
-#: panels/display/cc-night-light-page.ui:127
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Расклад"
 
-#: panels/display/cc-night-light-page.ui:136
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Ад заходу да ўсходу"
 
-#: panels/display/cc-night-light-page.ui:137
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Вызначаецца ўручную"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/region/cc-format-preview.ui:40
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Час"
 
-#: panels/display/cc-night-light-page.ui:165
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "З"
 
-#: panels/display/cc-night-light-page.ui:194
-#: panels/display/cc-night-light-page.ui:297
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Гадзіны"
 
-#: panels/display/cc-night-light-page.ui:203
-#: panels/display/cc-night-light-page.ui:306
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:222
-#: panels/display/cc-night-light-page.ui:325
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Хвіліны"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:234
-#: panels/display/cc-night-light-page.ui:337
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "AM"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:247
-#: panels/display/cc-night-light-page.ui:350
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PM"
 
-#: panels/display/cc-night-light-page.ui:267
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Да"
 
-#: panels/display/cc-night-light-page.ui:374
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Колеравая тэмпература"
 
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Дысплэі"
+
 #: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
-msgstr "Парадак выкарыстання падлучаных манітораў і праектары"
+msgstr "Выберыце як выкарыстоўваць падлучаныя маніторы і праектары"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1788,106 +1142,124 @@ msgstr ""
 "Панэль;Праектар;xrandr;Экран;Распазнавальнасць;Раздзяляльнасць;Разрознасць;"
 "Абнаўленне;Манітор;Ноч;Начное;Святло;колер;заход;усход;"
 
-#: panels/info-overview/cc-info-overview-panel.c:413
-#: panels/info-overview/cc-info-overview-panel.c:437
-#: panels/info-overview/cc-info-overview-panel.c:483
-#: panels/info-overview/cc-info-overview-panel.c:513
-#: panels/wwan/cc-wwan-details-dialog.c:101
-msgid "Unknown"
-msgstr "Невядома"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Secure boot прадухіляе загрузку шкоднага праграмнага забеспячэння падчас "
+"запуску прылады.\n"
+"\n"
+"Каб атрымаць дадатковыя звесткі, звярніцеся да вытворцы вашага абсталявання "
+"або да службы абслугоўвання і падтрымкі."
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:445
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; ID зборкі: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr "Узровень бяспекі"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:460
-#, c-format
-msgid "64-bit"
-msgstr "64-бітная"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Узровень 1"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:463
-#, c-format
-msgid "32-bit"
-msgstr "32-бітная"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Узровень 2"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Узровень 2"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Няма падзей"
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Невядома"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Бяспека прылады"
 
-#: panels/info-overview/cc-info-overview-panel.ui:52
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Статус бяспекі ўбудаванага ПЗ хоста"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"экран;блакіраванне;заблакіраваць;дыягностыка;аварыя;прыватны;нядаўні;часовы;"
+"назва;імя;сетка;сеціва;ідэнтыфікацыя;асоба;прыватнасць;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Імя прылады"
 
-#: panels/info-overview/cc-info-overview-panel.ui:74
+#: panels/info-overview/cc-info-overview-panel.ui:50
 msgid "Hardware Model"
 msgstr "Мадэль абсталявання"
 
-#: panels/info-overview/cc-info-overview-panel.ui:83
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "Памяць"
 
-#: panels/info-overview/cc-info-overview-panel.ui:92
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "Працэсар"
 
-#: panels/info-overview/cc-info-overview-panel.ui:101
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "Графіка"
 
-#: panels/info-overview/cc-info-overview-panel.ui:110
+#: panels/info-overview/cc-info-overview-panel.ui:82
 msgid "Disk Capacity"
 msgstr "Ёмістасць дыска"
 
-#: panels/info-overview/cc-info-overview-panel.ui:111
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "Вылічэнне…"
 
 #. translators: this field contains the distro name and version
-#: panels/info-overview/cc-info-overview-panel.ui:133
+#: panels/info-overview/cc-info-overview-panel.ui:98
 msgid "OS Name"
 msgstr "Назва АС"
 
-#: panels/info-overview/cc-info-overview-panel.ui:142
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID зборкі АС"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Тып АС"
 
-#: panels/info-overview/cc-info-overview-panel.ui:151
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Версія GNOME"
 
-#: panels/info-overview/cc-info-overview-panel.ui:161
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Загрузка…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Аконны інтэрфейс"
 
-#: panels/info-overview/cc-info-overview-panel.ui:169
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Віртуалізацыя"
 
-#: panels/info-overview/cc-info-overview-panel.ui:178
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Абнаўленне ПЗ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:199
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Перайменаваць прыладу"
 
-#: panels/info-overview/cc-info-overview-panel.ui:216
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1895,7 +1267,11 @@ msgstr ""
 "Імя прылады выкарыстоўваецца для яе апазнавання ў сетцы або пры спалучэнні "
 "прылад Bluetooth."
 
-#: panels/info-overview/cc-info-overview-panel.ui:234
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Імя прылады"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "_Перайменаваць"
 
@@ -1907,11 +1283,6 @@ msgstr "Інфармацыя"
 msgid "View information about your system"
 msgstr "Прагляд інфармацыі аб сістэме"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1970,7 +1341,7 @@ msgid "Eject"
 msgstr "Выняць"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:580
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Набор тэксту"
 
@@ -1989,6 +1360,12 @@ msgstr "Запуск праграм і функцый"
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Запусціць дапаможнік"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Налады"
 
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -2011,39 +1388,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Пошук"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "Здымкі экрана"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "Захаваць здымак экрана ў папцы $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Захаваць здымак акна ў папцы $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Захаваць здымак часткі экрана ў папцы $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "Скапіраваць здымак экрана ў буфер абмену"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Скапіраваць здымак акна ў буфер абмену"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Скапіраваць здымак часткі экрана ў буфер абмену"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "Запісаць кароткі скрынкаст"
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Сістэма"
 
@@ -2092,319 +1437,174 @@ msgstr "Паменшыць памер тэксту"
 msgid "High contrast on or off"
 msgstr "Уключыць/выключыць высокую кантраснасць"
 
-#: panels/keyboard/cc-input-chooser.c:193
-msgid "No input sources found"
-msgstr "Крыніцы ўводу не знойдзены"
-
-#: panels/keyboard/cc-input-chooser.c:964
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Іншы"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Дадаць крыніцу ўводу"
 
-#: panels/keyboard/cc-input-chooser.ui:77
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Метады ўводу немагчыма выкарыстоўваць на экране ўваходу"
 
-#: panels/keyboard/cc-input-list-box.ui:23
+#: panels/keyboard/cc-input-list-box.ui:24
 msgid "No input source selected"
 msgstr "Крыніца ўводу не выбрана"
 
-#: panels/keyboard/cc-input-row.ui:75
-msgid "Move up"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Параметры"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
 msgstr "Перамясціць вышэй"
 
-#: panels/keyboard/cc-input-row.ui:86
-msgid "Move down"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
 msgstr "Перамясціць ніжэй"
 
-#: panels/keyboard/cc-input-row.ui:103
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Параметры"
 
-#: panels/keyboard/cc-input-row.ui:120
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Прагляд раскладкі клавіятуры"
 
-#: panels/keyboard/cc-input-row.ui:137
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:286
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Выдаліць"
 
-#: panels/keyboard/cc-keyboard-manager.c:486
-#: panels/keyboard/cc-keyboard-manager.c:494
-#: panels/keyboard/cc-keyboard-manager.c:779
-msgid "Custom Shortcuts"
-msgstr "Кіраванне спалучэннямі клавіш"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.ui:213
-msgid "Alternate Characters Key"
-msgstr "Клавіша альтэрнатыўных сімвалаў"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Клавіша альтэрнатыўных сімвалаў можа выкарыстоўвацца для ўводу дадатковых "
-"сімвалаў. Яны часам нанесены на кнопках клавіятуры як трэці варыянт."
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Левы Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Правы Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:73
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Левы Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:74
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Правы Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:75
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Кнопка меню"
-
-#: panels/keyboard/cc-keyboard-panel.c:76
-#: panels/keyboard/cc-keyboard-panel.c:94
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Правы Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:84
-#: panels/keyboard/cc-keyboard-panel.ui:237
-msgid "Compose Key"
-msgstr "Клавіша Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Клавіша Compose дазваляе ўводзіць шмат самых разнастайных сімвалаў. Каб "
-"скарыстацца ёй, націсніце Compose, а затым паслядоўнасць сімвалаў. "
-"Напрыклад, калі націснуць клавішу Compose, а затым <b>C</b> і <b>o</b> "
-"атрымаецца <b>©</b>, <b>a</b> і ўслед <b>'</b> атрымаецца <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:95
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:96
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:97
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:233
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Крыніцы ўводу можна змяніць праз спалучэнне клавіш %s.\n"
-"Гэта спалучэнне таксама можна змяніць у наладах клавіятуры."
-
-#: panels/keyboard/cc-keyboard-panel.ui:48
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "Крыніцы ўводу"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:18
 msgid "Includes keyboard layouts and input methods."
 msgstr "Утрымлівае раскладкі клавіятуры і крыніцы ўводу."
 
-#: panels/keyboard/cc-keyboard-panel.ui:85
+#: panels/keyboard/cc-keyboard-panel.ui:28
 msgid "Input Source Switching"
 msgstr "Пераключэнне крыніцы ўводу"
 
-#: panels/keyboard/cc-keyboard-panel.ui:131
+#: panels/keyboard/cc-keyboard-panel.ui:31
 msgid "Use the _same source for all windows"
 msgstr "Выкарыстоўваць _адну крыніцу ўводу для ўсіх вокнаў"
 
-#: panels/keyboard/cc-keyboard-panel.ui:158
+#: panels/keyboard/cc-keyboard-panel.ui:43
 msgid "Switch input sources _individually for each window"
 msgstr "Пераключаць крыніцы ўводу _незалежна для кожнага акна"
 
-#: panels/keyboard/cc-keyboard-panel.ui:177
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Увод спецыяльных знакаў"
 
-#: panels/keyboard/cc-keyboard-panel.ui:188
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Спосабы ўводу сімвалаў і варыянтаў літар з клавіятуры."
 
-#: panels/keyboard/cc-keyboard-panel.ui:263
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:306
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:322 shell/cc-window.ui:326
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Клавіша альтэрнатыўных сімвалаў"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Клавіша Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Спалучэнні клавіш"
 
-#: panels/keyboard/cc-keyboard-panel.ui:283
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Прагляд і змяненне спалучэнняў клавіш"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:283
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d зменена"
-msgstr[1] "%d зменена"
-msgstr[2] "%d зменена"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Скінуць усе…"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:428
-msgid "Reset All Shortcuts?"
-msgstr "Скінуць усе спалучэнні клавіш?"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Скінуць усе спалучэнні клавіш на прадвызначаныя значэнні"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:431
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Скідванне спалучэнняў клавіш можа закрануць і ўласныя спалучэнні клавіш. "
-"Гэта дзеянне немагчыма адрабіць."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Раздзел"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:435
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:275
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-#: panels/wwan/cc-wwan-device-page.c:143
-msgid "Cancel"
-msgstr "Скасаваць"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Спалучэнні клавіш"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:436
-msgid "Reset All"
-msgstr "Скінуць усе"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Дадаць спалучэнне клавіш"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:115
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Дадаць уласныя спалучэнні клавіш"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:124
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "Задаць уласныя спалучэнні клавіш для запуску праграм, скрыптоў і іншых "
 "дзеянняў."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Дадаць спалучэнне клавіш"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:166
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Спалучэнне клавіш не знойдзена"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:211
-#: panels/region/cc-format-chooser.ui:48
-#: panels/user-accounts/cc-fingerprint-dialog.ui:53
-#: panels/wacom/wacom-stylus-page.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
-#: shell/cc-window.ui:230
-msgid "Back"
-msgstr "Назад"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Выдаліць"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:235
-msgid "Reset All…"
-msgstr "Скінуць усе…"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "За_мяніць"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:236
-msgid "Reset all shortcuts to their default keybindings"
-msgstr "Скінуць усе спалучэнні клавіш на прадвызначаныя значэнні"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "_Задаць"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:391
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s ужо выклікае функцыю %s. Калі вы націсніце замяніць, спалучэнне для "
-"функцыі %s будзе адключана"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:535
-msgid "Enter the new shortcut"
-msgstr "Увядзіце новае спалучэнне клавіш"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
-msgid "Set Custom Shortcut"
-msgstr "Задаць уласнае спалучэнне клавіш"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
-msgid "Set Shortcut"
-msgstr "Задаць спалучэнне клавіш"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:561
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Увядзіце новае спалучэнне клавіш для функцыі %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:987
-msgid "Add Custom Shortcut"
-msgstr "Дадаць уласнае спалучэнне клавіш"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:60
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr "Esc – адмена, Backspace – адключыць спалучэнне клавіш."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:135
-#: panels/printers/pp-details-dialog.ui:40
-#: panels/wwan/cc-wwan-apn-dialog.ui:132
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Назва"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:147
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Каманда"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:159
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Спалучэнне клавіш"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:238
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Задаць спалучэнне клавіш…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Няма"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:296
-#: panels/wwan/cc-wwan-apn-dialog.ui:44
-msgid "Add"
-msgstr "Дадаць"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:311
-msgid "Replace"
-msgstr "Замяніць"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:325
-msgid "Set"
-msgstr "Задаць"
-
-#: panels/keyboard/cc-keyboard-shortcut-row.ui:27
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Скінуць спалучэнне клавіш на прадвызначанае значэнне"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Прадвызначаны прынтар"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2418,7 +1618,6 @@ msgstr ""
 "Змяненне спалучэнняў клавіш, параметраў набору, клавіятурных раскладак і "
 "крыніц уводу"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2426,36 +1625,34 @@ msgstr ""
 "Скарот;Спалучэнне;клавішы;Працоўная;Прастора;Акно;Памер;Маштаб;Кантраснасць;"
 "Увод;Крыніца;Блакіроўка;Блакіраваць;Гучнасць;"
 
-#: panels/location/cc-location-panel.ui:31
-msgid "Location services turned off"
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
 msgstr "Сэрвісы месцазнаходжання выключаны"
 
-#: panels/location/cc-location-panel.ui:40
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Няма праграм, якія могуць атрымліваць звесткі пра месцазнаходжанне."
 
-#: panels/location/cc-location-panel.ui:72
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
 "Сэрвісы месцазнаходжання дазваляюць праграмам ведаць ваша месцазнаходжанне. "
 "Дакладнасць павялічваецца пры выкарыстанні Wi-Fi і шырокапалосага мабільнага "
-"злучэння."
+"злучэння.\n"
+"\n"
+"Выкарыстоўвацца сэрвіс месцазнаходжання Mozilla: <a href='https://location."
+"services.mozilla.com/privacy'>Палітыка прыватнасці</a>\n"
+"\n"
+"Дазволіць праграмам ніжэй вызначаць ваша месцазнаходжанне."
 
-#: panels/location/cc-location-panel.ui:81
-msgid ""
-"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
-msgstr ""
-"Выкарыстоўвае сэрвіс месцазнаходжання Mozilla. <a href='https://location."
-"services.mozilla.com/privacy'>Палітыка прыватнасці</a>"
-
-#: panels/location/cc-location-panel.ui:94
-msgid "Allow the applications below to determine your location."
-msgstr "Дазволіць праграмам ніжэй вызначаць ваша месцазнаходжанне."
-
-#: panels/location/cc-location-panel.ui:114
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Няма праграм, якія запыталі доступ да месцазнаходжання"
 
@@ -2463,190 +1660,32 @@ msgstr "Няма праграм, якія запыталі доступ да м�
 msgid "Protect your location information"
 msgstr "Абараніце звесткі пра сваё месцазнаходжанне"
 
-#. FIXME
-#: panels/lock/cc-lock-panel.ui:27
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
-msgstr ""
-"Аўтаматычнае блакіраванне экрана прадухіляе доступ да камп'ютара пабочным "
-"асобам, калі вы адышлі."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "месцазнаходжанне;gps;прыватнасць;канфідэнцыяльнасць;;"
 
-#: panels/lock/cc-lock-panel.ui:44
-msgid "Blank Screen Delay"
-msgstr "Затрымка да адключэння экрана"
-
-#: panels/lock/cc-lock-panel.ui:45
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Час бяздзейнасці пасля якога экран пагасне."
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Automatic Screen _Lock"
-msgstr "_Аўтаматычнае блакіраванне экрана"
-
-#: panels/lock/cc-lock-panel.ui:82
-msgid "Automatic _Screen Lock Delay"
-msgstr "Затрымка да аўтаматычнага блакіравання экрана"
-
-#: panels/lock/cc-lock-panel.ui:83
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "Час да аўтаматычнага блакіравання экрана пасля яго адключэння."
-
-#: panels/lock/cc-lock-panel.ui:103
-msgid "Show _Notifications on Lock Screen"
-msgstr "Паказваць _апавяшчэнні на экране блакіравання"
-
-#: panels/lock/cc-lock-panel.ui:120
-msgid "Forbid new _USB devices"
-msgstr "_Забараняць новыя USB-прылады"
-
-#: panels/lock/cc-lock-panel.ui:121
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Прадухіляе ўзаемадзеянне новых USB-прылад з сістэмай, калі экран "
-"заблакіраваны."
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:166
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Выключэнне экрана"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:170
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 секунд"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:174
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 хвіліна"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:178
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 хвіліны"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:182
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 хвіліны"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:186
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 хвілін"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:190
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 хвілін"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:194
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 гадзіна"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:209
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 хвіліна"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:213
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 хвіліны"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:217
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 хвіліны"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:221
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 хвіліны"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:225
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 хвілін"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:229
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 хвілін"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:233
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 хвілін"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:237
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 хвілін"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:241
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 хвілін"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:245
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Ніколі"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Блакіраванне экрана"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Заблакіраваць экран"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:34
-msgid "Microphone is turned off"
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
 msgstr "Мікрафон выключаны"
 
-#: panels/microphone/cc-microphone-panel.ui:43
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Няма праграм, якія могуць запісваць гук."
 
-#: panels/microphone/cc-microphone-panel.ui:75
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
-"properly."
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
 msgstr ""
 "Выкарыстанне мікрафона дазваляе праграмам запісваць і праслухваць гук. "
-"Адключэнне мікрафона можа прывесці да няправільнай працы некаторых праграм."
+"Адключэнне мікрафона можа прывесці да няправільнай працы некаторых праграм.\n"
+"\n"
+"Дазволіць пералічаным ніжэй праграмам выкарыстоўваць мікрафон."
 
-#: panels/microphone/cc-microphone-panel.ui:85
-msgid "Allow the applications below to use your microphone."
-msgstr "Дазволіць праграмам ніжэй выкарыстоўваць мікрафон."
-
-#: panels/microphone/cc-microphone-panel.ui:105
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Няма праграм, якія запыталі доступ да мікрафона"
 
@@ -2654,105 +1693,168 @@ msgstr "Няма праграм, якія запыталі доступ да м�
 msgid "Protect your conversations"
 msgstr "Абараніце свае размовы"
 
-#. FIXME
-#: panels/mouse/cc-mouse-panel.ui:37
-#: panels/multitasking/cc-multitasking-panel.ui:31
-msgid "General"
-msgstr "Агульныя"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "мікрафон;запіс;праграма;прыватнасць;"
 
-#: panels/mouse/cc-mouse-panel.ui:57
-msgid "Primary Button"
-msgstr "Асноўная кнопка"
-
-#: panels/mouse/cc-mouse-panel.ui:58
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "Задае парадак апаратных кнопак на мышы і сэнсарнай панэлі."
-
-#: panels/mouse/cc-mouse-panel.ui:84 panels/sound/cc-balance-slider.ui:13
-msgid "Left"
-msgstr "Левая"
-
-#: panels/mouse/cc-mouse-panel.ui:94 panels/sound/cc-balance-slider.ui:15
-msgid "Right"
-msgstr "Правая"
-
-#: panels/mouse/cc-mouse-panel.ui:122
-msgid "Mouse"
-msgstr "Мыш"
-
-#: panels/mouse/cc-mouse-panel.ui:142
-msgid "Mouse Speed"
-msgstr "Хуткасць указальніка мышы"
-
-#: panels/mouse/cc-mouse-panel.ui:154 panels/mouse/cc-mouse-panel.ui:258
-msgid "Double-click timeout"
-msgstr "Час на падвойнае націсканне"
-
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:166 panels/mouse/cc-mouse-panel.ui:230
-msgid "Natural Scrolling"
-msgstr "Натуральная прагортка"
-
-#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:231
-msgid "Scrolling moves the content, not the view."
-msgstr "Прагортка перамяшчае змесціва, а не паласу прагорткі (інверсія)."
-
-#: panels/mouse/cc-mouse-panel.ui:193 panels/mouse/cc-mouse-panel.ui:213
-msgid "Touchpad"
-msgstr "Сэнсарная панэль"
-
-#: panels/mouse/cc-mouse-panel.ui:247
-msgid "Touchpad Speed"
-msgstr "Хуткасць указальніка сэнсарнай панэлі"
-
-#: panels/mouse/cc-mouse-panel.ui:270
-msgid "Tap to Click"
-msgstr "Націсканне дотыкам"
-
-#: panels/mouse/cc-mouse-panel.ui:286
-msgid "Two-finger Scrolling"
-msgstr "Прагортка двума пальцамі"
-
-#: panels/mouse/cc-mouse-panel.ui:303
-msgid "Edge Scrolling"
-msgstr "Прагортка па краі"
-
-#: panels/mouse/cc-mouse-panel.ui:335 panels/wacom/cc-wacom-panel.c:441
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "_Праверыць налады"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:25
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Агульныя"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Асноўная кнопка"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Задае парадак апаратных кнопак на мышы і сэнсарнай панэлі."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Левая"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Правая"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Месцы пошуку"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Мыш"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "Хуткасць указальніка мышы"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Раздзел"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "Прагортка перамяшчае змесціва, а не паласу прагорткі (інверсія)."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Прагортка перамяшчае змесціва, а не паласу прагорткі (інверсія)."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Актыўна"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Сэнсарная панэль"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "Хуткасць указальніка сэнсарнай панэлі"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "Націсканне дотыкам"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr "Націсканне дотыкам"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Сэнсарная панэль (адносныя каардынаты)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Прагортка па краі"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "З двух бакоў"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Паспрабуйце зрабіць адзінарнае і падвойнае націсканне, прагортку"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Пяць націсканняў – час GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Падвойнае націсканне, асноўная кнопка"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Адзінарнае націсканне, асноўная кнопка"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Падвойнае націсканне, сярэдняя кнопка"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Адзінарнае націсканне, сярэдняя кнопка"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Падвойнае націсканне, другая кнопка"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Адзінарнае націсканне, другая кнопка"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2764,77 +1866,76 @@ msgid ""
 msgstr ""
 "Змяненне адчувальнасці мышы і сэнсарнай панэлі, налады для ляўшы або праўшы"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 "Trackpad;Трэкпад;Тачпад;Чулая;Сэнсарная;панэль;Паказальнік;Падвойнае;"
 "Націсканне;Пстрычка;Дотык;Кнопка;Трэкбол;Пракрутка;Прагортка;"
 
-#: panels/multitasking/cc-multitasking-panel.ui:56
+#: panels/multitasking/cc-multitasking-panel.ui:15
 msgid "_Hot Corner"
 msgstr "Актыўны _кут"
 
-#: panels/multitasking/cc-multitasking-panel.ui:57
+#: panels/multitasking/cc-multitasking-panel.ui:16
 msgid "Touch the top-left corner to open the Activities Overview."
 msgstr "Крананне верхняга левага кута адкрывае меню Агляд дзейнасці."
 
-#: panels/multitasking/cc-multitasking-panel.ui:84
+#: panels/multitasking/cc-multitasking-panel.ui:42
 msgid "_Active Screen Edges"
 msgstr "_Актыўныя краі экрана"
 
-#: panels/multitasking/cc-multitasking-panel.ui:85
+#: panels/multitasking/cc-multitasking-panel.ui:43
 msgid ""
 "Drag windows against the top, left, and right screen edges to resize them."
 msgstr ""
 "Каб змяніць памер акна, перацягніце яго да верхняга, левага ці правага краю "
 "экрана."
 
-#: panels/multitasking/cc-multitasking-panel.ui:114
+#: panels/multitasking/cc-multitasking-panel.ui:70
 msgid "Workspaces"
 msgstr "Працоўныя прасторы"
 
-#: panels/multitasking/cc-multitasking-panel.ui:139
+#: panels/multitasking/cc-multitasking-panel.ui:76
 msgid "_Dynamic workspaces"
 msgstr "_Дынамічныя працоўныя прасторы"
 
-#: panels/multitasking/cc-multitasking-panel.ui:140
+#: panels/multitasking/cc-multitasking-panel.ui:77
 msgid "Automatically removes empty workspaces."
 msgstr "Пустыя працоўныя прасторы выдаляюцца аўтаматычна."
 
-#: panels/multitasking/cc-multitasking-panel.ui:158
+#: panels/multitasking/cc-multitasking-panel.ui:91
 msgid "_Fixed number of workspaces"
 msgstr "_Фіксаваная колькасць працоўных прастор"
 
-#: panels/multitasking/cc-multitasking-panel.ui:159
+#: panels/multitasking/cc-multitasking-panel.ui:92
 msgid "Specify a number of permanent workspaces."
 msgstr "Вызначыце колькасць пастаянных працоўных прастор."
 
-#: panels/multitasking/cc-multitasking-panel.ui:179
+#: panels/multitasking/cc-multitasking-panel.ui:108
 msgid "_Number of Workspaces"
 msgstr "_Колькасць працоўных прастор"
 
-#: panels/multitasking/cc-multitasking-panel.ui:200
+#: panels/multitasking/cc-multitasking-panel.ui:124
 msgid "Multi-Monitor"
 msgstr "Некалькі манітораў"
 
-#: panels/multitasking/cc-multitasking-panel.ui:225
+#: panels/multitasking/cc-multitasking-panel.ui:130
 msgid "Workspaces on _primary display only"
 msgstr "Працоўныя прасторы толькі на _асноўным дысплэі"
 
-#: panels/multitasking/cc-multitasking-panel.ui:252
+#: panels/multitasking/cc-multitasking-panel.ui:156
 msgid "Workspaces on all d_isplays"
 msgstr "Працоўныя прасторы на _ўсіх дысплэях"
 
-#: panels/multitasking/cc-multitasking-panel.ui:282
+#: panels/multitasking/cc-multitasking-panel.ui:184
 msgid "Application Switching"
 msgstr "Пераключэнне паміж праграмамі"
 
-#: panels/multitasking/cc-multitasking-panel.ui:307
+#: panels/multitasking/cc-multitasking-panel.ui:190
 msgid "Include applications from all _workspaces"
 msgstr "Уключаць праграмы з усіх працоўных прастор"
 
-#: panels/multitasking/cc-multitasking-panel.ui:325
+#: panels/multitasking/cc-multitasking-panel.ui:204
 msgid "Include applications from the _current workspace only"
 msgstr "Уключаць толькі праграмы з бягучай працоўнай прасторы"
 
@@ -2846,97 +1947,53 @@ msgstr "Шматзадачнасць"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Кіраванне параметрамі прадукцыйнасці і шматзадачнасці"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
-msgstr "Шматзадачнасць;Прадукцыйнасць;Працоўны стол;Кастамізацыя;"
-
-#: panels/network/cc-network-panel.c:686 panels/network/cc-wifi-panel.ui:307
-msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
-"Нешта пайшло не так. Звяжыцеся з пастаўшчыком праграмнага забеспячэння."
+"Шматзадачнасць;Прадукцыйнасць;Працоўны стол;Кастамізацыя;Актыўны кут;Гарачы "
+"кут;Працоўныя прасторы;"
 
-#: panels/network/cc-network-panel.c:692
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager павінен быць запушчаны."
-
-#: panels/network/cc-network-panel.ui:66
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Іншыя прылады"
 
-#: panels/network/cc-network-panel.ui:107
-#: panels/network/connection-editor/net-connection-editor.c:587
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:151
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Дадаць злучэнне"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Не наладжана"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:262
-msgid "Insecure network (WEP)"
-msgstr "Небяспечная сетка (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "Бяспечная сетка (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:272
-msgid "Secure network (WPA2)"
-msgstr "Бяспечная сетка (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:277
-msgid "Secure network (WPA3)"
-msgstr "Бяспечная сетка (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:282
-msgid "Secure network"
-msgstr "Бяспечная сетка"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:68 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Злучана"
 
-#: panels/network/cc-wifi-connection-row.ui:102
-#: panels/network/net-device-ethernet.c:333
-#: panels/network/network-bluetooth.ui:76
-#: panels/network/network-ethernet.ui:111 panels/network/network-mobile.ui:450
-#: panels/network/network-vpn.ui:77
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Параметры…"
 
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:134
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Уключэнне хот-спота, адлучыць %s, доступ да інтэрнэту праз Wi-Fi будзе "
-"немагчымы."
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Павінен змяшчаць не больш за %d сімвал"
+msgstr[1] "Павінен змяшчаць не больш за %d сімвалы"
+msgstr[2] "Павінен змяшчаць не больш за %d сімвалаў"
 
-#: panels/network/cc-wifi-hotspot-dialog.c:267
-msgid "Must have a minimum of 8 characters"
-msgstr "Павінен змяшчаць не менш за 8 сімвалаў"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:272
-#, c-format
-msgid "Must have a maximum of %d characters"
-msgstr "Павінен змяшчаць не больш за %d сімвалаў"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:488
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
 msgid "Turn On Wi-Fi Hotspot?"
 msgstr "Уключыць Wi-Fi хот-спот?"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:19
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
 "Wi-Fi hotspot allows others to share your internet connection, by creating a "
 "Wi-Fi network that they can connect to. To do this, you must have an "
@@ -2946,176 +2003,88 @@ msgstr ""
 "Ствараецца сетка Wi-Fi, да якой могуць падключыцца іншыя людзі. Для гэтага "
 "вы павінны быць падключаны да інтэрнэту любым метадам акрамя Wi-Fi."
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:44
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
 msgstr "Назва сеткі"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:69
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:389
-#: panels/printers/pp-jobs-dialog.ui:70
-#: panels/user-accounts/cc-add-user-dialog.ui:249
-#: panels/wwan/cc-wwan-apn-dialog.ui:214
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Пароль"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:83
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Генерыраваць выпадковы пароль"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:84
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Аўтаматычна генерыраваць пароль"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:130
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Уключыць"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:53
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:864
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Спыніць хот-спот і адлучыць усіх карыстальнікаў?"
-
-#: panels/network/cc-wifi-panel.c:867
-msgid "_Stop Hotspot"
-msgstr "_Спыніць хот-спот"
-
-#: panels/network/cc-wifi-panel.ui:46
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Рэжым палёту"
 
-#: panels/network/cc-wifi-panel.ui:47
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Адключыць Wi-Fi, Bluetooth і мабільнае шырокапалоснае злучэнне"
 
-#: panels/network/cc-wifi-panel.ui:87
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Адаптар Wi-Fi не знойдзены"
 
-#: panels/network/cc-wifi-panel.ui:99
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Праверце, ці падключаны адаптар Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:134 panels/wwan/cc-wwan-panel.ui:143
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Рэжым палёту ўключаны"
 
-#: panels/network/cc-wifi-panel.ui:146
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Выключыць, каб карыстацца Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:184
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Хот-спот Wi-Fi актыўны"
 
-#: panels/network/cc-wifi-panel.ui:195
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Каб падлучыцца, мабільныя прылады могуць адсканаваць QR-код."
 
-#: panels/network/cc-wifi-panel.ui:205
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Уключыць хот-спот…"
 
-#: panels/network/cc-wifi-panel.ui:227
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Бачныя сеткі"
 
-#: panels/network/cc-wifi-panel.ui:296
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager павінен быць запушчаны"
 
-#: panels/network/connection-editor/8021x-security-page.ui:20
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Нешта пайшло не так. Звяжыцеся з пастаўшчыком праграмнага забеспячэння."
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Бяспека 802.1x"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:112
-#: panels/network/connection-editor/ce-page-security.c:424
-#: panels/network/connection-editor/details-page.ui:90
-msgid "Security"
-msgstr "Бяспека"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Не змяняць"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Пастаянны"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Выпадковы"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Стабільны"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Уведзены тут MAC-адрас будзе выкарыстоўвацца як апаратны адрас для сеткавай "
-"прылады, якая ўсталявала злучэнне. Гэта функцыя вядома як кланіраванне або "
-"падмена MAC-адраса. Прыклад: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Профіль %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:228
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:233
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:279
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:218
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Няма"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Ніколі"
-
-#: panels/network/connection-editor/ce-page-details.c:166
-#: panels/network/net-device-ethernet.c:108
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
@@ -3123,956 +2092,365 @@ msgstr[0] "%i дзень таму"
 msgstr[1] "%i дні таму"
 msgstr[2] "%i дзён таму"
 
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Мб/с (%1.1f ГГц)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:220
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Мб/с"
-
-#: panels/network/connection-editor/ce-page-details.c:308
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 ГГц / 5 ГГц"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz"
-msgstr "2.4 ГГц"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "5 GHz"
-msgstr "5 ГГц"
-
-#: panels/network/connection-editor/ce-page-details.c:332
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Няма"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Слабы"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Сярэдні"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Добры"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Выдатны"
-
-#: panels/network/connection-editor/ce-page-details.c:407
-#: panels/network/connection-editor/details-page.ui:108
-#: panels/network/net-device-ethernet.c:147
-#: panels/network/net-device-mobile.c:442
-msgid "IPv4 Address"
-msgstr "IPv4-адрас"
-
-#: panels/network/connection-editor/ce-page-details.c:408
-#: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-mobile.c:443 panels/network/network-mobile.ui:218
-msgid "IPv6 Address"
-msgstr "IPv6-адрас"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/ce-page-details.c:411
-#: panels/network/net-device-ethernet.c:152
-#: panels/network/net-device-ethernet.c:154
-#: panels/network/net-device-mobile.c:446
-#: panels/network/net-device-mobile.c:447 panels/network/network-mobile.ui:201
-msgid "IP Address"
-msgstr "IP-адрас"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-mobile.c:451
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/net-device-ethernet.c:170
-#: panels/network/net-device-mobile.c:452
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/connection-editor/details-page.ui:199
-#: panels/network/connection-editor/details-page.ui:218
-#: panels/network/connection-editor/ip4-page.ui:211
-#: panels/network/connection-editor/ip6-page.ui:225
-#: panels/network/net-device-ethernet.c:172
-#: panels/network/net-device-ethernet.c:174
-#: panels/network/net-device-mobile.c:454
-#: panels/network/net-device-mobile.c:455 panels/network/network-mobile.ui:253
-#: panels/network/network-mobile.ui:271
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:471
-msgid "Forget Connection"
-msgstr "Забыць злучэнне"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Remove Connection Profile"
-msgstr "Выдаліць профіль злучэння"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove VPN"
-msgstr "Выдаліць VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:493
-msgid "Details"
-msgstr "Падрабязнасці"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "аўтаматычна"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:150
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Ідэнтычнасць"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Выдаліць адрас"
-
-#: panels/network/connection-editor/ce-page-ip4.c:400
-#: panels/network/connection-editor/ce-page-ip6.c:370
-msgid "Delete Route"
-msgstr "Выдаліць маршрут"
-
-#: panels/network/connection-editor/ce-page-ip4.c:754
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:726
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:268
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Няма"
-
-#: panels/network/connection-editor/ce-page-security.c:303
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP, 40/128-бітны ключ (Hex або ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:313
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP, 128-бітная парольная фраза"
-
-#: panels/network/connection-editor/ce-page-security.c:326
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:339
-msgid "Dynamic WEP (802.1x)"
-msgstr "Дынамічны WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:353
-msgid "WPA & WPA2 Personal"
-msgstr "WPA і WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:367
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA і WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:381
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
-
-#: panels/network/connection-editor/details-page.ui:18
-#: panels/wwan/cc-wwan-details-dialog.ui:105
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Сіла сігналу"
 
-#: panels/network/connection-editor/details-page.ui:54
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Хуткасць сувязі"
 
-#: panels/network/connection-editor/details-page.ui:144
-#: panels/network/net-device-ethernet.c:157
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Бяспека"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4-адрас"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-адрас"
+
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Апаратны адрас"
 
-#: panels/network/connection-editor/details-page.ui:162
+#: panels/network/connection-editor/details-page.ui:142
 msgid "Supported Frequencies"
 msgstr "Падтрымліваюцца частоты"
 
-#: panels/network/connection-editor/details-page.ui:180
-#: panels/network/net-device-ethernet.c:161
-#: panels/network/net-device-ethernet.c:163
-#: panels/network/net-device-ethernet.c:165
-#: panels/network/network-mobile.ui:235
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Прадвызначаны маршрут"
 
-#: panels/network/connection-editor/details-page.ui:236
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Апошняе выкарыстанне"
 
-#: panels/network/connection-editor/details-page.ui:415
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "_Злучацца аўтаматычна"
 
-#: panels/network/connection-editor/details-page.ui:434
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Зрабіць даступным іншым _карыстальнікам"
 
-#: panels/network/connection-editor/details-page.ui:467
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 "_ Злучэнне з тарыфікацыяй: маецца ліміт перадачы даных або можа спаганяцца "
 "плата"
 
-#: panels/network/connection-editor/details-page.ui:478
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
 "Абнаўленне праграмнага забеспячэння і іншыя спампоўванні вялікага памеру не "
 "будуць запускацца аўтаматычна."
 
-#: panels/network/connection-editor/ethernet-page.ui:25
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Назва"
 
-#: panels/network/connection-editor/ethernet-page.ui:54
-#: panels/network/connection-editor/wifi-page.ui:67
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "MAC-_адрас"
 
-#: panels/network/connection-editor/ethernet-page.ui:105
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "_MTU"
 
-#: panels/network/connection-editor/ethernet-page.ui:122
-#: panels/network/connection-editor/wifi-page.ui:102
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "_Кланіраваны адрас"
 
-#: panels/network/connection-editor/ethernet-page.ui:137
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "байтаў"
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "Метад IPv_4"
 
-#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "Аўтаматычна (DHCP)"
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "Толькі лакальная сувязь"
 
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:118
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Уручную"
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "Адключыць"
 
-#: panels/network/connection-editor/ip4-page.ui:97
-#: panels/network/connection-editor/ip6-page.ui:111
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
 msgid "Shared to other computers"
 msgstr "Агульны доступ для іншых камп'ютараў"
 
-#: panels/network/connection-editor/ip4-page.ui:125
-#: panels/network/connection-editor/ip6-page.ui:139
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "Адрасы"
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
-#: panels/printers/pp-details-dialog.ui:95
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Адрас"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Маска сеткі"
 
-#: panels/network/connection-editor/ip4-page.ui:171
-#: panels/network/connection-editor/ip4-page.ui:355
-#: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:369
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Шлюз"
 
-#: panels/network/connection-editor/ip4-page.ui:223
-#: panels/network/connection-editor/ip4-page.ui:291
-#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/connection-editor/ip6-page.ui:305
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:107
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "Аўтаматычна"
 
-#: panels/network/connection-editor/ip4-page.ui:234
-#: panels/network/connection-editor/ip6-page.ui:248
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "Аўтаматычны DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:258
-#: panels/network/connection-editor/ip6-page.ui:272
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Адрас(ы) сервера DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Раздзяляйце IP-адрасы коскамі"
 
-#: panels/network/connection-editor/ip4-page.ui:279
-#: panels/network/connection-editor/ip6-page.ui:293
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Маршруты"
 
-#: panels/network/connection-editor/ip4-page.ui:302
-#: panels/network/connection-editor/ip6-page.ui:316
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Аўтаматычныя маршруты"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:368
-#: panels/network/connection-editor/ip6-page.ui:382
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Метрыка"
 
-#: panels/network/connection-editor/ip4-page.ui:398
-#: panels/network/connection-editor/ip6-page.ui:412
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "_Выкарыстоўваць злучэнне толькі для рэсурсаў у гэтай сетцы"
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "Метад IPv_6"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "Аўтаматычна, толькі DHCP"
 
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Прэфікс"
 
-#: panels/network/connection-editor/net-connection-editor.c:280
-msgid "Unable to open connection editor"
-msgstr "Немагчыма адкрыць рэдактар злучэння"
-
-#: panels/network/connection-editor/net-connection-editor.c:296
-msgid "New Profile"
-msgstr "Новы профіль"
-
-#: panels/network/connection-editor/net-connection-editor.c:731
-msgid "Import from file…"
-msgstr "Імпартаваць з файла…"
-
-#: panels/network/connection-editor/net-connection-editor.c:763
-msgid "Add VPN"
-msgstr "Дадаць VPN"
-
-#: panels/network/connection-editor/security-page.ui:20
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Бяспека"
 
-#: panels/network/connection-editor/vpn-helpers.c:139
-msgid "Cannot import VPN connection"
-msgstr "Немагчыма імпартаваць VPN-злучэнне"
-
-#: panels/network/connection-editor/vpn-helpers.c:141
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Не ўдалося прачытаць файл «%s» або ён не змяшчае зразумелай інфармацыі аб "
-"VPN-злучэнні\n"
-"\n"
-"Памылка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:173
-msgid "Select file to import"
-msgstr "Выберыце які файл імпартаваць"
-
-#: panels/network/connection-editor/vpn-helpers.c:225
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Файл з назвай «%s» ужо існуе."
-
-#: panels/network/connection-editor/vpn-helpers.c:227
-msgid "_Replace"
-msgstr "_Замяніць"
-
-#: panels/network/connection-editor/vpn-helpers.c:229
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Замяніць %s VPN-злучэннем, якое вы захоўваеце?"
-
-#: panels/network/connection-editor/vpn-helpers.c:264
-msgid "Cannot export VPN connection"
-msgstr "Немагчыма экспартаваць VPN-злучэнне"
-
-#: panels/network/connection-editor/vpn-helpers.c:266
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Не ўдалося экспартаваць VPN-злучэнне «%s» у %s.\n"
-"\n"
-"Памылка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:296
-msgid "Export VPN connection"
-msgstr "Экспартаваць VPN-злучэнне"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(Памылка. Не ўдалося загрузіць рэдактар VPN-злучэння)"
 
-#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Сетка"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Налады злучэння з інтэрнэтам"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;сетка;проксі;"
 "блютуз;мадэм;мабільнае;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Налады злучэння з сеткамі Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;DNS;Hotspot;хотспот;хот-спот;пункт "
 "доступу;бесправадная;сетка;"
 
-#: panels/network/net-device-ethernet.c:96
-msgid "never"
-msgstr "ніколі"
-
-#: panels/network/net-device-ethernet.c:104
-msgid "today"
-msgstr "сёння"
-
-#: panels/network/net-device-ethernet.c:106
-msgid "yesterday"
-msgstr "учора"
-
-#: panels/network/net-device-ethernet.c:180
-msgid "Last used"
-msgstr "Апошняе выкарыстанне"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:267
-#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Правадное"
 
-#: panels/network/net-device-mobile.c:209
-msgid "Add new connection"
-msgstr "Дадаць новае злучэнне"
-
-#: panels/network/net-device-wifi.c:851
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Сеткавыя звесткі для вылучаныя сетак, у тым ліку паролі і карыстальніцкія "
-"налады, будуць страчаны."
-
-#: panels/network/net-device-wifi.c:855
-msgid "_Forget"
-msgstr "_Забыць"
-
-#: panels/network/net-device-wifi.c:1034 panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Вядомыя сеткі Wi-Fi"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1076
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Забыць"
-
-#: panels/network/net-device-wifi.c:1217
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Палітыка сістэмы забараняе рэжым хот-спота"
-
-#: panels/network/net-device-wifi.c:1220
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Бесправадная прылада не падтрымлівае рэжым хот-спота"
-
-#: panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:260
-#: panels/power/cc-power-panel.c:856 panels/power/cc-power-panel.c:867
-#: panels/universal-access/cc-ua-panel.c:331
-#: panels/universal-access/cc-ua-panel.c:612
-#: panels/universal-access/cc-ua-panel.c:622
-#: panels/universal-access/cc-ua-panel.c:634
-#: panels/universal-access/cc-ua-panel.c:677
-#: panels/universal-access/cc-ua-panel.ui:338
-#: panels/universal-access/cc-ua-panel.ui:384
-#: panels/universal-access/cc-ua-panel.ui:430
-#: panels/universal-access/cc-ua-panel.ui:536
-#: panels/universal-access/cc-ua-panel.ui:689
-#: panels/universal-access/cc-ua-panel.ui:735
-#: panels/universal-access/cc-ua-panel.ui:781
-#: panels/universal-access/cc-ua-panel.ui:965
-msgid "Off"
-msgstr "Выключана"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Калі URL-адрас канфігурацыі не вызначаны, выкарыстоўваецца механізм "
-"аўтаматычнага пошуку сеціўнага проксі-сервера."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Не рэкамендавана для ненадзейных публічных сетак."
-
-#. update title
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/net-vpn.c:65 panels/network/net-vpn.c:158
-#, c-format
-msgid "%s VPN"
-msgstr "VPN %s"
-
-#: panels/network/network-bluetooth.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Выключыць прыладу"
 
-#: panels/network/network-mobile.ui:29
-#: panels/wwan/cc-wwan-details-dialog.ui:286
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Актыўна"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
-#: panels/network/network-mobile.ui:47
+#: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Правайдар"
 
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:96
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-адрас"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Сеткавы проксі-сервер"
 
-#: panels/network/network-proxy.ui:180
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "Прок_сі-сервер НТТР"
 
-#: panels/network/network-proxy.ui:199
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "Пр_оксі-сервер НТТРS"
 
-#: panels/network/network-proxy.ui:218
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "Про_ксі-сервер FTP"
 
-#: panels/network/network-proxy.ui:237
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "_Хост Socks"
 
-#: panels/network/network-proxy.ui:256
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "І_гнараваць хосты"
 
-#: panels/network/network-proxy.ui:294
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Порт проксі-сервера НТТР"
 
-#: panels/network/network-proxy.ui:371
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Порт проксі-сервера НТТРS"
 
-#: panels/network/network-proxy.ui:392
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Порт проксі-сервера FTP"
 
-#: panels/network/network-proxy.ui:413
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Порт проксі-сервера Socks"
 
-#: panels/network/network-proxy.ui:442
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "_URL-адрас налад"
 
-#: panels/network/network-vpn.ui:56
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "Выключыць VPN-злучэнне"
 
-#: panels/network/network-wifi.ui:22
+#: panels/network/network-wifi.ui:34
 msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Назва сеткі"
 
-#: panels/network/network-wifi.ui:28
+#: panels/network/network-wifi.ui:40
 msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Тып бяспекі"
 
-#: panels/network/network-wifi.ui:34
+#: panels/network/network-wifi.ui:46
 msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Пароль"
 
-#: panels/network/network-wifi.ui:84
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Выключыць Wi-Fi"
 
-#: panels/network/network-wifi.ui:116
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Больш параметраў…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Злучыцца са схаванай сеткай…"
 
-#: panels/network/network-wifi.ui:127
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Уключыць хот-спот Wi-Fi…"
 
-#: panels/network/network-wifi.ui:138
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Вядомыя сеткі Wi-Fi"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Невядомы стан"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Некіруемае"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Недаступна"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Злучэнне"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Патрабуецца праверка сапраўднасці"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Адлучэнне"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Не ўдалося злучыцца"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Невядомы стан (адсутнічае)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Не ўдалося наладзіць"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Не ўдалося наладзіць IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Налады IP састарэлі"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Паролі патрабуюцца, але яны адсутнічаюць"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Кліент 802.1x адлучаны"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Памылка канфігурацыі кліента 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Памылка кліента 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Занадта доўгае пацвярджэнне сапраўднасці кліента 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Не ўдалося запусціць сэрвіс PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Сэрвіс PPP адлучаны"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Памылка PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Не ўдалося запусціць DHCP-кліента"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Памылка DHCP-кліента"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Памылка DHCP-кліента"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Не ўдалося запусціць сэрвіс супольнага выкарыстання злучэння"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Памылка сэрвісу супольнага выкарыстання злучэння"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Не ўдалося запусціць сэрвіс AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Памылка сэрвісу AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Памылка сэрвісу AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Лінія занята"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Няма гудка"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Не ўдалося ўсталяваць канал сувязі"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Скончыўся тэрмін чакання для набора нумара"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Не ўдалося набраць нумар"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Не ўдалося ініцыялізаваць мадэм"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Не ўдалося выбраць вызначаны APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Пошук сетак не ажыццяўляецца"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Адмоўлена ў сеткавай рэгістрацыі"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Скончыўся тэрмін чакання сеткавай рэгістрацыі"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Не ўдалося зарэгістравацца ў запытанай сетцы"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Няўдалая праверка PIN-кода"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Убудаванае ПЗ прылады можа адсутнічаць"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Злучэнне знікла"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Чакалася наяўнасць злучэння"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Мадэм не знойдзены"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Памылка Bluetooth-злучэння"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM-карта не ўстаўлена"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Патрабуецца PIN-код SIM-карты"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Патрабуецца PUK-код SIM-карты"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Памылка SIM-карты"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Збой залежнасці злучэння"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Убудаванае ПЗ адсутнічае"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Кабель адключаны"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "невядомая памылка бяспекі 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:195
-msgid "no file selected"
-msgstr "файлы не выбраны"
-
-#: panels/network/wireless-security/eap-method.c:222
-msgid "unspecified error validating eap-method file"
-msgstr "нявызначаная памылка праверкі файла eap-method"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "закрытыя ключы DER, PEM або PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:400
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "сертыфікаты DER і PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:87
-msgid "missing EAP-FAST PAC file"
-msgstr "адсутнічае PAC-файл EAP-FAST"
-
-#: panels/network/wireless-security/eap-method-fast.c:347
-msgid "Choose a PAC file"
-msgstr "Выберыце PAC-файл"
-
-#: panels/network/wireless-security/eap-method-fast.c:352
-msgid "PAC files (*.pac)"
-msgstr "PAC-файлы (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4098,77 +2476,54 @@ msgstr "Сапраўднасць пацверджана"
 msgid "Both"
 msgstr "Абодва"
 
-#: panels/network/wireless-security/eap-method-fast.ui:49
-#: panels/network/wireless-security/eap-method-peap.ui:52
-#: panels/network/wireless-security/eap-method-ttls.ui:51
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
 msgid "Anony_mous identity"
 msgstr "_Ананімная ідэнтычнасць"
 
-#: panels/network/wireless-security/eap-method-fast.ui:75
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "PAC-ф_айл"
 
-#: panels/network/wireless-security/eap-method-fast.ui:115
-#: panels/network/wireless-security/eap-method-peap.ui:150
-#: panels/network/wireless-security/eap-method-ttls.ui:143
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Выберыце PAC-файл"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "_Унутраная праверка сапраўднасці"
 
-#: panels/network/wireless-security/eap-method-fast.ui:144
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Дазволіць аўтаматычную падрыхтоўку PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "адсутнічае імя карыстальніка EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "адсутнічае пароль EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.ui:17
-#: panels/network/wireless-security/eap-method-simple.ui:17
-#: panels/network/wireless-security/ws-leap.ui:18
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "І_мя карыстальніка"
 
-#: panels/network/wireless-security/eap-method-leap.ui:31
-#: panels/network/wireless-security/eap-method-simple.ui:31
-#: panels/network/wireless-security/ws-leap.ui:32
-#: panels/network/wireless-security/ws-sae.ui:14
-#: panels/network/wireless-security/ws-wpa-psk.ui:14
-#: panels/sharing/cc-sharing-panel.ui:202
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:365
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "Пар_оль"
 
-#: panels/network/wireless-security/eap-method-leap.ui:55
-#: panels/network/wireless-security/eap-method-simple.ui:73
-#: panels/network/wireless-security/eap-method-tls.ui:157
-#: panels/network/wireless-security/ws-leap.ui:56
-#: panels/network/wireless-security/ws-sae.ui:54
-#: panels/network/wireless-security/ws-wpa-psk.ui:64
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Паказваць пароль"
-
-#: panels/network/wireless-security/eap-method-peap.c:87
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "памылковы сертыфікат EAP-PEAP CA: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:96
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "памылковы сертыфікат EAP-PEAP CA: сертыфікат не ўказаны"
-
-#: panels/network/wireless-security/eap-method-peap.c:328
-#: panels/network/wireless-security/eap-method-tls.c:513
-#: panels/network/wireless-security/eap-method-ttls.c:336
-msgid "Choose a Certificate Authority certificate"
-msgstr "Выберыце сертыфікат цэнтра сертыфікацыі"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4184,103 +2539,43 @@ msgstr "Версія 0"
 msgid "Version 1"
 msgstr "Версія 1"
 
-#: panels/network/wireless-security/eap-method-peap.ui:78
-#: panels/network/wireless-security/eap-method-tls.ui:68
-#: panels/network/wireless-security/eap-method-ttls.ui:102
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "_Сертыфікат CA"
 
-#: panels/network/wireless-security/eap-method-peap.ui:100
-#: panels/network/wireless-security/eap-method-tls.ui:90
-#: panels/network/wireless-security/eap-method-ttls.ui:125
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Выберыце сертыфікат цэнтра сертыфікацыі"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "Сертыфікат CA не патрабуецца"
 
-#: panels/network/wireless-security/eap-method-peap.ui:118
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Версія PEAP"
 
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "адсутнічае імя карыстальніка EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "адсутнічае пароль EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:92
-msgid "missing EAP-TLS identity"
-msgstr "адсутнічае ідэнтычнасць EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:102
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "памылковы сертыфікат EAP-TLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:112
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "памылковы сертыфікат EAP-TLS CA: сертыфікат не вызначаны"
-
-#: panels/network/wireless-security/eap-method-tls.c:129
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "памылковы закрыты ключ EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:139
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "памылковы сертыфікат карыстальніка EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:272
-msgid "Unencrypted private keys are insecure"
-msgstr "Незашыфраваныя закрытыя ключы небяспечныя"
-
-#: panels/network/wireless-security/eap-method-tls.c:275
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Падобна, што выбраны закрыты ключ не абаронены паролем. Гэта можа прывесці "
-"да кампраметавання ўліковых даных. Выберыце закрыты ключ, абаронены "
-"паролем.\n"
-"\n"
-"(Вы можаце абараніць закрыты ключ паролем праз openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:506
-msgid "Choose your personal certificate"
-msgstr "Выберыце асабісты сертыфікат"
-
-#: panels/network/wireless-security/eap-method-tls.c:520
-msgid "Choose your private key"
-msgstr "Выберыце закрыты ключ"
-
-#: panels/network/wireless-security/eap-method-tls.ui:17
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "Ід_энтычнасць"
 
-#: panels/network/wireless-security/eap-method-tls.ui:43
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "Сертыфікат _карыстальніка"
 
-#: panels/network/wireless-security/eap-method-tls.ui:108
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "_Закрыты ключ"
 
-#: panels/network/wireless-security/eap-method-tls.ui:133
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Пароль для закрытага ключа"
-
-#: panels/network/wireless-security/eap-method-ttls.c:98
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "памылковы сертыфікат EAP-TTLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:106
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "памылковы сертыфікат EAP-TTLS CA: сертыфікат не ўказаны"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4298,20 +2593,20 @@ msgstr "MSCHAPv2 (без EAP)"
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.ui:76
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
 msgid "_Domain"
 msgstr "_Дамен"
-
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Невядомая памылка праверкі бяспекі 802.1X"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4333,64 +2628,16 @@ msgstr "Тунэльны TLS"
 msgid "Protected EAP (PEAP)"
 msgstr "Абаронены EAP (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:56
-#: panels/network/wireless-security/ws-wep-key.ui:102
-#: panels/network/wireless-security/ws-wpa-eap.ui:61
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Пра_верка сапраўднасці"
 
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "адсутнічае імя карыстальніка LEAP"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "адсутнічае пароль LEAP"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Адсутнічае пароль Wi-Fi."
-
-#: panels/network/wireless-security/ws-sae.ui:42
-#: panels/network/wireless-security/ws-wpa-psk.ui:42
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Тып"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "адсутнічае ключ WEP"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"памылковы ключ WEP. Ключ даўжынёй %zu павінен змяшчаць толькі шаснаццатковыя "
-"лічбы"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"памылковы ключ WEP. Ключ даўжынёй %zu павінен змяшчаць толькі сімвалы ASCII"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"памылковы ключ WEP. Няправільная даўжыня ключа %zu. Даўжыня ключа павінна "
-"быць 5/13 (ASCII) або 10/26 (HEX)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "памылковы ключ WEP. Парольная фраза не можа быць пустой"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"памылковы ключ WEP. Парольная фраза павінна быль карацейшай за 64 сімвалы"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4404,50 +2651,36 @@ msgstr "Адкрытая сістэма"
 msgid "Shared Key"
 msgstr "Агульны ключ"
 
-#: panels/network/wireless-security/ws-wep-key.ui:48
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "_Ключ"
 
-#: panels/network/wireless-security/ws-wep-key.ui:84
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "Паказаць к_люч"
 
-#: panels/network/wireless-security/ws-wep-key.ui:134
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP-і_ндэкс"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"памылковы wpa-psk. Памылковая даўжыня ключа  %zu. Павінна быць [8,63] байт "
-"або 64 шаснаццатковыя лічбы"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"памылковы wpa-psk. Немагчыма інтэрпрэтаваць ключ з 64 байтаў як шаснаццатковы"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:60
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "_Апавяшчэнні"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:112
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "Гукавыя _сігналы"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:168
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "_Усплывальныя апавяшчэнні"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:184
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
@@ -4456,36 +2689,26 @@ msgstr ""
 "паказвацца ў спісе апавяшчэнняў."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:249
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "Паказваць _змесціва паведамлення ва ўсплывальных вокнах"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:300
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "Апавяшчэнні на экране _блакіравання"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:351
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "Паказваць з_месціва паведамлення на экране блакіравання"
 
-#: panels/notifications/cc-notifications-panel.c:260
-#: panels/power/cc-power-panel.c:862 panels/power/cc-power-panel.c:869
-#: panels/universal-access/cc-ua-panel.c:331
-#: panels/universal-access/cc-ua-panel.c:612
-#: panels/universal-access/cc-ua-panel.c:622
-#: panels/universal-access/cc-ua-panel.c:634
-#: panels/universal-access/cc-ua-panel.c:677
-msgid "On"
-msgstr "Уключана"
-
-#: panels/notifications/cc-notifications-panel.ui:44
+#: panels/notifications/cc-notifications-panel.ui:10
 msgid "_Do Not Disturb"
 msgstr "_Не турбаваць"
 
-#: panels/notifications/cc-notifications-panel.ui:52
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr "Апавяшчэнні на экране _блакіравання"
 
@@ -4493,36 +2716,35 @@ msgstr "Апавяшчэнні на экране _блакіравання"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Кіраванне апавяшчэннямі, налады паказу і зместу"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Апавяшчэнні;Нагадванні;Абвесткі;Банер;Шыльда;Паведамленне;Трэй;Абшар;"
 "Выплыўное акенца;Усплывальны;"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:148
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Іншы"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Адрабіць"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:576
-#, c-format
-msgid "%s Account"
-msgstr "Уліковы запіс %s"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Закрыць апавяшчэнне"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:870
-msgid "Error removing account"
-msgstr "Памылка выдалення ўліковага запісу"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Злучэнне з данымі ў воблаку"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:936
-#, c-format
-msgid "%s removed"
-msgstr "%s выдалены"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Няма злучэння з інтэрнэтам — злучыцеся, каб наладзіць новыя ўліковыя запісы "
+"ў сетцы"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Дадаць уліковы запіс"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4532,10 +2754,6 @@ msgstr "Уліковыя запісы ў сетцы"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Падлучыцца да ўліковых запісаў у сетцы і вырашыць як іх выкарыстоўваць"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4543,33 +2761,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Сеціва;Інтэрнэт;Чат;Каляндар;Календары;Пошта;"
 "Кантакты;Сувязь;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:61
-msgid "Undo"
-msgstr "Адрабіць"
-
-#: panels/online-accounts/online-accounts.ui:94
-msgid "Connect to your data in the cloud"
-msgstr "Злучэнне з данымі ў воблаку"
-
-#: panels/online-accounts/online-accounts.ui:109
-msgid "No internet connection — connect to set up new online accounts"
-msgstr ""
-"Няма злучэння з інтэрнэтам — злучыцеся, каб наладзіць новыя ўліковыя запісы "
-"ў сетцы"
-
-#: panels/online-accounts/online-accounts.ui:134
-msgid "Add an account"
-msgstr "Дадаць уліковы запіс"
-
-#: panels/online-accounts/online-accounts.ui:223
-msgid "Remove Account"
-msgstr "Выдаліць уліковы запіс"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Час невядомы"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4587,13 +2778,6 @@ msgstr[0] "%i гадзіна"
 msgstr[1] "%i гадзіны"
 msgstr[2] "%i гадзін"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4608,373 +2792,151 @@ msgstr[0] "хвіліна"
 msgstr[1] "хвіліны"
 msgstr[2] "хвілін"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s да поўнага зараду"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Увага! Засталося %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Засталося %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Зараджана цалкам"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Не зараджаецца"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Няма зараду"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Зараджаецца"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Разраджаецца"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Бесправадная мыш"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Бесправадная клавіятура"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Крыніца бесперабойнага сілкавання"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "КПК"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Мабільны тэлефон"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Медыяплэер"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209 panels/wacom/cc-wacom-panel.c:728
-msgid "Tablet"
-msgstr "Планшэт"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Камп'ютар"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Гульнявая прылада ўводу"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:384
-#: panels/power/cc-power-panel.ui:63
-msgid "Battery"
-msgstr "Батарэя"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Асноўная"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Дадатковая"
-
-#: panels/power/cc-power-panel.c:382
-msgid "Batteries"
-msgstr "Батарэі"
-
-#: panels/power/cc-power-panel.c:644
-msgid "When _idle"
-msgstr "Пры _бяздзейнасці"
-
-#: panels/power/cc-power-panel.c:796
-msgid "Suspend"
-msgstr "Прыпыненне працы"
-
-#: panels/power/cc-power-panel.c:797
-msgid "Power Off"
-msgstr "Выключэнне камп'ютара"
-
-#: panels/power/cc-power-panel.c:798
-msgid "Hibernate"
-msgstr "Гібернацыя"
-
-#: panels/power/cc-power-panel.c:799
-msgid "Nothing"
-msgstr "Нічога не рабіць"
-
-#: panels/power/cc-power-panel.c:858
-msgid "When on battery power"
-msgstr "Сілкуючыся ад батарэі"
-
-#: panels/power/cc-power-panel.c:860
-msgid "When plugged in"
-msgstr "Сілкуючыся ад электрасеткі"
-
-#: panels/power/cc-power-panel.c:980
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Ніколі"
-
-#: panels/power/cc-power-panel.c:1066
-msgid "Automatic suspend"
-msgstr "Аўтаматычнае прыпыненне працы"
-
-#: panels/power/cc-power-panel.c:1171
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Рэжым высокай прадукцыйнасці часова адключаны, тэмпература прылады занадта "
-"высокая."
-
-#: panels/power/cc-power-panel.c:1173
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Вентыляцыйная адтуліна перакрыта. Рэжым высокай прадукцыйнасці часова "
-"адключаны. Каб узнавіць яго працу, перамясціце прыладу на роўную цвёрдую "
-"паверхню."
-
-#: panels/power/cc-power-panel.c:1175
-msgid "Performance mode temporarily disabled."
-msgstr "Рэжым высокай прадукцыйнасці часова адключаны."
-
-#: panels/power/cc-power-panel.c:1218
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Нізкі зарад акумулятара. Уключаны рэжым энергазберажэння. Калі акумулятар "
-"дастаткова зарадзіцца, папярэдні рэжым будзе адноўлены."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1226
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Праграма «%s» задзейнічала рэжым энергазберажэння."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1230
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Праграма «%s» задзейнічала рэжым прадукцыйнасці."
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "15 хвілін"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "20 хвілін"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "25 хвілін"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 хвілін"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 хвілін"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 гадзіна"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 хвілін"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 хвілін"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 хвілін"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 гадзіны"
 
-#: panels/power/cc-power-panel.ui:107
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батарэя"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Прылады"
+
+#: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Рэжым сілкавання"
 
-#: panels/power/cc-power-panel.ui:108
+#: panels/power/cc-power-panel.ui:94
 msgid "Affects system performance and power usage."
 msgstr "Уплывае на прадукцыйнасць сістэмы і спажыванне энергіі."
 
-#: panels/power/cc-power-panel.ui:142
+#: panels/power/cc-power-panel.ui:123
 msgid "Power Saving Options"
 msgstr "Параметры энергазберажэння"
 
-#: panels/power/cc-power-panel.ui:146
+#: panels/power/cc-power-panel.ui:126
 msgid "Automatic Screen Brightness"
 msgstr "Аўтакіраванне яркасцю экрана"
 
-#: panels/power/cc-power-panel.ui:147
+#: panels/power/cc-power-panel.ui:127
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "Яркасць экрана падстройваецца пад знешняе асвятленне."
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Прыцямненне экрана"
 
-#: panels/power/cc-power-panel.ui:161
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "Яркасць экрана паніжаецца, калі камп'ютар бяздзейнічае."
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "_Адключэнне экрана"
 
-#: panels/power/cc-power-panel.ui:175
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "Экран выключыцца пасля пазначанага перыяду бяздзейнасці."
 
-#: panels/power/cc-power-panel.ui:183
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Аўтаматычны рэжым энергазберажэння"
 
-#: panels/power/cc-power-panel.ui:184
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr "Калі зарад акумулятара нізкі, уключаецца рэжым энергазберажэння."
 
-#: panels/power/cc-power-panel.ui:198
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "_Аўтаматычнае прыпыненне працы"
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "Камп'ютар прыпыняе працу пасля пазначанага перыяду бяздзейнасці."
 
-#: panels/power/cc-power-panel.ui:217
-msgid "Suspend & Power Button"
-msgstr "Кнопкі прыпынення працы і выключэння"
-
-#: panels/power/cc-power-panel.ui:221
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Дзеянне для кнопкі _выключэння"
 
-#: panels/power/cc-power-panel.ui:229
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Узровень зараду батарэі ў працэнтах"
 
-#: panels/power/cc-power-panel.ui:268
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Аўтаматычнае прыпыненне працы"
 
-#: panels/power/cc-power-panel.ui:293
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "Ад _электрасеткі"
 
-#: panels/power/cc-power-panel.ui:309
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Ад _батарэі"
 
-#: panels/power/cc-power-panel.ui:354 panels/power/cc-power-panel.ui:414
-#: panels/universal-access/cc-repeat-keys-dialog.ui:74
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Затрымка"
-
-#: panels/power/cc-power-profile-row.c:61
-msgid "Lap detected: performance mode unavailable"
-msgstr ""
-"Вентыляцыйная адтуліна перакрыта: рэжым высокай прадукцыйнасці недаступны"
-
-#: panels/power/cc-power-profile-row.c:63
-msgid "High hardware temperature: performance mode unavailable"
-msgstr ""
-"Высокая тэмпература абсталявання: рэжым высокай прадукцыйнасці недаступны"
-
-#: panels/power/cc-power-profile-row.c:64
-msgid "Performance mode unavailable"
-msgstr "Рэжым высокай прадукцыйнасці недаступны"
-
-#: panels/power/cc-power-profile-row.c:86
-#: panels/power/cc-power-profile-row.c:185
-msgid "High performance and power usage."
-msgstr "Высокая прадукцыйнасць і спажыванне энергіі."
-
-#: panels/power/cc-power-profile-row.c:184
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Прадукцыйнасць"
-
-#: panels/power/cc-power-profile-row.c:188
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Збалансаваны"
-
-#: panels/power/cc-power-profile-row.c:189
-msgid "Standard performance and power usage."
-msgstr "Звычайная прадукцыйнасць і спажыванне энергіі."
-
-#: panels/power/cc-power-profile-row.c:192
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Энергазберажэнне"
-
-#: panels/power/cc-power-profile-row.c:193
-msgid "Reduced performance and power usage."
-msgstr "Паніжаная прадукцыйнасць і спажыванне энергіі."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4984,7 +2946,6 @@ msgstr "Сілкаванне"
 msgid "View your battery status and change power saving settings"
 msgstr "Прагляд стану акумулятара і налады энергазберажэння"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4992,47 +2953,6 @@ msgid ""
 msgstr ""
 "Энергія;Сілкаванне;Сон;Супынак;Гібернацыя;Батарэя;Акумулятар;Яркасць;"
 "Зацяненне;Ачыстка;Манітор;DPMS;Бяздзейнасць;Прыпыненне;Прыпыніць;"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "Пацвердзіць"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/new-printer-dialog.ui:366
-#: panels/printers/pp-jobs-dialog.ui:57 panels/wwan/cc-wwan-apn-dialog.ui:188
-msgid "Username"
-msgstr "Імя карыстальніка"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:339
-msgid "Authentication Required"
-msgstr "Патрабуецца праверка сапраўднасці"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:682
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Прынтар «%s» выдалены"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:926
-msgid "Failed to add new printer."
-msgstr "Не ўдалося дадаць новы прынтар."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1225
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Не ўдалося загрузіць інтэрфейс: %s"
-
-#: panels/printers/cc-printers-panel.c:1293
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Разблакіруйце, каб дадаваць прынтары і змяняць налады"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5042,201 +2962,97 @@ msgstr "Прынтары"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Падлучэнне прынтараў, прагляд іх заданняў і налады друку"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Прынтар;Чарга;Друк;Папера;Аркуш;Чарніла;Тонер;"
 
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:254
-#: panels/printers/pp-new-printer-dialog.c:311
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Дадаць прынтар"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
-#: panels/wwan/cc-wwan-device-page.ui:90
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Разблакіраваць"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Прынтары не знойдзены"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Увядзіце сеткавы адрас прынтара або пашукайце па назве"
 
-#: panels/printers/new-printer-dialog.ui:356
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Патрабуецца праверка сапраўднасці"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Увядзіце імя карыстальніка і пароль для прагляду прынтараў на серверы друку."
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:351
-#, c-format
-msgid "%s Details"
-msgstr "Падрабязнасці %s"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Імя карыстальніка"
 
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Прыдатны драйвер не знойдзены"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Імя прынтара не можа змяшчаць ПРАБЕЛ, TAB, # або /"
 
-#: panels/printers/pp-details-dialog.c:232
-msgid "Select PPD File"
-msgstr "Выберыце файл PDD"
-
-#: panels/printers/pp-details-dialog.c:241
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Файлы апісання прынтараў PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
-
-#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Размяшчэнне"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:122
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Драйвер"
 
-#: panels/printers/pp-details-dialog.ui:162
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Пошук найлепшага драйвера…"
 
-#: panels/printers/pp-details-dialog.ui:183
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Пошук драйвераў"
 
-#: panels/printers/pp-details-dialog.ui:192
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Выбраць з базы даных…"
 
-#: panels/printers/pp-details-dialog.ui:201
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Усталяваць PPD-файл…"
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "Выберыце драйвера прынтара"
-
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:107
-msgid "Select"
-msgstr "Выбраць"
 
 #: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "Загрузка базы даных драйвераў…"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Прынтар JetDirect"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Скасаваць"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Прынтар LPD"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Выбраць"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "З аднаго боку"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Доўгі край (звычайна)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Кароткі край (перавернута)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Кніжная"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Альбомная"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Перавернутая альбомная"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Перавернутая кніжная"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:106
-msgctxt "print job"
-msgid "Pending"
-msgstr "Чаканне"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:112
-msgctxt "print job"
-msgid "Paused"
-msgstr "Прыпынена"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:117
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Патрабуецца праверка сапраўднасці"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:122
-msgctxt "print job"
-msgid "Processing"
-msgstr "Апрацоўванне"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:126
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Спынена"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:130
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Скасавана"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Перарвана"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:138
-msgctxt "print job"
-msgid "Completed"
-msgstr "Завершана"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:249
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
@@ -5244,245 +3060,38 @@ msgstr[0] "%u заданне патрабуе праверкі сапраўдн�
 msgstr[1] "%u заданні патрабуюць праверкі сапраўднасці"
 msgstr[2] "%u заданняў патрабуюць праверкі сапраўднасці"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:401
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "Актыўныя заданні %s"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:405
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Увядзіце ўліковыя даныя для друку з %s."
-
 #. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/pp-jobs-dialog.ui:44
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
 msgid "Domain"
 msgstr "Дамен"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:129
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "П_ацвердзіць"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:169
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Ачысціць усе"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:232
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Пацвердзіць"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:358
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Няма актыўных заданняў друку"
 
-#: panels/printers/pp-new-printer-dialog.c:269
-msgid "Unlock Print Server"
-msgstr "Разблакіраваць сервер друку"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:273
-#, c-format
-msgid "Unlock %s."
-msgstr "Разблакіраваць %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:277
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Увядзіце імя карыстальніка і пароль для прагляду прынтараў на %s."
-
-#: panels/printers/pp-new-printer-dialog.c:587
-msgid "Searching for Printers"
-msgstr "Пошук прынтараў"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1375
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1380
-msgid "Serial Port"
-msgstr "Паслядоўны порт"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1387
-msgid "Parallel Port"
-msgstr "Паралельны порт"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1429
-#, c-format
-msgid "Location: %s"
-msgstr "Месцазнаходжанне: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1434
-#, c-format
-msgid "Address: %s"
-msgstr "Адрас: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1461
-msgid "Server requires authentication"
-msgstr "Сервер патрабуе праверку сапраўднасці"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Двухбаковы"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Тып паперы"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Крыніца паперы"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Выхадны латок"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Раздзяляльнасць"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Папярэдняя фільтрацыя GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:530
-msgid "Pages per side"
-msgstr "Старонак на бок"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:542
-msgid "Two-sided"
-msgstr "З двух бакоў"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:554
-msgid "Orientation"
-msgstr "Арыентацыя"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:651
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Агульныя"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Налады старонкі"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Даступныя параметры"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Заданне"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Якасць выявы"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Колер"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Завяршэнне"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Дадатковыя"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:857
-#: panels/printers/pp-options-dialog.ui:18
+#: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Пробная старонка"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:870
-msgid "Test page"
-msgstr "Пробная старонка"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Аўтаматычна"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Прадвызначаныя для прынтара"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Укараняць толькі шрыфты GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Пераўтварыць у PS level 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Пераўтварыць у PS level 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Без папярэдняга фільтравання"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:203
-msgid "Manufacturer"
-msgstr "Вытворца"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:523 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr "Няма актыўных заданняў"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:528
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
@@ -5490,288 +3099,158 @@ msgstr[0] "%u заданне"
 msgstr[1] "%u заданні"
 msgstr[2] "%u заданняў"
 
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:648
-msgid "Clean print heads"
-msgstr "Ачыстка друкуючых галовак"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:713
-msgid "Low on toner"
-msgstr "Тонер заканчваецца"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:715
-msgid "Out of toner"
-msgstr "Няма тонеру"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:718
-msgid "Low on developer"
-msgstr "Праявіцель заканчваецца"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of developer"
-msgstr "Няма праявіцелю"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:723
-msgid "Low on a marker supply"
-msgstr "Фарба аднаго з колераў заканчваецца"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:725
-msgid "Out of a marker supply"
-msgstr "Няма фарбы аднаго з колераў"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:727
-msgid "Open cover"
-msgstr "Адкрыта вечка"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:729
-msgid "Open door"
-msgstr "Адчынены дзверцы"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:731
-msgid "Low on paper"
-msgstr "Папера заканчваецца"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:733
-msgid "Out of paper"
-msgstr "Няма паперы"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:735
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Па-за сеткай"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:737
-#: panels/printers/pp-printer-entry.c:880
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Спынена"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:739
-msgid "Waste receptacle almost full"
-msgstr "Кантэйнер для лішкаў фарбы амаль поўны"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:741
-msgid "Waste receptacle full"
-msgstr "Кантэйнер для лішкаў фарбы поўны"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:743
-msgid "The optical photo conductor is near end of life"
-msgstr "Фотабарабан амаль вычарпаў свой рэсурс"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:745
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Фотабарабан больш не працуе"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:866
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Гатовы"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:871
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Не прымае заданняў"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:876
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Апрацоўванне"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "Параметры друку"
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "Падрабязнасці аб прынтары"
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "Прадвызначаны прынтар"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
-msgstr "Ачыстка друкуючых галовак"
+msgstr "Ачыстка друкавальных галовак"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Выдаліць прынтар"
 
-#: panels/printers/printer-entry.ui:193
-#: panels/wwan/cc-wwan-details-dialog.ui:229
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Няма актыўных заданняў"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Мадэль"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Узровень чарніла"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:313
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Перазапусціце, калі праблема вырашана."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:320
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Перазапусціць"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:12
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Дадаць прынтар…"
 
-#: panels/printers/printers.ui:187
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Дадаць прынтар…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Няма прынтараў"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:201
-msgid "Add a Printer…"
-msgstr "Дадаць прынтар…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:233
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
-"Сістэмны сэрвіс друку\n"
-"недаступны або не запушчаны."
+"На жаль, сістэмны сэрвіс друку\n"
+"    недаступны або не запушчаны."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:189
-#: panels/region/cc-format-chooser.ui:6 panels/region/cc-region-panel.ui:203
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Фарматы"
 
-#: panels/region/cc-format-chooser.ui:101
-msgid ""
-"Choose the format for numbers, dates and currencies. Changes take effect on "
-"next login."
-msgstr ""
-"Выберыце фармат для лікаў, даты і валют. Змены ўступяць у сілу пры наступным "
-"уваходзе."
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Пошук месца…"
 
-#: panels/region/cc-format-chooser.ui:117
-msgid "Search locales..."
-msgstr "Пошук месца..."
-
-#: panels/region/cc-format-chooser.ui:158
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Асноўныя фарматы"
 
-#: panels/region/cc-format-chooser.ui:189
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Усе фарматы"
 
-#: panels/region/cc-format-chooser.ui:242
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Нічога не знойдзена"
 
-#: panels/region/cc-format-chooser.ui:255
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Пошук можна рабіць па назвах краін або моў."
 
-#: panels/region/cc-format-chooser.ui:300
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Перадпрагляд"
 
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Імперская"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Метрычная"
-
-#: panels/region/cc-format-preview.ui:18
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Дата"
 
-#: panels/region/cc-format-preview.ui:62
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "Дата і час"
 
-#: panels/region/cc-format-preview.ui:84
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Лікі"
 
-#: panels/region/cc-format-preview.ui:106
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Сістэма мер"
 
-#: panels/region/cc-format-preview.ui:128
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Папера"
 
-#: panels/region/cc-region-panel.ui:42
-msgid "My Account"
-msgstr "Мой уліковы запіс"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Мова і фармат зменяцца пасля наступнага ўваходу"
 
-#: panels/region/cc-region-panel.ui:53
-msgid "Login Screen"
-msgstr "Экран уваходу"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Выйсці…"
 
-#: panels/region/cc-region-panel.ui:78
-msgid "Language"
-msgstr "Мова"
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Налады мовы выкарыстоўваюцца для тэксту інтэрфейсу і вэб-старонак. Фарматы "
+"выкарыстоўваюцца для лікаў, дат і валют."
 
-#: panels/region/cc-region-panel.ui:89
-msgid "The language used for text in windows and web pages."
-msgstr "Мова для тэксту ў вокнах і на вэб-старонках."
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
 
-#: panels/region/cc-region-panel.ui:129
-#: panels/user-accounts/cc-user-panel.ui:311
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr "Ваш уліковы запіс"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Мова"
 
-#: panels/region/cc-region-panel.ui:164
-msgid "Restart the session for changes to take effect"
-msgstr "Каб змены ўступілі ў сілу, перазапусціце сеанс"
-
-#: panels/region/cc-region-panel.ui:179
-msgid "Restart…"
-msgstr "Перазапусціць…"
-
-#: panels/region/cc-region-panel.ui:214
-msgid "The format used for numbers, dates, and currencies."
-msgstr "Фармат для лікаў, даты і валют."
-
-#: panels/region/cc-region-panel.ui:248
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Фарматы"
 
-#: panels/region/cc-region-panel.ui:275
-msgid "Login settings are used by all users when logging into the system"
-msgstr ""
-"Налады ўваходу выкарыстоўваюцца для ўсіх карыстальнікаў пры ўваходзе ў "
-"сістэму"
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "Экран уваходу"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
@@ -5781,138 +3260,47 @@ msgstr "Рэгіён і мова"
 msgid "Select your display language and formats"
 msgstr "Выбар мовы інтэрфейсу і фарматаў даных"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Мова;Раскладка;Клавіятура;Увод;"
 
-#: panels/removable-media/cc-removable-media-panel.c:267
-msgid "Ask what to do"
-msgstr "Спытаць, што рабіць"
-
-#: panels/removable-media/cc-removable-media-panel.c:271
-msgid "Do nothing"
-msgstr "Нічога не рабіць"
-
-#: panels/removable-media/cc-removable-media-panel.c:275
-msgid "Open folder"
-msgstr "Адкрыць папку"
-
-#: panels/removable-media/cc-removable-media-panel.c:341
-msgid "Other Media"
-msgstr "Іншыя носьбіты"
-
-#: panels/removable-media/cc-removable-media-panel.c:362
-msgid "Select an application for audio CDs"
-msgstr "Выберыце праграму для аўдыядыскаў"
-
-#: panels/removable-media/cc-removable-media-panel.c:363
-msgid "Select an application for video DVDs"
-msgstr "Выберыце праграму для відэа на DVD-дысках"
-
-#: panels/removable-media/cc-removable-media-panel.c:364
-msgid "Select an application to run when a music player is connected"
-msgstr "Выберыце праграму для запуску пры падлучэнні музычнага плэера"
-
-#: panels/removable-media/cc-removable-media-panel.c:365
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-"Выберыце праграму для запуску пры падлучэнні фотаапарата ці відэакамеры"
-
-#: panels/removable-media/cc-removable-media-panel.c:366
-msgid "Select an application for software CDs"
-msgstr "Выберыце праграму для дыскаў з праграмным забеспячэннем"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "audio DVD"
-msgstr "аўдыя на DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "blank Blu-ray disc"
-msgstr "пусты Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:380
-msgid "blank CD disc"
-msgstr "пусты CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:381
-msgid "blank DVD disc"
-msgstr "пусты DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:382
-msgid "blank HD DVD disc"
-msgstr "пусты HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:383
-msgid "Blu-ray video disc"
-msgstr "відэа на Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:384
-msgid "e-book reader"
-msgstr "электронная кніга"
-
-#: panels/removable-media/cc-removable-media-panel.c:385
-msgid "HD DVD video disc"
-msgstr "відэа на HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:386
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:387
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:388
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:389
-msgid "Windows software"
-msgstr "ПЗ Windows"
-
-#: panels/removable-media/cc-removable-media-panel.ui:44
+#: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
 msgstr "Выберыце, што рабіць з носьбітамі даных"
 
-#: panels/removable-media/cc-removable-media-panel.ui:75
+#: panels/removable-media/cc-removable-media-panel.ui:52
 msgid "CD _audio"
 msgstr "_Аўдыя на CD"
 
-#: panels/removable-media/cc-removable-media-panel.ui:92
+#: panels/removable-media/cc-removable-media-panel.ui:67
 msgid "_DVD video"
 msgstr "_Відэа на DVD"
 
-#: panels/removable-media/cc-removable-media-panel.ui:133
+#: panels/removable-media/cc-removable-media-panel.ui:102
 msgid "_Music player"
 msgstr "_Музычны плэер"
 
-#: panels/removable-media/cc-removable-media-panel.ui:191
+#: panels/removable-media/cc-removable-media-panel.ui:152
 msgid "_Software"
 msgstr "_Праграмнае забеспячэнне"
 
-#: panels/removable-media/cc-removable-media-panel.ui:229
+#: panels/removable-media/cc-removable-media-panel.ui:178
 msgid "_Other Media…"
 msgstr "І_ншыя носьбіты…"
 
-#: panels/removable-media/cc-removable-media-panel.ui:288
+#: panels/removable-media/cc-removable-media-panel.ui:195
 msgid "_Never prompt or start programs on media insertion"
 msgstr "_Нічога не пытаць і не запускаць пры ўстаўцы носьбітаў"
 
-#: panels/removable-media/cc-removable-media-panel.ui:342
+#: panels/removable-media/cc-removable-media-panel.ui:225
 msgid "Select how other media should be handled"
 msgstr "Выберыце, што рабіць з іншымі носьбітамі даных"
 
-#: panels/removable-media/cc-removable-media-panel.ui:389
+#: panels/removable-media/cc-removable-media-panel.ui:259
 msgid "_Action:"
 msgstr "_Дзеянне:"
 
-#: panels/removable-media/cc-removable-media-panel.ui:412
+#: panels/removable-media/cc-removable-media-panel.ui:278
 msgid "_Type:"
 msgstr "_Тып:"
 
@@ -5924,7 +3312,6 @@ msgstr "Здымныя носьбіты"
 msgid "Configure Removable Media settings"
 msgstr "Наладзіць здымныя носьбіты"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5934,222 +3321,266 @@ msgstr ""
 "дзеянні;праграма;cd;dvd;usb;гук;аўдыя;відэа;дыск;зменны;здымны;носьбіт;"
 "аўтазапуск;аўтаматычны запуск;"
 
-#: panels/search/cc-search-locations-dialog.c:636
-msgid "Select Location"
-msgstr "Выберыце размяшчэнне"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Блакіраванне экрана"
 
-#: panels/search/cc-search-locations-dialog.c:640
-msgid "_OK"
-msgstr "_Добра"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Аўтаматычнае блакіраванне экрана прадухіляе доступ да камп'ютара пабочным "
+"асобам, калі вы адышлі."
 
-#: panels/search/cc-search-locations-dialog.ui:9
-#: panels/search/cc-search-panel.ui:57
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Затрымка да адключэння экрана"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Час бяздзейнасці пасля якога экран пагасне."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Аўтаматычнае блакіраванне экрана"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Затрымка да аўтаматычнага блакіравання экрана"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Час да аўтаматычнага блакіравання экрана пасля яго адключэння."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Паказваць _апавяшчэнні на экране блакіравання"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Апавяшчэнні на экране _блакіравання"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "_Забараняць новыя USB-прылады"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Прадухіляе ўзаемадзеянне новых USB-прылад з сістэмай, калі экран "
+"заблакіраваны."
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr "Прыватнасць экрана"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr "Абмежаваць вугал прагляду"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Экран"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Налады экрана"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "экран;блакіраванне;блакаванне;прыватнасць;канфідэнцыяльнасць;;"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "Месцы пошуку"
 
-#: panels/search/cc-search-locations-dialog.ui:32
-#: panels/search/cc-search-locations-dialog.ui:69
-#: panels/search/cc-search-locations-dialog.ui:107
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
 msgstr ""
-"Папкі, у якіх сістэмныя праграмы выконваюць пошук, напрыклад «Файлы», "
-"«Відарысы» і «Відэа»."
+"Папкі, у якіх сістэмныя праграмы выконваюць пошук, напрыклад «Файлы», «Фота» "
+"і «Відэа»."
 
-#: panels/search/cc-search-locations-dialog.ui:52
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr "Месцы"
 
-#: panels/search/cc-search-locations-dialog.ui:91
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Закладкі"
 
-#: panels/search/cc-search-locations-dialog.ui:156
-msgid "Other"
-msgstr "Іншы"
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Іншае"
 
-#: panels/search/cc-search-panel.c:151
-msgid "No applications found"
-msgstr "Праграмы не знойдзены"
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Дадаць месца"
 
-#: panels/search/cc-search-panel-row.ui:92
-msgid "Move Up"
-msgstr "Перамясціць вышэй"
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Пошук праграмы"
 
-#: panels/search/cc-search-panel-row.ui:102
-msgid "Move Down"
-msgstr "Перамясціць ніжэй"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Уключаць вынікі пошуку, якія прапануе праграма."
 
-#: panels/search/cc-search-panel.ui:31
-msgid ""
-"Control which search results are shown in the Activities Overview. The order "
-"of search results can also be changed by moving rows in the list."
-msgstr ""
-"Кіруе вынікамі пошуку, якія паказваюцца ў рэжыме Агляд дзейнасці. Парадак "
-"паказу таксама можна змяняць праз перамяшчэнне радкоў у спісе."
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Папкі, у якіх выконваюць пошук сістэмныя праграмы."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Вынікі пошуку"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Вынікі паказваюцца згодна з парадкам у спісе."
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "Праграмы, якія паказваюць вынікі пошуку ў рэжыме Агляд дзейнасці"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Search;Find;Пошук;Індэкс;Схаваць;Прыватнасць;Асабістыя даныя;Вынікі;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:306
-msgid "No networks selected for sharing"
-msgstr "Сеткі для супольнага карыстання не выбраны"
-
-#: panels/sharing/cc-sharing-networks.ui:19
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Сеткі"
 
-#: panels/sharing/cc-sharing-panel.c:289
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Уключана"
-
-#: panels/sharing/cc-sharing-panel.c:291 panels/sharing/cc-sharing-panel.c:318
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Выключана"
-
-#: panels/sharing/cc-sharing-panel.c:321
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Уключана"
-
-#: panels/sharing/cc-sharing-panel.c:324
-msgctxt "service is active"
-msgid "Active"
-msgstr "Актыўна"
-
-#: panels/sharing/cc-sharing-panel.c:393
-msgid "Choose a Folder"
-msgstr "Выберыце папку"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:696
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Супольны доступ да файлаў дае доступ да агульнадаступнай папкі "
-"карыстальнікам вашай сеткі праз: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:702
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Калі ўключаны аддалены ўваход, аддаленыя карыстальнікі могуць злучацца праз "
-"каманду Secure Shell:\n"
-"%s"
-
-#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:708
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to %s"
-msgstr ""
-"Супольны доступ да экрана дазваляе аддаленым карыстальнікам бачыць або "
-"кантраляваць ваш экран злучыўшыся праз %s"
-
-#: panels/sharing/cc-sharing-panel.c:813
-msgid "Copy"
-msgstr "Капіяваць"
-
-#: panels/sharing/cc-sharing-panel.c:1203
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Супольны доступ"
 
-#: panels/sharing/cc-sharing-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr "Імя _камп'ютара"
 
-#: panels/sharing/cc-sharing-panel.ui:79
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr "Супольны доступ да _файлаў"
 
-#: panels/sharing/cc-sharing-panel.ui:87
-msgid "_Screen Sharing"
-msgstr "Супольны доступ да _экрана"
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Аддалены працоўны _стол"
 
-#: panels/sharing/cc-sharing-panel.ui:95
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr "Супольны доступ да _медыяфайлаў"
 
-#: panels/sharing/cc-sharing-panel.ui:103
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr "_Аддалены ўваход у сістэму"
 
-#: panels/sharing/cc-sharing-panel.ui:119
-msgid "Some services are disabled because of no network access."
-msgstr "Некаторыя сэрвісы адключаныя, бо няма доступу да сеткі."
-
-#: panels/sharing/cc-sharing-panel.ui:137
-#: panels/sharing/cc-sharing-panel.ui:264
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr "Супольны доступ да файлаў"
 
-#: panels/sharing/cc-sharing-panel.ui:184
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr "_Патрабаваць пароль"
 
-#: panels/sharing/cc-sharing-panel.ui:275
-#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "Аддалены ўваход у сістэму"
 
-#: panels/sharing/cc-sharing-panel.ui:368
-#: panels/sharing/cc-sharing-panel.ui:590
-msgid "Screen Sharing"
-msgstr "Супольны доступ да экрана"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Аддалены працоўны стол"
 
-#: panels/sharing/cc-sharing-panel.ui:422
-msgid "_Allow connections to control the screen"
-msgstr "_Дазволіць кіраванне экранам праз злучэнні"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Аддалены працоўны стол дазваляе праглядаць і кіраваць вашым працоўным сталом "
+"з іншага камп'ютара."
 
-#: panels/sharing/cc-sharing-panel.ui:447
-msgid "_Password:"
-msgstr "Пар_оль:"
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Уключыць або адключыць падлучэнне да гэтага камп'ютара праз аддалены "
+"працоўны стол."
 
-#: panels/sharing/cc-sharing-panel.ui:477
-msgid "_Show Password"
-msgstr "_Паказваць пароль"
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Аддаленае кіраванне"
 
-#: panels/sharing/cc-sharing-panel.ui:508
-msgid "Access Options"
-msgstr "Параметры доступу"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Дазваляе кіраванне экранам праз аддаленае злучэнне."
 
-#: panels/sharing/cc-sharing-panel.ui:522
-msgid "_New connections must ask for access"
-msgstr "Новым злучэнням патрэбна запытаць доступ"
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Як злучыцца"
 
-#: panels/sharing/cc-sharing-panel.ui:540
-msgid "_Require a password"
-msgstr "_Патрабаваць пароль"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Падлучайцеся да гэтага камп'ютара праз імя прылады або адрас аддаленага "
+"працоўнага стала."
 
-#: panels/sharing/cc-sharing-panel.ui:601
-#: panels/sharing/cc-sharing-panel.ui:695
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Капіяваць"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Адрас аддаленага працоўнага стала"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Праверка сапраўднасці"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Каб падлучыцца да гэтага камп'ютара, патрабуецца імя карыстальніка і пароль."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Імя карыстальніка"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Праверыць шыфраванне"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Лічбавы адбітак для шыфравання"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Лічбавы адбітак для шыфравання можа сустракацца пры падлучэннні кліентаў і "
+"тады ён павінен быць аднолькавым."
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Супольны доступ да медыяфайлаў"
 
-#: panels/sharing/cc-sharing-panel.ui:634
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Супольны доступ да вашай музыкі, фота і відэа праз сетку."
 
-#: panels/sharing/cc-sharing-panel.ui:649
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Папкі"
 
@@ -6157,7 +3588,6 @@ msgstr "Папкі"
 msgid "Control what you want to share with others"
 msgstr "Налады супольнага доступу да вашых даных"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6177,99 +3607,93 @@ msgstr ""
 "Для ўключэння ці адключэння аддаленага ўваходу патрабуецца праверка "
 "сапраўднасці"
 
-#: panels/sound/cc-alert-chooser.c:151
-msgid "Custom"
-msgstr "Уласны"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Брэх"
+msgid "Click"
+msgstr "Пстрык"
 
-#: panels/sound/cc-alert-chooser.ui:19
-msgid "Drip"
-msgstr "Кропля"
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Струна"
 
-#: panels/sound/cc-alert-chooser.ui:26
-msgid "Glass"
-msgstr "Шклянка"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Узмах"
 
-#: panels/sound/cc-alert-chooser.ui:33
-msgid "Sonar"
-msgstr "Гідралакатар"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Бэм"
 
-#: panels/sound/cc-fade-slider.ui:13
-msgid "Rear"
-msgstr "Тыл"
-
-#: panels/sound/cc-fade-slider.ui:15
-msgid "Front"
-msgstr "Фронт"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Праверка %s"
-
-#: panels/sound/cc-output-test-dialog.ui:127
-msgid "Click a speaker to test"
-msgstr "Націсніце на дынамік, каб праверыць"
-
-#: panels/sound/cc-sound-panel.ui:27
-msgid "System Volume"
-msgstr "Сістэмная гучнасць"
-
-#: panels/sound/cc-sound-panel.ui:43
-msgid "Volume Levels"
-msgstr "Узроўні гучнасці"
-
-#: panels/sound/cc-sound-panel.ui:63
-msgid "Output"
-msgstr "Выхад"
-
-#: panels/sound/cc-sound-panel.ui:90
-msgid "Output Device"
-msgstr "Выхадная прылада"
-
-#: panels/sound/cc-sound-panel.ui:113
-msgid "Test"
-msgstr "Праверыць"
-
-#: panels/sound/cc-sound-panel.ui:144 panels/sound/cc-sound-panel.ui:319
-msgid "Configuration"
-msgstr "Канфігурацыя"
-
-#: panels/sound/cc-sound-panel.ui:177
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 msgid "Balance"
 msgstr "Баланс"
 
-#: panels/sound/cc-sound-panel.ui:204
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 msgid "Fade"
 msgstr "Згасанне"
 
-#: panels/sound/cc-sound-panel.ui:231
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Тыл"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Фронт"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Націсніце на дынамік, каб праверыць"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Сістэмная гучнасць"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Агульная гучнасць"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Узроўні гучнасці"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Выхад"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Выхадная прылада"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Праверыць"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Канфігурацыя"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Сабвуфер"
 
-#: panels/sound/cc-sound-panel.ui:251
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Уваход"
 
-#: panels/sound/cc-sound-panel.ui:278
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Уваходная прылада"
 
-#: panels/sound/cc-sound-panel.ui:352
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Гучнасць"
 
-#: panels/sound/cc-sound-panel.ui:372
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Гук абвестак"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Адключыць гук"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6280,7 +3704,6 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Змяненне гучнасці, гукавых уваходаў і выхадаў, прызначэнне гукаў для абвестак"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6288,77 +3711,7 @@ msgstr ""
 "Audio;Output;Input;Мікрафон;Гучнасць;Згасанне;Баланс;Bluetooth;блютуз;"
 "Навушнікі;Аўдыя;Гук;Выхад;Уваход;Гук;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Адлучана"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Злучэнне"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Злучана"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Памылка аўтарызацыі"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Аўтарызацыя"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Дзейнічае з абмежаваннямі"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Палучана і аўтарызавана"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Невядома"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr "Аўтарызавана:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-msgid "Connected at:"
-msgstr "Злучана:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-msgid "Enrolled at:"
-msgstr "Зарэгістравана:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-msgid "Failed to authorize device: "
-msgstr "Не ўдалося аўтарызаваць прыладу: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-msgid "Failed to forget device: "
-msgstr "Не ўдалося забыць прыладу: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
@@ -6366,86 +3719,52 @@ msgstr[0] "Залежыць ад %u іншай прылады"
 msgstr[1] "Залежыць ад %u іншых прылад"
 msgstr[2] "Залежыць ад %u іншых прылад"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Закрыць апавяшчэнне"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Імя:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Стан:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Аўтарызаваць і злучыць"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Забыць прыладу"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Памылка"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Аўтарызавана"
-
-#: panels/thunderbolt/cc-bolt-panel.c:175
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Падсістэма Thunderbolt (boltd) не ўсталявана ці не наладжана належным чынам."
-
-#: panels/thunderbolt/cc-bolt-panel.c:468
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Не ўдалося выявіць Thunderbolt.\n"
-"Thunderbolt можа не падтрымлівацца сістэмай ці быць адключаным у BIOS або не "
-"падтрымлівацца праз зададзены ў BIOS ўзровень бяспекі."
-
-#: panels/thunderbolt/cc-bolt-panel.c:512
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Падтрымка Thunderbolt адключана ў BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:516
-msgid "Thunderbolt security level could not be determined."
-msgstr "Не ўдалося вызначыць узровень бяспекі Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:621
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Памылка пераключэння рэжыму прамога доступу: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
 msgstr "Thunderbolt не падтрымліваецца"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:246
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Не ўдалося падлучыцца да падсістэмы thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Прамы доступ"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr "Дазволіць прамы доступ да прылад накшталт док-станцый і знешніх GPU."
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr "Далучыцца могуць толькі прылады USB і Display Port."
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Прылады ў чаканні"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Няма далучаных прылад"
 
@@ -6457,394 +3776,320 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Кіраванне прыладамі Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;прыватнасць;канфідэнцыйнасць;"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:7
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 msgid "Cursor Blinking"
 msgstr "Мільганне курсора"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:37
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Курсор мільгае ў тэкставых палях."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:74
-#: panels/universal-access/cc-repeat-keys-dialog.ui:145
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Хуткасць"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:101
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Хуткасць мільгання курсора"
 
-#: panels/universal-access/cc-cursor-size-dialog.ui:7
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr "Памер курсора"
 
-#: panels/universal-access/cc-cursor-size-dialog.ui:29
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 "Каб палепшыць бачнасць курсора, змяненне яго памеру можна спалучаць з "
 "маштабаваннем."
 
-#: panels/universal-access/cc-pointing-dialog.ui:7
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "Дапамога з націсканнем мышы"
 
-#: panels/universal-access/cc-pointing-dialog.ui:43
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "_Сімуляцыя націскання правай кнопкі"
 
-#: panels/universal-access/cc-pointing-dialog.ui:56
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "Выклік націскання правай кнопкай пры зацісканні асноўнай кнопкі"
 
-#: panels/universal-access/cc-pointing-dialog.ui:79
-#: panels/universal-access/cc-typing-dialog.ui:158
-#: panels/universal-access/cc-typing-dialog.ui:307
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
 msgid "A_cceptance delay:"
 msgstr "_Затрымка да прыняцця:"
 
-#: panels/universal-access/cc-pointing-dialog.ui:95
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Кароткая"
 
-#: panels/universal-access/cc-pointing-dialog.ui:110
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "Затрымка да націскання правай кнопкай"
 
-#: panels/universal-access/cc-pointing-dialog.ui:120
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Доўгая"
 
-#: panels/universal-access/cc-pointing-dialog.ui:157
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "Націсканне пры навядзенні"
 
-#: panels/universal-access/cc-pointing-dialog.ui:170
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "Выклік націскання мышшу пры спыненні ўказальніка"
 
-#: panels/universal-access/cc-pointing-dialog.ui:193
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "_Затрымка:"
 
-#: panels/universal-access/cc-pointing-dialog.ui:210
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Кароткая"
 
-#: panels/universal-access/cc-pointing-dialog.ui:232
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Доўгая"
 
-#: panels/universal-access/cc-pointing-dialog.ui:253
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "_Парог зруху:"
 
-#: panels/universal-access/cc-pointing-dialog.ui:270
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Малы"
 
-#: panels/universal-access/cc-pointing-dialog.ui:292
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Вялікі"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:7
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
 msgid "Repeat Keys"
 msgstr "Паўтор клавіш"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:37
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Паўтараць увод, пакуль утрымліваецца націснутая клавіша."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:102
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Затрымка паўтарэння клавіш"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:174
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Хуткасць паўтарэння клавіш"
 
-#: panels/universal-access/cc-sound-keys-dialog.ui:7
-msgid "Sound Keys"
-msgstr "Агучванне клавіш"
-
-#: panels/universal-access/cc-sound-keys-dialog.ui:25
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "Гукавы сігнал пры націсканні на Num Lock або Caps Lock."
-
-#: panels/universal-access/cc-sound-keys-dialog.ui:45
-#: panels/universal-access/cc-ua-panel.ui:412
-msgid "_Sound Keys"
-msgstr "_Агучванне клавіш"
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:7
-msgid "Screen Reader"
-msgstr "Чытанне з экрана"
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:24
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "Праз чытанне з экрана прамаўляецца тэкст, на які пераходзіць фокус."
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:52
-msgid "_Screen Reader"
-msgstr "_Чытанне з экрана"
-
-#: panels/universal-access/cc-typing-dialog.ui:7
+#: panels/universal-access/cc-typing-dialog.ui:4
 msgid "Typing Assist"
 msgstr "Дапамога з уводам"
 
-#: panels/universal-access/cc-typing-dialog.ui:46
+#: panels/universal-access/cc-typing-dialog.ui:41
 msgid "_Sticky Keys"
 msgstr "_Ліпкія клавішы"
 
-#: panels/universal-access/cc-typing-dialog.ui:58
+#: panels/universal-access/cc-typing-dialog.ui:51
 msgid "Treats a sequence of modifier keys as a key combination"
 msgstr "Лічыць паслядоўна націснутыя клавішы-мадыфікатары адзіным спалучэннем"
 
-#: panels/universal-access/cc-typing-dialog.ui:72
+#: panels/universal-access/cc-typing-dialog.ui:63
 msgid "_Disable if two keys are pressed together"
 msgstr "_Адключаць пры адначасовым націсканні дзвюх клавіш"
 
-#: panels/universal-access/cc-typing-dialog.ui:85
+#: panels/universal-access/cc-typing-dialog.ui:71
 msgid "Beep when a _modifier key is pressed"
 msgstr "Гукавы сігнал пры націсканні клавішы-_мадыфікатара"
 
-#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:96
 msgid "S_low Keys"
 msgstr "_Павольныя клавішы"
 
-#: panels/universal-access/cc-typing-dialog.ui:135
+#: panels/universal-access/cc-typing-dialog.ui:106
 msgid "Puts a delay between when a key is pressed and when it is accepted"
 msgstr "Затрымка паміж націсканнем клавішы і яе прыняццем"
 
-#: panels/universal-access/cc-typing-dialog.ui:175
+#: panels/universal-access/cc-typing-dialog.ui:135
 msgctxt "slow keys delay"
 msgid "Short"
 msgstr "Кароткая"
 
-#: panels/universal-access/cc-typing-dialog.ui:190
+#: panels/universal-access/cc-typing-dialog.ui:147
 msgid "Slow keys typing delay"
 msgstr "Затрымка ўводу для павольных клавіш"
 
-#: panels/universal-access/cc-typing-dialog.ui:200
+#: panels/universal-access/cc-typing-dialog.ui:154
 msgctxt "slow keys delay"
 msgid "Long"
 msgstr "Доўгая"
 
-#: panels/universal-access/cc-typing-dialog.ui:212
+#: panels/universal-access/cc-typing-dialog.ui:166
 msgid "Beep when a key is pr_essed"
 msgstr "Гукавы сігнал пры націсканні _клавішы"
 
-#: panels/universal-access/cc-typing-dialog.ui:224
+#: panels/universal-access/cc-typing-dialog.ui:173
 msgid "Beep when a key is _accepted"
 msgstr "Гукавы сігнал, калі клавіша _прынята"
 
-#: panels/universal-access/cc-typing-dialog.ui:236
-#: panels/universal-access/cc-typing-dialog.ui:361
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
 msgid "Beep when a key is _rejected"
 msgstr "Гукавы сігнал, калі клавіша _не прынята"
 
-#: panels/universal-access/cc-typing-dialog.ui:272
+#: panels/universal-access/cc-typing-dialog.ui:203
 msgid "_Bounce Keys"
 msgstr "_Пругкія клавішы"
 
-#: panels/universal-access/cc-typing-dialog.ui:284
+#: panels/universal-access/cc-typing-dialog.ui:213
 msgid "Ignores fast duplicate keypresses"
 msgstr "Ігнараванне хуткага паўторнага націскання клавіш"
 
-#: panels/universal-access/cc-typing-dialog.ui:324
+#: panels/universal-access/cc-typing-dialog.ui:242
 msgctxt "bounce keys delay"
 msgid "Short"
 msgstr "Кароткая"
 
-#: panels/universal-access/cc-typing-dialog.ui:339
+#: panels/universal-access/cc-typing-dialog.ui:254
 msgid "Bounce keys typing delay"
 msgstr "Затрымка ўводу для пругкіх клавіш"
 
-#: panels/universal-access/cc-typing-dialog.ui:349
+#: panels/universal-access/cc-typing-dialog.ui:261
 msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Доўгая"
 
-#: panels/universal-access/cc-typing-dialog.ui:437
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "_Уключэнне з клавіятуры"
 
-#: panels/universal-access/cc-typing-dialog.ui:449
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Уключэнне і выключэнне спецыяльных магчымасцей з дапамогай клавіятуры"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:351
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Стандартны"
-
-#: panels/universal-access/cc-ua-panel.c:354
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Сярэді"
-
-#: panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Вялікі"
-
-#: panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Яшчэ большы"
-
-#: panels/universal-access/cc-ua-panel.c:363
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Самы вялікі"
-
-#: panels/universal-access/cc-ua-panel.c:367
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d піксель"
-msgstr[1] "%d пікселі"
-msgstr[2] "%d пікселяў"
-
-#: panels/universal-access/cc-ua-panel.ui:55
+#: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Заўсёды паказваць меню спецыяльных магчымасцей"
 
-#: panels/universal-access/cc-ua-panel.ui:97
+#: panels/universal-access/cc-ua-panel.ui:31
 msgid "Seeing"
 msgstr "Зрок"
 
-#: panels/universal-access/cc-ua-panel.ui:143
+#: panels/universal-access/cc-ua-panel.ui:34
 msgid "_High Contrast"
 msgstr "_Высокая кантраснасць"
 
-#: panels/universal-access/cc-ua-panel.ui:190
+#: panels/universal-access/cc-ua-panel.ui:46
 msgid "_Large Text"
 msgstr "_Вялікі тэкст"
 
-#: panels/universal-access/cc-ua-panel.ui:238
+#: panels/universal-access/cc-ua-panel.ui:58
 msgid "Enable A_nimations"
 msgstr "Уключыць _анімацыю"
 
-#: panels/universal-access/cc-ua-panel.ui:273
-msgid "C_ursor Size"
-msgstr "П_амер курсора"
-
-#: panels/universal-access/cc-ua-panel.ui:320
-#: panels/universal-access/cc-zoom-options-dialog.ui:91
-msgid "_Zoom"
-msgstr "_Маштабаванне"
-
-#: panels/universal-access/cc-ua-panel.ui:366
+#: panels/universal-access/cc-ua-panel.ui:70
 msgid "Screen _Reader"
 msgstr "_Чытанне з экрана"
 
-#: panels/universal-access/cc-ua-panel.ui:474
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Праз чытанне з экрана прамаўляецца тэкст, на які пераходзіць фокус."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Агучванне клавіш"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Гукавы сігнал пры націсканні на Num Lock або Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "П_амер курсора"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Маштабаванне"
+
+#: panels/universal-access/cc-ua-panel.ui:138
 msgid "Hearing"
 msgstr "Слых"
 
-#: panels/universal-access/cc-ua-panel.ui:518
-#: panels/universal-access/cc-visual-alerts-dialog.ui:68
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
 msgid "_Visual Alerts"
 msgstr "_Гукавыя сігналы"
 
-#: panels/universal-access/cc-ua-panel.ui:626
+#: panels/universal-access/cc-ua-panel.ui:166
 msgid "Screen _Keyboard"
 msgstr "_Экранная клавіятура"
 
-#: panels/universal-access/cc-ua-panel.ui:671
+#: panels/universal-access/cc-ua-panel.ui:178
 msgid "R_epeat Keys"
 msgstr "П_аўтор клавіш"
 
-#: panels/universal-access/cc-ua-panel.ui:717
+#: panels/universal-access/cc-ua-panel.ui:198
 msgid "Cursor _Blinking"
 msgstr "_Мільганне курсора"
 
-#: panels/universal-access/cc-ua-panel.ui:763
+#: panels/universal-access/cc-ua-panel.ui:218
 msgid "_Typing Assist (AccessX)"
 msgstr "Дапам_ога  з уводам (AccessX)"
 
-#: panels/universal-access/cc-ua-panel.ui:824
-msgid "Pointing & Clicking"
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
 msgstr "Навядзенне ўказальніка і націсканне мышшу"
 
-#: panels/universal-access/cc-ua-panel.ui:870
+#: panels/universal-access/cc-ua-panel.ui:243
 msgid "_Mouse Keys"
 msgstr "_Кіраванне ўказальнікам з клавіятуры"
 
-#: panels/universal-access/cc-ua-panel.ui:915
+#: panels/universal-access/cc-ua-panel.ui:255
 msgid "_Locate Pointer"
 msgstr "_Выяўленне ўказальніка мышы"
 
-#: panels/universal-access/cc-ua-panel.ui:947
+#: panels/universal-access/cc-ua-panel.ui:267
 msgid "_Click Assist"
 msgstr "Дапа_мога з націсканнем мышы"
 
-#: panels/universal-access/cc-ua-panel.ui:993
+#: panels/universal-access/cc-ua-panel.ui:287
 msgid "_Double-Click Delay"
 msgstr "_Затрымка для падвойнага націскання"
 
-#: panels/universal-access/cc-ua-panel.ui:1013
+#: panels/universal-access/cc-ua-panel.ui:297
 msgid "Double-Click Delay"
 msgstr "Затрымка для падвойнага націскання"
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:15
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
 msgid "Visual Alerts"
 msgstr "Візуальныя сігналы"
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:19
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
 msgid "_Test flash"
 msgstr "_Праверка сігналу"
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:48
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
 msgid "Use a visual indication when an alert sound occurs."
 msgstr "Візуальна абазначае гукавы сігнал."
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:94
-msgid "Flash the entire _window"
-msgstr "Мільганне ўсім _акном"
-
-#: panels/universal-access/cc-visual-alerts-dialog.ui:112
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
 msgid "Flash the entire _screen"
 msgstr "Мільганне ўсім _экранам"
 
-#: panels/universal-access/cc-zoom-options-dialog.c:303
-msgctxt "Distance"
-msgid "Short"
-msgstr "Кароткая"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:304
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ экрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:305
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ экрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ экрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "Long"
-msgstr "Доўгая"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Мільганне ўсім _акном"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6866,134 +4111,134 @@ msgstr "Левая палавіна"
 msgid "Right Half"
 msgstr "Правая палавіна"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:70
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "Параметры маштабавання"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:151
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
 msgstr "_Па_велічэнне:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:201
-msgid "_Follow mouse cursor"
-msgstr "_Накіроўвацца за курсорам мышы"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:221
-msgid "_Screen part:"
-msgstr "Частка _экрана:"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:278
-msgid "Magnifier _extends outside of screen"
-msgstr "Лупа _распаўсюджваецца за межы экрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:292
-msgid "_Keep magnifier cursor centered"
-msgstr "Указальнік лупы знаходзіцца ў _цэнтры"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:307
-msgid "Magnifier cursor _pushes contents around"
-msgstr "Указальнік лупы _ссоўвае змест экрана навокал"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:322
-msgid "Magnifier cursor moves with _contents"
-msgstr "Указальнік лупы перамяшчаецца разам са _зместам"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:347
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "Пазіцыя лупы:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:362
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Накіроўвацца за курсорам мышы"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Частка _экрана:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Лупа _распаўсюджваецца за межы экрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Указальнік лупы знаходзіцца ў _цэнтры"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Указальнік лупы _ссоўвае змест экрана навокал"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Указальнік лупы перамяшчаецца разам са _зместам"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Лупа"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:410
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Перакрыжаванне:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Накладанне на ўказальнік мышы"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
 msgstr "_Таўшчыня:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:436
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "Тонкая"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:458
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Тоўстая"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:479
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
 msgstr "_Даўжыня:"
 
 #. The color of the accessibility crosshair
-#: panels/universal-access/cc-zoom-options-dialog.ui:523
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
 msgstr "Ко_лер:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:577
-msgid "_Crosshairs:"
-msgstr "_Перакрыжаванне:"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:610
-msgid "_Overlaps mouse cursor"
-msgstr "_Накладанне на ўказальнік мышы"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:634
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "Перакрыжаванне"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:683
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Каляровыя эфекты:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
 msgstr "_Белы на чорным:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:703
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
 msgstr "_Яркасць:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:724
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
 msgstr "_Кантраснасць:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/cc-zoom-options-dialog.ui:744
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
 msgid "Co_lor"
 msgstr "_Насычанасць"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:769
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Няма"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:791
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Поўная"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:844
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Нізкая"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:867
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Высокая"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:893
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Нізкая"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:916
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Высокая"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:942
-msgid "Color Effects:"
-msgstr "Каляровыя эфекты:"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:958
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "Каляровыя эфекты"
 
@@ -7003,49 +4248,24 @@ msgstr ""
 "Дапамога для зроку і слыху; спрашчэнне ўводу, навядзення ўказальніка, "
 "націскання мышшу"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
-"audio;typing;"
+"audio;typing;animations;"
 msgstr ""
-"Клавіятура;Мыш;a11y;Спецыяльныя магчымасці;Універсальны доступ;Кантрастнасць;"
+"Клавіятура;Мыш;a11y;Спецыяльныя магчымасці;Універсальны доступ;Кантраснасць;"
 "Указальнік;Гук;Маштабаванне;Экран;Буйны;Вялікі;шрыфт;памер;AccessX;Ліпкія;"
 "клавішы;Павольныя;Пругкія;Кіраванне ўказальнікам;Падвойнае;націсканне;"
 "Затрымка;Хуткасць;Дапамога;Паўтарэнне;Паўтор;Мільганне;візуальныя;сігналы;"
-"слых;аўдыя;увод;"
+"слых;аўдыя;увод;друк;анімацыі;"
 
-#: panels/usage/cc-usage-panel.c:154
-msgid "Empty all items from Trash?"
-msgstr "Ачысціць сметніцу ад усяго яе змесціва?"
-
-#: panels/usage/cc-usage-panel.c:155
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Усё змесціва сметніцы будзе незваротна выдалена."
-
-#: panels/usage/cc-usage-panel.c:156
-msgid "_Empty Trash"
-msgstr "_Ачысціць сметніцу"
-
-#: panels/usage/cc-usage-panel.c:177
-msgid "Delete all the temporary files?"
-msgstr "Выдаліць усе часовыя файлы?"
-
-#: panels/usage/cc-usage-panel.c:178
-msgid "All the temporary files will be permanently deleted."
-msgstr "Усе часовыя файлы будуць незваротна выдалены."
-
-#: panels/usage/cc-usage-panel.c:179
-msgid "_Purge Temporary Files"
-msgstr "_Выдаліць часовыя файлы"
-
-#: panels/usage/cc-usage-panel.ui:29
+#: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
 msgstr "Гісторыя файлаў"
 
-#: panels/usage/cc-usage-panel.ui:41
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
 "File history keeps a record of files that you have used. This information is "
 "shared between applications, and makes it easier to find files that you "
@@ -7055,23 +4275,23 @@ msgstr ""
 "абагулены паміж праграмамі і дазваляюць прасцей знайсці файлы, якія вы, "
 "магчыма, захочаце выкарыстаць."
 
-#: panels/usage/cc-usage-panel.ui:56
+#: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
 msgstr "Г_історыя файлаў"
 
-#: panels/usage/cc-usage-panel.ui:78
+#: panels/usage/cc-usage-panel.ui:25
 msgid "File _History Duration"
 msgstr "Працягласць _гісторыі файлаў"
 
-#: panels/usage/cc-usage-panel.ui:119
+#: panels/usage/cc-usage-panel.ui:48
 msgid "_Clear History…"
 msgstr "_Ачысціць гісторыю…"
 
-#: panels/usage/cc-usage-panel.ui:135
-msgid "Trash & Temporary Files"
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
 msgstr "Сметніца і часовыя файлы"
 
-#: panels/usage/cc-usage-panel.ui:145
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
@@ -7079,109 +4299,25 @@ msgstr ""
 "Сметніца і часовыя файлы могуць змяшчаць прыватную інфармацыю. Аўтаматычнае "
 "выдаленне файлаў можа дапамагчы абараніць прыватнасць."
 
-#: panels/usage/cc-usage-panel.ui:159
+#: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
 msgstr "Аўтаматычна выдаляць змесціва сметніцы"
 
-#: panels/usage/cc-usage-panel.ui:174
+#: panels/usage/cc-usage-panel.ui:79
 msgid "Automatically Delete Temporary _Files"
 msgstr "Аўтаматычна выдаляць часовыя _файлы"
 
-#: panels/usage/cc-usage-panel.ui:196
+#: panels/usage/cc-usage-panel.ui:91
 msgid "Automatically Delete _Period"
 msgstr "_Перыядычнасць аўтаматычнага выдалення"
 
-#: panels/usage/cc-usage-panel.ui:238
+#: panels/usage/cc-usage-panel.ui:115
 msgid "_Empty Trash…"
 msgstr "_Ачысціць сметніцу…"
 
-#: panels/usage/cc-usage-panel.ui:250
+#: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
 msgstr "_Выдаліць часовыя файлы…"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:278
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 гадзіна"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:282
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 дзень"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:286
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 дні"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:290
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 дні"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:294
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 дні"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:298
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 дзён"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:302
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 дзён"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:306
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 дзён"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:310
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 дзён"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:314
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 дзён"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:329
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 дзень"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:333
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 дзён"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:337
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 дзён"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:341
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Заўсёды"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
@@ -7191,93 +4327,56 @@ msgstr "Гісторыя файлаў і сметніца"
 msgid "Don't leave traces"
 msgstr "Не пакідаць слядоў"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "Павінна супадаць з вэб-адрасам правайдара вашага ўліковага запісу."
-
-#: panels/user-accounts/cc-add-user-dialog.c:204
-msgid "Failed to add account"
-msgstr "Не ўдалося дадаць уліковы запіс"
-
-#: panels/user-accounts/cc-add-user-dialog.c:661
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "Паролі не супадаюць."
-
-#: panels/user-accounts/cc-add-user-dialog.c:875
-#: panels/user-accounts/cc-add-user-dialog.c:914
-#: panels/user-accounts/cc-add-user-dialog.c:932
-msgid "Failed to register account"
-msgstr "Не ўдалося зарэгістраваць уліковы запіс"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1047
-msgid "No supported way to authenticate with this domain"
-msgstr "Для гэтага дамену няма даступных спосабаў пацвярджэння сапраўднасці"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1111
-msgid "Failed to join domain"
-msgstr "Не ўдалося далучыцца да дамена"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1166
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Няправільнае імя карыстальніка. \n"
-"Паўтарыце спробу."
+"выкарыстанне;нядаўнія;апошнія;гісторыя;файлы;часовыя;tmp;прыватнасць;"
+"прыватны;сметніца;ачыстка;выдаленне;"
 
-#: panels/user-accounts/cc-add-user-dialog.c:1173
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Няправільны пароль. \n"
-"Паўтарыце спробу."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid "Failed to log into domain"
-msgstr "Не ўдалося ўвайсці ў дамен"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1236
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Не ўдалося знайсці дамен. Можа, вы памыліліся з яго напісаннем?"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Дадаць карыстальніка"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr "_Поўнае імя"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-msgid "Standard"
-msgstr "Звычайны"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "Адміністратар"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-msgid "Account _Type"
-msgstr "_Тып уліковага запісу"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Адміністратар можа дадаваць і выдаляць іншых карыстальнікаў, а таксама "
+"змяняць налады ўсіх карыстальнікаў. Бацькоўскі кантроль не можа быць ужыты "
+"да адміністратараў."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-msgid "Allow user to set a password when they next _login"
-msgstr "Дазволіць карыстальніку задаць пароль пры _ўваходзе"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Карыстальнік задае пароль падчас першага ўваходу"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
-msgid "Set a password _now"
-msgstr "_Задаць пароль"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Задаць пароль цяпер"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
-msgid "_Confirm"
-msgstr "_Пацвердзіць"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Пацвердзіць"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Карпаратыўны ўваход"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Уліковы запіс карыстальніка, якім кіруе кампанія або арганізацыя."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Вы па-за сеткай"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7287,27 +4386,7 @@ msgstr ""
 "кіруемы ўліковы запіс, які існуе. Такі ўліковы запіс таксама можна "
 "выкарыстоўваць, каб мець доступ да рэсурсаў кампаніі праз інтэрнэт."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:732
-msgid "You are Offline"
-msgstr "Вы па-за сеткай"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-msgid "You must be online in order to add enterprise users."
-msgstr "Каб дадаваць карпаратыўных карыстальнікаў, вы павінны быць у сетцы."
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "_Карпаратыўны ўваход"
-
-#: panels/user-accounts/cc-avatar-chooser.c:225
-msgid "Browse for more pictures"
-msgstr "Знайсці больш выяў"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:39
-msgid "Take a Picture…"
-msgstr "Зрабіць здымак…"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:46
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "Выбраць файл…"
 
@@ -7315,19 +4394,19 @@ msgstr "Выбраць файл…"
 msgid "Fingerprint Manager"
 msgstr "Менеджар адбіткаў пальцаў"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:23
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
 msgid "Fingerprint"
 msgstr "Адбітак пальца"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:118
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_Не"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:128
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Так"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:155
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7335,28 +4414,32 @@ msgstr ""
 "Хочаце выдаліць зарэгістраваныя адбіткі пальцаў і адключыць уваход праз "
 "чытальнік адбіткаў?"
 
-#. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
-msgid "No Fingerprint device"
-msgstr "Няма чытальніка адбіткаў пальцаў"
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:259
-msgid "Ensure the device is properly connected."
-msgstr "Пераканайцеся, што прылада падлучана належным чынам."
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:264
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Няма чытальніка адбіткаў пальцаў"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:280
-msgid "Choose the fingerprint device you want to configure"
-msgstr "Выберыце, які чытальнік адбіткаў пальцаў вы хочаце cканфігураваць"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Няма чытальніка адбіткаў пальцаў"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:309
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Пераканайцеся, што прылада падлучана належным чынам."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Чытальнік адбіткаў пальцаў"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:322
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Выберыце, які чытальнік адбіткаў пальцаў вы хочаце наладзіць"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Уваход праз адбітак пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7364,451 +4447,101 @@ msgstr ""
 "Уваход праз адбітак пальца дазваляе разблакіраваць камп'ютар і ўвайсці ў "
 "сістэму з дапамогай пальца"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:352
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "_Выдаліць адбіткі пальцаў"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:363
-msgid "Fingerprint Login"
-msgstr "Уваход праз адбітак пальца"
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:412
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Зарэгістраваць адбітак пальца"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:436
-msgid "_Re-enroll this finger…"
-msgstr "Зарэгістраваць адбітак гэтага пальца зноў…"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Назад"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:236
-msgid "the device needs to be claimed to perform this action"
-msgstr "каб выканаць дзеянне, трэба запытаць доступ да прылады"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Далей"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:238
-msgid "the device is already claimed by another process"
-msgstr "доступ да прылады ўжо запытаў іншы працэс"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:240
-msgid "you do not have permission to perform the action"
-msgstr "у вас няма дазволу на выкананне дзеяння"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:242
-msgid "no prints have been enrolled"
-msgstr "няма зарэгістраваных адбіткаў"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:251
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Не ўдалося звязацца з прыладай падчас рэгістрацыі адбітка"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:255
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Не ўдалося звязацца з чытальнікам адбіткаў пальцаў"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:257
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Не ўдалося звязацца з дэманам адбіткаў"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:585
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Не ўдалося скласці спіс адбіткаў пальцаў: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:652
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Не ўдалося выдаліць захаваныя адбіткі пальцаў: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:683
-msgid "Left thumb"
-msgstr "Левы вялікі палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:685
-msgid "Left middle finger"
-msgstr "Левы сярэдні палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:687
-msgid "_Left index finger"
-msgstr "_Левы ўказальны палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:689
-msgid "Left ring finger"
-msgstr "Левы безыменны палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:691
-msgid "Left little finger"
-msgstr "Левы мезены палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:693
-msgid "Right thumb"
-msgstr "Правы вялікі палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:695
-msgid "Right middle finger"
-msgstr "Правы сярэдні палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:697
-msgid "_Right index finger"
-msgstr "_Правы ўказальны палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:699
-msgid "Right ring finger"
-msgstr "Правы безыменны палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:701
-msgid "Right little finger"
-msgstr "Правы мезены палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:703
-msgid "Unknown Finger"
-msgstr "Невядомы палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:837
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Выканана"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:848
-msgid "Fingerprint device disconnected"
-msgstr "Чытальнік адбіткаў пальцаў не падлучаны"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:854
-msgid "Fingerprint device storage is full"
-msgstr "Памяць чытальніка адбіткаў пальцаў запоўнена"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:858
-msgid "Failed to enroll new fingerprint"
-msgstr "Не ўдалося зарэгістраваць новы адбітак пальца"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:889
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Не ўдалося запусціць рэгістрацыю: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:897
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Не ўдалося зарэгістраваць новы адбітак пальца"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Не ўдалося спыніць рэгістрацыю: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:974
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Аднімайце і прыкладвайце палец да чытальніка некалькі разоў, каб "
-"зарэгістраваць адбітак пальца"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1118
-msgid "Scan new fingerprint"
-msgstr "Счытванне новага адбітка пальца"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1157
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Не ўдалося вызваліць чытальнік адбіткаў пальцаў %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1229
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Праблема з прыладай счытвання"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1264
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Не ўдалося запытаць доступ да чытальніка адбіткаў пальцаў %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1413
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Не ўдалося атрымаць чытальнік адбіткаў пальцаў: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "На гэтым тыдні"
-
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
-msgstr "На мінулым тыдні"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%-d %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%-d %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:771
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:775
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr "Сеанс скончаны"
-
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr "Запуск сеанса"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — актыўнасць уліковага запісу"
-
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr "Выберыце іншы пароль."
-
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
-msgstr "Увядзіце бягучы пароль яшчэ раз."
-
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
-msgstr "Не ўдалося змяніць пароль"
-
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Змяніць пароль"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "_Змяніць"
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr "_Пацвердзіце новы пароль"
-
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr "_Новы пароль"
-
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
 msgstr "_Бягучы пароль"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "_Новы пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "_Пацвердзіце новы пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Паролі не супадаюць."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Дазволіць карыстальніку змяніць пароль пры ўваходзе"
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Задаць пароль"
 
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Немагчыма аўтаматычна далучыцца да дамена гэтага тыпу"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Карыстальнікі"
 
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Дамен ці рэгіён не знойдзены"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Не ўдалося ўвайсці як %s у дамен %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Памылковы пароль, паўтарыце спробу"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Не ўдалося злучыцца з даменам %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:222
-msgid "Your account"
-msgstr "Ваш уліковы запіс"
-
-#: panels/user-accounts/cc-user-panel.c:402
-msgid "Failed to delete user"
-msgstr "Не ўдалося выдаліць карыстальніка"
-
-#: panels/user-accounts/cc-user-panel.c:457
-#: panels/user-accounts/cc-user-panel.c:512
-#: panels/user-accounts/cc-user-panel.c:558
-msgid "Failed to revoke remotely managed user"
-msgstr "Не ўдалося ануляваць аддаленага карыстальніка"
-
-#: panels/user-accounts/cc-user-panel.c:607
-msgid "You cannot delete your own account."
-msgstr "Нельга выдаліць уласны ўліковы запіс."
-
-#: panels/user-accounts/cc-user-panel.c:616
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s не выйшаў з сістэмы"
-
-#: panels/user-accounts/cc-user-panel.c:620
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Выдаленне карыстальніка, які не выйшаў з сістэмы, можа прывесці сістэму ў "
-"супярэчлівы стан."
-
-#: panels/user-accounts/cc-user-panel.c:629
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Пакінуць файлы карыстальніка %s?"
-
-#: panels/user-accounts/cc-user-panel.c:633
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Пры выдаленні ўліковага запісу карыстальніка можна пакінуць яго хатні "
-"каталог, пошту і часовыя файлы."
-
-#: panels/user-accounts/cc-user-panel.c:636
-msgid "_Delete Files"
-msgstr "_Выдаліць файлы"
-
-#: panels/user-accounts/cc-user-panel.c:637
-msgid "_Keep Files"
-msgstr "_Захаваць файлы"
-
-#: panels/user-accounts/cc-user-panel.c:651
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Сапраўды ануляваць уліковы запіс аддаленага карыстальніка %s?"
-
-#: panels/user-accounts/cc-user-panel.c:655
-msgid "_Delete"
-msgstr "_Выдаліць"
-
-#: panels/user-accounts/cc-user-panel.c:705
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Уліковы запіс адключаны"
-
-#: panels/user-accounts/cc-user-panel.c:713
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Будзе зададзена пры наступным уваходзе"
-
-#: panels/user-accounts/cc-user-panel.c:716
-msgctxt "Password mode"
-msgid "None"
-msgstr "Няма"
-
-#: panels/user-accounts/cc-user-panel.c:759
-msgid "Logged in"
-msgstr "У сістэме"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:846
-#: panels/user-accounts/cc-user-panel.c:935
-#: panels/wwan/cc-wwan-device-page.c:443
-msgid "Enabled"
-msgstr "Уключана"
-
-#: panels/user-accounts/cc-user-panel.c:1259
-msgid "Failed to contact the accounts service"
-msgstr "Не ўдалося звязацца з сэрвісам уліковых запісаў"
-
-#: panels/user-accounts/cc-user-panel.c:1261
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Праверце, ці ўсталяваны і ўключаны AccountService."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Каб унесці змены,\n"
-"спачатку націсніце на значок *"
-
-#: panels/user-accounts/cc-user-panel.c:1366
-msgid "Delete the selected user account"
-msgstr "Выдаліць вылучаны ўліковы запіс карыстальніка"
-
-#: panels/user-accounts/cc-user-panel.c:1378
-#: panels/user-accounts/cc-user-panel.c:1489
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Каб выдаліць уліковы запіс вылучанага карыстальніка,\n"
-"спачатку націсніце на значок *"
-
-#: panels/user-accounts/cc-user-panel.c:1535
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Разблакіруйце, каб дадаваць карыстальнікаў і змяняць налады"
-
-#: panels/user-accounts/cc-user-panel.ui:6
-msgid "_Add User…"
-msgstr "_Дадаць карыстальніка…"
-
-#: panels/user-accounts/cc-user-panel.ui:9
-msgid "Create a user account"
-msgstr "Стварыць уліковы запіс карыстальніка"
-
-#: panels/user-accounts/cc-user-panel.ui:64
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "Каб змены ўступілі ў сілу, трэба перазапусціць сеанс"
 
-#: panels/user-accounts/cc-user-panel.ui:72
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Перазапусціць"
 
-#: panels/user-accounts/cc-user-panel.ui:157
-#: panels/user-accounts/cc-user-panel.ui:173
-msgid "User Icon"
-msgstr "Значок карыстальніка"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Закрыць"
 
-#: panels/user-accounts/cc-user-panel.ui:249
-msgid "Account Settings"
-msgstr "Налады ўліковага запісу"
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Змяніць аватар"
 
-#: panels/user-accounts/cc-user-panel.ui:267
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Поўнае імя"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Змяніць"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Уваход праз адбітак пальца"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Аўтаматычны ўваход"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Актыўнасць уліковага запісу"
+
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Адміністратар"
 
-#: panels/user-accounts/cc-user-panel.ui:268
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7816,68 +4549,58 @@ msgstr ""
 "Адміністратар можа дадаваць і выдаляць іншых карыстальнікаў, а таксама "
 "змяняць налады ўсіх карыстальнікаў."
 
-#: panels/user-accounts/cc-user-panel.ui:284
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "_Бацькоўскі кантроль"
 
-#: panels/user-accounts/cc-user-panel.ui:285
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Адкрыць праграму для бацькоўскага кантролю."
 
-#: panels/user-accounts/cc-user-panel.ui:347
-msgid "Authentication & Login"
-msgstr "Праверка сапраўднасці і ўваход"
-
-#: panels/user-accounts/cc-user-panel.ui:390
-msgid "_Fingerprint Login"
-msgstr "_Уваход праз адбітак пальца"
-
-#: panels/user-accounts/cc-user-panel.ui:415
-msgid "A_utomatic Login"
-msgstr "_Аўтаматычны ўваход"
-
-#: panels/user-accounts/cc-user-panel.ui:429
-msgid "Account Activity"
-msgstr "Актыўнасць уліковага запісу"
-
-#: panels/user-accounts/cc-user-panel.ui:460
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Выдаліць карыстальніка…"
 
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Іншыя карыстальнікі"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Дадаць карыстальніка…"
+
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:501
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Не знойдзена карыстальнікаў"
 
-#: panels/user-accounts/cc-user-panel.ui:511
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Разблакіруйце, каб дадаць уліковы запіс карыстальніка."
-
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
-msgid "Users"
-msgstr "Карыстальнікі"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "Дадаванне або выдаленне карыстальнікаў і змяненне пароля"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"Уваход;Сеанс;Імя карыстальніка;Адбіткі пальцаў;Сканер;Аватар;Лагатып;Выява;"
-"Твар;Вобраз;Пароль;"
+"Уваход;Сеанс;Імя;Адбітак;Адбіткі пальцаў;;Аватар;Лагатып;Выява;Твар;Вобраз;"
+"Пароль;Бацькоўскі кантроль;Абмежаванне часу сеанса;Абмежаванне праграм;"
+"Абмежаванне сайтаў;Абмежаванне выкарыстання;Тэрмін карыстання;Дзіцячы;Дзеці;"
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Зарэгістраваць"
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Імя адміністратара дамена"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -7887,11 +4610,11 @@ msgstr ""
 "зарэгістраваць гэты камп'ютар у дамене. Папрасіце адміністратара\n"
 "сеткі ўвесці сюды пароль для дамена."
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "І_мя адміністратара"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Пароль адміністратара"
 
@@ -7903,198 +4626,16 @@ msgstr "Налады ўліковых запісаў карыстальніка"
 msgid "Authentication is required to change user data"
 msgstr "Для змянення даных карыстальніка патрабуецца праверка сапраўднасці"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Новы пароль павінен адрознівацца ад старога."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Паспрабуйце змяніць некалькі літар ці лічбаў."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Паспрабуйце яшчэ больш змяніць пароль."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Пароль, які не змяшчае імені карыстальніка, будзе больш трывалым."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Пазбягайце ўжывання імені карыстальніка ў паролі."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Паспрабуйце прыбраць некаторыя словы з пароля."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Пазбягайце ўжывання агульнавядомых слоў."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Пазбягайце перастаноўкі існуючых слоў."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Паспрабуйце дадаць болей лічбаў."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Паспрабуйце дадаць болей літар верхняга рэгістра."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Паспрабуйце дадаць болей літар ніжняга рэгістра."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Паспрабуйце дадаць болей спецыяльных знакаў, напрыклад, пунктуацыйных."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Паспрабуйце чаргаваць літары, лічбы і знакаў прыпынку."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Пазбягайце паўтарэння аднаго і таго ж знака."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Пазбягайце паўтарэння тыпаў ужытых знакаў, чаргуйце літары з лічбамі і "
-"знакамі прыпынку."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Пазбягайце паслядоўнасці знакаў накшталт 1234 ці abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Пароль павінен быць даўжэйшым. Паспрабуйце дадаць болей літар, лічбаў і "
-"знакаў прыпынку."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Чаргуйце літары і верхняга і ніжняга рэгістра, паспрабуйце дадаць адну ці "
-"некалькі лічбаў."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Дадаванне вялікай колькасці літар, лічбаў і знакаў прыпынку зробіць пароль "
-"больш трывалым."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Сапраўднасць не пацверджана"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "Новы пароль надта кароткі"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "Новы пароль надта просты"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Стары і новы паролі надта падобныя"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Новы пароль нядаўна ўжо выкарыстоўваўся."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Новы пароль мусіць змяшчаць лічбы ці спецыяльныя знакі"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Стары і новы паролі аднолькавыя"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Ваш пароль змяніўся пасля апошняга пацвярджэння сапраўднасці!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Новы пароль не змяшчае дастатковай колькасці разнастайных знакаў"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Невядомая памылка"
-
-#: panels/user-accounts/user-utils.c:432
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Звычайна імя карыстальніка можа ўтрымліваць толькі лацінскія літары ў ніжнім "
-"рэгістры, лічбы і наступныя сімвалы: - _"
-
-#: panels/user-accounts/user-utils.c:436
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Гэтае імя карыстальніка недаступна. Паспрабуйце іншае."
-
-#: panels/user-accounts/user-utils.c:478
-msgid "The username is too long."
-msgstr "Імя карыстальніка занадта доўгае."
-
-#: panels/user-accounts/user-utils.c:537
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr "Выкарыстоўваецца як назва хатняй папкі і не можа быць зменена пазней."
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Прызначэнне кнопак"
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "_Закрыць"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Прызначыць функцыі кнопкам"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -8103,74 +4644,122 @@ msgstr ""
 "затым націсніце і ўтрымлівайце новае спалучэнне клавіш або націсніце "
 "Backspace, каб ачысціць."
 
-#: panels/wacom/calibrator/calibrator.ui:61
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Закрыць"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr "Кранайце маркеры, якія ўзнікаюць на экране, каб адкалібраваць планшэт."
 
-#: panels/wacom/calibrator/calibrator.ui:78
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "Выяўлена памылковае націсканне, перазапуск…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Кнопка %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Знешні графічны планшэт"
 
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Праграма вызначана"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Рэжым планшэта"
 
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Адправіць націснутыя клавішы"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Выкарыстоўваць абсалютнае пазіцыянаванне для пяра"
 
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Пераключэнне манітора"
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Прыстасаваць для левай рукі"
 
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Паказаць экранную даведку"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Планшэт і клавішы Express Keys™ павернуты для карыстання левай рукой"
 
-#: panels/wacom/cc-wacom-mapping-panel.c:245
-msgid "Output:"
-msgstr "Вывад:"
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Прывязаць да манітора"
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:257
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Захоўваць прапорцыі (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Захоўваць суадносіны бакоў"
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:268
-msgid "Map to single monitor"
-msgstr "Прывязаць да аднаго манітора"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Выкарыстоўваць толькі частку паверхні планшэта, каб захаваць суадносіны "
+"бакоў манітора"
 
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
-msgstr "%d з %d"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Адкалібраваць"
 
-#: panels/wacom/cc-wacom-page.c:516
-msgid "Display Mapping"
-msgstr "Прывязка да манітора"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Планшэт не знойдзены"
 
-#: panels/wacom/cc-wacom-panel.c:725 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
-msgstr "Пяро"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Падлучыце або ўключыце планшэт Wacom."
 
-#: panels/wacom/cc-wacom-stylus-page.c:357
-msgid "Button"
-msgstr "Кнопка"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Адчувальнасць націску пяра"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Мяккая"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Націск пяра"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Цвёрдая"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Кнопка 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Кнопка 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Кнопка 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Адчувальнасць націску сціркі"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Націск сціркі"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Сярэдняя кнопка мышы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Правая кнопка мышы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Наперад"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr "Планшэт Wacom"
 
@@ -8178,303 +4767,134 @@ msgstr "Планшэт Wacom"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Прызначэнне кнопак і змяненне адчувальнасці пяра графічных планшэтаў"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Планшэт;Wacom;Стыло;Пяро;Сцірка;Мыш;"
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "Планшэт (абсалютныя каардынаты)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
-msgstr "Сэнсарная панэль (адносныя каардынаты)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "Параметры планшэта"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "_Даведка"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
-msgstr "Планшэт не знойдзены"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Падлучыце або ўключыце планшэт Wacom"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
-msgstr "Налады Bluetooth"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
-msgstr "Рэжым адсочвання"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
-msgstr "Прыстасаваць для левай рукі"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Сімуляцыя націскання правай кнопкі"
 
-#: panels/wacom/gnome-wacom-properties.ui:296
-#: panels/wacom/gnome-wacom-properties.ui:401
-msgid "Map to Monitor…"
-msgstr "Прывязаць да манітора…"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "ПЗ Windows"
 
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
-msgstr "Прызначыць кнопкі…"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
-msgstr "Адкалібраваць…"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Тонер заканчваецца"
 
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
-msgstr "Змяніць налады мышы"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Затрымка да націскання правай кнопкай"
 
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
-msgstr "Наладзіць разрознасць дысплэя"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "ПЗ Windows"
 
-#: panels/wacom/gnome-wacom-properties.ui:376
-msgid "Decouple Display"
-msgstr "Раз'яднаць дысплэй"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Кіраванне параметрамі прадукцыйнасці і шматзадачнасці"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr "Новае спалучэнне клавіш…"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "Стандартны"
-
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "Сярэдняя кнопка мышы"
-
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "Правая кнопка мышы"
-
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "Наперад"
-
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
-msgstr "Пяро не знойдзена"
-
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr "Перамясціце пяро бліжэй да планшэта, каб наладзіць"
-
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
-msgstr "Адчувальнасць націску сціркі"
-
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
-msgid "Soft"
-msgstr "Мяккая"
-
-#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
-msgid "Firm"
-msgstr "Цвёрдая"
-
-#: panels/wacom/wacom-stylus-page.ui:234
-msgid "Top Button"
-msgstr "Верхняя кнопка"
-
-#: panels/wacom/wacom-stylus-page.ui:263
-msgid "Lower Button"
-msgstr "Ніжняя кнопка"
-
-#: panels/wacom/wacom-stylus-page.ui:292
-msgid "Lowest Button"
-msgstr "Самая ніжняя кнопка"
-
-#: panels/wacom/wacom-stylus-page.ui:321
-msgid "Tip Pressure Feel"
-msgstr "Адчувальнасць націску пяра"
-
-#: panels/wwan/cc-wwan-apn-dialog.ui:11
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Пункты доступу"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:160
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Дадаць"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Захаваць"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
 
-#: panels/wwan/cc-wwan-data.c:543
-msgid "Operation Cancelled"
-msgstr "Аперацыя скасавана"
-
-#: panels/wwan/cc-wwan-data.c:546
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Памылка.</b> Няма доступу на змяненне налад"
-
-#: panels/wwan/cc-wwan-data.c:549
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Памылка.</b> Памылка мабiльнага абсталявання"
-
-#: panels/wwan/cc-wwan-details-dialog.c:81
-msgid "Not Registered"
-msgstr "Не зарэгістраваны"
-
-#: panels/wwan/cc-wwan-details-dialog.c:85
-msgid "Registered"
-msgstr "Зарэгістраваны"
-
-#: panels/wwan/cc-wwan-details-dialog.c:89
-msgid "Roaming"
-msgstr "Роўмінг"
-
-#: panels/wwan/cc-wwan-details-dialog.c:93
-msgid "Searching"
-msgstr "Пошук"
-
-#: panels/wwan/cc-wwan-details-dialog.c:97
-msgid "Denied"
-msgstr "Адмоўлена"
-
-#: panels/wwan/cc-wwan-details-dialog.ui:4
+#: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
 msgstr "Падрабязнасці пра мадэм"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:33
+#: panels/wwan/cc-wwan-details-dialog.ui:16
 msgid "Modem Status"
 msgstr "Стан мадэма"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:53
+#: panels/wwan/cc-wwan-details-dialog.ui:25
 msgid "Carrier"
 msgstr "Аператар"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:79
+#: panels/wwan/cc-wwan-details-dialog.ui:49
 msgid "Network Type"
 msgstr "Тып сеткі"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:131
+#: panels/wwan/cc-wwan-details-dialog.ui:97
 msgid "Network Status"
 msgstr "Стан сеткі"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:158
+#: panels/wwan/cc-wwan-details-dialog.ui:122
 msgid "Own Number"
 msgstr "Свой нумар"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:185
+#: panels/wwan/cc-wwan-details-dialog.ui:151
 msgid "Device Details"
 msgstr "Падрабязнасці аб прыладзе"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:257
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Вытворца"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Версія ўбудаванага ПЗ"
 
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Толькі 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Толькі 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Толькі 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (пажадана)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (пажадана), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-#| msgid " (Preferred)"
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (пажадана), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-#| msgid " (Preferred)"
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (пажадана)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-#| msgid " (Preferred)"
-msgid "3G (Preferred), 4G"
-msgstr "3G (пажадана), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-#| msgid " (Preferred)"
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (пажадана)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-#| msgid " (Preferred)"
-msgid "2G (Preferred), 4G"
-msgstr "2G (пажадана), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-#| msgid " (Preferred)"
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (пажадана)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-#| msgid " (Preferred)"
-msgid "2G (Preferred), 3G"
-msgstr "2G (пажадана), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Невядома"
-
-#: panels/wwan/cc-wwan-device-page.c:141
-msgid "Unlock SIM card"
-msgstr "Разблакіраванне SIM-карты"
-
-#: panels/wwan/cc-wwan-device-page.c:142 panels/wwan/cc-wwan-device-page.c:190
-msgid "Unlock"
-msgstr "Разблакіраваць"
-
-#: panels/wwan/cc-wwan-device-page.c:147
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Увядзіце PIN-код для SIM-карты %d"
-
-#: panels/wwan/cc-wwan-device-page.c:148
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Увядзіце PIN-код, каб разблакіраваць SIM-карту"
-
-#: panels/wwan/cc-wwan-device-page.c:152
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Увядзіце PUK-код для SIM-карты %d"
-
-#: panels/wwan/cc-wwan-device-page.c:153
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Увядзіце PUK-код, каб разблакіраваць SIM-карту"
-
-#: panels/wwan/cc-wwan-device-page.c:171
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
 msgid "Wrong password entered. You have %1$u try left"
 msgid_plural "Wrong password entered. You have %1$u tries left"
@@ -8482,7 +4902,7 @@ msgstr[0] "Уведзены няправільны пароль. Застала�
 msgstr[1] "Уведзены няправільны пароль. Засталося %1$u спробы"
 msgstr[2] "Уведзены няправільны пароль. Засталося %1$u спроб"
 
-#: panels/wwan/cc-wwan-device-page.c:174
+#: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
@@ -8490,323 +4910,173 @@ msgstr[0] "Засталася %1$u спроба"
 msgstr[1] "Засталося %1$u спробы"
 msgstr[2] "Засталося %1$u спроб"
 
-#: panels/wwan/cc-wwan-device-page.c:179
-msgid "Wrong password entered."
-msgstr "Уведзены няправільны пароль."
-
-#: panels/wwan/cc-wwan-device-page.c:224
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK-код павінен змяшчаць 8 лічбаў"
-
-#: panels/wwan/cc-wwan-device-page.c:248
-msgid "Enter New PIN"
-msgstr "Увядзіце новы PIN-код"
-
-#: panels/wwan/cc-wwan-device-page.c:252
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN-код павінен павінен змяшчаць ад 4 да 8 лічбаў"
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "Unlocking..."
-msgstr "Разблакіраванне..."
-
-#: panels/wwan/cc-wwan-device-page.ui:34
+#: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
 msgstr "Няма SIM-карты"
 
-#: panels/wwan/cc-wwan-device-page.ui:45
+#: panels/wwan/cc-wwan-device-page.ui:19
 msgid "Insert a SIM card to use this modem"
 msgstr "Устаўце SIM-карту, каб выкарыстоўваць гэты мадэм"
 
-#: panels/wwan/cc-wwan-device-page.ui:78
+#: panels/wwan/cc-wwan-device-page.ui:33
 msgid "SIM Locked"
 msgstr "SIM-карта заблакіравана"
 
-#: panels/wwan/cc-wwan-device-page.ui:139
+#: panels/wwan/cc-wwan-device-page.ui:77
 msgid "_Mobile Data"
 msgstr "_Мабільныя даныя"
 
-#: panels/wwan/cc-wwan-device-page.ui:140
+#: panels/wwan/cc-wwan-device-page.ui:78
 msgid "Access data using mobile network"
-msgstr "Перадача даных праз мабiльную сетку"
+msgstr "Перадача даных праз мабільную сетку"
 
-#: panels/wwan/cc-wwan-device-page.ui:151
+#: panels/wwan/cc-wwan-device-page.ui:88
 msgid "_Data Roaming"
 msgstr "Перадача _даных у роўмінгу"
 
-#: panels/wwan/cc-wwan-device-page.ui:152
+#: panels/wwan/cc-wwan-device-page.ui:89
 msgid "Use mobile data when roaming"
 msgstr "Выкарыстанне перадачы даных праз мабільную сетку ў роўмінгу"
 
-#: panels/wwan/cc-wwan-device-page.ui:177
+#: panels/wwan/cc-wwan-device-page.ui:115
 msgid "_Network Mode"
 msgstr "_Рэжым сеткі"
 
-#: panels/wwan/cc-wwan-device-page.ui:187
+#: panels/wwan/cc-wwan-device-page.ui:122
 msgid "N_etwork"
 msgstr "_Сетка"
 
-#: panels/wwan/cc-wwan-device-page.ui:199
+#: panels/wwan/cc-wwan-device-page.ui:132
 msgid "Advanced"
 msgstr "Дадатковыя"
 
-#: panels/wwan/cc-wwan-device-page.ui:225
+#: panels/wwan/cc-wwan-device-page.ui:146
 msgid "_Access Point Names"
 msgstr "Назвы _пунктаў доступу"
 
-#: panels/wwan/cc-wwan-device-page.ui:235
+#: panels/wwan/cc-wwan-device-page.ui:155
 msgid "_SIM Lock"
 msgstr "Блакіраванне SIM-карты"
 
-#: panels/wwan/cc-wwan-device-page.ui:236
+#: panels/wwan/cc-wwan-device-page.ui:156
 msgid "Lock SIM with PIN"
 msgstr "Устанавіць PIN-код"
 
-#: panels/wwan/cc-wwan-device-page.ui:246
+#: panels/wwan/cc-wwan-device-page.ui:165
 msgid "M_odem Details"
 msgstr "Падрабязнасці пра _мадэм"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Збой тэлефона"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Няма злучэння з тэлефонам"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Аперацыя не дазволена"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Аперацыя не падтрымліваецца"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM-карта не ўстаўлена"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Патрабуецца PIN-код SIM-карты"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Патрабуецца PUK-код SIM-карты"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Збой SIM-карты"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM-карта занята"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Няправільны пароль"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Патрабуецца PIN2-код SIM-карты"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Патрабуецца PUK2-код SIM-карты"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Не знойдзена"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Сетка не абслугоўваецца"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Мінуў час чакання сеткі"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Паслуга GPRS не дазволена"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Роўмінг не дазволены ў гэтым рэгіёне"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Нявызначаная памылка GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "Дзеянне скасавана"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Доступ забаронены"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Невядомая памылка"
-
-#: panels/wwan/cc-wwan-mode-dialog.ui:4
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Рэжым сеткі"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:44
-#: panels/wwan/cc-wwan-network-dialog.ui:175
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:230
-msgid "_Set"
-msgstr "_Задаць"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:46 panels/wwan/cc-wwan-panel.ui:39
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:101
-msgid "Close"
-msgstr "Закрыць"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Аўтаматычна"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:100
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Выберыце сетку"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:118
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Абнавіць спіс правайдараў"
 
-#: panels/wwan/cc-wwan-panel.c:453 panels/wwan/cc-wwan-panel.c:482
-#, c-format
-msgid "SIM %d"
-msgstr "SIM-карта %d"
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Уключыць мабільную сетку"
 
-#: panels/wwan/cc-wwan-panel.ui:101
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "Адаптар WWAN не знойдзены"
 
-#: panels/wwan/cc-wwan-panel.ui:112
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr ""
 "Праверце, ці падключаны адаптар бесправадной глабальнай сеткі або мабільная "
 "прылада"
 
-#: panels/wwan/cc-wwan-panel.ui:154
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "Бесправадная глабальная сетак выключана ў рэжыме палёту"
 
-#: panels/wwan/cc-wwan-panel.ui:163
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "_Выключыць рэжым палёту"
 
-#: panels/wwan/cc-wwan-panel.ui:210
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "Перадача даных"
 
-#: panels/wwan/cc-wwan-panel.ui:224
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "SIM-карта, якая ўжываецца для доступу ў інтэрнэт"
 
-#: panels/wwan/cc-wwan-panel.ui:332
-msgid "Enable Mobile Network"
-msgstr "Уключыць мабiльную сетку"
-
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:11
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
 msgid "SIM Lock"
 msgstr "Блакіраванне SIM-карты"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:22
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
 msgid "_Next"
 msgstr "_Далей"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:141
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "_Устанавіць PIN-код"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:158
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "Змяніць PIN-код"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:256
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr "Увядзіце цяперашні PIN-код, каб змяняць налады блакіравання SIM-карты"
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:3
 msgid "Mobile Network"
-msgstr "Мабiльная сетка"
+msgstr "Мабільная сетка"
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:4
 msgid "Configure Telephony and mobile data connections"
 msgstr "Канфігураванне тэлефаніі і перадачы даных праз мабільную сетку"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/wwan/gnome-wwan-panel.desktop.in.in:17
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "сотавая;мабільная;тэлэфанія;сім;"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Settings"
-msgstr "Налады GNOME"
-
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
 msgstr "Утыліта для канфігуравання асяроддзя GNOME"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr "Налады — гэта асноўны інтэрфейс для канфігуравання сістэмы."
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:20
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "Праект GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Паказаць нумар версіі"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Катэгорыі налад"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Уключыць падрабязны рэжым"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Пошук радка"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Вывесці спіс магчымых назваў панэляў і выйсці"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Панэль для паказу"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[ПАНЭЛЬ] [АРГУМЕНТ…]"
-
-#: shell/cc-panel-list.ui:45 shell/cc-window.c:275
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Прыватнасць"
 
-#: shell/cc-panel-loader.c:299
-msgid "Available panels:"
-msgstr "Даступныя панэлі:"
-
-#: shell/cc-window.ui:136
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Усе налады"
 
-#: shell/cc-window.ui:174
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr "Асноўнае меню"
 
-#: shell/cc-window.ui:318
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr "Увага. Версія для распрацоўшчыкаў"
 
-#: shell/cc-window.ui:319
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
@@ -8815,14 +5085,9 @@ msgstr ""
 "Гэтая версія Налад прызначана толькі для распрацоўкі. Вы можаце сутыкнуцца з "
 "няправільнымі паводзінамі, стратай даных і іншымі нечаканымі праблемамі. "
 
-#: shell/cc-window.ui:330
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Даведка"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "Settings;Налады;Параметры;Настройкі;Настаўленні;"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -8854,6 +5119,10 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Скасаваць пошук"
 
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Settings;Налады;Параметры;Настройкі;Настаўленні;"
+
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
 msgstr "Ідэнтыфікатар апошняй адкрытай панэлі Налад"
@@ -8875,9 +5144,19 @@ msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Ці паказваць папярэджанне пры запуску версіі для распрацоўшчыкаў."
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Пачатковы стан акна"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Картэж, які змяшчае пачатковую шырыню, вышыню і стан разгорнутасці акна "
+"праграмы."
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
@@ -8885,9 +5164,7 @@ msgstr[0] "%u выхад"
 msgstr[1] "%u выхады"
 msgstr[2] "%u выхадаў"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
@@ -8895,9 +5172,3566 @@ msgstr[0] "%u уваход"
 msgstr[1] "%u уваходы"
 msgstr[2] "%u уваходаў"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "Сістэмныя гукі"
+#~ msgid "System Bus"
+#~ msgstr "Сістэмная шына"
+
+#~ msgid "Full access"
+#~ msgstr "Поўны доступ"
+
+#~ msgid "Session Bus"
+#~ msgstr "Шына сеанса"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Поўны доступ да /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Мае доступ да сеткі"
+
+#~ msgid "Home"
+#~ msgstr "Хатняя папка"
+
+#~ msgid "Read-only"
+#~ msgstr "Толькі для чытання"
+
+#~ msgid "File System"
+#~ msgstr "Файлавая сістэма"
+
+#~ msgid "Can change settings"
+#~ msgstr "Можа змяняць налады"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s мае наступныя ўбудаваныя дазволы, іх немагчыма змяніць. Калі гэтыя "
+#~ "дазволы вас непакояць, падумайце ці не варта выдаліць праграму."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u тып файла і спасылкі, які адкрываецца праграмай"
+#~ msgstr[1] "%u тыпы файлаў і спасылак, якія адкрываюцца праграмай"
+#~ msgstr[2] "%u тыпаў файлаў і спасылак, якія адкрываюцца праграмай"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> выкарыстоўваецца, каб адкрываць наступныя тыпы файлаў і "
+#~ "спасылак."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "Выкарыстана %s дыскавай прасторы."
+
+#~ msgid "Select a picture"
+#~ msgstr "Выберыце выяву"
+
+#~ msgid "_Open"
+#~ msgstr "_Адкрыць"
+
+#~ msgid "multiple sizes"
+#~ msgstr "некалькі памераў"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Без фону працоўнага стала"
+
+#~ msgid "Current background"
+#~ msgstr "Цяперашні фон"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Змясціце калібравальную прыладу на квадрат і націсніце «Пачаць»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Перамясціце калібравальную прыладу ў абазначанае месца і націсніце "
+#~ "«Працягнуць»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Перамясціце калібравальную прыладу на абазначаную паверхню і націсніце "
+#~ "«Працягнуць»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Закрыйце вечка ноўтбука"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Узнікла непапраўная ўнутраная памылка."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Не ўсталяваны інструменты для каліброўкі.."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Не ўдалося стварыць профіль."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Мэтавы пункт белага не атрыманы."
+
+#~ msgid "Complete!"
+#~ msgstr "Выканана!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Не ўдалося выканаць каліброўку!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Можна прыбраць калібравальную прыладу."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Падчас працы не чапайце калібравальную прыладу"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Экран ноўтбука"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Убудаваная вэб-камера"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Манітор %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Сканер %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Камера %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Прынтар %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Вэб-камера %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Уключыць кіраванне колерамі для %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Паказаць колеравыя профілі для %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Не адкалібраваны"
+
+#~ msgid "Default: "
+#~ msgstr "Прадвызначаны: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Колеравая прастора: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Тэставы профіль: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Выберыце файл профілю ICC"
+
+#~ msgid "_Import"
+#~ msgstr "І_мпартаваць"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Вядомыя профілі ICC"
+
+#~ msgid "All files"
+#~ msgstr "Усе файлы"
+
+#~ msgid "Save Profile"
+#~ msgstr "Захаваць профіль"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Стварыць колеравы профіль для вылучанай прылады"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Вымяральны інструмент не знойдзены. Праверце, што ён уключаны і правільна "
+#~ "падлучаны."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Вымяральны інструмент не падтрымлівае прафілявання прынтараў."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Гэты тып прылад зараз не падтрымліваецца."
+
+#~ msgid "Standard Space"
+#~ msgstr "Стандартная прастора"
+
+#~ msgid "Test Profile"
+#~ msgstr "Праверачны профіль"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Аўтаматычны"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Нізкая якасць"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Сярэдняя якасць"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Высокая якасць"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Прадвызначаны RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Прадвызначаны CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Прадвызначаны шэры"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Калібравальныя даныя ад вытворцы"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Поўнаэкранны рэжым карэкцыі дысплэя з гэтым профілем немагчымы"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Гэты профіль ужо можа быць недакладным"
+
+#~ msgid "Other…"
+#~ msgstr "Іншая…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Разблакіруйце, каб змяняць налады"
+
+#~ msgid "Today"
+#~ msgstr "Сёння"
+
+#~ msgid "Yesterday"
+#~ msgstr "Учора"
+
+#~ msgid "%b %e"
+#~ msgstr "%-d %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-d %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d гадзіна"
+#~ msgstr[1] "%d гадзіны"
+#~ msgstr[2] "%d гадзін"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d хвіліна"
+#~ msgstr[1] "%d хвіліны"
+#~ msgstr[2] "%d хвілін"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d секунда"
+#~ msgstr[1] "%d секунды"
+#~ msgstr[2] "%d секунд"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Хот-спот"
+
+#~ msgid "24-hour"
+#~ msgstr "24 гадзіны"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Справаздачы пра тэхнічныя праблемы дапамагаюць нам удасканальваць %s. Усе "
+#~ "справаздачы адпраўляюцца ананімна і не змяшчаюць персанальных дадзеных. %s"
+
+#~ msgid "On"
+#~ msgstr "Уключана"
+
+#~ msgid "Off"
+#~ msgstr "Выключана"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Ужыць змены?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Немагчыма ўжыць змены"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Магчыма, гэта з-за апаратных абмежаванняў."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Альбомная"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Кніжная (на правы бок)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Кніжная (на левы бок)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Альбомная (перавернутая)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Гц"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Secure Boot актыўна"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Secure boot прадухіляе загрузку шкоднага праграмнага забеспячэння падчас "
+#~ "запуску прылады. Зараз функцыя ўключана і працуе правільна."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Праблемы з Secure Boot"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Secure boot прадухіляе загрузку шкоднага праграмнага забеспячэння падчас "
+#~ "запуску прылады. Зараз функцыя ўключана, але не будзе працаваць з-за "
+#~ "памылковага ключа."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Праблемы з Secure boot часта можна вырашыць праз налады UEFI (BIOS) "
+#~ "камп'ютара і з дапамогай вытворцы вашага абсталявання, які можа даць "
+#~ "інфармацыю як гэта зрабіць."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Звярніцеся па дапамогу да вытворцы вашага абсталявання або да службы "
+#~ "абслугоўвання і падтрымкі."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Secure Boot выключана"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Secure boot прадухіляе загрузку шкоднага праграмнага забеспячэння падчас "
+#~ "запуску прылады. Зараз функцыя выключана."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Secure boot часта можна ўключыць праз налады UEFI (BIOS) камп'ютара. "
+#~ "Звярніцеся па дапамогу да вытворцы вашага абсталявання або да службы "
+#~ "абслугоўвання і падтрымкі."
+
+#~ msgid "Passed"
+#~ msgstr "Пройдзена"
+
+#~ msgid "Failed"
+#~ msgstr "Няўдача"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Прылада адпавядае %d узроўню HSI"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Узровень бяспекі 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Гэта прылада не мае абароны ад праблем бяспекі ў апаратнага забеспячэння. "
+#~ "Магчыма праблема з-за канфігурацыі апаратнага забеспячэння або "
+#~ "ўбудаванага ПЗ. Рэкамендуецца звярнуцца да службы абслугоўвання і "
+#~ "падтрымкі."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Узровень бяспекі 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Прылада мае мінімальную абарону ад праблем бяспекі ў апаратнага "
+#~ "забеспячэння. Гэта самы нізкі ўзровень бяспекі прылады, які забяспечвае "
+#~ "абарону толькі ад простых пагроз бяспекі."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Узровень бяспекі 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Прылада мае базавую абарону ад праблем бяспекі ў апаратнага забеспячэння. "
+#~ "Гэта забяспечвае абарону ад некаторых распаўсюджаных пагроз бяспекі."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Узровень бяспекі 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Прылада мае пашыраную абарону ад праблем бяспекі ў апаратнага "
+#~ "забеспячэння. Гэта самы высокі ўзровень бяспекі прылады, які забяспечвае "
+#~ "абарону ад сучасных пагроз бяспекі."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Для гэтай прылады недаступны ўзроўні бяспекі."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Звярніцеся да вытворцы вашага абсталявання, каб атрымаць дапамогу з "
+#~ "абнаўленнямі бяспекі."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Магчыма праблема можа быць вырашана праз налады ўбудаванага ПЗ UEFI або "
+#~ "праз службу тэхнічнай падтрымкі."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Магчыма праблема можа быць вырашана праз налады ўбудаванага ПЗ UEFI."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Магчыма праблема можа быць вырашана праз службу тэхнічнай падтрымкі."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr ""
+#~ "Абаронена ад шкоднага праграмнага забеспячэння падчас запуску прылады."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Праблемы з Secure Boot"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Маецца абарона падчас запуску прылады."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Secure Boot выключана"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Няма абароны падчас запуску прылады."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Праблема магла быць выклікана змяненнем налад убудаванага ПЗ UEFI, "
+#~ "канфігурацыі аперацыйнай сістэмы або дзеяннямі шкоднага праграмнага "
+#~ "забеспячэння ў гэтай сістэме."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Праблема магла быць выклікана змяненнем налад убудаванага ПЗ UEF або "
+#~ "дзеяннямі шкоднага праграмнага забеспячэння ў гэтай сістэме."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Праблема магла быць выклікана змяненнем канфігурацыі аперацыйнай сістэмы "
+#~ "або дзеяннямі шкоднага праграмнага забеспячэння ў гэтай сістэме."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Маюцца сур'ёзныя пагрозы бяспекі."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Абмежаваная абарона ад простых пагроз бяспекі."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Абаронена ад распаўсюджаных пагроз бяспекі."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Абаронена ад шырокага спектру пагроз бяспекі."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Комплексная абарона"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Абарона ад перазапісу ўбудаванага ПЗ"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Блакаванне абароны ад перазапісу ўбудаванага ПЗ"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Рэгіён убудаванага ПЗ BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Дэскрыптар убудаванага ПЗ BIOS"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Перадзагрузачная абарона DMA"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Правераная загрузка Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Абаронена Intel BootGuard ACM"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Палітыка памылак Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Засцерагальнік Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET уключана"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET актыўна"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Зашыфраваная RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Абарона IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux Kernel Lockdown"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux Kernel Verification"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Прыпыненне працы ў рэжым сна"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Прыпыненне працы ў рэжым чакання"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Ключ платформы UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI Secure Boot"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Канфігурацыя платформы TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Рэканструкцыя TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Вытворчы рэжым Intel Management Engine"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Перавызначэнне Intel Management Engine"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Версія Intel Management Engine"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Абнаўленні ўбудаванага ПЗ"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Атэстацыя ўбудаванага ПЗ"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Праверка сродку абнаўлення ўбудаванага ПЗ"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Адладка платформы"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Праверка бяспекі працэсара"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Абарона ад паніжэння версіі ўбудаванага ПЗ AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Абарона ад пераўсталявання ўбудаванага ПЗ AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Абарона ад перазапісу ўбудаванага ПЗ AMD"
+
+# Нешта пра PCH, перапальванне рэгістраў у крысталае на апаратным узроўні і гэта блок ад перазапісу. Незразумела, але добра, калі перапалілі. https://fwupd.github.io/libfwupdplugin/hsi.html#part-is-fused
+#~ msgid "Fused Platform"
+#~ msgstr "Сплаўленая платформа"
+
+#~ msgid "Valid"
+#~ msgstr "Сапраўдны"
+
+#~ msgid "Not Valid"
+#~ msgstr "Несапраўдны"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Не ўключана"
+
+#~ msgid "Locked"
+#~ msgstr "Заблакавана"
+
+#~ msgid "Not Locked"
+#~ msgstr "Не заблакавана"
+
+#~ msgid "Encrypted"
+#~ msgstr "Зашыфравана"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Не зашыфравана"
+
+#~ msgid "Tainted"
+#~ msgstr "Сапсавана"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Не сапсавана"
+
+#~ msgid "Found"
+#~ msgstr "Знойдзена"
+
+#~ msgid "Not Found"
+#~ msgstr "Не знойдзена"
+
+#~ msgid "Supported"
+#~ msgstr "Падтрымліваецца"
+
+#~ msgid "Not Supported"
+#~ msgstr "Не падтрымліваецца"
+
+#~ msgid "Unknown"
+#~ msgstr "Невядома"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-бітная"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-бітная"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Невядома"
+
+#~ msgid "Not Available"
+#~ msgstr "Недаступна"
+
+#~ msgid "System Logo"
+#~ msgstr "Лагатып сістэмы"
+
+#~ msgid "No input sources found"
+#~ msgstr "Крыніцы ўводу не знойдзены"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Іншы"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Кіраванне спалучэннямі клавіш"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Клавіша альтэрнатыўных сімвалаў можа выкарыстоўвацца для ўводу дадатковых "
+#~ "сімвалаў. Яны часам нанесены на кнопках клавіятуры як трэці варыянт."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Левы Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Правы Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Левы Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Правы Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Кнопка меню"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Правы Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Клавіша Compose дазваляе ўводзіць шмат самых разнастайных сімвалаў. Каб "
+#~ "скарыстацца ёй, націсніце Compose, а затым паслядоўнасць сімвалаў. "
+#~ "Напрыклад, калі націснуць клавішу Compose, а затым <b>C</b> і <b>o</b> "
+#~ "атрымаецца <b>©</b>, <b>a</b> і ўслед <b>'</b> атрымаецца <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Крыніцы ўводу можна змяніць праз спалучэнне клавіш %s.\n"
+#~ "Гэта спалучэнне таксама можна змяніць у наладах клавіятуры."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d зменена"
+#~ msgstr[1] "%d зменена"
+#~ msgstr[2] "%d зменена"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Скінуць усе спалучэнні клавіш?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Скідванне спалучэнняў клавіш можа закрануць і ўласныя спалучэнні клавіш. "
+#~ "Гэта дзеянне немагчыма адрабіць."
+
+#~ msgid "Reset All"
+#~ msgstr "Скінуць усе"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s ужо выклікае функцыю %s. Калі вы націсніце замяніць, спалучэнне для "
+#~ "функцыі %s будзе адключана"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Увядзіце новае спалучэнне клавіш"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Задаць уласнае спалучэнне клавіш"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Задаць спалучэнне клавіш"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Увядзіце новае спалучэнне клавіш для функцыі %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Дадаць уласнае спалучэнне клавіш"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Прагортка двума пальцамі"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Пяць націсканняў – час GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Падвойнае націсканне, асноўная кнопка"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Адзінарнае націсканне, асноўная кнопка"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Падвойнае націсканне, сярэдняя кнопка"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Адзінарнае націсканне, сярэдняя кнопка"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Падвойнае націсканне, другая кнопка"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Адзінарнае націсканне, другая кнопка"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager павінен быць запушчаны."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Небяспечная сетка (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Бяспечная сетка (WEP)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Бяспечная сетка (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Бяспечная сетка (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Бяспечная сетка"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Уключэнне хот-спота, адлучыць %s, доступ да інтэрнэту праз Wi-Fi будзе "
+#~ "немагчымы."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Павінен змяшчаць не менш за 8 сімвалаў"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Спыніць хот-спот і адлучыць усіх карыстальнікаў?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Спыніць хот-спот"
+
+#~ msgid "Preserve"
+#~ msgstr "Не змяняць"
+
+#~ msgid "Permanent"
+#~ msgstr "Пастаянны"
+
+#~ msgid "Random"
+#~ msgstr "Выпадковы"
+
+#~ msgid "Stable"
+#~ msgstr "Стабільны"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Уведзены тут MAC-адрас будзе выкарыстоўвацца як апаратны адрас для "
+#~ "сеткавай прылады, якая ўсталявала злучэнне. Гэта функцыя вядома як "
+#~ "кланіраванне або падмена MAC-адраса. Прыклад: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Профіль %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Няма"
+
+#~ msgid "Never"
+#~ msgstr "Ніколі"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Мб/с (%1.1f ГГц)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Мб/с"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 ГГц / 5 ГГц"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 ГГц"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 ГГц"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Няма"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Слабы"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Сярэдні"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Добры"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Выдатны"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Забыць злучэнне"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Выдаліць профіль злучэння"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Выдаліць VPN"
+
+#~ msgid "Details"
+#~ msgstr "Падрабязнасці"
+
+#~ msgid "automatic"
+#~ msgstr "аўтаматычна"
+
+#~ msgid "Identity"
+#~ msgstr "Ідэнтычнасць"
+
+#~ msgid "Delete Address"
+#~ msgstr "Выдаліць адрас"
+
+#~ msgid "Delete Route"
+#~ msgstr "Выдаліць маршрут"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Няма"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP, 40/128-бітны ключ (Hex або ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP, 128-бітная парольная фраза"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Дынамічны WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA і WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA і WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Немагчыма адкрыць рэдактар злучэння"
+
+#~ msgid "New Profile"
+#~ msgstr "Новы профіль"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Памылковы параметр %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Памылковы параметр %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Імпартаваць з файла…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Дадаць VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Немагчыма імпартаваць VPN-злучэнне"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Не ўдалося прачытаць файл «%s» або ён не змяшчае зразумелай інфармацыі аб "
+#~ "VPN-злучэнні\n"
+#~ "\n"
+#~ "Памылка: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Выберыце які файл імпартаваць"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Файл з назвай «%s» ужо існуе."
+
+#~ msgid "_Replace"
+#~ msgstr "_Замяніць"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Замяніць %s VPN-злучэннем, якое вы захоўваеце?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Немагчыма экспартаваць VPN-злучэнне"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Не ўдалося экспартаваць VPN-злучэнне «%s» у %s.\n"
+#~ "\n"
+#~ "Памылка: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Экспартаваць VPN-злучэнне"
+
+#~ msgid "never"
+#~ msgstr "ніколі"
+
+#~ msgid "today"
+#~ msgstr "сёння"
+
+#~ msgid "yesterday"
+#~ msgstr "учора"
+
+#~ msgid "Last used"
+#~ msgstr "Апошняе выкарыстанне"
+
+#~ msgid "Add new connection"
+#~ msgstr "Дадаць новае злучэнне"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Сеткавыя звесткі для вылучаныя сетак, у тым ліку паролі і карыстальніцкія "
+#~ "налады, будуць страчаны."
+
+#~ msgid "_Forget"
+#~ msgstr "_Забыць"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Вядомыя сеткі Wi-Fi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Забыць"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Палітыка сістэмы забараняе рэжым хот-спота"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Бесправадная прылада не падтрымлівае рэжым хот-спота"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Калі URL-адрас канфігурацыі не вызначаны, выкарыстоўваецца механізм "
+#~ "аўтаматычнага пошуку сеціўнага проксі-сервера."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Не рэкамендавана для ненадзейных публічных сетак."
+
+#~ msgid "Status unknown"
+#~ msgstr "Невядомы стан"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Некіруемае"
+
+#~ msgid "Unavailable"
+#~ msgstr "Недаступна"
+
+#~ msgid "Connecting"
+#~ msgstr "Злучэнне"
+
+#~ msgid "Authentication required"
+#~ msgstr "Патрабуецца праверка сапраўднасці"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Адлучэнне"
+
+#~ msgid "Connection failed"
+#~ msgstr "Не ўдалося злучыцца"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Невядомы стан (адсутнічае)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Не ўдалося наладзіць"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Не ўдалося наладзіць IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Налады IP састарэлі"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Паролі патрабуюцца, але яны адсутнічаюць"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Кліент 802.1x адлучаны"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Памылка канфігурацыі кліента 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Памылка кліента 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Занадта доўгае пацвярджэнне сапраўднасці кліента 802.1x"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Не ўдалося запусціць сэрвіс PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Сэрвіс PPP адлучаны"
+
+#~ msgid "PPP failed"
+#~ msgstr "Памылка PPP"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Не ўдалося запусціць DHCP-кліента"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Памылка DHCP-кліента"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Памылка DHCP-кліента"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Не ўдалося запусціць сэрвіс супольнага выкарыстання злучэння"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Памылка сэрвісу супольнага выкарыстання злучэння"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Не ўдалося запусціць сэрвіс AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Памылка сэрвісу AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Памылка сэрвісу AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "Лінія занята"
+
+#~ msgid "No dial tone"
+#~ msgstr "Няма гудка"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Не ўдалося ўсталяваць канал сувязі"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Скончыўся тэрмін чакання для набора нумара"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Не ўдалося набраць нумар"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Не ўдалося ініцыялізаваць мадэм"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Не ўдалося выбраць вызначаны APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Пошук сетак не ажыццяўляецца"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Адмоўлена ў сеткавай рэгістрацыі"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Скончыўся тэрмін чакання сеткавай рэгістрацыі"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Не ўдалося зарэгістравацца ў запытанай сетцы"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Няўдалая праверка PIN-кода"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Убудаванае ПЗ прылады можа адсутнічаць"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Злучэнне знікла"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Чакалася наяўнасць злучэння"
+
+#~ msgid "Modem not found"
+#~ msgstr "Мадэм не знойдзены"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Памылка Bluetooth-злучэння"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM-карта не ўстаўлена"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Патрабуецца PIN-код SIM-карты"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Патрабуецца PUK-код SIM-карты"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Памылка SIM-карты"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Збой залежнасці злучэння"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Убудаванае ПЗ адсутнічае"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Кабель адключаны"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "невядомая памылка бяспекі 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "файлы не выбраны"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "нявызначаная памылка праверкі файла eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Закрытыя ключы DER, PEM, PKCS#12 або PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Сертыфікаты DER або PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "адсутнічае PAC-файл EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC-файлы (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "адсутнічае імя карыстальніка EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "адсутнічае пароль EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "памылковы сертыфікат EAP-PEAP CA: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "памылковы сертыфікат EAP-PEAP CA: сертыфікат не ўказаны"
+
+#~ msgid "missing EAP username"
+#~ msgstr "адсутнічае імя карыстальніка EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "адсутнічае пароль EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "адсутнічае ідэнтычнасць EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "памылковы сертыфікат EAP-TLS CA: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "памылковы сертыфікат EAP-TLS CA: сертыфікат не вызначаны"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "памылковы закрыты ключ EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "памылковы сертыфікат карыстальніка EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Незашыфраваныя закрытыя ключы небяспечныя"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Падобна, што выбраны закрыты ключ не абаронены паролем. Гэта можа "
+#~ "прывесці да кампраметавання ўліковых даных. Выберыце закрыты ключ, "
+#~ "абаронены паролем.\n"
+#~ "\n"
+#~ "(Вы можаце абараніць закрыты ключ паролем праз openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Выберыце асабісты сертыфікат"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Выберыце закрыты ключ"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "памылковы сертыфікат EAP-TTLS CA: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "памылковы сертыфікат EAP-TTLS CA: сертыфікат не ўказаны"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Невядомая памылка праверкі бяспекі 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Выбраць файл"
+
+#~ msgid "missing leap-username"
+#~ msgstr "адсутнічае імя карыстальніка LEAP"
+
+#~ msgid "missing leap-password"
+#~ msgstr "адсутнічае пароль LEAP"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Адсутнічае пароль Wi-Fi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "адсутнічае ключ WEP"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "памылковы ключ WEP. Ключ даўжынёй %zu павінен змяшчаць толькі "
+#~ "шаснаццатковыя лічбы"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "памылковы ключ WEP. Ключ даўжынёй %zu павінен змяшчаць толькі сімвалы "
+#~ "ASCII"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "памылковы ключ WEP. Няправільная даўжыня ключа %zu. Даўжыня ключа павінна "
+#~ "быць 5/13 (ASCII) або 10/26 (HEX)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "памылковы ключ WEP. Парольная фраза не можа быць пустой"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "памылковы ключ WEP. Парольная фраза павінна быль карацейшай за 64 сімвалы"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "памылковы wpa-psk. Памылковая даўжыня ключа  %zu. Павінна быць [8,63] "
+#~ "байт або 64 шаснаццатковыя лічбы"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "памылковы wpa-psk. Немагчыма інтэрпрэтаваць ключ з 64 байтаў як "
+#~ "шаснаццатковы"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Іншы"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s выдалены"
+
+#~ msgid "Error removing account"
+#~ msgstr "Памылка выдалення ўліковага запісу"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Уліковы запіс %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Выдаліць уліковы запіс"
+
+#~ msgid "Unknown time"
+#~ msgstr "Час невядомы"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s да поўнага зараду"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Увага! Засталося %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Засталося %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Зараджана цалкам"
+
+#~ msgid "Not charging"
+#~ msgstr "Не зараджаецца"
+
+#~ msgid "Empty"
+#~ msgstr "Няма зараду"
+
+#~ msgid "Charging"
+#~ msgstr "Зараджаецца"
+
+#~ msgid "Discharging"
+#~ msgstr "Разраджаецца"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Бесправадная мыш"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Бесправадная клавіятура"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Крыніца бесперабойнага сілкавання"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "КПК"
+
+#~ msgid "Cellphone"
+#~ msgstr "Мабільны тэлефон"
+
+#~ msgid "Media player"
+#~ msgstr "Медыяплэер"
+
+#~ msgid "Tablet"
+#~ msgstr "Планшэт"
+
+#~ msgid "Computer"
+#~ msgstr "Камп'ютар"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Гульнявая прылада ўводу"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Асноўная"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Дадатковая"
+
+#~ msgid "Batteries"
+#~ msgstr "Батарэі"
+
+#~ msgid "When _idle"
+#~ msgstr "Пры _бяздзейнасці"
+
+#~ msgid "Suspend"
+#~ msgstr "Прыпыненне працы"
+
+#~ msgid "Power Off"
+#~ msgstr "Выключэнне камп'ютара"
+
+#~ msgid "Hibernate"
+#~ msgstr "Гібернацыя"
+
+#~ msgid "Nothing"
+#~ msgstr "Нічога не рабіць"
+
+#~ msgid "When on battery power"
+#~ msgstr "Сілкуючыся ад батарэі"
+
+#~ msgid "When plugged in"
+#~ msgstr "Сілкуючыся ад электрасеткі"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Ніколі"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Аўтаматычнае прыпыненне працы"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Рэжым высокай прадукцыйнасці часова адключаны, тэмпература прылады "
+#~ "занадта высокая."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Вентыляцыйная адтуліна перакрыта. Рэжым высокай прадукцыйнасці часова "
+#~ "адключаны. Каб узнавіць яго працу, перамясціце прыладу на роўную цвёрдую "
+#~ "паверхню."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Рэжым высокай прадукцыйнасці часова адключаны."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Нізкі зарад акумулятара. Уключаны рэжым энергазберажэння. Калі акумулятар "
+#~ "дастаткова зарадзіцца, папярэдні рэжым будзе адноўлены."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Праграма «%s» задзейнічала рэжым энергазберажэння."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Праграма «%s» задзейнічала рэжым прадукцыйнасці."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Прадукцыйнасць"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Высокая прадукцыйнасць і спажыванне энергіі."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Збалансаваны"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Звычайная прадукцыйнасць і спажыванне энергіі."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Энергазберажэнне"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Паніжаная прадукцыйнасць і спажыванне энергіі."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Прынтар «%s» выдалены"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Не ўдалося дадаць новы прынтар."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Не ўдалося загрузіць інтэрфейс: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Разблакіруйце, каб дадаваць прынтары і змяняць налады"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Падрабязнасці %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Прыдатны драйвер не знойдзены"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Выберыце файл PDD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Файлы апісання прынтараў PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Прынтар JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Прынтар LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "З аднаго боку"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Доўгі край (звычайна)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Кароткі край (перавернута)"
+
+#~ msgid "Portrait"
+#~ msgstr "Кніжная"
+
+#~ msgid "Landscape"
+#~ msgstr "Альбомная"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Перавернутая альбомная"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Перавернутая кніжная"
+
+#~ msgid "Resume"
+#~ msgstr "Узнавіць"
+
+#~ msgid "Pause"
+#~ msgstr "Прыпыніць"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Чаканне"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Прыпынена"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Патрабуецца праверка сапраўднасці"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Апрацоўванне"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Спынена"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Скасавана"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Перарвана"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Завершана"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Перамясціць гэта заданне ў пачатак чаргі"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "Актыўныя заданні %s"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Увядзіце ўліковыя даныя для друку з %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Разблакіраваць сервер друку"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Разблакіраваць %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Увядзіце імя карыстальніка і пароль для прагляду прынтараў на %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Пошук прынтараў"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Паслядоўны порт"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Паралельны порт"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Месцазнаходжанне: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Адрас: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Сервер патрабуе праверку сапраўднасці"
+
+#~ msgid "Two Sided"
+#~ msgstr "Двухбаковы"
+
+#~ msgid "Paper Type"
+#~ msgstr "Тып паперы"
+
+#~ msgid "Paper Source"
+#~ msgstr "Крыніца паперы"
+
+#~ msgid "Output Tray"
+#~ msgstr "Выхадны латок"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Раздзяляльнасць"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Папярэдняя фільтрацыя GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Старонак на бок"
+
+#~ msgid "Orientation"
+#~ msgstr "Арыентацыя"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Агульныя"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Налады старонкі"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Даступныя параметры"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Заданне"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Якасць выявы"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Колер"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Завяршэнне"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Дадатковыя"
+
+#~ msgid "Test page"
+#~ msgstr "Пробная старонка"
+
+#~ msgid "Auto Select"
+#~ msgstr "Аўтаматычна"
+
+#~ msgid "Printer Default"
+#~ msgstr "Прадвызначаныя для прынтара"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Укараняць толькі шрыфты GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Пераўтварыць у PS level 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Пераўтварыць у PS level 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Без папярэдняга фільтравання"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Ачыстка друкавальных галовак"
+
+#~ msgid "Out of toner"
+#~ msgstr "Няма тонеру"
+
+#~ msgid "Low on developer"
+#~ msgstr "Праявіцель заканчваецца"
+
+#~ msgid "Out of developer"
+#~ msgstr "Няма праявіцелю"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Фарба аднаго з колераў заканчваецца"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Няма фарбы аднаго з колераў"
+
+#~ msgid "Open cover"
+#~ msgstr "Адкрыта вечка"
+
+#~ msgid "Open door"
+#~ msgstr "Адчынены дзверцы"
+
+#~ msgid "Low on paper"
+#~ msgstr "Папера заканчваецца"
+
+#~ msgid "Out of paper"
+#~ msgstr "Няма паперы"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Па-за сеткай"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Спынена"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Кантэйнер для лішкаў фарбы амаль поўны"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Кантэйнер для лішкаў фарбы поўны"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Фотабарабан амаль вычарпаў свой рэсурс"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Фотабарабан больш не працуе"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Гатовы"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Не прымае заданняў"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Апрацоўванне"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Імперская"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Метрычная"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Спытаць, што рабіць"
+
+#~ msgid "Do nothing"
+#~ msgstr "Нічога не рабіць"
+
+#~ msgid "Open folder"
+#~ msgstr "Адкрыць папку"
+
+#~ msgid "Other Media"
+#~ msgstr "Іншыя носьбіты"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Выберыце праграму для аўдыядыскаў"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Выберыце праграму для відэа на DVD-дысках"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Выберыце праграму для запуску пры падлучэнні музычнага плэера"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Выберыце праграму для запуску пры падлучэнні фотаапарата ці відэакамеры"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Выберыце праграму для дыскаў з праграмным забеспячэннем"
+
+#~ msgid "audio DVD"
+#~ msgstr "аўдыя на DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "пусты Blu-ray"
+
+#~ msgid "blank CD disc"
+#~ msgstr "пусты CD"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "пусты DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "пусты HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "відэа на Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "электронная кніга"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "відэа на HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Выключэнне экрана"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 секунд"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 хвіліна"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 хвіліны"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 хвіліны"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 хвілін"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 хвілін"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 гадзіна"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 хвіліна"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 хвіліны"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 хвіліны"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 хвіліны"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 хвілін"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 хвілін"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 хвілін"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 хвілін"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 хвілін"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Ніколі"
+
+#~ msgid "Select Location"
+#~ msgstr "Выберыце размяшчэнне"
+
+#~ msgid "_OK"
+#~ msgstr "_Добра"
+
+#~ msgid "No applications found"
+#~ msgstr "Праграмы не знойдзены"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Сеткі для супольнага карыстання не выбраны"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Уключана"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Выключана"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Уключана"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Актыўна"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Выберыце папку"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Уключыць супольны доступ да медыяфайлаў"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Супольны доступ да файлаў дае доступ да агульнадаступнай папкі "
+#~ "карыстальнікам вашай сеткі праз: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Калі ўключаны аддалены ўваход, аддаленыя карыстальнікі могуць падлучацца "
+#~ "праз каманду Secure Shell:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Уключыць супольны доступ да асабістых медыяфайлаў"
+
+#~ msgid "Device name copied"
+#~ msgstr "Імя прылады скапіявана"
+
+#~ msgid "Device address copied"
+#~ msgstr "Адрас прылады скапіяваны"
+
+#~ msgid "Username copied"
+#~ msgstr "Імя карыстальніка скапіявана"
+
+#~ msgid "Password copied"
+#~ msgstr "Пароль скапіяваны"
+
+#~ msgid "Custom"
+#~ msgstr "Уласны"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Праверка %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Адлучана"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Злучэнне"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Злучана"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Памылка аўтарызацыі"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Аўтарызацыя"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Дзейнічае з абмежаваннямі"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Падлучана і аўтарызавана"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Невядома"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Аўтарызавана:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Злучана:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Зарэгістравана:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Не ўдалося аўтарызаваць прыладу: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Не ўдалося забыць прыладу: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Памылка"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Аўтарызавана"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Падсістэма Thunderbolt (boltd) не ўсталявана ці не наладжана належным "
+#~ "чынам."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Далучыцца могуць толькі прылады USB і Display Port."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Не ўдалося выявіць Thunderbolt.\n"
+#~ "Thunderbolt можа не падтрымлівацца сістэмай ці быць адключаным у BIOS або "
+#~ "не падтрымлівацца праз зададзены ў BIOS ўзровень бяспекі."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Падтрымка Thunderbolt адключана ў BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Не ўдалося вызначыць узровень бяспекі Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Памылка пераключэння рэжыму прамога доступу: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Стандартны"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Сярэді"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Вялікі"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Яшчэ большы"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Самы вялікі"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d піксель"
+#~ msgstr[1] "%d пікселі"
+#~ msgstr[2] "%d пікселяў"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Кароткая"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ экрана"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ экрана"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ экрана"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Доўгая"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 гадзіна"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 дзень"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 дні"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 дні"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 дні"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 дзён"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 дзён"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 дзён"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 дзён"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 дзён"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Ачысціць сметніцу ад усяго яе змесціва?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Усё змесціва сметніцы будзе незваротна выдалена."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Ачысціць сметніцу"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Выдаліць усе часовыя файлы?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Усе часовыя файлы будуць незваротна выдалены."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Выдаліць часовыя файлы"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 дзень"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 дзён"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 дзён"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Заўсёды"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Павінна супадаць з вэб-адрасам правайдара вашага ўліковага запісу."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Не ўдалося дадаць уліковы запіс"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Не ўдалося зарэгістраваць уліковы запіс"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Для гэтага дамену няма даступных спосабаў пацвярджэння сапраўднасці"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Не ўдалося далучыцца да дамена"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Няправільнае імя карыстальніка. \n"
+#~ "Паўтарыце спробу."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Няправільны пароль. \n"
+#~ "Паўтарыце спробу."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Не ўдалося ўвайсці ў дамен"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Не ўдалося знайсці дамен. Можа, вы памыліліся з яго напісаннем?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Знайсці больш выяў"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "каб выканаць дзеянне, трэба запытаць доступ да прылады"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "доступ да прылады ўжо запытаў іншы працэс"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "у вас няма дазволу на выкананне дзеяння"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "няма зарэгістраваных адбіткаў"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Не ўдалося звязацца з прыладай падчас рэгістрацыі адбітка"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Не ўдалося звязацца з чытальнікам адбіткаў пальцаў"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Не ўдалося звязацца з дэманам адбіткаў"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Не ўдалося скласці спіс адбіткаў пальцаў: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Не ўдалося выдаліць захаваныя адбіткі пальцаў: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Левы вялікі палец"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Левы сярэдні палец"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Левы ўказальны палец"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Левы безыменны палец"
+
+#~ msgid "Left little finger"
+#~ msgstr "Левы мезены палец"
+
+#~ msgid "Right thumb"
+#~ msgstr "Правы вялікі палец"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Правы сярэдні палец"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Правы ўказальны палец"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Правы безыменны палец"
+
+#~ msgid "Right little finger"
+#~ msgstr "Правы мезены палец"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Невядомы палец"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Выканана"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Чытальнік адбіткаў пальцаў не падлучаны"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Памяць чытальніка адбіткаў пальцаў запоўнена"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Не ўдалося зарэгістраваць новы адбітак пальца"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Не ўдалося запусціць рэгістрацыю: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Не ўдалося зарэгістраваць новы адбітак пальца"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Не ўдалося спыніць рэгістрацыю: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Аднімайце і прыкладвайце палец да чытальніка некалькі разоў, каб "
+#~ "зарэгістраваць адбітак пальца"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Зарэгістраваць адбітак гэтага пальца зноў…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Счытванне новага адбітка пальца"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Не ўдалося вызваліць чытальнік адбіткаў пальцаў %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Праблема з прыладай счытвання"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Не ўдалося запытаць доступ да чытальніка адбіткаў пальцаў %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Не ўдалося атрымаць чытальнік адбіткаў пальцаў: %s"
+
+#~ msgid "This Week"
+#~ msgstr "На гэтым тыдні"
+
+#~ msgid "Last Week"
+#~ msgstr "На мінулым тыдні"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%-d %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-d %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Сеанс скончаны"
+
+#~ msgid "Session Started"
+#~ msgstr "Запуск сеанса"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — актыўнасць уліковага запісу"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Выберыце іншы пароль."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Увядзіце бягучы пароль яшчэ раз."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Не ўдалося змяніць пароль"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Немагчыма аўтаматычна далучыцца да дамена гэтага тыпу"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Дамен ці рэгіён не знойдзены"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Не ўдалося ўвайсці як %s у дамен %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Памылковы пароль, паўтарыце спробу"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Не ўдалося злучыцца з даменам %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Не ўдалося выдаліць карыстальніка"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Не ўдалося ануляваць аддаленага карыстальніка"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Нельга выдаліць уласны ўліковы запіс."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s не выйшаў з сістэмы"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Выдаленне карыстальніка, які не выйшаў з сістэмы, можа прывесці сістэму ў "
+#~ "супярэчлівы стан."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Пакінуць файлы карыстальніка %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Пры выдаленні ўліковага запісу карыстальніка можна пакінуць яго хатні "
+#~ "каталог, пошту і часовыя файлы."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Выдаліць файлы"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Захаваць файлы"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Сапраўды ануляваць уліковы запіс аддаленага карыстальніка %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Выдаліць"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Уліковы запіс адключаны"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Будзе зададзена пры наступным уваходзе"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Няма"
+
+#~ msgid "Logged in"
+#~ msgstr "У сістэме"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Не ўдалося звязацца з сэрвісам уліковых запісаў"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Праверце, ці ўсталяваны і ўключаны AccountService."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Каб змяняць налады, трэба разблакіраваць гэту панэль"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Выдаліць вылучаны ўліковы запіс карыстальніка"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Каб выдаліць уліковы запіс вылучанага карыстальніка,\n"
+#~ "спачатку націсніце на значок *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Разблакіруйце, каб дадаваць карыстальнікаў і змяняць налады"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Новы пароль павінен адрознівацца ад старога."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Паспрабуйце змяніць некалькі літар ці лічбаў."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Паспрабуйце яшчэ больш змяніць пароль."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Пароль, які не змяшчае імені карыстальніка, будзе больш трывалым."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Пазбягайце ўжывання імені карыстальніка ў паролі."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Паспрабуйце прыбраць некаторыя словы з пароля."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Пазбягайце ўжывання агульнавядомых слоў."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Пазбягайце перастаноўкі існуючых слоў."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Паспрабуйце дадаць болей лічбаў."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Паспрабуйце дадаць болей літар верхняга рэгістра."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Паспрабуйце дадаць болей літар ніжняга рэгістра."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Паспрабуйце дадаць болей спецыяльных знакаў, напрыклад, пунктуацыйных."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Паспрабуйце чаргаваць літары, лічбы і знакаў прыпынку."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Пазбягайце паўтарэння аднаго і таго ж знака."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Пазбягайце паўтарэння тыпаў ужытых знакаў, чаргуйце літары з лічбамі і "
+#~ "знакамі прыпынку."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Пазбягайце паслядоўнасці знакаў накшталт 1234 ці abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Пароль павінен быць даўжэйшым. Паспрабуйце дадаць болей літар, лічбаў і "
+#~ "знакаў прыпынку."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Чаргуйце літары і верхняга і ніжняга рэгістра, паспрабуйце дадаць адну ці "
+#~ "некалькі лічбаў."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Дадаванне вялікай колькасці літар, лічбаў і знакаў прыпынку зробіць "
+#~ "пароль больш трывалым."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Сапраўднасць не пацверджана"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Новы пароль надта кароткі"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Новы пароль надта просты"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Стары і новы паролі надта падобныя"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Новы пароль нядаўна ўжо выкарыстоўваўся."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Новы пароль мусіць змяшчаць лічбы ці спецыяльныя знакі"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Стары і новы паролі аднолькавыя"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Ваш пароль змяніўся пасля апошняга пацвярджэння сапраўднасці!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Новы пароль не змяшчае дастатковай колькасці разнастайных знакаў"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Невядомая памылка"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Звычайна імя карыстальніка можа ўтрымліваць толькі лацінскія літары ў "
+#~ "ніжнім рэгістры, лічбы і наступныя сімвалы: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Гэтае імя карыстальніка недаступна. Паспрабуйце іншае."
+
+#~ msgid "The username is too long."
+#~ msgstr "Імя карыстальніка занадта доўгае."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Кнопка %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Праграма вызначана"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Адправіць націснутыя клавішы"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Пераключэнне манітора"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Паказаць экранную даведку"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Планшэт падлучаны да панэлі ноўтбука"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Планшэт падлучаны да знешняга дысплея"
+
+#~ msgid "External tablet device"
+#~ msgstr "Знешні графічны манітор"
+
+#~ msgid "All Displays"
+#~ msgstr "Усе дысплеі"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Пяро-аэрограф з націскам, нахілам і паўзунком"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Пяро-аэрограф з націскам, нахілам і паваротам"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Стандартнае пяро з націскам і нахілам"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Стандартнае пяро з націскам"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Новае спалучэнне клавіш…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Аперацыя скасавана"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Памылка.</b> Няма доступу на змяненне налад"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Памылка.</b> Памылка мабільнага абсталявання"
+
+#~ msgid "Not Registered"
+#~ msgstr "Не зарэгістраваны"
+
+#~ msgid "Registered"
+#~ msgstr "Зарэгістраваны"
+
+#~ msgid "Roaming"
+#~ msgstr "Роўмінг"
+
+#~ msgid "Searching"
+#~ msgstr "Пошук"
+
+#~ msgid "Denied"
+#~ msgstr "Адмоўлена"
+
+#~ msgid "2G Only"
+#~ msgstr "Толькі 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Толькі 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Толькі 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Толькі 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (пажадана)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (пажадана), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (пажадана), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (пажадана), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (пажадана)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (пажадана), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (пажадана), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (пажадана)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (пажадана), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (пажадана), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (пажадана)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (пажадана), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (пажадана), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (пажадана)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (пажадана), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (пажадана), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (пажадана)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (пажадана), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (пажадана)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (пажадана), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (пажадана)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (пажадана), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (пажадана)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (пажадана), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (пажадана)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (пажадана), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (пажадана)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (пажадана), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Невядома"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Разблакіраванне SIM-карты"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Увядзіце PIN-код для SIM-карты %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Увядзіце PIN-код, каб разблакіраваць SIM-карту"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Увядзіце PUK-код для SIM-карты %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Увядзіце PUK-код, каб разблакіраваць SIM-карту"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Уведзены няправільны пароль."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK-код павінен змяшчаць 8 лічбаў"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Увядзіце новы PIN-код"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN-код павінен павінен змяшчаць ад 4 да 8 лічбаў"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Разблакіраванне…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Збой тэлефона"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Няма злучэння з тэлефонам"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Аперацыя не дазволена"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Аперацыя не падтрымліваецца"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM-карта не ўстаўлена"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Патрабуецца PIN-код SIM-карты"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Патрабуецца PUK-код SIM-карты"
+
+#~ msgid "SIM failure"
+#~ msgstr "Збой SIM-карты"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM-карта занята"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Няправільны пароль"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Патрабуецца PIN2-код SIM-карты"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Патрабуецца PUK2-код SIM-карты"
+
+#~ msgid "Not found"
+#~ msgstr "Не знойдзена"
+
+#~ msgid "No network service"
+#~ msgstr "Сетка не абслугоўваецца"
+
+#~ msgid "Network timeout"
+#~ msgstr "Мінуў час чакання сеткі"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Паслуга GPRS не дазволена"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Роўмінг не дазволены ў гэтым рэгіёне"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Нявызначаная памылка GPRS"
+
+#~ msgid "No Error"
+#~ msgstr "Няма памылак"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Дзеянне скасавана"
+
+#~ msgid "Access denied"
+#~ msgstr "Доступ забаронены"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Невядомая памылка"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM-карта %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Паказаць нумар версіі"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Уключыць падрабязны рэжым"
+
+#~ msgid "Search for the string"
+#~ msgstr "Пошук радка"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Вывесці спіс магчымых назваў панэляў і выйсці"
+
+#~ msgid "Panel to display"
+#~ msgstr "Панэль для паказу"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[ПАНЭЛЬ] [АРГУМЕНТ…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Даступныя панэлі:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Сістэмныя гукі"
+
+#~ msgid "Web Links"
+#~ msgstr "Вэб-спасылкі"
+
+#~ msgid "Git Links"
+#~ msgstr "Спасылкі Git"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "Спасылкі %s"
+
+#~ msgid "Unset"
+#~ msgstr "Зняць"
+
+#~ msgid "Links"
+#~ msgstr "Спасылкі"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Гіпертэкставыя файлы"
+
+#~ msgid "Text Files"
+#~ msgstr "Тэкставыя файлы"
+
+#~ msgid "Image Files"
+#~ msgstr "Файлы відарысаў"
+
+#~ msgid "Font Files"
+#~ msgstr "Файлы шрыфтоў"
+
+#~ msgid "Archive Files"
+#~ msgstr "Файлы архіваў"
+
+#~ msgid "Package Files"
+#~ msgstr "Файлы пакетаў"
+
+#~ msgid "Audio Files"
+#~ msgstr "Аўдыяфайлы"
+
+#~ msgid "Video Files"
+#~ msgstr "Відэафайлы"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Дазволы і доступ"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Даныя і сэрвісы, да якіх праграма запытала доступ і патрэбныя ёй дазволы."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Немагчыма змяніць"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Асобныя дазволы для праграм можна пераглядзець у раздзеле налад <a "
+#~ "href=\"privacy\">Прыватнасць</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Інтэграцыя"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Задаць фон працоўнага стала"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Прадвызначаныя апрацоўшчыкі"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Тыпы файлаў і спасылак, якія адкрывае гэтая праграма."
+
+#~ msgid "Usage"
+#~ msgstr "Выкарыстанне"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Колькі рэсурсаў выкарыстоўвае гэтая праграма."
+
+#~ msgid "Open in Software"
+#~ msgstr "Адкрыць у Software"
+
+#~ msgid "Activities"
+#~ msgstr "Дзейнасць"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Wallpaper;абрус;фон;экран;працоўны стол;"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Дазволіць праграмам ніжэй выкарыстоўваць камеру."
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "экран;блакіраванне;блакіроўка;блакаванне;дыягностыка;аварыя;збой;прыватны;"
+#~ "нядаўні;апошні;часовы;назва;імя;сетка;сеціва;ідэнтыфікацыя;ідэнтычнасць;"
+#~ "асоба;"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Не ўдалося запампаваць файл на сервер: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Профіль запампаваны на:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Запішыце гэты URL-адрас."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Перазапусціце камп'ютар і загрузіце вашу звычайную аперацыйную сістэму."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Увядзіце гэты URL-адрас у сваім браўзеры, каб спампаваць і ўсталяваць "
+#~ "профіль."
+
+#~ msgid "Upload profile"
+#~ msgstr "Запампаваць профіль"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Патрабуецца інтэрнэт-злучэнне"
+
+#~ msgid "_Copy"
+#~ msgstr "_Капіяваць"
+
+#~ msgid "Select _All"
+#~ msgstr "Выбраць ус_е"
+
+#~ msgid "Single Display"
+#~ msgstr "Адзін дысплэй"
+
+#~ msgid "Join Displays"
+#~ msgstr "Аб'яднаць дысплэі"
+
+#~ msgid "Display Mode"
+#~ msgstr "Рэжым манітора"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Перацягніце дысплэі адпаведна з іх рэальным размяшчэннем. Выберыце "
+#~ "дысплэй, каб змяніць яго налады."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Упарадкаванне дысплэяў"
+
+#~ msgid "Active Display"
+#~ msgstr "Актыўны дысплэй"
+
+#~ msgid "More Warm"
+#~ msgstr "Больш цёплая"
+
+#~ msgid "Less Warm"
+#~ msgstr "Менш цёплая"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Захаваць здымак экрана ў папцы $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Захаваць здымак акна ў папцы $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Захаваць здымак часткі экрана ў папцы $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Скапіраваць здымак экрана ў буфер абмену"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Скапіраваць здымак акна ў буфер абмену"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Скапіраваць здымак часткі экрана ў буфер абмену"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Запісаць кароткі скрынкаст"
+
+#~ msgid "Move up"
+#~ msgstr "Перамясціць вышэй"
+
+#~ msgid "Move down"
+#~ msgstr "Перамясціць ніжэй"
+
+#~ msgid "Set"
+#~ msgstr "Задаць"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Сэрвісы месцазнаходжання дазваляюць праграмам ведаць ваша "
+#~ "месцазнаходжанне. Дакладнасць павялічваецца пры выкарыстанні Wi-Fi і "
+#~ "шырокапалосага мабільнага злучэння."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Выкарыстоўвае сэрвіс месцазнаходжання Mozilla. <a href='https://location."
+#~ "services.mozilla.com/privacy'>Палітыка прыватнасці</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Дазволіць праграмам ніжэй вызначаць ваша месцазнаходжанне."
+
+#~ msgid "Lock your screen"
+#~ msgstr "Заблакіраваць экран"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Дазволіць праграмам ніжэй выкарыстоўваць мікрафон."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Час на падвойнае націсканне"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "сертыфікаты DER і PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Кнопкі прыпынення працы і выключэння"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr ""
+#~ "Вентыляцыйная адтуліна перакрыта: рэжым высокай прадукцыйнасці недаступны"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr ""
+#~ "Высокая тэмпература абсталявання: рэжым высокай прадукцыйнасці недаступны"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Рэжым высокай прадукцыйнасці недаступны"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Пацвердзіць"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Выберыце фармат для лікаў, даты і валют. Змены ўступяць у сілу пры "
+#~ "наступным уваходзе."
+
+#~ msgid "My Account"
+#~ msgstr "Мой уліковы запіс"
+
+#~ msgid "Language"
+#~ msgstr "Мова"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Мова для тэксту ў вокнах і на вэб-старонках."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Каб змены ўступілі ў сілу, перазапусціце сеанс"
+
+#~ msgid "Restart…"
+#~ msgstr "Перазапусціць…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Налады ўваходу выкарыстоўваюцца для ўсіх карыстальнікаў пры ўваходзе ў "
+#~ "сістэму"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Кіруе вынікамі пошуку, якія паказваюцца ў рэжыме Агляд дзейнасці. Парадак "
+#~ "паказу таксама можна змяняць праз перамяшчэнне радкоў у спісе."
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Супольны доступ да экрана дазваляе аддаленым карыстальнікам бачыць або "
+#~ "кантраляваць ваш экран злучыўшыся праз %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Супольны доступ да _экрана"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Некаторыя сэрвісы адключаныя, бо няма доступу да сеткі."
+
+#~ msgid "_Password:"
+#~ msgstr "Пар_оль:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Паказваць пароль"
+
+#~ msgid "Access Options"
+#~ msgstr "Параметры доступу"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Новым злучэнням патрэбна запытаць доступ"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Патрабаваць пароль"
+
+#~ msgid "Bark"
+#~ msgstr "Брэх"
+
+#~ msgid "Drip"
+#~ msgstr "Кропля"
+
+#~ msgid "Glass"
+#~ msgstr "Шклянка"
+
+#~ msgid "Sonar"
+#~ msgstr "Гідралакатар"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Агучванне клавіш"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Чытанне з экрана"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Чытанне з экрана"
+
+#~ msgid "Standard"
+#~ msgstr "Звычайны"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Тып уліковага запісу"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Дазволіць карыстальніку задаць пароль пры _ўваходзе"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_Задаць пароль"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Каб дадаваць карпаратыўных карыстальнікаў, вы павінны быць у сетцы."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Зрабіць здымак…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Каб унесці змены,\n"
+#~ "спачатку націсніце на значок *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Стварыць уліковы запіс карыстальніка"
+
+#~ msgid "User Icon"
+#~ msgstr "Значок карыстальніка"
+
+#~ msgid "Account Settings"
+#~ msgstr "Налады ўліковага запісу"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Праверка сапраўднасці і ўваход"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Уваход;Сеанс;Імя карыстальніка;Адбіткі пальцаў;Сканер;Аватар;Лагатып;"
+#~ "Выява;Твар;Вобраз;Пароль;"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Выкарыстоўваецца як назва хатняй папкі і не можа быць зменена пазней."
+
+#~ msgid "Output:"
+#~ msgstr "Вывад:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Прывязаць да аднаго манітора"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d з %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Прывязка да манітора"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Планшэт (абсалютныя каардынаты)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Параметры планшэта"
+
+#~ msgid "_Help"
+#~ msgstr "_Даведка"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Налады Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Рэжым адсочвання"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Прызначыць кнопкі…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Змяніць налады мышы"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Наладзіць разрознасць дысплэя"
+
+#~ msgid "No stylus found"
+#~ msgstr "Пяро не знойдзена"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Перамясціце пяро бліжэй да планшэта, каб наладзіць"
+
+#~ msgid "Top Button"
+#~ msgstr "Верхняя кнопка"
+
+#~ msgid "Lower Button"
+#~ msgstr "Ніжняя кнопка"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Самая ніжняя кнопка"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Разблакіраванне..."
+
+#~ msgid "GNOME Settings"
+#~ msgstr "Налады GNOME"
 
 #~ msgid "PH-SIM PIN required"
 #~ msgstr "Патрабуецца PIN-код для PH-SIM"
@@ -8910,9 +8744,6 @@ msgstr "Сістэмныя гукі"
 
 #~ msgid "Memory full"
 #~ msgstr "Памяць запоўнена"
-
-#~ msgid "Invalid index"
-#~ msgstr "Няправільны індэкс"
 
 #~ msgid "Memory failure"
 #~ msgstr "Збой памяці"
@@ -8945,4 +8776,4 @@ msgstr "Сістэмныя гукі"
 #~ msgstr "Збой праверкі сапраўднасці PDP"
 
 #~ msgid "Invalid mobile class"
-#~ msgstr "Няправільны мабiльны клас"
+#~ msgstr "Няправільны мабільны клас"

--- a/po/be.po~
+++ b/po/be.po~
@@ -1,0 +1,10092 @@
+# Vital Khilko <dojlid@mova.org>, 2003.
+# Ales Nyakhaychyk <nab@mail.by>, 2003, 2004.
+# Yuri Matsuk <yuri@matsuk.net>, 2011.
+# Ihar Hrachyshka <ihar.hrachyshka@gmail.com>, 2011, 2012, 2013, 2014.
+# Kasia Bondarava <kasia.bondarava@gmail.com>, 2012.
+# Yuras Shumovich <shumovichy@gmail.com>, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-11-20 14:10+0000\n"
+"PO-Revision-Date: 2022-11-24 18:42+0300\n"
+"Last-Translator: Launchpad translators\n"
+"Language-Team: Belarusian <i18n-bel-gnome@googlegroups.com>\n"
+"Language: be\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Launchpad-Export-Date: 2020-05-05 21:37+0000\n"
+"X-Generator: Poedit 3.2\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Сістэмная шына"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Поўны доступ"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Шына сеанса"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Прылады"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Поўны доступ да /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Сетка"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Мае доступ да сеткі"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Хатняя папка"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Толькі для чытання"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Файлавая сістэма"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Налады"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Можа змяняць налады"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s мае наступныя ўбудаваныя дазволы, іх немагчыма змяніць. Калі гэтыя "
+"дазволы вас непакояць, падумайце ці не варта выдаліць праграму."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u тып файла і спасылкі, які адкрываецца праграмай"
+msgstr[1] "%u тыпы файлаў і спасылак, якія адкрываюцца праграмай"
+msgstr[2] "%u тыпаў файлаў і спасылак, якія адкрываюцца праграмай"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> выкарыстоўваецца, каб адкрываць наступныя тыпы файлаў і спасылак."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "Выкарыстана %s дыскавай прасторы."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Праграмы"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Няма праграм"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Усталяваць…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Адкрыць"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Паказаць падрабязнасці"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Пошук"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Атрымліваць пошукавых запытаў сістэмы і адпраўляць вынікі."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Адключана"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Апавяшчэнні"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Паказваць сістэмныя апавяшчэнні."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Запуск у фонавым рэжыме"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Дазволіць актыўнасць, калі праграма закрыта."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Здымкі экрана"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Рабіць здымкі экрана ў любы часы."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Змяненне шпалер"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Змяняць шпалеры працоўнага стала."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Гукі"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Прайграванне гуку."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Забараняць спалучэнні клавіш"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Блакіраваць стандартныя спалучэнні клавіш."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Камера"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Рабіць здымкі праз камеру."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Мікрафон"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Запісваць гук праз мікрафон."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Сэрвісы месцазнаходжання"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Доступ да звестак пра месцазнаходжанне прылады."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Убудаваныя дазволы"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Доступ да сістэмы, які запатрабавала праграма"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Суаднясенні файлаў і спасылак"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Сховішча"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Нічога не знойдзена"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Паспрабуйце змяніць пошукавы запыт"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Суаднясенні файлаў і спасылак"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Тыпы файлаў"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Тыпы спасылак"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Скінуць"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "Колькі месца на дыску займае гэтая праграма разам з данымі і кэшам."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Праграма"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Даныя"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Кэш"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Усяго</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Ачысціць кэш…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Кіраванне разнастайнымі дазволамі і наладамі праграмы"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "праграма;flatpak;дазвол;налада;параметр;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Выберыце выяву"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Скасаваць"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Адкрыць"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "некалькі памераў"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Без фону працоўнага стала"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Цяперашні фон"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Стыль"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Стандартны"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Цёмны"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Фон"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Дадаць выяву…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Выгляд"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Змяніць фонавую выяву або колеры інтэрфейсу карыстальніка"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Фон;шпалеры;экран;стыль;светлы;цёмны;выгляд;тэма;працоўны стол;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Уключыць"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Bluetooth не знойдзены"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Каб карыстацца Bluetooth, падключыце адаптар."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth выключаны"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Уключыце, каб злучаць прылады і прымаць файлы."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Рэжым палёту ўключаны"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth выключаны ў рэжыме палёту."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Выключыць рэжым палёту"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Апаратны рэжым палёту ўключаны"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Выключыце рэжым палёту, каб уключыць Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Уключэнне ці выключэнне Bluetooth і злучэнне з прыладамі"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;апублікаваць;абагуліць;супольны;агульны;bluetooth;obex;блютуз;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Камера выключана"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Няма праграм, якія могуць здымаць фота або відэа."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Выкарыстанне камеры дазваляе праграмам здымаць фота і відэа. Адключэнне "
+"камеры можа прывесці да няправільнай працы некаторых праграм.\n"
+"\n"
+"Дазволіць пералічаным ніжэй праграмам выкарыстоўваць камеру."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Няма праграм, якія запыталі доступ да камеры"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Абараніце свае фота"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"камера;фота;відэа;вэб-камера;прыватнасць;асабістыя;канфідэнцыяльнасць;"
+"блакіраванне;блакаванне;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Змясціце калібравальную прыладу на квадрат і націсніце «Пачаць»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Перамясціце калібравальную прыладу ў абазначанае месца і націсніце "
+"«Працягнуць»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Перамясціце калібравальную прыладу на абазначаную паверхню і націсніце "
+"«Працягнуць»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Закрыйце вечка ноўтбука"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Узнікла непапраўная ўнутраная памылка."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Не ўсталяваны інструменты для каліброўкі.."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Не ўдалося стварыць профіль."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Мэтавы пункт белага не атрыманы."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Выканана!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Не ўдалося выканаць каліброўку!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Можна прыбраць калібравальную прыладу."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Падчас працы не чапайце калібравальную прыладу"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Каліброўка дысплэя"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Пачаць"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Узнавіць"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Гатова"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Экран ноўтбука"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Убудаваная вэб-камера"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Манітор %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Сканер %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Камера %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Прынтар %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Вэб-камера %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Уключыць кіраванне колерамі для %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Паказаць колеравыя профілі для %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Не адкалібраваны"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Прадвызначаны: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Колеравая прастора: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Тэставы профіль: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Выберыце файл профілю ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "І_мпартаваць"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Вядомыя профілі ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Усе файлы"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Экран"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Захаваць профіль"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Захаваць"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Стварыць колеравы профіль для вылучанай прылады"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Вымяральны інструмент не знойдзены. Праверце, што ён уключаны і правільна "
+"падлучаны."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Вымяральны інструмент не падтрымлівае прафілявання прынтараў."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Гэты тып прылад зараз не падтрымліваецца."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Каліброўка экрана"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Якасць каліброўкі"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"У выніку калібравання будзе створаны профіль, прыдатны для кіравання "
+"колерамі экрана. Чым болей часу выдаткавана на калібраванне, тым лепш якасць "
+"колеравага профілю."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Падчас калібравання вы не зможаце карыстацца камп'ютарам."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Якасць"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Прыблізны час"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Калібравальная прылада"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Выберыце вымяральную прыладу для каліброўкі."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Тып дысплэя"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Выберыце тып падлучанага дысплэя."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Профіль пункта белага"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Выберыце для дысплэя мэтавы пункт белага. Большасць дысплэяў калібруецца "
+"адносна крыніцы святла D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Яркасць дысплэя"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Задайце звыклую для вас яркасць дысплэя. Кіраванне колерамі будзе найбольш "
+"дакладным для гэтага ўзроўні яркасці."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Таксама, вы можаце выкарыстаць узровень яркасці з іншага профілю для гэтай "
+"прылады."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Назва профілю"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Колеравы профіль можа быць выкарыстаны на розных камп'ютарах. Таксама вы "
+"можаце стварыць розныя профілі для рознага асвятлення."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Назва профілю:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Зводка"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Профіль створаны!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Скапіраваць профіль"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Патрабуецца носьбіт з магчымасцю запісу"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Вам могуць прыдацца наступныя інструкцыі аб тым, як можна выкарыстаць гэты "
+"профіль на сістэмах <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple "
+"OS X</a> і <a href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Дадаць профіль"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Выяўлены праблемы. Профіль можа працаваць няправільна. <a href="
+"\"\">Падрабязнасці.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Імпартаваць файл…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Дадаць"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Каб кіраваць колерамі, кожнай прыладзе трэба абнавіць колеравы профіль."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Даведацца больш"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Даведацца больш пра кіраванне колерам"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Устанавіць для ўсіх карыстальнікаў"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Устанавіць гэты профіль для ўсіх карыстальнікаў гэтага камп'ютара"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Уключыць"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Дадаць профіль"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Адкалібраваць…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Адкалібраваць прыладу"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Выдаліць профіль"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Паказаць падрабязнасці"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Не ўдалося выявіць прылады, якія могуць кіраваць колерам"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Праектар"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Плазма"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (падсветка CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (падсветка RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (белая падсветка LED)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Wide gamut LCD (падсветка CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Wide gamut LCD (падсветка RGB LED)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Высокая"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 хвілін"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Сярэдняя"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 хвілін"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Нізкая"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 хвілін"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Родная для гэтага дысплэя"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (друк і кнігавыдавецтва)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (фатаграфія і графіка)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Стандартная прастора"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Праверачны профіль"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Аўтаматычны"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Нізкая якасць"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Сярэдняя якасць"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Высокая якасць"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Прадвызначаны RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Прадвызначаны CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Прадвызначаны шэры"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Калібравальныя даныя ад вытворцы"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Поўнаэкранны рэжым карэкцыі дысплэя з гэтым профілем немагчымы"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Гэты профіль ужо можа быць недакладным"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Колер"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Калібраванне колераў прылад: дысплэяў, камер або прынтараў"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Calibrate;Колер;ICC;Колеравы;Профіль;Калібраванне;Каліброўка;Прынтар;Друк;"
+"Манітор;Экран;Дысплэй;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Іншая…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Выбраць мову"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Выбраць"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Мовы не знойдзены"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Яшчэ…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Разблакіруйце, каб змяняць налады"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Каб змяніць некаторыя налады, спачатку іх трэба разблакіраваць."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Разблакіраваць…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Прыбавіць гадзіну"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Прыбавіць хвіліну"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Час"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Адняць гадзіну"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Адняць хвіліну"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Сёння"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Учора"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%-d %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%-d %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d гадзіна"
+msgstr[1] "%d гадзіны"
+msgstr[2] "%d гадзін"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d хвіліна"
+msgstr[1] "%d хвіліны"
+msgstr[2] "%d хвілін"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d секунда"
+msgstr[1] "%d секунды"
+msgstr[2] "%d секунд"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 секунд"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Хот-спот"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 гадзіны"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Дата і час"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Год"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Месяц"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Студзень"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Люты"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Сакавік"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Красавік"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Май"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Чэрвень"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Ліпень"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Жнівень"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Верасень"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Кастрычнік"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Лістапад"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Снежань"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Дзень"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Часавы пояс"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Пошук горада"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Аўтаматычнае вызначэнне даты і часу"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Патрабуецца доступ да інтэрнэту"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Дата і _час"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Аўтаматычнае _вызначэнне часавага пояса"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Патрабуецца ўключэнне сэрвісаў месцазнаходжання і доступ да інтэрнэту"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Уключана"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Часавы п_ояс"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Фармат часу"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Змяненне даты і часу, у тым ліку часавага пояса"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Гадзіннік;Часавы пояс;Месцазнаходжанне;Месца;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Змяненне налад сістэмнага часу і даты"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Каб змяніць час або дату, трэба прайсці праверку сапраўднасці."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "І_нтэрнэт"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Пошта"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Каляндар"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Музыка"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Відэа"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Фота"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Прадвызначаныя праграмы"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Канфігураваць прадвызначаныя праграмы"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "прадвызначаны;перадвызначаны;па змаўчанні;праграма;перавагі;медыя;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Справаздачы пра тэхнічныя праблемы дапамагаюць нам удасканальваць %s. Усе "
+"справаздачы адпраўляюцца ананімна і не змяшчаюць персанальных дадзеных. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Справаздачы аб праблемах"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Аўтаматычныя справаздачы аб праблемах"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Дыягностыка"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Паведаміць аб праблеме"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "дыягностыка;збой;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Уключана"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Выключана"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Ужыць змены?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Немагчыма ўжыць змены"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Магчыма, гэта з-за апаратных абмежаванняў."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Ужыць"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Назад"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Налады дысплэя адключаны"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Некалькі дысплэяў"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Аб'яднаць"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Адлюстраванне"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Змяшчае верхнюю панэль і меню Дзейнасць"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Асноўны дысплэй"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Начное святло"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Альбомная"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Кніжная (на правы бок)"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Кніжная (на левы бок)"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Альбомная (перавернутая)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Гц"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Арыентацыя"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Раздзяляльнасць"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Частата абнаўлення"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Падстроіць для ТБ"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Маштабаванне"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Начное святло недаступна"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Гэта можа адбывацца з-за выкарыстанага графічнага драйвера або выкарыстання "
+"аддаленага працоўнага стала"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Часова адключана да заўтра"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Перазапусціць фільтр"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Начное святло робіць колеры на экране цяплейшымі. Гэта можа дапамагчы ад "
+"стамлення вачэй і бяссонніцы."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Расклад"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Ад заходу да ўсходу"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Вызначаецца ўручную"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Час"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "З"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Гадзіны"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Хвіліны"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Да"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Колеравая тэмпература"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Дысплэі"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Выберыце як выкарыстоўваць падлучаныя маніторы і праектары"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Панэль;Праектар;xrandr;Экран;Распазнавальнасць;Раздзяляльнасць;Разрознасць;"
+"Абнаўленне;Манітор;Ноч;Начное;Святло;колер;заход;усход;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Secure Boot актыўна"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Secure boot прадухіляе загрузку шкоднага праграмнага забеспячэння падчас "
+"запуску прылады. Зараз функцыя ўключана і працуе правільна."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Праблемы з Secure Boot"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Secure boot прадухіляе загрузку шкоднага праграмнага забеспячэння падчас "
+"запуску прылады. Зараз функцыя ўключана, але не будзе працаваць з-за "
+"памылковага ключа."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Праблемы з Secure boot часта можна вырашыць праз налады UEFI (BIOS) "
+"камп'ютара і з дапамогай вытворцы вашага абсталявання, які можа даць "
+"інфармацыю як гэта зрабіць."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Звярніцеся па дапамогу да вытворцы вашага абсталявання або да службы "
+"абслугоўвання і падтрымкі."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Secure Boot выключана"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Secure boot прадухіляе загрузку шкоднага праграмнага забеспячэння падчас "
+"запуску прылады. Зараз функцыя выключана."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Secure boot часта можна ўключыць праз налады UEFI (BIOS) камп'ютара. "
+"Звярніцеся па дапамогу да вытворцы вашага абсталявання або да службы "
+"абслугоўвання і падтрымкі."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Secure boot прадухіляе загрузку шкоднага праграмнага забеспячэння падчас "
+"запуску прылады.\n"
+"\n"
+"Каб атрымаць дадатковыя звесткі, звярніцеся да вытворцы вашага абсталявання "
+"або да службы абслугоўвання і падтрымкі."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Пройдзена"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Няўдача"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Прылада адпавядае %d узроўню HSI"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Узровень бяспекі 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Гэта прылада не мае абароны ад праблем бяспекі ў апаратнага забеспячэння. "
+"Магчыма праблема з-за канфігурацыі апаратнага забеспячэння або ўбудаванага "
+"ПЗ. Рэкамендуецца звярнуцца да службы абслугоўвання і падтрымкі."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Узровень бяспекі 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Прылада мае мінімальную абарону ад праблем бяспекі ў апаратнага "
+"забеспячэння. Гэта самы нізкі ўзровень бяспекі прылады, які забяспечвае "
+"абарону толькі ад простых пагроз бяспекі."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Узровень бяспекі 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Прылада мае базавую абарону ад праблем бяспекі ў апаратнага забеспячэння. "
+"Гэта забяспечвае абарону ад некаторых распаўсюджаных пагроз бяспекі."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Узровень бяспекі 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Прылада мае пашыраную абарону ад праблем бяспекі ў апаратнага забеспячэння. "
+"Гэта самы высокі ўзровень бяспекі прылады, які забяспечвае абарону ад "
+"сучасных пагроз бяспекі."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Узровень бяспекі"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Для гэтай прылады недаступны ўзроўні бяспекі."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Звярніцеся да вытворцы вашага абсталявання, каб атрымаць дапамогу з "
+"абнаўленнямі бяспекі."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Магчыма праблема можа быць вырашана праз налады ўбудаванага ПЗ UEFI або праз "
+"службу тэхнічнай падтрымкі."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "Магчыма праблема можа быць вырашана праз налады ўбудаванага ПЗ UEFI."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Магчыма праблема можа быць вырашана праз службу тэхнічнай падтрымкі."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Узровень 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Узровень 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Узровень 2"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Абаронена ад шкоднага праграмнага забеспячэння падчас запуску прылады."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Праблемы з Secure Boot"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Маецца абарона падчас запуску прылады."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Secure Boot выключана"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Няма абароны падчас запуску прылады."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Праблема магла быць выклікана змяненнем налад убудаванага ПЗ UEFI, "
+"канфігурацыі аперацыйнай сістэмы або дзеяннямі шкоднага праграмнага "
+"забеспячэння ў гэтай сістэме."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Праблема магла быць выклікана змяненнем налад убудаванага ПЗ UEF або "
+"дзеяннямі шкоднага праграмнага забеспячэння ў гэтай сістэме."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Праблема магла быць выклікана змяненнем канфігурацыі аперацыйнай сістэмы або "
+"дзеяннямі шкоднага праграмнага забеспячэння ў гэтай сістэме."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Маюцца сур'ёзныя пагрозы бяспекі."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Абмежаваная абарона ад простых пагроз бяспекі."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Абаронена ад распаўсюджаных пагроз бяспекі."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Абаронена ад шырокага спектру пагроз бяспекі."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Комплексная абарона"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Няма падзей"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Абарона ад перазапісу ўбудаванага ПЗ"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Блакаванне абароны ад перазапісу ўбудаванага ПЗ"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Рэгіён убудаванага ПЗ BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Дэскрыптар убудаванага ПЗ BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Перадзагрузачная абарона DMA"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Правераная загрузка Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Абаронена Intel BootGuard ACM"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Палітыка памылак Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Засцерагальнік Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET уключана"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET актыўна"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Зашыфраваная RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Абарона IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux Kernel Lockdown"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux Kernel Verification"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Прыпыненне працы ў рэжым сна"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Прыпыненне працы ў рэжым чакання"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Ключ платформы UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI Secure Boot"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Канфігурацыя платформы TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Рэканструкцыя TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Вытворчы рэжым Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Перавызначэнне Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Версія Intel Management Engine"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Абнаўленні ўбудаванага ПЗ"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Атэстацыя ўбудаванага ПЗ"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Праверка сродку абнаўлення ўбудаванага ПЗ"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Адладка платформы"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Праверка бяспекі працэсара"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Абарона ад паніжэння версіі ўбудаванага ПЗ AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Абарона ад пераўсталявання ўбудаванага ПЗ AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Абарона ад перазапісу ўбудаванага ПЗ AMD"
+
+# Нешта пра PCH, перапальванне рэгістраў у крысталае на апаратным узроўні і гэта блок ад перазапісу. Незразумела, але добра, калі перапалілі. https://fwupd.github.io/libfwupdplugin/hsi.html#part-is-fused
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Сплаўленая платформа"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Сапраўдны"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Несапраўдны"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Не ўключана"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Заблакавана"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Не заблакавана"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Зашыфравана"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Не зашыфравана"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Сапсавана"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Не сапсавана"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Знойдзена"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Не знойдзена"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Падтрымліваецца"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Не падтрымліваецца"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Бяспека прылады"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Статус бяспекі ўбудаванага ПЗ хоста"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"экран;блакіраванне;заблакіраваць;дыягностыка;аварыя;прыватны;нядаўні;часовы;"
+"назва;імя;сетка;сеціва;ідэнтыфікацыя;асоба;прыватнасць;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Невядома"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-бітная"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-бітная"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Невядома"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Недаступна"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Лагатып сістэмы"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Імя прылады"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Мадэль абсталявання"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Памяць"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Працэсар"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Графіка"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Ёмістасць дыска"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Вылічэнне…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Назва АС"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID зборкі АС"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Тып АС"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Версія GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Загрузка…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Аконны інтэрфейс"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Віртуалізацыя"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Абнаўленне ПЗ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Перайменаваць прыладу"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Імя прылады выкарыстоўваецца для яе апазнавання ў сетцы або пры спалучэнні "
+"прылад Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Імя прылады"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Перайменаваць"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Інфармацыя"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Прагляд інфармацыі аб сістэме"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"прылада;сістэма;інфармацыя;хост;імя хоста;назва вузла;памяць;працэсар;версія;"
+"па змаўчанні;прадвызначаны;прыкладанне;праграма;пераважны;cd;dvd;usb;аўдыя; "
+"відэа;дыск;здымны;носьбіт;аўтазапуск;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Гук і медыя"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Адключыць/уключыць гук"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Паменшыць гучнасць"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Павялічыць гучнасць"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Адключыць/уключыць мікрафон"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Запусціць медыяпрайгравальнік"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Прайграваць (прайграваць/паўза)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Прыпыніць прайграванне"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Спыніць прайграванне"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Папярэдні трэк"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Наступны трэк"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Выняць"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Набор тэксту"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Пераключыць на наступную крыніцу ўводу"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Пераключыць на папярэднюю крыніцу ўводу"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Запуск праграм і функцый"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Запусціць дапаможнік"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Запусціць калькулятар"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Запусціць паштовую праграму"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Запусціць браўзер"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Хатняя папка"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Пошук"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Сістэма"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Завяршыць сеанс"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Заблакіраваць экран"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Спецыяльныя магчымасці"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Уключыць/выключыць маштабаванне"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Павялічыць"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Паменшыць"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Уключыць/выключыць чытанне з экрана"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Уключыць/выключыць экранную клавіятуру"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Павялічыць памер тэксту"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Паменшыць памер тэксту"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Уключыць/выключыць высокую кантраснасць"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Крыніцы ўводу не знойдзены"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Іншы"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Дадаць крыніцу ўводу"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Метады ўводу немагчыма выкарыстоўваць на экране ўваходу"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Крыніца ўводу не выбрана"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Параметры"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Перамясціць вышэй"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Перамясціць ніжэй"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Параметры"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Прагляд раскладкі клавіятуры"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Выдаліць"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Кіраванне спалучэннямі клавіш"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Клавіша альтэрнатыўных сімвалаў"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Клавіша альтэрнатыўных сімвалаў можа выкарыстоўвацца для ўводу дадатковых "
+"сімвалаў. Яны часам нанесены на кнопках клавіятуры як трэці варыянт."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Левы Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Правы Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Левы Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Правы Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Кнопка меню"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Правы Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Клавіша Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Клавіша Compose дазваляе ўводзіць шмат самых разнастайных сімвалаў. Каб "
+"скарыстацца ёй, націсніце Compose, а затым паслядоўнасць сімвалаў. "
+"Напрыклад, калі націснуць клавішу Compose, а затым <b>C</b> і <b>o</b> "
+"атрымаецца <b>©</b>, <b>a</b> і ўслед <b>'</b> атрымаецца <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Крыніцы ўводу можна змяніць праз спалучэнне клавіш %s.\n"
+"Гэта спалучэнне таксама можна змяніць у наладах клавіятуры."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Крыніцы ўводу"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Утрымлівае раскладкі клавіятуры і крыніцы ўводу."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Пераключэнне крыніцы ўводу"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Выкарыстоўваць _адну крыніцу ўводу для ўсіх вокнаў"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Пераключаць крыніцы ўводу _незалежна для кожнага акна"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Увод спецыяльных знакаў"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Спосабы ўводу сімвалаў і варыянтаў літар з клавіятуры."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Спалучэнні клавіш"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Прагляд і змяненне спалучэнняў клавіш"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d зменена"
+msgstr[1] "%d зменена"
+msgstr[2] "%d зменена"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Скінуць усе спалучэнні клавіш?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Скідванне спалучэнняў клавіш можа закрануць і ўласныя спалучэнні клавіш. "
+"Гэта дзеянне немагчыма адрабіць."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Скасаваць"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Скінуць усе"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Скінуць усе…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Скінуць усе спалучэнні клавіш на прадвызначаныя значэнні"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Раздзел"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Спалучэнні клавіш"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Дадаць спалучэнне клавіш"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Дадаць уласныя спалучэнні клавіш"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Задаць уласныя спалучэнні клавіш для запуску праграм, скрыптоў і іншых "
+"дзеянняў."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Дадаць спалучэнне клавіш"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Спалучэнне клавіш не знойдзена"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s ужо выклікае функцыю %s. Калі вы націсніце замяніць, спалучэнне для "
+"функцыі %s будзе адключана"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Увядзіце новае спалучэнне клавіш"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Задаць уласнае спалучэнне клавіш"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Задаць спалучэнне клавіш"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Увядзіце новае спалучэнне клавіш для функцыі %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Дадаць уласнае спалучэнне клавіш"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Выдаліць"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "За_мяніць"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Задаць"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Esc – адмена, Backspace – адключыць спалучэнне клавіш."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Назва"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Каманда"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Спалучэнне клавіш"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Задаць спалучэнне клавіш…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Няма"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Скінуць спалучэнне клавіш на прадвызначанае значэнне"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Клавіятура"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Змяненне спалучэнняў клавіш, параметраў набору, клавіятурных раскладак і "
+"крыніц уводу"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Скарот;Спалучэнне;клавішы;Працоўная;Прастора;Акно;Памер;Маштаб;Кантраснасць;"
+"Увод;Крыніца;Блакіроўка;Блакіраваць;Гучнасць;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Сэрвісы месцазнаходжання выключаны"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Няма праграм, якія могуць атрымліваць звесткі пра месцазнаходжанне."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Сэрвісы месцазнаходжання дазваляюць праграмам ведаць ваша месцазнаходжанне. "
+"Дакладнасць павялічваецца пры выкарыстанні Wi-Fi і шырокапалосага мабільнага "
+"злучэння.\n"
+"\n"
+"Выкарыстоўвацца сэрвіс месцазнаходжання Mozilla: <a href='https://location."
+"services.mozilla.com/privacy'>Палітыка прыватнасці</a>\n"
+"\n"
+"Дазволіць праграмам ніжэй вызначаць ваша месцазнаходжанне."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Няма праграм, якія запыталі доступ да месцазнаходжання"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Абараніце звесткі пра сваё месцазнаходжанне"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "месцазнаходжанне;gps;прыватнасць;канфідэнцыяльнасць;;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Мікрафон выключаны"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Няма праграм, якія могуць запісваць гук."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Выкарыстанне мікрафона дазваляе праграмам запісваць і праслухваць гук. "
+"Адключэнне мікрафона можа прывесці да няправільнай працы некаторых праграм.\n"
+"\n"
+"Дазволіць пералічаным ніжэй праграмам выкарыстоўваць мікрафон."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Няма праграм, якія запыталі доступ да мікрафона"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Абараніце свае размовы"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "мікрафон;запіс;праграма;прыватнасць;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Праверыць налады"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Агульныя"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Асноўная кнопка"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Задае парадак апаратных кнопак на мышы і сэнсарнай панэлі."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Левая"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Правая"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Мыш"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Хуткасць указальніка мышы"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Натуральная прагортка"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Прагортка перамяшчае змесціва, а не паласу прагорткі (інверсія)."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Сэнсарная панэль"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Хуткасць указальніка сэнсарнай панэлі"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Націсканне дотыкам"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Націсканне дотыкам"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Прагортка двума пальцамі"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Прагортка па краі"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Паспрабуйце зрабіць адзінарнае і падвойнае націсканне, прагортку"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Пяць націсканняў – час GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Падвойнае націсканне, асноўная кнопка"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Адзінарнае націсканне, асноўная кнопка"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Падвойнае націсканне, сярэдняя кнопка"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Адзінарнае націсканне, сярэдняя кнопка"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Падвойнае націсканне, другая кнопка"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Адзінарнае націсканне, другая кнопка"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Мыш і сэнсарная панэль"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Змяненне адчувальнасці мышы і сэнсарнай панэлі, налады для ляўшы або праўшы"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Трэкпад;Тачпад;Чулая;Сэнсарная;панэль;Паказальнік;Падвойнае;"
+"Націсканне;Пстрычка;Дотык;Кнопка;Трэкбол;Пракрутка;Прагортка;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Актыўны _кут"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Крананне верхняга левага кута адкрывае меню Агляд дзейнасці."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Актыўныя краі экрана"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Каб змяніць памер акна, перацягніце яго да верхняга, левага ці правага краю "
+"экрана."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Працоўныя прасторы"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Дынамічныя працоўныя прасторы"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Пустыя працоўныя прасторы выдаляюцца аўтаматычна."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Фіксаваная колькасць працоўных прастор"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Вызначыце колькасць пастаянных працоўных прастор."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Колькасць працоўных прастор"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Некалькі манітораў"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Працоўныя прасторы толькі на _асноўным дысплэі"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Працоўныя прасторы на _ўсіх дысплэях"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Пераключэнне паміж праграмамі"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Уключаць праграмы з усіх працоўных прастор"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Уключаць толькі праграмы з бягучай працоўнай прасторы"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Шматзадачнасць"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Кіраванне параметрамі прадукцыйнасці і шматзадачнасці"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Шматзадачнасць;Прадукцыйнасць;Працоўны стол;Кастамізацыя;Актыўны кут;Гарачы "
+"кут;Працоўныя прасторы;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Нешта пайшло не так. Звяжыцеся з пастаўшчыком праграмнага забеспячэння."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager павінен быць запушчаны."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Іншыя прылады"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Дадаць злучэнне"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Не наладжана"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Небяспечная сетка (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Бяспечная сетка (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Бяспечная сетка (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Бяспечная сетка (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Бяспечная сетка"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Злучана"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Параметры…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Уключэнне хот-спота, адлучыць %s, доступ да інтэрнэту праз Wi-Fi будзе "
+"немагчымы."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Павінен змяшчаць не менш за 8 сімвалаў"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Павінен змяшчаць не больш за %d сімвал"
+msgstr[1] "Павінен змяшчаць не больш за %d сімвалы"
+msgstr[2] "Павінен змяшчаць не больш за %d сімвалаў"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Уключыць Wi-Fi хот-спот?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Хот-спот Wi-Fi дазваляе супольна выкарыстоўваць ваша інтэрнэт-злучэнне. "
+"Ствараецца сетка Wi-Fi, да якой могуць падключыцца іншыя людзі. Для гэтага "
+"вы павінны быць падключаны да інтэрнэту любым метадам акрамя Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Назва сеткі"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Генерыраваць выпадковы пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Аўтаматычна генерыраваць пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Уключыць"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Спыніць хот-спот і адлучыць усіх карыстальнікаў?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Спыніць хот-спот"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Рэжым палёту"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Адключыць Wi-Fi, Bluetooth і мабільнае шырокапалоснае злучэнне"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Адаптар Wi-Fi не знойдзены"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Праверце, ці падключаны адаптар Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Рэжым палёту ўключаны"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Выключыць, каб карыстацца Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Хот-спот Wi-Fi актыўны"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Каб падлучыцца, мабільныя прылады могуць адсканаваць QR-код."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Уключыць хот-спот…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Бачныя сеткі"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager павінен быць запушчаны"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Бяспека 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Бяспека"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Не змяняць"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Пастаянны"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Выпадковы"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Стабільны"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Уведзены тут MAC-адрас будзе выкарыстоўвацца як апаратны адрас для сеткавай "
+"прылады, якая ўсталявала злучэнне. Гэта функцыя вядома як кланіраванне або "
+"падмена MAC-адраса. Прыклад: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Профіль %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Няма"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Ніколі"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i дзень таму"
+msgstr[1] "%i дні таму"
+msgstr[2] "%i дзён таму"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Мб/с (%1.1f ГГц)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Мб/с"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 ГГц / 5 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Няма"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Слабы"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Сярэдні"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Добры"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Выдатны"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4-адрас"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-адрас"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-адрас"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Забыць злучэнне"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Выдаліць профіль злучэння"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Выдаліць VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Падрабязнасці"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "аўтаматычна"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Ідэнтычнасць"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Выдаліць адрас"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Выдаліць маршрут"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Няма"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP, 40/128-бітны ключ (Hex або ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP, 128-бітная парольная фраза"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Дынамічны WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA і WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA і WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Сіла сігналу"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Хуткасць сувязі"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Апаратны адрас"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Падтрымліваюцца частоты"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Прадвызначаны маршрут"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Апошняе выкарыстанне"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "_Злучацца аўтаматычна"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Зрабіць даступным іншым _карыстальнікам"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_ Злучэнне з тарыфікацыяй: маецца ліміт перадачы даных або можа спаганяцца "
+"плата"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Абнаўленне праграмнага забеспячэння і іншыя спампоўванні вялікага памеру не "
+"будуць запускацца аўтаматычна."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Назва"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC-_адрас"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "_MTU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Кланіраваны адрас"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "байтаў"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Метад IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Аўтаматычна (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Толькі лакальная сувязь"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Уручную"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Адключыць"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Агульны доступ для іншых камп'ютараў"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Адрасы"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Адрас"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Маска сеткі"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Аўтаматычна"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Аўтаматычны DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Адрас(ы) сервера DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Раздзяляйце IP-адрасы коскамі"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Маршруты"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Аўтаматычныя маршруты"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Метрыка"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "_Выкарыстоўваць злучэнне толькі для рэсурсаў у гэтай сетцы"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Метад IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Аўтаматычна, толькі DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Прэфікс"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Немагчыма адкрыць рэдактар злучэння"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Новы профіль"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Памылковы параметр %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Памылковы параметр %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Імпартаваць з файла…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Дадаць VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_Бяспека"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Немагчыма імпартаваць VPN-злучэнне"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Не ўдалося прачытаць файл «%s» або ён не змяшчае зразумелай інфармацыі аб "
+"VPN-злучэнні\n"
+"\n"
+"Памылка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Выберыце які файл імпартаваць"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Файл з назвай «%s» ужо існуе."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Замяніць"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Замяніць %s VPN-злучэннем, якое вы захоўваеце?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Немагчыма экспартаваць VPN-злучэнне"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Не ўдалося экспартаваць VPN-злучэнне «%s» у %s.\n"
+"\n"
+"Памылка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Экспартаваць VPN-злучэнне"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Памылка. Не ўдалося загрузіць рэдактар VPN-злучэння)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Налады злучэння з інтэрнэтам"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;сетка;проксі;"
+"блютуз;мадэм;мабільнае;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Налады злучэння з сеткамі Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;DNS;Hotspot;хотспот;хот-спот;пункт "
+"доступу;бесправадная;сетка;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "ніколі"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "сёння"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "учора"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Апошняе выкарыстанне"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Правадное"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Дадаць новае злучэнне"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Сеткавыя звесткі для вылучаныя сетак, у тым ліку паролі і карыстальніцкія "
+"налады, будуць страчаны."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Забыць"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Вядомыя сеткі Wi-Fi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Забыць"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Палітыка сістэмы забараняе рэжым хот-спота"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Бесправадная прылада не падтрымлівае рэжым хот-спота"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Калі URL-адрас канфігурацыі не вызначаны, выкарыстоўваецца механізм "
+"аўтаматычнага пошуку сеціўнага проксі-сервера."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Не рэкамендавана для ненадзейных публічных сетак."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Выключыць прыладу"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Актыўна"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Правайдар"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Сеткавы проксі-сервер"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Прок_сі-сервер НТТР"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Пр_оксі-сервер НТТРS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Про_ксі-сервер FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Хост Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "І_гнараваць хосты"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Порт проксі-сервера НТТР"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Порт проксі-сервера НТТРS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Порт проксі-сервера FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Порт проксі-сервера Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_URL-адрас налад"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Выключыць VPN-злучэнне"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Назва сеткі"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Тып бяспекі"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Пароль"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Выключыць Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Больш параметраў…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Злучыцца са схаванай сеткай…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Уключыць хот-спот Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Вядомыя сеткі Wi-Fi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Невядомы стан"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Некіруемае"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Недаступна"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Злучэнне"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Патрабуецца праверка сапраўднасці"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Адлучэнне"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Не ўдалося злучыцца"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Невядомы стан (адсутнічае)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Не ўдалося наладзіць"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Не ўдалося наладзіць IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Налады IP састарэлі"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Паролі патрабуюцца, але яны адсутнічаюць"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Кліент 802.1x адлучаны"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Памылка канфігурацыі кліента 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Памылка кліента 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Занадта доўгае пацвярджэнне сапраўднасці кліента 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Не ўдалося запусціць сэрвіс PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Сэрвіс PPP адлучаны"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Памылка PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Не ўдалося запусціць DHCP-кліента"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Памылка DHCP-кліента"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Памылка DHCP-кліента"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Не ўдалося запусціць сэрвіс супольнага выкарыстання злучэння"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Памылка сэрвісу супольнага выкарыстання злучэння"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Не ўдалося запусціць сэрвіс AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Памылка сэрвісу AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Памылка сэрвісу AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Лінія занята"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Няма гудка"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Не ўдалося ўсталяваць канал сувязі"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Скончыўся тэрмін чакання для набора нумара"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Не ўдалося набраць нумар"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Не ўдалося ініцыялізаваць мадэм"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Не ўдалося выбраць вызначаны APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Пошук сетак не ажыццяўляецца"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Адмоўлена ў сеткавай рэгістрацыі"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Скончыўся тэрмін чакання сеткавай рэгістрацыі"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Не ўдалося зарэгістравацца ў запытанай сетцы"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Няўдалая праверка PIN-кода"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Убудаванае ПЗ прылады можа адсутнічаць"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Злучэнне знікла"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Чакалася наяўнасць злучэння"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Мадэм не знойдзены"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Памылка Bluetooth-злучэння"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM-карта не ўстаўлена"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Патрабуецца PIN-код SIM-карты"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Патрабуецца PUK-код SIM-карты"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Памылка SIM-карты"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Збой залежнасці злучэння"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Убудаванае ПЗ адсутнічае"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Кабель адключаны"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "невядомая памылка бяспекі 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "файлы не выбраны"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "нявызначаная памылка праверкі файла eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Закрытыя ключы DER, PEM, PKCS#12 або PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Сертыфікаты DER або PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "адсутнічае PAC-файл EAP-FAST"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC-файлы (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Ананімна"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Сапраўднасць пацверджана"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Абодва"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_Ананімная ідэнтычнасць"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC-ф_айл"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Выберыце PAC-файл"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Унутраная праверка сапраўднасці"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Дазволіць аўтаматычную падрыхтоўку PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "адсутнічае імя карыстальніка EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "адсутнічае пароль EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "І_мя карыстальніка"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "Пар_оль"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Паказваць пароль"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "памылковы сертыфікат EAP-PEAP CA: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "памылковы сертыфікат EAP-PEAP CA: сертыфікат не ўказаны"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Версія 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Версія 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "_Сертыфікат CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Выберыце сертыфікат цэнтра сертыфікацыі"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Сертыфікат CA не патрабуецца"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Версія PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "адсутнічае імя карыстальніка EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "адсутнічае пароль EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "адсутнічае ідэнтычнасць EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "памылковы сертыфікат EAP-TLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "памылковы сертыфікат EAP-TLS CA: сертыфікат не вызначаны"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "памылковы закрыты ключ EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "памылковы сертыфікат карыстальніка EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Незашыфраваныя закрытыя ключы небяспечныя"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Падобна, што выбраны закрыты ключ не абаронены паролем. Гэта можа прывесці "
+"да кампраметавання ўліковых даных. Выберыце закрыты ключ, абаронены "
+"паролем.\n"
+"\n"
+"(Вы можаце абараніць закрыты ключ паролем праз openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Выберыце асабісты сертыфікат"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Выберыце закрыты ключ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "Ід_энтычнасць"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Сертыфікат _карыстальніка"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Закрыты ключ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Пароль для закрытага ключа"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "памылковы сертыфікат EAP-TTLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "памылковы сертыфікат EAP-TTLS CA: сертыфікат не ўказаны"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (без EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Дамен"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Невядомая памылка праверкі бяспекі 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Тунэльны TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Абаронены EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Пра_верка сапраўднасці"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Выбраць файл"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "адсутнічае імя карыстальніка LEAP"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "адсутнічае пароль LEAP"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Адсутнічае пароль Wi-Fi."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Тып"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "адсутнічае ключ WEP"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"памылковы ключ WEP. Ключ даўжынёй %zu павінен змяшчаць толькі шаснаццатковыя "
+"лічбы"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"памылковы ключ WEP. Ключ даўжынёй %zu павінен змяшчаць толькі сімвалы ASCII"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"памылковы ключ WEP. Няправільная даўжыня ключа %zu. Даўжыня ключа павінна "
+"быць 5/13 (ASCII) або 10/26 (HEX)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "памылковы ключ WEP. Парольная фраза не можа быць пустой"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"памылковы ключ WEP. Парольная фраза павінна быль карацейшай за 64 сімвалы"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (прадвызначана)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Адкрытая сістэма"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Агульны ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Паказаць к_люч"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP-і_ндэкс"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"памылковы wpa-psk. Памылковая даўжыня ключа  %zu. Павінна быць [8,63] байт "
+"або 64 шаснаццатковыя лічбы"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"памылковы wpa-psk. Немагчыма інтэрпрэтаваць ключ з 64 байтаў як шаснаццатковы"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Апавяшчэнні"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Гукавыя _сігналы"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Усплывальныя апавяшчэнні"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Нават калі ўсплывальныя вокны адключаны, апавяшчэнні і далей будуць "
+"паказвацца ў спісе апавяшчэнняў."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Паказваць _змесціва паведамлення ва ўсплывальных вокнах"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Апавяшчэнні на экране _блакіравання"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Паказваць з_месціва паведамлення на экране блакіравання"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Не турбаваць"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Апавяшчэнні на экране _блакіравання"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Кіраванне апавяшчэннямі, налады паказу і зместу"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Апавяшчэнні;Нагадванні;Абвесткі;Банер;Шыльда;Паведамленне;Трэй;Абшар;"
+"Выплыўное акенца;Усплывальны;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Іншы"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s выдалены"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Памылка выдалення ўліковага запісу"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Адрабіць"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Закрыць апавяшчэнне"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Злучэнне з данымі ў воблаку"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Няма злучэння з інтэрнэтам — злучыцеся, каб наладзіць новыя ўліковыя запісы "
+"ў сетцы"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Дадаць уліковы запіс"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Уліковы запіс %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Выдаліць уліковы запіс"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Уліковыя запісы ў сетцы"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Падлучыцца да ўліковых запісаў у сетцы і вырашыць як іх выкарыстоўваць"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Сеціва;Інтэрнэт;Чат;Каляндар;Календары;Пошта;"
+"Кантакты;Сувязь;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Час невядомы"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i хвіліна"
+msgstr[1] "%i хвіліны"
+msgstr[2] "%i хвілін"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i гадзіна"
+msgstr[1] "%i гадзіны"
+msgstr[2] "%i гадзін"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "гадзіна"
+msgstr[1] "гадзіны"
+msgstr[2] "гадзін"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "хвіліна"
+msgstr[1] "хвіліны"
+msgstr[2] "хвілін"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s да поўнага зараду"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Увага! Засталося %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Засталося %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Зараджана цалкам"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Не зараджаецца"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Няма зараду"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Зараджаецца"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Разраджаецца"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Бесправадная мыш"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Бесправадная клавіятура"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Крыніца бесперабойнага сілкавання"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "КПК"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Мабільны тэлефон"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Медыяплэер"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Планшэт"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Камп'ютар"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Гульнявая прылада ўводу"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батарэя"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Асноўная"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Дадатковая"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Батарэі"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Пры _бяздзейнасці"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Прыпыненне працы"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Выключэнне камп'ютара"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Гібернацыя"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Нічога не рабіць"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Сілкуючыся ад батарэі"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Сілкуючыся ад электрасеткі"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Ніколі"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Аўтаматычнае прыпыненне працы"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Рэжым высокай прадукцыйнасці часова адключаны, тэмпература прылады занадта "
+"высокая."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Вентыляцыйная адтуліна перакрыта. Рэжым высокай прадукцыйнасці часова "
+"адключаны. Каб узнавіць яго працу, перамясціце прыладу на роўную цвёрдую "
+"паверхню."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Рэжым высокай прадукцыйнасці часова адключаны."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Нізкі зарад акумулятара. Уключаны рэжым энергазберажэння. Калі акумулятар "
+"дастаткова зарадзіцца, папярэдні рэжым будзе адноўлены."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Праграма «%s» задзейнічала рэжым энергазберажэння."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Праграма «%s» задзейнічала рэжым прадукцыйнасці."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 хвілін"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 хвілін"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 хвілін"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 хвілін"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 хвілін"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 гадзіна"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 хвілін"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 хвілін"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 хвілін"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 гадзіны"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Рэжым сілкавання"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Уплывае на прадукцыйнасць сістэмы і спажыванне энергіі."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Параметры энергазберажэння"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Аўтакіраванне яркасцю экрана"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Яркасць экрана падстройваецца пад знешняе асвятленне."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Прыцямненне экрана"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Яркасць экрана паніжаецца, калі камп'ютар бяздзейнічае."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Адключэнне экрана"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Экран выключыцца пасля пазначанага перыяду бяздзейнасці."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Аўтаматычны рэжым энергазберажэння"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Калі зарад акумулятара нізкі, уключаецца рэжым энергазберажэння."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Аўтаматычнае прыпыненне працы"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Камп'ютар прыпыняе працу пасля пазначанага перыяду бяздзейнасці."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Дзеянне для кнопкі _выключэння"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Узровень зараду батарэі ў працэнтах"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Аўтаматычнае прыпыненне працы"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Ад _электрасеткі"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Ад _батарэі"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Затрымка"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Прадукцыйнасць"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Высокая прадукцыйнасць і спажыванне энергіі."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Збалансаваны"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Звычайная прадукцыйнасць і спажыванне энергіі."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Энергазберажэнне"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Паніжаная прадукцыйнасць і спажыванне энергіі."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Сілкаванне"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Прагляд стану акумулятара і налады энергазберажэння"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Энергія;Сілкаванне;Сон;Супынак;Гібернацыя;Батарэя;Акумулятар;Яркасць;"
+"Зацяненне;Ачыстка;Манітор;DPMS;Бяздзейнасць;Прыпыненне;Прыпыніць;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Прынтар «%s» выдалены"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Не ўдалося дадаць новы прынтар."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Не ўдалося загрузіць інтэрфейс: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Разблакіруйце, каб дадаваць прынтары і змяняць налады"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Прынтары"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Падлучэнне прынтараў, прагляд іх заданняў і налады друку"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Прынтар;Чарга;Друк;Папера;Аркуш;Чарніла;Тонер;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Дадаць прынтар"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Разблакіраваць"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Прынтары не знойдзены"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Увядзіце сеткавы адрас прынтара або пашукайце па назве"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Патрабуецца праверка сапраўднасці"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Увядзіце імя карыстальніка і пароль для прагляду прынтараў на серверы друку."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Імя карыстальніка"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Падрабязнасці %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Прыдатны драйвер не знойдзены"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Выберыце файл PDD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Файлы апісання прынтараў PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Імя прынтара не можа змяшчаць ПРАБЕЛ, TAB, # або /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Размяшчэнне"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Драйвер"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Пошук найлепшага драйвера…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Пошук драйвераў"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Выбраць з базы даных…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Усталяваць PPD-файл…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Выберыце драйвера прынтара"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Загрузка базы даных драйвераў…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Выбраць"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Прынтар JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Прынтар LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "З аднаго боку"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Доўгі край (звычайна)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Кароткі край (перавернута)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Кніжная"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Альбомная"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Перавернутая альбомная"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Перавернутая кніжная"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Узнавіць"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Прыпыніць"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Чаканне"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Прыпынена"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Патрабуецца праверка сапраўднасці"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Апрацоўванне"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Спынена"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Скасавана"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Перарвана"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Завершана"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Перамясціць гэта заданне ў пачатак чаргі"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u заданне патрабуе праверкі сапраўднасці"
+msgstr[1] "%u заданні патрабуюць праверкі сапраўднасці"
+msgstr[2] "%u заданняў патрабуюць праверкі сапраўднасці"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "Актыўныя заданні %s"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Увядзіце ўліковыя даныя для друку з %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Дамен"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "П_ацвердзіць"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Ачысціць усе"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Пацвердзіць"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Няма актыўных заданняў друку"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Разблакіраваць сервер друку"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Разблакіраваць %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Увядзіце імя карыстальніка і пароль для прагляду прынтараў на %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Пошук прынтараў"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Паслядоўны порт"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Паралельны порт"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Месцазнаходжанне: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Адрас: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Сервер патрабуе праверку сапраўднасці"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Двухбаковы"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Тып паперы"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Крыніца паперы"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Выхадны латок"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Раздзяляльнасць"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Папярэдняя фільтрацыя GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Старонак на бок"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "З двух бакоў"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Арыентацыя"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Агульныя"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Налады старонкі"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Даступныя параметры"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Заданне"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Якасць выявы"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Колер"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Завяршэнне"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Дадатковыя"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Пробная старонка"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Пробная старонка"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Аўтаматычна"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Прадвызначаныя для прынтара"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Укараняць толькі шрыфты GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Пераўтварыць у PS level 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Пераўтварыць у PS level 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Без папярэдняга фільтравання"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Вытворца"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Няма актыўных заданняў"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u заданне"
+msgstr[1] "%u заданні"
+msgstr[2] "%u заданняў"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Ачыстка друкавальных галовак"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Тонер заканчваецца"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Няма тонеру"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Праявіцель заканчваецца"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Няма праявіцелю"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Фарба аднаго з колераў заканчваецца"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Няма фарбы аднаго з колераў"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Адкрыта вечка"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Адчынены дзверцы"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Папера заканчваецца"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Няма паперы"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Па-за сеткай"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Спынена"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Кантэйнер для лішкаў фарбы амаль поўны"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Кантэйнер для лішкаў фарбы поўны"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Фотабарабан амаль вычарпаў свой рэсурс"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Фотабарабан больш не працуе"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Гатовы"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Не прымае заданняў"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Апрацоўванне"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Параметры друку"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Падрабязнасці аб прынтары"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Прадвызначаны прынтар"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Ачыстка друкавальных галовак"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Выдаліць прынтар"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Мадэль"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Узровень чарніла"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Перазапусціце, калі праблема вырашана."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Перазапусціць"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Дадаць прынтар…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Няма прынтараў"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"На жаль, сістэмны сэрвіс друку\n"
+"    недаступны або не запушчаны."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Фарматы"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Пошук месца…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Асноўныя фарматы"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Усе фарматы"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Нічога не знойдзена"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Пошук можна рабіць па назвах краін або моў."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Перадпрагляд"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Імперская"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Метрычная"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Дата"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Дата і час"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Лікі"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Сістэма мер"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Папера"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Мова і фармат зменяцца пасля наступнага ўваходу"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Выйсці…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Налады мовы выкарыстоўваюцца для тэксту інтэрфейсу і вэб-старонак. Фарматы "
+"выкарыстоўваюцца для лікаў, дат і валют."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Ваш уліковы запіс"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Мова"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Фарматы"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Экран уваходу"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Рэгіён і мова"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Выбар мовы інтэрфейсу і фарматаў даных"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Мова;Раскладка;Клавіятура;Увод;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Спытаць, што рабіць"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Нічога не рабіць"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Адкрыць папку"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Іншыя носьбіты"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Выберыце праграму для аўдыядыскаў"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Выберыце праграму для відэа на DVD-дысках"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Выберыце праграму для запуску пры падлучэнні музычнага плэера"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+"Выберыце праграму для запуску пры падлучэнні фотаапарата ці відэакамеры"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Выберыце праграму для дыскаў з праграмным забеспячэннем"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "аўдыя на DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "пусты Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "пусты CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "пусты DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "пусты HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "відэа на Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "электронная кніга"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "відэа на HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "ПЗ Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Выберыце, што рабіць з носьбітамі даных"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Аўдыя на CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_Відэа на DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Музычны плэер"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Праграмнае забеспячэнне"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "І_ншыя носьбіты…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Нічога не пытаць і не запускаць пры ўстаўцы носьбітаў"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Выберыце, што рабіць з іншымі носьбітамі даных"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Дзеянне:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Тып:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Здымныя носьбіты"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Наладзіць здымныя носьбіты"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"прыстасаванне;прылада;сістэма;сістэмны;перадвызначаныя;прадвызначаныя;"
+"дзеянні;праграма;cd;dvd;usb;гук;аўдыя;відэа;дыск;зменны;здымны;носьбіт;"
+"аўтазапуск;аўтаматычны запуск;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Выключэнне экрана"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 секунд"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 хвіліна"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 хвіліны"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 хвіліны"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 хвілін"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 хвілін"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 гадзіна"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 хвіліна"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 хвіліны"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 хвіліны"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 хвіліны"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 хвілін"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 хвілін"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 хвілін"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 хвілін"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 хвілін"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Ніколі"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Блакіраванне экрана"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Аўтаматычнае блакіраванне экрана прадухіляе доступ да камп'ютара пабочным "
+"асобам, калі вы адышлі."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Затрымка да адключэння экрана"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Час бяздзейнасці пасля якога экран пагасне."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Аўтаматычнае блакіраванне экрана"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Затрымка да аўтаматычнага блакіравання экрана"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Час да аўтаматычнага блакіравання экрана пасля яго адключэння."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Паказваць _апавяшчэнні на экране блакіравання"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "_Забараняць новыя USB-прылады"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Прадухіляе ўзаемадзеянне новых USB-прылад з сістэмай, калі экран "
+"заблакіраваны."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Прыватнасць экрана"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Абмежаваць вугал прагляду"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Налады экрана"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "экран;блакіраванне;блакаванне;прыватнасць;канфідэнцыяльнасць;;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Выберыце размяшчэнне"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Добра"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Месцы пошуку"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Папкі, у якіх сістэмныя праграмы выконваюць пошук, напрыклад «Файлы», «Фота» "
+"і «Відэа»."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Месцы"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Закладкі"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Іншае"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Дадаць месца"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Праграмы не знойдзены"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Пошук праграмы"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Уключаць вынікі пошуку, якія прапануе праграма."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Папкі, у якіх выконваюць пошук сістэмныя праграмы."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Вынікі пошуку"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Вынікі паказваюцца згодна з парадкам у спісе."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "Праграмы, якія паказваюць вынікі пошуку ў рэжыме Агляд дзейнасці"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Пошук;Індэкс;Схаваць;Прыватнасць;Асабістыя даныя;Вынікі;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Сеткі для супольнага карыстання не выбраны"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Сеткі"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Уключана"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Выключана"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Уключана"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Актыўна"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Выберыце папку"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Дадаць"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Уключыць супольны доступ да медыяфайлаў"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Супольны доступ да файлаў дае доступ да агульнадаступнай папкі "
+"карыстальнікам вашай сеткі праз: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Калі ўключаны аддалены ўваход, аддаленыя карыстальнікі могуць падлучацца "
+"праз каманду Secure Shell:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Уключыць супольны доступ да асабістых медыяфайлаў"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Імя прылады скапіявана"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Адрас прылады скапіяваны"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Імя карыстальніка скапіявана"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Пароль скапіяваны"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Супольны доступ"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Імя _камп'ютара"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Супольны доступ да _файлаў"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Аддалены працоўны _стол"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Супольны доступ да _медыяфайлаў"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Аддалены ўваход у сістэму"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Супольны доступ да файлаў"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Патрабаваць пароль"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Аддалены ўваход у сістэму"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Аддалены працоўны стол"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Аддалены працоўны стол дазваляе праглядаць і кіраваць вашым працоўным сталом "
+"з іншага камп'ютара."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Уключыць або адключыць падлучэнне да гэтага камп'ютара праз аддалены "
+"працоўны стол."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Аддаленае кіраванне"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Дазваляе кіраванне экранам праз аддаленае злучэнне."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Як злучыцца"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Падлучайцеся да гэтага камп'ютара праз імя прылады або адрас аддаленага "
+"працоўнага стала."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Капіяваць"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Адрас аддаленага працоўнага стала"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Праверка сапраўднасці"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Каб падлучыцца да гэтага камп'ютара, патрабуецца імя карыстальніка і пароль."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Імя карыстальніка"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Праверыць шыфраванне"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Лічбавы адбітак для шыфравання"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Лічбавы адбітак для шыфравання можа сустракацца пры падлучэннні кліентаў і "
+"тады ён павінен быць аднолькавым."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Супольны доступ да медыяфайлаў"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Супольны доступ да вашай музыкі, фота і відэа праз сетку."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Папкі"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Налады супольнага доступу да вашых даных"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"супольны доступ;агульны;абагуліць;рэсурс;ssh;хост;машына;аддалены;стол;медыя;"
+"гук;аўдыя;відэа;выявы;відарысы;малюнкі;рысункі;фота;фатаграфіі;фотаздымкі;"
+"фільмы;кліпы;сервер;рэндэрынг;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Уключыць або выключыць аддалены ўваход у сістэму"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Для ўключэння ці адключэння аддаленага ўваходу патрабуецца праверка "
+"сапраўднасці"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Уласны"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Пстрык"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Струна"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Узмах"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Бэм"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Баланс"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Згасанне"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Тыл"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Фронт"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Праверка %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Націсніце на дынамік, каб праверыць"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Сістэмная гучнасць"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Агульная гучнасць"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Узроўні гучнасці"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Выхад"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Выхадная прылада"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Праверыць"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Канфігурацыя"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Сабвуфер"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Уваход"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Уваходная прылада"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Гучнасць"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Гук абвестак"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Адключыць гук"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Гук"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Змяненне гучнасці, гукавых уваходаў і выхадаў, прызначэнне гукаў для абвестак"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Audio;Output;Input;Мікрафон;Гучнасць;Згасанне;Баланс;Bluetooth;блютуз;"
+"Навушнікі;Аўдыя;Гук;Выхад;Уваход;Гук;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Адлучана"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Злучэнне"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Злучана"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Памылка аўтарызацыі"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Аўтарызацыя"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Дзейнічае з абмежаваннямі"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Падлучана і аўтарызавана"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Невядома"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Аўтарызавана:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Злучана:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Зарэгістравана:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Не ўдалося аўтарызаваць прыладу: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Не ўдалося забыць прыладу: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Залежыць ад %u іншай прылады"
+msgstr[1] "Залежыць ад %u іншых прылад"
+msgstr[2] "Залежыць ад %u іншых прылад"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Закрыць апавяшчэнне"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Імя:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Стан:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Аўтарызаваць і злучыць"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Забыць прыладу"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Памылка"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Аўтарызавана"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Падсістэма Thunderbolt (boltd) не ўсталявана ці не наладжана належным чынам."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Дазволіць прамы доступ да прылад накшталт док-станцый і знешніх GPU."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Далучыцца могуць толькі прылады USB і Display Port."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Не ўдалося выявіць Thunderbolt.\n"
+"Thunderbolt можа не падтрымлівацца сістэмай ці быць адключаным у BIOS або не "
+"падтрымлівацца праз зададзены ў BIOS ўзровень бяспекі."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Падтрымка Thunderbolt адключана ў BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Не ўдалося вызначыць узровень бяспекі Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Памылка пераключэння рэжыму прамога доступу: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt не падтрымліваецца"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Не ўдалося падлучыцца да падсістэмы thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Прамы доступ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Прылады ў чаканні"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Няма далучаных прылад"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Кіраванне прыладамі Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;прыватнасць;канфідэнцыйнасць;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Мільганне курсора"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Курсор мільгае ў тэкставых палях."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Хуткасць"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Хуткасць мільгання курсора"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Памер курсора"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Каб палепшыць бачнасць курсора, змяненне яго памеру можна спалучаць з "
+"маштабаваннем."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Дапамога з націсканнем мышы"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Сімуляцыя націскання правай кнопкі"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Выклік націскання правай кнопкай пры зацісканні асноўнай кнопкі"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Затрымка да прыняцця:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Кароткая"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Затрымка да націскання правай кнопкай"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Доўгая"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Націсканне пры навядзенні"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Выклік націскання мышшу пры спыненні ўказальніка"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Затрымка:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Кароткая"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Доўгая"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Парог зруху:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Малы"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Вялікі"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Паўтор клавіш"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Паўтараць увод, пакуль утрымліваецца націснутая клавіша."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Затрымка паўтарэння клавіш"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Хуткасць паўтарэння клавіш"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Дапамога з уводам"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Ліпкія клавішы"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Лічыць паслядоўна націснутыя клавішы-мадыфікатары адзіным спалучэннем"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Адключаць пры адначасовым націсканні дзвюх клавіш"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Гукавы сігнал пры націсканні клавішы-_мадыфікатара"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Павольныя клавішы"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Затрымка паміж націсканнем клавішы і яе прыняццем"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Кароткая"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Затрымка ўводу для павольных клавіш"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Доўгая"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Гукавы сігнал пры націсканні _клавішы"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Гукавы сігнал, калі клавіша _прынята"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Гукавы сігнал, калі клавіша _не прынята"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Пругкія клавішы"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ігнараванне хуткага паўторнага націскання клавіш"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Кароткая"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Затрымка ўводу для пругкіх клавіш"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Доўгая"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Уключэнне з клавіятуры"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Уключэнне і выключэнне спецыяльных магчымасцей з дапамогай клавіятуры"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Стандартны"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Сярэді"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Вялікі"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Яшчэ большы"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Самы вялікі"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d піксель"
+msgstr[1] "%d пікселі"
+msgstr[2] "%d пікселяў"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Заўсёды паказваць меню спецыяльных магчымасцей"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Зрок"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Высокая кантраснасць"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Вялікі тэкст"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Уключыць _анімацыю"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Чытанне з экрана"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Праз чытанне з экрана прамаўляецца тэкст, на які пераходзіць фокус."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Агучванне клавіш"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Гукавы сігнал пры націсканні на Num Lock або Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "П_амер курсора"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Маштабаванне"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Слых"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Гукавыя сігналы"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Экранная клавіятура"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "П_аўтор клавіш"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Мільганне курсора"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Дапам_ога  з уводам (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Навядзенне ўказальніка і націсканне мышшу"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Кіраванне ўказальнікам з клавіятуры"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Выяўленне ўказальніка мышы"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Дапа_мога з націсканнем мышы"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Затрымка для падвойнага націскання"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Затрымка для падвойнага націскання"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Візуальныя сігналы"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Праверка сігналу"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Візуальна абазначае гукавы сігнал."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Мільганне ўсім _экранам"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Мільганне ўсім _акном"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Кароткая"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ экрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ экрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ экрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Доўгая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "На ўвесь экран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Верхняя палавіна"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Ніжняя палавіна"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Левая палавіна"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Правая палавіна"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Параметры маштабавання"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Па_велічэнне:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Пазіцыя лупы:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Накіроўвацца за курсорам мышы"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Частка _экрана:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Лупа _распаўсюджваецца за межы экрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Указальнік лупы знаходзіцца ў _цэнтры"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Указальнік лупы _ссоўвае змест экрана навокал"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Указальнік лупы перамяшчаецца разам са _зместам"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Лупа"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Перакрыжаванне:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Накладанне на ўказальнік мышы"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Таўшчыня:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Тонкая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Тоўстая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Даўжыня:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Ко_лер:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Перакрыжаванне"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Каляровыя эфекты:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Белы на чорным:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Яркасць:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Кантраснасць:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Насычанасць"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Няма"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Поўная"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Нізкая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Высокая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Нізкая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Высокая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Каляровыя эфекты"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"Дапамога для зроку і слыху; спрашчэнне ўводу, навядзення ўказальніка, "
+"націскання мышшу"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Клавіятура;Мыш;a11y;Спецыяльныя магчымасці;Універсальны доступ;Кантраснасць;"
+"Указальнік;Гук;Маштабаванне;Экран;Буйны;Вялікі;шрыфт;памер;AccessX;Ліпкія;"
+"клавішы;Павольныя;Пругкія;Кіраванне ўказальнікам;Падвойнае;націсканне;"
+"Затрымка;Хуткасць;Дапамога;Паўтарэнне;Паўтор;Мільганне;візуальныя;сігналы;"
+"слых;аўдыя;увод;друк;анімацыі;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 гадзіна"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 дзень"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 дні"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 дні"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 дні"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 дзён"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 дзён"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 дзён"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 дзён"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 дзён"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Ачысціць сметніцу ад усяго яе змесціва?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Усё змесціва сметніцы будзе незваротна выдалена."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Ачысціць сметніцу"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Выдаліць усе часовыя файлы?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Усе часовыя файлы будуць незваротна выдалены."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Выдаліць часовыя файлы"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 дзень"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 дзён"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 дзён"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Заўсёды"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Гісторыя файлаў"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Гісторыя файлаў запісвае, якія файлы вы выкарыстоўвалі. Гэтыя звесткі "
+"абагулены паміж праграмамі і дазваляюць прасцей знайсці файлы, якія вы, "
+"магчыма, захочаце выкарыстаць."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Г_історыя файлаў"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Працягласць _гісторыі файлаў"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Ачысціць гісторыю…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Сметніца і часовыя файлы"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Сметніца і часовыя файлы могуць змяшчаць прыватную інфармацыю. Аўтаматычнае "
+"выдаленне файлаў можа дапамагчы абараніць прыватнасць."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Аўтаматычна выдаляць змесціва сметніцы"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Аўтаматычна выдаляць часовыя _файлы"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Перыядычнасць аўтаматычнага выдалення"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Ачысціць сметніцу…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Выдаліць часовыя файлы…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Гісторыя файлаў і сметніца"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Не пакідаць слядоў"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"выкарыстанне;нядаўнія;апошнія;гісторыя;файлы;часовыя;tmp;прыватнасць;"
+"прыватны;сметніца;ачыстка;выдаленне;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Павінна супадаць з вэб-адрасам правайдара вашага ўліковага запісу."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Не ўдалося дадаць уліковы запіс"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Паролі не супадаюць."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Не ўдалося зарэгістраваць уліковы запіс"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Для гэтага дамену няма даступных спосабаў пацвярджэння сапраўднасці"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Не ўдалося далучыцца да дамена"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Няправільнае імя карыстальніка. \n"
+"Паўтарыце спробу."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Няправільны пароль. \n"
+"Паўтарыце спробу."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Не ўдалося ўвайсці ў дамен"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Не ўдалося знайсці дамен. Можа, вы памыліліся з яго напісаннем?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Дадаць карыстальніка"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Адміністратар"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Адміністратар можа дадаваць і выдаляць іншых карыстальнікаў, а таксама "
+"змяняць налады ўсіх карыстальнікаў. Бацькоўскі кантроль не можа быць ужыты "
+"да адміністратараў."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Карыстальнік задае пароль падчас першага ўваходу"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Задаць пароль цяпер"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Пацвердзіць"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Карпаратыўны ўваход"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Уліковы запіс карыстальніка, якім кіруе кампанія або арганізацыя."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Вы па-за сеткай"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Карпаратыўны ўваход дазваляе выкарыстоўваць на гэтай прыладзе цэнтралізавана "
+"кіруемы ўліковы запіс, які існуе. Такі ўліковы запіс таксама можна "
+"выкарыстоўваць, каб мець доступ да рэсурсаў кампаніі праз інтэрнэт."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Знайсці больш выяў"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Выбраць файл…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Менеджар адбіткаў пальцаў"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Адбітак пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Не"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Так"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Хочаце выдаліць зарэгістраваныя адбіткі пальцаў і адключыць уваход праз "
+"чытальнік адбіткаў?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Няма чытальніка адбіткаў пальцаў"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Няма чытальніка адбіткаў пальцаў"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Пераканайцеся, што прылада падлучана належным чынам."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Чытальнік адбіткаў пальцаў"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Выберыце, які чытальнік адбіткаў пальцаў вы хочаце наладзіць"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Уваход праз адбітак пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Уваход праз адбітак пальца дазваляе разблакіраваць камп'ютар і ўвайсці ў "
+"сістэму з дапамогай пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Выдаліць адбіткі пальцаў"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Зарэгістраваць адбітак пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "каб выканаць дзеянне, трэба запытаць доступ да прылады"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "доступ да прылады ўжо запытаў іншы працэс"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "у вас няма дазволу на выкананне дзеяння"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "няма зарэгістраваных адбіткаў"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Не ўдалося звязацца з прыладай падчас рэгістрацыі адбітка"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Не ўдалося звязацца з чытальнікам адбіткаў пальцаў"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Не ўдалося звязацца з дэманам адбіткаў"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Не ўдалося скласці спіс адбіткаў пальцаў: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Не ўдалося выдаліць захаваныя адбіткі пальцаў: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Левы вялікі палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Левы сярэдні палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "_Левы ўказальны палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Левы безыменны палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Левы мезены палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Правы вялікі палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Правы сярэдні палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "_Правы ўказальны палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Правы безыменны палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Правы мезены палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Невядомы палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Выканана"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Чытальнік адбіткаў пальцаў не падлучаны"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Памяць чытальніка адбіткаў пальцаў запоўнена"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Не ўдалося зарэгістраваць новы адбітак пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Не ўдалося запусціць рэгістрацыю: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Не ўдалося зарэгістраваць новы адбітак пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Не ўдалося спыніць рэгістрацыю: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Аднімайце і прыкладвайце палец да чытальніка некалькі разоў, каб "
+"зарэгістраваць адбітак пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "Зарэгістраваць адбітак гэтага пальца зноў…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Счытванне новага адбітка пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Не ўдалося вызваліць чытальнік адбіткаў пальцаў %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Праблема з прыладай счытвання"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Не ўдалося запытаць доступ да чытальніка адбіткаў пальцаў %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Не ўдалося атрымаць чытальнік адбіткаў пальцаў: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "На гэтым тыдні"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "На мінулым тыдні"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%-d %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%-d %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Сеанс скончаны"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Запуск сеанса"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — актыўнасць уліковага запісу"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Назад"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Далей"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Выберыце іншы пароль."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Увядзіце бягучы пароль яшчэ раз."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Не ўдалося змяніць пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Змяніць пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Змяніць"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "_Бягучы пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "_Новы пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "_Пацвердзіце новы пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Дазволіць карыстальніку змяніць пароль пры ўваходзе"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Задаць пароль"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Немагчыма аўтаматычна далучыцца да дамена гэтага тыпу"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Дамен ці рэгіён не знойдзены"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Не ўдалося ўвайсці як %s у дамен %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Памылковы пароль, паўтарыце спробу"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Не ўдалося злучыцца з даменам %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Не ўдалося выдаліць карыстальніка"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Не ўдалося ануляваць аддаленага карыстальніка"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Нельга выдаліць уласны ўліковы запіс."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s не выйшаў з сістэмы"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Выдаленне карыстальніка, які не выйшаў з сістэмы, можа прывесці сістэму ў "
+"супярэчлівы стан."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Пакінуць файлы карыстальніка %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Пры выдаленні ўліковага запісу карыстальніка можна пакінуць яго хатні "
+"каталог, пошту і часовыя файлы."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Выдаліць файлы"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Захаваць файлы"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Сапраўды ануляваць уліковы запіс аддаленага карыстальніка %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Выдаліць"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Уліковы запіс адключаны"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Будзе зададзена пры наступным уваходзе"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Няма"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "У сістэме"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Не ўдалося звязацца з сэрвісам уліковых запісаў"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Праверце, ці ўсталяваны і ўключаны AccountService."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Каб змяняць налады, трэба разблакіраваць гэту панэль"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Выдаліць вылучаны ўліковы запіс карыстальніка"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Каб выдаліць уліковы запіс вылучанага карыстальніка,\n"
+"спачатку націсніце на значок *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Разблакіруйце, каб дадаваць карыстальнікаў і змяняць налады"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Карыстальнікі"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Каб змены ўступілі ў сілу, трэба перазапусціць сеанс"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Перазапусціць"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Закрыць"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Змяніць аватар"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Поўнае імя"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Змяніць"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Уваход праз адбітак пальца"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Аўтаматычны ўваход"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Актыўнасць уліковага запісу"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Адміністратар"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Адміністратар можа дадаваць і выдаляць іншых карыстальнікаў, а таксама "
+"змяняць налады ўсіх карыстальнікаў."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Бацькоўскі кантроль"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Адкрыць праграму для бацькоўскага кантролю."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Выдаліць карыстальніка…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Іншыя карыстальнікі"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Дадаць карыстальніка…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Не знойдзена карыстальнікаў"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Разблакіруйце, каб дадаць уліковы запіс карыстальніка."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Дадаванне або выдаленне карыстальнікаў і змяненне пароля"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Уваход;Сеанс;Імя;Адбітак;Адбіткі пальцаў;;Аватар;Лагатып;Выява;Твар;Вобраз;"
+"Пароль;Бацькоўскі кантроль;Абмежаванне часу сеанса;Абмежаванне праграм;"
+"Абмежаванне сайтаў;Абмежаванне выкарыстання;Тэрмін карыстання;Дзіцячы;Дзеці;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Зарэгістраваць"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Імя адміністратара дамена"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Для карыстання сістэмай карпаратыўнага ўваходу ў сеанс трэба\n"
+"зарэгістраваць гэты камп'ютар у дамене. Папрасіце адміністратара\n"
+"сеткі ўвесці сюды пароль для дамена."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "І_мя адміністратара"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Пароль адміністратара"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Налады ўліковых запісаў карыстальніка"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Для змянення даных карыстальніка патрабуецца праверка сапраўднасці"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Новы пароль павінен адрознівацца ад старога."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Паспрабуйце змяніць некалькі літар ці лічбаў."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Паспрабуйце яшчэ больш змяніць пароль."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Пароль, які не змяшчае імені карыстальніка, будзе больш трывалым."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Пазбягайце ўжывання імені карыстальніка ў паролі."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Паспрабуйце прыбраць некаторыя словы з пароля."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Пазбягайце ўжывання агульнавядомых слоў."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Пазбягайце перастаноўкі існуючых слоў."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Паспрабуйце дадаць болей лічбаў."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Паспрабуйце дадаць болей літар верхняга рэгістра."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Паспрабуйце дадаць болей літар ніжняга рэгістра."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Паспрабуйце дадаць болей спецыяльных знакаў, напрыклад, пунктуацыйных."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Паспрабуйце чаргаваць літары, лічбы і знакаў прыпынку."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Пазбягайце паўтарэння аднаго і таго ж знака."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Пазбягайце паўтарэння тыпаў ужытых знакаў, чаргуйце літары з лічбамі і "
+"знакамі прыпынку."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Пазбягайце паслядоўнасці знакаў накшталт 1234 ці abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Пароль павінен быць даўжэйшым. Паспрабуйце дадаць болей літар, лічбаў і "
+"знакаў прыпынку."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Чаргуйце літары і верхняга і ніжняга рэгістра, паспрабуйце дадаць адну ці "
+"некалькі лічбаў."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Дадаванне вялікай колькасці літар, лічбаў і знакаў прыпынку зробіць пароль "
+"больш трывалым."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Сапраўднасць не пацверджана"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Новы пароль надта кароткі"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Новы пароль надта просты"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Стары і новы паролі надта падобныя"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Новы пароль нядаўна ўжо выкарыстоўваўся."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Новы пароль мусіць змяшчаць лічбы ці спецыяльныя знакі"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Стары і новы паролі аднолькавыя"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Ваш пароль змяніўся пасля апошняга пацвярджэння сапраўднасці!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Новы пароль не змяшчае дастатковай колькасці разнастайных знакаў"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Невядомая памылка"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Звычайна імя карыстальніка можа ўтрымліваць толькі лацінскія літары ў ніжнім "
+"рэгістры, лічбы і наступныя сімвалы: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Гэтае імя карыстальніка недаступна. Паспрабуйце іншае."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Імя карыстальніка занадта доўгае."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Прызначэнне кнопак"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Прызначыць функцыі кнопкам"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Каб змяніць спалучэнне клавіш, выберыце «Адправіць націснутыя клавішы», "
+"затым націсніце і ўтрымлівайце новае спалучэнне клавіш або націсніце "
+"Backspace, каб ачысціць."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Закрыць"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "Кранайце маркеры, якія ўзнікаюць на экране, каб адкалібраваць планшэт."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Выяўлена памылковае націсканне, перазапуск…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Кнопка %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Праграма вызначана"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Адправіць націснутыя клавішы"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Пераключэнне манітора"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Паказаць экранную даведку"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Планшэт падлучаны да панэлі ноўтбука"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Планшэт падлучаны да знешняга дысплея"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Знешні графічны манітор"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Знешні графічны планшэт"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Усе дысплеі"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Рэжым планшэта"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Выкарыстоўваць абсалютнае пазіцыянаванне для пяра"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Прыстасаваць для левай рукі"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Планшэт і клавішы Express Keys™ павернуты для карыстання левай рукой"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Прывязаць да манітора"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Захоўваць суадносіны бакоў"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Выкарыстоўваць толькі частку паверхні планшэта, каб захаваць суадносіны "
+"бакоў манітора"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Адкалібраваць"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Планшэт не знойдзены"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Падлучыце або ўключыце планшэт Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Адчувальнасць націску пяра"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Мяккая"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Націск пяра"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Цвёрдая"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Кнопка 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Кнопка 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Кнопка 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Адчувальнасць націску сціркі"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Націск сціркі"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Сярэдняя кнопка мышы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Правая кнопка мышы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Наперад"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Пяро-аэрограф з націскам, нахілам і паўзунком"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Пяро-аэрограф з націскам, нахілам і паваротам"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Стандартнае пяро з націскам і нахілам"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Стандартнае пяро з націскам"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Планшэт Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Прызначэнне кнопак і змяненне адчувальнасці пяра графічных планшэтаў"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Планшэт;Wacom;Стыло;Пяро;Сцірка;Мыш;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Новае спалучэнне клавіш…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Пункты доступу"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Аперацыя скасавана"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Памылка.</b> Няма доступу на змяненне налад"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Памылка.</b> Памылка мабільнага абсталявання"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Не зарэгістраваны"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Зарэгістраваны"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Роўмінг"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Пошук"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Адмоўлена"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Падрабязнасці пра мадэм"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Стан мадэма"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Аператар"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Тып сеткі"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Стан сеткі"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Свой нумар"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Падрабязнасці аб прыладзе"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Версія ўбудаванага ПЗ"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Толькі 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Толькі 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Толькі 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Толькі 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (пажадана), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (пажадана), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (пажадана), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (пажадана), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (пажадана), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (пажадана), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (пажадана), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (пажадана), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (пажадана), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (пажадана), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (пажадана), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (пажадана), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (пажадана), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (пажадана), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (пажадана), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (пажадана), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (пажадана)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (пажадана), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Невядома"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Разблакіраванне SIM-карты"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Разблакіраваць"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Увядзіце PIN-код для SIM-карты %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Увядзіце PIN-код, каб разблакіраваць SIM-карту"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Увядзіце PUK-код для SIM-карты %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Увядзіце PUK-код, каб разблакіраваць SIM-карту"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Уведзены няправільны пароль. Засталася %1$u спроба"
+msgstr[1] "Уведзены няправільны пароль. Засталося %1$u спробы"
+msgstr[2] "Уведзены няправільны пароль. Засталося %1$u спроб"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Засталася %1$u спроба"
+msgstr[1] "Засталося %1$u спробы"
+msgstr[2] "Засталося %1$u спроб"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Уведзены няправільны пароль."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK-код павінен змяшчаць 8 лічбаў"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Увядзіце новы PIN-код"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN-код павінен павінен змяшчаць ад 4 да 8 лічбаў"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Разблакіраванне…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Няма SIM-карты"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Устаўце SIM-карту, каб выкарыстоўваць гэты мадэм"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM-карта заблакіравана"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Мабільныя даныя"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Перадача даных праз мабільную сетку"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "Перадача _даных у роўмінгу"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Выкарыстанне перадачы даных праз мабільную сетку ў роўмінгу"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Рэжым сеткі"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Сетка"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Дадатковыя"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Назвы _пунктаў доступу"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Блакіраванне SIM-карты"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Устанавіць PIN-код"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Падрабязнасці пра _мадэм"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Збой тэлефона"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Няма злучэння з тэлефонам"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Аперацыя не дазволена"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Аперацыя не падтрымліваецца"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM-карта не ўстаўлена"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Патрабуецца PIN-код SIM-карты"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Патрабуецца PUK-код SIM-карты"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Збой SIM-карты"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM-карта занята"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Няправільны пароль"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Патрабуецца PIN2-код SIM-карты"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Патрабуецца PUK2-код SIM-карты"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Не знойдзена"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Сетка не абслугоўваецца"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Мінуў час чакання сеткі"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Паслуга GPRS не дазволена"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Роўмінг не дазволены ў гэтым рэгіёне"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Нявызначаная памылка GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Няма памылак"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Дзеянне скасавана"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Доступ забаронены"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Невядомая памылка"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Рэжым сеткі"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Аўтаматычна"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Выберыце сетку"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Абнавіць спіс правайдараў"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM-карта %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Уключыць мабільную сетку"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Адаптар WWAN не знойдзены"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+"Праверце, ці падключаны адаптар бесправадной глабальнай сеткі або мабільная "
+"прылада"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Бесправадная глабальная сетак выключана ў рэжыме палёту"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Выключыць рэжым палёту"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Перадача даных"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM-карта, якая ўжываецца для доступу ў інтэрнэт"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Блакіраванне SIM-карты"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Далей"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Устанавіць PIN-код"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Змяніць PIN-код"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Увядзіце цяперашні PIN-код, каб змяняць налады блакіравання SIM-карты"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Мабільная сетка"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Канфігураванне тэлефаніі і перадачы даных праз мабільную сетку"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "сотавая;мабільная;тэлэфанія;сім;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Утыліта для канфігуравання асяроддзя GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Налады — гэта асноўны інтэрфейс для канфігуравання сістэмы."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Праект GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Паказаць нумар версіі"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Уключыць падрабязны рэжым"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Пошук радка"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Вывесці спіс магчымых назваў панэляў і выйсці"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Панэль для паказу"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[ПАНЭЛЬ] [АРГУМЕНТ…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Катэгорыі налад"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Прыватнасць"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Даступныя панэлі:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Усе налады"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Асноўнае меню"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Увага. Версія для распрацоўшчыкаў"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Гэтая версія Налад прызначана толькі для распрацоўкі. Вы можаце сутыкнуцца з "
+"няправільнымі паводзінамі, стратай даных і іншымі нечаканымі праблемамі. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Даведка"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Агульныя"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Выйсці"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Пошук"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Панэлі"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Да папярэдняй панэлі"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Скасаваць пошук"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Settings;Налады;Параметры;Настройкі;Настаўленні;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Ідэнтыфікатар апошняй адкрытай панэлі Налад"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Ідэнтыфікатар апошняй адкрытай панэлі Налад. Непазнаныя значэнні будуць "
+"праігнараваны і выбіраецца самая першая панэль у спісе."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Паказваць папярэджанне пры запуску версіі Налад для распрацоўшчыкаў"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "Ці паказваць папярэджанне пры запуску версіі для распрацоўшчыкаў."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Пачатковы стан акна"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Картэж, які змяшчае пачатковую шырыню, вышыню і стан разгорнутасці акна "
+"праграмы."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u выхад"
+msgstr[1] "%u выхады"
+msgstr[2] "%u выхадаў"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u уваход"
+msgstr[1] "%u уваходы"
+msgstr[2] "%u уваходаў"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Сістэмныя гукі"
+
+#~ msgid "Web Links"
+#~ msgstr "Вэб-спасылкі"
+
+#~ msgid "Git Links"
+#~ msgstr "Спасылкі Git"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "Спасылкі %s"
+
+#~ msgid "Unset"
+#~ msgstr "Зняць"
+
+#~ msgid "Links"
+#~ msgstr "Спасылкі"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Гіпертэкставыя файлы"
+
+#~ msgid "Text Files"
+#~ msgstr "Тэкставыя файлы"
+
+#~ msgid "Image Files"
+#~ msgstr "Файлы відарысаў"
+
+#~ msgid "Font Files"
+#~ msgstr "Файлы шрыфтоў"
+
+#~ msgid "Archive Files"
+#~ msgstr "Файлы архіваў"
+
+#~ msgid "Package Files"
+#~ msgstr "Файлы пакетаў"
+
+#~ msgid "Audio Files"
+#~ msgstr "Аўдыяфайлы"
+
+#~ msgid "Video Files"
+#~ msgstr "Відэафайлы"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Дазволы і доступ"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Даныя і сэрвісы, да якіх праграма запытала доступ і патрэбныя ёй дазволы."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Немагчыма змяніць"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Асобныя дазволы для праграм можна пераглядзець у раздзеле налад <a href="
+#~ "\"privacy\">Прыватнасць</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Інтэграцыя"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Задаць фон працоўнага стала"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Прадвызначаныя апрацоўшчыкі"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Тыпы файлаў і спасылак, якія адкрывае гэтая праграма."
+
+#~ msgid "Usage"
+#~ msgstr "Выкарыстанне"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Колькі рэсурсаў выкарыстоўвае гэтая праграма."
+
+#~ msgid "Open in Software"
+#~ msgstr "Адкрыць у Software"
+
+#~ msgid "Activities"
+#~ msgstr "Дзейнасць"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Wallpaper;абрус;фон;экран;працоўны стол;"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Дазволіць праграмам ніжэй выкарыстоўваць камеру."
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "экран;блакіраванне;блакіроўка;блакаванне;дыягностыка;аварыя;збой;прыватны;"
+#~ "нядаўні;апошні;часовы;назва;імя;сетка;сеціва;ідэнтыфікацыя;ідэнтычнасць;"
+#~ "асоба;"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Не ўдалося запампаваць файл на сервер: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Профіль запампаваны на:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Запішыце гэты URL-адрас."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Перазапусціце камп'ютар і загрузіце вашу звычайную аперацыйную сістэму."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Увядзіце гэты URL-адрас у сваім браўзеры, каб спампаваць і ўсталяваць "
+#~ "профіль."
+
+#~ msgid "Upload profile"
+#~ msgstr "Запампаваць профіль"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Патрабуецца інтэрнэт-злучэнне"
+
+#~ msgid "_Copy"
+#~ msgstr "_Капіяваць"
+
+#~ msgid "Select _All"
+#~ msgstr "Выбраць ус_е"
+
+#~ msgid "Single Display"
+#~ msgstr "Адзін дысплэй"
+
+#~ msgid "Join Displays"
+#~ msgstr "Аб'яднаць дысплэі"
+
+#~ msgid "Display Mode"
+#~ msgstr "Рэжым манітора"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Перацягніце дысплэі адпаведна з іх рэальным размяшчэннем. Выберыце "
+#~ "дысплэй, каб змяніць яго налады."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Упарадкаванне дысплэяў"
+
+#~ msgid "Active Display"
+#~ msgstr "Актыўны дысплэй"
+
+#~ msgid "More Warm"
+#~ msgstr "Больш цёплая"
+
+#~ msgid "Less Warm"
+#~ msgstr "Менш цёплая"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Захаваць здымак экрана ў папцы $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Захаваць здымак акна ў папцы $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Захаваць здымак часткі экрана ў папцы $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Скапіраваць здымак экрана ў буфер абмену"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Скапіраваць здымак акна ў буфер абмену"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Скапіраваць здымак часткі экрана ў буфер абмену"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Запісаць кароткі скрынкаст"
+
+#~ msgid "Move up"
+#~ msgstr "Перамясціць вышэй"
+
+#~ msgid "Move down"
+#~ msgstr "Перамясціць ніжэй"
+
+#~ msgid "Set"
+#~ msgstr "Задаць"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Сэрвісы месцазнаходжання дазваляюць праграмам ведаць ваша "
+#~ "месцазнаходжанне. Дакладнасць павялічваецца пры выкарыстанні Wi-Fi і "
+#~ "шырокапалосага мабільнага злучэння."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Выкарыстоўвае сэрвіс месцазнаходжання Mozilla. <a href='https://location."
+#~ "services.mozilla.com/privacy'>Палітыка прыватнасці</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Дазволіць праграмам ніжэй вызначаць ваша месцазнаходжанне."
+
+#~ msgid "Lock your screen"
+#~ msgstr "Заблакіраваць экран"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Дазволіць праграмам ніжэй выкарыстоўваць мікрафон."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Час на падвойнае націсканне"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "сертыфікаты DER і PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Кнопкі прыпынення працы і выключэння"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr ""
+#~ "Вентыляцыйная адтуліна перакрыта: рэжым высокай прадукцыйнасці недаступны"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr ""
+#~ "Высокая тэмпература абсталявання: рэжым высокай прадукцыйнасці недаступны"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Рэжым высокай прадукцыйнасці недаступны"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Пацвердзіць"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Дадаць прынтар…"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Выберыце фармат для лікаў, даты і валют. Змены ўступяць у сілу пры "
+#~ "наступным уваходзе."
+
+#~ msgid "My Account"
+#~ msgstr "Мой уліковы запіс"
+
+#~ msgid "Language"
+#~ msgstr "Мова"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Мова для тэксту ў вокнах і на вэб-старонках."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Каб змены ўступілі ў сілу, перазапусціце сеанс"
+
+#~ msgid "Restart…"
+#~ msgstr "Перазапусціць…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Налады ўваходу выкарыстоўваюцца для ўсіх карыстальнікаў пры ўваходзе ў "
+#~ "сістэму"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Кіруе вынікамі пошуку, якія паказваюцца ў рэжыме Агляд дзейнасці. Парадак "
+#~ "паказу таксама можна змяняць праз перамяшчэнне радкоў у спісе."
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Супольны доступ да экрана дазваляе аддаленым карыстальнікам бачыць або "
+#~ "кантраляваць ваш экран злучыўшыся праз %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Супольны доступ да _экрана"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Некаторыя сэрвісы адключаныя, бо няма доступу да сеткі."
+
+#~ msgid "_Password:"
+#~ msgstr "Пар_оль:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Паказваць пароль"
+
+#~ msgid "Access Options"
+#~ msgstr "Параметры доступу"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Новым злучэнням патрэбна запытаць доступ"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Патрабаваць пароль"
+
+#~ msgid "Bark"
+#~ msgstr "Брэх"
+
+#~ msgid "Drip"
+#~ msgstr "Кропля"
+
+#~ msgid "Glass"
+#~ msgstr "Шклянка"
+
+#~ msgid "Sonar"
+#~ msgstr "Гідралакатар"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Агучванне клавіш"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Чытанне з экрана"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Чытанне з экрана"
+
+#~ msgid "Standard"
+#~ msgstr "Звычайны"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Тып уліковага запісу"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Дазволіць карыстальніку задаць пароль пры _ўваходзе"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_Задаць пароль"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Каб дадаваць карпаратыўных карыстальнікаў, вы павінны быць у сетцы."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Зрабіць здымак…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Каб унесці змены,\n"
+#~ "спачатку націсніце на значок *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Стварыць уліковы запіс карыстальніка"
+
+#~ msgid "User Icon"
+#~ msgstr "Значок карыстальніка"
+
+#~ msgid "Account Settings"
+#~ msgstr "Налады ўліковага запісу"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Праверка сапраўднасці і ўваход"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Уваход;Сеанс;Імя карыстальніка;Адбіткі пальцаў;Сканер;Аватар;Лагатып;"
+#~ "Выява;Твар;Вобраз;Пароль;"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Выкарыстоўваецца як назва хатняй папкі і не можа быць зменена пазней."
+
+#~ msgid "Output:"
+#~ msgstr "Вывад:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Прывязаць да аднаго манітора"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d з %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Прывязка да манітора"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Планшэт (абсалютныя каардынаты)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Сэнсарная панэль (адносныя каардынаты)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Параметры планшэта"
+
+#~ msgid "_Help"
+#~ msgstr "_Даведка"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Налады Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Рэжым адсочвання"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Прызначыць кнопкі…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Змяніць налады мышы"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Наладзіць разрознасць дысплэя"
+
+#~ msgid "No stylus found"
+#~ msgstr "Пяро не знойдзена"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Перамясціце пяро бліжэй да планшэта, каб наладзіць"
+
+#~ msgid "Top Button"
+#~ msgstr "Верхняя кнопка"
+
+#~ msgid "Lower Button"
+#~ msgstr "Ніжняя кнопка"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Самая ніжняя кнопка"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Разблакіраванне..."
+
+#~ msgid "GNOME Settings"
+#~ msgstr "Налады GNOME"
+
+#~ msgid "PH-SIM PIN required"
+#~ msgstr "Патрабуецца PIN-код для PH-SIM"
+
+#~ msgid "PH-FSIM PIN required"
+#~ msgstr "Патрабуецца PIN-код для PH-FSIM"
+
+#~ msgid "PH-FSIM PUK required"
+#~ msgstr "Патрабуецца PUK-код для PH-FSIM"
+
+#~ msgid "Memory full"
+#~ msgstr "Памяць запоўнена"
+
+#~ msgid "Memory failure"
+#~ msgstr "Збой памяці"
+
+#~ msgid "Network not allowed - emergency calls only"
+#~ msgstr "Сетка не дазволена, толькі экстранныя выклікі"
+
+#~ msgid "Illegal MS"
+#~ msgstr "Недапушчальны MS"
+
+#~ msgid "Illegal ME"
+#~ msgstr "Недапушчальны ME"
+
+#~ msgid "PLMN not allowed"
+#~ msgstr "PLMN не дазволена"
+
+#~ msgid "Location area not allowed"
+#~ msgstr "Рэгіён месцазнаходжання не дазволены"
+
+#~ msgid "Service option not supported"
+#~ msgstr "Паслуга не падтрымліваецца"
+
+#~ msgid "Requested service option not subscribed"
+#~ msgstr "Вы не падпісаны на запытаную паслугу"
+
+#~ msgid "Service option temporarily out of order"
+#~ msgstr "Паслуга часова працуе няспраўна"
+
+#~ msgid "PDP authentication failure"
+#~ msgstr "Збой праверкі сапраўднасці PDP"
+
+#~ msgid "Invalid mobile class"
+#~ msgstr "Няправільны мабільны клас"

--- a/po/be@latin.po
+++ b/po/be@latin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-02-25 23:01+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2009-02-25 23:01+0200\n"
 "Last-Translator: Alaksandar Navicki <zolak@lacinka.org>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -18,242 +18,4518 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "Abvodka vyjavy/etykietki"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
+msgstr "Šryft _aplikacyj:"
 
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "Šyrynia abvodki etykiety j vyjavy ŭ vaknie dyjalohu aściarohi"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "- Zmoŭčanyja aplikacyi GNOME"
 
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Zainstaluj"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Adčyni"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_Detali"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Šukaj"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Nieaktyŭny"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "Pałažeńnie:"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Pakažy opcyi dapamohi"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Fon"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Pamiery ekranu"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Biez špalery"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Huki"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Asablivyja skaroty"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Klavijaturnyja skaroty"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "_Nazva pałažeńnia:"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Biaz huku"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
 msgstr "Vid aściarohi"
 
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "Vid aściarohi"
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "Knopki aściarohi"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "Knopki, bačnyja ŭ vaknie aściarohi"
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "Pakažy _bolej detalaŭ"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Šryft _aplikacyj:"
 
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Place your left thumb on %s"
-msgstr "Pakładzi svoj levy adziniec na %s"
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Swipe your left thumb on %s"
-msgstr "Paciahni svaim levym adzincom pa %s"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Place your left index finger on %s"
-msgstr "Pakładzi svoj levy pakazalnik na %s"
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>E-mail</b>"
 
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Swipe your left index finger on %s"
-msgstr "Paciahni svaim levym pakazalnikam pa %s"
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Place your left middle finger on %s"
-msgstr "Pakładzi svoj levy siarednik na %s"
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Swipe your left middle finger on %s"
-msgstr "Paciahni svaim levym siarednikam pa %s"
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Place your left ring finger on %s"
-msgstr "Pakładzi svoj levy pierścianiec na %s"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Styl:"
 
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Swipe your left ring finger on %s"
-msgstr "Paciahni svaim levym pierściancom pa %s"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Zmoŭčanaja"
 
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Place your left little finger on %s"
-msgstr "Pakładzi svoj levy mieziniec na %s"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Swipe your left little finger on %s"
-msgstr "Paciahni svaim levym miezincam pa %s"
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Fon"
 
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Place your right thumb on %s"
-msgstr "Pakładzi svoj pravy adziniec na %s"
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Swipe your right thumb on %s"
-msgstr "Paciahni svaim pravym adzincom pa %s"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Vyhlad"
 
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Place your right index finger on %s"
-msgstr "Pakładzi svoj pravy pakazalnik na %s"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Swipe your right index finger on %s"
-msgstr "Paciahni svaim pravym pakazalnikam pa %s"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Place your right middle finger on %s"
-msgstr "Pakładzi svoj pravy siarednik na %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Swipe your right middle finger on %s"
-msgstr "Paciahni svaim pravym siarednikam pa %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Place your right ring finger on %s"
-msgstr "Pakładzi svoj pravy pierścianiec na %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Swipe your right ring finger on %s"
-msgstr "Paciahni svaim pravym pierściancom pa %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Place your right little finger on %s"
-msgstr "Pakładzi svoj pravy mieziniec na %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Swipe your right little finger on %s"
-msgstr "Paciahni svaim pravym miezincam pa %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:72
-#: ../capplets/about-me/fingerprint-strings.h:98
-msgid "Place your finger on the reader again"
-msgstr "Znoŭ pakładzi palec na čytnik"
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:74
-#: ../capplets/about-me/fingerprint-strings.h:100
-msgid "Swipe your finger again"
-msgstr "Znoŭ paciahni palcam pa čytniku"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:77
-#: ../capplets/about-me/fingerprint-strings.h:103
-msgid "Swipe was too short, try again"
-msgstr "Zamały prociah, paŭtary jašče"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:79
-#: ../capplets/about-me/fingerprint-strings.h:105
-msgid "Your finger was not centered, try swiping your finger again"
-msgstr "Tvoj palec nie zasiarodžany na čytniku, paŭtary prociah jašče"
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:81
-#: ../capplets/about-me/fingerprint-strings.h:107
-msgid "Remove your finger, and try swiping your finger again"
-msgstr "Prybiary palec i paŭtary prociah jašče"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:776
-msgid "Select Image"
-msgstr "Abiary vyjavu"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:778
-msgid "No Image"
-msgstr "Biez vyjavy"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:806
-#: ../capplets/appearance/appearance-desktop.c:660
-msgid "Images"
-msgstr "Vyjavy"
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:810
-#: ../capplets/appearance/theme-installer.c:695
-msgid "All Files"
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "Zroblena!"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Pamiery ekranu"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "Ekran"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Vialiki bieły kursor"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Nałady ekranu"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "nazva fajłu"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "nazva fajłu"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Kapijavańnie fajłaŭ"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
 msgstr "Usie fajły"
 
-#: ../capplets/about-me/gnome-about-me.c:956
+#: panels/color/cc-color-panel.ui:373
 msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
 msgstr ""
-"Pry sprobie atrymańnia infarmacyi ab adrasnaj knizie adbyłasia pamyłka\n"
-"Server danych Evolution nia moža absłužyć pratakoł"
 
-#: ../capplets/about-me/gnome-about-me.c:977
-msgid "Unable to open address book"
-msgstr "Niemahčyma adčynić adrasnuju knihu"
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:991
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr "Niaviadomaje ID aŭtaryzacyi, baza karystalnika moža być paškodžanaja"
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Dadaj..."
 
-#: ../capplets/about-me/gnome-about-me.c:1021
-#: ../capplets/about-me/gnome-about-me.c:1023
-#, c-format
-msgid "About %s"
-msgstr "Pra %s"
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:1041
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Enable _Fingerprint Login..."
-msgstr "Uklučy ŭvachod z _adbitkam palca..."
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:1044
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Disable _Fingerprint Login..."
-msgstr "Vyklučy ŭvachod z _adbitkam palca..."
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "About Me"
-msgstr "Pra mianie"
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "Vydal z ulubionych"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Detali"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "chvilin"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Siar_edni"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "chvilin"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "chvilin"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Kolery"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Abiary vyjavu"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Abiary"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Biaz huku"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_Spaźnieńnie:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Šukaj"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "Ekran"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Nieaktyŭny"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "sekundaŭ"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalandar:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "_Kalandar:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "- Zmoŭčanyja aplikacyi GNOME"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Adčyni pry dapamozie zmoŭčanaj aplikacyi"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Užyj _šryft"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+#, fuzzy
+msgid "Mirror"
+msgstr "Pamyłka"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Ekran"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<b>Aryjentacyja myšy</b>"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Pamiery"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "C_hutkaść abnaŭleńnia:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Častka zakončanaja"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Filter"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Z URI"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "chvilin"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+#, fuzzy
+msgid "Displays"
+msgstr "Ekran"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Pryłady"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Nazva:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Typ:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Terminał GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Akno zminimalizavanaje"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Pryłady"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Pryłady"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Źmiani nazvu..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Pra"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+#, fuzzy
+msgid "Pause playback"
+msgstr "_Hrańnie huku:"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "_Hrańnie huku:"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "Pierapynak u pisańni"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Zmoŭčanyja nałady"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+#, fuzzy
+msgid "Launch web browser"
+msgstr "Web-hartač Epiphany"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Šukaj"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Systemа"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:6
+#, fuzzy
+msgid "Lock screen"
+msgstr "Zablakuj ekran"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Dastupnaść"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opcyi"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+#, fuzzy
+msgid "Move Down"
+msgstr "Ruch nižej"
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Nałady"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Opcyi raskładki klavijatury"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "_Pali ŭvodu:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "_Užyj adzin i toj ža proxy dla ŭsich pratakołaŭ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Klavišy myšy"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Klavijaturnyja skaroty"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Asablivyja skaroty"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Dziejańnie"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Skarot"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Skarot"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Asablivyja skaroty"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Skarot"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Klavijaturnyja skaroty"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Nazva:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "_Zahad:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Skarot"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Skarot"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Niama"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "V_iarni zmoŭčanaje"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klavijatura"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
 msgstr "Naładžvaj asabistyja źviestki"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"Tabie nie dazvolena karystacca hetaj pryładaj. Źviarnisia da administratara "
-"hetaj systemy."
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
-msgid "The device is already in use."
-msgstr "Pryłada ŭžo zaniataja."
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:103
-msgid "An internal error occured"
-msgstr "Adbyłasia ŭnutranaja pamyłka"
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:220
-msgid "Delete registered fingerprints?"
-msgstr "Vydalić zarehistravanyja adbitki palcaŭ?"
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:223
-msgid "_Delete Fingerprints"
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Zmoŭčanyja nałady"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Ahulnaje"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Uleva"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Uprava"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_Vydali pałažeńnie"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Myš"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Klavišy myšy"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Akseleracyja:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Klik u knopku"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Akseleracyja:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Šryft _aplikacyj:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Pryłady"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Dziejańnie"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Nie padłučany"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Opcyi"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Sietkavyja servery"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Parol:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Dziejny _parol:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Režym akseleratara"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Chutkaść mirhańnia kursora"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Adras"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Adras"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Adras"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Zmoŭčany kursor"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Nazva:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Adras:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Adras:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Nieaktyŭny"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Adras"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adras"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "Aŭtamatyčnaje vyznačeńnie"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "chvilin"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Sietkavy proxy"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Dziejańnie"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "Adras"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Sietkavy proxy"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "_HTTP-proxy:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "_HTTP-proxy:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP-proxy:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "S_ocks-host:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "Śpis ihnaravanych hostaŭ"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "_HTTP-proxy:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "_HTTP-proxy:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP-proxy:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "_URL aŭtamatyčnaj kanfihuracyi:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Sietkavyja servery"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Parol:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Pakažy opcyi dapamohi"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "Aŭtaryzacyja ŭdałasia!"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "Usie fajły"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Užyvaj aŭtaryzacyju</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "Nazva _karystalnika:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Parol:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Novy parol:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Versija:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Versija:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_Aŭtaryzuj"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Uviadzi parol jašče raz:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_Aŭtaryzuj"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Typ:"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Zmoŭčanaja"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Fajłavaja systemа"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Abaročvańnie"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Hukavyja fajły"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "_Vydali pałažeńnie"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "chvilin"
+msgstr[1] "chvilin"
+msgstr[2] "chvilin"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "chvilin"
+msgstr[1] "chvilin"
+msgstr[2] "chvilin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "chvilin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "chvilin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "chvilin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "chvilin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "chvilin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "chvilin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "chvilin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "chvilin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+#, fuzzy
+msgid "Battery"
+msgstr "Papiaredžańnie pra stan batarei"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Pryłady"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Režym akseleratara"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Adlustruj ekrany"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Pamiery ekranu"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+#, fuzzy
+msgid "On _Battery Power"
+msgstr "Papiaredžańnie pra stan batarei"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Čas:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "Kursor"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "Kursor"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Biaz huku"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Aŭtaryzacyja ŭdałasia!"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "Nazva _karystalnika:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Pałažeńnie:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "Abiary palec"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Abiary"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_Aŭtaryzuj"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Aŭtaryzuj"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Pravier"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Opcyi"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Detali vyjaŭleńnia šryftoŭ"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "V_iarni zmoŭčanaje"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
+msgstr "Vydal z ulubionych"
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Madeli"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Upeŭnisia, ci pravilna zainstalavany hety aplet."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "_Vykanaj pry ŭruchamleńni"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Kursor"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "Narmalna"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Typovyja zadačy"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Usie fajły"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Pieradahlad:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "_Addzieł:"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "Vyjdzi"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+#, fuzzy
+msgid "_Language"
+msgstr "_Mova:"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Zablakuj ekran"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "Muzyčny player Muine"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Dziejańnie"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Typ:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Zablakuj ekran"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+#, fuzzy
+msgid "Screen"
+msgstr "Zablakuj ekran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Nałady ekranu %d\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "_Novaje pałažeńnie..."
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Inšaje"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Pałažeńnie:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Šryft _aplikacyj:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Šukaj"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Sietkavyja servery"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Stoł"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Vydali pałažeńnie"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Parol:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Stoł"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Kiravańnie UI"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Nie padłučany"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "S_kapijuj"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Aŭtaryzuj"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Nazva karystalnika:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
 msgstr "_Vydali adbitki palcaŭ"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:230
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Systemnyja huki"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+#, fuzzy
+msgid "Output"
+msgstr "Klanavanaje vyjście"
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Pryłady"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Pravier"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Kanfihuracyja proxy"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Pryłady"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Tryvožny syhnał"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Huk"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nazva:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Pryłady"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Pryłady"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>Mirhańnie kursora</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Kursor _mirhaje ŭ tekstavych paloch"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Chutkaść:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Chutkaść mirhańnia kursora"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Chutkaść mirhańnia kursora"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "<b>Symulavany druhi klik</b>"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+#, fuzzy
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "_Inicyjuj druhi klik, kali ŭtrymlivajecca pieršaja klaviša"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Skarot"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "_Druhi klik:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "_Dvuklik:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+#, fuzzy
+msgid "Trigger a click when the pointer hovers"
+msgstr "_Inicyjuj klik, kali spyniajecca kursor"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Spaźnieńnie:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Skarot"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Parohavy zruch:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Mały"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Vialiki"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Paŭtor klavišaŭ</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "_Paŭtor nacisku klavišy pry jaje ŭtrymańni"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Chutkaść paŭtoru klavišaŭ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Chutkaść paŭtoru klavišaŭ"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Manitor pracy klavijatury"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "<b>_Tryvałyja klavišy</b>"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "_Vyklučaj tryvałyja klavišy, kali razam nacisnutyja dźvie klavišy"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Hukavy syhnał, kali nacisnuty _madyfikatar"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "<b>Pavolnyja klavišy</b>"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Skarot"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Hukavy syhnał, kali nacisnutaja klaviša"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Hukavy syhnał, kali p_ryniataja klaviša"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Hukavy syhnał, kali adch_ilenaja klaviša"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "<b>Spružynistyja klavišy</b>"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "_Ihnaruj chutkija paŭtornyja naciski klavišaŭ"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Skarot"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "_Mahčymaści dastupnaści možna ŭklučać klavijaturnymi skarotami"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Dastupnaść _klavijatury"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Vialiki"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Ekranny čy_tač Linuksa"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Hukavyja fajły"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Hukavy _syhnał pry ŭklučeńni/vyklučeńni mahčymaściaŭ dastupnaści"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Vizualnaja tryvoha"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Ekrannaja _klavijatura GNOME"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Paŭtor klavišaŭ</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Mirhańnie kursora</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Klavišy myšy"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Vialiki kursor"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "<b>Spaźnieńnie dvukliku</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "_Dvuklik:"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+#, fuzzy
+msgid "Visual Alerts"
+msgstr "Vizualnaja tryvoha"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Mirhaj _usim ekranam"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Mirhaj _usim ekranam"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Zablakuj ekran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "Uleva"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "Uprava"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Opcyi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "Orca ź lupaj"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "Kolery"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Kantakt"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Niama"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Poŭny"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "Kolery"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Fajłavaja systemа"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "Pustaja śmietnica"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "Pieraniasi ŭ śmietnicu"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "Terminator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Novy parol:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Uklučy ŭvachod z adbitkam palca"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Abiary hukavy fajł"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Uklučy ŭvachod z adbitkam palca"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "_Vydali adbitki palcaŭ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Niama"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -261,3322 +4537,2934 @@ msgstr ""
 "Chočaš vydalić zarehistravanyja adbitki palcaŭ, što vyklučyć mahčymaść "
 "uvachodu takim sposabam aŭtaryzacyi?"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:343
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:583
-msgid "Done!"
-msgstr "Zroblena!"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "Nie ŭdałosia dastupicca da pryłady \"%s\""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:444
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "Nie ŭdałosia raspačać zapaminańnie adbitkaŭ dla pryłady \"%s\""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:491
-msgid "Could not access any fingerprint readers"
-msgstr "Nie ŭdałosia dastupicca da budź-jakoha čytnika adbitkaŭ palcaŭ"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:492
-msgid "Please contact your system administrator for help."
-msgstr "Źviarnisia da administratara tvajoj systemy pa dapamohu."
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:518
-msgid "Enable Fingerprint Login"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
 msgstr "Uklučy ŭvachod z adbitkam palca"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:534
-msgid "Select finger"
-msgstr "Abiary palec"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:555
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
 msgstr ""
-"Kab uklučyć mahčymaść uvachodu z adbitkam palca, treba zapisać adbitak "
-"tvajho palca z dapamohaj pryłady \"%s\"."
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:568
-msgid "Swipe finger on reader"
-msgstr "Paciahni palcam pa čytniku"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Uklučy ŭvachod z adbitkam palca"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:570
-msgid "Place finger on reader"
-msgstr "Pakładzi palec na čytnik"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:1
-msgid "Left index finger"
-msgstr "Levy pakazalnik"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:2
-msgid ""
-"Left thumb\n"
-"Left middle finger\n"
-"Left ring finger\n"
-"Left little finger\n"
-"Right thumb\n"
-"Right middle finger\n"
-"Right ring finger\n"
-"Right little finger"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
 msgstr ""
-"Levy adziniec\n"
-"Levy siarednik\n"
-"Levy pierścianiec\n"
-"Levy mieziniec\n"
-"Pravy adziniec\n"
-"Pravy siarednik\n"
-"Pravy pierścianiec\n"
-"Pravy mieziniec"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:10
-msgid "Other finger: "
-msgstr "Inšy palec: "
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Uklučy ŭvachod z adbitkam palca"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:11
-msgid "Right index finger"
-msgstr "Pravy pakazalnik"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:12
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
 msgstr ""
-"Adbitak tvajho palca zapisany. Ciapier ty zmožaš uvajści ŭ systemu z "
-"dapamohaj čytnika."
 
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-msgid "<b>Email</b>"
-msgstr "<b>E-mail</b>"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Vydali adbitki palcaŭ"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-msgid "<b>Home</b>"
-msgstr "<b>Dom</b>"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Uklučy ŭvachod z adbitkam palca"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Kamunikatary</b>"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Pieradahlad šryftoŭ"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Job</b>"
-msgstr "<b>Praca</b>"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Telephone</b>"
-msgstr "<b>Telefon</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Web</b>"
-msgstr "<b>Sieciva</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Work</b>"
-msgstr "<b>Praca</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Źmiani parol</span>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "A_ddress:"
-msgstr "A_dras:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_ssistant:"
-msgstr "A_systent:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "Address"
-msgstr "Adras"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "C_ity:"
-msgstr "H_orad:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "C_ompany:"
-msgstr "_Firma:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "Cale_ndar:"
-msgstr "_Kalandar:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "Change Passwo_rd..."
-msgstr "Źmiani _parol..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Change pa_ssword"
-msgstr "Źmiani pa_rol"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change password"
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
 msgstr "Źmiani parol"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Ci_ty:"
-msgstr "H_orad:"
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Nabor źmienaŭ"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Co_untry:"
-msgstr "K_raina:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Contact"
-msgstr "Kantakt"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Cou_ntry:"
-msgstr "_Kraina:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Current _password:"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "Dziejny _parol:"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "Full Name"
-msgstr "Imia j proźvišča"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "Hom_e:"
-msgstr "Do_m:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P.O. _box:"
-msgstr "_Paštovaja skrynka:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "P._O. box:"
-msgstr "Pašt_ovaja skrynka:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "Personal Info"
-msgstr "Persanalnyja źviestki"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#: ../capplets/about-me/gnome-about-me-password.c:938
-msgid ""
-"Please type your password again in the <b>Retype new password</b> field."
-msgstr "Uviadzi svoj parol jašče raz u poli <b>Uviadzi parol znoŭ</b>."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Select your photo"
-msgstr "Abiary fatahrafiju"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "State/Pro_vince:"
-msgstr "R_ehijon:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid ""
-"To change your password, enter your current password in the field below and "
-"click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for "
-"verification and click <b>Change password</b>."
-msgstr ""
-"Kab źmianić parol, uviadzi dziejny parol u poli nižej i klikni <b>Aŭtaryzuj</"
-"b>.\n"
-"Paśla aŭtaryzacyi ŭviadzi novy parol, uviadzi jaho znoŭ dziela veryfikacyi i "
-"klikni <b>Źmiani parol</b>."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "User name:"
-msgstr "Nazva karystalnika:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "Web _log:"
-msgstr "B_log:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "Wor_k:"
-msgstr "Pra_ca:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "Work _fax:"
-msgstr "_Faks na pracy:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "Zip/_Postal code:"
-msgstr "Paštovy _indeks:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Address:"
-msgstr "_Adras:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Authenticate"
-msgstr "_Aŭtaryzuj"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Department:"
-msgstr "_Addzieł:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_Groupwise:"
-msgstr "_Groupwise:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Home page:"
-msgstr "_Chatniaja staronka:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Home:"
-msgstr "Do_m:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_Jabber:"
-msgstr "_Jabber:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Manager:"
-msgstr "_Kiraŭnik:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Mobile:"
-msgstr "M_abilny telefon:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_New password:"
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
 msgstr "_Novy parol:"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Profession:"
-msgstr "_Prafesija:"
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Źmiani parol"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:55
-msgid "_Retype new password:"
-msgstr "_Uviadzi parol jašče raz:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:56
-msgid "_State/Province:"
-msgstr "Rehijo_n:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:57
-msgid "_Title:"
-msgstr "P_asada:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:58
-msgid "_Work:"
-msgstr "_Praca:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:59
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:60
-msgid "_Zip/Postal code:"
-msgstr "Paštovy _indeks:"
-
-#: ../capplets/about-me/gnome-about-me-password.c:162
-msgid "Child exited unexpectedly"
-msgstr "Praces naščadka niečakana zakončyŭsia"
-
-#: ../capplets/about-me/gnome-about-me-password.c:297
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr "Niamahčyma začynić kanał I/O backend_stdin: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:310
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr "Niemahčyma začynić kanał I/O backend_stdout: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:409
-msgid "Authenticated!"
-msgstr "Aŭtaryzacyja ŭdałasia!"
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:475
-#: ../capplets/about-me/gnome-about-me-password.c:551
-msgid ""
-"Your password has been changed since you initially authenticated! Please re-"
-"authenticate."
-msgstr ""
-"Tvoj parol byŭ źmienieny paśla pačatkovaj aŭtaryzacyi! Kali łaska, paŭtary "
-"aŭtaryzacyju."
-
-#: ../capplets/about-me/gnome-about-me-password.c:477
-msgid "That password was incorrect."
-msgstr "Parol byŭ niapravilny."
-
-#: ../capplets/about-me/gnome-about-me-password.c:524
-msgid "Your password has been changed."
-msgstr "Tvoj parol byŭ źmienieny."
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:534
-#, c-format
-msgid "System error: %s."
-msgstr "Systemnaja pamyłka: %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:537
-msgid "The password is too short."
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
 msgstr "Hety parol nadta karotki."
 
-#: ../capplets/about-me/gnome-about-me-password.c:540
-msgid "The password is too simple."
-msgstr "Hety parol nadta prosty."
-
-#: ../capplets/about-me/gnome-about-me-password.c:543
-msgid "The old and new passwords are too similar."
-msgstr "Novy parol nadta padobny da staroha."
-
-#: ../capplets/about-me/gnome-about-me-password.c:545
-msgid "The new password must contain numeric or special character(s)."
-msgstr "U novym paroli musiać być ličby albo admysłovyja znaki."
-
-#: ../capplets/about-me/gnome-about-me-password.c:548
-msgid "The old and new passwords are the same."
-msgstr "Novy parol taki ž, jak i stary."
-
-#. translators: Unable to launch <program>: <error message>
-#: ../capplets/about-me/gnome-about-me-password.c:820
-#, c-format
-msgid "Unable to launch %s: %s"
-msgstr "Niemahčyma ŭruchomić %s: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:824
-msgid "Unable to launch backend"
-msgstr "Niemahčyma ŭruchomić padtrymku"
-
-#: ../capplets/about-me/gnome-about-me-password.c:825
-msgid "A system error has occurred"
-msgstr "Adbyłasia systemnaja pamyłka"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:845
-msgid "Checking password..."
-msgstr "Pravierka parolu..."
-
-#: ../capplets/about-me/gnome-about-me-password.c:932
-msgid "Click <b>Change password</b> to change your password."
-msgstr "Klikni na <b>Źmiani parol</b>, kab źmianić jaho."
-
-#: ../capplets/about-me/gnome-about-me-password.c:935
-msgid "Please type your password in the <b>New password</b> field."
-msgstr "Uviadzi parol u poli <b>Novy parol</b>."
-
-#: ../capplets/about-me/gnome-about-me-password.c:941
-msgid "The two passwords are not equal."
-msgstr "Paroli roźniacca miž saboj."
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Assistive Technologies</b>"
-msgstr "<b>Technalohii dastupnaści</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Preferences</b>"
-msgstr "<b>Nałady</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid "Accessible Lo_gin"
-msgstr "_Dastupny ŭvachod"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technologies Preferences"
-msgstr "Nałady technalohij dastupnaści"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid ""
-"Changes to enable assistive technologies will not take effect until your "
-"next log in."
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
 msgstr ""
-"Źmieny dla ŭklučeńnia technalohij dastupnaści nie paŭpłyvajuć na dziejnyja "
-"nałady da nastupnaj tvajoj aŭtaryzacyi ŭ systemie."
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Close and _Log Out"
-msgstr "Začyni j vy_jdzi"
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Novy parol:"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "Jump to Preferred Applications dialog"
-msgstr "Pieraskoč da vakna \"Pažadanyja aplikacyi\""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "Jump to the Accessible Login dialog"
-msgstr "Pieraskoč da vakna \"Dastupny ŭvachod\""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "Jump to the Keyboard Accessibility dialog"
-msgstr "Pieraskoč da vakna \"Dastupnaść klavijatury\""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "Jump to the Mouse Accessibility dialog"
-msgstr "Pieraskoč da vakna \"Dastupnaść myšy\""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
-msgid "_Enable assistive technologies"
-msgstr "Uklučy technalohii dastupnaści"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
-msgid "_Keyboard Accessibility"
-msgstr "Dastupnaść _klavijatury"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
-msgid "_Mouse Accessibility"
-msgstr "Dastupnaść _myšy"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
-msgid "_Preferred Applications"
-msgstr "_Pažadanyja aplikacyi"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technologies"
-msgstr "Technalohii dastupnaści"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Choose which accessibility features to enable when you log in"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
 msgstr ""
-"Vybiery, jakija technalohii dastupnaśći treba ŭklučyć pry ŭvachodzie ŭ "
-"systemu"
 
-#: ../capplets/appearance/appearance-desktop.c:628
-msgid "Add Wallpaper"
-msgstr "Dadaj špaleru"
-
-#: ../capplets/appearance/appearance-desktop.c:664
-msgid "All files"
-msgstr "Usie fajły"
-
-#: ../capplets/appearance/appearance-font.c:494
-msgid "Font may be too large"
-msgstr "Šryft moža być nadta vialikim"
-
-#: ../capplets/appearance/appearance-font.c:498
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Abrany šryft maje vyšyniu %d punkt, i moža być ciažka efektyŭna jaho "
-"vykarystoŭvać u kamputary. Rekamendujecca abrać pamier, mienšy za %d."
-msgstr[1] ""
-"Abrany šryft maje vyšyniu %d punkty, i moža być ciažka efektyŭna jaho "
-"vykarystoŭvać u kamputary. Rekamendujecca abrać pamier, mienšy za %d."
-msgstr[2] ""
-"Abrany šryft maje vyšyniu %d punktaŭ, i moža być ciažka efektyŭna jaho "
-"vykarystoŭvać u kamputary. Rekamendujecca abrać pamier, mienšy za %d."
-
-#: ../capplets/appearance/appearance-font.c:511
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Abrany šryft maje vyšyniu %d punkt, i moža być ciažka efektyŭna jaho "
-"vykarystoŭvać u kamputary. Rekamendujecca abrać šryft mienšaha pamieru."
-msgstr[1] ""
-"Abrany šryft maje vyšyniu %d punkty, i moža być ciažka efektyŭna jaho "
-"vykarystoŭvać u kamputary. Rekamendujecca abrać šryft mienšaha pamieru."
-msgstr[2] ""
-"Abrany šryft maje vyšyniu %d punktaŭ, i moža być ciažka efektyŭna jaho "
-"vykarystoŭvać u kamputary. Rekamendujecca abrać šryft mienšaha pamieru."
-
-#: ../capplets/appearance/appearance-font.c:534
-msgid "Use previous font"
-msgstr "Užyj papiaredni šryft"
-
-#: ../capplets/appearance/appearance-font.c:536
-msgid "Use selected font"
-msgstr "Užyj zaznačany šryft"
-
-#: ../capplets/appearance/appearance-main.c:124
-msgid "Specify the filename of a theme to install"
-msgstr "Akreśl nazvu fajłu matyvu, jaki treba zainstalavać"
-
-#: ../capplets/appearance/appearance-main.c:125
-msgid "filename"
-msgstr "nazva fajłu"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/appearance/appearance-main.c:132
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
-"Akreśl nazvu staronki, jakuju treba pakazać (theme|background|fonts|"
-"interface)"
 
-#: ../capplets/appearance/appearance-main.c:133
-#: ../capplets/default-applications/gnome-da-capplet.c:897
-#: ../capplets/mouse/gnome-mouse-properties.c:442
-msgid "page"
-msgstr "staronka"
-
-#: ../capplets/appearance/appearance-main.c:140
-msgid "[WALLPAPER...]"
-msgstr "[ŠPALERA...]"
-
-#: ../capplets/appearance/appearance-style.c:173
-#: ../capplets/common/gnome-theme-info.c:445
-#: ../capplets/common/gnome-theme-info.c:637
-msgid "Default Pointer"
-msgstr "Zmoŭčany kursor"
-
-#: ../capplets/appearance/appearance-style.c:235
-#: ../capplets/appearance/appearance-themes.c:687
-msgid "Install"
-msgstr "Zainstaluj"
-
-#: ../capplets/appearance/appearance-style.c:255
-#: ../capplets/common/gnome-theme-info.c:1647
-#, c-format
-msgid ""
-"This theme will not look as intended because the required GTK+ theme engine "
-"'%s' is not installed."
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
 msgstr ""
-"Hety matyŭ nia budzie vyhladać, jak naležyć, bo nie zainstalavana patrebnaha "
-"ruchavika matyvaŭ GTK+ \"%s\"."
 
-#: ../capplets/appearance/appearance-themes.c:675
-msgid "Apply Background"
-msgstr "Užyj fon"
-
-#: ../capplets/appearance/appearance-themes.c:679
-msgid "Apply Font"
-msgstr "Užyj šryft"
-
-#: ../capplets/appearance/appearance-themes.c:683
-msgid "Revert Font"
-msgstr "Viarni šryft"
-
-#: ../capplets/appearance/appearance-themes.c:713
-msgid ""
-"The current theme suggests a background and a font. Also, the last applied "
-"font suggestion can be reverted."
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
 msgstr ""
-"Dziejny matyŭ raić peŭny fon i šryft. Zaŭsiody možna viarnuć papiaredni "
-"šryft."
 
-#: ../capplets/appearance/appearance-themes.c:715
-msgid ""
-"The current theme suggests a background. Also, the last applied font "
-"suggestion can be reverted."
-msgstr "Dziejny matyŭ raić peŭny fon. Zaŭsiody možna viarnuć papiaredni šryft."
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:717
-msgid "The current theme suggests a background and a font."
-msgstr "Dziejny matyŭ raić peŭny fon i šryft."
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Imia j proźvišča"
 
-#: ../capplets/appearance/appearance-themes.c:719
-msgid ""
-"The current theme suggests a font. Also, the last applied font suggestion "
-"can be reverted."
-msgstr "Dziejny matyŭ raić peŭny šryft. Zaŭsiody možna viarnuć papiaredni."
-
-#: ../capplets/appearance/appearance-themes.c:721
-msgid "The current theme suggests a background."
-msgstr "Dziejny matyŭ raić peŭny fon."
-
-#: ../capplets/appearance/appearance-themes.c:723
-msgid "The last applied font suggestion can be reverted."
-msgstr "Zaŭsiody možna viarnuć papiaredni šryft."
-
-#: ../capplets/appearance/appearance-themes.c:725
-msgid "The current theme suggests a font."
-msgstr "Dziejny matyŭ raić peŭny šryft."
-
-#: ../capplets/appearance/appearance-themes.c:1046
-#: ../capplets/default-applications/gnome-da-capplet.c:648
-msgid "Custom"
-msgstr "Admysłovy"
-
-#: ../capplets/appearance/data/appearance.glade.h:1
-msgid "<b>C_olors</b>"
-msgstr "<b>K_olery</b>"
-
-# Mechanizm papraŭleńnia jakaści druku na aparatury ź nizkaj padzielnaj zdolnaściu. Adpaviednika niama, pakinuŭ jak jość. Prapanuju heta pryniać tak jak i widget.
-#. font hinting
-#: ../capplets/appearance/data/appearance.glade.h:3
-msgid "<b>Hinting</b>"
-msgstr "<b>Hinting</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:4
-msgid "<b>Menus and Toolbars</b>"
-msgstr "<b>Paneli menu j pryładździa</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:5
-msgid "<b>Preview</b>"
-msgstr "<b>Pieradahlad</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:6
-msgid "<b>Rendering</b>"
-msgstr "<b>Vyjaŭleńnie</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:7
-msgid "<b>Smoothing</b>"
-msgstr "<b>Vyhładžvańnie</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:8
-msgid "<b>Subpixel Order</b>"
-msgstr "<b>Čarhovaść subpikselaŭ</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:9
-msgid "<b>_Desktop Background</b>"
-msgstr "<b>_Fon stała</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:10
-msgid "Appearance Preferences"
-msgstr "Nałady vyhladu"
-
-#: ../capplets/appearance/data/appearance.glade.h:11
-msgid "Background"
-msgstr "Fon"
-
-#: ../capplets/appearance/data/appearance.glade.h:12
-msgid "Best _shapes"
-msgstr "_Najlepšyja kštałty"
-
-#: ../capplets/appearance/data/appearance.glade.h:13
-msgid "Best co_ntrast"
-msgstr "Najlepšy _kantrast"
-
-#: ../capplets/appearance/data/appearance.glade.h:14
-msgid "C_ustomize..."
-msgstr "_Źmiani..."
-
-#: ../capplets/appearance/data/appearance.glade.h:15
-msgid "C_ut"
-msgstr "_Vytni"
-
-#: ../capplets/appearance/data/appearance.glade.h:16
-msgid "Changing your cursor theme takes effect the next time you log in."
-msgstr "Źmiena matyvu kursora paŭpłyvaje paśla nastupnaha ŭvachodu."
-
-#: ../capplets/appearance/data/appearance.glade.h:17
-msgid "Colors"
-msgstr "Kolery"
-
-#: ../capplets/appearance/data/appearance.glade.h:18
-msgid "Controls"
-msgstr "Elementy kiravańnia"
-
-#: ../capplets/appearance/data/appearance.glade.h:19
-msgid "Customize Theme"
-msgstr "Źmiani matyŭ"
-
-#: ../capplets/appearance/data/appearance.glade.h:20
-msgid "D_etails..."
-msgstr "_Detali..."
-
-#: ../capplets/appearance/data/appearance.glade.h:21
-msgid "Des_ktop font:"
-msgstr "Šryft dla _stała:"
-
-#: ../capplets/appearance/data/appearance.glade.h:22
+#: panels/user-accounts/cc-user-panel.ui:171
 msgid "Edit"
 msgstr "Redahuj"
 
-#: ../capplets/appearance/data/appearance.glade.h:23
-msgid "Font Rendering Details"
-msgstr "Detali vyjaŭleńnia šryftoŭ"
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+#, fuzzy
+msgid "_Fingerprint Login"
+msgstr "Uklučy ŭvachod z adbitkam palca"
 
-#: ../capplets/appearance/data/appearance.glade.h:24
-msgid "Fonts"
-msgstr "Šryfty"
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:25
-msgid "Gra_yscale"
-msgstr "Adcieńni _šeraha"
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:26
-msgid "Icons"
-msgstr "Ikony"
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:27
-msgid "Interface"
-msgstr "Interfejs"
-
-#: ../capplets/appearance/data/appearance.glade.h:28
-msgid "Large"
-msgstr "Vialiki"
-
-#: ../capplets/appearance/data/appearance.glade.h:29
-msgid "N_one"
-msgstr "_Niama"
-
-#: ../capplets/appearance/data/appearance.glade.h:30
-msgid "New File"
-msgstr "Novy fajł"
-
-#: ../capplets/appearance/data/appearance.glade.h:31
-msgid "Open File"
-msgstr "Adčyni fajł"
-
-#: ../capplets/appearance/data/appearance.glade.h:32
-msgid "Open a dialog to specify the color"
-msgstr "Adčyni vakno vybaru koleru"
-
-#: ../capplets/appearance/data/appearance.glade.h:33
-msgid "Pointer"
-msgstr "Kursor"
-
-#: ../capplets/appearance/data/appearance.glade.h:34
-msgid "R_esolution:"
-msgstr "Pa_miery:"
-
-#: ../capplets/appearance/data/appearance.glade.h:35
-msgid "Save File"
-msgstr "Zapišy fajł"
-
-#: ../capplets/appearance/data/appearance.glade.h:36
-msgid "Save Theme As..."
-msgstr "Za_pišy matyŭ jak..."
-
-#: ../capplets/appearance/data/appearance.glade.h:37
-msgid "Save _As..."
-msgstr "Za_pišy jak..."
-
-#: ../capplets/appearance/data/appearance.glade.h:38
-msgid "Save _background image"
-msgstr "Zapišy _fonavuju vyjavu"
-
-#: ../capplets/appearance/data/appearance.glade.h:39
-msgid "Show _icons in menus"
-msgstr "Pakazvaj _ikony ŭ menu"
-
-#: ../capplets/appearance/data/appearance.glade.h:40
-msgid "Small"
-msgstr "Mały"
-
-#: ../capplets/appearance/data/appearance.glade.h:41
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"Solid color\n"
-"Horizontal gradient\n"
-"Vertical gradient"
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
-"Adnastajny koler\n"
-"Haryzantalny hradyjent\n"
-"Vertykalny hradyjent"
 
-#: ../capplets/appearance/data/appearance.glade.h:44
-msgid "Sub_pixel (LCDs)"
-msgstr "_Subpikselnaje (ekrany LCD)"
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Elementy kiravańnia"
 
-#: ../capplets/appearance/data/appearance.glade.h:45
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "Sub_pikselnaje vyhładžvańnie (ekrany LCD)"
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Adčyni pry dapamozie zmoŭčanaj aplikacyi"
 
-#: ../capplets/appearance/data/appearance.glade.h:46
-msgid "Text"
-msgstr "Tekst"
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:47
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Inšy palec: "
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Biaz huku"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"Text below items\n"
-"Text beside items\n"
-"Icons only\n"
-"Text only"
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"Tekst nižej elementaŭ\n"
-"Tekst pobač z elementami\n"
-"Tolki ikony\n"
-"Tolki tekst"
 
-#: ../capplets/appearance/data/appearance.glade.h:51
-msgid "The current controls theme does not support color schemes."
-msgstr "Dziejny matyŭ elementaŭ kiravańnia nie absłuhoŭvaje schiemaŭ koleraŭ."
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:52
-msgid "Theme"
-msgstr "Matyŭ"
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:53
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"Tiled\n"
-"Zoom\n"
-"Centered\n"
-"Scaled\n"
-"Fill screen"
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
-"Pa susiedztvie\n"
-"Maštabavany\n"
-"Centravany\n"
-"Źmienieny pamier\n"
-"Zapaŭnieńnie ekranu"
 
-#: ../capplets/appearance/data/appearance.glade.h:58
-msgid "Toolbar _button labels:"
-msgstr "_Podpisy dla knopak paneli pryładździa:"
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
 
-#. vertical hinting, pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:60
-msgid "VB_GR"
-msgstr "VB_GR"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:61
-msgid "Window Border"
-msgstr "Kraj vakna"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:62
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
-msgid "_Add..."
-msgstr "_Dadaj..."
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:63
-msgid "_Application font:"
-msgstr "Šryft _aplikacyj:"
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Knopki aściarohi"
 
-#. pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:65
-msgid "_BGR"
-msgstr "_BGR"
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:66
-msgid "_Copy"
-msgstr "S_kapijuj"
-
-#: ../capplets/appearance/data/appearance.glade.h:67
-msgid "_Description:"
-msgstr "_Apisańnie:"
-
-#: ../capplets/appearance/data/appearance.glade.h:68
-msgid "_Document font:"
-msgstr "Šryft _dakumentaŭ:"
-
-#: ../capplets/appearance/data/appearance.glade.h:69
-msgid "_Editable menu shortcut keys"
-msgstr "_Źmianialnyja klavišy skarotaŭ menu"
-
-#: ../capplets/appearance/data/appearance.glade.h:70
-msgid "_File"
-msgstr "_Fajł"
-
-#: ../capplets/appearance/data/appearance.glade.h:71
-msgid "_Fixed width font:"
-msgstr "Šryft s_tałaj šyryni:"
-
-#: ../capplets/appearance/data/appearance.glade.h:72
-msgid "_Full"
-msgstr "_Poŭny"
-
-#: ../capplets/appearance/data/appearance.glade.h:73
-msgid "_Input boxes:"
-msgstr "_Pali ŭvodu:"
-
-#: ../capplets/appearance/data/appearance.glade.h:74
-msgid "_Install..."
-msgstr "Za_instaluj..."
-
-#: ../capplets/appearance/data/appearance.glade.h:75
-msgid "_Medium"
-msgstr "Siar_edni"
-
-#: ../capplets/appearance/data/appearance.glade.h:76
-msgid "_Monochrome"
-msgstr "_Monachromnaje"
-
-#: ../capplets/appearance/data/appearance.glade.h:77
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:5
-msgid "_Name:"
-msgstr "_Nazva:"
-
-#: ../capplets/appearance/data/appearance.glade.h:78
-msgid "_New"
-msgstr "_Novy"
-
-#: ../capplets/appearance/data/appearance.glade.h:79
-msgid "_None"
-msgstr "_Niama"
-
-#: ../capplets/appearance/data/appearance.glade.h:80
-msgid "_Open"
-msgstr "_Adčyni"
-
-#: ../capplets/appearance/data/appearance.glade.h:81
-msgid "_Paste"
-msgstr "Uk_lej"
-
-#: ../capplets/appearance/data/appearance.glade.h:82
-msgid "_Print"
-msgstr "Vy_drukuj"
-
-#: ../capplets/appearance/data/appearance.glade.h:83
-msgid "_Quit"
-msgstr "_Vyjdzi"
-
-#. pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:85
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:86
-msgid "_Reset to Defaults"
-msgstr "V_iarni zmoŭčanaje"
-
-#: ../capplets/appearance/data/appearance.glade.h:87
-msgid "_Save"
-msgstr "_Zapišy"
-
-#: ../capplets/appearance/data/appearance.glade.h:88
-msgid "_Selected items:"
-msgstr "_Zaznačanyja elementy:"
-
-#: ../capplets/appearance/data/appearance.glade.h:89
-msgid "_Size:"
-msgstr "_Pamier:"
-
-#: ../capplets/appearance/data/appearance.glade.h:90
-msgid "_Slight"
-msgstr "_Lohki"
-
-#: ../capplets/appearance/data/appearance.glade.h:91
-msgid "_Style:"
-msgstr "_Styl:"
-
-#: ../capplets/appearance/data/appearance.glade.h:92
-msgid "_Tooltips:"
-msgstr "_Padkazki:"
-
-#. vertical hinting, pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:94
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:95
-msgid "_Window title font:"
-msgstr "_Šryft zahałoŭku vakna:"
-
-#: ../capplets/appearance/data/appearance.glade.h:96
-msgid "_Windows:"
-msgstr "Vo_kny:"
-
-#: ../capplets/appearance/data/appearance.glade.h:97
-msgid "dots per inch"
-msgstr "punktaŭ na cal"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr "Vyhlad"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr "Źmiani vyhlad stała"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr "Instaluje pakunki matyvaŭ roznych častak asiarodździa"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr "Instalatar matyvaŭ"
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr "Pakunak matyvu GNOME"
-
-#: ../capplets/appearance/gnome-wp-info.c:50
-msgid "No Desktop Background"
-msgstr "Biaz fonu stała"
-
-#: ../capplets/appearance/gnome-wp-item.c:208
-msgid "Slide Show"
-msgstr "Slideshow"
-
-#. translators: <b>wallpaper name</b>
-#. * mime type, x pixel(s) by y pixel(s)
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:216
-#, c-format
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"<b>%s</b>\n"
-"%s, %d %s by %d %s\n"
-"Folder: %s"
-msgstr ""
-"<b>%s</b>\n"
-"%s, %d %s na %d %s\n"
-"Kataloh: %s"
-
-#: ../capplets/appearance/gnome-wp-item.c:222
-#: ../capplets/appearance/gnome-wp-item.c:224
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "piksel"
-msgstr[1] "pikseli"
-msgstr[2] "pikselaŭ"
-
-#: ../capplets/appearance/theme-installer.c:174
-#: ../capplets/appearance/theme-installer.c:224
-msgid "Cannot install theme"
-msgstr "Niemahčyma zainstalavać matyŭ"
-
-#: ../capplets/appearance/theme-installer.c:176
-#, c-format
-msgid "The %s utility is not installed."
-msgstr "Pryłada %s nie zainstalavanaja."
-
-#: ../capplets/appearance/theme-installer.c:226
-msgid "There was a problem while extracting the theme."
-msgstr "Uźnikła prablema ŭ časie raspakoŭvańnia matyvu."
-
-#: ../capplets/appearance/theme-installer.c:249
-msgid "There was an error installing the selected file"
-msgstr "U časie instalavańnia zaznačanaha fajłu ŭźnikła pamyłka"
-
-#: ../capplets/appearance/theme-installer.c:250
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme."
-msgstr "\"%s\" nie padobny na pravilny matyŭ."
-
-#: ../capplets/appearance/theme-installer.c:251
-#, c-format
-msgid ""
-"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
-"you need to compile."
-msgstr ""
-"\"%s\" nie padobny na pravilny matyŭ. Heta moža być prahramny matyŭ, jaki "
-"treba skampilavać."
-
-#: ../capplets/appearance/theme-installer.c:354
-#, c-format
-msgid "Installation for theme \"%s\" failed."
-msgstr "Pamyłka instalacyi matyvu \"%s\"."
-
-#: ../capplets/appearance/theme-installer.c:393
-#, c-format
-msgid "The theme \"%s\" has been installed."
-msgstr "Matyŭ \"%s\" zainstalavany."
-
-#: ../capplets/appearance/theme-installer.c:398
-msgid "Would you like to apply it now, or keep your current theme?"
-msgstr "Ty chočaš užyć matyŭ ciapier ci pakinuć dziejny matyŭ?"
-
-#: ../capplets/appearance/theme-installer.c:400
-msgid "Keep Current Theme"
-msgstr "Pakiń dziejny matyŭ"
-
-#: ../capplets/appearance/theme-installer.c:402
-msgid "Apply New Theme"
-msgstr "Užyj novy matyŭ"
-
-#: ../capplets/appearance/theme-installer.c:446
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "Matyŭ GNOME %s pravilna zainstalavany"
-
-#: ../capplets/appearance/theme-installer.c:505
-msgid "Failed to create temporary directory"
-msgstr "Niemahčyma stvaryć časovy kataloh"
-
-#: ../capplets/appearance/theme-installer.c:568
-msgid "New themes have been successfully installed."
-msgstr "Novyja matyvy paśpiachova zainstalavanyja."
-
-#: ../capplets/appearance/theme-installer.c:593
-msgid "No theme file location specified to install"
-msgstr "Nie padadziena pałažeńnia fajłu matyvu, jaki treba zainstalavać"
-
-#: ../capplets/appearance/theme-installer.c:614
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"Niedastatkova dazvołu, kab zainstalavać matyŭ u:\n"
-"%s"
-
-#: ../capplets/appearance/theme-installer.c:684
-msgid "Select Theme"
-msgstr "Abiary matyŭ"
-
-#: ../capplets/appearance/theme-installer.c:688
-msgid "Theme Packages"
-msgstr "Pakunki matyvaŭ"
-
-#: ../capplets/appearance/theme-save.c:93
-#, c-format
-msgid "Theme name must be present"
-msgstr "Matyŭ musić mieć nazvu"
-
-#: ../capplets/appearance/theme-save.c:156
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Taki matyŭ užo isnuje. Chočaš zamianić jaho?"
-
-#: ../capplets/appearance/theme-save.c:157
-#: ../capplets/common/file-transfer-dialog.c:450
-msgid "_Overwrite"
-msgstr "_Zamiani"
-
-#: ../capplets/appearance/theme-util.c:75
-msgid "Would you like to delete this theme?"
-msgstr "Ci chočaš vydalić hety matyŭ?"
-
-#: ../capplets/appearance/theme-util.c:125
-msgid "Theme cannot be deleted"
-msgstr "Niemahčyma vydalić matyŭ"
-
-#: ../capplets/appearance/theme-util.c:252
-msgid "Could not install theme engine"
-msgstr "Niemahčyma zainstalavać matyŭ"
-
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"Niemahčyma ŭklučyć kiraŭnika naładaŭ – \"gnome-settings-daemon\".\n"
-"Biaz spraŭnaha kiraŭnika naładaŭ GNOME peŭnyja nałady mohuć nia dziejničać. "
-"Heta moža śviedčyć ab prablemie z Bonobo albo ź inšym kiraŭnikom naładaŭ "
-"(napr. KDE), jaki kanfliktuje z kiraŭnikom GNOME."
-
-#: ../capplets/common/capplet-stock-icons.c:66
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "Niemahčyma zahruzić standartnuju ikonu '%s'\n"
-
-#: ../capplets/common/capplet-util.c:88
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Padčas pakazu dapamohi adbyłasia pamyłka: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:98
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "Kapijavańnie fajłu: %u z %u"
-
-#: ../capplets/common/file-transfer-dialog.c:145
-#, c-format
-msgid "Copying '%s'"
-msgstr "Kapijavańnie \"%s\""
-
-#: ../capplets/common/file-transfer-dialog.c:185
-#: ../capplets/common/file-transfer-dialog.c:312
-msgid "Copying files"
-msgstr "Kapijavańnie fajłaŭ"
-
-#: ../capplets/common/file-transfer-dialog.c:224
-msgid "Parent Window"
-msgstr "Baćkoŭskaje vakno"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Parent window of the dialog"
-msgstr "Baćkoŭskaje vakno dla vakna dyjalohu"
-
-#: ../capplets/common/file-transfer-dialog.c:231
-msgid "From URI"
-msgstr "Z URI"
-
-#: ../capplets/common/file-transfer-dialog.c:232
-msgid "URI currently transferring from"
-msgstr "URI ciapier zabirajecca z"
-
-#: ../capplets/common/file-transfer-dialog.c:239
-msgid "To URI"
-msgstr "Da URI"
-
-#: ../capplets/common/file-transfer-dialog.c:240
-msgid "URI currently transferring to"
-msgstr "URI ciapier pieradajecca da"
-
-#: ../capplets/common/file-transfer-dialog.c:247
-msgid "Fraction completed"
-msgstr "Častka zakončanaja"
-
-#: ../capplets/common/file-transfer-dialog.c:248
-msgid "Fraction of transfer currently completed"
-msgstr "Častka pieradačy zakončanaja"
-
-#: ../capplets/common/file-transfer-dialog.c:255
-msgid "Current URI index"
-msgstr "Indeks dziejnaha URI"
-
-#: ../capplets/common/file-transfer-dialog.c:256
-msgid "Current URI index - starts from 1"
-msgstr "Indeks dziejnaha URI (ličačy ad 1)"
-
-#: ../capplets/common/file-transfer-dialog.c:263
-msgid "Total URIs"
-msgstr "Poŭnaja kolkaść URI"
-
-#: ../capplets/common/file-transfer-dialog.c:264
-msgid "Total number of URIs"
-msgstr "Poŭnaja kolkaść URI"
-
-#: ../capplets/common/file-transfer-dialog.c:444
-#, c-format
-msgid "File '%s' already exists. Do you want to overwrite it?"
-msgstr "Fajł \"%s\" užo isnuje. Chočaš zamianić jaho?"
-
-#: ../capplets/common/file-transfer-dialog.c:447
-msgid "_Skip"
-msgstr "_Prapuści"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Overwrite _All"
-msgstr "Zamiani _ŭsio"
-
-#: ../capplets/common/gconf-property-editor.c:134
-msgid "Key"
-msgstr "Kluč"
-
-#: ../capplets/common/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr "Kluč GConfa, da jakoha dałučany hety redaktar ułaścivaściaŭ"
-
-#: ../capplets/common/gconf-property-editor.c:141
-msgid "Callback"
-msgstr "Advarotny vyklik"
-
-#: ../capplets/common/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-"Funkcyja, vyklikanaja, kali budzie źmienienaja vartaść, źviazanaja z hetym "
-"klučom"
-
-#: ../capplets/common/gconf-property-editor.c:147
-msgid "Change set"
-msgstr "Nabor źmienaŭ"
-
-#: ../capplets/common/gconf-property-editor.c:148
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"Nabor źmienaŭ GConfa, u jakim źmieščanyja źviestki, dasyłanyja klijentu "
-"GConfa padčas prymianieńnia"
-
-#: ../capplets/common/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr "Vyklikanaja funkcyja kanversii na widget"
-
-#: ../capplets/common/gconf-property-editor.c:154
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "Funkcyja, vyklikanaja pierad kanversijaj źviestak z GConfa na widget"
-
-#: ../capplets/common/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr "Vyklikanaja funkcyja kanversii z widgetu"
-
-#: ../capplets/common/gconf-property-editor.c:160
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr "Funkcyja, vyklikanaja pierad kanversijaj źviestak z widgetu na GConf"
-
-#: ../capplets/common/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "Kiravańnie UI"
-
-#: ../capplets/common/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr "Abjekt, jaki kantraluje ŭłaścivaść (zvyčajna widget)"
-
-#: ../capplets/common/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr "Źviestki abjektu redaktara ŭłaścivaściaŭ"
-
-#: ../capplets/common/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr "Asablivyja źviestki, vymahanyja admysłovym redaktaram ułaścivaściaŭ"
-
-#: ../capplets/common/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr ""
-"Funkcyja, vyklikanaja dziela vyzvaleńnia źviestak redaktara ŭłaścivaściaŭ"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Funkcyja, vyklikanaja pierad vyzvaleńniem źviestak ad abjektu redaktara "
-"ŭłaścivaściaŭ"
-
-#: ../capplets/common/gconf-property-editor.c:1404
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Niemahčyma znajści fajł \"%s\".\n"
-"\n"
-"Pierakanajsia, što fajł isnuje, i pasprabuj znoŭ, albo abiary inšuju "
-"fonavuju vyjavu."
-
-#: ../capplets/common/gconf-property-editor.c:1412
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Ja nia viedaju, jak adčynić fajł \"%s\".\n"
-"Mahčyma, što vyjavy hetaha typu nie absłuhoŭvajucca.\n"
-"\n"
-"Abiary inšy fajł vyjavy."
-
-#: ../capplets/common/gconf-property-editor.c:1532
-msgid "Please select an image."
-msgstr "Abiary vyjavu."
-
-#: ../capplets/common/gconf-property-editor.c:1537
-msgid "_Select"
-msgstr "_Abiary"
-
-#: ../capplets/common/gnome-theme-info.c:638
-msgid "Default Pointer - Current"
-msgstr "Zmoŭčany kursor – dziejny"
-
-#: ../capplets/common/gnome-theme-info.c:642
-msgid "White Pointer"
-msgstr "Bieły kursor"
-
-#: ../capplets/common/gnome-theme-info.c:643
-msgid "White Pointer - Current"
-msgstr "Bieły kursor – dziejny"
-
-#: ../capplets/common/gnome-theme-info.c:647
-msgid "Large Pointer"
-msgstr "Vialiki kursor"
-
-#: ../capplets/common/gnome-theme-info.c:648
-msgid "Large Pointer - Current"
-msgstr "Vialiki kursor – dziejny"
-
-#: ../capplets/common/gnome-theme-info.c:652
-msgid "Large White Pointer - Current"
-msgstr "Vialiki bieły kursor – dziejny"
-
-#: ../capplets/common/gnome-theme-info.c:653
-msgid "Large White Pointer"
-msgstr "Vialiki bieły kursor"
-
-#: ../capplets/common/gnome-theme-info.c:1623
-#, c-format
-msgid ""
-"This theme will not look as intended because the required GTK+ theme '%s' is "
-"not installed."
-msgstr ""
-"Hety matyŭ nia budzie vyhladać, jak naležyć, bo patrebny matyŭ GTK+ \"%s\" "
-"nie zainstalavany."
-
-#: ../capplets/common/gnome-theme-info.c:1631
-#, c-format
-msgid ""
-"This theme will not look as intended because the required window manager "
-"theme '%s' is not installed."
-msgstr ""
-"Hety matyŭ nia budzie vyhladać, jak naležyć, bo patrebny matyŭ kiraŭnika "
-"voknaŭ \"%s\" nie zainstalavany."
-
-#: ../capplets/common/gnome-theme-info.c:1638
-#, c-format
-msgid ""
-"This theme will not look as intended because the required icon theme '%s' is "
-"not installed."
-msgstr ""
-"Hety matyŭ nia budzie vyhladać, jak naležyć, bo patrebny matyŭ ikonaŭ \"%s\" "
-"nie zainstalavany."
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Preferred Applications"
-msgstr "Pažadanyja aplikacyi"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Abiary zmoŭčanyja aplikacyi"
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Start the preferred visual assistive technology"
-msgstr "Uklučy ŭlubionuju technalohiju vizualnaj dastupnaści"
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr "Vizualnaja dastupnaść"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:98
-#: ../capplets/default-applications/gnome-da-capplet.c:362
-#: ../capplets/default-applications/gnome-da-capplet.c:383
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "Pry zapisie kanfihuracyi adbyłasia pamyłka: %s"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:668
-msgid "Could not load the main interface"
-msgstr "Niemahčyma zahruzić hałoŭny interfejs."
-
-#: ../capplets/default-applications/gnome-da-capplet.c:670
-msgid "Please make sure that the applet is properly installed"
-msgstr "Upeŭnisia, ci pravilna zainstalavany hety aplet."
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/default-applications/gnome-da-capplet.c:896
-msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
-msgstr ""
-"Akreśli nazvu staronki, jakuju treba pakazać (internet|multimedia|system|"
-"a11y)"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:901
-msgid "- GNOME Default Applications"
-msgstr "- Zmoŭčanyja aplikacyi GNOME"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Image Viewer</b>"
-msgstr "<b>Prahladalnik hrafiki</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Instant Messenger</b>"
-msgstr "<b>Kamunikatar</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Mail Reader</b>"
-msgstr "<b>Paštovy čytač</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mobility</b>"
-msgstr "<b>Mabilnaść</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Multimedia Player</b>"
-msgstr "<b>Multymedyja-player</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>Emulatar terminału</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Text Editor</b>"
-msgstr "<b>Tekstavy redaktar</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Video Player</b>"
-msgstr "<b>Videa-player</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "<b>Visual</b>"
-msgstr "<b>Vizualny</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "<b>Web Browser</b>"
-msgstr "<b>Web-hartač</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
-msgid "Accessibility"
-msgstr "Dastupnaść"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "Va ŭsich miescach %s buduć zamienienyja na dziejnuju spasyłku"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "C_ommand:"
-msgstr "_Zahad:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Co_mmand:"
-msgstr "_Zahad:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "E_xecute flag:"
-msgstr "Opcyja vy_kanańnia:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Internet"
-msgstr "Internet"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Multimedia"
-msgstr "Multymedyja"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Open link in new _tab"
-msgstr "Adčyniaj spasyłki ŭ novaj _kartcy"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "Open link in new _window"
-msgstr "Adčyniaj spasyłki ŭ novym _аknie"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid "Open link with web browser _default"
-msgstr "Adčyniaj spasyłki sa _zmoŭčanymi naładami hartača"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Run at st_art"
-msgstr "Uruchom pry _ŭvachodzie"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Run in t_erminal"
-msgstr "Uruchom u t_erminale"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "System"
-msgstr "Systemа"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "_Run at start"
-msgstr "_Vykanaj pry ŭruchamleńni"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr "Muzyčny player Banshee"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr "Pošta Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr "Dasher"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr "Zmoŭčany hartač Debiana"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr "Emulatar terminału Debiana"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr "Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr "Web-hartač Epiphany"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr "Paštovy čytač Evolution"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr "Firebird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr "Lupa GNOME biez ekrannaha čytača"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr "Ekrannaja _klavijatura GNOME"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr "Terminał GNOME"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Gnopernicus"
-msgstr "Gnopernicus"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Gnopernicus with Magnifier"
-msgstr "Gnopernicus ź Lupaj"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Iceape"
-msgstr "Iceape"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Iceape Mail"
-msgstr "Pošta Iceape"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Icedove"
-msgstr "Icedove"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Iceweasel"
-msgstr "Iceweasel"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr "Lupa KDE biez ekrannaha čytača"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr "KMail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Konsole"
-msgstr "Konsole"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr "Ekranny čy_tač Linuksa"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr "Ekranny čytač Linuksa ź Lupaj"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Listen"
-msgstr "Listen"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Midori"
-msgstr "Midori"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Mozilla Mail"
-msgstr "Pošta Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Muine Music Player"
-msgstr "Muzyčny player Muine"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-msgid "NXterm"
-msgstr "NXTerm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Netscape Communicator"
-msgstr "Kamunikatar Netscape"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Opera"
-msgstr "Opera"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca"
-msgstr "Orca"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "Orca with Magnifier"
-msgstr "Orca ź lupaj"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-msgid "Rhythmbox Music Player"
-msgstr "Muzyčny player Rhythmbox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-msgid "SeaMonkey Mail"
-msgstr "Pošta SeaMonkey"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Standard XTerminal"
-msgstr "Standartny XTerminal"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-msgid "Sylpheed"
-msgstr "Sylpheed"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Terminator"
-msgstr "Terminator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "Totem Movie Player"
-msgstr "Player filmaŭ Totem"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/display/display-capplet.glade.h:1
-#: ../capplets/display/xrandr-capplet.c:460
-msgid "<b>Monitor</b>"
-msgstr "<b>Manitor</b>"
-
-#: ../capplets/display/display-capplet.glade.h:2
-msgid "<b>Panel icon</b>"
-msgstr "<b>Ikona paneli</b>"
-
-#: ../capplets/display/display-capplet.glade.h:3
-msgid "<i>Drag the monitors to set their place</i>"
-msgstr "<i>Pieraciahvaj manitory, kab uparadkavać ich</i>"
-
-#: ../capplets/display/display-capplet.glade.h:4
-msgid "Display Preferences"
-msgstr "Nałady ekranu"
-
-#: ../capplets/display/display-capplet.glade.h:5
-msgid "Include _panel"
-msgstr "Ułučy _panel"
-
-#: ../capplets/display/display-capplet.glade.h:6
-msgid ""
-"Normal\n"
-"Left\n"
-"Right\n"
-"Upside-down\n"
-msgstr ""
-"Zvyčajna\n"
-"Uleva\n"
-"Uprava\n"
-"Dahary nahami\n"
-
-#: ../capplets/display/display-capplet.glade.h:11
-msgid "Off"
-msgstr "Vyklučany"
-
-#: ../capplets/display/display-capplet.glade.h:12
-msgid "On"
-msgstr "Uklučany"
-
-#: ../capplets/display/display-capplet.glade.h:13
-msgid "R_otation:"
-msgstr "_Abaročvańnie:"
-
-#: ../capplets/display/display-capplet.glade.h:14
-msgid "Re_fresh rate:"
-msgstr "C_hutkaść aktualizacyi:"
-
-#: ../capplets/display/display-capplet.glade.h:15
-msgid "_Detect Monitors"
-msgstr "_Paznavaj manitory"
-
-#: ../capplets/display/display-capplet.glade.h:16
-msgid "_Mirror screens"
-msgstr "_Adlustroŭvaj ekrany"
-
-#: ../capplets/display/display-capplet.glade.h:17
-msgid "_Resolution:"
-msgstr "_Pamiery:"
-
-#: ../capplets/display/display-capplet.glade.h:18
-msgid "_Show displays in panel"
-msgstr "_Pakazvaj ekrany na paneli"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Źmiani pamiery ekranu"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Display"
-msgstr "Ekran"
-
-#: ../capplets/display/xrandr-capplet.c:327
-#: ../capplets/display/xrandr-capplet.c:366
-msgid "Normal"
-msgstr "Narmalna"
-
-#: ../capplets/display/xrandr-capplet.c:328
-msgid "Left"
-msgstr "Uleva"
-
-#: ../capplets/display/xrandr-capplet.c:329
-msgid "Right"
-msgstr "Uprava"
-
-#: ../capplets/display/xrandr-capplet.c:330
-msgid "Upside Down"
-msgstr "Dahary nahami"
-
-#: ../capplets/display/xrandr-capplet.c:403
-#: ../capplets/display/xrandr-capplet.c:411
-#: ../capplets/display/xrandr-capplet.c:412
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/xrandr-capplet.c:453
-#, c-format
-msgid "<b>Monitor: %s</b>"
-msgstr "<b>Manitor: %s</b>"
-
-#: ../capplets/display/xrandr-capplet.c:545
-#: ../capplets/display/xrandr-capplet.c:555
-#: ../capplets/display/xrandr-capplet.c:563
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../capplets/display/xrandr-capplet.c:1410
-msgid "Mirror Screens"
-msgstr "Adlustruj ekrany"
-
-#: ../capplets/display/xrandr-capplet.c:1729
-msgid "Could not apply the selected configuration"
-msgstr "Nie ŭdałosia ŭžyć vybranyja nałady"
-
-#: ../capplets/display/xrandr-capplet.c:1756
-msgid "Could not save the monitor configuration"
-msgstr "Nie ŭdałosia zapisać nałady manitora"
-
-#: ../capplets/display/xrandr-capplet.c:1767
-msgid "Could not get session bus while applying display configuration"
-msgstr "Nie ŭdałosia atrymać šynu sesii pry ŭžyćci naładaŭ ekranu"
-
-#: ../capplets/display/xrandr-capplet.c:1777
-msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
-msgstr "Nie ŭdałosia atrymać \"org.gnome.SettingsDaemon.XRANDR\""
-
-#: ../capplets/display/xrandr-capplet.c:1823
-msgid "Could not detect displays"
-msgstr "Nie ŭdałosia paznać ekrany"
-
-#: ../capplets/display/xrandr-capplet.c:2021
-msgid "Could not get screen information"
-msgstr "Nie ŭdałosia atrymać źviestki ekranu"
-
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-msgid "Sound"
-msgstr "Huk"
-
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-#: ../libslab/bookmark-agent.c:1146
-msgid "Desktop"
-msgstr "Stoł"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr "Novy skarot..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Klaviša akseleratara"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Madyfikatary akseleratara"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Kod klavišy akseleratara"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Režym akseleratara"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Typ akseleratara."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:103
-#: ../typing-break/drwright.c:479
-msgid "Disabled"
-msgstr "Nieaktyŭny"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:184
-msgid "<Unknown Action>"
-msgstr "<Nieviadomaje dziejańnie>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:925
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1548
-msgid "Custom Shortcuts"
-msgstr "Asablivyja skaroty"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1064
-msgid "Error saving the new shortcut"
-msgstr "Pamyłka zachavańnia novaha klavijaturnaha skarotu"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1143
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-"Skarot \"%s\" nielha vykarystać, bo nia budzie mahčymaści pisać, "
-"vykarystoŭvajučy hetuju klavišu.\n"
-"Pasprabuj u spałučeńni z takimi klavišami, jak Control, Alt albo Shift."
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1173
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-"Klavijaturny skarot \"%s\" užo vykarystoŭvajecca dla\n"
-"\"%s\""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1179
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-"Kali ty pieraaznačyš klavijaturny skarot na \"%s\", tady skarot \"%s\" "
-"budzie vyklučany."
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1187
-msgid "_Reassign"
-msgstr "_Pieraaznač"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1307
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s"
-msgstr ""
-"Pry ačystcy akseleratara ŭ bazie źviestak kanfihuracyi adbyłasia pamyłka: %s"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1503
-msgid "Too many custom shortcuts"
-msgstr "Zašmat ułasnych skarotaŭ"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1788
-msgid "Action"
-msgstr "Dziejańnie"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1810
-msgid "Shortcut"
-msgstr "Skarot"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-msgid "Custom Shortcut"
-msgstr "Ułasny skarot"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Klavijaturnyja skaroty"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:3
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new key "
-"combination, or press backspace to clear."
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 "Kab źmianić klavišu skarotu, klikni ŭ adpaviedny radok i ŭpišy novy "
 "klavijaturnaje spałučeńnie albo naciśni klavišu \"Backspace\", kab vyčyścić "
 "dziejnaje."
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:4
-msgid "_Command:"
-msgstr "_Zahad:"
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Pryviažy klavijaturnyja skaroty da zahadaŭ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:209
-#: ../capplets/keyboard/gnome-keyboard-properties.c:214
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
 msgstr ""
-"Tolki ŭžyj nałady j vyjdzi (tolki dziela zhodnaści, ciapier heta "
-"absłuhoŭvaje deman)"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:219
-msgid "Start the page with the typing break settings showing"
-msgstr "Adčyni staronku ŭłaścivaściaŭ pierapynku ŭ pisańni na klavijatury"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:224
-msgid "Start the page with the accessibility settings showing"
-msgstr "Pačynaj staronku, pakazvajučy nałady dastupnaści"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:230
-msgid "- GNOME Keyboard Preferences"
-msgstr "– Nałady klavijatury GNOME"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-msgid "<b>Bounce Keys</b>"
-msgstr "<b>Spružynistyja klavišy</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>Mirhańnie kursora</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "<b>General</b>"
-msgstr "<b>Ahulnaje</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Paŭtor klavišaŭ</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Slow Keys</b>"
-msgstr "<b>Pavolnyja klavišy</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>Sticky Keys</b>"
-msgstr "<b>_Tryvałyja klavišy</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<b>Visual cues for sounds</b>"
-msgstr "<b>Vizualnyja syhnały dla hukaŭ</b>"
-
-#. fast acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Chutka</i></small>"
-
-#. long delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Doŭha</i></small>"
-
-#. short delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Karotka</i></small>"
-
-#. slow acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Pavolna</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "A_cceleration:"
-msgstr "_Akseleracyja:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "All_ow postponing of breaks"
-msgstr "Dazvol adter_minoŭku pierapynkaŭ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Audio _Feedback..."
-msgstr "Hukavaja _reakcyja..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Beep when _accessibility features are turned on or off"
-msgstr "Hukavy _syhnał pry ŭklučeńni/vyklučeńni mahčymaściaŭ dastupnaści"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Beep when a _modifier key is pressed"
-msgstr "Hukavy syhnał, kali nacisnuty _madyfikatar"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Beep when a _toggle key is pressed"
-msgstr "Hukavy syhnał, kali nacisnutaja klaviša _pieraklučeńnia"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Beep when a key is pr_essed"
-msgstr "Hukavy syhnał, kali nacisnutaja klaviša"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Beep when a key is reje_cted"
-msgstr "Hukavy syhnał, kali adch_ilenaja klaviša"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Beep when key is _accepted"
-msgstr "Hukavy syhnał, kali p_ryniataja klaviša"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Beep when key is _rejected"
-msgstr "Hukavy syhnał, kali adch_ilenaja klaviša"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "By _country"
-msgstr "Pavodle _krainy"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "By _language"
-msgstr "Pavodle _movy"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Pravier, ci možna adterminoŭvać pierapynki"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Choose a Keyboard Model"
-msgstr "Abiary madel klavijatury"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Choose a Layout"
-msgstr "Abiary raskładku"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Cursor _blinks in text fields"
-msgstr "Kursor _mirhaje ŭ tekstavych paloch"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
-msgid "Cursor blinks speed"
-msgstr "Chutkaść mirhańnia kursora"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
-msgid "D_elay:"
-msgstr "_Spaźnieńnie:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Disa_ble sticky keys if two keys are pressed together"
-msgstr "_Vyklučaj tryvałyja klavišy, kali razam nacisnutyja dźvie klavišy"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Duration of the break when typing is disallowed"
-msgstr "Praciahłaść pierapynku, kali zabaronienaje pisańnie"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-msgid "Duration of work before forcing a break"
-msgstr "Praciahłaść pracy pierad vymušanym pierapynkam"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "Flash _window titlebar"
-msgstr "Mirhaj _zahałoŭkam akna"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "Flash entire _screen"
-msgstr "Mirhaj _usim ekranam"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
-msgid "General"
-msgstr "Ahulnaje"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "Key presses _repeat when key is held down"
-msgstr "_Paŭtor nacisku klavišy pry jaje ŭtrymańni"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "Keyboard Accessibility Audio Feedback"
-msgstr "Hukavaja reakcyja na klavijaturu"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "Keyboard Layout Options"
-msgstr "Opcyi raskładki klavijatury"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "Keyboard Preferences"
-msgstr "Nałady klavijatury"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "Keyboard _model:"
-msgstr "_Madel klavijatury:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "Layout _Options..."
-msgstr "_Opcyi raskładki..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "Layouts"
-msgstr "Raskładki"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
 msgstr ""
-"Blakuj ekran paśla akreślenaha času, kab papiaredzić traŭmy, źviazanyja z "
-"praciahłym pisańniem na klavijatury"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
-msgid "Mouse Keys"
-msgstr "Klavišy myšy"
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
-msgid "Preview:"
-msgstr "Pieradahlad:"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
-msgid "Repeat keys speed"
-msgstr "Chutkaść paŭtoru klavišaŭ"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
-msgid "Reset to De_faults"
-msgstr "V_iarni zmoŭčanaje"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
-msgid "S_peed:"
-msgstr "Ch_utkaść:"
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
-msgid "Separate _layout for each window"
-msgstr "Asobnaja _raskładka dla kožnaha vakna"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
-msgid "Show _visual feedback for the alert sound"
-msgstr "Pakazvaj _vizualnyja syhnały dla tryvožnych hukaŭ"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Manitor pracy klavijatury"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
-msgid "Typing Break"
-msgstr "Pierapynak u pisańni"
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
-msgid "_Accessibility features can be toggled with keyboard shortcuts"
-msgstr "_Mahčymaści dastupnaści možna ŭklučać klavijaturnymi skarotami"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
-msgid "_Break interval lasts:"
-msgstr "_Praciahłaść pierapynku:"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
-msgid "_Country:"
-msgstr "_Kraina:"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
-msgid "_Delay:"
-msgstr "_Čas:"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
-msgid "_Ignore fast duplicate keypresses"
-msgstr "_Ihnaruj chutkija paŭtornyja naciski klavišaŭ"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
-msgid "_Language:"
-msgstr "_Mova:"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
-msgid "_Lock screen to enforce typing break"
-msgstr "_Blakuj ekran, kab prymusić zrabić pierapynak padčas pisańnia"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
-msgid "_Models:"
-msgstr "_Madeli:"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
-msgid "_Only accept long keypresses"
-msgstr "_Pryjmaj tolki daŭhija naciski klavišaŭ"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Klik u knopku"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
-msgid "_Pointer can be controlled using the keypad"
-msgstr "_Dazvol kiravać kursoram z dapamohaj klavijatury"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Klik u knopku"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
-msgid "_Selected layouts:"
-msgstr "Vybranyja _raskładki:"
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Klik u knopku"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
-msgid "_Simulate simultaneous keypresses"
-msgstr "_Imituj adnačasovyja naciski klavišaŭ"
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
-msgid "_Speed:"
-msgstr "_Chutkaść:"
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
-msgid "_Type to test settings:"
-msgstr "_Napišy tekst, kab pravieryć nałady:"
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:68
-msgid "_Variants:"
-msgstr "_Varyjanty:"
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:69
-msgid "_Vendors:"
-msgstr "_Vytvorca:"
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:70
-msgid "_Work interval lasts:"
-msgstr "Praciahłaść času p_racy:"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:71
-msgid "minutes"
-msgstr "chvilin"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
-msgid "Unknown"
-msgstr "Nieviadomy"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:215
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:235
-#: ../capplets/network/gnome-network-properties.c:561
-msgid "Default"
-msgstr "Zmoŭčanaja"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:333
+#: panels/windows/cc-windows-panel.ui:8
 msgid "Layout"
 msgstr "Raskładka"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
-msgid "Vendors"
-msgstr "Vytvorcy"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
-msgid "Models"
-msgstr "Madeli"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Klavijatura"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Abiary nałady klavijatury"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:90
-msgid "gesture|Move left"
-msgstr "Ruch lavej"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:95
-msgid "gesture|Move right"
-msgstr "Ruch praviej"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:100
-msgid "gesture|Move up"
-msgstr "Ruch vyšej"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:105
-msgid "gesture|Move down"
-msgstr "Ruch nižej"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:110
-msgid "gesture|Disabled"
-msgstr "Vyklučana"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/mouse/gnome-mouse-properties.c:441
-msgid "Specify the name of the page to show (general|accessibility)"
-msgstr "Akreśli nazvu staronki, jakuju treba pakazać (general|accessibility)"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:446
-msgid "- GNOME Mouse Preferences"
-msgstr "– Nałady myšy dla GNOME"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-msgid "<b>Double-Click Timeout</b>"
-msgstr "<b>Spaźnieńnie dvukliku</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Pieraciahvańnie j puščańnie</b>"
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Dwell Click</b>"
-msgstr "<b>Klik zatrymkaj</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Raspałažy kursor</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>Aryjentacyja myšy</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<b>Pointer Speed</b>"
-msgstr "<b>Chutkaść kursora</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<b>Simulated Secondary Click</b>"
-msgstr "<b>Symulavany druhi klik</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid ""
-"<i>To test your double-click settings, try to double-click on the light bulb."
-"</i>"
-msgstr "<i>Kab pravieryć nałady dvuklika, možaš paklikać na lampačku.</i>"
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid ""
-"<i>You can also use the Dwell Click panel applet to choose the click type.</"
-"i>"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
 msgstr ""
-"<i>Ty možaš abrać typ kliku z dapamohaj apleta paneli \"Klik zatrymkaj\".</i>"
 
-#. high sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "<small><i>High</i></small>"
-msgstr "<small><i>Vysokaja</i></small>"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#. large threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "<small><i>Large</i></small>"
-msgstr "<small><i>Vialiki</i></small>"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#. low sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "<small><i>Low</i></small>"
-msgstr "<small><i>Nizkaja</i></small>"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#. small threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "<small><i>Small</i></small>"
-msgstr "<small><i>Mały</i></small>"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
-msgid "Choose type of click _beforehand"
-msgstr "Abiary typ _zaŭčasnaha kliku"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
-msgid "Choose type of click with mo_use gestures"
-msgstr "Abiary typ kliku, ruchajčy myššu"
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Baćkoŭskaje vakno"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
-msgid "D_ouble click:"
-msgstr "_Dvuklik:"
-
-#. click to initiate drag-and-drop (like normally click and hold)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
-msgid "D_rag click:"
-msgstr "_Pieraciahvalny klik:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
-msgid "Mouse Preferences"
-msgstr "Nałady myšy"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
-msgid "Seco_ndary click:"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
 msgstr "_Druhi klik:"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr "_Pakazvaj pałažeńnie kursora, kali nacisnutaja klaviša Control"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Vokny"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
-msgid "Show click type _window"
-msgstr "Pakažy _vakno vybaru typu klika"
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Klikni \"OK\", kab skončyć."
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
-msgid "Thr_eshold:"
-msgstr "_Parohavaja vartaść:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
-msgid "_Acceleration:"
-msgstr "_Akseleracyja:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
-msgid "_Initiate click when stopping pointer movement"
-msgstr "_Inicyjuj klik, kali spyniajecca kursor"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
-msgid "_Left-handed"
-msgstr "Dla _leŭšunoŭ"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
-msgid "_Motion threshold:"
-msgstr "_Parohavy zruch:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
-msgid "_Right-handed"
-msgstr "Dla _praŭšunoŭ"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
-msgid "_Sensitivity:"
-msgstr "_Čułaść:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
-msgid "_Single click:"
-msgstr "_Adzin klik:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
-msgid "_Timeout:"
-msgstr "_Spaźnieńnie:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr "_Inicyjuj druhi klik, kali ŭtrymlivajecca pieršaja klaviša"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Myš"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Abiary nałady myšy"
-
-#: ../capplets/network/gnome-network-properties.c:677
-#: ../capplets/network/gnome-network-properties.c:816
-msgid "New Location..."
-msgstr "_Novaje pałažeńnie..."
-
-#: ../capplets/network/gnome-network-properties.c:782
-msgid "Location already exists"
-msgstr "Takoje pałažeńnie ŭžo isnuje"
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Sietkavy proxy"
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "Abiary nałady sietkavaha proxy"
-
-#: ../capplets/network/gnome-network-properties.glade.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>_Pramoje internetnaje spałučeńnie</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:2
-msgid "<b>Ignore Host List</b>"
-msgstr "<b>Śpis ihnaravanych hostaŭ</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:3
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>_Autamatyčnaja kanfihuracyja proxy</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:4
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>_Ručnaja kanfihuracyja proxy</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:5
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Užyvaj aŭtaryzacyju</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:6
-msgid "Autoconfiguration _URL:"
-msgstr "_URL aŭtamatyčnaj kanfihuracyi:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:7
-msgid "C_reate"
-msgstr "_Stvary"
-
-#: ../capplets/network/gnome-network-properties.glade.h:8
-msgid "Create New Location"
-msgstr "Stvary novaje pałažeńnie"
-
-#: ../capplets/network/gnome-network-properties.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "Detali HTTP-proxy"
-
-#: ../capplets/network/gnome-network-properties.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "_HTTP-proxy:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:11
-msgid "Ignored Hosts"
-msgstr "Śpis ihnaravanych hostaŭ"
-
-#: ../capplets/network/gnome-network-properties.glade.h:12
-msgid "Location:"
-msgstr "Pałažeńnie:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:13
-msgid "Network Proxy Preferences"
-msgstr "Nałady sietkavaha proxy"
-
-#: ../capplets/network/gnome-network-properties.glade.h:14
-msgid "Port:"
-msgstr "Port:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:15
-msgid "Proxy Configuration"
-msgstr "Kanfihuracyja proxy"
-
-#: ../capplets/network/gnome-network-properties.glade.h:16
-msgid "S_ocks host:"
-msgstr "S_ocks-host:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:17
-msgid "The location already exists."
-msgstr "Takoje pałažeńnie ŭžo isnuje."
-
-#: ../capplets/network/gnome-network-properties.glade.h:18
-msgid "U_sername:"
-msgstr "Nazva _karystalnika:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:19
-msgid "_Delete Location"
-msgstr "_Vydali pałažeńnie"
-
-#: ../capplets/network/gnome-network-properties.glade.h:20
-msgid "_Details"
-msgstr "_Detali"
-
-#: ../capplets/network/gnome-network-properties.glade.h:21
-msgid "_FTP proxy:"
-msgstr "_FTP-proxy:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:22
-msgid "_Location name:"
-msgstr "_Nazva pałažeńnia:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:23
-msgid "_Password:"
-msgstr "_Parol:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:24
-msgid "_Secure HTTP proxy:"
-msgstr "_Biaśpiečny HTTP-proxy:"
-
-#: ../capplets/network/gnome-network-properties.glade.h:25
-msgid "_Use the same proxy for all protocols"
-msgstr "_Užyj adzin i toj ža proxy dla ŭsich pratakołaŭ"
-
-#: ../capplets/windows/gnome-window-properties.c:346
-msgid "Cannot start the preferences application for your window manager"
-msgstr "Niemahčyma ŭruchomić kanfihuracyjnuju aplikacyju dla kiraŭnika voknaŭ"
-
-#. translators: this is the Control key
-#: ../capplets/windows/gnome-window-properties.c:600
-msgid "C_ontrol"
-msgstr "C_ontrol"
-
-#: ../capplets/windows/gnome-window-properties.c:605
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:611
-msgid "H_yper"
-msgstr "H_yper"
-
-#: ../capplets/windows/gnome-window-properties.c:618
-msgid "S_uper (or \"Windows logo\")"
-msgstr "S_uper (albo \"klaviša Windows\")"
-
-#: ../capplets/windows/gnome-window-properties.c:625
-msgid "_Meta"
-msgstr "_Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Klaviša ruchu</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>Pavodziny zahałoŭku vakna</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Vybar akna</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
 msgstr ""
-"Kab pierasunuć akno, naciśni j prytrymaj hetuju klavišu, a potym schapi "
-"vakno:"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Nałady voknaŭ"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "_Druhi klik:"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "Ap_eracyja paśla dvukliku zahałoŭku:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "Ča_s pierad vysoŭvańniem:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_Vysoŭvaj abranyja vokny praź niekatory čas"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Zaznačaj vokny paśla raźmiaščeńnia nad imi kursora"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "sekundaŭ"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "Kanfihuruj ułaścivaści voknaŭ"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
 msgid "Windows"
 msgstr "Vokny"
 
-#. make start action
-#: ../libslab/application-tile.c:372
-#, c-format
-msgid "<b>Start %s</b>"
-msgstr "<b>Uklučy %s</b>"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
 
-#: ../libslab/application-tile.c:391
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "_Dastupny ŭvachod"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Adras"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Zapišy"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Detali"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Sietkavy proxy"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Sietkavyja servery"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Pryłady"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "M_abilny telefon:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Sietkavy proxy"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Sietkavy proxy"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Detali"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Sietkavy proxy"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_Aŭtaryzuj"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "Sietkavyja servery"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Spałučeńnie..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Nabor źmienaŭ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Zmoŭčanyja nałady"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Dapamoha"
 
-#: ../libslab/application-tile.c:438
-msgid "Upgrade"
-msgstr "Aktualizuj"
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Ahulnaje"
 
-#: ../libslab/application-tile.c:453
-msgid "Uninstall"
-msgstr "Adinstaluj"
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Vyjdzi"
 
-#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
-msgid "Remove from Favorites"
-msgstr "Vydal z ulubionych"
-
-#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
-msgid "Add to Favorites"
-msgstr "Dadaj da ŭlubionych"
-
-#: ../libslab/application-tile.c:867
-msgid "Remove from Startup Programs"
-msgstr "Vydal sa startavych prahramaŭ"
-
-#: ../libslab/application-tile.c:869
-msgid "Add to Startup Programs"
-msgstr "Dadaj da startavych prahramaŭ"
-
-#: ../libslab/app-shell.c:753
-#, c-format
-msgid ""
-"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
-"\n"
-" Your filter \"<b>%s</b>\" does not match any items.</span>"
-msgstr ""
-"<span size=\"large\"><b>Niama adpaviednikaŭ.</b> </span><span>\n"
-"\n"
-" Filter \"<b>%s</b>\" nie pasuje ni da adnaho z elementaŭ.</span>"
-
-#: ../libslab/app-shell.c:903
-msgid "Other"
-msgstr "Inšaje"
-
-#: ../libslab/bookmark-agent.c:1077
-msgid "New Spreadsheet"
-msgstr "Novy raźlikovy arkuš"
-
-#: ../libslab/bookmark-agent.c:1082
-msgid "New Document"
-msgstr "Novy dakument"
-
-#: ../libslab/bookmark-agent.c:1135
-msgid "Home"
-msgstr "Dom"
-
-#: ../libslab/bookmark-agent.c:1140
-msgid "Documents"
-msgstr "Dakumenty"
-
-#: ../libslab/bookmark-agent.c:1153
-msgid "File System"
-msgstr "Fajłavaja systemа"
-
-#: ../libslab/bookmark-agent.c:1157
-msgid "Network Servers"
-msgstr "Sietkavyja servery"
-
-#: ../libslab/bookmark-agent.c:1186
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Search"
 msgstr "Šukaj"
 
-#. make open with default action
-#: ../libslab/directory-tile.c:171
-#, c-format
-msgid "<b>Open</b>"
-msgstr "<b>Adčyni</b>"
-
-#. make rename action
-#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:231
-msgid "Rename..."
-msgstr "Źmiani nazvu..."
-
-#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
-#: ../libslab/document-tile.c:245 ../libslab/document-tile.c:254
-msgid "Send To..."
-msgstr "Vyšli da..."
-
-#. make move to trash action
-#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:280
-msgid "Move to Trash"
-msgstr "Pieraniasi ŭ śmietnicu"
-
-#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
-#: ../libslab/document-tile.c:290 ../libslab/document-tile.c:831
-msgid "Delete"
-msgstr "Vydal"
-
-#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:979
-#, c-format
-msgid "Are you sure you want to permanently delete \"%s\"?"
-msgstr "Ty sapraŭdy chočaš nazaŭždy vydalić \"%s\"?"
-
-#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:980
-msgid "If you delete an item, it is permanently lost."
-msgstr "Vydaleny elementy budzie stračany nazaŭždy."
-
-#: ../libslab/document-tile.c:192
-#, c-format
-msgid "<b>Open with \"%s\"</b>"
-msgstr "<b>Adčyni pry dapamozie \"%s\"</b>"
-
-#: ../libslab/document-tile.c:204
-msgid "Open with Default Application"
-msgstr "Adčyni pry dapamozie zmoŭčanaj aplikacyi"
-
-#: ../libslab/document-tile.c:215
-msgid "Open in File Manager"
-msgstr "Adčyni ŭ kiraŭniku fajłaŭ"
-
-#: ../libslab/document-tile.c:611
-msgid "?"
-msgstr "?"
-
-#: ../libslab/document-tile.c:618
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#: ../libslab/document-tile.c:626
-msgid "Today %l:%M %p"
-msgstr "Siońnia %l:%M %p"
-
-#: ../libslab/document-tile.c:636
-msgid "Yesterday %l:%M %p"
-msgstr "Učora %l:%M %p"
-
-#: ../libslab/document-tile.c:648
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
-
-#: ../libslab/document-tile.c:656
-msgid "%b %d %l:%M %p"
-msgstr "%b %d %l:%M %p"
-
-#: ../libslab/document-tile.c:658
-msgid "%b %d %Y"
-msgstr "%b %d %Y"
-
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
-msgstr "Znajdzi ciapier"
-
-#: ../libslab/system-tile.c:128
-#, c-format
-msgid "<b>Open %s</b>"
-msgstr "<b>Adčyni %s</b>"
-
-#: ../libslab/system-tile.c:141
-#, c-format
-msgid "Remove from System Items"
-msgstr "Vydal z systemnych elementaŭ"
-
-#: ../libwindow-settings/gnome-wm-manager.c:316
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "Kiraŭnik voknaŭ \"%s\" nie zarehistravaŭ pryładu kanfihuracyi\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:404
-msgid "Maximize"
-msgstr "Maksymalizuj"
-
-#: ../libwindow-settings/metacity-window-manager.c:405
-msgid "Maximize Vertically"
-msgstr "Maksymalizuj vertykalna"
-
-#: ../libwindow-settings/metacity-window-manager.c:406
-msgid "Maximize Horizontally"
-msgstr "Maksymalizuj haryzantalna"
-
-#: ../libwindow-settings/metacity-window-manager.c:407
-msgid "Minimize"
-msgstr "Minimalizuj"
-
-#: ../libwindow-settings/metacity-window-manager.c:408
-msgid "Roll up"
-msgstr "Razharni"
-
-#: ../libwindow-settings/metacity-window-manager.c:409
-msgid "None"
-msgstr "Niama"
-
-#: ../shell/control-center.c:54
-#, c-format
-msgid "key not found [%s]\n"
-msgstr "nia znojdzieny kluč [%s]\n"
-
-#: ../shell/control-center.c:151
-msgid "Filter"
-msgstr "Filter"
-
-#: ../shell/control-center.c:151
-msgid "Groups"
-msgstr "Hrupy"
-
-#: ../shell/control-center.c:151
-msgid "Common Tasks"
-msgstr "Typovyja zadačy"
-
-#: ../shell/control-center.c:155 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Centar kiravańnia"
-
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr "Začyni centar kiravańnia paśla aktyvizacyi zadačy"
-
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr "Vyjdzi z abałonki paśla dadańnia albo vydaleńnia"
-
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr "Vyjdzi z abałonki paśla pakazu dapamohi"
-
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr "Vyjdzi z abałonki paśla startu"
-
-#: ../shell/control-center.schemas.in.h:5
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr "Vyjdzi z abałonki paśla aktualizacyi albo adinstalavańnia"
-
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed."
-msgstr "Akreślivaje, ci začyniać abałonku paśla pakazu dapamohi."
-
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed."
-msgstr "Akreślivaje, ci začyniać abałonku paśla ŭruchamleńnia."
-
-#: ../shell/control-center.schemas.in.h:8
-msgid ""
-"Indicates whether to close the shell when an add or remove action is "
-"performed."
-msgstr "Akreślivaje, ci začyniać abałonku paśla dadavańnia albo vydaleńnia."
-
-#: ../shell/control-center.schemas.in.h:9
-msgid ""
-"Indicates whether to close the shell when an upgrade or uninstall action is "
-"performed."
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
 msgstr ""
-"Akreślivaje, ci začyniać abałonku paśla aktualizacyi albo adinstalavańnia."
 
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr "Nazvy zadačaŭ i adpaviednyja fajły .desktop"
-
-#: ../shell/control-center.schemas.in.h:11
-msgid ""
-"The task name to be displayed in the control-center followed by a \";\" "
-"separator then the filename of an associated .desktop file to launch for "
-"that task."
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
 msgstr ""
-"Nazva bačnaj u centry kiravańnia zadačy, paśla jakoj staić separatar \";\", "
-"a potym nazva adpaviednaha fajłu .desktop, kab uruchomić dla hetaj zadačy."
 
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
-msgid ""
-"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
-"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
 msgstr ""
-"[Źmiani matyŭ;gtk-theme-selector.desktop,Abiary zmoŭčanyja aplikacyi;default-"
-"applications.desktop,Dadaj drukarku;gnome-cups-manager.desktop]"
 
-#: ../shell/control-center.schemas.in.h:14
-msgid ""
-"if true, the control-center will close when a \"Common Task\" is activated."
-msgstr ""
-"Kali ŭklučana, center kiravańnia budzie začynieny pry ŭklučeńni \"Typovaj "
-"zadačy\"."
-
-#: ../shell/gnomecc.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "Pryłada kanfihuracyi GNOME"
-
-#: ../typing-break/drw-break-window.c:193
-msgid "_Postpone Break"
-msgstr "A_dterminuj pierapynak"
-
-#: ../typing-break/drw-break-window.c:249
-msgid "Take a break!"
-msgstr "Zrabi pierapynak!"
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#. translators: keep the initial "/"
-#: ../typing-break/drwright.c:129
-msgid "/_Preferences"
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
 msgstr "/_Nałady"
 
-#: ../typing-break/drwright.c:130
-msgid "/_About"
-msgstr "/_Pra"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
 
-#: ../typing-break/drwright.c:132
-msgid "/_Take a Break"
-msgstr "/Z_rabi pierapynak"
-
-#: ../typing-break/drwright.c:488
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "%d chvilina da pierapynku"
-msgstr[1] "%d chviliny da pierapynku"
-msgstr[2] "%d chvilin da pierapynku"
-
-#: ../typing-break/drwright.c:492
-#, c-format
-msgid "Less than one minute until the next break"
-msgstr "Da nastupnaha pierapynku mienš za chvilinu"
-
-#: ../typing-break/drwright.c:579
-#, c-format
+#: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
 msgstr ""
-"Niemahčyma pakazać akno ŭłaścivaściaŭ pierapynkaŭ u pisańni z-za nastupnaj "
-"pamyłki: %s"
 
-#: ../typing-break/drwright.c:598
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "Napisaŭ Richard Hult <richard@imendio.com>"
-
-#: ../typing-break/drwright.c:599
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Aŭtarskaja hrafika ad Anders Carlsson"
-
-#: ../typing-break/drwright.c:608
-msgid "A computer break reminder."
-msgstr "Prahrama nahadvańnia ab pierapynkach padčas pracy z kamputaram."
-
-#: ../typing-break/drwright.c:610
-msgid "translator-credits"
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
 msgstr ""
-"Łacinka.org\n"
-"Alaksandar Navicki <zolak@lacinka.prg>Ihar Hračyška <ihar.hrachyshka@gmail."
-"com>"
 
-#: ../typing-break/main.c:61
-msgid "Enable debugging code"
-msgstr "Uklučy debugavy kod"
-
-#: ../typing-break/main.c:63
-msgid "Don't check whether the notification area exists"
-msgstr "Nie praviaraj, ci isnuje abšar nahadvańnia"
-
-#: ../typing-break/main.c:89
-msgid "Typing Monitor"
-msgstr "Manitor pracy klavijatury"
-
-#: ../typing-break/main.c:105
+#: shell/org.gnome.Settings.gschema.xml:14
 msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+"Whether Settings should show a warning when running a development build."
 msgstr ""
-"Manitor pracy klavijatury vykarystoŭvaje abšar nahadvańniaŭ, kab pakazvać "
-"infarmacyju. Zdajecca, takoha abšaru niama na paneli. Jaho možna dadać, "
-"kliknuŭšy pravaj klavišaj myšy na paneli, potym abraŭšy \"Dadaj da paneli\", "
-"zaznačyŭšy \"Abšar nahadvańnia\" i kliknuŭšy \"Dadaj\"."
 
-#: ../font-viewer/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ OpenType."
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ PCF."
-
-#: ../font-viewer/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ TrueType."
-
-#: ../font-viewer/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ Type1."
-
-#: ../font-viewer/fontilus.schemas.in.h:5
+#: shell/org.gnome.Settings.gschema.xml:21
 msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
 msgstr ""
-"Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ OpenType."
 
-#: ../font-viewer/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr "Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ PCF."
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, fuzzy, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "Klanavanaje vyjście"
+msgstr[1] "Klanavanaje vyjście"
+msgstr[2] "Klanavanaje vyjście"
 
-#: ../font-viewer/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr ""
-"Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ TrueType."
-
-#: ../font-viewer/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr ""
-"Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ Type1."
-
-#: ../font-viewer/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "Zahad, kab stvarać minijatury dla šryftoŭ OpenType"
-
-#: ../font-viewer/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "Zahad, kab stvarać minijatury dla šryftoŭ PCF"
-
-#: ../font-viewer/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "Zahad, kab stvarać minijatury dla šryftoŭ TrueType"
-
-#: ../font-viewer/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Zahad, kab stvarać minijatury dla šryftoŭ Type1"
-
-#: ../font-viewer/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "Ci treba stvarać minijatury dla šryftoŭ OpenType"
-
-#: ../font-viewer/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "Ci treba stvarać minijatury dla šryftoŭ PCF"
-
-#: ../font-viewer/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "Ci treba stvarać minijatury dla šryftoŭ TrueType"
-
-#: ../font-viewer/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "Ci treba stvarać minijatury dla šryftoŭ Type1"
-
-#: ../font-viewer/font-view.c:113
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "Kiń źluku ŭściaž łaščyć. ŃŁŬŚŠČŹŽ 0123456789"
-
-#: ../font-viewer/font-view.c:275
-msgid "Name:"
-msgstr "Nazva:"
-
-#: ../font-viewer/font-view.c:278
-msgid "Style:"
-msgstr "Styl:"
-
-#: ../font-viewer/font-view.c:291
-msgid "Type:"
-msgstr "Typ:"
-
-#: ../font-viewer/font-view.c:295
-msgid "Size:"
-msgstr "Pamier:"
-
-#: ../font-viewer/font-view.c:339 ../font-viewer/font-view.c:352
-msgid "Version:"
-msgstr "Versija:"
-
-#: ../font-viewer/font-view.c:343 ../font-viewer/font-view.c:354
-msgid "Copyright:"
-msgstr "Aŭtarskija pravy:"
-
-#: ../font-viewer/font-view.c:347
-msgid "Description:"
-msgstr "Apisańnie:"
-
-#: ../font-viewer/font-view.c:437
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
-msgid "usage: %s fontfile\n"
-msgstr "užyćcio: %s fajł_šryftu\n"
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
-msgid "Font Viewer"
-msgstr "Prahladalnik šryftoŭ"
+#~ msgid "Image/label border"
+#~ msgstr "Abvodka vyjavy/etykietki"
 
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
-msgid "Preview fonts"
-msgstr "Pieradahlad šryftoŭ"
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "Šyrynia abvodki etykiety j vyjavy ŭ vaknie dyjalohu aściarohi"
 
-#: ../font-viewer/font-thumbnailer.c:243
-msgid "Text to thumbnail (default: Aa)"
-msgstr "Tekst minijatury (zmoŭčana: Aa)"
+#~ msgid "The type of alert"
+#~ msgstr "Vid aściarohi"
 
-#: ../font-viewer/font-thumbnailer.c:243
-msgid "TEXT"
-msgstr "TEKST"
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Knopki, bačnyja ŭ vaknie aściarohi"
 
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "Font size (default: 64)"
-msgstr "Pamier šryftu (zmoŭčana: 64)"
+#~ msgid "Show more _details"
+#~ msgstr "Pakažy _bolej detalaŭ"
 
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "SIZE"
-msgstr "PAMIER"
+#, c-format
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "Pakładzi svoj levy adziniec na %s"
+
+#, c-format
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "Paciahni svaim levym adzincom pa %s"
+
+#, c-format
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "Pakładzi svoj levy pakazalnik na %s"
+
+#, c-format
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "Paciahni svaim levym pakazalnikam pa %s"
+
+#, c-format
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "Pakładzi svoj levy siarednik na %s"
+
+#, c-format
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "Paciahni svaim levym siarednikam pa %s"
+
+#, c-format
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "Pakładzi svoj levy pierścianiec na %s"
+
+#, c-format
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "Paciahni svaim levym pierściancom pa %s"
+
+#, c-format
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "Pakładzi svoj levy mieziniec na %s"
+
+#, c-format
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "Paciahni svaim levym miezincam pa %s"
+
+#, c-format
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "Pakładzi svoj pravy adziniec na %s"
+
+#, c-format
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "Paciahni svaim pravym adzincom pa %s"
+
+#, c-format
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "Pakładzi svoj pravy pakazalnik na %s"
+
+#, c-format
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "Paciahni svaim pravym pakazalnikam pa %s"
+
+#, c-format
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "Pakładzi svoj pravy siarednik na %s"
+
+#, c-format
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "Paciahni svaim pravym siarednikam pa %s"
+
+#, c-format
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "Pakładzi svoj pravy pierścianiec na %s"
+
+#, c-format
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "Paciahni svaim pravym pierściancom pa %s"
+
+#, c-format
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "Pakładzi svoj pravy mieziniec na %s"
+
+#, c-format
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "Paciahni svaim pravym miezincam pa %s"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "Znoŭ pakładzi palec na čytnik"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "Znoŭ paciahni palcam pa čytniku"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "Zamały prociah, paŭtary jašče"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "Tvoj palec nie zasiarodžany na čytniku, paŭtary prociah jašče"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "Prybiary palec i paŭtary prociah jašče"
+
+#~ msgid "No Image"
+#~ msgstr "Biez vyjavy"
+
+#~ msgid "Images"
+#~ msgstr "Vyjavy"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Pry sprobie atrymańnia infarmacyi ab adrasnaj knizie adbyłasia pamyłka\n"
+#~ "Server danych Evolution nia moža absłužyć pratakoł"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Niemahčyma adčynić adrasnuju knihu"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr ""
+#~ "Niaviadomaje ID aŭtaryzacyi, baza karystalnika moža być paškodžanaja"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "Pra %s"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "Uklučy ŭvachod z _adbitkam palca..."
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "Vyklučy ŭvachod z _adbitkam palca..."
+
+#~ msgid "About Me"
+#~ msgstr "Pra mianie"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Tabie nie dazvolena karystacca hetaj pryładaj. Źviarnisia da "
+#~ "administratara hetaj systemy."
+
+#~ msgid "The device is already in use."
+#~ msgstr "Pryłada ŭžo zaniataja."
+
+#~ msgid "An internal error occured"
+#~ msgstr "Adbyłasia ŭnutranaja pamyłka"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Vydalić zarehistravanyja adbitki palcaŭ?"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "Nie ŭdałosia dastupicca da pryłady \"%s\""
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "Nie ŭdałosia raspačać zapaminańnie adbitkaŭ dla pryłady \"%s\""
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Nie ŭdałosia dastupicca da budź-jakoha čytnika adbitkaŭ palcaŭ"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Źviarnisia da administratara tvajoj systemy pa dapamohu."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "Kab uklučyć mahčymaść uvachodu z adbitkam palca, treba zapisać adbitak "
+#~ "tvajho palca z dapamohaj pryłady \"%s\"."
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "Paciahni palcam pa čytniku"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "Pakładzi palec na čytnik"
+
+#~ msgid "Left index finger"
+#~ msgstr "Levy pakazalnik"
+
+#~ msgid ""
+#~ "Left thumb\n"
+#~ "Left middle finger\n"
+#~ "Left ring finger\n"
+#~ "Left little finger\n"
+#~ "Right thumb\n"
+#~ "Right middle finger\n"
+#~ "Right ring finger\n"
+#~ "Right little finger"
+#~ msgstr ""
+#~ "Levy adziniec\n"
+#~ "Levy siarednik\n"
+#~ "Levy pierścianiec\n"
+#~ "Levy mieziniec\n"
+#~ "Pravy adziniec\n"
+#~ "Pravy siarednik\n"
+#~ "Pravy pierścianiec\n"
+#~ "Pravy mieziniec"
+
+#~ msgid "Right index finger"
+#~ msgstr "Pravy pakazalnik"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Adbitak tvajho palca zapisany. Ciapier ty zmožaš uvajści ŭ systemu z "
+#~ "dapamohaj čytnika."
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Dom</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Kamunikatary</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Praca</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Telefon</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Sieciva</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Praca</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Źmiani parol</span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "A_dras:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "A_systent:"
+
+#~ msgid "C_ity:"
+#~ msgstr "H_orad:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "_Firma:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Źmiani _parol..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "Źmiani pa_rol"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "H_orad:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "K_raina:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "_Kraina:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "Do_m:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "_Paštovaja skrynka:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "Pašt_ovaja skrynka:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Persanalnyja źviestki"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "Uviadzi svoj parol jašče raz u poli <b>Uviadzi parol znoŭ</b>."
+
+#~ msgid "Select your photo"
+#~ msgstr "Abiary fatahrafiju"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "R_ehijon:"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "Kab źmianić parol, uviadzi dziejny parol u poli nižej i klikni "
+#~ "<b>Aŭtaryzuj</b>.\n"
+#~ "Paśla aŭtaryzacyi ŭviadzi novy parol, uviadzi jaho znoŭ dziela "
+#~ "veryfikacyi i klikni <b>Źmiani parol</b>."
+
+#~ msgid "Web _log:"
+#~ msgstr "B_log:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "Pra_ca:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "_Faks na pracy:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "Paštovy _indeks:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Chatniaja staronka:"
+
+#~ msgid "_Home:"
+#~ msgstr "Do_m:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Kiraŭnik:"
+
+#~ msgid "_Profession:"
+#~ msgstr "_Prafesija:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "Rehijo_n:"
+
+#~ msgid "_Title:"
+#~ msgstr "P_asada:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Praca:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "Paštovy _indeks:"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "Praces naščadka niečakana zakončyŭsia"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "Niamahčyma začynić kanał I/O backend_stdin: %s"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "Niemahčyma začynić kanał I/O backend_stdout: %s"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr ""
+#~ "Tvoj parol byŭ źmienieny paśla pačatkovaj aŭtaryzacyi! Kali łaska, "
+#~ "paŭtary aŭtaryzacyju."
+
+#~ msgid "That password was incorrect."
+#~ msgstr "Parol byŭ niapravilny."
+
+#~ msgid "Your password has been changed."
+#~ msgstr "Tvoj parol byŭ źmienieny."
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "Systemnaja pamyłka: %s."
+
+#~ msgid "The password is too simple."
+#~ msgstr "Hety parol nadta prosty."
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "Novy parol nadta padobny da staroha."
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "U novym paroli musiać być ličby albo admysłovyja znaki."
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "Novy parol taki ž, jak i stary."
+
+#, c-format
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "Niemahčyma ŭruchomić %s: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "Niemahčyma ŭruchomić padtrymku"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "Adbyłasia systemnaja pamyłka"
+
+#~ msgid "Checking password..."
+#~ msgstr "Pravierka parolu..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "Klikni na <b>Źmiani parol</b>, kab źmianić jaho."
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "Uviadzi parol u poli <b>Novy parol</b>."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "Paroli roźniacca miž saboj."
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>Technalohii dastupnaści</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>Nałady</b>"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Nałady technalohij dastupnaści"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "Źmieny dla ŭklučeńnia technalohij dastupnaści nie paŭpłyvajuć na "
+#~ "dziejnyja nałady da nastupnaj tvajoj aŭtaryzacyi ŭ systemie."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Začyni j vy_jdzi"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Pieraskoč da vakna \"Pažadanyja aplikacyi\""
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "Pieraskoč da vakna \"Dastupny ŭvachod\""
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "Pieraskoč da vakna \"Dastupnaść klavijatury\""
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Pieraskoč da vakna \"Dastupnaść myšy\""
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "Uklučy technalohii dastupnaści"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "Dastupnaść _myšy"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "_Pažadanyja aplikacyi"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "Technalohii dastupnaści"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr ""
+#~ "Vybiery, jakija technalohii dastupnaśći treba ŭklučyć pry ŭvachodzie ŭ "
+#~ "systemu"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Dadaj špaleru"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Šryft moža być nadta vialikim"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Abrany šryft maje vyšyniu %d punkt, i moža być ciažka efektyŭna jaho "
+#~ "vykarystoŭvać u kamputary. Rekamendujecca abrać pamier, mienšy za %d."
+#~ msgstr[1] ""
+#~ "Abrany šryft maje vyšyniu %d punkty, i moža być ciažka efektyŭna jaho "
+#~ "vykarystoŭvać u kamputary. Rekamendujecca abrać pamier, mienšy za %d."
+#~ msgstr[2] ""
+#~ "Abrany šryft maje vyšyniu %d punktaŭ, i moža być ciažka efektyŭna jaho "
+#~ "vykarystoŭvać u kamputary. Rekamendujecca abrać pamier, mienšy za %d."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Abrany šryft maje vyšyniu %d punkt, i moža być ciažka efektyŭna jaho "
+#~ "vykarystoŭvać u kamputary. Rekamendujecca abrać šryft mienšaha pamieru."
+#~ msgstr[1] ""
+#~ "Abrany šryft maje vyšyniu %d punkty, i moža być ciažka efektyŭna jaho "
+#~ "vykarystoŭvać u kamputary. Rekamendujecca abrać šryft mienšaha pamieru."
+#~ msgstr[2] ""
+#~ "Abrany šryft maje vyšyniu %d punktaŭ, i moža być ciažka efektyŭna jaho "
+#~ "vykarystoŭvać u kamputary. Rekamendujecca abrać šryft mienšaha pamieru."
+
+#~ msgid "Use previous font"
+#~ msgstr "Užyj papiaredni šryft"
+
+#~ msgid "Use selected font"
+#~ msgstr "Užyj zaznačany šryft"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Akreśl nazvu fajłu matyvu, jaki treba zainstalavać"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "Akreśl nazvu staronki, jakuju treba pakazać (theme|background|fonts|"
+#~ "interface)"
+
+#~ msgid "page"
+#~ msgstr "staronka"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[ŠPALERA...]"
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "Hety matyŭ nia budzie vyhladać, jak naležyć, bo nie zainstalavana "
+#~ "patrebnaha ruchavika matyvaŭ GTK+ \"%s\"."
+
+#~ msgid "Apply Background"
+#~ msgstr "Užyj fon"
+
+#~ msgid "Apply Font"
+#~ msgstr "Užyj šryft"
+
+#~ msgid "Revert Font"
+#~ msgstr "Viarni šryft"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "Dziejny matyŭ raić peŭny fon i šryft. Zaŭsiody možna viarnuć papiaredni "
+#~ "šryft."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "Dziejny matyŭ raić peŭny fon. Zaŭsiody možna viarnuć papiaredni šryft."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "Dziejny matyŭ raić peŭny fon i šryft."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr "Dziejny matyŭ raić peŭny šryft. Zaŭsiody možna viarnuć papiaredni."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "Dziejny matyŭ raić peŭny fon."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "Zaŭsiody možna viarnuć papiaredni šryft."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "Dziejny matyŭ raić peŭny šryft."
+
+#~ msgid "Custom"
+#~ msgstr "Admysłovy"
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>K_olery</b>"
+
+# Mechanizm papraŭleńnia jakaści druku na aparatury ź nizkaj padzielnaj zdolnaściu. Adpaviednika niama, pakinuŭ jak jość. Prapanuju heta pryniać tak jak i widget.
+#~ msgid "<b>Hinting</b>"
+#~ msgstr "<b>Hinting</b>"
+
+#~ msgid "<b>Menus and Toolbars</b>"
+#~ msgstr "<b>Paneli menu j pryładździa</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Pieradahlad</b>"
+
+#~ msgid "<b>Rendering</b>"
+#~ msgstr "<b>Vyjaŭleńnie</b>"
+
+#~ msgid "<b>Smoothing</b>"
+#~ msgstr "<b>Vyhładžvańnie</b>"
+
+#~ msgid "<b>Subpixel Order</b>"
+#~ msgstr "<b>Čarhovaść subpikselaŭ</b>"
+
+#~ msgid "<b>_Desktop Background</b>"
+#~ msgstr "<b>_Fon stała</b>"
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "Nałady vyhladu"
+
+#~ msgid "Best _shapes"
+#~ msgstr "_Najlepšyja kštałty"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Najlepšy _kantrast"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "_Źmiani..."
+
+#~ msgid "C_ut"
+#~ msgstr "_Vytni"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "Źmiena matyvu kursora paŭpłyvaje paśla nastupnaha ŭvachodu."
+
+#~ msgid "Customize Theme"
+#~ msgstr "Źmiani matyŭ"
+
+#~ msgid "D_etails..."
+#~ msgstr "_Detali..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Šryft dla _stała:"
+
+#~ msgid "Fonts"
+#~ msgstr "Šryfty"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Adcieńni _šeraha"
+
+#~ msgid "Icons"
+#~ msgstr "Ikony"
+
+#~ msgid "Interface"
+#~ msgstr "Interfejs"
+
+#~ msgid "N_one"
+#~ msgstr "_Niama"
+
+#~ msgid "New File"
+#~ msgstr "Novy fajł"
+
+#~ msgid "Open File"
+#~ msgstr "Adčyni fajł"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Adčyni vakno vybaru koleru"
+
+#~ msgid "R_esolution:"
+#~ msgstr "Pa_miery:"
+
+#~ msgid "Save File"
+#~ msgstr "Zapišy fajł"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "Za_pišy matyŭ jak..."
+
+#~ msgid "Save _As..."
+#~ msgstr "Za_pišy jak..."
+
+#~ msgid "Save _background image"
+#~ msgstr "Zapišy _fonavuju vyjavu"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Pakazvaj _ikony ŭ menu"
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "Adnastajny koler\n"
+#~ "Haryzantalny hradyjent\n"
+#~ "Vertykalny hradyjent"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "_Subpikselnaje (ekrany LCD)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Sub_pikselnaje vyhładžvańnie (ekrany LCD)"
+
+#~ msgid "Text"
+#~ msgstr "Tekst"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "Tekst nižej elementaŭ\n"
+#~ "Tekst pobač z elementami\n"
+#~ "Tolki ikony\n"
+#~ "Tolki tekst"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr ""
+#~ "Dziejny matyŭ elementaŭ kiravańnia nie absłuhoŭvaje schiemaŭ koleraŭ."
+
+#~ msgid "Theme"
+#~ msgstr "Matyŭ"
+
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "Pa susiedztvie\n"
+#~ "Maštabavany\n"
+#~ "Centravany\n"
+#~ "Źmienieny pamier\n"
+#~ "Zapaŭnieńnie ekranu"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "_Podpisy dla knopak paneli pryładździa:"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "Window Border"
+#~ msgstr "Kraj vakna"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "_Apisańnie:"
+
+#~ msgid "_Document font:"
+#~ msgstr "Šryft _dakumentaŭ:"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "_Źmianialnyja klavišy skarotaŭ menu"
+
+#~ msgid "_File"
+#~ msgstr "_Fajł"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "Šryft s_tałaj šyryni:"
+
+#~ msgid "_Install..."
+#~ msgstr "Za_instaluj..."
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Monachromnaje"
+
+#~ msgid "_New"
+#~ msgstr "_Novy"
+
+#~ msgid "_Paste"
+#~ msgstr "Uk_lej"
+
+#~ msgid "_Print"
+#~ msgstr "Vy_drukuj"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Selected items:"
+#~ msgstr "_Zaznačanyja elementy:"
+
+#~ msgid "_Size:"
+#~ msgstr "_Pamier:"
+
+#~ msgid "_Slight"
+#~ msgstr "_Lohki"
+
+#~ msgid "_Style:"
+#~ msgstr "_Styl:"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "_Padkazki:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Šryft zahałoŭku vakna:"
+
+#~ msgid "_Windows:"
+#~ msgstr "Vo_kny:"
+
+#~ msgid "dots per inch"
+#~ msgstr "punktaŭ na cal"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Źmiani vyhlad stała"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Instaluje pakunki matyvaŭ roznych častak asiarodździa"
+
+#~ msgid "Theme Installer"
+#~ msgstr "Instalatar matyvaŭ"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Pakunak matyvu GNOME"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Biaz fonu stała"
+
+#~ msgid "Slide Show"
+#~ msgstr "Slideshow"
+
+#, c-format
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s by %d %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s na %d %s\n"
+#~ "Kataloh: %s"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "piksel"
+#~ msgstr[1] "pikseli"
+#~ msgstr[2] "pikselaŭ"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "Niemahčyma zainstalavać matyŭ"
+
+#, c-format
+#~ msgid "The %s utility is not installed."
+#~ msgstr "Pryłada %s nie zainstalavanaja."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "Uźnikła prablema ŭ časie raspakoŭvańnia matyvu."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "U časie instalavańnia zaznačanaha fajłu ŭźnikła pamyłka"
+
+#, c-format
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" nie padobny na pravilny matyŭ."
+
+#, c-format
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" nie padobny na pravilny matyŭ. Heta moža być prahramny matyŭ, jaki "
+#~ "treba skampilavać."
+
+#, c-format
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "Pamyłka instalacyi matyvu \"%s\"."
+
+#, c-format
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "Matyŭ \"%s\" zainstalavany."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "Ty chočaš užyć matyŭ ciapier ci pakinuć dziejny matyŭ?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Pakiń dziejny matyŭ"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Užyj novy matyŭ"
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "Matyŭ GNOME %s pravilna zainstalavany"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Niemahčyma stvaryć časovy kataloh"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "Novyja matyvy paśpiachova zainstalavanyja."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Nie padadziena pałažeńnia fajłu matyvu, jaki treba zainstalavać"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Niedastatkova dazvołu, kab zainstalavać matyŭ u:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "Abiary matyŭ"
+
+#~ msgid "Theme Packages"
+#~ msgstr "Pakunki matyvaŭ"
+
+#, c-format
+#~ msgid "Theme name must be present"
+#~ msgstr "Matyŭ musić mieć nazvu"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Taki matyŭ užo isnuje. Chočaš zamianić jaho?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_Zamiani"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Ci chočaš vydalić hety matyŭ?"
+
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "Niemahčyma vydalić matyŭ"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "Niemahčyma zainstalavać matyŭ"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Niemahčyma ŭklučyć kiraŭnika naładaŭ – \"gnome-settings-daemon\".\n"
+#~ "Biaz spraŭnaha kiraŭnika naładaŭ GNOME peŭnyja nałady mohuć nia "
+#~ "dziejničać. Heta moža śviedčyć ab prablemie z Bonobo albo ź inšym "
+#~ "kiraŭnikom naładaŭ (napr. KDE), jaki kanfliktuje z kiraŭnikom GNOME."
+
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Niemahčyma zahruzić standartnuju ikonu '%s'\n"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Padčas pakazu dapamohi adbyłasia pamyłka: %s"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Kapijavańnie fajłu: %u z %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "Kapijavańnie \"%s\""
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "Baćkoŭskaje vakno dla vakna dyjalohu"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI ciapier zabirajecca z"
+
+#~ msgid "To URI"
+#~ msgstr "Da URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI ciapier pieradajecca da"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Častka pieradačy zakončanaja"
+
+#~ msgid "Current URI index"
+#~ msgstr "Indeks dziejnaha URI"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Indeks dziejnaha URI (ličačy ad 1)"
+
+#~ msgid "Total URIs"
+#~ msgstr "Poŭnaja kolkaść URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Poŭnaja kolkaść URI"
+
+#, c-format
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "Fajł \"%s\" užo isnuje. Chočaš zamianić jaho?"
+
+#~ msgid "_Skip"
+#~ msgstr "_Prapuści"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "Zamiani _ŭsio"
+
+#~ msgid "Key"
+#~ msgstr "Kluč"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Kluč GConfa, da jakoha dałučany hety redaktar ułaścivaściaŭ"
+
+#~ msgid "Callback"
+#~ msgstr "Advarotny vyklik"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Funkcyja, vyklikanaja, kali budzie źmienienaja vartaść, źviazanaja z "
+#~ "hetym klučom"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Nabor źmienaŭ GConfa, u jakim źmieščanyja źviestki, dasyłanyja klijentu "
+#~ "GConfa padčas prymianieńnia"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Vyklikanaja funkcyja kanversii na widget"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Funkcyja, vyklikanaja pierad kanversijaj źviestak z GConfa na widget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Vyklikanaja funkcyja kanversii z widgetu"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Funkcyja, vyklikanaja pierad kanversijaj źviestak z widgetu na GConf"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Abjekt, jaki kantraluje ŭłaścivaść (zvyčajna widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Źviestki abjektu redaktara ŭłaścivaściaŭ"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Asablivyja źviestki, vymahanyja admysłovym redaktaram ułaścivaściaŭ"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr ""
+#~ "Funkcyja, vyklikanaja dziela vyzvaleńnia źviestak redaktara ŭłaścivaściaŭ"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Funkcyja, vyklikanaja pierad vyzvaleńniem źviestak ad abjektu redaktara "
+#~ "ŭłaścivaściaŭ"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Niemahčyma znajści fajł \"%s\".\n"
+#~ "\n"
+#~ "Pierakanajsia, što fajł isnuje, i pasprabuj znoŭ, albo abiary inšuju "
+#~ "fonavuju vyjavu."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Ja nia viedaju, jak adčynić fajł \"%s\".\n"
+#~ "Mahčyma, što vyjavy hetaha typu nie absłuhoŭvajucca.\n"
+#~ "\n"
+#~ "Abiary inšy fajł vyjavy."
+
+#~ msgid "Please select an image."
+#~ msgstr "Abiary vyjavu."
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Zmoŭčany kursor – dziejny"
+
+#~ msgid "White Pointer"
+#~ msgstr "Bieły kursor"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Bieły kursor – dziejny"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Vialiki kursor – dziejny"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Vialiki bieły kursor – dziejny"
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Hety matyŭ nia budzie vyhladać, jak naležyć, bo patrebny matyŭ GTK+ "
+#~ "\"%s\" nie zainstalavany."
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "Hety matyŭ nia budzie vyhladać, jak naležyć, bo patrebny matyŭ kiraŭnika "
+#~ "voknaŭ \"%s\" nie zainstalavany."
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Hety matyŭ nia budzie vyhladać, jak naležyć, bo patrebny matyŭ ikonaŭ "
+#~ "\"%s\" nie zainstalavany."
+
+#~ msgid "Preferred Applications"
+#~ msgstr "Pažadanyja aplikacyi"
+
+#~ msgid "Select your default applications"
+#~ msgstr "Abiary zmoŭčanyja aplikacyi"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "Uklučy ŭlubionuju technalohiju vizualnaj dastupnaści"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "Vizualnaja dastupnaść"
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Pry zapisie kanfihuracyi adbyłasia pamyłka: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Niemahčyma zahruzić hałoŭny interfejs."
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "Akreśli nazvu staronki, jakuju treba pakazać (internet|multimedia|system|"
+#~ "a11y)"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>Prahladalnik hrafiki</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>Kamunikatar</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>Paštovy čytač</b>"
+
+#~ msgid "<b>Mobility</b>"
+#~ msgstr "<b>Mabilnaść</b>"
+
+#~ msgid "<b>Multimedia Player</b>"
+#~ msgstr "<b>Multymedyja-player</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Emulatar terminału</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Tekstavy redaktar</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Videa-player</b>"
+
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b>Vizualny</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Web-hartač</b>"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Va ŭsich miescach %s buduć zamienienyja na dziejnuju spasyłku"
+
+#~ msgid "C_ommand:"
+#~ msgstr "_Zahad:"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "_Zahad:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "Opcyja vy_kanańnia:"
+
+#~ msgid "Internet"
+#~ msgstr "Internet"
+
+#~ msgid "Multimedia"
+#~ msgstr "Multymedyja"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Adčyniaj spasyłki ŭ novaj _kartcy"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Adčyniaj spasyłki ŭ novym _аknie"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Adčyniaj spasyłki sa _zmoŭčanymi naładami hartača"
+
+#~ msgid "Run at st_art"
+#~ msgstr "Uruchom pry _ŭvachodzie"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Uruchom u t_erminale"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Muzyčny player Banshee"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Pošta Claws"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Zmoŭčany hartač Debiana"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Emulatar terminału Debiana"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Paštovy čytač Evolution"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "Lupa GNOME biez ekrannaha čytača"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus ź Lupaj"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Pošta Iceape"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "Lupa KDE biez ekrannaha čytača"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Ekranny čytač Linuksa ź Lupaj"
+
+#~ msgid "Listen"
+#~ msgstr "Listen"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Pošta Mozilla"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXTerm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Kamunikatar Netscape"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Muzyčny player Rhythmbox"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "Pošta SeaMonkey"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Standartny XTerminal"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Player filmaŭ Totem"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "<b>Monitor</b>"
+#~ msgstr "<b>Manitor</b>"
+
+#~ msgid "<b>Panel icon</b>"
+#~ msgstr "<b>Ikona paneli</b>"
+
+#~ msgid "<i>Drag the monitors to set their place</i>"
+#~ msgstr "<i>Pieraciahvaj manitory, kab uparadkavać ich</i>"
+
+#~ msgid "Include _panel"
+#~ msgstr "Ułučy _panel"
+
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "Zvyčajna\n"
+#~ "Uleva\n"
+#~ "Uprava\n"
+#~ "Dahary nahami\n"
+
+#~ msgid "Off"
+#~ msgstr "Vyklučany"
+
+#~ msgid "On"
+#~ msgstr "Uklučany"
+
+#~ msgid "R_otation:"
+#~ msgstr "_Abaročvańnie:"
+
+#~ msgid "Re_fresh rate:"
+#~ msgstr "C_hutkaść aktualizacyi:"
+
+#~ msgid "_Detect Monitors"
+#~ msgstr "_Paznavaj manitory"
+
+#~ msgid "_Mirror screens"
+#~ msgstr "_Adlustroŭvaj ekrany"
+
+#~ msgid "_Resolution:"
+#~ msgstr "_Pamiery:"
+
+#~ msgid "_Show displays in panel"
+#~ msgstr "_Pakazvaj ekrany na paneli"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Źmiani pamiery ekranu"
+
+#~ msgid "Upside Down"
+#~ msgstr "Dahary nahami"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#, c-format
+#~ msgid "<b>Monitor: %s</b>"
+#~ msgstr "<b>Manitor: %s</b>"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "Could not apply the selected configuration"
+#~ msgstr "Nie ŭdałosia ŭžyć vybranyja nałady"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Nie ŭdałosia zapisać nałady manitora"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "Nie ŭdałosia atrymać šynu sesii pry ŭžyćci naładaŭ ekranu"
+
+#~ msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+#~ msgstr "Nie ŭdałosia atrymać \"org.gnome.SettingsDaemon.XRANDR\""
+
+#~ msgid "Could not detect displays"
+#~ msgstr "Nie ŭdałosia paznać ekrany"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Nie ŭdałosia atrymać źviestki ekranu"
+
+#~ msgid "New shortcut..."
+#~ msgstr "Novy skarot..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Klaviša akseleratara"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Madyfikatary akseleratara"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Kod klavišy akseleratara"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Typ akseleratara."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Nieviadomaje dziejańnie>"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "Pamyłka zachavańnia novaha klavijaturnaha skarotu"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Skarot \"%s\" nielha vykarystać, bo nia budzie mahčymaści pisać, "
+#~ "vykarystoŭvajučy hetuju klavišu.\n"
+#~ "Pasprabuj u spałučeńni z takimi klavišami, jak Control, Alt albo Shift."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Klavijaturny skarot \"%s\" užo vykarystoŭvajecca dla\n"
+#~ "\"%s\""
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Kali ty pieraaznačyš klavijaturny skarot na \"%s\", tady skarot \"%s\" "
+#~ "budzie vyklučany."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Pieraaznač"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr ""
+#~ "Pry ačystcy akseleratara ŭ bazie źviestak kanfihuracyi adbyłasia pamyłka: "
+#~ "%s"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Zašmat ułasnych skarotaŭ"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Ułasny skarot"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Pryviažy klavijaturnyja skaroty da zahadaŭ"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Tolki ŭžyj nałady j vyjdzi (tolki dziela zhodnaści, ciapier heta "
+#~ "absłuhoŭvaje deman)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Adčyni staronku ŭłaścivaściaŭ pierapynku ŭ pisańni na klavijatury"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Pačynaj staronku, pakazvajučy nałady dastupnaści"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "– Nałady klavijatury GNOME"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>Ahulnaje</b>"
+
+#~ msgid "<b>Visual cues for sounds</b>"
+#~ msgstr "<b>Vizualnyja syhnały dla hukaŭ</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Chutka</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Doŭha</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Karotka</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Pavolna</i></small>"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "_Akseleracyja:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Dazvol adter_minoŭku pierapynkaŭ"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Hukavaja _reakcyja..."
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "Hukavy syhnał, kali nacisnutaja klaviša _pieraklučeńnia"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Hukavy syhnał, kali adch_ilenaja klaviša"
+
+#~ msgid "By _country"
+#~ msgstr "Pavodle _krainy"
+
+#~ msgid "By _language"
+#~ msgstr "Pavodle _movy"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Pravier, ci možna adterminoŭvać pierapynki"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Abiary madel klavijatury"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Abiary raskładku"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Praciahłaść pierapynku, kali zabaronienaje pisańnie"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Praciahłaść pracy pierad vymušanym pierapynkam"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Mirhaj _zahałoŭkam akna"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Hukavaja reakcyja na klavijaturu"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Nałady klavijatury"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "_Madel klavijatury:"
+
+#~ msgid "Layout _Options..."
+#~ msgstr "_Opcyi raskładki..."
+
+#~ msgid "Layouts"
+#~ msgstr "Raskładki"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Blakuj ekran paśla akreślenaha času, kab papiaredzić traŭmy, źviazanyja z "
+#~ "praciahłym pisańniem na klavijatury"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "V_iarni zmoŭčanaje"
+
+#~ msgid "S_peed:"
+#~ msgstr "Ch_utkaść:"
+
+#~ msgid "Separate _layout for each window"
+#~ msgstr "Asobnaja _raskładka dla kožnaha vakna"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "Pakazvaj _vizualnyja syhnały dla tryvožnych hukaŭ"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Praciahłaść pierapynku:"
+
+#~ msgid "_Country:"
+#~ msgstr "_Kraina:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "_Blakuj ekran, kab prymusić zrabić pierapynak padčas pisańnia"
+
+#~ msgid "_Models:"
+#~ msgstr "_Madeli:"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_Pryjmaj tolki daŭhija naciski klavišaŭ"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "_Dazvol kiravać kursoram z dapamohaj klavijatury"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "Vybranyja _raskładki:"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Imituj adnačasovyja naciski klavišaŭ"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Napišy tekst, kab pravieryć nałady:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Varyjanty:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_Vytvorca:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "Praciahłaść času p_racy:"
+
+#~ msgid "Unknown"
+#~ msgstr "Nieviadomy"
+
+#~ msgid "Vendors"
+#~ msgstr "Vytvorcy"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Abiary nałady klavijatury"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "Ruch lavej"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "Ruch praviej"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "Ruch vyšej"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "Vyklučana"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr ""
+#~ "Akreśli nazvu staronki, jakuju treba pakazać (general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "– Nałady myšy dla GNOME"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Pieraciahvańnie j puščańnie</b>"
+
+#~ msgid "<b>Dwell Click</b>"
+#~ msgstr "<b>Klik zatrymkaj</b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Raspałažy kursor</b>"
+
+#~ msgid "<b>Pointer Speed</b>"
+#~ msgstr "<b>Chutkaść kursora</b>"
+
+#~ msgid ""
+#~ "<i>To test your double-click settings, try to double-click on the light "
+#~ "bulb.</i>"
+#~ msgstr "<i>Kab pravieryć nałady dvuklika, možaš paklikać na lampačku.</i>"
+
+#~ msgid ""
+#~ "<i>You can also use the Dwell Click panel applet to choose the click type."
+#~ "</i>"
+#~ msgstr ""
+#~ "<i>Ty možaš abrać typ kliku z dapamohaj apleta paneli \"Klik zatrymkaj\"."
+#~ "</i>"
+
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i>Vysokaja</i></small>"
+
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i>Vialiki</i></small>"
+
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>Nizkaja</i></small>"
+
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i>Mały</i></small>"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Abiary typ _zaŭčasnaha kliku"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "Abiary typ kliku, ruchajčy myššu"
+
+#~ msgid "D_rag click:"
+#~ msgstr "_Pieraciahvalny klik:"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Nałady myšy"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "_Pakazvaj pałažeńnie kursora, kali nacisnutaja klaviša Control"
+
+#~ msgid "Show click type _window"
+#~ msgstr "Pakažy _vakno vybaru typu klika"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "_Parohavaja vartaść:"
+
+#~ msgid "_Left-handed"
+#~ msgstr "Dla _leŭšunoŭ"
+
+#~ msgid "_Right-handed"
+#~ msgstr "Dla _praŭšunoŭ"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Čułaść:"
+
+#~ msgid "_Single click:"
+#~ msgstr "_Adzin klik:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Abiary nałady myšy"
+
+#~ msgid "Location already exists"
+#~ msgstr "Takoje pałažeńnie ŭžo isnuje"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Abiary nałady sietkavaha proxy"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>_Pramoje internetnaje spałučeńnie</b>"
+
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>Śpis ihnaravanych hostaŭ</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>_Autamatyčnaja kanfihuracyja proxy</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_Ručnaja kanfihuracyja proxy</b>"
+
+#~ msgid "C_reate"
+#~ msgstr "_Stvary"
+
+#~ msgid "Create New Location"
+#~ msgstr "Stvary novaje pałažeńnie"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Detali HTTP-proxy"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Nałady sietkavaha proxy"
+
+#~ msgid "Port:"
+#~ msgstr "Port:"
+
+#~ msgid "The location already exists."
+#~ msgstr "Takoje pałažeńnie ŭžo isnuje."
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Biaśpiečny HTTP-proxy:"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr ""
+#~ "Niemahčyma ŭruchomić kanfihuracyjnuju aplikacyju dla kiraŭnika voknaŭ"
+
+#~ msgid "C_ontrol"
+#~ msgstr "C_ontrol"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "S_uper (albo \"klaviša Windows\")"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Klaviša ruchu</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Pavodziny zahałoŭku vakna</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Vybar akna</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Kab pierasunuć akno, naciśni j prytrymaj hetuju klavišu, a potym schapi "
+#~ "vakno:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Nałady voknaŭ"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "Ap_eracyja paśla dvukliku zahałoŭku:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "Ča_s pierad vysoŭvańniem:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Vysoŭvaj abranyja vokny praź niekatory čas"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Zaznačaj vokny paśla raźmiaščeńnia nad imi kursora"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Kanfihuruj ułaścivaści voknaŭ"
+
+#, c-format
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>Uklučy %s</b>"
+
+#~ msgid "Upgrade"
+#~ msgstr "Aktualizuj"
+
+#~ msgid "Uninstall"
+#~ msgstr "Adinstaluj"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "Dadaj da ŭlubionych"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Vydal sa startavych prahramaŭ"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Dadaj da startavych prahramaŭ"
+
+#, c-format
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>Niama adpaviednikaŭ.</b> </span><span>\n"
+#~ "\n"
+#~ " Filter \"<b>%s</b>\" nie pasuje ni da adnaho z elementaŭ.</span>"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "Novy raźlikovy arkuš"
+
+#~ msgid "New Document"
+#~ msgstr "Novy dakument"
+
+#~ msgid "Home"
+#~ msgstr "Dom"
+
+#~ msgid "Documents"
+#~ msgstr "Dakumenty"
+
+#, c-format
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Adčyni</b>"
+
+#~ msgid "Send To..."
+#~ msgstr "Vyšli da..."
+
+#~ msgid "Delete"
+#~ msgstr "Vydal"
+
+#, c-format
+#~ msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgstr "Ty sapraŭdy chočaš nazaŭždy vydalić \"%s\"?"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "Vydaleny elementy budzie stračany nazaŭždy."
+
+#, c-format
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>Adčyni pry dapamozie \"%s\"</b>"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "Adčyni ŭ kiraŭniku fajłaŭ"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Siońnia %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "Učora %l:%M %p"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%b %d %l:%M %p"
+
+#~ msgid "%b %d %Y"
+#~ msgstr "%b %d %Y"
+
+#~ msgid "Find Now"
+#~ msgstr "Znajdzi ciapier"
+
+#, c-format
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Adčyni %s</b>"
+
+#, c-format
+#~ msgid "Remove from System Items"
+#~ msgstr "Vydal z systemnych elementaŭ"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Kiraŭnik voknaŭ \"%s\" nie zarehistravaŭ pryładu kanfihuracyi\n"
+
+#~ msgid "Maximize"
+#~ msgstr "Maksymalizuj"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "Maksymalizuj vertykalna"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Maksymalizuj haryzantalna"
+
+#~ msgid "Minimize"
+#~ msgstr "Minimalizuj"
+
+#~ msgid "Roll up"
+#~ msgstr "Razharni"
+
+#, c-format
+#~ msgid "key not found [%s]\n"
+#~ msgstr "nia znojdzieny kluč [%s]\n"
+
+#~ msgid "Groups"
+#~ msgstr "Hrupy"
+
+#~ msgid "Control Center"
+#~ msgstr "Centar kiravańnia"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Začyni centar kiravańnia paśla aktyvizacyi zadačy"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "Vyjdzi z abałonki paśla dadańnia albo vydaleńnia"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Vyjdzi z abałonki paśla pakazu dapamohi"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Vyjdzi z abałonki paśla startu"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "Vyjdzi z abałonki paśla aktualizacyi albo adinstalavańnia"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "Akreślivaje, ci začyniać abałonku paśla pakazu dapamohi."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "Akreślivaje, ci začyniać abałonku paśla ŭruchamleńnia."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr "Akreślivaje, ci začyniać abałonku paśla dadavańnia albo vydaleńnia."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "Akreślivaje, ci začyniać abałonku paśla aktualizacyi albo adinstalavańnia."
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "Nazvy zadačaŭ i adpaviednyja fajły .desktop"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "Nazva bačnaj u centry kiravańnia zadačy, paśla jakoj staić separatar \";"
+#~ "\", a potym nazva adpaviednaha fajłu .desktop, kab uruchomić dla hetaj "
+#~ "zadačy."
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[Źmiani matyŭ;gtk-theme-selector.desktop,Abiary zmoŭčanyja aplikacyi;"
+#~ "default-applications.desktop,Dadaj drukarku;gnome-cups-manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "Kali ŭklučana, center kiravańnia budzie začynieny pry ŭklučeńni \"Typovaj "
+#~ "zadačy\"."
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Pryłada kanfihuracyi GNOME"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "A_dterminuj pierapynak"
+
+#~ msgid "Take a break!"
+#~ msgstr "Zrabi pierapynak!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/Z_rabi pierapynak"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d chvilina da pierapynku"
+#~ msgstr[1] "%d chviliny da pierapynku"
+#~ msgstr[2] "%d chvilin da pierapynku"
+
+#, c-format
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Da nastupnaha pierapynku mienš za chvilinu"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Niemahčyma pakazać akno ŭłaścivaściaŭ pierapynkaŭ u pisańni z-za "
+#~ "nastupnaj pamyłki: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Napisaŭ Richard Hult <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Aŭtarskaja hrafika ad Anders Carlsson"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Prahrama nahadvańnia ab pierapynkach padčas pracy z kamputaram."
+
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "Łacinka.org\n"
+#~ "Alaksandar Navicki <zolak@lacinka.prg>Ihar Hračyška <ihar."
+#~ "hrachyshka@gmail.com>"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Uklučy debugavy kod"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Nie praviaraj, ci isnuje abšar nahadvańnia"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Manitor pracy klavijatury vykarystoŭvaje abšar nahadvańniaŭ, kab pakazvać "
+#~ "infarmacyju. Zdajecca, takoha abšaru niama na paneli. Jaho možna dadać, "
+#~ "kliknuŭšy pravaj klavišaj myšy na paneli, potym abraŭšy \"Dadaj da "
+#~ "paneli\", zaznačyŭšy \"Abšar nahadvańnia\" i kliknuŭšy \"Dadaj\"."
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ OpenType."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ PCF."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ TrueType."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ Type1."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ "
+#~ "OpenType."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ PCF."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ "
+#~ "TrueType."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ Type1."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Zahad, kab stvarać minijatury dla šryftoŭ OpenType"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Zahad, kab stvarać minijatury dla šryftoŭ PCF"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Zahad, kab stvarać minijatury dla šryftoŭ TrueType"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Zahad, kab stvarać minijatury dla šryftoŭ Type1"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Ci treba stvarać minijatury dla šryftoŭ OpenType"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Ci treba stvarać minijatury dla šryftoŭ PCF"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Ci treba stvarać minijatury dla šryftoŭ TrueType"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Ci treba stvarać minijatury dla šryftoŭ Type1"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Kiń źluku ŭściaž łaščyć. ŃŁŬŚŠČŹŽ 0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Pamier:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Aŭtarskija pravy:"
+
+#~ msgid "Description:"
+#~ msgstr "Apisańnie:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "užyćcio: %s fajł_šryftu\n"
+
+#~ msgid "Font Viewer"
+#~ msgstr "Prahladalnik šryftoŭ"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Tekst minijatury (zmoŭčana: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEKST"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Pamier šryftu (zmoŭčana: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "PAMIER"
 
 # #FIXME Vychadny ci vyjścievy?
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "FONT-FILE OUTPUT-FILE"
-msgstr "FAJŁ-ŠRYFTU VYCHADNY-FAJŁ"
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FAJŁ-ŠRYFTU VYCHADNY-FAJŁ"
 
-#: ../font-viewer/font-thumbnailer.c:265
 #, c-format
-msgid "Error parsing arguments: %s\n"
-msgstr "Pamyłka padčas razboru arhumentaŭ: %s\n"
-
-msgid "Show help options"
-msgstr "Pakažy opcyi dapamohi"
+#~ msgid "Error parsing arguments: %s\n"
+#~ msgstr "Pamyłka padčas razboru arhumentaŭ: %s\n"
 
 #~ msgid "Enable support for GNOME assistive technologies at login"
 #~ msgstr "Uklučaj padtrymku technalohij dastupnaści GNOME pry aŭtaryzacyi"
@@ -3584,26 +7472,8 @@ msgstr "Pakažy opcyi dapamohi"
 #~ msgid "<b>_Wallpaper</b>"
 #~ msgstr "<b>_Špalera</b>"
 
-#~ msgid "No Wallpaper"
-#~ msgstr "Biez špalery"
-
 #~ msgid "Monitor Resolution Settings"
 #~ msgstr "Nałady pamieraŭ manitora"
-
-#~ msgid "R_otation"
-#~ msgstr "_Abaročvańnie"
-
-#~ msgid "Re_fresh Rate:"
-#~ msgstr "C_hutkaść abnaŭleńnia:"
-
-#~ msgid "_Resolution"
-#~ msgstr "_Pamiery"
-
-#~ msgid "Screen Resolution"
-#~ msgstr "Pamiery ekranu"
-
-#~ msgid "Cloned Output"
-#~ msgstr "Klanavanaje vyjście"
 
 #~ msgid "New accelerator..."
 #~ msgstr "Novy akseleratar..."
@@ -3619,12 +7489,6 @@ msgstr "Pakažy opcyi dapamohi"
 
 #~ msgid "Failed to construct test pipeline for '%s'"
 #~ msgstr "Niemahčyma skanstrujavać testavy łancuh dla \"%s\""
-
-#~ msgid "Not connected"
-#~ msgstr "Nie padłučany"
-
-#~ msgid "Autodetect"
-#~ msgstr "Aŭtamatyčnaje vyznačeńnie"
 
 #~ msgid "ALSA - Advanced Linux Sound Architecture"
 #~ msgstr "ALSA – Advanced Linux Sound Architecture"
@@ -3671,20 +7535,11 @@ msgstr "Pakažy opcyi dapamohi"
 #~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
 #~ msgstr "<span weight=\"bold\" size=\"x-large\">Pravierka...</span>"
 
-#~ msgid "Click OK to finish."
-#~ msgstr "Klikni \"OK\", kab skončyć."
-
-#~ msgid "Devices"
-#~ msgstr "Pryłady"
-
 #~ msgid "Play _alert sound"
 #~ msgstr "_Padaj tryvožny syhnał"
 
 #~ msgid "Play _sound effects when buttons are clicked"
 #~ msgstr "_Ahučvaj kliki ŭ knopki"
-
-#~ msgid "S_ound playback:"
-#~ msgstr "_Hrańnie huku:"
 
 #~ msgid ""
 #~ "Select the device and tracks to control with the keyboard. Use the Shift "
@@ -3703,12 +7558,6 @@ msgstr "Pakažy opcyi dapamohi"
 #~ msgid "Sound Preferences"
 #~ msgstr "Nałady huku"
 
-#~ msgid "Sounds"
-#~ msgstr "Huki"
-
-#~ msgid "Test"
-#~ msgstr "Pravier"
-
 #~ msgid "Testing Pipeline"
 #~ msgstr "Testavy łancuh (pipeline)"
 
@@ -3721,17 +7570,8 @@ msgstr "Pakažy opcyi dapamohi"
 #~ msgid "_Sound playback:"
 #~ msgstr "_Hrańnie huku:"
 
-#~ msgid "Alert sound"
-#~ msgstr "Tryvožny syhnał"
-
-#~ msgid "Visual alert"
-#~ msgstr "Vizualnaja tryvoha"
-
 #~ msgid "Windows and Buttons"
 #~ msgstr "Vokny j knopki"
-
-#~ msgid "Button clicked"
-#~ msgstr "Klik u knopku"
 
 #~ msgid "Toggle button clicked"
 #~ msgstr "Klik u knopku pieraklučeńnia"
@@ -3742,20 +7582,11 @@ msgstr "Pakažy opcyi dapamohi"
 #~ msgid "Window unmaximized"
 #~ msgstr "Anulavanaja maksymalizacyja akna"
 
-#~ msgid "Window minimised"
-#~ msgstr "Akno zminimalizavanaje"
-
 #~ msgid "Login"
 #~ msgstr "Aŭtaryzuj"
 
-#~ msgid "Logout"
-#~ msgstr "Vyjdzi"
-
 #~ msgid "New e-mail"
 #~ msgstr "Novy list e-mail"
-
-#~ msgid "Empty trash"
-#~ msgstr "Pustaja śmietnica"
 
 #~ msgid "Long action completed (download, CD burning, etc.)"
 #~ msgstr "Skončyłasia daŭhaja aperacyja (zahruzka fajłu, zapis dysku itp.)"
@@ -3769,26 +7600,11 @@ msgstr "Pakažy opcyi dapamohi"
 #~ msgid "Warning"
 #~ msgstr "Papiaredžańnie"
 
-#~ msgid "Error"
-#~ msgstr "Pamyłka"
-
-#~ msgid "Battery warning"
-#~ msgstr "Papiaredžańnie pra stan batarei"
-
 #~ msgid "Testing event sound"
 #~ msgstr "Pravierka huku dla padziei"
 
-#~ msgid "Select Sound File"
-#~ msgstr "Abiary hukavy fajł"
-
-#~ msgid "Sound files"
-#~ msgstr "Hukavyja fajły"
-
 #~ msgid "Custom..."
 #~ msgstr "_Inšy..."
-
-#~ msgid "Lock Screen"
-#~ msgstr "Zablakuj ekran"
 
 #~ msgid "Shutdown"
 #~ msgstr "Vyklučy"
@@ -3837,20 +7653,11 @@ msgstr "Pakažy opcyi dapamohi"
 #~ msgid "Inverted"
 #~ msgstr "Invertavana"
 
-#~ msgid "Default Settings"
-#~ msgstr "Zmoŭčanyja nałady"
-
-#~ msgid "Screen %d Settings\n"
-#~ msgstr "Nałady ekranu %d\n"
-
 #~ msgid "Screen Resolution Preferences"
 #~ msgstr "Nałady pamieraŭ ekranu"
 
 #~ msgid "_Make default for this computer (%s) only"
 #~ msgstr "_Zrabi zmoŭčanym tolki dla hetaha kamputara (%s)"
-
-#~ msgid "Options"
-#~ msgstr "Opcyi"
 
 #~ msgid ""
 #~ "Testing the new settings. If you don't respond in %d second the previous "
@@ -3923,9 +7730,6 @@ msgstr "Pakažy opcyi dapamohi"
 #~ msgid "Beep"
 #~ msgstr "Zvanočak"
 
-#~ msgid "No sound"
-#~ msgstr "Biaz huku"
-
 #~ msgid "Sound not set for this event."
 #~ msgstr "Nie akreśleny huk dla hetaj padziei."
 
@@ -3945,9 +7749,6 @@ msgstr "Pakažy opcyi dapamohi"
 
 #~ msgid "Select sound file..."
 #~ msgstr "Abiary hukavy fajł..."
-
-#~ msgid "System Sounds"
-#~ msgstr "Systemnyja huki"
 
 #~ msgid "Set as Application Font"
 #~ msgstr "Zrabi šryftom aplikacyi"
@@ -3971,9 +7772,6 @@ msgstr "Pakažy opcyi dapamohi"
 #~ msgid "Just apply settings and quit"
 #~ msgstr "Prosta ŭžyj nałady j vyjdzi"
 
-#~ msgid "Connecting..."
-#~ msgstr "Spałučeńnie..."
-
 #~ msgid "Keyboard Accessibility Notifications"
 #~ msgstr "Nahadvańni ad dastupnaj klavijatury"
 
@@ -3993,9 +7791,6 @@ msgstr "Pakažy opcyi dapamohi"
 #~ "The theme you have selected suggests a new font. A preview of the font is "
 #~ "shown below."
 #~ msgstr "Abrany matyŭ raić novy šryft. Pieradahlad šryftu pakazany nižej."
-
-#~ msgid "_Apply font"
-#~ msgstr "Užyj _šryft"
 
 #~ msgid "Themes"
 #~ msgstr "Matyvy"

--- a/po/be@latin.po~
+++ b/po/be@latin.po~
@@ -1,0 +1,4066 @@
+# Biełaruski pierakład gnome-control-center
+# Copyright (C) 2007 Aleś Navicki
+# Distributed under the terms of gnome-control-center's license.
+# Aleś Navicki <zolak@lacinka.org>, 2007
+# Ihar Hrachyshka <ihar.hrachyshka@gmail.com>, 2007
+msgid ""
+msgstr ""
+"Project-Id-Version: control-center\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-02-25 23:01+0200\n"
+"PO-Revision-Date: 2009-02-25 23:01+0200\n"
+"Last-Translator: Alaksandar Navicki <zolak@lacinka.org>\n"
+"Language-Team: Polish <pl@li.org>\n"
+"Language: be@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "Abvodka vyjavy/etykietki"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "Šyrynia abvodki etykiety j vyjavy ŭ vaknie dyjalohu aściarohi"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "Vid aściarohi"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "Vid aściarohi"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "Knopki aściarohi"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "Knopki, bačnyja ŭ vaknie aściarohi"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "Pakažy _bolej detalaŭ"
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Place your left thumb on %s"
+msgstr "Pakładzi svoj levy adziniec na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Swipe your left thumb on %s"
+msgstr "Paciahni svaim levym adzincom pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Place your left index finger on %s"
+msgstr "Pakładzi svoj levy pakazalnik na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Swipe your left index finger on %s"
+msgstr "Paciahni svaim levym pakazalnikam pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Place your left middle finger on %s"
+msgstr "Pakładzi svoj levy siarednik na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Swipe your left middle finger on %s"
+msgstr "Paciahni svaim levym siarednikam pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Place your left ring finger on %s"
+msgstr "Pakładzi svoj levy pierścianiec na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Swipe your left ring finger on %s"
+msgstr "Paciahni svaim levym pierściancom pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Place your left little finger on %s"
+msgstr "Pakładzi svoj levy mieziniec na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Swipe your left little finger on %s"
+msgstr "Paciahni svaim levym miezincam pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Place your right thumb on %s"
+msgstr "Pakładzi svoj pravy adziniec na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Swipe your right thumb on %s"
+msgstr "Paciahni svaim pravym adzincom pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Place your right index finger on %s"
+msgstr "Pakładzi svoj pravy pakazalnik na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Swipe your right index finger on %s"
+msgstr "Paciahni svaim pravym pakazalnikam pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Place your right middle finger on %s"
+msgstr "Pakładzi svoj pravy siarednik na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Swipe your right middle finger on %s"
+msgstr "Paciahni svaim pravym siarednikam pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Place your right ring finger on %s"
+msgstr "Pakładzi svoj pravy pierścianiec na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Swipe your right ring finger on %s"
+msgstr "Paciahni svaim pravym pierściancom pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Place your right little finger on %s"
+msgstr "Pakładzi svoj pravy mieziniec na %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Swipe your right little finger on %s"
+msgstr "Paciahni svaim pravym miezincam pa %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:72
+#: ../capplets/about-me/fingerprint-strings.h:98
+msgid "Place your finger on the reader again"
+msgstr "Znoŭ pakładzi palec na čytnik"
+
+#: ../capplets/about-me/fingerprint-strings.h:74
+#: ../capplets/about-me/fingerprint-strings.h:100
+msgid "Swipe your finger again"
+msgstr "Znoŭ paciahni palcam pa čytniku"
+
+#: ../capplets/about-me/fingerprint-strings.h:77
+#: ../capplets/about-me/fingerprint-strings.h:103
+msgid "Swipe was too short, try again"
+msgstr "Zamały prociah, paŭtary jašče"
+
+#: ../capplets/about-me/fingerprint-strings.h:79
+#: ../capplets/about-me/fingerprint-strings.h:105
+msgid "Your finger was not centered, try swiping your finger again"
+msgstr "Tvoj palec nie zasiarodžany na čytniku, paŭtary prociah jašče"
+
+#: ../capplets/about-me/fingerprint-strings.h:81
+#: ../capplets/about-me/fingerprint-strings.h:107
+msgid "Remove your finger, and try swiping your finger again"
+msgstr "Prybiary palec i paŭtary prociah jašče"
+
+#: ../capplets/about-me/gnome-about-me.c:776
+msgid "Select Image"
+msgstr "Abiary vyjavu"
+
+#: ../capplets/about-me/gnome-about-me.c:778
+msgid "No Image"
+msgstr "Biez vyjavy"
+
+#: ../capplets/about-me/gnome-about-me.c:806
+#: ../capplets/appearance/appearance-desktop.c:660
+msgid "Images"
+msgstr "Vyjavy"
+
+#: ../capplets/about-me/gnome-about-me.c:810
+#: ../capplets/appearance/theme-installer.c:695
+msgid "All Files"
+msgstr "Usie fajły"
+
+#: ../capplets/about-me/gnome-about-me.c:956
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"Pry sprobie atrymańnia infarmacyi ab adrasnaj knizie adbyłasia pamyłka\n"
+"Server danych Evolution nia moža absłužyć pratakoł"
+
+#: ../capplets/about-me/gnome-about-me.c:977
+msgid "Unable to open address book"
+msgstr "Niemahčyma adčynić adrasnuju knihu"
+
+#: ../capplets/about-me/gnome-about-me.c:991
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr "Niaviadomaje ID aŭtaryzacyi, baza karystalnika moža być paškodžanaja"
+
+#: ../capplets/about-me/gnome-about-me.c:1021
+#: ../capplets/about-me/gnome-about-me.c:1023
+#, c-format
+msgid "About %s"
+msgstr "Pra %s"
+
+#: ../capplets/about-me/gnome-about-me.c:1041
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Enable _Fingerprint Login..."
+msgstr "Uklučy ŭvachod z _adbitkam palca..."
+
+#: ../capplets/about-me/gnome-about-me.c:1044
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Disable _Fingerprint Login..."
+msgstr "Vyklučy ŭvachod z _adbitkam palca..."
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "About Me"
+msgstr "Pra mianie"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "Naładžvaj asabistyja źviestki"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"Tabie nie dazvolena karystacca hetaj pryładaj. Źviarnisia da administratara "
+"hetaj systemy."
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
+msgid "The device is already in use."
+msgstr "Pryłada ŭžo zaniataja."
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:103
+msgid "An internal error occured"
+msgstr "Adbyłasia ŭnutranaja pamyłka"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:220
+msgid "Delete registered fingerprints?"
+msgstr "Vydalić zarehistravanyja adbitki palcaŭ?"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:223
+msgid "_Delete Fingerprints"
+msgstr "_Vydali adbitki palcaŭ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:230
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Chočaš vydalić zarehistravanyja adbitki palcaŭ, što vyklučyć mahčymaść "
+"uvachodu takim sposabam aŭtaryzacyi?"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:343
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:583
+msgid "Done!"
+msgstr "Zroblena!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "Nie ŭdałosia dastupicca da pryłady \"%s\""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:444
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "Nie ŭdałosia raspačać zapaminańnie adbitkaŭ dla pryłady \"%s\""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:491
+msgid "Could not access any fingerprint readers"
+msgstr "Nie ŭdałosia dastupicca da budź-jakoha čytnika adbitkaŭ palcaŭ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:492
+msgid "Please contact your system administrator for help."
+msgstr "Źviarnisia da administratara tvajoj systemy pa dapamohu."
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:518
+msgid "Enable Fingerprint Login"
+msgstr "Uklučy ŭvachod z adbitkam palca"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:534
+msgid "Select finger"
+msgstr "Abiary palec"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:555
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"Kab uklučyć mahčymaść uvachodu z adbitkam palca, treba zapisać adbitak "
+"tvajho palca z dapamohaj pryłady \"%s\"."
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:568
+msgid "Swipe finger on reader"
+msgstr "Paciahni palcam pa čytniku"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:570
+msgid "Place finger on reader"
+msgstr "Pakładzi palec na čytnik"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:1
+msgid "Left index finger"
+msgstr "Levy pakazalnik"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:2
+msgid ""
+"Left thumb\n"
+"Left middle finger\n"
+"Left ring finger\n"
+"Left little finger\n"
+"Right thumb\n"
+"Right middle finger\n"
+"Right ring finger\n"
+"Right little finger"
+msgstr ""
+"Levy adziniec\n"
+"Levy siarednik\n"
+"Levy pierścianiec\n"
+"Levy mieziniec\n"
+"Pravy adziniec\n"
+"Pravy siarednik\n"
+"Pravy pierścianiec\n"
+"Pravy mieziniec"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:10
+msgid "Other finger: "
+msgstr "Inšy palec: "
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:11
+msgid "Right index finger"
+msgstr "Pravy pakazalnik"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:12
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"Adbitak tvajho palca zapisany. Ciapier ty zmožaš uvajści ŭ systemu z "
+"dapamohaj čytnika."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+msgid "<b>Email</b>"
+msgstr "<b>E-mail</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+msgid "<b>Home</b>"
+msgstr "<b>Dom</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Kamunikatary</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Job</b>"
+msgstr "<b>Praca</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Telephone</b>"
+msgstr "<b>Telefon</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Web</b>"
+msgstr "<b>Sieciva</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Work</b>"
+msgstr "<b>Praca</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Źmiani parol</span>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "A_ddress:"
+msgstr "A_dras:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_ssistant:"
+msgstr "A_systent:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "Address"
+msgstr "Adras"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "C_ity:"
+msgstr "H_orad:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "C_ompany:"
+msgstr "_Firma:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "Cale_ndar:"
+msgstr "_Kalandar:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "Change Passwo_rd..."
+msgstr "Źmiani _parol..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Change pa_ssword"
+msgstr "Źmiani pa_rol"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change password"
+msgstr "Źmiani parol"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Ci_ty:"
+msgstr "H_orad:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Co_untry:"
+msgstr "K_raina:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Contact"
+msgstr "Kantakt"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Cou_ntry:"
+msgstr "_Kraina:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Current _password:"
+msgstr "Dziejny _parol:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "Full Name"
+msgstr "Imia j proźvišča"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "Hom_e:"
+msgstr "Do_m:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P.O. _box:"
+msgstr "_Paštovaja skrynka:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "P._O. box:"
+msgstr "Pašt_ovaja skrynka:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "Personal Info"
+msgstr "Persanalnyja źviestki"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#: ../capplets/about-me/gnome-about-me-password.c:938
+msgid ""
+"Please type your password again in the <b>Retype new password</b> field."
+msgstr "Uviadzi svoj parol jašče raz u poli <b>Uviadzi parol znoŭ</b>."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Select your photo"
+msgstr "Abiary fatahrafiju"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "State/Pro_vince:"
+msgstr "R_ehijon:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid ""
+"To change your password, enter your current password in the field below and "
+"click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for "
+"verification and click <b>Change password</b>."
+msgstr ""
+"Kab źmianić parol, uviadzi dziejny parol u poli nižej i klikni <b>Aŭtaryzuj</"
+"b>.\n"
+"Paśla aŭtaryzacyi ŭviadzi novy parol, uviadzi jaho znoŭ dziela veryfikacyi i "
+"klikni <b>Źmiani parol</b>."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "User name:"
+msgstr "Nazva karystalnika:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "Web _log:"
+msgstr "B_log:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "Wor_k:"
+msgstr "Pra_ca:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "Work _fax:"
+msgstr "_Faks na pracy:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "Zip/_Postal code:"
+msgstr "Paštovy _indeks:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Address:"
+msgstr "_Adras:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Authenticate"
+msgstr "_Aŭtaryzuj"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Department:"
+msgstr "_Addzieł:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_Groupwise:"
+msgstr "_Groupwise:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Home page:"
+msgstr "_Chatniaja staronka:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Home:"
+msgstr "Do_m:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_Jabber:"
+msgstr "_Jabber:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Manager:"
+msgstr "_Kiraŭnik:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Mobile:"
+msgstr "M_abilny telefon:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_New password:"
+msgstr "_Novy parol:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Profession:"
+msgstr "_Prafesija:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:55
+msgid "_Retype new password:"
+msgstr "_Uviadzi parol jašče raz:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:56
+msgid "_State/Province:"
+msgstr "Rehijo_n:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:57
+msgid "_Title:"
+msgstr "P_asada:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:58
+msgid "_Work:"
+msgstr "_Praca:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:59
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:60
+msgid "_Zip/Postal code:"
+msgstr "Paštovy _indeks:"
+
+#: ../capplets/about-me/gnome-about-me-password.c:162
+msgid "Child exited unexpectedly"
+msgstr "Praces naščadka niečakana zakončyŭsia"
+
+#: ../capplets/about-me/gnome-about-me-password.c:297
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr "Niamahčyma začynić kanał I/O backend_stdin: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:310
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr "Niemahčyma začynić kanał I/O backend_stdout: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:409
+msgid "Authenticated!"
+msgstr "Aŭtaryzacyja ŭdałasia!"
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:475
+#: ../capplets/about-me/gnome-about-me-password.c:551
+msgid ""
+"Your password has been changed since you initially authenticated! Please re-"
+"authenticate."
+msgstr ""
+"Tvoj parol byŭ źmienieny paśla pačatkovaj aŭtaryzacyi! Kali łaska, paŭtary "
+"aŭtaryzacyju."
+
+#: ../capplets/about-me/gnome-about-me-password.c:477
+msgid "That password was incorrect."
+msgstr "Parol byŭ niapravilny."
+
+#: ../capplets/about-me/gnome-about-me-password.c:524
+msgid "Your password has been changed."
+msgstr "Tvoj parol byŭ źmienieny."
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:534
+#, c-format
+msgid "System error: %s."
+msgstr "Systemnaja pamyłka: %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:537
+msgid "The password is too short."
+msgstr "Hety parol nadta karotki."
+
+#: ../capplets/about-me/gnome-about-me-password.c:540
+msgid "The password is too simple."
+msgstr "Hety parol nadta prosty."
+
+#: ../capplets/about-me/gnome-about-me-password.c:543
+msgid "The old and new passwords are too similar."
+msgstr "Novy parol nadta padobny da staroha."
+
+#: ../capplets/about-me/gnome-about-me-password.c:545
+msgid "The new password must contain numeric or special character(s)."
+msgstr "U novym paroli musiać być ličby albo admysłovyja znaki."
+
+#: ../capplets/about-me/gnome-about-me-password.c:548
+msgid "The old and new passwords are the same."
+msgstr "Novy parol taki ž, jak i stary."
+
+#. translators: Unable to launch <program>: <error message>
+#: ../capplets/about-me/gnome-about-me-password.c:820
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr "Niemahčyma ŭruchomić %s: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:824
+msgid "Unable to launch backend"
+msgstr "Niemahčyma ŭruchomić padtrymku"
+
+#: ../capplets/about-me/gnome-about-me-password.c:825
+msgid "A system error has occurred"
+msgstr "Adbyłasia systemnaja pamyłka"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:845
+msgid "Checking password..."
+msgstr "Pravierka parolu..."
+
+#: ../capplets/about-me/gnome-about-me-password.c:932
+msgid "Click <b>Change password</b> to change your password."
+msgstr "Klikni na <b>Źmiani parol</b>, kab źmianić jaho."
+
+#: ../capplets/about-me/gnome-about-me-password.c:935
+msgid "Please type your password in the <b>New password</b> field."
+msgstr "Uviadzi parol u poli <b>Novy parol</b>."
+
+#: ../capplets/about-me/gnome-about-me-password.c:941
+msgid "The two passwords are not equal."
+msgstr "Paroli roźniacca miž saboj."
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Assistive Technologies</b>"
+msgstr "<b>Technalohii dastupnaści</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Preferences</b>"
+msgstr "<b>Nałady</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid "Accessible Lo_gin"
+msgstr "_Dastupny ŭvachod"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technologies Preferences"
+msgstr "Nałady technalohij dastupnaści"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid ""
+"Changes to enable assistive technologies will not take effect until your "
+"next log in."
+msgstr ""
+"Źmieny dla ŭklučeńnia technalohij dastupnaści nie paŭpłyvajuć na dziejnyja "
+"nałady da nastupnaj tvajoj aŭtaryzacyi ŭ systemie."
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Close and _Log Out"
+msgstr "Začyni j vy_jdzi"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "Jump to Preferred Applications dialog"
+msgstr "Pieraskoč da vakna \"Pažadanyja aplikacyi\""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "Jump to the Accessible Login dialog"
+msgstr "Pieraskoč da vakna \"Dastupny ŭvachod\""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr "Pieraskoč da vakna \"Dastupnaść klavijatury\""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "Jump to the Mouse Accessibility dialog"
+msgstr "Pieraskoč da vakna \"Dastupnaść myšy\""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
+msgid "_Enable assistive technologies"
+msgstr "Uklučy technalohii dastupnaści"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
+msgid "_Keyboard Accessibility"
+msgstr "Dastupnaść _klavijatury"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
+msgid "_Mouse Accessibility"
+msgstr "Dastupnaść _myšy"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
+msgid "_Preferred Applications"
+msgstr "_Pažadanyja aplikacyi"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technologies"
+msgstr "Technalohii dastupnaści"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Choose which accessibility features to enable when you log in"
+msgstr ""
+"Vybiery, jakija technalohii dastupnaśći treba ŭklučyć pry ŭvachodzie ŭ "
+"systemu"
+
+#: ../capplets/appearance/appearance-desktop.c:628
+msgid "Add Wallpaper"
+msgstr "Dadaj špaleru"
+
+#: ../capplets/appearance/appearance-desktop.c:664
+msgid "All files"
+msgstr "Usie fajły"
+
+#: ../capplets/appearance/appearance-font.c:494
+msgid "Font may be too large"
+msgstr "Šryft moža być nadta vialikim"
+
+#: ../capplets/appearance/appearance-font.c:498
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Abrany šryft maje vyšyniu %d punkt, i moža być ciažka efektyŭna jaho "
+"vykarystoŭvać u kamputary. Rekamendujecca abrać pamier, mienšy za %d."
+msgstr[1] ""
+"Abrany šryft maje vyšyniu %d punkty, i moža być ciažka efektyŭna jaho "
+"vykarystoŭvać u kamputary. Rekamendujecca abrać pamier, mienšy za %d."
+msgstr[2] ""
+"Abrany šryft maje vyšyniu %d punktaŭ, i moža być ciažka efektyŭna jaho "
+"vykarystoŭvać u kamputary. Rekamendujecca abrać pamier, mienšy za %d."
+
+#: ../capplets/appearance/appearance-font.c:511
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Abrany šryft maje vyšyniu %d punkt, i moža być ciažka efektyŭna jaho "
+"vykarystoŭvać u kamputary. Rekamendujecca abrać šryft mienšaha pamieru."
+msgstr[1] ""
+"Abrany šryft maje vyšyniu %d punkty, i moža być ciažka efektyŭna jaho "
+"vykarystoŭvać u kamputary. Rekamendujecca abrać šryft mienšaha pamieru."
+msgstr[2] ""
+"Abrany šryft maje vyšyniu %d punktaŭ, i moža być ciažka efektyŭna jaho "
+"vykarystoŭvać u kamputary. Rekamendujecca abrać šryft mienšaha pamieru."
+
+#: ../capplets/appearance/appearance-font.c:534
+msgid "Use previous font"
+msgstr "Užyj papiaredni šryft"
+
+#: ../capplets/appearance/appearance-font.c:536
+msgid "Use selected font"
+msgstr "Užyj zaznačany šryft"
+
+#: ../capplets/appearance/appearance-main.c:124
+msgid "Specify the filename of a theme to install"
+msgstr "Akreśl nazvu fajłu matyvu, jaki treba zainstalavać"
+
+#: ../capplets/appearance/appearance-main.c:125
+msgid "filename"
+msgstr "nazva fajłu"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/appearance/appearance-main.c:132
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr ""
+"Akreśl nazvu staronki, jakuju treba pakazać (theme|background|fonts|"
+"interface)"
+
+#: ../capplets/appearance/appearance-main.c:133
+#: ../capplets/default-applications/gnome-da-capplet.c:897
+#: ../capplets/mouse/gnome-mouse-properties.c:442
+msgid "page"
+msgstr "staronka"
+
+#: ../capplets/appearance/appearance-main.c:140
+msgid "[WALLPAPER...]"
+msgstr "[ŠPALERA...]"
+
+#: ../capplets/appearance/appearance-style.c:173
+#: ../capplets/common/gnome-theme-info.c:445
+#: ../capplets/common/gnome-theme-info.c:637
+msgid "Default Pointer"
+msgstr "Zmoŭčany kursor"
+
+#: ../capplets/appearance/appearance-style.c:235
+#: ../capplets/appearance/appearance-themes.c:687
+msgid "Install"
+msgstr "Zainstaluj"
+
+#: ../capplets/appearance/appearance-style.c:255
+#: ../capplets/common/gnome-theme-info.c:1647
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme engine "
+"'%s' is not installed."
+msgstr ""
+"Hety matyŭ nia budzie vyhladać, jak naležyć, bo nie zainstalavana patrebnaha "
+"ruchavika matyvaŭ GTK+ \"%s\"."
+
+#: ../capplets/appearance/appearance-themes.c:675
+msgid "Apply Background"
+msgstr "Užyj fon"
+
+#: ../capplets/appearance/appearance-themes.c:679
+msgid "Apply Font"
+msgstr "Užyj šryft"
+
+#: ../capplets/appearance/appearance-themes.c:683
+msgid "Revert Font"
+msgstr "Viarni šryft"
+
+#: ../capplets/appearance/appearance-themes.c:713
+msgid ""
+"The current theme suggests a background and a font. Also, the last applied "
+"font suggestion can be reverted."
+msgstr ""
+"Dziejny matyŭ raić peŭny fon i šryft. Zaŭsiody možna viarnuć papiaredni "
+"šryft."
+
+#: ../capplets/appearance/appearance-themes.c:715
+msgid ""
+"The current theme suggests a background. Also, the last applied font "
+"suggestion can be reverted."
+msgstr "Dziejny matyŭ raić peŭny fon. Zaŭsiody možna viarnuć papiaredni šryft."
+
+#: ../capplets/appearance/appearance-themes.c:717
+msgid "The current theme suggests a background and a font."
+msgstr "Dziejny matyŭ raić peŭny fon i šryft."
+
+#: ../capplets/appearance/appearance-themes.c:719
+msgid ""
+"The current theme suggests a font. Also, the last applied font suggestion "
+"can be reverted."
+msgstr "Dziejny matyŭ raić peŭny šryft. Zaŭsiody možna viarnuć papiaredni."
+
+#: ../capplets/appearance/appearance-themes.c:721
+msgid "The current theme suggests a background."
+msgstr "Dziejny matyŭ raić peŭny fon."
+
+#: ../capplets/appearance/appearance-themes.c:723
+msgid "The last applied font suggestion can be reverted."
+msgstr "Zaŭsiody možna viarnuć papiaredni šryft."
+
+#: ../capplets/appearance/appearance-themes.c:725
+msgid "The current theme suggests a font."
+msgstr "Dziejny matyŭ raić peŭny šryft."
+
+#: ../capplets/appearance/appearance-themes.c:1046
+#: ../capplets/default-applications/gnome-da-capplet.c:648
+msgid "Custom"
+msgstr "Admysłovy"
+
+#: ../capplets/appearance/data/appearance.glade.h:1
+msgid "<b>C_olors</b>"
+msgstr "<b>K_olery</b>"
+
+# Mechanizm papraŭleńnia jakaści druku na aparatury ź nizkaj padzielnaj zdolnaściu. Adpaviednika niama, pakinuŭ jak jość. Prapanuju heta pryniać tak jak i widget.
+#. font hinting
+#: ../capplets/appearance/data/appearance.glade.h:3
+msgid "<b>Hinting</b>"
+msgstr "<b>Hinting</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:4
+msgid "<b>Menus and Toolbars</b>"
+msgstr "<b>Paneli menu j pryładździa</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:5
+msgid "<b>Preview</b>"
+msgstr "<b>Pieradahlad</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:6
+msgid "<b>Rendering</b>"
+msgstr "<b>Vyjaŭleńnie</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:7
+msgid "<b>Smoothing</b>"
+msgstr "<b>Vyhładžvańnie</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:8
+msgid "<b>Subpixel Order</b>"
+msgstr "<b>Čarhovaść subpikselaŭ</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:9
+msgid "<b>_Desktop Background</b>"
+msgstr "<b>_Fon stała</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:10
+msgid "Appearance Preferences"
+msgstr "Nałady vyhladu"
+
+#: ../capplets/appearance/data/appearance.glade.h:11
+msgid "Background"
+msgstr "Fon"
+
+#: ../capplets/appearance/data/appearance.glade.h:12
+msgid "Best _shapes"
+msgstr "_Najlepšyja kštałty"
+
+#: ../capplets/appearance/data/appearance.glade.h:13
+msgid "Best co_ntrast"
+msgstr "Najlepšy _kantrast"
+
+#: ../capplets/appearance/data/appearance.glade.h:14
+msgid "C_ustomize..."
+msgstr "_Źmiani..."
+
+#: ../capplets/appearance/data/appearance.glade.h:15
+msgid "C_ut"
+msgstr "_Vytni"
+
+#: ../capplets/appearance/data/appearance.glade.h:16
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr "Źmiena matyvu kursora paŭpłyvaje paśla nastupnaha ŭvachodu."
+
+#: ../capplets/appearance/data/appearance.glade.h:17
+msgid "Colors"
+msgstr "Kolery"
+
+#: ../capplets/appearance/data/appearance.glade.h:18
+msgid "Controls"
+msgstr "Elementy kiravańnia"
+
+#: ../capplets/appearance/data/appearance.glade.h:19
+msgid "Customize Theme"
+msgstr "Źmiani matyŭ"
+
+#: ../capplets/appearance/data/appearance.glade.h:20
+msgid "D_etails..."
+msgstr "_Detali..."
+
+#: ../capplets/appearance/data/appearance.glade.h:21
+msgid "Des_ktop font:"
+msgstr "Šryft dla _stała:"
+
+#: ../capplets/appearance/data/appearance.glade.h:22
+msgid "Edit"
+msgstr "Redahuj"
+
+#: ../capplets/appearance/data/appearance.glade.h:23
+msgid "Font Rendering Details"
+msgstr "Detali vyjaŭleńnia šryftoŭ"
+
+#: ../capplets/appearance/data/appearance.glade.h:24
+msgid "Fonts"
+msgstr "Šryfty"
+
+#: ../capplets/appearance/data/appearance.glade.h:25
+msgid "Gra_yscale"
+msgstr "Adcieńni _šeraha"
+
+#: ../capplets/appearance/data/appearance.glade.h:26
+msgid "Icons"
+msgstr "Ikony"
+
+#: ../capplets/appearance/data/appearance.glade.h:27
+msgid "Interface"
+msgstr "Interfejs"
+
+#: ../capplets/appearance/data/appearance.glade.h:28
+msgid "Large"
+msgstr "Vialiki"
+
+#: ../capplets/appearance/data/appearance.glade.h:29
+msgid "N_one"
+msgstr "_Niama"
+
+#: ../capplets/appearance/data/appearance.glade.h:30
+msgid "New File"
+msgstr "Novy fajł"
+
+#: ../capplets/appearance/data/appearance.glade.h:31
+msgid "Open File"
+msgstr "Adčyni fajł"
+
+#: ../capplets/appearance/data/appearance.glade.h:32
+msgid "Open a dialog to specify the color"
+msgstr "Adčyni vakno vybaru koleru"
+
+#: ../capplets/appearance/data/appearance.glade.h:33
+msgid "Pointer"
+msgstr "Kursor"
+
+#: ../capplets/appearance/data/appearance.glade.h:34
+msgid "R_esolution:"
+msgstr "Pa_miery:"
+
+#: ../capplets/appearance/data/appearance.glade.h:35
+msgid "Save File"
+msgstr "Zapišy fajł"
+
+#: ../capplets/appearance/data/appearance.glade.h:36
+msgid "Save Theme As..."
+msgstr "Za_pišy matyŭ jak..."
+
+#: ../capplets/appearance/data/appearance.glade.h:37
+msgid "Save _As..."
+msgstr "Za_pišy jak..."
+
+#: ../capplets/appearance/data/appearance.glade.h:38
+msgid "Save _background image"
+msgstr "Zapišy _fonavuju vyjavu"
+
+#: ../capplets/appearance/data/appearance.glade.h:39
+msgid "Show _icons in menus"
+msgstr "Pakazvaj _ikony ŭ menu"
+
+#: ../capplets/appearance/data/appearance.glade.h:40
+msgid "Small"
+msgstr "Mały"
+
+#: ../capplets/appearance/data/appearance.glade.h:41
+msgid ""
+"Solid color\n"
+"Horizontal gradient\n"
+"Vertical gradient"
+msgstr ""
+"Adnastajny koler\n"
+"Haryzantalny hradyjent\n"
+"Vertykalny hradyjent"
+
+#: ../capplets/appearance/data/appearance.glade.h:44
+msgid "Sub_pixel (LCDs)"
+msgstr "_Subpikselnaje (ekrany LCD)"
+
+#: ../capplets/appearance/data/appearance.glade.h:45
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "Sub_pikselnaje vyhładžvańnie (ekrany LCD)"
+
+#: ../capplets/appearance/data/appearance.glade.h:46
+msgid "Text"
+msgstr "Tekst"
+
+#: ../capplets/appearance/data/appearance.glade.h:47
+msgid ""
+"Text below items\n"
+"Text beside items\n"
+"Icons only\n"
+"Text only"
+msgstr ""
+"Tekst nižej elementaŭ\n"
+"Tekst pobač z elementami\n"
+"Tolki ikony\n"
+"Tolki tekst"
+
+#: ../capplets/appearance/data/appearance.glade.h:51
+msgid "The current controls theme does not support color schemes."
+msgstr "Dziejny matyŭ elementaŭ kiravańnia nie absłuhoŭvaje schiemaŭ koleraŭ."
+
+#: ../capplets/appearance/data/appearance.glade.h:52
+msgid "Theme"
+msgstr "Matyŭ"
+
+#: ../capplets/appearance/data/appearance.glade.h:53
+msgid ""
+"Tiled\n"
+"Zoom\n"
+"Centered\n"
+"Scaled\n"
+"Fill screen"
+msgstr ""
+"Pa susiedztvie\n"
+"Maštabavany\n"
+"Centravany\n"
+"Źmienieny pamier\n"
+"Zapaŭnieńnie ekranu"
+
+#: ../capplets/appearance/data/appearance.glade.h:58
+msgid "Toolbar _button labels:"
+msgstr "_Podpisy dla knopak paneli pryładździa:"
+
+#. vertical hinting, pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:60
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/appearance/data/appearance.glade.h:61
+msgid "Window Border"
+msgstr "Kraj vakna"
+
+#: ../capplets/appearance/data/appearance.glade.h:62
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
+msgid "_Add..."
+msgstr "_Dadaj..."
+
+#: ../capplets/appearance/data/appearance.glade.h:63
+msgid "_Application font:"
+msgstr "Šryft _aplikacyj:"
+
+#. pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:65
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/appearance/data/appearance.glade.h:66
+msgid "_Copy"
+msgstr "S_kapijuj"
+
+#: ../capplets/appearance/data/appearance.glade.h:67
+msgid "_Description:"
+msgstr "_Apisańnie:"
+
+#: ../capplets/appearance/data/appearance.glade.h:68
+msgid "_Document font:"
+msgstr "Šryft _dakumentaŭ:"
+
+#: ../capplets/appearance/data/appearance.glade.h:69
+msgid "_Editable menu shortcut keys"
+msgstr "_Źmianialnyja klavišy skarotaŭ menu"
+
+#: ../capplets/appearance/data/appearance.glade.h:70
+msgid "_File"
+msgstr "_Fajł"
+
+#: ../capplets/appearance/data/appearance.glade.h:71
+msgid "_Fixed width font:"
+msgstr "Šryft s_tałaj šyryni:"
+
+#: ../capplets/appearance/data/appearance.glade.h:72
+msgid "_Full"
+msgstr "_Poŭny"
+
+#: ../capplets/appearance/data/appearance.glade.h:73
+msgid "_Input boxes:"
+msgstr "_Pali ŭvodu:"
+
+#: ../capplets/appearance/data/appearance.glade.h:74
+msgid "_Install..."
+msgstr "Za_instaluj..."
+
+#: ../capplets/appearance/data/appearance.glade.h:75
+msgid "_Medium"
+msgstr "Siar_edni"
+
+#: ../capplets/appearance/data/appearance.glade.h:76
+msgid "_Monochrome"
+msgstr "_Monachromnaje"
+
+#: ../capplets/appearance/data/appearance.glade.h:77
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:5
+msgid "_Name:"
+msgstr "_Nazva:"
+
+#: ../capplets/appearance/data/appearance.glade.h:78
+msgid "_New"
+msgstr "_Novy"
+
+#: ../capplets/appearance/data/appearance.glade.h:79
+msgid "_None"
+msgstr "_Niama"
+
+#: ../capplets/appearance/data/appearance.glade.h:80
+msgid "_Open"
+msgstr "_Adčyni"
+
+#: ../capplets/appearance/data/appearance.glade.h:81
+msgid "_Paste"
+msgstr "Uk_lej"
+
+#: ../capplets/appearance/data/appearance.glade.h:82
+msgid "_Print"
+msgstr "Vy_drukuj"
+
+#: ../capplets/appearance/data/appearance.glade.h:83
+msgid "_Quit"
+msgstr "_Vyjdzi"
+
+#. pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:85
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:86
+msgid "_Reset to Defaults"
+msgstr "V_iarni zmoŭčanaje"
+
+#: ../capplets/appearance/data/appearance.glade.h:87
+msgid "_Save"
+msgstr "_Zapišy"
+
+#: ../capplets/appearance/data/appearance.glade.h:88
+msgid "_Selected items:"
+msgstr "_Zaznačanyja elementy:"
+
+#: ../capplets/appearance/data/appearance.glade.h:89
+msgid "_Size:"
+msgstr "_Pamier:"
+
+#: ../capplets/appearance/data/appearance.glade.h:90
+msgid "_Slight"
+msgstr "_Lohki"
+
+#: ../capplets/appearance/data/appearance.glade.h:91
+msgid "_Style:"
+msgstr "_Styl:"
+
+#: ../capplets/appearance/data/appearance.glade.h:92
+msgid "_Tooltips:"
+msgstr "_Padkazki:"
+
+#. vertical hinting, pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:94
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:95
+msgid "_Window title font:"
+msgstr "_Šryft zahałoŭku vakna:"
+
+#: ../capplets/appearance/data/appearance.glade.h:96
+msgid "_Windows:"
+msgstr "Vo_kny:"
+
+#: ../capplets/appearance/data/appearance.glade.h:97
+msgid "dots per inch"
+msgstr "punktaŭ na cal"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr "Vyhlad"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr "Źmiani vyhlad stała"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr "Instaluje pakunki matyvaŭ roznych častak asiarodździa"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr "Instalatar matyvaŭ"
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr "Pakunak matyvu GNOME"
+
+#: ../capplets/appearance/gnome-wp-info.c:50
+msgid "No Desktop Background"
+msgstr "Biaz fonu stała"
+
+#: ../capplets/appearance/gnome-wp-item.c:208
+msgid "Slide Show"
+msgstr "Slideshow"
+
+#. translators: <b>wallpaper name</b>
+#. * mime type, x pixel(s) by y pixel(s)
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:216
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %d %s by %d %s\n"
+"Folder: %s"
+msgstr ""
+"<b>%s</b>\n"
+"%s, %d %s na %d %s\n"
+"Kataloh: %s"
+
+#: ../capplets/appearance/gnome-wp-item.c:222
+#: ../capplets/appearance/gnome-wp-item.c:224
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "piksel"
+msgstr[1] "pikseli"
+msgstr[2] "pikselaŭ"
+
+#: ../capplets/appearance/theme-installer.c:174
+#: ../capplets/appearance/theme-installer.c:224
+msgid "Cannot install theme"
+msgstr "Niemahčyma zainstalavać matyŭ"
+
+#: ../capplets/appearance/theme-installer.c:176
+#, c-format
+msgid "The %s utility is not installed."
+msgstr "Pryłada %s nie zainstalavanaja."
+
+#: ../capplets/appearance/theme-installer.c:226
+msgid "There was a problem while extracting the theme."
+msgstr "Uźnikła prablema ŭ časie raspakoŭvańnia matyvu."
+
+#: ../capplets/appearance/theme-installer.c:249
+msgid "There was an error installing the selected file"
+msgstr "U časie instalavańnia zaznačanaha fajłu ŭźnikła pamyłka"
+
+#: ../capplets/appearance/theme-installer.c:250
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme."
+msgstr "\"%s\" nie padobny na pravilny matyŭ."
+
+#: ../capplets/appearance/theme-installer.c:251
+#, c-format
+msgid ""
+"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
+"you need to compile."
+msgstr ""
+"\"%s\" nie padobny na pravilny matyŭ. Heta moža być prahramny matyŭ, jaki "
+"treba skampilavać."
+
+#: ../capplets/appearance/theme-installer.c:354
+#, c-format
+msgid "Installation for theme \"%s\" failed."
+msgstr "Pamyłka instalacyi matyvu \"%s\"."
+
+#: ../capplets/appearance/theme-installer.c:393
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr "Matyŭ \"%s\" zainstalavany."
+
+#: ../capplets/appearance/theme-installer.c:398
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr "Ty chočaš užyć matyŭ ciapier ci pakinuć dziejny matyŭ?"
+
+#: ../capplets/appearance/theme-installer.c:400
+msgid "Keep Current Theme"
+msgstr "Pakiń dziejny matyŭ"
+
+#: ../capplets/appearance/theme-installer.c:402
+msgid "Apply New Theme"
+msgstr "Užyj novy matyŭ"
+
+#: ../capplets/appearance/theme-installer.c:446
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "Matyŭ GNOME %s pravilna zainstalavany"
+
+#: ../capplets/appearance/theme-installer.c:505
+msgid "Failed to create temporary directory"
+msgstr "Niemahčyma stvaryć časovy kataloh"
+
+#: ../capplets/appearance/theme-installer.c:568
+msgid "New themes have been successfully installed."
+msgstr "Novyja matyvy paśpiachova zainstalavanyja."
+
+#: ../capplets/appearance/theme-installer.c:593
+msgid "No theme file location specified to install"
+msgstr "Nie padadziena pałažeńnia fajłu matyvu, jaki treba zainstalavać"
+
+#: ../capplets/appearance/theme-installer.c:614
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"Niedastatkova dazvołu, kab zainstalavać matyŭ u:\n"
+"%s"
+
+#: ../capplets/appearance/theme-installer.c:684
+msgid "Select Theme"
+msgstr "Abiary matyŭ"
+
+#: ../capplets/appearance/theme-installer.c:688
+msgid "Theme Packages"
+msgstr "Pakunki matyvaŭ"
+
+#: ../capplets/appearance/theme-save.c:93
+#, c-format
+msgid "Theme name must be present"
+msgstr "Matyŭ musić mieć nazvu"
+
+#: ../capplets/appearance/theme-save.c:156
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Taki matyŭ užo isnuje. Chočaš zamianić jaho?"
+
+#: ../capplets/appearance/theme-save.c:157
+#: ../capplets/common/file-transfer-dialog.c:450
+msgid "_Overwrite"
+msgstr "_Zamiani"
+
+#: ../capplets/appearance/theme-util.c:75
+msgid "Would you like to delete this theme?"
+msgstr "Ci chočaš vydalić hety matyŭ?"
+
+#: ../capplets/appearance/theme-util.c:125
+msgid "Theme cannot be deleted"
+msgstr "Niemahčyma vydalić matyŭ"
+
+#: ../capplets/appearance/theme-util.c:252
+msgid "Could not install theme engine"
+msgstr "Niemahčyma zainstalavać matyŭ"
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"Niemahčyma ŭklučyć kiraŭnika naładaŭ – \"gnome-settings-daemon\".\n"
+"Biaz spraŭnaha kiraŭnika naładaŭ GNOME peŭnyja nałady mohuć nia dziejničać. "
+"Heta moža śviedčyć ab prablemie z Bonobo albo ź inšym kiraŭnikom naładaŭ "
+"(napr. KDE), jaki kanfliktuje z kiraŭnikom GNOME."
+
+#: ../capplets/common/capplet-stock-icons.c:66
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "Niemahčyma zahruzić standartnuju ikonu '%s'\n"
+
+#: ../capplets/common/capplet-util.c:88
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Padčas pakazu dapamohi adbyłasia pamyłka: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:98
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "Kapijavańnie fajłu: %u z %u"
+
+#: ../capplets/common/file-transfer-dialog.c:145
+#, c-format
+msgid "Copying '%s'"
+msgstr "Kapijavańnie \"%s\""
+
+#: ../capplets/common/file-transfer-dialog.c:185
+#: ../capplets/common/file-transfer-dialog.c:312
+msgid "Copying files"
+msgstr "Kapijavańnie fajłaŭ"
+
+#: ../capplets/common/file-transfer-dialog.c:224
+msgid "Parent Window"
+msgstr "Baćkoŭskaje vakno"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Parent window of the dialog"
+msgstr "Baćkoŭskaje vakno dla vakna dyjalohu"
+
+#: ../capplets/common/file-transfer-dialog.c:231
+msgid "From URI"
+msgstr "Z URI"
+
+#: ../capplets/common/file-transfer-dialog.c:232
+msgid "URI currently transferring from"
+msgstr "URI ciapier zabirajecca z"
+
+#: ../capplets/common/file-transfer-dialog.c:239
+msgid "To URI"
+msgstr "Da URI"
+
+#: ../capplets/common/file-transfer-dialog.c:240
+msgid "URI currently transferring to"
+msgstr "URI ciapier pieradajecca da"
+
+#: ../capplets/common/file-transfer-dialog.c:247
+msgid "Fraction completed"
+msgstr "Častka zakončanaja"
+
+#: ../capplets/common/file-transfer-dialog.c:248
+msgid "Fraction of transfer currently completed"
+msgstr "Častka pieradačy zakončanaja"
+
+#: ../capplets/common/file-transfer-dialog.c:255
+msgid "Current URI index"
+msgstr "Indeks dziejnaha URI"
+
+#: ../capplets/common/file-transfer-dialog.c:256
+msgid "Current URI index - starts from 1"
+msgstr "Indeks dziejnaha URI (ličačy ad 1)"
+
+#: ../capplets/common/file-transfer-dialog.c:263
+msgid "Total URIs"
+msgstr "Poŭnaja kolkaść URI"
+
+#: ../capplets/common/file-transfer-dialog.c:264
+msgid "Total number of URIs"
+msgstr "Poŭnaja kolkaść URI"
+
+#: ../capplets/common/file-transfer-dialog.c:444
+#, c-format
+msgid "File '%s' already exists. Do you want to overwrite it?"
+msgstr "Fajł \"%s\" užo isnuje. Chočaš zamianić jaho?"
+
+#: ../capplets/common/file-transfer-dialog.c:447
+msgid "_Skip"
+msgstr "_Prapuści"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Overwrite _All"
+msgstr "Zamiani _ŭsio"
+
+#: ../capplets/common/gconf-property-editor.c:134
+msgid "Key"
+msgstr "Kluč"
+
+#: ../capplets/common/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr "Kluč GConfa, da jakoha dałučany hety redaktar ułaścivaściaŭ"
+
+#: ../capplets/common/gconf-property-editor.c:141
+msgid "Callback"
+msgstr "Advarotny vyklik"
+
+#: ../capplets/common/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+"Funkcyja, vyklikanaja, kali budzie źmienienaja vartaść, źviazanaja z hetym "
+"klučom"
+
+#: ../capplets/common/gconf-property-editor.c:147
+msgid "Change set"
+msgstr "Nabor źmienaŭ"
+
+#: ../capplets/common/gconf-property-editor.c:148
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"Nabor źmienaŭ GConfa, u jakim źmieščanyja źviestki, dasyłanyja klijentu "
+"GConfa padčas prymianieńnia"
+
+#: ../capplets/common/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr "Vyklikanaja funkcyja kanversii na widget"
+
+#: ../capplets/common/gconf-property-editor.c:154
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "Funkcyja, vyklikanaja pierad kanversijaj źviestak z GConfa na widget"
+
+#: ../capplets/common/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr "Vyklikanaja funkcyja kanversii z widgetu"
+
+#: ../capplets/common/gconf-property-editor.c:160
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr "Funkcyja, vyklikanaja pierad kanversijaj źviestak z widgetu na GConf"
+
+#: ../capplets/common/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "Kiravańnie UI"
+
+#: ../capplets/common/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr "Abjekt, jaki kantraluje ŭłaścivaść (zvyčajna widget)"
+
+#: ../capplets/common/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr "Źviestki abjektu redaktara ŭłaścivaściaŭ"
+
+#: ../capplets/common/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr "Asablivyja źviestki, vymahanyja admysłovym redaktaram ułaścivaściaŭ"
+
+#: ../capplets/common/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr ""
+"Funkcyja, vyklikanaja dziela vyzvaleńnia źviestak redaktara ŭłaścivaściaŭ"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Funkcyja, vyklikanaja pierad vyzvaleńniem źviestak ad abjektu redaktara "
+"ŭłaścivaściaŭ"
+
+#: ../capplets/common/gconf-property-editor.c:1404
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Niemahčyma znajści fajł \"%s\".\n"
+"\n"
+"Pierakanajsia, što fajł isnuje, i pasprabuj znoŭ, albo abiary inšuju "
+"fonavuju vyjavu."
+
+#: ../capplets/common/gconf-property-editor.c:1412
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Ja nia viedaju, jak adčynić fajł \"%s\".\n"
+"Mahčyma, što vyjavy hetaha typu nie absłuhoŭvajucca.\n"
+"\n"
+"Abiary inšy fajł vyjavy."
+
+#: ../capplets/common/gconf-property-editor.c:1532
+msgid "Please select an image."
+msgstr "Abiary vyjavu."
+
+#: ../capplets/common/gconf-property-editor.c:1537
+msgid "_Select"
+msgstr "_Abiary"
+
+#: ../capplets/common/gnome-theme-info.c:638
+msgid "Default Pointer - Current"
+msgstr "Zmoŭčany kursor – dziejny"
+
+#: ../capplets/common/gnome-theme-info.c:642
+msgid "White Pointer"
+msgstr "Bieły kursor"
+
+#: ../capplets/common/gnome-theme-info.c:643
+msgid "White Pointer - Current"
+msgstr "Bieły kursor – dziejny"
+
+#: ../capplets/common/gnome-theme-info.c:647
+msgid "Large Pointer"
+msgstr "Vialiki kursor"
+
+#: ../capplets/common/gnome-theme-info.c:648
+msgid "Large Pointer - Current"
+msgstr "Vialiki kursor – dziejny"
+
+#: ../capplets/common/gnome-theme-info.c:652
+msgid "Large White Pointer - Current"
+msgstr "Vialiki bieły kursor – dziejny"
+
+#: ../capplets/common/gnome-theme-info.c:653
+msgid "Large White Pointer"
+msgstr "Vialiki bieły kursor"
+
+#: ../capplets/common/gnome-theme-info.c:1623
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme '%s' is "
+"not installed."
+msgstr ""
+"Hety matyŭ nia budzie vyhladać, jak naležyć, bo patrebny matyŭ GTK+ \"%s\" "
+"nie zainstalavany."
+
+#: ../capplets/common/gnome-theme-info.c:1631
+#, c-format
+msgid ""
+"This theme will not look as intended because the required window manager "
+"theme '%s' is not installed."
+msgstr ""
+"Hety matyŭ nia budzie vyhladać, jak naležyć, bo patrebny matyŭ kiraŭnika "
+"voknaŭ \"%s\" nie zainstalavany."
+
+#: ../capplets/common/gnome-theme-info.c:1638
+#, c-format
+msgid ""
+"This theme will not look as intended because the required icon theme '%s' is "
+"not installed."
+msgstr ""
+"Hety matyŭ nia budzie vyhladać, jak naležyć, bo patrebny matyŭ ikonaŭ \"%s\" "
+"nie zainstalavany."
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Preferred Applications"
+msgstr "Pažadanyja aplikacyi"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Abiary zmoŭčanyja aplikacyi"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Start the preferred visual assistive technology"
+msgstr "Uklučy ŭlubionuju technalohiju vizualnaj dastupnaści"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr "Vizualnaja dastupnaść"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:98
+#: ../capplets/default-applications/gnome-da-capplet.c:362
+#: ../capplets/default-applications/gnome-da-capplet.c:383
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "Pry zapisie kanfihuracyi adbyłasia pamyłka: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:668
+msgid "Could not load the main interface"
+msgstr "Niemahčyma zahruzić hałoŭny interfejs."
+
+#: ../capplets/default-applications/gnome-da-capplet.c:670
+msgid "Please make sure that the applet is properly installed"
+msgstr "Upeŭnisia, ci pravilna zainstalavany hety aplet."
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/default-applications/gnome-da-capplet.c:896
+msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+msgstr ""
+"Akreśli nazvu staronki, jakuju treba pakazać (internet|multimedia|system|"
+"a11y)"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:901
+msgid "- GNOME Default Applications"
+msgstr "- Zmoŭčanyja aplikacyi GNOME"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Image Viewer</b>"
+msgstr "<b>Prahladalnik hrafiki</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Instant Messenger</b>"
+msgstr "<b>Kamunikatar</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Mail Reader</b>"
+msgstr "<b>Paštovy čytač</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mobility</b>"
+msgstr "<b>Mabilnaść</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Multimedia Player</b>"
+msgstr "<b>Multymedyja-player</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>Emulatar terminału</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Text Editor</b>"
+msgstr "<b>Tekstavy redaktar</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Video Player</b>"
+msgstr "<b>Videa-player</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "<b>Visual</b>"
+msgstr "<b>Vizualny</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "<b>Web Browser</b>"
+msgstr "<b>Web-hartač</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
+msgid "Accessibility"
+msgstr "Dastupnaść"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "Va ŭsich miescach %s buduć zamienienyja na dziejnuju spasyłku"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "C_ommand:"
+msgstr "_Zahad:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Co_mmand:"
+msgstr "_Zahad:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "E_xecute flag:"
+msgstr "Opcyja vy_kanańnia:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Internet"
+msgstr "Internet"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Multimedia"
+msgstr "Multymedyja"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Open link in new _tab"
+msgstr "Adčyniaj spasyłki ŭ novaj _kartcy"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "Open link in new _window"
+msgstr "Adčyniaj spasyłki ŭ novym _аknie"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid "Open link with web browser _default"
+msgstr "Adčyniaj spasyłki sa _zmoŭčanymi naładami hartača"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Run at st_art"
+msgstr "Uruchom pry _ŭvachodzie"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Run in t_erminal"
+msgstr "Uruchom u t_erminale"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "System"
+msgstr "Systemа"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "_Run at start"
+msgstr "_Vykanaj pry ŭruchamleńni"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr "Muzyčny player Banshee"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr "Pošta Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr "Dasher"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr "Zmoŭčany hartač Debiana"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr "Emulatar terminału Debiana"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr "Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr "Web-hartač Epiphany"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr "Paštovy čytač Evolution"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr "Lupa GNOME biez ekrannaha čytača"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr "Ekrannaja _klavijatura GNOME"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr "Terminał GNOME"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Gnopernicus"
+msgstr "Gnopernicus"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Gnopernicus with Magnifier"
+msgstr "Gnopernicus ź Lupaj"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Iceape"
+msgstr "Iceape"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Iceape Mail"
+msgstr "Pošta Iceape"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Icedove"
+msgstr "Icedove"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Iceweasel"
+msgstr "Iceweasel"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr "Lupa KDE biez ekrannaha čytača"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Konsole"
+msgstr "Konsole"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr "Ekranny čy_tač Linuksa"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr "Ekranny čytač Linuksa ź Lupaj"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Listen"
+msgstr "Listen"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Midori"
+msgstr "Midori"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Mozilla Mail"
+msgstr "Pošta Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Muine Music Player"
+msgstr "Muzyčny player Muine"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+msgid "NXterm"
+msgstr "NXTerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Netscape Communicator"
+msgstr "Kamunikatar Netscape"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Opera"
+msgstr "Opera"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca"
+msgstr "Orca"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "Orca with Magnifier"
+msgstr "Orca ź lupaj"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+msgid "Rhythmbox Music Player"
+msgstr "Muzyčny player Rhythmbox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+msgid "SeaMonkey Mail"
+msgstr "Pošta SeaMonkey"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Standard XTerminal"
+msgstr "Standartny XTerminal"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+msgid "Sylpheed"
+msgstr "Sylpheed"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Terminator"
+msgstr "Terminator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "Totem Movie Player"
+msgstr "Player filmaŭ Totem"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/display/display-capplet.glade.h:1
+#: ../capplets/display/xrandr-capplet.c:460
+msgid "<b>Monitor</b>"
+msgstr "<b>Manitor</b>"
+
+#: ../capplets/display/display-capplet.glade.h:2
+msgid "<b>Panel icon</b>"
+msgstr "<b>Ikona paneli</b>"
+
+#: ../capplets/display/display-capplet.glade.h:3
+msgid "<i>Drag the monitors to set their place</i>"
+msgstr "<i>Pieraciahvaj manitory, kab uparadkavać ich</i>"
+
+#: ../capplets/display/display-capplet.glade.h:4
+msgid "Display Preferences"
+msgstr "Nałady ekranu"
+
+#: ../capplets/display/display-capplet.glade.h:5
+msgid "Include _panel"
+msgstr "Ułučy _panel"
+
+#: ../capplets/display/display-capplet.glade.h:6
+msgid ""
+"Normal\n"
+"Left\n"
+"Right\n"
+"Upside-down\n"
+msgstr ""
+"Zvyčajna\n"
+"Uleva\n"
+"Uprava\n"
+"Dahary nahami\n"
+
+#: ../capplets/display/display-capplet.glade.h:11
+msgid "Off"
+msgstr "Vyklučany"
+
+#: ../capplets/display/display-capplet.glade.h:12
+msgid "On"
+msgstr "Uklučany"
+
+#: ../capplets/display/display-capplet.glade.h:13
+msgid "R_otation:"
+msgstr "_Abaročvańnie:"
+
+#: ../capplets/display/display-capplet.glade.h:14
+msgid "Re_fresh rate:"
+msgstr "C_hutkaść aktualizacyi:"
+
+#: ../capplets/display/display-capplet.glade.h:15
+msgid "_Detect Monitors"
+msgstr "_Paznavaj manitory"
+
+#: ../capplets/display/display-capplet.glade.h:16
+msgid "_Mirror screens"
+msgstr "_Adlustroŭvaj ekrany"
+
+#: ../capplets/display/display-capplet.glade.h:17
+msgid "_Resolution:"
+msgstr "_Pamiery:"
+
+#: ../capplets/display/display-capplet.glade.h:18
+msgid "_Show displays in panel"
+msgstr "_Pakazvaj ekrany na paneli"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Źmiani pamiery ekranu"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Display"
+msgstr "Ekran"
+
+#: ../capplets/display/xrandr-capplet.c:327
+#: ../capplets/display/xrandr-capplet.c:366
+msgid "Normal"
+msgstr "Narmalna"
+
+#: ../capplets/display/xrandr-capplet.c:328
+msgid "Left"
+msgstr "Uleva"
+
+#: ../capplets/display/xrandr-capplet.c:329
+msgid "Right"
+msgstr "Uprava"
+
+#: ../capplets/display/xrandr-capplet.c:330
+msgid "Upside Down"
+msgstr "Dahary nahami"
+
+#: ../capplets/display/xrandr-capplet.c:403
+#: ../capplets/display/xrandr-capplet.c:411
+#: ../capplets/display/xrandr-capplet.c:412
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/xrandr-capplet.c:453
+#, c-format
+msgid "<b>Monitor: %s</b>"
+msgstr "<b>Manitor: %s</b>"
+
+#: ../capplets/display/xrandr-capplet.c:545
+#: ../capplets/display/xrandr-capplet.c:555
+#: ../capplets/display/xrandr-capplet.c:563
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../capplets/display/xrandr-capplet.c:1410
+msgid "Mirror Screens"
+msgstr "Adlustruj ekrany"
+
+#: ../capplets/display/xrandr-capplet.c:1729
+msgid "Could not apply the selected configuration"
+msgstr "Nie ŭdałosia ŭžyć vybranyja nałady"
+
+#: ../capplets/display/xrandr-capplet.c:1756
+msgid "Could not save the monitor configuration"
+msgstr "Nie ŭdałosia zapisać nałady manitora"
+
+#: ../capplets/display/xrandr-capplet.c:1767
+msgid "Could not get session bus while applying display configuration"
+msgstr "Nie ŭdałosia atrymać šynu sesii pry ŭžyćci naładaŭ ekranu"
+
+#: ../capplets/display/xrandr-capplet.c:1777
+msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+msgstr "Nie ŭdałosia atrymać \"org.gnome.SettingsDaemon.XRANDR\""
+
+#: ../capplets/display/xrandr-capplet.c:1823
+msgid "Could not detect displays"
+msgstr "Nie ŭdałosia paznać ekrany"
+
+#: ../capplets/display/xrandr-capplet.c:2021
+msgid "Could not get screen information"
+msgstr "Nie ŭdałosia atrymać źviestki ekranu"
+
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+msgid "Sound"
+msgstr "Huk"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+#: ../libslab/bookmark-agent.c:1146
+msgid "Desktop"
+msgstr "Stoł"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr "Novy skarot..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Klaviša akseleratara"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Madyfikatary akseleratara"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Kod klavišy akseleratara"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Režym akseleratara"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Typ akseleratara."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:103
+#: ../typing-break/drwright.c:479
+msgid "Disabled"
+msgstr "Nieaktyŭny"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:184
+msgid "<Unknown Action>"
+msgstr "<Nieviadomaje dziejańnie>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:925
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1548
+msgid "Custom Shortcuts"
+msgstr "Asablivyja skaroty"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1064
+msgid "Error saving the new shortcut"
+msgstr "Pamyłka zachavańnia novaha klavijaturnaha skarotu"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1143
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"Skarot \"%s\" nielha vykarystać, bo nia budzie mahčymaści pisać, "
+"vykarystoŭvajučy hetuju klavišu.\n"
+"Pasprabuj u spałučeńni z takimi klavišami, jak Control, Alt albo Shift."
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1173
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"Klavijaturny skarot \"%s\" užo vykarystoŭvajecca dla\n"
+"\"%s\""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1179
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"Kali ty pieraaznačyš klavijaturny skarot na \"%s\", tady skarot \"%s\" "
+"budzie vyklučany."
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1187
+msgid "_Reassign"
+msgstr "_Pieraaznač"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1307
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr ""
+"Pry ačystcy akseleratara ŭ bazie źviestak kanfihuracyi adbyłasia pamyłka: %s"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1503
+msgid "Too many custom shortcuts"
+msgstr "Zašmat ułasnych skarotaŭ"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1788
+msgid "Action"
+msgstr "Dziejańnie"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1810
+msgid "Shortcut"
+msgstr "Skarot"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+msgid "Custom Shortcut"
+msgstr "Ułasny skarot"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Klavijaturnyja skaroty"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:3
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new key "
+"combination, or press backspace to clear."
+msgstr ""
+"Kab źmianić klavišu skarotu, klikni ŭ adpaviedny radok i ŭpišy novy "
+"klavijaturnaje spałučeńnie albo naciśni klavišu \"Backspace\", kab vyčyścić "
+"dziejnaje."
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:4
+msgid "_Command:"
+msgstr "_Zahad:"
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Pryviažy klavijaturnyja skaroty da zahadaŭ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:209
+#: ../capplets/keyboard/gnome-keyboard-properties.c:214
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+"Tolki ŭžyj nałady j vyjdzi (tolki dziela zhodnaści, ciapier heta "
+"absłuhoŭvaje deman)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:219
+msgid "Start the page with the typing break settings showing"
+msgstr "Adčyni staronku ŭłaścivaściaŭ pierapynku ŭ pisańni na klavijatury"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:224
+msgid "Start the page with the accessibility settings showing"
+msgstr "Pačynaj staronku, pakazvajučy nałady dastupnaści"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:230
+msgid "- GNOME Keyboard Preferences"
+msgstr "– Nałady klavijatury GNOME"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+msgid "<b>Bounce Keys</b>"
+msgstr "<b>Spružynistyja klavišy</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Mirhańnie kursora</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "<b>General</b>"
+msgstr "<b>Ahulnaje</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Paŭtor klavišaŭ</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Slow Keys</b>"
+msgstr "<b>Pavolnyja klavišy</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>Sticky Keys</b>"
+msgstr "<b>_Tryvałyja klavišy</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<b>Visual cues for sounds</b>"
+msgstr "<b>Vizualnyja syhnały dla hukaŭ</b>"
+
+#. fast acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Chutka</i></small>"
+
+#. long delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Doŭha</i></small>"
+
+#. short delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Karotka</i></small>"
+
+#. slow acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Pavolna</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "A_cceleration:"
+msgstr "_Akseleracyja:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "All_ow postponing of breaks"
+msgstr "Dazvol adter_minoŭku pierapynkaŭ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Audio _Feedback..."
+msgstr "Hukavaja _reakcyja..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Beep when _accessibility features are turned on or off"
+msgstr "Hukavy _syhnał pry ŭklučeńni/vyklučeńni mahčymaściaŭ dastupnaści"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Beep when a _modifier key is pressed"
+msgstr "Hukavy syhnał, kali nacisnuty _madyfikatar"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Beep when a _toggle key is pressed"
+msgstr "Hukavy syhnał, kali nacisnutaja klaviša _pieraklučeńnia"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Beep when a key is pr_essed"
+msgstr "Hukavy syhnał, kali nacisnutaja klaviša"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Beep when a key is reje_cted"
+msgstr "Hukavy syhnał, kali adch_ilenaja klaviša"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Beep when key is _accepted"
+msgstr "Hukavy syhnał, kali p_ryniataja klaviša"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Beep when key is _rejected"
+msgstr "Hukavy syhnał, kali adch_ilenaja klaviša"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "By _country"
+msgstr "Pavodle _krainy"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "By _language"
+msgstr "Pavodle _movy"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Pravier, ci možna adterminoŭvać pierapynki"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Choose a Keyboard Model"
+msgstr "Abiary madel klavijatury"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Choose a Layout"
+msgstr "Abiary raskładku"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Cursor _blinks in text fields"
+msgstr "Kursor _mirhaje ŭ tekstavych paloch"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
+msgid "Cursor blinks speed"
+msgstr "Chutkaść mirhańnia kursora"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
+msgid "D_elay:"
+msgstr "_Spaźnieńnie:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr "_Vyklučaj tryvałyja klavišy, kali razam nacisnutyja dźvie klavišy"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Duration of the break when typing is disallowed"
+msgstr "Praciahłaść pierapynku, kali zabaronienaje pisańnie"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+msgid "Duration of work before forcing a break"
+msgstr "Praciahłaść pracy pierad vymušanym pierapynkam"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "Flash _window titlebar"
+msgstr "Mirhaj _zahałoŭkam akna"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "Flash entire _screen"
+msgstr "Mirhaj _usim ekranam"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
+msgid "General"
+msgstr "Ahulnaje"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "Key presses _repeat when key is held down"
+msgstr "_Paŭtor nacisku klavišy pry jaje ŭtrymańni"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "Keyboard Accessibility Audio Feedback"
+msgstr "Hukavaja reakcyja na klavijaturu"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "Keyboard Layout Options"
+msgstr "Opcyi raskładki klavijatury"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "Keyboard Preferences"
+msgstr "Nałady klavijatury"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "Keyboard _model:"
+msgstr "_Madel klavijatury:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "Layout _Options..."
+msgstr "_Opcyi raskładki..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "Layouts"
+msgstr "Raskładki"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Blakuj ekran paśla akreślenaha času, kab papiaredzić traŭmy, źviazanyja z "
+"praciahłym pisańniem na klavijatury"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
+msgid "Mouse Keys"
+msgstr "Klavišy myšy"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
+msgid "Preview:"
+msgstr "Pieradahlad:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
+msgid "Repeat keys speed"
+msgstr "Chutkaść paŭtoru klavišaŭ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
+msgid "Reset to De_faults"
+msgstr "V_iarni zmoŭčanaje"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
+msgid "S_peed:"
+msgstr "Ch_utkaść:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
+msgid "Separate _layout for each window"
+msgstr "Asobnaja _raskładka dla kožnaha vakna"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
+msgid "Show _visual feedback for the alert sound"
+msgstr "Pakazvaj _vizualnyja syhnały dla tryvožnych hukaŭ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
+msgid "Typing Break"
+msgstr "Pierapynak u pisańni"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
+msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgstr "_Mahčymaści dastupnaści možna ŭklučać klavijaturnymi skarotami"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
+msgid "_Break interval lasts:"
+msgstr "_Praciahłaść pierapynku:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
+msgid "_Country:"
+msgstr "_Kraina:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
+msgid "_Delay:"
+msgstr "_Čas:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
+msgid "_Ignore fast duplicate keypresses"
+msgstr "_Ihnaruj chutkija paŭtornyja naciski klavišaŭ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
+msgid "_Language:"
+msgstr "_Mova:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
+msgid "_Lock screen to enforce typing break"
+msgstr "_Blakuj ekran, kab prymusić zrabić pierapynak padčas pisańnia"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
+msgid "_Models:"
+msgstr "_Madeli:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
+msgid "_Only accept long keypresses"
+msgstr "_Pryjmaj tolki daŭhija naciski klavišaŭ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
+msgid "_Pointer can be controlled using the keypad"
+msgstr "_Dazvol kiravać kursoram z dapamohaj klavijatury"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
+msgid "_Selected layouts:"
+msgstr "Vybranyja _raskładki:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
+msgid "_Simulate simultaneous keypresses"
+msgstr "_Imituj adnačasovyja naciski klavišaŭ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
+msgid "_Speed:"
+msgstr "_Chutkaść:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
+msgid "_Type to test settings:"
+msgstr "_Napišy tekst, kab pravieryć nałady:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:68
+msgid "_Variants:"
+msgstr "_Varyjanty:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:69
+msgid "_Vendors:"
+msgstr "_Vytvorca:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:70
+msgid "_Work interval lasts:"
+msgstr "Praciahłaść času p_racy:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:71
+msgid "minutes"
+msgstr "chvilin"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
+msgid "Unknown"
+msgstr "Nieviadomy"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:215
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:235
+#: ../capplets/network/gnome-network-properties.c:561
+msgid "Default"
+msgstr "Zmoŭčanaja"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:333
+msgid "Layout"
+msgstr "Raskładka"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
+msgid "Vendors"
+msgstr "Vytvorcy"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
+msgid "Models"
+msgstr "Madeli"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Klavijatura"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Abiary nałady klavijatury"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:90
+msgid "gesture|Move left"
+msgstr "Ruch lavej"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:95
+msgid "gesture|Move right"
+msgstr "Ruch praviej"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:100
+msgid "gesture|Move up"
+msgstr "Ruch vyšej"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:105
+msgid "gesture|Move down"
+msgstr "Ruch nižej"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:110
+msgid "gesture|Disabled"
+msgstr "Vyklučana"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/mouse/gnome-mouse-properties.c:441
+msgid "Specify the name of the page to show (general|accessibility)"
+msgstr "Akreśli nazvu staronki, jakuju treba pakazać (general|accessibility)"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:446
+msgid "- GNOME Mouse Preferences"
+msgstr "– Nałady myšy dla GNOME"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+msgid "<b>Double-Click Timeout</b>"
+msgstr "<b>Spaźnieńnie dvukliku</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Pieraciahvańnie j puščańnie</b>"
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Dwell Click</b>"
+msgstr "<b>Klik zatrymkaj</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Raspałažy kursor</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>Aryjentacyja myšy</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<b>Pointer Speed</b>"
+msgstr "<b>Chutkaść kursora</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<b>Simulated Secondary Click</b>"
+msgstr "<b>Symulavany druhi klik</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid ""
+"<i>To test your double-click settings, try to double-click on the light bulb."
+"</i>"
+msgstr "<i>Kab pravieryć nałady dvuklika, možaš paklikać na lampačku.</i>"
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid ""
+"<i>You can also use the Dwell Click panel applet to choose the click type.</"
+"i>"
+msgstr ""
+"<i>Ty možaš abrać typ kliku z dapamohaj apleta paneli \"Klik zatrymkaj\".</i>"
+
+#. high sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "<small><i>High</i></small>"
+msgstr "<small><i>Vysokaja</i></small>"
+
+#. large threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "<small><i>Large</i></small>"
+msgstr "<small><i>Vialiki</i></small>"
+
+#. low sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "<small><i>Low</i></small>"
+msgstr "<small><i>Nizkaja</i></small>"
+
+#. small threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "<small><i>Small</i></small>"
+msgstr "<small><i>Mały</i></small>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
+msgid "Choose type of click _beforehand"
+msgstr "Abiary typ _zaŭčasnaha kliku"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
+msgid "Choose type of click with mo_use gestures"
+msgstr "Abiary typ kliku, ruchajčy myššu"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
+msgid "D_ouble click:"
+msgstr "_Dvuklik:"
+
+#. click to initiate drag-and-drop (like normally click and hold)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
+msgid "D_rag click:"
+msgstr "_Pieraciahvalny klik:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
+msgid "Mouse Preferences"
+msgstr "Nałady myšy"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
+msgid "Seco_ndary click:"
+msgstr "_Druhi klik:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr "_Pakazvaj pałažeńnie kursora, kali nacisnutaja klaviša Control"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
+msgid "Show click type _window"
+msgstr "Pakažy _vakno vybaru typu klika"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
+msgid "Thr_eshold:"
+msgstr "_Parohavaja vartaść:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
+msgid "_Acceleration:"
+msgstr "_Akseleracyja:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
+msgid "_Initiate click when stopping pointer movement"
+msgstr "_Inicyjuj klik, kali spyniajecca kursor"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
+msgid "_Left-handed"
+msgstr "Dla _leŭšunoŭ"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
+msgid "_Motion threshold:"
+msgstr "_Parohavy zruch:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
+msgid "_Right-handed"
+msgstr "Dla _praŭšunoŭ"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
+msgid "_Sensitivity:"
+msgstr "_Čułaść:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
+msgid "_Single click:"
+msgstr "_Adzin klik:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
+msgid "_Timeout:"
+msgstr "_Spaźnieńnie:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr "_Inicyjuj druhi klik, kali ŭtrymlivajecca pieršaja klaviša"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Myš"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Abiary nałady myšy"
+
+#: ../capplets/network/gnome-network-properties.c:677
+#: ../capplets/network/gnome-network-properties.c:816
+msgid "New Location..."
+msgstr "_Novaje pałažeńnie..."
+
+#: ../capplets/network/gnome-network-properties.c:782
+msgid "Location already exists"
+msgstr "Takoje pałažeńnie ŭžo isnuje"
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Sietkavy proxy"
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "Abiary nałady sietkavaha proxy"
+
+#: ../capplets/network/gnome-network-properties.glade.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>_Pramoje internetnaje spałučeńnie</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:2
+msgid "<b>Ignore Host List</b>"
+msgstr "<b>Śpis ihnaravanych hostaŭ</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:3
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>_Autamatyčnaja kanfihuracyja proxy</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:4
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>_Ručnaja kanfihuracyja proxy</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:5
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Užyvaj aŭtaryzacyju</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:6
+msgid "Autoconfiguration _URL:"
+msgstr "_URL aŭtamatyčnaj kanfihuracyi:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:7
+msgid "C_reate"
+msgstr "_Stvary"
+
+#: ../capplets/network/gnome-network-properties.glade.h:8
+msgid "Create New Location"
+msgstr "Stvary novaje pałažeńnie"
+
+#: ../capplets/network/gnome-network-properties.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "Detali HTTP-proxy"
+
+#: ../capplets/network/gnome-network-properties.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "_HTTP-proxy:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:11
+msgid "Ignored Hosts"
+msgstr "Śpis ihnaravanych hostaŭ"
+
+#: ../capplets/network/gnome-network-properties.glade.h:12
+msgid "Location:"
+msgstr "Pałažeńnie:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:13
+msgid "Network Proxy Preferences"
+msgstr "Nałady sietkavaha proxy"
+
+#: ../capplets/network/gnome-network-properties.glade.h:14
+msgid "Port:"
+msgstr "Port:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:15
+msgid "Proxy Configuration"
+msgstr "Kanfihuracyja proxy"
+
+#: ../capplets/network/gnome-network-properties.glade.h:16
+msgid "S_ocks host:"
+msgstr "S_ocks-host:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:17
+msgid "The location already exists."
+msgstr "Takoje pałažeńnie ŭžo isnuje."
+
+#: ../capplets/network/gnome-network-properties.glade.h:18
+msgid "U_sername:"
+msgstr "Nazva _karystalnika:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:19
+msgid "_Delete Location"
+msgstr "_Vydali pałažeńnie"
+
+#: ../capplets/network/gnome-network-properties.glade.h:20
+msgid "_Details"
+msgstr "_Detali"
+
+#: ../capplets/network/gnome-network-properties.glade.h:21
+msgid "_FTP proxy:"
+msgstr "_FTP-proxy:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:22
+msgid "_Location name:"
+msgstr "_Nazva pałažeńnia:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:23
+msgid "_Password:"
+msgstr "_Parol:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:24
+msgid "_Secure HTTP proxy:"
+msgstr "_Biaśpiečny HTTP-proxy:"
+
+#: ../capplets/network/gnome-network-properties.glade.h:25
+msgid "_Use the same proxy for all protocols"
+msgstr "_Užyj adzin i toj ža proxy dla ŭsich pratakołaŭ"
+
+#: ../capplets/windows/gnome-window-properties.c:346
+msgid "Cannot start the preferences application for your window manager"
+msgstr "Niemahčyma ŭruchomić kanfihuracyjnuju aplikacyju dla kiraŭnika voknaŭ"
+
+#. translators: this is the Control key
+#: ../capplets/windows/gnome-window-properties.c:600
+msgid "C_ontrol"
+msgstr "C_ontrol"
+
+#: ../capplets/windows/gnome-window-properties.c:605
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:611
+msgid "H_yper"
+msgstr "H_yper"
+
+#: ../capplets/windows/gnome-window-properties.c:618
+msgid "S_uper (or \"Windows logo\")"
+msgstr "S_uper (albo \"klaviša Windows\")"
+
+#: ../capplets/windows/gnome-window-properties.c:625
+msgid "_Meta"
+msgstr "_Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Klaviša ruchu</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>Pavodziny zahałoŭku vakna</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Vybar akna</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr ""
+"Kab pierasunuć akno, naciśni j prytrymaj hetuju klavišu, a potym schapi "
+"vakno:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Nałady voknaŭ"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "Ap_eracyja paśla dvukliku zahałoŭku:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "Ča_s pierad vysoŭvańniem:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_Vysoŭvaj abranyja vokny praź niekatory čas"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Zaznačaj vokny paśla raźmiaščeńnia nad imi kursora"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "sekundaŭ"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "Kanfihuruj ułaścivaści voknaŭ"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Vokny"
+
+#. make start action
+#: ../libslab/application-tile.c:372
+#, c-format
+msgid "<b>Start %s</b>"
+msgstr "<b>Uklučy %s</b>"
+
+#: ../libslab/application-tile.c:391
+msgid "Help"
+msgstr "Dapamoha"
+
+#: ../libslab/application-tile.c:438
+msgid "Upgrade"
+msgstr "Aktualizuj"
+
+#: ../libslab/application-tile.c:453
+msgid "Uninstall"
+msgstr "Adinstaluj"
+
+#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
+msgid "Remove from Favorites"
+msgstr "Vydal z ulubionych"
+
+#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
+msgid "Add to Favorites"
+msgstr "Dadaj da ŭlubionych"
+
+#: ../libslab/application-tile.c:867
+msgid "Remove from Startup Programs"
+msgstr "Vydal sa startavych prahramaŭ"
+
+#: ../libslab/application-tile.c:869
+msgid "Add to Startup Programs"
+msgstr "Dadaj da startavych prahramaŭ"
+
+#: ../libslab/app-shell.c:753
+#, c-format
+msgid ""
+"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+"\n"
+" Your filter \"<b>%s</b>\" does not match any items.</span>"
+msgstr ""
+"<span size=\"large\"><b>Niama adpaviednikaŭ.</b> </span><span>\n"
+"\n"
+" Filter \"<b>%s</b>\" nie pasuje ni da adnaho z elementaŭ.</span>"
+
+#: ../libslab/app-shell.c:903
+msgid "Other"
+msgstr "Inšaje"
+
+#: ../libslab/bookmark-agent.c:1077
+msgid "New Spreadsheet"
+msgstr "Novy raźlikovy arkuš"
+
+#: ../libslab/bookmark-agent.c:1082
+msgid "New Document"
+msgstr "Novy dakument"
+
+#: ../libslab/bookmark-agent.c:1135
+msgid "Home"
+msgstr "Dom"
+
+#: ../libslab/bookmark-agent.c:1140
+msgid "Documents"
+msgstr "Dakumenty"
+
+#: ../libslab/bookmark-agent.c:1153
+msgid "File System"
+msgstr "Fajłavaja systemа"
+
+#: ../libslab/bookmark-agent.c:1157
+msgid "Network Servers"
+msgstr "Sietkavyja servery"
+
+#: ../libslab/bookmark-agent.c:1186
+msgid "Search"
+msgstr "Šukaj"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:171
+#, c-format
+msgid "<b>Open</b>"
+msgstr "<b>Adčyni</b>"
+
+#. make rename action
+#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:231
+msgid "Rename..."
+msgstr "Źmiani nazvu..."
+
+#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
+#: ../libslab/document-tile.c:245 ../libslab/document-tile.c:254
+msgid "Send To..."
+msgstr "Vyšli da..."
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:280
+msgid "Move to Trash"
+msgstr "Pieraniasi ŭ śmietnicu"
+
+#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
+#: ../libslab/document-tile.c:290 ../libslab/document-tile.c:831
+msgid "Delete"
+msgstr "Vydal"
+
+#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:979
+#, c-format
+msgid "Are you sure you want to permanently delete \"%s\"?"
+msgstr "Ty sapraŭdy chočaš nazaŭždy vydalić \"%s\"?"
+
+#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:980
+msgid "If you delete an item, it is permanently lost."
+msgstr "Vydaleny elementy budzie stračany nazaŭždy."
+
+#: ../libslab/document-tile.c:192
+#, c-format
+msgid "<b>Open with \"%s\"</b>"
+msgstr "<b>Adčyni pry dapamozie \"%s\"</b>"
+
+#: ../libslab/document-tile.c:204
+msgid "Open with Default Application"
+msgstr "Adčyni pry dapamozie zmoŭčanaj aplikacyi"
+
+#: ../libslab/document-tile.c:215
+msgid "Open in File Manager"
+msgstr "Adčyni ŭ kiraŭniku fajłaŭ"
+
+#: ../libslab/document-tile.c:611
+msgid "?"
+msgstr "?"
+
+#: ../libslab/document-tile.c:618
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#: ../libslab/document-tile.c:626
+msgid "Today %l:%M %p"
+msgstr "Siońnia %l:%M %p"
+
+#: ../libslab/document-tile.c:636
+msgid "Yesterday %l:%M %p"
+msgstr "Učora %l:%M %p"
+
+#: ../libslab/document-tile.c:648
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../libslab/document-tile.c:656
+msgid "%b %d %l:%M %p"
+msgstr "%b %d %l:%M %p"
+
+#: ../libslab/document-tile.c:658
+msgid "%b %d %Y"
+msgstr "%b %d %Y"
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr "Znajdzi ciapier"
+
+#: ../libslab/system-tile.c:128
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr "<b>Adčyni %s</b>"
+
+#: ../libslab/system-tile.c:141
+#, c-format
+msgid "Remove from System Items"
+msgstr "Vydal z systemnych elementaŭ"
+
+#: ../libwindow-settings/gnome-wm-manager.c:316
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "Kiraŭnik voknaŭ \"%s\" nie zarehistravaŭ pryładu kanfihuracyi\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:404
+msgid "Maximize"
+msgstr "Maksymalizuj"
+
+#: ../libwindow-settings/metacity-window-manager.c:405
+msgid "Maximize Vertically"
+msgstr "Maksymalizuj vertykalna"
+
+#: ../libwindow-settings/metacity-window-manager.c:406
+msgid "Maximize Horizontally"
+msgstr "Maksymalizuj haryzantalna"
+
+#: ../libwindow-settings/metacity-window-manager.c:407
+msgid "Minimize"
+msgstr "Minimalizuj"
+
+#: ../libwindow-settings/metacity-window-manager.c:408
+msgid "Roll up"
+msgstr "Razharni"
+
+#: ../libwindow-settings/metacity-window-manager.c:409
+msgid "None"
+msgstr "Niama"
+
+#: ../shell/control-center.c:54
+#, c-format
+msgid "key not found [%s]\n"
+msgstr "nia znojdzieny kluč [%s]\n"
+
+#: ../shell/control-center.c:151
+msgid "Filter"
+msgstr "Filter"
+
+#: ../shell/control-center.c:151
+msgid "Groups"
+msgstr "Hrupy"
+
+#: ../shell/control-center.c:151
+msgid "Common Tasks"
+msgstr "Typovyja zadačy"
+
+#: ../shell/control-center.c:155 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Centar kiravańnia"
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr "Začyni centar kiravańnia paśla aktyvizacyi zadačy"
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr "Vyjdzi z abałonki paśla dadańnia albo vydaleńnia"
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr "Vyjdzi z abałonki paśla pakazu dapamohi"
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr "Vyjdzi z abałonki paśla startu"
+
+#: ../shell/control-center.schemas.in.h:5
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr "Vyjdzi z abałonki paśla aktualizacyi albo adinstalavańnia"
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed."
+msgstr "Akreślivaje, ci začyniać abałonku paśla pakazu dapamohi."
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed."
+msgstr "Akreślivaje, ci začyniać abałonku paśla ŭruchamleńnia."
+
+#: ../shell/control-center.schemas.in.h:8
+msgid ""
+"Indicates whether to close the shell when an add or remove action is "
+"performed."
+msgstr "Akreślivaje, ci začyniać abałonku paśla dadavańnia albo vydaleńnia."
+
+#: ../shell/control-center.schemas.in.h:9
+msgid ""
+"Indicates whether to close the shell when an upgrade or uninstall action is "
+"performed."
+msgstr ""
+"Akreślivaje, ci začyniać abałonku paśla aktualizacyi albo adinstalavańnia."
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr "Nazvy zadačaŭ i adpaviednyja fajły .desktop"
+
+#: ../shell/control-center.schemas.in.h:11
+msgid ""
+"The task name to be displayed in the control-center followed by a \";\" "
+"separator then the filename of an associated .desktop file to launch for "
+"that task."
+msgstr ""
+"Nazva bačnaj u centry kiravańnia zadačy, paśla jakoj staić separatar \";\", "
+"a potym nazva adpaviednaha fajłu .desktop, kab uruchomić dla hetaj zadačy."
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+msgid ""
+"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
+"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+msgstr ""
+"[Źmiani matyŭ;gtk-theme-selector.desktop,Abiary zmoŭčanyja aplikacyi;default-"
+"applications.desktop,Dadaj drukarku;gnome-cups-manager.desktop]"
+
+#: ../shell/control-center.schemas.in.h:14
+msgid ""
+"if true, the control-center will close when a \"Common Task\" is activated."
+msgstr ""
+"Kali ŭklučana, center kiravańnia budzie začynieny pry ŭklučeńni \"Typovaj "
+"zadačy\"."
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "Pryłada kanfihuracyi GNOME"
+
+#: ../typing-break/drw-break-window.c:193
+msgid "_Postpone Break"
+msgstr "A_dterminuj pierapynak"
+
+#: ../typing-break/drw-break-window.c:249
+msgid "Take a break!"
+msgstr "Zrabi pierapynak!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#. translators: keep the initial "/"
+#: ../typing-break/drwright.c:129
+msgid "/_Preferences"
+msgstr "/_Nałady"
+
+#: ../typing-break/drwright.c:130
+msgid "/_About"
+msgstr "/_Pra"
+
+#: ../typing-break/drwright.c:132
+msgid "/_Take a Break"
+msgstr "/Z_rabi pierapynak"
+
+#: ../typing-break/drwright.c:488
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "%d chvilina da pierapynku"
+msgstr[1] "%d chviliny da pierapynku"
+msgstr[2] "%d chvilin da pierapynku"
+
+#: ../typing-break/drwright.c:492
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr "Da nastupnaha pierapynku mienš za chvilinu"
+
+#: ../typing-break/drwright.c:579
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Niemahčyma pakazać akno ŭłaścivaściaŭ pierapynkaŭ u pisańni z-za nastupnaj "
+"pamyłki: %s"
+
+#: ../typing-break/drwright.c:598
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "Napisaŭ Richard Hult <richard@imendio.com>"
+
+#: ../typing-break/drwright.c:599
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Aŭtarskaja hrafika ad Anders Carlsson"
+
+#: ../typing-break/drwright.c:608
+msgid "A computer break reminder."
+msgstr "Prahrama nahadvańnia ab pierapynkach padčas pracy z kamputaram."
+
+#: ../typing-break/drwright.c:610
+msgid "translator-credits"
+msgstr ""
+"Łacinka.org\n"
+"Alaksandar Navicki <zolak@lacinka.prg>Ihar Hračyška <ihar.hrachyshka@gmail."
+"com>"
+
+#: ../typing-break/main.c:61
+msgid "Enable debugging code"
+msgstr "Uklučy debugavy kod"
+
+#: ../typing-break/main.c:63
+msgid "Don't check whether the notification area exists"
+msgstr "Nie praviaraj, ci isnuje abšar nahadvańnia"
+
+#: ../typing-break/main.c:89
+msgid "Typing Monitor"
+msgstr "Manitor pracy klavijatury"
+
+#: ../typing-break/main.c:105
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Manitor pracy klavijatury vykarystoŭvaje abšar nahadvańniaŭ, kab pakazvać "
+"infarmacyju. Zdajecca, takoha abšaru niama na paneli. Jaho možna dadać, "
+"kliknuŭšy pravaj klavišaj myšy na paneli, potym abraŭšy \"Dadaj da paneli\", "
+"zaznačyŭšy \"Abšar nahadvańnia\" i kliknuŭšy \"Dadaj\"."
+
+#: ../font-viewer/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ OpenType."
+
+#: ../font-viewer/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ PCF."
+
+#: ../font-viewer/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ TrueType."
+
+#: ../font-viewer/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "Kali ŭklučana, buduć hieneravacca minijatury dla šryftoŭ Type1."
+
+#: ../font-viewer/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ OpenType."
+
+#: ../font-viewer/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr "Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ PCF."
+
+#: ../font-viewer/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ TrueType."
+
+#: ../font-viewer/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla šryftoŭ Type1."
+
+#: ../font-viewer/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "Zahad, kab stvarać minijatury dla šryftoŭ OpenType"
+
+#: ../font-viewer/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "Zahad, kab stvarać minijatury dla šryftoŭ PCF"
+
+#: ../font-viewer/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "Zahad, kab stvarać minijatury dla šryftoŭ TrueType"
+
+#: ../font-viewer/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Zahad, kab stvarać minijatury dla šryftoŭ Type1"
+
+#: ../font-viewer/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "Ci treba stvarać minijatury dla šryftoŭ OpenType"
+
+#: ../font-viewer/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "Ci treba stvarać minijatury dla šryftoŭ PCF"
+
+#: ../font-viewer/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "Ci treba stvarać minijatury dla šryftoŭ TrueType"
+
+#: ../font-viewer/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "Ci treba stvarać minijatury dla šryftoŭ Type1"
+
+#: ../font-viewer/font-view.c:113
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "Kiń źluku ŭściaž łaščyć. ŃŁŬŚŠČŹŽ 0123456789"
+
+#: ../font-viewer/font-view.c:275
+msgid "Name:"
+msgstr "Nazva:"
+
+#: ../font-viewer/font-view.c:278
+msgid "Style:"
+msgstr "Styl:"
+
+#: ../font-viewer/font-view.c:291
+msgid "Type:"
+msgstr "Typ:"
+
+#: ../font-viewer/font-view.c:295
+msgid "Size:"
+msgstr "Pamier:"
+
+#: ../font-viewer/font-view.c:339 ../font-viewer/font-view.c:352
+msgid "Version:"
+msgstr "Versija:"
+
+#: ../font-viewer/font-view.c:343 ../font-viewer/font-view.c:354
+msgid "Copyright:"
+msgstr "Aŭtarskija pravy:"
+
+#: ../font-viewer/font-view.c:347
+msgid "Description:"
+msgstr "Apisańnie:"
+
+#: ../font-viewer/font-view.c:437
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "užyćcio: %s fajł_šryftu\n"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
+msgid "Font Viewer"
+msgstr "Prahladalnik šryftoŭ"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
+msgid "Preview fonts"
+msgstr "Pieradahlad šryftoŭ"
+
+#: ../font-viewer/font-thumbnailer.c:243
+msgid "Text to thumbnail (default: Aa)"
+msgstr "Tekst minijatury (zmoŭčana: Aa)"
+
+#: ../font-viewer/font-thumbnailer.c:243
+msgid "TEXT"
+msgstr "TEKST"
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "Font size (default: 64)"
+msgstr "Pamier šryftu (zmoŭčana: 64)"
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "SIZE"
+msgstr "PAMIER"
+
+# #FIXME Vychadny ci vyjścievy?
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr "FAJŁ-ŠRYFTU VYCHADNY-FAJŁ"
+
+#: ../font-viewer/font-thumbnailer.c:265
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr "Pamyłka padčas razboru arhumentaŭ: %s\n"
+
+msgid "Show help options"
+msgstr "Pakažy opcyi dapamohi"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "Uklučaj padtrymku technalohij dastupnaści GNOME pry aŭtaryzacyi"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>_Špalera</b>"
+
+#~ msgid "No Wallpaper"
+#~ msgstr "Biez špalery"
+
+#~ msgid "Monitor Resolution Settings"
+#~ msgstr "Nałady pamieraŭ manitora"
+
+#~ msgid "R_otation"
+#~ msgstr "_Abaročvańnie"
+
+#~ msgid "Re_fresh Rate:"
+#~ msgstr "C_hutkaść abnaŭleńnia:"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Pamiery"
+
+#~ msgid "Screen Resolution"
+#~ msgstr "Pamiery ekranu"
+
+#~ msgid "Cloned Output"
+#~ msgstr "Klanavanaje vyjście"
+
+#~ msgid "New accelerator..."
+#~ msgstr "Novy akseleratar..."
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Atrymaj i zachoŭvaj sastarełyja nałady"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Uklučy huk i źviazvaj huki z padziejami"
+
+#~ msgid "Unknown Volume Control %d"
+#~ msgstr "Nieviadomy rehulatar hučnaści %d"
+
+#~ msgid "Failed to construct test pipeline for '%s'"
+#~ msgstr "Niemahčyma skanstrujavać testavy łancuh dla \"%s\""
+
+#~ msgid "Not connected"
+#~ msgstr "Nie padłučany"
+
+#~ msgid "Autodetect"
+#~ msgstr "Aŭtamatyčnaje vyznačeńnie"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA – Advanced Linux Sound Architecture"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART Sound Daemon"
+
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ESD - Enlightened Sound Daemon"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - Open Sound System"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "PulseAudio Sound Server"
+
+#~ msgid "Test Sound"
+#~ msgstr "Pravier huk"
+
+#~ msgid "Silence"
+#~ msgstr "Cišynia"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "– Nałady huku GNOME"
+
+#~ msgid "<b>Alerts and Sound Effects</b>"
+#~ msgstr "<b>Tryvožnyja syhnały j hukavyja efekty</b>"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>Aŭdyjakanferencyi</b>"
+
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>Zmoŭčanyja ściežki miksera</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Muzyka j filmy</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>Hukavyja padziei</b>"
+
+#~ msgid "<b>Sound Theme</b>"
+#~ msgstr "<b>Matyŭ hukaŭ</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">Pravierka...</span>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "Klikni \"OK\", kab skončyć."
+
+#~ msgid "Devices"
+#~ msgstr "Pryłady"
+
+#~ msgid "Play _alert sound"
+#~ msgstr "_Padaj tryvožny syhnał"
+
+#~ msgid "Play _sound effects when buttons are clicked"
+#~ msgstr "_Ahučvaj kliki ŭ knopki"
+
+#~ msgid "S_ound playback:"
+#~ msgstr "_Hrańnie huku:"
+
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+#~ msgstr ""
+#~ "Abiary pryładu j ściežki, jakija majuć absłuhoŭvacca pry dapamozie "
+#~ "klavijatury. Kali treba, abiary niekalki ściežak z dapamohaj klavišaŭ "
+#~ "Shift i Control."
+
+#~ msgid "So_und playback:"
+#~ msgstr "Hrańnie huk_u:"
+
+#~ msgid "Sou_nd capture:"
+#~ msgstr "Pierachop hu_ku:"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Nałady huku"
+
+#~ msgid "Sounds"
+#~ msgstr "Huki"
+
+#~ msgid "Test"
+#~ msgstr "Pravier"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "Testavy łancuh (pipeline)"
+
+#~ msgid "_Device:"
+#~ msgstr "_Pryłada:"
+
+#~ msgid "_Play alerts and sound effects"
+#~ msgstr "_Padavaj tryvožnyja syhnały j hukavyja efekty"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "_Hrańnie huku:"
+
+#~ msgid "Alert sound"
+#~ msgstr "Tryvožny syhnał"
+
+#~ msgid "Visual alert"
+#~ msgstr "Vizualnaja tryvoha"
+
+#~ msgid "Windows and Buttons"
+#~ msgstr "Vokny j knopki"
+
+#~ msgid "Button clicked"
+#~ msgstr "Klik u knopku"
+
+#~ msgid "Toggle button clicked"
+#~ msgstr "Klik u knopku pieraklučeńnia"
+
+#~ msgid "Window maximized"
+#~ msgstr "Akno zmaksymalizavanaje"
+
+#~ msgid "Window unmaximized"
+#~ msgstr "Anulavanaja maksymalizacyja akna"
+
+#~ msgid "Window minimised"
+#~ msgstr "Akno zminimalizavanaje"
+
+#~ msgid "Login"
+#~ msgstr "Aŭtaryzuj"
+
+#~ msgid "Logout"
+#~ msgstr "Vyjdzi"
+
+#~ msgid "New e-mail"
+#~ msgstr "Novy list e-mail"
+
+#~ msgid "Empty trash"
+#~ msgstr "Pustaja śmietnica"
+
+#~ msgid "Long action completed (download, CD burning, etc.)"
+#~ msgstr "Skončyłasia daŭhaja aperacyja (zahruzka fajłu, zapis dysku itp.)"
+
+#~ msgid "Alerts"
+#~ msgstr "Tryvoha"
+
+#~ msgid "Information or question"
+#~ msgstr "Źviestki ci zapyt"
+
+#~ msgid "Warning"
+#~ msgstr "Papiaredžańnie"
+
+#~ msgid "Error"
+#~ msgstr "Pamyłka"
+
+#~ msgid "Battery warning"
+#~ msgstr "Papiaredžańnie pra stan batarei"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Pravierka huku dla padziei"
+
+#~ msgid "Select Sound File"
+#~ msgstr "Abiary hukavy fajł"
+
+#~ msgid "Sound files"
+#~ msgstr "Hukavyja fajły"
+
+#~ msgid "Custom..."
+#~ msgstr "_Inšy..."
+
+#~ msgid "Lock Screen"
+#~ msgstr "Zablakuj ekran"
+
+#~ msgid "Shutdown"
+#~ msgstr "Vyklučy"
+
+#~ msgid "Unexpected attribute '%s' for element '%s'"
+#~ msgstr "Niečakany atrybut \"%s\" dla elementu \"%s\""
+
+#~ msgid "Attribute '%s' of element '%s' not found"
+#~ msgstr "Atrybut \"%s\" dla elementu \"%s\" nia znojdzieny"
+
+#~ msgid "Unexpected tag '%s', tag '%s' expected"
+#~ msgstr "Niečakany tag \"%s\", čakaŭsia tag \"%s\""
+
+#~ msgid "Unexpected tag '%s' inside '%s'"
+#~ msgstr "Niečakany tag \"%s\" unutry \"%s\""
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "U katalohach danych nia znojdzieny pravilny fajł zakładak"
+
+#~ msgid "A bookmark for URI '%s' already exists"
+#~ msgstr "Zakładka dla URI \"%s\" užo isnuje"
+
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "Zakładka dla URI \"%s\" nia znojdzienaja"
+
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "Typ MIME nie akreśleny ŭ zakładcy dla URI \"%s\""
+
+#~ msgid "No private flag has been defined in bookmark for URI '%s'"
+#~ msgstr "Pryvatny ściažok nie akreśleny ŭ zakładcy dla URI \"%s\""
+
+#~ msgid "No groups set in bookmark for URI '%s'"
+#~ msgstr "Hrupy nie akreślenyja ŭ zakładcy dla URI \"%s\""
+
+#~ msgid "No application with name '%s' registered a bookmark for '%s'"
+#~ msgstr ""
+#~ "Aplikacyja z nazvaj \"%s\" nie zaheristravanaja dla zakładki dla \"%s\""
+
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s źjaŭlajecca ściežkaj, dzie buduć zainstalavanyja fajły matyvu. "
+#~ "Niemahčyma vybrać jaje ŭ jakaści pałažeńnia krynicy"
+
+#~ msgid "Inverted"
+#~ msgstr "Invertavana"
+
+#~ msgid "Default Settings"
+#~ msgstr "Zmoŭčanyja nałady"
+
+#~ msgid "Screen %d Settings\n"
+#~ msgstr "Nałady ekranu %d\n"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Nałady pamieraŭ ekranu"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Zrabi zmoŭčanym tolki dla hetaha kamputara (%s)"
+
+#~ msgid "Options"
+#~ msgstr "Opcyi"
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Testavańnie novych naładaŭ. Kali nie adkažaš ciaham %d sekundy, buduć "
+#~ "viernutyja papiarednija nałady."
+#~ msgstr[1] ""
+#~ "Testavańnie novych naładaŭ. Kali nie adkažaš ciaham %d sekundaŭ, buduć "
+#~ "viernutyja papiarednija nałady."
+#~ msgstr[2] ""
+#~ "Testavańnie novych naładaŭ. Kali nie adkažaš ciaham %d sekundaŭ, buduć "
+#~ "viernutyja papiarednija nałady."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Zachavaj pamiery"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Ty chočaš zachavać hetyja pamiery?"
+
+#~ msgid "Use _Previous Resolution"
+#~ msgstr "Užyj _papiarednija pamiery"
+
+#~ msgid "_Keep Resolution"
+#~ msgstr "_Zachavaj pamiery"
+
+#~ msgid ""
+#~ "The X server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "Server X nie absłuhoŭvaje pašyreńnia XRandR. Źmieny pamieraŭ ekranu "
+#~ "padčas pracy servera niemahčymyja."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Versija pašyreńnia XRandR nia zhodnaja z hetaj prahramaj. Źmieny pamieraŭ "
+#~ "padčas pracy niemahčymyja."
+
+#~ msgid "Error setting new accelerator in configuration database: %s"
+#~ msgstr ""
+#~ "Pry vystaŭleńni novaha akseleratara ŭ bazie źviestak kanfihuracyi "
+#~ "adbyłasia pamyłka: %s"
+
+#~ msgid "E_nable software sound mixing"
+#~ msgstr "U_klučy prahramnaje miksavańnie huku"
+
+#~ msgid "System Beep"
+#~ msgstr "Systemny syhnał"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "Uklučy _systemny syhnał"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "_Vizualny systemny syhnał"
+
+#~ msgid "Boing"
+#~ msgstr "Boing"
+
+#~ msgid "Siren"
+#~ msgstr "Syrena"
+
+#~ msgid "Clink"
+#~ msgstr "Klik"
+
+#~ msgid "Beep"
+#~ msgstr "Zvanočak"
+
+#~ msgid "No sound"
+#~ msgstr "Biaz huku"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "Nie akreśleny huk dla hetaj padziei."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "Hukavoha fajłu dla hetaj padziei nie isnuje.\n"
+#~ "Zainstaluj nabor zmoŭčanych hukaŭ z pakunku \"gnome-audio\"."
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Hukavoha fajłu dla hetaj padziei nie isnuje."
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "Fajł %s nie źjaŭlajecca pravilnym wav-fajłam"
+
+#~ msgid "Select sound file..."
+#~ msgstr "Abiary hukavy fajł..."
+
+#~ msgid "System Sounds"
+#~ msgstr "Systemnyja huki"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Zrabi šryftom aplikacyi"
+
+#~ msgid "Sets the default application font"
+#~ msgstr "Abiraje zmoŭčany šryft aplikacyi"
+
+#~ msgid ""
+#~ "Centered\n"
+#~ "Fill screen\n"
+#~ "Scaled\n"
+#~ "Zoom\n"
+#~ "Tiled"
+#~ msgstr ""
+#~ "Centravany\n"
+#~ "Zapaŭnieńnie ekranu\n"
+#~ "Źmienieny pamier\n"
+#~ "Maštabavany\n"
+#~ "Pa susiedztvie"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Prosta ŭžyj nałady j vyjdzi"
+
+#~ msgid "Connecting..."
+#~ msgstr "Spałučeńnie..."
+
+#~ msgid "Keyboard Accessibility Notifications"
+#~ msgstr "Nahadvańni ad dastupnaj klavijatury"
+
+#~ msgid "_Layouts:"
+#~ msgstr "_Raskładki:"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Pašyranaja kanfihuracyja"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Užyć novy šryft?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "_Nie ŭžyvaj šryft"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr "Abrany matyŭ raić novy šryft. Pieradahlad šryftu pakazany nižej."
+
+#~ msgid "_Apply font"
+#~ msgstr "Užyj _šryft"
+
+#~ msgid "Themes"
+#~ msgstr "Matyvy"
+
+#~ msgid "Description"
+#~ msgstr "Apisańnie"
+
+#~ msgid "Control theme"
+#~ msgstr "Matyŭ elementaŭ kiravańnia"
+
+#~ msgid "Window border theme"
+#~ msgstr "Matyŭ kraju vakna"
+
+#~ msgid "Icon theme"
+#~ msgstr "Matyŭ ikonaŭ"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr ""
+#~ "Kali ŭklučana, buduć stvaracca minijatury dla zainstalavanych matyvaŭ."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "Kali ŭklučana, buduć stvaracca minijatury dla matyvaŭ."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla zainstalavanych "
+#~ "matyvaŭ."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr "Akreśl dla hetaha kluča zahad, kab stvarać minijatury dla matyvaŭ."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Zahad, kab stvarać minijatury dla zainstalavanych matyvaŭ"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Zahad, kab stvarać minijatury dla matyvaŭ"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Ci stvarać minijatury dla zainstalavanych matyvaŭ"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Ci stvarać minijatury dla matyvaŭ"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCĆDEFGH"
+
+#~ msgid "[FILE]"
+#~ msgstr "[FAJŁ]"
+
+#~ msgid "Apply theme"
+#~ msgstr "Užyj matyŭ"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Viartaje zmoŭčany matyŭ"
+
+#~ msgid "Go _to Fonts Folder"
+#~ msgstr "Pierajdzi _da katalohu šryftoŭ"
+
+#~ msgid "Autostart the preferred AT"
+#~ msgstr "Aŭtamatyčna ŭklučaj vymahanyja technalohii"
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "      "
+#~ msgstr "      "

--- a/po/bg.po
+++ b/po/bg.po
@@ -18,9 +18,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center main\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-09 20:58+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-10 12:53+0200\n"
 "Last-Translator: Alexander Shopov <ash@kambanaria.org>\n"
 "Language-Team: Bulgarian <dict@fsa-bg.org>\n"
@@ -30,99 +29,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Системна шина"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Пълeн достъп"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Сесийна шина"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Устройства"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Пълен достъп до „/dev“"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Мрежа"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Има достъп до мрежата"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Домашна папка"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Само за четене"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Файлова система"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Настройки"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Може да променя настройки"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"Следните права са вградени в „%s“ и не може да бъдат променени. Ако това е "
-"проблем, деинсталирайте програмата."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u вид файл и връзки се отварят с програмата"
-msgstr[1] "%u вида файлове и връзки се отварят с програмата"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> отваря следните видове файлове и връзки."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "Ползват се %s от дисковото пространство."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -138,7 +45,6 @@ msgid "Install some…"
 msgstr "Инсталиране на…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Отваряне"
 
@@ -162,24 +68,13 @@ msgstr "Търсене"
 msgid "Receive system searches and send results."
 msgstr "Получаване на системните търсения и изпращане на резултатите."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "изключено"
 
@@ -344,82 +239,22 @@ msgstr "Изчистване на кеша…"
 msgid "Control various application permissions and settings"
 msgstr "Управление на настройките и правата на програмите"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "програма;приложение;флатпак;права;настройки;конфигурации;application;flatpak;"
 "permission;setting;"
 
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Избор на изображение"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Отказ"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Отваряне"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "различни размери"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Без фон на работния плот"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Текущ фон"
-
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Стил"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Стандартен"
 
@@ -443,7 +278,6 @@ msgstr "Външен вид"
 msgid "Change your background image or the UI colors"
 msgstr "Смяна на фона и темата"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -496,9 +330,7 @@ msgstr "Самолетният режим е изключен"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Изключване на самолетния режим, за да се включи Bluetoothл"
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Връзка по Bluetooth"
 
@@ -506,7 +338,6 @@ msgstr "Връзка по Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Включване и изключване на Bluetooth и свързване на устройствата"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr ""
@@ -541,96 +372,35 @@ msgstr "Никоя програма не е заявила достъп до к�
 msgid "Protect your pictures"
 msgstr "Защита на изображенията"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "камера;снимки;фотографии;видео;уебкамера;заключване;защита;лични;данни;"
 "camera;photos;video;webcam;lock;private;privacy;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Поставете калибриращото устройство върху квадрата и натиснете бутона „Начало“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Установете устройството на положение за калибриране и натиснете бутона "
-"„Нататък“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Установете калибриращото устройство към повърхността и натиснете бутона "
-"„Нататък“"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Затваряне на екрана на компютъра"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Възникна вътрешна грешка, която не може да бъде отстранена."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Инструментите за калибриране не са инсталирани."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Профилът не може да бъде създаден."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Целевата бяла точка не може да бъде достигната."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Калибрирането завърши!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Неуспешно калибриране!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Можете да махнете калибриращото устройство."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "По време на калибрирането не пипайте устройството и екрана"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Калибриране на екран"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Отказ"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -647,138 +417,6 @@ msgstr "_Продължаване"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Готово"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Екран на мобилен компютър"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Вградена камера"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Екран „%s“"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Скенер „%s“"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Фотоапарат „%s“"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Принтер „%s“"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Уеб камера „%s“"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Включване на управлението на цветовете за „%s“"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Показване на цветовите профили за „%s“"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Не е калибрирано"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Стандартен: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Цветово пространство: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Пробен профил: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Избиране на файл с цветови профил (ICC)"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Внасяне"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Поддържани цветови профили (ICC)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Всички файлове"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Екран"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Запазване на профил"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Запазване"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Създаване на цветови профил за избраното устройство"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "Не е открит колориметър. Проверете дали е включен и свързан правилно."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Колориметърът не поддържа принтери."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Текущият вид устройството не се поддържа."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -895,9 +533,9 @@ msgstr "Изисква носител с възможност за запис"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Инструкциите как да ползвате профила под различни операционни системи се "
 "намират тук: <a href='linux'>GNU/Linux</a>, <a href='osx'>Apple OS X</a> и "
@@ -921,7 +559,6 @@ msgstr "_Внасяне на файл…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -933,9 +570,7 @@ msgstr ""
 "Всяко устройство се нуждае от актуален цветови профил, за да бъдат "
 "управлявани цветовете му."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Научете повече"
 
@@ -1070,82 +705,6 @@ msgstr "D65 (Фотография и графики)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Стандартно пространство"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Пробен профил"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Автоматично генериран профил"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Ниско качество"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Средно качество"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Високо качество"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Стандартно ЧЗС (RGB)"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Стандартно ЦМЖЧ (CMYK)"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Стандартно сиво"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Стандартни калибровъчни данни от производителя на устройството"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "При този профил е невъзможна пълноекранна цветова корекция"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Профилът може вече да не е точен"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Цвят"
@@ -1155,16 +714,11 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Калибриране на цвета на устройствата като екрани, камери, принтери"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "цвят;профил;калибриране;принтер;екран;color;icc;profile;calibrate;printer;"
 "display;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Друг…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1179,13 +733,8 @@ msgid "No languages found"
 msgstr "Няма езици"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Допълнителни…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Отключете за промяна на настройките"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1214,151 +763,6 @@ msgstr "Час назад"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Минута назад"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "днес"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "вчера"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%е %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d час"
-msgstr[1] "%d часа"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d минута"
-msgstr[1] "%d минути"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d секунда"
-msgstr[1] "%d секунди"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 секунди"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Точка за безжичен достъп"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-часов"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "12-часов"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1453,17 +857,11 @@ msgstr "Автоматичен часови _пояс"
 msgid "Requires location services enabled and internet access"
 msgstr "Изисква връзка към Интернет и включени услуги за местоположение"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Включен"
 
@@ -1471,15 +869,43 @@ msgstr "Включен"
 msgid "Time Z_one"
 msgstr "_Часови пояс"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Отключване"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Формат на времето"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Дати"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 секунди"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Календар"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Числа"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Смяна на датата, часа, часовия пояс"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr ""
@@ -1529,22 +955,11 @@ msgstr "Стандартни програми"
 msgid "Configure Default Applications"
 msgstr "Задаване на стандартни програми"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "стандартни;предпочитани;приложения;програми;носители;медия;default;"
 "application;preferred;media;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Докладите за грешка помагат да се подобри „%s“. Те се изпращат анонимно и "
-"без идентифицираща потребителя информация. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1562,44 +977,9 @@ msgstr "Диагностика"
 msgid "Report your problems"
 msgstr "Докладвайте проблем"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "диагностика;забиване;блокиране;diagnostics;crash;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Включване"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Изключване"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Да се приложат ли промените?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Промените не може да се приложат"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Това може да се дължи на ограничение на хардуера."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1649,31 +1029,6 @@ msgstr "Основен екран"
 msgid "Night Light"
 msgstr "Нощен режим"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Хоризонтална"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Вертикална дясна"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Вертикална лява"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Хоризонтална обратна"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1697,6 +1052,17 @@ msgstr "За телевизор"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Мащабиране"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Естествено придвижване (като в OS X)"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1792,7 +1158,6 @@ msgstr "Екрани"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Изберете как да се използват свързаните екрани и проектори"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1801,81 +1166,6 @@ msgstr ""
 "панел;проектор;екран;разделителна;способност;опресняване;монитор;дисплей;нощ;"
 "светлина;яркост;завъртане;ротация;синя;червена;panel;projector;xrandr;screen;"
 "resolution;refresh;monitor;night;light;blue;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Атестираното стартиране е включено"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Атестираното стартиране (Secure boot) предотвратява зареждането на софтуер, "
-"който не е одобрен, при стартирането на системата. Тази защита е включена и "
-"в момента работи правилно."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Атестираното стартиране има проблеми"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Атестираното стартиране (Secure boot) предотвратява зареждането на софтуер, "
-"който не е одобрен, при стартирането на системата. Тази защита е включена, "
-"но не работи, защото ползва неправилен ключ."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Проблемите с атестираното стартиране (Secure boot) често може да се "
-"коригират от настройките на фърмуера UEFI (новият вариант на BIOS), а "
-"производителят на хардуера може да ви даде информация как да го направите."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"За помощ се обърнете към производителя на хардуера или доставчика ви на "
-"услуги по поддръжка на IT."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Атестираното стартиране е изключено"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Атестираното стартиране (Secure boot) предотвратява зареждането на софтуер, "
-"който не е одобрен, при стартирането на системата. Тази защита не е включена."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Атестираното стартиране (Secure boot) може да се включи от настройките на "
-"фърмуера UEFI (новият вариант на BIOS). За помощ се обърнете към "
-"производителя на хардуера или доставчика ви на услуги по поддръжка на IT."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1890,129 +1180,9 @@ msgstr ""
 "За помощ се обърнете към производителя на хардуера или доставчика ви на "
 "услуги по поддръжка на IT."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Успешно преминато"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Неуспешно преминаване"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Устройството отговаря на ниво HSI %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Ниво на сигурност 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Това устройство няма никаква защита срещу проблеми на сигурността на "
-"хардуера. Това може да се дължи на хардуерен или конфигурационен проблем. "
-"Препоръчваме ви да се свържете с доставчика ви на услуги по поддръжка на IT."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Ниво на сигурност 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Това устройство има минимална защита срещу проблеми на сигурността на "
-"хардуера. Това е най-ниското ниво сигурност и тя работи единствено срещу най-"
-"простите атаки."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Ниво на сигурност 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Това устройство има основна защита срещу проблеми на сигурността на "
-"хардуера. Тя работи срещу най-честите атаки."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Ниво на сигурност 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Това устройство има допълнителна защита срещу проблеми на сигурността на "
-"хардуера. Това е най-високото ниво на защита дори и срещу силни атаки."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Ниво на сигурността"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Нивата за сигурност не са приложими за това устройство."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr "Свържете се с производителя на хардуера за обновления на сигурността."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Възможно е проблемът да бъде отстранен с промяна на настройка във фърмуера "
-"UEFI или от служител от поддръжката."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Възможно е проблемът да бъде отстранен с промяна на настройка във фърмуера "
-"UEFI."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Възможно е проблемът да бъде отстранен от служител от поддръжката."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2026,339 +1196,9 @@ msgstr "Ниво 2"
 msgid "Level 3"
 msgstr "Ниво 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Има защита срещу злоумишлен софтуер при стартирането на устройството."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Проблеми в атестираното стартиране"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Някаква защита при стартиране на устройството."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Атестираното стартиране е изключено"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Без защита при стартиране на устройството."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Проблемът може да се дължи на промяна на настройките на фърмуера UEFI, "
-"промяна на настройките на операционната система или присъствието на "
-"злоумишлен софтуер."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Проблемът може да се дължи на промяна на настройките на фърмуера UEFI или "
-"присъствието на злоумишлен софтуер."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Проблемът може да се дължи на промяна на настройките на операционната "
-"система или присъствието на злоумишлен софтуер."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Никаква защита към атаки срещу сигурността."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Ограничена защита към най-простите атаки срещу сигурността."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Защитено към чести атаки срещу сигурността."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Защитено към голям спектър от атаки срещу сигурността."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Допълнителна защита"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Няма събития"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Защита на фърмуера срещу презапис"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Заключване на защитата на фърмуера срещу презапис"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Регион за фърмуера за BIOS"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Описание на фърмуера на BIOS-а"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr ""
-"Защита преди стартиране срещу атака с директния достъп до паметта (DMA)"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Стартирането е атестирано от Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Първоначалният блок за зареждане ще се провери (Intel BootGuard ACM)"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Политика на грешките на Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Бушон на Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Технологията за управление на контрола (Intel CET) е включена"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Технологията за управление на контрола (Intel CET) работи"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Предотвратяване на свръхадминистративен достъп (Intel SMAP)"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Шифрирана памет (RAM)"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Вх./Изх. защита IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Заключване на ядрото Linux"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Проверка на ядрото Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Странициране на Linux"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Приспиване към паметта"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Приспиване към бездействие"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Платформен ключ на UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Атестирано стартиране на UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Настройки на платформата за доверие (TPM)"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Възстановяване на платформата за доверие (TPM)"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "Модул за доверие на платформана (TPM) v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Режим на производител на модула за управление на Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Преодоляване на модула за управление на Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Версия на платформата за управление на Intel"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Обновления на фърмуера"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Атестиране на фърмуера"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Проверка на програмата за обновяване на фърмуера"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Изчистване на грешки на платформата"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Проверки на сигурността на процесора"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Защита на AMD срещу връщане на стара версия"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Защита на AMD срещу повтаряне на фърмуера"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Защита на AMD срещу запис на фърмуера"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Слята платформа"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Валидно"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Невалидно"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Изключено"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Заключено"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Отключено"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Шифрирано"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Нешифрирано"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Замърсено"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Чисто"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Открито"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Липсва"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Поддържано"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Неподдържано"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2368,7 +1208,6 @@ msgstr "Сигурност на устройство"
 msgid "Host firmware security status"
 msgstr "Състояние на сигурността на фърмуера"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2378,49 +1217,6 @@ msgstr ""
 "личен;таен;скрит;временен;индекс;име;мрежа;идентичност;защита;данни;screen;"
 "lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
 "identity;privacy;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Неизвестен"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64 бита"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32 бита"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Неизвестно"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Липсва"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Лого на системата"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2514,11 +1310,6 @@ msgstr "Относно"
 msgid "View information about your system"
 msgstr "Извеждане на информация за компютъра"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2599,6 +1390,12 @@ msgstr "Стартери"
 msgid "Launch help browser"
 msgstr "Стартиране на програмата за помощ"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Настройки"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Стартиране на калкулатор"
@@ -2620,7 +1417,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Търсене"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Система"
 
@@ -2669,15 +1466,6 @@ msgstr "Намаляване на размера на текста"
 msgid "High contrast on or off"
 msgstr "Включване/изключване на високия контраст"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Няма входни устройства"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Друго"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Добавяне на входно устройство"
@@ -2710,106 +1498,9 @@ msgstr "Настройки"
 msgid "View Keyboard Layout"
 msgstr "Подредба на клавиатурата"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Премахване"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Потребителски клавишни комбинации"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Клавиш за допълнителни знаци"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Този клавиш позволява да въвеждате допълнителни знаци. Понякога те са "
-"отпечатани като трети знак на съответния клавиш."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Ляв Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Десен Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Ляв Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Десен Супер"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Клавиш Menu"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Десен Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Клавиш Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"С клавиша „Compose“ можете да въвеждате (композирате) много различни знаци. "
-"За да го ползвате — натиснете го и след това въведете последователност от "
-"знаци. Например: „Compose“, <b>C</b> и <b>o</b> дават <b>©</b>, а „Compose“, "
-"<b>a</b> и <b>'</b> дават <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Може да сменяте входните методи с клавишната комбинация „%s“.\n"
-"Можете да промените това в настройките за клавишните комбинации"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2840,45 +1531,21 @@ msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Начини за въвеждане на специални знаци, символи и форми с клавиатурата."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Клавиш за допълнителни знаци"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Клавиш Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Клавишни комбинации"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Преглед и настройки на клавишните комбинации"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d променен"
-msgstr[1] "%d променени"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Използване на оригиналните клавишни комбинации?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Вашите комбинации ще се изчистят и ще се върнат оригиналните комбинации. "
-"Това действие е необратимо."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Отказ"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Оригинални комбинации"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2917,33 +1584,6 @@ msgstr "Добавяне на клавишна комбинация"
 msgid "No keyboard shortcut found"
 msgstr "Няма клавишни комбинации"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s вече се ползва за %s. Ако го замените, %s ще бъде изключен"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Въведете нова клавишна комбинация"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Потребителска клавишна комбинация"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Клавишна комбинация"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Въведете новата клавишна комбинация, за да смените %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Добавяне на клавишна комбинация"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "Пре_махване"
@@ -2955,7 +1595,6 @@ msgstr "З_амяна"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Задаване"
 
@@ -2991,6 +1630,11 @@ msgstr "Без"
 msgid "Reset the shortcut to its default value"
 msgstr "Използване на оригиналните клавишни комбинации"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Стандартен принтер"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Клавиатура"
@@ -3003,7 +1647,6 @@ msgstr ""
 "Настройки на клавишните комбинации, подредбите, входните методи и другите "
 "настройки на клавиатурата"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3047,7 +1690,6 @@ msgstr "Никоя програма не е поискала достъп до �
 msgid "Protect your location information"
 msgstr "Защита на местоположението"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "местоположение;защита;лични;данни;location;gps;private;privacy;"
@@ -3082,7 +1724,6 @@ msgstr "Никоя програма не е заявила достъп до м�
 msgid "Protect your conversations"
 msgstr "Защита на разговорите"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
@@ -3114,81 +1755,139 @@ msgstr "Ляв"
 msgid "Right"
 msgstr "Десен"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Къде да се търси"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Мишка"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Скорост на мишката"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Естествено придвижване (като в OS X)"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Никаква защита"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Придвижва се съдържанието, а не изгледът."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Придвижва се съдържанието, а не изгледът."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Активна"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Сензорен панел"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Скорост на сензорния панел"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Натискане чрез тупване"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Натискане чрез тупване"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Придвижване с два пръста"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Скорост на сензорния панел"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Придвижване чрез ръбовете"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Двустранно"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Изпробвайте натискане, двойно натискане и придвижване"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Пет натискания — време е за GEGL"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Двойно натискане на основния бутон"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Натискане на основния бутон"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Двойно натискане на средния бутон"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Натискане на средния бутон"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Двойно натискане на втория бутон"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Натискане на втория бутон"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3201,7 +1900,6 @@ msgstr ""
 "Избор на чувствителността на мишката или сензорния панел и дали е за лява "
 "или дясна ръка"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3285,7 +1983,6 @@ msgstr "Многозадачност"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Настройките за производителност и работа по много задачи"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3294,20 +1991,11 @@ msgstr ""
 "пространство;активни;ъгли;работни;пространства;multitasking;multitask;"
 "productivity;customize;desktop;hot corner;workspaces;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Възникна грешка, свържете се с доставчика на софтуера."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager трябва да е стартиран."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Други устройства"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "ВЧМ (VPN)"
 
@@ -3319,59 +2007,16 @@ msgstr "Добавяне на връзка"
 msgid "Not set up"
 msgstr "Не е настроена"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Несигурна мрежа (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Сигурна мрежа (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Сигурна мрежа (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Сигурна мрежа (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Сигурна мрежа"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Връзката е осъществена"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Настройки…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Ако включите точката за достъп, ще се изключите от %s и няма да имате достъп "
-"до Интернет през Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Трябва да е поне 8 знака."
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3421,21 +2066,6 @@ msgstr "Автоматично генериране на парола"
 msgid "_Turn On"
 msgstr "_Включване"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Безжична мрежа"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-"Спиране на точката за безжичен достъп и изключване на всички потребители?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Спиране на точката за безжичен достъп"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Самолетен режим"
@@ -3480,89 +2110,13 @@ msgstr "Видими мрежи"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager трябва да е стартиран"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Възникна грешка, свържете се с доставчика на софтуера."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Сигурност – 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Сигурност"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Запазване"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Постоянен"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Случаен"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Стабилен"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Апаратният адрес определя хардуерния адрес при задействането на мрежовата "
-"връзка. Тази възможност понякога се нарича клониране или имитиране на MAC "
-"адрес. Напр.: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Профил %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Подобрена отворена"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Корпоративна"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Без"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "никога"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3571,183 +2125,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "преди %i ден"
 msgstr[1] "преди %i дни"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz/5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Няма сигнал"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Слаб сигнал"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Задоволителен сигнал"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Добър сигнал"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Отличен сигнал"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Адрес (IPv4)"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Адрес (IPv6)"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Адрес по IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "Система от имена (DNS)"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Забравяне на връзка"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Изтриване на настройките на връзката"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Премахване на ВЧМ"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Подробности"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "автоматично"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Идентичност"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Изтриване на адрес"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Изтриване на маршрут"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Без"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "40/128 битов ключ за WEP (шестнайсетичен или ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "128 битова парола за WEP"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Динамичен WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "Частна WPA & WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "Корпоративна WPA или WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "Частна WPA3"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3758,8 +2135,20 @@ msgstr "Сила на сигнала"
 msgid "Link speed"
 msgstr "Скорост на връзката"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Сигурност"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Адрес (IPv4)"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Адрес (IPv6)"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Апаратен адрес"
 
@@ -3768,12 +2157,17 @@ msgid "Supported Frequencies"
 msgstr "Поддържани честоти"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Стандартен маршрут"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "Система от имена (DNS)"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3836,7 +2230,7 @@ msgstr "Само локално за връзката (169.254.0.0/16)"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Ръчно"
 
@@ -3880,9 +2274,8 @@ msgstr "Шлюз"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Автоматично"
 
@@ -3935,89 +2328,9 @@ msgstr "Автоматично – само DHCP"
 msgid "Prefix"
 msgstr "Префикс"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Неуспешно отваряне на редактора на адреси"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Нов профил"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Неправилни настройки за %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Неправилни настройки за %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Внасяне от файл…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Нова ВЧМ"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "С_игурност"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Настройките за ВЧМ не могат да бъдат внесени"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Файлът „%s“ не може да бъде прочетен или не съдържа позната информация за "
-"ВЧМ.\n"
-"\n"
-"Грешка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Избор на файл за внасяне"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Вече съществува файл с име „%s“."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Замяна"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Искате ли да замените „%s“ с ВЧМ, която внасяте?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Настройките за ВЧМ не могат да бъдат изнесени"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Настройките за ВЧМ „%s“ не могат да бъдат изнесени в „%s“.\n"
-"\n"
-"Грешка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Изнасяне на настройките за ВЧМ"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4031,11 +2344,16 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Мрежа"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Настройки на връзката към Интернет"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
@@ -4043,11 +2361,15 @@ msgstr ""
 "частна;връзка;име;имена;network;ip;lan;proxy;wan;broadband;modem;bluetooth;"
 "vpn;dns;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Безжична мрежа"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Настройки на безжичната връзка"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
@@ -4055,81 +2377,9 @@ msgstr ""
 "имена;гореща;точка;достъп;network;wireless;wi-fi;wifi;ip;lan;broadband;dns;"
 "hotspot"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "никога"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "днес"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "вчера"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Последно ползване"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Жична мрежа"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Добавяне на нова връзка"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Данните за посочените мрежи, включително пароли и потребителски настройки ще "
-"бъдат изгубени."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Забравяне"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Познати безжични мрежи"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Премахване"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Системните политики забраняват създаването на точка за безжичен достъп"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Безжичното устройство не поддържа режим за точка за безжичен достъп"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Автоматичното откриване на уеб сървър-посредник се използва, когато не е "
-"зададен адрес за настройка."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Не се препоръчва за недоверени, общодостъпни мрежи."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4148,6 +2398,10 @@ msgstr "Идентификатор за устройства (IMEI)"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Доставчик"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Адрес по IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4232,304 +2486,6 @@ msgstr "_Точка за безжичен достъп…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Познати безжични мрежи"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Неизвестно състояние"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Без управление"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Недостъпна"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Свързване"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Изисква се удостоверяване"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Прекъсване на връзката"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Връзката е неуспешна"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Състоянието на връзката е неизвестно (липсва информация)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Неуспешно настройване"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Неуспешно настройване на IP адреса"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Изтече времето за настройката на IP адреса"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Не бяха предоставени задължителните данни за установяване на връзката"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr ""
-"Връзката (802.1x) бе прекъсната от програмата за удостоверяване (supplicant)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-"Неуспех при настройка на програмата за удостоверяване (supplicant) на "
-"връзката (802.1x)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr ""
-"Програмата за удостоверяване (supplicant) на връзката (802.1x) приключи "
-"неуспешно"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-"Удостоверяването на връзката (802.1x) отне на програмата (supplicant) повече "
-"време от стандартното"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Неуспешно стартиране на услугата за връзка чрез PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Услугата за връзка чрез PPP е прекъсната"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Услугата за връзка чрез PPP приключи неуспешно"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr ""
-"Неуспешно стартиране на клиента за автоматична настройка на връзката (DHCP)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Грешка на клиента за автоматична настройка на връзката (DHCP)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr ""
-"Клиентът за автоматична настройка на връзката (DHCP) приключи неуспешно"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Неуспешно стартиране на услугата за споделяне на връзката"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Услугата за споделяне на връзката приключи неуспешно"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr ""
-"Неуспешно стартиране на услугата за локална връзка (AutoIP, 169.254.0.0/16, "
-"fe80::/10)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr ""
-"Грешка в услугата за локална връзка (AutoIP, 169.254.0.0/16, fe80::/10)"
-
-# AutoIP = link-local
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr ""
-"Услугата за локална връзка (AutoIP, 169.254.0.0/16, fe80::/10) приключи "
-"неуспешно"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Линията е заета"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Няма сигнал"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Неуспешно установяване на носещата честота"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Времето на заявката за набиране изтече"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Опитът за набиране приключи неуспешно"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Неуспешно инициализиране на модема"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Неуспешно избиране на зададената точка за достъп (APN)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Не се търсят мрежи"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Регистрацията в мрежата е отхвърлена"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Времето на заявката за регистрация в мрежата изтече"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Неуспешна регистрация в заявената мрежа"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Неуспешна проверка на ПИН кода"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Възможно е фърмуерът за устройството да липсва"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Връзката се изгуби"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Предполагаше се съществуваща връзка"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Няма модем"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Неуспешна връзка чрез Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr " SIM картата не е поставена"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Необходим е ПИН код за SIM картата"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Необходим е код (PUK) за SIM картата"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Грешна SIM карта"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Неуспешно активиране на зависимост за връзката"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Липсва фърмуер"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Кабелът е изваден"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "грешка в сигурността 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "не е избран файл"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "грешка при проверката на файла за eap"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Частни ключове във формат DER, PEM или PKCS#12"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Сертификати формат DER или PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "файлът за EAP-FAST PAC липсва"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Файлове във формат PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4578,14 +2534,6 @@ msgstr "_Вътрешно удостоверяване"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "_Автоматично осигуряване на PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "липсва потребителско име за EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "липсва парола за EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4611,16 +2559,6 @@ msgstr "_Парола"
 msgid "Sho_w password"
 msgstr "_Показване на паролата"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "неправилен сертификат на удостоверител за EAP-PEAP: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-"неправилен сертификат на удостоверител за EAP-PEAP: не е указан сертификат"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4642,7 +2580,6 @@ msgid "C_A certificate"
 msgstr "_Сертификат на удостоверител"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4657,63 +2594,6 @@ msgstr "_Не се изисква сертификат на удостовери
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Версия на PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "липсва потребителско име за EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "липсва парола за EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "липсва идентичност за EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "неправилен сертификат на удостоверител за EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-"неправилен сертификат на удостоверител за EAP-TLS: не е указан сертификат"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "неправилен частен ключ за EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "неправилен потребителски сертификат за EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Нешифрираните лични ключове са несигурни"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Избраният частен ключ не е защитен с парола. Това позволява компрометирането "
-"на идентичността ви. Изберете частен ключ, защитен с парола.\n"
-"\n"
-"(Можете да защитите частния ключ с парола чрез командата „openssl“)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Изберете личния си сертификат"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Изберете частния си ключ"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4730,16 +2610,6 @@ msgstr "_Частен ключ"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Парола за _частния ключ"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "неправилен сертификат на удостоверител за EAP-TTLS: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-"неправилен сертификат на удостоверител за EAP-TTLS: не е указан сертификат"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4762,14 +2632,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Област/домейн"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Грешка при валидиране на сигурността за 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4797,62 +2668,10 @@ msgstr "Защитен EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Удостоверяване"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Избор на файл"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "липсва потребителско име за leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "липсва парола за leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Липсва парола за безжичната мрежа."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Вид"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "липсва ключ за wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"неправилен ключ за wep: ключ с дължина от %zu знака трябва да съдържа само "
-"шестнадесетични цифри"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"неправилен ключ за wep: ключ с дължина от %zu знака трябва да съдържа само "
-"ASCII"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"неправилен ключ за wep: неправилна дължина на ключа — %zu. Той трябва да е "
-"дълъг или 5/13 знака за ASCII, или 10/26 знака за шестнадесетични цифри"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "неправилен ключ за wep: празна парола"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "неправилен ключ за wep: паролата трябва да е под 64 знака"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4877,21 +2696,6 @@ msgstr "Пок_азване на ключа"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Индек_с в WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"неправилен ключ за wpa-psk: дължината на ключа е %zu. Трябва да е от 8 до 63 "
-"байта или 64 шестнадесетични цифри"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"неправилен ключ за wpa-psk: ключът е дълъг 64 байта, но не се състои само от "
-"шестнадесетични цифри"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4946,29 +2750,11 @@ msgstr "Известия при _заключен екран"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Управление на известията и тяхната детайлност"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "предупреждения;известия;съобщения;тава;изскачащ;notifications;banner;message;"
 "tray;popup;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Друга"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s — изтрит"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Неуспешно премахване на регистрация"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4994,17 +2780,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Добавяне на регистрация в сайт"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Регистрация в „%s“"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Премахване на регистрация"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Регистрации в Интернет"
@@ -5015,10 +2790,6 @@ msgstr ""
 "Свързване с регистрациите ви в някои сайтове и задаване за какво да се "
 "ползват"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5028,10 +2799,6 @@ msgstr ""
 "оун;клауд;керберос;цербер;имап;smtp;покет;покит;рийд;google;facebook;twitter;"
 "yahoo;web;online;chat;calendar;mail;contact;owncloud;kerberos;imap;smtp;"
 "pocket;readitlater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Неизвестно време"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5047,13 +2814,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i час"
 msgstr[1] "%i часа"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s и %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5065,191 +2825,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "минута"
 msgstr[1] "минути"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "Остават %s до пълно зареждане"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Внимание: остават %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "остават %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Пълно зареждане"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Не се зарежда"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Разредена"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Зареждане"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Разреждане"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Безжична мишка"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Безжична клавиатура"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Непрекъсваемо токозахранване"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Цифров помощник"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Мобилен телефон"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Музикално устройство"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Таблет"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Компютър"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Контролер за игри"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Батерия"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Основна"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Допълнителна"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Батерии"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "При _бездействие"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "приспиване"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Изключване"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "дълбоко приспиване"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "нищо"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "При работа от батерии"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "При включване на захранването"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Никога"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Автоматично приспиване"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Режимът на висока производителност е изключен поради прекалено високата "
-"температура на хардуера."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Засечена е работа в скута на потребителя, затова режимът на висока "
-"производителност е недостъпен. Сложете устройството на стабилна повърхност, "
-"за се върне достъпът до този режим."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Високата производителност временно е изключена."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Нисък заряд на батерията, затова е включен режимът на енергоспестяване. "
-"Предишният режим ще се включи отново след достатъчно зареждане на батерията."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Енергоспестяването е включено от „%s“."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Високата производителност е включена от „%s“."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5310,6 +2885,15 @@ msgstr "100 минути"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 часа"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батерия"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Устройства"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5388,33 +2972,6 @@ msgstr "Работа от _батерии"
 msgid "Delay"
 msgstr "Закъснение"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Висока производителност"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Високи производителност и енергопотребление."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Баланс"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Стандартни производителност и енергопотребление."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Енергоспестяване"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "По-ниски производителност и енергопотребление."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Висока производителност"
@@ -5425,7 +2982,6 @@ msgstr ""
 "Преглед на състоянието на батерията и промяна на настройките на "
 "енергоспестяването"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5434,27 +2990,6 @@ msgstr ""
 "захранване;дълбоко;приспиване;заспиване;батерия;яркост;затъмняване;"
 "изчистване;екран;капак;бездействие;power;sleep;suspend;hibernate;battery;"
 "brightness;dim;blank;monitor;dpms;idle;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Принтерът „%s“ е изтрит"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Неуспешно добавяне на нов принтер."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Неуспешно зареждане на файла с потребителския интерфейс „%s“"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Отключете, за да добавите принтери и да промените настройките"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5465,7 +3000,6 @@ msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Добавяне на принтери, преглед на задачите за печат, настройки на печата"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -5475,8 +3009,6 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Добавяне на принтер"
 
@@ -5516,29 +3048,6 @@ msgstr ""
 msgid "Username"
 msgstr "Потребителско име"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Подробности за „%s“"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Няма подходящ драйвер"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Избор на файл – PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Файлове на PostScript за описание на принтери (*.ppd, *.PPD, *.ppd.gz, *.PPD."
-"gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Имената на принтери не може да съдържат празни знаци, „#“ или „/“"
@@ -5547,9 +3056,7 @@ msgstr "Имената на принтери не може да съдържат
 msgid "Location"
 msgstr "Местоположение"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Драйвер"
 
@@ -5577,140 +3084,20 @@ msgstr "Избор на драйвер за принтер"
 msgid "Loading drivers database…"
 msgstr "Зареждане на списъка с драйвери…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Отказ"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Избор"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Принтер по JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Принтер по LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Едностранно"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "По дългата страна (стандартно)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "По късата страна (завъртане)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Вертикална"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Хоризонтална"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Вертикална, обърната"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Хоризонтална, обърната"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Продължаване"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "На пауза"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "в опашката"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "На пауза"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Изисква се идентификация"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "обработвана"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "спряна"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "отказана"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "прекъсната"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "завършена"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Задачата да бъде първа в опашката"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u задача изисква удостоверяване"
 msgstr[1] "%u задачи изискват удостоверяване"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "„%s“ – активни задачи"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Удостоверете самоличността, за да печатате с „%s“."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5738,321 +3125,17 @@ msgstr "_Удостоверяване"
 msgid "No Active Printer Jobs"
 msgstr "Няма активни задачи"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Отключване на сървъра за печат"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Отключване на „%s“."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Въведете името и паролата си, за да видите принтерите при „%s“."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Търсене на принтери"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Сериен порт"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Паралелен порт"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Местоположение: „%s“"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Адрес: „%s“"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Сървърът изисква удостоверяване"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Двустранно"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Вид на хартията"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Източник на хартията"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Изходяща тава"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Разделителна способност"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Предварителен филтър на GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Страници на лист"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Двустранно"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Ориентация"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Общи"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Настройка на страницата"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Апаратни настройки"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Задача"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Качество на изображенията"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Цвят"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Довършителни"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Разширени"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Пробна страница"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Пробна страница"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Автоматичен избор"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Стандартното за принтера"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Вграждане само на шрифтовете на GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Преобразуване към PostScript, ниво 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Преобразуване към PostScript, ниво 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Без предварителен филтър"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Производител"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Няма активни задачи"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u задача"
 msgstr[1] "%u задачи"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Изчистване на печатащите глави"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Тонерът привършва"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Тонерът свърши"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Проявителят привършва"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Проявителят свърши"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Мастилото привършва"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Мастилото свърши"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Отворен капак"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Отворена вратичка"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Хартията привършва"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Хартията свърши"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Изключен"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "спрян"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Контейнерът за отпадъчно мастило е почти пълен"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Контейнерът за отпадъчно мастило е пълен"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Барабанът е почти износен"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Барабанът е износен"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "в готовност"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "не приема задачи"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "обработване"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6076,6 +3159,10 @@ msgstr "Изчистване на печатащите глави"
 msgid "Remove Printer"
 msgstr "Премахване на принтер"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Няма активни задачи"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6096,16 +3183,21 @@ msgid "Restart"
 msgstr "Рестартиране на принтера"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Добавяне на принтер…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Добавяне на принтер…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Няма принтери"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6113,7 +3205,6 @@ msgstr ""
 "Изглежда, че системната услуга\n"
 "    за печат не е налична."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Формати"
@@ -6141,16 +3232,6 @@ msgstr "Търсенето може да е по държави или езиц�
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Преглед"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "имперска"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "метрична"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6188,20 +3269,24 @@ msgstr ""
 "Настройките за език важат за интерфейса и уеб страниците. Форматите са за "
 "числа, дати и валути."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Моята регистрация"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Език"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Формати"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Екран за вход"
 
@@ -6214,101 +3299,9 @@ msgid "Select your display language and formats"
 msgstr ""
 "Избор на език на интерфейса и форматите на числата, датите, времето, парите"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "език;подредба;клавиатура;вход;language;layout;keyboard;input;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "да се пита за действие"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "нищо да не се прави"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "отваряне на папката"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Други носители"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Избор на програма, с която да отваряте аудио дискове (CD)"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Избор на програма, с която да отваряте видео дискове (DVD)"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Избор на програма, която да се изпълнява при свързване на преносимо "
-"устройство за музика"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Изберете програма, която да се изпълнява при свързване на камера"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Избор на програма, с която да се отварят дискове с програми"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "аудио диск – DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "празен диск – Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "празен диск – CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "празен диск – DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "празен диск – HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "видео диск – Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "четец на електронни книги"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "видео диск – HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "диск с изображения – CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "видео диск – Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "видео диск – Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Програми за Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6360,7 +3353,6 @@ msgstr "Преносими носители"
 msgid "Configure Removable Media settings"
 msgstr "Настройки за преносимите носители"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6370,114 +3362,6 @@ msgstr ""
 "звук;аудио;видео;диск;преносим;носител;автоматично;стартиране;device;system;"
 "default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;"
 "autorun;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Екранът се изключва"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 секунди"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 минута"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 минути"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 минути"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 минути"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 минути"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 час"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 минута"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 минути"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 минути"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 минути"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 минути"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 минути"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 минути"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 минути"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 минути"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "никога"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6515,11 +3399,16 @@ msgstr "Период след изключването на екрана, ког
 msgid "Show _Notifications on Lock Screen"
 msgstr "Показване на _известия при заключен екран"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Известия при _заключен екран"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "_Забраняване на нови устройства по USB"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6527,30 +3416,25 @@ msgstr ""
 "Устройствата по USB да не взаимодействат с компютъра, когато екранът е "
 "заключен."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Поверителност на екрана"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Ограничаване на ъгъла на видимост"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Екран"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Настройки на екрана"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "екран;заключване;поверителност;скриване;screen;lock;private;privacy;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Избор на регион"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Добре"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6581,10 +3465,6 @@ msgstr "Други"
 msgid "Add Location"
 msgstr "Добавяне на местоположение"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Няма програми"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Търсене чрез програмите"
@@ -6612,95 +3492,15 @@ msgstr ""
 "Определяне на приложенията, които да показват резултати в прегледа на "
 "дейностите"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "търсене;намиране;индекс;скриване;личен;частен;резултати;search;find;index;"
 "hide;privacy;results;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Не са избрани мрежи за споделяне"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Мрежи"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Включена"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Изключена"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Включена"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Активна"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Избор на папка"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Добавяне"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Включване на споделянето на медия"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Споделянето на лични файлове ви позволява да споделите папката „Публични“ с "
-"други потребители през текущата мрежа чрез следния адрес: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Позволяване на отдалечените потребители да се връзват към машината ви с "
-"команда за сигурна обвивка:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Включване на споделянето на собствените медийни файлове"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Името на устройството е копирано"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Адресът на устройството е копиран"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Потребителското име е копирано"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Паролата е копирана"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6832,7 +3632,6 @@ msgstr "Папки"
 msgid "Control what you want to share with others"
 msgstr "Определяне какво да се споделя с другите"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6853,10 +3652,6 @@ msgstr "Включване или изключване на отдалечена
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Изисква се удостоверяване за превключване на отдалечената графична връзка"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Потребителско"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6889,11 +3684,6 @@ msgstr "Отзад"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Отпред"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Проба на %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6947,11 +3737,6 @@ msgstr "Сила на звука"
 msgid "Alert Sound"
 msgstr "Сила на известяването"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100 %"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Заглушаване"
@@ -6966,7 +3751,6 @@ msgstr ""
 "Промяна на силата на звука, звуците свързани със събития, аудио входовете и "
 "изходите"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6974,76 +3758,6 @@ msgstr ""
 "карта;микрофон;сила;звука;затихване;баланс;блутут;син;зъб;слушалки;звук;"
 "аудио;увеличаване;намаляване;заглушаване;млъкване;вход;изход;жак;чинч;card;"
 "microphone;volume;fade;balance;bluetooth;headset;audio;output;input;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Без връзка"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Свързване"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Свързано"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Грешка при упълномощаване"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Упълномощаване"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Непълна функционалност"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Свързано и одобрено"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Неизвестно"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Одобрено на:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Свързано на:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Одобрено и добавено на:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Неуспешно одобряване на устройство: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Неуспешно забравяне на устройство: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7077,57 +3791,6 @@ msgstr "Одобряване и свързване"
 msgid "Forget Device"
 msgstr "Забравяне на устройство"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Грешка"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Одобрено"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Подсистемата за Thunderbolt (boltd) или не е инсталирана, или не е настроена "
-"правилно."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Позволяване на директен достъп до устройства като докинг станции и външни "
-"GPU-та."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Може да се свързват само устройства по USB и Display Port."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Не може да се засече Thunderbolt.\n"
-"Системата не поддържа Thunderbolt или в BIOS-а е изключен или там е зададено "
-"неподдържано ниво на сигурност."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Поддръжката на Thunderbolt е изключена в BIOS-а."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Нивото на сигурност на Thunderbolt не може да се установи."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Грешка при прeвключване на директния режим: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Thunderbolt не се поддържа"
@@ -7139,6 +3802,12 @@ msgstr "Неуспешно свързване с подсистемата за T
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Пряк достъп"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Позволяване на директен достъп до устройства като докинг станции и външни "
+"GPU-та."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7156,7 +3825,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Управление на устройства по Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "тъндърболт;лични;данни;защита;сигурност;thunderbolt;privacy;"
@@ -7357,40 +4025,6 @@ msgstr "_Включване чрез клавиатурата"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Включване и изключване на достъпността чрез клавиатурата"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Стандартен"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Среден"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Голям"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "По-голям"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Най-голям"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d пиксел"
-msgstr[1] "%d пиксела"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Винаги да се показва менюто за универсален достъп"
@@ -7504,31 +4138,6 @@ msgstr "Проблясване на целия _екран"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Проблясване на целия _прозорец"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "късо"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ екран"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ екран"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ екран"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "дълго"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7685,7 +4294,6 @@ msgstr "Цветови ефекти"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "По-лесно да се вижда, чува, въвежда текст, посочват и натискат обекти"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7700,114 +4308,6 @@ msgstr ""
 "accessibility;universal access;contrast;cursor;sound;zoom;screen;reader;big;"
 "high;large;text;font;size;accessx;sticky;keys;slow;bounce;mouse;double;click;"
 "delay;speed;assist;repeat;blink;visual;hearing;audio;typing;animations;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 час"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 ден"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 дена"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 дена"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 дена"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 дена"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 дена"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 дена"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 дена"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 дена"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Изчистване на кошчето"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Всичко в кошчето ще бъде безвъзвратно изтрито."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Изчистване на кошчето"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Да се изчистят ли всички временни файлове?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Всички временни файлове ще бъдат окончателно изтрити."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "И_зчистване на временните файлове"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 ден"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 дена"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 дена"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Завинаги"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7875,7 +4375,6 @@ msgstr "История на файловете и кошчето"
 msgid "Don't leave traces"
 msgstr "Без оставяне на следи"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
@@ -7883,57 +4382,6 @@ msgstr ""
 "употреба;скорошни;последни;история;временни;файлове;лични;данни;защита;кошче;"
 "изчистване;;usage;recent;history;files;temporary;tmp;private;privacy;trash;"
 "purge;retain;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Трябва да съвпада с уеб адреса на доставчика на регистрации."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Неуспешно добавяне на регистрация"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Паролите не съвпадат."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Неуспешна връзка с регистрация"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Няма поддръжка за удостоверяването на тази област/домейн"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Неуспешно присъединяване към областта/домейна"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Неправилно потребителско име.\n"
-"Опитайте отново."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Неправилна парола.\n"
-"Опитайте отново."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Неуспешен вход в областта/домейна"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Домейнът липсва. Да сте сбъркали името му?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7986,10 +4434,6 @@ msgstr ""
 "Корпоративният вход позволява на този компютър да бъдат ползвани централно "
 "управлявани потребителски регистрации. Това обикновено дава и достъп до "
 "ресурсите на компанията в интернет."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Разглеждане за други изображения"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8060,222 +4504,6 @@ msgstr "_Изтриване на отпечатъците"
 msgid "Fingerprint Enroll"
 msgstr "Въвеждане на пръстов отпечатък"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "за това действие трябва изключителен достъп до устройството"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "устройството вече се ползва от друг процес"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "нямате права за това действие"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "не са въведени отпечатъци"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Неуспешна комуникация с устройството при въвеждането"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Неуспешна комуникация с устройството за пръстови отпечатъци"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Неуспешна връзка към демона за пръстови отпечатъци"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Неуспешно изброяване на пръстовите отпечатъци: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Неуспешно изтриване на пръстов отпечатък: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Ляв палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Ляв среден"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Ляв показалец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Ляв безименен"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Ляво кутре"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Десен палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Десен среден"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Десен показалец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Десен безименен"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Дясно кутре"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Непознат пръст"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Готово!"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Изключено устройство за пръстови отпечатъци"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Мястото за пръстови отпечатъци свърши"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Неуспешно добавяне на нов отпечатък"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Неуспешно въвеждане: „%s“"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Неуспешно въвеждане на нов отпечатък"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Неуспешно спиране на въвеждането на нов отпечатък: „%s“"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Неколкократно поставете и вдигнете пръст върху четеца на отпечатъци, за да "
-"ги въведете"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Повторно въвеждане на този пръст…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Снимане на нов отпечатък"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Неуспешно освобождаване на устройството за пръстови отпечатъци %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Грешка при четене от устройството"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Неуспешно заявяване на устройството за пръстови отпечатъци %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Неуспешно изброяване на устройствата за пръстови отпечатъци: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Тази седмица"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Миналата седмица"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Сесията завърши"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Сесията започна"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — дейности по регистрацията"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Предишна"
@@ -8283,18 +4511,6 @@ msgstr "Предишна"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Следваща"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Изберете друга парола."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Въведете отново текущата си парола."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Паролата не бе сменена"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8316,6 +4532,10 @@ msgstr "Нова парола"
 msgid "Confirm Password"
 msgstr "Потвърждаване на нова парола"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Паролите не съвпадат."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Позволяване на потребителя да избере парола при следващото влизане"
@@ -8323,135 +4543,6 @@ msgstr "Позволяване на потребителя да избере п�
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "въвеждане на парола сега"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Не може автоматично да се присъедините към такава област/домейн"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Няма такъв домейн или област"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Неуспешно влизане като „%s“ в областта/домейна „%s“"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Грешна парола. Опитайте отново."
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Неуспешно свързване с домейна „%s“: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Неуспешно изтриване на потребител"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Неуспешно премахване на права на отдалечен потребител"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Невъзможно е да изтриете собствената си регистрация."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "„%s“ все още е в системата"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Изтриването на влезли потребители може да доведе до неправилно състояние на "
-"системата."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Желаете ли да запазите файловете на „%s“?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Възможно е да запазите домашната папка, пощенската кореспонденция и "
-"временните файлове, когато изтривате съответната потребителска регистрация."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Изтриване на файловете"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Запазване на файловете"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Наистина ли желаете да премахнете отдалечено управляваната регистрация „%s“?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Изтриване"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "регистрацията е изключена"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "ще бъде избрана при следващото влизане"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "без"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "В системата"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Неуспешно свързване с услугата за регистрации"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Уверете се дали програмата „AcountService“ е инсталирана и включена."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "За да променяте настройките в този панел, трябва да го отключите."
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Изтриване на избраната потребителска регистрация"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"За да изтриете избраната потребителска\n"
-"регистрация, първо натиснете иконата „*“"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Отключете за добавяне на потребители и управление на настройките им"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8479,7 +4570,6 @@ msgid "Full name"
 msgstr "Пълно име"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Редактиране"
 
@@ -8541,7 +4631,6 @@ msgstr "Отключете, за да създадете потребителс�
 msgid "Add or remove users and change your password"
 msgstr "Добавяне или премахване на потребители и смяна на парола"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8588,174 +4677,6 @@ msgstr "Управление на потребителски регистрац�
 msgid "Authentication is required to change user data"
 msgstr "Изисква се удостоверяване за промяна на потребителските данни"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Новата парола трябва да се различава от старата."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Променете някои от знаците и цифрите."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Променете паролата още малко."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "По-добре е паролата ви да не съдържа потребителското ви име."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Не използвайте потребителското си име в паролата си."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Не използвайте част от думите в паролата си."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Избягвайте често срещани думи."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Не трябва просто да разменяте думите, включени в паролата ви."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Използвайте още цифри."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Използвайте още главни букви."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Използвайте още малки букви."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Използвайте още специални знаци — като пунктуация."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Използвайте и букви, и цифри, и пунктуация."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Не повтаряйте един и същи знак."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Не използвайте само един вид знаци. Включете и букви, и цифри, и пунктуация."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Не използвайте последователности като „1234“ или „abcd“."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Паролата трябва да е по-дълга. Използвайте и букви, и цифри, и пунктуация."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Използвайте главни и малки букви, добавете и някоя и друга цифра."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Ако добавите още букви, цифри или знаци ще я направите още по-силна."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Неуспешно удостоверяване"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Новата парола е прекалено кратка"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Новата парола е прекалено лесна"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Старата и новата пароли много си приличат"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Новата парола е ползвана прекалено скоро в миналото"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Новата парола трябва да съдържа цифри или специални знаци"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Старата и новата пароли са еднакви"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Паролата ви е променена откакто първоначално сте се удостоверили!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Новата парола не съдържа достатъчно различни знаци"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Непозната грешка"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Потребителското име обикновено съдържа малки букви в диапазона a-z, цифри и "
-"знаците „-“ и „_“"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Това потребителско име е заето. Пробвайте с друго."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Потребителското име е прекалено дълго."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8788,52 +4709,10 @@ msgstr "Потупайте целевите места на екрана на т
 msgid "Mis-click detected, restarting…"
 msgstr "Погрешно потупване, ново калибриране…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Бутон № %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Дефинирани програми"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Натискане на клавиш"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Смяна на монитора"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Извеждане на помощ на екрана"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Таблетът е за екрана на таблета"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Таблетът е за външен екран"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Външно устройство за таблет"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Външно входно устройство"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Всички екрани"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8931,22 +4810,6 @@ msgstr "Натискане на втория бутон на мишката"
 msgid "Forward"
 msgstr "Напред"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Стандартен писец с натиск, наклон и вградено плъзгане"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Стандартен писец с натиск, наклон и завъртане"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Стандартен писец с натиск и наклон"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Стандартен писец с натиск"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Таблет"
@@ -8957,54 +4820,96 @@ msgstr ""
 "Присвояване на функции на бутоните на графичния таблет и управление на "
 "чувствителността на писалката"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "таблет;уаком;писалка;гума;мишка;tablet;wacom;stylus;eraser;mouse;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Нова клавишна комбинация…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Симулирано повторно натискане"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Програми за Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Тонерът привършва"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Закъснение при повторно натискане"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Програми за Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Настройките за производителност и работа по много задачи"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Точки за достъп (AP)"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Добавяне"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Запазване"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "Име на точка за достъп (APN)"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Отменена операция"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>ГРЕШКА</b>: отказан достъп при смяна на настройките"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>ГРЕШКА</b>: грешка в хардуера за достъп до мобилна мрежа"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Няма регистрация"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Регистрирано"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Роуминг"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Търсене"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Отказ"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9034,212 +4939,13 @@ msgstr "Собствен номер"
 msgid "Device Details"
 msgstr "Настройки на устройството"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Производител"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Версия на фърмуера"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G — само"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G — само"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G — само"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "5G — само"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (с предимство), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (с предимство), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (с предимство), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (с предимство), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (с предимство), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (с предимство), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (с предимство), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (с предимство), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (с предимство), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (с предимство), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (с предимство), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (с предимство), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (с предимство), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (с предимство), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (с предимство), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (с предимство), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (с предимство)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (с предимство), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Неизвестен"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Отключване на SIM карта"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Отключване"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Въведете ПИН за SIM карта %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Въведете ПИН за отключване на SIM карта"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Въведете код (PUK) за SIM карта %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Въведете код (PUK) за отключване на SIM карта"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9254,26 +4960,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Остава ви %u опит"
 msgstr[1] "стават ви %u опита"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Въведена е грешна парола."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK кодът трябва да е число с 8 цифри"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Въведете нов ПИН"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "ПИН кодът трябва да е число с 4 до 8 цифри"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Отключване…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9331,95 +5017,6 @@ msgstr "Заключване на SIM картата с ПИН"
 msgid "M_odem Details"
 msgstr "_Подробности за модема"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Грешка в телефона"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Няма връзка с телефона"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Непозволена операция"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Неподдържана операция"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr " SIM картата не е поставена"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Необходим е ПИН код за SIM картата"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Необходим е код (PUK) за SIM картата"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Грешка в SIM карта"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Заета SIM карта"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Неправилна парола"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Необходим е код (PIN2) за SIM картата"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Необходим е код (PUK2) за SIM картата"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Няма мрежа"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Няма мобилна мрежа"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Времето за мрежата изтече"
-
-# AutoIP = link-local
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Услугите GPRS не са позволени"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Роумингът не е позволен на това място"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Неуказана грешка от GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Няма грешки"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Отказано действие"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Отказан достъп"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Непозната грешка"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Режим на мрежата"
@@ -9435,11 +5032,6 @@ msgstr "Избор на мрежа"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Опресняване на доставчиците на мрежа"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9497,7 +5089,6 @@ msgstr "Мобилни мрежи"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Настройки на мобилни връзки и телефония"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -9515,41 +5106,13 @@ msgstr "Това е основният интерфейс за настройв�
 msgid "The GNOME Project"
 msgstr "Проектът GMOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Извеждане на номера на версията"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Включване на подробен режим"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Търсене за низа"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Извеждане на имената на панелите и изход от програмата"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Панел за показване"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[ПАНЕЛ] [АРГУМЕНТ…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Категории настройки"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Поверителност"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Налични панели:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9607,7 +5170,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Отказване на търсенето"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "настройки;конфигурация;опции;preferences;settings;"
@@ -9647,8 +5209,6 @@ msgstr ""
 "Комбинация от първоначалната широчина, височина и дали прозорецът на "
 "програмата е максимизиран."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9656,8 +5216,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u изход"
 msgstr[1] "%u изхода"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9665,9 +5223,3154 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u вход"
 msgstr[1] "%u входа"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Системни звуци"
+#~ msgid "System Bus"
+#~ msgstr "Системна шина"
+
+#~ msgid "Full access"
+#~ msgstr "Пълeн достъп"
+
+#~ msgid "Session Bus"
+#~ msgstr "Сесийна шина"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Пълен достъп до „/dev“"
+
+#~ msgid "Has network access"
+#~ msgstr "Има достъп до мрежата"
+
+#~ msgid "Home"
+#~ msgstr "Домашна папка"
+
+#~ msgid "Read-only"
+#~ msgstr "Само за четене"
+
+#~ msgid "File System"
+#~ msgstr "Файлова система"
+
+#~ msgid "Can change settings"
+#~ msgstr "Може да променя настройки"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "Следните права са вградени в „%s“ и не може да бъдат променени. Ако това "
+#~ "е проблем, деинсталирайте програмата."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u вид файл и връзки се отварят с програмата"
+#~ msgstr[1] "%u вида файлове и връзки се отварят с програмата"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> отваря следните видове файлове и връзки."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "Ползват се %s от дисковото пространство."
+
+#~ msgid "Select a picture"
+#~ msgstr "Избор на изображение"
+
+#~ msgid "_Open"
+#~ msgstr "_Отваряне"
+
+#~ msgid "multiple sizes"
+#~ msgstr "различни размери"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Без фон на работния плот"
+
+#~ msgid "Current background"
+#~ msgstr "Текущ фон"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Поставете калибриращото устройство върху квадрата и натиснете бутона "
+#~ "„Начало“"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Установете устройството на положение за калибриране и натиснете бутона "
+#~ "„Нататък“"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Установете калибриращото устройство към повърхността и натиснете бутона "
+#~ "„Нататък“"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Затваряне на екрана на компютъра"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Възникна вътрешна грешка, която не може да бъде отстранена."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Инструментите за калибриране не са инсталирани."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Профилът не може да бъде създаден."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Целевата бяла точка не може да бъде достигната."
+
+#~ msgid "Complete!"
+#~ msgstr "Калибрирането завърши!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Неуспешно калибриране!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Можете да махнете калибриращото устройство."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "По време на калибрирането не пипайте устройството и екрана"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Екран на мобилен компютър"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Вградена камера"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Екран „%s“"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Скенер „%s“"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Фотоапарат „%s“"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Принтер „%s“"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Уеб камера „%s“"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Включване на управлението на цветовете за „%s“"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Показване на цветовите профили за „%s“"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Не е калибрирано"
+
+#~ msgid "Default: "
+#~ msgstr "Стандартен: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Цветово пространство: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Пробен профил: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Избиране на файл с цветови профил (ICC)"
+
+#~ msgid "_Import"
+#~ msgstr "_Внасяне"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Поддържани цветови профили (ICC)"
+
+#~ msgid "All files"
+#~ msgstr "Всички файлове"
+
+#~ msgid "Save Profile"
+#~ msgstr "Запазване на профил"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Създаване на цветови профил за избраното устройство"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Не е открит колориметър. Проверете дали е включен и свързан правилно."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Колориметърът не поддържа принтери."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Текущият вид устройството не се поддържа."
+
+#~ msgid "Standard Space"
+#~ msgstr "Стандартно пространство"
+
+#~ msgid "Test Profile"
+#~ msgstr "Пробен профил"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Автоматично генериран профил"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Ниско качество"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Средно качество"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Високо качество"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Стандартно ЧЗС (RGB)"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Стандартно ЦМЖЧ (CMYK)"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Стандартно сиво"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Стандартни калибровъчни данни от производителя на устройството"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "При този профил е невъзможна пълноекранна цветова корекция"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Профилът може вече да не е точен"
+
+#~ msgid "Other…"
+#~ msgstr "Друг…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Отключете за промяна на настройките"
+
+#~ msgid "Today"
+#~ msgstr "днес"
+
+#~ msgid "Yesterday"
+#~ msgstr "вчера"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%е %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d час"
+#~ msgstr[1] "%d часа"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d минута"
+#~ msgstr[1] "%d минути"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d секунда"
+#~ msgstr[1] "%d секунди"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Точка за безжичен достъп"
+
+#~ msgid "24-hour"
+#~ msgstr "24-часов"
+
+#~ msgid "AM / PM"
+#~ msgstr "12-часов"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Докладите за грешка помагат да се подобри „%s“. Те се изпращат анонимно и "
+#~ "без идентифицираща потребителя информация. %s"
+
+#~ msgid "On"
+#~ msgstr "Включване"
+
+#~ msgid "Off"
+#~ msgstr "Изключване"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Да се приложат ли промените?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Промените не може да се приложат"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Това може да се дължи на ограничение на хардуера."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Хоризонтална"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Вертикална дясна"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Вертикална лява"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Хоризонтална обратна"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Атестираното стартиране е включено"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Атестираното стартиране (Secure boot) предотвратява зареждането на "
+#~ "софтуер, който не е одобрен, при стартирането на системата. Тази защита е "
+#~ "включена и в момента работи правилно."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Атестираното стартиране има проблеми"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Атестираното стартиране (Secure boot) предотвратява зареждането на "
+#~ "софтуер, който не е одобрен, при стартирането на системата. Тази защита е "
+#~ "включена, но не работи, защото ползва неправилен ключ."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Проблемите с атестираното стартиране (Secure boot) често може да се "
+#~ "коригират от настройките на фърмуера UEFI (новият вариант на BIOS), а "
+#~ "производителят на хардуера може да ви даде информация как да го направите."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "За помощ се обърнете към производителя на хардуера или доставчика ви на "
+#~ "услуги по поддръжка на IT."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Атестираното стартиране е изключено"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Атестираното стартиране (Secure boot) предотвратява зареждането на "
+#~ "софтуер, който не е одобрен, при стартирането на системата. Тази защита "
+#~ "не е включена."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Атестираното стартиране (Secure boot) може да се включи от настройките на "
+#~ "фърмуера UEFI (новият вариант на BIOS). За помощ се обърнете към "
+#~ "производителя на хардуера или доставчика ви на услуги по поддръжка на IT."
+
+#~ msgid "Passed"
+#~ msgstr "Успешно преминато"
+
+#~ msgid "Failed"
+#~ msgstr "Неуспешно преминаване"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Устройството отговаря на ниво HSI %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Ниво на сигурност 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Това устройство няма никаква защита срещу проблеми на сигурността на "
+#~ "хардуера. Това може да се дължи на хардуерен или конфигурационен проблем. "
+#~ "Препоръчваме ви да се свържете с доставчика ви на услуги по поддръжка на "
+#~ "IT."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Ниво на сигурност 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Това устройство има минимална защита срещу проблеми на сигурността на "
+#~ "хардуера. Това е най-ниското ниво сигурност и тя работи единствено срещу "
+#~ "най-простите атаки."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Ниво на сигурност 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Това устройство има основна защита срещу проблеми на сигурността на "
+#~ "хардуера. Тя работи срещу най-честите атаки."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Ниво на сигурност 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Това устройство има допълнителна защита срещу проблеми на сигурността на "
+#~ "хардуера. Това е най-високото ниво на защита дори и срещу силни атаки."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Нивата за сигурност не са приложими за това устройство."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Свържете се с производителя на хардуера за обновления на сигурността."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Възможно е проблемът да бъде отстранен с промяна на настройка във "
+#~ "фърмуера UEFI или от служител от поддръжката."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Възможно е проблемът да бъде отстранен с промяна на настройка във "
+#~ "фърмуера UEFI."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Възможно е проблемът да бъде отстранен от служител от поддръжката."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr ""
+#~ "Има защита срещу злоумишлен софтуер при стартирането на устройството."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Проблеми в атестираното стартиране"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Някаква защита при стартиране на устройството."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Атестираното стартиране е изключено"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Без защита при стартиране на устройството."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Проблемът може да се дължи на промяна на настройките на фърмуера UEFI, "
+#~ "промяна на настройките на операционната система или присъствието на "
+#~ "злоумишлен софтуер."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Проблемът може да се дължи на промяна на настройките на фърмуера UEFI или "
+#~ "присъствието на злоумишлен софтуер."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Проблемът може да се дължи на промяна на настройките на операционната "
+#~ "система или присъствието на злоумишлен софтуер."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Никаква защита към атаки срещу сигурността."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Ограничена защита към най-простите атаки срещу сигурността."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Защитено към чести атаки срещу сигурността."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Защитено към голям спектър от атаки срещу сигурността."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Допълнителна защита"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Защита на фърмуера срещу презапис"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Заключване на защитата на фърмуера срещу презапис"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Регион за фърмуера за BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Описание на фърмуера на BIOS-а"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr ""
+#~ "Защита преди стартиране срещу атака с директния достъп до паметта (DMA)"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Стартирането е атестирано от Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr ""
+#~ "Първоначалният блок за зареждане ще се провери (Intel BootGuard ACM)"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Политика на грешките на Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Бушон на Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Технологията за управление на контрола (Intel CET) е включена"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Технологията за управление на контрола (Intel CET) работи"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Предотвратяване на свръхадминистративен достъп (Intel SMAP)"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Шифрирана памет (RAM)"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Вх./Изх. защита IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Заключване на ядрото Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Проверка на ядрото Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Странициране на Linux"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Приспиване към паметта"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Приспиване към бездействие"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Платформен ключ на UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Атестирано стартиране на UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Настройки на платформата за доверие (TPM)"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Възстановяване на платформата за доверие (TPM)"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "Модул за доверие на платформана (TPM) v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Режим на производител на модула за управление на Intel"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Преодоляване на модула за управление на Intel"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Версия на платформата за управление на Intel"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Обновления на фърмуера"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Атестиране на фърмуера"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Проверка на програмата за обновяване на фърмуера"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Изчистване на грешки на платформата"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Проверки на сигурността на процесора"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Защита на AMD срещу връщане на стара версия"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Защита на AMD срещу повтаряне на фърмуера"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Защита на AMD срещу запис на фърмуера"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Слята платформа"
+
+#~ msgid "Valid"
+#~ msgstr "Валидно"
+
+#~ msgid "Not Valid"
+#~ msgstr "Невалидно"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Изключено"
+
+#~ msgid "Locked"
+#~ msgstr "Заключено"
+
+#~ msgid "Not Locked"
+#~ msgstr "Отключено"
+
+#~ msgid "Encrypted"
+#~ msgstr "Шифрирано"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Нешифрирано"
+
+#~ msgid "Tainted"
+#~ msgstr "Замърсено"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Чисто"
+
+#~ msgid "Found"
+#~ msgstr "Открито"
+
+#~ msgid "Not Found"
+#~ msgstr "Липсва"
+
+#~ msgid "Supported"
+#~ msgstr "Поддържано"
+
+#~ msgid "Not Supported"
+#~ msgstr "Неподдържано"
+
+#~ msgid "Unknown"
+#~ msgstr "Неизвестен"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 бита"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 бита"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Неизвестно"
+
+#~ msgid "Not Available"
+#~ msgstr "Липсва"
+
+#~ msgid "System Logo"
+#~ msgstr "Лого на системата"
+
+#~ msgid "No input sources found"
+#~ msgstr "Няма входни устройства"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Друго"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Потребителски клавишни комбинации"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Този клавиш позволява да въвеждате допълнителни знаци. Понякога те са "
+#~ "отпечатани като трети знак на съответния клавиш."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Ляв Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Десен Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Ляв Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Десен Супер"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Клавиш Menu"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Десен Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "С клавиша „Compose“ можете да въвеждате (композирате) много различни "
+#~ "знаци. За да го ползвате — натиснете го и след това въведете "
+#~ "последователност от знаци. Например: „Compose“, <b>C</b> и <b>o</b> дават "
+#~ "<b>©</b>, а „Compose“, <b>a</b> и <b>'</b> дават <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Може да сменяте входните методи с клавишната комбинация „%s“.\n"
+#~ "Можете да промените това в настройките за клавишните комбинации"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d променен"
+#~ msgstr[1] "%d променени"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Използване на оригиналните клавишни комбинации?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Вашите комбинации ще се изчистят и ще се върнат оригиналните комбинации. "
+#~ "Това действие е необратимо."
+
+#~ msgid "Reset All"
+#~ msgstr "Оригинални комбинации"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s вече се ползва за %s. Ако го замените, %s ще бъде изключен"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Въведете нова клавишна комбинация"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Потребителска клавишна комбинация"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Клавишна комбинация"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Въведете новата клавишна комбинация, за да смените %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Добавяне на клавишна комбинация"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Придвижване с два пръста"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Пет натискания — време е за GEGL"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Двойно натискане на основния бутон"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Натискане на основния бутон"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Двойно натискане на средния бутон"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Натискане на средния бутон"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Двойно натискане на втория бутон"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Натискане на втория бутон"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager трябва да е стартиран."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Несигурна мрежа (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Сигурна мрежа (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Сигурна мрежа (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Сигурна мрежа (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Сигурна мрежа"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Ако включите точката за достъп, ще се изключите от %s и няма да имате "
+#~ "достъп до Интернет през Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Трябва да е поне 8 знака."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr ""
+#~ "Спиране на точката за безжичен достъп и изключване на всички потребители?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Спиране на точката за безжичен достъп"
+
+#~ msgid "Preserve"
+#~ msgstr "Запазване"
+
+#~ msgid "Permanent"
+#~ msgstr "Постоянен"
+
+#~ msgid "Random"
+#~ msgstr "Случаен"
+
+#~ msgid "Stable"
+#~ msgstr "Стабилен"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Апаратният адрес определя хардуерния адрес при задействането на мрежовата "
+#~ "връзка. Тази възможност понякога се нарича клониране или имитиране на MAC "
+#~ "адрес. Напр.: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Профил %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Подобрена отворена"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Корпоративна"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Без"
+
+#~ msgid "Never"
+#~ msgstr "никога"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz/5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Няма сигнал"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Слаб сигнал"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Задоволителен сигнал"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Добър сигнал"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Отличен сигнал"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Забравяне на връзка"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Изтриване на настройките на връзката"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Премахване на ВЧМ"
+
+#~ msgid "Details"
+#~ msgstr "Подробности"
+
+#~ msgid "automatic"
+#~ msgstr "автоматично"
+
+#~ msgid "Identity"
+#~ msgstr "Идентичност"
+
+#~ msgid "Delete Address"
+#~ msgstr "Изтриване на адрес"
+
+#~ msgid "Delete Route"
+#~ msgstr "Изтриване на маршрут"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Без"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "40/128 битов ключ за WEP (шестнайсетичен или ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "128 битова парола за WEP"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Динамичен WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "Частна WPA & WPA2"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Корпоративна WPA или WPA2"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "Частна WPA3"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Неуспешно отваряне на редактора на адреси"
+
+#~ msgid "New Profile"
+#~ msgstr "Нов профил"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Неправилни настройки за %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Неправилни настройки за %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Внасяне от файл…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Нова ВЧМ"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Настройките за ВЧМ не могат да бъдат внесени"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Файлът „%s“ не може да бъде прочетен или не съдържа позната информация за "
+#~ "ВЧМ.\n"
+#~ "\n"
+#~ "Грешка: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Избор на файл за внасяне"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Вече съществува файл с име „%s“."
+
+#~ msgid "_Replace"
+#~ msgstr "_Замяна"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Искате ли да замените „%s“ с ВЧМ, която внасяте?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Настройките за ВЧМ не могат да бъдат изнесени"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Настройките за ВЧМ „%s“ не могат да бъдат изнесени в „%s“.\n"
+#~ "\n"
+#~ "Грешка: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Изнасяне на настройките за ВЧМ"
+
+#~ msgid "never"
+#~ msgstr "никога"
+
+#~ msgid "today"
+#~ msgstr "днес"
+
+#~ msgid "yesterday"
+#~ msgstr "вчера"
+
+#~ msgid "Last used"
+#~ msgstr "Последно ползване"
+
+#~ msgid "Add new connection"
+#~ msgstr "Добавяне на нова връзка"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Данните за посочените мрежи, включително пароли и потребителски настройки "
+#~ "ще бъдат изгубени."
+
+#~ msgid "_Forget"
+#~ msgstr "_Забравяне"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Познати безжични мрежи"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Премахване"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr ""
+#~ "Системните политики забраняват създаването на точка за безжичен достъп"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Безжичното устройство не поддържа режим за точка за безжичен достъп"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Автоматичното откриване на уеб сървър-посредник се използва, когато не е "
+#~ "зададен адрес за настройка."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Не се препоръчва за недоверени, общодостъпни мрежи."
+
+#~ msgid "Status unknown"
+#~ msgstr "Неизвестно състояние"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Без управление"
+
+#~ msgid "Unavailable"
+#~ msgstr "Недостъпна"
+
+#~ msgid "Connecting"
+#~ msgstr "Свързване"
+
+#~ msgid "Authentication required"
+#~ msgstr "Изисква се удостоверяване"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Прекъсване на връзката"
+
+#~ msgid "Connection failed"
+#~ msgstr "Връзката е неуспешна"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Състоянието на връзката е неизвестно (липсва информация)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Неуспешно настройване"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Неуспешно настройване на IP адреса"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Изтече времето за настройката на IP адреса"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr ""
+#~ "Не бяха предоставени задължителните данни за установяване на връзката"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr ""
+#~ "Връзката (802.1x) бе прекъсната от програмата за удостоверяване "
+#~ "(supplicant)"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr ""
+#~ "Неуспех при настройка на програмата за удостоверяване (supplicant) на "
+#~ "връзката (802.1x)"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr ""
+#~ "Програмата за удостоверяване (supplicant) на връзката (802.1x) приключи "
+#~ "неуспешно"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr ""
+#~ "Удостоверяването на връзката (802.1x) отне на програмата (supplicant) "
+#~ "повече време от стандартното"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Неуспешно стартиране на услугата за връзка чрез PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Услугата за връзка чрез PPP е прекъсната"
+
+#~ msgid "PPP failed"
+#~ msgstr "Услугата за връзка чрез PPP приключи неуспешно"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr ""
+#~ "Неуспешно стартиране на клиента за автоматична настройка на връзката "
+#~ "(DHCP)"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Грешка на клиента за автоматична настройка на връзката (DHCP)"
+
+#~ msgid "DHCP client failed"
+#~ msgstr ""
+#~ "Клиентът за автоматична настройка на връзката (DHCP) приключи неуспешно"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Неуспешно стартиране на услугата за споделяне на връзката"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Услугата за споделяне на връзката приключи неуспешно"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr ""
+#~ "Неуспешно стартиране на услугата за локална връзка (AutoIP, "
+#~ "169.254.0.0/16, fe80::/10)"
+
+#~ msgid "AutoIP service error"
+#~ msgstr ""
+#~ "Грешка в услугата за локална връзка (AutoIP, 169.254.0.0/16, fe80::/10)"
+
+# AutoIP = link-local
+#~ msgid "AutoIP service failed"
+#~ msgstr ""
+#~ "Услугата за локална връзка (AutoIP, 169.254.0.0/16, fe80::/10) приключи "
+#~ "неуспешно"
+
+#~ msgid "Line busy"
+#~ msgstr "Линията е заета"
+
+#~ msgid "No dial tone"
+#~ msgstr "Няма сигнал"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Неуспешно установяване на носещата честота"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Времето на заявката за набиране изтече"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Опитът за набиране приключи неуспешно"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Неуспешно инициализиране на модема"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Неуспешно избиране на зададената точка за достъп (APN)"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Не се търсят мрежи"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Регистрацията в мрежата е отхвърлена"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Времето на заявката за регистрация в мрежата изтече"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Неуспешна регистрация в заявената мрежа"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Неуспешна проверка на ПИН кода"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Възможно е фърмуерът за устройството да липсва"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Връзката се изгуби"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Предполагаше се съществуваща връзка"
+
+#~ msgid "Modem not found"
+#~ msgstr "Няма модем"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Неуспешна връзка чрез Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr " SIM картата не е поставена"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Необходим е ПИН код за SIM картата"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Необходим е код (PUK) за SIM картата"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Грешна SIM карта"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Неуспешно активиране на зависимост за връзката"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Липсва фърмуер"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Кабелът е изваден"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "грешка в сигурността 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "не е избран файл"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "грешка при проверката на файла за eap"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Частни ключове във формат DER, PEM или PKCS#12"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Сертификати формат DER или PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "файлът за EAP-FAST PAC липсва"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Файлове във формат PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "липсва потребителско име за EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "липсва парола за EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "неправилен сертификат на удостоверител за EAP-PEAP: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "неправилен сертификат на удостоверител за EAP-PEAP: не е указан сертификат"
+
+#~ msgid "missing EAP username"
+#~ msgstr "липсва потребителско име за EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "липсва парола за EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "липсва идентичност за EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "неправилен сертификат на удостоверител за EAP-TLS: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "неправилен сертификат на удостоверител за EAP-TLS: не е указан сертификат"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "неправилен частен ключ за EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "неправилен потребителски сертификат за EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Нешифрираните лични ключове са несигурни"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Избраният частен ключ не е защитен с парола. Това позволява "
+#~ "компрометирането на идентичността ви. Изберете частен ключ, защитен с "
+#~ "парола.\n"
+#~ "\n"
+#~ "(Можете да защитите частния ключ с парола чрез командата „openssl“)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Изберете личния си сертификат"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Изберете частния си ключ"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "неправилен сертификат на удостоверител за EAP-TTLS: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "неправилен сертификат на удостоверител за EAP-TTLS: не е указан сертификат"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Грешка при валидиране на сигурността за 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Избор на файл"
+
+#~ msgid "missing leap-username"
+#~ msgstr "липсва потребителско име за leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "липсва парола за leap"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Липсва парола за безжичната мрежа."
+
+#~ msgid "missing wep-key"
+#~ msgstr "липсва ключ за wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "неправилен ключ за wep: ключ с дължина от %zu знака трябва да съдържа "
+#~ "само шестнадесетични цифри"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "неправилен ключ за wep: ключ с дължина от %zu знака трябва да съдържа "
+#~ "само ASCII"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "неправилен ключ за wep: неправилна дължина на ключа — %zu. Той трябва да "
+#~ "е дълъг или 5/13 знака за ASCII, или 10/26 знака за шестнадесетични цифри"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "неправилен ключ за wep: празна парола"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "неправилен ключ за wep: паролата трябва да е под 64 знака"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "неправилен ключ за wpa-psk: дължината на ключа е %zu. Трябва да е от 8 до "
+#~ "63 байта или 64 шестнадесетични цифри"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "неправилен ключ за wpa-psk: ключът е дълъг 64 байта, но не се състои само "
+#~ "от шестнадесетични цифри"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Друга"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s — изтрит"
+
+#~ msgid "Error removing account"
+#~ msgstr "Неуспешно премахване на регистрация"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Регистрация в „%s“"
+
+#~ msgid "Remove Account"
+#~ msgstr "Премахване на регистрация"
+
+#~ msgid "Unknown time"
+#~ msgstr "Неизвестно време"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s и %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "Остават %s до пълно зареждане"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Внимание: остават %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "остават %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Пълно зареждане"
+
+#~ msgid "Not charging"
+#~ msgstr "Не се зарежда"
+
+#~ msgid "Empty"
+#~ msgstr "Разредена"
+
+#~ msgid "Charging"
+#~ msgstr "Зареждане"
+
+#~ msgid "Discharging"
+#~ msgstr "Разреждане"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Безжична мишка"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Безжична клавиатура"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Непрекъсваемо токозахранване"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Цифров помощник"
+
+#~ msgid "Cellphone"
+#~ msgstr "Мобилен телефон"
+
+#~ msgid "Media player"
+#~ msgstr "Музикално устройство"
+
+#~ msgid "Tablet"
+#~ msgstr "Таблет"
+
+#~ msgid "Computer"
+#~ msgstr "Компютър"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Контролер за игри"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Основна"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Допълнителна"
+
+#~ msgid "Batteries"
+#~ msgstr "Батерии"
+
+#~ msgid "When _idle"
+#~ msgstr "При _бездействие"
+
+#~ msgid "Suspend"
+#~ msgstr "приспиване"
+
+#~ msgid "Power Off"
+#~ msgstr "Изключване"
+
+#~ msgid "Hibernate"
+#~ msgstr "дълбоко приспиване"
+
+#~ msgid "Nothing"
+#~ msgstr "нищо"
+
+#~ msgid "When on battery power"
+#~ msgstr "При работа от батерии"
+
+#~ msgid "When plugged in"
+#~ msgstr "При включване на захранването"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Никога"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Автоматично приспиване"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Режимът на висока производителност е изключен поради прекалено високата "
+#~ "температура на хардуера."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Засечена е работа в скута на потребителя, затова режимът на висока "
+#~ "производителност е недостъпен. Сложете устройството на стабилна "
+#~ "повърхност, за се върне достъпът до този режим."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Високата производителност временно е изключена."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Нисък заряд на батерията, затова е включен режимът на енергоспестяване. "
+#~ "Предишният режим ще се включи отново след достатъчно зареждане на "
+#~ "батерията."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Енергоспестяването е включено от „%s“."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Високата производителност е включена от „%s“."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Висока производителност"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Високи производителност и енергопотребление."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Баланс"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Стандартни производителност и енергопотребление."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Енергоспестяване"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "По-ниски производителност и енергопотребление."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Принтерът „%s“ е изтрит"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Неуспешно добавяне на нов принтер."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Неуспешно зареждане на файла с потребителския интерфейс „%s“"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Отключете, за да добавите принтери и да промените настройките"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Подробности за „%s“"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Няма подходящ драйвер"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Избор на файл – PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Файлове на PostScript за описание на принтери (*.ppd, *.PPD, *.ppd.gz, *."
+#~ "PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Принтер по JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Принтер по LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Едностранно"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "По дългата страна (стандартно)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "По късата страна (завъртане)"
+
+#~ msgid "Portrait"
+#~ msgstr "Вертикална"
+
+#~ msgid "Landscape"
+#~ msgstr "Хоризонтална"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Вертикална, обърната"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Хоризонтална, обърната"
+
+#~ msgid "Resume"
+#~ msgstr "Продължаване"
+
+#~ msgid "Pause"
+#~ msgstr "На пауза"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "в опашката"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "На пауза"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Изисква се идентификация"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "обработвана"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "спряна"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "отказана"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "прекъсната"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "завършена"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Задачата да бъде първа в опашката"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "„%s“ – активни задачи"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Удостоверете самоличността, за да печатате с „%s“."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Отключване на сървъра за печат"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Отключване на „%s“."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Въведете името и паролата си, за да видите принтерите при „%s“."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Търсене на принтери"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Сериен порт"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Паралелен порт"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Местоположение: „%s“"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Адрес: „%s“"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Сървърът изисква удостоверяване"
+
+#~ msgid "Two Sided"
+#~ msgstr "Двустранно"
+
+#~ msgid "Paper Type"
+#~ msgstr "Вид на хартията"
+
+#~ msgid "Paper Source"
+#~ msgstr "Източник на хартията"
+
+#~ msgid "Output Tray"
+#~ msgstr "Изходяща тава"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Разделителна способност"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Предварителен филтър на GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Страници на лист"
+
+#~ msgid "Orientation"
+#~ msgstr "Ориентация"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Общи"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Настройка на страницата"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Апаратни настройки"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Задача"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Качество на изображенията"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Цвят"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Довършителни"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Разширени"
+
+#~ msgid "Test page"
+#~ msgstr "Пробна страница"
+
+#~ msgid "Auto Select"
+#~ msgstr "Автоматичен избор"
+
+#~ msgid "Printer Default"
+#~ msgstr "Стандартното за принтера"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Вграждане само на шрифтовете на GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Преобразуване към PostScript, ниво 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Преобразуване към PostScript, ниво 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Без предварителен филтър"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Изчистване на печатащите глави"
+
+#~ msgid "Out of toner"
+#~ msgstr "Тонерът свърши"
+
+#~ msgid "Low on developer"
+#~ msgstr "Проявителят привършва"
+
+#~ msgid "Out of developer"
+#~ msgstr "Проявителят свърши"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Мастилото привършва"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Мастилото свърши"
+
+#~ msgid "Open cover"
+#~ msgstr "Отворен капак"
+
+#~ msgid "Open door"
+#~ msgstr "Отворена вратичка"
+
+#~ msgid "Low on paper"
+#~ msgstr "Хартията привършва"
+
+#~ msgid "Out of paper"
+#~ msgstr "Хартията свърши"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Изключен"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "спрян"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Контейнерът за отпадъчно мастило е почти пълен"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Контейнерът за отпадъчно мастило е пълен"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Барабанът е почти износен"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Барабанът е износен"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "в готовност"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "не приема задачи"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "обработване"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "имперска"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "метрична"
+
+#~ msgid "Ask what to do"
+#~ msgstr "да се пита за действие"
+
+#~ msgid "Do nothing"
+#~ msgstr "нищо да не се прави"
+
+#~ msgid "Open folder"
+#~ msgstr "отваряне на папката"
+
+#~ msgid "Other Media"
+#~ msgstr "Други носители"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Избор на програма, с която да отваряте аудио дискове (CD)"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Избор на програма, с която да отваряте видео дискове (DVD)"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Избор на програма, която да се изпълнява при свързване на преносимо "
+#~ "устройство за музика"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Изберете програма, която да се изпълнява при свързване на камера"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Избор на програма, с която да се отварят дискове с програми"
+
+#~ msgid "audio DVD"
+#~ msgstr "аудио диск – DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "празен диск – Blu-ray"
+
+#~ msgid "blank CD disc"
+#~ msgstr "празен диск – CD"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "празен диск – DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "празен диск – HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "видео диск – Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "четец на електронни книги"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "видео диск – HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "диск с изображения – CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "видео диск – Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "видео диск – Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Екранът се изключва"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 секунди"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 минута"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 минути"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 минути"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 минути"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 минути"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 час"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 минута"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 минути"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 минути"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 минути"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 минути"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 минути"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 минути"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 минути"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 минути"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "никога"
+
+#~ msgid "Select Location"
+#~ msgstr "Избор на регион"
+
+#~ msgid "_OK"
+#~ msgstr "_Добре"
+
+#~ msgid "No applications found"
+#~ msgstr "Няма програми"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Не са избрани мрежи за споделяне"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Включена"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Изключена"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Включена"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Активна"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Избор на папка"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Включване на споделянето на медия"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Споделянето на лични файлове ви позволява да споделите папката „Публични“ "
+#~ "с други потребители през текущата мрежа чрез следния адрес: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Позволяване на отдалечените потребители да се връзват към машината ви с "
+#~ "команда за сигурна обвивка:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Включване на споделянето на собствените медийни файлове"
+
+#~ msgid "Device name copied"
+#~ msgstr "Името на устройството е копирано"
+
+#~ msgid "Device address copied"
+#~ msgstr "Адресът на устройството е копиран"
+
+#~ msgid "Username copied"
+#~ msgstr "Потребителското име е копирано"
+
+#~ msgid "Password copied"
+#~ msgstr "Паролата е копирана"
+
+#~ msgid "Custom"
+#~ msgstr "Потребителско"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Проба на %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100 %"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Без връзка"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Свързване"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Свързано"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Грешка при упълномощаване"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Упълномощаване"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Непълна функционалност"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Свързано и одобрено"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Неизвестно"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Одобрено на:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Свързано на:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Одобрено и добавено на:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Неуспешно одобряване на устройство: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Неуспешно забравяне на устройство: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Грешка"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Одобрено"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Подсистемата за Thunderbolt (boltd) или не е инсталирана, или не е "
+#~ "настроена правилно."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Може да се свързват само устройства по USB и Display Port."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Не може да се засече Thunderbolt.\n"
+#~ "Системата не поддържа Thunderbolt или в BIOS-а е изключен или там е "
+#~ "зададено неподдържано ниво на сигурност."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Поддръжката на Thunderbolt е изключена в BIOS-а."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Нивото на сигурност на Thunderbolt не може да се установи."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Грешка при прeвключване на директния режим: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Стандартен"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Среден"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Голям"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "По-голям"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Най-голям"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d пиксел"
+#~ msgstr[1] "%d пиксела"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "късо"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ екран"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ екран"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ екран"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "дълго"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 час"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 ден"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 дена"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 дена"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 дена"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 дена"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 дена"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 дена"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 дена"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 дена"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Изчистване на кошчето"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Всичко в кошчето ще бъде безвъзвратно изтрито."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Изчистване на кошчето"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Да се изчистят ли всички временни файлове?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Всички временни файлове ще бъдат окончателно изтрити."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "И_зчистване на временните файлове"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 ден"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 дена"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 дена"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Завинаги"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Трябва да съвпада с уеб адреса на доставчика на регистрации."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Неуспешно добавяне на регистрация"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Неуспешна връзка с регистрация"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Няма поддръжка за удостоверяването на тази област/домейн"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Неуспешно присъединяване към областта/домейна"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Неправилно потребителско име.\n"
+#~ "Опитайте отново."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Неправилна парола.\n"
+#~ "Опитайте отново."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Неуспешен вход в областта/домейна"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Домейнът липсва. Да сте сбъркали името му?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Разглеждане за други изображения"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "за това действие трябва изключителен достъп до устройството"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "устройството вече се ползва от друг процес"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "нямате права за това действие"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "не са въведени отпечатъци"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Неуспешна комуникация с устройството при въвеждането"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Неуспешна комуникация с устройството за пръстови отпечатъци"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Неуспешна връзка към демона за пръстови отпечатъци"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Неуспешно изброяване на пръстовите отпечатъци: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Неуспешно изтриване на пръстов отпечатък: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Ляв палец"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Ляв среден"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Ляв показалец"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Ляв безименен"
+
+#~ msgid "Left little finger"
+#~ msgstr "Ляво кутре"
+
+#~ msgid "Right thumb"
+#~ msgstr "Десен палец"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Десен среден"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Десен показалец"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Десен безименен"
+
+#~ msgid "Right little finger"
+#~ msgstr "Дясно кутре"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Непознат пръст"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Готово!"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Изключено устройство за пръстови отпечатъци"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Мястото за пръстови отпечатъци свърши"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Неуспешно добавяне на нов отпечатък"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Неуспешно въвеждане: „%s“"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Неуспешно въвеждане на нов отпечатък"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Неуспешно спиране на въвеждането на нов отпечатък: „%s“"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Неколкократно поставете и вдигнете пръст върху четеца на отпечатъци, за "
+#~ "да ги въведете"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Повторно въвеждане на този пръст…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Снимане на нов отпечатък"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr ""
+#~ "Неуспешно освобождаване на устройството за пръстови отпечатъци %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Грешка при четене от устройството"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Неуспешно заявяване на устройството за пръстови отпечатъци %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Неуспешно изброяване на устройствата за пръстови отпечатъци: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Тази седмица"
+
+#~ msgid "Last Week"
+#~ msgstr "Миналата седмица"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Сесията завърши"
+
+#~ msgid "Session Started"
+#~ msgstr "Сесията започна"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — дейности по регистрацията"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Изберете друга парола."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Въведете отново текущата си парола."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Паролата не бе сменена"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Не може автоматично да се присъедините към такава област/домейн"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Няма такъв домейн или област"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Неуспешно влизане като „%s“ в областта/домейна „%s“"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Грешна парола. Опитайте отново."
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Неуспешно свързване с домейна „%s“: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Неуспешно изтриване на потребител"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Неуспешно премахване на права на отдалечен потребител"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Невъзможно е да изтриете собствената си регистрация."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "„%s“ все още е в системата"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Изтриването на влезли потребители може да доведе до неправилно състояние "
+#~ "на системата."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Желаете ли да запазите файловете на „%s“?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Възможно е да запазите домашната папка, пощенската кореспонденция и "
+#~ "временните файлове, когато изтривате съответната потребителска "
+#~ "регистрация."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Изтриване на файловете"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Запазване на файловете"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Наистина ли желаете да премахнете отдалечено управляваната регистрация "
+#~ "„%s“?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Изтриване"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "регистрацията е изключена"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "ще бъде избрана при следващото влизане"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "без"
+
+#~ msgid "Logged in"
+#~ msgstr "В системата"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Неуспешно свързване с услугата за регистрации"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Уверете се дали програмата „AcountService“ е инсталирана и включена."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "За да променяте настройките в този панел, трябва да го отключите."
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Изтриване на избраната потребителска регистрация"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "За да изтриете избраната потребителска\n"
+#~ "регистрация, първо натиснете иконата „*“"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Отключете за добавяне на потребители и управление на настройките им"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Новата парола трябва да се различава от старата."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Променете някои от знаците и цифрите."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Променете паролата още малко."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "По-добре е паролата ви да не съдържа потребителското ви име."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Не използвайте потребителското си име в паролата си."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Не използвайте част от думите в паролата си."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Избягвайте често срещани думи."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Не трябва просто да разменяте думите, включени в паролата ви."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Използвайте още цифри."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Използвайте още главни букви."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Използвайте още малки букви."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Използвайте още специални знаци — като пунктуация."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Използвайте и букви, и цифри, и пунктуация."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Не повтаряйте един и същи знак."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Не използвайте само един вид знаци. Включете и букви, и цифри, и "
+#~ "пунктуация."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Не използвайте последователности като „1234“ или „abcd“."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Паролата трябва да е по-дълга. Използвайте и букви, и цифри, и пунктуация."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Използвайте главни и малки букви, добавете и някоя и друга цифра."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Ако добавите още букви, цифри или знаци ще я направите още по-силна."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Неуспешно удостоверяване"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Новата парола е прекалено кратка"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Новата парола е прекалено лесна"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Старата и новата пароли много си приличат"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Новата парола е ползвана прекалено скоро в миналото"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Новата парола трябва да съдържа цифри или специални знаци"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Старата и новата пароли са еднакви"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Паролата ви е променена откакто първоначално сте се удостоверили!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Новата парола не съдържа достатъчно различни знаци"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Непозната грешка"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Потребителското име обикновено съдържа малки букви в диапазона a-z, цифри "
+#~ "и знаците „-“ и „_“"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Това потребителско име е заето. Пробвайте с друго."
+
+#~ msgid "The username is too long."
+#~ msgstr "Потребителското име е прекалено дълго."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Бутон № %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Дефинирани програми"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Натискане на клавиш"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Смяна на монитора"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Извеждане на помощ на екрана"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Таблетът е за екрана на таблета"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Таблетът е за външен екран"
+
+#~ msgid "External tablet device"
+#~ msgstr "Външно устройство за таблет"
+
+#~ msgid "All Displays"
+#~ msgstr "Всички екрани"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Стандартен писец с натиск, наклон и вградено плъзгане"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Стандартен писец с натиск, наклон и завъртане"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Стандартен писец с натиск и наклон"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Стандартен писец с натиск"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Нова клавишна комбинация…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Отменена операция"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>ГРЕШКА</b>: отказан достъп при смяна на настройките"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>ГРЕШКА</b>: грешка в хардуера за достъп до мобилна мрежа"
+
+#~ msgid "Not Registered"
+#~ msgstr "Няма регистрация"
+
+#~ msgid "Registered"
+#~ msgstr "Регистрирано"
+
+#~ msgid "Roaming"
+#~ msgstr "Роуминг"
+
+#~ msgid "Searching"
+#~ msgstr "Търсене"
+
+#~ msgid "Denied"
+#~ msgstr "Отказ"
+
+#~ msgid "2G Only"
+#~ msgstr "2G — само"
+
+#~ msgid "3G Only"
+#~ msgstr "3G — само"
+
+#~ msgid "4G Only"
+#~ msgstr "4G — само"
+
+#~ msgid "5G Only"
+#~ msgstr "5G — само"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (с предимство)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (с предимство), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (с предимство), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (с предимство), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (с предимство)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (с предимство), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (с предимство), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (с предимство)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (с предимство), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (с предимство), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (с предимство)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (с предимство), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (с предимство), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (с предимство)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (с предимство), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (с предимство), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (с предимство)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (с предимство), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (с предимство)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (с предимство), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (с предимство)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (с предимство), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (с предимство)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (с предимство), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (с предимство)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (с предимство), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (с предимство)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (с предимство), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Неизвестен"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Отключване на SIM карта"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Въведете ПИН за SIM карта %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Въведете ПИН за отключване на SIM карта"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Въведете код (PUK) за SIM карта %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Въведете код (PUK) за отключване на SIM карта"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Въведена е грешна парола."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK кодът трябва да е число с 8 цифри"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Въведете нов ПИН"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "ПИН кодът трябва да е число с 4 до 8 цифри"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Отключване…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Грешка в телефона"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Няма връзка с телефона"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Непозволена операция"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Неподдържана операция"
+
+#~ msgid "SIM not inserted"
+#~ msgstr " SIM картата не е поставена"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Необходим е ПИН код за SIM картата"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Необходим е код (PUK) за SIM картата"
+
+#~ msgid "SIM failure"
+#~ msgstr "Грешка в SIM карта"
+
+#~ msgid "SIM busy"
+#~ msgstr "Заета SIM карта"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Неправилна парола"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Необходим е код (PIN2) за SIM картата"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Необходим е код (PUK2) за SIM картата"
+
+#~ msgid "Not found"
+#~ msgstr "Няма мрежа"
+
+#~ msgid "No network service"
+#~ msgstr "Няма мобилна мрежа"
+
+#~ msgid "Network timeout"
+#~ msgstr "Времето за мрежата изтече"
+
+# AutoIP = link-local
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Услугите GPRS не са позволени"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Роумингът не е позволен на това място"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Неуказана грешка от GPRS"
+
+#~ msgid "No Error"
+#~ msgstr "Няма грешки"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Отказано действие"
+
+#~ msgid "Access denied"
+#~ msgstr "Отказан достъп"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Непозната грешка"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Извеждане на номера на версията"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Включване на подробен режим"
+
+#~ msgid "Search for the string"
+#~ msgstr "Търсене за низа"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Извеждане на имената на панелите и изход от програмата"
+
+#~ msgid "Panel to display"
+#~ msgstr "Панел за показване"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[ПАНЕЛ] [АРГУМЕНТ…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Налични панели:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Системни звуци"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Грешка: нивото на HSI не може да се определи."
@@ -9678,9 +8381,6 @@ msgstr "Системни звуци"
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "Сертификати във формат DER или PEM (*.der, *.pem, *.crt, *.cer)"
 
-#~ msgid "Add a Printer…"
-#~ msgstr "Добавяне на принтер…"
-
 #~ msgid "Drip"
 #~ msgstr "Капка"
 
@@ -9689,9 +8389,6 @@ msgstr "Системни звуци"
 
 #~ msgid "Sonar"
 #~ msgstr "Сонар"
-
-#~ msgid "No Protection"
-#~ msgstr "Никаква защита"
 
 #~ msgid "Minimal Protection"
 #~ msgstr "Минимална защита"

--- a/po/bg.po~
+++ b/po/bg.po~
@@ -1,0 +1,9796 @@
+# Bulgarian translation of gnome-control-center po-file.
+# Copyright (C) 2002, 2004, 2005, 2006 Free Software Foundation, Inc.
+# Copyright (C) 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
+# Copyright (C) 2011, 2012, 2013, 2014 Free Software Foundation, Inc.
+# Copyright (C) 2015, 2016 Free Software Foundation, Inc.
+# Copyright (C) 2009 Krasimir "Bfaf" Chonov <mk2616@abv.bg>.
+# Copyright (C) 2021, 2022 Alexander Shopov <ash@kambanaria.org>.
+# Borislav Aleksandrov <B.Aleksandrov@cnsys.bg>, 2002.
+# Yanko Kaneti <yaneti@declera.com>, 2002.
+# Rostislav Raykov <zbrox@i-space.org>, 2004, 2005.
+# Vladimir Petkov <kaladan@gmial.com>, 2004, 2005, 2006.
+# Alexander Shopov <ash@kambanaria.org>, 2006, 2007, 2009, 2012, 2014, 2015, 2016, 2021, 2022.
+# Yavor Doganov <yavor@gnu.org>, 2007, 2008.
+# Krasimir "Bfaf" Chonov <mk2616@abv.bg>, 2009.
+# Jordan Miladinov <jordanmiladinov@gmail.com>, 2011
+# Ivaylo Valkov <ivaylo@e-valkov.org>, 2011, 2012, 2013.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center main\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-09 20:58+0000\n"
+"PO-Revision-Date: 2022-09-10 12:53+0200\n"
+"Last-Translator: Alexander Shopov <ash@kambanaria.org>\n"
+"Language-Team: Bulgarian <dict@fsa-bg.org>\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Системна шина"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Пълeн достъп"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Сесийна шина"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Устройства"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Пълен достъп до „/dev“"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Мрежа"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Има достъп до мрежата"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Домашна папка"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Само за четене"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Файлова система"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Настройки"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Може да променя настройки"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"Следните права са вградени в „%s“ и не може да бъдат променени. Ако това е "
+"проблем, деинсталирайте програмата."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u вид файл и връзки се отварят с програмата"
+msgstr[1] "%u вида файлове и връзки се отварят с програмата"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> отваря следните видове файлове и връзки."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "Ползват се %s от дисковото пространство."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Програми"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Няма програми"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Инсталиране на…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Отваряне"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Показване на подробности"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Търсене"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Получаване на системните търсения и изпращане на резултатите."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "изключено"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Известия"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Извеждане на системите известия."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Фонов режим"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Позволяване на работа, когато програмата е затворена."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Снимки на екрана"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Снимки на екрана във всеки момент."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Смяна на фона"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Смяна на фона на работния плот."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Звуци"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Възпроизвеждане на звуци."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Изключване на клавишните комбинации"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Спиране на стандартните клавишни комбинации."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Фотоапарат"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Снимка с камерата."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Микрофон"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Запис на звук с микрофона."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Услуги за местоположение"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Достъп до местоположението на устройството."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Стандартни права"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Достъп до системата, който програмата ползва"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Отваряне на файлове и връзки"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Съхранение на данни"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Няма резултати"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Пробвайте друго търсене"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Отваряне на файлове и връзки"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Видове файлове"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Видове връзки"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Нулиране"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Колко пространство за съхранение ползва програмата — включително данни и кеш."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Програма"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Данни"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Кеш"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Общо</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Изчистване на кеша…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Управление на настройките и правата на програмите"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"програма;приложение;флатпак;права;настройки;конфигурации;application;flatpak;"
+"permission;setting;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Избор на изображение"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Отказ"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Отваряне"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "различни размери"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Без фон на работния плот"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Текущ фон"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Стил"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Стандартен"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Тъмен"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Фон"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Добавяне на изображение…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Външен вид"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Смяна на фона и темата"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"фон;тапет;шарка;десен;екран;работен;плот;стил;светъл;тъмен;стил;външен;вид;"
+"background;wallpaper;screen;desktop;style;light;dark;appearance;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Включване"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Няма адаптери за Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Добавете адаптер за Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth е изключен"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Включете, за да свързвате устройства и да прехвърляте файлове."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Самолетният режим е включен"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth е изключен по време на самолетния режим"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Изключване на самолетния режим"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Самолетният режим е изключен"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Изключване на самолетния режим, за да се включи Bluetoothл"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Връзка по Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Включване и изключване на Bluetooth и свързване на устройствата"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+"блутут;син;зъб;споделяне;файл;слушалки;телефон;пренасяне;share;sharing;"
+"bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Камерата е изключена"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Няма програма за заснемане на снимки или видео."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Достъпът до камерата позволява на програмите да правят снимки и да снимат "
+"видео. Изключването на камерата може да попречи на приложенията да работят.\n"
+"\n"
+"Позволяване на програмите по-долу да достъпват камерата."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Никоя програма не е заявила достъп до камерата"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Защита на изображенията"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"камера;снимки;фотографии;видео;уебкамера;заключване;защита;лични;данни;"
+"camera;photos;video;webcam;lock;private;privacy;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Поставете калибриращото устройство върху квадрата и натиснете бутона „Начало“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Установете устройството на положение за калибриране и натиснете бутона "
+"„Нататък“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Установете калибриращото устройство към повърхността и натиснете бутона "
+"„Нататък“"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Затваряне на екрана на компютъра"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Възникна вътрешна грешка, която не може да бъде отстранена."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Инструментите за калибриране не са инсталирани."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Профилът не може да бъде създаден."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Целевата бяла точка не може да бъде достигната."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Калибрирането завърши!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Неуспешно калибриране!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Можете да махнете калибриращото устройство."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "По време на калибрирането не пипайте устройството и екрана"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Калибриране на екран"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Начало"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Продължаване"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Готово"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Екран на мобилен компютър"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Вградена камера"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Екран „%s“"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Скенер „%s“"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Фотоапарат „%s“"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Принтер „%s“"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Уеб камера „%s“"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Включване на управлението на цветовете за „%s“"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Показване на цветовите профили за „%s“"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Не е калибрирано"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Стандартен: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Цветово пространство: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Пробен профил: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Избиране на файл с цветови профил (ICC)"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Внасяне"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Поддържани цветови профили (ICC)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Всички файлове"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Екран"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Запазване на профил"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Запазване"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Създаване на цветови профил за избраното устройство"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "Не е открит колориметър. Проверете дали е включен и свързан правилно."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Колориметърът не поддържа принтери."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Текущият вид устройството не се поддържа."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Калибриране на екрана"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Качество на калибриране"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Калибрирането ще ви даде профил, с който можете да управлявате цветовете на "
+"екрана си. Колкото по-дълго е калибрирането, толкова по-добро е качеството "
+"на цветовия профил."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Няма да може да използвате компютъра си по време на калибрирането."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Качество"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Приблизително време"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Устройство за калибриране"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Изберете калибриращото устройство, което ще ползвате."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Вид на екрана"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Изберете вида на екрана."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Бяла точка на профила"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Изберете целевата бяла точка на екрана. Повечето устройства трябва да се "
+"калибрират към източник на светлина D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Яркост на екрана"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Задайте обичайната за вас яркост на екрана. Така управлението на цветовете "
+"ще бъда най-точно за нея."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Друг вариант е да използвате нивото на яркост съответстващо на някой от "
+"другите профили на екрана."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Име на профила"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Можете да създавате цветови профил за различни екрани, компютри или даже "
+"различни условия на осветление."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Име на профила:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Обобщение"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Профилът е създаден успешно!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Копиране на профил"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Изисква носител с възможност за запис"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Инструкциите как да ползвате профила под различни операционни системи се "
+"намират тук: <a href='linux'>GNU/Linux</a>, <a href='osx'>Apple OS X</a> и "
+"<a href='windows'>Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Добавяне на профил"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Има проблеми и профилът може да не сработи правилно. <a href=''>Повече "
+"детайли.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Внасяне на файл…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Добавяне"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Всяко устройство се нуждае от актуален цветови профил, за да бъдат "
+"управлявани цветовете му."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Научете повече"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Научете повече за управлението на цветовете"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Задаване за всички потребители"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Задаване на профила за всички потребители на този компютър"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Включване"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Добавяне на профил"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Калибриране…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Калибриране на устройството"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Премахване на профил"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Показване на подробности"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Липсват устройства, чийто цвят може да се калибрира"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "Течнокристален (LCD)"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "Светодиоден (LED)"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "Кинескоп (CRT)"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Проектор"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Плазмен"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "Течнокристален със студена флуоресцентна подсветка (LCD с CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "Течнокристален с трицветна подсветка (LCD с RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "Течнокристален с бяла подсветка (LCD с White LED)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+"Пълноцветен течнокристален със студена флуоресцентна подсветка (Wide Gamut "
+"LCD с CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+"Пълноцветен течнокристален с трицветна подсветка (Wide Gamut LCD с RGB LED)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Високо"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 минути"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Средно"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 минути"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Ниско"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 минути"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Стандартното за екрана"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Печат и издателска дейност)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Фотография и графики)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Стандартно пространство"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Пробен профил"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Автоматично генериран профил"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Ниско качество"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Средно качество"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Високо качество"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Стандартно ЧЗС (RGB)"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Стандартно ЦМЖЧ (CMYK)"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Стандартно сиво"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Стандартни калибровъчни данни от производителя на устройството"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "При този профил е невъзможна пълноекранна цветова корекция"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Профилът може вече да не е точен"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Цвят"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Калибриране на цвета на устройствата като екрани, камери, принтери"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"цвят;профил;калибриране;принтер;екран;color;icc;profile;calibrate;printer;"
+"display;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Друг…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Избор на език"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Избор"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Няма езици"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Допълнителни…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Отключете за промяна на настройките"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Преди да промените някои от настройките, трябва да ги отключите."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Отключване…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Час напред"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Минута напред"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Време"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Час назад"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Минута назад"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "днес"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "вчера"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%е %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d час"
+msgstr[1] "%d часа"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d минута"
+msgstr[1] "%d минути"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d секунда"
+msgstr[1] "%d секунди"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 секунди"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Точка за безжичен достъп"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-часов"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "12-часов"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Дата и час"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Година"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Месец"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "януари"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "февруари"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "март"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "април"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "май"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "юни"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "юли"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "август"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "септември"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "октомври"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "ноември"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "декември"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Ден"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Часови пояс"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Търсене на град"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Автоматични дата и час"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Изисква връзка към Интернет"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Дата и _час"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Автоматичен часови _пояс"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Изисква връзка към Интернет и включени услуги за местоположение"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Включен"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "_Часови пояс"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Формат на времето"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Смяна на датата, часа, часовия пояс"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+"часовник;часови;пояс;местоположение;часова;зона;време;clock;timezone;"
+"location;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Промяна на системните дата и час"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Ще трябва да се идентифицирате, за да промените настройките на датата или "
+"времето."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Уеб"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Поща"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Календар"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "М_узика"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Видео"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Снимки"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Стандартни програми"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Задаване на стандартни програми"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"стандартни;предпочитани;приложения;програми;носители;медия;default;"
+"application;preferred;media;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Докладите за грешка помагат да се подобри „%s“. Те се изпращат анонимно и "
+"без идентифицираща потребителя информация. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Докладване на грешка"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Автоматично докладване на грешки"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Диагностика"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Докладвайте проблем"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "диагностика;забиване;блокиране;diagnostics;crash;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Включване"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Изключване"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Да се приложат ли промените?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Промените не може да се приложат"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Това може да се дължи на ограничение на хардуера."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Прилагане"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Назад"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Настройките на екрана са изключени"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Много екрани"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Обединяване"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Еднакво изображение"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Съдържа горната лента и дейностите"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Основен екран"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Нощен режим"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Хоризонтална"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Вертикална дясна"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Вертикална лява"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Хоризонтална обратна"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Ориентация"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Разделителна способност"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Честота на опресняване"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "За телевизор"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Мащабиране"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Нощният режим липсва"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Това може да се дължи на драйвера за графичната карта или на това, че сте се "
+"свързали отдалечено към работния плот"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Временно изключен до изгрев слънце"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Рестартиране на филтъра"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Нощният режим прави цветовете на екрана по-топли като ограничава синята "
+"светлина. Това намаля умората на очите и безсънието."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Насрочване"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Залез до изгрев"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Други времена"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Времена"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "От"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Час"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Минута"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "пр.об."
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "сл.об."
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "До"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Температура на екрана"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Екрани"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Изберете как да се използват свързаните екрани и проектори"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"панел;проектор;екран;разделителна;способност;опресняване;монитор;дисплей;нощ;"
+"светлина;яркост;завъртане;ротация;синя;червена;panel;projector;xrandr;screen;"
+"resolution;refresh;monitor;night;light;blue;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Атестираното стартиране е включено"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Атестираното стартиране (Secure boot) предотвратява зареждането на софтуер, "
+"който не е одобрен, при стартирането на системата. Тази защита е включена и "
+"в момента работи правилно."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Атестираното стартиране има проблеми"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Атестираното стартиране (Secure boot) предотвратява зареждането на софтуер, "
+"който не е одобрен, при стартирането на системата. Тази защита е включена, "
+"но не работи, защото ползва неправилен ключ."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Проблемите с атестираното стартиране (Secure boot) често може да се "
+"коригират от настройките на фърмуера UEFI (новият вариант на BIOS), а "
+"производителят на хардуера може да ви даде информация как да го направите."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"За помощ се обърнете към производителя на хардуера или доставчика ви на "
+"услуги по поддръжка на IT."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Атестираното стартиране е изключено"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Атестираното стартиране (Secure boot) предотвратява зареждането на софтуер, "
+"който не е одобрен, при стартирането на системата. Тази защита не е включена."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Атестираното стартиране (Secure boot) може да се включи от настройките на "
+"фърмуера UEFI (новият вариант на BIOS). За помощ се обърнете към "
+"производителя на хардуера или доставчика ви на услуги по поддръжка на IT."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Атестираното стартиране (Secure boot) предотвратява зареждането на софтуер, "
+"който не е одобрен, при стартирането на системата.\n"
+"\n"
+"За помощ се обърнете към производителя на хардуера или доставчика ви на "
+"услуги по поддръжка на IT."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Успешно преминато"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Неуспешно преминаване"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Устройството отговаря на ниво HSI %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Ниво на сигурност 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Това устройство няма никаква защита срещу проблеми на сигурността на "
+"хардуера. Това може да се дължи на хардуерен или конфигурационен проблем. "
+"Препоръчваме ви да се свържете с доставчика ви на услуги по поддръжка на IT."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Ниво на сигурност 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Това устройство има минимална защита срещу проблеми на сигурността на "
+"хардуера. Това е най-ниското ниво сигурност и тя работи единствено срещу най-"
+"простите атаки."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Ниво на сигурност 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Това устройство има основна защита срещу проблеми на сигурността на "
+"хардуера. Тя работи срещу най-честите атаки."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Ниво на сигурност 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Това устройство има допълнителна защита срещу проблеми на сигурността на "
+"хардуера. Това е най-високото ниво на защита дори и срещу силни атаки."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Ниво на сигурността"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Нивата за сигурност не са приложими за това устройство."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr "Свържете се с производителя на хардуера за обновления на сигурността."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Възможно е проблемът да бъде отстранен с промяна на настройка във фърмуера "
+"UEFI или от служител от поддръжката."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Възможно е проблемът да бъде отстранен с промяна на настройка във фърмуера "
+"UEFI."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Възможно е проблемът да бъде отстранен от служител от поддръжката."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Ниво 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Ниво 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Ниво 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Има защита срещу злоумишлен софтуер при стартирането на устройството."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Проблеми в атестираното стартиране"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Някаква защита при стартиране на устройството."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Атестираното стартиране е изключено"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Без защита при стартиране на устройството."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Проблемът може да се дължи на промяна на настройките на фърмуера UEFI, "
+"промяна на настройките на операционната система или присъствието на "
+"злоумишлен софтуер."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Проблемът може да се дължи на промяна на настройките на фърмуера UEFI или "
+"присъствието на злоумишлен софтуер."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Проблемът може да се дължи на промяна на настройките на операционната "
+"система или присъствието на злоумишлен софтуер."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Никаква защита към атаки срещу сигурността."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Ограничена защита към най-простите атаки срещу сигурността."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Защитено към чести атаки срещу сигурността."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Защитено към голям спектър от атаки срещу сигурността."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Допълнителна защита"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Няма събития"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Защита на фърмуера срещу презапис"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Заключване на защитата на фърмуера срещу презапис"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Регион за фърмуера за BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Описание на фърмуера на BIOS-а"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr ""
+"Защита преди стартиране срещу атака с директния достъп до паметта (DMA)"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Стартирането е атестирано от Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Първоначалният блок за зареждане ще се провери (Intel BootGuard ACM)"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Политика на грешките на Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Бушон на Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Технологията за управление на контрола (Intel CET) е включена"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Технологията за управление на контрола (Intel CET) работи"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Предотвратяване на свръхадминистративен достъп (Intel SMAP)"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Шифрирана памет (RAM)"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Вх./Изх. защита IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Заключване на ядрото Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Проверка на ядрото Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Странициране на Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Приспиване към паметта"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Приспиване към бездействие"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Платформен ключ на UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Атестирано стартиране на UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Настройки на платформата за доверие (TPM)"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Възстановяване на платформата за доверие (TPM)"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "Модул за доверие на платформана (TPM) v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Режим на производител на модула за управление на Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Преодоляване на модула за управление на Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Версия на платформата за управление на Intel"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Обновления на фърмуера"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Атестиране на фърмуера"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Проверка на програмата за обновяване на фърмуера"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Изчистване на грешки на платформата"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Проверки на сигурността на процесора"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Защита на AMD срещу връщане на стара версия"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Защита на AMD срещу повтаряне на фърмуера"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Защита на AMD срещу запис на фърмуера"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Слята платформа"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Валидно"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Невалидно"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Изключено"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Заключено"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Отключено"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Шифрирано"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Нешифрирано"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Замърсено"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Чисто"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Открито"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Липсва"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Поддържано"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Неподдържано"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Сигурност на устройство"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Състояние на сигурността на фърмуера"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"екран;монитор;дисплей;заключване;затъмняване;диагностика;забиване;частен;"
+"личен;таен;скрит;временен;индекс;име;мрежа;идентичност;защита;данни;screen;"
+"lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
+"identity;privacy;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Неизвестен"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64 бита"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32 бита"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Липсва"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Лого на системата"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Име на устройство"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Модел"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Памет"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Процесор"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Графика"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Обем на диска"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Изчисляване…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Име на ОС"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Изграждане: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Вид ОС"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Версия на GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Зареждане…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Графична система"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Виртуализация"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Обновяване на програмите"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Преименуване на устройство"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Името, с което това устройство се идентифицира по мрежата или сдвояване по "
+"Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Име на устройство"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Преименуване"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Относно"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Извеждане на информация за компютъра"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"устройство;система;информация;име;хост;памет;процесор;версия;стандартна;"
+"програма;предпочитана;cd;dvd;usb;звук;видео;диск;преносим;носител;"
+"автоматично;стартиране;device;system;information;hostname;memory;processor;"
+"version;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;"
+"media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Звук и мултимедия"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Заглушаване на звука"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Намаляване на звука"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Увеличаване на звука"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Заглушаване/включване на микрофона"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Стартиране на програмата за мултимедия"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Изпълнение (или изпълнение/пауза)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Пауза при изпълнение на музика"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Спиране на изпълнението"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Предишна песен"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Следваща песен"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Изваждане"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Въвеждане на знаци"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Превключване към следващия вход"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Превключване към предишния вход"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Стартери"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Стартиране на програмата за помощ"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Стартиране на калкулатор"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Стартиране на програмата за е-поща"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Стартиране на Интернет браузър"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Домашна папка"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Търсене"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Система"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Изход"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Заключване на екрана"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Универсален достъп"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Включване или изключване на лупата"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Увеличаване"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Намаляване"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Включване или изключване на екранния четец"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Включване или изключване на екранната клавиатура"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Увеличаване на размера на текста"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Намаляване на размера на текста"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Включване/изключване на високия контраст"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Няма входни устройства"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Друго"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Добавяне на входно устройство"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Методите за въвеждане не могат да се използват на екрана за вход"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Не е избрано входно устройство"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Настройки"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Нагоре"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Надолу"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Настройки"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Подредба на клавиатурата"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Премахване"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Потребителски клавишни комбинации"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Клавиш за допълнителни знаци"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Този клавиш позволява да въвеждате допълнителни знаци. Понякога те са "
+"отпечатани като трети знак на съответния клавиш."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Ляв Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Десен Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Ляв Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Десен Супер"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Клавиш Menu"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Десен Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Клавиш Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"С клавиша „Compose“ можете да въвеждате (композирате) много различни знаци. "
+"За да го ползвате — натиснете го и след това въведете последователност от "
+"знаци. Например: „Compose“, <b>C</b> и <b>o</b> дават <b>©</b>, а „Compose“, "
+"<b>a</b> и <b>'</b> дават <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Може да сменяте входните методи с клавишната комбинация „%s“.\n"
+"Можете да промените това в настройките за клавишните комбинации"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Входни устройства"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Включва подредбата на клавиатурата и входните методи."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Смяна на входното устройство"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Използване на _еднакво входно устройство за всички прозорци"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "_Смяна на входния метод поотделно за всеки прозорец"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Въвеждане на специални знаци"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Начини за въвеждане на специални знаци, символи и форми с клавиатурата."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Клавишни комбинации"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Преглед и настройки на клавишните комбинации"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d променен"
+msgstr[1] "%d променени"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Използване на оригиналните клавишни комбинации?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Вашите комбинации ще се изчистят и ще се върнат оригиналните комбинации. "
+"Това действие е необратимо."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Отказ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Оригинални комбинации"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Оригинални комбинации…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Използване на оригиналните клавишни комбинации"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Раздел"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Клавишни комбинации"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Добавяне на клавишна комбинация"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Добавяне на друга клавишна комбинация"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Задаване на клавишни комбинации за стартирането на програми, скриптове и др."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Добавяне на клавишна комбинация"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Няма клавишни комбинации"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s вече се ползва за %s. Ако го замените, %s ще бъде изключен"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Въведете нова клавишна комбинация"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Потребителска клавишна комбинация"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Клавишна комбинация"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Въведете новата клавишна комбинация, за да смените %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Добавяне на клавишна комбинация"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Пре_махване"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "З_амяна"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Задаване"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "За отмяна натиснете Esc, а за да изключите комбинацията — Backspace."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Име"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Команда"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Клавишна комбинация"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Задаване на клавишна комбинация…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Без"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Използване на оригиналните клавишни комбинации"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Клавиатура"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Настройки на клавишните комбинации, подредбите, входните методи и другите "
+"настройки на клавиатурата"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"shortcut;workspace;window;resize;zoom;contrast;input;source;lock;volume;"
+"клавишни;комбинации;бързи;работно;място;плот;прозорец;преоразмеряване;"
+"увеличение;мащабиране;контраст;вход;източник;заключване;сила;звук;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Услугите за местоположение са изключени"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "В момента никоя програма не получава информация за местоположението."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Услугите за местоположението дават възможност на програмите да знаят къде се "
+"намирате. Използването на безжична мрежа и мобилен интернет подобрява "
+"точността.\n"
+"\n"
+"Използва услугата на Mozilla за местоположение: <a href='https://location."
+"services.mozilla.com/privacy'>Лични данни</a>\n"
+"\n"
+"Позволяване на програмите да научават местоположението ви."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Никоя програма не е поискала достъп до местоположението ви"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Защита на местоположението"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "местоположение;защита;лични;данни;location;gps;private;privacy;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Микрофонът е изключен"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Няма програми за запис на звук."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Ползването на микрофона позволява на програмите да получават звука през него "
+"и да го записват. Ако изключите микрофона, някои програми няма да работят "
+"правилно.\n"
+"\n"
+"Позволяване на програмите по-долу да използват микрофона."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Никоя програма не е заявила достъп до микрофона"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Защита на разговорите"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"микрофон;запис;програма;приложение;защита;лични;данни;microphone;recording;"
+"application;privacy;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Изпробване на _настройките"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Общи"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Основен бутон"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Задаване на подредбата на бутоните на мишките и сензорните панели."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Ляв"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Десен"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Мишка"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Скорост на мишката"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Естествено придвижване (като в OS X)"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Придвижва се съдържанието, а не изгледът."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Сензорен панел"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Скорост на сензорния панел"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Натискане чрез тупване"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Натискане чрез тупване"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Придвижване с два пръста"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Придвижване чрез ръбовете"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Изпробвайте натискане, двойно натискане и придвижване"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Пет натискания — време е за GEGL"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Двойно натискане на основния бутон"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Натискане на основния бутон"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Двойно натискане на средния бутон"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Натискане на средния бутон"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Двойно натискане на втория бутон"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Натискане на втория бутон"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Мишка и сензорен панел"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Избор на чувствителността на мишката или сензорния панел и дали е за лява "
+"или дясна ръка"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"сензорен панел;показалец;натискане;кликане;кликване;почукване;двойно "
+"натискане;бутон;джойстик;придвижване;trackpad;pointer;click;tap;double;"
+"button;trackball;scroll;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Активен _ъгъл"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+"Натиснете горния ляв ъгъл на екрана, за да отворите прегледа на дейностите."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Активни _ръбове"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Завлачете прозорците до горния, долния, левия или десния ръб на екрана, за "
+"да ги преоразмерите."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Работно пространство"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Динамични работни пространства"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Автоматично изчистване на незаети работни пространства."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Постоянен брой работни пространства"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Укажете точен брой на работните пространства"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Брой работни пространства"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "На много монитори"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Работни пространства _само на основния екран"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Работни пространства на _всички екрани"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Смяна на програмите"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Програми от всички _работни пространства"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Програми само от текущото _работно пространство"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Многозадачност"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Настройките за производителност и работа по много задачи"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"многозадачност;паралелност;производителност;продуктивност;работно "
+"пространство;активни;ъгли;работни;пространства;multitasking;multitask;"
+"productivity;customize;desktop;hot corner;workspaces;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Възникна грешка, свържете се с доставчика на софтуера."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager трябва да е стартиран."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Други устройства"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "ВЧМ (VPN)"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Добавяне на връзка"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Не е настроена"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Несигурна мрежа (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Сигурна мрежа (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Сигурна мрежа (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Сигурна мрежа (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Сигурна мрежа"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Връзката е осъществена"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Настройки…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Ако включите точката за достъп, ще се изключите от %s и няма да имате достъп "
+"до Интернет през Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Трябва да е поне 8 знака."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Не трябва да е повече от %d знак"
+msgstr[1] "Не трябва да е повече от %d знака"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Точка за достъп по Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Точката за достъп по Wi-Fi позволява да споделите връзката към Интернет, "
+"като се създава безжична мрежа, към която другите устройства се свързват. За "
+"да сработи това, споделената връзка не трябва да е по Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Име на мрежата"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Парола"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Генериране на случайна парола"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Автоматично генериране на парола"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Включване"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Безжична мрежа"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+"Спиране на точката за безжичен достъп и изключване на всички потребители?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Спиране на точката за безжичен достъп"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Самолетен режим"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Изключване на безжичната мрежа, Bluetooth и мобилните връзки"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Няма адаптер за безжична мрежа"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Проверете дали адаптерът за безжична мрежа е включен правилно"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Самолетен режим"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Изключете, за да ползвате безжична мрежа."
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Точка за безжичен достъп"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Мобилните устройства могат да изчетат QR код, за да се свържат."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "_Изключване на точка за безжичен достъп…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Видими мрежи"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager трябва да е стартиран"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Сигурност – 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Сигурност"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Запазване"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Постоянен"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Случаен"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Стабилен"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Апаратният адрес определя хардуерния адрес при задействането на мрежовата "
+"връзка. Тази възможност понякога се нарича клониране или имитиране на MAC "
+"адрес. Напр.: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Профил %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Подобрена отворена"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Корпоративна"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Без"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "никога"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "преди %i ден"
+msgstr[1] "преди %i дни"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz/5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Няма сигнал"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Слаб сигнал"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Задоволителен сигнал"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Добър сигнал"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Отличен сигнал"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Адрес (IPv4)"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Адрес (IPv6)"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Адрес по IP"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "Система от имена (DNS)"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Забравяне на връзка"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Изтриване на настройките на връзката"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Премахване на ВЧМ"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Подробности"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "автоматично"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Идентичност"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Изтриване на адрес"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Изтриване на маршрут"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Без"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "40/128 битов ключ за WEP (шестнайсетичен или ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "128 битова парола за WEP"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Динамичен WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "Частна WPA & WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "Корпоративна WPA или WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "Частна WPA3"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Сила на сигнала"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Скорост на връзката"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Апаратен адрес"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Поддържани честоти"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Стандартен маршрут"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Последно ползване"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "_Автоматично свързване"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "_Достъпна за всички потребители"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "_Мерена връзка: може да има ограничения за данни или такси"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Актуализациите на програмите и други големи изтегляния няма да се стартира "
+"автоматично."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Име"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC адрес"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Дублиран адрес"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "байтове"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Метод за IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Автоматично (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Само локално за връзката (169.254.0.0/16)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Ръчно"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Изключване"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Споделена с други компютри"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Адреси"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Адрес"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Мрежова маска"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Автоматично"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Автоматични настройки за DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Адреси на сървъри за DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Използвайте „,“ за разделител на IP адресите"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Маршрути"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Автоматични настройки за маршрути"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Метрика"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Връзката да се ползва само за _локални за нея ресурси"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Метод за IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Автоматично – само DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Префикс"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Неуспешно отваряне на редактора на адреси"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Нов профил"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Неправилни настройки за %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Неправилни настройки за %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Внасяне от файл…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Нова ВЧМ"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "С_игурност"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Настройките за ВЧМ не могат да бъдат внесени"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Файлът „%s“ не може да бъде прочетен или не съдържа позната информация за "
+"ВЧМ.\n"
+"\n"
+"Грешка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Избор на файл за внасяне"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Вече съществува файл с име „%s“."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Замяна"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Искате ли да замените „%s“ с ВЧМ, която внасяте?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Настройките за ВЧМ не могат да бъдат изнесени"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Настройките за ВЧМ „%s“ не могат да бъдат изнесени в „%s“.\n"
+"\n"
+"Грешка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Изнасяне на настройките за ВЧМ"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(грешка: редакторът за настройки на ВЧМ не може да бъде стартиран)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Настройки на връзката към Интернет"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"мрежа;адрес;локален;локална;глобална;широколентов;модем;виртуален;виртуална;"
+"частна;връзка;име;имена;network;ip;lan;proxy;wan;broadband;modem;bluetooth;"
+"vpn;dns;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Настройки на безжичната връзка"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"мрежа;безжична;интернет;адрес;порт;локален;локална;широколентов;връзка;име;"
+"имена;гореща;точка;достъп;network;wireless;wi-fi;wifi;ip;lan;broadband;dns;"
+"hotspot"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "никога"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "днес"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "вчера"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Последно ползване"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Жична мрежа"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Добавяне на нова връзка"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Данните за посочените мрежи, включително пароли и потребителски настройки ще "
+"бъдат изгубени."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Забравяне"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Познати безжични мрежи"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Премахване"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Системните политики забраняват създаването на точка за безжичен достъп"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Безжичното устройство не поддържа режим за точка за безжичен достъп"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Автоматичното откриване на уеб сървър-посредник се използва, когато не е "
+"зададен адрес за настройка."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Не се препоръчва за недоверени, общодостъпни мрежи."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Изключване на устройството"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Активна"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "Идентификатор за устройства (IMEI)"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Доставчик"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Мрежов сървър-посредник"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_Сървър-посредник за HTTP "
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "_HTTPS сървър-посредник"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Сървър-_посредник за FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Хост за Socks:"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "Хостове за _директна връзка"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Порт на сървъра-посредник за HTTP "
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Порт на сървъра-посредник за HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Порт на сървъра-посредник за FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Порт за Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "Адрес за _настройка"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Изключване на връзката към ВЧМ"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Име на мрежата"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Вид на сигурността"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Парола"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Изключване на безжичната мрежа"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Допълнителни настройки…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Свързване към скрита мрежа…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Точка за безжичен достъп…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Познати безжични мрежи"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Неизвестно състояние"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Без управление"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Недостъпна"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Свързване"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Изисква се удостоверяване"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Прекъсване на връзката"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Връзката е неуспешна"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Състоянието на връзката е неизвестно (липсва информация)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Неуспешно настройване"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Неуспешно настройване на IP адреса"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Изтече времето за настройката на IP адреса"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Не бяха предоставени задължителните данни за установяване на връзката"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr ""
+"Връзката (802.1x) бе прекъсната от програмата за удостоверяване (supplicant)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+"Неуспех при настройка на програмата за удостоверяване (supplicant) на "
+"връзката (802.1x)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr ""
+"Програмата за удостоверяване (supplicant) на връзката (802.1x) приключи "
+"неуспешно"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+"Удостоверяването на връзката (802.1x) отне на програмата (supplicant) повече "
+"време от стандартното"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Неуспешно стартиране на услугата за връзка чрез PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Услугата за връзка чрез PPP е прекъсната"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Услугата за връзка чрез PPP приключи неуспешно"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr ""
+"Неуспешно стартиране на клиента за автоматична настройка на връзката (DHCP)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Грешка на клиента за автоматична настройка на връзката (DHCP)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr ""
+"Клиентът за автоматична настройка на връзката (DHCP) приключи неуспешно"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Неуспешно стартиране на услугата за споделяне на връзката"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Услугата за споделяне на връзката приключи неуспешно"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr ""
+"Неуспешно стартиране на услугата за локална връзка (AutoIP, 169.254.0.0/16, "
+"fe80::/10)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr ""
+"Грешка в услугата за локална връзка (AutoIP, 169.254.0.0/16, fe80::/10)"
+
+# AutoIP = link-local
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr ""
+"Услугата за локална връзка (AutoIP, 169.254.0.0/16, fe80::/10) приключи "
+"неуспешно"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Линията е заета"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Няма сигнал"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Неуспешно установяване на носещата честота"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Времето на заявката за набиране изтече"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Опитът за набиране приключи неуспешно"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Неуспешно инициализиране на модема"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Неуспешно избиране на зададената точка за достъп (APN)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Не се търсят мрежи"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Регистрацията в мрежата е отхвърлена"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Времето на заявката за регистрация в мрежата изтече"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Неуспешна регистрация в заявената мрежа"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Неуспешна проверка на ПИН кода"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Възможно е фърмуерът за устройството да липсва"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Връзката се изгуби"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Предполагаше се съществуваща връзка"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Няма модем"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Неуспешна връзка чрез Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr " SIM картата не е поставена"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Необходим е ПИН код за SIM картата"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Необходим е код (PUK) за SIM картата"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Грешна SIM карта"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Неуспешно активиране на зависимост за връзката"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Липсва фърмуер"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Кабелът е изваден"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "грешка в сигурността 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "не е избран файл"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "грешка при проверката на файла за eap"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Частни ключове във формат DER, PEM или PKCS#12"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Сертификати формат DER или PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "файлът за EAP-FAST PAC липсва"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Файлове във формат PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC (карта за еднократни пароли)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2 (предизвикателство и ръкостискане)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Свободен достъп"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Удостоверяване"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "И двете"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_Анонимност"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Файл за PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Избор на файл PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Вътрешно удостоверяване"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "_Автоматично осигуряване на PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "липсва потребителско име за EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "липсва парола за EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Потребителско _име"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Парола"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Показване на паролата"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "неправилен сертификат на удостоверител за EAP-PEAP: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+"неправилен сертификат на удостоверител за EAP-PEAP: не е указан сертификат"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Версия 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Версия 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "_Сертификат на удостоверител"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Избор на сертификат на доставчик на удостоверителски услуги"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "_Не се изисква сертификат на удостоверител"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Версия на PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "липсва потребителско име за EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "липсва парола за EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "липсва идентичност за EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "неправилен сертификат на удостоверител за EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+"неправилен сертификат на удостоверител за EAP-TLS: не е указан сертификат"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "неправилен частен ключ за EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "неправилен потребителски сертификат за EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Нешифрираните лични ключове са несигурни"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Избраният частен ключ не е защитен с парола. Това позволява компрометирането "
+"на идентичността ви. Изберете частен ключ, защитен с парола.\n"
+"\n"
+"(Можете да защитите частния ключ с парола чрез командата „openssl“)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Изберете личния си сертификат"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Изберете частния си ключ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Идентичност"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Личен сертификат"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Частен ключ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Парола за _частния ключ"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "неправилен сертификат на удостоверител за EAP-TTLS: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+"неправилен сертификат на удостоверител за EAP-TTLS: не е указан сертификат"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (без EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Област/домейн"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Грешка при валидиране на сигурността за 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Тунел по TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Защитен EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Удостоверяване"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Избор на файл"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "липсва потребителско име за leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "липсва парола за leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Липсва парола за безжичната мрежа."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Вид"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "липсва ключ за wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"неправилен ключ за wep: ключ с дължина от %zu знака трябва да съдържа само "
+"шестнадесетични цифри"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"неправилен ключ за wep: ключ с дължина от %zu знака трябва да съдържа само "
+"ASCII"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"неправилен ключ за wep: неправилна дължина на ключа — %zu. Той трябва да е "
+"дълъг или 5/13 знака за ASCII, или 10/26 знака за шестнадесетични цифри"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "неправилен ключ за wep: празна парола"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "неправилен ключ за wep: паролата трябва да е под 64 знака"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (По подразбиране)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Открита система"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Споделен ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Пок_азване на ключа"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Индек_с в WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"неправилен ключ за wpa-psk: дължината на ключа е %zu. Трябва да е от 8 до 63 "
+"байта или 64 шестнадесетични цифри"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"неправилен ключ за wpa-psk: ключът е дълъг 64 байта, но не се състои само от "
+"шестнадесетични цифри"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Известия"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Звукови известия"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Изскачащи известия"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Известията пак ще се появяват в списъка с известия, дори и изскачащите "
+"варианти да са изключени."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Показване на _детайлите в изскачащите известия"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Известия при _заключен екран"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Показване на _съдържанието на известията при заключен екран"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Не безпокойте"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Известия при _заключен екран"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Управление на известията и тяхната детайлност"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"предупреждения;известия;съобщения;тава;изскачащ;notifications;banner;message;"
+"tray;popup;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Друга"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s — изтрит"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Неуспешно премахване на регистрация"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Връщане"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Затваряне на системното известие"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Свързване към данните в облака"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Няма връзка към Интернет. Тя ви трябва, за да добавите нови регистрации в "
+"сайтове"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Добавяне на регистрация в сайт"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Регистрация в „%s“"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Премахване на регистрация"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Регистрации в Интернет"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Свързване с регистрациите ви в някои сайтове и задаване за какво да се "
+"ползват"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"гугъл;фейсбук;туитър;яху;социален;уеб;мрежа;разговор;календар;поща;контакт;"
+"оун;клауд;керберос;цербер;имап;smtp;покет;покит;рийд;google;facebook;twitter;"
+"yahoo;web;online;chat;calendar;mail;contact;owncloud;kerberos;imap;smtp;"
+"pocket;readitlater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Неизвестно време"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i минута"
+msgstr[1] "%i минути"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i час"
+msgstr[1] "%i часа"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s и %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "час"
+msgstr[1] "часа"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "минута"
+msgstr[1] "минути"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "Остават %s до пълно зареждане"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Внимание: остават %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "остават %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Пълно зареждане"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Не се зарежда"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Разредена"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Зареждане"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Разреждане"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Безжична мишка"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Безжична клавиатура"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Непрекъсваемо токозахранване"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Цифров помощник"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Мобилен телефон"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Музикално устройство"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Таблет"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Компютър"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Контролер за игри"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батерия"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Основна"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Допълнителна"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Батерии"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "При _бездействие"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "приспиване"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Изключване"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "дълбоко приспиване"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "нищо"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "При работа от батерии"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "При включване на захранването"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Никога"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Автоматично приспиване"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Режимът на висока производителност е изключен поради прекалено високата "
+"температура на хардуера."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Засечена е работа в скута на потребителя, затова режимът на висока "
+"производителност е недостъпен. Сложете устройството на стабилна повърхност, "
+"за се върне достъпът до този режим."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Високата производителност временно е изключена."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Нисък заряд на батерията, затова е включен режимът на енергоспестяване. "
+"Предишният режим ще се включи отново след достатъчно зареждане на батерията."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Енергоспестяването е включено от „%s“."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Високата производителност е включена от „%s“."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 минути"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 минути"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 минути"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 минути"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 минути"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 час"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 минути"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 минути"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 минути"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 часа"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Енергопотребление"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Влияе на производителността и енергопотреблението."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Настройки за енергоспестяване"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Автоматична яркост на екрана"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Яркостта на екрана се променя според околната светлина."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Затъмняване на екрана"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Затъмняване на екрана при бездействие на компютъра."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Изключване на екрана"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Изключване на екрана след по-дълго бездействие на компютъра."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Автоматично енергоспестяване"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Превключване към енергоспестяващ режим при нисък заряд на батерията."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Автоматично приспиване"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Приспивате на компютъра след по-дълъг период на бездействие."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Поведение на _бутона за изключване"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "_Процент заряд на батерията"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Автоматично приспиване"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Включено захранване"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Работа от _батерии"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Закъснение"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Висока производителност"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Високи производителност и енергопотребление."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Баланс"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Стандартни производителност и енергопотребление."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Енергоспестяване"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "По-ниски производителност и енергопотребление."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Висока производителност"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Преглед на състоянието на батерията и промяна на настройките на "
+"енергоспестяването"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"захранване;дълбоко;приспиване;заспиване;батерия;яркост;затъмняване;"
+"изчистване;екран;капак;бездействие;power;sleep;suspend;hibernate;battery;"
+"brightness;dim;blank;monitor;dpms;idle;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Принтерът „%s“ е изтрит"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Неуспешно добавяне на нов принтер."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Неуспешно зареждане на файла с потребителския интерфейс „%s“"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Отключете, за да добавите принтери и да промените настройките"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Принтери"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Добавяне на принтери, преглед на задачите за печат, настройки на печата"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"принтер;опашка;печат;хартия;мастило;тонер;printer;queue;print;paper;ink;"
+"toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Добавяне на принтер"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Отключване"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Няма принтери"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Въведете мрежов адрес или потърсете принтер"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Изисква се удостоверяване"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Въведете името и паролата си, за да видите принтерите при сървъра за печат."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Потребителско име"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Подробности за „%s“"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Няма подходящ драйвер"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Избор на файл – PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Файлове на PostScript за описание на принтери (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+"gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Имената на принтери не може да съдържат празни знаци, „#“ или „/“"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Местоположение"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Драйвер"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Търсене на предпочитани драйвери…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Търсене на драйвери"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Избор от списъка с драйвери…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Инсталиране на файла с описанието (PPD)…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Избор на драйвер за принтер"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Зареждане на списъка с драйвери…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Избор"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Принтер по JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Принтер по LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Едностранно"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "По дългата страна (стандартно)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "По късата страна (завъртане)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Вертикална"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Хоризонтална"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Вертикална, обърната"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Хоризонтална, обърната"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Продължаване"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "На пауза"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "в опашката"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "На пауза"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Изисква се идентификация"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "обработвана"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "спряна"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "отказана"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "прекъсната"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "завършена"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Задачата да бъде първа в опашката"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u задача изисква удостоверяване"
+msgstr[1] "%u задачи изискват удостоверяване"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "„%s“ – активни задачи"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Удостоверете самоличността, за да печатате с „%s“."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Домейн"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Удостоверяване"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Изчистване на всички"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Удостоверяване"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Няма активни задачи"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Отключване на сървъра за печат"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Отключване на „%s“."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Въведете името и паролата си, за да видите принтерите при „%s“."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Търсене на принтери"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Сериен порт"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Паралелен порт"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Местоположение: „%s“"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Адрес: „%s“"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Сървърът изисква удостоверяване"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Двустранно"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Вид на хартията"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Източник на хартията"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Изходяща тава"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Разделителна способност"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Предварителен филтър на GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Страници на лист"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Двустранно"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Ориентация"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Общи"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Настройка на страницата"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Апаратни настройки"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Задача"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Качество на изображенията"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Цвят"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Довършителни"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Разширени"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Пробна страница"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Пробна страница"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Автоматичен избор"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Стандартното за принтера"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Вграждане само на шрифтовете на GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Преобразуване към PostScript, ниво 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Преобразуване към PostScript, ниво 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Без предварителен филтър"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Производител"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Няма активни задачи"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u задача"
+msgstr[1] "%u задачи"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Изчистване на печатащите глави"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Тонерът привършва"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Тонерът свърши"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Проявителят привършва"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Проявителят свърши"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Мастилото привършва"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Мастилото свърши"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Отворен капак"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Отворена вратичка"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Хартията привършва"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Хартията свърши"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Изключен"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "спрян"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Контейнерът за отпадъчно мастило е почти пълен"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Контейнерът за отпадъчно мастило е пълен"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Барабанът е почти износен"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Барабанът е износен"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "в готовност"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "не приема задачи"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "обработване"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Настройки за печат"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Подробности за принтера"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Стандартен принтер"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Изчистване на печатащите глави"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Премахване на принтер"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Модел"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Ниво на мастилото"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Рестартирайте принтера след коригиране на проблема."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Рестартиране на принтера"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Добавяне на принтер…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Няма принтери"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Изглежда, че системната услуга\n"
+"    за печат не е налична."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Формати"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Търсене на локали…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Чести формати"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Всички формати"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Няма резултати"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Търсенето може да е по държави или езици."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Преглед"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "имперска"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "метрична"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Дати"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Дати и часове"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Числа"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Система от единици"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Хартия"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Езикът и форматът се прилагат при следващия вход в системата"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Изход…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Настройките за език важат за интерфейса и уеб страниците. Форматите са за "
+"числа, дати и валути."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Моята регистрация"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Език"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Формати"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Екран за вход"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Регион и език"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+"Избор на език на интерфейса и форматите на числата, датите, времето, парите"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "език;подредба;клавиатура;вход;language;layout;keyboard;input;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "да се пита за действие"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "нищо да не се прави"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "отваряне на папката"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Други носители"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Избор на програма, с която да отваряте аудио дискове (CD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Избор на програма, с която да отваряте видео дискове (DVD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Избор на програма, която да се изпълнява при свързване на преносимо "
+"устройство за музика"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Изберете програма, която да се изпълнява при свързване на камера"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Избор на програма, с която да се отварят дискове с програми"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "аудио диск – DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "празен диск – Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "празен диск – CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "празен диск – DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "празен диск – HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "видео диск – Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "четец на електронни книги"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "видео диск – HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "диск с изображения – CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "видео диск – Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "видео диск – Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Програми за Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Изберете как да се управлява носителят"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Аудио диск — CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "Ви_део диск — DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Музикално устройство"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Програми"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Други носители…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Без показване на информация, без стартиране на програми при зареждане на "
+"носители"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Изберете как да се управляват другите видове носители"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Действие:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Вид:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Преносими носители"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Настройки за преносимите носители"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"устройство;система;стандартна;приложение;програма;предпочитана;cd;dvd;usb;"
+"звук;аудио;видео;диск;преносим;носител;автоматично;стартиране;device;system;"
+"default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;"
+"autorun;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Екранът се изключва"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 секунди"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 минута"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 минути"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 минути"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 минути"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 минути"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 час"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 минута"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 минути"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 минути"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 минути"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 минути"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 минути"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 минути"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 минути"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 минути"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "никога"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Заключване на екрана"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Автоматичното заключване на екрана предотвратява други да ползват компютъра "
+"докато не сте при него."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Забавяне за изчистване на екрана"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Период бездействие, след който екранът се изчиства."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Автоматично _заключване на екрана"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Изчакване преди автоматично _заключване на екрана"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Период след изключването на екрана, когато той се заключва."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Показване на _известия при заключен екран"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "_Забраняване на нови устройства по USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Устройствата по USB да не взаимодействат с компютъра, когато екранът е "
+"заключен."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Поверителност на екрана"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Ограничаване на ъгъла на видимост"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Настройки на екрана"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "екран;заключване;поверителност;скриване;screen;lock;private;privacy;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Избор на регион"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Добре"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Къде да се търси"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Папки, в които да се търси от системните програми като „Файлове“, „Снимки“, "
+"„Видео“."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Места"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Отметки"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Други"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Добавяне на местоположение"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Няма програми"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Търсене чрез програмите"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Включване на резултати от търсене чрез допълнителни програми."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Папки, в които да се търси от системните програми."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Резултати от търсенето"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Подредба на резултатите."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Определяне на приложенията, които да показват резултати в прегледа на "
+"дейностите"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"търсене;намиране;индекс;скриване;личен;частен;резултати;search;find;index;"
+"hide;privacy;results;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Не са избрани мрежи за споделяне"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Мрежи"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Включена"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Изключена"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Включена"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Активна"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Избор на папка"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Добавяне"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Включване на споделянето на медия"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Споделянето на лични файлове ви позволява да споделите папката „Публични“ с "
+"други потребители през текущата мрежа чрез следния адрес: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Позволяване на отдалечените потребители да се връзват към машината ви с "
+"команда за сигурна обвивка:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Включване на споделянето на собствените медийни файлове"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Името на устройството е копирано"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Адресът на устройството е копиран"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Потребителското име е копирано"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Паролата е копирана"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Споделяне"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Име на компютър"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Споделяне на _файлове"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_Отдалечена графична връзка"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Споделяне на _мултимедия"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Отдалечено влизане"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Споделяне на файлове"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Изискване на парола"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Отдалечената графична връзка"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Отдалечена графична връзка"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Отдалечената графична връзка позволява преглед и управление на този компютър "
+"от друг."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Включване или изключване на отдалечената графична връзка към този компютър."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Отдалечен контрол"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Позволяване на отдалечените връзки да управляват екрана."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Начин за връзка"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Връзка към този компютър чрез име на устройство или отдалечен адрес на "
+"работно място."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Копиране"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Адрес на отдалечения компютър"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Удостоверяване"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "За връзка към този компютър са необходими име и парола."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Потребителско име"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Криптографска проверка"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Криптографски отпечатък"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Криптографският отпечатък се вижда в клиентите при свързване. Той трябва да "
+"съвпада."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Споделяне на музика"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Споделяне на музика, снимки и видео по мрежата."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Папки"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Определяне какво да се споделя с другите"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"споделяне;достъп;даване;машина;компютър;хост;име;отдалечен;плот;блутут;син;"
+"зъб;медия;аудио;песен;песни;снимка;фото;фотография;видео;филм;клип;сървър;"
+"показвам;изобразяване;share;sharing;ssh;host;name;remote;desktop;bluetooth;"
+"obex;media;audio;video;pictures;photos;movies;server;renderer;share;sharing;"
+"ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;pictures;"
+"photos;movies;server;renderer;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Включване или изключване на отдалечената графична връзка"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Изисква се удостоверяване за превключване на отдалечената графична връзка"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Потребителско"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Прицъкване"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Низ"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Залюляване"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Тананикане"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Баланс"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Затихване"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Отзад"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Отпред"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Проба на %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Натиснете високоговорител за проба"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Ниво на системата"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Основно ниво"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Нива на звука"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Изход"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Изходно устройство"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Изпробване"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Настройки"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Бас"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Вход"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Входно устройство"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Сила на звука"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Сила на известяването"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100 %"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Заглушаване"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Звук"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Промяна на силата на звука, звуците свързани със събития, аудио входовете и "
+"изходите"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"карта;микрофон;сила;звука;затихване;баланс;блутут;син;зъб;слушалки;звук;"
+"аудио;увеличаване;намаляване;заглушаване;млъкване;вход;изход;жак;чинч;card;"
+"microphone;volume;fade;balance;bluetooth;headset;audio;output;input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Без връзка"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Свързване"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Свързано"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Грешка при упълномощаване"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Упълномощаване"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Непълна функционалност"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Свързано и одобрено"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Одобрено на:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Свързано на:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Одобрено и добавено на:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Неуспешно одобряване на устройство: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Неуспешно забравяне на устройство: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Зависи от %u друго устройство"
+msgstr[1] "Зависи от %u други устройства"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Затваряне на системно известие"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Име:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Състояние:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "Идентификатор:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Одобряване и свързване"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Забравяне на устройство"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Грешка"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Одобрено"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Подсистемата за Thunderbolt (boltd) или не е инсталирана, или не е настроена "
+"правилно."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Позволяване на директен достъп до устройства като докинг станции и външни "
+"GPU-та."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Може да се свързват само устройства по USB и Display Port."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Не може да се засече Thunderbolt.\n"
+"Системата не поддържа Thunderbolt или в BIOS-а е изключен или там е зададено "
+"неподдържано ниво на сигурност."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Поддръжката на Thunderbolt е изключена в BIOS-а."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Нивото на сигурност на Thunderbolt не може да се установи."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Грешка при прeвключване на директния режим: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt не се поддържа"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Неуспешно свързване с подсистемата за Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Пряк достъп"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Предстоящи устройства"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Няма свързани устройство"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Управление на устройства по Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "тъндърболт;лични;данни;защита;сигурност;thunderbolt;privacy;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Мигащ курсор"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Мигащ курсор в текстовите полета."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Скорост"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Скорост на мигане на курсора"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Размер на показалеца"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Може да комбинирате размера на показалеца с лупа, за да го виждате по-лесно."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Помощ при натискане"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Симулирано повторно натискане"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Второ натискане при задържане на основния бутон"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "За_къснение при отчитане:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "късо"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Закъснение при повторно натискане"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "дълго"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Натискане чрез _задържане"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Натискане при посочване с мишката"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Закъснение:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "късо"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "дълго"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "П_раг на движение:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "малък"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "голям"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Повторни клавиши"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Натискането на бутона се повтаря, ако той бъде задържан."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Време преди повтаряне на клавишите"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Скорост на повтаряне на клавишите"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Помощ при писане"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Лепкави клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Използване на модификаторите на клавиши като клавишни комбинации"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Изключване при натискането на _два клавиша едновременно"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Звук при натискане на _модификатор"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Бавни клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Въвеждане на закъснение между натискането на клавиш и отчитането му"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "късо"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Забавяне за бавните клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "дълго"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Звук при _натискане на клавиш"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Звук при _приемане на клавиш"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Звук при _отхвърляне на клавиш"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Подскачащи клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Игнориране на бързо натискане на еднакви клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "късо"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Забавяне за подскачащите клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "дълго"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Включване чрез клавиатурата"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Включване и изключване на достъпността чрез клавиатурата"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Стандартен"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Среден"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Голям"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "По-голям"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Най-голям"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d пиксел"
+msgstr[1] "%d пиксела"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Винаги да се показва менюто за универсален достъп"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Зрение"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Висок контраст"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Едър текст"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "_Анимации"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Екранен _четец"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Екранният четец произнася текста на фокус"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Звуци за клавишите"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Звуков сигнал при превключването на Num Lock и Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "_Размер на показалеца"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Лупа"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Слух"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Зрителни известия"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Екранна клавиатура"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Повторни клавиши"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Мигащ курсор"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Помощ при _въвеждане (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Посочване и натискане"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Бутони за мишката"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Откриване на принтер"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Помощ при _натискане"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Забавяне при _двойно натискане"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Забавяне при двойно натискане"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Зрителни известия"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Проба на проблясването"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Едновременно зрително и звуково известяване."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Проблясване на целия _екран"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Проблясване на целия _прозорец"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "късо"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ екран"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ екран"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ екран"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "дълго"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "На цял екран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Горната половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Долната половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Лявата половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Дясната половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Настройки на лупата"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Мащаб:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Положение на лупата:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Следване на показалеца на мишката"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Част на екрана:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "_Лупата да излиза извън екрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Показалецът на мишката да е в средата на лупата"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Показалецът на мишката да из_бутва съдържанието"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Показалецът на мишката да се движи _заедно с лупата"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Лупа"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Кръстачка:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Върху показалеца на мишката"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Дебелина:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "тънка"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "дебела"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "Дъл_жина:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Цвят:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Кръстачка"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Цветови ефекти:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Бяло на черно:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Яркост:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Контраст:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Цвят"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "без"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "пълноцветно"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "ниска"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "висока"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "нисък"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "висок"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Цветови ефекти"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "По-лесно да се вижда, чува, въвежда текст, посочват и натискат обекти"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"клавиатура;мишка;достъпност;универсален;достъп;контраст;курсор;показалец;"
+"звук;увеличение;мащаб;четец;голям;едър;екран;текст;шрифт;размер;лепкави;"
+"бавни;подскачащи;клавиши;бутони;мишка;двойно;натискане;забавяне;скорост;"
+"повтаряне;мигане;слух;аудио;набиране;анимации;keyboard;mouse;a11y;"
+"accessibility;universal access;contrast;cursor;sound;zoom;screen;reader;big;"
+"high;large;text;font;size;accessx;sticky;keys;slow;bounce;mouse;double;click;"
+"delay;speed;assist;repeat;blink;visual;hearing;audio;typing;animations;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 час"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 ден"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 дена"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 дена"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 дена"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 дена"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 дена"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 дена"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 дена"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 дена"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Изчистване на кошчето"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Всичко в кошчето ще бъде безвъзвратно изтрито."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Изчистване на кошчето"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Да се изчистят ли всички временни файлове?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Всички временни файлове ще бъдат окончателно изтрити."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "И_зчистване на временните файлове"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 ден"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 дена"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 дена"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Завинаги"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Използвани файлове"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"В използваните файлове се появяват файловете, които сте отваряли скоро. Тази "
+"информация се споделя между програмите и улеснява откриването на файловете, "
+"които ви трябват."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "_Използвани файлове"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "_Период за използваните файлове"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Изчистване на историята…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Кошче и временни файлове"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Кошчето и временните файлове понякога съдържат лични данни. Автоматичното им "
+"изтриване помага за защитата на личните данни."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Автоматично изчистване на _кошчето"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Автоматично изчистване на временните _файлове"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Автоматично изчистване след"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Изчистване на кошчето…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "И_зчистване на временните файлове…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "История на файловете и кошчето"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Без оставяне на следи"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"употреба;скорошни;последни;история;временни;файлове;лични;данни;защита;кошче;"
+"изчистване;;usage;recent;history;files;temporary;tmp;private;privacy;trash;"
+"purge;retain;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Трябва да съвпада с уеб адреса на доставчика на регистрации."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Неуспешно добавяне на регистрация"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Паролите не съвпадат."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Неуспешна връзка с регистрация"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Няма поддръжка за удостоверяването на тази област/домейн"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Неуспешно присъединяване към областта/домейна"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Неправилно потребителско име.\n"
+"Опитайте отново."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Неправилна парола.\n"
+"Опитайте отново."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Неуспешен вход в областта/домейна"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Домейнът липсва. Да сте сбъркали името му?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Добавяне на потребител"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Администратор"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Администраторите може да добавят и премахват потребители, както и да "
+"променят техните настройки. Администраторите не подлежат на родителски "
+"контрол."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Потребителят да зададе парола при следващото влизане"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Задаване на парола"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Потвърждаване"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Корпоративен вход"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Потребители, които се управляват от компания или организация."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Не сте на линия"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Корпоративният вход позволява на този компютър да бъдат ползвани централно "
+"управлявани потребителски регистрации. Това обикновено дава и достъп до "
+"ресурсите на компанията в интернет."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Разглеждане за други изображения"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Избор на файл…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Управление на пръстови отпечатъци"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Пръстов отпечатък"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Не"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Да"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Искате ли да изтриете въведените си отпечатъци и да изключите влизането с "
+"тях?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Няма устройство за пръстови отпечатъци"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Няма устройство за пръстови отпечатъци"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Проверете дали устройството е свързано правилно."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Устройство за пръстови отпечатъци"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Изберете устройството за пръстови отпечатъци, което да настроите"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Влизане с пръстов отпечатък"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Влизането с пръстов отпечатък позволява лесно и бързо отключване на "
+"компютъра с пръст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Изтриване на отпечатъците"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Въвеждане на пръстов отпечатък"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "за това действие трябва изключителен достъп до устройството"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "устройството вече се ползва от друг процес"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "нямате права за това действие"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "не са въведени отпечатъци"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Неуспешна комуникация с устройството при въвеждането"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Неуспешна комуникация с устройството за пръстови отпечатъци"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Неуспешна връзка към демона за пръстови отпечатъци"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Неуспешно изброяване на пръстовите отпечатъци: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Неуспешно изтриване на пръстов отпечатък: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Ляв палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Ляв среден"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Ляв показалец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Ляв безименен"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Ляво кутре"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Десен палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Десен среден"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Десен показалец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Десен безименен"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Дясно кутре"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Непознат пръст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Готово!"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Изключено устройство за пръстови отпечатъци"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Мястото за пръстови отпечатъци свърши"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Неуспешно добавяне на нов отпечатък"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Неуспешно въвеждане: „%s“"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Неуспешно въвеждане на нов отпечатък"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Неуспешно спиране на въвеждането на нов отпечатък: „%s“"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Неколкократно поставете и вдигнете пръст върху четеца на отпечатъци, за да "
+"ги въведете"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Повторно въвеждане на този пръст…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Снимане на нов отпечатък"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Неуспешно освобождаване на устройството за пръстови отпечатъци %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Грешка при четене от устройството"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Неуспешно заявяване на устройството за пръстови отпечатъци %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Неуспешно изброяване на устройствата за пръстови отпечатъци: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Тази седмица"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Миналата седмица"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Сесията завърши"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Сесията започна"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — дейности по регистрацията"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Предишна"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Следваща"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Изберете друга парола."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Въведете отново текущата си парола."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Паролата не бе сменена"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Смяна на паролата"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Смяна"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Текуща парола"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Нова парола"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Потвърждаване на нова парола"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Позволяване на потребителя да избере парола при следващото влизане"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "въвеждане на парола сега"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Не може автоматично да се присъедините към такава област/домейн"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Няма такъв домейн или област"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Неуспешно влизане като „%s“ в областта/домейна „%s“"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Грешна парола. Опитайте отново."
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Неуспешно свързване с домейна „%s“: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Неуспешно изтриване на потребител"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Неуспешно премахване на права на отдалечен потребител"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Невъзможно е да изтриете собствената си регистрация."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "„%s“ все още е в системата"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Изтриването на влезли потребители може да доведе до неправилно състояние на "
+"системата."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Желаете ли да запазите файловете на „%s“?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Възможно е да запазите домашната папка, пощенската кореспонденция и "
+"временните файлове, когато изтривате съответната потребителска регистрация."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Изтриване на файловете"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Запазване на файловете"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Наистина ли желаете да премахнете отдалечено управляваната регистрация „%s“?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Изтриване"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "регистрацията е изключена"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "ще бъде избрана при следващото влизане"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "без"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "В системата"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Неуспешно свързване с услугата за регистрации"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Уверете се дали програмата „AcountService“ е инсталирана и включена."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "За да променяте настройките в този панел, трябва да го отключите."
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Изтриване на избраната потребителска регистрация"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"За да изтриете избраната потребителска\n"
+"регистрация, първо натиснете иконата „*“"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Отключете за добавяне на потребители и управление на настройките им"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Потребители"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "За да влязат настройките в сила, трябва да рестартирате сесията"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Рестартиране"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Затваряне"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Редактиране на аватар"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Пълно име"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Редактиране"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Влизане с _пръстов отпечатък"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Автоматично влизане"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Дейности в регистрацията"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Администратор"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Администраторите може да добавят и премахват потребители, както и да "
+"променят всички настройки."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Родителски контрол"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Отваряне на програмата за родителски контрол."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Премахване на потребителска регистрация…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Други потребители"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Добавяне на потребител…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Няма потребители"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Отключете, за да създадете потребителска регистрация."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Добавяне или премахване на потребители и смяна на парола"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"login;name;fingerprint;avatar;logo;face;password;parental controls;screen "
+"time;app restrictions;web restrictions;usage;usage limit;kid;child;\n"
+"вход;влизане;име;отпечатък;аватар;лого;снимка;лице;парола;възрастови "
+"ограничения;родителски контрол;ограничения;забрани;употреба;лимит;граница;"
+"време;дете;деца;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Добавяне към домейн"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Вход за администратор на областта/домейна"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"За да влезете в корпоративната мрежа, компютърът ви трябва да бъде "
+"регистриран в домейна ѝ. Помолете вашия мрежови администратор да въведе "
+"паролата си тук."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Име на администратора"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Парола на администратора"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Управление на потребителски регистрации"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Изисква се удостоверяване за промяна на потребителските данни"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Новата парола трябва да се различава от старата."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Променете някои от знаците и цифрите."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Променете паролата още малко."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "По-добре е паролата ви да не съдържа потребителското ви име."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Не използвайте потребителското си име в паролата си."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Не използвайте част от думите в паролата си."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Избягвайте често срещани думи."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Не трябва просто да разменяте думите, включени в паролата ви."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Използвайте още цифри."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Използвайте още главни букви."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Използвайте още малки букви."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Използвайте още специални знаци — като пунктуация."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Използвайте и букви, и цифри, и пунктуация."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Не повтаряйте един и същи знак."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Не използвайте само един вид знаци. Включете и букви, и цифри, и пунктуация."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Не използвайте последователности като „1234“ или „abcd“."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Паролата трябва да е по-дълга. Използвайте и букви, и цифри, и пунктуация."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Използвайте главни и малки букви, добавете и някоя и друга цифра."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Ако добавите още букви, цифри или знаци ще я направите още по-силна."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Неуспешно удостоверяване"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Новата парола е прекалено кратка"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Новата парола е прекалено лесна"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Старата и новата пароли много си приличат"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Новата парола е ползвана прекалено скоро в миналото"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Новата парола трябва да съдържа цифри или специални знаци"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Старата и новата пароли са еднакви"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Паролата ви е променена откакто първоначално сте се удостоверили!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Новата парола не съдържа достатъчно различни знаци"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Непозната грешка"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Потребителското име обикновено съдържа малки букви в диапазона a-z, цифри и "
+"знаците „-“ и „_“"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Това потребителско име е заето. Пробвайте с друго."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Потребителското име е прекалено дълго."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Функции на бутоните"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Настройване на функциите на бутоните"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"За да редактирате клавишната комбинация, изберете „Натискане на клавиш“, "
+"въведете новата комбинация и задръжте новите клавиши. За изчистване "
+"натиснете Backspace."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Затваряне"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "Потупайте целевите места на екрана на таблета, за да го калибрирате."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Погрешно потупване, ново калибриране…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Бутон № %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Дефинирани програми"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Натискане на клавиш"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Смяна на монитора"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Извеждане на помощ на екрана"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Таблетът е за екрана на таблета"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Таблетът е за външен екран"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Външно устройство за таблет"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Външно входно устройство"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Всички екрани"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Режим на таблета"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Абсолютно позициониране на писеца"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Ориентация за лява ръка"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Завъртане на таблета и Express Keys™ за лява ръка"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "За кой монитор"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Запазване на пропорцията"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Да се ползва само част от повърхността на таблета, със същото отношение на "
+"страните като екрана"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Калибриране"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Няма таблет"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Свържете или включете таблета си Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Усещане на натиска на писеца"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Мек"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Стандартен натиск на писеца"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Твърд"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Бутон 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Бутон 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Бутон 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Усещане на натиска на гумата"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Натиск на гумата"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Натискане на средния бутон на мишката"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Натискане на втория бутон на мишката"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Напред"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Стандартен писец с натиск, наклон и вградено плъзгане"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Стандартен писец с натиск, наклон и завъртане"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Стандартен писец с натиск и наклон"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Стандартен писец с натиск"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Таблет"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Присвояване на функции на бутоните на графичния таблет и управление на "
+"чувствителността на писалката"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "таблет;уаком;писалка;гума;мишка;tablet;wacom;stylus;eraser;mouse;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Нова клавишна комбинация…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Точки за достъп (AP)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "Име на точка за достъп (APN)"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Отменена операция"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>ГРЕШКА</b>: отказан достъп при смяна на настройките"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>ГРЕШКА</b>: грешка в хардуера за достъп до мобилна мрежа"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Няма регистрация"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Регистрирано"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Роуминг"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Търсене"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Отказ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Настройки на модема"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Състояние на модема"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Мобилен оператор"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Вид на мрежата"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Състояние на мрежата"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Собствен номер"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Настройки на устройството"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Версия на фърмуера"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G — само"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G — само"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G — само"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "5G — само"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (с предимство), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (с предимство), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (с предимство), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (с предимство), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (с предимство), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (с предимство), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (с предимство), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (с предимство), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (с предимство), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (с предимство), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (с предимство), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (с предимство), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (с предимство), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (с предимство), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (с предимство), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (с предимство), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (с предимство)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (с предимство), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Неизвестен"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Отключване на SIM карта"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Отключване"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Въведете ПИН за SIM карта %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Въведете ПИН за отключване на SIM карта"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Въведете код (PUK) за SIM карта %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Въведете код (PUK) за отключване на SIM карта"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Въведена е грешна парола. Остава ви %1$u опит"
+msgstr[1] "Въведена е грешна парола. Остават ви %1$u опита"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Остава ви %u опит"
+msgstr[1] "стават ви %u опита"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Въведена е грешна парола."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK кодът трябва да е число с 8 цифри"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Въведете нов ПИН"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "ПИН кодът трябва да е число с 4 до 8 цифри"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Отключване…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Няма SIM карта"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Поставете SIM карта, за да ползвате този модем"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "Заключена SIM карта"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Мобилни данни"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Достът до данни през мобилна мрежа"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Роуминг"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Мобилни данни при роуминг"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Режим на мрежата"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Мрежа"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Разширени"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Имена на точките за достъп"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_Заключване на SIM картата"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Заключване на SIM картата с ПИН"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "_Подробности за модема"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Грешка в телефона"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Няма връзка с телефона"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Непозволена операция"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Неподдържана операция"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr " SIM картата не е поставена"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Необходим е ПИН код за SIM картата"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Необходим е код (PUK) за SIM картата"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Грешка в SIM карта"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Заета SIM карта"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Неправилна парола"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Необходим е код (PIN2) за SIM картата"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Необходим е код (PUK2) за SIM картата"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Няма мрежа"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Няма мобилна мрежа"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Времето за мрежата изтече"
+
+# AutoIP = link-local
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Услугите GPRS не са позволени"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Роумингът не е позволен на това място"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Неуказана грешка от GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Няма грешки"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Отказано действие"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Отказан достъп"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Непозната грешка"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Режим на мрежата"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Автоматично"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Избор на мрежа"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Опресняване на доставчиците на мрежа"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Включване на мобилната мрежа"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Няма адаптер за мобилна мрежа"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Проверете дали адаптерът за безжична/мобилна мрежа е включен правилно"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Безжичната мрежа е изключена по време на самолетния режим"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Изключване на самолетния режим"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Връзка за данни"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "За интернет се ползва SIM карта"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Заключване на SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Напред"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Заключване на SIM с ПИН"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Смяна на ПИН"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Въведете текущия ПИН, за да промените настройките на SIM картата"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Мобилни мрежи"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Настройки на мобилни връзки и телефония"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+"cellular;wwan;telephony;sim;mobile;клетъчна;безжична;мобилна;сим;телефон;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Инструменти за настройването на работната среда GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Това е основният интерфейс за настройването на системата ви."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Проектът GMOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Извеждане на номера на версията"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Включване на подробен режим"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Търсене за низа"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Извеждане на имената на панелите и изход от програмата"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Панел за показване"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[ПАНЕЛ] [АРГУМЕНТ…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Категории настройки"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Поверителност"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Налични панели:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Всички настройки"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Основно меню"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Предупреждение: версия за разработчици"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Тази версия следва да се ползва само по време на разработка. Рискувате "
+"системата да се държи неправилно, да загубите данни, както и напълно "
+"неочаквано поведение."
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Помощ"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Общи"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Спиране на програмата"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Търсене"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Панели"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Към предишния панел"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Отказване на търсенето"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "настройки;конфигурация;опции;preferences;settings;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Идентификатор на последно отворения панел от „Настройки“"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Идентификаторът на последно отворения панел в „Настройки“. Непознати "
+"стойности се интерпретират като първия панел в списъка."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Предупреждение при стартиране на версия за разработка на „Настройки“"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Дали „Настройки“ да извеждат предупреждение, ако е стартирана версия за "
+"разработка."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Първоначално състояние на прозореца"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Комбинация от първоначалната широчина, височина и дали прозорецът на "
+"програмата е максимизиран."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u изход"
+msgstr[1] "%u изхода"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u вход"
+msgstr[1] "%u входа"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Системни звуци"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Грешка: нивото на HSI не може да се определи."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Грешка: грешното ниво на HSI не може да се определи."
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Сертификати във формат DER или PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Добавяне на принтер…"
+
+#~ msgid "Drip"
+#~ msgstr "Капка"
+
+#~ msgid "Glass"
+#~ msgstr "Стъкло"
+
+#~ msgid "Sonar"
+#~ msgstr "Сонар"
+
+#~ msgid "No Protection"
+#~ msgstr "Никаква защита"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "Минимална защита"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Основна защита"
+
+#~ msgid "Extended Protection"
+#~ msgstr "Допълнителна защита"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "Минимална защита на сигурността"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Основна защита на сигурността"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Допълнитерна защита на сигурността"
+
+#~ msgid "Light"
+#~ msgstr "Светъл"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "екран;монитор;дисплей;заключване;затъмняване;диагностика;забиване;частен;"
+#~ "личен;таен;скрит;временен;индекс;име;мрежа;идентичност;screen;lock;"
+#~ "diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
+#~ "identity;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Подредба на екраните"
+
+#~ msgid "Set"
+#~ msgstr "Задаване"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Заключване на екрана"
+
+#~ msgid "Bark"
+#~ msgstr "Лай"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Панел на GNOME зя настройките на звука"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Панел на GNOME за настройките на мишката и сензорния панел"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Панел на GNOME за настройките на фона"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Панел на GNOME за настройките на клавиатурата"
+
+#~ msgid "More Warm"
+#~ msgstr "По-топла"
+
+#~ msgid "Less Warm"
+#~ msgstr "По-студена"
+
+#~ msgid "Move up"
+#~ msgstr "Нагоре"
+
+#~ msgid "Move down"
+#~ msgstr "Надолу"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "„%s“: ВЧМ"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Удостоверяване"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Споделянето на екрана позволява на отдалечените потребители да разглеждат "
+#~ "и евентуално да управляват екрана ви като се свържат към %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Споделяне на _екрана"
+
+#~ msgid "_Password:"
+#~ msgstr "_Парола:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Показване на паролата"
+
+#~ msgid "Access Options"
+#~ msgstr "Настройки за достъп"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Новите връзки да питат за достъп"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Изискване на парола"

--- a/po/bn.po
+++ b/po/bn.po
@@ -13,9 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bn\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2011-04-04 09:11+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2011-04-04 15:55+0600\n"
 "Last-Translator: Zenat Rahnuma <zenat@ankur.org.bd>\n"
 "Language-Team: Bengali <ankur-bd-l10n@googlegroups.com>\n"
@@ -27,3006 +26,4668 @@ msgstr ""
 "X-Generator: Translate Toolkit 1.3.0\n"
 "X-Language: bn_BD\n"
 
-#: ../gnome-control-center.schemas.in.h:1
-msgid "Current network location"
-msgstr "বর্তমান নেটওয়ার্কের অবস্থান"
-
-# Translated by sadia
-#: ../gnome-control-center.schemas.in.h:2
-msgid "More backgrounds URL"
-msgstr "আরও পটভূমির ইউআরএল"
-
-# Translated by sadia
-#: ../gnome-control-center.schemas.in.h:3
-msgid "More themes URL"
-msgstr "আরও থিমের ইউআরএল"
-
-# Translated by sadia
-#: ../gnome-control-center.schemas.in.h:4
-msgid ""
-"Set this to your current location name. This is used to determine the "
-"appropriate network proxy configuration."
-msgstr ""
-"এটাকে আপনার বর্তমান অবস্থান হিসেবে নির্ধারণ করুন। যথার্থ নেটওয়ার্কের প্রক্সি "
-"কনফিগারেশন নিরূপন করতে এটি ব্যবহৃত হয়।"
-
-# Translated by sadia
-#: ../gnome-control-center.schemas.in.h:5
-msgid ""
-"URL for where to get more desktop backgrounds. If set to an empty string the "
-"link will not appear."
-msgstr ""
-"আরও ডেক্সটপ পটভূমি যেখানে পাওয়া যাবে তার ইউআরএল। যদি ফাঁকা স্ট্রিং হিসেবে নির্ধারণ "
-"করা থাকে তবে লিংকটি দৃশ্যমান হবে না।"
-
-# Translated by sadia
-#: ../gnome-control-center.schemas.in.h:6
-msgid ""
-"URL for where to get more desktop themes. If set to an empty string the link "
-"will not appear."
-msgstr ""
-"আরও ডেক্সটপ থিম যেখানে পাওয়া যাবে তার ইউআরএল। যদি ফাঁকা স্ট্রিং হিসেবে নির্ধারণ "
-"করা থাকে তবে লিংকটি দৃশ্যমান হবে না।"
-
-#: ../libgnome-control-center/cc-lockbutton.c:347
-#: ../panels/screen/screen.ui.h:14
-msgid "Lock"
-msgstr "আবদ্ধ"
-
-#: ../libgnome-control-center/cc-lockbutton.c:356
-#: ../panels/network/network.ui.h:20
-msgid "Unlock"
-msgstr "অনাবদ্ধ"
-
-#: ../libgnome-control-center/cc-lockbutton.c:365
-msgid "Locked"
-msgstr "আবদ্ধ"
-
-#: ../libgnome-control-center/cc-lockbutton.c:374
-msgid ""
-"Dialog is unlocked.\n"
-"Click to prevent further changes"
-msgstr ""
-"সংলাপ অনাবদ্ধ।\n"
-"আরও পরিবর্তন প্রতিরোধ করতে ক্লিক"
-
-#: ../libgnome-control-center/cc-lockbutton.c:383
-msgid ""
-"Dialog is locked.\n"
-"Click to make changes"
-msgstr ""
-"সংলাপ আবদ্ধ।\n"
-"পরিবর্তন করতে ক্লিক"
-
-#: ../libgnome-control-center/cc-lockbutton.c:392
-msgid ""
-"System policy prevents changes.\n"
-"Contact your system administrator"
-msgstr ""
-"সিস্টেমের নীতিমালা পরিবর্তন প্রতিরোধ করে।\n"
-"আপনার সিস্টেম প্রশাসকের সাথে যোগাযোগ করুন"
-
-#: ../libgnome-control-center/gconf-property-editor.c:134
-msgid "Key"
-msgstr "কী"
-
-#: ../libgnome-control-center/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr "যে GConf কী এর সাথে এই বৈশিষ্ট্যনির্ধারণী সম্পাদক যুক্ত আছে"
-
-#: ../libgnome-control-center/gconf-property-editor.c:141
-msgid "Callback"
-msgstr "কলব্যাক"
-
-#: ../libgnome-control-center/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "কী এর সাথে যুক্ত মান পরিবর্তিত হলে এই কলব্যাক উৎপন্ন হবে"
-
-#: ../libgnome-control-center/gconf-property-editor.c:147
-msgid "Change set"
-msgstr "নির্ধারণ পরিবর্তন"
-
-#: ../libgnome-control-center/gconf-property-editor.c:148
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr "GConf নির্ধারণ পরিবর্তনে ধারণকৃত ডাটা gconf ক্লায়েন্টে প্রয়োগ করতে ফরওয়ার্ড"
-
-#: ../libgnome-control-center/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr "উইজেট কলব্যাকে রূপান্তর"
-
-#: ../libgnome-control-center/gconf-property-editor.c:154
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "তথ্যকে GConf থেকে উইজেটে রূপান্তরের সময় যে কলব্যাকটি ব্যবহৃত হবে"
-
-#: ../libgnome-control-center/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr "উইজেট কলব্যাক থেকে রূপান্তর"
-
-#: ../libgnome-control-center/gconf-property-editor.c:160
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr "তথ্যকে উইজেট থেকে GConf এ রূপান্তরের সময় যে কলব্যাকটি ব্যবহৃত হবে"
-
-#: ../libgnome-control-center/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "UI নিয়ন্ত্রণ"
-
-#: ../libgnome-control-center/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr "বৈশিষ্ট্য নির্ধারণী অবজেক্ট (সাধারণত এটি একটি উইজেট)"
-
-#: ../libgnome-control-center/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr "বৈশিষ্ট্য নির্ধারণী সম্পাদকের অবজেক্টবিষয়ক তথ্য"
-
-#: ../libgnome-control-center/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr "বৈশিষ্ট্য নির্ধারণী সম্পাদকের প্রয়োজনীয় স্বনির্বাচিত তথ্য"
-
-#: ../libgnome-control-center/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr "বৈশিষ্ট্য নির্ধারণী সম্পাদকের তথ্য কলব্যাকের ওপর থেকে নিয়ন্ত্রণ প্রত্যাহার করছে"
-
-#: ../libgnome-control-center/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"বৈশিষ্ট্য নির্ধারণী সম্পাদকের অবজেক্টবিষয়ক তথ্যের ওপর থেকে নিয়ন্ত্রণ প্রত্যাহারের সময় "
-"যে কলব্যাকটি ব্যবহৃত হবে"
-
-#: ../libgnome-control-center/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"'%s' নামক ফাইলটি পাওয়া যাচ্ছে না।\n"
-"\n"
-"দয়া করে নিশ্চিত হোন যে ফাইলটি আসলেই আছে কিনা এবং তারপর আবার চেষ্টা করুন, অথবা "
-"পটভূমির জন্য অন্য কোন ছবি বেছে নিন।"
-
-#: ../libgnome-control-center/gconf-property-editor.c:1482
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"'%s' ফাইলটি পড়তে পারছি না।\n"
-"সম্ভবত এখনো এ ধরনের ছবি ব্যবহারের ব্যবস্থা নেই।\n"
-"\n"
-"অনুগ্রহপূর্বক অন্য একটি ছবি বেছে নিন।"
-
-#: ../libgnome-control-center/gconf-property-editor.c:1604
-msgid "Please select an image."
-msgstr "অনুগ্রহপূর্বক একটি ছবি বেছে নিন।"
-
-#: ../libgnome-control-center/gconf-property-editor.c:1609
-msgid "_Select"
-msgstr "নির্বাচন (_S)"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
-msgid "Background"
-msgstr "পটভূমি"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change the background"
-msgstr "পটভূমির ছবি সংরক্ষণ"
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "ওয়ালপেপার;স্ক্রীন;ডেস্কটপ;"
-
-# Translated by sadia
-#: ../panels/background/background.ui.h:1
-msgid "Center"
-msgstr "কেন্দ্র"
-
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "সারা দিনের পরিবর্তন"
-
-#: ../panels/background/background.ui.h:4
-msgid "Fill"
-msgstr "সম্পূর্ণ"
-
-# Translated by sadia
-#: ../panels/background/background.ui.h:5
-msgid "Scale"
-msgstr "স্কেল"
-
-#: ../panels/background/background.ui.h:6
-msgid "Span"
-msgstr "স্প্যান"
-
-# Translated by sadia
-#: ../panels/background/background.ui.h:7
-msgid "Tile"
-msgstr "টালি "
-
-#: ../panels/background/background.ui.h:8
-msgid "Zoom"
-msgstr "বড় আকারে প্রদর্শন"
-
-#: ../panels/background/bg-colors-source.c:46
-msgid "Horizontal Gradient"
-msgstr "অনুভূমিক গ্র্যাডিয়েন্ট"
-
-#: ../panels/background/bg-colors-source.c:47
-msgid "Vertical Gradient"
-msgstr "উল্লম্ব গ্রেডিয়েন্ট"
-
-#: ../panels/background/bg-colors-source.c:48
-msgid "Solid Color"
-msgstr "নিরেট রং"
-
-#: ../panels/background/cc-background-panel.c:958
-#: ../panels/user-accounts/um-photo-dialog.c:217
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
-msgid "Browse for more pictures"
-msgstr "আরো ছবির জন্য ব্রাউজ"
-
-# Translated by sadia
-#: ../panels/background/cc-background-panel.c:1049
-msgid "Current background"
-msgstr "বর্তমানের পটভূমি"
-
-#: ../panels/background/cc-background-panel.c:1133
-msgid "Wallpapers"
-msgstr "ওয়াল-পেপার"
-
-#: ../panels/background/cc-background-panel.c:1140
-msgid "Pictures Folder"
-msgstr "ছবির ফোল্ডার"
-
-#: ../panels/background/cc-background-panel.c:1147
-msgid "Colors & Gradients"
-msgstr "রং এবং গ্রেডিয়েন্ট"
-
-#: ../panels/background/cc-background-panel.c:1155
-msgid "Flickr"
-msgstr "ফ্লিকার"
-
-# Translated by sadia
-#: ../panels/background/cc-background-item.c:148
-msgid "multiple sizes"
-msgstr "বিভিন্ন আকার"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:152
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:281
-msgid "No Desktop Background"
-msgstr "ডেস্কটপের কোনো পটভূমি প্রয়োগ করা হবে না"
-
-#: ../panels/common/gdm-languages.c:709
-msgid "Unspecified"
-msgstr "উল্লেখিত নয়"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "24-Hour Time"
-msgstr "২৪ ঘন্টা সময়"
-
-#. Translator: this is the separator between hours and minutes, like in HH:MM
-#: ../panels/datetime/datetime.ui.h:3
-msgid ":"
-msgstr ":"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "এপ্রিল"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "August"
-msgstr "আগস্ট"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "City:"
-msgstr "শহর:"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "December"
-msgstr "ডিসেম্বর"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "February"
-msgstr "ফেব্রুয়ারি"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "January"
-msgstr "জানুয়ারি"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "July"
-msgstr "জুলাই"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "June"
-msgstr "জুন"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "March"
-msgstr "মার্চ"
-
-#: ../panels/datetime/datetime.ui.h:13
-msgid "May"
-msgstr "মে"
-
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Network Time"
-msgstr "নেটওয়ার্ক সময়"
-
-#: ../panels/datetime/datetime.ui.h:15
-msgid "November"
-msgstr "নভেম্বর"
-
-#: ../panels/datetime/datetime.ui.h:16
-msgid "October"
-msgstr "অক্টোবর"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Region:"
-msgstr "অঞ্চল:"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "September"
-msgstr "সেপ্টেম্বর"
-
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Clock;Timezone;Location;"
-msgstr "ঘড়ি;টাইম জোন;অবস্থান;"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
-msgid "Date and Time"
-msgstr "তারিখ ও সময়"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
-msgid "Date and Time preferences panel"
-msgstr "তারিখ ও সময় পছন্দ করার প্যানেল"
-
-#: ../panels/display/display-capplet.ui.h:1
-msgid "Left"
-msgstr "বাম"
-
-# Translated by sadia
-#: ../panels/display/display-capplet.ui.h:2
-#: ../panels/display/xrandr-capplet.c:491
-msgid "Monitor"
-msgstr "মনিটর "
-
-#: ../panels/display/display-capplet.ui.h:3
-#: ../panels/display/xrandr-capplet.c:327
-#: ../panels/display/xrandr-capplet.c:366
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Normal"
-msgstr "স্বাভাবিক"
-
-#: ../panels/display/display-capplet.ui.h:4
-msgid "Note: may limit resolution options"
-msgstr "মনে রাখবেন: রেজল্যুশন অপশনের সীমা দিতে পারে"
-
-#: ../panels/display/display-capplet.ui.h:5
-msgid "R_otation:"
-msgstr "আবর্তন (_o): "
-
-#: ../panels/display/display-capplet.ui.h:6
-msgid "Right"
-msgstr "ডানদিকে"
-
-#: ../panels/display/display-capplet.ui.h:7
-msgid "Upside-down"
-msgstr "উল্টো"
-
-#: ../panels/display/display-capplet.ui.h:8
-msgid "_Detect Displays"
-msgstr "প্রদর্শন সনাক্ত (_D)"
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:10
-msgid "_Mirror displays"
-msgstr "পর্দার অনুলিপি তৈরি করা হবে (_M)"
-
-#: ../panels/display/display-capplet.ui.h:11
-msgid "_Resolution:"
-msgstr "রেজল্যুশন (_R):"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Change resolution and position of monitors and projectors"
-msgstr "মনিটর এবং প্রজেক্টরের রেজল্যুশন ও অবস্থান পরিবর্তন"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Displays"
-msgstr "প্রদর্শন"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr "প্যানেল;প্রজেক্টর,xrandr;স্ক্রীন,রেজল্যুশন;রিফ্রেশ;"
-
-#: ../panels/display/xrandr-capplet.c:328
-msgid "Counterclockwise"
-msgstr "বামাবর্তী"
-
-#: ../panels/display/xrandr-capplet.c:329
-msgid "Clockwise"
-msgstr "দক্ষিণাবর্তে"
-
-#: ../panels/display/xrandr-capplet.c:330
-msgid "180 Degrees"
-msgstr "১৮০ ডিগ্রী"
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../panels/display/xrandr-capplet.c:467
-msgid "Mirror Displays"
-msgstr "মিরর প্রদর্শন "
-
-#: ../panels/display/xrandr-capplet.c:597
-#, c-format
-msgid "%d x %d (%s)"
-msgstr "%d x %d (%s)"
-
-#: ../panels/display/xrandr-capplet.c:599
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#: ../panels/display/xrandr-capplet.c:1510
-msgid "Drag to change primary display."
-msgstr "প্রাথমিক প্রদর্শন পরিবর্তন করতে টানুন।"
-
-#: ../panels/display/xrandr-capplet.c:1568
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr ""
-"মনিটরের বৈশিষ্ট্য পরিবর্তন করতে নির্বাচন করুন; এর অবস্থান পুনরায় নির্ধারণ করতে টেনে "
-"আনুন।"
-
-#: ../panels/display/xrandr-capplet.c:1957
-msgid "%a %R"
-msgstr "%a %R"
-
-#: ../panels/display/xrandr-capplet.c:1959
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
-
-#: ../panels/display/xrandr-capplet.c:2205
-msgid "Could not save the monitor configuration"
-msgstr "মনিটর সংক্রান্ত কনফিগারেশন সংরক্ষণ করতে ব্যর্থ"
-
-#: ../panels/display/xrandr-capplet.c:2230
-msgid "Could not get session bus while applying display configuration"
-msgstr "ডিসপ্লে কনফিগারেশন প্রয়োগ করার সময় সেশন বাস পাওয়া যায়নি"
-
-#: ../panels/display/xrandr-capplet.c:2275
-msgid "Could not detect displays"
-msgstr "ডিসপ্লে সনাক্ত করতে ব্যর্থ"
-
-#: ../panels/display/xrandr-capplet.c:2470
-msgid "Could not get screen information"
-msgstr "পর্দা সংক্রান্ত পরিবর্তন পাওয়া যায়নি"
-
-#. Translators: VESA is an techncial acronym, don't translate it.
-#: ../panels/info/cc-info-panel.c:366
-#, c-format
-msgid "VESA: %s"
-msgstr "VESA: %s"
-
-#. TRANSLATORS: device type
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:390 ../panels/network/panel-common.c:79
-#: ../panels/network/panel-common.c:158
-msgid "Unknown"
-msgstr "অজ্ঞাত"
-
-#. translators: This is the type of architecture, for example:
-#. * "64-bit" or "32-bit"
-#: ../panels/info/cc-info-panel.c:528
-#, c-format
-msgid "%d-bit"
-msgstr "%d-bit"
-
-#: ../panels/info/cc-info-panel.c:542
-#, c-format
-msgid "%u byte"
-msgid_plural "%u bytes"
-msgstr[0] "%u byte"
-msgstr[1] "%u bytes"
-
-#: ../panels/info/cc-info-panel.c:550
-#, c-format
-msgid "%.1f KB"
-msgstr "%.1f KB"
-
-#: ../panels/info/cc-info-panel.c:555
-#, c-format
-msgid "%.1f MB"
-msgstr "%.1f MB"
-
-#: ../panels/info/cc-info-panel.c:560
-#, c-format
-msgid "%.1f GB"
-msgstr "%.1f GB"
-
-#: ../panels/info/cc-info-panel.c:565
-#, c-format
-msgid "%.1f TB"
-msgstr "%.1f TB"
-
-#: ../panels/info/cc-info-panel.c:570
-#, c-format
-msgid "%.1f PB"
-msgstr "%.1f PB"
-
-#: ../panels/info/cc-info-panel.c:575
-#, c-format
-msgid "%.1f EB"
-msgstr "%.1f EB"
-
-#: ../panels/info/cc-info-panel.c:686
-msgid "Unknown model"
-msgstr "অজ্ঞাত মডেল"
-
-#: ../panels/info/cc-info-panel.c:769
-msgid "The next login will attempt to use the standard experience."
-msgstr "আদর্শ অভিজ্ঞতা ব্যবহারের জন্য পরবর্তী লগইনের প্রচেষ্টা।"
-
-#: ../panels/info/cc-info-panel.c:771
-msgid ""
-"The next login will use the fallback mode intended for unsupported graphics "
-"hardware."
-msgstr ""
-"অসমর্থিত গ্রাফিক্স হার্ডওয়্যারের জন্য পরবর্তী লগইন উদ্দেশ্যকৃত ফলব্যাক মোড ব্যবহার করবে"
-
-#. translators: The hardware is not able to run GNOME 3's
-#. * shell, so we use the GNOME "Fallback" session
-#: ../panels/info/cc-info-panel.c:813
-msgctxt "Experience"
-msgid "Fallback"
-msgstr "ফলব্যাক"
-
-#. translators: The hardware is able to run GNOME 3's
-#. * shell, also called "Standard" experience
-#: ../panels/info/cc-info-panel.c:819
-msgctxt "Experience"
-msgid "Standard"
-msgstr "আদর্শ"
-
-#: ../panels/info/cc-info-panel.c:951
-#: ../panels/keyboard/keyboard-shortcuts.c:1712
-msgid "Section"
-msgstr "অংশ"
-
-#: ../panels/info/cc-info-panel.c:960 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "সারসংক্ষেপ"
-
-#: ../panels/info/cc-info-panel.c:966 ../panels/info/info.ui.h:2
-msgid "Default Applications"
-msgstr "পূর্বনির্ধারিত অ্যাপ্লিকেশন"
-
-#: ../panels/info/cc-info-panel.c:971 ../panels/info/info.ui.h:9
-msgid "Graphics"
-msgstr "গ্রাফিক্স"
-
-#: ../panels/info/cc-info-panel.c:996
-#, c-format
-msgid "Version %s"
-msgstr "সংস্করণ %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-msgid "System Info"
-msgstr "সিস্টেমের তথ্য"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "System Information"
-msgstr "সিস্টেমের তথ্য"
-
-#. Translators: those are keywords for the System Information panel
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"fallback;"
-msgstr "ডিভাইস;সিস্টেম;তথ্য;মেমরি;প্রসেসর;সংস্করণ;পূর্বনির্ধারিত;অ্যাপ্লিকেশন;ফলব্যাক;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Calendar"
-msgstr "ক্যালেন্ডার"
-
-#: ../panels/info/info.ui.h:3
-msgid "Device name"
-msgstr "ডিভাইসের নাম"
-
-#: ../panels/info/info.ui.h:4
-msgid "Disk"
-msgstr "ডিস্ক"
-
-#: ../panels/info/info.ui.h:5
-msgid "Driver"
-msgstr "ড্রাইভার"
-
-#: ../panels/info/info.ui.h:6
-msgid "Experience"
-msgstr "অভিজ্ঞতা"
-
-#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
-#: ../panels/info/info.ui.h:8
-msgid "Forced Fallback Mode"
-msgstr "ফলব্যাক মোডে বাধ্য"
-
-#: ../panels/info/info.ui.h:10
-msgid "Mail"
-msgstr "মেইল"
-
-#: ../panels/info/info.ui.h:11
-msgid "Memory"
-msgstr "মেমরি"
-
-#: ../panels/info/info.ui.h:12
-msgid "Music"
-msgstr "গান"
-
-#: ../panels/info/info.ui.h:13
-msgid "OS type"
-msgstr "OS এর ধরন"
-
-#: ../panels/info/info.ui.h:15
-msgid "Photos"
-msgstr "ছবি"
-
-#: ../panels/info/info.ui.h:16
-msgid "Processor"
-msgstr "প্রসেসর"
-
-#: ../panels/info/info.ui.h:17
-msgid "Updates Available"
-msgstr "হালনাগাদ বিদ্যমান"
-
-#: ../panels/info/info.ui.h:18
-msgid "Video"
-msgstr "ভিডিও"
-
-# Translated by sadia
-#: ../panels/info/info.ui.h:19
-msgid "Web"
-msgstr "ওয়েব"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
-msgid "Eject"
-msgstr "নির্গত"
-
-# Translated by sadia
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Launch media player"
-msgstr "মিডিয়া প্লেয়ার চালুকরণ"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
-msgid "Next track"
-msgstr "পরবর্তী ট্র্যাক"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
-msgid "Pause playback"
-msgstr "পুনরায় চালানো বিরতি"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
-msgid "Play (or play/pause)"
-msgstr "চালান (অথবা চালান/বিরতি)"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
-msgid "Previous track"
-msgstr "পূর্ববর্তী  ট্র্যাক"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
-msgid "Sound and Media"
-msgstr "শব্দ এবং মিডিয়া"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
-msgid "Stop playback"
-msgstr "পুনরায় চালানো বন্ধ"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
-msgid "Volume down"
-msgstr "ভলিউম কমানো"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
-msgid "Volume mute"
-msgstr "ভলিউম নিঃশব্দ"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
-msgid "Volume up"
-msgstr "ভলিউম বাড়ানো"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:1
-msgid "Home folder"
-msgstr "প্রধান ফোল্ডার"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:2
-msgid "Launch calculator"
-msgstr "ক্যালকুলেটর চালুকরণ"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:3
-msgid "Launch email client"
-msgstr "ইমেইল ক্লায়েন্ট চালুকরণ"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:4
-msgid "Launch help browser"
-msgstr "সহায়তা ব্রাউজার চালুকরণ"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:5
-msgid "Launch web browser"
-msgstr "ওয়েব ব্রাউজার চালুকরণ"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:6
-msgid "Launchers"
-msgstr "লঞ্চার"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "অ্যাপলিকেশন"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "অ্যাপলিকেশন"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "ইনস্টল করুন"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "দরজা খোলা"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "বিবরণ...(_e)"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "সন্ধান"
 
-#: ../panels/keyboard/01-system.xml.in.h:1
-msgid "Lock screen"
-msgstr "স্ক্রীন আবদ্ধ"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
 
-#: ../panels/keyboard/01-system.xml.in.h:2
-msgid "Log out"
-msgstr "লগআউট"
-
-#: ../panels/keyboard/01-system.xml.in.h:3
-msgid "System"
-msgstr "সিস্টেম"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-msgid "Decrease text size"
-msgstr "টেক্সটের আকার কমানো"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
-msgid "Increase text size"
-msgstr "টেক্সটের আকার বাড়ানো"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
-msgid "Magnifier zoom in"
-msgstr "বড় আকারে প্রদর্শনের বিবর্ধনযন্ত্র"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
-msgid "Magnifier zoom out"
-msgstr "ছোট আকারে প্রদর্শনের বিবর্ধনযন্ত্র"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
-msgid "Toggle contrast"
-msgstr "টগল বৈসাদৃশ্য"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
-msgid "Toggle magnifier"
-msgstr "টগল বিবর্ধনযন্ত্র"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
-msgid "Toggle on-screen keyboard"
-msgstr "টগল স্ক্রীণে কি-বোর্ড"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
-msgid "Toggle screen reader"
-msgstr "লিনাক্স স্ক্রীণ রিডার"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
-msgid "Universal Access"
-msgstr "সর্বজনীনে প্রবেশ"
-
-# FIXME
-#: ../panels/keyboard/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr "নতুন শর্টকাট..."
-
-#: ../panels/keyboard/eggcellrendererkeys.c:164
-#: ../panels/keyboard/eggcellrendererkeys.c:165
-msgid "Accelerator key"
-msgstr "এক্সিলেটর কী"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:174
-#: ../panels/keyboard/eggcellrendererkeys.c:175
-msgid "Accelerator modifiers"
-msgstr "এক্সিলেটর পরিবর্তক"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:183
-#: ../panels/keyboard/eggcellrendererkeys.c:184
-msgid "Accelerator keycode"
-msgstr "এক্সিলেটর কীকোড"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:194
-msgid "Accel Mode"
-msgstr "এক্সেল মোড"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:195
-msgid "The type of accelerator."
-msgstr "এক্সিলেটর কী-এর ধরন।"
-
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/eggcellrendererkeys.c:243
-#: ../panels/keyboard/keyboard-shortcuts.c:1153
-#: ../panels/sound/gvc-mixer-control.c:1084
-#: ../panels/user-accounts/um-fingerprint-dialog.c:177
-#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "নিষ্ক্রিয়"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Change keyboard settings"
-msgstr "কীবোর্ড সেটিং পরিবর্তন"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "অবস্থান"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "Keyboard"
-msgstr "কীবোর্ড"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "সিস্টেমের তথ্য"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "শর্টকাট;পুনরাবৃত্ত করা;মিটিমিটি জ্বলা;"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "পটভূমি"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:646
-#: ../panels/keyboard/keyboard-shortcuts.c:928
-#: ../panels/keyboard/keyboard-shortcuts.c:1506
-#: ../panels/keyboard/keyboard-shortcuts.c:1510
-msgid "Custom Shortcuts"
-msgstr "স্বনির্ধারিত শর্ট-কাট"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:780
-msgid "<Unknown Action>"
-msgstr "<অজানা কাজ>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1179
-msgid "Error saving the new shortcut"
-msgstr "নতুন শর্ট-কাট সংরক্ষণে সমস্যা"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1292
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
-"শর্টকাট-কি হিসেবে \"%s\" ব্যবহার করা যাবে না কারণ এর ফলে এই কী ব্যবহার করে কিছু "
-"টাইপ করা যাবে না।\n"
-"অনুগ্রহ করে Control, Alt বা Shift কী-এর একসাথে ব্যবহারের চেষ্টা করুন।"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1322
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+# Translated by sadia
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "স্ক্রীন"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
 msgstr ""
-"শর্টকাট \"%s\" বর্তমানে\n"
-"\"%s\"-র জন্য ব্যবহৃত হচ্ছে"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1327
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "\"%s\"-এ শর্ট-কাট স্থাপন করা হলে, \"%s\" শর্ট-কাটটি নিষ্ক্রিয় করা হবে।"
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "ওয়াল-পেপার"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1333
-msgid "_Reassign"
-msgstr "পুনরায় নির্ধারণ (_R)"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1445
-msgid "Too many custom shortcuts"
-msgstr "অত্যাধিক স্বনির্ধারিত শর্ট-কাট"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "শব্দ"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1765
-msgid "Action"
-msgstr "কাজ"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1788
-msgid "Shortcut"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
 msgstr "শর্টকাট"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "C_ommand:"
-msgstr "কমান্ড (_o): "
-
-# Translated by sadia
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "Cursor Blinking"
-msgstr "কার্সার জ্বলছে-নিভছে "
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "Cursor _blinks in text fields"
-msgstr "টেক্সট লেখার ক্ষেত্রে কার্সার ঝলকাবে (_b)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Cursor blinks speed"
-msgstr "কার্সার জ্বলানেভার গতি"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "Custom Shortcut"
-msgstr "স্বনির্ধারিত শর্ট-কাট"
-
-# Translated by sadia
-#. fast acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "Fast"
-msgstr "দ্রুত"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "General"
-msgstr "সাধারণ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "Key presses _repeat when key is held down"
-msgstr "কী চেপে ধরে রাখলে অনবরত লেখা হবে (_r)"
-
-# Translated by sadia
-#. long delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Long"
-msgstr "দীর্ঘ"
-
-# Translated by sadia
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgid "Repeat Keys"
-msgstr "পুনরাবৃত্তি কী "
-
-# FIXME
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "কী পুনরাবৃত্তির গতি"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgid "S_peed:"
-msgstr "গতি (_p):"
-
-# Translated by sadia
-#. short delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-#: ../panels/mouse/gnome-mouse-properties.ui.h:22
-#: ../panels/universal-access/uap.ui.h:54
-msgid "Short"
-msgstr "ছোট"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Shortcuts"
-msgstr "শর্টকাট"
-
-# Translated by sadia
-#. slow acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-#: ../panels/mouse/gnome-mouse-properties.ui.h:24
-msgid "Slow"
-msgstr "ধীর"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
 msgstr ""
-"কোনো শর্ট-কাট কী-এর মান পরিবর্তনের জন্য সংশ্লিষ্ট সারির উপর ক্লিক করুন ও নতুন কী ধরে "
-"রাখুন অথবা চাপুন। অথবা ব্যাক-স্পেস চেপে মুছে ফেলুন।"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "_Delay:"
-msgstr "বিলম্ব (_D):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-msgid "_Name:"
-msgstr "নাম (_N):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-msgid "_Speed:"
-msgstr "গতি (_S):"
-
-#: ../panels/media/cc-media-panel.c:322
-msgid "Ask what to do"
-msgstr "কি করতে হবে তা জিজ্ঞাসা করুন"
-
-# Translated by sadia
-#: ../panels/media/cc-media-panel.c:326 ../panels/power/power.ui.h:6
-msgid "Do nothing"
-msgstr "কিচ্ছু করার নেই"
-
-#: ../panels/media/cc-media-panel.c:330
-msgid "Open folder"
-msgstr "ফোল্ডার খোলা"
-
-#: ../panels/media/cc-media-panel.c:441
-msgid "Select an application for audio CDs"
-msgstr "অডিও সিডির জন্য অ্যাপ্লিকেশন নির্বাচন"
-
-#: ../panels/media/cc-media-panel.c:442
-msgid "Select an application for video DVDs"
-msgstr "ভিডিও ডিভিডির জন্য অ্যাপ্লিকেশন নির্বাচন"
-
-#: ../panels/media/cc-media-panel.c:443
-msgid "Select an application to run when a music player is connected"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
 msgstr ""
-"যখন একটি মিউজিক প্লেয়ার সংযুক্ত থাকবে তখন একটি অ্যাপ্লিকেশন চালানোর জন্য নির্বাচন "
-"করুন"
 
-#: ../panels/media/cc-media-panel.c:444
-msgid "Select an application to run when a camera is connected"
-msgstr "যখন ক্যামেরা সংযুক্ত থাকবে তখন একটি অ্যাপ্লিকেশন চালানোর জন্য নির্বাচন করুন"
-
-#: ../panels/media/cc-media-panel.c:445
-msgid "Select an application for software CDs"
-msgstr "সফ্টওয়্যারের সিডির জন্য অ্যাপ্লিকেশন নির্বাচন"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/media/cc-media-panel.c:457
-msgid "audio DVD"
-msgstr "অডিও DVD"
-
-#: ../panels/media/cc-media-panel.c:458
-msgid "blank Blu-ray disc"
-msgstr "খালি ব্লু-রে ডিস্ক "
-
-#: ../panels/media/cc-media-panel.c:459
-msgid "blank CD disc"
-msgstr "খালি সিডি ডিস্ক"
-
-#: ../panels/media/cc-media-panel.c:460
-msgid "blank DVD disc"
-msgstr "খালি ডিভিডি ডিস্ক"
-
-#: ../panels/media/cc-media-panel.c:461
-msgid "blank HD DVD disc"
-msgstr "খালি HD DVD ডিস্ক"
-
-#: ../panels/media/cc-media-panel.c:462
-msgid "Blu-ray video disc"
-msgstr "ব্লু-রে ভিডিও ডিস্ক "
-
-#: ../panels/media/cc-media-panel.c:463
-msgid "e-book reader"
-msgstr "ই-বুক রীডার"
-
-#: ../panels/media/cc-media-panel.c:464
-msgid "HD DVD video disc"
-msgstr "HD DVD ভিডিও ডিস্ক"
-
-#: ../panels/media/cc-media-panel.c:465
-msgid "Picture CD"
-msgstr "ছবি সিডি"
-
-#: ../panels/media/cc-media-panel.c:466
-msgid "Super Video CD"
-msgstr "চমৎকার ভিডিও সিডি"
-
-# Translated by sadia
-#: ../panels/media/cc-media-panel.c:467
-msgid "Video CD"
-msgstr "ভিডিও সিডি"
-
-#: ../panels/media/gnome-media-properties.ui.h:1
-msgid "Acti_on:"
-msgstr "কাজ (_o):"
-
-#: ../panels/media/gnome-media-properties.ui.h:2
-msgid "CD _audio:"
-msgstr "অডিও সিডি (_a):"
-
-#: ../panels/media/gnome-media-properties.ui.h:3
-msgid "Media and Autorun"
-msgstr "মিডিয়া এবং অটোরান"
-
-#: ../panels/media/gnome-media-properties.ui.h:4
-msgid "Select how media should be handled"
-msgstr "মিডিয়া কিভাবে চলবে তা নির্বাচন"
-
-#: ../panels/media/gnome-media-properties.ui.h:5
-msgid "Select how other media should be handled"
-msgstr "অন্যান্য মিডিয়া কিভাবে চলবে তা নির্বাচন"
-
-#: ../panels/media/gnome-media-properties.ui.h:6
-msgid "_DVD video:"
-msgstr "DVD ভিডিও (_D):"
-
-#: ../panels/media/gnome-media-properties.ui.h:7
-msgid "_Music player:"
-msgstr "মিউজিক প্লেয়ার (_M):"
-
-#: ../panels/media/gnome-media-properties.ui.h:8
-msgid "_Never prompt or start programs on media insertion"
-msgstr "মিডিয়া সন্নিবেশনে কখনই প্রোগ্রাম প্রম্পট অথবা আরম্ভ করা হবেনা (_N)"
-
-#: ../panels/media/gnome-media-properties.ui.h:9
-msgid "_Other Media..."
-msgstr "অন্যান্য মিডিয়া (_O)..."
-
-#: ../panels/media/gnome-media-properties.ui.h:10
-msgid "_Photos:"
-msgstr "ছবি (_P):"
-
-#: ../panels/media/gnome-media-properties.ui.h:11
-msgid "_Software:"
-msgstr "সফ্টওয়্যার (_S):"
-
-#: ../panels/media/gnome-media-properties.ui.h:12
-msgid "_Type:"
-msgstr "ধরন (_T):"
-
-#: ../panels/media/gnome-media-panel.desktop.in.in.h:1
-msgid "Configure media and autorun preferences"
-msgstr "মিডিয়া এবং অটোরান পছন্দ কনফিগার"
-
-#: ../panels/media/gnome-media-panel.desktop.in.in.h:2
-msgid "Removable Media"
-msgstr "অপসারণযোগ্য মিডিয়া"
-
-#. Translators: those are keywords for the media control-center panel
-#: ../panels/media/gnome-media-panel.desktop.in.in.h:4
-msgid "cd;dvd;usb;audio;video;disc;"
-msgstr "সিডি;ডিভিডি;ইউএসবি;ভিডিও;ডিস্ক;"
-
-# Translated by sadia
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:258
-msgid "Low on toner"
-msgstr "অনুচ্চ টোনার  "
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:260
-msgid "Out of toner"
-msgstr "টোনারের বাহিরে"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:263
-msgid "Low on developer"
-msgstr "ডেভেলপারে নিম্ন"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:266
-msgid "Out of developer"
-msgstr "ডেভেলপারের বাহিরে"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:268
-msgid "Low on a marker supply"
-msgstr "চিহ্নিতকারী সরবরাহ কম"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:270
-msgid "Out of a marker supply"
-msgstr "চিহ্নিতকারী সরবরাহ হচ্ছেনা"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:272
-msgid "Open cover"
-msgstr "কভার উন্মুক্ত"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:274
-msgid "Open door"
-msgstr "দরজা খোলা"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:276
-msgid "Low on paper"
-msgstr "কাগজ কম"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:278
-msgid "Out of paper"
-msgstr "কাগজ নেই"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:280
-msgctxt "printer state"
-msgid "Offline"
-msgstr "অফলাইন"
-
-#. Translators: Someone has paused the Printer
-#: ../panels/printers/cc-printers-panel.c:282
-msgctxt "printer state"
-msgid "Paused"
-msgstr "বিরত"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:284
-msgid "Waste receptacle almost full"
-msgstr "বর্জ্য রাখার পাত্র প্রায় পূর্ণ"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:286
-msgid "Waste receptacle full"
-msgstr "বর্জ্য রাখার পাত্র পূর্ণ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:288
-msgid "The optical photo conductor is near end of life"
-msgstr "আলোক সম্বন্ধীয় ছবি পরিবাহকের জীবনী শেষ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:290
-msgid "The optical photo conductor is no longer functioning"
-msgstr "আলোক সম্বন্ধীয় ছবি পরিবাহক আর কাজ করছেনা"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:434
-msgctxt "printer state"
-msgid "Ready"
-msgstr "প্রস্তুত"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:438
-msgctxt "printer state"
-msgid "Processing"
-msgstr "প্রক্রিয়াধীন"
-
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:442
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "বন্ধ"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:561
-msgid "Toner Level"
-msgstr "টোনারের স্তর"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:564
-msgid "Ink Level"
-msgstr "কালির স্তর"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:567
-msgid "Supply Level"
-msgstr "সরবরাহের স্তর"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:582
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u সক্রিয়"
-msgstr[1] "%u সক্রিয়"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:705
-msgid "No printers available"
-msgstr "মুদ্রণযন্ত্র বিদ্যমান নয়"
-
-# Translated by sadia
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/cc-printers-panel.c:996
-msgctxt "print job"
-msgid "Pending"
-msgstr "অমীমাংসিত"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/cc-printers-panel.c:1000
-msgctxt "print job"
-msgid "Held"
-msgstr "অনুষ্ঠিত"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/cc-printers-panel.c:1004
-msgctxt "print job"
-msgid "Processing"
-msgstr "প্রক্রিয়াধীন"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/cc-printers-panel.c:1008
-msgctxt "print job"
-msgid "Stopped"
-msgstr "বন্ধ"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/cc-printers-panel.c:1012
-msgctxt "print job"
-msgid "Canceled"
-msgstr "বাতিল"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/cc-printers-panel.c:1016
-msgctxt "print job"
-msgid "Aborted"
-msgstr "নিষ্ফলকৃত"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/cc-printers-panel.c:1020
-msgctxt "print job"
-msgid "Completed"
-msgstr "সম্পন্ন"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/cc-printers-panel.c:1112
-msgid "Job Title"
-msgstr "পদমর্যাদা"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/cc-printers-panel.c:1121
-msgid "Job State"
-msgstr "কাজেরঅবস্থা"
-
-# Translated by sadia
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/cc-printers-panel.c:1127
-msgid "Time"
-msgstr "সময়"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1842
-msgid "Failed to add new printer."
-msgstr "নতুন মুদ্রণযন্ত্র যোগ করতে ব্যর্থ।"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2014
-#: ../panels/printers/cc-printers-panel.c:2028
-msgid "Test page"
-msgstr "পরীক্ষামূলক পৃষ্ঠা"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2215
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui লোড করা যাচ্ছেনা: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
-msgid "Change printer settings"
-msgstr "মুদ্রণযন্ত্র সেটিং পরিবর্তন"
-
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
-msgid "Printer;Queue;Print;Paper;Ink;Toner;"
-msgstr "মুদ্রণযন্ত্র;সারি;মুদ্রণ;কাগজ;কালি;টোনার;"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
-msgid "Printers"
-msgstr "মুদ্রণযন্ত্র"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add"
-msgstr "যোগ"
-
-#: ../panels/printers/new-printer-dialog.ui.h:2
-msgid "Add a New Printer"
-msgstr "নতুন মুদ্রণযন্ত্র যোগ"
-
-#: ../panels/printers/new-printer-dialog.ui.h:3
-msgid "Address"
-msgstr "ঠিকানা"
-
-#: ../panels/printers/new-printer-dialog.ui.h:4
-#: ../panels/user-accounts/data/language-chooser.ui.h:1
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-msgid "Cancel"
-msgstr "বাতিল"
-
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "Search by Address"
-msgstr "ঠিকানা অনুসারে অনুসন্ধান"
-
-#: ../panels/printers/pp-new-printer-dialog.c:381
-msgid "Getting devices..."
-msgstr "ডিভাইস পাওয়া যাচ্ছে..."
-
-#. Translators: Column of devices which can be installed
-#: ../panels/printers/pp-new-printer-dialog.c:639
-#: ../panels/printers/pp-new-printer-dialog.c:644
-msgid "Devices"
-msgstr "ডিভাইস "
-
-# Translated by sadia
-#. Translators: Local means local printers
-#: ../panels/printers/pp-new-printer-dialog.c:669
-msgid "Local"
-msgstr "স্থানীয়"
-
-#. Translators: Network means network printers
-#: ../panels/printers/pp-new-printer-dialog.c:671
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-msgid "Network"
-msgstr "নেটওয়ার্ক"
-
-#. Translators: Device types column (network or local)
-#: ../panels/printers/pp-new-printer-dialog.c:712
-msgid "Device types"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "মাইক্রোফোনের ভলিউম"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "অবস্থান"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
 msgstr "ডিভাইসের  ধরণ"
 
-#. Translators: Name of job which makes printer to autoconfigure itself
-#: ../panels/printers/pp-new-printer-dialog.c:865
-#: ../panels/printers/pp-new-printer-dialog.c:1033
-msgid "Automatic configuration"
-msgstr "স্বয়ংক্রিয় কনফিগারেশন"
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:1
-msgid "---"
-msgstr "---"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
 
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:3
-msgid "Active Print Jobs"
-msgstr "মুদ্রণ কাজ সক্রিয়"
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
 
-#. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:5
-msgid "Add New Printer"
-msgstr "নতুন মুদ্রণযন্ত্র যোগ"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "অ্যাপলিকেশন"
 
-#: ../panels/printers/printers.ui.h:6
-msgid "Allowed users"
-msgstr "ব্যবহারকারীর অনুমোদন"
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
 
-#. Translators: Switch back to printer's info tab
-#: ../panels/printers/printers.ui.h:8
-msgid "Back"
-msgstr "পূর্ববর্তী"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:10
-#: ../panels/region/gnome-region-panel-xkbot.c:229
-#: ../panels/sound/gvc-sound-theme-chooser.c:586
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "বিন্যাস (_S):"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "পূর্বনির্ধারিত"
 
-#: ../panels/printers/printers.ui.h:11
-#: ../panels/network/cc-network-panel.c:1566
-#: ../panels/network/cc-network-panel.c:1569 ../panels/network/network.ui.h:11
-msgid "IP Address"
-msgstr "IP ঠিকানা"
-
-# Translated by sadia
-#: ../panels/printers/printers.ui.h:12
-msgid "Jobs"
-msgstr "কাজ"
-
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:14
-msgid "Location"
-msgstr "অবস্থান"
-
-#: ../panels/printers/printers.ui.h:15
-msgid "Model"
-msgstr "মডেল"
-
-# Translated by sadia
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:17
-msgid "Options"
-msgstr "অপশন"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:19
-msgid "Print Test Page"
-msgstr "মুদ্রণ পরীক্ষামূলক পৃষ্ঠা"
-
-#: ../panels/printers/printers.ui.h:20
-msgid "Printer"
-msgstr "মুদ্রণযন্ত্র"
-
-# Translated by sadia
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:22
-msgid "Printer Options"
-msgstr "মুদ্রণযন্ত্র অপশন"
-
-# Translated by sadia
-#: ../panels/printers/printers.ui.h:23
-msgid "Printing..."
-msgstr "মুদ্রণ করা হচ্ছে..."
-
-# Translated by sadia
-#. Tanslators: Switch to tab containing printer's jobs
-#: ../panels/printers/printers.ui.h:25
-msgid "Show"
-msgstr "প্রদর্শন"
-
-#. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:27
-msgid ""
-"Sorry! The system printing service\n"
-"doesn't seem to be available."
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
-"দুঃখিত! মনে হচ্ছে সিস্টেম মুদ্রণযন্ত্র সার্ভিস\n"
-"বিদ্যমান নয়।"
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:30
-msgid "Supply"
-msgstr "সরবরাহ"
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "পটভূমি"
 
-# Translated by sadia
-#: ../panels/region/gnome-region-panel.ui.h:1
-msgid "Allow different layouts for each window"
-msgstr "প্রতিটি উইন্ডোর জন্য পৃথক বহির্বিন্যাস"
-
-#: ../panels/region/gnome-region-panel.ui.h:2
-msgid "Install languages..."
-msgstr "ভাষা ইনস্টল..."
-
-#: ../panels/region/gnome-region-panel.ui.h:3
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "Language"
-msgstr "ভাষা"
-
-#: ../panels/region/gnome-region-panel.ui.h:4
-msgid "Layouts"
-msgstr "বিন্যাস"
-
-#: ../panels/region/gnome-region-panel.ui.h:5
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-msgid "Region and Language"
-msgstr "অঞ্চল এবং ভাষা"
-
-#: ../panels/region/gnome-region-panel.ui.h:6
-msgid ""
-"Replace the current keyboard layout settings with the\n"
-"default settings"
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
 msgstr ""
-"বর্তমান কীবোর্ডের লেআউট সেটিং প্রতিস্থাপন করুন\n"
-"পূর্বনির্ধারিত সেটিং এর সাহায্যে"
 
-# FIXME
-#: ../panels/region/gnome-region-panel.ui.h:8
-msgid "Reset to De_faults"
-msgstr "পূর্বনির্ধারিত মান পুনরায় স্থাপন করুন (_f)"
-
-#: ../panels/region/gnome-region-panel.ui.h:9
-msgid "Select a display language (change will be applied next time you log in)"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
 msgstr ""
-"প্রদর্শনের ভাষা নির্বাচন (পরবর্তী সময়ে আপনি লগইন করার সময় পরিবর্তন প্রয়োগ করা হবে)"
 
-# Translated by sadia
-#: ../panels/region/gnome-region-panel.ui.h:10
-msgid "Use default layout in new windows"
-msgstr "নতুন উইন্ডোর জন্য পূর্বনির্ধারিত বিন্যাস"
-
-#: ../panels/region/gnome-region-panel.ui.h:11
-msgid "Use previous window's layout in new windows"
-msgstr "নতুন উইন্ডোতে পূর্ববর্তী উইন্ডোর বহির্বিন্যাস ব্যবহার"
-
-# Translated by sadia
-#: ../panels/region/gnome-region-panel.ui.h:12
-msgid "Use same layout in all windows"
-msgstr "সব উইন্ডোতে একই বহির্বিন্যাস ব্যবহার"
-
-#: ../panels/region/gnome-region-panel.ui.h:13
-msgid "View and edit keyboard layout options"
-msgstr "কীবোর্ডের লেআউট অপশন প্রদর্শন এবং সম্পাদন"
-
-# Translated by sadia
-#: ../panels/region/gnome-region-panel.ui.h:14
-#: ../panels/network/network.ui.h:28
-msgid "_Options..."
-msgstr "অপশন (_O)... "
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
-msgid "Choose a Layout"
-msgstr "যে কোন একটি লে-আউট বেছে নিন"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
-msgid "Preview"
-msgstr "প্রাকদর্শন"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
-msgid "Select an input source to add"
-msgstr "ইনপুট উৎস যোগ করতে নির্বাচন"
-
-#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
-msgid "Keyboard Layout Options"
-msgstr "কীবোর্ড বহির্বিন্যাস সংক্রান্ত অপশন"
-
-#: ../panels/region/gnome-region-panel-xkblt.c:222
-msgid "Layout"
-msgstr "বহির্বিন্যাস"
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
-msgid "Change your region and language settings"
-msgstr "আপনার অঞ্চল এবং ভাষার সেটিং পরিবর্তন"
-
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
-msgid "Language;Layout;Keyboard;"
-msgstr "ভাষা;বহির্বিন্যাস;কীবোর্ড;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "Disable _touchpad while typing"
-msgstr "টাইপ করার সময় টাচপ্যাড নিস্ক্রিয় করুন (_t)"
-
-# Translated by sadia
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-Click Timeout"
-msgstr "ডবল ক্লিক-এর সময়উত্তীর্ণ"
-
-# Translated by sadia
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Drag and Drop"
-msgstr "টেনে এনে ছেড়ে দিন"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "Enable _mouse clicks with touchpad"
-msgstr "টাচপ্যাডের মাধ্যমে মাউস ক্লিক সক্রিয় করুন (_m)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Enable h_orizontal scrolling"
-msgstr "অনুভূমিক স্ক্রলিং সক্রিয় করুন (_o)"
-
-# Translated by sadia
-#. high sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgid "High"
-msgstr "উঁচু"
-
-#. large threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Large"
-msgstr "বড়"
-
-# Translated by sadia
-#. low sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Low"
-msgstr "নিচু"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Mouse"
-msgstr "মাউস"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Mouse Preferences"
-msgstr "মাউস সম্পর্কিত পছন্দ"
-
-# Translated by sadia
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
-msgid "Pointer Speed"
-msgstr "পয়েন্টারের গতি"
-
-# Translated by sadia
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "Scrolling"
-msgstr "স্ক্রল করা হচ্ছে"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:21
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr "কন্ট্রোল-কী চাপা হলে পয়েন্টারের অবস্থান প্রদর্শন করা হবে (_o)"
-
-#. small threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:26
-#: ../panels/universal-access/uap.ui.h:58
-msgid "Small"
-msgstr "ছোট"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:27
-msgid "Thr_eshold:"
-msgstr "থ্রেসহোল্ড (_e):"
-
-# Translated by sadia
-#: ../panels/mouse/gnome-mouse-properties.ui.h:28
-msgid "To test your settings, try to double-click on the face."
-msgstr "সেটিং পরীক্ষার জন্য, ফেসের উপর ডবল ক্লিক করার চেষ্টা করুন।"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:29
-msgid "Touchpad"
-msgstr "টাচপ্যাড"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:30
-msgid "Two-_finger scrolling"
-msgstr "দুই-আঙ্গুল স্ক্রলিং (_f)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:31
-msgid "_Acceleration:"
-msgstr "গতিবৃদ্ধি (_A):"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:32
-msgid "_Disabled"
-msgstr "নিষ্ক্রিয় (_D)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:33
-msgid "_Edge scrolling"
-msgstr "প্রান্ত স্ক্রলিং করুন (_E)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:34
-msgid "_Left-handed"
-msgstr "বামহাতি (_L)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:35
-msgid "_Right-handed"
-msgstr "ডান হাতি (_R)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:36
-msgid "_Sensitivity:"
-msgstr "সংবেদনশীলতা (_S):"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:37
-msgid "_Timeout:"
-msgstr "সময় শেষ (_T):"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse and Touchpad"
-msgstr "মাউস এবং টাচপ্যাড"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Set your mouse and touchpad preferences"
-msgstr "মাউস এবং টাচপ্যাড সম্পর্কিত আপনার পছন্দ নির্ধারণ"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-msgstr "ট্র্যাকপ্যাড;পয়েন্টার;ক্লিক;ট্যাপ;ডবল;বোতাম;ট্র্যাকবল;"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/cc-network-panel.c:193
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
 msgstr ""
-"যখন কনফিগারেশন URL দেওয়া থাকেনা তখন স্বয়ংক্রিয় ওয়েব প্রক্সি উদঘাটন ব্যবহৃত হয়। "
 
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/cc-network-panel.c:201
-msgid "This is not recommended for untrusted public networks."
-msgstr "অবিশ্বস্ত পাবলিক নেটওয়ার্কের জন্য এটি সুপারিশ করা হচ্ছেনা।"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/cc-network-panel.c:943
-msgid "WEP"
-msgstr "WEP"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "সক্রিয়"
 
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:947
-msgid "WPA"
-msgstr "WPA"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
+msgstr "ব্লুটুথ"
 
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:951
-msgid "WPA2"
-msgstr "WPA2"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
 
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/cc-network-panel.c:956
-msgid "Enterprise"
-msgstr "এন্টারপ্রাইজ"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "ব্লুটুথ"
 
-#. TRANSLATORS: this no (!) WiFi security
-#: ../panels/network/cc-network-panel.c:962
-#: ../panels/universal-access/uap.ui.h:43
-msgid "None"
-msgstr "একটিও না"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
 
-#. Translators: network device speed
-#: ../panels/network/cc-network-panel.c:1265
-#: ../panels/network/cc-network-panel.c:1310
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/cc-network-panel.c:1562 ../panels/network/network.ui.h:12
-msgid "IPv4 Address"
-msgstr "IPv4 ঠিকানা"
-
-#: ../panels/network/cc-network-panel.c:1563 ../panels/network/network.ui.h:13
-msgid "IPv6 Address"
-msgstr "IPv6 ঠিকানা"
-
-#: ../panels/network/cc-network-panel.c:1701
-msgid "Proxy"
-msgstr "প্রক্সি"
-
-#: ../panels/network/cc-network-panel.c:1765
-msgid "Network proxy"
-msgstr "নেটওয়ার্ক প্রক্সি"
-
-#: ../panels/network/cc-network-panel.c:1931
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1999
-msgid "The system network services are not compatible with this version."
-msgstr "এই সংস্করণের সাথে সিস্টেম নেটওয়ার্ক সার্ভিস সামঞ্জস্যপূর্ণ নয়।"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Network settings"
-msgstr "নেটওয়ার্ক সেটিং"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid "Network;Wireless;IP;LAN;"
-msgstr "নেটওয়ার্ক;ওয়ারলেস;IP;LAN;"
-
-#: ../panels/network/network.ui.h:1
-msgid "Air_plane Mode"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "বিমান মোড"
 
-#: ../panels/network/network.ui.h:2
-msgid "Create..."
-msgstr "তৈরি..."
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
 
-#: ../panels/network/network.ui.h:3
-msgid "DNS"
-msgstr "DNS"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "বিমান মোড"
 
-#: ../panels/network/network.ui.h:4
-msgid "Default Route"
-msgstr "পূর্বনির্ধারিত গমনপথ"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "বিমান মোড"
 
-#: ../panels/network/network.ui.h:5
-msgid "Gateway"
-msgstr "গেইটওয়ে"
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
 
-#: ../panels/network/network.ui.h:6
-msgid "Group Name"
-msgstr "গ্রুপের নাম"
-
-#: ../panels/network/network.ui.h:7
-msgid "Group Password"
-msgstr "গ্রুপের পাসওয়ার্ড"
-
-#: ../panels/network/network.ui.h:8
-msgid "H_TTPS Proxy"
-msgstr "HTTP প্রক্সি (_T)"
-
-#: ../panels/network/network.ui.h:9
-msgid "Hardware Address"
-msgstr "হার্ডওয়্যারের ঠিকানা"
-
-#: ../panels/network/network.ui.h:10
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network.ui.h:14
-msgid "Interface"
-msgstr "ইন্টারফেস"
-
-#: ../panels/network/network.ui.h:15
-msgid "Provider"
-msgstr "সরবরাহকারী"
-
-#: ../panels/network/network.ui.h:16
-msgid "Security"
-msgstr "নিরাপত্তা"
-
-#: ../panels/network/network.ui.h:17
-msgid "Select the interface to use for the new service"
-msgstr "নতুন সার্ভিস ব্যবহারের জন্য ইন্টারফেস নির্বাচন"
-
-#: ../panels/network/network.ui.h:18
-msgid "Speed"
-msgstr "গতি"
-
-#: ../panels/network/network.ui.h:19
-msgid "Subnet Mask"
-msgstr "সাবনেট মাস্ক"
-
-#: ../panels/network/network.ui.h:21
-msgid "Username"
-msgstr "ব্যবহারকারীর নাম"
-
-#: ../panels/network/network.ui.h:22
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/network.ui.h:23
-msgid "_Configuration URL"
-msgstr "কনফিগারেশনের URL (_C):"
-
-#: ../panels/network/network.ui.h:24
-msgid "_FTP Proxy"
-msgstr "FTP প্রক্সি (_F)"
-
-#: ../panels/network/network.ui.h:25
-msgid "_HTTP Proxy"
-msgstr "HTTP প্রক্সি (_T)"
-
-#: ../panels/network/network.ui.h:26
-msgid "_Method"
-msgstr "মেথড (_M)"
-
-#: ../panels/network/network.ui.h:27
-msgid "_Network Name"
-msgstr "নেটওয়ার্কের নাম (_N)"
-
-#: ../panels/network/network.ui.h:29
-msgid "_Socks Host"
-msgstr "Socks হোস্ট (_S)"
-
-#: ../panels/network/network.ui.h:30
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "স্বয়ংক্রিয়"
-
-#: ../panels/network/network.ui.h:31
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "স্বনির্ধারিত"
-
-#: ../panels/network/network.ui.h:32
-msgctxt "proxy method"
-msgid "None"
-msgstr "একটিও না"
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:83
-msgid "Wired"
-msgstr "তার দ্বারা সংযুক্ত"
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:87
-msgid "Wireless"
-msgstr "তারবিহীন"
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:94
-msgid "Mobile broadband"
-msgstr "মোবাইল ব্রডব্যান্ড"
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:99
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "ব্লুটুথ"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:103
-msgid "Mesh"
-msgstr "মেশ"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:162
-msgid "Ad-hoc"
-msgstr "এডহক"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:166
-msgid "Infrastructure"
-msgstr "পরিকাঠামো"
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:190 ../panels/network/panel-common.c:251
-msgid "Status unknown"
-msgstr "অজানা অবস্থা"
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "কোন অ্যাপ্লিকেশন বর্তমানে অডিও প্লে অথবা রেকর্ড করছেনা।"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:194
-msgid "Unmanaged"
-msgstr "অপরিকল্পিত"
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#: ../panels/network/panel-common.c:199
-msgid "Firmware missing"
-msgstr "ফার্মওয়্যার অনুপস্থিত"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#: ../panels/network/panel-common.c:202
-msgid "Cable unplugged"
-msgstr "কেবল আনপ্লাগকৃত"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "আরো ছবির জন্য ব্রাউজ"
 
-#: ../panels/network/panel-common.c:204
-msgid "Unavailable"
-msgstr "বিদ্যমান নয়"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:208
-msgid "Disconnected"
-msgstr "বিছিন্ন"
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:215 ../panels/network/panel-common.c:257
-msgid "Connecting"
-msgstr "সংযুক্ত করা হচ্ছে "
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "বাতিল (_C)"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
-msgid "Authentication required"
-msgstr "প্রমাণীকরণ আবশ্যকীয়"
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "সমাপ্ত!"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "প্রদর্শন"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "বড় সাদা পয়েন্টার"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "উজ্জ্বলতা"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "প্রোফাইল (_P):"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "প্রোফাইল (_P):"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "প্রোফাইল (_P):"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "যোগ করুন... (_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "সক্রিয়"
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "প্রোফাইল (_P):"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+#, fuzzy
+msgid "Projector"
+msgstr "সংযোগকারী (_C):"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+# Translated by sadia
+#: panels/color/cc-color-panel.ui:630
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "উঁচু"
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "১০ মিনিট"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "মাঝারি (_M)"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "৩০ মিনিট"
+
+# Translated by sadia
+#: panels/color/cc-color-panel.ui:640
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "নিচু"
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "৫ মিনিট"
+
+#: panels/color/cc-color-panel.ui:663
+#, fuzzy
+msgid "Native to display"
+msgstr "প্রদর্শনের প্যানেল"
+
+#: panels/color/cc-color-panel.ui:667
+#, fuzzy
+msgid "D50 (Printing and publishing)"
+msgstr "পয়েন্ট এবং ক্লিক"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+#, fuzzy
+msgid "D75"
+msgstr "৭৫%"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "রং"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "ছবি বেছে নিন"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "নির্বাচন (_S)"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "অনাবদ্ধ"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "আকার বাড়ানো:"
+
+# Translated by sadia
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "সময়"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "আকার কমানো"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+#, fuzzy
+msgid "Date & Time"
+msgstr "তারিখ ও সময়"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "জানুয়ারি"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ফেব্রুয়ারি"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "মার্চ"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "এপ্রিল"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "মে"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "জুন"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "জুলাই"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "আগস্ট"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "সেপ্টেম্বর"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "অক্টোবর"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "নভেম্বর"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ডিসেম্বর"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "মে"
+
+# Translated by sadia
+#: panels/datetime/cc-datetime-panel.ui:113
+#, fuzzy
+msgid "Time Zone"
+msgstr "সময়"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "তারিখ ও সময়"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "স্বয়ংক্রিয় লগইন"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "সক্রিয়"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "অনাবদ্ধ"
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "৩০ সেকেন্ড"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "ক্যালেন্ডার"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "ডিসেম্বর"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "ঘড়ি;টাইম জোন;অবস্থান;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "আপনার অঞ্চল এবং ভাষার সেটিং পরিবর্তন"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "মেইল"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "ক্যালেন্ডার"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+#, fuzzy
+msgid "M_usic"
+msgstr "গান"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+#, fuzzy
+msgid "_Video"
+msgstr "ভিডিও"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+#, fuzzy
+msgid "_Photos"
+msgstr "ছবি (_P):"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "পূর্বনির্ধারিত অ্যাপ্লিকেশন"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "পূর্বনির্ধারিত অ্যাপ্লিকেশন"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+#, fuzzy
+msgid "_Automatic Problem Reporting"
+msgstr "স্বয়ংক্রিয় লগইন"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "সরবরাহ"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "পূর্ববর্তী"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "মিরর প্রদর্শন "
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "মিরর প্রদর্শন "
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+# Translated by sadia
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "মুদ্রণযন্ত্র অপশন"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "রেজল্যুশন (_R):"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+# Translated by sadia
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "স্কেল"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "আংশিক সম্পন্ন"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "মুদ্রণযন্ত্র বিদ্যমান নয়"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+# Translated by sadia
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+#, fuzzy
+msgid "Times"
+msgstr "সময়"
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "URI থেকে"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "মিনিট"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "প্রদর্শন"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+#, fuzzy
+msgid "Choose how to use connected monitors and projectors"
+msgstr "মনিটর এবং প্রজেক্টরের রেজল্যুশন ও অবস্থান পরিবর্তন"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "প্যানেল;প্রজেক্টর,xrandr;স্ক্রীন,রেজল্যুশন;রিফ্রেশ;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "নিরাপত্তা"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "কালির স্তর"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "কালির স্তর"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "কালির স্তর"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "নিরাপত্তা"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ডিভাইসের নাম"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "হার্ডওয়্যারের ঠিকানা"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "মেমরি"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "প্রসেসর"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "গ্রাফিক্স"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "নাম:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "ধরন (_T):"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME টার্মিনাল"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "সফ্টওয়্যার (_S):"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "ডিভাইস"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ডিভাইসের নাম"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "ব্যবহারকারীর নাম (_U)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "%s-এর পরিচিতি"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr "ডিভাইস;সিস্টেম;তথ্য;মেমরি;প্রসেসর;সংস্করণ;পূর্বনির্ধারিত;অ্যাপ্লিকেশন;ফলব্যাক;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "শব্দ এবং মিডিয়া"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "ভলিউম নিঃশব্দ"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "ভলিউম কমানো"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "ভলিউম বাড়ানো"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "মাইক্রোফোনের ভলিউম"
+
+# Translated by sadia
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "মিডিয়া প্লেয়ার চালুকরণ"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "চালান (অথবা চালান/বিরতি)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "পুনরায় চালানো বিরতি"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "পুনরায় চালানো বন্ধ"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "পূর্ববর্তী  ট্র্যাক"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "পরবর্তী ট্র্যাক"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "নির্গত"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "টাইপ করা"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "ইনপুট উৎস যোগ করতে নির্বাচন"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "লঞ্চার"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "সহায়তা ব্রাউজার চালুকরণ"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "সব সেটিং (_A)"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "ক্যালকুলেটর চালুকরণ"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "ইমেইল ক্লায়েন্ট চালুকরণ"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "ওয়েব ব্রাউজার চালুকরণ"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "প্রধান ফোল্ডার"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "সন্ধান"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "সিস্টেম"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "লগআউট"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "স্ক্রীন আবদ্ধ"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "সহায়ক প্রযুক্তি"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+#, fuzzy
+msgid "Turn zoom on or off"
+msgstr "চালু অথবা বন্ধ করুন:"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "বড় আকারে প্রদর্শন:"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "ছোট আকারে প্রদর্শন:"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+#, fuzzy
+msgid "Turn screen reader on or off"
+msgstr "চালু অথবা বন্ধ করুন:"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "টগল স্ক্রীণে কি-বোর্ড"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "টেক্সটের আকার বাড়ানো"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "টেক্সটের আকার কমানো"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+#, fuzzy
+msgid "No input source selected"
+msgstr "ইনপুট উৎস যোগ করতে নির্বাচন"
+
+# Translated by sadia
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "অপশন"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+# Translated by sadia
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "পছন্দসমূহ"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "কীবোর্ড বহির্বিন্যাস সংক্রান্ত অপশন"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "ইনপুট ভলিউম (_I):"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+# Translated by sadia
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "সব উইন্ডোতে একই বহির্বিন্যাস ব্যবহার"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "মাউস কী"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+#, fuzzy
+msgid "Keyboard Shortcuts"
+msgstr "কি-বোর্ড সেটিং"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "স্বনির্ধারিত শর্ট-কাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "অংশ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "শর্টকাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "শর্টকাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "স্বনির্ধারিত শর্ট-কাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "শর্টকাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "নাম:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "কমান্ড (_o): "
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "শর্টকাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "শর্টকাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "একটিও না"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+# FIXME
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "ডিফল্ট মান পুনরায় স্থাপন (_R)"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "কীবোর্ড"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "কোন অ্যাপ্লিকেশন বর্তমানে অডিও প্লে অথবা রেকর্ড করছেনা।"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "আপনার ব্যক্তিগত তথ্য লিখুন"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "মাইক্রোফোনের ভলিউম"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "কোন অ্যাপ্লিকেশন বর্তমানে অডিও প্লে অথবা রেকর্ড করছেনা।"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "নেটওয়ার্ক সেটিং"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "সাধারণ"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "বাম"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "ডানদিকে"
+
+# Translated by sadia
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "মুদ্রণযন্ত্র অপশন"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "মাউস"
+
+# Translated by sadia
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "পয়েন্টারের গতি"
+
+# Translated by sadia
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "স্ক্রল করা হচ্ছে"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "গতিবৃদ্ধি (_A):"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "টাচপ্যাড"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "টাচপ্যাড"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "মেথড (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+# Translated by sadia
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "হোভার ক্লিক "
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "টাইপ করার সময় টাচপ্যাড নিস্ক্রিয় করুন (_t)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "গতিবৃদ্ধি (_A):"
+
+# Translated by sadia
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "স্ক্রল করা হচ্ছে"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "মেথড (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
+msgstr "মাউস এবং টাচপ্যাড"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+#, fuzzy
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ট্র্যাকপ্যাড;পয়েন্টার;ক্লিক;ট্যাপ;ডবল;বোতাম;ট্র্যাকবল;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+# Translated by sadia
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "মনিটর "
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "প্রাথমিক প্রদর্শন পরিবর্তন করতে টানুন।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "অ্যাপলিকেশন"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ডিভাইস "
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+# Translated by sadia
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "বিচ্ছিন্ন করা হচ্ছে"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "যোগকৃত"
 
 # Translated by sadia
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:227
-msgid "Disconnecting"
-msgstr "বিচ্ছিন্ন করা হচ্ছে"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "অপশন"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:231 ../panels/network/panel-common.c:269
-msgid "Connection failed"
-msgstr "সংযোগে ব্যর্থ"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:277
-msgid "Status unknown (missing)"
-msgstr "অজানা অবস্থা (অনুপস্থিত)"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
 
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:273
-msgid "Not connected"
-msgstr "সংযুক্ত নয়"
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "শক্তি"
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "নেটওয়ার্কের নাম (_N)"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Power management settings"
-msgstr "শক্তি পরিচালনা সেটিং"
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "পাসওয়ার্ড"
 
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid "Power;Sleep;Suspend;Hibernate;Battery;"
-msgstr "Power;Sleep;Suspend;Hibernate;Battery;"
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "গ্রুপের পাসওয়ার্ড"
 
-#: ../panels/power/cc-power-panel.c:153
-msgid "Unknown time"
-msgstr "অজ্ঞাত সময়"
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "তৈরিকৃত একটি পাসওয়ার্ড নির্বাচন"
 
-#: ../panels/power/cc-power-panel.c:159
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "বিমান মোড"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "বিমান মোড"
+
+#: panels/network/cc-wifi-panel.ui:165
+#, fuzzy
+msgid "Turn off to use Wi-Fi"
+msgstr "এর পরে বন্ধ করুন:"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "নেটওয়ার্ক"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+#, fuzzy
+msgid "802.1x _Security"
+msgstr "নিরাপত্তা"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "কার্সার জ্বলানেভার গতি"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "নিরাপত্তা"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 ঠিকানা"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 ঠিকানা"
+
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr "হার্ডওয়্যারের ঠিকানা"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "পূর্বনির্ধারিত গমনপথ"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "নাম (_N):"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "ঠিকানা (_A):"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "ঠিকানা (_A):"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+#, fuzzy
+msgid "bytes"
+msgstr "%u byte"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "মেথড (_M)"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+#, fuzzy
+msgid "Automatic (DHCP)"
+msgstr "স্বয়ংক্রিয়"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+#, fuzzy
+msgid "Manual"
+msgstr "স্বনির্ধারিত"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "নিষ্ক্রিয়"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "ঠিকানা"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ঠিকানা"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "গেইটওয়ে"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "স্বয়ংক্রিয়"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+#, fuzzy
+msgid "Automatic DNS"
+msgstr "স্বয়ংক্রিয়"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+#, fuzzy
+msgid "Automatic Routes"
+msgstr "স্বয়ংক্রিয়"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "মেথড (_M)"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+#, fuzzy
+msgid "Automatic, DHCP only"
+msgstr "স্বয়ংক্রিয় লগইন"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+#, fuzzy
+msgid "S_ecurity"
+msgstr "নিরাপত্তা"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "নেটওয়ার্ক"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "তার দ্বারা সংযুক্ত"
+
+#: panels/network/network-bluetooth.ui:11
+#, fuzzy
+msgid "Turn device off"
+msgstr "চালু অথবা বন্ধ করুন:"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "%u সক্রিয়"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "সরবরাহকারী"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP ঠিকানা"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "নেটওয়ার্ক প্রক্সি"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "HTTP প্রক্সি (_T)"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTP প্রক্সি (_T)"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "FTP প্রক্সি (_F)"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Socks হোস্ট (_S)"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "HTTP প্রক্সি (_T)"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "HTTP প্রক্সি (_T)"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "FTP প্রক্সি (_F)"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "কনফিগারেশনের URL (_C):"
+
+#: panels/network/network-vpn.ui:11
+#, fuzzy
+msgid "Turn VPN connection off"
+msgstr "চালু অথবা বন্ধ করুন:"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "নেটওয়ার্কের নাম (_N)"
+
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "নিরাপত্তা"
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "পাসওয়ার্ড"
+
+#: panels/network/network-wifi.ui:90
+#, fuzzy
+msgid "Turn Wi-Fi off"
+msgstr "চালু অথবা বন্ধ করুন:"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "সহায়তা সংক্রান্ত অপশন প্রদর্শন করা হবে"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "অনুমোদন (_A)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "সর্বধরনের ফাইল"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "অনুমোদন (_A)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "ব্যবহারকারীর নাম (_U)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "পাসওয়ার্ড"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "পাসওয়ার্ড প্রদর্শন (_S)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "সংস্করণ %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "সংস্করণ %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "অনুমোদন (_A)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "প্রমাণীকরণ আবশ্যকীয়"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "নতুন পাসওয়ার্ড (_N)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+#, fuzzy
+msgid "PAP"
+msgstr "WPA"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "অনুমোদন (_A)"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "ধরন (_T):"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "পূর্বনির্ধারিত"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "সিস্টেম"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "আবর্তন (_o): "
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "শব্দের প্রভাব"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "মনিটর সংক্রান্ত কনফিগারেশন সংরক্ষণ করতে ব্যর্থ"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "নতুন অবস্থান তৈরি"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Online Accounts"
+msgstr "অন্যান্য একাউন্ট"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i মিনিট"
 msgstr[1] "%i মিনিট"
 
-#: ../panels/power/cc-power-panel.c:171
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i ঘন্টা"
 msgstr[1] "%i ঘন্টা"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:179
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 # Translated by sadia
-#: ../panels/power/cc-power-panel.c:180
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ঘন্টা"
 msgstr[1] "ঘন্টা"
 
-#: ../panels/power/cc-power-panel.c:181
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "মিনিট"
 msgstr[1] "মিনিট"
 
-#: ../panels/power/cc-power-panel.c:253
-msgid "Battery charging"
-msgstr "ব্যাটারী চার্জ হচ্ছে"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "৫ মিনিট"
 
-#: ../panels/power/cc-power-panel.c:256
-msgid "Battery discharging"
-msgstr "ব্যাটারী চার্জ হচ্ছেনা"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "২ মিনিট"
 
-#: ../panels/power/cc-power-panel.c:267
-msgid "UPS charging"
-msgstr "UPS চার্জ হচ্ছে"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "৫ মিনিট"
 
-#: ../panels/power/cc-power-panel.c:270
-msgid "UPS discharging"
-msgstr "UPS চার্জ হচ্ছেনা"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:288
-#, c-format
-msgid "%s until charged (%.0lf%%)"
-msgstr "%s পর্যন্ত চার্জ (%.0lf%%)"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:294
-#, c-format
-msgid "%s until empty (%.0lf%%)"
-msgstr "%s পর্যন্ত খালি (%.0lf%%)"
-
-#. TRANSLATORS: %1 is a percentage value. Note: this string is only
-#. * used when we don't have a time value
-#: ../panels/power/cc-power-panel.c:302
-#, c-format
-msgid "%.0lf%% charged"
-msgstr "%.0lf%% চার্জকৃত"
-
-#: ../panels/power/power.ui.h:1 ../panels/screen/screen.ui.h:1
-msgid "1 hour"
-msgstr "১ ঘন্টা"
-
-#: ../panels/power/power.ui.h:2 ../panels/screen/screen.ui.h:3
-msgid "10 minutes"
-msgstr "১০ মিনিট"
-
-#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "৩০ মিনিট"
 
-#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:8
-msgid "5 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
 msgstr "৫ মিনিট"
 
-#: ../panels/power/power.ui.h:5
-msgid "Ask me"
-msgstr "আমাকে জিজ্ঞাসা করুন"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "১ ঘন্টা"
 
-#: ../panels/power/power.ui.h:7
-msgid "Hibernate"
-msgstr "হাইবারনেট"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "১০ মিনিট"
 
-#: ../panels/power/power.ui.h:8
-msgid "On AC power:"
-msgstr "AC পাওয়ার চালু:"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "১০ মিনিট"
 
-#: ../panels/power/power.ui.h:9
-msgid "On battery power:"
-msgstr "ব্যাটারী পাওয়ার চালু:"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "১০ মিনিট"
 
-#: ../panels/power/power.ui.h:10
-msgid "Put the computer to sleep when inactive:"
-msgstr "যখন নিষ্ক্রিয় থাকবে কম্পিউটারকে স্লীপ দিয়ে রাখুন:"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "১ ঘন্টা"
 
-#: ../panels/power/power.ui.h:11
-msgid "Shutdown"
-msgstr "বন্ধ"
+#: panels/power/cc-power-panel.ui:58
+#, fuzzy
+msgid "Battery"
+msgstr "ব্যাটারী চার্জ হচ্ছে"
 
-#: ../panels/power/power.ui.h:12
-msgid "Suspend"
-msgstr "স্থগিত "
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ডিভাইস "
 
-#: ../panels/power/power.ui.h:13
-msgid "When power is critically low:"
-msgstr "যখন পাওয়ার মারাত্মক কম থাকে:"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "শক্তি"
 
-#: ../panels/power/power.ui.h:14
-msgid "When the power button is pressed:"
-msgstr "যখন পাওয়ার বোতাম চাপা দেওয়া থাকে:"
-
-#: ../panels/power/power.ui.h:15
-msgid "When the sleep button is pressed:"
-msgstr "যখন স্লীপ বোতাম চাপা দেওয়া থাকে:"
-
-#. Translators: those are keywords for the brightness and lock control-center panel
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
-msgid "Brightness;Lock;Dim;Blank;Monitor;"
-msgstr "Brightness;Lock;Dim;Blank;Monitor;"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
 # Translated by sadia
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "মুদ্রণযন্ত্র অপশন"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "স্বয়ংক্রিয় কনফিগারেশন"
+
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "স্ক্রীন উজ্জ্বলতা এবং লক সেটিং"
+
+# Translated by sadia
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "স্ক্রীন"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+# Translated by sadia
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "স্ক্রীন"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "স্বয়ংক্রিয় লগইন"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "স্বয়ংক্রিয় লগইন"
+
+#: panels/power/cc-power-panel.ui:175
+#, fuzzy
+msgid "Pauses the computer after a period of inactivity."
+msgstr "যখন নিষ্ক্রিয় থাকবে কম্পিউটারকে স্লীপ দিয়ে রাখুন:"
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+#, fuzzy
+msgid "Automatic Suspend"
+msgstr "স্বয়ংক্রিয়"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+#, fuzzy
+msgid "On _Battery Power"
+msgstr "ব্যাটারী পাওয়ার চালু:"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "বিলম্ব (_D):"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "শক্তি"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "Power;Sleep;Suspend;Hibernate;Battery;"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "মুদ্রণযন্ত্র"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "মুদ্রণযন্ত্র;সারি;মুদ্রণ;কাগজ;কালি;টোনার;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "নতুন মুদ্রণযন্ত্র যোগ"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "অনাবদ্ধ"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "মুদ্রণযন্ত্র"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "প্রমাণীকরণ আবশ্যকীয়"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ব্যবহারকারীর নাম"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "অবস্থান"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "ড্রাইভার"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "ঠিকানা অনুসারে অনুসন্ধান"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "আঙ্গুল বেছে নিন"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "বাতিল"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "নির্বাচন"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "অনুমোদন (_A)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "অনুমোদন (_A)"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "মুদ্রণ কাজ সক্রিয়"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "পরীক্ষামূলক পৃষ্ঠা"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+# Translated by sadia
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "মুদ্রণযন্ত্র অপশন"
+
+# Translated by sadia
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "মুদ্রণযন্ত্র অপশন"
+
+# FIXME
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "ডিফল্ট মান পুনরায় স্থাপন (_R)"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "মুদ্রণের হেড পরিষ্কার"
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
+msgstr "মুদ্রণযন্ত্র"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "মুদ্রণ কাজ সক্রিয়"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "মডেল"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "কালির স্তর"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "প্রারম্ভে সঞ্চালিত হবে (_R)"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "নতুন মুদ্রণযন্ত্র যোগ"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "মুদ্রণযন্ত্র সেটিং পরিবর্তন"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "মুদ্রণযন্ত্র"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+#, fuzzy
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"দুঃখিত! মনে হচ্ছে সিস্টেম মুদ্রণযন্ত্র সার্ভিস\n"
+"বিদ্যমান নয়।"
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "স্বাভাবিক"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "সকল ফাইল"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "প্রাকদর্শন"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "তারিখ ও সময়"
+
+#: panels/region/cc-format-preview.ui:71
+#, fuzzy
+msgid "Numbers"
+msgstr "নভেম্বর"
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "বিভাগ (_D):"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "ভাষা ইনস্টল..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "আমার একাউন্ট"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+#, fuzzy
+msgid "_Language"
+msgstr "ভাষা"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "স্ক্রীন আবদ্ধ"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+#, fuzzy
+msgid "Region & Language"
+msgstr "অঞ্চল এবং ভাষা"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+#, fuzzy
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "ভাষা;বহির্বিন্যাস;কীবোর্ড;"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "মিডিয়া কিভাবে চলবে তা নির্বাচন"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+#, fuzzy
+msgid "CD _audio"
+msgstr "অডিও সিডি (_a):"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+#, fuzzy
+msgid "_DVD video"
+msgstr "DVD ভিডিও (_D):"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "মিউজিক প্লেয়ার (_M):"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+#, fuzzy
+msgid "_Software"
+msgstr "সফ্টওয়্যার (_S):"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+#, fuzzy
+msgid "_Other Media…"
+msgstr "অন্যান্য মিডিয়া (_O)..."
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "মিডিয়া সন্নিবেশনে কখনই প্রোগ্রাম প্রম্পট অথবা আরম্ভ করা হবেনা (_N)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "অন্যান্য মিডিয়া কিভাবে চলবে তা নির্বাচন"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "কাজ (_A)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "ধরন (_T):"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "অপসারণযোগ্য মিডিয়া"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "কীবোর্ড সেটিং পরিবর্তন"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+# Translated by sadia
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "স্ক্রীন"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+#, fuzzy
+msgid "Automatic Screen _Lock"
+msgstr "স্বয়ংক্রিয় লগইন"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "স্ক্রীন আবদ্ধ"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+# Translated by sadia
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "স্ক্রীন"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+# Translated by sadia
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
 msgid "Screen"
 msgstr "স্ক্রীন"
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
-msgid "Screen brightness and lock settings"
-msgstr "স্ক্রীন উজ্জ্বলতা এবং লক সেটিং"
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "শব্দের সেটিং"
 
-#: ../panels/screen/screen.ui.h:2
-msgid "1 minute"
-msgstr "১ মিনিট"
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:4
-msgid "2 minutes"
-msgstr "২ মিনিট"
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "অবস্থান"
 
-#: ../panels/screen/screen.ui.h:5
-msgid "3 minutes"
-msgstr "৩ মিনিট"
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:7
-msgid "30 seconds"
-msgstr "৩০ সেকেন্ড"
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:9
-msgid "Brightness"
-msgstr "উজ্জ্বলতা"
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:10
-msgid "Dim screen to save power"
-msgstr "পাওয়ার সংরক্ষণের জন্য ঝাপসা স্ক্রীন "
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "অন্যান্য..."
 
-#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
-#: ../panels/screen/screen.ui.h:12
-msgid "Don't lock when at home"
-msgstr "যখন হোমে থাকবেন তখন লক করবেননা"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "অবস্থান"
 
-# FIXME
-#: ../panels/screen/screen.ui.h:13
-msgid "Locations..."
-msgstr "অবস্থান..."
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "অ্যাপলিকেশন"
 
-#: ../panels/screen/screen.ui.h:15
-msgid "Lock screen after:"
-msgstr "এরপরে স্ক্রীন লক করুন:"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:16
-msgid "Screen turns off"
-msgstr "স্ক্রীন চালু বন্ধ করুন"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:17
-msgid "Turn off after:"
-msgstr "এর পরে বন্ধ করুন:"
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "ঠিকানা অনুসারে অনুসন্ধান"
 
-#: ../panels/sound/applet-main.c:49
-msgid "Enable debugging code"
-msgstr "কোড ডিবাগ ব্যবস্থা সক্রিয় করা হবে"
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
-#: ../panels/sound/applet-main.c:50
-msgid "Version of this application"
-msgstr "এই অ্যাপ্লিকেশনের সংস্করণ"
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
 
-#: ../panels/sound/applet-main.c:62
-msgid " — GNOME Volume Control Applet"
-msgstr " — GNOME ভলিউম কন্ট্রোল অ্যাপলেট"
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
 
-#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1923
-msgid "Output"
-msgstr "আউটপুট"
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "নেটওয়ার্ক"
 
-#: ../panels/sound/gvc-applet.c:278
-msgid "Sound Output Volume"
-msgstr "শব্দ আউটপুটের ভলিউম"
+# Translated by sadia
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+#, fuzzy
+msgid "Sharing"
+msgstr "শ্রুতি"
 
-#: ../panels/sound/gvc-applet.c:282 ../panels/sound/gvc-mixer-dialog.c:1840
-msgid "Input"
-msgstr "ইনপুট"
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
 
-#: ../panels/sound/gvc-applet.c:284
-msgid "Microphone Volume"
-msgstr "মাইক্রোফোনের ভলিউম"
+# Translated by sadia
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "শ্রুতি"
 
-#: ../panels/sound/gvc-balance-bar.c:111
-msgctxt "balance"
-msgid "Left"
-msgstr "বাম"
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:112
-msgctxt "balance"
-msgid "Right"
-msgstr "ডান"
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:115
-msgctxt "balance"
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr ""
+
+# Translated by sadia
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "শ্রুতি"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "নতুন পাসওয়ার্ড (_N)"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "ভলিউম কন্ট্রোল"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "সংযুক্ত নয়"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "অনুমোদন (_A)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ব্যবহারকারীর নাম"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "আঙ্গুলের ছাপ মুছে ফেলুন (_D)"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "মিডিয়া এবং অটোরান"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+#, fuzzy
+msgid "Enable or disable remote login"
+msgstr "অনুভূমিক স্ক্রলিং সক্রিয় করুন (_o)"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "ফ্লিকার"
+
+# Translated by sadia
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "শ্রুতি"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "সাম্যাবস্থা (_B):"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "বিবর্ণ হয়ে যাওয়া (_F):"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "পিছনে"
 
-#: ../panels/sound/gvc-balance-bar.c:116
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "সামনে"
 
-#: ../panels/sound/gvc-balance-bar.c:119
-msgctxt "balance"
-msgid "Minimum"
-msgstr "সর্বনিম্ন"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:120
-msgctxt "balance"
-msgid "Maximum"
-msgstr "সর্বোচ্চ"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Balance:"
-msgstr "সাম্যাবস্থা (_B):"
-
-#: ../panels/sound/gvc-balance-bar.c:298
-msgid "_Fade:"
-msgstr "বিবর্ণ হয়ে যাওয়া (_F):"
-
-#: ../panels/sound/gvc-balance-bar.c:301
-msgid "_Subwoofer:"
-msgstr "সাবউফার (_S):"
-
-#: ../panels/sound/gvc-channel-bar.c:603 ../panels/sound/gvc-channel-bar.c:612
-msgctxt "volume"
-msgid "100%"
-msgstr "১০০%"
-
-#: ../panels/sound/gvc-channel-bar.c:607
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "এমপ্লিফাইড নয়"
-
-#: ../panels/sound/gvc-channel-bar.c:901
-msgid "Mute"
-msgstr "নিঃশব্দ"
-
-#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:1631
-msgid "_Profile:"
-msgstr "প্রোফাইল (_P):"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1091
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u আউটপুট"
-msgstr[1] "%u আউটপুট"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1101
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u ইনপুট"
-msgstr[1] "%u ইনপুট"
-
-#: ../panels/sound/gvc-mixer-control.c:1399
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "সিস্টেমের শব্দ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:317
-#: ../panels/sound/gvc-mixer-dialog.c:618
-msgid "Co_nnector:"
-msgstr "সংযোগকারী (_C):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:531
-msgid "Peak detect"
-msgstr "সর্বোচ্চ চূড়া নির্ধারন"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1507
-#: ../panels/sound/gvc-mixer-dialog.c:1719
-#: ../panels/sound/gvc-sound-theme-chooser.c:596
-msgid "Name"
-msgstr "নাম:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1525
-msgid "Device"
-msgstr "ডিভাইস"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1573
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s এর জন্য স্পিকার পরীক্ষা"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1632
-msgid "Test Speakers"
-msgstr "স্পিকার পরীক্ষা"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1763
-msgid "_Output volume: "
-msgstr "আউটপুট ভলিউম (_O):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1777
-msgid "Sound Effects"
-msgstr "শব্দের প্রভাব"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1784
-msgid "_Alert volume: "
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
 msgstr "সতর্ক করার ভলিউম (_A):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1797
-msgid "Hardware"
-msgstr "হার্ডওয়্যার"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "ভলিউম নিঃশব্দ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1802
-msgid "C_hoose a device to configure:"
-msgstr "যে কোন ডিভাইস কনফিগার করতে নির্বাচন (_h):"
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "আউটপুট"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1829
-#: ../panels/sound/gvc-mixer-dialog.c:1952
-msgid "Settings for the selected device:"
-msgstr "নির্বাচিত ডিভাইসের জন্য সেটিং:"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "আউটপুট"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1847
-msgid "_Input volume: "
-msgstr "ইনপুট ভলিউম (_I):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1870
-msgid "Input level:"
-msgstr "ইনপুট স্তর:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1896
-msgid "C_hoose a device for sound input:"
-msgstr "শব্দের ইনপুটের জন্য ডিভাইস নির্বাচন:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1928
-msgid "C_hoose a device for sound output:"
-msgstr "শব্দের আউটপুটের জন্য ডিভাইস নির্বাচন:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1963
-msgid "Applications"
-msgstr "অ্যাপলিকেশন"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1967
-msgid "No application is currently playing or recording audio."
-msgstr "কোন অ্যাপ্লিকেশন বর্তমানে অডিও প্লে অথবা রেকর্ড করছেনা।"
-
-#: ../panels/sound/gvc-speaker-test.c:221
-msgid "Stop"
-msgstr "বন্ধ"
-
-#: ../panels/sound/gvc-speaker-test.c:221
-#: ../panels/sound/gvc-speaker-test.c:333
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "পরীক্ষা"
 
-#: ../panels/sound/gvc-speaker-test.c:229
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "কনফিগারেশনের URL (_C):"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "সাবউফার"
 
-#: ../panels/sound/gvc-stream-status-icon.c:235
-#, c-format
-msgid "Failed to start Sound Preferences: %s"
-msgstr "শব্দ পছন্দ আরম্ভ করতে ব্যর্থ: %s"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "ইনপুট"
 
-#: ../panels/sound/gvc-stream-status-icon.c:261
-msgid "_Mute"
-msgstr "নিঃশব্দ (_M)"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "ইনপুট স্তর:"
 
-#: ../panels/sound/gvc-stream-status-icon.c:270
-msgid "_Sound Preferences"
-msgstr "শব্দ পছন্দ (_S)"
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "ভলিউম বাড়ানো"
 
-#: ../panels/sound/gvc-stream-status-icon.c:415
-msgid "Muted"
-msgstr "নিঃশব্দ "
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "সতর্কবাণীর বোতাম"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:190
-msgid "Built-in"
-msgstr "বিল্ট ইন"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "নিঃশব্দ"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:456
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Sound Preferences"
-msgstr "শব্দ পছন্দ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:459
-#: ../panels/sound/gvc-sound-theme-chooser.c:470
-#: ../panels/sound/gvc-sound-theme-chooser.c:482
-msgid "Testing event sound"
-msgstr "ইভেন্টের শব্দ পরীক্ষা"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:587
-msgid "From theme"
-msgstr "থীম থেকে"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:782
-msgid "C_hoose an alert sound:"
-msgstr "সতর্ক করার জন্য শব্দ নির্বাচন:"
-
-#: ../panels/sound/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr "স্বনির্বাচিত"
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
-msgid "Show desktop volume control"
-msgstr "ডেস্কটপ ভলিউম কন্ট্রোল প্রদর্শন"
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
-msgid "Volume Control"
-msgstr "ভলিউম কন্ট্রোল"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
-msgstr "কার্ড;মাইক্রোফোন;ভলিউম;বিবর্ণ;ভারসাম্য;ব্লুটুথ;হেডসেট;"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
-msgid "Change sound volume and sound events"
-msgstr "শব্দের ভলিউম এবং শব্দের ইভেন্ট পরিবর্তন"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
 msgstr "শব্দ"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "ঘেউ ঘেউ "
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "শব্দের ভলিউম এবং শব্দের ইভেন্ট পরিবর্তন"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "ফোঁটা ফোঁটা করে পড়া"
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "কার্ড;মাইক্রোফোন;ভলিউম;বিবর্ণ;ভারসাম্য;ব্লুটুথ;হেডসেট;"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "কাঁচ"
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "প্রতিফলিত শব্দ তরঙ্গ"
-
-# FIXME
-#: ../panels/universal-access/cc-ua-panel.c:470
-#: ../panels/universal-access/cc-ua-panel.c:475
-msgid "No shortcut set"
-msgstr "কোন শর্টকাট নির্ধারিত নেই"
-
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Keyboard;Mouse;a11y;Accessibility;"
-msgstr "কীবোর্ড;মাউস;a11y;স্বাচ্ছন্দ্যকরণ;"
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
-msgid "Universal Access Preferences"
-msgstr "সর্বজনীন প্রবেশের পছন্দ"
-
-#: ../panels/universal-access/uap.ui.h:2
-#, no-c-format
-msgid "100%"
-msgstr "১০০%"
-
-#: ../panels/universal-access/uap.ui.h:4
-#, no-c-format
-msgid "125%"
-msgstr "১২৫%"
-
-#: ../panels/universal-access/uap.ui.h:6
-#, no-c-format
-msgid "150%"
-msgstr "১৫০%"
-
-#: ../panels/universal-access/uap.ui.h:8
-#, no-c-format
-msgid "75%"
-msgstr "৭৫%"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Acceptance delay:"
-msgstr "গ্রহণ করতে বিলম্ব:"
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "Beep when Caps and Num Lock are used"
-msgstr "Caps এবং Num Lock যখন ব্যবহার করা হবে তখন বিপ হবে"
-
-#: ../panels/universal-access/uap.ui.h:11
-msgid "Beep when a key is"
-msgstr "কী হলে বিপ হবে "
-
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Beep when a key is rejected"
-msgstr "কি-র মান প্রত্যাখ্যান করা হলে বিপ হবে"
-
-#: ../panels/universal-access/uap.ui.h:13
-msgid "Beep when a modifer key is pressed"
-msgstr "পরিবর্তক কি চাপা হলে বিপ হবে "
-
-# Translated by sadia
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Bounce Keys"
-msgstr "লাফানো কী  "
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "Caribou"
-msgstr "কারিবূ"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "Change contrast:"
-msgstr "রংয়ের বৈষম্য পরিবর্তন:"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Closed Captioning"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
 msgstr "শিরোনাম করা বন্ধ"
 
-#: ../panels/universal-access/uap.ui.h:18
-msgid "Contrast:"
-msgstr "রংয়ের বৈষম্য:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "নাম (_N):"
 
-#: ../panels/universal-access/uap.ui.h:19
-msgid "Control the pointer using the keypad"
-msgstr "কী-প্যাড সহযোগে পয়েন্টার নিয়ন্ত্রণ"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Control the pointer using the video camera."
-msgstr "ভিডিও ক্যামেরা সহযোগে পয়েন্টার নিয়ন্ত্রণ।"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:22
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "ডিভাইস"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "সর্বজনীনে প্রবেশ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "ডিভাইস পাওয়া যাচ্ছে..."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "থান্ডারবার্ড"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+# Translated by sadia
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "কার্সার জ্বলছে-নিভছে "
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "টেক্সট লেখার ক্ষেত্রে কার্সার ঝলকাবে (_b)"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "গতি"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "কার্সার জ্বলানেভার গতি"
+
+# Translated by sadia
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "কার্সার জ্বলছে-নিভছে "
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+# Translated by sadia
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "অনুকরণকৃত দ্বিতীয় ক্লিক"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "প্রধান বাটনটি টিপে রেখে, দ্বিতীয় ক্লিক ট্রিগার করুন"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+#, fuzzy
+msgid "A_cceptance delay:"
+msgstr "গ্রহণ করতে বিলম্ব:"
+
+# Translated by sadia
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "ছোট"
+
+# Translated by sadia
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "অনুকরণকৃত দ্বিতীয় ক্লিক"
+
+# Translated by sadia
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "দীর্ঘ"
+
+# Translated by sadia
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "হোভার ক্লিক "
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "পয়েন্টার হোভার করার সময় ট্রিগার ক্লিক "
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "বিলম্ব: (_e)"
 
-#: ../panels/universal-access/uap.ui.h:23
-msgid "Dasher"
-msgstr "ড্যাশার"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Decrease size:"
-msgstr "আকার কমানো"
-
-# FIXME
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Disable if two keys are pressed together"
-msgstr "একযোগে দুটি কি চাপা হলে নিষ্ক্রিয় করা হবে"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Display a textual description of speech and sounds"
-msgstr "স্পীচ এবং শব্দের মূলগ্রন্থ-সমন্ধীয় বর্ণনা প্রদর্শন"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Flash the entire screen"
-msgstr "সম্পূর্ণ পর্দা ঝলকানো হবে"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "Flash the window title"
-msgstr "উইন্ডোর শিরোনাম ঝলকানো হবে"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "GOK"
-msgstr "GOK"
+# Translated by sadia
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "ছোট"
 
 # Translated by sadia
-#: ../panels/universal-access/uap.ui.h:30
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "দীর্ঘ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "কম্পণের প্রান্তিক মান (_M):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "ছোট"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "বড়"
+
+# Translated by sadia
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "পুনরাবৃত্তি কী "
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "কী চেপে ধরে রাখলে অনবরত লেখা হবে (_r)"
+
+# FIXME
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "কী পুনরাবৃত্তির গতি"
+
+# FIXME
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "কী পুনরাবৃত্তির গতি"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "টাইপ করার সহকারী"
+
+# Translated by sadia
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "স্টিকি কী "
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "মোডিফায়ার কীর ক্রমকে কী সমাবেশ হিসেবে বিবেচনা করুন"
+
+# FIXME
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "একযোগে দুটি কি চাপা হলে নিষ্ক্রিয় করা হবে"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "পরিবর্তক কি চাপা হলে বিপ হবে "
+
+# Translated by sadia
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "ধীর গতির কী "
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "যখন একটি কী চাপার পরে গৃহীত হওয়া পর্যন্ত কিছু সময় বিরতি দিন"
+
+# Translated by sadia
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "ছোট"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+# Translated by sadia
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "দীর্ঘ"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "পরিবর্তক কি চাপা হলে বিপ হবে "
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "কি-র মান প্রত্যাখ্যান করা হলে বিপ হবে"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "কি-র মান প্রত্যাখ্যান করা হলে বিপ হবে"
+
+# Translated by sadia
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "লাফানো কী  "
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "দ্রুত গতিতে দুইবার কী চাপা হলে তা উপেক্ষা করা হবে"
+
+# Translated by sadia
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "ছোট"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+# Translated by sadia
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "দীর্ঘ"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "কীবোর্ড থেকে স্বাচ্ছন্দ্যকরণ বৈশিষ্ট্য চালু করুন"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "মাউস ব্যবহারের সহায়ক প্রযুক্তি (_M)"
+
+# Translated by sadia
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "দৃশ্যতা"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "রংয়ের বৈষম্য:"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "বড়"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "স্ক্রীণ রিডার"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+# Translated by sadia
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "লাফানো কী  "
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Caps এবং Num Lock যখন ব্যবহার করা হবে তখন বিপ হবে"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "বড় আকারে প্রদর্শন"
+
+# Translated by sadia
+#: panels/universal-access/cc-ua-panel.ui:138
 msgid "Hearing"
 msgstr "শ্রুতি"
 
 # Translated by sadia
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Hover Click"
-msgstr "হোভার ক্লিক "
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "দৃষ্টিনির্ভর সতর্কতা"
 
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Ignores fast duplicate keypresses"
-msgstr "দ্রুত গতিতে দুইবার কী চাপা হলে তা উপেক্ষা করা হবে"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Increase size:"
-msgstr "আকার বাড়ানো:"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Keyboard Settings"
-msgstr "কি-বোর্ড সেটিং"
-
-#: ../panels/universal-access/uap.ui.h:37
-msgid "Larger"
-msgstr "বড়"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Mouse Keys"
-msgstr "মাউস কী"
-
-# Translated by sadia
-#: ../panels/universal-access/uap.ui.h:41
-msgid "Mouse Settings"
-msgstr "মাউসের সেটিং"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Nomon"
-msgstr "নমন"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "On screen keyboard"
-msgstr "OnScreen কি-বোর্ড"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "OnBoard"
-msgstr "OnBoard"
-
-# Translated by sadia
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Options..."
-msgstr "অপশন..."
-
-#: ../panels/universal-access/uap.ui.h:48
-msgid "Pointing and Clicking"
-msgstr "পয়েন্ট এবং ক্লিক"
-
-#: ../panels/universal-access/uap.ui.h:49
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "যখন একটি কী চাপার পরে গৃহীত হওয়া পর্যন্ত কিছু সময় বিরতি দিন"
-
-#: ../panels/universal-access/uap.ui.h:50
-msgid "Screen Reader"
-msgstr "স্ক্রীণ রিডার"
-
-#: ../panels/universal-access/uap.ui.h:51
-msgid "Screen keyboard"
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
 msgstr "স্ক্রীণ কি-বোর্ড"
 
 # Translated by sadia
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Seeing"
-msgstr "দৃশ্যতা"
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "পুনরাবৃত্তি কী "
 
 # Translated by sadia
-#: ../panels/universal-access/uap.ui.h:55
-msgid "Simulated Secondary Click"
-msgstr "অনুকরণকৃত দ্বিতীয় ক্লিক"
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "কার্সার জ্বলছে-নিভছে "
 
-# Translated by sadia
-#: ../panels/universal-access/uap.ui.h:56
-msgid "Slow Keys"
-msgstr "ধীর গতির কী "
-
-#: ../panels/universal-access/uap.ui.h:59
-msgid "Sound Settings"
-msgstr "শব্দের সেটিং"
-
-# Translated by sadia
-#: ../panels/universal-access/uap.ui.h:60
-msgid "Sticky Keys"
-msgstr "স্টিকি কী "
-
-#: ../panels/universal-access/uap.ui.h:61
-msgid "Test flash"
-msgstr "ঝলক পরীক্ষা"
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "Text size:"
-msgstr "টেক্সটের আকার:"
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "মোডিফায়ার কীর ক্রমকে কী সমাবেশ হিসেবে বিবেচনা করুন"
-
-#: ../panels/universal-access/uap.ui.h:64
-msgid "Trigger a click when the pointer hovers"
-msgstr "পয়েন্টার হোভার করার সময় ট্রিগার ক্লিক "
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "প্রধান বাটনটি টিপে রেখে, দ্বিতীয় ক্লিক ট্রিগার করুন"
-
-#: ../panels/universal-access/uap.ui.h:66
-msgid "Turn on accessibility features from the keyboard"
-msgstr "কীবোর্ড থেকে স্বাচ্ছন্দ্যকরণ বৈশিষ্ট্য চালু করুন"
-
-#: ../panels/universal-access/uap.ui.h:67
-msgid "Turn on or off:"
-msgstr "চালু অথবা বন্ধ করুন:"
-
-#: ../panels/universal-access/uap.ui.h:68
-msgid "Type here to test settings"
-msgstr "সেটিং পরীক্ষার জন্য এখানে টাইপ করুন"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Typing"
-msgstr "টাইপ করা"
-
-#: ../panels/universal-access/uap.ui.h:70
-msgid "Typing Assistant"
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
 msgstr "টাইপ করার সহকারী"
 
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Use a visual indication when an alert sound occurs"
-msgstr "যখন একটি সতর্কতার শব্দ হওয়ার সময় দৃষ্টিনির্ভর প্রদর্শন"
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "পয়েন্ট এবং ক্লিক"
 
-#: ../panels/universal-access/uap.ui.h:72
-msgid "Video Mouse"
-msgstr "ভিডিও মাউস"
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "মাউস কী"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "সাদা পয়েন্টার"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
 
 # Translated by sadia
-#: ../panels/universal-access/uap.ui.h:73
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "ডবল ক্লিক-এর সময়উত্তীর্ণ"
+
+# Translated by sadia
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "ডবল ক্লিক-এর সময়উত্তীর্ণ"
+
+# Translated by sadia
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
 msgid "Visual Alerts"
 msgstr "দৃষ্টিনির্ভর সতর্কতা"
 
-#: ../panels/universal-access/uap.ui.h:74
-msgid "Zoom in:"
-msgstr "বড় আকারে প্রদর্শন:"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+#, fuzzy
+msgid "_Test flash"
+msgstr "ঝলক পরীক্ষা"
 
-#: ../panels/universal-access/uap.ui.h:75
-msgid "Zoom out:"
-msgstr "ছোট আকারে প্রদর্শন:"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+#, fuzzy
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "যখন একটি সতর্কতার শব্দ হওয়ার সময় দৃষ্টিনির্ভর প্রদর্শন"
 
-#: ../panels/universal-access/uap.ui.h:76
-msgid "_Motion threshold:"
-msgstr "কম্পণের প্রান্তিক মান (_M):"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "সম্পূর্ণ পর্দা ঝলকানো হবে"
 
-#: ../panels/universal-access/uap.ui.h:77
-msgid "accepted"
-msgstr "গৃহীত"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "সম্পূর্ণ পর্দা ঝলকানো হবে"
 
-#: ../panels/universal-access/uap.ui.h:78
-msgid "pressed"
-msgstr "চাপা"
+# Translated by sadia
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "স্ক্রীন"
 
-#: ../panels/universal-access/uap.ui.h:79
-msgid "rejected"
-msgstr "প্রত্যাখ্যান"
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:80
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "বাম"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "ডানদিকে"
+
+# Translated by sadia
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "অপশন"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "বড় আকারে প্রদর্শনের বিবর্ধনযন্ত্র"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "ব্যবহারকারীর অনুমোদন"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "স্ক্রীণ রিডার"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "বড় আকারে প্রদর্শনের বিবর্ধনযন্ত্র"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "শব্দের প্রভাব"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "উজ্জ্বলতা"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "রংয়ের বৈষম্য:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "<span size=\"x-large\">High/Inverse</span>"
-msgstr "<span size=\"x-large\">High/Inverse</span>"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:81
-msgctxt "universal access, contrast"
-msgid "<span size=\"x-large\">High</span>"
-msgstr "<span size=\"x-large\">High</span>"
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "একটিও না"
 
-#: ../panels/universal-access/uap.ui.h:82
-msgctxt "universal access, contrast"
-msgid "<span size=\"x-large\">Low</span>"
-msgstr "<span size=\"x-large\">Low</span>"
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
 
-# check
-#: ../panels/universal-access/uap.ui.h:83
-msgctxt "universal access, contrast"
-msgid "<span size=\"x-large\">Normal</span>"
-msgstr "<span size=\"x-large\">Normal</span>"
+# Translated by sadia
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "নিচু"
 
-#: ../panels/universal-access/uap.ui.h:84
-msgctxt "universal access, contrast"
+# Translated by sadia
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+#, fuzzy
+msgctxt "universal access, brightness"
 msgid "High"
 msgstr "উঁচু"
 
-#: ../panels/universal-access/uap.ui.h:85
-msgctxt "universal access, contrast"
-msgid "High/Inverse"
-msgstr "উঁচু/বিপরীত"
-
 # Translated by sadia
-#: ../panels/universal-access/uap.ui.h:86
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "নিচু"
 
-#: ../panels/universal-access/uap.ui.h:87
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
-msgid "Normal"
-msgstr "স্বাভাবিক"
+msgid "High"
+msgstr "উঁচু"
 
-#. Translators: this refers to theme contrast and font size
-#: ../panels/universal-access/uap.ui.h:89
-msgctxt "universal access, seeing"
-msgid "Display"
-msgstr "প্রদর্শন"
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "শব্দের প্রভাব"
 
-#. Translators: this refers to screen magnifier
-#: ../panels/universal-access/uap.ui.h:91
-msgctxt "universal access, seeing"
-msgid "Zoom"
-msgstr "বড় আকারে প্রদর্শন"
-
-#: ../panels/user-accounts/run-passwd.c:426
-msgid "Authentication failed"
-msgstr "প্রমাণীকরণে ব্যর্থ"
-
-#: ../panels/user-accounts/run-passwd.c:506
-#: ../panels/user-accounts/um-password-dialog.c:375
-#, c-format
-msgid "The new password is too short"
-msgstr "নতুন পাসওয়ার্ড অত্যন্ত ছোট।"
-
-#: ../panels/user-accounts/run-passwd.c:512
-#, c-format
-msgid "The new password is too simple"
-msgstr "নতুন পাসওয়ার্ড অত্যন্ত সরল।"
-
-#: ../panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "পুরনো ও নতুন পাসওয়ার্ডের গঠন অতিমাত্রায় অনুরূপ।"
-
-#: ../panels/user-accounts/run-passwd.c:521
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "নতুন পাসওয়ার্ড বর্তমানে ইতোমধ্যেই ব্যবহৃত হয়েছে।"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "নতুন পাসওয়ার্ডের মধ্যে সংখ্য ও বিশেষ অক্ষরের উপস্থিতি বাঞ্ছনীয়"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "পুরোনো ও নতুন পাসওয়ার্ড অনুরূপ"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "প্রারম্ভে আপনার পরিচয় অনুমোদিত হওয়ার ফলে আপনার পাসওয়ার্ড পরিবর্তিত হয়েছে!"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "নতুন পাসওয়ার্ডের মধ্যে যথেষ্ট ভিন্ন অক্ষর নেই।"
-
-#: ../panels/user-accounts/run-passwd.c:540
-#, c-format
-msgid "Unknown error"
-msgstr "অজ্ঞাত ত্রুটি "
-
-#: ../panels/user-accounts/um-account-dialog.c:78
-msgid "Failed to create user"
-msgstr "ব্যবহারকারী তৈরি করতে ব্যর্থ"
-
-#: ../panels/user-accounts/um-account-dialog.c:185
-#, c-format
-msgid "A user with the username '%s' already exists"
-msgstr "'%s'  নামের ব্যবহারকারী ইতোমধ্যেই আছে"
-
-#: ../panels/user-accounts/um-account-dialog.c:189
-#, c-format
-msgid "The username is too long"
-msgstr "ব্যবহারকারীর নাম অনেক দীর্ঘ"
-
-#: ../panels/user-accounts/um-account-dialog.c:192
-msgid "The username cannot start with a '-'"
-msgstr " '-' দিয়ে ব্যবহারকারীর নাম শুরু করা যাবেনা"
-
-#: ../panels/user-accounts/um-account-dialog.c:195
-msgid ""
-"The username must consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
-"ব্যবহারকারীর নাম অবশ্যই গঠিত হতে হবে:\n"
-" ➣ইংরেজি বর্ণমালার অক্ষর থেকে \n"
-" ➣সংখ্যা\n"
-" ➣ '.', '-' এবং '_' এর যে কোন অক্ষর"
 
-#: ../panels/user-accounts/um-account-type.c:35
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgctxt "Account type"
-msgid "Standard"
-msgstr "আদর্শ"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
 
-#: ../panels/user-accounts/um-account-type.c:37
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgctxt "Account type"
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "ফাইল মুছে ফেলুন (_D)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
 msgid "Administrator"
 msgstr "প্রশাসক"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:107
+#: panels/user-accounts/cc-add-user-dialog.ui:132
 msgid ""
-"You are not allowed to access the device. Contact your system administrator."
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"আপনি এই ডিভাইস ব্যবহার করতে অনুমোদিত নন। অনুগ্রহ করে সিস্টেম প্রশাসকের সাথে "
-"যোগাযোগ করুন।"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:109
-msgid "The device is already in use."
-msgstr "ডিভাইসটি বর্তমানে ব্যবহৃত হচ্ছে।"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "পরবর্তী লগইনে পাসওয়ার্ড নির্বাচন"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:111
-msgid "An internal error occurred."
-msgstr "একটি অভ্যন্তরীণ ত্রুটি হয়েছে।"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "পাসওয়ার্ড এখনই নির্ধারণ"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:181
-#: ../panels/user-accounts/um-fingerprint-dialog.c:182
-msgid "Enabled"
-msgstr "সক্রিয়"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:224
-msgid "Delete registered fingerprints?"
-msgstr "নিবন্ধিত আঙ্গুলের ছাপ মুছে ফেলা হবে কি?"
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "এন্টারপ্রাইজ"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:228
-msgid "_Delete Fingerprints"
-msgstr "আঙ্গুলের ছাপ মুছে ফেলুন (_D)"
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:235
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "অফলাইন"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "ছবি বেছে নিন"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "শূণ্য (_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -3034,545 +4695,2295 @@ msgstr ""
 "আঙ্গুলের ছাপ সহযোগে লগ-ইন ব্যবস্থা নিষ্ক্রিয় করার উদ্দেশ্যে নিবন্ধিত আঙ্গুলের ছাপগুলি কি "
 "মুছে ফেলা হবে?"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:363
-msgid "Done!"
-msgstr "সমাপ্ত!"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:409
-#: ../panels/user-accounts/um-fingerprint-dialog.c:431
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' ডিভাইস ব্যবহার করা যাচ্ছেনা"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:480
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "'%s' ডিভাইসের মধ্যে আঙ্গুলের ছাপ প্রাপ্তিতে ব্যর্থ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:549
-msgid "Could not access any fingerprint readers"
-msgstr "আঙ্গুলের ছাপ পাঠের কোনো ব্যবস্থা প্রয়োগ করা যায়নি"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:550
-msgid "Please contact your system administrator for help."
-msgstr "অনুগ্রহ করে সহায়তার জন্য আপনার সিস্টেম প্রশাসকের সাথে যোগাযোগ করুন।"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:587
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Enable Fingerprint Login"
-msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন সক্রিয়"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:621
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
 msgstr ""
-"আঙ্গুলের ছাপ সহযোগে লগ-ইন ব্যবস্থা সক্রিয় করার জন্য, '%s' ডিভাইস সহযোগে অন্তত একটি "
-"আঙ্গুলের ছাপ সংরক্ষণ করা আবশ্যক।"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:629
-#, c-format
-msgid ""
-"Enrolling fingerprints for\n"
-"<b><big>%s</big></b>"
-msgstr ""
-"যার জন্য আঙ্গুলের ছাঁপ তালিকাভুক্ত করা হবে\n"
-"<b><big>%s</big></b>"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন"
 
-#: ../panels/user-accounts/um-language-dialog.c:180
-msgid "Other..."
-msgstr "অন্যান্য..."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "যে কোন ডিভাইস কনফিগার করতে নির্বাচন (_h):"
 
-#: ../panels/user-accounts/um-password-dialog.c:179
-msgid "More choices..."
-msgstr "আরও পছন্দ..."
-
-#: ../panels/user-accounts/um-password-dialog.c:285
-msgid "Please choose another password."
-msgstr "অনুগ্রহ করে আরেকটি পাসওয়ার্ড নির্বাচন করুন।"
-
-#: ../panels/user-accounts/um-password-dialog.c:294
-msgid "Please type your current password again."
-msgstr "অনুগ্রহ করে আপনার বর্তমান পাসওয়ার্ড আবার লিখুন।"
-
-#: ../panels/user-accounts/um-password-dialog.c:300
-msgid "Password could not be changed"
-msgstr "পাসওয়ার্ড পরিবর্তন করা যাবেনা"
-
-#: ../panels/user-accounts/um-password-dialog.c:372
-msgid "You need to enter a new password"
-msgstr "নতুন পাসওয়ার্ড দিতে হবে"
-
-#: ../panels/user-accounts/um-password-dialog.c:381
-msgid "You need to confirm the password"
-msgstr "পাসওয়ার্ড নিশ্চিত করতে হবে"
-
-#: ../panels/user-accounts/um-password-dialog.c:384
-msgid "The passwords do not match"
-msgstr "পাসওয়ার্ড মিলছে না"
-
-#: ../panels/user-accounts/um-password-dialog.c:390
-msgid "You need to enter your current password"
-msgstr "আপনার বর্তমান পাসওয়ার্ড দিতে হবে"
-
-#: ../panels/user-accounts/um-password-dialog.c:393
-msgid "The current password is not correct"
-msgstr "বর্তমান পাসওয়ার্ড সঠিক নয়"
-
-#: ../panels/user-accounts/um-password-dialog.c:466
-#: ../panels/user-accounts/um-password-dialog.c:683
-msgctxt "Password strength"
-msgid "Too short"
-msgstr "অনেক ছোট"
-
-#: ../panels/user-accounts/um-password-dialog.c:469
-#: ../panels/user-accounts/um-password-dialog.c:684
-msgctxt "Password strength"
-msgid "Weak"
-msgstr "দুর্বল"
-
-#: ../panels/user-accounts/um-password-dialog.c:471
-#: ../panels/user-accounts/um-password-dialog.c:685
-msgctxt "Password strength"
-msgid "Fair"
-msgstr "ন্যায্য"
-
-#: ../panels/user-accounts/um-password-dialog.c:473
-#: ../panels/user-accounts/um-password-dialog.c:686
-msgctxt "Password strength"
-msgid "Good"
-msgstr "ভালো"
-
-#: ../panels/user-accounts/um-password-dialog.c:475
-#: ../panels/user-accounts/um-password-dialog.c:687
-msgctxt "Password strength"
-msgid "Strong"
-msgstr "দৃঢ়"
-
-#: ../panels/user-accounts/um-password-dialog.c:514
-msgid "Passwords do not match"
-msgstr "পাসওয়ার্ড মিলছেনা"
-
-#: ../panels/user-accounts/um-password-dialog.c:540
-msgid "Wrong password"
-msgstr "ভুল পাসওয়ার্ড"
-
-#: ../panels/user-accounts/um-photo-dialog.c:97
-#: ../panels/user-accounts/data/language-chooser.ui.h:2
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-msgid "Select"
-msgstr "নির্বাচন"
-
-#: ../panels/user-accounts/um-photo-dialog.c:445
-msgid "Disable image"
-msgstr "চিত্র নিষ্ক্রিয় "
-
-#: ../panels/user-accounts/um-photo-dialog.c:463
-msgid "Take a photo..."
-msgstr "ফটো তুলুন..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:481
-msgid "Browse for more pictures..."
-msgstr "আরও ছবির জন্য ব্রাউজ করুন..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:706
-#, c-format
-msgid "Used by %s"
-msgstr "%s দ্বারা ব্যবহৃত"
-
-#: ../panels/user-accounts/um-user-manager.c:432
-#, c-format
-msgid "A user with name '%s' already exists."
-msgstr "'%s' নামের ব্যবহারকারী ইতোমধ্যেই বর্তমান।"
-
-#: ../panels/user-accounts/um-user-manager.c:527
-msgid "This user does not exist."
-msgstr "ব্যবহারকারী বিদ্যমান নয়"
-
-#: ../panels/user-accounts/um-user-panel.c:357
-msgid "Failed to delete user"
-msgstr "ব্যবহাকারী মুছে ফেলতে ব্যর্থ"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "You cannot delete your own account."
-msgstr "আপনি আপনার নিজের একাউন্ট মুছে ফেলতে পারবেননা।"
-
-#: ../panels/user-accounts/um-user-panel.c:426
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s এখনো লগ ইন রয়েছে"
-
-#: ../panels/user-accounts/um-user-panel.c:430
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"ব্যবহারকারীরা লগইন থাকা অবস্থায় তাদেরকে মুছে ফেললে সিস্টেমে অসামঞ্জস্য অবস্থা হতে "
-"পারে।"
-
-#: ../panels/user-accounts/um-user-panel.c:439
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "%s ফইলটি রেখে দিতে চান?"
-
-#: ../panels/user-accounts/um-user-panel.c:443
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"ব্যবহারকারীর একাউন্ট মুছে ফেলার সময় প্রধান ডিরেক্টরি, মেইল স্পুল এবং অস্থায়ী ফাইল "
-"রেখে দেওয়া যায়।"
-
-#: ../panels/user-accounts/um-user-panel.c:446
-msgid "_Delete Files"
-msgstr "ফাইল মুছে ফেলুন (_D)"
-
-#: ../panels/user-accounts/um-user-panel.c:447
-msgid "_Keep Files"
-msgstr "ফাইল রাখুন (_K)"
-
-#: ../panels/user-accounts/um-user-panel.c:448
-msgid "_Cancel"
-msgstr "বাতিল (_C)"
-
-#: ../panels/user-accounts/um-user-panel.c:498
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "একাউন্ট নিষ্ক্রিয়"
-
-#: ../panels/user-accounts/um-user-panel.c:506
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "পরবর্তী লগ ইনে নির্ধারণ"
-
-#: ../panels/user-accounts/um-user-panel.c:509
-msgctxt "Password mode"
-msgid "None"
-msgstr "একটিও না"
-
-#: ../panels/user-accounts/um-user-panel.c:831
-msgid "Failed to contact the accounts service"
-msgstr "একাউন্ট সার্ভিসের সাথে যোগাযোগ করতে ব্যর্থ"
-
-#: ../panels/user-accounts/um-user-panel.c:833
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"অনুগ্রহপূর্বক নিশ্চিত হোন যে একাউন্ট সার্ভিস সঠিকভাবে ইনস্টল ও সক্রিয় করা আছে কি না"
-
-#: ../panels/user-accounts/um-user-panel.c:866
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"পরিবর্তন করতে,\n"
-"*আইকনটি প্রথমে ক্লিক করুন"
-
-#: ../panels/user-accounts/um-user-panel.c:904
-msgid "Create a user"
-msgstr "ব্যবহারকারী তৈরি"
-
-#: ../panels/user-accounts/um-user-panel.c:915
-#: ../panels/user-accounts/um-user-panel.c:1214
-msgid ""
-"To create a user,\n"
-"click the * icon first"
-msgstr ""
-"ব্যবহারকারী তৈরি করতে,\n"
-"*আইকনটি প্রথমে ক্লিক করুন"
-
-#: ../panels/user-accounts/um-user-panel.c:924
-msgid "Delete the selected user"
-msgstr "নির্বাচিত ব্যবহারকারী মুছে ফেলুন"
-
-#: ../panels/user-accounts/um-user-panel.c:936
-#: ../panels/user-accounts/um-user-panel.c:1219
-msgid ""
-"To delete the selected user,\n"
-"click the * icon first"
-msgstr "নির্বাচিত ব্যবহারকারী মুছে ফেলতে,*আইকনটি প্রথমে ক্লিক করুন"
-
-#: ../panels/user-accounts/um-user-panel.c:1114
-msgid "My Account"
-msgstr "আমার একাউন্ট"
-
-#: ../panels/user-accounts/um-user-panel.c:1124
-msgid "Other Accounts"
-msgstr "অন্যান্য একাউন্ট"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Add or remove users"
-msgstr "ব্যবহারকারী যোগ অথবা অপসারণ"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "লগ ইন;নাম;ফিঙ্গারপ্রিন্ট;এভাটার;লোগো;ফেস;পাসওয়ার্ড;"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "User Accounts"
-msgstr "ব্যবহারকারীর একাউন্ট"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-msgid "Cr_eate"
-msgstr "তৈরি (_e)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "Create new account"
-msgstr "নতুন অবস্থান তৈরি"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "_Account Type"
-msgstr "একাউন্টের ধরন (_A)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "_Full name"
-msgstr "পূর্ণ নাম (_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-msgid "_Username"
-msgstr "ব্যবহারকারীর নাম (_U)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid ""
-"How to choose a "
-"strong password"
-msgstr ""
-"দৃঢ় পাসওয়ার্ড "
-"কিভাবে নির্বাচন করবেন"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-msgid ""
-"<small>This hint may be displayed at the login screen.  It will be visible "
-"to all users of this system.  Do <b>not</b> include the password here.</"
-"small>"
-msgstr ""
-"<small>ইঙ্গিতটি লগ ইন স্ক্রীণে প্রদর্শিত হতে পারে। এই সিস্টেমে সব ব্যবহারকারী "
-"দৃশ্যমান হবে। এখানে পাসওয়ার্ড যুক্ত <b>হবেনা।</b></small>"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "C_onfirm password"
-msgstr "পাসওয়ার্ড সুনিশ্চিত (_o)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "Ch_ange"
-msgstr "পরিবর্তন (_a)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Changing password for"
-msgstr "এর জন্য পাসওয়ার্ড পরিবর্তন"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Choose a generated password"
-msgstr "তৈরিকৃত একটি পাসওয়ার্ড নির্বাচন"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Choose password at next login"
-msgstr "পরবর্তী লগইনে পাসওয়ার্ড নির্বাচন"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Current _password"
-msgstr "বর্তমান পাসওয়ার্ড (_p)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-msgid "Disable this account"
-msgstr "একাউন্টটি নিষ্ক্রিয়"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-msgid "Enable this account"
-msgstr "একাউন্টটি সক্রিয়"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-msgid "Fair"
-msgstr "ন্যায্য"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-msgid "Log in without a password"
-msgstr "পাসওয়ার্ড ছাড়া লগইন"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid "Set a password now"
-msgstr "পাসওয়ার্ড এখনই নির্ধারণ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-msgid "_Action"
-msgstr "কাজ (_A)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:15
-msgid "_Hint"
-msgstr "ইঙ্গিত (_H)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:16
-msgid "_New password"
-msgstr "নতুন পাসওয়ার্ড (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:17
-msgid "_Show password"
-msgstr "পাসওয়ার্ড প্রদর্শন (_S)"
-
-# Translated by sadia
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-msgid "Browse"
-msgstr "ব্রাউজ"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-msgid "Changing photo for:"
-msgstr "এর জন্য ফটো পরিবর্তন করা হচ্ছে:"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-msgid ""
-"Choose a picture that will be shown at the login screen for this account."
-msgstr "এই একাউন্টের জন্য এই লগইন স্ক্রীণে যে ছবি দেখানো হবে তা নির্বাচন।"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-msgid "Gallery"
-msgstr "গ্যালারি"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr "ফটো"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-msgid "Take a photograph"
-msgstr "ফটো তুলুন"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-msgid "Account Information"
-msgstr "একাউন্টের তথ্য"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-msgid "Account type"
-msgstr "একাউন্টের ধরণ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Automatic Login"
-msgstr "স্বয়ংক্রিয় লগইন"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন"
 
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "Login Options"
-msgstr "লগইন অপশন"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
 
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "Password"
-msgstr "পাসওয়ার্ড"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "আঙ্গুলের ছাপ মুছে ফেলুন (_D)"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left index finger"
-msgstr "বামহাতের তর্জনি"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন"
 
-# Translated by sadia
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left little finger"
-msgstr "বাম হাতের কড়ে আঙুল"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "পূর্ববর্তী  ট্র্যাক"
 
-# Translated by sadia
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left middle finger"
-msgstr "বামহাতের মধ্যাঙ্গুল"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
 
-# Translated by sadia
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Left ring finger"
-msgstr "বামহাতের অনামিকা"
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "পাসওয়ার্ড পরিবর্তন (_s)"
 
-# Translated by sadia
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Left thumb"
-msgstr "বাম হাতের বৃদ্ধাঙ্গুলি"
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "পরিবর্তন (_a)"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Other finger: "
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "বর্তমান পাসওয়ার্ড (_p)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "নতুন পাসওয়ার্ড (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "পাসওয়ার্ড সুনিশ্চিত (_o)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "পাসওয়ার্ড মিলছে না"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "পরবর্তী লগইনে পাসওয়ার্ড নির্বাচন"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "পাসওয়ার্ড এখনই নির্ধারণ"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Users"
+msgstr "ব্যবহারকারীর নাম"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "পূর্ণ নাম (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+#, fuzzy
+msgid "_Fingerprint Login"
+msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+#, fuzzy
+msgid "A_utomatic Login"
+msgstr "স্বয়ংক্রিয় লগইন"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "একাউন্টের ধরণ"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "প্রশাসক"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "নিয়ন্ত্রণ"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
 msgstr "অন্যান্য আঙ্গুল: "
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right index finger"
-msgstr "ডান হাতের তর্জনি"
-
-# Translated by sadia
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-msgid "Right little finger"
-msgstr "ডান হাতের কড়ে আঙুল"
-
-# Translated by sadia
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "Right middle finger"
-msgstr "ডান হাতের মধ্যাঙ্গুল"
-
-# Translated by sadia
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "Right ring finger"
-msgstr "ডান হাতের অনামিকা"
-
-# Translated by sadia
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "Right thumb"
-msgstr "ডান হাতের বৃদ্ধাঙ্গুলি"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
 msgstr ""
-"সাফল্যের সাথে আপনার আঙ্গুলের ছাপ সংরক্ষিত হয়েছে। আঙ্গুলের ছাপ রীডার সহযোগে আপনি "
-"এখন লগ-ইন করতে সক্ষম হবেন।"
 
-#: ../shell/control-center.c:50
-msgid "Enable verbose mode"
-msgstr "ভার্বোজ মোড সক্রিয় করা"
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
 
-#: ../shell/control-center.c:51
-msgid "Show the overview"
-msgstr "সারসংক্ষেপ প্রদর্শন"
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
 
-#: ../shell/control-center.c:52
-msgid "Panel to display"
-msgstr "প্রদর্শনের প্যানেল"
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+#, fuzzy
+msgid "Add or remove users and change your password"
+msgstr "ব্যবহারকারী যোগ অথবা অপসারণ"
 
-#: ../shell/control-center.c:69
-msgid "- System Settings"
-msgstr "- সিস্টেমের সেটিং"
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
-#: ../shell/control-center.c:76
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+#, fuzzy
+msgid "Domain Administrator Login"
+msgstr "প্রশাসক"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+#, fuzzy
+msgid "Administrator _Name"
+msgstr "প্রশাসক"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+#, fuzzy
+msgid "Administrator Password"
+msgstr "প্রশাসক"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+#, fuzzy
+msgid "Manage user accounts"
+msgstr "ব্যবহারকারীর একাউন্ট"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+#, fuzzy
+msgid "Authentication is required to change user data"
+msgstr "প্রমাণীকরণ আবশ্যকীয়"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "সতর্কবাণীর বোতাম"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"কোনো শর্ট-কাট কী-এর মান পরিবর্তনের জন্য সংশ্লিষ্ট সারির উপর ক্লিক করুন ও নতুন কী ধরে "
+"রাখুন অথবা চাপুন। অথবা ব্যাক-স্পেস চেপে মুছে ফেলুন।"
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+# Translated by sadia
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "মনিটর "
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "বহির্বিন্যাস"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "প্যারেন্ট উইন্ডো"
+
+# Translated by sadia
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "অনুকরণকৃত দ্বিতীয় ক্লিক"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "উইন্ডোজ (_W):"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+# Translated by sadia
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "অনুচ্চ টোনার  "
+
+# Translated by sadia
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "অনুকরণকৃত দ্বিতীয় ক্লিক"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "উইন্ডোজ (_W):"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "ব্যবহারযোগ্য লগ-ইন (_g)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "যোগ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "ফন্ট আঁকার খুঁটিনাটি"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "নেটওয়ার্ক সময়"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "নেটওয়ার্ক সেটিং"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "ডিভাইসের  ধরণ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+#, fuzzy
+msgid "Manufacturer"
+msgstr "পরিকাঠামো"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "ফার্মওয়্যার অনুপস্থিত"
+
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
-"%s\n"
-"Run '%s --বিদ্যমান কমান্ড লাইন অপশনের সম্পূর্ণ তালিকা দেখতে সহায়তা করে।\n"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
-msgid "System Settings"
-msgstr "সিস্টেমের সেটিং"
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
 
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "নিয়ন্ত্রণ কেন্দ্র"
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "আবদ্ধ"
 
-#: ../shell/shell.ui.h:2
-msgid "_All Settings"
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "মোবাইল ব্রডব্যান্ড"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "নেটওয়ার্কের নাম (_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "নেটওয়ার্ক"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "বাতিল"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "আবদ্ধ"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "ফন্ট আঁকার খুঁটিনাটি"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "নেটওয়ার্ক সময়"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "স্বয়ংক্রিয়"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "নেটওয়ার্ক"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "বিমান মোড"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "সংযুক্ত করা হচ্ছে "
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "আবদ্ধ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "পরিবর্তন (_a)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "নেটওয়ার্ক"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
 msgstr "সব সেটিং (_A)"
 
-msgid "Show help options"
-msgstr "সহায়তা সংক্রান্ত অপশন প্রদর্শন করা হবে"
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
 
-#~ msgid "Clean print heads"
-#~ msgstr "মুদ্রণের হেড পরিষ্কার"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "সাধারণ"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "সন্ধান"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "বাতিল"
+
+# Translated by sadia
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "পছন্দসমূহ"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u আউটপুট"
+msgstr[1] "%u আউটপুট"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ইনপুট"
+msgstr[1] "%u ইনপুট"
+
+#~ msgid "Current network location"
+#~ msgstr "বর্তমান নেটওয়ার্কের অবস্থান"
+
+# Translated by sadia
+#~ msgid "More backgrounds URL"
+#~ msgstr "আরও পটভূমির ইউআরএল"
+
+# Translated by sadia
+#~ msgid "More themes URL"
+#~ msgstr "আরও থিমের ইউআরএল"
+
+# Translated by sadia
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "এটাকে আপনার বর্তমান অবস্থান হিসেবে নির্ধারণ করুন। যথার্থ নেটওয়ার্কের প্রক্সি "
+#~ "কনফিগারেশন নিরূপন করতে এটি ব্যবহৃত হয়।"
+
+# Translated by sadia
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "আরও ডেক্সটপ পটভূমি যেখানে পাওয়া যাবে তার ইউআরএল। যদি ফাঁকা স্ট্রিং হিসেবে "
+#~ "নির্ধারণ করা থাকে তবে লিংকটি দৃশ্যমান হবে না।"
+
+# Translated by sadia
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "আরও ডেক্সটপ থিম যেখানে পাওয়া যাবে তার ইউআরএল। যদি ফাঁকা স্ট্রিং হিসেবে "
+#~ "নির্ধারণ করা থাকে তবে লিংকটি দৃশ্যমান হবে না।"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "সংলাপ অনাবদ্ধ।\n"
+#~ "আরও পরিবর্তন প্রতিরোধ করতে ক্লিক"
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "সংলাপ আবদ্ধ।\n"
+#~ "পরিবর্তন করতে ক্লিক"
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "সিস্টেমের নীতিমালা পরিবর্তন প্রতিরোধ করে।\n"
+#~ "আপনার সিস্টেম প্রশাসকের সাথে যোগাযোগ করুন"
+
+#~ msgid "Key"
+#~ msgstr "কী"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "যে GConf কী এর সাথে এই বৈশিষ্ট্যনির্ধারণী সম্পাদক যুক্ত আছে"
+
+#~ msgid "Callback"
+#~ msgstr "কলব্যাক"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "কী এর সাথে যুক্ত মান পরিবর্তিত হলে এই কলব্যাক উৎপন্ন হবে"
+
+#~ msgid "Change set"
+#~ msgstr "নির্ধারণ পরিবর্তন"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf নির্ধারণ পরিবর্তনে ধারণকৃত ডাটা gconf ক্লায়েন্টে প্রয়োগ করতে ফরওয়ার্ড"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "উইজেট কলব্যাকে রূপান্তর"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "তথ্যকে GConf থেকে উইজেটে রূপান্তরের সময় যে কলব্যাকটি ব্যবহৃত হবে"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "উইজেট কলব্যাক থেকে রূপান্তর"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "তথ্যকে উইজেট থেকে GConf এ রূপান্তরের সময় যে কলব্যাকটি ব্যবহৃত হবে"
+
+#~ msgid "UI Control"
+#~ msgstr "UI নিয়ন্ত্রণ"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "বৈশিষ্ট্য নির্ধারণী অবজেক্ট (সাধারণত এটি একটি উইজেট)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "বৈশিষ্ট্য নির্ধারণী সম্পাদকের অবজেক্টবিষয়ক তথ্য"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "বৈশিষ্ট্য নির্ধারণী সম্পাদকের প্রয়োজনীয় স্বনির্বাচিত তথ্য"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr ""
+#~ "বৈশিষ্ট্য নির্ধারণী সম্পাদকের তথ্য কলব্যাকের ওপর থেকে নিয়ন্ত্রণ প্রত্যাহার করছে"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "বৈশিষ্ট্য নির্ধারণী সম্পাদকের অবজেক্টবিষয়ক তথ্যের ওপর থেকে নিয়ন্ত্রণ প্রত্যাহারের "
+#~ "সময় যে কলব্যাকটি ব্যবহৃত হবে"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "'%s' নামক ফাইলটি পাওয়া যাচ্ছে না।\n"
+#~ "\n"
+#~ "দয়া করে নিশ্চিত হোন যে ফাইলটি আসলেই আছে কিনা এবং তারপর আবার চেষ্টা করুন, "
+#~ "অথবা পটভূমির জন্য অন্য কোন ছবি বেছে নিন।"
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' ফাইলটি পড়তে পারছি না।\n"
+#~ "সম্ভবত এখনো এ ধরনের ছবি ব্যবহারের ব্যবস্থা নেই।\n"
+#~ "\n"
+#~ "অনুগ্রহপূর্বক অন্য একটি ছবি বেছে নিন।"
+
+#~ msgid "Please select an image."
+#~ msgstr "অনুগ্রহপূর্বক একটি ছবি বেছে নিন।"
+
+#~ msgid "Change the background"
+#~ msgstr "পটভূমির ছবি সংরক্ষণ"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "ওয়ালপেপার;স্ক্রীন;ডেস্কটপ;"
+
+# Translated by sadia
+#~ msgid "Center"
+#~ msgstr "কেন্দ্র"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "সারা দিনের পরিবর্তন"
+
+#~ msgid "Fill"
+#~ msgstr "সম্পূর্ণ"
+
+#~ msgid "Span"
+#~ msgstr "স্প্যান"
+
+# Translated by sadia
+#~ msgid "Tile"
+#~ msgstr "টালি "
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "অনুভূমিক গ্র্যাডিয়েন্ট"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "উল্লম্ব গ্রেডিয়েন্ট"
+
+#~ msgid "Solid Color"
+#~ msgstr "নিরেট রং"
+
+# Translated by sadia
+#~ msgid "Current background"
+#~ msgstr "বর্তমানের পটভূমি"
+
+#~ msgid "Pictures Folder"
+#~ msgstr "ছবির ফোল্ডার"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "রং এবং গ্রেডিয়েন্ট"
+
+# Translated by sadia
+#~ msgid "multiple sizes"
+#~ msgstr "বিভিন্ন আকার"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "ডেস্কটপের কোনো পটভূমি প্রয়োগ করা হবে না"
+
+#~ msgid "Unspecified"
+#~ msgstr "উল্লেখিত নয়"
+
+#~ msgid "24-Hour Time"
+#~ msgstr "২৪ ঘন্টা সময়"
+
+#~ msgid "City:"
+#~ msgstr "শহর:"
+
+#~ msgid "Region:"
+#~ msgstr "অঞ্চল:"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "তারিখ ও সময় পছন্দ করার প্যানেল"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "মনে রাখবেন: রেজল্যুশন অপশনের সীমা দিতে পারে"
+
+#~ msgid "Upside-down"
+#~ msgstr "উল্টো"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "প্রদর্শন সনাক্ত (_D)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "পর্দার অনুলিপি তৈরি করা হবে (_M)"
+
+#~ msgid "Counterclockwise"
+#~ msgstr "বামাবর্তী"
+
+#~ msgid "Clockwise"
+#~ msgstr "দক্ষিণাবর্তে"
+
+#~ msgid "180 Degrees"
+#~ msgstr "১৮০ ডিগ্রী"
+
+#, c-format
+#~ msgid "%d x %d (%s)"
+#~ msgstr "%d x %d (%s)"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "মনিটরের বৈশিষ্ট্য পরিবর্তন করতে নির্বাচন করুন; এর অবস্থান পুনরায় নির্ধারণ করতে "
+#~ "টেনে আনুন।"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "ডিসপ্লে কনফিগারেশন প্রয়োগ করার সময় সেশন বাস পাওয়া যায়নি"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "ডিসপ্লে সনাক্ত করতে ব্যর্থ"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "পর্দা সংক্রান্ত পরিবর্তন পাওয়া যায়নি"
+
+#, c-format
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown"
+#~ msgstr "অজ্ঞাত"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-bit"
+
+#, c-format
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f KB"
+
+#, c-format
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f MB"
+
+#, c-format
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f GB"
+
+#, c-format
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TB"
+
+#, c-format
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PB"
+
+#, c-format
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EB"
+
+#~ msgid "Unknown model"
+#~ msgstr "অজ্ঞাত মডেল"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "আদর্শ অভিজ্ঞতা ব্যবহারের জন্য পরবর্তী লগইনের প্রচেষ্টা।"
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "অসমর্থিত গ্রাফিক্স হার্ডওয়্যারের জন্য পরবর্তী লগইন উদ্দেশ্যকৃত ফলব্যাক মোড ব্যবহার "
+#~ "করবে"
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "ফলব্যাক"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "আদর্শ"
+
+#~ msgid "Overview"
+#~ msgstr "সারসংক্ষেপ"
+
+#~ msgid "System Info"
+#~ msgstr "সিস্টেমের তথ্য"
+
+#~ msgid "Disk"
+#~ msgstr "ডিস্ক"
+
+#~ msgid "Experience"
+#~ msgstr "অভিজ্ঞতা"
+
+#~ msgid "Forced Fallback Mode"
+#~ msgstr "ফলব্যাক মোডে বাধ্য"
+
+#~ msgid "OS type"
+#~ msgstr "OS এর ধরন"
+
+#~ msgid "Photos"
+#~ msgstr "ছবি"
+
+#~ msgid "Updates Available"
+#~ msgstr "হালনাগাদ বিদ্যমান"
+
+# Translated by sadia
+#~ msgid "Web"
+#~ msgstr "ওয়েব"
+
+#~ msgid "Magnifier zoom out"
+#~ msgstr "ছোট আকারে প্রদর্শনের বিবর্ধনযন্ত্র"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "টগল বৈসাদৃশ্য"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "টগল বিবর্ধনযন্ত্র"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "লিনাক্স স্ক্রীণ রিডার"
+
+# FIXME
+#~ msgid "New shortcut..."
+#~ msgstr "নতুন শর্টকাট..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "এক্সিলেটর কী"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "এক্সিলেটর পরিবর্তক"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "এক্সিলেটর কীকোড"
+
+#~ msgid "Accel Mode"
+#~ msgstr "এক্সেল মোড"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "এক্সিলেটর কী-এর ধরন।"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "শর্টকাট;পুনরাবৃত্ত করা;মিটিমিটি জ্বলা;"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<অজানা কাজ>"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "নতুন শর্ট-কাট সংরক্ষণে সমস্যা"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "শর্টকাট-কি হিসেবে \"%s\" ব্যবহার করা যাবে না কারণ এর ফলে এই কী ব্যবহার করে "
+#~ "কিছু টাইপ করা যাবে না।\n"
+#~ "অনুগ্রহ করে Control, Alt বা Shift কী-এর একসাথে ব্যবহারের চেষ্টা করুন।"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "শর্টকাট \"%s\" বর্তমানে\n"
+#~ "\"%s\"-র জন্য ব্যবহৃত হচ্ছে"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "\"%s\"-এ শর্ট-কাট স্থাপন করা হলে, \"%s\" শর্ট-কাটটি নিষ্ক্রিয় করা হবে।"
+
+#~ msgid "_Reassign"
+#~ msgstr "পুনরায় নির্ধারণ (_R)"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "অত্যাধিক স্বনির্ধারিত শর্ট-কাট"
+
+#~ msgid "Action"
+#~ msgstr "কাজ"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "স্বনির্ধারিত শর্ট-কাট"
+
+# Translated by sadia
+#~ msgid "Fast"
+#~ msgstr "দ্রুত"
+
+#~ msgid "S_peed:"
+#~ msgstr "গতি (_p):"
+
+# Translated by sadia
+#~ msgid "Slow"
+#~ msgstr "ধীর"
+
+#~ msgid "_Speed:"
+#~ msgstr "গতি (_S):"
+
+#~ msgid "Ask what to do"
+#~ msgstr "কি করতে হবে তা জিজ্ঞাসা করুন"
+
+# Translated by sadia
+#~ msgid "Do nothing"
+#~ msgstr "কিচ্ছু করার নেই"
+
+#~ msgid "Open folder"
+#~ msgstr "ফোল্ডার খোলা"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "অডিও সিডির জন্য অ্যাপ্লিকেশন নির্বাচন"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "ভিডিও ডিভিডির জন্য অ্যাপ্লিকেশন নির্বাচন"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "যখন একটি মিউজিক প্লেয়ার সংযুক্ত থাকবে তখন একটি অ্যাপ্লিকেশন চালানোর জন্য "
+#~ "নির্বাচন করুন"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "যখন ক্যামেরা সংযুক্ত থাকবে তখন একটি অ্যাপ্লিকেশন চালানোর জন্য নির্বাচন করুন"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "সফ্টওয়্যারের সিডির জন্য অ্যাপ্লিকেশন নির্বাচন"
+
+#~ msgid "audio DVD"
+#~ msgstr "অডিও DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "খালি ব্লু-রে ডিস্ক "
+
+#~ msgid "blank CD disc"
+#~ msgstr "খালি সিডি ডিস্ক"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "খালি ডিভিডি ডিস্ক"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "খালি HD DVD ডিস্ক"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "ব্লু-রে ভিডিও ডিস্ক "
+
+#~ msgid "e-book reader"
+#~ msgstr "ই-বুক রীডার"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD ভিডিও ডিস্ক"
+
+#~ msgid "Picture CD"
+#~ msgstr "ছবি সিডি"
+
+#~ msgid "Super Video CD"
+#~ msgstr "চমৎকার ভিডিও সিডি"
+
+# Translated by sadia
+#~ msgid "Video CD"
+#~ msgstr "ভিডিও সিডি"
+
+#~ msgid "Acti_on:"
+#~ msgstr "কাজ (_o):"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "মিডিয়া এবং অটোরান পছন্দ কনফিগার"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "সিডি;ডিভিডি;ইউএসবি;ভিডিও;ডিস্ক;"
+
+#~ msgid "Out of toner"
+#~ msgstr "টোনারের বাহিরে"
+
+#~ msgid "Low on developer"
+#~ msgstr "ডেভেলপারে নিম্ন"
+
+#~ msgid "Out of developer"
+#~ msgstr "ডেভেলপারের বাহিরে"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "চিহ্নিতকারী সরবরাহ কম"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "চিহ্নিতকারী সরবরাহ হচ্ছেনা"
+
+#~ msgid "Open cover"
+#~ msgstr "কভার উন্মুক্ত"
+
+#~ msgid "Low on paper"
+#~ msgstr "কাগজ কম"
+
+#~ msgid "Out of paper"
+#~ msgstr "কাগজ নেই"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "বিরত"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "বর্জ্য রাখার পাত্র প্রায় পূর্ণ"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "বর্জ্য রাখার পাত্র পূর্ণ"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "আলোক সম্বন্ধীয় ছবি পরিবাহকের জীবনী শেষ"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "আলোক সম্বন্ধীয় ছবি পরিবাহক আর কাজ করছেনা"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "প্রস্তুত"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "প্রক্রিয়াধীন"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "বন্ধ"
+
+#~ msgid "Toner Level"
+#~ msgstr "টোনারের স্তর"
+
+#~ msgid "Supply Level"
+#~ msgstr "সরবরাহের স্তর"
+
+# Translated by sadia
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "অমীমাংসিত"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "অনুষ্ঠিত"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "প্রক্রিয়াধীন"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "বন্ধ"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "নিষ্ফলকৃত"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "সম্পন্ন"
+
+#~ msgid "Job Title"
+#~ msgstr "পদমর্যাদা"
+
+#~ msgid "Job State"
+#~ msgstr "কাজেরঅবস্থা"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "নতুন মুদ্রণযন্ত্র যোগ করতে ব্যর্থ।"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui লোড করা যাচ্ছেনা: %s"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "নতুন মুদ্রণযন্ত্র যোগ"
+
+# Translated by sadia
+#~ msgid "Local"
+#~ msgstr "স্থানীয়"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+# Translated by sadia
+#~ msgid "Jobs"
+#~ msgstr "কাজ"
+
+#~ msgid "Print Test Page"
+#~ msgstr "মুদ্রণ পরীক্ষামূলক পৃষ্ঠা"
+
+# Translated by sadia
+#~ msgid "Printing..."
+#~ msgstr "মুদ্রণ করা হচ্ছে..."
+
+# Translated by sadia
+#~ msgid "Show"
+#~ msgstr "প্রদর্শন"
+
+# Translated by sadia
+#~ msgid "Allow different layouts for each window"
+#~ msgstr "প্রতিটি উইন্ডোর জন্য পৃথক বহির্বিন্যাস"
+
+#~ msgid "Layouts"
+#~ msgstr "বিন্যাস"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "বর্তমান কীবোর্ডের লেআউট সেটিং প্রতিস্থাপন করুন\n"
+#~ "পূর্বনির্ধারিত সেটিং এর সাহায্যে"
+
+# FIXME
+#~ msgid "Reset to De_faults"
+#~ msgstr "পূর্বনির্ধারিত মান পুনরায় স্থাপন করুন (_f)"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "প্রদর্শনের ভাষা নির্বাচন (পরবর্তী সময়ে আপনি লগইন করার সময় পরিবর্তন প্রয়োগ করা "
+#~ "হবে)"
+
+# Translated by sadia
+#~ msgid "Use default layout in new windows"
+#~ msgstr "নতুন উইন্ডোর জন্য পূর্বনির্ধারিত বিন্যাস"
+
+#~ msgid "Use previous window's layout in new windows"
+#~ msgstr "নতুন উইন্ডোতে পূর্ববর্তী উইন্ডোর বহির্বিন্যাস ব্যবহার"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "কীবোর্ডের লেআউট অপশন প্রদর্শন এবং সম্পাদন"
+
+# Translated by sadia
+#~ msgid "_Options..."
+#~ msgstr "অপশন (_O)... "
+
+#~ msgid "Choose a Layout"
+#~ msgstr "যে কোন একটি লে-আউট বেছে নিন"
+
+# Translated by sadia
+#~ msgid "Drag and Drop"
+#~ msgstr "টেনে এনে ছেড়ে দিন"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "টাচপ্যাডের মাধ্যমে মাউস ক্লিক সক্রিয় করুন (_m)"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "মাউস সম্পর্কিত পছন্দ"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "কন্ট্রোল-কী চাপা হলে পয়েন্টারের অবস্থান প্রদর্শন করা হবে (_o)"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "থ্রেসহোল্ড (_e):"
+
+# Translated by sadia
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "সেটিং পরীক্ষার জন্য, ফেসের উপর ডবল ক্লিক করার চেষ্টা করুন।"
+
+#~ msgid "Two-_finger scrolling"
+#~ msgstr "দুই-আঙ্গুল স্ক্রলিং (_f)"
+
+#~ msgid "_Disabled"
+#~ msgstr "নিষ্ক্রিয় (_D)"
+
+#~ msgid "_Edge scrolling"
+#~ msgstr "প্রান্ত স্ক্রলিং করুন (_E)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "বামহাতি (_L)"
+
+#~ msgid "_Right-handed"
+#~ msgstr "ডান হাতি (_R)"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "সংবেদনশীলতা (_S):"
+
+#~ msgid "_Timeout:"
+#~ msgstr "সময় শেষ (_T):"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "মাউস এবং টাচপ্যাড সম্পর্কিত আপনার পছন্দ নির্ধারণ"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "যখন কনফিগারেশন URL দেওয়া থাকেনা তখন স্বয়ংক্রিয় ওয়েব প্রক্সি উদঘাটন ব্যবহৃত হয়। "
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "অবিশ্বস্ত পাবলিক নেটওয়ার্কের জন্য এটি সুপারিশ করা হচ্ছেনা।"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "Proxy"
+#~ msgstr "প্রক্সি"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "এই সংস্করণের সাথে সিস্টেম নেটওয়ার্ক সার্ভিস সামঞ্জস্যপূর্ণ নয়।"
+
+#~ msgid "Network;Wireless;IP;LAN;"
+#~ msgstr "নেটওয়ার্ক;ওয়ারলেস;IP;LAN;"
+
+#~ msgid "Create..."
+#~ msgstr "তৈরি..."
+
+#~ msgid "Group Name"
+#~ msgstr "গ্রুপের নাম"
+
+#~ msgid "Interface"
+#~ msgstr "ইন্টারফেস"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "নতুন সার্ভিস ব্যবহারের জন্য ইন্টারফেস নির্বাচন"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "সাবনেট মাস্ক"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "একটিও না"
+
+#~ msgid "Wireless"
+#~ msgstr "তারবিহীন"
+
+#~ msgid "Mesh"
+#~ msgstr "মেশ"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "এডহক"
+
+#~ msgid "Status unknown"
+#~ msgstr "অজানা অবস্থা"
+
+#~ msgid "Unmanaged"
+#~ msgstr "অপরিকল্পিত"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "কেবল আনপ্লাগকৃত"
+
+#~ msgid "Unavailable"
+#~ msgstr "বিদ্যমান নয়"
+
+#~ msgid "Disconnected"
+#~ msgstr "বিছিন্ন"
+
+#~ msgid "Connection failed"
+#~ msgstr "সংযোগে ব্যর্থ"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "অজানা অবস্থা (অনুপস্থিত)"
+
+#~ msgid "Power management settings"
+#~ msgstr "শক্তি পরিচালনা সেটিং"
+
+#~ msgid "Unknown time"
+#~ msgstr "অজ্ঞাত সময়"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#~ msgid "Battery discharging"
+#~ msgstr "ব্যাটারী চার্জ হচ্ছেনা"
+
+#~ msgid "UPS charging"
+#~ msgstr "UPS চার্জ হচ্ছে"
+
+#~ msgid "UPS discharging"
+#~ msgstr "UPS চার্জ হচ্ছেনা"
+
+#, c-format
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s পর্যন্ত চার্জ (%.0lf%%)"
+
+#, c-format
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s পর্যন্ত খালি (%.0lf%%)"
+
+#, c-format
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% চার্জকৃত"
+
+#~ msgid "Ask me"
+#~ msgstr "আমাকে জিজ্ঞাসা করুন"
+
+#~ msgid "Hibernate"
+#~ msgstr "হাইবারনেট"
+
+#~ msgid "On AC power:"
+#~ msgstr "AC পাওয়ার চালু:"
+
+#~ msgid "Shutdown"
+#~ msgstr "বন্ধ"
+
+#~ msgid "Suspend"
+#~ msgstr "স্থগিত "
+
+#~ msgid "When power is critically low:"
+#~ msgstr "যখন পাওয়ার মারাত্মক কম থাকে:"
+
+#~ msgid "When the power button is pressed:"
+#~ msgstr "যখন পাওয়ার বোতাম চাপা দেওয়া থাকে:"
+
+#~ msgid "When the sleep button is pressed:"
+#~ msgstr "যখন স্লীপ বোতাম চাপা দেওয়া থাকে:"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Brightness;Lock;Dim;Blank;Monitor;"
+
+#~ msgid "1 minute"
+#~ msgstr "১ মিনিট"
+
+#~ msgid "3 minutes"
+#~ msgstr "৩ মিনিট"
+
+#~ msgid "Dim screen to save power"
+#~ msgstr "পাওয়ার সংরক্ষণের জন্য ঝাপসা স্ক্রীন "
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "যখন হোমে থাকবেন তখন লক করবেননা"
+
+# FIXME
+#~ msgid "Locations..."
+#~ msgstr "অবস্থান..."
+
+#~ msgid "Lock screen after:"
+#~ msgstr "এরপরে স্ক্রীন লক করুন:"
+
+#~ msgid "Screen turns off"
+#~ msgstr "স্ক্রীন চালু বন্ধ করুন"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "কোড ডিবাগ ব্যবস্থা সক্রিয় করা হবে"
+
+#~ msgid "Version of this application"
+#~ msgstr "এই অ্যাপ্লিকেশনের সংস্করণ"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME ভলিউম কন্ট্রোল অ্যাপলেট"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "শব্দ আউটপুটের ভলিউম"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "বাম"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "ডান"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "সর্বনিম্ন"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "সর্বোচ্চ"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "সাবউফার (_S):"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "১০০%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "এমপ্লিফাইড নয়"
+
+#~ msgid "Peak detect"
+#~ msgstr "সর্বোচ্চ চূড়া নির্ধারন"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s এর জন্য স্পিকার পরীক্ষা"
+
+#~ msgid "Test Speakers"
+#~ msgstr "স্পিকার পরীক্ষা"
+
+#~ msgid "_Output volume: "
+#~ msgstr "আউটপুট ভলিউম (_O):"
+
+#~ msgid "Hardware"
+#~ msgstr "হার্ডওয়্যার"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "নির্বাচিত ডিভাইসের জন্য সেটিং:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "শব্দের ইনপুটের জন্য ডিভাইস নির্বাচন:"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "শব্দের আউটপুটের জন্য ডিভাইস নির্বাচন:"
+
+#~ msgid "Stop"
+#~ msgstr "বন্ধ"
+
+#, c-format
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "শব্দ পছন্দ আরম্ভ করতে ব্যর্থ: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "নিঃশব্দ (_M)"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "শব্দ পছন্দ (_S)"
+
+#~ msgid "Muted"
+#~ msgstr "নিঃশব্দ "
+
+#~ msgid "Built-in"
+#~ msgstr "বিল্ট ইন"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "শব্দ পছন্দ"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ইভেন্টের শব্দ পরীক্ষা"
+
+#~ msgid "From theme"
+#~ msgstr "থীম থেকে"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "সতর্ক করার জন্য শব্দ নির্বাচন:"
+
+#~ msgid "Custom"
+#~ msgstr "স্বনির্বাচিত"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "ডেস্কটপ ভলিউম কন্ট্রোল প্রদর্শন"
+
+#~ msgid "Bark"
+#~ msgstr "ঘেউ ঘেউ "
+
+#~ msgid "Drip"
+#~ msgstr "ফোঁটা ফোঁটা করে পড়া"
+
+#~ msgid "Glass"
+#~ msgstr "কাঁচ"
+
+#~ msgid "Sonar"
+#~ msgstr "প্রতিফলিত শব্দ তরঙ্গ"
+
+# FIXME
+#~ msgid "No shortcut set"
+#~ msgstr "কোন শর্টকাট নির্ধারিত নেই"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "কীবোর্ড;মাউস;a11y;স্বাচ্ছন্দ্যকরণ;"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "সর্বজনীন প্রবেশের পছন্দ"
+
+#, no-c-format
+#~ msgid "100%"
+#~ msgstr "১০০%"
+
+#, no-c-format
+#~ msgid "125%"
+#~ msgstr "১২৫%"
+
+#, no-c-format
+#~ msgid "150%"
+#~ msgstr "১৫০%"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "কী হলে বিপ হবে "
+
+#~ msgid "Caribou"
+#~ msgstr "কারিবূ"
+
+#~ msgid "Change contrast:"
+#~ msgstr "রংয়ের বৈষম্য পরিবর্তন:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "কী-প্যাড সহযোগে পয়েন্টার নিয়ন্ত্রণ"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "ভিডিও ক্যামেরা সহযোগে পয়েন্টার নিয়ন্ত্রণ।"
+
+#~ msgid "Dasher"
+#~ msgstr "ড্যাশার"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "স্পীচ এবং শব্দের মূলগ্রন্থ-সমন্ধীয় বর্ণনা প্রদর্শন"
+
+#~ msgid "Flash the window title"
+#~ msgstr "উইন্ডোর শিরোনাম ঝলকানো হবে"
+
+#~ msgid "GOK"
+#~ msgstr "GOK"
+
+#~ msgid "Larger"
+#~ msgstr "বড়"
+
+# Translated by sadia
+#~ msgid "Mouse Settings"
+#~ msgstr "মাউসের সেটিং"
+
+#~ msgid "Nomon"
+#~ msgstr "নমন"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "OnScreen কি-বোর্ড"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+# Translated by sadia
+#~ msgid "Options..."
+#~ msgstr "অপশন..."
+
+#~ msgid "Text size:"
+#~ msgstr "টেক্সটের আকার:"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "সেটিং পরীক্ষার জন্য এখানে টাইপ করুন"
+
+#~ msgid "Video Mouse"
+#~ msgstr "ভিডিও মাউস"
+
+#~ msgid "accepted"
+#~ msgstr "গৃহীত"
+
+#~ msgid "pressed"
+#~ msgstr "চাপা"
+
+#~ msgid "rejected"
+#~ msgstr "প্রত্যাখ্যান"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">High/Inverse</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">High</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">Low</span>"
+
+# check
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">Normal</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "উঁচু/বিপরীত"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "স্বাভাবিক"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "বড় আকারে প্রদর্শন"
+
+#~ msgid "Authentication failed"
+#~ msgstr "প্রমাণীকরণে ব্যর্থ"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "নতুন পাসওয়ার্ড অত্যন্ত ছোট।"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "নতুন পাসওয়ার্ড অত্যন্ত সরল।"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "পুরনো ও নতুন পাসওয়ার্ডের গঠন অতিমাত্রায় অনুরূপ।"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "নতুন পাসওয়ার্ড বর্তমানে ইতোমধ্যেই ব্যবহৃত হয়েছে।"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "নতুন পাসওয়ার্ডের মধ্যে সংখ্য ও বিশেষ অক্ষরের উপস্থিতি বাঞ্ছনীয়"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "পুরোনো ও নতুন পাসওয়ার্ড অনুরূপ"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "প্রারম্ভে আপনার পরিচয় অনুমোদিত হওয়ার ফলে আপনার পাসওয়ার্ড পরিবর্তিত হয়েছে!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "নতুন পাসওয়ার্ডের মধ্যে যথেষ্ট ভিন্ন অক্ষর নেই।"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "অজ্ঞাত ত্রুটি "
+
+#~ msgid "Failed to create user"
+#~ msgstr "ব্যবহারকারী তৈরি করতে ব্যর্থ"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists"
+#~ msgstr "'%s'  নামের ব্যবহারকারী ইতোমধ্যেই আছে"
+
+#, c-format
+#~ msgid "The username is too long"
+#~ msgstr "ব্যবহারকারীর নাম অনেক দীর্ঘ"
+
+#~ msgid "The username cannot start with a '-'"
+#~ msgstr " '-' দিয়ে ব্যবহারকারীর নাম শুরু করা যাবেনা"
+
+#~ msgid ""
+#~ "The username must consist of:\n"
+#~ " ➣ letters from the English alphabet\n"
+#~ " ➣ digits\n"
+#~ " ➣ any of the characters '.', '-' and '_'"
+#~ msgstr ""
+#~ "ব্যবহারকারীর নাম অবশ্যই গঠিত হতে হবে:\n"
+#~ " ➣ইংরেজি বর্ণমালার অক্ষর থেকে \n"
+#~ " ➣সংখ্যা\n"
+#~ " ➣ '.', '-' এবং '_' এর যে কোন অক্ষর"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "আদর্শ"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "আপনি এই ডিভাইস ব্যবহার করতে অনুমোদিত নন। অনুগ্রহ করে সিস্টেম প্রশাসকের সাথে "
+#~ "যোগাযোগ করুন।"
+
+#~ msgid "The device is already in use."
+#~ msgstr "ডিভাইসটি বর্তমানে ব্যবহৃত হচ্ছে।"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "একটি অভ্যন্তরীণ ত্রুটি হয়েছে।"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "নিবন্ধিত আঙ্গুলের ছাপ মুছে ফেলা হবে কি?"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' ডিভাইস ব্যবহার করা যাচ্ছেনা"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' ডিভাইসের মধ্যে আঙ্গুলের ছাপ প্রাপ্তিতে ব্যর্থ"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "আঙ্গুলের ছাপ পাঠের কোনো ব্যবস্থা প্রয়োগ করা যায়নি"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "অনুগ্রহ করে সহায়তার জন্য আপনার সিস্টেম প্রশাসকের সাথে যোগাযোগ করুন।"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন সক্রিয়"
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "আঙ্গুলের ছাপ সহযোগে লগ-ইন ব্যবস্থা সক্রিয় করার জন্য, '%s' ডিভাইস সহযোগে অন্তত "
+#~ "একটি আঙ্গুলের ছাপ সংরক্ষণ করা আবশ্যক।"
+
+#, c-format
+#~ msgid ""
+#~ "Enrolling fingerprints for\n"
+#~ "<b><big>%s</big></b>"
+#~ msgstr ""
+#~ "যার জন্য আঙ্গুলের ছাঁপ তালিকাভুক্ত করা হবে\n"
+#~ "<b><big>%s</big></b>"
+
+#~ msgid "More choices..."
+#~ msgstr "আরও পছন্দ..."
+
+#~ msgid "Please choose another password."
+#~ msgstr "অনুগ্রহ করে আরেকটি পাসওয়ার্ড নির্বাচন করুন।"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "অনুগ্রহ করে আপনার বর্তমান পাসওয়ার্ড আবার লিখুন।"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "পাসওয়ার্ড পরিবর্তন করা যাবেনা"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "নতুন পাসওয়ার্ড দিতে হবে"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "পাসওয়ার্ড নিশ্চিত করতে হবে"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "আপনার বর্তমান পাসওয়ার্ড দিতে হবে"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "বর্তমান পাসওয়ার্ড সঠিক নয়"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "অনেক ছোট"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "দুর্বল"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "ন্যায্য"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "ভালো"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "দৃঢ়"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "পাসওয়ার্ড মিলছেনা"
+
+#~ msgid "Wrong password"
+#~ msgstr "ভুল পাসওয়ার্ড"
+
+#~ msgid "Disable image"
+#~ msgstr "চিত্র নিষ্ক্রিয় "
+
+#~ msgid "Take a photo..."
+#~ msgstr "ফটো তুলুন..."
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "আরও ছবির জন্য ব্রাউজ করুন..."
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s দ্বারা ব্যবহৃত"
+
+#, c-format
+#~ msgid "A user with name '%s' already exists."
+#~ msgstr "'%s' নামের ব্যবহারকারী ইতোমধ্যেই বর্তমান।"
+
+#~ msgid "This user does not exist."
+#~ msgstr "ব্যবহারকারী বিদ্যমান নয়"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ব্যবহাকারী মুছে ফেলতে ব্যর্থ"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "আপনি আপনার নিজের একাউন্ট মুছে ফেলতে পারবেননা।"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s এখনো লগ ইন রয়েছে"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "ব্যবহারকারীরা লগইন থাকা অবস্থায় তাদেরকে মুছে ফেললে সিস্টেমে অসামঞ্জস্য অবস্থা "
+#~ "হতে পারে।"
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "%s ফইলটি রেখে দিতে চান?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ব্যবহারকারীর একাউন্ট মুছে ফেলার সময় প্রধান ডিরেক্টরি, মেইল স্পুল এবং অস্থায়ী ফাইল "
+#~ "রেখে দেওয়া যায়।"
+
+#~ msgid "_Keep Files"
+#~ msgstr "ফাইল রাখুন (_K)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "একাউন্ট নিষ্ক্রিয়"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "পরবর্তী লগ ইনে নির্ধারণ"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "একটিও না"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "একাউন্ট সার্ভিসের সাথে যোগাযোগ করতে ব্যর্থ"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "অনুগ্রহপূর্বক নিশ্চিত হোন যে একাউন্ট সার্ভিস সঠিকভাবে ইনস্টল ও সক্রিয় করা আছে কি না"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "পরিবর্তন করতে,\n"
+#~ "*আইকনটি প্রথমে ক্লিক করুন"
+
+#~ msgid "Create a user"
+#~ msgstr "ব্যবহারকারী তৈরি"
+
+#~ msgid ""
+#~ "To create a user,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ব্যবহারকারী তৈরি করতে,\n"
+#~ "*আইকনটি প্রথমে ক্লিক করুন"
+
+#~ msgid "Delete the selected user"
+#~ msgstr "নির্বাচিত ব্যবহারকারী মুছে ফেলুন"
+
+#~ msgid ""
+#~ "To delete the selected user,\n"
+#~ "click the * icon first"
+#~ msgstr "নির্বাচিত ব্যবহারকারী মুছে ফেলতে,*আইকনটি প্রথমে ক্লিক করুন"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "লগ ইন;নাম;ফিঙ্গারপ্রিন্ট;এভাটার;লোগো;ফেস;পাসওয়ার্ড;"
+
+#~ msgid "Cr_eate"
+#~ msgstr "তৈরি (_e)"
+
+#~ msgid "_Account Type"
+#~ msgstr "একাউন্টের ধরন (_A)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "দৃঢ় পাসওয়ার্ড কিভাবে নির্বাচন করবেন"
+
+#~ msgid ""
+#~ "<small>This hint may be displayed at the login screen.  It will be "
+#~ "visible to all users of this system.  Do <b>not</b> include the password "
+#~ "here.</small>"
+#~ msgstr ""
+#~ "<small>ইঙ্গিতটি লগ ইন স্ক্রীণে প্রদর্শিত হতে পারে। এই সিস্টেমে সব ব্যবহারকারী "
+#~ "দৃশ্যমান হবে। এখানে পাসওয়ার্ড যুক্ত <b>হবেনা।</b></small>"
+
+#~ msgid "Changing password for"
+#~ msgstr "এর জন্য পাসওয়ার্ড পরিবর্তন"
+
+#~ msgid "Disable this account"
+#~ msgstr "একাউন্টটি নিষ্ক্রিয়"
+
+#~ msgid "Enable this account"
+#~ msgstr "একাউন্টটি সক্রিয়"
+
+#~ msgid "Fair"
+#~ msgstr "ন্যায্য"
+
+#~ msgid "Log in without a password"
+#~ msgstr "পাসওয়ার্ড ছাড়া লগইন"
+
+#~ msgid "_Hint"
+#~ msgstr "ইঙ্গিত (_H)"
+
+# Translated by sadia
+#~ msgid "Browse"
+#~ msgstr "ব্রাউজ"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "এর জন্য ফটো পরিবর্তন করা হচ্ছে:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "এই একাউন্টের জন্য এই লগইন স্ক্রীণে যে ছবি দেখানো হবে তা নির্বাচন।"
+
+#~ msgid "Gallery"
+#~ msgstr "গ্যালারি"
+
+#~ msgid "Photograph"
+#~ msgstr "ফটো"
+
+#~ msgid "Take a photograph"
+#~ msgstr "ফটো তুলুন"
+
+#~ msgid "Account Information"
+#~ msgstr "একাউন্টের তথ্য"
+
+#~ msgid "Login Options"
+#~ msgstr "লগইন অপশন"
+
+#~ msgid "Left index finger"
+#~ msgstr "বামহাতের তর্জনি"
+
+# Translated by sadia
+#~ msgid "Left little finger"
+#~ msgstr "বাম হাতের কড়ে আঙুল"
+
+# Translated by sadia
+#~ msgid "Left middle finger"
+#~ msgstr "বামহাতের মধ্যাঙ্গুল"
+
+# Translated by sadia
+#~ msgid "Left ring finger"
+#~ msgstr "বামহাতের অনামিকা"
+
+# Translated by sadia
+#~ msgid "Left thumb"
+#~ msgstr "বাম হাতের বৃদ্ধাঙ্গুলি"
+
+#~ msgid "Right index finger"
+#~ msgstr "ডান হাতের তর্জনি"
+
+# Translated by sadia
+#~ msgid "Right little finger"
+#~ msgstr "ডান হাতের কড়ে আঙুল"
+
+# Translated by sadia
+#~ msgid "Right middle finger"
+#~ msgstr "ডান হাতের মধ্যাঙ্গুল"
+
+# Translated by sadia
+#~ msgid "Right ring finger"
+#~ msgstr "ডান হাতের অনামিকা"
+
+# Translated by sadia
+#~ msgid "Right thumb"
+#~ msgstr "ডান হাতের বৃদ্ধাঙ্গুলি"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "সাফল্যের সাথে আপনার আঙ্গুলের ছাপ সংরক্ষিত হয়েছে। আঙ্গুলের ছাপ রীডার সহযোগে আপনি "
+#~ "এখন লগ-ইন করতে সক্ষম হবেন।"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "ভার্বোজ মোড সক্রিয় করা"
+
+#~ msgid "Show the overview"
+#~ msgstr "সারসংক্ষেপ প্রদর্শন"
+
+#~ msgid "- System Settings"
+#~ msgstr "- সিস্টেমের সেটিং"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Run '%s --বিদ্যমান কমান্ড লাইন অপশনের সম্পূর্ণ তালিকা দেখতে সহায়তা করে।\n"
+
+#~ msgid "System Settings"
+#~ msgstr "সিস্টেমের সেটিং"
+
+#~ msgid "Control Center"
+#~ msgstr "নিয়ন্ত্রণ কেন্দ্র"
 
 #~ msgid "An error has occured during a maintenance command."
 #~ msgstr "কমান্ড রক্ষণাবেক্ষণের সময় ত্রুটি হয়েছে "
@@ -3591,9 +7002,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 
 #~ msgid "The type of alert"
 #~ msgstr "সতর্কবাণীর ধরন"
-
-#~ msgid "Alert Buttons"
-#~ msgstr "সতর্কবাণীর বোতাম"
 
 #~ msgid "The buttons shown in the alert dialog"
 #~ msgstr "সতর্ককারী ডায়ালগে প্রদর্শিত বোতাম"
@@ -3676,17 +7084,11 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "Remove your finger, and try swiping your finger again"
 #~ msgstr "আঙ্গুল সরিয়ে নিন ও পুনরায় তা রেখে সোয়াইপ করার প্রচেষ্টা করুন"
 
-#~ msgid "Select Image"
-#~ msgstr "ছবি বেছে নিন"
-
 #~ msgid "No Image"
 #~ msgstr "কোন ছবি নেই"
 
 #~ msgid "Images"
 #~ msgstr "ছবি"
-
-#~ msgid "All Files"
-#~ msgstr "সকল ফাইল"
 
 #~ msgid ""
 #~ "There was an error while trying to get the addressbook information\n"
@@ -3697,9 +7099,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 
 #~ msgid "Unable to open address book"
 #~ msgstr "ঠিকানা-বই খোলা যায় নি"
-
-#~ msgid "About %s"
-#~ msgstr "%s-এর পরিচিতি"
 
 #~ msgid "A_IM/iChat:"
 #~ msgstr "A_IM/iChat:"
@@ -3781,12 +7180,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "Zip/_Postal code:"
 #~ msgstr "জিপ/পোস্টাল কোড (_P):"
 
-#~ msgid "_Address:"
-#~ msgstr "ঠিকানা (_A):"
-
-#~ msgid "_Department:"
-#~ msgstr "বিভাগ (_D):"
-
 #~ msgid "_Groupwise:"
 #~ msgstr "গ্রুপ অনুসারে: (_G)"
 
@@ -3811,17 +7204,11 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "_Zip/Postal code:"
 #~ msgstr "জিপ/পোস্টাল কোড (_Z):"
 
-#~ msgid "Set your personal information"
-#~ msgstr "আপনার ব্যক্তিগত তথ্য লিখুন"
-
 #~ msgid "Swipe finger on reader"
 #~ msgstr "রিডারের উপর আঙ্গুল সোয়াইপ করুন"
 
 #~ msgid "Place finger on reader"
 #~ msgstr "রিডারের উপর আঙ্গুল রাখুন"
-
-#~ msgid "Select finger"
-#~ msgstr "আঙ্গুল বেছে নিন"
 
 #~ msgid "Child exited unexpectedly"
 #~ msgstr "চাইল্ড অপ্রত্যাশিতরূপে বন্ধ হয়ে গেছে"
@@ -3855,9 +7242,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgstr ""
 #~ "অনুগ্রহ করে <b>নতুন পাসওয়ার্ড পুনরায় লিখুন</b> শীর্ষক ক্ষেত্রে পাসওয়ার্ড পুনরায় লিখুন।"
 
-#~ msgid "Change pa_ssword"
-#~ msgstr "পাসওয়ার্ড পরিবর্তন (_s)"
-
 # Translated by sadia
 #~ msgid "Change your password"
 #~ msgstr "আপনার পাসওয়ার্ড পরিবর্তন করুন"
@@ -3872,12 +7256,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ "<b>অনুমোদন</b> এ ক্লিক করুন।\n"
 #~ "অনুমোদিত হলে, নতুন পাসওয়ার্ড লিখুন, সুনিশ্চিত করার জন্য পুনরায় পাসওয়ার্ড লিখে, "
 #~ "<b>পাসওয়ার্ড পরিবর্তন</b> এ ক্লিক করুন।"
-
-#~ msgid "_Authenticate"
-#~ msgstr "অনুমোদন (_A)"
-
-#~ msgid "Accessible Lo_gin"
-#~ msgstr "ব্যবহারযোগ্য লগ-ইন (_g)"
 
 #~ msgid "Assistive Technologies"
 #~ msgstr "সহায়ক প্রযুক্তি"
@@ -3907,15 +7285,8 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "Jump to the Mouse Accessibility dialog"
 #~ msgstr "মাউস সহায়ক প্রযুক্তি ডায়ালগে যান"
 
-# Translated by sadia
-#~ msgid "Preferences"
-#~ msgstr "পছন্দসমূহ"
-
 #~ msgid "_Enable assistive technologies"
 #~ msgstr "সহায়ক প্রযুক্তি সক্রিয় করুন (_E)"
-
-#~ msgid "_Mouse Accessibility"
-#~ msgstr "মাউস ব্যবহারের সহায়ক প্রযুক্তি (_M)"
 
 #~ msgid "_Preferred Applications"
 #~ msgstr "পছন্দের অ্যাপ্লিকেশন (_P)"
@@ -3923,9 +7294,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "Choose which accessibility features to enable when you log in"
 #~ msgstr ""
 #~ "লগ-ইন করার সময়, বিশেষ ব্যবহারের কোনো ব্যবস্থাগুলি সক্রিয় করা হবে তা নির্বাচন করুন"
-
-#~ msgid "All files"
-#~ msgstr "সর্বধরনের ফাইল"
 
 #~ msgid "Font may be too large"
 #~ msgstr "ফন্টটি সম্ভবত অত্যধিক বড়"
@@ -3975,9 +7343,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 
 #~ msgid "[WALLPAPER...]"
 #~ msgstr "[WALLPAPER...]"
-
-#~ msgid "Install"
-#~ msgstr "ইনস্টল করুন"
 
 #~ msgid ""
 #~ "This theme will not look as intended because the required GTK+ theme "
@@ -4041,23 +7406,11 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "Changing your cursor theme takes effect the next time you log in."
 #~ msgstr "কার্সারের থিম পরিবর্তন করা হলে, পরবর্তী লগ-ইনের পরে তা প্রয়োগ করা হবে।"
 
-#~ msgid "Colors"
-#~ msgstr "রং"
-
-#~ msgid "Controls"
-#~ msgstr "নিয়ন্ত্রণ"
-
 #~ msgid "Customize Theme"
 #~ msgstr "স্বনির্ধারিত থিম"
 
-#~ msgid "D_etails..."
-#~ msgstr "বিবরণ...(_e)"
-
 #~ msgid "Des_ktop font:"
 #~ msgstr "ডেস্কটপে ব্যবহৃত ফন্ট (_k):"
-
-#~ msgid "Font Rendering Details"
-#~ msgstr "ফন্ট আঁকার খুঁটিনাটি"
 
 # Translated by sadia
 #~ msgid "Get more backgrounds online"
@@ -4126,9 +7479,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "Window Border"
 #~ msgstr "উইন্ডোর সীমানা"
 
-#~ msgid "_Add..."
-#~ msgstr "যোগ করুন... (_A)"
-
 #~ msgid "_BGR"
 #~ msgstr "_BGR"
 
@@ -4141,21 +7491,11 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "_Fixed width font:"
 #~ msgstr "নির্দিষ্ট প্রস্থবিশিষ্ট ফন্ট (_F):"
 
-#~ msgid "_Medium"
-#~ msgstr "মাঝারি (_M)"
-
 #~ msgid "_Monochrome"
 #~ msgstr "সাদা-কালো (_M)"
 
-#~ msgid "_None"
-#~ msgstr "শূণ্য (_N)"
-
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
-
-# FIXME
-#~ msgid "_Reset to Defaults"
-#~ msgstr "ডিফল্ট মান পুনরায় স্থাপন (_R)"
 
 #~ msgid "_Selected items:"
 #~ msgstr "নির্বাচিত আইটেম (_S):"
@@ -4166,9 +7506,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "_Slight"
 #~ msgstr "স্বল্প (_S)"
 
-#~ msgid "_Style:"
-#~ msgstr "বিন্যাস (_S):"
-
 #~ msgid "_Tooltips:"
 #~ msgstr "টুল-টিপ (_T):"
 
@@ -4177,9 +7514,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 
 #~ msgid "_Window title font:"
 #~ msgstr "উইন্ডোর শিরোনামে ব্যবহৃত ফন্ট (_W):"
-
-#~ msgid "_Windows:"
-#~ msgstr "উইন্ডোজ (_W):"
 
 #~ msgid "dots per inch"
 #~ msgstr "প্রতি ইঞ্চিতে ডটের সংখ্যা"
@@ -4322,14 +7656,8 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "Copying '%s'"
 #~ msgstr " '%s'-কে অনুলিপি করা হচ্ছে"
 
-#~ msgid "Parent Window"
-#~ msgstr "প্যারেন্ট উইন্ডো"
-
 #~ msgid "Parent window of the dialog"
 #~ msgstr "বর্তমান ডায়লগের প্যারেন্ট উইন্ডো"
-
-#~ msgid "From URI"
-#~ msgstr "URI থেকে"
 
 #~ msgid "URI currently transferring from"
 #~ msgstr "URI থেকে বর্তমানে স্থানান্তরিত হচ্ছে"
@@ -4339,9 +7667,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 
 #~ msgid "URI currently transferring to"
 #~ msgstr "URI-এ বর্তমানে স্থানান্তরিত হচ্ছে"
-
-#~ msgid "Fraction completed"
-#~ msgstr "আংশিক সম্পন্ন"
 
 # FIXME: ভাল শোনাচ্ছে না ;-(
 #~ msgid "Fraction of transfer currently completed"
@@ -4373,9 +7698,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "Default Pointer - Current"
 #~ msgstr "ডিফল্ট পয়েন্টার - বর্তমানে যেটি ব্যবহৃত হচ্ছে"
 
-#~ msgid "White Pointer"
-#~ msgstr "সাদা পয়েন্টার"
-
 #~ msgid "White Pointer - Current"
 #~ msgstr "সাদা পয়েন্টার - বর্তমানে যেটি ব্যবহৃত হচ্ছে"
 
@@ -4384,9 +7706,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 
 #~ msgid "Large White Pointer - Current"
 #~ msgstr "বড় সাদা পয়েন্টার - বর্তমানে যেটি ব্যবহৃত হচ্ছে"
-
-#~ msgid "Large White Pointer"
-#~ msgstr "বড় সাদা পয়েন্টার"
 
 #~ msgid ""
 #~ "This theme will not look as intended because the required GTK+ theme '%s' "
@@ -4428,9 +7747,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid ""
 #~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
 #~ msgstr "প্রদর্শনযোগ্য পৃষ্ঠার নাম উল্লেখ করুন (internet|multimedia|system|a11y)"
-
-#~ msgid "Accessibility"
-#~ msgstr "সহায়ক প্রযুক্তি"
 
 # FIXME
 #~ msgid "All %s occurrences will be replaced with actual link"
@@ -4484,9 +7800,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 #~ msgid "Text Editor"
 #~ msgstr "টেক্সট সম্পাদক "
 
-#~ msgid "_Run at start"
-#~ msgstr "প্রারম্ভে সঞ্চালিত হবে (_R)"
-
 #~ msgid "Balsa"
 #~ msgstr "বালসা"
 
@@ -4517,9 +7830,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 
 #~ msgid "GNOME Magnifier without Screen Reader"
 #~ msgstr "পর্দার তথ্যে পাঠের ব্যবস্থা বিহীন GNOME বিবর্ধক"
-
-#~ msgid "GNOME Terminal"
-#~ msgstr "GNOME টার্মিনাল"
 
 #~ msgid "Gnopernicus"
 #~ msgstr "Gnopernicus"
@@ -4601,9 +7911,6 @@ msgstr "সহায়তা সংক্রান্ত অপশন প্রদ
 
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "Sylpheed-Claws"
-
-#~ msgid "Thunderbird"
-#~ msgstr "থান্ডারবার্ড"
 
 #~ msgid "Totem Movie Player"
 #~ msgstr "টটেম চলচ্চিত্র বাদন ব্যবস্থা"

--- a/po/bn.po~
+++ b/po/bn.po~
@@ -1,0 +1,4615 @@
+# Bangla Translation of the Gnome Control Center po file.
+# Copyright (c)  2003-2006 Free Software Foundation, Inc.
+# This file is distributed under the same license as the Gnome Control Center package.
+# 
+# Progga <progga@BengaLinux.Org>, 2003-2006.
+# Runa Bhattacharjee <runabh@gmail.com>, 2006, 2007.
+# Runa Bhattacharjee <runab@redhat.com>, 2008, 2009.
+# Maruf Ovee <maruf@ankur.org.bd>, 2009.
+# Sadia Afroz <sadia@ankur.org.bd>, 2010.
+# Israt Jahan <israt@ankur.org.bd>, 2010.
+# Zenat Rahnuma <zenat@ankur.org.bd>, 2011.
+# 
+msgid ""
+msgstr ""
+"Project-Id-Version: bn\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2011-04-04 09:11+0000\n"
+"PO-Revision-Date: 2011-04-04 15:55+0600\n"
+"Last-Translator: Zenat Rahnuma <zenat@ankur.org.bd>\n"
+"Language-Team: Bengali <ankur-bd-l10n@googlegroups.com>\n"
+"Language: bn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Translate Toolkit 1.3.0\n"
+"X-Language: bn_BD\n"
+
+#: ../gnome-control-center.schemas.in.h:1
+msgid "Current network location"
+msgstr "বর্তমান নেটওয়ার্কের অবস্থান"
+
+# Translated by sadia
+#: ../gnome-control-center.schemas.in.h:2
+msgid "More backgrounds URL"
+msgstr "আরও পটভূমির ইউআরএল"
+
+# Translated by sadia
+#: ../gnome-control-center.schemas.in.h:3
+msgid "More themes URL"
+msgstr "আরও থিমের ইউআরএল"
+
+# Translated by sadia
+#: ../gnome-control-center.schemas.in.h:4
+msgid ""
+"Set this to your current location name. This is used to determine the "
+"appropriate network proxy configuration."
+msgstr ""
+"এটাকে আপনার বর্তমান অবস্থান হিসেবে নির্ধারণ করুন। যথার্থ নেটওয়ার্কের প্রক্সি "
+"কনফিগারেশন নিরূপন করতে এটি ব্যবহৃত হয়।"
+
+# Translated by sadia
+#: ../gnome-control-center.schemas.in.h:5
+msgid ""
+"URL for where to get more desktop backgrounds. If set to an empty string the "
+"link will not appear."
+msgstr ""
+"আরও ডেক্সটপ পটভূমি যেখানে পাওয়া যাবে তার ইউআরএল। যদি ফাঁকা স্ট্রিং হিসেবে নির্ধারণ "
+"করা থাকে তবে লিংকটি দৃশ্যমান হবে না।"
+
+# Translated by sadia
+#: ../gnome-control-center.schemas.in.h:6
+msgid ""
+"URL for where to get more desktop themes. If set to an empty string the link "
+"will not appear."
+msgstr ""
+"আরও ডেক্সটপ থিম যেখানে পাওয়া যাবে তার ইউআরএল। যদি ফাঁকা স্ট্রিং হিসেবে নির্ধারণ "
+"করা থাকে তবে লিংকটি দৃশ্যমান হবে না।"
+
+#: ../libgnome-control-center/cc-lockbutton.c:347
+#: ../panels/screen/screen.ui.h:14
+msgid "Lock"
+msgstr "আবদ্ধ"
+
+#: ../libgnome-control-center/cc-lockbutton.c:356
+#: ../panels/network/network.ui.h:20
+msgid "Unlock"
+msgstr "অনাবদ্ধ"
+
+#: ../libgnome-control-center/cc-lockbutton.c:365
+msgid "Locked"
+msgstr "আবদ্ধ"
+
+#: ../libgnome-control-center/cc-lockbutton.c:374
+msgid ""
+"Dialog is unlocked.\n"
+"Click to prevent further changes"
+msgstr ""
+"সংলাপ অনাবদ্ধ।\n"
+"আরও পরিবর্তন প্রতিরোধ করতে ক্লিক"
+
+#: ../libgnome-control-center/cc-lockbutton.c:383
+msgid ""
+"Dialog is locked.\n"
+"Click to make changes"
+msgstr ""
+"সংলাপ আবদ্ধ।\n"
+"পরিবর্তন করতে ক্লিক"
+
+#: ../libgnome-control-center/cc-lockbutton.c:392
+msgid ""
+"System policy prevents changes.\n"
+"Contact your system administrator"
+msgstr ""
+"সিস্টেমের নীতিমালা পরিবর্তন প্রতিরোধ করে।\n"
+"আপনার সিস্টেম প্রশাসকের সাথে যোগাযোগ করুন"
+
+#: ../libgnome-control-center/gconf-property-editor.c:134
+msgid "Key"
+msgstr "কী"
+
+#: ../libgnome-control-center/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr "যে GConf কী এর সাথে এই বৈশিষ্ট্যনির্ধারণী সম্পাদক যুক্ত আছে"
+
+#: ../libgnome-control-center/gconf-property-editor.c:141
+msgid "Callback"
+msgstr "কলব্যাক"
+
+#: ../libgnome-control-center/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "কী এর সাথে যুক্ত মান পরিবর্তিত হলে এই কলব্যাক উৎপন্ন হবে"
+
+#: ../libgnome-control-center/gconf-property-editor.c:147
+msgid "Change set"
+msgstr "নির্ধারণ পরিবর্তন"
+
+#: ../libgnome-control-center/gconf-property-editor.c:148
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr "GConf নির্ধারণ পরিবর্তনে ধারণকৃত ডাটা gconf ক্লায়েন্টে প্রয়োগ করতে ফরওয়ার্ড"
+
+#: ../libgnome-control-center/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr "উইজেট কলব্যাকে রূপান্তর"
+
+#: ../libgnome-control-center/gconf-property-editor.c:154
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "তথ্যকে GConf থেকে উইজেটে রূপান্তরের সময় যে কলব্যাকটি ব্যবহৃত হবে"
+
+#: ../libgnome-control-center/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr "উইজেট কলব্যাক থেকে রূপান্তর"
+
+#: ../libgnome-control-center/gconf-property-editor.c:160
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr "তথ্যকে উইজেট থেকে GConf এ রূপান্তরের সময় যে কলব্যাকটি ব্যবহৃত হবে"
+
+#: ../libgnome-control-center/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "UI নিয়ন্ত্রণ"
+
+#: ../libgnome-control-center/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr "বৈশিষ্ট্য নির্ধারণী অবজেক্ট (সাধারণত এটি একটি উইজেট)"
+
+#: ../libgnome-control-center/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr "বৈশিষ্ট্য নির্ধারণী সম্পাদকের অবজেক্টবিষয়ক তথ্য"
+
+#: ../libgnome-control-center/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr "বৈশিষ্ট্য নির্ধারণী সম্পাদকের প্রয়োজনীয় স্বনির্বাচিত তথ্য"
+
+#: ../libgnome-control-center/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr "বৈশিষ্ট্য নির্ধারণী সম্পাদকের তথ্য কলব্যাকের ওপর থেকে নিয়ন্ত্রণ প্রত্যাহার করছে"
+
+#: ../libgnome-control-center/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"বৈশিষ্ট্য নির্ধারণী সম্পাদকের অবজেক্টবিষয়ক তথ্যের ওপর থেকে নিয়ন্ত্রণ প্রত্যাহারের সময় "
+"যে কলব্যাকটি ব্যবহৃত হবে"
+
+#: ../libgnome-control-center/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"'%s' নামক ফাইলটি পাওয়া যাচ্ছে না।\n"
+"\n"
+"দয়া করে নিশ্চিত হোন যে ফাইলটি আসলেই আছে কিনা এবং তারপর আবার চেষ্টা করুন, অথবা "
+"পটভূমির জন্য অন্য কোন ছবি বেছে নিন।"
+
+#: ../libgnome-control-center/gconf-property-editor.c:1482
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"'%s' ফাইলটি পড়তে পারছি না।\n"
+"সম্ভবত এখনো এ ধরনের ছবি ব্যবহারের ব্যবস্থা নেই।\n"
+"\n"
+"অনুগ্রহপূর্বক অন্য একটি ছবি বেছে নিন।"
+
+#: ../libgnome-control-center/gconf-property-editor.c:1604
+msgid "Please select an image."
+msgstr "অনুগ্রহপূর্বক একটি ছবি বেছে নিন।"
+
+#: ../libgnome-control-center/gconf-property-editor.c:1609
+msgid "_Select"
+msgstr "নির্বাচন (_S)"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "পটভূমি"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change the background"
+msgstr "পটভূমির ছবি সংরক্ষণ"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "ওয়ালপেপার;স্ক্রীন;ডেস্কটপ;"
+
+# Translated by sadia
+#: ../panels/background/background.ui.h:1
+msgid "Center"
+msgstr "কেন্দ্র"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "সারা দিনের পরিবর্তন"
+
+#: ../panels/background/background.ui.h:4
+msgid "Fill"
+msgstr "সম্পূর্ণ"
+
+# Translated by sadia
+#: ../panels/background/background.ui.h:5
+msgid "Scale"
+msgstr "স্কেল"
+
+#: ../panels/background/background.ui.h:6
+msgid "Span"
+msgstr "স্প্যান"
+
+# Translated by sadia
+#: ../panels/background/background.ui.h:7
+msgid "Tile"
+msgstr "টালি "
+
+#: ../panels/background/background.ui.h:8
+msgid "Zoom"
+msgstr "বড় আকারে প্রদর্শন"
+
+#: ../panels/background/bg-colors-source.c:46
+msgid "Horizontal Gradient"
+msgstr "অনুভূমিক গ্র্যাডিয়েন্ট"
+
+#: ../panels/background/bg-colors-source.c:47
+msgid "Vertical Gradient"
+msgstr "উল্লম্ব গ্রেডিয়েন্ট"
+
+#: ../panels/background/bg-colors-source.c:48
+msgid "Solid Color"
+msgstr "নিরেট রং"
+
+#: ../panels/background/cc-background-panel.c:958
+#: ../panels/user-accounts/um-photo-dialog.c:217
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+msgid "Browse for more pictures"
+msgstr "আরো ছবির জন্য ব্রাউজ"
+
+# Translated by sadia
+#: ../panels/background/cc-background-panel.c:1049
+msgid "Current background"
+msgstr "বর্তমানের পটভূমি"
+
+#: ../panels/background/cc-background-panel.c:1133
+msgid "Wallpapers"
+msgstr "ওয়াল-পেপার"
+
+#: ../panels/background/cc-background-panel.c:1140
+msgid "Pictures Folder"
+msgstr "ছবির ফোল্ডার"
+
+#: ../panels/background/cc-background-panel.c:1147
+msgid "Colors & Gradients"
+msgstr "রং এবং গ্রেডিয়েন্ট"
+
+#: ../panels/background/cc-background-panel.c:1155
+msgid "Flickr"
+msgstr "ফ্লিকার"
+
+# Translated by sadia
+#: ../panels/background/cc-background-item.c:148
+msgid "multiple sizes"
+msgstr "বিভিন্ন আকার"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:152
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:281
+msgid "No Desktop Background"
+msgstr "ডেস্কটপের কোনো পটভূমি প্রয়োগ করা হবে না"
+
+#: ../panels/common/gdm-languages.c:709
+msgid "Unspecified"
+msgstr "উল্লেখিত নয়"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "24-Hour Time"
+msgstr "২৪ ঘন্টা সময়"
+
+#. Translator: this is the separator between hours and minutes, like in HH:MM
+#: ../panels/datetime/datetime.ui.h:3
+msgid ":"
+msgstr ":"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "এপ্রিল"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "August"
+msgstr "আগস্ট"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "City:"
+msgstr "শহর:"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "December"
+msgstr "ডিসেম্বর"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "February"
+msgstr "ফেব্রুয়ারি"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "January"
+msgstr "জানুয়ারি"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "July"
+msgstr "জুলাই"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "June"
+msgstr "জুন"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "March"
+msgstr "মার্চ"
+
+#: ../panels/datetime/datetime.ui.h:13
+msgid "May"
+msgstr "মে"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Network Time"
+msgstr "নেটওয়ার্ক সময়"
+
+#: ../panels/datetime/datetime.ui.h:15
+msgid "November"
+msgstr "নভেম্বর"
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "October"
+msgstr "অক্টোবর"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Region:"
+msgstr "অঞ্চল:"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "September"
+msgstr "সেপ্টেম্বর"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Clock;Timezone;Location;"
+msgstr "ঘড়ি;টাইম জোন;অবস্থান;"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+msgid "Date and Time"
+msgstr "তারিখ ও সময়"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Date and Time preferences panel"
+msgstr "তারিখ ও সময় পছন্দ করার প্যানেল"
+
+#: ../panels/display/display-capplet.ui.h:1
+msgid "Left"
+msgstr "বাম"
+
+# Translated by sadia
+#: ../panels/display/display-capplet.ui.h:2
+#: ../panels/display/xrandr-capplet.c:491
+msgid "Monitor"
+msgstr "মনিটর "
+
+#: ../panels/display/display-capplet.ui.h:3
+#: ../panels/display/xrandr-capplet.c:327
+#: ../panels/display/xrandr-capplet.c:366
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Normal"
+msgstr "স্বাভাবিক"
+
+#: ../panels/display/display-capplet.ui.h:4
+msgid "Note: may limit resolution options"
+msgstr "মনে রাখবেন: রেজল্যুশন অপশনের সীমা দিতে পারে"
+
+#: ../panels/display/display-capplet.ui.h:5
+msgid "R_otation:"
+msgstr "আবর্তন (_o): "
+
+#: ../panels/display/display-capplet.ui.h:6
+msgid "Right"
+msgstr "ডানদিকে"
+
+#: ../panels/display/display-capplet.ui.h:7
+msgid "Upside-down"
+msgstr "উল্টো"
+
+#: ../panels/display/display-capplet.ui.h:8
+msgid "_Detect Displays"
+msgstr "প্রদর্শন সনাক্ত (_D)"
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:10
+msgid "_Mirror displays"
+msgstr "পর্দার অনুলিপি তৈরি করা হবে (_M)"
+
+#: ../panels/display/display-capplet.ui.h:11
+msgid "_Resolution:"
+msgstr "রেজল্যুশন (_R):"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Change resolution and position of monitors and projectors"
+msgstr "মনিটর এবং প্রজেক্টরের রেজল্যুশন ও অবস্থান পরিবর্তন"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Displays"
+msgstr "প্রদর্শন"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr "প্যানেল;প্রজেক্টর,xrandr;স্ক্রীন,রেজল্যুশন;রিফ্রেশ;"
+
+#: ../panels/display/xrandr-capplet.c:328
+msgid "Counterclockwise"
+msgstr "বামাবর্তী"
+
+#: ../panels/display/xrandr-capplet.c:329
+msgid "Clockwise"
+msgstr "দক্ষিণাবর্তে"
+
+#: ../panels/display/xrandr-capplet.c:330
+msgid "180 Degrees"
+msgstr "১৮০ ডিগ্রী"
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../panels/display/xrandr-capplet.c:467
+msgid "Mirror Displays"
+msgstr "মিরর প্রদর্শন "
+
+#: ../panels/display/xrandr-capplet.c:597
+#, c-format
+msgid "%d x %d (%s)"
+msgstr "%d x %d (%s)"
+
+#: ../panels/display/xrandr-capplet.c:599
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#: ../panels/display/xrandr-capplet.c:1510
+msgid "Drag to change primary display."
+msgstr "প্রাথমিক প্রদর্শন পরিবর্তন করতে টানুন।"
+
+#: ../panels/display/xrandr-capplet.c:1568
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr ""
+"মনিটরের বৈশিষ্ট্য পরিবর্তন করতে নির্বাচন করুন; এর অবস্থান পুনরায় নির্ধারণ করতে টেনে "
+"আনুন।"
+
+#: ../panels/display/xrandr-capplet.c:1957
+msgid "%a %R"
+msgstr "%a %R"
+
+#: ../panels/display/xrandr-capplet.c:1959
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../panels/display/xrandr-capplet.c:2205
+msgid "Could not save the monitor configuration"
+msgstr "মনিটর সংক্রান্ত কনফিগারেশন সংরক্ষণ করতে ব্যর্থ"
+
+#: ../panels/display/xrandr-capplet.c:2230
+msgid "Could not get session bus while applying display configuration"
+msgstr "ডিসপ্লে কনফিগারেশন প্রয়োগ করার সময় সেশন বাস পাওয়া যায়নি"
+
+#: ../panels/display/xrandr-capplet.c:2275
+msgid "Could not detect displays"
+msgstr "ডিসপ্লে সনাক্ত করতে ব্যর্থ"
+
+#: ../panels/display/xrandr-capplet.c:2470
+msgid "Could not get screen information"
+msgstr "পর্দা সংক্রান্ত পরিবর্তন পাওয়া যায়নি"
+
+#. Translators: VESA is an techncial acronym, don't translate it.
+#: ../panels/info/cc-info-panel.c:366
+#, c-format
+msgid "VESA: %s"
+msgstr "VESA: %s"
+
+#. TRANSLATORS: device type
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:390 ../panels/network/panel-common.c:79
+#: ../panels/network/panel-common.c:158
+msgid "Unknown"
+msgstr "অজ্ঞাত"
+
+#. translators: This is the type of architecture, for example:
+#. * "64-bit" or "32-bit"
+#: ../panels/info/cc-info-panel.c:528
+#, c-format
+msgid "%d-bit"
+msgstr "%d-bit"
+
+#: ../panels/info/cc-info-panel.c:542
+#, c-format
+msgid "%u byte"
+msgid_plural "%u bytes"
+msgstr[0] "%u byte"
+msgstr[1] "%u bytes"
+
+#: ../panels/info/cc-info-panel.c:550
+#, c-format
+msgid "%.1f KB"
+msgstr "%.1f KB"
+
+#: ../panels/info/cc-info-panel.c:555
+#, c-format
+msgid "%.1f MB"
+msgstr "%.1f MB"
+
+#: ../panels/info/cc-info-panel.c:560
+#, c-format
+msgid "%.1f GB"
+msgstr "%.1f GB"
+
+#: ../panels/info/cc-info-panel.c:565
+#, c-format
+msgid "%.1f TB"
+msgstr "%.1f TB"
+
+#: ../panels/info/cc-info-panel.c:570
+#, c-format
+msgid "%.1f PB"
+msgstr "%.1f PB"
+
+#: ../panels/info/cc-info-panel.c:575
+#, c-format
+msgid "%.1f EB"
+msgstr "%.1f EB"
+
+#: ../panels/info/cc-info-panel.c:686
+msgid "Unknown model"
+msgstr "অজ্ঞাত মডেল"
+
+#: ../panels/info/cc-info-panel.c:769
+msgid "The next login will attempt to use the standard experience."
+msgstr "আদর্শ অভিজ্ঞতা ব্যবহারের জন্য পরবর্তী লগইনের প্রচেষ্টা।"
+
+#: ../panels/info/cc-info-panel.c:771
+msgid ""
+"The next login will use the fallback mode intended for unsupported graphics "
+"hardware."
+msgstr ""
+"অসমর্থিত গ্রাফিক্স হার্ডওয়্যারের জন্য পরবর্তী লগইন উদ্দেশ্যকৃত ফলব্যাক মোড ব্যবহার করবে"
+
+#. translators: The hardware is not able to run GNOME 3's
+#. * shell, so we use the GNOME "Fallback" session
+#: ../panels/info/cc-info-panel.c:813
+msgctxt "Experience"
+msgid "Fallback"
+msgstr "ফলব্যাক"
+
+#. translators: The hardware is able to run GNOME 3's
+#. * shell, also called "Standard" experience
+#: ../panels/info/cc-info-panel.c:819
+msgctxt "Experience"
+msgid "Standard"
+msgstr "আদর্শ"
+
+#: ../panels/info/cc-info-panel.c:951
+#: ../panels/keyboard/keyboard-shortcuts.c:1712
+msgid "Section"
+msgstr "অংশ"
+
+#: ../panels/info/cc-info-panel.c:960 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "সারসংক্ষেপ"
+
+#: ../panels/info/cc-info-panel.c:966 ../panels/info/info.ui.h:2
+msgid "Default Applications"
+msgstr "পূর্বনির্ধারিত অ্যাপ্লিকেশন"
+
+#: ../panels/info/cc-info-panel.c:971 ../panels/info/info.ui.h:9
+msgid "Graphics"
+msgstr "গ্রাফিক্স"
+
+#: ../panels/info/cc-info-panel.c:996
+#, c-format
+msgid "Version %s"
+msgstr "সংস্করণ %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+msgid "System Info"
+msgstr "সিস্টেমের তথ্য"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "System Information"
+msgstr "সিস্টেমের তথ্য"
+
+#. Translators: those are keywords for the System Information panel
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;"
+msgstr "ডিভাইস;সিস্টেম;তথ্য;মেমরি;প্রসেসর;সংস্করণ;পূর্বনির্ধারিত;অ্যাপ্লিকেশন;ফলব্যাক;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Calendar"
+msgstr "ক্যালেন্ডার"
+
+#: ../panels/info/info.ui.h:3
+msgid "Device name"
+msgstr "ডিভাইসের নাম"
+
+#: ../panels/info/info.ui.h:4
+msgid "Disk"
+msgstr "ডিস্ক"
+
+#: ../panels/info/info.ui.h:5
+msgid "Driver"
+msgstr "ড্রাইভার"
+
+#: ../panels/info/info.ui.h:6
+msgid "Experience"
+msgstr "অভিজ্ঞতা"
+
+#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
+#: ../panels/info/info.ui.h:8
+msgid "Forced Fallback Mode"
+msgstr "ফলব্যাক মোডে বাধ্য"
+
+#: ../panels/info/info.ui.h:10
+msgid "Mail"
+msgstr "মেইল"
+
+#: ../panels/info/info.ui.h:11
+msgid "Memory"
+msgstr "মেমরি"
+
+#: ../panels/info/info.ui.h:12
+msgid "Music"
+msgstr "গান"
+
+#: ../panels/info/info.ui.h:13
+msgid "OS type"
+msgstr "OS এর ধরন"
+
+#: ../panels/info/info.ui.h:15
+msgid "Photos"
+msgstr "ছবি"
+
+#: ../panels/info/info.ui.h:16
+msgid "Processor"
+msgstr "প্রসেসর"
+
+#: ../panels/info/info.ui.h:17
+msgid "Updates Available"
+msgstr "হালনাগাদ বিদ্যমান"
+
+#: ../panels/info/info.ui.h:18
+msgid "Video"
+msgstr "ভিডিও"
+
+# Translated by sadia
+#: ../panels/info/info.ui.h:19
+msgid "Web"
+msgstr "ওয়েব"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Eject"
+msgstr "নির্গত"
+
+# Translated by sadia
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Launch media player"
+msgstr "মিডিয়া প্লেয়ার চালুকরণ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Next track"
+msgstr "পরবর্তী ট্র্যাক"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Pause playback"
+msgstr "পুনরায় চালানো বিরতি"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Play (or play/pause)"
+msgstr "চালান (অথবা চালান/বিরতি)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Previous track"
+msgstr "পূর্ববর্তী  ট্র্যাক"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Sound and Media"
+msgstr "শব্দ এবং মিডিয়া"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "পুনরায় চালানো বন্ধ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Volume down"
+msgstr "ভলিউম কমানো"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Volume mute"
+msgstr "ভলিউম নিঃশব্দ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Volume up"
+msgstr "ভলিউম বাড়ানো"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Home folder"
+msgstr "প্রধান ফোল্ডার"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch calculator"
+msgstr "ক্যালকুলেটর চালুকরণ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3
+msgid "Launch email client"
+msgstr "ইমেইল ক্লায়েন্ট চালুকরণ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch help browser"
+msgstr "সহায়তা ব্রাউজার চালুকরণ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch web browser"
+msgstr "ওয়েব ব্রাউজার চালুকরণ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launchers"
+msgstr "লঞ্চার"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Search"
+msgstr "সন্ধান"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "Lock screen"
+msgstr "স্ক্রীন আবদ্ধ"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "লগআউট"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "System"
+msgstr "সিস্টেম"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+msgid "Decrease text size"
+msgstr "টেক্সটের আকার কমানো"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Increase text size"
+msgstr "টেক্সটের আকার বাড়ানো"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Magnifier zoom in"
+msgstr "বড় আকারে প্রদর্শনের বিবর্ধনযন্ত্র"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Magnifier zoom out"
+msgstr "ছোট আকারে প্রদর্শনের বিবর্ধনযন্ত্র"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Toggle contrast"
+msgstr "টগল বৈসাদৃশ্য"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Toggle magnifier"
+msgstr "টগল বিবর্ধনযন্ত্র"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Toggle on-screen keyboard"
+msgstr "টগল স্ক্রীণে কি-বোর্ড"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Toggle screen reader"
+msgstr "লিনাক্স স্ক্রীণ রিডার"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
+msgid "Universal Access"
+msgstr "সর্বজনীনে প্রবেশ"
+
+# FIXME
+#: ../panels/keyboard/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr "নতুন শর্টকাট..."
+
+#: ../panels/keyboard/eggcellrendererkeys.c:164
+#: ../panels/keyboard/eggcellrendererkeys.c:165
+msgid "Accelerator key"
+msgstr "এক্সিলেটর কী"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:174
+#: ../panels/keyboard/eggcellrendererkeys.c:175
+msgid "Accelerator modifiers"
+msgstr "এক্সিলেটর পরিবর্তক"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:183
+#: ../panels/keyboard/eggcellrendererkeys.c:184
+msgid "Accelerator keycode"
+msgstr "এক্সিলেটর কীকোড"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:194
+msgid "Accel Mode"
+msgstr "এক্সেল মোড"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:195
+msgid "The type of accelerator."
+msgstr "এক্সিলেটর কী-এর ধরন।"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/eggcellrendererkeys.c:243
+#: ../panels/keyboard/keyboard-shortcuts.c:1153
+#: ../panels/sound/gvc-mixer-control.c:1084
+#: ../panels/user-accounts/um-fingerprint-dialog.c:177
+#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+msgid "Disabled"
+msgstr "নিষ্ক্রিয়"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Change keyboard settings"
+msgstr "কীবোর্ড সেটিং পরিবর্তন"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "Keyboard"
+msgstr "কীবোর্ড"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "শর্টকাট;পুনরাবৃত্ত করা;মিটিমিটি জ্বলা;"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:646
+#: ../panels/keyboard/keyboard-shortcuts.c:928
+#: ../panels/keyboard/keyboard-shortcuts.c:1506
+#: ../panels/keyboard/keyboard-shortcuts.c:1510
+msgid "Custom Shortcuts"
+msgstr "স্বনির্ধারিত শর্ট-কাট"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:780
+msgid "<Unknown Action>"
+msgstr "<অজানা কাজ>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1179
+msgid "Error saving the new shortcut"
+msgstr "নতুন শর্ট-কাট সংরক্ষণে সমস্যা"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1292
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"শর্টকাট-কি হিসেবে \"%s\" ব্যবহার করা যাবে না কারণ এর ফলে এই কী ব্যবহার করে কিছু "
+"টাইপ করা যাবে না।\n"
+"অনুগ্রহ করে Control, Alt বা Shift কী-এর একসাথে ব্যবহারের চেষ্টা করুন।"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1322
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"শর্টকাট \"%s\" বর্তমানে\n"
+"\"%s\"-র জন্য ব্যবহৃত হচ্ছে"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1327
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "\"%s\"-এ শর্ট-কাট স্থাপন করা হলে, \"%s\" শর্ট-কাটটি নিষ্ক্রিয় করা হবে।"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1333
+msgid "_Reassign"
+msgstr "পুনরায় নির্ধারণ (_R)"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1445
+msgid "Too many custom shortcuts"
+msgstr "অত্যাধিক স্বনির্ধারিত শর্ট-কাট"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1765
+msgid "Action"
+msgstr "কাজ"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1788
+msgid "Shortcut"
+msgstr "শর্টকাট"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "C_ommand:"
+msgstr "কমান্ড (_o): "
+
+# Translated by sadia
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "Cursor Blinking"
+msgstr "কার্সার জ্বলছে-নিভছে "
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "Cursor _blinks in text fields"
+msgstr "টেক্সট লেখার ক্ষেত্রে কার্সার ঝলকাবে (_b)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Cursor blinks speed"
+msgstr "কার্সার জ্বলানেভার গতি"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "Custom Shortcut"
+msgstr "স্বনির্ধারিত শর্ট-কাট"
+
+# Translated by sadia
+#. fast acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "Fast"
+msgstr "দ্রুত"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "General"
+msgstr "সাধারণ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "Key presses _repeat when key is held down"
+msgstr "কী চেপে ধরে রাখলে অনবরত লেখা হবে (_r)"
+
+# Translated by sadia
+#. long delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Long"
+msgstr "দীর্ঘ"
+
+# Translated by sadia
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgid "Repeat Keys"
+msgstr "পুনরাবৃত্তি কী "
+
+# FIXME
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "কী পুনরাবৃত্তির গতি"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgid "S_peed:"
+msgstr "গতি (_p):"
+
+# Translated by sadia
+#. short delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+#: ../panels/mouse/gnome-mouse-properties.ui.h:22
+#: ../panels/universal-access/uap.ui.h:54
+msgid "Short"
+msgstr "ছোট"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Shortcuts"
+msgstr "শর্টকাট"
+
+# Translated by sadia
+#. slow acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+#: ../panels/mouse/gnome-mouse-properties.ui.h:24
+msgid "Slow"
+msgstr "ধীর"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"কোনো শর্ট-কাট কী-এর মান পরিবর্তনের জন্য সংশ্লিষ্ট সারির উপর ক্লিক করুন ও নতুন কী ধরে "
+"রাখুন অথবা চাপুন। অথবা ব্যাক-স্পেস চেপে মুছে ফেলুন।"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "_Delay:"
+msgstr "বিলম্ব (_D):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+msgid "_Name:"
+msgstr "নাম (_N):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+msgid "_Speed:"
+msgstr "গতি (_S):"
+
+#: ../panels/media/cc-media-panel.c:322
+msgid "Ask what to do"
+msgstr "কি করতে হবে তা জিজ্ঞাসা করুন"
+
+# Translated by sadia
+#: ../panels/media/cc-media-panel.c:326 ../panels/power/power.ui.h:6
+msgid "Do nothing"
+msgstr "কিচ্ছু করার নেই"
+
+#: ../panels/media/cc-media-panel.c:330
+msgid "Open folder"
+msgstr "ফোল্ডার খোলা"
+
+#: ../panels/media/cc-media-panel.c:441
+msgid "Select an application for audio CDs"
+msgstr "অডিও সিডির জন্য অ্যাপ্লিকেশন নির্বাচন"
+
+#: ../panels/media/cc-media-panel.c:442
+msgid "Select an application for video DVDs"
+msgstr "ভিডিও ডিভিডির জন্য অ্যাপ্লিকেশন নির্বাচন"
+
+#: ../panels/media/cc-media-panel.c:443
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"যখন একটি মিউজিক প্লেয়ার সংযুক্ত থাকবে তখন একটি অ্যাপ্লিকেশন চালানোর জন্য নির্বাচন "
+"করুন"
+
+#: ../panels/media/cc-media-panel.c:444
+msgid "Select an application to run when a camera is connected"
+msgstr "যখন ক্যামেরা সংযুক্ত থাকবে তখন একটি অ্যাপ্লিকেশন চালানোর জন্য নির্বাচন করুন"
+
+#: ../panels/media/cc-media-panel.c:445
+msgid "Select an application for software CDs"
+msgstr "সফ্টওয়্যারের সিডির জন্য অ্যাপ্লিকেশন নির্বাচন"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/media/cc-media-panel.c:457
+msgid "audio DVD"
+msgstr "অডিও DVD"
+
+#: ../panels/media/cc-media-panel.c:458
+msgid "blank Blu-ray disc"
+msgstr "খালি ব্লু-রে ডিস্ক "
+
+#: ../panels/media/cc-media-panel.c:459
+msgid "blank CD disc"
+msgstr "খালি সিডি ডিস্ক"
+
+#: ../panels/media/cc-media-panel.c:460
+msgid "blank DVD disc"
+msgstr "খালি ডিভিডি ডিস্ক"
+
+#: ../panels/media/cc-media-panel.c:461
+msgid "blank HD DVD disc"
+msgstr "খালি HD DVD ডিস্ক"
+
+#: ../panels/media/cc-media-panel.c:462
+msgid "Blu-ray video disc"
+msgstr "ব্লু-রে ভিডিও ডিস্ক "
+
+#: ../panels/media/cc-media-panel.c:463
+msgid "e-book reader"
+msgstr "ই-বুক রীডার"
+
+#: ../panels/media/cc-media-panel.c:464
+msgid "HD DVD video disc"
+msgstr "HD DVD ভিডিও ডিস্ক"
+
+#: ../panels/media/cc-media-panel.c:465
+msgid "Picture CD"
+msgstr "ছবি সিডি"
+
+#: ../panels/media/cc-media-panel.c:466
+msgid "Super Video CD"
+msgstr "চমৎকার ভিডিও সিডি"
+
+# Translated by sadia
+#: ../panels/media/cc-media-panel.c:467
+msgid "Video CD"
+msgstr "ভিডিও সিডি"
+
+#: ../panels/media/gnome-media-properties.ui.h:1
+msgid "Acti_on:"
+msgstr "কাজ (_o):"
+
+#: ../panels/media/gnome-media-properties.ui.h:2
+msgid "CD _audio:"
+msgstr "অডিও সিডি (_a):"
+
+#: ../panels/media/gnome-media-properties.ui.h:3
+msgid "Media and Autorun"
+msgstr "মিডিয়া এবং অটোরান"
+
+#: ../panels/media/gnome-media-properties.ui.h:4
+msgid "Select how media should be handled"
+msgstr "মিডিয়া কিভাবে চলবে তা নির্বাচন"
+
+#: ../panels/media/gnome-media-properties.ui.h:5
+msgid "Select how other media should be handled"
+msgstr "অন্যান্য মিডিয়া কিভাবে চলবে তা নির্বাচন"
+
+#: ../panels/media/gnome-media-properties.ui.h:6
+msgid "_DVD video:"
+msgstr "DVD ভিডিও (_D):"
+
+#: ../panels/media/gnome-media-properties.ui.h:7
+msgid "_Music player:"
+msgstr "মিউজিক প্লেয়ার (_M):"
+
+#: ../panels/media/gnome-media-properties.ui.h:8
+msgid "_Never prompt or start programs on media insertion"
+msgstr "মিডিয়া সন্নিবেশনে কখনই প্রোগ্রাম প্রম্পট অথবা আরম্ভ করা হবেনা (_N)"
+
+#: ../panels/media/gnome-media-properties.ui.h:9
+msgid "_Other Media..."
+msgstr "অন্যান্য মিডিয়া (_O)..."
+
+#: ../panels/media/gnome-media-properties.ui.h:10
+msgid "_Photos:"
+msgstr "ছবি (_P):"
+
+#: ../panels/media/gnome-media-properties.ui.h:11
+msgid "_Software:"
+msgstr "সফ্টওয়্যার (_S):"
+
+#: ../panels/media/gnome-media-properties.ui.h:12
+msgid "_Type:"
+msgstr "ধরন (_T):"
+
+#: ../panels/media/gnome-media-panel.desktop.in.in.h:1
+msgid "Configure media and autorun preferences"
+msgstr "মিডিয়া এবং অটোরান পছন্দ কনফিগার"
+
+#: ../panels/media/gnome-media-panel.desktop.in.in.h:2
+msgid "Removable Media"
+msgstr "অপসারণযোগ্য মিডিয়া"
+
+#. Translators: those are keywords for the media control-center panel
+#: ../panels/media/gnome-media-panel.desktop.in.in.h:4
+msgid "cd;dvd;usb;audio;video;disc;"
+msgstr "সিডি;ডিভিডি;ইউএসবি;ভিডিও;ডিস্ক;"
+
+# Translated by sadia
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:258
+msgid "Low on toner"
+msgstr "অনুচ্চ টোনার  "
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:260
+msgid "Out of toner"
+msgstr "টোনারের বাহিরে"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:263
+msgid "Low on developer"
+msgstr "ডেভেলপারে নিম্ন"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:266
+msgid "Out of developer"
+msgstr "ডেভেলপারের বাহিরে"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:268
+msgid "Low on a marker supply"
+msgstr "চিহ্নিতকারী সরবরাহ কম"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:270
+msgid "Out of a marker supply"
+msgstr "চিহ্নিতকারী সরবরাহ হচ্ছেনা"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:272
+msgid "Open cover"
+msgstr "কভার উন্মুক্ত"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:274
+msgid "Open door"
+msgstr "দরজা খোলা"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:276
+msgid "Low on paper"
+msgstr "কাগজ কম"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:278
+msgid "Out of paper"
+msgstr "কাগজ নেই"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:280
+msgctxt "printer state"
+msgid "Offline"
+msgstr "অফলাইন"
+
+#. Translators: Someone has paused the Printer
+#: ../panels/printers/cc-printers-panel.c:282
+msgctxt "printer state"
+msgid "Paused"
+msgstr "বিরত"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:284
+msgid "Waste receptacle almost full"
+msgstr "বর্জ্য রাখার পাত্র প্রায় পূর্ণ"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:286
+msgid "Waste receptacle full"
+msgstr "বর্জ্য রাখার পাত্র পূর্ণ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:288
+msgid "The optical photo conductor is near end of life"
+msgstr "আলোক সম্বন্ধীয় ছবি পরিবাহকের জীবনী শেষ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:290
+msgid "The optical photo conductor is no longer functioning"
+msgstr "আলোক সম্বন্ধীয় ছবি পরিবাহক আর কাজ করছেনা"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:434
+msgctxt "printer state"
+msgid "Ready"
+msgstr "প্রস্তুত"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:438
+msgctxt "printer state"
+msgid "Processing"
+msgstr "প্রক্রিয়াধীন"
+
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:442
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "বন্ধ"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:561
+msgid "Toner Level"
+msgstr "টোনারের স্তর"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:564
+msgid "Ink Level"
+msgstr "কালির স্তর"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:567
+msgid "Supply Level"
+msgstr "সরবরাহের স্তর"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:582
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u সক্রিয়"
+msgstr[1] "%u সক্রিয়"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:705
+msgid "No printers available"
+msgstr "মুদ্রণযন্ত্র বিদ্যমান নয়"
+
+# Translated by sadia
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/cc-printers-panel.c:996
+msgctxt "print job"
+msgid "Pending"
+msgstr "অমীমাংসিত"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/cc-printers-panel.c:1000
+msgctxt "print job"
+msgid "Held"
+msgstr "অনুষ্ঠিত"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/cc-printers-panel.c:1004
+msgctxt "print job"
+msgid "Processing"
+msgstr "প্রক্রিয়াধীন"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/cc-printers-panel.c:1008
+msgctxt "print job"
+msgid "Stopped"
+msgstr "বন্ধ"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/cc-printers-panel.c:1012
+msgctxt "print job"
+msgid "Canceled"
+msgstr "বাতিল"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/cc-printers-panel.c:1016
+msgctxt "print job"
+msgid "Aborted"
+msgstr "নিষ্ফলকৃত"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/cc-printers-panel.c:1020
+msgctxt "print job"
+msgid "Completed"
+msgstr "সম্পন্ন"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/cc-printers-panel.c:1112
+msgid "Job Title"
+msgstr "পদমর্যাদা"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/cc-printers-panel.c:1121
+msgid "Job State"
+msgstr "কাজেরঅবস্থা"
+
+# Translated by sadia
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/cc-printers-panel.c:1127
+msgid "Time"
+msgstr "সময়"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1842
+msgid "Failed to add new printer."
+msgstr "নতুন মুদ্রণযন্ত্র যোগ করতে ব্যর্থ।"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2014
+#: ../panels/printers/cc-printers-panel.c:2028
+msgid "Test page"
+msgstr "পরীক্ষামূলক পৃষ্ঠা"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2215
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui লোড করা যাচ্ছেনা: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Change printer settings"
+msgstr "মুদ্রণযন্ত্র সেটিং পরিবর্তন"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "মুদ্রণযন্ত্র;সারি;মুদ্রণ;কাগজ;কালি;টোনার;"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printers"
+msgstr "মুদ্রণযন্ত্র"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add"
+msgstr "যোগ"
+
+#: ../panels/printers/new-printer-dialog.ui.h:2
+msgid "Add a New Printer"
+msgstr "নতুন মুদ্রণযন্ত্র যোগ"
+
+#: ../panels/printers/new-printer-dialog.ui.h:3
+msgid "Address"
+msgstr "ঠিকানা"
+
+#: ../panels/printers/new-printer-dialog.ui.h:4
+#: ../panels/user-accounts/data/language-chooser.ui.h:1
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+msgid "Cancel"
+msgstr "বাতিল"
+
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "Search by Address"
+msgstr "ঠিকানা অনুসারে অনুসন্ধান"
+
+#: ../panels/printers/pp-new-printer-dialog.c:381
+msgid "Getting devices..."
+msgstr "ডিভাইস পাওয়া যাচ্ছে..."
+
+#. Translators: Column of devices which can be installed
+#: ../panels/printers/pp-new-printer-dialog.c:639
+#: ../panels/printers/pp-new-printer-dialog.c:644
+msgid "Devices"
+msgstr "ডিভাইস "
+
+# Translated by sadia
+#. Translators: Local means local printers
+#: ../panels/printers/pp-new-printer-dialog.c:669
+msgid "Local"
+msgstr "স্থানীয়"
+
+#. Translators: Network means network printers
+#: ../panels/printers/pp-new-printer-dialog.c:671
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+msgid "Network"
+msgstr "নেটওয়ার্ক"
+
+#. Translators: Device types column (network or local)
+#: ../panels/printers/pp-new-printer-dialog.c:712
+msgid "Device types"
+msgstr "ডিভাইসের  ধরণ"
+
+#. Translators: Name of job which makes printer to autoconfigure itself
+#: ../panels/printers/pp-new-printer-dialog.c:865
+#: ../panels/printers/pp-new-printer-dialog.c:1033
+msgid "Automatic configuration"
+msgstr "স্বয়ংক্রিয় কনফিগারেশন"
+
+#: ../panels/printers/printers.ui.h:1
+msgid "---"
+msgstr "---"
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:3
+msgid "Active Print Jobs"
+msgstr "মুদ্রণ কাজ সক্রিয়"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:5
+msgid "Add New Printer"
+msgstr "নতুন মুদ্রণযন্ত্র যোগ"
+
+#: ../panels/printers/printers.ui.h:6
+msgid "Allowed users"
+msgstr "ব্যবহারকারীর অনুমোদন"
+
+#. Translators: Switch back to printer's info tab
+#: ../panels/printers/printers.ui.h:8
+msgid "Back"
+msgstr "পূর্ববর্তী"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:10
+#: ../panels/region/gnome-region-panel-xkbot.c:229
+#: ../panels/sound/gvc-sound-theme-chooser.c:586
+msgid "Default"
+msgstr "পূর্বনির্ধারিত"
+
+#: ../panels/printers/printers.ui.h:11
+#: ../panels/network/cc-network-panel.c:1566
+#: ../panels/network/cc-network-panel.c:1569 ../panels/network/network.ui.h:11
+msgid "IP Address"
+msgstr "IP ঠিকানা"
+
+# Translated by sadia
+#: ../panels/printers/printers.ui.h:12
+msgid "Jobs"
+msgstr "কাজ"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:14
+msgid "Location"
+msgstr "অবস্থান"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "Model"
+msgstr "মডেল"
+
+# Translated by sadia
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:17
+msgid "Options"
+msgstr "অপশন"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:19
+msgid "Print Test Page"
+msgstr "মুদ্রণ পরীক্ষামূলক পৃষ্ঠা"
+
+#: ../panels/printers/printers.ui.h:20
+msgid "Printer"
+msgstr "মুদ্রণযন্ত্র"
+
+# Translated by sadia
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:22
+msgid "Printer Options"
+msgstr "মুদ্রণযন্ত্র অপশন"
+
+# Translated by sadia
+#: ../panels/printers/printers.ui.h:23
+msgid "Printing..."
+msgstr "মুদ্রণ করা হচ্ছে..."
+
+# Translated by sadia
+#. Tanslators: Switch to tab containing printer's jobs
+#: ../panels/printers/printers.ui.h:25
+msgid "Show"
+msgstr "প্রদর্শন"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:27
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"দুঃখিত! মনে হচ্ছে সিস্টেম মুদ্রণযন্ত্র সার্ভিস\n"
+"বিদ্যমান নয়।"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:30
+msgid "Supply"
+msgstr "সরবরাহ"
+
+# Translated by sadia
+#: ../panels/region/gnome-region-panel.ui.h:1
+msgid "Allow different layouts for each window"
+msgstr "প্রতিটি উইন্ডোর জন্য পৃথক বহির্বিন্যাস"
+
+#: ../panels/region/gnome-region-panel.ui.h:2
+msgid "Install languages..."
+msgstr "ভাষা ইনস্টল..."
+
+#: ../panels/region/gnome-region-panel.ui.h:3
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "Language"
+msgstr "ভাষা"
+
+#: ../panels/region/gnome-region-panel.ui.h:4
+msgid "Layouts"
+msgstr "বিন্যাস"
+
+#: ../panels/region/gnome-region-panel.ui.h:5
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Region and Language"
+msgstr "অঞ্চল এবং ভাষা"
+
+#: ../panels/region/gnome-region-panel.ui.h:6
+msgid ""
+"Replace the current keyboard layout settings with the\n"
+"default settings"
+msgstr ""
+"বর্তমান কীবোর্ডের লেআউট সেটিং প্রতিস্থাপন করুন\n"
+"পূর্বনির্ধারিত সেটিং এর সাহায্যে"
+
+# FIXME
+#: ../panels/region/gnome-region-panel.ui.h:8
+msgid "Reset to De_faults"
+msgstr "পূর্বনির্ধারিত মান পুনরায় স্থাপন করুন (_f)"
+
+#: ../panels/region/gnome-region-panel.ui.h:9
+msgid "Select a display language (change will be applied next time you log in)"
+msgstr ""
+"প্রদর্শনের ভাষা নির্বাচন (পরবর্তী সময়ে আপনি লগইন করার সময় পরিবর্তন প্রয়োগ করা হবে)"
+
+# Translated by sadia
+#: ../panels/region/gnome-region-panel.ui.h:10
+msgid "Use default layout in new windows"
+msgstr "নতুন উইন্ডোর জন্য পূর্বনির্ধারিত বিন্যাস"
+
+#: ../panels/region/gnome-region-panel.ui.h:11
+msgid "Use previous window's layout in new windows"
+msgstr "নতুন উইন্ডোতে পূর্ববর্তী উইন্ডোর বহির্বিন্যাস ব্যবহার"
+
+# Translated by sadia
+#: ../panels/region/gnome-region-panel.ui.h:12
+msgid "Use same layout in all windows"
+msgstr "সব উইন্ডোতে একই বহির্বিন্যাস ব্যবহার"
+
+#: ../panels/region/gnome-region-panel.ui.h:13
+msgid "View and edit keyboard layout options"
+msgstr "কীবোর্ডের লেআউট অপশন প্রদর্শন এবং সম্পাদন"
+
+# Translated by sadia
+#: ../panels/region/gnome-region-panel.ui.h:14
+#: ../panels/network/network.ui.h:28
+msgid "_Options..."
+msgstr "অপশন (_O)... "
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
+msgid "Choose a Layout"
+msgstr "যে কোন একটি লে-আউট বেছে নিন"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
+msgid "Preview"
+msgstr "প্রাকদর্শন"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
+msgid "Select an input source to add"
+msgstr "ইনপুট উৎস যোগ করতে নির্বাচন"
+
+#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
+msgid "Keyboard Layout Options"
+msgstr "কীবোর্ড বহির্বিন্যাস সংক্রান্ত অপশন"
+
+#: ../panels/region/gnome-region-panel-xkblt.c:222
+msgid "Layout"
+msgstr "বহির্বিন্যাস"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Change your region and language settings"
+msgstr "আপনার অঞ্চল এবং ভাষার সেটিং পরিবর্তন"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
+msgid "Language;Layout;Keyboard;"
+msgstr "ভাষা;বহির্বিন্যাস;কীবোর্ড;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "Disable _touchpad while typing"
+msgstr "টাইপ করার সময় টাচপ্যাড নিস্ক্রিয় করুন (_t)"
+
+# Translated by sadia
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-Click Timeout"
+msgstr "ডবল ক্লিক-এর সময়উত্তীর্ণ"
+
+# Translated by sadia
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Drag and Drop"
+msgstr "টেনে এনে ছেড়ে দিন"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "Enable _mouse clicks with touchpad"
+msgstr "টাচপ্যাডের মাধ্যমে মাউস ক্লিক সক্রিয় করুন (_m)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Enable h_orizontal scrolling"
+msgstr "অনুভূমিক স্ক্রলিং সক্রিয় করুন (_o)"
+
+# Translated by sadia
+#. high sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgid "High"
+msgstr "উঁচু"
+
+#. large threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Large"
+msgstr "বড়"
+
+# Translated by sadia
+#. low sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Low"
+msgstr "নিচু"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Mouse"
+msgstr "মাউস"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Mouse Preferences"
+msgstr "মাউস সম্পর্কিত পছন্দ"
+
+# Translated by sadia
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+msgid "Pointer Speed"
+msgstr "পয়েন্টারের গতি"
+
+# Translated by sadia
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "Scrolling"
+msgstr "স্ক্রল করা হচ্ছে"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:21
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr "কন্ট্রোল-কী চাপা হলে পয়েন্টারের অবস্থান প্রদর্শন করা হবে (_o)"
+
+#. small threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:26
+#: ../panels/universal-access/uap.ui.h:58
+msgid "Small"
+msgstr "ছোট"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:27
+msgid "Thr_eshold:"
+msgstr "থ্রেসহোল্ড (_e):"
+
+# Translated by sadia
+#: ../panels/mouse/gnome-mouse-properties.ui.h:28
+msgid "To test your settings, try to double-click on the face."
+msgstr "সেটিং পরীক্ষার জন্য, ফেসের উপর ডবল ক্লিক করার চেষ্টা করুন।"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:29
+msgid "Touchpad"
+msgstr "টাচপ্যাড"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:30
+msgid "Two-_finger scrolling"
+msgstr "দুই-আঙ্গুল স্ক্রলিং (_f)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:31
+msgid "_Acceleration:"
+msgstr "গতিবৃদ্ধি (_A):"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:32
+msgid "_Disabled"
+msgstr "নিষ্ক্রিয় (_D)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:33
+msgid "_Edge scrolling"
+msgstr "প্রান্ত স্ক্রলিং করুন (_E)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:34
+msgid "_Left-handed"
+msgstr "বামহাতি (_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:35
+msgid "_Right-handed"
+msgstr "ডান হাতি (_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:36
+msgid "_Sensitivity:"
+msgstr "সংবেদনশীলতা (_S):"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:37
+msgid "_Timeout:"
+msgstr "সময় শেষ (_T):"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse and Touchpad"
+msgstr "মাউস এবং টাচপ্যাড"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Set your mouse and touchpad preferences"
+msgstr "মাউস এবং টাচপ্যাড সম্পর্কিত আপনার পছন্দ নির্ধারণ"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr "ট্র্যাকপ্যাড;পয়েন্টার;ক্লিক;ট্যাপ;ডবল;বোতাম;ট্র্যাকবল;"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/cc-network-panel.c:193
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"যখন কনফিগারেশন URL দেওয়া থাকেনা তখন স্বয়ংক্রিয় ওয়েব প্রক্সি উদঘাটন ব্যবহৃত হয়। "
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/cc-network-panel.c:201
+msgid "This is not recommended for untrusted public networks."
+msgstr "অবিশ্বস্ত পাবলিক নেটওয়ার্কের জন্য এটি সুপারিশ করা হচ্ছেনা।"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/cc-network-panel.c:943
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:947
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:951
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/cc-network-panel.c:956
+msgid "Enterprise"
+msgstr "এন্টারপ্রাইজ"
+
+#. TRANSLATORS: this no (!) WiFi security
+#: ../panels/network/cc-network-panel.c:962
+#: ../panels/universal-access/uap.ui.h:43
+msgid "None"
+msgstr "একটিও না"
+
+#. Translators: network device speed
+#: ../panels/network/cc-network-panel.c:1265
+#: ../panels/network/cc-network-panel.c:1310
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/cc-network-panel.c:1562 ../panels/network/network.ui.h:12
+msgid "IPv4 Address"
+msgstr "IPv4 ঠিকানা"
+
+#: ../panels/network/cc-network-panel.c:1563 ../panels/network/network.ui.h:13
+msgid "IPv6 Address"
+msgstr "IPv6 ঠিকানা"
+
+#: ../panels/network/cc-network-panel.c:1701
+msgid "Proxy"
+msgstr "প্রক্সি"
+
+#: ../panels/network/cc-network-panel.c:1765
+msgid "Network proxy"
+msgstr "নেটওয়ার্ক প্রক্সি"
+
+#: ../panels/network/cc-network-panel.c:1931
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1999
+msgid "The system network services are not compatible with this version."
+msgstr "এই সংস্করণের সাথে সিস্টেম নেটওয়ার্ক সার্ভিস সামঞ্জস্যপূর্ণ নয়।"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Network settings"
+msgstr "নেটওয়ার্ক সেটিং"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid "Network;Wireless;IP;LAN;"
+msgstr "নেটওয়ার্ক;ওয়ারলেস;IP;LAN;"
+
+#: ../panels/network/network.ui.h:1
+msgid "Air_plane Mode"
+msgstr "বিমান মোড"
+
+#: ../panels/network/network.ui.h:2
+msgid "Create..."
+msgstr "তৈরি..."
+
+#: ../panels/network/network.ui.h:3
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/network.ui.h:4
+msgid "Default Route"
+msgstr "পূর্বনির্ধারিত গমনপথ"
+
+#: ../panels/network/network.ui.h:5
+msgid "Gateway"
+msgstr "গেইটওয়ে"
+
+#: ../panels/network/network.ui.h:6
+msgid "Group Name"
+msgstr "গ্রুপের নাম"
+
+#: ../panels/network/network.ui.h:7
+msgid "Group Password"
+msgstr "গ্রুপের পাসওয়ার্ড"
+
+#: ../panels/network/network.ui.h:8
+msgid "H_TTPS Proxy"
+msgstr "HTTP প্রক্সি (_T)"
+
+#: ../panels/network/network.ui.h:9
+msgid "Hardware Address"
+msgstr "হার্ডওয়্যারের ঠিকানা"
+
+#: ../panels/network/network.ui.h:10
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network.ui.h:14
+msgid "Interface"
+msgstr "ইন্টারফেস"
+
+#: ../panels/network/network.ui.h:15
+msgid "Provider"
+msgstr "সরবরাহকারী"
+
+#: ../panels/network/network.ui.h:16
+msgid "Security"
+msgstr "নিরাপত্তা"
+
+#: ../panels/network/network.ui.h:17
+msgid "Select the interface to use for the new service"
+msgstr "নতুন সার্ভিস ব্যবহারের জন্য ইন্টারফেস নির্বাচন"
+
+#: ../panels/network/network.ui.h:18
+msgid "Speed"
+msgstr "গতি"
+
+#: ../panels/network/network.ui.h:19
+msgid "Subnet Mask"
+msgstr "সাবনেট মাস্ক"
+
+#: ../panels/network/network.ui.h:21
+msgid "Username"
+msgstr "ব্যবহারকারীর নাম"
+
+#: ../panels/network/network.ui.h:22
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/network.ui.h:23
+msgid "_Configuration URL"
+msgstr "কনফিগারেশনের URL (_C):"
+
+#: ../panels/network/network.ui.h:24
+msgid "_FTP Proxy"
+msgstr "FTP প্রক্সি (_F)"
+
+#: ../panels/network/network.ui.h:25
+msgid "_HTTP Proxy"
+msgstr "HTTP প্রক্সি (_T)"
+
+#: ../panels/network/network.ui.h:26
+msgid "_Method"
+msgstr "মেথড (_M)"
+
+#: ../panels/network/network.ui.h:27
+msgid "_Network Name"
+msgstr "নেটওয়ার্কের নাম (_N)"
+
+#: ../panels/network/network.ui.h:29
+msgid "_Socks Host"
+msgstr "Socks হোস্ট (_S)"
+
+#: ../panels/network/network.ui.h:30
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "স্বয়ংক্রিয়"
+
+#: ../panels/network/network.ui.h:31
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "স্বনির্ধারিত"
+
+#: ../panels/network/network.ui.h:32
+msgctxt "proxy method"
+msgid "None"
+msgstr "একটিও না"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:83
+msgid "Wired"
+msgstr "তার দ্বারা সংযুক্ত"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:87
+msgid "Wireless"
+msgstr "তারবিহীন"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:94
+msgid "Mobile broadband"
+msgstr "মোবাইল ব্রডব্যান্ড"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:99
+msgid "Bluetooth"
+msgstr "ব্লুটুথ"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:103
+msgid "Mesh"
+msgstr "মেশ"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:162
+msgid "Ad-hoc"
+msgstr "এডহক"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:166
+msgid "Infrastructure"
+msgstr "পরিকাঠামো"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:190 ../panels/network/panel-common.c:251
+msgid "Status unknown"
+msgstr "অজানা অবস্থা"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:194
+msgid "Unmanaged"
+msgstr "অপরিকল্পিত"
+
+#: ../panels/network/panel-common.c:199
+msgid "Firmware missing"
+msgstr "ফার্মওয়্যার অনুপস্থিত"
+
+#: ../panels/network/panel-common.c:202
+msgid "Cable unplugged"
+msgstr "কেবল আনপ্লাগকৃত"
+
+#: ../panels/network/panel-common.c:204
+msgid "Unavailable"
+msgstr "বিদ্যমান নয়"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:208
+msgid "Disconnected"
+msgstr "বিছিন্ন"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:215 ../panels/network/panel-common.c:257
+msgid "Connecting"
+msgstr "সংযুক্ত করা হচ্ছে "
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
+msgid "Authentication required"
+msgstr "প্রমাণীকরণ আবশ্যকীয়"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
+msgid "Connected"
+msgstr "যোগকৃত"
+
+# Translated by sadia
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:227
+msgid "Disconnecting"
+msgstr "বিচ্ছিন্ন করা হচ্ছে"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:231 ../panels/network/panel-common.c:269
+msgid "Connection failed"
+msgstr "সংযোগে ব্যর্থ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:277
+msgid "Status unknown (missing)"
+msgstr "অজানা অবস্থা (অনুপস্থিত)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:273
+msgid "Not connected"
+msgstr "সংযুক্ত নয়"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "শক্তি"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Power management settings"
+msgstr "শক্তি পরিচালনা সেটিং"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+msgstr "Power;Sleep;Suspend;Hibernate;Battery;"
+
+#: ../panels/power/cc-power-panel.c:153
+msgid "Unknown time"
+msgstr "অজ্ঞাত সময়"
+
+#: ../panels/power/cc-power-panel.c:159
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i মিনিট"
+msgstr[1] "%i মিনিট"
+
+#: ../panels/power/cc-power-panel.c:171
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ঘন্টা"
+msgstr[1] "%i ঘন্টা"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:179
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+# Translated by sadia
+#: ../panels/power/cc-power-panel.c:180
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ঘন্টা"
+msgstr[1] "ঘন্টা"
+
+#: ../panels/power/cc-power-panel.c:181
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "মিনিট"
+msgstr[1] "মিনিট"
+
+#: ../panels/power/cc-power-panel.c:253
+msgid "Battery charging"
+msgstr "ব্যাটারী চার্জ হচ্ছে"
+
+#: ../panels/power/cc-power-panel.c:256
+msgid "Battery discharging"
+msgstr "ব্যাটারী চার্জ হচ্ছেনা"
+
+#: ../panels/power/cc-power-panel.c:267
+msgid "UPS charging"
+msgstr "UPS চার্জ হচ্ছে"
+
+#: ../panels/power/cc-power-panel.c:270
+msgid "UPS discharging"
+msgstr "UPS চার্জ হচ্ছেনা"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:288
+#, c-format
+msgid "%s until charged (%.0lf%%)"
+msgstr "%s পর্যন্ত চার্জ (%.0lf%%)"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:294
+#, c-format
+msgid "%s until empty (%.0lf%%)"
+msgstr "%s পর্যন্ত খালি (%.0lf%%)"
+
+#. TRANSLATORS: %1 is a percentage value. Note: this string is only
+#. * used when we don't have a time value
+#: ../panels/power/cc-power-panel.c:302
+#, c-format
+msgid "%.0lf%% charged"
+msgstr "%.0lf%% চার্জকৃত"
+
+#: ../panels/power/power.ui.h:1 ../panels/screen/screen.ui.h:1
+msgid "1 hour"
+msgstr "১ ঘন্টা"
+
+#: ../panels/power/power.ui.h:2 ../panels/screen/screen.ui.h:3
+msgid "10 minutes"
+msgstr "১০ মিনিট"
+
+#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
+msgid "30 minutes"
+msgstr "৩০ মিনিট"
+
+#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:8
+msgid "5 minutes"
+msgstr "৫ মিনিট"
+
+#: ../panels/power/power.ui.h:5
+msgid "Ask me"
+msgstr "আমাকে জিজ্ঞাসা করুন"
+
+#: ../panels/power/power.ui.h:7
+msgid "Hibernate"
+msgstr "হাইবারনেট"
+
+#: ../panels/power/power.ui.h:8
+msgid "On AC power:"
+msgstr "AC পাওয়ার চালু:"
+
+#: ../panels/power/power.ui.h:9
+msgid "On battery power:"
+msgstr "ব্যাটারী পাওয়ার চালু:"
+
+#: ../panels/power/power.ui.h:10
+msgid "Put the computer to sleep when inactive:"
+msgstr "যখন নিষ্ক্রিয় থাকবে কম্পিউটারকে স্লীপ দিয়ে রাখুন:"
+
+#: ../panels/power/power.ui.h:11
+msgid "Shutdown"
+msgstr "বন্ধ"
+
+#: ../panels/power/power.ui.h:12
+msgid "Suspend"
+msgstr "স্থগিত "
+
+#: ../panels/power/power.ui.h:13
+msgid "When power is critically low:"
+msgstr "যখন পাওয়ার মারাত্মক কম থাকে:"
+
+#: ../panels/power/power.ui.h:14
+msgid "When the power button is pressed:"
+msgstr "যখন পাওয়ার বোতাম চাপা দেওয়া থাকে:"
+
+#: ../panels/power/power.ui.h:15
+msgid "When the sleep button is pressed:"
+msgstr "যখন স্লীপ বোতাম চাপা দেওয়া থাকে:"
+
+#. Translators: those are keywords for the brightness and lock control-center panel
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
+msgid "Brightness;Lock;Dim;Blank;Monitor;"
+msgstr "Brightness;Lock;Dim;Blank;Monitor;"
+
+# Translated by sadia
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
+msgid "Screen"
+msgstr "স্ক্রীন"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
+msgid "Screen brightness and lock settings"
+msgstr "স্ক্রীন উজ্জ্বলতা এবং লক সেটিং"
+
+#: ../panels/screen/screen.ui.h:2
+msgid "1 minute"
+msgstr "১ মিনিট"
+
+#: ../panels/screen/screen.ui.h:4
+msgid "2 minutes"
+msgstr "২ মিনিট"
+
+#: ../panels/screen/screen.ui.h:5
+msgid "3 minutes"
+msgstr "৩ মিনিট"
+
+#: ../panels/screen/screen.ui.h:7
+msgid "30 seconds"
+msgstr "৩০ সেকেন্ড"
+
+#: ../panels/screen/screen.ui.h:9
+msgid "Brightness"
+msgstr "উজ্জ্বলতা"
+
+#: ../panels/screen/screen.ui.h:10
+msgid "Dim screen to save power"
+msgstr "পাওয়ার সংরক্ষণের জন্য ঝাপসা স্ক্রীন "
+
+#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
+#: ../panels/screen/screen.ui.h:12
+msgid "Don't lock when at home"
+msgstr "যখন হোমে থাকবেন তখন লক করবেননা"
+
+# FIXME
+#: ../panels/screen/screen.ui.h:13
+msgid "Locations..."
+msgstr "অবস্থান..."
+
+#: ../panels/screen/screen.ui.h:15
+msgid "Lock screen after:"
+msgstr "এরপরে স্ক্রীন লক করুন:"
+
+#: ../panels/screen/screen.ui.h:16
+msgid "Screen turns off"
+msgstr "স্ক্রীন চালু বন্ধ করুন"
+
+#: ../panels/screen/screen.ui.h:17
+msgid "Turn off after:"
+msgstr "এর পরে বন্ধ করুন:"
+
+#: ../panels/sound/applet-main.c:49
+msgid "Enable debugging code"
+msgstr "কোড ডিবাগ ব্যবস্থা সক্রিয় করা হবে"
+
+#: ../panels/sound/applet-main.c:50
+msgid "Version of this application"
+msgstr "এই অ্যাপ্লিকেশনের সংস্করণ"
+
+#: ../panels/sound/applet-main.c:62
+msgid " — GNOME Volume Control Applet"
+msgstr " — GNOME ভলিউম কন্ট্রোল অ্যাপলেট"
+
+#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1923
+msgid "Output"
+msgstr "আউটপুট"
+
+#: ../panels/sound/gvc-applet.c:278
+msgid "Sound Output Volume"
+msgstr "শব্দ আউটপুটের ভলিউম"
+
+#: ../panels/sound/gvc-applet.c:282 ../panels/sound/gvc-mixer-dialog.c:1840
+msgid "Input"
+msgstr "ইনপুট"
+
+#: ../panels/sound/gvc-applet.c:284
+msgid "Microphone Volume"
+msgstr "মাইক্রোফোনের ভলিউম"
+
+#: ../panels/sound/gvc-balance-bar.c:111
+msgctxt "balance"
+msgid "Left"
+msgstr "বাম"
+
+#: ../panels/sound/gvc-balance-bar.c:112
+msgctxt "balance"
+msgid "Right"
+msgstr "ডান"
+
+#: ../panels/sound/gvc-balance-bar.c:115
+msgctxt "balance"
+msgid "Rear"
+msgstr "পিছনে"
+
+#: ../panels/sound/gvc-balance-bar.c:116
+msgctxt "balance"
+msgid "Front"
+msgstr "সামনে"
+
+#: ../panels/sound/gvc-balance-bar.c:119
+msgctxt "balance"
+msgid "Minimum"
+msgstr "সর্বনিম্ন"
+
+#: ../panels/sound/gvc-balance-bar.c:120
+msgctxt "balance"
+msgid "Maximum"
+msgstr "সর্বোচ্চ"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Balance:"
+msgstr "সাম্যাবস্থা (_B):"
+
+#: ../panels/sound/gvc-balance-bar.c:298
+msgid "_Fade:"
+msgstr "বিবর্ণ হয়ে যাওয়া (_F):"
+
+#: ../panels/sound/gvc-balance-bar.c:301
+msgid "_Subwoofer:"
+msgstr "সাবউফার (_S):"
+
+#: ../panels/sound/gvc-channel-bar.c:603 ../panels/sound/gvc-channel-bar.c:612
+msgctxt "volume"
+msgid "100%"
+msgstr "১০০%"
+
+#: ../panels/sound/gvc-channel-bar.c:607
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "এমপ্লিফাইড নয়"
+
+#: ../panels/sound/gvc-channel-bar.c:901
+msgid "Mute"
+msgstr "নিঃশব্দ"
+
+#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:1631
+msgid "_Profile:"
+msgstr "প্রোফাইল (_P):"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1091
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u আউটপুট"
+msgstr[1] "%u আউটপুট"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1101
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ইনপুট"
+msgstr[1] "%u ইনপুট"
+
+#: ../panels/sound/gvc-mixer-control.c:1399
+msgid "System Sounds"
+msgstr "সিস্টেমের শব্দ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:317
+#: ../panels/sound/gvc-mixer-dialog.c:618
+msgid "Co_nnector:"
+msgstr "সংযোগকারী (_C):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:531
+msgid "Peak detect"
+msgstr "সর্বোচ্চ চূড়া নির্ধারন"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1507
+#: ../panels/sound/gvc-mixer-dialog.c:1719
+#: ../panels/sound/gvc-sound-theme-chooser.c:596
+msgid "Name"
+msgstr "নাম:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1525
+msgid "Device"
+msgstr "ডিভাইস"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1573
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s এর জন্য স্পিকার পরীক্ষা"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1632
+msgid "Test Speakers"
+msgstr "স্পিকার পরীক্ষা"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1763
+msgid "_Output volume: "
+msgstr "আউটপুট ভলিউম (_O):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1777
+msgid "Sound Effects"
+msgstr "শব্দের প্রভাব"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1784
+msgid "_Alert volume: "
+msgstr "সতর্ক করার ভলিউম (_A):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1797
+msgid "Hardware"
+msgstr "হার্ডওয়্যার"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1802
+msgid "C_hoose a device to configure:"
+msgstr "যে কোন ডিভাইস কনফিগার করতে নির্বাচন (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1829
+#: ../panels/sound/gvc-mixer-dialog.c:1952
+msgid "Settings for the selected device:"
+msgstr "নির্বাচিত ডিভাইসের জন্য সেটিং:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1847
+msgid "_Input volume: "
+msgstr "ইনপুট ভলিউম (_I):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1870
+msgid "Input level:"
+msgstr "ইনপুট স্তর:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1896
+msgid "C_hoose a device for sound input:"
+msgstr "শব্দের ইনপুটের জন্য ডিভাইস নির্বাচন:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1928
+msgid "C_hoose a device for sound output:"
+msgstr "শব্দের আউটপুটের জন্য ডিভাইস নির্বাচন:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1963
+msgid "Applications"
+msgstr "অ্যাপলিকেশন"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1967
+msgid "No application is currently playing or recording audio."
+msgstr "কোন অ্যাপ্লিকেশন বর্তমানে অডিও প্লে অথবা রেকর্ড করছেনা।"
+
+#: ../panels/sound/gvc-speaker-test.c:221
+msgid "Stop"
+msgstr "বন্ধ"
+
+#: ../panels/sound/gvc-speaker-test.c:221
+#: ../panels/sound/gvc-speaker-test.c:333
+msgid "Test"
+msgstr "পরীক্ষা"
+
+#: ../panels/sound/gvc-speaker-test.c:229
+msgid "Subwoofer"
+msgstr "সাবউফার"
+
+#: ../panels/sound/gvc-stream-status-icon.c:235
+#, c-format
+msgid "Failed to start Sound Preferences: %s"
+msgstr "শব্দ পছন্দ আরম্ভ করতে ব্যর্থ: %s"
+
+#: ../panels/sound/gvc-stream-status-icon.c:261
+msgid "_Mute"
+msgstr "নিঃশব্দ (_M)"
+
+#: ../panels/sound/gvc-stream-status-icon.c:270
+msgid "_Sound Preferences"
+msgstr "শব্দ পছন্দ (_S)"
+
+#: ../panels/sound/gvc-stream-status-icon.c:415
+msgid "Muted"
+msgstr "নিঃশব্দ "
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:190
+msgid "Built-in"
+msgstr "বিল্ট ইন"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:456
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Sound Preferences"
+msgstr "শব্দ পছন্দ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:459
+#: ../panels/sound/gvc-sound-theme-chooser.c:470
+#: ../panels/sound/gvc-sound-theme-chooser.c:482
+msgid "Testing event sound"
+msgstr "ইভেন্টের শব্দ পরীক্ষা"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:587
+msgid "From theme"
+msgstr "থীম থেকে"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:782
+msgid "C_hoose an alert sound:"
+msgstr "সতর্ক করার জন্য শব্দ নির্বাচন:"
+
+#: ../panels/sound/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr "স্বনির্বাচিত"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
+msgid "Show desktop volume control"
+msgstr "ডেস্কটপ ভলিউম কন্ট্রোল প্রদর্শন"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
+msgid "Volume Control"
+msgstr "ভলিউম কন্ট্রোল"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+msgstr "কার্ড;মাইক্রোফোন;ভলিউম;বিবর্ণ;ভারসাম্য;ব্লুটুথ;হেডসেট;"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
+msgid "Change sound volume and sound events"
+msgstr "শব্দের ভলিউম এবং শব্দের ইভেন্ট পরিবর্তন"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Sound"
+msgstr "শব্দ"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "ঘেউ ঘেউ "
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "ফোঁটা ফোঁটা করে পড়া"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "কাঁচ"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "প্রতিফলিত শব্দ তরঙ্গ"
+
+# FIXME
+#: ../panels/universal-access/cc-ua-panel.c:470
+#: ../panels/universal-access/cc-ua-panel.c:475
+msgid "No shortcut set"
+msgstr "কোন শর্টকাট নির্ধারিত নেই"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Keyboard;Mouse;a11y;Accessibility;"
+msgstr "কীবোর্ড;মাউস;a11y;স্বাচ্ছন্দ্যকরণ;"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid "Universal Access Preferences"
+msgstr "সর্বজনীন প্রবেশের পছন্দ"
+
+#: ../panels/universal-access/uap.ui.h:2
+#, no-c-format
+msgid "100%"
+msgstr "১০০%"
+
+#: ../panels/universal-access/uap.ui.h:4
+#, no-c-format
+msgid "125%"
+msgstr "১২৫%"
+
+#: ../panels/universal-access/uap.ui.h:6
+#, no-c-format
+msgid "150%"
+msgstr "১৫০%"
+
+#: ../panels/universal-access/uap.ui.h:8
+#, no-c-format
+msgid "75%"
+msgstr "৭৫%"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Acceptance delay:"
+msgstr "গ্রহণ করতে বিলম্ব:"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "Beep when Caps and Num Lock are used"
+msgstr "Caps এবং Num Lock যখন ব্যবহার করা হবে তখন বিপ হবে"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Beep when a key is"
+msgstr "কী হলে বিপ হবে "
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Beep when a key is rejected"
+msgstr "কি-র মান প্রত্যাখ্যান করা হলে বিপ হবে"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "Beep when a modifer key is pressed"
+msgstr "পরিবর্তক কি চাপা হলে বিপ হবে "
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Bounce Keys"
+msgstr "লাফানো কী  "
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "Caribou"
+msgstr "কারিবূ"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "Change contrast:"
+msgstr "রংয়ের বৈষম্য পরিবর্তন:"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Closed Captioning"
+msgstr "শিরোনাম করা বন্ধ"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "Contrast:"
+msgstr "রংয়ের বৈষম্য:"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "Control the pointer using the keypad"
+msgstr "কী-প্যাড সহযোগে পয়েন্টার নিয়ন্ত্রণ"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Control the pointer using the video camera."
+msgstr "ভিডিও ক্যামেরা সহযোগে পয়েন্টার নিয়ন্ত্রণ।"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "D_elay:"
+msgstr "বিলম্ব: (_e)"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "Dasher"
+msgstr "ড্যাশার"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Decrease size:"
+msgstr "আকার কমানো"
+
+# FIXME
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Disable if two keys are pressed together"
+msgstr "একযোগে দুটি কি চাপা হলে নিষ্ক্রিয় করা হবে"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Display a textual description of speech and sounds"
+msgstr "স্পীচ এবং শব্দের মূলগ্রন্থ-সমন্ধীয় বর্ণনা প্রদর্শন"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Flash the entire screen"
+msgstr "সম্পূর্ণ পর্দা ঝলকানো হবে"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Flash the window title"
+msgstr "উইন্ডোর শিরোনাম ঝলকানো হবে"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "GOK"
+msgstr "GOK"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:30
+msgid "Hearing"
+msgstr "শ্রুতি"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Hover Click"
+msgstr "হোভার ক্লিক "
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Ignores fast duplicate keypresses"
+msgstr "দ্রুত গতিতে দুইবার কী চাপা হলে তা উপেক্ষা করা হবে"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Increase size:"
+msgstr "আকার বাড়ানো:"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Keyboard Settings"
+msgstr "কি-বোর্ড সেটিং"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgid "Larger"
+msgstr "বড়"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Mouse Keys"
+msgstr "মাউস কী"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:41
+msgid "Mouse Settings"
+msgstr "মাউসের সেটিং"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Nomon"
+msgstr "নমন"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "On screen keyboard"
+msgstr "OnScreen কি-বোর্ড"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "OnBoard"
+msgstr "OnBoard"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Options..."
+msgstr "অপশন..."
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Pointing and Clicking"
+msgstr "পয়েন্ট এবং ক্লিক"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "যখন একটি কী চাপার পরে গৃহীত হওয়া পর্যন্ত কিছু সময় বিরতি দিন"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Screen Reader"
+msgstr "স্ক্রীণ রিডার"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgid "Screen keyboard"
+msgstr "স্ক্রীণ কি-বোর্ড"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Seeing"
+msgstr "দৃশ্যতা"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Simulated Secondary Click"
+msgstr "অনুকরণকৃত দ্বিতীয় ক্লিক"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:56
+msgid "Slow Keys"
+msgstr "ধীর গতির কী "
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Sound Settings"
+msgstr "শব্দের সেটিং"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:60
+msgid "Sticky Keys"
+msgstr "স্টিকি কী "
+
+#: ../panels/universal-access/uap.ui.h:61
+msgid "Test flash"
+msgstr "ঝলক পরীক্ষা"
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "Text size:"
+msgstr "টেক্সটের আকার:"
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "মোডিফায়ার কীর ক্রমকে কী সমাবেশ হিসেবে বিবেচনা করুন"
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "Trigger a click when the pointer hovers"
+msgstr "পয়েন্টার হোভার করার সময় ট্রিগার ক্লিক "
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "প্রধান বাটনটি টিপে রেখে, দ্বিতীয় ক্লিক ট্রিগার করুন"
+
+#: ../panels/universal-access/uap.ui.h:66
+msgid "Turn on accessibility features from the keyboard"
+msgstr "কীবোর্ড থেকে স্বাচ্ছন্দ্যকরণ বৈশিষ্ট্য চালু করুন"
+
+#: ../panels/universal-access/uap.ui.h:67
+msgid "Turn on or off:"
+msgstr "চালু অথবা বন্ধ করুন:"
+
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Type here to test settings"
+msgstr "সেটিং পরীক্ষার জন্য এখানে টাইপ করুন"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Typing"
+msgstr "টাইপ করা"
+
+#: ../panels/universal-access/uap.ui.h:70
+msgid "Typing Assistant"
+msgstr "টাইপ করার সহকারী"
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Use a visual indication when an alert sound occurs"
+msgstr "যখন একটি সতর্কতার শব্দ হওয়ার সময় দৃষ্টিনির্ভর প্রদর্শন"
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "Video Mouse"
+msgstr "ভিডিও মাউস"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:73
+msgid "Visual Alerts"
+msgstr "দৃষ্টিনির্ভর সতর্কতা"
+
+#: ../panels/universal-access/uap.ui.h:74
+msgid "Zoom in:"
+msgstr "বড় আকারে প্রদর্শন:"
+
+#: ../panels/universal-access/uap.ui.h:75
+msgid "Zoom out:"
+msgstr "ছোট আকারে প্রদর্শন:"
+
+#: ../panels/universal-access/uap.ui.h:76
+msgid "_Motion threshold:"
+msgstr "কম্পণের প্রান্তিক মান (_M):"
+
+#: ../panels/universal-access/uap.ui.h:77
+msgid "accepted"
+msgstr "গৃহীত"
+
+#: ../panels/universal-access/uap.ui.h:78
+msgid "pressed"
+msgstr "চাপা"
+
+#: ../panels/universal-access/uap.ui.h:79
+msgid "rejected"
+msgstr "প্রত্যাখ্যান"
+
+#: ../panels/universal-access/uap.ui.h:80
+msgctxt "universal access, contrast"
+msgid "<span size=\"x-large\">High/Inverse</span>"
+msgstr "<span size=\"x-large\">High/Inverse</span>"
+
+#: ../panels/universal-access/uap.ui.h:81
+msgctxt "universal access, contrast"
+msgid "<span size=\"x-large\">High</span>"
+msgstr "<span size=\"x-large\">High</span>"
+
+#: ../panels/universal-access/uap.ui.h:82
+msgctxt "universal access, contrast"
+msgid "<span size=\"x-large\">Low</span>"
+msgstr "<span size=\"x-large\">Low</span>"
+
+# check
+#: ../panels/universal-access/uap.ui.h:83
+msgctxt "universal access, contrast"
+msgid "<span size=\"x-large\">Normal</span>"
+msgstr "<span size=\"x-large\">Normal</span>"
+
+#: ../panels/universal-access/uap.ui.h:84
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "উঁচু"
+
+#: ../panels/universal-access/uap.ui.h:85
+msgctxt "universal access, contrast"
+msgid "High/Inverse"
+msgstr "উঁচু/বিপরীত"
+
+# Translated by sadia
+#: ../panels/universal-access/uap.ui.h:86
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "নিচু"
+
+#: ../panels/universal-access/uap.ui.h:87
+msgctxt "universal access, contrast"
+msgid "Normal"
+msgstr "স্বাভাবিক"
+
+#. Translators: this refers to theme contrast and font size
+#: ../panels/universal-access/uap.ui.h:89
+msgctxt "universal access, seeing"
+msgid "Display"
+msgstr "প্রদর্শন"
+
+#. Translators: this refers to screen magnifier
+#: ../panels/universal-access/uap.ui.h:91
+msgctxt "universal access, seeing"
+msgid "Zoom"
+msgstr "বড় আকারে প্রদর্শন"
+
+#: ../panels/user-accounts/run-passwd.c:426
+msgid "Authentication failed"
+msgstr "প্রমাণীকরণে ব্যর্থ"
+
+#: ../panels/user-accounts/run-passwd.c:506
+#: ../panels/user-accounts/um-password-dialog.c:375
+#, c-format
+msgid "The new password is too short"
+msgstr "নতুন পাসওয়ার্ড অত্যন্ত ছোট।"
+
+#: ../panels/user-accounts/run-passwd.c:512
+#, c-format
+msgid "The new password is too simple"
+msgstr "নতুন পাসওয়ার্ড অত্যন্ত সরল।"
+
+#: ../panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "পুরনো ও নতুন পাসওয়ার্ডের গঠন অতিমাত্রায় অনুরূপ।"
+
+#: ../panels/user-accounts/run-passwd.c:521
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "নতুন পাসওয়ার্ড বর্তমানে ইতোমধ্যেই ব্যবহৃত হয়েছে।"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "নতুন পাসওয়ার্ডের মধ্যে সংখ্য ও বিশেষ অক্ষরের উপস্থিতি বাঞ্ছনীয়"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "পুরোনো ও নতুন পাসওয়ার্ড অনুরূপ"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "প্রারম্ভে আপনার পরিচয় অনুমোদিত হওয়ার ফলে আপনার পাসওয়ার্ড পরিবর্তিত হয়েছে!"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "নতুন পাসওয়ার্ডের মধ্যে যথেষ্ট ভিন্ন অক্ষর নেই।"
+
+#: ../panels/user-accounts/run-passwd.c:540
+#, c-format
+msgid "Unknown error"
+msgstr "অজ্ঞাত ত্রুটি "
+
+#: ../panels/user-accounts/um-account-dialog.c:78
+msgid "Failed to create user"
+msgstr "ব্যবহারকারী তৈরি করতে ব্যর্থ"
+
+#: ../panels/user-accounts/um-account-dialog.c:185
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr "'%s'  নামের ব্যবহারকারী ইতোমধ্যেই আছে"
+
+#: ../panels/user-accounts/um-account-dialog.c:189
+#, c-format
+msgid "The username is too long"
+msgstr "ব্যবহারকারীর নাম অনেক দীর্ঘ"
+
+#: ../panels/user-accounts/um-account-dialog.c:192
+msgid "The username cannot start with a '-'"
+msgstr " '-' দিয়ে ব্যবহারকারীর নাম শুরু করা যাবেনা"
+
+#: ../panels/user-accounts/um-account-dialog.c:195
+msgid ""
+"The username must consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr ""
+"ব্যবহারকারীর নাম অবশ্যই গঠিত হতে হবে:\n"
+" ➣ইংরেজি বর্ণমালার অক্ষর থেকে \n"
+" ➣সংখ্যা\n"
+" ➣ '.', '-' এবং '_' এর যে কোন অক্ষর"
+
+#: ../panels/user-accounts/um-account-type.c:35
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgctxt "Account type"
+msgid "Standard"
+msgstr "আদর্শ"
+
+#: ../panels/user-accounts/um-account-type.c:37
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "প্রশাসক"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:107
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"আপনি এই ডিভাইস ব্যবহার করতে অনুমোদিত নন। অনুগ্রহ করে সিস্টেম প্রশাসকের সাথে "
+"যোগাযোগ করুন।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:109
+msgid "The device is already in use."
+msgstr "ডিভাইসটি বর্তমানে ব্যবহৃত হচ্ছে।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:111
+msgid "An internal error occurred."
+msgstr "একটি অভ্যন্তরীণ ত্রুটি হয়েছে।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:181
+#: ../panels/user-accounts/um-fingerprint-dialog.c:182
+msgid "Enabled"
+msgstr "সক্রিয়"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:224
+msgid "Delete registered fingerprints?"
+msgstr "নিবন্ধিত আঙ্গুলের ছাপ মুছে ফেলা হবে কি?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:228
+msgid "_Delete Fingerprints"
+msgstr "আঙ্গুলের ছাপ মুছে ফেলুন (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:235
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"আঙ্গুলের ছাপ সহযোগে লগ-ইন ব্যবস্থা নিষ্ক্রিয় করার উদ্দেশ্যে নিবন্ধিত আঙ্গুলের ছাপগুলি কি "
+"মুছে ফেলা হবে?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:363
+msgid "Done!"
+msgstr "সমাপ্ত!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:409
+#: ../panels/user-accounts/um-fingerprint-dialog.c:431
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' ডিভাইস ব্যবহার করা যাচ্ছেনা"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:480
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "'%s' ডিভাইসের মধ্যে আঙ্গুলের ছাপ প্রাপ্তিতে ব্যর্থ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:549
+msgid "Could not access any fingerprint readers"
+msgstr "আঙ্গুলের ছাপ পাঠের কোনো ব্যবস্থা প্রয়োগ করা যায়নি"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:550
+msgid "Please contact your system administrator for help."
+msgstr "অনুগ্রহ করে সহায়তার জন্য আপনার সিস্টেম প্রশাসকের সাথে যোগাযোগ করুন।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:587
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Enable Fingerprint Login"
+msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন সক্রিয়"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:621
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"আঙ্গুলের ছাপ সহযোগে লগ-ইন ব্যবস্থা সক্রিয় করার জন্য, '%s' ডিভাইস সহযোগে অন্তত একটি "
+"আঙ্গুলের ছাপ সংরক্ষণ করা আবশ্যক।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:629
+#, c-format
+msgid ""
+"Enrolling fingerprints for\n"
+"<b><big>%s</big></b>"
+msgstr ""
+"যার জন্য আঙ্গুলের ছাঁপ তালিকাভুক্ত করা হবে\n"
+"<b><big>%s</big></b>"
+
+#: ../panels/user-accounts/um-language-dialog.c:180
+msgid "Other..."
+msgstr "অন্যান্য..."
+
+#: ../panels/user-accounts/um-password-dialog.c:179
+msgid "More choices..."
+msgstr "আরও পছন্দ..."
+
+#: ../panels/user-accounts/um-password-dialog.c:285
+msgid "Please choose another password."
+msgstr "অনুগ্রহ করে আরেকটি পাসওয়ার্ড নির্বাচন করুন।"
+
+#: ../panels/user-accounts/um-password-dialog.c:294
+msgid "Please type your current password again."
+msgstr "অনুগ্রহ করে আপনার বর্তমান পাসওয়ার্ড আবার লিখুন।"
+
+#: ../panels/user-accounts/um-password-dialog.c:300
+msgid "Password could not be changed"
+msgstr "পাসওয়ার্ড পরিবর্তন করা যাবেনা"
+
+#: ../panels/user-accounts/um-password-dialog.c:372
+msgid "You need to enter a new password"
+msgstr "নতুন পাসওয়ার্ড দিতে হবে"
+
+#: ../panels/user-accounts/um-password-dialog.c:381
+msgid "You need to confirm the password"
+msgstr "পাসওয়ার্ড নিশ্চিত করতে হবে"
+
+#: ../panels/user-accounts/um-password-dialog.c:384
+msgid "The passwords do not match"
+msgstr "পাসওয়ার্ড মিলছে না"
+
+#: ../panels/user-accounts/um-password-dialog.c:390
+msgid "You need to enter your current password"
+msgstr "আপনার বর্তমান পাসওয়ার্ড দিতে হবে"
+
+#: ../panels/user-accounts/um-password-dialog.c:393
+msgid "The current password is not correct"
+msgstr "বর্তমান পাসওয়ার্ড সঠিক নয়"
+
+#: ../panels/user-accounts/um-password-dialog.c:466
+#: ../panels/user-accounts/um-password-dialog.c:683
+msgctxt "Password strength"
+msgid "Too short"
+msgstr "অনেক ছোট"
+
+#: ../panels/user-accounts/um-password-dialog.c:469
+#: ../panels/user-accounts/um-password-dialog.c:684
+msgctxt "Password strength"
+msgid "Weak"
+msgstr "দুর্বল"
+
+#: ../panels/user-accounts/um-password-dialog.c:471
+#: ../panels/user-accounts/um-password-dialog.c:685
+msgctxt "Password strength"
+msgid "Fair"
+msgstr "ন্যায্য"
+
+#: ../panels/user-accounts/um-password-dialog.c:473
+#: ../panels/user-accounts/um-password-dialog.c:686
+msgctxt "Password strength"
+msgid "Good"
+msgstr "ভালো"
+
+#: ../panels/user-accounts/um-password-dialog.c:475
+#: ../panels/user-accounts/um-password-dialog.c:687
+msgctxt "Password strength"
+msgid "Strong"
+msgstr "দৃঢ়"
+
+#: ../panels/user-accounts/um-password-dialog.c:514
+msgid "Passwords do not match"
+msgstr "পাসওয়ার্ড মিলছেনা"
+
+#: ../panels/user-accounts/um-password-dialog.c:540
+msgid "Wrong password"
+msgstr "ভুল পাসওয়ার্ড"
+
+#: ../panels/user-accounts/um-photo-dialog.c:97
+#: ../panels/user-accounts/data/language-chooser.ui.h:2
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+msgid "Select"
+msgstr "নির্বাচন"
+
+#: ../panels/user-accounts/um-photo-dialog.c:445
+msgid "Disable image"
+msgstr "চিত্র নিষ্ক্রিয় "
+
+#: ../panels/user-accounts/um-photo-dialog.c:463
+msgid "Take a photo..."
+msgstr "ফটো তুলুন..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:481
+msgid "Browse for more pictures..."
+msgstr "আরও ছবির জন্য ব্রাউজ করুন..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:706
+#, c-format
+msgid "Used by %s"
+msgstr "%s দ্বারা ব্যবহৃত"
+
+#: ../panels/user-accounts/um-user-manager.c:432
+#, c-format
+msgid "A user with name '%s' already exists."
+msgstr "'%s' নামের ব্যবহারকারী ইতোমধ্যেই বর্তমান।"
+
+#: ../panels/user-accounts/um-user-manager.c:527
+msgid "This user does not exist."
+msgstr "ব্যবহারকারী বিদ্যমান নয়"
+
+#: ../panels/user-accounts/um-user-panel.c:357
+msgid "Failed to delete user"
+msgstr "ব্যবহাকারী মুছে ফেলতে ব্যর্থ"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "You cannot delete your own account."
+msgstr "আপনি আপনার নিজের একাউন্ট মুছে ফেলতে পারবেননা।"
+
+#: ../panels/user-accounts/um-user-panel.c:426
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s এখনো লগ ইন রয়েছে"
+
+#: ../panels/user-accounts/um-user-panel.c:430
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"ব্যবহারকারীরা লগইন থাকা অবস্থায় তাদেরকে মুছে ফেললে সিস্টেমে অসামঞ্জস্য অবস্থা হতে "
+"পারে।"
+
+#: ../panels/user-accounts/um-user-panel.c:439
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "%s ফইলটি রেখে দিতে চান?"
+
+#: ../panels/user-accounts/um-user-panel.c:443
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"ব্যবহারকারীর একাউন্ট মুছে ফেলার সময় প্রধান ডিরেক্টরি, মেইল স্পুল এবং অস্থায়ী ফাইল "
+"রেখে দেওয়া যায়।"
+
+#: ../panels/user-accounts/um-user-panel.c:446
+msgid "_Delete Files"
+msgstr "ফাইল মুছে ফেলুন (_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:447
+msgid "_Keep Files"
+msgstr "ফাইল রাখুন (_K)"
+
+#: ../panels/user-accounts/um-user-panel.c:448
+msgid "_Cancel"
+msgstr "বাতিল (_C)"
+
+#: ../panels/user-accounts/um-user-panel.c:498
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "একাউন্ট নিষ্ক্রিয়"
+
+#: ../panels/user-accounts/um-user-panel.c:506
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "পরবর্তী লগ ইনে নির্ধারণ"
+
+#: ../panels/user-accounts/um-user-panel.c:509
+msgctxt "Password mode"
+msgid "None"
+msgstr "একটিও না"
+
+#: ../panels/user-accounts/um-user-panel.c:831
+msgid "Failed to contact the accounts service"
+msgstr "একাউন্ট সার্ভিসের সাথে যোগাযোগ করতে ব্যর্থ"
+
+#: ../panels/user-accounts/um-user-panel.c:833
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"অনুগ্রহপূর্বক নিশ্চিত হোন যে একাউন্ট সার্ভিস সঠিকভাবে ইনস্টল ও সক্রিয় করা আছে কি না"
+
+#: ../panels/user-accounts/um-user-panel.c:866
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"পরিবর্তন করতে,\n"
+"*আইকনটি প্রথমে ক্লিক করুন"
+
+#: ../panels/user-accounts/um-user-panel.c:904
+msgid "Create a user"
+msgstr "ব্যবহারকারী তৈরি"
+
+#: ../panels/user-accounts/um-user-panel.c:915
+#: ../panels/user-accounts/um-user-panel.c:1214
+msgid ""
+"To create a user,\n"
+"click the * icon first"
+msgstr ""
+"ব্যবহারকারী তৈরি করতে,\n"
+"*আইকনটি প্রথমে ক্লিক করুন"
+
+#: ../panels/user-accounts/um-user-panel.c:924
+msgid "Delete the selected user"
+msgstr "নির্বাচিত ব্যবহারকারী মুছে ফেলুন"
+
+#: ../panels/user-accounts/um-user-panel.c:936
+#: ../panels/user-accounts/um-user-panel.c:1219
+msgid ""
+"To delete the selected user,\n"
+"click the * icon first"
+msgstr "নির্বাচিত ব্যবহারকারী মুছে ফেলতে,*আইকনটি প্রথমে ক্লিক করুন"
+
+#: ../panels/user-accounts/um-user-panel.c:1114
+msgid "My Account"
+msgstr "আমার একাউন্ট"
+
+#: ../panels/user-accounts/um-user-panel.c:1124
+msgid "Other Accounts"
+msgstr "অন্যান্য একাউন্ট"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Add or remove users"
+msgstr "ব্যবহারকারী যোগ অথবা অপসারণ"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "লগ ইন;নাম;ফিঙ্গারপ্রিন্ট;এভাটার;লোগো;ফেস;পাসওয়ার্ড;"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "User Accounts"
+msgstr "ব্যবহারকারীর একাউন্ট"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "Cr_eate"
+msgstr "তৈরি (_e)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "Create new account"
+msgstr "নতুন অবস্থান তৈরি"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "_Account Type"
+msgstr "একাউন্টের ধরন (_A)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "_Full name"
+msgstr "পূর্ণ নাম (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+msgid "_Username"
+msgstr "ব্যবহারকারীর নাম (_U)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid ""
+"How to choose a "
+"strong password"
+msgstr ""
+"দৃঢ় পাসওয়ার্ড "
+"কিভাবে নির্বাচন করবেন"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+msgid ""
+"<small>This hint may be displayed at the login screen.  It will be visible "
+"to all users of this system.  Do <b>not</b> include the password here.</"
+"small>"
+msgstr ""
+"<small>ইঙ্গিতটি লগ ইন স্ক্রীণে প্রদর্শিত হতে পারে। এই সিস্টেমে সব ব্যবহারকারী "
+"দৃশ্যমান হবে। এখানে পাসওয়ার্ড যুক্ত <b>হবেনা।</b></small>"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "C_onfirm password"
+msgstr "পাসওয়ার্ড সুনিশ্চিত (_o)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "Ch_ange"
+msgstr "পরিবর্তন (_a)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Changing password for"
+msgstr "এর জন্য পাসওয়ার্ড পরিবর্তন"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Choose a generated password"
+msgstr "তৈরিকৃত একটি পাসওয়ার্ড নির্বাচন"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Choose password at next login"
+msgstr "পরবর্তী লগইনে পাসওয়ার্ড নির্বাচন"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Current _password"
+msgstr "বর্তমান পাসওয়ার্ড (_p)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+msgid "Disable this account"
+msgstr "একাউন্টটি নিষ্ক্রিয়"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+msgid "Enable this account"
+msgstr "একাউন্টটি সক্রিয়"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+msgid "Fair"
+msgstr "ন্যায্য"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+msgid "Log in without a password"
+msgstr "পাসওয়ার্ড ছাড়া লগইন"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid "Set a password now"
+msgstr "পাসওয়ার্ড এখনই নির্ধারণ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+msgid "_Action"
+msgstr "কাজ (_A)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:15
+msgid "_Hint"
+msgstr "ইঙ্গিত (_H)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:16
+msgid "_New password"
+msgstr "নতুন পাসওয়ার্ড (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:17
+msgid "_Show password"
+msgstr "পাসওয়ার্ড প্রদর্শন (_S)"
+
+# Translated by sadia
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+msgid "Browse"
+msgstr "ব্রাউজ"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+msgid "Changing photo for:"
+msgstr "এর জন্য ফটো পরিবর্তন করা হচ্ছে:"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+msgid ""
+"Choose a picture that will be shown at the login screen for this account."
+msgstr "এই একাউন্টের জন্য এই লগইন স্ক্রীণে যে ছবি দেখানো হবে তা নির্বাচন।"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+msgid "Gallery"
+msgstr "গ্যালারি"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr "ফটো"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+msgid "Take a photograph"
+msgstr "ফটো তুলুন"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+msgid "Account Information"
+msgstr "একাউন্টের তথ্য"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+msgid "Account type"
+msgstr "একাউন্টের ধরণ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Automatic Login"
+msgstr "স্বয়ংক্রিয় লগইন"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Fingerprint Login"
+msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "Login Options"
+msgstr "লগইন অপশন"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "Password"
+msgstr "পাসওয়ার্ড"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left index finger"
+msgstr "বামহাতের তর্জনি"
+
+# Translated by sadia
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left little finger"
+msgstr "বাম হাতের কড়ে আঙুল"
+
+# Translated by sadia
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left middle finger"
+msgstr "বামহাতের মধ্যাঙ্গুল"
+
+# Translated by sadia
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Left ring finger"
+msgstr "বামহাতের অনামিকা"
+
+# Translated by sadia
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Left thumb"
+msgstr "বাম হাতের বৃদ্ধাঙ্গুলি"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Other finger: "
+msgstr "অন্যান্য আঙ্গুল: "
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right index finger"
+msgstr "ডান হাতের তর্জনি"
+
+# Translated by sadia
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+msgid "Right little finger"
+msgstr "ডান হাতের কড়ে আঙুল"
+
+# Translated by sadia
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "Right middle finger"
+msgstr "ডান হাতের মধ্যাঙ্গুল"
+
+# Translated by sadia
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "Right ring finger"
+msgstr "ডান হাতের অনামিকা"
+
+# Translated by sadia
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "Right thumb"
+msgstr "ডান হাতের বৃদ্ধাঙ্গুলি"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"সাফল্যের সাথে আপনার আঙ্গুলের ছাপ সংরক্ষিত হয়েছে। আঙ্গুলের ছাপ রীডার সহযোগে আপনি "
+"এখন লগ-ইন করতে সক্ষম হবেন।"
+
+#: ../shell/control-center.c:50
+msgid "Enable verbose mode"
+msgstr "ভার্বোজ মোড সক্রিয় করা"
+
+#: ../shell/control-center.c:51
+msgid "Show the overview"
+msgstr "সারসংক্ষেপ প্রদর্শন"
+
+#: ../shell/control-center.c:52
+msgid "Panel to display"
+msgstr "প্রদর্শনের প্যানেল"
+
+#: ../shell/control-center.c:69
+msgid "- System Settings"
+msgstr "- সিস্টেমের সেটিং"
+
+#: ../shell/control-center.c:76
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"Run '%s --বিদ্যমান কমান্ড লাইন অপশনের সম্পূর্ণ তালিকা দেখতে সহায়তা করে।\n"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
+msgid "System Settings"
+msgstr "সিস্টেমের সেটিং"
+
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "নিয়ন্ত্রণ কেন্দ্র"
+
+#: ../shell/shell.ui.h:2
+msgid "_All Settings"
+msgstr "সব সেটিং (_A)"
+
+msgid "Show help options"
+msgstr "সহায়তা সংক্রান্ত অপশন প্রদর্শন করা হবে"
+
+#~ msgid "Clean print heads"
+#~ msgstr "মুদ্রণের হেড পরিষ্কার"
+
+#~ msgid "An error has occured during a maintenance command."
+#~ msgstr "কমান্ড রক্ষণাবেক্ষণের সময় ত্রুটি হয়েছে "
+
+#~ msgid "DSL"
+#~ msgstr "DSL"
+
+#~ msgid "Mobile Broadband"
+#~ msgstr "মোবাইল ব্রডব্যান্ড"
+
+#~ msgid "Image/label border"
+#~ msgstr "ছবি/লেবেল-এর সীমানা"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "সতর্ককারী ডায়ালগে লেবেল এবং ছবির চারপাশের সীমানার প্রস্থ"
+
+#~ msgid "The type of alert"
+#~ msgstr "সতর্কবাণীর ধরন"
+
+#~ msgid "Alert Buttons"
+#~ msgstr "সতর্কবাণীর বোতাম"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "সতর্ককারী ডায়ালগে প্রদর্শিত বোতাম"
+
+#~ msgid "Show more _details"
+#~ msgstr "অতিরিক্ত বিবরণ প্রদর্শন করা হবে (_d)"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "%s-র মধ্যে বামহাতের বুড়ো আঙ্গুল রাখুন"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "%s-এর উপর বামহাতের বুড়ো আঙ্গুল সোয়াইপ করুন"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "%s-এর মধ্যে বামহাতের তর্জনি রাখুন"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "%s-এর উপর বামহাতের তর্জনি সোয়াইপ করুন"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "%s-এর মধ্যে বামহাতের মধ্যমা রাখুন"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "%s-এর উপর বামহাতের মধ্যমা সোয়াইপ করুন"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "%s-এর মধ্যে বামহাতের অনামিকা রাখুন"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "%s-এর উপর বামহাতের অনামিকা সোয়াইপ করুন"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "%s-এর মধ্যে বামহাতের কনিষ্টা রাখুন"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "%s-এর উপর বামহাতের কনিষ্টা সোয়াইপ করুন"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "%s-এর মধ্যে ডান হাতের বুড়ো আঙ্গুল রাখুন"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "%s-এর উপর ডান হাতের বুড়ো আঙ্গুল সোয়াইপ করুন"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "%s-এর মধ্যে ডান হাতের তর্জনি রাখুন"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "%s-এর মধ্যে ডান হাতের তর্জনি সোয়াইপ করুন"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "%s-এর মধ্যে ডান হাতের মধ্যমা রাখুন"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "%s-এর উপর ডান হাতের মধ্যমা সোয়াইপ করুন"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "%s-এর মধ্যে ডান হাতের অনামিকা রাখুন"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "%s-এর উপর ডান হাতের অনামিকা সোয়াইপ করুন"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "%s-এর মধ্যে ডান হাতের কনিষ্টা রাখুন"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "%s-এর উপর ডান হাতের কনিষ্টা সোয়াইপ করুন"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "রিডারের উপর আপনার আঙ্গুন পুনরায় রাখুন"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "পুনরায় আপনার আঙ্গুল সোয়াইপ করুন"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "অত্যন্ত কম সময় সোয়াইপ করা হয়েছে, পুনরায় প্রচেষ্টা করুন"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "আঙ্গুল কেন্দ্রে স্থাপিত ছিল না, পুনরায় সোয়াইপ করার চেষ্টা করুন"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "আঙ্গুল সরিয়ে নিন ও পুনরায় তা রেখে সোয়াইপ করার প্রচেষ্টা করুন"
+
+#~ msgid "Select Image"
+#~ msgstr "ছবি বেছে নিন"
+
+#~ msgid "No Image"
+#~ msgstr "কোন ছবি নেই"
+
+#~ msgid "Images"
+#~ msgstr "ছবি"
+
+#~ msgid "All Files"
+#~ msgstr "সকল ফাইল"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "ঠিকানা-বই সংক্রান্ত তথ্য সংগ্রহের সময় একটি সমস্যা হয়েছে।\n"
+#~ "ব্যবহৃত প্রোটোকলকে Evolution ডাটা সার্ভার বুঝতে পারছে না"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "ঠিকানা-বই খোলা যায় নি"
+
+#~ msgid "About %s"
+#~ msgstr "%s-এর পরিচিতি"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "ঠিকানা (_d):"
+
+#~ msgid "C_ompany:"
+#~ msgstr "কোম্পানি (_o):"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "পাসওয়ার্ড পরিবর্তন... (_r)"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "শহর (_t):"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "দেশ (_n):"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন নিষ্ক্রিয় করুন...(_F)"
+
+# Translated by sadia
+#~ msgid "Email"
+#~ msgstr "ইমেইল"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "আঙ্গুলের ছাপ সহযোগে লগ-ইন সক্রিয় করুন...(_F)"
+
+#~ msgid "Hom_e:"
+#~ msgstr "হোম (_e):"
+
+#~ msgid "Home"
+#~ msgstr "হোম"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+# Translated by sadia
+#~ msgid "Instant Messaging"
+#~ msgstr "তাৎক্ষণিক বার্তা"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "পোস্ট বক্স (_b):"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. box:"
+
+#~ msgid "Personal Info"
+#~ msgstr "ব্যক্তিগত তথ্য"
+
+#~ msgid "Select your photo"
+#~ msgstr "আপনার ছবি নির্বাচন করুন"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "রাজ্য/প্রদেশ (_v):"
+
+# Translated by sadia
+#~ msgid "Telephone"
+#~ msgstr "টেলিফোন "
+
+#~ msgid "Web _log:"
+#~ msgstr "ওয়েব লগ (_l):"
+
+#~ msgid "Wor_k:"
+#~ msgstr "কর্মস্থল (_k):"
+
+# 
+# Translated by sadia
+#~ msgid "Work"
+#~ msgstr "কাজ"
+
+#~ msgid "Work _fax:"
+#~ msgstr "কর্মস্থলের ফ্যাক্স (_f):"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "জিপ/পোস্টাল কোড (_P):"
+
+#~ msgid "_Address:"
+#~ msgstr "ঠিকানা (_A):"
+
+#~ msgid "_Department:"
+#~ msgstr "বিভাগ (_D):"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "গ্রুপ অনুসারে: (_G)"
+
+#~ msgid "_Home page:"
+#~ msgstr "হোম-পেজ: (_H)"
+
+#~ msgid "_Home:"
+#~ msgstr "হোম: (_H)"
+
+#~ msgid "_Jabber:"
+#~ msgstr "জ্যাবার (_J):"
+
+#~ msgid "_Manager:"
+#~ msgstr "ব্যবস্থাপক: (_M)"
+
+#~ msgid "_State/Province:"
+#~ msgstr "রাজ্য/প্রদেশ (_S):"
+
+#~ msgid "_Work:"
+#~ msgstr "কর্মস্থল (_W):"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "জিপ/পোস্টাল কোড (_Z):"
+
+#~ msgid "Set your personal information"
+#~ msgstr "আপনার ব্যক্তিগত তথ্য লিখুন"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "রিডারের উপর আঙ্গুল সোয়াইপ করুন"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "রিডারের উপর আঙ্গুল রাখুন"
+
+#~ msgid "Select finger"
+#~ msgstr "আঙ্গুল বেছে নিন"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "চাইল্ড অপ্রত্যাশিতরূপে বন্ধ হয়ে গেছে"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO চ্যানেল বন্ধ করতে ব্যর্থ: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO চ্যানেল বন্ধ করতে ব্যর্থ: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "সিস্টেম সংক্রান্ত সমস্যা: %s।"
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%1$s আরম্ভ করতে ব্যর্থ: %2$s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "ব্যাক-এন্ড চালু করা যায় নি"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "সিস্টেম সংক্রান্ত সমস্যা হয়েছে"
+
+#~ msgid "Checking password..."
+#~ msgstr "পাসওয়ার্ড পরীক্ষা..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "পাসওয়ার্ড পরিবর্তনের জন্য <b>পাসওয়ার্ড পরিবর্তন</b> এ ক্লিক করুন।"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "অনুগ্রহ করে <b>নতুন পাসওয়ার্ড পুনরায় লিখুন</b> শীর্ষক ক্ষেত্রে পাসওয়ার্ড পুনরায় লিখুন।"
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "পাসওয়ার্ড পরিবর্তন (_s)"
+
+# Translated by sadia
+#~ msgid "Change your password"
+#~ msgstr "আপনার পাসওয়ার্ড পরিবর্তন করুন"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "পাসওয়ার্ড পরিবর্তনের জন্য নিম্নলিখিত ক্ষেত্রে নিজের বর্তমান পাসওয়ার্ড লিখুন ও "
+#~ "<b>অনুমোদন</b> এ ক্লিক করুন।\n"
+#~ "অনুমোদিত হলে, নতুন পাসওয়ার্ড লিখুন, সুনিশ্চিত করার জন্য পুনরায় পাসওয়ার্ড লিখে, "
+#~ "<b>পাসওয়ার্ড পরিবর্তন</b> এ ক্লিক করুন।"
+
+#~ msgid "_Authenticate"
+#~ msgstr "অনুমোদন (_A)"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "ব্যবহারযোগ্য লগ-ইন (_g)"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "সহায়ক প্রযুক্তি"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "সহায়ক প্রযুক্তি বিষয়ক পছন্দ"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "পুনরায় লগ-ইন না করা পর্যন্ত সহায়ক প্রযুক্তি সংক্রান্ত এই পরিবর্তনগুলি প্রয়োগ করা হবে "
+#~ "না।"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "বন্ধ করে লগ-আউট করুন (_L)"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "পছন্দের অ্যাপ্লিকেশনের ডায়ালগে যান"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "ব্যবহারযোগ্য লগ-ইন ডায়ালগে যান"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "কি-বোর্ড সহায়ক প্রযুক্তি ডায়ালগে যান"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "মাউস সহায়ক প্রযুক্তি ডায়ালগে যান"
+
+# Translated by sadia
+#~ msgid "Preferences"
+#~ msgstr "পছন্দসমূহ"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "সহায়ক প্রযুক্তি সক্রিয় করুন (_E)"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "মাউস ব্যবহারের সহায়ক প্রযুক্তি (_M)"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "পছন্দের অ্যাপ্লিকেশন (_P)"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr ""
+#~ "লগ-ইন করার সময়, বিশেষ ব্যবহারের কোনো ব্যবস্থাগুলি সক্রিয় করা হবে তা নির্বাচন করুন"
+
+#~ msgid "All files"
+#~ msgstr "সর্বধরনের ফাইল"
+
+#~ msgid "Font may be too large"
+#~ msgstr "ফন্টটি সম্ভবত অত্যধিক বড়"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "নির্বাচিত ফন্টটি %1$d পয়েন্ট বড় ও কম্পিউটারে ব্যবহারের ক্ষেত্রে সমস্যা সৃষ্টি করতে "
+#~ "পারে।  %2$d-র থেকে ছোট মাপ নির্বাচন করা বাঞ্ছনীয়।"
+#~ msgstr[1] ""
+#~ "নির্বাচিত ফন্টটি %d পয়েন্ট বড় ও কম্পিউটারে ব্যবহারের ক্ষেত্রে সমস্যা সৃষ্টি করতে "
+#~ "পারে।  %d-র থেকে কম মাপ নির্বাচন করা বাঞ্ছনীয়।"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "নির্বাচিত ফন্টটি %d পয়েন্ট বড় ও কম্পিউটারে ব্যবহারের ক্ষেত্রে সমস্যা সৃষ্টি করতে "
+#~ "পারে।  কম মাপের ফন্ট নির্বাচন করা বাঞ্ছনীয়।"
+#~ msgstr[1] ""
+#~ "নির্বাচিত ফন্টটি %d পয়েন্ট বড় ও কম্পিউটারে ব্যবহারের ক্ষেত্রে সমস্যা সৃষ্টি করতে "
+#~ "পারে।  কম মাপের ফন্ট নির্বাচন করা বাঞ্ছনীয়।"
+
+#~ msgid "Use previous font"
+#~ msgstr "পূর্ববর্তী ফন্ট ব্যবহার করা হবে"
+
+#~ msgid "Use selected font"
+#~ msgstr "নির্বাচিত ফন্ট ব্যবহার করা হবে"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "ইনস্টল করার জন্য কোন থিম ফাইলের নাম উল্লেখ করুন"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr "প্রদর্শনযোগ্য পৃষ্ঠার নাম চিহ্নিত করুন (theme|background|fonts|interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid "Install"
+#~ msgstr "ইনস্টল করুন"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "আবশ্যক GTK+ থিম ইঞ্জিন '%s' ইনস্টল না থাকার ফলে চিহ্নিত থিমটি সঠিকরূপে প্রদর্শিত "
+#~ "হবে না।"
+
+#~ msgid "Apply Background"
+#~ msgstr "পটভূমি প্রয়োগ করুন"
+
+#~ msgid "Apply Font"
+#~ msgstr "ফন্ট প্রয়োগ করুন"
+
+#~ msgid "Revert Font"
+#~ msgstr "ফন্টের নির্বাচন নাকচ করুন"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "এই থিমের ক্ষেত্রে প্রস্তাবিত পটভূমি ও ফন্ট উপস্থিত রয়েছে। উপরন্তু, সর্বশেষ প্রস্তাবিত "
+#~ "ফন্ট নাকচ করা যাবে।"
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "এই থিমের ক্ষেত্রে প্রস্তাবিত পটভূমি উপস্থিত রয়েছে। উপরন্তু, সর্বশেষ প্রস্তাবিত ফন্ট "
+#~ "নাকচ করা যাবে।"
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "এই থিমের জন্য প্রস্তাবিত পটভূমি ও ফন্ট উপস্থিত রয়েছে।"
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "এই থিমের ক্ষেত্রে প্রস্তাবিত ফন্ট উপস্থিত রয়েছে। উপরন্তু, সর্বশেষ প্রস্তাবিত ফন্ট "
+#~ "নাকচ করা যাবে।"
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "এই থিমের জন্য প্রস্তাবিত পটভূমি উপস্থিত রয়েছে।"
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "সর্বশেষ প্রয়োগ করা প্রস্থাবিত ফন্টের নির্বাচন নাকচ করা যাবে।"
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "এই থিমের জন্য প্রস্তাবিত  ফন্ট উপস্থিত রয়েছে।"
+
+#~ msgid "Best _shapes"
+#~ msgstr "সর্বোত্তম আকার (_s)"
+
+# Translated by sadia
+#~ msgid "C_olors:"
+#~ msgstr "রং: (_o)"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "স্বনির্ধারিত...(_u)"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "কার্সারের থিম পরিবর্তন করা হলে, পরবর্তী লগ-ইনের পরে তা প্রয়োগ করা হবে।"
+
+#~ msgid "Colors"
+#~ msgstr "রং"
+
+#~ msgid "Controls"
+#~ msgstr "নিয়ন্ত্রণ"
+
+#~ msgid "Customize Theme"
+#~ msgstr "স্বনির্ধারিত থিম"
+
+#~ msgid "D_etails..."
+#~ msgstr "বিবরণ...(_e)"
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "ডেস্কটপে ব্যবহৃত ফন্ট (_k):"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "ফন্ট আঁকার খুঁটিনাটি"
+
+# Translated by sadia
+#~ msgid "Get more backgrounds online"
+#~ msgstr "অনলাইনে আরও পটভূমি পাওয়া যাবে"
+
+# Translated by sadia
+#~ msgid "Get more themes online"
+#~ msgstr "অনলাইনে আরও থিম পাওয়া যাবে"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "গ্রে-স্কেল (_y)"
+
+#~ msgid "Icons"
+#~ msgstr "আইকন"
+
+#~ msgid "Icons only"
+#~ msgstr "শুধুমাত্র আইকন"
+
+#~ msgid "N_one"
+#~ msgstr "শূণ্য (_o)"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "রং নির্ধারণের জন্য একটি ডায়ালগ খুলুন"
+
+#~ msgid "R_esolution:"
+#~ msgstr "রেজল্যুশন: (_e)"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "নতুন রূপে থিম সংরক্ষণ..."
+
+#~ msgid "Save _As..."
+#~ msgstr "নতুন রূপে সংরক্ষণ...(_A)"
+
+# Translated by sadia
+#~ msgid "Stretch"
+#~ msgstr "প্রসারিত করুন"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "সাবপিক্সেল (LCD) (_p)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "সাবপিক্সেল মসৃণকরণ (LCD) (_p)"
+
+# Translated by sadia
+#~ msgid "Subpixel Order"
+#~ msgstr "সাবপিক্সেলের ধারা "
+
+#~ msgid "Text below items"
+#~ msgstr "আইটেমের নিচের টেক্সট"
+
+#~ msgid "Text beside items"
+#~ msgstr "আইটেমের পাশের টেক্সট"
+
+#~ msgid "Text only"
+#~ msgstr "শুধুমাত্র টেক্সট"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "বর্তমান নিয়ন্ত্রণের থিমগুলো দ্বারা রং এর সংকলন সমর্থিত হয় না।"
+
+#~ msgid "Theme"
+#~ msgstr "থিম"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "Window Border"
+#~ msgstr "উইন্ডোর সীমানা"
+
+#~ msgid "_Add..."
+#~ msgstr "যোগ করুন... (_A)"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "বর্ণনা (_D):"
+
+#~ msgid "_Document font:"
+#~ msgstr "ডকুমেন্ট-এ ব্যবহৃত ফন্ট (_D):"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "নির্দিষ্ট প্রস্থবিশিষ্ট ফন্ট (_F):"
+
+#~ msgid "_Medium"
+#~ msgstr "মাঝারি (_M)"
+
+#~ msgid "_Monochrome"
+#~ msgstr "সাদা-কালো (_M)"
+
+#~ msgid "_None"
+#~ msgstr "শূণ্য (_N)"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+# FIXME
+#~ msgid "_Reset to Defaults"
+#~ msgstr "ডিফল্ট মান পুনরায় স্থাপন (_R)"
+
+#~ msgid "_Selected items:"
+#~ msgstr "নির্বাচিত আইটেম (_S):"
+
+#~ msgid "_Size:"
+#~ msgstr "আকার (_S):"
+
+#~ msgid "_Slight"
+#~ msgstr "স্বল্প (_S)"
+
+#~ msgid "_Style:"
+#~ msgstr "বিন্যাস (_S):"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "টুল-টিপ (_T):"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "উইন্ডোর শিরোনামে ব্যবহৃত ফন্ট (_W):"
+
+#~ msgid "_Windows:"
+#~ msgstr "উইন্ডোজ (_W):"
+
+#~ msgid "dots per inch"
+#~ msgstr "প্রতি ইঞ্চিতে ডটের সংখ্যা"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "ডেস্কটপের চেহারা পছন্দ অনুসারে নির্ধারণ করুন"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "ডেস্কটপের বিভিন্ন অংশের জন্য থিমের প্যাকেজ ইনস্টল করে"
+
+#~ msgid "Theme Installer"
+#~ msgstr "থিম ইনস্টলার"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Gnome থিম প্যাকেজ"
+
+#~ msgid "Slide Show"
+#~ msgstr "স্লাইড-শো"
+
+# Translated by sadia
+#~ msgid "Image"
+#~ msgstr "ছবি"
+
+# Translated by sadia
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+
+# Translated by sadia
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "থিম ইনস্টল করা যাবে না"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s ব্যবস্থা ইনস্টল করা নেই।"
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "থিম এক্সট্র্যাক্ট করতে সমস্যা।"
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "নির্বাচিত ফাইল ইনস্টল করতে সমস্যা"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" সম্ভবত বৈধ থিম ফাইল নয়।"
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" সম্ভবত বৈধ থিম ফাইল নয়। থিম ইঞ্জিন হয়ে থাকলে এটি কম্পাইল করা আবশ্যক।"
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "\"%s\" থিম ইনস্টল করতে ব্যর্থ"
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "\"%s\" থিম ইনস্টল করা হয়েছে।"
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "আপনি কি এটি এখন প্রয়োগ করতে চান, না বর্তমান থিম অপরিবর্তিত রাখা হবে?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "বর্তমান থিম অপরিবর্তিত রাখা হবে"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "নতুন থিম প্রয়োগ করা হবে"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME Tথিম %s সঠিকভাবে ইনস্টল করা আছে"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "নতুন থিম সাফল্যের সাথে ইনস্টল করা হয়েছে।"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "ইনস্টল করার জন্য কোন থিম ফাইলের অবস্থান উল্লেখ করা হয় নি"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "থিমটি এখানে ইনস্টল করার জন্য প্রয়োজনীয় অনুমতি নেই:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "থিম বেছে নিন"
+
+#~ msgid "Theme Packages"
+#~ msgstr "থিম প্যাকেজ"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "থিমের অবশ্যই একটি নাম থাকতে হবে"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "থিমটি ইতিমধ্যেই বিদ্যমান।  আপনি কি এটিকে প্রতিস্থাপন করতে চান?"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "আপনি কি এই থিমটি মুছে ফেলতে ইচ্ছুক?"
+
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "থিম মুছে ফেলা যাবে না"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "থিম ইঞ্জিন ইনস্টল করা যায়নি"
+
+# Translated by sadia
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "'জিনোম-সেটিংস-ডেমো' নামক বৈশিষ্ট্য নির্ধারণী ব্যবস্থাপকটিকে চালু করা যাচ্ছে না।\n"
+#~ "জিনোম বৈশিষ্ট্য নির্ধারণী ব্যবস্থাপকটিকে না চালানো গেলে, কিছু বৈশিষ্ট্য কার্যকর "
+#~ "হবে না। এটি হয়ত ডিবাস এর সাথে কোন সমস্যার কারণে হতে পারে অথবা জিনোমের অংশ "
+#~ "নয় (উদাহরণস্বরূপ কেডিই) এরকম কোন বৈশিষ্ট্য নির্ধারণী ব্যবস্থাপক হয়ত ইতিমধ্যেই "
+#~ "সক্রিয় আছে এবং জিনোম বৈশিষ্ট্য নির্ধারণী ব্যবস্থাপকের সাথে বিরোধ দেখাচ্ছে।"
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "স্টক আইকন '%s' লোড করা যায় নি\n"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "সাহায্যকারী তথ্য দেখাতে সমস্যা হয়েছে: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "ফাইল অনুলিপি করা হচ্ছে: %2$u এর %1$u"
+
+#~ msgid "Copying '%s'"
+#~ msgstr " '%s'-কে অনুলিপি করা হচ্ছে"
+
+#~ msgid "Parent Window"
+#~ msgstr "প্যারেন্ট উইন্ডো"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "বর্তমান ডায়লগের প্যারেন্ট উইন্ডো"
+
+#~ msgid "From URI"
+#~ msgstr "URI থেকে"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI থেকে বর্তমানে স্থানান্তরিত হচ্ছে"
+
+#~ msgid "To URI"
+#~ msgstr "URI এর উদ্দেশ্যে"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI-এ বর্তমানে স্থানান্তরিত হচ্ছে"
+
+#~ msgid "Fraction completed"
+#~ msgstr "আংশিক সম্পন্ন"
+
+# FIXME: ভাল শোনাচ্ছে না ;-(
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "এ পর্যন্ত স্থানান্তরিত তথ্যের পরিমাণ (ভগ্নাংশ হিসেবে)"
+
+#~ msgid "Current URI index"
+#~ msgstr "বর্তমান URI সূচি"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "বর্তমান URI সূচি - আরম্ভ হয়েছে ১ থেকে"
+
+#~ msgid "Total URIs"
+#~ msgstr "সর্বমোট URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "সর্বমোট URI সংখ্যা"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr ""
+#~ "'%s' ফাইলটি বর্তমানে উপস্থিত রয়েছে।  আপনি কি এটিকে প্রতিস্থাপন করতে চান?"
+
+#~ msgid "_Skip"
+#~ msgstr "উপেক্ষা করুন (_S)"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "সমস্ত নতুন করে লেখা হবে (_A)"
+
+# FIXME
+#~ msgid "Default Pointer - Current"
+#~ msgstr "ডিফল্ট পয়েন্টার - বর্তমানে যেটি ব্যবহৃত হচ্ছে"
+
+#~ msgid "White Pointer"
+#~ msgstr "সাদা পয়েন্টার"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "সাদা পয়েন্টার - বর্তমানে যেটি ব্যবহৃত হচ্ছে"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "বড় পয়েন্টার - বর্তমানে যেটি ব্যবহৃত হচ্ছে"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "বড় সাদা পয়েন্টার - বর্তমানে যেটি ব্যবহৃত হচ্ছে"
+
+#~ msgid "Large White Pointer"
+#~ msgstr "বড় সাদা পয়েন্টার"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "আবশ্যক GTK+ থিম '%s' ইনস্টল না থাকার ফলে চিহ্নিত থিমটি সঠিকরূপে প্রদর্শিত হবে "
+#~ "না।"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "আবশ্যক উইন্ডো পরিচালন ব্যবস্থার থিম '%s' ইনস্টল না থাকার ফলে চিহ্নিত থিমটি "
+#~ "সঠিকরূপে প্রদর্শিত হবে না।"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "আবশ্যক আইকন থিম '%s' ইনস্টল না থাকার ফলে চিহ্নিত থিমটি সঠিকরূপে প্রদর্শিত হবে "
+#~ "না।"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "পছন্দের অ্যাপলিকেশন"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "পছন্দসই ভিজুয়াল সহায়ক প্রযুক্তি আরম্ভ করা হবে"
+
+# FIXME: এটা আবার কি জিনিষ?!!#@!
+#~ msgid "Visual Assistance"
+#~ msgstr "ভিজুয়াল সহায়তা"
+
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "কনফিগারেশন সংরক্ষণ করতে সমস্যা হয়েছে: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "মূল ইন্টারফেস লোড করা যায় নি"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr "প্রদর্শনযোগ্য পৃষ্ঠার নাম উল্লেখ করুন (internet|multimedia|system|a11y)"
+
+#~ msgid "Accessibility"
+#~ msgstr "সহায়ক প্রযুক্তি"
+
+# FIXME
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "%s-টির সবগুলোকেই প্রকৃত লিঙ্ক দ্বারা প্রতিস্থাপিত করা হবে"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "কমান্ড (_m):"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "এক্সিকিউট ফ্ল্যাগ (_x):"
+
+# Translated by sadia
+#~ msgid "Image Viewer"
+#~ msgstr "ছবি প্রদর্শক"
+
+# Translated by sadia
+#~ msgid "Instant Messenger"
+#~ msgstr "তাৎ‍ক্ষণিক বার্তাবাহক "
+
+#~ msgid "Internet"
+#~ msgstr "ইন্টারনেট"
+
+# Translated by sadia
+#~ msgid "Mail Reader"
+#~ msgstr "মেইল পাঠক"
+
+# Translated by sadia
+#~ msgid "Mobility"
+#~ msgstr "গতিময়তা"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "নতুন ট্যাবর মধ্যে লিংক প্রদর্শন করা হবে (_t)"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "নতুন উইন্ডোর মধ্যে লিংক প্রদর্শন করা হবে (_w)"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "ওয়েব-ব্রাউজারের ডিফল্ট মান প্রয়োগ করে লিংক প্রদর্শন করা হবে (_d)"
+
+#~ msgid "Run at st_art"
+#~ msgstr "প্রারম্ভে সঞ্চালিত হবে (_a)"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "টার্মিনালে সঞ্চালন (_e)"
+
+# Translated by sadia
+#~ msgid "Terminal Emulator"
+#~ msgstr "টার্মিনাল এমুলেটর"
+
+# Translated by sadia
+#~ msgid "Text Editor"
+#~ msgstr "টেক্সট সম্পাদক "
+
+#~ msgid "_Run at start"
+#~ msgstr "প্রারম্ভে সঞ্চালিত হবে (_R)"
+
+#~ msgid "Balsa"
+#~ msgstr "বালসা"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "বাঁশী সংগীত বাদন ব্যবস্থা"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws মেইল"
+
+# FIXME
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "ডেবিয়ান সেনসিবল ব্রাউজার"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "ডেবিয়ান টার্মিনাল ইমুলেটর"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "ইনকমপাস"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "ইভোল্যুশন মেইল রিডার"
+
+#~ msgid "Firefox"
+#~ msgstr "ফায়ার ফক্স"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "পর্দার তথ্যে পাঠের ব্যবস্থা বিহীন GNOME বিবর্ধক"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "GNOME টার্মিনাল"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "বিবর্ধক সহ Gnopernicus"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape মেইল"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "পর্দার তথ্যে পাঠের ব্যবস্থা বিহীন KDE বিবর্ধক"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "কনসোল"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "বিবর্ধক সহ লিনাক্স স্ক্রীণ রিডার"
+
+#~ msgid "Listen"
+#~ msgstr "লিসেন"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "মোজিলা"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "মোজিলা ১.৬"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "মোজিলা মেইল"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "মোজিলা থান্ডারবার্ড"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "নেটস্কেপ কমিউনিকেটর"
+
+#~ msgid "Opera"
+#~ msgstr "অপেরা"
+
+#~ msgid "Orca"
+#~ msgstr "অর্কা"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "বিবর্ধক সহ অর্কা"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "রাইমবক্স সংগীত বাদন ব্যবস্থা"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "সিমাংকি"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "সিমাংকি মেইল"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Thunderbird"
+#~ msgstr "থান্ডারবার্ড"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "টটেম চলচ্চিত্র বাদন ব্যবস্থা"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Include _panel"
+#~ msgstr "প্যানেল অন্তর্ভুক্ত করা হবে (_p)"

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -17,9 +17,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: unnamed project\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2020-09-25 14:17+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2020-10-11 12:38+0530\n"
 "Last-Translator: Akarshan Biswas <akarshan.biswas@hotmail.com>\n"
 "Language-Team: Bengali <anubad@lists.ankur.org.in>\n"
@@ -31,331 +30,225 @@ msgstr ""
 "X-DamnedLies-Scope: partial\n"
 "X-Generator: Gtranslator 3.38.0\n"
 
-#: panels/applications/cc-applications-panel.c:815
-msgid "System Bus"
-msgstr "সিস্টেমের বাস"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/applications/cc-applications-panel.c:815
-#: panels/applications/cc-applications-panel.c:817
-#: panels/applications/cc-applications-panel.c:830
-#: panels/applications/cc-applications-panel.c:835
-msgid "Full access"
-msgstr "পূর্ণ প্রবেশাধিকার"
-
-#: panels/applications/cc-applications-panel.c:817
-msgid "Session Bus"
-msgstr "সেশন বাস"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#: panels/applications/cc-applications-panel.c:821
-#: panels/power/cc-power-panel.c:2325 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525
-msgid "Devices"
-msgstr "ডিভাইসগুলি"
-
-#: panels/applications/cc-applications-panel.c:821
-msgid "Full access to /dev"
-msgstr "/dev এ সম্পূর্ণ অ্যাক্সেস"
-
-# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
-#: panels/applications/cc-applications-panel.c:825
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:252
-msgid "Network"
-msgstr "নেটওয়ার্ক"
-
-# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/applications/cc-applications-panel.c:825
-msgid "Has network access"
-msgstr "নেটওয়ার্ক অ্যাক্সেস আছে"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/applications/cc-applications-panel.c:830
-#: panels/applications/cc-applications-panel.c:832
-#: panels/search/cc-search-locations-dialog.c:361
-msgid "Home"
-msgstr "গৃহ"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/applications/cc-applications-panel.c:837
-msgid "Read-only"
-msgstr "শুধুমাত্র পাঠযোগ্য"
-
-#: panels/applications/cc-applications-panel.c:835
-#: panels/applications/cc-applications-panel.c:837
-msgid "File System"
-msgstr "ফাইল সিস্টেম"
-
-#: panels/applications/cc-applications-panel.c:841
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:279
-#: shell/cc-window.c:933 shell/cc-window.ui:121
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr "সেটিং"
-
-#: panels/applications/cc-applications-panel.c:841
-msgid "Can change settings"
-msgstr "সেটিংস পরিবর্তন করতে পারে"
-
-#: panels/applications/cc-applications-panel.c:843
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s এর অন্তর্নির্মিত নিম্নলিখিত অনুমতি রয়েছে। এগুলি পরিবর্তন করা যায় না। আপনি যদি এই "
-"অনুমতিগুলি সম্পর্কে উদ্বিগ্ন হন তবে এই অ্যাপ্লিকেশনটি সরিয়ে ফেলার কথা বিবেচনা করুন।"
-
-#: panels/applications/cc-applications-panel.c:1016
-msgid "Web Links"
-msgstr "ওয়েব লিংকগুলি"
-
-#: panels/applications/cc-applications-panel.c:1026
-msgid "Git Links"
-msgstr "গিট লিঙ্কগুলি"
-
-#: panels/applications/cc-applications-panel.c:1032
-#, c-format
-msgid "%s Links"
-msgstr "%s লিঙ্কগুলি"
-
-#: panels/applications/cc-applications-panel.c:1040
-#: panels/applications/cc-applications-panel.c:1076
-msgid "Unset"
-msgstr "আনসেট"
-
-#: panels/applications/cc-applications-panel.c:1131
-msgid "Links"
-msgstr "লিঙ্কেগুলি"
-
-#: panels/applications/cc-applications-panel.c:1139
-msgid "Hypertext Files"
-msgstr "হাইপারটেক্সট ফাইলগুলি"
-
-#: panels/applications/cc-applications-panel.c:1153
-msgid "Text Files"
-msgstr "পাঠ্য ফাইলগুলি"
-
-#: panels/applications/cc-applications-panel.c:1167
-msgid "Image Files"
-msgstr "চিত্র ফাইলগুলি"
-
-#: panels/applications/cc-applications-panel.c:1183
-msgid "Font Files"
-msgstr "ফন্ট ফাইলগুলি"
-
-#: panels/applications/cc-applications-panel.c:1244
-msgid "Archive Files"
-msgstr "সংরক্ষণাগার ফাইলগুলি"
-
-#: panels/applications/cc-applications-panel.c:1264
-msgid "Package Files"
-msgstr "প্যাকেজ ফাইলগুলি"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/applications/cc-applications-panel.c:1287
-msgid "Audio Files"
-msgstr "অডিও ফাইলগুলি"
-
-#: panels/applications/cc-applications-panel.c:1304
-msgid "Video Files"
-msgstr "ভিডিও ফাইলগুলি"
-
-#: panels/applications/cc-applications-panel.c:1312
-msgid "Other Files"
-msgstr "অন্যান্য ফাইলগুলি"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1652
-#: panels/applications/cc-applications-panel.ui:416
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:78
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr "অ্যাপ্লিকেশনগুলি"
 
-#: panels/applications/cc-applications-panel.ui:43
+#: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
 msgstr "কোনও অ্যাপ্লিকেশন নেই"
 
-#: panels/applications/cc-applications-panel.ui:57
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr "কিছু ইনস্টল করুন…"
 
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "খুলুন (_O)"
+
 #: panels/applications/cc-applications-panel.ui:94
-msgid "Permissions & Access"
-msgstr "অনুমতি এবং অ্যাক্সেস"
-
-#: panels/applications/cc-applications-panel.ui:106
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-"এই অ্যাপ্লিকেশনটি যে ডেটা এবং পরিষেবাদিগুলির অ্যাক্সেস এবং এর জন্য প্রয়োজনীয় "
-"অনুমতিগুলির জন্য বলেছে।"
-
-#: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:127
-#: panels/camera/gnome-camera-panel.desktop.in.in:3
-msgid "Camera"
-msgstr "ক্যামেরা"
+#, fuzzy
+msgid "View Details"
+msgstr "বিস্তারিত দেখুন(_V)"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:128
-#: panels/applications/cc-applications-panel.ui:140
-#: panels/applications/cc-applications-panel.ui:152
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:262
-#: panels/keyboard/cc-keyboard-option.c:259
-#: panels/keyboard/cc-keyboard-option.c:378
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:85
-#: panels/keyboard/keyboard-shortcuts.c:368 panels/network/network-proxy.ui:126
-#: panels/user-accounts/cc-user-panel.c:865
-#: panels/user-accounts/cc-user-panel.c:957
-#: subprojects/gvc/gvc-mixer-control.c:1876
-msgid "Disabled"
-msgstr "নিষ্ক্রিয়"
-
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:139
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
-msgid "Microphone"
-msgstr "মাইক"
-
-# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:151
-#: panels/location/gnome-location-panel.desktop.in.in:3
-msgid "Location Services"
-msgstr "অবস্থান পরিষেবা"
-
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:499
-msgid "Built-in Permissions"
-msgstr "অন্তর্নির্মিত অনুমতিগুলি"
-
-#: panels/applications/cc-applications-panel.ui:158
-msgid "Cannot be changed"
-msgstr "পরিবর্তন করা যাবে না"
-
-#: panels/applications/cc-applications-panel.ui:175
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-"<a href=\"privacy\">গোপনীয়তা</a>সেটিংসে অ্যাপ্লিকেশনগুলির জন্য পৃথক অনুমতিগুলি "
-"পর্যালোচনা করা যেতে পারে।"
-
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#: panels/applications/cc-applications-panel.ui:199
-msgid "Integration"
-msgstr "মিশ্রণ"
-
-#: panels/applications/cc-applications-panel.ui:211
-msgid "System features used by this application."
-msgstr "এই অ্যাপ্লিকেশন দ্বারা ব্যবহৃত সিস্টেম বৈশিষ্ট্যগুলি।"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/applications/cc-applications-panel.ui:225
-#: panels/applications/cc-applications-panel.ui:231
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:151
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "অনুসন্ধান"
 
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "নিষ্ক্রিয়"
+
 # auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
-#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr "সূচনাবার্তা"
 
-#: panels/applications/cc-applications-panel.ui:243
-msgid "Run in background"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "বিজ্ঞপ্তিগুলি দেখান (_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "ব্যাকগ্রাউন্ডে চালান"
 
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/applications/cc-applications-panel.ui:249
-msgid "Set Desktop Background"
-msgstr "ডেস্কটপ ওয়ালপেপার সেট করুন"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "স্ক্রীনশট"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "ওয়ালপেপার"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/applications/cc-applications-panel.ui:255
-#: panels/applications/cc-applications-panel.ui:261
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "ধ্বনি"
 
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "শর্টকাট সেট করুন"
+
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/applications/cc-applications-panel.ui:267
-msgid "Inhibit system keyboard shortcuts"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
 msgstr "সিস্টেম কীবোর্ড শর্টকাটগুলি বাধা দিন"
 
-#: panels/applications/cc-applications-panel.ui:300
-msgid "Default Handlers"
-msgstr "ডিফল্ট হ্যান্ডেলার"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "ক্যামেরা"
 
-#: panels/applications/cc-applications-panel.ui:312
-msgid "Types of files and links that this application opens."
-msgstr "এই অ্যাপ্লিকেশনটি খোলার ফাইল এবং লিঙ্কগুলির প্রকার।"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:328
-msgid "Reset"
-msgstr "পুনঃসেট"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "মাইক"
 
-#: panels/applications/cc-applications-panel.ui:364
-msgid "Usage"
-msgstr "ব্যবহার"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:376
-msgid "How much resources this application is using."
-msgstr "এই অ্যাপ্লিকেশনটি কতগুলি সংস্থান ব্যবহার করছে।"
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "অবস্থান পরিষেবা"
 
-#: panels/applications/cc-applications-panel.ui:391
-#: panels/applications/cc-applications-panel.ui:535
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "অন্তর্নির্মিত অনুমতিগুলি"
+
+#: panels/applications/cc-applications-panel.ui:223
+#, fuzzy
+msgid "System access that is required by the app"
+msgstr "এই অ্যাপ্লিকেশন দ্বারা ব্যবহৃত সিস্টেম বৈশিষ্ট্যগুলি।"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "সংগ্রহস্থল"
 
-#: panels/applications/cc-applications-panel.ui:423
-msgid "Open in Software"
-msgstr "সফটওয়্যার এ খুলুন"
-
-#: panels/applications/cc-applications-panel.ui:473 shell/cc-panel-list.ui:121
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "কোন ফলাফল পাওয়া যায়নি"
 
-#: panels/applications/cc-applications-panel.ui:484
-#: panels/keyboard/cc-keyboard-panel.ui:189 shell/cc-panel-list.ui:132
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "একটি ভিন্ন অনুসন্ধান চেষ্টা করুন"
 
-#: panels/applications/cc-applications-panel.ui:552
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "ফাইল সিস্টেম"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "লিঙ্কের গতি"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "পুনঃসেট"
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "অ্যাপ্লিকেশন ডেটা এবং ক্যাশেগুলির সাথে এই অ্যাপ্লিকেশনটি কত ডিস্ক স্পেস দখল করছে।"
 
-#: panels/applications/cc-applications-panel.ui:561
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "অ্যাপ্লিকেশন"
 
-#: panels/applications/cc-applications-panel.ui:567
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "ডেটা"
 
-#: panels/applications/cc-applications-panel.ui:573
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "ক্যাশে"
 
-#: panels/applications/cc-applications-panel.ui:579
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>মোট</b>"
 
-#: panels/applications/cc-applications-panel.ui:596
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "ক্যাশে পরিষ্কার করুন…"
 
@@ -363,134 +256,102 @@ msgstr "ক্যাশে পরিষ্কার করুন…"
 msgid "Control various application permissions and settings"
 msgstr "বিভিন্ন অ্যাপ্লিকেশন অনুমতি এবং সেটিংস নিয়ন্ত্রণ করুন"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "অ্যাপ্লিকেশান;ফ্ল্যাটপ্যাক;অনুমতি;সেটিং;"
 
-#: panels/background/cc-background-chooser.c:346
-msgid "Select a picture"
-msgstr "একটি ছবি নির্বাচন করুন"
-
-#: panels/background/cc-background-chooser.c:349
-#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:238
-#: panels/color/cc-color-panel.c:886 panels/color/cc-color-panel.ui:657
-#: panels/common/cc-language-chooser.ui:24
-#: panels/display/cc-display-panel.c:943
-#: panels/info-overview/cc-info-overview-panel.ui:234
-#: panels/network/cc-wifi-hotspot-dialog.ui:122
-#: panels/network/cc-wifi-panel.c:865
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:176
-#: panels/network/connection-editor/vpn-helpers.c:299
-#: panels/network/net-device-wifi.c:854
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:251
-#: panels/region/cc-format-chooser.ui:28 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:638
-#: panels/sharing/cc-sharing-panel.c:396 panels/usage/cc-usage-panel.c:133
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:107
-#: panels/user-accounts/cc-avatar-chooser.c:235
-#: panels/user-accounts/cc-fingerprint-dialog.ui:36
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:652
-#: panels/user-accounts/cc-user-panel.c:670
-#: panels/user-accounts/data/join-dialog.ui:20
-msgid "_Cancel"
-msgstr "বাতিল করুন (_C)"
-
-#: panels/background/cc-background-chooser.c:350
-#: panels/network/connection-editor/vpn-helpers.c:177
-#: panels/printers/pp-details-dialog.c:252
-#: panels/sharing/cc-sharing-panel.c:397
-#: panels/user-accounts/cc-avatar-chooser.c:236
-msgid "_Open"
-msgstr "খুলুন (_O)"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "স্টাইলাস"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/background/cc-background-item.c:140
-msgid "multiple sizes"
-msgstr "একাধিক মাপ"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "ডিফল্ট"
 
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:144
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/background/cc-background-item.c:282
-msgid "No Desktop Background"
-msgstr "ডেস্কটপের কোনো পটভূমি প্রয়োগ করা হবে না"
-
-#: panels/background/cc-background-panel.c:112
-msgid "Current background"
-msgstr "বর্তমান পটভূমি"
-
-#: panels/background/cc-background-panel.ui:55
-msgid "Add Picture…"
-msgstr "ছবি যুক্ত করুন ..."
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "ক্রিয়াকলাপ"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "পটভূমি"
 
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "ছবি যুক্ত করুন ..."
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "ফ্রান্স"
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "আপনার পটভূমি চিত্রটি ওয়ালপেপার বা ফটোতে পরিবর্তন করুন"
 
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "ওয়ালপেপার;স্ক্রীন;ডেস্কটপ;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "সক্ষম করুন(_E)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "কোনো Bluetooth পাওয়া যায়নি"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "ব্লুটুথ ব্যবহার করতে একটি ডিঙ্গলে প্লাগ করুন।"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:69
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "ব্লুটুথ বন্ধ আছে"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:80
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "ডিভাইসগুলি সংযোগ করতে এবং ফাইল স্থানান্তর গ্রহণ করতে চালু করুন।"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:107
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "বিমান মোড চালু আছে"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:118
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "বিমান মোড চালু থাকলে ব্লুটুথ অক্ষম করা হয়।"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:124
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "বিমান মোড বন্ধ করুন"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:154
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
 msgstr "হার্ডওয়্যার এয়ারপ্লেন মোড চালু আছে"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:165
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "ব্লুটুথ সক্ষম করতে বিমান মোড সুইচটি বন্ধ করুন।"
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1628
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -498,32 +359,31 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Bluetooth চালু এবং বন্ধ করুন এবং আপনার ডিভাইসগুলি সংযুক্ত করুন"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "ভাগ;ভাগকরা;ব্লুটুথ;ওবেক্স;"
 
-#: panels/camera/cc-camera-panel.ui:34
-msgid "Camera is turned off"
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
 msgstr "ক্যামেরা বন্ধ আছে"
 
-#: panels/camera/cc-camera-panel.ui:43
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "কোনও অ্যাপ্লিকেশন ফটো বা ভিডিও ক্যাপচার করতে পারে না।"
 
-#: panels/camera/cc-camera-panel.ui:75
+#: panels/camera/cc-camera-panel.ui:39
+#, fuzzy
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 "ক্যামেরার ব্যবহার অ্যাপ্লিকেশনগুলিকে ফটো এবং ভিডিও ক্যাপচার করতে দেয়। ক্যামেরাটি "
 "অক্ষম করার ফলে কিছু অ্যাপ্লিকেশনগুলি সঠিকভাবে কাজ না করার কারণ হতে পারে।"
 
-#: panels/camera/cc-camera-panel.ui:85
-msgid "Allow the applications below to use your camera."
-msgstr "নীচের অ্যাপ্লিকেশনগুলিকে আপনার ক্যামেরাটি ব্যবহার করার অনুমতি দিন।"
-
-#: panels/camera/cc-camera-panel.ui:105
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "কোনও অ্যাপ্লিকেশন ক্যামেরা অ্যাক্সেসের জন্য জিজ্ঞাসা করেনি"
 
@@ -532,277 +392,59 @@ msgstr "কোনও অ্যাপ্লিকেশন ক্যামের�
 msgid "Protect your pictures"
 msgstr "আপনার ছবি রক্ষা করুন"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"স্ক্রীন;লক;সমস্যা নিরূপণ;ক্র্যাশ;ব্যক্তিগত;সাম্প্রতিক;অস্থায়ী;tmp;সূচি;নাম;নেটওয়ার্ক;"
-"পরিচয়;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "আপনার ক্রমাঙ্কন ডিভাইসটিকে স্কোয়ারের উপরে রাখুন এবং \"আরম্ভ\" টিপুন"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"আপনার ক্রমাঙ্কন ডিভাইসটিকে ক্রমাঙ্কিত অবস্থানে নিয়ে যান এবং \"চালিয়ে যান\" টিপুন"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"আপনার ক্রমাঙ্কন ডিভাইসটিকে পৃষ্ঠের অবস্থানে নিয়ে যান এবং \"চালিয়ে যান\" টিপুন"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "ল্যাপটপ লিড বন্ধ করুন"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "এক আভ্যন্তরীণ ত্রুটি দেখা দিয়েছে যা পুনরুদ্ধার করা যাবে না।"
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "ক্যালিব্রেশনের জন্য প্রয়োজনীয় সরঞ্জাম ইনস্টল করা নেই।"
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "প্রোফাইল প্রস্তুত করা যাবে না।"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "টার্গেট হোয়াইটপয়েন্ট প্রাপ্তযোগ্য নয়।"
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "সম্পন্ন!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "ক্যালিব্রেশন ব্যর্থ হয়েছে!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "আপনি ক্যালিব্রেশন ডিভাইস সরাতে পারেন।"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "কাজ চলছে এমন অবস্থায় ক্যালিব্রেশন ডিভাইসে হাত দেবেন না"
-
-#: panels/color/cc-color-calibrate.ui:7
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "ক্যালিব্রেশন দেখান"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "বাতিল করুন (_C)"
+
 #. This starts the calibration process
-#: panels/color/cc-color-calibrate.ui:40
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "আরম্ভ(_S)"
 
 #. This resumes the calibration process
-#: panels/color/cc-color-calibrate.ui:54
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "আবার শুরু করুন(_R)"
 
 #. This button returns the user back to the color control panel
-#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
-#: panels/user-accounts/cc-fingerprint-dialog.ui:73
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "সম্পন্ন (_D)"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "ল্যাপটপ স্ক্রীন"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "অন্তর্ভুক্ত ওয়েবক্যাম"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s মনিটর"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s স্ক্রীনার"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s ক্যামেরা"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s প্রিন্টার"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s ওয়েবক্যাম"
-
-#: panels/color/cc-color-device.c:90
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s এর রঙ ব্যবস্থাপনা সক্ষম করুন"
-
-#: panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s এর জন্য রঙের প্রোফাইল দেখান"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "ক্যালিব্রেট করা হয়নি"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:167
-msgid "Default: "
-msgstr "ডিফল্ট: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:175
-msgid "Colorspace: "
-msgstr "কালারস্পেস: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:182
-msgid "Test profile: "
-msgstr "টেস্ট প্রোফাইল:"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:236
-msgid "Select ICC Profile File"
-msgstr "ICC প্রোফাইল ফাইল নির্বাচন করুন"
-
-#: panels/color/cc-color-panel.c:239
-msgid "_Import"
-msgstr "আমদানি করুন (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:250
-msgid "Supported ICC profiles"
-msgstr "সমর্থিত ICC প্রোফাইলসমূহ"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:257
-#: panels/network/wireless-security/eap-method-fast.c:356
-msgid "All files"
-msgstr "সর্বধরনের ফাইল"
-
-#: panels/color/cc-color-panel.c:549
-msgid "Screen"
-msgstr "স্ক্রীন"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:839
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "ফাইল আপলোড করা গেল না: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:851
-msgid "The profile has been uploaded to:"
-msgstr "প্রোফাইল এখানে আপলোড করা হয়েছে:"
-
-#: panels/color/cc-color-panel.c:853
-msgid "Write down this URL."
-msgstr "এই URLটি লিখে রাখুন।"
-
-#: panels/color/cc-color-panel.c:854
-msgid "Restart this computer and boot your normal operating system."
-msgstr "এই কম্পিউটার রিস্টার্ট করুন এবং আপনার সাধারণ অপারেটিং সিস্টেম বুট করুন।"
-
-#: panels/color/cc-color-panel.c:855
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "প্রোফাইল ডাউনলোড এবং ইনস্টল করতে URLটি আপনার ব্রাউজারে লিখুন।"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:883
-msgid "Save Profile"
-msgstr "প্রোফাইল সংরক্ষণ করুন"
-
-#: panels/color/cc-color-panel.c:887
-#: panels/network/connection-editor/vpn-helpers.c:300
-msgid "_Save"
-msgstr "সংরক্ষণ করুন (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1196
-msgid "Create a color profile for the selected device"
-msgstr "নির্বাচিত ডিভাইসের জন্য একটি রঙ প্রোফাইল তৈরি করুন"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1211 panels/color/cc-color-panel.c:1235
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"পরিমাপের সরঞ্জাম সনাক্ত করা হয়নি। দয়া করে এটি যে চালু আছে এবং সঠিক ভাবে সংযুক্ত "
-"তা দেখে নিন।"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1245
-msgid "The measuring instrument does not support printer profiling."
-msgstr "পরিমাপের যন্ত্র প্রিন্টার প্রোফাইলিঙের সুবিধা দেয় না।"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1256
-msgid "The device type is not currently supported."
-msgstr "ডিভাইস ধরন বর্তমানে সমর্থিত নয়।"
-
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "স্ক্রীন ক্যালিব্রেশন"
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "ক্যালিব্রেশনের গুণমান"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -812,42 +454,42 @@ msgstr ""
 "ব্যবস্থাপনা করতে পারবেন। ক্যালিব্রেশনের ক্ষেত্রে আপনি যত বেশি সময় খরচ করবেন, রঙ "
 "প্রোফাইলের গুণমান তত উন্নত হবে।"
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "ক্যালিব্রেশন চলার সময়ে আপনি আপনার কম্পিউটার ব্যবহার করতে পারবেন না।"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "গুণমান"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "আনুমানিক সময়"
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr "ক্যালিব্রেশনের গুণমান"
-
-#: panels/color/cc-color-panel.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr "ক্যালিব্রেশনের জন্য আপনি সেন্সর ডিভাইস ব্যবহার করতে চান তা নির্বাচন করুন।"
-
-#: panels/color/cc-color-panel.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "ক্যালিব্রেশন ডিভাইস"
 
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
-msgstr "সংযুক্ত প্রদর্শনের ধরনটি নির্বাচন করুন।"
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ক্যালিব্রেশনের জন্য আপনি সেন্সর ডিভাইস ব্যবহার করতে চান তা নির্বাচন করুন।"
 
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "প্রদর্শনের ধরন"
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "সংযুক্ত প্রদর্শনের ধরনটি নির্বাচন করুন।"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "প্রোফাইল হোয়াইটপয়েন্ট"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -855,11 +497,11 @@ msgstr ""
 "একটি প্রদর্শন টার্গেট হোয়াইট পয়েন্ট নির্বাচন করুন। অধিকাংশ প্রদর্শন একটি D65 "
 "ইলিউমিনেন্টে ক্যালিব্রেট হবে।"
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
-msgstr "প্রোফাইল হোয়াইটপয়েন্ট"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "প্রদর্শন উজ্জ্বলতা"
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -867,7 +509,7 @@ msgstr ""
 "দয়া করে প্রদর্শন এমন এক উজ্জ্বলতায় সেট যা আপনার ক্ষেত্রে উপযুক্ত। উজ্জ্বলতার এই স্তরে "
 "রঙ ব্যবস্থাপনা সবথেকে যথাযথ হবে।"
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -875,11 +517,11 @@ msgstr ""
 "বিকল্প ভাবে, আপনি এই ডিভাইসের ক্ষেত্রে অন্যান্য প্রোফাইলের একটিতে ব্যবহার করা "
 "উজ্জ্বলতার স্তর ব্যবহার করতে পারবেন।"
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr "প্রদর্শন উজ্জ্বলতা"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "প্রোফাইলের নাম"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -887,285 +529,194 @@ msgstr ""
 "আপনি বিভিন্ন কম্পিউটারে একটি রঙ প্রোফাইল ব্যবহার করতে পারবেন, বা পৃথক আলোক অবস্থায় "
 "প্রোফাইল তৈরি করতে পারবেন।"
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "প্রোফাইলের নাম:"
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "প্রোফাইলের নাম"
-
-#: panels/color/cc-color-panel.ui:392
-msgid "Profile successfully created!"
-msgstr "প্রোফাইল সফলভাবে তৈরি হয়েছে!"
-
-#: panels/color/cc-color-panel.ui:443
-msgid "Copy profile"
-msgstr "প্রোফাইল অনুলিপি করুন"
-
-#: panels/color/cc-color-panel.ui:456
-msgid "Requires writable media"
-msgstr "লিখনযোগ্য মিডিয়ার প্রয়োজন"
-
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr "প্রোফাইল আপলোড করুন"
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr "ইন্টারনেট সংযোগের প্রয়োজন"
-
-#: panels/color/cc-color-panel.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> এবং <a href="
-"\"windows\">Microsoft Windows</a> সিস্টেমে প্রোফাইল ব্যবহার সংক্রান্ত এই "
-"নির্দেশগুলি আপনার কাছে আসতে পারে।"
-
-#: panels/color/cc-color-panel.ui:607
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "সারাংশ"
 
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "প্রোফাইল সফলভাবে তৈরি হয়েছে!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "প্রোফাইল অনুলিপি করুন"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "লিখনযোগ্য মিডিয়ার প্রয়োজন"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> এবং <a "
+"href=\"windows\">Microsoft Windows</a> সিস্টেমে প্রোফাইল ব্যবহার সংক্রান্ত এই "
+"নির্দেশগুলি আপনার কাছে আসতে পারে।"
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "প্রোফাইল যোগ করুন"
 
-#: panels/color/cc-color-panel.ui:643
-msgid "_Import File…"
-msgstr "ফাইল আমদানি করুন(_I)…"
-
-#: panels/color/cc-color-panel.ui:672
-#: panels/network/connection-editor/net-connection-editor.c:510
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/region/cc-input-chooser.ui:20
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr "যোগ করুন (_A)"
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"সমস্যাগুলি সনাক্ত হয়েছে। প্রোফাইল ঠিকঠাক ভাবে কাজ নাও করতে পারে। <a href="
-"\"\">বিস্তারিত দেখান।</a>"
+"সমস্যাগুলি সনাক্ত হয়েছে। প্রোফাইল ঠিকঠাক ভাবে কাজ নাও করতে পারে। <a "
+"href=\"\">বিস্তারিত দেখান।</a>"
 
-#: panels/color/cc-color-panel.ui:788
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "ফাইল আমদানি করুন(_I)…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "যোগ করুন (_A)"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "প্রত্যেক ডিভাইসের রঙ ব্যবস্থাপনার ক্ষেত্রে একটি আপ-টু-ডেট প্রোফাইলের প্রয়োজন।"
 
-#. translators: Text used in link to privacy policy
-#: panels/color/cc-color-panel.ui:810
-#: panels/diagnostics/cc-diagnostics-panel.c:143
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "আরো জানুন"
 
-#: panels/color/cc-color-panel.ui:815
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "রঙ ব্যবস্থাপনা বিষয়ে আরো জানুন"
 
-#: panels/color/cc-color-panel.ui:863
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "সকল ব্যবহারকারীর জন্য সেট করুন(_S)"
 
-#: panels/color/cc-color-panel.ui:867 panels/color/cc-color-panel.ui:882
-#: panels/color/cc-color-panel.ui:883
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "এই প্রোফাইল এই কম্পিউটারে সকল ব্যবহারকারীর জন্য সেট করুন"
 
-#: panels/color/cc-color-panel.ui:878
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "সক্ষম করুন(_E)"
 
-#: panels/color/cc-color-panel.ui:909
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "প্রোফাইল যোগ করুন(_A)"
 
-#: panels/color/cc-color-panel.ui:922
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "ক্যালিব্রেট করুন(_C)…"
 
-#: panels/color/cc-color-panel.ui:926
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "ডিভাইস ক্যালিব্রেট করুন"
 
-#: panels/color/cc-color-panel.ui:937
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "প্রোফাইল সরান(_R)"
 
-#: panels/color/cc-color-panel.ui:950
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "বিস্তারিত দেখুন(_V)"
 
-#: panels/color/cc-color-panel.ui:986
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "এমন কোনো ডিভাইস সনাক্ত করতে পারেনি যা রঙ ব্যবস্থাপিত হতে পারে"
 
-#: panels/color/cc-color-panel.ui:1030
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/cc-color-panel.ui:1035
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/cc-color-panel.ui:1040
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: panels/color/cc-color-panel.ui:1045
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "প্রোজেক্টর"
 
-#: panels/color/cc-color-panel.ui:1050
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "প্লাজমা"
 
-#: panels/color/cc-color-panel.ui:1055
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL পিছনের আলো)"
 
-#: panels/color/cc-color-panel.ui:1060
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED পিছনের আলো)"
 
-#: panels/color/cc-color-panel.ui:1065
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (সাদা LED পিছনের আলো)"
 
-#: panels/color/cc-color-panel.ui:1070
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "চওড়া গ্যামুট LCD (CCFL পিছনের আলো)"
 
-#: panels/color/cc-color-panel.ui:1075
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "চওড়া গ্যামুট LCD (RGB LED পিছনের আলো)"
 
-#: panels/color/cc-color-panel.ui:1092
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "উচ্চ"
 
-#: panels/color/cc-color-panel.ui:1093
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "৪০ মিনিট"
 
-#: panels/color/cc-color-panel.ui:1097
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "মাঝারি"
 
-#: panels/color/cc-color-panel.ui:1098
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "৩০ মিনিট"
 
-#: panels/color/cc-color-panel.ui:1102
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "নিম্ন"
 
-#: panels/color/cc-color-panel.ui:1103
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "১৫ মিনিট"
 
-#: panels/color/cc-color-panel.ui:1125
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "প্রদর্শনের নেটিভ"
 
-#: panels/color/cc-color-panel.ui:1129
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (মুদ্রণ এবং প্রকাশনা)"
 
-#: panels/color/cc-color-panel.ui:1133
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/cc-color-panel.ui:1137
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (ফটোগ্র্যাফি এবং গ্র্যাফিক্স)"
 
-#: panels/color/cc-color-panel.ui:1141
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "স্ট্যান্ডার্ড স্পেস"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "টেস্ট প্রোফাইল"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "স্বয়ংক্রিয়"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "নিম্ন মানের"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "মাঝারি মানের"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "উচ্চ মানের"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "ডিফল্ট RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "ডিফল্ট CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "ডিফল্ট গ্রে"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "ভেন্ডার সরবরাহকৃত ফ্যাক্টরি ক্যালিব্রেশন ডেটা"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "এই প্রোফাইলের ক্ষেত্রে সম্পূর্ণ স্ক্রীন প্রদর্শন সংশোধন সম্ভব নয়"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "এই প্রোফাইল আর হয়তো যথাযথ নেই"
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1176,337 +727,203 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "আপনার ডিভাইসের রঙ ক্যালিব্রেট করুন, যেমন প্রদর্শন, ক্যামেরা বা প্রিন্টার"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "রঙ;ICC;প্রোফাইল;ক্যালিব্রেট;প্রিন্টার;প্রদর্শন;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "অন্যান্য..."
-
-#: panels/common/cc-language-chooser.c:127 panels/region/cc-input-chooser.c:178
-msgid "More…"
-msgstr "আরো…"
-
-#: panels/common/cc-language-chooser.c:144
-msgid "No languages found"
-msgstr "কোনো ভাষা পাওয়া যায়নি"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
 msgstr "ভাষা বাছাই করুন"
 
-#: panels/common/cc-language-chooser.ui:12
+#: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
 msgstr "নির্বাচন করুন(_S)"
 
-#: panels/common/cc-permission-infobar.ui:20
-msgid "Unlock…"
-msgstr "আনলক করুন..."
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "কোনো ভাষা পাওয়া যায়নি"
 
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/common/cc-permission-infobar.ui:45
-msgid "Unlock to Change Settings"
-msgstr "সেটিংস পরিবর্তন করতে আনলক করুন"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "আরো…"
 
-#: panels/common/cc-permission-infobar.ui:55
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "কিছু সেটিংস পরিবর্তন করার আগে অবশ্যই তা আনলক করতে হবে।"
 
-#: panels/common/cc-time-editor.ui:33
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "আনলক করুন..."
+
+#: panels/common/cc-time-editor.ui:25
 msgid "Increment Hour"
 msgstr "বর্ধনের ঘণ্টা"
 
-#: panels/common/cc-time-editor.ui:65
+#: panels/common/cc-time-editor.ui:53
 msgid "Increment Minute"
 msgstr "বর্ধনের মিনিট"
 
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/common/cc-time-editor.ui:80
+#: panels/common/cc-time-editor.ui:73
 msgid "Time"
 msgstr "সময়"
 
-#: panels/common/cc-time-editor.ui:113
+#: panels/common/cc-time-editor.ui:94
 msgid "Decrement Hour"
 msgstr "হ্রাসের ঘণ্টা"
 
-#: panels/common/cc-time-editor.ui:145
+#: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "হ্রাসের মিনিট"
 
-# auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
-#: panels/common/cc-time-entry.c:219
-msgid "_Copy"
-msgstr "অনুলিপি(_C)"
-
-#: panels/common/cc-time-entry.c:225
-msgid "Select _All"
-msgstr "সমস্ত নির্বাচন করুন(_A)"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:158
-msgid "Today"
-msgstr "আজ"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:160
-msgid "Yesterday"
-msgstr "গতকাল"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d ঘন্টা"
-msgstr[1] "%d ঘন্টায়"
-
-# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
-#: panels/common/cc-util.c:166
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d মিনিট"
-msgstr[1] "%d মিনিটে"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d সেকেন্ড"
-msgstr[1] "%d সেকেন্ড"
-
-# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "০ সেকেন্ড"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "হটস্পট"
-
-#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
-#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
-msgid "Day"
-msgstr "দিন"
-
-#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
-#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
-msgid "Month"
-msgstr "মাস"
-
-#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
-#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
-msgid "Year"
-msgstr "বছর"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:258
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:263
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:432
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:459
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:466
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:471
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:476
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:481
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:26
-msgid "January"
-msgstr "জানুয়ারি"
-
-#: panels/datetime/cc-datetime-panel.ui:29
-msgid "February"
-msgstr "ফেব্রুয়ারি"
-
-#: panels/datetime/cc-datetime-panel.ui:32
-msgid "March"
-msgstr "মার্চ"
-
-#: panels/datetime/cc-datetime-panel.ui:35
-msgid "April"
-msgstr "এপ্রিল"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "May"
-msgstr "মে"
-
-#: panels/datetime/cc-datetime-panel.ui:41
-msgid "June"
-msgstr "জুন"
-
-#: panels/datetime/cc-datetime-panel.ui:44
-msgid "July"
-msgstr "জুলাই"
-
-#: panels/datetime/cc-datetime-panel.ui:47
-msgid "August"
-msgstr "আগস্ট"
-
-#: panels/datetime/cc-datetime-panel.ui:50
-msgid "September"
-msgstr "সেপ্টেম্বর"
-
-#: panels/datetime/cc-datetime-panel.ui:53
-msgid "October"
-msgstr "অক্টোবর"
-
-#: panels/datetime/cc-datetime-panel.ui:56
-msgid "November"
-msgstr "নভেম্বর"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/datetime/cc-datetime-panel.ui:59
-msgid "December"
-msgstr "ডিসেম্বর"
-
-#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "তিথি এবং সময়"
 
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "বছর"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "মাস"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "জানুয়ারি"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ফেব্রুয়ারি"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "মার্চ"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "এপ্রিল"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "মে"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "জুন"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "জুলাই"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "আগস্ট"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "সেপ্টেম্বর"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "অক্টোবর"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "নভেম্বর"
+
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/datetime/cc-datetime-panel.ui:102
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ডিসেম্বর"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "দিন"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "সময় জোন"
 
-#: panels/datetime/cc-datetime-panel.ui:123
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "শহর সন্ধান করুন"
 
-#: panels/datetime/cc-datetime-panel.ui:194
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "স্বয়ংক্রিয় তারিখ & সময় (_D)"
 
-#: panels/datetime/cc-datetime-panel.ui:195
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "ইন্টারনেট অ্যাক্সেসের প্রয়োজন"
 
-#: panels/datetime/cc-datetime-panel.ui:215
-msgid "Date & _Time"
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
 msgstr "তারিখ & সময় (_T)"
 
-#: panels/datetime/cc-datetime-panel.ui:254
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "স্বয়ংক্রিয় সময় জোন (_Z)"
 
-#: panels/datetime/cc-datetime-panel.ui:255
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "অবস্থান পরিষেবাদি সক্ষম এবং ইন্টারনেট অ্যাক্সেস প্রয়োজন"
 
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "সক্রিয়"
+
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/datetime/cc-datetime-panel.ui:270
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "সময় জোন(_o)"
 
-#: panels/datetime/cc-datetime-panel.ui:310
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ঘড়ির কাঁটার দিকে"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "সময় ফর্ম্যাট (_F)"
 
-#: panels/datetime/cc-datetime-panel.ui:319
-msgid "24-hour"
-msgstr "২৪ ঘন্টা"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:320
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "তিথি"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "০ সেকেন্ড"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "বর্ষপঞ্জি (_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "সংখ্যা"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "সময় অঞ্চল সমেত তারিখ এবং সময় পরিবর্তন করুন"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "ঘড়ি;সময় অঞ্চল;অবস্থান;"
@@ -1519,28 +936,28 @@ msgstr "সিস্টেম সময় এবং তারিখ সেট�
 msgid "To change time or date settings, you need to authenticate."
 msgstr "সময় বা তারিখ সেটিং পরিবর্তন করতে, আপনার প্রমাণীকরণের প্রয়োজন।"
 
-#: panels/default-apps/cc-default-apps-panel.ui:31
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "ওয়েব (_W)"
 
-#: panels/default-apps/cc-default-apps-panel.ui:43
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "মেল (_M)"
 
-#: panels/default-apps/cc-default-apps-panel.ui:59
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "বর্ষপঞ্জি (_C)"
 
-#: panels/default-apps/cc-default-apps-panel.ui:75
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "মিউজিক (_u)"
 
-#: panels/default-apps/cc-default-apps-panel.ui:91
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "ভিডিও (_V)"
 
-#: panels/default-apps/cc-default-apps-panel.ui:162
-#: panels/removable-media/cc-removable-media-panel.ui:162
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "ছবি (_P)"
 
@@ -1552,26 +969,15 @@ msgstr "ডিফল্ট অ্যাপ্লিকেশন"
 msgid "Configure Default Applications"
 msgstr "ডিফল্ট অ্যাপ্লিকেশনগুলি কনফিগার করুন"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "ডিফল্ট;অ্যাপ্লিকেশান;পছন্দসই;মিডিয়া;"
 
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:145
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"প্রযুক্তিগত সমস্যার প্রতিবেদন পাঠানো আমাদের %s উন্নত করতে সহায়তা করে। প্রতিবেদনগুলি "
-"বেনামে পাঠানো হয় এবং ব্যক্তিগত ডেটা স্ক্র্যাব করা হয়। %s"
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:28
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
 msgstr "সমস্যা প্রতিবেদন"
 
-#: panels/diagnostics/cc-diagnostics-panel.ui:65
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
 msgid "_Automatic Problem Reporting"
 msgstr "স্বয়ংক্রিয় সমস্যা প্রতিবেদন(_A)"
 
@@ -1583,168 +989,123 @@ msgstr "নিদানবিদ্যা"
 msgid "Report your problems"
 msgstr "আপনার সমস্যা রিপোর্ট করুন"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"স্ক্রিন;লক;ডায়গনিস্টিক;ক্র্যাশ;ব্যক্তিগত;সাম্প্রতিক;অস্থায়ী;tmp;সূচক;নাম;নেটওয়ার্ক;পরিচয়;"
-"গোপনীয়তা;"
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "নিদানবিদ্যা"
 
-#: panels/display/cc-display-panel.c:954
-#: panels/network/connection-editor/connection-editor.ui:27
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "প্রয়োগ করুন (_A)"
 
-#: panels/display/cc-display-panel.c:975
-msgid "Apply Changes?"
-msgstr "পরিবর্তনগুলি প্রয়োগ করবেন?"
+# auto translated by TM merge from project: rhn-client-tools, version: 6.2, DocId: rhn-client-tools
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "পূর্ববর্তী"
 
-#: panels/display/cc-display-panel.c:980
-msgid "Changes Cannot be Applied"
-msgstr "পরিবর্তনগুলি প্রয়োগ করা যায় না"
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Bluetooth অক্ষম"
 
-#: panels/display/cc-display-panel.c:981
-msgid "This could be due to hardware limitations."
-msgstr "এটি হার্ডওয়্যার সীমাবদ্ধতার কারণে হতে পারে।"
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "ডিসপ্লে ভাগ করুন"
 
-#: panels/display/cc-display-panel.ui:89
-msgid "Single Display"
-msgstr "একক ডিসপ্লে"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
 
-# auto translated by TM merge from project: virt-viewer, version: 0.5.7, DocId: virt-viewer
-#: panels/display/cc-display-panel.ui:108
-#: panels/display/cc-display-panel.ui:310
-msgid "Join Displays"
-msgstr "ডিসপ্লেগুলি যোগ করুন"
-
-#: panels/display/cc-display-panel.ui:126
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "মিরর"
 
-#: panels/display/cc-display-panel.ui:151
-msgid "Display Mode"
-msgstr "ডিসপ্লে ধরন"
-
-#: panels/display/cc-display-panel.ui:220
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "শীর্ষ বার এবং ক্রিয়াকলাপগুলি রয়েছে"
 
-#: panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "অপ্রধান ডিসপ্লে"
 
-#: panels/display/cc-display-panel.ui:243
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
-msgstr ""
-"আপনার শারীরিক ডিসপ্লে সেটআপের সাথে মেলে ডিসপ্লেগুলি টেনে আনুন। এর সেটিংস পরিবর্তন "
-"করতে একটি ডিসপ্লে নির্বাচন করুন।"
-
-#: panels/display/cc-display-panel.ui:250
-msgid "Display Arrangement"
-msgstr "ডিসপ্লে ব্যবস্থা"
-
-#: panels/display/cc-display-panel.ui:374
-msgid "Active Display"
-msgstr "সক্রিয় ডিসপ্লে"
-
-#: panels/display/cc-display-panel.ui:421
-msgid "Display Configuration"
-msgstr "ডিসপ্লে কনফিগারেশন"
-
-# auto translated by TM merge from project: virt-viewer, version: 0.5.7, DocId: virt-viewer
-#: panels/display/cc-display-panel.ui:440
-#: panels/display/gnome-display-panel.desktop.in.in:3
-msgid "Displays"
-msgstr "প্রদর্শন"
-
 # auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:451
-#: panels/display/cc-night-light-page.ui:111
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "নাইট লাইট"
 
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/display/cc-display-settings.c:103
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "ল্যাণ্ডস্কেপ"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/display/cc-display-settings.c:106
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "ডানদিকে পোর্ট্রেট"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/display/cc-display-settings.c:109
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "বামদিকে পোর্ট্রেট"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/display/cc-display-settings.c:112
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "ল্যান্ডস্কেপ (উল্টানো)"
-
-#: panels/display/cc-display-settings.c:186
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 # auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#: panels/display/cc-display-settings.ui:15
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "ঝোঁক"
 
 # auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/display/cc-display-settings.ui:24
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "রেসলোলিউশন"
 
-#: panels/display/cc-display-settings.ui:33
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "রিফ্রেশ রেট"
 
-#: panels/display/cc-display-settings.ui:42
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "টিভির জন্য সামঞ্জস্য করুন"
 
-#: panels/display/cc-display-settings.ui:59
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "স্কেল"
 
-#: panels/display/cc-night-light-page.c:627
-msgid "More Warm"
-msgstr "আরও উষ্ণ"
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "স্বাভাবিক স্ক্রোলিং"
 
-#: panels/display/cc-night-light-page.c:639
-msgid "Less Warm"
-msgstr "কম উষ্ণ"
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:28
-msgid "Restart Filter"
-msgstr "ফিল্টার পুনরায় আরম্ভ করুন"
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "নাইট লাইট"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:61
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "আগামীকাল অবধি সাময়িকভাবে অক্ষম করা হয়েছে"
 
-#: panels/display/cc-night-light-page.ui:88
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "ফিল্টার পুনরায় আরম্ভ করুন"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1752,68 +1113,72 @@ msgstr ""
 "রাতের আলো পর্দার রঙকে উষ্ণ করে তোলে। এটি চোখের চাপ এবং নিদ্রাহীনতা রোধ করতে "
 "সহায়তা করতে পারে।"
 
-#: panels/display/cc-night-light-page.ui:127
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "সময়সূচী"
 
-#: panels/display/cc-night-light-page.ui:136
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "সূর্যাস্ত থেকে সূর্যোদয়"
 
-#: panels/display/cc-night-light-page.ui:137
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "ম্যানুয়াল সময়সূচী"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/region/cc-format-chooser.ui:344
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "বার"
 
-#: panels/display/cc-night-light-page.ui:165
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "থেকে"
 
-#: panels/display/cc-night-light-page.ui:194
-#: panels/display/cc-night-light-page.ui:297
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "ঘন্টা"
 
-#: panels/display/cc-night-light-page.ui:203
-#: panels/display/cc-night-light-page.ui:306
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/display/cc-night-light-page.ui:222
-#: panels/display/cc-night-light-page.ui:325
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "মিনিট"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:234
-#: panels/display/cc-night-light-page.ui:337
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "পূর্বাহ্ণ"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:247
-#: panels/display/cc-night-light-page.ui:350
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "অপরাহ্ন"
 
-#: panels/display/cc-night-light-page.ui:267
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "থেকে"
 
-#: panels/display/cc-night-light-page.ui:374
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "রঙ তাপমাত্রা"
+
+# auto translated by TM merge from project: virt-viewer, version: 0.5.7, DocId: virt-viewer
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "প্রদর্শন"
 
 #: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr "সংযুক্ত মনিটর এবং প্রোজেক্টর কীভাবে ব্যবহার করতে হবে তা বাছুন"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1822,105 +1187,128 @@ msgstr ""
 "প্যানেল;প্রজেক্টর;xrandr;স্ক্রিন;রেজোলিউশন;রিফ্রেশ;মনিটর;নাইট;হাল্কা;নীল;redshift;"
 "রঙ;সূর্যাস্ত;সূর্যোদয়;"
 
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/info-overview/cc-info-overview-panel.c:416
-#: panels/info-overview/cc-info-overview-panel.c:431
-#: panels/info-overview/cc-info-overview-panel.c:443
-#: panels/info-overview/cc-info-overview-panel.c:489
-#: panels/info-overview/cc-info-overview-panel.c:519
-msgid "Unknown"
-msgstr "অজানা"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:451
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; বিল্ড আইডি: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "নিরাপত্তা ধরন"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:466
-#, c-format
-msgid "64-bit"
-msgstr "৬৪-বিট"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "কালির মাত্রা"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:469
-#, c-format
-msgid "32-bit"
-msgstr "৩২-বিট"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "কালির মাত্রা"
 
-#: panels/info-overview/cc-info-overview-panel.c:675
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "কালির মাত্রা"
 
-#: panels/info-overview/cc-info-overview-panel.c:679
-msgid "Wayland"
-msgstr "ওয়েল্যান্ড "
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "অজানা"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "নিরাপত্তা"
 
-#: panels/info-overview/cc-info-overview-panel.ui:52
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"স্ক্রিন;লক;ডায়গনিস্টিক;ক্র্যাশ;ব্যক্তিগত;সাম্প্রতিক;অস্থায়ী;tmp;সূচক;নাম;নেটওয়ার্ক;পরিচয়;"
+"গোপনীয়তা;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "ডিভাইস নাম"
 
-#: panels/info-overview/cc-info-overview-panel.ui:74
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "হার্ডওয়্যার ঠিকানা"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "মেমরি"
 
-#: panels/info-overview/cc-info-overview-panel.ui:83
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "প্রসেসর"
 
-#: panels/info-overview/cc-info-overview-panel.ui:92
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "গ্রাফিক্স"
 
-#: panels/info-overview/cc-info-overview-panel.ui:101
+#: panels/info-overview/cc-info-overview-panel.ui:82
 msgid "Disk Capacity"
 msgstr "ডিস্ক ক্ষমতা"
 
-#: panels/info-overview/cc-info-overview-panel.ui:102
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "গণনা করা হচ্ছে…"
 
 #. translators: this field contains the distro name and version
-#: panels/info-overview/cc-info-overview-panel.ui:124
+#: panels/info-overview/cc-info-overview-panel.ui:98
 msgid "OS Name"
 msgstr "OS এর নাম"
 
-#: panels/info-overview/cc-info-overview-panel.ui:133
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; বিল্ড আইডি: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "OS এর ধরন"
 
-#: panels/info-overview/cc-info-overview-panel.ui:142
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "জিনোম এর সংস্করণ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:152
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "লোডের বিকল্প…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "উইন্ডোয়িং সিস্টেম"
 
-#: panels/info-overview/cc-info-overview-panel.ui:160
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "ভার্চুয়ালাইজেশন"
 
 # auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
-#: panels/info-overview/cc-info-overview-panel.ui:169
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "সফটওয়্যার আপডেটগুলি"
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "ডিভাইসটির নাম পরিবর্তন করুন"
 
-#: panels/info-overview/cc-info-overview-panel.ui:207
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1928,8 +1316,13 @@ msgstr ""
 "ডিভাইসের নামটি যখন এই ডিভাইসটি নেটওয়ার্কের ওপরে দেখা হয় বা ব্লুটুথ ডিভাইসগুলির "
 "জুড়ি তৈরি হয় তখন এটি সনাক্ত করতে ব্যবহৃত হয়।"
 
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "ডিভাইস নাম"
+
 # auto translated by TM merge from project: gnome-boxes, version: 3.8.3, DocId: gnome-boxes
-#: panels/info-overview/cc-info-overview-panel.ui:225
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "পুনরায় নামকরণ(_R)"
 
@@ -1941,11 +1334,6 @@ msgstr "সম্পর্কিত"
 msgid "View information about your system"
 msgstr "আপনার সিস্টেম সম্বন্ধে তথ্য দেখুন"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2003,7 +1391,7 @@ msgid "Eject"
 msgstr "ইজেক্ট"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:563
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "টাইপ করা হচ্ছে"
 
@@ -2022,6 +1410,12 @@ msgstr "লঞ্চার"
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "সহায়তা ব্রাউজার লঞ্চ করুন"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "সেটিং"
 
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -2044,40 +1438,8 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "অনুসন্ধান"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "স্ক্রীনশট"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "$PICTURES এ একটি স্ক্রীনশট সংরক্ষণ করুন"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "একটি উইন্ডোর স্ক্রীনশট $PICTURES এ সংরক্ষণ করুন"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "কোনো অংশের স্ক্রীনশট $PICTURES এ সংরক্ষণ করুন"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "ক্লিপ-বোর্ডে একটি স্ক্রিন-শট কপি করুন"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "উইন্ডোর স্ক্রিন-শট ক্লিপ-বোর্ডে কপি করুন"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "একটি অঞ্চলের একটি স্ক্রীনশট ক্লিপবোর্ডে অনুলিপি করুন"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "একটি সংক্ষিপ্ত স্ক্রিনকাস্ট রেকর্ড করুন"
-
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "সিস্টেম"
 
@@ -2126,268 +1488,239 @@ msgstr "হরফের মাপ হ্রাস করুন"
 msgid "High contrast on or off"
 msgstr "গাঢ় তারতম্য চালু বা বন্ধ"
 
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:8
-#: panels/keyboard/cc-keyboard-panel.ui:72
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "একটি ইনপুট সোর্স যোগ করুন"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "লগিন স্ক্রীনে ইনপুট পদ্ধতি ব্যবহার করা যাবে না"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "কোনো ইনপুট সোর্স নির্বাচন করা হয়নি"
+
+# auto translated by TM merge from project: RHEL Deployment Guide, version: 6.2, DocId: Product_Subscriptions_and_Entitlements
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "বিকল্প"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "উপরে স্থানান্তর"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "নীচে স্থানান্তর"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "পছন্দ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "কি-বোর্ড শর্টকাট"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr "সরান"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "ইনপুট সোর্স"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+#, fuzzy
+msgid "Includes keyboard layouts and input methods."
+msgstr "কীবোর্ড বিন্যাস বা ইনপুট পদ্ধতি চয়ন করুন।"
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "ইনপুট সোর্স বিকল্প"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "সকল উইন্ডোর জন্য একই সোর্স ব্যবহার করুন (_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "প্রত্যেক উইন্ডোর জন্য আলাদা সোর্সের অনুমতি দিন (_d)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
 msgid "Alternate Characters Key"
 msgstr "বৈকল্পিক অক্ষর কী"
 
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:28
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"অতিরিক্ত অক্ষর লিখতে বিকল্প অক্ষর কী ব্যবহার করা যেতে পারে। এগুলি কখনও কখনও আপনার "
-"কীবোর্ডে তৃতীয় বিকল্প হিসাবে মুদ্রিত হয়।"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:45
-msgid "Left Alt"
-msgstr "বাম Alt"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:61
-msgid "Right Alt"
-msgstr "ডান Alt"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:77
-msgid "Left Super"
-msgstr "বাম সুপার"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:93
-msgid "Right Super"
-msgstr "ডান সুপার"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:109
-msgid "Menu key"
-msgstr "মেনু কী"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:125
-msgid "Right Ctrl"
-msgstr "ডান Ctrl"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/keyboard/cc-keyboard-manager.c:486
-#: panels/keyboard/cc-keyboard-manager.c:494
-#: panels/keyboard/cc-keyboard-manager.c:779
-msgid "Custom Shortcuts"
-msgstr "স্বনির্ধারিত শর্ট-কাট"
-
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: panels/keyboard/cc-keyboard-option.c:337
-msgid "Alternative Characters Key"
-msgstr "বৈকল্পিক অক্ষর কী"
-
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: panels/keyboard/cc-keyboard-option.c:346
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "রচনা কী"
 
-#: panels/keyboard/cc-keyboard-option.c:351
-msgid "Modifiers-only switch to next source"
-msgstr "পরবর্তী সোর্সে শুধুমাত্র-সংশোধক স্যুইচ"
-
-#: panels/keyboard/cc-keyboard-panel.c:94
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "ডান Ctrl"
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "কি-বোর্ড শর্টকাট"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/keyboard/cc-keyboard-panel.c:95
-msgctxt "keyboard key"
-msgid "Menu Key"
-msgstr "মেনু কী "
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "স্বনির্ধারিত শর্ট-কাট"
 
-#: panels/keyboard/cc-keyboard-panel.c:96
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "বাম সুপার"
-
-#: panels/keyboard/cc-keyboard-panel.c:97
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "ডান সুপার"
-
-#: panels/keyboard/cc-keyboard-panel.c:98
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "বাম Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:99
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "ডান Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:201
-msgid "Reset All Shortcuts?"
-msgstr "সমস্ত শর্টকাট পুনরায় সেট করবেন?"
-
-#: panels/keyboard/cc-keyboard-panel.c:204
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"শর্টকাটগুলি পুনরায় সেট করা আপনার কাস্টম শর্টকাটকে প্রভাবিত করতে পারে। এটা অসম্পূর্ণ "
-"থাকতে পারে না."
-
-#: panels/keyboard/cc-keyboard-panel.c:208
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:275
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-msgid "Cancel"
-msgstr "বাতিল"
-
-#: panels/keyboard/cc-keyboard-panel.c:209
-msgid "Reset All"
-msgstr "সব পুনরায় সেট করুন"
-
-#: panels/keyboard/cc-keyboard-panel.c:305
-msgid "Reset the shortcut to its default value"
-msgstr "শর্টকাটটিকে এর ডিফল্ট মানটিতে পুনরায় সেট করুন"
-
-#: panels/keyboard/cc-keyboard-panel.ui:73
-msgid "Hold down and type to enter different characters"
-msgstr "ধরে রাখুন এবং বিভিন্ন অক্ষর লিখতে টাইপ করুন"
-
-#: panels/keyboard/cc-keyboard-panel.ui:148
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
 msgstr "সব পুনরায় সেট করুন…"
 
-#: panels/keyboard/cc-keyboard-panel.ui:149
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "সমস্ত শর্টকাট তাদের ডিফল্ট কী-বাইন্ডিংগুলিতে পুনরায় সেট করুন"
 
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "বিভাগ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "শর্টকাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "শর্টকাট যোগ করুন"
+
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/keyboard/cc-keyboard-panel.ui:178
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "কাস্টম শর্টকাট যুক্ত করুন"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "শর্টকাট যোগ করুন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "কোনও কীবোর্ড শর্টকাট পাওয়া যায় নি"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:405
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "সরান"
+
+# auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "প্রতিস্থাপন করুন"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"%s ইতিমধ্যে %s এর জন্য ব্যবহৃত হচ্ছে। আপনি যদি এটি প্রতিস্থাপন করেন তবে %s অক্ষম হয়ে "
-"যাবে"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:549
-msgid "Enter the new shortcut"
-msgstr "নতুন শর্টকাট প্রবেশ করান"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:566
-msgid "Set Custom Shortcut"
-msgstr "কাস্টম শর্টকাট সেট করুন"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:566
-msgid "Set Shortcut"
-msgstr "শর্টকাট সেট করুন"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:577
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "%s পরিবর্তন করতে নতুন শর্টকাট প্রবেশ করান।"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:1004
-msgid "Add Custom Shortcut"
-msgstr "কাস্টম শর্টকাট যুক্ত করুন"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:60
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr "কীবোর্ড শর্টকাটটি বাতিল করতে Esc বা ব্যাকস্পেস টিপুন।"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:135
-#: panels/printers/pp-details-dialog.ui:40
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "নাম"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:147
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "কমান্ড"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:159
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "শর্টকাট"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:238
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "শর্টকাট সেট করুন ..."
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "কিছুই নেই"
 
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:286
-msgid "Remove"
-msgstr "সরান"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "শর্টকাটটিকে এর ডিফল্ট মানটিতে পুনরায় সেট করুন"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:296
-msgid "Add"
-msgstr "যোগ করুন"
-
-# auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:311
-msgid "Replace"
-msgstr "প্রতিস্থাপন করুন"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:324
-msgid "Set"
-msgstr "সেট"
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "ডিফল্ট দ্বারা প্রিন্টার ব্যবহার করুন"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
-#: panels/region/cc-region-panel.ui:392 shell/cc-window.ui:326
-msgid "Keyboard Shortcuts"
-msgstr "কি-বোর্ড শর্টকাট"
+msgid "Keyboard"
+msgstr "কি-বোর্ড"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
 "কীবোর্ড শর্টকাটগুলি দেখুন এবং পরিবর্তন করুন এবং আপনার টাইপিং অগ্রাধিকার সেট করুন"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr "শর্টকাট;কর্মপরিসর;উইন্ডো;পুনরায়মাপ;জুম;বৈপরীত্য;ইনপুট;উত্স;লক;ভলিউম;"
 
 # auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
-#: panels/location/cc-location-panel.ui:31
-msgid "Location services turned off"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
 msgstr "অবস্থান পরিষেবা বন্ধ আছে"
 
-#: panels/location/cc-location-panel.ui:40
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "কোনও অ্যাপ্লিকেশন লোকেশন তথ্য অর্জন করতে পারে না।"
 
-#: panels/location/cc-location-panel.ui:72
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"অবস্থান পরিষেবাদি অ্যাপ্লিকেশনগুলিকে আপনার অবস্থান জানার অনুমতি দেয়। ওয়াই-ফাই এবং "
-"মোবাইল ব্রডব্যান্ড ব্যবহার করে সঠিকতা বাড়ায়।"
-
-#: panels/location/cc-location-panel.ui:81
-msgid ""
+"mobile broadband increases accuracy.\n"
+"\n"
 "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
-"মজিলা অবস্থান পরিষেবা ব্যবহার করে: <a href='https://location.services.mozilla."
-"com/privacy'>গোপনীয়তা নীতি</a>"
 
-#: panels/location/cc-location-panel.ui:93
-msgid "Allow the applications below to determine your location."
-msgstr "নীচের অ্যাপ্লিকেশনগুলিকে আপনার অবস্থান নির্ধারণ করার অনুমতি দিন।"
-
-#: panels/location/cc-location-panel.ui:113
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "কোনও অ্যাপ্লিকেশন লোকেশন অ্যাক্সেসের জন্য জিজ্ঞাসা করেনি"
 
@@ -2395,194 +1728,33 @@ msgstr "কোনও অ্যাপ্লিকেশন লোকেশন অ
 msgid "Protect your location information"
 msgstr "আপনার অবস্থানের তথ্য রক্ষা করুন"
 
-#. FIXME
-#: panels/lock/cc-lock-panel.ui:27
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"স্ক্রিনটি স্বয়ংক্রিয়ভাবে লক করা আপনার দূরে থাকা অবস্থায় অন্যকে কম্পিউটার অ্যাক্সেস করা "
-"থেকে বিরত করে।"
 
-#: panels/lock/cc-lock-panel.ui:44
-msgid "Blank Screen Delay"
-msgstr "ফাঁকা স্ক্রিন বিলম্ব"
-
-#: panels/lock/cc-lock-panel.ui:45
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "নিষ্ক্রিয়তার সময়কালের পরে পর্দা ফাঁকা হয়ে যাবে।"
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Automatic Screen _Lock"
-msgstr "স্বয়ংক্রিয় স্ক্রীন লক (_L)"
-
-#: panels/lock/cc-lock-panel.ui:82
-msgid "Automatic _Screen Lock Delay"
-msgstr "স্বয়ংক্রিয় স্ক্রিন লক বিলম্ব(_S)"
-
-#: panels/lock/cc-lock-panel.ui:83
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "স্ক্রীন ফাঁকা হওয়ার পরে পিরিয়ডটি স্বয়ংক্রিয়ভাবে লক হয়ে যায়।"
-
-#: panels/lock/cc-lock-panel.ui:103
-msgid "Show _Notifications on Lock Screen"
-msgstr "লক স্ক্রিনে বিজ্ঞপ্তিগুলি দেখান(_N)"
-
-#: panels/lock/cc-lock-panel.ui:120
-msgid "Forbid new _USB devices"
-msgstr "নতুন ইউএসবি ডিভাইস নিষিদ্ধ করুন(_U)"
-
-#: panels/lock/cc-lock-panel.ui:121
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"স্ক্রিনটি লক হয়ে গেলে নতুন ইউএসবি ডিভাইসগুলি সিস্টেমের সাথে ইন্টারঅ্যাক্ট করা থেকে "
-"বিরত রাখুন।"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:166
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "স্ক্রীন বন্ধ হয়"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:170
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "৩০ সেকেন্ড"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:174
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "১ মিনিট"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:178
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "২ মিনিট"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:182
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "৩ মিনিট"
-
-# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:186
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "৫ মিনিট"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:190
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "৩০ মিনিট"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:194
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "১ ঘন্টা"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:209 panels/power/cc-power-panel.ui:63
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "১ মিনিট"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:213 panels/power/cc-power-panel.ui:67
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "২ মিনিট"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:217 panels/power/cc-power-panel.ui:71
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "৩ মিনিট"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:221 panels/power/cc-power-panel.ui:75
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "৪ মিনিট"
-
-# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:225 panels/power/cc-power-panel.ui:79
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "৫ মিনিট"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:229 panels/power/cc-power-panel.ui:83
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "৮ মিনিট"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:233 panels/power/cc-power-panel.ui:87
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "১০ মিনিট"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:237 panels/power/cc-power-panel.ui:91
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "১২ মিনিট"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:241 panels/power/cc-power-panel.ui:95
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "১৫ মিনিট"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:245 panels/power/cc-power-panel.ui:99
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "কখনও নয়"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "স্ক্রীন লক"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "স্ক্রীন লক করুন"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:34
-msgid "Microphone is turned off"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
 msgstr "মাইক্রোফোনটি বন্ধ আছে"
 
-#: panels/microphone/cc-microphone-panel.ui:43
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "কোনও অ্যাপ্লিকেশন ধ্বনি রেকর্ড করতে পারে না।"
 
-#: panels/microphone/cc-microphone-panel.ui:75
+#: panels/microphone/cc-microphone-panel.ui:37
+#, fuzzy
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
-"properly."
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
 msgstr ""
 "মাইক্রোফোনের ব্যবহার অ্যাপ্লিকেশনগুলিকে অডিও রেকর্ড করতে এবং শোনার অনুমতি দেয়। "
 "মাইক্রোফোনটি অক্ষম করার ফলে কিছু অ্যাপ্লিকেশনগুলি সঠিকভাবে কাজ না করার কারণ হতে "
 "পারে।"
 
-#: panels/microphone/cc-microphone-panel.ui:85
-msgid "Allow the applications below to use your microphone."
-msgstr "নীচের অ্যাপ্লিকেশনগুলিকে আপনার মাইক্রোফোনটি ব্যবহার করার অনুমতি দিন।"
-
-#: panels/microphone/cc-microphone-panel.ui:105
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "কোনও অ্যাপ্লিকেশন মাইক্রোফোন অ্যাক্সেসের জন্য জিজ্ঞাসা করেনি"
 
@@ -2590,110 +1762,178 @@ msgstr "কোনও অ্যাপ্লিকেশন মাইক্রো�
 msgid "Protect your conversations"
 msgstr "আপনার কথোপকথন রক্ষা করুন"
 
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "আপনার সেটিং পরীক্ষা করুন (_S)"
+
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#. FIXME
-#: panels/mouse/cc-mouse-panel.ui:37
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
 msgid "General"
 msgstr "সাধারণ"
 
-#: panels/mouse/cc-mouse-panel.ui:75
+#: panels/mouse/cc-mouse-panel.ui:26
 msgid "Primary Button"
 msgstr "প্রাথমিক বোতাম"
 
-#: panels/mouse/cc-mouse-panel.ui:94
+#: panels/mouse/cc-mouse-panel.ui:27
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "মাউস এবং টাচপ্যাডগুলিতে শারীরিক বোতামগুলির ক্রম সেট করে।"
 
-#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "বাম"
 
-#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "ডান"
 
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "অবস্থান সন্ধান"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/mouse/cc-mouse-panel.ui:169
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "মাউস"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/mouse/cc-mouse-panel.ui:208
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "মাউস এর গতি"
 
-#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
-msgid "Double-click timeout"
-msgstr "দুইবার ক্লিকের সময় সমাপ্ত"
+# auto translated by TM merge from project: evince, version: 3.8.3, DocId: evince
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "নীচে চলুন"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
-msgid "Natural Scrolling"
-msgstr "স্বাভাবিক স্ক্রোলিং"
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
 
 # auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "স্ক্রোলিং বিষয়বস্তু সরায়, ভিউ নয়।"
 
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "স্ক্রোলিং বিষয়বস্তু সরায়, ভিউ নয়।"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "সক্রিয়"
+
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "টাচ-প্যাড"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/mouse/cc-mouse-panel.ui:501
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "টাচ-প্যাড এর গতি"
 
-#: panels/mouse/cc-mouse-panel.ui:560
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "ক্লিক করতে আলতো চাপুন"
 
-#: panels/mouse/cc-mouse-panel.ui:612
-msgid "Two-finger Scrolling"
-msgstr "দুই আঙুলের স্ক্রোলিং"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:665
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "ক্লিক করতে আলতো চাপুন"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "টাইপ করার সময়ে অক্ষম করুন (_t)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "টাচপ্যাড (সম্পর্কিত)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "কণার দিকে স্ক্রোলিং"
 
-#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:441
-msgid "Test Your _Settings"
-msgstr "আপনার সেটিং পরীক্ষা করুন (_S)"
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "বাম দিকে স্ক্রোল করুন"
 
-#: panels/mouse/cc-mouse-test.c:132 panels/mouse/cc-mouse-test.ui:25
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "উভয় পৃষ্ঠা"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "ক্লিক, দুইবার ক্লিক, স্ক্রোল করার চেষ্টা করুন"
-
-#: panels/mouse/cc-mouse-test.c:137
-msgid "Five clicks, GEGL time!"
-msgstr "পাঁচ ক্লিক, GEGL সময়!"
-
-#: panels/mouse/cc-mouse-test.c:142
-msgid "Double click, primary button"
-msgstr "দুইবার ক্লিক, প্রাথমিক বোতাম"
-
-#: panels/mouse/cc-mouse-test.c:142
-msgid "Single click, primary button"
-msgstr "একবার ক্লিক, প্রাথমিক বোতাম"
-
-#: panels/mouse/cc-mouse-test.c:145
-msgid "Double click, middle button"
-msgstr "দুইবার ক্লিক, মাঝের বোতাম"
-
-#: panels/mouse/cc-mouse-test.c:145
-msgid "Single click, middle button"
-msgstr "একবার ক্লিক, মাঝের বোতাম"
-
-#: panels/mouse/cc-mouse-test.c:148
-msgid "Double click, secondary button"
-msgstr "দুইবার ক্লিক, অপ্রধান বোতাম"
-
-#: panels/mouse/cc-mouse-test.c:148
-msgid "Single click, secondary button"
-msgstr "একবার ক্লিক, অপ্রধান বোতাম"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2706,88 +1946,137 @@ msgstr ""
 "আপনার মাউস বা টাচপ্যাড সংবেদনশীল পরিবর্তন করুন এবং ডান বা বাম-হাতের দিক নির্বাচন "
 "করুন"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "ট্র্যাকপ্যাড;পয়েন্টার;ক্লিক;আলতো চাপুন;দ্বৈত;বোতাম;ট্র্যাকবল;স্ক্রোল;"
 
-#: panels/network/cc-network-panel.c:648 panels/network/cc-wifi-panel.ui:359
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "ওহো, কিছু ভুল হয়েছে। আপনার সফ্টওয়্যার বিক্রেতার সাথে যোগাযোগ করুন।"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: panels/network/cc-network-panel.c:654
-msgid "NetworkManager needs to be running."
-msgstr "নেটওয়ার্কম্যানেজারটি চলমান হওয়া দরকার।"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "কালারস্পেস: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "অস্থায়ী ফাইলগুলি স্বয়ংক্রিয় ভাবে মুছুন (_F)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "মনিটর"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "প্রাথমিক প্রদর্শন পরিবর্তন করতে টানুন।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "সংজ্ঞায়িত করা অ্যাপ্লিকেশন"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
 # auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#: panels/network/cc-network-panel.ui:66
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "অন্যান্য ডিভাইসগুলি"
 
 # auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#: panels/network/cc-network-panel.ui:107
-#: panels/network/connection-editor/net-connection-editor.c:593
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "ভিপিএন"
 
-#: panels/network/cc-network-panel.ui:151
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "নতুন সংযোগ যোগ করুন"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "সেট আপ করা হয়নি"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "সংযুক্ত"
 
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Insecure network (WEP)"
-msgstr "অনিরাপদ নেটওয়ার্ক (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:272
-msgid "Secure network (WPA)"
-msgstr "সুরক্ষিত নেটওয়ার্ক (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:277
-msgid "Secure network (WPA2)"
-msgstr "সুরক্ষিত নেটওয়ার্ক (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:282
-msgid "Secure network (WPA3)"
-msgstr "সুরক্ষিত নেটওয়ার্ক (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network"
-msgstr "সুরক্ষিত নেটওয়ার্ক"
-
-#: panels/network/cc-wifi-connection-row.ui:102
-#: panels/network/net-device-ethernet.c:316
-#: panels/network/network-bluetooth.ui:76
-#: panels/network/network-ethernet.ui:111 panels/network/network-mobile.ui:414
-#: panels/network/network-vpn.ui:75
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "বিকল্প…"
 
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:132
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"হটস্পটটি চালু করা %s থেকে সংযোগ বিচ্ছিন্ন হবে এবং ওয়াইফাই এর মাধ্যমে ইন্টারনেট "
-"অ্যাক্সেস করা সম্ভব হবে না।"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, fuzzy, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "সর্বনিম্ন ৮ টি অক্ষর থাকতে হবে"
+msgstr[1] "সর্বনিম্ন ৮ টি অক্ষর থাকতে হবে"
 
-#: panels/network/cc-wifi-hotspot-dialog.c:248
-msgid "Must have a minimum of 8 characters"
-msgstr "সর্বনিম্ন ৮ টি অক্ষর থাকতে হবে"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:458
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
 msgid "Turn On Wi-Fi Hotspot?"
 msgstr "ওয়াইফাই হটস্পট চালু করবেন?"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:19
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
 "Wi-Fi hotspot allows others to share your internet connection, by creating a "
 "Wi-Fi network that they can connect to. To do this, you must have an "
@@ -2798,1166 +2087,467 @@ msgstr ""
 "ছাড়া অন্য উত্সের মাধ্যমে একটি ইন্টারনেট সংযোগ থাকতে হবে।"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/cc-wifi-hotspot-dialog.ui:44
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
 msgstr "নেটওয়ার্কের নাম"
 
 # auto translated by TM merge from project: Skynet topics, version: 1, DocId: 5177-68190
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:69
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:383
-#: panels/printers/pp-jobs-dialog.ui:70
-#: panels/user-accounts/cc-add-user-dialog.ui:249
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "পাসওয়ার্ড"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:83
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "এলোমেলো পাসওয়ার্ড তৈরি করুন"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:84
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "পাসওয়ার্ড অটো জেনারেট করুন"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:130
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "চালু করুন (_T)"
 
-#: panels/network/cc-wifi-panel.c:543
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:53
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:863
-msgid "Stop hotspot and disconnect any users?"
-msgstr "হটস্পট বন্ধ এবং কোনো ব্যবহারকারীকে সংযোগবিচ্ছিন্ন করবেন?"
-
-#: panels/network/cc-wifi-panel.c:866
-msgid "_Stop Hotspot"
-msgstr "হটস্পট থামান (_S)"
-
-#: panels/network/cc-wifi-panel.ui:54
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "বিমান মোড"
 
-#: panels/network/cc-wifi-panel.ui:70
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Wi-Fi, ব্লুটুথ এবং মোবাইল ব্রডব্যান্ড অক্ষম করে"
 
-#: panels/network/cc-wifi-panel.ui:139
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "কোনও Wi-Fi অ্যাডাপ্টার পাওয়া যায় নি"
 
-#: panels/network/cc-wifi-panel.ui:151
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "আপনার ওয়াই-ফাই অ্যাডাপ্টার প্লাগ এবং চালু আছে তা নিশ্চিত করুন"
 
-#: panels/network/cc-wifi-panel.ui:186
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "বিমান মোড চালু"
 
-#: panels/network/cc-wifi-panel.ui:198
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "ওয়াইফাই ব্যাবহার করতে গেলে বন্ধ করুন"
 
-#: panels/network/cc-wifi-panel.ui:236
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Wi-Fi হটস্পট সক্রিয়"
 
-#: panels/network/cc-wifi-panel.ui:247
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "মোবাইল ডিভাইসগুলি সংযোগের জন্য কিউআর কোডটি স্ক্যান করতে পারে।"
 
-#: panels/network/cc-wifi-panel.ui:257
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "হটস্পট বন্ধ করুন..."
 
 # auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
-#: panels/network/cc-wifi-panel.ui:279
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "দৃশ্যমান নেটওয়ার্কগুলি"
 
-#: panels/network/cc-wifi-panel.ui:348
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "নেটওয়ার্কম্যানেজারটি চলমান হওয়া দরকার"
 
-#: panels/network/connection-editor/8021x-security-page.ui:20
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "ওহো, কিছু ভুল হয়েছে। আপনার সফ্টওয়্যার বিক্রেতার সাথে যোগাযোগ করুন।"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x নিরাপত্তা (_S)"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:112
-#: panels/network/connection-editor/ce-page-security.c:423
-#: panels/network/connection-editor/details-page.ui:90
-msgid "Security"
-msgstr "নিরাপত্তা"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "সংরক্ষিত"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "স্থায়ী"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "এলোমেলো"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "স্থিতিশীল"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"এখানে প্রবেশ করা ম্যাক ঠিকানাটি এই সংযোগটি সক্রিয় হওয়া নেটওয়ার্ক ডিভাইসের "
-"হার্ডওয়্যার ঠিকানা হিসাবে ব্যবহৃত হবে। এই বৈশিষ্ট্যটি ম্যাক ক্লোনিং বা স্পোফিং হিসাবে "
-"পরিচিত। উদাহরণ: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "প্রোফাইল %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:93
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:103
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-#: panels/network/connection-editor/ce-page-security.c:278
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:115
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:121
-msgid "Enterprise"
-msgstr "এন্টারপ্রাইজ "
-
-#: panels/network/connection-editor/ce-page-details.c:126
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "কিছুই নয়"
-
-#: panels/network/connection-editor/ce-page-details.c:147
-msgid "Never"
-msgstr "কখনও নয়"
-
-#: panels/network/connection-editor/ce-page-details.c:162
-#: panels/network/net-device-ethernet.c:107
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i দিন পূর্বে"
 msgstr[1] "%i দিন পূর্বে"
 
-#: panels/network/connection-editor/ce-page-details.c:287
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:289
-#: panels/network/net-device-ethernet.c:201
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:306
-msgid "2.4 GHz / 5 GHz"
-msgstr "২.৪ GHz / ৫ GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:308
-msgid "2.4 GHz"
-msgstr "২.৪ GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "5 GHz"
-msgstr "৫ GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:330
-msgctxt "Signal strength"
-msgid "None"
-msgstr "কিছুই নয়"
-
-#: panels/network/connection-editor/ce-page-details.c:332
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "দুর্বল"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ঠিক আছে"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "ভাল"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "দুর্দান্ত"
-
-#: panels/network/connection-editor/ce-page-details.c:396
-#: panels/network/connection-editor/details-page.ui:108
-#: panels/network/net-device-ethernet.c:142
-#: panels/network/net-device-mobile.c:430
-msgid "IPv4 Address"
-msgstr "IPv4 ঠিকানা"
-
-#: panels/network/connection-editor/ce-page-details.c:397
-#: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:143
-#: panels/network/net-device-ethernet.c:147
-#: panels/network/net-device-mobile.c:431 panels/network/network-mobile.ui:200
-msgid "IPv6 Address"
-msgstr "IPv6 ঠিকানা"
-
-# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
-#: panels/network/connection-editor/ce-page-details.c:400
-#: panels/network/connection-editor/ce-page-details.c:401
-#: panels/network/net-device-ethernet.c:145
-#: panels/network/net-device-mobile.c:434
-#: panels/network/net-device-mobile.c:435 panels/network/network-mobile.ui:183
-msgid "IP Address"
-msgstr "IP ঠিকানা"
-
-#: panels/network/connection-editor/ce-page-details.c:434
-msgid "Forget Connection"
-msgstr "সংযোগটি ভুলে যান"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/network/connection-editor/ce-page-details.c:436
-msgid "Remove Connection Profile"
-msgstr "সংযোগ প্রোফাইল সরান"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/network/connection-editor/ce-page-details.c:438
-msgid "Remove VPN"
-msgstr "ভিপিএন সরান"
-
-#: panels/network/connection-editor/ce-page-details.c:456
-msgid "Details"
-msgstr "বিবরণ"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "স্বয়ংক্রিয়"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:150
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "পরিচয়"
-
-#: panels/network/connection-editor/ce-page-ip4.c:246
-#: panels/network/connection-editor/ce-page-ip6.c:227
-msgid "Delete Address"
-msgstr "ঠিকানা মুছুন"
-
-#: panels/network/connection-editor/ce-page-ip4.c:405
-#: panels/network/connection-editor/ce-page-ip6.c:375
-msgid "Delete Route"
-msgstr "রাউট মুছুন"
-
-#: panels/network/connection-editor/ce-page-ip4.c:827
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:760
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:267
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "কিছুই নয়"
-
-#: panels/network/connection-editor/ce-page-security.c:302
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-বিট কী (Hex বা ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:312
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-বিট পাসফ্রেজ"
-
-#: panels/network/connection-editor/ce-page-security.c:325
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:338
-msgid "Dynamic WEP (802.1x)"
-msgstr "ডায়নামিক WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:352
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 ব্যক্তিগত"
-
-#: panels/network/connection-editor/ce-page-security.c:366
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 এন্টারপ্রাইজ"
-
-#: panels/network/connection-editor/ce-page-security.c:380
-msgid "WPA3 Personal"
-msgstr "WPA3 ব্যক্তিগত"
-
-#: panels/network/connection-editor/details-page.ui:18
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "সংকেতের শক্তি"
 
-#: panels/network/connection-editor/details-page.ui:54
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "লিঙ্কের গতি"
 
-#: panels/network/connection-editor/details-page.ui:144
-#: panels/network/net-device-ethernet.c:150
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "নিরাপত্তা"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 ঠিকানা"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 ঠিকানা"
+
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "হার্ডওয়্যার ঠিকানা"
 
-#: panels/network/connection-editor/details-page.ui:162
+#: panels/network/connection-editor/details-page.ui:142
 msgid "Supported Frequencies"
 msgstr "সমর্থিত ফ্রিকোয়েন্সিগুলি"
 
-#: panels/network/connection-editor/details-page.ui:180
-#: panels/network/net-device-ethernet.c:154
-#: panels/network/network-mobile.ui:217
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "ডিফল্ট রাউট"
 
-#: panels/network/connection-editor/details-page.ui:199
-#: panels/network/connection-editor/ip4-page.ui:211
-#: panels/network/connection-editor/ip6-page.ui:225
-#: panels/network/net-device-ethernet.c:156
-#: panels/network/network-mobile.ui:235
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: panels/network/connection-editor/details-page.ui:217
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "সর্বশেষ ব্যবহৃত"
 
-#: panels/network/connection-editor/details-page.ui:376
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "স্বয়ংক্রিয় ভাবে সংযোগ করুন (_a)"
 
-#: panels/network/connection-editor/details-page.ui:395
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "অন্যান্য ব্যবহারকারীর কাছে উপলব্ধ করান (_o)"
 
-#: panels/network/connection-editor/details-page.ui:428
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr "মিটার সংযোগ: ডেটা সীমা রয়েছে বা চার্জ বহন করতে পারে(_M)"
 
-#: panels/network/connection-editor/details-page.ui:439
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr "সফ্টওয়্যার আপডেট এবং অন্যান্য বড় ডাউনলোডগুলি স্বয়ংক্রিয়ভাবে শুরু হবে না।"
 
-#: panels/network/connection-editor/ethernet-page.ui:25
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "নাম (_N)"
 
-#: panels/network/connection-editor/ethernet-page.ui:54
-#: panels/network/connection-editor/wifi-page.ui:67
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "MAC ঠিকানা (_M)"
 
-#: panels/network/connection-editor/ethernet-page.ui:105
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: panels/network/connection-editor/ethernet-page.ui:122
-#: panels/network/connection-editor/wifi-page.ui:102
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "ক্লোনড ঠিকানা (_C)"
 
-#: panels/network/connection-editor/ethernet-page.ui:137
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "বাইট"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "IPv4 পদ্ধতি (_4)"
 
-#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "স্বয়ংক্রিয় (DHCP)"
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "শুধুমাত্র স্থানীয়-লিংক"
 
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:72 panels/network/network-proxy.ui:116
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "ম্যানুয়াল"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "নিষ্ক্রিয়"
 
-#: panels/network/connection-editor/ip4-page.ui:97
-#: panels/network/connection-editor/ip6-page.ui:111
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
 msgid "Shared to other computers"
 msgstr "অন্যান্য কম্পিউটারের সংগে ভাগ করা"
 
-#: panels/network/connection-editor/ip4-page.ui:125
-#: panels/network/connection-editor/ip6-page.ui:139
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "ঠিকানাগুলি"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
-#: panels/printers/pp-details-dialog.ui:95
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "ঠিকানা"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "নেটমাস্ক"
 
-#: panels/network/connection-editor/ip4-page.ui:171
-#: panels/network/connection-editor/ip4-page.ui:355
-#: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:369
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "গেটওয়ে"
 
-#: panels/network/connection-editor/ip4-page.ui:223
-#: panels/network/connection-editor/ip4-page.ui:291
-#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/connection-editor/ip6-page.ui:305
-#: panels/network/net-proxy.c:74 panels/network/network-proxy.ui:106
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "স্বয়ংক্রিয়"
 
-#: panels/network/connection-editor/ip4-page.ui:234
-#: panels/network/connection-editor/ip6-page.ui:248
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "স্বয়ংক্রিয় DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:258
-#: panels/network/connection-editor/ip6-page.ui:272
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "আইপি ঠিকানাগুলি কমা দিয়ে আলাদা করুন"
 
-#: panels/network/connection-editor/ip4-page.ui:279
-#: panels/network/connection-editor/ip6-page.ui:293
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "রাউট"
 
-#: panels/network/connection-editor/ip4-page.ui:302
-#: panels/network/connection-editor/ip6-page.ui:316
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "স্বয়ংক্রিয় রাউট"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:368
-#: panels/network/connection-editor/ip6-page.ui:382
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "মেট্রিক"
 
-#: panels/network/connection-editor/ip4-page.ui:398
-#: panels/network/connection-editor/ip6-page.ui:412
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "এই সংযোগ শুধুমাত্র এর নেটওয়ার্কে রিসোর্সগুলির জন্য ব্যবহার করুন (_o)"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "IPv6 পদ্ধতি (_6)"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "স্বয়ংক্রিয়, শুধুমাত্র DHCP"
 
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "প্রেফিক্স"
 
-#: panels/network/connection-editor/net-connection-editor.c:288
-msgid "Unable to open connection editor"
-msgstr "সংযোগ সম্পাদক খোলা গেল না"
-
-#: panels/network/connection-editor/net-connection-editor.c:304
-msgid "New Profile"
-msgstr "নতুন প্রোফাইল"
-
-#: panels/network/connection-editor/net-connection-editor.c:737
-msgid "Import from file…"
-msgstr "ফাইল থেকে আমদানি করুন…"
-
-#: panels/network/connection-editor/net-connection-editor.c:769
-msgid "Add VPN"
-msgstr "VPN যোগ করুন"
-
-#: panels/network/connection-editor/security-page.ui:20
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "নিরাপত্তা (_e)"
 
-#: panels/network/connection-editor/vpn-helpers.c:139
-msgid "Cannot import VPN connection"
-msgstr "VPN সংযোগ আমদানি করা যাবে না"
-
-#: panels/network/connection-editor/vpn-helpers.c:141
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"\"%s\" ফাইলটি পড়া যায়নি বা স্বীকৃত ভিপিএন সংযোগের তথ্য ধারণ করে না\n"
-"\n"
-"ত্রুটি: %s"
-
-#: panels/network/connection-editor/vpn-helpers.c:173
-msgid "Select file to import"
-msgstr "আমদানি করার জন্য ফাইল নির্বাচন করুন"
-
-#: panels/network/connection-editor/vpn-helpers.c:225
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "\"%s\" নামের একটি ফাইল ইতিমধ্যেই বিদ্যমান।"
-
-# auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
-#: panels/network/connection-editor/vpn-helpers.c:227
-msgid "_Replace"
-msgstr "প্রতিস্থাপন করুন (_R)"
-
-#: panels/network/connection-editor/vpn-helpers.c:229
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "আপনি যে VPN সংযোগ সংরক্ষণ করছেন তা দিয়ে %s প্রতিস্থাপন করতে চান?"
-
-#: panels/network/connection-editor/vpn-helpers.c:264
-msgid "Cannot export VPN connection"
-msgstr "VPN সংযোগ রপ্তানি করা যাবে না"
-
-#: panels/network/connection-editor/vpn-helpers.c:266
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN সংযোগ '%s' %s এ রপ্তানি করা যায়নি।\n"
-"\n"
-"ত্রুটি: %s।"
-
-#: panels/network/connection-editor/vpn-helpers.c:296
-msgid "Export VPN connection"
-msgstr "VPN সংযোগ রপ্তানি করুন"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(ত্রুটি: VPN সংযোগ সম্পাদক লোড করা যায়নি)"
 
-#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "নেটওয়ার্ক"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "ইন্টারনেটের সংগে আপনার সংযোগের ধরন নিয়ন্ত্রণ করুন"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "নেটওয়ার্ক;আইপি;LAN;প্রক্সি;WAN;ব্রডব্যান্ড;মোডেম;ব্লুটুথ;VPN;ডিএনএস;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "কীভাবে আপনি Wi-Fi নেটওয়ার্কগুলিতে সংযুক্ত হন তা নিয়ন্ত্রণ করুন"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "নেটওয়ার্ক;বেতার;Wi-Fi;Wifi;IP;LAN;প্রক্সি;WAN;ব্রডব্যান্ড;মোডেম;ব্লুটুথ;vpn;vlan;ব্রিজ;"
 "বন্ড;DNS;"
 
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/network/net-device-ethernet.c:95
-msgid "never"
-msgstr "কখনো নয়"
-
-# auto translated by TM merge from project: gnome-system-log, version: 3.8.1, DocId: gnome-system-log
-#: panels/network/net-device-ethernet.c:103
-msgid "today"
-msgstr "আজ"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#: panels/network/net-device-ethernet.c:105
-msgid "yesterday"
-msgstr "গতকাল"
-
-#: panels/network/net-device-ethernet.c:161
-msgid "Last used"
-msgstr "সর্বশেষ ব্যবহৃত"
-
 # auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:250
-#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "তারযুক্ত"
 
-#: panels/network/net-device-mobile.c:207
-msgid "Add new connection"
-msgstr "নতুন সংযোগ যোগ করুন"
-
-#: panels/network/net-device-wifi.c:851
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"পাসওয়ার্ড সমেত নির্বাচিত নেটওয়ার্কগুলির নেটওয়ার্ক বিস্তারিত এবং যেকোনো কাস্টম "
-"কনফিগারেশন হারিয়ে যাবে।"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/network/net-device-wifi.c:855
-msgid "_Forget"
-msgstr "মুছে ফেলা হবে (_F)"
-
-#: panels/network/net-device-wifi.c:1011 panels/network/net-device-wifi.c:1018
-msgid "Known Wi-Fi Networks"
-msgstr "জানা ওয়াইফাই নেটওয়ার্কগুলি"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1053
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "মুছে ফেলা হবে (_F)"
-
-#: panels/network/net-device-wifi.c:1193
-msgid "System policy prohibits use as a Hotspot"
-msgstr "হটস্পট হিসাবে ব্যবহার সিস্টেম নীতি নিষিদ্ধ করে"
-
-#: panels/network/net-device-wifi.c:1196
-msgid "Wireless device does not support Hotspot mode"
-msgstr "বেতার ডিভাইস হটস্পট মোড সমর্থন করে না"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/network/net-proxy.c:70
-#: panels/notifications/cc-notifications-panel.c:268
-#: panels/power/cc-power-panel.c:1728 panels/power/cc-power-panel.c:1739
-#: panels/universal-access/cc-ua-panel.c:480
-#: panels/universal-access/cc-ua-panel.c:840
-#: panels/universal-access/cc-ua-panel.c:853
-#: panels/universal-access/cc-ua-panel.c:865
-#: panels/universal-access/cc-ua-panel.c:1030
-#: panels/universal-access/cc-ua-panel.ui:321
-#: panels/universal-access/cc-ua-panel.ui:367
-#: panels/universal-access/cc-ua-panel.ui:413
-#: panels/universal-access/cc-ua-panel.ui:519
-#: panels/universal-access/cc-ua-panel.ui:672
-#: panels/universal-access/cc-ua-panel.ui:718
-#: panels/universal-access/cc-ua-panel.ui:764
-#: panels/universal-access/cc-ua-panel.ui:948
-msgid "Off"
-msgstr "বন্ধ"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:113
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"কনফিগারেশন URL সরবরাহ করা না হলে ওয়েব প্রক্সি স্বয়ংক্রিয়-ডিসকভারি ব্যবহার করা হয়।"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:121
-msgid "This is not recommended for untrusted public networks."
-msgstr "অবিশ্বস্ত সর্বজনীন নেটওয়ার্কের ক্ষেত্রে এটি প্রস্তাবিত নয়।"
-
-#. update title
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/net-vpn.c:66 panels/network/net-vpn.c:163
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#: panels/network/network-bluetooth.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "ডিভাইস বন্ধ করুন"
 
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "সক্রিয়"
+
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/network-mobile.ui:29
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/network-mobile.ui:47
+#: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "সরবরাহকারী"
 
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:95
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP ঠিকানা"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "নেটওয়ার্ক প্রক্সি"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/network-proxy.ui:176
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP প্রক্সি"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/network-proxy.ui:195
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "H_TTPS প্রক্সি"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/network-proxy.ui:214
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "_FTP প্রক্সি"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/network-proxy.ui:233
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "সকস হোস্ট (_S)"
 
-#: panels/network/network-proxy.ui:252
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "হোস্ট উপেক্ষা করুন (_I)"
 
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/network/network-proxy.ui:290
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "HTTP প্রক্সি পোর্ট"
 
-#: panels/network/network-proxy.ui:367
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "HTTPS প্রক্সি পোর্ট"
 
-#: panels/network/network-proxy.ui:388
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "FTP প্রক্সি পোর্ট"
 
-#: panels/network/network-proxy.ui:409
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Socks প্রক্সি পোর্ট"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/network-proxy.ui:438
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "কনফিগারেশন URL (_C)"
 
-#: panels/network/network-vpn.ui:55
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "VPN সংযোগ বন্ধ করুন"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/network/network-wifi.ui:22
+#: panels/network/network-wifi.ui:34
 msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "নেটওয়ার্কের নাম"
 
-#: panels/network/network-wifi.ui:28
+#: panels/network/network-wifi.ui:40
 msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "নিরাপত্তা ধরন"
 
 # auto translated by TM merge from project: Skynet topics, version: 1, DocId: 5177-68190
-#: panels/network/network-wifi.ui:34
+#: panels/network/network-wifi.ui:46
 msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "পাসওয়ার্ড"
 
-#: panels/network/network-wifi.ui:84
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Wi-Fi বন্ধ করুন"
 
-#: panels/network/network-wifi.ui:116
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "লোডের বিকল্প…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "লুকানো নেটওয়ার্কে সংযোগ করুন (_C)…"
 
-#: panels/network/network-wifi.ui:127
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Wi-Fi হটস্পট চালু করুন(_T)..."
 
-#: panels/network/network-wifi.ui:138
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "জানা ওয়াইফাই নেটওয়ার্কগুলি(_K)"
-
-# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "স্ট্যাটাস অজানা"
-
-# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "অপরিচালিত"
-
-# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
-#. TRANSLATORS: device status
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/network/panel-common.c:45 panels/user-accounts/cc-user-panel.c:950
-msgid "Unavailable"
-msgstr "উপলব্ধ নয়"
-
-# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "সংযোগ করা হচ্ছে"
-
-# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "অনুমোদন আবশ্যক"
-
-# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:63
-msgid "Connected"
-msgstr "সংযুক্ত"
-
-# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "সংযোগ বিচ্ছিন্ন করা হচ্ছে"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "সংযোগ বিফল"
-
-# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "স্ট্যাটাস অজানা (অনুপস্থিত)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "কনফিগারেশন করা যায়নি"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP কনফিগারেশন ব্যর্থ হয়েছে"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP কনফিগারেশনের মেয়াদ শেষ হয়েছে"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "গোপনীয় তথ্য আবশ্যক, কিন্তু উপলব্ধ নয়"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x সাপ্লিক্যান্টের সংযোগ বিচ্ছিন্ন করা হয়েছে"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x সাপ্লিক্যান্টের কনফিগারেশন বিফল হয়েছে"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x সাপ্লিক্যান্ট বিফল হয়েছে"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x সাপ্লিক্যান্ট অনুমোদন করতে অত্যাধিক সময় ব্যয় হয়েছে"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP পরিসেবা আরম্ভ করতে ব্যর্থ"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP পরিসেবার সাথে সংযোগ বিচ্ছিন্ন হয়েছে"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP বিফল"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP ক্লায়েন্ট আরম্ভ করতে ব্যর্থ"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP ক্লায়েন্ট সংক্রান্ত ত্রুটি"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP ক্লায়েন্ট বিফল হয়েছে"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "যৌথরূপে ব্যবহৃত সংযোগ পরিসেবা আরম্ভ হতে ব্যর্থ"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "যৌথরূপে ব্যবহৃত পরিসেবা বিফল হয়েছে"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP পরিসেবা আরম্ভ করতে ব্যর্থ"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP পরিসেবায় ত্রুটি"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP পরিসেবা বিফল"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "লাইন ব্যস্ত"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "ডায়েল টোন অনুপস্থিত"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "কোনো কেরিয়ার নির্ধারণ করা যায়নি"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "ডায়াল অনুরোধের সময় শেষ হয়ে গেছে"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "ডায়াল করার প্রচেষ্টা ব্যর্থ হয়েছে"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "মোডেম আরম্ভ করতে ব্যর্থ"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "চিহ্নিত APN নির্বাচন করতে ব্যর্থ"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "নেটওয়ার্ক সন্ধান করা হচ্ছে না"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "নেটওয়ার্ক নিবন্ধন প্রত্যাখ্যান করা হয়েছে"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "নেটওয়ার্ক নিবন্ধন করতে সময়সীমা উত্তীর্ণ হয়েছে"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "অনুরোধ করা নেটওয়ার্কে নিবন্ধন করতে ব্যর্থ"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN পরীক্ষা করতে ব্যর্থ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "অনুপস্থিত হতে পারে এমন ডিভাইসের ফার্মওয়্যার"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "সংযোগ চলে গেছে"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "বিদ্যমান সংযোগ ধরে নেওয়া হয়েছে"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "মোডেম পাওয়া যায়নি"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "ব্লুটুথ সংযোগ ব্যর্থ হয়েছে"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM কার্ড ঢোকানো হয়নি"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM পিন প্রয়োজনীয়"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM পুক প্রয়োজনীয়"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252
-msgid "SIM wrong"
-msgstr "SIM ভুল"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "সংযোগ নির্ভরশীলতা ব্যর্থ হয়েছে"
-
-# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:351
-msgid "Firmware missing"
-msgstr "ফায়ারওয়্যার অনুপস্থিত"
-
-# auto translated by TM merge from project: gnome-getting-started-docs, version: 3.8.3.0.1, DocId: gnome-getting-started-docs
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:355
-msgid "Cable unplugged"
-msgstr "কেবল বিচ্ছিন্ন করা হয়েছে"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "802.1X সুরক্ষা (ডাব্লুপিএ-এপ) এ অপরিজ্ঞাত ত্রুটি"
-
-#: panels/network/wireless-security/eap-method.c:195
-msgid "no file selected"
-msgstr "কোনও ফাইল নির্বাচিত হয়নি"
-
-#: panels/network/wireless-security/eap-method.c:222
-msgid "unspecified error validating eap-method file"
-msgstr "Eap-পদ্ধতি ফাইলটি বৈধকরণে অনির্দিষ্ট ত্রুটি"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, বা PKCS#12 ব্যক্তিগত কী (*.der, *.pem, *.p12)"
-
-#: panels/network/wireless-security/eap-method.c:400
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER বা PEM শংসাপত্র (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:87
-msgid "missing EAP-FAST PAC file"
-msgstr "EAP-FAST PAC ফাইল অনুপস্থিত"
-
-#: panels/network/wireless-security/eap-method-fast.c:347
-msgid "Choose a PAC file"
-msgstr "একটি PAC ফাইল বাছুন"
-
-#: panels/network/wireless-security/eap-method-fast.c:352
-msgid "PAC files (*.pac)"
-msgstr "PAC ফাইল (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -3986,77 +2576,56 @@ msgstr "অনুমোদিত"
 msgid "Both"
 msgstr "উভয়"
 
-#: panels/network/wireless-security/eap-method-fast.ui:49
-#: panels/network/wireless-security/eap-method-peap.ui:52
-#: panels/network/wireless-security/eap-method-ttls.ui:51
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
 msgid "Anony_mous identity"
 msgstr "নামবিহীন পরিচয় (_m)"
 
-#: panels/network/wireless-security/eap-method-fast.ui:75
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "PAC ফাইল (_f)"
 
-#: panels/network/wireless-security/eap-method-fast.ui:115
-#: panels/network/wireless-security/eap-method-peap.ui:150
-#: panels/network/wireless-security/eap-method-ttls.ui:143
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "একটি PAC ফাইল বাছুন"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "অভ্যন্তরীণ প্রমাণীকরণ (_I)"
 
-#: panels/network/wireless-security/eap-method-fast.ui:144
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr "স্বয়ংক্রিয় PAC pro_visioning এর অনুমতি দিন"
 
-#: panels/network/wireless-security/eap-method-leap.c:64
-msgid "missing EAP-LEAP username"
-msgstr "EAP-LEAP ব্যবহারকারীর নাম অনুপস্থিত"
-
-#: panels/network/wireless-security/eap-method-leap.c:73
-msgid "missing EAP-LEAP password"
-msgstr "EAP-LEAP পাসওয়ার্ড অনুপস্থিত"
-
 # auto translated by TM merge from project: gnome-boxes, version: 3.8.3, DocId: gnome-boxes
-#: panels/network/wireless-security/eap-method-leap.ui:17
-#: panels/network/wireless-security/eap-method-simple.ui:17
-#: panels/network/wireless-security/ws-leap.ui:18
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "ব্যবহারকারীর নাম (_U)"
 
 # auto translated by TM merge from project: gnome-boxes, version: 3.8.3, DocId: gnome-boxes
-#: panels/network/wireless-security/eap-method-leap.ui:31
-#: panels/network/wireless-security/eap-method-simple.ui:31
-#: panels/network/wireless-security/ws-leap.ui:32
-#: panels/network/wireless-security/ws-wpa-psk.ui:14
-#: panels/sharing/cc-sharing-panel.ui:202
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:436
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "পাসওয়ার্ড (_P)"
 
-#: panels/network/wireless-security/eap-method-leap.ui:55
-#: panels/network/wireless-security/eap-method-simple.ui:73
-#: panels/network/wireless-security/eap-method-tls.ui:157
-#: panels/network/wireless-security/ws-leap.ui:56
-#: panels/network/wireless-security/ws-wpa-psk.ui:64
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "পাসওয়ার্ড দেখান (_w)"
-
-#: panels/network/wireless-security/eap-method-peap.c:87
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "অবৈধ EAP-PEAP CA শংসাপত্র: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:96
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "অবৈধ EAP-PEAP CA শংসাপত্র: কোনও শংসাপত্র নির্দিষ্ট করা হয়নি"
-
-#: panels/network/wireless-security/eap-method-peap.c:328
-#: panels/network/wireless-security/eap-method-tls.c:507
-#: panels/network/wireless-security/eap-method-ttls.c:336
-msgid "Choose a Certificate Authority certificate"
-msgstr "একটি শংসাপত্র কর্তৃপক্ষ শংসাপত্র বাছুন"
 
 # auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
 #: panels/network/wireless-security/eap-method-peap.ui:17
@@ -4074,104 +2643,44 @@ msgstr "সংস্করণ ০"
 msgid "Version 1"
 msgstr "ভার্সান ১"
 
-#: panels/network/wireless-security/eap-method-peap.ui:78
-#: panels/network/wireless-security/eap-method-tls.ui:68
-#: panels/network/wireless-security/eap-method-ttls.ui:102
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "C_A শংসাপত্র"
 
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "একটি শংসাপত্র কর্তৃপক্ষ শংসাপত্র বাছুন"
+
 # auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
-#: panels/network/wireless-security/eap-method-peap.ui:100
-#: panels/network/wireless-security/eap-method-tls.ui:90
-#: panels/network/wireless-security/eap-method-ttls.ui:125
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "কোনও সিএ শংসাপত্রের প্রয়োজন নেই(_r)"
 
-#: panels/network/wireless-security/eap-method-peap.ui:118
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP সংস্করণ (_v)"
 
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "EAP ব্যবহারকারীর নাম অনুপস্থিত"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "EAP পাসওয়ার্ড অনুপস্থিত"
-
-#: panels/network/wireless-security/eap-method-tls.c:91
-msgid "missing EAP-TLS identity"
-msgstr "EAP-TLS পরিচয় অনুপস্থিত"
-
-#: panels/network/wireless-security/eap-method-tls.c:101
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "অবৈধ EAP-TLS CA শংসাপত্র: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:111
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "অবৈধ EAP-TLS CA শংসাপত্র: কোনও শংসাপত্র নির্দিষ্ট করা হয়নি"
-
-#: panels/network/wireless-security/eap-method-tls.c:125
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "অবৈধ EAP-TLS ব্যক্তিগত-কী: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:135
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "অবৈধ EAP-TLS ব্যবহারকারীর শংসাপত্র: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:266
-msgid "Unencrypted private keys are insecure"
-msgstr "এনক্রিপ্ট না করা ব্যক্তিগত কী অনিরাপদ"
-
-#: panels/network/wireless-security/eap-method-tls.c:269
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"নির্বাচিত ব্যক্তিগত কী কোনও পাসওয়ার্ড দ্বারা সুরক্ষিত বলে মনে হয় না। এটি আপনার "
-"সুরক্ষা শংসাপত্রগুলিকে আপস করার অনুমতি দিতে পারে। দয়া করে একটি পাসওয়ার্ড-সুরক্ষিত "
-"ব্যক্তিগত কী নির্বাচন করুন।\n"
-"\n"
-"(আপনি ওপেনএসএল দিয়ে আপনার ব্যক্তিগত কী পাসওয়ার্ড-সুরক্ষা রাখতে পারবেন)"
-
-#: panels/network/wireless-security/eap-method-tls.c:500
-msgid "Choose your personal certificate"
-msgstr "আপনার ব্যক্তিগত শংসাপত্র বাছুন"
-
-#: panels/network/wireless-security/eap-method-tls.c:514
-msgid "Choose your private key"
-msgstr "আপনার ব্যক্তিগত কী বাছুন"
-
-#: panels/network/wireless-security/eap-method-tls.ui:17
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "পরিচয় (_d)"
 
-#: panels/network/wireless-security/eap-method-tls.ui:43
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "ব্যবহারকারী শংসাপত্র (_U)"
 
-#: panels/network/wireless-security/eap-method-tls.ui:108
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "ব্যক্তিগত কী (_k)"
 
-#: panels/network/wireless-security/eap-method-tls.ui:133
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "ব্যক্তিগত কী পাসওয়ার্ড (_P)"
-
-#: panels/network/wireless-security/eap-method-ttls.c:98
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "অবৈধ EAP-TTLS CA শংসাপত্র: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:106
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "অবৈধ EAP-TTLS CA শংসাপত্র: কোনও শংসাপত্র নির্দিষ্ট করা হয়নি"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4190,21 +2699,21 @@ msgid "CHAP"
 msgstr "CHAP"
 
 # auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/network/wireless-security/eap-method-ttls.ui:76
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
 msgid "_Domain"
 msgstr "ডোমেইন (_D)"
-
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "802.1X সুরক্ষা বৈধকরণে অজানা ত্রুটি"
 
 # auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4226,51 +2735,17 @@ msgstr "টানেলড TLS"
 msgid "Protected EAP (PEAP)"
 msgstr "সুরক্ষিত EAP (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:56
-#: panels/network/wireless-security/ws-wep-key.ui:102
-#: panels/network/wireless-security/ws-wpa-eap.ui:61
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "প্রমাণীকরণ (_t)"
 
-#: panels/network/wireless-security/ws-leap.c:65
-msgid "missing leap-username"
-msgstr "লিপ-ব্যবহারকারীর নাম অনুপস্থিত"
-
-#: panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr "লিপ-পাসওয়ার্ড অনুপস্থিত"
-
-#: panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr "ওয়েপ-কি অনুপস্থিত"
-
-#: panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "অবৈধ ওয়েপ-কী: %zu দৈর্ঘ্যের কীটিতে অবশ্যই হেক্স-সংখ্যা থাকতে হবে"
-
-#: panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "অবৈধ ওয়েপ-কী: %zu দৈর্ঘ্যের কীটিতে অবশ্যই আসকি অক্ষর থাকতে হবে"
-
-#: panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"অবৈধ ওয়েপ-কী: ভুল কী দৈর্ঘ্য %zu। একটি কী দৈর্ঘ্যের 5/13 (ascii) বা 10/26 (হেক্স) "
-"এর হতে হবে"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "অবৈধ ওয়েপ-কী: পাসফ্রেজ অবশ্যই খালি থাকতে হবে"
-
-#: panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "অবৈধ ওয়েপ-কী: পাসফ্রেজটি ৬৪ টি অক্ষরের চেয়ে কম হওয়া উচিত"
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "ধরন (_T)"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4284,95 +2759,66 @@ msgstr "মুক্ত সিস্টেম"
 msgid "Shared Key"
 msgstr "ভাগ করা কী"
 
-#: panels/network/wireless-security/ws-wep-key.ui:48
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "কী (_K)"
 
-#: panels/network/wireless-security/ws-wep-key.ui:84
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "কী দেখান (_w)"
 
-#: panels/network/wireless-security/ws-wep-key.ui:134
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP সূচি (_x)"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"অবৈধ ডাব্লুপিএ-পিএসকি: অবৈধ কী-দৈর্ঘ্য %zu। অবশ্যই [৮,৬৩] বাইট বা ৬৪ হেক্স অঙ্কের "
-"হতে হবে"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "অবৈধ ডাব্লুপিএ-পিএসকি: ৬৪ বাইটকে হেক্স হিসাবে কী ব্যাখ্যা করতে পারে না"
-
-# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
-#: panels/network/wireless-security/ws-wpa-psk.ui:42
-msgid "_Type"
-msgstr "ধরন (_T)"
-
 # auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:60
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "সূচনাবার্তা (_N)"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:112
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "শব্দ সর্তকতা (_A)"
 
 # auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
-#: panels/notifications/cc-app-notifications-dialog.ui:168
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "বিজ্ঞপ্তি পপআপগুলি (_P)"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:184
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
 msgstr "পপআপগুলি অক্ষম করা হলে বিজ্ঞপ্তিগুলি বিজ্ঞপ্তি তালিকায় প্রদর্শিত হতে থাকবে।"
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:249
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "পপআপে বার্তা সামগ্রী দেখান(_C)"
 
 # auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
-#: panels/notifications/cc-app-notifications-dialog.ui:300
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "লক স্ক্রিন বিজ্ঞপ্তিগুলি (_L)"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:351
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "লক স্ক্রিনে বার্তা সামগ্রী প্রদর্শন করুন (_o)"
 
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/notifications/cc-notifications-panel.c:268
-#: panels/power/cc-power-panel.c:1734 panels/power/cc-power-panel.c:1741
-#: panels/universal-access/cc-ua-panel.c:480
-#: panels/universal-access/cc-ua-panel.c:840
-#: panels/universal-access/cc-ua-panel.c:853
-#: panels/universal-access/cc-ua-panel.c:865
-#: panels/universal-access/cc-ua-panel.c:1030
-msgid "On"
-msgstr "চালু"
-
-#: panels/notifications/cc-notifications-panel.ui:47
+#: panels/notifications/cc-notifications-panel.ui:10
 msgid "_Do Not Disturb"
 msgstr "বিরক্ত করবেন না(_D)"
 
 # auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
-#: panels/notifications/cc-notifications-panel.ui:55
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr "লক স্ক্রিন বিজ্ঞপ্তি (_L)"
 
@@ -4380,36 +2826,32 @@ msgstr "লক স্ক্রিন বিজ্ঞপ্তি (_L)"
 msgid "Control which notifications are displayed and what they show"
 msgstr "কোন বিজ্ঞপ্তিগুলি দেখানো হবে এবং তারা কী দেখায় তা নিয়ন্ত্রণ করুন"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "বিজ্ঞপ্তি;ব্যানার;বার্তা;ট্রে;পপ-আপ;"
 
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/online-accounts/cc-online-accounts-panel.c:150
-msgctxt "Online Account"
-msgid "Other"
-msgstr "অন্যান্য"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "পূর্বাবস্থায় ফিরুন"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:622
-#, c-format
-msgid "%s Account"
-msgstr "%s এর অ্যাকাউন্ট"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "অভ্যন্তরীণ প্রমাণীকরণ (_I)"
 
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/online-accounts/cc-online-accounts-panel.c:918
-msgid "Error removing account"
-msgstr "অ্যাকাউন্ট অপসারণের করার সময় ত্রুটি"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "ক্লাউডে আপনার ডেটা সংযোগ করুন"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:984
-#, c-format
-msgid "%s removed"
-msgstr "%s সরানো হয়েছে"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "কোনও ইন্টারনেট সংযোগ নেই - নতুন অনলাইন অ্যাকাউন্ট সেট আপ করতে সংযুক্ত হন"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "অ্যাকাউন্ট যোগ করুন"
 
 # auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
@@ -4422,10 +2864,6 @@ msgstr ""
 "আপনার অনলাইন অ্যাকাউন্টগুলিতে সংযোগ করুন এবং তাদের কী কাজে ব্যবহার করবেন তার স্থির "
 "করুন"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4434,34 +2872,8 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;অনলাইন;চ্যাট;ক্যালেন্ডার;মেল;পরিচিতি;ownCloud;"
 "Kerberos;IMAP;SMTP;পকেট;ReadItLater;"
 
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:61
-msgid "Undo"
-msgstr "পূর্বাবস্থায় ফিরুন"
-
-#: panels/online-accounts/online-accounts.ui:94
-msgid "Connect to your data in the cloud"
-msgstr "ক্লাউডে আপনার ডেটা সংযোগ করুন"
-
-#: panels/online-accounts/online-accounts.ui:109
-msgid "No internet connection — connect to set up new online accounts"
-msgstr "কোনও ইন্টারনেট সংযোগ নেই - নতুন অনলাইন অ্যাকাউন্ট সেট আপ করতে সংযুক্ত হন"
-
-#: panels/online-accounts/online-accounts.ui:134
-msgid "Add an account"
-msgstr "অ্যাকাউন্ট যোগ করুন"
-
-#: panels/online-accounts/online-accounts.ui:238
-msgid "Remove Account"
-msgstr "অ্যাকাউন্ট সরান"
-
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#: panels/power/cc-power-panel.c:331
-msgid "Unknown time"
-msgstr "অজানা সময়"
-
 # auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
-#: panels/power/cc-power-panel.c:337
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
@@ -4469,368 +2881,181 @@ msgstr[0] "%i মিনিট"
 msgstr[1] "%i মিনিটে"
 
 # auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
-#: panels/power/cc-power-panel.c:349
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i ঘন্টা"
 msgstr[1] "%i ঘন্টায়"
 
-# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-power-panel.c:357
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/power/cc-power-panel.c:358
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ঘন্টা"
 msgstr[1] "ঘন্টা"
 
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/power/cc-power-panel.c:359
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "মিনিট"
 msgstr[1] "মিনিট"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:377
-#, c-format
-msgid "%s until fully charged"
-msgstr "চার্জ পূর্ণ হতে %s বাকি"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:384
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "সর্তকতা: %s বাকি আছে"
-
-# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:389
-#, c-format
-msgid "%s remaining"
-msgstr "%s বাকি আছে"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:394 panels/power/cc-power-panel.c:424
-msgid "Fully charged"
-msgstr "সম্পূর্ণ চার্জ রয়েছে"
-
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:398 panels/power/cc-power-panel.c:428
-msgid "Not charging"
-msgstr "চার্জ করা হচ্ছে না"
-
-# auto translated by TM merge from project: RHEL Installation Guide, version: 6.0, DocId: Partitions-x86
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:402 panels/power/cc-power-panel.c:432
-msgid "Empty"
-msgstr "খালি"
-
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:415
-msgid "Charging"
-msgstr "ব্যাটারি চার্জ করা হচ্ছে"
-
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:420
-msgid "Discharging"
-msgstr "ব্যাটারি ব্যবহার করা হচ্ছে"
-
-#: panels/power/cc-power-panel.c:566
-msgctxt "Battery name"
-msgid "Main"
-msgstr "প্রধান"
-
-#: panels/power/cc-power-panel.c:568
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "অতিরিক্ত"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:643
-msgid "Wireless mouse"
-msgstr "বেতার মাউস"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:646
-msgid "Wireless keyboard"
-msgstr "বেতার কীবোর্ড"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:649
-msgid "Uninterruptible power supply"
-msgstr "নিরবিচ্ছিন্ন বিদ্যুত সরবরাহ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:652
-msgid "Personal digital assistant"
-msgstr "ব্যক্তিগত ডিজিট্যাল সহায়ক"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:655
-msgid "Cellphone"
-msgstr "সেলফোন"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:658
-msgid "Media player"
-msgstr "মিডিয়া প্লেয়ার"
-
-# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:661 panels/wacom/cc-wacom-panel.c:728
-msgid "Tablet"
-msgstr "ট্যাবলেট"
-
-# auto translated by TM merge from project: gvfs, version: 1.16.3, DocId: gvfs
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:664
-msgid "Computer"
-msgstr "কম্পিউটার"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:667
-msgid "Gaming input device"
-msgstr "গেমিং ইনপুট ডিভাইস"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-power-panel.c:670 panels/power/cc-power-panel.c:962
-#: panels/power/cc-power-panel.c:2278
-msgid "Battery"
-msgstr "ব্যাটারি"
-
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:731
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "ব্যাটারি চার্জ করা হচ্ছে"
-
-# auto translated by TM merge from project: gnome-doc-utils, version: 0.20.10, DocId: gnome-doc-utils
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:738
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "সতর্কতা"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:743
-msgctxt "Battery power"
-msgid "Low"
-msgstr "নিচু"
-
-# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:748
-msgctxt "Battery power"
-msgid "Good"
-msgstr "ভাল"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:753
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "সম্পূর্ণ চার্জ রয়েছে"
-
-# auto translated by TM merge from project: RHEL Installation Guide, version: 6.0, DocId: Partitions-x86
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:757
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "খালি"
-
-#: panels/power/cc-power-panel.c:960
-msgid "Batteries"
-msgstr "ব্যাটারিগুলি"
-
-#: panels/power/cc-power-panel.c:1182
-msgid "When _idle"
-msgstr "নীরব অবস্থায় (_i)"
-
-#: panels/power/cc-power-panel.c:1676
-msgid "Suspend"
-msgstr "নিম্বিত করুন"
-
-# auto translated by TM merge from project: gnome-shell-extensions, version: 3.8.3, DocId: gnome-shell-extensions
-#: panels/power/cc-power-panel.c:1677
-msgid "Power Off"
-msgstr "বন্ধ করুন"
-
-# auto translated by TM merge from project: gnome-shell-extensions, version: 3.8.3, DocId: gnome-shell-extensions
-#: panels/power/cc-power-panel.c:1678
-msgid "Hibernate"
-msgstr "নিদ্রিত অবস্থা"
-
-#: panels/power/cc-power-panel.c:1679
-msgid "Nothing"
-msgstr "কিছু নয়"
-
-#: panels/power/cc-power-panel.c:1730
-msgid "When on battery power"
-msgstr "যখন ব্যাটারি পাওয়ার চালু"
-
-#: panels/power/cc-power-panel.c:1732
-msgid "When plugged in"
-msgstr "প্লাগইন অবস্থায়"
-
-#: panels/power/cc-power-panel.c:1836
-msgid "Power Saving"
-msgstr "বিদ্যুতের সংরক্ষণ"
-
-#: panels/power/cc-power-panel.c:1872
-msgid "_Screen Brightness"
-msgstr "স্ক্রীন উজ্জ্বলতা (_S)"
-
-#: panels/power/cc-power-panel.c:1895
-msgid "Automatic Brightness"
-msgstr "স্বয়ংক্রিয় উজ্জ্বলতা"
-
-#: panels/power/cc-power-panel.c:1908
-msgid "_Keyboard Brightness"
-msgstr "কীবোর্ড উজ্জ্বলতা (_K)"
-
-#: panels/power/cc-power-panel.c:1921
-msgid "_Dim Screen When Inactive"
-msgstr "নিষ্ক্রিয় অবস্থায় আবছা স্ক্রীন (_D)"
-
-#: panels/power/cc-power-panel.c:1939
-msgid "_Blank Screen"
-msgstr "খালি স্ক্রীন (_B)"
-
-#: panels/power/cc-power-panel.c:1985
-msgid "_Automatic Suspend"
-msgstr "স্বয়ংক্রিয় বিলম্ব (_A)"
-
-#: panels/power/cc-power-panel.c:1986
-msgid "Automatic suspend"
-msgstr "স্বয়ংক্রিয় বিলম্ব"
-
-#: panels/power/cc-power-panel.c:2038
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: panels/power/cc-power-panel.c:2039
-msgid "Wi-Fi can be turned off to save power."
-msgstr "পাওয়ার বাঁচাতে Wi-Fi বন্ধ করা যেতে পারে।"
-
-#: panels/power/cc-power-panel.c:2055
-msgid "_Mobile Broadband"
-msgstr "মোবাইল ব্রড-ব্যান্ড (_M)"
-
-#: panels/power/cc-power-panel.c:2056
-msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
-msgstr ""
-"মোবাইল ব্রডব্যান্ড (এলটিই, ৪ জি, ৩ জি, ইত্যাদি) পাওয়ার সাশ্রয় করতে বন্ধ করা যেতে "
-"পারে।"
-
-#: panels/power/cc-power-panel.c:2106
-msgid "_Bluetooth"
-msgstr "ব্লুটুথ (_B)"
-
-#: panels/power/cc-power-panel.c:2107
-msgid "Bluetooth can be turned off to save power."
-msgstr "পাওয়ার বাঁচাতে ব্লুটুথ বন্ধ করা যেতে পারে।"
-
-#: panels/power/cc-power-panel.c:2144
-msgid "Show Battery _Percentage"
-msgstr "ব্যাটারি শতাংশ প্রদর্শন করুন(_P)"
-
-#. Frame header
-#: panels/power/cc-power-panel.c:2170
-msgid "Suspend & Power Button"
-msgstr "বিলম্বিত এবং পাওয়ার বন্ধ করুন"
-
-#: panels/power/cc-power-panel.c:2220
-msgid "Po_wer Button Behavior"
-msgstr "পাওয়ার বাটন আচরণ(_w)"
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "১৫ মিনিট"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "২০ মিনিট"
 
 # auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "২৫ মিনিট"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "৩০ মিনিট"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "৪৫ মিনিট"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "১ ঘন্টা"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "৮০ মিনিট"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "৯০ মিনিট"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "১০০ মিনিট"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "২ ঘন্টা"
 
-#: panels/power/cc-power-panel.ui:145
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "ব্যাটারি"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ডিভাইসগুলি"
+
+# auto translated by TM merge from project: gnome-session, version: 3.8.4, DocId: gnome-session-3.0
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "বন্ধ করুন"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "বিদ্যুতের সংরক্ষণ"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "স্বয়ংক্রিয় উজ্জ্বলতা"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "স্ক্রীন"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "স্ক্রীন রিডার (_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "স্বয়ংক্রিয় সমস্যা প্রতিবেদন(_A)"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "স্বয়ংক্রিয় বিলম্ব (_A)"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "পাওয়ার বাটন আচরণ(_w)"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "ব্যাটারি শতাংশ প্রদর্শন করুন(_P)"
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "স্বয়ংক্রিয় বিলম্ব"
 
-#: panels/power/cc-power-panel.ui:170
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "প্লাগইন অবস্থায় (_P)"
 
-#: panels/power/cc-power-panel.ui:186
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "ব্যাটারির পাওয়ারে (_B)"
 
-#: panels/power/cc-power-panel.ui:231 panels/power/cc-power-panel.ui:291
-#: panels/universal-access/cc-ua-panel.ui:1525
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "বিলম্ব"
 
@@ -4843,53 +3068,12 @@ msgstr "পাওয়ার"
 msgid "View your battery status and change power saving settings"
 msgstr "আপনার ব্যাটারির স্থিতি দেখুন এবং পাওয়ার সঞ্চয় সেটিং পরিবর্তন করুন"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
 msgstr ""
 "পাওয়ার;ঘুমন্ত;বিলম্ব;হাইবারনেট;ব্যাটারি;উজ্জ্বলতা;অন্ধকারময়;খালি;মনিটর;DPMS;নিশ্চল;"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-# auto translated by TM merge from project: polkit-gnome, version: 0.105, DocId: polkit-gnome-1
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "অনুমোদন"
-
-# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/new-printer-dialog.ui:362
-#: panels/printers/pp-jobs-dialog.ui:57
-msgid "Username"
-msgstr "ব্যবহারকারীর নাম"
-
-# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:337
-msgid "Authentication Required"
-msgstr "পরিচয় প্রমাণ করতে হবে"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:707
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "প্রিন্টার \"%s\" মুছে ফেলা হয়েছে"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:970
-msgid "Failed to add new printer."
-msgstr "নতুন প্রিন্টার যোগ করতে ব্যর্থ।"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1273
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui লোড করতে ব্যর্থ: %s"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4901,979 +3085,354 @@ msgstr ""
 "প্রিন্টারগুলি যোগ করুন, প্রিন্টার সংক্রান্ত কাজ দেখুন এবং আপনি কীভাবে প্রিন্ট করতে চান "
 "তা স্থির করুন"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "প্রিন্টার;সারি;মুদ্রণ;কাগজ;কালি;টোনার;"
 
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:348
-#: panels/printers/pp-new-printer-dialog.c:405
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "প্রিন্টার যোগ করুন"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "আনলক(_U)"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "কোনও প্রিন্টার পাওয়া যায় নি"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "একটি নেটওয়ার্ক ঠিকানা লিখুন বা একটি প্রিন্টার সন্ধান করুন"
 
-#: panels/printers/new-printer-dialog.ui:353
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "পরিচয় প্রমাণ করতে হবে"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr "প্রিন্ট সার্ভারে প্রিন্টারগুলি দেখতে ব্যবহারকারী নাম এবং পাসওয়ার্ড লিখুন।"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:367
-#, c-format
-msgid "%s Details"
-msgstr "%s বিশদ"
+# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ব্যবহারকারীর নাম"
 
-#: panels/printers/pp-details-dialog.c:121
-msgid "No suitable driver found"
-msgstr "কোনো উপযুক্ত ড্রাইভার পাওয়া যায়নি"
-
-#: panels/printers/pp-details-dialog.c:248
-msgid "Select PPD File"
-msgstr "PPD ফাইল নির্বাচন করুন"
-
-#: panels/printers/pp-details-dialog.c:257
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"PostScript প্রিন্টার উল্লেখকারী ফাইল (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
 
 # auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
-#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "অবস্থান"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:122
-#: panels/printers/pp-ppd-selection-dialog.c:250
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "ড্রাইভার"
 
-#: panels/printers/pp-details-dialog.ui:162
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "পছন্দসই ড্রাইভার সন্ধান করা হচ্ছে…"
 
-#: panels/printers/pp-details-dialog.ui:183
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "ড্রাইভারের জন্য অনুসন্ধান করুন"
 
-#: panels/printers/pp-details-dialog.ui:192
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "ডেটাবেস থেকে নির্বাচন করুন…"
 
-#: panels/printers/pp-details-dialog.ui:201
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "PPD ফাইল ইনস্টল করুন..."
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "প্রিন্টার ড্রাইভার নির্বাচন করুন"
 
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:109
-msgid "Select"
-msgstr "নির্বাচন করুন"
-
-#: panels/printers/ppd-selection-dialog.ui:73
+#: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "ড্রাইভার ডেটাবেস লোড হচ্ছে..."
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect প্রিন্টার"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "বাতিল"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD প্রিন্টার"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "নির্বাচন করুন"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "একপার্শ্বিক"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "দীর্ঘ প্রান্ত (প্রমিত মান)"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "ক্ষুদ্র প্রান্ত (উলট)"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "প্রতিকৃতি"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "ভূদৃশ্য"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "বিপরীত ভূদৃশ্য"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "বিপরীত প্রতিকৃতি"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-jobs-dialog.c:222
-msgctxt "print job"
-msgid "Pending"
-msgstr "অসমাপ্ত কর্ম"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-jobs-dialog.c:228
-msgctxt "print job"
-msgid "Paused"
-msgstr "থেমে আছে"
-
-# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-jobs-dialog.c:233
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "অনুমোদন আবশ্যক"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-jobs-dialog.c:238
-msgctxt "print job"
-msgid "Processing"
-msgstr "কর্মরত"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-jobs-dialog.c:242
-msgctxt "print job"
-msgid "Stopped"
-msgstr "স্থগিত"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-jobs-dialog.c:246
-msgctxt "print job"
-msgid "Canceled"
-msgstr "বাতিল করা"
-
-# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4312-85999
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-jobs-dialog.c:250
-msgctxt "print job"
-msgid "Aborted"
-msgstr "পরিত্যক্ত"
-
-# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-jobs-dialog.c:254
-msgctxt "print job"
-msgid "Completed"
-msgstr "সমাপ্ত"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:363
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u টা কাজের প্রমাণীকরণের প্রয়োজন"
 msgstr[1] "%u টি কাজের অনুমোদন প্রয়োজন"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:520
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — সক্রিয় কাজগুলি"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:524
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "%s থেকে প্রিন্ট করতে পরিচয়পত্র লিখুন।"
-
 # auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
 #. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/pp-jobs-dialog.ui:44
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
 msgid "Domain"
 msgstr "ডোমেইন"
 
 # auto translated by TM merge from project: polkit-gnome, version: 0.105, DocId: polkit-gnome-1
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:129
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "অনুমোদন (_u)"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:169
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "সব পরিষ্কার করুন"
 
 # auto translated by TM merge from project: polkit-gnome, version: 0.105, DocId: polkit-gnome-1
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:232
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "অনুমোদন(_A)"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:358
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "কোনও অ্যাক্টিভ প্রিন্টারের কাজ নেই"
 
-#: panels/printers/pp-new-printer-dialog.c:363
-msgid "Unlock Print Server"
-msgstr "আনলক প্রিন্ট সার্ভার"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:367
-#, c-format
-msgid "Unlock %s."
-msgstr "%s আনলক করুন।"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:371
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "%s এ প্রিন্টারগুলি দেখতে ব্যবহারকারী নাম এবং পাসওয়ার্ড লিখুন।"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#: panels/printers/pp-new-printer-dialog.c:794
-msgid "Searching for Printers"
-msgstr "প্রিন্টার অনুসন্ধান করা হচ্ছে"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1611
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1616
-msgid "Serial Port"
-msgstr "সিরিয়াল পোর্ট"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1623
-msgid "Parallel Port"
-msgstr "সমান্তরাল পোর্ট"
-
-# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1665
-#, c-format
-msgid "Location: %s"
-msgstr "অবস্থান: %s"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1670
-#, c-format
-msgid "Address: %s"
-msgstr "ঠিকানা: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1697
-msgid "Server requires authentication"
-msgstr "সার্ভারের প্রমাণীকরণের প্রয়োজন"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "উভয়পৃষ্ঠ"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "কাগজের ধরন"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "কাগজের সংগ্রহস্থল"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "আউটপুট-ট্রে"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "রেসলোলিউশন"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript প্রি-ফিল্টারিং"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:530
-msgid "Pages per side"
-msgstr "প্রতি পার্শ্বে পৃষ্ঠা"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:542
-msgid "Two-sided"
-msgstr "উভয় পৃষ্ঠা"
-
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:554
-msgid "Orientation"
-msgstr "সজ্জা"
-
-# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:651
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "সাধারণ"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "পৃষ্ঠার বৈশিষ্ট্য"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "ইনস্টল করার যোগ্য বিকল্প"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "কর্ম"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "ছবির গুণমান"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "রঙ"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "সমাপ্তি"
-
-# auto translated by TM merge from project: ekiga, version: 4.0.1, DocId: ekiga
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "উন্নত"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:863
-#: panels/printers/pp-options-dialog.ui:18
+#: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "পরীক্ষা পৃষ্ঠা"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:876
-msgid "Test page"
-msgstr "পরীক্ষা পৃষ্ঠা"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "স্বয়ংক্রিয় নির্বাচন"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "প্রিন্টারের ডিফল্ট মান"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "শুধুমাত্র GhostScript ফন্ট এমবেড করা হবে"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "PS লেভেল ১-এ রূপান্তর করা হবে"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "PS লেভেল ২-এ রূপান্তর করা হবে"
-
-# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "প্রি-ফিল্টারিং বিহীন"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "নির্মাতা"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:588 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr "কোনও সক্রিয় কাজ নেই"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:593
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u টি কাজ"
 msgstr[1] "%u টা কাজ"
 
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:711
-msgid "Clean print heads"
-msgstr "প্রিন্টারের হেড পরিষ্কার করুন"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:762
-msgid "Low on toner"
-msgstr "টোনার কম"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:764
-msgid "Out of toner"
-msgstr "টোনার শেষ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:767
-msgid "Low on developer"
-msgstr "ডেভেলপার কম"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:770
-msgid "Out of developer"
-msgstr "ডেভেলপার শেষ"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:772
-msgid "Low on a marker supply"
-msgstr "মার্কার সরবরাহ কম"
-
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:774
-msgid "Out of a marker supply"
-msgstr "মার্কার সরবরাহ শেষ হয়ে গেছে"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:776
-msgid "Open cover"
-msgstr "মুক্ত আবরণ"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:778
-msgid "Open door"
-msgstr "মুক্ত দরজা"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:780
-msgid "Low on paper"
-msgstr "কাগজ কম"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:782
-msgid "Out of paper"
-msgstr "কাগজ নেই"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:784
-msgctxt "printer state"
-msgid "Offline"
-msgstr "অফলাইন"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:786
-#: panels/printers/pp-printer-entry.c:929
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "থামানো হয়েছে"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:788
-msgid "Waste receptacle almost full"
-msgstr "আবর্জনা পাত্র প্রায় পূর্ণ"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:790
-msgid "Waste receptacle full"
-msgstr "আবর্জনা পাত্র পূর্ণ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:792
-msgid "The optical photo conductor is near end of life"
-msgstr "অপটিক্যাল ফোটো কনডাকটরের আয়ু প্রায় শেষ হয় এসেছে"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:794
-msgid "The optical photo conductor is no longer functioning"
-msgstr "অপটিক্যাল ফোটো কনডাকটার আর কাজ করছে না"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:915
-msgctxt "printer state"
-msgid "Ready"
-msgstr "প্রস্তুত"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:920
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "কাজ নিচ্ছে না"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:925
-msgctxt "printer state"
-msgid "Processing"
-msgstr "কর্মরত"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "প্রিন্টিং বিকল্প"
 
 # auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "প্রিন্টারের বিবরণ"
 
 # auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "ডিফল্ট দ্বারা প্রিন্টার ব্যবহার করুন"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "প্রিন্ট এর মাথা পরিষ্কার করুন"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "প্রিন্টার সরান"
 
-#: panels/printers/printer-entry.ui:193
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "কোনও সক্রিয় কাজ নেই"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "মডেল"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "কালির মাত্রা"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:312
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "সমস্যাটি সমাধান হয়ে গেলে পুনরায় চালু করুন।"
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:319
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "পুনরারম্ভ করুন"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:12
-msgid "Add…"
-msgstr "যোগ..."
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "প্রিন্টার যোগ করুন..."
 
-#: panels/printers/printers.ui:186
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "প্রিন্টার যোগ করুন..."
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "প্রিন্টার নেই"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:200
-msgid "Add a Printer…"
-msgstr "প্রিন্টার যোগ করুন..."
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:232
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "দুঃখিত! সিস্টেম প্রিন্টর পরিষেবাটি\n"
 "উপলব্ধ বলে মনে হচ্ছে না।"
 
-#: panels/region/cc-format-chooser.c:149
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ইম্পিরিয়াল"
-
-#: panels/region/cc-format-chooser.c:151
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "মেট্রিক"
-
-#: panels/region/cc-format-chooser.c:256 panels/region/cc-format-chooser.c:297
-#: panels/region/cc-format-chooser.ui:6
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ফর্ম্যাট"
 
-# auto translated by TM merge from project: rhn-client-tools, version: 6.2, DocId: rhn-client-tools
-#: panels/region/cc-format-chooser.ui:48
-#: panels/user-accounts/cc-fingerprint-dialog.ui:53
-#: panels/wacom/wacom-stylus-page.ui:37 shell/cc-window.ui:230
-msgid "Back"
-msgstr "পূর্ববর্তী"
-
-#: panels/region/cc-format-chooser.ui:101
-msgid ""
-"Choose the format for numbers, dates and currencies. Changes take effect on "
-"next login."
-msgstr ""
-"সংখ্যা, তিথি এবং মুদ্রার জন্য ফর্ম্যাটটি চয়ন করুন। পরিবর্তনগুলি পরবর্তী লগইনে কার্যকর "
-"হয়।"
-
-#: panels/region/cc-format-chooser.ui:117
-msgid "Search locales..."
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
 msgstr "লোকেলগুলি অনুসন্ধান করুন..."
 
-#: panels/region/cc-format-chooser.ui:158
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "সাধারণ ফর্ম্যাটসগুলি"
 
-#: panels/region/cc-format-chooser.ui:189
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "সব ফর্ম্যাটস"
 
-#: panels/region/cc-format-chooser.ui:242
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "কোন অনুসন্ধান ফলাফল নেই"
 
-#: panels/region/cc-format-chooser.ui:255
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "অনুসন্ধানগুলি দেশ বা ভাষার জন্য হতে পারে।"
 
-#: panels/region/cc-format-chooser.ui:307
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "পূর্বদৃশ্য"
 
-#: panels/region/cc-format-chooser.ui:322
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "তিথি"
 
-#: panels/region/cc-format-chooser.ui:366
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "তিথি এবং সময়"
 
-#: panels/region/cc-format-chooser.ui:388
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "সংখ্যা"
 
-#: panels/region/cc-format-chooser.ui:410
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "পরিমাপ"
 
-#: panels/region/cc-format-chooser.ui:432
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "কাগজ"
 
-#: panels/region/cc-input-chooser.c:193
-msgid "No input sources found"
-msgstr "কোনো ইনপুট সোর্স পাওয়া যায়নি"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/region/cc-input-chooser.c:948
-msgctxt "Input Source"
-msgid "Other"
-msgstr "অন্যান্য"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/region/cc-input-chooser.ui:5
-msgid "Add an Input Source"
-msgstr "একটি ইনপুট সোর্স যোগ করুন"
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#: panels/region/cc-input-chooser.ui:77
-msgid "Input methods can’t be used on the login screen"
-msgstr "লগিন স্ক্রীনে ইনপুট পদ্ধতি ব্যবহার করা যাবে না"
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
 
-#: panels/region/cc-region-panel.c:1507
-msgid "Login _Screen"
-msgstr "লগিন স্ক্রীন (_S)"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "আপনার অ্যাকাউন্ট"
 
-#: panels/region/cc-region-panel.ui:62
-#: panels/user-accounts/cc-user-panel.ui:364
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "ভাষা (_L)"
 
-#: panels/region/cc-region-panel.ui:97
-msgid "Restart the session for changes to take effect"
-msgstr "পরিবর্তনগুলি কার্যকর হওয়ার জন্য সেশনটি পুনরায় চালু করুন"
-
-#: panels/region/cc-region-panel.ui:112
-msgid "Restart…"
-msgstr "পুনরারম্ভ করুন"
-
-#: panels/region/cc-region-panel.ui:145
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "ফর্ম্যাটগুলি (_F)"
 
-#: panels/region/cc-region-panel.ui:193
-msgid "Input Sources"
-msgstr "ইনপুট সোর্স"
-
-#: panels/region/cc-region-panel.ui:207
-msgid "Choose keyboard layouts or input methods."
-msgstr "কীবোর্ড বিন্যাস বা ইনপুট পদ্ধতি চয়ন করুন।"
-
-#: panels/region/cc-region-panel.ui:264
-msgid "No input source selected"
-msgstr "কোনো ইনপুট সোর্স নির্বাচন করা হয়নি"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/region/cc-region-panel.ui:298
-msgid "Login settings are used by all users when logging into the system"
-msgstr "সিস্টেমে লগিন করার সময়ে সকল ব্যবহারকারীর দ্বারা লগিন সেটিং ব্যবহার করা হয়"
-
-#: panels/region/cc-region-panel.ui:335
-msgid "Input Source Options"
-msgstr "ইনপুট সোর্স বিকল্প"
-
-#: panels/region/cc-region-panel.ui:350
-msgid "Use the _same source for all windows"
-msgstr "সকল উইন্ডোর জন্য একই সোর্স ব্যবহার করুন (_s)"
-
-#: panels/region/cc-region-panel.ui:368
-msgid "Allow _different sources for each window"
-msgstr "প্রত্যেক উইন্ডোর জন্য আলাদা সোর্সের অনুমতি দিন (_d)"
-
-#: panels/region/cc-region-panel.ui:410
-msgid "Previous source"
-msgstr "পূর্ববর্তী উত্স"
-
-#: panels/region/cc-region-panel.ui:428
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/region/cc-region-panel.ui:443
-msgid "Next source"
-msgstr "পরবর্তী উত্স"
-
-#: panels/region/cc-region-panel.ui:461
-msgid "Super+Space"
-msgstr "Super+Space"
-
-#: panels/region/cc-region-panel.ui:476
-msgid "Left+Right Alt"
-msgstr "Left+Right Alt"
-
-#: panels/region/cc-region-panel.ui:492
-msgid "These keyboard shortcuts can be changed in the keyboard settings"
-msgstr "আপনি কীবোর্ড সেটিং থেকে এই শর্টকাটগুলি পরিবর্তন করতে পারবেন"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "লগিন স্ক্রীন (_S)"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "অঞ্চল & ভাষা"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr "আপনার প্রদর্শন ভাষা, ফর্ম্যাট, কীবোর্ড সজ্জা এবং ইনপুট সোর্স নির্বাচন করুন"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ভাষা;সজ্জা;কীবোর্ড;ইনপুট;"
 
-#: panels/removable-media/cc-removable-media-panel.c:267
-msgid "Ask what to do"
-msgstr "কী করতে হবে আমাকে জিজ্ঞাসা করুন"
-
-#: panels/removable-media/cc-removable-media-panel.c:271
-msgid "Do nothing"
-msgstr "কিছু নয়"
-
-#: panels/removable-media/cc-removable-media-panel.c:275
-msgid "Open folder"
-msgstr "ফোল্ডার খুলুন"
-
-#: panels/removable-media/cc-removable-media-panel.c:341
-msgid "Other Media"
-msgstr "অন্যান্য মিডিয়া"
-
-#: panels/removable-media/cc-removable-media-panel.c:362
-msgid "Select an application for audio CDs"
-msgstr "অডিও CD'র জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
-
-#: panels/removable-media/cc-removable-media-panel.c:363
-msgid "Select an application for video DVDs"
-msgstr "ভিডিও DVD'র জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
-
-#: panels/removable-media/cc-removable-media-panel.c:364
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"একটি মিউজিক প্লেয়ার সংযুক্ত অবস্থায় চালানোর জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
-
-#: panels/removable-media/cc-removable-media-panel.c:365
-msgid "Select an application to run when a camera is connected"
-msgstr "একটি ক্যামেরা সংযুক্ত অবস্থায় চালানোর জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
-
-#: panels/removable-media/cc-removable-media-panel.c:366
-msgid "Select an application for software CDs"
-msgstr "সফ্টওয়্যার CD'র জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "audio DVD"
-msgstr "অডিও DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "blank Blu-ray disc"
-msgstr "খালি Blu-ray ডিস্ক"
-
-#: panels/removable-media/cc-removable-media-panel.c:380
-msgid "blank CD disc"
-msgstr "খালি CD ডিস্ক"
-
-#: panels/removable-media/cc-removable-media-panel.c:381
-msgid "blank DVD disc"
-msgstr "খালি DVD ডিস্ক"
-
-#: panels/removable-media/cc-removable-media-panel.c:382
-msgid "blank HD DVD disc"
-msgstr "খালি HD DVD ডিস্ক"
-
-#: panels/removable-media/cc-removable-media-panel.c:383
-msgid "Blu-ray video disc"
-msgstr "Blu-ray ভিডিও ডিস্ক"
-
-#: panels/removable-media/cc-removable-media-panel.c:384
-msgid "e-book reader"
-msgstr "ই-বই রিডার"
-
-#: panels/removable-media/cc-removable-media-panel.c:385
-msgid "HD DVD video disc"
-msgstr "HD DVD ভিডিও ডিস্ক"
-
-# auto translated by TM merge from project: nautilus, version: 3.8.2, DocId: nautilus
-#: panels/removable-media/cc-removable-media-panel.c:386
-msgid "Picture CD"
-msgstr "ছবি CD"
-
-# auto translated by TM merge from project: nautilus, version: 3.8.2, DocId: nautilus
-#: panels/removable-media/cc-removable-media-panel.c:387
-msgid "Super Video CD"
-msgstr "সুপার ভিডিও CD"
-
-# auto translated by TM merge from project: nautilus, version: 3.8.2, DocId: nautilus
-#: panels/removable-media/cc-removable-media-panel.c:388
-msgid "Video CD"
-msgstr "ভিডিও CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:389
-msgid "Windows software"
-msgstr "Windows সফ্টওয়্যার"
-
-#: panels/removable-media/cc-removable-media-panel.ui:44
+#: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
 msgstr "মিডিয়া কীভাবে পরিচালিত হবে তা নির্বাচন করুন"
 
-#: panels/removable-media/cc-removable-media-panel.ui:75
+#: panels/removable-media/cc-removable-media-panel.ui:52
 msgid "CD _audio"
 msgstr "CD অডিও (_a)"
 
-#: panels/removable-media/cc-removable-media-panel.ui:92
+#: panels/removable-media/cc-removable-media-panel.ui:67
 msgid "_DVD video"
 msgstr "_DVD ভিডিও"
 
-#: panels/removable-media/cc-removable-media-panel.ui:133
+#: panels/removable-media/cc-removable-media-panel.ui:102
 msgid "_Music player"
 msgstr "মিউজিক প্লেয়ার (_M)"
 
-#: panels/removable-media/cc-removable-media-panel.ui:191
+#: panels/removable-media/cc-removable-media-panel.ui:152
 msgid "_Software"
 msgstr "সফ্টওয়্যার (_S)"
 
-#: panels/removable-media/cc-removable-media-panel.ui:229
+#: panels/removable-media/cc-removable-media-panel.ui:178
 msgid "_Other Media…"
 msgstr "অন্যান্য মিডিয়া (_O)…"
 
-#: panels/removable-media/cc-removable-media-panel.ui:288
+#: panels/removable-media/cc-removable-media-panel.ui:195
 msgid "_Never prompt or start programs on media insertion"
 msgstr "মিডিয়া সন্নিবেশের সময়ে কখনও সূচনা দেবেন না বা প্রোগ্রাম শুরু করবেন না (_N)"
 
-#: panels/removable-media/cc-removable-media-panel.ui:342
+#: panels/removable-media/cc-removable-media-panel.ui:225
 msgid "Select how other media should be handled"
 msgstr "অন্যান্য মিডিয়া কীভাবে পরিচালিত হবে তা নির্বাচন করুন"
 
-#: panels/removable-media/cc-removable-media-panel.ui:389
+#: panels/removable-media/cc-removable-media-panel.ui:259
 msgid "_Action:"
 msgstr "কর্ম (_A):"
 
-#: panels/removable-media/cc-removable-media-panel.ui:412
+#: panels/removable-media/cc-removable-media-panel.ui:278
 msgid "_Type:"
 msgstr "ধরন (_T):"
 
@@ -5885,7 +3444,6 @@ msgstr "অপসারণযোগ্য মিডিয়া"
 msgid "Configure Removable Media settings"
 msgstr "অপসারণযোগ্য মিডিয়া সেটিংস কনফিগার করুন"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5894,22 +3452,87 @@ msgstr ""
 "যন্ত্র;সিস্টেম;ডিফল্ট;আবেদন;পছন্দসই;সিডি;ডিভিডি;USB;অডিও;ভিডিও;ডিস্ক;অপসারণযোগ্য;"
 "মিডিয়া;অটোরান;"
 
-#: panels/search/cc-search-locations-dialog.c:635
-msgid "Select Location"
-msgstr "অবস্থান নির্বাচন করুন"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "স্ক্রীন লক"
 
-#: panels/search/cc-search-locations-dialog.c:639
-msgid "_OK"
-msgstr "ঠিক আছে (_O)"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"স্ক্রিনটি স্বয়ংক্রিয়ভাবে লক করা আপনার দূরে থাকা অবস্থায় অন্যকে কম্পিউটার অ্যাক্সেস করা "
+"থেকে বিরত করে।"
 
-#: panels/search/cc-search-locations-dialog.ui:9
-#: panels/search/cc-search-panel.ui:59
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "ফাঁকা স্ক্রিন বিলম্ব"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "নিষ্ক্রিয়তার সময়কালের পরে পর্দা ফাঁকা হয়ে যাবে।"
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "স্বয়ংক্রিয় স্ক্রীন লক (_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "স্বয়ংক্রিয় স্ক্রিন লক বিলম্ব(_S)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "স্ক্রীন ফাঁকা হওয়ার পরে পিরিয়ডটি স্বয়ংক্রিয়ভাবে লক হয়ে যায়।"
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "লক স্ক্রিনে বিজ্ঞপ্তিগুলি দেখান(_N)"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "পর্দা লক করুন"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "নতুন ইউএসবি ডিভাইস নিষিদ্ধ করুন(_U)"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"স্ক্রিনটি লক হয়ে গেলে নতুন ইউএসবি ডিভাইসগুলি সিস্টেমের সাথে ইন্টারঅ্যাক্ট করা থেকে "
+"বিরত রাখুন।"
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "গোপনীয়তা"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "স্ক্রীন"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "স্ক্রীন ভাগ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "অবস্থান সন্ধান"
 
-#: panels/search/cc-search-locations-dialog.ui:32
-#: panels/search/cc-search-locations-dialog.ui:69
-#: panels/search/cc-search-locations-dialog.ui:107
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
@@ -5917,216 +3540,200 @@ msgstr ""
 "ফাইল, ফটো এবং ভিডিওগুলির মতো সিস্টেম অ্যাপ্লিকেশন দ্বারা অনুসন্ধান করা ফোল্ডারগুলি।"
 
 # auto translated by TM merge from project: file-roller, version: 3.8.3, DocId: file-roller
-#: panels/search/cc-search-locations-dialog.ui:52
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr "অবস্থানগুলি"
 
 # auto translated by TM merge from project: gnome-documents, version: 3.8.3.1, DocId: gnome-documents
-#: panels/search/cc-search-locations-dialog.ui:91
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "বুকমার্কগুলি"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/search/cc-search-locations-dialog.ui:156
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "অন্যান্য"
 
-#: panels/search/cc-search-panel.c:152
-msgid "No applications found"
-msgstr "কোনো অ্যাপ্লিকেশন পাওয়া যায়নি"
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "অবস্থান"
 
-# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
-#: panels/search/cc-search-panel-row.ui:92
-msgid "Move Up"
-msgstr "উপরে স্থানান্তর"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "অ্যাপ্লিকেশন"
 
-# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
-#: panels/search/cc-search-panel-row.ui:102
-msgid "Move Down"
-msgstr "নীচে স্থানান্তর"
-
-#: panels/search/cc-search-panel.ui:31
-msgid ""
-"Control which search results are shown in the Activities Overview. The order "
-"of search results can also be changed by moving rows in the list."
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
 msgstr ""
-"ক্রিয়াকলাপ ওভারভিউতে কোন অনুসন্ধান ফলাফল দেখানো হয়েছে তা নিয়ন্ত্রণ করুন। তালিকায় "
-"সারি সরিয়েও অনুসন্ধানের ফলাফলের ক্রম পরিবর্তন করা যেতে পারে।"
+
+#: panels/search/cc-search-panel.ui:23
+#, fuzzy
+msgid "Folders which are searched by system applications."
+msgstr ""
+"ফাইল, ফটো এবং ভিডিওগুলির মতো সিস্টেম অ্যাপ্লিকেশন দ্বারা অনুসন্ধান করা ফোল্ডারগুলি।"
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "কোন অনুসন্ধান ফলাফল নেই"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "ক্রিয়াকলাপ পূর্বরূপে কোন অ্যাপ্লিকেশনগুলি সন্ধান ফলাফল দেখাবে তা নিয়ন্ত্রণ করুন"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "সন্ধান;খোঁজ;সূচি;লুকানো;গোপনীয়তা;ফলাফল;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:306
-msgid "No networks selected for sharing"
-msgstr "ভাগ করার জন্য কোনো নেটওয়ার্ক নির্বাচন করা হয়নি"
-
 # auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
-#: panels/sharing/cc-sharing-networks.ui:19
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "নেটওয়ার্ক"
 
-# auto translated by TM merge from project: control-center, version: 3.8.3, DocId: gnome-control-center-2.0
-#: panels/sharing/cc-sharing-panel.c:289
-msgctxt "service is enabled"
-msgid "On"
-msgstr "চালু"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#: panels/sharing/cc-sharing-panel.c:291 panels/sharing/cc-sharing-panel.c:318
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "বন্ধ"
-
-# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
-#: panels/sharing/cc-sharing-panel.c:321
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "সক্রিয়"
-
-#: panels/sharing/cc-sharing-panel.c:324
-msgctxt "service is active"
-msgid "Active"
-msgstr "সক্রিয়"
-
-#: panels/sharing/cc-sharing-panel.c:393
-msgid "Choose a Folder"
-msgstr "একটি ফোল্ডার বাছুন"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:696
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"ফাইল ভাগ করে নেওয়া আপনাকে: আপনার বর্তমান নেটওয়ার্কে অন্যদের সাথে আপনার পাবলিক "
-"ফোল্ডারটি ভাগ করে নিতে মঞ্জুরি দেয়: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:702
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"যখন রিমোট লগইন সক্ষম থাকে তখন দূরবর্তী ব্যবহারকারীরা সিকিউর শেল কমান্ডটি ব্যবহার "
-"করে সংযোগ করতে পারেন:\n"
-"%s"
-
-#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:708
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to %s"
-msgstr ""
-"স্ক্রিন ভাগ করে নেওয়া দূরবর্তী ব্যবহারকারীদের %s এর সাথে সংযুক্ত হয়ে আপনার স্ক্রিনটি "
-"দেখতে বা নিয়ন্ত্রণ করতে দেয়"
-
-# auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
-#: panels/sharing/cc-sharing-panel.c:813
-msgid "Copy"
-msgstr "কপি করুন"
-
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/sharing/cc-sharing-panel.c:1203
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "যৌথরূপে ব্যবহার"
 
 # auto translated by TM merge from project: gdm, version: 3.8.4, DocId: gdm
-#: panels/sharing/cc-sharing-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr "কম্পিউটারের নাম(_C)"
 
 # auto translated by TM merge from project: gnome-user-share, version: 3.8, DocId: gnome-user-share
-#: panels/sharing/cc-sharing-panel.ui:79
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr "ফাইল ভাগাভাগি (_F)"
 
-#: panels/sharing/cc-sharing-panel.ui:87
-msgid "_Screen Sharing"
-msgstr "স্ক্রীন ভাগ (_S)"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "রিমোট ভিউ"
 
-#: panels/sharing/cc-sharing-panel.ui:95
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr "মিডিয়া ভাগ (_M)"
 
 # auto translated by TM merge from project: gdm, version: 3.8.4, DocId: gdm
-#: panels/sharing/cc-sharing-panel.ui:103
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr "দূরবর্তী লগ-ইন (_R)"
 
-#: panels/sharing/cc-sharing-panel.ui:119
-msgid "Some services are disabled because of no network access."
-msgstr "কোনো নেটওয়ার্ক অ্যাক্সেস না থাকায় কিছু পরিষেবাদি নিষ্ক্রিয় করা হয়েছে।"
-
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/sharing/cc-sharing-panel.ui:137
-#: panels/sharing/cc-sharing-panel.ui:264
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr "ফাইল ভাগাভাগি"
 
-#: panels/sharing/cc-sharing-panel.ui:184
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr "পাসওয়ার্ড প্রয়োজনীয় (_R)"
 
 # auto translated by TM merge from project: gdm, version: 3.8.4, DocId: gdm
-#: panels/sharing/cc-sharing-panel.ui:275
-#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "দূরবর্তী লগ-ইন"
 
-#: panels/sharing/cc-sharing-panel.ui:368
-#: panels/sharing/cc-sharing-panel.ui:590
-msgid "Screen Sharing"
-msgstr "স্ক্রীন ভাগ"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "রিমোট ভিউ"
 
-#: panels/sharing/cc-sharing-panel.ui:422
-msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "রিমোট লগিন সক্রিয় বা নিষ্ক্রিয় করুন"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "রিমোট কন্ট্রোলের অনুমতি দিন"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
 msgstr "সংযোগগুলিকে স্ক্রিন নিয়ন্ত্রণ করতে অনুমতি দিন(_A)"
 
-# auto translated by TM merge from project: gnome-boxes, version: 3.8.3, DocId: gnome-boxes
-#: panels/sharing/cc-sharing-panel.ui:447
-msgid "_Password:"
-msgstr "পাসওয়ার্ড (_P):"
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "সংযোগ বিহীন"
 
-#: panels/sharing/cc-sharing-panel.ui:477
-msgid "_Show Password"
-msgstr "পাসওয়ার্ড দেখান (_S)"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-# auto translated by TM merge from project: RHEL Deployment Guide, version: 6.2, DocId: Product_Subscriptions_and_Entitlements
-#: panels/sharing/cc-sharing-panel.ui:508
-msgid "Access Options"
-msgstr "অ্যাক্সেস বিকল্প"
+# auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "কপি করুন"
 
-#: panels/sharing/cc-sharing-panel.ui:522
-msgid "_New connections must ask for access"
-msgstr "নতুন সংযোগগুলিকে অবশ্যই অ্যাক্সেস চাইতে হবে (_N)"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "ঠিকানা মুছুন"
 
-#: panels/sharing/cc-sharing-panel.ui:540
-msgid "_Require a password"
-msgstr "একটি পাসওয়ার্ডের প্রয়োজন(_R)"
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "প্রমাণীকরণ (_t)"
 
-#: panels/sharing/cc-sharing-panel.ui:601
-#: panels/sharing/cc-sharing-panel.ui:695
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ব্যবহারকারীর নাম"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "ফিংগারপ্রিন্ট"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "মিডিয়া ভাগ"
 
-#: panels/sharing/cc-sharing-panel.ui:634
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "নেটওয়ার্কের মাধ্যমে মিউজিক, ফোটো এবং ভিডিও ভাগ করুন।"
 
-#: panels/sharing/cc-sharing-panel.ui:649
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "ফোল্ডারগুলি"
 
@@ -6134,7 +3741,6 @@ msgstr "ফোল্ডারগুলি"
 msgid "Control what you want to share with others"
 msgstr "অন্যদের সংগে আপনি কী ভাগ করতে চান তা নিয়ন্ত্রণ করুন"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6151,103 +3757,100 @@ msgstr "রিমোট লগিন সক্রিয় বা নিষ্�
 msgid "Authentication is required to enable or disable remote login"
 msgstr "রিমোট লগিন সক্রিয় বা নিষ্ক্রিয় করতে অনুমোদনের প্রয়োজন"
 
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/sound/cc-alert-chooser.c:151
-msgid "Custom"
-msgstr "স্বনির্ধারিত"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "বার্ক"
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
 
-#: panels/sound/cc-alert-chooser.ui:19
-msgid "Drip"
-msgstr "ড্রিপ"
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "যৌথরূপে ব্যবহার"
 
-#: panels/sound/cc-alert-chooser.ui:26
-msgid "Glass"
-msgstr "গ্লাস"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:33
-msgid "Sonar"
-msgstr "সোনার"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "ব্যালেন্স"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "বিলীন"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "পিছনে"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "সম্মুখে"
 
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s পরীক্ষা করা হচ্ছে"
-
-#: panels/sound/cc-output-test-dialog.ui:127
+#: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
 msgstr "পরীক্ষা করতে একটি স্পিকার ক্লিক করুন"
 
-#: panels/sound/cc-sound-panel.ui:27
+#: panels/sound/cc-sound-panel.ui:8
 msgid "System Volume"
 msgstr "সিস্টেমের শব্দ"
 
-#: panels/sound/cc-sound-panel.ui:43
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "সিস্টেমের শব্দ"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "ভলিউম মাত্রা"
 
-#: panels/sound/cc-sound-panel.ui:65
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "আউটপুট"
 
-#: panels/sound/cc-sound-panel.ui:92
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "আউটপুট ডিভাইস"
 
 # auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#: panels/sound/cc-sound-panel.ui:115
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "পরীক্ষা"
 
 # auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/sound/cc-sound-panel.ui:146 panels/sound/cc-sound-panel.ui:323
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "কনফিগারেশন"
 
-#: panels/sound/cc-sound-panel.ui:179
-msgid "Balance"
-msgstr "ব্যালেন্স"
-
-#: panels/sound/cc-sound-panel.ui:206
-msgid "Fade"
-msgstr "বিলীন"
-
 # auto translated by TM merge from project: pulseaudio, version: 3.0, DocId: pulseaudio
-#: panels/sound/cc-sound-panel.ui:233
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
-#: panels/sound/cc-sound-panel.ui:255
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "ইনপুট"
 
-#: panels/sound/cc-sound-panel.ui:282
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "প্রেরণকারী যন্ত্র"
 
-#: panels/sound/cc-sound-panel.ui:356
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "ভলিউম"
 
-#: panels/sound/cc-sound-panel.ui:378
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "সতর্কতা শব্দ"
 
-#: panels/sound/cc-volume-slider.c:115
-msgctxt "volume"
-msgid "100%"
-msgstr "১০০%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
@@ -6258,177 +3861,70 @@ msgstr "শব্দ"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "শব্দের মাত্রা, ইনপুট, আউটপুট, এবং সর্তকতা শব্দ পরিবর্তন করুন"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr "কার্ড;মাইক্রোফোন;ভলিউম;বিবর্ণ;ব্যালেন্স;ব্লুটুথ;হেডসেট;অডিও;আউটপুট;ইনপুট;"
 
-# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "সংযোগ বিচ্ছিন্ন করা হয়েছে"
-
-# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "সংযোগ করা হচ্ছে"
-
-# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "সংযুক্ত"
-
-# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "অনুমোদনের ত্রুটি"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "অনুমোদিত করছে"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "হ্রাস করা কার্যকারিতা"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "সংযুক্ত ও অনুমোদিত"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "অজানা"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr "অনুমোদিত হয়েছিল:"
-
-# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-msgid "Connected at:"
-msgstr "সংযুক্ত হয়েছে:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-msgid "Enrolled at:"
-msgstr "নিবন্ধিত হয়েছে:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-msgid "Failed to authorize device: "
-msgstr "ডিভাইস অনুমোদিত করতে ব্যর্থ:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-msgid "Failed to forget device: "
-msgstr "ডিভাইস ভুলে যেতে ব্যর্থ:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] "অন্য %u ডিভাইসে নির্ভর করে"
 msgstr[1] "%u টি অন্যান্য ডিভাইসে নির্ভর করে"
 
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "সূচনাবার্তা"
+
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "নাম:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "স্থিতি:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "অনুমোদন এবং সংযোগ"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "ডিভাইসটি ভুলে যান"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "ত্রুটি"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "অনুমোদিত"
-
-#: panels/thunderbolt/cc-bolt-panel.c:175
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"থান্ডারবোল্ট সাবসিস্টেম (boltd) ইনস্টল করা হয়নি বা সঠিকভাবে সেট আপ করা হয়নি।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:468
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"থান্ডারবোল্ট সনাক্ত করা যায়নি।\n"
-"হয় সিস্টেমটিতে থান্ডারবোল্ট সমর্থনের অভাব রয়েছে, এটি BIOS এ অক্ষম করা হয়েছে বা "
-"BIOS- এ অসমর্থিত সুরক্ষা স্তরে সেট করা আছে।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:512
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "বায়োস-এ থান্ডারবোল্ট সমর্থন অক্ষম করা হয়েছে।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:516
-msgid "Thunderbolt security level could not be determined."
-msgstr "থান্ডারবোল্ট সুরক্ষা স্তর নির্ধারণ করা যায়নি।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:621
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "প্রত্যক্ষ মোডে স্যুইচ করার সময় ত্রুটি: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+#, fuzzy
+msgid "No Thunderbolt Support"
 msgstr "কোন থান্ডারবোল্ট সমর্থন নেই"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:246
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s ডোমেনে সংযোগ স্থাপন করতে ব্যর্থ: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "সরাসরি অ্যাক্সেস"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr "ডক্স এবং বাহ্যিক GPU- এর মতো ডিভাইসে সরাসরি অ্যাক্সেসের অনুমতি দিন।"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr "কেবল ইউএসবি এবং ডিসপ্লে পোর্ট ডিভাইস সংযুক্ত করতে পারে।"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "মুলতুবি ডিভাইসগুলি"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "কোনও ডিভাইস সংযুক্ত নেই"
 
@@ -6440,623 +3936,523 @@ msgstr "থান্ডারবোল্ট"
 msgid "Manage Thunderbolt devices"
 msgstr "থান্ডারবোল্ট ডিভাইসগুলি পরিচালনা করুন"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "থান্ডারবোল্ট;গোপনীয়তা;"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:500
-msgctxt "cursor size"
-msgid "Default"
-msgstr "ডিফল্ট"
-
-#: panels/universal-access/cc-ua-panel.c:503
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "মাঝারি"
-
-# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
-#: panels/universal-access/cc-ua-panel.c:506
-msgctxt "cursor size"
-msgid "Large"
-msgstr "বৃহৎ"
-
-#: panels/universal-access/cc-ua-panel.c:509
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "আরো বড়"
-
-# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
-#: panels/universal-access/cc-ua-panel.c:512
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "বৃহৎ"
-
-#: panels/universal-access/cc-ua-panel.c:516
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d টি পিক্সেল "
-msgstr[1] "%d পিক্সেল"
-
-#: panels/universal-access/cc-ua-panel.ui:76
-msgid "_Always Show Accessibility Menu"
-msgstr "সর্বদা অ্যাক্সেসিবিলিটি মেনু দেখান (_A)"
-
-#: panels/universal-access/cc-ua-panel.ui:118
-msgid "Seeing"
-msgstr "দেখা"
-
-# auto translated by TM merge from project: gnome-themes-standard, version: 3.8.3, DocId: gnome-themes-standard
-#: panels/universal-access/cc-ua-panel.ui:164
-msgid "_High Contrast"
-msgstr "গাঢ় তারতম্য (_H)"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/universal-access/cc-ua-panel.ui:211
-msgid "_Large Text"
-msgstr "বড় মাপের হরফ (_L)"
-
-#: panels/universal-access/cc-ua-panel.ui:256
-msgid "C_ursor Size"
-msgstr "কার্সার আকার(_u)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:303
-#: panels/universal-access/zoom-options.ui:99
-msgid "_Zoom"
-msgstr "জুম (_Z)"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/universal-access/cc-ua-panel.ui:349
-msgid "Screen _Reader"
-msgstr "স্ক্রীন রিডার (_R)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:395
-#: panels/universal-access/cc-ua-panel.ui:1261
-msgid "_Sound Keys"
-msgstr "শব্দ কী (_S)"
-
-#: panels/universal-access/cc-ua-panel.ui:457
-msgid "Hearing"
-msgstr "শোনা"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/universal-access/cc-ua-panel.ui:501
-#: panels/universal-access/cc-ua-panel.ui:1364
-msgid "_Visual Alerts"
-msgstr "দৃশ্যমান সূচনা (_V)"
-
-#: panels/universal-access/cc-ua-panel.ui:609
-msgid "Screen _Keyboard"
-msgstr "স্ক্রীন কীবোর্ড (_K)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:654
-msgid "R_epeat Keys"
-msgstr "পুনরাবৃত্তির-কি (_e)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:700
-msgid "Cursor _Blinking"
-msgstr "কার্সারের ঝলকানি(_B)"
-
-#: panels/universal-access/cc-ua-panel.ui:746
-msgid "_Typing Assist (AccessX)"
-msgstr "টাইপিং সহায়তা (_T) (AccessX)"
-
-#: panels/universal-access/cc-ua-panel.ui:807
-msgid "Pointing & Clicking"
-msgstr "পয়েন্টিং & ক্লিকিং"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:853
-msgid "_Mouse Keys"
-msgstr "মাউস-কি (_M)"
-
-#: panels/universal-access/cc-ua-panel.ui:898
-msgid "_Locate Pointer"
-msgstr "পয়েন্টার সন্ধান করুন (_L)"
-
-#: panels/universal-access/cc-ua-panel.ui:930
-msgid "_Click Assist"
-msgstr "ক্লিক সহায়তা (_C)"
-
-#: panels/universal-access/cc-ua-panel.ui:976
-msgid "_Double-Click Delay"
-msgstr "দুইবার ক্লিক বিলম্ব (_D)"
-
-#: panels/universal-access/cc-ua-panel.ui:996
-msgid "Double-Click Delay"
-msgstr "দুইবার ক্লিক বিলম্ব"
-
-#: panels/universal-access/cc-ua-panel.ui:1066
-msgid "Cursor Size"
-msgstr "কার্সার আকার"
-
-#: panels/universal-access/cc-ua-panel.ui:1093
-msgid ""
-"Cursor size can be combined with zoom to make it easier to see the cursor."
-msgstr "কার্সার আকারটি সহজ করে তুলতে জুমের সাথে একত্রিত করা যায়।"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/universal-access/cc-ua-panel.ui:1129
-msgid "Screen Reader"
-msgstr "স্ক্রীন রিডার"
-
-#: panels/universal-access/cc-ua-panel.ui:1146
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "আপনার ফোকাস সরানোর সাথে সাথে স্ক্রিন রিডার প্রদর্শিত পাঠ্য পড়ে।"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/universal-access/cc-ua-panel.ui:1179
-msgid "_Screen Reader"
-msgstr "স্ক্রীন রিডার (_S)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1218
-msgid "Sound Keys"
-msgstr "শব্দ কি"
-
-#: panels/universal-access/cc-ua-panel.ui:1236
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "Num Lock বা Caps Lock চালু করা হলে বীপ শব্দ করুন"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/universal-access/cc-ua-panel.ui:1306
-msgid "Visual Alerts"
-msgstr "দৃশ্যমান সূচনা"
-
-#: panels/universal-access/cc-ua-panel.ui:1310
-msgid "_Test flash"
-msgstr "ফ্ল্যাশ পরীক্ষা (_T)"
-
-#: panels/universal-access/cc-ua-panel.ui:1339
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "একটি সর্তকতা শব্দ দেখা দিলে একটি ভিজ্যুয়াল সূচনা ব্যবহার করুন।"
-
-#: panels/universal-access/cc-ua-panel.ui:1390
-msgid "Flash the entire _window"
-msgstr "সমগ্র উইন্ডো ফ্ল্যাশ করুন"
-
-#: panels/universal-access/cc-ua-panel.ui:1408
-msgid "Flash the entire _screen"
-msgstr "সমগ্র স্ক্রীন ফ্ল্যাশ করুন (_s)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1453
-msgid "Repeat Keys"
-msgstr "পুনরাবৃত্তির-কি"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1483
-msgid "Key presses repeat when key is held down."
-msgstr "কী চেপে ধরলে কী টিপুন পুনরাবৃত্তি করে।"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1563
-msgid "Repeat keys delay"
-msgstr "কি পুনরাবৃত্তির হার"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1611
-#: panels/universal-access/cc-ua-panel.ui:1746
-msgid "Speed"
-msgstr "গতি"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1650
-msgid "Repeat keys speed"
-msgstr "কি পুনরাবৃত্তির হার"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1674
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 msgid "Cursor Blinking"
 msgstr "কার্সারের ঝলকানি"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1704
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "টেক্সট লেখার ক্ষেত্রে কার্সার ঝলকাবে।"
 
-#: panels/universal-access/cc-ua-panel.ui:1783
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "গতি"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "কার্সার ব্লিঙ্ক গতি"
 
-#: panels/universal-access/cc-ua-panel.ui:1819
-msgid "Typing Assist"
-msgstr "টাইপিং সহায়তা"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "কার্সার আকার"
 
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1858
-msgid "_Sticky Keys"
-msgstr "স্টিকি-কি (_S)"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "কার্সার আকারটি সহজ করে তুলতে জুমের সাথে একত্রিত করা যায়।"
 
-#: panels/universal-access/cc-ua-panel.ui:1875
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "মডিফায়ার কীগুলির একটি ক্রমকে একটি কী সমন্বয় হিসাবে বিবেচ্য করুন"
-
-#: panels/universal-access/cc-ua-panel.ui:1899
-msgid "_Disable if two keys are pressed together"
-msgstr "দুইটি কী একসংগে টেপা হলে নিষ্ক্রিয় করুন (_D)"
-
-#: panels/universal-access/cc-ua-panel.ui:1917
-msgid "Beep when a _modifier key is pressed"
-msgstr "একটি মডিফায়ার কী টেপা হলে বীপ করুন (_m)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:1965
-msgid "S_low Keys"
-msgstr "ধীর গতির-কি (_l)"
-
-#: panels/universal-access/cc-ua-panel.ui:1982
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "একটি কী টেপা এবং একটিকে স্বীকার করার মধ্যে কিছুটা সময় রাখুন"
-
-#: panels/universal-access/cc-ua-panel.ui:2015
-#: panels/universal-access/cc-ua-panel.ui:2228
-#: panels/universal-access/cc-ua-panel.ui:2565
-msgid "A_cceptance delay:"
-msgstr "স্বীকার করতে বিলম্ব (_c):"
-
-#: panels/universal-access/cc-ua-panel.ui:2037
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "সংক্ষিপ্ত"
-
-#: panels/universal-access/cc-ua-panel.ui:2056
-msgid "Slow keys typing delay"
-msgstr "মন্থর কী টাইপিং বিলম্ব"
-
-#: panels/universal-access/cc-ua-panel.ui:2071
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "লম্বা"
-
-#: panels/universal-access/cc-ua-panel.ui:2098
-msgid "Beep when a key is pr_essed"
-msgstr "একটি কী টেপা হলে বীপ (_e)"
-
-#: panels/universal-access/cc-ua-panel.ui:2115
-msgid "Beep when a key is _accepted"
-msgstr "একটি কী গৃহিত হলে বীপ আওয়াজ করুন (_a)"
-
-#: panels/universal-access/cc-ua-panel.ui:2132
-#: panels/universal-access/cc-ua-panel.ui:2311
-msgid "Beep when a key is _rejected"
-msgstr "একটি কী প্রত্যাখ্যান হলে বীপ আওয়াজ করুন (_r)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:2178
-msgid "_Bounce Keys"
-msgstr "বাউন্স-কি (_B)"
-
-#: panels/universal-access/cc-ua-panel.ui:2195
-msgid "Ignores fast duplicate keypresses"
-msgstr "দ্রুত সদৃশ কী-টেপা উপেক্ষা করে"
-
-#: panels/universal-access/cc-ua-panel.ui:2250
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "সংক্ষিপ্ত"
-
-#: panels/universal-access/cc-ua-panel.ui:2269
-msgid "Bounce keys typing delay"
-msgstr "বাউন্স কী টাইপিং বিলম্ব"
-
-#: panels/universal-access/cc-ua-panel.ui:2284
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "লম্বা"
-
-#: panels/universal-access/cc-ua-panel.ui:2397
-msgid "_Enable by Keyboard"
-msgstr "কীবোর্ড দ্বারা সক্রিয় (_E)"
-
-#: panels/universal-access/cc-ua-panel.ui:2414
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "কীবোর্ড ব্যবহার করে অ্যাক্সেসযোগ্যতা বৈশিষ্ট্য চালু এবং বন্ধ করুন"
-
-#: panels/universal-access/cc-ua-panel.ui:2478
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "ক্লিক সহায়তা"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:2514
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "দ্বিতীয় ক্লিকের অনুকরণ (_S)"
 
-#: panels/universal-access/cc-ua-panel.ui:2532
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "প্রাথমিক বোতাম ধরে রেখে একটি অপ্রধান ক্লিক ট্রিগার করুন"
 
-#: panels/universal-access/cc-ua-panel.ui:2586
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "স্বীকার করতে বিলম্ব (_c):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "সংক্ষিপ্ত"
 
-#: panels/universal-access/cc-ua-panel.ui:2605
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "অপ্রধান ক্লিক বিলম্ব"
 
-#: panels/universal-access/cc-ua-panel.ui:2620
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "লম্বা"
 
-#: panels/universal-access/cc-ua-panel.ui:2677
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "হোভার ক্লিক (_H)"
 
-#: panels/universal-access/cc-ua-panel.ui:2695
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "পয়েন্টার হোভার করার সময়ে একটি ক্লিক ট্রিগার করুন"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/universal-access/cc-ua-panel.ui:2728
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "বিলম্ব: (_e)"
 
-#: panels/universal-access/cc-ua-panel.ui:2750
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "সংক্ষিপ্ত"
 
-#: panels/universal-access/cc-ua-panel.ui:2781
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "লম্বা"
 
-#: panels/universal-access/cc-ua-panel.ui:2817
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "মোশন থ্রেশোল্ড (_t):"
 
-#: panels/universal-access/cc-ua-panel.ui:2839
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "ছোট"
 
 # auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
-#: panels/universal-access/cc-ua-panel.ui:2870
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "বৃহৎ"
 
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "এটিকে দেখা, শোনা, ধরন, পয়েন্ট এবং ক্লিক করা সহজতর করুন"
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "পুনরাবৃত্তির-কি"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
-msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
-"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
-"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
-"audio;typing;"
-msgstr ""
-"কীবোর্ড;মাউস;a11y;অ্যাক্সেসিবিলিটি;ইউনিভার্সালএক্সেস;কনট্রাস্ট;কার্সার;সাউন্ড;জুম;"
-"স্ক্রিন;রিডার;বড়;লম্বা;টেক্সট;ফন্ট;সাইজ;অ্যাক্সেসএক্স;স্টিকি;কী;স্লো;বাউন্স;মাউস;ডাবল;"
-"ক্লিক;বিলম্ব;গতি;সহায়তা;পুনরাবৃত্তি;নাচা;চাক্ষুষ;শুনানি;অডিও;টাইপিং;"
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "কী চেপে ধরলে কী টিপুন পুনরাবৃত্তি করে।"
 
-# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
-#: panels/universal-access/zoom-options.c:303
-msgctxt "Distance"
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "কি পুনরাবৃত্তির হার"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "কি পুনরাবৃত্তির হার"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "টাইপিং সহায়তা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "স্টিকি-কি (_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "মডিফায়ার কীগুলির একটি ক্রমকে একটি কী সমন্বয় হিসাবে বিবেচ্য করুন"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "দুইটি কী একসংগে টেপা হলে নিষ্ক্রিয় করুন (_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "একটি মডিফায়ার কী টেপা হলে বীপ করুন (_m)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "ধীর গতির-কি (_l)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "একটি কী টেপা এবং একটিকে স্বীকার করার মধ্যে কিছুটা সময় রাখুন"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "সংক্ষিপ্ত"
 
-#: panels/universal-access/zoom-options.c:304
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ স্ক্রীন"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "মন্থর কী টাইপিং বিলম্ব"
 
-#: panels/universal-access/zoom-options.c:305
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ স্ক্রীন"
-
-#: panels/universal-access/zoom-options.c:306
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ স্ক্রীন"
-
-# auto translated by TM merge from project: control-center, version: 3.8.6, DocId: gnome-control-center-2.0
-#: panels/universal-access/zoom-options.c:307
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "লম্বা"
 
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "একটি কী টেপা হলে বীপ (_e)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "একটি কী গৃহিত হলে বীপ আওয়াজ করুন (_a)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "একটি কী প্রত্যাখ্যান হলে বীপ আওয়াজ করুন (_r)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "বাউন্স-কি (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "দ্রুত সদৃশ কী-টেপা উপেক্ষা করে"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "সংক্ষিপ্ত"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "বাউন্স কী টাইপিং বিলম্ব"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "লম্বা"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "কীবোর্ড দ্বারা সক্রিয় (_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "কীবোর্ড ব্যবহার করে অ্যাক্সেসযোগ্যতা বৈশিষ্ট্য চালু এবং বন্ধ করুন"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "সর্বদা অ্যাক্সেসিবিলিটি মেনু দেখান (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "দেখা"
+
+# auto translated by TM merge from project: gnome-themes-standard, version: 3.8.3, DocId: gnome-themes-standard
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "গাঢ় তারতম্য (_H)"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "বড় মাপের হরফ (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "স্ক্রীন রিডার (_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "আপনার ফোকাস সরানোর সাথে সাথে স্ক্রিন রিডার প্রদর্শিত পাঠ্য পড়ে।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "শব্দ কী (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num Lock বা Caps Lock চালু করা হলে বীপ শব্দ করুন"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "কার্সার আকার(_u)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "জুম (_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "শোনা"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "দৃশ্যমান সূচনা (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "স্ক্রীন কীবোর্ড (_K)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "পুনরাবৃত্তির-কি (_e)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "কার্সারের ঝলকানি(_B)"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "টাইপিং সহায়তা (_T) (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "পয়েন্টিং & ক্লিকিং"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "মাউস-কি (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "পয়েন্টার সন্ধান করুন (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "ক্লিক সহায়তা (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "দুইবার ক্লিক বিলম্ব (_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "দুইবার ক্লিক বিলম্ব"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "দৃশ্যমান সূচনা"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "ফ্ল্যাশ পরীক্ষা (_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "একটি সর্তকতা শব্দ দেখা দিলে একটি ভিজ্যুয়াল সূচনা ব্যবহার করুন।"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "সমগ্র স্ক্রীন ফ্ল্যাশ করুন (_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "সমগ্র উইন্ডো ফ্ল্যাশ করুন"
+
 # auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
-#: panels/universal-access/zoom-options.ui:48
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "সম্পূর্ণ পর্দা জুড়ে প্রদর্শন"
 
-#: panels/universal-access/zoom-options.ui:53
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "শীর্ষ অর্ধ"
 
-#: panels/universal-access/zoom-options.ui:58
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "নিম্ন অর্ধ"
 
-#: panels/universal-access/zoom-options.ui:63
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "বাম অর্ধ"
 
-#: panels/universal-access/zoom-options.ui:68
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "ডান অর্ধ"
 
-#: panels/universal-access/zoom-options.ui:78
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "জুম বিকল্প"
 
-#: panels/universal-access/zoom-options.ui:185
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
 msgstr "বর্ধিতকরণ (_M):"
 
-#: panels/universal-access/zoom-options.ui:249
-msgid "_Follow mouse cursor"
-msgstr "মাউস কার্সর অনুসরণ করুন (_F)"
-
-#: panels/universal-access/zoom-options.ui:269
-msgid "_Screen part:"
-msgstr "স্ক্রীন অংশ (_S):"
-
-#: panels/universal-access/zoom-options.ui:331
-msgid "Magnifier _extends outside of screen"
-msgstr "বিবর্ধক স্ক্রীনের বাইরে বাড়ানো হয় (_e)"
-
-#: panels/universal-access/zoom-options.ui:350
-msgid "_Keep magnifier cursor centered"
-msgstr "বিবর্ধন কার্সার কেন্দ্রে রাখুন (_K)"
-
-#: panels/universal-access/zoom-options.ui:370
-msgid "Magnifier cursor _pushes contents around"
-msgstr "বিবর্ধন কার্সার বিষয়বস্তু চারপাশে ঢেলে (_p)"
-
-#: panels/universal-access/zoom-options.ui:390
-msgid "Magnifier cursor moves with _contents"
-msgstr "বিবর্ধন কার্সার বিষয়বস্তুর সংগে সরে (_c)"
-
-#: panels/universal-access/zoom-options.ui:425
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "বিবর্ধন অবস্থান:"
 
-#: panels/universal-access/zoom-options.ui:446
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "মাউস কার্সর অনুসরণ করুন (_F)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "স্ক্রীন অংশ (_S):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "বিবর্ধক স্ক্রীনের বাইরে বাড়ানো হয় (_e)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "বিবর্ধন কার্সার কেন্দ্রে রাখুন (_K)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "বিবর্ধন কার্সার বিষয়বস্তু চারপাশে ঢেলে (_p)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "বিবর্ধন কার্সার বিষয়বস্তুর সংগে সরে (_c)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "বিবর্ধন"
 
-#: panels/universal-access/zoom-options.ui:493
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "ক্রসহেয়ার(_C):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "মাউস কার্সার ওভারল্যাপ করে (_O)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
 msgstr "বেধ (_T):"
 
-#: panels/universal-access/zoom-options.ui:519
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "পাতলা"
 
-#: panels/universal-access/zoom-options.ui:551
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "পুরু"
 
-#: panels/universal-access/zoom-options.ui:577
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
 msgstr "দৈর্ঘ্য (_L):"
 
 # auto translated by TM merge from project: evince, version: 3.8.3, DocId: evince
 #. The color of the accessibility crosshair
-#: panels/universal-access/zoom-options.ui:626
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
 msgstr "রঙ(_l) :"
 
-#: panels/universal-access/zoom-options.ui:690
-msgid "_Crosshairs:"
-msgstr "ক্রসহেয়ার(_C):"
-
-#: panels/universal-access/zoom-options.ui:738
-msgid "_Overlaps mouse cursor"
-msgstr "মাউস কার্সার ওভারল্যাপ করে (_O)"
-
-#: panels/universal-access/zoom-options.ui:776
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "ক্রসহেয়ার"
 
-#: panels/universal-access/zoom-options.ui:825
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "রং প্রভাব:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
 msgstr "কালোর উপরে সাদা(_W):"
 
 # auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#: panels/universal-access/zoom-options.ui:845
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
 msgstr "উজ্জ্বলতা(_B):"
 
-#: panels/universal-access/zoom-options.ui:866
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
 msgstr "বৈপরীত্য (_C):"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/zoom-options.ui:886
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
 msgid "Co_lor"
 msgstr "রঙ(_l)"
 
 # auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
-#: panels/universal-access/zoom-options.ui:911
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "শূণ্য"
 
-#: panels/universal-access/zoom-options.ui:943
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "সম্পূর্ণ"
 
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/universal-access/zoom-options.ui:1006
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "নিচু"
 
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/universal-access/zoom-options.ui:1039
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "উঁচু"
 
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/universal-access/zoom-options.ui:1070
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "কম"
 
 # auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/universal-access/zoom-options.ui:1103
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "বেশি"
 
-#: panels/universal-access/zoom-options.ui:1139
-msgid "Color Effects:"
-msgstr "রং প্রভাব:"
-
-#: panels/universal-access/zoom-options.ui:1164
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "রং প্রভাব"
 
-#: panels/usage/cc-usage-panel.c:154
-msgid "Empty all items from Trash?"
-msgstr "ট্র্যাশ সম্পূর্ণ খালি করবেন?"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "এটিকে দেখা, শোনা, ধরন, পয়েন্ট এবং ক্লিক করা সহজতর করুন"
 
-#: panels/usage/cc-usage-panel.c:155
-msgid "All items in the Trash will be permanently deleted."
-msgstr "ট্র্যাশের সবকিছু সম্পূর্ণ ভাবে মুছে যাবে।"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"কীবোর্ড;মাউস;a11y;অ্যাক্সেসিবিলিটি;ইউনিভার্সালএক্সেস;কনট্রাস্ট;কার্সার;সাউন্ড;জুম;"
+"স্ক্রিন;রিডার;বড়;লম্বা;টেক্সট;ফন্ট;সাইজ;অ্যাক্সেসএক্স;স্টিকি;কী;স্লো;বাউন্স;মাউস;ডাবল;"
+"ক্লিক;বিলম্ব;গতি;সহায়তা;পুনরাবৃত্তি;নাচা;চাক্ষুষ;শুনানি;অডিও;টাইপিং;"
 
-#: panels/usage/cc-usage-panel.c:156
-msgid "_Empty Trash"
-msgstr "ট্র্যাশ খালি করুন (_E)"
-
-#: panels/usage/cc-usage-panel.c:177
-msgid "Delete all the temporary files?"
-msgstr "সকল অস্থায়ী ফাইল মুছবেন?"
-
-#: panels/usage/cc-usage-panel.c:178
-msgid "All the temporary files will be permanently deleted."
-msgstr "সকল অস্থায়ী ফাইল সম্পূর্ণ ভাবে মুছে যাবে।"
-
-#: panels/usage/cc-usage-panel.c:179
-msgid "_Purge Temporary Files"
-msgstr "অস্থায়ী ফাইলগুলি পার্জ করুন (_P)"
-
-#: panels/usage/cc-usage-panel.ui:29
+#: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
 msgstr "ফাইল এর ইতিহাস"
 
-#: panels/usage/cc-usage-panel.ui:41
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
 "File history keeps a record of files that you have used. This information is "
 "shared between applications, and makes it easier to find files that you "
@@ -7066,23 +4462,24 @@ msgstr ""
 "অ্যাপ্লিকেশনগুলির মধ্যে ভাগ করা হয় এবং আপনি যে ফাইলগুলি ব্যবহার করতে চান তা সন্ধান "
 "করা আরও সহজ করে তোলে।"
 
-#: panels/usage/cc-usage-panel.ui:56
+#: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
 msgstr "ফাইল এর ইতিহাস(_i)"
 
-#: panels/usage/cc-usage-panel.ui:78
+#: panels/usage/cc-usage-panel.ui:25
 msgid "File _History Duration"
 msgstr "ফাইল ইতিহাসের সময়কাল(_H)"
 
-#: panels/usage/cc-usage-panel.ui:119
+#: panels/usage/cc-usage-panel.ui:48
 msgid "_Clear History…"
 msgstr "ইতিহাস মুছুন (_C)..."
 
-#: panels/usage/cc-usage-panel.ui:135
-msgid "Trash & Temporary Files"
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
 msgstr "ট্র্যাশ এবং অস্থায়ী ফাইল পার্জ করুন"
 
-#: panels/usage/cc-usage-panel.ui:145
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
@@ -7090,109 +4487,25 @@ msgstr ""
 "ট্র্যাশ এবং অস্থায়ী ফাইলগুলি কখনও কখনও ব্যক্তিগত বা সংবেদনশীল তথ্য অন্তর্ভুক্ত করতে "
 "পারে। এগুলি স্বয়ংক্রিয়ভাবে মুছে ফেলা গোপনীয়তা রক্ষা করতে সহায়তা করতে পারে।"
 
-#: panels/usage/cc-usage-panel.ui:159
+#: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
 msgstr "ট্র্যাশ স্বয়ংক্রিয় ভাবে খালি করুন (_T)"
 
-#: panels/usage/cc-usage-panel.ui:174
+#: panels/usage/cc-usage-panel.ui:79
 msgid "Automatically Delete Temporary _Files"
 msgstr "অস্থায়ী ফাইলগুলি স্বয়ংক্রিয় ভাবে মুছুন (_F)"
 
-#: panels/usage/cc-usage-panel.ui:196
+#: panels/usage/cc-usage-panel.ui:91
 msgid "Automatically Delete _Period"
 msgstr "স্বয়ংক্রিয়ভাবে মুছার সময়কাল (_P)"
 
-#: panels/usage/cc-usage-panel.ui:238
+#: panels/usage/cc-usage-panel.ui:115
 msgid "_Empty Trash…"
 msgstr "ট্র্যাশ খালি করুন (_E)..."
 
-#: panels/usage/cc-usage-panel.ui:250
+#: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
 msgstr "অস্থায়ী ফাইলগুলি মুছুন(_D)..."
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:278
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "১ ঘন্টা"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:282
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "১ দিন"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:286
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "২ দিন"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:290
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "৩ দিন"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:294
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "৪ দিন"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:298
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "৫ দিন"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:302
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "৬ দিন"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:306
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "৭ দিন"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:310
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "১৪ দিন"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:314
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "৩০ দিন"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:329
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "১ দিন"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:333
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "৭ দিন"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:337
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "৩০ দিন"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:341
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "অনন্তকাল"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
@@ -7202,103 +4515,60 @@ msgstr "ফাইলের ইতিহাস এবং ট্র্যাশ"
 msgid "Don't leave traces"
 msgstr "ট্রেস ছেড়ে যাবেন না"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "আপনার অ্যাকাউন্ট সরবরাহকারীর ওয়েব ঠিকানা মিলতে হবে।"
-
-#: panels/user-accounts/cc-add-user-dialog.c:205
-msgid "Failed to add account"
-msgstr "অ্যাকাউন্ট যোগ করতে ব্যর্থ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:676
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "পাসওয়ার্ড মিলছে না।"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-add-user-dialog.c:896
-#: panels/user-accounts/cc-add-user-dialog.c:942
-#: panels/user-accounts/cc-add-user-dialog.c:963
-msgid "Failed to register account"
-msgstr "অ্যাকাউন্ট রেজিস্টার করতে ব্যর্থ"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-add-user-dialog.c:1084
-msgid "No supported way to authenticate with this domain"
-msgstr "এই ডোমেন দিয়ে পরিচয়প্রমাণের কোনো সমর্থিত মাধ্যম নেই"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-add-user-dialog.c:1157
-msgid "Failed to join domain"
-msgstr "ডোমেন এ যোগদান করতে ব্যর্থ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1218
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"প্রদত্ত লগিন নামটি কাজ করেনি।\n"
-"দয়া করে আবার চেষ্টা করুন।"
 
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-add-user-dialog.c:1225
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"প্রদত্ত লগিন পাসওয়ার্ডটি কাজ করেনি।\n"
-"দয়া করে আবার চেষ্টা করুন।"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-add-user-dialog.c:1233
-msgid "Failed to log into domain"
-msgstr "ডোমেনে লগ ইন করতে ব্যর্থ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1291
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "ডোমেন খুঁজে পাওয়া যায়নি। হতে পারি আপনি বানান ভুল করেছেন?"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "ব্যবহারকারী যোগ করুন"
 
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr "সম্পূর্ণ নাম (_F)"
-
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-msgid "Standard"
-msgstr "সাধারণ"
-
 # auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "প্রশাসক"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-msgid "Account _Type"
-msgstr "অ্যাকাউন্ট ধরন (_T)"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-msgid "Allow user to set a password when they next _login"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+#, fuzzy
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"ব্যবহারকারী যখন পরের বার লগইন করবেন তখন তাকে একটি পাসওয়ার্ড সেট করার অনুমতি দিন "
-"(_l)"
+"প্রশাসকরা অন্যান্য ব্যবহারকারীদের যুক্ত করতে এবং মুছে ফেলতে পারে এবং সমস্ত "
+"ব্যবহারকারীর জন্য সেটিংস পরিবর্তন করতে পারে।"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
-msgid "Set a password _now"
-msgstr "এখনই একটি পাসওয়ার্ড সেট করুন(_n)"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr ""
+"ব্যবহারকারী যখন পরের বার লগইন করবেন তখন তাকে একটি পাসওয়ার্ড সেট করার অনুমতি দিন"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "এখনই একটি পাসওয়ার্ড সেট করুন"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "নিশ্চিত(_C)"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "এন্টারপ্রাইজ লগিন (_E)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "আপনি অফলাইন আছেন"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7307,28 +4577,7 @@ msgstr ""
 "এন্টারপ্রাইজ লগিন এই ডিভাইসে একটি বিদ্যমান কেন্দ্রীয় ভাবে পরিচালিত ব্যবহারকারী "
 "অ্যাকাউন্ট ব্যবহারের অনুমতি দেয়।"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:732
-msgid "You are Offline"
-msgstr "আপনি অফলাইন আছেন"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-msgid "You must be online in order to add enterprise users."
-msgstr "এন্টারপ্রাইজ ব্যবহারকারীদের যুক্ত করতে আপনাকে অবশ্যই অনলাইনে থাকতে হবে।"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "এন্টারপ্রাইজ লগিন (_E)"
-
-# auto translated by TM merge from project: gnome-contacts, version: 3.8.2, DocId: gnome-contacts
-#: panels/user-accounts/cc-avatar-chooser.c:232
-msgid "Browse for more pictures"
-msgstr "আরো ছবির জন্য ব্রাউজ করুন"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:39
-msgid "Take a Picture…"
-msgstr "একটি ফোটো তুলুন…"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:46
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "ফাইল নির্বাচন করুন..."
 
@@ -7336,20 +4585,20 @@ msgstr "ফাইল নির্বাচন করুন..."
 msgid "Fingerprint Manager"
 msgstr "ফিঙ্গারপ্রিন্ট ম্যানেজার"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:23
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
 msgid "Fingerprint"
 msgstr "ফিংগারপ্রিন্ট"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:118
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "না (_N)"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:128
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "হ্যাঁ(_Y)"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.ui:155
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7357,28 +4606,32 @@ msgstr ""
 "আঙুলের ছাপ সহযোগে লগ-ইন ব্যবস্থা নিষ্ক্রিয় করার উদ্দেশ্যে নিবন্ধিত আঙুলের ছাপগুলি মুছে "
 "ফেলা হবে কি?"
 
-#. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
-msgid "No Fingerprint device"
-msgstr "কোনও ফিঙ্গারপ্রিন্ট ডিভাইস নেই"
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:259
-msgid "Ensure the device is properly connected."
-msgstr "ডিভাইসটি সঠিকভাবে সংযুক্ত রয়েছে তা নিশ্চিত করুন।"
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:264
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "কোনও ফিঙ্গারপ্রিন্ট ডিভাইস নেই"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:280
-msgid "Choose the fingerprint device you want to configure"
-msgstr "আপনি কনফিগার করতে চান যে ফিঙ্গারপ্রিন্ট ডিভাইস ওটা চয়ন করুন"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "কোনও ফিঙ্গারপ্রিন্ট ডিভাইস নেই"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:309
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "ডিভাইসটি সঠিকভাবে সংযুক্ত রয়েছে তা নিশ্চিত করুন।"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:322
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "আপনি কনফিগার করতে চান যে ফিঙ্গারপ্রিন্ট ডিভাইস ওটা চয়ন করুন"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "ফিংগারপ্রিন্ট লগিন"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7386,437 +4639,111 @@ msgstr ""
 "ফিঙ্গারপ্রিন্ট লগইন আপনাকে আপনার আঙুল দিয়ে কম্পিউটারে আনলক এবং লগ ইন করতে দেয়"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.ui:352
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "আঙুলের ছাপ মুছে ফেলুন (_D)"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:363
-msgid "Fingerprint Login"
-msgstr "ফিংগারপ্রিন্ট লগিন"
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:412
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "ফিঙ্গারপ্রিন্ট নথিভুক্ত"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:436
-msgid "_Re-enroll this finger…"
-msgstr "এই আঙুলটি পুনরায় তালিকাভুক্ত করুন(_R)..."
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "পূর্ববর্তী সপ্তাহ"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:470
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "আঙুলের ছাপগুলি তালিকা করতে ব্যর্থ: %s"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "পরবর্তী সপ্তাহ"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:536
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "সংরক্ষিত আঙ্গুলের ছাপগুলি মুছতে ব্যর্থ: %s"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.c:565
-msgid "Left thumb"
-msgstr "বাঁহাতের বৃদ্ধাঙ্গুলি"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.c:567
-msgid "Left middle finger"
-msgstr "বাঁহাতের মধ্যমা"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:569
-msgid "_Left index finger"
-msgstr "বাম ইনডেক্স ফিংগার (_L)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.c:571
-msgid "Left ring finger"
-msgstr "বাঁহাতের অনামিকা"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.c:573
-msgid "Left little finger"
-msgstr "বাঁহাতের কনিষ্ঠা"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.c:575
-msgid "Right thumb"
-msgstr "ডান হাতের বৃদ্ধাঙ্গুলি"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.c:577
-msgid "Right middle finger"
-msgstr "ডান হাতের মধ্যমা"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:579
-msgid "_Right index finger"
-msgstr "ডান ইনডেক্স ফিংগার (_R)"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.c:581
-msgid "Right ring finger"
-msgstr "ডান হাতের অনামিকা"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/user-accounts/cc-fingerprint-dialog.c:583
-msgid "Right little finger"
-msgstr "ডান হাতের কনিষ্ঠা"
-
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#: panels/user-accounts/cc-fingerprint-dialog.c:585
-msgid "Unknown Finger"
-msgstr "অজানা আঙ্গুল"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:719
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "সম্পন্ন"
-
-# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
-#: panels/user-accounts/cc-fingerprint-dialog.c:729
-msgid "Fingerprint device disconnected"
-msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস সংযোগ বিচ্ছিন্ন"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:731
-msgid "Fingerprint device storage is full"
-msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস স্টোরেজ পূর্ণ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:733
-msgid "Failed to enroll new fingerprint"
-msgstr "নতুন আঙুলের ছাপ নিবন্ধন করতে ব্যর্থ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:764
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "তালিকাভুক্তি শুরু করতে ব্যর্থ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:772
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "নতুন আঙুলের ছাপ নিবন্ধন করতে ব্যর্থ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:803
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "তালিকাভুক্তি বন্ধ করতে ব্যর্থ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:847
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"আপনার আঙুলের ছাপটি তালিকাভুক্ত করতে বারবার আপনার আঙ্গুলটি পাঠকের উপরে তুলুন এবং রাখুন"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:989
-msgid "Scan new fingerprint"
-msgstr "নতুন আঙুলের ছাপ স্ক্যান করুন"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1029
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "%s ফিঙ্গারপ্রিন্ট ডিভাইস প্রকাশ করতে ব্যর্থ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "পড়ার যন্ত্রতে সমস্যা"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1133
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস %s দাবি করতে ব্যর্থ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1270
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "ফিঙ্গারপ্রিন্ট ডিভাইসগুলি পেতে ব্যর্থ: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "এই সপ্তাহে"
-
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
-msgstr "গত সপ্তাহে"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:782
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:786
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr "সেশন সমাপ্ত হয়েছে"
-
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr "সেশন শুরু হয়েছে"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — অ্যাকাউন্ট ক্রিয়াকলাপ"
-
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr "দয়া করে অপর একটি পাসওয়ার্ড বাছুন।"
-
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
-msgstr "দয়া করে আপনার বর্তমান পাসওয়ার্ড আবার টাইপ করুন।"
-
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
-msgstr "পাসওয়ার্ড পরিবর্তন করা যাবে না"
-
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "পাসওয়ার্ড পরিবর্তন করুন"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "পরিবর্তন করুন (_a)"
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr "পাসওয়ার্ড নিশ্চিত করুন (_C)"
-
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr "নতুন পাসওয়ার্ড (_N)"
-
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "বর্তমান পাসওয়ার্ড (_P)"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "নতুন পাসওয়ার্ড (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "পাসওয়ার্ড নিশ্চিত করুন (_C)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "পাসওয়ার্ড মিলছে না।"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
 "ব্যবহারকারী যখন পরের বার লগইন করবেন তখন তাকে একটি পাসওয়ার্ড সেট করার অনুমতি দিন"
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "এখনই একটি পাসওয়ার্ড সেট করুন"
 
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "Cannot automatically join this type of domain"
-msgstr "এই ধরনের ডোমেনে স্বয়ংক্রিয়ভাবে যোগ দেওয়া যায় না"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-realm-manager.c:309
-msgid "No such domain or realm found"
-msgstr "এমন কোন ডোমেন বা রিলম পাওয়া যায়নি"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-realm-manager.c:731
-#: panels/user-accounts/cc-realm-manager.c:745
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s হিসেবে %s ডোমেনে লগইন করা সম্ভব হচ্ছে না"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-realm-manager.c:737
-msgid "Invalid password, please try again"
-msgstr "অবৈধ পাসওয়ার্ড, পুনরায় চেষ্টা করুন"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-realm-manager.c:750
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "%s ডোমেনে সংযোগ স্থাপন করতে ব্যর্থ: %s"
-
-#: panels/user-accounts/cc-user-panel.c:220
-msgid "Your account"
-msgstr "আপনার অ্যাকাউন্ট"
-
-#: panels/user-accounts/cc-user-panel.c:401
-msgid "Failed to delete user"
-msgstr "ব্যবহারকারী মুছতে ব্যর্থ"
-
-#: panels/user-accounts/cc-user-panel.c:459
-#: panels/user-accounts/cc-user-panel.c:518
-#: panels/user-accounts/cc-user-panel.c:570
-msgid "Failed to revoke remotely managed user"
-msgstr "দূরবর্তীভাবে পরিচালিত ব্যবহারকারীকে প্রত্যাহার করতে ব্যর্থ"
-
-#: panels/user-accounts/cc-user-panel.c:621
-msgid "You cannot delete your own account."
-msgstr "আপনি আপনার নিজের অ্যাকাউন্ট মুছতে পারবেন না।"
-
-#: panels/user-accounts/cc-user-panel.c:630
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s এখনও লগিন আছে"
-
-#: panels/user-accounts/cc-user-panel.c:634
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"কোনো ব্যবহারকারীকে তার লগিন থাকা অবস্থাতেই মুছে ফেলা হলে, সিস্টেম অধারাবাহিক "
-"অবস্থায় চলে যেতে পারে।"
-
-#: panels/user-accounts/cc-user-panel.c:643
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "আপনি কি %s'র ফাইলগুলি রাখতে চান?"
-
-#: panels/user-accounts/cc-user-panel.c:647
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"একটি ব্যবহারকারী অ্যাকাউন্ট মোছার সময়ে হোম ডিরেক্টরি, মেল স্পুল এবং অস্থায়ী ফাইলগুলি "
-"হাতের কাছে রাখা সম্ভব।"
-
-#: panels/user-accounts/cc-user-panel.c:650
-msgid "_Delete Files"
-msgstr "ফাইলগুলি মুছুন (_D)"
-
-#: panels/user-accounts/cc-user-panel.c:651
-msgid "_Keep Files"
-msgstr "ফাইলগুলি রাখুন (_K)"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/cc-user-panel.c:665
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "আপনি কি নিশ্চিত যে দূরবর্তীভাবে পরিচালিত %s এর অ্যাকাউন্টটি বাতিল করতে চান?"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgid "_Delete"
-msgstr "মুছুন (_D)"
-
-#: panels/user-accounts/cc-user-panel.c:719
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "অ্যাকাউন্ট নিষ্ক্রিয়"
-
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "পরবর্তী লগিনো সেট করা হবে"
-
-# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
-#: panels/user-accounts/cc-user-panel.c:730
-msgctxt "Password mode"
-msgid "None"
-msgstr "শূণ্য"
-
-#: panels/user-accounts/cc-user-panel.c:775
-msgid "Logged in"
-msgstr "লগিন করা হয়েছে"
-
-# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:863
-#: panels/user-accounts/cc-user-panel.c:954
-msgid "Enabled"
-msgstr "সক্রিয়"
-
-#: panels/user-accounts/cc-user-panel.c:1265
-msgid "Failed to contact the accounts service"
-msgstr "অ্যাকাউন্ট পরিষেবায় যোগাযোগ করতে ব্যর্থ"
-
-#: panels/user-accounts/cc-user-panel.c:1267
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "দয়া করে নিশ্চিত করুন যে, AccountService ইনস্টল করা এবং সক্রিয় করা হয়েছে।"
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1299
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"পরিবর্তনগুলি করতে,\n"
-"প্রথমে * আইকন ক্লিক করুন"
-
-#: panels/user-accounts/cc-user-panel.c:1373
-msgid "Delete the selected user account"
-msgstr "নির্বাচিত ব্যবহারকারী অ্যাকাউন্ট মুছুন"
-
-#: panels/user-accounts/cc-user-panel.c:1385
-#: panels/user-accounts/cc-user-panel.c:1506
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"নির্বাচিত ব্যবহারকারী অ্যাকাউন্ট মুছতে,\n"
-"প্রথমে * আইকনে ক্লিক করুন"
-
-#: panels/user-accounts/cc-user-panel.ui:5
-msgid "_Add User…"
-msgstr "ব্যবহারকারী যোগ করুন (_A)"
-
-#: panels/user-accounts/cc-user-panel.ui:8
-msgid "Create a user account"
-msgstr "একটি ব্যবহারকারী অ্যাকাউন্ট তৈরি করুন"
+# auto translated by TM merge from project: Cloudforms Cloud Engine User Guide, version: 1.0, DocId: Users_And_Roles
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "ব্যবহারকারী"
 
 #: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "করা পরিবর্তনগুলি প্রয়োগ হতে আপনার সেশন রিস্টার্ট করা প্রয়োজন"
 
-#: panels/user-accounts/cc-user-panel.ui:71
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "এখনই পুনরারম্ভ করুন"
 
-#: panels/user-accounts/cc-user-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:168
-msgid "User Icon"
-msgstr "ব্যবহারকারী আইকন"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "বন্ধ করুন"
 
-#: panels/user-accounts/cc-user-panel.ui:244
-msgid "Account Settings"
-msgstr "অ্যাকাউন্ট সেটিংস"
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "সম্পূর্ণ নাম (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "ফিংগারপ্রিন্ট লগিন (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "স্বয়ংক্রিয় লগিন (_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "অ্যাকাউন্ট ক্রিয়াকলাপ"
 
 # auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/user-accounts/cc-user-panel.ui:271
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "প্রশাসক (_A)"
 
-#: panels/user-accounts/cc-user-panel.ui:291
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7824,64 +4751,58 @@ msgstr ""
 "প্রশাসকরা অন্যান্য ব্যবহারকারীদের যুক্ত করতে এবং মুছে ফেলতে পারে এবং সমস্ত "
 "ব্যবহারকারীর জন্য সেটিংস পরিবর্তন করতে পারে।"
 
-#: panels/user-accounts/cc-user-panel.ui:320
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "পিতামাতার নিয়ন্ত্রণ(_P)"
 
-#: panels/user-accounts/cc-user-panel.ui:410
-msgid "Authentication & Login"
-msgstr "প্রমাণীকরণ এবং লগইন"
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:479
-msgid "_Fingerprint Login"
-msgstr "ফিংগারপ্রিন্ট লগিন (_F)"
-
-#: panels/user-accounts/cc-user-panel.ui:521
-msgid "A_utomatic Login"
-msgstr "স্বয়ংক্রিয় লগিন (_u)"
-
-#: panels/user-accounts/cc-user-panel.ui:551
-msgid "Account Activity"
-msgstr "অ্যাকাউন্ট ক্রিয়াকলাপ"
-
-#: panels/user-accounts/cc-user-panel.ui:592
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "ব্যবহারকারীর অ্যাকাউন্ট সরান"
 
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "অন্যান্য ফাইলগুলি"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "ব্যবহারকারী যোগ করুন (_A)"
+
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:631
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "কোন ব্যবহারকারী পাওয়া যায়ে নি"
 
-#: panels/user-accounts/cc-user-panel.ui:641
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "কোনও ব্যবহারকারী অ্যাকাউন্ট যুক্ত করতে আনলক করুন।"
-
-# auto translated by TM merge from project: Cloudforms Cloud Engine User Guide, version: 1.0, DocId: Users_And_Roles
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
-msgid "Users"
-msgstr "ব্যবহারকারী"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "ব্যবহারকারীদের যোগ করুন বা সরান এবং আপনার পাসওয়ার্ড পরিবর্তন করুন"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "লগিন;নাম;ফিংগারপ্রিন্ট;অবতার;লোগো;ফেস;পাসওয়ার্ড;"
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "নথিভুক্ত করুন (_E)"
 
 # auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "ডোমেইন অ্যাডমিনিস্ট্রেটর লগিন"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -7892,12 +4813,12 @@ msgstr ""
 "এখানে ডোমেন পাসওয়ার্ড দিতে বলুন।"
 
 # auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "প্রশাসকের নাম (_N)"
 
 # auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "প্রশাসকের পাসওয়ার্ড"
 
@@ -7909,198 +4830,16 @@ msgstr "ব্যবহারকারী অ্যাকাউন্টগু�
 msgid "Authentication is required to change user data"
 msgstr "ব্যবহারকারী ডেটা পরিবর্তন করতে প্রমাণীকরণের প্রয়োজন"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "নতুন পাসওয়ার্ডটি পুরানো পাসওয়ার্ডের থেকে আলাদা হতে হবে।"
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "কিছু অক্ষর এবং সংখ্যা পরিবর্তন করে চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "পাসওয়ার্ডটি অনেকটা বদলে চেষ্টা করুন"
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "আপনার ব্যবহারকারী নাম ছাড়া কোনো পাসওয়ার্ড শক্তিশালী হবে।"
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "পাসওয়ার্ডে নিজের নাম ব্যবহার না করাই ভালো।"
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "পাসওয়ার্ডে অন্তর্ভুক্ত কিছু শব্দ এড়িয়ে যাওয়ার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "সাধারণ শব্দ এড়িয়ে যাওয়ার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "বিদ্যমান শব্দ আবার সাজানো এড়িয়ে যাওয়ার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "আরো সংখ্যা ব্যবহার করার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "আরো বেশি সংখ্যাক বড় হাতের অক্ষর ব্যবহার করার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "আরো বেশি সংখ্যক ছোট হাতের অক্ষর ব্যবহার করার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "যতিচিহ্নের মতো আরো বিশেষ অক্ষর ব্যবহার করার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "অক্ষর, সংখ্যা এবং যতিচিহ্ন মিলিয়েমিশিয়ে ব্যবহার করার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "একই অক্ষর পুনরাবৃত্ত করা এড়িয়ে চলুন।"
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"একই ধরনের অক্ষর লেখা এড়িয়ে যাওয়ার চেষ্টা করুন: আপনাকে অক্ষর, সংখ্যা এবং যতিচিহ্ন "
-"মিলিয়ে মিশিয়ে ব্যবহার করতে হবে।"
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 বা abcd-এর মতো ক্রম এড়িয়ে যাওয়ার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"পাসওয়ার্ড দীর্ঘ হওয়া দরকার। আরও অক্ষর, সংখ্যা এবং বিরামচিহ্ন যুক্ত করার চেষ্টা করুন।"
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"বড় এবং ছোট হাতের অক্ষর মিলিয়ে মিশিয়ে লিখুন এবং এক বা দুইটি সংখ্যা ব্যবহার করুন।"
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "আরও অক্ষর, সংখ্যা এবং বিরামচিহ্ন যুক্ত করা পাসওয়ার্ডকে শক্তিশালী করবে।"
-
-# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
-#: panels/user-accounts/run-passwd.c:424
-msgid "Authentication failed"
-msgstr "পরিচয় প্রমাণ করতে বিফল"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The new password is too short"
-msgstr "নতুন পাসওয়ার্ড অত্যন্ত ছোট"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password is too simple"
-msgstr "নতুন পাসওয়ার্ড অত্যন্ত সরল"
-
-#: panels/user-accounts/run-passwd.c:516
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "পুরনো এবং নতুন পাসওয়ার্ড প্রায় একই"
-
-#: panels/user-accounts/run-passwd.c:519
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "নতুন পাসওয়ার্ড ইতিমধ্যেই সাম্প্রতিক সময়ে ব্যবহৃত হয়েছে।"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "নতুন পাসওয়ার্ডে অবশ্যই সাংখ্যিক বা বিশেষ অক্ষর থাকতে হবে"
-
-#: panels/user-accounts/run-passwd.c:526
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "পুরনো এবং নতুন পাসওয়ার্ড একই"
-
-#: panels/user-accounts/run-passwd.c:530
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "আপনার প্রারম্ভিক ভাবে প্রমাণীকরণের সময়ে আপনার পাসওয়ার্ড পরিবর্তিত হয়েছে!"
-
-#: panels/user-accounts/run-passwd.c:534
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "নতুন পাসওয়ার্ডে যথেষ্ট আলাদা আলাদা অক্ষর নেই"
-
-# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
-#: panels/user-accounts/run-passwd.c:538
-#, c-format
-msgid "Unknown error"
-msgstr "অজানা ত্রুটি"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/user-utils.c:435
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"ব্যবহারকারীর নামটিতে কেবলমাত্র a-z, অঙ্ক এবং নিম্নলিখিত বর্ণগুলি থেকে নিম্ন বর্ণের "
-"অক্ষর থাকা উচিত: - _"
-
-#: panels/user-accounts/user-utils.c:439
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "দুঃখিত, সেই ব্যবহারকারীর নামটি উপলভ্য নয়। অন্য চেষ্টা করুন।"
-
-# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
-#: panels/user-accounts/user-utils.c:484
-msgid "The username is too long."
-msgstr "ব্যবহারকারীর নাম অতিশয় দীর্ঘ।"
-
-#: panels/user-accounts/user-utils.c:546
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr "এটি আপনার হোম ফোল্ডারের নামকরণ করতে ব্যবহৃত হবে এবং পরিবর্তন করা যাবে না।"
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "মানচিত্র বোতাম"
 
-# auto translated by TM merge from project: rhn-client-tools, version: 6.2, DocId: rhn-client-tools
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "বন্ধ করুন (_C)"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "কাজের মানচিত্র বোতাম"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -8108,7 +4847,12 @@ msgstr ""
 "একটি শর্টকাট সম্পাদনা করতে, \"কীস্ট্রোক প্রেরণ করুন\" ক্রিয়াটি চয়ন করুন, কীবোর্ড "
 "শর্টকাট বোতাম টিপুন এবং নতুন কীগুলি ধরে রাখুন বা সাফ করতে ব্যাকস্পেস টিপুন।"
 
-#: panels/wacom/calibrator/calibrator.ui:61
+# auto translated by TM merge from project: rhn-client-tools, version: 6.2, DocId: rhn-client-tools
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "বন্ধ করুন (_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -8116,71 +4860,122 @@ msgstr ""
 "ট্যাবলেট ক্যালিব্রেট করতে টার্গেট মার্কারগুলি স্ক্রীনে দেখা দেওয়ার সময়ে দয়া করে "
 "তাদের আলতো চাপুন।"
 
-#: panels/wacom/calibrator/calibrator.ui:78
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "মিস-ক্লিক সনাক্ত হয়েছে, পুনরায় চালু হচ্ছে..."
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "বোতাম %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "সংজ্ঞায়িত করা অ্যাপ্লিকেশন"
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "ট্যাবলেট"
 
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "কীস্ট্রোক পাঠান"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "মনিটর পাল্টান"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "বাম-হাতী সজ্জা"
 
-# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "অন-স্ক্রীন সহায়তা দেখান"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:245
-msgid "Output:"
-msgstr "আউটপুট:"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "মনিটর করতে ম্যাপ করুন…"
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:257
-msgid "Keep aspect ratio (letterbox):"
-msgstr "অ্যাসপেক্ট অনুমাত রাখুন (লেটারবক্স):"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "অ্যাসপেক্ট অনুমাত"
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:268
-msgid "Map to single monitor"
-msgstr "একক মনিটরে ম্যাপ করুন"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-# auto translated by TM merge from project: sushi, version: 3.8.1, DocId: sushi
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
-msgstr "%d, %d এর"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "ক্যালিব্রেট করুন…"
 
-#: panels/wacom/cc-wacom-page.c:516
-msgid "Display Mapping"
-msgstr "ম্যাপিং প্রদর্শন"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "কোনো ট্যাবলেট সনাক্ত হয়নি"
 
-#: panels/wacom/cc-wacom-panel.c:725 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
-msgstr "স্টাইলাস"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "দয়া করে প্লাগ ইন করুন বা আপনার Wacom ট্যাবলেট চালু করুন"
 
-#: panels/wacom/cc-wacom-stylus-page.c:357
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "টিপ প্রেসার ফিল"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "নরম"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "শক্ত"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "বোতাম"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "বোতাম"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "বোতাম"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "ইরেজার প্রেসার ফিল"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "ইরেজার প্রেসার ফিল"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "মধ্যম মাউস বোতাম ক্লিক"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "ডান মাউস বোতাম ক্লিক"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "ফরওয়ার্ড"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr "Wacom ট্যাবলেট"
 
@@ -8190,195 +4985,353 @@ msgstr ""
 "বোতাম ম্যাপিং সেট করুন এবং গ্র্যাফিক্স ট্যাবলেটের জন্য স্টাইলাস সংবেদনশীলতা "
 "সামঞ্জস্যপূর্ণ করুন"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "ট্যাবলেট;Wacom;স্টাইলাস;ইরেজার;মাউস;"
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "ট্যাবলেট (চরম)"
-
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
-msgstr "টাচপ্যাড (সম্পর্কিত)"
-
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "ট্যাবলেট অগ্রাধিকার"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "সাহায্য (_H)"
-
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
-msgstr "কোনো ট্যাবলেট সনাক্ত হয়নি"
-
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "দয়া করে প্লাগ ইন করুন বা আপনার Wacom ট্যাবলেট চালু করুন"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
-msgstr "ব্লু-টুথ সংক্রান্ত বৈশিষ্ট্য"
-
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
-msgstr "ট্র্যাকিং মোড"
-
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
-msgstr "বাম-হাতী সজ্জা"
-
-#: panels/wacom/gnome-wacom-properties.ui:296
-#: panels/wacom/gnome-wacom-properties.ui:401
-msgid "Map to Monitor…"
-msgstr "মনিটর করতে ম্যাপ করুন…"
-
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
-msgstr "ম্যাপ বোতাম…"
-
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
-msgstr "ক্যালিব্রেট করুন…"
-
-# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
-msgstr "মাউস সংক্রান্ত বৈশিষ্ট্য সামজ্ঞস্যপূর্ণ করুন"
-
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
-msgstr "প্রদর্শন রিজোলিউশন সামঞ্জস্যপূর্ণ করুন"
-
-#: panels/wacom/gnome-wacom-properties.ui:376
-msgid "Decouple Display"
-msgstr "ডিসপ্লে ভাগ করুন"
-
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr "নতুন শর্টকাট…"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "ডিফল্ট"
-
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "মধ্যম মাউস বোতাম ক্লিক"
-
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "ডান মাউস বোতাম ক্লিক"
-
-# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "ফরওয়ার্ড"
-
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
-msgstr "কোনও স্টাইলাস পাওয়া যায় নি"
-
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
 msgstr ""
-"এটির কনফিগার করতে দয়া করে আপনার স্টাইলাসটিকে ট্যাবলেটের সান্নিধ্যে স্থানান্তর করুন"
 
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
-msgstr "ইরেজার প্রেসার ফিল"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
-msgid "Soft"
-msgstr "নরম"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
-msgid "Firm"
-msgstr "শক্ত"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:234
-msgid "Top Button"
-msgstr "শীর্ষ বোতাম"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:263
-msgid "Lower Button"
-msgstr "নিম্ন বোতাম"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:292
-msgid "Lowest Button"
-msgstr "নিম্ন বোতাম"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:321
-msgid "Tip Pressure Feel"
-msgstr "টিপ প্রেসার ফিল"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Settings"
-msgstr "জিনোম সেটিংস"
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "দ্বিতীয় ক্লিকের অনুকরণ (_S)"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows সফ্টওয়্যার"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "টোনার কম"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "অপ্রধান"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows সফ্টওয়্যার"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+# auto translated by TM merge from project: RHEL Deployment Guide, version: 6.2, DocId: Product_Subscriptions_and_Entitlements
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "অ্যাক্সেস বিকল্প"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "যোগ করুন"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "সংরক্ষণ করুন (_S)"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "ভিপিএন"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "বিবরণ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+msgid "Modem Status"
+msgstr "স্থিতি:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "নেটওয়ার্ক সময় (_N)"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "নেটওয়ার্ক"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "সংখ্যা"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "প্রিন্টারের বিবরণ"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "নির্মাতা"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "ফায়ারওয়্যার অনুপস্থিত"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "মোবাইল ব্রড-ব্যান্ড (_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "নেটওয়ার্ক সময় (_N)"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "নেটওয়ার্ক"
+
+# auto translated by TM merge from project: ekiga, version: 4.0.1, DocId: ekiga
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "উন্নত"
+
+# auto translated by TM merge from project: RHEL Deployment Guide, version: 6.2, DocId: Product_Subscriptions_and_Entitlements
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "অ্যাক্সেস বিকল্প"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "স্ক্রীন লক"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "%s বিশদ"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "নেটওয়ার্কের নাম"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "স্বয়ংক্রিয়"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "আমার হোম নেটওয়ার্ক"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "আমার হোম নেটওয়ার্ক"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "কোনও Wi-Fi অ্যাডাপ্টার পাওয়া যায় নি"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "আপনার ওয়াই-ফাই অ্যাডাপ্টার প্লাগ এবং চালু আছে তা নিশ্চিত করুন"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "বিমান মোড চালু থাকলে ব্লুটুথ অক্ষম করা হয়।"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "বিমান মোড বন্ধ করুন"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "সংযোগটি ভুলে যান"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM কার্ড ঢোকানো হয়নি"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "স্ক্রীন লক"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "পরিবর্তন করুন (_a)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "আমার হোম নেটওয়ার্ক"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "অপসারণযোগ্য মিডিয়া সেটিংস কনফিগার করুন"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
 msgstr "জিনোম ডেস্কটপ কনফিগার করতে ইউটিলিটি"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr "আপনার সিস্টেমটি কনফিগার করার জন্য সেটিংস হল প্রাথমিক ইন্টারফেস।"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:20
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "জিনোম প্রকল্প"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "সংস্করণ নম্বর প্রদর্শন করুন"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "নতুন ড্রাইভার সেট করা হচ্ছে…"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "ভারবজ মোড সক্রিয় করুন"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "স্ট্রীং সন্ধান করুন"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "সম্ভাব্য প্যানেল নামগুলি তালিকাভুক্ত করুন এবং প্রস্থান করুন"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "প্রদর্শনের জন্য প্যানেল"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[প্যানেল] [আর্গুমেন্ট…]"
-
-#: shell/cc-panel-list.ui:45 shell/cc-window.c:275
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "গোপনীয়তা"
 
-#: shell/cc-panel-loader.c:288
-msgid "Available panels:"
-msgstr "উপলব্ধ প্যানেলগুলি:"
-
-#: shell/cc-window.ui:136
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "সকল সেটিং"
 
-#: shell/cc-window.ui:174
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr "প্রাথমিক মেনু"
 
-#: shell/cc-window.ui:318
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr "সতর্কতা: বিকাশ সংস্করণ"
 
-#: shell/cc-window.ui:319
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
@@ -8388,14 +5341,9 @@ msgstr ""
 "সিস্টেম আচরণ, ডেটা হ্রাস এবং অন্যান্য অপ্রত্যাশিত সমস্যা অনুভব করতে পারেন।"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: shell/cc-window.ui:330
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "সাহায্য"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "অগ্রাধিকার;সেটিং;"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
 #: shell/help-overlay.ui:15
@@ -8409,7 +5357,7 @@ msgid "Quit"
 msgstr "প্রস্থান"
 
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "অনুসন্ধান"
@@ -8419,16 +5367,20 @@ msgctxt "shortcut window"
 msgid "Panels"
 msgstr "প্যানেলগুলি"
 
-#: shell/help-overlay.ui:40
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
 msgstr "আগের প্যানেলে ফিরে যান"
 
 # auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#: shell/help-overlay.ui:53
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "অনুসন্ধান বাতিল করুন"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "অগ্রাধিকার;সেটিং;"
 
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
@@ -8451,10 +5403,18 @@ msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "উন্নয়ন বিল্ড চলাকালীন সেটিংস কোনও সতর্কতা প্রদর্শন করবে কিনা।"
 
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
 # auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1883
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
@@ -8462,25 +5422,2937 @@ msgstr[0] "%u আউটপুট"
 msgstr[1] "%u আউটপুট"
 
 # auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1893
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u ইনপুট"
 msgstr[1] "%u ইনপুট"
 
-#: subprojects/gvc/gvc-mixer-control.c:2750
-msgid "System Sounds"
-msgstr "সিস্টেমের শব্দ"
+#~ msgid "System Bus"
+#~ msgstr "সিস্টেমের বাস"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "Full access"
+#~ msgstr "পূর্ণ প্রবেশাধিকার"
+
+#~ msgid "Session Bus"
+#~ msgstr "সেশন বাস"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "/dev এ সম্পূর্ণ অ্যাক্সেস"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#~ msgid "Has network access"
+#~ msgstr "নেটওয়ার্ক অ্যাক্সেস আছে"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Home"
+#~ msgstr "গৃহ"
+
+#~ msgid "Read-only"
+#~ msgstr "শুধুমাত্র পাঠযোগ্য"
+
+#~ msgid "Can change settings"
+#~ msgstr "সেটিংস পরিবর্তন করতে পারে"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s এর অন্তর্নির্মিত নিম্নলিখিত অনুমতি রয়েছে। এগুলি পরিবর্তন করা যায় না। আপনি যদি "
+#~ "এই অনুমতিগুলি সম্পর্কে উদ্বিগ্ন হন তবে এই অ্যাপ্লিকেশনটি সরিয়ে ফেলার কথা বিবেচনা "
+#~ "করুন।"
+
+#~ msgid "Web Links"
+#~ msgstr "ওয়েব লিংকগুলি"
+
+#~ msgid "Git Links"
+#~ msgstr "গিট লিঙ্কগুলি"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "%s লিঙ্কগুলি"
+
+#~ msgid "Unset"
+#~ msgstr "আনসেট"
+
+#~ msgid "Links"
+#~ msgstr "লিঙ্কেগুলি"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "হাইপারটেক্সট ফাইলগুলি"
+
+#~ msgid "Text Files"
+#~ msgstr "পাঠ্য ফাইলগুলি"
+
+#~ msgid "Image Files"
+#~ msgstr "চিত্র ফাইলগুলি"
+
+#~ msgid "Font Files"
+#~ msgstr "ফন্ট ফাইলগুলি"
+
+#~ msgid "Archive Files"
+#~ msgstr "সংরক্ষণাগার ফাইলগুলি"
+
+#~ msgid "Package Files"
+#~ msgstr "প্যাকেজ ফাইলগুলি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Audio Files"
+#~ msgstr "অডিও ফাইলগুলি"
+
+#~ msgid "Video Files"
+#~ msgstr "ভিডিও ফাইলগুলি"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "অনুমতি এবং অ্যাক্সেস"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "এই অ্যাপ্লিকেশনটি যে ডেটা এবং পরিষেবাদিগুলির অ্যাক্সেস এবং এর জন্য প্রয়োজনীয় "
+#~ "অনুমতিগুলির জন্য বলেছে।"
+
+#~ msgid "Cannot be changed"
+#~ msgstr "পরিবর্তন করা যাবে না"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "<a href=\"privacy\">গোপনীয়তা</a>সেটিংসে অ্যাপ্লিকেশনগুলির জন্য পৃথক অনুমতিগুলি "
+#~ "পর্যালোচনা করা যেতে পারে।"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Integration"
+#~ msgstr "মিশ্রণ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Set Desktop Background"
+#~ msgstr "ডেস্কটপ ওয়ালপেপার সেট করুন"
+
+#~ msgid "Default Handlers"
+#~ msgstr "ডিফল্ট হ্যান্ডেলার"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "এই অ্যাপ্লিকেশনটি খোলার ফাইল এবং লিঙ্কগুলির প্রকার।"
+
+#~ msgid "Usage"
+#~ msgstr "ব্যবহার"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "এই অ্যাপ্লিকেশনটি কতগুলি সংস্থান ব্যবহার করছে।"
+
+#~ msgid "Open in Software"
+#~ msgstr "সফটওয়্যার এ খুলুন"
+
+#~ msgid "Select a picture"
+#~ msgstr "একটি ছবি নির্বাচন করুন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "multiple sizes"
+#~ msgstr "একাধিক মাপ"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "No Desktop Background"
+#~ msgstr "ডেস্কটপের কোনো পটভূমি প্রয়োগ করা হবে না"
+
+#~ msgid "Current background"
+#~ msgstr "বর্তমান পটভূমি"
+
+#~ msgid "Activities"
+#~ msgstr "ক্রিয়াকলাপ"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "ওয়ালপেপার;স্ক্রীন;ডেস্কটপ;"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "নীচের অ্যাপ্লিকেশনগুলিকে আপনার ক্যামেরাটি ব্যবহার করার অনুমতি দিন।"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "স্ক্রীন;লক;সমস্যা নিরূপণ;ক্র্যাশ;ব্যক্তিগত;সাম্প্রতিক;অস্থায়ী;tmp;সূচি;নাম;নেটওয়ার্ক;"
+#~ "পরিচয়;"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "আপনার ক্রমাঙ্কন ডিভাইসটিকে স্কোয়ারের উপরে রাখুন এবং \"আরম্ভ\" টিপুন"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "আপনার ক্রমাঙ্কন ডিভাইসটিকে ক্রমাঙ্কিত অবস্থানে নিয়ে যান এবং \"চালিয়ে যান\" টিপুন"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "আপনার ক্রমাঙ্কন ডিভাইসটিকে পৃষ্ঠের অবস্থানে নিয়ে যান এবং \"চালিয়ে যান\" টিপুন"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "ল্যাপটপ লিড বন্ধ করুন"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "এক আভ্যন্তরীণ ত্রুটি দেখা দিয়েছে যা পুনরুদ্ধার করা যাবে না।"
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "ক্যালিব্রেশনের জন্য প্রয়োজনীয় সরঞ্জাম ইনস্টল করা নেই।"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "প্রোফাইল প্রস্তুত করা যাবে না।"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "টার্গেট হোয়াইটপয়েন্ট প্রাপ্তযোগ্য নয়।"
+
+#~ msgid "Complete!"
+#~ msgstr "সম্পন্ন!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "ক্যালিব্রেশন ব্যর্থ হয়েছে!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "আপনি ক্যালিব্রেশন ডিভাইস সরাতে পারেন।"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "কাজ চলছে এমন অবস্থায় ক্যালিব্রেশন ডিভাইসে হাত দেবেন না"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "ল্যাপটপ স্ক্রীন"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "অন্তর্ভুক্ত ওয়েবক্যাম"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s মনিটর"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s স্ক্রীনার"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s ক্যামেরা"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s প্রিন্টার"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s ওয়েবক্যাম"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s এর রঙ ব্যবস্থাপনা সক্ষম করুন"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s এর জন্য রঙের প্রোফাইল দেখান"
+
+#~ msgid "Not calibrated"
+#~ msgstr "ক্যালিব্রেট করা হয়নি"
+
+#~ msgid "Default: "
+#~ msgstr "ডিফল্ট: "
+
+#~ msgid "Test profile: "
+#~ msgstr "টেস্ট প্রোফাইল:"
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC প্রোফাইল ফাইল নির্বাচন করুন"
+
+#~ msgid "_Import"
+#~ msgstr "আমদানি করুন (_I)"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "সমর্থিত ICC প্রোফাইলসমূহ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "All files"
+#~ msgstr "সর্বধরনের ফাইল"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "ফাইল আপলোড করা গেল না: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "প্রোফাইল এখানে আপলোড করা হয়েছে:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "এই URLটি লিখে রাখুন।"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "এই কম্পিউটার রিস্টার্ট করুন এবং আপনার সাধারণ অপারেটিং সিস্টেম বুট করুন।"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "প্রোফাইল ডাউনলোড এবং ইনস্টল করতে URLটি আপনার ব্রাউজারে লিখুন।"
+
+#~ msgid "Save Profile"
+#~ msgstr "প্রোফাইল সংরক্ষণ করুন"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "নির্বাচিত ডিভাইসের জন্য একটি রঙ প্রোফাইল তৈরি করুন"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "পরিমাপের সরঞ্জাম সনাক্ত করা হয়নি। দয়া করে এটি যে চালু আছে এবং সঠিক ভাবে "
+#~ "সংযুক্ত তা দেখে নিন।"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "পরিমাপের যন্ত্র প্রিন্টার প্রোফাইলিঙের সুবিধা দেয় না।"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "ডিভাইস ধরন বর্তমানে সমর্থিত নয়।"
+
+#~ msgid "Upload profile"
+#~ msgstr "প্রোফাইল আপলোড করুন"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "ইন্টারনেট সংযোগের প্রয়োজন"
+
+#~ msgid "Standard Space"
+#~ msgstr "স্ট্যান্ডার্ড স্পেস"
+
+#~ msgid "Test Profile"
+#~ msgstr "টেস্ট প্রোফাইল"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "স্বয়ংক্রিয়"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "নিম্ন মানের"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "মাঝারি মানের"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "উচ্চ মানের"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "ডিফল্ট RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "ডিফল্ট CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "ডিফল্ট গ্রে"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "ভেন্ডার সরবরাহকৃত ফ্যাক্টরি ক্যালিব্রেশন ডেটা"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "এই প্রোফাইলের ক্ষেত্রে সম্পূর্ণ স্ক্রীন প্রদর্শন সংশোধন সম্ভব নয়"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "এই প্রোফাইল আর হয়তো যথাযথ নেই"
+
+#~ msgid "Other…"
+#~ msgstr "অন্যান্য..."
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "সেটিংস পরিবর্তন করতে আনলক করুন"
+
+# auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
+#~ msgid "_Copy"
+#~ msgstr "অনুলিপি(_C)"
+
+#~ msgid "Select _All"
+#~ msgstr "সমস্ত নির্বাচন করুন(_A)"
+
+#~ msgid "Today"
+#~ msgstr "আজ"
+
+#~ msgid "Yesterday"
+#~ msgstr "গতকাল"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d ঘন্টা"
+#~ msgstr[1] "%d ঘন্টায়"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d মিনিট"
+#~ msgstr[1] "%d মিনিটে"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d সেকেন্ড"
+#~ msgstr[1] "%d সেকেন্ড"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "হটস্পট"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "24-hour"
+#~ msgstr "২৪ ঘন্টা"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "প্রযুক্তিগত সমস্যার প্রতিবেদন পাঠানো আমাদের %s উন্নত করতে সহায়তা করে। "
+#~ "প্রতিবেদনগুলি বেনামে পাঠানো হয় এবং ব্যক্তিগত ডেটা স্ক্র্যাব করা হয়। %s"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "পরিবর্তনগুলি প্রয়োগ করবেন?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "পরিবর্তনগুলি প্রয়োগ করা যায় না"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "এটি হার্ডওয়্যার সীমাবদ্ধতার কারণে হতে পারে।"
+
+#~ msgid "Single Display"
+#~ msgstr "একক ডিসপ্লে"
+
+# auto translated by TM merge from project: virt-viewer, version: 0.5.7, DocId: virt-viewer
+#~ msgid "Join Displays"
+#~ msgstr "ডিসপ্লেগুলি যোগ করুন"
+
+#~ msgid "Display Mode"
+#~ msgstr "ডিসপ্লে ধরন"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "আপনার শারীরিক ডিসপ্লে সেটআপের সাথে মেলে ডিসপ্লেগুলি টেনে আনুন। এর সেটিংস "
+#~ "পরিবর্তন করতে একটি ডিসপ্লে নির্বাচন করুন।"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "ডিসপ্লে ব্যবস্থা"
+
+#~ msgid "Active Display"
+#~ msgstr "সক্রিয় ডিসপ্লে"
+
+#~ msgid "Display Configuration"
+#~ msgstr "ডিসপ্লে কনফিগারেশন"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "ল্যাণ্ডস্কেপ"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "ডানদিকে পোর্ট্রেট"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "বামদিকে পোর্ট্রেট"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "ল্যান্ডস্কেপ (উল্টানো)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "More Warm"
+#~ msgstr "আরও উষ্ণ"
+
+#~ msgid "Less Warm"
+#~ msgstr "কম উষ্ণ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Unknown"
+#~ msgstr "অজানা"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "৬৪-বিট"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "৩২-বিট"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "ওয়েল্যান্ড "
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "অজানা"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "$PICTURES এ একটি স্ক্রীনশট সংরক্ষণ করুন"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "একটি উইন্ডোর স্ক্রীনশট $PICTURES এ সংরক্ষণ করুন"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "কোনো অংশের স্ক্রীনশট $PICTURES এ সংরক্ষণ করুন"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "ক্লিপ-বোর্ডে একটি স্ক্রিন-শট কপি করুন"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "উইন্ডোর স্ক্রিন-শট ক্লিপ-বোর্ডে কপি করুন"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "একটি অঞ্চলের একটি স্ক্রীনশট ক্লিপবোর্ডে অনুলিপি করুন"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "একটি সংক্ষিপ্ত স্ক্রিনকাস্ট রেকর্ড করুন"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "অতিরিক্ত অক্ষর লিখতে বিকল্প অক্ষর কী ব্যবহার করা যেতে পারে। এগুলি কখনও কখনও "
+#~ "আপনার কীবোর্ডে তৃতীয় বিকল্প হিসাবে মুদ্রিত হয়।"
+
+#~ msgid "Left Alt"
+#~ msgstr "বাম Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "ডান Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "বাম সুপার"
+
+#~ msgid "Right Super"
+#~ msgstr "ডান সুপার"
+
+#~ msgid "Menu key"
+#~ msgstr "মেনু কী"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "ডান Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "বৈকল্পিক অক্ষর কী"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "পরবর্তী সোর্সে শুধুমাত্র-সংশোধক স্যুইচ"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "ডান Ctrl"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "মেনু কী "
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "বাম সুপার"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "ডান সুপার"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "বাম Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "ডান Alt"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "সমস্ত শর্টকাট পুনরায় সেট করবেন?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "শর্টকাটগুলি পুনরায় সেট করা আপনার কাস্টম শর্টকাটকে প্রভাবিত করতে পারে। এটা "
+#~ "অসম্পূর্ণ থাকতে পারে না."
+
+#~ msgid "Reset All"
+#~ msgstr "সব পুনরায় সেট করুন"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "ধরে রাখুন এবং বিভিন্ন অক্ষর লিখতে টাইপ করুন"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s ইতিমধ্যে %s এর জন্য ব্যবহৃত হচ্ছে। আপনি যদি এটি প্রতিস্থাপন করেন তবে %s অক্ষম "
+#~ "হয়ে যাবে"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "নতুন শর্টকাট প্রবেশ করান"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "কাস্টম শর্টকাট সেট করুন"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "%s পরিবর্তন করতে নতুন শর্টকাট প্রবেশ করান।"
+
+#~ msgid "Set"
+#~ msgstr "সেট"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "অবস্থান পরিষেবাদি অ্যাপ্লিকেশনগুলিকে আপনার অবস্থান জানার অনুমতি দেয়। ওয়াই-ফাই "
+#~ "এবং মোবাইল ব্রডব্যান্ড ব্যবহার করে সঠিকতা বাড়ায়।"
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "মজিলা অবস্থান পরিষেবা ব্যবহার করে: <a href='https://location.services."
+#~ "mozilla.com/privacy'>গোপনীয়তা নীতি</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "নীচের অ্যাপ্লিকেশনগুলিকে আপনার অবস্থান নির্ধারণ করার অনুমতি দিন।"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "স্ক্রীন বন্ধ হয়"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "৩০ সেকেন্ড"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "১ মিনিট"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "২ মিনিট"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "৩ মিনিট"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "৫ মিনিট"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "৩০ মিনিট"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "১ ঘন্টা"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "১ মিনিট"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "২ মিনিট"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "৩ মিনিট"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "৪ মিনিট"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "৫ মিনিট"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "৮ মিনিট"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "১০ মিনিট"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "১২ মিনিট"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "১৫ মিনিট"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "কখনও নয়"
+
+#~ msgid "Lock your screen"
+#~ msgstr "স্ক্রীন লক করুন"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "নীচের অ্যাপ্লিকেশনগুলিকে আপনার মাইক্রোফোনটি ব্যবহার করার অনুমতি দিন।"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "দুইবার ক্লিকের সময় সমাপ্ত"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "দুই আঙুলের স্ক্রোলিং"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "পাঁচ ক্লিক, GEGL সময়!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "দুইবার ক্লিক, প্রাথমিক বোতাম"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "একবার ক্লিক, প্রাথমিক বোতাম"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "দুইবার ক্লিক, মাঝের বোতাম"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "একবার ক্লিক, মাঝের বোতাম"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "দুইবার ক্লিক, অপ্রধান বোতাম"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "একবার ক্লিক, অপ্রধান বোতাম"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "নেটওয়ার্কম্যানেজারটি চলমান হওয়া দরকার।"
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "অনিরাপদ নেটওয়ার্ক (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "সুরক্ষিত নেটওয়ার্ক (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "সুরক্ষিত নেটওয়ার্ক (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "সুরক্ষিত নেটওয়ার্ক (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "সুরক্ষিত নেটওয়ার্ক"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "হটস্পটটি চালু করা %s থেকে সংযোগ বিচ্ছিন্ন হবে এবং ওয়াইফাই এর মাধ্যমে ইন্টারনেট "
+#~ "অ্যাক্সেস করা সম্ভব হবে না।"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "হটস্পট বন্ধ এবং কোনো ব্যবহারকারীকে সংযোগবিচ্ছিন্ন করবেন?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "হটস্পট থামান (_S)"
+
+#~ msgid "Preserve"
+#~ msgstr "সংরক্ষিত"
+
+#~ msgid "Permanent"
+#~ msgstr "স্থায়ী"
+
+#~ msgid "Random"
+#~ msgstr "এলোমেলো"
+
+#~ msgid "Stable"
+#~ msgstr "স্থিতিশীল"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "এখানে প্রবেশ করা ম্যাক ঠিকানাটি এই সংযোগটি সক্রিয় হওয়া নেটওয়ার্ক ডিভাইসের "
+#~ "হার্ডওয়্যার ঠিকানা হিসাবে ব্যবহৃত হবে। এই বৈশিষ্ট্যটি ম্যাক ক্লোনিং বা স্পোফিং "
+#~ "হিসাবে পরিচিত। উদাহরণ: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "প্রোফাইল %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "এন্টারপ্রাইজ "
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "কিছুই নয়"
+
+#~ msgid "Never"
+#~ msgstr "কখনও নয়"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "২.৪ GHz / ৫ GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "২.৪ GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "৫ GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "কিছুই নয়"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "দুর্বল"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ঠিক আছে"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "ভাল"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "দুর্দান্ত"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#~ msgid "Remove Connection Profile"
+#~ msgstr "সংযোগ প্রোফাইল সরান"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "Remove VPN"
+#~ msgstr "ভিপিএন সরান"
+
+#~ msgid "automatic"
+#~ msgstr "স্বয়ংক্রিয়"
+
+#~ msgid "Identity"
+#~ msgstr "পরিচয়"
+
+#~ msgid "Delete Route"
+#~ msgstr "রাউট মুছুন"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "কিছুই নয়"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-বিট কী (Hex বা ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-বিট পাসফ্রেজ"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "ডায়নামিক WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 ব্যক্তিগত"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 এন্টারপ্রাইজ"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 ব্যক্তিগত"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "সংযোগ সম্পাদক খোলা গেল না"
+
+#~ msgid "New Profile"
+#~ msgstr "নতুন প্রোফাইল"
+
+#~ msgid "Import from file…"
+#~ msgstr "ফাইল থেকে আমদানি করুন…"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN যোগ করুন"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN সংযোগ আমদানি করা যাবে না"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "\"%s\" ফাইলটি পড়া যায়নি বা স্বীকৃত ভিপিএন সংযোগের তথ্য ধারণ করে না\n"
+#~ "\n"
+#~ "ত্রুটি: %s"
+
+#~ msgid "Select file to import"
+#~ msgstr "আমদানি করার জন্য ফাইল নির্বাচন করুন"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "\"%s\" নামের একটি ফাইল ইতিমধ্যেই বিদ্যমান।"
+
+# auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
+#~ msgid "_Replace"
+#~ msgstr "প্রতিস্থাপন করুন (_R)"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "আপনি যে VPN সংযোগ সংরক্ষণ করছেন তা দিয়ে %s প্রতিস্থাপন করতে চান?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN সংযোগ রপ্তানি করা যাবে না"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN সংযোগ '%s' %s এ রপ্তানি করা যায়নি।\n"
+#~ "\n"
+#~ "ত্রুটি: %s।"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN সংযোগ রপ্তানি করুন"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "never"
+#~ msgstr "কখনো নয়"
+
+# auto translated by TM merge from project: gnome-system-log, version: 3.8.1, DocId: gnome-system-log
+#~ msgid "today"
+#~ msgstr "আজ"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgid "yesterday"
+#~ msgstr "গতকাল"
+
+#~ msgid "Last used"
+#~ msgstr "সর্বশেষ ব্যবহৃত"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "পাসওয়ার্ড সমেত নির্বাচিত নেটওয়ার্কগুলির নেটওয়ার্ক বিস্তারিত এবং যেকোনো কাস্টম "
+#~ "কনফিগারেশন হারিয়ে যাবে।"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "_Forget"
+#~ msgstr "মুছে ফেলা হবে (_F)"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "জানা ওয়াইফাই নেটওয়ার্কগুলি"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "মুছে ফেলা হবে (_F)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "হটস্পট হিসাবে ব্যবহার সিস্টেম নীতি নিষিদ্ধ করে"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "বেতার ডিভাইস হটস্পট মোড সমর্থন করে না"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Off"
+#~ msgstr "বন্ধ"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "কনফিগারেশন URL সরবরাহ করা না হলে ওয়েব প্রক্সি স্বয়ংক্রিয়-ডিসকভারি ব্যবহার করা "
+#~ "হয়।"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "অবিশ্বস্ত সর্বজনীন নেটওয়ার্কের ক্ষেত্রে এটি প্রস্তাবিত নয়।"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#~ msgid "Status unknown"
+#~ msgstr "স্ট্যাটাস অজানা"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#~ msgid "Unmanaged"
+#~ msgstr "অপরিচালিত"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#~ msgid "Unavailable"
+#~ msgstr "উপলব্ধ নয়"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#~ msgid "Connecting"
+#~ msgstr "সংযোগ করা হচ্ছে"
+
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#~ msgid "Authentication required"
+#~ msgstr "অনুমোদন আবশ্যক"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#~ msgid "Disconnecting"
+#~ msgstr "সংযোগ বিচ্ছিন্ন করা হচ্ছে"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#~ msgid "Connection failed"
+#~ msgstr "সংযোগ বিফল"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#~ msgid "Status unknown (missing)"
+#~ msgstr "স্ট্যাটাস অজানা (অনুপস্থিত)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "কনফিগারেশন করা যায়নি"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP কনফিগারেশন ব্যর্থ হয়েছে"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP কনফিগারেশনের মেয়াদ শেষ হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "গোপনীয় তথ্য আবশ্যক, কিন্তু উপলব্ধ নয়"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x সাপ্লিক্যান্টের সংযোগ বিচ্ছিন্ন করা হয়েছে"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x সাপ্লিক্যান্টের কনফিগারেশন বিফল হয়েছে"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x সাপ্লিক্যান্ট বিফল হয়েছে"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x সাপ্লিক্যান্ট অনুমোদন করতে অত্যাধিক সময় ব্যয় হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP পরিসেবা আরম্ভ করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP পরিসেবার সাথে সংযোগ বিচ্ছিন্ন হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "PPP failed"
+#~ msgstr "PPP বিফল"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP ক্লায়েন্ট আরম্ভ করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP ক্লায়েন্ট সংক্রান্ত ত্রুটি"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP ক্লায়েন্ট বিফল হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "যৌথরূপে ব্যবহৃত সংযোগ পরিসেবা আরম্ভ হতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Shared connection service failed"
+#~ msgstr "যৌথরূপে ব্যবহৃত পরিসেবা বিফল হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP পরিসেবা আরম্ভ করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP পরিসেবায় ত্রুটি"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP পরিসেবা বিফল"
+
+#~ msgid "Line busy"
+#~ msgstr "লাইন ব্যস্ত"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "No dial tone"
+#~ msgstr "ডায়েল টোন অনুপস্থিত"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "No carrier could be established"
+#~ msgstr "কোনো কেরিয়ার নির্ধারণ করা যায়নি"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "ডায়াল অনুরোধের সময় শেষ হয়ে গেছে"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "ডায়াল করার প্রচেষ্টা ব্যর্থ হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Modem initialization failed"
+#~ msgstr "মোডেম আরম্ভ করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "চিহ্নিত APN নির্বাচন করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Not searching for networks"
+#~ msgstr "নেটওয়ার্ক সন্ধান করা হচ্ছে না"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Network registration denied"
+#~ msgstr "নেটওয়ার্ক নিবন্ধন প্রত্যাখ্যান করা হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Network registration timed out"
+#~ msgstr "নেটওয়ার্ক নিবন্ধন করতে সময়সীমা উত্তীর্ণ হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "অনুরোধ করা নেটওয়ার্কে নিবন্ধন করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "PIN check failed"
+#~ msgstr "PIN পরীক্ষা করতে ব্যর্থ"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "অনুপস্থিত হতে পারে এমন ডিভাইসের ফার্মওয়্যার"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "সংযোগ চলে গেছে"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "বিদ্যমান সংযোগ ধরে নেওয়া হয়েছে"
+
+#~ msgid "Modem not found"
+#~ msgstr "মোডেম পাওয়া যায়নি"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ব্লুটুথ সংযোগ ব্যর্থ হয়েছে"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM পিন প্রয়োজনীয়"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM পুক প্রয়োজনীয়"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM ভুল"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "সংযোগ নির্ভরশীলতা ব্যর্থ হয়েছে"
+
+# auto translated by TM merge from project: gnome-getting-started-docs, version: 3.8.3.0.1, DocId: gnome-getting-started-docs
+#~ msgid "Cable unplugged"
+#~ msgstr "কেবল বিচ্ছিন্ন করা হয়েছে"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "802.1X সুরক্ষা (ডাব্লুপিএ-এপ) এ অপরিজ্ঞাত ত্রুটি"
+
+#~ msgid "no file selected"
+#~ msgstr "কোনও ফাইল নির্বাচিত হয়নি"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "Eap-পদ্ধতি ফাইলটি বৈধকরণে অনির্দিষ্ট ত্রুটি"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "DER, PEM, বা PKCS#12 ব্যক্তিগত কী (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER বা PEM শংসাপত্র (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "EAP-FAST PAC ফাইল অনুপস্থিত"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ফাইল (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "EAP-LEAP ব্যবহারকারীর নাম অনুপস্থিত"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "EAP-LEAP পাসওয়ার্ড অনুপস্থিত"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "অবৈধ EAP-PEAP CA শংসাপত্র: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "অবৈধ EAP-PEAP CA শংসাপত্র: কোনও শংসাপত্র নির্দিষ্ট করা হয়নি"
+
+#~ msgid "missing EAP username"
+#~ msgstr "EAP ব্যবহারকারীর নাম অনুপস্থিত"
+
+#~ msgid "missing EAP password"
+#~ msgstr "EAP পাসওয়ার্ড অনুপস্থিত"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "EAP-TLS পরিচয় অনুপস্থিত"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "অবৈধ EAP-TLS CA শংসাপত্র: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "অবৈধ EAP-TLS CA শংসাপত্র: কোনও শংসাপত্র নির্দিষ্ট করা হয়নি"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "অবৈধ EAP-TLS ব্যক্তিগত-কী: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "অবৈধ EAP-TLS ব্যবহারকারীর শংসাপত্র: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "এনক্রিপ্ট না করা ব্যক্তিগত কী অনিরাপদ"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "নির্বাচিত ব্যক্তিগত কী কোনও পাসওয়ার্ড দ্বারা সুরক্ষিত বলে মনে হয় না। এটি আপনার "
+#~ "সুরক্ষা শংসাপত্রগুলিকে আপস করার অনুমতি দিতে পারে। দয়া করে একটি পাসওয়ার্ড-সুরক্ষিত "
+#~ "ব্যক্তিগত কী নির্বাচন করুন।\n"
+#~ "\n"
+#~ "(আপনি ওপেনএসএল দিয়ে আপনার ব্যক্তিগত কী পাসওয়ার্ড-সুরক্ষা রাখতে পারবেন)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "আপনার ব্যক্তিগত শংসাপত্র বাছুন"
+
+#~ msgid "Choose your private key"
+#~ msgstr "আপনার ব্যক্তিগত কী বাছুন"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "অবৈধ EAP-TTLS CA শংসাপত্র: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "অবৈধ EAP-TTLS CA শংসাপত্র: কোনও শংসাপত্র নির্দিষ্ট করা হয়নি"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "802.1X সুরক্ষা বৈধকরণে অজানা ত্রুটি"
+
+#~ msgid "missing leap-username"
+#~ msgstr "লিপ-ব্যবহারকারীর নাম অনুপস্থিত"
+
+#~ msgid "missing leap-password"
+#~ msgstr "লিপ-পাসওয়ার্ড অনুপস্থিত"
+
+#~ msgid "missing wep-key"
+#~ msgstr "ওয়েপ-কি অনুপস্থিত"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr "অবৈধ ওয়েপ-কী: %zu দৈর্ঘ্যের কীটিতে অবশ্যই হেক্স-সংখ্যা থাকতে হবে"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr "অবৈধ ওয়েপ-কী: %zu দৈর্ঘ্যের কীটিতে অবশ্যই আসকি অক্ষর থাকতে হবে"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "অবৈধ ওয়েপ-কী: ভুল কী দৈর্ঘ্য %zu। একটি কী দৈর্ঘ্যের 5/13 (ascii) বা 10/26 "
+#~ "(হেক্স) এর হতে হবে"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "অবৈধ ওয়েপ-কী: পাসফ্রেজ অবশ্যই খালি থাকতে হবে"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "অবৈধ ওয়েপ-কী: পাসফ্রেজটি ৬৪ টি অক্ষরের চেয়ে কম হওয়া উচিত"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "অবৈধ ডাব্লুপিএ-পিএসকি: অবৈধ কী-দৈর্ঘ্য %zu। অবশ্যই [৮,৬৩] বাইট বা ৬৪ হেক্স "
+#~ "অঙ্কের হতে হবে"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "অবৈধ ডাব্লুপিএ-পিএসকি: ৬৪ বাইটকে হেক্স হিসাবে কী ব্যাখ্যা করতে পারে না"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "On"
+#~ msgstr "চালু"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "অন্যান্য"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s এর অ্যাকাউন্ট"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "Error removing account"
+#~ msgstr "অ্যাকাউন্ট অপসারণের করার সময় ত্রুটি"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s সরানো হয়েছে"
+
+#~ msgid "Remove Account"
+#~ msgstr "অ্যাকাউন্ট সরান"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Unknown time"
+#~ msgstr "অজানা সময়"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "চার্জ পূর্ণ হতে %s বাকি"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "সর্তকতা: %s বাকি আছে"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s বাকি আছে"
+
+#~ msgid "Fully charged"
+#~ msgstr "সম্পূর্ণ চার্জ রয়েছে"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Not charging"
+#~ msgstr "চার্জ করা হচ্ছে না"
+
+# auto translated by TM merge from project: RHEL Installation Guide, version: 6.0, DocId: Partitions-x86
+#~ msgid "Empty"
+#~ msgstr "খালি"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Charging"
+#~ msgstr "ব্যাটারি চার্জ করা হচ্ছে"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Discharging"
+#~ msgstr "ব্যাটারি ব্যবহার করা হচ্ছে"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "প্রধান"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "অতিরিক্ত"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "বেতার মাউস"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "বেতার কীবোর্ড"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "নিরবিচ্ছিন্ন বিদ্যুত সরবরাহ"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "ব্যক্তিগত ডিজিট্যাল সহায়ক"
+
+#~ msgid "Cellphone"
+#~ msgstr "সেলফোন"
+
+#~ msgid "Media player"
+#~ msgstr "মিডিয়া প্লেয়ার"
+
+# auto translated by TM merge from project: gvfs, version: 1.16.3, DocId: gvfs
+#~ msgid "Computer"
+#~ msgstr "কম্পিউটার"
+
+#~ msgid "Gaming input device"
+#~ msgstr "গেমিং ইনপুট ডিভাইস"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "ব্যাটারি চার্জ করা হচ্ছে"
+
+# auto translated by TM merge from project: gnome-doc-utils, version: 0.20.10, DocId: gnome-doc-utils
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "সতর্কতা"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "নিচু"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "ভাল"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "সম্পূর্ণ চার্জ রয়েছে"
+
+# auto translated by TM merge from project: RHEL Installation Guide, version: 6.0, DocId: Partitions-x86
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "খালি"
+
+#~ msgid "Batteries"
+#~ msgstr "ব্যাটারিগুলি"
+
+#~ msgid "When _idle"
+#~ msgstr "নীরব অবস্থায় (_i)"
+
+#~ msgid "Suspend"
+#~ msgstr "নিম্বিত করুন"
+
+# auto translated by TM merge from project: gnome-shell-extensions, version: 3.8.3, DocId: gnome-shell-extensions
+#~ msgid "Power Off"
+#~ msgstr "বন্ধ করুন"
+
+# auto translated by TM merge from project: gnome-shell-extensions, version: 3.8.3, DocId: gnome-shell-extensions
+#~ msgid "Hibernate"
+#~ msgstr "নিদ্রিত অবস্থা"
+
+#~ msgid "Nothing"
+#~ msgstr "কিছু নয়"
+
+#~ msgid "When on battery power"
+#~ msgstr "যখন ব্যাটারি পাওয়ার চালু"
+
+#~ msgid "When plugged in"
+#~ msgstr "প্লাগইন অবস্থায়"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "স্ক্রীন উজ্জ্বলতা (_S)"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "কীবোর্ড উজ্জ্বলতা (_K)"
+
+#~ msgid "_Dim Screen When Inactive"
+#~ msgstr "নিষ্ক্রিয় অবস্থায় আবছা স্ক্রীন (_D)"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "খালি স্ক্রীন (_B)"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "স্বয়ংক্রিয় বিলম্ব"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "পাওয়ার বাঁচাতে Wi-Fi বন্ধ করা যেতে পারে।"
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "মোবাইল ব্রডব্যান্ড (এলটিই, ৪ জি, ৩ জি, ইত্যাদি) পাওয়ার সাশ্রয় করতে বন্ধ করা "
+#~ "যেতে পারে।"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "ব্লুটুথ (_B)"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "পাওয়ার বাঁচাতে ব্লুটুথ বন্ধ করা যেতে পারে।"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "বিলম্বিত এবং পাওয়ার বন্ধ করুন"
+
+#~ msgid " "
+#~ msgstr " "
+
+# auto translated by TM merge from project: polkit-gnome, version: 0.105, DocId: polkit-gnome-1
+#~ msgid "Authenticate"
+#~ msgstr "অনুমোদন"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "প্রিন্টার \"%s\" মুছে ফেলা হয়েছে"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "নতুন প্রিন্টার যোগ করতে ব্যর্থ।"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui লোড করতে ব্যর্থ: %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "কোনো উপযুক্ত ড্রাইভার পাওয়া যায়নি"
+
+#~ msgid "Select PPD File"
+#~ msgstr "PPD ফাইল নির্বাচন করুন"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript প্রিন্টার উল্লেখকারী ফাইল (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect প্রিন্টার"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD প্রিন্টার"
+
+#~ msgid "One Sided"
+#~ msgstr "একপার্শ্বিক"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "দীর্ঘ প্রান্ত (প্রমিত মান)"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "ক্ষুদ্র প্রান্ত (উলট)"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Portrait"
+#~ msgstr "প্রতিকৃতি"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Landscape"
+#~ msgstr "ভূদৃশ্য"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Reverse landscape"
+#~ msgstr "বিপরীত ভূদৃশ্য"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Reverse portrait"
+#~ msgstr "বিপরীত প্রতিকৃতি"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "অসমাপ্ত কর্ম"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "থেমে আছে"
+
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "অনুমোদন আবশ্যক"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "কর্মরত"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "স্থগিত"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "বাতিল করা"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4312-85999
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "পরিত্যক্ত"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "সমাপ্ত"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — সক্রিয় কাজগুলি"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "%s থেকে প্রিন্ট করতে পরিচয়পত্র লিখুন।"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "আনলক প্রিন্ট সার্ভার"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s আনলক করুন।"
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "%s এ প্রিন্টারগুলি দেখতে ব্যবহারকারী নাম এবং পাসওয়ার্ড লিখুন।"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Searching for Printers"
+#~ msgstr "প্রিন্টার অনুসন্ধান করা হচ্ছে"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "সিরিয়াল পোর্ট"
+
+#~ msgid "Parallel Port"
+#~ msgstr "সমান্তরাল পোর্ট"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "অবস্থান: %s"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "ঠিকানা: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "সার্ভারের প্রমাণীকরণের প্রয়োজন"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Two Sided"
+#~ msgstr "উভয়পৃষ্ঠ"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Paper Type"
+#~ msgstr "কাগজের ধরন"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Paper Source"
+#~ msgstr "কাগজের সংগ্রহস্থল"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Output Tray"
+#~ msgstr "আউটপুট-ট্রে"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "রেসলোলিউশন"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript প্রি-ফিল্টারিং"
+
+#~ msgid "Pages per side"
+#~ msgstr "প্রতি পার্শ্বে পৃষ্ঠা"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Orientation"
+#~ msgstr "সজ্জা"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "সাধারণ"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "পৃষ্ঠার বৈশিষ্ট্য"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "ইনস্টল করার যোগ্য বিকল্প"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "কর্ম"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "ছবির গুণমান"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "রঙ"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "সমাপ্তি"
+
+#~ msgid "Test page"
+#~ msgstr "পরীক্ষা পৃষ্ঠা"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Auto Select"
+#~ msgstr "স্বয়ংক্রিয় নির্বাচন"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Printer Default"
+#~ msgstr "প্রিন্টারের ডিফল্ট মান"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "শুধুমাত্র GhostScript ফন্ট এমবেড করা হবে"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS লেভেল ১-এ রূপান্তর করা হবে"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS লেভেল ২-এ রূপান্তর করা হবে"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#~ msgid "No pre-filtering"
+#~ msgstr "প্রি-ফিল্টারিং বিহীন"
+
+#~ msgid "Clean print heads"
+#~ msgstr "প্রিন্টারের হেড পরিষ্কার করুন"
+
+#~ msgid "Out of toner"
+#~ msgstr "টোনার শেষ"
+
+#~ msgid "Low on developer"
+#~ msgstr "ডেভেলপার কম"
+
+#~ msgid "Out of developer"
+#~ msgstr "ডেভেলপার শেষ"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "মার্কার সরবরাহ কম"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Out of a marker supply"
+#~ msgstr "মার্কার সরবরাহ শেষ হয়ে গেছে"
+
+#~ msgid "Open cover"
+#~ msgstr "মুক্ত আবরণ"
+
+#~ msgid "Open door"
+#~ msgstr "মুক্ত দরজা"
+
+#~ msgid "Low on paper"
+#~ msgstr "কাগজ কম"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgid "Out of paper"
+#~ msgstr "কাগজ নেই"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "অফলাইন"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "থামানো হয়েছে"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "আবর্জনা পাত্র প্রায় পূর্ণ"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "আবর্জনা পাত্র পূর্ণ"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "অপটিক্যাল ফোটো কনডাকটরের আয়ু প্রায় শেষ হয় এসেছে"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "অপটিক্যাল ফোটো কনডাকটার আর কাজ করছে না"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "প্রস্তুত"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "কাজ নিচ্ছে না"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "কর্মরত"
+
+#~ msgid "Add…"
+#~ msgstr "যোগ..."
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ইম্পিরিয়াল"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "মেট্রিক"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "সংখ্যা, তিথি এবং মুদ্রার জন্য ফর্ম্যাটটি চয়ন করুন। পরিবর্তনগুলি পরবর্তী লগইনে "
+#~ "কার্যকর হয়।"
+
+#~ msgid "No input sources found"
+#~ msgstr "কোনো ইনপুট সোর্স পাওয়া যায়নি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "অন্যান্য"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "পরিবর্তনগুলি কার্যকর হওয়ার জন্য সেশনটি পুনরায় চালু করুন"
+
+#~ msgid "Restart…"
+#~ msgstr "পুনরারম্ভ করুন"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "সিস্টেমে লগিন করার সময়ে সকল ব্যবহারকারীর দ্বারা লগিন সেটিং ব্যবহার করা হয়"
+
+#~ msgid "Previous source"
+#~ msgstr "পূর্ববর্তী উত্স"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "Next source"
+#~ msgstr "পরবর্তী উত্স"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Left+Right Alt"
+
+#~ msgid "These keyboard shortcuts can be changed in the keyboard settings"
+#~ msgstr "আপনি কীবোর্ড সেটিং থেকে এই শর্টকাটগুলি পরিবর্তন করতে পারবেন"
+
+#~ msgid "Ask what to do"
+#~ msgstr "কী করতে হবে আমাকে জিজ্ঞাসা করুন"
+
+#~ msgid "Do nothing"
+#~ msgstr "কিছু নয়"
+
+#~ msgid "Open folder"
+#~ msgstr "ফোল্ডার খুলুন"
+
+#~ msgid "Other Media"
+#~ msgstr "অন্যান্য মিডিয়া"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "অডিও CD'র জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "ভিডিও DVD'র জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "একটি মিউজিক প্লেয়ার সংযুক্ত অবস্থায় চালানোর জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "একটি ক্যামেরা সংযুক্ত অবস্থায় চালানোর জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "সফ্টওয়্যার CD'র জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#~ msgid "audio DVD"
+#~ msgstr "অডিও DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "খালি Blu-ray ডিস্ক"
+
+#~ msgid "blank CD disc"
+#~ msgstr "খালি CD ডিস্ক"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "খালি DVD ডিস্ক"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "খালি HD DVD ডিস্ক"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray ভিডিও ডিস্ক"
+
+#~ msgid "e-book reader"
+#~ msgstr "ই-বই রিডার"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD ভিডিও ডিস্ক"
+
+# auto translated by TM merge from project: nautilus, version: 3.8.2, DocId: nautilus
+#~ msgid "Picture CD"
+#~ msgstr "ছবি CD"
+
+# auto translated by TM merge from project: nautilus, version: 3.8.2, DocId: nautilus
+#~ msgid "Super Video CD"
+#~ msgstr "সুপার ভিডিও CD"
+
+# auto translated by TM merge from project: nautilus, version: 3.8.2, DocId: nautilus
+#~ msgid "Video CD"
+#~ msgstr "ভিডিও CD"
+
+#~ msgid "Select Location"
+#~ msgstr "অবস্থান নির্বাচন করুন"
+
+#~ msgid "_OK"
+#~ msgstr "ঠিক আছে (_O)"
+
+#~ msgid "No applications found"
+#~ msgstr "কোনো অ্যাপ্লিকেশন পাওয়া যায়নি"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "ক্রিয়াকলাপ ওভারভিউতে কোন অনুসন্ধান ফলাফল দেখানো হয়েছে তা নিয়ন্ত্রণ করুন। "
+#~ "তালিকায় সারি সরিয়েও অনুসন্ধানের ফলাফলের ক্রম পরিবর্তন করা যেতে পারে।"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "ভাগ করার জন্য কোনো নেটওয়ার্ক নির্বাচন করা হয়নি"
+
+# auto translated by TM merge from project: control-center, version: 3.8.3, DocId: gnome-control-center-2.0
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "চালু"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "বন্ধ"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "সক্রিয়"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "একটি ফোল্ডার বাছুন"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "ফাইল ভাগ করে নেওয়া আপনাকে: আপনার বর্তমান নেটওয়ার্কে অন্যদের সাথে আপনার "
+#~ "পাবলিক ফোল্ডারটি ভাগ করে নিতে মঞ্জুরি দেয়: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "যখন রিমোট লগইন সক্ষম থাকে তখন দূরবর্তী ব্যবহারকারীরা সিকিউর শেল কমান্ডটি "
+#~ "ব্যবহার করে সংযোগ করতে পারেন:\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "স্ক্রিন ভাগ করে নেওয়া দূরবর্তী ব্যবহারকারীদের %s এর সাথে সংযুক্ত হয়ে আপনার "
+#~ "স্ক্রিনটি দেখতে বা নিয়ন্ত্রণ করতে দেয়"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "স্ক্রীন ভাগ (_S)"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "কোনো নেটওয়ার্ক অ্যাক্সেস না থাকায় কিছু পরিষেবাদি নিষ্ক্রিয় করা হয়েছে।"
+
+# auto translated by TM merge from project: gnome-boxes, version: 3.8.3, DocId: gnome-boxes
+#~ msgid "_Password:"
+#~ msgstr "পাসওয়ার্ড (_P):"
+
+#~ msgid "_Show Password"
+#~ msgstr "পাসওয়ার্ড দেখান (_S)"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "নতুন সংযোগগুলিকে অবশ্যই অ্যাক্সেস চাইতে হবে (_N)"
+
+#~ msgid "_Require a password"
+#~ msgstr "একটি পাসওয়ার্ডের প্রয়োজন(_R)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Custom"
+#~ msgstr "স্বনির্ধারিত"
+
+#~ msgid "Bark"
+#~ msgstr "বার্ক"
+
+#~ msgid "Drip"
+#~ msgstr "ড্রিপ"
+
+#~ msgid "Glass"
+#~ msgstr "গ্লাস"
+
+#~ msgid "Sonar"
+#~ msgstr "সোনার"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s পরীক্ষা করা হচ্ছে"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "১০০%"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "সংযোগ বিচ্ছিন্ন করা হয়েছে"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "সংযোগ করা হচ্ছে"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "সংযুক্ত"
+
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "অনুমোদনের ত্রুটি"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "অনুমোদিত করছে"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "হ্রাস করা কার্যকারিতা"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "সংযুক্ত ও অনুমোদিত"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "অজানা"
+
+#~ msgid "Authorized at:"
+#~ msgstr "অনুমোদিত হয়েছিল:"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#~ msgid "Connected at:"
+#~ msgstr "সংযুক্ত হয়েছে:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "নিবন্ধিত হয়েছে:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "ডিভাইস অনুমোদিত করতে ব্যর্থ:"
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "ডিভাইস ভুলে যেতে ব্যর্থ:"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "ত্রুটি"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "অনুমোদিত"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "থান্ডারবোল্ট সাবসিস্টেম (boltd) ইনস্টল করা হয়নি বা সঠিকভাবে সেট আপ করা হয়নি।"
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "থান্ডারবোল্ট সনাক্ত করা যায়নি।\n"
+#~ "হয় সিস্টেমটিতে থান্ডারবোল্ট সমর্থনের অভাব রয়েছে, এটি BIOS এ অক্ষম করা হয়েছে বা "
+#~ "BIOS- এ অসমর্থিত সুরক্ষা স্তরে সেট করা আছে।"
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "বায়োস-এ থান্ডারবোল্ট সমর্থন অক্ষম করা হয়েছে।"
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "থান্ডারবোল্ট সুরক্ষা স্তর নির্ধারণ করা যায়নি।"
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "প্রত্যক্ষ মোডে স্যুইচ করার সময় ত্রুটি: %s"
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "কেবল ইউএসবি এবং ডিসপ্লে পোর্ট ডিভাইস সংযুক্ত করতে পারে।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "ডিফল্ট"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "মাঝারি"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "বৃহৎ"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "আরো বড়"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "বৃহৎ"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d টি পিক্সেল "
+#~ msgstr[1] "%d পিক্সেল"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#~ msgid "Screen Reader"
+#~ msgstr "স্ক্রীন রিডার"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#~ msgid "_Screen Reader"
+#~ msgstr "স্ক্রীন রিডার (_S)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Sound Keys"
+#~ msgstr "শব্দ কি"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "সংক্ষিপ্ত"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ স্ক্রীন"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ স্ক্রীন"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ স্ক্রীন"
+
+# auto translated by TM merge from project: control-center, version: 3.8.6, DocId: gnome-control-center-2.0
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "লম্বা"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "ট্র্যাশ সম্পূর্ণ খালি করবেন?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "ট্র্যাশের সবকিছু সম্পূর্ণ ভাবে মুছে যাবে।"
+
+#~ msgid "_Empty Trash"
+#~ msgstr "ট্র্যাশ খালি করুন (_E)"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "সকল অস্থায়ী ফাইল মুছবেন?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "সকল অস্থায়ী ফাইল সম্পূর্ণ ভাবে মুছে যাবে।"
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "অস্থায়ী ফাইলগুলি পার্জ করুন (_P)"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "১ ঘন্টা"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "১ দিন"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "২ দিন"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "৩ দিন"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "৪ দিন"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "৫ দিন"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "৬ দিন"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "৭ দিন"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "১৪ দিন"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "৩০ দিন"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "১ দিন"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "৭ দিন"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "৩০ দিন"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "অনন্তকাল"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "আপনার অ্যাকাউন্ট সরবরাহকারীর ওয়েব ঠিকানা মিলতে হবে।"
+
+#~ msgid "Failed to add account"
+#~ msgstr "অ্যাকাউন্ট যোগ করতে ব্যর্থ"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "Failed to register account"
+#~ msgstr "অ্যাকাউন্ট রেজিস্টার করতে ব্যর্থ"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "এই ডোমেন দিয়ে পরিচয়প্রমাণের কোনো সমর্থিত মাধ্যম নেই"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "Failed to join domain"
+#~ msgstr "ডোমেন এ যোগদান করতে ব্যর্থ"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "প্রদত্ত লগিন নামটি কাজ করেনি।\n"
+#~ "দয়া করে আবার চেষ্টা করুন।"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "প্রদত্ত লগিন পাসওয়ার্ডটি কাজ করেনি।\n"
+#~ "দয়া করে আবার চেষ্টা করুন।"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "Failed to log into domain"
+#~ msgstr "ডোমেনে লগ ইন করতে ব্যর্থ"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "ডোমেন খুঁজে পাওয়া যায়নি। হতে পারি আপনি বানান ভুল করেছেন?"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgid "Standard"
+#~ msgstr "সাধারণ"
+
+#~ msgid "Account _Type"
+#~ msgstr "অ্যাকাউন্ট ধরন (_T)"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "ব্যবহারকারী যখন পরের বার লগইন করবেন তখন তাকে একটি পাসওয়ার্ড সেট করার অনুমতি "
+#~ "দিন (_l)"
+
+#~ msgid "Set a password _now"
+#~ msgstr "এখনই একটি পাসওয়ার্ড সেট করুন(_n)"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "এন্টারপ্রাইজ ব্যবহারকারীদের যুক্ত করতে আপনাকে অবশ্যই অনলাইনে থাকতে হবে।"
+
+# auto translated by TM merge from project: gnome-contacts, version: 3.8.2, DocId: gnome-contacts
+#~ msgid "Browse for more pictures"
+#~ msgstr "আরো ছবির জন্য ব্রাউজ করুন"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "একটি ফোটো তুলুন…"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "এই আঙুলটি পুনরায় তালিকাভুক্ত করুন(_R)..."
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "আঙুলের ছাপগুলি তালিকা করতে ব্যর্থ: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "সংরক্ষিত আঙ্গুলের ছাপগুলি মুছতে ব্যর্থ: %s"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Left thumb"
+#~ msgstr "বাঁহাতের বৃদ্ধাঙ্গুলি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Left middle finger"
+#~ msgstr "বাঁহাতের মধ্যমা"
+
+#~ msgid "_Left index finger"
+#~ msgstr "বাম ইনডেক্স ফিংগার (_L)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Left ring finger"
+#~ msgstr "বাঁহাতের অনামিকা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Left little finger"
+#~ msgstr "বাঁহাতের কনিষ্ঠা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Right thumb"
+#~ msgstr "ডান হাতের বৃদ্ধাঙ্গুলি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Right middle finger"
+#~ msgstr "ডান হাতের মধ্যমা"
+
+#~ msgid "_Right index finger"
+#~ msgstr "ডান ইনডেক্স ফিংগার (_R)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Right ring finger"
+#~ msgstr "ডান হাতের অনামিকা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Right little finger"
+#~ msgstr "ডান হাতের কনিষ্ঠা"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Unknown Finger"
+#~ msgstr "অজানা আঙ্গুল"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "সম্পন্ন"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস সংযোগ বিচ্ছিন্ন"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস স্টোরেজ পূর্ণ"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "নতুন আঙুলের ছাপ নিবন্ধন করতে ব্যর্থ"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "তালিকাভুক্তি শুরু করতে ব্যর্থ: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "নতুন আঙুলের ছাপ নিবন্ধন করতে ব্যর্থ"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "তালিকাভুক্তি বন্ধ করতে ব্যর্থ: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "আপনার আঙুলের ছাপটি তালিকাভুক্ত করতে বারবার আপনার আঙ্গুলটি পাঠকের উপরে তুলুন এবং "
+#~ "রাখুন"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "নতুন আঙুলের ছাপ স্ক্যান করুন"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "%s ফিঙ্গারপ্রিন্ট ডিভাইস প্রকাশ করতে ব্যর্থ: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "পড়ার যন্ত্রতে সমস্যা"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস %s দাবি করতে ব্যর্থ: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "ফিঙ্গারপ্রিন্ট ডিভাইসগুলি পেতে ব্যর্থ: %s"
+
+#~ msgid "This Week"
+#~ msgstr "এই সপ্তাহে"
+
+#~ msgid "Last Week"
+#~ msgstr "গত সপ্তাহে"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "সেশন সমাপ্ত হয়েছে"
+
+#~ msgid "Session Started"
+#~ msgstr "সেশন শুরু হয়েছে"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — অ্যাকাউন্ট ক্রিয়াকলাপ"
+
+#~ msgid "Please choose another password."
+#~ msgstr "দয়া করে অপর একটি পাসওয়ার্ড বাছুন।"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "দয়া করে আপনার বর্তমান পাসওয়ার্ড আবার টাইপ করুন।"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "পাসওয়ার্ড পরিবর্তন করা যাবে না"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "এই ধরনের ডোমেনে স্বয়ংক্রিয়ভাবে যোগ দেওয়া যায় না"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "No such domain or realm found"
+#~ msgstr "এমন কোন ডোমেন বা রিলম পাওয়া যায়নি"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s হিসেবে %s ডোমেনে লগইন করা সম্ভব হচ্ছে না"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "Invalid password, please try again"
+#~ msgstr "অবৈধ পাসওয়ার্ড, পুনরায় চেষ্টা করুন"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ব্যবহারকারী মুছতে ব্যর্থ"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "দূরবর্তীভাবে পরিচালিত ব্যবহারকারীকে প্রত্যাহার করতে ব্যর্থ"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "আপনি আপনার নিজের অ্যাকাউন্ট মুছতে পারবেন না।"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s এখনও লগিন আছে"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "কোনো ব্যবহারকারীকে তার লগিন থাকা অবস্থাতেই মুছে ফেলা হলে, সিস্টেম অধারাবাহিক "
+#~ "অবস্থায় চলে যেতে পারে।"
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "আপনি কি %s'র ফাইলগুলি রাখতে চান?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "একটি ব্যবহারকারী অ্যাকাউন্ট মোছার সময়ে হোম ডিরেক্টরি, মেল স্পুল এবং অস্থায়ী "
+#~ "ফাইলগুলি হাতের কাছে রাখা সম্ভব।"
+
+#~ msgid "_Delete Files"
+#~ msgstr "ফাইলগুলি মুছুন (_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "ফাইলগুলি রাখুন (_K)"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "আপনি কি নিশ্চিত যে দূরবর্তীভাবে পরিচালিত %s এর অ্যাকাউন্টটি বাতিল করতে চান?"
+
+#~ msgid "_Delete"
+#~ msgstr "মুছুন (_D)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "অ্যাকাউন্ট নিষ্ক্রিয়"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "পরবর্তী লগিনো সেট করা হবে"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "শূণ্য"
+
+#~ msgid "Logged in"
+#~ msgstr "লগিন করা হয়েছে"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "অ্যাকাউন্ট পরিষেবায় যোগাযোগ করতে ব্যর্থ"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "দয়া করে নিশ্চিত করুন যে, AccountService ইনস্টল করা এবং সক্রিয় করা হয়েছে।"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "পরিবর্তনগুলি করতে,\n"
+#~ "প্রথমে * আইকন ক্লিক করুন"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "নির্বাচিত ব্যবহারকারী অ্যাকাউন্ট মুছুন"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "নির্বাচিত ব্যবহারকারী অ্যাকাউন্ট মুছতে,\n"
+#~ "প্রথমে * আইকনে ক্লিক করুন"
+
+#~ msgid "Create a user account"
+#~ msgstr "একটি ব্যবহারকারী অ্যাকাউন্ট তৈরি করুন"
+
+#~ msgid "User Icon"
+#~ msgstr "ব্যবহারকারী আইকন"
+
+#~ msgid "Account Settings"
+#~ msgstr "অ্যাকাউন্ট সেটিংস"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "প্রমাণীকরণ এবং লগইন"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "লগিন;নাম;ফিংগারপ্রিন্ট;অবতার;লোগো;ফেস;পাসওয়ার্ড;"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "নতুন পাসওয়ার্ডটি পুরানো পাসওয়ার্ডের থেকে আলাদা হতে হবে।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "কিছু অক্ষর এবং সংখ্যা পরিবর্তন করে চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "পাসওয়ার্ডটি অনেকটা বদলে চেষ্টা করুন"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "আপনার ব্যবহারকারী নাম ছাড়া কোনো পাসওয়ার্ড শক্তিশালী হবে।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "পাসওয়ার্ডে নিজের নাম ব্যবহার না করাই ভালো।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "পাসওয়ার্ডে অন্তর্ভুক্ত কিছু শব্দ এড়িয়ে যাওয়ার চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "সাধারণ শব্দ এড়িয়ে যাওয়ার চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "বিদ্যমান শব্দ আবার সাজানো এড়িয়ে যাওয়ার চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "আরো সংখ্যা ব্যবহার করার চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "আরো বেশি সংখ্যাক বড় হাতের অক্ষর ব্যবহার করার চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "আরো বেশি সংখ্যক ছোট হাতের অক্ষর ব্যবহার করার চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "যতিচিহ্নের মতো আরো বিশেষ অক্ষর ব্যবহার করার চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "অক্ষর, সংখ্যা এবং যতিচিহ্ন মিলিয়েমিশিয়ে ব্যবহার করার চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "একই অক্ষর পুনরাবৃত্ত করা এড়িয়ে চলুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "একই ধরনের অক্ষর লেখা এড়িয়ে যাওয়ার চেষ্টা করুন: আপনাকে অক্ষর, সংখ্যা এবং "
+#~ "যতিচিহ্ন মিলিয়ে মিশিয়ে ব্যবহার করতে হবে।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 বা abcd-এর মতো ক্রম এড়িয়ে যাওয়ার চেষ্টা করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "পাসওয়ার্ড দীর্ঘ হওয়া দরকার। আরও অক্ষর, সংখ্যা এবং বিরামচিহ্ন যুক্ত করার চেষ্টা "
+#~ "করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "বড় এবং ছোট হাতের অক্ষর মিলিয়ে মিশিয়ে লিখুন এবং এক বা দুইটি সংখ্যা ব্যবহার করুন।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "আরও অক্ষর, সংখ্যা এবং বিরামচিহ্ন যুক্ত করা পাসওয়ার্ডকে শক্তিশালী করবে।"
+
+# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
+#~ msgid "Authentication failed"
+#~ msgstr "পরিচয় প্রমাণ করতে বিফল"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "নতুন পাসওয়ার্ড অত্যন্ত ছোট"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "নতুন পাসওয়ার্ড অত্যন্ত সরল"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "পুরনো এবং নতুন পাসওয়ার্ড প্রায় একই"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "নতুন পাসওয়ার্ড ইতিমধ্যেই সাম্প্রতিক সময়ে ব্যবহৃত হয়েছে।"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "নতুন পাসওয়ার্ডে অবশ্যই সাংখ্যিক বা বিশেষ অক্ষর থাকতে হবে"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "পুরনো এবং নতুন পাসওয়ার্ড একই"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "আপনার প্রারম্ভিক ভাবে প্রমাণীকরণের সময়ে আপনার পাসওয়ার্ড পরিবর্তিত হয়েছে!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "নতুন পাসওয়ার্ডে যথেষ্ট আলাদা আলাদা অক্ষর নেই"
+
+# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "অজানা ত্রুটি"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "ব্যবহারকারীর নামটিতে কেবলমাত্র a-z, অঙ্ক এবং নিম্নলিখিত বর্ণগুলি থেকে নিম্ন "
+#~ "বর্ণের অক্ষর থাকা উচিত: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "দুঃখিত, সেই ব্যবহারকারীর নামটি উপলভ্য নয়। অন্য চেষ্টা করুন।"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "The username is too long."
+#~ msgstr "ব্যবহারকারীর নাম অতিশয় দীর্ঘ।"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "এটি আপনার হোম ফোল্ডারের নামকরণ করতে ব্যবহৃত হবে এবং পরিবর্তন করা যাবে না।"
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "বোতাম %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "কীস্ট্রোক পাঠান"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "মনিটর পাল্টান"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "অন-স্ক্রীন সহায়তা দেখান"
+
+#~ msgid "Output:"
+#~ msgstr "আউটপুট:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "অ্যাসপেক্ট অনুমাত রাখুন (লেটারবক্স):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "একক মনিটরে ম্যাপ করুন"
+
+# auto translated by TM merge from project: sushi, version: 3.8.1, DocId: sushi
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d, %d এর"
+
+#~ msgid "Display Mapping"
+#~ msgstr "ম্যাপিং প্রদর্শন"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "ট্যাবলেট (চরম)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "ট্যাবলেট অগ্রাধিকার"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "_Help"
+#~ msgstr "সাহায্য (_H)"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ব্লু-টুথ সংক্রান্ত বৈশিষ্ট্য"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ট্র্যাকিং মোড"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "ম্যাপ বোতাম…"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#~ msgid "Adjust mouse settings"
+#~ msgstr "মাউস সংক্রান্ত বৈশিষ্ট্য সামজ্ঞস্যপূর্ণ করুন"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "প্রদর্শন রিজোলিউশন সামঞ্জস্যপূর্ণ করুন"
+
+#~ msgid "New shortcut…"
+#~ msgstr "নতুন শর্টকাট…"
+
+#~ msgid "No stylus found"
+#~ msgstr "কোনও স্টাইলাস পাওয়া যায় নি"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "এটির কনফিগার করতে দয়া করে আপনার স্টাইলাসটিকে ট্যাবলেটের সান্নিধ্যে স্থানান্তর "
+#~ "করুন"
+
+#~ msgid "Top Button"
+#~ msgstr "শীর্ষ বোতাম"
+
+#~ msgid "Lower Button"
+#~ msgstr "নিম্ন বোতাম"
+
+#~ msgid "Lowest Button"
+#~ msgstr "নিম্ন বোতাম"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "জিনোম সেটিংস"
+
+#~ msgid "Display version number"
+#~ msgstr "সংস্করণ নম্বর প্রদর্শন করুন"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "ভারবজ মোড সক্রিয় করুন"
+
+#~ msgid "Search for the string"
+#~ msgstr "স্ট্রীং সন্ধান করুন"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "সম্ভাব্য প্যানেল নামগুলি তালিকাভুক্ত করুন এবং প্রস্থান করুন"
+
+#~ msgid "Panel to display"
+#~ msgstr "প্রদর্শনের জন্য প্যানেল"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[প্যানেল] [আর্গুমেন্ট…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "উপলব্ধ প্যানেলগুলি:"
+
+#~ msgid "System Sounds"
+#~ msgstr "সিস্টেমের শব্দ"
 
 #~ msgid "Changes throughout the day"
 #~ msgstr "সারাদিনব্যাপী পরিবর্তন"
-
-#~| msgid "Lock screen"
-#~ msgid "Lock Screen"
-#~ msgstr "পর্দা লক করুন"
 
 #~ msgctxt "background, style"
 #~ msgid "Tile"
@@ -8505,9 +8377,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "Select Background"
 #~ msgstr "পটভূমি নির্বাচন করুন"
 
-#~ msgid "Wallpapers"
-#~ msgstr "ওয়ালপেপার"
-
 #~ msgid "Pictures"
 #~ msgstr "ছবি"
 
@@ -8518,17 +8387,11 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "You can add images to your %s folder and they will show up here"
 #~ msgstr "আপনি আপনার %s ফোল্ডারে ছবি যোগ করতে পারেন এবং তাদের এখানে দেখানো হবে"
 
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "Bluetooth অক্ষম"
-
 #~ msgid "Done"
 #~ msgstr "সম্পন্ন"
 
 #~ msgid "United States"
 #~ msgstr "মার্কিন যুক্তরাষ্ট্র"
-
-#~ msgid "France"
-#~ msgstr "ফ্রান্স"
 
 #~ msgid "Spain"
 #~ msgstr "স্পেন"
@@ -8550,10 +8413,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "Mirrored"
 #~ msgstr "প্রতিফলিত"
 
-#~| msgid "Secondary click delay"
-#~ msgid "Secondary"
-#~ msgstr "অপ্রধান"
-
 #~| msgid "Mirrored Displays"
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "একত্রিত প্রদর্শন সাজান"
@@ -8563,9 +8422,6 @@ msgstr "সিস্টেমের শব্দ"
 
 #~ msgid "Size"
 #~ msgstr "মাপ"
-
-#~ msgid "Aspect Ratio"
-#~ msgstr "অ্যাসপেক্ট অনুমাত"
 
 #~ msgid "Show the top bar and Activities Overview on this display"
 #~ msgstr "এই প্রদর্শনে শীর্ষ দন্ড এবং ক্রিয়াকলাপ পূর্বরূপ দেখান "
@@ -8604,9 +8460,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "%s %d-bit"
 #~ msgstr "%s %d-বিট"
 
-#~ msgid "Section"
-#~ msgstr "বিভাগ"
-
 # auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
 #~ msgid "Overview"
 #~ msgstr "পূর্বরূপ"
@@ -8624,10 +8477,6 @@ msgstr "সিস্টেমের শব্দ"
 #~| msgid "Checking for Updates"
 #~ msgid "Check for updates"
 #~ msgstr "আপডেট আছে কিনা দেখুন"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#~ msgid "Keyboard"
-#~ msgstr "কি-বোর্ড"
 
 #~ msgid "Shortcut;Repeat;Blink;"
 #~ msgstr "শর্টকাট;পুনরাবৃত্তি;ব্লিঙ্ক;"
@@ -8655,9 +8504,6 @@ msgstr "সিস্টেমের শব্দ"
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
 #~ msgid "S_peed:"
 #~ msgstr "গতি: (_p)"
-
-#~ msgid "Add Shortcut"
-#~ msgstr "শর্টকাট যোগ করুন"
 
 #~ msgid ""
 #~ "To edit a shortcut, click the row and hold down the new keys or press "
@@ -8772,9 +8618,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "Fast"
 #~ msgstr "দ্রুত"
 
-#~ msgid "Disable while _typing"
-#~ msgstr "টাইপ করার সময়ে অক্ষম করুন (_t)"
-
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "এই সংস্করণের সংগে সিস্টেম নেটওয়ার্ক পরিষেবাদি সুসংগত নয়।"
 
@@ -8876,9 +8719,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgstr ""
 #~ "এই নেটওয়ার্কের সংগে সংশিষ্ট সমস্ত বিস্তারিত সরান এবং স্বয়ংক্রিয় ভাবে সংযোগ করার "
 #~ "চেষ্টা করুন"
-
-#~ msgid "My Home Network"
-#~ msgstr "আমার হোম নেটওয়ার্ক"
 
 #~ msgid "Bond slaves"
 #~ msgstr "বন্ড স্লেভস"
@@ -9007,10 +8847,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "Infrastructure"
 #~ msgstr "পরিকাঠামো"
 
-# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
-#~ msgid "Not connected"
-#~ msgstr "সংযোগ বিহীন"
-
 # auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
 #~ msgid "InfiniBand device does not support connected mode"
 #~ msgstr "InfiniBand ডিভাইস দ্বারা সংযুক্ত মোড সমর্থিত হয় না"
@@ -9129,10 +8965,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "When battery power is _critical"
 #~ msgstr "যখন ব্যাটারি পাওয়ার খুবই কম (_C)"
 
-# auto translated by TM merge from project: gnome-session, version: 3.8.4, DocId: gnome-session-3.0
-#~ msgid "Power off"
-#~ msgstr "বন্ধ করুন"
-
 #~ msgid "Toner Level"
 #~ msgstr "টোনারের মাত্রা"
 
@@ -9151,9 +8983,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgstr[0] "%u সক্রিয়"
 #~ msgstr[1] "%u সক্রিয়"
 
-#~ msgid "Close"
-#~ msgstr "বন্ধ করুন"
-
 #~ msgid "Resume Printing"
 #~ msgstr "মুদ্রণ আবার শুরু করুন"
 
@@ -9166,9 +8995,6 @@ msgstr "সিস্টেমের শব্দ"
 #~| msgid "Search for network printers or filter result"
 #~ msgid "Enter address of a printer or a text to filter results"
 #~ msgstr "ফলাফল বাছাই করতে একটি প্রিন্টারের ঠিকানা বা একটি পাঠ্য লিখুন"
-
-#~ msgid "Loading options…"
-#~ msgstr "লোডের বিকল্প…"
 
 # auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
 #~ msgctxt "print job"
@@ -9193,9 +9019,6 @@ msgstr "সিস্টেমের শব্দ"
 
 #~ msgid "label"
 #~ msgstr "স্তর"
-
-#~ msgid "Setting new driver…"
-#~ msgstr "নতুন ড্রাইভার সেট করা হচ্ছে…"
 
 #~ msgid "page 3"
 #~ msgstr "পৃষ্ঠা ৩"
@@ -9236,9 +9059,6 @@ msgstr "সিস্টেমের শব্দ"
 #~| msgid "Lock Screen _After Blank For"
 #~ msgid "Lock screen _after blank for"
 #~ msgstr "এত খালি থাকার পরে স্ক্রীন তালাবন্ধ করুন (_a)"
-
-#~ msgid "Show _Notifications"
-#~ msgstr "বিজ্ঞপ্তিগুলি দেখান (_N)"
 
 #~ msgid ""
 #~ "Automatically purge the Trash and temporary files to help keep your "
@@ -9290,19 +9110,11 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "United Kingdom"
 #~ msgstr "ইউনাইটেড কিংডম"
 
-# auto translated by TM merge from project: RHEL Deployment Guide, version: 6.2, DocId: Product_Subscriptions_and_Entitlements
-#~ msgid "Options"
-#~ msgstr "বিকল্প"
-
 # translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
 #~| msgid "Other"
 #~ msgctxt "Search Location"
 #~ msgid "Other"
 #~ msgstr "অন্যান্য"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#~ msgid "Preferences"
-#~ msgstr "পছন্দ"
 
 #~ msgid ""
 #~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
@@ -9316,10 +9128,6 @@ msgstr "সিস্টেমের শব্দ"
 
 #~ msgid "Save Received Files to Downloads Folder"
 #~ msgstr "প্রাপ্ত ফাইলগুলি ডাউনলোড ফোল্ডারে সংরক্ষণ করুন"
-
-#~| msgid "Remote Control"
-#~ msgid "Allow Remote Control"
-#~ msgstr "রিমোট কন্ট্রোলের অনুমতি দিন"
 
 # auto translated by TM merge from project: Skynet topics, version: 1, DocId: 5177-68190
 #~| msgid "Password"
@@ -9637,13 +9445,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "Scroll Up"
 #~ msgstr "উপরে চলুন"
 
-# auto translated by TM merge from project: evince, version: 3.8.3, DocId: evince
-#~ msgid "Scroll Down"
-#~ msgstr "নীচে চলুন"
-
-#~ msgid "Scroll Left"
-#~ msgstr "বাম দিকে স্ক্রোল করুন"
-
 #~ msgid "Show the overview"
 #~ msgstr "পূর্বরূপ দেখান"
 
@@ -9666,9 +9467,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgctxt "category"
 #~ msgid "System"
 #~ msgstr "সিস্টেম"
-
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "নতুন ডিভাইস সেট আপ করুন"
@@ -9756,9 +9554,6 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgid "_City:"
 #~ msgstr "শহর (_C):"
 
-#~ msgid "_Network Time"
-#~ msgstr "নেটওয়ার্ক সময় (_N)"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "সময় এক ঘন্টা আগে সেট করুন।"
 
@@ -9787,19 +9582,8 @@ msgstr "সিস্টেমের শব্দ"
 #~ msgstr "ঘড়ির কাঁটার বিপরীত দিকে"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "ঘড়ির কাঁটার দিকে"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "১৮০ ডিগ্রি"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
-#~ msgid "Monitor"
-#~ msgstr "মনিটর"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "প্রাথমিক প্রদর্শন পরিবর্তন করতে টানুন।"
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -9915,9 +9699,6 @@ msgstr "সিস্টেমের শব্দ"
 
 #~ msgid "Share Public Folder On This Network"
 #~ msgstr "এই নেটওয়ার্কে সার্বজনীন ফোল্ডার ভাগ করুন"
-
-#~ msgid "Remote View"
-#~ msgstr "রিমোট ভিউ"
 
 #~ msgid "Approve All Connections"
 #~ msgstr "সকল সংযোগের অনুমোদন দিন"
@@ -10036,12 +9817,6 @@ msgstr "সিস্টেমের শব্দ"
 # auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
 #~ msgid "C_ontinue"
 #~ msgstr "এগিয়ে চলুন (_o)"
-
-#~ msgid "Previous Week"
-#~ msgstr "পূর্ববর্তী সপ্তাহ"
-
-#~ msgid "Next Week"
-#~ msgstr "পরবর্তী সপ্তাহ"
 
 # auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
 #~ msgid "Next week"

--- a/po/bn_IN.po~
+++ b/po/bn_IN.po~
@@ -1,0 +1,10147 @@
+# translation of bn_IN.po to Bengali INDIA
+# Bangla Translation of the Gnome Control Center po file.
+# Copyright (c)  2003-2006 Free Software Foundation, Inc.
+# This file is distributed under the same license as the Gnome Control Center package.
+#
+#
+# Bengali translations for zanata_rhel package.
+# Copyright (C) 2013 THE zanata_rhel'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the zanata_rhel package.
+# Progga <progga@BengaLinux.Org>, 2003-2006.
+# Runa Bhattacharjee <runabh@gmail.com>, 2006, 2007.
+# Runa Bhattacharjee <runab@redhat.com>, 2008, 2009, 2010.
+# Automatically generated, 2013.
+# sray <sray@redhat.com>, 2014. #zanata.
+# Akarshan Biswas <akarshan.biswas@hotmail.com>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: unnamed project\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2020-09-25 14:17+0000\n"
+"PO-Revision-Date: 2020-10-11 12:38+0530\n"
+"Last-Translator: Akarshan Biswas <akarshan.biswas@hotmail.com>\n"
+"Language-Team: Bengali <anubad@lists.ankur.org.in>\n"
+"Language: bn_IN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-DamnedLies-Scope: partial\n"
+"X-Generator: Gtranslator 3.38.0\n"
+
+#: panels/applications/cc-applications-panel.c:815
+msgid "System Bus"
+msgstr "সিস্টেমের বাস"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/applications/cc-applications-panel.c:815
+#: panels/applications/cc-applications-panel.c:817
+#: panels/applications/cc-applications-panel.c:830
+#: panels/applications/cc-applications-panel.c:835
+msgid "Full access"
+msgstr "পূর্ণ প্রবেশাধিকার"
+
+#: panels/applications/cc-applications-panel.c:817
+msgid "Session Bus"
+msgstr "সেশন বাস"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/applications/cc-applications-panel.c:821
+#: panels/power/cc-power-panel.c:2325 panels/thunderbolt/cc-bolt-panel.ui:466
+#: panels/thunderbolt/cc-bolt-panel.ui:525
+msgid "Devices"
+msgstr "ডিভাইসগুলি"
+
+#: panels/applications/cc-applications-panel.c:821
+msgid "Full access to /dev"
+msgstr "/dev এ সম্পূর্ণ অ্যাক্সেস"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#: panels/applications/cc-applications-panel.c:825
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:252
+msgid "Network"
+msgstr "নেটওয়ার্ক"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/applications/cc-applications-panel.c:825
+msgid "Has network access"
+msgstr "নেটওয়ার্ক অ্যাক্সেস আছে"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/applications/cc-applications-panel.c:830
+#: panels/applications/cc-applications-panel.c:832
+#: panels/search/cc-search-locations-dialog.c:361
+msgid "Home"
+msgstr "গৃহ"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/applications/cc-applications-panel.c:837
+msgid "Read-only"
+msgstr "শুধুমাত্র পাঠযোগ্য"
+
+#: panels/applications/cc-applications-panel.c:835
+#: panels/applications/cc-applications-panel.c:837
+msgid "File System"
+msgstr "ফাইল সিস্টেম"
+
+#: panels/applications/cc-applications-panel.c:841
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:279
+#: shell/cc-window.c:933 shell/cc-window.ui:121
+#: shell/gnome-control-center.desktop.in.in:3
+msgid "Settings"
+msgstr "সেটিং"
+
+#: panels/applications/cc-applications-panel.c:841
+msgid "Can change settings"
+msgstr "সেটিংস পরিবর্তন করতে পারে"
+
+#: panels/applications/cc-applications-panel.c:843
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s এর অন্তর্নির্মিত নিম্নলিখিত অনুমতি রয়েছে। এগুলি পরিবর্তন করা যায় না। আপনি যদি এই "
+"অনুমতিগুলি সম্পর্কে উদ্বিগ্ন হন তবে এই অ্যাপ্লিকেশনটি সরিয়ে ফেলার কথা বিবেচনা করুন।"
+
+#: panels/applications/cc-applications-panel.c:1016
+msgid "Web Links"
+msgstr "ওয়েব লিংকগুলি"
+
+#: panels/applications/cc-applications-panel.c:1026
+msgid "Git Links"
+msgstr "গিট লিঙ্কগুলি"
+
+#: panels/applications/cc-applications-panel.c:1032
+#, c-format
+msgid "%s Links"
+msgstr "%s লিঙ্কগুলি"
+
+#: panels/applications/cc-applications-panel.c:1040
+#: panels/applications/cc-applications-panel.c:1076
+msgid "Unset"
+msgstr "আনসেট"
+
+#: panels/applications/cc-applications-panel.c:1131
+msgid "Links"
+msgstr "লিঙ্কেগুলি"
+
+#: panels/applications/cc-applications-panel.c:1139
+msgid "Hypertext Files"
+msgstr "হাইপারটেক্সট ফাইলগুলি"
+
+#: panels/applications/cc-applications-panel.c:1153
+msgid "Text Files"
+msgstr "পাঠ্য ফাইলগুলি"
+
+#: panels/applications/cc-applications-panel.c:1167
+msgid "Image Files"
+msgstr "চিত্র ফাইলগুলি"
+
+#: panels/applications/cc-applications-panel.c:1183
+msgid "Font Files"
+msgstr "ফন্ট ফাইলগুলি"
+
+#: panels/applications/cc-applications-panel.c:1244
+msgid "Archive Files"
+msgstr "সংরক্ষণাগার ফাইলগুলি"
+
+#: panels/applications/cc-applications-panel.c:1264
+msgid "Package Files"
+msgstr "প্যাকেজ ফাইলগুলি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/applications/cc-applications-panel.c:1287
+msgid "Audio Files"
+msgstr "অডিও ফাইলগুলি"
+
+#: panels/applications/cc-applications-panel.c:1304
+msgid "Video Files"
+msgstr "ভিডিও ফাইলগুলি"
+
+#: panels/applications/cc-applications-panel.c:1312
+msgid "Other Files"
+msgstr "অন্যান্য ফাইলগুলি"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1652
+#: panels/applications/cc-applications-panel.ui:416
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:78
+msgid "Applications"
+msgstr "অ্যাপ্লিকেশনগুলি"
+
+#: panels/applications/cc-applications-panel.ui:43
+msgid "No applications"
+msgstr "কোনও অ্যাপ্লিকেশন নেই"
+
+#: panels/applications/cc-applications-panel.ui:57
+msgid "Install some…"
+msgstr "কিছু ইনস্টল করুন…"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "Permissions & Access"
+msgstr "অনুমতি এবং অ্যাক্সেস"
+
+#: panels/applications/cc-applications-panel.ui:106
+msgid ""
+"Data and services that this app has asked for access to and permissions that "
+"it requires."
+msgstr ""
+"এই অ্যাপ্লিকেশনটি যে ডেটা এবং পরিষেবাদিগুলির অ্যাক্সেস এবং এর জন্য প্রয়োজনীয় "
+"অনুমতিগুলির জন্য বলেছে।"
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:127
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "ক্যামেরা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:128
+#: panels/applications/cc-applications-panel.ui:140
+#: panels/applications/cc-applications-panel.ui:152
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:262
+#: panels/keyboard/cc-keyboard-option.c:259
+#: panels/keyboard/cc-keyboard-option.c:378
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:85
+#: panels/keyboard/keyboard-shortcuts.c:368 panels/network/network-proxy.ui:126
+#: panels/user-accounts/cc-user-panel.c:865
+#: panels/user-accounts/cc-user-panel.c:957
+#: subprojects/gvc/gvc-mixer-control.c:1876
+msgid "Disabled"
+msgstr "নিষ্ক্রিয়"
+
+#: panels/applications/cc-applications-panel.ui:133
+#: panels/applications/cc-applications-panel.ui:139
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "মাইক"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
+#: panels/applications/cc-applications-panel.ui:145
+#: panels/applications/cc-applications-panel.ui:151
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "অবস্থান পরিষেবা"
+
+#: panels/applications/cc-applications-panel.ui:157
+#: panels/applications/cc-applications-panel.ui:499
+msgid "Built-in Permissions"
+msgstr "অন্তর্নির্মিত অনুমতিগুলি"
+
+#: panels/applications/cc-applications-panel.ui:158
+msgid "Cannot be changed"
+msgstr "পরিবর্তন করা যাবে না"
+
+#: panels/applications/cc-applications-panel.ui:175
+msgid ""
+"Individual permissions for applications can be reviewed in the <a href="
+"\"privacy\">Privacy</a> Settings."
+msgstr ""
+"<a href=\"privacy\">গোপনীয়তা</a>সেটিংসে অ্যাপ্লিকেশনগুলির জন্য পৃথক অনুমতিগুলি "
+"পর্যালোচনা করা যেতে পারে।"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#: panels/applications/cc-applications-panel.ui:199
+msgid "Integration"
+msgstr "মিশ্রণ"
+
+#: panels/applications/cc-applications-panel.ui:211
+msgid "System features used by this application."
+msgstr "এই অ্যাপ্লিকেশন দ্বারা ব্যবহৃত সিস্টেম বৈশিষ্ট্যগুলি।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/applications/cc-applications-panel.ui:225
+#: panels/applications/cc-applications-panel.ui:231
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:151
+msgid "Search"
+msgstr "অনুসন্ধান"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#: panels/applications/cc-applications-panel.ui:237
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "সূচনাবার্তা"
+
+#: panels/applications/cc-applications-panel.ui:243
+msgid "Run in background"
+msgstr "ব্যাকগ্রাউন্ডে চালান"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/applications/cc-applications-panel.ui:249
+msgid "Set Desktop Background"
+msgstr "ডেস্কটপ ওয়ালপেপার সেট করুন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/applications/cc-applications-panel.ui:255
+#: panels/applications/cc-applications-panel.ui:261
+msgid "Sounds"
+msgstr "ধ্বনি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/applications/cc-applications-panel.ui:267
+msgid "Inhibit system keyboard shortcuts"
+msgstr "সিস্টেম কীবোর্ড শর্টকাটগুলি বাধা দিন"
+
+#: panels/applications/cc-applications-panel.ui:300
+msgid "Default Handlers"
+msgstr "ডিফল্ট হ্যান্ডেলার"
+
+#: panels/applications/cc-applications-panel.ui:312
+msgid "Types of files and links that this application opens."
+msgstr "এই অ্যাপ্লিকেশনটি খোলার ফাইল এবং লিঙ্কগুলির প্রকার।"
+
+#: panels/applications/cc-applications-panel.ui:328
+msgid "Reset"
+msgstr "পুনঃসেট"
+
+#: panels/applications/cc-applications-panel.ui:364
+msgid "Usage"
+msgstr "ব্যবহার"
+
+#: panels/applications/cc-applications-panel.ui:376
+msgid "How much resources this application is using."
+msgstr "এই অ্যাপ্লিকেশনটি কতগুলি সংস্থান ব্যবহার করছে।"
+
+#: panels/applications/cc-applications-panel.ui:391
+#: panels/applications/cc-applications-panel.ui:535
+msgid "Storage"
+msgstr "সংগ্রহস্থল"
+
+#: panels/applications/cc-applications-panel.ui:423
+msgid "Open in Software"
+msgstr "সফটওয়্যার এ খুলুন"
+
+#: panels/applications/cc-applications-panel.ui:473 shell/cc-panel-list.ui:121
+msgid "No results found"
+msgstr "কোন ফলাফল পাওয়া যায়নি"
+
+#: panels/applications/cc-applications-panel.ui:484
+#: panels/keyboard/cc-keyboard-panel.ui:189 shell/cc-panel-list.ui:132
+msgid "Try a different search"
+msgstr "একটি ভিন্ন অনুসন্ধান চেষ্টা করুন"
+
+#: panels/applications/cc-applications-panel.ui:552
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"অ্যাপ্লিকেশন ডেটা এবং ক্যাশেগুলির সাথে এই অ্যাপ্লিকেশনটি কত ডিস্ক স্পেস দখল করছে।"
+
+#: panels/applications/cc-applications-panel.ui:561
+msgid "Application"
+msgstr "অ্যাপ্লিকেশন"
+
+#: panels/applications/cc-applications-panel.ui:567
+msgid "Data"
+msgstr "ডেটা"
+
+#: panels/applications/cc-applications-panel.ui:573
+msgid "Cache"
+msgstr "ক্যাশে"
+
+#: panels/applications/cc-applications-panel.ui:579
+msgid "<b>Total</b>"
+msgstr "<b>মোট</b>"
+
+#: panels/applications/cc-applications-panel.ui:596
+msgid "Clear Cache…"
+msgstr "ক্যাশে পরিষ্কার করুন…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "বিভিন্ন অ্যাপ্লিকেশন অনুমতি এবং সেটিংস নিয়ন্ত্রণ করুন"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "অ্যাপ্লিকেশান;ফ্ল্যাটপ্যাক;অনুমতি;সেটিং;"
+
+#: panels/background/cc-background-chooser.c:346
+msgid "Select a picture"
+msgstr "একটি ছবি নির্বাচন করুন"
+
+#: panels/background/cc-background-chooser.c:349
+#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:238
+#: panels/color/cc-color-panel.c:886 panels/color/cc-color-panel.ui:657
+#: panels/common/cc-language-chooser.ui:24
+#: panels/display/cc-display-panel.c:943
+#: panels/info-overview/cc-info-overview-panel.ui:234
+#: panels/network/cc-wifi-hotspot-dialog.ui:122
+#: panels/network/cc-wifi-panel.c:865
+#: panels/network/connection-editor/connection-editor.ui:17
+#: panels/network/connection-editor/vpn-helpers.c:176
+#: panels/network/connection-editor/vpn-helpers.c:299
+#: panels/network/net-device-wifi.c:854
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:251
+#: panels/region/cc-format-chooser.ui:28 panels/region/cc-input-chooser.ui:11
+#: panels/search/cc-search-locations-dialog.c:638
+#: panels/sharing/cc-sharing-panel.c:396 panels/usage/cc-usage-panel.c:133
+#: panels/user-accounts/cc-add-user-dialog.ui:28
+#: panels/user-accounts/cc-avatar-chooser.c:107
+#: panels/user-accounts/cc-avatar-chooser.c:235
+#: panels/user-accounts/cc-fingerprint-dialog.ui:36
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:652
+#: panels/user-accounts/cc-user-panel.c:670
+#: panels/user-accounts/data/join-dialog.ui:20
+msgid "_Cancel"
+msgstr "বাতিল করুন (_C)"
+
+#: panels/background/cc-background-chooser.c:350
+#: panels/network/connection-editor/vpn-helpers.c:177
+#: panels/printers/pp-details-dialog.c:252
+#: panels/sharing/cc-sharing-panel.c:397
+#: panels/user-accounts/cc-avatar-chooser.c:236
+msgid "_Open"
+msgstr "খুলুন (_O)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/background/cc-background-item.c:140
+msgid "multiple sizes"
+msgstr "একাধিক মাপ"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:144
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/background/cc-background-item.c:282
+msgid "No Desktop Background"
+msgstr "ডেস্কটপের কোনো পটভূমি প্রয়োগ করা হবে না"
+
+#: panels/background/cc-background-panel.c:112
+msgid "Current background"
+msgstr "বর্তমান পটভূমি"
+
+#: panels/background/cc-background-panel.ui:55
+msgid "Add Picture…"
+msgstr "ছবি যুক্ত করুন ..."
+
+#: panels/background/cc-background-preview.ui:55
+msgid "Activities"
+msgstr "ক্রিয়াকলাপ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "পটভূমি"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr "আপনার পটভূমি চিত্রটি ওয়ালপেপার বা ফটোতে পরিবর্তন করুন"
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "ওয়ালপেপার;স্ক্রীন;ডেস্কটপ;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "No Bluetooth Found"
+msgstr "কোনো Bluetooth পাওয়া যায়নি"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "ব্লুটুথ ব্যবহার করতে একটি ডিঙ্গলে প্লাগ করুন।"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:69
+msgid "Bluetooth Turned Off"
+msgstr "ব্লুটুথ বন্ধ আছে"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:80
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "ডিভাইসগুলি সংযোগ করতে এবং ফাইল স্থানান্তর গ্রহণ করতে চালু করুন।"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:107
+msgid "Airplane Mode is on"
+msgstr "বিমান মোড চালু আছে"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:118
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "বিমান মোড চালু থাকলে ব্লুটুথ অক্ষম করা হয়।"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:124
+msgid "Turn Off Airplane Mode"
+msgstr "বিমান মোড বন্ধ করুন"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:154
+msgid "Hardware Airplane Mode is on"
+msgstr "হার্ডওয়্যার এয়ারপ্লেন মোড চালু আছে"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:165
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "ব্লুটুথ সক্ষম করতে বিমান মোড সুইচটি বন্ধ করুন।"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1628
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Bluetooth চালু এবং বন্ধ করুন এবং আপনার ডিভাইসগুলি সংযুক্ত করুন"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "ভাগ;ভাগকরা;ব্লুটুথ;ওবেক্স;"
+
+#: panels/camera/cc-camera-panel.ui:34
+msgid "Camera is turned off"
+msgstr "ক্যামেরা বন্ধ আছে"
+
+#: panels/camera/cc-camera-panel.ui:43
+msgid "No applications can capture photos or video."
+msgstr "কোনও অ্যাপ্লিকেশন ফটো বা ভিডিও ক্যাপচার করতে পারে না।"
+
+#: panels/camera/cc-camera-panel.ui:75
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly."
+msgstr ""
+"ক্যামেরার ব্যবহার অ্যাপ্লিকেশনগুলিকে ফটো এবং ভিডিও ক্যাপচার করতে দেয়। ক্যামেরাটি "
+"অক্ষম করার ফলে কিছু অ্যাপ্লিকেশনগুলি সঠিকভাবে কাজ না করার কারণ হতে পারে।"
+
+#: panels/camera/cc-camera-panel.ui:85
+msgid "Allow the applications below to use your camera."
+msgstr "নীচের অ্যাপ্লিকেশনগুলিকে আপনার ক্যামেরাটি ব্যবহার করার অনুমতি দিন।"
+
+#: panels/camera/cc-camera-panel.ui:105
+msgid "No Applications Have Asked for Camera Access"
+msgstr "কোনও অ্যাপ্লিকেশন ক্যামেরা অ্যাক্সেসের জন্য জিজ্ঞাসা করেনি"
+
+# auto translated by TM merge from project: gnome-contacts, version: 3.8.2, DocId: gnome-contacts
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "আপনার ছবি রক্ষা করুন"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"স্ক্রীন;লক;সমস্যা নিরূপণ;ক্র্যাশ;ব্যক্তিগত;সাম্প্রতিক;অস্থায়ী;tmp;সূচি;নাম;নেটওয়ার্ক;"
+"পরিচয়;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "আপনার ক্রমাঙ্কন ডিভাইসটিকে স্কোয়ারের উপরে রাখুন এবং \"আরম্ভ\" টিপুন"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"আপনার ক্রমাঙ্কন ডিভাইসটিকে ক্রমাঙ্কিত অবস্থানে নিয়ে যান এবং \"চালিয়ে যান\" টিপুন"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"আপনার ক্রমাঙ্কন ডিভাইসটিকে পৃষ্ঠের অবস্থানে নিয়ে যান এবং \"চালিয়ে যান\" টিপুন"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "ল্যাপটপ লিড বন্ধ করুন"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "এক আভ্যন্তরীণ ত্রুটি দেখা দিয়েছে যা পুনরুদ্ধার করা যাবে না।"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "ক্যালিব্রেশনের জন্য প্রয়োজনীয় সরঞ্জাম ইনস্টল করা নেই।"
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "প্রোফাইল প্রস্তুত করা যাবে না।"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "টার্গেট হোয়াইটপয়েন্ট প্রাপ্তযোগ্য নয়।"
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "সম্পন্ন!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "ক্যালিব্রেশন ব্যর্থ হয়েছে!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "আপনি ক্যালিব্রেশন ডিভাইস সরাতে পারেন।"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "কাজ চলছে এমন অবস্থায় ক্যালিব্রেশন ডিভাইসে হাত দেবেন না"
+
+#: panels/color/cc-color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr "ক্যালিব্রেশন দেখান"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:40
+msgid "_Start"
+msgstr "আরম্ভ(_S)"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:54
+msgid "_Resume"
+msgstr "আবার শুরু করুন(_R)"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
+#: panels/user-accounts/cc-fingerprint-dialog.ui:73
+msgid "_Done"
+msgstr "সম্পন্ন (_D)"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "ল্যাপটপ স্ক্রীন"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "অন্তর্ভুক্ত ওয়েবক্যাম"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s মনিটর"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s স্ক্রীনার"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s ক্যামেরা"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s প্রিন্টার"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s ওয়েবক্যাম"
+
+#: panels/color/cc-color-device.c:90
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s এর রঙ ব্যবস্থাপনা সক্ষম করুন"
+
+#: panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s এর জন্য রঙের প্রোফাইল দেখান"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "ক্যালিব্রেট করা হয়নি"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:167
+msgid "Default: "
+msgstr "ডিফল্ট: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:175
+msgid "Colorspace: "
+msgstr "কালারস্পেস: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:182
+msgid "Test profile: "
+msgstr "টেস্ট প্রোফাইল:"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:236
+msgid "Select ICC Profile File"
+msgstr "ICC প্রোফাইল ফাইল নির্বাচন করুন"
+
+#: panels/color/cc-color-panel.c:239
+msgid "_Import"
+msgstr "আমদানি করুন (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:250
+msgid "Supported ICC profiles"
+msgstr "সমর্থিত ICC প্রোফাইলসমূহ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:257
+#: panels/network/wireless-security/eap-method-fast.c:356
+msgid "All files"
+msgstr "সর্বধরনের ফাইল"
+
+#: panels/color/cc-color-panel.c:549
+msgid "Screen"
+msgstr "স্ক্রীন"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:839
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "ফাইল আপলোড করা গেল না: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:851
+msgid "The profile has been uploaded to:"
+msgstr "প্রোফাইল এখানে আপলোড করা হয়েছে:"
+
+#: panels/color/cc-color-panel.c:853
+msgid "Write down this URL."
+msgstr "এই URLটি লিখে রাখুন।"
+
+#: panels/color/cc-color-panel.c:854
+msgid "Restart this computer and boot your normal operating system."
+msgstr "এই কম্পিউটার রিস্টার্ট করুন এবং আপনার সাধারণ অপারেটিং সিস্টেম বুট করুন।"
+
+#: panels/color/cc-color-panel.c:855
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "প্রোফাইল ডাউনলোড এবং ইনস্টল করতে URLটি আপনার ব্রাউজারে লিখুন।"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:883
+msgid "Save Profile"
+msgstr "প্রোফাইল সংরক্ষণ করুন"
+
+#: panels/color/cc-color-panel.c:887
+#: panels/network/connection-editor/vpn-helpers.c:300
+msgid "_Save"
+msgstr "সংরক্ষণ করুন (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1196
+msgid "Create a color profile for the selected device"
+msgstr "নির্বাচিত ডিভাইসের জন্য একটি রঙ প্রোফাইল তৈরি করুন"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1211 panels/color/cc-color-panel.c:1235
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"পরিমাপের সরঞ্জাম সনাক্ত করা হয়নি। দয়া করে এটি যে চালু আছে এবং সঠিক ভাবে সংযুক্ত "
+"তা দেখে নিন।"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1245
+msgid "The measuring instrument does not support printer profiling."
+msgstr "পরিমাপের যন্ত্র প্রিন্টার প্রোফাইলিঙের সুবিধা দেয় না।"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1256
+msgid "The device type is not currently supported."
+msgstr "ডিভাইস ধরন বর্তমানে সমর্থিত নয়।"
+
+#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+msgid "Screen Calibration"
+msgstr "স্ক্রীন ক্যালিব্রেশন"
+
+#: panels/color/cc-color-panel.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"ক্যালিব্রেশন একটি প্রোফাইল তৈরি করবে যা আপনি আপনার স্ক্রীনকে রঙের দিক থেকে "
+"ব্যবস্থাপনা করতে পারবেন। ক্যালিব্রেশনের ক্ষেত্রে আপনি যত বেশি সময় খরচ করবেন, রঙ "
+"প্রোফাইলের গুণমান তত উন্নত হবে।"
+
+#: panels/color/cc-color-panel.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "ক্যালিব্রেশন চলার সময়ে আপনি আপনার কম্পিউটার ব্যবহার করতে পারবেন না।"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:58
+msgid "Quality"
+msgstr "গুণমান"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:75
+msgid "Approximate Time"
+msgstr "আনুমানিক সময়"
+
+#: panels/color/cc-color-panel.ui:121
+msgid "Calibration Quality"
+msgstr "ক্যালিব্রেশনের গুণমান"
+
+#: panels/color/cc-color-panel.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ক্যালিব্রেশনের জন্য আপনি সেন্সর ডিভাইস ব্যবহার করতে চান তা নির্বাচন করুন।"
+
+#: panels/color/cc-color-panel.ui:174
+msgid "Calibration Device"
+msgstr "ক্যালিব্রেশন ডিভাইস"
+
+#: panels/color/cc-color-panel.ui:189
+msgid "Select the type of display that is connected."
+msgstr "সংযুক্ত প্রদর্শনের ধরনটি নির্বাচন করুন।"
+
+#: panels/color/cc-color-panel.ui:226
+msgid "Display Type"
+msgstr "প্রদর্শনের ধরন"
+
+#: panels/color/cc-color-panel.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"একটি প্রদর্শন টার্গেট হোয়াইট পয়েন্ট নির্বাচন করুন। অধিকাংশ প্রদর্শন একটি D65 "
+"ইলিউমিনেন্টে ক্যালিব্রেট হবে।"
+
+#: panels/color/cc-color-panel.ui:278
+msgid "Profile Whitepoint"
+msgstr "প্রোফাইল হোয়াইটপয়েন্ট"
+
+#: panels/color/cc-color-panel.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"দয়া করে প্রদর্শন এমন এক উজ্জ্বলতায় সেট যা আপনার ক্ষেত্রে উপযুক্ত। উজ্জ্বলতার এই স্তরে "
+"রঙ ব্যবস্থাপনা সবথেকে যথাযথ হবে।"
+
+#: panels/color/cc-color-panel.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"বিকল্প ভাবে, আপনি এই ডিভাইসের ক্ষেত্রে অন্যান্য প্রোফাইলের একটিতে ব্যবহার করা "
+"উজ্জ্বলতার স্তর ব্যবহার করতে পারবেন।"
+
+#: panels/color/cc-color-panel.ui:318
+msgid "Display Brightness"
+msgstr "প্রদর্শন উজ্জ্বলতা"
+
+#: panels/color/cc-color-panel.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"আপনি বিভিন্ন কম্পিউটারে একটি রঙ প্রোফাইল ব্যবহার করতে পারবেন, বা পৃথক আলোক অবস্থায় "
+"প্রোফাইল তৈরি করতে পারবেন।"
+
+#: panels/color/cc-color-panel.ui:348
+msgid "Profile Name:"
+msgstr "প্রোফাইলের নাম:"
+
+#: panels/color/cc-color-panel.ui:377
+msgid "Profile Name"
+msgstr "প্রোফাইলের নাম"
+
+#: panels/color/cc-color-panel.ui:392
+msgid "Profile successfully created!"
+msgstr "প্রোফাইল সফলভাবে তৈরি হয়েছে!"
+
+#: panels/color/cc-color-panel.ui:443
+msgid "Copy profile"
+msgstr "প্রোফাইল অনুলিপি করুন"
+
+#: panels/color/cc-color-panel.ui:456
+msgid "Requires writable media"
+msgstr "লিখনযোগ্য মিডিয়ার প্রয়োজন"
+
+#: panels/color/cc-color-panel.ui:519
+msgid "Upload profile"
+msgstr "প্রোফাইল আপলোড করুন"
+
+#: panels/color/cc-color-panel.ui:532
+msgid "Requires Internet connection"
+msgstr "ইন্টারনেট সংযোগের প্রয়োজন"
+
+#: panels/color/cc-color-panel.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> এবং <a href="
+"\"windows\">Microsoft Windows</a> সিস্টেমে প্রোফাইল ব্যবহার সংক্রান্ত এই "
+"নির্দেশগুলি আপনার কাছে আসতে পারে।"
+
+#: panels/color/cc-color-panel.ui:607
+msgid "Summary"
+msgstr "সারাংশ"
+
+#: panels/color/cc-color-panel.ui:621
+msgid "Add Profile"
+msgstr "প্রোফাইল যোগ করুন"
+
+#: panels/color/cc-color-panel.ui:643
+msgid "_Import File…"
+msgstr "ফাইল আমদানি করুন(_I)…"
+
+#: panels/color/cc-color-panel.ui:672
+#: panels/network/connection-editor/net-connection-editor.c:510
+#: panels/printers/new-printer-dialog.ui:80
+#: panels/region/cc-input-chooser.ui:20
+#: panels/user-accounts/cc-add-user-dialog.ui:47
+msgid "_Add"
+msgstr "যোগ করুন (_A)"
+
+#: panels/color/cc-color-panel.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"সমস্যাগুলি সনাক্ত হয়েছে। প্রোফাইল ঠিকঠাক ভাবে কাজ নাও করতে পারে। <a href="
+"\"\">বিস্তারিত দেখান।</a>"
+
+#: panels/color/cc-color-panel.ui:788
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "প্রত্যেক ডিভাইসের রঙ ব্যবস্থাপনার ক্ষেত্রে একটি আপ-টু-ডেট প্রোফাইলের প্রয়োজন।"
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:810
+#: panels/diagnostics/cc-diagnostics-panel.c:143
+msgid "Learn more"
+msgstr "আরো জানুন"
+
+#: panels/color/cc-color-panel.ui:815
+msgid "Learn more about color management"
+msgstr "রঙ ব্যবস্থাপনা বিষয়ে আরো জানুন"
+
+#: panels/color/cc-color-panel.ui:863
+msgid "_Set for all users"
+msgstr "সকল ব্যবহারকারীর জন্য সেট করুন(_S)"
+
+#: panels/color/cc-color-panel.ui:867 panels/color/cc-color-panel.ui:882
+#: panels/color/cc-color-panel.ui:883
+msgid "Set this profile for all users on this computer"
+msgstr "এই প্রোফাইল এই কম্পিউটারে সকল ব্যবহারকারীর জন্য সেট করুন"
+
+#: panels/color/cc-color-panel.ui:878
+msgid "_Enable"
+msgstr "সক্ষম করুন(_E)"
+
+#: panels/color/cc-color-panel.ui:909
+msgid "_Add profile"
+msgstr "প্রোফাইল যোগ করুন(_A)"
+
+#: panels/color/cc-color-panel.ui:922
+msgid "_Calibrate…"
+msgstr "ক্যালিব্রেট করুন(_C)…"
+
+#: panels/color/cc-color-panel.ui:926
+msgid "Calibrate the device"
+msgstr "ডিভাইস ক্যালিব্রেট করুন"
+
+#: panels/color/cc-color-panel.ui:937
+msgid "_Remove profile"
+msgstr "প্রোফাইল সরান(_R)"
+
+#: panels/color/cc-color-panel.ui:950
+msgid "_View details"
+msgstr "বিস্তারিত দেখুন(_V)"
+
+#: panels/color/cc-color-panel.ui:986
+msgid "Unable to detect any devices that can be color managed"
+msgstr "এমন কোনো ডিভাইস সনাক্ত করতে পারেনি যা রঙ ব্যবস্থাপিত হতে পারে"
+
+#: panels/color/cc-color-panel.ui:1030
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:1035
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:1040
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:1045
+msgid "Projector"
+msgstr "প্রোজেক্টর"
+
+#: panels/color/cc-color-panel.ui:1050
+msgid "Plasma"
+msgstr "প্লাজমা"
+
+#: panels/color/cc-color-panel.ui:1055
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL পিছনের আলো)"
+
+#: panels/color/cc-color-panel.ui:1060
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED পিছনের আলো)"
+
+#: panels/color/cc-color-panel.ui:1065
+msgid "LCD (white LED backlight)"
+msgstr "LCD (সাদা LED পিছনের আলো)"
+
+#: panels/color/cc-color-panel.ui:1070
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "চওড়া গ্যামুট LCD (CCFL পিছনের আলো)"
+
+#: panels/color/cc-color-panel.ui:1075
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "চওড়া গ্যামুট LCD (RGB LED পিছনের আলো)"
+
+#: panels/color/cc-color-panel.ui:1092
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "উচ্চ"
+
+#: panels/color/cc-color-panel.ui:1093
+msgid "40 minutes"
+msgstr "৪০ মিনিট"
+
+#: panels/color/cc-color-panel.ui:1097
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "মাঝারি"
+
+#: panels/color/cc-color-panel.ui:1098
+msgid "30 minutes"
+msgstr "৩০ মিনিট"
+
+#: panels/color/cc-color-panel.ui:1102
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "নিম্ন"
+
+#: panels/color/cc-color-panel.ui:1103
+msgid "15 minutes"
+msgstr "১৫ মিনিট"
+
+#: panels/color/cc-color-panel.ui:1125
+msgid "Native to display"
+msgstr "প্রদর্শনের নেটিভ"
+
+#: panels/color/cc-color-panel.ui:1129
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (মুদ্রণ এবং প্রকাশনা)"
+
+#: panels/color/cc-color-panel.ui:1133
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:1137
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (ফটোগ্র্যাফি এবং গ্র্যাফিক্স)"
+
+#: panels/color/cc-color-panel.ui:1141
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "স্ট্যান্ডার্ড স্পেস"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "টেস্ট প্রোফাইল"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "স্বয়ংক্রিয়"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "নিম্ন মানের"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "মাঝারি মানের"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "উচ্চ মানের"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "ডিফল্ট RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "ডিফল্ট CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "ডিফল্ট গ্রে"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "ভেন্ডার সরবরাহকৃত ফ্যাক্টরি ক্যালিব্রেশন ডেটা"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "এই প্রোফাইলের ক্ষেত্রে সম্পূর্ণ স্ক্রীন প্রদর্শন সংশোধন সম্ভব নয়"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "এই প্রোফাইল আর হয়তো যথাযথ নেই"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "রঙ"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "আপনার ডিভাইসের রঙ ক্যালিব্রেট করুন, যেমন প্রদর্শন, ক্যামেরা বা প্রিন্টার"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "রঙ;ICC;প্রোফাইল;ক্যালিব্রেট;প্রিন্টার;প্রদর্শন;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "অন্যান্য..."
+
+#: panels/common/cc-language-chooser.c:127 panels/region/cc-input-chooser.c:178
+msgid "More…"
+msgstr "আরো…"
+
+#: panels/common/cc-language-chooser.c:144
+msgid "No languages found"
+msgstr "কোনো ভাষা পাওয়া যায়নি"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "ভাষা বাছাই করুন"
+
+#: panels/common/cc-language-chooser.ui:12
+msgid "_Select"
+msgstr "নির্বাচন করুন(_S)"
+
+#: panels/common/cc-permission-infobar.ui:20
+msgid "Unlock…"
+msgstr "আনলক করুন..."
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/common/cc-permission-infobar.ui:45
+msgid "Unlock to Change Settings"
+msgstr "সেটিংস পরিবর্তন করতে আনলক করুন"
+
+#: panels/common/cc-permission-infobar.ui:55
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "কিছু সেটিংস পরিবর্তন করার আগে অবশ্যই তা আনলক করতে হবে।"
+
+#: panels/common/cc-time-editor.ui:33
+msgid "Increment Hour"
+msgstr "বর্ধনের ঘণ্টা"
+
+#: panels/common/cc-time-editor.ui:65
+msgid "Increment Minute"
+msgstr "বর্ধনের মিনিট"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/common/cc-time-editor.ui:80
+msgid "Time"
+msgstr "সময়"
+
+#: panels/common/cc-time-editor.ui:113
+msgid "Decrement Hour"
+msgstr "হ্রাসের ঘণ্টা"
+
+#: panels/common/cc-time-editor.ui:145
+msgid "Decrement Minute"
+msgstr "হ্রাসের মিনিট"
+
+# auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
+#: panels/common/cc-time-entry.c:219
+msgid "_Copy"
+msgstr "অনুলিপি(_C)"
+
+#: panels/common/cc-time-entry.c:225
+msgid "Select _All"
+msgstr "সমস্ত নির্বাচন করুন(_A)"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:158
+msgid "Today"
+msgstr "আজ"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:160
+msgid "Yesterday"
+msgstr "গতকাল"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d ঘন্টা"
+msgstr[1] "%d ঘন্টায়"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#: panels/common/cc-util.c:166
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d মিনিট"
+msgstr[1] "%d মিনিটে"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d সেকেন্ড"
+msgstr[1] "%d সেকেন্ড"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "০ সেকেন্ড"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "হটস্পট"
+
+#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
+#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
+msgid "Day"
+msgstr "দিন"
+
+#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
+#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
+msgid "Month"
+msgstr "মাস"
+
+#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
+#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
+msgid "Year"
+msgstr "বছর"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:258
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:263
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:432
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:459
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:466
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:471
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:476
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:481
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:26
+msgid "January"
+msgstr "জানুয়ারি"
+
+#: panels/datetime/cc-datetime-panel.ui:29
+msgid "February"
+msgstr "ফেব্রুয়ারি"
+
+#: panels/datetime/cc-datetime-panel.ui:32
+msgid "March"
+msgstr "মার্চ"
+
+#: panels/datetime/cc-datetime-panel.ui:35
+msgid "April"
+msgstr "এপ্রিল"
+
+#: panels/datetime/cc-datetime-panel.ui:38
+msgid "May"
+msgstr "মে"
+
+#: panels/datetime/cc-datetime-panel.ui:41
+msgid "June"
+msgstr "জুন"
+
+#: panels/datetime/cc-datetime-panel.ui:44
+msgid "July"
+msgstr "জুলাই"
+
+#: panels/datetime/cc-datetime-panel.ui:47
+msgid "August"
+msgstr "আগস্ট"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "September"
+msgstr "সেপ্টেম্বর"
+
+#: panels/datetime/cc-datetime-panel.ui:53
+msgid "October"
+msgstr "অক্টোবর"
+
+#: panels/datetime/cc-datetime-panel.ui:56
+msgid "November"
+msgstr "নভেম্বর"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/datetime/cc-datetime-panel.ui:59
+msgid "December"
+msgstr "ডিসেম্বর"
+
+#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "তিথি এবং সময়"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/datetime/cc-datetime-panel.ui:102
+msgid "Time Zone"
+msgstr "সময় জোন"
+
+#: panels/datetime/cc-datetime-panel.ui:123
+msgid "Search for a city"
+msgstr "শহর সন্ধান করুন"
+
+#: panels/datetime/cc-datetime-panel.ui:194
+msgid "Automatic _Date & Time"
+msgstr "স্বয়ংক্রিয় তারিখ & সময় (_D)"
+
+#: panels/datetime/cc-datetime-panel.ui:195
+msgid "Requires internet access"
+msgstr "ইন্টারনেট অ্যাক্সেসের প্রয়োজন"
+
+#: panels/datetime/cc-datetime-panel.ui:215
+msgid "Date & _Time"
+msgstr "তারিখ & সময় (_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:254
+msgid "Automatic Time _Zone"
+msgstr "স্বয়ংক্রিয় সময় জোন (_Z)"
+
+#: panels/datetime/cc-datetime-panel.ui:255
+msgid "Requires location services enabled and internet access"
+msgstr "অবস্থান পরিষেবাদি সক্ষম এবং ইন্টারনেট অ্যাক্সেস প্রয়োজন"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/datetime/cc-datetime-panel.ui:270
+msgid "Time Z_one"
+msgstr "সময় জোন(_o)"
+
+#: panels/datetime/cc-datetime-panel.ui:310
+msgid "Time _Format"
+msgstr "সময় ফর্ম্যাট (_F)"
+
+#: panels/datetime/cc-datetime-panel.ui:319
+msgid "24-hour"
+msgstr "২৪ ঘন্টা"
+
+#: panels/datetime/cc-datetime-panel.ui:320
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "সময় অঞ্চল সমেত তারিখ এবং সময় পরিবর্তন করুন"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "ঘড়ি;সময় অঞ্চল;অবস্থান;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "সিস্টেম সময় এবং তারিখ সেটিং পরিবর্তন করুন"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "সময় বা তারিখ সেটিং পরিবর্তন করতে, আপনার প্রমাণীকরণের প্রয়োজন।"
+
+#: panels/default-apps/cc-default-apps-panel.ui:31
+msgid "_Web"
+msgstr "ওয়েব (_W)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:43
+msgid "_Mail"
+msgstr "মেল (_M)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:59
+msgid "_Calendar"
+msgstr "বর্ষপঞ্জি (_C)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "M_usic"
+msgstr "মিউজিক (_u)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:91
+msgid "_Video"
+msgstr "ভিডিও (_V)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:162
+#: panels/removable-media/cc-removable-media-panel.ui:162
+msgid "_Photos"
+msgstr "ছবি (_P)"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "ডিফল্ট অ্যাপ্লিকেশন"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "ডিফল্ট অ্যাপ্লিকেশনগুলি কনফিগার করুন"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "ডিফল্ট;অ্যাপ্লিকেশান;পছন্দসই;মিডিয়া;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:145
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"প্রযুক্তিগত সমস্যার প্রতিবেদন পাঠানো আমাদের %s উন্নত করতে সহায়তা করে। প্রতিবেদনগুলি "
+"বেনামে পাঠানো হয় এবং ব্যক্তিগত ডেটা স্ক্র্যাব করা হয়। %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:28
+msgid "Problem Reporting"
+msgstr "সমস্যা প্রতিবেদন"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:65
+msgid "_Automatic Problem Reporting"
+msgstr "স্বয়ংক্রিয় সমস্যা প্রতিবেদন(_A)"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "নিদানবিদ্যা"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "আপনার সমস্যা রিপোর্ট করুন"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"স্ক্রিন;লক;ডায়গনিস্টিক;ক্র্যাশ;ব্যক্তিগত;সাম্প্রতিক;অস্থায়ী;tmp;সূচক;নাম;নেটওয়ার্ক;পরিচয়;"
+"গোপনীয়তা;"
+
+#: panels/display/cc-display-panel.c:954
+#: panels/network/connection-editor/connection-editor.ui:27
+msgid "_Apply"
+msgstr "প্রয়োগ করুন (_A)"
+
+#: panels/display/cc-display-panel.c:975
+msgid "Apply Changes?"
+msgstr "পরিবর্তনগুলি প্রয়োগ করবেন?"
+
+#: panels/display/cc-display-panel.c:980
+msgid "Changes Cannot be Applied"
+msgstr "পরিবর্তনগুলি প্রয়োগ করা যায় না"
+
+#: panels/display/cc-display-panel.c:981
+msgid "This could be due to hardware limitations."
+msgstr "এটি হার্ডওয়্যার সীমাবদ্ধতার কারণে হতে পারে।"
+
+#: panels/display/cc-display-panel.ui:89
+msgid "Single Display"
+msgstr "একক ডিসপ্লে"
+
+# auto translated by TM merge from project: virt-viewer, version: 0.5.7, DocId: virt-viewer
+#: panels/display/cc-display-panel.ui:108
+#: panels/display/cc-display-panel.ui:310
+msgid "Join Displays"
+msgstr "ডিসপ্লেগুলি যোগ করুন"
+
+#: panels/display/cc-display-panel.ui:126
+msgid "Mirror"
+msgstr "মিরর"
+
+#: panels/display/cc-display-panel.ui:151
+msgid "Display Mode"
+msgstr "ডিসপ্লে ধরন"
+
+#: panels/display/cc-display-panel.ui:220
+msgid "Contains top bar and Activities"
+msgstr "শীর্ষ বার এবং ক্রিয়াকলাপগুলি রয়েছে"
+
+#: panels/display/cc-display-panel.ui:221
+msgid "Primary Display"
+msgstr "অপ্রধান ডিসপ্লে"
+
+#: panels/display/cc-display-panel.ui:243
+msgid ""
+"Drag displays to match your physical display setup. Select a display to "
+"change its settings."
+msgstr ""
+"আপনার শারীরিক ডিসপ্লে সেটআপের সাথে মেলে ডিসপ্লেগুলি টেনে আনুন। এর সেটিংস পরিবর্তন "
+"করতে একটি ডিসপ্লে নির্বাচন করুন।"
+
+#: panels/display/cc-display-panel.ui:250
+msgid "Display Arrangement"
+msgstr "ডিসপ্লে ব্যবস্থা"
+
+#: panels/display/cc-display-panel.ui:374
+msgid "Active Display"
+msgstr "সক্রিয় ডিসপ্লে"
+
+#: panels/display/cc-display-panel.ui:421
+msgid "Display Configuration"
+msgstr "ডিসপ্লে কনফিগারেশন"
+
+# auto translated by TM merge from project: virt-viewer, version: 0.5.7, DocId: virt-viewer
+#: panels/display/cc-display-panel.ui:440
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "প্রদর্শন"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:451
+#: panels/display/cc-night-light-page.ui:111
+msgid "Night Light"
+msgstr "নাইট লাইট"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/display/cc-display-settings.c:103
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "ল্যাণ্ডস্কেপ"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/display/cc-display-settings.c:106
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "ডানদিকে পোর্ট্রেট"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/display/cc-display-settings.c:109
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "বামদিকে পোর্ট্রেট"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/display/cc-display-settings.c:112
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "ল্যান্ডস্কেপ (উল্টানো)"
+
+#: panels/display/cc-display-settings.c:186
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#: panels/display/cc-display-settings.ui:15
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "ঝোঁক"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/display/cc-display-settings.ui:24
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "রেসলোলিউশন"
+
+#: panels/display/cc-display-settings.ui:33
+msgid "Refresh Rate"
+msgstr "রিফ্রেশ রেট"
+
+#: panels/display/cc-display-settings.ui:42
+msgid "Adjust for TV"
+msgstr "টিভির জন্য সামঞ্জস্য করুন"
+
+#: panels/display/cc-display-settings.ui:59
+msgctxt "display setting"
+msgid "Scale"
+msgstr "স্কেল"
+
+#: panels/display/cc-night-light-page.c:627
+msgid "More Warm"
+msgstr "আরও উষ্ণ"
+
+#: panels/display/cc-night-light-page.c:639
+msgid "Less Warm"
+msgstr "কম উষ্ণ"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:28
+msgid "Restart Filter"
+msgstr "ফিল্টার পুনরায় আরম্ভ করুন"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:61
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "আগামীকাল অবধি সাময়িকভাবে অক্ষম করা হয়েছে"
+
+#: panels/display/cc-night-light-page.ui:88
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"রাতের আলো পর্দার রঙকে উষ্ণ করে তোলে। এটি চোখের চাপ এবং নিদ্রাহীনতা রোধ করতে "
+"সহায়তা করতে পারে।"
+
+#: panels/display/cc-night-light-page.ui:127
+msgid "Schedule"
+msgstr "সময়সূচী"
+
+#: panels/display/cc-night-light-page.ui:136
+msgid "Sunset to Sunrise"
+msgstr "সূর্যাস্ত থেকে সূর্যোদয়"
+
+#: panels/display/cc-night-light-page.ui:137
+msgid "Manual Schedule"
+msgstr "ম্যানুয়াল সময়সূচী"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/region/cc-format-chooser.ui:344
+msgid "Times"
+msgstr "বার"
+
+#: panels/display/cc-night-light-page.ui:165
+msgid "From"
+msgstr "থেকে"
+
+#: panels/display/cc-night-light-page.ui:194
+#: panels/display/cc-night-light-page.ui:297
+msgid "Hour"
+msgstr "ঘন্টা"
+
+#: panels/display/cc-night-light-page.ui:203
+#: panels/display/cc-night-light-page.ui:306
+msgid ":"
+msgstr ":"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/display/cc-night-light-page.ui:222
+#: panels/display/cc-night-light-page.ui:325
+msgid "Minute"
+msgstr "মিনিট"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:234
+#: panels/display/cc-night-light-page.ui:337
+msgid "AM"
+msgstr "পূর্বাহ্ণ"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:247
+#: panels/display/cc-night-light-page.ui:350
+msgid "PM"
+msgstr "অপরাহ্ন"
+
+#: panels/display/cc-night-light-page.ui:267
+msgid "To"
+msgstr "থেকে"
+
+#: panels/display/cc-night-light-page.ui:374
+msgid "Color Temperature"
+msgstr "রঙ তাপমাত্রা"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "সংযুক্ত মনিটর এবং প্রোজেক্টর কীভাবে ব্যবহার করতে হবে তা বাছুন"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"প্যানেল;প্রজেক্টর;xrandr;স্ক্রিন;রেজোলিউশন;রিফ্রেশ;মনিটর;নাইট;হাল্কা;নীল;redshift;"
+"রঙ;সূর্যাস্ত;সূর্যোদয়;"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/info-overview/cc-info-overview-panel.c:416
+#: panels/info-overview/cc-info-overview-panel.c:431
+#: panels/info-overview/cc-info-overview-panel.c:443
+#: panels/info-overview/cc-info-overview-panel.c:489
+#: panels/info-overview/cc-info-overview-panel.c:519
+msgid "Unknown"
+msgstr "অজানা"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:451
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; বিল্ড আইডি: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:466
+#, c-format
+msgid "64-bit"
+msgstr "৬৪-বিট"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:469
+#, c-format
+msgid "32-bit"
+msgstr "৩২-বিট"
+
+#: panels/info-overview/cc-info-overview-panel.c:675
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:679
+msgid "Wayland"
+msgstr "ওয়েল্যান্ড "
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "অজানা"
+
+#: panels/info-overview/cc-info-overview-panel.ui:52
+msgid "Device Name"
+msgstr "ডিভাইস নাম"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Memory"
+msgstr "মেমরি"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Processor"
+msgstr "প্রসেসর"
+
+#: panels/info-overview/cc-info-overview-panel.ui:92
+msgid "Graphics"
+msgstr "গ্রাফিক্স"
+
+#: panels/info-overview/cc-info-overview-panel.ui:101
+msgid "Disk Capacity"
+msgstr "ডিস্ক ক্ষমতা"
+
+#: panels/info-overview/cc-info-overview-panel.ui:102
+msgid "Calculating…"
+msgstr "গণনা করা হচ্ছে…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:124
+msgid "OS Name"
+msgstr "OS এর নাম"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "OS Type"
+msgstr "OS এর ধরন"
+
+#: panels/info-overview/cc-info-overview-panel.ui:142
+msgid "GNOME Version"
+msgstr "জিনোম এর সংস্করণ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:152
+msgid "Windowing System"
+msgstr "উইন্ডোয়িং সিস্টেম"
+
+#: panels/info-overview/cc-info-overview-panel.ui:160
+msgid "Virtualization"
+msgstr "ভার্চুয়ালাইজেশন"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#: panels/info-overview/cc-info-overview-panel.ui:169
+msgid "Software Updates"
+msgstr "সফটওয়্যার আপডেটগুলি"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid "Rename Device"
+msgstr "ডিভাইসটির নাম পরিবর্তন করুন"
+
+#: panels/info-overview/cc-info-overview-panel.ui:207
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"ডিভাইসের নামটি যখন এই ডিভাইসটি নেটওয়ার্কের ওপরে দেখা হয় বা ব্লুটুথ ডিভাইসগুলির "
+"জুড়ি তৈরি হয় তখন এটি সনাক্ত করতে ব্যবহৃত হয়।"
+
+# auto translated by TM merge from project: gnome-boxes, version: 3.8.3, DocId: gnome-boxes
+#: panels/info-overview/cc-info-overview-panel.ui:225
+msgid "_Rename"
+msgstr "পুনরায় নামকরণ(_R)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "সম্পর্কিত"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "আপনার সিস্টেম সম্বন্ধে তথ্য দেখুন"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"যন্ত্র;সিস্টেম;তথ্য;হোস্টনাম;মেমরির;প্রসেসর;সংস্করণ;ডিফল্ট;আবেদন;পছন্দসই;সিডি;ডিভিডি;"
+"USB;অডিও;ভিডিও;ডিস্ক;অপসারণযোগ্য;মিডিয়া;অটোরান;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "ধ্বনি এবং মিডিয়া"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "ভলিউম নিঃশব্দ/চালু"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "শব্দমাত্রা কমান"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "শব্দমাত্রা বৃদ্ধি করুন"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "মাইক্রোফোন নিঃশব্দ/চালু"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "মিডিয়া প্লেয়ার লঞ্চ করুন"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "বাজান (বা বাজান/বিরতি)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "প্লে-ব্যাক স্থগিত করুন"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "প্লে-ব্যাক বন্ধ করুন"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "পূর্ববর্তী গান"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "পরবর্তী গান"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "ইজেক্ট"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:563
+msgid "Typing"
+msgstr "টাইপ করা হচ্ছে"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "পরবর্তী ইনপুট সোর্সে স্যুইচ করুন"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "পূর্ববর্তী ইনপুট সোর্সে স্যুইচ করুন"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "লঞ্চার"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "সহায়তা ব্রাউজার লঞ্চ করুন"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "ক্যালকুলেটর আরম্ভ করুন"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "ই-মেইল ক্লায়েন্ট আরম্ভ করুন"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "ওয়েব ব্রাউজার চালু করুন"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "ব্যক্তিগত ফোল্ডার"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "অনুসন্ধান"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "স্ক্রীনশট"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr "$PICTURES এ একটি স্ক্রীনশট সংরক্ষণ করুন"
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "একটি উইন্ডোর স্ক্রীনশট $PICTURES এ সংরক্ষণ করুন"
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "কোনো অংশের স্ক্রীনশট $PICTURES এ সংরক্ষণ করুন"
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "ক্লিপ-বোর্ডে একটি স্ক্রিন-শট কপি করুন"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "উইন্ডোর স্ক্রিন-শট ক্লিপ-বোর্ডে কপি করুন"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "একটি অঞ্চলের একটি স্ক্রীনশট ক্লিপবোর্ডে অনুলিপি করুন"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr "একটি সংক্ষিপ্ত স্ক্রিনকাস্ট রেকর্ড করুন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "সিস্টেম"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "লগ আউট করুন"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "পর্দা লক করুন"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "অভিগম্যতা"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "জুম চালু বা বন্ধ করুন"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "বড় মাপে প্রদর্শন"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "ছোট মাপে প্রদর্শন"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "স্ক্রীন রিডার চালু বা বন্ধ করুন"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "অন-স্ক্রীন কীবোর্ড চালু বা বন্ধ করুন"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "হরফের মাপ বৃদ্ধি করুন"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "হরফের মাপ হ্রাস করুন"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "গাঢ় তারতম্য চালু বা বন্ধ"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:8
+#: panels/keyboard/cc-keyboard-panel.ui:72
+msgid "Alternate Characters Key"
+msgstr "বৈকল্পিক অক্ষর কী"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:28
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"অতিরিক্ত অক্ষর লিখতে বিকল্প অক্ষর কী ব্যবহার করা যেতে পারে। এগুলি কখনও কখনও আপনার "
+"কীবোর্ডে তৃতীয় বিকল্প হিসাবে মুদ্রিত হয়।"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:45
+msgid "Left Alt"
+msgstr "বাম Alt"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:61
+msgid "Right Alt"
+msgstr "ডান Alt"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:77
+msgid "Left Super"
+msgstr "বাম সুপার"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:93
+msgid "Right Super"
+msgstr "ডান সুপার"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:109
+msgid "Menu key"
+msgstr "মেনু কী"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:125
+msgid "Right Ctrl"
+msgstr "ডান Ctrl"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-keyboard-manager.c:486
+#: panels/keyboard/cc-keyboard-manager.c:494
+#: panels/keyboard/cc-keyboard-manager.c:779
+msgid "Custom Shortcuts"
+msgstr "স্বনির্ধারিত শর্ট-কাট"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: panels/keyboard/cc-keyboard-option.c:337
+msgid "Alternative Characters Key"
+msgstr "বৈকল্পিক অক্ষর কী"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: panels/keyboard/cc-keyboard-option.c:346
+msgid "Compose Key"
+msgstr "রচনা কী"
+
+#: panels/keyboard/cc-keyboard-option.c:351
+msgid "Modifiers-only switch to next source"
+msgstr "পরবর্তী সোর্সে শুধুমাত্র-সংশোধক স্যুইচ"
+
+#: panels/keyboard/cc-keyboard-panel.c:94
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "ডান Ctrl"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-keyboard-panel.c:95
+msgctxt "keyboard key"
+msgid "Menu Key"
+msgstr "মেনু কী "
+
+#: panels/keyboard/cc-keyboard-panel.c:96
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "বাম সুপার"
+
+#: panels/keyboard/cc-keyboard-panel.c:97
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "ডান সুপার"
+
+#: panels/keyboard/cc-keyboard-panel.c:98
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "বাম Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:99
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "ডান Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:201
+msgid "Reset All Shortcuts?"
+msgstr "সমস্ত শর্টকাট পুনরায় সেট করবেন?"
+
+#: panels/keyboard/cc-keyboard-panel.c:204
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"শর্টকাটগুলি পুনরায় সেট করা আপনার কাস্টম শর্টকাটকে প্রভাবিত করতে পারে। এটা অসম্পূর্ণ "
+"থাকতে পারে না."
+
+#: panels/keyboard/cc-keyboard-panel.c:208
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:275
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+msgid "Cancel"
+msgstr "বাতিল"
+
+#: panels/keyboard/cc-keyboard-panel.c:209
+msgid "Reset All"
+msgstr "সব পুনরায় সেট করুন"
+
+#: panels/keyboard/cc-keyboard-panel.c:305
+msgid "Reset the shortcut to its default value"
+msgstr "শর্টকাটটিকে এর ডিফল্ট মানটিতে পুনরায় সেট করুন"
+
+#: panels/keyboard/cc-keyboard-panel.ui:73
+msgid "Hold down and type to enter different characters"
+msgstr "ধরে রাখুন এবং বিভিন্ন অক্ষর লিখতে টাইপ করুন"
+
+#: panels/keyboard/cc-keyboard-panel.ui:148
+msgid "Reset All…"
+msgstr "সব পুনরায় সেট করুন…"
+
+#: panels/keyboard/cc-keyboard-panel.ui:149
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "সমস্ত শর্টকাট তাদের ডিফল্ট কী-বাইন্ডিংগুলিতে পুনরায় সেট করুন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-keyboard-panel.ui:178
+msgid "No keyboard shortcut found"
+msgstr "কোনও কীবোর্ড শর্টকাট পাওয়া যায় নি"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:405
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s ইতিমধ্যে %s এর জন্য ব্যবহৃত হচ্ছে। আপনি যদি এটি প্রতিস্থাপন করেন তবে %s অক্ষম হয়ে "
+"যাবে"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:549
+msgid "Enter the new shortcut"
+msgstr "নতুন শর্টকাট প্রবেশ করান"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:566
+msgid "Set Custom Shortcut"
+msgstr "কাস্টম শর্টকাট সেট করুন"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:566
+msgid "Set Shortcut"
+msgstr "শর্টকাট সেট করুন"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:577
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "%s পরিবর্তন করতে নতুন শর্টকাট প্রবেশ করান।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:1004
+msgid "Add Custom Shortcut"
+msgstr "কাস্টম শর্টকাট যুক্ত করুন"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:60
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "কীবোর্ড শর্টকাটটি বাতিল করতে Esc বা ব্যাকস্পেস টিপুন।"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:135
+#: panels/printers/pp-details-dialog.ui:40
+msgid "Name"
+msgstr "নাম"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:147
+msgid "Command"
+msgstr "কমান্ড"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:159
+msgid "Shortcut"
+msgstr "শর্টকাট"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:238
+msgid "Set Shortcut…"
+msgstr "শর্টকাট সেট করুন ..."
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "কিছুই নেই"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:286
+msgid "Remove"
+msgstr "সরান"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:296
+msgid "Add"
+msgstr "যোগ করুন"
+
+# auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:311
+msgid "Replace"
+msgstr "প্রতিস্থাপন করুন"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:324
+msgid "Set"
+msgstr "সেট"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+#: panels/region/cc-region-panel.ui:392 shell/cc-window.ui:326
+msgid "Keyboard Shortcuts"
+msgstr "কি-বোর্ড শর্টকাট"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"কীবোর্ড শর্টকাটগুলি দেখুন এবং পরিবর্তন করুন এবং আপনার টাইপিং অগ্রাধিকার সেট করুন"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr "শর্টকাট;কর্মপরিসর;উইন্ডো;পুনরায়মাপ;জুম;বৈপরীত্য;ইনপুট;উত্স;লক;ভলিউম;"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
+#: panels/location/cc-location-panel.ui:31
+msgid "Location services turned off"
+msgstr "অবস্থান পরিষেবা বন্ধ আছে"
+
+#: panels/location/cc-location-panel.ui:40
+msgid "No applications can obtain location information."
+msgstr "কোনও অ্যাপ্লিকেশন লোকেশন তথ্য অর্জন করতে পারে না।"
+
+#: panels/location/cc-location-panel.ui:72
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"অবস্থান পরিষেবাদি অ্যাপ্লিকেশনগুলিকে আপনার অবস্থান জানার অনুমতি দেয়। ওয়াই-ফাই এবং "
+"মোবাইল ব্রডব্যান্ড ব্যবহার করে সঠিকতা বাড়ায়।"
+
+#: panels/location/cc-location-panel.ui:81
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+"মজিলা অবস্থান পরিষেবা ব্যবহার করে: <a href='https://location.services.mozilla."
+"com/privacy'>গোপনীয়তা নীতি</a>"
+
+#: panels/location/cc-location-panel.ui:93
+msgid "Allow the applications below to determine your location."
+msgstr "নীচের অ্যাপ্লিকেশনগুলিকে আপনার অবস্থান নির্ধারণ করার অনুমতি দিন।"
+
+#: panels/location/cc-location-panel.ui:113
+msgid "No Applications Have Asked for Location Access"
+msgstr "কোনও অ্যাপ্লিকেশন লোকেশন অ্যাক্সেসের জন্য জিজ্ঞাসা করেনি"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "আপনার অবস্থানের তথ্য রক্ষা করুন"
+
+#. FIXME
+#: panels/lock/cc-lock-panel.ui:27
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"স্ক্রিনটি স্বয়ংক্রিয়ভাবে লক করা আপনার দূরে থাকা অবস্থায় অন্যকে কম্পিউটার অ্যাক্সেস করা "
+"থেকে বিরত করে।"
+
+#: panels/lock/cc-lock-panel.ui:44
+msgid "Blank Screen Delay"
+msgstr "ফাঁকা স্ক্রিন বিলম্ব"
+
+#: panels/lock/cc-lock-panel.ui:45
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "নিষ্ক্রিয়তার সময়কালের পরে পর্দা ফাঁকা হয়ে যাবে।"
+
+#: panels/lock/cc-lock-panel.ui:65
+msgid "Automatic Screen _Lock"
+msgstr "স্বয়ংক্রিয় স্ক্রীন লক (_L)"
+
+#: panels/lock/cc-lock-panel.ui:82
+msgid "Automatic _Screen Lock Delay"
+msgstr "স্বয়ংক্রিয় স্ক্রিন লক বিলম্ব(_S)"
+
+#: panels/lock/cc-lock-panel.ui:83
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "স্ক্রীন ফাঁকা হওয়ার পরে পিরিয়ডটি স্বয়ংক্রিয়ভাবে লক হয়ে যায়।"
+
+#: panels/lock/cc-lock-panel.ui:103
+msgid "Show _Notifications on Lock Screen"
+msgstr "লক স্ক্রিনে বিজ্ঞপ্তিগুলি দেখান(_N)"
+
+#: panels/lock/cc-lock-panel.ui:120
+msgid "Forbid new _USB devices"
+msgstr "নতুন ইউএসবি ডিভাইস নিষিদ্ধ করুন(_U)"
+
+#: panels/lock/cc-lock-panel.ui:121
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"স্ক্রিনটি লক হয়ে গেলে নতুন ইউএসবি ডিভাইসগুলি সিস্টেমের সাথে ইন্টারঅ্যাক্ট করা থেকে "
+"বিরত রাখুন।"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:166
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "স্ক্রীন বন্ধ হয়"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:170
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "৩০ সেকেন্ড"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:174
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "১ মিনিট"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:178
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "২ মিনিট"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:182
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "৩ মিনিট"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:186
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "৫ মিনিট"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:190
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "৩০ মিনিট"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:194
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "১ ঘন্টা"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:209 panels/power/cc-power-panel.ui:63
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "১ মিনিট"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:213 panels/power/cc-power-panel.ui:67
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "২ মিনিট"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:217 panels/power/cc-power-panel.ui:71
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "৩ মিনিট"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:221 panels/power/cc-power-panel.ui:75
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "৪ মিনিট"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:225 panels/power/cc-power-panel.ui:79
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "৫ মিনিট"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:229 panels/power/cc-power-panel.ui:83
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "৮ মিনিট"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:233 panels/power/cc-power-panel.ui:87
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "১০ মিনিট"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:237 panels/power/cc-power-panel.ui:91
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "১২ মিনিট"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:241 panels/power/cc-power-panel.ui:95
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "১৫ মিনিট"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:245 panels/power/cc-power-panel.ui:99
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "কখনও নয়"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "স্ক্রীন লক"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr "স্ক্রীন লক করুন"
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid "Microphone is turned off"
+msgstr "মাইক্রোফোনটি বন্ধ আছে"
+
+#: panels/microphone/cc-microphone-panel.ui:43
+msgid "No applications can record sound."
+msgstr "কোনও অ্যাপ্লিকেশন ধ্বনি রেকর্ড করতে পারে না।"
+
+#: panels/microphone/cc-microphone-panel.ui:75
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly."
+msgstr ""
+"মাইক্রোফোনের ব্যবহার অ্যাপ্লিকেশনগুলিকে অডিও রেকর্ড করতে এবং শোনার অনুমতি দেয়। "
+"মাইক্রোফোনটি অক্ষম করার ফলে কিছু অ্যাপ্লিকেশনগুলি সঠিকভাবে কাজ না করার কারণ হতে "
+"পারে।"
+
+#: panels/microphone/cc-microphone-panel.ui:85
+msgid "Allow the applications below to use your microphone."
+msgstr "নীচের অ্যাপ্লিকেশনগুলিকে আপনার মাইক্রোফোনটি ব্যবহার করার অনুমতি দিন।"
+
+#: panels/microphone/cc-microphone-panel.ui:105
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "কোনও অ্যাপ্লিকেশন মাইক্রোফোন অ্যাক্সেসের জন্য জিজ্ঞাসা করেনি"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "আপনার কথোপকথন রক্ষা করুন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:37
+msgid "General"
+msgstr "সাধারণ"
+
+#: panels/mouse/cc-mouse-panel.ui:75
+msgid "Primary Button"
+msgstr "প্রাথমিক বোতাম"
+
+#: panels/mouse/cc-mouse-panel.ui:94
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "মাউস এবং টাচপ্যাডগুলিতে শারীরিক বোতামগুলির ক্রম সেট করে।"
+
+#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "বাম"
+
+#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "ডান"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/mouse/cc-mouse-panel.ui:169
+msgid "Mouse"
+msgstr "মাউস"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/mouse/cc-mouse-panel.ui:208
+msgid "Mouse Speed"
+msgstr "মাউস এর গতি"
+
+#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
+msgid "Double-click timeout"
+msgstr "দুইবার ক্লিকের সময় সমাপ্ত"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
+msgid "Natural Scrolling"
+msgstr "স্বাভাবিক স্ক্রোলিং"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
+msgid "Scrolling moves the content, not the view."
+msgstr "স্ক্রোলিং বিষয়বস্তু সরায়, ভিউ নয়।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
+msgid "Touchpad"
+msgstr "টাচ-প্যাড"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/mouse/cc-mouse-panel.ui:501
+msgid "Touchpad Speed"
+msgstr "টাচ-প্যাড এর গতি"
+
+#: panels/mouse/cc-mouse-panel.ui:560
+msgid "Tap to Click"
+msgstr "ক্লিক করতে আলতো চাপুন"
+
+#: panels/mouse/cc-mouse-panel.ui:612
+msgid "Two-finger Scrolling"
+msgstr "দুই আঙুলের স্ক্রোলিং"
+
+#: panels/mouse/cc-mouse-panel.ui:665
+msgid "Edge Scrolling"
+msgstr "কণার দিকে স্ক্রোলিং"
+
+#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:441
+msgid "Test Your _Settings"
+msgstr "আপনার সেটিং পরীক্ষা করুন (_S)"
+
+#: panels/mouse/cc-mouse-test.c:132 panels/mouse/cc-mouse-test.ui:25
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ক্লিক, দুইবার ক্লিক, স্ক্রোল করার চেষ্টা করুন"
+
+#: panels/mouse/cc-mouse-test.c:137
+msgid "Five clicks, GEGL time!"
+msgstr "পাঁচ ক্লিক, GEGL সময়!"
+
+#: panels/mouse/cc-mouse-test.c:142
+msgid "Double click, primary button"
+msgstr "দুইবার ক্লিক, প্রাথমিক বোতাম"
+
+#: panels/mouse/cc-mouse-test.c:142
+msgid "Single click, primary button"
+msgstr "একবার ক্লিক, প্রাথমিক বোতাম"
+
+#: panels/mouse/cc-mouse-test.c:145
+msgid "Double click, middle button"
+msgstr "দুইবার ক্লিক, মাঝের বোতাম"
+
+#: panels/mouse/cc-mouse-test.c:145
+msgid "Single click, middle button"
+msgstr "একবার ক্লিক, মাঝের বোতাম"
+
+#: panels/mouse/cc-mouse-test.c:148
+msgid "Double click, secondary button"
+msgstr "দুইবার ক্লিক, অপ্রধান বোতাম"
+
+#: panels/mouse/cc-mouse-test.c:148
+msgid "Single click, secondary button"
+msgstr "একবার ক্লিক, অপ্রধান বোতাম"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "মাউস & টাচপ্যাড"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"আপনার মাউস বা টাচপ্যাড সংবেদনশীল পরিবর্তন করুন এবং ডান বা বাম-হাতের দিক নির্বাচন "
+"করুন"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ট্র্যাকপ্যাড;পয়েন্টার;ক্লিক;আলতো চাপুন;দ্বৈত;বোতাম;ট্র্যাকবল;স্ক্রোল;"
+
+#: panels/network/cc-network-panel.c:648 panels/network/cc-wifi-panel.ui:359
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "ওহো, কিছু ভুল হয়েছে। আপনার সফ্টওয়্যার বিক্রেতার সাথে যোগাযোগ করুন।"
+
+#: panels/network/cc-network-panel.c:654
+msgid "NetworkManager needs to be running."
+msgstr "নেটওয়ার্কম্যানেজারটি চলমান হওয়া দরকার।"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/network/cc-network-panel.ui:66
+msgid "Other Devices"
+msgstr "অন্যান্য ডিভাইসগুলি"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#: panels/network/cc-network-panel.ui:107
+#: panels/network/connection-editor/net-connection-editor.c:593
+msgid "VPN"
+msgstr "ভিপিএন"
+
+#: panels/network/cc-network-panel.ui:151
+msgid "Not set up"
+msgstr "সেট আপ করা হয়নি"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:207
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:267
+msgid "Insecure network (WEP)"
+msgstr "অনিরাপদ নেটওয়ার্ক (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:272
+msgid "Secure network (WPA)"
+msgstr "সুরক্ষিত নেটওয়ার্ক (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:277
+msgid "Secure network (WPA2)"
+msgstr "সুরক্ষিত নেটওয়ার্ক (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:282
+msgid "Secure network (WPA3)"
+msgstr "সুরক্ষিত নেটওয়ার্ক (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network"
+msgstr "সুরক্ষিত নেটওয়ার্ক"
+
+#: panels/network/cc-wifi-connection-row.ui:102
+#: panels/network/net-device-ethernet.c:316
+#: panels/network/network-bluetooth.ui:76
+#: panels/network/network-ethernet.ui:111 panels/network/network-mobile.ui:414
+#: panels/network/network-vpn.ui:75
+msgid "Options…"
+msgstr "বিকল্প…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:132
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"হটস্পটটি চালু করা %s থেকে সংযোগ বিচ্ছিন্ন হবে এবং ওয়াইফাই এর মাধ্যমে ইন্টারনেট "
+"অ্যাক্সেস করা সম্ভব হবে না।"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:248
+msgid "Must have a minimum of 8 characters"
+msgstr "সর্বনিম্ন ৮ টি অক্ষর থাকতে হবে"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:458
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "ওয়াইফাই হটস্পট চালু করবেন?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:19
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"ওয়াইফাই হটস্পট অন্যদের সাথে যোগাযোগ করতে পারে এমন একটি ওয়াইফাই নেটওয়ার্ক তৈরি "
+"করে আপনার ইন্টারনেট সংযোগ ভাগ করার অনুমতি দেয়। এটি করতে, আপনার অবশ্যই ওয়াই-ফাই "
+"ছাড়া অন্য উত্সের মাধ্যমে একটি ইন্টারনেট সংযোগ থাকতে হবে।"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/cc-wifi-hotspot-dialog.ui:44
+msgid "Network Name"
+msgstr "নেটওয়ার্কের নাম"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 5177-68190
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:69
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:383
+#: panels/printers/pp-jobs-dialog.ui:70
+#: panels/user-accounts/cc-add-user-dialog.ui:249
+msgid "Password"
+msgstr "পাসওয়ার্ড"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:83
+msgid "Generate Random Password"
+msgstr "এলোমেলো পাসওয়ার্ড তৈরি করুন"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:84
+msgid "Autogenerate Password"
+msgstr "পাসওয়ার্ড অটো জেনারেট করুন"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:130
+msgid "_Turn On"
+msgstr "চালু করুন (_T)"
+
+#: panels/network/cc-wifi-panel.c:543
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:53
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:863
+msgid "Stop hotspot and disconnect any users?"
+msgstr "হটস্পট বন্ধ এবং কোনো ব্যবহারকারীকে সংযোগবিচ্ছিন্ন করবেন?"
+
+#: panels/network/cc-wifi-panel.c:866
+msgid "_Stop Hotspot"
+msgstr "হটস্পট থামান (_S)"
+
+#: panels/network/cc-wifi-panel.ui:54
+msgid "Airplane Mode"
+msgstr "বিমান মোড"
+
+#: panels/network/cc-wifi-panel.ui:70
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Wi-Fi, ব্লুটুথ এবং মোবাইল ব্রডব্যান্ড অক্ষম করে"
+
+#: panels/network/cc-wifi-panel.ui:139
+msgid "No Wi-Fi Adapter Found"
+msgstr "কোনও Wi-Fi অ্যাডাপ্টার পাওয়া যায় নি"
+
+#: panels/network/cc-wifi-panel.ui:151
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "আপনার ওয়াই-ফাই অ্যাডাপ্টার প্লাগ এবং চালু আছে তা নিশ্চিত করুন"
+
+#: panels/network/cc-wifi-panel.ui:186
+msgid "Airplane Mode On"
+msgstr "বিমান মোড চালু"
+
+#: panels/network/cc-wifi-panel.ui:198
+msgid "Turn off to use Wi-Fi"
+msgstr "ওয়াইফাই ব্যাবহার করতে গেলে বন্ধ করুন"
+
+#: panels/network/cc-wifi-panel.ui:236
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi হটস্পট সক্রিয়"
+
+#: panels/network/cc-wifi-panel.ui:247
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "মোবাইল ডিভাইসগুলি সংযোগের জন্য কিউআর কোডটি স্ক্যান করতে পারে।"
+
+#: panels/network/cc-wifi-panel.ui:257
+msgid "Turn Off Hotspot…"
+msgstr "হটস্পট বন্ধ করুন..."
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#: panels/network/cc-wifi-panel.ui:279
+msgid "Visible Networks"
+msgstr "দৃশ্যমান নেটওয়ার্কগুলি"
+
+#: panels/network/cc-wifi-panel.ui:348
+msgid "NetworkManager needs to be running"
+msgstr "নেটওয়ার্কম্যানেজারটি চলমান হওয়া দরকার"
+
+#: panels/network/connection-editor/8021x-security-page.ui:20
+msgid "802.1x _Security"
+msgstr "802.1x নিরাপত্তা (_S)"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:112
+#: panels/network/connection-editor/ce-page-security.c:423
+#: panels/network/connection-editor/details-page.ui:90
+msgid "Security"
+msgstr "নিরাপত্তা"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "সংরক্ষিত"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "স্থায়ী"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "এলোমেলো"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "স্থিতিশীল"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"এখানে প্রবেশ করা ম্যাক ঠিকানাটি এই সংযোগটি সক্রিয় হওয়া নেটওয়ার্ক ডিভাইসের "
+"হার্ডওয়্যার ঠিকানা হিসাবে ব্যবহৃত হবে। এই বৈশিষ্ট্যটি ম্যাক ক্লোনিং বা স্পোফিং হিসাবে "
+"পরিচিত। উদাহরণ: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "প্রোফাইল %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:93
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:103
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+#: panels/network/connection-editor/ce-page-security.c:278
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:115
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:121
+msgid "Enterprise"
+msgstr "এন্টারপ্রাইজ "
+
+#: panels/network/connection-editor/ce-page-details.c:126
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "কিছুই নয়"
+
+#: panels/network/connection-editor/ce-page-details.c:147
+msgid "Never"
+msgstr "কখনও নয়"
+
+#: panels/network/connection-editor/ce-page-details.c:162
+#: panels/network/net-device-ethernet.c:107
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i দিন পূর্বে"
+msgstr[1] "%i দিন পূর্বে"
+
+#: panels/network/connection-editor/ce-page-details.c:287
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:289
+#: panels/network/net-device-ethernet.c:201
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:306
+msgid "2.4 GHz / 5 GHz"
+msgstr "২.৪ GHz / ৫ GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:308
+msgid "2.4 GHz"
+msgstr "২.৪ GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "5 GHz"
+msgstr "৫ GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:330
+msgctxt "Signal strength"
+msgid "None"
+msgstr "কিছুই নয়"
+
+#: panels/network/connection-editor/ce-page-details.c:332
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "দুর্বল"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ঠিক আছে"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "ভাল"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "দুর্দান্ত"
+
+#: panels/network/connection-editor/ce-page-details.c:396
+#: panels/network/connection-editor/details-page.ui:108
+#: panels/network/net-device-ethernet.c:142
+#: panels/network/net-device-mobile.c:430
+msgid "IPv4 Address"
+msgstr "IPv4 ঠিকানা"
+
+#: panels/network/connection-editor/ce-page-details.c:397
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:143
+#: panels/network/net-device-ethernet.c:147
+#: panels/network/net-device-mobile.c:431 panels/network/network-mobile.ui:200
+msgid "IPv6 Address"
+msgstr "IPv6 ঠিকানা"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#: panels/network/connection-editor/ce-page-details.c:400
+#: panels/network/connection-editor/ce-page-details.c:401
+#: panels/network/net-device-ethernet.c:145
+#: panels/network/net-device-mobile.c:434
+#: panels/network/net-device-mobile.c:435 panels/network/network-mobile.ui:183
+msgid "IP Address"
+msgstr "IP ঠিকানা"
+
+#: panels/network/connection-editor/ce-page-details.c:434
+msgid "Forget Connection"
+msgstr "সংযোগটি ভুলে যান"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/network/connection-editor/ce-page-details.c:436
+msgid "Remove Connection Profile"
+msgstr "সংযোগ প্রোফাইল সরান"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/network/connection-editor/ce-page-details.c:438
+msgid "Remove VPN"
+msgstr "ভিপিএন সরান"
+
+#: panels/network/connection-editor/ce-page-details.c:456
+msgid "Details"
+msgstr "বিবরণ"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "স্বয়ংক্রিয়"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:150
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "পরিচয়"
+
+#: panels/network/connection-editor/ce-page-ip4.c:246
+#: panels/network/connection-editor/ce-page-ip6.c:227
+msgid "Delete Address"
+msgstr "ঠিকানা মুছুন"
+
+#: panels/network/connection-editor/ce-page-ip4.c:405
+#: panels/network/connection-editor/ce-page-ip6.c:375
+msgid "Delete Route"
+msgstr "রাউট মুছুন"
+
+#: panels/network/connection-editor/ce-page-ip4.c:827
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:760
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:267
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "কিছুই নয়"
+
+#: panels/network/connection-editor/ce-page-security.c:302
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-বিট কী (Hex বা ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:312
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-বিট পাসফ্রেজ"
+
+#: panels/network/connection-editor/ce-page-security.c:325
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:338
+msgid "Dynamic WEP (802.1x)"
+msgstr "ডায়নামিক WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:352
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 ব্যক্তিগত"
+
+#: panels/network/connection-editor/ce-page-security.c:366
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 এন্টারপ্রাইজ"
+
+#: panels/network/connection-editor/ce-page-security.c:380
+msgid "WPA3 Personal"
+msgstr "WPA3 ব্যক্তিগত"
+
+#: panels/network/connection-editor/details-page.ui:18
+msgid "Signal Strength"
+msgstr "সংকেতের শক্তি"
+
+#: panels/network/connection-editor/details-page.ui:54
+msgid "Link speed"
+msgstr "লিঙ্কের গতি"
+
+#: panels/network/connection-editor/details-page.ui:144
+#: panels/network/net-device-ethernet.c:150
+msgid "Hardware Address"
+msgstr "হার্ডওয়্যার ঠিকানা"
+
+#: panels/network/connection-editor/details-page.ui:162
+msgid "Supported Frequencies"
+msgstr "সমর্থিত ফ্রিকোয়েন্সিগুলি"
+
+#: panels/network/connection-editor/details-page.ui:180
+#: panels/network/net-device-ethernet.c:154
+#: panels/network/network-mobile.ui:217
+msgid "Default Route"
+msgstr "ডিফল্ট রাউট"
+
+#: panels/network/connection-editor/details-page.ui:199
+#: panels/network/connection-editor/ip4-page.ui:211
+#: panels/network/connection-editor/ip6-page.ui:225
+#: panels/network/net-device-ethernet.c:156
+#: panels/network/network-mobile.ui:235
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:217
+msgid "Last Used"
+msgstr "সর্বশেষ ব্যবহৃত"
+
+#: panels/network/connection-editor/details-page.ui:376
+msgid "Connect _automatically"
+msgstr "স্বয়ংক্রিয় ভাবে সংযোগ করুন (_a)"
+
+#: panels/network/connection-editor/details-page.ui:395
+msgid "Make available to _other users"
+msgstr "অন্যান্য ব্যবহারকারীর কাছে উপলব্ধ করান (_o)"
+
+#: panels/network/connection-editor/details-page.ui:428
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "মিটার সংযোগ: ডেটা সীমা রয়েছে বা চার্জ বহন করতে পারে(_M)"
+
+#: panels/network/connection-editor/details-page.ui:439
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr "সফ্টওয়্যার আপডেট এবং অন্যান্য বড় ডাউনলোডগুলি স্বয়ংক্রিয়ভাবে শুরু হবে না।"
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "নাম (_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:54
+#: panels/network/connection-editor/wifi-page.ui:67
+msgid "_MAC Address"
+msgstr "MAC ঠিকানা (_M)"
+
+#: panels/network/connection-editor/ethernet-page.ui:105
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:122
+#: panels/network/connection-editor/wifi-page.ui:102
+msgid "_Cloned Address"
+msgstr "ক্লোনড ঠিকানা (_C)"
+
+#: panels/network/connection-editor/ethernet-page.ui:137
+msgid "bytes"
+msgstr "বাইট"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr "IPv4 পদ্ধতি (_4)"
+
+#: panels/network/connection-editor/ip4-page.ui:42
+msgid "Automatic (DHCP)"
+msgstr "স্বয়ংক্রিয় (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr "শুধুমাত্র স্থানীয়-লিংক"
+
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:72 panels/network/network-proxy.ui:116
+msgid "Manual"
+msgstr "ম্যানুয়াল"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr "নিষ্ক্রিয়"
+
+#: panels/network/connection-editor/ip4-page.ui:97
+#: panels/network/connection-editor/ip6-page.ui:111
+msgid "Shared to other computers"
+msgstr "অন্যান্য কম্পিউটারের সংগে ভাগ করা"
+
+#: panels/network/connection-editor/ip4-page.ui:125
+#: panels/network/connection-editor/ip6-page.ui:139
+msgid "Addresses"
+msgstr "ঠিকানাগুলি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/printers/pp-details-dialog.ui:95
+msgid "Address"
+msgstr "ঠিকানা"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+msgid "Netmask"
+msgstr "নেটমাস্ক"
+
+#: panels/network/connection-editor/ip4-page.ui:171
+#: panels/network/connection-editor/ip4-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:369
+msgid "Gateway"
+msgstr "গেটওয়ে"
+
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:291
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/connection-editor/ip6-page.ui:305
+#: panels/network/net-proxy.c:74 panels/network/network-proxy.ui:106
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "স্বয়ংক্রিয়"
+
+#: panels/network/connection-editor/ip4-page.ui:234
+#: panels/network/connection-editor/ip6-page.ui:248
+msgid "Automatic DNS"
+msgstr "স্বয়ংক্রিয় DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Separate IP addresses with commas"
+msgstr "আইপি ঠিকানাগুলি কমা দিয়ে আলাদা করুন"
+
+#: panels/network/connection-editor/ip4-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:293
+msgid "Routes"
+msgstr "রাউট"
+
+#: panels/network/connection-editor/ip4-page.ui:302
+#: panels/network/connection-editor/ip6-page.ui:316
+msgid "Automatic Routes"
+msgstr "স্বয়ংক্রিয় রাউট"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:368
+#: panels/network/connection-editor/ip6-page.ui:382
+msgid "Metric"
+msgstr "মেট্রিক"
+
+#: panels/network/connection-editor/ip4-page.ui:398
+#: panels/network/connection-editor/ip6-page.ui:412
+msgid "Use this connection _only for resources on its network"
+msgstr "এই সংযোগ শুধুমাত্র এর নেটওয়ার্কে রিসোর্সগুলির জন্য ব্যবহার করুন (_o)"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr "IPv6 পদ্ধতি (_6)"
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr "স্বয়ংক্রিয়, শুধুমাত্র DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Prefix"
+msgstr "প্রেফিক্স"
+
+#: panels/network/connection-editor/net-connection-editor.c:288
+msgid "Unable to open connection editor"
+msgstr "সংযোগ সম্পাদক খোলা গেল না"
+
+#: panels/network/connection-editor/net-connection-editor.c:304
+msgid "New Profile"
+msgstr "নতুন প্রোফাইল"
+
+#: panels/network/connection-editor/net-connection-editor.c:737
+msgid "Import from file…"
+msgstr "ফাইল থেকে আমদানি করুন…"
+
+#: panels/network/connection-editor/net-connection-editor.c:769
+msgid "Add VPN"
+msgstr "VPN যোগ করুন"
+
+#: panels/network/connection-editor/security-page.ui:20
+msgid "S_ecurity"
+msgstr "নিরাপত্তা (_e)"
+
+#: panels/network/connection-editor/vpn-helpers.c:139
+msgid "Cannot import VPN connection"
+msgstr "VPN সংযোগ আমদানি করা যাবে না"
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"\"%s\" ফাইলটি পড়া যায়নি বা স্বীকৃত ভিপিএন সংযোগের তথ্য ধারণ করে না\n"
+"\n"
+"ত্রুটি: %s"
+
+#: panels/network/connection-editor/vpn-helpers.c:173
+msgid "Select file to import"
+msgstr "আমদানি করার জন্য ফাইল নির্বাচন করুন"
+
+#: panels/network/connection-editor/vpn-helpers.c:225
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "\"%s\" নামের একটি ফাইল ইতিমধ্যেই বিদ্যমান।"
+
+# auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
+#: panels/network/connection-editor/vpn-helpers.c:227
+msgid "_Replace"
+msgstr "প্রতিস্থাপন করুন (_R)"
+
+#: panels/network/connection-editor/vpn-helpers.c:229
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "আপনি যে VPN সংযোগ সংরক্ষণ করছেন তা দিয়ে %s প্রতিস্থাপন করতে চান?"
+
+#: panels/network/connection-editor/vpn-helpers.c:264
+msgid "Cannot export VPN connection"
+msgstr "VPN সংযোগ রপ্তানি করা যাবে না"
+
+#: panels/network/connection-editor/vpn-helpers.c:266
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN সংযোগ '%s' %s এ রপ্তানি করা যায়নি।\n"
+"\n"
+"ত্রুটি: %s।"
+
+#: panels/network/connection-editor/vpn-helpers.c:296
+msgid "Export VPN connection"
+msgstr "VPN সংযোগ রপ্তানি করুন"
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ত্রুটি: VPN সংযোগ সম্পাদক লোড করা যায়নি)"
+
+#: panels/network/connection-editor/wifi-page.ui:20
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:36
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "ইন্টারনেটের সংগে আপনার সংযোগের ধরন নিয়ন্ত্রণ করুন"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "নেটওয়ার্ক;আইপি;LAN;প্রক্সি;WAN;ব্রডব্যান্ড;মোডেম;ব্লুটুথ;VPN;ডিএনএস;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "কীভাবে আপনি Wi-Fi নেটওয়ার্কগুলিতে সংযুক্ত হন তা নিয়ন্ত্রণ করুন"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"নেটওয়ার্ক;বেতার;Wi-Fi;Wifi;IP;LAN;প্রক্সি;WAN;ব্রডব্যান্ড;মোডেম;ব্লুটুথ;vpn;vlan;ব্রিজ;"
+"বন্ড;DNS;"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/network/net-device-ethernet.c:95
+msgid "never"
+msgstr "কখনো নয়"
+
+# auto translated by TM merge from project: gnome-system-log, version: 3.8.1, DocId: gnome-system-log
+#: panels/network/net-device-ethernet.c:103
+msgid "today"
+msgstr "আজ"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/network/net-device-ethernet.c:105
+msgid "yesterday"
+msgstr "গতকাল"
+
+#: panels/network/net-device-ethernet.c:161
+msgid "Last used"
+msgstr "সর্বশেষ ব্যবহৃত"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:250
+#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+msgid "Wired"
+msgstr "তারযুক্ত"
+
+#: panels/network/net-device-mobile.c:207
+msgid "Add new connection"
+msgstr "নতুন সংযোগ যোগ করুন"
+
+#: panels/network/net-device-wifi.c:851
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"পাসওয়ার্ড সমেত নির্বাচিত নেটওয়ার্কগুলির নেটওয়ার্ক বিস্তারিত এবং যেকোনো কাস্টম "
+"কনফিগারেশন হারিয়ে যাবে।"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/network/net-device-wifi.c:855
+msgid "_Forget"
+msgstr "মুছে ফেলা হবে (_F)"
+
+#: panels/network/net-device-wifi.c:1011 panels/network/net-device-wifi.c:1018
+msgid "Known Wi-Fi Networks"
+msgstr "জানা ওয়াইফাই নেটওয়ার্কগুলি"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1053
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "মুছে ফেলা হবে (_F)"
+
+#: panels/network/net-device-wifi.c:1193
+msgid "System policy prohibits use as a Hotspot"
+msgstr "হটস্পট হিসাবে ব্যবহার সিস্টেম নীতি নিষিদ্ধ করে"
+
+#: panels/network/net-device-wifi.c:1196
+msgid "Wireless device does not support Hotspot mode"
+msgstr "বেতার ডিভাইস হটস্পট মোড সমর্থন করে না"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/network/net-proxy.c:70
+#: panels/notifications/cc-notifications-panel.c:268
+#: panels/power/cc-power-panel.c:1728 panels/power/cc-power-panel.c:1739
+#: panels/universal-access/cc-ua-panel.c:480
+#: panels/universal-access/cc-ua-panel.c:840
+#: panels/universal-access/cc-ua-panel.c:853
+#: panels/universal-access/cc-ua-panel.c:865
+#: panels/universal-access/cc-ua-panel.c:1030
+#: panels/universal-access/cc-ua-panel.ui:321
+#: panels/universal-access/cc-ua-panel.ui:367
+#: panels/universal-access/cc-ua-panel.ui:413
+#: panels/universal-access/cc-ua-panel.ui:519
+#: panels/universal-access/cc-ua-panel.ui:672
+#: panels/universal-access/cc-ua-panel.ui:718
+#: panels/universal-access/cc-ua-panel.ui:764
+#: panels/universal-access/cc-ua-panel.ui:948
+msgid "Off"
+msgstr "বন্ধ"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:113
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"কনফিগারেশন URL সরবরাহ করা না হলে ওয়েব প্রক্সি স্বয়ংক্রিয়-ডিসকভারি ব্যবহার করা হয়।"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:121
+msgid "This is not recommended for untrusted public networks."
+msgstr "অবিশ্বস্ত সর্বজনীন নেটওয়ার্কের ক্ষেত্রে এটি প্রস্তাবিত নয়।"
+
+#. update title
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/net-vpn.c:66 panels/network/net-vpn.c:163
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#: panels/network/network-bluetooth.ui:50
+msgid "Turn device off"
+msgstr "ডিভাইস বন্ধ করুন"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/network-mobile.ui:29
+msgid "IMEI"
+msgstr "IMEI"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/network-mobile.ui:47
+msgid "Provider"
+msgstr "সরবরাহকারী"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:95
+msgid "Network Proxy"
+msgstr "নেটওয়ার্ক প্রক্সি"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/network-proxy.ui:176
+msgid "_HTTP Proxy"
+msgstr "_HTTP প্রক্সি"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/network-proxy.ui:195
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS প্রক্সি"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/network-proxy.ui:214
+msgid "_FTP Proxy"
+msgstr "_FTP প্রক্সি"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/network-proxy.ui:233
+msgid "_Socks Host"
+msgstr "সকস হোস্ট (_S)"
+
+#: panels/network/network-proxy.ui:252
+msgid "_Ignore Hosts"
+msgstr "হোস্ট উপেক্ষা করুন (_I)"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/network/network-proxy.ui:290
+msgid "HTTP proxy port"
+msgstr "HTTP প্রক্সি পোর্ট"
+
+#: panels/network/network-proxy.ui:367
+msgid "HTTPS proxy port"
+msgstr "HTTPS প্রক্সি পোর্ট"
+
+#: panels/network/network-proxy.ui:388
+msgid "FTP proxy port"
+msgstr "FTP প্রক্সি পোর্ট"
+
+#: panels/network/network-proxy.ui:409
+msgid "Socks proxy port"
+msgstr "Socks প্রক্সি পোর্ট"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/network-proxy.ui:438
+msgid "_Configuration URL"
+msgstr "কনফিগারেশন URL (_C)"
+
+#: panels/network/network-vpn.ui:55
+msgid "Turn VPN connection off"
+msgstr "VPN সংযোগ বন্ধ করুন"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/network/network-wifi.ui:22
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "নেটওয়ার্কের নাম"
+
+#: panels/network/network-wifi.ui:28
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "নিরাপত্তা ধরন"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 5177-68190
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "পাসওয়ার্ড"
+
+#: panels/network/network-wifi.ui:84
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi বন্ধ করুন"
+
+#: panels/network/network-wifi.ui:116
+msgid "_Connect to Hidden Network…"
+msgstr "লুকানো নেটওয়ার্কে সংযোগ করুন (_C)…"
+
+#: panels/network/network-wifi.ui:127
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi হটস্পট চালু করুন(_T)..."
+
+#: panels/network/network-wifi.ui:138
+msgid "_Known Wi-Fi Networks"
+msgstr "জানা ওয়াইফাই নেটওয়ার্কগুলি(_K)"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "স্ট্যাটাস অজানা"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "অপরিচালিত"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#. TRANSLATORS: device status
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/network/panel-common.c:45 panels/user-accounts/cc-user-panel.c:950
+msgid "Unavailable"
+msgstr "উপলব্ধ নয়"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "সংযোগ করা হচ্ছে"
+
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "অনুমোদন আবশ্যক"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "সংযুক্ত"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "সংযোগ বিচ্ছিন্ন করা হচ্ছে"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "সংযোগ বিফল"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "স্ট্যাটাস অজানা (অনুপস্থিত)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "কনফিগারেশন করা যায়নি"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP কনফিগারেশন ব্যর্থ হয়েছে"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP কনফিগারেশনের মেয়াদ শেষ হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "গোপনীয় তথ্য আবশ্যক, কিন্তু উপলব্ধ নয়"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x সাপ্লিক্যান্টের সংযোগ বিচ্ছিন্ন করা হয়েছে"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x সাপ্লিক্যান্টের কনফিগারেশন বিফল হয়েছে"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x সাপ্লিক্যান্ট বিফল হয়েছে"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x সাপ্লিক্যান্ট অনুমোদন করতে অত্যাধিক সময় ব্যয় হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP পরিসেবা আরম্ভ করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP পরিসেবার সাথে সংযোগ বিচ্ছিন্ন হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP বিফল"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP ক্লায়েন্ট আরম্ভ করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP ক্লায়েন্ট সংক্রান্ত ত্রুটি"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP ক্লায়েন্ট বিফল হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "যৌথরূপে ব্যবহৃত সংযোগ পরিসেবা আরম্ভ হতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "যৌথরূপে ব্যবহৃত পরিসেবা বিফল হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP পরিসেবা আরম্ভ করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP পরিসেবায় ত্রুটি"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP পরিসেবা বিফল"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "লাইন ব্যস্ত"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "ডায়েল টোন অনুপস্থিত"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "কোনো কেরিয়ার নির্ধারণ করা যায়নি"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "ডায়াল অনুরোধের সময় শেষ হয়ে গেছে"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "ডায়াল করার প্রচেষ্টা ব্যর্থ হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "মোডেম আরম্ভ করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "চিহ্নিত APN নির্বাচন করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "নেটওয়ার্ক সন্ধান করা হচ্ছে না"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "নেটওয়ার্ক নিবন্ধন প্রত্যাখ্যান করা হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "নেটওয়ার্ক নিবন্ধন করতে সময়সীমা উত্তীর্ণ হয়েছে"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "অনুরোধ করা নেটওয়ার্কে নিবন্ধন করতে ব্যর্থ"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN পরীক্ষা করতে ব্যর্থ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "অনুপস্থিত হতে পারে এমন ডিভাইসের ফার্মওয়্যার"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "সংযোগ চলে গেছে"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "বিদ্যমান সংযোগ ধরে নেওয়া হয়েছে"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "মোডেম পাওয়া যায়নি"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "ব্লুটুথ সংযোগ ব্যর্থ হয়েছে"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM কার্ড ঢোকানো হয়নি"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM পিন প্রয়োজনীয়"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM পুক প্রয়োজনীয়"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252
+msgid "SIM wrong"
+msgstr "SIM ভুল"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "সংযোগ নির্ভরশীলতা ব্যর্থ হয়েছে"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:351
+msgid "Firmware missing"
+msgstr "ফায়ারওয়্যার অনুপস্থিত"
+
+# auto translated by TM merge from project: gnome-getting-started-docs, version: 3.8.3.0.1, DocId: gnome-getting-started-docs
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:355
+msgid "Cable unplugged"
+msgstr "কেবল বিচ্ছিন্ন করা হয়েছে"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "802.1X সুরক্ষা (ডাব্লুপিএ-এপ) এ অপরিজ্ঞাত ত্রুটি"
+
+#: panels/network/wireless-security/eap-method.c:195
+msgid "no file selected"
+msgstr "কোনও ফাইল নির্বাচিত হয়নি"
+
+#: panels/network/wireless-security/eap-method.c:222
+msgid "unspecified error validating eap-method file"
+msgstr "Eap-পদ্ধতি ফাইলটি বৈধকরণে অনির্দিষ্ট ত্রুটি"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "DER, PEM, বা PKCS#12 ব্যক্তিগত কী (*.der, *.pem, *.p12)"
+
+#: panels/network/wireless-security/eap-method.c:400
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER বা PEM শংসাপত্র (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:87
+msgid "missing EAP-FAST PAC file"
+msgstr "EAP-FAST PAC ফাইল অনুপস্থিত"
+
+#: panels/network/wireless-security/eap-method-fast.c:347
+msgid "Choose a PAC file"
+msgstr "একটি PAC ফাইল বাছুন"
+
+#: panels/network/wireless-security/eap-method-fast.c:352
+msgid "PAC files (*.pac)"
+msgstr "PAC ফাইল (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "নামবিহীন"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "অনুমোদিত"
+
+# auto translated by TM merge from project: subscription-manager, version: 1.8.13, DocId: subscription-manager
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "উভয়"
+
+#: panels/network/wireless-security/eap-method-fast.ui:49
+#: panels/network/wireless-security/eap-method-peap.ui:52
+#: panels/network/wireless-security/eap-method-ttls.ui:51
+msgid "Anony_mous identity"
+msgstr "নামবিহীন পরিচয় (_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:75
+msgid "PAC _file"
+msgstr "PAC ফাইল (_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:115
+#: panels/network/wireless-security/eap-method-peap.ui:150
+#: panels/network/wireless-security/eap-method-ttls.ui:143
+msgid "_Inner authentication"
+msgstr "অভ্যন্তরীণ প্রমাণীকরণ (_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:144
+msgid "Allow automatic PAC pro_visioning"
+msgstr "স্বয়ংক্রিয় PAC pro_visioning এর অনুমতি দিন"
+
+#: panels/network/wireless-security/eap-method-leap.c:64
+msgid "missing EAP-LEAP username"
+msgstr "EAP-LEAP ব্যবহারকারীর নাম অনুপস্থিত"
+
+#: panels/network/wireless-security/eap-method-leap.c:73
+msgid "missing EAP-LEAP password"
+msgstr "EAP-LEAP পাসওয়ার্ড অনুপস্থিত"
+
+# auto translated by TM merge from project: gnome-boxes, version: 3.8.3, DocId: gnome-boxes
+#: panels/network/wireless-security/eap-method-leap.ui:17
+#: panels/network/wireless-security/eap-method-simple.ui:17
+#: panels/network/wireless-security/ws-leap.ui:18
+#: panels/user-accounts/cc-add-user-dialog.ui:146
+#: panels/user-accounts/cc-add-user-dialog.ui:527
+msgid "_Username"
+msgstr "ব্যবহারকারীর নাম (_U)"
+
+# auto translated by TM merge from project: gnome-boxes, version: 3.8.3, DocId: gnome-boxes
+#: panels/network/wireless-security/eap-method-leap.ui:31
+#: panels/network/wireless-security/eap-method-simple.ui:31
+#: panels/network/wireless-security/ws-leap.ui:32
+#: panels/network/wireless-security/ws-wpa-psk.ui:14
+#: panels/sharing/cc-sharing-panel.ui:202
+#: panels/user-accounts/cc-add-user-dialog.ui:310
+#: panels/user-accounts/cc-add-user-dialog.ui:547
+#: panels/user-accounts/cc-user-panel.ui:436
+msgid "_Password"
+msgstr "পাসওয়ার্ড (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:55
+#: panels/network/wireless-security/eap-method-simple.ui:73
+#: panels/network/wireless-security/eap-method-tls.ui:157
+#: panels/network/wireless-security/ws-leap.ui:56
+#: panels/network/wireless-security/ws-wpa-psk.ui:64
+msgid "Sho_w password"
+msgstr "পাসওয়ার্ড দেখান (_w)"
+
+#: panels/network/wireless-security/eap-method-peap.c:87
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "অবৈধ EAP-PEAP CA শংসাপত্র: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:96
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "অবৈধ EAP-PEAP CA শংসাপত্র: কোনও শংসাপত্র নির্দিষ্ট করা হয়নি"
+
+#: panels/network/wireless-security/eap-method-peap.c:328
+#: panels/network/wireless-security/eap-method-tls.c:507
+#: panels/network/wireless-security/eap-method-ttls.c:336
+msgid "Choose a Certificate Authority certificate"
+msgstr "একটি শংসাপত্র কর্তৃপক্ষ শংসাপত্র বাছুন"
+
+# auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "সংস্করণ ০"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "ভার্সান ১"
+
+#: panels/network/wireless-security/eap-method-peap.ui:78
+#: panels/network/wireless-security/eap-method-tls.ui:68
+#: panels/network/wireless-security/eap-method-ttls.ui:102
+msgid "C_A certificate"
+msgstr "C_A শংসাপত্র"
+
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#: panels/network/wireless-security/eap-method-peap.ui:100
+#: panels/network/wireless-security/eap-method-tls.ui:90
+#: panels/network/wireless-security/eap-method-ttls.ui:125
+msgid "No CA certificate is _required"
+msgstr "কোনও সিএ শংসাপত্রের প্রয়োজন নেই(_r)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:118
+msgid "PEAP _version"
+msgstr "PEAP সংস্করণ (_v)"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "EAP ব্যবহারকারীর নাম অনুপস্থিত"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "EAP পাসওয়ার্ড অনুপস্থিত"
+
+#: panels/network/wireless-security/eap-method-tls.c:91
+msgid "missing EAP-TLS identity"
+msgstr "EAP-TLS পরিচয় অনুপস্থিত"
+
+#: panels/network/wireless-security/eap-method-tls.c:101
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "অবৈধ EAP-TLS CA শংসাপত্র: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:111
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "অবৈধ EAP-TLS CA শংসাপত্র: কোনও শংসাপত্র নির্দিষ্ট করা হয়নি"
+
+#: panels/network/wireless-security/eap-method-tls.c:125
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "অবৈধ EAP-TLS ব্যক্তিগত-কী: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:135
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "অবৈধ EAP-TLS ব্যবহারকারীর শংসাপত্র: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:266
+msgid "Unencrypted private keys are insecure"
+msgstr "এনক্রিপ্ট না করা ব্যক্তিগত কী অনিরাপদ"
+
+#: panels/network/wireless-security/eap-method-tls.c:269
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"নির্বাচিত ব্যক্তিগত কী কোনও পাসওয়ার্ড দ্বারা সুরক্ষিত বলে মনে হয় না। এটি আপনার "
+"সুরক্ষা শংসাপত্রগুলিকে আপস করার অনুমতি দিতে পারে। দয়া করে একটি পাসওয়ার্ড-সুরক্ষিত "
+"ব্যক্তিগত কী নির্বাচন করুন।\n"
+"\n"
+"(আপনি ওপেনএসএল দিয়ে আপনার ব্যক্তিগত কী পাসওয়ার্ড-সুরক্ষা রাখতে পারবেন)"
+
+#: panels/network/wireless-security/eap-method-tls.c:500
+msgid "Choose your personal certificate"
+msgstr "আপনার ব্যক্তিগত শংসাপত্র বাছুন"
+
+#: panels/network/wireless-security/eap-method-tls.c:514
+msgid "Choose your private key"
+msgstr "আপনার ব্যক্তিগত কী বাছুন"
+
+#: panels/network/wireless-security/eap-method-tls.ui:17
+msgid "I_dentity"
+msgstr "পরিচয় (_d)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:43
+msgid "_User certificate"
+msgstr "ব্যবহারকারী শংসাপত্র (_U)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "Private _key"
+msgstr "ব্যক্তিগত কী (_k)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:133
+msgid "_Private key password"
+msgstr "ব্যক্তিগত কী পাসওয়ার্ড (_P)"
+
+#: panels/network/wireless-security/eap-method-ttls.c:98
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "অবৈধ EAP-TTLS CA শংসাপত্র: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:106
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "অবৈধ EAP-TTLS CA শংসাপত্র: কোনও শংসাপত্র নির্দিষ্ট করা হয়নি"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2(EAP নেই)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/network/wireless-security/eap-method-ttls.ui:76
+#: panels/user-accounts/cc-add-user-dialog.ui:507
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "ডোমেইন (_D)"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "802.1X সুরক্ষা বৈধকরণে অজানা ত্রুটি"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "টানেলড TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "সুরক্ষিত EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:102
+#: panels/network/wireless-security/ws-wpa-eap.ui:61
+msgid "Au_thentication"
+msgstr "প্রমাণীকরণ (_t)"
+
+#: panels/network/wireless-security/ws-leap.c:65
+msgid "missing leap-username"
+msgstr "লিপ-ব্যবহারকারীর নাম অনুপস্থিত"
+
+#: panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr "লিপ-পাসওয়ার্ড অনুপস্থিত"
+
+#: panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr "ওয়েপ-কি অনুপস্থিত"
+
+#: panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "অবৈধ ওয়েপ-কী: %zu দৈর্ঘ্যের কীটিতে অবশ্যই হেক্স-সংখ্যা থাকতে হবে"
+
+#: panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "অবৈধ ওয়েপ-কী: %zu দৈর্ঘ্যের কীটিতে অবশ্যই আসকি অক্ষর থাকতে হবে"
+
+#: panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"অবৈধ ওয়েপ-কী: ভুল কী দৈর্ঘ্য %zu। একটি কী দৈর্ঘ্যের 5/13 (ascii) বা 10/26 (হেক্স) "
+"এর হতে হবে"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "অবৈধ ওয়েপ-কী: পাসফ্রেজ অবশ্যই খালি থাকতে হবে"
+
+#: panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "অবৈধ ওয়েপ-কী: পাসফ্রেজটি ৬৪ টি অক্ষরের চেয়ে কম হওয়া উচিত"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "১ (ডিফল্ট)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "মুক্ত সিস্টেম"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "ভাগ করা কী"
+
+#: panels/network/wireless-security/ws-wep-key.ui:48
+msgid "_Key"
+msgstr "কী (_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:84
+msgid "Sho_w key"
+msgstr "কী দেখান (_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:134
+msgid "WEP inde_x"
+msgstr "WEP সূচি (_x)"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"অবৈধ ডাব্লুপিএ-পিএসকি: অবৈধ কী-দৈর্ঘ্য %zu। অবশ্যই [৮,৬৩] বাইট বা ৬৪ হেক্স অঙ্কের "
+"হতে হবে"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "অবৈধ ডাব্লুপিএ-পিএসকি: ৬৪ বাইটকে হেক্স হিসাবে কী ব্যাখ্যা করতে পারে না"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#: panels/network/wireless-security/ws-wpa-psk.ui:42
+msgid "_Type"
+msgstr "ধরন (_T)"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:60
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "সূচনাবার্তা (_N)"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:112
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "শব্দ সর্তকতা (_A)"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#: panels/notifications/cc-app-notifications-dialog.ui:168
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "বিজ্ঞপ্তি পপআপগুলি (_P)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:184
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr "পপআপগুলি অক্ষম করা হলে বিজ্ঞপ্তিগুলি বিজ্ঞপ্তি তালিকায় প্রদর্শিত হতে থাকবে।"
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:249
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "পপআপে বার্তা সামগ্রী দেখান(_C)"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#: panels/notifications/cc-app-notifications-dialog.ui:300
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "লক স্ক্রিন বিজ্ঞপ্তিগুলি (_L)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:351
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "লক স্ক্রিনে বার্তা সামগ্রী প্রদর্শন করুন (_o)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/notifications/cc-notifications-panel.c:268
+#: panels/power/cc-power-panel.c:1734 panels/power/cc-power-panel.c:1741
+#: panels/universal-access/cc-ua-panel.c:480
+#: panels/universal-access/cc-ua-panel.c:840
+#: panels/universal-access/cc-ua-panel.c:853
+#: panels/universal-access/cc-ua-panel.c:865
+#: panels/universal-access/cc-ua-panel.c:1030
+msgid "On"
+msgstr "চালু"
+
+#: panels/notifications/cc-notifications-panel.ui:47
+msgid "_Do Not Disturb"
+msgstr "বিরক্ত করবেন না(_D)"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#: panels/notifications/cc-notifications-panel.ui:55
+msgid "_Lock Screen Notifications"
+msgstr "লক স্ক্রিন বিজ্ঞপ্তি (_L)"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "কোন বিজ্ঞপ্তিগুলি দেখানো হবে এবং তারা কী দেখায় তা নিয়ন্ত্রণ করুন"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "বিজ্ঞপ্তি;ব্যানার;বার্তা;ট্রে;পপ-আপ;"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/online-accounts/cc-online-accounts-panel.c:150
+msgctxt "Online Account"
+msgid "Other"
+msgstr "অন্যান্য"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:622
+#, c-format
+msgid "%s Account"
+msgstr "%s এর অ্যাকাউন্ট"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/online-accounts/cc-online-accounts-panel.c:918
+msgid "Error removing account"
+msgstr "অ্যাকাউন্ট অপসারণের করার সময় ত্রুটি"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:984
+#, c-format
+msgid "%s removed"
+msgstr "%s সরানো হয়েছে"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "অনলাইন অ্যাকাউন্ট"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"আপনার অনলাইন অ্যাকাউন্টগুলিতে সংযোগ করুন এবং তাদের কী কাজে ব্যবহার করবেন তার স্থির "
+"করুন"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;অনলাইন;চ্যাট;ক্যালেন্ডার;মেল;পরিচিতি;ownCloud;"
+"Kerberos;IMAP;SMTP;পকেট;ReadItLater;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:61
+msgid "Undo"
+msgstr "পূর্বাবস্থায় ফিরুন"
+
+#: panels/online-accounts/online-accounts.ui:94
+msgid "Connect to your data in the cloud"
+msgstr "ক্লাউডে আপনার ডেটা সংযোগ করুন"
+
+#: panels/online-accounts/online-accounts.ui:109
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "কোনও ইন্টারনেট সংযোগ নেই - নতুন অনলাইন অ্যাকাউন্ট সেট আপ করতে সংযুক্ত হন"
+
+#: panels/online-accounts/online-accounts.ui:134
+msgid "Add an account"
+msgstr "অ্যাকাউন্ট যোগ করুন"
+
+#: panels/online-accounts/online-accounts.ui:238
+msgid "Remove Account"
+msgstr "অ্যাকাউন্ট সরান"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#: panels/power/cc-power-panel.c:331
+msgid "Unknown time"
+msgstr "অজানা সময়"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#: panels/power/cc-power-panel.c:337
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i মিনিট"
+msgstr[1] "%i মিনিটে"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#: panels/power/cc-power-panel.c:349
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ঘন্টা"
+msgstr[1] "%i ঘন্টায়"
+
+# auto translated by TM merge from project: gnome-packagekit, version: 3.8.2, DocId: gnome-packagekit
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-power-panel.c:357
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/power/cc-power-panel.c:358
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ঘন্টা"
+msgstr[1] "ঘন্টা"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/power/cc-power-panel.c:359
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "মিনিট"
+msgstr[1] "মিনিট"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:377
+#, c-format
+msgid "%s until fully charged"
+msgstr "চার্জ পূর্ণ হতে %s বাকি"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:384
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "সর্তকতা: %s বাকি আছে"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:389
+#, c-format
+msgid "%s remaining"
+msgstr "%s বাকি আছে"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:394 panels/power/cc-power-panel.c:424
+msgid "Fully charged"
+msgstr "সম্পূর্ণ চার্জ রয়েছে"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:398 panels/power/cc-power-panel.c:428
+msgid "Not charging"
+msgstr "চার্জ করা হচ্ছে না"
+
+# auto translated by TM merge from project: RHEL Installation Guide, version: 6.0, DocId: Partitions-x86
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:402 panels/power/cc-power-panel.c:432
+msgid "Empty"
+msgstr "খালি"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:415
+msgid "Charging"
+msgstr "ব্যাটারি চার্জ করা হচ্ছে"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:420
+msgid "Discharging"
+msgstr "ব্যাটারি ব্যবহার করা হচ্ছে"
+
+#: panels/power/cc-power-panel.c:566
+msgctxt "Battery name"
+msgid "Main"
+msgstr "প্রধান"
+
+#: panels/power/cc-power-panel.c:568
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "অতিরিক্ত"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:643
+msgid "Wireless mouse"
+msgstr "বেতার মাউস"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:646
+msgid "Wireless keyboard"
+msgstr "বেতার কীবোর্ড"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:649
+msgid "Uninterruptible power supply"
+msgstr "নিরবিচ্ছিন্ন বিদ্যুত সরবরাহ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:652
+msgid "Personal digital assistant"
+msgstr "ব্যক্তিগত ডিজিট্যাল সহায়ক"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:655
+msgid "Cellphone"
+msgstr "সেলফোন"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:658
+msgid "Media player"
+msgstr "মিডিয়া প্লেয়ার"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:661 panels/wacom/cc-wacom-panel.c:728
+msgid "Tablet"
+msgstr "ট্যাবলেট"
+
+# auto translated by TM merge from project: gvfs, version: 1.16.3, DocId: gvfs
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:664
+msgid "Computer"
+msgstr "কম্পিউটার"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:667
+msgid "Gaming input device"
+msgstr "গেমিং ইনপুট ডিভাইস"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-power-panel.c:670 panels/power/cc-power-panel.c:962
+#: panels/power/cc-power-panel.c:2278
+msgid "Battery"
+msgstr "ব্যাটারি"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:731
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "ব্যাটারি চার্জ করা হচ্ছে"
+
+# auto translated by TM merge from project: gnome-doc-utils, version: 0.20.10, DocId: gnome-doc-utils
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:738
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "সতর্কতা"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:743
+msgctxt "Battery power"
+msgid "Low"
+msgstr "নিচু"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:748
+msgctxt "Battery power"
+msgid "Good"
+msgstr "ভাল"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:753
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "সম্পূর্ণ চার্জ রয়েছে"
+
+# auto translated by TM merge from project: RHEL Installation Guide, version: 6.0, DocId: Partitions-x86
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:757
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "খালি"
+
+#: panels/power/cc-power-panel.c:960
+msgid "Batteries"
+msgstr "ব্যাটারিগুলি"
+
+#: panels/power/cc-power-panel.c:1182
+msgid "When _idle"
+msgstr "নীরব অবস্থায় (_i)"
+
+#: panels/power/cc-power-panel.c:1676
+msgid "Suspend"
+msgstr "নিম্বিত করুন"
+
+# auto translated by TM merge from project: gnome-shell-extensions, version: 3.8.3, DocId: gnome-shell-extensions
+#: panels/power/cc-power-panel.c:1677
+msgid "Power Off"
+msgstr "বন্ধ করুন"
+
+# auto translated by TM merge from project: gnome-shell-extensions, version: 3.8.3, DocId: gnome-shell-extensions
+#: panels/power/cc-power-panel.c:1678
+msgid "Hibernate"
+msgstr "নিদ্রিত অবস্থা"
+
+#: panels/power/cc-power-panel.c:1679
+msgid "Nothing"
+msgstr "কিছু নয়"
+
+#: panels/power/cc-power-panel.c:1730
+msgid "When on battery power"
+msgstr "যখন ব্যাটারি পাওয়ার চালু"
+
+#: panels/power/cc-power-panel.c:1732
+msgid "When plugged in"
+msgstr "প্লাগইন অবস্থায়"
+
+#: panels/power/cc-power-panel.c:1836
+msgid "Power Saving"
+msgstr "বিদ্যুতের সংরক্ষণ"
+
+#: panels/power/cc-power-panel.c:1872
+msgid "_Screen Brightness"
+msgstr "স্ক্রীন উজ্জ্বলতা (_S)"
+
+#: panels/power/cc-power-panel.c:1895
+msgid "Automatic Brightness"
+msgstr "স্বয়ংক্রিয় উজ্জ্বলতা"
+
+#: panels/power/cc-power-panel.c:1908
+msgid "_Keyboard Brightness"
+msgstr "কীবোর্ড উজ্জ্বলতা (_K)"
+
+#: panels/power/cc-power-panel.c:1921
+msgid "_Dim Screen When Inactive"
+msgstr "নিষ্ক্রিয় অবস্থায় আবছা স্ক্রীন (_D)"
+
+#: panels/power/cc-power-panel.c:1939
+msgid "_Blank Screen"
+msgstr "খালি স্ক্রীন (_B)"
+
+#: panels/power/cc-power-panel.c:1985
+msgid "_Automatic Suspend"
+msgstr "স্বয়ংক্রিয় বিলম্ব (_A)"
+
+#: panels/power/cc-power-panel.c:1986
+msgid "Automatic suspend"
+msgstr "স্বয়ংক্রিয় বিলম্ব"
+
+#: panels/power/cc-power-panel.c:2038
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: panels/power/cc-power-panel.c:2039
+msgid "Wi-Fi can be turned off to save power."
+msgstr "পাওয়ার বাঁচাতে Wi-Fi বন্ধ করা যেতে পারে।"
+
+#: panels/power/cc-power-panel.c:2055
+msgid "_Mobile Broadband"
+msgstr "মোবাইল ব্রড-ব্যান্ড (_M)"
+
+#: panels/power/cc-power-panel.c:2056
+msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+msgstr ""
+"মোবাইল ব্রডব্যান্ড (এলটিই, ৪ জি, ৩ জি, ইত্যাদি) পাওয়ার সাশ্রয় করতে বন্ধ করা যেতে "
+"পারে।"
+
+#: panels/power/cc-power-panel.c:2106
+msgid "_Bluetooth"
+msgstr "ব্লুটুথ (_B)"
+
+#: panels/power/cc-power-panel.c:2107
+msgid "Bluetooth can be turned off to save power."
+msgstr "পাওয়ার বাঁচাতে ব্লুটুথ বন্ধ করা যেতে পারে।"
+
+#: panels/power/cc-power-panel.c:2144
+msgid "Show Battery _Percentage"
+msgstr "ব্যাটারি শতাংশ প্রদর্শন করুন(_P)"
+
+#. Frame header
+#: panels/power/cc-power-panel.c:2170
+msgid "Suspend & Power Button"
+msgstr "বিলম্বিত এবং পাওয়ার বন্ধ করুন"
+
+#: panels/power/cc-power-panel.c:2220
+msgid "Po_wer Button Behavior"
+msgstr "পাওয়ার বাটন আচরণ(_w)"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:13
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "১৫ মিনিট"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:17
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "২০ মিনিট"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:21
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "২৫ মিনিট"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:25
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "৩০ মিনিট"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:29
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "৪৫ মিনিট"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:33
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "১ ঘন্টা"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:37
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "৮০ মিনিট"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:41
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "৯০ মিনিট"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:45
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "১০০ মিনিট"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:49
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "২ ঘন্টা"
+
+#: panels/power/cc-power-panel.ui:145
+msgid "Automatic Suspend"
+msgstr "স্বয়ংক্রিয় বিলম্ব"
+
+#: panels/power/cc-power-panel.ui:170
+msgid "_Plugged In"
+msgstr "প্লাগইন অবস্থায় (_P)"
+
+#: panels/power/cc-power-panel.ui:186
+msgid "On _Battery Power"
+msgstr "ব্যাটারির পাওয়ারে (_B)"
+
+#: panels/power/cc-power-panel.ui:231 panels/power/cc-power-panel.ui:291
+#: panels/universal-access/cc-ua-panel.ui:1525
+msgid "Delay"
+msgstr "বিলম্ব"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "পাওয়ার"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "আপনার ব্যাটারির স্থিতি দেখুন এবং পাওয়ার সঞ্চয় সেটিং পরিবর্তন করুন"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"পাওয়ার;ঘুমন্ত;বিলম্ব;হাইবারনেট;ব্যাটারি;উজ্জ্বলতা;অন্ধকারময়;খালি;মনিটর;DPMS;নিশ্চল;"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+# auto translated by TM merge from project: polkit-gnome, version: 0.105, DocId: polkit-gnome-1
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "অনুমোদন"
+
+# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/new-printer-dialog.ui:362
+#: panels/printers/pp-jobs-dialog.ui:57
+msgid "Username"
+msgstr "ব্যবহারকারীর নাম"
+
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:337
+msgid "Authentication Required"
+msgstr "পরিচয় প্রমাণ করতে হবে"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:707
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "প্রিন্টার \"%s\" মুছে ফেলা হয়েছে"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:970
+msgid "Failed to add new printer."
+msgstr "নতুন প্রিন্টার যোগ করতে ব্যর্থ।"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1273
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui লোড করতে ব্যর্থ: %s"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "প্রিন্টার"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"প্রিন্টারগুলি যোগ করুন, প্রিন্টার সংক্রান্ত কাজ দেখুন এবং আপনি কীভাবে প্রিন্ট করতে চান "
+"তা স্থির করুন"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "প্রিন্টার;সারি;মুদ্রণ;কাগজ;কালি;টোনার;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:348
+#: panels/printers/pp-new-printer-dialog.c:405
+msgid "Add Printer"
+msgstr "প্রিন্টার যোগ করুন"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+msgid "_Unlock"
+msgstr "আনলক(_U)"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:211
+msgid "No Printers Found"
+msgstr "কোনও প্রিন্টার পাওয়া যায় নি"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:284
+msgid "Enter a network address or search for a printer"
+msgstr "একটি নেটওয়ার্ক ঠিকানা লিখুন বা একটি প্রিন্টার সন্ধান করুন"
+
+#: panels/printers/new-printer-dialog.ui:353
+msgid "Enter username and password to view printers on Print Server."
+msgstr "প্রিন্ট সার্ভারে প্রিন্টারগুলি দেখতে ব্যবহারকারী নাম এবং পাসওয়ার্ড লিখুন।"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:367
+#, c-format
+msgid "%s Details"
+msgstr "%s বিশদ"
+
+#: panels/printers/pp-details-dialog.c:121
+msgid "No suitable driver found"
+msgstr "কোনো উপযুক্ত ড্রাইভার পাওয়া যায়নি"
+
+#: panels/printers/pp-details-dialog.c:248
+msgid "Select PPD File"
+msgstr "PPD ফাইল নির্বাচন করুন"
+
+#: panels/printers/pp-details-dialog.c:257
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript প্রিন্টার উল্লেখকারী ফাইল (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
+#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "অবস্থান"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:122
+#: panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "ড্রাইভার"
+
+#: panels/printers/pp-details-dialog.ui:162
+msgid "Searching for preferred drivers…"
+msgstr "পছন্দসই ড্রাইভার সন্ধান করা হচ্ছে…"
+
+#: panels/printers/pp-details-dialog.ui:183
+msgid "Search for Drivers"
+msgstr "ড্রাইভারের জন্য অনুসন্ধান করুন"
+
+#: panels/printers/pp-details-dialog.ui:192
+msgid "Select from Database…"
+msgstr "ডেটাবেস থেকে নির্বাচন করুন…"
+
+#: panels/printers/pp-details-dialog.ui:201
+msgid "Install PPD File…"
+msgstr "PPD ফাইল ইনস্টল করুন..."
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr "প্রিন্টার ড্রাইভার নির্বাচন করুন"
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/cc-avatar-chooser.c:109
+msgid "Select"
+msgstr "নির্বাচন করুন"
+
+#: panels/printers/ppd-selection-dialog.ui:73
+msgid "Loading drivers database…"
+msgstr "ড্রাইভার ডেটাবেস লোড হচ্ছে..."
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect প্রিন্টার"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD প্রিন্টার"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "একপার্শ্বিক"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "দীর্ঘ প্রান্ত (প্রমিত মান)"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "ক্ষুদ্র প্রান্ত (উলট)"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "প্রতিকৃতি"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "ভূদৃশ্য"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "বিপরীত ভূদৃশ্য"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "বিপরীত প্রতিকৃতি"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-jobs-dialog.c:222
+msgctxt "print job"
+msgid "Pending"
+msgstr "অসমাপ্ত কর্ম"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-jobs-dialog.c:228
+msgctxt "print job"
+msgid "Paused"
+msgstr "থেমে আছে"
+
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-jobs-dialog.c:233
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "অনুমোদন আবশ্যক"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-jobs-dialog.c:238
+msgctxt "print job"
+msgid "Processing"
+msgstr "কর্মরত"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-jobs-dialog.c:242
+msgctxt "print job"
+msgid "Stopped"
+msgstr "স্থগিত"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-jobs-dialog.c:246
+msgctxt "print job"
+msgid "Canceled"
+msgstr "বাতিল করা"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4312-85999
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-jobs-dialog.c:250
+msgctxt "print job"
+msgid "Aborted"
+msgstr "পরিত্যক্ত"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-jobs-dialog.c:254
+msgctxt "print job"
+msgid "Completed"
+msgstr "সমাপ্ত"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:363
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u টা কাজের প্রমাণীকরণের প্রয়োজন"
+msgstr[1] "%u টি কাজের অনুমোদন প্রয়োজন"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:520
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — সক্রিয় কাজগুলি"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:524
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "%s থেকে প্রিন্ট করতে পরিচয়পত্র লিখুন।"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:44
+msgid "Domain"
+msgstr "ডোমেইন"
+
+# auto translated by TM merge from project: polkit-gnome, version: 0.105, DocId: polkit-gnome-1
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:129
+msgid "A_uthenticate"
+msgstr "অনুমোদন (_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:169
+msgid "Clear All"
+msgstr "সব পরিষ্কার করুন"
+
+# auto translated by TM merge from project: polkit-gnome, version: 0.105, DocId: polkit-gnome-1
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:232
+msgid "_Authenticate"
+msgstr "অনুমোদন(_A)"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:358
+msgid "No Active Printer Jobs"
+msgstr "কোনও অ্যাক্টিভ প্রিন্টারের কাজ নেই"
+
+#: panels/printers/pp-new-printer-dialog.c:363
+msgid "Unlock Print Server"
+msgstr "আনলক প্রিন্ট সার্ভার"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:367
+#, c-format
+msgid "Unlock %s."
+msgstr "%s আনলক করুন।"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:371
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "%s এ প্রিন্টারগুলি দেখতে ব্যবহারকারী নাম এবং পাসওয়ার্ড লিখুন।"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#: panels/printers/pp-new-printer-dialog.c:794
+msgid "Searching for Printers"
+msgstr "প্রিন্টার অনুসন্ধান করা হচ্ছে"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1611
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1616
+msgid "Serial Port"
+msgstr "সিরিয়াল পোর্ট"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1623
+msgid "Parallel Port"
+msgstr "সমান্তরাল পোর্ট"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 4507-74586
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1665
+#, c-format
+msgid "Location: %s"
+msgstr "অবস্থান: %s"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1670
+#, c-format
+msgid "Address: %s"
+msgstr "ঠিকানা: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1697
+msgid "Server requires authentication"
+msgstr "সার্ভারের প্রমাণীকরণের প্রয়োজন"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "উভয়পৃষ্ঠ"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "কাগজের ধরন"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "কাগজের সংগ্রহস্থল"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "আউটপুট-ট্রে"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "রেসলোলিউশন"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript প্রি-ফিল্টারিং"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:530
+msgid "Pages per side"
+msgstr "প্রতি পার্শ্বে পৃষ্ঠা"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:542
+msgid "Two-sided"
+msgstr "উভয় পৃষ্ঠা"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:554
+msgid "Orientation"
+msgstr "সজ্জা"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:651
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "সাধারণ"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "পৃষ্ঠার বৈশিষ্ট্য"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "ইনস্টল করার যোগ্য বিকল্প"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "কর্ম"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "ছবির গুণমান"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "রঙ"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "সমাপ্তি"
+
+# auto translated by TM merge from project: ekiga, version: 4.0.1, DocId: ekiga
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "উন্নত"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:863
+#: panels/printers/pp-options-dialog.ui:18
+msgid "Test Page"
+msgstr "পরীক্ষা পৃষ্ঠা"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:876
+msgid "Test page"
+msgstr "পরীক্ষা পৃষ্ঠা"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "স্বয়ংক্রিয় নির্বাচন"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "প্রিন্টারের ডিফল্ট মান"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "শুধুমাত্র GhostScript ফন্ট এমবেড করা হবে"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "PS লেভেল ১-এ রূপান্তর করা হবে"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "PS লেভেল ২-এ রূপান্তর করা হবে"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "প্রি-ফিল্টারিং বিহীন"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "নির্মাতা"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:588 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr "কোনও সক্রিয় কাজ নেই"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:593
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u টি কাজ"
+msgstr[1] "%u টা কাজ"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:711
+msgid "Clean print heads"
+msgstr "প্রিন্টারের হেড পরিষ্কার করুন"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:762
+msgid "Low on toner"
+msgstr "টোনার কম"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:764
+msgid "Out of toner"
+msgstr "টোনার শেষ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:767
+msgid "Low on developer"
+msgstr "ডেভেলপার কম"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:770
+msgid "Out of developer"
+msgstr "ডেভেলপার শেষ"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:772
+msgid "Low on a marker supply"
+msgstr "মার্কার সরবরাহ কম"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:774
+msgid "Out of a marker supply"
+msgstr "মার্কার সরবরাহ শেষ হয়ে গেছে"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:776
+msgid "Open cover"
+msgstr "মুক্ত আবরণ"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:778
+msgid "Open door"
+msgstr "মুক্ত দরজা"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:780
+msgid "Low on paper"
+msgstr "কাগজ কম"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:782
+msgid "Out of paper"
+msgstr "কাগজ নেই"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:784
+msgctxt "printer state"
+msgid "Offline"
+msgstr "অফলাইন"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:786
+#: panels/printers/pp-printer-entry.c:929
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "থামানো হয়েছে"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:788
+msgid "Waste receptacle almost full"
+msgstr "আবর্জনা পাত্র প্রায় পূর্ণ"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:790
+msgid "Waste receptacle full"
+msgstr "আবর্জনা পাত্র পূর্ণ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:792
+msgid "The optical photo conductor is near end of life"
+msgstr "অপটিক্যাল ফোটো কনডাকটরের আয়ু প্রায় শেষ হয় এসেছে"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:794
+msgid "The optical photo conductor is no longer functioning"
+msgstr "অপটিক্যাল ফোটো কনডাকটার আর কাজ করছে না"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:915
+msgctxt "printer state"
+msgid "Ready"
+msgstr "প্রস্তুত"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:920
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "কাজ নিচ্ছে না"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:925
+msgctxt "printer state"
+msgid "Processing"
+msgstr "কর্মরত"
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr "প্রিন্টিং বিকল্প"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr "প্রিন্টারের বিবরণ"
+
+# auto translated by TM merge from project: gtk3, version: 3.8.2, DocId: gtk30
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr "ডিফল্ট দ্বারা প্রিন্টার ব্যবহার করুন"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr "প্রিন্ট এর মাথা পরিষ্কার করুন"
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "প্রিন্টার সরান"
+
+#: panels/printers/printer-entry.ui:193
+msgid "Model"
+msgstr "মডেল"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr "কালির মাত্রা"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:312
+msgid "Please restart when the problem is resolved."
+msgstr "সমস্যাটি সমাধান হয়ে গেলে পুনরায় চালু করুন।"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:319
+msgid "Restart"
+msgstr "পুনরারম্ভ করুন"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:12
+msgid "Add…"
+msgstr "যোগ..."
+
+#: panels/printers/printers.ui:186
+msgid "No printers"
+msgstr "প্রিন্টার নেই"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:200
+msgid "Add a Printer…"
+msgstr "প্রিন্টার যোগ করুন..."
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:232
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"দুঃখিত! সিস্টেম প্রিন্টর পরিষেবাটি\n"
+"উপলব্ধ বলে মনে হচ্ছে না।"
+
+#: panels/region/cc-format-chooser.c:149
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ইম্পিরিয়াল"
+
+#: panels/region/cc-format-chooser.c:151
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "মেট্রিক"
+
+#: panels/region/cc-format-chooser.c:256 panels/region/cc-format-chooser.c:297
+#: panels/region/cc-format-chooser.ui:6
+msgid "Formats"
+msgstr "ফর্ম্যাট"
+
+# auto translated by TM merge from project: rhn-client-tools, version: 6.2, DocId: rhn-client-tools
+#: panels/region/cc-format-chooser.ui:48
+#: panels/user-accounts/cc-fingerprint-dialog.ui:53
+#: panels/wacom/wacom-stylus-page.ui:37 shell/cc-window.ui:230
+msgid "Back"
+msgstr "পূর্ববর্তী"
+
+#: panels/region/cc-format-chooser.ui:101
+msgid ""
+"Choose the format for numbers, dates and currencies. Changes take effect on "
+"next login."
+msgstr ""
+"সংখ্যা, তিথি এবং মুদ্রার জন্য ফর্ম্যাটটি চয়ন করুন। পরিবর্তনগুলি পরবর্তী লগইনে কার্যকর "
+"হয়।"
+
+#: panels/region/cc-format-chooser.ui:117
+msgid "Search locales..."
+msgstr "লোকেলগুলি অনুসন্ধান করুন..."
+
+#: panels/region/cc-format-chooser.ui:158
+msgid "Common Formats"
+msgstr "সাধারণ ফর্ম্যাটসগুলি"
+
+#: panels/region/cc-format-chooser.ui:189
+msgid "All Formats"
+msgstr "সব ফর্ম্যাটস"
+
+#: panels/region/cc-format-chooser.ui:242
+msgid "No Search Results"
+msgstr "কোন অনুসন্ধান ফলাফল নেই"
+
+#: panels/region/cc-format-chooser.ui:255
+msgid "Searches can be for countries or languages."
+msgstr "অনুসন্ধানগুলি দেশ বা ভাষার জন্য হতে পারে।"
+
+#: panels/region/cc-format-chooser.ui:307
+msgid "Preview"
+msgstr "পূর্বদৃশ্য"
+
+#: panels/region/cc-format-chooser.ui:322
+msgid "Dates"
+msgstr "তিথি"
+
+#: panels/region/cc-format-chooser.ui:366
+msgid "Dates & Times"
+msgstr "তিথি এবং সময়"
+
+#: panels/region/cc-format-chooser.ui:388
+msgid "Numbers"
+msgstr "সংখ্যা"
+
+#: panels/region/cc-format-chooser.ui:410
+msgid "Measurement"
+msgstr "পরিমাপ"
+
+#: panels/region/cc-format-chooser.ui:432
+msgid "Paper"
+msgstr "কাগজ"
+
+#: panels/region/cc-input-chooser.c:193
+msgid "No input sources found"
+msgstr "কোনো ইনপুট সোর্স পাওয়া যায়নি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/region/cc-input-chooser.c:948
+msgctxt "Input Source"
+msgid "Other"
+msgstr "অন্যান্য"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/region/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "একটি ইনপুট সোর্স যোগ করুন"
+
+#: panels/region/cc-input-chooser.ui:77
+msgid "Input methods can’t be used on the login screen"
+msgstr "লগিন স্ক্রীনে ইনপুট পদ্ধতি ব্যবহার করা যাবে না"
+
+#: panels/region/cc-region-panel.c:1507
+msgid "Login _Screen"
+msgstr "লগিন স্ক্রীন (_S)"
+
+#: panels/region/cc-region-panel.ui:62
+#: panels/user-accounts/cc-user-panel.ui:364
+msgid "_Language"
+msgstr "ভাষা (_L)"
+
+#: panels/region/cc-region-panel.ui:97
+msgid "Restart the session for changes to take effect"
+msgstr "পরিবর্তনগুলি কার্যকর হওয়ার জন্য সেশনটি পুনরায় চালু করুন"
+
+#: panels/region/cc-region-panel.ui:112
+msgid "Restart…"
+msgstr "পুনরারম্ভ করুন"
+
+#: panels/region/cc-region-panel.ui:145
+msgid "_Formats"
+msgstr "ফর্ম্যাটগুলি (_F)"
+
+#: panels/region/cc-region-panel.ui:193
+msgid "Input Sources"
+msgstr "ইনপুট সোর্স"
+
+#: panels/region/cc-region-panel.ui:207
+msgid "Choose keyboard layouts or input methods."
+msgstr "কীবোর্ড বিন্যাস বা ইনপুট পদ্ধতি চয়ন করুন।"
+
+#: panels/region/cc-region-panel.ui:264
+msgid "No input source selected"
+msgstr "কোনো ইনপুট সোর্স নির্বাচন করা হয়নি"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/region/cc-region-panel.ui:298
+msgid "Login settings are used by all users when logging into the system"
+msgstr "সিস্টেমে লগিন করার সময়ে সকল ব্যবহারকারীর দ্বারা লগিন সেটিং ব্যবহার করা হয়"
+
+#: panels/region/cc-region-panel.ui:335
+msgid "Input Source Options"
+msgstr "ইনপুট সোর্স বিকল্প"
+
+#: panels/region/cc-region-panel.ui:350
+msgid "Use the _same source for all windows"
+msgstr "সকল উইন্ডোর জন্য একই সোর্স ব্যবহার করুন (_s)"
+
+#: panels/region/cc-region-panel.ui:368
+msgid "Allow _different sources for each window"
+msgstr "প্রত্যেক উইন্ডোর জন্য আলাদা সোর্সের অনুমতি দিন (_d)"
+
+#: panels/region/cc-region-panel.ui:410
+msgid "Previous source"
+msgstr "পূর্ববর্তী উত্স"
+
+#: panels/region/cc-region-panel.ui:428
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/region/cc-region-panel.ui:443
+msgid "Next source"
+msgstr "পরবর্তী উত্স"
+
+#: panels/region/cc-region-panel.ui:461
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: panels/region/cc-region-panel.ui:476
+msgid "Left+Right Alt"
+msgstr "Left+Right Alt"
+
+#: panels/region/cc-region-panel.ui:492
+msgid "These keyboard shortcuts can be changed in the keyboard settings"
+msgstr "আপনি কীবোর্ড সেটিং থেকে এই শর্টকাটগুলি পরিবর্তন করতে পারবেন"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "অঞ্চল & ভাষা"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr "আপনার প্রদর্শন ভাষা, ফর্ম্যাট, কীবোর্ড সজ্জা এবং ইনপুট সোর্স নির্বাচন করুন"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "ভাষা;সজ্জা;কীবোর্ড;ইনপুট;"
+
+#: panels/removable-media/cc-removable-media-panel.c:267
+msgid "Ask what to do"
+msgstr "কী করতে হবে আমাকে জিজ্ঞাসা করুন"
+
+#: panels/removable-media/cc-removable-media-panel.c:271
+msgid "Do nothing"
+msgstr "কিছু নয়"
+
+#: panels/removable-media/cc-removable-media-panel.c:275
+msgid "Open folder"
+msgstr "ফোল্ডার খুলুন"
+
+#: panels/removable-media/cc-removable-media-panel.c:341
+msgid "Other Media"
+msgstr "অন্যান্য মিডিয়া"
+
+#: panels/removable-media/cc-removable-media-panel.c:362
+msgid "Select an application for audio CDs"
+msgstr "অডিও CD'র জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#: panels/removable-media/cc-removable-media-panel.c:363
+msgid "Select an application for video DVDs"
+msgstr "ভিডিও DVD'র জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#: panels/removable-media/cc-removable-media-panel.c:364
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"একটি মিউজিক প্লেয়ার সংযুক্ত অবস্থায় চালানোর জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#: panels/removable-media/cc-removable-media-panel.c:365
+msgid "Select an application to run when a camera is connected"
+msgstr "একটি ক্যামেরা সংযুক্ত অবস্থায় চালানোর জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#: panels/removable-media/cc-removable-media-panel.c:366
+msgid "Select an application for software CDs"
+msgstr "সফ্টওয়্যার CD'র জন্য একটি অ্যাপ্লিকেশন নির্বাচন করুন"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "audio DVD"
+msgstr "অডিও DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "blank Blu-ray disc"
+msgstr "খালি Blu-ray ডিস্ক"
+
+#: panels/removable-media/cc-removable-media-panel.c:380
+msgid "blank CD disc"
+msgstr "খালি CD ডিস্ক"
+
+#: panels/removable-media/cc-removable-media-panel.c:381
+msgid "blank DVD disc"
+msgstr "খালি DVD ডিস্ক"
+
+#: panels/removable-media/cc-removable-media-panel.c:382
+msgid "blank HD DVD disc"
+msgstr "খালি HD DVD ডিস্ক"
+
+#: panels/removable-media/cc-removable-media-panel.c:383
+msgid "Blu-ray video disc"
+msgstr "Blu-ray ভিডিও ডিস্ক"
+
+#: panels/removable-media/cc-removable-media-panel.c:384
+msgid "e-book reader"
+msgstr "ই-বই রিডার"
+
+#: panels/removable-media/cc-removable-media-panel.c:385
+msgid "HD DVD video disc"
+msgstr "HD DVD ভিডিও ডিস্ক"
+
+# auto translated by TM merge from project: nautilus, version: 3.8.2, DocId: nautilus
+#: panels/removable-media/cc-removable-media-panel.c:386
+msgid "Picture CD"
+msgstr "ছবি CD"
+
+# auto translated by TM merge from project: nautilus, version: 3.8.2, DocId: nautilus
+#: panels/removable-media/cc-removable-media-panel.c:387
+msgid "Super Video CD"
+msgstr "সুপার ভিডিও CD"
+
+# auto translated by TM merge from project: nautilus, version: 3.8.2, DocId: nautilus
+#: panels/removable-media/cc-removable-media-panel.c:388
+msgid "Video CD"
+msgstr "ভিডিও CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:389
+msgid "Windows software"
+msgstr "Windows সফ্টওয়্যার"
+
+#: panels/removable-media/cc-removable-media-panel.ui:44
+msgid "Select how media should be handled"
+msgstr "মিডিয়া কীভাবে পরিচালিত হবে তা নির্বাচন করুন"
+
+#: panels/removable-media/cc-removable-media-panel.ui:75
+msgid "CD _audio"
+msgstr "CD অডিও (_a)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:92
+msgid "_DVD video"
+msgstr "_DVD ভিডিও"
+
+#: panels/removable-media/cc-removable-media-panel.ui:133
+msgid "_Music player"
+msgstr "মিউজিক প্লেয়ার (_M)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:191
+msgid "_Software"
+msgstr "সফ্টওয়্যার (_S)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:229
+msgid "_Other Media…"
+msgstr "অন্যান্য মিডিয়া (_O)…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:288
+msgid "_Never prompt or start programs on media insertion"
+msgstr "মিডিয়া সন্নিবেশের সময়ে কখনও সূচনা দেবেন না বা প্রোগ্রাম শুরু করবেন না (_N)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:342
+msgid "Select how other media should be handled"
+msgstr "অন্যান্য মিডিয়া কীভাবে পরিচালিত হবে তা নির্বাচন করুন"
+
+#: panels/removable-media/cc-removable-media-panel.ui:389
+msgid "_Action:"
+msgstr "কর্ম (_A):"
+
+#: panels/removable-media/cc-removable-media-panel.ui:412
+msgid "_Type:"
+msgstr "ধরন (_T):"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "অপসারণযোগ্য মিডিয়া"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "অপসারণযোগ্য মিডিয়া সেটিংস কনফিগার করুন"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"যন্ত্র;সিস্টেম;ডিফল্ট;আবেদন;পছন্দসই;সিডি;ডিভিডি;USB;অডিও;ভিডিও;ডিস্ক;অপসারণযোগ্য;"
+"মিডিয়া;অটোরান;"
+
+#: panels/search/cc-search-locations-dialog.c:635
+msgid "Select Location"
+msgstr "অবস্থান নির্বাচন করুন"
+
+#: panels/search/cc-search-locations-dialog.c:639
+msgid "_OK"
+msgstr "ঠিক আছে (_O)"
+
+#: panels/search/cc-search-locations-dialog.ui:9
+#: panels/search/cc-search-panel.ui:59
+msgid "Search Locations"
+msgstr "অবস্থান সন্ধান"
+
+#: panels/search/cc-search-locations-dialog.ui:32
+#: panels/search/cc-search-locations-dialog.ui:69
+#: panels/search/cc-search-locations-dialog.ui:107
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"ফাইল, ফটো এবং ভিডিওগুলির মতো সিস্টেম অ্যাপ্লিকেশন দ্বারা অনুসন্ধান করা ফোল্ডারগুলি।"
+
+# auto translated by TM merge from project: file-roller, version: 3.8.3, DocId: file-roller
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Places"
+msgstr "অবস্থানগুলি"
+
+# auto translated by TM merge from project: gnome-documents, version: 3.8.3.1, DocId: gnome-documents
+#: panels/search/cc-search-locations-dialog.ui:91
+msgid "Bookmarks"
+msgstr "বুকমার্কগুলি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/search/cc-search-locations-dialog.ui:156
+msgid "Other"
+msgstr "অন্যান্য"
+
+#: panels/search/cc-search-panel.c:152
+msgid "No applications found"
+msgstr "কোনো অ্যাপ্লিকেশন পাওয়া যায়নি"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#: panels/search/cc-search-panel-row.ui:92
+msgid "Move Up"
+msgstr "উপরে স্থানান্তর"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#: panels/search/cc-search-panel-row.ui:102
+msgid "Move Down"
+msgstr "নীচে স্থানান্তর"
+
+#: panels/search/cc-search-panel.ui:31
+msgid ""
+"Control which search results are shown in the Activities Overview. The order "
+"of search results can also be changed by moving rows in the list."
+msgstr ""
+"ক্রিয়াকলাপ ওভারভিউতে কোন অনুসন্ধান ফলাফল দেখানো হয়েছে তা নিয়ন্ত্রণ করুন। তালিকায় "
+"সারি সরিয়েও অনুসন্ধানের ফলাফলের ক্রম পরিবর্তন করা যেতে পারে।"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "ক্রিয়াকলাপ পূর্বরূপে কোন অ্যাপ্লিকেশনগুলি সন্ধান ফলাফল দেখাবে তা নিয়ন্ত্রণ করুন"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "সন্ধান;খোঁজ;সূচি;লুকানো;গোপনীয়তা;ফলাফল;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:306
+msgid "No networks selected for sharing"
+msgstr "ভাগ করার জন্য কোনো নেটওয়ার্ক নির্বাচন করা হয়নি"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#: panels/sharing/cc-sharing-networks.ui:19
+msgid "Networks"
+msgstr "নেটওয়ার্ক"
+
+# auto translated by TM merge from project: control-center, version: 3.8.3, DocId: gnome-control-center-2.0
+#: panels/sharing/cc-sharing-panel.c:289
+msgctxt "service is enabled"
+msgid "On"
+msgstr "চালু"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/sharing/cc-sharing-panel.c:291 panels/sharing/cc-sharing-panel.c:318
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "বন্ধ"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#: panels/sharing/cc-sharing-panel.c:321
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "সক্রিয়"
+
+#: panels/sharing/cc-sharing-panel.c:324
+msgctxt "service is active"
+msgid "Active"
+msgstr "সক্রিয়"
+
+#: panels/sharing/cc-sharing-panel.c:393
+msgid "Choose a Folder"
+msgstr "একটি ফোল্ডার বাছুন"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:696
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"ফাইল ভাগ করে নেওয়া আপনাকে: আপনার বর্তমান নেটওয়ার্কে অন্যদের সাথে আপনার পাবলিক "
+"ফোল্ডারটি ভাগ করে নিতে মঞ্জুরি দেয়: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:702
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"যখন রিমোট লগইন সক্ষম থাকে তখন দূরবর্তী ব্যবহারকারীরা সিকিউর শেল কমান্ডটি ব্যবহার "
+"করে সংযোগ করতে পারেন:\n"
+"%s"
+
+#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:708
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to %s"
+msgstr ""
+"স্ক্রিন ভাগ করে নেওয়া দূরবর্তী ব্যবহারকারীদের %s এর সাথে সংযুক্ত হয়ে আপনার স্ক্রিনটি "
+"দেখতে বা নিয়ন্ত্রণ করতে দেয়"
+
+# auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
+#: panels/sharing/cc-sharing-panel.c:813
+msgid "Copy"
+msgstr "কপি করুন"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/sharing/cc-sharing-panel.c:1203
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "যৌথরূপে ব্যবহার"
+
+# auto translated by TM merge from project: gdm, version: 3.8.4, DocId: gdm
+#: panels/sharing/cc-sharing-panel.ui:32
+msgid "_Computer Name"
+msgstr "কম্পিউটারের নাম(_C)"
+
+# auto translated by TM merge from project: gnome-user-share, version: 3.8, DocId: gnome-user-share
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_File Sharing"
+msgstr "ফাইল ভাগাভাগি (_F)"
+
+#: panels/sharing/cc-sharing-panel.ui:87
+msgid "_Screen Sharing"
+msgstr "স্ক্রীন ভাগ (_S)"
+
+#: panels/sharing/cc-sharing-panel.ui:95
+msgid "_Media Sharing"
+msgstr "মিডিয়া ভাগ (_M)"
+
+# auto translated by TM merge from project: gdm, version: 3.8.4, DocId: gdm
+#: panels/sharing/cc-sharing-panel.ui:103
+msgid "_Remote Login"
+msgstr "দূরবর্তী লগ-ইন (_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:119
+msgid "Some services are disabled because of no network access."
+msgstr "কোনো নেটওয়ার্ক অ্যাক্সেস না থাকায় কিছু পরিষেবাদি নিষ্ক্রিয় করা হয়েছে।"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/sharing/cc-sharing-panel.ui:137
+#: panels/sharing/cc-sharing-panel.ui:264
+msgid "File Sharing"
+msgstr "ফাইল ভাগাভাগি"
+
+#: panels/sharing/cc-sharing-panel.ui:184
+msgid "_Require Password"
+msgstr "পাসওয়ার্ড প্রয়োজনীয় (_R)"
+
+# auto translated by TM merge from project: gdm, version: 3.8.4, DocId: gdm
+#: panels/sharing/cc-sharing-panel.ui:275
+#: panels/sharing/cc-sharing-panel.ui:345
+msgid "Remote Login"
+msgstr "দূরবর্তী লগ-ইন"
+
+#: panels/sharing/cc-sharing-panel.ui:368
+#: panels/sharing/cc-sharing-panel.ui:590
+msgid "Screen Sharing"
+msgstr "স্ক্রীন ভাগ"
+
+#: panels/sharing/cc-sharing-panel.ui:422
+msgid "_Allow connections to control the screen"
+msgstr "সংযোগগুলিকে স্ক্রিন নিয়ন্ত্রণ করতে অনুমতি দিন(_A)"
+
+# auto translated by TM merge from project: gnome-boxes, version: 3.8.3, DocId: gnome-boxes
+#: panels/sharing/cc-sharing-panel.ui:447
+msgid "_Password:"
+msgstr "পাসওয়ার্ড (_P):"
+
+#: panels/sharing/cc-sharing-panel.ui:477
+msgid "_Show Password"
+msgstr "পাসওয়ার্ড দেখান (_S)"
+
+# auto translated by TM merge from project: RHEL Deployment Guide, version: 6.2, DocId: Product_Subscriptions_and_Entitlements
+#: panels/sharing/cc-sharing-panel.ui:508
+msgid "Access Options"
+msgstr "অ্যাক্সেস বিকল্প"
+
+#: panels/sharing/cc-sharing-panel.ui:522
+msgid "_New connections must ask for access"
+msgstr "নতুন সংযোগগুলিকে অবশ্যই অ্যাক্সেস চাইতে হবে (_N)"
+
+#: panels/sharing/cc-sharing-panel.ui:540
+msgid "_Require a password"
+msgstr "একটি পাসওয়ার্ডের প্রয়োজন(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:601
+#: panels/sharing/cc-sharing-panel.ui:695
+msgid "Media Sharing"
+msgstr "মিডিয়া ভাগ"
+
+#: panels/sharing/cc-sharing-panel.ui:634
+msgid "Share music, photos and videos over the network."
+msgstr "নেটওয়ার্কের মাধ্যমে মিউজিক, ফোটো এবং ভিডিও ভাগ করুন।"
+
+#: panels/sharing/cc-sharing-panel.ui:649
+msgid "Folders"
+msgstr "ফোল্ডারগুলি"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "অন্যদের সংগে আপনি কী ভাগ করতে চান তা নিয়ন্ত্রণ করুন"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"ভাগ;অংশীদারি;ssh;হোস্ট;নাম;রিমোট;ডেস্কটপ;ব্লুটুথ;obex;মিডিয়া;অডিও;ভিডিও;ছবি;ফোটো;"
+"মুভি;সার্ভার;রেন্ডরার;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "রিমোট লগিন সক্রিয় বা নিষ্ক্রিয় করুন"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "রিমোট লগিন সক্রিয় বা নিষ্ক্রিয় করতে অনুমোদনের প্রয়োজন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/sound/cc-alert-chooser.c:151
+msgid "Custom"
+msgstr "স্বনির্ধারিত"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr "বার্ক"
+
+#: panels/sound/cc-alert-chooser.ui:19
+msgid "Drip"
+msgstr "ড্রিপ"
+
+#: panels/sound/cc-alert-chooser.ui:26
+msgid "Glass"
+msgstr "গ্লাস"
+
+#: panels/sound/cc-alert-chooser.ui:33
+msgid "Sonar"
+msgstr "সোনার"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "পিছনে"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "সম্মুখে"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s পরীক্ষা করা হচ্ছে"
+
+#: panels/sound/cc-output-test-dialog.ui:127
+msgid "Click a speaker to test"
+msgstr "পরীক্ষা করতে একটি স্পিকার ক্লিক করুন"
+
+#: panels/sound/cc-sound-panel.ui:27
+msgid "System Volume"
+msgstr "সিস্টেমের শব্দ"
+
+#: panels/sound/cc-sound-panel.ui:43
+msgid "Volume Levels"
+msgstr "ভলিউম মাত্রা"
+
+#: panels/sound/cc-sound-panel.ui:65
+msgid "Output"
+msgstr "আউটপুট"
+
+#: panels/sound/cc-sound-panel.ui:92
+msgid "Output Device"
+msgstr "আউটপুট ডিভাইস"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/sound/cc-sound-panel.ui:115
+msgid "Test"
+msgstr "পরীক্ষা"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/sound/cc-sound-panel.ui:146 panels/sound/cc-sound-panel.ui:323
+msgid "Configuration"
+msgstr "কনফিগারেশন"
+
+#: panels/sound/cc-sound-panel.ui:179
+msgid "Balance"
+msgstr "ব্যালেন্স"
+
+#: panels/sound/cc-sound-panel.ui:206
+msgid "Fade"
+msgstr "বিলীন"
+
+# auto translated by TM merge from project: pulseaudio, version: 3.0, DocId: pulseaudio
+#: panels/sound/cc-sound-panel.ui:233
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:255
+msgid "Input"
+msgstr "ইনপুট"
+
+#: panels/sound/cc-sound-panel.ui:282
+msgid "Input Device"
+msgstr "প্রেরণকারী যন্ত্র"
+
+#: panels/sound/cc-sound-panel.ui:356
+msgid "Volume"
+msgstr "ভলিউম"
+
+#: panels/sound/cc-sound-panel.ui:378
+msgid "Alert Sound"
+msgstr "সতর্কতা শব্দ"
+
+#: panels/sound/cc-volume-slider.c:115
+msgctxt "volume"
+msgid "100%"
+msgstr "১০০%"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "শব্দ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "শব্দের মাত্রা, ইনপুট, আউটপুট, এবং সর্তকতা শব্দ পরিবর্তন করুন"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "কার্ড;মাইক্রোফোন;ভলিউম;বিবর্ণ;ব্যালেন্স;ব্লুটুথ;হেডসেট;অডিও;আউটপুট;ইনপুট;"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#: panels/thunderbolt/cc-bolt-device-dialog.c:94
+#: panels/thunderbolt/cc-bolt-device-entry.c:125
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "সংযোগ বিচ্ছিন্ন করা হয়েছে"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#: panels/thunderbolt/cc-bolt-device-dialog.c:97
+#: panels/thunderbolt/cc-bolt-device-entry.c:128
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "সংযোগ করা হচ্ছে"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#: panels/thunderbolt/cc-bolt-device-dialog.c:100
+#: panels/thunderbolt/cc-bolt-device-entry.c:132
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "সংযুক্ত"
+
+# auto translated by TM merge from project: evolution-data-server, version: el6, DocId: evolution-data-server-2.32
+#: panels/thunderbolt/cc-bolt-device-dialog.c:103
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "অনুমোদনের ত্রুটি"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:106
+#: panels/thunderbolt/cc-bolt-device-entry.c:138
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "অনুমোদিত করছে"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "হ্রাস করা কার্যকারিতা"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:115
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "সংযুক্ত ও অনুমোদিত"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/thunderbolt/cc-bolt-device-dialog.c:121
+#: panels/thunderbolt/cc-bolt-device-entry.c:152
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "অজানা"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:177
+msgid "Authorized at:"
+msgstr "অনুমোদিত হয়েছিল:"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:183
+msgid "Connected at:"
+msgstr "সংযুক্ত হয়েছে:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:190
+msgid "Enrolled at:"
+msgstr "নিবন্ধিত হয়েছে:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:264
+msgid "Failed to authorize device: "
+msgstr "ডিভাইস অনুমোদিত করতে ব্যর্থ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:333
+msgid "Failed to forget device: "
+msgstr "ডিভাইস ভুলে যেতে ব্যর্থ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "অন্য %u ডিভাইসে নির্ভর করে"
+msgstr[1] "%u টি অন্যান্য ডিভাইসে নির্ভর করে"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+msgid "Name:"
+msgstr "নাম:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "Status:"
+msgstr "স্থিতি:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+msgid "Authorize and Connect"
+msgstr "অনুমোদন এবং সংযোগ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+msgid "Forget Device"
+msgstr "ডিভাইসটি ভুলে যান"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:135
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "ত্রুটি"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/thunderbolt/cc-bolt-device-entry.c:146
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "অনুমোদিত"
+
+#: panels/thunderbolt/cc-bolt-panel.c:175
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"থান্ডারবোল্ট সাবসিস্টেম (boltd) ইনস্টল করা হয়নি বা সঠিকভাবে সেট আপ করা হয়নি।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:468
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"থান্ডারবোল্ট সনাক্ত করা যায়নি।\n"
+"হয় সিস্টেমটিতে থান্ডারবোল্ট সমর্থনের অভাব রয়েছে, এটি BIOS এ অক্ষম করা হয়েছে বা "
+"BIOS- এ অসমর্থিত সুরক্ষা স্তরে সেট করা আছে।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:512
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "বায়োস-এ থান্ডারবোল্ট সমর্থন অক্ষম করা হয়েছে।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:516
+msgid "Thunderbolt security level could not be determined."
+msgstr "থান্ডারবোল্ট সুরক্ষা স্তর নির্ধারণ করা যায়নি।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:621
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "প্রত্যক্ষ মোডে স্যুইচ করার সময় ত্রুটি: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:143
+msgid "No Thunderbolt support"
+msgstr "কোন থান্ডারবোল্ট সমর্থন নেই"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:246
+msgid "Direct Access"
+msgstr "সরাসরি অ্যাক্সেস"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:269
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "ডক্স এবং বাহ্যিক GPU- এর মতো ডিভাইসে সরাসরি অ্যাক্সেসের অনুমতি দিন।"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:289
+msgid "Only USB and Display Port devices can attach."
+msgstr "কেবল ইউএসবি এবং ডিসপ্লে পোর্ট ডিভাইস সংযুক্ত করতে পারে।"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:397
+msgid "Pending Devices"
+msgstr "মুলতুবি ডিভাইসগুলি"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:535
+msgid "No devices attached"
+msgstr "কোনও ডিভাইস সংযুক্ত নেই"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "থান্ডারবোল্ট"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "থান্ডারবোল্ট ডিভাইসগুলি পরিচালনা করুন"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "থান্ডারবোল্ট;গোপনীয়তা;"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:500
+msgctxt "cursor size"
+msgid "Default"
+msgstr "ডিফল্ট"
+
+#: panels/universal-access/cc-ua-panel.c:503
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "মাঝারি"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#: panels/universal-access/cc-ua-panel.c:506
+msgctxt "cursor size"
+msgid "Large"
+msgstr "বৃহৎ"
+
+#: panels/universal-access/cc-ua-panel.c:509
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "আরো বড়"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#: panels/universal-access/cc-ua-panel.c:512
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "বৃহৎ"
+
+#: panels/universal-access/cc-ua-panel.c:516
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d টি পিক্সেল "
+msgstr[1] "%d পিক্সেল"
+
+#: panels/universal-access/cc-ua-panel.ui:76
+msgid "_Always Show Accessibility Menu"
+msgstr "সর্বদা অ্যাক্সেসিবিলিটি মেনু দেখান (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:118
+msgid "Seeing"
+msgstr "দেখা"
+
+# auto translated by TM merge from project: gnome-themes-standard, version: 3.8.3, DocId: gnome-themes-standard
+#: panels/universal-access/cc-ua-panel.ui:164
+msgid "_High Contrast"
+msgstr "গাঢ় তারতম্য (_H)"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-ua-panel.ui:211
+msgid "_Large Text"
+msgstr "বড় মাপের হরফ (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:256
+msgid "C_ursor Size"
+msgstr "কার্সার আকার(_u)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:303
+#: panels/universal-access/zoom-options.ui:99
+msgid "_Zoom"
+msgstr "জুম (_Z)"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-ua-panel.ui:349
+msgid "Screen _Reader"
+msgstr "স্ক্রীন রিডার (_R)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:395
+#: panels/universal-access/cc-ua-panel.ui:1261
+msgid "_Sound Keys"
+msgstr "শব্দ কী (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:457
+msgid "Hearing"
+msgstr "শোনা"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-ua-panel.ui:501
+#: panels/universal-access/cc-ua-panel.ui:1364
+msgid "_Visual Alerts"
+msgstr "দৃশ্যমান সূচনা (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:609
+msgid "Screen _Keyboard"
+msgstr "স্ক্রীন কীবোর্ড (_K)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:654
+msgid "R_epeat Keys"
+msgstr "পুনরাবৃত্তির-কি (_e)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:700
+msgid "Cursor _Blinking"
+msgstr "কার্সারের ঝলকানি(_B)"
+
+#: panels/universal-access/cc-ua-panel.ui:746
+msgid "_Typing Assist (AccessX)"
+msgstr "টাইপিং সহায়তা (_T) (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:807
+msgid "Pointing & Clicking"
+msgstr "পয়েন্টিং & ক্লিকিং"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:853
+msgid "_Mouse Keys"
+msgstr "মাউস-কি (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:898
+msgid "_Locate Pointer"
+msgstr "পয়েন্টার সন্ধান করুন (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:930
+msgid "_Click Assist"
+msgstr "ক্লিক সহায়তা (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:976
+msgid "_Double-Click Delay"
+msgstr "দুইবার ক্লিক বিলম্ব (_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:996
+msgid "Double-Click Delay"
+msgstr "দুইবার ক্লিক বিলম্ব"
+
+#: panels/universal-access/cc-ua-panel.ui:1066
+msgid "Cursor Size"
+msgstr "কার্সার আকার"
+
+#: panels/universal-access/cc-ua-panel.ui:1093
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "কার্সার আকারটি সহজ করে তুলতে জুমের সাথে একত্রিত করা যায়।"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-ua-panel.ui:1129
+msgid "Screen Reader"
+msgstr "স্ক্রীন রিডার"
+
+#: panels/universal-access/cc-ua-panel.ui:1146
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "আপনার ফোকাস সরানোর সাথে সাথে স্ক্রিন রিডার প্রদর্শিত পাঠ্য পড়ে।"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-ua-panel.ui:1179
+msgid "_Screen Reader"
+msgstr "স্ক্রীন রিডার (_S)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1218
+msgid "Sound Keys"
+msgstr "শব্দ কি"
+
+#: panels/universal-access/cc-ua-panel.ui:1236
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num Lock বা Caps Lock চালু করা হলে বীপ শব্দ করুন"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/universal-access/cc-ua-panel.ui:1306
+msgid "Visual Alerts"
+msgstr "দৃশ্যমান সূচনা"
+
+#: panels/universal-access/cc-ua-panel.ui:1310
+msgid "_Test flash"
+msgstr "ফ্ল্যাশ পরীক্ষা (_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:1339
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "একটি সর্তকতা শব্দ দেখা দিলে একটি ভিজ্যুয়াল সূচনা ব্যবহার করুন।"
+
+#: panels/universal-access/cc-ua-panel.ui:1390
+msgid "Flash the entire _window"
+msgstr "সমগ্র উইন্ডো ফ্ল্যাশ করুন"
+
+#: panels/universal-access/cc-ua-panel.ui:1408
+msgid "Flash the entire _screen"
+msgstr "সমগ্র স্ক্রীন ফ্ল্যাশ করুন (_s)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1453
+msgid "Repeat Keys"
+msgstr "পুনরাবৃত্তির-কি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1483
+msgid "Key presses repeat when key is held down."
+msgstr "কী চেপে ধরলে কী টিপুন পুনরাবৃত্তি করে।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1563
+msgid "Repeat keys delay"
+msgstr "কি পুনরাবৃত্তির হার"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1611
+#: panels/universal-access/cc-ua-panel.ui:1746
+msgid "Speed"
+msgstr "গতি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1650
+msgid "Repeat keys speed"
+msgstr "কি পুনরাবৃত্তির হার"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1674
+msgid "Cursor Blinking"
+msgstr "কার্সারের ঝলকানি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1704
+msgid "Cursor blinks in text fields."
+msgstr "টেক্সট লেখার ক্ষেত্রে কার্সার ঝলকাবে।"
+
+#: panels/universal-access/cc-ua-panel.ui:1783
+msgid "Cursor blinking speed"
+msgstr "কার্সার ব্লিঙ্ক গতি"
+
+#: panels/universal-access/cc-ua-panel.ui:1819
+msgid "Typing Assist"
+msgstr "টাইপিং সহায়তা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1858
+msgid "_Sticky Keys"
+msgstr "স্টিকি-কি (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:1875
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "মডিফায়ার কীগুলির একটি ক্রমকে একটি কী সমন্বয় হিসাবে বিবেচ্য করুন"
+
+#: panels/universal-access/cc-ua-panel.ui:1899
+msgid "_Disable if two keys are pressed together"
+msgstr "দুইটি কী একসংগে টেপা হলে নিষ্ক্রিয় করুন (_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:1917
+msgid "Beep when a _modifier key is pressed"
+msgstr "একটি মডিফায়ার কী টেপা হলে বীপ করুন (_m)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:1965
+msgid "S_low Keys"
+msgstr "ধীর গতির-কি (_l)"
+
+#: panels/universal-access/cc-ua-panel.ui:1982
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "একটি কী টেপা এবং একটিকে স্বীকার করার মধ্যে কিছুটা সময় রাখুন"
+
+#: panels/universal-access/cc-ua-panel.ui:2015
+#: panels/universal-access/cc-ua-panel.ui:2228
+#: panels/universal-access/cc-ua-panel.ui:2565
+msgid "A_cceptance delay:"
+msgstr "স্বীকার করতে বিলম্ব (_c):"
+
+#: panels/universal-access/cc-ua-panel.ui:2037
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "সংক্ষিপ্ত"
+
+#: panels/universal-access/cc-ua-panel.ui:2056
+msgid "Slow keys typing delay"
+msgstr "মন্থর কী টাইপিং বিলম্ব"
+
+#: panels/universal-access/cc-ua-panel.ui:2071
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "লম্বা"
+
+#: panels/universal-access/cc-ua-panel.ui:2098
+msgid "Beep when a key is pr_essed"
+msgstr "একটি কী টেপা হলে বীপ (_e)"
+
+#: panels/universal-access/cc-ua-panel.ui:2115
+msgid "Beep when a key is _accepted"
+msgstr "একটি কী গৃহিত হলে বীপ আওয়াজ করুন (_a)"
+
+#: panels/universal-access/cc-ua-panel.ui:2132
+#: panels/universal-access/cc-ua-panel.ui:2311
+msgid "Beep when a key is _rejected"
+msgstr "একটি কী প্রত্যাখ্যান হলে বীপ আওয়াজ করুন (_r)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:2178
+msgid "_Bounce Keys"
+msgstr "বাউন্স-কি (_B)"
+
+#: panels/universal-access/cc-ua-panel.ui:2195
+msgid "Ignores fast duplicate keypresses"
+msgstr "দ্রুত সদৃশ কী-টেপা উপেক্ষা করে"
+
+#: panels/universal-access/cc-ua-panel.ui:2250
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "সংক্ষিপ্ত"
+
+#: panels/universal-access/cc-ua-panel.ui:2269
+msgid "Bounce keys typing delay"
+msgstr "বাউন্স কী টাইপিং বিলম্ব"
+
+#: panels/universal-access/cc-ua-panel.ui:2284
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "লম্বা"
+
+#: panels/universal-access/cc-ua-panel.ui:2397
+msgid "_Enable by Keyboard"
+msgstr "কীবোর্ড দ্বারা সক্রিয় (_E)"
+
+#: panels/universal-access/cc-ua-panel.ui:2414
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "কীবোর্ড ব্যবহার করে অ্যাক্সেসযোগ্যতা বৈশিষ্ট্য চালু এবং বন্ধ করুন"
+
+#: panels/universal-access/cc-ua-panel.ui:2478
+msgid "Click Assist"
+msgstr "ক্লিক সহায়তা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:2514
+msgid "_Simulated Secondary Click"
+msgstr "দ্বিতীয় ক্লিকের অনুকরণ (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:2532
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "প্রাথমিক বোতাম ধরে রেখে একটি অপ্রধান ক্লিক ট্রিগার করুন"
+
+#: panels/universal-access/cc-ua-panel.ui:2586
+msgctxt "secondary click"
+msgid "Short"
+msgstr "সংক্ষিপ্ত"
+
+#: panels/universal-access/cc-ua-panel.ui:2605
+msgid "Secondary click delay"
+msgstr "অপ্রধান ক্লিক বিলম্ব"
+
+#: panels/universal-access/cc-ua-panel.ui:2620
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "লম্বা"
+
+#: panels/universal-access/cc-ua-panel.ui:2677
+msgid "_Hover Click"
+msgstr "হোভার ক্লিক (_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:2695
+msgid "Trigger a click when the pointer hovers"
+msgstr "পয়েন্টার হোভার করার সময়ে একটি ক্লিক ট্রিগার করুন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/universal-access/cc-ua-panel.ui:2728
+msgid "D_elay:"
+msgstr "বিলম্ব: (_e)"
+
+#: panels/universal-access/cc-ua-panel.ui:2750
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "সংক্ষিপ্ত"
+
+#: panels/universal-access/cc-ua-panel.ui:2781
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "লম্বা"
+
+#: panels/universal-access/cc-ua-panel.ui:2817
+msgid "Motion _threshold:"
+msgstr "মোশন থ্রেশোল্ড (_t):"
+
+#: panels/universal-access/cc-ua-panel.ui:2839
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "ছোট"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#: panels/universal-access/cc-ua-panel.ui:2870
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "বৃহৎ"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "এটিকে দেখা, শোনা, ধরন, পয়েন্ট এবং ক্লিক করা সহজতর করুন"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;"
+msgstr ""
+"কীবোর্ড;মাউস;a11y;অ্যাক্সেসিবিলিটি;ইউনিভার্সালএক্সেস;কনট্রাস্ট;কার্সার;সাউন্ড;জুম;"
+"স্ক্রিন;রিডার;বড়;লম্বা;টেক্সট;ফন্ট;সাইজ;অ্যাক্সেসএক্স;স্টিকি;কী;স্লো;বাউন্স;মাউস;ডাবল;"
+"ক্লিক;বিলম্ব;গতি;সহায়তা;পুনরাবৃত্তি;নাচা;চাক্ষুষ;শুনানি;অডিও;টাইপিং;"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#: panels/universal-access/zoom-options.c:303
+msgctxt "Distance"
+msgid "Short"
+msgstr "সংক্ষিপ্ত"
+
+#: panels/universal-access/zoom-options.c:304
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ স্ক্রীন"
+
+#: panels/universal-access/zoom-options.c:305
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ স্ক্রীন"
+
+#: panels/universal-access/zoom-options.c:306
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ স্ক্রীন"
+
+# auto translated by TM merge from project: control-center, version: 3.8.6, DocId: gnome-control-center-2.0
+#: panels/universal-access/zoom-options.c:307
+msgctxt "Distance"
+msgid "Long"
+msgstr "লম্বা"
+
+# auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
+#: panels/universal-access/zoom-options.ui:48
+msgid "Full Screen"
+msgstr "সম্পূর্ণ পর্দা জুড়ে প্রদর্শন"
+
+#: panels/universal-access/zoom-options.ui:53
+msgid "Top Half"
+msgstr "শীর্ষ অর্ধ"
+
+#: panels/universal-access/zoom-options.ui:58
+msgid "Bottom Half"
+msgstr "নিম্ন অর্ধ"
+
+#: panels/universal-access/zoom-options.ui:63
+msgid "Left Half"
+msgstr "বাম অর্ধ"
+
+#: panels/universal-access/zoom-options.ui:68
+msgid "Right Half"
+msgstr "ডান অর্ধ"
+
+#: panels/universal-access/zoom-options.ui:78
+msgid "Zoom Options"
+msgstr "জুম বিকল্প"
+
+#: panels/universal-access/zoom-options.ui:185
+msgid "_Magnification:"
+msgstr "বর্ধিতকরণ (_M):"
+
+#: panels/universal-access/zoom-options.ui:249
+msgid "_Follow mouse cursor"
+msgstr "মাউস কার্সর অনুসরণ করুন (_F)"
+
+#: panels/universal-access/zoom-options.ui:269
+msgid "_Screen part:"
+msgstr "স্ক্রীন অংশ (_S):"
+
+#: panels/universal-access/zoom-options.ui:331
+msgid "Magnifier _extends outside of screen"
+msgstr "বিবর্ধক স্ক্রীনের বাইরে বাড়ানো হয় (_e)"
+
+#: panels/universal-access/zoom-options.ui:350
+msgid "_Keep magnifier cursor centered"
+msgstr "বিবর্ধন কার্সার কেন্দ্রে রাখুন (_K)"
+
+#: panels/universal-access/zoom-options.ui:370
+msgid "Magnifier cursor _pushes contents around"
+msgstr "বিবর্ধন কার্সার বিষয়বস্তু চারপাশে ঢেলে (_p)"
+
+#: panels/universal-access/zoom-options.ui:390
+msgid "Magnifier cursor moves with _contents"
+msgstr "বিবর্ধন কার্সার বিষয়বস্তুর সংগে সরে (_c)"
+
+#: panels/universal-access/zoom-options.ui:425
+msgid "Magnifier Position:"
+msgstr "বিবর্ধন অবস্থান:"
+
+#: panels/universal-access/zoom-options.ui:446
+msgid "Magnifier"
+msgstr "বিবর্ধন"
+
+#: panels/universal-access/zoom-options.ui:493
+msgid "_Thickness:"
+msgstr "বেধ (_T):"
+
+#: panels/universal-access/zoom-options.ui:519
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "পাতলা"
+
+#: panels/universal-access/zoom-options.ui:551
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "পুরু"
+
+#: panels/universal-access/zoom-options.ui:577
+msgid "_Length:"
+msgstr "দৈর্ঘ্য (_L):"
+
+# auto translated by TM merge from project: evince, version: 3.8.3, DocId: evince
+#. The color of the accessibility crosshair
+#: panels/universal-access/zoom-options.ui:626
+msgid "Co_lor:"
+msgstr "রঙ(_l) :"
+
+#: panels/universal-access/zoom-options.ui:690
+msgid "_Crosshairs:"
+msgstr "ক্রসহেয়ার(_C):"
+
+#: panels/universal-access/zoom-options.ui:738
+msgid "_Overlaps mouse cursor"
+msgstr "মাউস কার্সার ওভারল্যাপ করে (_O)"
+
+#: panels/universal-access/zoom-options.ui:776
+msgid "Crosshairs"
+msgstr "ক্রসহেয়ার"
+
+#: panels/universal-access/zoom-options.ui:825
+msgid "_White on black:"
+msgstr "কালোর উপরে সাদা(_W):"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/universal-access/zoom-options.ui:845
+msgid "_Brightness:"
+msgstr "উজ্জ্বলতা(_B):"
+
+#: panels/universal-access/zoom-options.ui:866
+msgid "_Contrast:"
+msgstr "বৈপরীত্য (_C):"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/zoom-options.ui:886
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "রঙ(_l)"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#: panels/universal-access/zoom-options.ui:911
+msgctxt "universal access, color"
+msgid "None"
+msgstr "শূণ্য"
+
+#: panels/universal-access/zoom-options.ui:943
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "সম্পূর্ণ"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/universal-access/zoom-options.ui:1006
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "নিচু"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/universal-access/zoom-options.ui:1039
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "উঁচু"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/universal-access/zoom-options.ui:1070
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "কম"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/universal-access/zoom-options.ui:1103
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "বেশি"
+
+#: panels/universal-access/zoom-options.ui:1139
+msgid "Color Effects:"
+msgstr "রং প্রভাব:"
+
+#: panels/universal-access/zoom-options.ui:1164
+msgid "Color Effects"
+msgstr "রং প্রভাব"
+
+#: panels/usage/cc-usage-panel.c:154
+msgid "Empty all items from Trash?"
+msgstr "ট্র্যাশ সম্পূর্ণ খালি করবেন?"
+
+#: panels/usage/cc-usage-panel.c:155
+msgid "All items in the Trash will be permanently deleted."
+msgstr "ট্র্যাশের সবকিছু সম্পূর্ণ ভাবে মুছে যাবে।"
+
+#: panels/usage/cc-usage-panel.c:156
+msgid "_Empty Trash"
+msgstr "ট্র্যাশ খালি করুন (_E)"
+
+#: panels/usage/cc-usage-panel.c:177
+msgid "Delete all the temporary files?"
+msgstr "সকল অস্থায়ী ফাইল মুছবেন?"
+
+#: panels/usage/cc-usage-panel.c:178
+msgid "All the temporary files will be permanently deleted."
+msgstr "সকল অস্থায়ী ফাইল সম্পূর্ণ ভাবে মুছে যাবে।"
+
+#: panels/usage/cc-usage-panel.c:179
+msgid "_Purge Temporary Files"
+msgstr "অস্থায়ী ফাইলগুলি পার্জ করুন (_P)"
+
+#: panels/usage/cc-usage-panel.ui:29
+msgid "File History"
+msgstr "ফাইল এর ইতিহাস"
+
+#: panels/usage/cc-usage-panel.ui:41
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"ফাইলের ইতিহাস আপনার ব্যবহার করা ফাইলগুলির একটি রেকর্ড রাখে। এই তথ্যটি "
+"অ্যাপ্লিকেশনগুলির মধ্যে ভাগ করা হয় এবং আপনি যে ফাইলগুলি ব্যবহার করতে চান তা সন্ধান "
+"করা আরও সহজ করে তোলে।"
+
+#: panels/usage/cc-usage-panel.ui:56
+msgid "File H_istory"
+msgstr "ফাইল এর ইতিহাস(_i)"
+
+#: panels/usage/cc-usage-panel.ui:78
+msgid "File _History Duration"
+msgstr "ফাইল ইতিহাসের সময়কাল(_H)"
+
+#: panels/usage/cc-usage-panel.ui:119
+msgid "_Clear History…"
+msgstr "ইতিহাস মুছুন (_C)..."
+
+#: panels/usage/cc-usage-panel.ui:135
+msgid "Trash & Temporary Files"
+msgstr "ট্র্যাশ এবং অস্থায়ী ফাইল পার্জ করুন"
+
+#: panels/usage/cc-usage-panel.ui:145
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"ট্র্যাশ এবং অস্থায়ী ফাইলগুলি কখনও কখনও ব্যক্তিগত বা সংবেদনশীল তথ্য অন্তর্ভুক্ত করতে "
+"পারে। এগুলি স্বয়ংক্রিয়ভাবে মুছে ফেলা গোপনীয়তা রক্ষা করতে সহায়তা করতে পারে।"
+
+#: panels/usage/cc-usage-panel.ui:159
+msgid "Automatically Delete _Trash Content"
+msgstr "ট্র্যাশ স্বয়ংক্রিয় ভাবে খালি করুন (_T)"
+
+#: panels/usage/cc-usage-panel.ui:174
+msgid "Automatically Delete Temporary _Files"
+msgstr "অস্থায়ী ফাইলগুলি স্বয়ংক্রিয় ভাবে মুছুন (_F)"
+
+#: panels/usage/cc-usage-panel.ui:196
+msgid "Automatically Delete _Period"
+msgstr "স্বয়ংক্রিয়ভাবে মুছার সময়কাল (_P)"
+
+#: panels/usage/cc-usage-panel.ui:238
+msgid "_Empty Trash…"
+msgstr "ট্র্যাশ খালি করুন (_E)..."
+
+#: panels/usage/cc-usage-panel.ui:250
+msgid "_Delete Temporary Files…"
+msgstr "অস্থায়ী ফাইলগুলি মুছুন(_D)..."
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:278
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "১ ঘন্টা"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:282
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "১ দিন"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:286
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "২ দিন"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:290
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "৩ দিন"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:294
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "৪ দিন"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:298
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "৫ দিন"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:302
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "৬ দিন"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:306
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "৭ দিন"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:310
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "১৪ দিন"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:314
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "৩০ দিন"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:329
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "১ দিন"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:333
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "৭ দিন"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:337
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "৩০ দিন"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:341
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "অনন্তকাল"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "ফাইলের ইতিহাস এবং ট্র্যাশ"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "ট্রেস ছেড়ে যাবেন না"
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "আপনার অ্যাকাউন্ট সরবরাহকারীর ওয়েব ঠিকানা মিলতে হবে।"
+
+#: panels/user-accounts/cc-add-user-dialog.c:205
+msgid "Failed to add account"
+msgstr "অ্যাকাউন্ট যোগ করতে ব্যর্থ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:676
+#: panels/user-accounts/cc-password-dialog.c:261
+msgid "The passwords do not match."
+msgstr "পাসওয়ার্ড মিলছে না।"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-add-user-dialog.c:896
+#: panels/user-accounts/cc-add-user-dialog.c:942
+#: panels/user-accounts/cc-add-user-dialog.c:963
+msgid "Failed to register account"
+msgstr "অ্যাকাউন্ট রেজিস্টার করতে ব্যর্থ"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-add-user-dialog.c:1084
+msgid "No supported way to authenticate with this domain"
+msgstr "এই ডোমেন দিয়ে পরিচয়প্রমাণের কোনো সমর্থিত মাধ্যম নেই"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-add-user-dialog.c:1157
+msgid "Failed to join domain"
+msgstr "ডোমেন এ যোগদান করতে ব্যর্থ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1218
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"প্রদত্ত লগিন নামটি কাজ করেনি।\n"
+"দয়া করে আবার চেষ্টা করুন।"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-add-user-dialog.c:1225
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"প্রদত্ত লগিন পাসওয়ার্ডটি কাজ করেনি।\n"
+"দয়া করে আবার চেষ্টা করুন।"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-add-user-dialog.c:1233
+msgid "Failed to log into domain"
+msgstr "ডোমেনে লগ ইন করতে ব্যর্থ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1291
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "ডোমেন খুঁজে পাওয়া যায়নি। হতে পারি আপনি বানান ভুল করেছেন?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "ব্যবহারকারী যোগ করুন"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/user-accounts/cc-add-user-dialog.ui:180
+msgid "_Full Name"
+msgstr "সম্পূর্ণ নাম (_F)"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: panels/user-accounts/cc-add-user-dialog.ui:206
+msgid "Standard"
+msgstr "সাধারণ"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/user-accounts/cc-add-user-dialog.ui:216
+msgid "Administrator"
+msgstr "প্রশাসক"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:232
+msgid "Account _Type"
+msgstr "অ্যাকাউন্ট ধরন (_T)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:269
+msgid "Allow user to set a password when they next _login"
+msgstr ""
+"ব্যবহারকারী যখন পরের বার লগইন করবেন তখন তাকে একটি পাসওয়ার্ড সেট করার অনুমতি দিন "
+"(_l)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:283
+msgid "Set a password _now"
+msgstr "এখনই একটি পাসওয়ার্ড সেট করুন(_n)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:405
+msgid "_Confirm"
+msgstr "নিশ্চিত(_C)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:485
+#: panels/user-accounts/cc-add-user-dialog.ui:692
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"এন্টারপ্রাইজ লগিন এই ডিভাইসে একটি বিদ্যমান কেন্দ্রীয় ভাবে পরিচালিত ব্যবহারকারী "
+"অ্যাকাউন্ট ব্যবহারের অনুমতি দেয়।"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:732
+msgid "You are Offline"
+msgstr "আপনি অফলাইন আছেন"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:751
+msgid "You must be online in order to add enterprise users."
+msgstr "এন্টারপ্রাইজ ব্যবহারকারীদের যুক্ত করতে আপনাকে অবশ্যই অনলাইনে থাকতে হবে।"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:782
+msgid "_Enterprise Login"
+msgstr "এন্টারপ্রাইজ লগিন (_E)"
+
+# auto translated by TM merge from project: gnome-contacts, version: 3.8.2, DocId: gnome-contacts
+#: panels/user-accounts/cc-avatar-chooser.c:232
+msgid "Browse for more pictures"
+msgstr "আরো ছবির জন্য ব্রাউজ করুন"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:39
+msgid "Take a Picture…"
+msgstr "একটি ফোটো তুলুন…"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:46
+msgid "Select a File…"
+msgstr "ফাইল নির্বাচন করুন..."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "ফিঙ্গারপ্রিন্ট ম্যানেজার"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:23
+msgid "Fingerprint"
+msgstr "ফিংগারপ্রিন্ট"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:118
+msgid "_No"
+msgstr "না (_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:128
+msgid "_Yes"
+msgstr "হ্যাঁ(_Y)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.ui:155
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"আঙুলের ছাপ সহযোগে লগ-ইন ব্যবস্থা নিষ্ক্রিয় করার উদ্দেশ্যে নিবন্ধিত আঙুলের ছাপগুলি মুছে "
+"ফেলা হবে কি?"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid "No Fingerprint device"
+msgstr "কোনও ফিঙ্গারপ্রিন্ট ডিভাইস নেই"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:259
+msgid "Ensure the device is properly connected."
+msgstr "ডিভাইসটি সঠিকভাবে সংযুক্ত রয়েছে তা নিশ্চিত করুন।"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:264
+msgid "No fingerprint device"
+msgstr "কোনও ফিঙ্গারপ্রিন্ট ডিভাইস নেই"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:280
+msgid "Choose the fingerprint device you want to configure"
+msgstr "আপনি কনফিগার করতে চান যে ফিঙ্গারপ্রিন্ট ডিভাইস ওটা চয়ন করুন"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:309
+msgid "Fingerprint Device"
+msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:322
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"ফিঙ্গারপ্রিন্ট লগইন আপনাকে আপনার আঙুল দিয়ে কম্পিউটারে আনলক এবং লগ ইন করতে দেয়"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.ui:352
+msgid "_Delete Fingerprints"
+msgstr "আঙুলের ছাপ মুছে ফেলুন (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:363
+msgid "Fingerprint Login"
+msgstr "ফিংগারপ্রিন্ট লগিন"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:412
+msgid "Fingerprint Enroll"
+msgstr "ফিঙ্গারপ্রিন্ট নথিভুক্ত"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:436
+msgid "_Re-enroll this finger…"
+msgstr "এই আঙুলটি পুনরায় তালিকাভুক্ত করুন(_R)..."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:470
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "আঙুলের ছাপগুলি তালিকা করতে ব্যর্থ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:536
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "সংরক্ষিত আঙ্গুলের ছাপগুলি মুছতে ব্যর্থ: %s"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.c:565
+msgid "Left thumb"
+msgstr "বাঁহাতের বৃদ্ধাঙ্গুলি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.c:567
+msgid "Left middle finger"
+msgstr "বাঁহাতের মধ্যমা"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:569
+msgid "_Left index finger"
+msgstr "বাম ইনডেক্স ফিংগার (_L)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.c:571
+msgid "Left ring finger"
+msgstr "বাঁহাতের অনামিকা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.c:573
+msgid "Left little finger"
+msgstr "বাঁহাতের কনিষ্ঠা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.c:575
+msgid "Right thumb"
+msgstr "ডান হাতের বৃদ্ধাঙ্গুলি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.c:577
+msgid "Right middle finger"
+msgstr "ডান হাতের মধ্যমা"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:579
+msgid "_Right index finger"
+msgstr "ডান ইনডেক্স ফিংগার (_R)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.c:581
+msgid "Right ring finger"
+msgstr "ডান হাতের অনামিকা"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/user-accounts/cc-fingerprint-dialog.c:583
+msgid "Right little finger"
+msgstr "ডান হাতের কনিষ্ঠা"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#: panels/user-accounts/cc-fingerprint-dialog.c:585
+msgid "Unknown Finger"
+msgstr "অজানা আঙ্গুল"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:719
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "সম্পন্ন"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#: panels/user-accounts/cc-fingerprint-dialog.c:729
+msgid "Fingerprint device disconnected"
+msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস সংযোগ বিচ্ছিন্ন"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:731
+msgid "Fingerprint device storage is full"
+msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস স্টোরেজ পূর্ণ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:733
+msgid "Failed to enroll new fingerprint"
+msgstr "নতুন আঙুলের ছাপ নিবন্ধন করতে ব্যর্থ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:764
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "তালিকাভুক্তি শুরু করতে ব্যর্থ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:772
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "নতুন আঙুলের ছাপ নিবন্ধন করতে ব্যর্থ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:803
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "তালিকাভুক্তি বন্ধ করতে ব্যর্থ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:847
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"আপনার আঙুলের ছাপটি তালিকাভুক্ত করতে বারবার আপনার আঙ্গুলটি পাঠকের উপরে তুলুন এবং রাখুন"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:989
+msgid "Scan new fingerprint"
+msgstr "নতুন আঙুলের ছাপ স্ক্যান করুন"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1029
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "%s ফিঙ্গারপ্রিন্ট ডিভাইস প্রকাশ করতে ব্যর্থ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "পড়ার যন্ত্রতে সমস্যা"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1133
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "ফিঙ্গারপ্রিন্ট ডিভাইস %s দাবি করতে ব্যর্থ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1270
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "ফিঙ্গারপ্রিন্ট ডিভাইসগুলি পেতে ব্যর্থ: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:69
+msgid "This Week"
+msgstr "এই সপ্তাহে"
+
+#: panels/user-accounts/cc-login-history-dialog.c:72
+msgid "Last Week"
+msgstr "গত সপ্তাহে"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:82
+#: panels/user-accounts/cc-login-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:91
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:96
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:173
+#: panels/user-accounts/cc-user-panel.c:782
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:176
+#: panels/user-accounts/cc-user-panel.c:786
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:243
+msgid "Session Ended"
+msgstr "সেশন সমাপ্ত হয়েছে"
+
+#: panels/user-accounts/cc-login-history-dialog.c:249
+msgid "Session Started"
+msgstr "সেশন শুরু হয়েছে"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:343
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — অ্যাকাউন্ট ক্রিয়াকলাপ"
+
+#: panels/user-accounts/cc-password-dialog.c:125
+msgid "Please choose another password."
+msgstr "দয়া করে অপর একটি পাসওয়ার্ড বাছুন।"
+
+#: panels/user-accounts/cc-password-dialog.c:134
+msgid "Please type your current password again."
+msgstr "দয়া করে আপনার বর্তমান পাসওয়ার্ড আবার টাইপ করুন।"
+
+#: panels/user-accounts/cc-password-dialog.c:140
+msgid "Password could not be changed"
+msgstr "পাসওয়ার্ড পরিবর্তন করা যাবে না"
+
+#: panels/user-accounts/cc-password-dialog.ui:7
+msgid "Change Password"
+msgstr "পাসওয়ার্ড পরিবর্তন করুন"
+
+#: panels/user-accounts/cc-password-dialog.ui:37
+msgid "Ch_ange"
+msgstr "পরিবর্তন করুন (_a)"
+
+#: panels/user-accounts/cc-password-dialog.ui:145
+msgid "_Confirm New Password"
+msgstr "পাসওয়ার্ড নিশ্চিত করুন (_C)"
+
+#: panels/user-accounts/cc-password-dialog.ui:162
+msgid "_New Password"
+msgstr "নতুন পাসওয়ার্ড (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:216
+msgid "Current _Password"
+msgstr "বর্তমান পাসওয়ার্ড (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:254
+msgid "Allow user to change their password on next login"
+msgstr ""
+"ব্যবহারকারী যখন পরের বার লগইন করবেন তখন তাকে একটি পাসওয়ার্ড সেট করার অনুমতি দিন"
+
+#: panels/user-accounts/cc-password-dialog.ui:267
+msgid "Set a password now"
+msgstr "এখনই একটি পাসওয়ার্ড সেট করুন"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "Cannot automatically join this type of domain"
+msgstr "এই ধরনের ডোমেনে স্বয়ংক্রিয়ভাবে যোগ দেওয়া যায় না"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-realm-manager.c:309
+msgid "No such domain or realm found"
+msgstr "এমন কোন ডোমেন বা রিলম পাওয়া যায়নি"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-realm-manager.c:731
+#: panels/user-accounts/cc-realm-manager.c:745
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s হিসেবে %s ডোমেনে লগইন করা সম্ভব হচ্ছে না"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-realm-manager.c:737
+msgid "Invalid password, please try again"
+msgstr "অবৈধ পাসওয়ার্ড, পুনরায় চেষ্টা করুন"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-realm-manager.c:750
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "%s ডোমেনে সংযোগ স্থাপন করতে ব্যর্থ: %s"
+
+#: panels/user-accounts/cc-user-panel.c:220
+msgid "Your account"
+msgstr "আপনার অ্যাকাউন্ট"
+
+#: panels/user-accounts/cc-user-panel.c:401
+msgid "Failed to delete user"
+msgstr "ব্যবহারকারী মুছতে ব্যর্থ"
+
+#: panels/user-accounts/cc-user-panel.c:459
+#: panels/user-accounts/cc-user-panel.c:518
+#: panels/user-accounts/cc-user-panel.c:570
+msgid "Failed to revoke remotely managed user"
+msgstr "দূরবর্তীভাবে পরিচালিত ব্যবহারকারীকে প্রত্যাহার করতে ব্যর্থ"
+
+#: panels/user-accounts/cc-user-panel.c:621
+msgid "You cannot delete your own account."
+msgstr "আপনি আপনার নিজের অ্যাকাউন্ট মুছতে পারবেন না।"
+
+#: panels/user-accounts/cc-user-panel.c:630
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s এখনও লগিন আছে"
+
+#: panels/user-accounts/cc-user-panel.c:634
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"কোনো ব্যবহারকারীকে তার লগিন থাকা অবস্থাতেই মুছে ফেলা হলে, সিস্টেম অধারাবাহিক "
+"অবস্থায় চলে যেতে পারে।"
+
+#: panels/user-accounts/cc-user-panel.c:643
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "আপনি কি %s'র ফাইলগুলি রাখতে চান?"
+
+#: panels/user-accounts/cc-user-panel.c:647
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"একটি ব্যবহারকারী অ্যাকাউন্ট মোছার সময়ে হোম ডিরেক্টরি, মেল স্পুল এবং অস্থায়ী ফাইলগুলি "
+"হাতের কাছে রাখা সম্ভব।"
+
+#: panels/user-accounts/cc-user-panel.c:650
+msgid "_Delete Files"
+msgstr "ফাইলগুলি মুছুন (_D)"
+
+#: panels/user-accounts/cc-user-panel.c:651
+msgid "_Keep Files"
+msgstr "ফাইলগুলি রাখুন (_K)"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/cc-user-panel.c:665
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "আপনি কি নিশ্চিত যে দূরবর্তীভাবে পরিচালিত %s এর অ্যাকাউন্টটি বাতিল করতে চান?"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgid "_Delete"
+msgstr "মুছুন (_D)"
+
+#: panels/user-accounts/cc-user-panel.c:719
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "অ্যাকাউন্ট নিষ্ক্রিয়"
+
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "পরবর্তী লগিনো সেট করা হবে"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#: panels/user-accounts/cc-user-panel.c:730
+msgctxt "Password mode"
+msgid "None"
+msgstr "শূণ্য"
+
+#: panels/user-accounts/cc-user-panel.c:775
+msgid "Logged in"
+msgstr "লগিন করা হয়েছে"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:863
+#: panels/user-accounts/cc-user-panel.c:954
+msgid "Enabled"
+msgstr "সক্রিয়"
+
+#: panels/user-accounts/cc-user-panel.c:1265
+msgid "Failed to contact the accounts service"
+msgstr "অ্যাকাউন্ট পরিষেবায় যোগাযোগ করতে ব্যর্থ"
+
+#: panels/user-accounts/cc-user-panel.c:1267
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "দয়া করে নিশ্চিত করুন যে, AccountService ইনস্টল করা এবং সক্রিয় করা হয়েছে।"
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/cc-user-panel.c:1299
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"পরিবর্তনগুলি করতে,\n"
+"প্রথমে * আইকন ক্লিক করুন"
+
+#: panels/user-accounts/cc-user-panel.c:1373
+msgid "Delete the selected user account"
+msgstr "নির্বাচিত ব্যবহারকারী অ্যাকাউন্ট মুছুন"
+
+#: panels/user-accounts/cc-user-panel.c:1385
+#: panels/user-accounts/cc-user-panel.c:1506
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"নির্বাচিত ব্যবহারকারী অ্যাকাউন্ট মুছতে,\n"
+"প্রথমে * আইকনে ক্লিক করুন"
+
+#: panels/user-accounts/cc-user-panel.ui:5
+msgid "_Add User…"
+msgstr "ব্যবহারকারী যোগ করুন (_A)"
+
+#: panels/user-accounts/cc-user-panel.ui:8
+msgid "Create a user account"
+msgstr "একটি ব্যবহারকারী অ্যাকাউন্ট তৈরি করুন"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "করা পরিবর্তনগুলি প্রয়োগ হতে আপনার সেশন রিস্টার্ট করা প্রয়োজন"
+
+#: panels/user-accounts/cc-user-panel.ui:71
+msgid "Restart Now"
+msgstr "এখনই পুনরারম্ভ করুন"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:168
+msgid "User Icon"
+msgstr "ব্যবহারকারী আইকন"
+
+#: panels/user-accounts/cc-user-panel.ui:244
+msgid "Account Settings"
+msgstr "অ্যাকাউন্ট সেটিংস"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/user-accounts/cc-user-panel.ui:271
+msgid "_Administrator"
+msgstr "প্রশাসক (_A)"
+
+#: panels/user-accounts/cc-user-panel.ui:291
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"প্রশাসকরা অন্যান্য ব্যবহারকারীদের যুক্ত করতে এবং মুছে ফেলতে পারে এবং সমস্ত "
+"ব্যবহারকারীর জন্য সেটিংস পরিবর্তন করতে পারে।"
+
+#: panels/user-accounts/cc-user-panel.ui:320
+msgid "_Parental Controls"
+msgstr "পিতামাতার নিয়ন্ত্রণ(_P)"
+
+#: panels/user-accounts/cc-user-panel.ui:410
+msgid "Authentication & Login"
+msgstr "প্রমাণীকরণ এবং লগইন"
+
+#: panels/user-accounts/cc-user-panel.ui:479
+msgid "_Fingerprint Login"
+msgstr "ফিংগারপ্রিন্ট লগিন (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:521
+msgid "A_utomatic Login"
+msgstr "স্বয়ংক্রিয় লগিন (_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:551
+msgid "Account Activity"
+msgstr "অ্যাকাউন্ট ক্রিয়াকলাপ"
+
+#: panels/user-accounts/cc-user-panel.ui:592
+msgid "Remove User…"
+msgstr "ব্যবহারকারীর অ্যাকাউন্ট সরান"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:631
+msgid "No Users Found"
+msgstr "কোন ব্যবহারকারী পাওয়া যায়ে নি"
+
+#: panels/user-accounts/cc-user-panel.ui:641
+msgid "Unlock to add a user account."
+msgstr "কোনও ব্যবহারকারী অ্যাকাউন্ট যুক্ত করতে আনলক করুন।"
+
+# auto translated by TM merge from project: Cloudforms Cloud Engine User Guide, version: 1.0, DocId: Users_And_Roles
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "ব্যবহারকারী"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "ব্যবহারকারীদের যোগ করুন বা সরান এবং আপনার পাসওয়ার্ড পরিবর্তন করুন"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "লগিন;নাম;ফিংগারপ্রিন্ট;অবতার;লোগো;ফেস;পাসওয়ার্ড;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr "নথিভুক্ত করুন (_E)"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "ডোমেইন অ্যাডমিনিস্ট্রেটর লগিন"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"এন্টারপ্রাইজ লগিন ব্যবহার করতে, এই কম্পিউটারটিকে এই ডোমেনে নথিভুক্ত\n"
+"করতে  হবে। অনুগ্রহ করে আপনার নেটওয়ার্ক প্রশাসককে\n"
+"এখানে ডোমেন পাসওয়ার্ড দিতে বলুন।"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "প্রশাসকের নাম (_N)"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "প্রশাসকের পাসওয়ার্ড"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "ব্যবহারকারী অ্যাকাউন্টগুলি পরিচালনা করুন"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "ব্যবহারকারী ডেটা পরিবর্তন করতে প্রমাণীকরণের প্রয়োজন"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "নতুন পাসওয়ার্ডটি পুরানো পাসওয়ার্ডের থেকে আলাদা হতে হবে।"
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "কিছু অক্ষর এবং সংখ্যা পরিবর্তন করে চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "পাসওয়ার্ডটি অনেকটা বদলে চেষ্টা করুন"
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "আপনার ব্যবহারকারী নাম ছাড়া কোনো পাসওয়ার্ড শক্তিশালী হবে।"
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "পাসওয়ার্ডে নিজের নাম ব্যবহার না করাই ভালো।"
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "পাসওয়ার্ডে অন্তর্ভুক্ত কিছু শব্দ এড়িয়ে যাওয়ার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "সাধারণ শব্দ এড়িয়ে যাওয়ার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "বিদ্যমান শব্দ আবার সাজানো এড়িয়ে যাওয়ার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "আরো সংখ্যা ব্যবহার করার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "আরো বেশি সংখ্যাক বড় হাতের অক্ষর ব্যবহার করার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "আরো বেশি সংখ্যক ছোট হাতের অক্ষর ব্যবহার করার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "যতিচিহ্নের মতো আরো বিশেষ অক্ষর ব্যবহার করার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "অক্ষর, সংখ্যা এবং যতিচিহ্ন মিলিয়েমিশিয়ে ব্যবহার করার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "একই অক্ষর পুনরাবৃত্ত করা এড়িয়ে চলুন।"
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"একই ধরনের অক্ষর লেখা এড়িয়ে যাওয়ার চেষ্টা করুন: আপনাকে অক্ষর, সংখ্যা এবং যতিচিহ্ন "
+"মিলিয়ে মিশিয়ে ব্যবহার করতে হবে।"
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 বা abcd-এর মতো ক্রম এড়িয়ে যাওয়ার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"পাসওয়ার্ড দীর্ঘ হওয়া দরকার। আরও অক্ষর, সংখ্যা এবং বিরামচিহ্ন যুক্ত করার চেষ্টা করুন।"
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"বড় এবং ছোট হাতের অক্ষর মিলিয়ে মিশিয়ে লিখুন এবং এক বা দুইটি সংখ্যা ব্যবহার করুন।"
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "আরও অক্ষর, সংখ্যা এবং বিরামচিহ্ন যুক্ত করা পাসওয়ার্ডকে শক্তিশালী করবে।"
+
+# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
+#: panels/user-accounts/run-passwd.c:424
+msgid "Authentication failed"
+msgstr "পরিচয় প্রমাণ করতে বিফল"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The new password is too short"
+msgstr "নতুন পাসওয়ার্ড অত্যন্ত ছোট"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password is too simple"
+msgstr "নতুন পাসওয়ার্ড অত্যন্ত সরল"
+
+#: panels/user-accounts/run-passwd.c:516
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "পুরনো এবং নতুন পাসওয়ার্ড প্রায় একই"
+
+#: panels/user-accounts/run-passwd.c:519
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "নতুন পাসওয়ার্ড ইতিমধ্যেই সাম্প্রতিক সময়ে ব্যবহৃত হয়েছে।"
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "নতুন পাসওয়ার্ডে অবশ্যই সাংখ্যিক বা বিশেষ অক্ষর থাকতে হবে"
+
+#: panels/user-accounts/run-passwd.c:526
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "পুরনো এবং নতুন পাসওয়ার্ড একই"
+
+#: panels/user-accounts/run-passwd.c:530
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "আপনার প্রারম্ভিক ভাবে প্রমাণীকরণের সময়ে আপনার পাসওয়ার্ড পরিবর্তিত হয়েছে!"
+
+#: panels/user-accounts/run-passwd.c:534
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "নতুন পাসওয়ার্ডে যথেষ্ট আলাদা আলাদা অক্ষর নেই"
+
+# auto translated by TM merge from project: evolution-mapi, version: el6, DocId: evolution-mapi
+#: panels/user-accounts/run-passwd.c:538
+#, c-format
+msgid "Unknown error"
+msgstr "অজানা ত্রুটি"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/user-utils.c:435
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"ব্যবহারকারীর নামটিতে কেবলমাত্র a-z, অঙ্ক এবং নিম্নলিখিত বর্ণগুলি থেকে নিম্ন বর্ণের "
+"অক্ষর থাকা উচিত: - _"
+
+#: panels/user-accounts/user-utils.c:439
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "দুঃখিত, সেই ব্যবহারকারীর নামটি উপলভ্য নয়। অন্য চেষ্টা করুন।"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#: panels/user-accounts/user-utils.c:484
+msgid "The username is too long."
+msgstr "ব্যবহারকারীর নাম অতিশয় দীর্ঘ।"
+
+#: panels/user-accounts/user-utils.c:546
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr "এটি আপনার হোম ফোল্ডারের নামকরণ করতে ব্যবহৃত হবে এবং পরিবর্তন করা যাবে না।"
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr "মানচিত্র বোতাম"
+
+# auto translated by TM merge from project: rhn-client-tools, version: 6.2, DocId: rhn-client-tools
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "বন্ধ করুন (_C)"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr "কাজের মানচিত্র বোতাম"
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"একটি শর্টকাট সম্পাদনা করতে, \"কীস্ট্রোক প্রেরণ করুন\" ক্রিয়াটি চয়ন করুন, কীবোর্ড "
+"শর্টকাট বোতাম টিপুন এবং নতুন কীগুলি ধরে রাখুন বা সাফ করতে ব্যাকস্পেস টিপুন।"
+
+#: panels/wacom/calibrator/calibrator.ui:61
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"ট্যাবলেট ক্যালিব্রেট করতে টার্গেট মার্কারগুলি স্ক্রীনে দেখা দেওয়ার সময়ে দয়া করে "
+"তাদের আলতো চাপুন।"
+
+#: panels/wacom/calibrator/calibrator.ui:78
+msgid "Mis-click detected, restarting…"
+msgstr "মিস-ক্লিক সনাক্ত হয়েছে, পুনরায় চালু হচ্ছে..."
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "বোতাম %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "সংজ্ঞায়িত করা অ্যাপ্লিকেশন"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "কীস্ট্রোক পাঠান"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "মনিটর পাল্টান"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "অন-স্ক্রীন সহায়তা দেখান"
+
+#: panels/wacom/cc-wacom-mapping-panel.c:245
+msgid "Output:"
+msgstr "আউটপুট:"
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:257
+msgid "Keep aspect ratio (letterbox):"
+msgstr "অ্যাসপেক্ট অনুমাত রাখুন (লেটারবক্স):"
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:268
+msgid "Map to single monitor"
+msgstr "একক মনিটরে ম্যাপ করুন"
+
+# auto translated by TM merge from project: sushi, version: 3.8.1, DocId: sushi
+#: panels/wacom/cc-wacom-nav-button.c:84
+#, c-format
+msgid "%d of %d"
+msgstr "%d, %d এর"
+
+#: panels/wacom/cc-wacom-page.c:516
+msgid "Display Mapping"
+msgstr "ম্যাপিং প্রদর্শন"
+
+#: panels/wacom/cc-wacom-panel.c:725 panels/wacom/wacom-stylus-page.ui:119
+msgid "Stylus"
+msgstr "স্টাইলাস"
+
+#: panels/wacom/cc-wacom-stylus-page.c:357
+msgid "Button"
+msgstr "বোতাম"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:200
+msgid "Wacom Tablet"
+msgstr "Wacom ট্যাবলেট"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"বোতাম ম্যাপিং সেট করুন এবং গ্র্যাফিক্স ট্যাবলেটের জন্য স্টাইলাস সংবেদনশীলতা "
+"সামঞ্জস্যপূর্ণ করুন"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "ট্যাবলেট;Wacom;স্টাইলাস;ইরেজার;মাউস;"
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr "ট্যাবলেট (চরম)"
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr "টাচপ্যাড (সম্পর্কিত)"
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr "ট্যাবলেট অগ্রাধিকার"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "সাহায্য (_H)"
+
+#: panels/wacom/gnome-wacom-properties.ui:125
+msgid "No tablet detected"
+msgstr "কোনো ট্যাবলেট সনাক্ত হয়নি"
+
+#: panels/wacom/gnome-wacom-properties.ui:141
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "দয়া করে প্লাগ ইন করুন বা আপনার Wacom ট্যাবলেট চালু করুন"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/wacom/gnome-wacom-properties.ui:161
+msgid "Bluetooth Settings"
+msgstr "ব্লু-টুথ সংক্রান্ত বৈশিষ্ট্য"
+
+#: panels/wacom/gnome-wacom-properties.ui:238
+msgid "Tracking Mode"
+msgstr "ট্র্যাকিং মোড"
+
+#: panels/wacom/gnome-wacom-properties.ui:266
+msgid "Left-Handed Orientation"
+msgstr "বাম-হাতী সজ্জা"
+
+#: panels/wacom/gnome-wacom-properties.ui:296
+#: panels/wacom/gnome-wacom-properties.ui:401
+msgid "Map to Monitor…"
+msgstr "মনিটর করতে ম্যাপ করুন…"
+
+#: panels/wacom/gnome-wacom-properties.ui:309
+msgid "Map Buttons…"
+msgstr "ম্যাপ বোতাম…"
+
+#: panels/wacom/gnome-wacom-properties.ui:322
+msgid "Calibrate…"
+msgstr "ক্যালিব্রেট করুন…"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#: panels/wacom/gnome-wacom-properties.ui:340
+msgid "Adjust mouse settings"
+msgstr "মাউস সংক্রান্ত বৈশিষ্ট্য সামজ্ঞস্যপূর্ণ করুন"
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Adjust display resolution"
+msgstr "প্রদর্শন রিজোলিউশন সামঞ্জস্যপূর্ণ করুন"
+
+#: panels/wacom/gnome-wacom-properties.ui:376
+msgid "Decouple Display"
+msgstr "ডিসপ্লে ভাগ করুন"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
+msgid "New shortcut…"
+msgstr "নতুন শর্টকাট…"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "ডিফল্ট"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr "মধ্যম মাউস বোতাম ক্লিক"
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr "ডান মাউস বোতাম ক্লিক"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "ফরওয়ার্ড"
+
+#: panels/wacom/wacom-stylus-page.ui:79
+msgid "No stylus found"
+msgstr "কোনও স্টাইলাস পাওয়া যায় নি"
+
+#: panels/wacom/wacom-stylus-page.ui:93
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr ""
+"এটির কনফিগার করতে দয়া করে আপনার স্টাইলাসটিকে ট্যাবলেটের সান্নিধ্যে স্থানান্তর করুন"
+
+#: panels/wacom/wacom-stylus-page.ui:159
+msgid "Eraser Pressure Feel"
+msgstr "ইরেজার প্রেসার ফিল"
+
+#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
+msgid "Soft"
+msgstr "নরম"
+
+#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
+msgid "Firm"
+msgstr "শক্ত"
+
+#: panels/wacom/wacom-stylus-page.ui:234
+msgid "Top Button"
+msgstr "শীর্ষ বোতাম"
+
+#: panels/wacom/wacom-stylus-page.ui:263
+msgid "Lower Button"
+msgstr "নিম্ন বোতাম"
+
+#: panels/wacom/wacom-stylus-page.ui:292
+msgid "Lowest Button"
+msgstr "নিম্ন বোতাম"
+
+#: panels/wacom/wacom-stylus-page.ui:321
+msgid "Tip Pressure Feel"
+msgstr "টিপ প্রেসার ফিল"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+msgid "GNOME Settings"
+msgstr "জিনোম সেটিংস"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "জিনোম ডেস্কটপ কনফিগার করতে ইউটিলিটি"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "আপনার সিস্টেমটি কনফিগার করার জন্য সেটিংস হল প্রাথমিক ইন্টারফেস।"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:20
+msgid "The GNOME Project"
+msgstr "জিনোম প্রকল্প"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "সংস্করণ নম্বর প্রদর্শন করুন"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "ভারবজ মোড সক্রিয় করুন"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "স্ট্রীং সন্ধান করুন"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "সম্ভাব্য প্যানেল নামগুলি তালিকাভুক্ত করুন এবং প্রস্থান করুন"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "প্রদর্শনের জন্য প্যানেল"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[প্যানেল] [আর্গুমেন্ট…]"
+
+#: shell/cc-panel-list.ui:45 shell/cc-window.c:275
+msgid "Privacy"
+msgstr "গোপনীয়তা"
+
+#: shell/cc-panel-loader.c:288
+msgid "Available panels:"
+msgstr "উপলব্ধ প্যানেলগুলি:"
+
+#: shell/cc-window.ui:136
+msgid "All Settings"
+msgstr "সকল সেটিং"
+
+#: shell/cc-window.ui:174
+msgid "Primary Menu"
+msgstr "প্রাথমিক মেনু"
+
+#: shell/cc-window.ui:318
+msgid "Warning: Development Version"
+msgstr "সতর্কতা: বিকাশ সংস্করণ"
+
+#: shell/cc-window.ui:319
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"সেটিংসের এই সংস্করণটি কেবলমাত্র উন্নয়নমূলক উদ্দেশ্যে ব্যবহার করা উচিত। আপনি ভুল "
+"সিস্টেম আচরণ, ডেটা হ্রাস এবং অন্যান্য অপ্রত্যাশিত সমস্যা অনুভব করতে পারেন।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: shell/cc-window.ui:330
+msgid "Help"
+msgstr "সাহায্য"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "অগ্রাধিকার;সেটিং;"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "সাধারণ"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "প্রস্থান"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "অনুসন্ধান"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "প্যানেলগুলি"
+
+#: shell/help-overlay.ui:40
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "আগের প্যানেলে ফিরে যান"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#: shell/help-overlay.ui:53
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "অনুসন্ধান বাতিল করুন"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "শেষ সেটিংস প্যানেলটি খোলার জন্য শনাক্তকারী"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"শেষ সেটিংস প্যানেলটি খোলার জন্য শনাক্তকারী। অজ্ঞাত মানগুলিকে উপেক্ষা করা হবে এবং "
+"তালিকার প্রথম প্যানেল নির্বাচিত হবে।"
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "সেটিংসের বিকাশ তৈরির সময় সতর্কতা দেখান"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "উন্নয়ন বিল্ড চলাকালীন সেটিংস কোনও সতর্কতা প্রদর্শন করবে কিনা।"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1883
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u আউটপুট"
+msgstr[1] "%u আউটপুট"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1893
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ইনপুট"
+msgstr[1] "%u ইনপুট"
+
+#: subprojects/gvc/gvc-mixer-control.c:2750
+msgid "System Sounds"
+msgstr "সিস্টেমের শব্দ"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "সারাদিনব্যাপী পরিবর্তন"
+
+#~| msgid "Lock screen"
+#~ msgid "Lock Screen"
+#~ msgstr "পর্দা লক করুন"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "টাইল"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "জুম"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "কেন্দ্র"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "পূরণ"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "স্প্যান"
+
+#~ msgid "Select Background"
+#~ msgstr "পটভূমি নির্বাচন করুন"
+
+#~ msgid "Wallpapers"
+#~ msgstr "ওয়ালপেপার"
+
+#~ msgid "Pictures"
+#~ msgstr "ছবি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Colors"
+#~ msgstr "রং"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "আপনি আপনার %s ফোল্ডারে ছবি যোগ করতে পারেন এবং তাদের এখানে দেখানো হবে"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "Bluetooth অক্ষম"
+
+#~ msgid "Done"
+#~ msgstr "সম্পন্ন"
+
+#~ msgid "United States"
+#~ msgstr "মার্কিন যুক্তরাষ্ট্র"
+
+#~ msgid "France"
+#~ msgstr "ফ্রান্স"
+
+#~ msgid "Spain"
+#~ msgstr "স্পেন"
+
+#~ msgid "China"
+#~ msgstr "চিন"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "সময় জোন (_Z)"
+
+#~| msgid "Close"
+#~ msgid "Lid Closed"
+#~ msgstr "লিড বন্ধ"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Mirrored"
+#~ msgstr "প্রতিফলিত"
+
+#~| msgid "Secondary click delay"
+#~ msgid "Secondary"
+#~ msgstr "অপ্রধান"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "একত্রিত প্রদর্শন সাজান"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "প্রদর্শনগুলিকে আবার সাজাতে তাদের টানুন"
+
+#~ msgid "Size"
+#~ msgstr "মাপ"
+
+#~ msgid "Aspect Ratio"
+#~ msgstr "অ্যাসপেক্ট অনুমাত"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "এই প্রদর্শনে শীর্ষ দন্ড এবং ক্রিয়াকলাপ পূর্বরূপ দেখান "
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "একটি অতিরিক্ত ওয়ার্কস্পেস তৈরি করতে এই প্রদর্শন অপর একটির সংগে যুক্ত করুন"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~| msgid "Orientation"
+#~ msgid "Presentation"
+#~ msgstr "সজ্জা"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "শুধুমাত্র স্লাইডশো এবং মিডিয়া দেখান"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "উভয় প্রদর্শনেই আপনার বিদ্যমান রূপ দেখান"
+
+#~| msgid "_Turn On"
+#~ msgid "Turn Off"
+#~ msgstr "বন্ধ করুন"
+
+#~| msgid "Panel to display"
+#~ msgid "Don't use this display"
+#~ msgstr "এই প্রদর্শন ব্যবহার করবেন না"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Could not get screen information"
+#~ msgstr "পর্দা সংক্রান্ত পরিবর্তন প্রাপ্ত করতে ব্যর্থ"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "একত্রিত প্রদর্শন সাজান (_A)"
+
+#~| msgid "%d-bit"
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-বিট"
+
+#~ msgid "Section"
+#~ msgstr "বিভাগ"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#~ msgid "Overview"
+#~ msgstr "পূর্বরূপ"
+
+#~ msgid "Version %s"
+#~ msgstr "সংস্করণ %s"
+
+#~| msgid "Open System"
+#~ msgid "Base system"
+#~ msgstr "বেস সিস্টেম"
+
+#~ msgid "Disk"
+#~ msgstr "ডিস্ক"
+
+#~| msgid "Checking for Updates"
+#~ msgid "Check for updates"
+#~ msgstr "আপডেট আছে কিনা দেখুন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Keyboard"
+#~ msgstr "কি-বোর্ড"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "শর্টকাট;পুনরাবৃত্তি;ব্লিঙ্ক;"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "_Delay:"
+#~ msgstr "বিলম্ব: (_D)"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "সংক্ষিপ্ত"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "মন্থর"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "লম্বা"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্রুত"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "S_peed:"
+#~ msgstr "গতি: (_p)"
+
+#~ msgid "Add Shortcut"
+#~ msgstr "শর্টকাট যোগ করুন"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "একটি শর্টকাট সম্পাদন করতে, সারিতে ক্লিক করুন এবং সাফ করতে নতুন কী ধরে থাকুন বা "
+#~ "Backspace টিপুন।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Unknown Action>"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "শর্টকাট-কি হিসেবে \"%s\" ব্যবহার করা যাবে না কারণ এর ফলে এই কি ব্যবহার করে "
+#~ "কিছু টাইপ করা যাবে না।\n"
+#~ "অনুগ্রহ করে Control, Alt অথবা Shift কি-র একত্রিত ব্যবহারের প্রচেষ্টা করুন।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "শর্টকাট \"%s\" বর্তমানে\n"
+#~ "\"%s\"-র জন্য ব্যবহৃত হচ্ছে"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "\"%s\"-এ শর্ট-কাট স্থাপন করা হলে, \"%s\" শর্ট-কাটটি নিষ্ক্রিয় করা হবে।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "_Reassign"
+#~ msgstr "পুনরায় নির্ধারণ (_R)"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" শর্টকাটের সংগে একটি \"%s\" শর্টকাট সংযুক্ত রয়েছে। আপনি কি এটি "
+#~ "স্বয়ংক্রিয়ভাবে \"%s\" এ সেট করতে চান?"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~| msgid ""
+#~| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~| "disabled."
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "বর্তমানে \"%s\" \"%s\"-এর সংগে সংশ্লিষ্ট, আপনি এগিয়ে গেলে এই শর্টকাট নিষ্ক্রিয় "
+#~ "হবে।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~| msgid "_Reassign"
+#~ msgid "_Assign"
+#~ msgstr "নিয়োগ (_A)"
+
+#~| msgid "Test Your _Settings"
+#~ msgid "Test Your Settings"
+#~ msgstr "আপনার সেটিং পরীক্ষা করুন"
+
+#~| msgctxt "keyboard, speed"
+#~| msgid "Slow"
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "মন্থর"
+
+#~| msgctxt "keyboard, speed"
+#~| msgid "Fast"
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্রুত"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "বাঁদিকে (_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "ডানদিকে (_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "পয়েন্টার গতি (_P)"
+
+#~| msgctxt "keyboard, speed"
+#~| msgid "Slow"
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "মন্থর"
+
+#~| msgctxt "keyboard, speed"
+#~| msgid "Fast"
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্রুত"
+
+#~| msgctxt "keyboard, speed"
+#~| msgid "Slow"
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "মন্থর"
+
+#~| msgctxt "keyboard, speed"
+#~| msgid "Fast"
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্রুত"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "টাইপ করার সময়ে অক্ষম করুন (_t)"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "এই সংস্করণের সংগে সিস্টেম নেটওয়ার্ক পরিষেবাদি সুসংগত নয়।"
+
+#~ msgid "page 1"
+#~ msgstr "পৃষ্ঠা ১"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "আভ্যন্তরীণ প্রমাণীকরণ (_a)"
+
+#~ msgid "page 2"
+#~ msgstr "পৃষ্ঠা ২"
+
+#~ msgid "Server"
+#~ msgstr "সার্ভার"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS সার্ভার মুছুন"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "ট্যুইসটেড পেয়ার (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "অ্যাটাচমেন্ট ইউনিট ইন্টারফেস (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "মিডিয়া ইন্ডিপেনডেন্ট ইন্টারফেস (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "অন্যান্য ব্যবহারকারীর কাছে উপলব্ধ করান (_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "ফায়ারওয়্যাল জোন (_Z)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~| msgid "Default"
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "ডিফল্ট"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "জোন সংযোগের বিশ্বস্ততার মাত্রা নির্দিষ্ট করে"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#~ msgid "Bond"
+#~ msgstr "বন্ড"
+
+#~ msgid "Team"
+#~ msgstr "দল"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#~ msgid "Bridge"
+#~ msgstr "ব্রিজ"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN প্লাগিন লোড করা যায়নি"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "নেটওয়ার্ক সংযোগ যোগ করুন"
+
+# auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
+#~ msgid "_Reset"
+#~ msgstr "রি-সেট (_R)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "পাসওয়ার্ড সমেত এই নেটওয়ার্কের জন্য সেটিং পুনঃসেট করুন, কিন্তু এটিকে পছন্দের "
+#~ "নেটওয়ার্ক হিসাবে মনে রাখুন"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "এই নেটওয়ার্কের সংগে সংশিষ্ট সমস্ত বিস্তারিত সরান এবং স্বয়ংক্রিয় ভাবে সংযোগ করার "
+#~ "চেষ্টা করুন"
+
+#~ msgid "My Home Network"
+#~ msgstr "আমার হোম নেটওয়ার্ক"
+
+#~ msgid "Bond slaves"
+#~ msgstr "বন্ড স্লেভস"
+
+#~ msgid "(none)"
+#~ msgstr "(কিছুই নয়)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "ব্রিজ স্লেভস"
+
+#~| msgid "Bridge slaves"
+#~ msgid "Team slaves"
+#~ msgstr "টিম স্লেভস"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "বেতার সংযোগ ছাড়া ইন্টারনেটের সংগে আপনার অন্য কোনো ধরনের সংযোগ থাকলে, অন্যদের "
+#~ "সংগে সংযোগ ভাগ করতে আপনি একটি বেতার হটস্পট সেট আপ করতে পারবেন।"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "বেতার হটস্পটে স্যুইচ করলে আপনি <b>%s</b> থেকে সংযোগবিচ্ছিন্ন হবেন।"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "হটস্পট সক্রিয় থাকার সময়ে আপনার বেতার মারফত ইন্টারনেট অ্যাক্সেস করা সম্ভব নয়।"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "Proxy"
+#~ msgstr "প্রক্সি"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "শূণ্য"
+
+# auto translated by TM merge from project: control-center, version: 3.8.6, DocId: gnome-control-center-2.0
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "ম্যানুয়াল"
+
+# auto translated by TM merge from project: gnome-terminal, version: 3.8.4, DocId: gnome-terminal
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "স্বয়ংক্রিয়"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#~ msgid "VPN Type"
+#~ msgstr "VPN ধরন"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#~ msgid "Group Name"
+#~ msgstr "গোষ্ঠী নাম"
+
+# auto translated by TM merge from project: anaconda, version: 19.31.34, DocId: anaconda
+#~ msgid "Group Password"
+#~ msgstr "গোষ্ঠী পাসওয়ার্ড"
+
+#~ msgid "details"
+#~ msgstr "বিস্তারিত"
+
+#~ msgid "Show P_assword"
+#~ msgstr "পাসওয়ার্ড দেখান (_a)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "অন্যান্য ব্যবহারকারীর কাছে উপলব্ধ করান"
+
+# auto translated by TM merge from project: RHEL Deployment Guide, version: 6.2, DocId: Product_Subscriptions_and_Entitlements
+#~ msgid "identity"
+#~ msgstr "পরিচয়"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "শুধুমাত্র স্বয়ংক্রিয় (DHCP) ঠিকানাগুলি"
+
+#~ msgid "Link-local only"
+#~ msgstr "শুধুমাত্র লিঙ্ক-স্থানীয়"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "স্বয়ংক্রিয় ভাবে প্রাপ্ত রাউট উপেক্ষা করুন (_I)"
+
+# auto translated by TM merge from project: firewalld, version: 0.3.4, DocId: firewalld
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+# auto translated by TM merge from project: firewalld, version: 0.3.4, DocId: firewalld
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "ক্লোনড MAC ঠিকানা (_C)"
+
+#~ msgid "hardware"
+#~ msgstr "হার্ডওয়্যার"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "এই সংযোগের সেটিংস তাদের ডিফল্টে পুনঃসেট করুন কিন্তু পছন্দের সংযোগ হিসাবে মনে "
+#~ "রাখুন।"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "এই নেটওয়ার্কের সংগে সংশিষ্ট সমস্ত বিস্তারিত সরান এবং এতে স্বয়ংক্রিয় ভাবে সংযোগ "
+#~ "করার চেষ্টা করবেন না।"
+
+#~ msgid "Hardware"
+#~ msgstr "হার্ডওয়্যার"
+
+#~ msgid "_History"
+#~ msgstr "ইতিহাস (_H)"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "একটি Wi-Fi নেটওয়ার্কে সংযোগ করতে স্যুইচ বন্ধ করুন"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "অ্যাড-হক"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "Infrastructure"
+#~ msgstr "পরিকাঠামো"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgid "Not connected"
+#~ msgstr "সংযোগ বিহীন"
+
+# auto translated by TM merge from project: NetworkManager, version: 0.9.8.2, DocId: NetworkManager
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand ডিভাইস দ্বারা সংযুক্ত মোড সমর্থিত হয় না"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "কোনো শংসাপত্র কর্তৃপক্ষ শংসাপত্র বাছা হয়নি"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "শংসাপত্র কর্তৃপক্ষ (CA) শংসাপত্র ব্যবহার না করার ফলে সংযোগ অনিরাপদ হয়ে যেতে "
+#~ "পারে, Wi-Fi নেটওয়ার্ক বিপজ্জনক হতে পারে। আপনি কি একটি শংসাপত্র কর্তৃপক্ষ "
+#~ "শংসাপত্র বাছতে চান?"
+
+# auto translated by TM merge from project: authconfig, version: 6.1.12-8, DocId: authconfig
+#~ msgid "Ignore"
+#~ msgstr "অগ্রাহ্য করা হবে"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA শংসাপত্র বাছুন"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "প্রতিবার এই পাসওয়ার্ড জিজ্ঞাসা করুন (_k)"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "আমাকে আবার সর্তক করবেন না (_w)"
+
+#~ msgid "Yes"
+#~ msgstr "হ্যাঁ"
+
+# auto translated by TM merge from project: RHEL Installation Guide, version: 6.0, DocId: Graphical_Installation-x86
+#~ msgid "2"
+#~ msgstr "২"
+
+# auto translated by TM merge from project: RHEL Installation Guide, version: 6.0, DocId: Graphical_Installation-x86
+#~ msgid "3"
+#~ msgstr "৩"
+
+# auto translated by TM merge from project: RHEL Installation Guide, version: 6.0, DocId: Graphical_Installation-x86
+#~ msgid "4"
+#~ msgstr "৪"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "পপ-আপ ব্যানার দেখান"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "ব্যানারে বিস্তারিত দেখান"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "লক স্ক্রীনে দেখুন"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "পপ-আপ ব্যানার দেখান"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "লক স্ক্রীনে দেখান"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "Add Account"
+#~ msgstr "অ্যাকাউন্ট যোগ করুন"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "Mail"
+#~ msgstr "মেইল"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "Contacts"
+#~ msgstr "পরিচিতি"
+
+#~ msgid "Chat"
+#~ msgstr "চ্যাট"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "অ্যাকাউন্টে লগ ইন করতে ত্রুটি"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "শংসাপত্রের মেয়াদ শেষ হয়ে গেছে।"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "এই অ্যাকাউন্ট সক্রিয় করতে সাইন ইন করুন।"
+
+#~ msgid "_Sign In"
+#~ msgstr "সাইন ইন করুন (_S)"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgid "Error creating account"
+#~ msgstr "অ্যাকাউন্ট তৈরি করতে ত্রুটি"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "কোনো অনলাইন অ্যাকাউন্ট কনফিগার করা হয়নি"
+
+# auto translated by TM merge from project: gnome-getting-started-docs, version: 3.8.3.0.1, DocId: gnome-getting-started-docs
+#~ msgid "Add an online account"
+#~ msgstr "একটি অনলাইন অ্যাকাউন্ট যোগ করুন"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "একটি অ্যাকাউন্ট যোগ করলে আপনার অ্যাপ্লিকেশনগুলি তা নথি, মেল, পরিচিতি, বর্ষপঞ্জি, "
+#~ "চ্যাট এবং আরো অনেক কিছুর জন্য অ্যাক্সেস করতে পারবে।"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "বেতার ডিভাইসগুলি বন্ধ করে"
+
+#~| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "মোবাইল ব্রডব্যান্ড (3G, 4G, WiMax, ইত্যাদি) ডিভাইসগুলি বন্ধ করে"
+
+#~| msgid "When Battery Power is _Critical"
+#~ msgid "When battery power is _critical"
+#~ msgstr "যখন ব্যাটারি পাওয়ার খুবই কম (_C)"
+
+# auto translated by TM merge from project: gnome-session, version: 3.8.4, DocId: gnome-session-3.0
+#~ msgid "Power off"
+#~ msgstr "বন্ধ করুন"
+
+#~ msgid "Toner Level"
+#~ msgstr "টোনারের মাত্রা"
+
+#~ msgid "Supply Level"
+#~ msgstr "সরবরাহের মাত্রা"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "ইনস্টল করা হচ্ছে"
+
+#~ msgid "No printers available"
+#~ msgstr "কোনো প্রিন্টার উপলব্ধ নেই"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u সক্রিয়"
+#~ msgstr[1] "%u সক্রিয়"
+
+#~ msgid "Close"
+#~ msgstr "বন্ধ করুন"
+
+#~ msgid "Resume Printing"
+#~ msgstr "মুদ্রণ আবার শুরু করুন"
+
+#~ msgid "Pause Printing"
+#~ msgstr "মুদ্রণ সাময়িক থামান"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "একটি নতুন প্রিন্টার যোগ করুন"
+
+#~| msgid "Search for network printers or filter result"
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "ফলাফল বাছাই করতে একটি প্রিন্টারের ঠিকানা বা একটি পাঠ্য লিখুন"
+
+#~ msgid "Loading options…"
+#~ msgstr "লোডের বিকল্প…"
+
+# auto translated by TM merge from project: system-config-printer, version: 1.1.16-23, DocId: system-config-printer
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "আটক করা"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "Job Title"
+#~ msgstr "কাজের শিরোনাম"
+
+#~ msgid "Job State"
+#~ msgstr "কাজের স্থিতি"
+
+#~ msgid "Supply"
+#~ msgstr "সরবরাহ করুন"
+
+#~ msgid "Jobs"
+#~ msgstr "কাজ"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "কাজ দেখান (_J)"
+
+#~ msgid "label"
+#~ msgstr "স্তর"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "নতুন ড্রাইভার সেট করা হচ্ছে…"
+
+#~ msgid "page 3"
+#~ msgstr "পৃষ্ঠা ৩"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "পরীক্ষা পৃষ্ঠা মুদ্রণ করুন (_T)"
+
+#~ msgid "_Options"
+#~ msgstr "বিকল্প (_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "নতুন প্রিন্টার যোগ করুন"
+
+#~ msgid "Usage & History"
+#~ msgstr "ব্যবহার & ইতিহাস"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "আপনার ব্যক্তিগত তথ্য সুরক্ষিত রাখুন এবং অন্যরা কী দেখতে পাবেন না পাবেন তা "
+#~ "নিয়ন্ত্রণ করুন"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "আপনার ইতিহাস মনে রাখলে তা কিছু আবার খোঁজার কাজকে সহজ করে তোলে। এইগুলি কখনও "
+#~ "নেটওয়ার্ক মারফত ভাগ করা হয়  না।"
+
+#~ msgid "_Recently Used"
+#~ msgstr "সাম্প্রতিক ব্যবহৃত (_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "ইতিহাস রেখে দিন (_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "আপনি দূরে থাকলে স্ক্রীন লক আপনার গোপনীয়তাকে সুরক্ষিত রাখে।"
+
+#~| msgid "Lock Screen _After Blank For"
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "এত খালি থাকার পরে স্ক্রীন তালাবন্ধ করুন (_a)"
+
+#~ msgid "Show _Notifications"
+#~ msgstr "বিজ্ঞপ্তিগুলি দেখান (_N)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "আপনার কম্পিউটারকে অপ্রয়োজনীয় সংবেদনশীল তথ্য থেকে মুক্ত রাখতে ট্র্যাশ এবং অস্থায়ী "
+#~ "ফাইলগুলি স্বয়ংক্রিয় ভাবে পার্জ করুন।"
+
+#~ msgid "Purge _After"
+#~ msgstr "এত পরে পার্জ করুন (_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "আপনি কোন সফ্টওয়্যার ব্যবহার করছেন সেই বিষয়ে আমাদের তথ্য দিলে তা আপনাকে আমাদের "
+#~ "তরফ থেকে আরো নির্ভুল প্রস্তাবনা দিতে সাহায্য করে। এটি আমাদের সফ্টওয়্যার উন্নত "
+#~ "করতেও সহায়তা করে।\n"
+#~ "\n"
+#~ "আমরা সকল তথ্য বেনামেই সংগ্রহ করে থাকি, এবং আমরা কখনই তৃতীয় পক্ষের সংগে আপনার "
+#~ "ডেটা ভাগ করে নেব না।"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "সফ্টওয়্যার ব্যবহারের পরিসংখ্যান পাঠান (_S)"
+
+#~| msgid "Privacy"
+#~ msgid "Privacy Policy"
+#~ msgstr "গোপনীয়তা নীতি"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "আপনার ভৌগোলিক অবস্থান নির্ধারণ করতে ব্যবহৃত"
+
+#~ msgid "Sorry"
+#~ msgstr "দুঃখিত"
+
+#~ msgid "Switch to next source"
+#~ msgstr "পরবর্তী সোর্সে স্যুইচ করুন"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "পরবর্তী সোর্সে বৈকল্পিক স্যুইচ"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "ইংরাজি (ইউনাইটেড কিংডম)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "ইউনাইটেড কিংডম"
+
+# auto translated by TM merge from project: RHEL Deployment Guide, version: 6.2, DocId: Product_Subscriptions_and_Entitlements
+#~ msgid "Options"
+#~ msgstr "বিকল্প"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~| msgid "Other"
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "অন্যান্য"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Preferences"
+#~ msgstr "পছন্দ"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "ব্লুটুথ ভাগের মাধ্যমে আপনি অন্যান্য ব্লুটুথ সক্রিয় ডিভাইসের সংগে ফাইল ভাগ করতে "
+#~ "পারবেন"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "শুধুমাত্র বিশ্বস্ত ডিভাইসগুলি থেকে প্রাপ্ত করুন"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "প্রাপ্ত ফাইলগুলি ডাউনলোড ফোল্ডারে সংরক্ষণ করুন"
+
+#~| msgid "Remote Control"
+#~ msgid "Allow Remote Control"
+#~ msgstr "রিমোট কন্ট্রোলের অনুমতি দিন"
+
+# auto translated by TM merge from project: Skynet topics, version: 1, DocId: 5177-68190
+#~| msgid "Password"
+#~ msgid "Password:"
+#~ msgstr "পাসওয়ার্ড:"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "সর্বনিম্ন"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "সর্বাধিক"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "সাব-উফার (_S):"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "আন-অ্যাপ্লিফায়েড"
+
+#~ msgid "_Profile:"
+#~ msgstr "প্রোফাইল (_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "স্পীকার পরীক্ষা (_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "পিক সনাক্ত"
+
+#~ msgid "Device"
+#~ msgstr "ডিভাইস"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s এর জন্য স্পীকার পরীক্ষা"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "শব্দ আউটপুটের জন্য একটি ডিভাইস বাছুন (_h):"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "নির্বাচিত ডিভাইসের সেটিং:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "ইনপুট ভলিউম (_I):"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "শব্দ ইনপুটের জন্য একটি ডিভাইস বাছুন (_h):"
+
+#~ msgid "Sound Effects"
+#~ msgstr "শব্দ প্রভাব"
+
+#~ msgid "Built-in"
+#~ msgstr "অন্তর্ভুক্ত"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "শব্দ বিষয়ক অগ্রাধিকার"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ইভেন্ট শব্দ পরীক্ষা"
+
+#~ msgid "From theme"
+#~ msgstr "থীম থেকে"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "একটি সর্তকতা শব্দ বাছুন (_h):"
+
+# auto translated by TM merge from project: gnome-clocks, version: 3.8.2, DocId: gnome-clocks
+#~ msgid "Stop"
+#~ msgstr "বন্ধ করুন"
+
+#~| msgid "Flash the window title"
+#~ msgid "Flash the _window title"
+#~ msgstr "উইন্ডো শিরোনাম ফ্ল্যাশ করুন (_w)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Zoom"
+#~ msgstr "প্রদর্শনের মাপ"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "রঙ"
+
+#~ msgid "_Verify"
+#~ msgstr "যাচাই (_V)"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "আঙুলের ছাপ সহযোগে লগ-ইনের ব্যবস্থা সক্রিয় করুন"
+
+#~ msgid "_Other finger:"
+#~ msgstr "অন্যান্য ফিংগার (_O):"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "আপনার আঙুলের ছাপ সাফল্যের সাথে সংরক্ষিত হয়েছে। আঙুলের ছাপ পাঠের ব্যবস্থা "
+#~ "(রিডার) সহযোগে আপনি এখন লগ-ইন করতে সক্ষম হবেন।"
+
+#~ msgid "Login History"
+#~ msgstr "লগিন ইতিহাস"
+
+#~| msgid "_New password"
+#~ msgid "_Verify New Password"
+#~ msgstr "নতুন পাসওয়ার্ড যাচাই করুন (_V)"
+
+#~ msgid "Add User Account"
+#~ msgstr "ব্যবহারকারী অ্যাকাউন্ট যোগ করুন"
+
+#~ msgid "Last Login"
+#~ msgstr "সর্বশেষ লগিন"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "আরো বেশি করে অক্ষর, সংখ্যা এবং সংকেত যোগ করার চেষ্টা করুন।"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "শক্তি: দুর্বল"
+
+#~| msgid "Length:"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "শক্তি: কম"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "শক্তি: মাঝারি"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "শক্তি: ভালো"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "শক্তি: উচ্চ"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~| msgid "Passwords do not match"
+#~ msgid "Passwords do not match."
+#~ msgstr "পাসওয়ার্ডগুলি মিলছে না।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "আপনি এই ডিভাইস ব্যবহার করতে অনুমোদিত নন। অনুগ্রহ করে সিস্টেম অ্যাডমিনিস্ট্রেটরের "
+#~ "সাথে যোগাযোগ করুন।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "The device is already in use."
+#~ msgstr "ডিভাইসটি বর্তমানে ব্যবহৃত হচ্ছে।"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "একটি অভ্যন্তরীণ ত্রুটি ঘটেছে।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "নিবন্ধিত আঙুলের ছাপ মুছে ফেলা হবে কি?"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Done!"
+#~ msgstr "সমাপ্ত!"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' ডিভাইস ব্যবহার করতে ব্যর্থ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' ডিভাইসের মধ্যে আঙুলের ছাপ প্রাপ্ত করতে ব্যর্থ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "আঙুলের ছাপ পাঠের কোনো ব্যবস্থা প্রয়োগ করা যায়নি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr ""
+#~ "অনুগ্রহ করে সহায়তার জন্য আপনার সিস্টেম অ্যাডমিনিস্ট্রটরের সাথে যোগাযোগ করুন।"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "আঙুলের ছাপ সহযোগে লগ-ইন ব্যবস্থা সক্রিয় করার জন্য, '%s' সহযোগে অন্তত একটি আঙুলের "
+#~ "ছাপ সংরক্ষণ করা আবশ্যক।"
+
+#~ msgid "Selecting finger"
+#~ msgstr "ফিংগার নির্বাচন করা হচ্ছে"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Disable image"
+#~ msgstr "ছবি নিষ্ক্রিয় করুন"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "আরো ছবির জন্য ব্রাউজ করুন…"
+
+#~ msgid "Used by %s"
+#~ msgstr "%s দ্বারা ব্যবহৃত"
+
+#~ msgid "Other Accounts"
+#~ msgstr "অন্যান্য অ্যাকাউন্ট"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "একটি ব্যবহারকারী অ্যাকাউন্ট তৈরি করতে,\n"
+#~ "প্রথমে * আইকনে ক্লিক করুন"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "%s নামের একটি ব্যবহারকারী ইতিমধ্যেই উপস্থিত রয়েছে।"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~| msgid "The username cannot start with a '-'"
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "একটি ব্যবহারকারীর নাম '-' দিয়ে শুরু হতে পারে না।"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "উপরে"
+
+# auto translated by TM merge from project: empathy, version: 3.8.3, DocId: empathy
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "নীচে"
+
+# auto translated by TM merge from project: rhsm-web, version: 0.0, DocId: management
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "শূণ্য"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Left Ring"
+#~ msgstr "বাঁদিকের রিং"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "বাঁদিকের রিং মোড #%d"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "ডানদিকের রিং মোড #%d"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Left Touchstrip"
+#~ msgstr "বাঁদিকের টাচ-স্ট্রিপ"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "বাঁদিকের টাচ-স্ট্রিপ মোড #%d"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Right Touchstrip"
+#~ msgstr "ডানদিকের টাচ-স্ট্রিপ"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "ডানদিকের টাচ-স্ট্রিপ মোড #%d"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "বাঁদিকের টাচ-রিং মোডের সুইচ"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "ডানদিকের টাচ-রিং মোডের সুইচ"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "বাঁদিকের টাচ-স্ট্রিপ মোডের সুইচ"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "ডানদিকের টাচ-স্ট্রিপ মোডের সুইচ"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Mode Switch #%d"
+#~ msgstr "মোডের সুইচ #%d"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Left Button #%d"
+#~ msgstr "বাঁদিকের বাটন #%d"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Right Button #%d"
+#~ msgstr "ডানদিকের বাটন #%d"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Top Button #%d"
+#~ msgstr "উপরের বাটন #%d"
+
+# auto translated by TM merge from project: gnome-settings-daemon, version: 3.8.4, DocId: gnome-settings-daemon
+#~ msgid "Bottom Button #%d"
+#~ msgstr "নীচের বাটন #%d"
+
+#~ msgid "No Action"
+#~ msgstr "কোনো কাজ নয়"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "বাম মাউস বোতাম ক্লিক"
+
+# auto translated by TM merge from project: evince, version: 3.8.3, DocId: evince
+#~ msgid "Scroll Up"
+#~ msgstr "উপরে চলুন"
+
+# auto translated by TM merge from project: evince, version: 3.8.3, DocId: evince
+#~ msgid "Scroll Down"
+#~ msgstr "নীচে চলুন"
+
+#~ msgid "Scroll Left"
+#~ msgstr "বাম দিকে স্ক্রোল করুন"
+
+#~ msgid "Show the overview"
+#~ msgstr "পূর্বরূপ দেখান"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Show help options"
+#~ msgstr "সহায়তা সংক্রান্ত বিকল্প প্রদর্শন করা হবে"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "কমান্ড-লাইন থেকে ব্যবহারযোগ্য বিকল্পের সম্পূর্ণ তালিকা দেখার জন্য '%s --help' "
+#~ "প্রয়োগ করুন।\n"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "হার্ডওয়্যার"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "সিস্টেম"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "নতুন ডিভাইস সেট আপ করুন"
+
+#~ msgid "Paired"
+#~ msgstr "জুটি"
+
+#~ msgid "Type"
+#~ msgstr "ধরন"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "মাউস & টাচপ্যাড সেটিং"
+
+#~ msgid "Send Files…"
+#~ msgstr "ফাইলগুলি পাঠান…"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” এর দৃশ্যমানতা"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "ডিভাইসগুলির তালিকা থেকে '%s' সরান?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "আপনি ডিভাইস সরিয়ে দিলে, পরের বার ব্যবহার করার আগে আপনাকে আবার তা সেট আপ "
+#~ "করতে হবে।"
+
+#~ msgid "Export"
+#~ msgstr "রপ্তানি করুন"
+
+#~ msgid "Device type:"
+#~ msgstr "ডিভাইসের ধরন:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "উত্পাদক:"
+
+#~ msgid "Model:"
+#~ msgstr "মডেল:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "উপরের ক্ষেত্রগুলিকে স্বয়ংক্রিয় ভাবে সম্পূর্ণ করতে এই উইন্ডোতে ছবি ফাইল টেনে আনা "
+#~ "যেতে পারে।"
+
+#~ msgid "Left Shift"
+#~ msgstr "বাম Shift"
+
+#~ msgid "Right Shift"
+#~ msgstr "ডান Shift"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "বাম Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "বাম Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "ডান Ctrl+Shift"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "Caps"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "_Region:"
+#~ msgstr "অঞ্চল (_R):"
+
+#~ msgid "_City:"
+#~ msgstr "শহর (_C):"
+
+#~ msgid "_Network Time"
+#~ msgstr "নেটওয়ার্ক সময় (_N)"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "সময় এক ঘন্টা আগে সেট করুন।"
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "সময় এক ঘন্টা পিছনে সেট করুন।"
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "সময় এক মিনিট আগে সেট করুন।"
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "সময় এক মিনিট পিছনে সেট করুন।"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM এবং PM এর মধ্যে অদলবদল করুন।"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "স্বাভাবিক"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "ঘড়ির কাঁটার বিপরীত দিকে"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "ঘড়ির কাঁটার দিকে"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "১৮০ ডিগ্রি"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Monitor"
+#~ msgstr "মনিটর"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "প্রাথমিক প্রদর্শন পরিবর্তন করতে টানুন।"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "কোনো মনিটরের বিশিষ্টতা পরিবর্তন করতে তা নির্বাচন করুন; তার অবস্থান পনঃসজ্জিত "
+#~ "করতে তাকে টানুন।"
+
+# auto translated by TM merge from project: gnome-desktop3, version: 3.8.3, DocId: gnome-desktop-3.0
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "মনিটর সংক্রান্ত কনফিগারেশন সংরক্ষণ করতে ব্যর্থ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Could not detect displays"
+#~ msgstr "ডিসপ্লে সনাক্ত করতে ব্যর্থ"
+
+#~ msgid "_Resolution"
+#~ msgstr "রিজোলিউশন (_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "ঘূর্ণন (_o)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "মিরর প্রদর্শন (_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "দ্রষ্টব্য: রিজোলিউশন বিকল্প সীমাবদ্ধ করতে পারে"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "সিস্টেম আপ-টু‍-ডেট"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Mouse Preferences"
+#~ msgstr "মাউস সম্পর্কিত পছন্দ"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "মন্থর"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "দ্রুত"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "আঙুলে আটকানো বিষয়বস্তু (_o)"
+
+# auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
+#~ msgid "_Options…"
+#~ msgstr "বিকল্প…(_O)"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "নতুন ডিভাইসের জন্য ব্যবহার করতে ইন্টারফেসটি নির্বাচন করুন"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgid "C_reate…"
+#~ msgstr "তৈরি করুন (_r)…"
+
+#~ msgid "_Interface"
+#~ msgstr "ইন্টারফেস (_I)"
+
+#~ msgid "_Default"
+#~ msgstr "ডিফল্ট (_D)"
+
+#~ msgid "Hidden"
+#~ msgstr "লুকানো"
+
+#~ msgid "Visible"
+#~ msgstr "দৃশ্যমান"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "নাম & দৃশ্যমানতা"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "আপনি স্ক্রীন এবং নেটওয়ার্কে কীভাবে উপস্থিত হন তা নিয়ন্ত্রণ করুন।"
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "শীর্ষ দণ্ডে সম্পূর্ণ নাম দেখান (_f)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "লক স্ক্রীনে সম্পূর্ণ নাম দেখান (_l)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "_Stealth মোড"
+
+#~ msgid "Immediately"
+#~ msgstr "অবিলম্বে"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "কিছুই নয়"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "সর্বজনীন ফোল্ডার ভাগ করুন"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "শুধুমাত্র বিশ্বস্ত ডিভাইসগুলির সংগে ভাগ করুন"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "এই নেটওয়ার্কে মিডিয়া ভাগ করুন"
+
+#~ msgid "Shared Folders"
+#~ msgstr "ভাগ করা ফোল্ডারগুলি"
+
+#~ msgid "column"
+#~ msgstr "কলাম"
+
+#~ msgid "Remove Folder"
+#~ msgstr "ফোল্ডার সরান"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "এই নেটওয়ার্কে সার্বজনীন ফোল্ডার ভাগ করুন"
+
+#~ msgid "Remote View"
+#~ msgstr "রিমোট ভিউ"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "সকল সংযোগের অনুমোদন দিন"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "স্বাভাবিক"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "উচ্চ/বিপরীত "
+
+#~ msgid "On screen keyboard"
+#~ msgstr "অন-স্ক্রীন কীবোর্ড"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "৭৫%"
+
+# auto translated by TM merge from project: evince, version: 3.8.3, DocId: evince
+#~ msgid "100%"
+#~ msgstr "১০০%"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "স্বাভাবিক"
+
+# auto translated by TM merge from project: evince, version: 3.8.3, DocId: evince
+#~ msgid "125%"
+#~ msgstr "১২৫%"
+
+# auto translated by TM merge from project: evince, version: 3.8.3, DocId: evince
+#~ msgid "150%"
+#~ msgstr "১৫০%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Caps এবং Num Lock এ বীপ"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "চালু বা বন্ধ:"
+
+# auto translated by TM merge from project: control-center, version: 3.8.3, DocId: gnome-control-center-2.0
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "জুম"
+
+#~ msgid "Zoom in:"
+#~ msgstr "জুম বাড়ান:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "জুম কমান:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "ক্লোজড ক্যাপশনিং"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "স্পীচ এবং শব্দের একটি টেক্সচুয়াল বর্ণনা দেখান"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "সংক্ষিপ্ত"
+
+# auto translated by TM merge from project: control-center, version: 3.8.6, DocId: gnome-control-center-2.0
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "লম্বা"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "বীপ আওয়াজ হোক, যখন একটি কী"
+
+#~ msgid "pressed"
+#~ msgstr "টেপা হলে"
+
+#~ msgid "accepted"
+#~ msgstr "স্বীকার করা হলে"
+
+#~ msgid "rejected"
+#~ msgstr "প্রত্যাখ্যান করা হলে"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "স্বীকার করতে বিলম্ব (_e):"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "কীপ্যাড ব্যবহার করে পয়েন্টার নিয়ন্ত্রণ করুন"
+
+#~ msgid "Video Mouse"
+#~ msgstr "ভিডিও মাউস"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "ভিডিও ক্যামেরা ব্যবহার করে পয়েন্টার নিয়ন্ত্রণ করুন।"
+
+# auto translated by TM merge from project: control-center, version: 3.8.6, DocId: gnome-control-center-2.0
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "ছোট"
+
+# auto translated by TM merge from project: totem, version: 3.8.2, DocId: totem
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "বৃহৎ"
+
+#~ msgid "_Local Account"
+#~ msgstr "স্থানীয় অ্যাকাউন্ট (_L)"
+
+#~ msgid "_Login Name"
+#~ msgstr "লগিন নাম (_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "পরামর্শ: এন্টারপ্রাইজ ডোমেন বা রিলম নাম"
+
+# auto translated by TM merge from project: brasero, version: 3.8.0, DocId: brasero
+#~ msgid "C_ontinue"
+#~ msgstr "এগিয়ে চলুন (_o)"
+
+#~ msgid "Previous Week"
+#~ msgstr "পূর্ববর্তী সপ্তাহ"
+
+#~ msgid "Next Week"
+#~ msgstr "পরবর্তী সপ্তাহ"
+
+# auto translated by TM merge from project: gnome-shell, version: 3.8.4, DocId: gnome-shell
+#~ msgid "Next week"
+#~ msgstr "পরবর্তী সপ্তাহ"
+
+#~ msgid "Log in without a password"
+#~ msgstr "একটি পাসওয়ার্ড ছাড়াই লগিন করুন"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "Disable this account"
+#~ msgstr "এই অ্যাকাউন্টটি নিষ্ক্রিয় করুন"
+
+#~ msgid "Enable this account"
+#~ msgstr "এই অ্যাকাউন্ট সক্রিয় করুন"
+
+# auto translated by TM merge from project: ekiga, version: 4.0.1, DocId: ekiga
+#~ msgid "_Action"
+#~ msgstr "কর্ম (_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "পাসওয়ার্ড দেখান (_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "কীভাবে একটি শক্তিশালী পাসওয়ার্ড বেছে নেবেন"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "এর জন্য ফোটো পরিবর্তন:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "একটি ছবি বাছুন, যা এই অ্যাকাউন্টের ক্ষেত্রে লগিন স্ক্রীনে দেখানো হবে।"
+
+#~ msgid "Gallery"
+#~ msgstr "গ্যালারি"
+
+#~ msgid "Take a photograph"
+#~ msgstr "একটি ফটোগ্র্যাফ তুলুন"
+
+# auto translated by TM merge from project: virt-manager, version: 0.9.0, DocId: virt-manager
+#~ msgid "Browse"
+#~ msgstr "ব্রাউজ করুন"
+
+#~ msgid "Photograph"
+#~ msgstr "ফটোগ্র্যাফ"
+
+# auto translated by TM merge from project: evolution, version: el6, DocId: evolution-2.32
+#~ msgid "Account Information"
+#~ msgstr "অ্যাকাউন্ট সংক্রান্ত তথ্য"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "খুবই ছোট"
+
+# auto translated by TM merge from project: gnome-initial-setup, version: 0.12, DocId: gnome-initial-setup
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "যথেষ্ট ভালো নয়"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "দুর্বল"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "মোটামুটি"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "ভাল"
+
+# auto translated by TM merge from project: gnome-disk-utility, version: 3.8.2, DocId: gnome-disk-utility
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "শক্তিশালী"
+
+#~ msgid "_Generate a password"
+#~ msgstr "একটি পাসওয়ার্ড প্রস্তুত করুন (_G)"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "আপনাকে একটি নতুন পাসওয়ার্ড দিতে হবে"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "নতুন পাসওয়ার্ড ততটা শক্তিশালী নয়"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "আপনাকে পাসওয়ার্ড নিশ্চিত করতে হবে"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "আপনাকে আপনার বর্তমান পাসওয়ার্ড দিতে হবে"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "বর্তমান পাসওয়ার্ডটি সঠিক নয়"
+
+#~ msgid "Switch Modes"
+#~ msgstr "মোডগুলি স্যুইচ করুন"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0
+#~ msgid "Action"
+#~ msgstr "কাজ"

--- a/po/br.po
+++ b/po/br.po
@@ -9,9 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Gnome-control-center\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-09-27 06:32+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-09-27 21:34+0100\n"
 "Last-Translator: Denis Arnaud <denisarnuad@yahoo.fr>\n"
 "Language-Team: Breton <br@li.org>\n"
@@ -21,6298 +20,4360 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Arloadoù"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Arloadoù"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Klask"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Diweredekaet"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Skrammañ dibarzhioù ar skoazell"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Drekleur"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Drekleurioù"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Son"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Berradennoù klavier personelaet"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Berradennoù ar c'hlavier"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Diskouez ar rizh"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Arloadoù"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Dre ziouer"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Drekleur"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "Ouzhpenn_añ un aelad..."
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "Bro C'hall"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
 msgstr ""
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "Lock Screen"
-msgstr "Prennañ ar skramm"
-
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Marell"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Zoumañ"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "Kreizañ"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Skeulaat"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Leuniañ"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "Ledañ"
-
-#: ../panels/background/cc-background-chooser-dialog.c:438
-msgid "Wallpapers"
-msgstr "Drekleurioù"
-
-#: ../panels/background/cc-background-chooser-dialog.c:447
-msgid "Colors"
-msgstr "Livioù"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:485
-msgid "Select Background"
-msgstr "Diuzit an drekleur"
-
-#: ../panels/background/cc-background-chooser-dialog.c:514
-msgid "Pictures"
-msgstr "Skeudennoù"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:546
-msgid "No Pictures Found"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
 
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:564
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
 msgstr ""
 
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:576
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
 msgstr ""
 
-#: ../panels/background/cc-background-chooser-dialog.c:583
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1537
-#: ../panels/display/cc-display-panel.c:1976
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1247
-#: ../panels/network/net-device-wifi.c:1440
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/cc-printers-panel.c:1947
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-#: ../panels/user-accounts/um-photo-dialog.c:95
-#: ../panels/user-accounts/um-photo-dialog.c:222
-#: ../panels/user-accounts/um-user-panel.c:513
-msgid "_Cancel"
-msgstr "_Nullañ"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth"
 
-#: ../panels/background/cc-background-chooser-dialog.c:584
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:97
-msgid "Select"
-msgstr "Diuzañ"
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "mentoù liesseurt"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "N'eus ket drekleur burev"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
 msgstr ""
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Drekleur;Skramm;Burev;"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "Diweredekaet eo ar Bluetooth"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Diweredekaet eo ar Bluetooth gant kemm ar periant"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1688
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Furchal evit muioc'h a skeudennoù"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr ""
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr ""
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr ""
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr ""
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr ""
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr ""
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr ""
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr ""
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr ""
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr ""
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s skramm"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s c'hwilerver"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr ""
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr ""
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s webcam"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr ""
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr ""
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-msgid "Not calibrated"
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "Dre ziouer : "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "Egorad livverkel : "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "Aelad arnodiñ : "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "Enporzh_iañ"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr ""
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "An holl restroù"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "Skramm"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr ""
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "Enrollañ an aelad"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr ""
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr ""
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr ""
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "Arnodiñ an aelad"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr ""
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr ""
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr ""
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr ""
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr ""
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr ""
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr ""
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr ""
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr ""
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr ""
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr ""
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Nullañ"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
 msgstr ""
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
 msgstr ""
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "Graet"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Graet"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr ""
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr ""
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr ""
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr ""
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr ""
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr ""
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr ""
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
 msgstr ""
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Diskouez ar rizh"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
 msgstr ""
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
 msgstr ""
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr ""
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr ""
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr ""
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "Eilañ an aelad"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr ""
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "Kargañ an aelad"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr ""
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr ""
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
 msgstr ""
 
-#: ../panels/color/color.ui.h:30
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Eilañ an aelad"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
 msgstr ""
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Ouzhpennañ un aelad"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "Enporzhiañ diouzh ur restr…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Gouzout hiroc'h"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr ""
 
-#: ../panels/color/color.ui.h:35
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "Arventnniñ evit an holl arveriaded"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr ""
 
-#: ../panels/color/color.ui.h:37
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
 msgstr ""
 
-#: ../panels/color/color.ui.h:38
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "Ouzhpennañ un aelad"
 
-#: ../panels/color/color.ui.h:39
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
 msgstr ""
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr ""
 
-#: ../panels/color/color.ui.h:41
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "Dilemel an aelad"
 
-#: ../panels/color/color.ui.h:42
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
 msgstr ""
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr ""
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr ""
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr ""
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr ""
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr ""
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr ""
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Uhel"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr ""
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr ""
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr ""
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Izel"
 
-#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr ""
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr ""
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr ""
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr ""
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Liv"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:684
-msgid "United States"
-msgstr "Stadoù-Unanet"
-
-#: ../panels/common/cc-common-language.c:685
-msgid "Germany"
-msgstr ""
-
-#: ../panels/common/cc-common-language.c:686
-msgid "France"
-msgstr "Bro C'hall"
-
-#: ../panels/common/cc-common-language.c:687
-msgid "Spain"
-msgstr ""
-
-#: ../panels/common/cc-common-language.c:688
-msgid "China"
-msgstr ""
-
-#: ../panels/common/cc-common-language.c:758
+#: panels/common/cc-language-chooser.ui:5
 #, fuzzy
-msgid "Other…"
-msgstr "Aelad all…"
+msgid "Select Language"
+msgstr "Diuzañ ur yezh"
 
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr ""
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Diuzañ"
 
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr ""
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
 msgstr ""
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "_Graet"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-#, fuzzy
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%a %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
 msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
 msgstr ""
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, fuzzy, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%d x %d (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
 msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-#, fuzzy
-msgid "%l:%M %p"
-msgstr "%a %l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
 msgstr ""
 
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, fuzzy, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%d x %d (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "Genver"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "C'hwevrer"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "Meurzh"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "Ebrel"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "Mae"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "Mezheven"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "Gouere"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "Eost"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "Gwengolo"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "Here"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "Du"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "Kerzu"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Deiziad hag eur"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr ""
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "Deiz"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "Miz"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "Bloaz"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Miz"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Genver"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "C'hwevrer"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Meurzh"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Ebrel"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mae"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Mezheven"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Gouere"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Eost"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Gwengolo"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Here"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Du"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Kerzu"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Deiz"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:23
+#: panels/datetime/cc-datetime-panel.ui:164
 #, fuzzy
-msgid "Automatic _Date & Time"
+msgid "Automatic _Date &amp; Time"
 msgstr "Deiziad hag eur"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Deiziad hag _eur"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "Date & _Time"
-msgstr "Deiziad hag _eur"
-
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
 msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:28
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24-eur"
-
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
 msgstr ""
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+msgid "Seconds"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Kerzu"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr ""
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr ""
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr ""
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr ""
 
-#: ../panels/display/cc-display-panel.c:487
-msgid "Lid Closed"
-msgstr ""
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-msgid "Mirrored"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2145
-msgid "Primary"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:497
-msgid "Secondary"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:1533
-msgid "Arrange Combined Displays"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:1539
-#: ../panels/display/cc-display-panel.c:1979
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:1560
-msgid "Drag displays to rearrange them"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2081
-msgid "Size"
-msgstr ""
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2094
-msgid "Aspect Ratio"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2115
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2146
-msgid "Show the top bar and Activities Overview on this display"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2152
-msgid "Secondary Display"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2153
-msgid "Join this display with another to create an extra workspace"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2160
-msgid "Presentation"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2161
-msgid "Show slideshows and media only"
-msgstr ""
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2166
-msgid "Mirror"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2167
-msgid "Show your existing view on both displays"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2173
-msgid "Turn Off"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2174
-msgid "Don't use this display"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2383
-msgid "Could not get screen information"
-msgstr "N'eus ket tu da gaout titouroù ar skramm"
-
-#: ../panels/display/cc-display-panel.c:2414
-msgid "_Arrange Combined Displays"
-msgstr ""
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr ""
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr ""
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr ""
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "Dianav"
-
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-msgid "%s %d-bit"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr ""
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1932
-msgid "Section"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr ""
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:46
-msgid "Details"
-msgstr ""
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr ""
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr ""
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr ""
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr ""
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr ""
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr ""
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr ""
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr ""
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr ""
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr ""
-
-#: ../panels/info/info.ui.h:13
-msgid "Check for updates"
-msgstr ""
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr ""
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr ""
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr ""
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr ""
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr ""
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr ""
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
 msgstr ""
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
 msgstr ""
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
 msgstr ""
 
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
 msgstr ""
 
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
 msgstr ""
 
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "Media_où all…"
-
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Diweredekaet eo ar Bluetooth"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "mentoù liesseurt"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "Biz bizoù dehou"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skeulaat"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr ""
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Rizh an drobarzhell :"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Trobarzhell"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Anv"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "_Rizh"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr ""
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Dilemel un drobarzhell"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Kas er-maez"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr ""
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr ""
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr ""
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr ""
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr ""
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "Arventennoù"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr ""
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr ""
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr ""
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "Teuliad ar gêr"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "Klask"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr ""
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr ""
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr ""
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr ""
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Reizhiad"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "Dilugañ"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "Prennañ ar skramm"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
 msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr ""
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1218
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-msgid "Disabled"
-msgstr "Diweredekaet"
-
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
 msgstr ""
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
 msgstr ""
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Klavier"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Neuziadoù"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
 msgstr ""
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "Personnalaat ar berradennoù"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Gwellvezio"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "_Anv :"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "Ar_c'had :"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "Arren ar stokelloù"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "Pa chomer gant ar stokell pouezet warni ez adskriver an arouezenn"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "_Dale :"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "_Tizh :"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "Berr"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "Gorrek"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "Arren tizh ar stokelloù"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "Hir"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+#: panels/keyboard/cc-input-row.ui:48
 #, fuzzy
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "Trumm"
+msgid "View Keyboard Layout"
+msgstr "Berradennoù ar c'hlavier"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "Blinkadur ar reti"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "Dilemel"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "Ar reti a vlink war _maeziennoù an destenn"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "_Tizh :"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Berradennoù ar c'hlavier"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Berradennoù klavier personelaet"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:635
-#: ../panels/keyboard/keyboard-shortcuts.c:643
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Berradenn nevez..."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "Berradennoù klavier personelaet"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:860
-msgid "<Unknown Action>"
-msgstr "<Gwered Dianav>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1357
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-"N'hallit ket ober gant ar verradenn-mañ \"%s\" rak ne vo ket tro da viziata "
-"en ur arverañ ar stokell-mañ.\n"
-"Mar plij, klaskit gant ur stokell evel Control, Alt pe Pennliz. war un dro."
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1387
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-"Arveret eo ar verradenn \"%s\" endeo evit\n"
-"\"%s\""
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1392
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-"Mar bez deverket ar verradenn da \"%s\" en-dro e vo diweredekaet ar "
-"verradenn \"%s\"."
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1398
-msgid "_Reassign"
-msgstr "_Deverkañ en-dro"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1439
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1449
-#, fuzzy, c-format
-msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
 msgstr ""
-"Mar bez deverket ar verradenn da \"%s\" en-dro e vo diweredekaet ar "
-"verradenn \"%s\"."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1456
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 #, fuzzy
-msgid "_Assign"
-msgstr "_Deverkañ en-dro"
+msgid "No keyboard shortcut found"
+msgstr "Berradennoù ar c'hlavier"
 
-#: ../panels/mouse/cc-mouse-panel.c:94
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Dilemel"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Anv"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Ar_c'had :"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+#, fuzzy
+msgid "Shortcut"
+msgstr "Berr"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Berradenn nevez..."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Tra ebet"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klavier"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 #, fuzzy
 msgid "Test Your _Settings"
 msgstr "Arventennoù ar son"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-#, fuzzy
-msgid "Test Your Settings"
-msgstr "Arventennoù ar son"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Hollek"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Biz bizoù kleiz"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Biz bizoù dehou"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Diuzit an drekleur"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Logodenn"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Stokelloù al logodenn"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Pavez stekiñ"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Pavez stekiñ"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "Hollek"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "Gorrek"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
 #, fuzzy
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "Trumm"
+msgid "Workspaces"
+msgstr "Egorad livverkel : "
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "Logodenn"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "Gorrek"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+#: panels/multitasking/cc-multitasking-panel.ui:124
 #, fuzzy
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "Trumm"
+msgid "Multi-Monitor"
+msgstr "%s skramm"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "Pavez stekiñ"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "Gorrek"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+#: panels/multitasking/cc-multitasking-panel.ui:184
 #, fuzzy
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "Trumm"
+msgid "Application Switching"
+msgstr "Arloadoù"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
 msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "_Natural scrolling"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Trobarzhelloù"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Ouzhpennañ ur c'hennask rouedad"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr ""
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Dibarzhioù..."
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr ""
-
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:369
-msgid "Air_plane Mode"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:977
-msgid "Network proxy"
-msgstr ""
-
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1156 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%s VPN"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
 msgstr ""
 
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1301
-msgid "The system network services are not compatible with this version."
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
 msgstr ""
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr ""
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Rouedadoù"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr ""
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "pajenn 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr ""
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr ""
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "pajenn 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr ""
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:218
-#: ../panels/network/net-device-wifi.c:382
-msgid "WEP"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:222
-#: ../panels/network/net-device-wifi.c:387
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:226
-msgid "WPA2"
-msgstr ""
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:231
-msgid "Enterprise"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:236
-#: ../panels/network/net-device-wifi.c:372
-msgctxt "Wifi security"
-msgid "None"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "Morse"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:819
-msgid "Today"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:822
-msgid "Yesterday"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:476
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:533
-#, c-format
-msgid "%d Mb/s"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "None"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:568
-msgctxt "Signal strength"
-msgid "Good"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:570
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "Chomlec'h"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "Dilemel ar chomlec'h"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "Ouzhpennañ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr ""
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP)"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Manual"
-msgstr "Dre zorn"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:51
-msgid "Reset"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Tra ebet"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr ""
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr ""
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr ""
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr ""
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr ""
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr ""
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr ""
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr ""
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr ""
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr ""
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr ""
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr ""
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Anv"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "Chomlec'h _MAC"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 #, fuzzy
 msgid "_Cloned Address"
 msgstr "Chomlec'h"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
-msgid "Connect _automatically"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
 msgstr ""
 
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "Dre ziouer"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Dre zorn"
 
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Diweredekaet"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
 msgstr ""
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr ""
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
 msgstr "Ch_omlec'hioù"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr ""
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Routes"
-msgstr ""
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr ""
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:34
-msgid "Use this connection _only for resources on its network"
-msgstr ""
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "Aelad nevez"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "Enporzhiañ diouzh ur restr…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "Ouzhpennañ ur c'hennask rouedad"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr ""
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1441
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr ""
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
-msgid "S_ecurity"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1948
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:223
-msgid "_Open"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-msgid "Export VPN connection"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr ""
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "_SSID"
-msgstr ""
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
-msgid "_BSSID"
-msgstr ""
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr ""
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
-msgid "Make available to _other users"
-msgstr ""
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr ""
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Control how you connect to the Internet"
-msgstr ""
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
-msgstr ""
-
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr ""
-
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr ""
-
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr ""
-
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:462
-msgid "never"
-msgstr ""
-
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:472
-msgid "today"
-msgstr ""
-
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:474
-msgid "yesterday"
-msgstr ""
-
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr ""
-
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr ""
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr ""
-
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1596
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "Dibarzhioù..."
-
-#: ../panels/network/net-device-ethernet.c:474
-#, c-format
-msgid "Profile %d"
-msgstr "Aelad %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr ""
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1154
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1158
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1162
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1245
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1248
-msgid "_Stop Hotspot"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1305
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1308
-msgid "Wireless device does not support Hotspot mode"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1437
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1745
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1749
-#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
-#: ../panels/wacom/cc-wacom-page.c:533
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Close"
-msgstr ""
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1757
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr ""
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr ""
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr ""
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "Ouzhpenn_añ un aelad..."
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr ""
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr ""
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr ""
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
-msgid "Manual"
-msgstr ""
-
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Chomlec'h"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
 msgstr ""
 
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
 msgstr ""
 
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
 msgstr ""
 
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "Dilemel un drobarzhell"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
 msgstr ""
 
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
 msgstr ""
 
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
 msgstr ""
 
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "Tra ebet"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Turn On"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:54
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Turn Wi-Fi off"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
 msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_Use as Hotspot…"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "_Connect to Hidden Network…"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
 msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:58
-msgid "_History"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
 msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Switch off to connect to a Wi-Fi network"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
 msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr ""
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Rouedadoù"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr ""
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
-msgstr ""
+msgstr "Rouedadoù"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Connected Devices"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:63
-msgid "Security key"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Ger-tremen"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
 msgstr ""
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Dibarzhioù..."
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
 msgstr ""
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
 msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr ""
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr ""
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr ""
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr ""
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr ""
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-msgid "Choose a PAC file"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "Restr _PAC"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "Restr _PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-msgid "Choose your personal certificate"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-msgid "Choose your private key"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr ""
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr ""
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domani"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "Ket"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "Ya"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr ""
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr ""
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr ""
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Rizh"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
 msgstr "1 (Dre ziouer)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+#: panels/network/wireless-security/ws-wep-key.ui:31
 #, fuzzy
 msgid "Open System"
 msgstr "Reizhiad"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+#: panels/network/wireless-security/ws-wep-key.ui:34
 msgid "Shared Key"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
-msgid "_Type"
-msgstr "_Rizh"
-
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
-msgctxt "notifications"
-msgid "Notifications"
-msgstr ""
-
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 #, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "_Notifications"
+msgstr "Arloadoù"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
 msgstr "Arventennoù ar son"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
-msgid "Show Popup Banners"
+msgid "Notification _Popups"
 msgstr ""
 
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
 msgstr ""
 
-#: ../panels/notifications/cc-edit-dialog.c:43
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 #, fuzzy
 msgctxt "notifications"
-msgid "View in Lock Screen"
+msgid "Show Message C_ontent on Lock Screen"
 msgstr "Prennañ ar skramm"
 
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
 msgstr ""
 
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
 msgstr ""
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
-msgstr ""
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr ""
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
 msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
 #, fuzzy
-msgid "Show in Lock Screen"
-msgstr "Prennañ ar skramm"
+msgid "Close the notification"
+msgstr "N'eus ket tu da enrollañ ar c'hefluniadur skramm"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-msgctxt "Online Account"
-msgid "Other"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
 msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "Dilemel"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr ""
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr ""
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr ""
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr ""
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:183
-msgid "Unknown time"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:189
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/power/cc-power-panel.c:201
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:209
-#, c-format
-msgid "%i %s %i %s"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:230
-#, c-format
-msgid "%s until fully charged"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
 msgstr ""
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:237
-#, c-format
-msgid "Caution: %s remaining"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
 msgstr ""
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:242
-#, c-format
-msgid "%s remaining"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
 msgstr ""
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
-msgid "Fully charged"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
 msgstr ""
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
-msgid "Empty"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Charging"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:271
-msgid "Discharging"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:396
-msgctxt "Battery name"
-msgid "Main"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:398
-msgctxt "Battery name"
-msgid "Extra"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:470
-msgid "Wireless mouse"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:473
-msgid "Wireless keyboard"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:476
-msgid "Uninterruptible power supply"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Personal digital assistant"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Cellphone"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Media player"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Tablet"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Computer"
-msgstr ""
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
-#: ../panels/power/cc-power-panel.c:2019
-msgid "Battery"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgctxt "Battery power"
-msgid "Charging"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Caution"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Low"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Good"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Empty"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:715
-msgid "Batteries"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1117
-msgid "When _idle"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1445
-msgid "Power Saving"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1473
-msgid "_Screen brightness"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1479
-#, fuzzy
-msgid "_Keyboard brightness"
-msgstr "Arventennoù ar c'hlavier"
-
-#: ../panels/power/cc-power-panel.c:1489
-msgid "_Dim screen when inactive"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1514
-#, fuzzy
-msgid "_Blank screen"
-msgstr "Prennañ ar skramm"
-
-#: ../panels/power/cc-power-panel.c:1551
-msgid "_Wi-Fi"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1556
-msgid "Turns off wireless devices"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1581
-msgid "_Mobile broadband"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1586
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1635
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: ../panels/power/cc-power-panel.c:1686
-msgid "When on battery power"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1688
-msgid "When plugged in"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Off"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1851
-msgid "_Automatic suspend"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1875
-msgid "When battery power is _critical"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1930
-msgid "Power Off"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Devices"
-msgstr "Trobarzhelloù"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr ""
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr ""
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr ""
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr ""
-
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr ""
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
-msgstr ""
+msgstr "24-eur"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr ""
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr ""
 
-#: ../panels/power/power.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr ""
 
-#: ../panels/power/power.ui.h:10
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
+msgstr "24-eur"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
 msgstr ""
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Trobarzhelloù"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
 msgstr ""
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
 msgstr ""
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Dibarzhioù ar c'hennask"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
 msgstr ""
 
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
 msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Skramm"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
 msgstr ""
 
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Skramm"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
 msgstr ""
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Deiziad hag eur"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
 msgstr ""
 
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
 msgstr ""
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr ""
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr ""
 
-#: ../panels/power/power.ui.h:22
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr ""
 
-#: ../panels/power/power.ui.h:23
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Dale"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
 msgstr ""
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
 msgstr ""
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr ""
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr ""
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr ""
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr ""
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr ""
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr ""
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr ""
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr ""
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr ""
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr ""
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr ""
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr ""
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr ""
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Toner Level"
-msgstr ""
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Ink Level"
-msgstr ""
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:928
-msgid "Supply Level"
-msgstr ""
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:946
-msgctxt "printer state"
-msgid "Installing"
-msgstr ""
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1123
-msgid "No printers available"
-msgstr ""
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1433
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] ""
-msgstr[1] ""
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1777
-msgid "Failed to add new printer."
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid "Select PPD File"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:1953
+#: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 
-#: ../panels/printers/cc-printers-panel.c:2258
-msgid "No suitable driver found"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2327
-msgid "Searching for preferred drivers…"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2342
-msgid "Select from database…"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2351
-msgid "Provide PPD File…"
-msgstr ""
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2502
-#: ../panels/printers/cc-printers-panel.c:2525
-msgid "Test page"
-msgstr ""
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2933
-#, c-format
-msgid "Could not load ui: %s"
-msgstr ""
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr ""
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr ""
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr ""
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr ""
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr ""
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr ""
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr ""
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "A_uthenticate"
-msgstr ""
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr ""
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-msgid "Enter address of a printer or a text to filter results"
-msgstr ""
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr ""
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr ""
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr ""
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-msgid "JetDirect Printer"
-msgstr ""
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-msgid "LPD Printer"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr ""
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr ""
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr ""
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr ""
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr ""
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr ""
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr ""
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr ""
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr ""
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr ""
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr ""
-
-#: ../panels/printers/pp-jobs-dialog.c:495
-#, c-format
-msgid "%s Active Jobs"
-msgstr ""
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "USB"
-msgstr ""
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Serial Port"
-msgstr ""
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1683
-msgid "Parallel Port"
-msgstr ""
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-msgid "Location: %s"
-msgstr ""
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1744
-#, c-format
-msgid "Address: %s"
-msgstr "Chomlec'h : %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1768
-msgid "Server requires authentication"
-msgstr ""
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr ""
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr ""
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr ""
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr ""
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr ""
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:531
-msgid "Pages per side"
-msgstr ""
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:543
-msgid "Two-sided"
-msgstr ""
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:555
-msgid "Orientation"
-msgstr ""
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:652
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr ""
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr ""
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr ""
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr ""
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr ""
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr ""
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr ""
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr ""
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr ""
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr ""
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr ""
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr ""
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
 msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
 msgstr ""
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr ""
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default printer"
-msgstr "Moulerez dre ziouer : "
-
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
 msgstr ""
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Diuzañ"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "_Domani"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Arnodiñ an aelad"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Dibarzhioù ar c'hennask"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr ""
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr ""
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr ""
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
 msgstr ""
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Ouzhpenn_añ un aelad..."
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
 msgstr ""
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
 msgstr ""
 
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
 msgstr ""
 
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
 msgstr ""
 
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
 msgstr ""
 
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
 msgstr ""
 
-#: ../panels/privacy/cc-privacy-panel.c:512
-msgid "Delete all the temporary files?"
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
 msgstr ""
 
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
 msgstr ""
 
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
 msgstr ""
 
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr ""
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr ""
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr ""
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:18
+#: panels/region/cc-format-preview.ui:53
 #, fuzzy
-msgid "Forever"
-msgstr "Morse"
+msgid "Dates & Times"
+msgstr "Deiziad hag eur"
 
-#: ../panels/privacy/privacy.ui.h:20
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
 msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
 msgstr ""
 
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
 msgstr ""
 
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Kontoù all"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Yezh"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
 msgstr ""
 
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:42
-msgid "_Location Services"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr ""
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr ""
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr ""
-
-#: ../panels/region/cc-format-chooser.c:284
-msgid "No regions found"
-msgstr ""
-
-#: ../panels/region/cc-input-chooser.c:179
-msgid "No input sources found"
-msgstr ""
-
-#: ../panels/region/cc-input-chooser.c:1076
-msgctxt "Input Source"
-msgid "Other"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:894
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:243
-#: ../panels/user-accounts/um-user-panel.c:898
-msgid "Restart Now"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:862
-msgid "No input source selected"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:1092
-msgid "Sorry"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:1094
-msgid "Input methods can't be used on the login screen"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:1731
+#: panels/region/cc-region-panel.ui:113
 #, fuzzy
 msgid "Login Screen"
 msgstr "Prennañ ar skramm"
 
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
-msgid "Formats"
-msgstr ""
-
-#: ../panels/region/format-chooser.ui.h:4
-msgid "Preview"
-msgstr ""
-
-#: ../panels/region/format-chooser.ui.h:5
-msgid "Dates"
-msgstr ""
-
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr ""
-
-#: ../panels/region/format-chooser.ui.h:7
-msgid "Numbers"
-msgstr ""
-
-#: ../panels/region/format-chooser.ui.h:8
-msgid "Measurement"
-msgstr ""
-
-#: ../panels/region/format-chooser.ui.h:9
-msgid "Paper"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
 msgstr ""
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Use the _same source for all windows"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Allow _different sources for each window"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Keyboard Shortcuts"
-msgstr "Berradennoù ar c'hlavier"
-
-#: ../panels/region/input-options.ui.h:6
-msgid "Switch to previous source"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "Media_où all…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Switch to next source"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:9
-msgid "Super+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:10
-msgid "You can change these shortcuts in the keyboard settings"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Alternative switch to next source"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:12
-msgid "Left+Right Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Kefluniañ an arventennoù Bluetooth"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
 msgstr ""
 
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
 msgstr ""
 
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "Neuziadoù"
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "Prennañ ar skramm"
 
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
 msgstr ""
 
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "Deiziad hag eur"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Prennañ ar skramm"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Prennañ ar skramm"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Skramm"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skramm"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "- Arventennoù"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr ""
 
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
 msgid "Bookmarks"
 msgstr "Sinedoù"
 
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
-msgstr ""
-
-#: ../panels/search/cc-search-locations-dialog.c:678
+#: panels/search/cc-search-locations-dialog.ui:52
 #, fuzzy
-msgid "Select Location"
+msgid "Others"
+msgstr "Aelad all…"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
 msgstr "Diuzit an drekleur"
 
-#: ../panels/search/cc-search-locations-dialog.c:682
-msgid "_OK"
-msgstr "Mat e_o"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Arloadoù"
 
-#: ../panels/search/cc-search-panel.c:176
-msgid "No applications found"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
 msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
 msgstr "Klask"
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr ""
-
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr ""
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr ""
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "Gwellvezio"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr ""
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr ""
-
-#: ../panels/sharing/cc-sharing-panel.c:304
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr ""
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-msgctxt "service is active"
-msgid "Active"
-msgstr ""
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "Dibab ur teuliad"
-
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "Eilañ"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-msgid "Sharing"
-msgstr ""
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr ""
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
-msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
-msgstr ""
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr ""
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr ""
-
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:299
-msgid "No networks selected for sharing"
-msgstr ""
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Rouedadoù"
 
-#: ../panels/sharing/sharing.ui.h:1
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
 #, fuzzy
-msgid "Bluetooth Sharing"
-msgstr "Bluetooth"
-
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
+msgid "_Computer Name"
 msgstr "Anv an urzhiater"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Bluetooth"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
 msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
 msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
-msgstr ""
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "Kennask a-bell"
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Bluetooth"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "Ger-tremen nevez"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "Kennask a-bell"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
-msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Allow Remote Control"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:21
-msgid "Password:"
-msgstr "Ger-tremen"
-
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "Skrammañ ar ger-tremen"
-
-#: ../panels/sharing/sharing.ui.h:23
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 #, fuzzy
-msgid "Access Options"
-msgstr "Neuziadoù"
+msgid "Remote Desktop"
+msgstr "Kennask a-bell"
 
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:25
-msgid "Require a password"
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
 msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:26
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Kennask a-bell"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Ouzhpennañ ur c'hennask rouedad"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Eilañ"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Dilemel ar chomlec'h"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Arloadoù"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Anv an urzhiater"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "_Dilemel ar roudoù biz"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:27
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Teuliadoù"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "Son"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
 msgstr ""
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 msgstr ""
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
 msgstr ""
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
 msgstr ""
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "Bro C'hall"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Reizhiad"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr ""
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr ""
-
-#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
-msgctxt "volume"
-msgid "100%"
-msgstr "10%"
-
-#: ../panels/sound/gvc-channel-bar.c:616
-msgctxt "volume"
-msgid "Unamplified"
-msgstr ""
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "_Aelad :"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1509
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "Anv"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1528
-msgid "Device"
-msgstr "Trobarzhell"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1591
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1649
-msgid "_Output volume:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1663
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr ""
 
-#: ../panels/sound/gvc-mixer-dialog.c:1668
-msgid "C_hoose a device for sound output:"
-msgstr ""
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Trobarzhell"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1693
-msgid "Settings for the selected device:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "Input"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "_Input volume:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1734
-msgid "Input level:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1762
-msgid "C_hoose a device for sound input:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "Sound Effects"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-msgid "_Alert volume:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1809
-msgid "Applications"
-msgstr "Arloadoù"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1813
-msgid "No application is currently playing or recording audio."
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "Gwellvezioù ar son"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "Dre ziouer"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:769
-msgid "C_hoose an alert sound:"
-msgstr ""
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr ""
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr ""
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr ""
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "Personelaet"
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
 msgstr ""
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Trobarzhell"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Son"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Son"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr ""
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:4
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
 #, fuzzy
-msgid "_Large Text"
-msgstr "Bras"
+msgid "Close notification"
+msgstr "Diuzit an drekleur"
 
-#: ../panels/universal-access/uap.ui.h:5
-msgid "_Zoom"
-msgstr "Zoumañ"
-
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:8
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 #, fuzzy
-msgid "_Sound Keys"
-msgstr "Stokelloù daslammus"
+msgid "Name:"
+msgstr "_Anv :"
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:12
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 #, fuzzy
-msgid "Screen _Keyboard"
-msgstr "Klavier"
+msgid "Forget Device"
+msgstr "Dilemel un drobarzhell"
 
-#: ../panels/universal-access/uap.ui.h:13
-msgid "_Typing Assist (AccessX)"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Pointing & Clicking"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:15
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 #, fuzzy
-msgid "_Mouse Keys"
-msgstr "Stokelloù al logodenn"
+msgid "Pending Devices"
+msgstr "Trobarzhelloù"
 
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Screen Reader"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:20
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Blinkadur ar reti"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 #, fuzzy
-msgid "Sound Keys"
-msgstr "Stokelloù daslammus"
+msgid "Cursor blinks in text fields."
+msgstr "Ar reti a vlink war _maeziennoù an destenn"
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Use a visual indication when an alert sound occurs."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Flash the _window title"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Flash the entire _screen"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Typing Assist"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:28
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 #, fuzzy
-msgid "_Sticky Keys"
-msgstr "Stokelloù pegus"
+msgid "Speed"
+msgstr "_Tizh :"
 
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifer key is pressed"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:32
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 #, fuzzy
-msgid "S_low Keys"
-msgstr "Stokelloù gorrek"
+msgid "Cursor blinking speed"
+msgstr "Blinkadur ar reti"
 
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:35
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Berr"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:37
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Hir"
-
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Beep when a key is pr_essed"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Beep when a key is _accepted"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:41
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 #, fuzzy
-msgid "_Bounce Keys"
-msgstr "Stokelloù daslammus"
+msgid "Cursor Size"
+msgstr "Blinkadur ar reti"
 
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:43
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Berr"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:45
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Hir"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Enable by Keyboard"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:49
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:51
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Berr"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:53
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Hir"
 
-#: ../panels/universal-access/uap.ui.h:54
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "Dal_e :"
 
-#: ../panels/universal-access/uap.ui.h:57
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Berr"
 
-#: ../panels/universal-access/uap.ui.h:58
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Hir"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:60
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Bihan"
 
-#: ../panels/universal-access/uap.ui.h:61
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Bras"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Arren ar stokelloù"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Pa chomer gant ar stokell pouezet warni ez adskriver an arouezenn"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Arren tizh ar stokelloù"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Arren tizh ar stokelloù"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Stokelloù pegus"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Stokelloù gorrek"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
+msgstr "Berr"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
+msgstr "Hir"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Stokelloù daslammus"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Berr"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Hir"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Bras"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Stokelloù daslammus"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "Zoumañ"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Klavier"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Arren ar stokelloù"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Blinkadur ar reti"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Stokelloù al logodenn"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "Zoum"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Skramm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
 msgstr ""
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "Liv :"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Arventennoù ar c'hlavier"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
 msgstr ""
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "Liv"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Tra ebet"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Full Name"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to set a password when they next login"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "_Domani"
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "Deiziad hag eur"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Dilemel ar restroù"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Ouzhpennañ un arveriad"
 
-#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
-msgid "_Enroll"
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
-msgid "Domain Administrator Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/cc-add-user-dialog.ui:132
 msgid ""
-"In order to use enterprise logins, this computer needs to be\n"
-"enrolled in the domain. Please have your network administrator\n"
-"type their domain password here."
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
-msgid "Administrator _Name"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
-msgid "Administrator Password"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Skrammañ ar ger-tremen"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "Biz meud kleiz"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "Biz bras kleiz"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "Biz bizoù kleiz"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "Biz bihan kleiz"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "Biz meud dehou"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "Biz bras dehou"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "Biz bizoù dehou"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "Biz bihan dehou"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:687
-msgid "Enable Fingerprint Login"
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
 msgstr "Gweredekaat an anaout dre roudoù biz"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
 msgstr ""
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"Deuet eo da vat ar gwaredur hoc'h roudoù biz. Bremañ, gallout a rit anaout "
-"deoc'h gant al lenner roudoù biz."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "Arveriaded"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
 
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr ""
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "Kemm_añ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "Ger-tremen nevez"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "Dibarzhioù ar c'hennask"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "Arlun an arveriad"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "_Yezh"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr ""
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
-msgid "Manage user accounts"
-msgstr ""
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
-msgid "Authentication is required to change user data"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "Fazi dianav"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-msgid "Passwords do not match."
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:138
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"N'hoc'h eus ket droad da vont en drobarzhell. Kit e darempred gant hoc'h "
-"ardoer reizhiad."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:140
-msgid "The device is already in use."
-msgstr "Implijet eo dija an drobarzhell."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid "An internal error occurred."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Enabled"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr "Dilemel roudoù biz gwaredet?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Diuzañ ur yezh"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Gweredekaat an anaout dre roudoù biz"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
 msgstr "_Dilemel ar roudoù biz"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Ket"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -6320,696 +4381,1123 @@ msgstr ""
 "C'hoant hoc'h eus dilemel roudoù biz gwaredet ha deweredekaat merour gant "
 "roudoù biz?"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:444
-msgid "Done!"
-msgstr "Echu !"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:505
-#: ../panels/user-accounts/um-fingerprint-dialog.c:547
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "N'eus ket tu da vonet en drobarzhell '%s'"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:588
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "N'eus ket tu da lañsañ an dapadenn roudoù biz gant an drobarzhell '%s'"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:638
-msgid "Could not access any fingerprint readers"
-msgstr "N'eus ket tu da vont en ul lenner roudoù biz ebet"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:639
-msgid "Please contact your system administrator for help."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
 msgstr ""
-"Mar plij ganeoc'h,kit e darempred gant hoc'h ardoer reizhiad evit skoazell "
-"ac'hanout."
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:721
-#, c-format
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Gweredekaat an anaout dre roudoù biz"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Gweredekaat an anaout dre roudoù biz"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Gweredekaat an anaout dre roudoù biz"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"Ret eo deoc'h gwrarediñ unan eus ho louc'hoù biz gant sikour trobarzhell "
-"'%s' evit gweredekaat ar c'hennaskañ dre al louc'hoù biz."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:728
-msgid "Selecting finger"
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
 msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:729
-msgid "Enrolling fingerprints"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Dilemel ar roudoù biz"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Gweredekaat an anaout dre roudoù biz"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
 msgstr ""
 
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
 msgstr ""
 
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
 msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr ""
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Kemm_añ"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr ""
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Ger-tremen nevez"
 
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr ""
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Ger-tremen nevez"
 
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:631
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr ""
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Skrammañ ar ger-tremen"
 
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:635
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr ""
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr ""
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:286
+#: panels/user-accounts/cc-password-dialog.ui:114
 msgid "The passwords do not match."
 msgstr ""
 
-#: ../panels/user-accounts/um-photo-dialog.c:219
-msgid "Browse for more pictures"
-msgstr "Furchal evit muioc'h a skeudennoù"
-
-#: ../panels/user-accounts/um-photo-dialog.c:453
-msgid "Disable image"
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
 msgstr ""
 
-#: ../panels/user-accounts/um-photo-dialog.c:471
-msgid "Take a photo…"
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
 msgstr ""
 
-#: ../panels/user-accounts/um-photo-dialog.c:489
-msgid "Browse for more pictures…"
-msgstr "Furchal evit muioc'h a skeudennoù..."
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Arveriaded"
 
-#: ../panels/user-accounts/um-photo-dialog.c:713
-#, c-format
-msgid "Used by %s"
-msgstr "Arveret gant %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
 msgstr ""
 
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
 msgstr ""
 
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
 msgstr ""
 
-#: ../panels/user-accounts/um-realm-manager.c:832
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:198
-msgid "Other Accounts"
-msgstr "Kontoù all"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "Failed to delete user"
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:482
-msgid "You cannot delete your own account."
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:491
-#, c-format
-msgid "%s is still logged in"
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:495
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:504
-#, c-format
-msgid "Do you want to keep %s's files?"
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:508
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Arveriaded"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "Ouzhpennañ un arveriad"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Arlun an arveriad"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:511
-msgid "_Delete Files"
-msgstr "_Dilemel ar restroù"
-
-#: ../panels/user-accounts/um-user-panel.c:512
-msgid "_Keep Files"
-msgstr "_Mirout ar restroù"
-
-#: ../panels/user-accounts/um-user-panel.c:564
-msgctxt "Password mode"
-msgid "Account disabled"
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:572
-msgctxt "Password mode"
-msgid "To be set at next login"
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:575
-msgctxt "Password mode"
-msgid "None"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:624
-msgid "Logged in"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1073
-msgid "Failed to contact the accounts service"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1075
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1116
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"To make changes,\n"
-"click the * icon first"
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:1154
-msgid "Create a user account"
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:1165
-#: ../panels/user-accounts/um-user-panel.c:1477
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:1175
-msgid "Delete the selected user account"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:1187
-#: ../panels/user-accounts/um-user-panel.c:1482
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:1391
-msgid "My Account"
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-msgid "A user with the username '%s' already exists."
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:571
-#, c-format
-msgid "The username is too long."
-msgstr "Re hir eo anv an arveriad."
-
-#: ../panels/user-accounts/um-utils.c:574
-msgid "The username cannot start with a '-'."
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:577
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:581
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e"
-msgstr ""
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:831
-msgid "%b %e, %Y"
-msgstr ""
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr ""
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr ""
 
-#: ../panels/wacom/button-mapping.ui.h:4
+#: panels/wacom/button-mapping.ui:51
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "%s skramm"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "Ec'hankad :"
-
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Wacom Tablet"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr ""
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Bluetooth Settings"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map to Monitor…"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map Buttons…"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust display resolution"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust mouse settings"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Tracking Mode"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Left-Handed Orientation"
-msgstr ""
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-#, fuzzy
-msgid "Left Ring"
-msgstr "Biz bizoù kleiz"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr ""
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-#, fuzzy
-msgid "Right Ring"
-msgstr "Biz bizoù dehou"
-
-#: ../panels/wacom/gsd-wacom-device.c:1104
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr ""
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-msgid "Left Touchstrip"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1157
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr ""
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-msgid "Right Touchstrip"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1214
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1216
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1219
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1221
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1226
-#, c-format
-msgid "Mode Switch #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1334
-#, c-format
-msgid "Left Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1337
-#, c-format
-msgid "Right Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1340
-#, c-format
-msgid "Top Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1343
-#, c-format
-msgid "Bottom Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "Berradenn nevez..."
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr ""
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
 msgstr ""
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
 
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
 msgstr ""
 
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
 msgstr ""
 
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "Skrammañ dibarzhioù ar skoazell"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
 msgstr ""
 
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
 msgstr ""
 
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- Arventennoù"
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
 
-#: ../shell/cc-application.c:163
-#, c-format
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
 msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
 msgstr ""
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "Skoazell"
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "Kuitaat"
+#: panels/windows/cc-windows-panel.ui:89
+msgid "Windows Focus"
+msgstr ""
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Neuziadoù"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Ouzhpennañ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Rouedadoù"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Rouedadoù"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Trobarzhelloù"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Rouedadoù"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Rouedadoù"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Neuziadoù"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Rouedadoù"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Rouedadoù"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Ouzhpennañ ur c'hennask rouedad"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Kemm_añ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Rouedadoù"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "An holl arventennoù"
 
-#. Add categories
-#: ../shell/cc-window.c:876
-msgctxt "category"
-msgid "Personal"
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
 msgstr ""
 
-#: ../shell/cc-window.c:877
-msgctxt "category"
-msgid "Hardware"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
 msgstr ""
 
-#: ../shell/cc-window.c:878
-msgctxt "category"
-msgid "System"
-msgstr "Reizhiad [Rummad]"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Skoazell"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Hollek"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Kuitaat"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Klask"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "_Nullañ"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Gwellvezioù;Arventennoù;"
 
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "Kefluniañ an arventennoù Bluetooth"
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Marell"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zoumañ"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Kreizañ"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Leuniañ"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Ledañ"
+
+#~ msgid "Colors"
+#~ msgstr "Livioù"
+
+#~ msgid "Select Background"
+#~ msgstr "Diuzit an drekleur"
+
+#~ msgid "Pictures"
+#~ msgstr "Skeudennoù"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "N'eus ket drekleur burev"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Drekleur;Skramm;Burev;"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s c'hwilerver"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s webcam"
+
+#~ msgid "Default: "
+#~ msgstr "Dre ziouer : "
+
+#~ msgid "Test profile: "
+#~ msgstr "Aelad arnodiñ : "
+
+#~ msgid "_Import"
+#~ msgstr "Enporzh_iañ"
+
+#~ msgid "All files"
+#~ msgstr "An holl restroù"
+
+#~ msgid "Save Profile"
+#~ msgstr "Enrollañ an aelad"
+
+#~ msgid "Done"
+#~ msgstr "Graet"
+
+#~ msgid "Upload profile"
+#~ msgstr "Kargañ an aelad"
+
+#~ msgid "United States"
+#~ msgstr "Stadoù-Unanet"
+
+#, fuzzy
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#, fuzzy, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%d x %d (%s)"
+
+#, fuzzy
+#~ msgid "%l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#, fuzzy, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%d x %d (%s)"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "N'eus ket tu da gaout titouroù ar skramm"
+
+#~ msgid "Unknown"
+#~ msgstr "Dianav"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Personnalaat ar berradennoù"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Dale :"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Gorrek"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Hir"
+
+#, fuzzy
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Trumm"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Tizh :"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Gwered Dianav>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "N'hallit ket ober gant ar verradenn-mañ \"%s\" rak ne vo ket tro da "
+#~ "viziata en ur arverañ ar stokell-mañ.\n"
+#~ "Mar plij, klaskit gant ur stokell evel Control, Alt pe Pennliz. war un "
+#~ "dro."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Arveret eo ar verradenn \"%s\" endeo evit\n"
+#~ "\"%s\""
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Mar bez deverket ar verradenn da \"%s\" en-dro e vo diweredekaet ar "
+#~ "verradenn \"%s\"."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Deverkañ en-dro"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "Mar bez deverket ar verradenn da \"%s\" en-dro e vo diweredekaet ar "
+#~ "verradenn \"%s\"."
+
+#, fuzzy
+#~ msgid "_Assign"
+#~ msgstr "_Deverkañ en-dro"
+
+#, fuzzy
+#~ msgid "Test Your Settings"
+#~ msgstr "Arventennoù ar son"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Gorrek"
+
+#, fuzzy
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Trumm"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Gorrek"
+
+#, fuzzy
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Trumm"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Gorrek"
+
+#, fuzzy
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Trumm"
+
+#~ msgid "page 1"
+#~ msgstr "pajenn 1"
+
+#~ msgid "page 2"
+#~ msgstr "pajenn 2"
+
+#~ msgid "Never"
+#~ msgstr "Morse"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Tra ebet"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Dre ziouer"
+
+#~ msgid "New Profile"
+#~ msgstr "Aelad nevez"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Aelad %d"
+
+#~ msgid "Yes"
+#~ msgstr "Ya"
+
+#, fuzzy
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Prennañ ar skramm"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Chomlec'h : %s"
+
+#~ msgid "_Default printer"
+#~ msgstr "Moulerez dre ziouer : "
+
+#, fuzzy
+#~ msgid "Forever"
+#~ msgstr "Morse"
+
+#~ msgid "_OK"
+#~ msgstr "Mat e_o"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Dibab ur teuliad"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "10%"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Aelad :"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Gwellvezioù ar son"
+
+#~ msgid "Custom"
+#~ msgstr "Personelaet"
+
+#, fuzzy
+#~ msgid "Sound Keys"
+#~ msgstr "Stokelloù daslammus"
+
+#~ msgid "Zoom"
+#~ msgstr "Zoum"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Liv"
+
+#~ msgid "Left thumb"
+#~ msgstr "Biz meud kleiz"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Biz bras kleiz"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Biz bizoù kleiz"
+
+#~ msgid "Left little finger"
+#~ msgstr "Biz bihan kleiz"
+
+#~ msgid "Right thumb"
+#~ msgstr "Biz meud dehou"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Biz bras dehou"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Biz bizoù dehou"
+
+#~ msgid "Right little finger"
+#~ msgstr "Biz bihan dehou"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Deuet eo da vat ar gwaredur hoc'h roudoù biz. Bremañ, gallout a rit "
+#~ "anaout deoc'h gant al lenner roudoù biz."
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Fazi dianav"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "N'hoc'h eus ket droad da vont en drobarzhell. Kit e darempred gant hoc'h "
+#~ "ardoer reizhiad."
+
+#~ msgid "The device is already in use."
+#~ msgstr "Implijet eo dija an drobarzhell."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Dilemel roudoù biz gwaredet?"
+
+#~ msgid "Done!"
+#~ msgstr "Echu !"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "N'eus ket tu da vonet en drobarzhell '%s'"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr ""
+#~ "N'eus ket tu da lañsañ an dapadenn roudoù biz gant an drobarzhell '%s'"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "N'eus ket tu da vont en ul lenner roudoù biz ebet"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr ""
+#~ "Mar plij ganeoc'h,kit e darempred gant hoc'h ardoer reizhiad evit "
+#~ "skoazell ac'hanout."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "Ret eo deoc'h gwrarediñ unan eus ho louc'hoù biz gant sikour trobarzhell "
+#~ "'%s' evit gweredekaat ar c'hennaskañ dre al louc'hoù biz."
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Furchal evit muioc'h a skeudennoù..."
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "Arveret gant %s"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Mirout ar restroù"
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "Re hir eo anv an arveriad."
+
+#~ msgid "Output:"
+#~ msgstr "Ec'hankad :"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Reizhiad [Rummad]"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "Arventenniñ un drobarzhell nevez"
@@ -7027,18 +5515,6 @@ msgstr "Gwellvezioù;Arventennoù;"
 #~ msgid "Add device"
 #~ msgstr "OUzhpennañ un drobarzhell"
 
-#~ msgid "Device type:"
-#~ msgstr "Rizh an drobarzhell :"
-
-#~ msgid "Select a language"
-#~ msgstr "Diuzañ ur yezh"
-
-#~ msgid "_Select"
-#~ msgstr "_Diuzañ"
-
-#~ msgid ":"
-#~ msgstr ":"
-
 #~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 derez"
@@ -7052,9 +5528,6 @@ msgstr "Gwellvezioù;Arventennoù;"
 #~ msgstr ""
 #~ "Diuzañ ur skramm a-benn kemmañ e berzhioù ; lakaat d'e riklañ a-benn "
 #~ "kempenn e lec'hiadur."
-
-#~ msgid "Could not save the monitor configuration"
-#~ msgstr "N'eus ket tu da enrollañ ar c'hefluniadur skramm"
 
 #~ msgid "Could not detect displays"
 #~ msgstr "N'hall ket dinoiñ ar skrammoù"

--- a/po/br.po~
+++ b/po/br.po~
@@ -1,0 +1,7069 @@
+# Breton translation of gnome-control-center.
+# Copyright (C) 2004-2014 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-menu package.
+#
+# Jérémy Ar Floc'h <jeremy.lefloch@gmail.com>, 2006-2008.
+# Jamy <jamybzh@free.fr>, 2009.
+# Denis Arnaud <denisarnuad@yahoo.fr>, 2014
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Gnome-control-center\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-09-27 06:32+0000\n"
+"PO-Revision-Date: 2014-09-27 21:34+0100\n"
+"Last-Translator: Denis Arnaud <denisarnuad@yahoo.fr>\n"
+"Language-Team: Breton <br@li.org>\n"
+"Language: br\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "Drekleur"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr ""
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "Lock Screen"
+msgstr "Prennañ ar skramm"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Marell"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Zoumañ"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "Kreizañ"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Skeulaat"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Leuniañ"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "Ledañ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:438
+msgid "Wallpapers"
+msgstr "Drekleurioù"
+
+#: ../panels/background/cc-background-chooser-dialog.c:447
+msgid "Colors"
+msgstr "Livioù"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:485
+msgid "Select Background"
+msgstr "Diuzit an drekleur"
+
+#: ../panels/background/cc-background-chooser-dialog.c:514
+msgid "Pictures"
+msgstr "Skeudennoù"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:546
+msgid "No Pictures Found"
+msgstr ""
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:564
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr ""
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:576
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr ""
+
+#: ../panels/background/cc-background-chooser-dialog.c:583
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1537
+#: ../panels/display/cc-display-panel.c:1976
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1247
+#: ../panels/network/net-device-wifi.c:1440
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/cc-printers-panel.c:1947
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+#: ../panels/user-accounts/um-photo-dialog.c:95
+#: ../panels/user-accounts/um-photo-dialog.c:222
+#: ../panels/user-accounts/um-user-panel.c:513
+msgid "_Cancel"
+msgstr "_Nullañ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:584
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:97
+msgid "Select"
+msgstr "Diuzañ"
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "mentoù liesseurt"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "N'eus ket drekleur burev"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr ""
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr ""
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Drekleur;Skramm;Burev;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "Diweredekaet eo ar Bluetooth"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "Diweredekaet eo ar Bluetooth gant kemm ar periant"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr ""
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr ""
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr ""
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr ""
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr ""
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr ""
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr ""
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr ""
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr ""
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr ""
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr ""
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr ""
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s skramm"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s c'hwilerver"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr ""
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr ""
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s webcam"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr ""
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr ""
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+msgid "Not calibrated"
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "Dre ziouer : "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "Egorad livverkel : "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "Aelad arnodiñ : "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "Enporzh_iañ"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr ""
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "An holl restroù"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "Skramm"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr ""
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "Enrollañ an aelad"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr ""
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr ""
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "Arnodiñ an aelad"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr ""
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr ""
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr ""
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr ""
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr ""
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr ""
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr ""
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr ""
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr ""
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr ""
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "Graet"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr ""
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr ""
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr ""
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "Diskouez ar rizh"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr ""
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr ""
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr ""
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr ""
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "Eilañ an aelad"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr ""
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "Kargañ an aelad"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr ""
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+msgid "Summary"
+msgstr ""
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr ""
+
+#: ../panels/color/color.ui.h:30
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr ""
+
+#: ../panels/color/color.ui.h:31
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: ../panels/color/color.ui.h:32
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: ../panels/color/color.ui.h:33
+msgid "Learn more"
+msgstr "Gouzout hiroc'h"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more about color management"
+msgstr ""
+
+#: ../panels/color/color.ui.h:35
+msgid "Set for all users"
+msgstr "Arventnniñ evit an holl arveriaded"
+
+#: ../panels/color/color.ui.h:36
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: ../panels/color/color.ui.h:37
+msgid "Enable"
+msgstr ""
+
+#: ../panels/color/color.ui.h:38
+msgid "Add profile"
+msgstr "Ouzhpennañ un aelad"
+
+#: ../panels/color/color.ui.h:39
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Calibrate…"
+msgstr ""
+
+#: ../panels/color/color.ui.h:40
+msgid "Calibrate the device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:41
+msgid "Remove profile"
+msgstr "Dilemel an aelad"
+
+#: ../panels/color/color.ui.h:42
+msgid "View details"
+msgstr ""
+
+#: ../panels/color/color.ui.h:43
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: ../panels/color/color.ui.h:44
+msgid "LCD"
+msgstr ""
+
+#: ../panels/color/color.ui.h:45
+msgid "LED"
+msgstr ""
+
+#: ../panels/color/color.ui.h:46
+msgid "CRT"
+msgstr ""
+
+#: ../panels/color/color.ui.h:47
+msgid "Projector"
+msgstr ""
+
+#: ../panels/color/color.ui.h:48
+msgid "Plasma"
+msgstr ""
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:52
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Uhel"
+
+#: ../panels/color/color.ui.h:55
+msgid "40 minutes"
+msgstr ""
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr ""
+
+#: ../panels/color/color.ui.h:58
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Izel"
+
+#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr ""
+
+#: ../panels/color/color.ui.h:60
+msgid "Native to display"
+msgstr ""
+
+#: ../panels/color/color.ui.h:61
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:62
+msgid "D55"
+msgstr ""
+
+#: ../panels/color/color.ui.h:63
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:64
+msgid "D75"
+msgstr ""
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "Liv"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:684
+msgid "United States"
+msgstr "Stadoù-Unanet"
+
+#: ../panels/common/cc-common-language.c:685
+msgid "Germany"
+msgstr ""
+
+#: ../panels/common/cc-common-language.c:686
+msgid "France"
+msgstr "Bro C'hall"
+
+#: ../panels/common/cc-common-language.c:687
+msgid "Spain"
+msgstr ""
+
+#: ../panels/common/cc-common-language.c:688
+msgid "China"
+msgstr ""
+
+#: ../panels/common/cc-common-language.c:758
+#, fuzzy
+msgid "Other…"
+msgstr "Aelad all…"
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr ""
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr ""
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr ""
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "_Graet"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+#, fuzzy
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr ""
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr ""
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, fuzzy, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%d x %d (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr ""
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+#, fuzzy
+msgid "%l:%M %p"
+msgstr "%a %l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr ""
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, fuzzy, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%d x %d (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "Genver"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "C'hwevrer"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "Meurzh"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "Ebrel"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "Mae"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "Mezheven"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "Gouere"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "Eost"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "Gwengolo"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "Here"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "Du"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "Kerzu"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "Deiziad hag eur"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr ""
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "Deiz"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "Miz"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "Bloaz"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Time Zone"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Search for a city"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:23
+#, fuzzy
+msgid "Automatic _Date & Time"
+msgstr "Deiziad hag eur"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "Date & _Time"
+msgstr "Deiziad hag _eur"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:28
+msgid "Time _Format"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24-eur"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr ""
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr ""
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:487
+msgid "Lid Closed"
+msgstr ""
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+msgid "Mirrored"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2145
+msgid "Primary"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:497
+msgid "Secondary"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:1533
+msgid "Arrange Combined Displays"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:1539
+#: ../panels/display/cc-display-panel.c:1979
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:1560
+msgid "Drag displays to rearrange them"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2081
+msgid "Size"
+msgstr ""
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2094
+msgid "Aspect Ratio"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2115
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2146
+msgid "Show the top bar and Activities Overview on this display"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2152
+msgid "Secondary Display"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2153
+msgid "Join this display with another to create an extra workspace"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2160
+msgid "Presentation"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2161
+msgid "Show slideshows and media only"
+msgstr ""
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2166
+msgid "Mirror"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2167
+msgid "Show your existing view on both displays"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2173
+msgid "Turn Off"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2174
+msgid "Don't use this display"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2383
+msgid "Could not get screen information"
+msgstr "N'eus ket tu da gaout titouroù ar skramm"
+
+#: ../panels/display/cc-display-panel.c:2414
+msgid "_Arrange Combined Displays"
+msgstr ""
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr ""
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "Dianav"
+
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+msgid "%s %d-bit"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr ""
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1932
+msgid "Section"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr ""
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:46
+msgid "Details"
+msgstr ""
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr ""
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr ""
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr ""
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr ""
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr ""
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr ""
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr ""
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr ""
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr ""
+
+#: ../panels/info/info.ui.h:13
+msgid "Check for updates"
+msgstr ""
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr ""
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr ""
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr ""
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr ""
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr ""
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr ""
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr ""
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr ""
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr ""
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr ""
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr ""
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "Media_où all…"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "Kas er-maez"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr ""
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr ""
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr ""
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr ""
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr ""
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "Arventennoù"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr ""
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr ""
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr ""
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "Teuliad ar gêr"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Klask"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr ""
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr ""
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr ""
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr ""
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "Reizhiad"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Dilugañ"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "Prennañ ar skramm"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr ""
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1218
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+msgid "Disabled"
+msgstr "Diweredekaet"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr ""
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr ""
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Klavier"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "Personnalaat ar berradennoù"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "_Anv :"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "Ar_c'had :"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "Arren ar stokelloù"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "Pa chomer gant ar stokell pouezet warni ez adskriver an arouezenn"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "_Dale :"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "_Tizh :"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "Berr"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "Gorrek"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "Arren tizh ar stokelloù"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "Hir"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+#, fuzzy
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "Trumm"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "Blinkadur ar reti"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "Ar reti a vlink war _maeziennoù an destenn"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "_Tizh :"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:635
+#: ../panels/keyboard/keyboard-shortcuts.c:643
+msgid "Custom Shortcuts"
+msgstr "Berradennoù klavier personelaet"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:860
+msgid "<Unknown Action>"
+msgstr "<Gwered Dianav>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1357
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"N'hallit ket ober gant ar verradenn-mañ \"%s\" rak ne vo ket tro da viziata "
+"en ur arverañ ar stokell-mañ.\n"
+"Mar plij, klaskit gant ur stokell evel Control, Alt pe Pennliz. war un dro."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1387
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"Arveret eo ar verradenn \"%s\" endeo evit\n"
+"\"%s\""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1392
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"Mar bez deverket ar verradenn da \"%s\" en-dro e vo diweredekaet ar "
+"verradenn \"%s\"."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1398
+msgid "_Reassign"
+msgstr "_Deverkañ en-dro"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1439
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1449
+#, fuzzy, c-format
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"Mar bez deverket ar verradenn da \"%s\" en-dro e vo diweredekaet ar "
+"verradenn \"%s\"."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1456
+#, fuzzy
+msgid "_Assign"
+msgstr "_Deverkañ en-dro"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Arventennoù ar son"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+#, fuzzy
+msgid "Test Your Settings"
+msgstr "Arventennoù ar son"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "Hollek"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "Gorrek"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+#, fuzzy
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "Trumm"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "Logodenn"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "Gorrek"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+#, fuzzy
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "Trumm"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "Pavez stekiñ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "Gorrek"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+#, fuzzy
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "Trumm"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr ""
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "_Natural scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr ""
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:369
+msgid "Air_plane Mode"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:977
+msgid "Network proxy"
+msgstr ""
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1156 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr ""
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1301
+msgid "The system network services are not compatible with this version."
+msgstr ""
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr ""
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "pajenn 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr ""
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr ""
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "pajenn 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr ""
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:218
+#: ../panels/network/net-device-wifi.c:382
+msgid "WEP"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:222
+#: ../panels/network/net-device-wifi.c:387
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:226
+msgid "WPA2"
+msgstr ""
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:231
+msgid "Enterprise"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:236
+#: ../panels/network/net-device-wifi.c:372
+msgctxt "Wifi security"
+msgid "None"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "Morse"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:819
+msgid "Today"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:822
+msgid "Yesterday"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:476
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:533
+#, c-format
+msgid "%d Mb/s"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "None"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:568
+msgctxt "Signal strength"
+msgid "Good"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:570
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "Chomlec'h"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "Dilemel ar chomlec'h"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "Ouzhpennañ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Manual"
+msgstr "Dre zorn"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:51
+msgid "Reset"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Tra ebet"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr ""
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr ""
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr ""
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr ""
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr ""
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr ""
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr ""
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr ""
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "_Anv"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "Chomlec'h _MAC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "Chomlec'h"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr ""
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "Dre ziouer"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "Ch_omlec'hioù"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "Aelad nevez"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "Enporzhiañ diouzh ur restr…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "Ouzhpennañ ur c'hennask rouedad"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr ""
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1441
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr ""
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1948
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:223
+msgid "_Open"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+msgid "Export VPN connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr ""
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr ""
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr ""
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr ""
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr ""
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr ""
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:462
+msgid "never"
+msgstr ""
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:472
+msgid "today"
+msgstr ""
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:474
+msgid "yesterday"
+msgstr ""
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr ""
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr ""
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr ""
+
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1596
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "Dibarzhioù..."
+
+#: ../panels/network/net-device-ethernet.c:474
+#, c-format
+msgid "Profile %d"
+msgstr "Aelad %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr ""
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1154
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1158
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1162
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1245
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1248
+msgid "_Stop Hotspot"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1305
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1308
+msgid "Wireless device does not support Hotspot mode"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1437
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1745
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1749
+#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
+#: ../panels/wacom/cc-wacom-page.c:533
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Close"
+msgstr ""
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1757
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr ""
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr ""
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "Ouzhpenn_añ un aelad..."
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr ""
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr ""
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr ""
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr ""
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "Dilemel un drobarzhell"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr ""
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr ""
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr ""
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr ""
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "Tra ebet"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Turn On"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Wi-Fi"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_Use as Hotspot…"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "_History"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Network Name"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Connected Devices"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "Security type"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:63
+msgid "Security key"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr ""
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+msgid "Choose a PAC file"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "Restr _PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+msgid "Choose your personal certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+msgid "Choose your private key"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr ""
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr ""
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "Ket"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "Ya"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr ""
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr ""
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr ""
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (Dre ziouer)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+#, fuzzy
+msgid "Open System"
+msgstr "Reizhiad"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "_Rizh"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+msgctxt "notifications"
+msgid "Notifications"
+msgstr ""
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "Arventennoù ar son"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr ""
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr ""
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+#, fuzzy
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "Prennañ ar skramm"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr ""
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr ""
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr ""
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr ""
+
+#: ../panels/notifications/notifications.ui.h:2
+#, fuzzy
+msgid "Show in Lock Screen"
+msgstr "Prennañ ar skramm"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+msgctxt "Online Account"
+msgid "Other"
+msgstr ""
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "Dilemel"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr ""
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:183
+msgid "Unknown time"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:189
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/power/cc-power-panel.c:201
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:209
+#, c-format
+msgid "%i %s %i %s"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:210
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:230
+#, c-format
+msgid "%s until fully charged"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:237
+#, c-format
+msgid "Caution: %s remaining"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:242
+#, c-format
+msgid "%s remaining"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
+msgid "Fully charged"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
+msgid "Empty"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Charging"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:271
+msgid "Discharging"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:396
+msgctxt "Battery name"
+msgid "Main"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:398
+msgctxt "Battery name"
+msgid "Extra"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:470
+msgid "Wireless mouse"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:473
+msgid "Wireless keyboard"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:476
+msgid "Uninterruptible power supply"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Personal digital assistant"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Cellphone"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Media player"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Tablet"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Computer"
+msgstr ""
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
+#: ../panels/power/cc-power-panel.c:2019
+msgid "Battery"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgctxt "Battery power"
+msgid "Charging"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Caution"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Low"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Good"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Empty"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:715
+msgid "Batteries"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1117
+msgid "When _idle"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1445
+msgid "Power Saving"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1473
+msgid "_Screen brightness"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1479
+#, fuzzy
+msgid "_Keyboard brightness"
+msgstr "Arventennoù ar c'hlavier"
+
+#: ../panels/power/cc-power-panel.c:1489
+msgid "_Dim screen when inactive"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1514
+#, fuzzy
+msgid "_Blank screen"
+msgstr "Prennañ ar skramm"
+
+#: ../panels/power/cc-power-panel.c:1551
+msgid "_Wi-Fi"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1556
+msgid "Turns off wireless devices"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1581
+msgid "_Mobile broadband"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1586
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1635
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: ../panels/power/cc-power-panel.c:1686
+msgid "When on battery power"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1688
+msgid "When plugged in"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Off"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1851
+msgid "_Automatic suspend"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1875
+msgid "When battery power is _critical"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1930
+msgid "Power Off"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Devices"
+msgstr "Trobarzhelloù"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr ""
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr ""
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr ""
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr ""
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr ""
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr ""
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr ""
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr ""
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr ""
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "Dale"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr ""
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr ""
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr ""
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr ""
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr ""
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr ""
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr ""
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr ""
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr ""
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr ""
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr ""
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr ""
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr ""
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr ""
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Toner Level"
+msgstr ""
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:928
+msgid "Supply Level"
+msgstr ""
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:946
+msgctxt "printer state"
+msgid "Installing"
+msgstr ""
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1123
+msgid "No printers available"
+msgstr ""
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1433
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1777
+msgid "Failed to add new printer."
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid "Select PPD File"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:1953
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2258
+msgid "No suitable driver found"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2327
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2342
+msgid "Select from database…"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2351
+msgid "Provide PPD File…"
+msgstr ""
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2502
+#: ../panels/printers/cc-printers-panel.c:2525
+msgid "Test page"
+msgstr ""
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2933
+#, c-format
+msgid "Could not load ui: %s"
+msgstr ""
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr ""
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr ""
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr ""
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr ""
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr ""
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr ""
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter address of a printer or a text to filter results"
+msgstr ""
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr ""
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr ""
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr ""
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+msgid "JetDirect Printer"
+msgstr ""
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+msgid "LPD Printer"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr ""
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr ""
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr ""
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr ""
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr ""
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr ""
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr ""
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr ""
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr ""
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr ""
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr ""
+
+#: ../panels/printers/pp-jobs-dialog.c:495
+#, c-format
+msgid "%s Active Jobs"
+msgstr ""
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "USB"
+msgstr ""
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Serial Port"
+msgstr ""
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1683
+msgid "Parallel Port"
+msgstr ""
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+msgid "Location: %s"
+msgstr ""
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1744
+#, c-format
+msgid "Address: %s"
+msgstr "Chomlec'h : %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1768
+msgid "Server requires authentication"
+msgstr ""
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr ""
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr ""
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr ""
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr ""
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr ""
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:531
+msgid "Pages per side"
+msgstr ""
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:543
+msgid "Two-sided"
+msgstr ""
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:555
+msgid "Orientation"
+msgstr ""
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:652
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr ""
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr ""
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr ""
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr ""
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr ""
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr ""
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr ""
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr ""
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr ""
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr ""
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr ""
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr ""
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr ""
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr ""
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr ""
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default printer"
+msgstr "Moulerez dre ziouer : "
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr ""
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr ""
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr ""
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+msgid "Delete all the temporary files?"
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr ""
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr ""
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:18
+#, fuzzy
+msgid "Forever"
+msgstr "Morse"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:42
+msgid "_Location Services"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr ""
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr ""
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr ""
+
+#: ../panels/region/cc-format-chooser.c:284
+msgid "No regions found"
+msgstr ""
+
+#: ../panels/region/cc-input-chooser.c:179
+msgid "No input sources found"
+msgstr ""
+
+#: ../panels/region/cc-input-chooser.c:1076
+msgctxt "Input Source"
+msgid "Other"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:894
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:243
+#: ../panels/user-accounts/um-user-panel.c:898
+msgid "Restart Now"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:862
+msgid "No input source selected"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:1092
+msgid "Sorry"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:1094
+msgid "Input methods can't be used on the login screen"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:1731
+#, fuzzy
+msgid "Login Screen"
+msgstr "Prennañ ar skramm"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr ""
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr ""
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr ""
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr ""
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr ""
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr ""
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Allow _different sources for each window"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Keyboard Shortcuts"
+msgstr "Berradennoù ar c'hlavier"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Switch to previous source"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Super+Shift+Space"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Switch to next source"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:9
+msgid "Super+Space"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:10
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Alternative switch to next source"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:12
+msgid "Left+Right Alt"
+msgstr ""
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr ""
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr ""
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "Neuziadoù"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr ""
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "Sinedoù"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr ""
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+#, fuzzy
+msgid "Select Location"
+msgstr "Diuzit an drekleur"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+msgid "_OK"
+msgstr "Mat e_o"
+
+#: ../panels/search/cc-search-panel.c:176
+msgid "No applications found"
+msgstr ""
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "Klask"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr ""
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr ""
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr ""
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "Gwellvezio"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr ""
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr ""
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr ""
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+msgctxt "service is active"
+msgid "Active"
+msgstr ""
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "Dibab ur teuliad"
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "Eilañ"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr ""
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr ""
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:299
+msgid "No networks selected for sharing"
+msgstr ""
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "Rouedadoù"
+
+#: ../panels/sharing/sharing.ui.h:1
+#, fuzzy
+msgid "Bluetooth Sharing"
+msgstr "Bluetooth"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "Anv an urzhiater"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "Kennask a-bell"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Allow Remote Control"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:21
+msgid "Password:"
+msgstr "Ger-tremen"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "Skrammañ ar ger-tremen"
+
+#: ../panels/sharing/sharing.ui.h:23
+#, fuzzy
+msgid "Access Options"
+msgstr "Neuziadoù"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:25
+msgid "Require a password"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:26
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:27
+msgid "Folders"
+msgstr "Teuliadoù"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "Son"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr ""
+
+#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
+msgctxt "volume"
+msgid "100%"
+msgstr "10%"
+
+#: ../panels/sound/gvc-channel-bar.c:616
+msgctxt "volume"
+msgid "Unamplified"
+msgstr ""
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "_Aelad :"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1509
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "Anv"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1528
+msgid "Device"
+msgstr "Trobarzhell"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1591
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1649
+msgid "_Output volume:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "Output"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1668
+msgid "C_hoose a device for sound output:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1693
+msgid "Settings for the selected device:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "Input"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "_Input volume:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1734
+msgid "Input level:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1762
+msgid "C_hoose a device for sound input:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "Sound Effects"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+msgid "_Alert volume:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1809
+msgid "Applications"
+msgstr "Arloadoù"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1813
+msgid "No application is currently playing or recording audio."
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "Gwellvezioù ar son"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "Dre ziouer"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:769
+msgid "C_hoose an alert sound:"
+msgstr ""
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr ""
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr ""
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr ""
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "Personelaet"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:4
+#, fuzzy
+msgid "_Large Text"
+msgstr "Bras"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "_Zoom"
+msgstr "Zoumañ"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:8
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Stokelloù daslammus"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:12
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Klavier"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Pointing & Clicking"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:15
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Stokelloù al logodenn"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Screen Reader"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:20
+#, fuzzy
+msgid "Sound Keys"
+msgstr "Stokelloù daslammus"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Flash the _window title"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Typing Assist"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:28
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Stokelloù pegus"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifer key is pressed"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:32
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Stokelloù gorrek"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:35
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Berr"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:37
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Hir"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:41
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Stokelloù daslammus"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:43
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Berr"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:45
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Hir"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Berr"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Hir"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "_Hover Click"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "Dal_e :"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Berr"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Hir"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:60
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Bihan"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Bras"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "Zoum"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "Liv :"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr ""
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "Liv"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Tra ebet"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Full Name"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to set a password when they next login"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "_Domani"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "Ouzhpennañ un arveriad"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "Biz meud kleiz"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "Biz bras kleiz"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "Biz bizoù kleiz"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "Biz bihan kleiz"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "Biz meud dehou"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "Biz bras dehou"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "Biz bizoù dehou"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "Biz bihan dehou"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:687
+msgid "Enable Fingerprint Login"
+msgstr "Gweredekaat an anaout dre roudoù biz"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"Deuet eo da vat ar gwaredur hoc'h roudoù biz. Bremañ, gallout a rit anaout "
+"deoc'h gant al lenner roudoù biz."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "Arveriaded"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr ""
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "Kemm_añ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "Ger-tremen nevez"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "Dibarzhioù ar c'hennask"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "Arlun an arveriad"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "_Yezh"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr ""
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr ""
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "Fazi dianav"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+msgid "Passwords do not match."
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:138
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"N'hoc'h eus ket droad da vont en drobarzhell. Kit e darempred gant hoc'h "
+"ardoer reizhiad."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:140
+msgid "The device is already in use."
+msgstr "Implijet eo dija an drobarzhell."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid "An internal error occurred."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Enabled"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr "Dilemel roudoù biz gwaredet?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr "_Dilemel ar roudoù biz"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"C'hoant hoc'h eus dilemel roudoù biz gwaredet ha deweredekaat merour gant "
+"roudoù biz?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:444
+msgid "Done!"
+msgstr "Echu !"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:505
+#: ../panels/user-accounts/um-fingerprint-dialog.c:547
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "N'eus ket tu da vonet en drobarzhell '%s'"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:588
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "N'eus ket tu da lañsañ an dapadenn roudoù biz gant an drobarzhell '%s'"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:638
+msgid "Could not access any fingerprint readers"
+msgstr "N'eus ket tu da vont en ul lenner roudoù biz ebet"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:639
+msgid "Please contact your system administrator for help."
+msgstr ""
+"Mar plij ganeoc'h,kit e darempred gant hoc'h ardoer reizhiad evit skoazell "
+"ac'hanout."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:721
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"Ret eo deoc'h gwrarediñ unan eus ho louc'hoù biz gant sikour trobarzhell "
+"'%s' evit gweredekaat ar c'hennaskañ dre al louc'hoù biz."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:728
+msgid "Selecting finger"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:729
+msgid "Enrolling fingerprints"
+msgstr ""
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr ""
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr ""
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr ""
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:631
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr ""
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr ""
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr ""
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "The passwords do not match."
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:219
+msgid "Browse for more pictures"
+msgstr "Furchal evit muioc'h a skeudennoù"
+
+#: ../panels/user-accounts/um-photo-dialog.c:453
+msgid "Disable image"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:471
+msgid "Take a photo…"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:489
+msgid "Browse for more pictures…"
+msgstr "Furchal evit muioc'h a skeudennoù..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:713
+#, c-format
+msgid "Used by %s"
+msgstr "Arveret gant %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:198
+msgid "Other Accounts"
+msgstr "Kontoù all"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "Failed to delete user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:482
+msgid "You cannot delete your own account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:491
+#, c-format
+msgid "%s is still logged in"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:495
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:504
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:511
+msgid "_Delete Files"
+msgstr "_Dilemel ar restroù"
+
+#: ../panels/user-accounts/um-user-panel.c:512
+msgid "_Keep Files"
+msgstr "_Mirout ar restroù"
+
+#: ../panels/user-accounts/um-user-panel.c:564
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:572
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:575
+msgctxt "Password mode"
+msgid "None"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:624
+msgid "Logged in"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1073
+msgid "Failed to contact the accounts service"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1075
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1116
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1154
+msgid "Create a user account"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1165
+#: ../panels/user-accounts/um-user-panel.c:1477
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1175
+msgid "Delete the selected user account"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1187
+#: ../panels/user-accounts/um-user-panel.c:1482
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1391
+msgid "My Account"
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+msgid "A user with the username '%s' already exists."
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:571
+#, c-format
+msgid "The username is too long."
+msgstr "Re hir eo anv an arveriad."
+
+#: ../panels/user-accounts/um-utils.c:574
+msgid "The username cannot start with a '-'."
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:577
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:581
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e"
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:831
+msgid "%b %e, %Y"
+msgstr ""
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr ""
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr ""
+
+#: ../panels/wacom/button-mapping.ui.h:4
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "Ec'hankad :"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr ""
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Wacom Tablet"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "No tablet detected"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Bluetooth Settings"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map to Monitor…"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map Buttons…"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust display resolution"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust mouse settings"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Tracking Mode"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Left-Handed Orientation"
+msgstr ""
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+#, fuzzy
+msgid "Left Ring"
+msgstr "Biz bizoù kleiz"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr ""
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+#, fuzzy
+msgid "Right Ring"
+msgstr "Biz bizoù dehou"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr ""
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+msgid "Left Touchstrip"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr ""
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+msgid "Right Touchstrip"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "Berradenn nevez..."
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr ""
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr ""
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr ""
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr ""
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "Skrammañ dibarzhioù ar skoazell"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr ""
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr ""
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- Arventennoù"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr ""
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "Skoazell"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "Kuitaat"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+msgid "All Settings"
+msgstr "An holl arventennoù"
+
+#. Add categories
+#: ../shell/cc-window.c:876
+msgctxt "category"
+msgid "Personal"
+msgstr ""
+
+#: ../shell/cc-window.c:877
+msgctxt "category"
+msgid "Hardware"
+msgstr ""
+
+#: ../shell/cc-window.c:878
+msgctxt "category"
+msgid "System"
+msgstr "Reizhiad [Rummad]"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "Gwellvezioù;Arventennoù;"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "Kefluniañ an arventennoù Bluetooth"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Arventenniñ un drobarzhell nevez"
+
+#~ msgid "Send Files..."
+#~ msgstr "Kas restroù..."
+
+#~ msgid "Browse Files..."
+#~ msgstr "Merdeiñ restroù..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Add device"
+#~ msgstr "OUzhpennañ un drobarzhell"
+
+#~ msgid "Device type:"
+#~ msgstr "Rizh an drobarzhell :"
+
+#~ msgid "Select a language"
+#~ msgstr "Diuzañ ur yezh"
+
+#~ msgid "_Select"
+#~ msgstr "_Diuzañ"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 derez"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Diuzañ ur skramm a-benn kemmañ e berzhioù ; lakaat d'e riklañ a-benn "
+#~ "kempenn e lec'hiadur."
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "N'eus ket tu da enrollañ ar c'hefluniadur skramm"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "N'hall ket dinoiñ ar skrammoù"
+
+#~ msgid "_Options..."
+#~ msgstr "_Dibarzhioù"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Gweredekaat ar boneg diveugañ"
+
+#~ msgid "Control Center"
+#~ msgstr "Kreizenn reoliñ"

--- a/po/bs.po
+++ b/po/bs.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.HEAD.bs\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2015-02-27 07:32+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2015-03-03 14:44+0100\n"
 "Last-Translator: Merima Cisija <cisijam@gmail.com>\n"
 "Language-Team: Bosnian <lokal@linux.org.ba>\n"
@@ -16,526 +15,425 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
-"10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2015-02-05 06:49+0000\n"
 "X-Generator: Poedit 1.7.4\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplikacije"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Nisu nađeni programi"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Otvori"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Pogledaj detalje"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Traži"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Napomene"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Prikaži _Napomene"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Pozadina"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Snimci ekrana"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Pozadine"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Zvuk"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Prečaci"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Prečice sa tastature"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "Usluge vezane za _Lokaciju"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Ugrađena Web kamera"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Nisu pronađene regije"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Tip prikaza"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Brzina veze"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Resetuj"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Aplikacije"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Olovka"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Podrazumijevano"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Pozadina"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "Promjene dana"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "_Dodaj Profil"
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "Lock Screen"
-msgstr "Zaključaj ekran"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Popločano"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Uvećaj"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "Centrirano"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Srazmjerno"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Popuna"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "Rasprostrto"
-
-#: ../panels/background/cc-background-chooser-dialog.c:437
-msgid "Wallpapers"
-msgstr "Pozadine"
-
-#: ../panels/background/cc-background-chooser-dialog.c:446
-msgid "Colors"
-msgstr "Boje"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:483
-msgid "Select Background"
-msgstr "Izaberi pozadinu"
-
-#: ../panels/background/cc-background-chooser-dialog.c:511
-msgid "Pictures"
-msgstr "Slike"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:543
-msgid "No Pictures Found"
-msgstr "Slike nisu nađene"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:561
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "Početna"
-
-#. translators: %s here is the nami of the Pictures directory, the string should bje translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:573
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "Mozes dodati slike u svoj %s folder i one će se pojaviti tamo"
-
-#: ../panels/background/cc-background-chooser-dialog.c:580
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1579
-#: ../panels/display/cc-display-panel.c:2022
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1247
-#: ../panels/network/net-device-wifi.c:1440
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/cc-printers-panel.c:1938
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:568
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-#: ../panels/user-accounts/um-photo-dialog.c:94
-#: ../panels/user-accounts/um-photo-dialog.c:217
-#: ../panels/user-accounts/um-user-panel.c:706
-#: ../panels/user-accounts/um-user-panel.c:724
-msgid "_Cancel"
-msgstr "_Odustani"
-
-#: ../panels/background/cc-background-chooser-dialog.c:581
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:96
-msgid "Select"
-msgstr "Odaberi"
-
-#: ../panels/background/cc-background-item.c:203
-msgid "multiple sizes"
-msgstr "više veličina"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:207
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:333
-msgid "No Desktop Background"
-msgstr "Nema pozadine za radnu površ"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "Trenutna pozadina"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Promijeni svoju pozadinu u pozadinu ili sliku"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Pozadina;Ekran;Radna površ;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "Bluetooth je onemogućen"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Omogući"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "Nisu pronađeni Bluetooth adapteri"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Djeljenje bluetoothom"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "Avionski način"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth je onemogućen hardverskim prekidačem"
 
-#. Translators: The found djevice is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1637
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "Avionski način"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Avionski način"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Uključi i isključi blutut i poveži svoje uređaje"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "Postavi svoj uređaj za kalibrisanje preko kvadrata i pritisni 'Start'"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Ni jedan program ne pušta ili snima zvuk."
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"Pomjeri svoj uređaj za kalibrisanje na poziciju za kalibrisanje i pritisni "
-"'Nastavi'"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-"Pomjeri svoj uredđaj za kalibrisanje na poziciju površine i pritisni "
-"'Nastavi'"
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "Zaklopite laptop"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Traži za više slika"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "Unutrašnja greška se dogodila koja ne može biti popravljena."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "Alati potrebni za kalibrisanje nisu instalirani."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "Profil nije mogao biti generisan."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- seje
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "Ciljana bijela tačka nije dobijena."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "Završeno!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "Kalibrisanje nije uspjelo!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "Možete ukloniti uređaj za kalibraciju."
-
-#. TRANSLATORS: The user has to bje careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ne pomjerajte uređaj za kalibrisanje dok se izvršava"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Ekran laptopa"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Ugrađena Web kamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s monitor"
-
-#. TRANSLATORS: a flatbed scanner djevice, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s skener"
-
-#. TRANSLATORS: a camera djevice, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s kamera"
-
-#. TRANSLATORS: a printer djevice, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s printer"
-
-#. TRANSLATORS: a webcam djevice, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s Web kamera"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Omogućeno upravljanje bojom za %s"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Prikaži profile boja za %s"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:323
-msgid "Not calibrated"
-msgstr "Nije kalibrisano"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "Podrazumijevano: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space liki AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "Prostor boja: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "Probni profil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "Izaberi datoteku ICC profila"
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "_Uvezi"
-
-#. TRANSLATORS: filter nami on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "Podržani ICC profili"
-
-#. TRANSLATORS: filter nami on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "Sve datoteke"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "Ekran"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Nije uspjelo postavljanje datoteke %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "Profil je postavljen na:"
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "Upišite ovaj URL."
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"Ponovo pokrenite ovaj kompjuter i pokrenite svoj normalni operativni sistem."
 
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "Ukucajte URL u svoj preglednik da bi skinuli i instalirali profil."
-
-#. TRANSLATORS: this is the dialog to savije the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "Snimi profil"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "_Snimi"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "Napravi profil boje za izabrani uređaj"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Mjerni uređaj nije otkriven. Provjerite da li je upaljen i ispravno "
-"priključen."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Mjerni uređaj ne podržava profilisanje štampača."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "Vrsta uređaja nije trenutno podržana."
-
-#. TRANSLATORS: standard spaces are well known colorspaces liki
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "Standardni prostor"
-
-#. TRANSLATORS: test profiles do things liki changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "Testni profil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatski"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may bje a poor reflection of the
-#. * djevice capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Niska kvaliteta"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Srednja kvaliteta"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Visoka kvaliteta"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Osnovna „RGB“"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Osnovna „CMYK“"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Osnovna siva"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "Vendor fabrika za isporuku podataka o kalibrisanju"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Popravka prikaza punog ekrana nije moguća za ovaj profil"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "Ovaj profil možda više nije precizan"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kalibracija prikaza"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1476
-msgid "Cancel"
-msgstr "Odustani"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Odustani"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "Početak"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "Nastavi"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "Završeno"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Završeno"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Kalibracija ekrana"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kvalitet kalibracije"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -544,43 +442,43 @@ msgstr ""
 "Kalibracija će stvoriti profil koji možete koristiti za upravljanje boje "
 "vašeg ekrana. Što duže provodite kalibrisanje, bolja kvaliteta boje profila."
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr ""
 "Nećete biti u mogućnosti koristiti vaš kompjuter dok traje kalibrisanje."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Kvalitet"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Približno vrijeme"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "Kvalitet kalibracije"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Odaberite senzorni uređaj koji želite koristiti za kalibrisanje."
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Uređaj za kalibrisanje"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "Odaberite tip prikaza koji je povezan."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Odaberite senzorni uređaj koji želite koristiti za kalibrisanje."
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Tip prikaza"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Odaberite tip prikaza koji je povezan."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Bijela tačka profila"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -588,11 +486,11 @@ msgstr ""
 "Odaberite ciljanu bijelu tačku za prikaz . Većina prikaza bi trebala biti "
 "kalibrisana na  D65 osvjetljenju."
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "Bijela tačka profila"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Osvjetljaj ekrana"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -600,7 +498,7 @@ msgstr ""
 "Molimo Vas, namjestite osvjetljenje prikaza koje vam je tipično. Upravljanje "
 "bojom će biti najpreciznije pri tom nivou osvjetljenja."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -608,11 +506,11 @@ msgstr ""
 "Alternativno, možete koristiti nivo osvjetljenja korišten na drugim "
 "profilima za ovaj uređaj."
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "Osvjetljaj ekrana"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Naziv profila"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -620,63 +518,42 @@ msgstr ""
 "Možete koristiti profil boje na drugom kompjuteru, ili čak kreirati profile "
 "za drukčije uslove osvjetljenja."
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Naziv profila:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "Naziv profila"
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Sažetak"
 
-#: ../panels/color/color.ui.h:21
+#: panels/color/cc-color-panel.ui:259
 msgid "Profile successfully created!"
 msgstr "Profil uspješno kreiran"
 
-#: ../panels/color/color.ui.h:22
+#: panels/color/cc-color-panel.ui:290
 msgid "Copy profile"
 msgstr "Kopija profila"
 
-#: ../panels/color/color.ui.h:23
+#: panels/color/cc-color-panel.ui:296
 msgid "Requires writable media"
 msgstr "Zahtijeva medij za pisanje"
 
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "Postavi profil"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "Zahtijeva povezanost na internet"
-
-#: ../panels/color/color.ui.h:26
+#: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Možete naći ove instrukcije u Kako koristiti profil na <a href=\"linux\">GNU/"
 "Linux</a>, <a href=\"osx\">Apple OS X</a> i <a href=\"windows\">Microsoft "
 "Windows</a> sistemima ."
 
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:732
-msgid "Summary"
-msgstr "Sažetak"
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Dodajte profil"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "Unesite datoteku…"
-
-#: ../panels/color/color.ui.h:30
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1477
-msgid "_Add"
-msgstr "_Dodaj"
-
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
@@ -684,1386 +561,1596 @@ msgstr ""
 "Otkriveni problemi. Profil možda više neće raditi tačno. <a href=\"\">Vidi "
 "detalje.</a>"
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "Unesite datoteku…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Dodaj"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Svakom uređaju je potreban jedan aktuelni profil boje da bi bio upravljan "
 "bojom."
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Saznajte više"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Saznajte više o upravljanju bojama"
 
-#: ../panels/color/color.ui.h:35
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "Podesi za sve korisnike"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Postavi profil za sve korisnike na ovom računaru"
 
-#: ../panels/color/color.ui.h:37
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "Omogući"
 
-#: ../panels/color/color.ui.h:38
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "Dodajte profil"
 
-#: ../panels/color/color.ui.h:39
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "Kalibriši…"
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Kalibrišite uređaj"
 
-#: ../panels/color/color.ui.h:41
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "Ukloni profil"
 
-#: ../panels/color/color.ui.h:42
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "Pogledaj detalje"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "Nemoguće otkriti uređaje koji mogu biti upravljani bojom"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "Katodna cijev"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Projektor"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plazma"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD(CCFL pzadinsko svjetlo)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED pozadinsko svjetlo)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (bijelo LED pozadinsko svjetlo)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Široka skala LCD (CCFL pozadinsko ssvjetlo)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Široka skala LCD (RGB LED pozadinsko svjetlo)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Visok"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 minuta"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Srednja"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 minuta"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Slabo"
 
-#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 minuta"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Prikaz koji odgovara ekranu"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (printanje i objavljivanje)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Fotografija i grafike)"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Boja"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Kalibrišite boju vaših uređaja, kao što su prikazi, kamere i printeri"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Boja;ICC;Profil;Kalibriši;Štampač;Prikaz;"
 
-#: ../panels/common/cc-common-language.c:323
-msgid "Other…"
-msgstr "Drugo…"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Jezik"
 
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:270
-#: ../panels/region/cc-input-chooser.c:167
-msgid "More…"
-msgstr "Više…"
+#: panels/common/cc-language-chooser.ui:13
+#, fuzzy
+msgid "_Select"
+msgstr "Odaberi"
 
-#: ../panels/common/cc-language-chooser.c:139
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Nisu nađeni jezici"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "Jezik"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Više…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "_Završeno"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Vrijeme"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will bje replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "Januar"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "Februar"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "Mart"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "April"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "Maj"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "Juni"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "Juli"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "August"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "Septembar"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "Oktobar"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "Novembar"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "Decembar"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Datum i vrijeme"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "Sat"
-
-#. Translator: this is the separator between hours and minutes, liki in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "Minuta"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "Dan"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "Mjesec"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "Godina"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mjesec"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januar"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Mart"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maj"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juni"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juli"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Septembar"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktobar"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembar"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Decembar"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dan"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Vremenska zona"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Traži grad"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "Automatsko _Datum i Vrijeme"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Zahtijeva pristup internetu"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Datum i _Vrijeme"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Automatska Vremenska _zona"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "Date & _Time"
-msgstr "Datum i _Vrijeme"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "Zahtijeva pristup internetu"
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
-msgstr "Vremenska _zona"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Omogućen"
 
-#: ../panels/datetime/datetime.ui.h:28
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "Vremenska zona"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format vremena"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24-sata"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datumi"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "Sekundarni"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalendar"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Brojevi"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Promijeni datum i vrijeme, uključujući vremensku zonu"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Sat;Vrijemenskazona;Lokacija;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "Promjena postavki vremena i datuma"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Za promjenu vremena i datuma trebate potvrditi identitet."
 
-#: ../panels/display/cc-display-panel.c:564
-msgid "Lid Closed"
-msgstr "Zatvoren poklopac"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
 
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:567
-msgid "Mirrored"
-msgstr "Preslikano"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Pošta"
 
-#: ../panels/display/cc-display-panel.c:569
-#: ../panels/display/cc-display-panel.c:2196
-msgid "Primary"
-msgstr "Primarni"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalendar"
 
-#: ../panels/display/cc-display-panel.c:571
-#: ../panels/notifications/cc-notifications-panel.c:247
-#: ../panels/power/cc-power-panel.c:1705 ../panels/power/cc-power-panel.c:1716
-#: ../panels/privacy/cc-privacy-panel.c:155
-#: ../panels/privacy/cc-privacy-panel.c:222
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "Isključeno"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_uzika"
 
-#: ../panels/display/cc-display-panel.c:574
-msgid "Secondary"
-msgstr "Sekundarni"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
 
-#. Title of displays dialog when multiple monitors are present.
-#: ../panels/display/cc-display-panel.c:1576
-msgid "Arrange Combined Displays"
-msgstr "Uredi kombinovani prikaz"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Slike"
 
-#: ../panels/display/cc-display-panel.c:1580
-#: ../panels/display/cc-display-panel.c:2023
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr "_Primijeni"
-
-#: ../panels/display/cc-display-panel.c:1604
-msgid "Drag displays to rearrange them"
-msgstr "Povlači prikaze da bi ih preuredili"
-
-#: ../panels/display/cc-display-panel.c:2075
-msgid "Rotate counterclockwise by 90°"
-msgstr "Rotiraj  za 90 stepeni suprotno od smijera kazaljke"
-
-#: ../panels/display/cc-display-panel.c:2093
-msgid "Rotate by 180°"
-msgstr "Rotiraj za 180°"
-
-#: ../panels/display/cc-display-panel.c:2111
-msgid "Rotate clockwise by 90°"
-msgstr "Rotiraj za 90°u smijeru kazaljke na satu"
-
-#: ../panels/display/cc-display-panel.c:2132
-msgid "Size"
-msgstr "Veličina"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2145
-msgid "Aspect Ratio"
-msgstr "Proporcija"
-
-#: ../panels/display/cc-display-panel.c:2166
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "Rezolucija"
-
-#: ../panels/display/cc-display-panel.c:2197
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "Prikaži na  gornjoj tabli  Pregled aktivnosti na ovom prikazu"
-
-#: ../panels/display/cc-display-panel.c:2203
-msgid "Secondary Display"
-msgstr "Sekundarni prikaz"
-
-#: ../panels/display/cc-display-panel.c:2204
-msgid "Join this display with another to create an extra workspace"
-msgstr "Spoji ovaj prikaz sa drugim da bi stvorili više radnog prostora"
-
-#: ../panels/display/cc-display-panel.c:2211
-msgid "Presentation"
-msgstr "Prezentacija"
-
-#: ../panels/display/cc-display-panel.c:2212
-msgid "Show slideshows and media only"
-msgstr "Prikaži samo pokretni prikaz i medije"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2217
-msgid "Mirror"
-msgstr "Ogledalo"
-
-#: ../panels/display/cc-display-panel.c:2218
-msgid "Show your existing view on both displays"
-msgstr "Prikaži potojeći pogled na oba prikaza"
-
-#: ../panels/display/cc-display-panel.c:2224
-msgid "Turn Off"
-msgstr "Isključi"
-
-#: ../panels/display/cc-display-panel.c:2225
-msgid "Don't use this display"
-msgstr "Nemoj koristiti ovaj prikaz"
-
-#: ../panels/display/cc-display-panel.c:2455
-msgid "Could not get screen information"
-msgstr "Ne mogu da dobijem podatke o ekranu"
-
-#: ../panels/display/cc-display-panel.c:2486
-msgid "_Arrange Combined Displays"
-msgstr "_Omogući kombinovane prikaze"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "Displeji"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr "Odaberi kako koristit povezane monitore i projektore"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "Panel;projektor;xrandr;Ekran;Rezolucija;Osvježi;Monitor;"
-
-#: ../panels/info/cc-info-panel.c:385
-msgid "Wayland"
-msgstr "Wayland"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:388 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "Nepoznato"
-
-#: ../panels/info/cc-info-panel.c:473
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-bit"
-
-#: ../panels/info/cc-info-panel.c:475
-#, c-format
-msgid "%d-bit"
-msgstr "%d-bit"
-
-#: ../panels/info/cc-info-panel.c:1155
-msgid "Ask what to do"
-msgstr "Pitaj šta da uradiš"
-
-#: ../panels/info/cc-info-panel.c:1159
-msgid "Do nothing"
-msgstr "Ne radi ništa"
-
-#: ../panels/info/cc-info-panel.c:1163
-msgid "Open folder"
-msgstr "Otvori direktorij"
-
-#: ../panels/info/cc-info-panel.c:1254
-msgid "Other Media"
-msgstr "Drugi mediji"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for audio CDs"
-msgstr "Odaberite aplikaciju za otvaranje audio CD-ova"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application for video DVDs"
-msgstr "Odaberite aplikaciju za otvaranje video DVD-ova"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Odaberite aplikaciju koja će se pokretati kad muzički plejer bude priključen"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application to run when a camera is connected"
-msgstr "Odaberite aplikaciju koja će se pokretati kad kamera bude priključena"
-
-#: ../panels/info/cc-info-panel.c:1289
-msgid "Select an application for software CDs"
-msgstr ""
-"Odaberite aplikaciju koja će se pokretati kad budete ubacili CD-ove sa "
-"softverom"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1301
-msgid "audio DVD"
-msgstr "audio DVD"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank Blu-ray disc"
-msgstr "prazan Blu-ray disk"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank CD disc"
-msgstr "prazan CD disk"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank DVD disc"
-msgstr "prazan DVD disk"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "blank HD DVD disc"
-msgstr "prazan HD DVD disk"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video disk"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "e-book reader"
-msgstr "e-book čitač"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "HD DVD video disc"
-msgstr "HD DVD video disk"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Picture CD"
-msgstr "CD sa slikama"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Video CD"
-msgstr "Video CD"
-
-#: ../panels/info/cc-info-panel.c:1312
-msgid "Windows software"
-msgstr "Windows softver"
-
-#: ../panels/info/cc-info-panel.c:1435
-#: ../panels/keyboard/keyboard-shortcuts.c:1947
-msgid "Section"
-msgstr "Odjeljak"
-
-#: ../panels/info/cc-info-panel.c:1444 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "Predpregled"
-
-#: ../panels/info/cc-info-panel.c:1450 ../panels/info/info.ui.h:21
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
 msgid "Default Applications"
 msgstr "Standardne aplikacije"
 
-#: ../panels/info/cc-info-panel.c:1455 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "Pokretni mediji"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Standardne aplikacije"
 
-#: ../panels/info/cc-info-panel.c:1480
-#, c-format
-msgid "Version %s"
-msgstr "Verzija %s"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:46
-msgid "Details"
-msgstr "Detalji"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Javljanje problema"
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatsko javljanje problema"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Primijeni"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Nazad"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Bluetooth je onemogućen"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "više veličina"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Ogledalo"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Sekundarni prikaz"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "Desni prsten"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orijentacija"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Srazmjerno"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Nije nađen nijedan štampač"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Restartuj Sada"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Vremena"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Sat"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuta"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Displeji"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Odaberi kako koristit povezane monitore i projektore"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Panel;projektor;xrandr;Ekran;Rezolucija;Osvježi;Monitor;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Sigurnosni ključ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Nivo mastila"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Nivo mastila"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Nivo mastila"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Sigurnost"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ekran;zaključano;dijagnosticiraj;sudar;privatno;nedavno;privremeno;tmp;"
+"indeks;ime;mreža;indentitet;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Ime uređaja"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Hardverska Adresa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memorija"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Računam…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Naziv"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "VPN Tip"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Verzija 0"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Učitavaju se opcije"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows softver"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualizacija"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Korištenje softvera"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Ukloni uređaj"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Ime uređaja"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_Ime korisničkog računa"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr "Pregled informacija o vašem sistemu"
 
-#. sure that you usi the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "uređaj;sistem;informacija;memorija:procesor;verzija;standardna;aplikacija;"
 "omiljeni;cd;dvd;usb;audio;video;disc;pokretan;medij;automatsko pokretanje;"
 
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "Odaberite kako bi se ostali mediji trebali pridržavati"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "_Radnja:"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "_Vrsta:"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "Ime uređaja"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "Memorija"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "Procesor"
-
-#. To translators: this field contains the distro nami, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "Osnovni sistem"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "Disk"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "Računam…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "Grafika"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "Virtualizacija"
-
-#: ../panels/info/info.ui.h:13
-msgid "Check for updates"
-msgstr "Provjeri ažuriranja"
-
-#: ../panels/info/info.ui.h:15
-msgid "_Web"
-msgstr "_Web"
-
-#: ../panels/info/info.ui.h:16
-msgid "_Mail"
-msgstr "_Pošta"
-
-#: ../panels/info/info.ui.h:17
-msgid "_Calendar"
-msgstr "_Kalendar"
-
-#: ../panels/info/info.ui.h:18
-msgid "M_usic"
-msgstr "M_uzika"
-
-#: ../panels/info/info.ui.h:19
-msgid "_Video"
-msgstr "_Video"
-
-#: ../panels/info/info.ui.h:20
-msgid "_Photos"
-msgstr "_Slike"
-
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "Odaberi kako bi se mediji trebali pridržavati"
-
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "CD _audio"
-
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "_DVD video"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "_Muzički program"
-
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "_Softver"
-
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "_Ostali mediji"
-
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr "_Ne pokreći programe po ubacivanju medija"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "Zvuk i mediji"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Ugasi zvuk"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Smanji zvuk"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Pojačaj zvuk"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Pokreni media plejer"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Sviraj (ili sviraj/pauza)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Pauziraj reprodukciju"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Zaustavi reprodukciju"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Prethodna numera"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Naredna numera"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Izbaci"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Tipkanje"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "Prijeđi na sljedeci ulaz"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "Prijeđi na prethodni ulaz"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "Pokretači"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Pokreni preglednik pomoći"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1604
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "Postavke"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Pokreni kalkulator"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "Pokreni program za e-poštu"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "Pokreni web preglednik"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "Početni direktorij"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "Traži"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "Snimci ekrana"
-
-#. translators: $PICTURES will bje replaced by the nami of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "Spasi snimke ekrana u $PICTURES"
-
-#. translators: $PICTURES will bje replaced by the nami of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Spasi snimke prozora  u $PICTURES"
-
-#. translators: $PICTURES will bje replaced by the nami of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Spasi snimke prostora ekrana u $PICTURES"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "Kopiraj snimak u  odlagalište"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Kopiraj snimak prozora u  odlagalište"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Kopiraj snimak područja u  odlagalište"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "Snimi kratku snimku ekrana"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistem"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "Odjava"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "Zaključaj ekran"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "Opšti pristup"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "Uključi/isključi uvećanje"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "Uvećaj"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "Umanji"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "Uključi/isključi čitač ekrana"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "Uključi/isključi ekransku tastaturu"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "Povećaj veličinu teksta"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "Smanji veličinu teksta"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "Uključi/isključi veliki kontrast"
 
-#. translators:
-#. * The djevice has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1219
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-msgid "Disabled"
-msgstr "Onemogućeno"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Dodaj Ulazne Izvore"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. Seje
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "Taster alternativnih znakova"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "Metode unosa ne mogu biti korištene na ekranu prijave"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * Seje http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "Taster za kompoziciju"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nije odabran ulazni izvor"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "Samo za ispravljače pređi za sljedeći izvor"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opcije"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Tastatura"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Pomjeri gore"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr ""
-"Pregled i promjena prečice za tastaturu i postavi svoje preferirano kucanje"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Pomjeri dolje"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Prečac;Ponovi;Blinkaj;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Postavke"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "Proizvoljna prečica"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Prečice sa tastature"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "_Ime:"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Ukloni"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "K_omanda:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "Ponavljanje tastera"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "_Ponovi pritiskanje tipki kada se tipka drži pritisnuta"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "_Odgoda:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "_Brzina:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "Kratko"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "Sporo"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "Brzina ponavljanja tastera"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "Dugo"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "Brzo"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "Treperenje kursora"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "Pokazivač _trepće u poljima za tekst"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "_Brzina:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "Brzina treptanja kursora"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "Ulazni izvori"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "Dodaj prečicu"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "Ukloni prečicu"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"Da bi ste uredili prečac, kliknite red i držite nove tastere ili Briši "
-"unazad da obrišete."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Opcije Ulaznog Izvora"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Koristi isti izvor za sve prozore"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "Omogući _različite izvore za svaki prozor"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "Taster alternativnih znakova"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Taster za kompoziciju"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Prečice sa tastature"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Proizvoljna prečica"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Odjeljak"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "Prečaci"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:636
-#: ../panels/keyboard/keyboard-shortcuts.c:644
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Dodaj prečicu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "Proizvoljna prečica"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:861
-msgid "<Unknown Action>"
-msgstr "<Nepoznata akcija>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1358
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"Prečica „%s“ ne može biti korišćena jer će biti nemoguće kucati koristeći "
-"ovaj taster.\n"
-"Pokušajte istovremeno sa tasterom kao što je Kontrol, Alt ili Šift."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1388
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Dodaj prečicu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Prečice sa tastature"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Ukloni"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "_Zamijeni"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"Prečica „%s“ se već koristi za\n"
-"„%s“"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1393
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"Ako ponovo dodijelite prečicu za „%s“, prečica za „%s“ će biti onemogućena."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1399
-msgid "_Reassign"
-msgstr "_Ponovo dodjeli"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Naziv"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1440
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "K_omanda:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+#, fuzzy
+msgid "Shortcut"
+msgstr "Prečaci"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Nova prečica…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ništa"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
 msgstr ""
-"\"%s\" prečica ima pridruženu \"%s\" prečicu . Želite li je automatski "
-"postaviti na \"%s\"?"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1450
-#, c-format
-msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
 msgstr ""
-"\"%s\" je trenutno povezan s \"%s\" , ovaj prečac će biti onemogućen ako se "
-"krene naprijed ."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1457
-msgid "_Assign"
-msgstr "_Dodijeli"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatura"
 
-#: ../panels/mouse/cc-mouse-panel.c:94
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Pregled i promjena prečice za tastaturu i postavi svoje preferirano kucanje"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "Usluge vezane za _Lokaciju"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Ni jedan program ne pušta ili snima zvuk."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Gasi se Ekran"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Nisu nađeni programi"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Provjeri Svoje _Postavke"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-msgid "Test Your Settings"
-msgstr "Provjeri Svoje Postavke"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Općenito"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "Primarna _tipka"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Lijevo"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Desno"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Traži Lokacije"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Miš"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "_Tipka miša"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Kliži prema dolje"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Kursor lupe se pomijera sa sadržajima"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktivno"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Dodirna površina"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Dodirna površina"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Metod"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "Tupni za _klik"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Tupni za _klik"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Onemogući sliku"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Dodirljiva ploča (relativno)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Kliži udesno"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Kliži ulijevo"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dvostrano"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Isprobajte klikanje, dvostruko klikanje, klizanje"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "Miš i dodirna ploča"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 "Promijeni osjetljivost svog miša ili dodirne ploče i odaberi za dešnjaka ili "
 "ljevaka"
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 "Podloga za traganje;Pokazivač;Klik;Tapši;Duplo;Dugme; Kugla za traganje;"
 "Spuštanje;"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "Općenito"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "Sporo"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "Vrijeme za dupli klik"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "Brzo"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "_Dupli klik"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Prostor boja: "
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "Primarna _tipka"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, lift button as primary"
-msgid "_Left"
-msgstr "_Lijevo"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "Automatski isprazni_Smeće"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "_Desno"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "Miš"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "Brzina _pokazivača"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "Sporo"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "%s monitor"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "Brzo"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "Dodirna površina"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "Sporo"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Aplikacije"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "Brzo"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Tap to _click"
-msgstr "Tupni za _klik"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Two _finger scroll"
-msgstr "_Skrol s dva prsta"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so usi the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
-msgid "_Natural scrolling"
-msgstr "_Standardno klizanje"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "Isprobajte klikanje, dvostruko klikanje, klizanje"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "Pet klikova, GEGL vrijeme!"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Uređaji"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "Dvostruki klik, primarna tipka"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "Jednostruki klik, primarna tipka"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Dodajte novu vezu"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "Dvostruki klik, srednja tipka"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "Jednostruki klik, srednja tipka"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Povezano"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "Dvostruki klik, sekundarna tipka"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opcije…"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "Jednostruki klik, sekundarna tipka"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:358
-msgid "Air_plane Mode"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "WI-Fi vruća tačka"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Ime mreže"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Lozinka"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Šifra grupe"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Trenutna_Lozinka"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Uključi"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
 msgstr "Avionski način"
 
-#: ../panels/network/cc-network-panel.c:966
-msgid "Network proxy"
-msgstr "Mrežni proxy"
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the djevice list.
-#.
-#: ../panels/network/cc-network-panel.c:1145 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Slike nisu nađene"
 
-#: ../panels/network/cc-network-panel.c:1299
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Avionski način"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "WI-Fi vruća tačka"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Koristi kao vruću tačku"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Mreže"
+
+#: panels/network/cc-wifi-panel.ui:297
+#, fuzzy
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager treba da bude pokrenut."
+
+#: panels/network/cc-wifi-panel.ui:303
 msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr ""
 "Ups, nešto je pošlo loše. Molim kontaktirajte vašeg isporučioca softvera."
 
-#: ../panels/network/cc-network-panel.c:1305
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager treba da bude pokrenut."
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _Sigurnost"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "strana 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "Anoni_mni identitet"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "Unutrašnja _autentikacija"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "strana 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "Sigurnost"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "automatski"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:218
-#: ../panels/network/net-device-wifi.c:382
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:222
-#: ../panels/network/net-device-wifi.c:387
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:226
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:231
-msgid "Enterprise"
-msgstr "Enterprajz"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:236
-#: ../panels/network/net-device-wifi.c:372
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nikakva"
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "Nikad"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:815
-msgid "Today"
-msgstr "Danas"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:818
-msgid "Yesterday"
-msgstr "Juče"
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:476
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
@@ -2071,1619 +2158,688 @@ msgstr[0] "Prije %i dan"
 msgstr[1] "Prije %i dana"
 msgstr[2] "Prije %i dana"
 
-#. Translators: network djevice speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:533
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nikakva"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Slaba"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "U redu"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:568
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Dobra"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:570
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Izvrsna"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "Identitet"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "Adresa"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "Mrežna maska"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "Mrežni izlaz"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "Obrisati adresu"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "Dodaj"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "Server"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "Obrisati DNS Server"
-
-#. Translators: Please seje https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "Metrički"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "Obrisati put"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP)"
-msgstr "Automatski (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:26
-#: ../panels/privacy/cc-privacy-panel.c:182
-msgid "Manual"
-msgstr "Ručno"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "Samo veži-lokalno"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "Prefiks"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:182
-msgid "Automatic"
-msgstr "Automatski"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "Automatski, samo DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:51
-msgid "Reset"
-msgstr "Resetuj"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ništa"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bitni ključ (Hex ili ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit lozinka"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dinamički WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "Lični WPA & WPA2"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "Poslovni WPA & WPA2"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Jačina Signala"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Brzina veze"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:157
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sigurnost"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 Adresa"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:158
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 Adresa"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:165
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Hardverska Adresa"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:169
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Podržani ICC profili"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Podrazumijevana putanja"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Posljednje korišteno"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "Parica (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Interfejs priložene jedinice (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "Medijski nezavisan interfejs (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "_Ime"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
-msgid "_MAC Address"
-msgstr "_MAC Adresa"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "M_TU"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "_Klonirana Adresa"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "bajtova"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "Omogući drugim _korisnicima"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "_Poveži se automatski"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "_Zona Zaštitnog zida"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:113
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "Podrazumijevano"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "Zona definira nivo povjerenja povezanosti"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
-msgstr "_Adrese"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "Automatski DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Routes"
-msgstr "Putanje"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "Automatske Putanje"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:34
-msgid "Use this connection _only for resources on its network"
-msgstr "Koristi ovu povezanost _samo za resurse na njegovoj mreži"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "Nemoguće otvoriti urednik povezanosti"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "Novi profil"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "Povez"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "Tim"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "Most"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "Nije  uspjelo unijeti VPN prključke"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "Uvezi iz datoteke"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "Dodati mrežnu konekciju"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "_Resetuj"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1441
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "_Zaboravi"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"Resetuj postavke za ovu mrežu,uključujući lozinke,ali zapamti je kao "
-"omiljenu mrežu"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"Ukloni sve detalje povezane sa ovom mrežom i ne pokušavaj automatsko "
-"povezivanje"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
-msgid "S_ecurity"
-msgstr "S_igurnost"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "Ne mogu da uvezem VPN vezu"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Ne mogu da pročitam datoteku „%s“ ili ona ne sadrži poznate VPN podatke o "
-"vezi\n"
-"\n"
-"Greška: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "Izaberite datoteku za uvoz"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1939
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "_Open"
-msgstr "_Otvori"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "Već postoji datoteka „%s“."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "_Zamijeni"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Da li želite da zamijenite %s VPN vezom koju hoćete da sačuvate?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "Ne mogu da izvezem VPN vezu"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN veza '%s' ne može biti izvezena u %s.\n"
-"\n"
-"Greška: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-msgid "Export VPN connection"
-msgstr "Izvoz VPN mreže"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(Greška, nemoguće uvesti VPN urednik veze)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "_SSID"
-msgstr "_SSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
-msgid "_BSSID"
-msgstr "_BSSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "_MojaStandardna Mreža"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Napravi dostupno _drugim korisnicima"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Ime"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC Adresa"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonirana Adresa"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bajtova"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "_Metod"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatski (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Samo veži-lokalno"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Ručno"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Onemogućeno"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "Podijeljeno sa drugim kompjuterima"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_Adrese"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresa"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Mrežna maska"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Mrežni izlaz"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Automatski"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatski DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Putanje"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatske Putanje"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "Metrički"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Koristi ovu povezanost _samo za resurse na njegovoj mreži"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "_Metod"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatski, samo DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefiks"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_igurnost"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Greška, nemoguće uvesti VPN urednik veze)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "Mreža"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+#: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Kontroliši povezivanje na Internet"
 
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Mreža;Wireless;Wi-Fi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;vlan;"
 "bridge;bond;DNS;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "Robovi veze"
-
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(nema)"
-
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "Robovi mosta"
-
-#: ../panels/network/net-device-ethernet.c:110
-#: ../panels/network/net-device-wifi.c:462
-msgid "never"
-msgstr "nikad"
-
-#: ../panels/network/net-device-ethernet.c:120
-#: ../panels/network/net-device-wifi.c:472
-msgid "today"
-msgstr "danas"
-
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:474
-msgid "yesterday"
-msgstr "juče"
-
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP Adresa"
-
-#: ../panels/network/net-device-ethernet.c:176
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "Zadnje koristeno"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * djevice list.
-#.
-#: ../panels/network/net-device-ethernet.c:286
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "Ožičeno"
-
-#: ../panels/network/net-device-ethernet.c:354
-#: ../panels/network/net-device-wifi.c:1597
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "Opcije…"
-
-#: ../panels/network/net-device-ethernet.c:472
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "Dodajte novu vezu"
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr "Robovi tima"
-
-#: ../panels/network/net-device-wifi.c:1154
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-"Ako imaate povezanost na internet koja nije bežična, možes kreirati bežičnu "
-"vruću tačku da dijeliš povezanost sa drugima."
-
-#: ../panels/network/net-device-wifi.c:1158
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "Uključivanjem bežične vruće tačke prekinućete vezu sa <b>%s</b>."
-
-#: ../panels/network/net-device-wifi.c:1162
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"Nije moguće pristupiti internetu preko vaše bežične veze dok je vruća tačka "
-"aktivna."
-
-#: ../panels/network/net-device-wifi.c:1245
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Da zaustavim vruću tačku i da prekinem vezu svim korisnicima?"
-
-#: ../panels/network/net-device-wifi.c:1248
-msgid "_Stop Hotspot"
-msgstr "_Zaustavi vruću tačku"
-
-#: ../panels/network/net-device-wifi.c:1305
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Pravila sistema zabranjuju korištenje vruće tačke"
-
-#: ../panels/network/net-device-wifi.c:1308
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Bežični uređaj ne podržava način vruće tačke"
-
-#: ../panels/network/net-device-wifi.c:1437
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Detalji netvorka za odabrani netvork, uključujući šifru i sve posebne "
-"promjene će biti izgubljene."
-
-#: ../panels/network/net-device-wifi.c:1750
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "Historija"
-
-#: ../panels/network/net-device-wifi.c:1754
-#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
-#: ../panels/wacom/cc-wacom-page.c:533
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "_Close"
-msgstr "_Zatvori"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1762
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Zaboravi"
-
-#. TRANSLATORS: this is when the usi leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "Web Proxy Autodiscovery se koristi kada URL-a konfiguracije nema."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "Ovo je preporučljivo za nepovjerljive javne mreže."
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "Proxy"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "_Dodaj Profil"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "Pružalac"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "Nikakav"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "Ručni"
-
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "Automatski"
-
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
-msgstr "_Metod"
-
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "_Konfiguracioni URL"
-
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "_HTTP Proxy"
-
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "H_TTPS proxy"
-
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "_FTP Proxy"
-
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "Domaćin čarapa"
-
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "_Ignoriši Domaćine"
-
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "Port za HTTP proxy"
-
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "Port za HTTPS proxy"
-
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "Port za FTP proxy"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "Port za Socks proxy"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "Isključi uređaj"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "Dodaj uređaj"
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "Ukloni uređaj"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN Tip"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "Ime grupe"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "Šifra grupe"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "Ime korisničkog računa"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr "Isključi VPN konekciju"
-
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "Automatska_Konekcija"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "detalji"
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "_Lozinka"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "Ništa"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "Prikaži Šifru"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr "Omogući drugim korisnicima"
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "identitet"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr "Automatski (DHCP) samo adrese"
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr "Link-samo lokalni"
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr "Podijeljeno sa drugim kompjuterima"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr "_Ignoriši automatski određene puteve"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr "_Kopirana MAC Adresa"
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr "hardver"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"Resetuj postavke za ovu konekciju na zadane, ali zapamti kao preferiranu "
-"konekciju."
-
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"Ukloni sve detalje povezane sa ovom mrežom i ne pokušavaj se automatski "
-"konektovati na nju."
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "reset"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "Hardver"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr "WI-Fi vruća tačka"
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Turn On"
-msgstr "_Uključi"
-
-#: ../panels/network/network-wifi.ui.h:54
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Turn Wi-Fi off"
-msgstr "Ugasi Wi-Fi"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Kontroliši povezivanje na Internet"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_Use as Hotspot…"
-msgstr "_Koristi kao vruću tačku"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Mreža;Wireless;Wi-Fi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;vlan;"
+"bridge;bond;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "_Connect to Hidden Network…"
-msgstr "_Konektuj na Skrivenu Mrežu"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Ožičeno"
 
-#: ../panels/network/network-wifi.ui.h:58
-msgid "_History"
-msgstr "_Historija"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Isključi uređaj"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Ugasi da se konektuje na Wi-Fi mrežu"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Aktivno"
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Pružalac"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP Adresa"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Mrežni proxy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP Proxy"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS proxy"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP Proxy"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Domaćin čarapa"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignoriši Domaćine"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Port za HTTP proxy"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Port za HTTPS proxy"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Port za FTP proxy"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Port za Socks proxy"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Konfiguracioni URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Isključi VPN konekciju"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Ime mreže"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Connected Devices"
-msgstr "Priključeni uređaji"
-
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Tip Sigrunosti"
 
-#: ../panels/network/network-wifi.ui.h:63
-msgid "Security key"
-msgstr "Sigurnosni ključ"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Lozinka"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Ugasi Wi-Fi"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "Infrastruktura"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Učitavaju se opcije"
 
-#. TRANSLATORS: djevice status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "Stanje je nepoznato"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Konektuj na Skrivenu Mrežu"
 
-#. TRANSLATORS: djevice status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "Neupravljivo"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "WI-Fi vruća tačka"
 
-#. TRANSLATORS: djevice status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "Nedostupno"
-
-#. TRANSLATORS: djevice status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "Povezujem"
-
-#. TRANSLATORS: djevice status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "Autentifikacija je potrebna"
-
-#. TRANSLATORS: djevice status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "Povezano"
-
-#. TRANSLATORS: djevice status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "Prekidanje veze"
-
-#. TRANSLATORS: djevice status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "Veza nije uspjela"
-
-#. TRANSLATORS: djevice status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "Stanje nije raspoloživo (nedostupno)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "Nije povezan"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "Nije uspjelo podešavanje"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "Nije uspjelo podešavanje IP-a"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "Isteklo je podešavanje IP-a"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "Tajne su bile zahtijevane ali nisu dane"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "Prekinuta je veza sa 802.1x suplikantom"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "Nije uspjelo podešavanje 802.1x suplikanta"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1x suplikant nije uspio"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Potvrđivanje identiteta 802.1x suplikanta je trajalo predugo"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "PPP servis neuspio u startu"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "PPP servis diskonektovan"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP neuspio"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "DHCP klijent neuspio u startu"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "Greška DHCP klijenta"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "Neuspjeh DHCP klijenta"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "Usluga dijeljene konekcije neuspjela u startu"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "Neuspjela usluga dijeljene konekcije"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "Neuspjela AutoIP usluga"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "Greška AutoIP usluge"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "Neuspjela AutoIP usluga"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "Linija zauzeta"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "Nema pozivnog tona"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "Zvučni nosač se ne može uspostaviti"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "Isteklo je vrijeme zahtjeva pozivanja"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "Pokušaj pozivanja nije uspeo"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "Inicijalizacija modema neuspjela"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "Neuspio izbor navedenog APN"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "Ne tražim mreže"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "Odbijena registracija mreža"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "Istekla registracija mreža"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "Neuspjela registracija na navedenu mrežu"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "Provjera PIN-a neuspjela"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "Možda nedostaje firmver za uređaj"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "Veza je nestala"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "Postojeća veza biće pretpostavljena"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "Nije pronađen modem"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "Veza Bluetooth nije uspjela"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "SIM kartica nije ubačena"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "Potreban je SIM PIN"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "Potreban je SIM PUK"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "Pogrešna SIM"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "InfiniBand uređaj ne podržava povezani režim"
-
-#. TRANSLATORS: djevice status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "Nije uspjela zavisnost veze"
-
-#. TRANSLATORS: djevice status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "Firmver nedostaje"
-
-#. TRANSLATORS: djevice status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "Izvučen kabl"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "Nije izabran sertifikat Potvrđivanja Autoriteta (CA)"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"Nekorištenje certikata koji je potvrdio Certifikacijski autoritet (CA) može "
-"rezultirati u konekcijama do nesigurnih Wi-Fi mreže. Želite li odabrati "
-"certifikat certifikacijskog autoriteta?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "Ignoriši"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "Izaberite certifikat PA (CA)"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, ili PKCS#12 lični ključevi (*.der, *.pijem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER ili PEM sertifikati (*.der, *.pijem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-msgid "Choose a PAC file"
-msgstr "Izaberi PAC datoteku"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC datoteke (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC_datoteka"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "_Unutrašnja autentifikacija"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "PAC pro_vizije"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "Anoniman"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "Autentifikovan"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "Obostrano"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anoni_mni identitet"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC_datoteka"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Izaberi PAC datoteku"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Unutrašnja autentifikacija"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC pro_vizije"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_Ime korisničkog računa"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Lozinka"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Prikaži _lozinku"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate"
-msgstr "Izaberi certifikat Certificate Authority"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "Verzija 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "Verzija 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "C_A certifikat"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Izaberi certifikat Certificate Authority"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Autentifikacija je potrebna"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP_verzija"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "Uvijek mi zatraži _lozinku"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "Nešifrovani privatni ključevi nisu sigurni"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Izgleda da izabrani privatni ključ nije zaštićen lozinkom.  Ovo može "
-"ugroziti vaše sigurnosne podatke.  Izaberite privatni ključ koji je zaštićen "
-"lozinkom.\n"
-"\n"
-"(Možete zaštititi privatne ključeve koristeći openssl)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-msgid "Choose your personal certificate"
-msgstr "Izaberi svoj lični certifikat"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-msgid "Choose your private key"
-msgstr "Izaberite lični ključ"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "I_dentitet"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "_Korisnički certifikat"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "Lični _ključ"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Lična lozinka za ključ"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "Ne _upozoravaj me više"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domena"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "Ne"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "Da"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "BRZO"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "Tunelski TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "Zaštićeni EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Au_tentifikacija"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (Podrazumijevano)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "Otvoreni sistem"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "Dijeljeni ključ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "_Ključ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "P_rikaži ključ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP inde_x"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Vrsta"
 
-#: ../panels/notifications/cc-notifications-panel.c:247
-#: ../panels/power/cc-power-panel.c:1711 ../panels/power/cc-power-panel.c:1718
-#: ../panels/privacy/cc-privacy-panel.c:155
-#: ../panels/privacy/cc-privacy-panel.c:222
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "Uključiti"
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Podrazumijevano)"
 
-#. This is the pir application switch for message tray usage.
-#: ../panels/notifications/edit-dialog.ui.h:2
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Otvoreni sistem"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Dijeljeni ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "P_rikaži ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP inde_x"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "Napomene"
 
 #. This is the setting to configure sounds associated with notifications.
-#: ../panels/notifications/edit-dialog.ui.h:4
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "Zvučna Upozorenja"
 
-#: ../panels/notifications/edit-dialog.ui.h:5
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Notification Banners"
-msgstr "Trake obavještenja "
-
-#. Banners here refers to message tray notifications in the middle of the screen.
-#: ../panels/notifications/edit-dialog.ui.h:7
-msgctxt "notifications"
-msgid "Show Message Content in Banners"
-msgstr "Prikaži sadržaj poruke u Trakama"
-
-#: ../panels/notifications/edit-dialog.ui.h:8
-msgctxt "notifications"
-msgid "Lock Screen Notifications"
-msgstr "Zaključaj obavještenja na ekranu"
-
-#: ../panels/notifications/edit-dialog.ui.h:9
-msgctxt "notifications"
-msgid "Show Message Content on Lock Screen"
-msgstr "Prikaži sadržaj poruke u Zaključanom Ekranu"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "Napomene"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Prikaži sadržaj poruke u Trakama"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Zaključaj obavještenja na ekranu"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Prikaži sadržaj poruke u Zaključanom Ekranu"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Zaključaj obavještenja na ekranu"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "Kontroliši koje napomene su prikazane i šta prikazuju"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Napomene;Trake;poruke;Poslužavnik;Skočni;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Notification Banners"
-msgstr "Trake obavještenja"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Lock Screen Notifications"
-msgstr "Zaključaj obavještenja na ekranu"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Unutrašnja _autentikacija"
 
-#. List of applications.
-#: ../panels/notifications/notifications.ui.h:4
-#: ../panels/sound/gvc-mixer-dialog.c:1781
-msgid "Applications"
-msgstr "Aplikacije"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Ostali"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
-msgstr "Dodaj nalog"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Dodajte nalog na mreži"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
-msgstr "Elektronska pošta"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr "Kontakti"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "Razgovor"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "Resursi"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "Greška prilikom prijavljivanja na nalog"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "Uvjerenja su istekla."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr "Prijavi se da omogućiš ovaj račun."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr "_Prijavi se"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "Greška prilikom stvaranja naloga"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Greška prilikom uklanjanja naloga"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "Da li ste sigurni da želite da uklonite nalog?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "Ovo neće ukloniti nalog na serveru."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "_Ukloni"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Nalozi na mreži"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Konektuj se na svoj online račun i odluči za šta ćeš ih koristiti"
 
-#. For ReadItLater and Pocket, seje http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -3691,31 +2847,7 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Kalendar;Mail;Kontakt;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "Nisu podešeni nalozi na mreži"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "Ukloni nalog"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "Dodajte nalog na mreži"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"Dodavanje naloga omogućava vašim aplikacijama da mu pristupe zbog "
-"dokumenata, pošte, kontakata, kalendara, ćaskanja i drugih stvari."
-
-#: ../panels/power/cc-power-panel.c:192
-msgid "Unknown time"
-msgstr "Nepoznato vrijeme"
-
-#: ../panels/power/cc-power-panel.c:198
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
@@ -3723,7 +2855,7 @@ msgstr[0] "%i minut"
 msgstr[1] "%i minuta"
 msgstr[2] "%i minuta"
 
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
@@ -3731,2295 +2863,1952 @@ msgstr[0] "%i sat"
 msgstr[1] "%i sata"
 msgstr[2] "%i sati"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:218
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s, %i %s"
-
-#: ../panels/power/cc-power-panel.c:219
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "sat"
 msgstr[1] "sata"
 msgstr[2] "sati"
 
-#: ../panels/power/cc-power-panel.c:220
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
 msgstr[1] "minuta"
 msgstr[2] "minuta"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:239
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s dok se ne napuni u potpunosti"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minuta"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:246
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Oprez: %s preostalo"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 minuta"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:251
-#, c-format
-msgid "%s remaining"
-msgstr "preostaje %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 minuta"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:256 ../panels/power/cc-power-panel.c:284
-msgid "Fully charged"
-msgstr "Napunjeno"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minuta"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:260 ../panels/power/cc-power-panel.c:288
-msgid "Empty"
-msgstr "Prazno"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minuta"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:275
-msgid "Charging"
-msgstr "Punjenje je u toku"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 sat"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:280
-msgid "Discharging"
-msgstr "Prazni se"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minuta"
 
-#: ../panels/power/cc-power-panel.c:405
-msgctxt "Battery nami"
-msgid "Main"
-msgstr "Glavni"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minuta"
 
-#: ../panels/power/cc-power-panel.c:407
-msgctxt "Battery nami"
-msgid "Extra"
-msgstr "Dodatno"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minuta"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Wireless mouse"
-msgstr "Bežični miš"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 sata"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Wireless keyboard"
-msgstr "Bežična tastatura"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Uninterruptible power supply"
-msgstr "Neprekidni izvor napajanja"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Personal digital assistant"
-msgstr "Lični digitalni pomoćnik"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Cellphone"
-msgstr "Mobilni telefon"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:494
-msgid "Media player"
-msgstr "Muzički uređaj"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:497
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:500
-msgid "Computer"
-msgstr "Računar"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:503 ../panels/power/cc-power-panel.c:734
-#: ../panels/power/cc-power-panel.c:2040
+#: panels/power/cc-power-panel.ui:58
 msgid "Battery"
 msgstr "Baterija"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Puni se"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:564
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Upozorenje"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:569
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Nisko"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:574
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Dobro"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:579
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Napunjeno"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:583
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Prazno"
-
-#: ../panels/power/cc-power-panel.c:732
-msgid "Batteries"
-msgstr "Baterije"
-
-#: ../panels/power/cc-power-panel.c:1134
-msgid "When _idle"
-msgstr "Kad_nepokretan"
-
-#: ../panels/power/cc-power-panel.c:1462
-msgid "Power Saving"
-msgstr "Ušteda energije"
-
-#: ../panels/power/cc-power-panel.c:1490
-msgid "_Screen brightness"
-msgstr "_Osvjetljenost ekrana"
-
-#: ../panels/power/cc-power-panel.c:1496
-msgid "_Keyboard brightness"
-msgstr "_Osvjetljenost tastatura"
-
-#: ../panels/power/cc-power-panel.c:1506
-msgid "_Dim screen when inactive"
-msgstr "_Zamrači ekran kad je neaktivan"
-
-#: ../panels/power/cc-power-panel.c:1531
-msgid "_Blank screen"
-msgstr "_Prazan ekran"
-
-#: ../panels/power/cc-power-panel.c:1568
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: ../panels/power/cc-power-panel.c:1573
-msgid "Wireless devices require extra power"
-msgstr "Bežični uređaji zahtijevaju dodatno napajanje"
-
-#: ../panels/power/cc-power-panel.c:1598
-msgid "_Mobile broadband"
-msgstr "_Širokopojasna veza"
-
-#: ../panels/power/cc-power-panel.c:1603
-msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
-msgstr ""
-"Mobilni širokopojasni uređaji(3G, 4G, WiMax, itd.) zahtijevaju dodatno "
-"napajanje"
-
-#: ../panels/power/cc-power-panel.c:1653
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: ../panels/power/cc-power-panel.c:1707
-msgid "When on battery power"
-msgstr "Kada se napaja baterijom"
-
-#: ../panels/power/cc-power-panel.c:1709
-msgid "When plugged in"
-msgstr "Kada je prikopčano"
-
-#: ../panels/power/cc-power-panel.c:1839
-msgid "Suspend & Power Off"
-msgstr "Obustavljen & Ugašen"
-
-#: ../panels/power/cc-power-panel.c:1872
-msgid "_Automatic suspend"
-msgstr "_Automatski obustavljen"
-
-#: ../panels/power/cc-power-panel.c:1896
-msgid "When battery power is _critical"
-msgstr "Kada  je jačina  baterije _kritična"
-
-#: ../panels/power/cc-power-panel.c:1951
-msgid "Power Off"
-msgstr "Ugasi"
-
-#: ../panels/power/cc-power-panel.c:2087
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
 msgid "Devices"
 msgstr "Uređaji"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Ugasi"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Ušteda energije"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "_Osvjetljenost ekrana"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Ekran"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "_Čitač Ekrana"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "_Automatsko javljanje problema"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Automatski Obustavi"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Niže dugme"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatski Obustavi"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Uključeno"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Na_Energiji Baterije"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Odgoda"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Napajanje"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+#: panels/power/gnome-power-panel.desktop.in.in:4
 msgid "View your battery status and change power saving settings"
 msgstr "Prikaži stanje baterije i promijeni postavke čuvanja energije"
 
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "Energija;Uspavaj;Obustavi;Zaledi;Baterija;Osvjetljenost;Zamrači;Prazan;"
 "Monitor;DPMS;Nepomičan;"
 
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "Hibernacija"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "Ugasi"
-
-#: ../panels/power/power.ui.h:5
-msgid "45 minutes"
-msgstr "45 minuta"
-
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
-msgid "1 hour"
-msgstr "1 sat"
-
-#: ../panels/power/power.ui.h:7
-msgid "80 minutes"
-msgstr "80 minuta"
-
-#: ../panels/power/power.ui.h:8
-msgid "90 minutes"
-msgstr "90 minuta"
-
-#: ../panels/power/power.ui.h:9
-msgid "100 minutes"
-msgstr "100 minuta"
-
-#: ../panels/power/power.ui.h:10
-msgid "2 hours"
-msgstr "2 sata"
-
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 minuta"
-
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 minuta"
-
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 minute"
-
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "4 minute"
-
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 minuta"
-
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "8 minuta"
-
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 minuta"
-
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "12 minuta"
-
-#: ../panels/power/power.ui.h:20
-msgid "Automatic Suspend"
-msgstr "Automatski Obustavi"
-
-#: ../panels/power/power.ui.h:21
-msgid "_Plugged In"
-msgstr "_Uključeno"
-
-#: ../panels/power/power.ui.h:22
-msgid "On _Battery Power"
-msgstr "Na_Energiji Baterije"
-
-#: ../panels/power/power.ui.h:23
-msgid "Delay"
-msgstr "Odgoda"
-
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "Autenticiraj"
-
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "Lozinka"
-
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "Obavezna provjera autentičnosti"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:588
-msgid "Low on toner"
-msgstr "Nizak nivo tonera"
-
-#. Translators: The printer has no toner lift
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Out of toner"
-msgstr "Nema tonera"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:593
-msgid "Low on developer"
-msgstr "Ima malo fotografskog proizvođača"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:596
-msgid "Out of developer"
-msgstr "Nema fotografskog proizvođača"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Low on a marker supply"
-msgstr "Ima malo zaliha markera"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Out of a marker supply"
-msgstr "Nema zaliha markera"
-
-#. Translators: One or more covers on the printer are opijen
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Open cover"
-msgstr "Otvori pokrivač na štampaču"
-
-#. Translators: One or more doors on the printer are opijen
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open door"
-msgstr "Otvori vratanca na štampaču"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Low on paper"
-msgstr "Ima malo papira"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Out of paper"
-msgstr "Nema papira"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:610
-msgctxt "printer stati"
-msgid "Offline"
-msgstr "Van mreže"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's stati (no jobs can bje processed)
-#: ../panels/printers/cc-printers-panel.c:612
-#: ../panels/printers/cc-printers-panel.c:803
-msgctxt "printer stati"
-msgid "Stopped"
-msgstr "Zaustavljen"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:614
-msgid "Waste receptacle almost full"
-msgstr "Posuda za smeće je skoro puna"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle full"
-msgstr "Posuda za smeće je puna"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "The optical photo conductor is near end of life"
-msgstr "Optički fotoprovodnik je blizu kraja života"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Optički fotoprovodnik više nije u funkciji"
-
-#. Translators: Printer's stati (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:730
-msgctxt "printer stati"
-msgid "Configuring"
-msgstr "Podešavam"
-
-#. Translators: Printer's stati (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:789
-msgctxt "printer stati"
-msgid "Ready"
-msgstr "Spreman"
-
-#. Translators: Printer's stati (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:794
-msgctxt "printer stati"
-msgid "Does not accept jobs"
-msgstr "Ne prihvata poslove"
-
-#. Translators: Printer's stati (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:799
-msgctxt "printer stati"
-msgid "Processing"
-msgstr "Obrada"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:919
-msgid "Toner Level"
-msgstr "Nivo tonera"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Ink Level"
-msgstr "Nivo mastila"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Supply Level"
-msgstr "Nivo zaliha"
-
-#. Translators: Printer's stati (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:943
-msgctxt "printer stati"
-msgid "Installing"
-msgstr "Instaliranje"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1119
-msgid "No printers available"
-msgstr "Nije nađen nijedan štampač"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1429
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u aktivan"
-msgstr[1] "%u aktivna"
-msgstr[2] "%u aktivna"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1768
-msgid "Failed to add new printer."
-msgstr "Nisam uspjeo da dodam novi štampač."
-
-#: ../panels/printers/cc-printers-panel.c:1935
-msgid "Select PPD File"
-msgstr "Izaberite PPD datoteku"
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Datoteke opisa PostScript štampača (*.ppd,*.PPD, *.ppd.gz, *PPD.gz, *.PPD.GZ)"
-
-#: ../panels/printers/cc-printers-panel.c:2251
-msgid "No suitable driver found"
-msgstr "Nisu pronađeni odgovarajući upravljački programi"
-
-#: ../panels/printers/cc-printers-panel.c:2322
-msgid "Searching for preferred drivers…"
-msgstr "Traži preferirane drajvere"
-
-#: ../panels/printers/cc-printers-panel.c:2343
-msgid "Select from database…"
-msgstr "Odaberi iz baze podataka"
-
-#: ../panels/printers/cc-printers-panel.c:2352
-msgid "Provide PPD File…"
-msgstr "Obezbijedi PPD Datoteku…"
-
-#. Translators: Nami of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2503
-#: ../panels/printers/cc-printers-panel.c:2526
-msgid "Test page"
-msgstr "Test strana"
-
-#. Translators: The XML file containing user interface can not bje loaded
-#: ../panels/printers/cc-printers-panel.c:2940
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Nije moguće učitati UI: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "Štampači"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Dodaj printere,prikaži poslove printera i odluči kako želiš printati"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Štampač;Red;Štampa;Papir;Mastilo;Toner;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "Aktivni zadaci"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "Zatvoreno"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "Nastavi štampanje"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "Pauziraj štampanje"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "Otkaži posao štampanja"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "Dodaj novi štampač"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "A_uthenticate"
-msgstr "A_utentifikuj"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "Nema otkrivenih štampača."
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-msgid "Enter a network address or search for a printer"
-msgstr "Unesite mrežnu adresu ili tražite printer"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "Učitavaju se opcije"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "Izaberite upravljački program štampača"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "Učitavam bazu podataka upravljačkih programa..."
-
-#. Translators: The found djevice is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-msgid "JetDirect Printer"
-msgstr "JetDirect Printer"
-
-#. Translators: The found djevice is a Linije Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-msgid "LPD Printer"
-msgstr "LPD Printer"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "Jednostrano"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "Duga ivica (Standard)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "Kratka ivica (Flip)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "Portret"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "Pejzaž"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "Obrnuti pejzaž"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "Prevrnuti portret"
-
-#. Translators: Job's stati (job is waiting to bje printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "U tijeku"
-
-#. Translators: Job's stati (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "Zadržan"
-
-#. Translators: Job's stati (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "U obradi"
-
-#. Translators: Job's stati (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Zaustavljen"
-
-#. Translators: Job's stati (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Otkazan"
-
-#. Translators: Job's stati (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Obustavljen"
-
-#. Translators: Job's stati (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Završen"
-
-#. Translators: Nami of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "Ime posla"
-
-#. Translators: Nami of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "Stanje posla"
-
-#. Translators: Nami of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "Vrijeme"
-
-#: ../panels/printers/pp-jobs-dialog.c:451
-#, c-format
-msgid "%s Active Jobs"
-msgstr "Aktivni poslovi %s"
-
-#. Translators: The found djevice is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1620
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found djevice is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1625
-msgid "Serial Port"
-msgstr "Serijski port"
-
-#. Translators: The found djevice is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1632
-msgid "Parallel Port"
-msgstr "Paralelni port"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1688
-#, c-format
-msgid "Location: %s"
-msgstr "Lokacija: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1693
-#, c-format
-msgid "Address: %s"
-msgstr "Adresa: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1717
-msgid "Server requires authentication"
-msgstr "Server zahtijeva autentifikaciju"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "Dvostrano"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "Tip papira"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "Izvor papira"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "Izlazna ladica"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript predfilter"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:533
-msgid "Pages per side"
-msgstr "Stranica na strani"
-
-#. Translators: This option sets whether to print on both sides of papir
-#: ../panels/printers/pp-options-dialog.c:545
-msgid "Two-sided"
-msgstr "Dvostrano"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:557
-msgid "Orientation"
-msgstr "Orijentacija"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Opšte"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, papir source, etc.)
-#: ../panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Postavka stranice"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opcije instaliranja"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Posao"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Kvalitet slike"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Boja"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Završavam"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:675
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Napredno"
-
-#. Translators: this is an option of "Papir Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "Automatski izbor"
-
-#. Translators: this is an option of "Papir Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "Predefinisano na štampaču"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "Ugradi samo GhostScript fontove"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "Prevedi u 1. nivo postskripta"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "Prevedi u 2. nivo postskripta"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "Bez predfiltriranja"
-
-#. Translators: Nami of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "Proizvođač"
-
-#. Translators: Nami of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "Upraviteljski program"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-"Unesi svoje korisničko ime i lozinku da se prikažu dostupni printeri na %s."
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Dodaj štampač"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "Ukloni štampač"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "Zalihe"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Slike nisu nađene"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Unesite mrežnu adresu ili tražite printer"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Obavezna provjera autentičnosti"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Unesi svoje korisničko ime i lozinku da se prikažu dostupni printeri na %s."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Ime korisničkog računa"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Lokacija"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default printer"
-msgstr "_Zadani printer"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Upraviteljski program"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "Poslovi"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Traži preferirane drajvere"
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "Prikaži _Poslove"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "Traži grad"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "Odaberi iz baze podataka"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Obezbijedi PPD Datoteku…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Izaberite upravljački program štampača"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "Učitavam bazu podataka upravljačkih programa..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Odustani"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Odaberi"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "Server zahtijeva autentifikaciju"
+msgstr[1] "Server zahtijeva autentifikaciju"
+msgstr[2] "Server zahtijeva autentifikaciju"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "_Domena"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utentifikuj"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Autenticiraj"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "Aktivni poslovi %s"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Test strana"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Opcije prijave"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Predefinisano na štampaču"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Predefinisano na štampaču"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "Otkaži posao štampanja"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Ukloni štampač"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Aktivni zadaci"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "oznaka"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nivo mastila"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "Postavljanje novog drajvera"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "strana 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "Štampaj _Test stranicu"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "_Opcije"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "Restartuj Sada"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "Dodaj novi štampač"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Dodaj štampač"
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Štampači"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Izvinjavamo se! Servis štampe\n"
 "se ne čini dostupnim."
 
-#: ../panels/privacy/cc-privacy-panel.c:352 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "Zaključan Ekran"
-
-#: ../panels/privacy/cc-privacy-panel.c:462 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "Upotreba & Historija"
-
-#: ../panels/privacy/cc-privacy-panel.c:587
-msgid "Empty all items from Trash?"
-msgstr "Da li da izbacim sve stavke iz smeća?"
-
-#: ../panels/privacy/cc-privacy-panel.c:588
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Sve stavke iz smeća će biti trajno uklonjene."
-
-#: ../panels/privacy/cc-privacy-panel.c:589 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "_Isprazni smeće"
-
-#: ../panels/privacy/cc-privacy-panel.c:612
-msgid "Delete all the temporary files?"
-msgstr "Izbriši sve privremene datoteke?"
-
-#: ../panels/privacy/cc-privacy-panel.c:613
-msgid "All the temporary files will be permanently deleted."
-msgstr "Sve privremene datoteke će biti trajno izbrisane."
-
-#: ../panels/privacy/cc-privacy-panel.c:614 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "_Očisti Privremene Datoteke"
-
-#: ../panels/privacy/cc-privacy-panel.c:636 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "Očisti Smeće & Privremene Datoteke"
-
-#: ../panels/privacy/cc-privacy-panel.c:676 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr "Korištenje softvera"
-
-#: ../panels/privacy/cc-privacy-panel.c:717 ../panels/privacy/privacy.ui.h:44
-msgid "Problem Reporting"
-msgstr "Javljanje problema"
-
-#. translators: '%s' is the distributor's nami, such as 'Fedora'
-#: ../panels/privacy/cc-privacy-panel.c:731
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-"Slanje izvještaja o tehničkim problemima nam pomaže da se poboljša %s. "
-"Izvještaji se anonimno šalju bez ličnih podataka."
-
-#: ../panels/privacy/cc-privacy-panel.c:743 ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "Polica privatnosti"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "Privatnost"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr "Zaštiti svoje privatne informacije i kontrole koje ostali mogu vidjeti"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"ekran;zaključano;dijagnosticiraj;sudar;privatno;nedavno;privremeno;tmp;"
-"indeks;ime;mreža;indentitet;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "Gasi se Ekran"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 sekundi"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 dan."
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 dana"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 dana"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 dana"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 dana"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 dana"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 dana"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 dana"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 dana"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "Zauvijek"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"Pamćenje historije olakšava ponovno traženje stvari.Ove stavke nisu nikad "
-"podijeljene preko mreže."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "_Nedavno Korišteno"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "Zadrži _Historiju"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "Očisti Nedavnu Historiju"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "Zaključavanje Ekrana štiti vašu privatnost kada niste tu."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "Automatsko Zaključavanje _Ekrana"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "Zaključaj ekran nakon praznog za"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "Prikaži _Napomene"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"Automatski očisti Smeće i privremene datoteke da pomognete održati svoj "
-"kompjuter čist od nepotrebnih osjetljivih informacija."
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "Automatski isprazni_Smeće"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "Automatski očisti Privremene_Datoteke"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "Očisti_Nakon"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"Slanjem informacije o tome koji program koristite pomažete nam da Vam "
-"ponudimo više tačnih preporuka . To nam također pomaže da poboljšamo "
-"softver ."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "_Pošalji statistiku o korištenju softvera"
-
-#: ../panels/privacy/privacy.ui.h:42
-msgid "_Location Services"
-msgstr "Usluge vezane za _Lokaciju"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "Koristi se za određivanje svog geografskog položaja"
-
-#: ../panels/privacy/privacy.ui.h:45
-msgid "_Automatic Problem Reporting"
-msgstr "_Automatsko javljanje problema"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperijal"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrički"
-
-#: ../panels/region/cc-format-chooser.c:286
-msgid "No regions found"
-msgstr "Nisu pronađene regije"
-
-#: ../panels/region/cc-input-chooser.c:180
-msgid "No input sources found"
-msgstr "Nisu pronađeni ulazni izvori"
-
-#: ../panels/region/cc-input-chooser.c:1084
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Ostali"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:1064
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "Vaša sesija se mora restartovati da bi se aktivirali promjene"
-
-#: ../panels/region/cc-region-panel.c:243
-#: ../panels/user-accounts/um-user-panel.c:1068
-msgid "Restart Now"
-msgstr "Restartuj Sada"
-
-#: ../panels/region/cc-region-panel.c:862
-msgid "No input source selected"
-msgstr "Nije odabran ulazni izvor"
-
-#: ../panels/region/cc-region-panel.c:1703
-msgid "Login Screen"
-msgstr "Prijavni ekran"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formati"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Traži Lokacije"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Formati"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Formati"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Pretpregled"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Datumi"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "Vremena"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Datum i vrijeme"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Brojevi"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Mjerenje"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Papir"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Moj račun"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Jezik"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "Formati"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "Prijavni ekran"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Region & jezik"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr ""
 "Odaberi prikazni jezik,formu,raspored slova na tastaturi i ulazne izvore"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Jezik;Raspored;Tastatura;Ulaz;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "Dodaj Ulazne Izvore"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Odaberi kako bi se mediji trebali pridržavati"
 
-#: ../panels/region/input-chooser.ui.h:4
-msgid "Input methods can't be used on the login screen"
-msgstr "Metode unosa ne mogu biti korištene na ekranu prijave"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _audio"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "Opcije Ulaznog Izvora"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD video"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Use the _same source for all windows"
-msgstr "Koristi isti izvor za sve prozore"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Muzički program"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Allow _different sources for each window"
-msgstr "Omogući _različite izvore za svaki prozor"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Softver"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Keyboard Shortcuts"
-msgstr "Prečice sa tastature"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Ostali mediji"
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Switch to previous source"
-msgstr "Pređi na prethodni izvor"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Ne pokreći programe po ubacivanju medija"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Razmak"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Odaberite kako bi se ostali mediji trebali pridržavati"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Switch to next source"
-msgstr "Pređi na naredni izvor"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Radnja:"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "Super+Space"
-msgstr "Super+Razmak"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Vrsta:"
 
-#: ../panels/region/input-options.ui.h:10
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "Možete promijeniti ove prečice u postavkama tastature"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Pokretni mediji"
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Alternative switch to next source"
-msgstr "Alternativni prijelaz na drugi izvor"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Pokretni mediji"
 
-#: ../panels/region/input-options.ui.h:12
-msgid "Left+Right Alt"
-msgstr "Lijevo+Desno Alt"
-
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "Engleski (Ujedinjeno Kraljevstvo)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "Ujedinjeno Kraljevstvo"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "Opcije"
-
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"Prijavljene postavke koriste svi korisnici kada su prijavljeni na sistem"
+"uređaj;sistem;informacija;memorija:procesor;verzija;standardna;aplikacija;"
+"omiljeni;cd;dvd;usb;audio;video;disc;pokretan;medij;automatsko pokretanje;"
 
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Zaključan Ekran"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "_Prazan ekran"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatsko Zaključavanje _Ekrana"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "Automatsko Zaključavanje _Ekrana"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Prikaži _Napomene"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Zaključaj ekran"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Privatnost"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Dijeljenje ekrana"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Traži Lokacije"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
 msgid "Places"
 msgstr "Mjesta"
 
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
 msgid "Bookmarks"
 msgstr "Zabilješke"
 
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Ostali"
 
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "Odaberi Lokaciju"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Lokacija"
 
-#: ../panels/search/cc-search-locations-dialog.c:682
-msgid "_OK"
-msgstr "U _redu"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Aplikacije"
 
-#: ../panels/search/cc-search-panel.c:177
-msgid "No applications found"
-msgstr "Nisu nađeni programi"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "Traži"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Traži Lokacije"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 "Kontrolira koji programi prikazuju rezultate pretrage u Pregledu Aktivnosti"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Pretraga;Pronađi;Sakri;rivatnost;Rezultati;"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr "Traži Lokacije"
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Mreže"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "Pomjeri gore"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "Pomjeri dolje"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "Postavke"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Uključiti"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Isključiti"
-
-#: ../panels/sharing/cc-sharing-panel.c:304
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Omogući"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktivno"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "Odaberi direktorij"
-
-#: ../panels/sharing/cc-sharing-panel.c:917
-msgid "Copy"
-msgstr "Kopiranje"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Dijeljenje"
 
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
+msgstr "Ime računara"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Dijeljenje ličnih datoteka"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "Dijeljenje medija"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "Udaljena prijava"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Dijeljenje"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "Lozinka potrebna"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Udaljena prijava"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Udaljena prijava"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Omogući ili onemogući prijavu iz daljine"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Dopusti upravljanje daljinskim upravljačem"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Nije povezan"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopiranje"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Obrisati adresu"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Au_tentifikacija"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Ime korisničkog računa"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Upisujem otiske prstiju"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Dijeljenje medija"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+#, fuzzy
+msgid "Share music, photos and videos over the network."
+msgstr ""
+"Dijeljen je medija vam omogućava da podijelite muziku, fotografije i video "
+"zapise putem mreže."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Direktorij"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
 msgstr "Kontroliši šta želiš dijeliti sa ostalima"
 
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 msgstr ""
 "podijeli;djeljenje;ssh;domaćin;ime;udaljeno;radna površina;bluetooth;medij;"
 "audio;video;slike;fotografije;filmovi;server;"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
 msgstr "Omogući ili onemogući prijavu iz daljine"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Autentifikacija je potrebna za omogućenje ili onemogućenje prijave  iz "
 "daljine"
 
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:303
-msgid "No networks selected for sharing"
-msgstr "Nema mreža odabranih za dijeljenje"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
-msgid "Networks"
-msgstr "Mreže"
-
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "Djeljenje bluetoothom"
-
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
 msgstr ""
-"Djeljenje bluetoothom omogućava vam da podijelite datoteke sa drugim "
-"uključenim bluetooth uređajima"
 
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "Primi samo od Povjerljivih Uređaja"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Dijeljenje"
 
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "Spasi primljene datoteke u Downloads direktorij"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
-msgstr "Ime računara"
-
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
-msgstr "Dijeljenje ličnih datoteka"
-
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "Dijeljenje ekrana"
-
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
-msgstr "Dijeljenje medija"
-
-#: ../panels/sharing/sharing.ui.h:9
-msgid "Remote Login"
-msgstr "Udaljena prijava"
-
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "Neki uređaji su onesposobljeni jer nemaju pristup mreži."
-
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
-msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
-"Dijeljene privatnih datoteka omogućuje vam da dijelite vas Privatni "
-"direktorij sa ostalim na vašoj trenutnoj mreži koristeći: <a href=\"dav://%s"
-"\">dav://%s</a>"
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr "Lozinka potrebna"
-
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
 msgstr ""
-"Omogući udaljene korisnike da se konektuju koristeći Sigurnu Školjka "
-"komandu \n"
-"<a href=\"ssh %s\">ssh %s</a>"
 
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"Omogući udaljenim korisnicima da vide ili kontrolišu vaš ekran konektujući "
-"se na: <a href=\"vnc://%s\">vnc://%s</a>"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Balans:"
 
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Allow Remote Control"
-msgstr "Dopusti upravljanje daljinskim upravljačem"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Izblijedi:"
 
-#: ../panels/sharing/sharing.ui.h:21
-msgid "Password:"
-msgstr "Lozinka:"
-
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "Prikaži lozinku"
-
-#: ../panels/sharing/sharing.ui.h:23
-msgid "Access Options"
-msgstr "Mogućnosti pristupa"
-
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "Nove konekcije moraju pitati za pristup"
-
-#: ../panels/sharing/sharing.ui.h:25
-msgid "Require a password"
-msgstr "Zahtjev lozinke"
-
-#: ../panels/sharing/sharing.ui.h:26
-msgid ""
-"Media sharing allows you to share music, photos and videos over the network."
-msgstr ""
-"Dijeljen je medija vam omogućava da podijelite muziku, fotografije i video "
-"zapise putem mreže."
-
-#: ../panels/sharing/sharing.ui.h:27
-msgid "Folders"
-msgstr "Direktorij"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "Zvuk"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "Promijeni nivo zvuka, ulazi , izlazi , i upozoravajuci zvukovi"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr ""
-"Kartica;Mikrofon;Jačina zvuka;Iščezavanje;Balans;Blutut;Slušalice;Zvuk;"
-
-#. Translators: This is the nami of an audio file that sounds liki the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "Lavež"
-
-#. Translators: This is the nami of an audio file that sounds liki a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "Žubor"
-
-#. Translators: This is the nami of an audio file that sounds liki tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "Staklo"
-
-#. Translators: This is the nami of an audio file that sounds sort of liki a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "Sonar"
-
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "Lijevo"
-
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "Desno"
-
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Nazadi"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Prednje"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Minimum"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Maksimum"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "_Balans:"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "_Izblijedi:"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "_Subvufer:"
-
-#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:615
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Bez pojačavanja"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "_Profil:"
-
-#. translators:
-#. * The number of sound outputs on a particular djevice
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u izlaz"
-msgstr[1] "%u izlaza"
-msgstr[2] "%u izlaza"
-
-#. translators:
-#. * The number of sound inputs on a particular djevice
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u ulaz"
-msgstr[1] "%u ulaza"
-msgstr[2] "%u ulaza"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "Sistemski zvuci"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "Provjeri _zvučnike"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Jačina _Alarma:"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "Praćenje šiljka"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Ugasi zvuk"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1491
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "Naziv"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1510
-msgid "Device"
-msgstr "Uređaj"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1573
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "Testiranje zvučnika za %s"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1629
-msgid "_Output volume:"
-msgstr "_OIzlazna jačina:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1643
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Izlaz"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1648
-msgid "C_hoose a device for sound output:"
-msgstr "Izaberite uređaj kao zvučni izlaz:"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "_OIzlazna jačina:"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1670
-msgid "Settings for the selected device:"
-msgstr "Podešavanja za izabrani uređaj:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1681
-msgid "Input"
-msgstr "Ulaz"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1688
-msgid "_Input volume:"
-msgstr "_Ulazna jačina:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1709
-msgid "Input level:"
-msgstr "Ulazni nivo:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1737
-msgid "C_hoose a device for sound input:"
-msgstr "Izaberite uređaj kao zvučni ulaz:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1761
-msgid "Sound Effects"
-msgstr "Zvučni Efekti"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1768
-msgid "_Alert volume:"
-msgstr "Jačina _Alarma:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1785
-msgid "No application is currently playing or recording audio."
-msgstr "Ni jedan program ne pušta ili snima zvuk."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "Ugrađen"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "Opcije zvuka"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "Provjera zvuka za događaj"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "Podrazumijevano"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "Na osnovu teme"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:770
-msgid "C_hoose an alert sound:"
-msgstr "I_zaberite zvuk za upozorenje:"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "Prekini"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Provjeri"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "_Konfiguracioni URL"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Sabvufer"
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "Prilagođeno"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Ulaz"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "Omogući lakši pregled,zvuk,tip,usmjeri i klikni"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Ulazni nivo:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Pojačaj zvuk"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Jačina _Alarma:"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Zvuk"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Promijeni nivo zvuka, ulazi , izlazi , i upozoravajuci zvukovi"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Kartica;Mikrofon;Jačina zvuka;Iščezavanje;Balans;Blutut;Slušalice;Zvuk;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "_Uvijek Prikaži Univerzalni Pristupni Meni"
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "Viđenje"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Napomene"
 
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "_Visoki kontrast"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Ime:"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "_Veliki Tekst"
-
-#: ../panels/universal-access/uap.ui.h:5
-msgid "_Zoom"
-msgstr "_Povećaj"
-
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr "_Čitač Ekrana"
-
-#: ../panels/universal-access/uap.ui.h:8
-msgid "_Sound Keys"
-msgstr "_Tipke za zvuk"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "Slušanje"
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
-msgstr "_Vidljiva upozorena"
-
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Screen _Keyboard"
-msgstr "_Tastatura na Ekranu"
-
-#: ../panels/universal-access/uap.ui.h:13
-msgid "_Typing Assist (AccessX)"
-msgstr "_Pomoć pri kucanju (AccessX)"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Pointing & Clicking"
-msgstr "Označiti & Kliknuti"
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "_Mouse Keys"
-msgstr "_Tipka miša"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "_Pomoć pri kliku"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "Čitač ekrana"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "Čitač ekrana Čita prikazani tekst kako pomjerate fokus."
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Screen Reader"
-msgstr "_Čitač ekrana"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Sound Keys"
-msgstr "Tipke zvuka"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "Pisni kada se uključe Num Lock ili Velika slova."
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "Vizualna upozorenja"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "Probni _bljesak"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "Koristi vizualnu naznaku kada se desi zvučno upozorenje."
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Flash the _window title"
-msgstr "Osvjetli Naslov prozora"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Flash the entire _screen"
-msgstr "Prikaži cijeli ekran"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Typing Assist"
-msgstr "Pomoć pri kucanju"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "_Sticky Keys"
-msgstr "Ljepljive Tipke"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"Ophodi se prema slijedu tastera za modifikaciju kao da su kombinacija tastera"
 
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "_Isključi ako su dva tastera pritisnuta istovremeno"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifier key is pressed"
-msgstr "Zvuk kada je pritisnut _modifikatorski taster"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "Automatska_Konekcija"
 
-#: ../panels/universal-access/uap.ui.h:32
-msgid "S_low Keys"
-msgstr "S_pore Tipke"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Ukloni uređaj"
 
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "Pravi odlaganje između pritiskanja i prihvatanja tastera"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "Kašnjenje _prihvatanja:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Ne mogu da se povežem na domen „%s“: %s"
 
-#: ../panels/universal-access/uap.ui.h:35
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Kratko"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Opšti pristup"
 
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "Zastoj kucanja sporih tastera"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:37
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Dugo"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Dodaj uređaj"
 
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Beep when a key is pr_essed"
-msgstr "Zapišti kada je pritisnut taster"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Beep when a key is _accepted"
-msgstr "Zapišti kada je _prihvaćena tipka"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "Zvuk kada taster nije _prihvaćen"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:41
-msgid "_Bounce Keys"
-msgstr "_Skoče Tipke"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "Ignoriše brze duple klikove"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Treperenje kursora"
 
-#: ../panels/universal-access/uap.ui.h:43
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Kratko"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Pokazivač _trepće u poljima za tekst"
 
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "Zastoj kucanja odskočnih tastera"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Brzina:"
 
-#: ../panels/universal-access/uap.ui.h:45
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Dugo"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Brzina treptanja kursora"
 
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Enable by Keyboard"
-msgstr "_Omogućeno pomoću tastature"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Brzina treptanja kursora"
 
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "Uključite/isključite funkcije pristupačnosti koristeći tastaturu"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "Pomoć pri Kliku"
 
-#: ../panels/universal-access/uap.ui.h:49
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "_Oponaša Sekundarni Klik"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "Izazovite sekundarni klik pritiskajući primarni klik dugo"
 
-#: ../panels/universal-access/uap.ui.h:51
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Kašnjenje _prihvatanja:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Kratko"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "Zastoj sekundarnog klika"
 
-#: ../panels/universal-access/uap.ui.h:53
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Dugo"
 
-#: ../panels/universal-access/uap.ui.h:54
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "_Lebdeći Klik"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "Pokren i  klik kada kursor nadleti"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "Zastoj:"
 
-#: ../panels/universal-access/uap.ui.h:57
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Kratko"
 
-#: ../panels/universal-access/uap.ui.h:58
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Dugo"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "_Osjetljivost na pokret:"
 
-#: ../panels/universal-access/uap.ui.h:60
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Malo"
 
-#: ../panels/universal-access/uap.ui.h:61
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Veliki"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Ponavljanje tastera"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "_Ponovi pritiskanje tipki kada se tipka drži pritisnuta"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Brzina ponavljanja tastera"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Brzina ponavljanja tastera"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Pomoć pri kucanju"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Ljepljive Tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Ophodi se prema slijedu tastera za modifikaciju kao da su kombinacija tastera"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Isključi ako su dva tastera pritisnuta istovremeno"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Zvuk kada je pritisnut _modifikatorski taster"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "S_pore Tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Pravi odlaganje između pritiskanja i prihvatanja tastera"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "Kratko"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ekrana"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Zastoj kucanja sporih tastera"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ekrana"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ekrana"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "Dugo"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Zapišti kada je pritisnut taster"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Zapišti kada je _prihvaćena tipka"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Zvuk kada taster nije _prihvaćen"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Skoče Tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignoriše brze duple klikove"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kratko"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Zastoj kucanja odskočnih tastera"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Omogućeno pomoću tastature"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Uključite/isključite funkcije pristupačnosti koristeći tastaturu"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Uvijek Prikaži Univerzalni Pristupni Meni"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Viđenje"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Visoki kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Veliki Tekst"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Čitač Ekrana"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Čitač ekrana Čita prikazani tekst kako pomjerate fokus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Tipke za zvuk"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pisni kada se uključe Num Lock ili Velika slova."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Brzina treptanja kursora"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Povećaj"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Slušanje"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Vidljiva upozorena"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Tastatura na Ekranu"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Ponavljanje tastera"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Treperenje kursora"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Pomoć pri kucanju (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Označiti & Kliknuti"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Tipka miša"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Ukloni štampač"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Pomoć pri kliku"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "_Dupli klik"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "_Dupli klik"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Vizualna upozorenja"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Probni _bljesak"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Koristi vizualnu naznaku kada se desi zvučno upozorenje."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Prikaži cijeli ekran"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Prikaži cijeli ekran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "Puni ekran"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "Gornja polovina"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "Donja polovina"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "Lijeva polovina"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "Desna polovina"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "Opcije uvećanja"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "Uvećaj"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "Uvećavanje:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "Prati kursor miša"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "Dio ekrana:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "Lupa se prostire izvan ekrana"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "Drži kursor lupe po sredini"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "Kursor lupe gura sadržaje unaokolo"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "Kursor lupe se pomijera sa sadržajima"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "Položaj lupe:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Prati kursor miša"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Dio ekrana:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "Lupa se prostire izvan ekrana"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "Drži kursor lupe po sredini"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Kursor lupe gura sadržaje unaokolo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "Kursor lupe se pomijera sa sadržajima"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Povećalo"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "Ukrštanje:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "Preklapa kursor miša"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "Debljina:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "Tanko"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Debelo"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "Dužina:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "Boja:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "Ukrštanje:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "Preklapa kursor miša"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "Krst"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efekti boje;:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "Bijelo na crnom:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "Osvjetljenje:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "Kontrast:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "Boja"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Nijedan"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Pun"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Nisko"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Visoko"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Nizak"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Visok"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "Efekti boje;:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "Efekti boje"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Standardni"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Omogući lakši pregled,zvuk,tip,usmjeri i klikni"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Historija"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "Historija"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "Očisti Nedavnu Historiju"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "Očisti Smeće & Privremene Datoteke"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "Automatski isprazni_Smeće"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automatski očisti Privremene_Datoteke"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "Automatski isprazni_Smeće"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "_Isprazni smeće"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Očisti Privremene Datoteke"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Dodaj korisnika"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
 msgid "Administrator"
 msgstr "Administrator"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Full Name"
-msgstr "_Ime i prezime"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "_Vrsta naloga"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to set a password when they next login"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
 msgstr "Dozvoli korisniku da postavi lozinku pri sljedećoj prijavi"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
 msgstr "Postavi zaporku sad"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "_Potvrdi"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "Podešavam"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_Poslovno prijavljivanje"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Van mreže"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
 "Službena prijava dozvoljava korištenje postojećeg centralno kontrolisanog "
 "korisničkog računa na ovom uređaju."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "_Domena"
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Izaberite PPD datoteku"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Ne"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
 msgstr ""
-"Idi online da bi dodao\n"
-"službenu prijavu računa."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "_Poslovno prijavljivanje"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Da li želite da obrišete registrovane otiske prsta kako bi onemogućili "
+"prijavu putem otiska prsta?"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1466
-msgid "Add User"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Nema otkrivenih štampača."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Obriši otiske prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Prethodna numera"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Promijeni lozinku"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Promijeni"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Trenutna_Lozinka"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Nova Lozinka"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Promijeni lozinku"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lozinke se ne podudaraju."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "Dozvoli korisniku da postavi lozinku pri sljedećoj prijavi"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Postavi zaporku sad"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Korisnici"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Vaša sesija se mora restartovati da bi se aktivirali promjene"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Restartuj Sada"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Zatvoreno"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Ime i prezime"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Automatsko prijavljivanje"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "_Vrsta naloga"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Ukloni korisnički nalog"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Drugi prst:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
 msgstr "Dodaj korisnika"
 
-#. Translators: This button enrolls the computer in the domain in order to usi enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Slike nisu nađene"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "Napravite korisnički nalog"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Dodaj ili ukloni korisnike i promijeni svoju lozinku"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Otkliži"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Prijavljivanje administratora domena"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6029,768 +4818,46 @@ msgstr ""
 "upisan u domenu. Neka administrator vaše mreže ovdje upiše lozinku\n"
 "njihovih domena."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "Ime _administratora"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Šifra Administratora"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "Lijevi palac"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "Srednji, lijevi prst"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "Domali, lijevi prst"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "Mali, lijevi prst"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "Desni palac"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "Desni, srednji prst"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "Desni, domali prsti"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "Desni, mali prst"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:689
-msgid "Enable Fingerprint Login"
-msgstr "Omogući prijavu putem otiska prsta"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "Domali, _desni prst"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "Domali, _lijevi prst"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "_Drugi prst:"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"Vaš otisak prsta je uspješno sačuvan. Sada se možete prijaviti na sistem "
-"preko čitača otisaka prsta."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "Korisnici"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr "Dodaj ili ukloni korisnike i promijeni svoju lozinku"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Prjava;Ime;Otisak;Ikonica;Logotip;Faca;Zaporka;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "Historija prijava"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr "Promijeni lozinku"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "_Promijeni"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "_Potvrdi novu lozinku"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "_Nova Lozinka"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "Trenutna_Lozinka"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "Dodaj korisnički nalog"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "Ukloni korisnički nalog"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "Opcije prijave"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "_Automatsko prijavljivanje"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "Prijavljivanje _otiskom prsta"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "Ikonica korisnika"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "_Jezik"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "Zadnja prijava"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "Upravljanje korisničkim nalozima"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "Prijava je potrebna za promjenu korisničkih podataka."
 
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Nova lozinka mora biti različita od stare."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Pokušaj promijeniti neka slova u brojeve."
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Pokušaj promijeniti lozinku još malo."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Lozinka bez vašeg korisničkog imena bi bila jača."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Pokušaj izbjeći korištenje svog imena u lozinci."
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Pokušaj izbjeći neke riječi uključene u lozinku."
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Pokušaj izbjeći obične riječi."
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Pokušaj izbjeći promjenu mjesta postojećih riječi."
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Pokušaj koristiti više brojeva."
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Pokušaj koristiti više velikih slova."
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Pokušaj koristiti više malih slova."
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-"Pokušaj korisiti više posebnih znakova, naprimjer znakovi interpunkcije."
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Pokušaj koristit mješavinu slova,brojeva i interpunkciskih znakova."
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Pokušaj izbječi ponavljanje istog znaka."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Pokušaj izbjeći ponavljanje istog tipa znaka:trebaš miješati slova,brojeve i "
-"interpunkciske znakove."
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Pokušaj izbjeći senkvence kao 1234 ili abcd."
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "Pokušaj dodati više slova,brojeva i znakova."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr "Miješaj velika i mala slova i iskoristi broj ili dva."
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-"Dobra lozinka!Dodavanje više slova,brojeva i znakova interpunkcije učiniti "
-"će je jačom."
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "Jačina:Slaba"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "Jačina:Niska"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "Jačina:Srednja"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "Jačina:Dobra"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "Jačina:Visoka"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "Autentifikacija nije prošla"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "Nova lozinka je prekratka"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "Nova lozinka je suviše jednostavna"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Stara i nova lozinka su suviše slične"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Nova lozinka je već upotrebljavana u skorije vrijeme."
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Nova lozinka mora da sadrži cifre ili specijalne karaktere"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Stara i nova lozinka su iste"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Vaša lozinka je promijenjena od kada ste se prvobitno ovlastili!"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Nova šifra nema dovoljno različitih znakova"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "Nepoznata greška"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "Trebali bi se poklapati sa web adresom vašem poslužavatelja računa."
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "Nisam uspio da dodam nalog"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-msgid "Passwords do not match."
-msgstr "Lozinke se ne podudaraju."
-
-#: ../panels/user-accounts/um-account-dialog.c:733
-#: ../panels/user-accounts/um-account-dialog.c:779
-#: ../panels/user-accounts/um-account-dialog.c:800
-msgid "Failed to register account"
-msgstr "Nisam uspio da upišem nalog"
-
-#: ../panels/user-accounts/um-account-dialog.c:923
-msgid "No supported way to authenticate with this domain"
-msgstr "Nema podržanog načina za potvrđivanje identiteta sa ovim domenom"
-
-#: ../panels/user-accounts/um-account-dialog.c:982
-msgid "Failed to join domain"
-msgstr "Nisam uspio da pristupim domenu"
-
-#: ../panels/user-accounts/um-account-dialog.c:1043
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"To ime za prijavu nije radilo .\n"
-"Molimo pokušajte ponovo."
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"To ime za prijavu nije radilo .\n"
-"Molimo pokušajte ponovo."
-
-#: ../panels/user-accounts/um-account-dialog.c:1058
-msgid "Failed to log into domain"
-msgstr "Nisam uspio da se prijavim na domen"
-
-#: ../panels/user-accounts/um-account-dialog.c:1116
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "Omogući pronalazak domena.Možda si ga pogrešno postavio."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:138
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"Nemate dozvole za pristup ovom uređaju. Kontaktirajte vašeg sistemskog "
-"administratora."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:140
-msgid "The device is already in use."
-msgstr "Uređaj je već u upotrebi."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid "An internal error occurred."
-msgstr "Desila se unutrašnja greška."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Enabled"
-msgstr "Omogućen"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr "Da obrišem registrovane otiske prsta?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
-msgstr "_Obriši otiske prsta"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"Da li želite da obrišete registrovane otiske prsta kako bi onemogućili "
-"prijavu putem otiska prsta?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:446
-msgid "Done!"
-msgstr "Završeno!"
-
-#. translators:
-#. * The variable is the nami of the djevice, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" djevice
-#: ../panels/user-accounts/um-fingerprint-dialog.c:507
-#: ../panels/user-accounts/um-fingerprint-dialog.c:549
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "Ne mogu da pristupim uređaju „%s“"
-
-#. translators:
-#. * The variable is the nami of the djevice, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" djevice
-#: ../panels/user-accounts/um-fingerprint-dialog.c:590
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "Ne mogu da uhvatim otisak prsta sa uređaja „%s“"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:640
-msgid "Could not access any fingerprint readers"
-msgstr "Ne mogu da pristupim čitačima prsta"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:641
-msgid "Please contact your system administrator for help."
-msgstr "Javite se sistemskom administratoru radi pomoći."
-
-#. translators:
-#. * The variable is the nami of the djevice, for example:
-#. * "To enable fingerprint login, you need to savije one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' djevice."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:723
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"Morate sačuvati jedan od vaših otisaka prsta sa uređaja „%s“, kako bi "
-"omogućili prijavu na sistem putem otiska prsta."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:730
-msgid "Selecting finger"
-msgstr "Prst iybora"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:731
-msgid "Enrolling fingerprints"
-msgstr "Upisujem otiske prstiju"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "Ove sedmice"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "Prošle sedmice"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:842
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:846
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "Sesija završila"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "Sesija počela"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "Izaberite drugu lozinku."
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "Ispišite vašu trenutnu zaporku ponovno."
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "Ne mogu da promijenim lozinku"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-msgid "The passwords do not match."
-msgstr "Lozinke se ne podudaraju."
-
-#: ../panels/user-accounts/um-photo-dialog.c:214
-msgid "Browse for more pictures"
-msgstr "Traži za više slika"
-
-#: ../panels/user-accounts/um-photo-dialog.c:448
-msgid "Disable image"
-msgstr "Onemogući sliku"
-
-#: ../panels/user-accounts/um-photo-dialog.c:466
-msgid "Take a photo…"
-msgstr "Uslikaj…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:484
-msgid "Browse for more pictures…"
-msgstr "Potraži još slika…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:708
-#, c-format
-msgid "Used by %s"
-msgstr "To koristi %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "Nije moguće automatski pristupiti ovoj vrsti domene."
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "Nije pronađen takav domen ili područje"
-
-#: ../panels/user-accounts/um-realm-manager.c:815
-#: ../panels/user-accounts/um-realm-manager.c:829
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Ne mogu da se prijavim kao „%s“ na domenu %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:821
-msgid "Invalid password, please try again"
-msgstr "Pogrešna lozinka, molimo pokušajte ponovo"
-
-#: ../panels/user-accounts/um-realm-manager.c:834
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "Ne mogu da se povežem na domen „%s“: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:238
-msgid "Other Accounts"
-msgstr "Ostali računi"
-
-#: ../panels/user-accounts/um-user-panel.c:448
-msgid "Failed to delete user"
-msgstr "Nije moguće obrisati korisnički račun"
-
-#: ../panels/user-accounts/um-user-panel.c:508
-#: ../panels/user-accounts/um-user-panel.c:567
-#: ../panels/user-accounts/um-user-panel.c:619
-msgid "Failed to revoke remotely managed user"
-msgstr "Nije moguće povući  daljinski upravljanog korisnika"
-
-#: ../panels/user-accounts/um-user-panel.c:675
-msgid "You cannot delete your own account."
-msgstr "Nije moguće obrisati sopstveni račun."
-
-#: ../panels/user-accounts/um-user-panel.c:684
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s je i dalje prijavljen"
-
-#: ../panels/user-accounts/um-user-panel.c:688
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Brisanje računa do je korisnik prijavljen može ostaviti sistem u "
-"zaglavljenom stanju!!!."
-
-#: ../panels/user-accounts/um-user-panel.c:697
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "Želite li sačuvati datoteke od korisnika '%s'?"
-
-#: ../panels/user-accounts/um-user-panel.c:701
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Moguće je zadržati kućni direktorij, mail i privremene datoteke kada se "
-"briše korisnički račun."
-
-#: ../panels/user-accounts/um-user-panel.c:704
-msgid "_Delete Files"
-msgstr "_Izbriši datoteke"
-
-#: ../panels/user-accounts/um-user-panel.c:705
-msgid "_Keep Files"
-msgstr "_Zadrži datoteke"
-
-#: ../panels/user-accounts/um-user-panel.c:719
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s's account?"
-msgstr ""
-"Da li ste sigurni da želite da uklonite daljinski upravljani nalog za %s?"
-
-#: ../panels/user-accounts/um-user-panel.c:723
-msgid "_Delete"
-msgstr "_Obriši"
-
-#: ../panels/user-accounts/um-user-panel.c:775
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Račun onemogućen"
-
-#: ../panels/user-accounts/um-user-panel.c:783
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Biće namještena na sljedećem prijavljivanju"
-
-#: ../panels/user-accounts/um-user-panel.c:786
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ništa"
-
-#: ../panels/user-accounts/um-user-panel.c:835
-msgid "Logged in"
-msgstr "Prijavljen"
-
-#: ../panels/user-accounts/um-user-panel.c:1267
-msgid "Failed to contact the accounts service"
-msgstr "Nije moguće kontaktirati servis računa"
-
-#: ../panels/user-accounts/um-user-panel.c:1269
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Morate se postarati da je ServisRačuna instaliran i omogućen."
-
-#: ../panels/user-accounts/um-user-panel.c:1310
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Da bi ste napravili promjene,\n"
-"kliknite na *"
-
-#: ../panels/user-accounts/um-user-panel.c:1348
-msgid "Create a user account"
-msgstr "Napravite korisnički nalog"
-
-#: ../panels/user-accounts/um-user-panel.c:1359
-#: ../panels/user-accounts/um-user-panel.c:1671
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Da napravite korisnički nalog,\n"
-"kliknite prvo na ikonicu *"
-
-#: ../panels/user-accounts/um-user-panel.c:1369
-msgid "Delete the selected user account"
-msgstr "Obrišite izabrani korisnički nalog"
-
-#: ../panels/user-accounts/um-user-panel.c:1381
-#: ../panels/user-accounts/um-user-panel.c:1676
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Da obrišete izabrani korisnički nalog,\n"
-"kliknite prvo na ikonicu *"
-
-#: ../panels/user-accounts/um-user-panel.c:1585
-msgid "My Account"
-msgstr "Moj račun"
-
-#: ../panels/user-accounts/um-utils.c:563
-#, c-format
-msgid "A user with the username '%s' already exists."
-msgstr "Korisnik sa imenom '%s' već postoji."
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-msgid "The username is too long."
-msgstr "Kornisničko ime je previše dugo."
-
-#: ../panels/user-accounts/um-utils.c:570
-msgid "The username cannot start with a '-'."
-msgstr "Korisničko ime počinje sa '-'."
-
-#: ../panels/user-accounts/um-utils.c:573
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"Korisničko ime bi se trebalo sastojati od malih i velikih slova od a do z, "
-"brojeva i karaktera '.', '-' i '_'."
-
-#: ../panels/user-accounts/um-utils.c:577
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-"Ovo će biti korišteno kao ime početne datoteke i neće se moći promjeniti."
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:823
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Mapiraj dugmad"
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Mapirajte dugmad prema funkcijama"
 
-#: ../panels/wacom/button-mapping.ui.h:4
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 "Da bi uredili prečicu,odaberite \"Send Keystroke\" akciju,pritisnite dugme "
 "prečice na tastaturu i držite pritisnutu novi tipku ili pritisnite Backspace "
 "da očistite."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Zatvori"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -6798,366 +4865,3262 @@ msgstr ""
 "Molim tupnite znake odredišta koji će se pojaviti na ekranu da kalibrišete "
 "tablicu."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "Otkriven je loš klik, počinjem iz početka..."
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "Gore"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "Dole"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tablet"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "Nikakva"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Pošalji otkucaj tastera"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Orijentacija prema lijevo"
 
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Promijeni monitor"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Prikaži pomoć na ekranu"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Poveži s monitorom"
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "Izlaz:"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Proporcija"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Zadrži odnos razmjere (crne trake):"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "Mapiraj na jedan monitor"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Kalibriši…"
 
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d od %d"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nema detektovanog tableta"
 
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "Mapiranje prikaza"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Molim priključite ili uključite Wacom tablet"
 
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Osjećaj pritiska pri tipkanju"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Meko"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Inertno"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Dugme"
 
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Dugme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Dugme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Osjećaj pritiska gumice"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Osjećaj pritiska gumice"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Klik srednjom tipkom miša"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Klik desnom tipkom miša"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Naprijed"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom Tablet"
 
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Postavi mapiranje dugmetom i namjesti stylus osjetljivost za grafičke tabele."
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Olovka;Gumica;Miš;"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "Tablet (asolutni)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "Dodirljiva ploča (relativno)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "Postavke tableta"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Help"
-msgstr "_Pomoć"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "No tablet detected"
-msgstr "Nema detektovanog tableta"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Molim priključite ili uključite Wacom tablet"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Bluetooth Settings"
-msgstr "Bluetooth postavke"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map to Monitor…"
-msgstr "Poveži s monitorom"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Map Buttons…"
-msgstr "Poveži dugmad"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust display resolution"
-msgstr "Podesite rezoluciju prikaza"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Adjust mouse settings"
-msgstr "Podesi osjetljivost miša"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Tracking Mode"
-msgstr "Režim praćenja"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:16
-msgid "Left-Handed Orientation"
-msgstr "Orijentacija prema lijevo"
-
-#. If no mode is available, we usi "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1024
-msgid "Left Ring"
-msgstr "Lijevi prsten"
-
-#: ../panels/wacom/gsd-wacom-device.c:1035
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "Režim lijevog prstena #%d"
-
-#. If no mode is available, we usi "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1055
-msgid "Right Ring"
-msgstr "Desni prsten"
-
-#: ../panels/wacom/gsd-wacom-device.c:1066
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "Režim desnog prstena #%d"
-
-#. If no mode is available, we usi "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1108
-msgid "Left Touchstrip"
-msgstr "Lijeva dodirna traka"
-
-#: ../panels/wacom/gsd-wacom-device.c:1119
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "Režim lijeve dodirne trake #%d"
-
-#. If no mode is available, we usi "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1139
-msgid "Right Touchstrip"
-msgstr "Desna dodirna traka"
-
-#: ../panels/wacom/gsd-wacom-device.c:1150
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "Režim desne dodirne trake #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1176
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "Režim prekidača lijevog dodirnog prstena"
-
-#: ../panels/wacom/gsd-wacom-device.c:1178
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "Režim prekidača desnog dodirnog prstena"
-
-#: ../panels/wacom/gsd-wacom-device.c:1181
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "Režim prekidača lijeve dodirne trake"
-
-#: ../panels/wacom/gsd-wacom-device.c:1183
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "Režim prekidača desne dodirne trake"
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "Režim prekidača #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1296
-#, c-format
-msgid "Left Button #%d"
-msgstr "Lijevo dugme #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1299
-#, c-format
-msgid "Right Button #%d"
-msgstr "Desno dugme #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1302
-#, c-format
-msgid "Top Button #%d"
-msgstr "Gornje dugme #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1305
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "Donje dugme #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "Nova prečica…"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "Bez akcije"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "Klik lijevom tipkom miša"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "Klik srednjom tipkom miša"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "Klik desnom tipkom miša"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "Kliži prema gore"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "Kliži prema dolje"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "Kliži ulijevo"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "Kliži udesno"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "Nazad"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "Naprijed"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "Olovka"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "Osjećaj pritiska gumice"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "Meko"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "Inertno"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "Gornje dugme"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "Niže dugme"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
-msgid "Tip Pressure Feel"
-msgstr "Osjećaj pritiska pri tipkanju"
-
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "Omogući pričljiv mod"
-
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "Prikaži pregled"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "Traži string"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "Priloži moguća imena panela i izađi"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "Prikaži opcije za pomoć"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "Panel za prikaz"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "-Postavke"
-
-#: ../shell/cc-application.c:163
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
 msgstr ""
-"%s\n"
-"Pokrenite „%s --help“ kako bi vidjeli spisak svih naredbi iz komandne "
-"linije.\n"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "Dostupni paneli:"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: ../shell/cc-application.c:326
-msgid "Help"
-msgstr "Pomoć"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: ../shell/cc-application.c:327
-msgid "Quit"
-msgstr "Izlaz"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1493
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Oponaša Sekundarni Klik"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows softver"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Nizak nivo tonera"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Sekundarni"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows softver"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Mogućnosti pristupa"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Dodaj"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Snimi"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Detalji"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Ime mreže"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Mreže"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Brojevi"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Pogledaj detalje"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Proizvođač"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Firmver nedostaje"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Širokopojasna veza"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Ime mreže"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Mreža"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Napredno"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Mogućnosti pristupa"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Zaključan Ekran"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Detalji"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Ime mreže"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Automatski"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "_MojaStandardna Mreža"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "_MojaStandardna Mreža"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Nisu pronađeni Bluetooth adapteri"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Avionski način"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Povezujem"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM kartica nije ubačena"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Zaključan Ekran"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "_Promijeni"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "_MojaStandardna Mreža"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "Postavljanje novog drajvera"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "Privatnost"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Sve Postavke"
 
-#. Add categories
-#: ../shell/cc-window.c:879
-msgctxt "category"
-msgid "Personal"
-msgstr "Lični"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Primarni"
 
-#: ../shell/cc-window.c:880
-msgctxt "category"
-msgid "Hardware"
-msgstr "Hardver"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:881
-msgctxt "category"
-msgid "System"
-msgstr "Sistem"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Pomoć"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Općenito"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Izlaz"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Traži"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Pređi na prethodni izvor"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Otkazan"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Postavke;Podešavanja;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u izlaz"
+msgstr[1] "%u izlaza"
+msgstr[2] "%u izlaza"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ulaz"
+msgstr[1] "%u ulaza"
+msgstr[2] "%u ulaza"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Promjene dana"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Popločano"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Uvećaj"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrirano"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Popuna"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Rasprostrto"
+
+#~ msgid "Colors"
+#~ msgstr "Boje"
+
+#~ msgid "Select Background"
+#~ msgstr "Izaberi pozadinu"
+
+#~ msgid "Pictures"
+#~ msgstr "Slike"
+
+#~ msgid "Home"
+#~ msgstr "Početna"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Mozes dodati slike u svoj %s folder i one će se pojaviti tamo"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Nema pozadine za radnu površ"
+
+#~ msgid "Current background"
+#~ msgstr "Trenutna pozadina"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Pozadina;Ekran;Radna površ;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr ""
+#~ "Postavi svoj uređaj za kalibrisanje preko kvadrata i pritisni 'Start'"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr ""
+#~ "Pomjeri svoj uređaj za kalibrisanje na poziciju za kalibrisanje i "
+#~ "pritisni 'Nastavi'"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr ""
+#~ "Pomjeri svoj uredđaj za kalibrisanje na poziciju površine i pritisni "
+#~ "'Nastavi'"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Zaklopite laptop"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Unutrašnja greška se dogodila koja ne može biti popravljena."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Alati potrebni za kalibrisanje nisu instalirani."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profil nije mogao biti generisan."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Ciljana bijela tačka nije dobijena."
+
+#~ msgid "Complete!"
+#~ msgstr "Završeno!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrisanje nije uspjelo!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Možete ukloniti uređaj za kalibraciju."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ne pomjerajte uređaj za kalibrisanje dok se izvršava"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Ekran laptopa"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s skener"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s printer"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s Web kamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Omogućeno upravljanje bojom za %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Prikaži profile boja za %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nije kalibrisano"
+
+#~ msgid "Default: "
+#~ msgstr "Podrazumijevano: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Probni profil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Izaberi datoteku ICC profila"
+
+#~ msgid "_Import"
+#~ msgstr "_Uvezi"
+
+#~ msgid "All files"
+#~ msgstr "Sve datoteke"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Nije uspjelo postavljanje datoteke %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profil je postavljen na:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Upišite ovaj URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Ponovo pokrenite ovaj kompjuter i pokrenite svoj normalni operativni "
+#~ "sistem."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Ukucajte URL u svoj preglednik da bi skinuli i instalirali profil."
+
+#~ msgid "Save Profile"
+#~ msgstr "Snimi profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Napravi profil boje za izabrani uređaj"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Mjerni uređaj nije otkriven. Provjerite da li je upaljen i ispravno "
+#~ "priključen."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Mjerni uređaj ne podržava profilisanje štampača."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Vrsta uređaja nije trenutno podržana."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standardni prostor"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testni profil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatski"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Niska kvaliteta"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Srednja kvaliteta"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Visoka kvaliteta"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Osnovna „RGB“"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Osnovna „CMYK“"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Osnovna siva"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Vendor fabrika za isporuku podataka o kalibrisanju"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Popravka prikaza punog ekrana nije moguća za ovaj profil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Ovaj profil možda više nije precizan"
+
+#~ msgid "Done"
+#~ msgstr "Završeno"
+
+#~ msgid "Upload profile"
+#~ msgstr "Postavi profil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Zahtijeva povezanost na internet"
+
+#~ msgid "Other…"
+#~ msgstr "Drugo…"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Vremenska _zona"
+
+#~ msgid "24-hour"
+#~ msgstr "24-sata"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Zatvoren poklopac"
+
+#~ msgid "Mirrored"
+#~ msgstr "Preslikano"
+
+#~ msgid "Off"
+#~ msgstr "Isključeno"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Uredi kombinovani prikaz"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Povlači prikaze da bi ih preuredili"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Rotiraj  za 90 stepeni suprotno od smijera kazaljke"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Rotiraj za 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Rotiraj za 90°u smijeru kazaljke na satu"
+
+#~ msgid "Size"
+#~ msgstr "Veličina"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Prikaži na  gornjoj tabli  Pregled aktivnosti na ovom prikazu"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Spoji ovaj prikaz sa drugim da bi stvorili više radnog prostora"
+
+#~ msgid "Presentation"
+#~ msgstr "Prezentacija"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Prikaži samo pokretni prikaz i medije"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Prikaži potojeći pogled na oba prikaza"
+
+#~ msgid "Turn Off"
+#~ msgstr "Isključi"
+
+#~ msgid "Don't use this display"
+#~ msgstr "Nemoj koristiti ovaj prikaz"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Ne mogu da dobijem podatke o ekranu"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Omogući kombinovane prikaze"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "Unknown"
+#~ msgstr "Nepoznato"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-bit"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Pitaj šta da uradiš"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ne radi ništa"
+
+#~ msgid "Open folder"
+#~ msgstr "Otvori direktorij"
+
+#~ msgid "Other Media"
+#~ msgstr "Drugi mediji"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Odaberite aplikaciju za otvaranje audio CD-ova"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Odaberite aplikaciju za otvaranje video DVD-ova"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Odaberite aplikaciju koja će se pokretati kad muzički plejer bude "
+#~ "priključen"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Odaberite aplikaciju koja će se pokretati kad kamera bude priključena"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr ""
+#~ "Odaberite aplikaciju koja će se pokretati kad budete ubacili CD-ove sa "
+#~ "softverom"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "prazan Blu-ray disk"
+
+#~ msgid "blank CD disc"
+#~ msgstr "prazan CD disk"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "prazan DVD disk"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "prazan HD DVD disk"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video disk"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-book čitač"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video disk"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD sa slikama"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "Overview"
+#~ msgstr "Predpregled"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "Verzija %s"
+
+#~ msgid "Base system"
+#~ msgstr "Osnovni sistem"
+
+#~ msgid "Disk"
+#~ msgstr "Disk"
+
+#~ msgid "Check for updates"
+#~ msgstr "Provjeri ažuriranja"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Spasi snimke ekrana u $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Spasi snimke prozora  u $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Spasi snimke prostora ekrana u $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopiraj snimak u  odlagalište"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopiraj snimak prozora u  odlagalište"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopiraj snimak područja u  odlagalište"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Snimi kratku snimku ekrana"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Samo za ispravljače pređi za sljedeći izvor"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Prečac;Ponovi;Blinkaj;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Proizvoljna prečica"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Odgoda:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Kratko"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Sporo"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Dugo"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Brzo"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Brzina:"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Ukloni prečicu"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Da bi ste uredili prečac, kliknite red i držite nove tastere ili Briši "
+#~ "unazad da obrišete."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Nepoznata akcija>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Prečica „%s“ ne može biti korišćena jer će biti nemoguće kucati koristeći "
+#~ "ovaj taster.\n"
+#~ "Pokušajte istovremeno sa tasterom kao što je Kontrol, Alt ili Šift."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Prečica „%s“ se već koristi za\n"
+#~ "„%s“"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Ako ponovo dodijelite prečicu za „%s“, prečica za „%s“ će biti "
+#~ "onemogućena."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Ponovo dodjeli"
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" prečica ima pridruženu \"%s\" prečicu . Želite li je automatski "
+#~ "postaviti na \"%s\"?"
+
+#, c-format
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" je trenutno povezan s \"%s\" , ovaj prečac će biti onemogućen ako "
+#~ "se krene naprijed ."
+
+#~ msgid "_Assign"
+#~ msgstr "_Dodijeli"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Provjeri Svoje Postavke"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Sporo"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Vrijeme za dupli klik"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Brzo"
+
+#~ msgctxt "mouse, lift button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Lijevo"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Desno"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "Brzina _pokazivača"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Sporo"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Brzo"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Sporo"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Brzo"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "_Skrol s dva prsta"
+
+#~ msgid "_Natural scrolling"
+#~ msgstr "_Standardno klizanje"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Pet klikova, GEGL vrijeme!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dvostruki klik, primarna tipka"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Jednostruki klik, primarna tipka"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dvostruki klik, srednja tipka"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Jednostruki klik, srednja tipka"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dvostruki klik, sekundarna tipka"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Jednostruki klik, sekundarna tipka"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "page 1"
+#~ msgstr "strana 1"
+
+#~ msgid "page 2"
+#~ msgstr "strana 2"
+
+#~ msgid "automatic"
+#~ msgstr "automatski"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprajz"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nikakva"
+
+#~ msgid "Never"
+#~ msgstr "Nikad"
+
+#~ msgid "Today"
+#~ msgstr "Danas"
+
+#~ msgid "Yesterday"
+#~ msgstr "Juče"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nikakva"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Slaba"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "U redu"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Dobra"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Izvrsna"
+
+#~ msgid "Identity"
+#~ msgstr "Identitet"
+
+#~ msgid "Server"
+#~ msgstr "Server"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Obrisati DNS Server"
+
+#~ msgid "Delete Route"
+#~ msgstr "Obrisati put"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ništa"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bitni ključ (Hex ili ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit lozinka"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dinamički WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "Lični WPA & WPA2"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Poslovni WPA & WPA2"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Parica (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Interfejs priložene jedinice (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Medijski nezavisan interfejs (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Omogući drugim _korisnicima"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Zona Zaštitnog zida"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Podrazumijevano"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Zona definira nivo povjerenja povezanosti"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Nemoguće otvoriti urednik povezanosti"
+
+#~ msgid "New Profile"
+#~ msgstr "Novi profil"
+
+#~ msgid "Bond"
+#~ msgstr "Povez"
+
+#~ msgid "Team"
+#~ msgstr "Tim"
+
+#~ msgid "Bridge"
+#~ msgstr "Most"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Nije  uspjelo unijeti VPN prključke"
+
+#~ msgid "Import from file…"
+#~ msgstr "Uvezi iz datoteke"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Dodati mrežnu konekciju"
+
+#~ msgid "_Reset"
+#~ msgstr "_Resetuj"
+
+#~ msgid "_Forget"
+#~ msgstr "_Zaboravi"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Resetuj postavke za ovu mrežu,uključujući lozinke,ali zapamti je kao "
+#~ "omiljenu mrežu"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Ukloni sve detalje povezane sa ovom mrežom i ne pokušavaj automatsko "
+#~ "povezivanje"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Ne mogu da uvezem VPN vezu"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Ne mogu da pročitam datoteku „%s“ ili ona ne sadrži poznate VPN podatke o "
+#~ "vezi\n"
+#~ "\n"
+#~ "Greška: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Izaberite datoteku za uvoz"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "Već postoji datoteka „%s“."
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Da li želite da zamijenite %s VPN vezom koju hoćete da sačuvate?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Ne mogu da izvezem VPN vezu"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN veza '%s' ne može biti izvezena u %s.\n"
+#~ "\n"
+#~ "Greška: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Izvoz VPN mreže"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Robovi veze"
+
+#~ msgid "(none)"
+#~ msgstr "(nema)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Robovi mosta"
+
+#~ msgid "never"
+#~ msgstr "nikad"
+
+#~ msgid "today"
+#~ msgstr "danas"
+
+#~ msgid "yesterday"
+#~ msgstr "juče"
+
+#~ msgid "Last used"
+#~ msgstr "Zadnje koristeno"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "Team slaves"
+#~ msgstr "Robovi tima"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Ako imaate povezanost na internet koja nije bežična, možes kreirati "
+#~ "bežičnu vruću tačku da dijeliš povezanost sa drugima."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Uključivanjem bežične vruće tačke prekinućete vezu sa <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Nije moguće pristupiti internetu preko vaše bežične veze dok je vruća "
+#~ "tačka aktivna."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Da zaustavim vruću tačku i da prekinem vezu svim korisnicima?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Zaustavi vruću tačku"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Pravila sistema zabranjuju korištenje vruće tačke"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Bežični uređaj ne podržava način vruće tačke"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Detalji netvorka za odabrani netvork, uključujući šifru i sve posebne "
+#~ "promjene će biti izgubljene."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Zaboravi"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "Web Proxy Autodiscovery se koristi kada URL-a konfiguracije nema."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Ovo je preporučljivo za nepovjerljive javne mreže."
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Nikakav"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Ručni"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatski"
+
+#~ msgid "Group Name"
+#~ msgstr "Ime grupe"
+
+#~ msgid "details"
+#~ msgstr "detalji"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Prikaži Šifru"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Omogući drugim korisnicima"
+
+#~ msgid "identity"
+#~ msgstr "identitet"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Automatski (DHCP) samo adrese"
+
+#~ msgid "Link-local only"
+#~ msgstr "Link-samo lokalni"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignoriši automatski određene puteve"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Kopirana MAC Adresa"
+
+#~ msgid "hardware"
+#~ msgstr "hardver"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Resetuj postavke za ovu konekciju na zadane, ali zapamti kao preferiranu "
+#~ "konekciju."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Ukloni sve detalje povezane sa ovom mrežom i ne pokušavaj se automatski "
+#~ "konektovati na nju."
+
+#~ msgid "reset"
+#~ msgstr "reset"
+
+#~ msgid "Hardware"
+#~ msgstr "Hardver"
+
+#~ msgid "_History"
+#~ msgstr "_Historija"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Ugasi da se konektuje na Wi-Fi mrežu"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Priključeni uređaji"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastruktura"
+
+#~ msgid "Status unknown"
+#~ msgstr "Stanje je nepoznato"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Neupravljivo"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nedostupno"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Prekidanje veze"
+
+#~ msgid "Connection failed"
+#~ msgstr "Veza nije uspjela"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Stanje nije raspoloživo (nedostupno)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Nije uspjelo podešavanje"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Nije uspjelo podešavanje IP-a"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Isteklo je podešavanje IP-a"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Tajne su bile zahtijevane ali nisu dane"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Prekinuta je veza sa 802.1x suplikantom"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Nije uspjelo podešavanje 802.1x suplikanta"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x suplikant nije uspio"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Potvrđivanje identiteta 802.1x suplikanta je trajalo predugo"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP servis neuspio u startu"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP servis diskonektovan"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP neuspio"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP klijent neuspio u startu"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Greška DHCP klijenta"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Neuspjeh DHCP klijenta"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Usluga dijeljene konekcije neuspjela u startu"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Neuspjela usluga dijeljene konekcije"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Neuspjela AutoIP usluga"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Greška AutoIP usluge"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Neuspjela AutoIP usluga"
+
+#~ msgid "Line busy"
+#~ msgstr "Linija zauzeta"
+
+#~ msgid "No dial tone"
+#~ msgstr "Nema pozivnog tona"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Zvučni nosač se ne može uspostaviti"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Isteklo je vrijeme zahtjeva pozivanja"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Pokušaj pozivanja nije uspeo"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Inicijalizacija modema neuspjela"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Neuspio izbor navedenog APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Ne tražim mreže"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Odbijena registracija mreža"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Istekla registracija mreža"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Neuspjela registracija na navedenu mrežu"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Provjera PIN-a neuspjela"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Možda nedostaje firmver za uređaj"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Veza je nestala"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Postojeća veza biće pretpostavljena"
+
+#~ msgid "Modem not found"
+#~ msgstr "Nije pronađen modem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Veza Bluetooth nije uspjela"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Potreban je SIM PIN"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Potreban je SIM PUK"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Pogrešna SIM"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand uređaj ne podržava povezani režim"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Nije uspjela zavisnost veze"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Izvučen kabl"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Nije izabran sertifikat Potvrđivanja Autoriteta (CA)"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Nekorištenje certikata koji je potvrdio Certifikacijski autoritet (CA) "
+#~ "može rezultirati u konekcijama do nesigurnih Wi-Fi mreže. Želite li "
+#~ "odabrati certifikat certifikacijskog autoriteta?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignoriši"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Izaberite certifikat PA (CA)"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, ili PKCS#12 lični ključevi (*.der, *.pijem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER ili PEM sertifikati (*.der, *.pijem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC datoteke (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Uvijek mi zatraži _lozinku"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Nešifrovani privatni ključevi nisu sigurni"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Izgleda da izabrani privatni ključ nije zaštićen lozinkom.  Ovo može "
+#~ "ugroziti vaše sigurnosne podatke.  Izaberite privatni ključ koji je "
+#~ "zaštićen lozinkom.\n"
+#~ "\n"
+#~ "(Možete zaštititi privatne ključeve koristeći openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Izaberi svoj lični certifikat"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Izaberite lični ključ"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Ne _upozoravaj me više"
+
+#~ msgid "Yes"
+#~ msgstr "Da"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "On"
+#~ msgstr "Uključiti"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification Banners"
+#~ msgstr "Trake obavještenja "
+
+#~ msgid "Notification Banners"
+#~ msgstr "Trake obavještenja"
+
+#~ msgid "Add Account"
+#~ msgstr "Dodaj nalog"
+
+#~ msgid "Mail"
+#~ msgstr "Elektronska pošta"
+
+#~ msgid "Contacts"
+#~ msgstr "Kontakti"
+
+#~ msgid "Chat"
+#~ msgstr "Razgovor"
+
+#~ msgid "Resources"
+#~ msgstr "Resursi"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Greška prilikom prijavljivanja na nalog"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Uvjerenja su istekla."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Prijavi se da omogućiš ovaj račun."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Prijavi se"
+
+#~ msgid "Error creating account"
+#~ msgstr "Greška prilikom stvaranja naloga"
+
+#~ msgid "Error removing account"
+#~ msgstr "Greška prilikom uklanjanja naloga"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Da li ste sigurni da želite da uklonite nalog?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Ovo neće ukloniti nalog na serveru."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Nisu podešeni nalozi na mreži"
+
+#~ msgid "Remove Account"
+#~ msgstr "Ukloni nalog"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Dodavanje naloga omogućava vašim aplikacijama da mu pristupe zbog "
+#~ "dokumenata, pošte, kontakata, kalendara, ćaskanja i drugih stvari."
+
+#~ msgid "Unknown time"
+#~ msgstr "Nepoznato vrijeme"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s, %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s dok se ne napuni u potpunosti"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Oprez: %s preostalo"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "preostaje %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Napunjeno"
+
+#~ msgid "Empty"
+#~ msgstr "Prazno"
+
+#~ msgid "Charging"
+#~ msgstr "Punjenje je u toku"
+
+#~ msgid "Discharging"
+#~ msgstr "Prazni se"
+
+#~ msgctxt "Battery nami"
+#~ msgid "Main"
+#~ msgstr "Glavni"
+
+#~ msgctxt "Battery nami"
+#~ msgid "Extra"
+#~ msgstr "Dodatno"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Bežični miš"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Bežična tastatura"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Neprekidni izvor napajanja"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Lični digitalni pomoćnik"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobilni telefon"
+
+#~ msgid "Media player"
+#~ msgstr "Muzički uređaj"
+
+#~ msgid "Computer"
+#~ msgstr "Računar"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Puni se"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Upozorenje"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Nisko"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Dobro"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Napunjeno"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Prazno"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterije"
+
+#~ msgid "When _idle"
+#~ msgstr "Kad_nepokretan"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "_Osvjetljenost tastatura"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "_Zamrači ekran kad je neaktivan"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Bežični uređaji zahtijevaju dodatno napajanje"
+
+#~ msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
+#~ msgstr ""
+#~ "Mobilni širokopojasni uređaji(3G, 4G, WiMax, itd.) zahtijevaju dodatno "
+#~ "napajanje"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "When on battery power"
+#~ msgstr "Kada se napaja baterijom"
+
+#~ msgid "When plugged in"
+#~ msgstr "Kada je prikopčano"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "Obustavljen & Ugašen"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automatski obustavljen"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Kada  je jačina  baterije _kritična"
+
+#~ msgid "Power Off"
+#~ msgstr "Ugasi"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernacija"
+
+#~ msgid "1 minute"
+#~ msgstr "1 minuta"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 minute"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 minute"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 minuta"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 minuta"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 minuta"
+
+#~ msgid "Out of toner"
+#~ msgstr "Nema tonera"
+
+#~ msgid "Low on developer"
+#~ msgstr "Ima malo fotografskog proizvođača"
+
+#~ msgid "Out of developer"
+#~ msgstr "Nema fotografskog proizvođača"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Ima malo zaliha markera"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Nema zaliha markera"
+
+#~ msgid "Open cover"
+#~ msgstr "Otvori pokrivač na štampaču"
+
+#~ msgid "Open door"
+#~ msgstr "Otvori vratanca na štampaču"
+
+#~ msgid "Low on paper"
+#~ msgstr "Ima malo papira"
+
+#~ msgid "Out of paper"
+#~ msgstr "Nema papira"
+
+#~ msgctxt "printer stati"
+#~ msgid "Stopped"
+#~ msgstr "Zaustavljen"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Posuda za smeće je skoro puna"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Posuda za smeće je puna"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Optički fotoprovodnik je blizu kraja života"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Optički fotoprovodnik više nije u funkciji"
+
+#~ msgctxt "printer stati"
+#~ msgid "Ready"
+#~ msgstr "Spreman"
+
+#~ msgctxt "printer stati"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Ne prihvata poslove"
+
+#~ msgctxt "printer stati"
+#~ msgid "Processing"
+#~ msgstr "Obrada"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nivo tonera"
+
+#~ msgid "Supply Level"
+#~ msgstr "Nivo zaliha"
+
+#~ msgctxt "printer stati"
+#~ msgid "Installing"
+#~ msgstr "Instaliranje"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktivan"
+#~ msgstr[1] "%u aktivna"
+#~ msgstr[2] "%u aktivna"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Nisam uspjeo da dodam novi štampač."
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Datoteke opisa PostScript štampača (*.ppd,*.PPD, *.ppd.gz, *PPD.gz, *.PPD."
+#~ "GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nisu pronađeni odgovarajući upravljački programi"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Nije moguće učitati UI: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Nastavi štampanje"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Pauziraj štampanje"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Dodaj novi štampač"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect Printer"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD Printer"
+
+#~ msgid "One Sided"
+#~ msgstr "Jednostrano"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Duga ivica (Standard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kratka ivica (Flip)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portret"
+
+#~ msgid "Landscape"
+#~ msgstr "Pejzaž"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Obrnuti pejzaž"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Prevrnuti portret"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "U tijeku"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Zadržan"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "U obradi"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Zaustavljen"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Obustavljen"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Završen"
+
+#~ msgid "Job Title"
+#~ msgstr "Ime posla"
+
+#~ msgid "Job State"
+#~ msgstr "Stanje posla"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serijski port"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralelni port"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Lokacija: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresa: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dvostrano"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tip papira"
+
+#~ msgid "Paper Source"
+#~ msgstr "Izvor papira"
+
+#~ msgid "Output Tray"
+#~ msgstr "Izlazna ladica"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript predfilter"
+
+#~ msgid "Pages per side"
+#~ msgstr "Stranica na strani"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Opšte"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Postavka stranice"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opcije instaliranja"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Posao"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Kvalitet slike"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Boja"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Završavam"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatski izbor"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Ugradi samo GhostScript fontove"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Prevedi u 1. nivo postskripta"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Prevedi u 2. nivo postskripta"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Bez predfiltriranja"
+
+#~ msgid "Supply"
+#~ msgstr "Zalihe"
+
+#~ msgid "_Default printer"
+#~ msgstr "_Zadani printer"
+
+#~ msgid "Jobs"
+#~ msgstr "Poslovi"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Prikaži _Poslove"
+
+#~ msgid "label"
+#~ msgstr "oznaka"
+
+#~ msgid "page 3"
+#~ msgstr "strana 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Štampaj _Test stranicu"
+
+#~ msgid "_Options"
+#~ msgstr "_Opcije"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Dodaj novi štampač"
+
+#~ msgid "Usage & History"
+#~ msgstr "Upotreba & Historija"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Da li da izbacim sve stavke iz smeća?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Sve stavke iz smeća će biti trajno uklonjene."
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Izbriši sve privremene datoteke?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Sve privremene datoteke će biti trajno izbrisane."
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Slanje izvještaja o tehničkim problemima nam pomaže da se poboljša %s. "
+#~ "Izvještaji se anonimno šalju bez ličnih podataka."
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Polica privatnosti"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Zaštiti svoje privatne informacije i kontrole koje ostali mogu vidjeti"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 sekundi"
+
+#~ msgid "1 day"
+#~ msgstr "1 dan."
+
+#~ msgid "2 days"
+#~ msgstr "2 dana"
+
+#~ msgid "3 days"
+#~ msgstr "3 dana"
+
+#~ msgid "4 days"
+#~ msgstr "4 dana"
+
+#~ msgid "5 days"
+#~ msgstr "5 dana"
+
+#~ msgid "6 days"
+#~ msgstr "6 dana"
+
+#~ msgid "7 days"
+#~ msgstr "7 dana"
+
+#~ msgid "14 days"
+#~ msgstr "14 dana"
+
+#~ msgid "30 days"
+#~ msgstr "30 dana"
+
+#~ msgid "Forever"
+#~ msgstr "Zauvijek"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Pamćenje historije olakšava ponovno traženje stvari.Ove stavke nisu nikad "
+#~ "podijeljene preko mreže."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Nedavno Korišteno"
+
+#~ msgid "Retain _History"
+#~ msgstr "Zadrži _Historiju"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Zaključavanje Ekrana štiti vašu privatnost kada niste tu."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Zaključaj ekran nakon praznog za"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Automatski očisti Smeće i privremene datoteke da pomognete održati svoj "
+#~ "kompjuter čist od nepotrebnih osjetljivih informacija."
+
+#~ msgid "Purge _After"
+#~ msgstr "Očisti_Nakon"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Slanjem informacije o tome koji program koristite pomažete nam da Vam "
+#~ "ponudimo više tačnih preporuka . To nam također pomaže da poboljšamo "
+#~ "softver ."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Pošalji statistiku o korištenju softvera"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Koristi se za određivanje svog geografskog položaja"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperijal"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrički"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nisu pronađeni ulazni izvori"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Ostali"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Razmak"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Pređi na naredni izvor"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Razmak"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "Možete promijeniti ove prečice u postavkama tastature"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Alternativni prijelaz na drugi izvor"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Lijevo+Desno Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Engleski (Ujedinjeno Kraljevstvo)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Ujedinjeno Kraljevstvo"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Prijavljene postavke koriste svi korisnici kada su prijavljeni na sistem"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Ostali"
+
+#~ msgid "Select Location"
+#~ msgstr "Odaberi Lokaciju"
+
+#~ msgid "_OK"
+#~ msgstr "U _redu"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Uključiti"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Isključiti"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Omogući"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Odaberi direktorij"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nema mreža odabranih za dijeljenje"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Djeljenje bluetoothom omogućava vam da podijelite datoteke sa drugim "
+#~ "uključenim bluetooth uređajima"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Primi samo od Povjerljivih Uređaja"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Spasi primljene datoteke u Downloads direktorij"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Neki uređaji su onesposobljeni jer nemaju pristup mreži."
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "Dijeljene privatnih datoteka omogućuje vam da dijelite vas Privatni "
+#~ "direktorij sa ostalim na vašoj trenutnoj mreži koristeći: <a href=\"dav://"
+#~ "%s\">dav://%s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "Omogući udaljene korisnike da se konektuju koristeći Sigurnu Školjka "
+#~ "komandu \n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "Omogući udaljenim korisnicima da vide ili kontrolišu vaš ekran "
+#~ "konektujući se na: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "Password:"
+#~ msgstr "Lozinka:"
+
+#~ msgid "Show Password"
+#~ msgstr "Prikaži lozinku"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "Nove konekcije moraju pitati za pristup"
+
+#~ msgid "Require a password"
+#~ msgstr "Zahtjev lozinke"
+
+#~ msgid "Bark"
+#~ msgstr "Lavež"
+
+#~ msgid "Drip"
+#~ msgstr "Žubor"
+
+#~ msgid "Glass"
+#~ msgstr "Staklo"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimum"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maksimum"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subvufer:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Bez pojačavanja"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "Provjeri _zvučnike"
+
+#~ msgid "Peak detect"
+#~ msgstr "Praćenje šiljka"
+
+#~ msgid "Device"
+#~ msgstr "Uređaj"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Testiranje zvučnika za %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Izaberite uređaj kao zvučni izlaz:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Podešavanja za izabrani uređaj:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Ulazna jačina:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Izaberite uređaj kao zvučni ulaz:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Zvučni Efekti"
+
+#~ msgid "Built-in"
+#~ msgstr "Ugrađen"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Opcije zvuka"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Provjera zvuka za događaj"
+
+#~ msgid "From theme"
+#~ msgstr "Na osnovu teme"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "I_zaberite zvuk za upozorenje:"
+
+#~ msgid "Stop"
+#~ msgstr "Prekini"
+
+#~ msgid "Custom"
+#~ msgstr "Prilagođeno"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Čitač ekrana"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Čitač ekrana"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Tipke zvuka"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Osvjetli Naslov prozora"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kratko"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ekrana"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ekrana"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ekrana"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Dugo"
+
+#~ msgid "Zoom"
+#~ msgstr "Uvećaj"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Boja"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standardni"
+
+#~ msgid "_Verify"
+#~ msgstr "_Potvrdi"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "Idi online da bi dodao\n"
+#~ "službenu prijavu računa."
+
+#~ msgid "Left thumb"
+#~ msgstr "Lijevi palac"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Srednji, lijevi prst"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Domali, lijevi prst"
+
+#~ msgid "Left little finger"
+#~ msgstr "Mali, lijevi prst"
+
+#~ msgid "Right thumb"
+#~ msgstr "Desni palac"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Desni, srednji prst"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Desni, domali prsti"
+
+#~ msgid "Right little finger"
+#~ msgstr "Desni, mali prst"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Omogući prijavu putem otiska prsta"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Domali, _desni prst"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Domali, _lijevi prst"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Vaš otisak prsta je uspješno sačuvan. Sada se možete prijaviti na sistem "
+#~ "preko čitača otisaka prsta."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Prjava;Ime;Otisak;Ikonica;Logotip;Faca;Zaporka;"
+
+#~ msgid "Login History"
+#~ msgstr "Historija prijava"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Potvrdi novu lozinku"
+
+#~ msgid "Add User Account"
+#~ msgstr "Dodaj korisnički nalog"
+
+#~ msgid "User Icon"
+#~ msgstr "Ikonica korisnika"
+
+#~ msgid "Last Login"
+#~ msgstr "Zadnja prijava"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Nova lozinka mora biti različita od stare."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Pokušaj promijeniti neka slova u brojeve."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Pokušaj promijeniti lozinku još malo."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Lozinka bez vašeg korisničkog imena bi bila jača."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Pokušaj izbjeći korištenje svog imena u lozinci."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Pokušaj izbjeći neke riječi uključene u lozinku."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Pokušaj izbjeći obične riječi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Pokušaj izbjeći promjenu mjesta postojećih riječi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Pokušaj koristiti više brojeva."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Pokušaj koristiti više velikih slova."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Pokušaj koristiti više malih slova."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Pokušaj korisiti više posebnih znakova, naprimjer znakovi interpunkcije."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Pokušaj koristit mješavinu slova,brojeva i interpunkciskih znakova."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Pokušaj izbječi ponavljanje istog znaka."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Pokušaj izbjeći ponavljanje istog tipa znaka:trebaš miješati slova,"
+#~ "brojeve i interpunkciske znakove."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Pokušaj izbjeći senkvence kao 1234 ili abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Pokušaj dodati više slova,brojeva i znakova."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr "Miješaj velika i mala slova i iskoristi broj ili dva."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr ""
+#~ "Dobra lozinka!Dodavanje više slova,brojeva i znakova interpunkcije "
+#~ "učiniti će je jačom."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Jačina:Slaba"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Jačina:Niska"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Jačina:Srednja"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Jačina:Dobra"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Jačina:Visoka"
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autentifikacija nije prošla"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Nova lozinka je prekratka"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Nova lozinka je suviše jednostavna"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Stara i nova lozinka su suviše slične"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Nova lozinka je već upotrebljavana u skorije vrijeme."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Nova lozinka mora da sadrži cifre ili specijalne karaktere"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Stara i nova lozinka su iste"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Vaša lozinka je promijenjena od kada ste se prvobitno ovlastili!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Nova šifra nema dovoljno različitih znakova"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Nepoznata greška"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "Trebali bi se poklapati sa web adresom vašem poslužavatelja računa."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Nisam uspio da dodam nalog"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Lozinke se ne podudaraju."
+
+#~ msgid "Failed to register account"
+#~ msgstr "Nisam uspio da upišem nalog"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nema podržanog načina za potvrđivanje identiteta sa ovim domenom"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Nisam uspio da pristupim domenu"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "To ime za prijavu nije radilo .\n"
+#~ "Molimo pokušajte ponovo."
+
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "To ime za prijavu nije radilo .\n"
+#~ "Molimo pokušajte ponovo."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Nisam uspio da se prijavim na domen"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "Omogući pronalazak domena.Možda si ga pogrešno postavio."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Nemate dozvole za pristup ovom uređaju. Kontaktirajte vašeg sistemskog "
+#~ "administratora."
+
+#~ msgid "The device is already in use."
+#~ msgstr "Uređaj je već u upotrebi."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Desila se unutrašnja greška."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Da obrišem registrovane otiske prsta?"
+
+#~ msgid "Done!"
+#~ msgstr "Završeno!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "Ne mogu da pristupim uređaju „%s“"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "Ne mogu da uhvatim otisak prsta sa uređaja „%s“"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Ne mogu da pristupim čitačima prsta"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Javite se sistemskom administratoru radi pomoći."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "Morate sačuvati jedan od vaših otisaka prsta sa uređaja „%s“, kako bi "
+#~ "omogućili prijavu na sistem putem otiska prsta."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Prst iybora"
+
+#~ msgid "This Week"
+#~ msgstr "Ove sedmice"
+
+#~ msgid "Last Week"
+#~ msgstr "Prošle sedmice"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sesija završila"
+
+#~ msgid "Session Started"
+#~ msgstr "Sesija počela"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Izaberite drugu lozinku."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Ispišite vašu trenutnu zaporku ponovno."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Ne mogu da promijenim lozinku"
+
+#~ msgid "Take a photo…"
+#~ msgstr "Uslikaj…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Potraži još slika…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "To koristi %s"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Nije moguće automatski pristupiti ovoj vrsti domene."
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nije pronađen takav domen ili područje"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Ne mogu da se prijavim kao „%s“ na domenu %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Pogrešna lozinka, molimo pokušajte ponovo"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Ostali računi"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Nije moguće obrisati korisnički račun"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Nije moguće povući  daljinski upravljanog korisnika"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nije moguće obrisati sopstveni račun."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s je i dalje prijavljen"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Brisanje računa do je korisnik prijavljen može ostaviti sistem u "
+#~ "zaglavljenom stanju!!!."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "Želite li sačuvati datoteke od korisnika '%s'?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Moguće je zadržati kućni direktorij, mail i privremene datoteke kada se "
+#~ "briše korisnički račun."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Izbriši datoteke"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Zadrži datoteke"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s's account?"
+#~ msgstr ""
+#~ "Da li ste sigurni da želite da uklonite daljinski upravljani nalog za %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Obriši"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Račun onemogućen"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Biće namještena na sljedećem prijavljivanju"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ništa"
+
+#~ msgid "Logged in"
+#~ msgstr "Prijavljen"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Nije moguće kontaktirati servis računa"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Morate se postarati da je ServisRačuna instaliran i omogućen."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Da bi ste napravili promjene,\n"
+#~ "kliknite na *"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Da napravite korisnički nalog,\n"
+#~ "kliknite prvo na ikonicu *"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Obrišite izabrani korisnički nalog"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Da obrišete izabrani korisnički nalog,\n"
+#~ "kliknite prvo na ikonicu *"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Korisnik sa imenom '%s' već postoji."
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "Kornisničko ime je previše dugo."
+
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "Korisničko ime počinje sa '-'."
+
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "Korisničko ime bi se trebalo sastojati od malih i velikih slova od a do "
+#~ "z, brojeva i karaktera '.', '-' i '_'."
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr ""
+#~ "Ovo će biti korišteno kao ime početne datoteke i neće se moći promjeniti."
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Gore"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Dole"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Nikakva"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Pošalji otkucaj tastera"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Promijeni monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Prikaži pomoć na ekranu"
+
+#~ msgid "Output:"
+#~ msgstr "Izlaz:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Zadrži odnos razmjere (crne trake):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapiraj na jedan monitor"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d od %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Mapiranje prikaza"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (asolutni)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Postavke tableta"
+
+#~ msgid "_Help"
+#~ msgstr "_Pomoć"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth postavke"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Poveži dugmad"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Podesite rezoluciju prikaza"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Podesi osjetljivost miša"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Režim praćenja"
+
+#~ msgid "Left Ring"
+#~ msgstr "Lijevi prsten"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Režim lijevog prstena #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Režim desnog prstena #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Lijeva dodirna traka"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Režim lijeve dodirne trake #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Desna dodirna traka"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Režim desne dodirne trake #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Režim prekidača lijevog dodirnog prstena"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Režim prekidača desnog dodirnog prstena"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Režim prekidača lijeve dodirne trake"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Režim prekidača desne dodirne trake"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Režim prekidača #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "Lijevo dugme #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "Desno dugme #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "Gornje dugme #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Donje dugme #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Bez akcije"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Klik lijevom tipkom miša"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Kliži prema gore"
+
+#~ msgid "Top Button"
+#~ msgstr "Gornje dugme"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Omogući pričljiv mod"
+
+#~ msgid "Show the overview"
+#~ msgstr "Prikaži pregled"
+
+#~ msgid "Search for the string"
+#~ msgstr "Traži string"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Priloži moguća imena panela i izađi"
+
+#~ msgid "Show help options"
+#~ msgstr "Prikaži opcije za pomoć"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel za prikaz"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "- Settings"
+#~ msgstr "-Postavke"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Pokrenite „%s --help“ kako bi vidjeli spisak svih naredbi iz komandne "
+#~ "linije.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "Dostupni paneli:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Lični"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardver"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistem"

--- a/po/bs.po~
+++ b/po/bs.po~
@@ -1,0 +1,7163 @@
+# translation of gnome-control-center.HEAD.bs.po to Bosnian
+# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER, 2004.
+# Kenan Hadžiavdić <kenan@bgnett.no>, 2004.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.HEAD.bs\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2015-02-27 07:32+0000\n"
+"PO-Revision-Date: 2015-03-03 14:44+0100\n"
+"Last-Translator: Merima Cisija <cisijam@gmail.com>\n"
+"Language-Team: Bosnian <lokal@linux.org.ba>\n"
+"Language: bs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
+"10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Launchpad-Export-Date: 2015-02-05 06:49+0000\n"
+"X-Generator: Poedit 1.7.4\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "Pozadina"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "Promjene dana"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "Lock Screen"
+msgstr "Zaključaj ekran"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Popločano"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Uvećaj"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "Centrirano"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Srazmjerno"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Popuna"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "Rasprostrto"
+
+#: ../panels/background/cc-background-chooser-dialog.c:437
+msgid "Wallpapers"
+msgstr "Pozadine"
+
+#: ../panels/background/cc-background-chooser-dialog.c:446
+msgid "Colors"
+msgstr "Boje"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:483
+msgid "Select Background"
+msgstr "Izaberi pozadinu"
+
+#: ../panels/background/cc-background-chooser-dialog.c:511
+msgid "Pictures"
+msgstr "Slike"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:543
+msgid "No Pictures Found"
+msgstr "Slike nisu nađene"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:561
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "Početna"
+
+#. translators: %s here is the nami of the Pictures directory, the string should bje translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:573
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "Mozes dodati slike u svoj %s folder i one će se pojaviti tamo"
+
+#: ../panels/background/cc-background-chooser-dialog.c:580
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1579
+#: ../panels/display/cc-display-panel.c:2022
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1247
+#: ../panels/network/net-device-wifi.c:1440
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/cc-printers-panel.c:1938
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:568
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+#: ../panels/user-accounts/um-photo-dialog.c:94
+#: ../panels/user-accounts/um-photo-dialog.c:217
+#: ../panels/user-accounts/um-user-panel.c:706
+#: ../panels/user-accounts/um-user-panel.c:724
+msgid "_Cancel"
+msgstr "_Odustani"
+
+#: ../panels/background/cc-background-chooser-dialog.c:581
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:96
+msgid "Select"
+msgstr "Odaberi"
+
+#: ../panels/background/cc-background-item.c:203
+msgid "multiple sizes"
+msgstr "više veličina"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:207
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:333
+msgid "No Desktop Background"
+msgstr "Nema pozadine za radnu površ"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "Trenutna pozadina"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Promijeni svoju pozadinu u pozadinu ili sliku"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Pozadina;Ekran;Radna površ;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "Bluetooth je onemogućen"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "Nisu pronađeni Bluetooth adapteri"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "Bluetooth je onemogućen hardverskim prekidačem"
+
+#. Translators: The found djevice is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1637
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Uključi i isključi blutut i poveži svoje uređaje"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "Postavi svoj uređaj za kalibrisanje preko kvadrata i pritisni 'Start'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+"Pomjeri svoj uređaj za kalibrisanje na poziciju za kalibrisanje i pritisni "
+"'Nastavi'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr ""
+"Pomjeri svoj uredđaj za kalibrisanje na poziciju površine i pritisni "
+"'Nastavi'"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "Zaklopite laptop"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "Unutrašnja greška se dogodila koja ne može biti popravljena."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "Alati potrebni za kalibrisanje nisu instalirani."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "Profil nije mogao biti generisan."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- seje
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "Ciljana bijela tačka nije dobijena."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "Završeno!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "Kalibrisanje nije uspjelo!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "Možete ukloniti uređaj za kalibraciju."
+
+#. TRANSLATORS: The user has to bje careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ne pomjerajte uređaj za kalibrisanje dok se izvršava"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Ekran laptopa"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Ugrađena Web kamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s monitor"
+
+#. TRANSLATORS: a flatbed scanner djevice, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s skener"
+
+#. TRANSLATORS: a camera djevice, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s kamera"
+
+#. TRANSLATORS: a printer djevice, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s printer"
+
+#. TRANSLATORS: a webcam djevice, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s Web kamera"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Omogućeno upravljanje bojom za %s"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Prikaži profile boja za %s"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:323
+msgid "Not calibrated"
+msgstr "Nije kalibrisano"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "Podrazumijevano: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space liki AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "Prostor boja: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "Probni profil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "Izaberi datoteku ICC profila"
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "_Uvezi"
+
+#. TRANSLATORS: filter nami on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "Podržani ICC profili"
+
+#. TRANSLATORS: filter nami on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "Sve datoteke"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "Ekran"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Nije uspjelo postavljanje datoteke %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "Profil je postavljen na:"
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "Upišite ovaj URL."
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+"Ponovo pokrenite ovaj kompjuter i pokrenite svoj normalni operativni sistem."
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "Ukucajte URL u svoj preglednik da bi skinuli i instalirali profil."
+
+#. TRANSLATORS: this is the dialog to savije the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "Snimi profil"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "_Snimi"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "Napravi profil boje za izabrani uređaj"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Mjerni uređaj nije otkriven. Provjerite da li je upaljen i ispravno "
+"priključen."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Mjerni uređaj ne podržava profilisanje štampača."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "Vrsta uređaja nije trenutno podržana."
+
+#. TRANSLATORS: standard spaces are well known colorspaces liki
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "Standardni prostor"
+
+#. TRANSLATORS: test profiles do things liki changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "Testni profil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatski"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may bje a poor reflection of the
+#. * djevice capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Niska kvaliteta"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Srednja kvaliteta"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Visoka kvaliteta"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Osnovna „RGB“"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Osnovna „CMYK“"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Osnovna siva"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "Vendor fabrika za isporuku podataka o kalibrisanju"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Popravka prikaza punog ekrana nije moguća za ovaj profil"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "Ovaj profil možda više nije precizan"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "Kalibracija prikaza"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1476
+msgid "Cancel"
+msgstr "Odustani"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "Početak"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "Nastavi"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "Završeno"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "Kalibracija ekrana"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibracija će stvoriti profil koji možete koristiti za upravljanje boje "
+"vašeg ekrana. Što duže provodite kalibrisanje, bolja kvaliteta boje profila."
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Nećete biti u mogućnosti koristiti vaš kompjuter dok traje kalibrisanje."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "Kvalitet"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "Približno vrijeme"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "Kvalitet kalibracije"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Odaberite senzorni uređaj koji želite koristiti za kalibrisanje."
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "Uređaj za kalibrisanje"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "Odaberite tip prikaza koji je povezan."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "Tip prikaza"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Odaberite ciljanu bijelu tačku za prikaz . Većina prikaza bi trebala biti "
+"kalibrisana na  D65 osvjetljenju."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "Bijela tačka profila"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Molimo Vas, namjestite osvjetljenje prikaza koje vam je tipično. Upravljanje "
+"bojom će biti najpreciznije pri tom nivou osvjetljenja."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativno, možete koristiti nivo osvjetljenja korišten na drugim "
+"profilima za ovaj uređaj."
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "Osvjetljaj ekrana"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Možete koristiti profil boje na drugom kompjuteru, ili čak kreirati profile "
+"za drukčije uslove osvjetljenja."
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "Naziv profila:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "Naziv profila"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "Profil uspješno kreiran"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "Kopija profila"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "Zahtijeva medij za pisanje"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "Postavi profil"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "Zahtijeva povezanost na internet"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Možete naći ove instrukcije u Kako koristiti profil na <a href=\"linux\">GNU/"
+"Linux</a>, <a href=\"osx\">Apple OS X</a> i <a href=\"windows\">Microsoft "
+"Windows</a> sistemima ."
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:732
+msgid "Summary"
+msgstr "Sažetak"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "Unesite datoteku…"
+
+#: ../panels/color/color.ui.h:30
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1477
+msgid "_Add"
+msgstr "_Dodaj"
+
+#: ../panels/color/color.ui.h:31
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Otkriveni problemi. Profil možda više neće raditi tačno. <a href=\"\">Vidi "
+"detalje.</a>"
+
+#: ../panels/color/color.ui.h:32
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Svakom uređaju je potreban jedan aktuelni profil boje da bi bio upravljan "
+"bojom."
+
+#: ../panels/color/color.ui.h:33
+msgid "Learn more"
+msgstr "Saznajte više"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more about color management"
+msgstr "Saznajte više o upravljanju bojama"
+
+#: ../panels/color/color.ui.h:35
+msgid "Set for all users"
+msgstr "Podesi za sve korisnike"
+
+#: ../panels/color/color.ui.h:36
+msgid "Set this profile for all users on this computer"
+msgstr "Postavi profil za sve korisnike na ovom računaru"
+
+#: ../panels/color/color.ui.h:37
+msgid "Enable"
+msgstr "Omogući"
+
+#: ../panels/color/color.ui.h:38
+msgid "Add profile"
+msgstr "Dodajte profil"
+
+#: ../panels/color/color.ui.h:39
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Calibrate…"
+msgstr "Kalibriši…"
+
+#: ../panels/color/color.ui.h:40
+msgid "Calibrate the device"
+msgstr "Kalibrišite uređaj"
+
+#: ../panels/color/color.ui.h:41
+msgid "Remove profile"
+msgstr "Ukloni profil"
+
+#: ../panels/color/color.ui.h:42
+msgid "View details"
+msgstr "Pogledaj detalje"
+
+#: ../panels/color/color.ui.h:43
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Nemoguće otkriti uređaje koji mogu biti upravljani bojom"
+
+#: ../panels/color/color.ui.h:44
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:45
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:46
+msgid "CRT"
+msgstr "Katodna cijev"
+
+#: ../panels/color/color.ui.h:47
+msgid "Projector"
+msgstr "Projektor"
+
+#: ../panels/color/color.ui.h:48
+msgid "Plasma"
+msgstr "Plazma"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (CCFL backlight)"
+msgstr "LCD(CCFL pzadinsko svjetlo)"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED pozadinsko svjetlo)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (white LED backlight)"
+msgstr "LCD (bijelo LED pozadinsko svjetlo)"
+
+#: ../panels/color/color.ui.h:52
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Široka skala LCD (CCFL pozadinsko ssvjetlo)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Široka skala LCD (RGB LED pozadinsko svjetlo)"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Visok"
+
+#: ../panels/color/color.ui.h:55
+msgid "40 minutes"
+msgstr "40 minuta"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Srednja"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 minuta"
+
+#: ../panels/color/color.ui.h:58
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Slabo"
+
+#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 minuta"
+
+#: ../panels/color/color.ui.h:60
+msgid "Native to display"
+msgstr "Prikaz koji odgovara ekranu"
+
+#: ../panels/color/color.ui.h:61
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (printanje i objavljivanje)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:63
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografija i grafike)"
+
+#: ../panels/color/color.ui.h:64
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "Boja"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Kalibrišite boju vaših uređaja, kao što su prikazi, kamere i printeri"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Boja;ICC;Profil;Kalibriši;Štampač;Prikaz;"
+
+#: ../panels/common/cc-common-language.c:323
+msgid "Other…"
+msgstr "Drugo…"
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:270
+#: ../panels/region/cc-input-chooser.c:167
+msgid "More…"
+msgstr "Više…"
+
+#: ../panels/common/cc-language-chooser.c:139
+msgid "No languages found"
+msgstr "Nisu nađeni jezici"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "Jezik"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "_Završeno"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will bje replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "Januar"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "Februar"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "Mart"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "April"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "Maj"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "Juni"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "Juli"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "August"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "Septembar"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "Oktobar"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "Novembar"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "Decembar"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "Datum i vrijeme"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "Sat"
+
+#. Translator: this is the separator between hours and minutes, liki in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "Minuta"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "Dan"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "Mjesec"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "Godina"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Time Zone"
+msgstr "Vremenska zona"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Search for a city"
+msgstr "Traži grad"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Automatic _Date & Time"
+msgstr "Automatsko _Datum i Vrijeme"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr "Zahtijeva pristup internetu"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Automatic Time _Zone"
+msgstr "Automatska Vremenska _zona"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "Date & _Time"
+msgstr "Datum i _Vrijeme"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr "Vremenska _zona"
+
+#: ../panels/datetime/datetime.ui.h:28
+msgid "Time _Format"
+msgstr "_Format vremena"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24-sata"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "Promijeni datum i vrijeme, uključujući vremensku zonu"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "Sat;Vrijemenskazona;Lokacija;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "Promjena postavki vremena i datuma"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Za promjenu vremena i datuma trebate potvrditi identitet."
+
+#: ../panels/display/cc-display-panel.c:564
+msgid "Lid Closed"
+msgstr "Zatvoren poklopac"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:567
+msgid "Mirrored"
+msgstr "Preslikano"
+
+#: ../panels/display/cc-display-panel.c:569
+#: ../panels/display/cc-display-panel.c:2196
+msgid "Primary"
+msgstr "Primarni"
+
+#: ../panels/display/cc-display-panel.c:571
+#: ../panels/notifications/cc-notifications-panel.c:247
+#: ../panels/power/cc-power-panel.c:1705 ../panels/power/cc-power-panel.c:1716
+#: ../panels/privacy/cc-privacy-panel.c:155
+#: ../panels/privacy/cc-privacy-panel.c:222
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "Isključeno"
+
+#: ../panels/display/cc-display-panel.c:574
+msgid "Secondary"
+msgstr "Sekundarni"
+
+#. Title of displays dialog when multiple monitors are present.
+#: ../panels/display/cc-display-panel.c:1576
+msgid "Arrange Combined Displays"
+msgstr "Uredi kombinovani prikaz"
+
+#: ../panels/display/cc-display-panel.c:1580
+#: ../panels/display/cc-display-panel.c:2023
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "_Primijeni"
+
+#: ../panels/display/cc-display-panel.c:1604
+msgid "Drag displays to rearrange them"
+msgstr "Povlači prikaze da bi ih preuredili"
+
+#: ../panels/display/cc-display-panel.c:2075
+msgid "Rotate counterclockwise by 90°"
+msgstr "Rotiraj  za 90 stepeni suprotno od smijera kazaljke"
+
+#: ../panels/display/cc-display-panel.c:2093
+msgid "Rotate by 180°"
+msgstr "Rotiraj za 180°"
+
+#: ../panels/display/cc-display-panel.c:2111
+msgid "Rotate clockwise by 90°"
+msgstr "Rotiraj za 90°u smijeru kazaljke na satu"
+
+#: ../panels/display/cc-display-panel.c:2132
+msgid "Size"
+msgstr "Veličina"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2145
+msgid "Aspect Ratio"
+msgstr "Proporcija"
+
+#: ../panels/display/cc-display-panel.c:2166
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: ../panels/display/cc-display-panel.c:2197
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "Prikaži na  gornjoj tabli  Pregled aktivnosti na ovom prikazu"
+
+#: ../panels/display/cc-display-panel.c:2203
+msgid "Secondary Display"
+msgstr "Sekundarni prikaz"
+
+#: ../panels/display/cc-display-panel.c:2204
+msgid "Join this display with another to create an extra workspace"
+msgstr "Spoji ovaj prikaz sa drugim da bi stvorili više radnog prostora"
+
+#: ../panels/display/cc-display-panel.c:2211
+msgid "Presentation"
+msgstr "Prezentacija"
+
+#: ../panels/display/cc-display-panel.c:2212
+msgid "Show slideshows and media only"
+msgstr "Prikaži samo pokretni prikaz i medije"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2217
+msgid "Mirror"
+msgstr "Ogledalo"
+
+#: ../panels/display/cc-display-panel.c:2218
+msgid "Show your existing view on both displays"
+msgstr "Prikaži potojeći pogled na oba prikaza"
+
+#: ../panels/display/cc-display-panel.c:2224
+msgid "Turn Off"
+msgstr "Isključi"
+
+#: ../panels/display/cc-display-panel.c:2225
+msgid "Don't use this display"
+msgstr "Nemoj koristiti ovaj prikaz"
+
+#: ../panels/display/cc-display-panel.c:2455
+msgid "Could not get screen information"
+msgstr "Ne mogu da dobijem podatke o ekranu"
+
+#: ../panels/display/cc-display-panel.c:2486
+msgid "_Arrange Combined Displays"
+msgstr "_Omogući kombinovane prikaze"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "Displeji"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Odaberi kako koristit povezane monitore i projektore"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "Panel;projektor;xrandr;Ekran;Rezolucija;Osvježi;Monitor;"
+
+#: ../panels/info/cc-info-panel.c:385
+msgid "Wayland"
+msgstr "Wayland"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:388 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#: ../panels/info/cc-info-panel.c:473
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-bit"
+
+#: ../panels/info/cc-info-panel.c:475
+#, c-format
+msgid "%d-bit"
+msgstr "%d-bit"
+
+#: ../panels/info/cc-info-panel.c:1155
+msgid "Ask what to do"
+msgstr "Pitaj šta da uradiš"
+
+#: ../panels/info/cc-info-panel.c:1159
+msgid "Do nothing"
+msgstr "Ne radi ništa"
+
+#: ../panels/info/cc-info-panel.c:1163
+msgid "Open folder"
+msgstr "Otvori direktorij"
+
+#: ../panels/info/cc-info-panel.c:1254
+msgid "Other Media"
+msgstr "Drugi mediji"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for audio CDs"
+msgstr "Odaberite aplikaciju za otvaranje audio CD-ova"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application for video DVDs"
+msgstr "Odaberite aplikaciju za otvaranje video DVD-ova"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Odaberite aplikaciju koja će se pokretati kad muzički plejer bude priključen"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application to run when a camera is connected"
+msgstr "Odaberite aplikaciju koja će se pokretati kad kamera bude priključena"
+
+#: ../panels/info/cc-info-panel.c:1289
+msgid "Select an application for software CDs"
+msgstr ""
+"Odaberite aplikaciju koja će se pokretati kad budete ubacili CD-ove sa "
+"softverom"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1301
+msgid "audio DVD"
+msgstr "audio DVD"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank Blu-ray disc"
+msgstr "prazan Blu-ray disk"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank CD disc"
+msgstr "prazan CD disk"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank DVD disc"
+msgstr "prazan DVD disk"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "blank HD DVD disc"
+msgstr "prazan HD DVD disk"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video disk"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "e-book reader"
+msgstr "e-book čitač"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "HD DVD video disc"
+msgstr "HD DVD video disk"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Picture CD"
+msgstr "CD sa slikama"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Video CD"
+msgstr "Video CD"
+
+#: ../panels/info/cc-info-panel.c:1312
+msgid "Windows software"
+msgstr "Windows softver"
+
+#: ../panels/info/cc-info-panel.c:1435
+#: ../panels/keyboard/keyboard-shortcuts.c:1947
+msgid "Section"
+msgstr "Odjeljak"
+
+#: ../panels/info/cc-info-panel.c:1444 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "Predpregled"
+
+#: ../panels/info/cc-info-panel.c:1450 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "Standardne aplikacije"
+
+#: ../panels/info/cc-info-panel.c:1455 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "Pokretni mediji"
+
+#: ../panels/info/cc-info-panel.c:1480
+#, c-format
+msgid "Version %s"
+msgstr "Verzija %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:46
+msgid "Details"
+msgstr "Detalji"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "Pregled informacija o vašem sistemu"
+
+#. sure that you usi the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"uređaj;sistem;informacija;memorija:procesor;verzija;standardna;aplikacija;"
+"omiljeni;cd;dvd;usb;audio;video;disc;pokretan;medij;automatsko pokretanje;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "Odaberite kako bi se ostali mediji trebali pridržavati"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "_Radnja:"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "_Vrsta:"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "Ime uređaja"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "Memorija"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "Procesor"
+
+#. To translators: this field contains the distro nami, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "Osnovni sistem"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "Disk"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "Računam…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "Grafika"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "Virtualizacija"
+
+#: ../panels/info/info.ui.h:13
+msgid "Check for updates"
+msgstr "Provjeri ažuriranja"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "_Web"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "_Pošta"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "_Kalendar"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "M_uzika"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "_Video"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "_Slike"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "Odaberi kako bi se mediji trebali pridržavati"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "CD _audio"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "_Muzički program"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "_Softver"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "_Ostali mediji"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Ne pokreći programe po ubacivanju medija"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "Zvuk i mediji"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "Ugasi zvuk"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "Smanji zvuk"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "Pojačaj zvuk"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "Pokreni media plejer"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "Sviraj (ili sviraj/pauza)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "Pauziraj reprodukciju"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "Zaustavi reprodukciju"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "Prethodna numera"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "Naredna numera"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "Izbaci"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "Tipkanje"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "Prijeđi na sljedeci ulaz"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "Prijeđi na prethodni ulaz"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "Pokretači"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "Pokreni preglednik pomoći"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1604
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "Postavke"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "Pokreni kalkulator"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "Pokreni program za e-poštu"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "Pokreni web preglednik"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "Početni direktorij"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Traži"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "Snimci ekrana"
+
+#. translators: $PICTURES will bje replaced by the nami of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "Spasi snimke ekrana u $PICTURES"
+
+#. translators: $PICTURES will bje replaced by the nami of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Spasi snimke prozora  u $PICTURES"
+
+#. translators: $PICTURES will bje replaced by the nami of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Spasi snimke prostora ekrana u $PICTURES"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "Kopiraj snimak u  odlagalište"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Kopiraj snimak prozora u  odlagalište"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Kopiraj snimak područja u  odlagalište"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "Snimi kratku snimku ekrana"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "Sistem"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Odjava"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "Zaključaj ekran"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "Opšti pristup"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "Uključi/isključi uvećanje"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "Uvećaj"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "Umanji"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "Uključi/isključi čitač ekrana"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "Uključi/isključi ekransku tastaturu"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "Povećaj veličinu teksta"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "Smanji veličinu teksta"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "Uključi/isključi veliki kontrast"
+
+#. translators:
+#. * The djevice has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1219
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. Seje
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "Taster alternativnih znakova"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * Seje http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "Taster za kompoziciju"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "Samo za ispravljače pređi za sljedeći izvor"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Tastatura"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"Pregled i promjena prečice za tastaturu i postavi svoje preferirano kucanje"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Prečac;Ponovi;Blinkaj;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "Proizvoljna prečica"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "_Ime:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "K_omanda:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "Ponavljanje tastera"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "_Ponovi pritiskanje tipki kada se tipka drži pritisnuta"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "_Odgoda:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "_Brzina:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "Kratko"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "Sporo"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "Brzina ponavljanja tastera"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "Brzo"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "Treperenje kursora"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "Pokazivač _trepće u poljima za tekst"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "_Brzina:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "Brzina treptanja kursora"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "Ulazni izvori"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "Dodaj prečicu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "Ukloni prečicu"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"Da bi ste uredili prečac, kliknite red i držite nove tastere ili Briši "
+"unazad da obrišete."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "Prečaci"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:636
+#: ../panels/keyboard/keyboard-shortcuts.c:644
+msgid "Custom Shortcuts"
+msgstr "Proizvoljna prečica"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:861
+msgid "<Unknown Action>"
+msgstr "<Nepoznata akcija>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1358
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"Prečica „%s“ ne može biti korišćena jer će biti nemoguće kucati koristeći "
+"ovaj taster.\n"
+"Pokušajte istovremeno sa tasterom kao što je Kontrol, Alt ili Šift."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1388
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"Prečica „%s“ se već koristi za\n"
+"„%s“"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1393
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"Ako ponovo dodijelite prečicu za „%s“, prečica za „%s“ će biti onemogućena."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1399
+msgid "_Reassign"
+msgstr "_Ponovo dodjeli"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1440
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"\"%s\" prečica ima pridruženu \"%s\" prečicu . Želite li je automatski "
+"postaviti na \"%s\"?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1450
+#, c-format
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"\"%s\" je trenutno povezan s \"%s\" , ovaj prečac će biti onemogućen ako se "
+"krene naprijed ."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1457
+msgid "_Assign"
+msgstr "_Dodijeli"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "Provjeri Svoje _Postavke"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+msgid "Test Your Settings"
+msgstr "Provjeri Svoje Postavke"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "Miš i dodirna ploča"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Promijeni osjetljivost svog miša ili dodirne ploče i odaberi za dešnjaka ili "
+"ljevaka"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Podloga za traganje;Pokazivač;Klik;Tapši;Duplo;Dugme; Kugla za traganje;"
+"Spuštanje;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "Općenito"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "Sporo"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "Vrijeme za dupli klik"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "Brzo"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "_Dupli klik"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "Primarna _tipka"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, lift button as primary"
+msgid "_Left"
+msgstr "_Lijevo"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "_Desno"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "Miš"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "Brzina _pokazivača"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "Sporo"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "Brzo"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "Dodirna površina"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "Sporo"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "Brzo"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Tap to _click"
+msgstr "Tupni za _klik"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Two _finger scroll"
+msgstr "_Skrol s dva prsta"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so usi the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+msgid "_Natural scrolling"
+msgstr "_Standardno klizanje"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Isprobajte klikanje, dvostruko klikanje, klizanje"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "Pet klikova, GEGL vrijeme!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "Dvostruki klik, primarna tipka"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "Jednostruki klik, primarna tipka"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "Dvostruki klik, srednja tipka"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "Jednostruki klik, srednja tipka"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "Dvostruki klik, sekundarna tipka"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "Jednostruki klik, sekundarna tipka"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:358
+msgid "Air_plane Mode"
+msgstr "Avionski način"
+
+#: ../panels/network/cc-network-panel.c:966
+msgid "Network proxy"
+msgstr "Mrežni proxy"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the djevice list.
+#.
+#: ../panels/network/cc-network-panel.c:1145 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#: ../panels/network/cc-network-panel.c:1299
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ups, nešto je pošlo loše. Molim kontaktirajte vašeg isporučioca softvera."
+
+#: ../panels/network/cc-network-panel.c:1305
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager treba da bude pokrenut."
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x _Sigurnost"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "strana 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "Anoni_mni identitet"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "Unutrašnja _autentikacija"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "strana 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "Sigurnost"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "automatski"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:218
+#: ../panels/network/net-device-wifi.c:382
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:222
+#: ../panels/network/net-device-wifi.c:387
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:226
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:231
+msgid "Enterprise"
+msgstr "Enterprajz"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:236
+#: ../panels/network/net-device-wifi.c:372
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nikakva"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "Nikad"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:815
+msgid "Today"
+msgstr "Danas"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:818
+msgid "Yesterday"
+msgstr "Juče"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:476
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "Prije %i dan"
+msgstr[1] "Prije %i dana"
+msgstr[2] "Prije %i dana"
+
+#. Translators: network djevice speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:533
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nikakva"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Slaba"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "U redu"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:568
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Dobra"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:570
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Izvrsna"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "Identitet"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "Adresa"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "Mrežna maska"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "Mrežni izlaz"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "Obrisati adresu"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "Dodaj"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "Server"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "Obrisati DNS Server"
+
+#. Translators: Please seje https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "Metrički"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "Obrisati put"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "Automatski (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:26
+#: ../panels/privacy/cc-privacy-panel.c:182
+msgid "Manual"
+msgstr "Ručno"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "Samo veži-lokalno"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "Prefiks"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:182
+msgid "Automatic"
+msgstr "Automatski"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "Automatski, samo DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:51
+msgid "Reset"
+msgstr "Resetuj"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ništa"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bitni ključ (Hex ili ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit lozinka"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dinamički WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "Lični WPA & WPA2"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "Poslovni WPA & WPA2"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr "Jačina Signala"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "Brzina veze"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:157
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 Adresa"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:158
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 Adresa"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:165
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "Hardverska Adresa"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:169
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "Podrazumijevana putanja"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "Posljednje korišteno"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "Parica (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Interfejs priložene jedinice (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "Medijski nezavisan interfejs (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "_Ime"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "_MAC Adresa"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "_Klonirana Adresa"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "bajtova"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "Omogući drugim _korisnicima"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "_Poveži se automatski"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "_Zona Zaštitnog zida"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:113
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "Podrazumijevano"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "Zona definira nivo povjerenja povezanosti"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "_Adrese"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "Automatski DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "Putanje"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "Automatske Putanje"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr "Koristi ovu povezanost _samo za resurse na njegovoj mreži"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "Nemoguće otvoriti urednik povezanosti"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "Novi profil"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "Povez"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "Tim"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "Most"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "Nije  uspjelo unijeti VPN prključke"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "Uvezi iz datoteke"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "Dodati mrežnu konekciju"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "_Resetuj"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1441
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "_Zaboravi"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"Resetuj postavke za ovu mrežu,uključujući lozinke,ali zapamti je kao "
+"omiljenu mrežu"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"Ukloni sve detalje povezane sa ovom mrežom i ne pokušavaj automatsko "
+"povezivanje"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "S_igurnost"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "Ne mogu da uvezem VPN vezu"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Ne mogu da pročitam datoteku „%s“ ili ona ne sadrži poznate VPN podatke o "
+"vezi\n"
+"\n"
+"Greška: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "Izaberite datoteku za uvoz"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1939
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "_Open"
+msgstr "_Otvori"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "Već postoji datoteka „%s“."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "_Zamijeni"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Da li želite da zamijenite %s VPN vezom koju hoćete da sačuvate?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "Ne mogu da izvezem VPN vezu"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN veza '%s' ne može biti izvezena u %s.\n"
+"\n"
+"Greška: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+msgid "Export VPN connection"
+msgstr "Izvoz VPN mreže"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Greška, nemoguće uvesti VPN urednik veze)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "_MojaStandardna Mreža"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "Napravi dostupno _drugim korisnicima"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "Mreža"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "Kontroliši povezivanje na Internet"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"Mreža;Wireless;Wi-Fi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;vlan;"
+"bridge;bond;DNS;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "Robovi veze"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(nema)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "Robovi mosta"
+
+#: ../panels/network/net-device-ethernet.c:110
+#: ../panels/network/net-device-wifi.c:462
+msgid "never"
+msgstr "nikad"
+
+#: ../panels/network/net-device-ethernet.c:120
+#: ../panels/network/net-device-wifi.c:472
+msgid "today"
+msgstr "danas"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:474
+msgid "yesterday"
+msgstr "juče"
+
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP Adresa"
+
+#: ../panels/network/net-device-ethernet.c:176
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "Zadnje koristeno"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * djevice list.
+#.
+#: ../panels/network/net-device-ethernet.c:286
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "Ožičeno"
+
+#: ../panels/network/net-device-ethernet.c:354
+#: ../panels/network/net-device-wifi.c:1597
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "Opcije…"
+
+#: ../panels/network/net-device-ethernet.c:472
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "Dodajte novu vezu"
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr "Robovi tima"
+
+#: ../panels/network/net-device-wifi.c:1154
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"Ako imaate povezanost na internet koja nije bežična, možes kreirati bežičnu "
+"vruću tačku da dijeliš povezanost sa drugima."
+
+#: ../panels/network/net-device-wifi.c:1158
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "Uključivanjem bežične vruće tačke prekinućete vezu sa <b>%s</b>."
+
+#: ../panels/network/net-device-wifi.c:1162
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"Nije moguće pristupiti internetu preko vaše bežične veze dok je vruća tačka "
+"aktivna."
+
+#: ../panels/network/net-device-wifi.c:1245
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Da zaustavim vruću tačku i da prekinem vezu svim korisnicima?"
+
+#: ../panels/network/net-device-wifi.c:1248
+msgid "_Stop Hotspot"
+msgstr "_Zaustavi vruću tačku"
+
+#: ../panels/network/net-device-wifi.c:1305
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Pravila sistema zabranjuju korištenje vruće tačke"
+
+#: ../panels/network/net-device-wifi.c:1308
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Bežični uređaj ne podržava način vruće tačke"
+
+#: ../panels/network/net-device-wifi.c:1437
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Detalji netvorka za odabrani netvork, uključujući šifru i sve posebne "
+"promjene će biti izgubljene."
+
+#: ../panels/network/net-device-wifi.c:1750
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "Historija"
+
+#: ../panels/network/net-device-wifi.c:1754
+#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
+#: ../panels/wacom/cc-wacom-page.c:533
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "_Close"
+msgstr "_Zatvori"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1762
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Zaboravi"
+
+#. TRANSLATORS: this is when the usi leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "Web Proxy Autodiscovery se koristi kada URL-a konfiguracije nema."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "Ovo je preporučljivo za nepovjerljive javne mreže."
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "Proxy"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "_Dodaj Profil"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "Pružalac"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "Nikakav"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "Ručni"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "Automatski"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "_Metod"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "_Konfiguracioni URL"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "_HTTP Proxy"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS proxy"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "_FTP Proxy"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "Domaćin čarapa"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "_Ignoriši Domaćine"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "Port za HTTP proxy"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "Port za HTTPS proxy"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "Port za FTP proxy"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "Port za Socks proxy"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "Isključi uređaj"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "Dodaj uređaj"
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "Ukloni uređaj"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN Tip"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "Ime grupe"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "Šifra grupe"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "Ime korisničkog računa"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "Isključi VPN konekciju"
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "Automatska_Konekcija"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "detalji"
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "_Lozinka"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "Ništa"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "Prikaži Šifru"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr "Omogući drugim korisnicima"
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "identitet"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr "Automatski (DHCP) samo adrese"
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr "Link-samo lokalni"
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr "Podijeljeno sa drugim kompjuterima"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr "_Ignoriši automatski određene puteve"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr "_Kopirana MAC Adresa"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr "hardver"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"Resetuj postavke za ovu konekciju na zadane, ali zapamti kao preferiranu "
+"konekciju."
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"Ukloni sve detalje povezane sa ovom mrežom i ne pokušavaj se automatski "
+"konektovati na nju."
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "reset"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "Hardver"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr "WI-Fi vruća tačka"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Turn On"
+msgstr "_Uključi"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Turn Wi-Fi off"
+msgstr "Ugasi Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_Use as Hotspot…"
+msgstr "_Koristi kao vruću tačku"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "_Connect to Hidden Network…"
+msgstr "_Konektuj na Skrivenu Mrežu"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "_History"
+msgstr "_Historija"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Ugasi da se konektuje na Wi-Fi mrežu"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Network Name"
+msgstr "Ime mreže"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Connected Devices"
+msgstr "Priključeni uređaji"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "Security type"
+msgstr "Tip Sigrunosti"
+
+#: ../panels/network/network-wifi.ui.h:63
+msgid "Security key"
+msgstr "Sigurnosni ključ"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "Infrastruktura"
+
+#. TRANSLATORS: djevice status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "Stanje je nepoznato"
+
+#. TRANSLATORS: djevice status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "Neupravljivo"
+
+#. TRANSLATORS: djevice status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "Nedostupno"
+
+#. TRANSLATORS: djevice status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "Povezujem"
+
+#. TRANSLATORS: djevice status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "Autentifikacija je potrebna"
+
+#. TRANSLATORS: djevice status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "Povezano"
+
+#. TRANSLATORS: djevice status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "Prekidanje veze"
+
+#. TRANSLATORS: djevice status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "Veza nije uspjela"
+
+#. TRANSLATORS: djevice status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "Stanje nije raspoloživo (nedostupno)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "Nije povezan"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "Nije uspjelo podešavanje"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "Nije uspjelo podešavanje IP-a"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "Isteklo je podešavanje IP-a"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "Tajne su bile zahtijevane ali nisu dane"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "Prekinuta je veza sa 802.1x suplikantom"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "Nije uspjelo podešavanje 802.1x suplikanta"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1x suplikant nije uspio"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Potvrđivanje identiteta 802.1x suplikanta je trajalo predugo"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "PPP servis neuspio u startu"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "PPP servis diskonektovan"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP neuspio"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "DHCP klijent neuspio u startu"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "Greška DHCP klijenta"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "Neuspjeh DHCP klijenta"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "Usluga dijeljene konekcije neuspjela u startu"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "Neuspjela usluga dijeljene konekcije"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "Neuspjela AutoIP usluga"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "Greška AutoIP usluge"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "Neuspjela AutoIP usluga"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "Linija zauzeta"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "Nema pozivnog tona"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "Zvučni nosač se ne može uspostaviti"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "Isteklo je vrijeme zahtjeva pozivanja"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "Pokušaj pozivanja nije uspeo"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "Inicijalizacija modema neuspjela"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "Neuspio izbor navedenog APN"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "Ne tražim mreže"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "Odbijena registracija mreža"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "Istekla registracija mreža"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "Neuspjela registracija na navedenu mrežu"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "Provjera PIN-a neuspjela"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "Možda nedostaje firmver za uređaj"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "Veza je nestala"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "Postojeća veza biće pretpostavljena"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "Nije pronađen modem"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "Veza Bluetooth nije uspjela"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "SIM kartica nije ubačena"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "Potreban je SIM PIN"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "Potreban je SIM PUK"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "Pogrešna SIM"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "InfiniBand uređaj ne podržava povezani režim"
+
+#. TRANSLATORS: djevice status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "Nije uspjela zavisnost veze"
+
+#. TRANSLATORS: djevice status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "Firmver nedostaje"
+
+#. TRANSLATORS: djevice status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "Izvučen kabl"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "Nije izabran sertifikat Potvrđivanja Autoriteta (CA)"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"Nekorištenje certikata koji je potvrdio Certifikacijski autoritet (CA) može "
+"rezultirati u konekcijama do nesigurnih Wi-Fi mreže. Želite li odabrati "
+"certifikat certifikacijskog autoriteta?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "Ignoriši"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "Izaberite certifikat PA (CA)"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, ili PKCS#12 lični ključevi (*.der, *.pijem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER ili PEM sertifikati (*.der, *.pijem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+msgid "Choose a PAC file"
+msgstr "Izaberi PAC datoteku"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC datoteke (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC_datoteka"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "_Unutrašnja autentifikacija"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "PAC pro_vizije"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "Anoniman"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "Autentifikovan"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "Obostrano"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "_Ime korisničkog računa"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "Prikaži _lozinku"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate"
+msgstr "Izaberi certifikat Certificate Authority"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "Verzija 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "Verzija 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "C_A certifikat"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP_verzija"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "Uvijek mi zatraži _lozinku"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "Nešifrovani privatni ključevi nisu sigurni"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Izgleda da izabrani privatni ključ nije zaštićen lozinkom.  Ovo može "
+"ugroziti vaše sigurnosne podatke.  Izaberite privatni ključ koji je zaštićen "
+"lozinkom.\n"
+"\n"
+"(Možete zaštititi privatne ključeve koristeći openssl)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+msgid "Choose your personal certificate"
+msgstr "Izaberi svoj lični certifikat"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+msgid "Choose your private key"
+msgstr "Izaberite lični ključ"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "I_dentitet"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "_Korisnički certifikat"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "Lični _ključ"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "_Lična lozinka za ključ"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "Ne _upozoravaj me više"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "Ne"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "Da"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "BRZO"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "Tunelski TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "Zaštićeni EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "Au_tentifikacija"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (Podrazumijevano)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "Otvoreni sistem"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "Dijeljeni ključ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "_Ključ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "P_rikaži ključ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP inde_x"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "_Vrsta"
+
+#: ../panels/notifications/cc-notifications-panel.c:247
+#: ../panels/power/cc-power-panel.c:1711 ../panels/power/cc-power-panel.c:1718
+#: ../panels/privacy/cc-privacy-panel.c:155
+#: ../panels/privacy/cc-privacy-panel.c:222
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "Uključiti"
+
+#. This is the pir application switch for message tray usage.
+#: ../panels/notifications/edit-dialog.ui.h:2
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "Napomene"
+
+#. This is the setting to configure sounds associated with notifications.
+#: ../panels/notifications/edit-dialog.ui.h:4
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "Zvučna Upozorenja"
+
+#: ../panels/notifications/edit-dialog.ui.h:5
+msgctxt "notifications"
+msgid "Notification Banners"
+msgstr "Trake obavještenja "
+
+#. Banners here refers to message tray notifications in the middle of the screen.
+#: ../panels/notifications/edit-dialog.ui.h:7
+msgctxt "notifications"
+msgid "Show Message Content in Banners"
+msgstr "Prikaži sadržaj poruke u Trakama"
+
+#: ../panels/notifications/edit-dialog.ui.h:8
+msgctxt "notifications"
+msgid "Lock Screen Notifications"
+msgstr "Zaključaj obavještenja na ekranu"
+
+#: ../panels/notifications/edit-dialog.ui.h:9
+msgctxt "notifications"
+msgid "Show Message Content on Lock Screen"
+msgstr "Prikaži sadržaj poruke u Zaključanom Ekranu"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "Napomene"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr "Kontroliši koje napomene su prikazane i šta prikazuju"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Napomene;Trake;poruke;Poslužavnik;Skočni;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Notification Banners"
+msgstr "Trake obavještenja"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Lock Screen Notifications"
+msgstr "Zaključaj obavještenja na ekranu"
+
+#. List of applications.
+#: ../panels/notifications/notifications.ui.h:4
+#: ../panels/sound/gvc-mixer-dialog.c:1781
+msgid "Applications"
+msgstr "Aplikacije"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Ostali"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "Dodaj nalog"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr "Elektronska pošta"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr "Kontakti"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "Razgovor"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "Resursi"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "Greška prilikom prijavljivanja na nalog"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "Uvjerenja su istekla."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr "Prijavi se da omogućiš ovaj račun."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr "_Prijavi se"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "Greška prilikom stvaranja naloga"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "Greška prilikom uklanjanja naloga"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "Da li ste sigurni da želite da uklonite nalog?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "Ovo neće ukloniti nalog na serveru."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "_Ukloni"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "Nalozi na mreži"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Konektuj se na svoj online račun i odluči za šta ćeš ih koristiti"
+
+#. For ReadItLater and Pocket, seje http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Kalendar;Mail;Kontakt;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "Nisu podešeni nalozi na mreži"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "Ukloni nalog"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "Dodajte nalog na mreži"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"Dodavanje naloga omogućava vašim aplikacijama da mu pristupe zbog "
+"dokumenata, pošte, kontakata, kalendara, ćaskanja i drugih stvari."
+
+#: ../panels/power/cc-power-panel.c:192
+msgid "Unknown time"
+msgstr "Nepoznato vrijeme"
+
+#: ../panels/power/cc-power-panel.c:198
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minut"
+msgstr[1] "%i minuta"
+msgstr[2] "%i minuta"
+
+#: ../panels/power/cc-power-panel.c:210
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i sat"
+msgstr[1] "%i sata"
+msgstr[2] "%i sati"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:218
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s, %i %s"
+
+#: ../panels/power/cc-power-panel.c:219
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "sat"
+msgstr[1] "sata"
+msgstr[2] "sati"
+
+#: ../panels/power/cc-power-panel.c:220
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minuta"
+msgstr[2] "minuta"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:239
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s dok se ne napuni u potpunosti"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:246
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Oprez: %s preostalo"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:251
+#, c-format
+msgid "%s remaining"
+msgstr "preostaje %s"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:256 ../panels/power/cc-power-panel.c:284
+msgid "Fully charged"
+msgstr "Napunjeno"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:260 ../panels/power/cc-power-panel.c:288
+msgid "Empty"
+msgstr "Prazno"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:275
+msgid "Charging"
+msgstr "Punjenje je u toku"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:280
+msgid "Discharging"
+msgstr "Prazni se"
+
+#: ../panels/power/cc-power-panel.c:405
+msgctxt "Battery nami"
+msgid "Main"
+msgstr "Glavni"
+
+#: ../panels/power/cc-power-panel.c:407
+msgctxt "Battery nami"
+msgid "Extra"
+msgstr "Dodatno"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Wireless mouse"
+msgstr "Bežični miš"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Wireless keyboard"
+msgstr "Bežična tastatura"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Uninterruptible power supply"
+msgstr "Neprekidni izvor napajanja"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Personal digital assistant"
+msgstr "Lični digitalni pomoćnik"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Cellphone"
+msgstr "Mobilni telefon"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:494
+msgid "Media player"
+msgstr "Muzički uređaj"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:497
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:500
+msgid "Computer"
+msgstr "Računar"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:503 ../panels/power/cc-power-panel.c:734
+#: ../panels/power/cc-power-panel.c:2040
+msgid "Battery"
+msgstr "Baterija"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Puni se"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:564
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Upozorenje"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:569
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Nisko"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:574
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Dobro"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:579
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Napunjeno"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:583
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Prazno"
+
+#: ../panels/power/cc-power-panel.c:732
+msgid "Batteries"
+msgstr "Baterije"
+
+#: ../panels/power/cc-power-panel.c:1134
+msgid "When _idle"
+msgstr "Kad_nepokretan"
+
+#: ../panels/power/cc-power-panel.c:1462
+msgid "Power Saving"
+msgstr "Ušteda energije"
+
+#: ../panels/power/cc-power-panel.c:1490
+msgid "_Screen brightness"
+msgstr "_Osvjetljenost ekrana"
+
+#: ../panels/power/cc-power-panel.c:1496
+msgid "_Keyboard brightness"
+msgstr "_Osvjetljenost tastatura"
+
+#: ../panels/power/cc-power-panel.c:1506
+msgid "_Dim screen when inactive"
+msgstr "_Zamrači ekran kad je neaktivan"
+
+#: ../panels/power/cc-power-panel.c:1531
+msgid "_Blank screen"
+msgstr "_Prazan ekran"
+
+#: ../panels/power/cc-power-panel.c:1568
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: ../panels/power/cc-power-panel.c:1573
+msgid "Wireless devices require extra power"
+msgstr "Bežični uređaji zahtijevaju dodatno napajanje"
+
+#: ../panels/power/cc-power-panel.c:1598
+msgid "_Mobile broadband"
+msgstr "_Širokopojasna veza"
+
+#: ../panels/power/cc-power-panel.c:1603
+msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
+msgstr ""
+"Mobilni širokopojasni uređaji(3G, 4G, WiMax, itd.) zahtijevaju dodatno "
+"napajanje"
+
+#: ../panels/power/cc-power-panel.c:1653
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: ../panels/power/cc-power-panel.c:1707
+msgid "When on battery power"
+msgstr "Kada se napaja baterijom"
+
+#: ../panels/power/cc-power-panel.c:1709
+msgid "When plugged in"
+msgstr "Kada je prikopčano"
+
+#: ../panels/power/cc-power-panel.c:1839
+msgid "Suspend & Power Off"
+msgstr "Obustavljen & Ugašen"
+
+#: ../panels/power/cc-power-panel.c:1872
+msgid "_Automatic suspend"
+msgstr "_Automatski obustavljen"
+
+#: ../panels/power/cc-power-panel.c:1896
+msgid "When battery power is _critical"
+msgstr "Kada  je jačina  baterije _kritična"
+
+#: ../panels/power/cc-power-panel.c:1951
+msgid "Power Off"
+msgstr "Ugasi"
+
+#: ../panels/power/cc-power-panel.c:2087
+msgid "Devices"
+msgstr "Uređaji"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "Napajanje"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr "Prikaži stanje baterije i promijeni postavke čuvanja energije"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"Energija;Uspavaj;Obustavi;Zaledi;Baterija;Osvjetljenost;Zamrači;Prazan;"
+"Monitor;DPMS;Nepomičan;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "Hibernacija"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "Ugasi"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "45 minuta"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 sat"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "80 minuta"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "90 minuta"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "100 minuta"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "2 sata"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 minuta"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 minuta"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 minute"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "4 minute"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 minuta"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "8 minuta"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 minuta"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "12 minuta"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "Automatski Obustavi"
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr "_Uključeno"
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr "Na_Energiji Baterije"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "Odgoda"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "Autenticiraj"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "Lozinka"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "Obavezna provjera autentičnosti"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:588
+msgid "Low on toner"
+msgstr "Nizak nivo tonera"
+
+#. Translators: The printer has no toner lift
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Out of toner"
+msgstr "Nema tonera"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:593
+msgid "Low on developer"
+msgstr "Ima malo fotografskog proizvođača"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:596
+msgid "Out of developer"
+msgstr "Nema fotografskog proizvođača"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Low on a marker supply"
+msgstr "Ima malo zaliha markera"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Out of a marker supply"
+msgstr "Nema zaliha markera"
+
+#. Translators: One or more covers on the printer are opijen
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Open cover"
+msgstr "Otvori pokrivač na štampaču"
+
+#. Translators: One or more doors on the printer are opijen
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open door"
+msgstr "Otvori vratanca na štampaču"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Low on paper"
+msgstr "Ima malo papira"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Out of paper"
+msgstr "Nema papira"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:610
+msgctxt "printer stati"
+msgid "Offline"
+msgstr "Van mreže"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's stati (no jobs can bje processed)
+#: ../panels/printers/cc-printers-panel.c:612
+#: ../panels/printers/cc-printers-panel.c:803
+msgctxt "printer stati"
+msgid "Stopped"
+msgstr "Zaustavljen"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:614
+msgid "Waste receptacle almost full"
+msgstr "Posuda za smeće je skoro puna"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle full"
+msgstr "Posuda za smeće je puna"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "The optical photo conductor is near end of life"
+msgstr "Optički fotoprovodnik je blizu kraja života"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Optički fotoprovodnik više nije u funkciji"
+
+#. Translators: Printer's stati (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:730
+msgctxt "printer stati"
+msgid "Configuring"
+msgstr "Podešavam"
+
+#. Translators: Printer's stati (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:789
+msgctxt "printer stati"
+msgid "Ready"
+msgstr "Spreman"
+
+#. Translators: Printer's stati (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:794
+msgctxt "printer stati"
+msgid "Does not accept jobs"
+msgstr "Ne prihvata poslove"
+
+#. Translators: Printer's stati (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:799
+msgctxt "printer stati"
+msgid "Processing"
+msgstr "Obrada"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:919
+msgid "Toner Level"
+msgstr "Nivo tonera"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Ink Level"
+msgstr "Nivo mastila"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Supply Level"
+msgstr "Nivo zaliha"
+
+#. Translators: Printer's stati (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:943
+msgctxt "printer stati"
+msgid "Installing"
+msgstr "Instaliranje"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1119
+msgid "No printers available"
+msgstr "Nije nađen nijedan štampač"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1429
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u aktivan"
+msgstr[1] "%u aktivna"
+msgstr[2] "%u aktivna"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1768
+msgid "Failed to add new printer."
+msgstr "Nisam uspjeo da dodam novi štampač."
+
+#: ../panels/printers/cc-printers-panel.c:1935
+msgid "Select PPD File"
+msgstr "Izaberite PPD datoteku"
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Datoteke opisa PostScript štampača (*.ppd,*.PPD, *.ppd.gz, *PPD.gz, *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2251
+msgid "No suitable driver found"
+msgstr "Nisu pronađeni odgovarajući upravljački programi"
+
+#: ../panels/printers/cc-printers-panel.c:2322
+msgid "Searching for preferred drivers…"
+msgstr "Traži preferirane drajvere"
+
+#: ../panels/printers/cc-printers-panel.c:2343
+msgid "Select from database…"
+msgstr "Odaberi iz baze podataka"
+
+#: ../panels/printers/cc-printers-panel.c:2352
+msgid "Provide PPD File…"
+msgstr "Obezbijedi PPD Datoteku…"
+
+#. Translators: Nami of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2503
+#: ../panels/printers/cc-printers-panel.c:2526
+msgid "Test page"
+msgstr "Test strana"
+
+#. Translators: The XML file containing user interface can not bje loaded
+#: ../panels/printers/cc-printers-panel.c:2940
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Nije moguće učitati UI: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "Štampači"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Dodaj printere,prikaži poslove printera i odluči kako želiš printati"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Štampač;Red;Štampa;Papir;Mastilo;Toner;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "Aktivni zadaci"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "Zatvoreno"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "Nastavi štampanje"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "Pauziraj štampanje"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "Otkaži posao štampanja"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "Dodaj novi štampač"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "A_uthenticate"
+msgstr "A_utentifikuj"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "Nema otkrivenih štampača."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter a network address or search for a printer"
+msgstr "Unesite mrežnu adresu ili tražite printer"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "Učitavaju se opcije"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "Izaberite upravljački program štampača"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "Učitavam bazu podataka upravljačkih programa..."
+
+#. Translators: The found djevice is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+msgid "JetDirect Printer"
+msgstr "JetDirect Printer"
+
+#. Translators: The found djevice is a Linije Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+msgid "LPD Printer"
+msgstr "LPD Printer"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "Jednostrano"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "Duga ivica (Standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "Kratka ivica (Flip)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "Portret"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "Pejzaž"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "Obrnuti pejzaž"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "Prevrnuti portret"
+
+#. Translators: Job's stati (job is waiting to bje printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "U tijeku"
+
+#. Translators: Job's stati (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "Zadržan"
+
+#. Translators: Job's stati (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "U obradi"
+
+#. Translators: Job's stati (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Zaustavljen"
+
+#. Translators: Job's stati (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Otkazan"
+
+#. Translators: Job's stati (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Obustavljen"
+
+#. Translators: Job's stati (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "Završen"
+
+#. Translators: Nami of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "Ime posla"
+
+#. Translators: Nami of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "Stanje posla"
+
+#. Translators: Nami of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "Vrijeme"
+
+#: ../panels/printers/pp-jobs-dialog.c:451
+#, c-format
+msgid "%s Active Jobs"
+msgstr "Aktivni poslovi %s"
+
+#. Translators: The found djevice is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1620
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found djevice is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1625
+msgid "Serial Port"
+msgstr "Serijski port"
+
+#. Translators: The found djevice is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1632
+msgid "Parallel Port"
+msgstr "Paralelni port"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+#, c-format
+msgid "Location: %s"
+msgstr "Lokacija: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1693
+#, c-format
+msgid "Address: %s"
+msgstr "Adresa: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1717
+msgid "Server requires authentication"
+msgstr "Server zahtijeva autentifikaciju"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "Dvostrano"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "Tip papira"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "Izvor papira"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "Izlazna ladica"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript predfilter"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:533
+msgid "Pages per side"
+msgstr "Stranica na strani"
+
+#. Translators: This option sets whether to print on both sides of papir
+#: ../panels/printers/pp-options-dialog.c:545
+msgid "Two-sided"
+msgstr "Dvostrano"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:557
+msgid "Orientation"
+msgstr "Orijentacija"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Opšte"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, papir source, etc.)
+#: ../panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Postavka stranice"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opcije instaliranja"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Posao"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Kvalitet slike"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Boja"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Završavam"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:675
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Napredno"
+
+#. Translators: this is an option of "Papir Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "Automatski izbor"
+
+#. Translators: this is an option of "Papir Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "Predefinisano na štampaču"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "Ugradi samo GhostScript fontove"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "Prevedi u 1. nivo postskripta"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "Prevedi u 2. nivo postskripta"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "Bez predfiltriranja"
+
+#. Translators: Nami of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "Proizvođač"
+
+#. Translators: Nami of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Upraviteljski program"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"Unesi svoje korisničko ime i lozinku da se prikažu dostupni printeri na %s."
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "Dodaj štampač"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "Ukloni štampač"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "Zalihe"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "Lokacija"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default printer"
+msgstr "_Zadani printer"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "Poslovi"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "Prikaži _Poslove"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "Model"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "oznaka"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "Postavljanje novog drajvera"
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "strana 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "Štampaj _Test stranicu"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "_Opcije"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "Dodaj novi štampač"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"Izvinjavamo se! Servis štampe\n"
+"se ne čini dostupnim."
+
+#: ../panels/privacy/cc-privacy-panel.c:352 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "Zaključan Ekran"
+
+#: ../panels/privacy/cc-privacy-panel.c:462 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "Upotreba & Historija"
+
+#: ../panels/privacy/cc-privacy-panel.c:587
+msgid "Empty all items from Trash?"
+msgstr "Da li da izbacim sve stavke iz smeća?"
+
+#: ../panels/privacy/cc-privacy-panel.c:588
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Sve stavke iz smeća će biti trajno uklonjene."
+
+#: ../panels/privacy/cc-privacy-panel.c:589 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "_Isprazni smeće"
+
+#: ../panels/privacy/cc-privacy-panel.c:612
+msgid "Delete all the temporary files?"
+msgstr "Izbriši sve privremene datoteke?"
+
+#: ../panels/privacy/cc-privacy-panel.c:613
+msgid "All the temporary files will be permanently deleted."
+msgstr "Sve privremene datoteke će biti trajno izbrisane."
+
+#: ../panels/privacy/cc-privacy-panel.c:614 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "_Očisti Privremene Datoteke"
+
+#: ../panels/privacy/cc-privacy-panel.c:636 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "Očisti Smeće & Privremene Datoteke"
+
+#: ../panels/privacy/cc-privacy-panel.c:676 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr "Korištenje softvera"
+
+#: ../panels/privacy/cc-privacy-panel.c:717 ../panels/privacy/privacy.ui.h:44
+msgid "Problem Reporting"
+msgstr "Javljanje problema"
+
+#. translators: '%s' is the distributor's nami, such as 'Fedora'
+#: ../panels/privacy/cc-privacy-panel.c:731
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+"Slanje izvještaja o tehničkim problemima nam pomaže da se poboljša %s. "
+"Izvještaji se anonimno šalju bez ličnih podataka."
+
+#: ../panels/privacy/cc-privacy-panel.c:743 ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "Polica privatnosti"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "Privatnost"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr "Zaštiti svoje privatne informacije i kontrole koje ostali mogu vidjeti"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"ekran;zaključano;dijagnosticiraj;sudar;privatno;nedavno;privremeno;tmp;"
+"indeks;ime;mreža;indentitet;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "Gasi se Ekran"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 sekundi"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 dan."
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 dana"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 dana"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 dana"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 dana"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 dana"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 dana"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 dana"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 dana"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "Zauvijek"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"Pamćenje historije olakšava ponovno traženje stvari.Ove stavke nisu nikad "
+"podijeljene preko mreže."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "_Nedavno Korišteno"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "Zadrži _Historiju"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "Očisti Nedavnu Historiju"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "Zaključavanje Ekrana štiti vašu privatnost kada niste tu."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "Automatsko Zaključavanje _Ekrana"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "Zaključaj ekran nakon praznog za"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "Prikaži _Napomene"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"Automatski očisti Smeće i privremene datoteke da pomognete održati svoj "
+"kompjuter čist od nepotrebnih osjetljivih informacija."
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "Automatski isprazni_Smeće"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "Automatski očisti Privremene_Datoteke"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "Očisti_Nakon"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"Slanjem informacije o tome koji program koristite pomažete nam da Vam "
+"ponudimo više tačnih preporuka . To nam također pomaže da poboljšamo "
+"softver ."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "_Pošalji statistiku o korištenju softvera"
+
+#: ../panels/privacy/privacy.ui.h:42
+msgid "_Location Services"
+msgstr "Usluge vezane za _Lokaciju"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "Koristi se za određivanje svog geografskog položaja"
+
+#: ../panels/privacy/privacy.ui.h:45
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatsko javljanje problema"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperijal"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrički"
+
+#: ../panels/region/cc-format-chooser.c:286
+msgid "No regions found"
+msgstr "Nisu pronađene regije"
+
+#: ../panels/region/cc-input-chooser.c:180
+msgid "No input sources found"
+msgstr "Nisu pronađeni ulazni izvori"
+
+#: ../panels/region/cc-input-chooser.c:1084
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Ostali"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:1064
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Vaša sesija se mora restartovati da bi se aktivirali promjene"
+
+#: ../panels/region/cc-region-panel.c:243
+#: ../panels/user-accounts/um-user-panel.c:1068
+msgid "Restart Now"
+msgstr "Restartuj Sada"
+
+#: ../panels/region/cc-region-panel.c:862
+msgid "No input source selected"
+msgstr "Nije odabran ulazni izvor"
+
+#: ../panels/region/cc-region-panel.c:1703
+msgid "Login Screen"
+msgstr "Prijavni ekran"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "Formati"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "Pretpregled"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "Datumi"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "Vremena"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "Brojevi"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "Mjerenje"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "Papir"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "Region & jezik"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"Odaberi prikazni jezik,formu,raspored slova na tastaturi i ulazne izvore"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Jezik;Raspored;Tastatura;Ulaz;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "Dodaj Ulazne Izvore"
+
+#: ../panels/region/input-chooser.ui.h:4
+msgid "Input methods can't be used on the login screen"
+msgstr "Metode unosa ne mogu biti korištene na ekranu prijave"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "Opcije Ulaznog Izvora"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Use the _same source for all windows"
+msgstr "Koristi isti izvor za sve prozore"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Allow _different sources for each window"
+msgstr "Omogući _različite izvore za svaki prozor"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Keyboard Shortcuts"
+msgstr "Prečice sa tastature"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Switch to previous source"
+msgstr "Pređi na prethodni izvor"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Razmak"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Switch to next source"
+msgstr "Pređi na naredni izvor"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "Super+Space"
+msgstr "Super+Razmak"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "Možete promijeniti ove prečice u postavkama tastature"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Alternative switch to next source"
+msgstr "Alternativni prijelaz na drugi izvor"
+
+#: ../panels/region/input-options.ui.h:12
+msgid "Left+Right Alt"
+msgstr "Lijevo+Desno Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "Engleski (Ujedinjeno Kraljevstvo)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "Ujedinjeno Kraljevstvo"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "Opcije"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"Prijavljene postavke koriste svi korisnici kada su prijavljeni na sistem"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr "Mjesta"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "Zabilješke"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr "Ostali"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "Odaberi Lokaciju"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+msgid "_OK"
+msgstr "U _redu"
+
+#: ../panels/search/cc-search-panel.c:177
+msgid "No applications found"
+msgstr "Nisu nađeni programi"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "Traži"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Kontrolira koji programi prikazuju rezultate pretrage u Pregledu Aktivnosti"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Pretraga;Pronađi;Sakri;rivatnost;Rezultati;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "Traži Lokacije"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "Pomjeri gore"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "Pomjeri dolje"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "Postavke"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Uključiti"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Isključiti"
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Omogući"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktivno"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "Odaberi direktorij"
+
+#: ../panels/sharing/cc-sharing-panel.c:917
+msgid "Copy"
+msgstr "Kopiranje"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "Dijeljenje"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "Kontroliši šta želiš dijeliti sa ostalima"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"podijeli;djeljenje;ssh;domaćin;ime;udaljeno;radna površina;bluetooth;medij;"
+"audio;video;slike;fotografije;filmovi;server;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "Omogući ili onemogući prijavu iz daljine"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Autentifikacija je potrebna za omogućenje ili onemogućenje prijave  iz "
+"daljine"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:303
+msgid "No networks selected for sharing"
+msgstr "Nema mreža odabranih za dijeljenje"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "Mreže"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "Djeljenje bluetoothom"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"Djeljenje bluetoothom omogućava vam da podijelite datoteke sa drugim "
+"uključenim bluetooth uređajima"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "Primi samo od Povjerljivih Uređaja"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "Spasi primljene datoteke u Downloads direktorij"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "Ime računara"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "Dijeljenje ličnih datoteka"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "Dijeljenje ekrana"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "Dijeljenje medija"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "Udaljena prijava"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "Neki uređaji su onesposobljeni jer nemaju pristup mreži."
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"Dijeljene privatnih datoteka omogućuje vam da dijelite vas Privatni "
+"direktorij sa ostalim na vašoj trenutnoj mreži koristeći: <a href=\"dav://%s"
+"\">dav://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr "Lozinka potrebna"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"Omogući udaljene korisnike da se konektuju koristeći Sigurnu Školjka "
+"komandu \n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"Omogući udaljenim korisnicima da vide ili kontrolišu vaš ekran konektujući "
+"se na: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Allow Remote Control"
+msgstr "Dopusti upravljanje daljinskim upravljačem"
+
+#: ../panels/sharing/sharing.ui.h:21
+msgid "Password:"
+msgstr "Lozinka:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "Prikaži lozinku"
+
+#: ../panels/sharing/sharing.ui.h:23
+msgid "Access Options"
+msgstr "Mogućnosti pristupa"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "Nove konekcije moraju pitati za pristup"
+
+#: ../panels/sharing/sharing.ui.h:25
+msgid "Require a password"
+msgstr "Zahtjev lozinke"
+
+#: ../panels/sharing/sharing.ui.h:26
+msgid ""
+"Media sharing allows you to share music, photos and videos over the network."
+msgstr ""
+"Dijeljen je medija vam omogućava da podijelite muziku, fotografije i video "
+"zapise putem mreže."
+
+#: ../panels/sharing/sharing.ui.h:27
+msgid "Folders"
+msgstr "Direktorij"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "Zvuk"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Promijeni nivo zvuka, ulazi , izlazi , i upozoravajuci zvukovi"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr ""
+"Kartica;Mikrofon;Jačina zvuka;Iščezavanje;Balans;Blutut;Slušalice;Zvuk;"
+
+#. Translators: This is the nami of an audio file that sounds liki the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "Lavež"
+
+#. Translators: This is the nami of an audio file that sounds liki a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "Žubor"
+
+#. Translators: This is the nami of an audio file that sounds liki tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "Staklo"
+
+#. Translators: This is the nami of an audio file that sounds sort of liki a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "Sonar"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "Lijevo"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "Desno"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "Nazadi"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "Prednje"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Minimum"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Maksimum"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "_Balans:"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "_Izblijedi:"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "_Subvufer:"
+
+#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:615
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Bez pojačavanja"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "_Profil:"
+
+#. translators:
+#. * The number of sound outputs on a particular djevice
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u izlaz"
+msgstr[1] "%u izlaza"
+msgstr[2] "%u izlaza"
+
+#. translators:
+#. * The number of sound inputs on a particular djevice
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ulaz"
+msgstr[1] "%u ulaza"
+msgstr[2] "%u ulaza"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "Sistemski zvuci"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "Provjeri _zvučnike"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "Praćenje šiljka"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1491
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "Naziv"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1510
+msgid "Device"
+msgstr "Uređaj"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1573
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "Testiranje zvučnika za %s"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1629
+msgid "_Output volume:"
+msgstr "_OIzlazna jačina:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1643
+msgid "Output"
+msgstr "Izlaz"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1648
+msgid "C_hoose a device for sound output:"
+msgstr "Izaberite uređaj kao zvučni izlaz:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1670
+msgid "Settings for the selected device:"
+msgstr "Podešavanja za izabrani uređaj:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1681
+msgid "Input"
+msgstr "Ulaz"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1688
+msgid "_Input volume:"
+msgstr "_Ulazna jačina:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1709
+msgid "Input level:"
+msgstr "Ulazni nivo:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1737
+msgid "C_hoose a device for sound input:"
+msgstr "Izaberite uređaj kao zvučni ulaz:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1761
+msgid "Sound Effects"
+msgstr "Zvučni Efekti"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1768
+msgid "_Alert volume:"
+msgstr "Jačina _Alarma:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1785
+msgid "No application is currently playing or recording audio."
+msgstr "Ni jedan program ne pušta ili snima zvuk."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "Ugrađen"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "Opcije zvuka"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "Provjera zvuka za događaj"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "Podrazumijevano"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "Na osnovu teme"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:770
+msgid "C_hoose an alert sound:"
+msgstr "I_zaberite zvuk za upozorenje:"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "Prekini"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "Provjeri"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "Sabvufer"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "Prilagođeno"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Omogući lakši pregled,zvuk,tip,usmjeri i klikni"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "_Uvijek Prikaži Univerzalni Pristupni Meni"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "Viđenje"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "_Visoki kontrast"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "_Veliki Tekst"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "_Zoom"
+msgstr "_Povećaj"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr "_Čitač Ekrana"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "_Sound Keys"
+msgstr "_Tipke za zvuk"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "Slušanje"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr "_Vidljiva upozorena"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Screen _Keyboard"
+msgstr "_Tastatura na Ekranu"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "_Typing Assist (AccessX)"
+msgstr "_Pomoć pri kucanju (AccessX)"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Pointing & Clicking"
+msgstr "Označiti & Kliknuti"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "_Mouse Keys"
+msgstr "_Tipka miša"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "_Pomoć pri kliku"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "Čitač ekrana"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Čitač ekrana Čita prikazani tekst kako pomjerate fokus."
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Screen Reader"
+msgstr "_Čitač ekrana"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Sound Keys"
+msgstr "Tipke zvuka"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "Pisni kada se uključe Num Lock ili Velika slova."
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "Vizualna upozorenja"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "Probni _bljesak"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Koristi vizualnu naznaku kada se desi zvučno upozorenje."
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Flash the _window title"
+msgstr "Osvjetli Naslov prozora"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Flash the entire _screen"
+msgstr "Prikaži cijeli ekran"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Typing Assist"
+msgstr "Pomoć pri kucanju"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "_Sticky Keys"
+msgstr "Ljepljive Tipke"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Ophodi se prema slijedu tastera za modifikaciju kao da su kombinacija tastera"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "_Isključi ako su dva tastera pritisnuta istovremeno"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifier key is pressed"
+msgstr "Zvuk kada je pritisnut _modifikatorski taster"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "S_low Keys"
+msgstr "S_pore Tipke"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Pravi odlaganje između pritiskanja i prihvatanja tastera"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "Kašnjenje _prihvatanja:"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kratko"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "Zastoj kucanja sporih tastera"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Beep when a key is pr_essed"
+msgstr "Zapišti kada je pritisnut taster"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Beep when a key is _accepted"
+msgstr "Zapišti kada je _prihvaćena tipka"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "Zvuk kada taster nije _prihvaćen"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "_Bounce Keys"
+msgstr "_Skoče Tipke"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignoriše brze duple klikove"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kratko"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "Zastoj kucanja odskočnih tastera"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Enable by Keyboard"
+msgstr "_Omogućeno pomoću tastature"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Uključite/isključite funkcije pristupačnosti koristeći tastaturu"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "Pomoć pri Kliku"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "_Simulated Secondary Click"
+msgstr "_Oponaša Sekundarni Klik"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Izazovite sekundarni klik pritiskajući primarni klik dugo"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kratko"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "Zastoj sekundarnog klika"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "_Hover Click"
+msgstr "_Lebdeći Klik"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "Pokren i  klik kada kursor nadleti"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "Zastoj:"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kratko"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "_Osjetljivost na pokret:"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Malo"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Veliki"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kratko"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ekrana"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ekrana"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ekrana"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "Dugo"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "Puni ekran"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "Gornja polovina"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "Donja polovina"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "Lijeva polovina"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "Desna polovina"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "Opcije uvećanja"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "Uvećaj"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "Uvećavanje:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "Prati kursor miša"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "Dio ekrana:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "Lupa se prostire izvan ekrana"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "Drži kursor lupe po sredini"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "Kursor lupe gura sadržaje unaokolo"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "Kursor lupe se pomijera sa sadržajima"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "Položaj lupe:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "Povećalo"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "Debljina:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tanko"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Debelo"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "Dužina:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "Boja:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "Ukrštanje:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "Preklapa kursor miša"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "Krst"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "Bijelo na crnom:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "Osvjetljenje:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "Boja"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Nijedan"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Pun"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Nisko"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Visoko"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Nizak"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Visok"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "Efekti boje;:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "Efekti boje"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Standardni"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Administrator"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Full Name"
+msgstr "_Ime i prezime"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "_Vrsta naloga"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to set a password when they next login"
+msgstr "Dozvoli korisniku da postavi lozinku pri sljedećoj prijavi"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "Postavi zaporku sad"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "_Potvrdi"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"Službena prijava dozvoljava korištenje postojećeg centralno kontrolisanog "
+"korisničkog računa na ovom uređaju."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "_Domena"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"Idi online da bi dodao\n"
+"službenu prijavu računa."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "_Poslovno prijavljivanje"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1466
+msgid "Add User"
+msgstr "Dodaj korisnika"
+
+#. Translators: This button enrolls the computer in the domain in order to usi enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "_Otkliži"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "Prijavljivanje administratora domena"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Da biste koristili poslovna prijavljivanja, ovaj računar treba da bude\n"
+"upisan u domenu. Neka administrator vaše mreže ovdje upiše lozinku\n"
+"njihovih domena."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "Ime _administratora"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "Šifra Administratora"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "Lijevi palac"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "Srednji, lijevi prst"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "Domali, lijevi prst"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "Mali, lijevi prst"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "Desni palac"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "Desni, srednji prst"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "Desni, domali prsti"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "Desni, mali prst"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:689
+msgid "Enable Fingerprint Login"
+msgstr "Omogući prijavu putem otiska prsta"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "Domali, _desni prst"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "Domali, _lijevi prst"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "_Drugi prst:"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"Vaš otisak prsta je uspješno sačuvan. Sada se možete prijaviti na sistem "
+"preko čitača otisaka prsta."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "Korisnici"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "Dodaj ili ukloni korisnike i promijeni svoju lozinku"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Prjava;Ime;Otisak;Ikonica;Logotip;Faca;Zaporka;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "Historija prijava"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr "Promijeni lozinku"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "_Promijeni"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "_Potvrdi novu lozinku"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "_Nova Lozinka"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "Trenutna_Lozinka"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "Dodaj korisnički nalog"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "Ukloni korisnički nalog"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "Opcije prijave"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "_Automatsko prijavljivanje"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "Ikonica korisnika"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "_Jezik"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "Zadnja prijava"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "Upravljanje korisničkim nalozima"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "Prijava je potrebna za promjenu korisničkih podataka."
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Nova lozinka mora biti različita od stare."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Pokušaj promijeniti neka slova u brojeve."
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Pokušaj promijeniti lozinku još malo."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Lozinka bez vašeg korisničkog imena bi bila jača."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Pokušaj izbjeći korištenje svog imena u lozinci."
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Pokušaj izbjeći neke riječi uključene u lozinku."
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Pokušaj izbjeći obične riječi."
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Pokušaj izbjeći promjenu mjesta postojećih riječi."
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Pokušaj koristiti više brojeva."
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Pokušaj koristiti više velikih slova."
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Pokušaj koristiti više malih slova."
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+"Pokušaj korisiti više posebnih znakova, naprimjer znakovi interpunkcije."
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Pokušaj koristit mješavinu slova,brojeva i interpunkciskih znakova."
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Pokušaj izbječi ponavljanje istog znaka."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Pokušaj izbjeći ponavljanje istog tipa znaka:trebaš miješati slova,brojeve i "
+"interpunkciske znakove."
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Pokušaj izbjeći senkvence kao 1234 ili abcd."
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "Pokušaj dodati više slova,brojeva i znakova."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr "Miješaj velika i mala slova i iskoristi broj ili dva."
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+"Dobra lozinka!Dodavanje više slova,brojeva i znakova interpunkcije učiniti "
+"će je jačom."
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "Jačina:Slaba"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "Jačina:Niska"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "Jačina:Srednja"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "Jačina:Dobra"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "Jačina:Visoka"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "Autentifikacija nije prošla"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "Nova lozinka je prekratka"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "Nova lozinka je suviše jednostavna"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Stara i nova lozinka su suviše slične"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Nova lozinka je već upotrebljavana u skorije vrijeme."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Nova lozinka mora da sadrži cifre ili specijalne karaktere"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Stara i nova lozinka su iste"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Vaša lozinka je promijenjena od kada ste se prvobitno ovlastili!"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Nova šifra nema dovoljno različitih znakova"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "Nepoznata greška"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "Trebali bi se poklapati sa web adresom vašem poslužavatelja računa."
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "Nisam uspio da dodam nalog"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+msgid "Passwords do not match."
+msgstr "Lozinke se ne podudaraju."
+
+#: ../panels/user-accounts/um-account-dialog.c:733
+#: ../panels/user-accounts/um-account-dialog.c:779
+#: ../panels/user-accounts/um-account-dialog.c:800
+msgid "Failed to register account"
+msgstr "Nisam uspio da upišem nalog"
+
+#: ../panels/user-accounts/um-account-dialog.c:923
+msgid "No supported way to authenticate with this domain"
+msgstr "Nema podržanog načina za potvrđivanje identiteta sa ovim domenom"
+
+#: ../panels/user-accounts/um-account-dialog.c:982
+msgid "Failed to join domain"
+msgstr "Nisam uspio da pristupim domenu"
+
+#: ../panels/user-accounts/um-account-dialog.c:1043
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"To ime za prijavu nije radilo .\n"
+"Molimo pokušajte ponovo."
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"To ime za prijavu nije radilo .\n"
+"Molimo pokušajte ponovo."
+
+#: ../panels/user-accounts/um-account-dialog.c:1058
+msgid "Failed to log into domain"
+msgstr "Nisam uspio da se prijavim na domen"
+
+#: ../panels/user-accounts/um-account-dialog.c:1116
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "Omogući pronalazak domena.Možda si ga pogrešno postavio."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:138
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"Nemate dozvole za pristup ovom uređaju. Kontaktirajte vašeg sistemskog "
+"administratora."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:140
+msgid "The device is already in use."
+msgstr "Uređaj je već u upotrebi."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid "An internal error occurred."
+msgstr "Desila se unutrašnja greška."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Enabled"
+msgstr "Omogućen"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr "Da obrišem registrovane otiske prsta?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr "_Obriši otiske prsta"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Da li želite da obrišete registrovane otiske prsta kako bi onemogućili "
+"prijavu putem otiska prsta?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:446
+msgid "Done!"
+msgstr "Završeno!"
+
+#. translators:
+#. * The variable is the nami of the djevice, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" djevice
+#: ../panels/user-accounts/um-fingerprint-dialog.c:507
+#: ../panels/user-accounts/um-fingerprint-dialog.c:549
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "Ne mogu da pristupim uređaju „%s“"
+
+#. translators:
+#. * The variable is the nami of the djevice, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" djevice
+#: ../panels/user-accounts/um-fingerprint-dialog.c:590
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "Ne mogu da uhvatim otisak prsta sa uređaja „%s“"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:640
+msgid "Could not access any fingerprint readers"
+msgstr "Ne mogu da pristupim čitačima prsta"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:641
+msgid "Please contact your system administrator for help."
+msgstr "Javite se sistemskom administratoru radi pomoći."
+
+#. translators:
+#. * The variable is the nami of the djevice, for example:
+#. * "To enable fingerprint login, you need to savije one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' djevice."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:723
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"Morate sačuvati jedan od vaših otisaka prsta sa uređaja „%s“, kako bi "
+"omogućili prijavu na sistem putem otiska prsta."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+msgid "Selecting finger"
+msgstr "Prst iybora"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:731
+msgid "Enrolling fingerprints"
+msgstr "Upisujem otiske prstiju"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "Ove sedmice"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "Prošle sedmice"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:842
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:846
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "Sesija završila"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "Sesija počela"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "Izaberite drugu lozinku."
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "Ispišite vašu trenutnu zaporku ponovno."
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "Ne mogu da promijenim lozinku"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "The passwords do not match."
+msgstr "Lozinke se ne podudaraju."
+
+#: ../panels/user-accounts/um-photo-dialog.c:214
+msgid "Browse for more pictures"
+msgstr "Traži za više slika"
+
+#: ../panels/user-accounts/um-photo-dialog.c:448
+msgid "Disable image"
+msgstr "Onemogući sliku"
+
+#: ../panels/user-accounts/um-photo-dialog.c:466
+msgid "Take a photo…"
+msgstr "Uslikaj…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:484
+msgid "Browse for more pictures…"
+msgstr "Potraži još slika…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:708
+#, c-format
+msgid "Used by %s"
+msgstr "To koristi %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "Nije moguće automatski pristupiti ovoj vrsti domene."
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "Nije pronađen takav domen ili područje"
+
+#: ../panels/user-accounts/um-realm-manager.c:815
+#: ../panels/user-accounts/um-realm-manager.c:829
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Ne mogu da se prijavim kao „%s“ na domenu %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:821
+msgid "Invalid password, please try again"
+msgstr "Pogrešna lozinka, molimo pokušajte ponovo"
+
+#: ../panels/user-accounts/um-realm-manager.c:834
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "Ne mogu da se povežem na domen „%s“: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:238
+msgid "Other Accounts"
+msgstr "Ostali računi"
+
+#: ../panels/user-accounts/um-user-panel.c:448
+msgid "Failed to delete user"
+msgstr "Nije moguće obrisati korisnički račun"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+#: ../panels/user-accounts/um-user-panel.c:567
+#: ../panels/user-accounts/um-user-panel.c:619
+msgid "Failed to revoke remotely managed user"
+msgstr "Nije moguće povući  daljinski upravljanog korisnika"
+
+#: ../panels/user-accounts/um-user-panel.c:675
+msgid "You cannot delete your own account."
+msgstr "Nije moguće obrisati sopstveni račun."
+
+#: ../panels/user-accounts/um-user-panel.c:684
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s je i dalje prijavljen"
+
+#: ../panels/user-accounts/um-user-panel.c:688
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Brisanje računa do je korisnik prijavljen može ostaviti sistem u "
+"zaglavljenom stanju!!!."
+
+#: ../panels/user-accounts/um-user-panel.c:697
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "Želite li sačuvati datoteke od korisnika '%s'?"
+
+#: ../panels/user-accounts/um-user-panel.c:701
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Moguće je zadržati kućni direktorij, mail i privremene datoteke kada se "
+"briše korisnički račun."
+
+#: ../panels/user-accounts/um-user-panel.c:704
+msgid "_Delete Files"
+msgstr "_Izbriši datoteke"
+
+#: ../panels/user-accounts/um-user-panel.c:705
+msgid "_Keep Files"
+msgstr "_Zadrži datoteke"
+
+#: ../panels/user-accounts/um-user-panel.c:719
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s's account?"
+msgstr ""
+"Da li ste sigurni da želite da uklonite daljinski upravljani nalog za %s?"
+
+#: ../panels/user-accounts/um-user-panel.c:723
+msgid "_Delete"
+msgstr "_Obriši"
+
+#: ../panels/user-accounts/um-user-panel.c:775
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Račun onemogućen"
+
+#: ../panels/user-accounts/um-user-panel.c:783
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Biće namještena na sljedećem prijavljivanju"
+
+#: ../panels/user-accounts/um-user-panel.c:786
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ništa"
+
+#: ../panels/user-accounts/um-user-panel.c:835
+msgid "Logged in"
+msgstr "Prijavljen"
+
+#: ../panels/user-accounts/um-user-panel.c:1267
+msgid "Failed to contact the accounts service"
+msgstr "Nije moguće kontaktirati servis računa"
+
+#: ../panels/user-accounts/um-user-panel.c:1269
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Morate se postarati da je ServisRačuna instaliran i omogućen."
+
+#: ../panels/user-accounts/um-user-panel.c:1310
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Da bi ste napravili promjene,\n"
+"kliknite na *"
+
+#: ../panels/user-accounts/um-user-panel.c:1348
+msgid "Create a user account"
+msgstr "Napravite korisnički nalog"
+
+#: ../panels/user-accounts/um-user-panel.c:1359
+#: ../panels/user-accounts/um-user-panel.c:1671
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Da napravite korisnički nalog,\n"
+"kliknite prvo na ikonicu *"
+
+#: ../panels/user-accounts/um-user-panel.c:1369
+msgid "Delete the selected user account"
+msgstr "Obrišite izabrani korisnički nalog"
+
+#: ../panels/user-accounts/um-user-panel.c:1381
+#: ../panels/user-accounts/um-user-panel.c:1676
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Da obrišete izabrani korisnički nalog,\n"
+"kliknite prvo na ikonicu *"
+
+#: ../panels/user-accounts/um-user-panel.c:1585
+msgid "My Account"
+msgstr "Moj račun"
+
+#: ../panels/user-accounts/um-utils.c:563
+#, c-format
+msgid "A user with the username '%s' already exists."
+msgstr "Korisnik sa imenom '%s' već postoji."
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+msgid "The username is too long."
+msgstr "Kornisničko ime je previše dugo."
+
+#: ../panels/user-accounts/um-utils.c:570
+msgid "The username cannot start with a '-'."
+msgstr "Korisničko ime počinje sa '-'."
+
+#: ../panels/user-accounts/um-utils.c:573
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"Korisničko ime bi se trebalo sastojati od malih i velikih slova od a do z, "
+"brojeva i karaktera '.', '-' i '_'."
+
+#: ../panels/user-accounts/um-utils.c:577
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+"Ovo će biti korišteno kao ime početne datoteke i neće se moći promjeniti."
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:823
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "Mapiraj dugmad"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr "Mapirajte dugmad prema funkcijama"
+
+#: ../panels/wacom/button-mapping.ui.h:4
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Da bi uredili prečicu,odaberite \"Send Keystroke\" akciju,pritisnite dugme "
+"prečice na tastaturu i držite pritisnutu novi tipku ili pritisnite Backspace "
+"da očistite."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Molim tupnite znake odredišta koji će se pojaviti na ekranu da kalibrišete "
+"tablicu."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "Otkriven je loš klik, počinjem iz početka..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "Gore"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "Dole"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "Nikakva"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Pošalji otkucaj tastera"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Promijeni monitor"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Prikaži pomoć na ekranu"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "Izlaz:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Zadrži odnos razmjere (crne trake):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "Mapiraj na jedan monitor"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d od %d"
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "Mapiranje prikaza"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "Dugme"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Postavi mapiranje dugmetom i namjesti stylus osjetljivost za grafičke tabele."
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Olovka;Gumica;Miš;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "Tablet (asolutni)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "Dodirljiva ploča (relativno)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "Postavke tableta"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Help"
+msgstr "_Pomoć"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "No tablet detected"
+msgstr "Nema detektovanog tableta"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Molim priključite ili uključite Wacom tablet"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Bluetooth Settings"
+msgstr "Bluetooth postavke"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map to Monitor…"
+msgstr "Poveži s monitorom"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Map Buttons…"
+msgstr "Poveži dugmad"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust display resolution"
+msgstr "Podesite rezoluciju prikaza"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Adjust mouse settings"
+msgstr "Podesi osjetljivost miša"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Tracking Mode"
+msgstr "Režim praćenja"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:16
+msgid "Left-Handed Orientation"
+msgstr "Orijentacija prema lijevo"
+
+#. If no mode is available, we usi "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1024
+msgid "Left Ring"
+msgstr "Lijevi prsten"
+
+#: ../panels/wacom/gsd-wacom-device.c:1035
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "Režim lijevog prstena #%d"
+
+#. If no mode is available, we usi "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1055
+msgid "Right Ring"
+msgstr "Desni prsten"
+
+#: ../panels/wacom/gsd-wacom-device.c:1066
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "Režim desnog prstena #%d"
+
+#. If no mode is available, we usi "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1108
+msgid "Left Touchstrip"
+msgstr "Lijeva dodirna traka"
+
+#: ../panels/wacom/gsd-wacom-device.c:1119
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "Režim lijeve dodirne trake #%d"
+
+#. If no mode is available, we usi "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1139
+msgid "Right Touchstrip"
+msgstr "Desna dodirna traka"
+
+#: ../panels/wacom/gsd-wacom-device.c:1150
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "Režim desne dodirne trake #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1176
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "Režim prekidača lijevog dodirnog prstena"
+
+#: ../panels/wacom/gsd-wacom-device.c:1178
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "Režim prekidača desnog dodirnog prstena"
+
+#: ../panels/wacom/gsd-wacom-device.c:1181
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "Režim prekidača lijeve dodirne trake"
+
+#: ../panels/wacom/gsd-wacom-device.c:1183
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "Režim prekidača desne dodirne trake"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "Režim prekidača #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1296
+#, c-format
+msgid "Left Button #%d"
+msgstr "Lijevo dugme #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1299
+#, c-format
+msgid "Right Button #%d"
+msgstr "Desno dugme #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1302
+#, c-format
+msgid "Top Button #%d"
+msgstr "Gornje dugme #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1305
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "Donje dugme #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "Nova prečica…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "Bez akcije"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "Klik lijevom tipkom miša"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "Klik srednjom tipkom miša"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "Klik desnom tipkom miša"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "Kliži prema gore"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "Kliži prema dolje"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "Kliži ulijevo"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "Kliži udesno"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "Nazad"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "Naprijed"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "Olovka"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "Osjećaj pritiska gumice"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "Meko"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "Inertno"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "Gornje dugme"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "Niže dugme"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "Osjećaj pritiska pri tipkanju"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "Omogući pričljiv mod"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "Prikaži pregled"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "Traži string"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "Priloži moguća imena panela i izađi"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "Prikaži opcije za pomoć"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "Panel za prikaz"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "-Postavke"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"Pokrenite „%s --help“ kako bi vidjeli spisak svih naredbi iz komandne "
+"linije.\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "Dostupni paneli:"
+
+#: ../shell/cc-application.c:326
+msgid "Help"
+msgstr "Pomoć"
+
+#: ../shell/cc-application.c:327
+msgid "Quit"
+msgstr "Izlaz"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1493
+msgid "All Settings"
+msgstr "Sve Postavke"
+
+#. Add categories
+#: ../shell/cc-window.c:879
+msgctxt "category"
+msgid "Personal"
+msgstr "Lični"
+
+#: ../shell/cc-window.c:880
+msgctxt "category"
+msgid "Hardware"
+msgstr "Hardver"
+
+#: ../shell/cc-window.c:881
+msgctxt "category"
+msgid "System"
+msgstr "Sistem"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "Postavke;Podešavanja;"

--- a/po/ca.po
+++ b/po/ca.po
@@ -29,9 +29,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issues\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
-"PO-Revision-Date: 2022-09-15 09:28+0100\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-10-09 09:28+0100\n"
 "Last-Translator: Jordi Mas i Hernàndez <jmas@softcatala.org>\n"
 "Language-Team: Catalan <tradgnome@softcatala.org>\n"
 "Language: ca\n"
@@ -41,101 +41,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Bus del sistema"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Accés complet"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Sessió del bus"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Dispositius"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Accés complet a /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Xarxa"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Té accés a la xarxa"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Inici"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Només lectura"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Sistema de fitxers"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Paràmetres"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Es poden canviar els paràmetres"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s té els següents permisos integrats. Aquests no poden ser alterats. Si "
-"esteu preocupats per aquests permisos, considereu suprimir aquesta "
-"aplicació."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u tipus de fitxer i d'enllaç que obre l'aplicació"
-msgstr[1] "%u tipus de fitxers i d'enllaços que obre l'aplicació"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> s'utilitza per a obrir els següents tipus de fitxers i enllaços."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s d'espai de disc utilitzat."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -151,7 +57,6 @@ msgid "Install some…"
 msgstr "Instal·la alguns..."
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Obre"
 
@@ -175,24 +80,13 @@ msgstr "Cerca"
 msgid "Receive system searches and send results."
 msgstr "Rebre cerques del sistema i enviar resultats."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367
 #: panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
 msgid "Disabled"
 msgstr "Inhabilitat"
 
@@ -356,81 +250,20 @@ msgstr "Neteja la memòria cau…"
 msgid "Control various application permissions and settings"
 msgstr "Controla diversos permisos i paràmetres d'aplicació"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate
-#. or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplicació;flatpak;permís;paràmetre;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Selecciona una imatge"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Cancel·la"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Obre"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "mides múltiples"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Sense imatge de fons de l'escriptori"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Imatge de fons actual"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Estil"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Per defecte"
 
@@ -454,14 +287,12 @@ msgstr "Aparença"
 msgid "Change your background image or the UI colors"
 msgstr "Canvieu la imatge de fons o els colors de la interfície"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Fons;Fons de pantalla;Pantalla;Escriptori;Estil;Clar;Fosc;Aparença;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:11
-#: panels/camera/cc-camera-panel.ui:8 panels/datetime/cc-datetime-panel.ui:172
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
 #: panels/diagnostics/cc-diagnostics-panel.ui:18
 #: panels/display/cc-night-light-page.ui:122
 #: panels/microphone/cc-microphone-panel.ui:9
@@ -507,9 +338,7 @@ msgstr "El mode d'avió del maquinari està activat"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Desactiva el mode d'avió per a habilitar el Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -517,8 +346,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Activeu i desactiveu el Bluetooth i connecteu els dispositius"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "comparteix;compartició;bluetooth;obex;"
@@ -533,13 +360,16 @@ msgstr "Cap aplicació pot capturar fotografies o vídeo."
 
 #: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Use of the camera allows applications to capture photos and video. Disabling the camera may cause some applications to not function properly.\n"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
 "\n"
 "Allow the applications below to use your camera."
 msgstr ""
-"L'ús de la càmera permet que les aplicacions capturin fotos i vídeos. La desactivació de la càmera pot provocar que algunes aplicacions no funcionin correctament.\n"
+"L'ús de la càmera permet que les aplicacions capturin fotos i vídeos. La "
+"desactivació de la càmera pot provocar que algunes aplicacions no funcionin "
+"correctament.\n"
 "\n"
-"Permet que les aplicacions següents utilitzin la teva càmera."
+"Permet que les aplicacions següents utilitzin la càmera."
 
 #: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
@@ -549,95 +379,33 @@ msgstr "Cap aplicació ha demanat accés a la càmera"
 msgid "Protect your pictures"
 msgstr "Protegiu les vostres imatges"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "càmera;fotografies;vídeo;cam;bloqueig;privat;privadesa;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Col·loqueu el dispositiu de calibratge sobre el quadre i premeu «Inicia»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Moveu el dispositiu de calibratge a la posició de calibratge i premeu "
-"«Continua»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Moveu el dispositiu de calibratge a la posició de la superfície i premeu "
-"«Continua»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Tanca la tapa del portàtil"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "S'ha produït un error intern que no s'ha pogut recuperar."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Les eines que calen per al calibratge no estan instal·lades."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "No s'ha pogut generar el perfil."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "No s'ha pogut obtenir el punt blanc de l'objectiu."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "S'ha completat"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Ha fallat el calibratge"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Podeu treure el dispositiu de calibratge."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "No interrompeu el dispositiu de calibratge mentre treballi"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibratge de la pantalla"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancel·la"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -654,140 +422,6 @@ msgstr "_Continua"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Fet"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Pantalla del portàtil"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Càmera web integrada"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Escàner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Càmera %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Impressora %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Càmera web %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Habilita la gestió del color per a %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Mostra els perfils de color per a %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Sense calibrar"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Per defecte: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Espai de color: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Perfil de comprovació: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Selecciona un fitxer de perfil ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importa"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Perfils ICC compatibles"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Tots els fitxers"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Pantalla"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Desa el perfil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "De_sa"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Crea un perfil de color per al dispositiu seleccionat"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"No s'ha detectat l'instrument de mesura. Comproveu que estigui encès i "
-"connectat correctament."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "L'instrument de mesura no admet el perfilat d'impressores."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "El tipus de dispositiu no és compatible actualment."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -844,8 +478,8 @@ msgstr "Punt blanc del perfil"
 
 #: panels/color/cc-color-panel.ui:160
 msgid ""
-"Select a display target white point. Most displays should be calibrated to a"
-" D65 illuminant."
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
 msgstr ""
 "Seleccioneu un punt blanc objectiu de la pantalla. La majoria de pantalles "
 "s'haurien de calibrar amb una il·luminació D65."
@@ -930,7 +564,6 @@ msgstr "_Importa un fitxer…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -942,9 +575,7 @@ msgstr ""
 "Cada dispositiu necessita un perfil de color actualitzat per a poder "
 "gestionar el color."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Més informació"
 
@@ -1077,84 +708,6 @@ msgstr "D65 (Fotografia i gràfics)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Espai estàndard"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Perfil de comprovació"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automàtic"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Qualitat baixa"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Qualitat mitjana"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Qualitat alta"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB per defecte"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK per defecte"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Gris per defecte"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Dades de calibratge de fàbrica proporcionades pel venedor"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-"Amb aquest perfil no es pot fer la correcció de la pantalla en mode pantalla"
-" completa"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Aquest perfil potser ja no és precís"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Color"
@@ -1165,15 +718,9 @@ msgid ""
 msgstr ""
 "Calibreu el color dels dispositius, com ara pantalles, càmeres o impressores"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Color;ICC;Perfil;Calibratge;Impressora;Pantalla;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Altres…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1188,13 +735,8 @@ msgid "No languages found"
 msgstr "No s'ha trobat cap idioma"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Més…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Desbloqueja per a canviar els paràmetres"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1223,152 +765,6 @@ msgstr "Redueix una hora"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Redueix un minut"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Avui"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Ahir"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d hora"
-msgstr[1] "%d hores"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minut"
-msgstr[1] "%d minuts"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d segon"
-msgstr[1] "%d segons"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 segons"
-
-#. translators: This is the default hotspot name, need to be less than
-#. 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Punt d'accés Wi-Fi"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 hores"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B de %Y a les %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B de %Y a les %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l∶%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%-H:%M"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1463,17 +859,11 @@ msgstr "_Fus horari automàtic"
 msgid "Requires location services enabled and internet access"
 msgstr "Requereix els serveis d'ubicació habilitats i accés a Internet"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Habilitat"
 
@@ -1481,16 +871,43 @@ msgstr "Habilitat"
 msgid "Time Z_one"
 msgstr "Fus h_orari"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desbloqueja"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format d'hora"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dates"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 segons"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Ca_lendari"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Nombres"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Canvieu la data i l'hora, incloent-hi el fus horari"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate
-#. or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Rellotge;Fus horari;Ubicació;"
@@ -1536,23 +953,9 @@ msgstr "Aplicacions per defecte"
 msgid "Configure Default Applications"
 msgstr "Configura les aplicacions per defecte"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT
-#. translate or localize the semicolons! The list MUST also end with a
-#. semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "per defecte; aplicació; preferida;multimèdia;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora',
-#. the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Enviar informes de problemes tècnics ajuda a millorar %s. Els informes "
-"s'envien anònimament i sense dades personals. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1570,53 +973,16 @@ msgstr "Diagnòstics"
 msgid "Report your problems"
 msgstr "Informeu de problemes"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate
-#. or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnòstics;fallada;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Activat"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Desactivat"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Voleu aplicar els canvis?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "No s'han aplicat els canvis"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Això pot ser degut a limitacions del maquinari."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Aplica"
 
-#: panels/display/cc-display-panel.ui:78
-#: panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
 #: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
 #: panels/printers/new-printer-dialog.ui:64
 #: panels/region/cc-format-chooser.ui:37
@@ -1652,38 +1018,12 @@ msgstr "Conté la barra superior i les Activitats"
 msgid "Primary Display"
 msgstr "Pantalla primària"
 
-#. This is the redshift functionality where we suppress blue light when the
-#. sun has gone down
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
 #: panels/display/cc-display-panel.ui:177
 #: panels/display/cc-display-panel.ui:228
 #: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Llum nocturna"
-
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Apaïsada"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Vertical dreta"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Vertical esquerra"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Apaïsada (capgirada)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
 
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
@@ -1708,6 +1048,17 @@ msgstr "Ajusta per televisió"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Escala"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Desplaçament natural"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1803,228 +1154,30 @@ msgstr "Pantalles"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Trieu com utilitzar els monitors i projectors connectats"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
-"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;color;sunset;sunrise;"
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
 msgstr ""
-"Quadre;Projector;xrandr;Pantalla;Resolució;Refresca;Monitor;Nit;Llum;Blau;color;posta"
-" de sol;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "L'arrencada segura està activa"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"L'arrencada segura evita que el programari maliciós es carregui quan "
-"s'iniciï el dispositiu. Actualment està activat i funciona correctament."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "L'arrencada segura té problemes"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"L'arrencada segura evita que el programari maliciós es carregui quan "
-"s'iniciï el dispositiu. Actualment està activada, però no funcionarà ja que "
-"té una clau no vàlida."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Els problemes amb l'arrencada segura sovint es poden resoldre des de la "
-"configuració del microprogramari UEFI (BIOS) de l'ordinador i el fabricant "
-"del maquinari pot proporcionar informació sobre com fer-ho."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Per a obtenir ajuda, contacteu amb el fabricant del maquinari o amb el  "
-"suport tècnic."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "L'arrencada segura està desactivada"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"L'arrencada segura evita que el programari maliciós es carregui quan "
-"s'iniciï el dispositiu. Actualment està desactivada."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"L'arrencada segura sovint es pot activar des de la configuració del "
-"microprogramari UEFI del vostre ordinador (BIOS). Per a obtenir ajuda, "
-"contacteu amb el fabricant del maquinari o amb el suport tècnic."
+"Quadre;Projector;xrandr;Pantalla;Resolució;Refresca;Monitor;Nit;Llum;Blau;"
+"color;posta de sol;"
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
-"Secure boot prevents malicious software from being loaded when the device starts.\n"
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
-"L'arrencada segura evita que el programari maliciós es carregui quan s'iniciï el dispositiu.\n"
+"L'arrencada segura evita que el programari maliciós es carregui quan "
+"s'iniciï el dispositiu.\n"
 "\n"
-"Per a més informació, contacteu amb el fabricant de maquinari o el suport tècnic."
+"Per a més informació, contacteu amb el fabricant de maquinari o el suport "
+"tècnic."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Correcte"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Ha fallat"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the
-#. computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "El dispositiu s'ajusta al nivell %d HSI"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "Nivell de seguretat 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Aquest dispositiu no té protecció contra problemes de seguretat del "
-"maquinari. Això pot ser degut a un problema de configuració de maquinari o "
-"microprogramari. Es recomana contactar amb el vostre suport tècnic."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "Nivell de seguretat 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is"
-" the lowest device security level and only provides protection against "
-"simple security threats."
-msgstr ""
-"Aquest dispositiu té una protecció mínima contra problemes de seguretat del "
-"maquinari. Aquest és el nivell de seguretat més baix del dispositiu i només "
-"proporciona protecció contra amenaces de seguretat simples."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "Nivell de seguretat 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Aquest dispositiu té protecció bàsica contra problemes de seguretat del "
-"maquinari. Això proporciona protecció contra algunes amenaces de seguretat "
-"comunes."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "Nivell de seguretat 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Aquest dispositiu té protecció ampliada contra problemes de seguretat del "
-"maquinari. Aquest és el nivell de seguretat de dispositiu més alt i "
-"proporciona protecció contra amenaces de seguretat avançades."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "Nivell de seguretat"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr ""
-"Els nivells de seguretat no estan disponibles per a aquest dispositiu."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Contacteu amb el fabricant del maquinari per a obtenir ajuda amb les "
-"actualitzacions de seguretat."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"És possible aquest problema a la configuració del microprogramari UEFI del "
-"dispositiu, o per un tècnic de suport."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"És possible resoldre aquest problema a la configuració del microprogramari "
-"UEFI del dispositiu."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Seria possible que un tècnic de suport resolgués aquest problema."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2038,344 +1191,9 @@ msgstr "Nivell 2"
 msgid "Level 3"
 msgstr "Nivell 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr "Protegit contra programari maliciós quan s'inicia el dispositiu."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "L'arrencada segura té problemes"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "Algunes proteccions quan s'inicia el dispositiu."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "L'arrencada segura està desactivada"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "No hi ha cap protecció quan s'inicia el dispositiu."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Aquest problema podria haver estat causat per un canvi en la configuració "
-"del microprogramari UEFI, un canvi en la configuració del sistema operatiu, "
-"o a causa d'un programari maliciós en aquest sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings,"
-" or because of malicious software on this system."
-msgstr ""
-"Aquest problema podria haver estat causat per un canvi en la configuració "
-"del microprogramari UEFI, o a causa del programari maliciós en aquest "
-"sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Aquest problema podria haver estat causat per un canvi de configuració del "
-"sistema operatiu, o a causa d'un programari maliciós en aquest sistema."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "Exposat a amenaces de seguretat perilloses."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "Protecció limitada contra amenaces de seguretat simples."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "Protegit contra amenaces de seguretat comunes."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "Protegit contra una àmplia gamma d'amenaces de seguretat."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "Protecció completa"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Sense esdeveniments"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Protecció d'escriptura del microprogramari"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Protecció de bloqueig d'escriptura del microprogramari"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Regió de BIOS de microprogramari"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Descriptor de BIOS de microprogramari"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Protecció DMA de prearrencada"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "BootGuard d'Intel"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Arrencada verificada d'Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Protegit amb Intel BootGuard ACM"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Política d'error d'Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard Fuse"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET habilitat"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET actiu"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "RAM xifrada"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Protecció IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Bloqueig del nucli de Linux"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Verificació del nucli de Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Intercanvi del Linux"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Suspèn a RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Suspèn en espera"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Clau de la plataforma UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Arrencada segura UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be
-#. empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Configuració de la plataforma TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Reconstrucció de TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Mode de fabricació del motor de gestió d'Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is
-#. enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on
-#. consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Sobreescriptura del motor de gestió d'Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Versió del motor de gestió d'Intel"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Actualitzacions del microprogramari"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Atestació del microprogramari"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Verificació de l'actualitzador de microprogramari"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Depuració de la plataforma"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Comprovacions de seguretat del processador"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Protecció contra la retroacció AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Protecció de reproducció de microprogramari AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Protecció d'escriptura de microprogramari AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Fused Platform"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid
-#. and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Vàlid"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "No vàlid"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Sense habilitar"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from
-#. malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Bloquejat"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Bloquejat"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Xifrada"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Sense xifrar"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Contaminat"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Sense contaminar"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Trobat"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "No s'ha trobat"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Compatible"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "No compatible"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2385,56 +1203,13 @@ msgstr "Seguretat del dispositiu"
 msgid "Host firmware security status"
 msgstr "Estat de seguretat del microprogramari de l'amfitrió"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;privacy;"
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
 msgstr ""
-"pantalla;bloca;diagnòstics;fallades;privat;recent;temporal;tmp;índex;nom;xarxa;identitat;privadesa;privacitat;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Desconegut"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Desconegut"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "No disponible"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo del sistema"
+"pantalla;bloca;diagnòstics;fallades;privat;recent;temporal;tmp;índex;nom;"
+"xarxa;identitat;privadesa;privacitat;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2509,8 +1284,8 @@ msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
 msgstr ""
-"El nom del dispositiu s'utilitza per a identificar aquest dispositiu quan es"
-" visualitza en xarxa, o quan s'emparella amb dispositius Bluetooth."
+"El nom del dispositiu s'utilitza per a identificar aquest dispositiu quan es "
+"visualitza en xarxa, o quan s'emparella amb dispositius Bluetooth."
 
 #: panels/info-overview/cc-info-overview-panel.ui:196
 msgid "Device name"
@@ -2528,18 +1303,14 @@ msgstr "Quant a"
 msgid "View information about your system"
 msgstr "Visualitzeu informació sobre el sistema"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
-"device;system;information;hostname;memory;processor;version;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "dispositiu;sistema;informació;amfitrió;memòria;processador;versió;per "
-"defecte;aplicació;preferit;cd;dvd;usb;àudio;vídeo;disc;extraïble;multimèdia;execució"
-" automàtica;"
+"defecte;aplicació;preferit;cd;dvd;usb;àudio;vídeo;disc;extraïble;multimèdia;"
+"execució automàtica;"
 
 #: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
@@ -2610,6 +1381,12 @@ msgstr "Llançadors"
 msgid "Launch help browser"
 msgstr "Inicia el navegador d'ajuda"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Paràmetres"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Inicia la calculadora"
@@ -2631,7 +1408,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Cerca"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
@@ -2680,15 +1457,6 @@ msgstr "Redueix la mida del text"
 msgid "High contrast on or off"
 msgstr "Activa o desactiva el contrast alt"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "No s'han trobat fonts d'entrada"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Altres"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Afegeix una font d'entrada"
@@ -2722,107 +1490,9 @@ msgstr "Preferències"
 msgid "View Keyboard Layout"
 msgstr "Visualitza la disposició del teclat"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Suprimeix"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Dreceres personalitzades"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Tecla de caràcters alternatius"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"La tecla de caràcters alternatius s'utilitza per a introduir caràcters "
-"addicionals. Aquests alguns cops estan impresos com a tercera opció en el "
-"teclat."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt esquerra"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt dreta"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Súper esquerra"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Súper dreta"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tecla de menú"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl dreta"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Tecla de composició"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"La tecla de composició permet introduir una gran varietat de caràcters. Per "
-"a utilitzar-la, premeu-la seguida d'una seqüència de caràcters.  Per "
-"exemple, la tecla de composició seguida de <b>C</b> i <b>o</b> introduirà "
-"<b>©</b>, i <b>a</b> seguida de <b>'</b> introduirà <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Bloq Maj"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Bloq Despl"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Impr Pant"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Les fonts d'entrada es poden canviar utilitzant la drecera de teclat %s.\n"
-"Això es pot canviar a la configuració de la drecera de teclat."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2853,45 +1523,21 @@ msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Mètodes per a introduir símbols i variants de lletres utilitzant el teclat."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de caràcters alternatius"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composició"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Dreceres de teclat"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Visualitza i personalitza les dreceres"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modificada"
-msgstr[1] "%d modificades"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Voleu restablir totes les dreceres?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Restablir les dreceres pot afectar les vostres dreceres personalitzades. "
-"Aquesta acció no es pot desfer."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Cancel·la"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Restableix-ho tot"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2931,34 +1577,6 @@ msgstr "Afegeix una drecera"
 msgid "No keyboard shortcut found"
 msgstr "No s'ha trobat la tecla de drecera"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid ""
-"%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s ja s'utilitza per %s. Si la reemplaceu, %s s'inhabilitarà"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Introduïu la drecera nova"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Estableix la drecera personalitzada"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Estableix la drecera"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Introduïu una drecera nova per a canviar %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Afegeix drecera personalitzada"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Suprimeix"
@@ -2970,7 +1588,6 @@ msgstr "R_eemplaça"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Estableix"
 
@@ -3006,6 +1623,11 @@ msgstr "Cap"
 msgid "Reset the shortcut to its default value"
 msgstr "Restableix la drecera al seu valor per omissió"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Utilitza la impressora per defecte"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Teclat"
@@ -3018,14 +1640,12 @@ msgstr ""
 "Canvieu les dreceres de teclat i establiu les vostres preferències "
 "d'escriptura, disposicions de teclat i fonts d'entrada"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
-"Drecera;Espai de treball;Finestra;Canvia la "
-"mida;Amplia;Contrast;Entrada;Font;Bloqueig;Volum;"
+"Drecera;Espai de treball;Finestra;Canvia la mida;Amplia;Contrast;Entrada;"
+"Font;Bloqueig;Volum;"
 
 #: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
@@ -3037,15 +1657,19 @@ msgstr "Cap aplicació pot obtenir informació sobre la ubicació."
 
 #: panels/location/cc-location-panel.ui:38
 msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and mobile broadband increases accuracy.\n"
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
 "\n"
-"Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/privacy'>Privacy Policy</a>\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
 "\n"
 "Allow the applications below to determine your location."
 msgstr ""
-"Els serveis de localització permeten a les aplicacions conèixer la vostra ubicació. L'ús de Wi-Fi i banda ampla mòbil augmenta la precisió.\n"
+"Els serveis de localització permeten a les aplicacions conèixer la vostra "
+"ubicació. L'ús de Wi-Fi i banda ampla mòbil augmenta la precisió.\n"
 "\n"
-"Utilitza el servei d'ubicació de Mozilla: <a href='https://location.services.mozilla.com/privacy'>política de privadesa</a>\n"
+"Utilitza el servei d'ubicació de Mozilla: <a href='https://location.services."
+"mozilla.com/privacy'>política de privadesa</a>\n"
 "\n"
 "Permeteu que les aplicacions següents determinin la vostra ubicació."
 
@@ -3057,8 +1681,6 @@ msgstr "Cap aplicació ha demanat accés a la ubicació"
 msgid "Protect your location information"
 msgstr "Protegiu la vostra informació d'ubicació"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "ubicació;gps;privat;privadesa;"
@@ -3073,11 +1695,15 @@ msgstr "No s'han trobat aplicacions."
 
 #: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
-"Use of the microphone allows applications to record and listen to audio. Disabling the microphone may cause some applications to not function properly.\n"
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
 "\n"
 "Allow the applications below to use your microphone."
 msgstr ""
-"L'ús del micròfon permet a les aplicacions enregistrar i escoltar àudio. Inhabilitar el micròfon pot causar que algunes aplicacions no funcionin correctament.\n"
+"L'ús del micròfon permet a les aplicacions enregistrar i escoltar àudio. "
+"Inhabilitar el micròfon pot causar que algunes aplicacions no funcionin "
+"correctament.\n"
 "\n"
 "Permet que les aplicacions de sota utilitzin el micròfon."
 
@@ -3089,8 +1715,6 @@ msgstr "Cap aplicació ha demanat accés al micròfon"
 msgid "Protect your conversations"
 msgstr "Protegiu les vostres converses"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "micròfon;enregistrament;aplicació;privadesa;"
@@ -3122,83 +1746,139 @@ msgstr "Esquerre"
 msgid "Right"
 msgstr "Dret"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Ubicacions de cerca"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Ratolí"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Velocitat del ratolí"
 
-#. Translators: This switch reverses the scrolling direction for mices. The
-#. term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads.
-#. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Desplaçament natural"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Secció"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "El desplaçament mou el contingut, no la vista."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "El desplaçament mou el contingut, no la vista."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Actiu"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Ratolí tàctil"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Velocitat del ratolí tàctil"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Fes un toc per a fer un clic"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Fes un toc per a fer un clic"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Desplaçament amb dos dits"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Velocitat del ratolí tàctil"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Desplaçament en la vora"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Bloq Despl"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Doble cara"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Proveu de fer clic, fer doble clic i desplaçar"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinc clics, és l'hora del GEGL"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Doble clic, botó primari"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Un sol clic, botó primari"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Doble clic, botó del mig"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Un sol clic, botó del mig"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Doble clic, botó secundari"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Un sol clic, botó secundari"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3211,9 +1891,6 @@ msgstr ""
 "Canvieu la sensibilitat del ratolí i del ratolí tàctil i seleccioneu l'ús "
 "per dretans o esquerrans"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT
-#. translate or localize the semicolons! The list MUST also end with a
-#. semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Ratolí tàctil;Punter;Clic;Toc;Doble;Botó;Ratolí de bola;Desplaça;"
@@ -3295,8 +1972,6 @@ msgstr "Multitasca"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Gestiona les preferències de productivitat i multitasca"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3304,22 +1979,11 @@ msgstr ""
 "Multitasca;Productivitat;Personalitza;Escriptori;Cantonada activa;Espais de "
 "treball"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"S'ha produït un error inesperat. Contacteu el vostre proveïdor de "
-"programari."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Cal que el NetworkManager estigui executant-se."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Altres dispositius"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3331,61 +1995,16 @@ msgstr "Afegeix una connexió"
 msgid "Not set up"
 msgstr "No s'ha configurat"
 
-#. TRANSLATORS: This happens when the connection name does not contain the
-#. SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Xarxa insegura (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Xarxa segura (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Xarxa segura (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Xarxa segura (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Xarxa segura"
-
-#. TRANSLATORS: device status
 #: panels/network/cc-wifi-connection-row.ui:41
-#: panels/network/panel-common.c:63
 msgid "Connected"
 msgstr "Connectat"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22
-#: panels/network/network-ethernet.ui:56 panels/network/network-mobile.ui:329
-#: panels/network/network-proxy.ui:62 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opcions…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"En activar el punt d'accés Wi-Fi es desconnectarà de %s, i no serà possible "
-"accedir a Internet a través de Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Ha de tenir com a mínim 8 caràcters"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3400,8 +2019,8 @@ msgstr "Cal activar el punt d'accés Wi-Fi?"
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
-"Wi-Fi hotspot allows others to share your internet connection, by creating a"
-" Wi-Fi network that they can connect to. To do this, you must have an "
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
 "internet connection through a source other than Wi-Fi."
 msgstr ""
 "El punt d'accés Wi-Fi permet compatir la vostra connexió a Internet amb "
@@ -3434,20 +2053,6 @@ msgstr "Genera una contrasenya automàticament"
 #: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Activa"
-
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Voleu aturar el punt d'accés Wi-Fi i desconnectar els usuaris?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Atura el punt d'accés Wi-Fi"
 
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
@@ -3493,89 +2098,14 @@ msgstr "Xarxes visibles"
 msgid "NetworkManager needs to be running"
 msgstr "Cal que el NetworkManager estigui executant-se"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"S'ha produït un error inesperat. Contacteu el vostre proveïdor de programari."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Seguretat 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Seguretat"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Conserva"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "A l'atzar"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Estable"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC"
-" cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"L'adreça MAC introduïda aquí s'utilitzarà com adreça de maquinari per la "
-"connexió per la qual s'activi aquest dispositiu. Aquesta funcionalitat es "
-"coneix com a clonació o falsejament de MAC. Per exemple: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Perfil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Obertura millorada"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Corporativa"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Cap"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Mai"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3584,183 +2114,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "fa %i dia"
 msgstr[1] "fa %i dies"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Cap"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Dèbil"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Acceptable"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Bona"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excel·lent"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Adreça IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Adreça IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Adreça IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Oblida la connexió"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Suprimeix el perfil de connexió"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Suprimeix VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Detalls"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automàtic"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitat"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Suprimeix l'adreça"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Suprimeix la ruta"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Cap"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Clau WEP 40/128-bit (hexadecimal o ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Contrasenya WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinàmic (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA i WPA2 personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA i WPA2 corporativa"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 personal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3771,8 +2124,20 @@ msgstr "Força del senyal"
 msgid "Link speed"
 msgstr "Velocitat de l'enllaç"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguretat"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Adreça IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adreça IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Adreça física"
 
@@ -3781,12 +2146,17 @@ msgid "Supported Frequencies"
 msgstr "Freqüències compatibles"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Ruta per defecte"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3806,8 +2176,7 @@ msgstr "Connexió li_mitada: té dades limitades o pot incórrer en càrrecs"
 
 #: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"Software updates and other large downloads will not be started "
-"automatically."
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 "Les actualitzacions de programari i altres baixades grans no s'iniciaran "
 "automàticament."
@@ -3850,7 +2219,7 @@ msgstr "Només enllaç local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
@@ -3894,9 +2263,8 @@ msgstr "Passarel·la"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automàtic"
 
@@ -3949,87 +2317,9 @@ msgstr "Automàtic, només DHCP"
 msgid "Prefix"
 msgstr "Prefix"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "No s'ha pogut obrir l'editor de connexions"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Perfil nou"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Configuració no vàlida %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Configuració no vàlida %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importa des d'un fitxer…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Afegeix VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_eguretat"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "No es pot importar la connexió VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"No s'ha pogut llegir el fitxer «%s» o no conté informació reconeguda d'una connexió VPN\n"
-"\n"
-"Error: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Seleccioneu el fitxer a importar"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Ja existeix un fitxer amb el nom «%s»."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Substitueix"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Voleu substituir %s amb la connexió VPN que esteu desant?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "No es pot exportar la connexió VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"No s'ha pogut exportar la connexió VPN «%s» a %s.\n"
-"\n"
-"Error: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Exporta la connexió VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4043,105 +2333,39 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Xarxa"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controleu com us connecteu a Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Xarxa;IP;LAN;Servidor intermediari;WAN;Banda ampla;Mòdem;Bluetooth;vpn;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controleu com us connecteu a les xarxes sense fil"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
-"Xarxa;Sense fil;Wi-Fi;Wifi;IP;LAN;Servidor intermediari;WAN;Banda "
-"ampla;DNS;punt d'accés Wi-Fi;"
+"Xarxa;Sense fil;Wi-Fi;Wifi;IP;LAN;Servidor intermediari;WAN;Banda ampla;DNS;"
+"punt d'accés Wi-Fi;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "mai"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "avui"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "ahir"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Utilitzada per últim cop"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Amb fil"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Afegeix una connexió nova"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Es perdran les dades de xarxa de les xarxes seleccionades, incloent-hi les "
-"contrasenyes i la configuració personalitzada."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Oblida"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Xarxes sense fil conegudes"
-
-#. translators: This is the label for the "Forget wireless network"
-#. functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Oblida"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-"La política del sistema prohibeix utilitzar-lo com a punt d'accés Wi-Fi"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "El dispositiu sense fil no admet el mode punt d'accés Wi-Fi"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"El descobriment automàtic de servidors intermediaris web s'utilitza quan no "
-"es proporciona un URL de configuració."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "No és recomanable en xarxes públiques sense confiança."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4160,6 +2384,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Proveïdor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adreça IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4244,289 +2472,6 @@ msgstr "_Activa el punt d'accés Wi-Fi…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Xarxes sense fil conegudes"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Estat desconegut"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "No gestionat"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "No disponible"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "S'està connectant"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Cal autenticació"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "S'està desconnectant"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Ha fallat la connexió"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Estat desconegut (manca)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Ha fallat la configuració"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Ha fallat la configuració de la IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Ha caducat la configuració de la IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Calen secrets, però no s'han proporcionat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "S'ha desconnectat el suplicant de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Ha fallat la configuració del suplicant de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Ha fallat el suplicant de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "El suplicant de 802.1x ha tardat massa en autenticar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "No s'ha pogut iniciar el servei PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "S'ha desconnectat el servei PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Ha fallat el PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "No s'ha pogut iniciar el client DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "S'ha produït un error en el client DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Ha fallat el client DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "No s'ha pogut iniciar el servei de connexió compartida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Ha fallat el servei de connexió compartida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "No s'ha pogut iniciar el servei AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "S'ha produït un error en el servei AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Ha fallat el servei AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Línia ocupada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "No hi ha to de trucada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "No s'ha pogut establir cap portadora"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Ha acabat el temps d'espera de la sol·licitud de trucada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Ha fallat l'intent de trucada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Ha fallat la inicialització del mòdem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "No s'ha pogut seleccionar l'APN especificat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "No s'estan cercant xarxes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "S'ha denegat el registre a la xarxa"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Ha acabat el temps d'espera del registre de la xarxa"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Ha fallat el registre amb la xarxa sol·licitada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Ha fallat la comprovació del PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Pot ser que falti el microprograma del dispositiu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Ha desaparegut la connexió"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "S'havia assumit una connexió existent"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "No s'ha trobat el mòdem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Ha fallat la connexió Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "No s'ha inserit la targeta SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Cal el PIN de la SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Cal el PUK de la SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM incorrecta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Ha fallat la dependència de la connexió"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Falta el microprogramari"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Cable desconnectat"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "s'ha produït un error no definit en la seguretat de 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "no s'ha seleccionat cap fitxer"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "s'ha produït un error no especificat en validar el fitxer eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Claus privades DER, PEM, PKCS#12 o PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Certificats DER o PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "falta el fitxer EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Fitxers PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4575,14 +2520,6 @@ msgstr "Autenticació _interna"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "_Permet la provisió automàtica PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "falta el nom d'usuari EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "falta la contrasenya EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4608,15 +2545,6 @@ msgstr "_Contrasenya"
 msgid "Sho_w password"
 msgstr "_Mostra la contrasenya"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "certificat CA EAP-PEAP no vàlid: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "certificat CA EAP-PEAP no vàlid: no s'ha especificat un certificat"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4638,7 +2566,6 @@ msgid "C_A certificate"
 msgstr "Certificat C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4653,59 +2580,6 @@ msgstr "_No es requereix un certificat CA"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versió PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "falta el nom d'usuari EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "falta la contrasenya EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "falta la identitat EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "certificat CA EAP-TLS invàlid: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TLS invàlid: no s'ha especificat un certificat"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "clau privada EAP-TLS no vàlida: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificat d'usuari EAP-TLS no vàlid: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Les claus privades sense xifrar no són segures"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This could allow your security credentials to be compromised. Please select a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"La clau privada que heu seleccionat no sembla protegida amb una contrasenya. Això podria permetre que les credencials de seguretat fossin compromeses. Seleccioneu una clau privada protegida per contrasenya.\n"
-"\n"
-"(Podeu protegir la vostra clau privada amb una contrasenya amb l'openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Trieu el vostre certificat personal"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Trieu la vostra clau privada"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4722,15 +2596,6 @@ msgstr "_Clau privada"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Contrasenya de clau _privada"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "certificat CA EAP-TTLS no vàlid: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TTLS no vàlid: no s'ha especificat un certificat"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4753,14 +2618,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domini"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "S'ha produït un error desconegut en validar la seguretat de 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4788,62 +2654,10 @@ msgstr "EAP protegit (PEAP)"
 msgid "Au_thentication"
 msgstr "Au_tenticació"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Selecciona un fitxer"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "manca el mom d'usuari LEAP"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "manca la contrasenya LEAP"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Falta la contrasenya Wi-Fi."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipus"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "manca la clau wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"clau wep invàlida: una clau amb longitud %zu ha de contenir només dígits "
-"hexadecimals"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"clau wep invàlida: una clau amb longitud %zu ha de contenir només caràcters "
-"ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"clau wep invàlida: la longitud de clau %zu és errònia. Una clau ha de tenir "
-"una longitud de 5/13 (ascii) o bé 10/26 (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "clau wep invàlida: la contrasenya no pot ser buida"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "clau wep invàlida: la contrasenya ha de tenir menys de 64 caràcters"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4868,21 +2682,6 @@ msgstr "_Mostra la clau"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Índe_x WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk no vàlid: longitud de clau %zu no vàlida. Ha de tenir [8,63] bytes o"
-" 64 dígits hexadecimals"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk no vàlid: no es pot interpretar la clau de 64 bytes com a "
-"hexadecimal"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4909,8 +2708,7 @@ msgstr ""
 "Les notificacions continuaran apareixent en la llista de notificacions "
 "encara que inhabiliteu les notificacions emergents."
 
-#. Popups here refers to message tray notifications in the middle of the
-#. screen.
+#. Popups here refers to message tray notifications in the middle of the screen.
 #: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
@@ -4938,30 +2736,11 @@ msgstr "_Notificacions a la pantalla de bloqueig"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controleu quines notificacions es mostren i què mostren"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate
-#. or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notificacions;Bàner;Missatge;Safata;Emergent;"
 
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Altres"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "s'ha suprimit %s"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "S'ha produït un error en suprimir el compte"
-
-#. Translators: This is the button which allows undoing the removal of the
-#. printer.
+#. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
 #: panels/printers/printers.ui:47
 msgid "Undo"
@@ -4978,23 +2757,12 @@ msgstr "Connecteu-vos a les vostres dades al núvol"
 #: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
-"No hi ha connexió a Internet. Connecteu-vos per a configurar nous comptes en"
-" línia"
+"No hi ha connexió a Internet. Connecteu-vos per a configurar nous comptes en "
+"línia"
 
 #: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Afegeix un compte"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Compte de %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Suprimeix el compte"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -5004,21 +2772,13 @@ msgstr "Comptes en línia"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Connecteu-vos als comptes en línia i decidiu quin ús en voleu fer"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see
-#. http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
-"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-"Google;Facebook;Twitter;Yahoo;Web;En "
-"línia;Xat;Calendari;Correu;Contacte;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Temps desconegut"
+"Google;Facebook;Twitter;Yahoo;Web;En línia;Xat;Calendari;Correu;Contacte;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5034,13 +2794,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i hora"
 msgstr[1] "%i hores"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5052,191 +2805,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
 msgstr[1] "minuts"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s fins que es carregui del tot"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Atenció: queden %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Queden %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Totalment carregada"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "No s'està carregant"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Buida"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "S'està carregant"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "S'està descarregant"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Ratolí sense fil"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Teclat sense fil"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Sistema d'alimentació ininterrompuda"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Auxiliar digital personal"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Telèfon mòbil"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Reproductor multimèdia"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tauleta gràfica"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Ordinador"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Dispositiu d'entrada de joc"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Bateria"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principal"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Addicional"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Bateries"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Quan estigui _inactiu"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Suspèn"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Apaga"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hiberna"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Res"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Quan s'utilitzi la bateria"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Quan estigui endollat"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Mai"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Suspèn automàticament"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"El mode de rendiment està temporalment inhabilitat a causa de l'alta "
-"temperatura d'operació."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a"
-" stable surface to restore."
-msgstr ""
-"S'ha detectat una volta: el mode de rendiment no està disponible "
-"temporalment. Moveu el dispositiu a una superfície estable per a restaurar-"
-"lo."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Mode de rendiment inhabilitat temporalment."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Bateria baixa: l'estalvi d'energia està habilitat. El mode anterior es "
-"restaurarà quan la bateria estigui prou carregada."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Mode d'estalvi d'energia activat per «%s»."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Mode de rendiment activat per «%s»."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5298,6 +2866,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 hores"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bateria"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositius"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Mode d'energia"
@@ -5324,8 +2901,7 @@ msgstr "Atenua la pantalla"
 
 #: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
-msgstr ""
-"Redueix la brillantor de la pantalla quan l'ordinador estigui inactiu."
+msgstr "Redueix la brillantor de la pantalla quan l'ordinador estigui inactiu."
 
 #: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
@@ -5376,33 +2952,6 @@ msgstr "Quan s'utilitza la _bateria"
 msgid "Delay"
 msgstr "Retard"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Rendiment"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Rendiment i ús d'energia alts."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Equilibrat"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Rendiment i ús d'energia estàndards."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Estalvi d'energia"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Rendiment i ús d'energia reduïts."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Energia"
@@ -5413,35 +2962,13 @@ msgstr ""
 "Visualitzeu l'estat de la bateria i canvieu els paràmetres d'estalvi "
 "d'energia"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;Energy;"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
-"Energia;Baix consum;suspèn;Hibernació;Bateria;Brillantor;Atenuar;En "
-"blanc;Monitor;DPMS;Inactiu;Energia;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "S'ha suprimit la impressora «%s»"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "No s'ha pogut afegir una impressora nova."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "No s'ha pogut carregar la interfície d'usuari: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Desbloqueja per a afegir usuaris i modificar els paràmetres"
+"Energia;Baix consum;suspèn;Hibernació;Bateria;Brillantor;Atenuar;En blanc;"
+"Monitor;DPMS;Inactiu;Energia;"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5453,8 +2980,6 @@ msgstr ""
 "Afegiu impressores, visualitzeu tasques d'impressió i decidiu com voleu "
 "imprimir"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Impressora;Cua;Imprimir;Paper;Tinta;Tòner;"
@@ -5462,8 +2987,6 @@ msgstr "Impressora;Cua;Imprimir;Paper;Tinta;Tòner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Afegeix una impressora"
 
@@ -5480,8 +3003,7 @@ msgstr "Desbloq_ueja"
 msgid "No Printers Found"
 msgstr "No s'ha trobat cap impressora"
 
-#. Translators: The entered text should contain network address of a printer
-#. or a text which will filter found devices (their names and locations)
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
 #: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Introduïu una adreça de xarxa o cerqueu una impressora"
@@ -5493,8 +3015,8 @@ msgstr "Cal autenticació"
 #: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
-"Introduïu el nom d'usuari i la contrasenya per a visualitzar les impressores"
-" al servidor d'impressió."
+"Introduïu el nom d'usuari i la contrasenya per a visualitzar les impressores "
+"al servidor d'impressió."
 
 #. Translators: This is a username on a print server.
 #: panels/printers/new-printer-dialog.ui:317
@@ -5505,42 +3027,15 @@ msgstr ""
 msgid "Username"
 msgstr "Nom d'usuari"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Detalls %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "No s'ha trobat cap controlador adequat"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Selecció d'un fitxer PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD.GZ)"
-msgstr ""
-"Fitxers de descripció d'impressora PostScript (*.ppd, *.PPD, *.ppd.gz, "
-"*.PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
-msgstr ""
-"Els noms de les impressores no poden contenir espai, tabulador, #, o /"
+msgstr "Els noms de les impressores no poden contenir espai, tabulador, #, o /"
 
-#: panels/printers/pp-details-dialog.ui:89
-#: panels/printers/printer-entry.ui:211
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Ubicació"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Controlador"
 
@@ -5568,122 +3063,14 @@ msgstr "Seleccioneu un controlador d'impressora"
 msgid "Loading drivers database…"
 msgstr "S'està carregant la base de dades de controladors..."
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Cancel·la"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Selecciona"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Impressora JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Impressora LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Una cara"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Cantó llarg (estàndard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Cantó curt (capgirat)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Vertical"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Apaïsat"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Apaïsat del revés"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Vertical del revés"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Reprèn"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pausat"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Pendent"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pausat"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Cal autenticació"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "S'està processant"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Aturada"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Cancel·lada"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Interrompuda"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Completada"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Mou aquest treball a la part superior de la cua"
-
-#. Translators: This label shows how many jobs of this printer needs to be
-#. authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5691,374 +3078,43 @@ msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u tasca requereix autenticació"
 msgstr[1] "%u tasques requereixen autenticació"
 
-#. Translators: This is the printer name for which we are showing the active
-#. jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - tasques actives"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Introduïu les credencials per a imprimir des de %s."
-
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
 #: panels/user-accounts/cc-add-user-dialog.ui:300
 msgid "Domain"
 msgstr "Domini"
 
-#. Translators: This button authenticates all print jobs and send them for
-#. printing.
+#. Translators: This button authenticates all print jobs and send them for printing.
 #: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "A_utentica"
 
-#. Translators: this action removes (purges) all the listed jobs from the
-#. list.
+#. Translators: this action removes (purges) all the listed jobs from the list.
 #: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Neteja-ho tot"
 
-#. Translators: This button pop up authentication dialog for print jobs which
-#. need credentials.
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
 #: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Autentica"
 
-#. Translators: this label describes the dialog empty state, with no jobs
-#. listed.
+#. Translators: this label describes the dialog empty state, with no jobs listed.
 #: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "No hi ha tasques d'impressió actives"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Desbloqueja el servidor d'impressió"
-
-#. Translators: Samba server needs authentication of the user to show list of
-#. its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Desbloqueja %s."
-
-#. Translators: Samba server needs authentication of the user to show list of
-#. its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Introduïu el nom d'usuari i la contrasenya per a visualitzar les impressores"
-" a %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "S'estan cercant les impressores"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Port en sèrie"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Port paral·lel"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Ubicació: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adreça: %s"
-
-#. Translators: This item is a server which needs authentication to show its
-#. printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "El servidor requereix autenticació"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Doble cara"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Tipus de paper"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Font del paper"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Safata de sortida"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolució"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Filtrat previ del GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Pàgines per cara"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Doble cara"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientació"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "General"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page
-#. size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Configuració de la pàgina"
-
-#. Translators: "Installable Options" tab contains settings of presence of
-#. installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opcions instal·lables"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Tasca"
-
-#. Translators: "Image Quality" tab contains settings for quality of output
-#. print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Qualitat de la imatge"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Color"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet
-#. printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Acabats"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avançat"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Pàgina de prova"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Pàgina de prova"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Selecció automàtica"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Per defecte de la impressora"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Incrusta només tipus de lletra del GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Converteix a PS nivell 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Converteix a PS nivell 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Sense filtrat previ"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Fabricant"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "No hi ha tasques actives"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u tasca"
 msgstr[1] "%u tasques"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Neteja els capçals d'impressió"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Tòner baix"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Sense tòner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Revelador baix"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Sense revelador"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Marcador baix"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Sense marcador"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Tapa oberta"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Porta oberta"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Té poc paper"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Sense paper"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Apagada"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Aturada"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "El receptacle de residus està quasi ple"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "El receptacle de residus està ple"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "El conductor òptic fotogràfic està al final de la seva vida"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "El conductor òptic fotogràfic ja no funciona"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "A punt"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "No accepta tasques"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "S'està processant"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6073,8 +3129,7 @@ msgstr "Detalls de la impressora"
 msgid "Use Printer by Default"
 msgstr "Utilitza la impressora per defecte"
 
-#. Translators: This button executes command which cleans print heads of the
-#. printer.
+#. Translators: This button executes command which cleans print heads of the printer.
 #: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "Neteja els capçals d'impressió"
@@ -6082,6 +3137,10 @@ msgstr "Neteja els capçals d'impressió"
 #: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Suprimeix la impressora"
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "No hi ha tasques actives"
 
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
@@ -6103,16 +3162,21 @@ msgid "Restart"
 msgstr "Torna a iniciar"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Afegeix una impressora…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Afegeix una impressora…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Sense impressores"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6120,7 +3184,6 @@ msgstr ""
 "Perdó! Sembla que el servei d'impressió\n"
 "del sistema no està disponible."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formats"
@@ -6148,16 +3211,6 @@ msgstr "Es pot cerca per països o idiomes."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Visualització prèvia"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Mètric"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6195,20 +3248,24 @@ msgstr ""
 "La configuració d'idioma s'utilitza per al text de la interfície i les "
 "pàgines web. Els formats s'utilitzen per a nombres, dates i monedes."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "El teu compte"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Idioma"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formats"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Pantalla d'inici de sessió"
 
@@ -6220,102 +3277,9 @@ msgstr "Regió i idioma"
 msgid "Select your display language and formats"
 msgstr "Seleccioneu l'idioma a mostrar i els formats"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT
-#. translate or localize the semicolons! The list MUST also end with a
-#. semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Disposició;Teclat;Entrada;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Pregunta què fer"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "No facis res"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Obre la carpeta"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Altres suports"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Seleccioneu l'aplicació per als CD d'àudio"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Seleccioneu l'aplicació per als DVD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Seleccioneu l'aplicació que s'iniciarà quan es connecti un reproductor de "
-"música"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Seleccioneu l'aplicació que s'iniciarà quan es connecti una càmera"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Seleccioneu l'aplicació per als CD de programari"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD d'àudio"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Disc Blu-ray en blanc"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "Disc CD en blanc"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "Disc DVD en blanc"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "Disc HD DVD en blanc"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Disc Blu-ray de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "lector de llibres digitals"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Disc HD DVD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "CD de fotos"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Supervídeo CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "CD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Programari del Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6365,124 +3329,13 @@ msgstr "Suports extraïbles"
 msgid "Configure Removable Media settings"
 msgstr "Configura els paràmetres del suport extraïble"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT
-#. translate or localize the semicolons! The list MUST also end with a
-#. semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"dispositiu;sistema;informació;per "
-"defecte;aplicació;preferit;cd;dvd;usb;àudio;vídeo;disc;extraïble;multimèdia;execució"
-" automàtica;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "S'apaga la pantalla"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 segons"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minut"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minuts"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minuts"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minuts"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minuts"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minuts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minuts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minuts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minuts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minuts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minuts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minuts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minuts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Mai"
+"dispositiu;sistema;informació;per defecte;aplicació;preferit;cd;dvd;usb;"
+"àudio;vídeo;disc;extraïble;multimèdia;execució automàtica;"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6490,8 +3343,8 @@ msgstr "Bloqueja la pantalla"
 
 #: panels/screen/cc-screen-panel.ui:9
 msgid ""
-"Automatically locking the screen prevents others from accessing the computer"
-" while you're away."
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
 msgstr ""
 "Bloquejar la pantalla automàticament evita que altres puguin accedir a "
 "l'ordinador mentre no hi sou."
@@ -6502,8 +3355,7 @@ msgstr "Retard per a posar la pantalla en blanc"
 
 #: panels/screen/cc-screen-panel.ui:15
 msgid "Period of inactivity after which the screen will go blank."
-msgstr ""
-"Període d'inactivitat després del qual la pantalla es posarà en blanc."
+msgstr "Període d'inactivitat després del qual la pantalla es posarà en blanc."
 
 #: panels/screen/cc-screen-panel.ui:33
 msgid "Automatic Screen _Lock"
@@ -6514,8 +3366,7 @@ msgid "Automatic _Screen Lock Delay"
 msgstr "_Retard per a bloquejar la pantalla automàticament"
 
 #: panels/screen/cc-screen-panel.ui:51
-msgid ""
-"Period after the screen blanks when the screen is automatically locked."
+msgid "Period after the screen blanks when the screen is automatically locked."
 msgstr ""
 "Període després del qual la pantalla es posa en blanc quan la pantalla es "
 "bloqueja automàticament."
@@ -6524,11 +3375,16 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "_Mostra les notificacions a la pantalla de bloqueig"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Notificacions a la pantalla de bloqueig"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "_Prohibeix els dispositius USB nous"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6536,31 +3392,25 @@ msgstr ""
 "Evita que els dispositius USB nous puguin interaccionar amb el sistema quan "
 "la pantalla estigui bloquejada."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Privacitat de la pantalla"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Restringeix l'angle de visualització"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantalla"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Paràmetres de la pantalla"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "pantalla;bloqueja;privat;privadesa;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Seleccioneu una ubicació"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_D'acord"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6569,8 +3419,8 @@ msgstr "Ubicacions de cerca"
 
 #: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
-"Folders which are searched by system applications, such as Files, Photos and"
-" Videos."
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
 msgstr ""
 "Carpetes que se cerquen per les aplicacions del sistema, com Fitxers, Fotos "
 "i Vídeos."
@@ -6590,10 +3440,6 @@ msgstr "Altres"
 #: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Afegeix una ubicació"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "No s'han trobat aplicacions"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -6622,93 +3468,13 @@ msgstr ""
 "Controleu quines aplicacions mostren resultats de cerca a la vista general "
 "d'activitats"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Cerca;Troba;Índex;Oculta;Privacitat;Resultats;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "No hi ha cap xarxa seleccionada per a compartir"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Xarxes"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Activat"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Desactivat"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Habilitat"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Actiu"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Trieu una carpeta"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Afegeix"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Habilita la compartició de mitjans"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"La compartició de fitxers us permet compartir la carpeta pública amb altres "
-"a la xarxa actual utilitzant: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to
-#. run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure Shell command:\n"
-"%s"
-msgstr ""
-"Quan l'inici de sessió remot està habilitat, els usuaris remots poden connectar-se utilitzant l'ordre del Secure Shell:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Habilita la compartició de mitjans personals"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "S'ha copiat el nom del dispositiu"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "S'ha copiat l'adreça del dispositiu"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "S'ha copiat el nom d'usuari"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "S'ha copiat la contrasenya"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6803,7 +3569,7 @@ msgstr "Autenticació"
 #: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr ""
-"Es requereix el nom d'usuari i la contrasenya per connectar-se a aquest "
+"Es requereix el nom d'usuari i la contrasenya per a connectar-se a aquest "
 "ordinador."
 
 #: panels/sharing/cc-sharing-panel.ui:366
@@ -6842,13 +3608,13 @@ msgstr "Carpetes"
 msgid "Control what you want to share with others"
 msgstr "Controleu què voleu compartir amb els altres"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;movies;server;renderer;"
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 msgstr ""
-"comparteix;compartició;ssh;amfitrió;nom;remot;escriptori;multimèdia;àudio;vídeo;imatges;fotografies;pel·lícules;servidor;renderitzar;"
+"comparteix;compartició;ssh;amfitrió;nom;remot;escriptori;multimèdia;àudio;"
+"vídeo;imatges;fotografies;pel·lícules;servidor;renderitzar;"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
@@ -6856,12 +3622,7 @@ msgstr "Habilita o inhabilita l'inici de sessió remot"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
-msgstr ""
-"Cal autenticació per a habilitar o inhabilitar l'inici de sessió remot"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Personalitzat"
+msgstr "Cal autenticació per a habilitar o inhabilitar l'inici de sessió remot"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6894,11 +3655,6 @@ msgstr "Posterior"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Frontal"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Provant %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6952,11 +3708,6 @@ msgstr "Volum"
 msgid "Alert Sound"
 msgstr "So d'alerta"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Silencia"
@@ -6970,83 +3721,12 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Canvieu els nivells de so, les entrades, les sortides i les alertes sonores"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
-"Targeta;Micròfon;Volum;Esvair;Balanç;Bluetooth;Auriculars;Àudio;Sortida;Entrada;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Desconnectat"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "S'està connectant"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Connectat"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "S'ha produït un error d'autorització"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "S'està autoritzant"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Funcionalitat reduïda"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Connectat i autoritzat"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Desconegut"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autoritzat a les:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Connectat a les:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Inscrits a les:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "S'ha produït un error en autoritzar el dispositiu: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "S'ha produït un error en oblidar el dispositiu: "
+"Targeta;Micròfon;Volum;Esvair;Balanç;Bluetooth;Auriculars;Àudio;Sortida;"
+"Entrada;"
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7080,53 +3760,6 @@ msgstr "Autoritza i connecta"
 msgid "Forget Device"
 msgstr "Oblida el dispositiu"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Error"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autoritzat"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"El subsistema Thunderbolt (boltd) no està instal·lat o configurat "
-"correctament."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Permet l'accés als dispositius com ara acobladors o CPU externs."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Només es poden adjuntar dispositius USB i pantalles."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"No s'ha pogut detectar Thunderbolt.\n"
-"O bé el sistema no és compatible amb Thunderbolt, s'ha inhabilitat al BIOS o està configurat amb un nivell de seguretat no compatible al BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "El suport per a aquesta funció està inhabilitat al BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "No s'ha pogut determinar el nivell de seguretat de Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "S'ha produït un error en canviar al mode directe: «%s»"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Sense compatibilitat Thunderbolt"
@@ -7138,6 +3771,10 @@ msgstr "No s'ha pogut connectar al subsistema Thunderbolt."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Accés directe"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Permet l'accés als dispositius com ara acobladors o CPU externs."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7155,9 +3792,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Administra dispositius Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel.
-#. Do NOT translate or localize the semicolons! The list MUST also end with a
-#. semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privadesa;"
@@ -7360,40 +3994,6 @@ msgstr "_Habilita per teclat"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Activa i desactiva les funcions d'accessibilitat utilitzant el teclat"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Per defecte"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Mitjà"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Gran"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Més gran"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "El més gran"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d píxel"
-msgstr[1] "%d píxels"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Mostra _sempre el menú d'accés universal"
@@ -7510,31 +4110,6 @@ msgstr "Fes parpellejar la _pantalla sencera"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Fes parpellejar la _finestra"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Curta"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ de pantalla"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ de pantalla"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ de pantalla"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Llarga"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7691,135 +4266,17 @@ msgstr "Efectes de color"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Feu més fàcil veure, sentir, teclejar, apuntar i fer clic"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate
-#. or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Universal "
-"Access;Contrast;Cursor;Sound;Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;animations;"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"Teclat;ratolí;a11y;accessibilitat;accés "
-"universal;contrast;cursor;so;zoom;pantalla;lector;gran;alt;ample;text;tipus "
-"de "
-"lletra;mida;AccessX;adhesiu;tecles;lent;rebot;ratolí;doble;clic;retard;velocitat;assistència;repetició;parpelleig;visual;audició;àudio;escriptura;animacions;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dia"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dies"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dies"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dies"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dies"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dies"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dies"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dies"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
-#. Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dies"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Voleu buidar la paperera?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Se suprimiran permanent tots els elements de la paperera."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Buida la paperera"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Voleu suprimir tots fitxers temporals?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Se suprimiran permanent tots els fitxers temporals."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Suprimeix els fitxers _temporals"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dia"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dies"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dies"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Per sempre"
+"Teclat;ratolí;a11y;accessibilitat;accés universal;contrast;cursor;so;zoom;"
+"pantalla;lector;gran;alt;ample;text;tipus de lletra;mida;AccessX;adhesiu;"
+"tecles;lent;rebot;ratolí;doble;clic;retard;velocitat;assistència;repetició;"
+"parpelleig;visual;audició;àudio;escriptura;animacions;"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7827,8 +4284,8 @@ msgstr "Historial dels fitxers"
 
 #: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"File history keeps a record of files that you have used. This information is"
-" shared between applications, and makes it easier to find files that you "
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
 "might want to use."
 msgstr ""
 "L'historial dels fitxers manté un registre dels fitxers que heu utilitzat. "
@@ -7888,64 +4345,12 @@ msgstr "Historial dels fitxers i paperera"
 msgid "Don't leave traces"
 msgstr "No deixis rastres"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"ús;recent;història;fitxers;temporal;tmp;privat;privacitat;brossa;neteja;mantén;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Ha de coincidir amb l'adreça web del proveïdor del compte."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "No s'ha pogut afegir el compte"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Les contrasenyes no coincideixen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "No s'ha pogut registrar el compte"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "No hi ha cap manera compatible per a autenticar-se amb aquest domini"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "No s'ha pogut unir al domini"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"El nom d'usuari no és correcte.\n"
-"Torneu-ho a provar."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"La contrasenya no és vàlida.\n"
-"Torneu-ho a provar."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "No s'ha pogut entrar al domini"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "No s'ha trobat el domini. Potser l'heu escrit malament?"
+"ús;recent;història;fitxers;temporal;tmp;privat;privacitat;brossa;neteja;"
+"mantén;"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7999,10 +4404,6 @@ msgstr ""
 "centralitzats en aquest dispositiu. També podeu usar aquest compte per a "
 "accedir als recursos de l'empresa a Internet."
 
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Navega per més imatges"
-
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "Selecciona un fitxer..."
@@ -8035,8 +4436,7 @@ msgstr ""
 msgid "No fingerprint device"
 msgstr "No hi ha cap dispositiu d'empremtes"
 
-#. Translators: This is the empty state page label which states that there are
-#. no devices ready.
+#. Translators: This is the empty state page label which states that there are no devices ready.
 #: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "No hi ha cap dispositiu d'empremtes"
@@ -8062,8 +4462,8 @@ msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
 msgstr ""
-"L'inici de sessió amb empremta dactilar permet desbloquejar i iniciar sessió"
-" a l'ordinador amb el dit"
+"L'inici de sessió amb empremta dactilar permet desbloquejar i iniciar sessió "
+"a l'ordinador amb el dit"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
@@ -8073,222 +4473,6 @@ msgstr "_Suprimeix les empremtes dactilars"
 msgid "Fingerprint Enroll"
 msgstr "Afegeix empremta dactilar"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "s'ha de reclamar al dispositiu que realitzi aquesta acció"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "el dispositiu ja l'ha reclamat un altre procés"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "no teniu permís per a executar l'acció"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "no s'ha registrat cap empremta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "No s'ha pogut comunicar amb el dispositiu durant el registre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "No s'ha pogut comunicar amb el lector d'empremtes digitals"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "No s'ha pogut comunicar amb el dimoni d'empremtes digitals"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "No s'ha pogut llistar les empremtes: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "No s'ha pogut suprimir les empremtes desades: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Polze esquerre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Dit del mig esquerre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Dit índex _esquerre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Dit anular esquerre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Dit petit esquerre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Polze dret"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Dit del mig dret"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Dit índex d_ret"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Dit anular dret"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Dit petit dret"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Dit desconegut"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Completat"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "S'ha desconnectat el dispositiu d'empremtes"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "L'emmagatzematge del dispositiu d'empremtes està ple"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "No s'ha pogut afegir l'empremta nova"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "No s'ha pogut iniciar la detecció: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "No s'ha pogut afegir l'empremta nova"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "No s'ha pogut aturar la detecció: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Aixequeu i poseu el dit al lector per a inscriure la vostra empremta "
-"dactilar"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Torna a afegir aquest dit..."
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "S'estan escanejant les empremtes dactilars noves"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "S'ha produït un error en alliberar el dispositiu d'empremtes %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Hi ha un problema llegint el dispositiu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "S'ha produït un error en reclamar el dispositiu d'empremtes %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "S'ha produït un error en obtenir el dispositiu d'empremtes: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Aquesta setmana"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Setmana passada"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Ha acabat la sessió"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "S'ha iniciat la sessió"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s - Activitat del compte"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Anterior"
@@ -8296,18 +4480,6 @@ msgstr "Anterior"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Següent"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Trieu una altra contrasenya."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Escriviu un altre cop la vostra contrasenya actual."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "No s'ha pogut canviar la contrasenya"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8329,6 +4501,10 @@ msgstr "Contrasenya nova"
 msgid "Confirm Password"
 msgstr "Confirma la contrasenya"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Les contrasenyes no coincideixen."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Permet a l'usuari establir la contrasenya a l'entrada següent"
@@ -8336,135 +4512,6 @@ msgstr "Permet a l'usuari establir la contrasenya a l'entrada següent"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Estableix una contrasenya ara"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "No es pot unir automàticament a aquest tipus de domini"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "No s'ha trobat aquest domini o regne"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "No s'ha pogut entrar com a %s al domini %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "La contrasenya no vàlida, torneu-ho a provar"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "No s'ha pogut connectar al domini %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "No s'ha pogut suprimir l'usuari"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "No s'ha pogut revocar l'usuari gestionat remotament"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "No podeu suprimir el vostre compte."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s encara està connectat"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Si suprimiu un usuari mentre està connectat pot deixar el sistema "
-"inconsistent."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Voleu conservar els fitxers de %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Es pot conservar el directori de l'usuari, la cua de correu i els fitxers "
-"temporals quan suprimiu un compte d'usuari."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Suprimeix els fitxers"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "C_onserva els fitxers"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Segur que voleu revocar el compte %s de l'usuari gestionat remotament?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Suprimeix"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Compte inhabilitat"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "S'ha de configurar la pròxima vegada que entri"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Cap"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Connectat"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "No s'ha pogut contactar amb el servei de comptes"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Assegureu-vos que el servei de comptes està instal·lat i habilitat."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Aquest quadre s'ha de desbloquejar per a canviar aquesta configuració"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Suprimeix el compte d'usuari seleccionat"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Per a suprimir el compte d'usuari seleccionat,\n"
-"primer feu clic a la icona *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Desbloqueja per a afegir usuaris i modificar els paràmetres"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8492,7 +4539,6 @@ msgid "Full name"
 msgstr "Nom complet"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Edita"
 
@@ -8541,8 +4587,7 @@ msgstr "Altres usuaris"
 msgid "Add User…"
 msgstr "Afegeix usuari…"
 
-#. Translators: This is the empty state page label which states that there are
-#. no users to show in the panel.
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
 #: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "No s'ha trobat cap usuari"
@@ -8555,20 +4600,16 @@ msgstr "Desbloqueja per a afegir un compte d'usuari."
 msgid "Add or remove users and change your password"
 msgstr "Afegiu o suprimiu usuaris i canvieu la contrasenya"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
 "Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"Inici de sessió;Nom;Empremta "
-"dactilar;Avatar;Logotip;Cara;Contrasenya;Control parental; Temps de "
-"pantalla; Restriccions d'aplicacions;Restriccions web;Ús;Límit "
-"d'ús;Nen;Nena;Infant;"
+"Inici de sessió;Nom;Empremta dactilar;Avatar;Logotip;Cara;Contrasenya;"
+"Control parental; Temps de pantalla; Restriccions d'aplicacions;Restriccions "
+"web;Ús;Límit d'ús;Nen;Nena;Infant;"
 
-#. Translators: This button enrolls the computer in the domain in order to use
-#. enterprise logins.
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
 #: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Afegeix-lo"
@@ -8603,180 +4644,6 @@ msgstr "Gestiona els comptes d'usuari"
 msgid "Authentication is required to change user data"
 msgstr "Cal autenticació per a canviar les dades de l'usuari"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "La contrasenya nova ha de ser diferent de la vella."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Canvieu algunes lletres i números."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Canvieu la contrasenya una mica més."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Una contrasenya sense el vostre nom d'usuari seria més segura."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Eviteu l'ús del vostre nom a la contrasenya."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Eviteu algunes de les paraules incloses a la contrasenya."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Eviteu utilitzar paraules comunes."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Eviteu utilitzar paraules desordenades."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Utilitzeu més nombres."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Utilitzeu més lletres majúscules."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Utilitzeu més lletres minúscules."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Utilitzeu més caràcters especials, com ara signes de puntuació."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-"Intenteu utilitzar una combinació de lletres, nombres i signes de puntuació."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Eviteu repetir el mateix caràcter."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Eviteu repetir el mateix tipus de caràcter: combineu lletres, números i "
-"signes de puntuació."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Eviteu emprar seqüències com ara 1234 o abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Cal que la contrasenya sigui més gran. Intenteu utilitzar una combinació de "
-"lletres, nombres i signes de puntuació."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Combineu majúscules i minúscules i empreu un o dos nombres."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password "
-"stronger."
-msgstr ""
-"Si hi afegiu més lletres, nombres i signes de puntuació la contrasenya serà "
-"més segura."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Ha fallat l'autenticació"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "La contrasenya nova és massa curta"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "La contrasenya nova és massa senzilla"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "La contrasenya nova i l'anterior són massa semblants"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "La contrasenya nova ja s'ha utilitzat recentment."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "La contrasenya nova ha de contenir caràcters numèrics o especials"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "La contrasenya nova i l'anterior són iguals"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "La vostra contrasenya ha canviat des que us heu autenticat."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "La contrasenya nova no conté suficients caràcters diferents"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Error desconegut"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"El nom d'usuari normalment només conté lletres minúscules de la «a» a la "
-"«z», dígits i els caràcters: «-» i «_»"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "El nom d'usuari no està disponible. Trieu-ne un altre."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "El nom d'usuari és massa llarg."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8792,8 +4659,8 @@ msgid ""
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 "Per a editar una drecera, feu clic a l'acció «Envia una pulsació de tecla», "
-"premeu el botó de drecera de teclat i premeu la combinació de tecles nova, o"
-" premeu la tecla de retrocés per a netejar-la."
+"premeu el botó de drecera de teclat i premeu la combinació de tecles nova, o "
+"premeu la tecla de retrocés per a netejar-la."
 
 #: panels/wacom/button-mapping.ui:66
 msgid "_Close"
@@ -8811,53 +4678,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "S'ha detectat una pulsació incorrecta, s'està reiniciant..."
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Botó %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplicació definida"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Envia una pulsació de tecla"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Commuta el monitor"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Mostra l'ajuda en pantalla"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tauleta muntada en portàtil"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tauleta muntada en pantalla externa"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Tauleta externa"
-
-#. translators: this is a drawing tablet pad, i.e. a collection of buttons and
-#. knobs
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Tauleta externa"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Totes les pantalles"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8955,22 +4779,6 @@ msgstr "Clic del botó dret del ratolí"
 msgid "Forward"
 msgstr "Endavant"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Llapis d'aerògraf amb pressió, inclinació i control lliscant integrat"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Llapis d'aerògraf amb pressió, inclinació i rotació"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Estilogràfica estàndard amb pressió i inclinació"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Estilogràfica estàndard amb pressió"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tauleta Wacom"
@@ -8981,55 +4789,96 @@ msgstr ""
 "Establiu el mapa de botons i ajusteu la sensibilitat de l'estilogràfica per "
 "a tauletes gràfiques"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate
-#. or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tauleta gràfica;Wacom;Estilogràfica;Esborrador;Ratolí;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Drecera nova…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Clic secundari _simulat"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Programari del Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Tòner baix"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Retard del clic secundari"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Programari del Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Gestiona les preferències de productivitat i multitasca"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Punts d'accés"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Afegeix"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "De_sa"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operació cancel·lada"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Error:</b> accés denegat en canviar els paràmetres"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Error:</b> error de l'equipament mòbil"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Sense registrar"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registrat"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Itinerància"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "S'està cercant"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Denegat"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9059,212 +4908,13 @@ msgstr "Número propi"
 msgid "Device Details"
 msgstr "Detalls del dispositiu"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricant"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Versió del microprogramari"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Només 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Només 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Només 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Només 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (preferit), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (preferit), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (preferit), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (preferit), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (preferit), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (preferit), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (preferit), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (preferit), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (preferit), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (preferit), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (preferit), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (preferit), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (preferit), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (preferit), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (preferit), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (preferit), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (preferit)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (preferit), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Desconegut"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Desbloqueja la targeta SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Desbloqueja"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Proporcioneu el codi PIN per a la SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Introduïu el PIN per a desbloquejar la targeta SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Introduïu el codi PUK per a la SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Introdueix el PUK per a desbloquejar la targeta SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9279,26 +4929,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Us queden %u intent"
 msgstr[1] "Us queden %u intents"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "La contrasenya introduïda és incorrecta."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "El codi PUK ha de ser un número de 8 dígits"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Introduïu un PIN nou"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "El codi PIN ha de ser un número de 4-8 dígits"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "S'està desbloquejant…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9356,94 +4986,6 @@ msgstr "Bloqueja la SIM amb el PIN"
 msgid "M_odem Details"
 msgstr "_Detalls del mòdem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Error del telèfon"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "No hi ha connexió al telèfon"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operació no permesa"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operació no admesa"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "No s'ha inserit la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Cal el PIN de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Cal el PUK de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Error de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM ocupada"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Contrasenya incorrecta"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Cal el PIN2 de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Cal el PUK2 de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "No s'ha trobat"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Sense servei de xarxa"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Temps d'espera de la xarxa"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "No es permeten els serveis GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "No es permet la itinerància en aquesta àrea d'ubicació"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "S'ha produït un error GPRS no especificat"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Cap error"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Acció cancel·lada"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Accés denegat"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Error desconegut"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Mode de xarxa"
@@ -9459,11 +5001,6 @@ msgstr "Tria una xarxa"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Actualitza els proveïdors de xarxa"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9522,8 +5059,6 @@ msgstr "Xarxa mòbil"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configura les connexions de dades de telefonia i mòbils"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cel·lular;wwan;telefonia;sim;mòbil;"
@@ -9540,41 +5075,13 @@ msgstr "El Paràmetres és la interfície principal per a configurar el sistema.
 msgid "The GNOME Project"
 msgstr "El projecte GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Mostra el número de versió"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Habilita el mode detallat"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Cerca la cadena"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Llista tots els noms de quadre possibles i surt"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Quadre a mostrar"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[QUADRE] [ARGUMENT…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Categories de configuració"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacitat"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Quadres disponibles:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9595,8 +5102,8 @@ msgid ""
 "issues. "
 msgstr ""
 "Aquesta versió del Paràmetres només s'ha d'utilitzar amb finalitats de "
-"desenvolupament. Podeu exposar-vos a un comportament incorrecte del sistema,"
-" pèrdua de dades, i altres problemes inesperats. "
+"desenvolupament. Podeu exposar-vos a un comportament incorrecte del sistema, "
+"pèrdua de dades, i altres problemes inesperats. "
 
 #: shell/cc-window.ui:164
 msgid "Help"
@@ -9632,8 +5139,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Cancel·la la cerca"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferències;Configuració;"
@@ -9644,8 +5149,8 @@ msgstr "L'identificador de l'últim quadre de configuració a obrir"
 
 #: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
-"The identifier for the last Settings panel to be opened. Unrecognised values"
-" will be ignored and the first panel in the list selected."
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
 msgstr ""
 "L'identificador de l'últim quadre de configuració a obrir. S'ignoraran els "
 "valors que no siguin reconeguts i se seleccionarà el primer quadre de la "
@@ -9675,8 +5180,6 @@ msgstr ""
 "Una tupla que conté l'amplada inicial, l'alçada i l'estat maximitzat de la "
 "finestra de l'aplicació."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9684,8 +5187,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u sortida"
 msgstr[1] "%u sortides"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9693,6 +5194,3139 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u entrada"
 msgstr[1] "%u entrades"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sons del sistema"
+#~ msgid "System Bus"
+#~ msgstr "Bus del sistema"
+
+#~ msgid "Full access"
+#~ msgstr "Accés complet"
+
+#~ msgid "Session Bus"
+#~ msgstr "Sessió del bus"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Accés complet a /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Té accés a la xarxa"
+
+#~ msgid "Home"
+#~ msgstr "Inici"
+
+#~ msgid "Read-only"
+#~ msgstr "Només lectura"
+
+#~ msgid "File System"
+#~ msgstr "Sistema de fitxers"
+
+#~ msgid "Can change settings"
+#~ msgstr "Es poden canviar els paràmetres"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s té els següents permisos integrats. Aquests no poden ser alterats. Si "
+#~ "esteu preocupats per aquests permisos, considereu suprimir aquesta "
+#~ "aplicació."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u tipus de fitxer i d'enllaç que obre l'aplicació"
+#~ msgstr[1] "%u tipus de fitxers i d'enllaços que obre l'aplicació"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> s'utilitza per a obrir els següents tipus de fitxers i enllaços."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s d'espai de disc utilitzat."
+
+#~ msgid "Select a picture"
+#~ msgstr "Selecciona una imatge"
+
+#~ msgid "_Open"
+#~ msgstr "_Obre"
+
+#~ msgid "multiple sizes"
+#~ msgstr "mides múltiples"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Sense imatge de fons de l'escriptori"
+
+#~ msgid "Current background"
+#~ msgstr "Imatge de fons actual"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Col·loqueu el dispositiu de calibratge sobre el quadre i premeu «Inicia»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Moveu el dispositiu de calibratge a la posició de calibratge i premeu "
+#~ "«Continua»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Moveu el dispositiu de calibratge a la posició de la superfície i premeu "
+#~ "«Continua»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Tanca la tapa del portàtil"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "S'ha produït un error intern que no s'ha pogut recuperar."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Les eines que calen per al calibratge no estan instal·lades."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "No s'ha pogut generar el perfil."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "No s'ha pogut obtenir el punt blanc de l'objectiu."
+
+#~ msgid "Complete!"
+#~ msgstr "S'ha completat"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Ha fallat el calibratge"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Podeu treure el dispositiu de calibratge."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "No interrompeu el dispositiu de calibratge mentre treballi"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Pantalla del portàtil"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Càmera web integrada"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Escàner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Càmera %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Impressora %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Càmera web %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Habilita la gestió del color per a %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Mostra els perfils de color per a %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Sense calibrar"
+
+#~ msgid "Default: "
+#~ msgstr "Per defecte: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Espai de color: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Perfil de comprovació: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Selecciona un fitxer de perfil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importa"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Perfils ICC compatibles"
+
+#~ msgid "All files"
+#~ msgstr "Tots els fitxers"
+
+#~ msgid "Save Profile"
+#~ msgstr "Desa el perfil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Crea un perfil de color per al dispositiu seleccionat"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "No s'ha detectat l'instrument de mesura. Comproveu que estigui encès i "
+#~ "connectat correctament."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "L'instrument de mesura no admet el perfilat d'impressores."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "El tipus de dispositiu no és compatible actualment."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espai estàndard"
+
+#~ msgid "Test Profile"
+#~ msgstr "Perfil de comprovació"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automàtic"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Qualitat baixa"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Qualitat mitjana"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Qualitat alta"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB per defecte"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK per defecte"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Gris per defecte"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Dades de calibratge de fàbrica proporcionades pel venedor"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "Amb aquest perfil no es pot fer la correcció de la pantalla en mode "
+#~ "pantalla completa"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Aquest perfil potser ja no és precís"
+
+#~ msgid "Other…"
+#~ msgstr "Altres…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Desbloqueja per a canviar els paràmetres"
+
+#~ msgid "Today"
+#~ msgstr "Avui"
+
+#~ msgid "Yesterday"
+#~ msgstr "Ahir"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d hora"
+#~ msgstr[1] "%d hores"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minut"
+#~ msgstr[1] "%d minuts"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d segon"
+#~ msgstr[1] "%d segons"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Punt d'accés Wi-Fi"
+
+#~ msgid "24-hour"
+#~ msgstr "24 hores"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B de %Y a les %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B de %Y a les %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l∶%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%-H:%M"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Enviar informes de problemes tècnics ajuda a millorar %s. Els informes "
+#~ "s'envien anònimament i sense dades personals. %s"
+
+#~ msgid "On"
+#~ msgstr "Activat"
+
+#~ msgid "Off"
+#~ msgstr "Desactivat"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Voleu aplicar els canvis?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "No s'han aplicat els canvis"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Això pot ser degut a limitacions del maquinari."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Apaïsada"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Vertical dreta"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Vertical esquerra"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Apaïsada (capgirada)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "L'arrencada segura està activa"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "L'arrencada segura evita que el programari maliciós es carregui quan "
+#~ "s'iniciï el dispositiu. Actualment està activat i funciona correctament."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "L'arrencada segura té problemes"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "L'arrencada segura evita que el programari maliciós es carregui quan "
+#~ "s'iniciï el dispositiu. Actualment està activada, però no funcionarà ja "
+#~ "que té una clau no vàlida."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Els problemes amb l'arrencada segura sovint es poden resoldre des de la "
+#~ "configuració del microprogramari UEFI (BIOS) de l'ordinador i el "
+#~ "fabricant del maquinari pot proporcionar informació sobre com fer-ho."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Per a obtenir ajuda, contacteu amb el fabricant del maquinari o amb el  "
+#~ "suport tècnic."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "L'arrencada segura està desactivada"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "L'arrencada segura evita que el programari maliciós es carregui quan "
+#~ "s'iniciï el dispositiu. Actualment està desactivada."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "L'arrencada segura sovint es pot activar des de la configuració del "
+#~ "microprogramari UEFI del vostre ordinador (BIOS). Per a obtenir ajuda, "
+#~ "contacteu amb el fabricant del maquinari o amb el suport tècnic."
+
+#~ msgid "Passed"
+#~ msgstr "Correcte"
+
+#~ msgid "Failed"
+#~ msgstr "Ha fallat"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "El dispositiu s'ajusta al nivell %d HSI"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Nivell de seguretat 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Aquest dispositiu no té protecció contra problemes de seguretat del "
+#~ "maquinari. Això pot ser degut a un problema de configuració de maquinari "
+#~ "o microprogramari. Es recomana contactar amb el vostre suport tècnic."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Nivell de seguretat 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Aquest dispositiu té una protecció mínima contra problemes de seguretat "
+#~ "del maquinari. Aquest és el nivell de seguretat més baix del dispositiu i "
+#~ "només proporciona protecció contra amenaces de seguretat simples."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Nivell de seguretat 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Aquest dispositiu té protecció bàsica contra problemes de seguretat del "
+#~ "maquinari. Això proporciona protecció contra algunes amenaces de "
+#~ "seguretat comunes."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Nivell de seguretat 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Aquest dispositiu té protecció ampliada contra problemes de seguretat del "
+#~ "maquinari. Aquest és el nivell de seguretat de dispositiu més alt i "
+#~ "proporciona protecció contra amenaces de seguretat avançades."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr ""
+#~ "Els nivells de seguretat no estan disponibles per a aquest dispositiu."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Contacteu amb el fabricant del maquinari per a obtenir ajuda amb les "
+#~ "actualitzacions de seguretat."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "És possible aquest problema a la configuració del microprogramari UEFI "
+#~ "del dispositiu, o per un tècnic de suport."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "És possible resoldre aquest problema a la configuració del "
+#~ "microprogramari UEFI del dispositiu."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Seria possible que un tècnic de suport resolgués aquest problema."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Protegit contra programari maliciós quan s'inicia el dispositiu."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "L'arrencada segura té problemes"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Algunes proteccions quan s'inicia el dispositiu."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "L'arrencada segura està desactivada"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "No hi ha cap protecció quan s'inicia el dispositiu."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Aquest problema podria haver estat causat per un canvi en la configuració "
+#~ "del microprogramari UEFI, un canvi en la configuració del sistema "
+#~ "operatiu, o a causa d'un programari maliciós en aquest sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Aquest problema podria haver estat causat per un canvi en la configuració "
+#~ "del microprogramari UEFI, o a causa del programari maliciós en aquest "
+#~ "sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Aquest problema podria haver estat causat per un canvi de configuració "
+#~ "del sistema operatiu, o a causa d'un programari maliciós en aquest "
+#~ "sistema."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Exposat a amenaces de seguretat perilloses."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Protecció limitada contra amenaces de seguretat simples."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Protegit contra amenaces de seguretat comunes."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Protegit contra una àmplia gamma d'amenaces de seguretat."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Protecció completa"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Protecció d'escriptura del microprogramari"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Protecció de bloqueig d'escriptura del microprogramari"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Regió de BIOS de microprogramari"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Descriptor de BIOS de microprogramari"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Protecció DMA de prearrencada"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "BootGuard d'Intel"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Arrencada verificada d'Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Protegit amb Intel BootGuard ACM"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Política d'error d'Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard Fuse"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET habilitat"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET actiu"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "RAM xifrada"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Protecció IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Bloqueig del nucli de Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Verificació del nucli de Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Intercanvi del Linux"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Suspèn a RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Suspèn en espera"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Clau de la plataforma UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Arrencada segura UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Configuració de la plataforma TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Reconstrucció de TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Mode de fabricació del motor de gestió d'Intel"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Sobreescriptura del motor de gestió d'Intel"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Versió del motor de gestió d'Intel"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Actualitzacions del microprogramari"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Atestació del microprogramari"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Verificació de l'actualitzador de microprogramari"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Depuració de la plataforma"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Comprovacions de seguretat del processador"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Protecció contra la retroacció AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Protecció de reproducció de microprogramari AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Protecció d'escriptura de microprogramari AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Fused Platform"
+
+#~ msgid "Valid"
+#~ msgstr "Vàlid"
+
+#~ msgid "Not Valid"
+#~ msgstr "No vàlid"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Sense habilitar"
+
+#~ msgid "Locked"
+#~ msgstr "Bloquejat"
+
+#~ msgid "Not Locked"
+#~ msgstr "Bloquejat"
+
+#~ msgid "Encrypted"
+#~ msgstr "Xifrada"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Sense xifrar"
+
+#~ msgid "Tainted"
+#~ msgstr "Contaminat"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Sense contaminar"
+
+#~ msgid "Found"
+#~ msgstr "Trobat"
+
+#~ msgid "Not Found"
+#~ msgstr "No s'ha trobat"
+
+#~ msgid "Supported"
+#~ msgstr "Compatible"
+
+#~ msgid "Not Supported"
+#~ msgstr "No compatible"
+
+#~ msgid "Unknown"
+#~ msgstr "Desconegut"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Desconegut"
+
+#~ msgid "Not Available"
+#~ msgstr "No disponible"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo del sistema"
+
+#~ msgid "No input sources found"
+#~ msgstr "No s'han trobat fonts d'entrada"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Altres"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Dreceres personalitzades"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "La tecla de caràcters alternatius s'utilitza per a introduir caràcters "
+#~ "addicionals. Aquests alguns cops estan impresos com a tercera opció en el "
+#~ "teclat."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt esquerra"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt dreta"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Súper esquerra"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Súper dreta"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tecla de menú"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl dreta"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "La tecla de composició permet introduir una gran varietat de caràcters. "
+#~ "Per a utilitzar-la, premeu-la seguida d'una seqüència de caràcters.  Per "
+#~ "exemple, la tecla de composició seguida de <b>C</b> i <b>o</b> introduirà "
+#~ "<b>©</b>, i <b>a</b> seguida de <b>'</b> introduirà <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Bloq Maj"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Impr Pant"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Les fonts d'entrada es poden canviar utilitzant la drecera de teclat %s.\n"
+#~ "Això es pot canviar a la configuració de la drecera de teclat."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificada"
+#~ msgstr[1] "%d modificades"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Voleu restablir totes les dreceres?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Restablir les dreceres pot afectar les vostres dreceres personalitzades. "
+#~ "Aquesta acció no es pot desfer."
+
+#~ msgid "Reset All"
+#~ msgstr "Restableix-ho tot"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s ja s'utilitza per %s. Si la reemplaceu, %s s'inhabilitarà"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Introduïu la drecera nova"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Estableix la drecera personalitzada"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Estableix la drecera"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Introduïu una drecera nova per a canviar %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Afegeix drecera personalitzada"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Desplaçament amb dos dits"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinc clics, és l'hora del GEGL"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Doble clic, botó primari"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Un sol clic, botó primari"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Doble clic, botó del mig"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Un sol clic, botó del mig"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Doble clic, botó secundari"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Un sol clic, botó secundari"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Cal que el NetworkManager estigui executant-se."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Xarxa insegura (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Xarxa segura (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Xarxa segura (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Xarxa segura (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Xarxa segura"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "En activar el punt d'accés Wi-Fi es desconnectarà de %s, i no serà "
+#~ "possible accedir a Internet a través de Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Ha de tenir com a mínim 8 caràcters"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Voleu aturar el punt d'accés Wi-Fi i desconnectar els usuaris?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Atura el punt d'accés Wi-Fi"
+
+#~ msgid "Preserve"
+#~ msgstr "Conserva"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "A l'atzar"
+
+#~ msgid "Stable"
+#~ msgstr "Estable"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "L'adreça MAC introduïda aquí s'utilitzarà com adreça de maquinari per la "
+#~ "connexió per la qual s'activi aquest dispositiu. Aquesta funcionalitat es "
+#~ "coneix com a clonació o falsejament de MAC. Per exemple: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Perfil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Obertura millorada"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Corporativa"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Dèbil"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Acceptable"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bona"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excel·lent"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Oblida la connexió"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Suprimeix el perfil de connexió"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Suprimeix VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detalls"
+
+#~ msgid "automatic"
+#~ msgstr "automàtic"
+
+#~ msgid "Identity"
+#~ msgstr "Identitat"
+
+#~ msgid "Delete Address"
+#~ msgstr "Suprimeix l'adreça"
+
+#~ msgid "Delete Route"
+#~ msgstr "Suprimeix la ruta"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Clau WEP 40/128-bit (hexadecimal o ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Contrasenya WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinàmic (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA i WPA2 personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA i WPA2 corporativa"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "No s'ha pogut obrir l'editor de connexions"
+
+#~ msgid "New Profile"
+#~ msgstr "Perfil nou"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Configuració no vàlida %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Configuració no vàlida %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importa des d'un fitxer…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Afegeix VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "No es pot importar la connexió VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "No s'ha pogut llegir el fitxer «%s» o no conté informació reconeguda "
+#~ "d'una connexió VPN\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Seleccioneu el fitxer a importar"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Ja existeix un fitxer amb el nom «%s»."
+
+#~ msgid "_Replace"
+#~ msgstr "_Substitueix"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Voleu substituir %s amb la connexió VPN que esteu desant?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "No es pot exportar la connexió VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "No s'ha pogut exportar la connexió VPN «%s» a %s.\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exporta la connexió VPN"
+
+#~ msgid "never"
+#~ msgstr "mai"
+
+#~ msgid "today"
+#~ msgstr "avui"
+
+#~ msgid "yesterday"
+#~ msgstr "ahir"
+
+#~ msgid "Last used"
+#~ msgstr "Utilitzada per últim cop"
+
+#~ msgid "Add new connection"
+#~ msgstr "Afegeix una connexió nova"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Es perdran les dades de xarxa de les xarxes seleccionades, incloent-hi "
+#~ "les contrasenyes i la configuració personalitzada."
+
+#~ msgid "_Forget"
+#~ msgstr "_Oblida"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Xarxes sense fil conegudes"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Oblida"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr ""
+#~ "La política del sistema prohibeix utilitzar-lo com a punt d'accés Wi-Fi"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "El dispositiu sense fil no admet el mode punt d'accés Wi-Fi"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "El descobriment automàtic de servidors intermediaris web s'utilitza quan "
+#~ "no es proporciona un URL de configuració."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "No és recomanable en xarxes públiques sense confiança."
+
+#~ msgid "Status unknown"
+#~ msgstr "Estat desconegut"
+
+#~ msgid "Unmanaged"
+#~ msgstr "No gestionat"
+
+#~ msgid "Unavailable"
+#~ msgstr "No disponible"
+
+#~ msgid "Connecting"
+#~ msgstr "S'està connectant"
+
+#~ msgid "Authentication required"
+#~ msgstr "Cal autenticació"
+
+#~ msgid "Disconnecting"
+#~ msgstr "S'està desconnectant"
+
+#~ msgid "Connection failed"
+#~ msgstr "Ha fallat la connexió"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Estat desconegut (manca)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Ha fallat la configuració"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Ha fallat la configuració de la IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Ha caducat la configuració de la IP"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Calen secrets, però no s'han proporcionat"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "S'ha desconnectat el suplicant de 802.1x"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Ha fallat la configuració del suplicant de 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Ha fallat el suplicant de 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "El suplicant de 802.1x ha tardat massa en autenticar"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "No s'ha pogut iniciar el servei PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "S'ha desconnectat el servei PPP"
+
+#~ msgid "PPP failed"
+#~ msgstr "Ha fallat el PPP"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "No s'ha pogut iniciar el client DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "S'ha produït un error en el client DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Ha fallat el client DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "No s'ha pogut iniciar el servei de connexió compartida"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Ha fallat el servei de connexió compartida"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "No s'ha pogut iniciar el servei AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "S'ha produït un error en el servei AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Ha fallat el servei AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "Línia ocupada"
+
+#~ msgid "No dial tone"
+#~ msgstr "No hi ha to de trucada"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "No s'ha pogut establir cap portadora"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Ha acabat el temps d'espera de la sol·licitud de trucada"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Ha fallat l'intent de trucada"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Ha fallat la inicialització del mòdem"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "No s'ha pogut seleccionar l'APN especificat"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "No s'estan cercant xarxes"
+
+#~ msgid "Network registration denied"
+#~ msgstr "S'ha denegat el registre a la xarxa"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Ha acabat el temps d'espera del registre de la xarxa"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Ha fallat el registre amb la xarxa sol·licitada"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Ha fallat la comprovació del PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Pot ser que falti el microprograma del dispositiu"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Ha desaparegut la connexió"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "S'havia assumit una connexió existent"
+
+#~ msgid "Modem not found"
+#~ msgstr "No s'ha trobat el mòdem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Ha fallat la connexió Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "No s'ha inserit la targeta SIM"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Cal el PIN de la SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Cal el PUK de la SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM incorrecta"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Ha fallat la dependència de la connexió"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Falta el microprogramari"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cable desconnectat"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr ""
+#~ "s'ha produït un error no definit en la seguretat de 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "no s'ha seleccionat cap fitxer"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr ""
+#~ "s'ha produït un error no especificat en validar el fitxer eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Claus privades DER, PEM, PKCS#12 o PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certificats DER o PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "falta el fitxer EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Fitxers PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "falta el nom d'usuari EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "falta la contrasenya EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "certificat CA EAP-PEAP no vàlid: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-PEAP no vàlid: no s'ha especificat un certificat"
+
+#~ msgid "missing EAP username"
+#~ msgstr "falta el nom d'usuari EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "falta la contrasenya EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "falta la identitat EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TLS invàlid: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TLS invàlid: no s'ha especificat un certificat"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "clau privada EAP-TLS no vàlida: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificat d'usuari EAP-TLS no vàlid: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Les claus privades sense xifrar no són segures"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "La clau privada que heu seleccionat no sembla protegida amb una "
+#~ "contrasenya. Això podria permetre que les credencials de seguretat fossin "
+#~ "compromeses. Seleccioneu una clau privada protegida per contrasenya.\n"
+#~ "\n"
+#~ "(Podeu protegir la vostra clau privada amb una contrasenya amb l'openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Trieu el vostre certificat personal"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Trieu la vostra clau privada"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TTLS no vàlid: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TTLS no vàlid: no s'ha especificat un certificat"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "S'ha produït un error desconegut en validar la seguretat de 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Selecciona un fitxer"
+
+#~ msgid "missing leap-username"
+#~ msgstr "manca el mom d'usuari LEAP"
+
+#~ msgid "missing leap-password"
+#~ msgstr "manca la contrasenya LEAP"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Falta la contrasenya Wi-Fi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "manca la clau wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "clau wep invàlida: una clau amb longitud %zu ha de contenir només dígits "
+#~ "hexadecimals"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "clau wep invàlida: una clau amb longitud %zu ha de contenir només "
+#~ "caràcters ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "clau wep invàlida: la longitud de clau %zu és errònia. Una clau ha de "
+#~ "tenir una longitud de 5/13 (ascii) o bé 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "clau wep invàlida: la contrasenya no pot ser buida"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "clau wep invàlida: la contrasenya ha de tenir menys de 64 caràcters"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk no vàlid: longitud de clau %zu no vàlida. Ha de tenir [8,63] "
+#~ "bytes o 64 dígits hexadecimals"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk no vàlid: no es pot interpretar la clau de 64 bytes com a "
+#~ "hexadecimal"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Altres"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "s'ha suprimit %s"
+
+#~ msgid "Error removing account"
+#~ msgstr "S'ha produït un error en suprimir el compte"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Compte de %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Suprimeix el compte"
+
+#~ msgid "Unknown time"
+#~ msgstr "Temps desconegut"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s fins que es carregui del tot"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Atenció: queden %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Queden %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Totalment carregada"
+
+#~ msgid "Not charging"
+#~ msgstr "No s'està carregant"
+
+#~ msgid "Empty"
+#~ msgstr "Buida"
+
+#~ msgid "Charging"
+#~ msgstr "S'està carregant"
+
+#~ msgid "Discharging"
+#~ msgstr "S'està descarregant"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Ratolí sense fil"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Teclat sense fil"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Sistema d'alimentació ininterrompuda"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Auxiliar digital personal"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telèfon mòbil"
+
+#~ msgid "Media player"
+#~ msgstr "Reproductor multimèdia"
+
+#~ msgid "Tablet"
+#~ msgstr "Tauleta gràfica"
+
+#~ msgid "Computer"
+#~ msgstr "Ordinador"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Dispositiu d'entrada de joc"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principal"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Addicional"
+
+#~ msgid "Batteries"
+#~ msgstr "Bateries"
+
+#~ msgid "When _idle"
+#~ msgstr "Quan estigui _inactiu"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspèn"
+
+#~ msgid "Power Off"
+#~ msgstr "Apaga"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hiberna"
+
+#~ msgid "Nothing"
+#~ msgstr "Res"
+
+#~ msgid "When on battery power"
+#~ msgstr "Quan s'utilitzi la bateria"
+
+#~ msgid "When plugged in"
+#~ msgstr "Quan estigui endollat"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Suspèn automàticament"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "El mode de rendiment està temporalment inhabilitat a causa de l'alta "
+#~ "temperatura d'operació."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "S'ha detectat una volta: el mode de rendiment no està disponible "
+#~ "temporalment. Moveu el dispositiu a una superfície estable per a "
+#~ "restaurar-lo."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Mode de rendiment inhabilitat temporalment."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Bateria baixa: l'estalvi d'energia està habilitat. El mode anterior es "
+#~ "restaurarà quan la bateria estigui prou carregada."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Mode d'estalvi d'energia activat per «%s»."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Mode de rendiment activat per «%s»."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Rendiment"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Rendiment i ús d'energia alts."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Equilibrat"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Rendiment i ús d'energia estàndards."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Estalvi d'energia"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Rendiment i ús d'energia reduïts."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "S'ha suprimit la impressora «%s»"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "No s'ha pogut afegir una impressora nova."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "No s'ha pogut carregar la interfície d'usuari: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Desbloqueja per a afegir usuaris i modificar els paràmetres"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detalls %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "No s'ha trobat cap controlador adequat"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Selecció d'un fitxer PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Fitxers de descripció d'impressora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
+#~ "PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Impressora JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Impressora LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Una cara"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Cantó llarg (estàndard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Cantó curt (capgirat)"
+
+#~ msgid "Portrait"
+#~ msgstr "Vertical"
+
+#~ msgid "Landscape"
+#~ msgstr "Apaïsat"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Apaïsat del revés"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Vertical del revés"
+
+#~ msgid "Resume"
+#~ msgstr "Reprèn"
+
+#~ msgid "Pause"
+#~ msgstr "Pausat"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Pendent"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pausat"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Cal autenticació"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "S'està processant"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Aturada"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Cancel·lada"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Interrompuda"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Completada"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Mou aquest treball a la part superior de la cua"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - tasques actives"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Introduïu les credencials per a imprimir des de %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Desbloqueja el servidor d'impressió"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Desbloqueja %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Introduïu el nom d'usuari i la contrasenya per a visualitzar les "
+#~ "impressores a %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "S'estan cercant les impressores"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Port en sèrie"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Port paral·lel"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Ubicació: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adreça: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "El servidor requereix autenticació"
+
+#~ msgid "Two Sided"
+#~ msgstr "Doble cara"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tipus de paper"
+
+#~ msgid "Paper Source"
+#~ msgstr "Font del paper"
+
+#~ msgid "Output Tray"
+#~ msgstr "Safata de sortida"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolució"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Filtrat previ del GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Pàgines per cara"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientació"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "General"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Configuració de la pàgina"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opcions instal·lables"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Tasca"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Qualitat de la imatge"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Acabats"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avançat"
+
+#~ msgid "Test page"
+#~ msgstr "Pàgina de prova"
+
+#~ msgid "Auto Select"
+#~ msgstr "Selecció automàtica"
+
+#~ msgid "Printer Default"
+#~ msgstr "Per defecte de la impressora"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Incrusta només tipus de lletra del GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Converteix a PS nivell 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Converteix a PS nivell 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Sense filtrat previ"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Neteja els capçals d'impressió"
+
+#~ msgid "Out of toner"
+#~ msgstr "Sense tòner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Revelador baix"
+
+#~ msgid "Out of developer"
+#~ msgstr "Sense revelador"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Marcador baix"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Sense marcador"
+
+#~ msgid "Open cover"
+#~ msgstr "Tapa oberta"
+
+#~ msgid "Open door"
+#~ msgstr "Porta oberta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Té poc paper"
+
+#~ msgid "Out of paper"
+#~ msgstr "Sense paper"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Apagada"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Aturada"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "El receptacle de residus està quasi ple"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "El receptacle de residus està ple"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "El conductor òptic fotogràfic està al final de la seva vida"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "El conductor òptic fotogràfic ja no funciona"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "A punt"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "No accepta tasques"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "S'està processant"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Mètric"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Pregunta què fer"
+
+#~ msgid "Do nothing"
+#~ msgstr "No facis res"
+
+#~ msgid "Open folder"
+#~ msgstr "Obre la carpeta"
+
+#~ msgid "Other Media"
+#~ msgstr "Altres suports"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Seleccioneu l'aplicació per als CD d'àudio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Seleccioneu l'aplicació per als DVD de vídeo"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Seleccioneu l'aplicació que s'iniciarà quan es connecti un reproductor de "
+#~ "música"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Seleccioneu l'aplicació que s'iniciarà quan es connecti una càmera"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Seleccioneu l'aplicació per als CD de programari"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD d'àudio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Disc Blu-ray en blanc"
+
+#~ msgid "blank CD disc"
+#~ msgstr "Disc CD en blanc"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "Disc DVD en blanc"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Disc HD DVD en blanc"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disc Blu-ray de vídeo"
+
+#~ msgid "e-book reader"
+#~ msgstr "lector de llibres digitals"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disc HD DVD de vídeo"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD de fotos"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Supervídeo CD"
+
+#~ msgid "Video CD"
+#~ msgstr "CD de vídeo"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "S'apaga la pantalla"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 segons"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minut"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuts"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuts"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuts"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minuts"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minuts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minuts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minuts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minuts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minuts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#~ msgid "Select Location"
+#~ msgstr "Seleccioneu una ubicació"
+
+#~ msgid "_OK"
+#~ msgstr "_D'acord"
+
+#~ msgid "No applications found"
+#~ msgstr "No s'han trobat aplicacions"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "No hi ha cap xarxa seleccionada per a compartir"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Activat"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Desactivat"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Habilitat"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Actiu"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Trieu una carpeta"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Habilita la compartició de mitjans"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "La compartició de fitxers us permet compartir la carpeta pública amb "
+#~ "altres a la xarxa actual utilitzant: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Quan l'inici de sessió remot està habilitat, els usuaris remots poden "
+#~ "connectar-se utilitzant l'ordre del Secure Shell:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Habilita la compartició de mitjans personals"
+
+#~ msgid "Device name copied"
+#~ msgstr "S'ha copiat el nom del dispositiu"
+
+#~ msgid "Device address copied"
+#~ msgstr "S'ha copiat l'adreça del dispositiu"
+
+#~ msgid "Username copied"
+#~ msgstr "S'ha copiat el nom d'usuari"
+
+#~ msgid "Password copied"
+#~ msgstr "S'ha copiat la contrasenya"
+
+#~ msgid "Custom"
+#~ msgstr "Personalitzat"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Provant %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Desconnectat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "S'està connectant"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Connectat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "S'ha produït un error d'autorització"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "S'està autoritzant"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Funcionalitat reduïda"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Connectat i autoritzat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Desconegut"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autoritzat a les:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Connectat a les:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Inscrits a les:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "S'ha produït un error en autoritzar el dispositiu: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "S'ha produït un error en oblidar el dispositiu: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Error"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autoritzat"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "El subsistema Thunderbolt (boltd) no està instal·lat o configurat "
+#~ "correctament."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Només es poden adjuntar dispositius USB i pantalles."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "No s'ha pogut detectar Thunderbolt.\n"
+#~ "O bé el sistema no és compatible amb Thunderbolt, s'ha inhabilitat al "
+#~ "BIOS o està configurat amb un nivell de seguretat no compatible al BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "El suport per a aquesta funció està inhabilitat al BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "No s'ha pogut determinar el nivell de seguretat de Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "S'ha produït un error en canviar al mode directe: «%s»"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Per defecte"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Mitjà"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Gran"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Més gran"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "El més gran"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d píxel"
+#~ msgstr[1] "%d píxels"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Curta"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Llarga"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dia"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dies"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Voleu buidar la paperera?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Se suprimiran permanent tots els elements de la paperera."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Buida la paperera"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Voleu suprimir tots fitxers temporals?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Se suprimiran permanent tots els fitxers temporals."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Suprimeix els fitxers _temporals"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dia"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dies"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dies"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Per sempre"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Ha de coincidir amb l'adreça web del proveïdor del compte."
+
+#~ msgid "Failed to add account"
+#~ msgstr "No s'ha pogut afegir el compte"
+
+#~ msgid "Failed to register account"
+#~ msgstr "No s'ha pogut registrar el compte"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr ""
+#~ "No hi ha cap manera compatible per a autenticar-se amb aquest domini"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "No s'ha pogut unir al domini"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "El nom d'usuari no és correcte.\n"
+#~ "Torneu-ho a provar."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "La contrasenya no és vàlida.\n"
+#~ "Torneu-ho a provar."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "No s'ha pogut entrar al domini"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "No s'ha trobat el domini. Potser l'heu escrit malament?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Navega per més imatges"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "s'ha de reclamar al dispositiu que realitzi aquesta acció"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "el dispositiu ja l'ha reclamat un altre procés"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "no teniu permís per a executar l'acció"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "no s'ha registrat cap empremta"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "No s'ha pogut comunicar amb el dispositiu durant el registre"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "No s'ha pogut comunicar amb el lector d'empremtes digitals"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "No s'ha pogut comunicar amb el dimoni d'empremtes digitals"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "No s'ha pogut llistar les empremtes: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "No s'ha pogut suprimir les empremtes desades: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Polze esquerre"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Dit del mig esquerre"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Dit índex _esquerre"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Dit anular esquerre"
+
+#~ msgid "Left little finger"
+#~ msgstr "Dit petit esquerre"
+
+#~ msgid "Right thumb"
+#~ msgstr "Polze dret"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Dit del mig dret"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Dit índex d_ret"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Dit anular dret"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dit petit dret"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Dit desconegut"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Completat"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "S'ha desconnectat el dispositiu d'empremtes"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "L'emmagatzematge del dispositiu d'empremtes està ple"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "No s'ha pogut afegir l'empremta nova"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "No s'ha pogut iniciar la detecció: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "No s'ha pogut afegir l'empremta nova"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "No s'ha pogut aturar la detecció: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Aixequeu i poseu el dit al lector per a inscriure la vostra empremta "
+#~ "dactilar"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Torna a afegir aquest dit..."
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "S'estan escanejant les empremtes dactilars noves"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "S'ha produït un error en alliberar el dispositiu d'empremtes %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Hi ha un problema llegint el dispositiu"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "S'ha produït un error en reclamar el dispositiu d'empremtes %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "S'ha produït un error en obtenir el dispositiu d'empremtes: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Aquesta setmana"
+
+#~ msgid "Last Week"
+#~ msgstr "Setmana passada"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Ha acabat la sessió"
+
+#~ msgid "Session Started"
+#~ msgstr "S'ha iniciat la sessió"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s - Activitat del compte"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Trieu una altra contrasenya."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Escriviu un altre cop la vostra contrasenya actual."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "No s'ha pogut canviar la contrasenya"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "No es pot unir automàticament a aquest tipus de domini"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "No s'ha trobat aquest domini o regne"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "No s'ha pogut entrar com a %s al domini %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "La contrasenya no vàlida, torneu-ho a provar"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "No s'ha pogut connectar al domini %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "No s'ha pogut suprimir l'usuari"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "No s'ha pogut revocar l'usuari gestionat remotament"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "No podeu suprimir el vostre compte."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s encara està connectat"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Si suprimiu un usuari mentre està connectat pot deixar el sistema "
+#~ "inconsistent."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Voleu conservar els fitxers de %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Es pot conservar el directori de l'usuari, la cua de correu i els fitxers "
+#~ "temporals quan suprimiu un compte d'usuari."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Suprimeix els fitxers"
+
+#~ msgid "_Keep Files"
+#~ msgstr "C_onserva els fitxers"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Segur que voleu revocar el compte %s de l'usuari gestionat remotament?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Suprimeix"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Compte inhabilitat"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "S'ha de configurar la pròxima vegada que entri"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgid "Logged in"
+#~ msgstr "Connectat"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "No s'ha pogut contactar amb el servei de comptes"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Assegureu-vos que el servei de comptes està instal·lat i habilitat."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr ""
+#~ "Aquest quadre s'ha de desbloquejar per a canviar aquesta configuració"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Suprimeix el compte d'usuari seleccionat"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Per a suprimir el compte d'usuari seleccionat,\n"
+#~ "primer feu clic a la icona *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Desbloqueja per a afegir usuaris i modificar els paràmetres"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "La contrasenya nova ha de ser diferent de la vella."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Canvieu algunes lletres i números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Canvieu la contrasenya una mica més."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Una contrasenya sense el vostre nom d'usuari seria més segura."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Eviteu l'ús del vostre nom a la contrasenya."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Eviteu algunes de les paraules incloses a la contrasenya."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Eviteu utilitzar paraules comunes."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Eviteu utilitzar paraules desordenades."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Utilitzeu més nombres."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Utilitzeu més lletres majúscules."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Utilitzeu més lletres minúscules."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Utilitzeu més caràcters especials, com ara signes de puntuació."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Intenteu utilitzar una combinació de lletres, nombres i signes de "
+#~ "puntuació."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Eviteu repetir el mateix caràcter."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Eviteu repetir el mateix tipus de caràcter: combineu lletres, números i "
+#~ "signes de puntuació."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Eviteu emprar seqüències com ara 1234 o abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Cal que la contrasenya sigui més gran. Intenteu utilitzar una combinació "
+#~ "de lletres, nombres i signes de puntuació."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Combineu majúscules i minúscules i empreu un o dos nombres."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Si hi afegiu més lletres, nombres i signes de puntuació la contrasenya "
+#~ "serà més segura."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Ha fallat l'autenticació"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "La contrasenya nova és massa curta"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "La contrasenya nova és massa senzilla"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "La contrasenya nova i l'anterior són massa semblants"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "La contrasenya nova ja s'ha utilitzat recentment."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "La contrasenya nova ha de contenir caràcters numèrics o especials"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "La contrasenya nova i l'anterior són iguals"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "La vostra contrasenya ha canviat des que us heu autenticat."
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "La contrasenya nova no conté suficients caràcters diferents"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Error desconegut"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "El nom d'usuari normalment només conté lletres minúscules de la «a» a la "
+#~ "«z», dígits i els caràcters: «-» i «_»"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "El nom d'usuari no està disponible. Trieu-ne un altre."
+
+#~ msgid "The username is too long."
+#~ msgstr "El nom d'usuari és massa llarg."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Botó %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Aplicació definida"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Envia una pulsació de tecla"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Commuta el monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Mostra l'ajuda en pantalla"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tauleta muntada en portàtil"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tauleta muntada en pantalla externa"
+
+#~ msgid "External tablet device"
+#~ msgstr "Tauleta externa"
+
+#~ msgid "All Displays"
+#~ msgstr "Totes les pantalles"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Llapis d'aerògraf amb pressió, inclinació i control lliscant integrat"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Llapis d'aerògraf amb pressió, inclinació i rotació"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Estilogràfica estàndard amb pressió i inclinació"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Estilogràfica estàndard amb pressió"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Drecera nova…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operació cancel·lada"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Error:</b> accés denegat en canviar els paràmetres"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Error:</b> error de l'equipament mòbil"
+
+#~ msgid "Not Registered"
+#~ msgstr "Sense registrar"
+
+#~ msgid "Registered"
+#~ msgstr "Registrat"
+
+#~ msgid "Roaming"
+#~ msgstr "Itinerància"
+
+#~ msgid "Searching"
+#~ msgstr "S'està cercant"
+
+#~ msgid "Denied"
+#~ msgstr "Denegat"
+
+#~ msgid "2G Only"
+#~ msgstr "Només 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Només 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Només 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Només 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (preferit)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (preferit), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (preferit), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (preferit), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (preferit)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (preferit), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (preferit), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (preferit)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (preferit), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (preferit), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (preferit)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (preferit), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (preferit), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (preferit)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (preferit), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (preferit), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (preferit)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (preferit), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (preferit)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (preferit), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (preferit)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (preferit), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (preferit)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (preferit), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (preferit)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (preferit), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (preferit)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (preferit), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Desconegut"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Desbloqueja la targeta SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Proporcioneu el codi PIN per a la SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Introduïu el PIN per a desbloquejar la targeta SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Introduïu el codi PUK per a la SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Introdueix el PUK per a desbloquejar la targeta SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "La contrasenya introduïda és incorrecta."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "El codi PUK ha de ser un número de 8 dígits"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Introduïu un PIN nou"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "El codi PIN ha de ser un número de 4-8 dígits"
+
+#~ msgid "Unlocking…"
+#~ msgstr "S'està desbloquejant…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Error del telèfon"
+
+#~ msgid "No connection to phone"
+#~ msgstr "No hi ha connexió al telèfon"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operació no permesa"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operació no admesa"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "No s'ha inserit la SIM"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Cal el PIN de la SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Cal el PUK de la SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Error de la SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM ocupada"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Contrasenya incorrecta"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Cal el PIN2 de la SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Cal el PUK2 de la SIM"
+
+#~ msgid "Not found"
+#~ msgstr "No s'ha trobat"
+
+#~ msgid "No network service"
+#~ msgstr "Sense servei de xarxa"
+
+#~ msgid "Network timeout"
+#~ msgstr "Temps d'espera de la xarxa"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "No es permeten els serveis GPRS"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "No es permet la itinerància en aquesta àrea d'ubicació"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "S'ha produït un error GPRS no especificat"
+
+#~ msgid "No Error"
+#~ msgstr "Cap error"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Acció cancel·lada"
+
+#~ msgid "Access denied"
+#~ msgstr "Accés denegat"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Error desconegut"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Mostra el número de versió"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Habilita el mode detallat"
+
+#~ msgid "Search for the string"
+#~ msgstr "Cerca la cadena"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Llista tots els noms de quadre possibles i surt"
+
+#~ msgid "Panel to display"
+#~ msgstr "Quadre a mostrar"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[QUADRE] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Quadres disponibles:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sons del sistema"

--- a/po/ca.po~
+++ b/po/ca.po~
@@ -1,0 +1,9698 @@
+# Traducció del gnome-control-center de l'equip de Softcatalà.
+# Copyright © 1999-2009 Free Software Foundation, Inc.
+#
+# Ivan Vilata i Balaguer <ivan@selidor.net>, 1999, 2000.
+# Softcatalà <linux@softcatala.org>, 2000, 2001.
+# Jordi Mallach <jordi@sindominio.net>, 2002, 2003, 2004, 2005.
+# Xavier Conde Rueda <xavi.conde@gmail.com>, 2005.
+# Josep Puigdemont i Casamajó <josep.puigdemont@gmail.com>, 2005, 2006, 2007.
+# Joan Duran <jodufi@gmail.com>, 2008-2013.
+# Jordi Serratosa <jordis@softcatala.cat>, 2012, 2017.
+# Josep Sànchez <papapep@gmx.com>, 2013.
+# Jordi Mas i Hernàndez <jmas@softcatala.org>, 2015-2022
+# Gil Forcada <gilforcada@guifi.net>, 2013-2020.
+# Carles Ferrando Garcia <carles.ferrando@gmail.com>, 2018.
+#
+#
+# Terminologia utilitzada
+#
+#   Anglès           |  Català
+#   -----------------+---------------------------------
+#   disabled         | inhabilitat
+#   enabled          | habilitat
+#   hotspot          | punt d'accés Wi-Fi
+#   login            | inici de sessió
+#   log out          | tanca la sessió
+#   plugged In       | endollat (si es refereix al corrent)
+#   suspend          | suspèn
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issues\n"
+"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"PO-Revision-Date: 2022-10-09 09:28+0100\n"
+"Last-Translator: Jordi Mas i Hernàndez <jmas@softcatala.org>\n"
+"Language-Team: Catalan <tradgnome@softcatala.org>\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Bus del sistema"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Accés complet"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Sessió del bus"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositius"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Accés complet a /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Xarxa"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Té accés a la xarxa"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Inici"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Només lectura"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Sistema de fitxers"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Paràmetres"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Es poden canviar els paràmetres"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s té els següents permisos integrats. Aquests no poden ser alterats. Si "
+"esteu preocupats per aquests permisos, considereu suprimir aquesta "
+"aplicació."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u tipus de fitxer i d'enllaç que obre l'aplicació"
+msgstr[1] "%u tipus de fitxers i d'enllaços que obre l'aplicació"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> s'utilitza per a obrir els següents tipus de fitxers i enllaços."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s d'espai de disc utilitzat."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicacions"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Sense aplicacions"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Instal·la alguns..."
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Obre"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Veure detalls"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Cerca"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Rebre cerques del sistema i enviar resultats."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367
+#: panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Inhabilitat"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificacions"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Mostra les notificacions del sistema."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Executa en segon pla"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Permet l'activitat quan es tanqui l'aplicació."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Captures de pantalla"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Pren fotos de la pantalla en qualsevol moment."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Canvia el fons de pantalla"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Canvia el fons de pantalla de l'escriptori."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sons"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reproduir sons."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Inhabilita les dreceres"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Bloqueja les dreceres de teclat estàndard."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Càmera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Fes fotos amb la càmera."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Micròfon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Enregistra àudio amb el micròfon."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Serveis d'ubicació"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Accedeix a les dades d'ubicació del dispositiu."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Permisos integrats"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Accés al sistema que requereix l'aplicació"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Fitxer &amp; Associacions d'enllaç"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Emmagatzematge"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "No s'ha trobat cap resultat"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Proveu amb una cerca diferent"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Fitxer i associacions d'enllaç"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Tipus de fitxer"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Tipus d'enllaç"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Reinicia"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "Espai en disc que aquesta aplicació ocupa amb dades i memòria cau."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplicació"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Dades"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Memòria cau"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Neteja la memòria cau…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Controla diversos permisos i paràmetres d'aplicació"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate
+#. or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplicació;flatpak;permís;paràmetre;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Selecciona una imatge"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancel·la"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Obre"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "mides múltiples"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Sense imatge de fons de l'escriptori"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Imatge de fons actual"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Estil"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Per defecte"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Fosc"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Fons"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Afegeix una imatge…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aparença"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Canvieu la imatge de fons o els colors de la interfície"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Fons;Fons de pantalla;Pantalla;Escriptori;Estil;Clar;Fosc;Aparença;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11
+#: panels/camera/cc-camera-panel.ui:8 panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Habilita"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "No s'ha trobat el Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Connecteu una motxilla per a usar Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Activeu-lo per a connectar dispositius i rebre transferències de fitxers."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "El mode d'avió està activat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "El Bluetooth està inhabilitat quan el mode d'avió està activat."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Desactiva el mode d'avió"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "El mode d'avió del maquinari està activat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Desactiva el mode d'avió per a habilitar el Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Activeu i desactiveu el Bluetooth i connecteu els dispositius"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "comparteix;compartició;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "La càmera està apagada"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Cap aplicació pot capturar fotografies o vídeo."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"L'ús de la càmera permet que les aplicacions capturin fotos i vídeos. La desactivació de la càmera pot provocar que algunes aplicacions no funcionin correctament.\n"
+"\n"
+"Permet que les aplicacions següents utilitzin la càmera."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Cap aplicació ha demanat accés a la càmera"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Protegiu les vostres imatges"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "càmera;fotografies;vídeo;cam;bloqueig;privat;privadesa;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Col·loqueu el dispositiu de calibratge sobre el quadre i premeu «Inicia»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Moveu el dispositiu de calibratge a la posició de calibratge i premeu "
+"«Continua»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Moveu el dispositiu de calibratge a la posició de la superfície i premeu "
+"«Continua»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Tanca la tapa del portàtil"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "S'ha produït un error intern que no s'ha pogut recuperar."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Les eines que calen per al calibratge no estan instal·lades."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "No s'ha pogut generar el perfil."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "No s'ha pogut obtenir el punt blanc de l'objectiu."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "S'ha completat"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Ha fallat el calibratge"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Podeu treure el dispositiu de calibratge."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "No interrompeu el dispositiu de calibratge mentre treballi"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Calibratge de la pantalla"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Inicia"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Continua"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Fet"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Pantalla del portàtil"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Càmera web integrada"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Escàner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Càmera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Impressora %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Càmera web %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Habilita la gestió del color per a %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Mostra els perfils de color per a %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Sense calibrar"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Per defecte: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Espai de color: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Perfil de comprovació: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Selecciona un fitxer de perfil ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importa"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Perfils ICC compatibles"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Tots els fitxers"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantalla"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Desa el perfil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "De_sa"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Crea un perfil de color per al dispositiu seleccionat"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"No s'ha detectat l'instrument de mesura. Comproveu que estigui encès i "
+"connectat correctament."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "L'instrument de mesura no admet el perfilat d'impressores."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "El tipus de dispositiu no és compatible actualment."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Calibratge de la pantalla"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Qualitat del calibratge"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"El calibratge produirà un perfil que podeu utilitzar en la gestió del color "
+"de la pantalla. Com més temps passeu en el calibratge, més bona serà la "
+"qualitat del perfil de color."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "No podreu utilitzar l'ordinador mentre es faci el calibratge."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Qualitat"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Temps aproximat"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Dispositiu de calibratge"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Seleccioneu el sensor que voleu utilitzar per al calibratge."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tipus de pantalla"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Seleccioneu el tipus de pantalla que està connectat."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Punt blanc del perfil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a"
+" D65 illuminant."
+msgstr ""
+"Seleccioneu un punt blanc objectiu de la pantalla. La majoria de pantalles "
+"s'haurien de calibrar amb una il·luminació D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Brillantor de la pantalla"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Establiu la brillantor de la pantalla que acostumeu a utilitzar. La gestió "
+"del color serà més precisa en aquest nivell de brillantor."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"També podeu utilitzar el nivell de brillantor utilitzat per un dels altres "
+"perfils d'aquest dispositiu."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nom del perfil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Podeu utilitzar un perfil de color en diferents ordinadors o fins i tot "
+"crear perfils per diferents condicions d'il·luminació."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nom del perfil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Resum"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "S'ha creat el perfil amb èxit"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copia el perfil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Requereix un suport al qual es pugui escriure"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Podeu trobar les instruccions de com utilitzar el perfil als sistemes <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> i <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Afegeix un perfil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"S'han detectat problemes. Aquest perfil no funcionarà correctament. <a "
+"href=\"\">Mostra els detalls.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importa un fitxer…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Afegeix"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Cada dispositiu necessita un perfil de color actualitzat per a poder "
+"gestionar el color."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Més informació"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Apreneu més sobre la gestió del color"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Estableix per a tots els usuaris"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Estableix aquest perfil per a tots els usuaris d'aquest ordinador"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Habilita"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Afegeix un perfil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibra…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibra el dispositiu"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Suprimeix el perfil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Mostra els detalls"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+"No s'ha pogut detectar cap dispositiu en el qual es pugui gestionar el color"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projector"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (retroil·luminació CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (retroil·luminació RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (retroil·luminació de LED blanc)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD de gamma àmplia (retroil·luminació CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD de gamma àmplia (retroil·luminació de LED RGB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alta"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minuts"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Mitjana"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minuts"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Baixa"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minuts"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Nadiu de la pantalla"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Impressions i publicacions)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografia i gràfics)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Espai estàndard"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Perfil de comprovació"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automàtic"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Qualitat baixa"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Qualitat mitjana"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Qualitat alta"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB per defecte"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK per defecte"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Gris per defecte"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Dades de calibratge de fàbrica proporcionades pel venedor"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+"Amb aquest perfil no es pot fer la correcció de la pantalla en mode pantalla"
+" completa"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Aquest perfil potser ja no és precís"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Color"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibreu el color dels dispositius, com ara pantalles, càmeres o impressores"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Perfil;Calibratge;Impressora;Pantalla;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Altres…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Seleccioneu un idioma"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Selecciona"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "No s'ha trobat cap idioma"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Més…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Desbloqueja per a canviar els paràmetres"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Alguns paràmetres s'han de desbloquejar abans de poder-los canviar."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Desbloqueja…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Incrementa una hora"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Incrementa un minut"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Hores"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Redueix una hora"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Redueix un minut"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Avui"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Ahir"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hora"
+msgstr[1] "%d hores"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minut"
+msgstr[1] "%d minuts"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d segon"
+msgstr[1] "%d segons"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 segons"
+
+#. translators: This is the default hotspot name, need to be less than
+#. 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Punt d'accés Wi-Fi"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 hores"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B de %Y a les %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B de %Y a les %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l∶%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%-H:%M"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data i hora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Any"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mes"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Gener"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Febrer"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Març"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Abril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maig"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juny"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juliol"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Agost"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Setembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Octubre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembre"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Desembre"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dia"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Fus horari"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Cerqueu una ciutat"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Data i hora automàtiques"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Requereix accés a Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Data i _hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "_Fus horari automàtic"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Requereix els serveis d'ubicació habilitats i accés a Internet"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Habilitat"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Fus h_orari"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Format d'hora"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Canvieu la data i l'hora, incloent-hi el fus horari"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate
+#. or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Rellotge;Fus horari;Ubicació;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Canvieu els paràmetres d'hora i data del sistema"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Per a canviar els paràmetres d'hora i data, us heu d'autentificar."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Correu"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "Ca_lendari"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Música"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Vídeo"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicacions per defecte"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configura les aplicacions per defecte"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT
+#. translate or localize the semicolons! The list MUST also end with a
+#. semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "per defecte; aplicació; preferida;multimèdia;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora',
+#. the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Enviar informes de problemes tècnics ajuda a millorar %s. Els informes "
+"s'envien anònimament i sense dades personals. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Informa de problemes"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Informa de problemes automàticament"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnòstics"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Informeu de problemes"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate
+#. or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnòstics;fallada;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Activat"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Desactivat"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Voleu aplicar els canvis?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "No s'han aplicat els canvis"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Això pot ser degut a limitacions del maquinari."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Aplica"
+
+#: panels/display/cc-display-panel.ui:78
+#: panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Enrere"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "S'ha inhabilitat la configuració de la pantalla"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Múltiples pantalles"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Unir-se"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Mirall"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Conté la barra superior i les Activitats"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Pantalla primària"
+
+#. This is the redshift functionality where we suppress blue light when the
+#. sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Llum nocturna"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Apaïsada"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Vertical dreta"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Vertical esquerra"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Apaïsada (capgirada)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientació"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolució"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Freqüència de refresc"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Ajusta per televisió"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Escala"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Llum nocturna no disponible"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Això podria ser degut al fet que un controlador gràfic s'està usant, o que "
+"l'escriptoris'utilitza remotament"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Inhabilitat temporalment fins demà"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Torna a iniciar el filtre"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"La llum nocturna fa que el color de pantalla sigui més càlid. Això us pot "
+"ajudar a prevenir la fatiga visual i la sensació de son."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Planificació"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Posta de sol a la sortida del sol"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Planificació manual"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Hores"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Des de"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hora"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minut"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "A"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura del color"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Pantalles"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Trieu com utilitzar els monitors i projectors connectats"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;color;sunset;sunrise;"
+msgstr ""
+"Quadre;Projector;xrandr;Pantalla;Resolució;Refresca;Monitor;Nit;Llum;Blau;color;posta"
+" de sol;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:109
+msgid "Secure Boot is Active"
+msgstr "L'arrencada segura està activa"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"L'arrencada segura evita que el programari maliciós es carregui quan "
+"s'iniciï el dispositiu. Actualment està activat i funciona correctament."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "L'arrencada segura té problemes"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"L'arrencada segura evita que el programari maliciós es carregui quan "
+"s'iniciï el dispositiu. Actualment està activada, però no funcionarà ja que "
+"té una clau no vàlida."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Els problemes amb l'arrencada segura sovint es poden resoldre des de la "
+"configuració del microprogramari UEFI (BIOS) de l'ordinador i el fabricant "
+"del maquinari pot proporcionar informació sobre com fer-ho."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Per a obtenir ajuda, contacteu amb el fabricant del maquinari o amb el  "
+"suport tècnic."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "L'arrencada segura està desactivada"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"L'arrencada segura evita que el programari maliciós es carregui quan "
+"s'iniciï el dispositiu. Actualment està desactivada."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"L'arrencada segura sovint es pot activar des de la configuració del "
+"microprogramari UEFI del vostre ordinador (BIOS). Per a obtenir ajuda, "
+"contacteu amb el fabricant del maquinari o amb el suport tècnic."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"L'arrencada segura evita que el programari maliciós es carregui quan s'iniciï el dispositiu.\n"
+"\n"
+"Per a més informació, contacteu amb el fabricant de maquinari o el suport tècnic."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Correcte"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Ha fallat"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the
+#. computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "El dispositiu s'ajusta al nivell %d HSI"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:482
+msgid "Security Level 0"
+msgstr "Nivell de seguretat 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Aquest dispositiu no té protecció contra problemes de seguretat del "
+"maquinari. Això pot ser degut a un problema de configuració de maquinari o "
+"microprogramari. Es recomana contactar amb el vostre suport tècnic."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:489
+msgid "Security Level 1"
+msgstr "Nivell de seguretat 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is"
+" the lowest device security level and only provides protection against "
+"simple security threats."
+msgstr ""
+"Aquest dispositiu té una protecció mínima contra problemes de seguretat del "
+"maquinari. Aquest és el nivell de seguretat més baix del dispositiu i només "
+"proporciona protecció contra amenaces de seguretat simples."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:496
+msgid "Security Level 2"
+msgstr "Nivell de seguretat 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Aquest dispositiu té protecció bàsica contra problemes de seguretat del "
+"maquinari. Això proporciona protecció contra algunes amenaces de seguretat "
+"comunes."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:503
+msgid "Security Level 3"
+msgstr "Nivell de seguretat 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Aquest dispositiu té protecció ampliada contra problemes de seguretat del "
+"maquinari. Aquest és el nivell de seguretat de dispositiu més alt i "
+"proporciona protecció contra amenaces de seguretat avançades."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:518
+msgid "Security Level"
+msgstr "Nivell de seguretat"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:519
+msgid "Security levels are not available for this device."
+msgstr ""
+"Els nivells de seguretat no estan disponibles per a aquest dispositiu."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Contacteu amb el fabricant del maquinari per a obtenir ajuda amb les "
+"actualitzacions de seguretat."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"És possible aquest problema a la configuració del microprogramari UEFI del "
+"dispositiu, o per un tècnic de suport."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"És possible resoldre aquest problema a la configuració del microprogramari "
+"UEFI del dispositiu."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Seria possible que un tècnic de suport resolgués aquest problema."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nivell 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nivell 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nivell 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:110
+msgid "Protected against malicious software when the device starts."
+msgstr "Protegit contra programari maliciós quan s'inicia el dispositiu."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:116
+msgid "Secure Boot has Problems"
+msgstr "L'arrencada segura té problemes"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:117
+msgid "Some protection when the device is started."
+msgstr "Algunes proteccions quan s'inicia el dispositiu."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:122
+msgid "Secure Boot is Off"
+msgstr "L'arrencada segura està desactivada"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:123
+msgid "No protection when the device is started."
+msgstr "No hi ha cap protecció quan s'inicia el dispositiu."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:142
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Aquest problema podria haver estat causat per un canvi en la configuració "
+"del microprogramari UEFI, un canvi en la configuració del sistema operatiu, "
+"o a causa d'un programari maliciós en aquest sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:150
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings,"
+" or because of malicious software on this system."
+msgstr ""
+"Aquest problema podria haver estat causat per un canvi en la configuració "
+"del microprogramari UEFI, o a causa del programari maliciós en aquest "
+"sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:157
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Aquest problema podria haver estat causat per un canvi de configuració del "
+"sistema operatiu, o a causa d'un programari maliciós en aquest sistema."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:483
+msgid "Exposed to serious security threats."
+msgstr "Exposat a amenaces de seguretat perilloses."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:490
+msgid "Limited protection against simple security threats."
+msgstr "Protecció limitada contra amenaces de seguretat simples."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:497
+msgid "Protected against common security threats."
+msgstr "Protegit contra amenaces de seguretat comunes."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:504
+#: panels/firmware-security/cc-firmware-security-panel.c:512
+msgid "Protected against a wide range of security threats."
+msgstr "Protegit contra una àmplia gamma d'amenaces de seguretat."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:511
+msgid "Comprehensive Protection"
+msgstr "Protecció completa"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Sense esdeveniments"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Protecció d'escriptura del microprogramari"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Protecció de bloqueig d'escriptura del microprogramari"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Regió de BIOS de microprogramari"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Descriptor de BIOS de microprogramari"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Protecció DMA de prearrencada"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "BootGuard d'Intel"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Arrencada verificada d'Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Protegit amb Intel BootGuard ACM"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Política d'error d'Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard Fuse"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET habilitat"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET actiu"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "RAM xifrada"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Protecció IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Bloqueig del nucli de Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Verificació del nucli de Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Intercanvi del Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Suspèn a RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Suspèn en espera"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Clau de la plataforma UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Arrencada segura UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be
+#. empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Configuració de la plataforma TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Reconstrucció de TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Mode de fabricació del motor de gestió d'Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is
+#. enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on
+#. consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Sobreescriptura del motor de gestió d'Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Versió del motor de gestió d'Intel"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Actualitzacions del microprogramari"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Atestació del microprogramari"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Verificació de l'actualitzador de microprogramari"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Depuració de la plataforma"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Comprovacions de seguretat del processador"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Protecció contra la retroacció AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Protecció de reproducció de microprogramari AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Protecció d'escriptura de microprogramari AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Fused Platform"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid
+#. and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Vàlid"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "No vàlid"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Sense habilitar"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from
+#. malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Bloquejat"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Bloquejat"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Xifrada"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Sense xifrar"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Contaminat"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Sense contaminar"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Trobat"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "No s'ha trobat"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Compatible"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "No compatible"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Seguretat del dispositiu"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Estat de seguretat del microprogramari de l'amfitrió"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;privacy;"
+msgstr ""
+"pantalla;bloca;diagnòstics;fallades;privat;recent;temporal;tmp;índex;nom;xarxa;identitat;privadesa;privacitat;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Desconegut"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Desconegut"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "No disponible"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo del sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nom del dispositiu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Model de maquinari"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memòria"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processador"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Targeta gràfica"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacitat del disc"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "S'està calculant…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nom del SO"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID del muntatge del SO: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tipus del SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Versió del GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "S'està carregant…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Sistema de finestres"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualització"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Actualitzacions de programari"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Canvia el nom del dispositiu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"El nom del dispositiu s'utilitza per a identificar aquest dispositiu quan es"
+" visualitza en xarxa, o quan s'emparella amb dispositius Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nom del dispositiu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Canvia el nom"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Quant a"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Visualitzeu informació sobre el sistema"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositiu;sistema;informació;amfitrió;memòria;processador;versió;per "
+"defecte;aplicació;preferit;cd;dvd;usb;àudio;vídeo;disc;extraïble;multimèdia;execució"
+" automàtica;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "So i multimèdia"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Silencia o no el volum"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Abaixa el volum"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Apuja el volum"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Silencia o no el micròfon"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Inicia el reproductor multimèdia"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Reprodueix (o reprodueix/fes una pausa)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Fes una pausa a la reproducció"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Atura la reproducció"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Salta a la peça anterior"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Salta a la peça següent"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Expulsa"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Escriptura"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Commuta a la font d'entrada següent"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Commuta a la font d'entrada anterior"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Llançadors"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Inicia el navegador d'ajuda"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Inicia la calculadora"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Inicia el client de correu"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Inicia el navegador web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Carpeta d'usuari"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Cerca"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Surt"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Bloqueja la pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accessibilitat"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Activa o desactiva l'ampliació"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Ampliació"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Reducció"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Activa o desactiva el lector de pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Activa o desactiva el teclat a la pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Augmenta la mida del text"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Redueix la mida del text"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Activa o desactiva el contrast alt"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "No s'han trobat fonts d'entrada"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Altres"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Afegeix una font d'entrada"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+"Els mètodes d'entrada no es poden utilitzar a la pantalla d'inici de sessió"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "No s'ha seleccionat cap font d'entrada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opcions"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Mou amunt"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Mou avall"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferències"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Visualitza la disposició del teclat"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Suprimeix"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Dreceres personalitzades"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de caràcters alternatius"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"La tecla de caràcters alternatius s'utilitza per a introduir caràcters "
+"addicionals. Aquests alguns cops estan impresos com a tercera opció en el "
+"teclat."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt esquerra"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt dreta"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Súper esquerra"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Súper dreta"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tecla de menú"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl dreta"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composició"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"La tecla de composició permet introduir una gran varietat de caràcters. Per "
+"a utilitzar-la, premeu-la seguida d'una seqüència de caràcters.  Per "
+"exemple, la tecla de composició seguida de <b>C</b> i <b>o</b> introduirà "
+"<b>©</b>, i <b>a</b> seguida de <b>'</b> introduirà <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Bloq Maj"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Bloq Despl"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Impr Pant"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Les fonts d'entrada es poden canviar utilitzant la drecera de teclat %s.\n"
+"Això es pot canviar a la configuració de la drecera de teclat."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Fonts d'entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Inclou disposicions de teclat i mètodes d'entrada."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Commutació de fonts d'entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Utilitza la _mateixa font a totes les finestres"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Commuta les fonts d'entrada de cada finestra _individualment"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Estrada de caràcters especials"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Mètodes per a introduir símbols i variants de lletres utilitzant el teclat."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Dreceres de teclat"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Visualitza i personalitza les dreceres"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificada"
+msgstr[1] "%d modificades"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Voleu restablir totes les dreceres?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Restablir les dreceres pot afectar les vostres dreceres personalitzades. "
+"Aquesta acció no es pot desfer."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Restableix-ho tot"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Restableix-ho tot..."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Restableix totes les dreceres als seus valors per omissió"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Secció"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Dreceres"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Afegeix una drecera"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Afegeix dreceres personalitzades"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Configureu dreceres personalitzades per a iniciar aplicacions, executar "
+"scripts i més."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Afegeix una drecera"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "No s'ha trobat la tecla de drecera"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid ""
+"%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s ja s'utilitza per %s. Si la reemplaceu, %s s'inhabilitarà"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Introduïu la drecera nova"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Estableix la drecera personalitzada"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Estableix la drecera"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Introduïu una drecera nova per a canviar %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Afegeix drecera personalitzada"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Suprimeix"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "R_eemplaça"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Estableix"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Premeu Esc o Retrocés per a inhabilitar la drecera de teclat."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nom"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Ordre"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Drecera"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Estableix la drecera..."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Cap"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Restableix la drecera al seu valor per omissió"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Teclat"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Canvieu les dreceres de teclat i establiu les vostres preferències "
+"d'escriptura, disposicions de teclat i fonts d'entrada"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Drecera;Espai de treball;Finestra;Canvia la "
+"mida;Amplia;Contrast;Entrada;Font;Bloqueig;Volum;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Serveis d'ubicació desactivats"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Cap aplicació pot obtenir informació sobre la ubicació."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Els serveis de localització permeten a les aplicacions conèixer la vostra ubicació. L'ús de Wi-Fi i banda ampla mòbil augmenta la precisió.\n"
+"\n"
+"Utilitza el servei d'ubicació de Mozilla: <a href='https://location.services.mozilla.com/privacy'>política de privadesa</a>\n"
+"\n"
+"Permeteu que les aplicacions següents determinin la vostra ubicació."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Cap aplicació ha demanat accés a la ubicació"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Protegiu la vostra informació d'ubicació"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "ubicació;gps;privat;privadesa;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "El micròfon està apagat"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "No s'han trobat aplicacions."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. Disabling the microphone may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"L'ús del micròfon permet a les aplicacions enregistrar i escoltar àudio. Inhabilitar el micròfon pot causar que algunes aplicacions no funcionin correctament.\n"
+"\n"
+"Permet que les aplicacions de sota utilitzin el micròfon."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Cap aplicació ha demanat accés al micròfon"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Protegiu les vostres converses"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "micròfon;enregistrament;aplicació;privadesa;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Comprova els paràmetres"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "General"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Botó primari"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Estableix l'ordre dels botons als ratolins i ratolins tàctils."
+
+# N.T.: Es refereix al botó
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Esquerre"
+
+# N.T.: Es refereix al botó
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Dret"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Ratolí"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Velocitat del ratolí"
+
+#. Translators: This switch reverses the scrolling direction for mices. The
+#. term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads.
+#. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Desplaçament natural"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "El desplaçament mou el contingut, no la vista."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Ratolí tàctil"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Velocitat del ratolí tàctil"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Fes un toc per a fer un clic"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Fes un toc per a fer un clic"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Desplaçament amb dos dits"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Desplaçament en la vora"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Proveu de fer clic, fer doble clic i desplaçar"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinc clics, és l'hora del GEGL"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Doble clic, botó primari"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Un sol clic, botó primari"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Doble clic, botó del mig"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Un sol clic, botó del mig"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Doble clic, botó secundari"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Un sol clic, botó secundari"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Ratolí i ratolí tàctil"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Canvieu la sensibilitat del ratolí i del ratolí tàctil i seleccioneu l'ús "
+"per dretans o esquerrans"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT
+#. translate or localize the semicolons! The list MUST also end with a
+#. semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Ratolí tàctil;Punter;Clic;Toc;Doble;Botó;Ratolí de bola;Desplaça;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Cantonada activa"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+"Toqueu la cantonada superior esquerra per a obrir la vista general "
+"d'Activitats."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Activa les vores de la pantalla"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Arrossegueu les finestres a les vores superior, esquerra i dreta de la "
+"pantalla per a redimensionar-les."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Espais de treball"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Espais de treball dinàmics"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Suprimeix automàticament els espais de treball buits."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Nombre fix d'espais de treball"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Especifiqueu un nombre d'espais de treball permanents."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Nombre d'espais de treball"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Múltiples monitors"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "_Només espais de treball en la pantalla primària"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "_Espais de treball en totes les pantalles"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Commutació d'aplicacions"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "_Inclou aplicacions de tots els espais de treball"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "I_nclou aplicacions només de l'espai de treball actual"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitasca"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Gestiona les preferències de productivitat i multitasca"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasca;Productivitat;Personalitza;Escriptori;Cantonada activa;Espais de "
+"treball"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"S'ha produït un error inesperat. Contacteu el vostre proveïdor de "
+"programari."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Cal que el NetworkManager estigui executant-se."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Altres dispositius"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Afegeix una connexió"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "No s'ha configurat"
+
+#. TRANSLATORS: This happens when the connection name does not contain the
+#. SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Xarxa insegura (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Xarxa segura (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Xarxa segura (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Xarxa segura (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Xarxa segura"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41
+#: panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Connectat"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22
+#: panels/network/network-ethernet.ui:56 panels/network/network-mobile.ui:329
+#: panels/network/network-proxy.ui:62 panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opcions…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"En activar el punt d'accés Wi-Fi es desconnectarà de %s, i no serà possible "
+"accedir a Internet a través de Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Ha de tenir com a mínim 8 caràcters"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Ha de tenir com a màxim %d caràcter"
+msgstr[1] "Ha de tenir com a màxim %d caràcters"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Cal activar el punt d'accés Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a"
+" Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"El punt d'accés Wi-Fi permet compatir la vostra connexió a Internet amb "
+"altres creant una xarxa amb la qual es poden connectar. Per a fer això, heu "
+"de tenir una connexió a Internet per un mitjà que no sigui la Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nom de la xarxa"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Contrasenya"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Genera una contrasenya aleatòria"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Genera una contrasenya automàticament"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Activa"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Voleu aturar el punt d'accés Wi-Fi i desconnectar els usuaris?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Atura el punt d'accés Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Mode d'avió"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Inhabilita Wi-Fi, Bluetooth i banda ampla mòbil"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "No s'ha trobat cap adaptador Wi-fi"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Assegureu-vos que teniu un adaptador Wi-fi connectat i activat"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Mode d'avió activat"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Desactiveu-lo per a utilitzar la Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Punt d'accés Wi-Fi actiu"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Els dispositius mòbils poden escanejar el codi QR per a connectar-se."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Desactiva el punt d'accés Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Xarxes visibles"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Cal que el NetworkManager estigui executant-se"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Seguretat 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguretat"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Conserva"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "A l'atzar"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Estable"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC"
+" cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"L'adreça MAC introduïda aquí s'utilitzarà com adreça de maquinari per la "
+"connexió per la qual s'activi aquest dispositiu. Aquesta funcionalitat es "
+"coneix com a clonació o falsejament de MAC. Per exemple: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Perfil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Obertura millorada"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Corporativa"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Cap"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Mai"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "fa %i dia"
+msgstr[1] "fa %i dies"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Cap"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Dèbil"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Acceptable"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bona"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excel·lent"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Adreça IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adreça IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adreça IP"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Oblida la connexió"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Suprimeix el perfil de connexió"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Suprimeix VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Detalls"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automàtic"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitat"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Suprimeix l'adreça"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Suprimeix la ruta"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Cap"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Clau WEP 40/128-bit (hexadecimal o ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Contrasenya WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinàmic (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA i WPA2 personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA i WPA2 corporativa"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Força del senyal"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Velocitat de l'enllaç"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Adreça física"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Freqüències compatibles"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Ruta per defecte"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Utilitzada per últim cop"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Connecta _automàticament"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Fes-la disponible a _altres usuaris"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "Connexió li_mitada: té dades limitades o pot incórrer en càrrecs"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started "
+"automatically."
+msgstr ""
+"Les actualitzacions de programari i altres baixades grans no s'iniciaran "
+"automàticament."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nom"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Adreça _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Adreça _clonada"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "_Mètode IPv4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automàtic (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Només enllaç local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Inhabilita"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Compartit a altres ordinadors"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adreces"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adreça"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Màscara de xarxa"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Passarel·la"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automàtic"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automàtic"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Adreça(es) del servidor DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Separa les adreces IP amb comes"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rutes"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Rutes automàtiques"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Mètrica"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "_Utilitza aquesta connexió només per als recursos d'aquesta xarxa"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "_Mètode IPv6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automàtic, només DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefix"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "No s'ha pogut obrir l'editor de connexions"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Perfil nou"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Configuració no vàlida %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Configuració no vàlida %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importa des d'un fitxer…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Afegeix VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_eguretat"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "No es pot importar la connexió VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"No s'ha pogut llegir el fitxer «%s» o no conté informació reconeguda d'una connexió VPN\n"
+"\n"
+"Error: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Seleccioneu el fitxer a importar"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Ja existeix un fitxer amb el nom «%s»."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Substitueix"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Voleu substituir %s amb la connexió VPN que esteu desant?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "No es pot exportar la connexió VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"No s'ha pogut exportar la connexió VPN «%s» a %s.\n"
+"\n"
+"Error: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exporta la connexió VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Error: no s'ha pogut carregar l'editor de connexió VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Controleu com us connecteu a Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Xarxa;IP;LAN;Servidor intermediari;WAN;Banda ampla;Mòdem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controleu com us connecteu a les xarxes sense fil"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Xarxa;Sense fil;Wi-Fi;Wifi;IP;LAN;Servidor intermediari;WAN;Banda "
+"ampla;DNS;punt d'accés Wi-Fi;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "mai"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "avui"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "ahir"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Utilitzada per últim cop"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Amb fil"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Afegeix una connexió nova"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Es perdran les dades de xarxa de les xarxes seleccionades, incloent-hi les "
+"contrasenyes i la configuració personalitzada."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Oblida"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Xarxes sense fil conegudes"
+
+#. translators: This is the label for the "Forget wireless network"
+#. functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Oblida"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+"La política del sistema prohibeix utilitzar-lo com a punt d'accés Wi-Fi"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "El dispositiu sense fil no admet el mode punt d'accés Wi-Fi"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"El descobriment automàtic de servidors intermediaris web s'utilitza quan no "
+"es proporciona un URL de configuració."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "No és recomanable en xarxes públiques sense confiança."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Apaga el dispositiu"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Actiu"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Proveïdor"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Servidor intermediari de xarxa"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Servidor intermediari d'_HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "_Servidor intermediari d'HTTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Servidor intermediari d'_FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Servidor de sòcols"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignora els servidors"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Port del servidor intermediari d'HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Port del servidor intermediari d'HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Port del servidor intermediari d'FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Port del servidor intermediari de sòcols"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuració"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Desactiva la connexió VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nom de la xarxa"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tipus de seguretat"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Contrasenya"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Desactiva el Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Més opcions…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Connecta't a una xarxa oculta…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Activa el punt d'accés Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Xarxes sense fil conegudes"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Estat desconegut"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "No gestionat"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "No disponible"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "S'està connectant"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Cal autenticació"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "S'està desconnectant"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Ha fallat la connexió"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Estat desconegut (manca)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Ha fallat la configuració"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Ha fallat la configuració de la IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Ha caducat la configuració de la IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Calen secrets, però no s'han proporcionat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "S'ha desconnectat el suplicant de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Ha fallat la configuració del suplicant de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Ha fallat el suplicant de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "El suplicant de 802.1x ha tardat massa en autenticar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "No s'ha pogut iniciar el servei PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "S'ha desconnectat el servei PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Ha fallat el PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "No s'ha pogut iniciar el client DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "S'ha produït un error en el client DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Ha fallat el client DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "No s'ha pogut iniciar el servei de connexió compartida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Ha fallat el servei de connexió compartida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "No s'ha pogut iniciar el servei AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "S'ha produït un error en el servei AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Ha fallat el servei AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Línia ocupada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "No hi ha to de trucada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "No s'ha pogut establir cap portadora"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Ha acabat el temps d'espera de la sol·licitud de trucada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Ha fallat l'intent de trucada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Ha fallat la inicialització del mòdem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "No s'ha pogut seleccionar l'APN especificat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "No s'estan cercant xarxes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "S'ha denegat el registre a la xarxa"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Ha acabat el temps d'espera del registre de la xarxa"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Ha fallat el registre amb la xarxa sol·licitada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Ha fallat la comprovació del PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Pot ser que falti el microprograma del dispositiu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Ha desaparegut la connexió"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "S'havia assumit una connexió existent"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "No s'ha trobat el mòdem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Ha fallat la connexió Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "No s'ha inserit la targeta SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Cal el PIN de la SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Cal el PUK de la SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM incorrecta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Ha fallat la dependència de la connexió"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Falta el microprogramari"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Cable desconnectat"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "s'ha produït un error no definit en la seguretat de 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "no s'ha seleccionat cap fitxer"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "s'ha produït un error no especificat en validar el fitxer eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Claus privades DER, PEM, PKCS#12 o PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certificats DER o PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "falta el fitxer EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Fitxers PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anònim"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "S'ha autenticat"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ambdós"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identitat _anònima"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Fitxer PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Trieu un fitxer PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autenticació _interna"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "_Permet la provisió automàtica PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "falta el nom d'usuari EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "falta la contrasenya EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nom d'_usuari"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Contrasenya"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Mostra la contrasenya"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "certificat CA EAP-PEAP no vàlid: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "certificat CA EAP-PEAP no vàlid: no s'ha especificat un certificat"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versió 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versió 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificat C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Trieu un certificat d'una autoritat de certificació"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "_No es requereix un certificat CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Versió PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "falta el nom d'usuari EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "falta la contrasenya EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "falta la identitat EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "certificat CA EAP-TLS invàlid: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TLS invàlid: no s'ha especificat un certificat"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "clau privada EAP-TLS no vàlida: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificat d'usuari EAP-TLS no vàlid: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Les claus privades sense xifrar no són segures"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This could allow your security credentials to be compromised. Please select a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"La clau privada que heu seleccionat no sembla protegida amb una contrasenya. Això podria permetre que les credencials de seguretat fossin compromeses. Seleccioneu una clau privada protegida per contrasenya.\n"
+"\n"
+"(Podeu protegir la vostra clau privada amb una contrasenya amb l'openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Trieu el vostre certificat personal"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Trieu la vostra clau privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificat d'_usuari"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Clau privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Contrasenya de clau _privada"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "certificat CA EAP-TTLS no vàlid: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TTLS no vàlid: no s'ha especificat un certificat"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (sense EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domini"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "S'ha produït un error desconegut en validar la seguretat de 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS a través de túnel"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP protegit (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tenticació"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Selecciona un fitxer"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "manca el mom d'usuari LEAP"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "manca la contrasenya LEAP"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Falta la contrasenya Wi-Fi."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipus"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "manca la clau wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"clau wep invàlida: una clau amb longitud %zu ha de contenir només dígits "
+"hexadecimals"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"clau wep invàlida: una clau amb longitud %zu ha de contenir només caràcters "
+"ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"clau wep invàlida: la longitud de clau %zu és errònia. Una clau ha de tenir "
+"una longitud de 5/13 (ascii) o bé 10/26 (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "clau wep invàlida: la contrasenya no pot ser buida"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "clau wep invàlida: la contrasenya ha de tenir menys de 64 caràcters"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (per defecte)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistema obert"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Clau compartida"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Clau"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Mostra la clau"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Índe_x WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk no vàlid: longitud de clau %zu no vàlida. Ha de tenir [8,63] bytes o"
+" 64 dígits hexadecimals"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk no vàlid: no es pot interpretar la clau de 64 bytes com a "
+"hexadecimal"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificacions"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alertes sonores"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Notificacions emergents"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Les notificacions continuaran apareixent en la llista de notificacions "
+"encara que inhabiliteu les notificacions emergents."
+
+#. Popups here refers to message tray notifications in the middle of the
+#. screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "_Mostra el contingut de les notificacions emergents"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Notificacions a la pantalla de bloqueig"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "_Mostra el contingut dels missatges a la pantalla de bloqueig"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_No molesteu"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Notificacions a la pantalla de bloqueig"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controleu quines notificacions es mostren i què mostren"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate
+#. or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notificacions;Bàner;Missatge;Safata;Emergent;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Altres"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "s'ha suprimit %s"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "S'ha produït un error en suprimir el compte"
+
+#. Translators: This is the button which allows undoing the removal of the
+#. printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Desfés"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Tanca la notificació"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Connecteu-vos a les vostres dades al núvol"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"No hi ha connexió a Internet. Connecteu-vos per a configurar nous comptes en"
+" línia"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Afegeix un compte"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Compte de %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Suprimeix el compte"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Comptes en línia"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Connecteu-vos als comptes en línia i decidiu quin ús en voleu fer"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see
+#. http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;En "
+"línia;Xat;Calendari;Correu;Contacte;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Temps desconegut"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minut"
+msgstr[1] "%i minuts"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hora"
+msgstr[1] "%i hores"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hora"
+msgstr[1] "hores"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minuts"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s fins que es carregui del tot"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Atenció: queden %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Queden %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Totalment carregada"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "No s'està carregant"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Buida"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "S'està carregant"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "S'està descarregant"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Ratolí sense fil"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Teclat sense fil"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Sistema d'alimentació ininterrompuda"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Auxiliar digital personal"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Telèfon mòbil"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Reproductor multimèdia"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tauleta gràfica"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Ordinador"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Dispositiu d'entrada de joc"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bateria"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principal"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Addicional"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Bateries"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Quan estigui _inactiu"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Suspèn"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Apaga"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hiberna"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Res"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Quan s'utilitzi la bateria"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Quan estigui endollat"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Mai"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Suspèn automàticament"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"El mode de rendiment està temporalment inhabilitat a causa de l'alta "
+"temperatura d'operació."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a"
+" stable surface to restore."
+msgstr ""
+"S'ha detectat una volta: el mode de rendiment no està disponible "
+"temporalment. Moveu el dispositiu a una superfície estable per a restaurar-"
+"lo."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Mode de rendiment inhabilitat temporalment."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Bateria baixa: l'estalvi d'energia està habilitat. El mode anterior es "
+"restaurarà quan la bateria estigui prou carregada."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Mode d'estalvi d'energia activat per «%s»."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Mode de rendiment activat per «%s»."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minuts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minuts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minuts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minuts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minuts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minuts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minuts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minuts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 hores"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Mode d'energia"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Afecta el rendiment del sistema i a l'ús de l'energia."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opcions d'estalvi d'energia"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Brillantor de la pantalla automàtica"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "La brillantor de la pantalla s'ajusta a la llum de l'ambient."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Atenua la pantalla"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+"Redueix la brillantor de la pantalla quan l'ordinador estigui inactiu."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Pantalla en blanc"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Desactiva la pantalla després d'un període d'inactivitat."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Estalvi d'energia automàtic"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Activa el mode d'estalvi d'energia quan la bateria estigui baixa."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Suspèn automàticament"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Posa en pausa l'ordinador després d'un període d'inactivitat."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "_Comportament del botó d'engegada"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "_Mostra el percentatge de la bateria"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Suspèn automàticament"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Endollat"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Quan s'utilitza la _bateria"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Retard"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Rendiment"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Rendiment i ús d'energia alts."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Equilibrat"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Rendiment i ús d'energia estàndards."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Estalvi d'energia"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Rendiment i ús d'energia reduïts."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energia"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Visualitzeu l'estat de la bateria i canvieu els paràmetres d'estalvi "
+"d'energia"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;Energy;"
+msgstr ""
+"Energia;Baix consum;suspèn;Hibernació;Bateria;Brillantor;Atenuar;En "
+"blanc;Monitor;DPMS;Inactiu;Energia;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "S'ha suprimit la impressora «%s»"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "No s'ha pogut afegir una impressora nova."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "No s'ha pogut carregar la interfície d'usuari: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Desbloqueja per a afegir usuaris i modificar els paràmetres"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Impressores"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Afegiu impressores, visualitzeu tasques d'impressió i decidiu com voleu "
+"imprimir"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Impressora;Cua;Imprimir;Paper;Tinta;Tòner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Afegeix una impressora"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "Desbloq_ueja"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "No s'ha trobat cap impressora"
+
+#. Translators: The entered text should contain network address of a printer
+#. or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Introduïu una adreça de xarxa o cerqueu una impressora"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Cal autenticació"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Introduïu el nom d'usuari i la contrasenya per a visualitzar les impressores"
+" al servidor d'impressió."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nom d'usuari"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Detalls %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "No s'ha trobat cap controlador adequat"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Selecció d'un fitxer PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD.GZ)"
+msgstr ""
+"Fitxers de descripció d'impressora PostScript (*.ppd, *.PPD, *.ppd.gz, "
+"*.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+"Els noms de les impressores no poden contenir espai, tabulador, #, o /"
+
+#: panels/printers/pp-details-dialog.ui:89
+#: panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Ubicació"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Controlador"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "S'estan cercant els controladors preferits…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Cerca controladors"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Seleccioneu de la base de dades…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instal·la un fitxer PPD..."
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Seleccioneu un controlador d'impressora"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "S'està carregant la base de dades de controladors..."
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Selecciona"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Impressora JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Impressora LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Una cara"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Cantó llarg (estàndard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Cantó curt (capgirat)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Vertical"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Apaïsat"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Apaïsat del revés"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Vertical del revés"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Reprèn"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pausat"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Pendent"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pausat"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Cal autenticació"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "S'està processant"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Aturada"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Cancel·lada"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Interrompuda"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Completada"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Mou aquest treball a la part superior de la cua"
+
+#. Translators: This label shows how many jobs of this printer needs to be
+#. authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u tasca requereix autenticació"
+msgstr[1] "%u tasques requereixen autenticació"
+
+#. Translators: This is the printer name for which we are showing the active
+#. jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - tasques actives"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Introduïu les credencials per a imprimir des de %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domini"
+
+#. Translators: This button authenticates all print jobs and send them for
+#. printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utentica"
+
+#. Translators: this action removes (purges) all the listed jobs from the
+#. list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Neteja-ho tot"
+
+#. Translators: This button pop up authentication dialog for print jobs which
+#. need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autentica"
+
+#. Translators: this label describes the dialog empty state, with no jobs
+#. listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "No hi ha tasques d'impressió actives"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Desbloqueja el servidor d'impressió"
+
+#. Translators: Samba server needs authentication of the user to show list of
+#. its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Desbloqueja %s."
+
+#. Translators: Samba server needs authentication of the user to show list of
+#. its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Introduïu el nom d'usuari i la contrasenya per a visualitzar les impressores"
+" a %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "S'estan cercant les impressores"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Port en sèrie"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Port paral·lel"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Ubicació: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adreça: %s"
+
+#. Translators: This item is a server which needs authentication to show its
+#. printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "El servidor requereix autenticació"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Doble cara"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tipus de paper"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Font del paper"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Safata de sortida"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolució"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Filtrat previ del GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Pàgines per cara"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Doble cara"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientació"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "General"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page
+#. size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Configuració de la pàgina"
+
+#. Translators: "Installable Options" tab contains settings of presence of
+#. installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opcions instal·lables"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Tasca"
+
+#. Translators: "Image Quality" tab contains settings for quality of output
+#. print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Qualitat de la imatge"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Color"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet
+#. printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Acabats"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avançat"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Pàgina de prova"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Pàgina de prova"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Selecció automàtica"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Per defecte de la impressora"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Incrusta només tipus de lletra del GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Converteix a PS nivell 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Converteix a PS nivell 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Sense filtrat previ"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricant"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "No hi ha tasques actives"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u tasca"
+msgstr[1] "%u tasques"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Neteja els capçals d'impressió"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Tòner baix"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Sense tòner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Revelador baix"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Sense revelador"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Marcador baix"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Sense marcador"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Tapa oberta"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Porta oberta"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Té poc paper"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Sense paper"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Apagada"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Aturada"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "El receptacle de residus està quasi ple"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "El receptacle de residus està ple"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "El conductor òptic fotogràfic està al final de la seva vida"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "El conductor òptic fotogràfic ja no funciona"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "A punt"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "No accepta tasques"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "S'està processant"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Opcions d'impressió"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Detalls de la impressora"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Utilitza la impressora per defecte"
+
+#. Translators: This button executes command which cleans print heads of the
+#. printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Neteja els capçals d'impressió"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Suprimeix la impressora"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nivell de tinta"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Reinicieu quan el problema estigui resolt."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Torna a iniciar"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Afegeix una impressora…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Sense impressores"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Perdó! Sembla que el servei d'impressió\n"
+"del sistema no està disponible."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formats"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Cerca en configuracions locals…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Formats comuns"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Tots els formats"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "La cerca no ha retornat resultats"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Es pot cerca per països o idiomes."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Visualització prèvia"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Mètric"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Dates"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dates i hores"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Nombres"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mesura"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Paper"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "L'idioma i el format es canviaran després del proper inici de sessió"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Tanca la sessió…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"La configuració d'idioma s'utilitza per al text de la interfície i les "
+"pàgines web. Els formats s'utilitzen per a nombres, dates i monedes."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "El teu compte"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Idioma"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formats"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Pantalla d'inici de sessió"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Regió i idioma"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Seleccioneu l'idioma a mostrar i els formats"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT
+#. translate or localize the semicolons! The list MUST also end with a
+#. semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Idioma;Disposició;Teclat;Entrada;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Pregunta què fer"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "No facis res"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Obre la carpeta"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Altres suports"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Seleccioneu l'aplicació per als CD d'àudio"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Seleccioneu l'aplicació per als DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Seleccioneu l'aplicació que s'iniciarà quan es connecti un reproductor de "
+"música"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Seleccioneu l'aplicació que s'iniciarà quan es connecti una càmera"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Seleccioneu l'aplicació per als CD de programari"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD d'àudio"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Disc Blu-ray en blanc"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "Disc CD en blanc"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "Disc DVD en blanc"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "Disc HD DVD en blanc"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Disc Blu-ray de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "lector de llibres digitals"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Disc HD DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "CD de fotos"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Supervídeo CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "CD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Programari del Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Seleccioneu com s'han de gestionar els suports"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_CD d'àudio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Reproductor de _música"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Programari"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Altres suports…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_No preguntis mai ni iniciïs programes quan s'insereixin suports"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Seleccioneu com s'han de gestionar els altres suports"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Acció:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipus:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Suports extraïbles"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configura els paràmetres del suport extraïble"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT
+#. translate or localize the semicolons! The list MUST also end with a
+#. semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositiu;sistema;informació;per "
+"defecte;aplicació;preferit;cd;dvd;usb;àudio;vídeo;disc;extraïble;multimèdia;execució"
+" automàtica;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "S'apaga la pantalla"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 segons"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minut"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minuts"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minuts"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minuts"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minuts"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minuts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minuts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minuts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minuts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minuts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minuts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minuts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minuts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Mai"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Bloqueja la pantalla"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer"
+" while you're away."
+msgstr ""
+"Bloquejar la pantalla automàticament evita que altres puguin accedir a "
+"l'ordinador mentre no hi sou."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Retard per a posar la pantalla en blanc"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+"Període d'inactivitat després del qual la pantalla es posarà en blanc."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Bloqueja la pantalla automàticament"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Retard per a bloquejar la pantalla automàticament"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid ""
+"Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Període després del qual la pantalla es posa en blanc quan la pantalla es "
+"bloqueja automàticament."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Mostra les notificacions a la pantalla de bloqueig"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "_Prohibeix els dispositius USB nous"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Evita que els dispositius USB nous puguin interaccionar amb el sistema quan "
+"la pantalla estigui bloquejada."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Privacitat de la pantalla"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Restringeix l'angle de visualització"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Paràmetres de la pantalla"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "pantalla;bloqueja;privat;privadesa;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Seleccioneu una ubicació"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_D'acord"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Ubicacions de cerca"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and"
+" Videos."
+msgstr ""
+"Carpetes que se cerquen per les aplicacions del sistema, com Fitxers, Fotos "
+"i Vídeos."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Llocs"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Adreces d'interès"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Altres"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Afegeix una ubicació"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "No s'han trobat aplicacions"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Cerca d'aplicacions"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Inclou els resultats de la cerca proporcionats per l'aplicació."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Carpetes on cerquen les aplicacions del sistema."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Resultats de cerca"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Els resultats es mostren segons l'ordre de la llista."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controleu quines aplicacions mostren resultats de cerca a la vista general "
+"d'activitats"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Cerca;Troba;Índex;Oculta;Privacitat;Resultats;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "No hi ha cap xarxa seleccionada per a compartir"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Xarxes"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Activat"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Desactivat"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Habilitat"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Actiu"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Trieu una carpeta"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Afegeix"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Habilita la compartició de mitjans"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"La compartició de fitxers us permet compartir la carpeta pública amb altres "
+"a la xarxa actual utilitzant: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to
+#. run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure Shell command:\n"
+"%s"
+msgstr ""
+"Quan l'inici de sessió remot està habilitat, els usuaris remots poden connectar-se utilitzant l'ordre del Secure Shell:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Habilita la compartició de mitjans personals"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "S'ha copiat el nom del dispositiu"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "S'ha copiat l'adreça del dispositiu"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "S'ha copiat el nom d'usuari"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "S'ha copiat la contrasenya"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Compartició"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Nom de l'ordinador"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Compartició de fitxers"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_Escriptori remot"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Compartició de mitjans"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Inici de sessió remot"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Compartició de fitxers"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Demana contrasenya"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Inici de sessió remot"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Escriptori remot"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"L'escriptori remot permet veure i controlar l'escriptori des d'un altre "
+"ordinador."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Habilita o inhabilita les connexions d'escriptori remot en aquest ordinador."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Control remot"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Permet a les connexions remotes controlar la pantalla."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Com connectar-vos"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Connecta a aquest ordinador amb el nom del dispositiu o l'adreça "
+"d'escriptori remota."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copia"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Adreça remota de l'escriptori"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autenticació"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Es requereix el nom d'usuari i la contrasenya per a connectar-se a aquest "
+"ordinador."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nom d'usuari"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Verifica el xifrat"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Empremta digital de xifratge"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"L'empremta digital de xifratge es pot veure quan es connecten els clients i "
+"hauria de ser idèntica."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Compartició de mitjans"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Compartiu música, fotografies i vídeos a través de la xarxa."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Carpetes"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controleu què voleu compartir amb els altres"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;movies;server;renderer;"
+msgstr ""
+"comparteix;compartició;ssh;amfitrió;nom;remot;escriptori;multimèdia;àudio;vídeo;imatges;fotografies;pel·lícules;servidor;renderitzar;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Habilita o inhabilita l'inici de sessió remot"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Cal autenticació per a habilitar o inhabilitar l'inici de sessió remot"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Personalitzat"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Clic"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Cadena"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Swing"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Hum"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balanç"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Esvaeix"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Posterior"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Frontal"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Provant %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Feu clic a un altaveu per a provar-lo"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volum del sistema"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Volum general"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Nivells de volum"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Sortida"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Dispositiu de sortida"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Prova"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuració"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Altaveu de greus"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Entrada"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Dispositiu d'entrada"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volum"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "So d'alerta"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Silencia"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "So"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Canvieu els nivells de so, les entrades, les sortides i les alertes sonores"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Targeta;Micròfon;Volum;Esvair;Balanç;Bluetooth;Auriculars;Àudio;Sortida;Entrada;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Desconnectat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "S'està connectant"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Connectat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "S'ha produït un error d'autorització"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "S'està autoritzant"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Funcionalitat reduïda"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Connectat i autoritzat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Desconegut"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autoritzat a les:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Connectat a les:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Inscrits a les:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "S'ha produït un error en autoritzar el dispositiu: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "S'ha produït un error en oblidar el dispositiu: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Depèn d'un altre dispositiu"
+msgstr[1] "Depèn de %u altres dispositius"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Tanca la notificació"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nom:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Estat:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autoritza i connecta"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Oblida el dispositiu"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Error"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autoritzat"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"El subsistema Thunderbolt (boltd) no està instal·lat o configurat "
+"correctament."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Permet l'accés als dispositius com ara acobladors o CPU externs."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Només es poden adjuntar dispositius USB i pantalles."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"No s'ha pogut detectar Thunderbolt.\n"
+"O bé el sistema no és compatible amb Thunderbolt, s'ha inhabilitat al BIOS o està configurat amb un nivell de seguretat no compatible al BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "El suport per a aquesta funció està inhabilitat al BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "No s'ha pogut determinar el nivell de seguretat de Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "S'ha produït un error en canviar al mode directe: «%s»"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Sense compatibilitat Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "No s'ha pogut connectar al subsistema Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Accés directe"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Dispositius pendents"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "No hi ha cap dispositiu adjuntat"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Administra dispositius Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel.
+#. Do NOT translate or localize the semicolons! The list MUST also end with a
+#. semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privadesa;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Parpelleig del cursor"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "El cursor parpelleja en els camps de text."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocitat"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Velocitat del parpelleig del cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Mida del cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"La mida del cursor pot combinar-se amb l'ampliació perquè sigui més fàcil "
+"veure el cursor."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Assistència en fer clic"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Clic secundari _simulat"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Fes un clic secundari en mantenir premut el botó primari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Retard d'a_cceptació:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Retard del clic secundari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Clic en passar per sobre"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Fes un clic en passar el punter per sobre"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "R_etard:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Llindar de _moviment:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Petit"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Gran"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetició de tecles"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Es repeteix la tecla quan es manté premuda."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Retard en la repetició de tecles"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocitat de la repetició de tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Assistent d'escriptura"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Tecles _enganxoses"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Tracta una seqüència de tecles modificadores com una combinació de tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Inhabilita si es premen dues tecles alhora"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Fes un avís sonor quan es premi una tecla _modificadora"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Tecles _lentes"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introdueix un retard entre que es prem una tecla i s'accepta"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Retard d'escriptura de les tecles lentes"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Fes un avís sonor quan es _premi una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Fes un avís sonor quan s'_accepti una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Fes un avís sonor quan es _rebutgi una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Repetició de tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignora les pulsacions duplicades ràpides"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Retard d'escriptura en la repetició de tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Habilita per teclat"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Activa i desactiva les funcions d'accessibilitat utilitzant el teclat"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Per defecte"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Mitjà"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Gran"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Més gran"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "El més gran"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d píxel"
+msgstr[1] "%d píxels"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Mostra _sempre el menú d'accés universal"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Visió"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Contrast alt"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Text _gran"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "A_ctiva les animacions"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Lector de _pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"El lector de pantalla llegeix el text visualitzat mentre moveu el focus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_So de les tecles"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Fes un avís sonor quan s'activi o desactivi la fixació numèrica o de les "
+"majúscules."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Mida del _cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Ampliació"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audició"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Alertes _visuals"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Teclat en pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Repetició de tecles"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Parpelleig del cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Assistent d'escriptura (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Apuntar i fer clic"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Tecles del _ratolí"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Localitza el punter"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "A_ssistència en fer clic"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Retard del doble clic"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Retard del doble clic"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alertes visuals"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Prova el parpelleig"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Utilitza una indicació visual quan es produeixi una alerta sonora."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Fes parpellejar la _pantalla sencera"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Fes parpellejar la _finestra"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Curta"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ de pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ de pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ de pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Llarga"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Pantalla completa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Meitat superior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Meitat inferior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Meitat esquerra"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Meitat dreta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Opcions d'ampliació"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Ampliació:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posició de l'ampliador:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Segueix el cursor del ratolí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Part de la pantalla:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "L'_ampliador s'estén fora de la pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Mantén el cursor de l'ampliador centrat"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "_El cursor de l'ampliador empeny el contingut del voltant"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "El _cursor de l'ampliador es mou amb el contingut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Ampliador"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Creus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Sobreposa el cursor del ratolí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Gruix:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Prim"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Gruixut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Longitud:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Color:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Creus"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efectes de color:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Blanc sobre negre:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Brillantor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Colo_r"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Cap"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Tot"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Baixa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Baix"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efectes de color"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Feu més fàcil veure, sentir, teclejar, apuntar i fer clic"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate
+#. or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal "
+"Access;Contrast;Cursor;Sound;Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;animations;"
+msgstr ""
+"Teclat;ratolí;a11y;accessibilitat;accés "
+"universal;contrast;cursor;so;zoom;pantalla;lector;gran;alt;ample;text;tipus "
+"de "
+"lletra;mida;AccessX;adhesiu;tecles;lent;rebot;ratolí;doble;clic;retard;velocitat;assistència;repetició;parpelleig;visual;audició;àudio;escriptura;animacions;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dia"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary
+#. Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dies"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Voleu buidar la paperera?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Se suprimiran permanent tots els elements de la paperera."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Buida la paperera"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Voleu suprimir tots fitxers temporals?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Se suprimiran permanent tots els fitxers temporals."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Suprimeix els fitxers _temporals"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dia"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dies"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dies"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Per sempre"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Historial dels fitxers"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is"
+" shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"L'historial dels fitxers manté un registre dels fitxers que heu utilitzat. "
+"Aquesta informació es comparteix entre aplicacions i fa més senzill trobar "
+"els fitxers que voleu usar."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "_Historial dels fitxers"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "_Duració de l'historial dels fitxers"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Neteja l'historial…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Paperera i fitxers temporals"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"La paperera i els fitxers temporals poden alguns cops incloure informació "
+"personal o sensible. Suprimir-los automàticament pot ajudar a protegir la "
+"privadesa."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Buida automàticament el contingut de la _paperera"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Suprimeix automàticament els _fitxers temporals"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Període per a la supressió automàtica"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Buida la paperera..."
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Suprimeix els fitxers _temporals…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Historial dels fitxers i paperera"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "No deixis rastres"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"ús;recent;història;fitxers;temporal;tmp;privat;privacitat;brossa;neteja;mantén;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Ha de coincidir amb l'adreça web del proveïdor del compte."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "No s'ha pogut afegir el compte"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Les contrasenyes no coincideixen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "No s'ha pogut registrar el compte"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "No hi ha cap manera compatible per a autenticar-se amb aquest domini"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "No s'ha pogut unir al domini"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"El nom d'usuari no és correcte.\n"
+"Torneu-ho a provar."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"La contrasenya no és vàlida.\n"
+"Torneu-ho a provar."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "No s'ha pogut entrar al domini"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "No s'ha trobat el domini. Potser l'heu escrit malament?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Afegeix un usuari"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrador"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Els administradors poden afegir i eliminar altres usuaris, i poden canviar "
+"la configuració de tots els usuaris. Els controls parentals no es poden "
+"aplicar als administradors."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "L'usuari estableix la contrasenya al primer inici de sessió"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Estableix una contrasenya ara"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirma"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Inici de sessió corporatiu"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Comptes d'usuari gestionats per una empresa o organització."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Esteu fora de línia"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"L'inici de sessió corporatiu permet utilitzar comptes d'usuari corporatius "
+"centralitzats en aquest dispositiu. També podeu usar aquest compte per a "
+"accedir als recursos de l'empresa a Internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Navega per més imatges"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Selecciona un fitxer..."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Gestor de l'empremta dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Empremta dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_No"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Sí"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Voleu suprimir les empremtes dactilars registrades de manera que "
+"s'inhabiliti l'inici de sessió amb empremta dactilar?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "No hi ha cap dispositiu d'empremtes"
+
+#. Translators: This is the empty state page label which states that there are
+#. no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "No hi ha cap dispositiu d'empremtes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Assegureu-vos que el dispositiu està correctament connectat."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Dispositiu d'empremtes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Trieu el dispositiu d'empremtes que voleu configurar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Inici de sessió amb empremta dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"L'inici de sessió amb empremta dactilar permet desbloquejar i iniciar sessió"
+" a l'ordinador amb el dit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Suprimeix les empremtes dactilars"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Afegeix empremta dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "s'ha de reclamar al dispositiu que realitzi aquesta acció"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "el dispositiu ja l'ha reclamat un altre procés"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "no teniu permís per a executar l'acció"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "no s'ha registrat cap empremta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "No s'ha pogut comunicar amb el dispositiu durant el registre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "No s'ha pogut comunicar amb el lector d'empremtes digitals"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "No s'ha pogut comunicar amb el dimoni d'empremtes digitals"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "No s'ha pogut llistar les empremtes: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "No s'ha pogut suprimir les empremtes desades: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Polze esquerre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Dit del mig esquerre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "Dit índex _esquerre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Dit anular esquerre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Dit petit esquerre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Polze dret"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Dit del mig dret"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Dit índex d_ret"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Dit anular dret"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Dit petit dret"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Dit desconegut"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Completat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "S'ha desconnectat el dispositiu d'empremtes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "L'emmagatzematge del dispositiu d'empremtes està ple"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "No s'ha pogut afegir l'empremta nova"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "No s'ha pogut iniciar la detecció: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "No s'ha pogut afegir l'empremta nova"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "No s'ha pogut aturar la detecció: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Aixequeu i poseu el dit al lector per a inscriure la vostra empremta "
+"dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Torna a afegir aquest dit..."
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "S'estan escanejant les empremtes dactilars noves"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "S'ha produït un error en alliberar el dispositiu d'empremtes %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Hi ha un problema llegint el dispositiu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "S'ha produït un error en reclamar el dispositiu d'empremtes %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "S'ha produït un error en obtenir el dispositiu d'empremtes: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Aquesta setmana"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Setmana passada"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Ha acabat la sessió"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "S'ha iniciat la sessió"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s - Activitat del compte"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Anterior"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Següent"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Trieu una altra contrasenya."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Escriviu un altre cop la vostra contrasenya actual."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "No s'ha pogut canviar la contrasenya"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Canvi de la contrasenya"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "C_anvia"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Contrasenya actual"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Contrasenya nova"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Confirma la contrasenya"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Permet a l'usuari establir la contrasenya a l'entrada següent"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Estableix una contrasenya ara"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "No es pot unir automàticament a aquest tipus de domini"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "No s'ha trobat aquest domini o regne"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "No s'ha pogut entrar com a %s al domini %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "La contrasenya no vàlida, torneu-ho a provar"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "No s'ha pogut connectar al domini %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "No s'ha pogut suprimir l'usuari"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "No s'ha pogut revocar l'usuari gestionat remotament"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "No podeu suprimir el vostre compte."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s encara està connectat"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Si suprimiu un usuari mentre està connectat pot deixar el sistema "
+"inconsistent."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Voleu conservar els fitxers de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Es pot conservar el directori de l'usuari, la cua de correu i els fitxers "
+"temporals quan suprimiu un compte d'usuari."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Suprimeix els fitxers"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "C_onserva els fitxers"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Segur que voleu revocar el compte %s de l'usuari gestionat remotament?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Suprimeix"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Compte inhabilitat"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "S'ha de configurar la pròxima vegada que entri"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Cap"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Connectat"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "No s'ha pogut contactar amb el servei de comptes"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Assegureu-vos que el servei de comptes està instal·lat i habilitat."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Aquest quadre s'ha de desbloquejar per a canviar aquesta configuració"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Suprimeix el compte d'usuari seleccionat"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Per a suprimir el compte d'usuari seleccionat,\n"
+"primer feu clic a la icona *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Desbloqueja per a afegir usuaris i modificar els paràmetres"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Usuaris"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "S'ha de tornar a iniciar la sessió perquè els canvis tinguin efecte"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Reinicia ara"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Tanca"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Edita l'avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Nom complet"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Edita"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Inici de sessió amb _empremta dactilar"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Inici de sessió a_utomàtic"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Activitat del compte"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrador"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Els administradors poden afegir i suprimir altres usuaris, i poden canviar "
+"els paràmetres de tots els usuaris."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Controls parentals"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Obre l'aplicació de controls parentals."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Suprimeix l'usuari..."
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Altres usuaris"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Afegeix usuari…"
+
+#. Translators: This is the empty state page label which states that there are
+#. no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "No s'ha trobat cap usuari"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Desbloqueja per a afegir un compte d'usuari."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Afegiu o suprimiu usuaris i canvieu la contrasenya"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Inici de sessió;Nom;Empremta "
+"dactilar;Avatar;Logotip;Cara;Contrasenya;Control parental; Temps de "
+"pantalla; Restriccions d'aplicacions;Restriccions web;Ús;Límit "
+"d'ús;Nen;Nena;Infant;"
+
+#. Translators: This button enrolls the computer in the domain in order to use
+#. enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Afegeix-lo"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Inici de sessió de l'administrador del domini"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Per a poder utilitzar inicis de sessió corporatius, aquest ordinador\n"
+"necessita formar part del domini. Demaneu a l'administrador que\n"
+"introdueixi aquí la seva contrasenya."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nom de l'administrador"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Contrasenya de l'administrador"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Gestiona els comptes d'usuari"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Cal autenticació per a canviar les dades de l'usuari"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "La contrasenya nova ha de ser diferent de la vella."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Canvieu algunes lletres i números."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Canvieu la contrasenya una mica més."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Una contrasenya sense el vostre nom d'usuari seria més segura."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Eviteu l'ús del vostre nom a la contrasenya."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Eviteu algunes de les paraules incloses a la contrasenya."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Eviteu utilitzar paraules comunes."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Eviteu utilitzar paraules desordenades."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Utilitzeu més nombres."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Utilitzeu més lletres majúscules."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Utilitzeu més lletres minúscules."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Utilitzeu més caràcters especials, com ara signes de puntuació."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+"Intenteu utilitzar una combinació de lletres, nombres i signes de puntuació."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Eviteu repetir el mateix caràcter."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Eviteu repetir el mateix tipus de caràcter: combineu lletres, números i "
+"signes de puntuació."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Eviteu emprar seqüències com ara 1234 o abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Cal que la contrasenya sigui més gran. Intenteu utilitzar una combinació de "
+"lletres, nombres i signes de puntuació."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Combineu majúscules i minúscules i empreu un o dos nombres."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password "
+"stronger."
+msgstr ""
+"Si hi afegiu més lletres, nombres i signes de puntuació la contrasenya serà "
+"més segura."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Ha fallat l'autenticació"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "La contrasenya nova és massa curta"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "La contrasenya nova és massa senzilla"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "La contrasenya nova i l'anterior són massa semblants"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "La contrasenya nova ja s'ha utilitzat recentment."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "La contrasenya nova ha de contenir caràcters numèrics o especials"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "La contrasenya nova i l'anterior són iguals"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "La vostra contrasenya ha canviat des que us heu autenticat."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "La contrasenya nova no conté suficients caràcters diferents"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Error desconegut"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"El nom d'usuari normalment només conté lletres minúscules de la «a» a la "
+"«z», dígits i els caràcters: «-» i «_»"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "El nom d'usuari no està disponible. Trieu-ne un altre."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "El nom d'usuari és massa llarg."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Mapa els botons"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Mapa els botons a les funcions"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Per a editar una drecera, feu clic a l'acció «Envia una pulsació de tecla», "
+"premeu el botó de drecera de teclat i premeu la combinació de tecles nova, o"
+" premeu la tecla de retrocés per a netejar-la."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Tanca"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Feu un toc als marcadors objectius a mesura que apareguin a la pantalla per "
+"a calibrar la tauleta gràfica."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "S'ha detectat una pulsació incorrecta, s'està reiniciant..."
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Botó %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplicació definida"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Envia una pulsació de tecla"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Commuta el monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Mostra l'ajuda en pantalla"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tauleta muntada en portàtil"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tauleta muntada en pantalla externa"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Tauleta externa"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and
+#. knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Tauleta externa"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Totes les pantalles"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Mode tauleta"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Utilitza el posicionament absolut per al llapis"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientació d'esquerrans"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "La tauleta i les Express Keys™ es giren per a l'ús de la mà esquerra"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Assigna al monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Mantén la ràtio d'aspecte"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Utilitzeu només una part de la superfície de la tauleta per a mantenir la "
+"relació d'aspecte del monitor"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Calibrar"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "No s'ha detectat cap tauleta"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Connecteu o activeu la tauleta Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensibilitat de pressió del llapis"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Suau"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pressió del llapis"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Ferma"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Botó 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botó 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botó 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilitat de pressió de l'esborrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pressió de l'esborrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Clic del botó del mig del ratolí"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Clic del botó dret del ratolí"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Endavant"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Llapis d'aerògraf amb pressió, inclinació i control lliscant integrat"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Llapis d'aerògraf amb pressió, inclinació i rotació"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Estilogràfica estàndard amb pressió i inclinació"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Estilogràfica estàndard amb pressió"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tauleta Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Establiu el mapa de botons i ajusteu la sensibilitat de l'estilogràfica per "
+"a tauletes gràfiques"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate
+#. or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tauleta gràfica;Wacom;Estilogràfica;Esborrador;Ratolí;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Drecera nova…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Punts d'accés"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operació cancel·lada"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Error:</b> accés denegat en canviar els paràmetres"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Error:</b> error de l'equipament mòbil"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Sense registrar"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registrat"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Itinerància"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "S'està cercant"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Denegat"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Detalls del mòdem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Estat del mòdem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operador"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tipus de xarxa"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Estat de la xarxa"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Número propi"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Detalls del dispositiu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Versió del microprogramari"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Només 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Només 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Només 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Només 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (preferit), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (preferit), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (preferit), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (preferit), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (preferit), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (preferit), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (preferit), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (preferit), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (preferit), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (preferit), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (preferit), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (preferit), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (preferit), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (preferit), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (preferit), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (preferit), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (preferit)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (preferit), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Desbloqueja la targeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Desbloqueja"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Proporcioneu el codi PIN per a la SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Introduïu el PIN per a desbloquejar la targeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Introduïu el codi PUK per a la SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Introdueix el PUK per a desbloquejar la targeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "La contrasenya introduïda és incorrecta. Us queda %1$u intent"
+msgstr[1] "La contrasenya introduïda és incorrecta. Us queden %1$u intents"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Us queden %u intent"
+msgstr[1] "Us queden %u intents"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "La contrasenya introduïda és incorrecta."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "El codi PUK ha de ser un número de 8 dígits"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Introduïu un PIN nou"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "El codi PIN ha de ser un número de 4-8 dígits"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "S'està desbloquejant…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Sense SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Inseriu una targeta SIM per a utilitzar aquest mòdem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM bloquejada"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Dades mòbils"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Accedir a les dades mitjançant la xarxa mòbil"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Itinerància de dades"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Utilitza dades mòbils quan s'estigui en itinerància"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Mode de xarxa"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Xarxa"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avançat"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Noms dels punts d'accés"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_Bloqueig de la SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Bloqueja la SIM amb el PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "_Detalls del mòdem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Error del telèfon"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "No hi ha connexió al telèfon"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operació no permesa"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operació no admesa"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "No s'ha inserit la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Cal el PIN de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Cal el PUK de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Error de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM ocupada"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Contrasenya incorrecta"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Cal el PIN2 de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Cal el PUK2 de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "No s'ha trobat"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Sense servei de xarxa"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Temps d'espera de la xarxa"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "No es permeten els serveis GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "No es permet la itinerància en aquesta àrea d'ubicació"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "S'ha produït un error GPRS no especificat"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Cap error"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Acció cancel·lada"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Accés denegat"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Error desconegut"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Mode de xarxa"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automàtic"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Tria una xarxa"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Actualitza els proveïdors de xarxa"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Habilita la xarxa mòbil"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "No s'ha trobat cap adaptador WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Assegureu-vos de tenir un dispositiu de xarxa o mòbil sense fil"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "El Wan sense fil està inhabilitat quan el mode d'avió està activat"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Desactiva el mode d'avió"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Connexió de dades"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Targeta SIM utilitzada per a Internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Bloqueig de la SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Següent"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Bloqueja la SIM amb el PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Canvia el PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+"Introduïu el PIN actual per a canviar la configuració de bloqueig de la SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Xarxa mòbil"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configura les connexions de dades de telefonia i mòbils"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cel·lular;wwan;telefonia;sim;mòbil;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilitats per a configurar l'escriptori GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "El Paràmetres és la interfície principal per a configurar el sistema."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "El projecte GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Mostra el número de versió"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Habilita el mode detallat"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Cerca la cadena"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Llista tots els noms de quadre possibles i surt"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Quadre a mostrar"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[QUADRE] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categories de configuració"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privacitat"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Quadres disponibles:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Tots els paràmetres"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menú primari"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Avís: versió de desenvolupament"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Aquesta versió del Paràmetres només s'ha d'utilitzar amb finalitats de "
+"desenvolupament. Podeu exposar-vos a un comportament incorrecte del sistema,"
+" pèrdua de dades, i altres problemes inesperats. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Ajuda"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "General"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Surt"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Cerca"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Quadres"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Torna al quadre anterior"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Cancel·la la cerca"
+
+#. Translators: Search terms to find this application. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferències;Configuració;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "L'identificador de l'últim quadre de configuració a obrir"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values"
+" will be ignored and the first panel in the list selected."
+msgstr ""
+"L'identificador de l'últim quadre de configuració a obrir. S'ignoraran els "
+"valors que no siguin reconeguts i se seleccionarà el primer quadre de la "
+"llista."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Mostra un avís que s'executa un muntatge de desenvolupament del Paràmetres"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Si el Paràmetres ha de mostrar un avís que s'executa un muntatge de "
+"desenvolupament."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Estat inicial de la finestra"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Una tupla que conté l'amplada inicial, l'alçada i l'estat maximitzat de la "
+"finestra de l'aplicació."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u sortida"
+msgstr[1] "%u sortides"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrada"
+msgstr[1] "%u entrades"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sons del sistema"

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -19,9 +19,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2017-09-22 13:24+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2017-08-15 08:15+0200\n"
 "Last-Translator: Xavi Ivars <xavi.ivars@gmail.com>\n"
 "Language-Team: Catalan <tradgnome@softcatala.org>\n"
@@ -32,549 +31,419 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.0.1\n"
 
-#: ../panels/background/background.ui.h:1
-msgid "_Background"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicacions"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "No s'han trobat aplicacions"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Instal·la un fitxer PPD..."
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Obri"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_Mostra els detalls"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Busca"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Inhabilitat"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_Notificacions"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Mostra les _notificacions"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "_Fons"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "Canvia durant el dia"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "_Lock Screen"
-msgstr "_Pantalla de bloqueig"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Captures de pantalla"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Mosaic"
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
 
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Amplia"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "Centra"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Escala"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Omple"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "Allarga"
-
-#: ../panels/background/cc-background-chooser-dialog.c:430
-msgid "Wallpapers"
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
 msgstr "Fons de pantalla"
 
-#: ../panels/background/cc-background-chooser-dialog.c:439
-msgid "Colors"
-msgstr "Colors"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:476
-msgid "Select Background"
-msgstr "Selecciona el fons"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "So"
 
-#: ../panels/background/cc-background-chooser-dialog.c:504
-msgid "Pictures"
-msgstr "Imatges"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:536
-msgid "No Pictures Found"
-msgstr "No s'ha trobat cap imatge"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Estableix la drecera"
 
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:554
-#: ../panels/search/cc-search-locations-dialog.c:302
-msgid "Home"
-msgstr "Inici"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "No s'ha trobat la tecla de drecera"
 
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:566
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "Podeu afegir imatges a la carpeta %s i apareixeran ací"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "Càmera %s"
 
-#: ../panels/background/cc-background-chooser-dialog.c:573
-#: ../panels/color/cc-color-panel.c:225 ../panels/color/cc-color-panel.c:963
-#: ../panels/color/color-calibrate.ui.h:2 ../panels/color/color.ui.h:30
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:2697
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:181
-#: ../panels/network/connection-editor/vpn-helpers.c:310
-#: ../panels/network/net-device-wifi.c:1318
-#: ../panels/network/net-device-wifi.c:1398
-#: ../panels/network/net-device-wifi.c:1633
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/printers/pp-details-dialog.c:319
-#: ../panels/privacy/cc-privacy-panel.c:1049
-#: ../panels/region/format-chooser.ui.h:3 ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:642
-#: ../panels/sharing/cc-sharing-panel.c:382
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/join-dialog.ui.h:2
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-#: ../panels/user-accounts/um-photo-dialog.c:94
-#: ../panels/user-accounts/um-photo-dialog.c:221
-#: ../panels/user-accounts/um-user-panel.c:644
-#: ../panels/user-accounts/um-user-panel.c:662
-msgid "_Cancel"
-msgstr "_Cancel·la"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../panels/background/cc-background-chooser-dialog.c:574
-msgid "_Select"
-msgstr "_Selecciona"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
 
-#: ../panels/background/cc-background-item.c:203
-msgid "multiple sizes"
-msgstr "mides múltiples"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:207
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Serveis d'ubicació"
 
-#: ../panels/background/cc-background-item.c:333
-msgid "No Desktop Background"
-msgstr "Sense imatge de fons de l'escriptori"
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
 
-#: ../panels/background/cc-background-panel.c:497
-msgid "Current background"
-msgstr "Imatge de fons actual"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Càmera web integrada"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Back­ground"
-msgstr "Fons"
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:3
-msgid "Change your background image to a wallpaper or photo"
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "No s'ha trobat cap resultat."
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Proveu amb una busca diferent"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Tipus de pantalla"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Velocitat de l'enllaç"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Reinicia"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Aplicacions"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Estilogràfica"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Per defecte"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "_Fons"
+
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "Afig una impressora..."
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "França"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Canvieu la imatge de fons a un fons de pantalla o fotografia"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:5
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Fons de pantalla;Pantalla;Escriptori;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:268
-msgid "Turn Off Airplane Mode"
-msgstr "Desactiveu el mode d'avió"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "_Habilita"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:334
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "No s'ha trobat el Bluetooth"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:334
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Connecteu una motxilla per a usar Bluetooth."
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:335
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth desactivat"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:335
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 "Activeu-lo per connectar dispositius i rebre transferències de fitxers."
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:336
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "El mode d'avió està activat"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:336
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "El Bluetooth està inhabilitat quan el mode d'avió està activat."
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:337
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Desactiveu el mode d'avió"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
 msgstr "El mode d'avió del maquinari està activat"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:337
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Desactiveu el mode d'avió per a habilitar el Bluetooth."
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
-msgid "Blue­tooth"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:3
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Activeu i desactiveu el Bluetooth i connecteu els dispositius"
 
-#. Translators: those are keywords for the bluetooth control-center panel
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:5
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "comparteix;compartició;bluetooth;obex;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Col·loqueu el dispositiu de calibratge sobre el quadre i premeu «Inicia»."
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "Bluetooth desactivat"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Actualment cap aplicació no està reproduint ni gravant àudio."
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"Moveu el dispositiu de calibratge a la posició de calibratge i premeu "
-"«Continua»."
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-"Moveu el dispositiu de calibratge a la posició de la superfície i premeu "
-"«Continua»."
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "Tanca la tapa del portàtil"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Busca més imatges"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "S'ha produït un error intern que no s'ha pogut recuperar."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "Les eines que calen pel calibratge no estan instal·lades."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "No s'ha pogut generar el perfil."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "No s'ha pogut obtindre el punt blanc de l'objectiu."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "S'ha completat"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "Ha fallat el calibratge"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "Podeu treure el dispositiu de calibratge."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "No interrompeu el dispositiu de calibratge mentre treballi"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Pantalla del portàtil"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Càmera web integrada"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Escànner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Càmera %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Impressora %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Càmera web %s"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Habilita la gestió del color per a %s"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Mostra els perfils de color per a %s"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:323
-msgid "Not calibrated"
-msgstr "Sense calibrar"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:141
-msgid "Default: "
-msgstr "Per defecte: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:149
-msgid "Colorspace: "
-msgstr "Espai de color: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:156
-msgid "Test profile: "
-msgstr "Perfil de comprovació: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:223
-msgid "Select ICC Profile File"
-msgstr "Selecciona un fitxer de perfil ICC"
-
-#: ../panels/color/cc-color-panel.c:226
-msgid "_Import"
-msgstr "_Importa"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:237
-msgid "Supported ICC profiles"
-msgstr "Perfils ICC compatibles"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:244
-#: ../panels/network/wireless-security/eap-method-fast.c:417
-msgid "All files"
-msgstr "Tots els fitxers"
-
-#: ../panels/color/cc-color-panel.c:583
-msgid "Screen"
-msgstr "Pantalla"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:908
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "No s'ha pogut pujar el fitxer: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:922
-msgid "The profile has been uploaded to:"
-msgstr "S'ha actualitzat el perfil a:"
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Write down this URL."
-msgstr "Apunteu este URL."
-
-#: ../panels/color/cc-color-panel.c:925
-msgid "Restart this computer and boot your normal operating system."
-msgstr "Reinicieu l'ordinador i arrenqueu el vostre sistema operatiu normal."
-
-#: ../panels/color/cc-color-panel.c:926
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "Escriviu l'URL al navegador web per baixar i instal·lar el perfil."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:960
-msgid "Save Profile"
-msgstr "Guarda el perfil"
-
-#: ../panels/color/cc-color-panel.c:964
-#: ../panels/network/connection-editor/vpn-helpers.c:311
-msgid "_Save"
-msgstr "Al_ça"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1324
-msgid "Create a color profile for the selected device"
-msgstr "Crea un perfil de color per al dispositiu seleccionat"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"No s'ha detectat l'instrument de mesura. Comproveu que estiga encés i "
-"connectat correctament."
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1373
-msgid "The measuring instrument does not support printer profiling."
-msgstr "L'instrument de mesura no admet el perfilat d'impressores."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1384
-msgid "The device type is not currently supported."
-msgstr "El tipus de dispositiu no és compatible actualment."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "Espai estàndard"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "Perfil de comprovació"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automàtic"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Qualitat baixa"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Qualitat mitjana"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Qualitat alta"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB per defecte"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK per defecte"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Gris per defecte"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "Dades de calibratge de fàbrica proporcionades pel venedor"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-"Amb este perfil no es pot fer la correcció de la pantalla en mode pantalla "
-"completa "
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "Este perfil potser ja no és precís"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibratge de la pantalla"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancel·la"
+
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "_Inicia"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "_Continua"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Fet"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Calibratge de la pantalla"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Qualitat del calibratge"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -584,42 +453,42 @@ msgstr ""
 "de la pantalla. Com més temps passeu en el calibratge, més bona serà la "
 "qualitat del perfil de color."
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "No podreu utilitzar l'ordinador mentre es faça el calibratge."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Qualitat"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Temps aproximat"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "Qualitat del calibratge"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Seleccioneu el sensor que voleu utilitzar pel calibratge."
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Dispositiu de calibratge"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "Seleccioneu el tipus de pantalla que està connectat."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Seleccioneu el sensor que voleu utilitzar pel calibratge."
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Tipus de pantalla"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Seleccioneu el tipus de pantalla que està connectat."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Punt blanc del perfil"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -627,11 +496,11 @@ msgstr ""
 "Seleccioneu un punt blanc objectiu de la pantalla. La majoria de pantalles "
 "s'haurien de calibrar amb una il·luminació D65."
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "Punt blanc del perfil"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Brillantor de la pantalla"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -639,7 +508,7 @@ msgstr ""
 "Establiu la brillantor de la pantalla que acostumeu a utilitzar. La gestió "
 "del color serà més precisa en este nivell de brillantor."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -647,11 +516,11 @@ msgstr ""
 "També podeu utilitzar el nivell de brillantor utilitzat per un dels altres "
 "perfils d'este dispositiu."
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "Brillantor de la pantalla"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nom del perfil"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -659,598 +528,581 @@ msgstr ""
 "Podeu utilitzar un perfil de color en diferents ordinadors o fins i tot "
 "crear perfils per diferents condicions d'il·luminació."
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Nom del perfil:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "Nom del perfil"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "S'ha creat el perfil amb èxit"
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "Copia el perfil"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "Requereix un suport al qual s'hi puga escriure"
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "Puja el perfil"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "Requereix connexió a Internet"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"Podeu trobar les instruccions de com utilitzar el perfil als sistemes <a "
-"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> i <a href="
-"\"windows\">Microsoft Windows</a>."
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:723
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Resum"
 
-#: ../panels/color/color.ui.h:28
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "S'ha creat el perfil amb èxit"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copia el perfil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Requereix un suport al qual s'hi puga escriure"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Podeu trobar les instruccions de com utilitzar el perfil als sistemes <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> i <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "Afig un perfil"
 
-#: ../panels/color/color.ui.h:29
-msgid "_Import File…"
-msgstr "_Importa un fitxer…"
-
-#: ../panels/color/color.ui.h:31
-#: ../panels/network/connection-editor/net-connection-editor.c:519
-#: ../panels/printers/new-printer-dialog.ui.h:4
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-msgid "_Add"
-msgstr "_Afig"
-
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"S'han detectat problemes. Este perfil no funcionarà correctament. <a href="
-"\"\">Mostra els detalls.</a>"
+"S'han detectat problemes. Este perfil no funcionarà correctament. <a "
+"href=\"\">Mostra els detalls.</a>"
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importa un fitxer…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Afig"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Cada dispositiu necessita un perfil de color actualitzat per poder gestionar "
 "el color."
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Més informació"
 
-#: ../panels/color/color.ui.h:35
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Apreneu més sobre la gestió del color"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "_Estableix per a tots els usuaris"
 
-#: ../panels/color/color.ui.h:37
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Estableix este perfil per a tots els usuaris d'este ordinador"
 
-#: ../panels/color/color.ui.h:38
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "_Habilita"
 
-#: ../panels/color/color.ui.h:39
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "_Afig un perfil"
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "_Calibra…"
 
-#: ../panels/color/color.ui.h:41
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Calibra el dispositiu"
 
-#: ../panels/color/color.ui.h:42
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "_Suprimeix un perfil"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "_Mostra els detalls"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr ""
-"No s'ha pogut detectar cap dispositiu en el qual s'hi puga gestionar el "
-"color"
+"No s'ha pogut detectar cap dispositiu en el qual s'hi puga gestionar el color"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Projector"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plasma"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (retroil·luminació CCFL)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (retroil·luminació RGB LED)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (retroil·luminació de LED blanc)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "LCD de gamma àmplia (retroil·luminació CCFL)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "LCD de gamma àmplia (retroil·luminació de LED RGB)"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Alta"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 minuts"
 
-#: ../panels/color/color.ui.h:57
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Mitjana"
 
-#: ../panels/color/color.ui.h:58 ../panels/power/power.ui.h:2
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 minuts"
 
-#: ../panels/color/color.ui.h:59
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Baixa"
 
-#: ../panels/color/color.ui.h:60 ../panels/power/power.ui.h:1
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 minuts"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Nadiu de la pantalla"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Impressions i publicacions)"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Fotografia i gràfics)"
 
-#: ../panels/color/color.ui.h:65
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Co­lor"
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
 msgstr "Color"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:3
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 "Calibreu el color dels dispositius, com ara pantalles, càmeres o impressores"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:5
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Color;ICC;Perfil;Calibratge;Impressora;Pantalla;"
 
-#: ../panels/common/cc-common-language.c:323
-msgid "Other…"
-msgstr "Altres…"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Idioma"
 
-#: ../panels/common/cc-language-chooser.c:124
-#: ../panels/region/cc-format-chooser.c:269
-#: ../panels/region/cc-input-chooser.c:169
-msgid "More…"
-msgstr "Més…"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Selecciona"
 
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "No s'ha trobat cap idioma"
 
-#: ../panels/common/cc-util.c:127
-#: ../panels/network/connection-editor/ce-page-details.c:106
-msgid "Today"
-msgstr "Hui"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Més…"
 
-#: ../panels/common/cc-util.c:131
-#: ../panels/network/connection-editor/ce-page-details.c:108
-msgid "Yesterday"
-msgstr "Ahir"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e de %b"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "Desbloq_ueja"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e de %b, %Y"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: ../panels/common/language-chooser.ui.h:1
-msgid "Language"
-msgstr "Idioma"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#: ../panels/datetime/big.ui.h:1 ../panels/datetime/little.ui.h:1
-#: ../panels/datetime/middle.ui.h:1 ../panels/datetime/ydm.ui.h:1
-msgid "Day"
-msgstr "Dia"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Hora"
 
-#: ../panels/datetime/big.ui.h:2 ../panels/datetime/little.ui.h:2
-#: ../panels/datetime/middle.ui.h:2 ../panels/datetime/ydm.ui.h:2
-msgid "Month"
-msgstr "Mes"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../panels/datetime/big.ui.h:3 ../panels/datetime/little.ui.h:3
-#: ../panels/datetime/middle.ui.h:3 ../panels/datetime/ydm.ui.h:3
-msgid "Year"
-msgstr "Any"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:339
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e de %B del %Y a les %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:344
-msgid "%e %B %Y, %R"
-msgstr "%e de %B de %Y a les %R"
-
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:522
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:552
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:560
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:565
-msgid "%l:%M %p"
-msgstr "%l∶%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:570
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:575
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "Gener"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "Febrer"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "Març"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "Abril"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "Maig"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "Juny"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "Juliol"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "Agost"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "Setembre"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "Octubre"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "Novembre"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "Desembre"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Data i hora"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "Hora"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Any"
 
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr ":"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mes"
 
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "Minut"
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Gener"
 
-#: ../panels/datetime/datetime.ui.h:18
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Febrer"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Març"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Abril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maig"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juny"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juliol"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Agost"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Setembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Octubre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembre"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Desembre"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dia"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Fus horari"
 
-#: ../panels/datetime/datetime.ui.h:19
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Cerqueu una ciutat"
 
-#: ../panels/datetime/datetime.ui.h:20
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "_Data i hora automàtiques"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Requereix accés a Internet"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Data i _hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "_Fus horari automàtic"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Date & _Time"
-msgstr "Data i _hora"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "Requereix accés a Internet"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Habilitat"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Fus h_orari"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desbloq_ueja"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format del temps"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "24-hour"
-msgstr "24 hores"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dates"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "Secundària"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Calendari"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Nombres"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Canvieu la data i l'hora, incloent-hi la zona horària"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:5
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Rellotge;Zona horària;Ubicació;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "Canvieu els paràmetres d'hora i data del sistema"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Per canviar els paràmetres d'hora i data, vos heu d'autentificar."
 
-#: ../panels/display/cc-display-panel.c:738
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Apaïsada"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
 
-#: ../panels/display/cc-display-panel.c:741
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Vertical dreta"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Correu"
 
-#: ../panels/display/cc-display-panel.c:744
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Vertical esquerra"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "Ca_lendari"
 
-#: ../panels/display/cc-display-panel.c:747
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Apaïsada (capgirada)"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Música"
 
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/display/cc-display-panel.c:788
-#: ../panels/display/cc-display-panel.c:838
-#: ../panels/printers/pp-options-dialog.c:558
-msgid "Orientation"
-msgstr "Orientació"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Vídeo"
 
-#: ../panels/display/cc-display-panel.c:881
-#: ../panels/display/cc-display-panel.c:933
-#: ../panels/display/cc-display-panel.c:1751
-#: ../panels/display/cc-display-panel.c:1797
-#: ../panels/printers/pp-options-dialog.c:87
-msgid "Resolution"
-msgstr "Resolució"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotos"
 
-#: ../panels/display/cc-display-panel.c:978
-#: ../panels/display/cc-display-panel.c:1049
-msgid "Refresh Rate"
-msgstr "Freqüència de refresc"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicacions per defecte"
 
-#: ../panels/display/cc-display-panel.c:1186
-msgid "Scale"
-msgstr "Redimensiona"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configura les aplicacions per defecte"
 
-#: ../panels/display/cc-display-panel.c:1239
-msgid "Adjust for TV"
-msgstr "Ajusta per a televisió"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "per defecte; aplicació; preferida;multimèdia;"
 
-#: ../panels/display/cc-display-panel.c:1451
-#: ../panels/display/cc-display-panel.c:1497
-msgid "Primary Display"
-msgstr "Pantalla primària"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Informa de problemes"
 
-#: ../panels/display/cc-display-panel.c:1546
-msgid "Display Arrangement"
-msgstr "Disposició de les pantalles"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Informa de problemes automàticament"
 
-#: ../panels/display/cc-display-panel.c:1547
-msgid ""
-"Drag displays to match your setup. The top bar is placed on the primary "
-"display."
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
 msgstr ""
-"Arrossegueu les pantalles per configurar-les. La barra superior se situa a "
-"la pantalla primària."
 
-#: ../panels/display/cc-display-panel.c:1985
-msgid "Display Mode"
-msgstr "Mode de pantalla"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/display/cc-display-panel.c:2001
-msgid "Join Displays"
-msgstr "Uneix pantalles"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
 
-#: ../panels/display/cc-display-panel.c:2004
-msgid "Mirror"
-msgstr "Mirall"
-
-#: ../panels/display/cc-display-panel.c:2007
-msgid "Single Display"
-msgstr "Pantalla única"
-
-#: ../panels/display/cc-display-panel.c:2693
-msgid "Apply Changes?"
-msgstr "Voleu aplicar els canvis?"
-
-#: ../panels/display/cc-display-panel.c:2707
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Aplica"
 
-#: ../panels/display/cc-display-panel.c:3083
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Arrere"
 
-#. TRANSLATORS: the state of the night light setting
-#: ../panels/display/cc-display-panel.c:3299
-#: ../panels/notifications/cc-notifications-panel.c:293
-#: ../panels/power/cc-power-panel.c:1970 ../panels/power/cc-power-panel.c:1977
-#: ../panels/privacy/cc-privacy-panel.c:190
-#: ../panels/privacy/cc-privacy-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:331
-#: ../panels/universal-access/cc-ua-panel.c:712
-#: ../panels/universal-access/cc-ua-panel.c:725
-#: ../panels/universal-access/cc-ua-panel.c:737
-#: ../panels/universal-access/cc-ua-panel.c:908
-msgid "On"
-msgstr "Activat"
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "El Bluetooth està inhabilitat"
 
-#: ../panels/display/cc-display-panel.c:3299 ../panels/network/net-proxy.c:54
-#: ../panels/notifications/cc-notifications-panel.c:293
-#: ../panels/power/cc-power-panel.c:1964 ../panels/power/cc-power-panel.c:1975
-#: ../panels/privacy/cc-privacy-panel.c:190
-#: ../panels/privacy/cc-privacy-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:331
-#: ../panels/universal-access/cc-ua-panel.c:712
-#: ../panels/universal-access/cc-ua-panel.c:725
-#: ../panels/universal-access/cc-ua-panel.c:737
-#: ../panels/universal-access/cc-ua-panel.c:908
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Off"
-msgstr "Desactivat"
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Pantalla única"
 
-#: ../panels/display/cc-display-panel.c:3320
-msgid "_Night Light"
-msgstr "_Llum nocturna"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
 
-#: ../panels/display/cc-display-panel.c:3385
-msgid "Could not get screen information"
-msgstr "No s'ha pogut obtindre la informació de la pantalla"
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Mirall"
 
-#. This cancels the redshift inhibit.
-#: ../panels/display/display.ui.h:2
-msgid "Restart Filter"
-msgstr "Torna a iniciar el filtre"
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Pantalla primària"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Llum nocturna"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientació"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolució"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Freqüència de refresc"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Ajusta per a televisió"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Redimensiona"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Desplaçament natural"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Llum nocturna"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: ../panels/display/display.ui.h:4
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Inhabilitat temporalment fins demà"
 
-#: ../panels/display/display.ui.h:5
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Torna a iniciar el filtre"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1258,61 +1110,73 @@ msgstr ""
 "La llum nocturna fa que el color de pantalla siga més càlid. Això vos pot "
 "ajudar a prevenir la fatiga visual i la sensació de son."
 
-#. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: ../panels/display/display.ui.h:7
-msgid "Night Light"
-msgstr "Llum nocturna"
-
-#: ../panels/display/display.ui.h:8
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Planificació"
 
-#: ../panels/display/display.ui.h:9
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Posta de sol a l'eixida del sol"
 
-#: ../panels/display/display.ui.h:10
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-#: ../panels/network/net-proxy.c:56 ../panels/network/network-proxy.ui.h:3
-#: ../panels/network/network-wifi.ui.h:26
-#: ../panels/privacy/cc-privacy-panel.c:217
-msgid "Manual"
-msgstr "Manual"
+#: panels/display/cc-night-light-page.ui:141
+#, fuzzy
+msgid "Manual Schedule"
+msgstr "Planificació"
 
-#: ../panels/display/display.ui.h:11
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Hores"
+
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Des de"
 
-#: ../panels/display/display.ui.h:12
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hora"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minut"
+
 #. This is the short form for the time period in the morning
-#: ../panels/display/display.ui.h:14
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "AM"
 
 #. This is the short form for the time period in the afternoon
-#: ../panels/display/display.ui.h:16
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PM"
 
-#: ../panels/display/display.ui.h:17
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "A"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Dis­plays"
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+#, fuzzy
+msgid "Displays"
 msgstr "Pantalles"
 
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:3
+#: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Trieu com utilitzar els monitors i projectors connectats"
 
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:5
+#: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
@@ -1320,2402 +1184,1572 @@ msgstr ""
 "Quadre;Projector;xrandr;Pantalla;Resolució;Refresca;Monitor;Nit;Llum;Blau;"
 "color;posta de sol;"
 
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-overview-panel.c:381
-#: ../panels/info/cc-info-overview-panel.c:468
-#: ../panels/network/panel-common.c:123
-msgid "Unknown"
-msgstr "Desconegut"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: ../panels/info/cc-info-overview-panel.c:476
-#, c-format
-msgid "%s; Build ID: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Clau de seguretat"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Nivell de tinta"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Nivell de tinta"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Nivell de tinta"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Seguretat"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"pantalla;bloca;diagnòstics;fallades;privat;recent;temporal;tmp;índex;nom;"
+"xarxa;identitat;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Nom del dispositiu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Adreça física"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memòria"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processador"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Gràfics"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "S'està calculant…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Nom"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
 msgstr "%s; ID del muntatge: %s"
 
-#. translators: This is the type of architecture for the OS
-#: ../panels/info/cc-info-overview-panel.c:493
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Tipus de VPN"
 
-#. translators: This is the type of architecture for the OS
-#: ../panels/info/cc-info-overview-panel.c:496
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Versió 0"
 
-#: ../panels/info/cc-info-overview-panel.c:807
-#, c-format
-msgid "Version %s"
-msgstr "Versió %s"
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "S'estan carregant les opcions…"
 
-#: ../panels/info/cc-info-panel.c:138
-msgid "Section"
-msgstr "Secció"
-
-#: ../panels/info/cc-info-panel.c:147 ../panels/info/info.ui.h:1
-msgid "Overview"
-msgstr "Visió general"
-
-#: ../panels/info/cc-info-panel.c:153 ../panels/info/info.ui.h:2
-msgid "Default Applications"
-msgstr "Aplicacions per defecte"
-
-#: ../panels/info/cc-info-panel.c:158 ../panels/info/info.ui.h:3
-msgid "Removable Media"
-msgstr "Suport extraïble"
-
-#: ../panels/info/cc-info-removable-media-panel.c:312
-msgid "Ask what to do"
-msgstr "Pregunta què fer"
-
-#: ../panels/info/cc-info-removable-media-panel.c:316
-msgid "Do nothing"
-msgstr "No faces res"
-
-#: ../panels/info/cc-info-removable-media-panel.c:320
-msgid "Open folder"
-msgstr "Obri la carpeta"
-
-#: ../panels/info/cc-info-removable-media-panel.c:411
-msgid "Other Media"
-msgstr "Altres suports"
-
-#: ../panels/info/cc-info-removable-media-panel.c:444
-msgid "Select an application for audio CDs"
-msgstr "Seleccioneu l'aplicació per als CD d'àudio"
-
-#: ../panels/info/cc-info-removable-media-panel.c:445
-msgid "Select an application for video DVDs"
-msgstr "Seleccioneu l'aplicació per als DVD de vídeo"
-
-#: ../panels/info/cc-info-removable-media-panel.c:446
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Seleccioneu l'aplicació que s'iniciarà quan es connecte un reproductor de "
-"música"
-
-#: ../panels/info/cc-info-removable-media-panel.c:447
-msgid "Select an application to run when a camera is connected"
-msgstr "Seleccioneu l'aplicació que s'iniciarà quan es connecte una càmera"
-
-#: ../panels/info/cc-info-removable-media-panel.c:448
-msgid "Select an application for software CDs"
-msgstr "Seleccioneu l'aplicació per als CD de programari"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-removable-media-panel.c:460
-msgid "audio DVD"
-msgstr "DVD d'àudio"
-
-#: ../panels/info/cc-info-removable-media-panel.c:461
-msgid "blank Blu-ray disc"
-msgstr "Disc Blu-ray en blanc"
-
-#: ../panels/info/cc-info-removable-media-panel.c:462
-msgid "blank CD disc"
-msgstr "Disc CD en blanc"
-
-#: ../panels/info/cc-info-removable-media-panel.c:463
-msgid "blank DVD disc"
-msgstr "Disc DVD en blanc"
-
-#: ../panels/info/cc-info-removable-media-panel.c:464
-msgid "blank HD DVD disc"
-msgstr "Disc HD DVD en blanc"
-
-#: ../panels/info/cc-info-removable-media-panel.c:465
-msgid "Blu-ray video disc"
-msgstr "Disc Blu-ray de vídeo"
-
-#: ../panels/info/cc-info-removable-media-panel.c:466
-msgid "e-book reader"
-msgstr "Lector de llibres digitals"
-
-#: ../panels/info/cc-info-removable-media-panel.c:467
-msgid "HD DVD video disc"
-msgstr "Disc HD DVD de vídeo"
-
-#: ../panels/info/cc-info-removable-media-panel.c:468
-msgid "Picture CD"
-msgstr "CD de fotos"
-
-#: ../panels/info/cc-info-removable-media-panel.c:469
-msgid "Super Video CD"
-msgstr "Supervídeo CD"
-
-#: ../panels/info/cc-info-removable-media-panel.c:470
-msgid "Video CD"
-msgstr "CD de vídeo"
-
-#: ../panels/info/cc-info-removable-media-panel.c:471
-msgid "Windows software"
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
 msgstr "Programari del Windows"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:2
-msgid "Defa­ult Applications"
-msgstr "Aplicacions per defecte"
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualització"
 
-#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:3
-msgid "Configure Default Applications"
-msgstr "Configura les aplicacions per defecte"
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Ús de programari"
 
-#. Translators: those are keywords for the Default Applications panel
-#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:5
-msgid "default;application;preferred;media;"
-msgstr "per defecte; aplicació; preferida;multimèdia;"
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Suprimeix el dispositiu"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:2
-msgid "Ab­out"
-msgstr "Quant a"
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
 
-#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:3
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:3
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nom del dispositiu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Nom d'_usuari"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr "Visualitzeu informació sobre el sistema"
 
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:5
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:5
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "dispositiu;sistema;informació;memòria;processador;versió;per defecte;"
 "aplicació;preferit;cd;dvd;usb;àudio;vídeo;disc;extraïble;multimèdia;execució "
 "automàtica;"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "De­tails"
-msgstr "Detalls"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:2
-msgid "Remo­vable Media"
-msgstr "Suport extraïble"
-
-#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:3
-msgid "Configure Removable Media settings"
-msgstr "Configura els paràmetres del suport extraïble"
-
-#. Translators: those are keywords for the Removable Media panel
-#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:5
-msgid ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
-"removable;media;autorun;"
-msgstr ""
-"dispositiu;sistema;informació;per defecte;aplicació;preferit;cd;dvd;usb;"
-"àudio;vídeo;disc;extraïble;multimèdia;execució automàtica;"
-
-#: ../panels/info/info-default-apps.ui.h:1
-msgid "_Web"
-msgstr "_Web"
-
-#: ../panels/info/info-default-apps.ui.h:2
-msgid "_Mail"
-msgstr "_Correu"
-
-#: ../panels/info/info-default-apps.ui.h:3
-msgid "_Calendar"
-msgstr "Ca_lendari"
-
-#: ../panels/info/info-default-apps.ui.h:4
-msgid "M_usic"
-msgstr "_Música"
-
-#: ../panels/info/info-default-apps.ui.h:5
-msgid "_Video"
-msgstr "_Vídeo"
-
-#: ../panels/info/info-default-apps.ui.h:6
-#: ../panels/info/info-removable-media.ui.h:5
-msgid "_Photos"
-msgstr "_Fotos"
-
-#: ../panels/info/info-overview.ui.h:1
-msgid "Device name"
-msgstr "Nom del dispositiu"
-
-#: ../panels/info/info-overview.ui.h:2
-msgid "Memory"
-msgstr "Memòria"
-
-#: ../panels/info/info-overview.ui.h:3
-msgid "Processor"
-msgstr "Processador"
-
-#: ../panels/info/info-overview.ui.h:4
-msgid "Graphics"
-msgstr "Gràfics"
-
-#. To translators: this field contains the distro name and version
-#: ../panels/info/info-overview.ui.h:6
-msgid "OS name"
-msgstr "Nom del sistema operatiu"
-
-#. To translators: this field contains the distro type
-#: ../panels/info/info-overview.ui.h:8
-msgid "OS type"
-msgstr "Tipus de sistema operatiu"
-
-#: ../panels/info/info-overview.ui.h:9
-msgid "Virtualization"
-msgstr "Virtualització"
-
-#: ../panels/info/info-overview.ui.h:10
-msgid "Disk"
-msgstr "Disc"
-
-#: ../panels/info/info-overview.ui.h:11
-msgid "Calculating…"
-msgstr "S'està calculant…"
-
-#: ../panels/info/info-overview.ui.h:12
-msgid "Check for updates"
-msgstr "Comprova si hi ha actualitzacions"
-
-#: ../panels/info/info-removable-media.ui.h:1
-msgid "Select how media should be handled"
-msgstr "Seleccioneu com s'han de gestionar els suports"
-
-#: ../panels/info/info-removable-media.ui.h:2
-msgid "CD _audio"
-msgstr "_CD d'àudio"
-
-#: ../panels/info/info-removable-media.ui.h:3
-msgid "_DVD video"
-msgstr "_DVD de vídeo"
-
-#: ../panels/info/info-removable-media.ui.h:4
-msgid "_Music player"
-msgstr "Reproductor de _música"
-
-#: ../panels/info/info-removable-media.ui.h:6
-msgid "_Software"
-msgstr "_Programari"
-
-#: ../panels/info/info-removable-media.ui.h:7
-msgid "_Other Media…"
-msgstr "_Altres suports…"
-
-#: ../panels/info/info-removable-media.ui.h:8
-msgid "_Never prompt or start programs on media insertion"
-msgstr "_No preguntes mai ni inicies programes quan s'inserisquen suports"
-
-#: ../panels/info/info-removable-media.ui.h:9
-msgid "Select how other media should be handled"
-msgstr "Seleccioneu com s'han de gestionar els altres suports"
-
-#: ../panels/info/info-removable-media.ui.h:10
-msgid "_Action:"
-msgstr "_Acció:"
-
-#: ../panels/info/info-removable-media.ui.h:11
-msgid "_Type:"
-msgstr "_Tipus:"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "So i multimèdia"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Silencia el volum"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Abaixa el volum"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Apuja el volum"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Inicia el reproductor multimèdia"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Reprodueix (o reprodueix/fes una pausa)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Fes una pausa a la reproducció"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Atura la reproducció"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Salta a la peça anterior"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Salta a la peça següent"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Expulsa"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/universal-access/uap.ui.h:12
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Escriptura"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "Commuta a la font d'entrada següent"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "Commuta a la font d'entrada anterior"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "Llançadors"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Inicia el navegador d'ajuda"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/alt/cc-window.c:1590
-#: ../shell/cc-window.c:251 ../shell/cc-window.c:831
-#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/window.ui.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "Paràmetres"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Inicia la calculadora"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "Inicia el client de correu"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "Inicia el navegador web"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "Carpeta personal"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "Busca"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "Captures de pantalla"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "Guarda una captura de pantalla a $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Guarda una captura de pantalla d'una finestra a $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Guarda una captura de pantalla d'una àrea a $PICTURES"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "Copia una captura de pantalla al porta-retalls"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Copia una captura de pantalla d'una finestra al porta-retalls"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Copia una captura de pantalla d'una àrea al porta-retalls"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "Grava un screencast curt"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "Ix"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "Bloca la pantalla"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-msgid "Universal Access"
-msgstr "Accés universal"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "Activa o desactiva l'ampliació"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "Ampliació"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "Reducció"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "Activa o desactiva el lector de pantalla"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "Activa o desactiva el teclat a la pantalla"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "Augmenta la mida del text"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "Redueix la mida del text"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "Activa o desactiva el contrast alt"
 
-#: ../panels/keyboard/cc-keyboard-manager.c:506
-#: ../panels/keyboard/cc-keyboard-manager.c:514
-#: ../panels/keyboard/cc-keyboard-manager.c:822
-msgid "Custom Shortcuts"
-msgstr "Dreceres personalitzades"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Afig una font d'entrada"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:435
-#: ../panels/keyboard/shortcut-editor.ui.h:2
-#: ../panels/network/network-proxy.ui.h:4
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1866
-#: ../panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Disabled"
-msgstr "Inhabilitat"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Els mètodes d'entrada no es poden utilitzar a la pantalla d'entrada"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "No s'ha seleccionat cap font d'entrada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opcions"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Mou amunt"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Mou avall"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferències"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Dreceres de teclat"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr "Suprimeix"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Fonts d'entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Opcions de la font d'entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Utilitza la _mateixa font a totes les finestres"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "Permet fonts _diferents per a cada finestra"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "Tecla de caràcters alternatius"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "Tecla de composició"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "Només els modificadors commuten a la font següent"
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Dreceres de teclat"
 
-#: ../panels/keyboard/cc-keyboard-panel.c:181
-msgid "Reset All Shortcuts?"
-msgstr "Voleu restablir totes les dreceres?"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Dreceres personalitzades"
 
-#: ../panels/keyboard/cc-keyboard-panel.c:184
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Restableix-ho tot..."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Restableix totes les dreceres als seus valors per omissió"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Secció"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Drecera"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Afegeix una drecera"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Afig drecera personalitzada"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"Restablir les dreceres pot afectar les vostres dreceres personalitzades. "
-"Esta acció no es pot desfer."
 
-#: ../panels/keyboard/cc-keyboard-panel.c:188
-#: ../panels/keyboard/shortcut-editor.ui.h:9
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-msgid "Cancel"
-msgstr "Cancel·la"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Afegeix una drecera"
 
-#: ../panels/keyboard/cc-keyboard-panel.c:189
-msgid "Reset All"
-msgstr "Restableix-ho tot"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "No s'ha trobat la tecla de drecera"
 
-#: ../panels/keyboard/cc-keyboard-panel.c:281
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Suprimeix"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "Reemplaça"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+#, fuzzy
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Premeu Esc o Retrocés per a reiniciar la drecera de teclat."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nom"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Orde"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Drecera"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Estableix la drecera..."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Cap"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Restableix la drecera al seu valor per omissió"
 
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:427
-#, c-format
-msgid ""
-"%s is already being used for <b>%s</b>. If you replace it, %s will be "
-"disabled"
-msgstr "%s ja s'utilitza per <b>%s</b>. Si la reemplaceu, %s s'inhabilitarà"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Utilitza la impressora per defecte"
 
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:597
-msgid "Set Custom Shortcut"
-msgstr "Estableix la drecera personalitzada"
-
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:597
-msgid "Set Shortcut"
-msgstr "Estableix la drecera"
-
-#. Setup the top label
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:606
-#, c-format
-msgid "Enter new shortcut to change <b>%s</b>."
-msgstr "Introduïu una drecera nova per canviar <b>%s</b>."
-
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:1033
-msgid "Add Custom Shortcut"
-msgstr "Afig drecera personalitzada"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "Key­board"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+#, fuzzy
+msgid "Keyboard"
 msgstr "Teclat"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:3
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
 "Visualitzeu i canvieu les dreceres de teclat i establiu les preferències "
 "d'escriptura"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:5
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
 "Drecera;Espai de treball;Finestra;Canvia la mida;Amplia;Contrast;Entrada;"
 "Font;Bloqueig;Volum;"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-#: ../panels/region/input-options.ui.h:4 ../shell/cc-application.c:251
-msgid "Keyboard Shortcuts"
-msgstr "Dreceres de teclat"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "Serveis d'ubicació"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "Reset All…"
-msgstr "Restableix-ho tot..."
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Actualment cap aplicació no està reproduint ni gravant àudio."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "Reset all shortcuts to their default keybindings"
-msgstr "Restableix totes les dreceres als seus valors per omissió"
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "No keyboard shortcut found"
-msgstr "No s'ha trobat la tecla de drecera"
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5 ../shell/panel-list.ui.h:4
-msgid "Try a different search"
-msgstr "Proveu amb una busca diferent"
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
 
-#: ../panels/keyboard/shortcut-editor.ui.h:1
-msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Premeu Esc o Retrocés per a reiniciar la drecera de teclat."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
 
-#: ../panels/keyboard/shortcut-editor.ui.h:3
-#: ../panels/printers/details-dialog.ui.h:1
-#: ../panels/sound/gvc-mixer-dialog.c:1493
-#: ../panels/sound/gvc-sound-theme-chooser.c:564
-msgid "Name"
-msgstr "Nom"
+# N.T.: En minúscula ja que s'afegeix visualment a una altre cadena
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "s'apaga la pantalla"
 
-#: ../panels/keyboard/shortcut-editor.ui.h:4
-msgid "Command"
-msgstr "Orde"
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "No s'han trobat aplicacions"
 
-#: ../panels/keyboard/shortcut-editor.ui.h:5
-msgid "Shortcut"
-msgstr "Drecera"
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
 
-#: ../panels/keyboard/shortcut-editor.ui.h:6
-msgid "Set Shortcut…"
-msgstr "Estableix la drecera..."
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
 
-#: ../panels/keyboard/shortcut-editor.ui.h:7
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "Cap"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
 
-#: ../panels/keyboard/shortcut-editor.ui.h:8
-msgid "Enter the new shortcut"
-msgstr "Introduïu la drecera nova"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
 
-#: ../panels/keyboard/shortcut-editor.ui.h:10
-msgid "Remove"
-msgstr "Suprimeix"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:11
-msgid "Add"
-msgstr "Afig"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:12
-msgid "Replace"
-msgstr "Reemplaça"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:13
-msgid "Set"
-msgstr "Estableix"
-
-#: ../panels/mouse/cc-mouse-panel.c:82 ../panels/wacom/cc-wacom-panel.c:402
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "_Comprova els paràmetres"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Mouse & Touch­pad"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "General"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Botó primari"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Estableix l'orde dels botons als ratolins i ratolins tàctils."
+
+# N.T.: Es refereix al botó
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Esquerre"
+
+# N.T.: Es refereix al botó
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Dret"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Ubicacions de busca"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Ratolí"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "Velocitat del ratolí"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Desplaça cap avall"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "El desplaçament mou el contingut, no la vista."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "El desplaçament mou el contingut, no la vista."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Actiu"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Ratolí tàctil"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "Velocitat del ratolí tàctil"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Mètode"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "Fes un toc per fer un clic"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Fes un toc per fer un clic"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_Inhabilita mentre s'escriu"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Ratolí tàctil (relatiu)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Desplaçament en la vora"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Desplaça cap a l'esquerra"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Doble cara"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Proveu de fer clic, fer doble clic i desplaçar"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
 msgstr "Ratolí i ratolí tàctil"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:3
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 "Canvieu la sensibilitat del ratolí i del ratolí tàctil i seleccioneu l'ús "
 "per dretans o esquerrans"
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:5
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Ratolí tàctil;Punter;Clic;Toc;Doble;Botó;Ratolí de bola;Desplaça;"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "General"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "Primary Button"
-msgstr "Botó primari"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "Estableix l'orde dels botons als ratolins i ratolins tàctils."
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-# N.T.: Es refereix al botó
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Left"
-msgstr "Esquerre"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-# N.T.: Es refereix al botó
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "Right"
-msgstr "Dret"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Espai de color: "
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Mouse"
-msgstr "Ratolí"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Mouse Speed"
-msgstr "Velocitat del ratolí"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "Buida automàticament la _paperera"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "Double-click timeout"
-msgstr "Temps d'espera del doble clic"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "Natural Scrolling"
-msgstr "Desplaçament natural"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgid "Scrolling moves the content, not the view."
-msgstr "El desplaçament mou el contingut, no la vista."
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgid "Touchpad"
-msgstr "Ratolí tàctil"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Monitor %s"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad Speed"
-msgstr "Velocitat del ratolí tàctil"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgid "Tap to Click"
-msgstr "Fes un toc per fer un clic"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgid "Two-finger Scrolling"
-msgstr "Desplaçament amb dos dits"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Aplicació definida"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Edge Scrolling"
-msgstr "Desplaçament en la vora"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "Proveu de fer clic, fer doble clic i desplaçar"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "Cinc clics, és l'hora del GEGL"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "Doble clic, botó primari"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "Un sol clic, botó primari"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "Doble clic, botó del mig"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Dispositius"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "Un sol clic, botó del mig"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "Doble clic, botó secundari"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Afig una connexió nova"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "Un sol clic, botó secundari"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "No s'ha configurat"
 
-#. add proxy to device list
-#: ../panels/network/cc-network-panel.c:579
-msgid "Network proxy"
-msgstr "Servidor intermediari de xarxa"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Connectat"
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:715 ../panels/network/net-vpn.c:192
-#: ../panels/network/net-vpn.c:321
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opcions…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../panels/network/cc-network-panel.c:779 ../panels/network/wifi.ui.h:7
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Activa el punt d'accés Wi-Fi"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nom de la xarxa"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Contrasenya"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Contrasenya del grup"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Contrasenya _actual"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Activa"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Mode d'avió"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Inhabilita Wi-Fi, Bluetooth i banda ampla mòbil"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "No s'ha trobat cap adaptador Wi-fi"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Assegureu-vos que teniu un adaptador Wi-fi connectat i activat"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Mode d'avió"
+
+#: panels/network/cc-wifi-panel.ui:165
+#, fuzzy
+msgid "Turn off to use Wi-Fi"
+msgstr "Desactiveu la Wifi per estalviar energia."
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Punt d'accés Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Activa el punt d'accés Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Xarxes visibles"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Cal que el NetworkManager estiga executant-se"
+
+#: panels/network/cc-wifi-panel.ui:303
 msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr ""
 "S'ha produït un error inesperat. Contacteu el vostre proveïdor de programari."
 
-#: ../panels/network/cc-network-panel.c:785
-msgid "NetworkManager needs to be running."
-msgstr "Cal que el NetworkManager estiga executant-se."
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/network/cc-wifi-panel.c:209
-#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:2
-#: ../panels/network/network-wifi.ui.h:58
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Seguretat 802.1x"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "page 1"
-msgstr "pàgina 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-msgid "Anony_mous identity"
-msgstr "Identitat _anònima"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "_Autenticació interna"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "page 2"
-msgstr "pàgina 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:101
-#: ../panels/network/connection-editor/ce-page-security.c:445
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "Seguretat"
-
-#: ../panels/network/connection-editor/ce-page.c:481
-msgid "automatic"
-msgstr "automàtic"
-
-#: ../panels/network/connection-editor/ce-page.c:521
-#, c-format
-msgid "Profile %d"
-msgstr "Perfil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:231
-#: ../panels/network/net-device-wifi.c:407
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:235
-#: ../panels/network/net-device-wifi.c:412
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:64
-#: ../panels/network/net-device-wifi.c:239
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:69
-#: ../panels/network/net-device-wifi.c:244
-msgid "Enterprise"
-msgstr "Corporativa"
-
-#: ../panels/network/connection-editor/ce-page-details.c:74
-#: ../panels/network/net-device-wifi.c:249
-#: ../panels/network/net-device-wifi.c:397
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Cap"
-
-#: ../panels/network/connection-editor/ce-page-details.c:95
-#: ../panels/power/power.ui.h:17
-msgid "Never"
-msgstr "Mai"
-
-#: ../panels/network/connection-editor/ce-page-details.c:110
-#: ../panels/network/net-device-ethernet.c:120
-#: ../panels/network/net-device-wifi.c:505
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "fa %i dia"
 msgstr[1] "fa %i dies"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:176
-#: ../panels/network/net-device-ethernet.c:50
-#: ../panels/network/net-device-wifi.c:561
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:202
-#: ../panels/network/net-device-wifi.c:590
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Cap"
-
-#: ../panels/network/connection-editor/ce-page-details.c:204
-#: ../panels/network/net-device-wifi.c:592
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Dèbil"
-
-#: ../panels/network/connection-editor/ce-page-details.c:206
-#: ../panels/network/net-device-wifi.c:594
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Acceptable"
-
-#: ../panels/network/connection-editor/ce-page-details.c:208
-#: ../panels/network/net-device-wifi.c:596
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Bona"
-
-#: ../panels/network/connection-editor/ce-page-details.c:210
-#: ../panels/network/net-device-wifi.c:598
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excel·lent"
-
-#: ../panels/network/connection-editor/ce-page-details.c:248
-msgid "Forget Connection"
-msgstr "Oblida la connexió"
-
-#: ../panels/network/connection-editor/ce-page-details.c:250
-msgid "Remove Connection Profile"
-msgstr "Suprimeix el perfil de connexió"
-
-#: ../panels/network/connection-editor/ce-page-details.c:252
-msgid "Remove VPN"
-msgstr "Suprimeix VPN"
-
-#: ../panels/network/connection-editor/ce-page-details.c:280
-#: ../panels/network/network-wifi.ui.h:46 ../shell/cc-window.c:243
-#: ../shell/panel-list.ui.h:2
-msgid "Details"
-msgstr "Detalls"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:173
-#: ../panels/network/connection-editor/ce-page-vpn.c:188
-#: ../panels/network/connection-editor/ce-page-wifi.c:194
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "Identitat"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:251
-#: ../panels/network/connection-editor/ce-page-ip6.c:230
-msgid "Delete Address"
-msgstr "Suprimeix l'adreça"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:422
-#: ../panels/network/connection-editor/ce-page-ip6.c:390
-msgid "Delete Route"
-msgstr "Suprimeix la ruta"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:896
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:827
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-security.c:245
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Cap"
-
-#: ../panels/network/connection-editor/ce-page-security.c:268
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Clau WEP 40/128-bit (hexadecimal o ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:278
-msgid "WEP 128-bit Passphrase"
-msgstr "Contrasenya WEP 128-bit"
-
-#: ../panels/network/connection-editor/ce-page-security.c:291
-#: ../panels/network/wireless-security/wireless-security.c:465
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:304
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinàmic (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:318
-msgid "WPA & WPA2 Personal"
-msgstr "WPA i WPA2 personal"
-
-#: ../panels/network/connection-editor/ce-page-security.c:332
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA i WPA2 corporativa"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Força del senyal"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Velocitat de l'enllaç"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:153
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:644
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguretat"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "Adreça IPv4"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:154
-#: ../panels/network/net-device-ethernet.c:158
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:645
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "Adreça IPv6"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:161
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Adreça física"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:165
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Perfils ICC compatibles"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Ruta per defecte"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:10
-#: ../panels/network/connection-editor/ip6-page.ui.h:11
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Utilitzada per últim cop"
 
-#: ../panels/network/connection-editor/details-page.ui.h:10
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "Connecta _automàticament"
 
-#: ../panels/network/connection-editor/details-page.ui.h:11
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Fes-la disponible a _altres usuaris"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:11
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/net-proxy.c:58 ../panels/network/network-proxy.ui.h:2
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/privacy/cc-privacy-panel.c:217
-msgid "Automatic"
-msgstr "Automàtic"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "Parells trenats (TP)"
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Interfície d'unitat d'acoblament (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "Interfície independent de medis (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Nom"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "Adreça _MAC"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "Adreça _clonada"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "bytes"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "_Mètode IPv4"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:27
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "Automàtic (DHCP)"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "Només enllaç local"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "Inhabilita"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "Compartit amb altres ordinadors"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "Adreces"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/printers/details-dialog.ui.h:3
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Adreça"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Màscara de xarxa"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:9
-#: ../panels/network/connection-editor/ip6-page.ui.h:10
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Porta d'enllaç"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:12
-#: ../panels/network/connection-editor/ip6-page.ui.h:12
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Automàtic"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "DNS automàtic"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:13
-#: ../panels/network/connection-editor/ip6-page.ui.h:13
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Separa les adreces IP amb comes"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:14
-#: ../panels/network/connection-editor/ip6-page.ui.h:14
-#: ../panels/network/network-wifi.ui.h:32
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Rutes"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:15
-#: ../panels/network/connection-editor/ip6-page.ui.h:15
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Rutes automàtiques"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ip4-page.ui.h:17
-#: ../panels/network/connection-editor/ip6-page.ui.h:17
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Mètrica"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:18
-#: ../panels/network/connection-editor/ip6-page.ui.h:18
-#: ../panels/network/network-wifi.ui.h:34
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "_Utilitza esta connexió només per als recursos d'esta xarxa"
 
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "_Mètode IPv6"
 
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "Automàtic, només DHCP"
 
-#: ../panels/network/connection-editor/ip6-page.ui.h:9
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Prefix"
 
-#: ../panels/network/connection-editor/net-connection-editor.c:273
-msgid "Unable to open connection editor"
-msgstr "No s'ha pogut obrir l'editor de connexions"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:291
-msgid "New Profile"
-msgstr "Perfil nou"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:603
-#: ../panels/network/network.ui.h:2
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:751
-msgid "Import from file…"
-msgstr "Importa des d'un fitxer…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:785
-msgid "Add VPN"
-msgstr "Afig VPN"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_eguretat"
 
-#: ../panels/network/connection-editor/vpn-helpers.c:141
-msgid "Cannot import VPN connection"
-msgstr "No es pot importar la connexió VPN"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:143
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"No s'ha pogut llegir el fitxer «%s» o no conté informació reconeguda d'una "
-"connexió VPN\n"
-"\n"
-"Error: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:178
-msgid "Select file to import"
-msgstr "Seleccioneu el fitxer a importar"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:182
-#: ../panels/printers/pp-details-dialog.c:320
-#: ../panels/sharing/cc-sharing-panel.c:383
-#: ../panels/user-accounts/um-photo-dialog.c:222
-msgid "_Open"
-msgstr "_Obri"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:230
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Ja existeix un fitxer amb el nom «%s»."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:232
-msgid "_Replace"
-msgstr "_Substitueix"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:234
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Voleu substituir %s amb la connexió VPN que esteu desant?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:270
-msgid "Cannot export VPN connection"
-msgstr "No es pot exportar la connexió VPN"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:272
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"No s'ha pogut exportar la connexió VPN «%s» a %s.\n"
-"\n"
-"Error: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:307
-msgid "Export VPN connection"
-msgstr "Exporta la connexió VPN"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(Error: no s'ha pogut carregar l'editor de connexió VPN)"
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "La meua xarxa"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Net­work"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
 msgstr "Xarxa"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:3
+#: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controleu com vos connecteu a Internet"
 
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:5
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"DNS;"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Xarxa;Sense fil;Wi-Fi;Wifi;IP;LAN;Servidor intermediari;WAN;Banda ampla;"
 "Mòdem;Bluetooth;vpn;DNS;"
 
-#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:3
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controleu com vos connecteu a les xarxes sense fil"
 
-#. Translators: those are keywords for the wi-fi control-center panel
-#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:5
-msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Xarxa;Sense fil;Wi-Fi;Wifi;IP;LAN;Servidor intermediari;WAN;Banda ampla;DNS;"
 
-#: ../panels/network/net-device-ethernet.c:106
-#: ../panels/network/net-device-wifi.c:491
-msgid "never"
-msgstr "mai"
-
-#: ../panels/network/net-device-ethernet.c:116
-#: ../panels/network/net-device-wifi.c:501
-msgid "today"
-msgstr "hui"
-
-#: ../panels/network/net-device-ethernet.c:118
-#: ../panels/network/net-device-wifi.c:503
-msgid "yesterday"
-msgstr "ahir"
-
-#: ../panels/network/net-device-ethernet.c:156
-#: ../panels/network/network-mobile.ui.h:3 ../panels/network/panel-common.c:647
-#: ../panels/network/panel-common.c:649
-msgid "IP Address"
-msgstr "Adreça IP"
-
-#: ../panels/network/net-device-ethernet.c:172
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "Utilitzada per últim cop"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:275
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Amb fil"
 
-#: ../panels/network/net-device-ethernet.c:343
-#: ../panels/network/net-device-wifi.c:1792
-#: ../panels/network/network-ethernet.ui.h:2
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:3 ../panels/network/network-vpn.ui.h:2
-msgid "Options…"
-msgstr "Opcions…"
-
-#: ../panels/network/net-device-mobile.c:238
-msgid "Add new connection"
-msgstr "Afig una connexió nova"
-
-#: ../panels/network/net-device-wifi.c:1275
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "Si activeu el punt d'accés sense fil vos desconnectareu de <b>%s</b>."
-
-#: ../panels/network/net-device-wifi.c:1279
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"No és possible accedir a Internet a través de la xarxa sense fil mentre el "
-"punt d'accés està actiu."
-
-#: ../panels/network/net-device-wifi.c:1286
-msgid "Turn On Wi-Fi Hotspot?"
-msgstr "Activa el punt d'accés Wi-Fi"
-
-#: ../panels/network/net-device-wifi.c:1308
-msgid ""
-"Wi-Fi hotspots are usually used to share an additional Internet connection "
-"over Wi-Fi."
-msgstr ""
-"Els punts d'accés Wi-Fi s'utilitzen habitualment per compartir una connexió "
-"Internet addicional per Wi-fi."
-
-#: ../panels/network/net-device-wifi.c:1319
-msgid "_Turn On"
-msgstr "_Activa"
-
-#: ../panels/network/net-device-wifi.c:1396
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Voleu aturar el punt d'accés Wi-Fi i desconnectar els usuaris?"
-
-#: ../panels/network/net-device-wifi.c:1399
-msgid "_Stop Hotspot"
-msgstr "_Atura el punt d'accés Wi-Fi"
-
-#: ../panels/network/net-device-wifi.c:1496
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-"La política del sistema prohibeix utilitzar-lo com a punt d'accés Wi-Fi"
-
-#: ../panels/network/net-device-wifi.c:1499
-msgid "Wireless device does not support Hotspot mode"
-msgstr "El dispositiu sense fil no admet el mode punt d'accés Wi-Fi"
-
-#: ../panels/network/net-device-wifi.c:1630
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Es perdran les dades de xarxa de les xarxes seleccionades, incloent les "
-"contrasenyes i la configuració personalitzada."
-
-#: ../panels/network/net-device-wifi.c:1634
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "_Oblida"
-
-#: ../panels/network/net-device-wifi.c:1943
-#: ../panels/network/net-device-wifi.c:1950
-msgid "Known Wi-Fi Networks"
-msgstr "Xarxes sense fil conegudes"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1983
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Oblida"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:102
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"El descobriment automàtic de servidors intermediaris web s'utilitza quan no "
-"es proporciona un URL de configuració."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:110
-msgid "This is not recommended for untrusted public networks."
-msgstr "No és recomanable en xarxes públiques sense confiança."
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "Proveïdor"
-
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "Xarxa"
-
-#: ../panels/network/network-proxy.ui.h:1
-msgid "Network Proxy"
-msgstr "Servidor intermediari de xarxa"
-
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_HTTP Proxy"
-msgstr "Servidor intermediari d'_HTTP"
-
-#: ../panels/network/network-proxy.ui.h:6
-msgid "H_TTPS Proxy"
-msgstr "_Servidor intermediari d'HTTPS"
-
-#: ../panels/network/network-proxy.ui.h:7
-msgid "_FTP Proxy"
-msgstr "Servidor intermediari d'_FTP"
-
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_Socks Host"
-msgstr "_Servidor de sòcols"
-
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Ignore Hosts"
-msgstr "_Ignora els servidors"
-
-#: ../panels/network/network-proxy.ui.h:10
-msgid "HTTP proxy port"
-msgstr "Port del servidor intermediari d'HTTP"
-
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTPS proxy port"
-msgstr "Port del servidor intermediari d'HTTPS"
-
-#: ../panels/network/network-proxy.ui.h:12
-msgid "FTP proxy port"
-msgstr "Port del servidor intermediari d'FTP"
-
-#: ../panels/network/network-proxy.ui.h:13
-msgid "Socks proxy port"
-msgstr "Port del servidor intermediari de sòcols"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "_Configuration URL"
-msgstr "URL de _configuració"
-
-#: ../panels/network/network-simple.ui.h:2
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Apaga el dispositiu"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/network/network.ui.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1816
-msgid "Bluetooth"
-msgstr "Bluetooth"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Actiu"
 
-#: ../panels/network/network.ui.h:3
-msgid "Not set up"
-msgstr "No s'ha configurat"
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
 
-#: ../panels/network/network-vpn.ui.h:1
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Proveïdor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adreça IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Servidor intermediari de xarxa"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Servidor intermediari d'_HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "_Servidor intermediari d'HTTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Servidor intermediari d'_FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Servidor de sòcols"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignora els servidors"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Port del servidor intermediari d'HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Port del servidor intermediari d'HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Port del servidor intermediari d'FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Port del servidor intermediari de sòcols"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuració"
+
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "Desactiva la connexió VPN"
 
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "_Connecta automàticament"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "detalls"
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/sharing/sharing.ui.h:9
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "_Contrasenya"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "_Mostra la contrasenya"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr "Fes-la disponible a altres usuaris"
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "identitat"
-
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
-msgstr "_Adreces"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr "Només adreces automàtiques (DHCP)"
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr "Només enllaç local"
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr "Compartit amb altres ordinadors"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr "_Ignora les rutes obtingudes automàticament"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr "Adreça MAC _clonada"
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr "maquinari"
-
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "_Reinicia"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"Reinicia els paràmetres d'esta connexió als valors per defecte, però "
-"recorda-la com a connexió preferida."
-
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"Suprimeix totes les dades relacionades amb esta xarxa i no intentes "
-"connectar-t'hi automàticament."
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "reinicia"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "Maquinari"
-
-#: ../panels/network/network-wifi.ui.h:51
-msgctxt "tab"
-msgid "Reset"
-msgstr "Restableix"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr "Punt d'accés Wi-Fi"
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Desactiva-ho per connectar-se a una xarxa Wi-Fi"
-
-#: ../panels/network/network-wifi.ui.h:54
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Nom de la xarxa"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Connected Devices"
-msgstr "Dispositius connectats"
-
-#: ../panels/network/network-wifi.ui.h:56
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Tipus de seguretat"
 
-#: ../panels/network/network-wifi.ui.h:57
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/printers/new-printer-dialog.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Contrasenya"
 
-#: ../panels/network/network-wifi.ui.h:59
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Desactiva el Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "S'estan carregant les opcions…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Connecta't a una xarxa oculta…"
 
-#: ../panels/network/network-wifi.ui.h:61
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Activa el punt d'accés Wi-Fi…"
 
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Xarxes sense fil conegudes"
 
-#: ../panels/network/wifi.ui.h:1
-msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
-msgstr "Assegureu-vos que teniu un adaptador Wi-fi connectat i activat"
-
-#: ../panels/network/wifi.ui.h:2
-msgid "No Wi-Fi Adapter Found"
-msgstr "No s'ha trobat cap adaptador Wi-fi"
-
-#: ../panels/network/wifi.ui.h:3
-msgid "Airplane Mode"
-msgstr "Mode d'avió"
-
-#: ../panels/network/wifi.ui.h:4
-msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
-msgstr "Inhabilita Wi-Fi, Bluetooth i banda ampla mòbil"
-
-#: ../panels/network/wifi.ui.h:5
-msgid "Visible Networks"
-msgstr "Xarxes visibles"
-
-#: ../panels/network/wifi.ui.h:6
-msgid "NetworkManager needs to be running"
-msgstr "Cal que el NetworkManager estiga executant-se"
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:127
-msgid "Ad-hoc"
-msgstr "Ad hoc"
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Infrastructure"
-msgstr "Infraestructura"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:147 ../panels/network/panel-common.c:201
-msgid "Status unknown"
-msgstr "Estat desconegut"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:151
-msgid "Unmanaged"
-msgstr "No gestionat"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unavailable"
-msgstr "No disponible"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:165 ../panels/network/panel-common.c:207
-msgid "Connecting"
-msgstr "S'està connectant"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Authentication required"
-msgstr "Cal autenticació"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Connected"
-msgstr "Connectat"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:177
-msgid "Disconnecting"
-msgstr "S'està desconnectant"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:181 ../panels/network/panel-common.c:219
-msgid "Connection failed"
-msgstr "Ha fallat la connexió"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:227
-msgid "Status unknown (missing)"
-msgstr "Estat desconegut (falta)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223
-msgid "Not connected"
-msgstr "Sense connectar"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:248
-msgid "Configuration failed"
-msgstr "Ha fallat la configuració"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "IP configuration failed"
-msgstr "Ha fallat la configuració de la IP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration expired"
-msgstr "Ha caducat la configuració de la IP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "Secrets were required, but not provided"
-msgstr "Calen secrets, però no s'han proporcionat"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "802.1x supplicant disconnected"
-msgstr "S'ha desconnectat el suplicant de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant configuration failed"
-msgstr "Ha fallat la configuració del suplicant de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant failed"
-msgstr "Ha fallat el suplicant de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "El suplicant de 802.1x ha tardat massa en autenticar"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "PPP service failed to start"
-msgstr "No s'ha pogut iniciar el servei PPP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service disconnected"
-msgstr "S'ha desconnectat el servei PPP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP failed"
-msgstr "Ha fallat el PPP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "DHCP client failed to start"
-msgstr "No s'ha pogut iniciar el client DHCP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client error"
-msgstr "S'ha produït un error en el client DHCP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client failed"
-msgstr "Ha fallat el client DHCP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "Shared connection service failed to start"
-msgstr "No s'ha pogut iniciar el servei de connexió compartida"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed"
-msgstr "Ha fallat el servei de connexió compartida"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "AutoIP service failed to start"
-msgstr "No s'ha pogut iniciar el servei AutoIP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service error"
-msgstr "S'ha produït un error en el servei AutoIP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service failed"
-msgstr "Ha fallat el servei AutoIP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "Line busy"
-msgstr "Línia ocupada"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "No dial tone"
-msgstr "No hi ha to de trucada"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No carrier could be established"
-msgstr "No s'ha pogut establir cap portadora"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "Dialing request timed out"
-msgstr "Ha acabat el temps d'espera de la sol·licitud de trucada"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing attempt failed"
-msgstr "Ha fallat l'intent de trucada"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Modem initialization failed"
-msgstr "Ha fallat la inicialització del mòdem"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Failed to select the specified APN"
-msgstr "No s'ha pogut seleccionar l'APN especificat"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Not searching for networks"
-msgstr "No s'estan cercant xarxes"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Network registration denied"
-msgstr "S'ha denegat el registre a la xarxa"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration timed out"
-msgstr "Ha acabat el temps d'espera del registre de la xarxa"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Failed to register with the requested network"
-msgstr "Ha fallat el registre amb la xarxa sol·licitada"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "PIN check failed"
-msgstr "Ha fallat la comprovació del PIN"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "Firmware for the device may be missing"
-msgstr "Pot ser que falti el microprograma del dispositiu"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Connection disappeared"
-msgstr "Ha desaparegut la connexió"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Existing connection was assumed"
-msgstr "S'havia assumit una connexió existent"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Modem not found"
-msgstr "No s'ha trobat el mòdem"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Bluetooth connection failed"
-msgstr "Ha fallat la connexió Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "SIM Card not inserted"
-msgstr "No s'ha inserit la targeta SIM"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Pin required"
-msgstr "Cal el PIN de la SIM"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Puk required"
-msgstr "Cal el PUK de la SIM"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM wrong"
-msgstr "SIM incorrecta"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "Connection dependency failed"
-msgstr "Ha fallat la dependència de la connexió"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:433
-msgid "Firmware missing"
-msgstr "Falta el microprogramari"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:437
-msgid "Cable unplugged"
-msgstr "Cable desconnectat"
-
-#: ../panels/network/wireless-security/eap-method.c:57
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "s'ha produït un error no definit en la seguretat de 802.1X (wpa-eap)"
-
-#: ../panels/network/wireless-security/eap-method.c:233
-msgid "no file selected"
-msgstr "no s'ha seleccionat cap fitxer"
-
-#: ../panels/network/wireless-security/eap-method.c:264
-msgid "unspecified error validating eap-method file"
-msgstr "s'ha produït un error no especificat en validar el fitxer eap-method"
-
-#: ../panels/network/wireless-security/eap-method.c:439
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "Claus privades DER, PEM o PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: ../panels/network/wireless-security/eap-method.c:442
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Certificats DER o PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:72
-msgid "missing EAP-FAST PAC file"
-msgstr "falta el fitxer EAP-FAST PAC"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:268
-#: ../panels/network/wireless-security/eap-method-peap.c:302
-#: ../panels/network/wireless-security/eap-method-ttls.c:351
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:283
-#: ../panels/network/wireless-security/eap-method-peap.c:272
-#: ../panels/network/wireless-security/eap-method-ttls.c:289
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:406
-msgid "Choose a PAC file"
-msgstr "Trieu un fitxer PAC"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:413
-msgid "PAC files (*.pac)"
-msgstr "Fitxers PAC (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "Anònim"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "S'ha autenticat"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "Ambdós"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identitat _anònima"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "_Fitxer PAC"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Trieu un fitxer PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "Autenticació _interna"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr "_Permet la provisió automàtica PAC"
 
-#: ../panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "falta el nom d'usuari EAP-LEAP"
-
-#: ../panels/network/wireless-security/eap-method-leap.c:74
-msgid "missing EAP-LEAP password"
-msgstr "falta la contrasenya EAP-LEAP"
-
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "Nom d'_usuari"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:7
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Contrasenya"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Mostra la contrasenya"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:63
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "certificat CA EAP-PEAP no vàlid: %s"
-
-#: ../panels/network/wireless-security/eap-method-peap.c:68
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "certificat CA EAP-PEAP no vàlid: no s'ha especificat un certificat"
-
-#: ../panels/network/wireless-security/eap-method-peap.c:287
-#: ../panels/network/wireless-security/eap-method-ttls.c:336
-#: ../panels/network/wireless-security/wireless-security.c:441
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:381
-#: ../panels/network/wireless-security/eap-method-tls.c:501
-#: ../panels/network/wireless-security/eap-method-ttls.c:430
-msgid "Choose a Certificate Authority certificate"
-msgstr "Trieu un certificat d'una autoritat de certificació"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "Versió 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "Versió 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "Certificat C_A"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Trieu un certificat d'una autoritat de certificació"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "_No es requereix un certificat CA"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versió PEAP"
 
-#: ../panels/network/wireless-security/eap-method-simple.c:74
-msgid "missing EAP username"
-msgstr "falta el nom d'usuari EAP"
-
-#: ../panels/network/wireless-security/eap-method-simple.c:87
-msgid "missing EAP password"
-msgstr "falta la contrasenya EAP"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:68
-msgid "missing EAP-TLS identity"
-msgstr "falta la identitat EAP-TLS"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:77
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "certificat CA EAP-TLS invàlid: %s"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:84
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TLS invàlid: no s'ha especificat un certificat"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:95
-msgid "invalid EAP-TLS password: missing"
-msgstr "contrasenya EAP-TLS invàlida: falta la contrasenya"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:109
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "clau privada EAP-TLS no vàlida: %s"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:119
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificat d'usuari EAP-TLS no vàlid: %s"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:316
-msgid "Unencrypted private keys are insecure"
-msgstr "Les claus privades sense encriptar no són segures"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:319
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"La clau privada que heu seleccionat no pareix protegida amb una contrasenya. "
-"Això podria permetre que les credencials de seguretat fossin compromeses. "
-"Seleccioneu una clau privada protegida per contrasenya.\n"
-"\n"
-"(Podeu protegir la vostra clau privada amb una contrasenya amb l'openssl)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:495
-msgid "Choose your personal certificate"
-msgstr "Trieu el vostre certificat personal"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:507
-msgid "Choose your private key"
-msgstr "Trieu la vostra clau privada"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "I_dentitat"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "Certificat d'_usuari"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "_Clau privada"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Contrasenya de clau _privada"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:63
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "certificat CA EAP-TTLS no vàlid: %s"
-
-#: ../panels/network/wireless-security/eap-method-ttls.c:68
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TTLS no vàlid: no s'ha especificat un certificat"
-
-#: ../panels/network/wireless-security/eap-method-ttls.c:259
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:274
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:305
+#: panels/network/wireless-security/eap-method-ttls.ui:25
 msgid "MSCHAPv2 (no EAP)"
 msgstr "MSCHAPv2 (sense EAP)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:321
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/wireless-security.c:87
-msgid "Unknown error validating 802.1X security"
-msgstr "S'ha produït un error desconegut en validar la seguretat de 802.1X"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domini"
 
-#: ../panels/network/wireless-security/wireless-security.c:453
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:477
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
 msgid "PWD"
 msgstr "PWD"
 
-#: ../panels/network/wireless-security/wireless-security.c:488
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:499
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "TLS a través de túnel"
 
-#: ../panels/network/wireless-security/wireless-security.c:510
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "EAP protegit (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Au_tenticació"
 
-#: ../panels/network/wireless-security/ws-leap.c:63
-msgid "missing leap-username"
-msgstr "falta el mom d'usuari LEAP"
-
-#: ../panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr "falta la contrasenya LEAP"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr "falta la clau wep"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"clau wep invàlida: una clau amb longitud %zu ha de contindre només dígits "
-"hexadecimals"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"clau wep invàlida: una clau amb longitud %zu ha de contindre només caràcters "
-"ascii"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"clau wep invàlida: la longitud de clau %zu és errònia. Una clau ha de tindre "
-"una longitud de 5/13 (ascii) o bé 10/26 (hex)"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "clau wep invàlida: la contrasenya no pot ser buida."
-
-#: ../panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "clau wep invàlida: la contrasenya ha de tindre menys de 64 caràcters"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (per defecte)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "Open System"
-msgstr "Sistema obert"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "Shared Key"
-msgstr "Clau compartida"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "_Key"
-msgstr "_Clau"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Sho_w key"
-msgstr "_Mostra la clau"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "WEP inde_x"
-msgstr "Índe_x WEP"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk no vàlid: longitud de clau %zu no vàlida. Ha de tindre [8,63] bytes o "
-"64 dígits hexadecimals"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk no vàlid: no es pot interpretar la clau de 64 bytes com a hexadecimal"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipus"
 
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (per defecte)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistema obert"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Clau compartida"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Clau"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Mostra la clau"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Índe_x WEP"
+
 #. This is the per application switch for message tray usage.
-#: ../panels/notifications/edit-dialog.ui.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "_Notificacions"
 
 #. This is the setting to configure sounds associated with notifications.
-#: ../panels/notifications/edit-dialog.ui.h:4
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "_Alertes sonores"
 
-#: ../panels/notifications/edit-dialog.ui.h:5
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "_Notificacions emergents"
 
-#: ../panels/notifications/edit-dialog.ui.h:6
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
@@ -3724,84 +2758,72 @@ msgstr ""
 "encara que inhabiliteu les notificacions emergents."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: ../panels/notifications/edit-dialog.ui.h:8
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "_Mostra el contingut de les notificacions emergents"
 
-#: ../panels/notifications/edit-dialog.ui.h:9
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "_Notificacions a la pantalla de bloqueig"
 
-#: ../panels/notifications/edit-dialog.ui.h:10
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "_Mostra el contingut dels missatges a la pantalla de bloqueig"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
-msgid "No­ti­fi­ca­tions"
-msgstr "Notificacions"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:3
-msgid "Control which notifications are displayed and what they show"
-msgstr "Controleu quines notificacions es mostren i què mostren"
-
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:5
-msgid "Notifications;Banner;Message;Tray;Popup;"
-msgstr "Notificacions;Bàner;Missatge;Safata;Emergent;"
-
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Notification _Popups"
-msgstr "_Notificacions emergents"
-
-#: ../panels/notifications/notifications.ui.h:2
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr "_Notificacions a la pantalla de bloqueig"
 
-#. List of applications.
-#: ../panels/notifications/notifications.ui.h:4
-#: ../panels/privacy/privacy.ui.h:45 ../panels/sound/gvc-mixer-dialog.c:1781
-msgid "Applications"
-msgstr "Aplicacions"
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controleu quines notificacions es mostren i què mostren"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:148
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Altres"
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notificacions;Bàner;Missatge;Safata;Emergent;"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: ../panels/online-accounts/cc-online-accounts-panel.c:603
-#, c-format
-msgid "%s Account"
-msgstr "Compte de %s"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Desfés"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:895
-msgid "Error removing account"
-msgstr "S'ha produït un error en suprimir el compte"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "_Autenticació interna"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: ../panels/online-accounts/cc-online-accounts-panel.c:960
-#, c-format
-msgid "<b>%s</b> removed"
-msgstr "<b>%s</b> s'ha suprimit"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Connecteu-vos a les vostres dades al núvol"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "On­line Accounts"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"No hi ha connexió a Internet. Connecteu-vos per configurar nous comptes en "
+"línia."
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Afig un compte"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Online Accounts"
 msgstr "Comptes en línia"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Connecteu-vos als comptes en línia i decidiu quin ús en voleu fer"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:5
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -3809,1575 +2831,868 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;En línia;Xat;Calendari;Correu;Contacte;"
 "ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: ../panels/online-accounts/online-accounts.ui.h:1
-#: ../panels/printers/printers.ui.h:4
-msgid "Undo"
-msgstr "Desfés"
-
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Connect to your data in the cloud"
-msgstr "Connecteu-vos a les vostres dades al núvol"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "No internet connection — connect to set up new online accounts"
-msgstr ""
-"No hi ha connexió a Internet. Connecteu-vos per configurar nous comptes en "
-"línia."
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an account"
-msgstr "Afig un compte"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid "Remove Account"
-msgstr "Suprimeix el compte"
-
-#: ../panels/power/cc-power-panel.c:253
-msgid "Unknown time"
-msgstr "Temps desconegut"
-
-#: ../panels/power/cc-power-panel.c:259
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i minut"
 msgstr[1] "%i minuts"
 
-#: ../panels/power/cc-power-panel.c:271
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i hora"
 msgstr[1] "%i hores"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:279
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:280
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "hora"
 msgstr[1] "hores"
 
-#: ../panels/power/cc-power-panel.c:281
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
 msgstr[1] "minuts"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:300
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s fins que es carregi del tot"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minuts"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:307
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Atenció: queden %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 minuts"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:312
-#, c-format
-msgid "%s remaining"
-msgstr "Queden %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 minuts"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:317 ../panels/power/cc-power-panel.c:345
-msgid "Fully charged"
-msgstr "Totalment carregada"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minuts"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:321 ../panels/power/cc-power-panel.c:349
-msgid "Empty"
-msgstr "Buida"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minuts"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:336
-msgid "Charging"
-msgstr "S'està carregant"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hora"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:341
-msgid "Discharging"
-msgstr "S'està descarregant"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minuts"
 
-#: ../panels/power/cc-power-panel.c:464
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principal"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minuts"
 
-#: ../panels/power/cc-power-panel.c:466
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Addicional"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minuts"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:537
-msgid "Wireless mouse"
-msgstr "Ratolí sense fil"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 hores"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgid "Wireless keyboard"
-msgstr "Teclat sense fil"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:543
-msgid "Uninterruptible power supply"
-msgstr "Sistema d'alimentació ininterrompuda"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:546
-msgid "Personal digital assistant"
-msgstr "Auxiliar digital personal"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:549
-msgid "Cellphone"
-msgstr "Telèfon mòbil"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgid "Media player"
-msgstr "Reproductor multimèdia"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:555 ../panels/wacom/cc-wacom-panel.c:793
-msgid "Tablet"
-msgstr "Tauleta gràfica"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:558
-msgid "Computer"
-msgstr "Ordinador"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:561 ../panels/power/cc-power-panel.c:801
-#: ../panels/power/cc-power-panel.c:2356
+#: panels/power/cc-power-panel.ui:58
 msgid "Battery"
 msgstr "Bateria"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:615
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "S'està carregant"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:622
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Precaució"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:627
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Baixa"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:632
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Bona"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:637
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Totalment carregada"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:641
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Buida"
-
-#: ../panels/power/cc-power-panel.c:799
-msgid "Batteries"
-msgstr "Bateries"
-
-#: ../panels/power/cc-power-panel.c:1227
-msgid "When _idle"
-msgstr "Quan estiga _inactiu"
-
-#: ../panels/power/cc-power-panel.c:1681
-msgid "Power Saving"
-msgstr "Estalvi d'energia"
-
-#: ../panels/power/cc-power-panel.c:1712
-msgid "_Screen brightness"
-msgstr "Brillantor de la _pantalla"
-
-#: ../panels/power/cc-power-panel.c:1731
-msgid "Automatic brightness"
-msgstr "Brillantor automàtica"
-
-#: ../panels/power/cc-power-panel.c:1751
-msgid "_Keyboard brightness"
-msgstr "Brillantor del _teclat"
-
-#: ../panels/power/cc-power-panel.c:1761
-msgid "_Dim screen when inactive"
-msgstr "_Atenua la pantalla quan estiga inactiva"
-
-#: ../panels/power/cc-power-panel.c:1786
-msgid "_Blank screen"
-msgstr "Pantalla en _blanc"
-
-#: ../panels/power/cc-power-panel.c:1823
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: ../panels/power/cc-power-panel.c:1828
-msgid "Turn off Wi-Fi to save power."
-msgstr "Desactiveu la Wifi per estalviar energia."
-
-#: ../panels/power/cc-power-panel.c:1853
-msgid "_Mobile broadband"
-msgstr "Banda ampla _mòbil"
-
-#: ../panels/power/cc-power-panel.c:1858
-msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
-msgstr ""
-"Desactiveu la banda ampla mòbil (3G, 4G, WiMax, etc.) per estalviar energia."
-
-#: ../panels/power/cc-power-panel.c:1903
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: ../panels/power/cc-power-panel.c:1966
-msgid "When on battery power"
-msgstr "Quan s'utilitze la bateria"
-
-#: ../panels/power/cc-power-panel.c:1968
-msgid "When plugged in"
-msgstr "Quan estiga endollat"
-
-#: ../panels/power/cc-power-panel.c:2063
-msgid "Suspend"
-msgstr "Atura temporalment"
-
-#: ../panels/power/cc-power-panel.c:2064
-msgid "Power Off"
-msgstr "Apaga"
-
-#: ../panels/power/cc-power-panel.c:2065
-msgid "Hibernate"
-msgstr "Hiberna"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Nothing"
-msgstr "Res"
-
-#. Frame header
-#: ../panels/power/cc-power-panel.c:2180
-msgid "Suspend & Power Button"
-msgstr "Botó d'aturada temporal i d'engegada"
-
-#: ../panels/power/cc-power-panel.c:2219
-msgid "_Automatic suspend"
-msgstr "_Aturada temporal automàtica"
-
-#: ../panels/power/cc-power-panel.c:2220
-msgid "Automatic suspend"
-msgstr "Aturada temporal automàtica"
-
-#: ../panels/power/cc-power-panel.c:2287
-msgid "_When the Power Button is pressed"
-msgstr "_Quan es prem el botó d'engegada"
-
-#: ../panels/power/cc-power-panel.c:2406 ../shell/cc-window.c:247
-#: ../shell/panel-list.ui.h:1
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
 msgid "Devices"
 msgstr "Dispositius"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Po­wer"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Apaga"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Estalvi d'energia"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Brillantor automàtica"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Pantalla"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Lector de _pantalla"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "_Informa de problemes automàticament"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Atura temporalment automàticament"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Botó inferior"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Atura temporalment automàticament"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Endollat"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Quan s'utilitza la _bateria"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Retard"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
 msgstr "Energia"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:3
+#: panels/power/gnome-power-panel.desktop.in.in:4
 msgid "View your battery status and change power saving settings"
 msgstr ""
 "Visualitzeu l'estat de la bateria i canvieu els paràmetres d'estalvi "
 "d'energia"
 
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:5
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "Energia;Baix consum;Aturada temporal;Hibernació;Bateria;Brillantor;Atenuar;"
 "En blanc;Monitor;DPMS;Inactiu;"
 
-#: ../panels/power/power.ui.h:3
-msgid "45 minutes"
-msgstr "45 minuts"
-
-#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
-msgid "1 hour"
-msgstr "1 hora"
-
-#: ../panels/power/power.ui.h:5
-msgid "80 minutes"
-msgstr "80 minuts"
-
-#: ../panels/power/power.ui.h:6
-msgid "90 minutes"
-msgstr "90 minuts"
-
-#: ../panels/power/power.ui.h:7
-msgid "100 minutes"
-msgstr "100 minuts"
-
-#: ../panels/power/power.ui.h:8
-msgid "2 hours"
-msgstr "2 hores"
-
-#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 minut"
-
-#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 minuts"
-
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 minuts"
-
-#: ../panels/power/power.ui.h:12
-msgid "4 minutes"
-msgstr "4 minuts"
-
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 minuts"
-
-#: ../panels/power/power.ui.h:14
-msgid "8 minutes"
-msgstr "8 minuts"
-
-#: ../panels/power/power.ui.h:15
-msgid "10 minutes"
-msgstr "10 minuts"
-
-#: ../panels/power/power.ui.h:16
-msgid "12 minutes"
-msgstr "12 minuts"
-
-#: ../panels/power/power.ui.h:18
-msgid "Automatic Suspend"
-msgstr "Atura temporalment automàticament"
-
-#: ../panels/power/power.ui.h:19
-msgid "_Plugged In"
-msgstr "_Endollat"
-
-#: ../panels/power/power.ui.h:20
-msgid "On _Battery Power"
-msgstr "Quan s'utilitza la _bateria"
-
-#: ../panels/power/power.ui.h:21 ../panels/universal-access/uap.ui.h:36
-msgid "Delay"
-msgstr "Retard"
-
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "Autenticació"
-
-#: ../panels/printers/authentication-dialog.ui.h:4
-#: ../panels/printers/new-printer-dialog.ui.h:13
-msgid "Username"
-msgstr "Nom d'usuari"
-
-#: ../panels/printers/authentication-dialog.ui.h:6
-#: ../panels/printers/new-printer-dialog.ui.h:11
-msgid "Authentication Required"
-msgstr "Cal autenticació"
-
-#. Translators: %s is the printer name
-#: ../panels/printers/cc-printers-panel.c:718
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "S'ha suprimit la impressora «%s»"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:909
-msgid "Failed to add new printer."
-msgstr "No s'ha pogut afegir una impressora nova."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:1221
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "No s'ha pogut carregar la interfície d'usuari: %s"
-
-#: ../panels/printers/details-dialog.ui.h:2
-#: ../panels/printers/printer-entry.ui.h:9
-msgid "Location"
-msgstr "Ubicació:"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/details-dialog.ui.h:4
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "Controlador"
-
-#: ../panels/printers/details-dialog.ui.h:5
-msgid "Searching for preferred drivers…"
-msgstr "S'estan cercant els controladors preferits…"
-
-#: ../panels/printers/details-dialog.ui.h:6
-msgid "Search for Drivers"
-msgstr "Busca controladors"
-
-#: ../panels/printers/details-dialog.ui.h:7
-msgid "Select from Database…"
-msgstr "Seleccioneu de la base de dades…"
-
-#: ../panels/printers/details-dialog.ui.h:8
-msgid "Install PPD File…"
-msgstr "Instal·la un fitxer PPD..."
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
-msgid "Prin­ters"
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
 msgstr "Impressores"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Afegiu impressores, visualitzeu tasques d'impressió i decidiu com voleu "
 "imprimir"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:5
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Impressora;Cua;Imprimir;Paper;Tinta;Tòner;"
 
-#. Translators: this action removes (purges) all the listed jobs from the list.
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Clear All"
-msgstr "Neteja-ho tot"
-
-#. Translators: this label describes the dialog empty state, with no jobs listed.
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "No Active Printer Jobs"
-msgstr "No hi ha tasques d'impressió actives"
-
 #. Translators: This is the title presented at top of the dialog.
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/printers/pp-new-printer-dialog.c:384
-#: ../panels/printers/pp-new-printer-dialog.c:456
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Afig una impressora"
 
+#. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:6
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "Desbloq_ueja"
 
 #. Translators: No printers were detected
-#: ../panels/printers/new-printer-dialog.ui.h:8
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "No s'ha trobat cap impressora"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:10
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Introduïu una adreça de xarxa o cerqueu una impressora"
 
-#: ../panels/printers/new-printer-dialog.ui.h:12
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Cal autenticació"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Introduïu el nom d'usuari i la contrasenya per visualitzar les impressores "
 "al servidor d'impressió."
 
-#. Translators: This button triggers the printing of a test page.
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/options-dialog.ui.h:2
-#: ../panels/printers/pp-options-dialog.c:893
-msgid "Test Page"
-msgstr "Pàgina de prova"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nom d'usuari"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: ../panels/printers/pp-details-dialog.c:123
-#: ../panels/printers/pp-details-dialog.c:415
-#, c-format
-msgid "%s Details"
-msgstr "Detalls %s"
-
-#: ../panels/printers/pp-details-dialog.c:172
-msgid "No suitable driver found"
-msgstr "No s'ha trobat cap controlador adequat"
-
-#: ../panels/printers/pp-details-dialog.c:316
-msgid "Select PPD File"
-msgstr "Selecció d'un fitxer PPD"
-
-#: ../panels/printers/pp-details-dialog.c:325
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"Fitxers de descripció d'impressora PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD."
-"gz, *.PPD.GZ)"
 
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Ubicació:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Controlador"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "S'estan cercant els controladors preferits…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Busca controladors"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Seleccioneu de la base de dades…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instal·la un fitxer PPD..."
+
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "Seleccioneu un controlador d'impressora"
 
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:96
-msgid "Select"
-msgstr "Selecciona"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
+#: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "S'està carregant la base de dades de controladors..."
 
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:539
-msgid "JetDirect Printer"
-msgstr "Impressora JetDirect"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Cancel·la"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:795
-msgid "LPD Printer"
-msgstr "Impressora LPD"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Selecciona"
 
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "Una cara"
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "El servidor requereix autenticació"
+msgstr[1] "El servidor requereix autenticació"
 
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "Cantó llarg (estàndard)"
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "_Domini"
 
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "Cantó curt (capgirat)"
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utentica"
 
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "Vertical"
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Neteja-ho tot"
 
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "Apaïsat"
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Autenticació"
 
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "Apaïsat del revés"
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "No hi ha tasques d'impressió actives"
 
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "Vertical del revés"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:104
-msgctxt "print job"
-msgid "Pending"
-msgstr "Pendent"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:108
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pausat"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:112
-msgctxt "print job"
-msgid "Processing"
-msgstr "S'està processant"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:116
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Aturada"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:120
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Cancel·lada"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:124
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Interrompuda"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:128
-msgctxt "print job"
-msgid "Completed"
-msgstr "Completada"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: ../panels/printers/pp-jobs-dialog.c:310
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - tasques actives"
-
-#: ../panels/printers/pp-new-printer-dialog.c:402
-msgid "Unlock Print Server"
-msgstr "Desbloqueja el servidor d'impressió"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-new-printer-dialog.c:406
-#, c-format
-msgid "Unlock %s."
-msgstr "Desbloqueja %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-new-printer-dialog.c:411
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Introduïu el nom d'usuari i la contrasenya per visualitzar les impressores a "
-"%s."
-
-#: ../panels/printers/pp-new-printer-dialog.c:876
-msgid "Searching for Printers"
-msgstr "S'estan cercant les impressores"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1799
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1804
-msgid "Serial Port"
-msgstr "Port en sèrie"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1811
-msgid "Parallel Port"
-msgstr "Port paral·lel"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1853
-#, c-format
-msgid "Location: %s"
-msgstr "Ubicació: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1858
-#, c-format
-msgid "Address: %s"
-msgstr "Adreça: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1887
-msgid "Server requires authentication"
-msgstr "El servidor requereix autenticació"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Two Sided"
-msgstr "Doble cara"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Paper Type"
-msgstr "Tipus de paper"
-
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Paper Source"
-msgstr "Font del paper"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "Output Tray"
-msgstr "Safata d'eixida"
-
-#: ../panels/printers/pp-options-dialog.c:88
-msgid "GhostScript pre-filtering"
-msgstr "Filtrat previ del GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:534
-msgid "Pages per side"
-msgstr "Pàgines per cara"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:546
-msgid "Two-sided"
-msgstr "Doble cara"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "General"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Configuració de la pàgina"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opcions instal·lables"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Tasca"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Qualitat de la imatge"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Color"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Acabats"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:676
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avançat"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/pp-options-dialog.c:908
-msgid "Test page"
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
 msgstr "Pàgina de prova"
 
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "Selecció automàtica"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "Per defecte de la impressora"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "Incrusta només tipus de lletra del GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "Converteix a PS nivell 1"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "Converteix a PS nivell 2"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "Sense filtrat previ"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "Fabricant"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: ../panels/printers/pp-printer-entry.c:577
-msgid "No Active Jobs"
-msgstr "No hi ha tasques actives"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: ../panels/printers/pp-printer-entry.c:582
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u tasca"
 msgstr[1] "%u tasques"
 
-#. Translators: The printer is low on toner
-#: ../panels/printers/pp-printer-entry.c:730
-msgid "Low on toner"
-msgstr "Tòner baix"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/pp-printer-entry.c:732
-msgid "Out of toner"
-msgstr "Sense tòner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/pp-printer-entry.c:735
-msgid "Low on developer"
-msgstr "Revelador baix"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/pp-printer-entry.c:738
-msgid "Out of developer"
-msgstr "Sense revelador"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/pp-printer-entry.c:740
-msgid "Low on a marker supply"
-msgstr "Marcador baix"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/pp-printer-entry.c:742
-msgid "Out of a marker supply"
-msgstr "Sense marcador"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/pp-printer-entry.c:744
-msgid "Open cover"
-msgstr "Tapa oberta"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/pp-printer-entry.c:746
-msgid "Open door"
-msgstr "Porta oberta"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/pp-printer-entry.c:748
-msgid "Low on paper"
-msgstr "Paper baix"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/pp-printer-entry.c:750
-msgid "Out of paper"
-msgstr "Sense paper"
-
-#. Translators: The printer is offline
-#: ../panels/printers/pp-printer-entry.c:752
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Apagada"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/pp-printer-entry.c:754
-#: ../panels/printers/pp-printer-entry.c:884
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Aturada"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/pp-printer-entry.c:756
-msgid "Waste receptacle almost full"
-msgstr "El receptacle de residus està quasi ple"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/pp-printer-entry.c:758
-msgid "Waste receptacle full"
-msgstr "El receptacle de residus està ple"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/pp-printer-entry.c:760
-msgid "The optical photo conductor is near end of life"
-msgstr "El conductor òptic fotogràfic està al final de la seua vida"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/pp-printer-entry.c:762
-msgid "The optical photo conductor is no longer functioning"
-msgstr "El conductor òptic fotogràfic ja no funciona"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/pp-printer-entry.c:870
-msgctxt "printer state"
-msgid "Ready"
-msgstr "A punt"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/pp-printer-entry.c:875
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "No accepta tasques"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/pp-printer-entry.c:880
-msgctxt "printer state"
-msgid "Processing"
-msgstr "S'està processant"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: ../panels/printers/pp-printer-entry.c:904
-msgid "Clean print heads"
-msgstr "Neteja els capçals d'impressió"
-
-#: ../panels/printers/printer-entry.ui.h:1
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "Opcions d'impressió"
 
-#: ../panels/printers/printer-entry.ui.h:2
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "Detalls de la impressora"
 
 #. Set this printer as default
-#: ../panels/printers/printer-entry.ui.h:4
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "Utilitza la impressora per defecte"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: ../panels/printers/printer-entry.ui.h:6
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "Neteja els capçals d'impressió"
 
-#: ../panels/printers/printer-entry.ui.h:7
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Suprimeix la impressora"
 
-#: ../panels/printers/printer-entry.ui.h:8
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "No hi ha tasques actives"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: ../panels/printers/printer-entry.ui.h:10
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Nivell de tinta"
 
 #. Translators: This is the message which follows the printer error.
-#: ../panels/printers/printer-entry.ui.h:12
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Reinicieu quan el problema estiga resolt."
 
 #. Translators: This is the button which restarts the printer.
-#: ../panels/printers/printer-entry.ui.h:14
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Torna a iniciar"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:2
-msgid "Add…"
-msgstr "Afig..."
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Afig una impressora..."
 
-#: ../panels/printers/printers.ui.h:5
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Afig una impressora..."
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Sense impressores"
 
-#. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:7
-msgid "Add a Printer…"
-msgstr "Afig una impressora..."
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:9
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Perdó! Pareix que el servei d'impressió\n"
 "del sistema no està disponible."
 
-#: ../panels/privacy/cc-privacy-panel.c:387 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "Bloca la pantalla"
-
-#: ../panels/privacy/cc-privacy-panel.c:438
-msgid "In use"
-msgstr "En ús"
-
-#: ../panels/privacy/cc-privacy-panel.c:443
-msgctxt "Location services status"
-msgid "On"
-msgstr "Activat"
-
-#: ../panels/privacy/cc-privacy-panel.c:444
-msgctxt "Location services status"
-msgid "Off"
-msgstr "Desactivat"
-
-#: ../panels/privacy/cc-privacy-panel.c:823 ../panels/privacy/privacy.ui.h:42
-msgid "Location Services"
-msgstr "Serveis d'ubicació"
-
-#: ../panels/privacy/cc-privacy-panel.c:942 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "Ús i historial"
-
-#: ../panels/privacy/cc-privacy-panel.c:1071
-msgid "Empty all items from Trash?"
-msgstr "Voleu buidar la paperera?"
-
-#: ../panels/privacy/cc-privacy-panel.c:1072
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Se suprimiran permanent tots els elements de la paperera."
-
-#: ../panels/privacy/cc-privacy-panel.c:1073
-msgid "_Empty Trash"
-msgstr "_Buida la paperera"
-
-#: ../panels/privacy/cc-privacy-panel.c:1096
-msgid "Delete all the temporary files?"
-msgstr "Voleu suprimir tots fitxers temporals?"
-
-#: ../panels/privacy/cc-privacy-panel.c:1097
-msgid "All the temporary files will be permanently deleted."
-msgstr "Se suprimiran permanent tots els fitxers temporals."
-
-#: ../panels/privacy/cc-privacy-panel.c:1098
-msgid "_Purge Temporary Files"
-msgstr "Suprimeix els fitxers _temporals"
-
-#: ../panels/privacy/cc-privacy-panel.c:1120 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "Buida la paperera i els fitxers temporals"
-
-#: ../panels/privacy/cc-privacy-panel.c:1160 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr "Ús de programari"
-
-#: ../panels/privacy/cc-privacy-panel.c:1201 ../panels/privacy/privacy.ui.h:46
-msgid "Problem Reporting"
-msgstr "Informa de problemes"
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: ../panels/privacy/cc-privacy-panel.c:1215
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-"Enviar informes de problemes tècnics ajuda a millorar %s. Els informes "
-"s'envien anònimament i sense dades personals."
-
-#: ../panels/privacy/cc-privacy-panel.c:1227 ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "Política de privacitat"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Pri­va­cy"
-msgstr "Privadesa"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:3
-msgid "Protect your personal information and control what others might see"
-msgstr "Protegiu la informació personal i controleu què poden veure els altres"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:5
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"pantalla;bloca;diagnòstics;fallades;privat;recent;temporal;tmp;índex;nom;"
-"xarxa;identitat;"
-
-# N.T.: En minúscula ja que s'afegeix visualment a una altre cadena
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "s'apaga la pantalla"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 segons"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 dia"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 dies"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 dies"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 dies"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 dies"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 dies"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 dies"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 dies"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 dies"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "Per sempre"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"Si es recorda l'historial, és més fàcil tornar a trobar les coses. Estos "
-"elements no es comparteixen mai a la xarxa."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "Utilitzat _recentment"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "Conserva l'_historial"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "_Neteja l'historial recent"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr ""
-"El bloqueig de la pantalla protegeix la vostra privacitat quan no hi sou."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "_Bloca la pantalla automàticament"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "_Bloca la pantalla després d'estar en blanc durant"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "Mostra les _notificacions"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"Buideu automàticament la paperera i els fitxers temporals per ajudar a "
-"mantindre l'ordinador lliure d'informació sensible innecessària."
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "Buida automàticament la _paperera"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "Suprimeix automàticament els _fitxers temporals"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "Suprimeix _després de"
-
-#: ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash…"
-msgstr "_Buida la paperera..."
-
-#: ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files…"
-msgstr "Suprimeix els fitxers _temporals..."
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"L'enviament d'informació sobre el programari que feu servir ens ajuda a "
-"donar-vos recomanacions més adequades. Això també ens ajuda a millorar el "
-"nostre programari.\n"
-"\n"
-"Tota la informació recollida és anònima i mai no compartirem les vostres "
-"dades amb terceres parts."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "Envia e_stadístiques d'ús de programari"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"Els serveis d'ubicació permeten que les aplicacions puguen saber on sou. "
-"L'ús de Wi-Fi i de dades mòbils permet millorar la precisió."
-
-#: ../panels/privacy/privacy.ui.h:44
-msgid "_Location Services"
-msgstr "Serveis d'_ubicació"
-
-#: ../panels/privacy/privacy.ui.h:47
-msgid "_Automatic Problem Reporting"
-msgstr "_Informa de problemes automàticament"
-
-#: ../panels/region/cc-format-chooser.c:118
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: ../panels/region/cc-format-chooser.c:120
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Mètric"
-
-#: ../panels/region/cc-format-chooser.c:285
-msgid "No regions found"
-msgstr "No s'han trobat regions"
-
-#: ../panels/region/cc-input-chooser.c:182
-msgid "No input sources found"
-msgstr "No s'han trobat fonts d'entrada"
-
-#: ../panels/region/cc-input-chooser.c:1012
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Altres"
-
-#: ../panels/region/cc-region-panel.c:881
-msgid "No input source selected"
-msgstr "No s'ha seleccionat cap font d'entrada"
-
-#: ../panels/region/cc-region-panel.c:1773
-msgid "Login _Screen"
-msgstr "_Pantalla d'entrada"
-
-#: ../panels/region/format-chooser.ui.h:1
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formats"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Ubicacions de busca"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Formats"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Formats"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "No s'ha trobat cap resultat."
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Visualització prèvia"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Dates"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "Hores"
-
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "Dates i hores"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Nombres"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Mesura"
 
-#: ../panels/region/format-chooser.ui.h:10
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Paper"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid "Re­gion & Lan­guage"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "El vostre compte"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Idioma"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr "_Formats"
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "_Pantalla d'entrada"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+#, fuzzy
+msgid "Region & Language"
 msgstr "Regió i idioma"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr ""
 "Seleccioneu l'idioma a mostrar, els formats, les disposicions de teclat i "
 "les fonts d'entrada"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:5
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Disposició;Teclat;Entrada;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "Afig una font d'entrada"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Seleccioneu com s'han de gestionar els suports"
 
-#: ../panels/region/input-chooser.ui.h:4
-msgid "Input methods can’t be used on the login screen"
-msgstr "Els mètodes d'entrada no es poden utilitzar a la pantalla d'entrada"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_CD d'àudio"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "Opcions de la font d'entrada"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD de vídeo"
 
-#: ../panels/region/input-options.ui.h:2
-msgid "Use the _same source for all windows"
-msgstr "Utilitza la _mateixa font a totes les finestres"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Reproductor de _música"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Allow _different sources for each window"
-msgstr "Permet fonts _diferents per a cada finestra"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Programari"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Switch to previous source"
-msgstr "Commuta a la font anterior"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Altres suports…"
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Super+Shift+Space"
-msgstr "Súper+Maj+Espai"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_No preguntes mai ni inicies programes quan s'inserisquen suports"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Switch to next source"
-msgstr "Commuta a la font següent"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Seleccioneu com s'han de gestionar els altres suports"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Super+Space"
-msgstr "Súper+Espai"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Acció:"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "Podeu canviar estes dreceres als paràmetres del teclat"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipus:"
 
-#: ../panels/region/input-options.ui.h:10
-msgid "Alternative switch to next source"
-msgstr "Forma alternativa per canviar a la font següent"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Suport extraïble"
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Left+Right Alt"
-msgstr "Alt dreta i esquerra"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configura els paràmetres del suport extraïble"
 
-#: ../panels/region/region.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "_Idioma"
-
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "Anglés (Regne Unit)"
-
-#: ../panels/region/region.ui.h:3
-msgid "Restart the session for changes to take effect"
-msgstr "Cal que reinicieu la sessió perquè els canvis tinguen efecte."
-
-#: ../panels/region/region.ui.h:4
-msgid "Restart…"
-msgstr "Reinicia…"
-
-#: ../panels/region/region.ui.h:5
-msgid "_Formats"
-msgstr "_Formats"
-
-#: ../panels/region/region.ui.h:6
-msgid "United Kingdom"
-msgstr "Regne Unit"
-
-#: ../panels/region/region.ui.h:7
-msgid "Input Sources"
-msgstr "Fonts d'entrada"
-
-#: ../panels/region/region.ui.h:8
-msgid "_Options"
-msgstr "_Opcions"
-
-#: ../panels/region/region.ui.h:9
-msgid "Add input source"
-msgstr "Afig una font d'entrada"
-
-#: ../panels/region/region.ui.h:10
-msgid "Remove input source"
-msgstr "Suprimeix una font d'entrada"
-
-#: ../panels/region/region.ui.h:11
-msgid "Move input source up"
-msgstr "Mou la font d'entrada amunt"
-
-#: ../panels/region/region.ui.h:12
-msgid "Move input source down"
-msgstr "Mou la font d'entrada avall"
-
-#: ../panels/region/region.ui.h:13
-msgid "Configure input source"
-msgstr "Configura la font d'entrada"
-
-#: ../panels/region/region.ui.h:14
-msgid "Show input source keyboard layout"
-msgstr "Mostra la disposició del teclat de la font d'entrada"
-
-#: ../panels/region/region.ui.h:15
-msgid "Login settings are used by all users when logging into the system"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"Tots els usuaris utilitzen els paràmetres d'entrada en entrar al sistema"
+"dispositiu;sistema;informació;per defecte;aplicació;preferit;cd;dvd;usb;"
+"àudio;vídeo;disc;extraïble;multimèdia;execució automàtica;"
 
-#: ../panels/search/cc-search-locations-dialog.c:639
-msgid "Select Location"
-msgstr "Seleccioneu una ubicació"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Bloca la pantalla"
 
-#: ../panels/search/cc-search-locations-dialog.c:643
-msgid "_OK"
-msgstr "_D'acord"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
 
-#: ../panels/search/cc-search-panel.c:178
-msgid "No applications found"
-msgstr "No s'han trobat aplicacions"
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "Pantalla en _blanc"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
-msgid "Search"
-msgstr "Busca"
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:3
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Bloca la pantalla automàticament"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Bloca la pantalla automàticament"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Mostra les _notificacions"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Pantalla de bloqueig"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Privacitat"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantalla"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Compartició de pantalla"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Ubicacions de busca"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Llocs"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Adreces d'interés"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Altres"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Ubicació:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Aplicacions"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Ubicacions de busca"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 "Controleu quines aplicacions mostren resultats de busca a la vista general "
 "d'activitats"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:5
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Busca;Troba;Índex;Oculta;Privacitat;Resultats;"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr "Ubicacions de busca"
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Xarxes"
 
-#: ../panels/search/search-locations-dialog.ui.h:2
-msgid "Places"
-msgstr "Llocs"
-
-#: ../panels/search/search-locations-dialog.ui.h:3
-msgid "Bookmarks"
-msgstr "Adreces d'interés"
-
-#: ../panels/search/search-locations-dialog.ui.h:4
-msgid "Other"
-msgstr "Altres"
-
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "Mou amunt"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "Mou avall"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "Preferències"
-
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:303
-msgid "No networks selected for sharing"
-msgstr "No hi ha cap xarxa seleccionada per compartir"
-
-#: ../panels/sharing/cc-sharing-panel.c:273
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Activat"
-
-#: ../panels/sharing/cc-sharing-panel.c:275
-#: ../panels/sharing/cc-sharing-panel.c:302
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Desactivat"
-
-#: ../panels/sharing/cc-sharing-panel.c:305
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Habilitat"
-
-#: ../panels/sharing/cc-sharing-panel.c:308
-msgctxt "service is active"
-msgid "Active"
-msgstr "Actiu"
-
-#: ../panels/sharing/cc-sharing-panel.c:379
-msgid "Choose a Folder"
-msgstr "Trieu una carpeta"
-
-#: ../panels/sharing/cc-sharing-panel.c:690
-#, c-format
-msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr ""
-"La compartició de fitxers personals vos permet compartir la carpeta pública "
-"amb altres a la xarxa actual utilitzant: <a href=\"dav://%s\">dav://%s</a>"
-
-#: ../panels/sharing/cc-sharing-panel.c:692
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"Quan l'entrada remota està habilitada, els usuaris remots poden connectar-se "
-"utilitzant l'orde del Secure Shell:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/cc-sharing-panel.c:694
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"La compartició de pantalla permet a usuaris remots visualitzar o controlar "
-"la pantalla connectant-se a: <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/cc-sharing-panel.c:806
-msgid "Copy"
-msgstr "Copia"
-
-#: ../panels/sharing/cc-sharing-panel.c:1233
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Compartició"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Sha­ring"
-msgstr "Compartició"
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Nom de l'ordinador"
 
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:3
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Compartició de fitxers"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Compartició multimèdia"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Entrada remota"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Compartició de fitxers"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Demana contrasenya"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Entrada remota"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Entrada remota"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Habilita o inhabilita l'entrada remota"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "_Permet el control remot"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
+msgstr "_Permet a les connexions controlar la pantalla"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Sense connectar"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copia"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Suprimeix l'adreça"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Au_tenticació"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Nom d'usuari"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "S'estan registrant les empremtes dactilars"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Compartició multimèdia"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Compartiu música, fotografies i vídeos a través de la xarxa."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Carpetes"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
 msgstr "Controleu què voleu compartir amb els altres"
 
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:5
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
 "movies;server;renderer;"
@@ -5385,1005 +3700,1045 @@ msgstr ""
 "comparteix;compartició;ssh;amfitrió;nom;remot;escriptori;multimèdia;àudio;"
 "vídeo;imatges;fotografies;pel·lícules;servidor;renderitzar;"
 
-#: ../panels/sharing/networks.ui.h:1
-msgid "Networks"
-msgstr "Xarxes"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
 msgstr "Habilita o inhabilita l'entrada remota"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Cal autenticació per habilitar o inhabilitar l'entrada remota"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "_Computer Name"
-msgstr "_Nom de l'ordinador"
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid "_File Sharing"
-msgstr "_Compartició de fitxers"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Compartició"
 
-#: ../panels/sharing/sharing.ui.h:3
-msgid "_Screen Sharing"
-msgstr "_Compartició de pantalla"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:4
-msgid "_Media Sharing"
-msgstr "_Compartició multimèdia"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:5
-msgid "_Remote Login"
-msgstr "_Entrada remota"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Balanç:"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Some services are disabled because of no network access."
-msgstr "Alguns serveis estan inhabilitats perquè no hi ha accés a la xarxa."
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Esvaeix:"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "File Sharing"
-msgstr "Compartició de fitxers"
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
+msgid "Rear"
+msgstr "Darrere"
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "_Require Password"
-msgstr "_Demana contrasenya"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
+msgid "Front"
+msgstr "Frontal"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Remote Login"
-msgstr "Entrada remota"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:11
-msgid "Screen Sharing"
-msgstr "Compartició de pantalla"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Sons del sistema"
 
-#: ../panels/sharing/sharing.ui.h:12
-msgid "_Allow connections to control the screen"
-msgstr "_Permet a les connexions controlar la pantalla"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Volum d'_alerta:"
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "_Password:"
-msgstr "_Contrasenya:"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Silencia el volum"
 
-#: ../panels/sharing/sharing.ui.h:14
-msgid "_Show Password"
-msgstr "_Mostra la contrasenya"
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Eixida"
 
-#: ../panels/sharing/sharing.ui.h:15
-msgid "Access Options"
-msgstr "Opcions d'accés"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Volum d'ei_xida:"
 
-#: ../panels/sharing/sharing.ui.h:16
-msgid "_New connections must ask for access"
-msgstr "_Les connexions noves han de demanar accés"
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Prova"
 
-#: ../panels/sharing/sharing.ui.h:17
-msgid "_Require a password"
-msgstr "_Demana una contrasenya"
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "URL de _configuració"
 
-#: ../panels/sharing/sharing.ui.h:18
-msgid "Media Sharing"
-msgstr "Compartició multimèdia"
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Altaveu de greus"
 
-#: ../panels/sharing/sharing.ui.h:19
-msgid "Share music, photos and videos over the network."
-msgstr "Compartiu música, fotografies i vídeos a través de la xarxa."
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Entrada"
 
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Folders"
-msgstr "Carpetes"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Nivell d'entrada:"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Apuja el volum"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Volum d'_alerta:"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
 msgstr "So"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Canvieu els nivells de so, les entrades, les eixides i les alertes sonores"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr "Targeta;Micròfon;Volum;Esvair;Balanç;Bluetooth;Auriculars;Àudio;"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "Lladruc"
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "Goteig"
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "Vidre"
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "Sonar"
-
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "Esquerra"
-
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "Dreta"
-
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
-msgid "Rear"
-msgstr "Darrere"
-
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
-msgid "Front"
-msgstr "Frontal"
-
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Mínim"
-
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Màxim"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "_Balanç:"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "_Esvaeix:"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "Altaveu de _greus:"
-
-#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:615
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Sense amplificar"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
-#: ../panels/sound/gvc-mixer-dialog.c:515
-msgid "_Profile:"
-msgstr "_Perfil:"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1873
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u eixida"
-msgstr[1] "%u eixides"
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1883
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u entrada"
-msgstr[1] "%u entrades"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Mostra les _notificacions"
 
-#: ../panels/sound/gvc/gvc-mixer-control.c:2738
-msgid "System Sounds"
-msgstr "Sons del sistema"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Nom:"
 
-#: ../panels/sound/gvc-mixer-dialog.c:251
-msgid "_Test Speakers"
-msgstr "_Prova els altaveus"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../panels/sound/gvc-mixer-dialog.c:420
-msgid "Peak detect"
-msgstr "Detecció de pics"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/sound/gvc-mixer-dialog.c:1512
-msgid "Device"
-msgstr "Dispositiu"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "_Connecta automàticament"
 
-# N.T.: Títol de quadre de diàleg
-#: ../panels/sound/gvc-mixer-dialog.c:1575
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "Prova d'altaveus per a %s"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Suprimeix el dispositiu"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1631
-msgid "_Output volume:"
-msgstr "Volum d'ei_xida:"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/sound/gvc-mixer-dialog.c:1645
-msgid "Output"
-msgstr "Eixida"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "No s'ha pogut connectar al domini %s: %s"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1650
-msgid "C_hoose a device for sound output:"
-msgstr "_Trieu un dispositiu per a l'eixida de so:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1672
-msgid "Settings for the selected device:"
-msgstr "Paràmetres del dispositiu seleccionat:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1683
-msgid "Input"
-msgstr "Entrada"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1690
-msgid "_Input volume:"
-msgstr "Volum d'_entrada:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "Input level:"
-msgstr "Nivell d'entrada:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1737
-msgid "C_hoose a device for sound input:"
-msgstr "_Trieu un dispositiu per a l'entrada de so:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1761
-msgid "Sound Effects"
-msgstr "Efectes de so"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1768
-msgid "_Alert volume:"
-msgstr "Volum d'_alerta:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1785
-msgid "No application is currently playing or recording audio."
-msgstr "Actualment cap aplicació no està reproduint ni gravant àudio."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "Integrat"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "Preferències de so"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "S'està provant el so de l'esdeveniment"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:554
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "Default"
-msgstr "Per defecte"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:555
-msgid "From theme"
-msgstr "Del tema"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:740
-msgid "C_hoose an alert sound:"
-msgstr "Trieu un so d'_alerta:"
-
-#: ../panels/sound/gvc-speaker-test.c:231
-msgid "Stop"
-msgstr "Atura"
-
-#: ../panels/sound/gvc-speaker-test.c:231
-#: ../panels/sound/gvc-speaker-test.c:343
-msgid "Test"
-msgstr "Prova"
-
-#: ../panels/sound/gvc-speaker-test.c:239
-msgid "Subwoofer"
-msgstr "Altaveu de greus"
-
-#: ../panels/sound/sound-theme-file-utils.c:304
-msgid "Custom"
-msgstr "Personalitzat"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: ../panels/universal-access/cc-ua-panel.c:351
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Per defecte"
-
-#: ../panels/universal-access/cc-ua-panel.c:354
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Mitjà"
-
-#: ../panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Gran"
-
-#: ../panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Més gran"
-
-#: ../panels/universal-access/cc-ua-panel.c:363
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "El més gran"
-
-#: ../panels/universal-access/cc-ua-panel.c:367
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d píxel"
-msgstr[1] "%d píxels"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Uni­ver­sal Access"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
 msgstr "Accés universal"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "Feu més fàcil veure, escoltar, teclejar, apuntar i fer clic"
-
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:5
-msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
-"Teclat;Ratolí;a11y;Accessibilitat;Contrast;Zoom;Pantalla;Lector;text;lletra;"
-"mida;AccessX;Tecles enganxoses;Tecles;Lent;Salt;Ratolí;Doble;clic;Retard;"
-"Assistència;Repetició;Parpelleig;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "Mostra _sempre el menú d'accés universal"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Afegeix un dispositiu"
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "Visió"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "_Contrast alt"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "Text _gran"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:5
-msgid "C_ursor Size"
-msgstr "Mida del _cursor"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:6
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "_Zoom"
-msgstr "_Ampliació"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Parpelleig del cursor"
 
-#: ../panels/universal-access/uap.ui.h:8
-msgid "Screen _Reader"
-msgstr "Lector de _pantalla"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "El cursor parpelleja en els camps de text."
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "_Sound Keys"
-msgstr "_So de les tecles"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocitat:"
 
-#: ../panels/universal-access/uap.ui.h:10
-msgid "Hearing"
-msgstr "Audició"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Velocitat del parpelleig del cursor"
 
-#: ../panels/universal-access/uap.ui.h:11
-msgid "_Visual Alerts"
-msgstr "Alertes _visuals"
-
-#: ../panels/universal-access/uap.ui.h:13
-msgid "Screen _Keyboard"
-msgstr "_Teclat en pantalla"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgid "R_epeat Keys"
-msgstr "_Repetició de tecles"
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "Cursor _Blinking"
-msgstr "_Parpelleig del cursor"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Typing Assist (AccessX)"
-msgstr "Assistent d'escriptura (AccessX)"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Pointing & Clicking"
-msgstr "Apuntar i fer clic"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "_Mouse Keys"
-msgstr "Tecles del _ratolí"
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Click Assist"
-msgstr "A_ssistència en fer clic"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "_Double-Click Delay"
-msgstr "_Retard del doble clic"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Double-Click Delay"
-msgstr "Retard del doble clic"
-
-#: ../panels/universal-access/uap.ui.h:22
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr "Mida del cursor"
 
-#: ../panels/universal-access/uap.ui.h:23
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 "La mida del cursor pot combinar-se amb l'ampliació perquè siga més fàcil "
 "veure el cursor."
 
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Screen Reader"
-msgstr "Lector de pantalla"
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Assistència en fer clic"
 
-#: ../panels/universal-access/uap.ui.h:25
-msgid "The screen reader reads displayed text as you move the focus."
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Clic secundari _simulat"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Fes un clic secundari en mantindre premut el botó primari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Retard d'a_cceptació:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Retard del clic secundari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Clic en passar per sobre"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Fes un clic en passar el punter per sobre"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "R_etard:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Llindar de _moviment:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Petit"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Gran"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetició de tecles"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Es repeteix la tecla quan es manté premuda."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Retard en la repetició de tecles"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocitat de la repetició de tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Assistent d'escriptura"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Tecles _enganxoses"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
 msgstr ""
-"El lector de pantalla llig el text visualitzat mentre moveu el focus."
+"Tracta una seqüència de tecles modificadores com una combinació de tecles"
 
-#: ../panels/universal-access/uap.ui.h:26
-msgid "_Screen Reader"
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Inhabilita si es premen dues tecles alhora"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Fes un avís sonor quan es prema una tecla _modificadora"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Tecles _lentes"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introdueix un retard entre que es prem una tecla i s'accepta"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Retard d'escriptura de les tecles lentes"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Fes un avís sonor quan es _prema una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Fes un avís sonor quan s'_accepti una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Fes un avís sonor quan es _rebutgi una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Omet tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignora les pulsacions duplicades ràpides"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Retard d'escriptura en ometre tecles"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Habilita per teclat"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Activa i desactiva les funcions d'accessibilitat utilitzant el teclat"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Mostra _sempre el menú d'accés universal"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Visió"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Contrast alt"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Text _gran"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
 msgstr "Lector de _pantalla"
 
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Sound Keys"
-msgstr "So de les tecles"
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "El lector de pantalla llig el text visualitzat mentre moveu el focus."
 
-#: ../panels/universal-access/uap.ui.h:28
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_So de les tecles"
+
+#: panels/universal-access/cc-ua-panel.ui:84
 msgid "Beep when Num Lock or Caps Lock are turned on or off."
 msgstr ""
 "Fes un avís sonor quan s'active o desactive la fixació numèrica o de les "
 "majúscules."
 
-#: ../panels/universal-access/uap.ui.h:29
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Mida del _cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Ampliació"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audició"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Alertes _visuals"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Teclat en pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Repetició de tecles"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Parpelleig del cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Assistent d'escriptura (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Apuntar i fer clic"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Tecles del _ratolí"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Suprimeix la impressora"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "A_ssistència en fer clic"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Retard del doble clic"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Retard del doble clic"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
 msgid "Visual Alerts"
 msgstr "Alertes visuals"
 
-#: ../panels/universal-access/uap.ui.h:30
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
 msgid "_Test flash"
 msgstr "_Prova el parpelleig"
 
-#: ../panels/universal-access/uap.ui.h:31
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
 msgid "Use a visual indication when an alert sound occurs."
 msgstr "Utilitza una indicació visual quan es produïsca una alerta sonora."
 
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Flash the _window title"
-msgstr "Fes parpellejar el títol de la _finestra"
-
-#: ../panels/universal-access/uap.ui.h:33
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
 msgid "Flash the entire _screen"
 msgstr "Fes parpellejar la _pantalla sencera"
 
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Repeat Keys"
-msgstr "Repetició de tecles"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Fes parpellejar la _pantalla sencera"
 
-#: ../panels/universal-access/uap.ui.h:35
-msgid "Key presses repeat when key is held down."
-msgstr "Es repeteix la tecla quan es manté premuda."
-
-#: ../panels/universal-access/uap.ui.h:37
-msgid "Repeat keys delay"
-msgstr "Retard en la repetició de tecles"
-
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Speed"
-msgstr "Velocitat:"
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Repeat keys speed"
-msgstr "Velocitat de la repetició de tecles"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Cursor Blinking"
-msgstr "Parpelleig del cursor"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "Cursor blinks in text fields."
-msgstr "El cursor parpelleja en els camps de text."
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Cursor blinking speed"
-msgstr "Velocitat del parpelleig del cursor"
-
-#: ../panels/universal-access/uap.ui.h:43
-msgid "Typing Assist"
-msgstr "Assistent d'escriptura"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "_Sticky Keys"
-msgstr "Tecles _enganxoses"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr ""
-"Tracta una seqüència de tecles modificadores com una combinació de tecles"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Disable if two keys are pressed together"
-msgstr "_Inhabilita si es premen dues tecles alhora"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Beep when a _modifier key is pressed"
-msgstr "Fes un avís sonor quan es prema una tecla _modificadora"
-
-#: ../panels/universal-access/uap.ui.h:48
-msgid "S_low Keys"
-msgstr "Tecles _lentes"
-
-#: ../panels/universal-access/uap.ui.h:49
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "Introdueix un retard entre que es prem una tecla i s'accepta"
-
-#: ../panels/universal-access/uap.ui.h:50
-msgid "A_cceptance delay:"
-msgstr "Retard d'a_cceptació:"
-
-#: ../panels/universal-access/uap.ui.h:51
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Curt"
-
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Slow keys typing delay"
-msgstr "Retard d'escriptura de les tecles lentes"
-
-#: ../panels/universal-access/uap.ui.h:53
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Llarg"
-
-#: ../panels/universal-access/uap.ui.h:54
-msgid "Beep when a key is pr_essed"
-msgstr "Fes un avís sonor quan es _prema una tecla"
-
-#: ../panels/universal-access/uap.ui.h:55
-msgid "Beep when a key is _accepted"
-msgstr "Fes un avís sonor quan s'_accepti una tecla"
-
-#: ../panels/universal-access/uap.ui.h:56
-msgid "Beep when a key is _rejected"
-msgstr "Fes un avís sonor quan es _rebutgi una tecla"
-
-#: ../panels/universal-access/uap.ui.h:57
-msgid "_Bounce Keys"
-msgstr "_Omet tecles"
-
-#: ../panels/universal-access/uap.ui.h:58
-msgid "Ignores fast duplicate keypresses"
-msgstr "Ignora les pulsacions duplicades ràpides"
-
-#: ../panels/universal-access/uap.ui.h:59
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Curt"
-
-#: ../panels/universal-access/uap.ui.h:60
-msgid "Bounce keys typing delay"
-msgstr "Retard d'escriptura en ometre tecles"
-
-#: ../panels/universal-access/uap.ui.h:61
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Llarg"
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "_Enable by Keyboard"
-msgstr "_Habilita per teclat"
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "Activa i desactiva les funcions d'accessibilitat utilitzant el teclat"
-
-#: ../panels/universal-access/uap.ui.h:64
-msgid "Click Assist"
-msgstr "Assistència en fer clic"
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "_Simulated Secondary Click"
-msgstr "Clic secundari _simulat"
-
-#: ../panels/universal-access/uap.ui.h:66
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "Fes un clic secundari en mantindre premut el botó primari"
-
-#: ../panels/universal-access/uap.ui.h:67
-msgctxt "secondary click"
-msgid "Short"
-msgstr "Curt"
-
-#: ../panels/universal-access/uap.ui.h:68
-msgid "Secondary click delay"
-msgstr "Retard del clic secundari"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgctxt "secondary click delay"
-msgid "Long"
-msgstr "Llarg"
-
-#: ../panels/universal-access/uap.ui.h:70
-msgid "_Hover Click"
-msgstr "Clic en passar per sobre"
-
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Trigger a click when the pointer hovers"
-msgstr "Fes un clic en passar el punter per sobre"
-
-#: ../panels/universal-access/uap.ui.h:72
-msgid "D_elay:"
-msgstr "R_etard:"
-
-#: ../panels/universal-access/uap.ui.h:73
-msgctxt "dwell click delay"
-msgid "Short"
-msgstr "Curt"
-
-#: ../panels/universal-access/uap.ui.h:74
-msgctxt "dwell click delay"
-msgid "Long"
-msgstr "Llarg"
-
-#: ../panels/universal-access/uap.ui.h:75
-msgid "Motion _threshold:"
-msgstr "Llindar de _moviment:"
-
-#: ../panels/universal-access/uap.ui.h:76
-msgctxt "dwell click threshold"
-msgid "Small"
-msgstr "Petit"
-
-#: ../panels/universal-access/uap.ui.h:77
-msgctxt "dwell click threshold"
-msgid "Large"
-msgstr "Gran"
-
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
-msgid "Short"
-msgstr "Curta"
-
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ de pantalla"
-
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ de pantalla"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ de pantalla"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
-msgid "Long"
-msgstr "Llarga"
-
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "Pantalla completa"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "Meitat superior"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "Meitat inferior"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "Meitat esquerra"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "Meitat dreta"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "Opcions d'ampliació"
 
-#: ../panels/universal-access/zoom-options.ui.h:8
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
 msgstr "_Ampliació:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "_Follow mouse cursor"
-msgstr "_Segueix el cursor del ratolí"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "_Screen part:"
-msgstr "_Part de la pantalla:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier _extends outside of screen"
-msgstr "L'_ampliador s'estén fora de la pantalla"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "_Keep magnifier cursor centered"
-msgstr "_Mantén el cursor de l'ampliador centrat"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor _pushes contents around"
-msgstr "_El cursor de l'ampliador empeny el contingut del voltant"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with _contents"
-msgstr "El _cursor de l'ampliador es mou amb el contingut"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "Posició de l'ampliador:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Segueix el cursor del ratolí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Part de la pantalla:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "L'_ampliador s'estén fora de la pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Mantén el cursor de l'ampliador centrat"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "_El cursor de l'ampliador empeny el contingut del voltant"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "El _cursor de l'ampliador es mou amb el contingut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Ampliador"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Creus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Sobreposa el cursor del ratolí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
 msgstr "_Gruix:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "Prim"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Gruixut"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
 msgstr "_Longitud:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
 msgstr "_Color:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "_Crosshairs:"
-msgstr "_Creus:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "_Overlaps mouse cursor"
-msgstr "_Sobreposa el cursor del ratolí"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "Creus"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efectes de color:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
 msgstr "_Blanc sobre negre:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
 msgstr "_Brillantor:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
 msgstr "_Contrast:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
 msgid "Co_lor"
 msgstr "Colo_r"
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Cap"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Tot"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Baixa"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Alta"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Baix"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Alt"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "Efectes de color:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "Efectes de color"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/join-dialog.ui.h:1
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Feu més fàcil veure, escoltar, teclejar, apuntar i fer clic"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Teclat;Ratolí;a11y;Accessibilitat;Contrast;Zoom;Pantalla;Lector;text;lletra;"
+"mida;AccessX;Tecles enganxoses;Tecles;Lent;Salt;Ratolí;Doble;clic;Retard;"
+"Assistència;Repetició;Parpelleig;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Historial"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "Historial"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "_Neteja l'historial recent"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "Buida la paperera i els fitxers temporals"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "Buida automàticament la _paperera"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Suprimeix automàticament els _fitxers temporals"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "Buida automàticament la _paperera"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Buida la paperera..."
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "Suprimeix els fitxers _temporals..."
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Afig un usuari"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "_Full Name"
-msgstr "_Nom complet"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Standard"
-msgstr "Estàndard"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "Administrador"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Account _Type"
-msgstr "_Tipus de compte"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "Allow user to set a password when they next _login"
-msgstr "_Permet a l'usuari establir la contrasenya a l'entrada següent"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Permet a l'usuari establir la contrasenya a l'entrada següent"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-msgid "Set a password _now"
-msgstr "_Estableix una contrasenya ara"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Estableix una contrasenya ara"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "_Confirma"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:14
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_Entrada corporativa"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Esteu fora de línia"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
 "resources on the internet."
 msgstr ""
 "Els accessos corporatius permeten utilitzar comptes d'usuari corporatius "
-"centralitzats en este dispositiu. També podeu usar este compte per "
-"accedir als recursos de l'empresa a Internet."
+"centralitzats en este dispositiu. També podeu usar este compte per accedir "
+"als recursos de l'empresa a Internet."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-#: ../panels/user-accounts/data/join-dialog.ui.h:9
-msgid "_Domain"
-msgstr "_Domini"
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Selecció d'un fitxer PPD"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-msgid "You are Offline"
-msgstr "Esteu fora de línia"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Entrada amb _empremta dactilar"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-msgid "You must be online in order to add enterprise users."
-msgstr "Heu d'estar en línia per afegir usuaris corporatius."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Entrada amb _empremta dactilar"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:18
-msgid "_Enterprise Login"
-msgstr "_Entrada corporativa"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "No"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "Polze esquerre"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "Dit del mig esquerre"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "Dit anular esquerre"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "Dit petit esquerre"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "Polze dret"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "Dit del mig dret"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "Dit anular dret"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "Dit petit dret"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:680
-msgid "Enable Fingerprint Login"
-msgstr "Habilita l'entrada amb empremta dactilar"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "Dit índex d_ret"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "Dit índex _esquerre"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "Un _altre dit:"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
 msgstr ""
-"La vostra empremta dactilar s'ha guardat correctament. Hauríeu de poder entrar "
-"utilitzant el lector d'empremtes dactilars."
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Voleu suprimir les empremtes dactilars registrades de manera que "
+"s'inhabiliti l'entrada amb empremta dactilar?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "No s'ha detectat cap impressora."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Entrada amb _empremta dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Entrada amb _empremta dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Entrada amb _empremta dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Suprimeix les empremtes dactilars"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Entrada amb _empremta dactilar"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Salta a la peça anterior"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Canvi de la contrasenya"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "C_anvia"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Contrasenya _actual"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Contrasenya _nova"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Canvi de la contrasenya"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Les contrasenyes no coincideixen."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Permet a l'usuari establir la contrasenya a l'entrada següent"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Estableix una contrasenya ara"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Usuaris"
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "S'ha de tornar a iniciar la sessió perquè els canvis tinguen efecte"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Renicia ara"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Tanca"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Nom complet"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Edita"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Entrada amb _empremta dactilar"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Entrada a_utomàtica"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "_Activitat del compte"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Administrador"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Suprimeix l'usuari..."
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Un _altre dit:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "_Afig usuari…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "No s'ha trobat cap impressora"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "Crea un compte d'usuari"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "Afegiu o suprimiu usuaris i canvieu la contrasenya"
 
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Entrada;Nom;Empremta dactilar;Avatar;Logotip;Cara;Contrasenya;"
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/join-dialog.ui.h:4
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Afig-lo"
 
-#: ../panels/user-accounts/data/join-dialog.ui.h:5
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Entrada de l'administrador del domini"
 
-#: ../panels/user-accounts/data/join-dialog.ui.h:6
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6393,677 +4748,32 @@ msgstr ""
 "necessita formar part del domini. Demaneu a l'administrador que\n"
 "introduïsca ací la seua contrasenya."
 
-#: ../panels/user-accounts/data/join-dialog.ui.h:10
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "_Nom de l'administrador"
 
-#: ../panels/user-accounts/data/join-dialog.ui.h:11
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Contrasenya de l'administrador"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr "Canvi de la contrasenya"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "C_anvia"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "_Verifica la contrasenya nova"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "Contrasenya _nova"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "Contrasenya _actual"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to change their password on next login"
-msgstr "Permet a l'usuari establir la contrasenya a l'entrada següent"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "Estableix una contrasenya ara"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-msgid "_Add User…"
-msgstr "_Afig usuari…"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "S'ha de tornar a iniciar la sessió perquè els canvis tinguen efecte"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Restart Now"
-msgstr "Renicia ara"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "Entrada a_utomàtica"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "Entrada amb _empremta dactilar"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "Icona d'usuari"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "Últim inici de sessió"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "Remove User…"
-msgstr "Suprimeix l'usuari..."
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "Gestiona els comptes d'usuari"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "Cal autenticació per canviar les dades de l'usuari"
 
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "La contrasenya nova ha de ser diferent de la vella."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Canvieu algunes lletres i números."
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Canvieu la contrasenya una mica més."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Una contrasenya sense el vostre nom d'usuari seria més segura."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Eviteu l'ús del vostre nom a la contrasenya."
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Eviteu algunes de les paraules incloses a la contrasenya."
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Eviteu utilitzar paraules comunes."
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Eviteu utilitzar paraules desordenades."
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Utilitzeu més nombres."
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Utilitzeu més lletres majúscules."
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Utilitzeu més lletres minúscules."
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Utilitzeu més caràcters especials, com ara signes de puntuació."
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-"Intenteu utilitzar una combinació de lletres, nombres i signes de puntuació."
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Eviteu repetir el mateix caràcter."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Eviteu repetir el mateix tipus de caràcter: combineu lletres, números i "
-"signes de puntuació."
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Eviteu emprar seqüències com ara 1234 o abcd."
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Cal que la contrasenya siga més gran. Intenteu utilitzar una combinació de "
-"lletres, nombres i signes de puntuació."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Combineu majúscules i minúscules i empreu un o dos nombres."
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Si hi afegiu més lletres, nombres i signes de puntuació la contrasenya serà "
-"més segura."
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "Ha fallat l'autenticació"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "La contrasenya nova és massa curta"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "La contrasenya nova és massa senzilla"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "La contrasenya nova i l'anterior són massa semblants"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "La contrasenya nova ja s'ha utilitzat recentment."
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "La contrasenya nova ha de contindre caràcters numèrics o especials"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "La contrasenya nova i l'anterior són iguals"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "La vostra contrasenya ha canviat des que vos heu autenticat."
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "La contrasenya nova no conté suficients caràcters diferents"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "Error desconegut"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "Ha de coincidir amb l'adreça web del proveïdor del compte."
-
-#: ../panels/user-accounts/um-account-dialog.c:229
-msgid "Failed to add account"
-msgstr "No s'ha pogut afegir el compte"
-
-#: ../panels/user-accounts/um-account-dialog.c:462
-msgid "Passwords do not match."
-msgstr "Les contrasenyes no coincideixen."
-
-#: ../panels/user-accounts/um-account-dialog.c:717
-#: ../panels/user-accounts/um-account-dialog.c:763
-#: ../panels/user-accounts/um-account-dialog.c:784
-msgid "Failed to register account"
-msgstr "No s'ha pogut registrar el compte"
-
-#: ../panels/user-accounts/um-account-dialog.c:907
-msgid "No supported way to authenticate with this domain"
-msgstr "No hi ha cap manera compatible per autenticar-se amb este domini"
-
-#: ../panels/user-accounts/um-account-dialog.c:980
-msgid "Failed to join domain"
-msgstr "No s'ha pogut unir al domini"
-
-#: ../panels/user-accounts/um-account-dialog.c:1041
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"El nom d'usuari no és correcte.\n"
-"Torneu-ho a provar."
-
-#: ../panels/user-accounts/um-account-dialog.c:1048
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"La contrasenya no és vàlida.\n"
-"Torneu-ho a provar."
-
-#: ../panels/user-accounts/um-account-dialog.c:1056
-msgid "Failed to log into domain"
-msgstr "No s'ha pogut entrar al domini"
-
-#: ../panels/user-accounts/um-account-dialog.c:1114
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "No s'ha trobat el domini. Potser l'heu escrit malament?"
-
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Estàndard"
-
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "Administrador"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"No teniu permís per accedir al dispositiu. Contacteu amb l'administrador del "
-"sistema."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:144
-msgid "The device is already in use."
-msgstr "El dispositiu ja està en ús."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:146
-msgid "An internal error occurred."
-msgstr "S'ha produït un error intern."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:217
-msgid "Enabled"
-msgstr "Habilitat"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr "Voleu suprimir les empremtes dactilars registrades?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
-msgstr "_Suprimeix les empremtes dactilars"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"Voleu suprimir les empremtes dactilars registrades de manera que "
-"s'inhabiliti l'entrada amb empremta dactilar?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:443
-msgid "Done!"
-msgstr "Fet"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:504
-#: ../panels/user-accounts/um-fingerprint-dialog.c:546
-#, c-format
-msgid "Could not access “%s” device"
-msgstr "No s'ha pogut accedir al dispositiu «%s»."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:587
-#, c-format
-msgid "Could not start finger capture on “%s” device"
-msgstr ""
-"No s'ha pogut iniciar la captura de l'empremta dactilar al dispositiu «%s»."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:631
-msgid "Could not access any fingerprint readers"
-msgstr "No s'ha pogut accedir a cap lector d'empremtes dactilars"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:632
-msgid "Please contact your system administrator for help."
-msgstr "Contacteu amb l'administrador del sistema per obtindre ajuda."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:714
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the “%s” device."
-msgstr ""
-"Per habilitar l'entrada amb empremta dactilar, cal que guardeu una de les "
-"vostres empremtes dactilars utilitzant el dispositiu «%s»."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:721
-msgid "Selecting finger"
-msgstr "S'està seleccionant un dit"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:722
-msgid "Enrolling fingerprints"
-msgstr "S'estan registrant les empremtes dactilars"
-
-#: ../panels/user-accounts/um-history-dialog.c:70
-msgid "This Week"
-msgstr "Esta setmana"
-
-#: ../panels/user-accounts/um-history-dialog.c:73
-msgid "Last Week"
-msgstr "Setmana passada"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:79
-#: ../panels/user-accounts/um-history-dialog.c:83
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e de %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:93
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:177
-#: ../panels/user-accounts/um-user-panel.c:776
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:180
-#: ../panels/user-accounts/um-user-panel.c:780
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:250
-msgid "Session Ended"
-msgstr "Ha acabat la sessió"
-
-#: ../panels/user-accounts/um-history-dialog.c:256
-msgid "Session Started"
-msgstr "S'ha iniciat la sessió"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: ../panels/user-accounts/um-history-dialog.c:299
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s - Activitat del compte"
-
-#: ../panels/user-accounts/um-password-dialog.c:144
-msgid "Please choose another password."
-msgstr "Trieu una altra contrasenya."
-
-#: ../panels/user-accounts/um-password-dialog.c:153
-msgid "Please type your current password again."
-msgstr "Escriviu un altre cop la vostra contrasenya actual."
-
-#: ../panels/user-accounts/um-password-dialog.c:159
-msgid "Password could not be changed"
-msgstr "No s'ha pogut canviar la contrasenya"
-
-#: ../panels/user-accounts/um-password-dialog.c:285
-msgid "The passwords do not match."
-msgstr "Les contrasenyes no coincideixen."
-
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "Browse for more pictures"
-msgstr "Busca més imatges"
-
-#: ../panels/user-accounts/um-photo-dialog.c:452
-msgid "Disable image"
-msgstr "Inhabilita la imatge"
-
-#: ../panels/user-accounts/um-photo-dialog.c:470
-msgid "Take a photo…"
-msgstr "Fes una fotografia…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:488
-msgid "Browse for more pictures…"
-msgstr "Busca més imatges…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:714
-#, c-format
-msgid "Used by %s"
-msgstr "Utilitzat per %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "No es pot unir automàticament a este tipus de domini"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "No s'ha trobat este domini o regne"
-
-#: ../panels/user-accounts/um-realm-manager.c:815
-#: ../panels/user-accounts/um-realm-manager.c:829
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "No s'ha pogut entrar com a %s al domini %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:821
-msgid "Invalid password, please try again"
-msgstr "La contrasenya no vàlida, torneu-ho a provar"
-
-#: ../panels/user-accounts/um-realm-manager.c:834
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "No s'ha pogut connectar al domini %s: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:195
-msgid "Your account"
-msgstr "El vostre compte"
-
-#: ../panels/user-accounts/um-user-panel.c:390
-msgid "Failed to delete user"
-msgstr "No s'ha pogut suprimir l'usuari"
-
-#: ../panels/user-accounts/um-user-panel.c:448
-#: ../panels/user-accounts/um-user-panel.c:507
-#: ../panels/user-accounts/um-user-panel.c:559
-msgid "Failed to revoke remotely managed user"
-msgstr "No s'ha pogut revocar l'usuari gestionat remotament"
-
-#: ../panels/user-accounts/um-user-panel.c:613
-msgid "You cannot delete your own account."
-msgstr "No podeu suprimir el vostre compte."
-
-#: ../panels/user-accounts/um-user-panel.c:622
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s encara està connectat"
-
-#: ../panels/user-accounts/um-user-panel.c:626
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Si suprimiu un usuari mentre està connectat pot deixar el sistema "
-"inconsistent."
-
-#: ../panels/user-accounts/um-user-panel.c:635
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Voleu conservar els fitxers de %s?"
-
-#: ../panels/user-accounts/um-user-panel.c:639
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Es pot conservar el directori de l'usuari, la cua de correu i els fitxers "
-"temporals quan suprimiu un compte d'usuari."
-
-#: ../panels/user-accounts/um-user-panel.c:642
-msgid "_Delete Files"
-msgstr "_Suprimeix els fitxers"
-
-#: ../panels/user-accounts/um-user-panel.c:643
-msgid "_Keep Files"
-msgstr "C_onserva els fitxers"
-
-#: ../panels/user-accounts/um-user-panel.c:657
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Segur que voleu revocar el compte %s de l'usuari gestionat remotament?"
-
-#: ../panels/user-accounts/um-user-panel.c:661
-msgid "_Delete"
-msgstr "_Suprimeix"
-
-#: ../panels/user-accounts/um-user-panel.c:711
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Compte inhabilitat"
-
-#: ../panels/user-accounts/um-user-panel.c:719
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "S'ha de configurar la pròxima vegada que entri"
-
-#: ../panels/user-accounts/um-user-panel.c:722
-msgctxt "Password mode"
-msgid "None"
-msgstr "Cap"
-
-#: ../panels/user-accounts/um-user-panel.c:769
-msgid "Logged in"
-msgstr "Connectat"
-
-#: ../panels/user-accounts/um-user-panel.c:1117
-msgid "Failed to contact the accounts service"
-msgstr "No s'ha pogut contactar amb el servei de comptes"
-
-#: ../panels/user-accounts/um-user-panel.c:1119
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Assegureu-vos que el servei de comptes està instal·lat i habilitat."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: ../panels/user-accounts/um-user-panel.c:1155
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Per fer-hi canvis,\n"
-"primer feu clic a la icona *"
-
-#: ../panels/user-accounts/um-user-panel.c:1195
-msgid "Create a user account"
-msgstr "Crea un compte d'usuari"
-
-#: ../panels/user-accounts/um-user-panel.c:1206
-#: ../panels/user-accounts/um-user-panel.c:1385
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Per crear un compte d'usuari,\n"
-"primer feu clic a la icona *"
-
-#: ../panels/user-accounts/um-user-panel.c:1216
-msgid "Delete the selected user account"
-msgstr "Suprimeix el compte d'usuari seleccionat"
-
-#: ../panels/user-accounts/um-user-panel.c:1228
-#: ../panels/user-accounts/um-user-panel.c:1390
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Per suprimir el compte d'usuari seleccionat,\n"
-"primer feu clic a la icona *"
-
-#: ../panels/user-accounts/um-utils.c:507
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "El nom d'usuari no està disponible. Trieu-ne un altre."
-
-#: ../panels/user-accounts/um-utils.c:510
-#, c-format
-msgid "The username is too long."
-msgstr "El nom d'usuari és massa llarg."
-
-#: ../panels/user-accounts/um-utils.c:513
-msgid "The username cannot start with a “-”."
-msgstr "El nom d'usuari no pot començar amb un «-»."
-
-#: ../panels/user-accounts/um-utils.c:516
-msgid ""
-"The username should only consist of upper and lower case letters from a-z, "
-"digits and the following characters: . - _"
-msgstr ""
-"El nom d'usuari només ha de consistir en lletres minúscules i majúscules de "
-"la «a» a la «z», dígits i qualsevol dels caràcters «.», «-» i «_»"
-
-#: ../panels/user-accounts/um-utils.c:520
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr ""
-"Es farà servir per anomenar la vostra carpeta personal i no es pot canviar."
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Mapa els botons"
 
-#: ../panels/wacom/button-mapping.ui.h:2 ../panels/wacom/cc-wacom-page.c:547
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "_Close"
-msgstr "_Tanca"
-
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Mapa els botons a les funcions"
 
-#: ../panels/wacom/button-mapping.ui.h:4
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -7072,7 +4782,11 @@ msgstr ""
 "premeu el botó de drecera de teclat i premeu la combinació de tecles nova, o "
 "premeu la tecla de retrocés per netejar-la."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Tanca"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -7080,319 +4794,3199 @@ msgstr ""
 "Feu un toc als marcadors objectius a mesura que apareguen a la pantalla per "
 "calibrar la tauleta gràfica."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "S'ha detectat una pulsació incorrecta, s'està reiniciant..."
 
-#: ../panels/wacom/cc-wacom-button-row.c:266
-#, c-format
-msgid "Button %d"
-msgstr "Botó %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:53
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplicació definida"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tauleta gràfica"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Envia una pulsació de tecla"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Commuta el monitor"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Orientació d'esquerrans"
 
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Mostra l'ajuda en pantalla"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:260
-msgid "Output:"
-msgstr "Eixida:"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapa a la pantalla…"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:272
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Mantén la relació d'aspecte (format de bústia):"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Relació d'aspecte"
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:283
-msgid "Map to single monitor"
-msgstr "Mapa a una sola pantalla"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-nav-button.c:86
-#, c-format
-msgid "%d of %d"
-msgstr "%d de %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Calibra…"
 
-#: ../panels/wacom/cc-wacom-page.c:544
-msgid "Display Mapping"
-msgstr "Mapat de la pantalla"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "No s'ha detectat cap tauleta gràfica"
 
-#: ../panels/wacom/cc-wacom-panel.c:790
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Stylus"
-msgstr "Estilogràfica"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Connecteu o engegueu la tauleta gràfica Wacom"
 
-#: ../panels/wacom/cc-wacom-stylus-page.c:347
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensibilitat de pressió del llapis"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Suau"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Ferma"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Botó"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Wa­com Tab­let"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botó"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botó"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilitat de pressió de l'esborrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Sensibilitat de pressió de l'esborrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Clic amb el botó del mig del ratolí"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Clic amb el botó dret del ratolí"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Avant"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
 msgstr "Tauleta gràfica Wacom"
 
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Establiu el mapa de botons i ajusteu la sensibilitat de l'estilogràfica per "
 "a tauletes gràfiques"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:5
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tauleta gràfica;Wacom;Estilogràfica;Esborrador;Ratolí;"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "Tauleta gràfica (absolut)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "Ratolí tàctil (relatiu)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "Preferències de la tauleta gràfica"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Help"
-msgstr "_Ajuda"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "No tablet detected"
-msgstr "No s'ha detectat cap tauleta gràfica"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Connecteu o engegueu la tauleta gràfica Wacom"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Bluetooth Settings"
-msgstr "Paràmetres del Bluetooth"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Wacom Tablet"
-msgstr "Tauleta gràfica Wacom"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map to Monitor…"
-msgstr "Mapa a la pantalla…"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Clic secundari _simulat"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Map Buttons…"
-msgstr "Mapa els botons…"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Programari del Windows"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Calibrate…"
-msgstr "Calibra…"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust display resolution"
-msgstr "Ajusta la resolució de la pantalla"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Tòner baix"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Adjust mouse settings"
-msgstr "Ajusta els paràmetres del ratolí"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Secundària"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Tracking Mode"
-msgstr "Mode de seguiment"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Programari del Windows"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:16
-msgid "Left-Handed Orientation"
-msgstr "Orientació d'esquerrans"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
 
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "Drecera nova…"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Middle Mouse Button Click"
-msgstr "Clic amb el botó del mig del ratolí"
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Opcions d'accés"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Right Mouse Button Click"
-msgstr "Clic amb el botó dret del ratolí"
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Afig"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Back"
-msgstr "Arrere"
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "Al_ça"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Forward"
-msgstr "Avant"
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "No stylus found"
-msgstr "No s'ha trobat cap llapis"
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Detalls"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr "Moveu el llapis a prop de la tauleta per configurar-lo."
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Eraser Pressure Feel"
-msgstr "Sensibilitat de pressió de l'esborrador"
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Soft"
-msgstr "Suau"
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Nom de la xarxa"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Firm"
-msgstr "Ferma"
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Xarxes"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Top Button"
-msgstr "Botó superior"
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Nombres"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Lower Button"
-msgstr "Botó inferior"
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Detalls de la impressora"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Tip Pressure Feel"
-msgstr "Sensibilitat de pressió del llapis"
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricant"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
-msgid "page 3"
-msgstr "pàgina 3"
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Falta el microprogramari"
 
-#: ../shell/alt/cc-window.c:53 ../shell/alt/cc-window.c:1484
-#: ../shell/cc-window.c:758
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "Banda ampla _mòbil"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Nom de la xarxa"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Xarxa"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Avançat"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Opcions d'accés"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Bloca la pantalla"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Detalls %s"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Nom de la xarxa"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Automàtic"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "La meua xarxa"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "La meua xarxa"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "No s'ha trobat cap adaptador Wi-fi"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Assegureu-vos que teniu un adaptador Wi-fi connectat i activat"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "El Bluetooth està inhabilitat quan el mode d'avió està activat."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Desactiveu el mode d'avió"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Oblida la connexió"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "No s'ha inserit la targeta SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Bloca la pantalla"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "C_anvia"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "La meua xarxa"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configura els paràmetres del suport extraïble"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+#, fuzzy
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilitats per configurar l'escriptori GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "S'està establint el controlador nou…"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "Privacitat"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Tots els paràmetres"
 
-#. Add categories
-#: ../shell/alt/cc-window.c:875
-msgctxt "category"
-msgid "Personal"
-msgstr "Personal"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Primària"
 
-#: ../shell/alt/cc-window.c:876
-msgctxt "category"
-msgid "Hardware"
-msgstr "Maquinari"
-
-#: ../shell/alt/cc-window.c:877
-msgctxt "category"
-msgid "System"
-msgstr "Sistema"
-
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
-msgid "GNOME Control Center"
-msgstr "Centre de control del GNOME"
-
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
-msgid "Utilities to configure the GNOME desktop"
-msgstr "Utilitats per configurar l'escriptori GNOME"
-
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
-msgid ""
-"The control center is GNOME’s main interface for configuration of various "
-"aspects of your desktop."
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
 msgstr ""
-"El centre de control és la interfície principal del GNOME per a la "
-"configuració de diversos aspectes de l'escriptori."
 
-#: ../shell/cc-application.c:45
-msgid "Display version number"
-msgstr "Mostra el número de versió"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/cc-application.c:46
-msgid "Enable verbose mode"
-msgstr "Habilita el mode detallat"
-
-#: ../shell/cc-application.c:47
-msgid "Show the overview"
-msgstr "Mostra la visió general"
-
-#: ../shell/cc-application.c:48
-msgid "Search for the string"
-msgstr "Busca la cadena"
-
-#: ../shell/cc-application.c:49
-msgid "List possible panel names and exit"
-msgstr "Llista tots els noms de quadre possibles i ix"
-
-#: ../shell/cc-application.c:50
-msgid "Panel to display"
-msgstr "Quadre a mostrar"
-
-#: ../shell/cc-application.c:50
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[QUADRE] [ARGUMENT…]"
-
-#: ../shell/cc-application.c:113
-msgid "Available panels:"
-msgstr "Quadres disponibles:"
-
-#: ../shell/cc-application.c:252
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../shell/cc-application.c:253
-msgid "Quit"
-msgstr "Ix"
-
-#: ../shell/gnome-control-center.desktop.in.in.h:2
-msgid "Preferences;Settings;"
-msgstr "Preferències;Paràmetres;"
-
-#: ../shell/help-overlay.ui.h:1
+#: shell/help-overlay.ui:15
 msgctxt "shortcut window"
 msgid "General"
 msgstr "General"
 
-#: ../shell/help-overlay.ui.h:2
+#: shell/help-overlay.ui:20
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Ix"
 
-#: ../shell/help-overlay.ui.h:3
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "Busca"
 
-#: ../shell/help-overlay.ui.h:4
+#: shell/help-overlay.ui:35
 msgctxt "shortcut window"
 msgid "Panels"
 msgstr "Quadres"
 
-#: ../shell/help-overlay.ui.h:5
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
 msgctxt "shortcut window"
-msgid "Go back to the overview"
+msgid "Go back to previous panel"
 msgstr "Torna a la visió general"
 
-#: ../shell/help-overlay.ui.h:6
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Cancel·la la busca"
 
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: ../shell/hostname-helper.c:189
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Punt d'accés Wi-Fi"
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferències;Paràmetres;"
 
-#: ../shell/panel-list.ui.h:3
-msgid "No results found"
-msgstr "No s'ha trobat cap resultat."
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u eixida"
+msgstr[1] "%u eixides"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrada"
+msgstr[1] "%u entrades"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Canvia durant el dia"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Mosaic"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Amplia"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centra"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Escala"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Omple"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Allarga"
+
+#~ msgid "Colors"
+#~ msgstr "Colors"
+
+#~ msgid "Select Background"
+#~ msgstr "Selecciona el fons"
+
+#~ msgid "Pictures"
+#~ msgstr "Imatges"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "No s'ha trobat cap imatge"
+
+#~ msgid "Home"
+#~ msgstr "Inici"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Podeu afegir imatges a la carpeta %s i apareixeran ací"
+
+#~ msgid "multiple sizes"
+#~ msgstr "mides múltiples"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Sense imatge de fons de l'escriptori"
+
+#~ msgid "Current background"
+#~ msgstr "Imatge de fons actual"
+
+#~ msgid "Back­ground"
+#~ msgstr "Fons"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Fons de pantalla;Pantalla;Escriptori;"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Col·loqueu el dispositiu de calibratge sobre el quadre i premeu «Inicia»."
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Moveu el dispositiu de calibratge a la posició de calibratge i premeu "
+#~ "«Continua»."
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Moveu el dispositiu de calibratge a la posició de la superfície i premeu "
+#~ "«Continua»."
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Tanca la tapa del portàtil"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "S'ha produït un error intern que no s'ha pogut recuperar."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Les eines que calen pel calibratge no estan instal·lades."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "No s'ha pogut generar el perfil."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "No s'ha pogut obtindre el punt blanc de l'objectiu."
+
+#~ msgid "Complete!"
+#~ msgstr "S'ha completat"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Ha fallat el calibratge"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Podeu treure el dispositiu de calibratge."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "No interrompeu el dispositiu de calibratge mentre treballi"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Pantalla del portàtil"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Escànner %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Impressora %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Càmera web %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Habilita la gestió del color per a %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Mostra els perfils de color per a %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Sense calibrar"
+
+#~ msgid "Default: "
+#~ msgstr "Per defecte: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Perfil de comprovació: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Selecciona un fitxer de perfil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importa"
+
+#~ msgid "All files"
+#~ msgstr "Tots els fitxers"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "No s'ha pogut pujar el fitxer: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "S'ha actualitzat el perfil a:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Apunteu este URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Reinicieu l'ordinador i arrenqueu el vostre sistema operatiu normal."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Escriviu l'URL al navegador web per baixar i instal·lar el perfil."
+
+#~ msgid "Save Profile"
+#~ msgstr "Guarda el perfil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Crea un perfil de color per al dispositiu seleccionat"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "No s'ha detectat l'instrument de mesura. Comproveu que estiga encés i "
+#~ "connectat correctament."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "L'instrument de mesura no admet el perfilat d'impressores."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "El tipus de dispositiu no és compatible actualment."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espai estàndard"
+
+#~ msgid "Test Profile"
+#~ msgstr "Perfil de comprovació"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automàtic"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Qualitat baixa"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Qualitat mitjana"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Qualitat alta"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB per defecte"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK per defecte"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Gris per defecte"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Dades de calibratge de fàbrica proporcionades pel venedor"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "Amb este perfil no es pot fer la correcció de la pantalla en mode "
+#~ "pantalla completa "
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Este perfil potser ja no és precís"
+
+#~ msgid "Upload profile"
+#~ msgstr "Puja el perfil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Requereix connexió a Internet"
+
+#~ msgid "Co­lor"
+#~ msgstr "Color"
+
+#~ msgid "Other…"
+#~ msgstr "Altres…"
+
+#~ msgid "Today"
+#~ msgstr "Hui"
+
+#~ msgid "Yesterday"
+#~ msgstr "Ahir"
+
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b, %Y"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e de %B del %Y a les %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e de %B de %Y a les %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l∶%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr ":"
+
+#~ msgid "24-hour"
+#~ msgstr "24 hores"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Apaïsada"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Vertical dreta"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Vertical esquerra"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Apaïsada (capgirada)"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Disposició de les pantalles"
+
+#~ msgid ""
+#~ "Drag displays to match your setup. The top bar is placed on the primary "
+#~ "display."
+#~ msgstr ""
+#~ "Arrossegueu les pantalles per configurar-les. La barra superior se situa "
+#~ "a la pantalla primària."
+
+#~ msgid "Display Mode"
+#~ msgstr "Mode de pantalla"
+
+#~ msgid "Join Displays"
+#~ msgstr "Uneix pantalles"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Voleu aplicar els canvis?"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "On"
+#~ msgstr "Activat"
+
+#~ msgid "Off"
+#~ msgstr "Desactivat"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Llum nocturna"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "No s'ha pogut obtindre la informació de la pantalla"
+
+#~ msgid "Unknown"
+#~ msgstr "Desconegut"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "Versió %s"
+
+#~ msgid "Overview"
+#~ msgstr "Visió general"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Pregunta què fer"
+
+#~ msgid "Do nothing"
+#~ msgstr "No faces res"
+
+#~ msgid "Open folder"
+#~ msgstr "Obri la carpeta"
+
+#~ msgid "Other Media"
+#~ msgstr "Altres suports"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Seleccioneu l'aplicació per als CD d'àudio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Seleccioneu l'aplicació per als DVD de vídeo"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Seleccioneu l'aplicació que s'iniciarà quan es connecte un reproductor de "
+#~ "música"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Seleccioneu l'aplicació que s'iniciarà quan es connecte una càmera"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Seleccioneu l'aplicació per als CD de programari"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD d'àudio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Disc Blu-ray en blanc"
+
+#~ msgid "blank CD disc"
+#~ msgstr "Disc CD en blanc"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "Disc DVD en blanc"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Disc HD DVD en blanc"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disc Blu-ray de vídeo"
+
+#~ msgid "e-book reader"
+#~ msgstr "Lector de llibres digitals"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disc HD DVD de vídeo"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD de fotos"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Supervídeo CD"
+
+#~ msgid "Video CD"
+#~ msgstr "CD de vídeo"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Aplicacions per defecte"
+
+#~ msgid "Ab­out"
+#~ msgstr "Quant a"
+
+#~ msgid "De­tails"
+#~ msgstr "Detalls"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Suport extraïble"
+
+#~ msgid "OS name"
+#~ msgstr "Nom del sistema operatiu"
+
+#~ msgid "OS type"
+#~ msgstr "Tipus de sistema operatiu"
+
+#~ msgid "Disk"
+#~ msgstr "Disc"
+
+#~ msgid "Check for updates"
+#~ msgstr "Comprova si hi ha actualitzacions"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Guarda una captura de pantalla a $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Guarda una captura de pantalla d'una finestra a $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Guarda una captura de pantalla d'una àrea a $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copia una captura de pantalla al porta-retalls"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copia una captura de pantalla d'una finestra al porta-retalls"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copia una captura de pantalla d'una àrea al porta-retalls"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Grava un screencast curt"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Només els modificadors commuten a la font següent"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Voleu restablir totes les dreceres?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Restablir les dreceres pot afectar les vostres dreceres personalitzades. "
+#~ "Esta acció no es pot desfer."
+
+#~ msgid "Reset All"
+#~ msgstr "Restableix-ho tot"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for <b>%s</b>. If you replace it, %s will be "
+#~ "disabled"
+#~ msgstr "%s ja s'utilitza per <b>%s</b>. Si la reemplaceu, %s s'inhabilitarà"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Estableix la drecera personalitzada"
+
+#, c-format
+#~ msgid "Enter new shortcut to change <b>%s</b>."
+#~ msgstr "Introduïu una drecera nova per canviar <b>%s</b>."
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Introduïu la drecera nova"
+
+#~ msgid "Set"
+#~ msgstr "Estableix"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Temps d'espera del doble clic"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Desplaçament amb dos dits"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinc clics, és l'hora del GEGL"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Doble clic, botó primari"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Un sol clic, botó primari"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Doble clic, botó del mig"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Un sol clic, botó del mig"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Doble clic, botó secundari"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Un sol clic, botó secundari"
+
+#~ msgid "Network proxy"
+#~ msgstr "Servidor intermediari de xarxa"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Cal que el NetworkManager estiga executant-se."
+
+#~ msgid "page 1"
+#~ msgstr "pàgina 1"
+
+#~ msgid "page 2"
+#~ msgstr "pàgina 2"
+
+#~ msgid "automatic"
+#~ msgstr "automàtic"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Perfil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Corporativa"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Dèbil"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Acceptable"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bona"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excel·lent"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Suprimeix el perfil de connexió"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Suprimeix VPN"
+
+#~ msgid "Identity"
+#~ msgstr "Identitat"
+
+#~ msgid "Delete Route"
+#~ msgstr "Suprimeix la ruta"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Clau WEP 40/128-bit (hexadecimal o ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Contrasenya WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinàmic (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA i WPA2 personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA i WPA2 corporativa"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Parells trenats (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Interfície d'unitat d'acoblament (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Interfície independent de medis (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "No s'ha pogut obrir l'editor de connexions"
+
+#~ msgid "New Profile"
+#~ msgstr "Perfil nou"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importa des d'un fitxer…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Afig VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "No es pot importar la connexió VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "No s'ha pogut llegir el fitxer «%s» o no conté informació reconeguda "
+#~ "d'una connexió VPN\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Seleccioneu el fitxer a importar"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Ja existeix un fitxer amb el nom «%s»."
+
+#~ msgid "_Replace"
+#~ msgstr "_Substitueix"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Voleu substituir %s amb la connexió VPN que esteu desant?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "No es pot exportar la connexió VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "No s'ha pogut exportar la connexió VPN «%s» a %s.\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exporta la connexió VPN"
+
+#~ msgid "Net­work"
+#~ msgstr "Xarxa"
+
+#~ msgid "never"
+#~ msgstr "mai"
+
+#~ msgid "today"
+#~ msgstr "hui"
+
+#~ msgid "yesterday"
+#~ msgstr "ahir"
+
+#~ msgid "Last used"
+#~ msgstr "Utilitzada per últim cop"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Si activeu el punt d'accés sense fil vos desconnectareu de <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "No és possible accedir a Internet a través de la xarxa sense fil mentre "
+#~ "el punt d'accés està actiu."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Els punts d'accés Wi-Fi s'utilitzen habitualment per compartir una "
+#~ "connexió Internet addicional per Wi-fi."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Voleu aturar el punt d'accés Wi-Fi i desconnectar els usuaris?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Atura el punt d'accés Wi-Fi"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr ""
+#~ "La política del sistema prohibeix utilitzar-lo com a punt d'accés Wi-Fi"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "El dispositiu sense fil no admet el mode punt d'accés Wi-Fi"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Es perdran les dades de xarxa de les xarxes seleccionades, incloent les "
+#~ "contrasenyes i la configuració personalitzada."
+
+#~ msgid "_Forget"
+#~ msgstr "_Oblida"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Xarxes sense fil conegudes"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Oblida"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "El descobriment automàtic de servidors intermediaris web s'utilitza quan "
+#~ "no es proporciona un URL de configuració."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "No és recomanable en xarxes públiques sense confiança."
+
+#~ msgid "details"
+#~ msgstr "detalls"
+
+#~ msgid "Show P_assword"
+#~ msgstr "_Mostra la contrasenya"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Fes-la disponible a altres usuaris"
+
+#~ msgid "identity"
+#~ msgstr "identitat"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adreces"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Només adreces automàtiques (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Només enllaç local"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignora les rutes obtingudes automàticament"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Adreça MAC _clonada"
+
+#~ msgid "hardware"
+#~ msgstr "maquinari"
+
+#~ msgid "_Reset"
+#~ msgstr "_Reinicia"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Reinicia els paràmetres d'esta connexió als valors per defecte, però "
+#~ "recorda-la com a connexió preferida."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Suprimeix totes les dades relacionades amb esta xarxa i no intentes "
+#~ "connectar-t'hi automàticament."
+
+#~ msgid "reset"
+#~ msgstr "reinicia"
+
+#~ msgid "Hardware"
+#~ msgstr "Maquinari"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Restableix"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Desactiva-ho per connectar-se a una xarxa Wi-Fi"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Dispositius connectats"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infraestructura"
+
+#~ msgid "Status unknown"
+#~ msgstr "Estat desconegut"
+
+#~ msgid "Unmanaged"
+#~ msgstr "No gestionat"
+
+#~ msgid "Unavailable"
+#~ msgstr "No disponible"
+
+#~ msgid "Connecting"
+#~ msgstr "S'està connectant"
+
+#~ msgid "Authentication required"
+#~ msgstr "Cal autenticació"
+
+#~ msgid "Disconnecting"
+#~ msgstr "S'està desconnectant"
+
+#~ msgid "Connection failed"
+#~ msgstr "Ha fallat la connexió"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Estat desconegut (falta)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Ha fallat la configuració"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Ha fallat la configuració de la IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Ha caducat la configuració de la IP"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Calen secrets, però no s'han proporcionat"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "S'ha desconnectat el suplicant de 802.1x"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Ha fallat la configuració del suplicant de 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Ha fallat el suplicant de 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "El suplicant de 802.1x ha tardat massa en autenticar"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "No s'ha pogut iniciar el servei PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "S'ha desconnectat el servei PPP"
+
+#~ msgid "PPP failed"
+#~ msgstr "Ha fallat el PPP"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "No s'ha pogut iniciar el client DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "S'ha produït un error en el client DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Ha fallat el client DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "No s'ha pogut iniciar el servei de connexió compartida"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Ha fallat el servei de connexió compartida"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "No s'ha pogut iniciar el servei AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "S'ha produït un error en el servei AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Ha fallat el servei AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "Línia ocupada"
+
+#~ msgid "No dial tone"
+#~ msgstr "No hi ha to de trucada"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "No s'ha pogut establir cap portadora"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Ha acabat el temps d'espera de la sol·licitud de trucada"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Ha fallat l'intent de trucada"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Ha fallat la inicialització del mòdem"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "No s'ha pogut seleccionar l'APN especificat"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "No s'estan cercant xarxes"
+
+#~ msgid "Network registration denied"
+#~ msgstr "S'ha denegat el registre a la xarxa"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Ha acabat el temps d'espera del registre de la xarxa"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Ha fallat el registre amb la xarxa sol·licitada"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Ha fallat la comprovació del PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Pot ser que falti el microprograma del dispositiu"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Ha desaparegut la connexió"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "S'havia assumit una connexió existent"
+
+#~ msgid "Modem not found"
+#~ msgstr "No s'ha trobat el mòdem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Ha fallat la connexió Bluetooth"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Cal el PIN de la SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Cal el PUK de la SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM incorrecta"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Ha fallat la dependència de la connexió"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cable desconnectat"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr ""
+#~ "s'ha produït un error no definit en la seguretat de 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "no s'ha seleccionat cap fitxer"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr ""
+#~ "s'ha produït un error no especificat en validar el fitxer eap-method"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "Claus privades DER, PEM o PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificats DER o PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "falta el fitxer EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Fitxers PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "falta el nom d'usuari EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "falta la contrasenya EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "certificat CA EAP-PEAP no vàlid: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-PEAP no vàlid: no s'ha especificat un certificat"
+
+#~ msgid "missing EAP username"
+#~ msgstr "falta el nom d'usuari EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "falta la contrasenya EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "falta la identitat EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TLS invàlid: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TLS invàlid: no s'ha especificat un certificat"
+
+#~ msgid "invalid EAP-TLS password: missing"
+#~ msgstr "contrasenya EAP-TLS invàlida: falta la contrasenya"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "clau privada EAP-TLS no vàlida: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificat d'usuari EAP-TLS no vàlid: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Les claus privades sense encriptar no són segures"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "La clau privada que heu seleccionat no pareix protegida amb una "
+#~ "contrasenya. Això podria permetre que les credencials de seguretat fossin "
+#~ "compromeses. Seleccioneu una clau privada protegida per contrasenya.\n"
+#~ "\n"
+#~ "(Podeu protegir la vostra clau privada amb una contrasenya amb l'openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Trieu el vostre certificat personal"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Trieu la vostra clau privada"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TTLS no vàlid: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TTLS no vàlid: no s'ha especificat un certificat"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "S'ha produït un error desconegut en validar la seguretat de 802.1X"
+
+#~ msgid "missing leap-username"
+#~ msgstr "falta el mom d'usuari LEAP"
+
+#~ msgid "missing leap-password"
+#~ msgstr "falta la contrasenya LEAP"
+
+#~ msgid "missing wep-key"
+#~ msgstr "falta la clau wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "clau wep invàlida: una clau amb longitud %zu ha de contindre només dígits "
+#~ "hexadecimals"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "clau wep invàlida: una clau amb longitud %zu ha de contindre només "
+#~ "caràcters ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "clau wep invàlida: la longitud de clau %zu és errònia. Una clau ha de "
+#~ "tindre una longitud de 5/13 (ascii) o bé 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "clau wep invàlida: la contrasenya no pot ser buida."
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "clau wep invàlida: la contrasenya ha de tindre menys de 64 caràcters"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk no vàlid: longitud de clau %zu no vàlida. Ha de tindre [8,63] "
+#~ "bytes o 64 dígits hexadecimals"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk no vàlid: no es pot interpretar la clau de 64 bytes com a "
+#~ "hexadecimal"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Notificacions"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Notificacions emergents"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Altres"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Compte de %s"
+
+#~ msgid "Error removing account"
+#~ msgstr "S'ha produït un error en suprimir el compte"
+
+#, c-format
+#~ msgid "<b>%s</b> removed"
+#~ msgstr "<b>%s</b> s'ha suprimit"
+
+#~ msgid "Remove Account"
+#~ msgstr "Suprimeix el compte"
+
+#~ msgid "Unknown time"
+#~ msgstr "Temps desconegut"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s fins que es carregi del tot"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Atenció: queden %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Queden %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Totalment carregada"
+
+#~ msgid "Empty"
+#~ msgstr "Buida"
+
+#~ msgid "Charging"
+#~ msgstr "S'està carregant"
+
+#~ msgid "Discharging"
+#~ msgstr "S'està descarregant"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principal"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Addicional"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Ratolí sense fil"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Teclat sense fil"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Sistema d'alimentació ininterrompuda"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Auxiliar digital personal"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telèfon mòbil"
+
+#~ msgid "Media player"
+#~ msgstr "Reproductor multimèdia"
+
+#~ msgid "Computer"
+#~ msgstr "Ordinador"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "S'està carregant"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Precaució"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Baixa"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Bona"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Totalment carregada"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Buida"
+
+#~ msgid "Batteries"
+#~ msgstr "Bateries"
+
+#~ msgid "When _idle"
+#~ msgstr "Quan estiga _inactiu"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "Brillantor de la _pantalla"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "Brillantor del _teclat"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "_Atenua la pantalla quan estiga inactiva"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+#~ msgstr ""
+#~ "Desactiveu la banda ampla mòbil (3G, 4G, WiMax, etc.) per estalviar "
+#~ "energia."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "When on battery power"
+#~ msgstr "Quan s'utilitze la bateria"
+
+#~ msgid "When plugged in"
+#~ msgstr "Quan estiga endollat"
+
+#~ msgid "Suspend"
+#~ msgstr "Atura temporalment"
+
+#~ msgid "Power Off"
+#~ msgstr "Apaga"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hiberna"
+
+#~ msgid "Nothing"
+#~ msgstr "Res"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Botó d'aturada temporal i d'engegada"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Aturada temporal automàtica"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Aturada temporal automàtica"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Quan es prem el botó d'engegada"
+
+#~ msgid "Po­wer"
+#~ msgstr "Energia"
+
+#~ msgid "1 minute"
+#~ msgstr "1 minut"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 minuts"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 minuts"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 minuts"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 minuts"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 minuts"
+
+#~ msgid " "
+#~ msgstr " "
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "S'ha suprimit la impressora «%s»"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "No s'ha pogut afegir una impressora nova."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "No s'ha pogut carregar la interfície d'usuari: %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "No s'ha trobat cap controlador adequat"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Fitxers de descripció d'impressora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
+#~ "PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Impressora JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Impressora LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Una cara"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Cantó llarg (estàndard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Cantó curt (capgirat)"
+
+#~ msgid "Portrait"
+#~ msgstr "Vertical"
+
+#~ msgid "Landscape"
+#~ msgstr "Apaïsat"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Apaïsat del revés"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Vertical del revés"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Pendent"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pausat"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "S'està processant"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Aturada"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Cancel·lada"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Interrompuda"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Completada"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - tasques actives"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Desbloqueja el servidor d'impressió"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Desbloqueja %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Introduïu el nom d'usuari i la contrasenya per visualitzar les "
+#~ "impressores a %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "S'estan cercant les impressores"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Port en sèrie"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Port paral·lel"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Ubicació: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adreça: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "Doble cara"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tipus de paper"
+
+#~ msgid "Paper Source"
+#~ msgstr "Font del paper"
+
+#~ msgid "Output Tray"
+#~ msgstr "Safata d'eixida"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Filtrat previ del GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Pàgines per cara"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "General"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Configuració de la pàgina"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opcions instal·lables"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Tasca"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Qualitat de la imatge"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Acabats"
+
+#~ msgid "Test page"
+#~ msgstr "Pàgina de prova"
+
+#~ msgid "Auto Select"
+#~ msgstr "Selecció automàtica"
+
+#~ msgid "Printer Default"
+#~ msgstr "Per defecte de la impressora"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Incrusta només tipus de lletra del GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Converteix a PS nivell 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Converteix a PS nivell 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Sense filtrat previ"
+
+#~ msgid "Out of toner"
+#~ msgstr "Sense tòner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Revelador baix"
+
+#~ msgid "Out of developer"
+#~ msgstr "Sense revelador"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Marcador baix"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Sense marcador"
+
+#~ msgid "Open cover"
+#~ msgstr "Tapa oberta"
+
+#~ msgid "Open door"
+#~ msgstr "Porta oberta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Paper baix"
+
+#~ msgid "Out of paper"
+#~ msgstr "Sense paper"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Apagada"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Aturada"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "El receptacle de residus està quasi ple"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "El receptacle de residus està ple"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "El conductor òptic fotogràfic està al final de la seua vida"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "El conductor òptic fotogràfic ja no funciona"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "A punt"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "No accepta tasques"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "S'està processant"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Neteja els capçals d'impressió"
+
+#~ msgid "Add…"
+#~ msgstr "Afig..."
+
+#~ msgid "In use"
+#~ msgstr "En ús"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Activat"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Desactivat"
+
+#~ msgid "Usage & History"
+#~ msgstr "Ús i historial"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Voleu buidar la paperera?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Se suprimiran permanent tots els elements de la paperera."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Buida la paperera"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Voleu suprimir tots fitxers temporals?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Se suprimiran permanent tots els fitxers temporals."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Suprimeix els fitxers _temporals"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Enviar informes de problemes tècnics ajuda a millorar %s. Els informes "
+#~ "s'envien anònimament i sense dades personals."
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Política de privacitat"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Privadesa"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Protegiu la informació personal i controleu què poden veure els altres"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 segons"
+
+#~ msgid "1 day"
+#~ msgstr "1 dia"
+
+#~ msgid "2 days"
+#~ msgstr "2 dies"
+
+#~ msgid "3 days"
+#~ msgstr "3 dies"
+
+#~ msgid "4 days"
+#~ msgstr "4 dies"
+
+#~ msgid "5 days"
+#~ msgstr "5 dies"
+
+#~ msgid "6 days"
+#~ msgstr "6 dies"
+
+#~ msgid "7 days"
+#~ msgstr "7 dies"
+
+#~ msgid "14 days"
+#~ msgstr "14 dies"
+
+#~ msgid "30 days"
+#~ msgstr "30 dies"
+
+#~ msgid "Forever"
+#~ msgstr "Per sempre"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Si es recorda l'historial, és més fàcil tornar a trobar les coses. Estos "
+#~ "elements no es comparteixen mai a la xarxa."
+
+#~ msgid "_Recently Used"
+#~ msgstr "Utilitzat _recentment"
+
+#~ msgid "Retain _History"
+#~ msgstr "Conserva l'_historial"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "El bloqueig de la pantalla protegeix la vostra privacitat quan no hi sou."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "_Bloca la pantalla després d'estar en blanc durant"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Buideu automàticament la paperera i els fitxers temporals per ajudar a "
+#~ "mantindre l'ordinador lliure d'informació sensible innecessària."
+
+#~ msgid "Purge _After"
+#~ msgstr "Suprimeix _després de"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "L'enviament d'informació sobre el programari que feu servir ens ajuda a "
+#~ "donar-vos recomanacions més adequades. Això també ens ajuda a millorar el "
+#~ "nostre programari.\n"
+#~ "\n"
+#~ "Tota la informació recollida és anònima i mai no compartirem les vostres "
+#~ "dades amb terceres parts."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "Envia e_stadístiques d'ús de programari"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Els serveis d'ubicació permeten que les aplicacions puguen saber on sou. "
+#~ "L'ús de Wi-Fi i de dades mòbils permet millorar la precisió."
+
+#~ msgid "_Location Services"
+#~ msgstr "Serveis d'_ubicació"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Mètric"
+
+#~ msgid "No regions found"
+#~ msgstr "No s'han trobat regions"
+
+#~ msgid "No input sources found"
+#~ msgstr "No s'han trobat fonts d'entrada"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Altres"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Commuta a la font anterior"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Súper+Maj+Espai"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Commuta a la font següent"
+
+#~ msgid "Super+Space"
+#~ msgstr "Súper+Espai"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "Podeu canviar estes dreceres als paràmetres del teclat"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Forma alternativa per canviar a la font següent"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt dreta i esquerra"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Anglés (Regne Unit)"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Cal que reinicieu la sessió perquè els canvis tinguen efecte."
+
+#~ msgid "Restart…"
+#~ msgstr "Reinicia…"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Regne Unit"
+
+#~ msgid "_Options"
+#~ msgstr "_Opcions"
+
+#~ msgid "Add input source"
+#~ msgstr "Afig una font d'entrada"
+
+#~ msgid "Remove input source"
+#~ msgstr "Suprimeix una font d'entrada"
+
+#~ msgid "Move input source up"
+#~ msgstr "Mou la font d'entrada amunt"
+
+#~ msgid "Move input source down"
+#~ msgstr "Mou la font d'entrada avall"
+
+#~ msgid "Configure input source"
+#~ msgstr "Configura la font d'entrada"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Mostra la disposició del teclat de la font d'entrada"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Tots els usuaris utilitzen els paràmetres d'entrada en entrar al sistema"
+
+#~ msgid "Select Location"
+#~ msgstr "Seleccioneu una ubicació"
+
+#~ msgid "_OK"
+#~ msgstr "_D'acord"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "No hi ha cap xarxa seleccionada per compartir"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Activat"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Desactivat"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Habilitat"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Trieu una carpeta"
+
+#, c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "La compartició de fitxers personals vos permet compartir la carpeta "
+#~ "pública amb altres a la xarxa actual utilitzant: <a href=\"dav://"
+#~ "%s\">dav://%s</a>"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "Quan l'entrada remota està habilitada, els usuaris remots poden connectar-"
+#~ "se utilitzant l'orde del Secure Shell:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "La compartició de pantalla permet a usuaris remots visualitzar o "
+#~ "controlar la pantalla connectant-se a: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Compartició"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Compartició de pantalla"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Alguns serveis estan inhabilitats perquè no hi ha accés a la xarxa."
+
+#~ msgid "_Password:"
+#~ msgstr "_Contrasenya:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Mostra la contrasenya"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Les connexions noves han de demanar accés"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Demana una contrasenya"
+
+#~ msgid "Bark"
+#~ msgstr "Lladruc"
+
+#~ msgid "Drip"
+#~ msgstr "Goteig"
+
+#~ msgid "Glass"
+#~ msgstr "Vidre"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Esquerra"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Dreta"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Mínim"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Màxim"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "Altaveu de _greus:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Sense amplificar"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Perfil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Prova els altaveus"
+
+#~ msgid "Peak detect"
+#~ msgstr "Detecció de pics"
+
+#~ msgid "Device"
+#~ msgstr "Dispositiu"
+
+# N.T.: Títol de quadre de diàleg
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Prova d'altaveus per a %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Trieu un dispositiu per a l'eixida de so:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Paràmetres del dispositiu seleccionat:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Volum d'_entrada:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Trieu un dispositiu per a l'entrada de so:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Efectes de so"
+
+#~ msgid "Built-in"
+#~ msgstr "Integrat"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferències de so"
+
+#~ msgid "Testing event sound"
+#~ msgstr "S'està provant el so de l'esdeveniment"
+
+#~ msgid "From theme"
+#~ msgstr "Del tema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Trieu un so d'_alerta:"
+
+#~ msgid "Stop"
+#~ msgstr "Atura"
+
+#~ msgid "Custom"
+#~ msgstr "Personalitzat"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Per defecte"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Mitjà"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Gran"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Més gran"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "El més gran"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d píxel"
+#~ msgstr[1] "%d píxels"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Accés universal"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Lector de pantalla"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Lector de _pantalla"
+
+#~ msgid "Sound Keys"
+#~ msgstr "So de les tecles"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Fes parpellejar el títol de la _finestra"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Curta"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Llarga"
+
+#~ msgid "Standard"
+#~ msgstr "Estàndard"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Tipus de compte"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "_Permet a l'usuari establir la contrasenya a l'entrada següent"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_Estableix una contrasenya ara"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Heu d'estar en línia per afegir usuaris corporatius."
+
+#~ msgid "Left thumb"
+#~ msgstr "Polze esquerre"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Dit del mig esquerre"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Dit anular esquerre"
+
+#~ msgid "Left little finger"
+#~ msgstr "Dit petit esquerre"
+
+#~ msgid "Right thumb"
+#~ msgstr "Polze dret"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Dit del mig dret"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Dit anular dret"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dit petit dret"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Habilita l'entrada amb empremta dactilar"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Dit índex d_ret"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Dit índex _esquerre"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "La vostra empremta dactilar s'ha guardat correctament. Hauríeu de poder "
+#~ "entrar utilitzant el lector d'empremtes dactilars."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Entrada;Nom;Empremta dactilar;Avatar;Logotip;Cara;Contrasenya;"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Verifica la contrasenya nova"
+
+#~ msgid "User Icon"
+#~ msgstr "Icona d'usuari"
+
+#~ msgid "Last Login"
+#~ msgstr "Últim inici de sessió"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "La contrasenya nova ha de ser diferent de la vella."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Canvieu algunes lletres i números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Canvieu la contrasenya una mica més."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Una contrasenya sense el vostre nom d'usuari seria més segura."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Eviteu l'ús del vostre nom a la contrasenya."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Eviteu algunes de les paraules incloses a la contrasenya."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Eviteu utilitzar paraules comunes."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Eviteu utilitzar paraules desordenades."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Utilitzeu més nombres."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Utilitzeu més lletres majúscules."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Utilitzeu més lletres minúscules."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Utilitzeu més caràcters especials, com ara signes de puntuació."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Intenteu utilitzar una combinació de lletres, nombres i signes de "
+#~ "puntuació."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Eviteu repetir el mateix caràcter."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Eviteu repetir el mateix tipus de caràcter: combineu lletres, números i "
+#~ "signes de puntuació."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Eviteu emprar seqüències com ara 1234 o abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Cal que la contrasenya siga més gran. Intenteu utilitzar una combinació "
+#~ "de lletres, nombres i signes de puntuació."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Combineu majúscules i minúscules i empreu un o dos nombres."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Si hi afegiu més lletres, nombres i signes de puntuació la contrasenya "
+#~ "serà més segura."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Ha fallat l'autenticació"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "La contrasenya nova és massa curta"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "La contrasenya nova és massa senzilla"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "La contrasenya nova i l'anterior són massa semblants"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "La contrasenya nova ja s'ha utilitzat recentment."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "La contrasenya nova ha de contindre caràcters numèrics o especials"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "La contrasenya nova i l'anterior són iguals"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "La vostra contrasenya ha canviat des que vos heu autenticat."
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "La contrasenya nova no conté suficients caràcters diferents"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Error desconegut"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Ha de coincidir amb l'adreça web del proveïdor del compte."
+
+#~ msgid "Failed to add account"
+#~ msgstr "No s'ha pogut afegir el compte"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Les contrasenyes no coincideixen."
+
+#~ msgid "Failed to register account"
+#~ msgstr "No s'ha pogut registrar el compte"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "No hi ha cap manera compatible per autenticar-se amb este domini"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "No s'ha pogut unir al domini"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "El nom d'usuari no és correcte.\n"
+#~ "Torneu-ho a provar."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "La contrasenya no és vàlida.\n"
+#~ "Torneu-ho a provar."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "No s'ha pogut entrar al domini"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "No s'ha trobat el domini. Potser l'heu escrit malament?"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Estàndard"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrador"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "No teniu permís per accedir al dispositiu. Contacteu amb l'administrador "
+#~ "del sistema."
+
+#~ msgid "The device is already in use."
+#~ msgstr "El dispositiu ja està en ús."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "S'ha produït un error intern."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Voleu suprimir les empremtes dactilars registrades?"
+
+#~ msgid "Done!"
+#~ msgstr "Fet"
+
+#, c-format
+#~ msgid "Could not access “%s” device"
+#~ msgstr "No s'ha pogut accedir al dispositiu «%s»."
+
+#, c-format
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr ""
+#~ "No s'ha pogut iniciar la captura de l'empremta dactilar al dispositiu "
+#~ "«%s»."
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "No s'ha pogut accedir a cap lector d'empremtes dactilars"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Contacteu amb l'administrador del sistema per obtindre ajuda."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Per habilitar l'entrada amb empremta dactilar, cal que guardeu una de les "
+#~ "vostres empremtes dactilars utilitzant el dispositiu «%s»."
+
+#~ msgid "Selecting finger"
+#~ msgstr "S'està seleccionant un dit"
+
+#~ msgid "This Week"
+#~ msgstr "Esta setmana"
+
+#~ msgid "Last Week"
+#~ msgstr "Setmana passada"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Ha acabat la sessió"
+
+#~ msgid "Session Started"
+#~ msgstr "S'ha iniciat la sessió"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s - Activitat del compte"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Trieu una altra contrasenya."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Escriviu un altre cop la vostra contrasenya actual."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "No s'ha pogut canviar la contrasenya"
+
+#~ msgid "Disable image"
+#~ msgstr "Inhabilita la imatge"
+
+#~ msgid "Take a photo…"
+#~ msgstr "Fes una fotografia…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Busca més imatges…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "Utilitzat per %s"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "No es pot unir automàticament a este tipus de domini"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "No s'ha trobat este domini o regne"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "No s'ha pogut entrar com a %s al domini %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "La contrasenya no vàlida, torneu-ho a provar"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "No s'ha pogut suprimir l'usuari"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "No s'ha pogut revocar l'usuari gestionat remotament"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "No podeu suprimir el vostre compte."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s encara està connectat"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Si suprimiu un usuari mentre està connectat pot deixar el sistema "
+#~ "inconsistent."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Voleu conservar els fitxers de %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Es pot conservar el directori de l'usuari, la cua de correu i els fitxers "
+#~ "temporals quan suprimiu un compte d'usuari."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Suprimeix els fitxers"
+
+#~ msgid "_Keep Files"
+#~ msgstr "C_onserva els fitxers"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Segur que voleu revocar el compte %s de l'usuari gestionat remotament?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Suprimeix"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Compte inhabilitat"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "S'ha de configurar la pròxima vegada que entri"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgid "Logged in"
+#~ msgstr "Connectat"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "No s'ha pogut contactar amb el servei de comptes"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Assegureu-vos que el servei de comptes està instal·lat i habilitat."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Per fer-hi canvis,\n"
+#~ "primer feu clic a la icona *"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Per crear un compte d'usuari,\n"
+#~ "primer feu clic a la icona *"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Suprimeix el compte d'usuari seleccionat"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Per suprimir el compte d'usuari seleccionat,\n"
+#~ "primer feu clic a la icona *"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "El nom d'usuari no està disponible. Trieu-ne un altre."
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "El nom d'usuari és massa llarg."
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "El nom d'usuari no pot començar amb un «-»."
+
+#~ msgid ""
+#~ "The username should only consist of upper and lower case letters from a-"
+#~ "z, digits and the following characters: . - _"
+#~ msgstr ""
+#~ "El nom d'usuari només ha de consistir en lletres minúscules i majúscules "
+#~ "de la «a» a la «z», dígits i qualsevol dels caràcters «.», «-» i «_»"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Es farà servir per anomenar la vostra carpeta personal i no es pot "
+#~ "canviar."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Botó %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Envia una pulsació de tecla"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Commuta el monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Mostra l'ajuda en pantalla"
+
+#~ msgid "Output:"
+#~ msgstr "Eixida:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Mantén la relació d'aspecte (format de bústia):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapa a una sola pantalla"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Mapat de la pantalla"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Tauleta gràfica Wacom"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tauleta gràfica (absolut)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferències de la tauleta gràfica"
+
+#~ msgid "_Help"
+#~ msgstr "_Ajuda"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Paràmetres del Bluetooth"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Mapa els botons…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Ajusta la resolució de la pantalla"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Ajusta els paràmetres del ratolí"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Mode de seguiment"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Drecera nova…"
+
+#~ msgid "No stylus found"
+#~ msgstr "No s'ha trobat cap llapis"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Moveu el llapis a prop de la tauleta per configurar-lo."
+
+#~ msgid "Top Button"
+#~ msgstr "Botó superior"
+
+#~ msgid "page 3"
+#~ msgstr "pàgina 3"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Personal"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Maquinari"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistema"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Centre de control del GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "El centre de control és la interfície principal del GNOME per a la "
+#~ "configuració de diversos aspectes de l'escriptori."
+
+#~ msgid "Display version number"
+#~ msgstr "Mostra el número de versió"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Habilita el mode detallat"
+
+#~ msgid "Show the overview"
+#~ msgstr "Mostra la visió general"
+
+#~ msgid "Search for the string"
+#~ msgstr "Busca la cadena"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Llista tots els noms de quadre possibles i ix"
+
+#~ msgid "Panel to display"
+#~ msgstr "Quadre a mostrar"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[QUADRE] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Quadres disponibles:"
+
+#~ msgid "Quit"
+#~ msgstr "Ix"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Punt d'accés Wi-Fi"
 
 #~ msgid "Apply"
 #~ msgstr "Aplica"
@@ -7402,12 +7996,6 @@ msgstr "No s'ha trobat cap resultat."
 
 #~ msgid "Mirrored"
 #~ msgstr "Duplicat"
-
-#~ msgid "Primary"
-#~ msgstr "Primària"
-
-#~ msgid "Secondary"
-#~ msgstr "Secundària"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Organitzeu les pantalles combinades"
@@ -7432,9 +8020,6 @@ msgstr "No s'ha trobat cap resultat."
 
 #~ msgid "Size"
 #~ msgstr "Mida"
-
-#~ msgid "Aspect Ratio"
-#~ msgstr "Relació d'aspecte"
 
 #~ msgid "Show the top bar and Activities Overview on this display"
 #~ msgstr ""
@@ -7491,23 +8076,8 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "Automatic"
 #~ msgstr "Automàtic"
 
-#~ msgid "_Method"
-#~ msgstr "_Mètode"
-
-#~ msgid "Add Device"
-#~ msgstr "Afegeix un dispositiu"
-
-#~ msgid "Remove Device"
-#~ msgstr "Suprimeix el dispositiu"
-
-#~ msgid "VPN Type"
-#~ msgstr "Tipus de VPN"
-
 #~ msgid "Group Name"
 #~ msgstr "Nom del grup"
-
-#~ msgid "Group Password"
-#~ msgstr "Contrasenya del grup"
 
 #~ msgid "_Use as Hotspot…"
 #~ msgstr "_Utilitza com a punt d'accés Wi-Fi…"
@@ -7517,9 +8087,6 @@ msgstr "No s'ha trobat cap resultat."
 
 #~ msgid "Press Esc to cancel."
 #~ msgstr "Premeu Esc per cancel·lar."
-
-#~ msgid "Reset"
-#~ msgstr "Reinicia"
 
 #~ msgid "Make available to other _users"
 #~ msgstr "Fes-la disponible a altres _usuaris"
@@ -7544,12 +8111,6 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgstr ""
 #~ "Si teniu una connexió a Internet que no sigui la xarxa sense fil, podeu "
 #~ "establir un punt d'accés sense fil per compartir-la amb altres."
-
-#~ msgid "History"
-#~ msgstr "Historial"
-
-#~ msgid "Loading options…"
-#~ msgstr "S'estan carregant les opcions…"
 
 #~ msgid "%s %d-bit (Build ID: %s)"
 #~ msgstr "%s %d-bit (ID del muntatge: %s)"
@@ -7609,9 +8170,6 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "<small>Your account</small>"
 #~ msgstr "<small>Compte</small>"
 
-#~ msgid "Edit"
-#~ msgstr "Edita"
-
 #~ msgctxt "button"
 #~ msgid "Set Shortcut"
 #~ msgstr "Estableix la drecera"
@@ -7621,9 +8179,6 @@ msgstr "No s'ha trobat cap resultat."
 
 #~ msgid "Mail"
 #~ msgstr "Correu"
-
-#~ msgid "Calendar"
-#~ msgstr "Calendari"
 
 #~ msgid "Contacts"
 #~ msgstr "Contactes"
@@ -7672,9 +8227,6 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "label"
 #~ msgstr "etiqueta"
 
-#~ msgid "Setting new driver…"
-#~ msgstr "S'està establint el controlador nou…"
-
 #~ msgid "Print _Test Page"
 #~ msgstr "_Imprimeix una pàgina de prova"
 
@@ -7703,9 +8255,6 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "No se suprimirà el compte al servidor."
 
-#~ msgid "_Remove"
-#~ msgstr "_Suprimeix"
-
 #~ msgid "No online accounts configured"
 #~ msgstr "No s'ha configurat cap compte en línia"
 
@@ -7718,12 +8267,6 @@ msgstr "No s'ha trobat cap resultat."
 
 #~ msgid "Add a New Printer"
 #~ msgstr "Afegeix una impressora nova"
-
-#~ msgid "A_uthenticate"
-#~ msgstr "A_utentica"
-
-#~ msgid "No printers detected."
-#~ msgstr "No s'ha detectat cap impressora."
 
 #~ msgctxt "login history week label"
 #~ msgid "%s - %s"
@@ -7798,12 +8341,6 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "Scroll Up"
 #~ msgstr "Desplaça cap amunt"
 
-#~ msgid "Scroll Down"
-#~ msgstr "Desplaça cap avall"
-
-#~ msgid "Scroll Left"
-#~ msgstr "Desplaça cap a l'esquerra"
-
 #~ msgid "Scroll Right"
 #~ msgstr "Desplaça cap a la dreta"
 
@@ -7829,12 +8366,6 @@ msgstr "No s'ha trobat cap resultat."
 
 #~ msgid "_Sign In"
 #~ msgstr "_Entra"
-
-#~ msgid "_Name:"
-#~ msgstr "_Nom:"
-
-#~ msgid "Add Shortcut"
-#~ msgstr "Afegeix una drecera"
 
 #~ msgid "Remove Shortcut"
 #~ msgstr "Suprimeix una drecera"
@@ -7887,12 +8418,6 @@ msgstr "No s'ha trobat cap resultat."
 
 #~ msgid "Add User Account"
 #~ msgstr "Afegeix un compte d'usuari"
-
-#~ msgid "_Account Activity"
-#~ msgstr "_Activitat del compte"
-
-#~ msgid "Color"
-#~ msgstr "Color"
 
 #~ msgid "Bond"
 #~ msgstr "Enllaç"
@@ -7951,17 +8476,8 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "Don't _warn me again"
 #~ msgstr "_No em tornis a avisar"
 
-#~ msgid "No"
-#~ msgstr "No"
-
 #~ msgid "Yes"
 #~ msgstr "Sí"
-
-#~ msgid "Power"
-#~ msgstr "Energia"
-
-#~ msgid "Privacy"
-#~ msgstr "Privacitat"
 
 #~ msgctxt "Search Location"
 #~ msgid "Other"
@@ -7969,9 +8485,6 @@ msgstr "No s'ha trobat cap resultat."
 
 #~ msgid "Personal File Sharing"
 #~ msgstr "Compartició de fitxers personals"
-
-#~ msgid "_Allow Remote Control"
-#~ msgstr "_Permet el control remot"
 
 #~ msgid "_Verify"
 #~ msgstr "_Verifica"
@@ -8060,9 +8573,6 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "No printers available"
 #~ msgstr "No hi ha cap impressora disponible"
 
-#~ msgid "Close"
-#~ msgstr "Tanca"
-
 #~ msgid "Resume Printing"
 #~ msgstr "Continua la impressió"
 
@@ -8079,14 +8589,8 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "Job State"
 #~ msgstr "Estat de la tasca"
 
-#~ msgid "Time"
-#~ msgstr "Hora"
-
 #~ msgid "Add New Printer"
 #~ msgstr "Afegeix una impressora nova"
-
-#~ msgid "Options"
-#~ msgstr "Opcions"
 
 #~ msgid "Password:"
 #~ msgstr "Contrasenya:"
@@ -8098,17 +8602,8 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "Color"
 #~ msgstr "Color"
 
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "El Bluetooth està inhabilitat"
-
-#~ msgid "Security key"
-#~ msgstr "Clau de seguretat"
-
 #~ msgid "When battery power is _critical"
 #~ msgstr "Quan la càrrega de la bateria sigui _crítica"
-
-#~ msgid "Power off"
-#~ msgstr "Apaga"
 
 #~ msgid ""
 #~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
@@ -8143,17 +8638,11 @@ msgstr "No s'ha trobat cap resultat."
 #~ msgid "Germany"
 #~ msgstr "Alemanya"
 
-#~ msgid "France"
-#~ msgstr "França"
-
 #~ msgid "Spain"
 #~ msgstr "Espanya"
 
 #~ msgid "China"
 #~ msgstr "Xina"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "_Inhabilita mentre s'escriu"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr ""

--- a/po/ca@valencia.po~
+++ b/po/ca@valencia.po~
@@ -1,0 +1,8184 @@
+# Traducció del gnome-control-center de l'equip de Softcatalà.
+# Copyright © 1999-2009 Free Software Foundation, Inc.
+# Ivan Vilata i Balaguer <ivan@selidor.net>, 1999, 2000.
+# Softcatalà <linux@softcatala.org>, 2000, 2001.
+# Jordi Mallach <jordi@sindominio.net>, 2002, 2003, 2004, 2005.
+# Xavier Conde Rueda <xavi.conde@gmail.com>, 2005
+# Josep Puigdemont i Casamajó <josep.puigdemont@gmail.com>, 2005, 2006, 2007.
+# Joan Duran <jodufi@gmail.com>, 2008-2013.
+# Jordi Serratosa <jordis@softcatala.cat>, 2012, 2017.
+# Josep Sànchez <papapep@gmx.com>, 2013.
+# Jordi Mas i Hernàndez <jmas@softcatala.org>, 2015-2017
+# Gil Forcada <gilforcada@guifi.net>, 2013, 2014, 2016.
+#
+# Terminologia
+#
+#   Hotspot -> punt d'accés Wi-Fi
+#   Plugged In -> endollat (si es refereix al corrent)
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2017-09-22 13:24+0000\n"
+"PO-Revision-Date: 2017-08-15 08:15+0200\n"
+"Last-Translator: Xavi Ivars <xavi.ivars@gmail.com>\n"
+"Language-Team: Catalan <tradgnome@softcatala.org>\n"
+"Language: ca-valencia\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 2.0.1\n"
+
+#: ../panels/background/background.ui.h:1
+msgid "_Background"
+msgstr "_Fons"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "Canvia durant el dia"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "_Lock Screen"
+msgstr "_Pantalla de bloqueig"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Mosaic"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Amplia"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "Centra"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Escala"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Omple"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "Allarga"
+
+#: ../panels/background/cc-background-chooser-dialog.c:430
+msgid "Wallpapers"
+msgstr "Fons de pantalla"
+
+#: ../panels/background/cc-background-chooser-dialog.c:439
+msgid "Colors"
+msgstr "Colors"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:476
+msgid "Select Background"
+msgstr "Selecciona el fons"
+
+#: ../panels/background/cc-background-chooser-dialog.c:504
+msgid "Pictures"
+msgstr "Imatges"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:536
+msgid "No Pictures Found"
+msgstr "No s'ha trobat cap imatge"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:554
+#: ../panels/search/cc-search-locations-dialog.c:302
+msgid "Home"
+msgstr "Inici"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:566
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "Podeu afegir imatges a la carpeta %s i apareixeran ací"
+
+#: ../panels/background/cc-background-chooser-dialog.c:573
+#: ../panels/color/cc-color-panel.c:225 ../panels/color/cc-color-panel.c:963
+#: ../panels/color/color-calibrate.ui.h:2 ../panels/color/color.ui.h:30
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:2697
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:181
+#: ../panels/network/connection-editor/vpn-helpers.c:310
+#: ../panels/network/net-device-wifi.c:1318
+#: ../panels/network/net-device-wifi.c:1398
+#: ../panels/network/net-device-wifi.c:1633
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/printers/pp-details-dialog.c:319
+#: ../panels/privacy/cc-privacy-panel.c:1049
+#: ../panels/region/format-chooser.ui.h:3 ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:642
+#: ../panels/sharing/cc-sharing-panel.c:382
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/join-dialog.ui.h:2
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+#: ../panels/user-accounts/um-photo-dialog.c:94
+#: ../panels/user-accounts/um-photo-dialog.c:221
+#: ../panels/user-accounts/um-user-panel.c:644
+#: ../panels/user-accounts/um-user-panel.c:662
+msgid "_Cancel"
+msgstr "_Cancel·la"
+
+#: ../panels/background/cc-background-chooser-dialog.c:574
+msgid "_Select"
+msgstr "_Selecciona"
+
+#: ../panels/background/cc-background-item.c:203
+msgid "multiple sizes"
+msgstr "mides múltiples"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:207
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:333
+msgid "No Desktop Background"
+msgstr "Sense imatge de fons de l'escriptori"
+
+#: ../panels/background/cc-background-panel.c:497
+msgid "Current background"
+msgstr "Imatge de fons actual"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Back­ground"
+msgstr "Fons"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:3
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Canvieu la imatge de fons a un fons de pantalla o fotografia"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:5
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Fons de pantalla;Pantalla;Escriptori;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:268
+msgid "Turn Off Airplane Mode"
+msgstr "Desactiveu el mode d'avió"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:334
+msgid "No Bluetooth Found"
+msgstr "No s'ha trobat el Bluetooth"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:334
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Connecteu una motxilla per a usar Bluetooth."
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:335
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:335
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Activeu-lo per connectar dispositius i rebre transferències de fitxers."
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:336
+msgid "Airplane Mode is on"
+msgstr "El mode d'avió està activat"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:336
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "El Bluetooth està inhabilitat quan el mode d'avió està activat."
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:337
+msgid "Hardware Airplane Mode is on"
+msgstr "El mode d'avió del maquinari està activat"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:337
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Desactiveu el mode d'avió per a habilitar el Bluetooth."
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Blue­tooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:3
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Activeu i desactiveu el Bluetooth i connecteu els dispositius"
+
+#. Translators: those are keywords for the bluetooth control-center panel
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:5
+msgid "share;sharing;bluetooth;obex;"
+msgstr "comparteix;compartició;bluetooth;obex;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Col·loqueu el dispositiu de calibratge sobre el quadre i premeu «Inicia»."
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Moveu el dispositiu de calibratge a la posició de calibratge i premeu "
+"«Continua»."
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Moveu el dispositiu de calibratge a la posició de la superfície i premeu "
+"«Continua»."
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "Tanca la tapa del portàtil"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "S'ha produït un error intern que no s'ha pogut recuperar."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "Les eines que calen pel calibratge no estan instal·lades."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "No s'ha pogut generar el perfil."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "No s'ha pogut obtindre el punt blanc de l'objectiu."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "S'ha completat"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "Ha fallat el calibratge"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "Podeu treure el dispositiu de calibratge."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "No interrompeu el dispositiu de calibratge mentre treballi"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Pantalla del portàtil"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Càmera web integrada"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Escànner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Càmera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Impressora %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Càmera web %s"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Habilita la gestió del color per a %s"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Mostra els perfils de color per a %s"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:323
+msgid "Not calibrated"
+msgstr "Sense calibrar"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:141
+msgid "Default: "
+msgstr "Per defecte: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:149
+msgid "Colorspace: "
+msgstr "Espai de color: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:156
+msgid "Test profile: "
+msgstr "Perfil de comprovació: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:223
+msgid "Select ICC Profile File"
+msgstr "Selecciona un fitxer de perfil ICC"
+
+#: ../panels/color/cc-color-panel.c:226
+msgid "_Import"
+msgstr "_Importa"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:237
+msgid "Supported ICC profiles"
+msgstr "Perfils ICC compatibles"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:244
+#: ../panels/network/wireless-security/eap-method-fast.c:417
+msgid "All files"
+msgstr "Tots els fitxers"
+
+#: ../panels/color/cc-color-panel.c:583
+msgid "Screen"
+msgstr "Pantalla"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:908
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "No s'ha pogut pujar el fitxer: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:922
+msgid "The profile has been uploaded to:"
+msgstr "S'ha actualitzat el perfil a:"
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Write down this URL."
+msgstr "Apunteu este URL."
+
+#: ../panels/color/cc-color-panel.c:925
+msgid "Restart this computer and boot your normal operating system."
+msgstr "Reinicieu l'ordinador i arrenqueu el vostre sistema operatiu normal."
+
+#: ../panels/color/cc-color-panel.c:926
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "Escriviu l'URL al navegador web per baixar i instal·lar el perfil."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:960
+msgid "Save Profile"
+msgstr "Guarda el perfil"
+
+#: ../panels/color/cc-color-panel.c:964
+#: ../panels/network/connection-editor/vpn-helpers.c:311
+msgid "_Save"
+msgstr "Al_ça"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1324
+msgid "Create a color profile for the selected device"
+msgstr "Crea un perfil de color per al dispositiu seleccionat"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"No s'ha detectat l'instrument de mesura. Comproveu que estiga encés i "
+"connectat correctament."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1373
+msgid "The measuring instrument does not support printer profiling."
+msgstr "L'instrument de mesura no admet el perfilat d'impressores."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1384
+msgid "The device type is not currently supported."
+msgstr "El tipus de dispositiu no és compatible actualment."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "Espai estàndard"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "Perfil de comprovació"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automàtic"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Qualitat baixa"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Qualitat mitjana"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Qualitat alta"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB per defecte"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK per defecte"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Gris per defecte"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "Dades de calibratge de fàbrica proporcionades pel venedor"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+"Amb este perfil no es pot fer la correcció de la pantalla en mode pantalla "
+"completa "
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "Este perfil potser ja no és precís"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "Calibratge de la pantalla"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "_Start"
+msgstr "_Inicia"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "_Resume"
+msgstr "_Continua"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "_Fet"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "Calibratge de la pantalla"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"El calibratge produirà un perfil que podeu utilitzar en la gestió del color "
+"de la pantalla. Com més temps passeu en el calibratge, més bona serà la "
+"qualitat del perfil de color."
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "No podreu utilitzar l'ordinador mentre es faça el calibratge."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "Qualitat"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "Temps aproximat"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "Qualitat del calibratge"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Seleccioneu el sensor que voleu utilitzar pel calibratge."
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "Dispositiu de calibratge"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "Seleccioneu el tipus de pantalla que està connectat."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "Tipus de pantalla"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Seleccioneu un punt blanc objectiu de la pantalla. La majoria de pantalles "
+"s'haurien de calibrar amb una il·luminació D65."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "Punt blanc del perfil"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Establiu la brillantor de la pantalla que acostumeu a utilitzar. La gestió "
+"del color serà més precisa en este nivell de brillantor."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"També podeu utilitzar el nivell de brillantor utilitzat per un dels altres "
+"perfils d'este dispositiu."
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "Brillantor de la pantalla"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Podeu utilitzar un perfil de color en diferents ordinadors o fins i tot "
+"crear perfils per diferents condicions d'il·luminació."
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "Nom del perfil:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "Nom del perfil"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "S'ha creat el perfil amb èxit"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "Copia el perfil"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "Requereix un suport al qual s'hi puga escriure"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "Puja el perfil"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "Requereix connexió a Internet"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Podeu trobar les instruccions de com utilitzar el perfil als sistemes <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> i <a href="
+"\"windows\">Microsoft Windows</a>."
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:723
+msgid "Summary"
+msgstr "Resum"
+
+#: ../panels/color/color.ui.h:28
+msgid "Add Profile"
+msgstr "Afig un perfil"
+
+#: ../panels/color/color.ui.h:29
+msgid "_Import File…"
+msgstr "_Importa un fitxer…"
+
+#: ../panels/color/color.ui.h:31
+#: ../panels/network/connection-editor/net-connection-editor.c:519
+#: ../panels/printers/new-printer-dialog.ui.h:4
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Add"
+msgstr "_Afig"
+
+#: ../panels/color/color.ui.h:32
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"S'han detectat problemes. Este perfil no funcionarà correctament. <a href="
+"\"\">Mostra els detalls.</a>"
+
+#: ../panels/color/color.ui.h:33
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Cada dispositiu necessita un perfil de color actualitzat per poder gestionar "
+"el color."
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more"
+msgstr "Més informació"
+
+#: ../panels/color/color.ui.h:35
+msgid "Learn more about color management"
+msgstr "Apreneu més sobre la gestió del color"
+
+#: ../panels/color/color.ui.h:36
+msgid "_Set for all users"
+msgstr "_Estableix per a tots els usuaris"
+
+#: ../panels/color/color.ui.h:37
+msgid "Set this profile for all users on this computer"
+msgstr "Estableix este perfil per a tots els usuaris d'este ordinador"
+
+#: ../panels/color/color.ui.h:38
+msgid "_Enable"
+msgstr "_Habilita"
+
+#: ../panels/color/color.ui.h:39
+msgid "_Add profile"
+msgstr "_Afig un perfil"
+
+#: ../panels/color/color.ui.h:40
+msgid "_Calibrate…"
+msgstr "_Calibra…"
+
+#: ../panels/color/color.ui.h:41
+msgid "Calibrate the device"
+msgstr "Calibra el dispositiu"
+
+#: ../panels/color/color.ui.h:42
+msgid "_Remove profile"
+msgstr "_Suprimeix un perfil"
+
+#: ../panels/color/color.ui.h:43
+msgid "_View details"
+msgstr "_Mostra els detalls"
+
+#: ../panels/color/color.ui.h:44
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+"No s'ha pogut detectar cap dispositiu en el qual s'hi puga gestionar el "
+"color"
+
+#: ../panels/color/color.ui.h:45
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:46
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:47
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:48
+msgid "Projector"
+msgstr "Projector"
+
+#: ../panels/color/color.ui.h:49
+msgid "Plasma"
+msgstr "Plasma"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (retroil·luminació CCFL)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (retroil·luminació RGB LED)"
+
+#: ../panels/color/color.ui.h:52
+msgid "LCD (white LED backlight)"
+msgstr "LCD (retroil·luminació de LED blanc)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD de gamma àmplia (retroil·luminació CCFL)"
+
+#: ../panels/color/color.ui.h:54
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD de gamma àmplia (retroil·luminació de LED RGB)"
+
+#: ../panels/color/color.ui.h:55
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alta"
+
+#: ../panels/color/color.ui.h:56
+msgid "40 minutes"
+msgstr "40 minuts"
+
+#: ../panels/color/color.ui.h:57
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Mitjana"
+
+#: ../panels/color/color.ui.h:58 ../panels/power/power.ui.h:2
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 minuts"
+
+#: ../panels/color/color.ui.h:59
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Baixa"
+
+#: ../panels/color/color.ui.h:60 ../panels/power/power.ui.h:1
+msgid "15 minutes"
+msgstr "15 minuts"
+
+#: ../panels/color/color.ui.h:61
+msgid "Native to display"
+msgstr "Nadiu de la pantalla"
+
+#: ../panels/color/color.ui.h:62
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Impressions i publicacions)"
+
+#: ../panels/color/color.ui.h:63
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:64
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografia i gràfics)"
+
+#: ../panels/color/color.ui.h:65
+msgid "D75"
+msgstr "D75"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Co­lor"
+msgstr "Color"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:3
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibreu el color dels dispositius, com ara pantalles, càmeres o impressores"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:5
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Perfil;Calibratge;Impressora;Pantalla;"
+
+#: ../panels/common/cc-common-language.c:323
+msgid "Other…"
+msgstr "Altres…"
+
+#: ../panels/common/cc-language-chooser.c:124
+#: ../panels/region/cc-format-chooser.c:269
+#: ../panels/region/cc-input-chooser.c:169
+msgid "More…"
+msgstr "Més…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "No s'ha trobat cap idioma"
+
+#: ../panels/common/cc-util.c:127
+#: ../panels/network/connection-editor/ce-page-details.c:106
+msgid "Today"
+msgstr "Hui"
+
+#: ../panels/common/cc-util.c:131
+#: ../panels/network/connection-editor/ce-page-details.c:108
+msgid "Yesterday"
+msgstr "Ahir"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e de %b, %Y"
+
+#: ../panels/common/language-chooser.ui.h:1
+msgid "Language"
+msgstr "Idioma"
+
+#: ../panels/datetime/big.ui.h:1 ../panels/datetime/little.ui.h:1
+#: ../panels/datetime/middle.ui.h:1 ../panels/datetime/ydm.ui.h:1
+msgid "Day"
+msgstr "Dia"
+
+#: ../panels/datetime/big.ui.h:2 ../panels/datetime/little.ui.h:2
+#: ../panels/datetime/middle.ui.h:2 ../panels/datetime/ydm.ui.h:2
+msgid "Month"
+msgstr "Mes"
+
+#: ../panels/datetime/big.ui.h:3 ../panels/datetime/little.ui.h:3
+#: ../panels/datetime/middle.ui.h:3 ../panels/datetime/ydm.ui.h:3
+msgid "Year"
+msgstr "Any"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:339
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e de %B del %Y a les %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:344
+msgid "%e %B %Y, %R"
+msgstr "%e de %B de %Y a les %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:522
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:552
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:560
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:565
+msgid "%l:%M %p"
+msgstr "%l∶%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:570
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:575
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "Gener"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "Febrer"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "Març"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "Abril"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "Maig"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "Juny"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "Juliol"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "Agost"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "Setembre"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "Octubre"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "Novembre"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "Desembre"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Date & Time"
+msgstr "Data i hora"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "Hora"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr ":"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "Minut"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Time Zone"
+msgstr "Fus horari"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Search for a city"
+msgstr "Cerqueu una ciutat"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Automatic _Date & Time"
+msgstr "_Data i hora automàtiques"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Requires internet access"
+msgstr "Requereix accés a Internet"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Automatic Time _Zone"
+msgstr "_Fus horari automàtic"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Date & _Time"
+msgstr "Data i _hora"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Time Z_one"
+msgstr "Fus h_orari"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Time _Format"
+msgstr "_Format del temps"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "24-hour"
+msgstr "24 hores"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+msgid "Change the date and time, including time zone"
+msgstr "Canvieu la data i l'hora, incloent-hi la zona horària"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:5
+msgid "Clock;Timezone;Location;"
+msgstr "Rellotge;Zona horària;Ubicació;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "Canvieu els paràmetres d'hora i data del sistema"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Per canviar els paràmetres d'hora i data, vos heu d'autentificar."
+
+#: ../panels/display/cc-display-panel.c:738
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Apaïsada"
+
+#: ../panels/display/cc-display-panel.c:741
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Vertical dreta"
+
+#: ../panels/display/cc-display-panel.c:744
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Vertical esquerra"
+
+#: ../panels/display/cc-display-panel.c:747
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Apaïsada (capgirada)"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/display/cc-display-panel.c:788
+#: ../panels/display/cc-display-panel.c:838
+#: ../panels/printers/pp-options-dialog.c:558
+msgid "Orientation"
+msgstr "Orientació"
+
+#: ../panels/display/cc-display-panel.c:881
+#: ../panels/display/cc-display-panel.c:933
+#: ../panels/display/cc-display-panel.c:1751
+#: ../panels/display/cc-display-panel.c:1797
+#: ../panels/printers/pp-options-dialog.c:87
+msgid "Resolution"
+msgstr "Resolució"
+
+#: ../panels/display/cc-display-panel.c:978
+#: ../panels/display/cc-display-panel.c:1049
+msgid "Refresh Rate"
+msgstr "Freqüència de refresc"
+
+#: ../panels/display/cc-display-panel.c:1186
+msgid "Scale"
+msgstr "Redimensiona"
+
+#: ../panels/display/cc-display-panel.c:1239
+msgid "Adjust for TV"
+msgstr "Ajusta per a televisió"
+
+#: ../panels/display/cc-display-panel.c:1451
+#: ../panels/display/cc-display-panel.c:1497
+msgid "Primary Display"
+msgstr "Pantalla primària"
+
+#: ../panels/display/cc-display-panel.c:1546
+msgid "Display Arrangement"
+msgstr "Disposició de les pantalles"
+
+#: ../panels/display/cc-display-panel.c:1547
+msgid ""
+"Drag displays to match your setup. The top bar is placed on the primary "
+"display."
+msgstr ""
+"Arrossegueu les pantalles per configurar-les. La barra superior se situa a "
+"la pantalla primària."
+
+#: ../panels/display/cc-display-panel.c:1985
+msgid "Display Mode"
+msgstr "Mode de pantalla"
+
+#: ../panels/display/cc-display-panel.c:2001
+msgid "Join Displays"
+msgstr "Uneix pantalles"
+
+#: ../panels/display/cc-display-panel.c:2004
+msgid "Mirror"
+msgstr "Mirall"
+
+#: ../panels/display/cc-display-panel.c:2007
+msgid "Single Display"
+msgstr "Pantalla única"
+
+#: ../panels/display/cc-display-panel.c:2693
+msgid "Apply Changes?"
+msgstr "Voleu aplicar els canvis?"
+
+#: ../panels/display/cc-display-panel.c:2707
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "_Aplica"
+
+#: ../panels/display/cc-display-panel.c:3083
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#. TRANSLATORS: the state of the night light setting
+#: ../panels/display/cc-display-panel.c:3299
+#: ../panels/notifications/cc-notifications-panel.c:293
+#: ../panels/power/cc-power-panel.c:1970 ../panels/power/cc-power-panel.c:1977
+#: ../panels/privacy/cc-privacy-panel.c:190
+#: ../panels/privacy/cc-privacy-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:331
+#: ../panels/universal-access/cc-ua-panel.c:712
+#: ../panels/universal-access/cc-ua-panel.c:725
+#: ../panels/universal-access/cc-ua-panel.c:737
+#: ../panels/universal-access/cc-ua-panel.c:908
+msgid "On"
+msgstr "Activat"
+
+#: ../panels/display/cc-display-panel.c:3299 ../panels/network/net-proxy.c:54
+#: ../panels/notifications/cc-notifications-panel.c:293
+#: ../panels/power/cc-power-panel.c:1964 ../panels/power/cc-power-panel.c:1975
+#: ../panels/privacy/cc-privacy-panel.c:190
+#: ../panels/privacy/cc-privacy-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:331
+#: ../panels/universal-access/cc-ua-panel.c:712
+#: ../panels/universal-access/cc-ua-panel.c:725
+#: ../panels/universal-access/cc-ua-panel.c:737
+#: ../panels/universal-access/cc-ua-panel.c:908
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Off"
+msgstr "Desactivat"
+
+#: ../panels/display/cc-display-panel.c:3320
+msgid "_Night Light"
+msgstr "_Llum nocturna"
+
+#: ../panels/display/cc-display-panel.c:3385
+msgid "Could not get screen information"
+msgstr "No s'ha pogut obtindre la informació de la pantalla"
+
+#. This cancels the redshift inhibit.
+#: ../panels/display/display.ui.h:2
+msgid "Restart Filter"
+msgstr "Torna a iniciar el filtre"
+
+#. Inhibit the redshift functionality until the next day starts
+#: ../panels/display/display.ui.h:4
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Inhabilitat temporalment fins demà"
+
+#: ../panels/display/display.ui.h:5
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"La llum nocturna fa que el color de pantalla siga més càlid. Això vos pot "
+"ajudar a prevenir la fatiga visual i la sensació de son."
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: ../panels/display/display.ui.h:7
+msgid "Night Light"
+msgstr "Llum nocturna"
+
+#: ../panels/display/display.ui.h:8
+msgid "Schedule"
+msgstr "Planificació"
+
+#: ../panels/display/display.ui.h:9
+msgid "Sunset to Sunrise"
+msgstr "Posta de sol a l'eixida del sol"
+
+#: ../panels/display/display.ui.h:10
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+#: ../panels/network/net-proxy.c:56 ../panels/network/network-proxy.ui.h:3
+#: ../panels/network/network-wifi.ui.h:26
+#: ../panels/privacy/cc-privacy-panel.c:217
+msgid "Manual"
+msgstr "Manual"
+
+#: ../panels/display/display.ui.h:11
+msgid "From"
+msgstr "Des de"
+
+#: ../panels/display/display.ui.h:12
+msgid ":"
+msgstr ":"
+
+#. This is the short form for the time period in the morning
+#: ../panels/display/display.ui.h:14
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: ../panels/display/display.ui.h:16
+msgid "PM"
+msgstr "PM"
+
+#: ../panels/display/display.ui.h:17
+msgid "To"
+msgstr "A"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Dis­plays"
+msgstr "Pantalles"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:3
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Trieu com utilitzar els monitors i projectors connectats"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:5
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Quadre;Projector;xrandr;Pantalla;Resolució;Refresca;Monitor;Nit;Llum;Blau;"
+"color;posta de sol;"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-overview-panel.c:381
+#: ../panels/info/cc-info-overview-panel.c:468
+#: ../panels/network/panel-common.c:123
+msgid "Unknown"
+msgstr "Desconegut"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: ../panels/info/cc-info-overview-panel.c:476
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; ID del muntatge: %s"
+
+#. translators: This is the type of architecture for the OS
+#: ../panels/info/cc-info-overview-panel.c:493
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: ../panels/info/cc-info-overview-panel.c:496
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: ../panels/info/cc-info-overview-panel.c:807
+#, c-format
+msgid "Version %s"
+msgstr "Versió %s"
+
+#: ../panels/info/cc-info-panel.c:138
+msgid "Section"
+msgstr "Secció"
+
+#: ../panels/info/cc-info-panel.c:147 ../panels/info/info.ui.h:1
+msgid "Overview"
+msgstr "Visió general"
+
+#: ../panels/info/cc-info-panel.c:153 ../panels/info/info.ui.h:2
+msgid "Default Applications"
+msgstr "Aplicacions per defecte"
+
+#: ../panels/info/cc-info-panel.c:158 ../panels/info/info.ui.h:3
+msgid "Removable Media"
+msgstr "Suport extraïble"
+
+#: ../panels/info/cc-info-removable-media-panel.c:312
+msgid "Ask what to do"
+msgstr "Pregunta què fer"
+
+#: ../panels/info/cc-info-removable-media-panel.c:316
+msgid "Do nothing"
+msgstr "No faces res"
+
+#: ../panels/info/cc-info-removable-media-panel.c:320
+msgid "Open folder"
+msgstr "Obri la carpeta"
+
+#: ../panels/info/cc-info-removable-media-panel.c:411
+msgid "Other Media"
+msgstr "Altres suports"
+
+#: ../panels/info/cc-info-removable-media-panel.c:444
+msgid "Select an application for audio CDs"
+msgstr "Seleccioneu l'aplicació per als CD d'àudio"
+
+#: ../panels/info/cc-info-removable-media-panel.c:445
+msgid "Select an application for video DVDs"
+msgstr "Seleccioneu l'aplicació per als DVD de vídeo"
+
+#: ../panels/info/cc-info-removable-media-panel.c:446
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Seleccioneu l'aplicació que s'iniciarà quan es connecte un reproductor de "
+"música"
+
+#: ../panels/info/cc-info-removable-media-panel.c:447
+msgid "Select an application to run when a camera is connected"
+msgstr "Seleccioneu l'aplicació que s'iniciarà quan es connecte una càmera"
+
+#: ../panels/info/cc-info-removable-media-panel.c:448
+msgid "Select an application for software CDs"
+msgstr "Seleccioneu l'aplicació per als CD de programari"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-removable-media-panel.c:460
+msgid "audio DVD"
+msgstr "DVD d'àudio"
+
+#: ../panels/info/cc-info-removable-media-panel.c:461
+msgid "blank Blu-ray disc"
+msgstr "Disc Blu-ray en blanc"
+
+#: ../panels/info/cc-info-removable-media-panel.c:462
+msgid "blank CD disc"
+msgstr "Disc CD en blanc"
+
+#: ../panels/info/cc-info-removable-media-panel.c:463
+msgid "blank DVD disc"
+msgstr "Disc DVD en blanc"
+
+#: ../panels/info/cc-info-removable-media-panel.c:464
+msgid "blank HD DVD disc"
+msgstr "Disc HD DVD en blanc"
+
+#: ../panels/info/cc-info-removable-media-panel.c:465
+msgid "Blu-ray video disc"
+msgstr "Disc Blu-ray de vídeo"
+
+#: ../panels/info/cc-info-removable-media-panel.c:466
+msgid "e-book reader"
+msgstr "Lector de llibres digitals"
+
+#: ../panels/info/cc-info-removable-media-panel.c:467
+msgid "HD DVD video disc"
+msgstr "Disc HD DVD de vídeo"
+
+#: ../panels/info/cc-info-removable-media-panel.c:468
+msgid "Picture CD"
+msgstr "CD de fotos"
+
+#: ../panels/info/cc-info-removable-media-panel.c:469
+msgid "Super Video CD"
+msgstr "Supervídeo CD"
+
+#: ../panels/info/cc-info-removable-media-panel.c:470
+msgid "Video CD"
+msgstr "CD de vídeo"
+
+#: ../panels/info/cc-info-removable-media-panel.c:471
+msgid "Windows software"
+msgstr "Programari del Windows"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:2
+msgid "Defa­ult Applications"
+msgstr "Aplicacions per defecte"
+
+#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:3
+msgid "Configure Default Applications"
+msgstr "Configura les aplicacions per defecte"
+
+#. Translators: those are keywords for the Default Applications panel
+#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:5
+msgid "default;application;preferred;media;"
+msgstr "per defecte; aplicació; preferida;multimèdia;"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:2
+msgid "Ab­out"
+msgstr "Quant a"
+
+#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:3
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:3
+msgid "View information about your system"
+msgstr "Visualitzeu informació sobre el sistema"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:5
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:5
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositiu;sistema;informació;memòria;processador;versió;per defecte;"
+"aplicació;preferit;cd;dvd;usb;àudio;vídeo;disc;extraïble;multimèdia;execució "
+"automàtica;"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "De­tails"
+msgstr "Detalls"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:2
+msgid "Remo­vable Media"
+msgstr "Suport extraïble"
+
+#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:3
+msgid "Configure Removable Media settings"
+msgstr "Configura els paràmetres del suport extraïble"
+
+#. Translators: those are keywords for the Removable Media panel
+#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:5
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"dispositiu;sistema;informació;per defecte;aplicació;preferit;cd;dvd;usb;"
+"àudio;vídeo;disc;extraïble;multimèdia;execució automàtica;"
+
+#: ../panels/info/info-default-apps.ui.h:1
+msgid "_Web"
+msgstr "_Web"
+
+#: ../panels/info/info-default-apps.ui.h:2
+msgid "_Mail"
+msgstr "_Correu"
+
+#: ../panels/info/info-default-apps.ui.h:3
+msgid "_Calendar"
+msgstr "Ca_lendari"
+
+#: ../panels/info/info-default-apps.ui.h:4
+msgid "M_usic"
+msgstr "_Música"
+
+#: ../panels/info/info-default-apps.ui.h:5
+msgid "_Video"
+msgstr "_Vídeo"
+
+#: ../panels/info/info-default-apps.ui.h:6
+#: ../panels/info/info-removable-media.ui.h:5
+msgid "_Photos"
+msgstr "_Fotos"
+
+#: ../panels/info/info-overview.ui.h:1
+msgid "Device name"
+msgstr "Nom del dispositiu"
+
+#: ../panels/info/info-overview.ui.h:2
+msgid "Memory"
+msgstr "Memòria"
+
+#: ../panels/info/info-overview.ui.h:3
+msgid "Processor"
+msgstr "Processador"
+
+#: ../panels/info/info-overview.ui.h:4
+msgid "Graphics"
+msgstr "Gràfics"
+
+#. To translators: this field contains the distro name and version
+#: ../panels/info/info-overview.ui.h:6
+msgid "OS name"
+msgstr "Nom del sistema operatiu"
+
+#. To translators: this field contains the distro type
+#: ../panels/info/info-overview.ui.h:8
+msgid "OS type"
+msgstr "Tipus de sistema operatiu"
+
+#: ../panels/info/info-overview.ui.h:9
+msgid "Virtualization"
+msgstr "Virtualització"
+
+#: ../panels/info/info-overview.ui.h:10
+msgid "Disk"
+msgstr "Disc"
+
+#: ../panels/info/info-overview.ui.h:11
+msgid "Calculating…"
+msgstr "S'està calculant…"
+
+#: ../panels/info/info-overview.ui.h:12
+msgid "Check for updates"
+msgstr "Comprova si hi ha actualitzacions"
+
+#: ../panels/info/info-removable-media.ui.h:1
+msgid "Select how media should be handled"
+msgstr "Seleccioneu com s'han de gestionar els suports"
+
+#: ../panels/info/info-removable-media.ui.h:2
+msgid "CD _audio"
+msgstr "_CD d'àudio"
+
+#: ../panels/info/info-removable-media.ui.h:3
+msgid "_DVD video"
+msgstr "_DVD de vídeo"
+
+#: ../panels/info/info-removable-media.ui.h:4
+msgid "_Music player"
+msgstr "Reproductor de _música"
+
+#: ../panels/info/info-removable-media.ui.h:6
+msgid "_Software"
+msgstr "_Programari"
+
+#: ../panels/info/info-removable-media.ui.h:7
+msgid "_Other Media…"
+msgstr "_Altres suports…"
+
+#: ../panels/info/info-removable-media.ui.h:8
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_No preguntes mai ni inicies programes quan s'inserisquen suports"
+
+#: ../panels/info/info-removable-media.ui.h:9
+msgid "Select how other media should be handled"
+msgstr "Seleccioneu com s'han de gestionar els altres suports"
+
+#: ../panels/info/info-removable-media.ui.h:10
+msgid "_Action:"
+msgstr "_Acció:"
+
+#: ../panels/info/info-removable-media.ui.h:11
+msgid "_Type:"
+msgstr "_Tipus:"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "So i multimèdia"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "Silencia el volum"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "Abaixa el volum"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "Apuja el volum"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "Inicia el reproductor multimèdia"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "Reprodueix (o reprodueix/fes una pausa)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "Fes una pausa a la reproducció"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "Atura la reproducció"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "Salta a la peça anterior"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "Salta a la peça següent"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "Expulsa"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Typing"
+msgstr "Escriptura"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "Commuta a la font d'entrada següent"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "Commuta a la font d'entrada anterior"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "Llançadors"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "Inicia el navegador d'ajuda"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/alt/cc-window.c:1590
+#: ../shell/cc-window.c:251 ../shell/cc-window.c:831
+#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/window.ui.h:1
+msgid "Settings"
+msgstr "Paràmetres"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "Inicia la calculadora"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "Inicia el client de correu"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "Inicia el navegador web"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "Carpeta personal"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Busca"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "Captures de pantalla"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "Guarda una captura de pantalla a $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Guarda una captura de pantalla d'una finestra a $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Guarda una captura de pantalla d'una àrea a $PICTURES"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "Copia una captura de pantalla al porta-retalls"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Copia una captura de pantalla d'una finestra al porta-retalls"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Copia una captura de pantalla d'una àrea al porta-retalls"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "Grava un screencast curt"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "Sistema"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Ix"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "Bloca la pantalla"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+msgid "Universal Access"
+msgstr "Accés universal"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "Activa o desactiva l'ampliació"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "Ampliació"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "Reducció"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "Activa o desactiva el lector de pantalla"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "Activa o desactiva el teclat a la pantalla"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "Augmenta la mida del text"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "Redueix la mida del text"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "Activa o desactiva el contrast alt"
+
+#: ../panels/keyboard/cc-keyboard-manager.c:506
+#: ../panels/keyboard/cc-keyboard-manager.c:514
+#: ../panels/keyboard/cc-keyboard-manager.c:822
+msgid "Custom Shortcuts"
+msgstr "Dreceres personalitzades"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:435
+#: ../panels/keyboard/shortcut-editor.ui.h:2
+#: ../panels/network/network-proxy.ui.h:4
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1866
+#: ../panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Disabled"
+msgstr "Inhabilitat"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "Tecla de caràcters alternatius"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "Tecla de composició"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "Només els modificadors commuten a la font següent"
+
+#: ../panels/keyboard/cc-keyboard-panel.c:181
+msgid "Reset All Shortcuts?"
+msgstr "Voleu restablir totes les dreceres?"
+
+#: ../panels/keyboard/cc-keyboard-panel.c:184
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Restablir les dreceres pot afectar les vostres dreceres personalitzades. "
+"Esta acció no es pot desfer."
+
+#: ../panels/keyboard/cc-keyboard-panel.c:188
+#: ../panels/keyboard/shortcut-editor.ui.h:9
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: ../panels/keyboard/cc-keyboard-panel.c:189
+msgid "Reset All"
+msgstr "Restableix-ho tot"
+
+#: ../panels/keyboard/cc-keyboard-panel.c:281
+msgid "Reset the shortcut to its default value"
+msgstr "Restableix la drecera al seu valor per omissió"
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:427
+#, c-format
+msgid ""
+"%s is already being used for <b>%s</b>. If you replace it, %s will be "
+"disabled"
+msgstr "%s ja s'utilitza per <b>%s</b>. Si la reemplaceu, %s s'inhabilitarà"
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:597
+msgid "Set Custom Shortcut"
+msgstr "Estableix la drecera personalitzada"
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:597
+msgid "Set Shortcut"
+msgstr "Estableix la drecera"
+
+#. Setup the top label
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:606
+#, c-format
+msgid "Enter new shortcut to change <b>%s</b>."
+msgstr "Introduïu una drecera nova per canviar <b>%s</b>."
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:1033
+msgid "Add Custom Shortcut"
+msgstr "Afig drecera personalitzada"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "Key­board"
+msgstr "Teclat"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:3
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"Visualitzeu i canvieu les dreceres de teclat i establiu les preferències "
+"d'escriptura"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:5
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Drecera;Espai de treball;Finestra;Canvia la mida;Amplia;Contrast;Entrada;"
+"Font;Bloqueig;Volum;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+#: ../panels/region/input-options.ui.h:4 ../shell/cc-application.c:251
+msgid "Keyboard Shortcuts"
+msgstr "Dreceres de teclat"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "Reset All…"
+msgstr "Restableix-ho tot..."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Restableix totes les dreceres als seus valors per omissió"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "No keyboard shortcut found"
+msgstr "No s'ha trobat la tecla de drecera"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5 ../shell/panel-list.ui.h:4
+msgid "Try a different search"
+msgstr "Proveu amb una busca diferent"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:1
+msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
+msgstr "Premeu Esc o Retrocés per a reiniciar la drecera de teclat."
+
+#: ../panels/keyboard/shortcut-editor.ui.h:3
+#: ../panels/printers/details-dialog.ui.h:1
+#: ../panels/sound/gvc-mixer-dialog.c:1493
+#: ../panels/sound/gvc-sound-theme-chooser.c:564
+msgid "Name"
+msgstr "Nom"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:4
+msgid "Command"
+msgstr "Orde"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:5
+msgid "Shortcut"
+msgstr "Drecera"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:6
+msgid "Set Shortcut…"
+msgstr "Estableix la drecera..."
+
+#: ../panels/keyboard/shortcut-editor.ui.h:7
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "Cap"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:8
+msgid "Enter the new shortcut"
+msgstr "Introduïu la drecera nova"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:10
+msgid "Remove"
+msgstr "Suprimeix"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:11
+msgid "Add"
+msgstr "Afig"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:12
+msgid "Replace"
+msgstr "Reemplaça"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:13
+msgid "Set"
+msgstr "Estableix"
+
+#: ../panels/mouse/cc-mouse-panel.c:82 ../panels/wacom/cc-wacom-panel.c:402
+msgid "Test Your _Settings"
+msgstr "_Comprova els paràmetres"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Mouse & Touch­pad"
+msgstr "Ratolí i ratolí tàctil"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:3
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Canvieu la sensibilitat del ratolí i del ratolí tàctil i seleccioneu l'ús "
+"per dretans o esquerrans"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:5
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Ratolí tàctil;Punter;Clic;Toc;Doble;Botó;Ratolí de bola;Desplaça;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "General"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "Primary Button"
+msgstr "Botó primari"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Estableix l'orde dels botons als ratolins i ratolins tàctils."
+
+# N.T.: Es refereix al botó
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Left"
+msgstr "Esquerre"
+
+# N.T.: Es refereix al botó
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "Right"
+msgstr "Dret"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Mouse"
+msgstr "Ratolí"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Mouse Speed"
+msgstr "Velocitat del ratolí"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "Double-click timeout"
+msgstr "Temps d'espera del doble clic"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "Natural Scrolling"
+msgstr "Desplaçament natural"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgid "Scrolling moves the content, not the view."
+msgstr "El desplaçament mou el contingut, no la vista."
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgid "Touchpad"
+msgstr "Ratolí tàctil"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad Speed"
+msgstr "Velocitat del ratolí tàctil"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgid "Tap to Click"
+msgstr "Fes un toc per fer un clic"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgid "Two-finger Scrolling"
+msgstr "Desplaçament amb dos dits"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Edge Scrolling"
+msgstr "Desplaçament en la vora"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Proveu de fer clic, fer doble clic i desplaçar"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "Cinc clics, és l'hora del GEGL"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "Doble clic, botó primari"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "Un sol clic, botó primari"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "Doble clic, botó del mig"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "Un sol clic, botó del mig"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "Doble clic, botó secundari"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "Un sol clic, botó secundari"
+
+#. add proxy to device list
+#: ../panels/network/cc-network-panel.c:579
+msgid "Network proxy"
+msgstr "Servidor intermediari de xarxa"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:715 ../panels/network/net-vpn.c:192
+#: ../panels/network/net-vpn.c:321
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#: ../panels/network/cc-network-panel.c:779 ../panels/network/wifi.ui.h:7
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"S'ha produït un error inesperat. Contacteu el vostre proveïdor de programari."
+
+#: ../panels/network/cc-network-panel.c:785
+msgid "NetworkManager needs to be running."
+msgstr "Cal que el NetworkManager estiga executant-se."
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/network/cc-wifi-panel.c:209
+#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:2
+#: ../panels/network/network-wifi.ui.h:58
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "_Seguretat 802.1x"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "page 1"
+msgstr "pàgina 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+msgid "Anony_mous identity"
+msgstr "Identitat _anònima"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "_Autenticació interna"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "page 2"
+msgstr "pàgina 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:101
+#: ../panels/network/connection-editor/ce-page-security.c:445
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "Seguretat"
+
+#: ../panels/network/connection-editor/ce-page.c:481
+msgid "automatic"
+msgstr "automàtic"
+
+#: ../panels/network/connection-editor/ce-page.c:521
+#, c-format
+msgid "Profile %d"
+msgstr "Perfil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:231
+#: ../panels/network/net-device-wifi.c:407
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:235
+#: ../panels/network/net-device-wifi.c:412
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:64
+#: ../panels/network/net-device-wifi.c:239
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:69
+#: ../panels/network/net-device-wifi.c:244
+msgid "Enterprise"
+msgstr "Corporativa"
+
+#: ../panels/network/connection-editor/ce-page-details.c:74
+#: ../panels/network/net-device-wifi.c:249
+#: ../panels/network/net-device-wifi.c:397
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Cap"
+
+#: ../panels/network/connection-editor/ce-page-details.c:95
+#: ../panels/power/power.ui.h:17
+msgid "Never"
+msgstr "Mai"
+
+#: ../panels/network/connection-editor/ce-page-details.c:110
+#: ../panels/network/net-device-ethernet.c:120
+#: ../panels/network/net-device-wifi.c:505
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "fa %i dia"
+msgstr[1] "fa %i dies"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:176
+#: ../panels/network/net-device-ethernet.c:50
+#: ../panels/network/net-device-wifi.c:561
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:202
+#: ../panels/network/net-device-wifi.c:590
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Cap"
+
+#: ../panels/network/connection-editor/ce-page-details.c:204
+#: ../panels/network/net-device-wifi.c:592
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Dèbil"
+
+#: ../panels/network/connection-editor/ce-page-details.c:206
+#: ../panels/network/net-device-wifi.c:594
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Acceptable"
+
+#: ../panels/network/connection-editor/ce-page-details.c:208
+#: ../panels/network/net-device-wifi.c:596
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bona"
+
+#: ../panels/network/connection-editor/ce-page-details.c:210
+#: ../panels/network/net-device-wifi.c:598
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excel·lent"
+
+#: ../panels/network/connection-editor/ce-page-details.c:248
+msgid "Forget Connection"
+msgstr "Oblida la connexió"
+
+#: ../panels/network/connection-editor/ce-page-details.c:250
+msgid "Remove Connection Profile"
+msgstr "Suprimeix el perfil de connexió"
+
+#: ../panels/network/connection-editor/ce-page-details.c:252
+msgid "Remove VPN"
+msgstr "Suprimeix VPN"
+
+#: ../panels/network/connection-editor/ce-page-details.c:280
+#: ../panels/network/network-wifi.ui.h:46 ../shell/cc-window.c:243
+#: ../shell/panel-list.ui.h:2
+msgid "Details"
+msgstr "Detalls"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:173
+#: ../panels/network/connection-editor/ce-page-vpn.c:188
+#: ../panels/network/connection-editor/ce-page-wifi.c:194
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "Identitat"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:251
+#: ../panels/network/connection-editor/ce-page-ip6.c:230
+msgid "Delete Address"
+msgstr "Suprimeix l'adreça"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:422
+#: ../panels/network/connection-editor/ce-page-ip6.c:390
+msgid "Delete Route"
+msgstr "Suprimeix la ruta"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:896
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:827
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-security.c:245
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Cap"
+
+#: ../panels/network/connection-editor/ce-page-security.c:268
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Clau WEP 40/128-bit (hexadecimal o ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:278
+msgid "WEP 128-bit Passphrase"
+msgstr "Contrasenya WEP 128-bit"
+
+#: ../panels/network/connection-editor/ce-page-security.c:291
+#: ../panels/network/wireless-security/wireless-security.c:465
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:304
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinàmic (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:318
+msgid "WPA & WPA2 Personal"
+msgstr "WPA i WPA2 personal"
+
+#: ../panels/network/connection-editor/ce-page-security.c:332
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA i WPA2 corporativa"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr "Força del senyal"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "Velocitat de l'enllaç"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:153
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:644
+msgid "IPv4 Address"
+msgstr "Adreça IPv4"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:154
+#: ../panels/network/net-device-ethernet.c:158
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:645
+msgid "IPv6 Address"
+msgstr "Adreça IPv6"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:161
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "Adreça física"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:165
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "Ruta per defecte"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:10
+#: ../panels/network/connection-editor/ip6-page.ui.h:11
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "Utilitzada per últim cop"
+
+#: ../panels/network/connection-editor/details-page.ui.h:10
+msgid "Connect _automatically"
+msgstr "Connecta _automàticament"
+
+#: ../panels/network/connection-editor/details-page.ui.h:11
+msgid "Make available to _other users"
+msgstr "Fes-la disponible a _altres usuaris"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:11
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/net-proxy.c:58 ../panels/network/network-proxy.ui.h:2
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/privacy/cc-privacy-panel.c:217
+msgid "Automatic"
+msgstr "Automàtic"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "Parells trenats (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Interfície d'unitat d'acoblament (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "Interfície independent de medis (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "_Nom"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "Adreça _MAC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "Adreça _clonada"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "bytes"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+msgid "IPv_4 Method"
+msgstr "_Mètode IPv4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "Automàtic (DHCP)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+msgid "Link-Local Only"
+msgstr "Només enllaç local"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+msgid "Disable"
+msgstr "Inhabilita"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Addresses"
+msgstr "Adreces"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/printers/details-dialog.ui.h:3
+msgid "Address"
+msgstr "Adreça"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+msgid "Netmask"
+msgstr "Màscara de xarxa"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:9
+#: ../panels/network/connection-editor/ip6-page.ui.h:10
+msgid "Gateway"
+msgstr "Porta d'enllaç"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:12
+#: ../panels/network/connection-editor/ip6-page.ui.h:12
+msgid "Automatic DNS"
+msgstr "DNS automàtic"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:13
+#: ../panels/network/connection-editor/ip6-page.ui.h:13
+msgid "Separate IP addresses with commas"
+msgstr "Separa les adreces IP amb comes"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:14
+#: ../panels/network/connection-editor/ip6-page.ui.h:14
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "Rutes"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:15
+#: ../panels/network/connection-editor/ip6-page.ui.h:15
+msgid "Automatic Routes"
+msgstr "Rutes automàtiques"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ip4-page.ui.h:17
+#: ../panels/network/connection-editor/ip6-page.ui.h:17
+msgid "Metric"
+msgstr "Mètrica"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:18
+#: ../panels/network/connection-editor/ip6-page.ui.h:18
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr "_Utilitza esta connexió només per als recursos d'esta xarxa"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+msgid "IPv_6 Method"
+msgstr "_Mètode IPv6"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+msgid "Automatic, DHCP only"
+msgstr "Automàtic, només DHCP"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:9
+msgid "Prefix"
+msgstr "Prefix"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:273
+msgid "Unable to open connection editor"
+msgstr "No s'ha pogut obrir l'editor de connexions"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:291
+msgid "New Profile"
+msgstr "Perfil nou"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:603
+#: ../panels/network/network.ui.h:2
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:751
+msgid "Import from file…"
+msgstr "Importa des d'un fitxer…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:785
+msgid "Add VPN"
+msgstr "Afig VPN"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "S_eguretat"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:141
+msgid "Cannot import VPN connection"
+msgstr "No es pot importar la connexió VPN"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:143
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"No s'ha pogut llegir el fitxer «%s» o no conté informació reconeguda d'una "
+"connexió VPN\n"
+"\n"
+"Error: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:178
+msgid "Select file to import"
+msgstr "Seleccioneu el fitxer a importar"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:182
+#: ../panels/printers/pp-details-dialog.c:320
+#: ../panels/sharing/cc-sharing-panel.c:383
+#: ../panels/user-accounts/um-photo-dialog.c:222
+msgid "_Open"
+msgstr "_Obri"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:230
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Ja existeix un fitxer amb el nom «%s»."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:232
+msgid "_Replace"
+msgstr "_Substitueix"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:234
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Voleu substituir %s amb la connexió VPN que esteu desant?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:270
+msgid "Cannot export VPN connection"
+msgstr "No es pot exportar la connexió VPN"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:272
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"No s'ha pogut exportar la connexió VPN «%s» a %s.\n"
+"\n"
+"Error: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:307
+msgid "Export VPN connection"
+msgstr "Exporta la connexió VPN"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Error: no s'ha pogut carregar l'editor de connexió VPN)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "La meua xarxa"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Net­work"
+msgstr "Xarxa"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:3
+msgid "Control how you connect to the Internet"
+msgstr "Controleu com vos connecteu a Internet"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:5
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;"
+msgstr ""
+"Xarxa;Sense fil;Wi-Fi;Wifi;IP;LAN;Servidor intermediari;WAN;Banda ampla;"
+"Mòdem;Bluetooth;vpn;DNS;"
+
+#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:3
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controleu com vos connecteu a les xarxes sense fil"
+
+#. Translators: those are keywords for the wi-fi control-center panel
+#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:5
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+msgstr ""
+"Xarxa;Sense fil;Wi-Fi;Wifi;IP;LAN;Servidor intermediari;WAN;Banda ampla;DNS;"
+
+#: ../panels/network/net-device-ethernet.c:106
+#: ../panels/network/net-device-wifi.c:491
+msgid "never"
+msgstr "mai"
+
+#: ../panels/network/net-device-ethernet.c:116
+#: ../panels/network/net-device-wifi.c:501
+msgid "today"
+msgstr "hui"
+
+#: ../panels/network/net-device-ethernet.c:118
+#: ../panels/network/net-device-wifi.c:503
+msgid "yesterday"
+msgstr "ahir"
+
+#: ../panels/network/net-device-ethernet.c:156
+#: ../panels/network/network-mobile.ui.h:3 ../panels/network/panel-common.c:647
+#: ../panels/network/panel-common.c:649
+msgid "IP Address"
+msgstr "Adreça IP"
+
+#: ../panels/network/net-device-ethernet.c:172
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "Utilitzada per últim cop"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:275
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "Amb fil"
+
+#: ../panels/network/net-device-ethernet.c:343
+#: ../panels/network/net-device-wifi.c:1792
+#: ../panels/network/network-ethernet.ui.h:2
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:3 ../panels/network/network-vpn.ui.h:2
+msgid "Options…"
+msgstr "Opcions…"
+
+#: ../panels/network/net-device-mobile.c:238
+msgid "Add new connection"
+msgstr "Afig una connexió nova"
+
+#: ../panels/network/net-device-wifi.c:1275
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "Si activeu el punt d'accés sense fil vos desconnectareu de <b>%s</b>."
+
+#: ../panels/network/net-device-wifi.c:1279
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"No és possible accedir a Internet a través de la xarxa sense fil mentre el "
+"punt d'accés està actiu."
+
+#: ../panels/network/net-device-wifi.c:1286
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Activa el punt d'accés Wi-Fi"
+
+#: ../panels/network/net-device-wifi.c:1308
+msgid ""
+"Wi-Fi hotspots are usually used to share an additional Internet connection "
+"over Wi-Fi."
+msgstr ""
+"Els punts d'accés Wi-Fi s'utilitzen habitualment per compartir una connexió "
+"Internet addicional per Wi-fi."
+
+#: ../panels/network/net-device-wifi.c:1319
+msgid "_Turn On"
+msgstr "_Activa"
+
+#: ../panels/network/net-device-wifi.c:1396
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Voleu aturar el punt d'accés Wi-Fi i desconnectar els usuaris?"
+
+#: ../panels/network/net-device-wifi.c:1399
+msgid "_Stop Hotspot"
+msgstr "_Atura el punt d'accés Wi-Fi"
+
+#: ../panels/network/net-device-wifi.c:1496
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+"La política del sistema prohibeix utilitzar-lo com a punt d'accés Wi-Fi"
+
+#: ../panels/network/net-device-wifi.c:1499
+msgid "Wireless device does not support Hotspot mode"
+msgstr "El dispositiu sense fil no admet el mode punt d'accés Wi-Fi"
+
+#: ../panels/network/net-device-wifi.c:1630
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Es perdran les dades de xarxa de les xarxes seleccionades, incloent les "
+"contrasenyes i la configuració personalitzada."
+
+#: ../panels/network/net-device-wifi.c:1634
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "_Oblida"
+
+#: ../panels/network/net-device-wifi.c:1943
+#: ../panels/network/net-device-wifi.c:1950
+msgid "Known Wi-Fi Networks"
+msgstr "Xarxes sense fil conegudes"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1983
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Oblida"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:102
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"El descobriment automàtic de servidors intermediaris web s'utilitza quan no "
+"es proporciona un URL de configuració."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:110
+msgid "This is not recommended for untrusted public networks."
+msgstr "No és recomanable en xarxes públiques sense confiança."
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "Proveïdor"
+
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "Xarxa"
+
+#: ../panels/network/network-proxy.ui.h:1
+msgid "Network Proxy"
+msgstr "Servidor intermediari de xarxa"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_HTTP Proxy"
+msgstr "Servidor intermediari d'_HTTP"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "H_TTPS Proxy"
+msgstr "_Servidor intermediari d'HTTPS"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "_FTP Proxy"
+msgstr "Servidor intermediari d'_FTP"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_Socks Host"
+msgstr "_Servidor de sòcols"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Ignore Hosts"
+msgstr "_Ignora els servidors"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "HTTP proxy port"
+msgstr "Port del servidor intermediari d'HTTP"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTPS proxy port"
+msgstr "Port del servidor intermediari d'HTTPS"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "FTP proxy port"
+msgstr "Port del servidor intermediari d'FTP"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "Socks proxy port"
+msgstr "Port del servidor intermediari de sòcols"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "_Configuration URL"
+msgstr "URL de _configuració"
+
+#: ../panels/network/network-simple.ui.h:2
+msgid "Turn device off"
+msgstr "Apaga el dispositiu"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/network/network.ui.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1816
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/network/network.ui.h:3
+msgid "Not set up"
+msgstr "No s'ha configurat"
+
+#: ../panels/network/network-vpn.ui.h:1
+msgid "Turn VPN connection off"
+msgstr "Desactiva la connexió VPN"
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "_Connecta automàticament"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "detalls"
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/sharing/sharing.ui.h:9
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "_Contrasenya"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "_Mostra la contrasenya"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr "Fes-la disponible a altres usuaris"
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "identitat"
+
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "_Adreces"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr "Només adreces automàtiques (DHCP)"
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr "Només enllaç local"
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr "Compartit amb altres ordinadors"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr "_Ignora les rutes obtingudes automàticament"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr "Adreça MAC _clonada"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr "maquinari"
+
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "_Reinicia"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"Reinicia els paràmetres d'esta connexió als valors per defecte, però "
+"recorda-la com a connexió preferida."
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"Suprimeix totes les dades relacionades amb esta xarxa i no intentes "
+"connectar-t'hi automàticament."
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "reinicia"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "Maquinari"
+
+#: ../panels/network/network-wifi.ui.h:51
+msgctxt "tab"
+msgid "Reset"
+msgstr "Restableix"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr "Punt d'accés Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Desactiva-ho per connectar-se a una xarxa Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Network Name"
+msgstr "Nom de la xarxa"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Connected Devices"
+msgstr "Dispositius connectats"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "Security type"
+msgstr "Tipus de seguretat"
+
+#: ../panels/network/network-wifi.ui.h:57
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/printers/new-printer-dialog.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+msgid "Password"
+msgstr "Contrasenya"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Turn Wi-Fi off"
+msgstr "Desactiva el Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "_Connect to Hidden Network…"
+msgstr "_Connecta't a una xarxa oculta…"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Activa el punt d'accés Wi-Fi…"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "_Known Wi-Fi Networks"
+msgstr "_Xarxes sense fil conegudes"
+
+#: ../panels/network/wifi.ui.h:1
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Assegureu-vos que teniu un adaptador Wi-fi connectat i activat"
+
+#: ../panels/network/wifi.ui.h:2
+msgid "No Wi-Fi Adapter Found"
+msgstr "No s'ha trobat cap adaptador Wi-fi"
+
+#: ../panels/network/wifi.ui.h:3
+msgid "Airplane Mode"
+msgstr "Mode d'avió"
+
+#: ../panels/network/wifi.ui.h:4
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Inhabilita Wi-Fi, Bluetooth i banda ampla mòbil"
+
+#: ../panels/network/wifi.ui.h:5
+msgid "Visible Networks"
+msgstr "Xarxes visibles"
+
+#: ../panels/network/wifi.ui.h:6
+msgid "NetworkManager needs to be running"
+msgstr "Cal que el NetworkManager estiga executant-se"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:127
+msgid "Ad-hoc"
+msgstr "Ad hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Infrastructure"
+msgstr "Infraestructura"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:147 ../panels/network/panel-common.c:201
+msgid "Status unknown"
+msgstr "Estat desconegut"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:151
+msgid "Unmanaged"
+msgstr "No gestionat"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unavailable"
+msgstr "No disponible"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:165 ../panels/network/panel-common.c:207
+msgid "Connecting"
+msgstr "S'està connectant"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Authentication required"
+msgstr "Cal autenticació"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Connected"
+msgstr "Connectat"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:177
+msgid "Disconnecting"
+msgstr "S'està desconnectant"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:181 ../panels/network/panel-common.c:219
+msgid "Connection failed"
+msgstr "Ha fallat la connexió"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:227
+msgid "Status unknown (missing)"
+msgstr "Estat desconegut (falta)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223
+msgid "Not connected"
+msgstr "Sense connectar"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:248
+msgid "Configuration failed"
+msgstr "Ha fallat la configuració"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "IP configuration failed"
+msgstr "Ha fallat la configuració de la IP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration expired"
+msgstr "Ha caducat la configuració de la IP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "Secrets were required, but not provided"
+msgstr "Calen secrets, però no s'han proporcionat"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "802.1x supplicant disconnected"
+msgstr "S'ha desconnectat el suplicant de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant configuration failed"
+msgstr "Ha fallat la configuració del suplicant de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant failed"
+msgstr "Ha fallat el suplicant de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "El suplicant de 802.1x ha tardat massa en autenticar"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "PPP service failed to start"
+msgstr "No s'ha pogut iniciar el servei PPP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service disconnected"
+msgstr "S'ha desconnectat el servei PPP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP failed"
+msgstr "Ha fallat el PPP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "DHCP client failed to start"
+msgstr "No s'ha pogut iniciar el client DHCP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client error"
+msgstr "S'ha produït un error en el client DHCP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client failed"
+msgstr "Ha fallat el client DHCP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "Shared connection service failed to start"
+msgstr "No s'ha pogut iniciar el servei de connexió compartida"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed"
+msgstr "Ha fallat el servei de connexió compartida"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "AutoIP service failed to start"
+msgstr "No s'ha pogut iniciar el servei AutoIP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service error"
+msgstr "S'ha produït un error en el servei AutoIP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service failed"
+msgstr "Ha fallat el servei AutoIP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "Line busy"
+msgstr "Línia ocupada"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "No dial tone"
+msgstr "No hi ha to de trucada"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No carrier could be established"
+msgstr "No s'ha pogut establir cap portadora"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "Dialing request timed out"
+msgstr "Ha acabat el temps d'espera de la sol·licitud de trucada"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing attempt failed"
+msgstr "Ha fallat l'intent de trucada"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Modem initialization failed"
+msgstr "Ha fallat la inicialització del mòdem"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Failed to select the specified APN"
+msgstr "No s'ha pogut seleccionar l'APN especificat"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Not searching for networks"
+msgstr "No s'estan cercant xarxes"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Network registration denied"
+msgstr "S'ha denegat el registre a la xarxa"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration timed out"
+msgstr "Ha acabat el temps d'espera del registre de la xarxa"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Failed to register with the requested network"
+msgstr "Ha fallat el registre amb la xarxa sol·licitada"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "PIN check failed"
+msgstr "Ha fallat la comprovació del PIN"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "Firmware for the device may be missing"
+msgstr "Pot ser que falti el microprograma del dispositiu"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Connection disappeared"
+msgstr "Ha desaparegut la connexió"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Existing connection was assumed"
+msgstr "S'havia assumit una connexió existent"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Modem not found"
+msgstr "No s'ha trobat el mòdem"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Bluetooth connection failed"
+msgstr "Ha fallat la connexió Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "SIM Card not inserted"
+msgstr "No s'ha inserit la targeta SIM"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Pin required"
+msgstr "Cal el PIN de la SIM"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Puk required"
+msgstr "Cal el PUK de la SIM"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM wrong"
+msgstr "SIM incorrecta"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "Connection dependency failed"
+msgstr "Ha fallat la dependència de la connexió"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:433
+msgid "Firmware missing"
+msgstr "Falta el microprogramari"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:437
+msgid "Cable unplugged"
+msgstr "Cable desconnectat"
+
+#: ../panels/network/wireless-security/eap-method.c:57
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "s'ha produït un error no definit en la seguretat de 802.1X (wpa-eap)"
+
+#: ../panels/network/wireless-security/eap-method.c:233
+msgid "no file selected"
+msgstr "no s'ha seleccionat cap fitxer"
+
+#: ../panels/network/wireless-security/eap-method.c:264
+msgid "unspecified error validating eap-method file"
+msgstr "s'ha produït un error no especificat en validar el fitxer eap-method"
+
+#: ../panels/network/wireless-security/eap-method.c:439
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "Claus privades DER, PEM o PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: ../panels/network/wireless-security/eap-method.c:442
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "Certificats DER o PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:72
+msgid "missing EAP-FAST PAC file"
+msgstr "falta el fitxer EAP-FAST PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:268
+#: ../panels/network/wireless-security/eap-method-peap.c:302
+#: ../panels/network/wireless-security/eap-method-ttls.c:351
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:283
+#: ../panels/network/wireless-security/eap-method-peap.c:272
+#: ../panels/network/wireless-security/eap-method-ttls.c:289
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:406
+msgid "Choose a PAC file"
+msgstr "Trieu un fitxer PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:413
+msgid "PAC files (*.pac)"
+msgstr "Fitxers PAC (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+msgid "Anonymous"
+msgstr "Anònim"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "Authenticated"
+msgstr "S'ha autenticat"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+msgid "Both"
+msgstr "Ambdós"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+msgid "PAC _file"
+msgstr "_Fitxer PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "Autenticació _interna"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Allow automatic PAC pro_visioning"
+msgstr "_Permet la provisió automàtica PAC"
+
+#: ../panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "falta el nom d'usuari EAP-LEAP"
+
+#: ../panels/network/wireless-security/eap-method-leap.c:74
+msgid "missing EAP-LEAP password"
+msgstr "falta la contrasenya EAP-LEAP"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Username"
+msgstr "Nom d'_usuari"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:7
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "_Mostra la contrasenya"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:63
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "certificat CA EAP-PEAP no vàlid: %s"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:68
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "certificat CA EAP-PEAP no vàlid: no s'ha especificat un certificat"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:287
+#: ../panels/network/wireless-security/eap-method-ttls.c:336
+#: ../panels/network/wireless-security/wireless-security.c:441
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:381
+#: ../panels/network/wireless-security/eap-method-tls.c:501
+#: ../panels/network/wireless-security/eap-method-ttls.c:430
+msgid "Choose a Certificate Authority certificate"
+msgstr "Trieu un certificat d'una autoritat de certificació"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Version 0"
+msgstr "Versió 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 1"
+msgstr "Versió 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "C_A certificate"
+msgstr "Certificat C_A"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "No CA certificate is _required"
+msgstr "_No es requereix un certificat CA"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "_Versió PEAP"
+
+#: ../panels/network/wireless-security/eap-method-simple.c:74
+msgid "missing EAP username"
+msgstr "falta el nom d'usuari EAP"
+
+#: ../panels/network/wireless-security/eap-method-simple.c:87
+msgid "missing EAP password"
+msgstr "falta la contrasenya EAP"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:68
+msgid "missing EAP-TLS identity"
+msgstr "falta la identitat EAP-TLS"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:77
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "certificat CA EAP-TLS invàlid: %s"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:84
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TLS invàlid: no s'ha especificat un certificat"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:95
+msgid "invalid EAP-TLS password: missing"
+msgstr "contrasenya EAP-TLS invàlida: falta la contrasenya"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:109
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "clau privada EAP-TLS no vàlida: %s"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:119
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificat d'usuari EAP-TLS no vàlid: %s"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:316
+msgid "Unencrypted private keys are insecure"
+msgstr "Les claus privades sense encriptar no són segures"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:319
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"La clau privada que heu seleccionat no pareix protegida amb una contrasenya. "
+"Això podria permetre que les credencials de seguretat fossin compromeses. "
+"Seleccioneu una clau privada protegida per contrasenya.\n"
+"\n"
+"(Podeu protegir la vostra clau privada amb una contrasenya amb l'openssl)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:495
+msgid "Choose your personal certificate"
+msgstr "Trieu el vostre certificat personal"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:507
+msgid "Choose your private key"
+msgstr "Trieu la vostra clau privada"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "I_dentitat"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "Certificat d'_usuari"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "Private _key"
+msgstr "_Clau privada"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+msgid "_Private key password"
+msgstr "Contrasenya de clau _privada"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:63
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "certificat CA EAP-TTLS no vàlid: %s"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:68
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TTLS no vàlid: no s'ha especificat un certificat"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:259
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:274
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:305
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (sense EAP)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:321
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/wireless-security.c:87
+msgid "Unknown error validating 802.1X security"
+msgstr "S'ha produït un error desconegut en validar la seguretat de 802.1X"
+
+#: ../panels/network/wireless-security/wireless-security.c:453
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:477
+msgid "PWD"
+msgstr "PWD"
+
+#: ../panels/network/wireless-security/wireless-security.c:488
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:499
+msgid "Tunneled TLS"
+msgstr "TLS a través de túnel"
+
+#: ../panels/network/wireless-security/wireless-security.c:510
+msgid "Protected EAP (PEAP)"
+msgstr "EAP protegit (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+msgid "Au_thentication"
+msgstr "Au_tenticació"
+
+#: ../panels/network/wireless-security/ws-leap.c:63
+msgid "missing leap-username"
+msgstr "falta el mom d'usuari LEAP"
+
+#: ../panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr "falta la contrasenya LEAP"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr "falta la clau wep"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"clau wep invàlida: una clau amb longitud %zu ha de contindre només dígits "
+"hexadecimals"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"clau wep invàlida: una clau amb longitud %zu ha de contindre només caràcters "
+"ascii"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"clau wep invàlida: la longitud de clau %zu és errònia. Una clau ha de tindre "
+"una longitud de 5/13 (ascii) o bé 10/26 (hex)"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "clau wep invàlida: la contrasenya no pot ser buida."
+
+#: ../panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "clau wep invàlida: la contrasenya ha de tindre menys de 64 caràcters"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (per defecte)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "Open System"
+msgstr "Sistema obert"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "Shared Key"
+msgstr "Clau compartida"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "_Key"
+msgstr "_Clau"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Sho_w key"
+msgstr "_Mostra la clau"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "WEP inde_x"
+msgstr "Índe_x WEP"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk no vàlid: longitud de clau %zu no vàlida. Ha de tindre [8,63] bytes o "
+"64 dígits hexadecimals"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk no vàlid: no es pot interpretar la clau de 64 bytes com a hexadecimal"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "_Tipus"
+
+#. This is the per application switch for message tray usage.
+#: ../panels/notifications/edit-dialog.ui.h:2
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificacions"
+
+#. This is the setting to configure sounds associated with notifications.
+#: ../panels/notifications/edit-dialog.ui.h:4
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alertes sonores"
+
+#: ../panels/notifications/edit-dialog.ui.h:5
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Notificacions emergents"
+
+#: ../panels/notifications/edit-dialog.ui.h:6
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Les notificacions continuaran apareixent en la llista de notificacions "
+"encara que inhabiliteu les notificacions emergents."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: ../panels/notifications/edit-dialog.ui.h:8
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "_Mostra el contingut de les notificacions emergents"
+
+#: ../panels/notifications/edit-dialog.ui.h:9
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Notificacions a la pantalla de bloqueig"
+
+#: ../panels/notifications/edit-dialog.ui.h:10
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "_Mostra el contingut dels missatges a la pantalla de bloqueig"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "No­ti­fi­ca­tions"
+msgstr "Notificacions"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:3
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controleu quines notificacions es mostren i què mostren"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:5
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notificacions;Bàner;Missatge;Safata;Emergent;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Notification _Popups"
+msgstr "_Notificacions emergents"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "_Lock Screen Notifications"
+msgstr "_Notificacions a la pantalla de bloqueig"
+
+#. List of applications.
+#: ../panels/notifications/notifications.ui.h:4
+#: ../panels/privacy/privacy.ui.h:45 ../panels/sound/gvc-mixer-dialog.c:1781
+msgid "Applications"
+msgstr "Aplicacions"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:148
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Altres"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: ../panels/online-accounts/cc-online-accounts-panel.c:603
+#, c-format
+msgid "%s Account"
+msgstr "Compte de %s"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:895
+msgid "Error removing account"
+msgstr "S'ha produït un error en suprimir el compte"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: ../panels/online-accounts/cc-online-accounts-panel.c:960
+#, c-format
+msgid "<b>%s</b> removed"
+msgstr "<b>%s</b> s'ha suprimit"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "On­line Accounts"
+msgstr "Comptes en línia"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Connecteu-vos als comptes en línia i decidiu quin ús en voleu fer"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:5
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;En línia;Xat;Calendari;Correu;Contacte;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: ../panels/online-accounts/online-accounts.ui.h:1
+#: ../panels/printers/printers.ui.h:4
+msgid "Undo"
+msgstr "Desfés"
+
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Connect to your data in the cloud"
+msgstr "Connecteu-vos a les vostres dades al núvol"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"No hi ha connexió a Internet. Connecteu-vos per configurar nous comptes en "
+"línia."
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an account"
+msgstr "Afig un compte"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid "Remove Account"
+msgstr "Suprimeix el compte"
+
+#: ../panels/power/cc-power-panel.c:253
+msgid "Unknown time"
+msgstr "Temps desconegut"
+
+#: ../panels/power/cc-power-panel.c:259
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minut"
+msgstr[1] "%i minuts"
+
+#: ../panels/power/cc-power-panel.c:271
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hora"
+msgstr[1] "%i hores"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:279
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:280
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hora"
+msgstr[1] "hores"
+
+#: ../panels/power/cc-power-panel.c:281
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minuts"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:300
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s fins que es carregi del tot"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:307
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Atenció: queden %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:312
+#, c-format
+msgid "%s remaining"
+msgstr "Queden %s"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:317 ../panels/power/cc-power-panel.c:345
+msgid "Fully charged"
+msgstr "Totalment carregada"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:321 ../panels/power/cc-power-panel.c:349
+msgid "Empty"
+msgstr "Buida"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:336
+msgid "Charging"
+msgstr "S'està carregant"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:341
+msgid "Discharging"
+msgstr "S'està descarregant"
+
+#: ../panels/power/cc-power-panel.c:464
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principal"
+
+#: ../panels/power/cc-power-panel.c:466
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Addicional"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:537
+msgid "Wireless mouse"
+msgstr "Ratolí sense fil"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgid "Wireless keyboard"
+msgstr "Teclat sense fil"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:543
+msgid "Uninterruptible power supply"
+msgstr "Sistema d'alimentació ininterrompuda"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:546
+msgid "Personal digital assistant"
+msgstr "Auxiliar digital personal"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:549
+msgid "Cellphone"
+msgstr "Telèfon mòbil"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgid "Media player"
+msgstr "Reproductor multimèdia"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:555 ../panels/wacom/cc-wacom-panel.c:793
+msgid "Tablet"
+msgstr "Tauleta gràfica"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:558
+msgid "Computer"
+msgstr "Ordinador"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:561 ../panels/power/cc-power-panel.c:801
+#: ../panels/power/cc-power-panel.c:2356
+msgid "Battery"
+msgstr "Bateria"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:615
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "S'està carregant"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:622
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Precaució"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:627
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Baixa"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:632
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Bona"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:637
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Totalment carregada"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:641
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Buida"
+
+#: ../panels/power/cc-power-panel.c:799
+msgid "Batteries"
+msgstr "Bateries"
+
+#: ../panels/power/cc-power-panel.c:1227
+msgid "When _idle"
+msgstr "Quan estiga _inactiu"
+
+#: ../panels/power/cc-power-panel.c:1681
+msgid "Power Saving"
+msgstr "Estalvi d'energia"
+
+#: ../panels/power/cc-power-panel.c:1712
+msgid "_Screen brightness"
+msgstr "Brillantor de la _pantalla"
+
+#: ../panels/power/cc-power-panel.c:1731
+msgid "Automatic brightness"
+msgstr "Brillantor automàtica"
+
+#: ../panels/power/cc-power-panel.c:1751
+msgid "_Keyboard brightness"
+msgstr "Brillantor del _teclat"
+
+#: ../panels/power/cc-power-panel.c:1761
+msgid "_Dim screen when inactive"
+msgstr "_Atenua la pantalla quan estiga inactiva"
+
+#: ../panels/power/cc-power-panel.c:1786
+msgid "_Blank screen"
+msgstr "Pantalla en _blanc"
+
+#: ../panels/power/cc-power-panel.c:1823
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: ../panels/power/cc-power-panel.c:1828
+msgid "Turn off Wi-Fi to save power."
+msgstr "Desactiveu la Wifi per estalviar energia."
+
+#: ../panels/power/cc-power-panel.c:1853
+msgid "_Mobile broadband"
+msgstr "Banda ampla _mòbil"
+
+#: ../panels/power/cc-power-panel.c:1858
+msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+msgstr ""
+"Desactiveu la banda ampla mòbil (3G, 4G, WiMax, etc.) per estalviar energia."
+
+#: ../panels/power/cc-power-panel.c:1903
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: ../panels/power/cc-power-panel.c:1966
+msgid "When on battery power"
+msgstr "Quan s'utilitze la bateria"
+
+#: ../panels/power/cc-power-panel.c:1968
+msgid "When plugged in"
+msgstr "Quan estiga endollat"
+
+#: ../panels/power/cc-power-panel.c:2063
+msgid "Suspend"
+msgstr "Atura temporalment"
+
+#: ../panels/power/cc-power-panel.c:2064
+msgid "Power Off"
+msgstr "Apaga"
+
+#: ../panels/power/cc-power-panel.c:2065
+msgid "Hibernate"
+msgstr "Hiberna"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Nothing"
+msgstr "Res"
+
+#. Frame header
+#: ../panels/power/cc-power-panel.c:2180
+msgid "Suspend & Power Button"
+msgstr "Botó d'aturada temporal i d'engegada"
+
+#: ../panels/power/cc-power-panel.c:2219
+msgid "_Automatic suspend"
+msgstr "_Aturada temporal automàtica"
+
+#: ../panels/power/cc-power-panel.c:2220
+msgid "Automatic suspend"
+msgstr "Aturada temporal automàtica"
+
+#: ../panels/power/cc-power-panel.c:2287
+msgid "_When the Power Button is pressed"
+msgstr "_Quan es prem el botó d'engegada"
+
+#: ../panels/power/cc-power-panel.c:2406 ../shell/cc-window.c:247
+#: ../shell/panel-list.ui.h:1
+msgid "Devices"
+msgstr "Dispositius"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Po­wer"
+msgstr "Energia"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:3
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Visualitzeu l'estat de la bateria i canvieu els paràmetres d'estalvi "
+"d'energia"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:5
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"Energia;Baix consum;Aturada temporal;Hibernació;Bateria;Brillantor;Atenuar;"
+"En blanc;Monitor;DPMS;Inactiu;"
+
+#: ../panels/power/power.ui.h:3
+msgid "45 minutes"
+msgstr "45 minuts"
+
+#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 hora"
+
+#: ../panels/power/power.ui.h:5
+msgid "80 minutes"
+msgstr "80 minuts"
+
+#: ../panels/power/power.ui.h:6
+msgid "90 minutes"
+msgstr "90 minuts"
+
+#: ../panels/power/power.ui.h:7
+msgid "100 minutes"
+msgstr "100 minuts"
+
+#: ../panels/power/power.ui.h:8
+msgid "2 hours"
+msgstr "2 hores"
+
+#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 minut"
+
+#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 minuts"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 minuts"
+
+#: ../panels/power/power.ui.h:12
+msgid "4 minutes"
+msgstr "4 minuts"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 minuts"
+
+#: ../panels/power/power.ui.h:14
+msgid "8 minutes"
+msgstr "8 minuts"
+
+#: ../panels/power/power.ui.h:15
+msgid "10 minutes"
+msgstr "10 minuts"
+
+#: ../panels/power/power.ui.h:16
+msgid "12 minutes"
+msgstr "12 minuts"
+
+#: ../panels/power/power.ui.h:18
+msgid "Automatic Suspend"
+msgstr "Atura temporalment automàticament"
+
+#: ../panels/power/power.ui.h:19
+msgid "_Plugged In"
+msgstr "_Endollat"
+
+#: ../panels/power/power.ui.h:20
+msgid "On _Battery Power"
+msgstr "Quan s'utilitza la _bateria"
+
+#: ../panels/power/power.ui.h:21 ../panels/universal-access/uap.ui.h:36
+msgid "Delay"
+msgstr "Retard"
+
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "Autenticació"
+
+#: ../panels/printers/authentication-dialog.ui.h:4
+#: ../panels/printers/new-printer-dialog.ui.h:13
+msgid "Username"
+msgstr "Nom d'usuari"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+#: ../panels/printers/new-printer-dialog.ui.h:11
+msgid "Authentication Required"
+msgstr "Cal autenticació"
+
+#. Translators: %s is the printer name
+#: ../panels/printers/cc-printers-panel.c:718
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "S'ha suprimit la impressora «%s»"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:909
+msgid "Failed to add new printer."
+msgstr "No s'ha pogut afegir una impressora nova."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:1221
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "No s'ha pogut carregar la interfície d'usuari: %s"
+
+#: ../panels/printers/details-dialog.ui.h:2
+#: ../panels/printers/printer-entry.ui.h:9
+msgid "Location"
+msgstr "Ubicació:"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/details-dialog.ui.h:4
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Controlador"
+
+#: ../panels/printers/details-dialog.ui.h:5
+msgid "Searching for preferred drivers…"
+msgstr "S'estan cercant els controladors preferits…"
+
+#: ../panels/printers/details-dialog.ui.h:6
+msgid "Search for Drivers"
+msgstr "Busca controladors"
+
+#: ../panels/printers/details-dialog.ui.h:7
+msgid "Select from Database…"
+msgstr "Seleccioneu de la base de dades…"
+
+#: ../panels/printers/details-dialog.ui.h:8
+msgid "Install PPD File…"
+msgstr "Instal·la un fitxer PPD..."
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Prin­ters"
+msgstr "Impressores"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Afegiu impressores, visualitzeu tasques d'impressió i decidiu com voleu "
+"imprimir"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:5
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Impressora;Cua;Imprimir;Paper;Tinta;Tòner;"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Clear All"
+msgstr "Neteja-ho tot"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "No Active Printer Jobs"
+msgstr "No hi ha tasques d'impressió actives"
+
+#. Translators: This is the title presented at top of the dialog.
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/printers/pp-new-printer-dialog.c:384
+#: ../panels/printers/pp-new-printer-dialog.c:456
+msgid "Add Printer"
+msgstr "Afig una impressora"
+
+#. Translators: This buttons submits the credentials for the selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:6
+msgid "_Unlock"
+msgstr "Desbloq_ueja"
+
+#. Translators: No printers were detected
+#: ../panels/printers/new-printer-dialog.ui.h:8
+msgid "No Printers Found"
+msgstr "No s'ha trobat cap impressora"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:10
+msgid "Enter a network address or search for a printer"
+msgstr "Introduïu una adreça de xarxa o cerqueu una impressora"
+
+#: ../panels/printers/new-printer-dialog.ui.h:12
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Introduïu el nom d'usuari i la contrasenya per visualitzar les impressores "
+"al servidor d'impressió."
+
+#. Translators: This button triggers the printing of a test page.
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/options-dialog.ui.h:2
+#: ../panels/printers/pp-options-dialog.c:893
+msgid "Test Page"
+msgstr "Pàgina de prova"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: ../panels/printers/pp-details-dialog.c:123
+#: ../panels/printers/pp-details-dialog.c:415
+#, c-format
+msgid "%s Details"
+msgstr "Detalls %s"
+
+#: ../panels/printers/pp-details-dialog.c:172
+msgid "No suitable driver found"
+msgstr "No s'ha trobat cap controlador adequat"
+
+#: ../panels/printers/pp-details-dialog.c:316
+msgid "Select PPD File"
+msgstr "Selecció d'un fitxer PPD"
+
+#: ../panels/printers/pp-details-dialog.c:325
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Fitxers de descripció d'impressora PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+"gz, *.PPD.GZ)"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "Seleccioneu un controlador d'impressora"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:96
+msgid "Select"
+msgstr "Selecciona"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database…"
+msgstr "S'està carregant la base de dades de controladors..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:539
+msgid "JetDirect Printer"
+msgstr "Impressora JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:795
+msgid "LPD Printer"
+msgstr "Impressora LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "Una cara"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "Cantó llarg (estàndard)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "Cantó curt (capgirat)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "Vertical"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "Apaïsat"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "Apaïsat del revés"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "Vertical del revés"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:104
+msgctxt "print job"
+msgid "Pending"
+msgstr "Pendent"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:108
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pausat"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:112
+msgctxt "print job"
+msgid "Processing"
+msgstr "S'està processant"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:116
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Aturada"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:120
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Cancel·lada"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:124
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Interrompuda"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:128
+msgctxt "print job"
+msgid "Completed"
+msgstr "Completada"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: ../panels/printers/pp-jobs-dialog.c:310
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - tasques actives"
+
+#: ../panels/printers/pp-new-printer-dialog.c:402
+msgid "Unlock Print Server"
+msgstr "Desbloqueja el servidor d'impressió"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-new-printer-dialog.c:406
+#, c-format
+msgid "Unlock %s."
+msgstr "Desbloqueja %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-new-printer-dialog.c:411
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Introduïu el nom d'usuari i la contrasenya per visualitzar les impressores a "
+"%s."
+
+#: ../panels/printers/pp-new-printer-dialog.c:876
+msgid "Searching for Printers"
+msgstr "S'estan cercant les impressores"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1799
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1804
+msgid "Serial Port"
+msgstr "Port en sèrie"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1811
+msgid "Parallel Port"
+msgstr "Port paral·lel"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1853
+#, c-format
+msgid "Location: %s"
+msgstr "Ubicació: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1858
+#, c-format
+msgid "Address: %s"
+msgstr "Adreça: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1887
+msgid "Server requires authentication"
+msgstr "El servidor requereix autenticació"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Two Sided"
+msgstr "Doble cara"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Paper Type"
+msgstr "Tipus de paper"
+
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Paper Source"
+msgstr "Font del paper"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "Output Tray"
+msgstr "Safata d'eixida"
+
+#: ../panels/printers/pp-options-dialog.c:88
+msgid "GhostScript pre-filtering"
+msgstr "Filtrat previ del GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:534
+msgid "Pages per side"
+msgstr "Pàgines per cara"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:546
+msgid "Two-sided"
+msgstr "Doble cara"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "General"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Configuració de la pàgina"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opcions instal·lables"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Tasca"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Qualitat de la imatge"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Color"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Acabats"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:676
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avançat"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/pp-options-dialog.c:908
+msgid "Test page"
+msgstr "Pàgina de prova"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "Selecció automàtica"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "Per defecte de la impressora"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "Incrusta només tipus de lletra del GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "Converteix a PS nivell 1"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "Converteix a PS nivell 2"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "Sense filtrat previ"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "Fabricant"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: ../panels/printers/pp-printer-entry.c:577
+msgid "No Active Jobs"
+msgstr "No hi ha tasques actives"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: ../panels/printers/pp-printer-entry.c:582
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u tasca"
+msgstr[1] "%u tasques"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/pp-printer-entry.c:730
+msgid "Low on toner"
+msgstr "Tòner baix"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/pp-printer-entry.c:732
+msgid "Out of toner"
+msgstr "Sense tòner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/pp-printer-entry.c:735
+msgid "Low on developer"
+msgstr "Revelador baix"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/pp-printer-entry.c:738
+msgid "Out of developer"
+msgstr "Sense revelador"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/pp-printer-entry.c:740
+msgid "Low on a marker supply"
+msgstr "Marcador baix"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/pp-printer-entry.c:742
+msgid "Out of a marker supply"
+msgstr "Sense marcador"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/pp-printer-entry.c:744
+msgid "Open cover"
+msgstr "Tapa oberta"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/pp-printer-entry.c:746
+msgid "Open door"
+msgstr "Porta oberta"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/pp-printer-entry.c:748
+msgid "Low on paper"
+msgstr "Paper baix"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/pp-printer-entry.c:750
+msgid "Out of paper"
+msgstr "Sense paper"
+
+#. Translators: The printer is offline
+#: ../panels/printers/pp-printer-entry.c:752
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Apagada"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/pp-printer-entry.c:754
+#: ../panels/printers/pp-printer-entry.c:884
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Aturada"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/pp-printer-entry.c:756
+msgid "Waste receptacle almost full"
+msgstr "El receptacle de residus està quasi ple"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/pp-printer-entry.c:758
+msgid "Waste receptacle full"
+msgstr "El receptacle de residus està ple"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/pp-printer-entry.c:760
+msgid "The optical photo conductor is near end of life"
+msgstr "El conductor òptic fotogràfic està al final de la seua vida"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/pp-printer-entry.c:762
+msgid "The optical photo conductor is no longer functioning"
+msgstr "El conductor òptic fotogràfic ja no funciona"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/pp-printer-entry.c:870
+msgctxt "printer state"
+msgid "Ready"
+msgstr "A punt"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/pp-printer-entry.c:875
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "No accepta tasques"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/pp-printer-entry.c:880
+msgctxt "printer state"
+msgid "Processing"
+msgstr "S'està processant"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: ../panels/printers/pp-printer-entry.c:904
+msgid "Clean print heads"
+msgstr "Neteja els capçals d'impressió"
+
+#: ../panels/printers/printer-entry.ui.h:1
+msgid "Printing Options"
+msgstr "Opcions d'impressió"
+
+#: ../panels/printers/printer-entry.ui.h:2
+msgid "Printer Details"
+msgstr "Detalls de la impressora"
+
+#. Set this printer as default
+#: ../panels/printers/printer-entry.ui.h:4
+msgid "Use Printer by Default"
+msgstr "Utilitza la impressora per defecte"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: ../panels/printers/printer-entry.ui.h:6
+msgid "Clean Print Heads"
+msgstr "Neteja els capçals d'impressió"
+
+#: ../panels/printers/printer-entry.ui.h:7
+msgid "Remove Printer"
+msgstr "Suprimeix la impressora"
+
+#: ../panels/printers/printer-entry.ui.h:8
+msgid "Model"
+msgstr "Model"
+
+#: ../panels/printers/printer-entry.ui.h:10
+msgid "Ink Level"
+msgstr "Nivell de tinta"
+
+#. Translators: This is the message which follows the printer error.
+#: ../panels/printers/printer-entry.ui.h:12
+msgid "Please restart when the problem is resolved."
+msgstr "Reinicieu quan el problema estiga resolt."
+
+#. Translators: This is the button which restarts the printer.
+#: ../panels/printers/printer-entry.ui.h:14
+msgid "Restart"
+msgstr "Torna a iniciar"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:2
+msgid "Add…"
+msgstr "Afig..."
+
+#: ../panels/printers/printers.ui.h:5
+msgid "No printers"
+msgstr "Sense impressores"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:7
+msgid "Add a Printer…"
+msgstr "Afig una impressora..."
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:9
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"Perdó! Pareix que el servei d'impressió\n"
+"del sistema no està disponible."
+
+#: ../panels/privacy/cc-privacy-panel.c:387 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "Bloca la pantalla"
+
+#: ../panels/privacy/cc-privacy-panel.c:438
+msgid "In use"
+msgstr "En ús"
+
+#: ../panels/privacy/cc-privacy-panel.c:443
+msgctxt "Location services status"
+msgid "On"
+msgstr "Activat"
+
+#: ../panels/privacy/cc-privacy-panel.c:444
+msgctxt "Location services status"
+msgid "Off"
+msgstr "Desactivat"
+
+#: ../panels/privacy/cc-privacy-panel.c:823 ../panels/privacy/privacy.ui.h:42
+msgid "Location Services"
+msgstr "Serveis d'ubicació"
+
+#: ../panels/privacy/cc-privacy-panel.c:942 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "Ús i historial"
+
+#: ../panels/privacy/cc-privacy-panel.c:1071
+msgid "Empty all items from Trash?"
+msgstr "Voleu buidar la paperera?"
+
+#: ../panels/privacy/cc-privacy-panel.c:1072
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Se suprimiran permanent tots els elements de la paperera."
+
+#: ../panels/privacy/cc-privacy-panel.c:1073
+msgid "_Empty Trash"
+msgstr "_Buida la paperera"
+
+#: ../panels/privacy/cc-privacy-panel.c:1096
+msgid "Delete all the temporary files?"
+msgstr "Voleu suprimir tots fitxers temporals?"
+
+#: ../panels/privacy/cc-privacy-panel.c:1097
+msgid "All the temporary files will be permanently deleted."
+msgstr "Se suprimiran permanent tots els fitxers temporals."
+
+#: ../panels/privacy/cc-privacy-panel.c:1098
+msgid "_Purge Temporary Files"
+msgstr "Suprimeix els fitxers _temporals"
+
+#: ../panels/privacy/cc-privacy-panel.c:1120 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "Buida la paperera i els fitxers temporals"
+
+#: ../panels/privacy/cc-privacy-panel.c:1160 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr "Ús de programari"
+
+#: ../panels/privacy/cc-privacy-panel.c:1201 ../panels/privacy/privacy.ui.h:46
+msgid "Problem Reporting"
+msgstr "Informa de problemes"
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: ../panels/privacy/cc-privacy-panel.c:1215
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+"Enviar informes de problemes tècnics ajuda a millorar %s. Els informes "
+"s'envien anònimament i sense dades personals."
+
+#: ../panels/privacy/cc-privacy-panel.c:1227 ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "Política de privacitat"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Pri­va­cy"
+msgstr "Privadesa"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:3
+msgid "Protect your personal information and control what others might see"
+msgstr "Protegiu la informació personal i controleu què poden veure els altres"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:5
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"pantalla;bloca;diagnòstics;fallades;privat;recent;temporal;tmp;índex;nom;"
+"xarxa;identitat;"
+
+# N.T.: En minúscula ja que s'afegeix visualment a una altre cadena
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "s'apaga la pantalla"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 segons"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 dia"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 dies"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 dies"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 dies"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 dies"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 dies"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 dies"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 dies"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 dies"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "Per sempre"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"Si es recorda l'historial, és més fàcil tornar a trobar les coses. Estos "
+"elements no es comparteixen mai a la xarxa."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "Utilitzat _recentment"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "Conserva l'_historial"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "_Neteja l'historial recent"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr ""
+"El bloqueig de la pantalla protegeix la vostra privacitat quan no hi sou."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "_Bloca la pantalla automàticament"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "_Bloca la pantalla després d'estar en blanc durant"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "Mostra les _notificacions"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"Buideu automàticament la paperera i els fitxers temporals per ajudar a "
+"mantindre l'ordinador lliure d'informació sensible innecessària."
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "Buida automàticament la _paperera"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "Suprimeix automàticament els _fitxers temporals"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "Suprimeix _després de"
+
+#: ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash…"
+msgstr "_Buida la paperera..."
+
+#: ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files…"
+msgstr "Suprimeix els fitxers _temporals..."
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"L'enviament d'informació sobre el programari que feu servir ens ajuda a "
+"donar-vos recomanacions més adequades. Això també ens ajuda a millorar el "
+"nostre programari.\n"
+"\n"
+"Tota la informació recollida és anònima i mai no compartirem les vostres "
+"dades amb terceres parts."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "Envia e_stadístiques d'ús de programari"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"Els serveis d'ubicació permeten que les aplicacions puguen saber on sou. "
+"L'ús de Wi-Fi i de dades mòbils permet millorar la precisió."
+
+#: ../panels/privacy/privacy.ui.h:44
+msgid "_Location Services"
+msgstr "Serveis d'_ubicació"
+
+#: ../panels/privacy/privacy.ui.h:47
+msgid "_Automatic Problem Reporting"
+msgstr "_Informa de problemes automàticament"
+
+#: ../panels/region/cc-format-chooser.c:118
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: ../panels/region/cc-format-chooser.c:120
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Mètric"
+
+#: ../panels/region/cc-format-chooser.c:285
+msgid "No regions found"
+msgstr "No s'han trobat regions"
+
+#: ../panels/region/cc-input-chooser.c:182
+msgid "No input sources found"
+msgstr "No s'han trobat fonts d'entrada"
+
+#: ../panels/region/cc-input-chooser.c:1012
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Altres"
+
+#: ../panels/region/cc-region-panel.c:881
+msgid "No input source selected"
+msgstr "No s'ha seleccionat cap font d'entrada"
+
+#: ../panels/region/cc-region-panel.c:1773
+msgid "Login _Screen"
+msgstr "_Pantalla d'entrada"
+
+#: ../panels/region/format-chooser.ui.h:1
+msgid "Formats"
+msgstr "Formats"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "Visualització prèvia"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "Dates"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "Hores"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Dates & Times"
+msgstr "Dates i hores"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Numbers"
+msgstr "Nombres"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Measurement"
+msgstr "Mesura"
+
+#: ../panels/region/format-chooser.ui.h:10
+msgid "Paper"
+msgstr "Paper"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid "Re­gion & Lan­guage"
+msgstr "Regió i idioma"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"Seleccioneu l'idioma a mostrar, els formats, les disposicions de teclat i "
+"les fonts d'entrada"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:5
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Idioma;Disposició;Teclat;Entrada;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "Afig una font d'entrada"
+
+#: ../panels/region/input-chooser.ui.h:4
+msgid "Input methods can’t be used on the login screen"
+msgstr "Els mètodes d'entrada no es poden utilitzar a la pantalla d'entrada"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "Opcions de la font d'entrada"
+
+#: ../panels/region/input-options.ui.h:2
+msgid "Use the _same source for all windows"
+msgstr "Utilitza la _mateixa font a totes les finestres"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Allow _different sources for each window"
+msgstr "Permet fonts _diferents per a cada finestra"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Switch to previous source"
+msgstr "Commuta a la font anterior"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Super+Shift+Space"
+msgstr "Súper+Maj+Espai"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Switch to next source"
+msgstr "Commuta a la font següent"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Super+Space"
+msgstr "Súper+Espai"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "Podeu canviar estes dreceres als paràmetres del teclat"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "Alternative switch to next source"
+msgstr "Forma alternativa per canviar a la font següent"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Left+Right Alt"
+msgstr "Alt dreta i esquerra"
+
+#: ../panels/region/region.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "_Idioma"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "Anglés (Regne Unit)"
+
+#: ../panels/region/region.ui.h:3
+msgid "Restart the session for changes to take effect"
+msgstr "Cal que reinicieu la sessió perquè els canvis tinguen efecte."
+
+#: ../panels/region/region.ui.h:4
+msgid "Restart…"
+msgstr "Reinicia…"
+
+#: ../panels/region/region.ui.h:5
+msgid "_Formats"
+msgstr "_Formats"
+
+#: ../panels/region/region.ui.h:6
+msgid "United Kingdom"
+msgstr "Regne Unit"
+
+#: ../panels/region/region.ui.h:7
+msgid "Input Sources"
+msgstr "Fonts d'entrada"
+
+#: ../panels/region/region.ui.h:8
+msgid "_Options"
+msgstr "_Opcions"
+
+#: ../panels/region/region.ui.h:9
+msgid "Add input source"
+msgstr "Afig una font d'entrada"
+
+#: ../panels/region/region.ui.h:10
+msgid "Remove input source"
+msgstr "Suprimeix una font d'entrada"
+
+#: ../panels/region/region.ui.h:11
+msgid "Move input source up"
+msgstr "Mou la font d'entrada amunt"
+
+#: ../panels/region/region.ui.h:12
+msgid "Move input source down"
+msgstr "Mou la font d'entrada avall"
+
+#: ../panels/region/region.ui.h:13
+msgid "Configure input source"
+msgstr "Configura la font d'entrada"
+
+#: ../panels/region/region.ui.h:14
+msgid "Show input source keyboard layout"
+msgstr "Mostra la disposició del teclat de la font d'entrada"
+
+#: ../panels/region/region.ui.h:15
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"Tots els usuaris utilitzen els paràmetres d'entrada en entrar al sistema"
+
+#: ../panels/search/cc-search-locations-dialog.c:639
+msgid "Select Location"
+msgstr "Seleccioneu una ubicació"
+
+#: ../panels/search/cc-search-locations-dialog.c:643
+msgid "_OK"
+msgstr "_D'acord"
+
+#: ../panels/search/cc-search-panel.c:178
+msgid "No applications found"
+msgstr "No s'han trobat aplicacions"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid "Search"
+msgstr "Busca"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:3
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controleu quines aplicacions mostren resultats de busca a la vista general "
+"d'activitats"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:5
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Busca;Troba;Índex;Oculta;Privacitat;Resultats;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "Ubicacions de busca"
+
+#: ../panels/search/search-locations-dialog.ui.h:2
+msgid "Places"
+msgstr "Llocs"
+
+#: ../panels/search/search-locations-dialog.ui.h:3
+msgid "Bookmarks"
+msgstr "Adreces d'interés"
+
+#: ../panels/search/search-locations-dialog.ui.h:4
+msgid "Other"
+msgstr "Altres"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "Mou amunt"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "Mou avall"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "Preferències"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:303
+msgid "No networks selected for sharing"
+msgstr "No hi ha cap xarxa seleccionada per compartir"
+
+#: ../panels/sharing/cc-sharing-panel.c:273
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Activat"
+
+#: ../panels/sharing/cc-sharing-panel.c:275
+#: ../panels/sharing/cc-sharing-panel.c:302
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Desactivat"
+
+#: ../panels/sharing/cc-sharing-panel.c:305
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Habilitat"
+
+#: ../panels/sharing/cc-sharing-panel.c:308
+msgctxt "service is active"
+msgid "Active"
+msgstr "Actiu"
+
+#: ../panels/sharing/cc-sharing-panel.c:379
+msgid "Choose a Folder"
+msgstr "Trieu una carpeta"
+
+#: ../panels/sharing/cc-sharing-panel.c:690
+#, c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"La compartició de fitxers personals vos permet compartir la carpeta pública "
+"amb altres a la xarxa actual utilitzant: <a href=\"dav://%s\">dav://%s</a>"
+
+#: ../panels/sharing/cc-sharing-panel.c:692
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"Quan l'entrada remota està habilitada, els usuaris remots poden connectar-se "
+"utilitzant l'orde del Secure Shell:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/cc-sharing-panel.c:694
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"La compartició de pantalla permet a usuaris remots visualitzar o controlar "
+"la pantalla connectant-se a: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/cc-sharing-panel.c:806
+msgid "Copy"
+msgstr "Copia"
+
+#: ../panels/sharing/cc-sharing-panel.c:1233
+msgid "Sharing"
+msgstr "Compartició"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Sha­ring"
+msgstr "Compartició"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:3
+msgid "Control what you want to share with others"
+msgstr "Controleu què voleu compartir amb els altres"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:5
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"comparteix;compartició;ssh;amfitrió;nom;remot;escriptori;multimèdia;àudio;"
+"vídeo;imatges;fotografies;pel·lícules;servidor;renderitzar;"
+
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "Xarxes"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "Habilita o inhabilita l'entrada remota"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Cal autenticació per habilitar o inhabilitar l'entrada remota"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "_Computer Name"
+msgstr "_Nom de l'ordinador"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid "_File Sharing"
+msgstr "_Compartició de fitxers"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "_Screen Sharing"
+msgstr "_Compartició de pantalla"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "_Media Sharing"
+msgstr "_Compartició multimèdia"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "_Remote Login"
+msgstr "_Entrada remota"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Some services are disabled because of no network access."
+msgstr "Alguns serveis estan inhabilitats perquè no hi ha accés a la xarxa."
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "File Sharing"
+msgstr "Compartició de fitxers"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "_Require Password"
+msgstr "_Demana contrasenya"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Remote Login"
+msgstr "Entrada remota"
+
+#: ../panels/sharing/sharing.ui.h:11
+msgid "Screen Sharing"
+msgstr "Compartició de pantalla"
+
+#: ../panels/sharing/sharing.ui.h:12
+msgid "_Allow connections to control the screen"
+msgstr "_Permet a les connexions controlar la pantalla"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "_Password:"
+msgstr "_Contrasenya:"
+
+#: ../panels/sharing/sharing.ui.h:14
+msgid "_Show Password"
+msgstr "_Mostra la contrasenya"
+
+#: ../panels/sharing/sharing.ui.h:15
+msgid "Access Options"
+msgstr "Opcions d'accés"
+
+#: ../panels/sharing/sharing.ui.h:16
+msgid "_New connections must ask for access"
+msgstr "_Les connexions noves han de demanar accés"
+
+#: ../panels/sharing/sharing.ui.h:17
+msgid "_Require a password"
+msgstr "_Demana una contrasenya"
+
+#: ../panels/sharing/sharing.ui.h:18
+msgid "Media Sharing"
+msgstr "Compartició multimèdia"
+
+#: ../panels/sharing/sharing.ui.h:19
+msgid "Share music, photos and videos over the network."
+msgstr "Compartiu música, fotografies i vídeos a través de la xarxa."
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Folders"
+msgstr "Carpetes"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "So"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Canvieu els nivells de so, les entrades, les eixides i les alertes sonores"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "Targeta;Micròfon;Volum;Esvair;Balanç;Bluetooth;Auriculars;Àudio;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "Lladruc"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "Goteig"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "Vidre"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "Sonar"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "Esquerra"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "Dreta"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "Darrere"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "Frontal"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Mínim"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Màxim"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "_Balanç:"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "_Esvaeix:"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "Altaveu de _greus:"
+
+#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:615
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Sense amplificar"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
+#: ../panels/sound/gvc-mixer-dialog.c:515
+msgid "_Profile:"
+msgstr "_Perfil:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1873
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u eixida"
+msgstr[1] "%u eixides"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1883
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrada"
+msgstr[1] "%u entrades"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2738
+msgid "System Sounds"
+msgstr "Sons del sistema"
+
+#: ../panels/sound/gvc-mixer-dialog.c:251
+msgid "_Test Speakers"
+msgstr "_Prova els altaveus"
+
+#: ../panels/sound/gvc-mixer-dialog.c:420
+msgid "Peak detect"
+msgstr "Detecció de pics"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1512
+msgid "Device"
+msgstr "Dispositiu"
+
+# N.T.: Títol de quadre de diàleg
+#: ../panels/sound/gvc-mixer-dialog.c:1575
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "Prova d'altaveus per a %s"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1631
+msgid "_Output volume:"
+msgstr "Volum d'ei_xida:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1645
+msgid "Output"
+msgstr "Eixida"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1650
+msgid "C_hoose a device for sound output:"
+msgstr "_Trieu un dispositiu per a l'eixida de so:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1672
+msgid "Settings for the selected device:"
+msgstr "Paràmetres del dispositiu seleccionat:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1683
+msgid "Input"
+msgstr "Entrada"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1690
+msgid "_Input volume:"
+msgstr "Volum d'_entrada:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "Input level:"
+msgstr "Nivell d'entrada:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1737
+msgid "C_hoose a device for sound input:"
+msgstr "_Trieu un dispositiu per a l'entrada de so:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1761
+msgid "Sound Effects"
+msgstr "Efectes de so"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1768
+msgid "_Alert volume:"
+msgstr "Volum d'_alerta:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1785
+msgid "No application is currently playing or recording audio."
+msgstr "Actualment cap aplicació no està reproduint ni gravant àudio."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "Integrat"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "Preferències de so"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "S'està provant el so de l'esdeveniment"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:554
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "Default"
+msgstr "Per defecte"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:555
+msgid "From theme"
+msgstr "Del tema"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:740
+msgid "C_hoose an alert sound:"
+msgstr "Trieu un so d'_alerta:"
+
+#: ../panels/sound/gvc-speaker-test.c:231
+msgid "Stop"
+msgstr "Atura"
+
+#: ../panels/sound/gvc-speaker-test.c:231
+#: ../panels/sound/gvc-speaker-test.c:343
+msgid "Test"
+msgstr "Prova"
+
+#: ../panels/sound/gvc-speaker-test.c:239
+msgid "Subwoofer"
+msgstr "Altaveu de greus"
+
+#: ../panels/sound/sound-theme-file-utils.c:304
+msgid "Custom"
+msgstr "Personalitzat"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: ../panels/universal-access/cc-ua-panel.c:351
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Per defecte"
+
+#: ../panels/universal-access/cc-ua-panel.c:354
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Mitjà"
+
+#: ../panels/universal-access/cc-ua-panel.c:357
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Gran"
+
+#: ../panels/universal-access/cc-ua-panel.c:360
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Més gran"
+
+#: ../panels/universal-access/cc-ua-panel.c:363
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "El més gran"
+
+#: ../panels/universal-access/cc-ua-panel.c:367
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d píxel"
+msgstr[1] "%d píxels"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Uni­ver­sal Access"
+msgstr "Accés universal"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Feu més fàcil veure, escoltar, teclejar, apuntar i fer clic"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:5
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+msgstr ""
+"Teclat;Ratolí;a11y;Accessibilitat;Contrast;Zoom;Pantalla;Lector;text;lletra;"
+"mida;AccessX;Tecles enganxoses;Tecles;Lent;Salt;Ratolí;Doble;clic;Retard;"
+"Assistència;Repetició;Parpelleig;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "Mostra _sempre el menú d'accés universal"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "Visió"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "_Contrast alt"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "Text _gran"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "C_ursor Size"
+msgstr "Mida del _cursor"
+
+#: ../panels/universal-access/uap.ui.h:6
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "_Zoom"
+msgstr "_Ampliació"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "Screen _Reader"
+msgstr "Lector de _pantalla"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "_Sound Keys"
+msgstr "_So de les tecles"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "Hearing"
+msgstr "Audició"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgid "_Visual Alerts"
+msgstr "Alertes _visuals"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "Screen _Keyboard"
+msgstr "_Teclat en pantalla"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "R_epeat Keys"
+msgstr "_Repetició de tecles"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "Cursor _Blinking"
+msgstr "_Parpelleig del cursor"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Typing Assist (AccessX)"
+msgstr "Assistent d'escriptura (AccessX)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Pointing & Clicking"
+msgstr "Apuntar i fer clic"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "_Mouse Keys"
+msgstr "Tecles del _ratolí"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Click Assist"
+msgstr "A_ssistència en fer clic"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "_Double-Click Delay"
+msgstr "_Retard del doble clic"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Double-Click Delay"
+msgstr "Retard del doble clic"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Cursor Size"
+msgstr "Mida del cursor"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"La mida del cursor pot combinar-se amb l'ampliació perquè siga més fàcil "
+"veure el cursor."
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Screen Reader"
+msgstr "Lector de pantalla"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"El lector de pantalla llig el text visualitzat mentre moveu el focus."
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "_Screen Reader"
+msgstr "Lector de _pantalla"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Sound Keys"
+msgstr "So de les tecles"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Fes un avís sonor quan s'active o desactive la fixació numèrica o de les "
+"majúscules."
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Visual Alerts"
+msgstr "Alertes visuals"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Test flash"
+msgstr "_Prova el parpelleig"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Utilitza una indicació visual quan es produïsca una alerta sonora."
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Flash the _window title"
+msgstr "Fes parpellejar el títol de la _finestra"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Flash the entire _screen"
+msgstr "Fes parpellejar la _pantalla sencera"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Repeat Keys"
+msgstr "Repetició de tecles"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgid "Key presses repeat when key is held down."
+msgstr "Es repeteix la tecla quan es manté premuda."
+
+#: ../panels/universal-access/uap.ui.h:37
+msgid "Repeat keys delay"
+msgstr "Retard en la repetició de tecles"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Speed"
+msgstr "Velocitat:"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Repeat keys speed"
+msgstr "Velocitat de la repetició de tecles"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Cursor Blinking"
+msgstr "Parpelleig del cursor"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "Cursor blinks in text fields."
+msgstr "El cursor parpelleja en els camps de text."
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Cursor blinking speed"
+msgstr "Velocitat del parpelleig del cursor"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgid "Typing Assist"
+msgstr "Assistent d'escriptura"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "_Sticky Keys"
+msgstr "Tecles _enganxoses"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Tracta una seqüència de tecles modificadores com una combinació de tecles"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Disable if two keys are pressed together"
+msgstr "_Inhabilita si es premen dues tecles alhora"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Beep when a _modifier key is pressed"
+msgstr "Fes un avís sonor quan es prema una tecla _modificadora"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "S_low Keys"
+msgstr "Tecles _lentes"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introdueix un retard entre que es prem una tecla i s'accepta"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "A_cceptance delay:"
+msgstr "Retard d'a_cceptació:"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Slow keys typing delay"
+msgstr "Retard d'escriptura de les tecles lentes"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "Beep when a key is pr_essed"
+msgstr "Fes un avís sonor quan es _prema una tecla"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Beep when a key is _accepted"
+msgstr "Fes un avís sonor quan s'_accepti una tecla"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "Beep when a key is _rejected"
+msgstr "Fes un avís sonor quan es _rebutgi una tecla"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgid "_Bounce Keys"
+msgstr "_Omet tecles"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignora les pulsacions duplicades ràpides"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgid "Bounce keys typing delay"
+msgstr "Retard d'escriptura en ometre tecles"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "_Enable by Keyboard"
+msgstr "_Habilita per teclat"
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Activa i desactiva les funcions d'accessibilitat utilitzant el teclat"
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "Click Assist"
+msgstr "Assistència en fer clic"
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "_Simulated Secondary Click"
+msgstr "Clic secundari _simulat"
+
+#: ../panels/universal-access/uap.ui.h:66
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Fes un clic secundari en mantindre premut el botó primari"
+
+#: ../panels/universal-access/uap.ui.h:67
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curt"
+
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Secondary click delay"
+msgstr "Retard del clic secundari"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: ../panels/universal-access/uap.ui.h:70
+msgid "_Hover Click"
+msgstr "Clic en passar per sobre"
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Trigger a click when the pointer hovers"
+msgstr "Fes un clic en passar el punter per sobre"
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "D_elay:"
+msgstr "R_etard:"
+
+#: ../panels/universal-access/uap.ui.h:73
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curt"
+
+#: ../panels/universal-access/uap.ui.h:74
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Llarg"
+
+#: ../panels/universal-access/uap.ui.h:75
+msgid "Motion _threshold:"
+msgstr "Llindar de _moviment:"
+
+#: ../panels/universal-access/uap.ui.h:76
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Petit"
+
+#: ../panels/universal-access/uap.ui.h:77
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Gran"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "Curta"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ de pantalla"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ de pantalla"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ de pantalla"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "Llarga"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "Pantalla completa"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "Meitat superior"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "Meitat inferior"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "Meitat esquerra"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "Meitat dreta"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "Opcions d'ampliació"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "_Magnification:"
+msgstr "_Ampliació:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "_Follow mouse cursor"
+msgstr "_Segueix el cursor del ratolí"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "_Screen part:"
+msgstr "_Part de la pantalla:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier _extends outside of screen"
+msgstr "L'_ampliador s'estén fora de la pantalla"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "_Keep magnifier cursor centered"
+msgstr "_Mantén el cursor de l'ampliador centrat"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor _pushes contents around"
+msgstr "_El cursor de l'ampliador empeny el contingut del voltant"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with _contents"
+msgstr "El _cursor de l'ampliador es mou amb el contingut"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "Posició de l'ampliador:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "Ampliador"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "_Thickness:"
+msgstr "_Gruix:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Prim"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Gruixut"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "_Length:"
+msgstr "_Longitud:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Co_lor:"
+msgstr "_Color:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "_Crosshairs:"
+msgstr "_Creus:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "_Overlaps mouse cursor"
+msgstr "_Sobreposa el cursor del ratolí"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "Creus"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "_White on black:"
+msgstr "_Blanc sobre negre:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "_Brightness:"
+msgstr "_Brillantor:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "_Contrast:"
+msgstr "_Contrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Colo_r"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Cap"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Tot"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Baixa"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alta"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Baix"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alt"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "Efectes de color:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "Efectes de color"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/join-dialog.ui.h:1
+msgid "Add User"
+msgstr "Afig un usuari"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "_Full Name"
+msgstr "_Nom complet"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Standard"
+msgstr "Estàndard"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Administrator"
+msgstr "Administrador"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Account _Type"
+msgstr "_Tipus de compte"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "Allow user to set a password when they next _login"
+msgstr "_Permet a l'usuari establir la contrasenya a l'entrada següent"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid "Set a password _now"
+msgstr "_Estableix una contrasenya ara"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid "_Confirm"
+msgstr "_Confirma"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:14
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Els accessos corporatius permeten utilitzar comptes d'usuari corporatius "
+"centralitzats en este dispositiu. També podeu usar este compte per "
+"accedir als recursos de l'empresa a Internet."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+#: ../panels/user-accounts/data/join-dialog.ui.h:9
+msgid "_Domain"
+msgstr "_Domini"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+msgid "You are Offline"
+msgstr "Esteu fora de línia"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+msgid "You must be online in order to add enterprise users."
+msgstr "Heu d'estar en línia per afegir usuaris corporatius."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:18
+msgid "_Enterprise Login"
+msgstr "_Entrada corporativa"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "Polze esquerre"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "Dit del mig esquerre"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "Dit anular esquerre"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "Dit petit esquerre"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "Polze dret"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "Dit del mig dret"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "Dit anular dret"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "Dit petit dret"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:680
+msgid "Enable Fingerprint Login"
+msgstr "Habilita l'entrada amb empremta dactilar"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "Dit índex d_ret"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "Dit índex _esquerre"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "Un _altre dit:"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"La vostra empremta dactilar s'ha guardat correctament. Hauríeu de poder entrar "
+"utilitzant el lector d'empremtes dactilars."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "Usuaris"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "Afegiu o suprimiu usuaris i canvieu la contrasenya"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Entrada;Nom;Empremta dactilar;Avatar;Logotip;Cara;Contrasenya;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/join-dialog.ui.h:4
+msgid "_Enroll"
+msgstr "_Afig-lo"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:5
+msgid "Domain Administrator Login"
+msgstr "Entrada de l'administrador del domini"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:6
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Per poder utilitzar entrades corporatives, este ordinador\n"
+"necessita formar part del domini. Demaneu a l'administrador que\n"
+"introduïsca ací la seua contrasenya."
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:10
+msgid "Administrator _Name"
+msgstr "_Nom de l'administrador"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:11
+msgid "Administrator Password"
+msgstr "Contrasenya de l'administrador"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr "Canvi de la contrasenya"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "C_anvia"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "_Verifica la contrasenya nova"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "Contrasenya _nova"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "Contrasenya _actual"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to change their password on next login"
+msgstr "Permet a l'usuari establir la contrasenya a l'entrada següent"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "Estableix una contrasenya ara"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+msgid "_Add User…"
+msgstr "_Afig usuari…"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "S'ha de tornar a iniciar la sessió perquè els canvis tinguen efecte"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Restart Now"
+msgstr "Renicia ara"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "Entrada a_utomàtica"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "Entrada amb _empremta dactilar"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "Icona d'usuari"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "Últim inici de sessió"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "Remove User…"
+msgstr "Suprimeix l'usuari..."
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "Gestiona els comptes d'usuari"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "Cal autenticació per canviar les dades de l'usuari"
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "La contrasenya nova ha de ser diferent de la vella."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Canvieu algunes lletres i números."
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Canvieu la contrasenya una mica més."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Una contrasenya sense el vostre nom d'usuari seria més segura."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Eviteu l'ús del vostre nom a la contrasenya."
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Eviteu algunes de les paraules incloses a la contrasenya."
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Eviteu utilitzar paraules comunes."
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Eviteu utilitzar paraules desordenades."
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Utilitzeu més nombres."
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Utilitzeu més lletres majúscules."
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Utilitzeu més lletres minúscules."
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Utilitzeu més caràcters especials, com ara signes de puntuació."
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+"Intenteu utilitzar una combinació de lletres, nombres i signes de puntuació."
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Eviteu repetir el mateix caràcter."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Eviteu repetir el mateix tipus de caràcter: combineu lletres, números i "
+"signes de puntuació."
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Eviteu emprar seqüències com ara 1234 o abcd."
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Cal que la contrasenya siga més gran. Intenteu utilitzar una combinació de "
+"lletres, nombres i signes de puntuació."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Combineu majúscules i minúscules i empreu un o dos nombres."
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Si hi afegiu més lletres, nombres i signes de puntuació la contrasenya serà "
+"més segura."
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "Ha fallat l'autenticació"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "La contrasenya nova és massa curta"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "La contrasenya nova és massa senzilla"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "La contrasenya nova i l'anterior són massa semblants"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "La contrasenya nova ja s'ha utilitzat recentment."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "La contrasenya nova ha de contindre caràcters numèrics o especials"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "La contrasenya nova i l'anterior són iguals"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "La vostra contrasenya ha canviat des que vos heu autenticat."
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "La contrasenya nova no conté suficients caràcters diferents"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "Error desconegut"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "Ha de coincidir amb l'adreça web del proveïdor del compte."
+
+#: ../panels/user-accounts/um-account-dialog.c:229
+msgid "Failed to add account"
+msgstr "No s'ha pogut afegir el compte"
+
+#: ../panels/user-accounts/um-account-dialog.c:462
+msgid "Passwords do not match."
+msgstr "Les contrasenyes no coincideixen."
+
+#: ../panels/user-accounts/um-account-dialog.c:717
+#: ../panels/user-accounts/um-account-dialog.c:763
+#: ../panels/user-accounts/um-account-dialog.c:784
+msgid "Failed to register account"
+msgstr "No s'ha pogut registrar el compte"
+
+#: ../panels/user-accounts/um-account-dialog.c:907
+msgid "No supported way to authenticate with this domain"
+msgstr "No hi ha cap manera compatible per autenticar-se amb este domini"
+
+#: ../panels/user-accounts/um-account-dialog.c:980
+msgid "Failed to join domain"
+msgstr "No s'ha pogut unir al domini"
+
+#: ../panels/user-accounts/um-account-dialog.c:1041
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"El nom d'usuari no és correcte.\n"
+"Torneu-ho a provar."
+
+#: ../panels/user-accounts/um-account-dialog.c:1048
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"La contrasenya no és vàlida.\n"
+"Torneu-ho a provar."
+
+#: ../panels/user-accounts/um-account-dialog.c:1056
+msgid "Failed to log into domain"
+msgstr "No s'ha pogut entrar al domini"
+
+#: ../panels/user-accounts/um-account-dialog.c:1114
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "No s'ha trobat el domini. Potser l'heu escrit malament?"
+
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Estàndard"
+
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Administrador"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"No teniu permís per accedir al dispositiu. Contacteu amb l'administrador del "
+"sistema."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:144
+msgid "The device is already in use."
+msgstr "El dispositiu ja està en ús."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:146
+msgid "An internal error occurred."
+msgstr "S'ha produït un error intern."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:217
+msgid "Enabled"
+msgstr "Habilitat"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr "Voleu suprimir les empremtes dactilars registrades?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr "_Suprimeix les empremtes dactilars"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Voleu suprimir les empremtes dactilars registrades de manera que "
+"s'inhabiliti l'entrada amb empremta dactilar?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:443
+msgid "Done!"
+msgstr "Fet"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:504
+#: ../panels/user-accounts/um-fingerprint-dialog.c:546
+#, c-format
+msgid "Could not access “%s” device"
+msgstr "No s'ha pogut accedir al dispositiu «%s»."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:587
+#, c-format
+msgid "Could not start finger capture on “%s” device"
+msgstr ""
+"No s'ha pogut iniciar la captura de l'empremta dactilar al dispositiu «%s»."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:631
+msgid "Could not access any fingerprint readers"
+msgstr "No s'ha pogut accedir a cap lector d'empremtes dactilars"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:632
+msgid "Please contact your system administrator for help."
+msgstr "Contacteu amb l'administrador del sistema per obtindre ajuda."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:714
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the “%s” device."
+msgstr ""
+"Per habilitar l'entrada amb empremta dactilar, cal que guardeu una de les "
+"vostres empremtes dactilars utilitzant el dispositiu «%s»."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:721
+msgid "Selecting finger"
+msgstr "S'està seleccionant un dit"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:722
+msgid "Enrolling fingerprints"
+msgstr "S'estan registrant les empremtes dactilars"
+
+#: ../panels/user-accounts/um-history-dialog.c:70
+msgid "This Week"
+msgstr "Esta setmana"
+
+#: ../panels/user-accounts/um-history-dialog.c:73
+msgid "Last Week"
+msgstr "Setmana passada"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:79
+#: ../panels/user-accounts/um-history-dialog.c:83
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e de %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:93
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:177
+#: ../panels/user-accounts/um-user-panel.c:776
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:180
+#: ../panels/user-accounts/um-user-panel.c:780
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:250
+msgid "Session Ended"
+msgstr "Ha acabat la sessió"
+
+#: ../panels/user-accounts/um-history-dialog.c:256
+msgid "Session Started"
+msgstr "S'ha iniciat la sessió"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: ../panels/user-accounts/um-history-dialog.c:299
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s - Activitat del compte"
+
+#: ../panels/user-accounts/um-password-dialog.c:144
+msgid "Please choose another password."
+msgstr "Trieu una altra contrasenya."
+
+#: ../panels/user-accounts/um-password-dialog.c:153
+msgid "Please type your current password again."
+msgstr "Escriviu un altre cop la vostra contrasenya actual."
+
+#: ../panels/user-accounts/um-password-dialog.c:159
+msgid "Password could not be changed"
+msgstr "No s'ha pogut canviar la contrasenya"
+
+#: ../panels/user-accounts/um-password-dialog.c:285
+msgid "The passwords do not match."
+msgstr "Les contrasenyes no coincideixen."
+
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "Browse for more pictures"
+msgstr "Busca més imatges"
+
+#: ../panels/user-accounts/um-photo-dialog.c:452
+msgid "Disable image"
+msgstr "Inhabilita la imatge"
+
+#: ../panels/user-accounts/um-photo-dialog.c:470
+msgid "Take a photo…"
+msgstr "Fes una fotografia…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:488
+msgid "Browse for more pictures…"
+msgstr "Busca més imatges…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:714
+#, c-format
+msgid "Used by %s"
+msgstr "Utilitzat per %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "No es pot unir automàticament a este tipus de domini"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "No s'ha trobat este domini o regne"
+
+#: ../panels/user-accounts/um-realm-manager.c:815
+#: ../panels/user-accounts/um-realm-manager.c:829
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "No s'ha pogut entrar com a %s al domini %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:821
+msgid "Invalid password, please try again"
+msgstr "La contrasenya no vàlida, torneu-ho a provar"
+
+#: ../panels/user-accounts/um-realm-manager.c:834
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "No s'ha pogut connectar al domini %s: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:195
+msgid "Your account"
+msgstr "El vostre compte"
+
+#: ../panels/user-accounts/um-user-panel.c:390
+msgid "Failed to delete user"
+msgstr "No s'ha pogut suprimir l'usuari"
+
+#: ../panels/user-accounts/um-user-panel.c:448
+#: ../panels/user-accounts/um-user-panel.c:507
+#: ../panels/user-accounts/um-user-panel.c:559
+msgid "Failed to revoke remotely managed user"
+msgstr "No s'ha pogut revocar l'usuari gestionat remotament"
+
+#: ../panels/user-accounts/um-user-panel.c:613
+msgid "You cannot delete your own account."
+msgstr "No podeu suprimir el vostre compte."
+
+#: ../panels/user-accounts/um-user-panel.c:622
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s encara està connectat"
+
+#: ../panels/user-accounts/um-user-panel.c:626
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Si suprimiu un usuari mentre està connectat pot deixar el sistema "
+"inconsistent."
+
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Voleu conservar els fitxers de %s?"
+
+#: ../panels/user-accounts/um-user-panel.c:639
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Es pot conservar el directori de l'usuari, la cua de correu i els fitxers "
+"temporals quan suprimiu un compte d'usuari."
+
+#: ../panels/user-accounts/um-user-panel.c:642
+msgid "_Delete Files"
+msgstr "_Suprimeix els fitxers"
+
+#: ../panels/user-accounts/um-user-panel.c:643
+msgid "_Keep Files"
+msgstr "C_onserva els fitxers"
+
+#: ../panels/user-accounts/um-user-panel.c:657
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Segur que voleu revocar el compte %s de l'usuari gestionat remotament?"
+
+#: ../panels/user-accounts/um-user-panel.c:661
+msgid "_Delete"
+msgstr "_Suprimeix"
+
+#: ../panels/user-accounts/um-user-panel.c:711
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Compte inhabilitat"
+
+#: ../panels/user-accounts/um-user-panel.c:719
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "S'ha de configurar la pròxima vegada que entri"
+
+#: ../panels/user-accounts/um-user-panel.c:722
+msgctxt "Password mode"
+msgid "None"
+msgstr "Cap"
+
+#: ../panels/user-accounts/um-user-panel.c:769
+msgid "Logged in"
+msgstr "Connectat"
+
+#: ../panels/user-accounts/um-user-panel.c:1117
+msgid "Failed to contact the accounts service"
+msgstr "No s'ha pogut contactar amb el servei de comptes"
+
+#: ../panels/user-accounts/um-user-panel.c:1119
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Assegureu-vos que el servei de comptes està instal·lat i habilitat."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: ../panels/user-accounts/um-user-panel.c:1155
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Per fer-hi canvis,\n"
+"primer feu clic a la icona *"
+
+#: ../panels/user-accounts/um-user-panel.c:1195
+msgid "Create a user account"
+msgstr "Crea un compte d'usuari"
+
+#: ../panels/user-accounts/um-user-panel.c:1206
+#: ../panels/user-accounts/um-user-panel.c:1385
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Per crear un compte d'usuari,\n"
+"primer feu clic a la icona *"
+
+#: ../panels/user-accounts/um-user-panel.c:1216
+msgid "Delete the selected user account"
+msgstr "Suprimeix el compte d'usuari seleccionat"
+
+#: ../panels/user-accounts/um-user-panel.c:1228
+#: ../panels/user-accounts/um-user-panel.c:1390
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Per suprimir el compte d'usuari seleccionat,\n"
+"primer feu clic a la icona *"
+
+#: ../panels/user-accounts/um-utils.c:507
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "El nom d'usuari no està disponible. Trieu-ne un altre."
+
+#: ../panels/user-accounts/um-utils.c:510
+#, c-format
+msgid "The username is too long."
+msgstr "El nom d'usuari és massa llarg."
+
+#: ../panels/user-accounts/um-utils.c:513
+msgid "The username cannot start with a “-”."
+msgstr "El nom d'usuari no pot començar amb un «-»."
+
+#: ../panels/user-accounts/um-utils.c:516
+msgid ""
+"The username should only consist of upper and lower case letters from a-z, "
+"digits and the following characters: . - _"
+msgstr ""
+"El nom d'usuari només ha de consistir en lletres minúscules i majúscules de "
+"la «a» a la «z», dígits i qualsevol dels caràcters «.», «-» i «_»"
+
+#: ../panels/user-accounts/um-utils.c:520
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr ""
+"Es farà servir per anomenar la vostra carpeta personal i no es pot canviar."
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "Mapa els botons"
+
+#: ../panels/wacom/button-mapping.ui.h:2 ../panels/wacom/cc-wacom-page.c:547
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "_Close"
+msgstr "_Tanca"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr "Mapa els botons a les funcions"
+
+#: ../panels/wacom/button-mapping.ui.h:4
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Per editar una drecera, feu clic a l'acció «Envia una pulsació de tecla», "
+"premeu el botó de drecera de teclat i premeu la combinació de tecles nova, o "
+"premeu la tecla de retrocés per netejar-la."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Feu un toc als marcadors objectius a mesura que apareguen a la pantalla per "
+"calibrar la tauleta gràfica."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting…"
+msgstr "S'ha detectat una pulsació incorrecta, s'està reiniciant..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:266
+#, c-format
+msgid "Button %d"
+msgstr "Botó %d"
+
+#: ../panels/wacom/cc-wacom-button-row.h:53
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplicació definida"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Envia una pulsació de tecla"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Commuta el monitor"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Mostra l'ajuda en pantalla"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:260
+msgid "Output:"
+msgstr "Eixida:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:272
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Mantén la relació d'aspecte (format de bústia):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:283
+msgid "Map to single monitor"
+msgstr "Mapa a una sola pantalla"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:86
+#, c-format
+msgid "%d of %d"
+msgstr "%d de %d"
+
+#: ../panels/wacom/cc-wacom-page.c:544
+msgid "Display Mapping"
+msgstr "Mapat de la pantalla"
+
+#: ../panels/wacom/cc-wacom-panel.c:790
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Stylus"
+msgstr "Estilogràfica"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:347
+msgid "Button"
+msgstr "Botó"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Wa­com Tab­let"
+msgstr "Tauleta gràfica Wacom"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Establiu el mapa de botons i ajusteu la sensibilitat de l'estilogràfica per "
+"a tauletes gràfiques"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:5
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tauleta gràfica;Wacom;Estilogràfica;Esborrador;Ratolí;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "Tauleta gràfica (absolut)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "Ratolí tàctil (relatiu)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "Preferències de la tauleta gràfica"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Help"
+msgstr "_Ajuda"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "No tablet detected"
+msgstr "No s'ha detectat cap tauleta gràfica"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Connecteu o engegueu la tauleta gràfica Wacom"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Bluetooth Settings"
+msgstr "Paràmetres del Bluetooth"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Wacom Tablet"
+msgstr "Tauleta gràfica Wacom"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map to Monitor…"
+msgstr "Mapa a la pantalla…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Map Buttons…"
+msgstr "Mapa els botons…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Calibrate…"
+msgstr "Calibra…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust display resolution"
+msgstr "Ajusta la resolució de la pantalla"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Adjust mouse settings"
+msgstr "Ajusta els paràmetres del ratolí"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Tracking Mode"
+msgstr "Mode de seguiment"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:16
+msgid "Left-Handed Orientation"
+msgstr "Orientació d'esquerrans"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "Drecera nova…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Middle Mouse Button Click"
+msgstr "Clic amb el botó del mig del ratolí"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Right Mouse Button Click"
+msgstr "Clic amb el botó dret del ratolí"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Back"
+msgstr "Arrere"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Forward"
+msgstr "Avant"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "No stylus found"
+msgstr "No s'ha trobat cap llapis"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr "Moveu el llapis a prop de la tauleta per configurar-lo."
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilitat de pressió de l'esborrador"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Soft"
+msgstr "Suau"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Firm"
+msgstr "Ferma"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Top Button"
+msgstr "Botó superior"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Lower Button"
+msgstr "Botó inferior"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Tip Pressure Feel"
+msgstr "Sensibilitat de pressió del llapis"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "page 3"
+msgstr "pàgina 3"
+
+#: ../shell/alt/cc-window.c:53 ../shell/alt/cc-window.c:1484
+#: ../shell/cc-window.c:758
+msgid "All Settings"
+msgstr "Tots els paràmetres"
+
+#. Add categories
+#: ../shell/alt/cc-window.c:875
+msgctxt "category"
+msgid "Personal"
+msgstr "Personal"
+
+#: ../shell/alt/cc-window.c:876
+msgctxt "category"
+msgid "Hardware"
+msgstr "Maquinari"
+
+#: ../shell/alt/cc-window.c:877
+msgctxt "category"
+msgid "System"
+msgstr "Sistema"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
+msgid "GNOME Control Center"
+msgstr "Centre de control del GNOME"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
+msgid "Utilities to configure the GNOME desktop"
+msgstr "Utilitats per configurar l'escriptori GNOME"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
+msgid ""
+"The control center is GNOME’s main interface for configuration of various "
+"aspects of your desktop."
+msgstr ""
+"El centre de control és la interfície principal del GNOME per a la "
+"configuració de diversos aspectes de l'escriptori."
+
+#: ../shell/cc-application.c:45
+msgid "Display version number"
+msgstr "Mostra el número de versió"
+
+#: ../shell/cc-application.c:46
+msgid "Enable verbose mode"
+msgstr "Habilita el mode detallat"
+
+#: ../shell/cc-application.c:47
+msgid "Show the overview"
+msgstr "Mostra la visió general"
+
+#: ../shell/cc-application.c:48
+msgid "Search for the string"
+msgstr "Busca la cadena"
+
+#: ../shell/cc-application.c:49
+msgid "List possible panel names and exit"
+msgstr "Llista tots els noms de quadre possibles i ix"
+
+#: ../shell/cc-application.c:50
+msgid "Panel to display"
+msgstr "Quadre a mostrar"
+
+#: ../shell/cc-application.c:50
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[QUADRE] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:113
+msgid "Available panels:"
+msgstr "Quadres disponibles:"
+
+#: ../shell/cc-application.c:252
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../shell/cc-application.c:253
+msgid "Quit"
+msgstr "Ix"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "Preferències;Paràmetres;"
+
+#: ../shell/help-overlay.ui.h:1
+msgctxt "shortcut window"
+msgid "General"
+msgstr "General"
+
+#: ../shell/help-overlay.ui.h:2
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Ix"
+
+#: ../shell/help-overlay.ui.h:3
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Busca"
+
+#: ../shell/help-overlay.ui.h:4
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Quadres"
+
+#: ../shell/help-overlay.ui.h:5
+msgctxt "shortcut window"
+msgid "Go back to the overview"
+msgstr "Torna a la visió general"
+
+#: ../shell/help-overlay.ui.h:6
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Cancel·la la busca"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: ../shell/hostname-helper.c:189
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Punt d'accés Wi-Fi"
+
+#: ../shell/panel-list.ui.h:3
+msgid "No results found"
+msgstr "No s'ha trobat cap resultat."
+
+#~ msgid "Apply"
+#~ msgstr "Aplica"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Tapa tancada"
+
+#~ msgid "Mirrored"
+#~ msgstr "Duplicat"
+
+#~ msgid "Primary"
+#~ msgstr "Primària"
+
+#~ msgid "Secondary"
+#~ msgstr "Secundària"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Organitzeu les pantalles combinades"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Arrossegueu les pantalles per a reordenar-les"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Gira en sentit antihorari 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Gira 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Gira en sentit horari 90°"
+
+#~ msgid "Size"
+#~ msgstr "Mida"
+
+#~ msgid "Aspect Ratio"
+#~ msgstr "Relació d'aspecte"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr ""
+#~ "Mostra la barra superior i la vista general d'activitats en aquesta "
+#~ "pantalla"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Ajunta aquesta pantalla amb una altra per crear un espai de treball "
+#~ "addicional"
+
+#~ msgid "Presentation"
+#~ msgstr "Presentació"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Mostra només seqüències d'imatges i multimèdia"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Mostra el mateix a les dues pantalles"
+
+#~ msgid "Turn Off"
+#~ msgstr "Desactiva"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "No usis aquesta pantalla"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Organitzeu les pantalles combinades"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "_Mode d'avió"
+
+#~ msgid "Server"
+#~ msgstr "Servidor"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Suprimeix el servidor DNS"
+
+#~ msgid "Proxy"
+#~ msgstr "Servidor intermediari"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Afegeix un perfil…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manual"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automàtic"
+
+#~ msgid "_Method"
+#~ msgstr "_Mètode"
+
+#~ msgid "Add Device"
+#~ msgstr "Afegeix un dispositiu"
+
+#~ msgid "Remove Device"
+#~ msgstr "Suprimeix el dispositiu"
+
+#~ msgid "VPN Type"
+#~ msgstr "Tipus de VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "Nom del grup"
+
+#~ msgid "Group Password"
+#~ msgstr "Contrasenya del grup"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Utilitza com a punt d'accés Wi-Fi…"
+
+#~ msgid "_History"
+#~ msgstr "_Historial"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Premeu Esc per cancel·lar."
+
+#~ msgid "Reset"
+#~ msgstr "Reinicia"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Fes-la disponible a altres _usuaris"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Reinicia els paràmetres d'aquesta xarxa, incloent les contrasenyes, però "
+#~ "recorda-la com una xarxa preferida"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Suprimeix totes les dades relacionades amb aquesta xarxa i no intentis "
+#~ "connectar-t'hi automàticament"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Si teniu una connexió a Internet que no sigui la xarxa sense fil, podeu "
+#~ "establir un punt d'accés sense fil per compartir-la amb altres."
+
+#~ msgid "History"
+#~ msgstr "Historial"
+
+#~ msgid "Loading options…"
+#~ msgstr "S'estan carregant les opcions…"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (ID del muntatge: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "Sistema base"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Drecera;Repeteix;Parpelleig;"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Zona del tallafoc"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Per defecte"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "La zona defineix el nivell de confiança en la connexió"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Afegiu-hi més lletres, nombres i símbols."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Seguretat: dèbil"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Seguretat: baixa"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Seguretat: mitjana"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Seguretat: bona"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Seguretat: alta"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Compte</small>"
+
+#~ msgid "Edit"
+#~ msgstr "Edita"
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Estableix la drecera"
+
+#~ msgid "Add Account"
+#~ msgstr "Afegeix un compte"
+
+#~ msgid "Mail"
+#~ msgstr "Correu"
+
+#~ msgid "Calendar"
+#~ msgstr "Calendari"
+
+#~ msgid "Contacts"
+#~ msgstr "Contactes"
+
+#~ msgid "Chat"
+#~ msgstr "Xat"
+
+#~ msgid "Resources"
+#~ msgstr "Recursos"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "S'està configurant"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nivell del tòner"
+
+#~ msgid "Supply Level"
+#~ msgstr "Nivell dels subministraments"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "S'està instal·lant"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u actiu"
+#~ msgstr[1] "%u actius"
+
+#~ msgctxt "button"
+#~ msgid "Add Printer"
+#~ msgstr "Afegeix una impressora"
+
+#~ msgid "Supply"
+#~ msgstr "Subministrament"
+
+#~ msgid "_Default printer"
+#~ msgstr "Impressora per _defecte"
+
+#~ msgid "Jobs"
+#~ msgstr "Tasques"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Mostra les _tasques"
+
+#~ msgid "label"
+#~ msgstr "etiqueta"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "S'està establint el controlador nou…"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "_Imprimeix una pàgina de prova"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Altres comptes"
+
+#~ msgid "My Account"
+#~ msgstr "El meu compte"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Bàners de notificació"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "_Bàners de notificació"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "Error creating account"
+#~ msgstr "S'ha produït un error en crear el compte"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Segur que voleu suprimir el compte?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "No se suprimirà el compte al servidor."
+
+#~ msgid "_Remove"
+#~ msgstr "_Suprimeix"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "No s'ha configurat cap compte en línia"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Afegir un compte permet a les aplicacions accedir-hi per obtenir "
+#~ "documents, correu, contactes, calendari, xat i més."
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Afegeix una impressora nova"
+
+#~ msgid "A_uthenticate"
+#~ msgstr "A_utentica"
+
+#~ msgid "No printers detected."
+#~ msgstr "No s'ha detectat cap impressora."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Amunt"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Avall"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Cap"
+
+#~ msgid "Left Ring"
+#~ msgstr "Anell esquerre"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Mode de l'anell esquerre número %d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Mode de l'anell dret número %d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Banda tàctil esquerra"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Mode de la banda tàctil esquerra número %d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Banda tàctil dreta"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Mode de la banda tàctil dreta número %d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Mode de commutació de l'anell tàctil esquerre"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Mode de commutació de l'anell tàctil dret"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Mode de commutació de la banda tàctil esquerra"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Mode de commutació de la banda tàctil dreta"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Mode de commutació número %d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Botó esquerre número %d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Botó dret número %d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Botó superior número %d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Botó inferior número %d"
+
+#~ msgid "No Action"
+#~ msgstr "Cap acció"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Clic amb el botó esquerre del ratolí"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Desplaça cap amunt"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Desplaça cap avall"
+
+#~ msgid "Scroll Left"
+#~ msgstr "Desplaça cap a l'esquerra"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Desplaça cap a la dreta"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr ""
+#~ "Drecera de teclat per <b>%s</b>. Introduïu la drecera nova a canviar."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Per editar una drecera, feu clic a la fila corresponent i premeu la "
+#~ "combinació de tecles nova, o premeu la tecla de retrocés per netejar-la."
+
+#~ msgid "Error logging into the account"
+#~ msgstr "S'ha produït un error en entrar al compte"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Han caducat les credencials."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Entreu per habilitar aquest compte."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Entra"
+
+#~ msgid "_Name:"
+#~ msgstr "_Nom:"
+
+#~ msgid "Add Shortcut"
+#~ msgstr "Afegeix una drecera"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Suprimeix una drecera"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<acció desconeguda>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "No es pot fer servir la drecera «%s» perquè no seria possible escriure "
+#~ "amb aquesta tecla.\n"
+#~ "Proveu amb una altra tecla com ara la de Control, l'Alt o de Majúscules a "
+#~ "la vegada."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Ja s'utilitza la drecera «%s» per a\n"
+#~ "«%s»"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Si torneu a assignar la drecera a «%s», s'inhabilitarà la drecera «%s»."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Torna a assignar"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "La drecera «%s» té la drecera «%s» associada. Voleu canviar-la "
+#~ "automàticament a «%s»?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "La drecera «%s» ja està associada amb «%s», s'inhabilitarà aquesta "
+#~ "drecera si continueu."
+
+#~ msgid "_Assign"
+#~ msgstr "_Assigna"
+
+#~ msgid "Add User Account"
+#~ msgstr "Afegeix un compte d'usuari"
+
+#~ msgid "_Account Activity"
+#~ msgstr "_Activitat del compte"
+
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgid "Bond"
+#~ msgstr "Enllaç"
+
+#~ msgid "Team"
+#~ msgstr "Equip"
+
+#~ msgid "Bridge"
+#~ msgstr "Pont"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "No s'han pogut carregar els connectors VPN"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Afegeix una connexió de xarxa"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Enllaça esclaus"
+
+#~ msgid "(none)"
+#~ msgstr "(cap)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Fes un pont als esclaus"
+
+#~ msgid "Team slaves"
+#~ msgstr "Esclaus de l'equip"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "El dispositiu InfiniBand no admet el mode connectat"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "No s'ha triat cap certificat d'autoritat de certificació"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Si no utilitzeu un certificat d'autoritat de certificació (CA) podeu "
+#~ "acabar connectar-vos a xarxes sense fil dubtoses o insegures. Voleu triar "
+#~ "un certificat d'autoritat de certificació?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignora"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Trieu el certificat CA"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "_Sol·licita aquesta contrasenya cada vegada"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "_No em tornis a avisar"
+
+#~ msgid "No"
+#~ msgstr "No"
+
+#~ msgid "Yes"
+#~ msgstr "Sí"
+
+#~ msgid "Power"
+#~ msgstr "Energia"
+
+#~ msgid "Privacy"
+#~ msgstr "Privacitat"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Altres"
+
+#~ msgid "Personal File Sharing"
+#~ msgstr "Compartició de fitxers personals"
+
+#~ msgid "_Allow Remote Control"
+#~ msgstr "_Permet el control remot"
+
+#~ msgid "_Verify"
+#~ msgstr "_Verifica"
+
+#~ msgid "Login History"
+#~ msgstr "Historial d'entrades"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Ja existeix un usuari amb el nom d'usuari «%s»."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "S'utilitzen per trobar la vostra ubicació geogràfica"
+
+#~ msgid "%d ے %d"
+#~ msgstr "%d ے %d"
+
+#~ msgid "Done"
+#~ msgstr "Fet"
+
+#~ msgid "Time _Zone"
+#~ msgstr "_Fus Horari"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Retard:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Curt"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Llarg"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Ràpida"
+
+#~ msgid "S_peed:"
+#~ msgstr "Ve_locitat:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Comprova els paràmetres"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Ràpida"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Esquerre"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Dret"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "Velocitat del _punter"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Ràpida"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Ràpida"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Els dispositius sense fil requereixen més energia"
+
+#~ msgid "No printers available"
+#~ msgstr "No hi ha cap impressora disponible"
+
+#~ msgid "Close"
+#~ msgstr "Tanca"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Continua la impressió"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Fes una pausa a la impressió"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Retinguda"
+
+#~ msgid "Job Title"
+#~ msgstr "Títol de la tasca"
+
+#~ msgid "Job State"
+#~ msgstr "Estat de la tasca"
+
+#~ msgid "Time"
+#~ msgstr "Hora"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Afegeix una impressora nova"
+
+#~ msgid "Options"
+#~ msgstr "Opcions"
+
+#~ msgid "Password:"
+#~ msgstr "Contrasenya:"
+
+#~ msgid "Zoom"
+#~ msgstr "Amplia"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "El Bluetooth està inhabilitat"
+
+#~ msgid "Security key"
+#~ msgstr "Clau de seguretat"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Quan la càrrega de la bateria sigui _crítica"
+
+#~ msgid "Power off"
+#~ msgstr "Apaga"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "La compartició Bluetooth us permet compartir fitxers amb altres "
+#~ "dispositius Bluetooth"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Rep només de dispositius de confiança"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Desa els fitxers rebuts a la carpeta de baixades"
+
+#~ msgid "Show help options"
+#~ msgstr "Mostra les opcions d'ajuda"
+
+#~ msgid "- Settings"
+#~ msgstr "- Paràmetres"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Executeu «%s --help» per veure una llista completa d'opcions disponibles "
+#~ "a la línia d'ordres.\n"
+
+#~ msgid "United States"
+#~ msgstr "Estats Units"
+
+#~ msgid "Germany"
+#~ msgstr "Alemanya"
+
+#~ msgid "France"
+#~ msgstr "França"
+
+#~ msgid "Spain"
+#~ msgstr "Espanya"
+
+#~ msgid "China"
+#~ msgstr "Xina"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "_Inhabilita mentre s'escriu"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr ""
+#~ "Els serveis de xarxa del sistema no són compatibles amb aquesta versió."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Mostra els bàners emergents"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Mostra'ls a la pantalla de bloqueig"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Mostra els bàners emergents"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "Mostra a la pantalla de bloqueig"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Apaga els dispositius sense fil"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr ""
+#~ "Introduïu l'adreça d'una impressora o un text per filtrar els resultats"
+
+#~ msgid "Sorry"
+#~ msgstr "Ho sentim"

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -6,702 +6,332 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
-"POT-Creation-Date: 2019-10-15 17:52+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2020-03-28 18:25+0300\n"
 "Last-Translator: Jwtiyar Nariman <jwtiyar@gmail.com>\n"
 "Language-Team: Kurdish (Sorani) <ckb@li.org>\n"
+"Language: ckb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Launchpad-Export-Date: 2020-03-28 15:24+0000\n"
 "X-Generator: Poedit 2.3\n"
-"Language: ckb\n"
-
-#: panels/applications/cc-applications-panel.c:748
-msgid "System Bus"
-msgstr "تێپەڕگەی سیستەم"
-
-#: panels/applications/cc-applications-panel.c:748
-#: panels/applications/cc-applications-panel.c:750
-#: panels/applications/cc-applications-panel.c:763
-#: panels/applications/cc-applications-panel.c:768
-msgid "Full access"
-msgstr "دەستپێگەشتنی تەواو"
-
-#: panels/applications/cc-applications-panel.c:750
-msgid "Session Bus"
-msgstr "تێپەڕگەی وانەکۆڕ"
-
-#: panels/applications/cc-applications-panel.c:754
-#: panels/power/cc-power-panel.c:2472 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525
-msgid "Devices"
-msgstr "ئامێرەکان"
-
-#: panels/applications/cc-applications-panel.c:754
-msgid "Full access to /dev"
-msgstr "دەستپێگەشتنی تەواو بۆ /dev"
-
-#: panels/applications/cc-applications-panel.c:758
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:252
-msgid "Network"
-msgstr "ڕایەڵە"
-
-#: panels/applications/cc-applications-panel.c:758
-#: panels/applications/cc-snap-row.c:109
-msgid "Has network access"
-msgstr "دەستگەیشتنی بۆ ڕایەڵە هەیە"
-
-#: panels/applications/cc-applications-panel.c:763
-#: panels/applications/cc-applications-panel.c:765
-#: panels/search/cc-search-locations-dialog.c:361
-msgid "Home"
-msgstr "ماڵەوە"
-
-#: panels/applications/cc-applications-panel.c:765
-#: panels/applications/cc-applications-panel.c:770
-msgid "Read-only"
-msgstr "تەنها-خوێندنەوە"
-
-#: panels/applications/cc-applications-panel.c:768
-#: panels/applications/cc-applications-panel.c:770
-msgid "File System"
-msgstr "پەڕگەی سیستەم"
-
-#: panels/applications/cc-applications-panel.c:774
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:281
-#: shell/cc-window.c:964 shell/cc-window.ui:125
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr "ڕێكخستنەكان"
-
-#: panels/applications/cc-applications-panel.c:774
-#: panels/applications/cc-snap-row.c:73
-msgid "Can change settings"
-msgstr "ڕێكخستنەكان دەتوانرێ بگۆڕدرێ"
-
-#: panels/applications/cc-applications-panel.c:776
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s شوێن مۆڵەتپێدانەکان دەکەوێت کە لەناویدا هەیە. ئەمانە ناتوانرێ بگۆڕدرێ. "
-"ئەگەر تۆ نیگەرانی دەربارەی ئەم مۆڵەتپێدانانە، ڕەچاوی سڕینەوەی ئەم بەرنامەیە "
-"بکە."
-
-#: panels/applications/cc-applications-panel.c:937
-msgid "Web Links"
-msgstr "بەستەرەکانی وێب"
-
-#: panels/applications/cc-applications-panel.c:947
-msgid "Git Links"
-msgstr "بەستەرەکانی گێت (Git)"
-
-#: panels/applications/cc-applications-panel.c:953
-#, c-format
-msgid "%s Links"
-msgstr "بەستەرەکان %s"
-
-#: panels/applications/cc-applications-panel.c:961
-#: panels/applications/cc-applications-panel.c:997
-msgid "Unset"
-msgstr "دانەنان"
-
-#: panels/applications/cc-applications-panel.c:1052
-msgid "Links"
-msgstr "به‌سته‌ره‌كان"
-
-#: panels/applications/cc-applications-panel.c:1060
-msgid "Hypertext Files"
-msgstr "پەڕگەکانی سەروودەق"
-
-#: panels/applications/cc-applications-panel.c:1074
-msgid "Text Files"
-msgstr "فایلەکانی دەق"
-
-#: panels/applications/cc-applications-panel.c:1088
-msgid "Image Files"
-msgstr "پەڕگەکانی وێنە"
-
-#: panels/applications/cc-applications-panel.c:1104
-msgid "Font Files"
-msgstr "پەڕگەکانی فۆنت"
-
-#: panels/applications/cc-applications-panel.c:1165
-msgid "Archive Files"
-msgstr "پەڕگەکانی ئەرشیف"
-
-#: panels/applications/cc-applications-panel.c:1185
-msgid "Package Files"
-msgstr "پەڕگەکانی بوخچە"
-
-#: panels/applications/cc-applications-panel.c:1208
-msgid "Audio Files"
-msgstr "پەڕگەکانی دەنگ"
-
-#: panels/applications/cc-applications-panel.c:1225
-msgid "Video Files"
-msgstr "پەڕگەکانی ڤیدیۆ"
-
-#: panels/applications/cc-applications-panel.c:1233
-msgid "Other Files"
-msgstr "پەڕگەکانی دیکە"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1575
-#: panels/applications/cc-applications-panel.ui:418
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:167
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr "نەرمەواڵەکان"
 
-#: panels/applications/cc-applications-panel.ui:45
+#: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
 msgstr "نەرمەواڵەکان نییە"
 
-#: panels/applications/cc-applications-panel.ui:59
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr "هەندێک دادەمەزرێن..."
 
-#: panels/applications/cc-applications-panel.ui:99
-msgid "Permissions & Access"
-msgstr "مۆڵەتپێدانەکان و دەستپێگەشتن"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_کردنەوە"
 
-#: panels/applications/cc-applications-panel.ui:111
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-"دراو و خزمەتگوزارییەکان کە ئەم بەرنامەیە پرسیاریکرد بۆ دەستگەیشتن پێی و "
-"مۆڵەتپێدانی پێویستە(داواکراوە)."
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_پیشاندانی ناسنامە"
 
-#: panels/applications/cc-applications-panel.ui:126
-#: panels/applications/cc-applications-panel.ui:132
-#: panels/camera/gnome-camera-panel.desktop.in.in:3
-msgid "Camera"
-msgstr "کامێرا"
-
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:237
-#: panels/applications/cc-applications-panel.ui:267
-#: panels/keyboard/cc-keyboard-option.c:259
-#: panels/keyboard/cc-keyboard-option.c:378
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:96
-#: panels/keyboard/keyboard-shortcuts.c:425 panels/network/network-proxy.ui:126
-#: panels/user-accounts/um-fingerprint-dialog.c:211
-#: subprojects/gvc/gvc-mixer-control.c:1876
-msgid "Disabled"
-msgstr "ناچالاککراو"
-
-#: panels/applications/cc-applications-panel.ui:138
-#: panels/applications/cc-applications-panel.ui:144
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
-msgid "Microphone"
-msgstr "مایکرۆفۆن"
-
-#: panels/applications/cc-applications-panel.ui:150
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/location/gnome-location-panel.desktop.in.in:3
-msgid "Location Services"
-msgstr "خزمەتگوزارییەکانی شوێن"
-
-#: panels/applications/cc-applications-panel.ui:162
-#: panels/applications/cc-applications-panel.ui:501
-msgid "Built-in Permissions"
-msgstr "مۆڵەتپێدانی تێدا دانراو"
-
-#: panels/applications/cc-applications-panel.ui:163
-msgid "Cannot be changed"
-msgstr "ناتوانرێ بگۆڕدرێ"
-
-#: panels/applications/cc-applications-panel.ui:180
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-"مۆڵەتپێدانە تاکەکەسییەکان بۆ بەرنامەکان دەتوانرێ پیداچوونەوەی بۆ بکرێ لە <a "
-"href=\"privacy\">تایبەتێتی</a>کەی ڕێکخستنەکان."
-
-#: panels/applications/cc-applications-panel.ui:204
-msgid "Integration"
-msgstr "یەکخستن"
-
-#: panels/applications/cc-applications-panel.ui:216
-msgid "System features used by this application."
-msgstr "تایبەتمەندیەکانی سیستەم بەکارهێنراوە لەلایەن ئەم بەرنامەیە."
-
-#: panels/applications/cc-applications-panel.ui:230
-#: panels/applications/cc-applications-panel.ui:236
-#: panels/keyboard/01-launchers.xml.in:18
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:155
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "گەڕان"
 
-#: panels/applications/cc-applications-panel.ui:242
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "ناچالاککراو"
+
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr "ئاگادارکردنەوەکان"
 
-#: panels/applications/cc-applications-panel.ui:260
-#: panels/applications/cc-applications-panel.ui:266
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "preferences-system-notifications"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "پاشبنەما"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "وێنەکانی شاشە"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "کاغەزەکانی دیوار"
+
+#: panels/applications/cc-applications-panel.ui:148
+#, fuzzy
+msgid "Change the desktop wallpaper."
+msgstr "هەڵبژاردەکانی-دیوارپۆشی-ڕوومێز"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "دەنگەکان"
 
-#: panels/applications/cc-applications-panel.ui:299
-msgid "Default Handlers"
-msgstr "وەدەستخەرە بنەڕەتییەکان"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:311
-msgid "Types of files and links that this application opens."
-msgstr "جۆرەکانی پەرڕگەکان و بەستەرەکان کە لەم بەرنامەیە دەکرێنەوە."
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "قەدبڕ دابنێ"
 
-#: panels/applications/cc-applications-panel.ui:327
-msgid "Reset"
-msgstr "ڕێکخستنەوە"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "هیچ قەدبڕی تەختەکلیلێک نەدۆزرایەوە"
 
-#: panels/applications/cc-applications-panel.ui:363
-msgid "Usage"
-msgstr "بەکارهێنان"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "کامێرا"
 
-#: panels/applications/cc-applications-panel.ui:375
-msgid "How much resources this application is using."
-msgstr "ئەم بەرنامەیە چەند سەرچاوە بەکاردەهێنێت."
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:390
-#: panels/applications/cc-applications-panel.ui:537
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "مایکرۆفۆن"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "خزمەتگوزارییەکانی شوێن"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+#, fuzzy
+msgid "Access device location data."
+msgstr "دەستبگرە بەسەر شوێنەکەتا"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "مۆڵەتپێدانی تێدا دانراو"
+
+#: panels/applications/cc-applications-panel.ui:223
+#, fuzzy
+msgid "System access that is required by the app"
+msgstr "تایبەتمەندیەکانی سیستەم بەکارهێنراوە لەلایەن ئەم بەرنامەیە."
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "بیرگە"
 
-#: panels/applications/cc-applications-panel.ui:425
-msgid "Open in Software"
-msgstr "بیکەرەوە لە نەرمەواڵا"
-
-#: panels/applications/cc-applications-panel.ui:475 shell/cc-panel-list.ui:121
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "هیچ ئەنجامێک نەدۆزرایەوە"
 
-#: panels/applications/cc-applications-panel.ui:486
-#: panels/keyboard/cc-keyboard-panel.ui:188 shell/cc-panel-list.ui:132
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "گەڕانێکی جیاواز تاقیبکەرەوە"
 
-#: panels/applications/cc-applications-panel.ui:554
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "پەڕگەی سیستەم"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "خێرایی بەستەر"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "ڕێکخستنەوە"
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr "ئەم بەرنامەیە چەند بۆشایی داگیردەکات بە دراوی بەرنامە و کاشەکان."
 
-#: panels/applications/cc-applications-panel.ui:563
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "نەرمەواڵا"
 
-#: panels/applications/cc-applications-panel.ui:569
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "دراو"
 
-#: panels/applications/cc-applications-panel.ui:575
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "کاش"
 
-#: panels/applications/cc-applications-panel.ui:581
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>سەرجەم</b>"
 
-#: panels/applications/cc-applications-panel.ui:598
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "کاش پاکبکەرەوە..."
-
-#: panels/applications/cc-snap-row.c:55
-msgid "Add user accounts and change passwords"
-msgstr "هەژمارەکانی بەکارهێنەر زیاد بکە و تێپەڕەوشەکان بگۆڕە"
-
-#: panels/applications/cc-snap-row.c:57 panels/applications/cc-snap-row.c:133
-msgid "Play and record sound"
-msgstr "دەنگ لێبدە و تۆماربکە"
-
-#: panels/applications/cc-snap-row.c:59
-msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
-msgstr ""
-"ئامێرەکانی ڕایەڵە بدۆزەرەوە کە mDNS/DNS-SD بەکاردەهێنن (Bonjour/zeroconf)"
-
-#: panels/applications/cc-snap-row.c:61
-msgid "Access bluetooth hardware directly"
-msgstr "ڕاستەوخۆ دەستبگرە بەسەر ڕەقەکاڵای بلووتووس"
-
-#: panels/applications/cc-snap-row.c:63
-msgid "Use bluetooth devices"
-msgstr "ئامێرەکانی بلووتووس بەکاربێنە"
-
-#: panels/applications/cc-snap-row.c:65
-msgid "Use your camera"
-msgstr "کامێراکەت بەکابێنە"
-
-#: panels/applications/cc-snap-row.c:67
-msgid "Print documents"
-msgstr "بەڵگەنامەکان چامبکە"
-
-#: panels/applications/cc-snap-row.c:69
-msgid "Use any connected joystick"
-msgstr "هەر گێڕ و دەسکێکی پەیوەستکراو بەکاربێنە"
-
-#: panels/applications/cc-snap-row.c:71
-msgid "Allow connecting to the Docker service"
-msgstr "ڕێگەبدە بە پەیوەستبوون بە خزمەتگوزاریەکانی (Docker)ەکە"
-
-#: panels/applications/cc-snap-row.c:75
-msgid "Configure network firewall"
-msgstr "دیواری ئاگرینی ڕایەڵە ڕێکبخە"
-
-#: panels/applications/cc-snap-row.c:77
-msgid "Setup and use privileged FUSE filesystems"
-msgstr "سیستەمەکانی پەڕگەی FUSE  شاراوە بەکار بهێنە و جێگیریبکە"
-
-#: panels/applications/cc-snap-row.c:79
-msgid "Update firmware on this device"
-msgstr "لەم ئامێرە پتەوواڵە نوێبکەوە"
-
-#: panels/applications/cc-snap-row.c:81
-msgid "Access hardware information"
-msgstr "زانیاری دەستپێگەشتنی ڕەقەکاڵا"
-
-#: panels/applications/cc-snap-row.c:83
-msgid "Provide entropy to hardware random number generator"
-msgstr "ئینترۆپی بەدەست بێنە بۆ ڕەقەکاڵای پێکهێنەری ژمارە هەڕەمەکییەکان"
-
-#: panels/applications/cc-snap-row.c:85
-msgid "Use hardware-generated random numbers"
-msgstr "ڕەقەکاڵای-بەرهەمهاتووی ژمارە هەڕەمەکییەکان"
-
-#: panels/applications/cc-snap-row.c:87
-msgid "Access files in your home folder"
-msgstr "دەستبگرە بەسەر پەرڕگەکان لە بوخچەی ماڵەوەت"
-
-#: panels/applications/cc-snap-row.c:89
-msgid "Access libvirt service"
-msgstr "دەستبگرە بەسەر خزمەتگوزارییەکانی libvirt"
-
-#: panels/applications/cc-snap-row.c:91
-msgid "Change system language and region settings"
-msgstr "زمانی سیستەم و ناوچەی ڕێکخستنەکان بگۆڕە"
-
-#: panels/applications/cc-snap-row.c:93
-msgid "Change location settings and providers"
-msgstr "شوێنی ڕێکخستنەکان و دابینکەرەکان بگۆڕە"
-
-#: panels/applications/cc-snap-row.c:95
-msgid "Access your location"
-msgstr "دەستبگرە بەسەر شوێنەکەتا"
-
-#: panels/applications/cc-snap-row.c:97
-msgid "Read system and application logs"
-msgstr "سیستەم و تۆماری بەرنامەکان بخوێنەوە"
-
-#: panels/applications/cc-snap-row.c:99
-msgid "Access LXD service"
-msgstr "دەستبگرە بەسەر خزمەتگوزاری LXD"
-
-#: panels/applications/cc-snap-row.c:101
-msgid "access the media-hub service"
-msgstr "دەستبگرە بەسەر خزمەتگوزاری ناوەندی-میدیا کە"
-
-#: panels/applications/cc-snap-row.c:103
-msgid "Use and configure modems"
-msgstr "مۆدیۆمەکان بەکاربێنە و ڕێکیبخە"
-
-#: panels/applications/cc-snap-row.c:105
-msgid "Read system mount information and disk quotas"
-msgstr "زانیاری گرێدانی سیستەم و بەشی دیسک بخوێنەوە"
-
-#: panels/applications/cc-snap-row.c:107
-msgid "Control music and video players"
-msgstr "کۆنتڕۆڵی مۆسیقا و ڤیدیۆ پەخشکەرەکان بکە"
-
-#: panels/applications/cc-snap-row.c:111
-msgid "Change low-level network settings"
-msgstr "ڕێکخستنی ڕایەڵەی ئاست-نزم بگۆڕە"
-
-#: panels/applications/cc-snap-row.c:113
-msgid "Access the NetworkManager service to read and change network settings"
-msgstr ""
-"دەستبگرە بەسەر خزمەتگوزاری بەڕێوبەری ڕایەڵە بۆ خوێندنەوە و گۆڕینی "
-"ڕێکخستنەکانی ڕایەڵە"
-
-#: panels/applications/cc-snap-row.c:115
-msgid "Read access to network settings"
-msgstr "دەستگەیشتنی ڕێکخستنەکانی ڕایەڵە بخوێنەوە"
-
-#: panels/applications/cc-snap-row.c:117
-msgid "Change network settings"
-msgstr "ڕێکخستنەکانی ڕایەڵە بگۆڕە"
-
-#: panels/applications/cc-snap-row.c:119
-msgid "Read network settings"
-msgstr "ڕێکخستنەکانی ڕایەڵە بخوێنەوە"
-
-#: panels/applications/cc-snap-row.c:121
-msgid ""
-"Access the ofono service to read and change network settings for mobile "
-"telephony"
-msgstr ""
-"دەستبگرە بەسەر خزمەتگوزاری ئۆفۆنۆ بۆ خوێندنەوە و گۆڕینی ڕێکخستنەکانی ڕایەڵە "
-"بۆ بەکارهێنانەکانی مۆبایل"
-
-#: panels/applications/cc-snap-row.c:123
-msgid "Control Open vSwitch hardware"
-msgstr "کۆنتڕۆڵی ڕەقەواڵای Open vSwitch"
-
-#: panels/applications/cc-snap-row.c:125
-msgid "Read from CD/DVD"
-msgstr "بخوێنەوە لەڕێی CD/DVD"
-
-#: panels/applications/cc-snap-row.c:127
-msgid "Read, add, change, or remove saved passwords"
-msgstr "تێپەڕەوشە خەزنکراوەکان بخوێنەوە، زیادبکە ،بگۆڕە ،یان بیسڕەوە"
-
-#: panels/applications/cc-snap-row.c:129
-msgid ""
-"Access pppd and ppp devices for configuring Point-to-Point Protocol "
-"connections"
-msgstr ""
-"دەسبگرە بەسەر ئامێرەکانی pppd و ppp بۆ خاڵ-بۆ-خاڵ ی پەیوەندییەکانی کۆنووس"
-
-#: panels/applications/cc-snap-row.c:131
-msgid "Pause or end any process on the system"
-msgstr "بیوەستێنە یان کۆتیی بە هەر پڕۆسەیەکی سیستەمەکە بێنە"
-
-#: panels/applications/cc-snap-row.c:135
-msgid "Access USB hardware directly"
-msgstr "ڕاستەوخۆ دەستبگرە بەسەر ڕەقەواڵای USB"
-
-#: panels/applications/cc-snap-row.c:137
-msgid "Read/write files on removable storage devices"
-msgstr "پەڕگەکان بخوێنەوە/بنووسە لە ئامێرەکانی بیرگە دەرەکییەکان"
-
-#: panels/applications/cc-snap-row.c:139
-msgid "Prevent screen sleep/lock"
-msgstr "ڕێبگرە لە خەوتن/قفڵبوون"
-
-#: panels/applications/cc-snap-row.c:141
-msgid "Access serial port hardware"
-msgstr "دەستبگرە بەسەر ڕەقەواڵای دەرچەی سڕیاڵ"
-
-#: panels/applications/cc-snap-row.c:143
-msgid "Restart or power off the device"
-msgstr "ئامێرەکە داستپێبکەرەوە یان بیکوژێنەوە"
-
-#: panels/applications/cc-snap-row.c:145
-msgid "Install, remove and configure software"
-msgstr "نەرمەواڵا دابمەزرێنە، بیسڕەوە و ڕێکیبخە"
-
-#: panels/applications/cc-snap-row.c:147
-msgid "Access Storage Framework service"
-msgstr "دەستبگرە بەسەر خزمەتگوزاری بناغەی بیرگە"
-
-#: panels/applications/cc-snap-row.c:149
-msgid "Read process and system information"
-msgstr "پڕۆسە و زانیاری سیستەم بخوێنەوە"
-
-#: panels/applications/cc-snap-row.c:151
-msgid "Monitor and control any running program"
-msgstr "چاودێری و کۆنتڕۆڵی هەر بەرنامەیەکی ‌هەڵکراو بکە"
-
-#: panels/applications/cc-snap-row.c:153
-msgid "Change the date and time"
-msgstr "بەروار و کاتەکە بگۆڕە"
-
-#: panels/applications/cc-snap-row.c:155
-msgid "Change time server settings"
-msgstr "کاتی ڕێکخستنەکانی ڕاژە بگۆڕە"
-
-#: panels/applications/cc-snap-row.c:157
-msgid "Change the time zone"
-msgstr "کاتی هەرێمەکەت بگۆڕە"
-
-#: panels/applications/cc-snap-row.c:159
-msgid "Access the UDisks2 service for configuring disks and removable media"
-msgstr ""
-"دەستبگرە بەسەر خزمەتگوزاری UDisks2ەکە بۆ ڕێکخستنی دیسکەکان و میدیا دەرکییەکان"
-
-#: panels/applications/cc-snap-row.c:161
-msgid "Read/change shared calendar events in Ubuntu Unity 8"
-msgstr "بۆنەکانی ڕۆژژمێری هاوبەشی پێکراو بخوێنەوە/بگۆڕە لە ئۆبونتو یونتی ٨"
-
-#: panels/applications/cc-snap-row.c:163
-msgid "Read/change shared contacts in Ubuntu Unity 8"
-msgstr "پەیوەندییەکان هاوبەش بکە لە یوونیتی ٨ ی ئوبونتو بخوێنەوە/بگۆڕەوە"
-
-#: panels/applications/cc-snap-row.c:165
-msgid "Access energy usage data"
-msgstr "دەستبگرە بەسەر دراوی بەکارهێنانی وزە"
-
-#: panels/applications/cc-snap-row.c:167
-msgid "Read/write access to U2F devices exposed"
-msgstr "دەستبگرە بەسەر خوێندنەوە/نوسینی پێشاندانی ئامێرەکانی U2F"
 
 #: panels/applications/gnome-applications-panel.desktop.in.in:4
 msgid "Control various application permissions and settings"
 msgstr "کۆنتڕۆڵی مۆڵەتەکان و ڕێکخستنەکانی بەرنامە جۆراوجۆرەکان بکە"
 
-#. FIXME
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/applications/gnome-applications-panel.desktop.in.in:8
-msgid "application-x-executable"
-msgstr "application-x-executable"
-
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "بەرنامە؛فلاتپاک؛مۆڵەت؛ڕێکخستن؛"
 
-#: panels/background/cc-background-chooser.c:340
-msgid "Select a picture"
-msgstr "وێنەیەک دیاریبکە"
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr ""
 
-#: panels/background/cc-background-chooser.c:343
-#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:240
-#: panels/color/cc-color-panel.c:893 panels/color/cc-color-panel.ui:657
-#: panels/common/cc-language-chooser.ui:24
-#: panels/display/cc-display-panel.c:947
-#: panels/info-overview/cc-info-overview-panel.ui:237
-#: panels/network/cc-wifi-hotspot-dialog.ui:122
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:176
-#: panels/network/connection-editor/vpn-helpers.c:299
-#: panels/network/net-device-wifi.c:800 panels/network/net-device-wifi.c:908
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:252
-#: panels/region/cc-format-chooser.ui:28 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:638
-#: panels/sharing/cc-sharing-panel.c:410 panels/usage/cc-usage-panel.c:134
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:107
-#: panels/user-accounts/cc-avatar-chooser.c:235
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:636
-#: panels/user-accounts/cc-user-panel.c:654
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/user-accounts/um-fingerprint-dialog.c:260
-msgid "_Cancel"
-msgstr "_پاشگەزبوونەوە"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "بنەڕەت"
 
-#: panels/background/cc-background-chooser.c:344
-#: panels/network/connection-editor/vpn-helpers.c:177
-#: panels/printers/pp-details-dialog.c:253
-#: panels/sharing/cc-sharing-panel.c:411
-#: panels/user-accounts/cc-avatar-chooser.c:236
-msgid "_Open"
-msgstr "_کردنەوە"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#: panels/background/cc-background-chooser.ui:104
-msgid "Set Background and Lock Screen"
-msgstr "پاشبنەما و قفڵی شاشە دابنێ"
-
-#: panels/background/cc-background-chooser.ui:114
-msgid "Set Background"
-msgstr "پاشبنەما دابنێ"
-
-#: panels/background/cc-background-chooser.ui:121
-msgid "Set Lock Screen"
-msgstr "قفڵی شاشە دابنێ"
-
-#: panels/background/cc-background-chooser.ui:143
-msgid "Remove Background"
-msgstr "قفڵی شاشە بسڕەوە"
-
-#: panels/background/cc-background-item.c:140
-msgid "multiple sizes"
-msgstr "قەبارەى زۆر"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:144
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:282
-msgid "No Desktop Background"
-msgstr "پاشبنەمای ڕوومێز نییە"
-
-#: panels/background/cc-background-panel.c:115
-msgid "Current background"
-msgstr "پاشبنەمای ئێستا"
-
-#: panels/background/cc-background-panel.ui:55
-msgid "Add Picture…"
-msgstr "وێنە زیادبکە..."
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "چالاکییەکان"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "پاشبنەما"
 
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "وێنە زیادبکە..."
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "وێنەی پاشبنەماکەت بگۆڕە بۆ دیوارپۆشێک یان وێنەیەک"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/background/gnome-background-panel.desktop.in.in:7
-msgid "preferences-desktop-wallpaper"
-msgstr "هەڵبژاردەکانی-دیوارپۆشی-ڕوومێز"
-
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "دیوارپۆش؛شاشە؛ڕوومێز"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "چالاككراوە"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "بلووتووس نەدۆزرایەوە"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "دۆنگڵ پێوەبکە بۆ بەکارهێنانی بلووتووس"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:69
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "بلووتووس کوژاوەتەو"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:80
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "هەڵیبکە بۆ پەیوەستبوون بە ئامێرەکان و وەرگرتنی پەڕگە نێردراوەکان."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:107
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "دۆخی فڕۆکە چالاکە"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:118
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "بلووتووس ناچالاک دەکرێت کاتێک دوخی فڕۆکە هەڵبکرێ"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:154
-msgid "Hardware Airplane Mode is on"
-msgstr "ڕەقەواڵای دۆخی فڕۆکە هەڵکراوە"
-
-#: panels/bluetooth/cc-bluetooth-panel.ui:165
-msgid "Turn off the Airplane mode switch to enable Bluetooth."
-msgstr "سویچی دۆخی فڕۆکە بکوژێنەوە"
-
-#: panels/bluetooth/cc-bluetooth-panel.ui:124
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "دۆخی فڕۆکە بکوژێنەوە"
 
-#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "ڕەقەواڵای دۆخی فڕۆکە هەڵکراوە"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "سویچی دۆخی فڕۆکە بکوژێنەوە"
+
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1714
 msgid "Bluetooth"
 msgstr "بلووتووس"
 
@@ -709,258 +339,93 @@ msgstr "بلووتووس"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "بلووتووس هەڵبکە و بیکوژێنەوە و ئامێرەکانت پەیوەست بکە"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:6
-msgid "bluetooth"
-msgstr "بلوتوبلووتووس"
-
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "هاوبەشیبکە;هاوبەشیدەکات;بلووتووس;بەربەست;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:348
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"ئامێرە مەزەندەکراوەکەت دابنێ لەسەر چوارگۆشەکە و پەنجەبنێ بە \"دەستپێکردن\""
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "بلووتووس کوژاوەتەو"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:354
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+#, fuzzy
 msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"ئامێرە مەزەندەکراوەکەت بجوڵێنە بۆ شوێنی پێوانەکردنەکە و پەنجەبنێ بە "
-"“بەردەوامبوون”"
+"بەکارهێنانی کامێرا ڕیگە ئەدات بە بەرنامەکان بتوانن وێنە بگرن و گرتەی ڤیدیۆ "
+"تۆمار بکەن. ئەگەر کامێراکە ناچالاک بێ، ئەوا بۆی هەیە کە بەرنامەکان نەتوانن "
+"بەڕێکوپێکی هەموو کارێکی وێنە و ڤیدیۆت بۆ ئەنجام بدەن."
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:360
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-"ئامێرە مەزەندەکراوەکەت بجوڵێنە بۆ شوێنی ڕووبەرەکە و  پەنجەبنێ بە "
-"“بەردەوامبوون”"
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:366
-msgid "Shut the laptop lid"
-msgstr "شاشەی لاپتۆپەکە پێوەبدە"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "بگەڕی بۆ وێنەی زیاتر"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:397
-msgid "An internal error occurred that could not be recovered."
-msgstr "هەڵەیەکی ناوخۆیی ڕوویدا کە ناتونرێ چاکبکرێتەوە."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:402
-msgid "Tools required for calibration are not installed."
-msgstr "ئامڕازە داواکراوەکان بۆ مەزندەکردن دانەمەزراون"
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:408
-msgid "The profile could not be generated."
-msgstr "زانیارییە کەسییەکە ناتوانرێ دروستبکرێ"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:414
-msgid "The target whitepoint was not obtainable."
-msgstr "ئامانجە خاڵ سپییەکە دەستنەکەوت"
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:453
-msgid "Complete!"
-msgstr "تەواو!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:461
-msgid "Calibration failed!"
-msgstr "مەزندەکردن شکستیهێنا!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:468
-msgid "You can remove the calibration device."
-msgstr "دەتوانی ئامێرە مەزندەکراوەکان لێبکەیتەوە."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:537
-msgid "Do not disturb the calibration device while in progress"
-msgstr "ئامێرە مەزندەکراوەکان تێکمەدە لە کاتی پڕۆسەدا"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "شاشەی لاپتۆپ"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "وێبكامی لەناودایە"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s مۆنیتەر"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s پشکنەر"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s کامێرا"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s چاپکەر"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s وێبکام"
-
-#: panels/color/cc-color-device.c:91
-#, c-format
-msgid "Enable color management for %s"
-msgstr "بەڕێوەبەرایەتی ڕەنگەکان چالاک بکە بۆ %s"
-
-#: panels/color/cc-color-device.c:94
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "ڕەنگی زانیارییە کەسەییەکان پیشان بدە بۆ %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:303
-msgid "Not calibrated"
-msgstr "مەدندەنەکراوە"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:169
-msgid "Default: "
-msgstr "بنەڕەت: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:177
-msgid "Colorspace: "
-msgstr "ڕێکخەری دیاریکراوی ڕەنگ: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:184
-msgid "Test profile: "
-msgstr "زانیاری کەسی تاقیبکەرەوە: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:238
-msgid "Select ICC Profile File"
-msgstr "پەڕگەی زانیاری کەسی ICC دیاریبکە"
-
-#: panels/color/cc-color-panel.c:241
-msgid "_Import"
-msgstr "_هێنان"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:252
-msgid "Supported ICC profiles"
-msgstr "زانیارییە کەسییەکانی ICC پشتگیریکراون"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:259
-#: panels/network/wireless-security/eap-method-fast.c:356
-msgid "All files"
-msgstr "هه‌موو په‌ڕگه‌كان"
-
-#: panels/color/cc-color-panel.c:554
-msgid "Screen"
-msgstr "شاشە"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:846
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "بارکردنی پەڕگە شکستی هێنا: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:858
-msgid "The profile has been uploaded to:"
-msgstr "زانیارییە کەسییەکان بارکران بۆ:"
-
-#: panels/color/cc-color-panel.c:860
-msgid "Write down this URL."
-msgstr "لەخوارەوە ئەم URL بنووسە."
-
-#: panels/color/cc-color-panel.c:861
-msgid "Restart this computer and boot your normal operating system."
-msgstr "ئەم کۆمپیتەرە دەستپێکەرەوە و سیستەمی کارپێکەری ئاسایت بخەرە ڕێ."
-
-#: panels/color/cc-color-panel.c:862
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "URLەکە لەناو وێبگەڕەکەت بنووسە"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:890
-msgid "Save Profile"
-msgstr "زانیاری کەسی پاشەکەوت بکە"
-
-#: panels/color/cc-color-panel.c:894
-#: panels/network/connection-editor/vpn-helpers.c:300
-msgid "_Save"
-msgstr "_پاشەکەوتکردن"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1208
-msgid "Create a color profile for the selected device"
-msgstr "ڕەنگێکی زانیاری کەسی دروستبکە بۆ ئامێرە دیاریکراوەکە"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1223 panels/color/cc-color-panel.c:1247
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"ئامێری پێوانەکردنەکە نەزدۆرایەوە. تکایە بیپشکنە کە هەڵکراوە و  ئێستا "
-"پەیوەستبووە."
 
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1257
-msgid "The measuring instrument does not support printer profiling."
-msgstr "ئامێری پێوانەکردنەکە پشتگیری کورتەی چاپکەرەکە ناکات."
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "خەمڵاندنی شاشە"
 
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1268
-msgid "The device type is not currently supported."
-msgstr "جۆری ئامێرەکە بە لەم کاتەدا پشتگیری ناکرێ."
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_پاشگەزبوونەوە"
 
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_دەستپێکردن"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_دەستپێکردنەوە"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_ئەنجامدرا"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "پێوانەکردنی شاشە"
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "جۆرایەتی پێوانەکردن"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -970,42 +435,42 @@ msgstr ""
 "شاشەکەت. ئەو کاتە درێژەی تۆ بەسەری دەبەیت لە پێوانەکردن، باشترە جۆرایەتی "
 "ڕەنگی پڕؤفایلەکە."
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "تۆ ناتوانیت کۆمپیتەرەکەت بەکاربێنی کاتێک پێوانەکردن شوێن دەگرێ."
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "جۆرایه‌تی"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "کاتی هاوتا"
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr "جۆرایەتی پێوانەکردن"
-
-#: panels/color/cc-color-panel.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr "ئامێرە هەستەوەرەکەی کە دەتوەێت بۆ پێوانەکردن بەکاری بهێنی دیاریبکە."
-
-#: panels/color/cc-color-panel.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "ئامێری پێوانەکردن"
 
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
-msgstr "خۆری ئەو شاشەیەی کە پەیوەستبووە دیاری بکە."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ئامێرە هەستەوەرەکەی کە دەتوەێت بۆ پێوانەکردن بەکاری بهێنی دیاریبکە."
 
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "جۆری شاشە"
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "خۆری ئەو شاشەیەی کە پەیوەستبووە دیاری بکە."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "خاڵی سپی زانیاری کەسی"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -1013,11 +478,11 @@ msgstr ""
 "خاڵی سپی ئامانجی شاشەیەک دیاریبکە. زۆربەی شاشەکان پێوەیستە پێوانەبکرێن بۆ "
 "(D65 illuminant) ێک."
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
-msgstr "خاڵی سپی زانیاری کەسی"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "ڕۆشنایی شاشە"
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -1025,7 +490,7 @@ msgstr ""
 "تکایە ڕۆشنایی شاشاکە وا دابنێ کا ئاسایی بێ بۆ تۆ. بەڕێوەبردنی ڕەنگەکان کاتێک "
 "تەواو دەبێ کە لەو ئاستی ڕووناکییە بێ."
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -1033,11 +498,11 @@ msgstr ""
 "بەلەجیاتی، تۆ دەتوانیت ئەو ئاستی ڕۆشنایی بەکاربێنی کە بەەکاردێ‌ لەگەڵ یەکێک "
 "لە زانیارییە کەسییەکانی کە بۆ ئەم ئامێرە بەکاردێ."
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr "ڕۆشنایی شاشە"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "ناوی زانیاری کەسی"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -1045,307 +510,196 @@ msgstr ""
 "تۆ دەتوانی ڕەنگە کەسییەک بەکاربێنی لە کۆپیتەرێکی جیاواز، یان تەنانەت زانیاری "
 "کەسیی دروستبکەیت"
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "ناوی زانیاری کەسیی:"
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "ناوی زانیاری کەسی"
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "پوختە"
 
-#: panels/color/cc-color-panel.ui:392
+#: panels/color/cc-color-panel.ui:259
 msgid "Profile successfully created!"
 msgstr "زانیاری کەسی بە سەرکەووتوی دروستکرا!"
 
-#: panels/color/cc-color-panel.ui:443
+#: panels/color/cc-color-panel.ui:290
 msgid "Copy profile"
 msgstr "زانیاری کەسی لەبەربگرەوە"
 
-#: panels/color/cc-color-panel.ui:456
+#: panels/color/cc-color-panel.ui:296
 msgid "Requires writable media"
 msgstr "ڕەنگاڵەی خوێندەنی داواکراوە"
 
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr "پرۆفایل بەرزبکەرەوە"
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr "پێویستی بە هێڵی ئینتەرنێتە"
-
-#: panels/color/cc-color-panel.ui:591
+#: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "لەوانەیە ئەم ڕێنماییانە بدۆزیتەوە کە چۆن پڕۆفایلەکە بەکاربێنیت لەم سیستەمە "
 "سوودبەخشانە <a href=\"linux\">گنوو/لینوکس</a>,  <a href=\"osx\">ئۆ ئێس ئێکسی "
 "ئەپڵ</a> و <a href=\"windows\">ویندۆزی مایکرۆسۆفت</a> ."
 
-#: panels/color/cc-color-panel.ui:607
-#: panels/user-accounts/um-fingerprint-dialog.c:719
-msgid "Summary"
-msgstr "پوختە"
-
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "زانیاری کەسی زیادبکە"
 
-#: panels/color/cc-color-panel.ui:643
-msgid "_Import File…"
-msgstr "_هێنانی پەڕگە"
-
-#: panels/color/cc-color-panel.ui:672
-#: panels/network/connection-editor/net-connection-editor.c:513
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/region/cc-input-chooser.ui:20
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr "_زیادکردن"
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"کێشەکان دۆزرانەوە.لەوانەیە زانیارییە کەسییەکە بە دروستی کار نەکات. <a href="
-"\"\">زانیاری زیاتر ببینە.</a>"
+"کێشەکان دۆزرانەوە.لەوانەیە زانیارییە کەسییەکە بە دروستی کار نەکات. <a "
+"href=\"\">زانیاری زیاتر ببینە.</a>"
 
-#: panels/color/cc-color-panel.ui:790
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_هێنانی پەڕگە"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_زیادکردن"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "هەر ئامێرێک نوێکردنەوەی ڕەنگی زانیاری کەسی پێویستە بۆ ئەوەی ڕەنگەکە "
 "بەڕێوەببرێ."
 
-#. translators: Text used in link to privacy policy
-#: panels/color/cc-color-panel.ui:812
-#: panels/diagnostics/cc-diagnostics-panel.c:260
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "زیاتر فێربە"
 
-#: panels/color/cc-color-panel.ui:817
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "زیاتر فێربە دەربارەی بەڕێوبەرایەتی ڕەنگ"
 
-#: panels/color/cc-color-panel.ui:865
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "_سازی بدە بۆ هەموو بەکارهێنەران"
 
-#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
-#: panels/color/cc-color-panel.ui:885
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "ئەم  پرۆفایلە بۆ هەموو بەکارهێنەرانی ئەم کۆمپیتەرە دابنێ"
 
-#: panels/color/cc-color-panel.ui:880
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:911
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:924
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "_پێوانەکردن..."
 
-#: panels/color/cc-color-panel.ui:928
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "ئامێرەکە پێوانەبکە"
 
-#: panels/color/cc-color-panel.ui:939
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "_سڕینەوەی ناسنامە"
 
-#: panels/color/cc-color-panel.ui:952
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "_پیشاندانی ناسنامە"
 
-#: panels/color/cc-color-panel.ui:988
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "ناتوانرێ هیچ‌ ئامێرێک دیاریبکرێ کە بتوانێ ڕەنگ بەڕێوەبەرێ"
 
-#: panels/color/cc-color-panel.ui:1032
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/cc-color-panel.ui:1037
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/cc-color-panel.ui:1042
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: panels/color/cc-color-panel.ui:1047
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "وێنه‌نوێن"
 
-#: panels/color/cc-color-panel.ui:1052
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "پلازما"
 
-#: panels/color/cc-color-panel.ui:1057
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL ڕووناکی پشتەوە)"
 
-#: panels/color/cc-color-panel.ui:1062
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED ڕووناکی پشتەوە)"
 
-#: panels/color/cc-color-panel.ui:1067
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD ( LED ی سپی ڕووناکی دواوە)"
 
-#: panels/color/cc-color-panel.ui:1072
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "LCDی هەموو چینە جیاوازە پانەکان (لایتی دواوەی CCFL)"
 
-#: panels/color/cc-color-panel.ui:1077
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "LCDی هەموو چینە جیاوازە پانەکان (لایتی دواوەی RGB LED)"
 
-#: panels/color/cc-color-panel.ui:1094
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "به‌رز"
 
-#: panels/color/cc-color-panel.ui:1095
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "٤٠ خولەک"
 
-#: panels/color/cc-color-panel.ui:1099
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "ناوەند"
 
-#: panels/color/cc-color-panel.ui:1100
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "۳۰ خولەک"
 
-#: panels/color/cc-color-panel.ui:1104
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "نزم"
 
-#: panels/color/cc-color-panel.ui:1105
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "۱٥ خولەک"
 
-#: panels/color/cc-color-panel.ui:1127
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "بنەڕەت بۆ پیشاندان"
 
-#: panels/color/cc-color-panel.ui:1131
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (چاپکردن و بڵاوکردنەوە)"
 
-#: panels/color/cc-color-panel.ui:1135
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/cc-color-panel.ui:1139
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (وێنەگرتن و هێڵکاریەکان)"
 
-#: panels/color/cc-color-panel.ui:1143
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:100
-msgid "Standard Space"
-msgstr "بۆشای ئاسای"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:106
-msgid "Test Profile"
-msgstr "پڕۆفایلی بۆ تاقیکردنەوە"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:114
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "خۆکار"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:124
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "جۆرایەتی لاواز"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:129
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "جۆرێتی ناوەند"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:136
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "جۆرێتی بەرز"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:153
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB بنەڕەت"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:160
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK بنەڕەت"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:167
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "رەساسی بنەڕەت"
-
-#: panels/color/cc-color-profile.c:190
-msgid "Vendor supplied factory calibration data"
-msgstr "دراوی خەمڵێنراوی کارگەی سامانی فرۆشیار"
-
-#: panels/color/cc-color-profile.c:199
-msgid "Full-screen display correction not possible with this profile"
-msgstr "ڕاستکەرەوەی پیشاندەری شاشەی پڕ بەردەست نییە لەم پڕۆفایلە"
-
-#: panels/color/cc-color-profile.c:221
-msgid "This profile may no longer be accurate"
-msgstr "ئەم پڕؤفایلە لەوانەیە لەمەودوا تەواو نەبێت"
-
-#: panels/color/cc-color-calibrate.ui:7
-msgid "Display Calibration"
-msgstr "خەمڵاندنی شاشە"
-
-#. This starts the calibration process
-#: panels/color/cc-color-calibrate.ui:40
-msgid "_Start"
-msgstr "_دەستپێکردن"
-
-#. This resumes the calibration process
-#: panels/color/cc-color-calibrate.ui:54
-msgid "_Resume"
-msgstr "_دەستپێکردنەوە"
-
-#. This button returns the user back to the color control panel
-#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
-msgid "_Done"
-msgstr "_ئەنجامدرا"
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1356,246 +710,200 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "ڕەنگی ئامێرەکەت بخەمڵێنە، وەک پشاندەر، کامێراکان یان چاپکەرەکان"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/color/gnome-color-panel.desktop.in.in:7
-msgid "preferences-color"
-msgstr "ڕەنگی-هەڵبژاردەکان"
-
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "ڕەنگ;ICC;پڕۆفایل;خەمڵاندن;جاپکەر;پشاندەر"
-
-#: panels/common/cc-language-chooser.c:145 panels/region/cc-input-chooser.c:178
-msgid "More…"
-msgstr "زیاتر..."
-
-#: panels/common/cc-language-chooser.c:162
-msgid "No languages found"
-msgstr "هیچ لە زمانەکان نەدۆزرایەوە"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
 msgstr "زمان دیاری بکە"
 
-#: panels/common/cc-language-chooser.ui:12
+#: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
 msgstr "_دیاریبکە"
 
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:152
-msgid "Today"
-msgstr "ئەمڕۆ"
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "هیچ لە زمانەکان نەدۆزرایەوە"
 
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:154
-msgid "Yesterday"
-msgstr "دوێنێ"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "زیاتر..."
 
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "_بیکەرەوە"
 
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "خاڵی داخ"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
-#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
-msgid "Day"
-msgstr "ڕۆژ"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
-#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
-msgid "Month"
-msgstr "مانگ"
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "کاتەکان"
 
-#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
-#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
-msgid "Year"
-msgstr "ساڵ"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:334
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:339
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:504
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:531
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:538
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:543
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:548
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:26
-msgid "January"
-msgstr "كانونی دووه‌م"
-
-#: panels/datetime/cc-datetime-panel.ui:29
-msgid "February"
-msgstr "شوبات"
-
-#: panels/datetime/cc-datetime-panel.ui:32
-msgid "March"
-msgstr "ئازار"
-
-#: panels/datetime/cc-datetime-panel.ui:35
-msgid "April"
-msgstr "نیسان"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "May"
-msgstr "ئایار"
-
-#: panels/datetime/cc-datetime-panel.ui:41
-msgid "June"
-msgstr "حوزه‌یران"
-
-#: panels/datetime/cc-datetime-panel.ui:44
-msgid "July"
-msgstr "ته‌مموز"
-
-#: panels/datetime/cc-datetime-panel.ui:47
-msgid "August"
-msgstr "ئاب"
-
-#: panels/datetime/cc-datetime-panel.ui:50
-msgid "September"
-msgstr "ئه‌یلول"
-
-#: panels/datetime/cc-datetime-panel.ui:53
-msgid "October"
-msgstr "تشرینی یه‌كه‌م"
-
-#: panels/datetime/cc-datetime-panel.ui:56
-msgid "November"
-msgstr "تشرینی دووه‌م"
-
-#: panels/datetime/cc-datetime-panel.ui:59
-msgid "December"
-msgstr "كانونی یه‌كه‌م"
-
-#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "کات & ڕیکەوت"
 
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "ساڵ"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "مانگ"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "كانونی دووه‌م"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "شوبات"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "ئازار"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "نیسان"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "ئایار"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "حوزه‌یران"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "ته‌مموز"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "ئاب"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "ئه‌یلول"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "تشرینی یه‌كه‌م"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "تشرینی دووه‌م"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "كانونی یه‌كه‌م"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "ڕۆژ"
+
 #: panels/datetime/cc-datetime-panel.ui:113
-#: panels/display/cc-night-light-page.ui:194
-#: panels/display/cc-night-light-page.ui:314
-msgid "Hour"
-msgstr "کاتژمێر"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: panels/datetime/cc-datetime-panel.ui:128
-msgid "∶"
-msgstr "∶"
-
-#: panels/datetime/cc-datetime-panel.ui:152
-#: panels/display/cc-night-light-page.ui:222
-#: panels/display/cc-night-light-page.ui:342
-msgid "Minute"
-msgstr "خولەک"
-
-#: panels/datetime/cc-datetime-panel.ui:219
 msgid "Time Zone"
 msgstr "کاتی ناوچەکە"
 
-#: panels/datetime/cc-datetime-panel.ui:240
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "بگەڕی بۆ شارێک"
 
-#: panels/datetime/cc-datetime-panel.ui:313
-msgid "Automatic _Date & Time"
-msgstr ""
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
+msgstr "کاتی _ناوچەی خۆکار"
 
-#: panels/datetime/cc-datetime-panel.ui:314
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "ئینتەرنێت پێویستە هەبێت"
 
-#: panels/datetime/cc-datetime-panel.ui:334
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "_کات و بەروار"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "کاتی _ناوچەی خۆکار"
 
-#: panels/datetime/cc-datetime-panel.ui:335
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "پێوستە خزمەتگوزاری شوینی هەڵکرابێت و ئینتەرنێت هەبێت"
 
-#: panels/datetime/cc-datetime-panel.ui:350
-msgid "Date & _Time"
-msgstr "_کات و بەروار"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "چالاككراوە"
 
-#: panels/datetime/cc-datetime-panel.ui:366
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "ش_وێنی کات"
 
-#: panels/datetime/cc-datetime-panel.ui:405
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "_بیکەرەوە"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_ڕێکخستنی کات"
 
-#: panels/datetime/cc-datetime-panel.ui:414
-msgid "24-hour"
-msgstr "24-کاتژمێر"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:415
-msgid "AM / PM"
-msgstr "پێش ن/دوا ن"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "ڕێکەوتەکان"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "٠ چرکە"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_ڕۆژژمێر"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "ژمارەکان"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "کات و بەروارەکە بگۆڕە، هەروەها شوێنی کاتیش"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/datetime/gnome-datetime-panel.desktop.in.in:7
-msgid "preferences-system-time"
-msgstr "preferences-system-time"
-
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "کاتژمێر;ناوچەی کات;شوێن;"
@@ -1608,424 +916,30 @@ msgstr "ڕێکخستنەکانی کات و بەرواری سیستەم بگۆڕ�
 msgid "To change time or date settings, you need to authenticate."
 msgstr "بۆ گۆڕینی ڕێکخسنەکانی کات یان بەروار، پێویستت بە ساغکردنەوە دەبێت."
 
-#: panels/display/cc-display-panel.c:958
-#: panels/network/connection-editor/connection-editor.ui:27
-msgid "_Apply"
-msgstr "_جێبەجێکردن"
-
-#: panels/display/cc-display-panel.c:979
-msgid "Apply Changes?"
-msgstr "گۆڕناکان جێبەجێبکرێت؟"
-
-#: panels/display/cc-display-panel.c:984
-msgid "Changes Cannot be Applied"
-msgstr "گۆڕانەکان ناتوانرێ جێبەجێبکرێ"
-
-#: panels/display/cc-display-panel.c:985
-msgid "This could be due to hardware limitations."
-msgstr "دەتوانرێ پێشبینیبکرێ بۆ سنوردارکردنی ڕەقەکاڵا."
-
-#: panels/display/cc-display-panel.ui:91
-msgid "Single Display"
-msgstr "پشاندەری تاک"
-
-#: panels/display/cc-display-panel.ui:110
-#: panels/display/cc-display-panel.ui:315
-msgid "Join Displays"
-msgstr "پشاندەرەکان پەیوەستبکە"
-
-#: panels/display/cc-display-panel.ui:128
-msgid "Mirror"
-msgstr "ئاوێنە"
-
-#: panels/display/cc-display-panel.ui:153
-msgid "Display Mode"
-msgstr "دۆزی پشاندەر"
-
-#: panels/display/cc-display-panel.ui:245
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
-msgstr ""
-"پشاندەرەکان ڕابکێشە بۆ گونجاندنی پیشاندەرە جێگیرکراوە فیزیاییکەت. پیشاندەرێک "
-"دیاریبکە بۆ گۆڕینی ڕێکخسنەکان."
-
-#: panels/display/cc-display-panel.ui:252
-msgid "Display Arrangement"
-msgstr "ڕێکخستنی پیشاندەر"
-
-#: panels/display/cc-display-panel.ui:434
-msgid "Display Configuration"
-msgstr "شێوەپێدانی پیشاندەر"
-
-#: panels/display/cc-display-panel.ui:453
-#: panels/display/gnome-display-panel.desktop.in.in:3
-msgid "Displays"
-msgstr "پیشاندەرەکان"
-
-#. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:464
-#: panels/display/cc-night-light-page.ui:111
-msgid "Night Light"
-msgstr "ڕووناکی شەو"
-
-#: panels/display/cc-display-settings.c:104
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "ئاسۆی"
-
-#: panels/display/cc-display-settings.c:107
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "لەسەر لای ڕاست"
-
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "لەسەر لای چەپ"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "ئاسۆی (هەڵگەڕاوە)"
-
-#: panels/display/cc-display-settings.c:187
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf هێرتز"
-
-#: panels/display/cc-display-settings.ui:15
-msgctxt "display setting"
-msgid "Orientation"
-msgstr "ئاڕاستە"
-
-#: panels/display/cc-display-settings.ui:24
-msgctxt "display setting"
-msgid "Resolution"
-msgstr "وردی نیشاندانی شاشە"
-
-#: panels/display/cc-display-settings.ui:33
-msgid "Refresh Rate"
-msgstr "ڕێژەی نوێبوونەوە"
-
-#: panels/display/cc-display-settings.ui:42
-msgid "Adjust for TV"
-msgstr "گونجاندن ڤۆ TV"
-
-#: panels/display/cc-display-settings.ui:59
-msgctxt "display setting"
-msgid "Scale"
-msgstr "پێوانە کردن"
-
-#: panels/display/cc-night-light-page.c:622
-msgid "More Warm"
-msgstr "گەرم تر"
-
-#: panels/display/cc-night-light-page.c:634
-msgid "Less Warm"
-msgstr "کەمتر گەرم"
-
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:28
-msgid "Restart Filter"
-msgstr "پاڵێوەری دووبارە نوێبوونەوە"
-
-#. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:61
-msgid "Temporarily Disabled Until Tomorrow"
-msgstr "کاتتینە ناچالاکی بکە تاکو بەیانی"
-
-#: panels/display/cc-night-light-page.ui:88
-msgid ""
-"Night light makes the screen color warmer. This can help to prevent eye "
-"strain and sleeplessness."
-msgstr ""
-"ڕووناکی شەوانە ڕەنگی شاشەکە گەرمتر دەکات. ئەمە دەتوانێت یارمەتیتبدات لە "
-"نەهێشتنی گوشاری چاو و بەئاگاى."
-
-#: panels/display/cc-night-light-page.ui:127
-msgid "Schedule"
-msgstr "نانەوە"
-
-#: panels/display/cc-night-light-page.ui:136
-msgid "Sunset to Sunrise"
-msgstr "خۆرئاوابوون بۆ خۆرهەڵاتن"
-
-#: panels/display/cc-night-light-page.ui:137
-msgid "Manual Schedule"
-msgstr "نانەوی خودکار"
-
-#: panels/display/cc-night-light-page.ui:148
-#: panels/region/cc-format-chooser.ui:346
-msgid "Times"
-msgstr "کاتەکان"
-
-#: panels/display/cc-night-light-page.ui:165
-msgid "From"
-msgstr "لە"
-
-#: panels/display/cc-night-light-page.ui:203
-#: panels/display/cc-night-light-page.ui:323
-msgid ":"
-msgstr ":"
-
-#. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:234
-#: panels/display/cc-night-light-page.ui:354
-msgid "AM"
-msgstr "پ ن"
-
-#. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:250
-#: panels/display/cc-night-light-page.ui:370
-msgid "PM"
-msgstr "د ن"
-
-#: panels/display/cc-night-light-page.ui:284
-msgid "To"
-msgstr "بۆ"
-
-#: panels/display/cc-night-light-page.ui:408
-msgid "Color Temperature"
-msgstr "پلەی گەرمی ڕەنگ"
-
-#: panels/display/gnome-display-panel.desktop.in.in:4
-msgid "Choose how to use connected monitors and projectors"
-msgstr "هەڵیبژێرە چۆن دەتوانیت پڕۆژەدروستکەرەکان و پیشاندەرەکان بەکاربێنیت"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/display/gnome-display-panel.desktop.in.in:7
-msgid "preferences-desktop-display"
-msgstr "preferences-desktop-display"
-
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/display/gnome-display-panel.desktop.in.in:19
-msgid ""
-"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
-"redshift;color;sunset;sunrise;"
-msgstr ""
-"بەش;پڕۆژەدروستکەر;xrandr;شاشە;وردی نیشاندانی شاشە;نوێبوونەوە;مۆنیتەر؛شەو;"
-"ڕووناکی;شین;گۆڕینی سوور;ڕەنگ;خۆرئاوابوون;خۆرهەڵاتن;"
-
-#: panels/default-apps/cc-default-apps-panel.ui:31
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "_تۆڕ"
 
-#: panels/default-apps/cc-default-apps-panel.ui:43
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "_پۆست"
 
-#: panels/default-apps/cc-default-apps-panel.ui:59
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "_ڕۆژژمێر"
 
-#: panels/default-apps/cc-default-apps-panel.ui:75
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "مۆـسیقا"
 
-#: panels/default-apps/cc-default-apps-panel.ui:91
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "_ڤیدیۆ"
 
-#: panels/default-apps/cc-default-apps-panel.ui:162
-#: panels/removable-media/cc-removable-media-panel.ui:162
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "_وێنەکان"
-
-#: panels/info-overview/cc-info-overview-panel.c:407
-#: panels/info-overview/cc-info-overview-panel.c:422
-#: panels/info-overview/cc-info-overview-panel.c:434
-#: panels/info-overview/cc-info-overview-panel.c:480
-#: panels/info-overview/cc-info-overview-panel.c:510
-msgid "Unknown"
-msgstr "نەزانراو"
-
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:442
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; ناسنامەی دروستکردن: %s"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:457
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:460
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info/info-overview.ui:62
-msgid "Device name"
-msgstr ""
-
-#: panels/info-overview/cc-info-overview-panel.ui:77
-msgid "Memory"
-msgstr "بیرگە"
-
-#: panels/info-overview/cc-info-overview-panel.ui:86
-msgid "Processor"
-msgstr "چاره‌سه‌ركه‌ر"
-
-#: panels/info-overview/cc-info-overview-panel.ui:95
-msgid "Graphics"
-msgstr "گرافیک"
-
-#. To translators: this field contains the distro type
-#: panels/info/info-overview.ui:141
-msgid "OS type"
-msgstr ""
-
-#: panels/info-overview/cc-info-overview-panel.ui:163
-msgid "Virtualization"
-msgstr "بەخەیاڵی کردن"
-
-#: panels/info/info-overview.ui:173
-msgid "Disk"
-msgstr ""
-
-#: panels/info-overview/cc-info-overview-panel.ui:105
-msgid "Calculating…"
-msgstr "دەژمێرێت..."
-
-#: panels/info/info-overview.ui:318
-msgid "Check for updates"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:267
-msgid "Ask what to do"
-msgstr "پرسیاربکە بۆ ئەوەی چیبکات"
-
-#: panels/removable-media/cc-removable-media-panel.c:271
-msgid "Do nothing"
-msgstr "هیچ مەکە"
-
-#: panels/removable-media/cc-removable-media-panel.c:275
-msgid "Open folder"
-msgstr "بوخچە بکەرەوە"
-
-#: panels/removable-media/cc-removable-media-panel.c:341
-msgid "Other Media"
-msgstr "میدیای تر"
-
-#: panels/removable-media/cc-removable-media-panel.c:362
-msgid "Select an application for audio CDs"
-msgstr "داوانامە هەڵبژێرە بۆ سی دی دەنگی"
-
-#: panels/removable-media/cc-removable-media-panel.c:363
-msgid "Select an application for video DVDs"
-msgstr "داوانامە هەڵبژێرە بۆ دی-ڤیدی دەنگ و ڕەنگ"
-
-#: panels/removable-media/cc-removable-media-panel.c:364
-msgid "Select an application to run when a music player is connected"
-msgstr "داوانامە هەڵبژێرە بۆ کارکردن کاتێک لێدەری میوزیک پەیوەست دەکرێت"
-
-#: panels/removable-media/cc-removable-media-panel.c:365
-msgid "Select an application to run when a camera is connected"
-msgstr "داوانامە هەڵبژێرە بۆ کارکردن کاتێک کامێرا پەیوەست دەکرێت"
-
-#: panels/removable-media/cc-removable-media-panel.c:366
-msgid "Select an application for software CDs"
-msgstr "داوانامە هەڵبژێرە بۆ داوانامەی سی-دی"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "audio DVD"
-msgstr "دی-ڤیدی دەنگی"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "blank Blu-ray disc"
-msgstr "پەپکەی بەتاڵی بلو-ڕەی"
-
-#: panels/removable-media/cc-removable-media-panel.c:380
-msgid "blank CD disc"
-msgstr "پەپکەی بەتاڵی سی-دی"
-
-#: panels/removable-media/cc-removable-media-panel.c:381
-msgid "blank DVD disc"
-msgstr "پەپکەی بەتاڵی دی-ڤیدی"
-
-#: panels/removable-media/cc-removable-media-panel.c:382
-msgid "blank HD DVD disc"
-msgstr "پەپکەی بەتاڵی HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:383
-msgid "Blu-ray video disc"
-msgstr "پەپکەی ڤیدیۆی بلو-ڕەی"
-
-#: panels/removable-media/cc-removable-media-panel.c:384
-msgid "e-book reader"
-msgstr "خوێنەرەوەی کتێکی-ئەلکترۆنی"
-
-#: panels/removable-media/cc-removable-media-panel.c:385
-msgid "HD DVD video disc"
-msgstr "پەپکەی ڤیدیۆییHD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:386
-msgid "Picture CD"
-msgstr "سی-دی وێنە"
-
-#: panels/removable-media/cc-removable-media-panel.c:387
-msgid "Super Video CD"
-msgstr "سی-دی ڤیدیۆیی سوپەر"
-
-#: panels/removable-media/cc-removable-media-panel.c:388
-msgid "Video CD"
-msgstr "سی-دی ڤیدیۆیی"
-
-#: panels/removable-media/cc-removable-media-panel.c:389
-msgid "Windows software"
-msgstr "نەرمەواڵەی پەنجەرەکان"
-
-#: panels/removable-media/cc-removable-media-panel.ui:44
-msgid "Select how media should be handled"
-msgstr "پیشانی بدە چۆن میدیا بەدەستبخرێت"
-
-#: panels/removable-media/cc-removable-media-panel.ui:75
-msgid "CD _audio"
-msgstr "سیدی _دەنگی"
-
-#: panels/removable-media/cc-removable-media-panel.ui:92
-msgid "_DVD video"
-msgstr "_ڤیدیۆیی دی-ڤیدی"
-
-#: panels/removable-media/cc-removable-media-panel.ui:133
-msgid "_Music player"
-msgstr "_لێدەری میوزیک"
-
-#: panels/removable-media/cc-removable-media-panel.ui:191
-msgid "_Software"
-msgstr "_نەرمەواڵە"
-
-#: panels/removable-media/cc-removable-media-panel.ui:229
-msgid "_Other Media…"
-msgstr "_میدیای تر..."
-
-#: panels/removable-media/cc-removable-media-panel.ui:288
-msgid "_Never prompt or start programs on media insertion"
-msgstr "_هەرگیز یەکسەر یان بەرنامەکان مەکەوە لەناو ڕەنگاڵە تێخراوەکان"
-
-#: panels/removable-media/cc-removable-media-panel.ui:342
-msgid "Select how other media should be handled"
-msgstr "دیاریبکە چۆن ڕەنگاڵەی دیکە بەدەست دەکەون"
-
-#: panels/removable-media/cc-removable-media-panel.ui:389
-msgid "_Action:"
-msgstr "_کردارەکان:"
-
-#: panels/removable-media/cc-removable-media-panel.ui:412
-msgid "_Type:"
-msgstr "_جۆر:"
 
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
 msgid "Default Applications"
@@ -2035,15 +949,357 @@ msgstr "نەرمەواڵا بنەڕەتییەکان"
 msgid "Configure Default Applications"
 msgstr "نەرمەواڵا بنەڕەتییەکان ڕێکبخە"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:7
-msgid "starred"
-msgstr "دەستپێکرا"
-
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "بنەڕەت;نەرمەواڵا;پەسەندکراو;ڕەنگاڵە;"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "ڕاپۆرتکردنی کێشە"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_جێبەجێکردن"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "بڕۆدواوە"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "پشاندەری تاک"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "ئاوێنە"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "پشاندەرەکان پەیوەستبکە"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "ڕووناکی شەو"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "ئاڕاستە"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "وردی نیشاندانی شاشە"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "ڕێژەی نوێبوونەوە"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "گونجاندن ڤۆ TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "پێوانە کردن"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "پێچۆکه‌گه‌ری سروشتی"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "ڕووناکی شەو"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "کاتتینە ناچالاکی بکە تاکو بەیانی"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "پاڵێوەری دووبارە نوێبوونەوە"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"ڕووناکی شەوانە ڕەنگی شاشەکە گەرمتر دەکات. ئەمە دەتوانێت یارمەتیتبدات لە "
+"نەهێشتنی گوشاری چاو و بەئاگاى."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "نانەوە"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "خۆرئاوابوون بۆ خۆرهەڵاتن"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "نانەوی خودکار"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "کاتەکان"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "لە"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "کاتژمێر"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "خولەک"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "پ ن"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "د ن"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "بۆ"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "پلەی گەرمی ڕەنگ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "پیشاندەرەکان"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "هەڵیبژێرە چۆن دەتوانیت پڕۆژەدروستکەرەکان و پیشاندەرەکان بەکاربێنیت"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"بەش;پڕۆژەدروستکەر;xrandr;شاشە;وردی نیشاندانی شاشە;نوێبوونەوە;مۆنیتەر؛شەو;"
+"ڕووناکی;شین;گۆڕینی سوور;ڕەنگ;خۆرئاوابوون;خۆرهەڵاتن;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "جۆری ئاسایش"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "ئاستی مەرەکەب"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "ئاستی مەرەکەب"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "ئاستی مەرەکەب"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "ئاسایش"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"شاشە;قفڵ;دەستنیشانکاری;تێکشکان;تایبەتی;نوێترین;کاتی;tmp;نیشاندەر;ناو;ڕایەڵە;"
+"ناسنامه;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ئامێرەکان"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "ناونیشانی ڕەقەکاڵا"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "بیرگە"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "چاره‌سه‌ركه‌ر"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "گرافیک"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "دەژمێرێت..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "ناو"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; ناسنامەی دروستکردن: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "_جۆر"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "ڕێکخستنەکانی گنۆم"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "نەرمەواڵەی پەنجەرەکان"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "بەخەیاڵی کردن"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "_نەرمەواڵە"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "ئامێری چاوەڕوانکراو"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_ناوی بەکارهێنەر"
 
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
 msgid "About"
@@ -2053,40 +1309,11 @@ msgstr "دەربارە"
 msgid "View information about your system"
 msgstr "زانیاری ببینە دەربارەی سیستەمەکەت"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:7
-msgid "help-about"
-msgstr "help-about"
-
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
-#: panels/info/gnome-info-overview-panel.desktop.in.in:23
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-
-#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
-msgid "Removable Media"
-msgstr "مێدیای هەڵگرتەنی"
-
-#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
-msgid "Configure Removable Media settings"
-msgstr "ڕێکخستنەکانی میدیای هەڵگرتەنی چاک بکە"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:7
-msgid "media-removable"
-msgstr "media-removable"
-
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
-msgid ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
-"removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;"
@@ -2140,7 +1367,7 @@ msgid "Eject"
 msgstr "دەریبکە"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:565
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "نووسین"
 
@@ -2160,6 +1387,12 @@ msgstr "کارپێکەر"
 msgid "Launch help browser"
 msgstr "وێبگەڕی یارمەتی کارپێبکە"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "ڕێكخستنەكان"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "ژمێرەر کارپێبکە"
@@ -2169,55 +1402,19 @@ msgid "Launch email client"
 msgstr "پۆستی ڕاژەخواز کارپێبکە"
 
 #: panels/keyboard/01-launchers.xml.in:12
-msgid "Launch terminal"
-msgstr "کۆتاگه‌ کارپێبکە"
-
-#: panels/keyboard/01-launchers.xml.in:14
 msgid "Launch web browser"
 msgstr "وێبگەڕی تۆڕ کارپێبکە"
 
-#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "بوخچەی سەرەکی"
 
-#: panels/keyboard/01-launchers.xml.in:18
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "گەڕان"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "وێنەکانی شاشە"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "وێنەیەکی شاشە پاشەکەوتبکە بۆ $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "وێنەیەکی شاشەی پەنجەرەیەک پاشەکەوتبکە بۆ $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "وێنەیەکی شاشەی ناوچەیەک پاشەکەوتبکە بۆ $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "وێنەیەکی شاشەیەک لەبەربگرەوە بۆ لیستەی لەبەرگیراوە"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "وێنەیەکی شاشەی پەنجەرەیەک پاشەکەوتبکە بۆ لیستەی لەبەرگیراوە"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "وێنەیەکی شاشەی ناوچەیەک پاشەکەوتبکە بۆ لیستەی لەبەرگیراوە"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "ڤیدیۆیەکی کورتی شاشە تۆماربکە"
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "سیسته‌م"
 
@@ -2231,8 +1428,8 @@ msgstr "قفڵی شاشە"
 
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
-msgid "Universal Access"
-msgstr "دەستگەیشنی گەردوونی"
+msgid "Accessibility"
+msgstr ""
 
 #: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
@@ -2266,167 +1463,431 @@ msgstr "قەبارەی نووسین کەمبکە"
 msgid "High contrast on or off"
 msgstr "جیاوازی بەرز هەڵبکە یان بیکوژێنەوە"
 
-#: panels/keyboard/cc-keyboard-manager.c:501
-#: panels/keyboard/cc-keyboard-manager.c:509
-#: panels/keyboard/cc-keyboard-manager.c:809
-msgid "Custom Shortcuts"
-msgstr "قەدبڕی دروستکراو"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "سەرچاوی تێخستن زیادبکە"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: panels/keyboard/cc-keyboard-option.c:337
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "شێوازەکانی تێچووەکە ناتوانرێ بەکاربهێنرێت لەسەر قفڵی شاشەکە"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "هیچ سەرچاوەی تێخستن دیارینەکراوە"
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "هەڵبژاردەکان..."
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "جوڵان بۆ سەرەوە"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "جۆڵان بۆ خوارەوە"
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "هەڵبژاردەکانی تاتەبژمێر"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "قەدبڕەکانی تەختەکلیل"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr "سڕینەوە"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "سەرچاوەی تێخستن"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+#, fuzzy
+msgid "Includes keyboard layouts and input methods."
+msgstr "کڵێشەی تەختەکلیل یان شێوزی نووسین بگۆڕە."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "هەڵبژاردەکانی سەرچاوەی تێخستن"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "_هەمان سەرچاوە بەکاربێنە بۆ هەموو پەنجەرەکان"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "ڕێگەبدە بە سەرچاوە _جیاوازەکان بۆ هەر پەنجەرەیەک"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "کلیل نووسە جێگرەوەکان"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: panels/keyboard/cc-keyboard-option.c:346
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "دووگمەی کەمپەوز"
 
-#: panels/keyboard/cc-keyboard-option.c:351
-msgid "Modifiers-only switch to next source"
-msgstr "تەنها-ڕێکخەرەکان بیگۆڕە سەر سەرچاوەی دواتر"
-
-#: panels/keyboard/cc-keyboard-panel.c:201
-msgid "Reset All Shortcuts?"
-msgstr "هەمووی قەدبڕەکان ڕێکدەخەیتەوە؟"
-
-#: panels/keyboard/cc-keyboard-panel.c:204
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"رێکخستنەوهی قەدبڕەکان لەوانەیە کاریگەری هەبێ لەسەر قەدبڕە دروستکراوەکان. "
-"ئەمە ناتوانرێ هەڵ بوەشێندرێتەوە."
-
-#: panels/keyboard/cc-keyboard-panel.c:208
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:346
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-msgid "Cancel"
-msgstr "هه‌ڵوه‌شاندنه‌وه‌"
-
-#: panels/keyboard/cc-keyboard-panel.c:209
-msgid "Reset All"
-msgstr "هەمووی ڕێکبخەوە"
-
-#: panels/keyboard/cc-keyboard-panel.c:305
-msgid "Reset the shortcut to its default value"
-msgstr "قەدبڕەکە ڕێکبخەوە بۆ بەها بنەڕەتییەکەی خۆی"
-
-#: panels/keyboard/cc-keyboard-panel.ui:147
-msgid "Reset All…"
-msgstr "هەمووی ڕێکبخەوە..."
-
-#: panels/keyboard/cc-keyboard-panel.ui:148
-msgid "Reset all shortcuts to their default keybindings"
-msgstr "قەدبڕەکە ڕێکبخەوە بۆ کلیلە بنەڕەتییەکانی خۆی"
-
-#: panels/keyboard/cc-keyboard-panel.ui:177
-msgid "No keyboard shortcut found"
-msgstr "هیچ قەدبڕی تەختەکلیلێک نەدۆزرایەوە"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:411
-#, c-format
-msgid ""
-"%s is already being used for <b>%s</b>. If you replace it, %s will be "
-"disabled"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
-msgid "Set Custom Shortcut"
-msgstr "قەدبڕی دروستکراو دابنێ"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
-msgid "Set Shortcut"
-msgstr "قەدبڕ دابنێ"
-
-#. Setup the top label
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:590
-#, c-format
-msgid "Enter new shortcut to change <b>%s</b>."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:1016
-msgid "Add Custom Shortcut"
-msgstr "قەدبڕی دروستکراو زیادبکە"
-
-#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
-#: panels/region/cc-region-panel.ui:420 shell/cc-window.ui:327
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "قەدبڕەکانی تەختەکلیل"
 
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "قەدبڕی دروستکراو"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "هەمووی ڕێکبخەوە..."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "قەدبڕەکە ڕێکبخەوە بۆ کلیلە بنەڕەتییەکانی خۆی"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "_کردارەکان:"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "قەدبڕ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "قەدبڕی دروستکراو زیادبکە"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "قەدبڕی دروستکراو زیادبکە"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "قەدبڕ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "هیچ قەدبڕی تەختەکلیلێک نەدۆزرایەوە"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "سڕینەوە"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "جێگرتنەوە"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Esc بکە بۆ هەڵوەشاندنەو یان Backspace بۆ ناچالاک کردنی قەدبڕی تەختەکلیل."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "ناو"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "فرمان"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "قەدبڕ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "قەدبڕ دابنێ..."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "نییە"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "قەدبڕەکە ڕێکبخەوە بۆ بەها بنەڕەتییەکەی خۆی"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "کامێراکەت بەکابێنە"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+#, fuzzy
+msgid "Keyboard"
+msgstr "_تەختەکلیلی شاشە"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr "قەبڕەکانی تەختەکلیل ببینە و بگۆڕە و هەڵبژاردەی نووسینەکەت دابنی"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:7
-msgid "input-keyboard"
-msgstr "input-keyboard"
-
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
 "قەدبڕ;شوێنکار;پەنجەرە;گۆڕینی قەبارە;زووم;جیاوازی;تێجوو;سەرچاوە;قفڵ;قەبارە;"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:68
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:318
-msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "خزمەتگوزارییەکانی شوێن"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
 msgstr ""
-"Esc بکە بۆ هەڵوەشاندنەو یان Backspace بۆ ناچالاک کردنی قەدبڕی تەختەکلیل."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:156
-#: panels/printers/pp-details-dialog.ui:40
-msgid "Name"
-msgstr "ناو"
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:168
-msgid "Command"
-msgstr "فرمان"
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:180
-msgid "Shortcut"
-msgstr "قەدبڕ"
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:259
-msgid "Set Shortcut…"
-msgstr "قەدبڕ دابنێ..."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:272
-msgid "None"
-msgstr "نییە"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "مایکرۆفۆن بێدەنگ کردن/لابردنی بێدەنگ کردن"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:303
-msgid "Enter the new shortcut"
-msgstr "قەدبڕە نوێییەکە تۆماربکە"
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "هیچ داوانامەیەک نەدۆزرایەوە"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:357
-msgid "Remove"
-msgstr "سڕینەوە"
+#: panels/microphone/cc-microphone-panel.ui:37
+#, fuzzy
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"بەکارهێنانی کامێرا ڕیگە ئەدات بە بەرنامەکان بتوانن وێنە بگرن و گرتەی ڤیدیۆ "
+"تۆمار بکەن. ئەگەر کامێراکە ناچالاک بێ، ئەوا بۆی هەیە کە بەرنامەکان نەتوانن "
+"بەڕێکوپێکی هەموو کارێکی وێنە و ڤیدیۆت بۆ ئەنجام بدەن."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:367
-msgid "Add"
-msgstr "زیادکردن"
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:382
-msgid "Replace"
-msgstr "جێگرتنەوە"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:395
-msgid "Set"
-msgstr "دانان"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:436
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "_ڕێکخستنەکانت تاقی بکەرەوە"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "گشتی"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "دوگمەی سەرەکی"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "فرمانی دوگمە فیزیاییەکان دادەنرێت لە مشکەکان و مشکەکانی لاپتۆپ"
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "چەپ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "ڕاست"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "گەڕان بۆ شوێن"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "مشک"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "خێرای مشک"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "پێچۆکه‌گه‌ری ناوەڕۆکەکە دەجوڵێنێت، نەک دیمەنەکە."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "پێچۆکه‌گه‌ری ناوەڕۆکەکە دەجوڵێنێت، نەک دیمەنەکە."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "چالاك"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "مشکی لاپتۆپ"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "خێرای مشکی لاپتۆپ"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "پەنجەی لێبدە بۆ کرتەکردن"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "پەنجەی لێبدە بۆ کرتەکردن"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "خێرای مشکی لاپتۆپ"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "پێچۆکه‌گه‌ری لێوار"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "دوو-لاگیر"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "کرتەکردن، جووت کرتەکردن، پێچۆکه‌گه‌ری تاقی بکەرەوە"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2438,1368 +1899,586 @@ msgid ""
 msgstr ""
 "هەستیاری مشکەکەت و مشکی لاپتۆپەکەت بگۆڕە و دەستە ڕاست یان چەپ دیاری بکە"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/mouse/gnome-mouse-panel.desktop.in.in:7
-msgid "input-mouse"
-msgstr "input-mouse"
-
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "تراکپاد;نیشاندەر;کرتە;پەنجە لێدان;جووت;دوگمە;گۆسووڕ;پێچۆکە;"
 
-#: panels/mouse/cc-mouse-panel.ui:37
-msgid "General"
-msgstr "گشتی"
-
-#: panels/mouse/cc-mouse-panel.ui:75
-msgid "Primary Button"
-msgstr "دوگمەی سەرەکی"
-
-#: panels/mouse/cc-mouse-panel.ui:94
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "فرمانی دوگمە فیزیاییەکان دادەنرێت لە مشکەکان و مشکەکانی لاپتۆپ"
-
-#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
-msgid "Left"
-msgstr "چەپ"
-
-#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
-msgid "Right"
-msgstr "ڕاست"
-
-#: panels/mouse/cc-mouse-panel.ui:169
-msgid "Mouse"
-msgstr "مشک"
-
-#: panels/mouse/cc-mouse-panel.ui:208
-msgid "Mouse Speed"
-msgstr "خێرای مشک"
-
-#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
-msgid "Double-click timeout"
-msgstr "وەستانی جووت-کلیک"
-
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
-msgid "Natural Scrolling"
-msgstr "پێچۆکه‌گه‌ری سروشتی"
-
-#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
-msgid "Scrolling moves the content, not the view."
-msgstr "پێچۆکه‌گه‌ری ناوەڕۆکەکە دەجوڵێنێت، نەک دیمەنەکە."
-
-#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
-msgid "Touchpad"
-msgstr "مشکی لاپتۆپ"
-
-#: panels/mouse/cc-mouse-panel.ui:501
-msgid "Touchpad Speed"
-msgstr "خێرای مشکی لاپتۆپ"
-
-#: panels/mouse/cc-mouse-panel.ui:560
-msgid "Tap to Click"
-msgstr "پەنجەی لێبدە بۆ کرتەکردن"
-
-#: panels/mouse/cc-mouse-panel.ui:612
-msgid "Two-finger Scrolling"
-msgstr "پێچۆکه‌گه‌ری دوو-پەنجە"
-
-#: panels/mouse/cc-mouse-panel.ui:665
-msgid "Edge Scrolling"
-msgstr "پێچۆکه‌گه‌ری لێوار"
-
-#: panels/mouse/cc-mouse-test.c:132 panels/mouse/cc-mouse-test.ui:25
-msgid "Try clicking, double clicking, scrolling"
-msgstr "کرتەکردن، جووت کرتەکردن، پێچۆکه‌گه‌ری تاقی بکەرەوە"
-
-#: panels/mouse/cc-mouse-test.c:137
-msgid "Five clicks, GEGL time!"
-msgstr "پێنج کرتە، کاتی (GEGL)ـە!"
-
-#: panels/mouse/cc-mouse-test.c:142
-msgid "Double click, primary button"
-msgstr "جووت کرتە، دوگمەی سەرەکی"
-
-#: panels/mouse/cc-mouse-test.c:142
-msgid "Single click, primary button"
-msgstr "تاک کرتە، دوگمەی سەرەکی"
-
-#: panels/mouse/cc-mouse-test.c:145
-msgid "Double click, middle button"
-msgstr "جووت کرتە، دوگمەی ناوەڕاست"
-
-#: panels/mouse/cc-mouse-test.c:145
-msgid "Single click, middle button"
-msgstr "تاک کرتە، دوگمەی ناوەڕاست"
-
-#: panels/mouse/cc-mouse-test.c:148
-msgid "Double click, secondary button"
-msgstr "جووت کرتە، دوگمەی لاوەکی"
-
-#: panels/mouse/cc-mouse-test.c:148
-msgid "Single click, secondary button"
-msgstr "تاک کرتە، دوگمەی لاوەکی"
-
-#. add proxy to device list
-#: panels/network/cc-network-panel.c:582
-msgid "Network proxy"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
 msgstr ""
 
-#. update title
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/net-vpn.c:66 panels/network/net-vpn.c:163
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: panels/network/cc-network-panel.c:648 panels/network/cc-wifi-panel.ui:306
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "ڕێکخەری دیاریکراوی ڕەنگ: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "%s مۆنیتەر"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "داوانامە ناسراوە"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "ئامێرەکان تر"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "پەیوەندی نوێ زیادبکە"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "دانەنراوە"
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "پەیوەستە"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "هەڵبژاردەکان..."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "خاڵی داخی Wi-Fi هەڵدەکەیت؟"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "ناوی ڕایەڵە"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "تێپەڕەوشە"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "تێپەڕەوشەی بەڕێوبەر"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "وشەی تێپەڕبوونی _ئێستا"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_هەڵی بکە"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "دۆخی فڕۆکە"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Wi-Fi، بلووتووس و ئینتەرنێتی خێرای مۆبایل ناچالاک دەکرێت"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "هیچ گونجێنەرێکی Wi-Fi نەدۆزرایەوە"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "دڵنیابە کە گونجێنەرێکی Wi-Fi پێوەکراوە و هەڵکراوە"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "دۆخی تەیارە هەڵکراوە"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "بیکوژێنەوە بۆ ئەوەی Wi-Fi بەکاربێنیت"
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "ئاگری داخی وای-فای"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_هەڵکردنی هۆتسپۆتی وایفای..."
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "ڕایەڵە دیارەکان"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "پێویستە بەڕێوبەری ڕایەڵە کاربکات"
+
+#: panels/network/cc-wifi-panel.ui:303
 msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr ""
 "ئۆو، هەنێکشت بە ‌هەڵەدا ڕۆشتوون. تکایە پەیوەندی بکە بە فرۆشیاری نەرمەکاڵاکەت."
 
-#: panels/network/cc-network-panel.c:654
-msgid "NetworkManager needs to be running."
-msgstr "پێوستە بەڕێوبەری ڕایەڵە کاربکات"
-
-#: panels/network/cc-network-panel.ui:68
-msgid "Other Devices"
-msgstr "ئامێرەکان تر"
-
-#: panels/network/cc-network-panel.ui:109
-#: panels/network/connection-editor/net-connection-editor.c:596
-msgid "VPN"
-msgstr "VPN"
-
-#: panels/network/cc-network-panel.ui:153
-msgid "Not set up"
-msgstr "دانەنراوە"
-
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:198
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.ui:102
-#: panels/network/net-device-ethernet.c:318
-#: panels/network/network-bluetooth.ui:76
-#: panels/network/network-ethernet.ui:102 panels/network/network-mobile.ui:414
-#: panels/network/network-vpn.ui:75
-msgid "Options…"
-msgstr "هەڵبژاردەکان..."
-
-#: panels/network/cc-wifi-panel.c:276
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:233
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.ui:56
-msgid "Airplane Mode"
-msgstr "دۆخی فڕۆکە"
-
-#: panels/network/cc-wifi-panel.ui:72
-msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
-msgstr "Wi-Fi، بلووتووس و ئینتەرنێتی خێرای مۆبایل ناچالاک دەکرێت"
-
-#: panels/network/cc-wifi-panel.ui:141
-msgid "No Wi-Fi Adapter Found"
-msgstr "هیچ گونجێنەرێکی Wi-Fi نەدۆزرایەوە"
-
-#: panels/network/cc-wifi-panel.ui:153
-msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
-msgstr "دڵنیابە کە گونجێنەرێکی Wi-Fi پێوەکراوە و هەڵکراوە"
-
-#: panels/network/cc-wifi-panel.ui:188
-msgid "Airplane Mode On"
-msgstr "دۆخی تەیارە هەڵکراوە"
-
-#: panels/network/cc-wifi-panel.ui:200
-msgid "Turn off to use Wi-Fi"
-msgstr "بیکوژێنەوە بۆ ئەوەی Wi-Fi بەکاربێنیت"
-
-#: panels/network/cc-wifi-panel.ui:227
-msgid "Visible Networks"
-msgstr "ڕایەڵە دیارەکان"
-
-#: panels/network/cc-wifi-panel.ui:295
-msgid "NetworkManager needs to be running"
-msgstr "پێویستە بەڕێوبەری ڕایەڵە کاربکات"
-
-#: panels/network/connection-editor/8021x-security-page.ui:20
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_ئاسایشی 802.1x"
 
-#: panels/network/connection-editor/8021x-security-page.ui:73
-#: panels/network/connection-editor/security-page.ui:72
-#: panels/wacom/wacom-stylus-page.ui:108
-msgid "page 1"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.ui:49
-#: panels/network/wireless-security/eap-method-peap.ui:52
-#: panels/network/wireless-security/eap-method-ttls.ui:51
-msgid "Anony_mous identity"
-msgstr "ناسنامەی نە_ناسراو"
-
-#: panels/network/connection-editor/8021x-security-page.ui:238
-#: panels/network/connection-editor/security-page.ui:237
-msgid "Inner _authentication"
-msgstr ""
-
-#: panels/network/connection-editor/8021x-security-page.ui:281
-#: panels/network/connection-editor/security-page.ui:280
-#: panels/wacom/wacom-stylus-page.ui:426
-msgid "page 2"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:112
-#: panels/network/connection-editor/ce-page-security.c:404
-#: panels/network/connection-editor/details-page.ui:90
-msgid "Security"
-msgstr "ئاسایش"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "ناوچەی پارێزراو"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "هەمیشەیی"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "هەڕەمەکی"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "جێگیر"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "خۆکار"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "زانیاریئ کەسیی %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:93
-#: panels/network/net-device-wifi.c:235
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:240
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:109
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:115
-msgid "Enterprise"
-msgstr "پرۆژەی ئابووری"
-
-#: panels/network/connection-editor/ce-page-details.c:120
-#: panels/network/net-device-wifi.c:225
-msgctxt "Wifi security"
-msgid "None"
-msgstr "نییە"
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:119
-#: panels/network/connection-editor/ce-page-details.c:141
-msgid "Never"
-msgstr "هه‌رگیز"
-
-#: panels/network/connection-editor/ce-page-details.c:156
-#: panels/network/net-device-ethernet.c:108
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i ڕۆژ لەمەو پێش"
 msgstr[1] "%i ڕۆژ لەمەو پێش"
 
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:283
-#: panels/network/net-device-ethernet.c:202
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:324
-msgctxt "Signal strength"
-msgid "None"
-msgstr "نییە"
-
-#: panels/network/connection-editor/ce-page-details.c:326
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "لاواز"
-
-#: panels/network/connection-editor/ce-page-details.c:328
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "باشە"
-
-#: panels/network/connection-editor/ce-page-details.c:330
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "باش"
-
-#: panels/network/connection-editor/ce-page-details.c:332
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "نایاب"
-
-#: panels/network/connection-editor/ce-page-details.c:429
-msgid "Forget Connection"
-msgstr "پەیوەستبوون لەبیربکە"
-
-#: panels/network/connection-editor/ce-page-details.c:431
-msgid "Remove Connection Profile"
-msgstr "پڕۆفایلی پەیوەستبوون بسڕەوە"
-
-#: panels/network/connection-editor/ce-page-details.c:433
-msgid "Remove VPN"
-msgstr "VPN بسڕەوە"
-
-#: panels/network/connection-editor/ce-page-details.c:451
-msgid "Details"
-msgstr "وردەکارییەکان"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:150
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "ناسنامە"
-
-#: panels/network/connection-editor/ce-page-ip4.c:268
-#: panels/network/connection-editor/ce-page-ip6.c:249
-msgid "Delete Address"
-msgstr "ناونیشان بسڕەوە"
-
-#: panels/network/connection-editor/ce-page-ip4.c:428
-#: panels/network/connection-editor/ce-page-ip6.c:398
-msgid "Delete Route"
-msgstr "ڕێگە بسڕەوە"
-
-#: panels/network/connection-editor/ce-page-ip4.c:852
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:783
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:260
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "نییە"
-
-#: panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit Key (Hex or ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:293
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit Passphrase"
-
-#: panels/network/connection-editor/ce-page-security.c:306
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:319
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamic WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:333
-msgid "WPA & WPA2 Personal"
-msgstr "WPA و WPA2 کەسی"
-
-#: panels/network/connection-editor/ce-page-security.c:347
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA و WPA2 پڕۆژەی ئابووری"
-
-#: panels/network/connection-editor/details-page.ui:18
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "هێزی نیشانە"
 
-#: panels/network/connection-editor/details-page.ui:54
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "خێرایی بەستەر"
 
-#: panels/network/connection-editor/ce-page-details.c:390
-#: panels/network/connection-editor/details-page.ui:108
-#: panels/network/net-device-ethernet.c:143
-#: panels/network/net-device-mobile.c:431
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "ئاسایش"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "ناونیشانی IPv4"
 
-#: panels/network/connection-editor/ce-page-details.c:391
-#: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-ethernet.c:148
-#: panels/network/net-device-mobile.c:432 panels/network/network-mobile.ui:200
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "ناونیشانی IPv6"
 
-#: panels/network/connection-editor/details-page.ui:144
-#: panels/network/net-device-ethernet.c:151
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "ناونیشانی ڕەقەکاڵا"
 
-#: panels/network/connection-editor/details-page.ui:180
-#: panels/network/net-device-ethernet.c:155
-#: panels/network/network-mobile.ui:217
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "زانیارییە کەسییەکانی ICC پشتگیریکراون"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "ڕیگەی بنەڕەت"
 
-#: panels/network/connection-editor/details-page.ui:199
-#: panels/network/connection-editor/ip4-page.ui:211
-#: panels/network/connection-editor/ip6-page.ui:225
-#: panels/network/net-device-ethernet.c:157
-#: panels/network/network-mobile.ui:235
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: panels/network/connection-editor/details-page.ui:217
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "داواین بەکارهێنان"
 
-#: panels/network/connection-editor/details-page.ui:376
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "_خۆکارانە پەیوەستببە"
 
-#: panels/network/connection-editor/details-page.ui:395
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "بەردەستیبکە بۆ بەکارهێنەرانی _دیکە"
 
-#: panels/network/connection-editor/details-page.ui:428
-msgid "Restrict _background data usage"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:439
-msgid "Appropriate for connections that have data charges or limits."
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: panels/diagnostics/cc-diagnostics-panel.ui:120
-#: panels/network/connection-editor/ip4-page.ui:223
-#: panels/network/connection-editor/ip4-page.ui:291
-#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_ناو"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "ناونیشانی _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "ناونێشانی _لێکچوو"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "بایت"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "شێوازی IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "(DHCP)ی خۆاکر"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "تەها بەستەری-ناوخۆیی"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "دەستکار"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "ناچالاککردن"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "ناونیشانەکان"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ناونیشان"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "دەمامکی تۆڕ"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "دەرەڕێ"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/connection-editor/ip6-page.ui:305
-#: panels/network/net-proxy.c:74 panels/network/network-proxy.ui:106
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "خۆکار"
 
-#: panels/network/connection-editor/ethernet-page.ui:19
-msgid "Twisted Pair (TP)"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:22
-msgid "Attachment Unit Interface (AUI)"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:25
-msgid "BNC"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:28
-msgid "Media Independent Interface (MII)"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:42
-msgid "10 Mb/s"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:45
-msgid "100 Mb/s"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:48
-msgid "1 Gb/s"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:51
-msgid "10 Gb/s"
-msgstr ""
-
-#: panels/network/connection-editor/ethernet-page.ui:25
-#: panels/network/connection-editor/vpn-page.ui:23
-msgid "_Name"
-msgstr "_ناو"
-
-#: panels/network/connection-editor/ethernet-page.ui:54
-#: panels/network/connection-editor/wifi-page.ui:67
-msgid "_MAC Address"
-msgstr "ناونیشانی _MAC"
-
-#: panels/network/connection-editor/ethernet-page.ui:105
-msgid "M_TU"
-msgstr "M_TU"
-
-#: panels/network/connection-editor/ethernet-page.ui:122
-#: panels/network/connection-editor/wifi-page.ui:102
-msgid "_Cloned Address"
-msgstr "ناونێشانی _لێکچوو"
-
-#: panels/network/connection-editor/ethernet-page.ui:137
-msgid "bytes"
-msgstr "بایت"
-
-#: panels/network/connection-editor/ip4-page.ui:27
-msgid "IPv_4 Method"
-msgstr "شێوازی IPv_4"
-
-#: panels/network/connection-editor/ip4-page.ui:42
-msgid "Automatic (DHCP)"
-msgstr "(DHCP)ی خۆاکر"
-
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
-msgid "Link-Local Only"
-msgstr "تەها بەستەری-ناوخۆیی"
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:121
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:72 panels/network/network-proxy.ui:116
-msgid "Manual"
-msgstr "دەستکار"
-
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
-msgid "Disable"
-msgstr "ناچالاککردن"
-
-#: panels/network/connection-editor/ip4-page.ui:125
-#: panels/network/connection-editor/ip6-page.ui:139
-msgid "Addresses"
-msgstr "ناونیشانەکان"
-
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
-#: panels/printers/pp-details-dialog.ui:95
-msgid "Address"
-msgstr "ناونیشان"
-
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
-msgid "Netmask"
-msgstr "دەمامکی تۆڕ"
-
-#: panels/network/connection-editor/ip4-page.ui:171
-#: panels/network/connection-editor/ip4-page.ui:355
-#: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:369
-msgid "Gateway"
-msgstr "دەرەڕێ"
-
-#: panels/network/connection-editor/ip4-page.ui:234
-#: panels/network/connection-editor/ip6-page.ui:248
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "DNSی خۆکار"
 
-#: panels/network/connection-editor/ip4-page.ui:258
-#: panels/network/connection-editor/ip6-page.ui:272
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "ناونیشانەکانی IP جیاکراوە لەگەڵ بۆرەکان"
 
-#: panels/network/connection-editor/ip4-page.ui:279
-#: panels/network/connection-editor/ip6-page.ui:293
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "ڕێگەکان"
 
-#: panels/network/connection-editor/ip4-page.ui:302
-#: panels/network/connection-editor/ip6-page.ui:316
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "ڕێگە خۆکارەکان"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:368
-#: panels/network/connection-editor/ip6-page.ui:382
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metric"
 
-#: panels/network/connection-editor/ip4-page.ui:398
-#: panels/network/connection-editor/ip6-page.ui:412
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "ئەم پەیوەندییە بەکاربێنە _تەنها بۆ سەرچاوەکان لەو ڕایەڵەیە"
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "شێوازی IPv_6"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "خۆکار، تەنها DHCP"
 
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "پێشگر"
 
-#: panels/network/connection-editor/net-connection-editor.c:291
-msgid "Unable to open connection editor"
-msgstr "ناتوانرێ دەستکاریکەری پەیوەندی بکرێتەوە"
-
-#: panels/network/connection-editor/net-connection-editor.c:307
-msgid "New Profile"
-msgstr "زانیاری کەسیی نوێ"
-
-#: panels/network/connection-editor/net-connection-editor.c:740
-msgid "Import from file…"
-msgstr "هێنان لە پەڕگە..."
-
-#: panels/network/connection-editor/net-connection-editor.c:772
-msgid "Add VPN"
-msgstr "VPN زیادبکە"
-
-#: panels/network/connection-editor/security-page.ui:20
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr ""
 
-#: panels/network/connection-editor/vpn-helpers.c:139
-msgid "Cannot import VPN connection"
-msgstr "ناتوانرێت پەیوەندی VPNبهێنرێت"
-
-#: panels/network/connection-editor/vpn-helpers.c:141
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:173
-msgid "Select file to import"
-msgstr "پەڕگە دیاریبکە بۆ هێنان"
-
-#: panels/network/connection-editor/vpn-helpers.c:225
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "پەڕگەیەک بە ناوی “%s” پێشتر بوونی هەیە."
-
-#: panels/network/connection-editor/vpn-helpers.c:227
-msgid "_Replace"
-msgstr "_جێگرتنەوە"
-
-#: panels/network/connection-editor/vpn-helpers.c:229
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:264
-msgid "Cannot export VPN connection"
-msgstr "ناتوانرێت پەیوەندی VPN هاوردەبکرێ"
-
-#: panels/network/connection-editor/vpn-helpers.c:266
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:296
-msgid "Export VPN connection"
-msgstr "پەیوەندی VPN هاوردەبکە"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr ""
 
-#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "ڕایەڵە"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr ""
 
-#. FIXME
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/connectivity/gnome-connectivity-panel.desktop.in.in:8
-#: panels/network/gnome-network-panel.desktop.in.in:7
-msgid "network-workgroup"
-msgstr "network-workgroup"
-
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr ""
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/network/gnome-wifi-panel.desktop.in.in:7
-msgid "network-wireless"
-msgstr "network-wireless"
-
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 
-#: panels/network/net-device-ethernet.c:96
-msgid "never"
-msgstr "هەرگیز"
-
-#: panels/network/net-device-ethernet.c:104
-msgid "today"
-msgstr "ئەمڕۆ"
-
-#: panels/network/net-device-ethernet.c:106
-msgid "yesterday"
-msgstr "دوێنێ"
-
-#: panels/network/connection-editor/ce-page-details.c:394
-#: panels/network/connection-editor/ce-page-details.c:395
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:435
-#: panels/network/net-device-mobile.c:436 panels/network/network-mobile.ui:183
-msgid "IP Address"
-msgstr "ناونیشانی پرۆتۆکۆڵی ئینتەرنێت"
-
-#: panels/network/net-device-ethernet.c:162
-msgid "Last used"
-msgstr "دواین بەکارهێنان"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:252
-#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "بەستراو بە وایەر"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "پەیوەندی نوێ زیادبکە"
-
-#: panels/network/net-device-wifi.c:1368
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1372
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.c:458
-msgid "Turn On Wi-Fi Hotspot?"
-msgstr "خاڵی داخی Wi-Fi هەڵدەکەیت؟"
-
-#: panels/network/net-device-wifi.c:1401
-msgid ""
-"Wi-Fi hotspots are usually used to share an additional Internet connection "
-"over Wi-Fi."
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.ui:130
-msgid "_Turn On"
-msgstr "_هەڵی بکە"
-
-#: panels/network/net-device-wifi.c:798
-msgid "Stop hotspot and disconnect any users?"
-msgstr "خاڵی داخ بوەستێنە و هەر بەکار‌هێنەرێک ناچالاک بکرێت؟"
-
-#: panels/network/net-device-wifi.c:801
-msgid "_Stop Hotspot"
-msgstr "خاڵیداخ _بوەستێنە"
-
-#: panels/network/net-device-wifi.c:1268
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1271
-msgid "Wireless device does not support Hotspot mode"
-msgstr "ئامێری بێتەل پشتگیری دۆخی خاڵی داخ ناکات"
-
-#: panels/network/net-device-wifi.c:905
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-
-#: panels/network/net-device-wifi.c:909
-msgid "_Forget"
-msgstr "_لەبیرکردن"
-
-#: panels/network/net-device-wifi.c:1065 panels/network/net-device-wifi.c:1072
-msgid "Known Wi-Fi Networks"
-msgstr "ڕایەڵەکانی وای-فای ناسراوە"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1107
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_لەبیرکردن"
-
-#: panels/network/net-proxy.c:70
-#: panels/notifications/cc-notifications-panel.c:267
-#: panels/power/cc-power-panel.c:2068 panels/power/cc-power-panel.c:2079
-#: panels/universal-access/cc-ua-panel.c:480
-#: panels/universal-access/cc-ua-panel.c:843
-#: panels/universal-access/cc-ua-panel.c:856
-#: panels/universal-access/cc-ua-panel.c:868
-#: panels/universal-access/cc-ua-panel.c:1033
-#: panels/universal-access/cc-ua-panel.ui:323
-#: panels/universal-access/cc-ua-panel.ui:369
-#: panels/universal-access/cc-ua-panel.ui:415
-#: panels/universal-access/cc-ua-panel.ui:521
-#: panels/universal-access/cc-ua-panel.ui:674
-#: panels/universal-access/cc-ua-panel.ui:720
-#: panels/universal-access/cc-ua-panel.ui:766
-#: panels/universal-access/cc-ua-panel.ui:950
-msgid "Off"
-msgstr "کوژاوەتەوە"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:113
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:121
-msgid "This is not recommended for untrusted public networks."
-msgstr ""
-
-#: panels/network/network-mobile.ui:29
-msgid "IMEI"
-msgstr "IMEI"
-
-#: panels/network/network-mobile.ui:47
-msgid "Provider"
-msgstr "دابینکەر"
-
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:95
-msgid "Network Proxy"
-msgstr "پرۆکسی ڕایەڵە"
-
-#: panels/network/network-proxy.ui:176
-msgid "_HTTP Proxy"
-msgstr ""
-
-#: panels/network/network-proxy.ui:195
-msgid "H_TTPS Proxy"
-msgstr "پرۆکسی H_TTPS"
-
-#: panels/network/network-proxy.ui:214
-msgid "_FTP Proxy"
-msgstr "پڕۆکسی _FTP"
-
-#: panels/network/network-proxy.ui:233
-msgid "_Socks Host"
-msgstr ""
-
-#: panels/network/network-proxy.ui:252
-msgid "_Ignore Hosts"
-msgstr "خانەخوێیەکان _پشتگوێبخە"
-
-#: panels/network/network-proxy.ui:290
-msgid "HTTP proxy port"
-msgstr ""
-
-#: panels/network/network-proxy.ui:367
-msgid "HTTPS proxy port"
-msgstr ""
-
-#: panels/network/network-proxy.ui:388
-msgid "FTP proxy port"
-msgstr ""
-
-#: panels/network/network-proxy.ui:409
-msgid "Socks proxy port"
-msgstr ""
-
-#: panels/network/network-proxy.ui:438
-msgid "_Configuration URL"
-msgstr ""
-
-#: panels/network/network-bluetooth.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "ئامێر بکوژێنەوە"
 
-#: panels/network/network-vpn.ui:55
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "چالاك"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "دابینکەر"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "ناونیشانی پرۆتۆکۆڵی ئینتەرنێت"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "پرۆکسی ڕایەڵە"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "پرۆکسی H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "پڕۆکسی _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "خانەخوێیەکان _پشتگوێبخە"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr ""
+
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "پەیوەندی VPN بکوژێنەوە"
 
-#: panels/network/network-wifi.ui:127
-msgid "Automatic _Connect"
-msgstr ""
-
-#: panels/network/network-wifi.ui:474
-msgid "details"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.ui:31
-#: panels/network/wireless-security/eap-method-simple.ui:31
-#: panels/network/wireless-security/ws-leap.ui:32
-#: panels/network/wireless-security/ws-wpa-psk.ui:14
-#: panels/sharing/cc-sharing-panel.ui:351
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:385
-msgid "_Password"
-msgstr "_تێپەڕەوشە"
-
-#: panels/network/network-wifi.ui:622
-msgid "Show P_assword"
-msgstr ""
-
-#: panels/network/network-wifi.ui:652
-msgid "Make available to other users"
-msgstr ""
-
-#: panels/network/network-wifi.ui:680
-msgid "identity"
-msgstr ""
-
-#: panels/network/network-wifi.ui:714
-msgid "IPv_4"
-msgstr ""
-
-#: panels/network/network-wifi.ui:755 panels/network/network-wifi.ui:1032
-msgid "_Addresses"
-msgstr ""
-
-#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
-msgid "Automatic (DHCP) addresses only"
-msgstr ""
-
-#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
-msgid "Link-local only"
-msgstr ""
-
-#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
-msgid "Shared with other computers"
-msgstr ""
-
-#: panels/network/network-wifi.ui:917 panels/network/network-wifi.ui:1194
-msgid "_Ignore automatically obtained routes"
-msgstr ""
-
-#: panels/network/network-wifi.ui:960
-msgid "ipv4"
-msgstr ""
-
-#: panels/network/network-wifi.ui:991
-msgid "IPv_6"
-msgstr ""
-
-#: panels/network/network-wifi.ui:1237
-msgid "ipv6"
-msgstr ""
-
-#: panels/network/network-wifi.ui:1277
-msgid "_Cloned MAC Address"
-msgstr ""
-
-#: panels/network/network-wifi.ui:1346
-msgid "_Reset"
-msgstr ""
-
-#: panels/network/network-wifi.ui:1382
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-
-#: panels/network/network-wifi.ui:1399
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-
-#: panels/network/network-wifi.ui:1472
-msgid "Hardware"
-msgstr ""
-
-#: panels/network/network-wifi.ui:1476
-msgctxt "tab"
-msgid "Reset"
-msgstr ""
-
-#: panels/network/network-wifi.ui:37
-msgid "Wi-Fi Hotspot"
-msgstr "ئاگری داخی وای-فای"
-
-#: panels/network/network-wifi.ui:55
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "بیکوژێنەوە بۆ ئەوەی پەیوەندی بکەی بە ئینتەرنێت"
-
-#: panels/network/cc-wifi-hotspot-dialog.ui:44
-#: panels/network/network-wifi.ui:105
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "ناوی ڕایەڵە"
 
-#: panels/network/network-wifi.ui:1621
-msgid "Connected Devices"
-msgstr ""
-
-#: panels/network/network-wifi.ui:123
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "جۆری ئاسایش"
 
-#: panels/network/network-wifi.ui:175
-msgctxt "Wi-Fi passkey"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "تێپەڕەوشە"
 
-#: panels/network/network-wifi.ui:264
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "وای-فای بکوژێنەوە"
 
-#: panels/network/network-wifi.ui:296
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "هەڵبژاردەکان..."
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_پەیوەندی بکە بە ڕایەڵەی شاراوە..."
 
-#: panels/network/network-wifi.ui:307
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_هەڵکردنی هۆتسپۆتی وایفای..."
 
-#: panels/network/network-wifi.ui:318
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "ڕایەڵەی وایفای _ناسراو"
-
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:127
-msgid "Ad-hoc"
-msgstr ""
-
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:131
-msgid "Infrastructure"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "دۆخ نەزانراوە"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "ڕێکنەخراوە"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "بەردەست نییە"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "پەیوەندی دەگرێت"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "ڕێپێدان پێویستە"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:63
-msgid "Connected"
-msgstr "پەیوەستە"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "لە پەیوەندی دەرچوون"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "پەیوەندی سەرکەوتوونەبوو"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "دۆخ نەزانراوە (بوونی نیە)"
-
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:223
-msgid "Not connected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "ڕێکخستن سەرکەوتوو نەبوو"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "مۆدیۆم نەدۆزرایەوە"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "پەیوەستبوونەوەی بلووتووس سەرکەوتوو نەبوو"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "سیم کارت تێنەخراوە"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252
-msgid "SIM wrong"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:351
-msgid "Firmware missing"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:355
-msgid "Cable unplugged"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:195
-msgid "no file selected"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:222
-msgid "unspecified error validating eap-method file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:400
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:87
-msgid "missing EAP-FAST PAC file"
-msgstr ""
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -3813,14 +2492,6 @@ msgstr "GTC"
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: panels/network/wireless-security/eap-method-fast.c:347
-msgid "Choose a PAC file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:352
-msgid "PAC files (*.pac)"
-msgstr ""
-
 #: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "نەناسراو"
@@ -3833,64 +2504,60 @@ msgstr "ڕێپێدرا"
 msgid "Both"
 msgstr "هەردووک"
 
-#: panels/network/wireless-security/eap-method-fast.ui:75
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "ناسنامەی نە_ناسراو"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.ui:115
-#: panels/network/wireless-security/eap-method-peap.ui:150
-#: panels/network/wireless-security/eap-method-ttls.ui:143
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.ui:144
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-leap.c:64
-msgid "missing EAP-LEAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.c:73
-msgid "missing EAP-LEAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.ui:17
-#: panels/network/wireless-security/eap-method-simple.ui:17
-#: panels/network/wireless-security/ws-leap.ui:18
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_ناوی بەکارهێنەر"
 
-#: panels/network/wireless-security/eap-method-leap.ui:55
-#: panels/network/wireless-security/eap-method-simple.ui:73
-#: panels/network/wireless-security/eap-method-tls.ui:157
-#: panels/network/wireless-security/ws-leap.ui:56
-#: panels/network/wireless-security/ws-wpa-psk.ui:64
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_تێپەڕەوشە"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "تێپەڕەوشە پشانبد_ە"
-
-#: panels/network/wireless-security/eap-method-peap.c:87
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:96
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
-
-#: panels/network/wireless-security/eap-method-peap.c:328
-#: panels/network/wireless-security/eap-method-tls.c:507
-#: panels/network/wireless-security/eap-method-ttls.c:336
-msgid "Choose a Certificate Authority certificate"
-msgstr ""
 
 #: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
@@ -3900,97 +2567,42 @@ msgstr "وەشان ٠"
 msgid "Version 1"
 msgstr "وەشان ١"
 
-#: panels/network/wireless-security/eap-method-peap.ui:78
-#: panels/network/wireless-security/eap-method-tls.ui:68
-#: panels/network/wireless-security/eap-method-ttls.ui:102
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-peap.ui:100
-#: panels/network/wireless-security/eap-method-tls.ui:90
-#: panels/network/wireless-security/eap-method-ttls.ui:125
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-peap.ui:118
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:91
-msgid "missing EAP-TLS identity"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:101
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:111
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:125
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:135
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:266
-msgid "Unencrypted private keys are insecure"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:269
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:500
-msgid "Choose your personal certificate"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:514
-msgid "Choose your private key"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.ui:17
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "ن_اسنامە"
 
-#: panels/network/wireless-security/eap-method-tls.ui:43
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-tls.ui:108
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-tls.ui:133
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:98
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:106
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
 msgstr ""
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
@@ -4009,20 +2621,20 @@ msgstr "MSCHAPv2 (no EAP)"
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.ui:76
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
 msgid "_Domain"
 msgstr "_دۆمەین"
-
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr ""
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4044,49 +2656,16 @@ msgstr "Tunneled TLS"
 msgid "Protected EAP (PEAP)"
 msgstr "Protected EAP (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:56
-#: panels/network/wireless-security/ws-wep-key.ui:102
-#: panels/network/wireless-security/ws-wpa-eap.ui:61
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "ڕێپێ_دان"
 
-#: panels/network/wireless-security/ws-leap.c:65
-msgid "missing leap-username"
-msgstr ""
-
-#: panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_جۆر"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4100,51 +2679,36 @@ msgstr "سیستەم بکەرەوە"
 msgid "Shared Key"
 msgstr "کلیلی بڵاوکراوە"
 
-#: panels/network/wireless-security/ws-wep-key.ui:48
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "_کلیل"
 
-#: panels/network/wireless-security/ws-wep-key.ui:84
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "کلیل پیشان_بدە"
 
-#: panels/network/wireless-security/ws-wep-key.ui:134
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr ""
 
-#: panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.ui:42
-msgid "_Type"
-msgstr "_جۆر"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:60
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "_ئاگادارکردنەوەکان"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:112
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr ""
 
-#: panels/notifications/cc-app-notifications-dialog.ui:168
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "دەرپەڕاندنی _ئاگادارنامەکان"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:184
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
@@ -4153,36 +2717,26 @@ msgstr ""
 "دەرپەڕاندنەکان ناچالاک دەکرێن."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:249
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "_ناوەڕۆکی پەیام پشانبدە لە دەڕپەڕاینەکان"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:300
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "ئاگادارنامەکانی  _قفڵی شاشەی"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:351
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "نا_وەڕۆکی پەیام پشانبدە لەسەر قفڵی شاشە"
 
-#: panels/notifications/cc-notifications-panel.c:267
-#: panels/power/cc-power-panel.c:2074 panels/power/cc-power-panel.c:2081
-#: panels/universal-access/cc-ua-panel.c:480
-#: panels/universal-access/cc-ua-panel.c:843
-#: panels/universal-access/cc-ua-panel.c:856
-#: panels/universal-access/cc-ua-panel.c:868
-#: panels/universal-access/cc-ua-panel.c:1033
-msgid "On"
-msgstr "هەڵکراوە"
-
-#: panels/notifications/cc-notifications-panel.ui:70
-msgid "Notification _Popups"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
 msgstr ""
 
-#: panels/notifications/cc-notifications-panel.ui:121
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr "ئاگادارنامەکانی  _قفڵی شاشەی"
 
@@ -4190,39 +2744,34 @@ msgstr "ئاگادارنامەکانی  _قفڵی شاشەی"
 msgid "Control which notifications are displayed and what they show"
 msgstr "کۆنتڕۆڵی چی ئاگادارنامەیەک پشانبدرێن و ئەوان چی پشانبدەن بکە"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/notifications/gnome-notifications-panel.desktop.in.in:7
-msgid "preferences-system-notifications"
-msgstr "preferences-system-notifications"
-
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "ئاگادارنامەکان;مانشێت;پەیام;ترەی;دەرپەڕیوو;"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:150
-msgctxt "Online Account"
-msgid "Other"
-msgstr "هیتر"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "گەڕانەوە"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:632
-#, c-format
-msgid "%s Account"
-msgstr "هەژماری %s"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "ڕێپێ_دان"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:929
-msgid "Error removing account"
-msgstr "هەڵەیەک ڕویدا لەکاتی سڕینەوەی هەژمار"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "پەیوەستبە بە دراوەکانتەوە لە هەورەکەت"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:994
-#, c-format
-msgid "<b>%s</b> removed"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
+"هیچ پەیوەندییەکی ئینتەرنێت نییە — پەیوەستبە بۆ ئەوەی هەژمارە سەرهێڵە "
+"نوێییەکان ڕێکبخەیت"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "هەژمار زیاد بکە"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4232,15 +2781,6 @@ msgstr "هەژمارەکانی سەرهێڵ"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "هەژمارە سەرهێڵەکانت پەیوەستبکە و بڕیاربدە بۆ چی بەکاریان بێنی"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:7
-msgid "goa-panel"
-msgstr "goa-panel"
-
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4249,479 +2789,182 @@ msgstr ""
 "گۆگڵ;فەیسبووک;تویتەر;یاهوو;تۆڕ;سەرهێل;دوان;ڕۆژژمێر;نامە;پەیوەندی;ئاونکڵاود;"
 "کیربیرەس;SMTP;IMAP;پۆکێت;ڕیدئتلەیتەر;"
 
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:54
-msgid "Undo"
-msgstr "گەڕانەوە"
-
-#: panels/online-accounts/online-accounts.ui:96
-msgid "Connect to your data in the cloud"
-msgstr "پەیوەستبە بە دراوەکانتەوە لە هەورەکەت"
-
-#: panels/online-accounts/online-accounts.ui:111
-msgid "No internet connection — connect to set up new online accounts"
-msgstr ""
-"هیچ پەیوەندییەکی ئینتەرنێت نییە — پەیوەستبە بۆ ئەوەی هەژمارە سەرهێڵە "
-"نوێییەکان ڕێکبخەیت"
-
-#: panels/online-accounts/online-accounts.ui:136
-msgid "Add an account"
-msgstr "هەژمار زیاد بکە"
-
-#: panels/online-accounts/online-accounts.ui:243
-msgid "Remove Account"
-msgstr "هەژمار بسڕەوە"
-
-#: panels/power/cc-power-panel.c:331
-msgid "Unknown time"
-msgstr "کات نەزانراوە"
-
-#: panels/power/cc-power-panel.c:337
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i خولەک"
 msgstr[1] "%i خولەک"
 
-#: panels/power/cc-power-panel.c:349
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i کاژێر"
 msgstr[1] "%i کاژێر"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-power-panel.c:357
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: panels/power/cc-power-panel.c:358
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "کاژێر"
 msgstr[1] "کاژێرەکان"
 
-#: panels/power/cc-power-panel.c:359
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "خوله‌ک"
 msgstr[1] "خولەک"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:377
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s تا بە تەواوی بارگاوی دەبێت"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:384
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "ئاگاداری: %s ماوە"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:389
-#, c-format
-msgid "%s remaining"
-msgstr "%s ماوە"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:394 panels/power/cc-power-panel.c:424
-msgid "Fully charged"
-msgstr "بەتەواویی بارگاوی کرا"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:398 panels/power/cc-power-panel.c:428
-msgid "Not charging"
-msgstr "بارگاوی نابێت"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:402 panels/power/cc-power-panel.c:432
-msgid "Empty"
-msgstr "بەتاڵ"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:415
-msgid "Charging"
-msgstr "بارگاوی کردن"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:420
-msgid "Discharging"
-msgstr "بارگاویناکرێ"
-
-#: panels/power/cc-power-panel.c:553
-msgctxt "Battery name"
-msgid "Main"
-msgstr "سەرەکی"
-
-#: panels/power/cc-power-panel.c:555
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "زیادە"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:630
-msgid "Wireless mouse"
-msgstr "مشکی بێ تەل"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:633
-msgid "Wireless keyboard"
-msgstr "تەختەکلیلی بێ تەل"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:636
-msgid "Uninterruptible power supply"
-msgstr "نەبڕینی سەرچاوەی وزە"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:639
-msgid "Personal digital assistant"
-msgstr "یاریدەدەری دیجیتاڵی کەسی"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:642
-msgid "Cellphone"
-msgstr "تەلەفۆنی پەیوەندی"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:645
-msgid "Media player"
-msgstr "لێدەری ڕەنگاڵە"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:648 panels/wacom/cc-wacom-panel.c:809
-msgid "Tablet"
-msgstr "تابلێت"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:651
-msgid "Computer"
-msgstr "کۆمپیتەر"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:654
-msgid "Gaming input device"
-msgstr "ئامێری تێچووی یاریکردن"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-power-panel.c:657 panels/power/cc-power-panel.c:939
-#: panels/power/cc-power-panel.c:2425
-msgid "Battery"
-msgstr "پاتری"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:718
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "بارگاوی کردن"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:725
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "ئاگاداری"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:730
-msgctxt "Battery power"
-msgid "Low"
-msgstr "نزم"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:735
-msgctxt "Battery power"
-msgid "Good"
-msgstr "باش"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:740
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "بەتەواویی بارگاوی کرا"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:744
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "بەتاڵ"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Batteries"
-msgstr "پاترییەکان"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d  کاژێر"
-msgstr[1] "%d  کاژێر"
-
-#: panels/common/cc-util.c:166
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d خولەک"
-msgstr[1] "%d خولەک"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d چرکە"
-msgstr[1] "%d چرکە"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:172
-#, c-format
-msgctxt "time"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:177
-#, c-format
-msgctxt "time"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:187
-msgid "0 seconds"
-msgstr "٠ چرکە"
-
-#: panels/power/cc-power-panel.c:1378
-msgid "When _idle"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1829
-msgid "Power Saving"
-msgstr "خەزنکردنی وزە"
-
-#: panels/power/cc-power-panel.c:1863
-msgid "_Screen Brightness"
-msgstr "_ڕووناکی شاشە"
-
-#: panels/power/cc-power-panel.c:1884
-msgid "Automatic Brightness"
-msgstr "ڕووناکی خودکار"
-
-#: panels/power/cc-power-panel.c:1897
-msgid "_Keyboard Brightness"
-msgstr "_ڕوونی تەختەکلیل"
-
-#: panels/power/cc-power-panel.c:1908
-msgid "_Dim Screen When Inactive"
-msgstr "شاشەکە _تاریک کاتێک بەکارناهێنرێت"
-
-#: panels/power/cc-power-panel.c:1926
-msgid "_Blank Screen"
-msgstr "شاشەی _بەتاڵ"
-
-#: panels/power/cc-power-panel.c:1949
-msgid "_Wi-Fi"
-msgstr "_وای-فای"
-
-#: panels/power/cc-power-panel.c:1950
-msgid "Wi-Fi can be turned off to save power."
-msgstr "دەتوانرێت وای-فای بکوژێنرێتەوە بۆ خەزنکردنی وزە."
-
-#: panels/power/cc-power-panel.c:1966
-msgid "_Mobile Broadband"
-msgstr "ئینتەرنێتی خێرای _مۆبایل"
-
-#: panels/power/cc-power-panel.c:1967
-msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
-msgstr ""
-"ئینتەرنێتی خێرای مۆبایل (LTE, 4G, 3G, هتد...) دەتوانرێت بکوژێندرێتەوە بۆ "
-"خەزنکردنی وزە."
-
-#: panels/power/cc-power-panel.c:2017
-msgid "_Bluetooth"
-msgstr "_بلووتووس"
-
-#: panels/power/cc-power-panel.c:2018
-msgid "Bluetooth can be turned off to save power."
-msgstr "بلووتووس دەتوانرێت بکوژێندرێتەوە بۆ خەزنکردنی وزە."
-
-#: panels/power/cc-power-panel.c:2070
-msgid "When on battery power"
-msgstr "کاتێک لەسەر وزەی پاتریت"
-
-#: panels/power/cc-power-panel.c:2072
-msgid "When plugged in"
-msgstr "کاتێک بارگاوی دەبێت"
-
-#: panels/power/cc-power-panel.c:2166
-msgid "Suspend"
-msgstr "ڕاگرتن"
-
-#: panels/power/cc-power-panel.c:2167
-msgid "Power Off"
-msgstr "بیکوژێنەوە"
-
-#: panels/power/cc-power-panel.c:2168
-msgid "Hibernate"
-msgstr "دۆخەپشوو"
-
-#: panels/power/cc-power-panel.c:2169
-msgid "Nothing"
-msgstr "هیچ نەکات"
-
-#. Frame header
-#: panels/power/cc-power-panel.c:2269
-msgid "Suspend & Power Button"
-msgstr "دۆخەپشو و دوگمەی وزە"
-
-#: panels/power/cc-power-panel.c:2310
-msgid "_Automatic Suspend"
-msgstr "دۆخەپشووی _خوودکار"
-
-#: panels/power/cc-power-panel.c:2311
-msgid "Automatic suspend"
-msgstr "دۆخەپشووی خوودکار"
-
-#: panels/power/cc-power-panel.c:2369
-msgid "Po_wer Button Action"
-msgstr "کاری دووگمەی و_زە"
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "١٥ خولەک"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "٢٠ خولەک"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "٢٥ خولەک"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "٣٠ خولەک"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "٤٥ خولەک"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "١ کاژێر"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "٨٠ خولەک"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "٩٠ خولەک"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "١٠٠ خولەک"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "٢ کاژێر"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:209 panels/power/cc-power-panel.ui:63
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "١ خولەک"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "پاتری"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:213 panels/power/cc-power-panel.ui:67
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "٢ خولەک"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ئامێرەکان"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:217 panels/power/cc-power-panel.ui:71
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "٣ خولەک"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "وزە"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:221 panels/power/cc-power-panel.ui:75
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "٤ خولەک"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:225 panels/power/cc-power-panel.ui:79
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "۵ خولەک"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "خەزنکردنی وزە"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:229 panels/power/cc-power-panel.ui:83
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "٨ خولەک"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "ڕووناکی خودکار"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:233 panels/power/cc-power-panel.ui:87
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "۱۰ خولەک"
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:237 panels/power/cc-power-panel.ui:91
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "١٢ خولەک"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "شاشە"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:241 panels/power/cc-power-panel.ui:95
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "۱٥ خولەک"
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:245 panels/power/cc-power-panel.ui:99
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "هه‌رگیز"
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "خوێنەری _پەردە"
 
-#: panels/power/cc-power-panel.ui:147
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "ڕێگە خۆکارەکان"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "دۆخەپشووی _خوودکار"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "کاری دووگمەی و_زە"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "دۆخەپشووی خودکار"
 
-#: panels/power/cc-power-panel.ui:172
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_بارگاوی دەکرێت"
 
-#: panels/power/cc-power-panel.ui:188
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "لە سەر وزەی _پاتری"
 
-#: panels/power/cc-power-panel.ui:233 panels/power/cc-power-panel.ui:293
-#: panels/universal-access/cc-ua-panel.ui:1527
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "دواخستن"
 
@@ -4733,89 +2976,13 @@ msgstr "وزە"
 msgid "View your battery status and change power saving settings"
 msgstr "دۆخی پاترییەکەت ببینە و ڕێکخستنەکانی خەزنکردنی وزە بگۆڕە"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/power/gnome-power-panel.desktop.in.in:7
-msgid "gnome-power-manager"
-msgstr "gnome-power-manager"
-
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "وزە;خەوتن;وەستان;دۆخەپشوو;پاتری;ڕووناکی;تاریک;بەتاڵ;مۆنیتەر;DPMS;بەفیڕۆچوون;"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "رێگەپێدان"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/new-printer-dialog.ui:362
-#: panels/printers/pp-jobs-dialog.ui:57
-msgid "Username"
-msgstr "ناوی بەکارهێنەر"
-
-#. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:69
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:383
-#: panels/printers/pp-jobs-dialog.ui:70
-#: panels/user-accounts/cc-add-user-dialog.ui:249
-msgid "Password"
-msgstr "تێپەڕەوشە"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:337
-msgid "Authentication Required"
-msgstr "ڕێگەپێدان داواکراوە"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:700
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "چاپکەری “%s” سڕاوەتەوە"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:923
-msgid "Failed to add new printer."
-msgstr "زیادکردنی چاپکەری نوێ سەرنەکەوت."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1236
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ناتوانرێت ui بار بکرێت: %s"
-
-#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
-msgid "Location"
-msgstr "شوێن"
-
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:122
-#: panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "وەگەڕخەر"
-
-#: panels/printers/pp-details-dialog.ui:162
-msgid "Searching for preferred drivers…"
-msgstr "بگەڕێ بۆ وەگەڕخەری پەسەندکراو..."
-
-#: panels/printers/pp-details-dialog.ui:183
-msgid "Search for Drivers"
-msgstr "بگەڕێ بۆ وەگەڕخەرەکان"
-
-#: panels/printers/pp-details-dialog.ui:192
-msgid "Select from Database…"
-msgstr "لە بنکەداروەوە دیاریبکە..."
-
-#: panels/printers/pp-details-dialog.ui:201
-msgid "Install PPD File…"
-msgstr "پەڕگەی PPD دابمەزرێنە..."
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4825,1374 +2992,635 @@ msgstr "چاپکەرەکان"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "پرێنتەرەکان زیادبکە، کارەکانی پرێنتەر ببینە و  بڕیاربدە چۆن چاپبکەیت"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/printers/gnome-printers-panel.desktop.in.in:7
-msgid "printer"
-msgstr "printer"
-
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "چاپکەر;ڕیز;چاپکردن;کاخەز;مرەکەب;تەنەر;"
 
-#. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/pp-jobs-dialog.ui:44
-msgid "Domain"
-msgstr "دۆمەین"
-
-#. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:129
-msgid "A_uthenticate"
-msgstr "ڕ_ێگەپێبدە"
-
-#. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:169
-msgid "Clear All"
-msgstr "هه‌مووی پاک بکه‌ره‌وه‌"
-
-#. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:232
-msgid "_Authenticate"
-msgstr "ـڕێیپێبدە"
-
-#. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:358
-msgid "No Active Printer Jobs"
-msgstr "هیچ چاپکەرێکی چالاک کارناکات"
-
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:363
-#: panels/printers/pp-new-printer-dialog.c:427
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "چاپکەر زیادبکە"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_بیکەرەوە"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "هیچ لە چاپکەرەکان نەدۆزرانەوە"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "ناونیشانی ڕایەڵەکەت بنووسە یان بگەڕی بۆ چاپکەرەکەت"
 
-#: panels/printers/new-printer-dialog.ui:353
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "ڕێگەپێدان داواکراوە"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "ناوی بەکارهێنەر و تێپەڕەوشە بنوسە بۆ بینینی چاپکەرەکان و ڕاژەی چاپکردن."
 
-#. Translators: Name of job which makes printer to print test page
-#. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:869
-#: panels/printers/pp-options-dialog.ui:18
-msgid "Test Page"
-msgstr "پەڕەی تاقیکردنەوە"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ناوی بەکارهێنەر"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:75
-#: panels/printers/pp-details-dialog.c:370
-#, c-format
-msgid "%s Details"
-msgstr "%s وردەکارییەکان"
-
-#: panels/printers/pp-details-dialog.c:122
-msgid "No suitable driver found"
-msgstr "وەگەڕخەری گونجاو نەدۆزرایەوە"
-
-#: panels/printers/pp-details-dialog.c:249
-msgid "Select PPD File"
-msgstr "پەڕگەی PPD دیاریبکە"
-
-#: panels/printers/pp-details-dialog.c:258
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"فایلەکانی پێناسی چاپکەرەکانی پۆست-سکریپت (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD.GZ)"
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "شوێن"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "وەگەڕخەر"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "بگەڕێ بۆ وەگەڕخەری پەسەندکراو..."
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "بگەڕێ بۆ وەگەڕخەرەکان"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "لە بنکەداروەوە دیاریبکە..."
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "پەڕگەی PPD دابمەزرێنە..."
+
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "وەگەڕخەری چاپکەر دیاریبکە"
 
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:109
-msgid "Select"
-msgstr "دیاریکردن"
-
-#: panels/printers/ppd-selection-dialog.ui:73
+#: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "بنکەدراوی وەگەڕخەرەکان باردەکرێن..."
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:479
-msgid "JetDirect Printer"
-msgstr "چاپکەری جێت-دایرێکت"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "هه‌ڵوه‌شاندنه‌وه‌"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:714
-msgid "LPD Printer"
-msgstr "چاپکەری LPD"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "دیاریکردن"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:65
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "یەک لاگیری"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:67
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "لێواری درێژ (ئاسایی)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:69
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "لێواری کورت (هەڵگەڕاوە)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:71
-msgid "Portrait"
-msgstr "ستوونی"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:73
-msgid "Landscape"
-msgstr "ئاسۆی"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:75
-msgid "Reverse landscape"
-msgstr "ئاسۆیی هەڵگەڕاوە"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:77
-msgid "Reverse portrait"
-msgstr "ستوونی هەڵگەڕاوە"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-jobs-dialog.c:222
-msgctxt "print job"
-msgid "Pending"
-msgstr "لەچاوەڕوانیدایە"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-jobs-dialog.c:228
-msgctxt "print job"
-msgid "Paused"
-msgstr "ڕاگیرا"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-jobs-dialog.c:233
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "ڕێپێدان پێویستە"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-jobs-dialog.c:238
-msgctxt "print job"
-msgid "Processing"
-msgstr "لە کاردایا"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-jobs-dialog.c:242
-msgctxt "print job"
-msgid "Stopped"
-msgstr "وەستێنرا"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-jobs-dialog.c:246
-msgctxt "print job"
-msgid "Canceled"
-msgstr "هەڵوەشێنرایەوە"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-jobs-dialog.c:250
-msgctxt "print job"
-msgid "Aborted"
-msgstr "لەباربرا"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-jobs-dialog.c:254
-msgctxt "print job"
-msgid "Completed"
-msgstr "تەواوبوو"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:363
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "کاری %u پێویستی بە ڕێگەپێدان هەیە"
 msgstr[1] "کارەکانی %u پێویستی بە ڕێگەپێدان هەیە"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:520
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — کارا چالاکەکان"
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "دۆمەین"
 
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:524
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "بەڵگەنامەی باوەڕپێکردن بنووسە بۆ چاپکردن لە %s"
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "ڕ_ێگەپێبدە"
 
-#: panels/printers/pp-new-printer-dialog.c:380
-msgid "Unlock Print Server"
-msgstr "ڕاژەی چاپکەر بکەرەوە"
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "هه‌مووی پاک بکه‌ره‌وه‌"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:384
-#, c-format
-msgid "Unlock %s."
-msgstr "%s بکەرەوە."
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "ـڕێیپێبدە"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:388
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "ناوی بەکارهێنەر و تێپەڕەوشە بنووسە بۆ بینینی چاپکەرەکان لە %s."
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "هیچ چاپکەرێکی چالاک کارناکات"
 
-#: panels/printers/pp-new-printer-dialog.c:838
-msgid "Searching for Printers"
-msgstr "بگەڕی بۆ چاپکەرەکان"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1697
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1702
-msgid "Serial Port"
-msgstr "دەرچەی زنجیرەیی"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1709
-msgid "Parallel Port"
-msgstr "دەرچەی هاوشان"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1751
-#, c-format
-msgid "Location: %s"
-msgstr "شوێن: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1756
-#, c-format
-msgid "Address: %s"
-msgstr "ناونیشان: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1783
-msgid "Server requires authentication"
-msgstr "ڕاژەکان پێویستی بە ڕێگەپێدانە"
-
-#: panels/printers/pp-options-dialog.c:91
-msgid "Two Sided"
-msgstr "دوو لاگیری"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "Paper Type"
-msgstr "جۆری کاخەز"
-
-#: panels/printers/pp-options-dialog.c:93
-msgid "Paper Source"
-msgstr "سەرچاوەی کاخەز"
-
-#: panels/printers/pp-options-dialog.c:94
-msgid "Output Tray"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:95
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "وردی نیشاندانی شاشە"
-
-#: panels/printers/pp-options-dialog.c:96
-msgid "GhostScript pre-filtering"
-msgstr "لەپێش فلتەرکردنی گۆست-سکریپت"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:534
-msgid "Pages per side"
-msgstr "پەڕەکانی لاگیر"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:546
-msgid "Two-sided"
-msgstr "دوو-لاگیر"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:558
-msgid "Orientation"
-msgstr "ئاڕاستە"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "گشتی"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "ڕێکخستنی پەڕە"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "هەڵبژاردنەکانی دامەزراندن"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "کار"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "جۆرایەتی وێنە"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "ڕەنگ"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "کۆتاییهێنان"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:676
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "پەرەسەندوو"
-
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:882
-msgid "Test page"
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
 msgstr "پەڕەی تاقیکردنەوە"
 
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "دیاریکردنی خودکار"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "چاپکەری بنەڕەت"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "تەنها فۆنتەکانی گۆست-سکریپت بگونجێنە"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "بیگۆڕە بۆ PSی ئاستی ١"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "بیگۆڕە بۆ PSی ئاست ٢"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "پاڵوتنی پێشوەختە نییە"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "دامەزراوە"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:594 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr "هیچ لە کاراکان چالاک نین"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:599
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u کار"
 msgstr[1] "%u کارەکان"
 
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:745
-msgid "Low on toner"
-msgstr "مەرەکەبی کەمە"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:747
-msgid "Out of toner"
-msgstr "مەرەکەبی تیا نییە"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:750
-msgid "Low on developer"
-msgstr "گەشەپێدەری وێنەی کەمە"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:753
-msgid "Out of developer"
-msgstr "گەشەپێدەری وێنەی نییە"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:755
-msgid "Low on a marker supply"
-msgstr "سەرچاوەی ئاماژەپێدەری  کەمە"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:757
-msgid "Out of a marker supply"
-msgstr "سەرچاوەی ئاماژەپێدەری  نییە"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:759
-msgid "Open cover"
-msgstr "بەرگ بکەوە"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:761
-msgid "Open door"
-msgstr "دەرگا بکەوە"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:763
-msgid "Low on paper"
-msgstr "لە نزمی پەڕە"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:765
-msgid "Out of paper"
-msgstr "لە دەرەوە پەڕە"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:767
-msgctxt "printer state"
-msgid "Offline"
-msgstr "دەرهێڵ"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:769
-#: panels/printers/pp-printer-entry.c:897
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "وەستێنرا"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:771
-msgid "Waste receptacle almost full"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:773
-msgid "Waste receptacle full"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:775
-msgid "The optical photo conductor is near end of life"
-msgstr "گەیەنەری وێنەی بینیەکە لە کۆتایی تەمەنیەتی (لە کار دەکەوێت)"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:777
-msgid "The optical photo conductor is no longer functioning"
-msgstr "گەیەنەری وێنەی بینیەکە لەمەودوا کار ناکات"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:883
-msgctxt "printer state"
-msgid "Ready"
-msgstr "ئامادەیە"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:888
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "کارەکان قبوڵ نەکرا"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:893
-msgctxt "printer state"
-msgid "Processing"
-msgstr "لە کاردایا"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:917
-msgid "Clean print heads"
-msgstr "سەرەکانی چاپکردن پاکبکەوە"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "هەڵبژاردەکانی چاپکردن"
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "زانیارییەکانی چاپکەر"
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "چاپکەر بەکاربێنە بە بنەڕەت"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "سەرەکانی چاپکردن پاکبکەوە"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "چاپکەر بسڕەوە"
 
-#: panels/printers/printer-entry.ui:193
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "هیچ لە کاراکان چالاک نین"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "مۆدێل"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "ئاستی مەرەکەب"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:312
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "تکایە سیستم پێبکەرەوە کە کیشەکە چارەسەر بوو."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:319
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "دووبارە پێکردنەوە"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:8
-msgid "Add…"
-msgstr "زیادبکە..."
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "چاپکەرێک زیادبکە..."
 
-#: panels/printers/printers.ui:150 panels/printers/printers.ui:238
+#: panels/printers/printers.ui:134
 msgid "Additional Printer Settings…"
 msgstr "ڕێکخستنی زیاتری چاپکەر..."
 
-#: panels/printers/printers.ui:206
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "هیچ لە چاپکەرەکان نییە"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:220
-msgid "Add a Printer…"
-msgstr "چاپکەرێک زیادبکە..."
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:268
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "ببورە! خزمەتگوزاری چاپکردنی سیستەمەکە \n"
 "وادیار نییە بەردەستبێت."
 
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "قفڵی شاشە"
-
-#: panels/privacy/cc-privacy-panel.c:466
-msgid "In use"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:471
-msgctxt "Location services status"
-msgid "On"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:472
-msgctxt "Location services status"
-msgid "Off"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:926
-msgctxt "Camera status"
-msgid "Off"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:928
-msgctxt "Camera status"
-msgid "On"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:959
-msgctxt "Microphone status"
-msgid "Off"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:961
-msgctxt "Microphone status"
-msgid "On"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:974 panels/privacy/privacy.ui:127
-msgid "Usage & History"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:155
-msgid "Empty all items from Trash?"
-msgstr "پاککردنەوەی هەموو بڕگەکان لە ناو تەنەکە خۆڵ؟"
-
-#: panels/usage/cc-usage-panel.c:156
-msgid "All items in the Trash will be permanently deleted."
-msgstr "هەموو بڕگە و پەڕەکانی ناو گڵێشدان بە هەمیشەیی دەسڕێنەوە."
-
-#: panels/usage/cc-usage-panel.c:157
-msgid "_Empty Trash"
-msgstr "ته‌نه‌که‌ی فڕێدان _به‌تاڵکه‌"
-
-#: panels/usage/cc-usage-panel.c:178
-msgid "Delete all the temporary files?"
-msgstr "سڕینەوەی هەموو پەڕگە کاتییەکان؟"
-
-#: panels/usage/cc-usage-panel.c:179
-msgid "All the temporary files will be permanently deleted."
-msgstr "هەموو پەڕگە کاتییەکان بۆ هەمیشە دەسڕێنەوە."
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "_Purge Temporary Files"
-msgstr "_لەناوبردنی پەڕگە کاتییەکان"
-
-#: panels/privacy/cc-privacy-panel.c:1152 panels/privacy/privacy.ui:432
-msgid "Purge Trash & Temporary Files"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:1192 panels/privacy/privacy.ui:637
-msgid "Software Usage"
-msgstr ""
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:30
-msgid "Problem Reporting"
-msgstr "ڕاپۆرتکردنی کێشە"
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: panels/diagnostics/cc-diagnostics-panel.c:256
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:1363 panels/privacy/privacy.ui:750
-msgid "Privacy Policy"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:1469 panels/privacy/privacy.ui:1180
-msgid "Connectivity Checking"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:166
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "شاشە دەکوژێتەوە"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:170
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "٣٠ چرکە"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:174
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "١ خولەک"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:178
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "٢ خولەک"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:182
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "٣ خولەک"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:186
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "۵ خولەک"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:190
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "۳۰ خولەک"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:194
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "١ کاژێر"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:280
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "١ کاژێر"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:284
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "١ ڕۆژ"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:288
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "۲ ڕۆژ"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:292
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "٣ ڕۆژ"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:296
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "٤ ڕۆژ"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:300
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "٥ ڕۆژ"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:304
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "٦ ڕۆژ"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:308
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "٧ ڕۆژ"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:312
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "١٤ ڕۆژ"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:316
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "٣٠ ڕۆژ"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:331
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 ڕۆژ"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:335
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "٧ ڕۆژ"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:339
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "٣٠ ڕۆژ"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:343
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "هەتا هەتایە"
-
-#: panels/privacy/privacy.ui:148
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-
-#: panels/privacy/privacy.ui:176
-msgid "_Recently Used"
-msgstr ""
-
-#: panels/privacy/privacy.ui:207
-msgid "Retain _History"
-msgstr ""
-
-#: panels/privacy/privacy.ui:247
-msgid "Cl_ear Recent History"
-msgstr ""
-
-#: panels/privacy/privacy.ui:301
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:67
-msgid "Automatic Screen _Lock"
-msgstr "_قفڵی شاشەی خودکار"
-
-#: panels/privacy/privacy.ui:362
-msgid "Lock screen _after blank for"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:105
-msgid "Lock Screen on Suspend"
-msgstr "شاشەکە قفڵ بکە لە ڕاگرتن"
-
-#: panels/privacy/cc-privacy-panel.ui:425
-msgid "Lock Screen _Notifications"
-msgstr ""
-
-#: panels/privacy/privacy.ui:454
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-
-#: panels/privacy/privacy.ui:483
-msgid "Automatically empty _Trash"
-msgstr ""
-
-#: panels/privacy/privacy.ui:515
-msgid "Automatically purge Temporary _Files"
-msgstr ""
-
-#: panels/privacy/privacy.ui:546
-msgid "Purge _After"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.ui:240
-msgid "_Empty Trash…"
-msgstr "_بەتاڵکردنی تەنەکەخۆڵ..."
-
-#: panels/privacy/privacy.ui:606
-msgid "_Purge Temporary Files…"
-msgstr ""
-
-#: panels/privacy/privacy.ui:654
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-
-#: panels/privacy/privacy.ui:681
-msgid "_Send software usage statistics"
-msgstr ""
-
-#: panels/camera/cc-camera-panel.ui:77
-msgid ""
-"Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
-msgstr ""
-"بەکارهێنانی کامێرا ڕیگە ئەدات بە بەرنامەکان بتوانن وێنە بگرن و گرتەی ڤیدیۆ "
-"تۆمار بکەن. ئەگەر کامێراکە ناچالاک بێ، ئەوا بۆی هەیە کە بەرنامەکان نەتوانن "
-"بەڕێکوپێکی هەموو کارێکی وێنە و ڤیدیۆت بۆ ئەنجام بدەن."
-
-#: panels/privacy/cc-privacy-panel.ui:843
-msgid "_Camera"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.ui:900
-msgid ""
-"Use of the microphone allows applications to capture sounds. Disabling the "
-"microphone may cause some applications to not function properly."
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.ui:948
-msgid "_Microphone"
-msgstr ""
-
-#: panels/location/cc-location-panel.ui:74
-msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"خزمەتگوزارییەکانی شوین دەهێڵێت بەرنامەکان شوێنەکەت بزانێت.Wi-Fi و دەستەی "
-"بێسنووری مۆبایل بەکاربینە بۆ زیادکردنی دروست."
-
-#: panels/location/cc-location-panel.ui:83
-msgid ""
-"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
-msgstr ""
-"مۆزێلا خزمەتگوزاری شوێنی بەکاردەهێنێت: <a href='https://location.services."
-"mozilla.com/privacy'>سیاسەتی تایبەتی</a>"
-
-#: panels/privacy/privacy.ui:859
-msgid "_Location Services"
-msgstr ""
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:67
-msgid "_Automatic Problem Reporting"
-msgstr ""
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:101
-msgid "Send error reports to Canonical"
-msgstr "ڕاپۆرتەکانی هەڵە بنێرە بۆ کانۆنیکاڵ"
-
-#: panels/privacy/privacy.ui:1131
-msgid "Send reports automatically"
-msgstr ""
-
-#: panels/privacy/privacy.ui:1149
-msgid "Show a dialog for each error before reporting"
-msgstr ""
-
-#: panels/connectivity/cc-connectivity-panel.ui:28
-msgid ""
-"Connectivity checking is used to detect connection issues and helps you to "
-"stay online. If your network communications are being monitored, it could be "
-"used to gather technical information about this computer."
-msgstr ""
-"پشکنینی پەیوەستێتی بەکاردێ بۆ دۆزینەوەی  کێشەکانی پەیوەندی و یارمەتیت دەدا "
-"سەرهێڵ بمێنیتەوە. ئەگەر ئاڵوگۆڕکردنەکانی ڕایەڵەکەت چاودێری بکرێت، دەتوانرێت "
-"بەکاربهێنرێت بۆ کۆکردنەوەی زانیری تەکنیکی دەربارەی ئەم کۆمپیتەرە."
-
-#: panels/connectivity/cc-connectivity-panel.ui:42
-msgid "_Connectivity Checking"
-msgstr "_گەڕان بۆ پەیوەنددارێتی"
-
-#: shell/cc-panel-list.ui:45 shell/cc-window.c:277
-msgid "Privacy"
-msgstr "تایبەتێتی"
-
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-
-#. FIXME
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:8
-msgid "preferences-system-privacy"
-msgstr ""
-
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"شاشە;قفڵ;دەستنیشانکاری;تێکشکان;تایبەتی;نوێترین;کاتی;tmp;نیشاندەر;ناو;ڕایەڵە;"
-"ناسنامه;"
-
-#: panels/region/cc-format-chooser.c:148
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "شاهانە"
-
-#: panels/region/cc-format-chooser.c:150
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metric"
-
-#: panels/region/cc-format-chooser.c:314
-msgid "No regions found"
-msgstr ""
-
-#: panels/region/cc-format-chooser.c:255 panels/region/cc-format-chooser.c:296
-#: panels/region/cc-format-chooser.ui:6
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "فۆرماتەکان"
 
-#: panels/region/cc-format-chooser.ui:309
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "گەڕان بۆ شوێن"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "فۆرماتەکان"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "فۆرماتەکان"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "هیچ ئەنجامێک نەدۆزرایەوە"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "پێشبینین"
 
-#: panels/region/cc-format-chooser.ui:324
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "ڕێکەوتەکان"
 
-#: panels/region/cc-format-chooser.ui:368
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "ڕێکەوت و کات"
 
-#: panels/region/cc-format-chooser.ui:390
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "ژمارەکان"
 
-#: panels/region/cc-format-chooser.ui:412
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "پێوانەکردن"
 
-#: panels/region/cc-format-chooser.ui:434
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "پەڕە"
 
-#: panels/region/cc-input-chooser.c:193
-msgid "No input sources found"
-msgstr "سەرچاوەی تێخستن نەدۆزرایەوە"
-
-#: panels/region/cc-input-chooser.c:948
-msgctxt "Input Source"
-msgid "Other"
-msgstr "هیتر"
-
-#: panels/region/cc-input-chooser.ui:5
-msgid "Add an Input Source"
-msgstr "سەرچاوی تێخستن زیادبکە"
-
-#: panels/region/cc-input-chooser.ui:77
-msgid "Input methods can’t be used on the login screen"
-msgstr "شێوازەکانی تێچووەکە ناتوانرێ بەکاربهێنرێت لەسەر قفڵی شاشەکە"
-
-#: panels/region/cc-region-panel.c:1586
-msgid "Login _Screen"
-msgstr "پەردەی _چوونەژوورەوە"
-
-#: panels/region/cc-region-panel.ui:64
-#: panels/user-accounts/cc-user-panel.ui:313
-msgid "_Language"
-msgstr "_زمان"
-
-#: panels/region/cc-region-panel.ui:99
-msgid "Restart the session for changes to take effect"
-msgstr "دانیشتن پێبکەرەوە بۆ ئەنجامدانی گۆڕانکارییەکان"
-
-#: panels/region/cc-region-panel.ui:114
-msgid "Restart…"
-msgstr "پێکردنەوە..."
-
-#: panels/region/cc-region-panel.ui:147
-msgid "_Formats"
-msgstr "_ڕێکخستنەکان"
-
-#: panels/region/cc-region-panel.ui:195
-msgid "Input Sources"
-msgstr "سەرچاوەی تێخستن"
-
-#: panels/region/cc-region-panel.ui:209
-msgid "Choose keyboard layouts or input methods."
-msgstr "کڵێشەی تەختەکلیل یان شێوزی نووسین بگۆڕە."
-
-#: panels/region/cc-region-panel.ui:266
-msgid "No input source selected"
-msgstr "هیچ سەرچاوەی تێخستن دیارینەکراوە"
-
-#: panels/region/cc-region-panel.ui:300
-msgid "Login settings are used by all users when logging into the system"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
 msgstr ""
-"ڕێخستنەکانی چوونەژوورەوە بەکاردەبرێت لەلایان هەموو بەکار‌هێنەرەکان کاتێک "
-"دەچیتە ناو سیستەمەکە"
 
-#: panels/region/cc-region-panel.ui:314
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
 msgid "Manage Installed Languages"
 msgstr "ڕێکخستنی زمانە دامەزراوەکان"
 
-#: panels/region/cc-region-panel.ui:363
-msgid "Input Source Options"
-msgstr "هەڵبژاردەکانی سەرچاوەی تێخستن"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "هەژمارەکەت"
 
-#: panels/region/cc-region-panel.ui:378
-msgid "Use the _same source for all windows"
-msgstr "_هەمان سەرچاوە بەکاربێنە بۆ هەموو پەنجەرەکان"
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_زمان"
 
-#: panels/region/cc-region-panel.ui:396
-msgid "Allow _different sources for each window"
-msgstr "ڕێگەبدە بە سەرچاوە _جیاوازەکان بۆ هەر پەنجەرەیەک"
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr "_ڕێکخستنەکان"
 
-#: panels/region/cc-region-panel.ui:438
-msgid "Previous source"
-msgstr "سەرچاوە پێشوو"
-
-#: panels/region/cc-region-panel.ui:456
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
-
-#: panels/region/cc-region-panel.ui:471
-msgid "Next source"
-msgstr "سەرچاوەی داهاتوو"
-
-#: panels/region/cc-region-panel.ui:489
-msgid "Super+Space"
-msgstr "Super+Space"
-
-#: panels/region/cc-region-panel.ui:504
-msgid "Left+Right Alt"
-msgstr "Left+Right Alt"
-
-#: panels/region/cc-region-panel.ui:520
-msgid "These keyboard shortcuts can be changed in the keyboard settings"
-msgstr "ئەم قەدبڕانە دەتوانرێت بگۆڕدرێت لە ڕێکخستنی تەختەکلیل"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "پەردەی _چوونەژوورەوە"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "شوێن و زمانەکان"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr ""
 "زمانی پیشاندان، فۆرماتەکان، کڵێسەی تەختە کلیل سەرچاوەی تێخستنی نووسین "
 "دیاریبکە"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/region/gnome-region-panel.desktop.in.in:7
-msgid "preferences-desktop-locale"
-msgstr "preferences-desktop-locale"
-
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:635
-msgid "Select Location"
-msgstr "شوێن هەڵبژێرە"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "پیشانی بدە چۆن میدیا بەدەستبخرێت"
 
-#: panels/search/cc-search-locations-dialog.c:639
-msgid "_OK"
-msgstr "_باشە"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "سیدی _دەنگی"
 
-#: panels/search/cc-search-panel.c:152
-msgid "No applications found"
-msgstr "هیچ داوانامەیەک نەدۆزرایەوە"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_ڤیدیۆیی دی-ڤیدی"
 
-#: panels/search/cc-search-panel-row.ui:92
-msgid "Move Up"
-msgstr "جوڵان بۆ سەرەوە"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_لێدەری میوزیک"
 
-#: panels/search/cc-search-panel-row.ui:102
-msgid "Move Down"
-msgstr "جۆڵان بۆ خوارەوە"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_نەرمەواڵە"
 
-#: panels/search/cc-search-panel.ui:33
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_میدیای تر..."
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_هەرگیز یەکسەر یان بەرنامەکان مەکەوە لەناو ڕەنگاڵە تێخراوەکان"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "دیاریبکە چۆن ڕەنگاڵەی دیکە بەدەست دەکەون"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_کردارەکان:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_جۆر:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "مێدیای هەڵگرتەنی"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "ڕێکخستنەکانی میدیای هەڵگرتەنی چاک بکە"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
-"Control which search results are shown in the Activities Overview. The order "
-"of search results can also be changed by moving rows in the list."
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "قفڵی شاشە"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.ui:9
-#: panels/search/cc-search-panel.ui:61
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "شاشەی _بەتاڵ"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_قفڵی شاشەی خودکار"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "_قفڵی شاشەی خودکار"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "نا_وەڕۆکی پەیام پشانبدە لەسەر قفڵی شاشە"
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr "شاشەکە قفڵ بکە لە ڕاگرتن"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "تایبەتێتی"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "شاشە"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "بڵاکوردنەوەی پەردە"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "گەڕان بۆ شوێن"
 
-#: panels/search/gnome-search-panel.desktop.in.in:4
-msgid ""
-"Control which applications show search results in the Activities Overview"
-msgstr ""
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/search/gnome-search-panel.desktop.in.in:7
-msgid "preferences-system-search"
-msgstr "preferences-system-search"
-
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/search/gnome-search-panel.desktop.in.in:19
-msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "Search;Find;Index;Hide;Privacy;Results;"
-
-#: panels/search/cc-search-locations-dialog.ui:32
-#: panels/search/cc-search-locations-dialog.ui:69
-#: panels/search/cc-search-locations-dialog.ui:107
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
 msgstr ""
 "بەرنامەکانی سیستەم دەگەڕێن بەناو بوخچەکان، وەک پەڕگەکان، وێنەکان و ڤیدیۆکان."
 
-#: panels/search/cc-search-locations-dialog.ui:52
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr "شوێنەکان"
 
-#: panels/search/cc-search-locations-dialog.ui:91
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "دڵخوازەکان"
 
-#: panels/search/cc-search-locations-dialog.ui:156
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "هیتر"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:307
-msgid "No networks selected for sharing"
-msgstr "هیچ ڕایەڵەیەک دیارینەکرا بۆ بڵاوکردنەوە"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "شوێن"
 
-#: panels/sharing/cc-sharing-panel.c:302
-msgctxt "service is enabled"
-msgid "On"
-msgstr "هەڵکراوە"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "نەرمەواڵا"
 
-#: panels/sharing/cc-sharing-panel.c:304 panels/sharing/cc-sharing-panel.c:331
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "کوژاوەتەوە"
-
-#: panels/sharing/cc-sharing-panel.c:334
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "چالاككراو"
-
-#: panels/sharing/cc-sharing-panel.c:337
-msgctxt "service is active"
-msgid "Active"
-msgstr "چالاك"
-
-#: panels/sharing/cc-sharing-panel.c:407
-msgid "Choose a Folder"
-msgstr "بوخچە هەڵبژێرە"
-
-#: panels/sharing/cc-sharing-panel.c:726
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: <a href=\"dav://%s\">dav://%s</a>"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.c:728
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
+#: panels/search/cc-search-panel.ui:23
+#, fuzzy
+msgid "Folders which are searched by system applications."
+msgstr ""
+"بەرنامەکانی سیستەم دەگەڕێن بەناو بوخچەکان، وەک پەڕگەکان، وێنەکان و ڤیدیۆکان."
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "گەڕان بۆ شوێن"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.c:730
-#, c-format
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+"Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.c:828
-msgid "Copy"
-msgstr "لەبەرگرتنەوە"
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;"
 
-#: panels/sharing/cc-sharing-panel.c:1279
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "ڕایەڵەکان"
+
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "ىڵاوکردنەوە"
 
-#: panels/sharing/cc-sharing-panel.ui:34
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr "_ناوی کۆمپیوتەر"
 
-#: panels/sharing/cc-sharing-panel.ui:94
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr "_بڵاوکردنەوەی پەڕگە"
 
-#: panels/sharing/cc-sharing-panel.ui:139
-msgid "_Screen Sharing"
-msgstr "_بڵاوکردنەوەی پەردە"
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:184
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr "_بڵاوکردنەوەی میدیا"
 
-#: panels/sharing/cc-sharing-panel.ui:229
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr "_چوونەژوورەوەی دوور"
 
-#: panels/sharing/cc-sharing-panel.ui:268
-msgid "Some services are disabled because of no network access."
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.ui:286
-#: panels/sharing/cc-sharing-panel.ui:413
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr "بڵاوکردنەوەی پەڕگە"
 
-#: panels/sharing/cc-sharing-panel.ui:333
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr "_تێپەڕەووشە داواکراوە"
 
-#: panels/sharing/cc-sharing-panel.ui:424
-#: panels/sharing/cc-sharing-panel.ui:494
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "چوونەژوورەوەی دوور"
 
-#: panels/sharing/cc-sharing-panel.ui:517
-#: panels/sharing/cc-sharing-panel.ui:763
-msgid "Screen Sharing"
-msgstr "بڵاکوردنەوەی پەردە"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "چوونەژوورەوەی دوور"
 
-#: panels/sharing/cc-sharing-panel.ui:575
-msgid "_Allow connections to control the screen"
-msgstr "_ڕێگە بدە پەیوەندییەکان پەردە بگرنە ژێردەست"
-
-#: panels/sharing/cc-sharing-panel.ui:620
-msgid "_Password:"
-msgstr "_تێپپەڕەوشە:"
-
-#: panels/sharing/cc-sharing-panel.ui:650
-msgid "_Show Password"
-msgstr "_وشەی تێپەڕبوون پیشان بدە"
-
-#: panels/sharing/cc-sharing-panel.ui:681
-msgid "Access Options"
-msgstr "هەڵبژاردەکانی چوونەناو"
-
-#: panels/sharing/cc-sharing-panel.ui:695
-msgid "_New connections must ask for access"
-msgstr "_پەیوەندی نوێ پێوستە داوای چوونەناو بکات"
-
-#: panels/sharing/cc-sharing-panel.ui:713
-msgid "_Require a password"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:774
-#: panels/sharing/cc-sharing-panel.ui:868
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "چالاک کردن و ناچالاک کردنی چوونەناوی دوور"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "چوونەژوورەوەی دوور"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
+msgstr "_ڕێگە بدە پەیوەندییەکان پەردە بگرنە ژێردەست"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "پەیوەستبوون لەبیربکە"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "لەبەرگرتنەوە"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "ناونیشان بسڕەوە"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "ڕێپێ_دان"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ناوی بەکارهێنەر"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "تۆمارکرنی پەنجەمۆرەکان"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:807
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "مۆسیقا، وێنەکان و ڤیدیۆکان بڵاوبکەوە لە سەر ئینتەرنێت."
 
-#: panels/sharing/cc-sharing-panel.ui:822
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "بوخچەکان"
 
@@ -6200,12 +3628,6 @@ msgstr "بوخچەکان"
 msgid "Control what you want to share with others"
 msgstr "دەستبگرە بەسەر ئەوەی دەتەوێت بڵاویبکەیتەوە لەگەڵ کەسانی دیکە"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/sharing/gnome-sharing-panel.desktop.in.in:7
-msgid "preferences-system-sharing"
-msgstr "preferences-system-sharing"
-
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6213,10 +3635,6 @@ msgid ""
 msgstr ""
 "بڵاوکردنەوە;بڵاودەکرێتەوە;ssh;خانەخوێ;ناو;کۆنتڕۆڵ-لە-دوور;ڕوومێز;ڕەنگاڵە;"
 "دەنگ;ڤیدیۆ;وێنەکان;وێنەکان;فلیمەکان;ڕاژە;ڕێندەرکەر;"
-
-#: panels/sharing/cc-sharing-networks.ui:19
-msgid "Networks"
-msgstr "ڕایەڵەکان"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
@@ -6226,111 +3644,95 @@ msgstr "چالاک کردن و ناچالاک کردنی چوونەناوی دو
 msgid "Authentication is required to enable or disable remote login"
 msgstr "چالاک کردن و ناچالاک کردنی چوونەناوی دوور پێویستی بە دەسەڵاتی ڕێپێدانە"
 
-#: panels/sound/cc-alert-chooser.c:173
-msgid "Custom"
-msgstr "ڕاسپێراو"
-
-#: panels/sound/cc-alert-chooser.ui:19
-msgid "Bark"
-msgstr "بارک"
-
-#: panels/sound/cc-alert-chooser.ui:26
-msgid "Drip"
-msgstr "دریپ"
-
-#: panels/sound/cc-alert-chooser.ui:33
-msgid "Glass"
-msgstr "گلاس"
-
-#: panels/sound/cc-alert-chooser.ui:40
-msgid "Sonar"
-msgstr "سۆنەر"
-
-#: panels/sound/cc-fade-slider.ui:13
-msgid "Rear"
-msgstr "دواوە"
-
-#: panels/sound/cc-fade-slider.ui:15
-msgid "Front"
-msgstr "پێشەوە"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "تاقیکردنەوەی %s"
-
-#: panels/sound/cc-output-test-dialog.ui:127
-msgid "Click a speaker to test"
-msgstr "کرتە بکە لە بڵندگۆ بۆ تاقیکردنەوە"
-
-#: panels/sound/cc-sound-panel.ui:29
-msgid "System Volume"
-msgstr "پلەدەنگی سیستم"
-
-#: panels/sound/cc-sound-panel.ui:82
-msgid "Over-Amplification"
-msgstr "پلەدەنگی-بەزتر"
-
-#: panels/sound/cc-sound-panel.ui:110
-msgid ""
-"Allows raising the volume above 100%. This can result in a loss of audio "
-"quality; it is better to increase application volume settings, if possible."
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
 msgstr ""
-"ڕێگەدان بۆ زیاتر لە %١٠٠. ئەمە دەبێتە هۆی لەدەستدانی جۆرێتی دەنگەکە، وا "
-"باشترە ڕێکستنەکانی دەنگی داوانامە زیادبکرێت. ئەگەر دەکرێت."
 
-#: panels/sound/cc-sound-panel.ui:137
-msgid "Volume Levels"
-msgstr "ئاستی دەنگ"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "ىڵاوکردنەوە"
 
-#: panels/sound/cc-sound-panel.ui:159
-msgid "Output"
-msgstr "دەرخستە"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: panels/sound/cc-sound-panel.ui:186
-msgid "Output Device"
-msgstr "ئامێری دەرخستن"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-sound-panel.ui:209
-msgid "Test"
-msgstr "تاقیکردنەوە"
-
-#: panels/sound/cc-sound-panel.ui:240 panels/sound/cc-sound-panel.ui:417
-msgid "Configuration"
-msgstr "ڕێکخستن"
-
-#: panels/sound/cc-sound-panel.ui:273
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 msgid "Balance"
 msgstr "هاوسەنگی"
 
-#: panels/sound/cc-sound-panel.ui:300
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 msgid "Fade"
 msgstr "کاڵبوونەوە"
 
-#: panels/sound/cc-sound-panel.ui:327
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "دواوە"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "پێشەوە"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "کرتە بکە لە بڵندگۆ بۆ تاقیکردنەوە"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "پلەدەنگی سیستم"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "پلەدەنگی سیستم"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "ئاستی دەنگ"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "دەرخستە"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "ئامێری دەرخستن"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "تاقیکردنەوە"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "ڕێکخستن"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "بەرزکەرەوەی دەنگ (سەبوۆفەر)"
 
-#: panels/sound/cc-sound-panel.ui:349
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "تێخستە"
 
-#: panels/sound/cc-sound-panel.ui:376
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "ئامێری تێخراو"
 
-#: panels/sound/cc-sound-panel.ui:450
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "پلەی دەنگ"
 
-#: panels/sound/cc-sound-panel.ui:472
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "دەنگی ئاگاداری"
 
-#: panels/sound/cc-volume-slider.c:115
-msgctxt "volume"
-msgid "100%"
-msgstr "%۱۰۰"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6340,171 +3742,68 @@ msgstr "دەنگ"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "گۆڕینی ئاستی دەنگ، تێخستن، دەرخستن، ودەنگی ئاگادارکردنەوە"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/sound/gnome-sound-panel.desktop.in.in:7
-msgid "multimedia-volume-control"
-msgstr "multimedia-volume-control"
-
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "هێڵەکە بچڕا"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "پەیوەندی دەگرێت"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "پەیوەستە"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "هەڵە لە ڕێپێدان"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "ڕێپێدان"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "کردار کەمکراوە"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "پەیوەستەو ڕێپێدراوە"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "نەناسراو"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr "ڕێپێدراوە لە:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-msgid "Connected at:"
-msgstr "پەیوەستە لە:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-msgid "Enrolled at:"
-msgstr "بەشدارە لە:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-msgid "Failed to authorize device: "
-msgstr "ڕێگە نەدراوە بە ئامێری: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-msgid "Failed to forget device: "
-msgstr "‌نەتونرا ئامیرە لەبیر بکرێ "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "ئاگادارکردنەوەکان"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "ناو:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "دۆخ:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "ڕێبدە و پەیوەندی بکە"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "ئامێر لەبیربکە"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "هەڵە"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "ڕێپێدراوە"
-
-#: panels/thunderbolt/cc-bolt-panel.c:175
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:468
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:512
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:516
-msgid "Thunderbolt security level could not be determined."
-msgstr "ئاستی ئاسایشی سەندەربۆڵت ناتوانرێت دیاریبکرێت"
-
-#: panels/thunderbolt/cc-bolt-panel.c:621
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+#, fuzzy
+msgid "No Thunderbolt Support"
 msgstr "پشتگیری سەندەربۆڵت نییە"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:246
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "ناتوانین پەیوەستببین بە دۆمەینی %s: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "ڕێپێدانی ڕاستەوخۆ"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "ئامێری چاوەڕوانکراو"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "هیچ ئامێرێک نەبەستراوە"
 
@@ -6516,1129 +3815,850 @@ msgstr "سەندەربۆڵت"
 msgid "Manage Thunderbolt devices"
 msgstr ""
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:7
-msgid "thunderbolt"
-msgstr "thunderbolt"
-
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
-msgid "Thunderbolt;"
-msgstr ""
+#, fuzzy
+msgid "Thunderbolt;privacy;"
+msgstr "سەندەربۆڵت"
 
-#: panels/ubuntu/cc-ubuntu-panel.c:134
-msgid "All displays"
-msgstr "هەموو پیشاندەرەکان"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "تروکاندنی جێنیشاندەر"
 
-#: panels/ubuntu/cc-ubuntu-panel.ui:198
-msgid "Auto-hide the Dock"
-msgstr "شاردنەوەی خۆکاری دۆک"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "جێنیشاندەر دەتروکێت لە بوواری دەقەکان."
 
-#: panels/ubuntu/cc-ubuntu-panel.ui:213
-msgid "The dock hides when any windows overlap with it."
-msgstr "دۆک لادەچیت کاتێک پەنجەرەیەک دێتە سەری."
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "خێرایی"
 
-#: panels/ubuntu/cc-ubuntu-panel.ui:257
-msgid "Icon size"
-msgstr "قەبارەی وێنۆچکە"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "خێرایی تروکاندنی جێنیشاندەر"
 
-#: panels/ubuntu/cc-ubuntu-panel.ui:295
-msgid "Show on"
-msgstr "پیشانی بدە لە"
-
-#: panels/ubuntu/cc-ubuntu-panel.ui:336
-msgid "Position on screen"
-msgstr "شوێنی لە پەردە"
-
-#: panels/ubuntu/cc-ubuntu-panel.ui:353
-msgctxt "Position on screen for the Ubuntu dock"
-msgid "Left"
-msgstr "چەپ"
-
-#: panels/ubuntu/cc-ubuntu-panel.ui:354
-msgctxt "Position on screen for the Ubuntu dock"
-msgid "Bottom"
-msgstr "خوارەوە"
-
-#: panels/ubuntu/cc-ubuntu-panel.ui:355
-msgctxt "Position on screen for the Ubuntu dock"
-msgid "Right"
-msgstr "ڕاست"
-
-#. Dock settings.
-#: panels/ubuntu/cc-ubuntu-panel.ui:161
-msgid "Dock"
-msgstr "لەنگەرگا(دۆک)"
-
-#: panels/ubuntu/gnome-ubuntu-panel.desktop.in.in:4
-msgid "Ubuntu Dock Settings"
-msgstr ""
-
-#: panels/ubuntu/gnome-ubuntu-panel.desktop.in.in:6
-msgid "preferences-ubuntu-panel"
-msgstr "preferences-ubuntu-panel"
-
-#. Translators: those are keywords for the ubuntu control-center panel
-#: panels/ubuntu/gnome-ubuntu-panel.desktop.in.in:17
-msgid "Dock;Launcher;"
-msgstr ""
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:500
-msgctxt "cursor size"
-msgid "Default"
-msgstr "بنەڕەتی"
-
-#: panels/universal-access/cc-ua-panel.c:503
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "ناوەند"
-
-#: panels/universal-access/cc-ua-panel.c:506
-msgctxt "cursor size"
-msgid "Large"
-msgstr "گەورە"
-
-#: panels/universal-access/cc-ua-panel.c:509
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "گەورەتر"
-
-#: panels/universal-access/cc-ua-panel.c:512
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "گەورەترین"
-
-#: panels/universal-access/cc-ua-panel.c:516
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d پیکسڵ"
-msgstr[1] "%d پیکسڵ"
-
-#: panels/universal-access/cc-ua-panel.ui:78
-msgid "_Always Show Universal Access Menu"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:120
-msgid "Seeing"
-msgstr "دەبینرێت"
-
-#: panels/universal-access/cc-ua-panel.ui:166
-msgid "_High Contrast"
-msgstr "_تۆخ و گەورە"
-
-#: panels/universal-access/cc-ua-panel.ui:213
-msgid "_Large Text"
-msgstr "_دەقی گەورە"
-
-#: panels/universal-access/cc-ua-panel.ui:258
-msgid "C_ursor Size"
-msgstr "قەبارەی ج_ێنیشاندەر"
-
-#: panels/universal-access/cc-ua-panel.ui:305
-#: panels/universal-access/zoom-options.ui:99
-msgid "_Zoom"
-msgstr "_هێنانە پێش"
-
-#: panels/universal-access/cc-ua-panel.ui:351
-msgid "Screen _Reader"
-msgstr "خوێنەری _پەردە"
-
-#: panels/universal-access/cc-ua-panel.ui:397
-#: panels/universal-access/cc-ua-panel.ui:1263
-msgid "_Sound Keys"
-msgstr "_کلیلی دەنگ"
-
-#: panels/universal-access/cc-ua-panel.ui:459
-msgid "Hearing"
-msgstr "دەبیسترێت"
-
-#: panels/universal-access/cc-ua-panel.ui:503
-#: panels/universal-access/cc-ua-panel.ui:1366
-msgid "_Visual Alerts"
-msgstr "ئاگادارکردنەوە _بینراوەکان"
-
-#: panels/universal-access/cc-ua-panel.ui:611
-msgid "Screen _Keyboard"
-msgstr "_تەختەکلیلی شاشە"
-
-#: panels/universal-access/cc-ua-panel.ui:656
-msgid "R_epeat Keys"
-msgstr "کلیلە د_ووبارەبووەوەکان"
-
-#: panels/universal-access/cc-ua-panel.ui:702
-msgid "Cursor _Blinking"
-msgstr "_تروکاندنی جێنیشاندەر"
-
-#: panels/universal-access/cc-ua-panel.ui:748
-msgid "_Typing Assist (AccessX)"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:809
-msgid "Pointing & Clicking"
-msgstr "نیاشانەکردن و کرتەکردن"
-
-#: panels/universal-access/cc-ua-panel.ui:855
-msgid "_Mouse Keys"
-msgstr "کلیلەکانی _مشک"
-
-#: panels/universal-access/cc-ua-panel.ui:932
-msgid "_Click Assist"
-msgstr "_کرتەی هاوکاریکەر"
-
-#: panels/universal-access/cc-ua-panel.ui:978
-msgid "_Double-Click Delay"
-msgstr "_دوواکەوتنی دوو-کرتە"
-
-#: panels/universal-access/cc-ua-panel.ui:998
-msgid "Double-Click Delay"
-msgstr "دوواکەوتنی دوو-کرتە"
-
-#: panels/universal-access/cc-ua-panel.ui:1068
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr "قەبارەی جێنیشاندەر"
 
-#: panels/universal-access/cc-ua-panel.ui:1095
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 "قەبارەی جێنیشاندەر دەتوانرێت بە هێنانە پیش بکرێت بۆ ئەوەی بە جوانی "
 "جێنیشاندەر ببینیت."
 
-#: panels/universal-access/cc-ua-panel.ui:1131
-msgid "Screen Reader"
-msgstr "خوێنەرەوەی ڕووپەر"
-
-#: panels/universal-access/cc-ua-panel.ui:1148
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "خوێنەریڕووپەر خوێندنەوە ب ۆپەردە دەکات هەر کاتێک تۆ سەرنج دەجوڵێنی ."
-
-#: panels/universal-access/cc-ua-panel.ui:1181
-msgid "_Screen Reader"
-msgstr "_خوێنەری رووپەر"
-
-#: panels/universal-access/cc-ua-panel.ui:1220
-msgid "Sound Keys"
-msgstr "کیلی دەنگ"
-
-#: panels/universal-access/cc-ua-panel.ui:1238
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1308
-msgid "Visual Alerts"
-msgstr "ئاگانامەیی بینەیی"
-
-#: panels/universal-access/cc-ua-panel.ui:1312
-msgid "_Test flash"
-msgstr "_فلاش تاقیبکەرەوە"
-
-#: panels/universal-access/cc-ua-panel.ui:1341
-msgid "Use a visual indication when an alert sound occurs."
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1360
-msgid "Flash the _window title"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1410
-msgid "Flash the entire _screen"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1455
-msgid "Repeat Keys"
-msgstr "کلیلی دووبارە"
-
-#: panels/universal-access/cc-ua-panel.ui:1485
-msgid "Key presses repeat when key is held down."
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1565
-msgid "Repeat keys delay"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1613
-#: panels/universal-access/cc-ua-panel.ui:1748
-msgid "Speed"
-msgstr "خێرایی"
-
-#: panels/universal-access/cc-ua-panel.ui:1652
-msgid "Repeat keys speed"
-msgstr "خێرایی کلیلەکان سووبارە بکەرەوە"
-
-#: panels/universal-access/cc-ua-panel.ui:1676
-msgid "Cursor Blinking"
-msgstr "تروکاندنی جێنیشاندەر"
-
-#: panels/universal-access/cc-ua-panel.ui:1706
-msgid "Cursor blinks in text fields."
-msgstr "جێنیشاندەر دەتروکێت لە بوواری دەقەکان."
-
-#: panels/universal-access/cc-ua-panel.ui:1785
-msgid "Cursor blinking speed"
-msgstr "خێرایی تروکاندنی جێنیشاندەر"
-
-#: panels/universal-access/cc-ua-panel.ui:1821
-msgid "Typing Assist"
-msgstr "یارمەتیدەری نووسین"
-
-#: panels/universal-access/cc-ua-panel.ui:1860
-msgid "_Sticky Keys"
-msgstr "کلیلە _پێوەنوساوەکان"
-
-#: panels/universal-access/cc-ua-panel.ui:1877
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1901
-msgid "_Disable if two keys are pressed together"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1919
-msgid "Beep when a _modifier key is pressed"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1967
-msgid "S_low Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1984
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2017
-#: panels/universal-access/cc-ua-panel.ui:2230
-#: panels/universal-access/cc-ua-panel.ui:2567
-msgid "A_cceptance delay:"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2039
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "کورت"
-
-#: panels/universal-access/cc-ua-panel.ui:2058
-msgid "Slow keys typing delay"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2073
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "دوورودرێژ"
-
-#: panels/universal-access/cc-ua-panel.ui:2100
-msgid "Beep when a key is pr_essed"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2117
-msgid "Beep when a key is _accepted"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2134
-#: panels/universal-access/cc-ua-panel.ui:2313
-msgid "Beep when a key is _rejected"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2180
-msgid "_Bounce Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2197
-msgid "Ignores fast duplicate keypresses"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2252
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "کورت"
-
-#: panels/universal-access/cc-ua-panel.ui:2271
-msgid "Bounce keys typing delay"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2286
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2399
-msgid "_Enable by Keyboard"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2416
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2480
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2516
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2534
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2588
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "کورت"
 
-#: panels/universal-access/cc-ua-panel.ui:2607
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "دوواکەوتنی کرتەی لاوەکیی"
 
-#: panels/universal-access/cc-ua-panel.ui:2622
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "دوورودرێژ"
 
-#: panels/universal-access/cc-ua-panel.ui:2679
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2697
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2730
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2752
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "کورت"
 
-#: panels/universal-access/cc-ua-panel.ui:2783
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "دوورودرێژ"
 
-#: panels/universal-access/cc-ua-panel.ui:2819
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2841
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "بچووک"
 
-#: panels/universal-access/cc-ua-panel.ui:2872
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "گەورە"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "کلیلی دووبارە"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "خێرایی کلیلەکان سووبارە بکەرەوە"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "یارمەتیدەری نووسین"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "کلیلە _پێوەنوساوەکان"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "کورت"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "دوورودرێژ"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "کورت"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "دەبینرێت"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_تۆخ و گەورە"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_دەقی گەورە"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "خوێنەری _پەردە"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "خوێنەریڕووپەر خوێندنەوە ب ۆپەردە دەکات هەر کاتێک تۆ سەرنج دەجوڵێنی ."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_کلیلی دەنگ"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "قەبارەی ج_ێنیشاندەر"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_هێنانە پێش"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "دەبیسترێت"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "ئاگادارکردنەوە _بینراوەکان"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_تەختەکلیلی شاشە"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "کلیلە د_ووبارەبووەوەکان"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_تروکاندنی جێنیشاندەر"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "نیاشانەکردن و کرتەکردن"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "کلیلەکانی _مشک"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "چاپکەر بسڕەوە"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_کرتەی هاوکاریکەر"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_دوواکەوتنی دوو-کرتە"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "دوواکەوتنی دوو-کرتە"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "ئاگانامەیی بینەیی"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_فلاش تاقیبکەرەوە"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "بینینی پڕاوپڕ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "نیوەی سەرەوە"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "نیوەی خوارەوە"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "نیوەی ڕاست"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "هەڵبژاردەکانی نزیککردنەوە"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_ئاوساندن:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "شوێنی هەڵئاوساندن:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_دووای جێنیشاندەری مشک بکەوە"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_بەشی ڕووپەر:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "ئاوسان  _دیوی دەرەوەی ڕووپەر فراوان دەکات"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_جێنیشاندەری ئاوساندن لە ناوەڕاست بهێڵەوە،"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "جێنیشاندەری ئاوساندن  _پاڵ بە ناوەڕۆکەکان دەنا بۆ ناوەوە (خولگەیی)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "جێنیشاندەری ئاوساندن دەجوڵێت لەگەڵ _ناوەڕۆکەکاندا"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "هەڵئاوساندەر"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_ئەستووری:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "تەنک"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_درێژی:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "ڕه‌_نگ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_سپی لەسەر ڕەش:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_ڕووناکی:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_کۆنتراست:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "ڕە_نگ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "هیج"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "هەموو"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "نزم"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "بەرز"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "نزم"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "بەرز"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "کاریگەری ڕەنگ"
 
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "وای لێبکە ئاسان ببینرێت، ببیسترێت، بنوسرێت، خاڵ و کرتە"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:7
-msgid "preferences-desktop-accessibility"
-msgstr "preferences-desktop-accessibility"
-
-#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
 "Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
 "big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
 "click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
-msgstr ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
-"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
-"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
 
-#: panels/universal-access/zoom-options.c:305
-msgctxt "Distance"
-msgid "Short"
-msgstr "کورت"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "پەڕگەی سیستەم"
 
-#: panels/universal-access/zoom-options.c:306
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "چارەکی ڕووپەر"
-
-#: panels/universal-access/zoom-options.c:307
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "نیوەی ڕووپەر"
-
-#: panels/universal-access/zoom-options.c:308
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "سێ چارەکی ڕووپەر"
-
-#: panels/universal-access/zoom-options.c:309
-msgctxt "Distance"
-msgid "Long"
-msgstr "دوورودرێژ"
-
-#: panels/universal-access/zoom-options.ui:48
-msgid "Full Screen"
-msgstr "بینینی پڕاوپڕ"
-
-#: panels/universal-access/zoom-options.ui:53
-msgid "Top Half"
-msgstr "نیوەی سەرەوە"
-
-#: panels/universal-access/zoom-options.ui:58
-msgid "Bottom Half"
-msgstr "نیوەی خوارەوە"
-
-#: panels/universal-access/zoom-options.ui:63
-msgid "Left Half"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:68
-msgid "Right Half"
-msgstr "نیوەی ڕاست"
-
-#: panels/universal-access/zoom-options.ui:78
-msgid "Zoom Options"
-msgstr "هەڵبژاردەکانی نزیککردنەوە"
-
-#: panels/universal-access/zoom-options.ui:185
-msgid "_Magnification:"
-msgstr "_ئاوساندن:"
-
-#: panels/universal-access/zoom-options.ui:249
-msgid "_Follow mouse cursor"
-msgstr "_دووای جێنیشاندەری مشک بکەوە"
-
-#: panels/universal-access/zoom-options.ui:269
-msgid "_Screen part:"
-msgstr "_بەشی ڕووپەر:"
-
-#: panels/universal-access/zoom-options.ui:331
-msgid "Magnifier _extends outside of screen"
-msgstr "ئاوسان  _دیوی دەرەوەی ڕووپەر فراوان دەکات"
-
-#: panels/universal-access/zoom-options.ui:350
-msgid "_Keep magnifier cursor centered"
-msgstr "_جێنیشاندەری ئاوساندن لە ناوەڕاست بهێڵەوە،"
-
-#: panels/universal-access/zoom-options.ui:370
-msgid "Magnifier cursor _pushes contents around"
-msgstr "جێنیشاندەری ئاوساندن  _پاڵ بە ناوەڕۆکەکان دەنا بۆ ناوەوە (خولگەیی)"
-
-#: panels/universal-access/zoom-options.ui:390
-msgid "Magnifier cursor moves with _contents"
-msgstr "جێنیشاندەری ئاوساندن دەجوڵێت لەگەڵ _ناوەڕۆکەکاندا"
-
-#: panels/universal-access/zoom-options.ui:425
-msgid "Magnifier Position:"
-msgstr "شوێنی هەڵئاوساندن:"
-
-#: panels/universal-access/zoom-options.ui:446
-msgid "Magnifier"
-msgstr "هەڵئاوساندەر"
-
-#: panels/universal-access/zoom-options.ui:493
-msgid "_Thickness:"
-msgstr "_ئەستووری:"
-
-#: panels/universal-access/zoom-options.ui:519
-msgctxt "universal access, thickness"
-msgid "Thin"
-msgstr "تەنک"
-
-#: panels/universal-access/zoom-options.ui:551
-msgctxt "universal access, thickness"
-msgid "Thick"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:577
-msgid "_Length:"
-msgstr "_درێژی:"
-
-#. The color of the accessibility crosshair
-#: panels/universal-access/zoom-options.ui:626
-msgid "Co_lor:"
-msgstr "ڕه‌_نگ"
-
-#: panels/universal-access/zoom-options.ui:690
-msgid "_Crosshairs:"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:738
-msgid "_Overlaps mouse cursor"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:776
-msgid "Crosshairs"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:825
-msgid "_White on black:"
-msgstr "_سپی لەسەر ڕەش:"
-
-#: panels/universal-access/zoom-options.ui:845
-msgid "_Brightness:"
-msgstr "_ڕووناکی:"
-
-#: panels/universal-access/zoom-options.ui:866
-msgid "_Contrast:"
-msgstr "_کۆنتراست:"
-
-#. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/zoom-options.ui:886
-msgctxt "universal access, contrast"
-msgid "Co_lor"
-msgstr "ڕە_نگ"
-
-#: panels/universal-access/zoom-options.ui:911
-msgctxt "universal access, color"
-msgid "None"
-msgstr "هیج"
-
-#: panels/universal-access/zoom-options.ui:943
-msgctxt "universal access, color"
-msgid "Full"
-msgstr "هەموو"
-
-#: panels/universal-access/zoom-options.ui:1006
-msgctxt "universal access, brightness"
-msgid "Low"
-msgstr "نزم"
-
-#: panels/universal-access/zoom-options.ui:1039
-msgctxt "universal access, brightness"
-msgid "High"
-msgstr "بەرز"
-
-#: panels/universal-access/zoom-options.ui:1070
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "نزم"
-
-#: panels/universal-access/zoom-options.ui:1103
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "بەرز"
-
-#: panels/universal-access/zoom-options.ui:1139
-msgid "Color Effects:"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:1164
-msgid "Color Effects"
-msgstr "کاریگەری ڕەنگ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "پێویستە ناونیشنای تۆڕی دابینکەری چوونەژوورەوەکەت بگونجێنیت"
-
-#: panels/user-accounts/cc-add-user-dialog.c:205
-msgid "Failed to add account"
-msgstr "نەتوانرا هەژمار زیادبکرێت"
-
-#: panels/user-accounts/cc-add-user-dialog.c:676
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "تێپەڕەوشەکان وەک یەک نین."
-
-#: panels/user-accounts/cc-add-user-dialog.c:898
-#: panels/user-accounts/cc-add-user-dialog.c:944
-#: panels/user-accounts/cc-add-user-dialog.c:965
-msgid "Failed to register account"
-msgstr "تۆمارکردنی هەژمارەکەت شکستی هێنا"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1088
-msgid "No supported way to authenticate with this domain"
-msgstr "هیچ ڕێگایەک نییە بۆ سەلماندن لەگەڵ ئەم دۆمەینە"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1161
-msgid "Failed to join domain"
-msgstr "پەیوەستبوون بە دۆمەینەوە شکستی هێنا"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1222
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"ناوی چوونەژورەوە کاری نەکرد. \n"
-"تکایە هەوڵبدەرەوە."
 
-#: panels/user-accounts/cc-add-user-dialog.c:1229
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "_لەناوبردنی پەڕگە کاتییەکان"
+
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
-"That login password didn’t work.\n"
-"Please try again."
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
 msgstr ""
-"تیپەڕوشەی چوونەژورەوە کاری نەکرد. \n"
-"تکایە هەوڵبدەرەوە."
 
-#: panels/user-accounts/cc-add-user-dialog.c:1237
-msgid "Failed to log into domain"
-msgstr "چوونەژوورەوە بۆ دۆمەینەکە شکستی هێنا"
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.c:1295
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "ناتوانرێت دۆمەین بدۆزرێتەوە. لەوانەیە"
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "سڕینەوەی هەموو پەڕگە کاتییەکان؟"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "_قفڵی شاشەی خودکار"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_بەتاڵکردنی تەنەکەخۆڵ..."
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_لەناوبردنی پەڕگە کاتییەکان"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "بەکارهێنەر زیادبکە"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr "_ناوی تەواو"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-msgid "Standard"
-msgstr "ستاندارد"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "بەڕێوەبەر"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-msgid "Account _Type"
-msgstr "جۆری _هەژمار"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-msgid "Allow user to set a password when they next _login"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"ڕێگە بە بەکارهێنەر بدە جاری داهاتوو وشەی تێپەڕ بگۆڕدرێت کە هاتە _ژوورەوە"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
-msgid "Set a password _now"
-msgstr "وشەی تێپەڕبوون دابنێ _ئێستا"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "ڕێگە بدە بەکارهێنەر وشەی تێپەڕبوونی بگۆڕێت دووای چوونە ژوورەوە"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "وشەی تێپەڕبوون دابنێ ئێستا"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "_دڵنیابوونەوە"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_چوونەژورەوەی ئابووری"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "تۆ لەدەرەوی هێڵی"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
 "resources on the internet."
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:732
-msgid "You are Offline"
-msgstr "تۆ لەدەرەوی هێڵی"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-msgid "You must be online in order to add enterprise users."
-msgstr "پێویستە لەسەرهێڵ بی بۆ ئەوەی بەکارهێنەری ئابووری زیادبکەی."
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "_چوونەژورەوەی ئابووری"
-
-#: panels/user-accounts/cc-avatar-chooser.c:232
-msgid "Browse for more pictures"
-msgstr "بگەڕی بۆ وێنەی زیاتر"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:39
-msgid "Take a Picture…"
-msgstr "وێنەیەک بگرە..."
-
-#: panels/user-accounts/cc-avatar-chooser.ui:46
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "پەڕگە دیاریبکە..."
 
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "ئەم هەفتەیە"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "_چوونەژورەوە بە پەنجەمۆر"
 
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
-msgstr "کۆتا هەفتە"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "_چوونەژورەوە بە پەنجەمۆر"
 
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
 
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"تۆ دەتەوێت پەنجەمۆرە تۆمارکراوەکانت بسڕیتەوە کەواتە چوونەژوورەوەی پەنجەمۆر "
+"ناچالاک دەکرێت؟"
 
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:766
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "ئامێری تێچووی یاریکردن"
 
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:770
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "_چوونەژورەوە بە پەنجەمۆر"
 
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr "دانیشتن کۆتایهات"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
 
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr "دانیشتن دەستیپێکرد"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "_چوونەژورەوە بە پەنجەمۆر"
 
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — چالاکی هەژمار"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr "تکایە وشەی تێپەڕبوون تر بنووسە."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "_چوونەژورەوە بە پەنجەمۆر"
 
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
-msgstr "تکایە وشەی تێپەڕبوونی ئێستات بنووسەرەوە"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
-msgstr "وشەی تێپەڕبوون ناگۆڕدرێت"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "پەنجەمۆرەکان _بسڕەوە"
 
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "_چوونەژورەوە بە پەنجەمۆر"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "تراکی پێشتر"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "گۆڕینی وشەی تێپەڕبوون"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "گۆڕ_ین"
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr "_دڵنیابەرەوە لە وشەی تێپەڕبوونی نوێ"
-
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr "_وشەی تێپەڕبوونی نوێ"
-
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "وشەی تێپەڕبوونی _ئێستا"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_وشەی تێپەڕبوونی نوێ"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "_دڵنیابەرەوە لە وشەی تێپەڕبوونی نوێ"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "تێپەڕەوشەکان وەک یەک نین."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "ڕێگە بدە بەکارهێنەر وشەی تێپەڕبوونی بگۆڕێت دووای چوونە ژوورەوە"
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "وشەی تێپەڕبوون دابنێ ئێستا"
 
-#: panels/user-accounts/cc-realm-manager.c:307
-msgid "Cannot automatically join this type of domain"
-msgstr "ناتوانیت خۆکارانە بچیتە ئەم جۆرە دۆمەینەوە"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "بەکارهێنەران"
 
-#: panels/user-accounts/cc-realm-manager.c:310
-msgid "No such domain or realm found"
-msgstr "هیچ دۆمەینێکی ڕاستی نەدۆزرایەوە"
-
-#: panels/user-accounts/cc-realm-manager.c:732
-#: panels/user-accounts/cc-realm-manager.c:746
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "ناتوانرێت وەکو %s بچیتە ژوورەوە لە %s دۆمەین"
-
-#: panels/user-accounts/cc-realm-manager.c:738
-msgid "Invalid password, please try again"
-msgstr "ووشەی تێپەڕبوون هەڵەیە ،تکایە هەوڵ بدەرەوە"
-
-#: panels/user-accounts/cc-realm-manager.c:751
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "ناتوانین پەیوەستببین بە دۆمەینی %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:209
-msgid "Your account"
-msgstr "هەژمارەکەت"
-
-#: panels/user-accounts/cc-user-panel.c:384
-msgid "Failed to delete user"
-msgstr "نەتوانرا بەکارهێنەر بسڕیتەوە"
-
-#: panels/user-accounts/cc-user-panel.c:442
-#: panels/user-accounts/cc-user-panel.c:501
-#: panels/user-accounts/cc-user-panel.c:553
-msgid "Failed to revoke remotely managed user"
-msgstr "نەتوانرا بەکارهێنەری بەڕێوبردن لەدوورەوە هەڵبوەشێندرێتەوە"
-
-#: panels/user-accounts/cc-user-panel.c:605
-msgid "You cannot delete your own account."
-msgstr "ناتوانی هەژماری خۆت بسڕیتەوە."
-
-#: panels/user-accounts/cc-user-panel.c:614
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s هێشتا لە ژوورەوەیە"
-
-#: panels/user-accounts/cc-user-panel.c:618
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"سڕینەوەی بەکارهێنەرێک کە لە ژوورەوەیە دەتوانێت سیستەمەکەی لە دۆخێکی ناجێگیر "
-"بەجێبێڵێت"
-
-#: panels/user-accounts/cc-user-panel.c:627
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "دەتەوێت پەڕگەکانی %s بهێڵیتەوە؟"
-
-#: panels/user-accounts/cc-user-panel.c:631
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"دەتوانرێت بوخچەی ماڵەوە، نۆرە نامە و پەڕگە کاتییەکانی ئەو ناوە بپارێزیت "
-"کاتێک هەژماری بەکارهێنەرێک. دەسڕیتەوە"
-
-#: panels/user-accounts/cc-user-panel.c:634
-msgid "_Delete Files"
-msgstr "_پەڕگەکان بسڕەوە"
-
-#: panels/user-accounts/cc-user-panel.c:635
-msgid "_Keep Files"
-msgstr "_پەڕگەکان بهێڵەوە"
-
-#: panels/user-accounts/cc-user-panel.c:649
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "تۆ دڵنیای دەتەوێت هەژماری %s لە دوورەوە بەڕێوەبراو هەڵبوەشێنیتەوە؟"
-
-#: panels/user-accounts/cc-user-panel.c:653
-msgid "_Delete"
-msgstr "_سڕینەوە"
-
-#: panels/user-accounts/cc-user-panel.c:703
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "هەژمار ناچالاک کرا"
-
-#: panels/user-accounts/cc-user-panel.c:711
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "جێبەجێدەکرێت لە چوونەژورەوەی داهاتوو"
-
-#: panels/user-accounts/cc-user-panel.c:714
-msgctxt "Password mode"
-msgid "None"
-msgstr "نییە"
-
-#: panels/user-accounts/cc-user-panel.c:759
-msgid "Logged in"
-msgstr "لەژوورەوەیە"
-
-#: panels/user-accounts/cc-user-panel.c:1143
-msgid "Failed to contact the accounts service"
-msgstr "نەتوانرا پەیوەندی بکرێت بە خزمەتگوزاری هەژمارەکان"
-
-#: panels/user-accounts/cc-user-panel.c:1145
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "تکاتە دڵنیابە کە خزمەتگوزاری-هەژمار دامەزراوە و چالاکە."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1177
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"بۆ گۆڕانکاری،\n"
-"کرتە لە وێنۆچکەکە بکە"
-
-#: panels/user-accounts/cc-user-panel.c:1250
-msgid "Create a user account"
-msgstr "هەژماری بەکارهێنەر دروستبکە"
-
-#: panels/user-accounts/cc-user-panel.c:1261
-#: panels/user-accounts/cc-user-panel.c:1389
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"بۆ دروستکردنی هەژماری بەکارهێنەر،\n"
-"کرتە لە وێنۆچکەکە بکە"
-
-#: panels/user-accounts/cc-user-panel.c:1270
-msgid "Delete the selected user account"
-msgstr "هەژماری بەکارهێنەری دیاریکراو بسڕەوە"
-
-#: panels/user-accounts/cc-user-panel.c:1282
-#: panels/user-accounts/cc-user-panel.c:1393
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"بۆ سڕینەوی هەژماری بەکارهێنەری دیاریکراو\n"
-"کرتە لە وێنۆچکەکە بکە"
-
-#: panels/user-accounts/cc-user-panel.ui:5
-msgid "_Add User…"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:52
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 "دانیشتنەکەت پێویستە دەسپێبکرێتەوە بۆ گۆڕانکاری  بۆ ئەوەی کاریگەرییەکانی "
 "دەربکەوێت"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "دەسپێکردنەوە ئەنجام بدە"
 
-#: panels/user-accounts/cc-user-panel.ui:470
-msgid "A_utomatic Login"
-msgstr "چوونەژورەوە خ_ۆکار"
+#: panels/user-accounts/cc-user-panel.ui:79
+#, fuzzy
+msgid "Close"
+msgstr "_داخستن"
 
-#: panels/user-accounts/cc-user-panel.ui:428
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_ناوی تەواو"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "_چوونەژورەوە بە پەنجەمۆر"
 
-#: panels/user-accounts/cc-user-panel.ui:146
-#: panels/user-accounts/cc-user-panel.ui:162
-msgid "User Icon"
-msgstr "وێنۆچکەی بەکارهێنەر"
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "چوونەژورەوە خ_ۆکار"
 
-#: panels/user-accounts/cc-user-panel.ui:404
-msgid "Last Login"
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "%s — چالاکی هەژمار"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "بەڕێوەبەر"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:541
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "سڕینەوەی بەکارهێنەر..."
 
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "پەڕگەکانی دیکە"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "بەکارهێنەر زیادبکە"
+
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:580
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "هیچ بەکارهێنەرێک نەدۆزرایەوە"
 
-#: panels/user-accounts/cc-user-panel.ui:590
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "بیکەرەوە بۆ ئەوەی بەکارهێنەر زیادبکەی بۆ  هەژمار."
-
-#: panels/user-accounts/data/account-fingerprint.ui:12
-msgid "Left thumb"
-msgstr "پەنجەی چەپ"
-
-#: panels/user-accounts/data/account-fingerprint.ui:15
-msgid "Left middle finger"
-msgstr "پەنجەی ناوەڕاستی چەپ"
-
-#: panels/user-accounts/data/account-fingerprint.ui:18
-msgid "Left ring finger"
-msgstr "ئەڵقەی پەنجەی چەپ"
-
-#: panels/user-accounts/data/account-fingerprint.ui:21
-msgid "Left little finger"
-msgstr "پەنجە بچووکی چەپ"
-
-#: panels/user-accounts/data/account-fingerprint.ui:24
-msgid "Right thumb"
-msgstr "پەنجە گەورەی ڕاست"
-
-#: panels/user-accounts/data/account-fingerprint.ui:27
-msgid "Right middle finger"
-msgstr "پەنجەی ناوەڕاست ڕاست"
-
-#: panels/user-accounts/data/account-fingerprint.ui:30
-msgid "Right ring finger"
-msgstr "ئەڵقەی پەنجەی ڕاست"
-
-#: panels/user-accounts/data/account-fingerprint.ui:33
-msgid "Right little finger"
-msgstr "پەنجەی بچووکی ڕاست"
-
-#: panels/user-accounts/data/account-fingerprint.ui:39
-#: panels/user-accounts/um-fingerprint-dialog.c:676
-msgid "Enable Fingerprint Login"
-msgstr "چوونەژورەوە بە پەنجەمۆر چالاک بکە"
-
-#: panels/user-accounts/data/account-fingerprint.ui:89
-msgid "_Right index finger"
-msgstr "پەنجەی نیشاندەری _ڕاست"
-
-#: panels/user-accounts/data/account-fingerprint.ui:105
-msgid "_Left index finger"
-msgstr "پەنجەی نیشاندەری _چەپ"
-
-#: panels/user-accounts/data/account-fingerprint.ui:126
-msgid "_Other finger:"
-msgstr "_پەنجەکانی تر:"
-
-#: panels/user-accounts/data/account-fingerprint.ui:324
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"پەنجەمۆر بەسەرکەوتووی زیادکرا. ئێستا دەتوانیت بە پەنجەمۆر بچیتە ژوورەوە."
-
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
-msgid "Users"
-msgstr "بەکارهێنەران"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "زیادکردن یان سڕینەوە بەکارهێنەر و گۆڕینی وشەی تێپەڕبوون"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:7
-msgid "system-users"
-msgstr "system-users"
-
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_تۆمارکردن"
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "چونەژوورەی بەڕیوەبەری دۆمەین"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here."
 msgstr ""
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "ناوی _بەڕێوبەر"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "تێپەڕەوشەی بەڕێوبەر"
 
@@ -7650,350 +4670,143 @@ msgstr "ڕێکخستنی هەژمارەکانی بەکارهێنەر"
 msgid "Authentication is required to change user data"
 msgstr "ڕێپێدان داواکراوە بۆ گۆڕینی زانیاری بەکارهێنەر"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "پێویستە تێپەڕەوشەی نوێ جیاوازبێ لە کۆنەکە."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "هەوڵبدە چەن پیتێک و ژمارە بگۆڕە."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "هەوڵ بدە هەندێ لە وشەی تێپەڕبوونەکە بگۆڕە."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "ئەگەر وشەی تێپەڕبوون ناوەکەتی تێدا نەبێت بەهێزتر دەبێت."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "هەوڵ بدە ناوەکەت تێکەڵ مەکە بە وشەی تێپەڕبوونەکە."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "هەوڵ بدە چەند پیتێک بەکارمەهێنە کە لە وشەی تێپەڕبوونەکە هەیە."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "هەوڵ بدە پیتی باو بەکارمەهێنە."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "هەوڵ بدە پیتە نووسراوەکان ڕێک مەخەرەوە و بینوسیتەوە."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "هەوڵ بدە ژمارەی زیاتر بنووسە."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "هەوڵ بدە پیتی گەورە بنووسیت."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "هەوڵ بدە پیتی بچووک بەکاربێنە."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "هەوڵ بدە هێمای تایبەت، وەکو خاڵبەندی بەکاربێنە."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "هەوڵ بدە تێکەڵەیەک لە پیتەکان، ژمارەکان و خاڵبەندییەکان بەکاربێنە."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "هەوڵ بدە هەمان هێما دووبارە مەکەرەوە."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"هەوڵ بدە هەمان هێما دووبارە مەکەرەوە: پێویستە تێکەڵیەک لە پیتەکان، ژمارەکان "
-"و خاڵبەندییەکان بەکاربێنیت."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "هەوڵ زنجیرەی لە دووای یەک وەکو ١٢٣٤ یان ابجد بەکارمەهێنە."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"وشەی تێپەڕبوون پێویستە درێژتر بێ. هەوڵ بدە پیت، ژمارە، خاڵبەندی زیاتر "
-"بەکاربێنە."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "هەردوو پیتی گەورە و بچووک تێکەڵبکە لەگەڵ ژمارەیەک یا زیاتر."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "پیتی زیاتر بەکاربێنە، ژمارە و خاڵبەندی تێپەرەوشە بەهێزتر دەبێت."
-
-#: panels/user-accounts/run-passwd.c:424
-msgid "Authentication failed"
-msgstr "ڕێپێدان سەرکەوتوو نەبوو"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The new password is too short"
-msgstr "وشەی تێپەڕبوونی نوێ زۆر کورتە"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password is too simple"
-msgstr "وشەی تێپەڕبوونی نوێ زۆر سادەیە"
-
-#: panels/user-accounts/run-passwd.c:516
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "وشەی تێپەڕبوونی نوێ و کۆن زۆر لەیەک دەچن"
-
-#: panels/user-accounts/run-passwd.c:519
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "وشەی تێپەڕبوونی نوێ پێشتر بەکارهێنراوە."
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "وشەی تێپەڕبوونی نوێ دەبێت ژمارە یان هێمای تایبەتی تێدابێت."
-
-#: panels/user-accounts/run-passwd.c:526
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "وشەی تێپەڕبوونی نوێ و کۆن وەکو یەکن"
-
-#: panels/user-accounts/run-passwd.c:530
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:534
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "تێپەڕە وشە نوێییەکە بەشی پێویست نووسە جیاوازەکانی تێدانییە"
-
-#: panels/user-accounts/run-passwd.c:538
-#, c-format
-msgid "Unknown error"
-msgstr "هەڵەیەکی نەزانراو"
-
-#: panels/user-accounts/user-utils.c:439
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-
-#: panels/user-accounts/user-utils.c:443
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "ببورە، ئەو نازناوە بەردەست نییە. تکایە دانەیەکیتر تاقی بکەرەوە."
-
-#: panels/user-accounts/user-utils.c:488
-msgid "The username is too long."
-msgstr "نازناوەکە زۆر درێژە"
-
-#: panels/user-accounts/user-utils.c:550
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr "ئەمە بەکاردێ بۆ بوخچەی ماڵەوە وە ناتوانرێ بگۆڕدرێ."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"تۆ ڕێگەپێدراو نیت تا دەستبگریت بەسەر ئامێرەکە. پەیوەندی بکە بە "
-"بەڕێوبەریسیستەمەکەت."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "ئامێر لە کاردایە."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr "هەڵەی ناوەکی ڕویدا."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Enabled"
-msgstr "چالاككراوە"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:259
-msgid "Delete registered fingerprints?"
-msgstr "پەنجەمۆرە تۆمارکراوەکان دەسڕیتەوە؟"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "_Delete Fingerprints"
-msgstr "پەنجەمۆرەکان _بسڕەوە"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:269
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"تۆ دەتەوێت پەنجەمۆرە تۆمارکراوەکانت بسڕیتەوە کەواتە چوونەژوورەوەی پەنجەمۆر "
-"ناچالاک دەکرێت؟"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:439
-msgid "Done!"
-msgstr "ئەنجام درا!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:500
-#: panels/user-accounts/um-fingerprint-dialog.c:542
-#, c-format
-msgid "Could not access “%s” device"
-msgstr "ناتوانرێت بچیتە ناو ئامێری  “%s”"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:583
-#, c-format
-msgid "Could not start finger capture on “%s” device"
-msgstr "ناتوانرێت دەستبکرێت بە تۆمارکردنی پەنجە لە ئامێری  “%s”"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:627
-msgid "Could not access any fingerprint readers"
-msgstr "ناتوانرێت دەستبگیرێت بەسەر هیچ لە خوێنەرەکانی  پەنجەمۆر"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:628
-msgid "Please contact your system administrator for help."
-msgstr "تکایە پەیوەندی بکە بە بەڕیوەبەری سیستم بۆ یارمەتی."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: panels/user-accounts/um-fingerprint-dialog.c:710
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the “%s” device."
-msgstr ""
-"بۆ چالاککردنی چوونەژوورەوەی پەنجەمۆر، پێویستە یەکێک لە پەنجەمۆرەکانت خەزن "
-"بکەی، بە بەکارهێنانی ئامێری “%s”."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:717
-msgid "Selecting finger"
-msgstr "دیاریکردنی پەنجە"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:718
-msgid "Enrolling fingerprints"
-msgstr "تۆمارکرنی پەنجەمۆرەکان"
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "نەخشەی دوگمەکان"
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "_داخستن"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "نەخشەی دوگمەکان بۆ کردارەکان"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 
-#: panels/wacom/calibrator/calibrator.ui:61
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_داخستن"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
 
-#: panels/wacom/calibrator/calibrator.ui:78
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.c:249
-#, c-format
-msgid "Button %d"
-msgstr "دوگمەی %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "داوانامە ناسراوە"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "گۆڕینی پیشاندەر"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "تابلێت"
 
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:249
-msgid "Output:"
-msgstr "دەرخستە:"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "ئاڕاستە"
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:261
-msgid "Keep aspect ratio (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:272
-msgid "Map to single monitor"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "%s مۆنیتەر"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
 msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
-msgstr "%d  لە %d"
-
-#: panels/wacom/cc-wacom-page.c:516
-msgid "Display Mapping"
-msgstr "نەخشەی پیشاندان"
-
-#: panels/wacom/cc-wacom-panel.c:806 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#: panels/wacom/cc-wacom-stylus-page.c:360
-msgid "Button"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "_پێوانەکردن..."
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "تاتەبژمێر نەدۆزرایەوە"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "تکایە پێوەی بکە و تاتەژمێری واکۆم بخەئیش"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "نەرم"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "دوگمە"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "دوگمە"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "دوگمە"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "کرتەی دوگمەی ناوەڕاستی مشک"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "کرتەی دوگمەی ڕاستی مشک"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "بڕۆ پێشەوە"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr "تاتەبژمێری واکۆم"
 
@@ -8001,206 +4814,347 @@ msgstr "تاتەبژمێری واکۆم"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/wacom/gnome-wacom-panel.desktop.in.in:7
-msgid "input-tablet"
-msgstr "input-tablet"
-
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "تاتەبژمێر (ڕەها)"
-
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "هەڵبژاردەکانی تاتەبژمێر"
-
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "_یارمەتی"
-
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
-msgstr "تاتەبژمێر نەدۆزرایەوە"
-
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "تکایە پێوەی بکە و تاتەژمێری واکۆم بخەئیش"
-
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
-msgstr "ڕێکخستنەکانی بلووتووس"
-
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
-msgstr "دۆزی بەدواداچوون"
-
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:296
-#: panels/wacom/gnome-wacom-properties.ui:401
-msgid "Map to Monitor…"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
-msgstr "ڕێکخستنی مشک چاک بکە"
-
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
-msgstr "ڕێککردنی وردی پیشاندەر"
-
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr "قەدبڕی نوێ..."
-
-#: panels/sound/cc-alert-chooser.ui:12 panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "بنەڕەت"
-
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "کرتەی دوگمەی ناوەڕاستی مشک"
-
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "کرتەی دوگمەی ڕاستی مشک"
-
-#: panels/region/cc-format-chooser.ui:48 panels/wacom/wacom-stylus-page.ui:37
-#: shell/cc-window.ui:232
-msgid "Back"
-msgstr "بڕۆدواوە"
-
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "بڕۆ پێشەوە"
-
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
-msgid "Soft"
-msgstr "نەرم"
-
-#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
-msgid "Firm"
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:234
-msgid "Top Button"
-msgstr "دوگمەی سەرەوە"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "نەرمەواڵەی پەنجەرەکان"
 
-#: panels/wacom/wacom-stylus-page.ui:263
-msgid "Lower Button"
-msgstr "دوگمەی خوارەوە"
-
-#: panels/wacom/wacom-stylus-page.ui:292
-msgid "Lowest Button"
-msgstr "دوگمەی خوارخوارەوە"
-
-#: panels/wacom/wacom-stylus-page.ui:321
-msgid "Tip Pressure Feel"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
 msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Settings"
-msgstr "ڕێکخستنەکانی گنۆم"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "مەرەکەبی کەمە"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "دوواکەوتنی کرتەی لاوەکیی"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "نەرمەواڵەی پەنجەرەکان"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "هەڵبژاردەکانی چوونەناو"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "زیادکردن"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_پاشەکەوتکردن"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "وردەکارییەکان"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+msgid "Modem Status"
+msgstr "دۆخ:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "ناوی ڕایەڵە"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "ڕایەڵەکان"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "ژمارەکان"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "زانیارییەکانی چاپکەر"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "دامەزراوە"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "ئینتەرنێتی خێرای _مۆبایل"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "ناوی ڕایەڵە"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "ڕایەڵە"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "پەرەسەندوو"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "هەڵبژاردەکانی چوونەناو"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "قفڵی شاشە"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "%s وردەکارییەکان"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "ناوی ڕایەڵە"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "خۆکار"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "ڕایەڵە دیارەکان"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "هیچ گونجێنەرێکی Wi-Fi نەدۆزرایەوە"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "دڵنیابە کە گونجێنەرێکی Wi-Fi پێوەکراوە و هەڵکراوە"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "بلووتووس ناچالاک دەکرێت کاتێک دوخی فڕۆکە هەڵبکرێ"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "دۆخی فڕۆکە بکوژێنەوە"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "پەیوەستبوون لەبیربکە"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "سیم کارت تێنەخراوە"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "قفڵی شاشە"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "گۆڕ_ین"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "ڕایەڵە دیارەکان"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "ڕێکخستنەکانی میدیای هەڵگرتەنی چاک بکە"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
 msgstr "ئامرازێکە بۆ ڕێکخستنی ڕوومێزی گنۆم"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr ""
 
-#: shell/cc-application.c:58
-msgid "Display version number"
-msgstr "ژمارەی وەشان پیشان بدە"
-
-#: shell/cc-application.c:59
-msgid "Enable verbose mode"
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
 msgstr ""
 
-#: shell/cc-application.c:60
-msgid "Search for the string"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
 msgstr ""
 
-#: shell/cc-application.c:61
-msgid "List possible panel names and exit"
-msgstr ""
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "تایبەتێتی"
 
-#: shell/cc-application.c:62
-msgid "Panel to display"
-msgstr "بەش بۆ پیشان دان"
-
-#: shell/cc-application.c:62
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: shell/cc-panel-loader.c:293
-msgid "Available panels:"
-msgstr "بەشە بەردەسەکان:"
-
-#: shell/cc-window.ui:140
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "هەموو ڕێکخستنەکان"
 
-#: shell/cc-window.ui:178
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr "پێڕستی سەرەکی"
 
-#: shell/cc-window.ui:319
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr "ئاگاداربە: وەشانی گەشەپێدەرانە"
 
-#: shell/cc-window.ui:320
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
 "issues. "
 msgstr ""
 
-#: shell/cc-window.ui:331
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "یارمەتی"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: shell/gnome-control-center.desktop.in.in:5
-msgid "org.gnome.Settings"
-msgstr "org.gnome.Settings"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "Preferences;Settings;"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -8212,7 +5166,7 @@ msgctxt "shortcut window"
 msgid "Quit"
 msgstr "دەرچوون"
 
-#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "گەڕان"
@@ -8222,15 +5176,19 @@ msgctxt "shortcut window"
 msgid "Panels"
 msgstr "بەشەکان"
 
-#: shell/help-overlay.ui:40
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
 msgstr ""
 
-#: shell/help-overlay.ui:53
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "گەڕان هەڵبوەشێنەوە"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;"
 
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
@@ -8251,30 +5209,2429 @@ msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1883
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1893
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: subprojects/gvc/gvc-mixer-control.c:2750
-msgid "System Sounds"
-msgstr "دەنگەکانی سیستم"
+#~ msgid "System Bus"
+#~ msgstr "تێپەڕگەی سیستەم"
 
-#~ msgid "Wallpapers"
-#~ msgstr "کاغەزەکانی دیوار"
+#~ msgid "Full access"
+#~ msgstr "دەستپێگەشتنی تەواو"
+
+#~ msgid "Session Bus"
+#~ msgstr "تێپەڕگەی وانەکۆڕ"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "دەستپێگەشتنی تەواو بۆ /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "دەستگەیشتنی بۆ ڕایەڵە هەیە"
+
+#~ msgid "Home"
+#~ msgstr "ماڵەوە"
+
+#~ msgid "Read-only"
+#~ msgstr "تەنها-خوێندنەوە"
+
+#~ msgid "Can change settings"
+#~ msgstr "ڕێكخستنەكان دەتوانرێ بگۆڕدرێ"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s شوێن مۆڵەتپێدانەکان دەکەوێت کە لەناویدا هەیە. ئەمانە ناتوانرێ بگۆڕدرێ. "
+#~ "ئەگەر تۆ نیگەرانی دەربارەی ئەم مۆڵەتپێدانانە، ڕەچاوی سڕینەوەی ئەم "
+#~ "بەرنامەیە بکە."
+
+#~ msgid "Web Links"
+#~ msgstr "بەستەرەکانی وێب"
+
+#~ msgid "Git Links"
+#~ msgstr "بەستەرەکانی گێت (Git)"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "بەستەرەکان %s"
+
+#~ msgid "Unset"
+#~ msgstr "دانەنان"
+
+#~ msgid "Links"
+#~ msgstr "به‌سته‌ره‌كان"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "پەڕگەکانی سەروودەق"
+
+#~ msgid "Text Files"
+#~ msgstr "فایلەکانی دەق"
+
+#~ msgid "Image Files"
+#~ msgstr "پەڕگەکانی وێنە"
+
+#~ msgid "Font Files"
+#~ msgstr "پەڕگەکانی فۆنت"
+
+#~ msgid "Archive Files"
+#~ msgstr "پەڕگەکانی ئەرشیف"
+
+#~ msgid "Package Files"
+#~ msgstr "پەڕگەکانی بوخچە"
+
+#~ msgid "Audio Files"
+#~ msgstr "پەڕگەکانی دەنگ"
+
+#~ msgid "Video Files"
+#~ msgstr "پەڕگەکانی ڤیدیۆ"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "مۆڵەتپێدانەکان و دەستپێگەشتن"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "دراو و خزمەتگوزارییەکان کە ئەم بەرنامەیە پرسیاریکرد بۆ دەستگەیشتن پێی و "
+#~ "مۆڵەتپێدانی پێویستە(داواکراوە)."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "ناتوانرێ بگۆڕدرێ"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "مۆڵەتپێدانە تاکەکەسییەکان بۆ بەرنامەکان دەتوانرێ پیداچوونەوەی بۆ بکرێ لە "
+#~ "<a href=\"privacy\">تایبەتێتی</a>کەی ڕێکخستنەکان."
+
+#~ msgid "Integration"
+#~ msgstr "یەکخستن"
+
+#~ msgid "Default Handlers"
+#~ msgstr "وەدەستخەرە بنەڕەتییەکان"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "جۆرەکانی پەرڕگەکان و بەستەرەکان کە لەم بەرنامەیە دەکرێنەوە."
+
+#~ msgid "Usage"
+#~ msgstr "بەکارهێنان"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "ئەم بەرنامەیە چەند سەرچاوە بەکاردەهێنێت."
+
+#~ msgid "Open in Software"
+#~ msgstr "بیکەرەوە لە نەرمەواڵا"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "هەژمارەکانی بەکارهێنەر زیاد بکە و تێپەڕەوشەکان بگۆڕە"
+
+#~ msgid "Play and record sound"
+#~ msgstr "دەنگ لێبدە و تۆماربکە"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr ""
+#~ "ئامێرەکانی ڕایەڵە بدۆزەرەوە کە mDNS/DNS-SD بەکاردەهێنن (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "ڕاستەوخۆ دەستبگرە بەسەر ڕەقەکاڵای بلووتووس"
+
+#~ msgid "Use bluetooth devices"
+#~ msgstr "ئامێرەکانی بلووتووس بەکاربێنە"
+
+#~ msgid "Print documents"
+#~ msgstr "بەڵگەنامەکان چامبکە"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "هەر گێڕ و دەسکێکی پەیوەستکراو بەکاربێنە"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "ڕێگەبدە بە پەیوەستبوون بە خزمەتگوزاریەکانی (Docker)ەکە"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "دیواری ئاگرینی ڕایەڵە ڕێکبخە"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "سیستەمەکانی پەڕگەی FUSE  شاراوە بەکار بهێنە و جێگیریبکە"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "لەم ئامێرە پتەوواڵە نوێبکەوە"
+
+#~ msgid "Access hardware information"
+#~ msgstr "زانیاری دەستپێگەشتنی ڕەقەکاڵا"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "ئینترۆپی بەدەست بێنە بۆ ڕەقەکاڵای پێکهێنەری ژمارە هەڕەمەکییەکان"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "ڕەقەکاڵای-بەرهەمهاتووی ژمارە هەڕەمەکییەکان"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "دەستبگرە بەسەر پەرڕگەکان لە بوخچەی ماڵەوەت"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "دەستبگرە بەسەر خزمەتگوزارییەکانی libvirt"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "زمانی سیستەم و ناوچەی ڕێکخستنەکان بگۆڕە"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "شوێنی ڕێکخستنەکان و دابینکەرەکان بگۆڕە"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "سیستەم و تۆماری بەرنامەکان بخوێنەوە"
+
+#~ msgid "Access LXD service"
+#~ msgstr "دەستبگرە بەسەر خزمەتگوزاری LXD"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "دەستبگرە بەسەر خزمەتگوزاری ناوەندی-میدیا کە"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "مۆدیۆمەکان بەکاربێنە و ڕێکیبخە"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "زانیاری گرێدانی سیستەم و بەشی دیسک بخوێنەوە"
+
+#~ msgid "Control music and video players"
+#~ msgstr "کۆنتڕۆڵی مۆسیقا و ڤیدیۆ پەخشکەرەکان بکە"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "ڕێکخستنی ڕایەڵەی ئاست-نزم بگۆڕە"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "دەستبگرە بەسەر خزمەتگوزاری بەڕێوبەری ڕایەڵە بۆ خوێندنەوە و گۆڕینی "
+#~ "ڕێکخستنەکانی ڕایەڵە"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "دەستگەیشتنی ڕێکخستنەکانی ڕایەڵە بخوێنەوە"
+
+#~ msgid "Change network settings"
+#~ msgstr "ڕێکخستنەکانی ڕایەڵە بگۆڕە"
+
+#~ msgid "Read network settings"
+#~ msgstr "ڕێکخستنەکانی ڕایەڵە بخوێنەوە"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "دەستبگرە بەسەر خزمەتگوزاری ئۆفۆنۆ بۆ خوێندنەوە و گۆڕینی ڕێکخستنەکانی "
+#~ "ڕایەڵە بۆ بەکارهێنانەکانی مۆبایل"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "کۆنتڕۆڵی ڕەقەواڵای Open vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "بخوێنەوە لەڕێی CD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "تێپەڕەوشە خەزنکراوەکان بخوێنەوە، زیادبکە ،بگۆڕە ،یان بیسڕەوە"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "دەسبگرە بەسەر ئامێرەکانی pppd و ppp بۆ خاڵ-بۆ-خاڵ ی پەیوەندییەکانی کۆنووس"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "بیوەستێنە یان کۆتیی بە هەر پڕۆسەیەکی سیستەمەکە بێنە"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "ڕاستەوخۆ دەستبگرە بەسەر ڕەقەواڵای USB"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "پەڕگەکان بخوێنەوە/بنووسە لە ئامێرەکانی بیرگە دەرەکییەکان"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "ڕێبگرە لە خەوتن/قفڵبوون"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "دەستبگرە بەسەر ڕەقەواڵای دەرچەی سڕیاڵ"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "ئامێرەکە داستپێبکەرەوە یان بیکوژێنەوە"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "نەرمەواڵا دابمەزرێنە، بیسڕەوە و ڕێکیبخە"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "دەستبگرە بەسەر خزمەتگوزاری بناغەی بیرگە"
+
+#~ msgid "Read process and system information"
+#~ msgstr "پڕۆسە و زانیاری سیستەم بخوێنەوە"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "چاودێری و کۆنتڕۆڵی هەر بەرنامەیەکی ‌هەڵکراو بکە"
+
+#~ msgid "Change the date and time"
+#~ msgstr "بەروار و کاتەکە بگۆڕە"
+
+#~ msgid "Change time server settings"
+#~ msgstr "کاتی ڕێکخستنەکانی ڕاژە بگۆڕە"
+
+#~ msgid "Change the time zone"
+#~ msgstr "کاتی هەرێمەکەت بگۆڕە"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "دەستبگرە بەسەر خزمەتگوزاری UDisks2ەکە بۆ ڕێکخستنی دیسکەکان و میدیا "
+#~ "دەرکییەکان"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "بۆنەکانی ڕۆژژمێری هاوبەشی پێکراو بخوێنەوە/بگۆڕە لە ئۆبونتو یونتی ٨"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "پەیوەندییەکان هاوبەش بکە لە یوونیتی ٨ ی ئوبونتو بخوێنەوە/بگۆڕەوە"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "دەستبگرە بەسەر دراوی بەکارهێنانی وزە"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "دەستبگرە بەسەر خوێندنەوە/نوسینی پێشاندانی ئامێرەکانی U2F"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "Select a picture"
+#~ msgstr "وێنەیەک دیاریبکە"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "پاشبنەما و قفڵی شاشە دابنێ"
+
+#~ msgid "Set Background"
+#~ msgstr "پاشبنەما دابنێ"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "قفڵی شاشە دابنێ"
+
+#~ msgid "Remove Background"
+#~ msgstr "قفڵی شاشە بسڕەوە"
+
+#~ msgid "multiple sizes"
+#~ msgstr "قەبارەى زۆر"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "پاشبنەمای ڕوومێز نییە"
+
+#~ msgid "Current background"
+#~ msgstr "پاشبنەمای ئێستا"
+
+#~ msgid "Activities"
+#~ msgstr "چالاکییەکان"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "دیوارپۆش؛شاشە؛ڕوومێز"
+
+#~ msgid "bluetooth"
+#~ msgstr "بلوتوبلووتووس"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "ئامێرە مەزەندەکراوەکەت دابنێ لەسەر چوارگۆشەکە و پەنجەبنێ بە \"دەستپێکردن\""
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "ئامێرە مەزەندەکراوەکەت بجوڵێنە بۆ شوێنی پێوانەکردنەکە و پەنجەبنێ بە "
+#~ "“بەردەوامبوون”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "ئامێرە مەزەندەکراوەکەت بجوڵێنە بۆ شوێنی ڕووبەرەکە و  پەنجەبنێ بە "
+#~ "“بەردەوامبوون”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "شاشەی لاپتۆپەکە پێوەبدە"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "هەڵەیەکی ناوخۆیی ڕوویدا کە ناتونرێ چاکبکرێتەوە."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "ئامڕازە داواکراوەکان بۆ مەزندەکردن دانەمەزراون"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "زانیارییە کەسییەکە ناتوانرێ دروستبکرێ"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "ئامانجە خاڵ سپییەکە دەستنەکەوت"
+
+#~ msgid "Complete!"
+#~ msgstr "تەواو!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "مەزندەکردن شکستیهێنا!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "دەتوانی ئامێرە مەزندەکراوەکان لێبکەیتەوە."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "ئامێرە مەزندەکراوەکان تێکمەدە لە کاتی پڕۆسەدا"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "شاشەی لاپتۆپ"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "وێبكامی لەناودایە"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s پشکنەر"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s کامێرا"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s چاپکەر"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s وێبکام"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "بەڕێوەبەرایەتی ڕەنگەکان چالاک بکە بۆ %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "ڕەنگی زانیارییە کەسەییەکان پیشان بدە بۆ %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "مەدندەنەکراوە"
+
+#~ msgid "Default: "
+#~ msgstr "بنەڕەت: "
+
+#~ msgid "Test profile: "
+#~ msgstr "زانیاری کەسی تاقیبکەرەوە: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "پەڕگەی زانیاری کەسی ICC دیاریبکە"
+
+#~ msgid "_Import"
+#~ msgstr "_هێنان"
+
+#~ msgid "All files"
+#~ msgstr "هه‌موو په‌ڕگه‌كان"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "بارکردنی پەڕگە شکستی هێنا: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "زانیارییە کەسییەکان بارکران بۆ:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "لەخوارەوە ئەم URL بنووسە."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "ئەم کۆمپیتەرە دەستپێکەرەوە و سیستەمی کارپێکەری ئاسایت بخەرە ڕێ."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "URLەکە لەناو وێبگەڕەکەت بنووسە"
+
+#~ msgid "Save Profile"
+#~ msgstr "زانیاری کەسی پاشەکەوت بکە"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "ڕەنگێکی زانیاری کەسی دروستبکە بۆ ئامێرە دیاریکراوەکە"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "ئامێری پێوانەکردنەکە نەزدۆرایەوە. تکایە بیپشکنە کە هەڵکراوە و  ئێستا "
+#~ "پەیوەستبووە."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "ئامێری پێوانەکردنەکە پشتگیری کورتەی چاپکەرەکە ناکات."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "جۆری ئامێرەکە بە لەم کاتەدا پشتگیری ناکرێ."
+
+#~ msgid "Upload profile"
+#~ msgstr "پرۆفایل بەرزبکەرەوە"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "پێویستی بە هێڵی ئینتەرنێتە"
+
+#~ msgid "Standard Space"
+#~ msgstr "بۆشای ئاسای"
+
+#~ msgid "Test Profile"
+#~ msgstr "پڕۆفایلی بۆ تاقیکردنەوە"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "خۆکار"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "جۆرایەتی لاواز"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "جۆرێتی ناوەند"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "جۆرێتی بەرز"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB بنەڕەت"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK بنەڕەت"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "رەساسی بنەڕەت"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "دراوی خەمڵێنراوی کارگەی سامانی فرۆشیار"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "ڕاستکەرەوەی پیشاندەری شاشەی پڕ بەردەست نییە لەم پڕۆفایلە"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "ئەم پڕؤفایلە لەوانەیە لەمەودوا تەواو نەبێت"
+
+#~ msgid "preferences-color"
+#~ msgstr "ڕەنگی-هەڵبژاردەکان"
+
+#~ msgid "Today"
+#~ msgstr "ئەمڕۆ"
+
+#~ msgid "Yesterday"
+#~ msgstr "دوێنێ"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "خاڵی داخ"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "24-hour"
+#~ msgstr "24-کاتژمێر"
+
+#~ msgid "AM / PM"
+#~ msgstr "پێش ن/دوا ن"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "گۆڕناکان جێبەجێبکرێت؟"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "گۆڕانەکان ناتوانرێ جێبەجێبکرێ"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "دەتوانرێ پێشبینیبکرێ بۆ سنوردارکردنی ڕەقەکاڵا."
+
+#~ msgid "Display Mode"
+#~ msgstr "دۆزی پشاندەر"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "پشاندەرەکان ڕابکێشە بۆ گونجاندنی پیشاندەرە جێگیرکراوە فیزیاییکەت. "
+#~ "پیشاندەرێک دیاریبکە بۆ گۆڕینی ڕێکخسنەکان."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "ڕێکخستنی پیشاندەر"
+
+#~ msgid "Display Configuration"
+#~ msgstr "شێوەپێدانی پیشاندەر"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "ئاسۆی"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "لەسەر لای ڕاست"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "لەسەر لای چەپ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "ئاسۆی (هەڵگەڕاوە)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf هێرتز"
+
+#~ msgid "More Warm"
+#~ msgstr "گەرم تر"
+
+#~ msgid "Less Warm"
+#~ msgstr "کەمتر گەرم"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "Unknown"
+#~ msgstr "نەزانراو"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "Ask what to do"
+#~ msgstr "پرسیاربکە بۆ ئەوەی چیبکات"
+
+#~ msgid "Do nothing"
+#~ msgstr "هیچ مەکە"
+
+#~ msgid "Open folder"
+#~ msgstr "بوخچە بکەرەوە"
+
+#~ msgid "Other Media"
+#~ msgstr "میدیای تر"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "داوانامە هەڵبژێرە بۆ سی دی دەنگی"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "داوانامە هەڵبژێرە بۆ دی-ڤیدی دەنگ و ڕەنگ"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "داوانامە هەڵبژێرە بۆ کارکردن کاتێک لێدەری میوزیک پەیوەست دەکرێت"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "داوانامە هەڵبژێرە بۆ کارکردن کاتێک کامێرا پەیوەست دەکرێت"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "داوانامە هەڵبژێرە بۆ داوانامەی سی-دی"
+
+#~ msgid "audio DVD"
+#~ msgstr "دی-ڤیدی دەنگی"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "پەپکەی بەتاڵی بلو-ڕەی"
+
+#~ msgid "blank CD disc"
+#~ msgstr "پەپکەی بەتاڵی سی-دی"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "پەپکەی بەتاڵی دی-ڤیدی"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "پەپکەی بەتاڵی HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "پەپکەی ڤیدیۆی بلو-ڕەی"
+
+#~ msgid "e-book reader"
+#~ msgstr "خوێنەرەوەی کتێکی-ئەلکترۆنی"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "پەپکەی ڤیدیۆییHD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "سی-دی وێنە"
+
+#~ msgid "Super Video CD"
+#~ msgstr "سی-دی ڤیدیۆیی سوپەر"
+
+#~ msgid "Video CD"
+#~ msgstr "سی-دی ڤیدیۆیی"
+
+#~ msgid "starred"
+#~ msgstr "دەستپێکرا"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "Launch terminal"
+#~ msgstr "کۆتاگه‌ کارپێبکە"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "وێنەیەکی شاشە پاشەکەوتبکە بۆ $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "وێنەیەکی شاشەی پەنجەرەیەک پاشەکەوتبکە بۆ $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "وێنەیەکی شاشەی ناوچەیەک پاشەکەوتبکە بۆ $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "وێنەیەکی شاشەیەک لەبەربگرەوە بۆ لیستەی لەبەرگیراوە"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "وێنەیەکی شاشەی پەنجەرەیەک پاشەکەوتبکە بۆ لیستەی لەبەرگیراوە"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "وێنەیەکی شاشەی ناوچەیەک پاشەکەوتبکە بۆ لیستەی لەبەرگیراوە"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "ڤیدیۆیەکی کورتی شاشە تۆماربکە"
+
+#~ msgid "Universal Access"
+#~ msgstr "دەستگەیشنی گەردوونی"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "تەنها-ڕێکخەرەکان بیگۆڕە سەر سەرچاوەی دواتر"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "هەمووی قەدبڕەکان ڕێکدەخەیتەوە؟"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "رێکخستنەوهی قەدبڕەکان لەوانەیە کاریگەری هەبێ لەسەر قەدبڕە دروستکراوەکان. "
+#~ "ئەمە ناتوانرێ هەڵ بوەشێندرێتەوە."
+
+#~ msgid "Reset All"
+#~ msgstr "هەمووی ڕێکبخەوە"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "قەدبڕی دروستکراو دابنێ"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "قەدبڕە نوێییەکە تۆماربکە"
+
+#~ msgid "Set"
+#~ msgstr "دانان"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "وەستانی جووت-کلیک"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "پێچۆکه‌گه‌ری دوو-پەنجە"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "پێنج کرتە، کاتی (GEGL)ـە!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "جووت کرتە، دوگمەی سەرەکی"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "تاک کرتە، دوگمەی سەرەکی"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "جووت کرتە، دوگمەی ناوەڕاست"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "تاک کرتە، دوگمەی ناوەڕاست"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "جووت کرتە، دوگمەی لاوەکی"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "تاک کرتە، دوگمەی لاوەکی"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "پێوستە بەڕێوبەری ڕایەڵە کاربکات"
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Preserve"
+#~ msgstr "ناوچەی پارێزراو"
+
+#~ msgid "Permanent"
+#~ msgstr "هەمیشەیی"
+
+#~ msgid "Random"
+#~ msgstr "هەڕەمەکی"
+
+#~ msgid "Stable"
+#~ msgstr "جێگیر"
+
+#~ msgid "automatic"
+#~ msgstr "خۆکار"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "زانیاریئ کەسیی %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "پرۆژەی ئابووری"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "نییە"
+
+#~ msgid "Never"
+#~ msgstr "هه‌رگیز"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "نییە"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "لاواز"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "باشە"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "باش"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "نایاب"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "پڕۆفایلی پەیوەستبوون بسڕەوە"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN بسڕەوە"
+
+#~ msgid "Identity"
+#~ msgstr "ناسنامە"
+
+#~ msgid "Delete Route"
+#~ msgstr "ڕێگە بسڕەوە"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "نییە"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit Passphrase"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamic WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA و WPA2 کەسی"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA و WPA2 پڕۆژەی ئابووری"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "ناتوانرێ دەستکاریکەری پەیوەندی بکرێتەوە"
+
+#~ msgid "New Profile"
+#~ msgstr "زانیاری کەسیی نوێ"
+
+#~ msgid "Import from file…"
+#~ msgstr "هێنان لە پەڕگە..."
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN زیادبکە"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "ناتوانرێت پەیوەندی VPNبهێنرێت"
+
+#~ msgid "Select file to import"
+#~ msgstr "پەڕگە دیاریبکە بۆ هێنان"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "پەڕگەیەک بە ناوی “%s” پێشتر بوونی هەیە."
+
+#~ msgid "_Replace"
+#~ msgstr "_جێگرتنەوە"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "ناتوانرێت پەیوەندی VPN هاوردەبکرێ"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "پەیوەندی VPN هاوردەبکە"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "never"
+#~ msgstr "هەرگیز"
+
+#~ msgid "today"
+#~ msgstr "ئەمڕۆ"
+
+#~ msgid "yesterday"
+#~ msgstr "دوێنێ"
+
+#~ msgid "Last used"
+#~ msgstr "دواین بەکارهێنان"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "خاڵی داخ بوەستێنە و هەر بەکار‌هێنەرێک ناچالاک بکرێت؟"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "خاڵیداخ _بوەستێنە"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "ئامێری بێتەل پشتگیری دۆخی خاڵی داخ ناکات"
+
+#~ msgid "_Forget"
+#~ msgstr "_لەبیرکردن"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "ڕایەڵەکانی وای-فای ناسراوە"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_لەبیرکردن"
+
+#~ msgid "Off"
+#~ msgstr "کوژاوەتەوە"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "بیکوژێنەوە بۆ ئەوەی پەیوەندی بکەی بە ئینتەرنێت"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "تێپەڕەوشە"
+
+#~ msgid "Status unknown"
+#~ msgstr "دۆخ نەزانراوە"
+
+#~ msgid "Unmanaged"
+#~ msgstr "ڕێکنەخراوە"
+
+#~ msgid "Unavailable"
+#~ msgstr "بەردەست نییە"
+
+#~ msgid "Connecting"
+#~ msgstr "پەیوەندی دەگرێت"
+
+#~ msgid "Authentication required"
+#~ msgstr "ڕێپێدان پێویستە"
+
+#~ msgid "Disconnecting"
+#~ msgstr "لە پەیوەندی دەرچوون"
+
+#~ msgid "Connection failed"
+#~ msgstr "پەیوەندی سەرکەوتوونەبوو"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "دۆخ نەزانراوە (بوونی نیە)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "ڕێکخستن سەرکەوتوو نەبوو"
+
+#~ msgid "Modem not found"
+#~ msgstr "مۆدیۆم نەدۆزرایەوە"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "پەیوەستبوونەوەی بلووتووس سەرکەوتوو نەبوو"
+
+#~ msgid "On"
+#~ msgstr "هەڵکراوە"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "هیتر"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "هەژماری %s"
+
+#~ msgid "Error removing account"
+#~ msgstr "هەڵەیەک ڕویدا لەکاتی سڕینەوەی هەژمار"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "Remove Account"
+#~ msgstr "هەژمار بسڕەوە"
+
+#~ msgid "Unknown time"
+#~ msgstr "کات نەزانراوە"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s تا بە تەواوی بارگاوی دەبێت"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "ئاگاداری: %s ماوە"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s ماوە"
+
+#~ msgid "Fully charged"
+#~ msgstr "بەتەواویی بارگاوی کرا"
+
+#~ msgid "Not charging"
+#~ msgstr "بارگاوی نابێت"
+
+#~ msgid "Empty"
+#~ msgstr "بەتاڵ"
+
+#~ msgid "Charging"
+#~ msgstr "بارگاوی کردن"
+
+#~ msgid "Discharging"
+#~ msgstr "بارگاویناکرێ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "سەرەکی"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "زیادە"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "مشکی بێ تەل"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "تەختەکلیلی بێ تەل"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "نەبڕینی سەرچاوەی وزە"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "یاریدەدەری دیجیتاڵی کەسی"
+
+#~ msgid "Cellphone"
+#~ msgstr "تەلەفۆنی پەیوەندی"
+
+#~ msgid "Media player"
+#~ msgstr "لێدەری ڕەنگاڵە"
+
+#~ msgid "Computer"
+#~ msgstr "کۆمپیتەر"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "بارگاوی کردن"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "ئاگاداری"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "نزم"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "باش"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "بەتەواویی بارگاوی کرا"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "بەتاڵ"
+
+#~ msgid "Batteries"
+#~ msgstr "پاترییەکان"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d  کاژێر"
+#~ msgstr[1] "%d  کاژێر"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d خولەک"
+#~ msgstr[1] "%d خولەک"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d چرکە"
+#~ msgstr[1] "%d چرکە"
+
+#, c-format
+#~ msgctxt "time"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "time"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_ڕووناکی شاشە"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_ڕوونی تەختەکلیل"
+
+#~ msgid "_Dim Screen When Inactive"
+#~ msgstr "شاشەکە _تاریک کاتێک بەکارناهێنرێت"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_وای-فای"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "دەتوانرێت وای-فای بکوژێنرێتەوە بۆ خەزنکردنی وزە."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "ئینتەرنێتی خێرای مۆبایل (LTE, 4G, 3G, هتد...) دەتوانرێت بکوژێندرێتەوە بۆ "
+#~ "خەزنکردنی وزە."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_بلووتووس"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "بلووتووس دەتوانرێت بکوژێندرێتەوە بۆ خەزنکردنی وزە."
+
+#~ msgid "When on battery power"
+#~ msgstr "کاتێک لەسەر وزەی پاتریت"
+
+#~ msgid "When plugged in"
+#~ msgstr "کاتێک بارگاوی دەبێت"
+
+#~ msgid "Suspend"
+#~ msgstr "ڕاگرتن"
+
+#~ msgid "Power Off"
+#~ msgstr "بیکوژێنەوە"
+
+#~ msgid "Hibernate"
+#~ msgstr "دۆخەپشوو"
+
+#~ msgid "Nothing"
+#~ msgstr "هیچ نەکات"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "دۆخەپشو و دوگمەی وزە"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "دۆخەپشووی خوودکار"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "١ خولەک"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "٢ خولەک"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "٣ خولەک"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "٤ خولەک"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "۵ خولەک"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "٨ خولەک"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "۱۰ خولەک"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "١٢ خولەک"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "۱٥ خولەک"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "هه‌رگیز"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "رێگەپێدان"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "چاپکەری “%s” سڕاوەتەوە"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "زیادکردنی چاپکەری نوێ سەرنەکەوت."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ناتوانرێت ui بار بکرێت: %s"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "وەگەڕخەری گونجاو نەدۆزرایەوە"
+
+#~ msgid "Select PPD File"
+#~ msgstr "پەڕگەی PPD دیاریبکە"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "فایلەکانی پێناسی چاپکەرەکانی پۆست-سکریپت (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+#~ "gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "چاپکەری جێت-دایرێکت"
+
+#~ msgid "LPD Printer"
+#~ msgstr "چاپکەری LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "یەک لاگیری"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "لێواری درێژ (ئاسایی)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "لێواری کورت (هەڵگەڕاوە)"
+
+#~ msgid "Portrait"
+#~ msgstr "ستوونی"
+
+#~ msgid "Landscape"
+#~ msgstr "ئاسۆی"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "ئاسۆیی هەڵگەڕاوە"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "ستوونی هەڵگەڕاوە"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "لەچاوەڕوانیدایە"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "ڕاگیرا"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "ڕێپێدان پێویستە"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "لە کاردایا"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "وەستێنرا"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "هەڵوەشێنرایەوە"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "لەباربرا"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "تەواوبوو"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — کارا چالاکەکان"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "بەڵگەنامەی باوەڕپێکردن بنووسە بۆ چاپکردن لە %s"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "ڕاژەی چاپکەر بکەرەوە"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s بکەرەوە."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "ناوی بەکارهێنەر و تێپەڕەوشە بنووسە بۆ بینینی چاپکەرەکان لە %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "بگەڕی بۆ چاپکەرەکان"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "دەرچەی زنجیرەیی"
+
+#~ msgid "Parallel Port"
+#~ msgstr "دەرچەی هاوشان"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "شوێن: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "ناونیشان: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "ڕاژەکان پێویستی بە ڕێگەپێدانە"
+
+#~ msgid "Two Sided"
+#~ msgstr "دوو لاگیری"
+
+#~ msgid "Paper Type"
+#~ msgstr "جۆری کاخەز"
+
+#~ msgid "Paper Source"
+#~ msgstr "سەرچاوەی کاخەز"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "وردی نیشاندانی شاشە"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "لەپێش فلتەرکردنی گۆست-سکریپت"
+
+#~ msgid "Pages per side"
+#~ msgstr "پەڕەکانی لاگیر"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "گشتی"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "ڕێکخستنی پەڕە"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "هەڵبژاردنەکانی دامەزراندن"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "کار"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "جۆرایەتی وێنە"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "ڕەنگ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "کۆتاییهێنان"
+
+#~ msgid "Test page"
+#~ msgstr "پەڕەی تاقیکردنەوە"
+
+#~ msgid "Auto Select"
+#~ msgstr "دیاریکردنی خودکار"
+
+#~ msgid "Printer Default"
+#~ msgstr "چاپکەری بنەڕەت"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "تەنها فۆنتەکانی گۆست-سکریپت بگونجێنە"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "بیگۆڕە بۆ PSی ئاستی ١"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "بیگۆڕە بۆ PSی ئاست ٢"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "پاڵوتنی پێشوەختە نییە"
+
+#~ msgid "Out of toner"
+#~ msgstr "مەرەکەبی تیا نییە"
+
+#~ msgid "Low on developer"
+#~ msgstr "گەشەپێدەری وێنەی کەمە"
+
+#~ msgid "Out of developer"
+#~ msgstr "گەشەپێدەری وێنەی نییە"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "سەرچاوەی ئاماژەپێدەری  کەمە"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "سەرچاوەی ئاماژەپێدەری  نییە"
+
+#~ msgid "Open cover"
+#~ msgstr "بەرگ بکەوە"
+
+#~ msgid "Open door"
+#~ msgstr "دەرگا بکەوە"
+
+#~ msgid "Low on paper"
+#~ msgstr "لە نزمی پەڕە"
+
+#~ msgid "Out of paper"
+#~ msgstr "لە دەرەوە پەڕە"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "دەرهێڵ"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "وەستێنرا"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "گەیەنەری وێنەی بینیەکە لە کۆتایی تەمەنیەتی (لە کار دەکەوێت)"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "گەیەنەری وێنەی بینیەکە لەمەودوا کار ناکات"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "ئامادەیە"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "کارەکان قبوڵ نەکرا"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "لە کاردایا"
+
+#~ msgid "Clean print heads"
+#~ msgstr "سەرەکانی چاپکردن پاکبکەوە"
+
+#~ msgid "Add…"
+#~ msgstr "زیادبکە..."
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "پاککردنەوەی هەموو بڕگەکان لە ناو تەنەکە خۆڵ؟"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "هەموو بڕگە و پەڕەکانی ناو گڵێشدان بە هەمیشەیی دەسڕێنەوە."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "ته‌نه‌که‌ی فڕێدان _به‌تاڵکه‌"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "هەموو پەڕگە کاتییەکان بۆ هەمیشە دەسڕێنەوە."
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "شاشە دەکوژێتەوە"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "٣٠ چرکە"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "١ خولەک"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "٢ خولەک"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "٣ خولەک"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "۵ خولەک"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "۳۰ خولەک"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "١ کاژێر"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "١ کاژێر"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "١ ڕۆژ"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "۲ ڕۆژ"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "٣ ڕۆژ"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "٤ ڕۆژ"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "٥ ڕۆژ"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "٦ ڕۆژ"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "٧ ڕۆژ"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "١٤ ڕۆژ"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "٣٠ ڕۆژ"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 ڕۆژ"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "٧ ڕۆژ"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "٣٠ ڕۆژ"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "هەتا هەتایە"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "خزمەتگوزارییەکانی شوین دەهێڵێت بەرنامەکان شوێنەکەت بزانێت.Wi-Fi و دەستەی "
+#~ "بێسنووری مۆبایل بەکاربینە بۆ زیادکردنی دروست."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "مۆزێلا خزمەتگوزاری شوێنی بەکاردەهێنێت: <a href='https://location.services."
+#~ "mozilla.com/privacy'>سیاسەتی تایبەتی</a>"
+
+#~ msgid "Send error reports to Canonical"
+#~ msgstr "ڕاپۆرتەکانی هەڵە بنێرە بۆ کانۆنیکاڵ"
+
+#~ msgid ""
+#~ "Connectivity checking is used to detect connection issues and helps you "
+#~ "to stay online. If your network communications are being monitored, it "
+#~ "could be used to gather technical information about this computer."
+#~ msgstr ""
+#~ "پشکنینی پەیوەستێتی بەکاردێ بۆ دۆزینەوەی  کێشەکانی پەیوەندی و یارمەتیت "
+#~ "دەدا سەرهێڵ بمێنیتەوە. ئەگەر ئاڵوگۆڕکردنەکانی ڕایەڵەکەت چاودێری بکرێت، "
+#~ "دەتوانرێت بەکاربهێنرێت بۆ کۆکردنەوەی زانیری تەکنیکی دەربارەی ئەم "
+#~ "کۆمپیتەرە."
+
+#~ msgid "_Connectivity Checking"
+#~ msgstr "_گەڕان بۆ پەیوەنددارێتی"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "شاهانە"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metric"
+
+#~ msgid "No input sources found"
+#~ msgstr "سەرچاوەی تێخستن نەدۆزرایەوە"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "هیتر"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "دانیشتن پێبکەرەوە بۆ ئەنجامدانی گۆڕانکارییەکان"
+
+#~ msgid "Restart…"
+#~ msgstr "پێکردنەوە..."
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "ڕێخستنەکانی چوونەژوورەوە بەکاردەبرێت لەلایان هەموو بەکار‌هێنەرەکان کاتێک "
+#~ "دەچیتە ناو سیستەمەکە"
+
+#~ msgid "Previous source"
+#~ msgstr "سەرچاوە پێشوو"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "سەرچاوەی داهاتوو"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Left+Right Alt"
+
+#~ msgid "These keyboard shortcuts can be changed in the keyboard settings"
+#~ msgstr "ئەم قەدبڕانە دەتوانرێت بگۆڕدرێت لە ڕێکخستنی تەختەکلیل"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Select Location"
+#~ msgstr "شوێن هەڵبژێرە"
+
+#~ msgid "_OK"
+#~ msgstr "_باشە"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "هیچ ڕایەڵەیەک دیارینەکرا بۆ بڵاوکردنەوە"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "هەڵکراوە"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "کوژاوەتەوە"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "چالاككراو"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "بوخچە هەڵبژێرە"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_بڵاوکردنەوەی پەردە"
+
+#~ msgid "_Password:"
+#~ msgstr "_تێپپەڕەوشە:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_وشەی تێپەڕبوون پیشان بدە"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_پەیوەندی نوێ پێوستە داوای چوونەناو بکات"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "Custom"
+#~ msgstr "ڕاسپێراو"
+
+#~ msgid "Bark"
+#~ msgstr "بارک"
+
+#~ msgid "Drip"
+#~ msgstr "دریپ"
+
+#~ msgid "Glass"
+#~ msgstr "گلاس"
+
+#~ msgid "Sonar"
+#~ msgstr "سۆنەر"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "تاقیکردنەوەی %s"
+
+#~ msgid "Over-Amplification"
+#~ msgstr "پلەدەنگی-بەزتر"
+
+#~ msgid ""
+#~ "Allows raising the volume above 100%. This can result in a loss of audio "
+#~ "quality; it is better to increase application volume settings, if "
+#~ "possible."
+#~ msgstr ""
+#~ "ڕێگەدان بۆ زیاتر لە %١٠٠. ئەمە دەبێتە هۆی لەدەستدانی جۆرێتی دەنگەکە، وا "
+#~ "باشترە ڕێکستنەکانی دەنگی داوانامە زیادبکرێت. ئەگەر دەکرێت."
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "%۱۰۰"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "هێڵەکە بچڕا"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "پەیوەندی دەگرێت"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "پەیوەستە"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "هەڵە لە ڕێپێدان"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "ڕێپێدان"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "کردار کەمکراوە"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "پەیوەستەو ڕێپێدراوە"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "نەناسراو"
+
+#~ msgid "Authorized at:"
+#~ msgstr "ڕێپێدراوە لە:"
+
+#~ msgid "Connected at:"
+#~ msgstr "پەیوەستە لە:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "بەشدارە لە:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "ڕێگە نەدراوە بە ئامێری: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "‌نەتونرا ئامیرە لەبیر بکرێ "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "هەڵە"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "ڕێپێدراوە"
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "ئاستی ئاسایشی سەندەربۆڵت ناتوانرێت دیاریبکرێت"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "All displays"
+#~ msgstr "هەموو پیشاندەرەکان"
+
+#~ msgid "Auto-hide the Dock"
+#~ msgstr "شاردنەوەی خۆکاری دۆک"
+
+#~ msgid "The dock hides when any windows overlap with it."
+#~ msgstr "دۆک لادەچیت کاتێک پەنجەرەیەک دێتە سەری."
+
+#~ msgid "Icon size"
+#~ msgstr "قەبارەی وێنۆچکە"
+
+#~ msgid "Show on"
+#~ msgstr "پیشانی بدە لە"
+
+#~ msgid "Position on screen"
+#~ msgstr "شوێنی لە پەردە"
+
+#~ msgctxt "Position on screen for the Ubuntu dock"
+#~ msgid "Left"
+#~ msgstr "چەپ"
+
+#~ msgctxt "Position on screen for the Ubuntu dock"
+#~ msgid "Bottom"
+#~ msgstr "خوارەوە"
+
+#~ msgctxt "Position on screen for the Ubuntu dock"
+#~ msgid "Right"
+#~ msgstr "ڕاست"
+
+#~ msgid "Dock"
+#~ msgstr "لەنگەرگا(دۆک)"
+
+#~ msgid "preferences-ubuntu-panel"
+#~ msgstr "preferences-ubuntu-panel"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "بنەڕەتی"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "ناوەند"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "گەورە"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "گەورەتر"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "گەورەترین"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d پیکسڵ"
+#~ msgstr[1] "%d پیکسڵ"
+
+#~ msgid "Screen Reader"
+#~ msgstr "خوێنەرەوەی ڕووپەر"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_خوێنەری رووپەر"
+
+#~ msgid "Sound Keys"
+#~ msgstr "کیلی دەنگ"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "کورت"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "چارەکی ڕووپەر"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "نیوەی ڕووپەر"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "سێ چارەکی ڕووپەر"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "دوورودرێژ"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "پێویستە ناونیشنای تۆڕی دابینکەری چوونەژوورەوەکەت بگونجێنیت"
+
+#~ msgid "Failed to add account"
+#~ msgstr "نەتوانرا هەژمار زیادبکرێت"
+
+#~ msgid "Failed to register account"
+#~ msgstr "تۆمارکردنی هەژمارەکەت شکستی هێنا"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "هیچ ڕێگایەک نییە بۆ سەلماندن لەگەڵ ئەم دۆمەینە"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "پەیوەستبوون بە دۆمەینەوە شکستی هێنا"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ناوی چوونەژورەوە کاری نەکرد. \n"
+#~ "تکایە هەوڵبدەرەوە."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "تیپەڕوشەی چوونەژورەوە کاری نەکرد. \n"
+#~ "تکایە هەوڵبدەرەوە."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "چوونەژوورەوە بۆ دۆمەینەکە شکستی هێنا"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "ناتوانرێت دۆمەین بدۆزرێتەوە. لەوانەیە"
+
+#~ msgid "Standard"
+#~ msgstr "ستاندارد"
+
+#~ msgid "Account _Type"
+#~ msgstr "جۆری _هەژمار"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "ڕێگە بە بەکارهێنەر بدە جاری داهاتوو وشەی تێپەڕ بگۆڕدرێت کە هاتە _ژوورەوە"
+
+#~ msgid "Set a password _now"
+#~ msgstr "وشەی تێپەڕبوون دابنێ _ئێستا"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "پێویستە لەسەرهێڵ بی بۆ ئەوەی بەکارهێنەری ئابووری زیادبکەی."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "وێنەیەک بگرە..."
+
+#~ msgid "This Week"
+#~ msgstr "ئەم هەفتەیە"
+
+#~ msgid "Last Week"
+#~ msgstr "کۆتا هەفتە"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "دانیشتن کۆتایهات"
+
+#~ msgid "Session Started"
+#~ msgstr "دانیشتن دەستیپێکرد"
+
+#~ msgid "Please choose another password."
+#~ msgstr "تکایە وشەی تێپەڕبوون تر بنووسە."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "تکایە وشەی تێپەڕبوونی ئێستات بنووسەرەوە"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "وشەی تێپەڕبوون ناگۆڕدرێت"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "ناتوانیت خۆکارانە بچیتە ئەم جۆرە دۆمەینەوە"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "هیچ دۆمەینێکی ڕاستی نەدۆزرایەوە"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "ناتوانرێت وەکو %s بچیتە ژوورەوە لە %s دۆمەین"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "ووشەی تێپەڕبوون هەڵەیە ،تکایە هەوڵ بدەرەوە"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "نەتوانرا بەکارهێنەر بسڕیتەوە"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "نەتوانرا بەکارهێنەری بەڕێوبردن لەدوورەوە هەڵبوەشێندرێتەوە"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "ناتوانی هەژماری خۆت بسڕیتەوە."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s هێشتا لە ژوورەوەیە"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "سڕینەوەی بەکارهێنەرێک کە لە ژوورەوەیە دەتوانێت سیستەمەکەی لە دۆخێکی "
+#~ "ناجێگیر بەجێبێڵێت"
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "دەتەوێت پەڕگەکانی %s بهێڵیتەوە؟"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "دەتوانرێت بوخچەی ماڵەوە، نۆرە نامە و پەڕگە کاتییەکانی ئەو ناوە بپارێزیت "
+#~ "کاتێک هەژماری بەکارهێنەرێک. دەسڕیتەوە"
+
+#~ msgid "_Delete Files"
+#~ msgstr "_پەڕگەکان بسڕەوە"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_پەڕگەکان بهێڵەوە"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "تۆ دڵنیای دەتەوێت هەژماری %s لە دوورەوە بەڕێوەبراو هەڵبوەشێنیتەوە؟"
+
+#~ msgid "_Delete"
+#~ msgstr "_سڕینەوە"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "هەژمار ناچالاک کرا"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "جێبەجێدەکرێت لە چوونەژورەوەی داهاتوو"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "نییە"
+
+#~ msgid "Logged in"
+#~ msgstr "لەژوورەوەیە"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "نەتوانرا پەیوەندی بکرێت بە خزمەتگوزاری هەژمارەکان"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "تکاتە دڵنیابە کە خزمەتگوزاری-هەژمار دامەزراوە و چالاکە."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "بۆ گۆڕانکاری،\n"
+#~ "کرتە لە وێنۆچکەکە بکە"
+
+#~ msgid "Create a user account"
+#~ msgstr "هەژماری بەکارهێنەر دروستبکە"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "بۆ دروستکردنی هەژماری بەکارهێنەر،\n"
+#~ "کرتە لە وێنۆچکەکە بکە"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "هەژماری بەکارهێنەری دیاریکراو بسڕەوە"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "بۆ سڕینەوی هەژماری بەکارهێنەری دیاریکراو\n"
+#~ "کرتە لە وێنۆچکەکە بکە"
+
+#~ msgid "User Icon"
+#~ msgstr "وێنۆچکەی بەکارهێنەر"
+
+#~ msgid "Left thumb"
+#~ msgstr "پەنجەی چەپ"
+
+#~ msgid "Left middle finger"
+#~ msgstr "پەنجەی ناوەڕاستی چەپ"
+
+#~ msgid "Left ring finger"
+#~ msgstr "ئەڵقەی پەنجەی چەپ"
+
+#~ msgid "Left little finger"
+#~ msgstr "پەنجە بچووکی چەپ"
+
+#~ msgid "Right thumb"
+#~ msgstr "پەنجە گەورەی ڕاست"
+
+#~ msgid "Right middle finger"
+#~ msgstr "پەنجەی ناوەڕاست ڕاست"
+
+#~ msgid "Right ring finger"
+#~ msgstr "ئەڵقەی پەنجەی ڕاست"
+
+#~ msgid "Right little finger"
+#~ msgstr "پەنجەی بچووکی ڕاست"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "چوونەژورەوە بە پەنجەمۆر چالاک بکە"
+
+#~ msgid "_Right index finger"
+#~ msgstr "پەنجەی نیشاندەری _ڕاست"
+
+#~ msgid "_Left index finger"
+#~ msgstr "پەنجەی نیشاندەری _چەپ"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_پەنجەکانی تر:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "پەنجەمۆر بەسەرکەوتووی زیادکرا. ئێستا دەتوانیت بە پەنجەمۆر بچیتە ژوورەوە."
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "پێویستە تێپەڕەوشەی نوێ جیاوازبێ لە کۆنەکە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "هەوڵبدە چەن پیتێک و ژمارە بگۆڕە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "هەوڵ بدە هەندێ لە وشەی تێپەڕبوونەکە بگۆڕە."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "ئەگەر وشەی تێپەڕبوون ناوەکەتی تێدا نەبێت بەهێزتر دەبێت."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "هەوڵ بدە ناوەکەت تێکەڵ مەکە بە وشەی تێپەڕبوونەکە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "هەوڵ بدە چەند پیتێک بەکارمەهێنە کە لە وشەی تێپەڕبوونەکە هەیە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "هەوڵ بدە پیتی باو بەکارمەهێنە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "هەوڵ بدە پیتە نووسراوەکان ڕێک مەخەرەوە و بینوسیتەوە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "هەوڵ بدە ژمارەی زیاتر بنووسە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "هەوڵ بدە پیتی گەورە بنووسیت."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "هەوڵ بدە پیتی بچووک بەکاربێنە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "هەوڵ بدە هێمای تایبەت، وەکو خاڵبەندی بەکاربێنە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "هەوڵ بدە تێکەڵەیەک لە پیتەکان، ژمارەکان و خاڵبەندییەکان بەکاربێنە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "هەوڵ بدە هەمان هێما دووبارە مەکەرەوە."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "هەوڵ بدە هەمان هێما دووبارە مەکەرەوە: پێویستە تێکەڵیەک لە پیتەکان، "
+#~ "ژمارەکان و خاڵبەندییەکان بەکاربێنیت."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "هەوڵ زنجیرەی لە دووای یەک وەکو ١٢٣٤ یان ابجد بەکارمەهێنە."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "وشەی تێپەڕبوون پێویستە درێژتر بێ. هەوڵ بدە پیت، ژمارە، خاڵبەندی زیاتر "
+#~ "بەکاربێنە."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "هەردوو پیتی گەورە و بچووک تێکەڵبکە لەگەڵ ژمارەیەک یا زیاتر."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "پیتی زیاتر بەکاربێنە، ژمارە و خاڵبەندی تێپەرەوشە بەهێزتر دەبێت."
+
+#~ msgid "Authentication failed"
+#~ msgstr "ڕێپێدان سەرکەوتوو نەبوو"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "وشەی تێپەڕبوونی نوێ زۆر کورتە"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "وشەی تێپەڕبوونی نوێ زۆر سادەیە"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "وشەی تێپەڕبوونی نوێ و کۆن زۆر لەیەک دەچن"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "وشەی تێپەڕبوونی نوێ پێشتر بەکارهێنراوە."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "وشەی تێپەڕبوونی نوێ دەبێت ژمارە یان هێمای تایبەتی تێدابێت."
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "وشەی تێپەڕبوونی نوێ و کۆن وەکو یەکن"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "تێپەڕە وشە نوێییەکە بەشی پێویست نووسە جیاوازەکانی تێدانییە"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "هەڵەیەکی نەزانراو"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "ببورە، ئەو نازناوە بەردەست نییە. تکایە دانەیەکیتر تاقی بکەرەوە."
+
+#~ msgid "The username is too long."
+#~ msgstr "نازناوەکە زۆر درێژە"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "ئەمە بەکاردێ بۆ بوخچەی ماڵەوە وە ناتوانرێ بگۆڕدرێ."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "تۆ ڕێگەپێدراو نیت تا دەستبگریت بەسەر ئامێرەکە. پەیوەندی بکە بە "
+#~ "بەڕێوبەریسیستەمەکەت."
+
+#~ msgid "The device is already in use."
+#~ msgstr "ئامێر لە کاردایە."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "هەڵەی ناوەکی ڕویدا."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "پەنجەمۆرە تۆمارکراوەکان دەسڕیتەوە؟"
+
+#~ msgid "Done!"
+#~ msgstr "ئەنجام درا!"
+
+#, c-format
+#~ msgid "Could not access “%s” device"
+#~ msgstr "ناتوانرێت بچیتە ناو ئامێری  “%s”"
+
+#, c-format
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "ناتوانرێت دەستبکرێت بە تۆمارکردنی پەنجە لە ئامێری  “%s”"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "ناتوانرێت دەستبگیرێت بەسەر هیچ لە خوێنەرەکانی  پەنجەمۆر"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "تکایە پەیوەندی بکە بە بەڕیوەبەری سیستم بۆ یارمەتی."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "بۆ چالاککردنی چوونەژوورەوەی پەنجەمۆر، پێویستە یەکێک لە پەنجەمۆرەکانت خەزن "
+#~ "بکەی، بە بەکارهێنانی ئامێری “%s”."
+
+#~ msgid "Selecting finger"
+#~ msgstr "دیاریکردنی پەنجە"
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "دوگمەی %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "گۆڕینی پیشاندەر"
+
+#~ msgid "Output:"
+#~ msgstr "دەرخستە:"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d  لە %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "نەخشەی پیشاندان"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "تاتەبژمێر (ڕەها)"
+
+#~ msgid "_Help"
+#~ msgstr "_یارمەتی"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ڕێکخستنەکانی بلووتووس"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "دۆزی بەدواداچوون"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "ڕێکخستنی مشک چاک بکە"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "ڕێککردنی وردی پیشاندەر"
+
+#~ msgid "New shortcut…"
+#~ msgstr "قەدبڕی نوێ..."
+
+#~ msgid "Top Button"
+#~ msgstr "دوگمەی سەرەوە"
+
+#~ msgid "Lower Button"
+#~ msgstr "دوگمەی خوارەوە"
+
+#~ msgid "Lowest Button"
+#~ msgstr "دوگمەی خوارخوارەوە"
+
+#~ msgid "Display version number"
+#~ msgstr "ژمارەی وەشان پیشان بدە"
+
+#~ msgid "Panel to display"
+#~ msgstr "بەش بۆ پیشان دان"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "بەشە بەردەسەکان:"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "System Sounds"
+#~ msgstr "دەنگەکانی سیستم"
 
 #~ msgctxt "background, style"
 #~ msgid "Span"

--- a/po/ckb.po~
+++ b/po/ckb.po~
@@ -1,0 +1,8310 @@
+# Kurdish (Sorani) translation for gnome-control-center
+# Copyright (c) 2008 Rosetta Contributors and Canonical Ltd 2008
+# This file is distributed under the same license as the gnome-control-center package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2008.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2019-10-15 17:52+0000\n"
+"PO-Revision-Date: 2020-03-28 18:25+0300\n"
+"Last-Translator: Jwtiyar Nariman <jwtiyar@gmail.com>\n"
+"Language-Team: Kurdish (Sorani) <ckb@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Launchpad-Export-Date: 2020-03-28 15:24+0000\n"
+"X-Generator: Poedit 2.3\n"
+"Language: ckb\n"
+
+#: panels/applications/cc-applications-panel.c:748
+msgid "System Bus"
+msgstr "تێپەڕگەی سیستەم"
+
+#: panels/applications/cc-applications-panel.c:748
+#: panels/applications/cc-applications-panel.c:750
+#: panels/applications/cc-applications-panel.c:763
+#: panels/applications/cc-applications-panel.c:768
+msgid "Full access"
+msgstr "دەستپێگەشتنی تەواو"
+
+#: panels/applications/cc-applications-panel.c:750
+msgid "Session Bus"
+msgstr "تێپەڕگەی وانەکۆڕ"
+
+#: panels/applications/cc-applications-panel.c:754
+#: panels/power/cc-power-panel.c:2472 panels/thunderbolt/cc-bolt-panel.ui:466
+#: panels/thunderbolt/cc-bolt-panel.ui:525
+msgid "Devices"
+msgstr "ئامێرەکان"
+
+#: panels/applications/cc-applications-panel.c:754
+msgid "Full access to /dev"
+msgstr "دەستپێگەشتنی تەواو بۆ /dev"
+
+#: panels/applications/cc-applications-panel.c:758
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:252
+msgid "Network"
+msgstr "ڕایەڵە"
+
+#: panels/applications/cc-applications-panel.c:758
+#: panels/applications/cc-snap-row.c:109
+msgid "Has network access"
+msgstr "دەستگەیشتنی بۆ ڕایەڵە هەیە"
+
+#: panels/applications/cc-applications-panel.c:763
+#: panels/applications/cc-applications-panel.c:765
+#: panels/search/cc-search-locations-dialog.c:361
+msgid "Home"
+msgstr "ماڵەوە"
+
+#: panels/applications/cc-applications-panel.c:765
+#: panels/applications/cc-applications-panel.c:770
+msgid "Read-only"
+msgstr "تەنها-خوێندنەوە"
+
+#: panels/applications/cc-applications-panel.c:768
+#: panels/applications/cc-applications-panel.c:770
+msgid "File System"
+msgstr "پەڕگەی سیستەم"
+
+#: panels/applications/cc-applications-panel.c:774
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:281
+#: shell/cc-window.c:964 shell/cc-window.ui:125
+#: shell/gnome-control-center.desktop.in.in:3
+msgid "Settings"
+msgstr "ڕێكخستنەكان"
+
+#: panels/applications/cc-applications-panel.c:774
+#: panels/applications/cc-snap-row.c:73
+msgid "Can change settings"
+msgstr "ڕێكخستنەكان دەتوانرێ بگۆڕدرێ"
+
+#: panels/applications/cc-applications-panel.c:776
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s شوێن مۆڵەتپێدانەکان دەکەوێت کە لەناویدا هەیە. ئەمانە ناتوانرێ بگۆڕدرێ. "
+"ئەگەر تۆ نیگەرانی دەربارەی ئەم مۆڵەتپێدانانە، ڕەچاوی سڕینەوەی ئەم بەرنامەیە "
+"بکە."
+
+#: panels/applications/cc-applications-panel.c:937
+msgid "Web Links"
+msgstr "بەستەرەکانی وێب"
+
+#: panels/applications/cc-applications-panel.c:947
+msgid "Git Links"
+msgstr "بەستەرەکانی گێت (Git)"
+
+#: panels/applications/cc-applications-panel.c:953
+#, c-format
+msgid "%s Links"
+msgstr "بەستەرەکان %s"
+
+#: panels/applications/cc-applications-panel.c:961
+#: panels/applications/cc-applications-panel.c:997
+msgid "Unset"
+msgstr "دانەنان"
+
+#: panels/applications/cc-applications-panel.c:1052
+msgid "Links"
+msgstr "به‌سته‌ره‌كان"
+
+#: panels/applications/cc-applications-panel.c:1060
+msgid "Hypertext Files"
+msgstr "پەڕگەکانی سەروودەق"
+
+#: panels/applications/cc-applications-panel.c:1074
+msgid "Text Files"
+msgstr "فایلەکانی دەق"
+
+#: panels/applications/cc-applications-panel.c:1088
+msgid "Image Files"
+msgstr "پەڕگەکانی وێنە"
+
+#: panels/applications/cc-applications-panel.c:1104
+msgid "Font Files"
+msgstr "پەڕگەکانی فۆنت"
+
+#: panels/applications/cc-applications-panel.c:1165
+msgid "Archive Files"
+msgstr "پەڕگەکانی ئەرشیف"
+
+#: panels/applications/cc-applications-panel.c:1185
+msgid "Package Files"
+msgstr "پەڕگەکانی بوخچە"
+
+#: panels/applications/cc-applications-panel.c:1208
+msgid "Audio Files"
+msgstr "پەڕگەکانی دەنگ"
+
+#: panels/applications/cc-applications-panel.c:1225
+msgid "Video Files"
+msgstr "پەڕگەکانی ڤیدیۆ"
+
+#: panels/applications/cc-applications-panel.c:1233
+msgid "Other Files"
+msgstr "پەڕگەکانی دیکە"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1575
+#: panels/applications/cc-applications-panel.ui:418
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:167
+msgid "Applications"
+msgstr "نەرمەواڵەکان"
+
+#: panels/applications/cc-applications-panel.ui:45
+msgid "No applications"
+msgstr "نەرمەواڵەکان نییە"
+
+#: panels/applications/cc-applications-panel.ui:59
+msgid "Install some…"
+msgstr "هەندێک دادەمەزرێن..."
+
+#: panels/applications/cc-applications-panel.ui:99
+msgid "Permissions & Access"
+msgstr "مۆڵەتپێدانەکان و دەستپێگەشتن"
+
+#: panels/applications/cc-applications-panel.ui:111
+msgid ""
+"Data and services that this app has asked for access to and permissions that "
+"it requires."
+msgstr ""
+"دراو و خزمەتگوزارییەکان کە ئەم بەرنامەیە پرسیاریکرد بۆ دەستگەیشتن پێی و "
+"مۆڵەتپێدانی پێویستە(داواکراوە)."
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/applications/cc-applications-panel.ui:132
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "کامێرا"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:133
+#: panels/applications/cc-applications-panel.ui:145
+#: panels/applications/cc-applications-panel.ui:157
+#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:267
+#: panels/keyboard/cc-keyboard-option.c:259
+#: panels/keyboard/cc-keyboard-option.c:378
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:96
+#: panels/keyboard/keyboard-shortcuts.c:425 panels/network/network-proxy.ui:126
+#: panels/user-accounts/um-fingerprint-dialog.c:211
+#: subprojects/gvc/gvc-mixer-control.c:1876
+msgid "Disabled"
+msgstr "ناچالاککراو"
+
+#: panels/applications/cc-applications-panel.ui:138
+#: panels/applications/cc-applications-panel.ui:144
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "مایکرۆفۆن"
+
+#: panels/applications/cc-applications-panel.ui:150
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "خزمەتگوزارییەکانی شوێن"
+
+#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:501
+msgid "Built-in Permissions"
+msgstr "مۆڵەتپێدانی تێدا دانراو"
+
+#: panels/applications/cc-applications-panel.ui:163
+msgid "Cannot be changed"
+msgstr "ناتوانرێ بگۆڕدرێ"
+
+#: panels/applications/cc-applications-panel.ui:180
+msgid ""
+"Individual permissions for applications can be reviewed in the <a href="
+"\"privacy\">Privacy</a> Settings."
+msgstr ""
+"مۆڵەتپێدانە تاکەکەسییەکان بۆ بەرنامەکان دەتوانرێ پیداچوونەوەی بۆ بکرێ لە <a "
+"href=\"privacy\">تایبەتێتی</a>کەی ڕێکخستنەکان."
+
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Integration"
+msgstr "یەکخستن"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System features used by this application."
+msgstr "تایبەتمەندیەکانی سیستەم بەکارهێنراوە لەلایەن ئەم بەرنامەیە."
+
+#: panels/applications/cc-applications-panel.ui:230
+#: panels/applications/cc-applications-panel.ui:236
+#: panels/keyboard/01-launchers.xml.in:18
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:155
+msgid "Search"
+msgstr "گەڕان"
+
+#: panels/applications/cc-applications-panel.ui:242
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "ئاگادارکردنەوەکان"
+
+#: panels/applications/cc-applications-panel.ui:260
+#: panels/applications/cc-applications-panel.ui:266
+msgid "Sounds"
+msgstr "دەنگەکان"
+
+#: panels/applications/cc-applications-panel.ui:299
+msgid "Default Handlers"
+msgstr "وەدەستخەرە بنەڕەتییەکان"
+
+#: panels/applications/cc-applications-panel.ui:311
+msgid "Types of files and links that this application opens."
+msgstr "جۆرەکانی پەرڕگەکان و بەستەرەکان کە لەم بەرنامەیە دەکرێنەوە."
+
+#: panels/applications/cc-applications-panel.ui:327
+msgid "Reset"
+msgstr "ڕێکخستنەوە"
+
+#: panels/applications/cc-applications-panel.ui:363
+msgid "Usage"
+msgstr "بەکارهێنان"
+
+#: panels/applications/cc-applications-panel.ui:375
+msgid "How much resources this application is using."
+msgstr "ئەم بەرنامەیە چەند سەرچاوە بەکاردەهێنێت."
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/applications/cc-applications-panel.ui:537
+msgid "Storage"
+msgstr "بیرگە"
+
+#: panels/applications/cc-applications-panel.ui:425
+msgid "Open in Software"
+msgstr "بیکەرەوە لە نەرمەواڵا"
+
+#: panels/applications/cc-applications-panel.ui:475 shell/cc-panel-list.ui:121
+msgid "No results found"
+msgstr "هیچ ئەنجامێک نەدۆزرایەوە"
+
+#: panels/applications/cc-applications-panel.ui:486
+#: panels/keyboard/cc-keyboard-panel.ui:188 shell/cc-panel-list.ui:132
+msgid "Try a different search"
+msgstr "گەڕانێکی جیاواز تاقیبکەرەوە"
+
+#: panels/applications/cc-applications-panel.ui:554
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "ئەم بەرنامەیە چەند بۆشایی داگیردەکات بە دراوی بەرنامە و کاشەکان."
+
+#: panels/applications/cc-applications-panel.ui:563
+msgid "Application"
+msgstr "نەرمەواڵا"
+
+#: panels/applications/cc-applications-panel.ui:569
+msgid "Data"
+msgstr "دراو"
+
+#: panels/applications/cc-applications-panel.ui:575
+msgid "Cache"
+msgstr "کاش"
+
+#: panels/applications/cc-applications-panel.ui:581
+msgid "<b>Total</b>"
+msgstr "<b>سەرجەم</b>"
+
+#: panels/applications/cc-applications-panel.ui:598
+msgid "Clear Cache…"
+msgstr "کاش پاکبکەرەوە..."
+
+#: panels/applications/cc-snap-row.c:55
+msgid "Add user accounts and change passwords"
+msgstr "هەژمارەکانی بەکارهێنەر زیاد بکە و تێپەڕەوشەکان بگۆڕە"
+
+#: panels/applications/cc-snap-row.c:57 panels/applications/cc-snap-row.c:133
+msgid "Play and record sound"
+msgstr "دەنگ لێبدە و تۆماربکە"
+
+#: panels/applications/cc-snap-row.c:59
+msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+msgstr ""
+"ئامێرەکانی ڕایەڵە بدۆزەرەوە کە mDNS/DNS-SD بەکاردەهێنن (Bonjour/zeroconf)"
+
+#: panels/applications/cc-snap-row.c:61
+msgid "Access bluetooth hardware directly"
+msgstr "ڕاستەوخۆ دەستبگرە بەسەر ڕەقەکاڵای بلووتووس"
+
+#: panels/applications/cc-snap-row.c:63
+msgid "Use bluetooth devices"
+msgstr "ئامێرەکانی بلووتووس بەکاربێنە"
+
+#: panels/applications/cc-snap-row.c:65
+msgid "Use your camera"
+msgstr "کامێراکەت بەکابێنە"
+
+#: panels/applications/cc-snap-row.c:67
+msgid "Print documents"
+msgstr "بەڵگەنامەکان چامبکە"
+
+#: panels/applications/cc-snap-row.c:69
+msgid "Use any connected joystick"
+msgstr "هەر گێڕ و دەسکێکی پەیوەستکراو بەکاربێنە"
+
+#: panels/applications/cc-snap-row.c:71
+msgid "Allow connecting to the Docker service"
+msgstr "ڕێگەبدە بە پەیوەستبوون بە خزمەتگوزاریەکانی (Docker)ەکە"
+
+#: panels/applications/cc-snap-row.c:75
+msgid "Configure network firewall"
+msgstr "دیواری ئاگرینی ڕایەڵە ڕێکبخە"
+
+#: panels/applications/cc-snap-row.c:77
+msgid "Setup and use privileged FUSE filesystems"
+msgstr "سیستەمەکانی پەڕگەی FUSE  شاراوە بەکار بهێنە و جێگیریبکە"
+
+#: panels/applications/cc-snap-row.c:79
+msgid "Update firmware on this device"
+msgstr "لەم ئامێرە پتەوواڵە نوێبکەوە"
+
+#: panels/applications/cc-snap-row.c:81
+msgid "Access hardware information"
+msgstr "زانیاری دەستپێگەشتنی ڕەقەکاڵا"
+
+#: panels/applications/cc-snap-row.c:83
+msgid "Provide entropy to hardware random number generator"
+msgstr "ئینترۆپی بەدەست بێنە بۆ ڕەقەکاڵای پێکهێنەری ژمارە هەڕەمەکییەکان"
+
+#: panels/applications/cc-snap-row.c:85
+msgid "Use hardware-generated random numbers"
+msgstr "ڕەقەکاڵای-بەرهەمهاتووی ژمارە هەڕەمەکییەکان"
+
+#: panels/applications/cc-snap-row.c:87
+msgid "Access files in your home folder"
+msgstr "دەستبگرە بەسەر پەرڕگەکان لە بوخچەی ماڵەوەت"
+
+#: panels/applications/cc-snap-row.c:89
+msgid "Access libvirt service"
+msgstr "دەستبگرە بەسەر خزمەتگوزارییەکانی libvirt"
+
+#: panels/applications/cc-snap-row.c:91
+msgid "Change system language and region settings"
+msgstr "زمانی سیستەم و ناوچەی ڕێکخستنەکان بگۆڕە"
+
+#: panels/applications/cc-snap-row.c:93
+msgid "Change location settings and providers"
+msgstr "شوێنی ڕێکخستنەکان و دابینکەرەکان بگۆڕە"
+
+#: panels/applications/cc-snap-row.c:95
+msgid "Access your location"
+msgstr "دەستبگرە بەسەر شوێنەکەتا"
+
+#: panels/applications/cc-snap-row.c:97
+msgid "Read system and application logs"
+msgstr "سیستەم و تۆماری بەرنامەکان بخوێنەوە"
+
+#: panels/applications/cc-snap-row.c:99
+msgid "Access LXD service"
+msgstr "دەستبگرە بەسەر خزمەتگوزاری LXD"
+
+#: panels/applications/cc-snap-row.c:101
+msgid "access the media-hub service"
+msgstr "دەستبگرە بەسەر خزمەتگوزاری ناوەندی-میدیا کە"
+
+#: panels/applications/cc-snap-row.c:103
+msgid "Use and configure modems"
+msgstr "مۆدیۆمەکان بەکاربێنە و ڕێکیبخە"
+
+#: panels/applications/cc-snap-row.c:105
+msgid "Read system mount information and disk quotas"
+msgstr "زانیاری گرێدانی سیستەم و بەشی دیسک بخوێنەوە"
+
+#: panels/applications/cc-snap-row.c:107
+msgid "Control music and video players"
+msgstr "کۆنتڕۆڵی مۆسیقا و ڤیدیۆ پەخشکەرەکان بکە"
+
+#: panels/applications/cc-snap-row.c:111
+msgid "Change low-level network settings"
+msgstr "ڕێکخستنی ڕایەڵەی ئاست-نزم بگۆڕە"
+
+#: panels/applications/cc-snap-row.c:113
+msgid "Access the NetworkManager service to read and change network settings"
+msgstr ""
+"دەستبگرە بەسەر خزمەتگوزاری بەڕێوبەری ڕایەڵە بۆ خوێندنەوە و گۆڕینی "
+"ڕێکخستنەکانی ڕایەڵە"
+
+#: panels/applications/cc-snap-row.c:115
+msgid "Read access to network settings"
+msgstr "دەستگەیشتنی ڕێکخستنەکانی ڕایەڵە بخوێنەوە"
+
+#: panels/applications/cc-snap-row.c:117
+msgid "Change network settings"
+msgstr "ڕێکخستنەکانی ڕایەڵە بگۆڕە"
+
+#: panels/applications/cc-snap-row.c:119
+msgid "Read network settings"
+msgstr "ڕێکخستنەکانی ڕایەڵە بخوێنەوە"
+
+#: panels/applications/cc-snap-row.c:121
+msgid ""
+"Access the ofono service to read and change network settings for mobile "
+"telephony"
+msgstr ""
+"دەستبگرە بەسەر خزمەتگوزاری ئۆفۆنۆ بۆ خوێندنەوە و گۆڕینی ڕێکخستنەکانی ڕایەڵە "
+"بۆ بەکارهێنانەکانی مۆبایل"
+
+#: panels/applications/cc-snap-row.c:123
+msgid "Control Open vSwitch hardware"
+msgstr "کۆنتڕۆڵی ڕەقەواڵای Open vSwitch"
+
+#: panels/applications/cc-snap-row.c:125
+msgid "Read from CD/DVD"
+msgstr "بخوێنەوە لەڕێی CD/DVD"
+
+#: panels/applications/cc-snap-row.c:127
+msgid "Read, add, change, or remove saved passwords"
+msgstr "تێپەڕەوشە خەزنکراوەکان بخوێنەوە، زیادبکە ،بگۆڕە ،یان بیسڕەوە"
+
+#: panels/applications/cc-snap-row.c:129
+msgid ""
+"Access pppd and ppp devices for configuring Point-to-Point Protocol "
+"connections"
+msgstr ""
+"دەسبگرە بەسەر ئامێرەکانی pppd و ppp بۆ خاڵ-بۆ-خاڵ ی پەیوەندییەکانی کۆنووس"
+
+#: panels/applications/cc-snap-row.c:131
+msgid "Pause or end any process on the system"
+msgstr "بیوەستێنە یان کۆتیی بە هەر پڕۆسەیەکی سیستەمەکە بێنە"
+
+#: panels/applications/cc-snap-row.c:135
+msgid "Access USB hardware directly"
+msgstr "ڕاستەوخۆ دەستبگرە بەسەر ڕەقەواڵای USB"
+
+#: panels/applications/cc-snap-row.c:137
+msgid "Read/write files on removable storage devices"
+msgstr "پەڕگەکان بخوێنەوە/بنووسە لە ئامێرەکانی بیرگە دەرەکییەکان"
+
+#: panels/applications/cc-snap-row.c:139
+msgid "Prevent screen sleep/lock"
+msgstr "ڕێبگرە لە خەوتن/قفڵبوون"
+
+#: panels/applications/cc-snap-row.c:141
+msgid "Access serial port hardware"
+msgstr "دەستبگرە بەسەر ڕەقەواڵای دەرچەی سڕیاڵ"
+
+#: panels/applications/cc-snap-row.c:143
+msgid "Restart or power off the device"
+msgstr "ئامێرەکە داستپێبکەرەوە یان بیکوژێنەوە"
+
+#: panels/applications/cc-snap-row.c:145
+msgid "Install, remove and configure software"
+msgstr "نەرمەواڵا دابمەزرێنە، بیسڕەوە و ڕێکیبخە"
+
+#: panels/applications/cc-snap-row.c:147
+msgid "Access Storage Framework service"
+msgstr "دەستبگرە بەسەر خزمەتگوزاری بناغەی بیرگە"
+
+#: panels/applications/cc-snap-row.c:149
+msgid "Read process and system information"
+msgstr "پڕۆسە و زانیاری سیستەم بخوێنەوە"
+
+#: panels/applications/cc-snap-row.c:151
+msgid "Monitor and control any running program"
+msgstr "چاودێری و کۆنتڕۆڵی هەر بەرنامەیەکی ‌هەڵکراو بکە"
+
+#: panels/applications/cc-snap-row.c:153
+msgid "Change the date and time"
+msgstr "بەروار و کاتەکە بگۆڕە"
+
+#: panels/applications/cc-snap-row.c:155
+msgid "Change time server settings"
+msgstr "کاتی ڕێکخستنەکانی ڕاژە بگۆڕە"
+
+#: panels/applications/cc-snap-row.c:157
+msgid "Change the time zone"
+msgstr "کاتی هەرێمەکەت بگۆڕە"
+
+#: panels/applications/cc-snap-row.c:159
+msgid "Access the UDisks2 service for configuring disks and removable media"
+msgstr ""
+"دەستبگرە بەسەر خزمەتگوزاری UDisks2ەکە بۆ ڕێکخستنی دیسکەکان و میدیا دەرکییەکان"
+
+#: panels/applications/cc-snap-row.c:161
+msgid "Read/change shared calendar events in Ubuntu Unity 8"
+msgstr "بۆنەکانی ڕۆژژمێری هاوبەشی پێکراو بخوێنەوە/بگۆڕە لە ئۆبونتو یونتی ٨"
+
+#: panels/applications/cc-snap-row.c:163
+msgid "Read/change shared contacts in Ubuntu Unity 8"
+msgstr "پەیوەندییەکان هاوبەش بکە لە یوونیتی ٨ ی ئوبونتو بخوێنەوە/بگۆڕەوە"
+
+#: panels/applications/cc-snap-row.c:165
+msgid "Access energy usage data"
+msgstr "دەستبگرە بەسەر دراوی بەکارهێنانی وزە"
+
+#: panels/applications/cc-snap-row.c:167
+msgid "Read/write access to U2F devices exposed"
+msgstr "دەستبگرە بەسەر خوێندنەوە/نوسینی پێشاندانی ئامێرەکانی U2F"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "کۆنتڕۆڵی مۆڵەتەکان و ڕێکخستنەکانی بەرنامە جۆراوجۆرەکان بکە"
+
+#. FIXME
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/applications/gnome-applications-panel.desktop.in.in:8
+msgid "application-x-executable"
+msgstr "application-x-executable"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "بەرنامە؛فلاتپاک؛مۆڵەت؛ڕێکخستن؛"
+
+#: panels/background/cc-background-chooser.c:340
+msgid "Select a picture"
+msgstr "وێنەیەک دیاریبکە"
+
+#: panels/background/cc-background-chooser.c:343
+#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:240
+#: panels/color/cc-color-panel.c:893 panels/color/cc-color-panel.ui:657
+#: panels/common/cc-language-chooser.ui:24
+#: panels/display/cc-display-panel.c:947
+#: panels/info-overview/cc-info-overview-panel.ui:237
+#: panels/network/cc-wifi-hotspot-dialog.ui:122
+#: panels/network/connection-editor/connection-editor.ui:17
+#: panels/network/connection-editor/vpn-helpers.c:176
+#: panels/network/connection-editor/vpn-helpers.c:299
+#: panels/network/net-device-wifi.c:800 panels/network/net-device-wifi.c:908
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:252
+#: panels/region/cc-format-chooser.ui:28 panels/region/cc-input-chooser.ui:11
+#: panels/search/cc-search-locations-dialog.c:638
+#: panels/sharing/cc-sharing-panel.c:410 panels/usage/cc-usage-panel.c:134
+#: panels/user-accounts/cc-add-user-dialog.ui:28
+#: panels/user-accounts/cc-avatar-chooser.c:107
+#: panels/user-accounts/cc-avatar-chooser.c:235
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:636
+#: panels/user-accounts/cc-user-panel.c:654
+#: panels/user-accounts/data/join-dialog.ui:20
+#: panels/user-accounts/um-fingerprint-dialog.c:260
+msgid "_Cancel"
+msgstr "_پاشگەزبوونەوە"
+
+#: panels/background/cc-background-chooser.c:344
+#: panels/network/connection-editor/vpn-helpers.c:177
+#: panels/printers/pp-details-dialog.c:253
+#: panels/sharing/cc-sharing-panel.c:411
+#: panels/user-accounts/cc-avatar-chooser.c:236
+msgid "_Open"
+msgstr "_کردنەوە"
+
+#: panels/background/cc-background-chooser.ui:104
+msgid "Set Background and Lock Screen"
+msgstr "پاشبنەما و قفڵی شاشە دابنێ"
+
+#: panels/background/cc-background-chooser.ui:114
+msgid "Set Background"
+msgstr "پاشبنەما دابنێ"
+
+#: panels/background/cc-background-chooser.ui:121
+msgid "Set Lock Screen"
+msgstr "قفڵی شاشە دابنێ"
+
+#: panels/background/cc-background-chooser.ui:143
+msgid "Remove Background"
+msgstr "قفڵی شاشە بسڕەوە"
+
+#: panels/background/cc-background-item.c:140
+msgid "multiple sizes"
+msgstr "قەبارەى زۆر"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:144
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:282
+msgid "No Desktop Background"
+msgstr "پاشبنەمای ڕوومێز نییە"
+
+#: panels/background/cc-background-panel.c:115
+msgid "Current background"
+msgstr "پاشبنەمای ئێستا"
+
+#: panels/background/cc-background-panel.ui:55
+msgid "Add Picture…"
+msgstr "وێنە زیادبکە..."
+
+#: panels/background/cc-background-preview.ui:55
+msgid "Activities"
+msgstr "چالاکییەکان"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "پاشبنەما"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr "وێنەی پاشبنەماکەت بگۆڕە بۆ دیوارپۆشێک یان وێنەیەک"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/background/gnome-background-panel.desktop.in.in:7
+msgid "preferences-desktop-wallpaper"
+msgstr "هەڵبژاردەکانی-دیوارپۆشی-ڕوومێز"
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "دیوارپۆش؛شاشە؛ڕوومێز"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "No Bluetooth Found"
+msgstr "بلووتووس نەدۆزرایەوە"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "دۆنگڵ پێوەبکە بۆ بەکارهێنانی بلووتووس"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:69
+msgid "Bluetooth Turned Off"
+msgstr "بلووتووس کوژاوەتەو"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:80
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "هەڵیبکە بۆ پەیوەستبوون بە ئامێرەکان و وەرگرتنی پەڕگە نێردراوەکان."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:107
+msgid "Airplane Mode is on"
+msgstr "دۆخی فڕۆکە چالاکە"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:118
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "بلووتووس ناچالاک دەکرێت کاتێک دوخی فڕۆکە هەڵبکرێ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:154
+msgid "Hardware Airplane Mode is on"
+msgstr "ڕەقەواڵای دۆخی فڕۆکە هەڵکراوە"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:165
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "سویچی دۆخی فڕۆکە بکوژێنەوە"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:124
+msgid "Turn Off Airplane Mode"
+msgstr "دۆخی فڕۆکە بکوژێنەوە"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1714
+msgid "Bluetooth"
+msgstr "بلووتووس"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "بلووتووس هەڵبکە و بیکوژێنەوە و ئامێرەکانت پەیوەست بکە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:6
+msgid "bluetooth"
+msgstr "بلوتوبلووتووس"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "هاوبەشیبکە;هاوبەشیدەکات;بلووتووس;بەربەست;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:348
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"ئامێرە مەزەندەکراوەکەت دابنێ لەسەر چوارگۆشەکە و پەنجەبنێ بە \"دەستپێکردن\""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:354
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"ئامێرە مەزەندەکراوەکەت بجوڵێنە بۆ شوێنی پێوانەکردنەکە و پەنجەبنێ بە "
+"“بەردەوامبوون”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:360
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"ئامێرە مەزەندەکراوەکەت بجوڵێنە بۆ شوێنی ڕووبەرەکە و  پەنجەبنێ بە "
+"“بەردەوامبوون”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:366
+msgid "Shut the laptop lid"
+msgstr "شاشەی لاپتۆپەکە پێوەبدە"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:397
+msgid "An internal error occurred that could not be recovered."
+msgstr "هەڵەیەکی ناوخۆیی ڕوویدا کە ناتونرێ چاکبکرێتەوە."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:402
+msgid "Tools required for calibration are not installed."
+msgstr "ئامڕازە داواکراوەکان بۆ مەزندەکردن دانەمەزراون"
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:408
+msgid "The profile could not be generated."
+msgstr "زانیارییە کەسییەکە ناتوانرێ دروستبکرێ"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:414
+msgid "The target whitepoint was not obtainable."
+msgstr "ئامانجە خاڵ سپییەکە دەستنەکەوت"
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:453
+msgid "Complete!"
+msgstr "تەواو!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:461
+msgid "Calibration failed!"
+msgstr "مەزندەکردن شکستیهێنا!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:468
+msgid "You can remove the calibration device."
+msgstr "دەتوانی ئامێرە مەزندەکراوەکان لێبکەیتەوە."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:537
+msgid "Do not disturb the calibration device while in progress"
+msgstr "ئامێرە مەزندەکراوەکان تێکمەدە لە کاتی پڕۆسەدا"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "شاشەی لاپتۆپ"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "وێبكامی لەناودایە"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s مۆنیتەر"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s پشکنەر"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s کامێرا"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s چاپکەر"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s وێبکام"
+
+#: panels/color/cc-color-device.c:91
+#, c-format
+msgid "Enable color management for %s"
+msgstr "بەڕێوەبەرایەتی ڕەنگەکان چالاک بکە بۆ %s"
+
+#: panels/color/cc-color-device.c:94
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "ڕەنگی زانیارییە کەسەییەکان پیشان بدە بۆ %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:303
+msgid "Not calibrated"
+msgstr "مەدندەنەکراوە"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:169
+msgid "Default: "
+msgstr "بنەڕەت: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:177
+msgid "Colorspace: "
+msgstr "ڕێکخەری دیاریکراوی ڕەنگ: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:184
+msgid "Test profile: "
+msgstr "زانیاری کەسی تاقیبکەرەوە: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:238
+msgid "Select ICC Profile File"
+msgstr "پەڕگەی زانیاری کەسی ICC دیاریبکە"
+
+#: panels/color/cc-color-panel.c:241
+msgid "_Import"
+msgstr "_هێنان"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:252
+msgid "Supported ICC profiles"
+msgstr "زانیارییە کەسییەکانی ICC پشتگیریکراون"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:259
+#: panels/network/wireless-security/eap-method-fast.c:356
+msgid "All files"
+msgstr "هه‌موو په‌ڕگه‌كان"
+
+#: panels/color/cc-color-panel.c:554
+msgid "Screen"
+msgstr "شاشە"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:846
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "بارکردنی پەڕگە شکستی هێنا: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:858
+msgid "The profile has been uploaded to:"
+msgstr "زانیارییە کەسییەکان بارکران بۆ:"
+
+#: panels/color/cc-color-panel.c:860
+msgid "Write down this URL."
+msgstr "لەخوارەوە ئەم URL بنووسە."
+
+#: panels/color/cc-color-panel.c:861
+msgid "Restart this computer and boot your normal operating system."
+msgstr "ئەم کۆمپیتەرە دەستپێکەرەوە و سیستەمی کارپێکەری ئاسایت بخەرە ڕێ."
+
+#: panels/color/cc-color-panel.c:862
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "URLەکە لەناو وێبگەڕەکەت بنووسە"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:890
+msgid "Save Profile"
+msgstr "زانیاری کەسی پاشەکەوت بکە"
+
+#: panels/color/cc-color-panel.c:894
+#: panels/network/connection-editor/vpn-helpers.c:300
+msgid "_Save"
+msgstr "_پاشەکەوتکردن"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1208
+msgid "Create a color profile for the selected device"
+msgstr "ڕەنگێکی زانیاری کەسی دروستبکە بۆ ئامێرە دیاریکراوەکە"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1223 panels/color/cc-color-panel.c:1247
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"ئامێری پێوانەکردنەکە نەزدۆرایەوە. تکایە بیپشکنە کە هەڵکراوە و  ئێستا "
+"پەیوەستبووە."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1257
+msgid "The measuring instrument does not support printer profiling."
+msgstr "ئامێری پێوانەکردنەکە پشتگیری کورتەی چاپکەرەکە ناکات."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1268
+msgid "The device type is not currently supported."
+msgstr "جۆری ئامێرەکە بە لەم کاتەدا پشتگیری ناکرێ."
+
+#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+msgid "Screen Calibration"
+msgstr "پێوانەکردنی شاشە"
+
+#: panels/color/cc-color-panel.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"پێوانەکردن پڕۆفایلێک دروستدەکات کە دەتوانی بەکاریبهێنیت بۆ بەڕێوەبردنی ڕەنگی "
+"شاشەکەت. ئەو کاتە درێژەی تۆ بەسەری دەبەیت لە پێوانەکردن، باشترە جۆرایەتی "
+"ڕەنگی پڕؤفایلەکە."
+
+#: panels/color/cc-color-panel.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "تۆ ناتوانیت کۆمپیتەرەکەت بەکاربێنی کاتێک پێوانەکردن شوێن دەگرێ."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:58
+msgid "Quality"
+msgstr "جۆرایه‌تی"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:75
+msgid "Approximate Time"
+msgstr "کاتی هاوتا"
+
+#: panels/color/cc-color-panel.ui:121
+msgid "Calibration Quality"
+msgstr "جۆرایەتی پێوانەکردن"
+
+#: panels/color/cc-color-panel.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ئامێرە هەستەوەرەکەی کە دەتوەێت بۆ پێوانەکردن بەکاری بهێنی دیاریبکە."
+
+#: panels/color/cc-color-panel.ui:174
+msgid "Calibration Device"
+msgstr "ئامێری پێوانەکردن"
+
+#: panels/color/cc-color-panel.ui:189
+msgid "Select the type of display that is connected."
+msgstr "خۆری ئەو شاشەیەی کە پەیوەستبووە دیاری بکە."
+
+#: panels/color/cc-color-panel.ui:226
+msgid "Display Type"
+msgstr "جۆری شاشە"
+
+#: panels/color/cc-color-panel.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"خاڵی سپی ئامانجی شاشەیەک دیاریبکە. زۆربەی شاشەکان پێوەیستە پێوانەبکرێن بۆ "
+"(D65 illuminant) ێک."
+
+#: panels/color/cc-color-panel.ui:278
+msgid "Profile Whitepoint"
+msgstr "خاڵی سپی زانیاری کەسی"
+
+#: panels/color/cc-color-panel.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"تکایە ڕۆشنایی شاشاکە وا دابنێ کا ئاسایی بێ بۆ تۆ. بەڕێوەبردنی ڕەنگەکان کاتێک "
+"تەواو دەبێ کە لەو ئاستی ڕووناکییە بێ."
+
+#: panels/color/cc-color-panel.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"بەلەجیاتی، تۆ دەتوانیت ئەو ئاستی ڕۆشنایی بەکاربێنی کە بەەکاردێ‌ لەگەڵ یەکێک "
+"لە زانیارییە کەسییەکانی کە بۆ ئەم ئامێرە بەکاردێ."
+
+#: panels/color/cc-color-panel.ui:318
+msgid "Display Brightness"
+msgstr "ڕۆشنایی شاشە"
+
+#: panels/color/cc-color-panel.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"تۆ دەتوانی ڕەنگە کەسییەک بەکاربێنی لە کۆپیتەرێکی جیاواز، یان تەنانەت زانیاری "
+"کەسیی دروستبکەیت"
+
+#: panels/color/cc-color-panel.ui:348
+msgid "Profile Name:"
+msgstr "ناوی زانیاری کەسیی:"
+
+#: panels/color/cc-color-panel.ui:377
+msgid "Profile Name"
+msgstr "ناوی زانیاری کەسی"
+
+#: panels/color/cc-color-panel.ui:392
+msgid "Profile successfully created!"
+msgstr "زانیاری کەسی بە سەرکەووتوی دروستکرا!"
+
+#: panels/color/cc-color-panel.ui:443
+msgid "Copy profile"
+msgstr "زانیاری کەسی لەبەربگرەوە"
+
+#: panels/color/cc-color-panel.ui:456
+msgid "Requires writable media"
+msgstr "ڕەنگاڵەی خوێندەنی داواکراوە"
+
+#: panels/color/cc-color-panel.ui:519
+msgid "Upload profile"
+msgstr "پرۆفایل بەرزبکەرەوە"
+
+#: panels/color/cc-color-panel.ui:532
+msgid "Requires Internet connection"
+msgstr "پێویستی بە هێڵی ئینتەرنێتە"
+
+#: panels/color/cc-color-panel.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"لەوانەیە ئەم ڕێنماییانە بدۆزیتەوە کە چۆن پڕۆفایلەکە بەکاربێنیت لەم سیستەمە "
+"سوودبەخشانە <a href=\"linux\">گنوو/لینوکس</a>,  <a href=\"osx\">ئۆ ئێس ئێکسی "
+"ئەپڵ</a> و <a href=\"windows\">ویندۆزی مایکرۆسۆفت</a> ."
+
+#: panels/color/cc-color-panel.ui:607
+#: panels/user-accounts/um-fingerprint-dialog.c:719
+msgid "Summary"
+msgstr "پوختە"
+
+#: panels/color/cc-color-panel.ui:621
+msgid "Add Profile"
+msgstr "زانیاری کەسی زیادبکە"
+
+#: panels/color/cc-color-panel.ui:643
+msgid "_Import File…"
+msgstr "_هێنانی پەڕگە"
+
+#: panels/color/cc-color-panel.ui:672
+#: panels/network/connection-editor/net-connection-editor.c:513
+#: panels/printers/new-printer-dialog.ui:80
+#: panels/region/cc-input-chooser.ui:20
+#: panels/user-accounts/cc-add-user-dialog.ui:47
+msgid "_Add"
+msgstr "_زیادکردن"
+
+#: panels/color/cc-color-panel.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"کێشەکان دۆزرانەوە.لەوانەیە زانیارییە کەسییەکە بە دروستی کار نەکات. <a href="
+"\"\">زانیاری زیاتر ببینە.</a>"
+
+#: panels/color/cc-color-panel.ui:790
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"هەر ئامێرێک نوێکردنەوەی ڕەنگی زانیاری کەسی پێویستە بۆ ئەوەی ڕەنگەکە "
+"بەڕێوەببرێ."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:812
+#: panels/diagnostics/cc-diagnostics-panel.c:260
+msgid "Learn more"
+msgstr "زیاتر فێربە"
+
+#: panels/color/cc-color-panel.ui:817
+msgid "Learn more about color management"
+msgstr "زیاتر فێربە دەربارەی بەڕێوبەرایەتی ڕەنگ"
+
+#: panels/color/cc-color-panel.ui:865
+msgid "_Set for all users"
+msgstr "_سازی بدە بۆ هەموو بەکارهێنەران"
+
+#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
+#: panels/color/cc-color-panel.ui:885
+msgid "Set this profile for all users on this computer"
+msgstr "ئەم  پرۆفایلە بۆ هەموو بەکارهێنەرانی ئەم کۆمپیتەرە دابنێ"
+
+#: panels/color/cc-color-panel.ui:880
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:911
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:924
+msgid "_Calibrate…"
+msgstr "_پێوانەکردن..."
+
+#: panels/color/cc-color-panel.ui:928
+msgid "Calibrate the device"
+msgstr "ئامێرەکە پێوانەبکە"
+
+#: panels/color/cc-color-panel.ui:939
+msgid "_Remove profile"
+msgstr "_سڕینەوەی ناسنامە"
+
+#: panels/color/cc-color-panel.ui:952
+msgid "_View details"
+msgstr "_پیشاندانی ناسنامە"
+
+#: panels/color/cc-color-panel.ui:988
+msgid "Unable to detect any devices that can be color managed"
+msgstr "ناتوانرێ هیچ‌ ئامێرێک دیاریبکرێ کە بتوانێ ڕەنگ بەڕێوەبەرێ"
+
+#: panels/color/cc-color-panel.ui:1032
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:1037
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:1042
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:1047
+msgid "Projector"
+msgstr "وێنه‌نوێن"
+
+#: panels/color/cc-color-panel.ui:1052
+msgid "Plasma"
+msgstr "پلازما"
+
+#: panels/color/cc-color-panel.ui:1057
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL ڕووناکی پشتەوە)"
+
+#: panels/color/cc-color-panel.ui:1062
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED ڕووناکی پشتەوە)"
+
+#: panels/color/cc-color-panel.ui:1067
+msgid "LCD (white LED backlight)"
+msgstr "LCD ( LED ی سپی ڕووناکی دواوە)"
+
+#: panels/color/cc-color-panel.ui:1072
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCDی هەموو چینە جیاوازە پانەکان (لایتی دواوەی CCFL)"
+
+#: panels/color/cc-color-panel.ui:1077
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCDی هەموو چینە جیاوازە پانەکان (لایتی دواوەی RGB LED)"
+
+#: panels/color/cc-color-panel.ui:1094
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "به‌رز"
+
+#: panels/color/cc-color-panel.ui:1095
+msgid "40 minutes"
+msgstr "٤٠ خولەک"
+
+#: panels/color/cc-color-panel.ui:1099
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "ناوەند"
+
+#: panels/color/cc-color-panel.ui:1100
+msgid "30 minutes"
+msgstr "۳۰ خولەک"
+
+#: panels/color/cc-color-panel.ui:1104
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "نزم"
+
+#: panels/color/cc-color-panel.ui:1105
+msgid "15 minutes"
+msgstr "۱٥ خولەک"
+
+#: panels/color/cc-color-panel.ui:1127
+msgid "Native to display"
+msgstr "بنەڕەت بۆ پیشاندان"
+
+#: panels/color/cc-color-panel.ui:1131
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (چاپکردن و بڵاوکردنەوە)"
+
+#: panels/color/cc-color-panel.ui:1135
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:1139
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (وێنەگرتن و هێڵکاریەکان)"
+
+#: panels/color/cc-color-panel.ui:1143
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:100
+msgid "Standard Space"
+msgstr "بۆشای ئاسای"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:106
+msgid "Test Profile"
+msgstr "پڕۆفایلی بۆ تاقیکردنەوە"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:114
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "خۆکار"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:124
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "جۆرایەتی لاواز"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:129
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "جۆرێتی ناوەند"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:136
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "جۆرێتی بەرز"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:153
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB بنەڕەت"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:160
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK بنەڕەت"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:167
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "رەساسی بنەڕەت"
+
+#: panels/color/cc-color-profile.c:190
+msgid "Vendor supplied factory calibration data"
+msgstr "دراوی خەمڵێنراوی کارگەی سامانی فرۆشیار"
+
+#: panels/color/cc-color-profile.c:199
+msgid "Full-screen display correction not possible with this profile"
+msgstr "ڕاستکەرەوەی پیشاندەری شاشەی پڕ بەردەست نییە لەم پڕۆفایلە"
+
+#: panels/color/cc-color-profile.c:221
+msgid "This profile may no longer be accurate"
+msgstr "ئەم پڕؤفایلە لەوانەیە لەمەودوا تەواو نەبێت"
+
+#: panels/color/cc-color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr "خەمڵاندنی شاشە"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:40
+msgid "_Start"
+msgstr "_دەستپێکردن"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:54
+msgid "_Resume"
+msgstr "_دەستپێکردنەوە"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
+msgid "_Done"
+msgstr "_ئەنجامدرا"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "ڕەنگ"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "ڕەنگی ئامێرەکەت بخەمڵێنە، وەک پشاندەر، کامێراکان یان چاپکەرەکان"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/color/gnome-color-panel.desktop.in.in:7
+msgid "preferences-color"
+msgstr "ڕەنگی-هەڵبژاردەکان"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "ڕەنگ;ICC;پڕۆفایل;خەمڵاندن;جاپکەر;پشاندەر"
+
+#: panels/common/cc-language-chooser.c:145 panels/region/cc-input-chooser.c:178
+msgid "More…"
+msgstr "زیاتر..."
+
+#: panels/common/cc-language-chooser.c:162
+msgid "No languages found"
+msgstr "هیچ لە زمانەکان نەدۆزرایەوە"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "زمان دیاری بکە"
+
+#: panels/common/cc-language-chooser.ui:12
+msgid "_Select"
+msgstr "_دیاریبکە"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:152
+msgid "Today"
+msgstr "ئەمڕۆ"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:154
+msgid "Yesterday"
+msgstr "دوێنێ"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "خاڵی داخ"
+
+#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
+#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
+msgid "Day"
+msgstr "ڕۆژ"
+
+#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
+#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
+msgid "Month"
+msgstr "مانگ"
+
+#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
+#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
+msgid "Year"
+msgstr "ساڵ"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:334
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:339
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:504
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:531
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:538
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:543
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:548
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:26
+msgid "January"
+msgstr "كانونی دووه‌م"
+
+#: panels/datetime/cc-datetime-panel.ui:29
+msgid "February"
+msgstr "شوبات"
+
+#: panels/datetime/cc-datetime-panel.ui:32
+msgid "March"
+msgstr "ئازار"
+
+#: panels/datetime/cc-datetime-panel.ui:35
+msgid "April"
+msgstr "نیسان"
+
+#: panels/datetime/cc-datetime-panel.ui:38
+msgid "May"
+msgstr "ئایار"
+
+#: panels/datetime/cc-datetime-panel.ui:41
+msgid "June"
+msgstr "حوزه‌یران"
+
+#: panels/datetime/cc-datetime-panel.ui:44
+msgid "July"
+msgstr "ته‌مموز"
+
+#: panels/datetime/cc-datetime-panel.ui:47
+msgid "August"
+msgstr "ئاب"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "September"
+msgstr "ئه‌یلول"
+
+#: panels/datetime/cc-datetime-panel.ui:53
+msgid "October"
+msgstr "تشرینی یه‌كه‌م"
+
+#: panels/datetime/cc-datetime-panel.ui:56
+msgid "November"
+msgstr "تشرینی دووه‌م"
+
+#: panels/datetime/cc-datetime-panel.ui:59
+msgid "December"
+msgstr "كانونی یه‌كه‌م"
+
+#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "کات & ڕیکەوت"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#: panels/display/cc-night-light-page.ui:194
+#: panels/display/cc-night-light-page.ui:314
+msgid "Hour"
+msgstr "کاتژمێر"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: panels/datetime/cc-datetime-panel.ui:128
+msgid "∶"
+msgstr "∶"
+
+#: panels/datetime/cc-datetime-panel.ui:152
+#: panels/display/cc-night-light-page.ui:222
+#: panels/display/cc-night-light-page.ui:342
+msgid "Minute"
+msgstr "خولەک"
+
+#: panels/datetime/cc-datetime-panel.ui:219
+msgid "Time Zone"
+msgstr "کاتی ناوچەکە"
+
+#: panels/datetime/cc-datetime-panel.ui:240
+msgid "Search for a city"
+msgstr "بگەڕی بۆ شارێک"
+
+#: panels/datetime/cc-datetime-panel.ui:313
+msgid "Automatic _Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:314
+msgid "Requires internet access"
+msgstr "ئینتەرنێت پێویستە هەبێت"
+
+#: panels/datetime/cc-datetime-panel.ui:334
+msgid "Automatic Time _Zone"
+msgstr "کاتی _ناوچەی خۆکار"
+
+#: panels/datetime/cc-datetime-panel.ui:335
+msgid "Requires location services enabled and internet access"
+msgstr "پێوستە خزمەتگوزاری شوینی هەڵکرابێت و ئینتەرنێت هەبێت"
+
+#: panels/datetime/cc-datetime-panel.ui:350
+msgid "Date & _Time"
+msgstr "_کات و بەروار"
+
+#: panels/datetime/cc-datetime-panel.ui:366
+msgid "Time Z_one"
+msgstr "ش_وێنی کات"
+
+#: panels/datetime/cc-datetime-panel.ui:405
+msgid "Time _Format"
+msgstr "_ڕێکخستنی کات"
+
+#: panels/datetime/cc-datetime-panel.ui:414
+msgid "24-hour"
+msgstr "24-کاتژمێر"
+
+#: panels/datetime/cc-datetime-panel.ui:415
+msgid "AM / PM"
+msgstr "پێش ن/دوا ن"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "کات و بەروارەکە بگۆڕە، هەروەها شوێنی کاتیش"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:7
+msgid "preferences-system-time"
+msgstr "preferences-system-time"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "کاتژمێر;ناوچەی کات;شوێن;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "ڕێکخستنەکانی کات و بەرواری سیستەم بگۆڕە"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "بۆ گۆڕینی ڕێکخسنەکانی کات یان بەروار، پێویستت بە ساغکردنەوە دەبێت."
+
+#: panels/display/cc-display-panel.c:958
+#: panels/network/connection-editor/connection-editor.ui:27
+msgid "_Apply"
+msgstr "_جێبەجێکردن"
+
+#: panels/display/cc-display-panel.c:979
+msgid "Apply Changes?"
+msgstr "گۆڕناکان جێبەجێبکرێت؟"
+
+#: panels/display/cc-display-panel.c:984
+msgid "Changes Cannot be Applied"
+msgstr "گۆڕانەکان ناتوانرێ جێبەجێبکرێ"
+
+#: panels/display/cc-display-panel.c:985
+msgid "This could be due to hardware limitations."
+msgstr "دەتوانرێ پێشبینیبکرێ بۆ سنوردارکردنی ڕەقەکاڵا."
+
+#: panels/display/cc-display-panel.ui:91
+msgid "Single Display"
+msgstr "پشاندەری تاک"
+
+#: panels/display/cc-display-panel.ui:110
+#: panels/display/cc-display-panel.ui:315
+msgid "Join Displays"
+msgstr "پشاندەرەکان پەیوەستبکە"
+
+#: panels/display/cc-display-panel.ui:128
+msgid "Mirror"
+msgstr "ئاوێنە"
+
+#: panels/display/cc-display-panel.ui:153
+msgid "Display Mode"
+msgstr "دۆزی پشاندەر"
+
+#: panels/display/cc-display-panel.ui:245
+msgid ""
+"Drag displays to match your physical display setup. Select a display to "
+"change its settings."
+msgstr ""
+"پشاندەرەکان ڕابکێشە بۆ گونجاندنی پیشاندەرە جێگیرکراوە فیزیاییکەت. پیشاندەرێک "
+"دیاریبکە بۆ گۆڕینی ڕێکخسنەکان."
+
+#: panels/display/cc-display-panel.ui:252
+msgid "Display Arrangement"
+msgstr "ڕێکخستنی پیشاندەر"
+
+#: panels/display/cc-display-panel.ui:434
+msgid "Display Configuration"
+msgstr "شێوەپێدانی پیشاندەر"
+
+#: panels/display/cc-display-panel.ui:453
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "پیشاندەرەکان"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:464
+#: panels/display/cc-night-light-page.ui:111
+msgid "Night Light"
+msgstr "ڕووناکی شەو"
+
+#: panels/display/cc-display-settings.c:104
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "ئاسۆی"
+
+#: panels/display/cc-display-settings.c:107
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "لەسەر لای ڕاست"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "لەسەر لای چەپ"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "ئاسۆی (هەڵگەڕاوە)"
+
+#: panels/display/cc-display-settings.c:187
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf هێرتز"
+
+#: panels/display/cc-display-settings.ui:15
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "ئاڕاستە"
+
+#: panels/display/cc-display-settings.ui:24
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "وردی نیشاندانی شاشە"
+
+#: panels/display/cc-display-settings.ui:33
+msgid "Refresh Rate"
+msgstr "ڕێژەی نوێبوونەوە"
+
+#: panels/display/cc-display-settings.ui:42
+msgid "Adjust for TV"
+msgstr "گونجاندن ڤۆ TV"
+
+#: panels/display/cc-display-settings.ui:59
+msgctxt "display setting"
+msgid "Scale"
+msgstr "پێوانە کردن"
+
+#: panels/display/cc-night-light-page.c:622
+msgid "More Warm"
+msgstr "گەرم تر"
+
+#: panels/display/cc-night-light-page.c:634
+msgid "Less Warm"
+msgstr "کەمتر گەرم"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:28
+msgid "Restart Filter"
+msgstr "پاڵێوەری دووبارە نوێبوونەوە"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:61
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "کاتتینە ناچالاکی بکە تاکو بەیانی"
+
+#: panels/display/cc-night-light-page.ui:88
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"ڕووناکی شەوانە ڕەنگی شاشەکە گەرمتر دەکات. ئەمە دەتوانێت یارمەتیتبدات لە "
+"نەهێشتنی گوشاری چاو و بەئاگاى."
+
+#: panels/display/cc-night-light-page.ui:127
+msgid "Schedule"
+msgstr "نانەوە"
+
+#: panels/display/cc-night-light-page.ui:136
+msgid "Sunset to Sunrise"
+msgstr "خۆرئاوابوون بۆ خۆرهەڵاتن"
+
+#: panels/display/cc-night-light-page.ui:137
+msgid "Manual Schedule"
+msgstr "نانەوی خودکار"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/region/cc-format-chooser.ui:346
+msgid "Times"
+msgstr "کاتەکان"
+
+#: panels/display/cc-night-light-page.ui:165
+msgid "From"
+msgstr "لە"
+
+#: panels/display/cc-night-light-page.ui:203
+#: panels/display/cc-night-light-page.ui:323
+msgid ":"
+msgstr ":"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:234
+#: panels/display/cc-night-light-page.ui:354
+msgid "AM"
+msgstr "پ ن"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:250
+#: panels/display/cc-night-light-page.ui:370
+msgid "PM"
+msgstr "د ن"
+
+#: panels/display/cc-night-light-page.ui:284
+msgid "To"
+msgstr "بۆ"
+
+#: panels/display/cc-night-light-page.ui:408
+msgid "Color Temperature"
+msgstr "پلەی گەرمی ڕەنگ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "هەڵیبژێرە چۆن دەتوانیت پڕۆژەدروستکەرەکان و پیشاندەرەکان بەکاربێنیت"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/display/gnome-display-panel.desktop.in.in:7
+msgid "preferences-desktop-display"
+msgstr "preferences-desktop-display"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"بەش;پڕۆژەدروستکەر;xrandr;شاشە;وردی نیشاندانی شاشە;نوێبوونەوە;مۆنیتەر؛شەو;"
+"ڕووناکی;شین;گۆڕینی سوور;ڕەنگ;خۆرئاوابوون;خۆرهەڵاتن;"
+
+#: panels/default-apps/cc-default-apps-panel.ui:31
+msgid "_Web"
+msgstr "_تۆڕ"
+
+#: panels/default-apps/cc-default-apps-panel.ui:43
+msgid "_Mail"
+msgstr "_پۆست"
+
+#: panels/default-apps/cc-default-apps-panel.ui:59
+msgid "_Calendar"
+msgstr "_ڕۆژژمێر"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "M_usic"
+msgstr "مۆـسیقا"
+
+#: panels/default-apps/cc-default-apps-panel.ui:91
+msgid "_Video"
+msgstr "_ڤیدیۆ"
+
+#: panels/default-apps/cc-default-apps-panel.ui:162
+#: panels/removable-media/cc-removable-media-panel.ui:162
+msgid "_Photos"
+msgstr "_وێنەکان"
+
+#: panels/info-overview/cc-info-overview-panel.c:407
+#: panels/info-overview/cc-info-overview-panel.c:422
+#: panels/info-overview/cc-info-overview-panel.c:434
+#: panels/info-overview/cc-info-overview-panel.c:480
+#: panels/info-overview/cc-info-overview-panel.c:510
+msgid "Unknown"
+msgstr "نەزانراو"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:442
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; ناسنامەی دروستکردن: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:457
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:460
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info/info-overview.ui:62
+msgid "Device name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:77
+msgid "Memory"
+msgstr "بیرگە"
+
+#: panels/info-overview/cc-info-overview-panel.ui:86
+msgid "Processor"
+msgstr "چاره‌سه‌ركه‌ر"
+
+#: panels/info-overview/cc-info-overview-panel.ui:95
+msgid "Graphics"
+msgstr "گرافیک"
+
+#. To translators: this field contains the distro type
+#: panels/info/info-overview.ui:141
+msgid "OS type"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:163
+msgid "Virtualization"
+msgstr "بەخەیاڵی کردن"
+
+#: panels/info/info-overview.ui:173
+msgid "Disk"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:105
+msgid "Calculating…"
+msgstr "دەژمێرێت..."
+
+#: panels/info/info-overview.ui:318
+msgid "Check for updates"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:267
+msgid "Ask what to do"
+msgstr "پرسیاربکە بۆ ئەوەی چیبکات"
+
+#: panels/removable-media/cc-removable-media-panel.c:271
+msgid "Do nothing"
+msgstr "هیچ مەکە"
+
+#: panels/removable-media/cc-removable-media-panel.c:275
+msgid "Open folder"
+msgstr "بوخچە بکەرەوە"
+
+#: panels/removable-media/cc-removable-media-panel.c:341
+msgid "Other Media"
+msgstr "میدیای تر"
+
+#: panels/removable-media/cc-removable-media-panel.c:362
+msgid "Select an application for audio CDs"
+msgstr "داوانامە هەڵبژێرە بۆ سی دی دەنگی"
+
+#: panels/removable-media/cc-removable-media-panel.c:363
+msgid "Select an application for video DVDs"
+msgstr "داوانامە هەڵبژێرە بۆ دی-ڤیدی دەنگ و ڕەنگ"
+
+#: panels/removable-media/cc-removable-media-panel.c:364
+msgid "Select an application to run when a music player is connected"
+msgstr "داوانامە هەڵبژێرە بۆ کارکردن کاتێک لێدەری میوزیک پەیوەست دەکرێت"
+
+#: panels/removable-media/cc-removable-media-panel.c:365
+msgid "Select an application to run when a camera is connected"
+msgstr "داوانامە هەڵبژێرە بۆ کارکردن کاتێک کامێرا پەیوەست دەکرێت"
+
+#: panels/removable-media/cc-removable-media-panel.c:366
+msgid "Select an application for software CDs"
+msgstr "داوانامە هەڵبژێرە بۆ داوانامەی سی-دی"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "audio DVD"
+msgstr "دی-ڤیدی دەنگی"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "blank Blu-ray disc"
+msgstr "پەپکەی بەتاڵی بلو-ڕەی"
+
+#: panels/removable-media/cc-removable-media-panel.c:380
+msgid "blank CD disc"
+msgstr "پەپکەی بەتاڵی سی-دی"
+
+#: panels/removable-media/cc-removable-media-panel.c:381
+msgid "blank DVD disc"
+msgstr "پەپکەی بەتاڵی دی-ڤیدی"
+
+#: panels/removable-media/cc-removable-media-panel.c:382
+msgid "blank HD DVD disc"
+msgstr "پەپکەی بەتاڵی HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:383
+msgid "Blu-ray video disc"
+msgstr "پەپکەی ڤیدیۆی بلو-ڕەی"
+
+#: panels/removable-media/cc-removable-media-panel.c:384
+msgid "e-book reader"
+msgstr "خوێنەرەوەی کتێکی-ئەلکترۆنی"
+
+#: panels/removable-media/cc-removable-media-panel.c:385
+msgid "HD DVD video disc"
+msgstr "پەپکەی ڤیدیۆییHD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:386
+msgid "Picture CD"
+msgstr "سی-دی وێنە"
+
+#: panels/removable-media/cc-removable-media-panel.c:387
+msgid "Super Video CD"
+msgstr "سی-دی ڤیدیۆیی سوپەر"
+
+#: panels/removable-media/cc-removable-media-panel.c:388
+msgid "Video CD"
+msgstr "سی-دی ڤیدیۆیی"
+
+#: panels/removable-media/cc-removable-media-panel.c:389
+msgid "Windows software"
+msgstr "نەرمەواڵەی پەنجەرەکان"
+
+#: panels/removable-media/cc-removable-media-panel.ui:44
+msgid "Select how media should be handled"
+msgstr "پیشانی بدە چۆن میدیا بەدەستبخرێت"
+
+#: panels/removable-media/cc-removable-media-panel.ui:75
+msgid "CD _audio"
+msgstr "سیدی _دەنگی"
+
+#: panels/removable-media/cc-removable-media-panel.ui:92
+msgid "_DVD video"
+msgstr "_ڤیدیۆیی دی-ڤیدی"
+
+#: panels/removable-media/cc-removable-media-panel.ui:133
+msgid "_Music player"
+msgstr "_لێدەری میوزیک"
+
+#: panels/removable-media/cc-removable-media-panel.ui:191
+msgid "_Software"
+msgstr "_نەرمەواڵە"
+
+#: panels/removable-media/cc-removable-media-panel.ui:229
+msgid "_Other Media…"
+msgstr "_میدیای تر..."
+
+#: panels/removable-media/cc-removable-media-panel.ui:288
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_هەرگیز یەکسەر یان بەرنامەکان مەکەوە لەناو ڕەنگاڵە تێخراوەکان"
+
+#: panels/removable-media/cc-removable-media-panel.ui:342
+msgid "Select how other media should be handled"
+msgstr "دیاریبکە چۆن ڕەنگاڵەی دیکە بەدەست دەکەون"
+
+#: panels/removable-media/cc-removable-media-panel.ui:389
+msgid "_Action:"
+msgstr "_کردارەکان:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:412
+msgid "_Type:"
+msgstr "_جۆر:"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "نەرمەواڵا بنەڕەتییەکان"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "نەرمەواڵا بنەڕەتییەکان ڕێکبخە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:7
+msgid "starred"
+msgstr "دەستپێکرا"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "بنەڕەت;نەرمەواڵا;پەسەندکراو;ڕەنگاڵە;"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "دەربارە"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "زانیاری ببینە دەربارەی سیستەمەکەت"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:7
+msgid "help-about"
+msgstr "help-about"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "مێدیای هەڵگرتەنی"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "ڕێکخستنەکانی میدیای هەڵگرتەنی چاک بکە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:7
+msgid "media-removable"
+msgstr "media-removable"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "دەنگ و ڕەنگاڵە"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "قەبارەی بیدەنگ/لابردنی بێدەنگی"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "زیادکردن"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "کەمکردن"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "مایکرۆفۆن بێدەنگ کردن/لابردنی بێدەنگ کردن"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "داگیرساندنی لێدەری ڕەنگاڵه"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "لێیبدە (یان لێیبدە/بیوەسێنە)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "پلەیباک بۆستێنە"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "پلەیباک ڕابگرە"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "تراکی پێشتر"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "تراکی دواتر"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "دەریبکە"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:565
+msgid "Typing"
+msgstr "نووسین"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "بیگۆڕە سەر سەرچاوەی تێچووی دواتر"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "بیگۆڕە سەر سەرچاوەی تێچووی پێشتر"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "کارپێکەر"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "وێبگەڕی یارمەتی کارپێبکە"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "ژمێرەر کارپێبکە"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "پۆستی ڕاژەخواز کارپێبکە"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch terminal"
+msgstr "کۆتاگه‌ کارپێبکە"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Launch web browser"
+msgstr "وێبگەڕی تۆڕ کارپێبکە"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgid "Home folder"
+msgstr "بوخچەی سەرەکی"
+
+#: panels/keyboard/01-launchers.xml.in:18
+msgctxt "keybinding"
+msgid "Search"
+msgstr "گەڕان"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "وێنەکانی شاشە"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr "وێنەیەکی شاشە پاشەکەوتبکە بۆ $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "وێنەیەکی شاشەی پەنجەرەیەک پاشەکەوتبکە بۆ $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "وێنەیەکی شاشەی ناوچەیەک پاشەکەوتبکە بۆ $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "وێنەیەکی شاشەیەک لەبەربگرەوە بۆ لیستەی لەبەرگیراوە"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "وێنەیەکی شاشەی پەنجەرەیەک پاشەکەوتبکە بۆ لیستەی لەبەرگیراوە"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "وێنەیەکی شاشەی ناوچەیەک پاشەکەوتبکە بۆ لیستەی لەبەرگیراوە"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr "ڤیدیۆیەکی کورتی شاشە تۆماربکە"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "سیسته‌م"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "چوونە دەرەوە"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "قفڵی شاشە"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Universal Access"
+msgstr "دەستگەیشنی گەردوونی"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "نزیکی بکەوە یان دوری بخەوە"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "نزیکردنەوە"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "دوورکردنەوە"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "شاشەی خوێنەر هەڵبکە یان بیکوژێنەوە"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "تەختەکلیلی سەر شاشە هەڵبکە یان بیکوژێنەوە"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "قەبارەی نووسین زیادبکە"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "قەبارەی نووسین کەمبکە"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "جیاوازی بەرز هەڵبکە یان بیکوژێنەوە"
+
+#: panels/keyboard/cc-keyboard-manager.c:501
+#: panels/keyboard/cc-keyboard-manager.c:509
+#: panels/keyboard/cc-keyboard-manager.c:809
+msgid "Custom Shortcuts"
+msgstr "قەدبڕی دروستکراو"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: panels/keyboard/cc-keyboard-option.c:337
+msgid "Alternative Characters Key"
+msgstr "کلیل نووسە جێگرەوەکان"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: panels/keyboard/cc-keyboard-option.c:346
+msgid "Compose Key"
+msgstr "دووگمەی کەمپەوز"
+
+#: panels/keyboard/cc-keyboard-option.c:351
+msgid "Modifiers-only switch to next source"
+msgstr "تەنها-ڕێکخەرەکان بیگۆڕە سەر سەرچاوەی دواتر"
+
+#: panels/keyboard/cc-keyboard-panel.c:201
+msgid "Reset All Shortcuts?"
+msgstr "هەمووی قەدبڕەکان ڕێکدەخەیتەوە؟"
+
+#: panels/keyboard/cc-keyboard-panel.c:204
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"رێکخستنەوهی قەدبڕەکان لەوانەیە کاریگەری هەبێ لەسەر قەدبڕە دروستکراوەکان. "
+"ئەمە ناتوانرێ هەڵ بوەشێندرێتەوە."
+
+#: panels/keyboard/cc-keyboard-panel.c:208
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:346
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+msgid "Cancel"
+msgstr "هه‌ڵوه‌شاندنه‌وه‌"
+
+#: panels/keyboard/cc-keyboard-panel.c:209
+msgid "Reset All"
+msgstr "هەمووی ڕێکبخەوە"
+
+#: panels/keyboard/cc-keyboard-panel.c:305
+msgid "Reset the shortcut to its default value"
+msgstr "قەدبڕەکە ڕێکبخەوە بۆ بەها بنەڕەتییەکەی خۆی"
+
+#: panels/keyboard/cc-keyboard-panel.ui:147
+msgid "Reset All…"
+msgstr "هەمووی ڕێکبخەوە..."
+
+#: panels/keyboard/cc-keyboard-panel.ui:148
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "قەدبڕەکە ڕێکبخەوە بۆ کلیلە بنەڕەتییەکانی خۆی"
+
+#: panels/keyboard/cc-keyboard-panel.ui:177
+msgid "No keyboard shortcut found"
+msgstr "هیچ قەدبڕی تەختەکلیلێک نەدۆزرایەوە"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:411
+#, c-format
+msgid ""
+"%s is already being used for <b>%s</b>. If you replace it, %s will be "
+"disabled"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+msgid "Set Custom Shortcut"
+msgstr "قەدبڕی دروستکراو دابنێ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+msgid "Set Shortcut"
+msgstr "قەدبڕ دابنێ"
+
+#. Setup the top label
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:590
+#, c-format
+msgid "Enter new shortcut to change <b>%s</b>."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:1016
+msgid "Add Custom Shortcut"
+msgstr "قەدبڕی دروستکراو زیادبکە"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+#: panels/region/cc-region-panel.ui:420 shell/cc-window.ui:327
+msgid "Keyboard Shortcuts"
+msgstr "قەدبڕەکانی تەختەکلیل"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "قەبڕەکانی تەختەکلیل ببینە و بگۆڕە و هەڵبژاردەی نووسینەکەت دابنی"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:7
+msgid "input-keyboard"
+msgstr "input-keyboard"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"قەدبڕ;شوێنکار;پەنجەرە;گۆڕینی قەبارە;زووم;جیاوازی;تێجوو;سەرچاوە;قفڵ;قەبارە;"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:68
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:318
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Esc بکە بۆ هەڵوەشاندنەو یان Backspace بۆ ناچالاک کردنی قەدبڕی تەختەکلیل."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:156
+#: panels/printers/pp-details-dialog.ui:40
+msgid "Name"
+msgstr "ناو"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:168
+msgid "Command"
+msgstr "فرمان"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:180
+msgid "Shortcut"
+msgstr "قەدبڕ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:259
+msgid "Set Shortcut…"
+msgstr "قەدبڕ دابنێ..."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:272
+msgid "None"
+msgstr "نییە"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:303
+msgid "Enter the new shortcut"
+msgstr "قەدبڕە نوێییەکە تۆماربکە"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:357
+msgid "Remove"
+msgstr "سڕینەوە"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:367
+msgid "Add"
+msgstr "زیادکردن"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:382
+msgid "Replace"
+msgstr "جێگرتنەوە"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:395
+msgid "Set"
+msgstr "دانان"
+
+#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:436
+msgid "Test Your _Settings"
+msgstr "_ڕێکخستنەکانت تاقی بکەرەوە"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "مشک و مشکی لاپتۆپ"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"هەستیاری مشکەکەت و مشکی لاپتۆپەکەت بگۆڕە و دەستە ڕاست یان چەپ دیاری بکە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:7
+msgid "input-mouse"
+msgstr "input-mouse"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "تراکپاد;نیشاندەر;کرتە;پەنجە لێدان;جووت;دوگمە;گۆسووڕ;پێچۆکە;"
+
+#: panels/mouse/cc-mouse-panel.ui:37
+msgid "General"
+msgstr "گشتی"
+
+#: panels/mouse/cc-mouse-panel.ui:75
+msgid "Primary Button"
+msgstr "دوگمەی سەرەکی"
+
+#: panels/mouse/cc-mouse-panel.ui:94
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "فرمانی دوگمە فیزیاییەکان دادەنرێت لە مشکەکان و مشکەکانی لاپتۆپ"
+
+#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "چەپ"
+
+#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "ڕاست"
+
+#: panels/mouse/cc-mouse-panel.ui:169
+msgid "Mouse"
+msgstr "مشک"
+
+#: panels/mouse/cc-mouse-panel.ui:208
+msgid "Mouse Speed"
+msgstr "خێرای مشک"
+
+#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
+msgid "Double-click timeout"
+msgstr "وەستانی جووت-کلیک"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
+msgid "Natural Scrolling"
+msgstr "پێچۆکه‌گه‌ری سروشتی"
+
+#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
+msgid "Scrolling moves the content, not the view."
+msgstr "پێچۆکه‌گه‌ری ناوەڕۆکەکە دەجوڵێنێت، نەک دیمەنەکە."
+
+#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
+msgid "Touchpad"
+msgstr "مشکی لاپتۆپ"
+
+#: panels/mouse/cc-mouse-panel.ui:501
+msgid "Touchpad Speed"
+msgstr "خێرای مشکی لاپتۆپ"
+
+#: panels/mouse/cc-mouse-panel.ui:560
+msgid "Tap to Click"
+msgstr "پەنجەی لێبدە بۆ کرتەکردن"
+
+#: panels/mouse/cc-mouse-panel.ui:612
+msgid "Two-finger Scrolling"
+msgstr "پێچۆکه‌گه‌ری دوو-پەنجە"
+
+#: panels/mouse/cc-mouse-panel.ui:665
+msgid "Edge Scrolling"
+msgstr "پێچۆکه‌گه‌ری لێوار"
+
+#: panels/mouse/cc-mouse-test.c:132 panels/mouse/cc-mouse-test.ui:25
+msgid "Try clicking, double clicking, scrolling"
+msgstr "کرتەکردن، جووت کرتەکردن، پێچۆکه‌گه‌ری تاقی بکەرەوە"
+
+#: panels/mouse/cc-mouse-test.c:137
+msgid "Five clicks, GEGL time!"
+msgstr "پێنج کرتە، کاتی (GEGL)ـە!"
+
+#: panels/mouse/cc-mouse-test.c:142
+msgid "Double click, primary button"
+msgstr "جووت کرتە، دوگمەی سەرەکی"
+
+#: panels/mouse/cc-mouse-test.c:142
+msgid "Single click, primary button"
+msgstr "تاک کرتە، دوگمەی سەرەکی"
+
+#: panels/mouse/cc-mouse-test.c:145
+msgid "Double click, middle button"
+msgstr "جووت کرتە، دوگمەی ناوەڕاست"
+
+#: panels/mouse/cc-mouse-test.c:145
+msgid "Single click, middle button"
+msgstr "تاک کرتە، دوگمەی ناوەڕاست"
+
+#: panels/mouse/cc-mouse-test.c:148
+msgid "Double click, secondary button"
+msgstr "جووت کرتە، دوگمەی لاوەکی"
+
+#: panels/mouse/cc-mouse-test.c:148
+msgid "Single click, secondary button"
+msgstr "تاک کرتە، دوگمەی لاوەکی"
+
+#. add proxy to device list
+#: panels/network/cc-network-panel.c:582
+msgid "Network proxy"
+msgstr ""
+
+#. update title
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/net-vpn.c:66 panels/network/net-vpn.c:163
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#: panels/network/cc-network-panel.c:648 panels/network/cc-wifi-panel.ui:306
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"ئۆو، هەنێکشت بە ‌هەڵەدا ڕۆشتوون. تکایە پەیوەندی بکە بە فرۆشیاری نەرمەکاڵاکەت."
+
+#: panels/network/cc-network-panel.c:654
+msgid "NetworkManager needs to be running."
+msgstr "پێوستە بەڕێوبەری ڕایەڵە کاربکات"
+
+#: panels/network/cc-network-panel.ui:68
+msgid "Other Devices"
+msgstr "ئامێرەکان تر"
+
+#: panels/network/cc-network-panel.ui:109
+#: panels/network/connection-editor/net-connection-editor.c:596
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:153
+msgid "Not set up"
+msgstr "دانەنراوە"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:198
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.ui:102
+#: panels/network/net-device-ethernet.c:318
+#: panels/network/network-bluetooth.ui:76
+#: panels/network/network-ethernet.ui:102 panels/network/network-mobile.ui:414
+#: panels/network/network-vpn.ui:75
+msgid "Options…"
+msgstr "هەڵبژاردەکان..."
+
+#: panels/network/cc-wifi-panel.c:276
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:233
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:56
+msgid "Airplane Mode"
+msgstr "دۆخی فڕۆکە"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Wi-Fi، بلووتووس و ئینتەرنێتی خێرای مۆبایل ناچالاک دەکرێت"
+
+#: panels/network/cc-wifi-panel.ui:141
+msgid "No Wi-Fi Adapter Found"
+msgstr "هیچ گونجێنەرێکی Wi-Fi نەدۆزرایەوە"
+
+#: panels/network/cc-wifi-panel.ui:153
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "دڵنیابە کە گونجێنەرێکی Wi-Fi پێوەکراوە و هەڵکراوە"
+
+#: panels/network/cc-wifi-panel.ui:188
+msgid "Airplane Mode On"
+msgstr "دۆخی تەیارە هەڵکراوە"
+
+#: panels/network/cc-wifi-panel.ui:200
+msgid "Turn off to use Wi-Fi"
+msgstr "بیکوژێنەوە بۆ ئەوەی Wi-Fi بەکاربێنیت"
+
+#: panels/network/cc-wifi-panel.ui:227
+msgid "Visible Networks"
+msgstr "ڕایەڵە دیارەکان"
+
+#: panels/network/cc-wifi-panel.ui:295
+msgid "NetworkManager needs to be running"
+msgstr "پێویستە بەڕێوبەری ڕایەڵە کاربکات"
+
+#: panels/network/connection-editor/8021x-security-page.ui:20
+msgid "802.1x _Security"
+msgstr "_ئاسایشی 802.1x"
+
+#: panels/network/connection-editor/8021x-security-page.ui:73
+#: panels/network/connection-editor/security-page.ui:72
+#: panels/wacom/wacom-stylus-page.ui:108
+msgid "page 1"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:49
+#: panels/network/wireless-security/eap-method-peap.ui:52
+#: panels/network/wireless-security/eap-method-ttls.ui:51
+msgid "Anony_mous identity"
+msgstr "ناسنامەی نە_ناسراو"
+
+#: panels/network/connection-editor/8021x-security-page.ui:238
+#: panels/network/connection-editor/security-page.ui:237
+msgid "Inner _authentication"
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:281
+#: panels/network/connection-editor/security-page.ui:280
+#: panels/wacom/wacom-stylus-page.ui:426
+msgid "page 2"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:112
+#: panels/network/connection-editor/ce-page-security.c:404
+#: panels/network/connection-editor/details-page.ui:90
+msgid "Security"
+msgstr "ئاسایش"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "ناوچەی پارێزراو"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "هەمیشەیی"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "هەڕەمەکی"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "جێگیر"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "خۆکار"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "زانیاریئ کەسیی %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:93
+#: panels/network/net-device-wifi.c:235
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:240
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:109
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:115
+msgid "Enterprise"
+msgstr "پرۆژەی ئابووری"
+
+#: panels/network/connection-editor/ce-page-details.c:120
+#: panels/network/net-device-wifi.c:225
+msgctxt "Wifi security"
+msgid "None"
+msgstr "نییە"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:119
+#: panels/network/connection-editor/ce-page-details.c:141
+msgid "Never"
+msgstr "هه‌رگیز"
+
+#: panels/network/connection-editor/ce-page-details.c:156
+#: panels/network/net-device-ethernet.c:108
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i ڕۆژ لەمەو پێش"
+msgstr[1] "%i ڕۆژ لەمەو پێش"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:283
+#: panels/network/net-device-ethernet.c:202
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:324
+msgctxt "Signal strength"
+msgid "None"
+msgstr "نییە"
+
+#: panels/network/connection-editor/ce-page-details.c:326
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "لاواز"
+
+#: panels/network/connection-editor/ce-page-details.c:328
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "باشە"
+
+#: panels/network/connection-editor/ce-page-details.c:330
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "باش"
+
+#: panels/network/connection-editor/ce-page-details.c:332
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "نایاب"
+
+#: panels/network/connection-editor/ce-page-details.c:429
+msgid "Forget Connection"
+msgstr "پەیوەستبوون لەبیربکە"
+
+#: panels/network/connection-editor/ce-page-details.c:431
+msgid "Remove Connection Profile"
+msgstr "پڕۆفایلی پەیوەستبوون بسڕەوە"
+
+#: panels/network/connection-editor/ce-page-details.c:433
+msgid "Remove VPN"
+msgstr "VPN بسڕەوە"
+
+#: panels/network/connection-editor/ce-page-details.c:451
+msgid "Details"
+msgstr "وردەکارییەکان"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:150
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "ناسنامە"
+
+#: panels/network/connection-editor/ce-page-ip4.c:268
+#: panels/network/connection-editor/ce-page-ip6.c:249
+msgid "Delete Address"
+msgstr "ناونیشان بسڕەوە"
+
+#: panels/network/connection-editor/ce-page-ip4.c:428
+#: panels/network/connection-editor/ce-page-ip6.c:398
+msgid "Delete Route"
+msgstr "ڕێگە بسڕەوە"
+
+#: panels/network/connection-editor/ce-page-ip4.c:852
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:783
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:260
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "نییە"
+
+#: panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:293
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit Passphrase"
+
+#: panels/network/connection-editor/ce-page-security.c:306
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:319
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamic WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:333
+msgid "WPA & WPA2 Personal"
+msgstr "WPA و WPA2 کەسی"
+
+#: panels/network/connection-editor/ce-page-security.c:347
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA و WPA2 پڕۆژەی ئابووری"
+
+#: panels/network/connection-editor/details-page.ui:18
+msgid "Signal Strength"
+msgstr "هێزی نیشانە"
+
+#: panels/network/connection-editor/details-page.ui:54
+msgid "Link speed"
+msgstr "خێرایی بەستەر"
+
+#: panels/network/connection-editor/ce-page-details.c:390
+#: panels/network/connection-editor/details-page.ui:108
+#: panels/network/net-device-ethernet.c:143
+#: panels/network/net-device-mobile.c:431
+msgid "IPv4 Address"
+msgstr "ناونیشانی IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:391
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-ethernet.c:148
+#: panels/network/net-device-mobile.c:432 panels/network/network-mobile.ui:200
+msgid "IPv6 Address"
+msgstr "ناونیشانی IPv6"
+
+#: panels/network/connection-editor/details-page.ui:144
+#: panels/network/net-device-ethernet.c:151
+msgid "Hardware Address"
+msgstr "ناونیشانی ڕەقەکاڵا"
+
+#: panels/network/connection-editor/details-page.ui:180
+#: panels/network/net-device-ethernet.c:155
+#: panels/network/network-mobile.ui:217
+msgid "Default Route"
+msgstr "ڕیگەی بنەڕەت"
+
+#: panels/network/connection-editor/details-page.ui:199
+#: panels/network/connection-editor/ip4-page.ui:211
+#: panels/network/connection-editor/ip6-page.ui:225
+#: panels/network/net-device-ethernet.c:157
+#: panels/network/network-mobile.ui:235
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:217
+msgid "Last Used"
+msgstr "داواین بەکارهێنان"
+
+#: panels/network/connection-editor/details-page.ui:376
+msgid "Connect _automatically"
+msgstr "_خۆکارانە پەیوەستببە"
+
+#: panels/network/connection-editor/details-page.ui:395
+msgid "Make available to _other users"
+msgstr "بەردەستیبکە بۆ بەکارهێنەرانی _دیکە"
+
+#: panels/network/connection-editor/details-page.ui:428
+msgid "Restrict _background data usage"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:439
+msgid "Appropriate for connections that have data charges or limits."
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:120
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:291
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/connection-editor/ip6-page.ui:305
+#: panels/network/net-proxy.c:74 panels/network/network-proxy.ui:106
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "خۆکار"
+
+#: panels/network/connection-editor/ethernet-page.ui:19
+msgid "Twisted Pair (TP)"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:22
+msgid "Attachment Unit Interface (AUI)"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+msgid "BNC"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:28
+msgid "Media Independent Interface (MII)"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+msgid "10 Mb/s"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:45
+msgid "100 Mb/s"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:48
+msgid "1 Gb/s"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:51
+msgid "10 Gb/s"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "_ناو"
+
+#: panels/network/connection-editor/ethernet-page.ui:54
+#: panels/network/connection-editor/wifi-page.ui:67
+msgid "_MAC Address"
+msgstr "ناونیشانی _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:105
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:122
+#: panels/network/connection-editor/wifi-page.ui:102
+msgid "_Cloned Address"
+msgstr "ناونێشانی _لێکچوو"
+
+#: panels/network/connection-editor/ethernet-page.ui:137
+msgid "bytes"
+msgstr "بایت"
+
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr "شێوازی IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:42
+msgid "Automatic (DHCP)"
+msgstr "(DHCP)ی خۆاکر"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr "تەها بەستەری-ناوخۆیی"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:121
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:72 panels/network/network-proxy.ui:116
+msgid "Manual"
+msgstr "دەستکار"
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr "ناچالاککردن"
+
+#: panels/network/connection-editor/ip4-page.ui:125
+#: panels/network/connection-editor/ip6-page.ui:139
+msgid "Addresses"
+msgstr "ناونیشانەکان"
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/printers/pp-details-dialog.ui:95
+msgid "Address"
+msgstr "ناونیشان"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+msgid "Netmask"
+msgstr "دەمامکی تۆڕ"
+
+#: panels/network/connection-editor/ip4-page.ui:171
+#: panels/network/connection-editor/ip4-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:369
+msgid "Gateway"
+msgstr "دەرەڕێ"
+
+#: panels/network/connection-editor/ip4-page.ui:234
+#: panels/network/connection-editor/ip6-page.ui:248
+msgid "Automatic DNS"
+msgstr "DNSی خۆکار"
+
+#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Separate IP addresses with commas"
+msgstr "ناونیشانەکانی IP جیاکراوە لەگەڵ بۆرەکان"
+
+#: panels/network/connection-editor/ip4-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:293
+msgid "Routes"
+msgstr "ڕێگەکان"
+
+#: panels/network/connection-editor/ip4-page.ui:302
+#: panels/network/connection-editor/ip6-page.ui:316
+msgid "Automatic Routes"
+msgstr "ڕێگە خۆکارەکان"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:368
+#: panels/network/connection-editor/ip6-page.ui:382
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/network/connection-editor/ip4-page.ui:398
+#: panels/network/connection-editor/ip6-page.ui:412
+msgid "Use this connection _only for resources on its network"
+msgstr "ئەم پەیوەندییە بەکاربێنە _تەنها بۆ سەرچاوەکان لەو ڕایەڵەیە"
+
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr "شێوازی IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr "خۆکار، تەنها DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Prefix"
+msgstr "پێشگر"
+
+#: panels/network/connection-editor/net-connection-editor.c:291
+msgid "Unable to open connection editor"
+msgstr "ناتوانرێ دەستکاریکەری پەیوەندی بکرێتەوە"
+
+#: panels/network/connection-editor/net-connection-editor.c:307
+msgid "New Profile"
+msgstr "زانیاری کەسیی نوێ"
+
+#: panels/network/connection-editor/net-connection-editor.c:740
+msgid "Import from file…"
+msgstr "هێنان لە پەڕگە..."
+
+#: panels/network/connection-editor/net-connection-editor.c:772
+msgid "Add VPN"
+msgstr "VPN زیادبکە"
+
+#: panels/network/connection-editor/security-page.ui:20
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:139
+msgid "Cannot import VPN connection"
+msgstr "ناتوانرێت پەیوەندی VPNبهێنرێت"
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:173
+msgid "Select file to import"
+msgstr "پەڕگە دیاریبکە بۆ هێنان"
+
+#: panels/network/connection-editor/vpn-helpers.c:225
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "پەڕگەیەک بە ناوی “%s” پێشتر بوونی هەیە."
+
+#: panels/network/connection-editor/vpn-helpers.c:227
+msgid "_Replace"
+msgstr "_جێگرتنەوە"
+
+#: panels/network/connection-editor/vpn-helpers.c:229
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:264
+msgid "Cannot export VPN connection"
+msgstr "ناتوانرێت پەیوەندی VPN هاوردەبکرێ"
+
+#: panels/network/connection-editor/vpn-helpers.c:266
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:296
+msgid "Export VPN connection"
+msgstr "پەیوەندی VPN هاوردەبکە"
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:20
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:36
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#. FIXME
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/connectivity/gnome-connectivity-panel.desktop.in.in:8
+#: panels/network/gnome-network-panel.desktop.in.in:7
+msgid "network-workgroup"
+msgstr "network-workgroup"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/network/gnome-wifi-panel.desktop.in.in:7
+msgid "network-wireless"
+msgstr "network-wireless"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/net-device-ethernet.c:96
+msgid "never"
+msgstr "هەرگیز"
+
+#: panels/network/net-device-ethernet.c:104
+msgid "today"
+msgstr "ئەمڕۆ"
+
+#: panels/network/net-device-ethernet.c:106
+msgid "yesterday"
+msgstr "دوێنێ"
+
+#: panels/network/connection-editor/ce-page-details.c:394
+#: panels/network/connection-editor/ce-page-details.c:395
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:435
+#: panels/network/net-device-mobile.c:436 panels/network/network-mobile.ui:183
+msgid "IP Address"
+msgstr "ناونیشانی پرۆتۆکۆڵی ئینتەرنێت"
+
+#: panels/network/net-device-ethernet.c:162
+msgid "Last used"
+msgstr "دواین بەکارهێنان"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:252
+#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+msgid "Wired"
+msgstr "بەستراو بە وایەر"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "پەیوەندی نوێ زیادبکە"
+
+#: panels/network/net-device-wifi.c:1368
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1372
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:458
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "خاڵی داخی Wi-Fi هەڵدەکەیت؟"
+
+#: panels/network/net-device-wifi.c:1401
+msgid ""
+"Wi-Fi hotspots are usually used to share an additional Internet connection "
+"over Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:130
+msgid "_Turn On"
+msgstr "_هەڵی بکە"
+
+#: panels/network/net-device-wifi.c:798
+msgid "Stop hotspot and disconnect any users?"
+msgstr "خاڵی داخ بوەستێنە و هەر بەکار‌هێنەرێک ناچالاک بکرێت؟"
+
+#: panels/network/net-device-wifi.c:801
+msgid "_Stop Hotspot"
+msgstr "خاڵیداخ _بوەستێنە"
+
+#: panels/network/net-device-wifi.c:1268
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1271
+msgid "Wireless device does not support Hotspot mode"
+msgstr "ئامێری بێتەل پشتگیری دۆخی خاڵی داخ ناکات"
+
+#: panels/network/net-device-wifi.c:905
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+
+#: panels/network/net-device-wifi.c:909
+msgid "_Forget"
+msgstr "_لەبیرکردن"
+
+#: panels/network/net-device-wifi.c:1065 panels/network/net-device-wifi.c:1072
+msgid "Known Wi-Fi Networks"
+msgstr "ڕایەڵەکانی وای-فای ناسراوە"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1107
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_لەبیرکردن"
+
+#: panels/network/net-proxy.c:70
+#: panels/notifications/cc-notifications-panel.c:267
+#: panels/power/cc-power-panel.c:2068 panels/power/cc-power-panel.c:2079
+#: panels/universal-access/cc-ua-panel.c:480
+#: panels/universal-access/cc-ua-panel.c:843
+#: panels/universal-access/cc-ua-panel.c:856
+#: panels/universal-access/cc-ua-panel.c:868
+#: panels/universal-access/cc-ua-panel.c:1033
+#: panels/universal-access/cc-ua-panel.ui:323
+#: panels/universal-access/cc-ua-panel.ui:369
+#: panels/universal-access/cc-ua-panel.ui:415
+#: panels/universal-access/cc-ua-panel.ui:521
+#: panels/universal-access/cc-ua-panel.ui:674
+#: panels/universal-access/cc-ua-panel.ui:720
+#: panels/universal-access/cc-ua-panel.ui:766
+#: panels/universal-access/cc-ua-panel.ui:950
+msgid "Off"
+msgstr "کوژاوەتەوە"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:113
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:121
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#: panels/network/network-mobile.ui:29
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:47
+msgid "Provider"
+msgstr "دابینکەر"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:95
+msgid "Network Proxy"
+msgstr "پرۆکسی ڕایەڵە"
+
+#: panels/network/network-proxy.ui:176
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:195
+msgid "H_TTPS Proxy"
+msgstr "پرۆکسی H_TTPS"
+
+#: panels/network/network-proxy.ui:214
+msgid "_FTP Proxy"
+msgstr "پڕۆکسی _FTP"
+
+#: panels/network/network-proxy.ui:233
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:252
+msgid "_Ignore Hosts"
+msgstr "خانەخوێیەکان _پشتگوێبخە"
+
+#: panels/network/network-proxy.ui:290
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:367
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:388
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:409
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:438
+msgid "_Configuration URL"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:50
+msgid "Turn device off"
+msgstr "ئامێر بکوژێنەوە"
+
+#: panels/network/network-vpn.ui:55
+msgid "Turn VPN connection off"
+msgstr "پەیوەندی VPN بکوژێنەوە"
+
+#: panels/network/network-wifi.ui:127
+msgid "Automatic _Connect"
+msgstr ""
+
+#: panels/network/network-wifi.ui:474
+msgid "details"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:31
+#: panels/network/wireless-security/eap-method-simple.ui:31
+#: panels/network/wireless-security/ws-leap.ui:32
+#: panels/network/wireless-security/ws-wpa-psk.ui:14
+#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/user-accounts/cc-add-user-dialog.ui:310
+#: panels/user-accounts/cc-add-user-dialog.ui:547
+#: panels/user-accounts/cc-user-panel.ui:385
+msgid "_Password"
+msgstr "_تێپەڕەوشە"
+
+#: panels/network/network-wifi.ui:622
+msgid "Show P_assword"
+msgstr ""
+
+#: panels/network/network-wifi.ui:652
+msgid "Make available to other users"
+msgstr ""
+
+#: panels/network/network-wifi.ui:680
+msgid "identity"
+msgstr ""
+
+#: panels/network/network-wifi.ui:714
+msgid "IPv_4"
+msgstr ""
+
+#: panels/network/network-wifi.ui:755 panels/network/network-wifi.ui:1032
+msgid "_Addresses"
+msgstr ""
+
+#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
+msgid "Automatic (DHCP) addresses only"
+msgstr ""
+
+#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
+msgid "Link-local only"
+msgstr ""
+
+#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
+msgid "Shared with other computers"
+msgstr ""
+
+#: panels/network/network-wifi.ui:917 panels/network/network-wifi.ui:1194
+msgid "_Ignore automatically obtained routes"
+msgstr ""
+
+#: panels/network/network-wifi.ui:960
+msgid "ipv4"
+msgstr ""
+
+#: panels/network/network-wifi.ui:991
+msgid "IPv_6"
+msgstr ""
+
+#: panels/network/network-wifi.ui:1237
+msgid "ipv6"
+msgstr ""
+
+#: panels/network/network-wifi.ui:1277
+msgid "_Cloned MAC Address"
+msgstr ""
+
+#: panels/network/network-wifi.ui:1346
+msgid "_Reset"
+msgstr ""
+
+#: panels/network/network-wifi.ui:1382
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+
+#: panels/network/network-wifi.ui:1399
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+
+#: panels/network/network-wifi.ui:1472
+msgid "Hardware"
+msgstr ""
+
+#: panels/network/network-wifi.ui:1476
+msgctxt "tab"
+msgid "Reset"
+msgstr ""
+
+#: panels/network/network-wifi.ui:37
+msgid "Wi-Fi Hotspot"
+msgstr "ئاگری داخی وای-فای"
+
+#: panels/network/network-wifi.ui:55
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "بیکوژێنەوە بۆ ئەوەی پەیوەندی بکەی بە ئینتەرنێت"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:44
+#: panels/network/network-wifi.ui:105
+msgid "Network Name"
+msgstr "ناوی ڕایەڵە"
+
+#: panels/network/network-wifi.ui:1621
+msgid "Connected Devices"
+msgstr ""
+
+#: panels/network/network-wifi.ui:123
+msgid "Security type"
+msgstr "جۆری ئاسایش"
+
+#: panels/network/network-wifi.ui:175
+msgctxt "Wi-Fi passkey"
+msgid "Password"
+msgstr "تێپەڕەوشە"
+
+#: panels/network/network-wifi.ui:264
+msgid "Turn Wi-Fi off"
+msgstr "وای-فای بکوژێنەوە"
+
+#: panels/network/network-wifi.ui:296
+msgid "_Connect to Hidden Network…"
+msgstr "_پەیوەندی بکە بە ڕایەڵەی شاراوە..."
+
+#: panels/network/network-wifi.ui:307
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_هەڵکردنی هۆتسپۆتی وایفای..."
+
+#: panels/network/network-wifi.ui:318
+msgid "_Known Wi-Fi Networks"
+msgstr "ڕایەڵەی وایفای _ناسراو"
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:127
+msgid "Ad-hoc"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:131
+msgid "Infrastructure"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "دۆخ نەزانراوە"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "ڕێکنەخراوە"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "بەردەست نییە"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "پەیوەندی دەگرێت"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "ڕێپێدان پێویستە"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "پەیوەستە"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "لە پەیوەندی دەرچوون"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "پەیوەندی سەرکەوتوونەبوو"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "دۆخ نەزانراوە (بوونی نیە)"
+
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:223
+msgid "Not connected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "ڕێکخستن سەرکەوتوو نەبوو"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "مۆدیۆم نەدۆزرایەوە"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "پەیوەستبوونەوەی بلووتووس سەرکەوتوو نەبوو"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "سیم کارت تێنەخراوە"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252
+msgid "SIM wrong"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:351
+msgid "Firmware missing"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:355
+msgid "Cable unplugged"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:195
+msgid "no file selected"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:222
+msgid "unspecified error validating eap-method file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:400
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:87
+msgid "missing EAP-FAST PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.c:347
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:352
+msgid "PAC files (*.pac)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "نەناسراو"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "ڕێپێدرا"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "هەردووک"
+
+#: panels/network/wireless-security/eap-method-fast.ui:75
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:115
+#: panels/network/wireless-security/eap-method-peap.ui:150
+#: panels/network/wireless-security/eap-method-ttls.ui:143
+msgid "_Inner authentication"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:144
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:64
+msgid "missing EAP-LEAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:73
+msgid "missing EAP-LEAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:17
+#: panels/network/wireless-security/eap-method-simple.ui:17
+#: panels/network/wireless-security/ws-leap.ui:18
+#: panels/user-accounts/cc-add-user-dialog.ui:146
+#: panels/user-accounts/cc-add-user-dialog.ui:527
+msgid "_Username"
+msgstr "_ناوی بەکارهێنەر"
+
+#: panels/network/wireless-security/eap-method-leap.ui:55
+#: panels/network/wireless-security/eap-method-simple.ui:73
+#: panels/network/wireless-security/eap-method-tls.ui:157
+#: panels/network/wireless-security/ws-leap.ui:56
+#: panels/network/wireless-security/ws-wpa-psk.ui:64
+msgid "Sho_w password"
+msgstr "تێپەڕەوشە پشانبد_ە"
+
+#: panels/network/wireless-security/eap-method-peap.c:87
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:96
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.c:328
+#: panels/network/wireless-security/eap-method-tls.c:507
+#: panels/network/wireless-security/eap-method-ttls.c:336
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "وەشان ٠"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "وەشان ١"
+
+#: panels/network/wireless-security/eap-method-peap.ui:78
+#: panels/network/wireless-security/eap-method-tls.ui:68
+#: panels/network/wireless-security/eap-method-ttls.ui:102
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:100
+#: panels/network/wireless-security/eap-method-tls.ui:90
+#: panels/network/wireless-security/eap-method-ttls.ui:125
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:118
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:91
+msgid "missing EAP-TLS identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:101
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:111
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:125
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:135
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:266
+msgid "Unencrypted private keys are insecure"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:269
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:500
+msgid "Choose your personal certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:514
+msgid "Choose your private key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:17
+msgid "I_dentity"
+msgstr "ن_اسنامە"
+
+#: panels/network/wireless-security/eap-method-tls.ui:43
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:133
+msgid "_Private key password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:98
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:106
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:76
+#: panels/user-accounts/cc-add-user-dialog.ui:507
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "_دۆمەین"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunneled TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Protected EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:102
+#: panels/network/wireless-security/ws-wpa-eap.ui:61
+msgid "Au_thentication"
+msgstr "ڕێپێ_دان"
+
+#: panels/network/wireless-security/ws-leap.c:65
+msgid "missing leap-username"
+msgstr ""
+
+#: panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "سیستەم بکەرەوە"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "کلیلی بڵاوکراوە"
+
+#: panels/network/wireless-security/ws-wep-key.ui:48
+msgid "_Key"
+msgstr "_کلیل"
+
+#: panels/network/wireless-security/ws-wep-key.ui:84
+msgid "Sho_w key"
+msgstr "کلیل پیشان_بدە"
+
+#: panels/network/wireless-security/ws-wep-key.ui:134
+msgid "WEP inde_x"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.ui:42
+msgid "_Type"
+msgstr "_جۆر"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:60
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_ئاگادارکردنەوەکان"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:112
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:168
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "دەرپەڕاندنی _ئاگادارنامەکان"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:184
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"ئاگادارنامەکان بەردەوام دەبن بۆ دەرکەوتنی لە خشتەی ئاگادارنامە کاتێکە "
+"دەرپەڕاندنەکان ناچالاک دەکرێن."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:249
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "_ناوەڕۆکی پەیام پشانبدە لە دەڕپەڕاینەکان"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:300
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "ئاگادارنامەکانی  _قفڵی شاشەی"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:351
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "نا_وەڕۆکی پەیام پشانبدە لەسەر قفڵی شاشە"
+
+#: panels/notifications/cc-notifications-panel.c:267
+#: panels/power/cc-power-panel.c:2074 panels/power/cc-power-panel.c:2081
+#: panels/universal-access/cc-ua-panel.c:480
+#: panels/universal-access/cc-ua-panel.c:843
+#: panels/universal-access/cc-ua-panel.c:856
+#: panels/universal-access/cc-ua-panel.c:868
+#: panels/universal-access/cc-ua-panel.c:1033
+msgid "On"
+msgstr "هەڵکراوە"
+
+#: panels/notifications/cc-notifications-panel.ui:70
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:121
+msgid "_Lock Screen Notifications"
+msgstr "ئاگادارنامەکانی  _قفڵی شاشەی"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "کۆنتڕۆڵی چی ئاگادارنامەیەک پشانبدرێن و ئەوان چی پشانبدەن بکە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:7
+msgid "preferences-system-notifications"
+msgstr "preferences-system-notifications"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "ئاگادارنامەکان;مانشێت;پەیام;ترەی;دەرپەڕیوو;"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:150
+msgctxt "Online Account"
+msgid "Other"
+msgstr "هیتر"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:632
+#, c-format
+msgid "%s Account"
+msgstr "هەژماری %s"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:929
+msgid "Error removing account"
+msgstr "هەڵەیەک ڕویدا لەکاتی سڕینەوەی هەژمار"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:994
+#, c-format
+msgid "<b>%s</b> removed"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "هەژمارەکانی سەرهێڵ"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "هەژمارە سەرهێڵەکانت پەیوەستبکە و بڕیاربدە بۆ چی بەکاریان بێنی"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:7
+msgid "goa-panel"
+msgstr "goa-panel"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"گۆگڵ;فەیسبووک;تویتەر;یاهوو;تۆڕ;سەرهێل;دوان;ڕۆژژمێر;نامە;پەیوەندی;ئاونکڵاود;"
+"کیربیرەس;SMTP;IMAP;پۆکێت;ڕیدئتلەیتەر;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:54
+msgid "Undo"
+msgstr "گەڕانەوە"
+
+#: panels/online-accounts/online-accounts.ui:96
+msgid "Connect to your data in the cloud"
+msgstr "پەیوەستبە بە دراوەکانتەوە لە هەورەکەت"
+
+#: panels/online-accounts/online-accounts.ui:111
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"هیچ پەیوەندییەکی ئینتەرنێت نییە — پەیوەستبە بۆ ئەوەی هەژمارە سەرهێڵە "
+"نوێییەکان ڕێکبخەیت"
+
+#: panels/online-accounts/online-accounts.ui:136
+msgid "Add an account"
+msgstr "هەژمار زیاد بکە"
+
+#: panels/online-accounts/online-accounts.ui:243
+msgid "Remove Account"
+msgstr "هەژمار بسڕەوە"
+
+#: panels/power/cc-power-panel.c:331
+msgid "Unknown time"
+msgstr "کات نەزانراوە"
+
+#: panels/power/cc-power-panel.c:337
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i خولەک"
+msgstr[1] "%i خولەک"
+
+#: panels/power/cc-power-panel.c:349
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i کاژێر"
+msgstr[1] "%i کاژێر"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-power-panel.c:357
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-power-panel.c:358
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "کاژێر"
+msgstr[1] "کاژێرەکان"
+
+#: panels/power/cc-power-panel.c:359
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "خوله‌ک"
+msgstr[1] "خولەک"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:377
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s تا بە تەواوی بارگاوی دەبێت"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:384
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "ئاگاداری: %s ماوە"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:389
+#, c-format
+msgid "%s remaining"
+msgstr "%s ماوە"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:394 panels/power/cc-power-panel.c:424
+msgid "Fully charged"
+msgstr "بەتەواویی بارگاوی کرا"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:398 panels/power/cc-power-panel.c:428
+msgid "Not charging"
+msgstr "بارگاوی نابێت"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:402 panels/power/cc-power-panel.c:432
+msgid "Empty"
+msgstr "بەتاڵ"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:415
+msgid "Charging"
+msgstr "بارگاوی کردن"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:420
+msgid "Discharging"
+msgstr "بارگاویناکرێ"
+
+#: panels/power/cc-power-panel.c:553
+msgctxt "Battery name"
+msgid "Main"
+msgstr "سەرەکی"
+
+#: panels/power/cc-power-panel.c:555
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "زیادە"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:630
+msgid "Wireless mouse"
+msgstr "مشکی بێ تەل"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:633
+msgid "Wireless keyboard"
+msgstr "تەختەکلیلی بێ تەل"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:636
+msgid "Uninterruptible power supply"
+msgstr "نەبڕینی سەرچاوەی وزە"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:639
+msgid "Personal digital assistant"
+msgstr "یاریدەدەری دیجیتاڵی کەسی"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:642
+msgid "Cellphone"
+msgstr "تەلەفۆنی پەیوەندی"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:645
+msgid "Media player"
+msgstr "لێدەری ڕەنگاڵە"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:648 panels/wacom/cc-wacom-panel.c:809
+msgid "Tablet"
+msgstr "تابلێت"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:651
+msgid "Computer"
+msgstr "کۆمپیتەر"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:654
+msgid "Gaming input device"
+msgstr "ئامێری تێچووی یاریکردن"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-power-panel.c:657 panels/power/cc-power-panel.c:939
+#: panels/power/cc-power-panel.c:2425
+msgid "Battery"
+msgstr "پاتری"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:718
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "بارگاوی کردن"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:725
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "ئاگاداری"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:730
+msgctxt "Battery power"
+msgid "Low"
+msgstr "نزم"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:735
+msgctxt "Battery power"
+msgid "Good"
+msgstr "باش"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:740
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "بەتەواویی بارگاوی کرا"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:744
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "بەتاڵ"
+
+#: panels/power/cc-power-panel.c:937
+msgid "Batteries"
+msgstr "پاترییەکان"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d  کاژێر"
+msgstr[1] "%d  کاژێر"
+
+#: panels/common/cc-util.c:166
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d خولەک"
+msgstr[1] "%d خولەک"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d چرکە"
+msgstr[1] "%d چرکە"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:172
+#, c-format
+msgctxt "time"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:177
+#, c-format
+msgctxt "time"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:187
+msgid "0 seconds"
+msgstr "٠ چرکە"
+
+#: panels/power/cc-power-panel.c:1378
+msgid "When _idle"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1829
+msgid "Power Saving"
+msgstr "خەزنکردنی وزە"
+
+#: panels/power/cc-power-panel.c:1863
+msgid "_Screen Brightness"
+msgstr "_ڕووناکی شاشە"
+
+#: panels/power/cc-power-panel.c:1884
+msgid "Automatic Brightness"
+msgstr "ڕووناکی خودکار"
+
+#: panels/power/cc-power-panel.c:1897
+msgid "_Keyboard Brightness"
+msgstr "_ڕوونی تەختەکلیل"
+
+#: panels/power/cc-power-panel.c:1908
+msgid "_Dim Screen When Inactive"
+msgstr "شاشەکە _تاریک کاتێک بەکارناهێنرێت"
+
+#: panels/power/cc-power-panel.c:1926
+msgid "_Blank Screen"
+msgstr "شاشەی _بەتاڵ"
+
+#: panels/power/cc-power-panel.c:1949
+msgid "_Wi-Fi"
+msgstr "_وای-فای"
+
+#: panels/power/cc-power-panel.c:1950
+msgid "Wi-Fi can be turned off to save power."
+msgstr "دەتوانرێت وای-فای بکوژێنرێتەوە بۆ خەزنکردنی وزە."
+
+#: panels/power/cc-power-panel.c:1966
+msgid "_Mobile Broadband"
+msgstr "ئینتەرنێتی خێرای _مۆبایل"
+
+#: panels/power/cc-power-panel.c:1967
+msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+msgstr ""
+"ئینتەرنێتی خێرای مۆبایل (LTE, 4G, 3G, هتد...) دەتوانرێت بکوژێندرێتەوە بۆ "
+"خەزنکردنی وزە."
+
+#: panels/power/cc-power-panel.c:2017
+msgid "_Bluetooth"
+msgstr "_بلووتووس"
+
+#: panels/power/cc-power-panel.c:2018
+msgid "Bluetooth can be turned off to save power."
+msgstr "بلووتووس دەتوانرێت بکوژێندرێتەوە بۆ خەزنکردنی وزە."
+
+#: panels/power/cc-power-panel.c:2070
+msgid "When on battery power"
+msgstr "کاتێک لەسەر وزەی پاتریت"
+
+#: panels/power/cc-power-panel.c:2072
+msgid "When plugged in"
+msgstr "کاتێک بارگاوی دەبێت"
+
+#: panels/power/cc-power-panel.c:2166
+msgid "Suspend"
+msgstr "ڕاگرتن"
+
+#: panels/power/cc-power-panel.c:2167
+msgid "Power Off"
+msgstr "بیکوژێنەوە"
+
+#: panels/power/cc-power-panel.c:2168
+msgid "Hibernate"
+msgstr "دۆخەپشوو"
+
+#: panels/power/cc-power-panel.c:2169
+msgid "Nothing"
+msgstr "هیچ نەکات"
+
+#. Frame header
+#: panels/power/cc-power-panel.c:2269
+msgid "Suspend & Power Button"
+msgstr "دۆخەپشو و دوگمەی وزە"
+
+#: panels/power/cc-power-panel.c:2310
+msgid "_Automatic Suspend"
+msgstr "دۆخەپشووی _خوودکار"
+
+#: panels/power/cc-power-panel.c:2311
+msgid "Automatic suspend"
+msgstr "دۆخەپشووی خوودکار"
+
+#: panels/power/cc-power-panel.c:2369
+msgid "Po_wer Button Action"
+msgstr "کاری دووگمەی و_زە"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:13
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "١٥ خولەک"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:17
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "٢٠ خولەک"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:21
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "٢٥ خولەک"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:25
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "٣٠ خولەک"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:29
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "٤٥ خولەک"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:33
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "١ کاژێر"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:37
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "٨٠ خولەک"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:41
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "٩٠ خولەک"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:45
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "١٠٠ خولەک"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:49
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "٢ کاژێر"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:209 panels/power/cc-power-panel.ui:63
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "١ خولەک"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:213 panels/power/cc-power-panel.ui:67
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "٢ خولەک"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:217 panels/power/cc-power-panel.ui:71
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "٣ خولەک"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:221 panels/power/cc-power-panel.ui:75
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "٤ خولەک"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:225 panels/power/cc-power-panel.ui:79
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "۵ خولەک"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:229 panels/power/cc-power-panel.ui:83
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "٨ خولەک"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:233 panels/power/cc-power-panel.ui:87
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "۱۰ خولەک"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:237 panels/power/cc-power-panel.ui:91
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "١٢ خولەک"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:241 panels/power/cc-power-panel.ui:95
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "۱٥ خولەک"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:245 panels/power/cc-power-panel.ui:99
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "هه‌رگیز"
+
+#: panels/power/cc-power-panel.ui:147
+msgid "Automatic Suspend"
+msgstr "دۆخەپشووی خودکار"
+
+#: panels/power/cc-power-panel.ui:172
+msgid "_Plugged In"
+msgstr "_بارگاوی دەکرێت"
+
+#: panels/power/cc-power-panel.ui:188
+msgid "On _Battery Power"
+msgstr "لە سەر وزەی _پاتری"
+
+#: panels/power/cc-power-panel.ui:233 panels/power/cc-power-panel.ui:293
+#: panels/universal-access/cc-ua-panel.ui:1527
+msgid "Delay"
+msgstr "دواخستن"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "وزە"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "دۆخی پاترییەکەت ببینە و ڕێکخستنەکانی خەزنکردنی وزە بگۆڕە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/power/gnome-power-panel.desktop.in.in:7
+msgid "gnome-power-manager"
+msgstr "gnome-power-manager"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"وزە;خەوتن;وەستان;دۆخەپشوو;پاتری;ڕووناکی;تاریک;بەتاڵ;مۆنیتەر;DPMS;بەفیڕۆچوون;"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "رێگەپێدان"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/new-printer-dialog.ui:362
+#: panels/printers/pp-jobs-dialog.ui:57
+msgid "Username"
+msgstr "ناوی بەکارهێنەر"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:69
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:383
+#: panels/printers/pp-jobs-dialog.ui:70
+#: panels/user-accounts/cc-add-user-dialog.ui:249
+msgid "Password"
+msgstr "تێپەڕەوشە"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:337
+msgid "Authentication Required"
+msgstr "ڕێگەپێدان داواکراوە"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:700
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "چاپکەری “%s” سڕاوەتەوە"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:923
+msgid "Failed to add new printer."
+msgstr "زیادکردنی چاپکەری نوێ سەرنەکەوت."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1236
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ناتوانرێت ui بار بکرێت: %s"
+
+#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "شوێن"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:122
+#: panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "وەگەڕخەر"
+
+#: panels/printers/pp-details-dialog.ui:162
+msgid "Searching for preferred drivers…"
+msgstr "بگەڕێ بۆ وەگەڕخەری پەسەندکراو..."
+
+#: panels/printers/pp-details-dialog.ui:183
+msgid "Search for Drivers"
+msgstr "بگەڕێ بۆ وەگەڕخەرەکان"
+
+#: panels/printers/pp-details-dialog.ui:192
+msgid "Select from Database…"
+msgstr "لە بنکەداروەوە دیاریبکە..."
+
+#: panels/printers/pp-details-dialog.ui:201
+msgid "Install PPD File…"
+msgstr "پەڕگەی PPD دابمەزرێنە..."
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "چاپکەرەکان"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "پرێنتەرەکان زیادبکە، کارەکانی پرێنتەر ببینە و  بڕیاربدە چۆن چاپبکەیت"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/printers/gnome-printers-panel.desktop.in.in:7
+msgid "printer"
+msgstr "printer"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "چاپکەر;ڕیز;چاپکردن;کاخەز;مرەکەب;تەنەر;"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:44
+msgid "Domain"
+msgstr "دۆمەین"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:129
+msgid "A_uthenticate"
+msgstr "ڕ_ێگەپێبدە"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:169
+msgid "Clear All"
+msgstr "هه‌مووی پاک بکه‌ره‌وه‌"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:232
+msgid "_Authenticate"
+msgstr "ـڕێیپێبدە"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:358
+msgid "No Active Printer Jobs"
+msgstr "هیچ چاپکەرێکی چالاک کارناکات"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:363
+#: panels/printers/pp-new-printer-dialog.c:427
+msgid "Add Printer"
+msgstr "چاپکەر زیادبکە"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+msgid "_Unlock"
+msgstr "_بیکەرەوە"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:211
+msgid "No Printers Found"
+msgstr "هیچ لە چاپکەرەکان نەدۆزرانەوە"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:284
+msgid "Enter a network address or search for a printer"
+msgstr "ناونیشانی ڕایەڵەکەت بنووسە یان بگەڕی بۆ چاپکەرەکەت"
+
+#: panels/printers/new-printer-dialog.ui:353
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"ناوی بەکارهێنەر و تێپەڕەوشە بنوسە بۆ بینینی چاپکەرەکان و ڕاژەی چاپکردن."
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:869
+#: panels/printers/pp-options-dialog.ui:18
+msgid "Test Page"
+msgstr "پەڕەی تاقیکردنەوە"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:75
+#: panels/printers/pp-details-dialog.c:370
+#, c-format
+msgid "%s Details"
+msgstr "%s وردەکارییەکان"
+
+#: panels/printers/pp-details-dialog.c:122
+msgid "No suitable driver found"
+msgstr "وەگەڕخەری گونجاو نەدۆزرایەوە"
+
+#: panels/printers/pp-details-dialog.c:249
+msgid "Select PPD File"
+msgstr "پەڕگەی PPD دیاریبکە"
+
+#: panels/printers/pp-details-dialog.c:258
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"فایلەکانی پێناسی چاپکەرەکانی پۆست-سکریپت (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD.GZ)"
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr "وەگەڕخەری چاپکەر دیاریبکە"
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/cc-avatar-chooser.c:109
+msgid "Select"
+msgstr "دیاریکردن"
+
+#: panels/printers/ppd-selection-dialog.ui:73
+msgid "Loading drivers database…"
+msgstr "بنکەدراوی وەگەڕخەرەکان باردەکرێن..."
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:479
+msgid "JetDirect Printer"
+msgstr "چاپکەری جێت-دایرێکت"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:714
+msgid "LPD Printer"
+msgstr "چاپکەری LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:65
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "یەک لاگیری"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:67
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "لێواری درێژ (ئاسایی)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:69
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "لێواری کورت (هەڵگەڕاوە)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:71
+msgid "Portrait"
+msgstr "ستوونی"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:73
+msgid "Landscape"
+msgstr "ئاسۆی"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:75
+msgid "Reverse landscape"
+msgstr "ئاسۆیی هەڵگەڕاوە"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:77
+msgid "Reverse portrait"
+msgstr "ستوونی هەڵگەڕاوە"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-jobs-dialog.c:222
+msgctxt "print job"
+msgid "Pending"
+msgstr "لەچاوەڕوانیدایە"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-jobs-dialog.c:228
+msgctxt "print job"
+msgid "Paused"
+msgstr "ڕاگیرا"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-jobs-dialog.c:233
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "ڕێپێدان پێویستە"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-jobs-dialog.c:238
+msgctxt "print job"
+msgid "Processing"
+msgstr "لە کاردایا"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-jobs-dialog.c:242
+msgctxt "print job"
+msgid "Stopped"
+msgstr "وەستێنرا"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-jobs-dialog.c:246
+msgctxt "print job"
+msgid "Canceled"
+msgstr "هەڵوەشێنرایەوە"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-jobs-dialog.c:250
+msgctxt "print job"
+msgid "Aborted"
+msgstr "لەباربرا"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-jobs-dialog.c:254
+msgctxt "print job"
+msgid "Completed"
+msgstr "تەواوبوو"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:363
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "کاری %u پێویستی بە ڕێگەپێدان هەیە"
+msgstr[1] "کارەکانی %u پێویستی بە ڕێگەپێدان هەیە"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:520
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — کارا چالاکەکان"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:524
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "بەڵگەنامەی باوەڕپێکردن بنووسە بۆ چاپکردن لە %s"
+
+#: panels/printers/pp-new-printer-dialog.c:380
+msgid "Unlock Print Server"
+msgstr "ڕاژەی چاپکەر بکەرەوە"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:384
+#, c-format
+msgid "Unlock %s."
+msgstr "%s بکەرەوە."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:388
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "ناوی بەکارهێنەر و تێپەڕەوشە بنووسە بۆ بینینی چاپکەرەکان لە %s."
+
+#: panels/printers/pp-new-printer-dialog.c:838
+msgid "Searching for Printers"
+msgstr "بگەڕی بۆ چاپکەرەکان"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1697
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1702
+msgid "Serial Port"
+msgstr "دەرچەی زنجیرەیی"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1709
+msgid "Parallel Port"
+msgstr "دەرچەی هاوشان"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1751
+#, c-format
+msgid "Location: %s"
+msgstr "شوێن: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1756
+#, c-format
+msgid "Address: %s"
+msgstr "ناونیشان: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1783
+msgid "Server requires authentication"
+msgstr "ڕاژەکان پێویستی بە ڕێگەپێدانە"
+
+#: panels/printers/pp-options-dialog.c:91
+msgid "Two Sided"
+msgstr "دوو لاگیری"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "Paper Type"
+msgstr "جۆری کاخەز"
+
+#: panels/printers/pp-options-dialog.c:93
+msgid "Paper Source"
+msgstr "سەرچاوەی کاخەز"
+
+#: panels/printers/pp-options-dialog.c:94
+msgid "Output Tray"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:95
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "وردی نیشاندانی شاشە"
+
+#: panels/printers/pp-options-dialog.c:96
+msgid "GhostScript pre-filtering"
+msgstr "لەپێش فلتەرکردنی گۆست-سکریپت"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:534
+msgid "Pages per side"
+msgstr "پەڕەکانی لاگیر"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:546
+msgid "Two-sided"
+msgstr "دوو-لاگیر"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:558
+msgid "Orientation"
+msgstr "ئاڕاستە"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "گشتی"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "ڕێکخستنی پەڕە"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "هەڵبژاردنەکانی دامەزراندن"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "کار"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "جۆرایەتی وێنە"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "ڕەنگ"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "کۆتاییهێنان"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:676
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "پەرەسەندوو"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:882
+msgid "Test page"
+msgstr "پەڕەی تاقیکردنەوە"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "دیاریکردنی خودکار"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "چاپکەری بنەڕەت"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "تەنها فۆنتەکانی گۆست-سکریپت بگونجێنە"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "بیگۆڕە بۆ PSی ئاستی ١"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "بیگۆڕە بۆ PSی ئاست ٢"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "پاڵوتنی پێشوەختە نییە"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "دامەزراوە"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:594 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr "هیچ لە کاراکان چالاک نین"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:599
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u کار"
+msgstr[1] "%u کارەکان"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:745
+msgid "Low on toner"
+msgstr "مەرەکەبی کەمە"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:747
+msgid "Out of toner"
+msgstr "مەرەکەبی تیا نییە"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:750
+msgid "Low on developer"
+msgstr "گەشەپێدەری وێنەی کەمە"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:753
+msgid "Out of developer"
+msgstr "گەشەپێدەری وێنەی نییە"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:755
+msgid "Low on a marker supply"
+msgstr "سەرچاوەی ئاماژەپێدەری  کەمە"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:757
+msgid "Out of a marker supply"
+msgstr "سەرچاوەی ئاماژەپێدەری  نییە"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:759
+msgid "Open cover"
+msgstr "بەرگ بکەوە"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:761
+msgid "Open door"
+msgstr "دەرگا بکەوە"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:763
+msgid "Low on paper"
+msgstr "لە نزمی پەڕە"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:765
+msgid "Out of paper"
+msgstr "لە دەرەوە پەڕە"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:767
+msgctxt "printer state"
+msgid "Offline"
+msgstr "دەرهێڵ"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:769
+#: panels/printers/pp-printer-entry.c:897
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "وەستێنرا"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:771
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:773
+msgid "Waste receptacle full"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:775
+msgid "The optical photo conductor is near end of life"
+msgstr "گەیەنەری وێنەی بینیەکە لە کۆتایی تەمەنیەتی (لە کار دەکەوێت)"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:777
+msgid "The optical photo conductor is no longer functioning"
+msgstr "گەیەنەری وێنەی بینیەکە لەمەودوا کار ناکات"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:883
+msgctxt "printer state"
+msgid "Ready"
+msgstr "ئامادەیە"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:888
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "کارەکان قبوڵ نەکرا"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:893
+msgctxt "printer state"
+msgid "Processing"
+msgstr "لە کاردایا"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:917
+msgid "Clean print heads"
+msgstr "سەرەکانی چاپکردن پاکبکەوە"
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr "هەڵبژاردەکانی چاپکردن"
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr "زانیارییەکانی چاپکەر"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr "چاپکەر بەکاربێنە بە بنەڕەت"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr "سەرەکانی چاپکردن پاکبکەوە"
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "چاپکەر بسڕەوە"
+
+#: panels/printers/printer-entry.ui:193
+msgid "Model"
+msgstr "مۆدێل"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr "ئاستی مەرەکەب"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:312
+msgid "Please restart when the problem is resolved."
+msgstr "تکایە سیستم پێبکەرەوە کە کیشەکە چارەسەر بوو."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:319
+msgid "Restart"
+msgstr "دووبارە پێکردنەوە"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:8
+msgid "Add…"
+msgstr "زیادبکە..."
+
+#: panels/printers/printers.ui:150 panels/printers/printers.ui:238
+msgid "Additional Printer Settings…"
+msgstr "ڕێکخستنی زیاتری چاپکەر..."
+
+#: panels/printers/printers.ui:206
+msgid "No printers"
+msgstr "هیچ لە چاپکەرەکان نییە"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:220
+msgid "Add a Printer…"
+msgstr "چاپکەرێک زیادبکە..."
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:268
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"ببورە! خزمەتگوزاری چاپکردنی سیستەمەکە \n"
+"وادیار نییە بەردەستبێت."
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "قفڵی شاشە"
+
+#: panels/privacy/cc-privacy-panel.c:466
+msgid "In use"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:471
+msgctxt "Location services status"
+msgid "On"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:472
+msgctxt "Location services status"
+msgid "Off"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:926
+msgctxt "Camera status"
+msgid "Off"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:928
+msgctxt "Camera status"
+msgid "On"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:959
+msgctxt "Microphone status"
+msgid "Off"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:961
+msgctxt "Microphone status"
+msgid "On"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:974 panels/privacy/privacy.ui:127
+msgid "Usage & History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:155
+msgid "Empty all items from Trash?"
+msgstr "پاککردنەوەی هەموو بڕگەکان لە ناو تەنەکە خۆڵ؟"
+
+#: panels/usage/cc-usage-panel.c:156
+msgid "All items in the Trash will be permanently deleted."
+msgstr "هەموو بڕگە و پەڕەکانی ناو گڵێشدان بە هەمیشەیی دەسڕێنەوە."
+
+#: panels/usage/cc-usage-panel.c:157
+msgid "_Empty Trash"
+msgstr "ته‌نه‌که‌ی فڕێدان _به‌تاڵکه‌"
+
+#: panels/usage/cc-usage-panel.c:178
+msgid "Delete all the temporary files?"
+msgstr "سڕینەوەی هەموو پەڕگە کاتییەکان؟"
+
+#: panels/usage/cc-usage-panel.c:179
+msgid "All the temporary files will be permanently deleted."
+msgstr "هەموو پەڕگە کاتییەکان بۆ هەمیشە دەسڕێنەوە."
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "_Purge Temporary Files"
+msgstr "_لەناوبردنی پەڕگە کاتییەکان"
+
+#: panels/privacy/cc-privacy-panel.c:1152 panels/privacy/privacy.ui:432
+msgid "Purge Trash & Temporary Files"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:1192 panels/privacy/privacy.ui:637
+msgid "Software Usage"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:30
+msgid "Problem Reporting"
+msgstr "ڕاپۆرتکردنی کێشە"
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: panels/diagnostics/cc-diagnostics-panel.c:256
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:1363 panels/privacy/privacy.ui:750
+msgid "Privacy Policy"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:1469 panels/privacy/privacy.ui:1180
+msgid "Connectivity Checking"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:166
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "شاشە دەکوژێتەوە"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:170
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "٣٠ چرکە"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:174
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "١ خولەک"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:178
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "٢ خولەک"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:182
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "٣ خولەک"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:186
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "۵ خولەک"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:190
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "۳۰ خولەک"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:194
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "١ کاژێر"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:280
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "١ کاژێر"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:284
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "١ ڕۆژ"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:288
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "۲ ڕۆژ"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:292
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "٣ ڕۆژ"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:296
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "٤ ڕۆژ"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:300
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "٥ ڕۆژ"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:304
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "٦ ڕۆژ"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:308
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "٧ ڕۆژ"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:312
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "١٤ ڕۆژ"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:316
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "٣٠ ڕۆژ"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:331
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 ڕۆژ"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:335
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "٧ ڕۆژ"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:339
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "٣٠ ڕۆژ"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:343
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "هەتا هەتایە"
+
+#: panels/privacy/privacy.ui:148
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+
+#: panels/privacy/privacy.ui:176
+msgid "_Recently Used"
+msgstr ""
+
+#: panels/privacy/privacy.ui:207
+msgid "Retain _History"
+msgstr ""
+
+#: panels/privacy/privacy.ui:247
+msgid "Cl_ear Recent History"
+msgstr ""
+
+#: panels/privacy/privacy.ui:301
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:67
+msgid "Automatic Screen _Lock"
+msgstr "_قفڵی شاشەی خودکار"
+
+#: panels/privacy/privacy.ui:362
+msgid "Lock screen _after blank for"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:105
+msgid "Lock Screen on Suspend"
+msgstr "شاشەکە قفڵ بکە لە ڕاگرتن"
+
+#: panels/privacy/cc-privacy-panel.ui:425
+msgid "Lock Screen _Notifications"
+msgstr ""
+
+#: panels/privacy/privacy.ui:454
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+
+#: panels/privacy/privacy.ui:483
+msgid "Automatically empty _Trash"
+msgstr ""
+
+#: panels/privacy/privacy.ui:515
+msgid "Automatically purge Temporary _Files"
+msgstr ""
+
+#: panels/privacy/privacy.ui:546
+msgid "Purge _After"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:240
+msgid "_Empty Trash…"
+msgstr "_بەتاڵکردنی تەنەکەخۆڵ..."
+
+#: panels/privacy/privacy.ui:606
+msgid "_Purge Temporary Files…"
+msgstr ""
+
+#: panels/privacy/privacy.ui:654
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+
+#: panels/privacy/privacy.ui:681
+msgid "_Send software usage statistics"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:77
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly."
+msgstr ""
+"بەکارهێنانی کامێرا ڕیگە ئەدات بە بەرنامەکان بتوانن وێنە بگرن و گرتەی ڤیدیۆ "
+"تۆمار بکەن. ئەگەر کامێراکە ناچالاک بێ، ئەوا بۆی هەیە کە بەرنامەکان نەتوانن "
+"بەڕێکوپێکی هەموو کارێکی وێنە و ڤیدیۆت بۆ ئەنجام بدەن."
+
+#: panels/privacy/cc-privacy-panel.ui:843
+msgid "_Camera"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.ui:900
+msgid ""
+"Use of the microphone allows applications to capture sounds. Disabling the "
+"microphone may cause some applications to not function properly."
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.ui:948
+msgid "_Microphone"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:74
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"خزمەتگوزارییەکانی شوین دەهێڵێت بەرنامەکان شوێنەکەت بزانێت.Wi-Fi و دەستەی "
+"بێسنووری مۆبایل بەکاربینە بۆ زیادکردنی دروست."
+
+#: panels/location/cc-location-panel.ui:83
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+"مۆزێلا خزمەتگوزاری شوێنی بەکاردەهێنێت: <a href='https://location.services."
+"mozilla.com/privacy'>سیاسەتی تایبەتی</a>"
+
+#: panels/privacy/privacy.ui:859
+msgid "_Location Services"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:67
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:101
+msgid "Send error reports to Canonical"
+msgstr "ڕاپۆرتەکانی هەڵە بنێرە بۆ کانۆنیکاڵ"
+
+#: panels/privacy/privacy.ui:1131
+msgid "Send reports automatically"
+msgstr ""
+
+#: panels/privacy/privacy.ui:1149
+msgid "Show a dialog for each error before reporting"
+msgstr ""
+
+#: panels/connectivity/cc-connectivity-panel.ui:28
+msgid ""
+"Connectivity checking is used to detect connection issues and helps you to "
+"stay online. If your network communications are being monitored, it could be "
+"used to gather technical information about this computer."
+msgstr ""
+"پشکنینی پەیوەستێتی بەکاردێ بۆ دۆزینەوەی  کێشەکانی پەیوەندی و یارمەتیت دەدا "
+"سەرهێڵ بمێنیتەوە. ئەگەر ئاڵوگۆڕکردنەکانی ڕایەڵەکەت چاودێری بکرێت، دەتوانرێت "
+"بەکاربهێنرێت بۆ کۆکردنەوەی زانیری تەکنیکی دەربارەی ئەم کۆمپیتەرە."
+
+#: panels/connectivity/cc-connectivity-panel.ui:42
+msgid "_Connectivity Checking"
+msgstr "_گەڕان بۆ پەیوەنددارێتی"
+
+#: shell/cc-panel-list.ui:45 shell/cc-window.c:277
+msgid "Privacy"
+msgstr "تایبەتێتی"
+
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+
+#. FIXME
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:8
+msgid "preferences-system-privacy"
+msgstr ""
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"شاشە;قفڵ;دەستنیشانکاری;تێکشکان;تایبەتی;نوێترین;کاتی;tmp;نیشاندەر;ناو;ڕایەڵە;"
+"ناسنامه;"
+
+#: panels/region/cc-format-chooser.c:148
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "شاهانە"
+
+#: panels/region/cc-format-chooser.c:150
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/region/cc-format-chooser.c:314
+msgid "No regions found"
+msgstr ""
+
+#: panels/region/cc-format-chooser.c:255 panels/region/cc-format-chooser.c:296
+#: panels/region/cc-format-chooser.ui:6
+msgid "Formats"
+msgstr "فۆرماتەکان"
+
+#: panels/region/cc-format-chooser.ui:309
+msgid "Preview"
+msgstr "پێشبینین"
+
+#: panels/region/cc-format-chooser.ui:324
+msgid "Dates"
+msgstr "ڕێکەوتەکان"
+
+#: panels/region/cc-format-chooser.ui:368
+msgid "Dates & Times"
+msgstr "ڕێکەوت و کات"
+
+#: panels/region/cc-format-chooser.ui:390
+msgid "Numbers"
+msgstr "ژمارەکان"
+
+#: panels/region/cc-format-chooser.ui:412
+msgid "Measurement"
+msgstr "پێوانەکردن"
+
+#: panels/region/cc-format-chooser.ui:434
+msgid "Paper"
+msgstr "پەڕە"
+
+#: panels/region/cc-input-chooser.c:193
+msgid "No input sources found"
+msgstr "سەرچاوەی تێخستن نەدۆزرایەوە"
+
+#: panels/region/cc-input-chooser.c:948
+msgctxt "Input Source"
+msgid "Other"
+msgstr "هیتر"
+
+#: panels/region/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "سەرچاوی تێخستن زیادبکە"
+
+#: panels/region/cc-input-chooser.ui:77
+msgid "Input methods can’t be used on the login screen"
+msgstr "شێوازەکانی تێچووەکە ناتوانرێ بەکاربهێنرێت لەسەر قفڵی شاشەکە"
+
+#: panels/region/cc-region-panel.c:1586
+msgid "Login _Screen"
+msgstr "پەردەی _چوونەژوورەوە"
+
+#: panels/region/cc-region-panel.ui:64
+#: panels/user-accounts/cc-user-panel.ui:313
+msgid "_Language"
+msgstr "_زمان"
+
+#: panels/region/cc-region-panel.ui:99
+msgid "Restart the session for changes to take effect"
+msgstr "دانیشتن پێبکەرەوە بۆ ئەنجامدانی گۆڕانکارییەکان"
+
+#: panels/region/cc-region-panel.ui:114
+msgid "Restart…"
+msgstr "پێکردنەوە..."
+
+#: panels/region/cc-region-panel.ui:147
+msgid "_Formats"
+msgstr "_ڕێکخستنەکان"
+
+#: panels/region/cc-region-panel.ui:195
+msgid "Input Sources"
+msgstr "سەرچاوەی تێخستن"
+
+#: panels/region/cc-region-panel.ui:209
+msgid "Choose keyboard layouts or input methods."
+msgstr "کڵێشەی تەختەکلیل یان شێوزی نووسین بگۆڕە."
+
+#: panels/region/cc-region-panel.ui:266
+msgid "No input source selected"
+msgstr "هیچ سەرچاوەی تێخستن دیارینەکراوە"
+
+#: panels/region/cc-region-panel.ui:300
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"ڕێخستنەکانی چوونەژوورەوە بەکاردەبرێت لەلایان هەموو بەکار‌هێنەرەکان کاتێک "
+"دەچیتە ناو سیستەمەکە"
+
+#: panels/region/cc-region-panel.ui:314
+msgid "Manage Installed Languages"
+msgstr "ڕێکخستنی زمانە دامەزراوەکان"
+
+#: panels/region/cc-region-panel.ui:363
+msgid "Input Source Options"
+msgstr "هەڵبژاردەکانی سەرچاوەی تێخستن"
+
+#: panels/region/cc-region-panel.ui:378
+msgid "Use the _same source for all windows"
+msgstr "_هەمان سەرچاوە بەکاربێنە بۆ هەموو پەنجەرەکان"
+
+#: panels/region/cc-region-panel.ui:396
+msgid "Allow _different sources for each window"
+msgstr "ڕێگەبدە بە سەرچاوە _جیاوازەکان بۆ هەر پەنجەرەیەک"
+
+#: panels/region/cc-region-panel.ui:438
+msgid "Previous source"
+msgstr "سەرچاوە پێشوو"
+
+#: panels/region/cc-region-panel.ui:456
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: panels/region/cc-region-panel.ui:471
+msgid "Next source"
+msgstr "سەرچاوەی داهاتوو"
+
+#: panels/region/cc-region-panel.ui:489
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: panels/region/cc-region-panel.ui:504
+msgid "Left+Right Alt"
+msgstr "Left+Right Alt"
+
+#: panels/region/cc-region-panel.ui:520
+msgid "These keyboard shortcuts can be changed in the keyboard settings"
+msgstr "ئەم قەدبڕانە دەتوانرێت بگۆڕدرێت لە ڕێکخستنی تەختەکلیل"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "شوێن و زمانەکان"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"زمانی پیشاندان، فۆرماتەکان، کڵێسەی تەختە کلیل سەرچاوەی تێخستنی نووسین "
+"دیاریبکە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/region/gnome-region-panel.desktop.in.in:7
+msgid "preferences-desktop-locale"
+msgstr "preferences-desktop-locale"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;"
+
+#: panels/search/cc-search-locations-dialog.c:635
+msgid "Select Location"
+msgstr "شوێن هەڵبژێرە"
+
+#: panels/search/cc-search-locations-dialog.c:639
+msgid "_OK"
+msgstr "_باشە"
+
+#: panels/search/cc-search-panel.c:152
+msgid "No applications found"
+msgstr "هیچ داوانامەیەک نەدۆزرایەوە"
+
+#: panels/search/cc-search-panel-row.ui:92
+msgid "Move Up"
+msgstr "جوڵان بۆ سەرەوە"
+
+#: panels/search/cc-search-panel-row.ui:102
+msgid "Move Down"
+msgstr "جۆڵان بۆ خوارەوە"
+
+#: panels/search/cc-search-panel.ui:33
+msgid ""
+"Control which search results are shown in the Activities Overview. The order "
+"of search results can also be changed by moving rows in the list."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:9
+#: panels/search/cc-search-panel.ui:61
+msgid "Search Locations"
+msgstr "گەڕان بۆ شوێن"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/search/gnome-search-panel.desktop.in.in:7
+msgid "preferences-system-search"
+msgstr "preferences-system-search"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;"
+
+#: panels/search/cc-search-locations-dialog.ui:32
+#: panels/search/cc-search-locations-dialog.ui:69
+#: panels/search/cc-search-locations-dialog.ui:107
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"بەرنامەکانی سیستەم دەگەڕێن بەناو بوخچەکان، وەک پەڕگەکان، وێنەکان و ڤیدیۆکان."
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Places"
+msgstr "شوێنەکان"
+
+#: panels/search/cc-search-locations-dialog.ui:91
+msgid "Bookmarks"
+msgstr "دڵخوازەکان"
+
+#: panels/search/cc-search-locations-dialog.ui:156
+msgid "Other"
+msgstr "هیتر"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:307
+msgid "No networks selected for sharing"
+msgstr "هیچ ڕایەڵەیەک دیارینەکرا بۆ بڵاوکردنەوە"
+
+#: panels/sharing/cc-sharing-panel.c:302
+msgctxt "service is enabled"
+msgid "On"
+msgstr "هەڵکراوە"
+
+#: panels/sharing/cc-sharing-panel.c:304 panels/sharing/cc-sharing-panel.c:331
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "کوژاوەتەوە"
+
+#: panels/sharing/cc-sharing-panel.c:334
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "چالاككراو"
+
+#: panels/sharing/cc-sharing-panel.c:337
+msgctxt "service is active"
+msgid "Active"
+msgstr "چالاك"
+
+#: panels/sharing/cc-sharing-panel.c:407
+msgid "Choose a Folder"
+msgstr "بوخچە هەڵبژێرە"
+
+#: panels/sharing/cc-sharing-panel.c:726
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:728
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:730
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:828
+msgid "Copy"
+msgstr "لەبەرگرتنەوە"
+
+#: panels/sharing/cc-sharing-panel.c:1279
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "ىڵاوکردنەوە"
+
+#: panels/sharing/cc-sharing-panel.ui:34
+msgid "_Computer Name"
+msgstr "_ناوی کۆمپیوتەر"
+
+#: panels/sharing/cc-sharing-panel.ui:94
+msgid "_File Sharing"
+msgstr "_بڵاوکردنەوەی پەڕگە"
+
+#: panels/sharing/cc-sharing-panel.ui:139
+msgid "_Screen Sharing"
+msgstr "_بڵاوکردنەوەی پەردە"
+
+#: panels/sharing/cc-sharing-panel.ui:184
+msgid "_Media Sharing"
+msgstr "_بڵاوکردنەوەی میدیا"
+
+#: panels/sharing/cc-sharing-panel.ui:229
+msgid "_Remote Login"
+msgstr "_چوونەژوورەوەی دوور"
+
+#: panels/sharing/cc-sharing-panel.ui:268
+msgid "Some services are disabled because of no network access."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:286
+#: panels/sharing/cc-sharing-panel.ui:413
+msgid "File Sharing"
+msgstr "بڵاوکردنەوەی پەڕگە"
+
+#: panels/sharing/cc-sharing-panel.ui:333
+msgid "_Require Password"
+msgstr "_تێپەڕەووشە داواکراوە"
+
+#: panels/sharing/cc-sharing-panel.ui:424
+#: panels/sharing/cc-sharing-panel.ui:494
+msgid "Remote Login"
+msgstr "چوونەژوورەوەی دوور"
+
+#: panels/sharing/cc-sharing-panel.ui:517
+#: panels/sharing/cc-sharing-panel.ui:763
+msgid "Screen Sharing"
+msgstr "بڵاکوردنەوەی پەردە"
+
+#: panels/sharing/cc-sharing-panel.ui:575
+msgid "_Allow connections to control the screen"
+msgstr "_ڕێگە بدە پەیوەندییەکان پەردە بگرنە ژێردەست"
+
+#: panels/sharing/cc-sharing-panel.ui:620
+msgid "_Password:"
+msgstr "_تێپپەڕەوشە:"
+
+#: panels/sharing/cc-sharing-panel.ui:650
+msgid "_Show Password"
+msgstr "_وشەی تێپەڕبوون پیشان بدە"
+
+#: panels/sharing/cc-sharing-panel.ui:681
+msgid "Access Options"
+msgstr "هەڵبژاردەکانی چوونەناو"
+
+#: panels/sharing/cc-sharing-panel.ui:695
+msgid "_New connections must ask for access"
+msgstr "_پەیوەندی نوێ پێوستە داوای چوونەناو بکات"
+
+#: panels/sharing/cc-sharing-panel.ui:713
+msgid "_Require a password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:774
+#: panels/sharing/cc-sharing-panel.ui:868
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:807
+msgid "Share music, photos and videos over the network."
+msgstr "مۆسیقا، وێنەکان و ڤیدیۆکان بڵاوبکەوە لە سەر ئینتەرنێت."
+
+#: panels/sharing/cc-sharing-panel.ui:822
+msgid "Folders"
+msgstr "بوخچەکان"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "دەستبگرە بەسەر ئەوەی دەتەوێت بڵاویبکەیتەوە لەگەڵ کەسانی دیکە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:7
+msgid "preferences-system-sharing"
+msgstr "preferences-system-sharing"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"بڵاوکردنەوە;بڵاودەکرێتەوە;ssh;خانەخوێ;ناو;کۆنتڕۆڵ-لە-دوور;ڕوومێز;ڕەنگاڵە;"
+"دەنگ;ڤیدیۆ;وێنەکان;وێنەکان;فلیمەکان;ڕاژە;ڕێندەرکەر;"
+
+#: panels/sharing/cc-sharing-networks.ui:19
+msgid "Networks"
+msgstr "ڕایەڵەکان"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "چالاک کردن و ناچالاک کردنی چوونەناوی دوور"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "چالاک کردن و ناچالاک کردنی چوونەناوی دوور پێویستی بە دەسەڵاتی ڕێپێدانە"
+
+#: panels/sound/cc-alert-chooser.c:173
+msgid "Custom"
+msgstr "ڕاسپێراو"
+
+#: panels/sound/cc-alert-chooser.ui:19
+msgid "Bark"
+msgstr "بارک"
+
+#: panels/sound/cc-alert-chooser.ui:26
+msgid "Drip"
+msgstr "دریپ"
+
+#: panels/sound/cc-alert-chooser.ui:33
+msgid "Glass"
+msgstr "گلاس"
+
+#: panels/sound/cc-alert-chooser.ui:40
+msgid "Sonar"
+msgstr "سۆنەر"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "دواوە"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "پێشەوە"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "تاقیکردنەوەی %s"
+
+#: panels/sound/cc-output-test-dialog.ui:127
+msgid "Click a speaker to test"
+msgstr "کرتە بکە لە بڵندگۆ بۆ تاقیکردنەوە"
+
+#: panels/sound/cc-sound-panel.ui:29
+msgid "System Volume"
+msgstr "پلەدەنگی سیستم"
+
+#: panels/sound/cc-sound-panel.ui:82
+msgid "Over-Amplification"
+msgstr "پلەدەنگی-بەزتر"
+
+#: panels/sound/cc-sound-panel.ui:110
+msgid ""
+"Allows raising the volume above 100%. This can result in a loss of audio "
+"quality; it is better to increase application volume settings, if possible."
+msgstr ""
+"ڕێگەدان بۆ زیاتر لە %١٠٠. ئەمە دەبێتە هۆی لەدەستدانی جۆرێتی دەنگەکە، وا "
+"باشترە ڕێکستنەکانی دەنگی داوانامە زیادبکرێت. ئەگەر دەکرێت."
+
+#: panels/sound/cc-sound-panel.ui:137
+msgid "Volume Levels"
+msgstr "ئاستی دەنگ"
+
+#: panels/sound/cc-sound-panel.ui:159
+msgid "Output"
+msgstr "دەرخستە"
+
+#: panels/sound/cc-sound-panel.ui:186
+msgid "Output Device"
+msgstr "ئامێری دەرخستن"
+
+#: panels/sound/cc-sound-panel.ui:209
+msgid "Test"
+msgstr "تاقیکردنەوە"
+
+#: panels/sound/cc-sound-panel.ui:240 panels/sound/cc-sound-panel.ui:417
+msgid "Configuration"
+msgstr "ڕێکخستن"
+
+#: panels/sound/cc-sound-panel.ui:273
+msgid "Balance"
+msgstr "هاوسەنگی"
+
+#: panels/sound/cc-sound-panel.ui:300
+msgid "Fade"
+msgstr "کاڵبوونەوە"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Subwoofer"
+msgstr "بەرزکەرەوەی دەنگ (سەبوۆفەر)"
+
+#: panels/sound/cc-sound-panel.ui:349
+msgid "Input"
+msgstr "تێخستە"
+
+#: panels/sound/cc-sound-panel.ui:376
+msgid "Input Device"
+msgstr "ئامێری تێخراو"
+
+#: panels/sound/cc-sound-panel.ui:450
+msgid "Volume"
+msgstr "پلەی دەنگ"
+
+#: panels/sound/cc-sound-panel.ui:472
+msgid "Alert Sound"
+msgstr "دەنگی ئاگاداری"
+
+#: panels/sound/cc-volume-slider.c:115
+msgctxt "volume"
+msgid "100%"
+msgstr "%۱۰۰"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "دەنگ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "گۆڕینی ئاستی دەنگ، تێخستن، دەرخستن، ودەنگی ئاگادارکردنەوە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/sound/gnome-sound-panel.desktop.in.in:7
+msgid "multimedia-volume-control"
+msgstr "multimedia-volume-control"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:94
+#: panels/thunderbolt/cc-bolt-device-entry.c:125
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "هێڵەکە بچڕا"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:97
+#: panels/thunderbolt/cc-bolt-device-entry.c:128
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "پەیوەندی دەگرێت"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:100
+#: panels/thunderbolt/cc-bolt-device-entry.c:132
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "پەیوەستە"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:103
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "هەڵە لە ڕێپێدان"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:106
+#: panels/thunderbolt/cc-bolt-device-entry.c:138
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "ڕێپێدان"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "کردار کەمکراوە"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:115
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "پەیوەستەو ڕێپێدراوە"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:121
+#: panels/thunderbolt/cc-bolt-device-entry.c:152
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "نەناسراو"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:177
+msgid "Authorized at:"
+msgstr "ڕێپێدراوە لە:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:183
+msgid "Connected at:"
+msgstr "پەیوەستە لە:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:190
+msgid "Enrolled at:"
+msgstr "بەشدارە لە:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:264
+msgid "Failed to authorize device: "
+msgstr "ڕێگە نەدراوە بە ئامێری: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:333
+msgid "Failed to forget device: "
+msgstr "‌نەتونرا ئامیرە لەبیر بکرێ "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+msgid "Name:"
+msgstr "ناو:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "Status:"
+msgstr "دۆخ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+msgid "Authorize and Connect"
+msgstr "ڕێبدە و پەیوەندی بکە"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+msgid "Forget Device"
+msgstr "ئامێر لەبیربکە"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:135
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "هەڵە"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:146
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "ڕێپێدراوە"
+
+#: panels/thunderbolt/cc-bolt-panel.c:175
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:468
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:512
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:516
+msgid "Thunderbolt security level could not be determined."
+msgstr "ئاستی ئاسایشی سەندەربۆڵت ناتوانرێت دیاریبکرێت"
+
+#: panels/thunderbolt/cc-bolt-panel.c:621
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:143
+msgid "No Thunderbolt support"
+msgstr "پشتگیری سەندەربۆڵت نییە"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:246
+msgid "Direct Access"
+msgstr "ڕێپێدانی ڕاستەوخۆ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:269
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:289
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:397
+msgid "Pending Devices"
+msgstr "ئامێری چاوەڕوانکراو"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:535
+msgid "No devices attached"
+msgstr "هیچ ئامێرێک نەبەستراوە"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "سەندەربۆڵت"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:7
+msgid "thunderbolt"
+msgstr "thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;"
+msgstr ""
+
+#: panels/ubuntu/cc-ubuntu-panel.c:134
+msgid "All displays"
+msgstr "هەموو پیشاندەرەکان"
+
+#: panels/ubuntu/cc-ubuntu-panel.ui:198
+msgid "Auto-hide the Dock"
+msgstr "شاردنەوەی خۆکاری دۆک"
+
+#: panels/ubuntu/cc-ubuntu-panel.ui:213
+msgid "The dock hides when any windows overlap with it."
+msgstr "دۆک لادەچیت کاتێک پەنجەرەیەک دێتە سەری."
+
+#: panels/ubuntu/cc-ubuntu-panel.ui:257
+msgid "Icon size"
+msgstr "قەبارەی وێنۆچکە"
+
+#: panels/ubuntu/cc-ubuntu-panel.ui:295
+msgid "Show on"
+msgstr "پیشانی بدە لە"
+
+#: panels/ubuntu/cc-ubuntu-panel.ui:336
+msgid "Position on screen"
+msgstr "شوێنی لە پەردە"
+
+#: panels/ubuntu/cc-ubuntu-panel.ui:353
+msgctxt "Position on screen for the Ubuntu dock"
+msgid "Left"
+msgstr "چەپ"
+
+#: panels/ubuntu/cc-ubuntu-panel.ui:354
+msgctxt "Position on screen for the Ubuntu dock"
+msgid "Bottom"
+msgstr "خوارەوە"
+
+#: panels/ubuntu/cc-ubuntu-panel.ui:355
+msgctxt "Position on screen for the Ubuntu dock"
+msgid "Right"
+msgstr "ڕاست"
+
+#. Dock settings.
+#: panels/ubuntu/cc-ubuntu-panel.ui:161
+msgid "Dock"
+msgstr "لەنگەرگا(دۆک)"
+
+#: panels/ubuntu/gnome-ubuntu-panel.desktop.in.in:4
+msgid "Ubuntu Dock Settings"
+msgstr ""
+
+#: panels/ubuntu/gnome-ubuntu-panel.desktop.in.in:6
+msgid "preferences-ubuntu-panel"
+msgstr "preferences-ubuntu-panel"
+
+#. Translators: those are keywords for the ubuntu control-center panel
+#: panels/ubuntu/gnome-ubuntu-panel.desktop.in.in:17
+msgid "Dock;Launcher;"
+msgstr ""
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:500
+msgctxt "cursor size"
+msgid "Default"
+msgstr "بنەڕەتی"
+
+#: panels/universal-access/cc-ua-panel.c:503
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "ناوەند"
+
+#: panels/universal-access/cc-ua-panel.c:506
+msgctxt "cursor size"
+msgid "Large"
+msgstr "گەورە"
+
+#: panels/universal-access/cc-ua-panel.c:509
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "گەورەتر"
+
+#: panels/universal-access/cc-ua-panel.c:512
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "گەورەترین"
+
+#: panels/universal-access/cc-ua-panel.c:516
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d پیکسڵ"
+msgstr[1] "%d پیکسڵ"
+
+#: panels/universal-access/cc-ua-panel.ui:78
+msgid "_Always Show Universal Access Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:120
+msgid "Seeing"
+msgstr "دەبینرێت"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "_High Contrast"
+msgstr "_تۆخ و گەورە"
+
+#: panels/universal-access/cc-ua-panel.ui:213
+msgid "_Large Text"
+msgstr "_دەقی گەورە"
+
+#: panels/universal-access/cc-ua-panel.ui:258
+msgid "C_ursor Size"
+msgstr "قەبارەی ج_ێنیشاندەر"
+
+#: panels/universal-access/cc-ua-panel.ui:305
+#: panels/universal-access/zoom-options.ui:99
+msgid "_Zoom"
+msgstr "_هێنانە پێش"
+
+#: panels/universal-access/cc-ua-panel.ui:351
+msgid "Screen _Reader"
+msgstr "خوێنەری _پەردە"
+
+#: panels/universal-access/cc-ua-panel.ui:397
+#: panels/universal-access/cc-ua-panel.ui:1263
+msgid "_Sound Keys"
+msgstr "_کلیلی دەنگ"
+
+#: panels/universal-access/cc-ua-panel.ui:459
+msgid "Hearing"
+msgstr "دەبیسترێت"
+
+#: panels/universal-access/cc-ua-panel.ui:503
+#: panels/universal-access/cc-ua-panel.ui:1366
+msgid "_Visual Alerts"
+msgstr "ئاگادارکردنەوە _بینراوەکان"
+
+#: panels/universal-access/cc-ua-panel.ui:611
+msgid "Screen _Keyboard"
+msgstr "_تەختەکلیلی شاشە"
+
+#: panels/universal-access/cc-ua-panel.ui:656
+msgid "R_epeat Keys"
+msgstr "کلیلە د_ووبارەبووەوەکان"
+
+#: panels/universal-access/cc-ua-panel.ui:702
+msgid "Cursor _Blinking"
+msgstr "_تروکاندنی جێنیشاندەر"
+
+#: panels/universal-access/cc-ua-panel.ui:748
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:809
+msgid "Pointing & Clicking"
+msgstr "نیاشانەکردن و کرتەکردن"
+
+#: panels/universal-access/cc-ua-panel.ui:855
+msgid "_Mouse Keys"
+msgstr "کلیلەکانی _مشک"
+
+#: panels/universal-access/cc-ua-panel.ui:932
+msgid "_Click Assist"
+msgstr "_کرتەی هاوکاریکەر"
+
+#: panels/universal-access/cc-ua-panel.ui:978
+msgid "_Double-Click Delay"
+msgstr "_دوواکەوتنی دوو-کرتە"
+
+#: panels/universal-access/cc-ua-panel.ui:998
+msgid "Double-Click Delay"
+msgstr "دوواکەوتنی دوو-کرتە"
+
+#: panels/universal-access/cc-ua-panel.ui:1068
+msgid "Cursor Size"
+msgstr "قەبارەی جێنیشاندەر"
+
+#: panels/universal-access/cc-ua-panel.ui:1095
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"قەبارەی جێنیشاندەر دەتوانرێت بە هێنانە پیش بکرێت بۆ ئەوەی بە جوانی "
+"جێنیشاندەر ببینیت."
+
+#: panels/universal-access/cc-ua-panel.ui:1131
+msgid "Screen Reader"
+msgstr "خوێنەرەوەی ڕووپەر"
+
+#: panels/universal-access/cc-ua-panel.ui:1148
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "خوێنەریڕووپەر خوێندنەوە ب ۆپەردە دەکات هەر کاتێک تۆ سەرنج دەجوڵێنی ."
+
+#: panels/universal-access/cc-ua-panel.ui:1181
+msgid "_Screen Reader"
+msgstr "_خوێنەری رووپەر"
+
+#: panels/universal-access/cc-ua-panel.ui:1220
+msgid "Sound Keys"
+msgstr "کیلی دەنگ"
+
+#: panels/universal-access/cc-ua-panel.ui:1238
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1308
+msgid "Visual Alerts"
+msgstr "ئاگانامەیی بینەیی"
+
+#: panels/universal-access/cc-ua-panel.ui:1312
+msgid "_Test flash"
+msgstr "_فلاش تاقیبکەرەوە"
+
+#: panels/universal-access/cc-ua-panel.ui:1341
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1360
+msgid "Flash the _window title"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1410
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1455
+msgid "Repeat Keys"
+msgstr "کلیلی دووبارە"
+
+#: panels/universal-access/cc-ua-panel.ui:1485
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1565
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1613
+#: panels/universal-access/cc-ua-panel.ui:1748
+msgid "Speed"
+msgstr "خێرایی"
+
+#: panels/universal-access/cc-ua-panel.ui:1652
+msgid "Repeat keys speed"
+msgstr "خێرایی کلیلەکان سووبارە بکەرەوە"
+
+#: panels/universal-access/cc-ua-panel.ui:1676
+msgid "Cursor Blinking"
+msgstr "تروکاندنی جێنیشاندەر"
+
+#: panels/universal-access/cc-ua-panel.ui:1706
+msgid "Cursor blinks in text fields."
+msgstr "جێنیشاندەر دەتروکێت لە بوواری دەقەکان."
+
+#: panels/universal-access/cc-ua-panel.ui:1785
+msgid "Cursor blinking speed"
+msgstr "خێرایی تروکاندنی جێنیشاندەر"
+
+#: panels/universal-access/cc-ua-panel.ui:1821
+msgid "Typing Assist"
+msgstr "یارمەتیدەری نووسین"
+
+#: panels/universal-access/cc-ua-panel.ui:1860
+msgid "_Sticky Keys"
+msgstr "کلیلە _پێوەنوساوەکان"
+
+#: panels/universal-access/cc-ua-panel.ui:1877
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1901
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1919
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1967
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1984
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2017
+#: panels/universal-access/cc-ua-panel.ui:2230
+#: panels/universal-access/cc-ua-panel.ui:2567
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2039
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "کورت"
+
+#: panels/universal-access/cc-ua-panel.ui:2058
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2073
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "دوورودرێژ"
+
+#: panels/universal-access/cc-ua-panel.ui:2100
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2117
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2134
+#: panels/universal-access/cc-ua-panel.ui:2313
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2180
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2197
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2252
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "کورت"
+
+#: panels/universal-access/cc-ua-panel.ui:2271
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2286
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2399
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2416
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2480
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2516
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2534
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2588
+msgctxt "secondary click"
+msgid "Short"
+msgstr "کورت"
+
+#: panels/universal-access/cc-ua-panel.ui:2607
+msgid "Secondary click delay"
+msgstr "دوواکەوتنی کرتەی لاوەکیی"
+
+#: panels/universal-access/cc-ua-panel.ui:2622
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "دوورودرێژ"
+
+#: panels/universal-access/cc-ua-panel.ui:2679
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2697
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2730
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2752
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "کورت"
+
+#: panels/universal-access/cc-ua-panel.ui:2783
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "دوورودرێژ"
+
+#: panels/universal-access/cc-ua-panel.ui:2819
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2841
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "بچووک"
+
+#: panels/universal-access/cc-ua-panel.ui:2872
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "گەورە"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "وای لێبکە ئاسان ببینرێت، ببیسترێت، بنوسرێت، خاڵ و کرتە"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:7
+msgid "preferences-desktop-accessibility"
+msgstr "preferences-desktop-accessibility"
+
+#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
+"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
+"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
+"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
+"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+
+#: panels/universal-access/zoom-options.c:305
+msgctxt "Distance"
+msgid "Short"
+msgstr "کورت"
+
+#: panels/universal-access/zoom-options.c:306
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "چارەکی ڕووپەر"
+
+#: panels/universal-access/zoom-options.c:307
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "نیوەی ڕووپەر"
+
+#: panels/universal-access/zoom-options.c:308
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "سێ چارەکی ڕووپەر"
+
+#: panels/universal-access/zoom-options.c:309
+msgctxt "Distance"
+msgid "Long"
+msgstr "دوورودرێژ"
+
+#: panels/universal-access/zoom-options.ui:48
+msgid "Full Screen"
+msgstr "بینینی پڕاوپڕ"
+
+#: panels/universal-access/zoom-options.ui:53
+msgid "Top Half"
+msgstr "نیوەی سەرەوە"
+
+#: panels/universal-access/zoom-options.ui:58
+msgid "Bottom Half"
+msgstr "نیوەی خوارەوە"
+
+#: panels/universal-access/zoom-options.ui:63
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:68
+msgid "Right Half"
+msgstr "نیوەی ڕاست"
+
+#: panels/universal-access/zoom-options.ui:78
+msgid "Zoom Options"
+msgstr "هەڵبژاردەکانی نزیککردنەوە"
+
+#: panels/universal-access/zoom-options.ui:185
+msgid "_Magnification:"
+msgstr "_ئاوساندن:"
+
+#: panels/universal-access/zoom-options.ui:249
+msgid "_Follow mouse cursor"
+msgstr "_دووای جێنیشاندەری مشک بکەوە"
+
+#: panels/universal-access/zoom-options.ui:269
+msgid "_Screen part:"
+msgstr "_بەشی ڕووپەر:"
+
+#: panels/universal-access/zoom-options.ui:331
+msgid "Magnifier _extends outside of screen"
+msgstr "ئاوسان  _دیوی دەرەوەی ڕووپەر فراوان دەکات"
+
+#: panels/universal-access/zoom-options.ui:350
+msgid "_Keep magnifier cursor centered"
+msgstr "_جێنیشاندەری ئاوساندن لە ناوەڕاست بهێڵەوە،"
+
+#: panels/universal-access/zoom-options.ui:370
+msgid "Magnifier cursor _pushes contents around"
+msgstr "جێنیشاندەری ئاوساندن  _پاڵ بە ناوەڕۆکەکان دەنا بۆ ناوەوە (خولگەیی)"
+
+#: panels/universal-access/zoom-options.ui:390
+msgid "Magnifier cursor moves with _contents"
+msgstr "جێنیشاندەری ئاوساندن دەجوڵێت لەگەڵ _ناوەڕۆکەکاندا"
+
+#: panels/universal-access/zoom-options.ui:425
+msgid "Magnifier Position:"
+msgstr "شوێنی هەڵئاوساندن:"
+
+#: panels/universal-access/zoom-options.ui:446
+msgid "Magnifier"
+msgstr "هەڵئاوساندەر"
+
+#: panels/universal-access/zoom-options.ui:493
+msgid "_Thickness:"
+msgstr "_ئەستووری:"
+
+#: panels/universal-access/zoom-options.ui:519
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "تەنک"
+
+#: panels/universal-access/zoom-options.ui:551
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:577
+msgid "_Length:"
+msgstr "_درێژی:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/zoom-options.ui:626
+msgid "Co_lor:"
+msgstr "ڕه‌_نگ"
+
+#: panels/universal-access/zoom-options.ui:690
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:738
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:776
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:825
+msgid "_White on black:"
+msgstr "_سپی لەسەر ڕەش:"
+
+#: panels/universal-access/zoom-options.ui:845
+msgid "_Brightness:"
+msgstr "_ڕووناکی:"
+
+#: panels/universal-access/zoom-options.ui:866
+msgid "_Contrast:"
+msgstr "_کۆنتراست:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/zoom-options.ui:886
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "ڕە_نگ"
+
+#: panels/universal-access/zoom-options.ui:911
+msgctxt "universal access, color"
+msgid "None"
+msgstr "هیج"
+
+#: panels/universal-access/zoom-options.ui:943
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "هەموو"
+
+#: panels/universal-access/zoom-options.ui:1006
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "نزم"
+
+#: panels/universal-access/zoom-options.ui:1039
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "بەرز"
+
+#: panels/universal-access/zoom-options.ui:1070
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "نزم"
+
+#: panels/universal-access/zoom-options.ui:1103
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "بەرز"
+
+#: panels/universal-access/zoom-options.ui:1139
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:1164
+msgid "Color Effects"
+msgstr "کاریگەری ڕەنگ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "پێویستە ناونیشنای تۆڕی دابینکەری چوونەژوورەوەکەت بگونجێنیت"
+
+#: panels/user-accounts/cc-add-user-dialog.c:205
+msgid "Failed to add account"
+msgstr "نەتوانرا هەژمار زیادبکرێت"
+
+#: panels/user-accounts/cc-add-user-dialog.c:676
+#: panels/user-accounts/cc-password-dialog.c:261
+msgid "The passwords do not match."
+msgstr "تێپەڕەوشەکان وەک یەک نین."
+
+#: panels/user-accounts/cc-add-user-dialog.c:898
+#: panels/user-accounts/cc-add-user-dialog.c:944
+#: panels/user-accounts/cc-add-user-dialog.c:965
+msgid "Failed to register account"
+msgstr "تۆمارکردنی هەژمارەکەت شکستی هێنا"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1088
+msgid "No supported way to authenticate with this domain"
+msgstr "هیچ ڕێگایەک نییە بۆ سەلماندن لەگەڵ ئەم دۆمەینە"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1161
+msgid "Failed to join domain"
+msgstr "پەیوەستبوون بە دۆمەینەوە شکستی هێنا"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1222
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"ناوی چوونەژورەوە کاری نەکرد. \n"
+"تکایە هەوڵبدەرەوە."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1229
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"تیپەڕوشەی چوونەژورەوە کاری نەکرد. \n"
+"تکایە هەوڵبدەرەوە."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1237
+msgid "Failed to log into domain"
+msgstr "چوونەژوورەوە بۆ دۆمەینەکە شکستی هێنا"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1295
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "ناتوانرێت دۆمەین بدۆزرێتەوە. لەوانەیە"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "بەکارهێنەر زیادبکە"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:180
+msgid "_Full Name"
+msgstr "_ناوی تەواو"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:206
+msgid "Standard"
+msgstr "ستاندارد"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:216
+msgid "Administrator"
+msgstr "بەڕێوەبەر"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:232
+msgid "Account _Type"
+msgstr "جۆری _هەژمار"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:269
+msgid "Allow user to set a password when they next _login"
+msgstr ""
+"ڕێگە بە بەکارهێنەر بدە جاری داهاتوو وشەی تێپەڕ بگۆڕدرێت کە هاتە _ژوورەوە"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:283
+msgid "Set a password _now"
+msgstr "وشەی تێپەڕبوون دابنێ _ئێستا"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:405
+msgid "_Confirm"
+msgstr "_دڵنیابوونەوە"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:485
+#: panels/user-accounts/cc-add-user-dialog.ui:692
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:732
+msgid "You are Offline"
+msgstr "تۆ لەدەرەوی هێڵی"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:751
+msgid "You must be online in order to add enterprise users."
+msgstr "پێویستە لەسەرهێڵ بی بۆ ئەوەی بەکارهێنەری ئابووری زیادبکەی."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:782
+msgid "_Enterprise Login"
+msgstr "_چوونەژورەوەی ئابووری"
+
+#: panels/user-accounts/cc-avatar-chooser.c:232
+msgid "Browse for more pictures"
+msgstr "بگەڕی بۆ وێنەی زیاتر"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:39
+msgid "Take a Picture…"
+msgstr "وێنەیەک بگرە..."
+
+#: panels/user-accounts/cc-avatar-chooser.ui:46
+msgid "Select a File…"
+msgstr "پەڕگە دیاریبکە..."
+
+#: panels/user-accounts/cc-login-history-dialog.c:69
+msgid "This Week"
+msgstr "ئەم هەفتەیە"
+
+#: panels/user-accounts/cc-login-history-dialog.c:72
+msgid "Last Week"
+msgstr "کۆتا هەفتە"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:82
+#: panels/user-accounts/cc-login-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:91
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:96
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:173
+#: panels/user-accounts/cc-user-panel.c:766
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:176
+#: panels/user-accounts/cc-user-panel.c:770
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:243
+msgid "Session Ended"
+msgstr "دانیشتن کۆتایهات"
+
+#: panels/user-accounts/cc-login-history-dialog.c:249
+msgid "Session Started"
+msgstr "دانیشتن دەستیپێکرد"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:343
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — چالاکی هەژمار"
+
+#: panels/user-accounts/cc-password-dialog.c:125
+msgid "Please choose another password."
+msgstr "تکایە وشەی تێپەڕبوون تر بنووسە."
+
+#: panels/user-accounts/cc-password-dialog.c:134
+msgid "Please type your current password again."
+msgstr "تکایە وشەی تێپەڕبوونی ئێستات بنووسەرەوە"
+
+#: panels/user-accounts/cc-password-dialog.c:140
+msgid "Password could not be changed"
+msgstr "وشەی تێپەڕبوون ناگۆڕدرێت"
+
+#: panels/user-accounts/cc-password-dialog.ui:7
+msgid "Change Password"
+msgstr "گۆڕینی وشەی تێپەڕبوون"
+
+#: panels/user-accounts/cc-password-dialog.ui:37
+msgid "Ch_ange"
+msgstr "گۆڕ_ین"
+
+#: panels/user-accounts/cc-password-dialog.ui:145
+msgid "_Confirm New Password"
+msgstr "_دڵنیابەرەوە لە وشەی تێپەڕبوونی نوێ"
+
+#: panels/user-accounts/cc-password-dialog.ui:162
+msgid "_New Password"
+msgstr "_وشەی تێپەڕبوونی نوێ"
+
+#: panels/user-accounts/cc-password-dialog.ui:216
+msgid "Current _Password"
+msgstr "وشەی تێپەڕبوونی _ئێستا"
+
+#: panels/user-accounts/cc-password-dialog.ui:254
+msgid "Allow user to change their password on next login"
+msgstr "ڕێگە بدە بەکارهێنەر وشەی تێپەڕبوونی بگۆڕێت دووای چوونە ژوورەوە"
+
+#: panels/user-accounts/cc-password-dialog.ui:267
+msgid "Set a password now"
+msgstr "وشەی تێپەڕبوون دابنێ ئێستا"
+
+#: panels/user-accounts/cc-realm-manager.c:307
+msgid "Cannot automatically join this type of domain"
+msgstr "ناتوانیت خۆکارانە بچیتە ئەم جۆرە دۆمەینەوە"
+
+#: panels/user-accounts/cc-realm-manager.c:310
+msgid "No such domain or realm found"
+msgstr "هیچ دۆمەینێکی ڕاستی نەدۆزرایەوە"
+
+#: panels/user-accounts/cc-realm-manager.c:732
+#: panels/user-accounts/cc-realm-manager.c:746
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "ناتوانرێت وەکو %s بچیتە ژوورەوە لە %s دۆمەین"
+
+#: panels/user-accounts/cc-realm-manager.c:738
+msgid "Invalid password, please try again"
+msgstr "ووشەی تێپەڕبوون هەڵەیە ،تکایە هەوڵ بدەرەوە"
+
+#: panels/user-accounts/cc-realm-manager.c:751
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "ناتوانین پەیوەستببین بە دۆمەینی %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:209
+msgid "Your account"
+msgstr "هەژمارەکەت"
+
+#: panels/user-accounts/cc-user-panel.c:384
+msgid "Failed to delete user"
+msgstr "نەتوانرا بەکارهێنەر بسڕیتەوە"
+
+#: panels/user-accounts/cc-user-panel.c:442
+#: panels/user-accounts/cc-user-panel.c:501
+#: panels/user-accounts/cc-user-panel.c:553
+msgid "Failed to revoke remotely managed user"
+msgstr "نەتوانرا بەکارهێنەری بەڕێوبردن لەدوورەوە هەڵبوەشێندرێتەوە"
+
+#: panels/user-accounts/cc-user-panel.c:605
+msgid "You cannot delete your own account."
+msgstr "ناتوانی هەژماری خۆت بسڕیتەوە."
+
+#: panels/user-accounts/cc-user-panel.c:614
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s هێشتا لە ژوورەوەیە"
+
+#: panels/user-accounts/cc-user-panel.c:618
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"سڕینەوەی بەکارهێنەرێک کە لە ژوورەوەیە دەتوانێت سیستەمەکەی لە دۆخێکی ناجێگیر "
+"بەجێبێڵێت"
+
+#: panels/user-accounts/cc-user-panel.c:627
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "دەتەوێت پەڕگەکانی %s بهێڵیتەوە؟"
+
+#: panels/user-accounts/cc-user-panel.c:631
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"دەتوانرێت بوخچەی ماڵەوە، نۆرە نامە و پەڕگە کاتییەکانی ئەو ناوە بپارێزیت "
+"کاتێک هەژماری بەکارهێنەرێک. دەسڕیتەوە"
+
+#: panels/user-accounts/cc-user-panel.c:634
+msgid "_Delete Files"
+msgstr "_پەڕگەکان بسڕەوە"
+
+#: panels/user-accounts/cc-user-panel.c:635
+msgid "_Keep Files"
+msgstr "_پەڕگەکان بهێڵەوە"
+
+#: panels/user-accounts/cc-user-panel.c:649
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "تۆ دڵنیای دەتەوێت هەژماری %s لە دوورەوە بەڕێوەبراو هەڵبوەشێنیتەوە؟"
+
+#: panels/user-accounts/cc-user-panel.c:653
+msgid "_Delete"
+msgstr "_سڕینەوە"
+
+#: panels/user-accounts/cc-user-panel.c:703
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "هەژمار ناچالاک کرا"
+
+#: panels/user-accounts/cc-user-panel.c:711
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "جێبەجێدەکرێت لە چوونەژورەوەی داهاتوو"
+
+#: panels/user-accounts/cc-user-panel.c:714
+msgctxt "Password mode"
+msgid "None"
+msgstr "نییە"
+
+#: panels/user-accounts/cc-user-panel.c:759
+msgid "Logged in"
+msgstr "لەژوورەوەیە"
+
+#: panels/user-accounts/cc-user-panel.c:1143
+msgid "Failed to contact the accounts service"
+msgstr "نەتوانرا پەیوەندی بکرێت بە خزمەتگوزاری هەژمارەکان"
+
+#: panels/user-accounts/cc-user-panel.c:1145
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "تکاتە دڵنیابە کە خزمەتگوزاری-هەژمار دامەزراوە و چالاکە."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/cc-user-panel.c:1177
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"بۆ گۆڕانکاری،\n"
+"کرتە لە وێنۆچکەکە بکە"
+
+#: panels/user-accounts/cc-user-panel.c:1250
+msgid "Create a user account"
+msgstr "هەژماری بەکارهێنەر دروستبکە"
+
+#: panels/user-accounts/cc-user-panel.c:1261
+#: panels/user-accounts/cc-user-panel.c:1389
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"بۆ دروستکردنی هەژماری بەکارهێنەر،\n"
+"کرتە لە وێنۆچکەکە بکە"
+
+#: panels/user-accounts/cc-user-panel.c:1270
+msgid "Delete the selected user account"
+msgstr "هەژماری بەکارهێنەری دیاریکراو بسڕەوە"
+
+#: panels/user-accounts/cc-user-panel.c:1282
+#: panels/user-accounts/cc-user-panel.c:1393
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"بۆ سڕینەوی هەژماری بەکارهێنەری دیاریکراو\n"
+"کرتە لە وێنۆچکەکە بکە"
+
+#: panels/user-accounts/cc-user-panel.ui:5
+msgid "_Add User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:52
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+"دانیشتنەکەت پێویستە دەسپێبکرێتەوە بۆ گۆڕانکاری  بۆ ئەوەی کاریگەرییەکانی "
+"دەربکەوێت"
+
+#: panels/user-accounts/cc-user-panel.ui:60
+msgid "Restart Now"
+msgstr "دەسپێکردنەوە ئەنجام بدە"
+
+#: panels/user-accounts/cc-user-panel.ui:470
+msgid "A_utomatic Login"
+msgstr "چوونەژورەوە خ_ۆکار"
+
+#: panels/user-accounts/cc-user-panel.ui:428
+msgid "_Fingerprint Login"
+msgstr "_چوونەژورەوە بە پەنجەمۆر"
+
+#: panels/user-accounts/cc-user-panel.ui:146
+#: panels/user-accounts/cc-user-panel.ui:162
+msgid "User Icon"
+msgstr "وێنۆچکەی بەکارهێنەر"
+
+#: panels/user-accounts/cc-user-panel.ui:404
+msgid "Last Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:541
+msgid "Remove User…"
+msgstr "سڕینەوەی بەکارهێنەر..."
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:580
+msgid "No Users Found"
+msgstr "هیچ بەکارهێنەرێک نەدۆزرایەوە"
+
+#: panels/user-accounts/cc-user-panel.ui:590
+msgid "Unlock to add a user account."
+msgstr "بیکەرەوە بۆ ئەوەی بەکارهێنەر زیادبکەی بۆ  هەژمار."
+
+#: panels/user-accounts/data/account-fingerprint.ui:12
+msgid "Left thumb"
+msgstr "پەنجەی چەپ"
+
+#: panels/user-accounts/data/account-fingerprint.ui:15
+msgid "Left middle finger"
+msgstr "پەنجەی ناوەڕاستی چەپ"
+
+#: panels/user-accounts/data/account-fingerprint.ui:18
+msgid "Left ring finger"
+msgstr "ئەڵقەی پەنجەی چەپ"
+
+#: panels/user-accounts/data/account-fingerprint.ui:21
+msgid "Left little finger"
+msgstr "پەنجە بچووکی چەپ"
+
+#: panels/user-accounts/data/account-fingerprint.ui:24
+msgid "Right thumb"
+msgstr "پەنجە گەورەی ڕاست"
+
+#: panels/user-accounts/data/account-fingerprint.ui:27
+msgid "Right middle finger"
+msgstr "پەنجەی ناوەڕاست ڕاست"
+
+#: panels/user-accounts/data/account-fingerprint.ui:30
+msgid "Right ring finger"
+msgstr "ئەڵقەی پەنجەی ڕاست"
+
+#: panels/user-accounts/data/account-fingerprint.ui:33
+msgid "Right little finger"
+msgstr "پەنجەی بچووکی ڕاست"
+
+#: panels/user-accounts/data/account-fingerprint.ui:39
+#: panels/user-accounts/um-fingerprint-dialog.c:676
+msgid "Enable Fingerprint Login"
+msgstr "چوونەژورەوە بە پەنجەمۆر چالاک بکە"
+
+#: panels/user-accounts/data/account-fingerprint.ui:89
+msgid "_Right index finger"
+msgstr "پەنجەی نیشاندەری _ڕاست"
+
+#: panels/user-accounts/data/account-fingerprint.ui:105
+msgid "_Left index finger"
+msgstr "پەنجەی نیشاندەری _چەپ"
+
+#: panels/user-accounts/data/account-fingerprint.ui:126
+msgid "_Other finger:"
+msgstr "_پەنجەکانی تر:"
+
+#: panels/user-accounts/data/account-fingerprint.ui:324
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"پەنجەمۆر بەسەرکەوتووی زیادکرا. ئێستا دەتوانیت بە پەنجەمۆر بچیتە ژوورەوە."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "بەکارهێنەران"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "زیادکردن یان سڕینەوە بەکارهێنەر و گۆڕینی وشەی تێپەڕبوون"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:7
+msgid "system-users"
+msgstr "system-users"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr "_تۆمارکردن"
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "چونەژوورەی بەڕیوەبەری دۆمەین"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "ناوی _بەڕێوبەر"
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "تێپەڕەوشەی بەڕێوبەر"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "ڕێکخستنی هەژمارەکانی بەکارهێنەر"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "ڕێپێدان داواکراوە بۆ گۆڕینی زانیاری بەکارهێنەر"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "پێویستە تێپەڕەوشەی نوێ جیاوازبێ لە کۆنەکە."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "هەوڵبدە چەن پیتێک و ژمارە بگۆڕە."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "هەوڵ بدە هەندێ لە وشەی تێپەڕبوونەکە بگۆڕە."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "ئەگەر وشەی تێپەڕبوون ناوەکەتی تێدا نەبێت بەهێزتر دەبێت."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "هەوڵ بدە ناوەکەت تێکەڵ مەکە بە وشەی تێپەڕبوونەکە."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "هەوڵ بدە چەند پیتێک بەکارمەهێنە کە لە وشەی تێپەڕبوونەکە هەیە."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "هەوڵ بدە پیتی باو بەکارمەهێنە."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "هەوڵ بدە پیتە نووسراوەکان ڕێک مەخەرەوە و بینوسیتەوە."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "هەوڵ بدە ژمارەی زیاتر بنووسە."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "هەوڵ بدە پیتی گەورە بنووسیت."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "هەوڵ بدە پیتی بچووک بەکاربێنە."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "هەوڵ بدە هێمای تایبەت، وەکو خاڵبەندی بەکاربێنە."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "هەوڵ بدە تێکەڵەیەک لە پیتەکان، ژمارەکان و خاڵبەندییەکان بەکاربێنە."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "هەوڵ بدە هەمان هێما دووبارە مەکەرەوە."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"هەوڵ بدە هەمان هێما دووبارە مەکەرەوە: پێویستە تێکەڵیەک لە پیتەکان، ژمارەکان "
+"و خاڵبەندییەکان بەکاربێنیت."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "هەوڵ زنجیرەی لە دووای یەک وەکو ١٢٣٤ یان ابجد بەکارمەهێنە."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"وشەی تێپەڕبوون پێویستە درێژتر بێ. هەوڵ بدە پیت، ژمارە، خاڵبەندی زیاتر "
+"بەکاربێنە."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "هەردوو پیتی گەورە و بچووک تێکەڵبکە لەگەڵ ژمارەیەک یا زیاتر."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "پیتی زیاتر بەکاربێنە، ژمارە و خاڵبەندی تێپەرەوشە بەهێزتر دەبێت."
+
+#: panels/user-accounts/run-passwd.c:424
+msgid "Authentication failed"
+msgstr "ڕێپێدان سەرکەوتوو نەبوو"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The new password is too short"
+msgstr "وشەی تێپەڕبوونی نوێ زۆر کورتە"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password is too simple"
+msgstr "وشەی تێپەڕبوونی نوێ زۆر سادەیە"
+
+#: panels/user-accounts/run-passwd.c:516
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "وشەی تێپەڕبوونی نوێ و کۆن زۆر لەیەک دەچن"
+
+#: panels/user-accounts/run-passwd.c:519
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "وشەی تێپەڕبوونی نوێ پێشتر بەکارهێنراوە."
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "وشەی تێپەڕبوونی نوێ دەبێت ژمارە یان هێمای تایبەتی تێدابێت."
+
+#: panels/user-accounts/run-passwd.c:526
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "وشەی تێپەڕبوونی نوێ و کۆن وەکو یەکن"
+
+#: panels/user-accounts/run-passwd.c:530
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:534
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "تێپەڕە وشە نوێییەکە بەشی پێویست نووسە جیاوازەکانی تێدانییە"
+
+#: panels/user-accounts/run-passwd.c:538
+#, c-format
+msgid "Unknown error"
+msgstr "هەڵەیەکی نەزانراو"
+
+#: panels/user-accounts/user-utils.c:439
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:443
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "ببورە، ئەو نازناوە بەردەست نییە. تکایە دانەیەکیتر تاقی بکەرەوە."
+
+#: panels/user-accounts/user-utils.c:488
+msgid "The username is too long."
+msgstr "نازناوەکە زۆر درێژە"
+
+#: panels/user-accounts/user-utils.c:550
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr "ئەمە بەکاردێ بۆ بوخچەی ماڵەوە وە ناتوانرێ بگۆڕدرێ."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"تۆ ڕێگەپێدراو نیت تا دەستبگریت بەسەر ئامێرەکە. پەیوەندی بکە بە "
+"بەڕێوبەریسیستەمەکەت."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "ئامێر لە کاردایە."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr "هەڵەی ناوەکی ڕویدا."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Enabled"
+msgstr "چالاككراوە"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:259
+msgid "Delete registered fingerprints?"
+msgstr "پەنجەمۆرە تۆمارکراوەکان دەسڕیتەوە؟"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "_Delete Fingerprints"
+msgstr "پەنجەمۆرەکان _بسڕەوە"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:269
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"تۆ دەتەوێت پەنجەمۆرە تۆمارکراوەکانت بسڕیتەوە کەواتە چوونەژوورەوەی پەنجەمۆر "
+"ناچالاک دەکرێت؟"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:439
+msgid "Done!"
+msgstr "ئەنجام درا!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:500
+#: panels/user-accounts/um-fingerprint-dialog.c:542
+#, c-format
+msgid "Could not access “%s” device"
+msgstr "ناتوانرێت بچیتە ناو ئامێری  “%s”"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:583
+#, c-format
+msgid "Could not start finger capture on “%s” device"
+msgstr "ناتوانرێت دەستبکرێت بە تۆمارکردنی پەنجە لە ئامێری  “%s”"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:627
+msgid "Could not access any fingerprint readers"
+msgstr "ناتوانرێت دەستبگیرێت بەسەر هیچ لە خوێنەرەکانی  پەنجەمۆر"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:628
+msgid "Please contact your system administrator for help."
+msgstr "تکایە پەیوەندی بکە بە بەڕیوەبەری سیستم بۆ یارمەتی."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: panels/user-accounts/um-fingerprint-dialog.c:710
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the “%s” device."
+msgstr ""
+"بۆ چالاککردنی چوونەژوورەوەی پەنجەمۆر، پێویستە یەکێک لە پەنجەمۆرەکانت خەزن "
+"بکەی، بە بەکارهێنانی ئامێری “%s”."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:717
+msgid "Selecting finger"
+msgstr "دیاریکردنی پەنجە"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:718
+msgid "Enrolling fingerprints"
+msgstr "تۆمارکرنی پەنجەمۆرەکان"
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr "نەخشەی دوگمەکان"
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "_داخستن"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr "نەخشەی دوگمەکان بۆ کردارەکان"
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:61
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:78
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.c:249
+#, c-format
+msgid "Button %d"
+msgstr "دوگمەی %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "داوانامە ناسراوە"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "گۆڕینی پیشاندەر"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr ""
+
+#: panels/wacom/cc-wacom-mapping-panel.c:249
+msgid "Output:"
+msgstr "دەرخستە:"
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:261
+msgid "Keep aspect ratio (letterbox):"
+msgstr ""
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:272
+msgid "Map to single monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-nav-button.c:84
+#, c-format
+msgid "%d of %d"
+msgstr "%d  لە %d"
+
+#: panels/wacom/cc-wacom-page.c:516
+msgid "Display Mapping"
+msgstr "نەخشەی پیشاندان"
+
+#: panels/wacom/cc-wacom-panel.c:806 panels/wacom/wacom-stylus-page.ui:119
+msgid "Stylus"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.c:360
+msgid "Button"
+msgstr "دوگمە"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:200
+msgid "Wacom Tablet"
+msgstr "تاتەبژمێری واکۆم"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:7
+msgid "input-tablet"
+msgstr "input-tablet"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr "تاتەبژمێر (ڕەها)"
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr "هەڵبژاردەکانی تاتەبژمێر"
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "_یارمەتی"
+
+#: panels/wacom/gnome-wacom-properties.ui:125
+msgid "No tablet detected"
+msgstr "تاتەبژمێر نەدۆزرایەوە"
+
+#: panels/wacom/gnome-wacom-properties.ui:141
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "تکایە پێوەی بکە و تاتەژمێری واکۆم بخەئیش"
+
+#: panels/wacom/gnome-wacom-properties.ui:161
+msgid "Bluetooth Settings"
+msgstr "ڕێکخستنەکانی بلووتووس"
+
+#: panels/wacom/gnome-wacom-properties.ui:238
+msgid "Tracking Mode"
+msgstr "دۆزی بەدواداچوون"
+
+#: panels/wacom/gnome-wacom-properties.ui:266
+msgid "Left-Handed Orientation"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:296
+#: panels/wacom/gnome-wacom-properties.ui:401
+msgid "Map to Monitor…"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:309
+msgid "Map Buttons…"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:322
+msgid "Calibrate…"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:340
+msgid "Adjust mouse settings"
+msgstr "ڕێکخستنی مشک چاک بکە"
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Adjust display resolution"
+msgstr "ڕێککردنی وردی پیشاندەر"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
+msgid "New shortcut…"
+msgstr "قەدبڕی نوێ..."
+
+#: panels/sound/cc-alert-chooser.ui:12 panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "بنەڕەت"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr "کرتەی دوگمەی ناوەڕاستی مشک"
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr "کرتەی دوگمەی ڕاستی مشک"
+
+#: panels/region/cc-format-chooser.ui:48 panels/wacom/wacom-stylus-page.ui:37
+#: shell/cc-window.ui:232
+msgid "Back"
+msgstr "بڕۆدواوە"
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "بڕۆ پێشەوە"
+
+#: panels/wacom/wacom-stylus-page.ui:79
+msgid "No stylus found"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:93
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:159
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
+msgid "Soft"
+msgstr "نەرم"
+
+#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:234
+msgid "Top Button"
+msgstr "دوگمەی سەرەوە"
+
+#: panels/wacom/wacom-stylus-page.ui:263
+msgid "Lower Button"
+msgstr "دوگمەی خوارەوە"
+
+#: panels/wacom/wacom-stylus-page.ui:292
+msgid "Lowest Button"
+msgstr "دوگمەی خوارخوارەوە"
+
+#: panels/wacom/wacom-stylus-page.ui:321
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+msgid "GNOME Settings"
+msgstr "ڕێکخستنەکانی گنۆم"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "ئامرازێکە بۆ ڕێکخستنی ڕوومێزی گنۆم"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/cc-application.c:58
+msgid "Display version number"
+msgstr "ژمارەی وەشان پیشان بدە"
+
+#: shell/cc-application.c:59
+msgid "Enable verbose mode"
+msgstr ""
+
+#: shell/cc-application.c:60
+msgid "Search for the string"
+msgstr ""
+
+#: shell/cc-application.c:61
+msgid "List possible panel names and exit"
+msgstr ""
+
+#: shell/cc-application.c:62
+msgid "Panel to display"
+msgstr "بەش بۆ پیشان دان"
+
+#: shell/cc-application.c:62
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-loader.c:293
+msgid "Available panels:"
+msgstr "بەشە بەردەسەکان:"
+
+#: shell/cc-window.ui:140
+msgid "All Settings"
+msgstr "هەموو ڕێکخستنەکان"
+
+#: shell/cc-window.ui:178
+msgid "Primary Menu"
+msgstr "پێڕستی سەرەکی"
+
+#: shell/cc-window.ui:319
+msgid "Warning: Development Version"
+msgstr "ئاگاداربە: وەشانی گەشەپێدەرانە"
+
+#: shell/cc-window.ui:320
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:331
+msgid "Help"
+msgstr "یارمەتی"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: shell/gnome-control-center.desktop.in.in:5
+msgid "org.gnome.Settings"
+msgstr "org.gnome.Settings"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "گشتی"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "دەرچوون"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "گەڕان"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "بەشەکان"
+
+#: shell/help-overlay.ui:40
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:53
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "گەڕان هەڵبوەشێنەوە"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1883
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1893
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:2750
+msgid "System Sounds"
+msgstr "دەنگەکانی سیستم"
+
+#~ msgid "Wallpapers"
+#~ msgstr "کاغەزەکانی دیوار"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "بست"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "ناوه‌ڕاست"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "زووم"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "پڕکردنەوە"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "پێوانە کردن"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "سەرتاسەری ڕۆژەکەت بگۆڕە"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "خشت"
+
+#~ msgid "_Lock Screen"
+#~ msgstr "ـشاشە قفڵبکە"
+
+#~ msgid "_Background"
+#~ msgstr "_پاشبنه‌ما"

--- a/po/crh.po
+++ b/po/crh.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-05-21 19:21-0500\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2013-05-23 18:26-0500\n"
 "Last-Translator: Reşat SABIQ <tilde.birlik@gmail.com>\n"
 "Language-Team: QIRIMTATARCA (Qırım Türkçesi) <tilde-birlik-meydan@lists."
@@ -19,6228 +19,5034 @@ msgstr ""
 "X-Launchpad-Export-Date: 2013-04-18 01:48+0000\n"
 "X-Generator: Launchpad (build 16567)\n"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:2
-msgid "Changes throughout the day"
-msgstr "Kün boyunca deñişir"
-
-#: ../panels/background/background.ui.h:3
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Töşe"
-
-# tüklü
-#: ../panels/background/background.ui.h:4
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Miqyasla"
-
-#: ../panels/background/background.ui.h:5
-msgctxt "background, style"
-msgid "Center"
-msgstr "Ortala"
-
-# tüklü
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Miqyasla"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Toldur"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Span"
-msgstr "Qarışla"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:199
-msgid "Select Background"
-msgstr "Arqazemin Sayla"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Uyğulamalar"
 
 # tr
-#: ../panels/background/cc-background-chooser-dialog.c:218
-msgid "Wallpapers"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Tapılğan uyğulamalar yoq"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Qurula"
+
+# tr
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Aç"
+
+# tr
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Ayrıntıları görüntüle"
+
+# tr
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Qıdır"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Ğayrıqabilleştirilgen"
+
+# tr
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Tebliğler"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "_Tebliğlerni Köster"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Arqazemin"
+
+#: panels/applications/cc-applications-panel.ui:134
+#, fuzzy
+msgid "Allow activity when the app is closed."
+msgstr "Kapak kapalı olduğunda"
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Ekran Körüntüleri"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+# tr
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
 msgstr "Duvar Kağıtları"
 
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
 # tr
-#: ../panels/background/cc-background-chooser-dialog.c:227
-msgid "Pictures"
-msgstr "Resimler"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Davuş"
 
-#: ../panels/background/cc-background-chooser-dialog.c:235
-msgid "Colors"
-msgstr "Tüsler"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: ../panels/background/cc-background-chooser-dialog.c:244
-msgid "Flickr"
-msgstr "Flickr"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Qısqayollar"
 
-#: ../panels/background/cc-background-chooser-dialog.c:286
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-#: ../panels/user-accounts/um-photo-dialog.c:98
-msgid "Select"
-msgstr "Sayla"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Klavye Qısqayolları"
 
-#: ../panels/background/cc-background-item.c:150
-msgid "multiple sizes"
-msgstr "müteaddit ölçü"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s Kamerası"
 
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:154
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../panels/background/cc-background-item.c:283
-msgid "No Desktop Background"
-msgstr "Masaüstü Arqazemini Yoq"
+# tr
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "Mikrofon Sesi"
 
-#: ../panels/background/cc-background-panel.c:453
-msgid "Current background"
-msgstr "Cari arqazemin"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+# tr
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "Konum"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Yapı-içi Ağ Kamerası"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+# tr
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Tapılğan bölgeler yoq"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Kösterim Türü"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "İlişim sür'atı"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Sıfırla"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Uyğulamalar"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Tema</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+# tr
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Tablet Kalemi (Stylus)"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Ögbelgilengen"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Arqazemin"
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "_Profil ekle…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Körüniş"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Arqazemin suretiñizni bir divar kâğıtına yaki fotoğa deñiştiriñiz"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Divar kâğıtı;Ekran;Masaüstü;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/bluetooth.ui.h:1
-msgid "Set Up New Device"
-msgstr "Yañı Cihaznı Ayarla"
-
-#: ../panels/bluetooth/bluetooth.ui.h:2 ../panels/network/network.ui.h:9
-msgid "Remove Device"
-msgstr "Cihaznı Çetleştir"
-
-#: ../panels/bluetooth/bluetooth.ui.h:3
-msgid "Connection"
-msgstr "Bağlantı"
-
-#: ../panels/bluetooth/bluetooth.ui.h:4
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "sahife 1"
-
-#: ../panels/bluetooth/bluetooth.ui.h:5
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "sahife 2"
-
-#: ../panels/bluetooth/bluetooth.ui.h:6
-msgid "Paired"
-msgstr "Çiftlengen"
-
-#: ../panels/bluetooth/bluetooth.ui.h:7 ../panels/wacom/cc-wacom-page.c:833
-msgid "Type"
-msgstr "Tür"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Qabilleştir"
 
 # tr
-#: ../panels/bluetooth/bluetooth.ui.h:8
-#: ../panels/network/connection-editor/ce-page-ip4.c:189
-#: ../panels/network/connection-editor/ce-page-ip4.c:441
-#: ../panels/network/connection-editor/ce-page-ip6.c:191
-#: ../panels/network/connection-editor/ce-page-ip6.c:445
-msgid "Address"
-msgstr "Adres"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
+msgstr "Bluetooth bağdaştırıcısı bulunamadı"
 
-#: ../panels/bluetooth/bluetooth.ui.h:9
-msgid "Mouse & Touchpad Settings"
-msgstr "Sıçan & Tiyüv-şiltesi Ayarları"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
 
-#: ../panels/bluetooth/bluetooth.ui.h:10
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Sound Settings"
-msgstr "Davuş Ayarları"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth Üleşimi"
 
-#: ../panels/bluetooth/bluetooth.ui.h:11
-msgid "Keyboard Settings"
-msgstr "Klavye Ayarları"
-
-#: ../panels/bluetooth/bluetooth.ui.h:12
-msgid "Send Files…"
-msgstr "Dosyelerni Yiber…"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:355
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "Ebet"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:355
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "Hayır"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
 
 # tr
-#: ../panels/bluetooth/cc-bluetooth-panel.c:469
-msgid "Bluetooth is disabled"
-msgstr "Bluetooth etkin değil"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "Uçak Kipi"
 
 # tr
-#: ../panels/bluetooth/cc-bluetooth-panel.c:474
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth donanım anahtarı ile kapatıldı"
 
 # tr
-#: ../panels/bluetooth/cc-bluetooth-panel.c:478
-msgid "No Bluetooth adapters found"
-msgstr "Bluetooth bağdaştırıcısı bulunamadı"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:577
-msgid "Visibility"
-msgstr "Körünirlik"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:581
-#, c-format
-msgid "Visibility of “%s”"
-msgstr "“%s” körünirligi"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "Uçak Kipi"
 
 # tr
-#: ../panels/bluetooth/cc-bluetooth-panel.c:625
-#, c-format
-msgid "Remove '%s' from the list of devices?"
-msgstr "'%s' aygıtlar listesinden kaldırılsın mı?"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Uçak Kipi"
 
-# tr
-#: ../panels/bluetooth/cc-bluetooth-panel.c:627
-msgid ""
-"If you remove the device, you will have to set it up again before next use."
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
-"Eğer aygıtı kaldırırsanız, sonraki kullanımdan önce yeniden kurmanız "
-"gerekecek."
 
 # tr
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:360
-msgid "Place your calibration device over the square and press 'Start'"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:366
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+# tr
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Herhangi bir uygulama ses kaydı ya da yürütmesi yapmıyor."
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:372
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:378
-msgid "Shut the laptop lid"
-msgstr ""
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:409
-msgid "An internal error occurred that could not be recovered."
-msgstr "Toparlanılalmağan dahiliy bir hata hasıl oldı."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:414
-msgid "Tools required for calibration are not installed."
-msgstr ""
-
-# tüklü
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:420
-msgid "The profile could not be generated."
-msgstr "Profil doğurtılamadı."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:426
-msgid "The target whitepoint was not obtainable."
-msgstr ""
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:466
-msgid "Complete!"
-msgstr "Tamam!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:474
-msgid "Calibration failed!"
-msgstr "Kalibrasyon muvaffaqiyetsiz!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:481
-msgid "You can remove the calibration device."
-msgstr ""
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:552
-msgid "Do not disturb the calibration device while in progress"
-msgstr ""
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Tizüstü Ekranı"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Yapı-içi Ağ Kamerası"
-
-# tüklü
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s Monitorı"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s Tarayıcısı"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s Kamerası"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s Bastırıcısı"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s Ağ kamerası"
 
 # tr
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s içün tüs idaresini qabilleştir"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Daha fazla resim için göz at"
 
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-msgid "Not calibrated"
-msgstr "Kalibrasyonsız"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:136
-msgid "Default: "
-msgstr "Ögbelgilengen: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:144
-msgid "Colorspace: "
-msgstr "Renk fezası: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:151
-msgid "Test profile: "
-msgstr "Sınama profili: "
-
 # tr
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:219
-msgid "Select ICC Profile File"
-msgstr "ICC Profil Dosyasını Seç"
-
-#: ../panels/color/cc-color-panel.c:222
-msgid "_Import"
-msgstr "_İthal Et"
-
-# tr
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:233
-msgid "Supported ICC profiles"
-msgstr "Desteklenen ICC profilleri"
-
-# tr
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:240
-#: ../panels/network/wireless-security/eap-method-fast.c:410
-msgid "All files"
-msgstr "Tüm dosyalar"
-
-#: ../panels/color/cc-color-panel.c:587
-msgid "Screen"
-msgstr "Ekran"
-
-# tr
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:913
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Dosye yükletilamadı: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:927
-msgid "The profile has been uploaded to:"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:929
-msgid "Write down this URL."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:930
-msgid "Restart this computer and boot your normal operating system."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:931
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:965
-msgid "Save Profile"
-msgstr "Profilni Saqla"
-
-# tr
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1326
-msgid "Create a color profile for the selected device"
-msgstr "Seçilen aygıt için bir renk profili oluştur"
-
-# tr
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1341 ../panels/color/cc-color-panel.c:1365
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Ölçüm cihazı algılanamadı. Lütfen açık durumda olduğundan ve doğru "
-"bağlandığından emin olunuz."
-
-# tr
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1375
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Ölçüm cihazı yazıcı profillemeyi desteklemiyor."
-
-# tr
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1386
-msgid "The device type is not currently supported."
-msgstr "Aygıt türü şu anda desteklenmiyor."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:101
-msgid "Standard Space"
-msgstr "Standart Feza"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:107
-msgid "Test Profile"
-msgstr "Sınama Profili"
-
-# tr
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:115
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Otomatik"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:125
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Tüşük Keyfiyet"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:130
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Orta Keyfiyet"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:137
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Yüksek Keyfiyet"
-
-# tr
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:154
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Öntanımlı RGB"
-
-# tr
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:161
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Öntanımlı CMYK"
-
-# tr
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:168
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Öntanımlı Gri"
-
-#: ../panels/color/cc-color-profile.c:192
-msgid "Vendor supplied factory calibration data"
-msgstr ""
-
-#: ../panels/color/cc-color-profile.c:201
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-
-#: ../panels/color/cc-color-profile.c:223
-msgid "This profile may no longer be accurate"
-msgstr "Bu profil belki artıq daqıq degildir"
-
-# tr
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kösterim Kalibrasyonı"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-#: ../panels/user-accounts/um-account-dialog.c:1082
-msgid "Cancel"
-msgstr "Vazgeç"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Vazgeç"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "Başlat"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "Devam Et"
 
+# tr
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "Tamam"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Tamam"
 
 # tr
-#. Timeout parameters
-#. 5000 = 5 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:81
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Ekran Kalibrasyonu"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibrasyon Keyfiyeti"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr ""
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Keyfiyet"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr ""
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "Kalibrasyon Keyfiyeti"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr ""
-
 # tr
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Kalibrasyon Cihazı"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
 msgstr ""
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Kösterim Türü"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profil Aq Noqtası"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "Profil Aq Noqtası"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Kösterim Parlaqlığı"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "Kösterim Parlaqlığı"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profil İsmi"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Profil İsmi:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "Profil İsmi"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr ""
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "Profilni kopiyala"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr ""
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "Profilni yüklet"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "İnternet bağlantısı şart"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-
 # tr
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:743
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Hulâsa"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
 msgstr ""
 
-#: ../panels/color/color.ui.h:29
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Profilni kopiyala"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Profil ekle"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
 
-#: ../panels/color/color.ui.h:30
-msgid "Device type:"
-msgstr "Cihaz türü:"
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "Dosyeden ithal et…"
 
-#: ../panels/color/color.ui.h:31
-msgid "Manufacturer:"
-msgstr "İmalâtçı:"
-
-#: ../panels/color/color.ui.h:32
-msgid "Model:"
-msgstr "Model:"
-
-# tr
-#: ../panels/color/color.ui.h:33
-msgid ""
-"Image files can be dragged on this window to auto-complete the above fields."
-msgstr ""
-"Yukarıdaki alanların otomatik tamamlanması için resim dosyalarını bu "
-"pencereye sürükleyebilirsiniz."
-
-#: ../panels/color/color.ui.h:34
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
-msgid "Color"
-msgstr "Tüs"
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Ekle"
 
 # tr
-#: ../panels/color/color.ui.h:35
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Her aygıt, renk yönetimleri için güncel bir renk profiline gereksinim duyar."
 
 # tr
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Daha fazlasını öğren"
 
 # tr
-#: ../panels/color/color.ui.h:37
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Renk yönetimi hakkında daha fazla bilgi edinin"
 
 # tr
-#: ../panels/color/color.ui.h:38
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "Tüm kullanıcılar için ayarla"
 
 # tr
-#: ../panels/color/color.ui.h:39
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr ""
 "Bu profilni bu bilgisayar üzerindeki qullanıcılarnıñ hepsi içün tesbit et"
 
-#: ../panels/color/color.ui.h:40
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "Qabilleştir"
 
-#: ../panels/color/color.ui.h:41
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "Profil ekle"
 
 # tr
-#: ../panels/color/color.ui.h:42
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "Kalibrasyon..."
 
 # tr
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Aygıtı kalibre et"
 
-#: ../panels/color/color.ui.h:44
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "Profilni çetleştir"
 
 # tr
-#: ../panels/color/color.ui.h:45
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "Ayrıntıları görüntüle"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr ""
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr ""
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr ""
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr ""
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Proyektor"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr ""
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:57
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Yüksek"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 daqqa"
 
-#: ../panels/color/color.ui.h:59
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Orta"
 
-#: ../panels/color/color.ui.h:60 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 daqqa"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Tüşük"
 
-#: ../panels/color/color.ui.h:62 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 daqqa"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Kösterimge fıtriy"
 
 # tr
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Bastıruv ve neşretüv)"
 
-#: ../panels/color/color.ui.h:65
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr ""
 
-#: ../panels/color/color.ui.h:66
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr ""
 
-#: ../panels/color/color.ui.h:67
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Tüs"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 
 # tr
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Renk;ICC;Profil;Ayar;Yazıcı;Görünüm;"
 
-# tr
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:682
-msgid "United States"
-msgstr "Birleşik Devletler"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Bir til saylañız"
 
 # tr
-#: ../panels/common/cc-common-language.c:683
-msgid "Germany"
-msgstr "Almanya"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Sayla"
 
 # tr
-#: ../panels/common/cc-common-language.c:684
-msgid "France"
-msgstr "Fransa"
-
-# tr
-#: ../panels/common/cc-common-language.c:685
-msgid "Spain"
-msgstr "İspanya"
-
-#: ../panels/common/cc-common-language.c:686
-msgid "China"
-msgstr "Çin"
-
-#: ../panels/common/cc-common-language.c:752
-msgid "Other…"
-msgstr "Diger…"
-
-#: ../panels/common/cc-language-chooser.c:176
-#: ../panels/region/cc-format-chooser.c:266
-#: ../panels/region/cc-input-chooser.c:174
-msgid "More…"
-msgstr "Diger…"
-
-# tr
-#: ../panels/common/cc-language-chooser.c:193
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Daha çoq til tapıldı"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/common/cc-util.c:28 ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:416
-#: ../panels/keyboard/keyboard-shortcuts.c:1159
-#: ../panels/network/network-wifi.ui.h:29
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:215
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Disabled"
-msgstr "Ğayrıqabilleştirilgen"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Diger…"
 
-#: ../panels/common/cc-util.c:29
-msgid "Left Shift"
-msgstr "Sol Shift"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#: ../panels/common/cc-util.c:30
-msgid "Left Alt"
-msgstr "Sol Alt"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "Kilidi Aç"
 
-#: ../panels/common/cc-util.c:31
-msgid "Left Ctrl"
-msgstr "Sol Ctrl"
-
-# tr
-#: ../panels/common/cc-util.c:32
-msgid "Right Shift"
-msgstr "Sağ Shift"
-
-# tr
-#: ../panels/common/cc-util.c:33
-msgid "Right Alt"
-msgstr "Sağ Alt"
-
-# tr
-#: ../panels/common/cc-util.c:34
-msgid "Right Ctrl"
-msgstr "Sağ Ctrl"
-
-#: ../panels/common/cc-util.c:35
-msgid "Left Alt+Shift"
-msgstr "Sol Alt+Shift"
-
-# tr
-#: ../panels/common/cc-util.c:36
-msgid "Right Alt+Shift"
-msgstr "Oñ Alt+Shift"
-
-#: ../panels/common/cc-util.c:37
-msgid "Left Ctrl+Shift"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
 msgstr ""
 
 # tr
-#: ../panels/common/cc-util.c:38
-msgid "Right Ctrl+Shift"
-msgstr "Oñ Ctrl+Shift"
-
-#: ../panels/common/cc-util.c:39
-msgid "Left+Right Shift"
-msgstr ""
-
-#: ../panels/common/cc-util.c:40 ../panels/region/input-options.ui.h:11
-msgid "Left+Right Alt"
-msgstr ""
-
-#: ../panels/common/cc-util.c:41
-msgid "Left+Right Ctrl"
-msgstr ""
-
-#: ../panels/common/cc-util.c:42
-msgid "Alt+Shift"
-msgstr ""
-
-#: ../panels/common/cc-util.c:43
-msgid "Ctrl+Shift"
-msgstr ""
-
-#: ../panels/common/cc-util.c:44
-msgid "Alt+Ctrl"
-msgstr ""
-
-#: ../panels/common/cc-util.c:45
-msgid "Caps"
-msgstr ""
-
-#: ../panels/common/cc-util.c:46
-msgid "Shift+Caps"
-msgstr ""
-
-#: ../panels/common/cc-util.c:47
-msgid "Alt+Caps"
-msgstr ""
-
-#: ../panels/common/cc-util.c:48
-msgid "Ctrl+Caps"
-msgstr ""
-
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "Til"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "Boyutu artır:"
 
 # tr
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "_Tamam"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Zaman"
 
-#: ../panels/datetime/datetime.ui.h:1
-msgid "_Region:"
-msgstr "_Bölge:"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:2
-msgid "_City:"
-msgstr "_Şeher:"
+# tr
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "Boyutu düşür:"
 
-#: ../panels/datetime/datetime.ui.h:3
-msgid "_Network Time"
-msgstr "_Şebeke Vaqtı"
-
-#. Translator: this is the separator between hours and minutes, like in HH:MM
-#: ../panels/datetime/datetime.ui.h:5
-msgid ":"
-msgstr ":"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "Set the time one hour ahead."
-msgstr "Saatni bir saat ileri tesbit et."
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "Set the time one hour back."
-msgstr "Saatni bir saat keri tesbit et."
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "Set the time one minute ahead."
-msgstr "Saatni bir daqqa ileri tesbit et."
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "Set the time one minute back."
-msgstr "Saatni bir daqqa keri tesbit et."
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "Switch between AM and PM."
-msgstr "Üyleden evvel ve üyleden soñ arasında almaştır."
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "Month"
-msgstr "Ay"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "Day"
-msgstr "Kün"
-
-#: ../panels/datetime/datetime.ui.h:13
-msgid "Year"
-msgstr "Yıl"
-
-#: ../panels/datetime/datetime.ui.h:14
-msgid "24-hour"
-msgstr "24-saat"
-
-#: ../panels/datetime/datetime.ui.h:15
-msgid "AM/PM"
-msgstr "ÜE/ÜS"
-
-#: ../panels/datetime/datetime.ui.h:16
-msgid "January"
-msgstr "Ocaq"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "February"
-msgstr "Şubat"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "March"
-msgstr "Mart"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "April"
-msgstr "Nisan"
-
-#: ../panels/datetime/datetime.ui.h:20
-msgid "May"
-msgstr "Mayıs"
-
-#: ../panels/datetime/datetime.ui.h:21
-msgid "June"
-msgstr "Haziran"
-
-#: ../panels/datetime/datetime.ui.h:22
-msgid "July"
-msgstr "Temmuz"
-
-#: ../panels/datetime/datetime.ui.h:23
-msgid "August"
-msgstr "Ağustos"
-
-#: ../panels/datetime/datetime.ui.h:24
-msgid "September"
-msgstr "Eylül"
-
-#: ../panels/datetime/datetime.ui.h:25
-msgid "October"
-msgstr "Ekim"
-
-#: ../panels/datetime/datetime.ui.h:26
-msgid "November"
-msgstr "Qasım"
-
-#: ../panels/datetime/datetime.ui.h:27
-msgid "December"
-msgstr "Aralıq"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Tarih & Saat"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Yıl"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Ay"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Ocaq"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Şubat"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Mart"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Nisan"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mayıs"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Haziran"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Temmuz"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Ağustos"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Eylül"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Ekim"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Qasım"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Aralıq"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Kün"
+
+# tr
+#: panels/datetime/cc-datetime-panel.ui:113
+#, fuzzy
+msgid "Time Zone"
+msgstr "Zaman"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "Qonumlarnı Qıdır"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+#, fuzzy
+msgid "Requires internet access"
+msgstr "İnternet bağlantısı şart"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Tarih & Saat"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "Avtomatik _Bağlan"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Qabilleştirilgen"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Kilidi Aç"
+
+#: panels/datetime/cc-datetime-panel.ui:246
+#, fuzzy
+msgid "Time _Format"
+msgstr "Formatlar"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Tarihler"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "30 saniye"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Taqvim"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Sayılar"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr ""
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Saat;Saat Tilimi;Qonum;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "Sistem vaqtı ve tarih ayarlarını deñiştir"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Vaqıt yaki tarih ayarlarını deñiştirmek içün sahihlenmeñiz kerek."
 
-#: ../panels/display/cc-display-panel.c:483
-msgctxt "display panel, rotation"
-msgid "Normal"
-msgstr "Normal"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Ağ"
 
-#: ../panels/display/cc-display-panel.c:484
-msgctxt "display panel, rotation"
-msgid "Counterclockwise"
-msgstr "Saat yönü tersine"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Poşta"
 
-#: ../panels/display/cc-display-panel.c:485
-msgctxt "display panel, rotation"
-msgid "Clockwise"
-msgstr "Saat yönünde"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Taqvim"
 
-#: ../panels/display/cc-display-panel.c:486
-msgctxt "display panel, rotation"
-msgid "180 Degrees"
-msgstr "180 Derece"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Musıqi"
 
-#. Keep this string in sync with gnome-desktop/libgnome-desktop/gnome-rr-labeler.c
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external projector.  Here, "Mirrored" is being
-#. * used as an adjective.  For example, the Spanish translation could be
-#. * "Pantallas en Espejo".
-#.
-#. Keep this string in sync with gnome-control-center/capplets/display/xrandr-capplet.c:get_display_name()
-#. Translators:  this is the feature where what you see on your
-#. * laptop's screen is the same as your external projector.
-#. * Here, "Mirrored" is being used as an adjective.  For example,
-#. * the Spanish translation could be "Pantallas en Espejo".
-#.
-#: ../panels/display/cc-display-panel.c:625
-#: ../panels/display/cc-rr-labeler.c:418
-msgid "Mirrored Displays"
-msgstr "Küzgülengen Ekranlar"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
 
-#: ../panels/display/cc-display-panel.c:649
-#: ../panels/display/display-capplet.ui.h:1
-msgid "Monitor"
-msgstr "Ekran"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotolar"
 
-# tr
-#: ../panels/display/cc-display-panel.c:1669
-msgid "Drag to change primary display."
-msgstr "Birincil ekranı değiştirmek için taşıyın."
-
-# tüklü
-#: ../panels/display/cc-display-panel.c:1727
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr ""
-"Hasiyetlerini deñiştirmek içün bir ekran saylañız; yerleştirilmesini kene "
-"tertiplemek içün onı süyrekleñiz."
-
-# tr
-#: ../panels/display/cc-display-panel.c:2115
-msgid "%a %R"
-msgstr "%a %R"
-
-# tr
-#: ../panels/display/cc-display-panel.c:2117
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
-
-# tr
-#: ../panels/display/cc-display-panel.c:2279
-#: ../panels/display/cc-display-panel.c:2331
-#, c-format
-msgid "Failed to apply configuration: %s"
-msgstr "Yapılandırmanın uygulanması başarısız oldu: %s"
-
-# tr
-#: ../panels/display/cc-display-panel.c:2359
-msgid "Could not save the monitor configuration"
-msgstr "Ekran yapılandırması kaydedilemedi"
-
-# tr
-#: ../panels/display/cc-display-panel.c:2419
-msgid "Could not detect displays"
-msgstr "Ekranlar tespit edilemedi"
-
-# tr
-#: ../panels/display/cc-display-panel.c:2614
-msgid "Could not get screen information"
-msgstr "Ekran bilgisi alınamadı"
-
-#: ../panels/display/display-capplet.ui.h:2
-msgid "_Resolution"
-msgstr "_Çezinirlik"
-
-#: ../panels/display/display-capplet.ui.h:3
-msgid "R_otation"
-msgstr "_Aylandırma"
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:5
-msgid "_Mirror displays"
-msgstr "Ekranlarnı _Küzgüle"
-
-# tr
-#: ../panels/display/display-capplet.ui.h:6
-msgid "Note: may limit resolution options"
-msgstr "Bilgi: çözünürlük seçeneklerini kısıtlayabilir"
-
-#: ../panels/display/display-capplet.ui.h:7
-msgid "_Detect Displays"
-msgstr "Ekranları _Alğıla"
-
-# tr
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "Ekranlar"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr "Bağlanğan monitorlar ve proyektorlarnıñ nasıl qullanılacağını sayla"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr "Panel;Proyektor;xrandr;Ekran;Çezinirlik;Tazeleme;"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:450 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "Bilinmegen"
-
-#: ../panels/info/cc-info-panel.c:532
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-bit"
-
-# tr
-#: ../panels/info/cc-info-panel.c:534
-#, c-format
-msgid "%d-bit"
-msgstr "%d-bit"
-
-#: ../panels/info/cc-info-panel.c:1209
-msgid "Ask what to do"
-msgstr "Ne yapılacağını sora"
-
-#: ../panels/info/cc-info-panel.c:1213
-msgid "Do nothing"
-msgstr "Hiç bir şey yapma"
-
-#: ../panels/info/cc-info-panel.c:1217
-msgid "Open folder"
-msgstr "Cilbent aç"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Other Media"
-msgstr "Diger Vasatlar"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1339
-msgid "Select an application for audio CDs"
-msgstr "Müzik CD'leri için uygulama seçin"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1340
-msgid "Select an application for video DVDs"
-msgstr "Vidyo DVD'leri için uygulama seçin"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1341
-msgid "Select an application to run when a music player is connected"
-msgstr "Müzik çalar bağlandığında çalıştırılacak uygulamayı seçin"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1342
-msgid "Select an application to run when a camera is connected"
-msgstr "Kamera bağlandığında çalıştırılacak uygulamayı seçin"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1343
-msgid "Select an application for software CDs"
-msgstr "Yazılım CD' leri için uygulama seçin"
-
-# tr
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1355
-msgid "audio DVD"
-msgstr "ses DVD' si"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1356
-msgid "blank Blu-ray disc"
-msgstr "boş Blu-ray diski"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1357
-msgid "blank CD disc"
-msgstr "boş CD diski"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1358
-msgid "blank DVD disc"
-msgstr "boş DVD diski"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1359
-msgid "blank HD DVD disc"
-msgstr "boş HD DVD diski"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1360
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video diski"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1361
-msgid "e-book reader"
-msgstr "e-kitap okuyucu"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1362
-msgid "HD DVD video disc"
-msgstr "HD DVD vidyo diski"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1363
-msgid "Picture CD"
-msgstr "Resim CD' si"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1364
-msgid "Super Video CD"
-msgstr "Süper Vidyo CD"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1365
-msgid "Video CD"
-msgstr "Vidyo CD"
-
-#: ../panels/info/cc-info-panel.c:1366
-msgid "Windows software"
-msgstr "Windows yazılımı"
-
-#: ../panels/info/cc-info-panel.c:1367
-msgid "Software"
-msgstr "Yazılım"
-
-# tr
-#: ../panels/info/cc-info-panel.c:1490
-#: ../panels/keyboard/keyboard-shortcuts.c:1696
-msgid "Section"
-msgstr "Bölüm"
-
-#: ../panels/info/cc-info-panel.c:1499 ../panels/info/info.ui.h:13
-msgid "Overview"
-msgstr "Üstbaqış"
-
-#: ../panels/info/cc-info-panel.c:1505 ../panels/info/info.ui.h:20
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
 msgid "Default Applications"
 msgstr "Ögbelgilengen Uyğulamalar"
 
-#: ../panels/info/cc-info-panel.c:1510 ../panels/info/info.ui.h:28
-msgid "Removable Media"
-msgstr "Çetleştirilebilir Vasat"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Ögbelgilengen Uyğulamalar"
 
-#: ../panels/info/cc-info-panel.c:1535
-#, c-format
-msgid "Version %s"
-msgstr "Sürüm %s"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/cc-info-panel.c:1585
-msgid "Install Updates"
-msgstr "Yañartmalarnı Qur"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
 
-#: ../panels/info/cc-info-panel.c:1589
-msgid "System Up-To-Date"
-msgstr "Sistem Küncel"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/info/cc-info-panel.c:1593
-msgid "Checking for Updates"
-msgstr "Yañartmalar içün Teşkerile"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:44
-msgid "Details"
-msgstr "Tafsilât"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Uyğula"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Keri"
+
+# tr
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Bluetooth etkin değil"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Küzgülengen Ekranlar"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+#, fuzzy
+msgid "Mirror"
+msgstr "¼ Ekran"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Ekranlarnı Küzgüle"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "Oñ Alqa"
+
+# tr
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Yöneldirim"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Çezinirlik"
+
+# tr
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "_Tazeleme hızı:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Miqyasla"
+
+# tr
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "İşlem tamamlandı"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+# tr
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Mevcut yazıcı bulunmuyor"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Süzgüç"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+# tr
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Defa"
+
+# tr
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Kaynak URI"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "daqqa"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+# tr
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ekranlar"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Bağlanğan monitorlar ve proyektorlarnıñ nasıl qullanılacağını sayla"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Panel;Proyektor;xrandr;Ekran;Çezinirlik;Tazeleme;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Emniyet anahtarı"
+
+# tr
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Mürekkep Seviyesi"
+
+# tr
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Mürekkep Seviyesi"
+
+# tr
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Mürekkep Seviyesi"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Emniyet"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Cihaz adı"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Donanım Adresi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Hafiza"
+
+# tr
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "İşlemci"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafikler"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Hesaplana…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "İsim"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Tür"
+
+# tr
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME Terminal"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Yükleme seçenekleri…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows yazılımı"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Sanallaştırma"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Yazılım"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Cihaznı Çetleştir"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Cihaz adı"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "İcat Et..."
+
+# tr
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Hakkında"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr ""
 
 # tüklü
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "cihaz;sistem;malümat;hafiza;işlemci;sürüm;ögbelgilengen;uyğulama;tercihli;cd;"
 "dvd;usb;davuş;video;disk;çetleştirilebilir;vasat;avtoçaptır;"
 
 # tr
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "Diğer ortamların nasıl kullanılacağını seçin"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "_Amel:"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "_Tür:"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "Cihaz adı"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "Hafiza"
-
-# tr
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "İşlemci"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "Temel sistem"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "Disk"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "Hesaplana…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "Grafikler"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "Sanallaştırma"
-
-#: ../panels/info/info.ui.h:14
-msgid "_Web"
-msgstr "_Ağ"
-
-#: ../panels/info/info.ui.h:15
-msgid "_Mail"
-msgstr "_Poşta"
-
-#: ../panels/info/info.ui.h:16
-msgid "_Calendar"
-msgstr "_Taqvim"
-
-#: ../panels/info/info.ui.h:17
-msgid "M_usic"
-msgstr "_Musıqi"
-
-#: ../panels/info/info.ui.h:18
-msgid "_Video"
-msgstr "_Video"
-
-#: ../panels/info/info.ui.h:19
-msgid "_Photos"
-msgstr "_Fotolar"
-
-# tr
-#: ../panels/info/info.ui.h:21
-msgid "Select how media should be handled"
-msgstr "Ortamın nasıl kullanılacağını seçin"
-
-# tr
-#: ../panels/info/info.ui.h:22
-msgid "CD _audio"
-msgstr "CD _sesi"
-
-#: ../panels/info/info.ui.h:23
-msgid "_DVD video"
-msgstr "_DVD videosı"
-
-#: ../panels/info/info.ui.h:24
-msgid "_Music player"
-msgstr "_Musıqi çalar"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Software"
-msgstr "_Yazılım"
-
-#: ../panels/info/info.ui.h:26
-msgid "_Other Media…"
-msgstr "_Diger Vasatlar…"
-
-# tr
-#: ../panels/info/info.ui.h:27
-msgid "_Never prompt or start programs on media insertion"
-msgstr "_Asla bir uygulama çalıştırma ya da sorma..."
-
-# tr
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "Ses ve Ortam"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Davuşsızlandır"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Davuş gürlügi aşağı"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Davuş gürlügi yuqarı"
 
 # tr
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "Mikrofon Sesi"
+
+# tr
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Ortam oynatıcısını çalıştır"
 
 # tr
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Oynat (ya da oynat/beklet)"
 
 # tr
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Oynatmayı beklet"
 
 # tr
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Oynatmayı durdur"
 
 # tr
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Önceki parça"
 
 # tr
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Sonraki parça"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Çıqart"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/universal-access/uap.ui.h:66
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Tuşlama"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "Soñraki kirdi menbasına almaş"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "Evvelki kirdi menbasına almaş"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "Fırlatıcılar"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Yardım kezicisini fırlat"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Ayarlar"
+
 # tr
-#: ../panels/keyboard/01-launchers.xml.in.h:3
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Hesap makinesini çalıştır"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "E-posta müşterisini fırlat"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "Web kezicisini fırlat"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "Ev cilbenti"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "Qıdır"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "Ekran Körüntüleri"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "Bir ekran körüntisini $PICTURES cilbentine saqla"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Bir pencereniñ bir ekran körüntisini $PICTURES cilbentine saqla"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Bir mıntıqanıñ bir ekran körüntisini $PICTURES cilbentine saqla"
-
 # tr
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "Bir ekran görüntüsünü panoya kopyala"
-
-# tr
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Bir pencerenin ekran görüntüsünü panoya kopyala"
-
-# tr
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Bir alanın ekran görüntüsünü panoya kopyala"
-
-# tr
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistem"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "Tışarı imzalan"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "Ekrannı kilitle"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "Cihanşümul İrişim"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "Körünirlik"
 
 # tr
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "Yakınlaştırmayı aç ya da kapat"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "Yaqınlaştır"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "Uzaqlaştır"
 
 # tr
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "Ekran okuyucuyu aç ya da kapat"
 
 # tr
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "Ekran klavyesini aç ya da kapat"
 
 # tr
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "Yazıyı büyüt"
 
 # tr
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "Yazıyı küçült"
 
 # tr
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "Yüksek karşıtlık açık ya da kapalı"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:366
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Bir Kirdi Menbası Ekle"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Saylanğan kirdi menbası yoq"
+
+# tr
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Seçenekler"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Yuqarı Avuştır"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Aşağı Avuştır"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Tercihler"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Klavye Tizilimi"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Çetleştir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Kirdi Qaynaqları"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+#, fuzzy
+msgid "Includes keyboard layouts and input methods."
+msgstr "Klavye yaaki kirdi usulı ayarlarıñıznı deñiştiriñiz"
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Kirdi Menbası Seçenekleri"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Bütün pencereler içün _aynı menbani qullan"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "Her pencere içün _farqlı menbalarğa izin ber"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "Alternativ Remizler Tuşu"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:375
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "Telif Tuşu"
 
-#: ../panels/keyboard/cc-keyboard-option.c:379
-msgid "Modifiers-only switch to next source"
-msgstr "Soñraki menbağa faqat-başqalaştırıcılar almaştırıcısı"
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Klavye Qısqayolları"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+# tr
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Özel Qısqayollar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+# tr
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Bölüm"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Qısqayollar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Qısqayol Ekle"
+
+# tr
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Özel Qısqayollar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Qısqayol Ekle"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Klavye Qısqayolları"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Çetleştir"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "İsim"
+
+# tr
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Kom_ut:"
+
+# tr
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Qısqayol"
+
+# tr
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Qısqayol"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Hiç biri"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Ögbelgilemelerge _Sıfırla"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Klavye"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
 "Klavye qısqayollarını seyretiñiz hem deñiştiriñiz ve tuşlama tercihleriñizni "
 "tesbit etiñiz"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Qısqayol;Tekrar;Qıpma;"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "Özel Qısqayol"
-
-# tr
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "_Name:"
-msgstr "İ_sim:"
-
-# tr
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "C_ommand:"
-msgstr "Kom_ut:"
-
-# tüklü
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "Repeat Keys"
-msgstr "Tekrarlama Tuşları"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Key presses _repeat when key is held down"
-msgstr "Tuş basıq tutulğanda klavye basmaları _tekrarlanır"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "_Delay:"
-msgstr "_Keçikme:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Speed:"
-msgstr "_Sur'at:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "Qısqa"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "Yavaş"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgid "Repeat keys speed"
-msgstr "Terkrarlama tuşları sur'atı"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "Uzun"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "Tez"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgid "Cursor Blinking"
-msgstr "İmleç Qıpması"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor _blinks in text fields"
-msgstr "Metin alanlarında imleç _qıpar"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "S_peed:"
-msgstr "_Sur'at:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "Cursor blink speed"
-msgstr "İmleç qıpması sür'atı"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-#: ../panels/region/region.ui.h:5
-msgid "Input Sources"
-msgstr "Kirdi Qaynaqları"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-msgid "Add Shortcut"
-msgstr "Qısqayol Ekle"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Remove Shortcut"
-msgstr "Qısqayolnı Çetleştir"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
-"Bir qısqayolnı tahrir etmek içün, satırğa çertiñiz ve tuşlarnı basıq tutuñız "
-"ya da temizlemek içün Backspace tuşuna basıñız."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid "Shortcuts"
-msgstr "Qısqayollar"
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
 
 # tr
-#: ../panels/keyboard/keyboard-shortcuts.c:585
-#: ../panels/keyboard/keyboard-shortcuts.c:593
-msgid "Custom Shortcuts"
-msgstr "Özel Qısqayollar"
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Herhangi bir uygulama ses kaydı ya da yürütmesi yapmıyor."
 
-# tr
-#: ../panels/keyboard/keyboard-shortcuts.c:804
-msgid "<Unknown Action>"
-msgstr "<Bilinmegen Amel>"
-
-# tr
-#: ../panels/keyboard/keyboard-shortcuts.c:1300
-#, c-format
+#: panels/location/cc-location-panel.ui:38
 msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
-"Kısayol tuşu \"%s\" kullanılamıyor çünkü kullanımı halinde bu tuş "
-"kullanılarak yazmak mümkün olmayacak.\n"
-"Lütfen Control, Alt ya da Shift gibi tuşlar ile aynı anda deneyin."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
 
 # tr
-#: ../panels/keyboard/keyboard-shortcuts.c:1332
-#, c-format
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Mikrofon Sesi"
+
+# tr
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Tapılğan uyğulamalar yoq"
+
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
 msgstr ""
-"\"%s\" kısayolu bu işlem için kullanılıyor:\n"
-"\"%s\""
 
-# tr
-#: ../panels/keyboard/keyboard-shortcuts.c:1337
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
 msgstr ""
-"Eğer kısayolu \"%s\" olarak tekrar atarsanız, \"%s\" kısayolu "
-"etkinsizleştirilecek."
 
-# tr
-#: ../panels/keyboard/keyboard-shortcuts.c:1343
-msgid "_Reassign"
-msgstr "_Kene tayin et"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
 
-#: ../panels/mouse/cc-mouse-panel.c:123
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Ayarlarıñıznı _Sınañız"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Umumiy"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "Birlemci _dögme"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+# tr
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Sol"
+
+# tr
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Sağ"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Qonumlarnı Qıdır"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Sıçan"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Sıçan Tuşları"
+
+# tr
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Aşağı Kaydır"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+# tr
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Büyüteç imleci içerikle birlikte hareket ediyor"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Tezleşme:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+# tüklü
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Tiyüv-şiltesi"
+
+# tüklü
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Tiyüv-şiltesi"
+
+# tr
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "Y_öntem"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+# tüklü
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "_Çertmek içün türt"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+# tüklü
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "_Çertmek içün türt"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_Tuşlağanda ğayrıqabilleştir"
+
+# tr
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "İmleçsürer (Touchpad) (göreceli)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "Taydıruv"
+
+# tr
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Sola Kaydır"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Eki-yanlı"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Çertmege, çift çertmege, taydırmağa deñeñiz"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "Sıçan & Tiyüv-şiltesi"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 
 # tr
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+#, fuzzy
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Trackpad;İşaretçi;Tıklama;Vurma;Çift;Düğme;Trackball;"
 
+#: panels/multitasking/cc-multitasking-panel.ui:15
+#, fuzzy
+msgid "_Hot Corner"
+msgstr "Sol üst köşe"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Renk fezası: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Ekran"
+
 # tr
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "Mouse Preferences"
-msgstr "Fare Tercihleri"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Birincil ekranı değiştirmek için taşıyın."
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "General"
-msgstr "Umumiy"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "Yavaş"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Uyğulama Menüsi"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Double-click timeout"
-msgstr "Çift-çertme zaman aşımı"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "Tez"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "_Double-click"
-msgstr "_Çift-çertme"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Primary _button"
-msgstr "Birlemci _dögme"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-# tr
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "_Sol"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-# tr
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "_Oñ"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Cihazlar"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "Mouse"
-msgstr "Sıçan"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgid "_Pointer speed"
-msgstr "_İbre sür'atı"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Yañı bağlantı ekle"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "Yavaş"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "Tez"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Bağlanğan"
 
-# tüklü
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgid "Touchpad"
-msgstr "Tiyüv-şiltesi"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Seçenekler…"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "Yavaş"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "Tez"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Disable while _typing"
-msgstr "_Tuşlağanda ğayrıqabilleştir"
-
-# tüklü
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Tap to _click"
-msgstr "_Çertmek içün türt"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
-msgid "Two _finger scroll"
-msgstr "Eki-_parmaqlı taydırma"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "C_ontent sticks to fingers"
-msgstr "_Muhteva parmaqlarğa yapışır"
-
-#: ../panels/mouse/gnome-mouse-test.c:134
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "Çertmege, çift çertmege, taydırmağa deñeñiz"
-
-# tüklü
-#: ../panels/mouse/gnome-mouse-test.c:139
-msgid "Five clicks, GEGL time!"
-msgstr "Beş çertme, GEGL zamanı!"
-
-#: ../panels/mouse/gnome-mouse-test.c:144
-msgid "Double click, primary button"
-msgstr "Çift çertme, birlemci dögme"
-
-#: ../panels/mouse/gnome-mouse-test.c:144
-msgid "Single click, primary button"
-msgstr "Tek çertme, birlemci dögme"
-
-#: ../panels/mouse/gnome-mouse-test.c:147
-msgid "Double click, middle button"
-msgstr "Çift çertme, orta dögme"
-
-#: ../panels/mouse/gnome-mouse-test.c:147
-msgid "Single click, middle button"
-msgstr "Tek çertme, orta dögme"
-
-#: ../panels/mouse/gnome-mouse-test.c:150
-msgid "Double click, secondary button"
-msgstr "Çift çertme, ekilemci dögme"
-
-#: ../panels/mouse/gnome-mouse-test.c:150
-msgid "Single click, secondary button"
-msgstr "Tek çertme, ekilemci dögme"
-
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:364
-msgid "Air_plane Mode"
-msgstr "Uça_k Kipi"
-
-#: ../panels/network/cc-network-panel.c:927
-msgid "Network proxy"
-msgstr "Şebekede proksisi"
-
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1106 ../panels/network/net-vpn.c:285
-#: ../panels/network/net-vpn.c:438
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Telsiz-Vefa Sıcaqnoqtası"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Şebeke Adı"
 
 # tr
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1241
-msgid "The system network services are not compatible with this version."
-msgstr "Sistem ağ yöneticisi bu sürümle uyumlu değil."
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Sır-söz"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+# tüklü
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Bir sır-sözni doğurt"
+
+# tüklü
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Bir sır-sözni doğurt"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Aç"
+
+# tr
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Uçak Kipi"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+# tr
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Bluetooth bağdaştırıcısı bulunamadı"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+# tr
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Uçak Kipi"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Telsiz-Vefa Sıcaqnoqtası"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+# tr
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Sıcaqnoqta olaraq qullan..."
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Şebeke"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _Emniyet"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr ""
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "İç _sahihlenim"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:4
-msgid "Security"
-msgstr "Emniyet"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "avtomatik"
-
-# tr
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:224
-#: ../panels/network/net-device-wifi.c:385
-msgid "WEP"
-msgstr "WEP"
-
-# tr
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:228
-#: ../panels/network/net-device-wifi.c:390
-#: ../panels/network/network-wifi.ui.h:17
-msgid "WPA"
-msgstr "WPA"
-
-# tr
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:232
-msgid "WPA2"
-msgstr "WPA2"
-
-# tr
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:237
-msgid "Enterprise"
-msgstr "Kurumsal"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:242
-#: ../panels/network/net-device-wifi.c:375
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Yoq"
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "Asla"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:790
-msgid "Today"
-msgstr "Bugün"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:793
-msgid "Yesterday"
-msgstr "Tünevin"
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:479
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i kün evvel"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:537
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/sn"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Yoq"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:568
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Zayıf"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:570
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Tamam"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:572
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Eyi"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:574
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Mükemmel"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:213
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:255
-#: ../panels/network/network-wifi.ui.h:45
-msgid "Identity"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:202
-#: ../panels/network/connection-editor/ce-page-ip4.c:454
-msgid "Netmask"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:216
-#: ../panels/network/connection-editor/ce-page-ip4.c:467
-#: ../panels/network/connection-editor/ce-page-ip6.c:217
-#: ../panels/network/connection-editor/ce-page-ip6.c:475
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "Savaq"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:233
-#: ../panels/network/connection-editor/ce-page-ip6.c:234
-msgid "Delete Address"
-msgstr "Adresni Sil"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:285
-#: ../panels/network/connection-editor/ce-page-ip6.c:286
-msgid "Add"
-msgstr "Ekle"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:350
-#: ../panels/network/connection-editor/ce-page-ip6.c:354
-msgid "Server"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:367
-#: ../panels/network/connection-editor/ce-page-ip6.c:371
-msgid "Delete DNS Server"
-msgstr "DNS Sunucısını sil"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:481
-#: ../panels/network/connection-editor/ce-page-ip6.c:489
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "Metrik"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:502
-#: ../panels/network/connection-editor/ce-page-ip6.c:510
-msgid "Delete Route"
-msgstr "Rotanı Sil"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:616
-#: ../panels/network/network-wifi.ui.h:25
-msgid "Automatic (DHCP)"
-msgstr "Avtomatik (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:620
-#: ../panels/network/connection-editor/ce-page-ip6.c:622
-#: ../panels/network/network-wifi.ui.h:24
-msgid "Manual"
-msgstr "Elden"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:624
-#: ../panels/network/connection-editor/ce-page-ip6.c:626
-msgid "Link-Local Only"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:925
-#: ../panels/network/network-wifi.ui.h:46
-msgid "IPv4"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:204
-#: ../panels/network/connection-editor/ce-page-ip6.c:458
-msgid "Prefix"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:614
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "Avtomatik"
-
-# tüklü
-#: ../panels/network/connection-editor/ce-page-ip6.c:618
-msgid "Automatic, DHCP only"
-msgstr "Avtomatik, faqat DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:886
-#: ../panels/network/network-wifi.ui.h:47
-msgid "IPv6"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:49
-msgid "Reset"
-msgstr "Sıfırla"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Hiç biri"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr ""
-
-# tüklü
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Qurumsal"
-
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-msgid "_Apply"
-msgstr "_Uyğula"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:2
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Signal Küçü"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:3
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "İlişim sür'atı"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Emniyet"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 Adresi"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 Adresi"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:7
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Donanım Adresi"
 
 # tr
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:8
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Desteklenen ICC profilleri"
+
+# tr
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Öntanımlı Geçit"
 
 # tr
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
 # tüklü
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Soñki Qullanılğan"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr ""
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr ""
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "İ_sim"
 
 # tüklü
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:36
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "_MAC Adresi"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "_Klonlanğan Adres"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
+# tr
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "Y_öntem"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Avtomatik (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
-msgid "Connect _automatically"
-msgstr ""
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Elden"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr ""
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Ğayrıqabilleştirilgen"
 
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "Ögbelgilengen"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr ""
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:22
-msgid "IPv_4"
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
 msgstr ""
 
 # tr
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:23
-msgid "_Addresses"
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
 msgstr "_Adresler"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
+# tr
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adres"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Savaq"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Avtomatik"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "Avtomatik DNS"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:30
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Rotalar"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Avtomatik Rotalar"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:32
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr ""
 
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:34
-msgid "IPv_6"
+# tr
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "Y_öntem"
+
+# tüklü
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Avtomatik, faqat DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
 msgstr ""
 
-#: ../panels/network/connection-editor/net-connection-editor.c:268
-msgid "Unable to open connection editor"
-msgstr "Bağlantı muharriri açılalmay"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:286
-msgid "New Profile"
-msgstr "Yañı Profil"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:511
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1083
-msgid "_Add"
-msgstr "_Ekle"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:593
-#: ../panels/network/network.ui.h:4 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:594
-msgid "Bond"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:595
-msgid "Bridge"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:596
-msgid "VLAN"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:746
-msgid "Could not load VPN plugins"
-msgstr "VPN plaginleri yüklenamadı: %s"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:810
-msgid "Import from file…"
-msgstr "Dosyeden ithal et…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:877
-msgid "Add Network Connection"
-msgstr "Şebeke Bağlantısını Ekle"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Reset"
-msgstr "_Sıfırla"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1411
-#: ../panels/network/network-wifi.ui.h:40
-msgid "_Forget"
-msgstr "_Unut"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Emniyet"
 
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "İthal etilecek dosye sayla"
-
-# tr
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "Bir \"%s\" adlı dosye endi mevcuttır."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-msgid "Export VPN connection..."
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr ""
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:12
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr ""
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:13
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr ""
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:16
-msgid "My Home Network"
-msgstr "Ev Şebekem"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
-msgid "Make available to _other users"
-msgstr ""
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "Şebeke"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+#: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "İnternet'ke nasıl bağlanğanıñıznı muraqabe etiñiz"
 
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr ""
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Telsiz-Vefa"
 
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr ""
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "İnternet'ke nasıl bağlanğanıñıznı muraqabe etiñiz"
 
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:465
-msgid "never"
-msgstr "asla"
+# tüklü
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Şebeke;Kabelsiz;İP;LAN;Proksi;"
 
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:475
-msgid "today"
-msgstr "bugün"
-
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:477
-msgid "yesterday"
-msgstr "tünevin"
-
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "İP Adresi"
-
-# tr
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:10
-msgid "Last used"
-msgstr "Soñki qullanılğan"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Kabelli"
 
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1549
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8 ../panels/universal-access/uap.ui.h:23
-msgid "Options…"
-msgstr "Seçenekler…"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Cihaznı söndür"
 
-#: ../panels/network/net-device-ethernet.c:491
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#: ../panels/network/net-device-mobile.c:239
-msgid "Add new connection"
-msgstr "Yañı bağlantı ekle"
-
-#: ../panels/network/net-device-wifi.c:1120
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-"Telsizden başqa İnternet'ke bir bağlantıñız bar ise, bağlantıñıznı digerler "
-"ile üleşmek üzre bir telsiz sıcaq-noqtanı ayarlaybilirsiñiz."
-
-#: ../panels/network/net-device-wifi.c:1124
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "Telsiz sıcaqnoqtanıñ açılması <b>%s</b> bağlantıñıznı qoparır."
-
-#: ../panels/network/net-device-wifi.c:1128
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"Sıcaqnoqta faal olğanda telsiziñiz arqalı İnternet'ke irişmek mümkün "
-"degildir."
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Faal İşler"
 
 # tr
-#: ../panels/network/net-device-wifi.c:1202
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Etkin nokta durdurulup tüm kullanıcıların bağlantısı kesilsin mi?"
-
-# tr
-#: ../panels/network/net-device-wifi.c:1205
-msgid "_Stop Hotspot"
-msgstr "Etkin Noktayı _Durdur"
-
-#: ../panels/network/net-device-wifi.c:1277
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1280
-msgid "Wireless device does not support Hotspot mode"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1407
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Saylanğan şebekeler içün şebeke tafsilâtı, sır-söz ve her hangi özel "
-"endamlandırış dahil, ğayıp etilecek."
-
-#: ../panels/network/net-device-wifi.c:1712
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:14
-msgid "History"
-msgstr ""
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1724
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Unut"
-
-# tr
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Yapılandırma URL'si verilmediğinde vekil sunucu otomatik bulma kullanılır."
-
-# tr
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "Bu güvenli olmayan açık ağlarda önerilmez."
-
-#: ../panels/network/net-proxy.c:408
-msgid "Proxy"
-msgstr "Proksi"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "_Profil ekle…"
-
-# tr
-#: ../panels/network/network-mobile.ui.h:1
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
-#: ../panels/network/network-mobile.ui.h:2
+#: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Teminatçı"
 
-# tr
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:5
-msgctxt "proxy method"
-msgid "None"
-msgstr "Hiçbiri"
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "İP Adresi"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Şebekede proksisi"
 
 # tr
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:6
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "El ile"
-
-# tr
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:7
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "Otomatik"
-
-# tr
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
-msgstr "Y_öntem"
-
-# tr
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "_Yapılandırma URL'si"
-
-# tr
-#: ../panels/network/network-proxy.ui.h:6
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP Vekili"
 
-#: ../panels/network/network-proxy.ui.h:7
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "H_TTPS Proksisi"
 
 # tr
-#: ../panels/network/network-proxy.ui.h:8
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "_FTP Vekili"
 
 # tr
-#: ../panels/network/network-proxy.ui.h:9
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "_Socks Makinesi"
 
-#: ../panels/network/network-proxy.ui.h:10
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "Qonaqbaylarnı _İhmal Et"
 
-#: ../panels/network/network-proxy.ui.h:11
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "HTTP proksi limanı"
 
-#: ../panels/network/network-proxy.ui.h:12
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "HTTPS proksi limanı"
 
-#: ../panels/network/network-proxy.ui.h:13
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "FTP proksi limanı"
 
-#: ../panels/network/network-proxy.ui.h:14
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Socks proksi limanı"
 
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "Cihaznı söndür"
-
 # tr
-#: ../panels/network/network.ui.h:1
-msgid "Select the interface to use for the new service"
-msgstr "Yeni hizmetin kullanılacağı arayüzü seçin"
-
-# tr
-#: ../panels/network/network.ui.h:2
-msgid "C_reate…"
-msgstr "İcat _Et…"
-
-# tr
-#: ../panels/network/network.ui.h:3
-msgid "_Interface"
-msgstr "_Arayüz"
-
-#: ../panels/network/network.ui.h:8
-msgid "Add Device"
-msgstr "Cihaz Ekle"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN Türü"
-
-# tr
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "Grup İsmi"
-
-# tr
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "Grup Parolası"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "Qullanıcı Adı"
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Yapılandırma URL'si"
 
 # tüklü
-#: ../panels/network/network-vpn.ui.h:7
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "VPN bağlantısını qapaq"
 
-#: ../panels/network/network-wifi.ui.h:1
-msgid "Automatic _Connect"
-msgstr "Avtomatik _Bağlan"
-
-#: ../panels/network/network-wifi.ui.h:11
-msgid "details"
-msgstr "tafsilât"
-
-# tr
-#: ../panels/network/network-wifi.ui.h:15
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "_Password"
-msgstr "_Parola"
-
-#: ../panels/network/network-wifi.ui.h:18
-#: ../panels/universal-access/uap.ui.h:8
-msgid "None"
-msgstr "Hiç biri"
-
-# tr
-#: ../panels/network/network-wifi.ui.h:19
-msgid "Show P_assword"
-msgstr "_Sır-sözni Köster"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "Make available to other users"
-msgstr "Diger qullanıcılarğa müsait yap"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "identity"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Automatic (DHCP) addresses only"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Link-local only"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Shared with other computers"
-msgstr ""
-
-# tüklü
-#: ../panels/network/network-wifi.ui.h:31
-msgid "_Ignore automatically obtained routes"
-msgstr "Avtomatik olaraq elde etilgen rotalarnı _ihmal et"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "ipv4"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv6"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "_Cloned MAC Address"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:38
-msgid "hardware"
-msgstr "donanım"
-
-#: ../panels/network/network-wifi.ui.h:41
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:42
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid "reset"
-msgstr "sıfırla"
-
-#: ../panels/network/network-wifi.ui.h:48
-msgid "Hardware"
-msgstr "Donanım"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Wi-Fi Hotspot"
-msgstr "Telsiz-Vefa Sıcaqnoqtası"
-
-#: ../panels/network/network-wifi.ui.h:51
-msgid "_Turn On"
-msgstr "_Aç"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi"
-msgstr "Telsiz-Vefa"
-
-# tr
-#: ../panels/network/network-wifi.ui.h:53
-msgid "Turn Wi-Fi off"
-msgstr "Telsiz-Vefanı qapat"
-
-# tr
-#: ../panels/network/network-wifi.ui.h:54
-msgid "_Use as Hotspot…"
-msgstr "_Sıcaqnoqta olaraq qullan..."
-
-#: ../panels/network/network-wifi.ui.h:55
-msgid "_Connect to Hidden Network…"
-msgstr "Gizli bir Şebekege _Bağlan…"
-
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_History"
-msgstr "_Keçmiş"
-
-#: ../panels/network/network-wifi.ui.h:57
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Bir Telsiz-Vefa şebekesine bağlanmaq içün qapatıñız"
-
-#: ../panels/network/network-wifi.ui.h:58
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Şebeke Adı"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Connected Devices"
-msgstr "Bağlanğan Cihazlar"
-
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Emniyet türü"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Security key"
-msgstr "Emniyet anahtarı"
+# tr
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Sır-söz"
 
 # tr
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Telsiz-Vefanı qapat"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "Altyapı"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Yükleme seçenekleri…"
 
-# tr
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "Durum bilinmiyor"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "Gizli bir Şebekege _Bağlan…"
 
-# tr
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "Yönetilmeyen"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Telsiz-Vefa Sıcaqnoqtası"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "Faydalanışsız"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "Bağlanıla"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "Sahihlenim kerekli"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "Bağlanğan"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "Bağlantı qoparıla"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "Bağlantı muvaffaqiyetsiz"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "Status bilinmey (eksik)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "Bağlanmağan"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "Endamlandırış muvaffaqiyetsiz"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "İP endamlandırışı muvaffaqiyetsiz"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "İP endamlandırışı eskirdi"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "PPP hızmeti bağlantısı qoparılğan"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "DHCP müşterisi başlayamadı"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP müşterisi hatası"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP müşterisi muvaffaqiyetsiz edi"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "Üleşilgen bağlantı hızmeti muvaffaqiyetsiz edi"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "AvtoİP hızmeti muvaffaqiyetsiz edi"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "Hat meşğul"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "Modem başlanğıçlandırması muvaffaqiyetsiz edi"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "Belirtilgen APN (İrişim Noqtası İsmi; İNİ) saylanamadı"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "Şebeke qaydı inkâr etildi"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "Bağlantı ğayıp oldı"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "Mevcut bağlantı üstlenildi"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "Modem tapılmadı"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth bağlantısı muvaffaqiyetsiz edi"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "SİM Kartı qıstırılğan degil"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "SİM yañlış"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "Bağlantı bağlılığı muvaffaqiyetsiz edi"
-
-# tr
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "Firmware kayıp"
-
-# tr
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "Kablo takılı değil"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
-msgstr ""
-
-# tr
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "İhmal Et"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.c:261
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-fast.c:277
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-fast.c:399
-msgid "Choose a PAC file..."
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.c:406
-msgid "PAC files (*.pac)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC _dosyesi"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "_Dahiliy sahihlenim"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "Sahihlengen"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _dosyesi"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+#, fuzzy
+msgid "Choose a PAC file"
+msgstr "Bir Cilbent Saylañız"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Dahiliy sahihlenim"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_Qullanıcı adı"
 
 # tr
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Parola"
+
+# tr
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Sır-sözni _köster"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:434
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate..."
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "Sürüm 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "Sürüm 1"
 
 # tr
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "Şehadetname _Salâhiyeti (CA; ŞS) şehadetnamesi"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Sahihlenim kerekli"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:260
-msgid "Unencrypted private keys are insecure"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:263
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:428
-msgid "Choose your personal certificate..."
-msgstr "Şahsiy şehadetnameñizni saylañız..."
-
-#: ../panels/network/wireless-security/eap-method-tls.c:440
-msgid "Choose your private key..."
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Hususiy anahtar sır-sözü"
 
 # tr
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP (Sır-söz Sahihlenim Protokolı; SSP)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP (Mikrosoft Hodrimeydan-Elsıqışma Sahihlenim Protokolı; MSHESP)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP (Hodrimeydan-Elsıqışma Sahihlenim Protokolı; HESP)"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "Meni yañıdan _tenbih etme"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Saha"
 
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr ""
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr ""
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr ""
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "_Sahihlenim"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (Ögbelgilengen)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-# tr
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "Açıq Sistem"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tür"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:39
-msgctxt "notifications"
-msgid "Notifications"
-msgstr "Tebliğler"
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Ögbelgilengen)"
 
 # tr
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:41
-msgctxt "notifications"
-msgid "Sound Alerts"
-msgstr "Davuş İqazları"
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Açıq Sistem"
 
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Popup Banners"
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
 msgstr ""
 
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:44
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "Tasilâtnı Afişlerde Köster"
-
-#: ../panels/notifications/cc-edit-dialog.c:45
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "Kilit Ekranında Seyrettir"
-
-#: ../panels/notifications/cc-edit-dialog.c:46
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "Tasilâtnı Kilit Ekranında Köster"
-
-#: ../panels/notifications/cc-notifications-panel.c:203
-#: ../panels/power/cc-power-panel.c:1637 ../panels/power/cc-power-panel.c:1644
-#: ../panels/privacy/cc-privacy-panel.c:78
-#: ../panels/privacy/cc-privacy-panel.c:145
-msgid "On"
-msgstr "Açıq"
-
-#: ../panels/notifications/cc-notifications-panel.c:203
-#: ../panels/power/cc-power-panel.c:1631 ../panels/power/cc-power-panel.c:1642
-#: ../panels/privacy/cc-privacy-panel.c:78
-#: ../panels/privacy/cc-privacy-panel.c:145
-msgid "Off"
-msgstr "Qapalı"
-
-# tr
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "Tebliğler"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+# tr
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Davuş İqazları"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Tebliğler"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Tebliğler"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Tasilâtnı Kilit Ekranında Köster"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+# tr
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Tebliğler"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr ""
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
 msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "Kilit Ekranında Köster"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "İç _sahihlenim"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:191
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Diger"
-
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:292
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
-msgstr "Hesap Ekle"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:331
-msgid "Mail"
-msgstr "Poşta"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:337
-msgid "Contacts"
-msgstr "Temaslar"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:343
-msgid "Resources"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
 msgstr ""
 
-# tr
-#: ../panels/online-accounts/cc-online-accounts-panel.c:425
-msgid "Error logging into the account"
-msgstr "Hesaba giriş yapılırken hata oluştu"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Credentials have expired."
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:501
-msgid "Sign in to enable this account."
-msgstr "Bu hesapnı qabilleştirmek içün içeri imzalan."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:506
-msgid "_Sign In"
-msgstr "_İçeri İmzalan"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Hesap ekle"
 
 # tr
-#: ../panels/online-accounts/cc-online-accounts-panel.c:747
-msgid "Error creating account"
-msgstr "Hesap oluşturulurken hata meydana geldi"
-
-# tr
-#: ../panels/online-accounts/cc-online-accounts-panel.c:787
-msgid "Error removing account"
-msgstr "Hesap silinirken hata oluştu"
-
-# tr
-#: ../panels/online-accounts/cc-online-accounts-panel.c:823
-msgid "Are you sure you want to remove the account?"
-msgstr "Hesabı silmek istediğinizden emin misiniz?"
-
-# tr
-#: ../panels/online-accounts/cc-online-accounts-panel.c:825
-msgid "This will not remove the account on the server."
-msgstr "Bu işlem, sunucudaki hesabı silmeyecektir."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:826
-msgid "_Remove"
-msgstr "_Çetleştir"
-
-# tr
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Çevrimiçi Hesaplar"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 
 # tr
-#. Translators: those are keywords for the online-accounts control-center panel
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+#, fuzzy
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Devre-içi;Suhbet;Taqvim;Poçta;Temas;"
 "ownCloud;"
 
-# tr
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "Endamlandırılğan devre-içi hesaplar yoq"
-
-# tr
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "Hesabı Kaldır"
-
-# tr
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "Bir devre-içi hesap ekle"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"Bir hesapnıñ eklenmesi uyğulamalarıñızğa onı vesiqalar, poçta, temaslar, "
-"taqvim, suhbet vs. içün oña irişmege imkân berir."
-
-#: ../panels/power/cc-power-panel.c:184
-msgid "Unknown time"
-msgstr "Bilinmegen vaqıt"
-
-#: ../panels/power/cc-power-panel.c:190
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i daqqa"
 
-#: ../panels/power/cc-power-panel.c:202
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i saat"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:210
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 # tr
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "saat"
 
-#: ../panels/power/cc-power-panel.c:212
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "daqqa"
 
-# tr
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:231
-#, c-format
-msgid "%s until fully charged"
-msgstr "Tamamen tolmasına qadar %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:238
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "İhtiyat: %s qala"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:243
-#, c-format
-msgid "%s remaining"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:248 ../panels/power/cc-power-panel.c:276
-msgid "Fully charged"
-msgstr "Tamamen yükletilgen"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:252 ../panels/power/cc-power-panel.c:280
-msgid "Empty"
-msgstr "Boş"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 daqqa"
 
 # tr
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:267
-msgid "Charging"
-msgstr "Doluyor"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 dakika"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:272
-msgid "Discharging"
-msgstr "Yüksüzlene"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 daqqa"
 
-#: ../panels/power/cc-power-panel.c:324
-#, c-format
-msgid "Estimated battery capacity: %s"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 daqqa"
 
-#: ../panels/power/cc-power-panel.c:404
-msgctxt "Battery name"
-msgid "Main"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 daqqa"
 
-#: ../panels/power/cc-power-panel.c:406
-msgctxt "Battery name"
-msgid "Extra"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 saat"
 
-# tr
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:493
-msgid "Wireless mouse"
-msgstr "Kablosuz fare"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 daqqa"
 
-# tr
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:497
-msgid "Wireless keyboard"
-msgstr "Kablosuz klavye"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 daqqa"
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:501
-msgid "Uninterruptible power supply"
-msgstr "Kesintisiz qudret arzı"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 daqqa"
 
-# tr
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:506
-msgid "Personal digital assistant"
-msgstr "Kişisel dijital yardımcı"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 saat"
 
-# tr
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:510
-msgid "Cellphone"
-msgstr "Cep telefonu"
-
-# tr
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:514
-msgid "Media player"
-msgstr "Ortam yürütücüsü"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:518
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:522
-msgid "Computer"
-msgstr "Bilgisayar"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:526 ../panels/power/cc-power-panel.c:734
-#: ../panels/power/cc-power-panel.c:1938
+#: panels/power/cc-power-panel.ui:58
 msgid "Battery"
 msgstr "Pil"
 
-# tüklü
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:535
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Yükletile"
-
-# tr
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:542
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "İhtiyat"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Tüşük"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Eyi"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Tam yükletilgen"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:561
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Boş"
-
-#: ../panels/power/cc-power-panel.c:732
-msgid "Batteries"
-msgstr "Piller"
-
-#: ../panels/power/cc-power-panel.c:1074
-msgid "When _idle"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1401
-msgid "Power Saving"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1430
-msgid "_Screen Brightness"
-msgstr "_Ekran Parlaqlığı"
-
-# tüklü
-#: ../panels/power/cc-power-panel.c:1458
-msgid "_Dim Screen when Inactive"
-msgstr "Ğayrıfaal olğanda Ekrannı _Sönükleştir"
-
-#: ../panels/power/cc-power-panel.c:1481
-msgid "_Blank Screen"
-msgstr "_Boş Ekran"
-
-#: ../panels/power/cc-power-panel.c:1516
-msgid "_Wi-Fi"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1521
-msgid "Turns off wireless devices"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1544
-msgid "_Mobile Broadband"
-msgstr "_Mobil Kenişbant"
-
-#: ../panels/power/cc-power-panel.c:1549
-msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1582
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: ../panels/power/cc-power-panel.c:1633
-msgid "When on battery power"
-msgstr "Pil qudretinde olğanda"
-
-# tr
-#: ../panels/power/cc-power-panel.c:1635
-msgid "When plugged in"
-msgstr "Fişe takıldığıında"
-
-#: ../panels/power/cc-power-panel.c:1762
-msgid "Suspend & Power Off"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1793
-msgid "_Automatic Suspend"
-msgstr "_Avtomatik Sarqıtım"
-
-#: ../panels/power/cc-power-panel.c:1815
-msgid "When Battery Power is _Critical"
-msgstr "Pil Qudreti _Kritik Olğanda"
-
-#: ../panels/power/cc-power-panel.c:1848
-msgid "Power Off"
-msgstr "Söndür"
-
-#: ../panels/power/cc-power-panel.c:1990
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
 msgid "Devices"
 msgstr "Cihazlar"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+# tr
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Kapat"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "İçeri İmzalanma Seçenekleri"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "_Ekran Parlaqlığı"
+
+# tr
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Ekran parlaklığı ve kilitleme ayarları"
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Ekran"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Ekran Kiliti"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Avtomatik Rotalar"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Avtomatik Sarqıtım"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+# tüklü
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Alt Dögme"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Avtomatik Sarqıtım"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Rozetke Tıqılğan"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "_Pil Qudretinde"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Keçikme"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Qudret"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+#: panels/power/gnome-power-panel.desktop.in.in:4
 msgid "View your battery status and change power saving settings"
 msgstr ""
 
 # tüklü
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "Qudret;Yuqu;Sarqıt;Yuqlat;Pil;Parlaqlıq;Sönükleştir;Boş;Monitor;DPMS;Atıl;"
 
-# tr
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "Derin Uyku"
-
-# tr
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "Kapat"
-
-#: ../panels/power/power.ui.h:5
-msgid "45 minutes"
-msgstr "45 daqqa"
-
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
-msgid "1 hour"
-msgstr "1 saat"
-
-#: ../panels/power/power.ui.h:7
-msgid "80 minutes"
-msgstr "80 daqqa"
-
-#: ../panels/power/power.ui.h:8
-msgid "90 minutes"
-msgstr "90 daqqa"
-
-#: ../panels/power/power.ui.h:9
-msgid "100 minutes"
-msgstr "100 daqqa"
-
-#: ../panels/power/power.ui.h:10
-msgid "2 hours"
-msgstr "2 saat"
-
-# tr
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 dakika"
-
-# tr
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 dakika"
-
-# tr
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 dakika"
-
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "4 daqqa"
-
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 daqqa"
-
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "8 daqqa"
-
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 daqqa"
-
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "12 daqqa"
-
-#: ../panels/power/power.ui.h:20
-msgid "Automatic Suspend"
-msgstr "Avtomatik Sarqıtım"
-
-#: ../panels/power/power.ui.h:21 ../panels/privacy/privacy.ui.h:10
-msgid "_Close"
-msgstr "_Qapat"
-
-#: ../panels/power/power.ui.h:22
-msgid "_Plugged In"
-msgstr "_Rozetke Tıqılğan"
-
-#: ../panels/power/power.ui.h:23
-msgid "On _Battery Power"
-msgstr "_Pil Qudretinde"
-
-#: ../panels/power/power.ui.h:24
-msgid "Delay"
-msgstr "Keçikme"
-
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "Sahihlen"
-
-# tr
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Password"
-msgstr "Sır-söz"
-
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "Sahihlenim Şart"
-
-# tr
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:591
-msgid "Low on toner"
-msgstr "Toner düşük seviyede"
-
-# tr
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:593
-msgid "Out of toner"
-msgstr "Toner tükendi"
-
-# tr
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:596
-msgid "Low on developer"
-msgstr "Film banyo kimyasalı az"
-
-# tr
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:599
-msgid "Out of developer"
-msgstr "Film banyo kimyasalı bitti"
-
-# tr
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:601
-msgid "Low on a marker supply"
-msgstr "Renk kartuşu az"
-
-# tr
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:603
-msgid "Out of a marker supply"
-msgstr "Renk kartuşu bitti"
-
-# tr
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:605
-msgid "Open cover"
-msgstr "Kapak açık"
-
-# tr
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:607
-msgid "Open door"
-msgstr "Kapı açık"
-
-# tr
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:609
-msgid "Low on paper"
-msgstr "Kağıt az"
-
-# tr
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:611
-msgid "Out of paper"
-msgstr "Kağıt bitti"
-
-# tr
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:613
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Kapalı"
-
-# tr
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:615
-#: ../panels/printers/cc-printers-panel.c:806
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Durduruldu"
-
-# tr
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:617
-msgid "Waste receptacle almost full"
-msgstr "Atık kutusu neredeyse dolu"
-
-# tr
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:619
-msgid "Waste receptacle full"
-msgstr "Atık kutusu dolu"
-
-# tr
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:621
-msgid "The optical photo conductor is near end of life"
-msgstr "Baskı silindiri ömrünü doldurmak üzere"
-
-# tr
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:623
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Baskı silindiri artık çalışmıyor"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:733
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "Endamlandırıla"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:792
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Hazır"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:797
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr ""
-
-# tr
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:802
-msgctxt "printer state"
-msgid "Processing"
-msgstr "İşleniyor"
-
-# tr
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:923
-msgid "Toner Level"
-msgstr "Toner Seviyesi"
-
-# tr
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:926
-msgid "Ink Level"
-msgstr "Mürekkep Seviyesi"
-
-# tr
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:929
-msgid "Supply Level"
-msgstr "Malzeme Seviyesi"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:947
-msgctxt "printer state"
-msgid "Installing"
-msgstr "Qurula"
-
-# tr
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1124
-msgid "No printers available"
-msgstr "Mevcut yazıcı bulunmuyor"
-
-# tr
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1432
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u etkin"
-
-# tr
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1776
-msgid "Failed to add new printer."
-msgstr "Yeni yazıcı eklenemedi."
-
-# tr
-#: ../panels/printers/cc-printers-panel.c:1943
-msgid "Select PPD File"
-msgstr "PPD Dosyesini Sayla"
-
-#: ../panels/printers/cc-printers-panel.c:1952
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2257
-msgid "No suitable driver found"
-msgstr "Kelişikli sürüci tapılamadı"
-
-#: ../panels/printers/cc-printers-panel.c:2326
-msgid "Searching for preferred drivers…"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2341
-msgid "Select from database…"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2350
-msgid "Provide PPD File…"
-msgstr "PPD Dosyesini Temin Et…"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2501
-#: ../panels/printers/cc-printers-panel.c:2524
-msgid "Test page"
-msgstr "Deñeme sahifesi"
-
-# tr
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2932
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Arayüz yüklenemedi: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "Bastırıcılar"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
 # tr
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Yazıcı;Kuyruk;Yazdur;Kâğıt;Mürekkep;Toner;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "Faal İşler"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-#: ../panels/user-accounts/data/history-dialog.ui.h:2
-msgid "Close"
-msgstr "Qapat"
-
 # tr
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "Yazdırmayı Devam Ettir"
-
-# tr
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "Yazdırmayı Duraklat"
-
-# tr
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "Yazdırma İşini İptal Et"
-
-# tr
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "Yeni Yazıcı Ekle"
-
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/user-accounts/um-user-panel.c:467
-msgid "_Cancel"
-msgstr "_Vazgeç"
-
-# tr
-#: ../panels/printers/new-printer-dialog.ui.h:4
-msgid "Search for network printers or filter result"
-msgstr "Şebeke bastırıcıları içün qıdır yaki neticelerni süzgüçle"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "Yükleme seçenekleri…"
-
-# tüklü
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "Bastırıcı Sürücisini Saylañız"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:67
-#: ../panels/printers/pp-ppd-option-widget.c:71
-msgid "One Sided"
-msgstr "Tek Yanlı"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:69
-#: ../panels/printers/pp-ppd-option-widget.c:73
-msgid "Long Edge (Standard)"
-msgstr "Uzun Ağız (Standart)"
-
-# tüklü
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:71
-#: ../panels/printers/pp-ppd-option-widget.c:75
-msgid "Short Edge (Flip)"
-msgstr "Qısqa Ağız (Aylandır)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:73
-msgid "Portrait"
-msgstr "Portret"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:75
-msgid "Landscape"
-msgstr "Manzara"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:77
-msgid "Reverse landscape"
-msgstr "Ters manzara"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:79
-msgid "Reverse portrait"
-msgstr "Ters portret"
-
-# tr
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:143
-msgctxt "print job"
-msgid "Pending"
-msgstr "Sırada"
-
-# tr
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:147
-msgctxt "print job"
-msgid "Held"
-msgstr "Bekliyor"
-
-# tr
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:151
-msgctxt "print job"
-msgid "Processing"
-msgstr "İşleniyor"
-
-# tr
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:155
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Durduruldu"
-
-# tr
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:159
-msgctxt "print job"
-msgid "Canceled"
-msgstr "İptal edildi"
-
-# tr
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:163
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Hata nedeniyle iptal edildi"
-
-# tr
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:167
-msgctxt "print job"
-msgid "Completed"
-msgstr "Tamamlandı"
-
-# tr
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:289
-msgid "Job Title"
-msgstr "İş Adı"
-
-# tr
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:298
-msgid "Job State"
-msgstr "İş Durumu"
-
-# tr
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:304
-msgid "Time"
-msgstr "Zaman"
-
-# tr
-#: ../panels/printers/pp-jobs-dialog.c:496
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s Faal İş"
-
-# tr
-#. Translators: No printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1468
-msgid "No printers detected."
-msgstr "Alğılanğan bastırıcılar yoq."
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Two Sided"
-msgstr "Eki Yanlı"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Type"
-msgstr "Kâğıt Türü"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Paper Source"
-msgstr "Kâğıt Qaynağı"
-
-# tr
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Output Tray"
-msgstr "Çıqtı Sinisi"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "Resolution"
-msgstr "Çezinirlik"
-
-#: ../panels/printers/pp-options-dialog.c:87
-msgid "GhostScript pre-filtering"
-msgstr ""
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:532
-msgid "Pages per side"
-msgstr "Yan başına sahife sayısı"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:544
-msgid "Two-sided"
-msgstr "Eki-yanlı"
-
-# tr
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:556
-msgid "Orientation"
-msgstr "Yöneldirim"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Umumiy"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Sahife Ayarlaması"
-
-# tr
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Qurulabilir Seçenekler"
-
-# tr
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:662
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "İş"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:665
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Suret Keyfiyeti"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:668
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Tüs"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:671
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Bitirile"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:674
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "İleriletilgen"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:77
-#: ../panels/printers/pp-ppd-option-widget.c:79
-#: ../panels/printers/pp-ppd-option-widget.c:87
-msgid "Auto Select"
-msgstr "Avto Sayla"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:81
-#: ../panels/printers/pp-ppd-option-widget.c:83
-#: ../panels/printers/pp-ppd-option-widget.c:85
-#: ../panels/printers/pp-ppd-option-widget.c:89
-msgid "Printer Default"
-msgstr "Bastırıcı Ögbelgilemesi"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:91
-msgid "Embed GhostScript fonts only"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 1"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:95
-msgid "Convert to PS level 2"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:97
-msgid "No pre-filtering"
-msgstr "Ög-süzgüçleme yoq"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "İmalâtçı"
-
-# tüklü
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "Sürüci"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:247
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-
-# tr
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Yazıcı Ekle"
 
-# tr
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "Yazıcıyı Kaldır"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "Kilidi Aç"
 
 # tr
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "Malzeme"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Tapılğan bölgeler yoq"
 
-# tr
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
-msgid "Location"
-msgstr "Konum"
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
 
-# tr
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default"
-msgstr "_Öntanımlı"
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Sahihlenim Şart"
 
-# tr
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "İşler"
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Qullanıcı Adı"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
 
 # tr
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Konum"
+
+# tüklü
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Sürüci"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+# tüklü
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "Bastırıcı Sürücisini Saylañız"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Yañartmalarnı Qur"
+
+# tüklü
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Bastırıcı Sürücisini Saylañız"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Vazgeç"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Sayla"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "İç _sahihlenim"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "_Saha"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "Sahihlen"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Sahihlen"
+
+# tr
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "Etkin Yazdırma İşleri"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Deñeme sahifesi"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "İçeri İmzalanma Seçenekleri"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Bastırıcı Ögbelgilemesi"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Bastırıcı Ögbelgilemesi"
+
+# tr
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "Yazdırma İşini İptal Et"
+
+# tr
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Yazıcıyı Kaldır"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Faal İşler"
+
+# tr
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "etiket"
-
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "Yañı sürüci tesbit etile…"
-
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "sahife 3"
+# tr
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Mürekkep Seviyesi"
 
 # tr
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "_Sınama Sayfası Yazdır"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Lütfen AccountService' in kurulu ve etkin olduğundan emin olun."
 
-# tr
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "_Seçenekler"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "Başlat"
 
 # tr
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "Yeni Yazıcı Ekle"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Yazıcı Ekle"
+
+# tr
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Yazıcı ayarlarını değiştir"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Bastırıcılar"
 
 # tr
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Üzgünüm! Sistemin yazdırma hizmeti\n"
 "kullanılamıyor."
 
-#: ../panels/privacy/cc-privacy-panel.c:105
-msgid "Hidden"
-msgstr "Gizli"
-
-#: ../panels/privacy/cc-privacy-panel.c:105
-msgid "Visible"
-msgstr "Körünir"
-
-#: ../panels/privacy/cc-privacy-panel.c:271 ../panels/privacy/privacy.ui.h:31
-msgid "Screen Lock"
-msgstr "Ekran Kiliti"
-
-#: ../panels/privacy/cc-privacy-panel.c:338 ../panels/privacy/privacy.ui.h:9
-msgid "Name & Visibility"
-msgstr "İsim & Körünirlik"
-
-#: ../panels/privacy/cc-privacy-panel.c:446 ../panels/privacy/privacy.ui.h:26
-msgid "Usage & History"
-msgstr ""
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-msgid "Purge Trash & Temporary Files"
-msgstr ""
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr ""
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "Ekran Söndürilgenden Soñ"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 saniye"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "Control how you appear on the screen and the network."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "Display _full name in top bar"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "Display full name in _lock screen"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "_Stealth Mode"
-msgstr "_Gizlilik Tarzı"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "Immediately"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "1 day"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "2 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "3 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:19
-msgid "4 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid "5 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "6 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "7 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "14 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:24
-msgid "30 days"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "Forever"
-msgstr "İlelebet"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Cl_ear Recent History"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:29
-msgid "_Recently Used"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid "Retain _History"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr ""
-
-# tr
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Automatic Screen _Lock"
-msgstr "Avtomatik Ekran _Kiliti"
-
-# tr
-#: ../panels/privacy/privacy.ui.h:34
-msgid "Lock screen _after blank for"
-msgstr "Şu süre qadar boş olğandan soñ ekrannı _kilitle"
-
-#: ../panels/privacy/privacy.ui.h:35
-msgid "Show _Notifications"
-msgstr "_Tebliğlerni Köster"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid "_Empty Trash"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:38
-msgid "_Purge Temporary Files"
-msgstr "Muvaqqat Dosyelerni _İzale Et"
-
-#: ../panels/privacy/privacy.ui.h:39
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "Automatically empty _Trash"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:41
-msgid "Automatically purge Temporary _Files"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:42
-msgid "Purge _After"
-msgstr ""
-
-#: ../panels/region/cc-format-chooser.c:122
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "İngliz ölçüler"
-
-#: ../panels/region/cc-format-chooser.c:124
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrik"
-
-# tr
-#: ../panels/region/cc-format-chooser.c:283
-msgid "No regions found"
-msgstr "Tapılğan bölgeler yoq"
-
-# tr
-#: ../panels/region/cc-input-chooser.c:188
-msgid "No input sources found"
-msgstr "Tapılğan kirdi menbaları yoq"
-
-#: ../panels/region/cc-input-chooser.c:1091
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Diger"
-
-#: ../panels/region/cc-region-panel.c:240
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:241
-msgid "Restart Now"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:566
-msgctxt "Language"
-msgid "None"
-msgstr "Hiç biri"
-
-#: ../panels/region/cc-region-panel.c:1058
-msgid "Sorry"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:1060
-msgid "Input methods can't be used on the login screen"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:1509
-msgid "No input source selected"
-msgstr "Saylanğan kirdi menbası yoq"
-
-#: ../panels/region/cc-region-panel.c:1690
-msgid "Login Screen"
-msgstr "İçeri İmzalanım Ekranı"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formatlar"
 
-#: ../panels/region/format-chooser.ui.h:3
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Qonumlarnı Qıdır"
+
+# tüklü
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Umumiy Vazifeler"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Formatlar"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Ögbaqış"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Tarihler"
 
-# tr
-#: ../panels/region/format-chooser.ui.h:5
-msgid "Times"
-msgstr "Defa"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Tarih & Saat"
 
-#: ../panels/region/format-chooser.ui.h:6
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Sayılar"
 
 # tr
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Ölçüm"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Kâğıt"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Tillerni qur..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Hesabım"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Til"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "Formatlar"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "İçeri İmzalanım Ekranı"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Bölge & Til"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
 msgstr ""
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Til;Tizilim;Klavye;Kirdi;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "Bir Kirdi Menbası Ekle"
+# tr
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Ortamın nasıl kullanılacağını seçin"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "Kirdi Menbası Seçenekleri"
+# tr
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _sesi"
 
-#: ../panels/region/input-options.ui.h:2
-msgid "Use the _same source for all windows"
-msgstr "Bütün pencereler içün _aynı menbani qullan"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD videosı"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Allow _different sources for each window"
-msgstr "Her pencere içün _farqlı menbalarğa izin ber"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Musıqi çalar"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Keyboard Shortcuts"
-msgstr "Klavye Qısqayolları"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Yazılım"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Switch to previous source"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Diger Vasatlar…"
+
+# tr
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Asla bir uygulama çalıştırma ya da sorma..."
+
+# tr
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Diğer ortamların nasıl kullanılacağını seçin"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Amel:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tür:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Çetleştirilebilir Vasat"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Bluetooth ayarlarını endamlandır"
+
+# tüklü
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"cihaz;sistem;malümat;hafiza;işlemci;sürüm;ögbelgilengen;uyğulama;tercihli;cd;"
+"dvd;usb;davuş;video;disk;çetleştirilebilir;vasat;avtoçaptır;"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Ekran Kiliti"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Super+Shift+Space"
-msgstr ""
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "_Boş Ekran"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Switch to next source"
-msgstr "Soñraki menbağa almaştır"
-
-#: ../panels/region/input-options.ui.h:8
-msgid "Super+Space"
-msgstr ""
-
-#: ../panels/region/input-options.ui.h:9
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr ""
-
-#: ../panels/region/input-options.ui.h:10
-msgid "Alternative switch to next source"
-msgstr ""
-
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr ""
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
 msgstr ""
 
 # tr
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "Seçenekler"
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Avtomatik Ekran _Kiliti"
 
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
+# tr
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "Avtomatik Ekran _Kiliti"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
 msgstr ""
 
-#: ../panels/search/cc-search-locations-dialog.c:276
-msgid "Home"
-msgstr "Ev"
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Tasilâtnı Kilit Ekranında Köster"
 
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Ekrannı kilitle"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+# tr
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Ekran Üleşimi"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Ayarlarnı Kopiyala"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Qonumlarnı Qıdır"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr ""
 
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr ""
 
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Diger"
 
-#: ../panels/search/cc-search-locations-dialog.c:676
-msgid "Select Location"
-msgstr "Qonum Saylañız"
+# tr
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Konum"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Uyğulama Menüsi"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
 # tr
-#: ../panels/search/cc-search-panel.c:182
-msgid "No applications found"
-msgstr "Tapılğan uyğulamalar yoq"
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "_Adrese göre Ara"
 
-# tr
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "Qıdır"
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr "Qonumlarnı Qıdır"
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Şebeke"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "Yuqarı Avuştır"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "Aşağı Avuştır"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "Tercihler"
-
-#: ../panels/sharing/cc-sharing-panel.c:259
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Açıq"
-
-# tüklü
-#: ../panels/sharing/cc-sharing-panel.c:261
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Qapalı"
-
-#: ../panels/sharing/cc-sharing-panel.c:407
-msgid "Choose a Folder"
-msgstr "Bir Cilbent Saylañız"
-
-#: ../panels/sharing/cc-sharing-panel.c:585
-msgid "Copy"
-msgstr "Kopiyala"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Üleşim"
 
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr ""
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
-msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
-msgstr ""
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "Uzaqtan içeri imzalanmanı qabilleştir yaki ğayrıqabilleştir"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "Uzaqtan içeri imzalanmanı qabilleştirmek içün sahihlenim şarttır"
-
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "Bluetooth Üleşimi"
-
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Share Public Folder"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Only Receive From Trusted Devices"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Save Received Files to Downloads Folder"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Only share with Trusted Devices"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "Bilgisayar İsmi"
 
-#: ../panels/sharing/sharing.ui.h:8
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Şahsiy Dosye Üleşimi"
+
+# tr
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Masaüstü"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "Vasat Üleşimi"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "Uzaqtan İçeri İmzalanım"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Üleşim"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "Sır-söz Şart Olsun"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "Uzaqtan İçeri İmzalanım"
 
-#: ../panels/sharing/sharing.ui.h:9
-msgid "Some services are disabled because of no network access."
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Media Sharing"
-msgstr "Vasat Üleşimi"
-
-#: ../panels/sharing/sharing.ui.h:11
-msgid "Share Music, Photos and Videos with others on the current network."
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:12
-msgid "Share Media On This Network"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Shared Folders"
-msgstr "Üleşilgen Cilbentler"
-
-#: ../panels/sharing/sharing.ui.h:14
-msgid "column"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:15
-msgid "Add Folder"
-msgstr "Cilbent Ekle"
-
 # tr
-#: ../panels/sharing/sharing.ui.h:16
-msgid "Remove Folder"
-msgstr "Cilbentni Çetleştir"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Masaüstü"
 
-#: ../panels/sharing/sharing.ui.h:17
-msgid "Personal File Sharing"
-msgstr "Şahsiy Dosye Üleşimi"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Share Public Folder On This Network"
-msgstr ""
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Uzaqtan içeri imzalanmanı qabilleştir yaki ğayrıqabilleştir"
 
-#: ../panels/sharing/sharing.ui.h:21
-msgid "Require Password"
-msgstr "Sır-söz Şart Olsun"
-
-#: ../panels/sharing/sharing.ui.h:24
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-
-# tr
-#: ../panels/sharing/sharing.ui.h:26
-msgid "Screen Sharing"
-msgstr "Ekran Üleşimi"
-
-#: ../panels/sharing/sharing.ui.h:28
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-
-# tüklü
-#: ../panels/sharing/sharing.ui.h:29
-msgid "Remote View"
-msgstr "Uzaqtan Seyir"
-
-#: ../panels/sharing/sharing.ui.h:30
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "Uzaqtan Kontrol"
 
-#: ../panels/sharing/sharing.ui.h:31
-msgid "Approve All Connections"
-msgstr "Bağlantılarnıñ Hepsini Tasvip Et"
-
-#: ../panels/sharing/sharing.ui.h:32
-msgid "Show Password"
-msgstr "Sır-sözni Köster"
-
-# tr
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "Davuş"
-
-# tr
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
 msgstr ""
-"Davuş seviyelerini, kirdilerni, çıqtılarnı ve iqaz davuşlarını deñiştir"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "Kart;Mikrofon;Gürlük;Solma;Muvazenet;Bluetooth;Baş-Seti;Davuş;"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Bağlanmağan"
 
-# tr
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "Havlama"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-# tr
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "Damlama"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopiyala"
 
-# tr
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "Cam"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Adresni Sil"
 
-# tr
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "Sonar"
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Sahihlenim"
 
-# tr
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Left"
-msgstr "Sol"
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
 
-# tr
-#: ../panels/sound/gvc-balance-bar.c:107
-msgctxt "balance"
-msgid "Right"
-msgstr "Sağ"
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Qullanıcı Adı"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
 
 # tr
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Parmak izleri kaydediliyor"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Vasat Üleşimi"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+#, fuzzy
+msgid "Folders"
+msgstr "Cilbent Ekle"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Uzaqtan içeri imzalanmanı qabilleştir yaki ğayrıqabilleştir"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Uzaqtan içeri imzalanmanı qabilleştirmek içün sahihlenim şarttır"
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Üleşim"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+# tr
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Denge:"
+
+# tr
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Kaybolma:"
+
+# tr
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Arka"
 
 # tr
-#: ../panels/sound/gvc-balance-bar.c:111
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Ön"
 
-# tr
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Minimum"
-msgstr "En Az"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
 # tr
-#: ../panels/sound/gvc-balance-bar.c:115
-msgctxt "balance"
-msgid "Maximum"
-msgstr "En Çok"
-
-# tr
-#: ../panels/sound/gvc-balance-bar.c:290
-msgid "_Balance:"
-msgstr "_Denge:"
-
-# tr
-#: ../panels/sound/gvc-balance-bar.c:293
-msgid "_Fade:"
-msgstr "_Kaybolma:"
-
-# tr
-#: ../panels/sound/gvc-balance-bar.c:296
-msgid "_Subwoofer:"
-msgstr "_Subwoofer:"
-
-# tr
-#: ../panels/sound/gvc-channel-bar.c:613 ../panels/sound/gvc-channel-bar.c:622
-msgctxt "volume"
-msgid "100%"
-msgstr "%100"
-
-# tr
-#: ../panels/sound/gvc-channel-bar.c:617
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Yükseltilmemiş"
-
-#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "_Profil:"
-
-# tr
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u Çıkış"
-
-# tr
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u Giriş"
-
-# tr
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "Sistem Sesleri"
 
 # tr
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "Hoparlörleri _Sına"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "_Uyarı ses düzeyi:"
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Davuşsızlandır"
 
 # tr
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "Tepe algılama"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1508
-#: ../panels/sound/gvc-sound-theme-chooser.c:595
-msgid "Name"
-msgstr "İsim"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1527
-msgid "Device"
-msgstr "Cihaz"
-
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1590
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s için Hoparlör Sınaması"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1644
-msgid "_Output volume:"
-msgstr "_Çıqtı gürlügi:"
-
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1658
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Çıktı"
 
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1663
-msgid "C_hoose a device for sound output:"
-msgstr "Ses çıkışı için aygıt _seçin:"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "_Çıqtı gürlügi:"
 
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1688
-msgid "Settings for the selected device:"
-msgstr "Seçili aygıt ayarları:"
-
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1699
-msgid "Input"
-msgstr "Giriş"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1706
-msgid "_Input volume:"
-msgstr "_Kirdi gürlügi:"
-
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1729
-msgid "Input level:"
-msgstr "Giriş seviyesi:"
-
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1757
-msgid "C_hoose a device for sound input:"
-msgstr "Ses girişi için aygıt _seçin:"
-
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1784
-msgid "Sound Effects"
-msgstr "Ses Efektleri"
-
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1791
-msgid "_Alert volume:"
-msgstr "_Uyarı ses düzeyi:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1804
-msgid "Applications"
-msgstr "Uyğulamalar"
-
-# tr
-#: ../panels/sound/gvc-mixer-dialog.c:1808
-msgid "No application is currently playing or recording audio."
-msgstr "Herhangi bir uygulama ses kaydı ya da yürütmesi yapmıyor."
-
-# tr
-#: ../panels/sound/gvc-sound-theme-chooser.c:189
-msgid "Built-in"
-msgstr "Dahili"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:455
-#: ../panels/sound/gvc-sound-theme-chooser.c:467
-#: ../panels/sound/gvc-sound-theme-chooser.c:479
-msgid "Sound Preferences"
-msgstr "Davuş Tercihleri"
-
-# tr
-#: ../panels/sound/gvc-sound-theme-chooser.c:458
-#: ../panels/sound/gvc-sound-theme-chooser.c:469
-#: ../panels/sound/gvc-sound-theme-chooser.c:481
-msgid "Testing event sound"
-msgstr "Olay sesi deneniyor"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "Default"
-msgstr "Ögbelgilengen"
-
-# tr
-#: ../panels/sound/gvc-sound-theme-chooser.c:586
-msgid "From theme"
-msgstr "Temadan"
-
-# tr
-#: ../panels/sound/gvc-sound-theme-chooser.c:770
-msgid "C_hoose an alert sound:"
-msgstr "Uyarı sesi se_çin:"
-
-#: ../panels/sound/gvc-speaker-test.c:220
-msgid "Stop"
-msgstr "Toqta"
-
-#: ../panels/sound/gvc-speaker-test.c:220
-#: ../panels/sound/gvc-speaker-test.c:332
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Sına"
 
 # tr
-#: ../panels/sound/gvc-speaker-test.c:228
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "_Yapılandırma URL'si"
+
+# tr
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
 # tr
-#: ../panels/sound/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr "Özel"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Giriş"
 
 # tr
-#: ../panels/universal-access/cc-ua-panel.c:281
-#: ../panels/universal-access/cc-ua-panel.c:287
-msgid "No shortcut set"
-msgstr "Kısayol belirlenmemiş"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Giriş seviyesi:"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Davuş gürlügi yuqarı"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Sınama Sesi"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Sessiz"
+
+# tr
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Davuş"
+
+# tr
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
+"Davuş seviyelerini, kirdilerni, çıqtılarnı ve iqaz davuşlarını deñiştir"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
-"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "Kart;Mikrofon;Gürlük;Solma;Muvazenet;Bluetooth;Baş-Seti;Davuş;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+
+# tr
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Tebliğler"
+
+# tr
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "İ_sim:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"Klavye;Sıçan;i15k;İrişilebilirlik;Tezat;Miqyas;Ekran Oquyıcı;metin;hurufat;"
-"ölçü;İrişimX;Yapışaq Tuşlar;Yavaş Tuşlar;Sıçrama Tuşları;Sıçan Tuşları;"
 
-#: ../panels/universal-access/uap.ui.h:1
-#: ../panels/universal-access/zoom-options.ui.h:35
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "Tüşük"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgctxt "universal access, contrast"
-msgid "Normal"
-msgstr "Normal"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "Avtomatik _Bağlan"
 
-#: ../panels/universal-access/uap.ui.h:3
-#: ../panels/universal-access/zoom-options.ui.h:36
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "Yüksek"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Cihaznı Çetleştir"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgctxt "universal access, contrast"
-msgid "High/Inverse"
-msgstr "Yüksek/Ters"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:5
-msgid "On screen keyboard"
-msgstr "Ekran-üstü klavye"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s sahasına bağlanılamadı: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Cihanşümul İrişim"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
 # tr
-#: ../panels/universal-access/uap.ui.h:6
-msgid "GOK"
-msgstr "GOK"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Aygıtlar aranıyor..."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
 # tr
-#: ../panels/universal-access/uap.ui.h:7
-msgid "OnBoard"
-msgstr "Dahili"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
 
-#: ../panels/universal-access/uap.ui.h:10
-#, no-c-format
-msgid "75%"
-msgstr "%75"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:11
-msgctxt "universal access, text size"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "İmleç Qıpması"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Metin alanlarında imleç _qıpar"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Hız"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "İmleç qıpması sür'atı"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "İmleç qıpması sür'atı"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Ekilemci Çertmeni Taqlit Etüv"
+
+# tr
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "İlk düğme basılı tutulduğunda ikincil tıklama tetikle"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Q_abul keçikmesi:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Qısqa"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Ekilemci çertme keçikmesi"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Uzun"
+
+# tr
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "Durağan Tıklama"
+
+# tr
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Belirteç nesne üstüne geldiğinde tıklama yap"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Keçikme:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Qısqa"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Uzun"
+
+# tr
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Hareket _eşiği:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Küçük"
 
-#: ../panels/universal-access/uap.ui.h:13
-#, no-c-format
-msgid "100%"
-msgstr "%100"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgctxt "universal access, text size"
-msgid "Normal"
-msgstr "Normal"
-
-#: ../panels/universal-access/uap.ui.h:16
-#, no-c-format
-msgid "125%"
-msgstr "%125"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgctxt "universal access, text size"
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Balaban"
 
-#: ../panels/universal-access/uap.ui.h:19
-#, no-c-format
-msgid "150%"
-msgstr "%150"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgctxt "universal access, text size"
-msgid "Larger"
-msgstr "Daha Balaban"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "High Contrast"
-msgstr "Yüksek Tezat"
-
 # tüklü
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Beep on Caps and Num Lock"
-msgstr "Caps ve Num Lock üzerine biple"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Tekrarlama Tuşları"
 
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Screen Reader"
-msgstr "Ekran Oquyıcı"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Tuş basıq tutulğanda klavye basmaları _tekrarlanır"
 
-# tr
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Turn on or off:"
-msgstr "Aç ya da kapat:"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Terkrarlama tuşları sur'atı"
 
-#: ../panels/universal-access/uap.ui.h:26
-msgctxt "universal access, zoom"
-msgid "Zoom"
-msgstr "Miqyasla"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Terkrarlama tuşları sur'atı"
 
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Zoom in:"
-msgstr "Yaqınlaştır:"
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Tuşlama Muavini"
 
-#: ../panels/universal-access/uap.ui.h:28
-msgid "Zoom out:"
-msgstr "Uzaqlaştır:"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Large Text"
-msgstr "Büyük Metin"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "Seeing"
-msgstr "Körüş"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Visual Alerts"
-msgstr "Körsel İqazlar"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Use a visual indication when an alert sound occurs"
-msgstr "Uyarı sesi çalındığında görsel uyarı kullan"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Flash the window title"
-msgstr "Pencere başlığı yanıp sönsün"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Flash the entire screen"
-msgstr "Tüm ekran yanıp sönsün"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:35
-msgid "Closed Captioning"
-msgstr "Gizli Altyazı"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Display a textual description of speech and sounds"
-msgstr "Konuşma ve sesler için yazılı açıklama göster"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:37
-msgid "_Test flash"
-msgstr "_Flaşı sına"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Hearing"
-msgstr "İşitme"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "On Screen Keyboard"
-msgstr "Ekran Üzeri Klavye"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "Sticky Keys"
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
 msgstr "Yapışaq Tuşlar"
 
 # tr
-#: ../panels/universal-access/uap.ui.h:42
+#: panels/universal-access/cc-typing-dialog.ui:51
 msgid "Treats a sequence of modifier keys as a key combination"
 msgstr "Bir dizi değiştirici tuşu kombinasyon olarak kabul eder"
 
 # tr
-#: ../panels/universal-access/uap.ui.h:43
+#: panels/universal-access/cc-typing-dialog.ui:63
 msgid "_Disable if two keys are pressed together"
 msgstr "İki tuşa birden basıldığında _devre dışı bırak"
 
 # tr
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Beep when a _modifer key is pressed"
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
 msgstr "_Değiştirici tuşa basıldığında biple"
 
-#: ../panels/universal-access/uap.ui.h:45
-msgid "Slow Keys"
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
 msgstr "Yavaş Tuşlar"
 
 # tr
-#: ../panels/universal-access/uap.ui.h:46
+#: panels/universal-access/cc-typing-dialog.ui:106
 msgid "Puts a delay between when a key is pressed and when it is accepted"
 msgstr "Bir tuşa basılmasıyla kabulü arasına gecikme koyar"
 
-#: ../panels/universal-access/uap.ui.h:47
-msgid "A_cceptance delay:"
-msgstr "Q_abul keçikmesi:"
-
-#: ../panels/universal-access/uap.ui.h:48
-msgctxt "universal access, delay"
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "Qısqa"
 
-#: ../panels/universal-access/uap.ui.h:49
+#: panels/universal-access/cc-typing-dialog.ui:147
 msgid "Slow keys typing delay"
 msgstr "Yavaş tuşlar tuşlama keçikmesi"
 
-#: ../panels/universal-access/uap.ui.h:50
-msgctxt "universal access, delay"
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "Uzun"
 
-# Bir tuş aşağıdaki halette olğanda biple:
-#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Beep when a key is"
-msgstr "Tuş biplemesiniñ olacağı haletler:"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:54
-msgid "pressed"
-msgstr "basıq"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:56
-msgid "accepted"
-msgstr "qabul etilgen"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:58
-msgid "rejected"
-msgstr "red etilgen"
-
-#: ../panels/universal-access/uap.ui.h:59
-msgid "Bounce Keys"
-msgstr "Sıçrama Tuşları"
+# tr
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "_Değiştirici tuşa basıldığında biple"
 
 # tr
-#: ../panels/universal-access/uap.ui.h:60
-msgid "Ignores fast duplicate keypresses"
-msgstr "Kısa aralıklı tuş tekrarlarını yok sayar"
-
-#: ../panels/universal-access/uap.ui.h:61
-msgid "Acc_eptance delay:"
-msgstr "Qab_ul keçikmesi:"
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "Bounce keys typing delay"
-msgstr "Sıçrama tuşları tuşlama keçikmesi"
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Bir tuş _reddedildiğinde biple"
 
 # tr
-#: ../panels/universal-access/uap.ui.h:63
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
 msgid "Beep when a key is _rejected"
 msgstr "Bir tuş _reddedildiğinde biple"
 
-#: ../panels/universal-access/uap.ui.h:64
-msgid "Enable by Keyboard"
-msgstr "Klavye ile Qabilleştir"
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "İrişilebilirlik hususiyetlerini klavyeni qullanaraq aç ve qapat"
-
-#: ../panels/universal-access/uap.ui.h:67
-msgid "Mouse Keys"
-msgstr "Sıçan Tuşları"
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Sıçrama Tuşları"
 
 # tr
-#: ../panels/universal-access/uap.ui.h:68
-msgid "Control the pointer using the keypad"
-msgstr "Belirteci klavye ile kontrol et"
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Kısa aralıklı tuş tekrarlarını yok sayar"
 
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Video Mouse"
-msgstr "Video Sıçan"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:70
-msgid "Control the pointer using the video camera."
-msgstr "İşaretçiyi vidyo kamerasıyla yönet."
-
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Simulated Secondary Click"
-msgstr "Ekilemci Çertmeni Taqlit Etüv"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:72
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "İlk düğme basılı tutulduğunda ikincil tıklama tetikle"
-
-#: ../panels/universal-access/uap.ui.h:73
-msgid "Secondary click delay"
-msgstr "Ekilemci çertme keçikmesi"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:74
-msgid "Hover Click"
-msgstr "Durağan Tıklama"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:75
-msgid "Trigger a click when the pointer hovers"
-msgstr "Belirteç nesne üstüne geldiğinde tıklama yap"
-
-#: ../panels/universal-access/uap.ui.h:76
-msgid "D_elay:"
-msgstr "_Keçikme:"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:77
-msgid "Motion _threshold:"
-msgstr "Hareket _eşiği:"
-
-#: ../panels/universal-access/uap.ui.h:78
-msgctxt "universal access, threshold"
-msgid "Small"
-msgstr "Kiçik"
-
-#: ../panels/universal-access/uap.ui.h:79
-msgctxt "universal access, threshold"
-msgid "Large"
-msgstr "Balaban"
-
-#: ../panels/universal-access/uap.ui.h:80
-msgid "Mouse Settings"
-msgstr "Sıçan Ayarları"
-
-# tr
-#: ../panels/universal-access/uap.ui.h:81
-msgid "Pointing and Clicking"
-msgstr "İşaretleme ve Tıklama"
-
-#: ../panels/universal-access/zoom-options.c:357
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
 msgid "Short"
 msgstr "Qısqa"
 
-#: ../panels/universal-access/zoom-options.c:358
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ Ekran"
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Sıçrama tuşları tuşlama keçikmesi"
 
-#: ../panels/universal-access/zoom-options.c:359
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ Ekran"
-
-#: ../panels/universal-access/zoom-options.c:360
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ Ekran"
-
-#: ../panels/universal-access/zoom-options.c:361
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Uzun"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:335
+#, fuzzy
+msgid "_Enable by Keyboard"
+msgstr "Klavye ile Qabilleştir"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "İrişilebilirlik hususiyetlerini klavyeni qullanaraq aç ve qapat"
+
+# tr
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Klavye Erişilebilirliği"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Körüş"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "Yüksek Tezat"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Büyük Metin"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Ekran Oquyıcı"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Sıçrama Tuşları"
+
+# tr
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Erişilebilirlik özelliklerini klavyeden _aç"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "İmleç qıpması sür'atı"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Miqyasla"
+
+# tr
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "İşitme"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Körsel İqazlar"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Ekran Klavyesi"
+
+# tüklü
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Tekrarlama Tuşları"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "İmleç Qıpması"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
+msgstr "Tuşlama Muavini"
+
+# tr
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "İşaretleme ve Tıklama"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Sıçan Tuşları"
+
+# tr
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Yazıcıyı Kaldır"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "_Çift-çertme"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "Çift-Çertme Zaman Aşımı"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Körsel İqazlar"
+
+# tr
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Flaşı sına"
+
+# tr
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+#, fuzzy
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Uyarı sesi çalındığında görsel uyarı kullan"
+
+# tr
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Tüm ekran yanıp sönsün"
+
+# tr
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Tüm ekran yanıp sönsün"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "Tam Ekran"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "Töpe Yarı"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "Tüp Yarı"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "Sol Yarı"
 
 # tr
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "Sağ Yarı"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "Yaqınlaştırma Seçenekleri"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "Miqyasla"
-
 # tr
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "Büyütme:"
 
 # tr
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "Fare imlecini izle"
-
-# tr
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "Ekran bölümü:"
-
-# tr
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "Büyüteç ekran dışına taşıyor"
-
-# tr
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "Büyüteç imlecini ortala"
-
-# tr
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "Büyüteç imleci içerik etrafını çevreliyor"
-
-# tr
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "Büyüteç imleci içerikle birlikte hareket ediyor"
-
-# tr
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "Büyüteç Konumu:"
 
+# tr
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Fare imlecini izle"
+
+# tr
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Ekran bölümü:"
+
+# tr
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "Büyüteç ekran dışına taşıyor"
+
+# tr
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "Büyüteç imlecini ortala"
+
+# tr
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Büyüteç imleci içerik etrafını çevreliyor"
+
+# tr
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "Büyüteç imleci içerikle birlikte hareket ediyor"
+
 # tüklü
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Mercek"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+# tüklü
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "Çapraz:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "Sıçan imleci ile örtüşe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "Qalınlıq:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "İnce"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Qalın"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "Uzunluq:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "Tüs:"
 
 # tüklü
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "Çapraz:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "Sıçan imleci ile örtüşe"
-
-# tüklü
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "Çapraz"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+# tr
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Tüs Efektleri:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "Qara üzeri aq:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "Parlaqlıq:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
-msgstr "Tezat:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Tezat:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "Tüs"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Hiç biri"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Tam"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Tüşük"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Yüksek"
 
-# tr
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "Tüs Efektleri:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Tüşük"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Yüksek"
 
 # tr
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "Tüs Efektleri"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:35
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Standart"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:37
-msgctxt "Account type"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Klavye;Sıçan;i15k;İrişilebilirlik;Tezat;Miqyas;Ekran Oquyıcı;metin;hurufat;"
+"ölçü;İrişimX;Yapışaq Tuşlar;Yavaş Tuşlar;Sıçrama Tuşları;Sıçan Tuşları;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "İçeri İmzalanma Keçmişi"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "İçeri İmzalanma Keçmişi"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "_Keçmiş"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "Muvaqqat Dosyelerni _İzale Et"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "Avtomatik _Bağlan"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Muvaqqat Dosyelerni _İzale Et"
+
+# tr
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "Avtomatik Ekran _Kiliti"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "Muvaqqat Dosyelerni _İzale Et"
+
+# tr
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "Çöpe Taşı"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+# tr
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Kullanıcı Ekle"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
 msgid "Administrator"
 msgstr "Memur"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-msgid "Add account"
-msgstr "Hesap ekle"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Local Account"
-msgstr "_Yerli Hesap"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
 # tr
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "_Enterprise Login"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Sonraki girişte parola seç"
+
+# tr
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Şimdi parola belirle"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "Endamlandırıla"
+
+# tr
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
 msgstr "_Qurumsal İçeri İmzalanım"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-msgid "_Full name"
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+# tr
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Kapalı"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+# tr
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PPD Dosyesini Sayla"
+
+# tr
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "_Parmak İziyle Giriş"
+
+# tr
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "_Parmak İziyle Giriş"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Hayır"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+# tr
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Kayıtlı parmak izlerini silerek parmak izi girişini kapatmak ister misiniz?"
+
+# tr
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Alğılanğan bastırıcılar yoq."
+
+# tr
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "_Parmak İziyle Giriş"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+# tr
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "_Parmak İziyle Giriş"
+
+# tr
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Yapılandırmak için aygıt _seçin:"
+
+# tr
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "_Parmak İziyle Giriş"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+# tr
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Parmak İzlerini Sil"
+
+# tr
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "_Parmak İziyle Giriş"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Evvelki Hafta"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "Soñraki Hafta"
+
+# tr
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Parola değiştiriliyor"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "D_eñiştir"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Cari _sır-söz"
+
+# tr
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Yeni p_arola"
+
+# tr
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Parolayı _onayla"
+
+# tr
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Parolalar eşleşmiyor"
+
+# tr
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "Sonraki girişte parola seç"
+
+# tr
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Şimdi parola belirle"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Qullanıcılar"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Qapat"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
 msgstr "_Tam İsim"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Account _Type"
-msgstr "Hesap _Türü"
+# tr
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Düzenle"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-msgid "_Domain"
-msgstr "_Saha"
+# tr
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Parmak İziyle Giriş"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Login Name"
-msgstr "İçeri İmzalanım _Adı"
+# tr
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Otomatik Giriş"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "Tip: Enterprise domain or realm name"
-msgstr "Qarane: Qurum saha yaki hükümranlıq adı"
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "Hesap _türü"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid "C_ontinue"
-msgstr "_Devam Et"
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Memur"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:14
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Uzaqtan Kontrol"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Ögbelgilengen Uyğulamalar"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Qullanıcı Hesabını Çetleştir"
+
+# tr
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Diğer parmak:"
+
+# tr
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "Kullanıcı Ekle"
+
+# tr
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Tapılğan bölgeler yoq"
+
+# tr
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "Kullanıcı hesabı oluştur"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+"Qullanıcılarnı ekleñiz ya da çetleştiriñiz ve sır-sözüñizni deñiştiriñiz"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Saha Memurı İçeri İmzalanımı"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6250,747 +5056,49 @@ msgstr ""
 "bir sahağa qayd olmağa ihtiyacı bar. Lütfen şebeke memurıñız \n"
 "saha parolini mında tuşlamasını rica etiñiz."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:18
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "Memur _Adı"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Memur Sır-sözü"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "Sol başparmaq"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "Sol orta parmaq"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "Sol yüzük parmağı"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "Sol çinatiy parmaq"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "Oñ başparmaq"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "Oñ orta parmaq"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "Oñ yüzük parmağı"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "Oñ çinatiy parmaq"
-
 # tr
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:700
-msgid "Enable Fingerprint Login"
-msgstr "Parmak İzi Girişi Etkinleştir"
-
-# tr
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "_Sağ işaret parmağı"
-
-# tr
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "S_ol işaret parmağı"
-
-# tr
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "_Diğer parmak:"
-
-# tr
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"Parmak iziniz başarıyla kaydedildi. Artık parmak izi okuyucusunu kullanarak "
-"giriş yapabilirsiniz."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "Qullanıcılar"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr ""
-"Qullanıcılarnı ekleñiz ya da çetleştiriñiz ve sır-sözüñizni deñiştiriñiz"
-
-# tr
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Giriş;İsim;Parmak izi;Kullanıcı simgesi;Logo;Yüz;Parola;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "İçeri İmzalanma Keçmişi"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:3
-msgid "Previous Week"
-msgstr "Evvelki Hafta"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:4
-msgid "Next Week"
-msgstr "Soñraki Hafta"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:5
-msgid "Next week"
-msgstr "Soñraki hafta"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Set a password now"
-msgstr "Şimdi parola belirle"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-msgid "Choose password at next login"
-msgstr "Sonraki girişte parola seç"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Log in without a password"
-msgstr "Parolasız giriş yap"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "Disable this account"
-msgstr "Bu hesabı devre dışı bırak"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Enable this account"
-msgstr "Bu hesabı etkinleştir"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "C_onfirm password"
-msgstr "Parolayı _onayla"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "_New password"
-msgstr "Yeni p_arola"
-
-# tüklü
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Generate a password"
-msgstr "Bir sır-sözni doğurt"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-msgid "Current _password"
-msgstr "Cari _sır-söz"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-msgid "_Action"
-msgstr "_Amel"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-msgid "Changing password for"
-msgstr "Parola değiştiriliyor"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-msgid "_Show password"
-msgstr "Parolayı _Göster"
-
-# tr
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid "How to choose a strong password"
-msgstr "Nasıl güçlü bir parola seçilir"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-msgid "Ch_ange"
-msgstr "D_eñiştir"
-
-# tr
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-msgid "Changing photo for:"
-msgstr "Kullanıcının fotosu değiştiriliyor:"
-
-# tr
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
-msgid ""
-"Choose a picture that will be shown at the login screen for this account."
-msgstr "Giriş ekranında bu hesap için kullanılacak bir resim seçin."
-
-# tr
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-msgid "Gallery"
-msgstr "Galeri"
-
-# tr
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "Browse for more pictures"
-msgstr "Daha fazla resim için göz at"
-
-# tr
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-msgid "Take a photograph"
-msgstr "Fotograf çek"
-
-# tr
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-msgid "Browse"
-msgstr "Gözat"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr "Foto"
-
-# tr
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Account Information"
-msgstr "Hesap bilgisi"
-
-# tr
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Add User Account"
-msgstr "Kullanıcı Hesabı Ekle"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Remove User Account"
-msgstr "Qullanıcı Hesabını Çetleştir"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "Login Options"
-msgstr "İçeri İmzalanma Seçenekleri"
-
-# tr
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "A_utomatic Login"
-msgstr "_Otomatik Giriş"
-
-# tr
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "_Fingerprint Login"
-msgstr "_Parmak İziyle Giriş"
-
-# tr
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "User Icon"
-msgstr "Kullanıcı Simgesi"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "_Language"
-msgstr "_Til"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "Last Login"
-msgstr "Soñki İçeri İmzalanma"
-
-# tr
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "Qullanıcı hesaplarını idare et"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "Qullanıcı verilerini deñiştirmek içün sahihlenim şarttır"
 
-#: ../panels/user-accounts/pw-utils.c:94
-#: ../panels/user-accounts/um-password-dialog.c:597
-msgctxt "Password strength"
-msgid "Too short"
-msgstr "Artqaç qısqa"
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password strength"
-msgid "Not good enough"
-msgstr "Yeterlice yahşı degil"
-
-#: ../panels/user-accounts/pw-utils.c:108
-#: ../panels/user-accounts/um-password-dialog.c:598
-msgctxt "Password strength"
-msgid "Weak"
-msgstr "Zayıf"
-
-#: ../panels/user-accounts/pw-utils.c:111
-#: ../panels/user-accounts/um-password-dialog.c:599
-msgctxt "Password strength"
-msgid "Fair"
-msgstr "Ortaca"
-
-#: ../panels/user-accounts/pw-utils.c:114
-#: ../panels/user-accounts/um-password-dialog.c:600
-msgctxt "Password strength"
-msgid "Good"
-msgstr "Eyi"
-
-#: ../panels/user-accounts/pw-utils.c:117
-#: ../panels/user-accounts/um-password-dialog.c:601
-msgctxt "Password strength"
-msgid "Strong"
-msgstr "Küçlü"
-
-#: ../panels/user-accounts/run-passwd.c:424
-msgid "Authentication failed"
-msgstr "Sahihlenim muvaffaqiyetsiz"
-
 # tr
-#: ../panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The new password is too short"
-msgstr "Yeni parola çok kısa"
-
-# tr
-#: ../panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password is too simple"
-msgstr "Yeni parola çok basit"
-
-# tr
-#: ../panels/user-accounts/run-passwd.c:516
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Eski ve yeni parolalar birbirine çok benziyor"
-
-# tr
-#: ../panels/user-accounts/run-passwd.c:519
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Yañı parol demin endi qullanılğandır."
-
-# tr
-#: ../panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Yeni parola rakam ya da özel karakterler içermeli"
-
-# tr
-#: ../panels/user-accounts/run-passwd.c:526
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Eski ve yeni parolalar birbirinin aynısı"
-
-# tr
-#: ../panels/user-accounts/run-passwd.c:530
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Parolanız önceki kimlik doğrulamasından sonra değiştirildi!"
-
-# tr
-#: ../panels/user-accounts/run-passwd.c:534
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Yeni parola yeterli sayıda farklı karakterler içermiyor"
-
-#: ../panels/user-accounts/run-passwd.c:538
-#, c-format
-msgid "Unknown error"
-msgstr "Bilinmegen hata"
-
-#: ../panels/user-accounts/um-account-dialog.c:186
-msgid "Failed to add account"
-msgstr "Hesap eklenamadı"
-
-# tr
-#: ../panels/user-accounts/um-account-dialog.c:407
-#: ../panels/user-accounts/um-account-dialog.c:448
-msgid "Failed to register account"
-msgstr "Hesap qayd etilamadı"
-
-#: ../panels/user-accounts/um-account-dialog.c:581
-msgid "No supported way to authenticate with this domain"
-msgstr "Bu saha ile sahihlenmek içün desteklengen yol yoq"
-
-#: ../panels/user-accounts/um-account-dialog.c:635
-msgid "Failed to join domain"
-msgstr "Sahağa qoşulınamadı"
-
-#: ../panels/user-accounts/um-account-dialog.c:703
-msgid "Failed to log into domain"
-msgstr "Sahağa içeri imzalanılamadı"
-
-# tr
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"Aygıta erişiminize izin verilmedi. Sistem yöneticinizle bağlantıya geçin."
-
-# tr
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "Aygıt zaten kullanımda."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr "Dahiliy hata hasıl oldı."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:219
-#: ../panels/user-accounts/um-fingerprint-dialog.c:220
-msgid "Enabled"
-msgstr "Qabilleştirilgen"
-
-# tr
-#: ../panels/user-accounts/um-fingerprint-dialog.c:268
-msgid "Delete registered fingerprints?"
-msgstr "Kayıtlı parmak izleri silinsin mi?"
-
-# tr
-#: ../panels/user-accounts/um-fingerprint-dialog.c:272
-msgid "_Delete Fingerprints"
-msgstr "_Parmak İzlerini Sil"
-
-# tr
-#: ../panels/user-accounts/um-fingerprint-dialog.c:279
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"Kayıtlı parmak izlerini silerek parmak izi girişini kapatmak ister misiniz?"
-
-# tr
-#: ../panels/user-accounts/um-fingerprint-dialog.c:455
-msgid "Done!"
-msgstr "Tamamlandı!"
-
-# tr
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:516
-#: ../panels/user-accounts/um-fingerprint-dialog.c:558
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' aygıtına erişilemedi"
-
-# tr
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:599
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "'%s' aygıtı üzerinde parmak yakalama başlatılamadı"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:650
-msgid "Could not access any fingerprint readers"
-msgstr "Hiç bir parmaq izi oquyıcısına irişilamadı"
-
-# tr
-#: ../panels/user-accounts/um-fingerprint-dialog.c:651
-msgid "Please contact your system administrator for help."
-msgstr "Lütfen yardım için sistem yöneticinizle bağlantıya geçin."
-
-# tr
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:734
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"Parmak izi girişin etkinleşebilmesi için parmak izlerinizden bir tanesini "
-"'%s' aygıtını kullanarak kaydetmelisiniz."
-
-# tr
-#: ../panels/user-accounts/um-fingerprint-dialog.c:741
-msgid "Selecting finger"
-msgstr "Parmak seçiliyor"
-
-# tr
-#: ../panels/user-accounts/um-fingerprint-dialog.c:742
-msgid "Enrolling fingerprints"
-msgstr "Parmak izleri kaydediliyor"
-
-#: ../panels/user-accounts/um-history-dialog.c:88
-msgid "This Week"
-msgstr "Bu Hafta"
-
-#: ../panels/user-accounts/um-history-dialog.c:91
-msgid "Last Week"
-msgstr "Keçken Hafta"
-
-#: ../panels/user-accounts/um-password-dialog.c:128
-msgid "_Generate a password"
-msgstr "Bir sır-sözni _doğurt"
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:181
-msgid "Please choose another password."
-msgstr "Lütfen farklı bir parola seçin"
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:190
-msgid "Please type your current password again."
-msgstr "Lütfen parolanızı tekrar girin."
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:196
-msgid "Password could not be changed"
-msgstr "Parolanız değiştirilemedi"
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:301
-msgid "You need to enter a new password"
-msgstr "Yeni bir parola girmelisiniz"
-
-#: ../panels/user-accounts/um-password-dialog.c:304
-msgid "The new password is not strong enough"
-msgstr "Yañı parol yeterli derecede küçlü degildir"
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:310
-msgid "You need to confirm the password"
-msgstr "Parolayı onaylamanız gerekiyor"
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:313
-msgid "The passwords do not match"
-msgstr "Parolalar eşleşmiyor"
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:319
-msgid "You need to enter your current password"
-msgstr "Mevcut parolanızı girmeniz gerekiyor"
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:322
-msgid "The current password is not correct"
-msgstr "Şu anki parola hatalı"
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:385
-msgid "Passwords do not match"
-msgstr "Parolalar uyuşmuyor"
-
-# tr
-#: ../panels/user-accounts/um-password-dialog.c:439
-msgid "Wrong password"
-msgstr "Hatalı parola"
-
-# tr
-#: ../panels/user-accounts/um-photo-dialog.c:443
-msgid "Disable image"
-msgstr "Resmi etkisizleştir"
-
-#: ../panels/user-accounts/um-photo-dialog.c:461
-msgid "Take a photo…"
-msgstr "Bir foto çıqar…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:479
-msgid "Browse for more pictures…"
-msgstr "Daha fazla resim içün kezin…"
-
-# tr
-#: ../panels/user-accounts/um-photo-dialog.c:703
-#, c-format
-msgid "Used by %s"
-msgstr "%s tarafından kullanılıyor"
-
-#: ../panels/user-accounts/um-realm-manager.c:351
-msgid "Cannot automatically join this type of domain"
-msgstr "Bu tür sahağa avtomatik olaraq qoşulalmayım"
-
-#: ../panels/user-accounts/um-realm-manager.c:414
-#, c-format
-msgid "No such domain or realm found"
-msgstr "Böyle bir saha yaki hükümranlıq tapılmadı"
-
-#: ../panels/user-accounts/um-realm-manager.c:814
-#: ../panels/user-accounts/um-realm-manager.c:828
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s sahasında %s olaraq içeri imzalanalmayım."
-
-#: ../panels/user-accounts/um-realm-manager.c:820
-msgid "Invalid password, please try again"
-msgstr "Keçersiz parol, lütfen yañıdan deñeñiz"
-
-#: ../panels/user-accounts/um-realm-manager.c:833
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "%s sahasına bağlanılamadı: %s"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:376
-msgid "Failed to delete user"
-msgstr "Kullanıcı silinemedi"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:436
-msgid "You cannot delete your own account."
-msgstr "Kendi hesabınızı silemezsiniz."
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:445
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s halen sisteme giriş yapmış durumda"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:449
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Giriş yapmış bir kullanıcıyı silmek sistemi tutarsız bir duruma sokabilir."
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:458
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "%s' in dosyalarını bırakmak ister misiniz?"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:462
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Kullanıcı silerken ev klasörünü, postalarını ve geçici dosyalarını bırakmak "
-"mümkün."
-
-#: ../panels/user-accounts/um-user-panel.c:465
-msgid "_Delete Files"
-msgstr "Dosyelerni _Sil"
-
-#: ../panels/user-accounts/um-user-panel.c:466
-msgid "_Keep Files"
-msgstr "Dosyelerni _Qoru"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:518
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Hesap devre dışı"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:526
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Bir sonraki girişte ayarlanacak"
-
-#: ../panels/user-accounts/um-user-panel.c:529
-msgctxt "Password mode"
-msgid "None"
-msgstr "Hiç biri"
-
-#: ../panels/user-accounts/um-user-panel.c:578
-msgid "Logged in"
-msgstr ""
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:943
-msgid "Failed to contact the accounts service"
-msgstr "Hesap hizmetiyle bağlantı kurulamadı"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:945
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Lütfen AccountService' in kurulu ve etkin olduğundan emin olun."
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:986
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Değişiklik yapmak için,\n"
-"önce * simgesine tıklayın"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:1024
-msgid "Create a user account"
-msgstr "Kullanıcı hesabı oluştur"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:1035
-#: ../panels/user-accounts/um-user-panel.c:1321
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Kullanıcı hesabı oluşturmak için,\n"
-"önce * simgesine tıklayın"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:1044
-msgid "Delete the selected user account"
-msgstr "Seçilen kullanıcı hesabını sil"
-
-# tr
-#: ../panels/user-accounts/um-user-panel.c:1056
-#: ../panels/user-accounts/um-user-panel.c:1326
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Seçilen kullanıcı hesabını silmek için,\n"
-"önce * simgesine tıklayın"
-
-#: ../panels/user-accounts/um-user-panel.c:1230
-msgid "My Account"
-msgstr "Hesabım"
-
-#: ../panels/user-accounts/um-user-panel.c:1239
-msgid "Other Accounts"
-msgstr "Diger Hesaplar"
-
-# tr
-#: ../panels/user-accounts/um-utils.c:535
-#, c-format
-msgid "A user with the username '%s' already exists"
-msgstr "'%s' kullanıcısı zaten mevcut"
-
-# tr
-#: ../panels/user-accounts/um-utils.c:539
-#, c-format
-msgid "The username is too long"
-msgstr "Kullanıcı adı fazlasıyla uzun"
-
-# tr
-#: ../panels/user-accounts/um-utils.c:542
-msgid "The username cannot start with a '-'"
-msgstr "Kullanıcı adı '-' ile başlayamaz"
-
-# tr
-#: ../panels/user-accounts/um-utils.c:545
-msgid ""
-"The username must only consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-"Kullanıcı adı sadece şunlardan oluşmalıdır:\n"
-" ➣ İngiliz alfabesinden harfler\n"
-" ➣ rakamlar\n"
-" ➣ '.', '-' ve '_' karakterlerinden herhangi biri"
-
-# tr
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Düğmeleri Eşleyin"
 
 # tr
-#: ../panels/wacom/button-mapping.ui.h:2
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Düğmeleri işlevlere eşleyin"
 
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Bir qısqayolnı tahrir etmek içün, satırğa çertiñiz ve tuşlarnı basıq tutuñız "
+"ya da temizlemek içün Backspace tuşuna basıñız."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Qapat"
+
 # tr
-#: ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -6999,409 +5107,3103 @@ msgstr ""
 "göründükçe dokunun."
 
 # tr
-#: ../panels/wacom/calibrator/calibrator-gui.c:86
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "Yanlış tıklama tespit edildi, yeniden başlatılıyor..."
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Output:"
-msgstr "Çıqtı:"
-
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:287
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Aspekt nisbetini qoru (mektüpqutusı):"
-
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:298
-msgid "Map to single monitor"
-msgstr "Tek monitorğa haritala"
-
-#: ../panels/wacom/cc-wacom-nav-button.c:89
-#, c-format
-msgid "%d of %d"
-msgstr "%d / %d"
-
-#: ../panels/wacom/cc-wacom-page.c:123 ../panels/wacom/cc-wacom-page.c:424
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "Hiç biri"
-
-#: ../panels/wacom/cc-wacom-page.c:124
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Tuş-çarpmanı Yiber"
-
-#: ../panels/wacom/cc-wacom-page.c:125
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Monitorlarnı Almaştır"
-
-#: ../panels/wacom/cc-wacom-page.c:126
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-page.c:665
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "Yuqarı"
-
-#: ../panels/wacom/cc-wacom-page.c:665
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "Aşağı"
-
-#: ../panels/wacom/cc-wacom-page.c:706
-msgid "Switch Modes"
-msgstr "Tarzlarnı Almaştır"
-
-#: ../panels/wacom/cc-wacom-page.c:796
-#: ../panels/wacom/cc-wacom-stylus-page.c:373
-msgid "Button"
-msgstr "Dögme"
-
 # tr
-#: ../panels/wacom/cc-wacom-page.c:854
-msgid "Action"
-msgstr "Amel"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "Sanal aygıt oluştur"
 
-# tr
-#: ../panels/wacom/cc-wacom-page.c:964
-msgid "Display Mapping"
-msgstr "Eşlemeyi görüntüle"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tablet"
 
-# tr
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr "Wacom Tablet"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
 # tr
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "Tablet;Wacom;Kalem;Silgi;Fare;"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Sol Elle Kullanım Yerleşimi"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Monitorğa Haritala…"
+
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Sistem ayarları"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
 # tr
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "Tablet (mutlak)"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Kalibrasyon..."
 
 # tr
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "İmleçsürer (Touchpad) (göreceli)"
-
-# tr
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "Tablet Tercihleri"
-
-# tr
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "Tablet bulunamadı"
 
 # tr
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "Lütfen Wacom tabletinizi açın veya bağlayın"
 
 # tr
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr "Bluetooth Ayarları"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Map to Monitor…"
-msgstr "Monitorğa Haritala…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map Buttons…"
-msgstr "Dögmelerni Haritalañız…"
-
-# tr
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr "Görüntü çözünürlüğünü ayarla"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust mouse settings"
-msgstr "Sıçan ayarlarını tadil et"
-
-# tr
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Tracking Mode"
-msgstr "İzleme Kipi"
-
-# tr
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Left-Handed Orientation"
-msgstr "Sol Elle Kullanım Yerleşimi"
-
-# tüklü
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1078
-msgid "Left Ring"
-msgstr "Sol Alqa"
-
-# tüklü
-#: ../panels/wacom/gsd-wacom-device.c:1089
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "Sol Alqa Tarzı #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1109
-msgid "Right Ring"
-msgstr "Oñ Alqa"
-
-#: ../panels/wacom/gsd-wacom-device.c:1120
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "Oñ Alqa Tarzı #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1162
-msgid "Left Touchstrip"
-msgstr "Sol Tiyüv Şeriti"
-
-#: ../panels/wacom/gsd-wacom-device.c:1173
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "Sol Tiyüv Şeriti Tarzı #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1193
-msgid "Right Touchstrip"
-msgstr "Oñ Tiyüv Şeriti"
-
-#: ../panels/wacom/gsd-wacom-device.c:1204
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "Oñ Tiyüv Şeriti Tarzı #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1230
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "Sol Tiyüv Alqası Tarzı Almaştırğıçı"
-
-#: ../panels/wacom/gsd-wacom-device.c:1232
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "Oñ Tiyüv Alqası Tarzı Almaştırğıçı"
-
-#: ../panels/wacom/gsd-wacom-device.c:1235
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "Sol Tiyüv Şeriti Tarzı Almaştırğıçı"
-
-#: ../panels/wacom/gsd-wacom-device.c:1237
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "Oñ Tiyüv Şeriti Tarzı Almaştırğıçı"
-
-#: ../panels/wacom/gsd-wacom-device.c:1242
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "Tarz Almaştırğıçı #%d"
-
-# tr
-#: ../panels/wacom/gsd-wacom-device.c:1351
-#, c-format
-msgid "Left Button #%d"
-msgstr "Sol Düğme #%d"
-
-# tr
-#: ../panels/wacom/gsd-wacom-device.c:1354
-#, c-format
-msgid "Right Button #%d"
-msgstr "Sağ Düğme #%d"
-
-# tr
-#: ../panels/wacom/gsd-wacom-device.c:1357
-#, c-format
-msgid "Top Button #%d"
-msgstr "Üst Düğme #%d"
-
-# tr
-#: ../panels/wacom/gsd-wacom-device.c:1360
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "Alt Düğme #%d"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "Eylem Yok"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "Sol Fare Düğmesi Tıklaması"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "Orta Fare Düğmesi Tıklaması"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "Sağ Fare Düğmesi Tıklaması"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "Yukarı Kaydır"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "Aşağı Kaydır"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "Sola Kaydır"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "Sağa Kaydır"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "Keri"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "İleri"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "Tablet Kalemi (Stylus)"
-
-# tüklü
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "Silgi Basım Sezilişi"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "Yumuşak"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "Sıkı"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "Üst Dögme"
-
-# tüklü
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "Alt Dögme"
-
-# tr
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "Parmak Ucu Basınç Hissi"
 
 # tr
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "Detay kipini etkinleştir"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Yumuşak"
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "Üstbaqışnı köster"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr ""
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "Yardım seçeneklerini köster"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "Kösterilecek panel"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr ""
-
-#: ../shell/cc-application.c:142
-msgid "- Settings"
-msgstr "- Ayarlar"
 
 # tr
-#: ../shell/cc-application.c:160
-#, c-format
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Sıkı"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Dögme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Dögme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Dögme"
+
+# tüklü
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Silgi Basım Sezilişi"
+
+# tüklü
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Silgi Basım Sezilişi"
+
+# tr
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Orta Fare Düğmesi Tıklaması"
+
+# tr
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Sağ Fare Düğmesi Tıklaması"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "İleri"
+
+# tr
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+# tr
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Kalem;Silgi;Fare;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Tizilim"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+#, fuzzy
+msgid "Behaviour"
+msgstr "Davranış"
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
 msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
-"%s\n"
-"Kullanılabilir komut satırı seçeneklerini görmek için '%s --help' komutunu "
-"çalıştırın.\n"
-
-#: ../shell/cc-application.c:190
-msgid "Available panels:"
-msgstr "Faydalanışlı paneller:"
-
-#: ../shell/cc-application.c:325
-msgid "Help"
-msgstr "Yardım"
-
-#: ../shell/cc-application.c:326
-msgid "Quit"
-msgstr "Terk et"
-
-#: ../shell/cc-window.c:61 ../shell/gnome-control-center.desktop.in.in.h:1
-msgid "Settings"
-msgstr "Ayarlar"
-
-#. Add categories
-#: ../shell/cc-window.c:857
-msgctxt "category"
-msgid "Personal"
-msgstr "Şahsiy"
-
-#: ../shell/cc-window.c:858
-msgctxt "category"
-msgid "Hardware"
-msgstr "Donanım"
 
 # tr
-#: ../shell/cc-window.c:859
-msgctxt "category"
-msgid "System"
-msgstr "Sistem"
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Üst Pencere"
 
-#: ../shell/cc-window.c:1421
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Ekilemci Çertmeni Taqlit Etüv"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows yazılımı"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+# tr
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Toner düşük seviyede"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Ekilemci çertme keçikmesi"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows yazılımı"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+# tr
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Erişilebilir _Giriş"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Ekle"
+
+# tr
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Kaydet"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Tafsilât"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_Şebeke Vaqtı"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Şebeke ayarları"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Sayılar"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Cihaz türleri"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "İmalâtçı"
+
+# tr
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Firmware kayıp"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Profil:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_Şebeke Vaqtı"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Şebeke"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "İleriletilgen"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "İçeri İmzalanım _Adı"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Kilitle"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Tafsilât"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Şebeke Adı"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Avtomatik"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Ev Şebekem"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "Şebeke Adı"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Klavye ile Qabilleştir"
+
+# tr
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Bluetooth bağdaştırıcısı bulunamadı"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+# tr
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Uçak Kipi"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Bağlantı"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SİM Kartı qıstırılğan degil"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Kilitle"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "D_eñiştir"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Ev Şebekem"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "%s için ayarlar"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Hepsi Ayarlar"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Birlemci _dögme"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Yardım"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Umumiy"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Terk et"
+
+# tr
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Qıdır"
+
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panel işaretçigi"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+# tr
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "İptal edildi"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Tercihler;Ayarlar;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+# tr
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u Çıkış"
+
+# tr
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u Giriş"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Kün boyunca deñişir"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Töşe"
+
+# tüklü
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Miqyasla"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Ortala"
+
+# tüklü
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Miqyasla"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Toldur"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Qarışla"
+
+#~ msgid "Select Background"
+#~ msgstr "Arqazemin Sayla"
+
+# tr
+#~ msgid "Pictures"
+#~ msgstr "Resimler"
+
+#~ msgid "Colors"
+#~ msgstr "Tüsler"
+
+#~ msgid "multiple sizes"
+#~ msgstr "müteaddit ölçü"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Masaüstü Arqazemini Yoq"
+
+#~ msgid "Current background"
+#~ msgstr "Cari arqazemin"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Divar kâğıtı;Ekran;Masaüstü;"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Yañı Cihaznı Ayarla"
+
+#~ msgid "page 1"
+#~ msgstr "sahife 1"
+
+#~ msgid "page 2"
+#~ msgstr "sahife 2"
+
+#~ msgid "Paired"
+#~ msgstr "Çiftlengen"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Sıçan & Tiyüv-şiltesi Ayarları"
+
+#~ msgid "Sound Settings"
+#~ msgstr "Davuş Ayarları"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Klavye Ayarları"
+
+#~ msgid "Send Files…"
+#~ msgstr "Dosyelerni Yiber…"
+
+#~ msgid "Yes"
+#~ msgstr "Ebet"
+
+#~ msgid "Visibility"
+#~ msgstr "Körünirlik"
+
+#, c-format
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” körünirligi"
+
+# tr
+#, c-format
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "'%s' aygıtlar listesinden kaldırılsın mı?"
+
+# tr
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Eğer aygıtı kaldırırsanız, sonraki kullanımdan önce yeniden kurmanız "
+#~ "gerekecek."
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Toparlanılalmağan dahiliy bir hata hasıl oldı."
+
+# tüklü
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profil doğurtılamadı."
+
+#~ msgid "Complete!"
+#~ msgstr "Tamam!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrasyon muvaffaqiyetsiz!"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Tizüstü Ekranı"
+
+# tüklü
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s Monitorı"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s Tarayıcısı"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s Bastırıcısı"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s Ağ kamerası"
+
+# tr
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s içün tüs idaresini qabilleştir"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Kalibrasyonsız"
+
+#~ msgid "Default: "
+#~ msgstr "Ögbelgilengen: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Sınama profili: "
+
+# tr
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC Profil Dosyasını Seç"
+
+#~ msgid "_Import"
+#~ msgstr "_İthal Et"
+
+# tr
+#~ msgid "All files"
+#~ msgstr "Tüm dosyalar"
+
+# tr
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Dosye yükletilamadı: %s"
+
+#~ msgid "Save Profile"
+#~ msgstr "Profilni Saqla"
+
+# tr
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Seçilen aygıt için bir renk profili oluştur"
+
+# tr
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Ölçüm cihazı algılanamadı. Lütfen açık durumda olduğundan ve doğru "
+#~ "bağlandığından emin olunuz."
+
+# tr
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Ölçüm cihazı yazıcı profillemeyi desteklemiyor."
+
+# tr
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Aygıt türü şu anda desteklenmiyor."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standart Feza"
+
+#~ msgid "Test Profile"
+#~ msgstr "Sınama Profili"
+
+# tr
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Otomatik"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Tüşük Keyfiyet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Orta Keyfiyet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Yüksek Keyfiyet"
+
+# tr
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Öntanımlı RGB"
+
+# tr
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Öntanımlı CMYK"
+
+# tr
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Öntanımlı Gri"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Bu profil belki artıq daqıq degildir"
+
+#~ msgid "Done"
+#~ msgstr "Tamam"
+
+#~ msgid "Upload profile"
+#~ msgstr "Profilni yüklet"
+
+#~ msgid "Device type:"
+#~ msgstr "Cihaz türü:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "İmalâtçı:"
+
+#~ msgid "Model:"
+#~ msgstr "Model:"
+
+# tr
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Yukarıdaki alanların otomatik tamamlanması için resim dosyalarını bu "
+#~ "pencereye sürükleyebilirsiniz."
+
+# tr
+#~ msgid "United States"
+#~ msgstr "Birleşik Devletler"
+
+# tr
+#~ msgid "Germany"
+#~ msgstr "Almanya"
+
+# tr
+#~ msgid "France"
+#~ msgstr "Fransa"
+
+# tr
+#~ msgid "Spain"
+#~ msgstr "İspanya"
+
+#~ msgid "China"
+#~ msgstr "Çin"
+
+#~ msgid "Other…"
+#~ msgstr "Diger…"
+
+#~ msgid "Left Shift"
+#~ msgstr "Sol Shift"
+
+#~ msgid "Left Alt"
+#~ msgstr "Sol Alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "Sol Ctrl"
+
+# tr
+#~ msgid "Right Shift"
+#~ msgstr "Sağ Shift"
+
+# tr
+#~ msgid "Right Alt"
+#~ msgstr "Sağ Alt"
+
+# tr
+#~ msgid "Right Ctrl"
+#~ msgstr "Sağ Ctrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Sol Alt+Shift"
+
+# tr
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Oñ Alt+Shift"
+
+# tr
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Oñ Ctrl+Shift"
+
+#~ msgid "Language"
+#~ msgstr "Til"
+
+#~ msgid "_Region:"
+#~ msgstr "_Bölge:"
+
+#~ msgid "_City:"
+#~ msgstr "_Şeher:"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Saatni bir saat ileri tesbit et."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Saatni bir saat keri tesbit et."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Saatni bir daqqa ileri tesbit et."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Saatni bir daqqa keri tesbit et."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Üyleden evvel ve üyleden soñ arasında almaştır."
+
+#~ msgid "24-hour"
+#~ msgstr "24-saat"
+
+#~ msgid "AM/PM"
+#~ msgstr "ÜE/ÜS"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "Saat yönü tersine"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Saat yönünde"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 Derece"
+
+# tüklü
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Hasiyetlerini deñiştirmek içün bir ekran saylañız; yerleştirilmesini kene "
+#~ "tertiplemek içün onı süyrekleñiz."
+
+# tr
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+# tr
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+# tr
+#, c-format
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "Yapılandırmanın uygulanması başarısız oldu: %s"
+
+# tr
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Ekran yapılandırması kaydedilemedi"
+
+# tr
+#~ msgid "Could not detect displays"
+#~ msgstr "Ekranlar tespit edilemedi"
+
+# tr
+#~ msgid "Could not get screen information"
+#~ msgstr "Ekran bilgisi alınamadı"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Çezinirlik"
+
+#~ msgid "R_otation"
+#~ msgstr "_Aylandırma"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "Ekranlarnı _Küzgüle"
+
+# tr
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Bilgi: çözünürlük seçeneklerini kısıtlayabilir"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "Ekranları _Alğıla"
+
+#~ msgid "Unknown"
+#~ msgstr "Bilinmegen"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+# tr
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-bit"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Ne yapılacağını sora"
+
+#~ msgid "Do nothing"
+#~ msgstr "Hiç bir şey yapma"
+
+#~ msgid "Open folder"
+#~ msgstr "Cilbent aç"
+
+#~ msgid "Other Media"
+#~ msgstr "Diger Vasatlar"
+
+# tr
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Müzik CD'leri için uygulama seçin"
+
+# tr
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Vidyo DVD'leri için uygulama seçin"
+
+# tr
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Müzik çalar bağlandığında çalıştırılacak uygulamayı seçin"
+
+# tr
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Kamera bağlandığında çalıştırılacak uygulamayı seçin"
+
+# tr
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Yazılım CD' leri için uygulama seçin"
+
+# tr
+#~ msgid "audio DVD"
+#~ msgstr "ses DVD' si"
+
+# tr
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "boş Blu-ray diski"
+
+# tr
+#~ msgid "blank CD disc"
+#~ msgstr "boş CD diski"
+
+# tr
+#~ msgid "blank DVD disc"
+#~ msgstr "boş DVD diski"
+
+# tr
+#~ msgid "blank HD DVD disc"
+#~ msgstr "boş HD DVD diski"
+
+# tr
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video diski"
+
+# tr
+#~ msgid "e-book reader"
+#~ msgstr "e-kitap okuyucu"
+
+# tr
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD vidyo diski"
+
+# tr
+#~ msgid "Picture CD"
+#~ msgstr "Resim CD' si"
+
+# tr
+#~ msgid "Super Video CD"
+#~ msgstr "Süper Vidyo CD"
+
+# tr
+#~ msgid "Video CD"
+#~ msgstr "Vidyo CD"
+
+#~ msgid "Overview"
+#~ msgstr "Üstbaqış"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "Sürüm %s"
+
+#~ msgid "Install Updates"
+#~ msgstr "Yañartmalarnı Qur"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Sistem Küncel"
+
+#~ msgid "Checking for Updates"
+#~ msgstr "Yañartmalar içün Teşkerile"
+
+#~ msgid "Base system"
+#~ msgstr "Temel sistem"
+
+#~ msgid "Disk"
+#~ msgstr "Disk"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Bir ekran körüntisini $PICTURES cilbentine saqla"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Bir pencereniñ bir ekran körüntisini $PICTURES cilbentine saqla"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Bir mıntıqanıñ bir ekran körüntisini $PICTURES cilbentine saqla"
+
+# tr
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Bir ekran görüntüsünü panoya kopyala"
+
+# tr
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Bir pencerenin ekran görüntüsünü panoya kopyala"
+
+# tr
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Bir alanın ekran görüntüsünü panoya kopyala"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Soñraki menbağa faqat-başqalaştırıcılar almaştırıcısı"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Qısqayol;Tekrar;Qıpma;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Özel Qısqayol"
+
+# tr
+#~ msgid "_Name:"
+#~ msgstr "İ_sim:"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Keçikme:"
+
+#~ msgid "_Speed:"
+#~ msgstr "_Sur'at:"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Yavaş"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Tez"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Sur'at:"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Qısqayolnı Çetleştir"
+
+# tr
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Bilinmegen Amel>"
+
+# tr
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Kısayol tuşu \"%s\" kullanılamıyor çünkü kullanımı halinde bu tuş "
+#~ "kullanılarak yazmak mümkün olmayacak.\n"
+#~ "Lütfen Control, Alt ya da Shift gibi tuşlar ile aynı anda deneyin."
+
+# tr
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "\"%s\" kısayolu bu işlem için kullanılıyor:\n"
+#~ "\"%s\""
+
+# tr
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Eğer kısayolu \"%s\" olarak tekrar atarsanız, \"%s\" kısayolu "
+#~ "etkinsizleştirilecek."
+
+# tr
+#~ msgid "_Reassign"
+#~ msgstr "_Kene tayin et"
+
+# tr
+#~ msgid "Mouse Preferences"
+#~ msgstr "Fare Tercihleri"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Yavaş"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Çift-çertme zaman aşımı"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Tez"
+
+# tr
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Sol"
+
+# tr
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Oñ"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_İbre sür'atı"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Yavaş"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Tez"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Yavaş"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Tez"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "Eki-_parmaqlı taydırma"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "_Muhteva parmaqlarğa yapışır"
+
+# tüklü
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Beş çertme, GEGL zamanı!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Çift çertme, birlemci dögme"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Tek çertme, birlemci dögme"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Çift çertme, orta dögme"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Tek çertme, orta dögme"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Çift çertme, ekilemci dögme"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Tek çertme, ekilemci dögme"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "Uça_k Kipi"
+
+#~ msgid "Network proxy"
+#~ msgstr "Şebekede proksisi"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+# tr
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Sistem ağ yöneticisi bu sürümle uyumlu değil."
+
+#~ msgid "automatic"
+#~ msgstr "avtomatik"
+
+# tr
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+# tr
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+# tr
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+# tr
+#~ msgid "Enterprise"
+#~ msgstr "Kurumsal"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Yoq"
+
+#~ msgid "Never"
+#~ msgstr "Asla"
+
+#~ msgid "Today"
+#~ msgstr "Bugün"
+
+#~ msgid "Yesterday"
+#~ msgstr "Tünevin"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/sn"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Yoq"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Zayıf"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Tamam"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Eyi"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Mükemmel"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS Sunucısını sil"
+
+#~ msgid "Delete Route"
+#~ msgstr "Rotanı Sil"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Hiç biri"
+
+# tüklü
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Qurumsal"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Ögbelgilengen"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Bağlantı muharriri açılalmay"
+
+#~ msgid "New Profile"
+#~ msgstr "Yañı Profil"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN plaginleri yüklenamadı: %s"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Şebeke Bağlantısını Ekle"
+
+#~ msgid "_Reset"
+#~ msgstr "_Sıfırla"
+
+#~ msgid "_Forget"
+#~ msgstr "_Unut"
+
+#~ msgid "Select file to import"
+#~ msgstr "İthal etilecek dosye sayla"
+
+# tr
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "Bir \"%s\" adlı dosye endi mevcuttır."
+
+#~ msgid "never"
+#~ msgstr "asla"
+
+#~ msgid "today"
+#~ msgstr "bugün"
+
+#~ msgid "yesterday"
+#~ msgstr "tünevin"
+
+# tr
+#~ msgid "Last used"
+#~ msgstr "Soñki qullanılğan"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Telsizden başqa İnternet'ke bir bağlantıñız bar ise, bağlantıñıznı "
+#~ "digerler ile üleşmek üzre bir telsiz sıcaq-noqtanı ayarlaybilirsiñiz."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Telsiz sıcaqnoqtanıñ açılması <b>%s</b> bağlantıñıznı qoparır."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Sıcaqnoqta faal olğanda telsiziñiz arqalı İnternet'ke irişmek mümkün "
+#~ "degildir."
+
+# tr
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Etkin nokta durdurulup tüm kullanıcıların bağlantısı kesilsin mi?"
+
+# tr
+#~ msgid "_Stop Hotspot"
+#~ msgstr "Etkin Noktayı _Durdur"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Saylanğan şebekeler içün şebeke tafsilâtı, sır-söz ve her hangi özel "
+#~ "endamlandırış dahil, ğayıp etilecek."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Unut"
+
+# tr
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Yapılandırma URL'si verilmediğinde vekil sunucu otomatik bulma kullanılır."
+
+# tr
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Bu güvenli olmayan açık ağlarda önerilmez."
+
+#~ msgid "Proxy"
+#~ msgstr "Proksi"
+
+# tr
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Hiçbiri"
+
+# tr
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "El ile"
+
+# tr
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Otomatik"
+
+# tr
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Yeni hizmetin kullanılacağı arayüzü seçin"
+
+# tr
+#~ msgid "C_reate…"
+#~ msgstr "İcat _Et…"
+
+# tr
+#~ msgid "_Interface"
+#~ msgstr "_Arayüz"
+
+#~ msgid "Add Device"
+#~ msgstr "Cihaz Ekle"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN Türü"
+
+# tr
+#~ msgid "Group Name"
+#~ msgstr "Grup İsmi"
+
+# tr
+#~ msgid "Group Password"
+#~ msgstr "Grup Parolası"
+
+#~ msgid "details"
+#~ msgstr "tafsilât"
+
+# tr
+#~ msgid "Show P_assword"
+#~ msgstr "_Sır-sözni Köster"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Diger qullanıcılarğa müsait yap"
+
+# tüklü
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "Avtomatik olaraq elde etilgen rotalarnı _ihmal et"
+
+#~ msgid "hardware"
+#~ msgstr "donanım"
+
+#~ msgid "reset"
+#~ msgstr "sıfırla"
+
+#~ msgid "Hardware"
+#~ msgstr "Donanım"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Bir Telsiz-Vefa şebekesine bağlanmaq içün qapatıñız"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Bağlanğan Cihazlar"
+
+# tr
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Altyapı"
+
+# tr
+#~ msgid "Status unknown"
+#~ msgstr "Durum bilinmiyor"
+
+# tr
+#~ msgid "Unmanaged"
+#~ msgstr "Yönetilmeyen"
+
+#~ msgid "Unavailable"
+#~ msgstr "Faydalanışsız"
+
+#~ msgid "Connecting"
+#~ msgstr "Bağlanıla"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Bağlantı qoparıla"
+
+#~ msgid "Connection failed"
+#~ msgstr "Bağlantı muvaffaqiyetsiz"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Status bilinmey (eksik)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Endamlandırış muvaffaqiyetsiz"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "İP endamlandırışı muvaffaqiyetsiz"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "İP endamlandırışı eskirdi"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP hızmeti bağlantısı qoparılğan"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP müşterisi başlayamadı"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP müşterisi hatası"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP müşterisi muvaffaqiyetsiz edi"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Üleşilgen bağlantı hızmeti muvaffaqiyetsiz edi"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AvtoİP hızmeti muvaffaqiyetsiz edi"
+
+#~ msgid "Line busy"
+#~ msgstr "Hat meşğul"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Modem başlanğıçlandırması muvaffaqiyetsiz edi"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Belirtilgen APN (İrişim Noqtası İsmi; İNİ) saylanamadı"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Şebeke qaydı inkâr etildi"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Bağlantı ğayıp oldı"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Mevcut bağlantı üstlenildi"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem tapılmadı"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth bağlantısı muvaffaqiyetsiz edi"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SİM yañlış"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Bağlantı bağlılığı muvaffaqiyetsiz edi"
+
+# tr
+#~ msgid "Cable unplugged"
+#~ msgstr "Kablo takılı değil"
+
+# tr
+#~ msgid "Ignore"
+#~ msgstr "İhmal Et"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Choose your personal certificate..."
+#~ msgstr "Şahsiy şehadetnameñizni saylañız..."
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Meni yañıdan _tenbih etme"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "Tasilâtnı Afişlerde Köster"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Kilit Ekranında Seyrettir"
+
+#~ msgid "On"
+#~ msgstr "Açıq"
+
+#~ msgid "Off"
+#~ msgstr "Qapalı"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "Kilit Ekranında Köster"
+
+#~ msgid "Add Account"
+#~ msgstr "Hesap Ekle"
+
+#~ msgid "Mail"
+#~ msgstr "Poşta"
+
+#~ msgid "Contacts"
+#~ msgstr "Temaslar"
+
+# tr
+#~ msgid "Error logging into the account"
+#~ msgstr "Hesaba giriş yapılırken hata oluştu"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Bu hesapnı qabilleştirmek içün içeri imzalan."
+
+#~ msgid "_Sign In"
+#~ msgstr "_İçeri İmzalan"
+
+# tr
+#~ msgid "Error creating account"
+#~ msgstr "Hesap oluşturulurken hata meydana geldi"
+
+# tr
+#~ msgid "Error removing account"
+#~ msgstr "Hesap silinirken hata oluştu"
+
+# tr
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Hesabı silmek istediğinizden emin misiniz?"
+
+# tr
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Bu işlem, sunucudaki hesabı silmeyecektir."
+
+# tr
+#~ msgid "No online accounts configured"
+#~ msgstr "Endamlandırılğan devre-içi hesaplar yoq"
+
+# tr
+#~ msgid "Remove Account"
+#~ msgstr "Hesabı Kaldır"
+
+# tr
+#~ msgid "Add an online account"
+#~ msgstr "Bir devre-içi hesap ekle"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Bir hesapnıñ eklenmesi uyğulamalarıñızğa onı vesiqalar, poçta, temaslar, "
+#~ "taqvim, suhbet vs. içün oña irişmege imkân berir."
+
+#~ msgid "Unknown time"
+#~ msgstr "Bilinmegen vaqıt"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+# tr
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "Tamamen tolmasına qadar %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "İhtiyat: %s qala"
+
+#~ msgid "Fully charged"
+#~ msgstr "Tamamen yükletilgen"
+
+#~ msgid "Empty"
+#~ msgstr "Boş"
+
+# tr
+#~ msgid "Charging"
+#~ msgstr "Doluyor"
+
+#~ msgid "Discharging"
+#~ msgstr "Yüksüzlene"
+
+# tr
+#~ msgid "Wireless mouse"
+#~ msgstr "Kablosuz fare"
+
+# tr
+#~ msgid "Wireless keyboard"
+#~ msgstr "Kablosuz klavye"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Kesintisiz qudret arzı"
+
+# tr
+#~ msgid "Personal digital assistant"
+#~ msgstr "Kişisel dijital yardımcı"
+
+# tr
+#~ msgid "Cellphone"
+#~ msgstr "Cep telefonu"
+
+# tr
+#~ msgid "Media player"
+#~ msgstr "Ortam yürütücüsü"
+
+#~ msgid "Computer"
+#~ msgstr "Bilgisayar"
+
+# tüklü
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Yükletile"
+
+# tr
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "İhtiyat"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Tüşük"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Eyi"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Tam yükletilgen"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Boş"
+
+#~ msgid "Batteries"
+#~ msgstr "Piller"
+
+# tüklü
+#~ msgid "_Dim Screen when Inactive"
+#~ msgstr "Ğayrıfaal olğanda Ekrannı _Sönükleştir"
+
+#~ msgid "_Mobile Broadband"
+#~ msgstr "_Mobil Kenişbant"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "When on battery power"
+#~ msgstr "Pil qudretinde olğanda"
+
+# tr
+#~ msgid "When plugged in"
+#~ msgstr "Fişe takıldığıında"
+
+#~ msgid "When Battery Power is _Critical"
+#~ msgstr "Pil Qudreti _Kritik Olğanda"
+
+#~ msgid "Power Off"
+#~ msgstr "Söndür"
+
+# tr
+#~ msgid "Hibernate"
+#~ msgstr "Derin Uyku"
+
+# tr
+#~ msgid "1 minute"
+#~ msgstr "1 dakika"
+
+# tr
+#~ msgid "3 minutes"
+#~ msgstr "3 dakika"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 daqqa"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 daqqa"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 daqqa"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 daqqa"
+
+# tr
+#~ msgid "Out of toner"
+#~ msgstr "Toner tükendi"
+
+# tr
+#~ msgid "Low on developer"
+#~ msgstr "Film banyo kimyasalı az"
+
+# tr
+#~ msgid "Out of developer"
+#~ msgstr "Film banyo kimyasalı bitti"
+
+# tr
+#~ msgid "Low on a marker supply"
+#~ msgstr "Renk kartuşu az"
+
+# tr
+#~ msgid "Out of a marker supply"
+#~ msgstr "Renk kartuşu bitti"
+
+# tr
+#~ msgid "Open cover"
+#~ msgstr "Kapak açık"
+
+# tr
+#~ msgid "Open door"
+#~ msgstr "Kapı açık"
+
+# tr
+#~ msgid "Low on paper"
+#~ msgstr "Kağıt az"
+
+# tr
+#~ msgid "Out of paper"
+#~ msgstr "Kağıt bitti"
+
+# tr
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Durduruldu"
+
+# tr
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Atık kutusu neredeyse dolu"
+
+# tr
+#~ msgid "Waste receptacle full"
+#~ msgstr "Atık kutusu dolu"
+
+# tr
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Baskı silindiri ömrünü doldurmak üzere"
+
+# tr
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Baskı silindiri artık çalışmıyor"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Hazır"
+
+# tr
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "İşleniyor"
+
+# tr
+#~ msgid "Toner Level"
+#~ msgstr "Toner Seviyesi"
+
+# tr
+#~ msgid "Supply Level"
+#~ msgstr "Malzeme Seviyesi"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Qurula"
+
+# tr
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u etkin"
+
+# tr
+#~ msgid "Failed to add new printer."
+#~ msgstr "Yeni yazıcı eklenemedi."
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Kelişikli sürüci tapılamadı"
+
+#~ msgid "Provide PPD File…"
+#~ msgstr "PPD Dosyesini Temin Et…"
+
+# tr
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Arayüz yüklenemedi: %s"
+
+# tr
+#~ msgid "Resume Printing"
+#~ msgstr "Yazdırmayı Devam Ettir"
+
+# tr
+#~ msgid "Pause Printing"
+#~ msgstr "Yazdırmayı Duraklat"
+
+# tr
+#~ msgid "Add a New Printer"
+#~ msgstr "Yeni Yazıcı Ekle"
+
+# tr
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Şebeke bastırıcıları içün qıdır yaki neticelerni süzgüçle"
+
+#~ msgid "One Sided"
+#~ msgstr "Tek Yanlı"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Uzun Ağız (Standart)"
+
+# tüklü
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Qısqa Ağız (Aylandır)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portret"
+
+#~ msgid "Landscape"
+#~ msgstr "Manzara"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Ters manzara"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Ters portret"
+
+# tr
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Sırada"
+
+# tr
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Bekliyor"
+
+# tr
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "İşleniyor"
+
+# tr
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Durduruldu"
+
+# tr
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Hata nedeniyle iptal edildi"
+
+# tr
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Tamamlandı"
+
+# tr
+#~ msgid "Job Title"
+#~ msgstr "İş Adı"
+
+# tr
+#~ msgid "Job State"
+#~ msgstr "İş Durumu"
+
+# tr
+#, c-format
+#~ msgid "%s Active Jobs"
+#~ msgstr "%s Faal İş"
+
+#~ msgid "Two Sided"
+#~ msgstr "Eki Yanlı"
+
+#~ msgid "Paper Type"
+#~ msgstr "Kâğıt Türü"
+
+#~ msgid "Paper Source"
+#~ msgstr "Kâğıt Qaynağı"
+
+# tr
+#~ msgid "Output Tray"
+#~ msgstr "Çıqtı Sinisi"
+
+#~ msgid "Pages per side"
+#~ msgstr "Yan başına sahife sayısı"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Umumiy"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Sahife Ayarlaması"
+
+# tr
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Qurulabilir Seçenekler"
+
+# tr
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "İş"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Suret Keyfiyeti"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Tüs"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Bitirile"
+
+#~ msgid "Auto Select"
+#~ msgstr "Avto Sayla"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Ög-süzgüçleme yoq"
+
+# tr
+#~ msgid "Supply"
+#~ msgstr "Malzeme"
+
+# tr
+#~ msgid "_Default"
+#~ msgstr "_Öntanımlı"
+
+# tr
+#~ msgid "Jobs"
+#~ msgstr "İşler"
+
+#~ msgid "label"
+#~ msgstr "etiket"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "Yañı sürüci tesbit etile…"
+
+#~ msgid "page 3"
+#~ msgstr "sahife 3"
+
+# tr
+#~ msgid "Print _Test Page"
+#~ msgstr "_Sınama Sayfası Yazdır"
+
+# tr
+#~ msgid "_Options"
+#~ msgstr "_Seçenekler"
+
+# tr
+#~ msgid "Add New Printer"
+#~ msgstr "Yeni Yazıcı Ekle"
+
+#~ msgid "Hidden"
+#~ msgstr "Gizli"
+
+#~ msgid "Visible"
+#~ msgstr "Körünir"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "İsim & Körünirlik"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "Ekran Söndürilgenden Soñ"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 saniye"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "_Gizlilik Tarzı"
+
+#~ msgid "Forever"
+#~ msgstr "İlelebet"
+
+# tr
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Şu süre qadar boş olğandan soñ ekrannı _kilitle"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "İngliz ölçüler"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrik"
+
+# tr
+#~ msgid "No input sources found"
+#~ msgstr "Tapılğan kirdi menbaları yoq"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Diger"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Hiç biri"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Soñraki menbağa almaştır"
+
+#~ msgid "Home"
+#~ msgstr "Ev"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Diger"
+
+#~ msgid "Select Location"
+#~ msgstr "Qonum Saylañız"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Açıq"
+
+# tüklü
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Qapalı"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Üleşilgen Cilbentler"
+
+# tr
+#~ msgid "Remove Folder"
+#~ msgstr "Cilbentni Çetleştir"
+
+# tüklü
+#~ msgid "Remote View"
+#~ msgstr "Uzaqtan Seyir"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Bağlantılarnıñ Hepsini Tasvip Et"
+
+#~ msgid "Show Password"
+#~ msgstr "Sır-sözni Köster"
+
+# tr
+#~ msgid "Bark"
+#~ msgstr "Havlama"
+
+# tr
+#~ msgid "Drip"
+#~ msgstr "Damlama"
+
+# tr
+#~ msgid "Glass"
+#~ msgstr "Cam"
+
+# tr
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+# tr
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "En Az"
+
+# tr
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "En Çok"
+
+# tr
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+# tr
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "%100"
+
+# tr
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Yükseltilmemiş"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profil:"
+
+# tr
+#~ msgid "_Test Speakers"
+#~ msgstr "Hoparlörleri _Sına"
+
+# tr
+#~ msgid "Peak detect"
+#~ msgstr "Tepe algılama"
+
+#~ msgid "Device"
+#~ msgstr "Cihaz"
+
+# tr
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s için Hoparlör Sınaması"
+
+# tr
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Ses çıkışı için aygıt _seçin:"
+
+# tr
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Seçili aygıt ayarları:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Kirdi gürlügi:"
+
+# tr
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Ses girişi için aygıt _seçin:"
+
+# tr
+#~ msgid "Sound Effects"
+#~ msgstr "Ses Efektleri"
+
+# tr
+#~ msgid "Built-in"
+#~ msgstr "Dahili"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Davuş Tercihleri"
+
+# tr
+#~ msgid "Testing event sound"
+#~ msgstr "Olay sesi deneniyor"
+
+# tr
+#~ msgid "From theme"
+#~ msgstr "Temadan"
+
+# tr
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Uyarı sesi se_çin:"
+
+#~ msgid "Stop"
+#~ msgstr "Toqta"
+
+# tr
+#~ msgid "Custom"
+#~ msgstr "Özel"
+
+# tr
+#~ msgid "No shortcut set"
+#~ msgstr "Kısayol belirlenmemiş"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Yüksek/Ters"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Ekran-üstü klavye"
+
+# tr
+#~ msgid "GOK"
+#~ msgstr "GOK"
+
+# tr
+#~ msgid "OnBoard"
+#~ msgstr "Dahili"
+
+#, no-c-format
+#~ msgid "75%"
+#~ msgstr "%75"
+
+#, no-c-format
+#~ msgid "100%"
+#~ msgstr "%100"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#, no-c-format
+#~ msgid "125%"
+#~ msgstr "%125"
+
+#, no-c-format
+#~ msgid "150%"
+#~ msgstr "%150"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "Daha Balaban"
+
+# tüklü
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Caps ve Num Lock üzerine biple"
+
+# tr
+#~ msgid "Turn on or off:"
+#~ msgstr "Aç ya da kapat:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Miqyasla"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Yaqınlaştır:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Uzaqlaştır:"
+
+# tr
+#~ msgid "Flash the window title"
+#~ msgstr "Pencere başlığı yanıp sönsün"
+
+# tr
+#~ msgid "Closed Captioning"
+#~ msgstr "Gizli Altyazı"
+
+# tr
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Konuşma ve sesler için yazılı açıklama göster"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "Ekran Üzeri Klavye"
+
+# tr
+#~ msgid "Beep when a _modifer key is pressed"
+#~ msgstr "_Değiştirici tuşa basıldığında biple"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "Qısqa"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "Uzun"
+
+# Bir tuş aşağıdaki halette olğanda biple:
+#~ msgid "Beep when a key is"
+#~ msgstr "Tuş biplemesiniñ olacağı haletler:"
+
+#~ msgid "pressed"
+#~ msgstr "basıq"
+
+#~ msgid "accepted"
+#~ msgstr "qabul etilgen"
+
+#~ msgid "rejected"
+#~ msgstr "red etilgen"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "Qab_ul keçikmesi:"
+
+# tr
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Belirteci klavye ile kontrol et"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Video Sıçan"
+
+# tr
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "İşaretçiyi vidyo kamerasıyla yönet."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "Kiçik"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "Balaban"
+
+#~ msgid "Mouse Settings"
+#~ msgstr "Sıçan Ayarları"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Qısqa"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ Ekran"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ Ekran"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ Ekran"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Uzun"
+
+#~ msgid "Contrast:"
+#~ msgstr "Tezat:"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Tüs"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standart"
+
+#~ msgid "_Local Account"
+#~ msgstr "_Yerli Hesap"
+
+#~ msgid "Account _Type"
+#~ msgstr "Hesap _Türü"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "Qarane: Qurum saha yaki hükümranlıq adı"
+
+#~ msgid "C_ontinue"
+#~ msgstr "_Devam Et"
+
+#~ msgid "Left thumb"
+#~ msgstr "Sol başparmaq"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Sol orta parmaq"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Sol yüzük parmağı"
+
+#~ msgid "Left little finger"
+#~ msgstr "Sol çinatiy parmaq"
+
+#~ msgid "Right thumb"
+#~ msgstr "Oñ başparmaq"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Oñ orta parmaq"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Oñ yüzük parmağı"
+
+#~ msgid "Right little finger"
+#~ msgstr "Oñ çinatiy parmaq"
+
+# tr
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Parmak İzi Girişi Etkinleştir"
+
+# tr
+#~ msgid "_Right index finger"
+#~ msgstr "_Sağ işaret parmağı"
+
+# tr
+#~ msgid "_Left index finger"
+#~ msgstr "S_ol işaret parmağı"
+
+# tr
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Parmak iziniz başarıyla kaydedildi. Artık parmak izi okuyucusunu "
+#~ "kullanarak giriş yapabilirsiniz."
+
+# tr
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Giriş;İsim;Parmak izi;Kullanıcı simgesi;Logo;Yüz;Parola;"
+
+#~ msgid "Next week"
+#~ msgstr "Soñraki hafta"
+
+# tr
+#~ msgid "Log in without a password"
+#~ msgstr "Parolasız giriş yap"
+
+# tr
+#~ msgid "Disable this account"
+#~ msgstr "Bu hesabı devre dışı bırak"
+
+# tr
+#~ msgid "Enable this account"
+#~ msgstr "Bu hesabı etkinleştir"
+
+#~ msgid "_Action"
+#~ msgstr "_Amel"
+
+# tr
+#~ msgid "Changing password for"
+#~ msgstr "Parola değiştiriliyor"
+
+# tr
+#~ msgid "_Show password"
+#~ msgstr "Parolayı _Göster"
+
+# tr
+#~ msgid "How to choose a strong password"
+#~ msgstr "Nasıl güçlü bir parola seçilir"
+
+# tr
+#~ msgid "Changing photo for:"
+#~ msgstr "Kullanıcının fotosu değiştiriliyor:"
+
+# tr
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "Giriş ekranında bu hesap için kullanılacak bir resim seçin."
+
+# tr
+#~ msgid "Gallery"
+#~ msgstr "Galeri"
+
+# tr
+#~ msgid "Take a photograph"
+#~ msgstr "Fotograf çek"
+
+# tr
+#~ msgid "Browse"
+#~ msgstr "Gözat"
+
+#~ msgid "Photograph"
+#~ msgstr "Foto"
+
+# tr
+#~ msgid "Account Information"
+#~ msgstr "Hesap bilgisi"
+
+# tr
+#~ msgid "Add User Account"
+#~ msgstr "Kullanıcı Hesabı Ekle"
+
+# tr
+#~ msgid "User Icon"
+#~ msgstr "Kullanıcı Simgesi"
+
+#~ msgid "Last Login"
+#~ msgstr "Soñki İçeri İmzalanma"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Artqaç qısqa"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "Yeterlice yahşı degil"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Zayıf"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Ortaca"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Eyi"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Küçlü"
+
+#~ msgid "Authentication failed"
+#~ msgstr "Sahihlenim muvaffaqiyetsiz"
+
+# tr
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Yeni parola çok kısa"
+
+# tr
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Yeni parola çok basit"
+
+# tr
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Eski ve yeni parolalar birbirine çok benziyor"
+
+# tr
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Yañı parol demin endi qullanılğandır."
+
+# tr
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Yeni parola rakam ya da özel karakterler içermeli"
+
+# tr
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Eski ve yeni parolalar birbirinin aynısı"
+
+# tr
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Parolanız önceki kimlik doğrulamasından sonra değiştirildi!"
+
+# tr
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Yeni parola yeterli sayıda farklı karakterler içermiyor"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Bilinmegen hata"
+
+#~ msgid "Failed to add account"
+#~ msgstr "Hesap eklenamadı"
+
+# tr
+#~ msgid "Failed to register account"
+#~ msgstr "Hesap qayd etilamadı"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Bu saha ile sahihlenmek içün desteklengen yol yoq"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Sahağa qoşulınamadı"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Sahağa içeri imzalanılamadı"
+
+# tr
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Aygıta erişiminize izin verilmedi. Sistem yöneticinizle bağlantıya geçin."
+
+# tr
+#~ msgid "The device is already in use."
+#~ msgstr "Aygıt zaten kullanımda."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Dahiliy hata hasıl oldı."
+
+# tr
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Kayıtlı parmak izleri silinsin mi?"
+
+# tr
+#~ msgid "Done!"
+#~ msgstr "Tamamlandı!"
+
+# tr
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' aygıtına erişilemedi"
+
+# tr
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' aygıtı üzerinde parmak yakalama başlatılamadı"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Hiç bir parmaq izi oquyıcısına irişilamadı"
+
+# tr
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Lütfen yardım için sistem yöneticinizle bağlantıya geçin."
+
+# tr
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "Parmak izi girişin etkinleşebilmesi için parmak izlerinizden bir tanesini "
+#~ "'%s' aygıtını kullanarak kaydetmelisiniz."
+
+# tr
+#~ msgid "Selecting finger"
+#~ msgstr "Parmak seçiliyor"
+
+#~ msgid "This Week"
+#~ msgstr "Bu Hafta"
+
+#~ msgid "Last Week"
+#~ msgstr "Keçken Hafta"
+
+#~ msgid "_Generate a password"
+#~ msgstr "Bir sır-sözni _doğurt"
+
+# tr
+#~ msgid "Please choose another password."
+#~ msgstr "Lütfen farklı bir parola seçin"
+
+# tr
+#~ msgid "Please type your current password again."
+#~ msgstr "Lütfen parolanızı tekrar girin."
+
+# tr
+#~ msgid "Password could not be changed"
+#~ msgstr "Parolanız değiştirilemedi"
+
+# tr
+#~ msgid "You need to enter a new password"
+#~ msgstr "Yeni bir parola girmelisiniz"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "Yañı parol yeterli derecede küçlü degildir"
+
+# tr
+#~ msgid "You need to confirm the password"
+#~ msgstr "Parolayı onaylamanız gerekiyor"
+
+# tr
+#~ msgid "You need to enter your current password"
+#~ msgstr "Mevcut parolanızı girmeniz gerekiyor"
+
+# tr
+#~ msgid "The current password is not correct"
+#~ msgstr "Şu anki parola hatalı"
+
+# tr
+#~ msgid "Passwords do not match"
+#~ msgstr "Parolalar uyuşmuyor"
+
+# tr
+#~ msgid "Wrong password"
+#~ msgstr "Hatalı parola"
+
+# tr
+#~ msgid "Disable image"
+#~ msgstr "Resmi etkisizleştir"
+
+#~ msgid "Take a photo…"
+#~ msgstr "Bir foto çıqar…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Daha fazla resim içün kezin…"
+
+# tr
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s tarafından kullanılıyor"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Bu tür sahağa avtomatik olaraq qoşulalmayım"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "Böyle bir saha yaki hükümranlıq tapılmadı"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s sahasında %s olaraq içeri imzalanalmayım."
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Keçersiz parol, lütfen yañıdan deñeñiz"
+
+# tr
+#~ msgid "Failed to delete user"
+#~ msgstr "Kullanıcı silinemedi"
+
+# tr
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Kendi hesabınızı silemezsiniz."
+
+# tr
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s halen sisteme giriş yapmış durumda"
+
+# tr
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Giriş yapmış bir kullanıcıyı silmek sistemi tutarsız bir duruma sokabilir."
+
+# tr
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "%s' in dosyalarını bırakmak ister misiniz?"
+
+# tr
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Kullanıcı silerken ev klasörünü, postalarını ve geçici dosyalarını "
+#~ "bırakmak mümkün."
+
+#~ msgid "_Delete Files"
+#~ msgstr "Dosyelerni _Sil"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Dosyelerni _Qoru"
+
+# tr
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Hesap devre dışı"
+
+# tr
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Bir sonraki girişte ayarlanacak"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Hiç biri"
+
+# tr
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Hesap hizmetiyle bağlantı kurulamadı"
+
+# tr
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Lütfen AccountService' in kurulu ve etkin olduğundan emin olun."
+
+# tr
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Değişiklik yapmak için,\n"
+#~ "önce * simgesine tıklayın"
+
+# tr
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Kullanıcı hesabı oluşturmak için,\n"
+#~ "önce * simgesine tıklayın"
+
+# tr
+#~ msgid "Delete the selected user account"
+#~ msgstr "Seçilen kullanıcı hesabını sil"
+
+# tr
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Seçilen kullanıcı hesabını silmek için,\n"
+#~ "önce * simgesine tıklayın"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Diger Hesaplar"
+
+# tr
+#, c-format
+#~ msgid "A user with the username '%s' already exists"
+#~ msgstr "'%s' kullanıcısı zaten mevcut"
+
+# tr
+#, c-format
+#~ msgid "The username is too long"
+#~ msgstr "Kullanıcı adı fazlasıyla uzun"
+
+# tr
+#~ msgid "The username cannot start with a '-'"
+#~ msgstr "Kullanıcı adı '-' ile başlayamaz"
+
+# tr
+#~ msgid ""
+#~ "The username must only consist of:\n"
+#~ " ➣ letters from the English alphabet\n"
+#~ " ➣ digits\n"
+#~ " ➣ any of the characters '.', '-' and '_'"
+#~ msgstr ""
+#~ "Kullanıcı adı sadece şunlardan oluşmalıdır:\n"
+#~ " ➣ İngiliz alfabesinden harfler\n"
+#~ " ➣ rakamlar\n"
+#~ " ➣ '.', '-' ve '_' karakterlerinden herhangi biri"
+
+#~ msgid "Output:"
+#~ msgstr "Çıqtı:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Aspekt nisbetini qoru (mektüpqutusı):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Tek monitorğa haritala"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d / %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Hiç biri"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Tuş-çarpmanı Yiber"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Monitorlarnı Almaştır"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Yuqarı"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Aşağı"
+
+#~ msgid "Switch Modes"
+#~ msgstr "Tarzlarnı Almaştır"
+
+# tr
+#~ msgid "Action"
+#~ msgstr "Amel"
+
+# tr
+#~ msgid "Display Mapping"
+#~ msgstr "Eşlemeyi görüntüle"
+
+# tr
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (mutlak)"
+
+# tr
+#~ msgid "Tablet Preferences"
+#~ msgstr "Tablet Tercihleri"
+
+# tr
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth Ayarları"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Dögmelerni Haritalañız…"
+
+# tr
+#~ msgid "Adjust display resolution"
+#~ msgstr "Görüntü çözünürlüğünü ayarla"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Sıçan ayarlarını tadil et"
+
+# tr
+#~ msgid "Tracking Mode"
+#~ msgstr "İzleme Kipi"
+
+# tüklü
+#~ msgid "Left Ring"
+#~ msgstr "Sol Alqa"
+
+# tüklü
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Sol Alqa Tarzı #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Oñ Alqa Tarzı #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Sol Tiyüv Şeriti"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Sol Tiyüv Şeriti Tarzı #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Oñ Tiyüv Şeriti"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Oñ Tiyüv Şeriti Tarzı #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Sol Tiyüv Alqası Tarzı Almaştırğıçı"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Oñ Tiyüv Alqası Tarzı Almaştırğıçı"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Sol Tiyüv Şeriti Tarzı Almaştırğıçı"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Oñ Tiyüv Şeriti Tarzı Almaştırğıçı"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Tarz Almaştırğıçı #%d"
+
+# tr
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "Sol Düğme #%d"
+
+# tr
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "Sağ Düğme #%d"
+
+# tr
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "Üst Düğme #%d"
+
+# tr
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Alt Düğme #%d"
+
+# tr
+#~ msgid "No Action"
+#~ msgstr "Eylem Yok"
+
+# tr
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Sol Fare Düğmesi Tıklaması"
+
+# tr
+#~ msgid "Scroll Up"
+#~ msgstr "Yukarı Kaydır"
+
+# tr
+#~ msgid "Scroll Right"
+#~ msgstr "Sağa Kaydır"
+
+# tr
+#~ msgid "Stylus"
+#~ msgstr "Tablet Kalemi (Stylus)"
+
+#~ msgid "Top Button"
+#~ msgstr "Üst Dögme"
+
+# tr
+#~ msgid "Enable verbose mode"
+#~ msgstr "Detay kipini etkinleştir"
+
+#~ msgid "Show the overview"
+#~ msgstr "Üstbaqışnı köster"
+
+#~ msgid "Show help options"
+#~ msgstr "Yardım seçeneklerini köster"
+
+#~ msgid "Panel to display"
+#~ msgstr "Kösterilecek panel"
+
+#~ msgid "- Settings"
+#~ msgstr "- Ayarlar"
+
+# tr
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Kullanılabilir komut satırı seçeneklerini görmek için '%s --help' "
+#~ "komutunu çalıştırın.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "Faydalanışlı paneller:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Şahsiy"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Donanım"
+
+# tr
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistem"
 
 #~ msgid "English"
 #~ msgstr "İnglizce"
@@ -7619,10 +8421,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ "Kimliğinizi doğruladıktan sonra, yeni parolanızı girin, onay için tekrar "
 #~ "girin ve <b>Parola değiştir</b>'e tıklayın."
 
-# tr
-#~ msgid "Accessible Lo_gin"
-#~ msgstr "Erişilebilir _Giriş"
-
 #~ msgid "Assistive Technologies"
 #~ msgstr "Yardımcıl Tehnologiyalar"
 
@@ -7656,10 +8454,6 @@ msgstr "Tercihler;Ayarlar;"
 
 #~ msgid "_Enable assistive technologies"
 #~ msgstr "_Yardımcıl tehnologiyalarnı qabilleştir"
-
-# tr
-#~ msgid "_Keyboard Accessibility"
-#~ msgstr "_Klavye Erişilebilirliği"
 
 # tr
 #~ msgid "_Mouse Accessibility"
@@ -8109,16 +8903,8 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr "Dosye kopiyalana: %u / %u"
 
 # tr
-#~ msgid "Parent Window"
-#~ msgstr "Üst Pencere"
-
-# tr
 #~ msgid "Parent window of the dialog"
 #~ msgstr "Pencerenin üst penceresi"
-
-# tr
-#~ msgid "From URI"
-#~ msgstr "Kaynak URI"
 
 # tr
 #~ msgid "URI currently transferring from"
@@ -8131,10 +8917,6 @@ msgstr "Tercihler;Ayarlar;"
 # tr
 #~ msgid "URI currently transferring to"
 #~ msgstr "URI halen buraya aktarıyor"
-
-# tr
-#~ msgid "Fraction completed"
-#~ msgstr "İşlem tamamlandı"
 
 # tr
 #~ msgid "Fraction of transfer currently completed"
@@ -8273,10 +9055,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr "Ekran Okuyucu olmadan GNOME Büyüteci"
 
 # tr
-#~ msgid "GNOME Terminal"
-#~ msgstr "GNOME Terminal"
-
-# tr
 #~ msgid "Gnopernicus"
 #~ msgstr "Gnopernicus"
 
@@ -8323,13 +9101,6 @@ msgstr "Tercihler;Ayarlar;"
 # tr
 #~ msgid "Include _panel"
 #~ msgstr "_Paneli dahil et"
-
-#~ msgid "Panel icon"
-#~ msgstr "Panel işaretçigi"
-
-# tr
-#~ msgid "Re_fresh rate:"
-#~ msgstr "_Tazeleme hızı:"
 
 #~ msgid "Sa_me image in all monitors"
 #~ msgstr "Hepsi ekranlarda _aynı suret"
@@ -8396,10 +9167,6 @@ msgstr "Tercihler;Ayarlar;"
 # tr
 #~ msgid "%d Hz"
 #~ msgstr "%d Hz"
-
-# tr
-#~ msgid "Desktop"
-#~ msgstr "Masaüstü"
 
 # tr
 #~ msgid "Error unsetting accelerator in configuration database: %s"
@@ -8603,13 +9370,6 @@ msgstr "Tercihler;Ayarlar;"
 
 #~ msgid "Hide on start (useful to preload the shell)"
 #~ msgstr "Başlağanda gizle (qabuqnı ög-yüklemek içün faydalıdır)"
-
-#~ msgid "Filter"
-#~ msgstr "Süzgüç"
-
-# tüklü
-#~ msgid "Common Tasks"
-#~ msgstr "Umumiy Vazifeler"
 
 # tr
 #~ msgid "Close the control-center when a task is activated"
@@ -8882,10 +9642,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr "Belgeler"
 
 # tr
-#~ msgid "Move to Trash"
-#~ msgstr "Çöpe Taşı"
-
-# tr
 #~ msgid "If you delete an item, it is permanently lost."
 #~ msgstr "Eğer bir öğeyi silerseniz, o tamamen kaybolacak."
 
@@ -9011,10 +9767,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "Sylpheed-Claws"
 
-# tr
-#~ msgid "Thunderbird"
-#~ msgstr "Thunderbird"
-
 #~ msgid ""
 #~ "Testing the new settings. If you don't respond in %d second the previous "
 #~ "settings will be restored."
@@ -9127,10 +9879,6 @@ msgstr "Tercihler;Ayarlar;"
 # tr
 #~ msgid "_Jabber:"
 #~ msgstr "_Jabber:"
-
-# tr
-#~ msgid "Edit"
-#~ msgstr "Düzenle"
 
 # tr
 #~ msgid "Show _icons in menus"
@@ -9248,14 +9996,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr "_Yeni"
 
 # tr
-#~ msgid "_Open"
-#~ msgstr "_Aç"
-
-# tr
-#~ msgid "_Save"
-#~ msgstr "_Kaydet"
-
-# tr
 #~ msgid ""
 #~ "Normal\n"
 #~ "Left\n"
@@ -9279,10 +10019,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ "<span size=\"large\"><b>Hiç bir eşleşme tapılmadı.</b> </span><span>\n"
 #~ "\n"
 #~ " Süzgüçiñiz olğan \"<b>%s</b>\" hiç bir unsur ile eşleşmey.</span>"
-
-# tr
-#~ msgid "/_About"
-#~ msgstr "/_Hakkında"
 
 # tr
 #~ msgid "Zip/_Postal code:"
@@ -9323,9 +10059,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Change the background"
 #~ msgstr "Arqazeminni deñiştir"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "Bluetooth ayarlarını endamlandır"
-
 #~ msgid "Browse Files..."
 #~ msgstr "Dosyelerni Kezin..."
 
@@ -9333,10 +10066,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgctxt "Power"
 #~ msgid "Bluetooth"
 #~ msgstr "Bluetooth"
-
-# tr
-#~ msgid "Create virtual device"
-#~ msgstr "Sanal aygıt oluştur"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "Ekranlar içün Faydalanışlı Profiller"
@@ -9428,13 +10157,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Unspecified"
 #~ msgstr "Belirtilmegen"
 
-#~ msgid "Select a language"
-#~ msgstr "Bir til saylañız"
-
-# tr
-#~ msgid "_Select"
-#~ msgstr "_Sayla"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "Tarih ve Saat tercihleri paneli"
 
@@ -9493,10 +10215,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr "Tizilim Ayarları"
 
 # tr
-#~ msgid "Shortcut"
-#~ msgstr "Qısqayol"
-
-# tr
 #~ msgid "Set your mouse and touchpad preferences"
 #~ msgstr "Fare ve imleçsürer tercihlerinizi yapın"
 
@@ -9530,9 +10248,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Drag Threshold"
 #~ msgstr "Süyrekleme Eşigi"
 
-#~ msgid "Double-Click Timeout"
-#~ msgstr "Çift-Çertme Zaman Aşımı"
-
 # tr
 #~ msgid "_Timeout:"
 #~ msgstr "_Zaman aşımı:"
@@ -9543,9 +10258,6 @@ msgstr "Tercihler;Ayarlar;"
 # tüklü
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "Tiyüv-şiltesi ile _sıçan çertmelerini faalleştir"
-
-#~ msgid "Scrolling"
-#~ msgstr "Taydıruv"
 
 #~ msgid "_Disabled"
 #~ msgstr "_Ğayrı qabilleştirilgen"
@@ -9573,14 +10285,6 @@ msgstr "Tercihler;Ayarlar;"
 # tr
 #~ msgid "Create _Hotspot"
 #~ msgstr "Etkin Nokta _Oluştur"
-
-# tr
-#~ msgid "Airplane Mode"
-#~ msgstr "Uçak Kipi"
-
-# tüklü
-#~ msgid "Network;Wireless;IP;LAN;Proxy;"
-#~ msgstr "Şebeke;Kabelsiz;İP;LAN;Proksi;"
 
 #~ msgid "Create..."
 #~ msgstr "İcat Et..."
@@ -9697,20 +10401,8 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr "Şu yüzden etkisiz olunca askıya al:"
 
 # tr
-#~ msgid "Change printer settings"
-#~ msgstr "Yazıcı ayarlarını değiştir"
-
-# tr
 #~ msgid "A_ddress:"
 #~ msgstr "_Adres:"
-
-# tr
-#~ msgid "_Search by Address"
-#~ msgstr "_Adrese göre Ara"
-
-# tr
-#~ msgid "Getting devices..."
-#~ msgstr "Aygıtlar aranıyor..."
 
 # tr
 #~ msgid ""
@@ -9727,9 +10419,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgctxt "printer type"
 #~ msgid "Network"
 #~ msgstr "Şebeke"
-
-#~ msgid "Device types"
-#~ msgstr "Cihaz türleri"
 
 # tr
 #~ msgid "Automatic configuration"
@@ -9754,10 +10443,6 @@ msgstr "Tercihler;Ayarlar;"
 # tr
 #~ msgid "_Back"
 #~ msgstr "_Geri"
-
-# tr
-#~ msgid "Add User"
-#~ msgstr "Kullanıcı Ekle"
 
 # tr
 #~ msgid "Allowed users"
@@ -9797,9 +10482,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr ""
 #~ "Bir kösterim tili saylañız (deñişiklik bir soñraki kere içeri "
 #~ "imzalanğanıñızda yürerlikke kirecek)"
-
-#~ msgid "Install languages..."
-#~ msgstr "Tillerni qur..."
 
 #~ msgid "Add Language"
 #~ msgstr "Til Ekle"
@@ -9862,15 +10544,8 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "System settings"
 #~ msgstr "Sistem ayarları"
 
-#~ msgid "Layout"
-#~ msgstr "Tizilim"
-
 #~ msgid "Brightness and Lock"
 #~ msgstr "Parlaqlıq ve Kilit"
-
-# tr
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "Ekran parlaklığı ve kilitleme ayarları"
 
 # tr
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
@@ -9886,9 +10561,6 @@ msgstr "Tercihler;Ayarlar;"
 
 #~ msgid "Locations..."
 #~ msgstr "Qonumlar..."
-
-#~ msgid "Lock"
-#~ msgstr "Kilitle"
 
 # tr
 #~ msgid "Enable debugging code"
@@ -9906,14 +10578,6 @@ msgstr "Tercihler;Ayarlar;"
 # tr
 #~ msgid "Sound Output Volume"
 #~ msgstr "Ses Çıkış Şiddeti"
-
-# tr
-#~ msgid "Microphone Volume"
-#~ msgstr "Mikrofon Sesi"
-
-# tr
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "Yapılandırmak için aygıt _seçin:"
 
 # tr
 #~ msgid "Failed to start Sound Preferences: %s"
@@ -9950,14 +10614,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "_Text size:"
 #~ msgstr "_Yazı boyutu:"
 
-# tr
-#~ msgid "Increase size:"
-#~ msgstr "Boyutu artır:"
-
-# tr
-#~ msgid "Decrease size:"
-#~ msgstr "Boyutu düşür:"
-
 #~ msgctxt "universal access, seeing"
 #~ msgid "Display"
 #~ msgstr "Kösterim"
@@ -9969,12 +10625,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgctxt "universal access, seeing"
 #~ msgid "Zoom"
 #~ msgstr "Odaklama"
-
-#~ msgid "Screen keyboard"
-#~ msgstr "Ekran Klavyesi"
-
-#~ msgid "Typing Assistant"
-#~ msgstr "Tuşlama Muavini"
 
 # tr
 #~ msgid "Type here to test settings"
@@ -10023,9 +10673,6 @@ msgstr "Tercihler;Ayarlar;"
 
 #~ msgid "Fair"
 #~ msgstr "Ortaca"
-
-#~ msgid "Account _type"
-#~ msgstr "Hesap _türü"
 
 # tr
 #~ msgid "More choices..."
@@ -10135,10 +10782,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr "Cep telefonu"
 
 #, fuzzy
-#~ msgid "User name:"
-#~ msgstr "Qullanıcı Adı"
-
-#, fuzzy
 #~ msgid "Web"
 #~ msgstr "_Ağ"
 
@@ -10150,10 +10793,6 @@ msgstr "Tercihler;Ayarlar;"
 #, fuzzy
 #~ msgid "_Home page:"
 #~ msgstr "Deñeme sahifesi"
-
-#, fuzzy
-#~ msgid "_Mobile:"
-#~ msgstr "_Profil:"
 
 # tr
 #, fuzzy
@@ -10257,11 +10896,6 @@ msgstr "Tercihler;Ayarlar;"
 # tr
 #, fuzzy
 #~ msgid "Change pa_ssword"
-#~ msgstr "Parola değiştiriliyor"
-
-# tr
-#, fuzzy
-#~ msgid "Change password"
 #~ msgstr "Parola değiştiriliyor"
 
 # tr
@@ -10398,10 +11032,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "_None"
 #~ msgstr "Hiç biri"
 
-#, fuzzy
-#~ msgid "_Reset to Defaults"
-#~ msgstr "Ögbelgilemelerge _Sıfırla"
-
 # tr
 #, fuzzy
 #~ msgid "_Selected items:"
@@ -10416,9 +11046,6 @@ msgstr "Tercihler;Ayarlar;"
 #, fuzzy
 #~ msgid "_Style:"
 #~ msgstr "Tablet Kalemi (Stylus)"
-
-#~ msgid "Appearance"
-#~ msgstr "Körüniş"
 
 #, fuzzy
 #~ msgid "%d %s by %d %s"
@@ -10581,18 +11208,9 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Could not load the main interface"
 #~ msgstr "Ekran yapılandırması kaydedilemedi"
 
-# tr
-#, fuzzy
-#~ msgid "Please make sure that the applet is properly installed"
-#~ msgstr "Lütfen AccountService' in kurulu ve etkin olduğundan emin olun."
-
 #, fuzzy
 #~ msgid "- GNOME Default Applications"
 #~ msgstr "Ögbelgilengen Uyğulamalar"
-
-#, fuzzy
-#~ msgid "Accessibility"
-#~ msgstr "Körünirlik"
 
 # tr
 #, fuzzy
@@ -10713,10 +11331,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr "Aşağı Avuştır"
 
 #, fuzzy
-#~ msgid "Mirror Screens"
-#~ msgstr "¼ Ekran"
-
-#, fuzzy
 #~ msgid "Monitor: %s"
 #~ msgstr "Ekran"
 
@@ -10786,32 +11400,12 @@ msgstr "Tercihler;Ayarlar;"
 
 # tr
 #, fuzzy
-#~ msgid "Beep when _accessibility features are turned on or off"
-#~ msgstr "Erişilebilirlik özelliklerini klavyeden _aç"
-
-# tr
-#, fuzzy
-#~ msgid "Beep when a _modifier key is pressed"
-#~ msgstr "_Değiştirici tuşa basıldığında biple"
-
-# tr
-#, fuzzy
 #~ msgid "Beep when a _toggle key is pressed"
 #~ msgstr "_Değiştirici tuşa basıldığında biple"
 
 # tr
 #, fuzzy
-#~ msgid "Beep when a key is pr_essed"
-#~ msgstr "_Değiştirici tuşa basıldığında biple"
-
-# tr
-#, fuzzy
 #~ msgid "Beep when a key is reje_cted"
-#~ msgstr "Bir tuş _reddedildiğinde biple"
-
-# tr
-#, fuzzy
-#~ msgid "Beep when key is _accepted"
 #~ msgstr "Bir tuş _reddedildiğinde biple"
 
 # tr
@@ -10872,10 +11466,6 @@ msgstr "Tercihler;Ayarlar;"
 #, fuzzy
 #~ msgid "Typing Break"
 #~ msgstr "Tuşlama"
-
-#, fuzzy
-#~ msgid "_Acceleration:"
-#~ msgstr "_Tezleşme:"
 
 #, fuzzy
 #~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
@@ -10959,15 +11549,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Dwell Click"
 #~ msgstr "Durağan Tıklama"
 
-# tr
-#, fuzzy
-#~ msgid "Locate Pointer"
-#~ msgstr "Yazıcıyı Kaldır"
-
-#, fuzzy
-#~ msgid "Seco_ndary click:"
-#~ msgstr "Ekilemci çertme keçikmesi"
-
 #, fuzzy
 #~ msgid ""
 #~ "To test your double-click settings, try to double-click on the light bulb."
@@ -10996,10 +11577,6 @@ msgstr "Tercihler;Ayarlar;"
 #, fuzzy
 #~ msgid "New Location..."
 #~ msgstr "Qonumlar..."
-
-#, fuzzy
-#~ msgid "Network Proxy"
-#~ msgstr "Şebekede proksisi"
 
 # tr
 #, fuzzy
@@ -11050,10 +11627,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "U_sername:"
 #~ msgstr "Qullanıcı Adı"
 
-#, fuzzy
-#~ msgid "_Details"
-#~ msgstr "Tafsilât"
-
 # tr
 #, fuzzy
 #~ msgid "_Location name:"
@@ -11096,14 +11669,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Window Selection"
 #~ msgstr "Bölüm"
 
-#, fuzzy
-#~ msgid "seconds"
-#~ msgstr "30 saniye"
-
-#, fuzzy
-#~ msgid "Windows"
-#~ msgstr "Windows yazılımı"
-
 # tr
 #, fuzzy
 #~ msgid "Maximize"
@@ -11140,16 +11705,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Typing Monitor"
 #~ msgstr "Ekran"
 
-# tr
-#, fuzzy
-#~ msgid "Name:"
-#~ msgstr "İ_sim:"
-
-# tr
-#, fuzzy
-#~ msgid "Style:"
-#~ msgstr "Tablet Kalemi (Stylus)"
-
 #, fuzzy
 #~ msgid "Type:"
 #~ msgstr "_Tür:"
@@ -11162,14 +11717,6 @@ msgstr "Tercihler;Ayarlar;"
 #, fuzzy
 #~ msgid "Description:"
 #~ msgstr "Bölüm"
-
-#, fuzzy
-#~ msgid "Installed"
-#~ msgstr "Qurula"
-
-#, fuzzy
-#~ msgid "Install Failed"
-#~ msgstr "Yañartmalarnı Qur"
 
 #, fuzzy
 #~ msgid "I_nstall Font"
@@ -11193,16 +11740,8 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgstr "Profilni çetleştir"
 
 #, fuzzy
-#~ msgid "Network Servers"
-#~ msgstr "Şebeke Adı"
-
-#, fuzzy
 #~ msgid "<b>Open</b>"
 #~ msgstr "<b>Tema</b>"
-
-#, fuzzy
-#~ msgid "Rename..."
-#~ msgstr "İcat Et..."
 
 #, fuzzy
 #~ msgid "Send To..."
@@ -11216,10 +11755,6 @@ msgstr "Tercihler;Ayarlar;"
 #, fuzzy
 #~ msgid "Are you sure you want to permanently delete \"%s\"?"
 #~ msgstr "Hesabı silmek istediğinizden emin misiniz?"
-
-#, fuzzy
-#~ msgid "Open with Default Application"
-#~ msgstr "Ögbelgilengen Uyğulamalar"
 
 # tr
 #, fuzzy
@@ -11258,10 +11793,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "KMail"
 #~ msgstr "_Poşta"
 
-#, fuzzy
-#~ msgid "Keep Settings"
-#~ msgstr "Ayarlarnı Kopiyala"
-
 # tr
 #, fuzzy
 #~ msgid "Do you want to keep these settings?"
@@ -11274,10 +11805,6 @@ msgstr "Tercihler;Ayarlar;"
 #, fuzzy
 #~ msgid "Visual Effects"
 #~ msgstr "Körsel İqazlar"
-
-#, fuzzy
-#~ msgid "_Keep settings"
-#~ msgstr "Sistem ayarları"
 
 # tr
 #, fuzzy
@@ -11386,10 +11913,6 @@ msgstr "Tercihler;Ayarlar;"
 #, fuzzy
 #~ msgid "New windows get layout \"foobar\""
 #~ msgstr "Yañı pencereler ögbelgilengen tizilimni qullanır"
-
-#, fuzzy
-#~ msgid "<b>Email</b>"
-#~ msgstr "<b>Tema</b>"
 
 #, fuzzy
 #~ msgid "<b>Home</b>"
@@ -11513,9 +12036,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Left side"
 #~ msgstr "Sol yan"
 
-#~ msgid "Top left corner"
-#~ msgstr "Sol üst köşe"
-
 #~ msgid "Other reveal option"
 #~ msgstr "Diğer ayarları göster"
 
@@ -11539,9 +12059,6 @@ msgstr "Tercihler;Ayarlar;"
 
 #~ msgid "Restore Default Behaviours"
 #~ msgstr "Öntanımlı Davranışları Geri Yükle"
-
-#~ msgid "Behavior"
-#~ msgstr "Davranış"
 
 #~ msgid "default"
 #~ msgstr "öntanımlı"
@@ -11567,23 +12084,11 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "When battery is charging/in use"
 #~ msgstr "Pil şarj olurken/kullanımdayken"
 
-#~ msgid "When the lid is closed"
-#~ msgstr "Kapak kapalı olduğunda"
-
 #~ msgid "Show battery status in the _menu bar"
 #~ msgstr "_Menü çubuğunda pil durumunu göster"
 
-#~ msgid "Keyboard Layout"
-#~ msgstr "Klavye Tizilimi"
-
 #~ msgid "Require my password when waking from suspend"
 #~ msgstr "Askıya alınıp uyandıktan sonra parolama gerek duyulsun"
-
-#~ msgid "Mute"
-#~ msgstr "Sessiz"
-
-#~ msgid "Settings for %s"
-#~ msgstr "%s için ayarlar"
 
 #~ msgid "Mode:"
 #~ msgstr "Kip:"
@@ -11591,17 +12096,8 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Test:"
 #~ msgstr "Sınama:"
 
-#~ msgid "Test Sound"
-#~ msgstr "Sınama Sesi"
-
-#~ msgid "Application Menu"
-#~ msgstr "Uyğulama Menüsi"
-
 #~ msgid "Shutdown"
 #~ msgstr "Kapat"
-
-#~ msgid "Unlock"
-#~ msgstr "Kilidi Aç"
 
 #~ msgid "Clockwise"
 #~ msgstr "Saat Yönünde"
@@ -11653,9 +12149,6 @@ msgstr "Tercihler;Ayarlar;"
 
 #~ msgid "Network;Wireless;IP;LAN;"
 #~ msgstr "Ağ;Kablosuz;İP;LAN;"
-
-#~ msgid "Speed"
-#~ msgstr "Hız"
 
 #~ msgid "Battery charging"
 #~ msgstr "Pil doluyor"
@@ -11756,9 +12249,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "_Other Media..."
 #~ msgstr "_Diger Vasatlar..."
 
-#~ msgid "Network settings"
-#~ msgstr "Şebeke ayarları"
-
 # tr
 #~ msgid "Out of range"
 #~ msgstr "Menzil tışı"
@@ -11825,9 +12315,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Your settings"
 #~ msgstr "Ayarlarıñız"
 
-#~ msgid "Change your keyboard or input method settings"
-#~ msgstr "Klavye yaaki kirdi usulı ayarlarıñıznı deñiştiriñiz"
-
 #~ msgid "Brightness & Lock"
 #~ msgstr "Parlaqlıq & Kilit"
 
@@ -11866,9 +12353,6 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Center"
 #~ msgstr "Ortala"
 
-#~ msgid "Scale"
-#~ msgstr "Miqyasla"
-
 #~ msgid "Tile"
 #~ msgstr "Töşe"
 
@@ -11887,9 +12371,6 @@ msgstr "Tercihler;Ayarlar;"
 
 #~ msgid "Date and Time"
 #~ msgstr "Tarih ve Saat"
-
-#~ msgid "Mirror Displays"
-#~ msgstr "Ekranlarnı Küzgüle"
 
 # tr
 #~ msgid ""
@@ -11912,16 +12393,9 @@ msgstr "Tercihler;Ayarlar;"
 #~ msgid "Good"
 #~ msgstr "Eyi"
 
-# tr
-#~ msgid "Active Print Jobs"
-#~ msgstr "Etkin Yazdırma İşleri"
-
 # tüklü
 #~ msgid "Beep when Caps and Num Lock are used"
 #~ msgstr "Caps ve Num Lock qullanılğanında biple"
-
-#~ msgid "_Contrast:"
-#~ msgstr "_Tezat:"
 
 #~ msgid "Change the background and theme"
 #~ msgstr "Arqazemin ve temanı deñiştir"

--- a/po/crh.po~
+++ b/po/crh.po~
@@ -1,0 +1,11933 @@
+# Qırımtatarca gnome-control-center.
+# This file is distributed under the same license as the gnome-control-center package.
+# Reşat SABIQ <tilde.birlik@gmail.com>, 2009, 2010, 2011, 2012, 2013.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-05-21 19:21-0500\n"
+"PO-Revision-Date: 2013-05-23 18:26-0500\n"
+"Last-Translator: Reşat SABIQ <tilde.birlik@gmail.com>\n"
+"Language-Team: QIRIMTATARCA (Qırım Türkçesi) <tilde-birlik-meydan@lists."
+"sourceforge.net>\n"
+"Language: crh\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: UTF-8\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Launchpad-Export-Date: 2013-04-18 01:48+0000\n"
+"X-Generator: Launchpad (build 16567)\n"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:2
+msgid "Changes throughout the day"
+msgstr "Kün boyunca deñişir"
+
+#: ../panels/background/background.ui.h:3
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Töşe"
+
+# tüklü
+#: ../panels/background/background.ui.h:4
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Miqyasla"
+
+#: ../panels/background/background.ui.h:5
+msgctxt "background, style"
+msgid "Center"
+msgstr "Ortala"
+
+# tüklü
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Miqyasla"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Toldur"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Span"
+msgstr "Qarışla"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:199
+msgid "Select Background"
+msgstr "Arqazemin Sayla"
+
+# tr
+#: ../panels/background/cc-background-chooser-dialog.c:218
+msgid "Wallpapers"
+msgstr "Duvar Kağıtları"
+
+# tr
+#: ../panels/background/cc-background-chooser-dialog.c:227
+msgid "Pictures"
+msgstr "Resimler"
+
+#: ../panels/background/cc-background-chooser-dialog.c:235
+msgid "Colors"
+msgstr "Tüsler"
+
+#: ../panels/background/cc-background-chooser-dialog.c:244
+msgid "Flickr"
+msgstr "Flickr"
+
+#: ../panels/background/cc-background-chooser-dialog.c:286
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+#: ../panels/user-accounts/um-photo-dialog.c:98
+msgid "Select"
+msgstr "Sayla"
+
+#: ../panels/background/cc-background-item.c:150
+msgid "multiple sizes"
+msgstr "müteaddit ölçü"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:154
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:283
+msgid "No Desktop Background"
+msgstr "Masaüstü Arqazemini Yoq"
+
+#: ../panels/background/cc-background-panel.c:453
+msgid "Current background"
+msgstr "Cari arqazemin"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "Arqazemin"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Arqazemin suretiñizni bir divar kâğıtına yaki fotoğa deñiştiriñiz"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Divar kâğıtı;Ekran;Masaüstü;"
+
+#: ../panels/bluetooth/bluetooth.ui.h:1
+msgid "Set Up New Device"
+msgstr "Yañı Cihaznı Ayarla"
+
+#: ../panels/bluetooth/bluetooth.ui.h:2 ../panels/network/network.ui.h:9
+msgid "Remove Device"
+msgstr "Cihaznı Çetleştir"
+
+#: ../panels/bluetooth/bluetooth.ui.h:3
+msgid "Connection"
+msgstr "Bağlantı"
+
+#: ../panels/bluetooth/bluetooth.ui.h:4
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "sahife 1"
+
+#: ../panels/bluetooth/bluetooth.ui.h:5
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "sahife 2"
+
+#: ../panels/bluetooth/bluetooth.ui.h:6
+msgid "Paired"
+msgstr "Çiftlengen"
+
+#: ../panels/bluetooth/bluetooth.ui.h:7 ../panels/wacom/cc-wacom-page.c:833
+msgid "Type"
+msgstr "Tür"
+
+# tr
+#: ../panels/bluetooth/bluetooth.ui.h:8
+#: ../panels/network/connection-editor/ce-page-ip4.c:189
+#: ../panels/network/connection-editor/ce-page-ip4.c:441
+#: ../panels/network/connection-editor/ce-page-ip6.c:191
+#: ../panels/network/connection-editor/ce-page-ip6.c:445
+msgid "Address"
+msgstr "Adres"
+
+#: ../panels/bluetooth/bluetooth.ui.h:9
+msgid "Mouse & Touchpad Settings"
+msgstr "Sıçan & Tiyüv-şiltesi Ayarları"
+
+#: ../panels/bluetooth/bluetooth.ui.h:10
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Sound Settings"
+msgstr "Davuş Ayarları"
+
+#: ../panels/bluetooth/bluetooth.ui.h:11
+msgid "Keyboard Settings"
+msgstr "Klavye Ayarları"
+
+#: ../panels/bluetooth/bluetooth.ui.h:12
+msgid "Send Files…"
+msgstr "Dosyelerni Yiber…"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:355
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "Ebet"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:355
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "Hayır"
+
+# tr
+#: ../panels/bluetooth/cc-bluetooth-panel.c:469
+msgid "Bluetooth is disabled"
+msgstr "Bluetooth etkin değil"
+
+# tr
+#: ../panels/bluetooth/cc-bluetooth-panel.c:474
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "Bluetooth donanım anahtarı ile kapatıldı"
+
+# tr
+#: ../panels/bluetooth/cc-bluetooth-panel.c:478
+msgid "No Bluetooth adapters found"
+msgstr "Bluetooth bağdaştırıcısı bulunamadı"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:577
+msgid "Visibility"
+msgstr "Körünirlik"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:581
+#, c-format
+msgid "Visibility of “%s”"
+msgstr "“%s” körünirligi"
+
+# tr
+#: ../panels/bluetooth/cc-bluetooth-panel.c:625
+#, c-format
+msgid "Remove '%s' from the list of devices?"
+msgstr "'%s' aygıtlar listesinden kaldırılsın mı?"
+
+# tr
+#: ../panels/bluetooth/cc-bluetooth-panel.c:627
+msgid ""
+"If you remove the device, you will have to set it up again before next use."
+msgstr ""
+"Eğer aygıtı kaldırırsanız, sonraki kullanımdan önce yeniden kurmanız "
+"gerekecek."
+
+# tr
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:360
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:366
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:372
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr ""
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:378
+msgid "Shut the laptop lid"
+msgstr ""
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:409
+msgid "An internal error occurred that could not be recovered."
+msgstr "Toparlanılalmağan dahiliy bir hata hasıl oldı."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:414
+msgid "Tools required for calibration are not installed."
+msgstr ""
+
+# tüklü
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:420
+msgid "The profile could not be generated."
+msgstr "Profil doğurtılamadı."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:426
+msgid "The target whitepoint was not obtainable."
+msgstr ""
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:466
+msgid "Complete!"
+msgstr "Tamam!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:474
+msgid "Calibration failed!"
+msgstr "Kalibrasyon muvaffaqiyetsiz!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:481
+msgid "You can remove the calibration device."
+msgstr ""
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:552
+msgid "Do not disturb the calibration device while in progress"
+msgstr ""
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Tizüstü Ekranı"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Yapı-içi Ağ Kamerası"
+
+# tüklü
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s Monitorı"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s Tarayıcısı"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s Kamerası"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s Bastırıcısı"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s Ağ kamerası"
+
+# tr
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s içün tüs idaresini qabilleştir"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr ""
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+msgid "Not calibrated"
+msgstr "Kalibrasyonsız"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:136
+msgid "Default: "
+msgstr "Ögbelgilengen: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:144
+msgid "Colorspace: "
+msgstr "Renk fezası: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:151
+msgid "Test profile: "
+msgstr "Sınama profili: "
+
+# tr
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:219
+msgid "Select ICC Profile File"
+msgstr "ICC Profil Dosyasını Seç"
+
+#: ../panels/color/cc-color-panel.c:222
+msgid "_Import"
+msgstr "_İthal Et"
+
+# tr
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:233
+msgid "Supported ICC profiles"
+msgstr "Desteklenen ICC profilleri"
+
+# tr
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:240
+#: ../panels/network/wireless-security/eap-method-fast.c:410
+msgid "All files"
+msgstr "Tüm dosyalar"
+
+#: ../panels/color/cc-color-panel.c:587
+msgid "Screen"
+msgstr "Ekran"
+
+# tr
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:913
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Dosye yükletilamadı: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:927
+msgid "The profile has been uploaded to:"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:929
+msgid "Write down this URL."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:930
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:931
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:965
+msgid "Save Profile"
+msgstr "Profilni Saqla"
+
+# tr
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1326
+msgid "Create a color profile for the selected device"
+msgstr "Seçilen aygıt için bir renk profili oluştur"
+
+# tr
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1341 ../panels/color/cc-color-panel.c:1365
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Ölçüm cihazı algılanamadı. Lütfen açık durumda olduğundan ve doğru "
+"bağlandığından emin olunuz."
+
+# tr
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1375
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Ölçüm cihazı yazıcı profillemeyi desteklemiyor."
+
+# tr
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1386
+msgid "The device type is not currently supported."
+msgstr "Aygıt türü şu anda desteklenmiyor."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:101
+msgid "Standard Space"
+msgstr "Standart Feza"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:107
+msgid "Test Profile"
+msgstr "Sınama Profili"
+
+# tr
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:115
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Otomatik"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:125
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Tüşük Keyfiyet"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:130
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Orta Keyfiyet"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:137
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Yüksek Keyfiyet"
+
+# tr
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:154
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Öntanımlı RGB"
+
+# tr
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:161
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Öntanımlı CMYK"
+
+# tr
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:168
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Öntanımlı Gri"
+
+#: ../panels/color/cc-color-profile.c:192
+msgid "Vendor supplied factory calibration data"
+msgstr ""
+
+#: ../panels/color/cc-color-profile.c:201
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+
+#: ../panels/color/cc-color-profile.c:223
+msgid "This profile may no longer be accurate"
+msgstr "Bu profil belki artıq daqıq degildir"
+
+# tr
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "Kösterim Kalibrasyonı"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+#: ../panels/user-accounts/um-account-dialog.c:1082
+msgid "Cancel"
+msgstr "Vazgeç"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "Başlat"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "Devam Et"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "Tamam"
+
+# tr
+#. Timeout parameters
+#. 5000 = 5 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:81
+msgid "Screen Calibration"
+msgstr "Ekran Kalibrasyonu"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "Keyfiyet"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr ""
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "Kalibrasyon Keyfiyeti"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+# tr
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "Kalibrasyon Cihazı"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "Kösterim Türü"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "Profil Aq Noqtası"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "Kösterim Parlaqlığı"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "Profil İsmi:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "Profil İsmi"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr ""
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "Profilni kopiyala"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr ""
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "Profilni yüklet"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "İnternet bağlantısı şart"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+# tr
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:743
+msgid "Summary"
+msgstr "Hulâsa"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr ""
+
+#: ../panels/color/color.ui.h:29
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: ../panels/color/color.ui.h:30
+msgid "Device type:"
+msgstr "Cihaz türü:"
+
+#: ../panels/color/color.ui.h:31
+msgid "Manufacturer:"
+msgstr "İmalâtçı:"
+
+#: ../panels/color/color.ui.h:32
+msgid "Model:"
+msgstr "Model:"
+
+# tr
+#: ../panels/color/color.ui.h:33
+msgid ""
+"Image files can be dragged on this window to auto-complete the above fields."
+msgstr ""
+"Yukarıdaki alanların otomatik tamamlanması için resim dosyalarını bu "
+"pencereye sürükleyebilirsiniz."
+
+#: ../panels/color/color.ui.h:34
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "Tüs"
+
+# tr
+#: ../panels/color/color.ui.h:35
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Her aygıt, renk yönetimleri için güncel bir renk profiline gereksinim duyar."
+
+# tr
+#: ../panels/color/color.ui.h:36
+msgid "Learn more"
+msgstr "Daha fazlasını öğren"
+
+# tr
+#: ../panels/color/color.ui.h:37
+msgid "Learn more about color management"
+msgstr "Renk yönetimi hakkında daha fazla bilgi edinin"
+
+# tr
+#: ../panels/color/color.ui.h:38
+msgid "Set for all users"
+msgstr "Tüm kullanıcılar için ayarla"
+
+# tr
+#: ../panels/color/color.ui.h:39
+msgid "Set this profile for all users on this computer"
+msgstr ""
+"Bu profilni bu bilgisayar üzerindeki qullanıcılarnıñ hepsi içün tesbit et"
+
+#: ../panels/color/color.ui.h:40
+msgid "Enable"
+msgstr "Qabilleştir"
+
+#: ../panels/color/color.ui.h:41
+msgid "Add profile"
+msgstr "Profil ekle"
+
+# tr
+#: ../panels/color/color.ui.h:42
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate…"
+msgstr "Kalibrasyon..."
+
+# tr
+#: ../panels/color/color.ui.h:43
+msgid "Calibrate the device"
+msgstr "Aygıtı kalibre et"
+
+#: ../panels/color/color.ui.h:44
+msgid "Remove profile"
+msgstr "Profilni çetleştir"
+
+# tr
+#: ../panels/color/color.ui.h:45
+msgid "View details"
+msgstr "Ayrıntıları görüntüle"
+
+#: ../panels/color/color.ui.h:46
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: ../panels/color/color.ui.h:47
+msgid "LCD"
+msgstr ""
+
+#: ../panels/color/color.ui.h:48
+msgid "LED"
+msgstr ""
+
+#: ../panels/color/color.ui.h:49
+msgid "CRT"
+msgstr ""
+
+#: ../panels/color/color.ui.h:50
+msgid "Projector"
+msgstr "Proyektor"
+
+#: ../panels/color/color.ui.h:51
+msgid "Plasma"
+msgstr ""
+
+#: ../panels/color/color.ui.h:52
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:53
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:54
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:55
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:56
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:57
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Yüksek"
+
+#: ../panels/color/color.ui.h:58
+msgid "40 minutes"
+msgstr "40 daqqa"
+
+#: ../panels/color/color.ui.h:59
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Orta"
+
+#: ../panels/color/color.ui.h:60 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 daqqa"
+
+#: ../panels/color/color.ui.h:61
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Tüşük"
+
+#: ../panels/color/color.ui.h:62 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 daqqa"
+
+#: ../panels/color/color.ui.h:63
+msgid "Native to display"
+msgstr "Kösterimge fıtriy"
+
+# tr
+#: ../panels/color/color.ui.h:64
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Bastıruv ve neşretüv)"
+
+#: ../panels/color/color.ui.h:65
+msgid "D55"
+msgstr ""
+
+#: ../panels/color/color.ui.h:66
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: ../panels/color/color.ui.h:67
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+# tr
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Renk;ICC;Profil;Ayar;Yazıcı;Görünüm;"
+
+# tr
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:682
+msgid "United States"
+msgstr "Birleşik Devletler"
+
+# tr
+#: ../panels/common/cc-common-language.c:683
+msgid "Germany"
+msgstr "Almanya"
+
+# tr
+#: ../panels/common/cc-common-language.c:684
+msgid "France"
+msgstr "Fransa"
+
+# tr
+#: ../panels/common/cc-common-language.c:685
+msgid "Spain"
+msgstr "İspanya"
+
+#: ../panels/common/cc-common-language.c:686
+msgid "China"
+msgstr "Çin"
+
+#: ../panels/common/cc-common-language.c:752
+msgid "Other…"
+msgstr "Diger…"
+
+#: ../panels/common/cc-language-chooser.c:176
+#: ../panels/region/cc-format-chooser.c:266
+#: ../panels/region/cc-input-chooser.c:174
+msgid "More…"
+msgstr "Diger…"
+
+# tr
+#: ../panels/common/cc-language-chooser.c:193
+msgid "No languages found"
+msgstr "Daha çoq til tapıldı"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/common/cc-util.c:28 ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:416
+#: ../panels/keyboard/keyboard-shortcuts.c:1159
+#: ../panels/network/network-wifi.ui.h:29
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:215
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Disabled"
+msgstr "Ğayrıqabilleştirilgen"
+
+#: ../panels/common/cc-util.c:29
+msgid "Left Shift"
+msgstr "Sol Shift"
+
+#: ../panels/common/cc-util.c:30
+msgid "Left Alt"
+msgstr "Sol Alt"
+
+#: ../panels/common/cc-util.c:31
+msgid "Left Ctrl"
+msgstr "Sol Ctrl"
+
+# tr
+#: ../panels/common/cc-util.c:32
+msgid "Right Shift"
+msgstr "Sağ Shift"
+
+# tr
+#: ../panels/common/cc-util.c:33
+msgid "Right Alt"
+msgstr "Sağ Alt"
+
+# tr
+#: ../panels/common/cc-util.c:34
+msgid "Right Ctrl"
+msgstr "Sağ Ctrl"
+
+#: ../panels/common/cc-util.c:35
+msgid "Left Alt+Shift"
+msgstr "Sol Alt+Shift"
+
+# tr
+#: ../panels/common/cc-util.c:36
+msgid "Right Alt+Shift"
+msgstr "Oñ Alt+Shift"
+
+#: ../panels/common/cc-util.c:37
+msgid "Left Ctrl+Shift"
+msgstr ""
+
+# tr
+#: ../panels/common/cc-util.c:38
+msgid "Right Ctrl+Shift"
+msgstr "Oñ Ctrl+Shift"
+
+#: ../panels/common/cc-util.c:39
+msgid "Left+Right Shift"
+msgstr ""
+
+#: ../panels/common/cc-util.c:40 ../panels/region/input-options.ui.h:11
+msgid "Left+Right Alt"
+msgstr ""
+
+#: ../panels/common/cc-util.c:41
+msgid "Left+Right Ctrl"
+msgstr ""
+
+#: ../panels/common/cc-util.c:42
+msgid "Alt+Shift"
+msgstr ""
+
+#: ../panels/common/cc-util.c:43
+msgid "Ctrl+Shift"
+msgstr ""
+
+#: ../panels/common/cc-util.c:44
+msgid "Alt+Ctrl"
+msgstr ""
+
+#: ../panels/common/cc-util.c:45
+msgid "Caps"
+msgstr ""
+
+#: ../panels/common/cc-util.c:46
+msgid "Shift+Caps"
+msgstr ""
+
+#: ../panels/common/cc-util.c:47
+msgid "Alt+Caps"
+msgstr ""
+
+#: ../panels/common/cc-util.c:48
+msgid "Ctrl+Caps"
+msgstr ""
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "Til"
+
+# tr
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "_Tamam"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "_Region:"
+msgstr "_Bölge:"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "_City:"
+msgstr "_Şeher:"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "_Network Time"
+msgstr "_Şebeke Vaqtı"
+
+#. Translator: this is the separator between hours and minutes, like in HH:MM
+#: ../panels/datetime/datetime.ui.h:5
+msgid ":"
+msgstr ":"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "Set the time one hour ahead."
+msgstr "Saatni bir saat ileri tesbit et."
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "Set the time one hour back."
+msgstr "Saatni bir saat keri tesbit et."
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "Set the time one minute ahead."
+msgstr "Saatni bir daqqa ileri tesbit et."
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "Set the time one minute back."
+msgstr "Saatni bir daqqa keri tesbit et."
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "Switch between AM and PM."
+msgstr "Üyleden evvel ve üyleden soñ arasında almaştır."
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "Month"
+msgstr "Ay"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "Day"
+msgstr "Kün"
+
+#: ../panels/datetime/datetime.ui.h:13
+msgid "Year"
+msgstr "Yıl"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "24-hour"
+msgstr "24-saat"
+
+#: ../panels/datetime/datetime.ui.h:15
+msgid "AM/PM"
+msgstr "ÜE/ÜS"
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "January"
+msgstr "Ocaq"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "February"
+msgstr "Şubat"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "March"
+msgstr "Mart"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "April"
+msgstr "Nisan"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "May"
+msgstr "Mayıs"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "June"
+msgstr "Haziran"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "July"
+msgstr "Temmuz"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "August"
+msgstr "Ağustos"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "September"
+msgstr "Eylül"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "October"
+msgstr "Ekim"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "November"
+msgstr "Qasım"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "December"
+msgstr "Aralıq"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "Tarih & Saat"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "Saat;Saat Tilimi;Qonum;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "Sistem vaqtı ve tarih ayarlarını deñiştir"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Vaqıt yaki tarih ayarlarını deñiştirmek içün sahihlenmeñiz kerek."
+
+#: ../panels/display/cc-display-panel.c:483
+msgctxt "display panel, rotation"
+msgid "Normal"
+msgstr "Normal"
+
+#: ../panels/display/cc-display-panel.c:484
+msgctxt "display panel, rotation"
+msgid "Counterclockwise"
+msgstr "Saat yönü tersine"
+
+#: ../panels/display/cc-display-panel.c:485
+msgctxt "display panel, rotation"
+msgid "Clockwise"
+msgstr "Saat yönünde"
+
+#: ../panels/display/cc-display-panel.c:486
+msgctxt "display panel, rotation"
+msgid "180 Degrees"
+msgstr "180 Derece"
+
+#. Keep this string in sync with gnome-desktop/libgnome-desktop/gnome-rr-labeler.c
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external projector.  Here, "Mirrored" is being
+#. * used as an adjective.  For example, the Spanish translation could be
+#. * "Pantallas en Espejo".
+#.
+#. Keep this string in sync with gnome-control-center/capplets/display/xrandr-capplet.c:get_display_name()
+#. Translators:  this is the feature where what you see on your
+#. * laptop's screen is the same as your external projector.
+#. * Here, "Mirrored" is being used as an adjective.  For example,
+#. * the Spanish translation could be "Pantallas en Espejo".
+#.
+#: ../panels/display/cc-display-panel.c:625
+#: ../panels/display/cc-rr-labeler.c:418
+msgid "Mirrored Displays"
+msgstr "Küzgülengen Ekranlar"
+
+#: ../panels/display/cc-display-panel.c:649
+#: ../panels/display/display-capplet.ui.h:1
+msgid "Monitor"
+msgstr "Ekran"
+
+# tr
+#: ../panels/display/cc-display-panel.c:1669
+msgid "Drag to change primary display."
+msgstr "Birincil ekranı değiştirmek için taşıyın."
+
+# tüklü
+#: ../panels/display/cc-display-panel.c:1727
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr ""
+"Hasiyetlerini deñiştirmek içün bir ekran saylañız; yerleştirilmesini kene "
+"tertiplemek içün onı süyrekleñiz."
+
+# tr
+#: ../panels/display/cc-display-panel.c:2115
+msgid "%a %R"
+msgstr "%a %R"
+
+# tr
+#: ../panels/display/cc-display-panel.c:2117
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+# tr
+#: ../panels/display/cc-display-panel.c:2279
+#: ../panels/display/cc-display-panel.c:2331
+#, c-format
+msgid "Failed to apply configuration: %s"
+msgstr "Yapılandırmanın uygulanması başarısız oldu: %s"
+
+# tr
+#: ../panels/display/cc-display-panel.c:2359
+msgid "Could not save the monitor configuration"
+msgstr "Ekran yapılandırması kaydedilemedi"
+
+# tr
+#: ../panels/display/cc-display-panel.c:2419
+msgid "Could not detect displays"
+msgstr "Ekranlar tespit edilemedi"
+
+# tr
+#: ../panels/display/cc-display-panel.c:2614
+msgid "Could not get screen information"
+msgstr "Ekran bilgisi alınamadı"
+
+#: ../panels/display/display-capplet.ui.h:2
+msgid "_Resolution"
+msgstr "_Çezinirlik"
+
+#: ../panels/display/display-capplet.ui.h:3
+msgid "R_otation"
+msgstr "_Aylandırma"
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:5
+msgid "_Mirror displays"
+msgstr "Ekranlarnı _Küzgüle"
+
+# tr
+#: ../panels/display/display-capplet.ui.h:6
+msgid "Note: may limit resolution options"
+msgstr "Bilgi: çözünürlük seçeneklerini kısıtlayabilir"
+
+#: ../panels/display/display-capplet.ui.h:7
+msgid "_Detect Displays"
+msgstr "Ekranları _Alğıla"
+
+# tr
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "Ekranlar"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Bağlanğan monitorlar ve proyektorlarnıñ nasıl qullanılacağını sayla"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr "Panel;Proyektor;xrandr;Ekran;Çezinirlik;Tazeleme;"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:450 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "Bilinmegen"
+
+#: ../panels/info/cc-info-panel.c:532
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-bit"
+
+# tr
+#: ../panels/info/cc-info-panel.c:534
+#, c-format
+msgid "%d-bit"
+msgstr "%d-bit"
+
+#: ../panels/info/cc-info-panel.c:1209
+msgid "Ask what to do"
+msgstr "Ne yapılacağını sora"
+
+#: ../panels/info/cc-info-panel.c:1213
+msgid "Do nothing"
+msgstr "Hiç bir şey yapma"
+
+#: ../panels/info/cc-info-panel.c:1217
+msgid "Open folder"
+msgstr "Cilbent aç"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Other Media"
+msgstr "Diger Vasatlar"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1339
+msgid "Select an application for audio CDs"
+msgstr "Müzik CD'leri için uygulama seçin"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1340
+msgid "Select an application for video DVDs"
+msgstr "Vidyo DVD'leri için uygulama seçin"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1341
+msgid "Select an application to run when a music player is connected"
+msgstr "Müzik çalar bağlandığında çalıştırılacak uygulamayı seçin"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1342
+msgid "Select an application to run when a camera is connected"
+msgstr "Kamera bağlandığında çalıştırılacak uygulamayı seçin"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1343
+msgid "Select an application for software CDs"
+msgstr "Yazılım CD' leri için uygulama seçin"
+
+# tr
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1355
+msgid "audio DVD"
+msgstr "ses DVD' si"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1356
+msgid "blank Blu-ray disc"
+msgstr "boş Blu-ray diski"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1357
+msgid "blank CD disc"
+msgstr "boş CD diski"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1358
+msgid "blank DVD disc"
+msgstr "boş DVD diski"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1359
+msgid "blank HD DVD disc"
+msgstr "boş HD DVD diski"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1360
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video diski"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1361
+msgid "e-book reader"
+msgstr "e-kitap okuyucu"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1362
+msgid "HD DVD video disc"
+msgstr "HD DVD vidyo diski"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1363
+msgid "Picture CD"
+msgstr "Resim CD' si"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1364
+msgid "Super Video CD"
+msgstr "Süper Vidyo CD"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1365
+msgid "Video CD"
+msgstr "Vidyo CD"
+
+#: ../panels/info/cc-info-panel.c:1366
+msgid "Windows software"
+msgstr "Windows yazılımı"
+
+#: ../panels/info/cc-info-panel.c:1367
+msgid "Software"
+msgstr "Yazılım"
+
+# tr
+#: ../panels/info/cc-info-panel.c:1490
+#: ../panels/keyboard/keyboard-shortcuts.c:1696
+msgid "Section"
+msgstr "Bölüm"
+
+#: ../panels/info/cc-info-panel.c:1499 ../panels/info/info.ui.h:13
+msgid "Overview"
+msgstr "Üstbaqış"
+
+#: ../panels/info/cc-info-panel.c:1505 ../panels/info/info.ui.h:20
+msgid "Default Applications"
+msgstr "Ögbelgilengen Uyğulamalar"
+
+#: ../panels/info/cc-info-panel.c:1510 ../panels/info/info.ui.h:28
+msgid "Removable Media"
+msgstr "Çetleştirilebilir Vasat"
+
+#: ../panels/info/cc-info-panel.c:1535
+#, c-format
+msgid "Version %s"
+msgstr "Sürüm %s"
+
+#: ../panels/info/cc-info-panel.c:1585
+msgid "Install Updates"
+msgstr "Yañartmalarnı Qur"
+
+#: ../panels/info/cc-info-panel.c:1589
+msgid "System Up-To-Date"
+msgstr "Sistem Küncel"
+
+#: ../panels/info/cc-info-panel.c:1593
+msgid "Checking for Updates"
+msgstr "Yañartmalar içün Teşkerile"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:44
+msgid "Details"
+msgstr "Tafsilât"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr ""
+
+# tüklü
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"cihaz;sistem;malümat;hafiza;işlemci;sürüm;ögbelgilengen;uyğulama;tercihli;cd;"
+"dvd;usb;davuş;video;disk;çetleştirilebilir;vasat;avtoçaptır;"
+
+# tr
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "Diğer ortamların nasıl kullanılacağını seçin"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "_Amel:"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "_Tür:"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "Cihaz adı"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "Hafiza"
+
+# tr
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "İşlemci"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "Temel sistem"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "Disk"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "Hesaplana…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "Grafikler"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "Sanallaştırma"
+
+#: ../panels/info/info.ui.h:14
+msgid "_Web"
+msgstr "_Ağ"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Mail"
+msgstr "_Poşta"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Calendar"
+msgstr "_Taqvim"
+
+#: ../panels/info/info.ui.h:17
+msgid "M_usic"
+msgstr "_Musıqi"
+
+#: ../panels/info/info.ui.h:18
+msgid "_Video"
+msgstr "_Video"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Photos"
+msgstr "_Fotolar"
+
+# tr
+#: ../panels/info/info.ui.h:21
+msgid "Select how media should be handled"
+msgstr "Ortamın nasıl kullanılacağını seçin"
+
+# tr
+#: ../panels/info/info.ui.h:22
+msgid "CD _audio"
+msgstr "CD _sesi"
+
+#: ../panels/info/info.ui.h:23
+msgid "_DVD video"
+msgstr "_DVD videosı"
+
+#: ../panels/info/info.ui.h:24
+msgid "_Music player"
+msgstr "_Musıqi çalar"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Software"
+msgstr "_Yazılım"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Other Media…"
+msgstr "_Diger Vasatlar…"
+
+# tr
+#: ../panels/info/info.ui.h:27
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Asla bir uygulama çalıştırma ya da sorma..."
+
+# tr
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "Ses ve Ortam"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "Davuşsızlandır"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "Davuş gürlügi aşağı"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "Davuş gürlügi yuqarı"
+
+# tr
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "Ortam oynatıcısını çalıştır"
+
+# tr
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "Oynat (ya da oynat/beklet)"
+
+# tr
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "Oynatmayı beklet"
+
+# tr
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "Oynatmayı durdur"
+
+# tr
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "Önceki parça"
+
+# tr
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "Sonraki parça"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "Çıqart"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/universal-access/uap.ui.h:66
+msgid "Typing"
+msgstr "Tuşlama"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "Soñraki kirdi menbasına almaş"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "Evvelki kirdi menbasına almaş"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "Fırlatıcılar"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "Yardım kezicisini fırlat"
+
+# tr
+#: ../panels/keyboard/01-launchers.xml.in.h:3
+msgid "Launch calculator"
+msgstr "Hesap makinesini çalıştır"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch email client"
+msgstr "E-posta müşterisini fırlat"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch web browser"
+msgstr "Web kezicisini fırlat"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Home folder"
+msgstr "Ev cilbenti"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Qıdır"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "Ekran Körüntüleri"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "Bir ekran körüntisini $PICTURES cilbentine saqla"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Bir pencereniñ bir ekran körüntisini $PICTURES cilbentine saqla"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Bir mıntıqanıñ bir ekran körüntisini $PICTURES cilbentine saqla"
+
+# tr
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "Bir ekran görüntüsünü panoya kopyala"
+
+# tr
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Bir pencerenin ekran görüntüsünü panoya kopyala"
+
+# tr
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Bir alanın ekran görüntüsünü panoya kopyala"
+
+# tr
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "Sistem"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Tışarı imzalan"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "Ekrannı kilitle"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "Cihanşümul İrişim"
+
+# tr
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "Yakınlaştırmayı aç ya da kapat"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "Yaqınlaştır"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "Uzaqlaştır"
+
+# tr
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "Ekran okuyucuyu aç ya da kapat"
+
+# tr
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "Ekran klavyesini aç ya da kapat"
+
+# tr
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "Yazıyı büyüt"
+
+# tr
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "Yazıyı küçült"
+
+# tr
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "Yüksek karşıtlık açık ya da kapalı"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:366
+msgid "Alternative Characters Key"
+msgstr "Alternativ Remizler Tuşu"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:375
+msgid "Compose Key"
+msgstr "Telif Tuşu"
+
+#: ../panels/keyboard/cc-keyboard-option.c:379
+msgid "Modifiers-only switch to next source"
+msgstr "Soñraki menbağa faqat-başqalaştırıcılar almaştırıcısı"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "Keyboard"
+msgstr "Klavye"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"Klavye qısqayollarını seyretiñiz hem deñiştiriñiz ve tuşlama tercihleriñizni "
+"tesbit etiñiz"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Qısqayol;Tekrar;Qıpma;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "Özel Qısqayol"
+
+# tr
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "_Name:"
+msgstr "İ_sim:"
+
+# tr
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "C_ommand:"
+msgstr "Kom_ut:"
+
+# tüklü
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "Repeat Keys"
+msgstr "Tekrarlama Tuşları"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Key presses _repeat when key is held down"
+msgstr "Tuş basıq tutulğanda klavye basmaları _tekrarlanır"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "_Delay:"
+msgstr "_Keçikme:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Speed:"
+msgstr "_Sur'at:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "Qısqa"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "Yavaş"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgid "Repeat keys speed"
+msgstr "Terkrarlama tuşları sur'atı"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "Uzun"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "Tez"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgid "Cursor Blinking"
+msgstr "İmleç Qıpması"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor _blinks in text fields"
+msgstr "Metin alanlarında imleç _qıpar"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "S_peed:"
+msgstr "_Sur'at:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "Cursor blink speed"
+msgstr "İmleç qıpması sür'atı"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "Kirdi Qaynaqları"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+msgid "Add Shortcut"
+msgstr "Qısqayol Ekle"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Remove Shortcut"
+msgstr "Qısqayolnı Çetleştir"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"Bir qısqayolnı tahrir etmek içün, satırğa çertiñiz ve tuşlarnı basıq tutuñız "
+"ya da temizlemek içün Backspace tuşuna basıñız."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid "Shortcuts"
+msgstr "Qısqayollar"
+
+# tr
+#: ../panels/keyboard/keyboard-shortcuts.c:585
+#: ../panels/keyboard/keyboard-shortcuts.c:593
+msgid "Custom Shortcuts"
+msgstr "Özel Qısqayollar"
+
+# tr
+#: ../panels/keyboard/keyboard-shortcuts.c:804
+msgid "<Unknown Action>"
+msgstr "<Bilinmegen Amel>"
+
+# tr
+#: ../panels/keyboard/keyboard-shortcuts.c:1300
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"Kısayol tuşu \"%s\" kullanılamıyor çünkü kullanımı halinde bu tuş "
+"kullanılarak yazmak mümkün olmayacak.\n"
+"Lütfen Control, Alt ya da Shift gibi tuşlar ile aynı anda deneyin."
+
+# tr
+#: ../panels/keyboard/keyboard-shortcuts.c:1332
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"\"%s\" kısayolu bu işlem için kullanılıyor:\n"
+"\"%s\""
+
+# tr
+#: ../panels/keyboard/keyboard-shortcuts.c:1337
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"Eğer kısayolu \"%s\" olarak tekrar atarsanız, \"%s\" kısayolu "
+"etkinsizleştirilecek."
+
+# tr
+#: ../panels/keyboard/keyboard-shortcuts.c:1343
+msgid "_Reassign"
+msgstr "_Kene tayin et"
+
+#: ../panels/mouse/cc-mouse-panel.c:123
+msgid "Test Your _Settings"
+msgstr "Ayarlarıñıznı _Sınañız"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "Sıçan & Tiyüv-şiltesi"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+# tr
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr "Trackpad;İşaretçi;Tıklama;Vurma;Çift;Düğme;Trackball;"
+
+# tr
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "Mouse Preferences"
+msgstr "Fare Tercihleri"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "General"
+msgstr "Umumiy"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "Yavaş"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Double-click timeout"
+msgstr "Çift-çertme zaman aşımı"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "Tez"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "_Double-click"
+msgstr "_Çift-çertme"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Primary _button"
+msgstr "Birlemci _dögme"
+
+# tr
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "_Sol"
+
+# tr
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "_Oñ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "Mouse"
+msgstr "Sıçan"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgid "_Pointer speed"
+msgstr "_İbre sür'atı"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "Yavaş"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "Tez"
+
+# tüklü
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgid "Touchpad"
+msgstr "Tiyüv-şiltesi"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "Yavaş"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "Tez"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Disable while _typing"
+msgstr "_Tuşlağanda ğayrıqabilleştir"
+
+# tüklü
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Tap to _click"
+msgstr "_Çertmek içün türt"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+msgid "Two _finger scroll"
+msgstr "Eki-_parmaqlı taydırma"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "C_ontent sticks to fingers"
+msgstr "_Muhteva parmaqlarğa yapışır"
+
+#: ../panels/mouse/gnome-mouse-test.c:134
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Çertmege, çift çertmege, taydırmağa deñeñiz"
+
+# tüklü
+#: ../panels/mouse/gnome-mouse-test.c:139
+msgid "Five clicks, GEGL time!"
+msgstr "Beş çertme, GEGL zamanı!"
+
+#: ../panels/mouse/gnome-mouse-test.c:144
+msgid "Double click, primary button"
+msgstr "Çift çertme, birlemci dögme"
+
+#: ../panels/mouse/gnome-mouse-test.c:144
+msgid "Single click, primary button"
+msgstr "Tek çertme, birlemci dögme"
+
+#: ../panels/mouse/gnome-mouse-test.c:147
+msgid "Double click, middle button"
+msgstr "Çift çertme, orta dögme"
+
+#: ../panels/mouse/gnome-mouse-test.c:147
+msgid "Single click, middle button"
+msgstr "Tek çertme, orta dögme"
+
+#: ../panels/mouse/gnome-mouse-test.c:150
+msgid "Double click, secondary button"
+msgstr "Çift çertme, ekilemci dögme"
+
+#: ../panels/mouse/gnome-mouse-test.c:150
+msgid "Single click, secondary button"
+msgstr "Tek çertme, ekilemci dögme"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:364
+msgid "Air_plane Mode"
+msgstr "Uça_k Kipi"
+
+#: ../panels/network/cc-network-panel.c:927
+msgid "Network proxy"
+msgstr "Şebekede proksisi"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1106 ../panels/network/net-vpn.c:285
+#: ../panels/network/net-vpn.c:438
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+# tr
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1241
+msgid "The system network services are not compatible with this version."
+msgstr "Sistem ağ yöneticisi bu sürümle uyumlu değil."
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x _Emniyet"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr ""
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "İç _sahihlenim"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Security"
+msgstr "Emniyet"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "avtomatik"
+
+# tr
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:224
+#: ../panels/network/net-device-wifi.c:385
+msgid "WEP"
+msgstr "WEP"
+
+# tr
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:228
+#: ../panels/network/net-device-wifi.c:390
+#: ../panels/network/network-wifi.ui.h:17
+msgid "WPA"
+msgstr "WPA"
+
+# tr
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:232
+msgid "WPA2"
+msgstr "WPA2"
+
+# tr
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:237
+msgid "Enterprise"
+msgstr "Kurumsal"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:242
+#: ../panels/network/net-device-wifi.c:375
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Yoq"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "Asla"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:790
+msgid "Today"
+msgstr "Bugün"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:793
+msgid "Yesterday"
+msgstr "Tünevin"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:479
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i kün evvel"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:537
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/sn"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Yoq"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:568
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Zayıf"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:570
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Tamam"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:572
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Eyi"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:574
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Mükemmel"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:213
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:255
+#: ../panels/network/network-wifi.ui.h:45
+msgid "Identity"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:202
+#: ../panels/network/connection-editor/ce-page-ip4.c:454
+msgid "Netmask"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:216
+#: ../panels/network/connection-editor/ce-page-ip4.c:467
+#: ../panels/network/connection-editor/ce-page-ip6.c:217
+#: ../panels/network/connection-editor/ce-page-ip6.c:475
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "Savaq"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:233
+#: ../panels/network/connection-editor/ce-page-ip6.c:234
+msgid "Delete Address"
+msgstr "Adresni Sil"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:285
+#: ../panels/network/connection-editor/ce-page-ip6.c:286
+msgid "Add"
+msgstr "Ekle"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:350
+#: ../panels/network/connection-editor/ce-page-ip6.c:354
+msgid "Server"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:367
+#: ../panels/network/connection-editor/ce-page-ip6.c:371
+msgid "Delete DNS Server"
+msgstr "DNS Sunucısını sil"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:481
+#: ../panels/network/connection-editor/ce-page-ip6.c:489
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "Metrik"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:502
+#: ../panels/network/connection-editor/ce-page-ip6.c:510
+msgid "Delete Route"
+msgstr "Rotanı Sil"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:616
+#: ../panels/network/network-wifi.ui.h:25
+msgid "Automatic (DHCP)"
+msgstr "Avtomatik (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:620
+#: ../panels/network/connection-editor/ce-page-ip6.c:622
+#: ../panels/network/network-wifi.ui.h:24
+msgid "Manual"
+msgstr "Elden"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:624
+#: ../panels/network/connection-editor/ce-page-ip6.c:626
+msgid "Link-Local Only"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:925
+#: ../panels/network/network-wifi.ui.h:46
+msgid "IPv4"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:204
+#: ../panels/network/connection-editor/ce-page-ip6.c:458
+msgid "Prefix"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:614
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "Avtomatik"
+
+# tüklü
+#: ../panels/network/connection-editor/ce-page-ip6.c:618
+msgid "Automatic, DHCP only"
+msgstr "Avtomatik, faqat DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:886
+#: ../panels/network/network-wifi.ui.h:47
+msgid "IPv6"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:49
+msgid "Reset"
+msgstr "Sıfırla"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Hiç biri"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr ""
+
+# tüklü
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Qurumsal"
+
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+msgid "_Apply"
+msgstr "_Uyğula"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:2
+msgid "Signal Strength"
+msgstr "Signal Küçü"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Link speed"
+msgstr "İlişim sür'atı"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 Adresi"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 Adresi"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:7
+msgid "Hardware Address"
+msgstr "Donanım Adresi"
+
+# tr
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:8
+msgid "Default Route"
+msgstr "Öntanımlı Geçit"
+
+# tr
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:9
+msgid "DNS"
+msgstr "DNS"
+
+# tüklü
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "Soñki Qullanılğan"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "İ_sim"
+
+# tüklü
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:36
+msgid "_MAC Address"
+msgstr "_MAC Adresi"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "_Klonlanğan Adres"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr ""
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "Ögbelgilengen"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:22
+msgid "IPv_4"
+msgstr ""
+
+# tr
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:23
+msgid "_Addresses"
+msgstr "_Adresler"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "Avtomatik DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Routes"
+msgstr "Rotalar"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "Avtomatik Rotalar"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:34
+msgid "IPv_6"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:268
+msgid "Unable to open connection editor"
+msgstr "Bağlantı muharriri açılalmay"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:286
+msgid "New Profile"
+msgstr "Yañı Profil"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:511
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1083
+msgid "_Add"
+msgstr "_Ekle"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:593
+#: ../panels/network/network.ui.h:4 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:594
+msgid "Bond"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:595
+msgid "Bridge"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:596
+msgid "VLAN"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:746
+msgid "Could not load VPN plugins"
+msgstr "VPN plaginleri yüklenamadı: %s"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:810
+msgid "Import from file…"
+msgstr "Dosyeden ithal et…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:877
+msgid "Add Network Connection"
+msgstr "Şebeke Bağlantısını Ekle"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Reset"
+msgstr "_Sıfırla"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1411
+#: ../panels/network/network-wifi.ui.h:40
+msgid "_Forget"
+msgstr "_Unut"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "S_ecurity"
+msgstr "_Emniyet"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "İthal etilecek dosye sayla"
+
+# tr
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "Bir \"%s\" adlı dosye endi mevcuttır."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+msgid "Export VPN connection..."
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:12
+msgid "_SSID"
+msgstr ""
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:13
+msgid "_BSSID"
+msgstr ""
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:16
+msgid "My Home Network"
+msgstr "Ev Şebekem"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "Şebeke"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "İnternet'ke nasıl bağlanğanıñıznı muraqabe etiñiz"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;"
+msgstr ""
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr ""
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr ""
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:465
+msgid "never"
+msgstr "asla"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:475
+msgid "today"
+msgstr "bugün"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:477
+msgid "yesterday"
+msgstr "tünevin"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "İP Adresi"
+
+# tr
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Last used"
+msgstr "Soñki qullanılğan"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "Kabelli"
+
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1549
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8 ../panels/universal-access/uap.ui.h:23
+msgid "Options…"
+msgstr "Seçenekler…"
+
+#: ../panels/network/net-device-ethernet.c:491
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#: ../panels/network/net-device-mobile.c:239
+msgid "Add new connection"
+msgstr "Yañı bağlantı ekle"
+
+#: ../panels/network/net-device-wifi.c:1120
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"Telsizden başqa İnternet'ke bir bağlantıñız bar ise, bağlantıñıznı digerler "
+"ile üleşmek üzre bir telsiz sıcaq-noqtanı ayarlaybilirsiñiz."
+
+#: ../panels/network/net-device-wifi.c:1124
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "Telsiz sıcaqnoqtanıñ açılması <b>%s</b> bağlantıñıznı qoparır."
+
+#: ../panels/network/net-device-wifi.c:1128
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"Sıcaqnoqta faal olğanda telsiziñiz arqalı İnternet'ke irişmek mümkün "
+"degildir."
+
+# tr
+#: ../panels/network/net-device-wifi.c:1202
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Etkin nokta durdurulup tüm kullanıcıların bağlantısı kesilsin mi?"
+
+# tr
+#: ../panels/network/net-device-wifi.c:1205
+msgid "_Stop Hotspot"
+msgstr "Etkin Noktayı _Durdur"
+
+#: ../panels/network/net-device-wifi.c:1277
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1280
+msgid "Wireless device does not support Hotspot mode"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1407
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Saylanğan şebekeler içün şebeke tafsilâtı, sır-söz ve her hangi özel "
+"endamlandırış dahil, ğayıp etilecek."
+
+#: ../panels/network/net-device-wifi.c:1712
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:14
+msgid "History"
+msgstr ""
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1724
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Unut"
+
+# tr
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Yapılandırma URL'si verilmediğinde vekil sunucu otomatik bulma kullanılır."
+
+# tr
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "Bu güvenli olmayan açık ağlarda önerilmez."
+
+#: ../panels/network/net-proxy.c:408
+msgid "Proxy"
+msgstr "Proksi"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "_Profil ekle…"
+
+# tr
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "Teminatçı"
+
+# tr
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:5
+msgctxt "proxy method"
+msgid "None"
+msgstr "Hiçbiri"
+
+# tr
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:6
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "El ile"
+
+# tr
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:7
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "Otomatik"
+
+# tr
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "Y_öntem"
+
+# tr
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "_Yapılandırma URL'si"
+
+# tr
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "_HTTP Vekili"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS Proksisi"
+
+# tr
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "_FTP Vekili"
+
+# tr
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "_Socks Makinesi"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "Qonaqbaylarnı _İhmal Et"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "HTTP proksi limanı"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "HTTPS proksi limanı"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "FTP proksi limanı"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "Socks proksi limanı"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "Cihaznı söndür"
+
+# tr
+#: ../panels/network/network.ui.h:1
+msgid "Select the interface to use for the new service"
+msgstr "Yeni hizmetin kullanılacağı arayüzü seçin"
+
+# tr
+#: ../panels/network/network.ui.h:2
+msgid "C_reate…"
+msgstr "İcat _Et…"
+
+# tr
+#: ../panels/network/network.ui.h:3
+msgid "_Interface"
+msgstr "_Arayüz"
+
+#: ../panels/network/network.ui.h:8
+msgid "Add Device"
+msgstr "Cihaz Ekle"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN Türü"
+
+# tr
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "Grup İsmi"
+
+# tr
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "Grup Parolası"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "Qullanıcı Adı"
+
+# tüklü
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "VPN bağlantısını qapaq"
+
+#: ../panels/network/network-wifi.ui.h:1
+msgid "Automatic _Connect"
+msgstr "Avtomatik _Bağlan"
+
+#: ../panels/network/network-wifi.ui.h:11
+msgid "details"
+msgstr "tafsilât"
+
+# tr
+#: ../panels/network/network-wifi.ui.h:15
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "_Password"
+msgstr "_Parola"
+
+#: ../panels/network/network-wifi.ui.h:18
+#: ../panels/universal-access/uap.ui.h:8
+msgid "None"
+msgstr "Hiç biri"
+
+# tr
+#: ../panels/network/network-wifi.ui.h:19
+msgid "Show P_assword"
+msgstr "_Sır-sözni Köster"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "Make available to other users"
+msgstr "Diger qullanıcılarğa müsait yap"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "identity"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Automatic (DHCP) addresses only"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Link-local only"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Shared with other computers"
+msgstr ""
+
+# tüklü
+#: ../panels/network/network-wifi.ui.h:31
+msgid "_Ignore automatically obtained routes"
+msgstr "Avtomatik olaraq elde etilgen rotalarnı _ihmal et"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "ipv4"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv6"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "_Cloned MAC Address"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:38
+msgid "hardware"
+msgstr "donanım"
+
+#: ../panels/network/network-wifi.ui.h:41
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:42
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid "reset"
+msgstr "sıfırla"
+
+#: ../panels/network/network-wifi.ui.h:48
+msgid "Hardware"
+msgstr "Donanım"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Wi-Fi Hotspot"
+msgstr "Telsiz-Vefa Sıcaqnoqtası"
+
+#: ../panels/network/network-wifi.ui.h:51
+msgid "_Turn On"
+msgstr "_Aç"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi"
+msgstr "Telsiz-Vefa"
+
+# tr
+#: ../panels/network/network-wifi.ui.h:53
+msgid "Turn Wi-Fi off"
+msgstr "Telsiz-Vefanı qapat"
+
+# tr
+#: ../panels/network/network-wifi.ui.h:54
+msgid "_Use as Hotspot…"
+msgstr "_Sıcaqnoqta olaraq qullan..."
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "_Connect to Hidden Network…"
+msgstr "Gizli bir Şebekege _Bağlan…"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_History"
+msgstr "_Keçmiş"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Bir Telsiz-Vefa şebekesine bağlanmaq içün qapatıñız"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "Network Name"
+msgstr "Şebeke Adı"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Connected Devices"
+msgstr "Bağlanğan Cihazlar"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Security type"
+msgstr "Emniyet türü"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Security key"
+msgstr "Emniyet anahtarı"
+
+# tr
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "Altyapı"
+
+# tr
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "Durum bilinmiyor"
+
+# tr
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "Yönetilmeyen"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "Faydalanışsız"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "Bağlanıla"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "Sahihlenim kerekli"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "Bağlanğan"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "Bağlantı qoparıla"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "Bağlantı muvaffaqiyetsiz"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "Status bilinmey (eksik)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "Bağlanmağan"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "Endamlandırış muvaffaqiyetsiz"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "İP endamlandırışı muvaffaqiyetsiz"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "İP endamlandırışı eskirdi"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "PPP hızmeti bağlantısı qoparılğan"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "DHCP müşterisi başlayamadı"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP müşterisi hatası"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP müşterisi muvaffaqiyetsiz edi"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "Üleşilgen bağlantı hızmeti muvaffaqiyetsiz edi"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "AvtoİP hızmeti muvaffaqiyetsiz edi"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "Hat meşğul"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "Modem başlanğıçlandırması muvaffaqiyetsiz edi"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "Belirtilgen APN (İrişim Noqtası İsmi; İNİ) saylanamadı"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "Şebeke qaydı inkâr etildi"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "Bağlantı ğayıp oldı"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "Mevcut bağlantı üstlenildi"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "Modem tapılmadı"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth bağlantısı muvaffaqiyetsiz edi"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "SİM Kartı qıstırılğan degil"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "SİM yañlış"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "Bağlantı bağlılığı muvaffaqiyetsiz edi"
+
+# tr
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "Firmware kayıp"
+
+# tr
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "Kablo takılı değil"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+
+# tr
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "İhmal Et"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.c:261
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.c:277
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.c:399
+msgid "Choose a PAC file..."
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.c:406
+msgid "PAC files (*.pac)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC _dosyesi"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "_Dahiliy sahihlenim"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "Sahihlengen"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "_Username"
+msgstr "_Qullanıcı adı"
+
+# tr
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "Sır-sözni _köster"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:434
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate..."
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "Sürüm 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "Sürüm 1"
+
+# tr
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "Şehadetname _Salâhiyeti (CA; ŞS) şehadetnamesi"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:260
+msgid "Unencrypted private keys are insecure"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:263
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:428
+msgid "Choose your personal certificate..."
+msgstr "Şahsiy şehadetnameñizni saylañız..."
+
+#: ../panels/network/wireless-security/eap-method-tls.c:440
+msgid "Choose your private key..."
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "_Hususiy anahtar sır-sözü"
+
+# tr
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP (Sır-söz Sahihlenim Protokolı; SSP)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP (Mikrosoft Hodrimeydan-Elsıqışma Sahihlenim Protokolı; MSHESP)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP (Hodrimeydan-Elsıqışma Sahihlenim Protokolı; HESP)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "Meni yañıdan _tenbih etme"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr ""
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr ""
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr ""
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "_Sahihlenim"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (Ögbelgilengen)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+# tr
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "Açıq Sistem"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "_Tür"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "Tebliğler"
+
+# tr
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:41
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "Davuş İqazları"
+
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr ""
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "Tasilâtnı Afişlerde Köster"
+
+#: ../panels/notifications/cc-edit-dialog.c:45
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "Kilit Ekranında Seyrettir"
+
+#: ../panels/notifications/cc-edit-dialog.c:46
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "Tasilâtnı Kilit Ekranında Köster"
+
+#: ../panels/notifications/cc-notifications-panel.c:203
+#: ../panels/power/cc-power-panel.c:1637 ../panels/power/cc-power-panel.c:1644
+#: ../panels/privacy/cc-privacy-panel.c:78
+#: ../panels/privacy/cc-privacy-panel.c:145
+msgid "On"
+msgstr "Açıq"
+
+#: ../panels/notifications/cc-notifications-panel.c:203
+#: ../panels/power/cc-power-panel.c:1631 ../panels/power/cc-power-panel.c:1642
+#: ../panels/privacy/cc-privacy-panel.c:78
+#: ../panels/privacy/cc-privacy-panel.c:145
+msgid "Off"
+msgstr "Qapalı"
+
+# tr
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "Tebliğler"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr ""
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "Kilit Ekranında Köster"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:191
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Diger"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:292
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "Hesap Ekle"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:331
+msgid "Mail"
+msgstr "Poşta"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:337
+msgid "Contacts"
+msgstr "Temaslar"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:343
+msgid "Resources"
+msgstr ""
+
+# tr
+#: ../panels/online-accounts/cc-online-accounts-panel.c:425
+msgid "Error logging into the account"
+msgstr "Hesaba giriş yapılırken hata oluştu"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Credentials have expired."
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:501
+msgid "Sign in to enable this account."
+msgstr "Bu hesapnı qabilleştirmek içün içeri imzalan."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:506
+msgid "_Sign In"
+msgstr "_İçeri İmzalan"
+
+# tr
+#: ../panels/online-accounts/cc-online-accounts-panel.c:747
+msgid "Error creating account"
+msgstr "Hesap oluşturulurken hata meydana geldi"
+
+# tr
+#: ../panels/online-accounts/cc-online-accounts-panel.c:787
+msgid "Error removing account"
+msgstr "Hesap silinirken hata oluştu"
+
+# tr
+#: ../panels/online-accounts/cc-online-accounts-panel.c:823
+msgid "Are you sure you want to remove the account?"
+msgstr "Hesabı silmek istediğinizden emin misiniz?"
+
+# tr
+#: ../panels/online-accounts/cc-online-accounts-panel.c:825
+msgid "This will not remove the account on the server."
+msgstr "Bu işlem, sunucudaki hesabı silmeyecektir."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:826
+msgid "_Remove"
+msgstr "_Çetleştir"
+
+# tr
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "Çevrimiçi Hesaplar"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+# tr
+#. Translators: those are keywords for the online-accounts control-center panel
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Devre-içi;Suhbet;Taqvim;Poçta;Temas;"
+"ownCloud;"
+
+# tr
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "Endamlandırılğan devre-içi hesaplar yoq"
+
+# tr
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "Hesabı Kaldır"
+
+# tr
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "Bir devre-içi hesap ekle"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"Bir hesapnıñ eklenmesi uyğulamalarıñızğa onı vesiqalar, poçta, temaslar, "
+"taqvim, suhbet vs. içün oña irişmege imkân berir."
+
+#: ../panels/power/cc-power-panel.c:184
+msgid "Unknown time"
+msgstr "Bilinmegen vaqıt"
+
+#: ../panels/power/cc-power-panel.c:190
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i daqqa"
+
+#: ../panels/power/cc-power-panel.c:202
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i saat"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:210
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+# tr
+#: ../panels/power/cc-power-panel.c:211
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "saat"
+
+#: ../panels/power/cc-power-panel.c:212
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "daqqa"
+
+# tr
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:231
+#, c-format
+msgid "%s until fully charged"
+msgstr "Tamamen tolmasına qadar %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:238
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "İhtiyat: %s qala"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:243
+#, c-format
+msgid "%s remaining"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:248 ../panels/power/cc-power-panel.c:276
+msgid "Fully charged"
+msgstr "Tamamen yükletilgen"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:252 ../panels/power/cc-power-panel.c:280
+msgid "Empty"
+msgstr "Boş"
+
+# tr
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:267
+msgid "Charging"
+msgstr "Doluyor"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:272
+msgid "Discharging"
+msgstr "Yüksüzlene"
+
+#: ../panels/power/cc-power-panel.c:324
+#, c-format
+msgid "Estimated battery capacity: %s"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:404
+msgctxt "Battery name"
+msgid "Main"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:406
+msgctxt "Battery name"
+msgid "Extra"
+msgstr ""
+
+# tr
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:493
+msgid "Wireless mouse"
+msgstr "Kablosuz fare"
+
+# tr
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:497
+msgid "Wireless keyboard"
+msgstr "Kablosuz klavye"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:501
+msgid "Uninterruptible power supply"
+msgstr "Kesintisiz qudret arzı"
+
+# tr
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:506
+msgid "Personal digital assistant"
+msgstr "Kişisel dijital yardımcı"
+
+# tr
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:510
+msgid "Cellphone"
+msgstr "Cep telefonu"
+
+# tr
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:514
+msgid "Media player"
+msgstr "Ortam yürütücüsü"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:518
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:522
+msgid "Computer"
+msgstr "Bilgisayar"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:526 ../panels/power/cc-power-panel.c:734
+#: ../panels/power/cc-power-panel.c:1938
+msgid "Battery"
+msgstr "Pil"
+
+# tüklü
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:535
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Yükletile"
+
+# tr
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:542
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "İhtiyat"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Tüşük"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Eyi"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Tam yükletilgen"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:561
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Boş"
+
+#: ../panels/power/cc-power-panel.c:732
+msgid "Batteries"
+msgstr "Piller"
+
+#: ../panels/power/cc-power-panel.c:1074
+msgid "When _idle"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1401
+msgid "Power Saving"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1430
+msgid "_Screen Brightness"
+msgstr "_Ekran Parlaqlığı"
+
+# tüklü
+#: ../panels/power/cc-power-panel.c:1458
+msgid "_Dim Screen when Inactive"
+msgstr "Ğayrıfaal olğanda Ekrannı _Sönükleştir"
+
+#: ../panels/power/cc-power-panel.c:1481
+msgid "_Blank Screen"
+msgstr "_Boş Ekran"
+
+#: ../panels/power/cc-power-panel.c:1516
+msgid "_Wi-Fi"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1521
+msgid "Turns off wireless devices"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1544
+msgid "_Mobile Broadband"
+msgstr "_Mobil Kenişbant"
+
+#: ../panels/power/cc-power-panel.c:1549
+msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1582
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: ../panels/power/cc-power-panel.c:1633
+msgid "When on battery power"
+msgstr "Pil qudretinde olğanda"
+
+# tr
+#: ../panels/power/cc-power-panel.c:1635
+msgid "When plugged in"
+msgstr "Fişe takıldığıında"
+
+#: ../panels/power/cc-power-panel.c:1762
+msgid "Suspend & Power Off"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1793
+msgid "_Automatic Suspend"
+msgstr "_Avtomatik Sarqıtım"
+
+#: ../panels/power/cc-power-panel.c:1815
+msgid "When Battery Power is _Critical"
+msgstr "Pil Qudreti _Kritik Olğanda"
+
+#: ../panels/power/cc-power-panel.c:1848
+msgid "Power Off"
+msgstr "Söndür"
+
+#: ../panels/power/cc-power-panel.c:1990
+msgid "Devices"
+msgstr "Cihazlar"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "Qudret"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+# tüklü
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"Qudret;Yuqu;Sarqıt;Yuqlat;Pil;Parlaqlıq;Sönükleştir;Boş;Monitor;DPMS;Atıl;"
+
+# tr
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "Derin Uyku"
+
+# tr
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "Kapat"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "45 daqqa"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 saat"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "80 daqqa"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "90 daqqa"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "100 daqqa"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "2 saat"
+
+# tr
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 dakika"
+
+# tr
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 dakika"
+
+# tr
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 dakika"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "4 daqqa"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 daqqa"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "8 daqqa"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 daqqa"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "12 daqqa"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "Avtomatik Sarqıtım"
+
+#: ../panels/power/power.ui.h:21 ../panels/privacy/privacy.ui.h:10
+msgid "_Close"
+msgstr "_Qapat"
+
+#: ../panels/power/power.ui.h:22
+msgid "_Plugged In"
+msgstr "_Rozetke Tıqılğan"
+
+#: ../panels/power/power.ui.h:23
+msgid "On _Battery Power"
+msgstr "_Pil Qudretinde"
+
+#: ../panels/power/power.ui.h:24
+msgid "Delay"
+msgstr "Keçikme"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "Sahihlen"
+
+# tr
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Password"
+msgstr "Sır-söz"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "Sahihlenim Şart"
+
+# tr
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:591
+msgid "Low on toner"
+msgstr "Toner düşük seviyede"
+
+# tr
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:593
+msgid "Out of toner"
+msgstr "Toner tükendi"
+
+# tr
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:596
+msgid "Low on developer"
+msgstr "Film banyo kimyasalı az"
+
+# tr
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:599
+msgid "Out of developer"
+msgstr "Film banyo kimyasalı bitti"
+
+# tr
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:601
+msgid "Low on a marker supply"
+msgstr "Renk kartuşu az"
+
+# tr
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:603
+msgid "Out of a marker supply"
+msgstr "Renk kartuşu bitti"
+
+# tr
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:605
+msgid "Open cover"
+msgstr "Kapak açık"
+
+# tr
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:607
+msgid "Open door"
+msgstr "Kapı açık"
+
+# tr
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:609
+msgid "Low on paper"
+msgstr "Kağıt az"
+
+# tr
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:611
+msgid "Out of paper"
+msgstr "Kağıt bitti"
+
+# tr
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:613
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Kapalı"
+
+# tr
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:615
+#: ../panels/printers/cc-printers-panel.c:806
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Durduruldu"
+
+# tr
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:617
+msgid "Waste receptacle almost full"
+msgstr "Atık kutusu neredeyse dolu"
+
+# tr
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:619
+msgid "Waste receptacle full"
+msgstr "Atık kutusu dolu"
+
+# tr
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:621
+msgid "The optical photo conductor is near end of life"
+msgstr "Baskı silindiri ömrünü doldurmak üzere"
+
+# tr
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:623
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Baskı silindiri artık çalışmıyor"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:733
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "Endamlandırıla"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:792
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Hazır"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:797
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr ""
+
+# tr
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:802
+msgctxt "printer state"
+msgid "Processing"
+msgstr "İşleniyor"
+
+# tr
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:923
+msgid "Toner Level"
+msgstr "Toner Seviyesi"
+
+# tr
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:926
+msgid "Ink Level"
+msgstr "Mürekkep Seviyesi"
+
+# tr
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:929
+msgid "Supply Level"
+msgstr "Malzeme Seviyesi"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:947
+msgctxt "printer state"
+msgid "Installing"
+msgstr "Qurula"
+
+# tr
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1124
+msgid "No printers available"
+msgstr "Mevcut yazıcı bulunmuyor"
+
+# tr
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1432
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u etkin"
+
+# tr
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1776
+msgid "Failed to add new printer."
+msgstr "Yeni yazıcı eklenemedi."
+
+# tr
+#: ../panels/printers/cc-printers-panel.c:1943
+msgid "Select PPD File"
+msgstr "PPD Dosyesini Sayla"
+
+#: ../panels/printers/cc-printers-panel.c:1952
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2257
+msgid "No suitable driver found"
+msgstr "Kelişikli sürüci tapılamadı"
+
+#: ../panels/printers/cc-printers-panel.c:2326
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2341
+msgid "Select from database…"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2350
+msgid "Provide PPD File…"
+msgstr "PPD Dosyesini Temin Et…"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2501
+#: ../panels/printers/cc-printers-panel.c:2524
+msgid "Test page"
+msgstr "Deñeme sahifesi"
+
+# tr
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2932
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Arayüz yüklenemedi: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "Bastırıcılar"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+# tr
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Yazıcı;Kuyruk;Yazdur;Kâğıt;Mürekkep;Toner;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "Faal İşler"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+#: ../panels/user-accounts/data/history-dialog.ui.h:2
+msgid "Close"
+msgstr "Qapat"
+
+# tr
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "Yazdırmayı Devam Ettir"
+
+# tr
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "Yazdırmayı Duraklat"
+
+# tr
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "Yazdırma İşini İptal Et"
+
+# tr
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "Yeni Yazıcı Ekle"
+
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/user-accounts/um-user-panel.c:467
+msgid "_Cancel"
+msgstr "_Vazgeç"
+
+# tr
+#: ../panels/printers/new-printer-dialog.ui.h:4
+msgid "Search for network printers or filter result"
+msgstr "Şebeke bastırıcıları içün qıdır yaki neticelerni süzgüçle"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "Yükleme seçenekleri…"
+
+# tüklü
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "Bastırıcı Sürücisini Saylañız"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:67
+#: ../panels/printers/pp-ppd-option-widget.c:71
+msgid "One Sided"
+msgstr "Tek Yanlı"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:69
+#: ../panels/printers/pp-ppd-option-widget.c:73
+msgid "Long Edge (Standard)"
+msgstr "Uzun Ağız (Standart)"
+
+# tüklü
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:71
+#: ../panels/printers/pp-ppd-option-widget.c:75
+msgid "Short Edge (Flip)"
+msgstr "Qısqa Ağız (Aylandır)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:73
+msgid "Portrait"
+msgstr "Portret"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:75
+msgid "Landscape"
+msgstr "Manzara"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:77
+msgid "Reverse landscape"
+msgstr "Ters manzara"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:79
+msgid "Reverse portrait"
+msgstr "Ters portret"
+
+# tr
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:143
+msgctxt "print job"
+msgid "Pending"
+msgstr "Sırada"
+
+# tr
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:147
+msgctxt "print job"
+msgid "Held"
+msgstr "Bekliyor"
+
+# tr
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:151
+msgctxt "print job"
+msgid "Processing"
+msgstr "İşleniyor"
+
+# tr
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:155
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Durduruldu"
+
+# tr
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:159
+msgctxt "print job"
+msgid "Canceled"
+msgstr "İptal edildi"
+
+# tr
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:163
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Hata nedeniyle iptal edildi"
+
+# tr
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:167
+msgctxt "print job"
+msgid "Completed"
+msgstr "Tamamlandı"
+
+# tr
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:289
+msgid "Job Title"
+msgstr "İş Adı"
+
+# tr
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:298
+msgid "Job State"
+msgstr "İş Durumu"
+
+# tr
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:304
+msgid "Time"
+msgstr "Zaman"
+
+# tr
+#: ../panels/printers/pp-jobs-dialog.c:496
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s Faal İş"
+
+# tr
+#. Translators: No printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1468
+msgid "No printers detected."
+msgstr "Alğılanğan bastırıcılar yoq."
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Two Sided"
+msgstr "Eki Yanlı"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Type"
+msgstr "Kâğıt Türü"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Paper Source"
+msgstr "Kâğıt Qaynağı"
+
+# tr
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Output Tray"
+msgstr "Çıqtı Sinisi"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "Resolution"
+msgstr "Çezinirlik"
+
+#: ../panels/printers/pp-options-dialog.c:87
+msgid "GhostScript pre-filtering"
+msgstr ""
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:532
+msgid "Pages per side"
+msgstr "Yan başına sahife sayısı"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:544
+msgid "Two-sided"
+msgstr "Eki-yanlı"
+
+# tr
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:556
+msgid "Orientation"
+msgstr "Yöneldirim"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Umumiy"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Sahife Ayarlaması"
+
+# tr
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Qurulabilir Seçenekler"
+
+# tr
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:662
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "İş"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:665
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Suret Keyfiyeti"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:668
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Tüs"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:671
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Bitirile"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:674
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "İleriletilgen"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:77
+#: ../panels/printers/pp-ppd-option-widget.c:79
+#: ../panels/printers/pp-ppd-option-widget.c:87
+msgid "Auto Select"
+msgstr "Avto Sayla"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:81
+#: ../panels/printers/pp-ppd-option-widget.c:83
+#: ../panels/printers/pp-ppd-option-widget.c:85
+#: ../panels/printers/pp-ppd-option-widget.c:89
+msgid "Printer Default"
+msgstr "Bastırıcı Ögbelgilemesi"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:91
+msgid "Embed GhostScript fonts only"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 1"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:95
+msgid "Convert to PS level 2"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:97
+msgid "No pre-filtering"
+msgstr "Ög-süzgüçleme yoq"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "İmalâtçı"
+
+# tüklü
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Sürüci"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:247
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+
+# tr
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "Yazıcı Ekle"
+
+# tr
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "Yazıcıyı Kaldır"
+
+# tr
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "Malzeme"
+
+# tr
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "Konum"
+
+# tr
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default"
+msgstr "_Öntanımlı"
+
+# tr
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "İşler"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr ""
+
+# tr
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "Model"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "etiket"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "Yañı sürüci tesbit etile…"
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "sahife 3"
+
+# tr
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "_Sınama Sayfası Yazdır"
+
+# tr
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "_Seçenekler"
+
+# tr
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "Yeni Yazıcı Ekle"
+
+# tr
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"Üzgünüm! Sistemin yazdırma hizmeti\n"
+"kullanılamıyor."
+
+#: ../panels/privacy/cc-privacy-panel.c:105
+msgid "Hidden"
+msgstr "Gizli"
+
+#: ../panels/privacy/cc-privacy-panel.c:105
+msgid "Visible"
+msgstr "Körünir"
+
+#: ../panels/privacy/cc-privacy-panel.c:271 ../panels/privacy/privacy.ui.h:31
+msgid "Screen Lock"
+msgstr "Ekran Kiliti"
+
+#: ../panels/privacy/cc-privacy-panel.c:338 ../panels/privacy/privacy.ui.h:9
+msgid "Name & Visibility"
+msgstr "İsim & Körünirlik"
+
+#: ../panels/privacy/cc-privacy-panel.c:446 ../panels/privacy/privacy.ui.h:26
+msgid "Usage & History"
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+msgid "Purge Trash & Temporary Files"
+msgstr ""
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr ""
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "Ekran Söndürilgenden Soñ"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 saniye"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "Control how you appear on the screen and the network."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "Display _full name in top bar"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "Display full name in _lock screen"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "_Stealth Mode"
+msgstr "_Gizlilik Tarzı"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "Immediately"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "1 day"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "2 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "3 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:19
+msgid "4 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid "5 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "6 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "7 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "14 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:24
+msgid "30 days"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "Forever"
+msgstr "İlelebet"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Cl_ear Recent History"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:29
+msgid "_Recently Used"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid "Retain _History"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr ""
+
+# tr
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Automatic Screen _Lock"
+msgstr "Avtomatik Ekran _Kiliti"
+
+# tr
+#: ../panels/privacy/privacy.ui.h:34
+msgid "Lock screen _after blank for"
+msgstr "Şu süre qadar boş olğandan soñ ekrannı _kilitle"
+
+#: ../panels/privacy/privacy.ui.h:35
+msgid "Show _Notifications"
+msgstr "_Tebliğlerni Köster"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid "_Empty Trash"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:38
+msgid "_Purge Temporary Files"
+msgstr "Muvaqqat Dosyelerni _İzale Et"
+
+#: ../panels/privacy/privacy.ui.h:39
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "Automatically empty _Trash"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:41
+msgid "Automatically purge Temporary _Files"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:42
+msgid "Purge _After"
+msgstr ""
+
+#: ../panels/region/cc-format-chooser.c:122
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "İngliz ölçüler"
+
+#: ../panels/region/cc-format-chooser.c:124
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrik"
+
+# tr
+#: ../panels/region/cc-format-chooser.c:283
+msgid "No regions found"
+msgstr "Tapılğan bölgeler yoq"
+
+# tr
+#: ../panels/region/cc-input-chooser.c:188
+msgid "No input sources found"
+msgstr "Tapılğan kirdi menbaları yoq"
+
+#: ../panels/region/cc-input-chooser.c:1091
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Diger"
+
+#: ../panels/region/cc-region-panel.c:240
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:241
+msgid "Restart Now"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:566
+msgctxt "Language"
+msgid "None"
+msgstr "Hiç biri"
+
+#: ../panels/region/cc-region-panel.c:1058
+msgid "Sorry"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:1060
+msgid "Input methods can't be used on the login screen"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:1509
+msgid "No input source selected"
+msgstr "Saylanğan kirdi menbası yoq"
+
+#: ../panels/region/cc-region-panel.c:1690
+msgid "Login Screen"
+msgstr "İçeri İmzalanım Ekranı"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "Formatlar"
+
+#: ../panels/region/format-chooser.ui.h:3
+msgid "Preview"
+msgstr "Ögbaqış"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Dates"
+msgstr "Tarihler"
+
+# tr
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Times"
+msgstr "Defa"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Numbers"
+msgstr "Sayılar"
+
+# tr
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Measurement"
+msgstr "Ölçüm"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Paper"
+msgstr "Kâğıt"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "Bölge & Til"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Til;Tizilim;Klavye;Kirdi;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "Bir Kirdi Menbası Ekle"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "Kirdi Menbası Seçenekleri"
+
+#: ../panels/region/input-options.ui.h:2
+msgid "Use the _same source for all windows"
+msgstr "Bütün pencereler içün _aynı menbani qullan"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Allow _different sources for each window"
+msgstr "Her pencere içün _farqlı menbalarğa izin ber"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Keyboard Shortcuts"
+msgstr "Klavye Qısqayolları"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Switch to previous source"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Super+Shift+Space"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Switch to next source"
+msgstr "Soñraki menbağa almaştır"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Super+Space"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:9
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:10
+msgid "Alternative switch to next source"
+msgstr ""
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr ""
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr ""
+
+# tr
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "Seçenekler"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+
+#: ../panels/search/cc-search-locations-dialog.c:276
+msgid "Home"
+msgstr "Ev"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr ""
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr ""
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr "Diger"
+
+#: ../panels/search/cc-search-locations-dialog.c:676
+msgid "Select Location"
+msgstr "Qonum Saylañız"
+
+# tr
+#: ../panels/search/cc-search-panel.c:182
+msgid "No applications found"
+msgstr "Tapılğan uyğulamalar yoq"
+
+# tr
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "Qıdır"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "Qonumlarnı Qıdır"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "Yuqarı Avuştır"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "Aşağı Avuştır"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "Tercihler"
+
+#: ../panels/sharing/cc-sharing-panel.c:259
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Açıq"
+
+# tüklü
+#: ../panels/sharing/cc-sharing-panel.c:261
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Qapalı"
+
+#: ../panels/sharing/cc-sharing-panel.c:407
+msgid "Choose a Folder"
+msgstr "Bir Cilbent Saylañız"
+
+#: ../panels/sharing/cc-sharing-panel.c:585
+msgid "Copy"
+msgstr "Kopiyala"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "Üleşim"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr ""
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "Uzaqtan içeri imzalanmanı qabilleştir yaki ğayrıqabilleştir"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Uzaqtan içeri imzalanmanı qabilleştirmek içün sahihlenim şarttır"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "Bluetooth Üleşimi"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Share Public Folder"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Only Receive From Trusted Devices"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Save Received Files to Downloads Folder"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Only share with Trusted Devices"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Computer Name"
+msgstr "Bilgisayar İsmi"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Remote Login"
+msgstr "Uzaqtan İçeri İmzalanım"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Some services are disabled because of no network access."
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Media Sharing"
+msgstr "Vasat Üleşimi"
+
+#: ../panels/sharing/sharing.ui.h:11
+msgid "Share Music, Photos and Videos with others on the current network."
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:12
+msgid "Share Media On This Network"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Shared Folders"
+msgstr "Üleşilgen Cilbentler"
+
+#: ../panels/sharing/sharing.ui.h:14
+msgid "column"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:15
+msgid "Add Folder"
+msgstr "Cilbent Ekle"
+
+# tr
+#: ../panels/sharing/sharing.ui.h:16
+msgid "Remove Folder"
+msgstr "Cilbentni Çetleştir"
+
+#: ../panels/sharing/sharing.ui.h:17
+msgid "Personal File Sharing"
+msgstr "Şahsiy Dosye Üleşimi"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Share Public Folder On This Network"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:21
+msgid "Require Password"
+msgstr "Sır-söz Şart Olsun"
+
+#: ../panels/sharing/sharing.ui.h:24
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+
+# tr
+#: ../panels/sharing/sharing.ui.h:26
+msgid "Screen Sharing"
+msgstr "Ekran Üleşimi"
+
+#: ../panels/sharing/sharing.ui.h:28
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+
+# tüklü
+#: ../panels/sharing/sharing.ui.h:29
+msgid "Remote View"
+msgstr "Uzaqtan Seyir"
+
+#: ../panels/sharing/sharing.ui.h:30
+msgid "Remote Control"
+msgstr "Uzaqtan Kontrol"
+
+#: ../panels/sharing/sharing.ui.h:31
+msgid "Approve All Connections"
+msgstr "Bağlantılarnıñ Hepsini Tasvip Et"
+
+#: ../panels/sharing/sharing.ui.h:32
+msgid "Show Password"
+msgstr "Sır-sözni Köster"
+
+# tr
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "Davuş"
+
+# tr
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Davuş seviyelerini, kirdilerni, çıqtılarnı ve iqaz davuşlarını deñiştir"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "Kart;Mikrofon;Gürlük;Solma;Muvazenet;Bluetooth;Baş-Seti;Davuş;"
+
+# tr
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "Havlama"
+
+# tr
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "Damlama"
+
+# tr
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "Cam"
+
+# tr
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "Sonar"
+
+# tr
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Left"
+msgstr "Sol"
+
+# tr
+#: ../panels/sound/gvc-balance-bar.c:107
+msgctxt "balance"
+msgid "Right"
+msgstr "Sağ"
+
+# tr
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Rear"
+msgstr "Arka"
+
+# tr
+#: ../panels/sound/gvc-balance-bar.c:111
+msgctxt "balance"
+msgid "Front"
+msgstr "Ön"
+
+# tr
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Minimum"
+msgstr "En Az"
+
+# tr
+#: ../panels/sound/gvc-balance-bar.c:115
+msgctxt "balance"
+msgid "Maximum"
+msgstr "En Çok"
+
+# tr
+#: ../panels/sound/gvc-balance-bar.c:290
+msgid "_Balance:"
+msgstr "_Denge:"
+
+# tr
+#: ../panels/sound/gvc-balance-bar.c:293
+msgid "_Fade:"
+msgstr "_Kaybolma:"
+
+# tr
+#: ../panels/sound/gvc-balance-bar.c:296
+msgid "_Subwoofer:"
+msgstr "_Subwoofer:"
+
+# tr
+#: ../panels/sound/gvc-channel-bar.c:613 ../panels/sound/gvc-channel-bar.c:622
+msgctxt "volume"
+msgid "100%"
+msgstr "%100"
+
+# tr
+#: ../panels/sound/gvc-channel-bar.c:617
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Yükseltilmemiş"
+
+#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "_Profil:"
+
+# tr
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u Çıkış"
+
+# tr
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u Giriş"
+
+# tr
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "Sistem Sesleri"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "Hoparlörleri _Sına"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "Tepe algılama"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1508
+#: ../panels/sound/gvc-sound-theme-chooser.c:595
+msgid "Name"
+msgstr "İsim"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1527
+msgid "Device"
+msgstr "Cihaz"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1590
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s için Hoparlör Sınaması"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1644
+msgid "_Output volume:"
+msgstr "_Çıqtı gürlügi:"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1658
+msgid "Output"
+msgstr "Çıktı"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "C_hoose a device for sound output:"
+msgstr "Ses çıkışı için aygıt _seçin:"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1688
+msgid "Settings for the selected device:"
+msgstr "Seçili aygıt ayarları:"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1699
+msgid "Input"
+msgstr "Giriş"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1706
+msgid "_Input volume:"
+msgstr "_Kirdi gürlügi:"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1729
+msgid "Input level:"
+msgstr "Giriş seviyesi:"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1757
+msgid "C_hoose a device for sound input:"
+msgstr "Ses girişi için aygıt _seçin:"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1784
+msgid "Sound Effects"
+msgstr "Ses Efektleri"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1791
+msgid "_Alert volume:"
+msgstr "_Uyarı ses düzeyi:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1804
+msgid "Applications"
+msgstr "Uyğulamalar"
+
+# tr
+#: ../panels/sound/gvc-mixer-dialog.c:1808
+msgid "No application is currently playing or recording audio."
+msgstr "Herhangi bir uygulama ses kaydı ya da yürütmesi yapmıyor."
+
+# tr
+#: ../panels/sound/gvc-sound-theme-chooser.c:189
+msgid "Built-in"
+msgstr "Dahili"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:455
+#: ../panels/sound/gvc-sound-theme-chooser.c:467
+#: ../panels/sound/gvc-sound-theme-chooser.c:479
+msgid "Sound Preferences"
+msgstr "Davuş Tercihleri"
+
+# tr
+#: ../panels/sound/gvc-sound-theme-chooser.c:458
+#: ../panels/sound/gvc-sound-theme-chooser.c:469
+#: ../panels/sound/gvc-sound-theme-chooser.c:481
+msgid "Testing event sound"
+msgstr "Olay sesi deneniyor"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "Default"
+msgstr "Ögbelgilengen"
+
+# tr
+#: ../panels/sound/gvc-sound-theme-chooser.c:586
+msgid "From theme"
+msgstr "Temadan"
+
+# tr
+#: ../panels/sound/gvc-sound-theme-chooser.c:770
+msgid "C_hoose an alert sound:"
+msgstr "Uyarı sesi se_çin:"
+
+#: ../panels/sound/gvc-speaker-test.c:220
+msgid "Stop"
+msgstr "Toqta"
+
+#: ../panels/sound/gvc-speaker-test.c:220
+#: ../panels/sound/gvc-speaker-test.c:332
+msgid "Test"
+msgstr "Sına"
+
+# tr
+#: ../panels/sound/gvc-speaker-test.c:228
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+# tr
+#: ../panels/sound/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr "Özel"
+
+# tr
+#: ../panels/universal-access/cc-ua-panel.c:281
+#: ../panels/universal-access/cc-ua-panel.c:287
+msgid "No shortcut set"
+msgstr "Kısayol belirlenmemiş"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
+"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+msgstr ""
+"Klavye;Sıçan;i15k;İrişilebilirlik;Tezat;Miqyas;Ekran Oquyıcı;metin;hurufat;"
+"ölçü;İrişimX;Yapışaq Tuşlar;Yavaş Tuşlar;Sıçrama Tuşları;Sıçan Tuşları;"
+
+#: ../panels/universal-access/uap.ui.h:1
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Tüşük"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgctxt "universal access, contrast"
+msgid "Normal"
+msgstr "Normal"
+
+#: ../panels/universal-access/uap.ui.h:3
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Yüksek"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgctxt "universal access, contrast"
+msgid "High/Inverse"
+msgstr "Yüksek/Ters"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "On screen keyboard"
+msgstr "Ekran-üstü klavye"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:6
+msgid "GOK"
+msgstr "GOK"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:7
+msgid "OnBoard"
+msgstr "Dahili"
+
+#: ../panels/universal-access/uap.ui.h:10
+#, no-c-format
+msgid "75%"
+msgstr "%75"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgctxt "universal access, text size"
+msgid "Small"
+msgstr "Küçük"
+
+#: ../panels/universal-access/uap.ui.h:13
+#, no-c-format
+msgid "100%"
+msgstr "%100"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgctxt "universal access, text size"
+msgid "Normal"
+msgstr "Normal"
+
+#: ../panels/universal-access/uap.ui.h:16
+#, no-c-format
+msgid "125%"
+msgstr "%125"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgctxt "universal access, text size"
+msgid "Large"
+msgstr "Balaban"
+
+#: ../panels/universal-access/uap.ui.h:19
+#, no-c-format
+msgid "150%"
+msgstr "%150"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgctxt "universal access, text size"
+msgid "Larger"
+msgstr "Daha Balaban"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "High Contrast"
+msgstr "Yüksek Tezat"
+
+# tüklü
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Beep on Caps and Num Lock"
+msgstr "Caps ve Num Lock üzerine biple"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Screen Reader"
+msgstr "Ekran Oquyıcı"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Turn on or off:"
+msgstr "Aç ya da kapat:"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgctxt "universal access, zoom"
+msgid "Zoom"
+msgstr "Miqyasla"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Zoom in:"
+msgstr "Yaqınlaştır:"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Zoom out:"
+msgstr "Uzaqlaştır:"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Large Text"
+msgstr "Büyük Metin"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "Seeing"
+msgstr "Körüş"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Visual Alerts"
+msgstr "Körsel İqazlar"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Use a visual indication when an alert sound occurs"
+msgstr "Uyarı sesi çalındığında görsel uyarı kullan"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Flash the window title"
+msgstr "Pencere başlığı yanıp sönsün"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Flash the entire screen"
+msgstr "Tüm ekran yanıp sönsün"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:35
+msgid "Closed Captioning"
+msgstr "Gizli Altyazı"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Display a textual description of speech and sounds"
+msgstr "Konuşma ve sesler için yazılı açıklama göster"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:37
+msgid "_Test flash"
+msgstr "_Flaşı sına"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Hearing"
+msgstr "İşitme"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "On Screen Keyboard"
+msgstr "Ekran Üzeri Klavye"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "Sticky Keys"
+msgstr "Yapışaq Tuşlar"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Bir dizi değiştirici tuşu kombinasyon olarak kabul eder"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:43
+msgid "_Disable if two keys are pressed together"
+msgstr "İki tuşa birden basıldığında _devre dışı bırak"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Beep when a _modifer key is pressed"
+msgstr "_Değiştirici tuşa basıldığında biple"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "Slow Keys"
+msgstr "Yavaş Tuşlar"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:46
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Bir tuşa basılmasıyla kabulü arasına gecikme koyar"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "A_cceptance delay:"
+msgstr "Q_abul keçikmesi:"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgctxt "universal access, delay"
+msgid "Short"
+msgstr "Qısqa"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Slow keys typing delay"
+msgstr "Yavaş tuşlar tuşlama keçikmesi"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgctxt "universal access, delay"
+msgid "Long"
+msgstr "Uzun"
+
+# Bir tuş aşağıdaki halette olğanda biple:
+#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Beep when a key is"
+msgstr "Tuş biplemesiniñ olacağı haletler:"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:54
+msgid "pressed"
+msgstr "basıq"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:56
+msgid "accepted"
+msgstr "qabul etilgen"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:58
+msgid "rejected"
+msgstr "red etilgen"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Bounce Keys"
+msgstr "Sıçrama Tuşları"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:60
+msgid "Ignores fast duplicate keypresses"
+msgstr "Kısa aralıklı tuş tekrarlarını yok sayar"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgid "Acc_eptance delay:"
+msgstr "Qab_ul keçikmesi:"
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "Bounce keys typing delay"
+msgstr "Sıçrama tuşları tuşlama keçikmesi"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Beep when a key is _rejected"
+msgstr "Bir tuş _reddedildiğinde biple"
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "Enable by Keyboard"
+msgstr "Klavye ile Qabilleştir"
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "İrişilebilirlik hususiyetlerini klavyeni qullanaraq aç ve qapat"
+
+#: ../panels/universal-access/uap.ui.h:67
+msgid "Mouse Keys"
+msgstr "Sıçan Tuşları"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Control the pointer using the keypad"
+msgstr "Belirteci klavye ile kontrol et"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Video Mouse"
+msgstr "Video Sıçan"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:70
+msgid "Control the pointer using the video camera."
+msgstr "İşaretçiyi vidyo kamerasıyla yönet."
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Simulated Secondary Click"
+msgstr "Ekilemci Çertmeni Taqlit Etüv"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:72
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "İlk düğme basılı tutulduğunda ikincil tıklama tetikle"
+
+#: ../panels/universal-access/uap.ui.h:73
+msgid "Secondary click delay"
+msgstr "Ekilemci çertme keçikmesi"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:74
+msgid "Hover Click"
+msgstr "Durağan Tıklama"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:75
+msgid "Trigger a click when the pointer hovers"
+msgstr "Belirteç nesne üstüne geldiğinde tıklama yap"
+
+#: ../panels/universal-access/uap.ui.h:76
+msgid "D_elay:"
+msgstr "_Keçikme:"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:77
+msgid "Motion _threshold:"
+msgstr "Hareket _eşiği:"
+
+#: ../panels/universal-access/uap.ui.h:78
+msgctxt "universal access, threshold"
+msgid "Small"
+msgstr "Kiçik"
+
+#: ../panels/universal-access/uap.ui.h:79
+msgctxt "universal access, threshold"
+msgid "Large"
+msgstr "Balaban"
+
+#: ../panels/universal-access/uap.ui.h:80
+msgid "Mouse Settings"
+msgstr "Sıçan Ayarları"
+
+# tr
+#: ../panels/universal-access/uap.ui.h:81
+msgid "Pointing and Clicking"
+msgstr "İşaretleme ve Tıklama"
+
+#: ../panels/universal-access/zoom-options.c:357
+msgctxt "Distance"
+msgid "Short"
+msgstr "Qısqa"
+
+#: ../panels/universal-access/zoom-options.c:358
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ Ekran"
+
+#: ../panels/universal-access/zoom-options.c:359
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ Ekran"
+
+#: ../panels/universal-access/zoom-options.c:360
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ Ekran"
+
+#: ../panels/universal-access/zoom-options.c:361
+msgctxt "Distance"
+msgid "Long"
+msgstr "Uzun"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "Tam Ekran"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "Töpe Yarı"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "Tüp Yarı"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "Sol Yarı"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "Sağ Yarı"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "Yaqınlaştırma Seçenekleri"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "Miqyasla"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "Büyütme:"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "Fare imlecini izle"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "Ekran bölümü:"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "Büyüteç ekran dışına taşıyor"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "Büyüteç imlecini ortala"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "Büyüteç imleci içerik etrafını çevreliyor"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "Büyüteç imleci içerikle birlikte hareket ediyor"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "Büyüteç Konumu:"
+
+# tüklü
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "Mercek"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "Qalınlıq:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "İnce"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Qalın"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "Uzunluq:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "Tüs:"
+
+# tüklü
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "Çapraz:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "Sıçan imleci ile örtüşe"
+
+# tüklü
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "Çapraz"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "Qara üzeri aq:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "Parlaqlıq:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "Tezat:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "Tüs"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Hiç biri"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Tam"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Tüşük"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Yüksek"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "Tüs Efektleri:"
+
+# tr
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "Tüs Efektleri"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:35
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Standart"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:37
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Memur"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "Add account"
+msgstr "Hesap ekle"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Local Account"
+msgstr "_Yerli Hesap"
+
+# tr
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "_Enterprise Login"
+msgstr "_Qurumsal İçeri İmzalanım"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+msgid "_Full name"
+msgstr "_Tam İsim"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Account _Type"
+msgstr "Hesap _Türü"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+msgid "_Domain"
+msgstr "_Saha"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Login Name"
+msgstr "İçeri İmzalanım _Adı"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "Tip: Enterprise domain or realm name"
+msgstr "Qarane: Qurum saha yaki hükümranlıq adı"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid "C_ontinue"
+msgstr "_Devam Et"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:14
+msgid "Domain Administrator Login"
+msgstr "Saha Memurı İçeri İmzalanımı"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Qurumsal içeri imzalanımlarnı qullanmaq içün, bu bilgisayarnıñ\n"
+"bir sahağa qayd olmağa ihtiyacı bar. Lütfen şebeke memurıñız \n"
+"saha parolini mında tuşlamasını rica etiñiz."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:18
+msgid "Administrator _Name"
+msgstr "Memur _Adı"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "Administrator Password"
+msgstr "Memur Sır-sözü"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "Sol başparmaq"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "Sol orta parmaq"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "Sol yüzük parmağı"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "Sol çinatiy parmaq"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "Oñ başparmaq"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "Oñ orta parmaq"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "Oñ yüzük parmağı"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "Oñ çinatiy parmaq"
+
+# tr
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:700
+msgid "Enable Fingerprint Login"
+msgstr "Parmak İzi Girişi Etkinleştir"
+
+# tr
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "_Sağ işaret parmağı"
+
+# tr
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "S_ol işaret parmağı"
+
+# tr
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "_Diğer parmak:"
+
+# tr
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"Parmak iziniz başarıyla kaydedildi. Artık parmak izi okuyucusunu kullanarak "
+"giriş yapabilirsiniz."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "Qullanıcılar"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr ""
+"Qullanıcılarnı ekleñiz ya da çetleştiriñiz ve sır-sözüñizni deñiştiriñiz"
+
+# tr
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Giriş;İsim;Parmak izi;Kullanıcı simgesi;Logo;Yüz;Parola;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "İçeri İmzalanma Keçmişi"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:3
+msgid "Previous Week"
+msgstr "Evvelki Hafta"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:4
+msgid "Next Week"
+msgstr "Soñraki Hafta"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:5
+msgid "Next week"
+msgstr "Soñraki hafta"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Set a password now"
+msgstr "Şimdi parola belirle"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+msgid "Choose password at next login"
+msgstr "Sonraki girişte parola seç"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Log in without a password"
+msgstr "Parolasız giriş yap"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "Disable this account"
+msgstr "Bu hesabı devre dışı bırak"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Enable this account"
+msgstr "Bu hesabı etkinleştir"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "C_onfirm password"
+msgstr "Parolayı _onayla"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "_New password"
+msgstr "Yeni p_arola"
+
+# tüklü
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Generate a password"
+msgstr "Bir sır-sözni doğurt"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+msgid "Current _password"
+msgstr "Cari _sır-söz"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+msgid "_Action"
+msgstr "_Amel"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+msgid "Changing password for"
+msgstr "Parola değiştiriliyor"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+msgid "_Show password"
+msgstr "Parolayı _Göster"
+
+# tr
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid "How to choose a strong password"
+msgstr "Nasıl güçlü bir parola seçilir"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+msgid "Ch_ange"
+msgstr "D_eñiştir"
+
+# tr
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+msgid "Changing photo for:"
+msgstr "Kullanıcının fotosu değiştiriliyor:"
+
+# tr
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+msgid ""
+"Choose a picture that will be shown at the login screen for this account."
+msgstr "Giriş ekranında bu hesap için kullanılacak bir resim seçin."
+
+# tr
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+msgid "Gallery"
+msgstr "Galeri"
+
+# tr
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "Browse for more pictures"
+msgstr "Daha fazla resim için göz at"
+
+# tr
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+msgid "Take a photograph"
+msgstr "Fotograf çek"
+
+# tr
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+msgid "Browse"
+msgstr "Gözat"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr "Foto"
+
+# tr
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Account Information"
+msgstr "Hesap bilgisi"
+
+# tr
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Add User Account"
+msgstr "Kullanıcı Hesabı Ekle"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Remove User Account"
+msgstr "Qullanıcı Hesabını Çetleştir"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "Login Options"
+msgstr "İçeri İmzalanma Seçenekleri"
+
+# tr
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "A_utomatic Login"
+msgstr "_Otomatik Giriş"
+
+# tr
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "_Fingerprint Login"
+msgstr "_Parmak İziyle Giriş"
+
+# tr
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "User Icon"
+msgstr "Kullanıcı Simgesi"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "_Language"
+msgstr "_Til"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "Last Login"
+msgstr "Soñki İçeri İmzalanma"
+
+# tr
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "Qullanıcı hesaplarını idare et"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "Qullanıcı verilerini deñiştirmek içün sahihlenim şarttır"
+
+#: ../panels/user-accounts/pw-utils.c:94
+#: ../panels/user-accounts/um-password-dialog.c:597
+msgctxt "Password strength"
+msgid "Too short"
+msgstr "Artqaç qısqa"
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password strength"
+msgid "Not good enough"
+msgstr "Yeterlice yahşı degil"
+
+#: ../panels/user-accounts/pw-utils.c:108
+#: ../panels/user-accounts/um-password-dialog.c:598
+msgctxt "Password strength"
+msgid "Weak"
+msgstr "Zayıf"
+
+#: ../panels/user-accounts/pw-utils.c:111
+#: ../panels/user-accounts/um-password-dialog.c:599
+msgctxt "Password strength"
+msgid "Fair"
+msgstr "Ortaca"
+
+#: ../panels/user-accounts/pw-utils.c:114
+#: ../panels/user-accounts/um-password-dialog.c:600
+msgctxt "Password strength"
+msgid "Good"
+msgstr "Eyi"
+
+#: ../panels/user-accounts/pw-utils.c:117
+#: ../panels/user-accounts/um-password-dialog.c:601
+msgctxt "Password strength"
+msgid "Strong"
+msgstr "Küçlü"
+
+#: ../panels/user-accounts/run-passwd.c:424
+msgid "Authentication failed"
+msgstr "Sahihlenim muvaffaqiyetsiz"
+
+# tr
+#: ../panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The new password is too short"
+msgstr "Yeni parola çok kısa"
+
+# tr
+#: ../panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password is too simple"
+msgstr "Yeni parola çok basit"
+
+# tr
+#: ../panels/user-accounts/run-passwd.c:516
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Eski ve yeni parolalar birbirine çok benziyor"
+
+# tr
+#: ../panels/user-accounts/run-passwd.c:519
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Yañı parol demin endi qullanılğandır."
+
+# tr
+#: ../panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Yeni parola rakam ya da özel karakterler içermeli"
+
+# tr
+#: ../panels/user-accounts/run-passwd.c:526
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Eski ve yeni parolalar birbirinin aynısı"
+
+# tr
+#: ../panels/user-accounts/run-passwd.c:530
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Parolanız önceki kimlik doğrulamasından sonra değiştirildi!"
+
+# tr
+#: ../panels/user-accounts/run-passwd.c:534
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Yeni parola yeterli sayıda farklı karakterler içermiyor"
+
+#: ../panels/user-accounts/run-passwd.c:538
+#, c-format
+msgid "Unknown error"
+msgstr "Bilinmegen hata"
+
+#: ../panels/user-accounts/um-account-dialog.c:186
+msgid "Failed to add account"
+msgstr "Hesap eklenamadı"
+
+# tr
+#: ../panels/user-accounts/um-account-dialog.c:407
+#: ../panels/user-accounts/um-account-dialog.c:448
+msgid "Failed to register account"
+msgstr "Hesap qayd etilamadı"
+
+#: ../panels/user-accounts/um-account-dialog.c:581
+msgid "No supported way to authenticate with this domain"
+msgstr "Bu saha ile sahihlenmek içün desteklengen yol yoq"
+
+#: ../panels/user-accounts/um-account-dialog.c:635
+msgid "Failed to join domain"
+msgstr "Sahağa qoşulınamadı"
+
+#: ../panels/user-accounts/um-account-dialog.c:703
+msgid "Failed to log into domain"
+msgstr "Sahağa içeri imzalanılamadı"
+
+# tr
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"Aygıta erişiminize izin verilmedi. Sistem yöneticinizle bağlantıya geçin."
+
+# tr
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "Aygıt zaten kullanımda."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr "Dahiliy hata hasıl oldı."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:219
+#: ../panels/user-accounts/um-fingerprint-dialog.c:220
+msgid "Enabled"
+msgstr "Qabilleştirilgen"
+
+# tr
+#: ../panels/user-accounts/um-fingerprint-dialog.c:268
+msgid "Delete registered fingerprints?"
+msgstr "Kayıtlı parmak izleri silinsin mi?"
+
+# tr
+#: ../panels/user-accounts/um-fingerprint-dialog.c:272
+msgid "_Delete Fingerprints"
+msgstr "_Parmak İzlerini Sil"
+
+# tr
+#: ../panels/user-accounts/um-fingerprint-dialog.c:279
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Kayıtlı parmak izlerini silerek parmak izi girişini kapatmak ister misiniz?"
+
+# tr
+#: ../panels/user-accounts/um-fingerprint-dialog.c:455
+msgid "Done!"
+msgstr "Tamamlandı!"
+
+# tr
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:516
+#: ../panels/user-accounts/um-fingerprint-dialog.c:558
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' aygıtına erişilemedi"
+
+# tr
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:599
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "'%s' aygıtı üzerinde parmak yakalama başlatılamadı"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:650
+msgid "Could not access any fingerprint readers"
+msgstr "Hiç bir parmaq izi oquyıcısına irişilamadı"
+
+# tr
+#: ../panels/user-accounts/um-fingerprint-dialog.c:651
+msgid "Please contact your system administrator for help."
+msgstr "Lütfen yardım için sistem yöneticinizle bağlantıya geçin."
+
+# tr
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:734
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"Parmak izi girişin etkinleşebilmesi için parmak izlerinizden bir tanesini "
+"'%s' aygıtını kullanarak kaydetmelisiniz."
+
+# tr
+#: ../panels/user-accounts/um-fingerprint-dialog.c:741
+msgid "Selecting finger"
+msgstr "Parmak seçiliyor"
+
+# tr
+#: ../panels/user-accounts/um-fingerprint-dialog.c:742
+msgid "Enrolling fingerprints"
+msgstr "Parmak izleri kaydediliyor"
+
+#: ../panels/user-accounts/um-history-dialog.c:88
+msgid "This Week"
+msgstr "Bu Hafta"
+
+#: ../panels/user-accounts/um-history-dialog.c:91
+msgid "Last Week"
+msgstr "Keçken Hafta"
+
+#: ../panels/user-accounts/um-password-dialog.c:128
+msgid "_Generate a password"
+msgstr "Bir sır-sözni _doğurt"
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:181
+msgid "Please choose another password."
+msgstr "Lütfen farklı bir parola seçin"
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:190
+msgid "Please type your current password again."
+msgstr "Lütfen parolanızı tekrar girin."
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:196
+msgid "Password could not be changed"
+msgstr "Parolanız değiştirilemedi"
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:301
+msgid "You need to enter a new password"
+msgstr "Yeni bir parola girmelisiniz"
+
+#: ../panels/user-accounts/um-password-dialog.c:304
+msgid "The new password is not strong enough"
+msgstr "Yañı parol yeterli derecede küçlü degildir"
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:310
+msgid "You need to confirm the password"
+msgstr "Parolayı onaylamanız gerekiyor"
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:313
+msgid "The passwords do not match"
+msgstr "Parolalar eşleşmiyor"
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:319
+msgid "You need to enter your current password"
+msgstr "Mevcut parolanızı girmeniz gerekiyor"
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:322
+msgid "The current password is not correct"
+msgstr "Şu anki parola hatalı"
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:385
+msgid "Passwords do not match"
+msgstr "Parolalar uyuşmuyor"
+
+# tr
+#: ../panels/user-accounts/um-password-dialog.c:439
+msgid "Wrong password"
+msgstr "Hatalı parola"
+
+# tr
+#: ../panels/user-accounts/um-photo-dialog.c:443
+msgid "Disable image"
+msgstr "Resmi etkisizleştir"
+
+#: ../panels/user-accounts/um-photo-dialog.c:461
+msgid "Take a photo…"
+msgstr "Bir foto çıqar…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:479
+msgid "Browse for more pictures…"
+msgstr "Daha fazla resim içün kezin…"
+
+# tr
+#: ../panels/user-accounts/um-photo-dialog.c:703
+#, c-format
+msgid "Used by %s"
+msgstr "%s tarafından kullanılıyor"
+
+#: ../panels/user-accounts/um-realm-manager.c:351
+msgid "Cannot automatically join this type of domain"
+msgstr "Bu tür sahağa avtomatik olaraq qoşulalmayım"
+
+#: ../panels/user-accounts/um-realm-manager.c:414
+#, c-format
+msgid "No such domain or realm found"
+msgstr "Böyle bir saha yaki hükümranlıq tapılmadı"
+
+#: ../panels/user-accounts/um-realm-manager.c:814
+#: ../panels/user-accounts/um-realm-manager.c:828
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s sahasında %s olaraq içeri imzalanalmayım."
+
+#: ../panels/user-accounts/um-realm-manager.c:820
+msgid "Invalid password, please try again"
+msgstr "Keçersiz parol, lütfen yañıdan deñeñiz"
+
+#: ../panels/user-accounts/um-realm-manager.c:833
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "%s sahasına bağlanılamadı: %s"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:376
+msgid "Failed to delete user"
+msgstr "Kullanıcı silinemedi"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:436
+msgid "You cannot delete your own account."
+msgstr "Kendi hesabınızı silemezsiniz."
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:445
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s halen sisteme giriş yapmış durumda"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:449
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Giriş yapmış bir kullanıcıyı silmek sistemi tutarsız bir duruma sokabilir."
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:458
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "%s' in dosyalarını bırakmak ister misiniz?"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:462
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Kullanıcı silerken ev klasörünü, postalarını ve geçici dosyalarını bırakmak "
+"mümkün."
+
+#: ../panels/user-accounts/um-user-panel.c:465
+msgid "_Delete Files"
+msgstr "Dosyelerni _Sil"
+
+#: ../panels/user-accounts/um-user-panel.c:466
+msgid "_Keep Files"
+msgstr "Dosyelerni _Qoru"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:518
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Hesap devre dışı"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:526
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Bir sonraki girişte ayarlanacak"
+
+#: ../panels/user-accounts/um-user-panel.c:529
+msgctxt "Password mode"
+msgid "None"
+msgstr "Hiç biri"
+
+#: ../panels/user-accounts/um-user-panel.c:578
+msgid "Logged in"
+msgstr ""
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:943
+msgid "Failed to contact the accounts service"
+msgstr "Hesap hizmetiyle bağlantı kurulamadı"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:945
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Lütfen AccountService' in kurulu ve etkin olduğundan emin olun."
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:986
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Değişiklik yapmak için,\n"
+"önce * simgesine tıklayın"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:1024
+msgid "Create a user account"
+msgstr "Kullanıcı hesabı oluştur"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:1035
+#: ../panels/user-accounts/um-user-panel.c:1321
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Kullanıcı hesabı oluşturmak için,\n"
+"önce * simgesine tıklayın"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:1044
+msgid "Delete the selected user account"
+msgstr "Seçilen kullanıcı hesabını sil"
+
+# tr
+#: ../panels/user-accounts/um-user-panel.c:1056
+#: ../panels/user-accounts/um-user-panel.c:1326
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Seçilen kullanıcı hesabını silmek için,\n"
+"önce * simgesine tıklayın"
+
+#: ../panels/user-accounts/um-user-panel.c:1230
+msgid "My Account"
+msgstr "Hesabım"
+
+#: ../panels/user-accounts/um-user-panel.c:1239
+msgid "Other Accounts"
+msgstr "Diger Hesaplar"
+
+# tr
+#: ../panels/user-accounts/um-utils.c:535
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr "'%s' kullanıcısı zaten mevcut"
+
+# tr
+#: ../panels/user-accounts/um-utils.c:539
+#, c-format
+msgid "The username is too long"
+msgstr "Kullanıcı adı fazlasıyla uzun"
+
+# tr
+#: ../panels/user-accounts/um-utils.c:542
+msgid "The username cannot start with a '-'"
+msgstr "Kullanıcı adı '-' ile başlayamaz"
+
+# tr
+#: ../panels/user-accounts/um-utils.c:545
+msgid ""
+"The username must only consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr ""
+"Kullanıcı adı sadece şunlardan oluşmalıdır:\n"
+" ➣ İngiliz alfabesinden harfler\n"
+" ➣ rakamlar\n"
+" ➣ '.', '-' ve '_' karakterlerinden herhangi biri"
+
+# tr
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "Düğmeleri Eşleyin"
+
+# tr
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr "Düğmeleri işlevlere eşleyin"
+
+# tr
+#: ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Tabletinizi kalibre etmek için lütfen hedef işaretçilerine ekranda "
+"göründükçe dokunun."
+
+# tr
+#: ../panels/wacom/calibrator/calibrator-gui.c:86
+msgid "Mis-click detected, restarting..."
+msgstr "Yanlış tıklama tespit edildi, yeniden başlatılıyor..."
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Output:"
+msgstr "Çıqtı:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:287
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Aspekt nisbetini qoru (mektüpqutusı):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:298
+msgid "Map to single monitor"
+msgstr "Tek monitorğa haritala"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:89
+#, c-format
+msgid "%d of %d"
+msgstr "%d / %d"
+
+#: ../panels/wacom/cc-wacom-page.c:123 ../panels/wacom/cc-wacom-page.c:424
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "Hiç biri"
+
+#: ../panels/wacom/cc-wacom-page.c:124
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Tuş-çarpmanı Yiber"
+
+#: ../panels/wacom/cc-wacom-page.c:125
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Monitorlarnı Almaştır"
+
+#: ../panels/wacom/cc-wacom-page.c:126
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:665
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "Yuqarı"
+
+#: ../panels/wacom/cc-wacom-page.c:665
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "Aşağı"
+
+#: ../panels/wacom/cc-wacom-page.c:706
+msgid "Switch Modes"
+msgstr "Tarzlarnı Almaştır"
+
+#: ../panels/wacom/cc-wacom-page.c:796
+#: ../panels/wacom/cc-wacom-stylus-page.c:373
+msgid "Button"
+msgstr "Dögme"
+
+# tr
+#: ../panels/wacom/cc-wacom-page.c:854
+msgid "Action"
+msgstr "Amel"
+
+# tr
+#: ../panels/wacom/cc-wacom-page.c:964
+msgid "Display Mapping"
+msgstr "Eşlemeyi görüntüle"
+
+# tr
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+# tr
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Kalem;Silgi;Fare;"
+
+# tr
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "Tablet (mutlak)"
+
+# tr
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "İmleçsürer (Touchpad) (göreceli)"
+
+# tr
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "Tablet Tercihleri"
+
+# tr
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr "Tablet bulunamadı"
+
+# tr
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Lütfen Wacom tabletinizi açın veya bağlayın"
+
+# tr
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr "Bluetooth Ayarları"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Map to Monitor…"
+msgstr "Monitorğa Haritala…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map Buttons…"
+msgstr "Dögmelerni Haritalañız…"
+
+# tr
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr "Görüntü çözünürlüğünü ayarla"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust mouse settings"
+msgstr "Sıçan ayarlarını tadil et"
+
+# tr
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Tracking Mode"
+msgstr "İzleme Kipi"
+
+# tr
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Left-Handed Orientation"
+msgstr "Sol Elle Kullanım Yerleşimi"
+
+# tüklü
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1078
+msgid "Left Ring"
+msgstr "Sol Alqa"
+
+# tüklü
+#: ../panels/wacom/gsd-wacom-device.c:1089
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "Sol Alqa Tarzı #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1109
+msgid "Right Ring"
+msgstr "Oñ Alqa"
+
+#: ../panels/wacom/gsd-wacom-device.c:1120
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "Oñ Alqa Tarzı #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1162
+msgid "Left Touchstrip"
+msgstr "Sol Tiyüv Şeriti"
+
+#: ../panels/wacom/gsd-wacom-device.c:1173
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "Sol Tiyüv Şeriti Tarzı #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1193
+msgid "Right Touchstrip"
+msgstr "Oñ Tiyüv Şeriti"
+
+#: ../panels/wacom/gsd-wacom-device.c:1204
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "Oñ Tiyüv Şeriti Tarzı #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1230
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "Sol Tiyüv Alqası Tarzı Almaştırğıçı"
+
+#: ../panels/wacom/gsd-wacom-device.c:1232
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "Oñ Tiyüv Alqası Tarzı Almaştırğıçı"
+
+#: ../panels/wacom/gsd-wacom-device.c:1235
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "Sol Tiyüv Şeriti Tarzı Almaştırğıçı"
+
+#: ../panels/wacom/gsd-wacom-device.c:1237
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "Oñ Tiyüv Şeriti Tarzı Almaştırğıçı"
+
+#: ../panels/wacom/gsd-wacom-device.c:1242
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "Tarz Almaştırğıçı #%d"
+
+# tr
+#: ../panels/wacom/gsd-wacom-device.c:1351
+#, c-format
+msgid "Left Button #%d"
+msgstr "Sol Düğme #%d"
+
+# tr
+#: ../panels/wacom/gsd-wacom-device.c:1354
+#, c-format
+msgid "Right Button #%d"
+msgstr "Sağ Düğme #%d"
+
+# tr
+#: ../panels/wacom/gsd-wacom-device.c:1357
+#, c-format
+msgid "Top Button #%d"
+msgstr "Üst Düğme #%d"
+
+# tr
+#: ../panels/wacom/gsd-wacom-device.c:1360
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "Alt Düğme #%d"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "Eylem Yok"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "Sol Fare Düğmesi Tıklaması"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "Orta Fare Düğmesi Tıklaması"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "Sağ Fare Düğmesi Tıklaması"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "Yukarı Kaydır"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "Aşağı Kaydır"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "Sola Kaydır"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "Sağa Kaydır"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "Keri"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "İleri"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "Tablet Kalemi (Stylus)"
+
+# tüklü
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "Silgi Basım Sezilişi"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "Yumuşak"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "Sıkı"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "Üst Dögme"
+
+# tüklü
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "Alt Dögme"
+
+# tr
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "Parmak Ucu Basınç Hissi"
+
+# tr
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "Detay kipini etkinleştir"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "Üstbaqışnı köster"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr ""
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr ""
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "Yardım seçeneklerini köster"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "Kösterilecek panel"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr ""
+
+#: ../shell/cc-application.c:142
+msgid "- Settings"
+msgstr "- Ayarlar"
+
+# tr
+#: ../shell/cc-application.c:160
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"Kullanılabilir komut satırı seçeneklerini görmek için '%s --help' komutunu "
+"çalıştırın.\n"
+
+#: ../shell/cc-application.c:190
+msgid "Available panels:"
+msgstr "Faydalanışlı paneller:"
+
+#: ../shell/cc-application.c:325
+msgid "Help"
+msgstr "Yardım"
+
+#: ../shell/cc-application.c:326
+msgid "Quit"
+msgstr "Terk et"
+
+#: ../shell/cc-window.c:61 ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "Ayarlar"
+
+#. Add categories
+#: ../shell/cc-window.c:857
+msgctxt "category"
+msgid "Personal"
+msgstr "Şahsiy"
+
+#: ../shell/cc-window.c:858
+msgctxt "category"
+msgid "Hardware"
+msgstr "Donanım"
+
+# tr
+#: ../shell/cc-window.c:859
+msgctxt "category"
+msgid "System"
+msgstr "Sistem"
+
+#: ../shell/cc-window.c:1421
+msgid "All Settings"
+msgstr "Hepsi Ayarlar"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "Tercihler;Ayarlar;"
+
+#~ msgid "English"
+#~ msgstr "İnglizce"
+
+#~ msgid "British English"
+#~ msgstr "Britaniya İnglizcesi"
+
+#~ msgid "French"
+#~ msgstr "Frenkçe"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Çince (basitleştirilgen)"
+
+#~ msgid "Current network location"
+#~ msgstr "Ağımdaki şebeke qonumı"
+
+#~ msgid "More themes URL"
+#~ msgstr "Daha çoq temalar içün URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "Bunı ağımdaki qonum ismiñizge tesbit etiñiz. Bu, munasip şebeke proksisi "
+#~ "yapılandırmasını belgilemek içün qullanılır."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "Daha çoq masaüstü arqa-zeminleriniñ alınabilecegi URL. Boş bir tizgige "
+#~ "tesbit etilse ilişim körülmeycek."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "Daha çoq masaüstü temalarınıñ alınabilecegi URL. Boş bir tizgige tesbit "
+#~ "etilse ilişim körülmeycek."
+
+#~ msgid "Image/label border"
+#~ msgstr "Suret/etiket sıñırı"
+
+# tr
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr ""
+#~ "Uyarı penceresindeki resmin ve etiketin çevresindeki kenarlığın genişliği"
+
+# tr
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Uyarı penceresinde gösterilen düğmeler"
+
+# tr
+#~ msgid "No Image"
+#~ msgstr "Resim Yok"
+
+# tr
+#~ msgid "Images"
+#~ msgstr "Resimler"
+
+# tr
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Adres defteri bilgileri alınmaya çalışılırken bir hata oluştu\n"
+#~ "Evolution Veri Sunucusu bu protokolü işleyemiyor"
+
+# tr
+#~ msgid "About %s"
+#~ msgstr "%s Hakkında"
+
+# tr
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "About Me"
+#~ msgstr "Menim Haqqımda"
+
+# tr
+#~ msgid "Ci_ty:"
+#~ msgstr "Ş_ehir:"
+
+# tr
+#~ msgid "Co_untry:"
+#~ msgstr "Ü_lke:"
+
+# tr
+#~ msgid "Cou_ntry:"
+#~ msgstr "Ül_ke:"
+
+#~ msgid "Email"
+#~ msgstr "E-poçta"
+
+# tr
+#~ msgid "Hom_e:"
+#~ msgstr "_Ev:"
+
+# tr
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "Aniy Mesajlaşma"
+
+# tr
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+# tr
+#~ msgid "P.O. _box:"
+#~ msgstr "Posta _Kutusu:"
+
+# tr
+#~ msgid "P._O. box:"
+#~ msgstr "P_osta Kutusu:"
+
+# tr
+#~ msgid "Select your photo"
+#~ msgstr "Fotoğrafınızı seçin"
+
+# tr
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Eyalet/_Mahalle:"
+
+# tr
+#~ msgid "Web _log:"
+#~ msgstr "Web _günlüğü:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_İş:"
+
+#~ msgid "Work"
+#~ msgstr "İş"
+
+#~ msgid "Work _fax:"
+#~ msgstr "İş _faksı:"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "_Poçta kodu:"
+
+#~ msgid "_GroupWise:"
+#~ msgstr "_GroupWise:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Ev:"
+
+# tr
+#~ msgid "_Manager:"
+#~ msgstr "_Yönetici:"
+
+# tr
+#~ msgid "_State/Province:"
+#~ msgstr "_Eyalet/Mahalle:"
+
+# tr
+#~ msgid "_Work:"
+#~ msgstr "_İş:"
+
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+
+# tr
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+# tr
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "_Poşta kodu:"
+
+# tr
+#~ msgid "Swipe finger on reader"
+#~ msgstr "Parmağınızı okuyucu üzerinden kaydırın"
+
+# tr
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "Alt beklenmeyen biçimde çıktı"
+
+# tr
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO kanalı kapatılamadı: %s"
+
+# tr
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO kanalı kapatılamadı: %s"
+
+# tr
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%s çalıştırılamadı: %s"
+
+# tr
+#~ msgid "Unable to launch backend"
+#~ msgstr "Araç çalıştırılamadı"
+
+# tr
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr ""
+#~ "Parolayı değiştirmek için <b>Parola değiştir</b>'in üzerine tıklayın."
+
+# tr
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "Lütfen parolanızı <b>Yeni parolanızı tekrar yazın</b> alanına tekrar yazı."
+
+# tr
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "Parolanızı değiştirmek için, mevcut parolanızı aşağıdaki alana yazın ve "
+#~ "<b>Kimlik Doğrula</b>'ya tıklayın.\n"
+#~ "Kimliğinizi doğruladıktan sonra, yeni parolanızı girin, onay için tekrar "
+#~ "girin ve <b>Parola değiştir</b>'e tıklayın."
+
+# tr
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "Erişilebilir _Giriş"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "Yardımcıl Tehnologiyalar"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "Yardımcıl tehnologiyalarnı qabilleştirgen deñişiklikler bir soñraki içeri "
+#~ "imzalanuvıñızğa qadar yürerlikke kirmez."
+
+#~ msgid "Changes to visual system bell take effect immediately."
+#~ msgstr "Körsel sistem ziline yapılğan deñişiklikler heman yürerlikke kirer."
+
+#~ msgid "Enable _visual system bell"
+#~ msgstr "_Körsel sistem zili qabil olsun"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Tercih Etilgen Uyğulamalar penceresine sekir"
+
+# tr
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "Erişilebilir Giriş penceresine geç"
+
+# tr
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "Klavye Erişilebilirliği penceresine geç"
+
+# tr
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Fare Erişilebilirliği penceresine geç"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Yardımcıl tehnologiyalarnı qabilleştir"
+
+# tr
+#~ msgid "_Keyboard Accessibility"
+#~ msgstr "_Klavye Erişilebilirliği"
+
+# tr
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "_Fare Erişilebilirliği"
+
+#~ msgid "_Password dialogs as normal windows"
+#~ msgstr "Sır-söz _dialogları normal pencereler olaraq"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr ""
+#~ "İçeri imzalanğanıñızda hangi irişilebilirlik hususiyetleriniñ "
+#~ "qabilleştirilecegini saylañız"
+
+# tr
+#~ msgid "Font may be too large"
+#~ msgstr "Yazıtipi çok büyük olabilir"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Saylanğan hurufat %d noqta büyükliginde olıp bu bilgisayarnıñ effektiv "
+#~ "qullanıluvını qıyınlaştırabilir.  %d büyükliginden daha kiçik bir ölçü "
+#~ "saylavıñız tevsiye etile."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Saylanğan hurufat %d noqta büyükliginde olıp bu bilgisayarnıñ tesirli "
+#~ "qullanıluvını qıyınlaştırabilir. Daha kiçik ölçüdeki bir hurufat "
+#~ "saylavıñız tevsiye etile."
+
+# tr
+#~ msgid "Use previous font"
+#~ msgstr "Önceki yazıtipini kullan"
+
+# tr
+#~ msgid "Use selected font"
+#~ msgstr "Seçili yazıtipini kullan"
+
+# tr
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Yüklemek için bir temanın dosya ismini belirtin"
+
+# tr
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "(theme|background|fonts|interface) göstermek için sayfanın ismini belirtin"
+
+# tr
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[DUVAR KAĞIDI...]"
+
+# tr
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "But tema istenildiği gibi görünmeyebilir çünkü gerekli GTK+ tema aygıtı "
+#~ "'%s' yüklü değil."
+
+# tr
+#~ msgid "Apply Font"
+#~ msgstr "Yazıtipini Uygula"
+
+# tr
+#~ msgid "Revert Font"
+#~ msgstr "Yazıtipini Geri Çevir"
+
+#~ msgid ""
+#~ "The current theme suggests a background, a font and a button layout. "
+#~ "Also, the last applied font and button layout suggestion can be reverted."
+#~ msgstr ""
+#~ "Cari tema bir arqazemin, bir hurufat ve bir dögme tizilimi telqin ete. "
+#~ "Bir de, soñki uyğulanğan hurufat ve dögme tizilimi telqini keri "
+#~ "döndürilebilir."
+
+# tr
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "Mevcut tema bir arkaplan ve bir yazıtipi tavsiye ediyor. Ayrıca son "
+#~ "uygulanan yazıtipi tavsiyesi geriye çevirilebilir."
+
+#~ msgid ""
+#~ "The current theme suggests a background, a font and a button layout. "
+#~ "Also, the last applied button layout suggestion can be reverted."
+#~ msgstr ""
+#~ "Cari tema bir arqazemin, bir hurufat ve bir dögme tizilimi telqin ete. "
+#~ "Bir de, soñki uyğulanğan dögme tizilimi telqini keri döndürilebilir."
+
+#~ msgid ""
+#~ "The current theme suggests a background and a button layout. Also, the "
+#~ "last applied font and button layout suggestion can be reverted."
+#~ msgstr ""
+#~ "Cari tema bir arqazemin ve bir dögme tizilimi telqin ete. Bir de, soñki "
+#~ "uyğulanğan hurufat ve dögme tizilimi telqini keri döndürilebilir."
+
+# tr
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "Mevcut tema bir arkaplan tavsiye ediyor. Ayrıca son uygulanan yazıtipi "
+#~ "tavsiyesi geri alınabilir."
+
+# tr
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "Bu tema bir arkaplan ve yazıtipi öneriyor."
+
+# tr
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "Mevcut tema bir yazıtipi tavsiye ediyor. Ayrıca, sonra uygulanan yazıtipi "
+#~ "tavsiyesi geriye çevirilebilir."
+
+#~ msgid ""
+#~ "The current theme suggests a font and a button layout. Also, the last "
+#~ "applied button_layout suggestion can be reverted."
+#~ msgstr ""
+#~ "Cari tema bir hurufat ve bir dögme tizilimi telqin ete. Bir de, soñki "
+#~ "uyğulanğan dögme tizilimi telqini keri döndürilebilir."
+
+# tr
+#~ msgid "The current theme suggests a background."
+#~ msgstr "Bu tema bir arkaplan öneriyor."
+
+# tr
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "Son uygulanan yazıtipi tavsiyesi geriye çevrilebilir."
+
+# tr
+#~ msgid "The current theme suggests a font."
+#~ msgstr "Bu tema bir yazıtipi öneriyor."
+
+#~ msgid ""
+#~ "The current theme suggests a button layout. Also, the last button layout "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "Cari tema bir dögme tizilimi telqin ete. Bir de, soñki uyğulanğan dögme "
+#~ "tizilimi telqini keri döndürilebilir."
+
+# tr
+#~ msgid "Best _shapes"
+#~ msgstr "_En iyi şekiller"
+
+# tr
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "İmleç temanızın değiştirilmesi bir sonraki girişinizde etkin olur."
+
+# tr
+#~ msgid "Customize Theme"
+#~ msgstr "Temayı Özelleştir"
+
+# tr
+#~ msgid "Des_ktop font:"
+#~ msgstr "_Masaüstü yazıtipi:"
+
+# tr
+#~ msgid "Font Rendering Details"
+#~ msgstr "Yazıtipi Tarama Ayrıntıları"
+
+# tr
+#~ msgid "Fonts"
+#~ msgstr "Yazıtipleri"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "Daha çoq arqa-zeminini devre-içi elde etiñiz"
+
+#~ msgid "Get more themes online"
+#~ msgstr "Daha çoq temanı devre-içi elde etiñiz"
+
+# tr
+#~ msgid "Gra_yscale"
+#~ msgstr "_Griölçek"
+
+# tr
+#~ msgid "Icons"
+#~ msgstr "Simgeler"
+
+#~ msgid "Icons only"
+#~ msgstr "Faqat işaretçikler"
+
+#~ msgid "N_one"
+#~ msgstr "_Hiç biri"
+
+# tr
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Bir renk belirtmek için pencere aç"
+
+# tr
+#~ msgid "Save Theme As..."
+#~ msgstr "Temayı Farklı Kaydet..."
+
+# tr
+#~ msgid "Save _As..."
+#~ msgstr "_Farklı Kaydet..."
+
+# tr
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Alt _benek (LCD ekranlar)"
+
+# tr
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Alt _benek yumuşatma (LCD ekranlar)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "Alt-piksel Sırası"
+
+# tr
+#~ msgid "Text"
+#~ msgstr "Metin"
+
+#~ msgid "Text below items"
+#~ msgstr "Metin unsurlarnıñ altında"
+
+#~ msgid "Text beside items"
+#~ msgstr "Metin unsurlarnıñ yanında"
+
+#~ msgid "Text only"
+#~ msgstr "Faqat metin"
+
+# tr
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "Mevcut kontroller teması renk şemasını desteklemiyor."
+
+# tr
+#~ msgid "Theme"
+#~ msgstr "Tema"
+
+# tr
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+# tr
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+# tr
+#~ msgid "_Document font:"
+#~ msgstr "_Belge yazıtipi:"
+
+# tr
+#~ msgid "_Fixed width font:"
+#~ msgstr "_Sabit genişlikli yazıtipi:"
+
+# tr
+#~ msgid "_Monochrome"
+#~ msgstr "_Siyah-beyaz"
+
+# tr
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+# tr
+#~ msgid "_Size:"
+#~ msgstr "_Boyut:"
+
+# tr
+#~ msgid "_Tooltips:"
+#~ msgstr "_Baloncuklar:"
+
+# tr
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+# tr
+#~ msgid "_Window title font:"
+#~ msgstr "_Pencere başlık yazıtipi:"
+
+# tr
+#~ msgid "_Windows:"
+#~ msgstr "_Pencereler:"
+
+# tr
+#~ msgid "dots per inch"
+#~ msgstr "inç başına nokta"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Masaüstü körünişini şahsiyleştir"
+
+# tr
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Masaüstünün farklı noktaları için tema yükler"
+
+# tr
+#~ msgid "Theme Installer"
+#~ msgstr "Tema Yükleyici"
+
+# tr
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Gnome Tema Paketi"
+
+# tr
+#~ msgid "Slide Show"
+#~ msgstr "Slayt Gösterisi"
+
+#~ msgid "Image"
+#~ msgstr "Suret"
+
+# tr
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "piksel"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Cilbent: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Cilbent: %s"
+
+# tr
+#~ msgid "Cannot install theme"
+#~ msgstr "Tema yüklenemiyor"
+
+# tr
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s aracı kurulu değil."
+
+# tr
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "Tema açılırken bir problem oluştu."
+
+# tr
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "Seçili dosya yüklenirken bir hata oluştu"
+
+# tr
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" geçerli bir tema gibi gözükmüyor."
+
+# tr
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" geçerli bir tema gibi gözükmüyor. O derlemeniz gereken bir tema "
+#~ "aracı olabilir."
+
+# tr
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "\"%s\" teması kurulumu başarısız oldu."
+
+# tr
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "Team \"%s\" başarıyla kuruldu."
+
+# tr
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr ""
+#~ "Temayı şimdi mi uygulamak istersiniz, yoksa mevcut temayı mı tutmak "
+#~ "istersiniz?"
+
+# tr
+#~ msgid "Keep Current Theme"
+#~ msgstr "Mevcut Temayı Tut"
+
+# tr
+#~ msgid "Apply New Theme"
+#~ msgstr "Yeni Temayı Uygula"
+
+# tr
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME Teması %s başarıyla kuruldu"
+
+# tr
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "Yeni temalar başarıyla kuruldu."
+
+# tr
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Yüklemek için bir tema dosyası belirtilmedi"
+
+# tr
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Temayı aşağıdaki konuma kurmak için yetersiz izin:\n"
+#~ "%s"
+
+# tr
+#~ msgid "Theme Packages"
+#~ msgstr "Tema Paketleri"
+
+# tr
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Tema zaten mevcut. Onun yerin koymak ister misinz?"
+
+# tr
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Bu temayı silmek ister misiniz?"
+
+# tr
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "Tema silinemiyor"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Ayarlar idarecisi 'gnome-settings-daemon' başlatılalmay.\n"
+#~ "GNOME ayarlar idarecisi çapmadan, bazı tercihler amelge kirmez. Bu, DBus "
+#~ "ile bir meseleniñ işareti olabilir, ya da bir GNOME-tışı (meselâ, KDE) "
+#~ "ayarlar idarecisi endi faal olıp GNOME ayarlar idarecisi ile çatışa "
+#~ "olabilir."
+
+# tr
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Depo simgesi '%s' yüklenemiyor\n"
+
+# tr
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Yardım dosyasının görüntülenmesinde bir hata oluştu: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Dosye kopiyalana: %u / %u"
+
+# tr
+#~ msgid "Parent Window"
+#~ msgstr "Üst Pencere"
+
+# tr
+#~ msgid "Parent window of the dialog"
+#~ msgstr "Pencerenin üst penceresi"
+
+# tr
+#~ msgid "From URI"
+#~ msgstr "Kaynak URI"
+
+# tr
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI buradan aktarıyor"
+
+# tr
+#~ msgid "To URI"
+#~ msgstr "Hedef URI"
+
+# tr
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI halen buraya aktarıyor"
+
+# tr
+#~ msgid "Fraction completed"
+#~ msgstr "İşlem tamamlandı"
+
+# tr
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Transfer işlemi şu anda tamamlandı"
+
+# tr
+#~ msgid "Current URI index"
+#~ msgstr "Güncel URI dizini"
+
+# tr
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Güncel URI dizini - 1'den başlar"
+
+# tr
+#~ msgid "Total URIs"
+#~ msgstr "Toplam URI"
+
+# tr
+#~ msgid "Total number of URIs"
+#~ msgstr "Toplam URI sayısı"
+
+# tr
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "Dosya '%s' zaten mevcut. Onun üzerine yazmak ister misinz?"
+
+# tr
+#~ msgid "_Skip"
+#~ msgstr "_Atla"
+
+# tr
+#~ msgid "Overwrite _All"
+#~ msgstr "Ü_zerine Yaz"
+
+# tr
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Öntanımlı Belirteç - Şimdiki"
+
+# tr
+#~ msgid "White Pointer"
+#~ msgstr "Beyaz Belirteç"
+
+# tr
+#~ msgid "White Pointer - Current"
+#~ msgstr "Beyaz Belirteç - Şimdiki"
+
+# tr
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Büyük Belirteç - Şimdiki"
+
+# tr
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Büyük Beyaz Belirteç - Şimdiki"
+
+# tr
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Bu tema istenildiği gibi görünmeyecek çünkü gerekli GTK+ teması '%s' "
+#~ "kurulu değil."
+
+# tr
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "Bu tema istenildiği gibi görünmeyecek çünkü pencere yöneticisi teması "
+#~ "'%s' kurulu değil."
+
+# tr
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Bu tema istenildiği gibi görünmeyecek çünkü gerekli simge teması '%s' "
+#~ "kurulu değil."
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "Tercih etilgen körsel yardımcıl tehnologiyanı başlat"
+
+# tr
+#~ msgid "Error setting default browser: %s"
+#~ msgstr "Ögbelgilengen kezicini tesbit etkende hata: %s"
+
+# tr
+#~ msgid "Error setting default mailer: %s"
+#~ msgstr "Ögbelgilengen poçtacını tesbit etkende hata: %s"
+
+# tr
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "(internet|multimedia|system|a11y) göstermek için sayfanın ismini belirtin"
+
+# tr
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Tüm %s belirimleri asıl bağ ile değiştirilecek"
+
+# tr
+#~ msgid "E_xecute flag:"
+#~ msgstr "Ç_alıştırma imi:"
+
+#~ msgid "Image Viewer"
+#~ msgstr "Suret Körüntileyici"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "Aniy Mesajcı"
+
+#~ msgid "Mail Reader"
+#~ msgstr "Poçta Oquyıcı"
+
+#~ msgid "Multimedia"
+#~ msgstr "Çoqlu-vasat"
+
+# tr
+#~ msgid "Run at st_art"
+#~ msgstr "_Başlangıçta çalıştır"
+
+# tüklü
+#~ msgid "Terminal Emulator"
+#~ msgstr "Terminal Taqlitçisi"
+
+#~ msgid "Text Editor"
+#~ msgstr "Metin Muharriri"
+
+# tr
+#~ msgid "_Run at start"
+#~ msgstr "_Başlangıçta çalıştır"
+
+# tr
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+# tr
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "Ekran Okuyucu olmadan GNOME Büyüteci"
+
+# tr
+#~ msgid "GNOME Terminal"
+#~ msgstr "GNOME Terminal"
+
+# tr
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+# tr
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Büyüteçli Gnopernicus"
+
+# tr
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "Ekran Okuyucu olmadan KDE Büyüteci"
+
+# tr
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+# tr
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Büyüteçli Linux Ekran Okuyucu"
+
+# tr
+#~ msgid "Listen"
+#~ msgstr "Dinle"
+
+# tr
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+# tr
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+# tr
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+# tr
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem Film Oynatıcı"
+
+# tr
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+# tr
+#~ msgid "Include _panel"
+#~ msgstr "_Paneli dahil et"
+
+#~ msgid "Panel icon"
+#~ msgstr "Panel işaretçigi"
+
+# tr
+#~ msgid "Re_fresh rate:"
+#~ msgstr "_Tazeleme hızı:"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "Hepsi ekranlarda _aynı suret"
+
+#~ msgid "Upside-down"
+#~ msgstr "Baş-aşağı"
+
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "Qullanım: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "Bu program çoq-monitorlı ayarlamalar içün sistem-boyu bir qonumğa\n"
+#~ "bir RANDR profili qurar. Neticelengen profil, gnome-settings-daemon\n"
+#~ "içinde RANDR plagini çaptırılğanda qullanılacaq.\n"
+#~ "\n"
+#~ "SOURCE_FILE - tam bir yolaq adı, tipik olaraq /home/username/.config/"
+#~ "monitors.xml\n"
+#~ "\n"
+#~ "DEST_NAME - qurulğan dosye içün nisbiy isim.  Bu, RANDR yapılandırışları\n"
+#~ "             içün sistem-boyu fihristke qoyulacaq, ondan dolayı netice "
+#~ "tipik olaraq\n"
+#~ "             %s/DEST_NAME olacaq\n"
+
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "Bu program ancaq tamır qullanıcı tarafından qullanılabilir"
+
+# tr
+#~ msgid "The source filename must be absolute"
+#~ msgstr "Menba dosye adı mutlaq olmalı"
+
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s muntazam bir dosye olmalı\n"
+
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "Bu program ancaq pkexec(1) aşa çaptırılmalı"
+
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "PKEXEC_UID bir tamsayı qıymetine tesbit etilmeli"
+
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "%s sizge ait olmalı\n"
+
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s her hangi fihrist bileşenlerine sahip olmamalı\n"
+
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s bir fihrist olmalı\n"
+
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "Çoq-monitorlı ayarlarnı bütün sistem içün qur"
+
+# tr
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+# tr
+#~ msgid "Desktop"
+#~ msgstr "Masaüstü"
+
+# tr
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "Hızlandırıcıyı yapılandırma veritabanından silerken hata oluştu: %s"
+
+# tr
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Komutlara kısayol ata"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Sadece tesbitlerni uyğula ve çıq (faqat telif qabiliyeti; şimdi cın "
+#~ "tarafından qollanır)"
+
+# tüklü
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Saifeni tuşlav teneffüsi ayarlarını köstererek başlat"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Saifeni irişilebilirlik tesbitlerini köstererek başlat"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Klavye İrişilebilirligi Davuş Keri Beslemesi"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "Uyanıqlama davuşı içün _körsel keri beslemeni köster"
+
+# tüklü
+#~ msgid "Visual cues for sounds"
+#~ msgstr "Davuşlar içün körsel imalar"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Teneffüslerniñ keçiktirilüvine _izin ber"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Davuş _Keri Beslemesi..."
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Teneffüslerniñ keçiktirilüvine izin berilgen olıp olmağanını teşker"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Tuşlamağa izin berilmegende teneffüsniñ uzunlığı"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Teneffüsni cebir etmeden evelki çalışma uzunlığı"
+
+#~ msgid "List of keyboard layouts selected for usage"
+#~ msgstr "Qullanım içün saylanğan klavye tizilimleri listesi"
+
+# tüklü
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Mükerrer klavye qullanımınıñ yol açqanı rahatsızlıqlarğa yol bermemek "
+#~ "içün belli bir müddetten soñ ekrannı kilitle"
+
+#~ msgid "Move the selected keyboard layout down in the list"
+#~ msgstr "Saylanğan klavye tizilimini listede aşağı avuştır"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "Saylanğan klavye tiziliminiñ bir diagramını bastır"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "Listege eklenmek üzre bir klavye tizilimini sayla"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Teneffüs aralığı uzunlığı:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "Tuşlav teneffüsini mecburiy qılmaq içün ekrannı _kilitle"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_Faqat uzun tuş basmalarını qabul et"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "Eşzamanlı tuş basmalarını _taqlit et"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Çalışma aralığı uzunlığı:"
+
+#~ msgid "_Country:"
+#~ msgstr "_Memleket:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variantlar:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_İstihsalcılar:"
+
+#~ msgid "Vendors"
+#~ msgstr "İstihsalcılar"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "Solğa taşı"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "Sağğa taşı"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "Yuqarı taşı"
+
+# tr
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "(general|accesibility) göstermek için sayfanın ismini belirtin"
+
+# tr
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Tıklama türümü ö_nceden seç"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "_Sıçan imaları içün çertme türüni saylañız"
+
+# tr
+#~ msgid "D_rag click:"
+#~ msgstr "_Taşıma tıklaması:"
+
+# tr
+#~ msgid "Show click type _window"
+#~ msgstr "Tılama türü _penceresini göster"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr ""
+#~ "Çertme türüni saylamaq içün Qonaqlayıcı Çertme panel uyğulamaçığını da "
+#~ "qullanabilirsiñiz."
+
+# tr
+#~ msgid "_Single click:"
+#~ msgstr "_Tek tık:"
+
+#~ msgid ""
+#~ "Do you want to apply these settings system-wide, so that they are also "
+#~ "used for package installation and other system services?"
+#~ msgstr ""
+#~ "Bu ayarlar paket qurulımı ve diger sistem hızmetleri içün de qullanılsın "
+#~ "dep, bu ayarlarnı sistem miqyasında uyğulamağa isteysiñizmi?"
+
+# tr
+#~ msgid "Location already exists"
+#~ msgstr "Konum zaten mevcut"
+
+# tr
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Elle _vekil ayarı</b>"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "Qonaqbay İhmal Etüv Cedveli"
+
+# tr
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "Pencere yöneticiniz için tercihler uygulaması çalıştırılamıyor"
+
+# tr
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+# tr
+#~ msgid "H_yper"
+#~ msgstr "_Hiper"
+
+# tr
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "_Süper (ya da \"Windows logosu\")"
+
+# tr
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Bir pencereyi taşımak için, bu tuşa basılı tutarak pencereyi sürükleyin:"
+
+# tr
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Bu işlemi gerçekleştirmek için başlık çubuğuna çift tıklayın:"
+
+# tr
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Yükseltmeden önceki gecikme:"
+
+# tr
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Belirli bir süre sonra seçilen pencereleri yükselt"
+
+# tr
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Fare bir pencerenin üzerine geldiğinde onu yükselt"
+
+# tr
+#~ msgid "Set your window properties"
+#~ msgstr "Pencere özelliklerinizi ayarlayın"
+
+# tr
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Pencere yöneticisi \"%s\" bir yapılandırma aygıtına kayıtlı değil\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "Vertikal olaraq Azamiyleştir"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Ufqiy olaraq Azamiyleştir"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "Başlağanda gizle (qabuqnı ög-yüklemek içün faydalıdır)"
+
+#~ msgid "Filter"
+#~ msgstr "Süzgüç"
+
+# tüklü
+#~ msgid "Common Tasks"
+#~ msgstr "Umumiy Vazifeler"
+
+# tr
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Bir görev etkinleştirildiğinde control-center'ı kapat"
+
+# tr
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "Bir ekleme ya da çıkartma eylemi gerçekleştiğinde kabuktan çık"
+
+# tr
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Yardım eylemi gerçekleştiğinde kabuktan çık"
+
+# tr
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Başlatma eylemi gerçekleştiğinden kabuktan çık"
+
+# tr
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "Güncelle ya da kaldır eylemi gerçekleştiğinde kabuktan çık"
+
+# tr
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "Yardım eylemi gerçekleştirildiğinde kabuğun kapatılmasını belirtir."
+
+# tr
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr ""
+#~ "Başlatma eylemi gerçekleştirildiğinde kabuğun kapatılmasını belirtir."
+
+# tr
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "Ekleme ya da çıkartma eylemi gerçekleştirildiğinde kabuğun kapatılmasını "
+#~ "belirtir."
+
+# tr
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "Güncelleme ya da kaldırma eylemi gerçekleştirildiğinde kabuğun "
+#~ "kapatılmasını belirtir."
+
+# tr
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "Görev isimleri ve ilişkili .desktop dosyaları"
+
+# tr
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "control-center'da gösterilecek görev ismini takip eden \";\" ayıracından "
+#~ "sonra başlatmak için bu görevle ilişkili .desktop dosyasının dosya ismi."
+
+# tr
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[Tema Değiştir;gtk-theme-selector.desktop,Tercih Edilen Uygulamaları Ata;"
+#~ "default-applications.desktop,Yazıcı Ekle;gnome-cups-manager.desktop]"
+
+# tr
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "Eğer seçiliyse, control-center bir \"Sık Kullanılan Görev\" "
+#~ "etkinleştirildiğinde kapatılacak."
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_Teneffüsni Keçiktir"
+
+#~ msgid "Take a break now (next in %dm)"
+#~ msgstr "Şimdi bir ara ber (soñrakisi %dd soñra)"
+
+# tr
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "Sonraki molaya kadar %d dakika kaldı"
+
+#~ msgid "Take a break now (next in less than one minute)"
+#~ msgstr "Şimdi bir ara ber (soñrakisi bir daqqadan az soñra)"
+
+# tr
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Sonraki molaya bir dakikadan az bir zaman kaldı"
+
+# tr
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Bu hata yüzünde yazım molası özellikleri penceresi yukarı getirilemiyor: "
+#~ "%s"
+
+# tr
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Richard Hult <richard@imendio.com> taraından yazıldı"
+
+# tr
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Eye candy, Anders Carlsson tarafından eklendi"
+
+# tr
+#~ msgid "A computer break reminder."
+#~ msgstr "Bilgisayar molası hatırlatıcısı."
+
+#~ msgid "translator-credits"
+#~ msgstr "Reşat SABIQ <tilde.birlik@gmail.com>"
+
+# tr
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Uyarı alanının mevcut olup olmadığını kontrol etme"
+
+# tr
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Yazım gözetleyicisi bilgileri göstermek için uyarı alanını kullanır. "
+#~ "Panelinizde uyarı alanı yok gibi görülüyor. Panele sağ tıklayıp 'Panele "
+#~ "ekle', 'Uyarı alanı' ve 'Ekle'yi tıklayarak alanı ekleyebilirsiniz."
+
+# tr
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "Eğer doğruya ayarlı ise, OpenType yazıtipleri örneklendirilecek."
+
+# tr
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Eğer doğru'ya ayarlı ise, PCF yazıtipleri örneklendirilecek."
+
+# tr
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "Eğer doğru'ya ayarlı ise, TrueType yazıtipleri örneklendirilecek."
+
+# tr
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Eğer doğru'ya ayarlı ise, Type1 yazıtipleri örneklendirilecek."
+
+# tr
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Bu anahtarı OpenType yazıtipleri için örnek oluşturacak komuta ayarlayın."
+
+# tr
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Bu anahtarı PCF yazıtipleri için örnek oluşturacak komuta ayarlayın."
+
+# tr
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Bu anahtarı TrueType yazıtipleri için örnek oluşturacak komuta ayarlayın."
+
+# tr
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Bu anahtarı Type1 yazıtipleri için örnek oluşturacak komuta ayarlayın."
+
+# tr
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "OpenType yazıtipleri için örnekleme komutu"
+
+# tr
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "PCF yazıtipleri için örnekleme komutu"
+
+# tr
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "TrueType yazıtipleri için örnekleme komutu"
+
+# tr
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Type1 yazıtipleri için örnekleme komutu"
+
+# tr
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "OpenType yazıtiplerinin örneklendirilip yada örneklendirilmeyeceği"
+
+# tr
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCF yazıtiplerinin örneklendirilip yada örneklendirilmeyeceği"
+
+# tr
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "TrueType yazıtiplerinin örneklendirilip yada örneklendirilmeyeceği"
+
+# tr
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Type1 yazıtiplerinin örneklendirilip yada örneklendirilmeyeceği"
+
+#~ msgid "Size:"
+#~ msgstr "Ölçü:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Telif haqqı:"
+
+# tr
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "kullanım: %s yazıtipi-dosyası\n"
+
+#~ msgid "Font Viewer"
+#~ msgstr "Hurufat Körüntileyici"
+
+# tr
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Örneklendirilecek metin (öntanımlı: Aa)"
+
+# tr
+#~ msgid "TEXT"
+#~ msgstr "METİN"
+
+# tr
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Yazıtipi boyutu (öntanımlı: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "ÖLÇÜ"
+
+# tr
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "YAZITİPİ-DOSYASI ÇIKTI-DOSYASI"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "Süzgüçiñiz, \"%s\", her hangi unsurlar ile eşleşmey."
+
+# tr
+#~ msgid "Upgrade"
+#~ msgstr "Yükselt"
+
+# tr
+#~ msgid "Add to Favorites"
+#~ msgstr "Sık Kullanılanlara Ekle"
+
+# tr
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Başlangıç Programlarından Çıkart"
+
+# tr
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Başlangıç Programlarına Ekle"
+
+# tr
+#~ msgid "New Spreadsheet"
+#~ msgstr "Yeni Çizelge"
+
+# tr
+#~ msgid "New Document"
+#~ msgstr "Yeni Belge"
+
+#~ msgctxt "Home folder"
+#~ msgid "Home"
+#~ msgstr "Ev"
+
+# tr
+#~ msgid "Documents"
+#~ msgstr "Belgeler"
+
+# tr
+#~ msgid "Move to Trash"
+#~ msgstr "Çöpe Taşı"
+
+# tr
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "Eğer bir öğeyi silerseniz, o tamamen kaybolacak."
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "\"%s\" ile Aç"
+
+# tr
+#~ msgid "Open in File Manager"
+#~ msgstr "Dosya Yöneticisinde Aç"
+
+# tr
+#~ msgid "Remove from recent menu"
+#~ msgstr "Deminkiler menüsinden çetleştir"
+
+#~ msgid "Purge all the recent items"
+#~ msgstr "Deminki unsurlarnıñ hepsini izale et"
+
+# tr
+#~ msgid "?"
+#~ msgstr "?"
+
+# tr
+#~ msgid "Find Now"
+#~ msgstr "Şimdi Bul"
+
+# tr
+#~ msgid "Remove from System Items"
+#~ msgstr "Sistem Öğelerinden Kaldır"
+
+# tr
+#~ msgid "Open link in new _tab"
+#~ msgstr "Bağı yeni _sekmede aç"
+
+# tr
+#~ msgid "Open link in new _window"
+#~ msgstr "Bağı yeni _pencerede aç"
+
+# tr
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Bağı ö_ntanımlı web tarayıcısı ile aç"
+
+# tr
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+# tr
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+# tr
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+# tr
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution E-posta Okuyucu"
+
+# tr
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+# tr
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+# tr
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+# tr
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+# tr
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape Mail"
+
+# tr
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+# tr
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+# tr
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+# tr
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+# tr
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+# tr
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+# tr
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+# tr
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+# tr
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+# tr
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey Mail"
+
+# tr
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+# tr
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+# tr
+#~ msgid "Thunderbird"
+#~ msgstr "Thunderbird"
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Yañı ayarlar sınala. Eger %d saniye içerisinde cevap bermeseñiz evelki "
+#~ "ayarlar keri tiklenecek."
+
+#~ msgid "<b>C_ustom:</b> Uses custom set of effects."
+#~ msgstr ""
+#~ "<b>Şahsiy_leştirilgen:</b> Şahsiyleştirilgen effektler kümesini qullanır."
+
+#~ msgid "<b>Compiz is not installed</b>"
+#~ msgstr "<b>Compiz qurulğan degil</b>"
+
+#~ msgid ""
+#~ "<b>E_xtra:</b> Provides more aesthetically pleasing set of effects. "
+#~ "Requires faster graphics card."
+#~ msgstr ""
+#~ "<b>_Ziyade:</b> Estetik olaraq daa hoş effektler kümesini temin eter. Daa "
+#~ "tez grafik kartını kerektirir."
+
+#~ msgid ""
+#~ "<b>N_ormal:</b> Provides improved usability and good balance between "
+#~ "attractiveness and moderate performance requirements."
+#~ msgstr ""
+#~ "<b>N_ormal:</b> Yahşılaştırılğan qullanışlılıqnı ve cazibe ile mutedil "
+#~ "icraat talapları arasında yahşı muvazenetni temin eter."
+
+#~ msgid ""
+#~ "<b>_None:</b> Provides a simple desktop environment without any effects."
+#~ msgstr ""
+#~ "<b>_Hiç biri:</b> Effektsiz, basit bir masaüstü çevresini temin eter."
+
+#~ msgid ""
+#~ "It appears that your graphics driver does not support the necessary "
+#~ "extensions to use this tool.  Do you want to use your graphics driver "
+#~ "vendor's tool instead?"
+#~ msgstr ""
+#~ "Grafik sürüciñiz bu aletniñ qullanılması içün kerekli uzantılarnı "
+#~ "desteklemey ğaliba.  Yerine grafik istisalcıñıznıñ aletini qullanmağa "
+#~ "isteysiñizmi?"
+
+#~ msgid ""
+#~ "Your settings cannot be applied because the virtual resolution is not big "
+#~ "enough to contain your screens"
+#~ msgstr ""
+#~ "Ayarlarıñız uyğulanalmay çünki sanal çezinirlik ekranlarıñıznı ihtiva "
+#~ "etmek içün yeterli derecede balaban degildir"
+
+#~ msgid "Please log out and log back in again"
+#~ msgstr "Lütfen tışarı imzalanıñız ve yañıdan içeri imzalanıñız"
+
+#~ msgid ""
+#~ "The installation of an additional component (%s) is required in order to "
+#~ "apply your settings. Would you like to install it now?"
+#~ msgstr ""
+#~ "Ayarlarıñıznı uyğulamaq üzre ek bir komponentniñ (%s) qurulımı şarttır. "
+#~ "Onı şimdi qurmağa ister ediñizmi?"
+
+#~ msgid ""
+#~ "Please run \"Appearance/Desktop Effects\" again after restarting the "
+#~ "computer, when the new graphics driver is active."
+#~ msgstr ""
+#~ "Lütfen bilgisayarnı kene başlatqan soñ, yañı grafik sürücisi faal "
+#~ "olğanda, \"Körüniş/Masaüstü Effektleri\"ni yañıdan çaptırıñız."
+
+#~ msgid "<b>Mutter is running, can't switch to other effects.</b>"
+#~ msgstr "<b>Mutter çapa, diger effektlerge almaşılalmay.</b>"
+
+# tr
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "Sol baş parmağınızı %s üzerine koyun"
+
+# tr
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "Sol başparmağınızı %s üzerinden geçirin"
+
+# tr
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "Sağ baş parmağınızı %s üzerine koyun"
+
+# tr
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "Sağ başparmağınızı %s üzerinden geçirin"
+
+# tr
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "Parmağınızı okuyucuya tekrar koyun"
+
+# tr
+#~ msgid "Swipe your finger again"
+#~ msgstr "Parmağınızı okuyucudan tekrar kaydırın"
+
+# tr
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "Kaydırma çok kısaydı, tekrar deneyin"
+
+# tr
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr ""
+#~ "Parmağınız ortalanmış değildi, parmağınızı tekrar kaydırmayı deneyin"
+
+# tr
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "Parmağınızı kaldırın ve tekrar kaydırmayı deneyin"
+
+# tr
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+# tr
+#~ msgid "Edit"
+#~ msgstr "Düzenle"
+
+# tr
+#~ msgid "Show _icons in menus"
+#~ msgstr "Menülerde _simge göster"
+
+# tr
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Araç çubuğu _düğme etiketleri:"
+
+# tr
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "_Düzenlenebilir menü kısayol tuşları"
+
+# tr
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr ""
+#~ "Muş sefahat pasajı önündeki borçlu yorgun bir ağızla cevapladı. 0123456789"
+
+# tr
+#~ msgid "Drag the monitors to set their place"
+#~ msgstr "Yerlerini tesbit etmek içün ekranlarnı süyrekleñiz"
+
+# tr
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian Duyarlı Tarayıcı"
+
+# tr
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian Terminal Uygulaması"
+
+# tr
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+# tr
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+# tr
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+# tr
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "Bilinmeyen giriş ID'si, kullanıcı veritabanı bozulmuş olabilir"
+
+# tr
+#~ msgid ""
+#~ "Left thumb\n"
+#~ "Left middle finger\n"
+#~ "Left ring finger\n"
+#~ "Left little finger\n"
+#~ "Right thumb\n"
+#~ "Right middle finger\n"
+#~ "Right ring finger\n"
+#~ "Right little finger"
+#~ msgstr ""
+#~ "Sol baş parmak\n"
+#~ "Sol orta parmak\n"
+#~ "Sol yüzük parmağı\n"
+#~ "Sol serçe parmağı\n"
+#~ "Sağ baş parmak\n"
+#~ "Sağ orta parmak\n"
+#~ "Sağ yüzük parmağı\n"
+#~ "Sağ serçe parmağı"
+
+# tr
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Parolayı değiştir</span>"
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>Yardımcıl Tehnologiyalar</b>"
+
+# tr
+#~ msgid "C_ut"
+#~ msgstr "_Kes"
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "Som tüs\n"
+#~ "Ufqiy dereceçen\n"
+#~ "Vertikal dereceçen"
+
+# tr
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "Öğelerin altında metin\n"
+#~ "Öğelerin yanında metin\n"
+#~ "Sadece simge\n"
+#~ "Sadece metin"
+
+# tr
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "Döşenmiş\n"
+#~ "Odaklanmış\n"
+#~ "Ortalanmış\n"
+#~ "Ölçeklenmiş\n"
+#~ "Tüm ekran"
+
+# tr
+#~ msgid "_New"
+#~ msgstr "_Yeni"
+
+# tr
+#~ msgid "_Open"
+#~ msgstr "_Aç"
+
+# tr
+#~ msgid "_Save"
+#~ msgstr "_Kaydet"
+
+# tr
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "Normal\n"
+#~ "Sol\n"
+#~ "Sağ\n"
+#~ "Baş aşağı\n"
+
+# tr
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>Makine Listesini Yok Say</b>"
+
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>Hiç bir eşleşme tapılmadı.</b> </span><span>\n"
+#~ "\n"
+#~ " Süzgüçiñiz olğan \"<b>%s</b>\" hiç bir unsur ile eşleşmey.</span>"
+
+# tr
+#~ msgid "/_About"
+#~ msgstr "/_Hakkında"
+
+# tr
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "_Posta kodu:"
+
+# tr
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+# tr
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "_Posta kodu:"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "Divar kağıtı ekle"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "Duvar kağıtını çetleştir"
+
+#~ msgid "Swap colors"
+#~ msgstr "Renklerni almaştır"
+
+#~ msgid "Secondary color"
+#~ msgstr "Ekilemci renk"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Ufqiy Qademeçen"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Vertikal Qademeçen"
+
+#~ msgid "Solid Color"
+#~ msgstr "Som Tüs"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "Renkler ve Qademeçenler"
+
+#~ msgid "Change the background"
+#~ msgstr "Arqazeminni deñiştir"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "Bluetooth ayarlarını endamlandır"
+
+#~ msgid "Browse Files..."
+#~ msgstr "Dosyelerni Kezin..."
+
+# tr
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+# tr
+#~ msgid "Create virtual device"
+#~ msgstr "Sanal aygıt oluştur"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Ekranlar içün Faydalanışlı Profiller"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Tarayıcılar içün Faydalanışlı Profiller"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Bastırıcılar içün Faydalanışlı Profiller"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Kameralar içün Faydalanışlı Profiller"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Ağ Kameraları içün Faydalanışlı Profiller"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i yıl"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i ay"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i hafta"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "1 haftadan az"
+
+# tr
+#~ msgid "This device is not color managed."
+#~ msgstr "Bu aygıt renk yönetimli değildir."
+
+# tr
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "Bu aygıt, fabrika önayarlı verilerini kullanıyor."
+
+# tr
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "Bu aygıt, tam ekran renk düzeltme için uygun bir profile sahip değil."
+
+# tr
+#~ msgid "Not specified"
+#~ msgstr "Belirtilmemiş"
+
+# tr
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "Renk yönetimini destekleyen hiçbir aygıt tespit edilemedi"
+
+#~ msgctxt "Device kind"
+#~ msgid "Display"
+#~ msgstr "Kösterim"
+
+#~ msgid "Add device"
+#~ msgstr "Cihaz ekle"
+
+# tr
+#~ msgid "Add a virtual device"
+#~ msgstr "Sanal bir aygıt ekle"
+
+#~ msgid "Remove a device"
+#~ msgstr "Bir cihaznı çetleştir"
+
+# tr
+#~ msgid "Color management settings"
+#~ msgstr "Renk yönetim ayarları"
+
+# tr
+#, fuzzy
+#~ msgid "German"
+#~ msgstr "Almanya"
+
+#, fuzzy
+#~ msgid "Spanish"
+#~ msgstr "Qarışla"
+
+#, fuzzy
+#~ msgid "Other..."
+#~ msgstr "Diger..."
+
+#~ msgid "Select a region"
+#~ msgstr "Bir bölge saylañız"
+
+#~ msgid "Unspecified"
+#~ msgstr "Belirtilmegen"
+
+#~ msgid "Select a language"
+#~ msgstr "Bir til saylañız"
+
+# tr
+#~ msgid "_Select"
+#~ msgstr "_Sayla"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Tarih ve Saat tercihleri paneli"
+
+# tr
+#~ msgid "%d x %d (%s)"
+#~ msgstr "%d x %d (%s)"
+
+# tr
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+# tr
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+# tr
+#~ msgid "Unknown model"
+#~ msgstr "Bilinmeyen model"
+
+# tr
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "Sonraki oturum açmada standart deneyim kullanılmaya çalışılacak."
+
+# tr
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "Sonraki oturum açmada desteklenmeyen grafik donanımı için korumalı modu "
+#~ "kullan."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Ricat"
+
+#~ msgid "System Information"
+#~ msgstr "Sistem Malümatı"
+
+# tr
+#~ msgid "Acti_on:"
+#~ msgstr "E_ylem:"
+
+#~ msgid "OS type"
+#~ msgstr "İS türü"
+
+#~ msgid "Experience"
+#~ msgstr "Tecribe"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "Cebr Etilgen _Ricat Tarzı"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "Klavye ayarlarını deñiştir"
+
+#~ msgid "Layout Settings"
+#~ msgstr "Tizilim Ayarları"
+
+# tr
+#~ msgid "Shortcut"
+#~ msgstr "Qısqayol"
+
+# tr
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Fare ve imleçsürer tercihlerinizi yapın"
+
+# tr
+#~ msgid "_Right-handed"
+#~ msgstr "_Sağ el için"
+
+# tr
+#~ msgid "_Left-handed"
+#~ msgstr "_Solak için"
+
+# tr
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Kontrol tuşuna basıldığında belitecin _konumunu göster"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "_Tezleşme:"
+
+# tr
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Hassasiyet:"
+
+# tr
+#~ msgid "Drag and Drop"
+#~ msgstr "Süyrekle ve Tüşür"
+
+# tr
+#~ msgid "Thr_eshold:"
+#~ msgstr "_Eşik:"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "Süyrekleme Eşigi"
+
+#~ msgid "Double-Click Timeout"
+#~ msgstr "Çift-Çertme Zaman Aşımı"
+
+# tr
+#~ msgid "_Timeout:"
+#~ msgstr "_Zaman aşımı:"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "Ayarlarıñıznı sınamaq içün yüzge çift-çertmege deñeñiz."
+
+# tüklü
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "Tiyüv-şiltesi ile _sıçan çertmelerini faalleştir"
+
+#~ msgid "Scrolling"
+#~ msgstr "Taydıruv"
+
+#~ msgid "_Disabled"
+#~ msgstr "_Ğayrı qabilleştirilgen"
+
+# tüklü
+#~ msgid "_Edge scrolling"
+#~ msgstr "_Ayrıt taydırması"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "Diger..."
+
+# tr
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "Yine de etkin nokta oluşturulsun mu?"
+
+# tr
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "%s ile bağlantıyı kesilip yeni bir etkin nokta oluşturulsun mu?"
+
+# tr
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "Bu sizin internete olan tek bağlantınız."
+
+# tr
+#~ msgid "Create _Hotspot"
+#~ msgstr "Etkin Nokta _Oluştur"
+
+# tr
+#~ msgid "Airplane Mode"
+#~ msgstr "Uçak Kipi"
+
+# tüklü
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "Şebeke;Kabelsiz;İP;LAN;Proksi;"
+
+#~ msgid "Create..."
+#~ msgstr "İcat Et..."
+
+# tr
+#~ msgid "Subnet Mask"
+#~ msgstr "Alt Ağ Maskesi"
+
+#~ msgid "_Options..."
+#~ msgstr "_İhtiyariyat..."
+
+#~ msgid "_Network Name"
+#~ msgstr "_Şebeke Adı"
+
+# tr
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "Etkin Noktayı _Durdur..."
+
+# tr
+#~ msgid "Disable VPN"
+#~ msgstr "VPN'i Kapat"
+
+# tr
+#~ msgid "_Configure..."
+#~ msgstr "_Yapılandır..."
+
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP Limanı (Port)"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "HTTPS Limanı"
+
+# tr
+#~ msgid "FTP Port"
+#~ msgstr "FTP Limanı (Port)"
+
+#~ msgid "Wireless"
+#~ msgstr "Kabelsiz"
+
+# tr
+#~ msgid "Mesh"
+#~ msgstr "Mesh"
+
+# tr
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "Kimlik bilgileri zaman aşımına uğramış. Lütfen tekrar oturum açın."
+
+#~ msgid "_Log In"
+#~ msgstr "_İçeri İmzalan"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "Yañı bir hesap eklemek içün, evvelâ hesap türünü saylañız"
+
+#~ msgid "_Add..."
+#~ msgstr "_Ekle..."
+
+# tr
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "Dikkat! Düşük pil, kalan süre: %s"
+
+# tr
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "Pil gücünü kullanıyor - kalan süre: %s"
+
+# tr
+#~ msgid "Using battery power"
+#~ msgstr "Pil gücünü kullanıyor"
+
+# tr
+#~ msgid "Charging - fully charged"
+#~ msgstr "Doluyor - tamamen dolu"
+
+# tr
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "UPS gücü kullanılıyor - %s kaldı"
+
+# tr
+#~ msgid "Caution low UPS"
+#~ msgstr "Dikkat düşük UPS gücü"
+
+# tr
+#~ msgid "Using UPS power"
+#~ msgstr "UPS gücü kullanılıyor"
+
+# tr
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "İkincil piliniz tamamen dolu"
+
+# tr
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "İkincil piliniz boş"
+
+# tr
+#~ msgid "Tip:"
+#~ msgstr "İpucu:"
+
+# tr
+#~ msgid "Brightness Settings"
+#~ msgstr "Parlaklık Ayarları"
+
+# tr
+#~ msgid "affect how much power is used"
+#~ msgstr "ne kadar güç kullanıldığını etkiler"
+
+#~ msgid "Power management settings"
+#~ msgstr "Qudret idaresi ayarları"
+
+# tr
+#~ msgid "Don't suspend"
+#~ msgstr "Askıya alma"
+
+# tr
+#~ msgid "Suspend when inactive for"
+#~ msgstr "Şu yüzden etkisiz olunca askıya al:"
+
+# tr
+#~ msgid "Change printer settings"
+#~ msgstr "Yazıcı ayarlarını değiştir"
+
+# tr
+#~ msgid "A_ddress:"
+#~ msgstr "_Adres:"
+
+# tr
+#~ msgid "_Search by Address"
+#~ msgstr "_Adrese göre Ara"
+
+# tr
+#~ msgid "Getting devices..."
+#~ msgstr "Aygıtlar aranıyor..."
+
+# tr
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD çalışmıyor. Ağ yazıcı taraması firewallda mdns, ipp, ipp-client "
+#~ "ve samba-client hizmetlerinin çalışmasına ihtiyaç duyuyor."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "Yerli"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "Şebeke"
+
+#~ msgid "Device types"
+#~ msgstr "Cihaz türleri"
+
+# tr
+#~ msgid "Automatic configuration"
+#~ msgstr "Otomatik yapılandırma"
+
+# tr
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "mDNS bağlantıları için güvenlik duvarı açılıyor"
+
+# tr
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Samba bağlantıları için güvenlik duvarı açılıyor"
+
+# tr
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "IPP bağlantıları için güvenlik duvarı açılıyor"
+
+# tr
+#~ msgid "_Show"
+#~ msgstr "_Göster"
+
+# tr
+#~ msgid "_Back"
+#~ msgstr "_Geri"
+
+# tr
+#~ msgid "Add User"
+#~ msgstr "Kullanıcı Ekle"
+
+# tr
+#~ msgid "Allowed users"
+#~ msgstr "İzin verilen kullanıcılar"
+
+# tr
+#~ msgid "Change your region and language settings"
+#~ msgstr "Bölge ve dil ayarlarını değiştirin"
+
+#~ msgid "Keyboard Layout Options"
+#~ msgstr "Klavye Tizilimi İhtiyariyatı"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "İçeri imzalanma ekranı, sistem hesapları ve yañı qullanıcı hesapları "
+#~ "sistem miqyasındaki Bölge ve Til ayarlarını qullanır."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "İçeri imzalanma ekranı, sistem hesapları ve yañı qullanıcı hesapları "
+#~ "sistem miqyasındaki Bölge ve Til ayarlarını qullanır. Sistem ayarlarını "
+#~ "kendi ayarlarıñızğa uyacaq şekilde deñiştirebilirsiñiz."
+
+#~ msgid "Copy Settings"
+#~ msgstr "Ayarlarnı Kopiyala"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "Ayarlarnı Kopiyala..."
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Bir kösterim tili saylañız (deñişiklik bir soñraki kere içeri "
+#~ "imzalanğanıñızda yürerlikke kirecek)"
+
+#~ msgid "Install languages..."
+#~ msgstr "Tillerni qur..."
+
+#~ msgid "Add Language"
+#~ msgstr "Til Ekle"
+
+#~ msgid "Remove Language"
+#~ msgstr "Tilni Çetleştir"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr ""
+#~ "Bir bölge saylañız (deñişiklik bir soñraki kere içeri imzalanğanıñızda "
+#~ "yürerlikke kirecek)"
+
+#~ msgid "Add Region"
+#~ msgstr "Bölge Ekle"
+
+# tr
+#~ msgid "Currency"
+#~ msgstr "Para Birimi"
+
+#~ msgid "Examples"
+#~ msgstr "Misaller"
+
+#~ msgid "Add Layout"
+#~ msgstr "Tizilim Ekle"
+
+#~ msgid "Remove Layout"
+#~ msgstr "Tizilimni Çetleştir"
+
+#~ msgid "Preview Layout"
+#~ msgstr "Tizilimge Ög-baq"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "Yañı pencereler ögbelgilengen tizilimni qullanır"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "Yañı pencereler evvelki pencereniñ tizilimini qullanır"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "Klavye tizilimi seçeneklerini körüntile ve tahrir et"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "Ögbelgilemelerge _Sıfırla"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Cari klavye tizilimi ayarlarını ögbelgilengen ayarlar\n"
+#~ "ile ivaz et"
+
+#~ msgid "Layouts"
+#~ msgstr "Tizilimler"
+
+#~ msgid "Display language:"
+#~ msgstr "Kösterim Tili:"
+
+#~ msgid "Format:"
+#~ msgstr "Format:"
+
+#~ msgid "System settings"
+#~ msgstr "Sistem ayarları"
+
+#~ msgid "Layout"
+#~ msgstr "Tizilim"
+
+#~ msgid "Brightness and Lock"
+#~ msgstr "Parlaqlıq ve Kilit"
+
+# tr
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "Ekran parlaklığı ve kilitleme ayarları"
+
+# tr
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Parlaklık;Kilitle;Karartma;Boş;Monitör;"
+
+# tr
+#~ msgid "_Dim screen to save power"
+#~ msgstr "Güç tasarrufu için ekranı _karart"
+
+# tr
+#~ msgid "Don't lock when at home"
+#~ msgstr "Evdeyken kilitleme"
+
+#~ msgid "Locations..."
+#~ msgstr "Qonumlar..."
+
+#~ msgid "Lock"
+#~ msgstr "Kilitle"
+
+# tr
+#~ msgid "Enable debugging code"
+#~ msgstr "Hata ayıklama kodunu etkinleştir"
+
+#~ msgid "Version of this application"
+#~ msgstr "Bu uyğulamanıñ sürümi"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME Gürlük Kontroli Uyğulamaçığı"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Masaüstü gürlük kontrolini köster"
+
+# tr
+#~ msgid "Sound Output Volume"
+#~ msgstr "Ses Çıkış Şiddeti"
+
+# tr
+#~ msgid "Microphone Volume"
+#~ msgstr "Mikrofon Sesi"
+
+# tr
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "Yapılandırmak için aygıt _seçin:"
+
+# tr
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "Ses Tercihleri başlatılamadı: %ss"
+
+#~ msgid "_Mute"
+#~ msgstr "_Davuşsızlandır"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "_Davuş Tercihleri"
+
+#~ msgid "Muted"
+#~ msgstr "Davuşsız"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Cihanşümul İrişim Tercihleri"
+
+# tr
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+# tr
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+# tr
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~ msgid "Change contrast:"
+#~ msgstr "Tezatnı deñiştir:"
+
+# tr
+#~ msgid "_Text size:"
+#~ msgstr "_Yazı boyutu:"
+
+# tr
+#~ msgid "Increase size:"
+#~ msgstr "Boyutu artır:"
+
+# tr
+#~ msgid "Decrease size:"
+#~ msgstr "Boyutu düşür:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "Kösterim"
+
+#~ msgid "Options..."
+#~ msgstr "Seçenekler..."
+
+# tr
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "Odaklama"
+
+#~ msgid "Screen keyboard"
+#~ msgstr "Ekran Klavyesi"
+
+#~ msgid "Typing Assistant"
+#~ msgstr "Tuşlama Muavini"
+
+# tr
+#~ msgid "Type here to test settings"
+#~ msgstr "Ayarları denemek için buraya yazın"
+
+# tr
+#~ msgid "1/4 Screen"
+#~ msgstr "Ekranın 1/4'ü"
+
+# tr
+#~ msgid "1/2 Screen"
+#~ msgstr "Ekranın 1/2'si"
+
+# tr
+#~ msgid "3/4 Screen"
+#~ msgstr "Ekranın 3/4'ü"
+
+# tr
+#~ msgid "Create new account"
+#~ msgstr "Yeni hesap oluştur"
+
+#~ msgid "_Account Type"
+#~ msgstr "_Hesap Türü"
+
+#~ msgid "Cr_eate"
+#~ msgstr "_İcat Et"
+
+#~ msgid "User Accounts"
+#~ msgstr "Qullanıcı Hesapları"
+
+# tr
+#~ msgid "_Hint"
+#~ msgstr "_İpucu"
+
+# tr
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "Bu ipucu, giriş ekranında gösterilebilir.  Bu sistemdeki tüm "
+#~ "kullanıcılarca görülebilecektir.  Buraya parolanızı <b>yazmayın.</b>"
+
+# tr
+#~ msgid "Choose a generated password"
+#~ msgstr "Üretilen parolalardan birini seçin"
+
+#~ msgid "Fair"
+#~ msgstr "Ortaca"
+
+#~ msgid "Account _type"
+#~ msgstr "Hesap _türü"
+
+# tr
+#~ msgid "More choices..."
+#~ msgstr "Daha çok seçenek..."
+
+# tr
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Başka resimlere göz at..."
+
+# tr
+#~ msgid "This user does not exist."
+#~ msgstr "Böyle bir kullanıcı mevcut değil."
+
+# tr
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Wacom Grafik Tablet"
+
+# tr
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Wacom tablet tercihlerinizi ayarlayın"
+
+# tr
+#~ msgid "Map Buttons..."
+#~ msgstr "Düğmelere Eşle..."
+
+# tr
+#~ msgid "Calibrate..."
+#~ msgstr "Kalibrasyon..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- Sistem Ayarları"
+
+# tr
+#~ msgid "Control Center"
+#~ msgstr "Kontrol Merkezi"
+
+#~ msgid "System Settings"
+#~ msgstr "Sistem Ayarları"
+
+#, fuzzy
+#~ msgid "More backgrounds URL"
+#~ msgstr "Cari arqazemin"
+
+# tr
+#, fuzzy
+#~ msgid "The type of alert"
+#~ msgstr "Hızlandırıcı türü."
+
+# tüklü
+#, fuzzy
+#~ msgid "Alert Buttons"
+#~ msgstr "Alt Dögme"
+
+# tr
+#, fuzzy
+#~ msgid "Show more _details"
+#~ msgstr "Ayrıntıları görüntüle"
+
+#, fuzzy
+#~ msgid "Select Image"
+#~ msgstr "Bir til saylañız"
+
+# tr
+#, fuzzy
+#~ msgid "All Files"
+#~ msgstr "Tüm dosyalar"
+
+#, fuzzy
+#~ msgid "A_ssistant:"
+#~ msgstr "Tuşlama Muavini"
+
+#, fuzzy
+#~ msgid "C_ity:"
+#~ msgstr "_Şeher:"
+
+# tr
+#, fuzzy
+#~ msgid "C_ompany:"
+#~ msgstr "Kom_ut:"
+
+#, fuzzy
+#~ msgid "Cale_ndar:"
+#~ msgstr "_Taqvim"
+
+# tr
+#, fuzzy
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Parola değiştiriliyor"
+
+# tr
+#, fuzzy
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "Parmak İzi Girişi Etkinleştir"
+
+# tr
+#, fuzzy
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "Parmak İzi Girişi Etkinleştir"
+
+#, fuzzy
+#~ msgid "Full Name"
+#~ msgstr "_Tam İsim"
+
+# tr
+#, fuzzy
+#~ msgid "Telephone"
+#~ msgstr "Cep telefonu"
+
+#, fuzzy
+#~ msgid "User name:"
+#~ msgstr "Qullanıcı Adı"
+
+#, fuzzy
+#~ msgid "Web"
+#~ msgstr "_Ağ"
+
+# tr
+#, fuzzy
+#~ msgid "_Department:"
+#~ msgstr "Ölçüm"
+
+#, fuzzy
+#~ msgid "_Home page:"
+#~ msgstr "Deñeme sahifesi"
+
+#, fuzzy
+#~ msgid "_Mobile:"
+#~ msgstr "_Profil:"
+
+# tr
+#, fuzzy
+#~ msgid "_Profession:"
+#~ msgstr "İşleniyor"
+
+# tr
+#, fuzzy
+#~ msgid "_Title:"
+#~ msgstr "İş Adı"
+
+#, fuzzy
+#~ msgid "An internal error occured"
+#~ msgstr "Dahiliy hata hasıl oldı."
+
+#, fuzzy
+#~ msgid "Place finger on reader"
+#~ msgstr "Hiç bir parmaq izi oquyıcısına irişilamadı"
+
+# tr
+#, fuzzy
+#~ msgid "Left index finger"
+#~ msgstr "S_ol işaret parmağı"
+
+# tr
+#, fuzzy
+#~ msgid "Other finger: "
+#~ msgstr "_Diğer parmak:"
+
+# tr
+#, fuzzy
+#~ msgid "Right index finger"
+#~ msgstr "_Sağ işaret parmağı"
+
+# tr
+#, fuzzy
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr "Parolanız önceki kimlik doğrulamasından sonra değiştirildi!"
+
+# tr
+#, fuzzy
+#~ msgid "That password was incorrect."
+#~ msgstr "Şu anki parola hatalı"
+
+# tr
+#, fuzzy
+#~ msgid "Your password has been changed."
+#~ msgstr "Parolanız değiştirilemedi"
+
+# tr
+#, fuzzy
+#~ msgid "System error: %s."
+#~ msgstr "Sistem Sesleri"
+
+# tr
+#, fuzzy
+#~ msgid "The password is too short."
+#~ msgstr "Yeni parola çok kısa"
+
+# tr
+#, fuzzy
+#~ msgid "The password is too simple."
+#~ msgstr "Yeni parola çok basit"
+
+# tr
+#, fuzzy
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "Eski ve yeni parolalar birbirine çok benziyor"
+
+# tr
+#, fuzzy
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "Yeni parola rakam ya da özel karakterler içermeli"
+
+# tr
+#, fuzzy
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "Eski ve yeni parolalar birbirinin aynısı"
+
+#, fuzzy
+#~ msgid "A system error has occurred"
+#~ msgstr "Dahiliy hata hasıl oldı."
+
+# tr
+#, fuzzy
+#~ msgid "Checking password..."
+#~ msgstr "Parola değiştiriliyor"
+
+# tr
+#, fuzzy
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "Lütfen parolanızı tekrar girin."
+
+# tr
+#, fuzzy
+#~ msgid "The two passwords are not equal."
+#~ msgstr "Parolalar eşleşmiyor"
+
+# tr
+#, fuzzy
+#~ msgid "Change pa_ssword"
+#~ msgstr "Parola değiştiriliyor"
+
+# tr
+#, fuzzy
+#~ msgid "Change password"
+#~ msgstr "Parola değiştiriliyor"
+
+# tr
+#, fuzzy
+#~ msgid "Change your password"
+#~ msgstr "Parola değiştiriliyor"
+
+#, fuzzy
+#~ msgid "Current _password:"
+#~ msgstr "Cari _sır-söz"
+
+# tr
+#, fuzzy
+#~ msgid "_New password:"
+#~ msgstr "Yeni p_arola"
+
+#, fuzzy
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Cihanşümul İrişim Tercihleri"
+
+#, fuzzy
+#~ msgid "Close and _Log Out"
+#~ msgstr "Bir Tizilim Saylañız"
+
+#, fuzzy
+#~ msgid "_Preferred Applications"
+#~ msgstr "Ögbelgilengen Uyğulamalar"
+
+#, fuzzy
+#~ msgid "Add Wallpaper"
+#~ msgstr "Divar kağıtı ekle"
+
+# tr
+#, fuzzy
+#~ msgid "Could not load user interface file: %s"
+#~ msgstr "Arayüz yüklenemedi: %s"
+
+# tr
+#, fuzzy
+#~ msgid "Default Pointer"
+#~ msgstr "Öntanımlı Geçit"
+
+#, fuzzy
+#~ msgid "Apply Background"
+#~ msgstr "Arqazemin"
+
+#, fuzzy
+#~ msgid "Revert Button Layout"
+#~ msgstr "Tizilimni Çetleştir"
+
+# tr
+#, fuzzy
+#~ msgid "Appearance Preferences"
+#~ msgstr "Tablet Tercihleri"
+
+#, fuzzy
+#~ msgid "Best co_ntrast"
+#~ msgstr "Karşıtlık düğmesi"
+
+#, fuzzy
+#~ msgid "C_olors:"
+#~ msgstr "Tüsler"
+
+# tr
+#, fuzzy
+#~ msgid "C_ustomize..."
+#~ msgstr "Özel"
+
+# tr
+#, fuzzy
+#~ msgid "Controls"
+#~ msgstr "Arayüz Kontrolü"
+
+#, fuzzy
+#~ msgid "D_etails..."
+#~ msgstr "Tafsilât"
+
+# tr
+#, fuzzy
+#~ msgid "Hinting"
+#~ msgstr "_İpucu"
+
+#, fuzzy
+#~ msgid "Horizontal gradient"
+#~ msgstr "Ufqiy Qademeçen"
+
+#, fuzzy
+#~ msgid "Pointer"
+#~ msgstr "Bastırıcı"
+
+# tr
+#, fuzzy
+#~ msgid "R_esolution:"
+#~ msgstr "Çö_zünürlük:"
+
+# tr
+#, fuzzy
+#~ msgid "Rendering"
+#~ msgstr "İşitme"
+
+#, fuzzy
+#~ msgid "Save _background image"
+#~ msgstr "Arqazemin Sayla"
+
+#, fuzzy
+#~ msgid "Smoothing"
+#~ msgstr "Hiç bir şey yapma"
+
+#, fuzzy
+#~ msgid "Solid color"
+#~ msgstr "Som Tüs"
+
+#, fuzzy
+#~ msgid "Stretch"
+#~ msgstr "Küç"
+
+#, fuzzy
+#~ msgid "Vertical gradient"
+#~ msgstr "Vertikal Qademeçen"
+
+#, fuzzy
+#~ msgid "_Description:"
+#~ msgstr "_Amel:"
+
+#, fuzzy
+#~ msgid "_Input boxes:"
+#~ msgstr "_Kirdi gürlügi:"
+
+#, fuzzy
+#~ msgid "_Install..."
+#~ msgstr "Qurula"
+
+#, fuzzy
+#~ msgid "_None"
+#~ msgstr "Hiç biri"
+
+#, fuzzy
+#~ msgid "_Reset to Defaults"
+#~ msgstr "Ögbelgilemelerge _Sıfırla"
+
+# tr
+#, fuzzy
+#~ msgid "_Selected items:"
+#~ msgstr "_Sayla"
+
+# tr
+#, fuzzy
+#~ msgid "_Slight"
+#~ msgstr "_Oñ"
+
+# tr
+#, fuzzy
+#~ msgid "_Style:"
+#~ msgstr "Tablet Kalemi (Stylus)"
+
+#~ msgid "Appearance"
+#~ msgstr "Körüniş"
+
+#, fuzzy
+#~ msgid "%d %s by %d %s"
+#~ msgstr "%i %s %i %s"
+
+# tr
+#, fuzzy
+#~ msgid "Image missing"
+#~ msgstr "Firmware kayıp"
+
+# tr
+#, fuzzy
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Kullanıcı oluşturma başarısız oldu"
+
+#, fuzzy
+#~ msgid "Select Theme"
+#~ msgstr "Sayla"
+
+#, fuzzy
+#~ msgid "Theme name must be present"
+#~ msgstr "Pil şimdiki durumdayken"
+
+#, fuzzy
+#~ msgid "_Overwrite"
+#~ msgstr "Üstbaqış"
+
+# tr
+#, fuzzy
+#~ msgid "Could not install theme engine"
+#~ msgstr "Ekran yapılandırması kaydedilemedi"
+
+#, fuzzy
+#~ msgid "Copying '%s'"
+#~ msgstr "Ayarlarnı Kopiyala"
+
+#, fuzzy
+#~ msgid "Copying files"
+#~ msgstr "Ayarlarnı Kopiyala"
+
+# tr
+#~ msgid "Key"
+#~ msgstr "Anahtar"
+
+# tr
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Bu özellik düzenleyicisinin bağlı olduğu GConf tuşu"
+
+# tr
+#~ msgid "Callback"
+#~ msgstr "Geriçağır"
+
+# tr
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Bu geriçağırımı anahtar ile alakalı değer değiştiği zaman kullanın"
+
+# tr
+#~ msgid "Change set"
+#~ msgstr "Değiştirme takımı"
+
+# tr
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf değiştirme takımı gconf istemcisine uygulandığında yönlendirilecek "
+#~ "verileri içerir"
+
+# tr
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Parçacık geriçağırımına dönüşüm"
+
+# tr
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "Veri GConf'dan parçacığa dönüştüğünde uygulanacak geriçağırım"
+
+# tr
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Parçacıktan dönüşüm geriçağırımı"
+
+# tr
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "Veri parçacıktan GConf'a dönüştüğünde uygulanacak geriçağırım"
+
+# tr
+#~ msgid "UI Control"
+#~ msgstr "Arayüz Kontrolü"
+
+# tr
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Bir özelliği kontrol eden nesne (genellikle bir parçacık)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Hasiyet muharriri nesne verileri"
+
+# tr
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Belli özellik düzenleyicileri için gerekli tercihsel veri"
+
+# tr
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Özellik düzenleyici veri boşaltma geriçağırımı"
+
+# tr
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Özellik düzenleyici nesne verisi boşaltılacağında kullanılacak geriçağırım"
+
+# tr
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "'%s' dosyası bulunamadı.\n"
+#~ "\n"
+#~ "Lütfen dosyanın bulunduğundan emin olun ve tekrar deneyin, ya da farklı "
+#~ "bir arkaplan resmi kullanın."
+
+# tr
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' dosyası açılamıyor.\n"
+#~ "Bu resim, henüz desteklenmiyor olabilir.\n"
+#~ "\n"
+#~ "Lütfen bunun yerine başka bir resim seçin."
+
+# tr
+#~ msgid "Please select an image."
+#~ msgstr "Lütfen bir resim seçin."
+
+#, fuzzy
+#~ msgid "Large Pointer"
+#~ msgstr "Daha Balaban"
+
+#, fuzzy
+#~ msgid "Preferred Applications"
+#~ msgstr "Ögbelgilengen Uyğulamalar"
+
+#, fuzzy
+#~ msgid "Select your default applications"
+#~ msgstr "Ögbelgilengen Uyğulamalar"
+
+#, fuzzy
+#~ msgid "Visual Assistance"
+#~ msgstr "Tuşlama Muavini"
+
+# tr
+#, fuzzy
+#~ msgid "Could not load the main interface"
+#~ msgstr "Ekran yapılandırması kaydedilemedi"
+
+# tr
+#, fuzzy
+#~ msgid "Please make sure that the applet is properly installed"
+#~ msgstr "Lütfen AccountService' in kurulu ve etkin olduğundan emin olun."
+
+#, fuzzy
+#~ msgid "- GNOME Default Applications"
+#~ msgstr "Ögbelgilengen Uyğulamalar"
+
+#, fuzzy
+#~ msgid "Accessibility"
+#~ msgstr "Körünirlik"
+
+# tr
+#, fuzzy
+#~ msgid "Co_mmand:"
+#~ msgstr "Kom_ut:"
+
+# tr
+#, fuzzy
+#~ msgid "Internet"
+#~ msgstr "Arayüz"
+
+#, fuzzy
+#~ msgid "Mobility"
+#~ msgstr "Körünirlik"
+
+# tr
+#, fuzzy
+#~ msgid "Multimedia Player"
+#~ msgstr "Ortam yürütücüsü"
+
+#, fuzzy
+#~ msgid "Run in t_erminal"
+#~ msgstr "Terminalnı fırlat"
+
+#, fuzzy
+#~ msgid "Video Player"
+#~ msgstr "Video Sıçan"
+
+#, fuzzy
+#~ msgid "Visual"
+#~ msgstr "Körsel İqazlar"
+
+# tr
+#, fuzzy
+#~ msgid "Web Browser"
+#~ msgstr "Gözat"
+
+#, fuzzy
+#~ msgid "Banshee Music Player"
+#~ msgstr "_Musıqi çalar"
+
+#, fuzzy
+#~ msgid "GNOME OnScreen Keyboard"
+#~ msgstr "Ekran Üzeri Klavye"
+
+#, fuzzy
+#~ msgid "Linux Screen Reader"
+#~ msgstr "Ekran Oquyıcı"
+
+#, fuzzy
+#~ msgid "Muine Music Player"
+#~ msgstr "_Musıqi çalar"
+
+# tüklü
+#, fuzzy
+#~ msgid "Orca with Magnifier"
+#~ msgstr "Mercek"
+
+#, fuzzy
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "_Musıqi çalar"
+
+#, fuzzy
+#~ msgid "Standard XTerminal"
+#~ msgstr "Standart"
+
+#, fuzzy
+#~ msgid "Terminator"
+#~ msgstr "Memur"
+
+# tr
+#, fuzzy
+#~ msgid "Monitor Preferences"
+#~ msgstr "Fare Tercihleri"
+
+# tr
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+# tr
+#~ msgid "R_otation:"
+#~ msgstr "Ç_evirme:"
+
+#, fuzzy
+#~ msgid "_Detect monitors"
+#~ msgstr "Ekranları _Alğıla"
+
+# tr
+#~ msgid "_Resolution:"
+#~ msgstr "Çö_zünürlük:"
+
+# tr
+#, fuzzy
+#~ msgid "Change resolution and position of monitors"
+#~ msgstr "Monitör ve projektör çözünürlüğü ve konumunu değiştir"
+
+#, fuzzy
+#~ msgid "Monitors"
+#~ msgstr "Ekran"
+
+# tr
+#, fuzzy
+#~ msgid "Could not get information for %s: %s\n"
+#~ msgstr "Ekran bilgisi alınamadı"
+
+# tr
+#, fuzzy
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "Arayüz yüklenemedi: %s"
+
+# tr
+#, fuzzy
+#~ msgid "Could not rename %s to %s: %s\n"
+#~ msgstr "Arayüz yüklenemedi: %s"
+
+#, fuzzy
+#~ msgid "Upside Down"
+#~ msgstr "Aşağı Avuştır"
+
+#, fuzzy
+#~ msgid "Mirror Screens"
+#~ msgstr "¼ Ekran"
+
+#, fuzzy
+#~ msgid "Monitor: %s"
+#~ msgstr "Ekran"
+
+# tr
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "Görüntü yapılandırması uygulanırken oturum veriyolu alınamadı"
+
+# tr
+#, fuzzy
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "Ekran yapılandırması kaydedilemedi"
+
+#, fuzzy
+#~ msgid "This configuration will be used the next time someone logs in."
+#~ msgstr ""
+#~ "Bir bölge saylañız (deñişiklik bir soñraki kere içeri imzalanğanıñızda "
+#~ "yürerlikke kirecek)"
+
+# tr
+#, fuzzy
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "Ekran yapılandırması kaydedilemedi"
+
+# tr
+#~ msgid "New shortcut..."
+#~ msgstr "Yeni kısayol..."
+
+# tr
+#~ msgid "Accelerator key"
+#~ msgstr "Hızlandırma tuşu"
+
+# tr
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Hızlandırma düzenleyicileri"
+
+# tr
+#~ msgid "Accelerator keycode"
+#~ msgstr "Hızlandırma tuşkodu"
+
+# tr
+#~ msgid "Accel Mode"
+#~ msgstr "Hızlandırma Kipi"
+
+# tr
+#~ msgid "The type of accelerator."
+#~ msgstr "Hızlandırıcı türü."
+
+# tr
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "Yeni kısa yol kaydedilirken hata"
+
+# tr
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Çok fazla özel kısayol"
+
+#, fuzzy
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new key "
+#~ "combination, or press backspace to clear."
+#~ msgstr ""
+#~ "Bir qısqayolnı tahrir etmek içün, satırğa çertiñiz ve tuşlarnı basıq "
+#~ "tutuñız ya da temizlemek içün Backspace tuşuna basıñız."
+
+#, fuzzy
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "Davuş Tercihleri"
+
+# tr
+#, fuzzy
+#~ msgid "Beep when _accessibility features are turned on or off"
+#~ msgstr "Erişilebilirlik özelliklerini klavyeden _aç"
+
+# tr
+#, fuzzy
+#~ msgid "Beep when a _modifier key is pressed"
+#~ msgstr "_Değiştirici tuşa basıldığında biple"
+
+# tr
+#, fuzzy
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "_Değiştirici tuşa basıldığında biple"
+
+# tr
+#, fuzzy
+#~ msgid "Beep when a key is pr_essed"
+#~ msgstr "_Değiştirici tuşa basıldığında biple"
+
+# tr
+#, fuzzy
+#~ msgid "Beep when a key is reje_cted"
+#~ msgstr "Bir tuş _reddedildiğinde biple"
+
+# tr
+#, fuzzy
+#~ msgid "Beep when key is _accepted"
+#~ msgstr "Bir tuş _reddedildiğinde biple"
+
+# tr
+#, fuzzy
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Bir tuş _reddedildiğinde biple"
+
+# tr
+#, fuzzy
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Pencere başlığı yanıp sönsün"
+
+# tr
+#, fuzzy
+#~ msgid "Flash entire _screen"
+#~ msgstr "Tüm ekran yanıp sönsün"
+
+#, fuzzy
+#~ msgid "Apply System-Wide..."
+#~ msgstr "Sistem çapında uygula"
+
+#~ msgid "Cursor blinks speed"
+#~ msgstr "İmleç qıpması sur'atı"
+
+# tr
+#, fuzzy
+#~ msgid "Disa_ble sticky keys if two keys are pressed together"
+#~ msgstr "İki tuşa birden basıldığında _devre dışı bırak"
+
+#, fuzzy
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Davuş Tercihleri"
+
+#, fuzzy
+#~ msgid "Keyboard _model:"
+#~ msgstr "Klavye"
+
+#, fuzzy
+#~ msgid "Move _Down"
+#~ msgstr "Aşağı Avuştır"
+
+#, fuzzy
+#~ msgid "Move _Up"
+#~ msgstr "Yuqarı Avuştır"
+
+#, fuzzy
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "Klavye tizilimi seçeneklerini körüntile ve tahrir et"
+
+#, fuzzy
+#~ msgid "New windows u_se active window's layout"
+#~ msgstr "Yañı pencereler evvelki pencereniñ tizilimini qullanır"
+
+#, fuzzy
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "Klavye tizilimi seçeneklerini körüntile ve tahrir et"
+
+#, fuzzy
+#~ msgid "Typing Break"
+#~ msgstr "Tuşlama"
+
+#, fuzzy
+#~ msgid "_Acceleration:"
+#~ msgstr "_Tezleşme:"
+
+#, fuzzy
+#~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#~ msgstr "İrişilebilirlik hususiyetlerini klavyeni qullanaraq aç ve qapat"
+
+# tr
+#, fuzzy
+#~ msgid "_Ignore fast duplicate keypresses"
+#~ msgstr "Kısa aralıklı tuş tekrarlarını yok sayar"
+
+# tr
+#, fuzzy
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "Belirteci klavye ile kontrol et"
+
+#, fuzzy
+#~ msgid "_Separate layout for each window"
+#~ msgstr "Bütün pencereler içün aynı tizilimni qullan"
+
+# tr
+#, fuzzy
+#~ msgid "_Show..."
+#~ msgstr "_Göster"
+
+# tr
+#, fuzzy
+#~ msgid "_Type to test settings:"
+#~ msgstr "Ayarları denemek için buraya yazın"
+
+#, fuzzy
+#~ msgid "By _country"
+#~ msgstr "Hesabım"
+
+#, fuzzy
+#~ msgid "By _language"
+#~ msgstr "_Til"
+
+#, fuzzy
+#~ msgid "Preview:"
+#~ msgstr "Ögbaqış"
+
+#, fuzzy
+#~ msgid "_Language:"
+#~ msgstr "_Til"
+
+# tr
+#, fuzzy
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Uyarı sesi se_çin:"
+
+#, fuzzy
+#~ msgid "_Models:"
+#~ msgstr "Model:"
+
+# tr
+#, fuzzy
+#~ msgid "Models"
+#~ msgstr "Model"
+
+# tr
+#, fuzzy
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Wacom tablet tercihlerinizi ayarlayın"
+
+#, fuzzy
+#~ msgid "gesture|Move down"
+#~ msgstr "Aşağı Avuştır"
+
+# tr
+#, fuzzy
+#~ msgid "gesture|Disabled"
+#~ msgstr "Ğayrıqabilleştirilgen"
+
+# tr
+#, fuzzy
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "Fare Tercihleri"
+
+# tr
+#, fuzzy
+#~ msgid "Dwell Click"
+#~ msgstr "Durağan Tıklama"
+
+# tr
+#, fuzzy
+#~ msgid "Locate Pointer"
+#~ msgstr "Yazıcıyı Kaldır"
+
+#, fuzzy
+#~ msgid "Seco_ndary click:"
+#~ msgstr "Ekilemci çertme keçikmesi"
+
+#, fuzzy
+#~ msgid ""
+#~ "To test your double-click settings, try to double-click on the light bulb."
+#~ msgstr "Ayarlarıñıznı sınamaq içün yüzge çift-çertmege deñeñiz."
+
+# tr
+#, fuzzy
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "Belirteç nesne üstüne geldiğinde tıklama yap"
+
+# tr
+#, fuzzy
+#~ msgid "_Motion threshold:"
+#~ msgstr "Hareket _eşiği:"
+
+# tr
+#, fuzzy
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr "İlk düğme basılı tutulduğunda ikincil tıklama tetikle"
+
+# tr
+#, fuzzy
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Fare ve imleçsürer tercihlerinizi yapın"
+
+#, fuzzy
+#~ msgid "New Location..."
+#~ msgstr "Qonumlar..."
+
+#, fuzzy
+#~ msgid "Network Proxy"
+#~ msgstr "Şebekede proksisi"
+
+# tr
+#, fuzzy
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Wacom tablet tercihlerinizi ayarlayın"
+
+# tr
+#, fuzzy
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "Otomatik yapılandırma"
+
+# tr
+#, fuzzy
+#~ msgid "Autoconfiguration _URL:"
+#~ msgstr "_Yapılandırma URL'si"
+
+# tr
+#, fuzzy
+#~ msgid "Create New Location"
+#~ msgstr "Yeni hesap oluştur"
+
+# tr
+#, fuzzy
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "_HTTP Vekili"
+
+# tr
+#, fuzzy
+#~ msgid "Location:"
+#~ msgstr "Konum"
+
+# tr
+#, fuzzy
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Tablet Tercihleri"
+
+# tr
+#, fuzzy
+#~ msgid "S_ocks host:"
+#~ msgstr "_Socks Makinesi"
+
+# tr
+#, fuzzy
+#~ msgid "The location already exists."
+#~ msgstr "Aygıt zaten kullanımda."
+
+#, fuzzy
+#~ msgid "U_sername:"
+#~ msgstr "Qullanıcı Adı"
+
+#, fuzzy
+#~ msgid "_Details"
+#~ msgstr "Tafsilât"
+
+# tr
+#, fuzzy
+#~ msgid "_Location name:"
+#~ msgstr "Konum"
+
+# tr
+#, fuzzy
+#~ msgid "_Password:"
+#~ msgstr "_Parola"
+
+# tr
+#, fuzzy
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_HTTP Vekili"
+
+#, fuzzy
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "Bütün pencereler içün aynı tizilimni qullan"
+
+# tr
+#, fuzzy
+#~ msgid "_Meta"
+#~ msgstr "Y_öntem"
+
+#, fuzzy
+#~ msgid "Movement Key"
+#~ msgstr "Sıçan Tuşları"
+
+# tr
+#, fuzzy
+#~ msgid "Titlebar Action"
+#~ msgstr "Yazıcı Seçenekleri"
+
+#, fuzzy
+#~ msgid "Window Preferences"
+#~ msgstr "Davuş Tercihleri"
+
+# tr
+#, fuzzy
+#~ msgid "Window Selection"
+#~ msgstr "Bölüm"
+
+#, fuzzy
+#~ msgid "seconds"
+#~ msgstr "30 saniye"
+
+#, fuzzy
+#~ msgid "Windows"
+#~ msgstr "Windows yazılımı"
+
+# tr
+#, fuzzy
+#~ msgid "Maximize"
+#~ msgstr "En Çok"
+
+# tr
+#, fuzzy
+#~ msgid "Minimize"
+#~ msgstr "En Az"
+
+# tr
+#, fuzzy
+#~ msgid "Roll up"
+#~ msgstr "Yukarı Kaydır"
+
+# tr
+#, fuzzy
+#~ msgid "Groups"
+#~ msgstr "Grup İsmi"
+
+#, fuzzy
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "İP endamlandırışı muvaffaqiyetsiz"
+
+#, fuzzy
+#~ msgid "Take a break!"
+#~ msgstr "Bir ekran körüntisini al"
+
+#, fuzzy
+#~ msgid "_Take a Break"
+#~ msgstr "Bir ekran körüntisini al"
+
+#, fuzzy
+#~ msgid "Typing Monitor"
+#~ msgstr "Ekran"
+
+# tr
+#, fuzzy
+#~ msgid "Name:"
+#~ msgstr "İ_sim:"
+
+# tr
+#, fuzzy
+#~ msgid "Style:"
+#~ msgstr "Tablet Kalemi (Stylus)"
+
+#, fuzzy
+#~ msgid "Type:"
+#~ msgstr "_Tür:"
+
+#, fuzzy
+#~ msgid "Version:"
+#~ msgstr "Sürüm %s"
+
+# tr
+#, fuzzy
+#~ msgid "Description:"
+#~ msgstr "Bölüm"
+
+#, fuzzy
+#~ msgid "Installed"
+#~ msgstr "Qurula"
+
+#, fuzzy
+#~ msgid "Install Failed"
+#~ msgstr "Yañartmalarnı Qur"
+
+#, fuzzy
+#~ msgid "I_nstall Font"
+#~ msgstr "Qurula"
+
+#, fuzzy
+#~ msgid "Preview fonts"
+#~ msgstr "Tizilimge Ög-baq"
+
+# tr
+#, fuzzy
+#~ msgid "Error parsing arguments: %s\n"
+#~ msgstr "Hesap oluşturulurken hata meydana geldi"
+
+#, fuzzy
+#~ msgid "Uninstall"
+#~ msgstr "Qurula"
+
+#, fuzzy
+#~ msgid "Remove from Favorites"
+#~ msgstr "Profilni çetleştir"
+
+#, fuzzy
+#~ msgid "Network Servers"
+#~ msgstr "Şebeke Adı"
+
+#, fuzzy
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Tema</b>"
+
+#, fuzzy
+#~ msgid "Rename..."
+#~ msgstr "İcat Et..."
+
+#, fuzzy
+#~ msgid "Send To..."
+#~ msgstr "Dosyelerni Yiber..."
+
+#, fuzzy
+#~ msgid "Delete"
+#~ msgstr "Cihaznı sil"
+
+# tr
+#, fuzzy
+#~ msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgstr "Hesabı silmek istediğinizden emin misiniz?"
+
+#, fuzzy
+#~ msgid "Open with Default Application"
+#~ msgstr "Ögbelgilengen Uyğulamalar"
+
+# tr
+#, fuzzy
+#~ msgid "%l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+# tr
+#, fuzzy
+#~ msgid "Today %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+# tr
+#, fuzzy
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+# tr
+#, fuzzy
+#~ msgid "%b %d %Y"
+#~ msgstr "%d x %d (%s)"
+
+#, fuzzy
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Tema</b>"
+
+# tr
+#, fuzzy
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Yapılandırmanın uygulanması başarısız oldu: %s"
+
+#, fuzzy
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Web kezicisini fırlat"
+
+#, fuzzy
+#~ msgid "KMail"
+#~ msgstr "_Poşta"
+
+#, fuzzy
+#~ msgid "Keep Settings"
+#~ msgstr "Ayarlarnı Kopiyala"
+
+# tr
+#, fuzzy
+#~ msgid "Do you want to keep these settings?"
+#~ msgstr "%s' in dosyalarını bırakmak ister misiniz?"
+
+#, fuzzy
+#~ msgid "Use _previous settings"
+#~ msgstr "_Fare Ayarları"
+
+#, fuzzy
+#~ msgid "Visual Effects"
+#~ msgstr "Körsel İqazlar"
+
+#, fuzzy
+#~ msgid "_Keep settings"
+#~ msgstr "Sistem ayarları"
+
+# tr
+#, fuzzy
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "S_ol işaret parmağı"
+
+# tr
+#, fuzzy
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "S_ol işaret parmağı"
+
+#, fuzzy
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "Sol orta parmaq"
+
+#, fuzzy
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "Sol orta parmaq"
+
+#, fuzzy
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "Sol yüzük parmağı"
+
+#, fuzzy
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "Sol yüzük parmağı"
+
+#, fuzzy
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "Sol çinatiy parmaq"
+
+#, fuzzy
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "Sol çinatiy parmaq"
+
+# tr
+#, fuzzy
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "_Sağ işaret parmağı"
+
+# tr
+#, fuzzy
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "_Sağ işaret parmağı"
+
+#, fuzzy
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "Oñ orta parmaq"
+
+#, fuzzy
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "Oñ orta parmaq"
+
+#, fuzzy
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "Oñ yüzük parmağı"
+
+#, fuzzy
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "Oñ yüzük parmağı"
+
+#, fuzzy
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "Oñ çinatiy parmaq"
+
+#, fuzzy
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "Oñ çinatiy parmaq"
+
+#, fuzzy
+#~ msgid "_File"
+#~ msgstr "Dosyelerni _Qoru"
+
+# tr
+#, fuzzy
+#~ msgid "Display Preferences"
+#~ msgstr "Fare Tercihleri"
+
+#, fuzzy
+#~ msgid "_Mirror screens"
+#~ msgstr "Ekranlarnı _Küzgüle"
+
+# tr
+#, fuzzy
+#~ msgid "Change screen resolution"
+#~ msgstr "Ekran bilgisi alınamadı"
+
+# tr
+#, fuzzy
+#~ msgid "_Selected layouts:"
+#~ msgstr "Bir hesap seçin"
+
+# tr
+#, fuzzy
+#~ msgid "C_ontrol"
+#~ msgstr "Arayüz Kontrolü"
+
+#, fuzzy
+#~ msgid "Fill screen"
+#~ msgstr "Tam Ekran"
+
+#, fuzzy
+#~ msgid "Menus and Toolbars"
+#~ msgstr "Sıçan ve Tiyüv-şiltesi"
+
+#, fuzzy
+#~ msgid "New windows get layout \"foobar\""
+#~ msgstr "Yañı pencereler ögbelgilengen tizilimni qullanır"
+
+#, fuzzy
+#~ msgid "<b>Email</b>"
+#~ msgstr "<b>Tema</b>"
+
+#, fuzzy
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Tema</b>"
+
+#, fuzzy
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Tema</b>"
+
+#, fuzzy
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Tema</b>"
+
+#, fuzzy
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Tema</b>"
+
+# tr
+#, fuzzy
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "Tablet Tercihleri"
+
+#, fuzzy
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "Tüsler"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Tema</b>"
+
+#, fuzzy
+#~ msgid "<b>_Desktop Background</b>"
+#~ msgstr "<b>Arqazemin</b>"
+
+#, fuzzy
+#~ msgid "New File"
+#~ msgstr "Dosyelerni _Qoru"
+
+#, fuzzy
+#~ msgid "Open File"
+#~ msgstr "Cilbent aç"
+
+#, fuzzy
+#~ msgid "_Print"
+#~ msgstr "Bastırıcı"
+
+# tr
+#, fuzzy
+#~ msgid "Could not apply the selected configuration"
+#~ msgstr "Ekran yapılandırması kaydedilemedi"
+
+#, fuzzy
+#~ msgid "<b>Bounce Keys</b>"
+#~ msgstr "Sıçrama Tuşları"
+
+#, fuzzy
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>Tema</b>"
+
+#, fuzzy
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small>Yüksek</small>"
+
+#, fuzzy
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small>Düşük</small>"
+
+#, fuzzy
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small>Yüksek</small>"
+
+#, fuzzy
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small>Düşük</small>"
+
+#, fuzzy
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Başlatıcı simge boyutu</b>"
+
+#, fuzzy
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small>Yüksek</small>"
+
+#, fuzzy
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small>Yüksek</small>"
+
+#, fuzzy
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small>Düşük</small>"
+
+#, fuzzy
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small>Yüksek</small>"
+
+#~ msgid "Add dots"
+#~ msgstr "Nokta ekle"
+
+#~ msgid "<b>Theme</b>"
+#~ msgstr "<b>Tema</b>"
+
+#~ msgid "<b>Launcher icon size</b>"
+#~ msgstr "<b>Başlatıcı simge boyutu</b>"
+
+#~ msgid "Look"
+#~ msgstr "Görünüm"
+
+#~ msgid "<b>Auto-hide the Launcher</b>"
+#~ msgstr "<b>Başlatıcıyı otomatik gizle</b>"
+
+#~ msgid ""
+#~ "<span size=\"small\">The launcher will reveal when moving the pointer to "
+#~ "the defined hot spot.</span>"
+#~ msgstr ""
+#~ "<span size=\"small\">İmleç tanımlanmış etkin bölgeye hareket "
+#~ "ettirildiğinde başlatıcı ortaya çıkacak.</span>"
+
+#~ msgid "Reveal location:"
+#~ msgstr "Ortaya çıkış konumu"
+
+#~ msgid "Left side"
+#~ msgstr "Sol yan"
+
+#~ msgid "Top left corner"
+#~ msgstr "Sol üst köşe"
+
+#~ msgid "Other reveal option"
+#~ msgstr "Diğer ayarları göster"
+
+#~ msgid "Reveal sensitivity"
+#~ msgstr "Ortaya çıkış duyarlılığı"
+
+#~ msgid "<small>Low</small>"
+#~ msgstr "<small>Düşük</small>"
+
+#~ msgid "<small>High</small>"
+#~ msgstr "<small>Yüksek</small>"
+
+#~ msgid ""
+#~ "Some settings have been overriden by an external program, press \"Restore "
+#~ "Default Behaviors\"  to reset the behavior and return control to this "
+#~ "panel."
+#~ msgstr ""
+#~ "Bazı ayarlar başka bir yazılım tarafından bozuldu, ayarları sıfırlamak "
+#~ "için \"Varsayılan Ayarları Geri Yükle\"ye basın ve ayarları denetlemek "
+#~ "için geri dönün."
+
+#~ msgid "Restore Default Behaviours"
+#~ msgstr "Öntanımlı Davranışları Geri Yükle"
+
+#~ msgid "Behavior"
+#~ msgstr "Davranış"
+
+#~ msgid "default"
+#~ msgstr "öntanımlı"
+
+#~ msgid "Wallpaper;Screen;Desktop;Theme;Appearance;Launcher;Unity;Menus;"
+#~ msgstr "Arkaplan;Ekran;Masaüstü;Tema;Görünüm;Başlatıcı;Unity;Menüler;"
+
+#~ msgid "All displays"
+#~ msgstr "Tüm ekranlar"
+
+#~ msgid "L_auncher placement"
+#~ msgstr "_Başlatıcı yerleşimi"
+
+#~ msgid "Apply system wide"
+#~ msgstr "Sistem çapında uygula"
+
+#~ msgid "Suspend"
+#~ msgstr "Beklet"
+
+#~ msgid "When battery is present"
+#~ msgstr "Pil şimdiki durumdayken"
+
+#~ msgid "When battery is charging/in use"
+#~ msgstr "Pil şarj olurken/kullanımdayken"
+
+#~ msgid "When the lid is closed"
+#~ msgstr "Kapak kapalı olduğunda"
+
+#~ msgid "Show battery status in the _menu bar"
+#~ msgstr "_Menü çubuğunda pil durumunu göster"
+
+#~ msgid "Keyboard Layout"
+#~ msgstr "Klavye Tizilimi"
+
+#~ msgid "Require my password when waking from suspend"
+#~ msgstr "Askıya alınıp uyandıktan sonra parolama gerek duyulsun"
+
+#~ msgid "Mute"
+#~ msgstr "Sessiz"
+
+#~ msgid "Settings for %s"
+#~ msgstr "%s için ayarlar"
+
+#~ msgid "Mode:"
+#~ msgstr "Kip:"
+
+#~ msgid "Test:"
+#~ msgstr "Sınama:"
+
+#~ msgid "Test Sound"
+#~ msgstr "Sınama Sesi"
+
+#~ msgid "Application Menu"
+#~ msgstr "Uyğulama Menüsi"
+
+#~ msgid "Shutdown"
+#~ msgstr "Kapat"
+
+#~ msgid "Unlock"
+#~ msgstr "Kilidi Aç"
+
+#~ msgid "Clockwise"
+#~ msgstr "Saat Yönünde"
+
+#~ msgid "180 Degrees"
+#~ msgstr "180 Derece"
+
+#~ msgid "System Info"
+#~ msgstr "Sistem Bilgisi"
+
+#~ msgid "Magnifier zoom out"
+#~ msgstr "Mercek uzaklaştır"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "Karşıtlık düğmesi"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "Mercek düğmesi"
+
+#~ msgid "Toggle on-screen keyboard"
+#~ msgstr "Ekran klavyesi düğmesi"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "Ekran okuyucu düğmesi"
+
+#~ msgid "CD _audio:"
+#~ msgstr "_Ses CD' si:"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "Ortam ve Oto-çalıştır"
+
+#~ msgid "_DVD video:"
+#~ msgstr "_DVD vidyo:"
+
+#~ msgid "_Music player:"
+#~ msgstr "_Müzik Çalar:"
+
+#~ msgid "_Photos:"
+#~ msgstr "_Fotoğraf:"
+
+#~ msgid "_Software:"
+#~ msgstr "_Yazılım:"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "Ortam ve oto çalıştır seçeneklerini ayarla"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "cd;dvd;usb;ses;vidyo;disk;"
+
+#~ msgid "Network;Wireless;IP;LAN;"
+#~ msgstr "Ağ;Kablosuz;İP;LAN;"
+
+#~ msgid "Speed"
+#~ msgstr "Hız"
+
+#~ msgid "Battery charging"
+#~ msgstr "Pil doluyor"
+
+#~ msgid "Battery discharging"
+#~ msgstr "Pil boşalıyor"
+
+#~ msgid "UPS charging"
+#~ msgstr "KGK doluyor"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s dolmasına (%.0lf%%) var"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s boşalmasına (%.0lf%%) var"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% dolu"
+
+#~ msgid "Ask me"
+#~ msgstr "Bana sor"
+
+#~ msgid "Create a user"
+#~ msgstr "Kullanıcı oluştur"
+
+#~ msgid ""
+#~ "To create a user,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Kullanıcı oluşturmak için,\n"
+#~ "önce * simgesine tıklayın"
+
+#~ msgid "Delete the selected user"
+#~ msgstr "Seçili kullanıcıyı sil"
+
+#~ msgid ""
+#~ "To delete the selected user,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Seçili kullanıcıyı silmek için,\n"
+#~ "önce * simgesine tıklayın"
+
+#~ msgid "Counterclockwise"
+#~ msgstr "Saatin Ters Yönünde"
+
+#~ msgid "_Keyboard Settings"
+#~ msgstr "_Klavye Ayarları"
+
+#~ msgid "_Mouse Settings"
+#~ msgstr "_Fare Ayarları"
+
+#~ msgid "_Sound Settings"
+#~ msgstr "_Ses Ayarları"
+
+#~ msgid ""
+#~ "device;system;information;memory;processor;version;default;application;"
+#~ "fallback;preferred;"
+#~ msgstr ""
+#~ "aygıt;sistem;bilgi;bellek;işlemci;sürüm;varsayılan;uygulama;geriplan;"
+#~ "önerilen;"
+
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr "Sadece aşağıda listelenecek olan profiller aygıtla uyumludur."
+
+#~ msgid "_Turn off after:"
+#~ msgstr "Bunun sonrasında _kapat:"
+
+#~ msgid "Theme to be used for the UI"
+#~ msgstr "Kullanıcı arayüzü için kullanılacak tema"
+
+#~ msgid "Suspend when inactive for:"
+#~ msgstr "Şu kadar süre etkin değilse askıya al:"
+
+#~ msgid "When the lid is closed:"
+#~ msgstr "Dizüstü ekranı kapatıldığında:"
+
+#~ msgid "Left-Handed Orientation:"
+#~ msgstr "Sol Elle kullanım"
+
+#~ msgid "When power is _critically low:"
+#~ msgstr "Güç düzeyi _çok düşük olduğunda:"
+
+#~ msgid ""
+#~ "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;"
+#~ "size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys"
+#~ msgstr ""
+#~ "Klavye;Fare;a11y;Erişebilirlik;Karşıtlık;Yakınlaştırma;Ekran Okuyucusu;"
+#~ "metin;yazı tipi;boyut;AccessX;Yapışkan Tuşlar;Yavaş Tuşlar;Seken Tuşlar;"
+#~ "Fare Tuşları"
+
+#~ msgid "S_ticky edges"
+#~ msgstr "Yapışaq _ağızlar"
+
+#~ msgid "Legal Notice"
+#~ msgstr "Qanuniy Tebliğ"
+
+#~ msgid "_Other Media..."
+#~ msgstr "_Diger Vasatlar..."
+
+#~ msgid "Network settings"
+#~ msgstr "Şebeke ayarları"
+
+# tr
+#~ msgid "Out of range"
+#~ msgstr "Menzil tışı"
+
+#~ msgid "C_reate..."
+#~ msgstr "_İcat Et..."
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "Telsiz Sıcaqnoqta"
+
+#~ msgid "_Disconnect"
+#~ msgstr "Bağlantını _Qopar"
+
+#~ msgid "_Connect"
+#~ msgstr "_Bağlan"
+
+#~ msgid "_Forget Network"
+#~ msgstr "Şebekeni Unut"
+
+#~ msgid "Disconnected"
+#~ msgstr "Bağlantı qoparılğan"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "Taşıyıcı/ilişim deñişti"
+
+# tr
+#~ msgid "Manage online accounts"
+#~ msgstr "Çevrimiçi hesapları yönet"
+
+# tr
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "Yükletile - tam yükletilgen"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "Qarane: <a href=\"screen\">ekran parlaqlığı</a> ne qadar qudretniñ "
+#~ "qullanılğanına tesir eter"
+
+# tr
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "Bekletildi"
+
+# tr
+#~ msgid "%s Options"
+#~ msgstr "%s Seçenekleri"
+
+#~ msgid "Manufacturers"
+#~ msgstr "İmalâtçılar"
+
+# tüklü
+#~ msgid "Drivers"
+#~ msgstr "Sürüciler"
+
+#~ msgid "Language;Layout;Keyboard;"
+#~ msgstr "Til;Tizilim;Klavye;"
+
+#~ msgid "Region and Language"
+#~ msgstr "Bölge Ve Til"
+
+#~ msgid "Your settings"
+#~ msgstr "Ayarlarıñız"
+
+#~ msgid "Change your keyboard or input method settings"
+#~ msgstr "Klavye yaaki kirdi usulı ayarlarıñıznı deñiştiriñiz"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "Parlaqlıq & Kilit"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "Tüs"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "Hiç biri"
+
+# tr
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "'%s' adlı bir qullanıcı mevcut degildir."
+
+# tr
+#~ msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+#~ msgstr "Kart;Mikrofon;Ses;Kaybolma;Denge;Bluetooth;Kulaklık Seti;"
+
+# tüklü
+#~ msgid "Play sound through"
+#~ msgstr "Davuşnı şunıñ arqalı oynat"
+
+#~ msgid "Settings for the selected device"
+#~ msgstr "Saylanğan cihaz içün ayarlar"
+
+#~ msgid "Record sound from"
+#~ msgstr "Davuşnı şundan qayd et"
+
+#~ msgid "Pointer Speed"
+#~ msgstr "İmleç Sur'atı"
+
+#~ msgid "Two-_finger scrolling"
+#~ msgstr "_Eki-parmaqlı taydırma"
+
+#~ msgid "Center"
+#~ msgstr "Ortala"
+
+#~ msgid "Scale"
+#~ msgstr "Miqyasla"
+
+#~ msgid "Tile"
+#~ msgstr "Töşe"
+
+#~ msgid "Disable _touchpad while typing"
+#~ msgstr "Tuşlağanda _tiyüv-şiltesini ğayrı faalleştir"
+
+#~ msgid "Fill"
+#~ msgstr "Toldur"
+
+#~ msgid "Primary Color"
+#~ msgstr "Birlemci Renk"
+
+# tr
+#~ msgid "Set this device for all users on this computer"
+#~ msgstr "Bu aygıtı, bilgisayarı kullanan tüm kullanıcılar için ayarla"
+
+#~ msgid "Date and Time"
+#~ msgstr "Tarih ve Saat"
+
+#~ msgid "Mirror Displays"
+#~ msgstr "Ekranlarnı Küzgüle"
+
+# tr
+#~ msgid ""
+#~ "Network details for %s including password and any custom configuration "
+#~ "will be lost"
+#~ msgstr ""
+#~ "Parolayı ve tüm yapılandırmayı içeren %s için olan ağ ayrıntıları "
+#~ "kaybedilecek"
+
+#~ msgid "Security Key"
+#~ msgstr "Emniyet Anahtarı"
+
+#~ msgid "Account Type:"
+#~ msgstr "Hesap Türü:"
+
+# tr
+#~ msgid "Caution"
+#~ msgstr "Dikkat"
+
+#~ msgid "Good"
+#~ msgstr "Eyi"
+
+# tr
+#~ msgid "Active Print Jobs"
+#~ msgstr "Etkin Yazdırma İşleri"
+
+# tüklü
+#~ msgid "Beep when Caps and Num Lock are used"
+#~ msgstr "Caps ve Num Lock qullanılğanında biple"
+
+#~ msgid "_Contrast:"
+#~ msgstr "_Tezat:"
+
+#~ msgid "Change the background and theme"
+#~ msgstr "Arqazemin ve temanı deñiştir"
+
+#~ msgid "Integrated in menu bar and hidden"
+#~ msgstr "Menü çıbığında bütünleşken ve gizlengen"
+
+#~ msgid "Integrated in menu bar and visible"
+#~ msgstr "Menü çıbığında bütünleşken ve körünir"

--- a/po/cs.po
+++ b/po/cs.po
@@ -23,9 +23,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-05 15:18+0200\n"
 "Last-Translator: Marek Černocký <marek@manet.cz>\n"
 "Language-Team: Czech <gnome-cs-list@gnome.org>\n"
@@ -37,100 +36,7 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Systémová sběrnice"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Plný přístup"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Sběrnice sezení"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Zařízení"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Úplný přístup k /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Síť"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Má přístup k síti"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Domů"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Jen ke čtení"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Souborový systém"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Nastavení"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Nastavení lze měnit"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s má následující oprávnění zabudovaná a nelze je měnit. Pokud z těchto "
-"oprávnění máte obavy, zvažte odstranění celé aplikace."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u typ souboru a odkazu, který otevírá tato aplikace"
-msgstr[1] "%u typy souborů a odkazů, které otevírá tato aplikace"
-msgstr[2] "%u typů souborů a odkazů, které otevírá tato aplikace"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> se používá k otevření následujících typů souborů a odkazů."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "Z místa na disku je využito %s."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -146,7 +52,6 @@ msgid "Install some…"
 msgstr "Nějakou nainstalovat…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Otevřít"
 
@@ -170,24 +75,13 @@ msgstr "Hledání"
 msgid "Receive system searches and send results."
 msgstr "Přijímat od systému požadavky na hledání a předávat výsledky."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Vypnuto"
 
@@ -351,80 +245,20 @@ msgstr "Vyprázdnit mezipaměť…"
 msgid "Control various application permissions and settings"
 msgstr "Určujte různorodá oprávnění a nastavení aplikací"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplikace;flatpak;oprávnění;nastavení;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Vyběr obrázku"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Zrušit"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Otevřít"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "více velikostí"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Bez pozadí pracovní plochy"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Aktuální pozadí"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Styl"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Výchozí"
 
@@ -448,7 +282,6 @@ msgstr "Vzhled"
 msgid "Change your background image or the UI colors"
 msgstr "Změnit obrázek na pozadí nebo barvy uživatelského rozhraní"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "pozadí;tapeta;obrazovka;plocha;styl;světlý;tmavý;vzhled;"
@@ -499,9 +332,7 @@ msgstr "Hardwarový režim „letadlo“ je zapnutý"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Vypněte přepínač režimu „letadlo“, aby se povolilo Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -509,7 +340,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Zapnout a vypnout Bluetooth a připojit se k zařízením"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "sdílet;sdílení;bluetooth;obex;"
@@ -542,93 +372,35 @@ msgstr "Žádná aplikace si nepožádala o přístup ke kameře"
 msgid "Protect your pictures"
 msgstr "Ochránit své obrázky"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "kamera;fotky;fotografie;snímky;video;webová kamera;zámek;uzamknutí;uzamčení;"
 "zamknout;uzamknout;uzamčít;soukromí;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Umístěte kalibrační zařízení na čtverec a zmáčkněte „Začít“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Posuňte kalibrační zařízení do kalibrační pozice a zmáčkněte „Pokračovat“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Posuňte kalibrační zařízení do pozice na povrchu a zmáčkněte „Pokračovat“"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Zavřete víko notebooku"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Došlo k vnitřní chybě, z které už se nelze obnovit."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Nástroje vyžadované pro kalibraci nejsou nainstalované."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Profil nemohl být vygenerován."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Cílový bílý bod nebyl dosažitelný."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Dokončeno!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrace selhala!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Můžete oddělat kalibrační zařízení."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Zamezte otřesům kalibračního zařízení během procesu kalibrace"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kalibrace displeje"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Zrušit"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -645,140 +417,6 @@ msgstr "_Pokračovat"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Hotovo"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Obrazovka notebooku"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Zabudovaná webkamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Skener %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Fotoaparát %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Tiskárna %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webová kamera %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Povolit správu barev pro %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Zobrazit barevné profily pro %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Nezkalibrováno"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Výchozí: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Prostor barev: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Testovací profil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Výběr souboru s profilem ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importovat"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Podporované profily ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Všechny soubory"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Obrazovka"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Uložit profil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Uložit"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Vytvořit barevný profil pro vybrané zařízení"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Měřící sonda nebyla nalezena. Zkontrolujte prosím, zda je správně připojena "
-"a zapnutá."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Měřící sonda nepodporuje profilování tiskáren."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Typ zařízení není v současnosti podporován."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -895,9 +533,9 @@ msgstr "Vyžaduje zapisovatelné médium"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Tyto instrukce, jak použít profil na systémech <a href=\"linux\">GNU/Linux</"
 "a>, <a href=\"osx\">Apple OS X</a> a <a href=\"windows\">Microsoft Windows</"
@@ -921,7 +559,6 @@ msgstr "_Importovat soubor…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -933,9 +570,7 @@ msgstr ""
 "Aby u jednotlivých zařízení byla uplatněna správa barev, potřebují aktuální "
 "barevné profily."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Dozvědět se více"
 
@@ -1067,82 +702,6 @@ msgstr "D65 (fotografie a grafika)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standardní rozsah"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testovací profil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatický"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Nízká kvalita"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Střední kvalita"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Vysoká kvalita"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Výchozí RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Výchozí CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Výchozí odstíny šedé"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Výrobce dodal tovární kalibrační data"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Celoobrazovková korekce není s tímto profilem možná"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Tento profil už nemusí být přesný"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Barevnost"
@@ -1152,14 +711,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Kalibrovat barvy zařízení, jako jsou obrazovky, kamery nebo tiskárny"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "barvy;ICC;profil;kalibrace;tiskárna;obrazovka;displej;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Ostatní…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1174,13 +728,8 @@ msgid "No languages found"
 msgstr "Žádné jazyky nebyly nenalezeny"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Více…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Odemkněte, abyste mohli měnit nastavení"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1209,154 +758,6 @@ msgstr "Ubrat hodinu"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Ubrat minutu"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "dnes"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "včera"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %B"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %B %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d hodiny"
-msgstr[1] "%d hodin"
-msgstr[2] "%d hodin"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuty"
-msgstr[1] "%d minut"
-msgstr[2] "%d minut"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekundy"
-msgstr[1] "%d sekund"
-msgstr[2] "%d sekund"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekund"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Přístupový bod"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24hodinový"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "dop./odp."
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e. %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e. %B %Y, %k:%M"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l∶%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%k∶%M"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1451,17 +852,11 @@ msgstr "Časové pás_mo automaticky"
 msgid "Requires location services enabled and internet access"
 msgstr "Vyžaduje zapnuté služby určování polohy a přístup k Internetu"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Zapnuto"
 
@@ -1469,15 +864,43 @@ msgstr "Zapnuto"
 msgid "Time Z_one"
 msgstr "Čas_ové pásmo"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Odemknout"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Formát času"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datum"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekund"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalendář"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Čísla"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Změnit datum a čas, včetně časového pásma"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "hodiny;časové pásmo;umístění;"
@@ -1523,22 +946,11 @@ msgstr "Výchozí aplikace"
 msgid "Configure Default Applications"
 msgstr "Nastavit výchozí aplikace"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "výchozí;aplikace;preferovaný;preferovaná;preferované;upřednostňovaný;"
 "upřednostňovaná;upřednostňované;média;médium;multimédia;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Díky odesílání hlášení o technických problémech se může %s vylepšovat. "
-"Hlášení jsou odesílána anonymně a jsou z nich odstraněny osobní údaje. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1556,44 +968,9 @@ msgstr "Diagnostiky"
 msgid "Report your problems"
 msgstr "Nahlásit problémy"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostika;diagnostiky;zhroucení;pád;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Zapnuto"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Vypnuto"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Použít změny?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Změny nelze použít"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Může to být dáno omezeními hardwaru."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1643,31 +1020,6 @@ msgstr "Hlavní displej"
 msgid "Night Light"
 msgstr "Noční světlo"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Na šířku"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Na výšku vpravo"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Na výšku vlevo"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Na šířku (překlopené)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1691,6 +1043,17 @@ msgstr "Přizpůsobit pro TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Škálovat"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Přirozený posuv"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1786,7 +1149,6 @@ msgstr "Displeje"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Zvolit, jak se mají používat připojené monitory a projektory"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1795,79 +1157,6 @@ msgstr ""
 "panel;projektor;xrandr;obrazovka;rozlišení;obnovovací frekvence;monitor;"
 "displej;noc;tma;světlo;modrá;červený;posuv;posun;barva;rozbřesk;soumrak;"
 "východ;západ;slunce;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "Bezpečné zavádění je aktivní"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení. V "
-"tuto chvíli je zapnuté a správně funguje."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Bezpečné zavádění má problémy"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení. V "
-"tuto chvíli je zapnuté, ale nefunguje, protože má neplatný klíč."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Problémy s bezpečným zaváděním se dají často vyřešit v nastaveních firmwaru "
-"UEFI vašeho počítače (dříve BIOS). Hledejte „Secure Boot“. Výrobce vašeho "
-"hardwaru by měl poskytovat návod, jak postupovat."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Ohledně pomoci kontaktujte výrobce vašeho hardwaru nebo poskytovatele "
-"technické podpory."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Bezpečné zavádění je vypnuté"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení. V "
-"tuto chvíli je vypnuté."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Bezpečné zavádění se obvykle zapíná v nastaveních firmwaru UEFI vašeho "
-"počítače (dříve BIOS). Hledejte „Secure Boot“. Ohledně pomoci kontaktujte "
-"výrobce vašeho hardwaru nebo poskytovatele technické podpory."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1881,131 +1170,9 @@ msgstr ""
 "Ohledně pomoci kontaktujte výrobce vašeho hardwaru nebo poskytovatele "
 "technické podpory."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Prošlo"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Selhalo"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Zařízení je v souladu s HSI úrovně %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "Úroveň zabezpečení 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Toto zařízení nemá žádnou ochranu proti hardwarovým bezpečnostním hrozbám. "
-"Může to být jen otázka nastavení hardwaru nebo firmwaru. Doporučujeme vám "
-"kontaktovat svého poskytovatele technické podpory."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "Úroveň zabezpečení 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Toto zařízení má jen minimální ochranu proti hardwarovým bezpečnostním "
-"hrozbám. Jedná se o nejnižší úroveň bezpečnosti zařízení a poskytuje ochranu "
-"jen proti jednoduchým bezpečnostním útokům."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "Úroveň zabezpečení 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Toto zařízení má základní ochranu proti hardwarovým bezpečnostním hrozbám. "
-"Ta poskytuje ochranu proti některým běžným bezpečnostním útokům."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "Úroveň zabezpečení 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Toto zařízení má rozšířenou ochranu proti hardwarovým bezpečnostním "
-"hrozbám. Jedná se o nejvyšší úroveň bezpečnosti zařízení a poskytuje ochranu "
-"i proti pokročilým bezpečnostním útokům."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "Úroveň zabezpečení"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr "Pro toto zařízení nejsou dostupné různé úrovně zabezpečení."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Kontaktujte výrobce svého hardwaru ohledně pomoci s aktualizacemi zabezpečení."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Řešení tohoto problému možná spočívá jen v nastavení firmwaru UEFI tohoto "
-"zařízení nebo by vám mohla poradit technická podpora."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Řešení tohoto problému možná spočívá jen v nastavení firmwaru UEFI tohoto "
-"zařízení."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "S řešením tohoto problému by vám mohla pomoci technická podpora."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2019,337 +1186,9 @@ msgstr "Úroveň 2"
 msgid "Level 3"
 msgstr "Úroveň 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr "Chráněno proti škodlivému softwaru při spouštění zařízení."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "Bezpečné zavádění má problémy"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "Aspoň nějaká ochrana při spouštění zařízení."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "Bezpečné zavádění je vypnuté"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "Bez ochrany při spouštění zařízení."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Tato záležitost by mohla být způsobena změnou nastavení firmwaru UEFI, změnou "
-"nastavení operačního systému nebo škodlivým softwarem v systému."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Tato záležitost by mohla být způsobena změnou nastavení firmwaru UEFI nebo "
-"škodlivým softwarem v systému."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Tato záležitost by mohla být způsobena změnou nastavení operačního systému "
-"nebo škodlivým softwarem v systému."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "Vystaveno vážným bezpečnostním hrozbám."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "Omezená ochrana proti jednoduchým bezpečnostním hrozbám."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "Ochrana proti běžným bezpečnostním hrozbám."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "Ochrana proti širokému spektru bezpečnostních hrozeb."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "Celková ochrana"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Žádné události"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Ochrana firmwaru proti zápisu"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Zámek ochryny firmwaru proti zápisu"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Oblasti firmwaru BIOS"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Oblast Descriptor firmwaru BIOS"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Ochrana DMA před zavedením systému"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Zavedení systému ověřené přes Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Itel BootGuard chráněn pomocí ACM"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Zásady pro chyby Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Jednorázový zápis Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET je povolený"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET je aktivní"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Šifrovaná RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Ochrana IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Uzamknutí linuxového jádra"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Ověřování linuxového jádra"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Odkládací oddíl Linuxu"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Uspávání do paměti"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Uspávání do nečinnosti"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI Platform Key"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI Secure Boot"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Nastavení TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Obnovení TPM PCR"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Tovární režim Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Přepisování Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Verze Intel Management Engine"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Aktualizace firmwaru"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Atestace firmwaru"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Ověřování aktualizačních modulů firmwaru"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Ladění platformy"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Bezpečnostní kontroly procesoru"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Ochrana firmwaru AMD proti návratu starších vrzí"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Ochrana firmwaru AMD proti opakovanému zápisu"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Ochrana firmwaru AMD proti zápisu"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr ""
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Platné"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Neplatné"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Není zapnuto"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Uzamknuto"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Neuzamknuto"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Šifrováno"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Nešifrováno"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Pošpiněno"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Nepošpiněno"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Nalezeno"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Nenalezeno"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Podporováno"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Nepodporováno"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2359,7 +1198,6 @@ msgstr "Zabezpečení zařízení"
 msgid "Host firmware security status"
 msgstr "Bezpečnostní stav firmwaru hostitele"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2367,49 +1205,6 @@ msgid ""
 msgstr ""
 "obrazovka;zamknout;zámek;diagnostika;pád;zhroucení;soukromý;osobní;nedávný;"
 "dočasný;tmp;index;jméno;síť;identita;soukromí;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Není známo"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64bitový"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32bitový"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "neznámý"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "nelze zjistit"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo systému"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2503,11 +1298,6 @@ msgstr "O systému"
 msgid "View information about your system"
 msgstr "Zobrazit informace o systému"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2586,6 +1376,12 @@ msgstr "Spouštěče"
 msgid "Launch help browser"
 msgstr "Spustit prohlížeč nápovědy"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Nastavení"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Spustit kalkulačku"
@@ -2607,7 +1403,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Hledat"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Systém"
 
@@ -2656,15 +1452,6 @@ msgstr "Zmenšit velikost textu"
 msgid "High contrast on or off"
 msgstr "Zapnout nebo vypnout vysoký kontrast"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Žádné vstupní zdroje nenalezeny"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Další"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Přidání vstupního zdroje"
@@ -2697,107 +1484,9 @@ msgstr "Předvolby"
 msgid "View Keyboard Layout"
 msgstr "Zobrazit rozložení klávesnice"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Odebrat"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Vlastní klávesové zkratky"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Klávesa alternativních znaků"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Klávesu alternativních znaků můžete použít, když chcete zadávat některé "
-"speciální znaky. Někdy můžete tyto znaky najít jako doplňující popisek přímo "
-"na klávesách klávesnice."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "levý Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "pravý Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "levý Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "pravý Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Mmnu"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "pravý Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Klávesa Compose umožňuje zadávání široké škály různých znaků. Používá se "
-"tak, že zmáčknete Compose a po té posloupnost znaků. Například klávesa "
-"Compse následovaná znaky <b>C</b> a <b>o</b> vloží <b>©</b>, <b>r</b> "
-"následované <b>'</b> vloží <b>ŕ</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Vstupní zdroje můžete přepínat pomocí klávesové zkratky %s.\n"
-"Tu můžete změněnit v nastavení klávesových zkratek."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2827,46 +1516,21 @@ msgstr "Psaní speciálních znaků"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Způsoby zadávání symbolů a variant písmen pomocí klávesnice."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Klávesa alternativních znaků"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Klávesové zkratky"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Zobrazit a přizpůsobit klávesové zkratky"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d změněná"
-msgstr[1] "%d změněné"
-msgstr[2] "%d změněných"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Vráti všechny klávesové zkratky na výchozí?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Vrácení klávesových zkratek na výchozí může ovlivnit vaše vlastní klávesové "
-"zkratky. A nepůjde to vrátit zpět."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Zrušit"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Všechny na výchozí"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2906,35 +1570,6 @@ msgstr "Přidat klávesovou zkratku"
 msgid "No keyboard shortcut found"
 msgstr "Nebyla nalezena žádná klávesová zkratka"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s se již používá pro činnost „%s“. Pokud ji nahradíte, bude klávesová "
-"zkratka pro činnost „%s“ zakázána."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Zadejte novou klávesovou zkratku"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Nastavení vlastní klávesové zkratky"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Nastavit zkratku"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Zadejte novou zkratku pro činnost „%s“."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Přidání vlastní klávesové zkratky"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "Odeb_rat"
@@ -2946,7 +1581,6 @@ msgstr "Na_hradit"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "Nas_tavit"
 
@@ -2983,6 +1617,11 @@ msgstr "Žádná"
 msgid "Reset the shortcut to its default value"
 msgstr "Vrátit klávesovou zkratku na výchozí"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Používat tiskárnu jako výchozí"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Klávesnice"
@@ -2995,7 +1634,6 @@ msgstr ""
 "Změnit klávesové zkratky a nastavit předvolby pro psaní, rozložení "
 "klávesnice a vstupních zdrojů."
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3038,7 +1676,6 @@ msgstr "Žádná aplikace si nepožádala o přístup k informacím o poloze"
 msgid "Protect your location information"
 msgstr "Ochraňte informace o své poloze"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "místo;poloha;pozice;gps;galileo;glonass;gnss;soukromí;"
@@ -3072,7 +1709,6 @@ msgstr "Žádná aplikace si nepožádala o přístup k mikrofonu"
 msgid "Protect your conversations"
 msgstr "Ochránit své konverzace"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofon;nahrávání;nahrávka;záznam;aplikace;soukromí;"
@@ -3102,81 +1738,139 @@ msgstr "Levé"
 msgid "Right"
 msgstr "Pravé"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Prohledávaná umístění"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Myš"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Rychlost myši"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Přirozený posuv"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Skupina"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Posouvá se obsah, a ne zobrazení."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Posouvá se obsah, a ne zobrazení."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktivní"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Rychlost touchpadu"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Kliknutí klepnutím"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Kliknutí klepnutím"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Posunování dvěma prsty"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Rychlost touchpadu"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Posunování po hraně"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Oboustrannost"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Zkuste jednoduché a dvojité kliknutí a posouvání"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Pětiklepnutí – čas na GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dvojité kliknutí, hlavní tlačítko"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Kliknutí, hlavní tlačítko"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dvojité kliknutí, prostřední tlačítko"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Kliknutí, prostřední tlačítko"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dvojité kliknutí, vedlejší tlačítko"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Kliknutí, vedlejší tlačítko"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3189,7 +1883,6 @@ msgstr ""
 "Změnit citlivost myši nebo touchpadu a vybrat ovládání pro praváky nebo "
 "leváky"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3271,7 +1964,6 @@ msgstr "Multitasking"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Správa předvoleb pro produktivitu a multitasking"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3279,20 +1971,11 @@ msgstr ""
 "multitasking;multitask;více úkolů;více úloh;produktivita;přizpůsobit;"
 "přizpůsobení;desktop;citlivý roh;pracovní plochy;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Problém, něco se stalo špatně. Kontaktujte prosím vyrobce softwaru."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Je zapotřebí, aby běžel program NetworkManager."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Ostatní zařízení"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3304,59 +1987,16 @@ msgstr "Přidat připojení"
 msgid "Not set up"
 msgstr "Nenastaveno"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Nezabezpečená síť (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Zabezpečená síť (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Zabezpečená síť (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Zabezpečená síť (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Zabezpečená síť"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Připojeno"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Volby…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Zapnutí přístupového bodu způsobí odpojení od sítě %s a nebudete moci "
-"přistupovat do Internetu přes Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Musí mít nejméně 8 znaků"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3408,20 +2048,6 @@ msgstr "automaticky vygenerované heslo"
 msgid "_Turn On"
 msgstr "Zapnou_t"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Zastavit přístupový bod a odpojit případné uživatele?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "Za_stavit přístupový bod"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Režim „Letadlo“"
@@ -3466,90 +2092,13 @@ msgstr "Viditelné sítě"
 msgid "NetworkManager needs to be running"
 msgstr "Je zapotřebí, aby běžel program NetworkManager"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Problém, něco se stalo špatně. Kontaktujte prosím vyrobce softwaru."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Zabezpečení 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Zabezpečení"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "současná"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "trvalá"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "náhodná"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "stabilní"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Zde zadaná adresa MAC bude použita jako hardwarová adresa pro síťové "
-"zařízení, na kterém je toto připojení aktivováno. Funkcionalita se nazývá "
-"klonování MAC nebo spoofing. Příklad: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Podnikové"
-
-# Zabezpečení
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Žádné"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "nikdy"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3560,186 +2109,6 @@ msgstr[0] "před %i dnem"
 msgstr[1] "před %i dny"
 msgstr[2] "před %i dny"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-# Síla signálu
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Žádná"
-
-# Síla signálu
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Slabá"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Dostačující"
-
-# Síla signálu
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Dobrá"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Výborná"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Adresa IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Adresa IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Adresa IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Zapomenout připojení"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Odebrat profil připojení"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Odebrat VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Podrobnosti"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automaticky"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identita"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Smazat adresu"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Smazat směrování"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Žádné"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP, 40/128bitový klíč (Hex nebo ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP, 128bitová heslová fráze"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamické WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA a WPA2, osobní"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA a WPA2, podnikové"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3, osobní"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3749,8 +2118,20 @@ msgstr "Síla signálu"
 msgid "Link speed"
 msgstr "Rychlost spojení"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Zabezpečení"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Adresa IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adresa IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hardwarová adresa"
 
@@ -3759,12 +2140,17 @@ msgid "Supported Frequencies"
 msgstr "Podporované frekvence"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Výchozí směrování"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3827,7 +2213,7 @@ msgstr "Pouze link-local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Ruční"
 
@@ -3871,9 +2257,8 @@ msgstr "Brána"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automatické"
 
@@ -3926,89 +2311,9 @@ msgstr "Automatické, pouze DHCP"
 msgid "Prefix"
 msgstr "Prefix"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Nelze otevřít editor připojení"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Nový profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Neplatné nastavení %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Neplatné nastavení %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importovat ze souboru…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Přidání VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Zab_ezpečení"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Nelze importovat připojení VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Soubor „%s“ nelze přečíst nebo neobsahuje rozpoznatelné informace o "
-"připojení VPN\n"
-"\n"
-"Chyba: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Výběr souboru pro import"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Soubor s názvem „%s“ již existuje."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Nahradit"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Chcete nahradit %s připojením VPN, které ukládáte?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Nelze exportovat připojení VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Připojení VPN „%s“ nemůže být exportováno do %s.\n"
-"\n"
-"Chyba: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Exportovat připojení VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4022,101 +2327,38 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Síť"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Určit, jak se připojujete k Internetu"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "síť;IP;LAN;proxy;WAN;širokopásmové;připojení;modem;Bluetooth;vpn;dns;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Určit, jak se připojujete k sítím Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "síť;bezdrátové;bezdrátová;Wi-Fi;WiFi;drátové;drátová;IP;LAN;širokopásmové;"
 "připojení;dns;přístupový bod;hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nikdy"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "dnes"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "včera"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Naposledy použito"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Drátová"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Přidat nové připojení"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Informace o síti pro vybrané sítě, včetně hesel a vlastního nastavení, budou "
-"ztraceny."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Zapomenout"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Známé sítě Wi-Fi"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Zapomenout"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Systémová zásada zakazuje použití jako přístupový bod"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Bezdrátové zařízení nepodporuje režim přístupového bodu"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Pokud není adresa URL pro nastavení poskytnuta, použije se automatické "
-"vyhledání webové proxy."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Nedoporučuje se v nedůvěryhodných veřejných sítích."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4135,6 +2377,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Poskytovatel"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adresa IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4219,289 +2465,6 @@ msgstr "Zapnou_t bezdrátový přístupový bod…"
 msgid "_Known Wi-Fi Networks"
 msgstr "Známé sítě Wi-_Fi"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Neznámý stav"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Nespravováno"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Nedostupné"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Připojuje se"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Požadována autentizace"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Odpojuje se"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Připojení selhalo"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Neznámý stav (chybí)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Nastavení selhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Nastavení IP selhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Konfigurace IP vypršela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Hesla byla požadována, ale neposkytnuta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Žadatel 802.1x odpojen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Konfigurace žadatele 802.1x selhala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Žadatel 802.1x selhal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Žadateli 802.1x trvalo ověření příliš dlouho"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Spuštění služby PPP selhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Služba PPP odpojena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP selhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Spuštění klienta DHCP selhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Chyba klienta DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Klient DHCP selhal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Spuštění služby sdíleného připojení selhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Služba sdíleného připojení selhala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Spuštění služby AutoIP selhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Chyba služby AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Služba AutoIP selhala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linka obsazena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Žádný vytáčecí tón"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Nelze navázat spojení"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Požadavek na vytáčení vypršel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Pokus o vytáčení selhal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Inicializace modemu selhala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Výběr zvoleného APN selhal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Nevyhledávají se sítě"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Registrace do sítě zamítnuta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Registrace do sítě vypršela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Registrace do požadované sítě selhala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Ověření PIN selhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Firmware zařízení nejspíše chybí"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Připojení bylo ztraceno"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Existující spojení bylo převzato"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem nenalezen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Připojení Bluetooth selhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Karta SIM není vložena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Požadován PIN karty SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Požadován PUK karty SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Chybná SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Závislost připojení selhala"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Schází firmware"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Odpojen kabel"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "nedefinovaná chyba v zabezpečení 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "není vybrán žádný soubor"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "blíže neurčená chyba při ověřování souboru s metodou eap"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Soukromé klíče DER, PEM, PKCS#12 nebo PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Certifikáty DER nebo PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "schází soubor EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Soubory PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4550,14 +2513,6 @@ msgstr "_Interní ověření totožnosti"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Umožnit automatické _zajišťování PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "chybí uživatelské jméno pro EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "chybí heslo pro EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4583,17 +2538,6 @@ msgstr "_Heslo"
 msgid "Sho_w password"
 msgstr "Zobrazit he_slo"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "neplatný certifikát EAP-PEAP certifikační autority: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-"neplatný certifikát EAP-PEAP certifikační autority: žádný certifikát není "
-"zadán"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4615,7 +2559,6 @@ msgid "C_A certificate"
 msgstr "Certifikát C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4630,65 +2573,6 @@ msgstr "_Certifikát CA není požadován"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Verze PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "chybí uživatelské jméno pro EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "chybí heslo pro EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "chybí identita pro EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "neplatný certifikát EAP-TLS certifikační autority: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-"neplatný certifikát EAP-TLS certifikační autority: žádný certifikát není "
-"zadán"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "neplatný soukromý klíč pro EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "neplatný uživatelský certifikát pro EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Nešifrované soukromé klíče nejsou bezpečné"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Vypadá to, že vybraný soukromý klíč není chráněný heslem.  To může způsobit, "
-"že vaše bezpečnostní údaje budou kompromitovány. Vyberte prosím soukromý "
-"klíč chráněný heslem.\n"
-"\n"
-"(Soukromý klíč můžete zabezpečit heslem pomocí openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Vyberte svůj osobní certifikát"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Vyberte svůj soukromý klíč"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4705,17 +2589,6 @@ msgstr "Soukromý _klíč"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Heslo k _soukromému klíči"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "neplatný certifikát EAP-TTLS certifikační autority: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-"neplatný certifikát EAP-TTLS certifikační autority: žádný certifikát není "
-"zadán"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4738,14 +2611,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Doména"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Neznámá chyba při ověřování zabezpečení 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4773,60 +2647,10 @@ msgstr "Chráněné EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Ověření totožnosti"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Vybrat soubor"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "chybí uživatelské jméno pro LEAP"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "chybí heslo pro LEAP"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Schází heslo k Wi-Fi."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Typ"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "chybí klíč WEP"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"neplatný klíč WEP: klíč s délkou %zu musí obsahovat jen šestnáctkové číslice"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"neplatný klíč WEP: klíč s délkou %zu musí obsahovat jen znaky sady ASCII"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"neplatný klíč WEP: nesprávná délka klíče %zu. Klíč musí mít délku 5/13 "
-"(ASCII) nebo 10/26 (HEX)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "neplatný klíč WEP: heslová fráze nesmí být prázdná"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "neplatný klíč WEP: heslová fráze musí být kratší než 64 znaků"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4851,20 +2675,6 @@ msgstr "Z_obrazit klíč"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Inde_x WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"neplatný osobní klíč WPA: neplatná délka klíče %zu. Musí být [8,63] bajtů "
-"nebo 64 šestnáctkový číslic"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"neplatný osobní klíč WPA: nelze zpracovat klíč s 64 bajty jako šestnáctkový"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4919,27 +2729,9 @@ msgstr "Upozornění na za_mykací obrazovce"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Spravovat to, jak jsou upozornění zobrazována a co ukazují"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "upozornění;proužek;zpráva;oblast;pruh;cedule;baner;banner;vyskakovací;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Jiný"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s byl odebrán"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Chyba při odebírání účtu"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4964,17 +2756,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Přidat účet"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Účet %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Odebrat účet"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Účty on-line"
@@ -4983,10 +2764,6 @@ msgstr "Účty on-line"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Přihlaste se k účtům on-line a rozhodněte se, k čemu je používat"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4994,10 +2771,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;web;on-line;diskuze;chat;kalendář;e-mail;mail;"
 "email;pošta;kontakt;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Neznámý čas"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5015,13 +2788,6 @@ msgstr[0] "%i hodina"
 msgstr[1] "%i hodiny"
 msgstr[2] "%i hodin"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5035,189 +2801,6 @@ msgid_plural "minutes"
 msgstr[0] "minuta"
 msgstr[1] "minuty"
 msgstr[2] "minut"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s do plného nabití"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Pozor, zbývá %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Zbývá %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Plně nabito"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Nenabíjí se"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Vybitá"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Nabíjí se"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Vybíjí se"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Bezdrátová myš"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Bezdrátová klávesnice"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Záložní zdroj napájení"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Osobní digitální asistent (PDA)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobilní telefon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Multimediální přehrávač"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Počítač"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Herní vstupní zařízení"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Baterie"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Hlavní"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Přídavná"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Baterie"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Při _nečinnosti"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Uspat do paměti"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Vypnout"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Uspat na disk"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nic nedělat"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Při napájení z baterie"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Při napájení ze sítě"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nikdy"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automaticky uspat"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Režim vysokého výkonu byl dočasně vypnut z důvodu zvýšené operační teploty."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Pravděpodobně máte počítač na klíně, proto není režim vysokého výkonu "
-"dočasně k dispozici. Přesuňte zařízení na stabilní povrch, aby se obnovil."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Režim vysokého výkonu je dočasně zakázaný."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Nízký stav baterie: zapnuto šetření energií. Předchozí režim bude obnoven, "
-"jakmile se baterie dostatečně nabije."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Režim úspory energie byl aktivován aplikací „%s“."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Režim vysokého výkonu byl aktivován aplikací „%s“."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5278,6 +2861,15 @@ msgstr "100 minut"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 hodin"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterie"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Zařízení"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5356,33 +2948,6 @@ msgstr "_Při napájení z baterie"
 msgid "Delay"
 msgstr "Po uplynutí"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Vysoký výkon"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Vysoký výkon za cenu vyšší spotřeby energie."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Rovnováha"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standardní výkon i spotřeba energie."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Šetření energií"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Šetří energii za cenu sníženého výkonu."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Napájení"
@@ -5391,7 +2956,6 @@ msgstr "Napájení"
 msgid "View your battery status and change power saving settings"
 msgstr "Zobrazit stav baterie a změnit nastavení šetření energií"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5399,27 +2963,6 @@ msgid ""
 msgstr ""
 "napájení;uspání;uspání do paměti;uspání na disk;baterie;jas;ztlumit;monitor;"
 "DPMS;neaktivní;energie;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Tiskárna „%s“ byla odebrána"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Selhalo přidání nové tiskárny."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Nelze načíst uživatelské rozhraní: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Odemkněte, abyste mohli přidávat tiskárny a měnit nastavení"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5431,7 +2974,6 @@ msgstr ""
 "Přidejte tiskárny, prohlédněte si tiskové úlohy a rozhodněte, jak chcete "
 "tisknout"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "tiskárna;fronta;tisk;papír;inkoust;toner;"
@@ -5439,8 +2981,6 @@ msgstr "tiskárna;fronta;tisk;papír;inkoust;toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Přidat tiskárnu"
 
@@ -5481,29 +3021,6 @@ msgstr ""
 msgid "Username"
 msgstr "Uživatelské jméno"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Podrobnosti o tiskárně %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Nenalezen vyhovující ovladač"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Vyberte soubor PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Soubory popisu tiskárny PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Název tiskárny nesmí obsahovat mezeru, tabulátor, # nebo /"
@@ -5512,9 +3029,7 @@ msgstr "Název tiskárny nesmí obsahovat mezeru, tabulátor, # nebo /"
 msgid "Location"
 msgstr "Umístění"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Ovladač"
 
@@ -5542,121 +3057,14 @@ msgstr "Vyberte ovladač tiskárny"
 msgid "Loading drivers database…"
 msgstr "Načítá se databáze ovladačů…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Zrušit"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Vybrat"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Tiskárna JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Tiskárna LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Jednostranně"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Delší okraj (standardní)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Kratší okraj (obráceno)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Na výšku"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Na šířku"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Obráceně na šířku"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Obráceně na výšku"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Pokračovat"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pozastavit"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Čeká"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pozastaveno"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Požadováno ověření"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Zpracovává se"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Zastaveno"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Zrušeno"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Přerušeno"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Dokončeno"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Přesunout tuto úlohu na začátek fronty"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5664,19 +3072,6 @@ msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u úloha vyžaduje ověření"
 msgstr[1] "%u úlohy vyžadují ověření"
 msgstr[2] "%u úloh vyžaduje ověření"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s – aktivní úlohy"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Zadejte pověření pro tisk z tiskárny %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5704,207 +3099,11 @@ msgstr "_Ověřit"
 msgid "No Active Printer Jobs"
 msgstr "Nejsou žádné aktivní tiskové úlohy"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Odemknout tiskový server"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Odemknout server %s"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Chcete-li vidět tiskárny ze serveru %s, zadejte uživatelské jméno a heslo."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Vyhledávají se tiskárny"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Sériový port"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Paralelní port"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Umístění: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adresa: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Server požaduje ověření totožnosti"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Oboustranně"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Typ papíru"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Zdroj papíru"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Výstupní zásobník"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Rozlišení"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Předfiltrování GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Stránek na stranu papíru"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Oboustrannost"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientace"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Obecné"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Vzhled strany"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Volitelné doplňky"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Úloha"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Kvalita obrazu"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Barevnost"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Dokončení"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Pokročilé"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testovací stránka"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Testovací stránka"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Vybrat automaticky"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Výchozí nastavení tiskárny"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Zahrnout pouze písma GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Převést na PostScript úrovně 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Převést na PostScript úrovně 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Bez předfiltrování"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Výrobce"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Nejsou žádné aktivní úlohy"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5912,115 +3111,6 @@ msgid_plural "%u Jobs"
 msgstr[0] "%u úloha"
 msgstr[1] "%u úlohy"
 msgstr[2] "%u úloh"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Čištění tiskových hlav"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Dochází toner"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Došel toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Životnost vývojové jednotka se blíží ke konci"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Opotřebená vývojová jednotka"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Životnost zásobníku se blíží ke konci"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Opotřebený zásobník"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Otevřen kryt"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Otevřena dvířka"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Dochází papír"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Došel papír"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Off-line"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Zastaveno"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Odpadní nádobka je téměř plná"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Odpadní nádobka je plná"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Životnost optického válce se blíží ke konci"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Optický válec není nadále funkční"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Připraveno"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Nepřijímá úlohy"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Zpracovává se"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6044,6 +3134,10 @@ msgstr "Vyčistit tiskové hlavy"
 msgid "Remove Printer"
 msgstr "Odebrat tiskárnu"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nejsou žádné aktivní úlohy"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6064,16 +3158,21 @@ msgid "Restart"
 msgstr "Restartovat"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Přidat tiskárnu…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Přidat tiskárnu…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Žádné tiskárny"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6081,7 +3180,6 @@ msgstr ""
 "Bohužel to vypadá, že systémová\n"
 "   služba tisku není dostupná."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formáty"
@@ -6109,16 +3207,6 @@ msgstr "Hledat můžete země nebo jazyky."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Náhled"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperiální"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrické"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6156,20 +3244,24 @@ msgstr ""
 "Nastavení jazyka se používá pro texty uživatelského rozhraní a webové "
 "stránky. Formát se používá pro čísla, data a měny."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Váš účet"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "Jazy_k"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formáty"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Přihlašovací obrazovka"
 
@@ -6181,100 +3273,9 @@ msgstr "Region a jazyk"
 msgid "Select your display language and formats"
 msgstr "Vybrat jazyk a formáty pro zobrazení"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "jazyk;rozložení;klávesnice;vstup;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Zeptat se na další postup"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Nic nedělat"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Otevřít složku"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Ostatní média"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Vyberte aplikaci pro zvuková CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Vyberte aplikaci pro DVD s videem"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Vyberte aplikaci, která má být spuštěna po připojení hudebního přehrávače"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Vyberte aplikaci, která má být spuštěna po připojení fotoaparátu"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Vyberte aplikaci pro CD se softwarem"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "zvukové DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "prázdný disk Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "prázdný disk CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "prázdný disk DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "prázdný disk HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "videodisk Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "čtečka elektronických knih"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "videodisk HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Software Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6324,7 +3325,6 @@ msgstr "Výměnná média"
 msgid "Configure Removable Media settings"
 msgstr "Nastavte si pravidla pro výměnná média"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6333,114 +3333,6 @@ msgstr ""
 "zařízení;systém;výchozí;aplikace;preferovaný;preferovaná;upřednostňovaný;"
 "upřednostňovaná;cd;dvd;usb;zvuk;audio;video;disk;výměnný;výměnná;výměnné;"
 "vyměnitelný;vyměnitelná;vyměnitelné;média;médium;automatické spuštění;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "ihned po zčernání"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "po 30 sekundách"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "po 1 minutě"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "po 2 minutách"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "po 3 minutách"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "po 5 minutách"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "po 30 minutách"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "po 1 hodině"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "po 1 minutě"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "po 2 minutách"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "po 3 minutách"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "po 4 minutách"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "po 5 minutách"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "po 8 minutách"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "po 10 minutách"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "po 12 minutách"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "po 15 minutách"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "nikdy"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6479,11 +3371,16 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "Zobrazovat upozor_nění na uzamknuté obrazovce"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Upozornění na za_mykací obrazovce"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Zakázat nová zařízení _USB"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6491,30 +3388,25 @@ msgstr ""
 "Zabránit novému zařízení USB ve spolupráci se systémem, kdež je uzamknutá "
 "obrazovka."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Soukromí obrazovky"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Omezit úhel viditelnosti"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Obrazovka"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Nastavení obrazovky"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "obrazovka;zámek;zamknutí;zamčení;uzamknutí;uzamčení;soukromí;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Vyberte umístění"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Budiž"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6545,10 +3437,6 @@ msgstr "Ostatní"
 msgid "Add Location"
 msgstr "Přidat umístění"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nenalezeny žádné aplikace"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Hledat pomocí aplikací"
@@ -6576,93 +3464,13 @@ msgstr ""
 "Ovládejte, které aplikace mohou zobrazovat výsledky hledání v přehledu "
 "Činnosti"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "hledání;hledat;najít;index;skrýt;soukromí;privátní;výsledky;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Nebyly zvoleny žádné sítě pro sdílení"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Sítě"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Zapnuto"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Vypnuto"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Zapnuto"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktivní"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Výběr složky"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Přidat"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Povolit sdílení multimédií"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Sdílení souborů vám umožňuje sdílet složku Veřejné s ostatními v aktuální "
-"síti pomocí: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Když je vzdálené přihlašování povolené, mohou se vzdálení uživatelé připojit "
-"příkazem Secure Shell:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Povolit sdílení osobních multimédií"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Byl zkopírován název zařízení"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Byla zkopírována adresa zařízení"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Bylo zkopírováno uživatelské jméno"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Bylo zkopírováno heslo"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6795,7 +3603,6 @@ msgstr "Složky"
 msgid "Control what you want to share with others"
 msgstr "Určete, co chcete sdílet s ostatními"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6814,10 +3621,6 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Pro povolení nebo zakázání vzdáleného přihlášení je vyžadováno ověření "
 "totožnosti"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Vlastní"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6850,11 +3653,6 @@ msgstr "Zadní"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Přední"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Testuje se %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6908,11 +3706,6 @@ msgstr "Hlasitost"
 msgid "Alert Sound"
 msgstr "Zvuk upozornění"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Ztišit"
@@ -6925,83 +3718,12 @@ msgstr "Zvuk"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Změnit hlasitost zvuku, vstupy, výstupy a upozornění"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "karta;mikrofon;hlasitost;prolínání;vyvážení;bluetooth;náhlavní souprava;zvuk;"
 "výstup;vstup;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Odpojeno"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Připojuje se"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Připojeno"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Chyba ověřování"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Ověřuje se"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Omezená funkcionalita"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Připojeno a ověřeno"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Neznámý"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Ověřeno:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Připojeno:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Registrováno:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Selhalo ověření zařízení: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Zapomenutí zařízení selhalo: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7036,57 +3758,6 @@ msgstr "Ověřit a připojit"
 msgid "Forget Device"
 msgstr "Zapomenout zařízení"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Chyba"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Ověřeno"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Subsystém Thunderbolt (boltd) není nainstalovaný, nebo není správně "
-"nastavený."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Umožňuje přímý přístup k zařízením, jako jsou dokovací stanice nebo externí "
-"GPU."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Připojeny mohou být jen zařízení USB a Display Port."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt se nezdařilo nalézt.\n"
-"Buď systém postrádá podporu pro Thunderbolt, nebo je vypnutá přes BIOS, nebo "
-"je v něm nastavená nepodporovaná úroveň zabezpečení."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Podpora pro Thunderbolt je vypnutá přes BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Úroveň zabezpečení zařízení Thunderbolt nemohla být určena."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Chyba při přepínání přímého režimu: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Bez podpory pro Thunderbolt"
@@ -7098,6 +3769,12 @@ msgstr "Nezdařilo se připojit k subsystému thunderbolt."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Přímý přístup"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Umožňuje přímý přístup k zařízením, jako jsou dokovací stanice nebo externí "
+"GPU."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7115,7 +3792,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Spravujte zařízení Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;soukromí;"
@@ -7317,41 +3993,6 @@ msgstr "Zapnout z kláv_esnice"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Zapínat funkce zpřístupnění pomocí klávesnice"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Výchozí"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Střední"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Velký"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Větší"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Největší"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixely"
-msgstr[2] "%d pixelů"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Vždy zobr_azovat nabídku přístupnosti"
@@ -7466,31 +4107,6 @@ msgstr "Bliknout _celou obrazovkou"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Bliknout _celým oknem"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Krátká"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ obrazovky"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ obrazovky"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ obrazovky"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Dlouhá"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7647,7 +4263,6 @@ msgstr "Ovlivnění barev"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Usnadněte si čtení, poslech, psaní, klikání a další činnosti"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7661,114 +4276,6 @@ msgstr ""
 "prstem;pomalé klávesy;vícenásobná zmáčknutí kláves;klávesnice myší;dvojitý;"
 "klik;kliknutí;klepnutí;poklepání;prodleva;rychlost;asistent;opakování;"
 "blikání;blikat;poruchy;handicap;vidění;sluch;psaní;animace;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 hodině"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dnech"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dnech"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dnech"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dnech"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dnech"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dnech"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dnech"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dnech"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Vysypat všechny položky z koše?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Všechny položky v koši budou trvale smazány."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Vyprázdnit koš"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Odstranit dočasné soubory?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Všechny dočasné soubory budou trvale smazány."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Odstranit dočasné soubor_y"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 den"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dní"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dní"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "napořád"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7836,65 +4343,12 @@ msgstr "Historie souborů a koš"
 msgid "Don't leave traces"
 msgstr "Nezanechávejte po sobě stopy"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "využití;nedávný;nedávné;historie;soubory;dočasné;dočasný;tmp;soukromí;koš;"
 "vysypat;smazat;mazat;zachovat;uchování;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr ""
-"Mělo by se shodovat s webovou adresou poskytovatele vašeho přihlašování."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Přidání účtu selhalo"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Hesla si neodpovídají."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Registrace účtu selhala"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Ověření s touto doménou není podporováno"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Připojení k doméně selhalo"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Toto přihlašovací jméno nefunguje.\n"
-"Zkuste to, prosím, znovu."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Toto přihlašovací heslo nefunguje.\n"
-"Zkuste to, prosím, znovu."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Přihlášení do domény selhalo"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Nelze najít doménu. Nemáte v názvu překlep?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7946,10 +4400,6 @@ msgstr ""
 "Přihlašování do domény umožňuje použít na tomto zařízení stávající centrálně "
 "spravované uživatelské účty. Tento účet můžete pak použít i pro přístup k "
 "firemním prostředkům na Internetu."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Procházet další obrázky"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8020,222 +4470,6 @@ msgstr "_Smazat otisky prstů"
 msgid "Fingerprint Enroll"
 msgstr "Sejmutí otisku prstu"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "k provedení této činnosti je potřeba výhradní přístup k zařízení"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "zařízení si již nárokuje jiný proces"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "nemáte oprávnění provádět tuto činnost"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "nebyl sejmut žádný otisk prstu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Selhala komunikace se zařízením během snímání otisku prstu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Selhala komunikace se čtečkou otisků prstů"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Selhala komunikace s démonem pro otisky prstů"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Selhalo vypsání otisku prstů: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Selhalo smazání uložených otisků prstů: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Palec levé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Prostředníček levé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Ukazováček _levé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Prsteníček levé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Malíček levé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Palec pravé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Prostředníček pravé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Ukazováček p_ravé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Prsteníček pravé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Malíček pravé ruky"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Neznámý otisk prstu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Dokončeno"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Čtečka otisků prstů je odpojená"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Úložiště čtečky otisku prstů je plné"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Selhalo sejmutí nového otisku prstu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Selhalo započetí snímání: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Selhalo sejmutí nového otisku prstu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Selhalo zastavení snímání: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Opakovaně zvedněte a přiložte svůj prst ke čtečce, aby se mohl sejmout otisk "
-"prstu."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Znovu sejmout tento otisk p_rstu…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Sejmout nový otisku prstu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Selhalo uvolnění čtečky otisku prstu %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problém při čtení ze zařízení"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Selhalo vyžádání čtečky otisku prstu %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Selhalo získání čtečky otisku prstu: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Tento týden"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Minulý týden"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %B"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %B %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sezení ukončeno"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sezení započato"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s – Aktivita účtu"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Předchozí"
@@ -8243,18 +4477,6 @@ msgstr "Předchozí"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Následující"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Zvolte prosím jiné heslo."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Zadejte prosím své současné heslo ještě jednou."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Heslo nelze změnit"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8276,6 +4498,10 @@ msgstr "Nové heslo"
 msgid "Confirm Password"
 msgstr "Potvrzení hesla"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Hesla si neodpovídají."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Nabídnout uživateli změnu jeho hesla při příštím přihlášení"
@@ -8283,136 +4509,6 @@ msgstr "Nabídnout uživateli změnu jeho hesla při příštím přihlášení"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Nastavit heslo nyní"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Nelze se automaticky připojit k tomuto typu domény"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Doména nebyla nalezena"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Nelze se přihlásit jako „%s“ v doméně „%s“"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Neplatné heslo, zkuste to, prosím, znovu"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Nelze se připojit k doméně „%s“: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Selhalo smazání účtu"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Selhalo zneplatnění vzdáleně spravovaného uživatele"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Nemůžete smazat svůj vlastní účet."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "Uživatel %s je doposud přihlášen"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Smazání účtu, zatímco je dotyčný uživatel přihlášen, může přivést systém do "
-"nekonzistentního stavu."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Chcete zachovat soubory uživatele %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Je možné zachovat domovskou složku, poštovní schránku a dočasné soubory, i "
-"když bude uživatelský účet smazán."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "O_dstranit soubory"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "Zacho_vat soubory"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Opravdu chcete zneplatnit vzdáleně spravovaný účet uživatele %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "O_dstranit"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Účet zakázán"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Bude nastaveno při příštím přihlášení"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Žádné"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "právě přihlášený"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Selhalo kontaktování účtovací služby"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Zkontrolujte prosím, že je účtovací služba AccountService nainstalovaná a "
-"zapnutá."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Abyste mohli měnit nastavení, je panel zapotřebí odemknout"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Odstranit vybraný uživatelský účet"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Pro odstranění uživatelského účtu\n"
-"nejprve klikněte na ikonu *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Odemkněte, abyste mohli přidávat uživatele a měnit nastavení"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8440,7 +4536,6 @@ msgid "Full name"
 msgstr "Celé jméno"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Upravit"
 
@@ -8502,7 +4597,6 @@ msgstr "Odemkněte, abyste mohli přidat účet."
 msgid "Add or remove users and change your password"
 msgstr "Přidat nebo odebrat uživatele a změnit heslo"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8548,178 +4642,6 @@ msgstr "Správa uživatelských účtů"
 msgid "Authentication is required to change user data"
 msgstr "Ke změně uživatelských dat je vyžadováno ověření."
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Nové heslo se musí lišit od toho starého."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Zkuste změnit některá písmena a číslice."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Zkuste změnit heslo trochu víc."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Heslo bez vašeho uživatelského jména by bylo silnější."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Zkuste se vyhnout použití svého jména v heslu."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Zkuste se vyhnout použití některých slov v hesle."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Zkuste se vyhnout běžným slovům."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Zkuste se vyhnout změně pořadí stávajících slov."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Zkuste použít víc číslic."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Zkuste použít víc velkých písmen."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Zkuste použít víc malých písmen."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Zkuste použít více speciálních znaků, jako jsou interpunkční znaménka."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Zkuste použít směs písmen, číslic a interpunkčních znamének."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Zkuste se vyhnout opakování stejného znaku."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Zkuste se vyhnout opakování stejného typu znaků: měli byste kombinovat "
-"písmena, čísla a interpunkční znaménka."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Zkuste se vyhnout sekvencím, jako je 1234 nebo abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Heslo musí být delší. Zkuste přidat další písmena, číslice a interpunkční "
-"znaménka."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Zkombinujte velká a malá písmena a zkuste použít jednu či dvě číslice."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Přidáním dalších písmen, číslic a interpunkčních znamének můžete heslo ještě "
-"dále zesílit."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Autentizace selhala"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Nové heslo je příliš krátké"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Nové heslo je příliš jednoduché"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Nové heslo je příliš podobné starému"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Stejné heslo, jako nové, bylo použito nedávno."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Nové heslo musí obsahovat číslice nebo speciální znaky."
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Staré a nové heslo jsou stejné"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Vaše heslo se od vaší prvotní autentizace změnilo!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Nové heslo neobsahuje dostatek různorodých znaků"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Neznámá chyba"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Uživatelské jméno se musí obvykle skládat jen z malých písmen a-z, číslic a "
-"následujících znaků: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Toto uživatelské jméno není bohužel dostupné. Zkuste prosím jiné."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Uživatelské jméno je příliš dlouhé."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8754,52 +4676,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Zjištěno chybějící kliknutí, začíná se znovu…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Tlačítko %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Definováno aplikací"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Vyvolat klávesovou zkratku"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Přepnout obrazovku"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Zobrazit nápovědu na obrazovce"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Grafický tablet osazený na displeji notebooku"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Grafický tablet osazený na externím displeji"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Externí grafický tablet"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr ""
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Všechny displeje"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8897,22 +4777,6 @@ msgstr "Kliknutí pravým tlačítkem myši"
 msgid "Forward"
 msgstr "Vpřed"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Stylus Airbrush citlivý na přítlak, sklon a s integrovaným kolečkem"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Stylus Airbrush citlivý na přítlak, sklon a natočení"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standardní stylus citlivý na přítlak a sklon"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standardní stylus citlivý na přítlak"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Grafický tablet"
@@ -8921,54 +4785,96 @@ msgstr "Grafický tablet"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Nastavit mapování tlačítek a přizpůsobit citlivost grafických tabletů"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "tablet;Wacom;stalus;pero;eraser;guma;myš;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Nová klávesová zkratka…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulované druhé kliknutí"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Software Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Dochází toner"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Zpoždění druhého kliknutí"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Software Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Správa předvoleb pro produktivitu a multitasking"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Přístupové body"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Přidat"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Uložit"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operace zrušena"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Chyba:</b> Zamítnut přístup ke změnám nastavení"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Chyba:</b> Chyba mobilního zařízení"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Nezaregistrováno"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Zaregistrováno"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Vyhledává se"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Odepřeno"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8998,212 +4904,13 @@ msgstr "Vlastní číslo"
 msgid "Device Details"
 msgstr "Podrobnosti o zařízení"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Výrobce"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Verze firmwaru"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "pouze 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "pouze 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "pouze 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "pouze 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (preferovaná), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (preferovaná), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (preferovaná), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (preferovaná), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (preferovaná), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (preferovaná), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (preferovaná), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (preferovaná), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (preferovaná), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (preferovaná), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (preferovaná), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G, 4G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (preferovaná), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (preferovaná), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (preferovaná), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (preferovaná), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (preferovaná)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (preferovaná), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "neznámý"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Odemknutí karty SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Odemknout"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Zadejte prosím kód PIN pro SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Zadejte PIN pro odemknutí své karty SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Zadejte prosím kód PUK pro SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Zadejte PUK pro odemknutí své karty SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9220,26 +4927,6 @@ msgid_plural "You have %u tries left"
 msgstr[0] "Zbývá vám %u pokus"
 msgstr[1] "Zbývají vám %u pokusy"
 msgstr[2] "Zbývá vám %u pokusů"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Bylo zadáno nesprávné heslo."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Kód PUK by měl mít 8 číslic"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Zadejte nový PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Kód PIN by měl mít 4 až 8 číslic"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Odemyká se…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9297,94 +4984,6 @@ msgstr "Uzamknutí SIM pomocí PIN"
 msgid "M_odem Details"
 msgstr "P_odrobnosti o modemu"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Telefon selhal"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Není spojení s telefonem"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operace není povolena"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operace není podporována"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Karta SIM není vložena"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Požadován kód PIN pro SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Požadován kód PUK pro SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "karta SIM selhala"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Karta SIM je zaneprázdněna"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Nesprávné heslo"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Požadován kód PIN2 pro SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Požadován kód PUK2 pro SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Nenalezeno"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Žádná síťová služba"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Síť neodpověděla"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Služby GPRS nejsou povoleny"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "V této oblasti není povolen roaming"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Nespecifikovaná chyba GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Bez chyb"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Činnost byla zrušena"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Přístup byl zamítnut"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Neznámá chyba"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Režim sítě"
@@ -9400,11 +4999,6 @@ msgstr "Zvolte síť"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Aktualizovat poskytevatele sítí"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9462,7 +5056,6 @@ msgstr "Mobilní síť"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Nastavte si telefonní a mobilní datová připojení"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "celulární;wwan;telefon;telefonie;sim;karta;mobil;mobilní;"
@@ -9479,41 +5072,13 @@ msgstr "Aplikace Nastavení je hlavním rozhraním pro nastavení vašeho systé
 msgid "The GNOME Project"
 msgstr "Projekt GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Zobrazit číslo verze"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Zapnout podrobný režim"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Hledat řetězec"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Vypsat všechny možné názvy panelů a skončit"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel, který se má zobrazit"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Kategorie nastavení"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Soukromí"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Dostupné panely:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9570,7 +5135,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Zrušit vyhledávání"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "předvolby;nastavení;"
@@ -9609,8 +5173,6 @@ msgid ""
 msgstr ""
 "N-tice obsahující počáteční šířku, výšku a stav maximalizace okna s aplikací."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9619,8 +5181,6 @@ msgstr[0] "%u výstup"
 msgstr[1] "%u výstupy"
 msgstr[2] "%u výstupů"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9629,6 +5189,3134 @@ msgstr[0] "%u vstup"
 msgstr[1] "%u vstupy"
 msgstr[2] "%u vstupů"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Systémové zvuky"
+#~ msgid "System Bus"
+#~ msgstr "Systémová sběrnice"
+
+#~ msgid "Full access"
+#~ msgstr "Plný přístup"
+
+#~ msgid "Session Bus"
+#~ msgstr "Sběrnice sezení"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Úplný přístup k /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Má přístup k síti"
+
+#~ msgid "Home"
+#~ msgstr "Domů"
+
+#~ msgid "Read-only"
+#~ msgstr "Jen ke čtení"
+
+#~ msgid "File System"
+#~ msgstr "Souborový systém"
+
+#~ msgid "Can change settings"
+#~ msgstr "Nastavení lze měnit"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s má následující oprávnění zabudovaná a nelze je měnit. Pokud z těchto "
+#~ "oprávnění máte obavy, zvažte odstranění celé aplikace."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u typ souboru a odkazu, který otevírá tato aplikace"
+#~ msgstr[1] "%u typy souborů a odkazů, které otevírá tato aplikace"
+#~ msgstr[2] "%u typů souborů a odkazů, které otevírá tato aplikace"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> se používá k otevření následujících typů souborů a odkazů."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "Z místa na disku je využito %s."
+
+#~ msgid "Select a picture"
+#~ msgstr "Vyběr obrázku"
+
+#~ msgid "_Open"
+#~ msgstr "_Otevřít"
+
+#~ msgid "multiple sizes"
+#~ msgstr "více velikostí"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Bez pozadí pracovní plochy"
+
+#~ msgid "Current background"
+#~ msgstr "Aktuální pozadí"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Umístěte kalibrační zařízení na čtverec a zmáčkněte „Začít“"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Posuňte kalibrační zařízení do kalibrační pozice a zmáčkněte „Pokračovat“"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Posuňte kalibrační zařízení do pozice na povrchu a zmáčkněte „Pokračovat“"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Zavřete víko notebooku"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Došlo k vnitřní chybě, z které už se nelze obnovit."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Nástroje vyžadované pro kalibraci nejsou nainstalované."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profil nemohl být vygenerován."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Cílový bílý bod nebyl dosažitelný."
+
+#~ msgid "Complete!"
+#~ msgstr "Dokončeno!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrace selhala!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Můžete oddělat kalibrační zařízení."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Zamezte otřesům kalibračního zařízení během procesu kalibrace"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Obrazovka notebooku"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Zabudovaná webkamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Skener %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Fotoaparát %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Tiskárna %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webová kamera %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Povolit správu barev pro %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Zobrazit barevné profily pro %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nezkalibrováno"
+
+#~ msgid "Default: "
+#~ msgstr "Výchozí: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Prostor barev: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testovací profil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Výběr souboru s profilem ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importovat"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Podporované profily ICC"
+
+#~ msgid "All files"
+#~ msgstr "Všechny soubory"
+
+#~ msgid "Save Profile"
+#~ msgstr "Uložit profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Vytvořit barevný profil pro vybrané zařízení"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Měřící sonda nebyla nalezena. Zkontrolujte prosím, zda je správně "
+#~ "připojena a zapnutá."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Měřící sonda nepodporuje profilování tiskáren."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Typ zařízení není v současnosti podporován."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standardní rozsah"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testovací profil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatický"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Nízká kvalita"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Střední kvalita"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Vysoká kvalita"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Výchozí RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Výchozí CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Výchozí odstíny šedé"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Výrobce dodal tovární kalibrační data"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Celoobrazovková korekce není s tímto profilem možná"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Tento profil už nemusí být přesný"
+
+#~ msgid "Other…"
+#~ msgstr "Ostatní…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Odemkněte, abyste mohli měnit nastavení"
+
+#~ msgid "Today"
+#~ msgstr "dnes"
+
+#~ msgid "Yesterday"
+#~ msgstr "včera"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %B"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %B %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d hodiny"
+#~ msgstr[1] "%d hodin"
+#~ msgstr[2] "%d hodin"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuty"
+#~ msgstr[1] "%d minut"
+#~ msgstr[2] "%d minut"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekundy"
+#~ msgstr[1] "%d sekund"
+#~ msgstr[2] "%d sekund"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Přístupový bod"
+
+#~ msgid "24-hour"
+#~ msgstr "24hodinový"
+
+#~ msgid "AM / PM"
+#~ msgstr "dop./odp."
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e. %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e. %B %Y, %k:%M"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l∶%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%k∶%M"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Díky odesílání hlášení o technických problémech se může %s vylepšovat. "
+#~ "Hlášení jsou odesílána anonymně a jsou z nich odstraněny osobní údaje. %s"
+
+#~ msgid "On"
+#~ msgstr "Zapnuto"
+
+#~ msgid "Off"
+#~ msgstr "Vypnuto"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Použít změny?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Změny nelze použít"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Může to být dáno omezeními hardwaru."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Na šířku"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Na výšku vpravo"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Na výšku vlevo"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Na šířku (překlopené)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Bezpečné zavádění je aktivní"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení. "
+#~ "V tuto chvíli je zapnuté a správně funguje."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Bezpečné zavádění má problémy"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení. "
+#~ "V tuto chvíli je zapnuté, ale nefunguje, protože má neplatný klíč."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Problémy s bezpečným zaváděním se dají často vyřešit v nastaveních "
+#~ "firmwaru UEFI vašeho počítače (dříve BIOS). Hledejte „Secure Boot“. "
+#~ "Výrobce vašeho hardwaru by měl poskytovat návod, jak postupovat."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Ohledně pomoci kontaktujte výrobce vašeho hardwaru nebo poskytovatele "
+#~ "technické podpory."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Bezpečné zavádění je vypnuté"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení. "
+#~ "V tuto chvíli je vypnuté."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Bezpečné zavádění se obvykle zapíná v nastaveních firmwaru UEFI vašeho "
+#~ "počítače (dříve BIOS). Hledejte „Secure Boot“. Ohledně pomoci kontaktujte "
+#~ "výrobce vašeho hardwaru nebo poskytovatele technické podpory."
+
+#~ msgid "Passed"
+#~ msgstr "Prošlo"
+
+#~ msgid "Failed"
+#~ msgstr "Selhalo"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Zařízení je v souladu s HSI úrovně %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Úroveň zabezpečení 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Toto zařízení nemá žádnou ochranu proti hardwarovým bezpečnostním "
+#~ "hrozbám. Může to být jen otázka nastavení hardwaru nebo firmwaru. "
+#~ "Doporučujeme vám kontaktovat svého poskytovatele technické podpory."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Úroveň zabezpečení 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Toto zařízení má jen minimální ochranu proti hardwarovým bezpečnostním "
+#~ "hrozbám. Jedná se o nejnižší úroveň bezpečnosti zařízení a poskytuje "
+#~ "ochranu jen proti jednoduchým bezpečnostním útokům."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Úroveň zabezpečení 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Toto zařízení má základní ochranu proti hardwarovým bezpečnostním "
+#~ "hrozbám. Ta poskytuje ochranu proti některým běžným bezpečnostním útokům."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Úroveň zabezpečení 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Toto zařízení má rozšířenou ochranu proti hardwarovým bezpečnostním "
+#~ "hrozbám. Jedná se o nejvyšší úroveň bezpečnosti zařízení a poskytuje "
+#~ "ochranu i proti pokročilým bezpečnostním útokům."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Pro toto zařízení nejsou dostupné různé úrovně zabezpečení."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Kontaktujte výrobce svého hardwaru ohledně pomoci s aktualizacemi "
+#~ "zabezpečení."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Řešení tohoto problému možná spočívá jen v nastavení firmwaru UEFI tohoto "
+#~ "zařízení nebo by vám mohla poradit technická podpora."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Řešení tohoto problému možná spočívá jen v nastavení firmwaru UEFI tohoto "
+#~ "zařízení."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "S řešením tohoto problému by vám mohla pomoci technická podpora."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Chráněno proti škodlivému softwaru při spouštění zařízení."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Bezpečné zavádění má problémy"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Aspoň nějaká ochrana při spouštění zařízení."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Bezpečné zavádění je vypnuté"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Bez ochrany při spouštění zařízení."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Tato záležitost by mohla být způsobena změnou nastavení firmwaru UEFI, "
+#~ "změnou nastavení operačního systému nebo škodlivým softwarem v systému."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Tato záležitost by mohla být způsobena změnou nastavení firmwaru UEFI "
+#~ "nebo škodlivým softwarem v systému."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Tato záležitost by mohla být způsobena změnou nastavení operačního "
+#~ "systému nebo škodlivým softwarem v systému."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Vystaveno vážným bezpečnostním hrozbám."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Omezená ochrana proti jednoduchým bezpečnostním hrozbám."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Ochrana proti běžným bezpečnostním hrozbám."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Ochrana proti širokému spektru bezpečnostních hrozeb."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Celková ochrana"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Ochrana firmwaru proti zápisu"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Zámek ochrany firmwaru proti zápisu"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Oblasti firmwaru BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Oblast Descriptor firmwaru BIOS"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Ochrana DMA před zavedením systému"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Zavedení systému ověřené přes Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard chráněn pomocí ACM"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Zásady pro chyby Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Jednorázový zápis Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET je povolený"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET je aktivní"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Šifrovaná RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Ochrana IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Uzamknutí linuxového jádra"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Ověřování linuxového jádra"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Odkládací oddíl Linuxu"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Uspávání do paměti"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Uspávání do nečinnosti"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI Platform Key"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI Secure Boot"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Nastavení TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Obnovení TPM PCR"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Tovární režim Intel Management Engine"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Přepisování Intel Management Engine"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Verze Intel Management Engine"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Aktualizace firmwaru"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Atestace firmwaru"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Ověřování aktualizačních modulů firmwaru"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Ladění platformy"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Bezpečnostní kontroly procesoru"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Ochrana firmwaru AMD proti návratu starších verzí"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Ochrana firmwaru AMD proti opakovanému zápisu"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Ochrana firmwaru AMD proti zápisu"
+
+#~ msgid "Valid"
+#~ msgstr "Platné"
+
+#~ msgid "Not Valid"
+#~ msgstr "Neplatné"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Není zapnuto"
+
+#~ msgid "Locked"
+#~ msgstr "Uzamknuto"
+
+#~ msgid "Not Locked"
+#~ msgstr "Neuzamknuto"
+
+#~ msgid "Encrypted"
+#~ msgstr "Šifrováno"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Nešifrováno"
+
+#~ msgid "Tainted"
+#~ msgstr "Pošpiněno"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Nepošpiněno"
+
+#~ msgid "Found"
+#~ msgstr "Nalezeno"
+
+#~ msgid "Not Found"
+#~ msgstr "Nenalezeno"
+
+#~ msgid "Supported"
+#~ msgstr "Podporováno"
+
+#~ msgid "Not Supported"
+#~ msgstr "Nepodporováno"
+
+#~ msgid "Unknown"
+#~ msgstr "Není známo"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64bitový"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32bitový"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "neznámý"
+
+#~ msgid "Not Available"
+#~ msgstr "nelze zjistit"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo systému"
+
+#~ msgid "No input sources found"
+#~ msgstr "Žádné vstupní zdroje nenalezeny"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Další"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Vlastní klávesové zkratky"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Klávesu alternativních znaků můžete použít, když chcete zadávat některé "
+#~ "speciální znaky. Někdy můžete tyto znaky najít jako doplňující popisek "
+#~ "přímo na klávesách klávesnice."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "levý Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "pravý Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "levý Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "pravý Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Mmnu"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "pravý Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Klávesa Compose umožňuje zadávání široké škály různých znaků. Používá se "
+#~ "tak, že zmáčknete Compose a po té posloupnost znaků. Například klávesa "
+#~ "Compse následovaná znaky <b>C</b> a <b>o</b> vloží <b>©</b>, <b>r</b> "
+#~ "následované <b>'</b> vloží <b>ŕ</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Vstupní zdroje můžete přepínat pomocí klávesové zkratky %s.\n"
+#~ "Tu můžete změněnit v nastavení klávesových zkratek."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d změněná"
+#~ msgstr[1] "%d změněné"
+#~ msgstr[2] "%d změněných"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Vráti všechny klávesové zkratky na výchozí?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Vrácení klávesových zkratek na výchozí může ovlivnit vaše vlastní "
+#~ "klávesové zkratky. A nepůjde to vrátit zpět."
+
+#~ msgid "Reset All"
+#~ msgstr "Všechny na výchozí"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s se již používá pro činnost „%s“. Pokud ji nahradíte, bude klávesová "
+#~ "zkratka pro činnost „%s“ zakázána."
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Zadejte novou klávesovou zkratku"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Nastavení vlastní klávesové zkratky"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Nastavit zkratku"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Zadejte novou zkratku pro činnost „%s“."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Přidání vlastní klávesové zkratky"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Posunování dvěma prsty"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Pětiklepnutí – čas na GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dvojité kliknutí, hlavní tlačítko"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Kliknutí, hlavní tlačítko"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dvojité kliknutí, prostřední tlačítko"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Kliknutí, prostřední tlačítko"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dvojité kliknutí, vedlejší tlačítko"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Kliknutí, vedlejší tlačítko"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Je zapotřebí, aby běžel program NetworkManager."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Nezabezpečená síť (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Zabezpečená síť (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Zabezpečená síť (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Zabezpečená síť (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Zabezpečená síť"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Zapnutí přístupového bodu způsobí odpojení od sítě %s a nebudete moci "
+#~ "přistupovat do Internetu přes Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Musí mít nejméně 8 znaků"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Zastavit přístupový bod a odpojit případné uživatele?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "Za_stavit přístupový bod"
+
+#~ msgid "Preserve"
+#~ msgstr "současná"
+
+#~ msgid "Permanent"
+#~ msgstr "trvalá"
+
+#~ msgid "Random"
+#~ msgstr "náhodná"
+
+#~ msgid "Stable"
+#~ msgstr "stabilní"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Zde zadaná adresa MAC bude použita jako hardwarová adresa pro síťové "
+#~ "zařízení, na kterém je toto připojení aktivováno. Funkcionalita se nazývá "
+#~ "klonování MAC nebo spoofing. Příklad: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Podnikové"
+
+# Zabezpečení
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Žádné"
+
+#~ msgid "Never"
+#~ msgstr "nikdy"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+# Síla signálu
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Žádná"
+
+# Síla signálu
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Slabá"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Dostačující"
+
+# Síla signálu
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Dobrá"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Výborná"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Zapomenout připojení"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Odebrat profil připojení"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Odebrat VPN"
+
+#~ msgid "Details"
+#~ msgstr "Podrobnosti"
+
+#~ msgid "automatic"
+#~ msgstr "automaticky"
+
+#~ msgid "Identity"
+#~ msgstr "Identita"
+
+#~ msgid "Delete Address"
+#~ msgstr "Smazat adresu"
+
+#~ msgid "Delete Route"
+#~ msgstr "Smazat směrování"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Žádné"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP, 40/128bitový klíč (Hex nebo ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP, 128bitová heslová fráze"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamické WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA a WPA2, osobní"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA a WPA2, podnikové"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3, osobní"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Nelze otevřít editor připojení"
+
+#~ msgid "New Profile"
+#~ msgstr "Nový profil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Neplatné nastavení %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Neplatné nastavení %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importovat ze souboru…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Přidání VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Nelze importovat připojení VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Soubor „%s“ nelze přečíst nebo neobsahuje rozpoznatelné informace o "
+#~ "připojení VPN\n"
+#~ "\n"
+#~ "Chyba: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Výběr souboru pro import"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Soubor s názvem „%s“ již existuje."
+
+#~ msgid "_Replace"
+#~ msgstr "_Nahradit"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Chcete nahradit %s připojením VPN, které ukládáte?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Nelze exportovat připojení VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Připojení VPN „%s“ nemůže být exportováno do %s.\n"
+#~ "\n"
+#~ "Chyba: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportovat připojení VPN"
+
+#~ msgid "never"
+#~ msgstr "nikdy"
+
+#~ msgid "today"
+#~ msgstr "dnes"
+
+#~ msgid "yesterday"
+#~ msgstr "včera"
+
+#~ msgid "Last used"
+#~ msgstr "Naposledy použito"
+
+#~ msgid "Add new connection"
+#~ msgstr "Přidat nové připojení"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Informace o síti pro vybrané sítě, včetně hesel a vlastního nastavení, "
+#~ "budou ztraceny."
+
+#~ msgid "_Forget"
+#~ msgstr "_Zapomenout"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Známé sítě Wi-Fi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Zapomenout"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Systémová zásada zakazuje použití jako přístupový bod"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Bezdrátové zařízení nepodporuje režim přístupového bodu"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Pokud není adresa URL pro nastavení poskytnuta, použije se automatické "
+#~ "vyhledání webové proxy."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Nedoporučuje se v nedůvěryhodných veřejných sítích."
+
+#~ msgid "Status unknown"
+#~ msgstr "Neznámý stav"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Nespravováno"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nedostupné"
+
+#~ msgid "Connecting"
+#~ msgstr "Připojuje se"
+
+#~ msgid "Authentication required"
+#~ msgstr "Požadována autentizace"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Odpojuje se"
+
+#~ msgid "Connection failed"
+#~ msgstr "Připojení selhalo"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Neznámý stav (chybí)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Nastavení selhalo"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Nastavení IP selhalo"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Konfigurace IP vypršela"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Hesla byla požadována, ale neposkytnuta"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Žadatel 802.1x odpojen"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Konfigurace žadatele 802.1x selhala"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Žadatel 802.1x selhal"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Žadateli 802.1x trvalo ověření příliš dlouho"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Spuštění služby PPP selhalo"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Služba PPP odpojena"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP selhalo"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Spuštění klienta DHCP selhalo"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Chyba klienta DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Klient DHCP selhal"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Spuštění služby sdíleného připojení selhalo"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Služba sdíleného připojení selhala"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Spuštění služby AutoIP selhalo"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Chyba služby AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Služba AutoIP selhala"
+
+#~ msgid "Line busy"
+#~ msgstr "Linka obsazena"
+
+#~ msgid "No dial tone"
+#~ msgstr "Žádný vytáčecí tón"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Nelze navázat spojení"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Požadavek na vytáčení vypršel"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Pokus o vytáčení selhal"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Inicializace modemu selhala"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Výběr zvoleného APN selhal"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Nevyhledávají se sítě"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Registrace do sítě zamítnuta"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Registrace do sítě vypršela"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Registrace do požadované sítě selhala"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Ověření PIN selhalo"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firmware zařízení nejspíše chybí"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Připojení bylo ztraceno"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Existující spojení bylo převzato"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem nenalezen"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Připojení Bluetooth selhalo"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Karta SIM není vložena"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Požadován PIN karty SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Požadován PUK karty SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Chybná SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Závislost připojení selhala"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Schází firmware"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Odpojen kabel"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "nedefinovaná chyba v zabezpečení 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "není vybrán žádný soubor"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "blíže neurčená chyba při ověřování souboru s metodou eap"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Soukromé klíče DER, PEM, PKCS#12 nebo PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certifikáty DER nebo PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "schází soubor EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Soubory PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "chybí uživatelské jméno pro EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "chybí heslo pro EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "neplatný certifikát EAP-PEAP certifikační autority: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "neplatný certifikát EAP-PEAP certifikační autority: žádný certifikát není "
+#~ "zadán"
+
+#~ msgid "missing EAP username"
+#~ msgstr "chybí uživatelské jméno pro EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "chybí heslo pro EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "chybí identita pro EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "neplatný certifikát EAP-TLS certifikační autority: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "neplatný certifikát EAP-TLS certifikační autority: žádný certifikát není "
+#~ "zadán"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "neplatný soukromý klíč pro EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "neplatný uživatelský certifikát pro EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Nešifrované soukromé klíče nejsou bezpečné"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Vypadá to, že vybraný soukromý klíč není chráněný heslem.  To může "
+#~ "způsobit, že vaše bezpečnostní údaje budou kompromitovány. Vyberte prosím "
+#~ "soukromý klíč chráněný heslem.\n"
+#~ "\n"
+#~ "(Soukromý klíč můžete zabezpečit heslem pomocí openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Vyberte svůj osobní certifikát"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Vyberte svůj soukromý klíč"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "neplatný certifikát EAP-TTLS certifikační autority: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "neplatný certifikát EAP-TTLS certifikační autority: žádný certifikát není "
+#~ "zadán"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Neznámá chyba při ověřování zabezpečení 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Vybrat soubor"
+
+#~ msgid "missing leap-username"
+#~ msgstr "chybí uživatelské jméno pro LEAP"
+
+#~ msgid "missing leap-password"
+#~ msgstr "chybí heslo pro LEAP"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Schází heslo k Wi-Fi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "chybí klíč WEP"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "neplatný klíč WEP: klíč s délkou %zu musí obsahovat jen šestnáctkové "
+#~ "číslice"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "neplatný klíč WEP: klíč s délkou %zu musí obsahovat jen znaky sady ASCII"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "neplatný klíč WEP: nesprávná délka klíče %zu. Klíč musí mít délku 5/13 "
+#~ "(ASCII) nebo 10/26 (HEX)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "neplatný klíč WEP: heslová fráze nesmí být prázdná"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "neplatný klíč WEP: heslová fráze musí být kratší než 64 znaků"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "neplatný osobní klíč WPA: neplatná délka klíče %zu. Musí být [8,63] bajtů "
+#~ "nebo 64 šestnáctkový číslic"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "neplatný osobní klíč WPA: nelze zpracovat klíč s 64 bajty jako "
+#~ "šestnáctkový"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Jiný"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s byl odebrán"
+
+#~ msgid "Error removing account"
+#~ msgstr "Chyba při odebírání účtu"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Účet %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Odebrat účet"
+
+#~ msgid "Unknown time"
+#~ msgstr "Neznámý čas"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s do plného nabití"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Pozor, zbývá %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Zbývá %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Plně nabito"
+
+#~ msgid "Not charging"
+#~ msgstr "Nenabíjí se"
+
+#~ msgid "Empty"
+#~ msgstr "Vybitá"
+
+#~ msgid "Charging"
+#~ msgstr "Nabíjí se"
+
+#~ msgid "Discharging"
+#~ msgstr "Vybíjí se"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Bezdrátová myš"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Bezdrátová klávesnice"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Záložní zdroj napájení"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Osobní digitální asistent (PDA)"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobilní telefon"
+
+#~ msgid "Media player"
+#~ msgstr "Multimediální přehrávač"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Počítač"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Herní vstupní zařízení"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Hlavní"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Přídavná"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterie"
+
+#~ msgid "When _idle"
+#~ msgstr "Při _nečinnosti"
+
+#~ msgid "Suspend"
+#~ msgstr "Uspat do paměti"
+
+#~ msgid "Power Off"
+#~ msgstr "Vypnout"
+
+#~ msgid "Hibernate"
+#~ msgstr "Uspat na disk"
+
+#~ msgid "Nothing"
+#~ msgstr "Nic nedělat"
+
+#~ msgid "When on battery power"
+#~ msgstr "Při napájení z baterie"
+
+#~ msgid "When plugged in"
+#~ msgstr "Při napájení ze sítě"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nikdy"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automaticky uspat"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Režim vysokého výkonu byl dočasně vypnut z důvodu zvýšené operační "
+#~ "teploty."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Pravděpodobně máte počítač na klíně, proto není režim vysokého výkonu "
+#~ "dočasně k dispozici. Přesuňte zařízení na stabilní povrch, aby se obnovil."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Režim vysokého výkonu je dočasně zakázaný."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Nízký stav baterie: zapnuto šetření energií. Předchozí režim bude "
+#~ "obnoven, jakmile se baterie dostatečně nabije."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Režim úspory energie byl aktivován aplikací „%s“."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Režim vysokého výkonu byl aktivován aplikací „%s“."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Vysoký výkon"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Vysoký výkon za cenu vyšší spotřeby energie."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Rovnováha"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standardní výkon i spotřeba energie."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Šetření energií"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Šetří energii za cenu sníženého výkonu."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Tiskárna „%s“ byla odebrána"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Selhalo přidání nové tiskárny."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Nelze načíst uživatelské rozhraní: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Odemkněte, abyste mohli přidávat tiskárny a měnit nastavení"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Podrobnosti o tiskárně %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nenalezen vyhovující ovladač"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Vyberte soubor PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Soubory popisu tiskárny PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Tiskárna JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Tiskárna LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Jednostranně"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Delší okraj (standardní)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kratší okraj (obráceno)"
+
+#~ msgid "Portrait"
+#~ msgstr "Na výšku"
+
+#~ msgid "Landscape"
+#~ msgstr "Na šířku"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Obráceně na šířku"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Obráceně na výšku"
+
+#~ msgid "Resume"
+#~ msgstr "Pokračovat"
+
+#~ msgid "Pause"
+#~ msgstr "Pozastavit"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Čeká"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pozastaveno"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Požadováno ověření"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Zpracovává se"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Zastaveno"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Zrušeno"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Přerušeno"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Dokončeno"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Přesunout tuto úlohu na začátek fronty"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s – aktivní úlohy"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Zadejte pověření pro tisk z tiskárny %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Odemknout tiskový server"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Odemknout server %s"
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Chcete-li vidět tiskárny ze serveru %s, zadejte uživatelské jméno a heslo."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Vyhledávají se tiskárny"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Sériový port"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralelní port"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Umístění: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresa: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Server požaduje ověření totožnosti"
+
+#~ msgid "Two Sided"
+#~ msgstr "Oboustranně"
+
+#~ msgid "Paper Type"
+#~ msgstr "Typ papíru"
+
+#~ msgid "Paper Source"
+#~ msgstr "Zdroj papíru"
+
+#~ msgid "Output Tray"
+#~ msgstr "Výstupní zásobník"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Rozlišení"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Předfiltrování GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Stránek na stranu papíru"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientace"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Obecné"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Vzhled strany"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Volitelné doplňky"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Úloha"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Kvalita obrazu"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Barevnost"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Dokončení"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Pokročilé"
+
+#~ msgid "Test page"
+#~ msgstr "Testovací stránka"
+
+#~ msgid "Auto Select"
+#~ msgstr "Vybrat automaticky"
+
+#~ msgid "Printer Default"
+#~ msgstr "Výchozí nastavení tiskárny"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Zahrnout pouze písma GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Převést na PostScript úrovně 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Převést na PostScript úrovně 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Bez předfiltrování"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Čištění tiskových hlav"
+
+#~ msgid "Out of toner"
+#~ msgstr "Došel toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Životnost vývojové jednotka se blíží ke konci"
+
+#~ msgid "Out of developer"
+#~ msgstr "Opotřebená vývojová jednotka"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Životnost zásobníku se blíží ke konci"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Opotřebený zásobník"
+
+#~ msgid "Open cover"
+#~ msgstr "Otevřen kryt"
+
+#~ msgid "Open door"
+#~ msgstr "Otevřena dvířka"
+
+#~ msgid "Low on paper"
+#~ msgstr "Dochází papír"
+
+#~ msgid "Out of paper"
+#~ msgstr "Došel papír"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Off-line"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Zastaveno"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Odpadní nádobka je téměř plná"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Odpadní nádobka je plná"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Životnost optického válce se blíží ke konci"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Optický válec není nadále funkční"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Připraveno"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Nepřijímá úlohy"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Zpracovává se"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperiální"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrické"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Zeptat se na další postup"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nic nedělat"
+
+#~ msgid "Open folder"
+#~ msgstr "Otevřít složku"
+
+#~ msgid "Other Media"
+#~ msgstr "Ostatní média"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Vyberte aplikaci pro zvuková CD"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Vyberte aplikaci pro DVD s videem"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Vyberte aplikaci, která má být spuštěna po připojení hudebního přehrávače"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Vyberte aplikaci, která má být spuštěna po připojení fotoaparátu"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Vyberte aplikaci pro CD se softwarem"
+
+#~ msgid "audio DVD"
+#~ msgstr "zvukové DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "prázdný disk Blu-ray"
+
+#~ msgid "blank CD disc"
+#~ msgstr "prázdný disk CD"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "prázdný disk DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "prázdný disk HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "videodisk Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "čtečka elektronických knih"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "videodisk HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "ihned po zčernání"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "po 30 sekundách"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "po 1 minutě"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "po 2 minutách"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "po 3 minutách"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "po 5 minutách"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "po 30 minutách"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "po 1 hodině"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "po 1 minutě"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "po 2 minutách"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "po 3 minutách"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "po 4 minutách"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "po 5 minutách"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "po 8 minutách"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "po 10 minutách"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "po 12 minutách"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "po 15 minutách"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "nikdy"
+
+#~ msgid "Select Location"
+#~ msgstr "Vyberte umístění"
+
+#~ msgid "_OK"
+#~ msgstr "_Budiž"
+
+#~ msgid "No applications found"
+#~ msgstr "Nenalezeny žádné aplikace"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nebyly zvoleny žádné sítě pro sdílení"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Zapnuto"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Vypnuto"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Zapnuto"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktivní"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Výběr složky"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Povolit sdílení multimédií"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Sdílení souborů vám umožňuje sdílet složku Veřejné s ostatními v aktuální "
+#~ "síti pomocí: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Když je vzdálené přihlašování povolené, mohou se vzdálení uživatelé "
+#~ "připojit příkazem Secure Shell:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Povolit sdílení osobních multimédií"
+
+#~ msgid "Device name copied"
+#~ msgstr "Byl zkopírován název zařízení"
+
+#~ msgid "Device address copied"
+#~ msgstr "Byla zkopírována adresa zařízení"
+
+#~ msgid "Username copied"
+#~ msgstr "Bylo zkopírováno uživatelské jméno"
+
+#~ msgid "Password copied"
+#~ msgstr "Bylo zkopírováno heslo"
+
+#~ msgid "Custom"
+#~ msgstr "Vlastní"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Testuje se %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Odpojeno"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Připojuje se"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Připojeno"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Chyba ověřování"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Ověřuje se"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Omezená funkcionalita"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Připojeno a ověřeno"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Neznámý"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Ověřeno:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Připojeno:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Registrováno:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Selhalo ověření zařízení: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Zapomenutí zařízení selhalo: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Chyba"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Ověřeno"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Subsystém Thunderbolt (boltd) není nainstalovaný, nebo není správně "
+#~ "nastavený."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Připojeny mohou být jen zařízení USB a Display Port."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt se nezdařilo nalézt.\n"
+#~ "Buď systém postrádá podporu pro Thunderbolt, nebo je vypnutá přes BIOS, "
+#~ "nebo je v něm nastavená nepodporovaná úroveň zabezpečení."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Podpora pro Thunderbolt je vypnutá přes BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Úroveň zabezpečení zařízení Thunderbolt nemohla být určena."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Chyba při přepínání přímého režimu: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Výchozí"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Střední"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Velký"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Větší"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Největší"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixely"
+#~ msgstr[2] "%d pixelů"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Krátká"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ obrazovky"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ obrazovky"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ obrazovky"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Dlouhá"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 hodině"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dnech"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dnech"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dnech"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dnech"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dnech"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dnech"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dnech"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dnech"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Vysypat všechny položky z koše?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Všechny položky v koši budou trvale smazány."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Vyprázdnit koš"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Odstranit dočasné soubory?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Všechny dočasné soubory budou trvale smazány."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Odstranit dočasné soubor_y"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 den"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dní"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dní"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "napořád"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr ""
+#~ "Mělo by se shodovat s webovou adresou poskytovatele vašeho přihlašování."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Přidání účtu selhalo"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Registrace účtu selhala"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Ověření s touto doménou není podporováno"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Připojení k doméně selhalo"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Toto přihlašovací jméno nefunguje.\n"
+#~ "Zkuste to, prosím, znovu."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Toto přihlašovací heslo nefunguje.\n"
+#~ "Zkuste to, prosím, znovu."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Přihlášení do domény selhalo"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Nelze najít doménu. Nemáte v názvu překlep?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Procházet další obrázky"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "k provedení této činnosti je potřeba výhradní přístup k zařízení"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "zařízení si již nárokuje jiný proces"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "nemáte oprávnění provádět tuto činnost"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "nebyl sejmut žádný otisk prstu"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Selhala komunikace se zařízením během snímání otisku prstu"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Selhala komunikace se čtečkou otisků prstů"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Selhala komunikace s démonem pro otisky prstů"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Selhalo vypsání otisku prstů: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Selhalo smazání uložených otisků prstů: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Palec levé ruky"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Prostředníček levé ruky"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Ukazováček _levé ruky"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Prsteníček levé ruky"
+
+#~ msgid "Left little finger"
+#~ msgstr "Malíček levé ruky"
+
+#~ msgid "Right thumb"
+#~ msgstr "Palec pravé ruky"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Prostředníček pravé ruky"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Ukazováček p_ravé ruky"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Prsteníček pravé ruky"
+
+#~ msgid "Right little finger"
+#~ msgstr "Malíček pravé ruky"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Neznámý otisk prstu"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Dokončeno"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Čtečka otisků prstů je odpojená"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Úložiště čtečky otisku prstů je plné"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Selhalo sejmutí nového otisku prstu"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Selhalo započetí snímání: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Selhalo sejmutí nového otisku prstu"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Selhalo zastavení snímání: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Opakovaně zvedněte a přiložte svůj prst ke čtečce, aby se mohl sejmout "
+#~ "otisk prstu."
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Znovu sejmout tento otisk p_rstu…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Sejmout nový otisku prstu"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Selhalo uvolnění čtečky otisku prstu %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problém při čtení ze zařízení"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Selhalo vyžádání čtečky otisku prstu %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Selhalo získání čtečky otisku prstu: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Tento týden"
+
+#~ msgid "Last Week"
+#~ msgstr "Minulý týden"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %B"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %B %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sezení ukončeno"
+
+#~ msgid "Session Started"
+#~ msgstr "Sezení započato"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s – Aktivita účtu"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Zvolte prosím jiné heslo."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Zadejte prosím své současné heslo ještě jednou."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Heslo nelze změnit"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Nelze se automaticky připojit k tomuto typu domény"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Doména nebyla nalezena"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Nelze se přihlásit jako „%s“ v doméně „%s“"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Neplatné heslo, zkuste to, prosím, znovu"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Nelze se připojit k doméně „%s“: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Selhalo smazání účtu"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Selhalo zneplatnění vzdáleně spravovaného uživatele"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nemůžete smazat svůj vlastní účet."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "Uživatel %s je doposud přihlášen"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Smazání účtu, zatímco je dotyčný uživatel přihlášen, může přivést systém "
+#~ "do nekonzistentního stavu."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Chcete zachovat soubory uživatele %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Je možné zachovat domovskou složku, poštovní schránku a dočasné soubory, "
+#~ "i když bude uživatelský účet smazán."
+
+#~ msgid "_Delete Files"
+#~ msgstr "O_dstranit soubory"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Zacho_vat soubory"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Opravdu chcete zneplatnit vzdáleně spravovaný účet uživatele %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "O_dstranit"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Účet zakázán"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Bude nastaveno při příštím přihlášení"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Žádné"
+
+#~ msgid "Logged in"
+#~ msgstr "právě přihlášený"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Selhalo kontaktování účtovací služby"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Zkontrolujte prosím, že je účtovací služba AccountService nainstalovaná a "
+#~ "zapnutá."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Abyste mohli měnit nastavení, je panel zapotřebí odemknout"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Odstranit vybraný uživatelský účet"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pro odstranění uživatelského účtu\n"
+#~ "nejprve klikněte na ikonu *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Odemkněte, abyste mohli přidávat uživatele a měnit nastavení"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Nové heslo se musí lišit od toho starého."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Zkuste změnit některá písmena a číslice."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Zkuste změnit heslo trochu víc."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Heslo bez vašeho uživatelského jména by bylo silnější."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Zkuste se vyhnout použití svého jména v heslu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Zkuste se vyhnout použití některých slov v hesle."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Zkuste se vyhnout běžným slovům."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Zkuste se vyhnout změně pořadí stávajících slov."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Zkuste použít víc číslic."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Zkuste použít víc velkých písmen."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Zkuste použít víc malých písmen."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Zkuste použít více speciálních znaků, jako jsou interpunkční znaménka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Zkuste použít směs písmen, číslic a interpunkčních znamének."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Zkuste se vyhnout opakování stejného znaku."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Zkuste se vyhnout opakování stejného typu znaků: měli byste kombinovat "
+#~ "písmena, čísla a interpunkční znaménka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Zkuste se vyhnout sekvencím, jako je 1234 nebo abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Heslo musí být delší. Zkuste přidat další písmena, číslice a interpunkční "
+#~ "znaménka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Zkombinujte velká a malá písmena a zkuste použít jednu či dvě číslice."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Přidáním dalších písmen, číslic a interpunkčních znamének můžete heslo "
+#~ "ještě dále zesílit."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autentizace selhala"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Nové heslo je příliš krátké"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Nové heslo je příliš jednoduché"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Nové heslo je příliš podobné starému"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Stejné heslo, jako nové, bylo použito nedávno."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Nové heslo musí obsahovat číslice nebo speciální znaky."
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Staré a nové heslo jsou stejné"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Vaše heslo se od vaší prvotní autentizace změnilo!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Nové heslo neobsahuje dostatek různorodých znaků"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Neznámá chyba"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Uživatelské jméno se musí obvykle skládat jen z malých písmen a-z, číslic "
+#~ "a následujících znaků: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Toto uživatelské jméno není bohužel dostupné. Zkuste prosím jiné."
+
+#~ msgid "The username is too long."
+#~ msgstr "Uživatelské jméno je příliš dlouhé."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Tlačítko %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Definováno aplikací"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Vyvolat klávesovou zkratku"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Přepnout obrazovku"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Zobrazit nápovědu na obrazovce"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Grafický tablet osazený na displeji notebooku"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Grafický tablet osazený na externím displeji"
+
+#~ msgid "External tablet device"
+#~ msgstr "Externí grafický tablet"
+
+#~ msgid "All Displays"
+#~ msgstr "Všechny displeje"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Stylus Airbrush citlivý na přítlak, sklon a s integrovaným kolečkem"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Stylus Airbrush citlivý na přítlak, sklon a natočení"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standardní stylus citlivý na přítlak a sklon"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standardní stylus citlivý na přítlak"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nová klávesová zkratka…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operace zrušena"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Chyba:</b> Zamítnut přístup ke změnám nastavení"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Chyba:</b> Chyba mobilního zařízení"
+
+#~ msgid "Not Registered"
+#~ msgstr "Nezaregistrováno"
+
+#~ msgid "Registered"
+#~ msgstr "Zaregistrováno"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Vyhledává se"
+
+#~ msgid "Denied"
+#~ msgstr "Odepřeno"
+
+#~ msgid "2G Only"
+#~ msgstr "pouze 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "pouze 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "pouze 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "pouze 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (preferovaná)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (preferovaná), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (preferovaná), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (preferovaná), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (preferovaná)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (preferovaná), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (preferovaná), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (preferovaná)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (preferovaná), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (preferovaná), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (preferovaná)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (preferovaná), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (preferovaná), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (preferovaná)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (preferovaná), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (preferovaná), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (preferovaná)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G, 4G (preferovaná)"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (preferovaná)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (preferovaná), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (preferovaná)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (preferovaná), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (preferovaná)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (preferovaná), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (preferovaná)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (preferovaná), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (preferovaná)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (preferovaná), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "neznámý"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Odemknutí karty SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Zadejte prosím kód PIN pro SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Zadejte PIN pro odemknutí své karty SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Zadejte prosím kód PUK pro SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Zadejte PUK pro odemknutí své karty SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Bylo zadáno nesprávné heslo."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Kód PUK by měl mít 8 číslic"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Zadejte nový PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Kód PIN by měl mít 4 až 8 číslic"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Odemyká se…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Telefon selhal"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Není spojení s telefonem"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operace není povolena"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operace není podporována"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Karta SIM není vložena"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Požadován kód PIN pro SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Požadován kód PUK pro SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "karta SIM selhala"
+
+#~ msgid "SIM busy"
+#~ msgstr "Karta SIM je zaneprázdněna"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Nesprávné heslo"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Požadován kód PIN2 pro SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Požadován kód PUK2 pro SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Nenalezeno"
+
+#~ msgid "No network service"
+#~ msgstr "Žádná síťová služba"
+
+#~ msgid "Network timeout"
+#~ msgstr "Síť neodpověděla"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Služby GPRS nejsou povoleny"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "V této oblasti není povolen roaming"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Nespecifikovaná chyba GPRS"
+
+#~ msgid "No Error"
+#~ msgstr "Bez chyb"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Činnost byla zrušena"
+
+#~ msgid "Access denied"
+#~ msgstr "Přístup byl zamítnut"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Neznámá chyba"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Zobrazit číslo verze"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Zapnout podrobný režim"
+
+#~ msgid "Search for the string"
+#~ msgstr "Hledat řetězec"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Vypsat všechny možné názvy panelů a skončit"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel, který se má zobrazit"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Dostupné panely:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Systémové zvuky"

--- a/po/cs.po~
+++ b/po/cs.po~
@@ -1,0 +1,9634 @@
+# Czech translation of gnome-control-center.
+# Copyright (C) 1999, 2003, 2006, 2007, 2008, 2009, 2010, 2011 the author(s) of gnome-control-center.
+# Copyright (C) 2003, 2004, 2005, 2006 Miloslav Trmac <mitr@volny.cz>.
+# Copyright (C) 2006 Lukas Novotny <lukasnov@cvs.gnome.org>.
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# David Šauer <davids@penguin.cz>, 1999.
+# Jiří Lebl <jirka@5z.cz>, 2002.
+# Michal Bukovjan <bukm@centrum.cz>, 2002, 2003.
+# Miloslav Trmac <mitr@volny.cz>, 2003, 2004, 2005, 2006.
+# Jakub Friedl <jfriedl@suse.cz>, 2006, 2007.
+# Petr Tomeš <ptomes@gmail.com>, 2006.
+# Lukas Novotny <lukasnov@cvs.gnome.org>, 2006.
+# Petr Kovar <pknbe@volny.cz>, 2007, 2008, 2009, 2010, 2011, 2012.
+# Andre Klapper <ak-47@gmx.net>, 2009.
+# Ondřej Kopka <ondrej.kopka@gmail.com>, 2011.
+# Adam Matoušek <adamatousek@gmail.com>, 2012.
+# Jiri Eischmann <jiri@eischmann.cz>, 2013.
+# František Zatloukal <Zatloukal.Frantisek@gmail.com>, 2014.
+# Marek Černocký <marek@manet.cz>, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022.
+# Vojtěch Perník <translations@pervoj.cz>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"PO-Revision-Date: 2022-09-05 15:18+0200\n"
+"Last-Translator: Marek Černocký <marek@manet.cz>\n"
+"Language-Team: Czech <gnome-cs-list@gnome.org>\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Poedit 3.0.1\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Systémová sběrnice"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Plný přístup"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Sběrnice sezení"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Zařízení"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Úplný přístup k /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Síť"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Má přístup k síti"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Domů"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Jen ke čtení"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Souborový systém"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Nastavení"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Nastavení lze měnit"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s má následující oprávnění zabudovaná a nelze je měnit. Pokud z těchto "
+"oprávnění máte obavy, zvažte odstranění celé aplikace."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u typ souboru a odkazu, který otevírá tato aplikace"
+msgstr[1] "%u typy souborů a odkazů, které otevírá tato aplikace"
+msgstr[2] "%u typů souborů a odkazů, které otevírá tato aplikace"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> se používá k otevření následujících typů souborů a odkazů."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "Z místa na disku je využito %s."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplikace"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Žádné aplikace"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Nějakou nainstalovat…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Otevřít"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Zobrazit podrobnosti"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Hledání"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Přijímat od systému požadavky na hledání a předávat výsledky."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Vypnuto"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Upozornění"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Zobrazovat systémová upozornění."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Běh na pozadí"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Povolit činnost, i když je aplikace zavřená."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Snímky obrazovky"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Kdykoliv pořizovat snímky obrazovky."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Změna tapety"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Měnit tapetu na ploše."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Zvuky"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Produkovat zvuky."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Blokování klávesových zkratek"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Znemožňovat použití standardních klávesových zkratek."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Pořizovat obrázky pomocí kamerty."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Nahrávat zvuk pomocí mikrofonu."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Služby určování polohy"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Přístupovat k údajům o zeměpisné poloze zařízení."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Zabudovaná oprávnění"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Přístup k systému, který tato aplikace požaduje."
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Přiřazené soubory a odkazy"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Úložiště"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Nebyly nalezeny žádné výsledky"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Zkuste jiné hledání"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Přiřazené soubory a odkazy"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Typy souborů"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Typy odkazů"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Výchozí"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "Kolik místa na disku tato aplikace zabírá, včetně dat a mezipamětí."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplikace"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Mezipaměť"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Celkem</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Vyprázdnit mezipaměť…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Určujte různorodá oprávnění a nastavení aplikací"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplikace;flatpak;oprávnění;nastavení;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Vyběr obrázku"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Zrušit"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Otevřít"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "více velikostí"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Bez pozadí pracovní plochy"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Aktuální pozadí"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Styl"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Výchozí"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Tmavý"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Pozadí"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Přidat obrázek…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Vzhled"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Změnit obrázek na pozadí nebo barvy uživatelského rozhraní"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "pozadí;tapeta;obrazovka;plocha;styl;světlý;tmavý;vzhled;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Povolit"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Nebylo nalezeno žádné Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Připojte adaptér, aby šlo používat Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth vypnuto"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Zapněte jej, aby se připojila zařízení a mohly přenášet soubory."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Režim „letadlo“ je zapnutý"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Když je zapnutý režim „letadlo“, je Bluetooth zakázané."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Vypnout režim „letadlo“"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Hardwarový režim „letadlo“ je zapnutý"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Vypněte přepínač režimu „letadlo“, aby se povolilo Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Zapnout a vypnout Bluetooth a připojit se k zařízením"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "sdílet;sdílení;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera je vypnutá"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Žádná aplikace nemůže pořizovat fotky nebo nahrávat video."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Díky kameře mohou aplikace pořizovat fotky a nahrávat videa. Její vypnutí "
+"může způsobit, že některé aplikace nebudou fungovat správně.\n"
+"\n"
+"Aplikacím níže můžete povolit používat kameru."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Žádná aplikace si nepožádala o přístup ke kameře"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Ochránit své obrázky"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"kamera;fotky;fotografie;snímky;video;webová kamera;zámek;uzamknutí;uzamčení;"
+"zamknout;uzamknout;uzamčít;soukromí;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Umístěte kalibrační zařízení na čtverec a zmáčkněte „Začít“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Posuňte kalibrační zařízení do kalibrační pozice a zmáčkněte „Pokračovat“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Posuňte kalibrační zařízení do pozice na povrchu a zmáčkněte „Pokračovat“"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Zavřete víko notebooku"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Došlo k vnitřní chybě, z které už se nelze obnovit."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Nástroje vyžadované pro kalibraci nejsou nainstalované."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Profil nemohl být vygenerován."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Cílový bílý bod nebyl dosažitelný."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Dokončeno!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrace selhala!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Můžete oddělat kalibrační zařízení."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Zamezte otřesům kalibračního zařízení během procesu kalibrace"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Kalibrace displeje"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "Z_ačít"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Pokračovat"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Hotovo"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Obrazovka notebooku"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Zabudovaná webkamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Skener %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Fotoaparát %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Tiskárna %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webová kamera %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Povolit správu barev pro %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Zobrazit barevné profily pro %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Nezkalibrováno"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Výchozí: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Prostor barev: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Testovací profil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Výběr souboru s profilem ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importovat"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Podporované profily ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Všechny soubory"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Obrazovka"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Uložit profil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Uložit"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Vytvořit barevný profil pro vybrané zařízení"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Měřící sonda nebyla nalezena. Zkontrolujte prosím, zda je správně připojena "
+"a zapnutá."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Měřící sonda nepodporuje profilování tiskáren."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Typ zařízení není v současnosti podporován."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Kalibrace obrazovky"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kvalita kalibrace"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrace vytvoří profil, který můžete použít pro barevnou správu vaší "
+"obrazovky. Čím více času strávíte kalibrací, tím vyšší kvalitu profil bude "
+"mít."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Během kalibrace nebudete moct počítač používat."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kvalita"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Odhadovaný čas"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibrační zařízení"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Vyberte senzorové zařízení, které chcete použít pro kalibraci."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Typ displeje"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Vyberte typ displeje, který je připojený."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profilový bílý bod"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Vyberte cílový bílý bod na obrazovce. Většina displejů by měla být "
+"kalibrována na luminaci D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Jas displeje"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Nastavte prosím displej na jas, který běžně používáte. Správa barev bude "
+"nejpřesnější právě na této hladině jasu."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativně můžete použít hladinu jasu, která je použitá v jiném profilu "
+"pro toto zařízení."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Název profilu"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Barevný profil můžete použít i na jiných počítačích, nebo můžete dokonce "
+"vytvořit profily pro různé světelné podmínky."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Název profilu:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Souhrn"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil úspěšně vytvořen!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopírovat profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Vyžaduje zapisovatelné médium"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Tyto instrukce, jak použít profil na systémech <a href=\"linux\">GNU/Linux</"
+"a>, <a href=\"osx\">Apple OS X</a> a <a href=\"windows\">Microsoft Windows</"
+"a>, pro vás mohou být užitečné."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Přidání profilu"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Zjištěny problémy. Profil nemusí fungovat správně. <a href=\"\">Zobrazit "
+"podrobnosti.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importovat soubor…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "Přid_at"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Aby u jednotlivých zařízení byla uplatněna správa barev, potřebují aktuální "
+"barevné profily."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Dozvědět se více"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Dozvědět se více o správě barev"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Pro _všechny uživatele"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Nastavit tento profil pro všechny uživatele tohoto počítače"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "Povo_lit"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Přid_at profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrovat…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibrovat zařízení"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Odeb_rat profil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Zobrazit detaily"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Nelze najít žádná zařízení, u kterých lze provádět správu barev"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (podsvětlení výbojkami CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (podsvětlení RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (podsvětlení bílými LED)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Široký gamut LCD (podsvětlení výbojkami CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Široký gamut LCD (podsvětlení RGB LED)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Vysoká"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minut"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Střední"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minut"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Nízká"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minut"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Nativní pro zobrazení"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (tisk a publikování)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografie a grafika)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standardní rozsah"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testovací profil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatický"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Nízká kvalita"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Střední kvalita"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Vysoká kvalita"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Výchozí RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Výchozí CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Výchozí odstíny šedé"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Výrobce dodal tovární kalibrační data"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Celoobrazovková korekce není s tímto profilem možná"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Tento profil už nemusí být přesný"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Barevnost"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Kalibrovat barvy zařízení, jako jsou obrazovky, kamery nebo tiskárny"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "barvy;ICC;profil;kalibrace;tiskárna;obrazovka;displej;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Ostatní…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Výběr jazyka"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Vybrat"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Žádné jazyky nebyly nenalezeny"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Více…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Odemkněte, abyste mohli měnit nastavení"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Některá nastavení musí být odemknuta, než je můžete změnit."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Odemknout…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Přidat hodinu"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Přidat minutu"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Čas"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Ubrat hodinu"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Ubrat minutu"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "dnes"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "včera"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %B"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %B %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hodiny"
+msgstr[1] "%d hodin"
+msgstr[2] "%d hodin"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuty"
+msgstr[1] "%d minut"
+msgstr[2] "%d minut"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekundy"
+msgstr[1] "%d sekund"
+msgstr[2] "%d sekund"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekund"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Přístupový bod"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24hodinový"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "dop./odp."
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e. %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e. %B %Y, %k:%M"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l∶%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%k∶%M"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Datum a čas"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Rok"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Měsíc"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "leden"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "únor"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "březen"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "duben"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "květen"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "červen"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "červenec"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "srpen"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "září"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "říjen"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "listopad"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "prosinec"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Den"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Časové pásmo"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "hledat město"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Datum a čas automaticky"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Vyžaduje přístup k Internetu"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Da_tum a čas"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Časové pás_mo automaticky"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Vyžaduje zapnuté služby určování polohy a přístup k Internetu"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Zapnuto"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Čas_ové pásmo"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Formát času"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Změnit datum a čas, včetně časového pásma"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "hodiny;časové pásmo;umístění;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Změnit nastavení systémového času a data"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Abyste mohli měnit nastavení času a data, musíte se autentizovat."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Pošta"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalendář"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "H_udba"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotografie"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Výchozí aplikace"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Nastavit výchozí aplikace"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"výchozí;aplikace;preferovaný;preferovaná;preferované;upřednostňovaný;"
+"upřednostňovaná;upřednostňované;média;médium;multimédia;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Díky odesílání hlášení o technických problémech se může %s vylepšovat. "
+"Hlášení jsou odesílána anonymně a jsou z nich odstraněny osobní údaje. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Hlášení problémů"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatické hlášení problémů"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostiky"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Nahlásit problémy"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostika;diagnostiky;zhroucení;pád;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Zapnuto"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Vypnuto"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Použít změny?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Změny nelze použít"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Může to být dáno omezeními hardwaru."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Použít"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Zpět"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Nastavení displeje jsou zakázána"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Více displejů"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Spojit"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Duplikovat"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Obsahuje horní lištu a Činnosti"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Hlavní displej"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Noční světlo"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Na šířku"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Na výšku vpravo"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Na výšku vlevo"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Na šířku (překlopené)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientace"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Rozlišení"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Obnovovací frekvence"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Přizpůsobit pro TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Škálovat"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Noční světlo dostupné"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Může to být způsobeno používaným grafickým ovladačem, nebo je uživatelské "
+"prostředí používáno vzdáleně."
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Dočasně vypnout do zítřka"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Restartovat filtr"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Noční světlo dělá barvy obrazovky teplejší. To pomáhá zabránit únavě očí a "
+"nespavosti."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Plánování"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Od soumraku do rozbřesku"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Ruční plánování"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Čas"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Od"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hodina"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuta"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "dop."
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "odp."
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Do"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Barevná teplota"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Displeje"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Zvolit, jak se mají používat připojené monitory a projektory"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"panel;projektor;xrandr;obrazovka;rozlišení;obnovovací frekvence;monitor;"
+"displej;noc;tma;světlo;modrá;červený;posuv;posun;barva;rozbřesk;soumrak;"
+"východ;západ;slunce;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:109
+msgid "Secure Boot is Active"
+msgstr "Bezpečné zavádění je aktivní"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení. V "
+"tuto chvíli je zapnuté a správně funguje."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Bezpečné zavádění má problémy"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení. V "
+"tuto chvíli je zapnuté, ale nefunguje, protože má neplatný klíč."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Problémy s bezpečným zaváděním se dají často vyřešit v nastaveních firmwaru "
+"UEFI vašeho počítače (dříve BIOS). Hledejte „Secure Boot“. Výrobce vašeho "
+"hardwaru by měl poskytovat návod, jak postupovat."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Ohledně pomoci kontaktujte výrobce vašeho hardwaru nebo poskytovatele "
+"technické podpory."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Bezpečné zavádění je vypnuté"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení. V "
+"tuto chvíli je vypnuté."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Bezpečné zavádění se obvykle zapíná v nastaveních firmwaru UEFI vašeho "
+"počítače (dříve BIOS). Hledejte „Secure Boot“. Ohledně pomoci kontaktujte "
+"výrobce vašeho hardwaru nebo poskytovatele technické podpory."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Bezpečné zavádění brání načtení škodlivého softwaru při startu zařízení.\n"
+"\n"
+"Ohledně pomoci kontaktujte výrobce vašeho hardwaru nebo poskytovatele "
+"technické podpory."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Prošlo"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Selhalo"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Zařízení je v souladu s HSI úrovně %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:482
+msgid "Security Level 0"
+msgstr "Úroveň zabezpečení 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Toto zařízení nemá žádnou ochranu proti hardwarovým bezpečnostním hrozbám. "
+"Může to být jen otázka nastavení hardwaru nebo firmwaru. Doporučujeme vám "
+"kontaktovat svého poskytovatele technické podpory."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:489
+msgid "Security Level 1"
+msgstr "Úroveň zabezpečení 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Toto zařízení má jen minimální ochranu proti hardwarovým bezpečnostním "
+"hrozbám. Jedná se o nejnižší úroveň bezpečnosti zařízení a poskytuje ochranu "
+"jen proti jednoduchým bezpečnostním útokům."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:496
+msgid "Security Level 2"
+msgstr "Úroveň zabezpečení 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Toto zařízení má základní ochranu proti hardwarovým bezpečnostním hrozbám. "
+"Ta poskytuje ochranu proti některým běžným bezpečnostním útokům."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:503
+msgid "Security Level 3"
+msgstr "Úroveň zabezpečení 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Toto zařízení má rozšířenou ochranu proti hardwarovým bezpečnostním "
+"hrozbám. Jedná se o nejvyšší úroveň bezpečnosti zařízení a poskytuje ochranu "
+"i proti pokročilým bezpečnostním útokům."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:518
+msgid "Security Level"
+msgstr "Úroveň zabezpečení"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:519
+msgid "Security levels are not available for this device."
+msgstr "Pro toto zařízení nejsou dostupné různé úrovně zabezpečení."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Kontaktujte výrobce svého hardwaru ohledně pomoci s aktualizacemi zabezpečení."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Řešení tohoto problému možná spočívá jen v nastavení firmwaru UEFI tohoto "
+"zařízení nebo by vám mohla poradit technická podpora."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Řešení tohoto problému možná spočívá jen v nastavení firmwaru UEFI tohoto "
+"zařízení."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "S řešením tohoto problému by vám mohla pomoci technická podpora."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Úroveň 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Úroveň 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Úroveň 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:110
+msgid "Protected against malicious software when the device starts."
+msgstr "Chráněno proti škodlivému softwaru při spouštění zařízení."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:116
+msgid "Secure Boot has Problems"
+msgstr "Bezpečné zavádění má problémy"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:117
+msgid "Some protection when the device is started."
+msgstr "Aspoň nějaká ochrana při spouštění zařízení."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:122
+msgid "Secure Boot is Off"
+msgstr "Bezpečné zavádění je vypnuté"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:123
+msgid "No protection when the device is started."
+msgstr "Bez ochrany při spouštění zařízení."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:142
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Tato záležitost by mohla být způsobena změnou nastavení firmwaru UEFI, změnou "
+"nastavení operačního systému nebo škodlivým softwarem v systému."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:150
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Tato záležitost by mohla být způsobena změnou nastavení firmwaru UEFI nebo "
+"škodlivým softwarem v systému."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:157
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Tato záležitost by mohla být způsobena změnou nastavení operačního systému "
+"nebo škodlivým softwarem v systému."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:483
+msgid "Exposed to serious security threats."
+msgstr "Vystaveno vážným bezpečnostním hrozbám."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:490
+msgid "Limited protection against simple security threats."
+msgstr "Omezená ochrana proti jednoduchým bezpečnostním hrozbám."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:497
+msgid "Protected against common security threats."
+msgstr "Ochrana proti běžným bezpečnostním hrozbám."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:504
+#: panels/firmware-security/cc-firmware-security-panel.c:512
+msgid "Protected against a wide range of security threats."
+msgstr "Ochrana proti širokému spektru bezpečnostních hrozeb."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:511
+msgid "Comprehensive Protection"
+msgstr "Celková ochrana"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Žádné události"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Ochrana firmwaru proti zápisu"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Zámek ochrany firmwaru proti zápisu"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Oblasti firmwaru BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Oblast Descriptor firmwaru BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Ochrana DMA před zavedením systému"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Zavedení systému ověřené přes Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard chráněn pomocí ACM"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Zásady pro chyby Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Jednorázový zápis Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET je povolený"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET je aktivní"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Šifrovaná RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Ochrana IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Uzamknutí linuxového jádra"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Ověřování linuxového jádra"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Odkládací oddíl Linuxu"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Uspávání do paměti"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Uspávání do nečinnosti"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI Platform Key"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI Secure Boot"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Nastavení TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Obnovení TPM PCR"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Tovární režim Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Přepisování Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Verze Intel Management Engine"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Aktualizace firmwaru"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Atestace firmwaru"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Ověřování aktualizačních modulů firmwaru"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Ladění platformy"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Bezpečnostní kontroly procesoru"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Ochrana firmwaru AMD proti návratu starších verzí"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Ochrana firmwaru AMD proti opakovanému zápisu"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Ochrana firmwaru AMD proti zápisu"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr ""
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Platné"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Neplatné"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Není zapnuto"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Uzamknuto"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Neuzamknuto"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Šifrováno"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Nešifrováno"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Pošpiněno"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Nepošpiněno"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Nalezeno"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Nenalezeno"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Podporováno"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Nepodporováno"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Zabezpečení zařízení"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Bezpečnostní stav firmwaru hostitele"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"obrazovka;zamknout;zámek;diagnostika;pád;zhroucení;soukromý;osobní;nedávný;"
+"dočasný;tmp;index;jméno;síť;identita;soukromí;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Není známo"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64bitový"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32bitový"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "neznámý"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "nelze zjistit"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo systému"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Název zařízení"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Model hardwaru"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Paměť"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Kapacita disku"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Počítá se…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Název OS"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID sestavení: OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Typ OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Verze GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Načítá se…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Okenní systém"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualizace"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Aktualizace softwaru"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Přejmenovat zařízení"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Název zařízení se používá k identifikaci tohoto zařízení, když je prohlíženo "
+"přes síť, nebo když se párují zařízení Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Název zařízení"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "Přej_menovat"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "O systému"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Zobrazit informace o systému"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"zařízení;počítač;systém;informace;hostname;název;paměť;procesor;verze;"
+"výchozí;aplikace;upřednostňovaný;cd;dvd;usb;zvuk;video;disk;výměnný;média;"
+"automatické spuštění;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Zvuk a média"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Vypnout/zapnout zvuk"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Snížit hlasitost"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Zvýšit hlasitost"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Vypnout/zapnout mikrofon"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Spustit multimediální přehrávač"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Přehrát (nebo přehrát/pozastavit)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pozastavit přehrávání"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Zastavit přehrávání"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Předchozí stopa"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Následující stopa"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Vysunout"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Psaní"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Přepnout na další vstupní zdroj"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Přepnout na předchozí vstupní zdroj"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Spouštěče"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Spustit prohlížeč nápovědy"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Spustit kalkulačku"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Spustit poštovního klienta"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Spustit webový prohlížeč"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Domovská složka"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Hledat"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Systém"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Odhlásit se"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Uzamknout obrazovku"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Přístupnost"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Zapnout nebo vypnout přiblížení"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Přiblížit"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Oddálit"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Zapnout nebo vypnout čtení obrazovky"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Zapnout nebo vypnout klávesnici na obrazovce"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Zvětšit velikost textu"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Zmenšit velikost textu"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Zapnout nebo vypnout vysoký kontrast"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Žádné vstupní zdroje nenalezeny"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Další"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Přidání vstupního zdroje"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Vstupní metody nemohou být použity na přihlašovací obrazovce"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Není vybrán žádný vstupní zdroj"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Volby"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Posunout výš"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Posunout níž"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Předvolby"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Zobrazit rozložení klávesnice"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Odebrat"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Vlastní klávesové zkratky"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Klávesa alternativních znaků"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Klávesu alternativních znaků můžete použít, když chcete zadávat některé "
+"speciální znaky. Někdy můžete tyto znaky najít jako doplňující popisek přímo "
+"na klávesách klávesnice."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "levý Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "pravý Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "levý Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "pravý Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Mmnu"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "pravý Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Klávesa Compose umožňuje zadávání široké škály různých znaků. Používá se "
+"tak, že zmáčknete Compose a po té posloupnost znaků. Například klávesa "
+"Compse následovaná znaky <b>C</b> a <b>o</b> vloží <b>©</b>, <b>r</b> "
+"následované <b>'</b> vloží <b>ŕ</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Vstupní zdroje můžete přepínat pomocí klávesové zkratky %s.\n"
+"Tu můžete změněnit v nastavení klávesových zkratek."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Vstupní zdroje"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Zahrnuje rozložení klávesnice a metody zadávání."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Přepínání vstupního zdroje"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Použít _stejný zdroj pro všechna okna"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Přepínat vstupní zdroje samostatně pro jednotl_ivá okna"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Psaní speciálních znaků"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Způsoby zadávání symbolů a variant písmen pomocí klávesnice."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Klávesové zkratky"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Zobrazit a přizpůsobit klávesové zkratky"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d změněná"
+msgstr[1] "%d změněné"
+msgstr[2] "%d změněných"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Vráti všechny klávesové zkratky na výchozí?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Vrácení klávesových zkratek na výchozí může ovlivnit vaše vlastní klávesové "
+"zkratky. A nepůjde to vrátit zpět."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Zrušit"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Všechny na výchozí"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Všechny na výchozí…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Vrátit všechny klávesové zkratky na výchozí klávesy"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Skupina"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Klávesové zkratky"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Přidat klávesovou zkratku"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Přidání vlastních klávesových zkratek"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Nastavte si vlastní klávesové zkratky pro spouštění aplikací, provádění "
+"skriptů a další věci."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Přidat klávesovou zkratku"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nebyla nalezena žádná klávesová zkratka"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s se již používá pro činnost „%s“. Pokud ji nahradíte, bude klávesová "
+"zkratka pro činnost „%s“ zakázána."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Zadejte novou klávesovou zkratku"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Nastavení vlastní klávesové zkratky"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Nastavit zkratku"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Zadejte novou zkratku pro činnost „%s“."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Přidání vlastní klávesové zkratky"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Odeb_rat"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Na_hradit"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "Nas_tavit"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Zmáčknutím Esc přerušíte, zmáčknutím Backspace zakážete klávesovou zkratku."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Název"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Příkaz"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Klávesová zkratka"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Nastavit klávesovou zkratku…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Žádná"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Vrátit klávesovou zkratku na výchozí"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klávesnice"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Změnit klávesové zkratky a nastavit předvolby pro psaní, rozložení "
+"klávesnice a vstupních zdrojů."
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"klávesová zkratka;zkratka;pracovní plocha;okno;změnit velikost;změna "
+"velikosti;přiblížit;přiblížení;zvětšit;zmenšit;kontrast;vstup;zdroj;zámek;"
+"zamknout;hlasitost;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Služby určování polohy jsou vypnuty"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Žádné aplikace nemohou získat informace o poloze."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Služby určovaná polohy umožňují aplikacím znát vaši zeměpisnou polohu. "
+"Použití Wi-Fi a mobilního připojení zvyšuje přesnost.\n"
+"\n"
+"Využívá se Mozilla Location Service: <a href='https://location.services."
+"mozilla.com/privacy'>Ochrana soukromí</a>\n"
+"\n"
+"Aplikacím níže můžete povolit určování polohy."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Žádná aplikace si nepožádala o přístup k informacím o poloze"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Ochraňte informace o své poloze"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "místo;poloha;pozice;gps;galileo;glonass;gnss;soukromí;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofon je vypnutý"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Žádné aplikace nemohou nahrávat zvuk."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Díky mikrofonu mohou aplikace nahrávat a poslouchat zvuky. Jeho vypnutí může "
+"způsobit, že některé aplikace nemusí fungovat správně.\n"
+"\n"
+"Aplikacím níže můžete povolit používat mikrofon."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Žádná aplikace si nepožádala o přístup k mikrofonu"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Ochránit své konverzace"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofon;nahrávání;nahrávka;záznam;aplikace;soukromí;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Vyzkoušet na_stavení"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Obecné"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Hlavní tlačítko"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Nastavuje pořadí fyzických tlačítek myši a touchpadu."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Levé"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Pravé"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Myš"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Rychlost myši"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Přirozený posuv"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Posouvá se obsah, a ne zobrazení."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Rychlost touchpadu"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Kliknutí klepnutím"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Kliknutí klepnutím"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Posunování dvěma prsty"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Posunování po hraně"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Zkuste jednoduché a dvojité kliknutí a posouvání"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Pětiklepnutí – čas na GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dvojité kliknutí, hlavní tlačítko"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Kliknutí, hlavní tlačítko"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dvojité kliknutí, prostřední tlačítko"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Kliknutí, prostřední tlačítko"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dvojité kliknutí, vedlejší tlačítko"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Kliknutí, vedlejší tlačítko"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Myš a touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Změnit citlivost myši nebo touchpadu a vybrat ovládání pro praváky nebo "
+"leváky"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"trackpad;ukazatel;kliknutí;klepnutí;dvojité;tlačítko;trackball;posuv;"
+"posouvat;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Citlivý ro_h"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Dotkněte se levého horního roku a otevře se přehled Činností."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Aktivní okraje obrazovky"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Přetažením okna k horní, levé nebo pravé hraně obrazovky změníte jeho "
+"velikost."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Pracovní plochy"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dynamické pracovní plochy"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Bude automaticky odebírat prázdné pracovní plochy."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Neměnný počet pracovních ploch"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Je dán počet trvalých pracovních ploch."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Počet pracovních ploch"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Více monitorů"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Pracovní plochy pouze na _hlavním displeji"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Pracovní plochy na _všech displejích"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Přepínání aplikací"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Zahrnovat aplikace ze _všech pracovních ploch"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Zahrnovat jen aplikace ze _aktuální pracovní plochy"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitasking"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Správa předvoleb pro produktivitu a multitasking"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"multitasking;multitask;více úkolů;více úloh;produktivita;přizpůsobit;"
+"přizpůsobení;desktop;citlivý roh;pracovní plochy;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Problém, něco se stalo špatně. Kontaktujte prosím vyrobce softwaru."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Je zapotřebí, aby běžel program NetworkManager."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Ostatní zařízení"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Přidat připojení"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nenastaveno"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Nezabezpečená síť (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Zabezpečená síť (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Zabezpečená síť (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Zabezpečená síť (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Zabezpečená síť"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Připojeno"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Volby…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Zapnutí přístupového bodu způsobí odpojení od sítě %s a nebudete moci "
+"přistupovat do Internetu přes Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Musí mít nejméně 8 znaků"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Musí mít nanejvíš %d znak"
+msgstr[1] "Musí mít nanejvíš %d znaky"
+msgstr[2] "Musí mít nanejvíš %d znaků"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Zapnout bezdrátový přístupový bod?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Přístupový bod Wi-Fi umožňuje sdílet s ostatními internetové připojení tím, "
+"že se vytvoří síť Wi-Fi, ke které se ostatní mohou připojit. Aby to mohlo "
+"fungovat, musíte být k Internetu připojení jinak, než přes Wi-Fi, která se "
+"ke sdílení použije."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Název sítě"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Heslo"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Vygenerovat náhodné heslo"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "automaticky vygenerované heslo"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "Zapnou_t"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Zastavit přístupový bod a odpojit případné uživatele?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "Za_stavit přístupový bod"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Režim „Letadlo“"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Vypnout Wi-Fi, Bluetooth a mobilní připojení"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nebyl nalezen žádný adaptér Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Ujistěte se, že máte adaptér Wi-Fi připojený a zapnutý"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Režim „Letadlo“ je zapnutý"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Musíte jej vypnout, když chcete používat Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Bezdrátový přístupový bod je aktivní"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobilní zařízení mohou pro připojení načíst QR kód."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Vypnout přístupový bod…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Viditelné sítě"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Je zapotřebí, aby běžel program NetworkManager"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Zabezpečení 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Zabezpečení"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "současná"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "trvalá"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "náhodná"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "stabilní"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Zde zadaná adresa MAC bude použita jako hardwarová adresa pro síťové "
+"zařízení, na kterém je toto připojení aktivováno. Funkcionalita se nazývá "
+"klonování MAC nebo spoofing. Příklad: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Podnikové"
+
+# Zabezpečení
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Žádné"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "nikdy"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "před %i dnem"
+msgstr[1] "před %i dny"
+msgstr[2] "před %i dny"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+# Síla signálu
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Žádná"
+
+# Síla signálu
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Slabá"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Dostačující"
+
+# Síla signálu
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Dobrá"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Výborná"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Adresa IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adresa IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adresa IP"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Zapomenout připojení"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Odebrat profil připojení"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Odebrat VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Podrobnosti"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automaticky"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identita"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Smazat adresu"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Smazat směrování"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Žádné"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP, 40/128bitový klíč (Hex nebo ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP, 128bitová heslová fráze"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamické WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA a WPA2, osobní"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA a WPA2, podnikové"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3, osobní"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Síla signálu"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Rychlost spojení"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hardwarová adresa"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Podporované frekvence"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Výchozí směrování"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Naposledy použito"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Připojit _automaticky"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Zpřístupnit _ostatním uživatelům"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "_Měřené připojení: má omezení dat nebo účtované poplatky"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Aktualizace softwaru a další objemná stahování dat nebudou spouštěna "
+"automaticky."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Název"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC adresa"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonovaná adresa"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bajtů"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Metoda IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatické (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Pouze link-local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Ruční"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Zakázat"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Sdíleno s dalšími počítači"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresy"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresa"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Maska sítě"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Brána"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automatické"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatické DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Adresy serverů DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Adresy IP oddělte čárkami"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Směrování"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatické směrování"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrika"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Použít toto připojení _pouze pro zdroje na jeho síti"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Metoda IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatické, pouze DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefix"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Nelze otevřít editor připojení"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Nový profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Neplatné nastavení %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Neplatné nastavení %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importovat ze souboru…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Přidání VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Zab_ezpečení"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Nelze importovat připojení VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Soubor „%s“ nelze přečíst nebo neobsahuje rozpoznatelné informace o "
+"připojení VPN\n"
+"\n"
+"Chyba: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Výběr souboru pro import"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Soubor s názvem „%s“ již existuje."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Nahradit"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Chcete nahradit %s připojením VPN, které ukládáte?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Nelze exportovat připojení VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Připojení VPN „%s“ nemůže být exportováno do %s.\n"
+"\n"
+"Chyba: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exportovat připojení VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Chyba: nelze načíst editor připojení VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Určit, jak se připojujete k Internetu"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "síť;IP;LAN;proxy;WAN;širokopásmové;připojení;modem;Bluetooth;vpn;dns;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Určit, jak se připojujete k sítím Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"síť;bezdrátové;bezdrátová;Wi-Fi;WiFi;drátové;drátová;IP;LAN;širokopásmové;"
+"připojení;dns;přístupový bod;hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nikdy"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "dnes"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "včera"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Naposledy použito"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Drátová"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Přidat nové připojení"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Informace o síti pro vybrané sítě, včetně hesel a vlastního nastavení, budou "
+"ztraceny."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Zapomenout"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Známé sítě Wi-Fi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Zapomenout"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Systémová zásada zakazuje použití jako přístupový bod"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Bezdrátové zařízení nepodporuje režim přístupového bodu"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Pokud není adresa URL pro nastavení poskytnuta, použije se automatické "
+"vyhledání webové proxy."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Nedoporučuje se v nedůvěryhodných veřejných sítích."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Vypnout zařízení"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktivní"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Poskytovatel"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Síťová proxy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Hostitel _SOCKS"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorovat hostitele"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Port proxy HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Port proxy HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Port proxy FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Port proxy Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_URL s nastavením"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Vypnout připojení VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Název sítě"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Typ zabezpečení"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Heslo"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Zapnout Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Další volby…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "Přip_ojit ke skryté síti…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Zapnou_t bezdrátový přístupový bod…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Známé sítě Wi-_Fi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Neznámý stav"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Nespravováno"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Nedostupné"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Připojuje se"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Požadována autentizace"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Odpojuje se"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Připojení selhalo"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Neznámý stav (chybí)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Nastavení selhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Nastavení IP selhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Konfigurace IP vypršela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Hesla byla požadována, ale neposkytnuta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Žadatel 802.1x odpojen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Konfigurace žadatele 802.1x selhala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Žadatel 802.1x selhal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Žadateli 802.1x trvalo ověření příliš dlouho"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Spuštění služby PPP selhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Služba PPP odpojena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP selhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Spuštění klienta DHCP selhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Chyba klienta DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Klient DHCP selhal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Spuštění služby sdíleného připojení selhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Služba sdíleného připojení selhala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Spuštění služby AutoIP selhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Chyba služby AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Služba AutoIP selhala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linka obsazena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Žádný vytáčecí tón"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Nelze navázat spojení"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Požadavek na vytáčení vypršel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Pokus o vytáčení selhal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Inicializace modemu selhala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Výběr zvoleného APN selhal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Nevyhledávají se sítě"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Registrace do sítě zamítnuta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Registrace do sítě vypršela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Registrace do požadované sítě selhala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Ověření PIN selhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Firmware zařízení nejspíše chybí"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Připojení bylo ztraceno"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Existující spojení bylo převzato"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem nenalezen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Připojení Bluetooth selhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Karta SIM není vložena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Požadován PIN karty SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Požadován PUK karty SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Chybná SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Závislost připojení selhala"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Schází firmware"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Odpojen kabel"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "nedefinovaná chyba v zabezpečení 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "není vybrán žádný soubor"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "blíže neurčená chyba při ověřování souboru s metodou eap"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Soukromé klíče DER, PEM, PKCS#12 nebo PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certifikáty DER nebo PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "schází soubor EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Soubory PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonymní"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Totožnost ověřena"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Obojí"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anony_mní identita"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Soubory PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Vybrat soubor PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Interní ověření totožnosti"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Umožnit automatické _zajišťování PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "chybí uživatelské jméno pro EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "chybí heslo pro EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Uživatelské jméno"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Heslo"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Zobrazit he_slo"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "neplatný certifikát EAP-PEAP certifikační autority: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+"neplatný certifikát EAP-PEAP certifikační autority: žádný certifikát není "
+"zadán"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Verze 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Verze 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certifikát C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Vybrat certifikát certifikační autority"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "_Certifikát CA není požadován"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Verze PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "chybí uživatelské jméno pro EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "chybí heslo pro EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "chybí identita pro EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "neplatný certifikát EAP-TLS certifikační autority: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+"neplatný certifikát EAP-TLS certifikační autority: žádný certifikát není "
+"zadán"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "neplatný soukromý klíč pro EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "neplatný uživatelský certifikát pro EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Nešifrované soukromé klíče nejsou bezpečné"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Vypadá to, že vybraný soukromý klíč není chráněný heslem.  To může způsobit, "
+"že vaše bezpečnostní údaje budou kompromitovány. Vyberte prosím soukromý "
+"klíč chráněný heslem.\n"
+"\n"
+"(Soukromý klíč můžete zabezpečit heslem pomocí openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Vyberte svůj osobní certifikát"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Vyberte svůj soukromý klíč"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentita"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Uživatelský certifikát"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Soukromý _klíč"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Heslo k _soukromému klíči"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "neplatný certifikát EAP-TTLS certifikační autority: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+"neplatný certifikát EAP-TTLS certifikační autority: žádný certifikát není "
+"zadán"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (bez EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Doména"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Neznámá chyba při ověřování zabezpečení 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunelované TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Chráněné EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Ověření totožnosti"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Vybrat soubor"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "chybí uživatelské jméno pro LEAP"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "chybí heslo pro LEAP"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Schází heslo k Wi-Fi."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Typ"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "chybí klíč WEP"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"neplatný klíč WEP: klíč s délkou %zu musí obsahovat jen šestnáctkové číslice"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"neplatný klíč WEP: klíč s délkou %zu musí obsahovat jen znaky sady ASCII"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"neplatný klíč WEP: nesprávná délka klíče %zu. Klíč musí mít délku 5/13 "
+"(ASCII) nebo 10/26 (HEX)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "neplatný klíč WEP: heslová fráze nesmí být prázdná"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "neplatný klíč WEP: heslová fráze musí být kratší než 64 znaků"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (výchozí)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Otevřený systém"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Sdílený klíč"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Klíč"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Z_obrazit klíč"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Inde_x WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"neplatný osobní klíč WPA: neplatná délka klíče %zu. Musí být [8,63] bajtů "
+"nebo 64 šestnáctkový číslic"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"neplatný osobní klíč WPA: nelze zpracovat klíč s 64 bajty jako šestnáctkový"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Upozornění"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Zvuková _upozornění"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Vyskakovací u_pozornění"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"I když je vyskakování upozornění vypnuté, budou se upozornění nadále "
+"objevovat v seznamu upozornění."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Zobrazovat o_bsah zpráv ve vyskakovacích cedulích"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Upozornění na za_mykací obrazovce"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Zobrazovat _obsah zpráv na uzamknuté obrazovce"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Nerušit"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Upozornění na za_mykací obrazovce"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Spravovat to, jak jsou upozornění zobrazována a co ukazují"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "upozornění;proužek;zpráva;oblast;pruh;cedule;baner;banner;vyskakovací;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Jiný"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s byl odebrán"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Chyba při odebírání účtu"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Zpět"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Zavřít upozornění"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Připojení k vašim datům v cloudu"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Bez internetového připojení – připojte se, abyste mohli nastavit nové účty"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Přidat účet"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Účet %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Odebrat účet"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Účty on-line"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Přihlaste se k účtům on-line a rozhodněte se, k čemu je používat"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;web;on-line;diskuze;chat;kalendář;e-mail;mail;"
+"email;pošta;kontakt;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Neznámý čas"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuta"
+msgstr[1] "%i minuty"
+msgstr[2] "%i minut"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hodina"
+msgstr[1] "%i hodiny"
+msgstr[2] "%i hodin"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hodina"
+msgstr[1] "hodiny"
+msgstr[2] "hodin"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuta"
+msgstr[1] "minuty"
+msgstr[2] "minut"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s do plného nabití"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Pozor, zbývá %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Zbývá %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Plně nabito"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Nenabíjí se"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Vybitá"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Nabíjí se"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Vybíjí se"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Bezdrátová myš"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Bezdrátová klávesnice"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Záložní zdroj napájení"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Osobní digitální asistent (PDA)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobilní telefon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Multimediální přehrávač"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Počítač"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Herní vstupní zařízení"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterie"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Hlavní"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Přídavná"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Baterie"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Při _nečinnosti"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Uspat do paměti"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Vypnout"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Uspat na disk"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nic nedělat"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Při napájení z baterie"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Při napájení ze sítě"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nikdy"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automaticky uspat"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Režim vysokého výkonu byl dočasně vypnut z důvodu zvýšené operační teploty."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Pravděpodobně máte počítač na klíně, proto není režim vysokého výkonu "
+"dočasně k dispozici. Přesuňte zařízení na stabilní povrch, aby se obnovil."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Režim vysokého výkonu je dočasně zakázaný."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Nízký stav baterie: zapnuto šetření energií. Předchozí režim bude obnoven, "
+"jakmile se baterie dostatečně nabije."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Režim úspory energie byl aktivován aplikací „%s“."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Režim vysokého výkonu byl aktivován aplikací „%s“."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hodiny"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 hodin"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Režim napájení"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Ovlivňuje výkon systému a spotřebu energie."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Volby šetření energií"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatický jas obrazovky"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Jas obrazovky se přizpůsobuje okolnímu světlu."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Stmívání obrazovky"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Sníží jas obrazovky, když je počítač neaktivní."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Zhasínat _obrazovku"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Vypne obrazovku po nějaké době nečinnosti."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatický režim šetření energií"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Zapne režim šetření enrgií, když je nízký stav baterie."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automaticky uspat"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pozastaví běh počítače po nějaké době nečinnosti"
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Chování tlačítka na_pájení"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Zobrazovat _procenta baterie"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatické uspání"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Při _napájení ze sítě"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "_Při napájení z baterie"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Po uplynutí"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Vysoký výkon"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Vysoký výkon za cenu vyšší spotřeby energie."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Rovnováha"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standardní výkon i spotřeba energie."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Šetření energií"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Šetří energii za cenu sníženého výkonu."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Napájení"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Zobrazit stav baterie a změnit nastavení šetření energií"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"napájení;uspání;uspání do paměti;uspání na disk;baterie;jas;ztlumit;monitor;"
+"DPMS;neaktivní;energie;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Tiskárna „%s“ byla odebrána"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Selhalo přidání nové tiskárny."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Nelze načíst uživatelské rozhraní: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Odemkněte, abyste mohli přidávat tiskárny a měnit nastavení"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Tiskárny"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Přidejte tiskárny, prohlédněte si tiskové úlohy a rozhodněte, jak chcete "
+"tisknout"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "tiskárna;fronta;tisk;papír;inkoust;toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Přidat tiskárnu"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "Odemkno_ut"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Žádná tiskárna nebyla nalezena"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Zadejte síťovou adresu tiskárny nebo ji vyhledejte"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Požadováno ověření totožnosti"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Chcete-li vidět tiskárny z tiskového serveru, zadejte uživatelské jméno a "
+"heslo."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Uživatelské jméno"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Podrobnosti o tiskárně %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Nenalezen vyhovující ovladač"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Vyberte soubor PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Soubory popisu tiskárny PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Název tiskárny nesmí obsahovat mezeru, tabulátor, # nebo /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Umístění"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Ovladač"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Vyhledávají se upřednostňované ovladače…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Hledat ovladač"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Vybrat z databáze…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instalovat soubor PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Vyberte ovladač tiskárny"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Načítá se databáze ovladačů…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Vybrat"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Tiskárna JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Tiskárna LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Jednostranně"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Delší okraj (standardní)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Kratší okraj (obráceno)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Na výšku"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Na šířku"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Obráceně na šířku"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Obráceně na výšku"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Pokračovat"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pozastavit"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Čeká"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pozastaveno"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Požadováno ověření"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Zpracovává se"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Zastaveno"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Zrušeno"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Přerušeno"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Dokončeno"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Přesunout tuto úlohu na začátek fronty"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u úloha vyžaduje ověření"
+msgstr[1] "%u úlohy vyžadují ověření"
+msgstr[2] "%u úloh vyžaduje ověření"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s – aktivní úlohy"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Zadejte pověření pro tisk z tiskárny %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Doména"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "O_věřit"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Vymazat vše"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Ověřit"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Nejsou žádné aktivní tiskové úlohy"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Odemknout tiskový server"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Odemknout server %s"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Chcete-li vidět tiskárny ze serveru %s, zadejte uživatelské jméno a heslo."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Vyhledávají se tiskárny"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Sériový port"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Paralelní port"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Umístění: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adresa: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Server požaduje ověření totožnosti"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Oboustranně"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Typ papíru"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Zdroj papíru"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Výstupní zásobník"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Rozlišení"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Předfiltrování GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Stránek na stranu papíru"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Oboustrannost"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientace"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Obecné"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Vzhled strany"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Volitelné doplňky"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Úloha"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Kvalita obrazu"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Barevnost"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Dokončení"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Testovací stránka"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Testovací stránka"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Vybrat automaticky"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Výchozí nastavení tiskárny"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Zahrnout pouze písma GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Převést na PostScript úrovně 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Převést na PostScript úrovně 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Bez předfiltrování"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Výrobce"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nejsou žádné aktivní úlohy"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u úloha"
+msgstr[1] "%u úlohy"
+msgstr[2] "%u úloh"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Čištění tiskových hlav"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Dochází toner"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Došel toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Životnost vývojové jednotka se blíží ke konci"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Opotřebená vývojová jednotka"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Životnost zásobníku se blíží ke konci"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Opotřebený zásobník"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Otevřen kryt"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Otevřena dvířka"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Dochází papír"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Došel papír"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Off-line"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Zastaveno"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Odpadní nádobka je téměř plná"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Odpadní nádobka je plná"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Životnost optického válce se blíží ke konci"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Optický válec není nadále funkční"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Připraveno"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Nepřijímá úlohy"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Zpracovává se"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Volby tisku"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Podrobnosti o tiskárně"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Používat tiskárnu jako výchozí"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Vyčistit tiskové hlavy"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Odebrat tiskárnu"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Stav množství inkoustu"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Po vyřešení problému prosím restartujte."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Restartovat"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Přidat tiskárnu…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Žádné tiskárny"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Bohužel to vypadá, že systémová\n"
+"   služba tisku není dostupná."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formáty"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Hledat národní prostředí…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Běžné formáty"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Všechny formáty"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Nic nebylo nalezeno"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Hledat můžete země nebo jazyky."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Náhled"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperiální"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrické"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datum"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Datum a čas"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Čísla"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Měrné jednotky"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papír"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Jazyk a formát budou změněny při příštím přihlášení"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Odhlásit se…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Nastavení jazyka se používá pro texty uživatelského rozhraní a webové "
+"stránky. Formát se používá pro čísla, data a měny."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Váš účet"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "Jazy_k"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formáty"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Přihlašovací obrazovka"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Region a jazyk"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Vybrat jazyk a formáty pro zobrazení"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "jazyk;rozložení;klávesnice;vstup;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Zeptat se na další postup"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Nic nedělat"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Otevřít složku"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Ostatní média"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Vyberte aplikaci pro zvuková CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Vyberte aplikaci pro DVD s videem"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Vyberte aplikaci, která má být spuštěna po připojení hudebního přehrávače"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Vyberte aplikaci, která má být spuštěna po připojení fotoaparátu"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Vyberte aplikaci pro CD se softwarem"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "zvukové DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "prázdný disk Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "prázdný disk CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "prázdný disk DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "prázdný disk HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "videodisk Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "čtečka elektronických knih"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "videodisk HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Software Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Vyberte, jak budou média obsluhována"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "Zvukové _CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "Videodisk _DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Hudební přehrávač"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Ostatní média…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nikdy se nedotazovat nebo spouštět programy na vloženém médiu"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Vyberte, jak by měla být obsluhována ostatní média"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Činnost:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Typ:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Výměnná média"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Nastavte si pravidla pro výměnná média"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"zařízení;systém;výchozí;aplikace;preferovaný;preferovaná;upřednostňovaný;"
+"upřednostňovaná;cd;dvd;usb;zvuk;audio;video;disk;výměnný;výměnná;výměnné;"
+"vyměnitelný;vyměnitelná;vyměnitelné;média;médium;automatické spuštění;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "ihned po zčernání"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "po 30 sekundách"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "po 1 minutě"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "po 2 minutách"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "po 3 minutách"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "po 5 minutách"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "po 30 minutách"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "po 1 hodině"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "po 1 minutě"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "po 2 minutách"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "po 3 minutách"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "po 4 minutách"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "po 5 minutách"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "po 8 minutách"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "po 10 minutách"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "po 12 minutách"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "po 15 minutách"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "nikdy"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Zamykání obrazovky"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatické zamykání obrazovky zabrání ostatním v přístupu k počítači, když "
+"jste pryč."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Kdy obrazovku vypnout"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Doba nečinnosti, po které obrazovka zčerná."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automaticky uzamykat _obrazovku"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Kdy o_brazovku automaticky uzamknout"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Doba od zčernání obrazovky, po které je obrazovka automaticky uzamknuta."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Zobrazovat upozor_nění na uzamknuté obrazovce"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Zakázat nová zařízení _USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Zabránit novému zařízení USB ve spolupráci se systémem, kdež je uzamknutá "
+"obrazovka."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Soukromí obrazovky"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Omezit úhel viditelnosti"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Nastavení obrazovky"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "obrazovka;zámek;zamknutí;zamčení;uzamknutí;uzamčení;soukromí;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Vyberte umístění"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Budiž"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Prohledávaná umístění"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Složky, které jsou prohledávané systémovými aplikacemi, jako jsou Soubory, "
+"Fotky a Videa."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Místa"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Záložky"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Ostatní"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Přidat umístění"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nenalezeny žádné aplikace"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Hledat pomocí aplikací"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Zahrnovat výsledky hledání poskytované aplikacemi."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Složky, které jsou prohledávané systémovými aplikacemi."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Nic nebylo nalezeno"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Výsledky jsou zobrazovány podle pořadí v seznamu."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Ovládejte, které aplikace mohou zobrazovat výsledky hledání v přehledu "
+"Činnosti"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "hledání;hledat;najít;index;skrýt;soukromí;privátní;výsledky;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Nebyly zvoleny žádné sítě pro sdílení"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Sítě"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Zapnuto"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Vypnuto"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Zapnuto"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktivní"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Výběr složky"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Přidat"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Povolit sdílení multimédií"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Sdílení souborů vám umožňuje sdílet složku Veřejné s ostatními v aktuální "
+"síti pomocí: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Když je vzdálené přihlašování povolené, mohou se vzdálení uživatelé připojit "
+"příkazem Secure Shell:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Povolit sdílení osobních multimédií"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Byl zkopírován název zařízení"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Byla zkopírována adresa zařízení"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Bylo zkopírováno uživatelské jméno"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Bylo zkopírováno heslo"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Sdílení"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Název _počítače"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "S_dílení souborů"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Vz_dálená plocha"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Sdílení _multimédií"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Vzdálené přihlášení"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Sdílení souborů"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "V_yžadovat heslo"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Vzdálené přihlášení"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Vzdálená plocha"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Vzdálená plocha umožňuje zobrazení a ovládání vašeho uživatelského prostředí "
+"z jiného počítače."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Povolit nebo zakázat u tohoto počítače přihlášení přes vzdálenou plochu."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Vzdálené ovládání"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Umožnit vzdálenému připojení ovládat obrazovku."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Jak se připojovat"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Připojovat se k tomuto počítači pomocí názvu zařízení nebo adresy vzdálené "
+"plochy."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Zkopírovat"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Adresa vzdálené plochy"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Ověření totožnosti"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Pro připojení k tomuto počítači je vyžadováno uživatelské jméno a heslo."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Uživatelské jméno"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Ověřit šifrování"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Otisk šifrovacího klíče"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Otisk šifrovacího klíče by měl být vidět na připojovaném klientovi a měl by "
+"se shodovat."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Sdílení multimédií"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Sdílet hudbu, fotografie a videa po síti."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Složky"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Určete, co chcete sdílet s ostatními"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"sdílet;sdílení;ssh;hostitel;název;vzdálený;obrazovka;desktop;pracovní plocha;"
+"multimédia;zvuk;video;obraz;obrázky;fotografie;filmy;server;vykreslování;"
+"renderer;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Povolit nebo zakázat vzdálené přihlášení"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Pro povolení nebo zakázání vzdáleného přihlášení je vyžadováno ověření "
+"totožnosti"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Vlastní"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Lupnutí"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Brnknutí"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Šlehnutí"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Bzuknutí"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Vyvážení"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Prolínání"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Zadní"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Přední"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Testuje se %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Kliknutím na reproduktor jej otestujete"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Systémová hlasitost"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Hlavní nastavení hlasitosti"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Úrovně hlasitosti"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Výstup"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Výstupní zařízení"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testovat"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Nastavení"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Vstup"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Vstupní zařízení"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Hlasitost"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Zvuk upozornění"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Ztišit"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Zvuk"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Změnit hlasitost zvuku, vstupy, výstupy a upozornění"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"karta;mikrofon;hlasitost;prolínání;vyvážení;bluetooth;náhlavní souprava;zvuk;"
+"výstup;vstup;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Odpojeno"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Připojuje se"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Připojeno"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Chyba ověřování"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Ověřuje se"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Omezená funkcionalita"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Připojeno a ověřeno"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Neznámý"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Ověřeno:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Připojeno:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Registrováno:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Selhalo ověření zařízení: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Zapomenutí zařízení selhalo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Závisí na dalším zařízení"
+msgstr[1] "Závisí na dalších %u zařízeních"
+msgstr[2] "Závisí na dalších %u zařízeních"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Zavřít upozornění"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Název:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Stav:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Ověřit a připojit"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Zapomenout zařízení"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Chyba"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Ověřeno"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Subsystém Thunderbolt (boltd) není nainstalovaný, nebo není správně "
+"nastavený."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Umožňuje přímý přístup k zařízením, jako jsou dokovací stanice nebo externí "
+"GPU."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Připojeny mohou být jen zařízení USB a Display Port."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt se nezdařilo nalézt.\n"
+"Buď systém postrádá podporu pro Thunderbolt, nebo je vypnutá přes BIOS, nebo "
+"je v něm nastavená nepodporovaná úroveň zabezpečení."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Podpora pro Thunderbolt je vypnutá přes BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Úroveň zabezpečení zařízení Thunderbolt nemohla být určena."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Chyba při přepínání přímého režimu: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Bez podpory pro Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Nezdařilo se připojit k subsystému thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Přímý přístup"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Čekající zařízení"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Nejsou připojena žádná zařízení"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Spravujte zařízení Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;soukromí;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Blikání kurzoru"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Kurzor v textových polích bliká."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Rychlost"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Rychlost blikání kurzoru"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Velikost kurzoru"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Velikost kurzoru se dá kombinovat s přiblížením, aby byl kurzor lépe vidět."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Pomoc s klikáním"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulované druhé kliknutí"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Zahájit druhé kliknutí podržením hlavního tlačítka"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Zpož_dění přijetí:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Krátké"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Zpoždění druhého kliknutí"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Dlouhé"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Kl_iknutí posečkáním"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Zahájit kliknutí při zastavení pohybu ukazatele"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Zpož_dění:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Krátké"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Dlouhé"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Práh poh_ybu:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Nízký"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Vysoký"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Opakování kláves"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Opakovat zmáčknutí klávesy, když držíte klávesu zmáčknutou."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Prodleva před opakováním kláves"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Rychlost opakování kláves"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Pomoc s psaním"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Kombinace kláves jedním pr_stem"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Posloupnost modifikačních kláves považovat za kombinaci těchto kláves"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Vypnout při souběžném zmáčknutí _dvou kláves"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Zvukové znamení při zmáčknutí _modifikační klávesy"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Poma_lé klávesy"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Zadejte jaké má být zpoždění, než je klávesa přijata po té, co je zmáčknuta"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Krátké"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Prodleva při psaní pomalými klávesami"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Dlouhé"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Zvukové znam_ení při zmáčknutí klávesy"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Zvukové zn_amení při příjmutí klávesy"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Zvukové znamení při _odmítnutí klávesy"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Vícenáso_bná zmáčknutí kláves"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorovat rychle opakované zmáčknutí klávesy"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Krátké"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Prodleva při psaní s vícenásobným zmáčknutím kláves"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Dlouhé"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Zapnout z kláv_esnice"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Zapínat funkce zpřístupnění pomocí klávesnice"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Výchozí"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Střední"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Velký"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Větší"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Největší"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixely"
+msgstr[2] "%d pixelů"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Vždy zobr_azovat nabídku přístupnosti"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Zrak"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "V_ysoký kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Ve_lký text"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Povolit a_nimace"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Čtečka ob_razovky"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Čtečka obrazovky čte zobrazený text postupně, jak text získává zaměření."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Ozvučení kláve_s"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pípnout při zapnutí nebo vypnutí klávesy Num Lock nebo Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Velikost k_urzoru"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Přiblížení"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Sluch"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Vizuální upozornění"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Klávesnice na obrazovce"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Op_akování kláves"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Blikání kurzoru"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Pomáha_t s psaním"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Ukazování a klikání"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Myš z klávesnice"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Vyh_ledávání ukazatele"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Pomá_hat s klikáním"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Zpoždění _dvojitého kliknutí"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Zpoždění dvojitého kliknutí"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Vizuální upozornění"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "O_testovat blikání"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Použít vizuální signalizaci, když se objeví zvukové upozornění."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Bliknout _celou obrazovkou"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Bliknout _celým oknem"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Krátká"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ obrazovky"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ obrazovky"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ obrazovky"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Dlouhá"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Celá obrazovka"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Horní polovina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Dolní polovina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Levá polovina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Pravá polovina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Volby přiblížení"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "Zvětšení _lupou:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Poloha lupy:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Následovat ukazatel myši"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Část o_brazovky:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Lupa se rozšiřuj_e mimo obrazovku"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Udržovat u_kazatel lupy na středu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Ukazatel lu_py odsouvá okolní obsah"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Ukazatel lupy se přesouvá s o_bsahem"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Zaměřovací _kříž:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Překrývat ukazat_el myši"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Tloušťka:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tenký"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Tlustý"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "Dé_lka:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Barva:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Zaměřovací kříž"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Ovlivnění barev:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Bílá na černém:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Jas:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Barva"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Žádná"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Plná"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Nízký"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Vysoký"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Nízký"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Vysoký"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Ovlivnění barev"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Usnadněte si čtení, poslech, psaní, klikání a další činnosti"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"klávesnice;myš;a11y;přístupnost;zpřístupnění;univerzální přístup;kontrast;"
+"kurzor;zvuk;přiblížení;zvětšení;čtečka obrazovky;čtení obrazovky;text;velký;"
+"obrovský;písmo;font;velikost;přístup;zpřístupnění;kombinace kláves jedním "
+"prstem;pomalé klávesy;vícenásobná zmáčknutí kláves;klávesnice myší;dvojitý;"
+"klik;kliknutí;klepnutí;poklepání;prodleva;rychlost;asistent;opakování;"
+"blikání;blikat;poruchy;handicap;vidění;sluch;psaní;animace;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 hodině"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dnech"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dnech"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dnech"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dnech"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dnech"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dnech"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dnech"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dnech"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Vysypat všechny položky z koše?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Všechny položky v koši budou trvale smazány."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Vyprázdnit koš"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Odstranit dočasné soubory?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Všechny dočasné soubory budou trvale smazány."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Odstranit dočasné soubor_y"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 den"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dní"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dní"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "napořád"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Historie souborů"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Historie souborů uchovává záznamy o souborech, které jste použili. Tyto "
+"informace jsou sdílené mezi aplikacemi a usnadňují nalezení souborů, které "
+"možná budete chtít použít."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "H_istorie souborů"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Trvání _historie souborů"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "V_yčistit historii…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Koš a dočasné soubory"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Koš a dočasné soubory mohou někdy obsahovat osobní nebo citlivé informace. "
+"Jejich automatické mazání může pomoci s ochranou soukromí."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Automaticky mazat obsah _koše"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automaticky mazat dočasné _soubory"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Automaticky mazat _po"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Vyprázdnit koš…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Smazat _dočasné soubory…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Historie souborů a koš"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Nezanechávejte po sobě stopy"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"využití;nedávný;nedávné;historie;soubory;dočasné;dočasný;tmp;soukromí;koš;"
+"vysypat;smazat;mazat;zachovat;uchování;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr ""
+"Mělo by se shodovat s webovou adresou poskytovatele vašeho přihlašování."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Přidání účtu selhalo"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Hesla si neodpovídají."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Registrace účtu selhala"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Ověření s touto doménou není podporováno"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Připojení k doméně selhalo"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Toto přihlašovací jméno nefunguje.\n"
+"Zkuste to, prosím, znovu."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Toto přihlašovací heslo nefunguje.\n"
+"Zkuste to, prosím, znovu."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Přihlášení do domény selhalo"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Nelze najít doménu. Nemáte v názvu překlep?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Přidání uživatele"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Správce"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Správce může přidávat a odebírat ostatní uživatele a měnit nastavení u všech "
+"uživatelů. Na správce nelze uplatnit rodičovskou kontrolu."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Uživatel nastaví heslo při prvním přihlášení"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Nastavit heslo nyní"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Ověření"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Přihlášení do domény"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Uživatelské účty spravované firmou nebo organizací."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Jste odpojeni"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Přihlašování do domény umožňuje použít na tomto zařízení stávající centrálně "
+"spravované uživatelské účty. Tento účet můžete pak použít i pro přístup k "
+"firemním prostředkům na Internetu."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Procházet další obrázky"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Vybrat soubor…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Správa otisků prstů"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Otiskem prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Ne"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Ano"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Přejete si smazat registrované otisky prstů, čímž dojde k vypnutí přihlášení "
+"otiskem prstů?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Není k dispozici žádná čtečka otisku prstu"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Není k dispozici žádná čtečka otisku prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Ujistěte se, že zařízení je správně připojené."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Čtečka otisku prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Zvolte čtečku otisku prstu, kterou chcete nastavit."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Přihlášení otiskem prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Pomocí přihlášení otiskem prstu můžete svůj počítač odemknout a přihlásit se "
+"do něj pouhým přiložením prstu."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Smazat otisky prstů"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Sejmutí otisku prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "k provedení této činnosti je potřeba výhradní přístup k zařízení"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "zařízení si již nárokuje jiný proces"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "nemáte oprávnění provádět tuto činnost"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "nebyl sejmut žádný otisk prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Selhala komunikace se zařízením během snímání otisku prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Selhala komunikace se čtečkou otisků prstů"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Selhala komunikace s démonem pro otisky prstů"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Selhalo vypsání otisku prstů: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Selhalo smazání uložených otisků prstů: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Palec levé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Prostředníček levé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "Ukazováček _levé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Prsteníček levé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Malíček levé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Palec pravé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Prostředníček pravé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Ukazováček p_ravé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Prsteníček pravé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Malíček pravé ruky"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Neznámý otisk prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Dokončeno"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Čtečka otisků prstů je odpojená"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Úložiště čtečky otisku prstů je plné"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Selhalo sejmutí nového otisku prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Selhalo započetí snímání: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Selhalo sejmutí nového otisku prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Selhalo zastavení snímání: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Opakovaně zvedněte a přiložte svůj prst ke čtečce, aby se mohl sejmout otisk "
+"prstu."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Znovu sejmout tento otisk p_rstu…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Sejmout nový otisku prstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Selhalo uvolnění čtečky otisku prstu %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problém při čtení ze zařízení"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Selhalo vyžádání čtečky otisku prstu %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Selhalo získání čtečky otisku prstu: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Tento týden"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Minulý týden"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %B"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %B %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sezení ukončeno"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sezení započato"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s – Aktivita účtu"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Předchozí"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Následující"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Zvolte prosím jiné heslo."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Zadejte prosím své současné heslo ještě jednou."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Heslo nelze změnit"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Změna hesla"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Změn_it"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Současné heslo"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nové heslo"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Potvrzení hesla"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Nabídnout uživateli změnu jeho hesla při příštím přihlášení"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Nastavit heslo nyní"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Nelze se automaticky připojit k tomuto typu domény"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Doména nebyla nalezena"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Nelze se přihlásit jako „%s“ v doméně „%s“"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Neplatné heslo, zkuste to, prosím, znovu"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Nelze se připojit k doméně „%s“: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Selhalo smazání účtu"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Selhalo zneplatnění vzdáleně spravovaného uživatele"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Nemůžete smazat svůj vlastní účet."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "Uživatel %s je doposud přihlášen"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Smazání účtu, zatímco je dotyčný uživatel přihlášen, může přivést systém do "
+"nekonzistentního stavu."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Chcete zachovat soubory uživatele %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Je možné zachovat domovskou složku, poštovní schránku a dočasné soubory, i "
+"když bude uživatelský účet smazán."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "O_dstranit soubory"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "Zacho_vat soubory"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Opravdu chcete zneplatnit vzdáleně spravovaný účet uživatele %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "O_dstranit"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Účet zakázán"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Bude nastaveno při příštím přihlášení"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Žádné"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "právě přihlášený"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Selhalo kontaktování účtovací služby"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Zkontrolujte prosím, že je účtovací služba AccountService nainstalovaná a "
+"zapnutá."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Abyste mohli měnit nastavení, je panel zapotřebí odemknout"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Odstranit vybraný uživatelský účet"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Pro odstranění uživatelského účtu\n"
+"nejprve klikněte na ikonu *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Odemkněte, abyste mohli přidávat uživatele a měnit nastavení"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Uživatelé"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Aby se změny projevily, musí být sezení restartováno"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Restartovat nyní"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Zavřít"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Upravit avatara"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Celé jméno"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Upravit"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Přihlášení otiskem _prstu"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatické přihlašování"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Aktivita účtu"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Správce"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Správce může přidávat a odebírat ostatní uživatele a měnit nastavení u všech "
+"uživatelů."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Rodičovská kontrola"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Otevřít aplikaci pro rodičovskou kontrolu."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Odebrat uživatele…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Ostatní uživatelé"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Přidat uživatele…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Žádný uživatel nebyl nalezen"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Odemkněte, abyste mohli přidat účet."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Přidat nebo odebrat uživatele a změnit heslo"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"přihlášení;přihlásit;otis prstu;otisky prstů;avatar;fotka;obličej;heslo;"
+"rodičovská kontrola;čas u obrazovky;omezení webů;omezení stránek;omezit weby;"
+"omezit stránky;používání;využívání;strávený čas;omezené používání;omezit "
+"používání;dítě;děti;dětská;dětské;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "R_egistrovat"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Přihlášení doménového správce"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Abyste mohli použít přihlašování do domény, musí být tento\n"
+"počítač v doméně zahrnut. Požádejte prosím svého správce\n"
+"sítě o vepsání doménového hesla zde."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Jméno správce"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Heslo správce"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Správa uživatelských účtů"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Ke změně uživatelských dat je vyžadováno ověření."
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Nové heslo se musí lišit od toho starého."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Zkuste změnit některá písmena a číslice."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Zkuste změnit heslo trochu víc."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Heslo bez vašeho uživatelského jména by bylo silnější."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Zkuste se vyhnout použití svého jména v heslu."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Zkuste se vyhnout použití některých slov v hesle."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Zkuste se vyhnout běžným slovům."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Zkuste se vyhnout změně pořadí stávajících slov."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Zkuste použít víc číslic."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Zkuste použít víc velkých písmen."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Zkuste použít víc malých písmen."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Zkuste použít více speciálních znaků, jako jsou interpunkční znaménka."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Zkuste použít směs písmen, číslic a interpunkčních znamének."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Zkuste se vyhnout opakování stejného znaku."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Zkuste se vyhnout opakování stejného typu znaků: měli byste kombinovat "
+"písmena, čísla a interpunkční znaménka."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Zkuste se vyhnout sekvencím, jako je 1234 nebo abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Heslo musí být delší. Zkuste přidat další písmena, číslice a interpunkční "
+"znaménka."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Zkombinujte velká a malá písmena a zkuste použít jednu či dvě číslice."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Přidáním dalších písmen, číslic a interpunkčních znamének můžete heslo ještě "
+"dále zesílit."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Autentizace selhala"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Nové heslo je příliš krátké"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Nové heslo je příliš jednoduché"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Nové heslo je příliš podobné starému"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Stejné heslo, jako nové, bylo použito nedávno."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Nové heslo musí obsahovat číslice nebo speciální znaky."
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Staré a nové heslo jsou stejné"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Vaše heslo se od vaší prvotní autentizace změnilo!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Nové heslo neobsahuje dostatek různorodých znaků"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Neznámá chyba"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Uživatelské jméno se musí obvykle skládat jen z malých písmen a-z, číslic a "
+"následujících znaků: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Toto uživatelské jméno není bohužel dostupné. Zkuste prosím jiné."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Uživatelské jméno je příliš dlouhé."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Mapování tlačítek"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Mapování tlačítek na funkce"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Zkratku upravíte tak, že zvolíte „Vyvolat klávesovou zkratku“, zmáčknete na "
+"klávesnici zkratkové tlačítko a držíte zmáčknuté nové klávesy, případně je "
+"pomocí Backspace smažete."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Zavřít"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Klepněte prosím na terčíky, které se objevily na obrazovce a tím "
+"zkalibrujete tablet."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Zjištěno chybějící kliknutí, začíná se znovu…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Tlačítko %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Definováno aplikací"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Vyvolat klávesovou zkratku"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Přepnout obrazovku"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Zobrazit nápovědu na obrazovce"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Grafický tablet osazený na displeji notebooku"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Grafický tablet osazený na externím displeji"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Externí grafický tablet"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Všechny displeje"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Režim tabletu"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Používat pro pero absolutní souřadnice"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientace pro leváky"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tablet a tlačítka Express Keys™ jsou otočená pro použití leváky"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapování na obrazovku"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Zachovat poměr stran"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Používat pouze část povrchu tabletu, aby se dodržel stejný poměr stran jako "
+"na monitoru"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibrovat"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nenalezen žádný tablet"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Připojte prosím, nebo zapněte, grafický tablet."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Pocit z přítlaku hrotu"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Měkký"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Přítlak hrotu stylusu"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Tvrdý"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Tlačítko 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Tlačítko 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Tlačítko 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Pocit z přítlaku gumy"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Přítlak gumy"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Kliknutí prostředním tlačítkem myši"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Kliknutí pravým tlačítkem myši"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Vpřed"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Stylus Airbrush citlivý na přítlak, sklon a s integrovaným kolečkem"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Stylus Airbrush citlivý na přítlak, sklon a natočení"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standardní stylus citlivý na přítlak a sklon"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standardní stylus citlivý na přítlak"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Grafický tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Nastavit mapování tlačítek a přizpůsobit citlivost grafických tabletů"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "tablet;Wacom;stalus;pero;eraser;guma;myš;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Nová klávesová zkratka…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Přístupové body"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operace zrušena"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Chyba:</b> Zamítnut přístup ke změnám nastavení"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Chyba:</b> Chyba mobilního zařízení"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Nezaregistrováno"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Zaregistrováno"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Vyhledává se"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Odepřeno"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Podrobnosti k modemu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Stav modemu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operátor"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Typ sítě"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Stav sítě"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Vlastní číslo"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Podrobnosti o zařízení"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Verze firmwaru"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "pouze 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "pouze 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "pouze 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "pouze 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (preferovaná), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (preferovaná), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (preferovaná), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (preferovaná), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (preferovaná), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (preferovaná), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (preferovaná), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (preferovaná), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (preferovaná), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (preferovaná), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (preferovaná), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G, 4G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (preferovaná), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (preferovaná), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (preferovaná), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (preferovaná), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (preferovaná)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (preferovaná), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "neznámý"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Odemknutí karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Odemknout"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Zadejte prosím kód PIN pro SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Zadejte PIN pro odemknutí své karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Zadejte prosím kód PUK pro SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Zadejte PUK pro odemknutí své karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Bylo zadáno nesprávné heslo. Zbývá vám %1$u pokus."
+msgstr[1] "Bylo zadáno nesprávné heslo. Zbývají vám %1$u pokusy."
+msgstr[2] "Bylo zadáno nesprávné heslo. Zbývá vám %1$u pokusů."
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Zbývá vám %u pokus"
+msgstr[1] "Zbývají vám %u pokusy"
+msgstr[2] "Zbývá vám %u pokusů"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Bylo zadáno nesprávné heslo."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Kód PUK by měl mít 8 číslic"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Zadejte nový PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Kód PIN by měl mít 4 až 8 číslic"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Odemyká se…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Žádná SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Vložte kartu SIM, abyste mohli modem používat"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM je zamknutá"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobilní data"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Přístup k datům pomocí mobilní sítě"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Datový roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Používat mobilní data při roamingu"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Režim sítě"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Síť"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Názvy přístupového bodu"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Uzamknout _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Uzamknutí SIM pomocí PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "P_odrobnosti o modemu"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Telefon selhal"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Není spojení s telefonem"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operace není povolena"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operace není podporována"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Karta SIM není vložena"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Požadován kód PIN pro SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Požadován kód PUK pro SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "karta SIM selhala"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Karta SIM je zaneprázdněna"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Nesprávné heslo"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Požadován kód PIN2 pro SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Požadován kód PUK2 pro SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Nenalezeno"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Žádná síťová služba"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Síť neodpověděla"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Služby GPRS nejsou povoleny"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "V této oblasti není povolen roaming"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Nespecifikovaná chyba GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Bez chyb"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Činnost byla zrušena"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Přístup byl zamítnut"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Neznámá chyba"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Režim sítě"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automaticky"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Zvolte síť"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Aktualizovat poskytevatele sítí"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Povolit mobilní síť"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nebyl nalezen žádný adaptér WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Ujistěte se, že máte zařízení pro bezdrátovou WAN/mobilní síť"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Když je zapnutý režim „letadlo“, je bezdrátová WAN zakázaná."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Vypnou_t režim „letadlo“"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Datové připojení"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Karta SIM používaná pro internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Zamykání SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Další"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Zamknout SIM pomocí kódu PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Změnit PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Zadejte současný PIN, abyste mohli změnit zamykání SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobilní síť"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Nastavte si telefonní a mobilní datová připojení"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "celulární;wwan;telefon;telefonie;sim;karta;mobil;mobilní;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Nástroj pro nastavení uživatelského prostředí GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Aplikace Nastavení je hlavním rozhraním pro nastavení vašeho systému."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Projekt GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Zobrazit číslo verze"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Zapnout podrobný režim"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Hledat řetězec"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Vypsat všechny možné názvy panelů a skončit"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel, který se má zobrazit"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Kategorie nastavení"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Soukromí"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Dostupné panely:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Všechna nastavení"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Hlavní nabídka"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Varování: Vývojová verze"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Tato verze Nastavení by se měla používat jen pro účely vývoje. Můžete s ní "
+"narazit na nesprávné chování systému, ztrátu dat a další neočekávané chování."
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Nápověda"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Obecné"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Ukončit"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Hledat"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panely"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Zpět na předchozí panel"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Zrušit vyhledávání"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "předvolby;nastavení;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Identifikátor naposledy otevřeného panelu Nastavení"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Identifikátor panelu Nastavení, který byl otevřený jako poslední. "
+"Nerozpoznané hodnoty budou ignorovány a v takovém případě bude vybrán první "
+"panel v seznamu."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Zobrazit varování při spuštění vývojové sestavení"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Zda mají Nastavení zobrazit varování, když je spuštěno vývojové sestavení."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Počáteční stav okna"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"N-tice obsahující počáteční šířku, výšku a stav maximalizace okna s aplikací."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u výstup"
+msgstr[1] "%u výstupy"
+msgstr[2] "%u výstupů"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u vstup"
+msgstr[1] "%u vstupy"
+msgstr[2] "%u vstupů"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Systémové zvuky"

--- a/po/cy.po
+++ b/po/cy.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-03-08 13:45+0000\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2006-03-08 12:53-0000\n"
 "Last-Translator: Rhys Jones <rhys@sucs.org>\n"
 "Language-Team: Cymraeg <gnome-cy@pengwyn.linux.org.uk>\n"
@@ -32,3529 +32,7431 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n == 2) ? 1 : 0;\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "Border delwedd/label"
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "Lled y border o amgylch y label a'r ddelwedd yn y ddeialog rhybudd"
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr "Math y Rhybudd"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "Y math o rybudd"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "Botymau Rhybudd"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "Y botymau a ddangosir yn y ddeialog rhybudd"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "Dangos _mwy o fanylion"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "About Me"
-msgstr "Amdana I"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "Gosodwch eich gwybodaeth bersonol"
-
-#: ../capplets/about-me/gnome-about-me.c:604
-msgid "Select Image"
-msgstr "Dewis Delwedd"
-
-#: ../capplets/about-me/gnome-about-me.c:606
-msgid "No Image"
-msgstr "Dim Delwedd"
-
-#: ../capplets/about-me/gnome-about-me.c:769
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-"Roedd gwall wrth geisio cael gwybodaeth y llyfr cyfeiriadau\n"
-"Fedr Gweinydd Data Evolution ddim delio â'r protocol"
-
-#: ../capplets/about-me/gnome-about-me.c:790
-msgid "Unable to open address book"
-msgstr "Methu agor y llyfr cyfeiriadau"
-
-#: ../capplets/about-me/gnome-about-me.c:802
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-"ID mewngofnodi anhysbys, gall fod y gronfa ddata o ddefnyddwyr wedi ei llygru"
-
-#: ../capplets/about-me/gnome-about-me.c:833
-#: ../capplets/about-me/gnome-about-me.c:835
-#, c-format
-msgid "About %s"
-msgstr "Ynghylch %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:707
-msgid "Old password is incorrect, please retype it"
-msgstr "Hen gyfrinair yn anghywir, aildeipiwch ef"
-
-#: ../capplets/about-me/gnome-about-me-password.c:127
-msgid "System error has occurred"
-msgstr "Digwyddodd gwall system"
-
-#: ../capplets/about-me/gnome-about-me-password.c:128
-msgid "Could not run /usr/bin/passwd"
-msgstr "Methu rhedeg /usr/bin/passwd"
-
-#: ../capplets/about-me/gnome-about-me-password.c:129
-msgid "Unable to launch backend"
-msgstr "Methu lansio'r ochr gefn"
-
-#: ../capplets/about-me/gnome-about-me-password.c:131
-#: ../capplets/about-me/gnome-about-me-password.c:132
-msgid "Unexpected error has occurred"
-msgstr "Digwyddodd gwall anhysbys"
-
-#: ../capplets/about-me/gnome-about-me-password.c:331
-msgid "Password is too short"
-msgstr "Cyfrinair yn rhy fyr"
-
-#: ../capplets/about-me/gnome-about-me-password.c:334
-#: ../capplets/about-me/gnome-about-me-password.c:337
-msgid "Password is too simple"
-msgstr "Cyfrinair yn rhy syml"
-
-#: ../capplets/about-me/gnome-about-me-password.c:340
-msgid "Old and new passwords are too similar"
-msgstr "Mae'r cyfrinair newydd yn rhy debyg i'r hen un"
-
-#: ../capplets/about-me/gnome-about-me-password.c:343
-msgid "Must contain numeric or special character(s)"
-msgstr "Rhaid iddo gynnwys nod(au) arbennig neu rif(au)"
-
-#: ../capplets/about-me/gnome-about-me-password.c:348
-msgid "Old and new password are the same"
-msgstr "Mae'r cyfrinair newydd yr un peth â'r hen un"
-
-#: ../capplets/about-me/gnome-about-me-password.c:634
-msgid "Please type the passwords."
-msgstr "Teipiwch y cyfrineiriau."
-
-#: ../capplets/about-me/gnome-about-me-password.c:642
-msgid "Please type the password again, it is wrong."
-msgstr "Teipiwch y cyfrinair eto: mae'n anghywir."
-
-#: ../capplets/about-me/gnome-about-me-password.c:645
-msgid "Click on Change Password to change the password."
-msgstr "Cliciwch Newid Cyfrinair er mwyn newid y cyfrinair."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-msgid "    "
-msgstr "    "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Email</b>"
-msgstr "<b>E-bost</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Home</b>"
-msgstr "<b>Cartref</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Negesu Chwim</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Job</b>"
-msgstr "<b>Swydd</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
-msgstr "<b>Teipiwch y cyfrineiriau.</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<b>Telephone</b>"
-msgstr "<b>Ffôn</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "<b>Web</b>"
-msgstr "<b>Gwe</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "<b>Work</b>"
-msgstr "<b>Gwaith</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "A_ddress:"
-msgstr "_Cyfeiriad:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr "_Cynorthwyydd:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "Address"
-msgstr "Cyfeiriad"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "C_ity:"
-msgstr "_Dinas:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "C_ompany:"
-msgstr "_Cwmni:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Cale_ndar:"
-msgstr "C_alendr:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change Passwo_rd..."
-msgstr "Newid C_yfrinair..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Change Password"
-msgstr "Newid Cyfrinair"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Ci_ty:"
-msgstr "_Dinas:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Co_untry:"
-msgstr "_Gwlad:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Contact"
-msgstr "Cyswllt"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Cou_ntry:"
-msgstr "G_wlad:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr "Enw Llawn"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Hom_e:"
-msgstr "_Cartref:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "Old pa_ssword:"
-msgstr "Hen _gyfrinair:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P.O. _box:"
-msgstr "Blwch _post:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P._O. box:"
-msgstr "_Blwch post:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "Personal Info"
-msgstr "Gwybodaeth Bersonol"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "State/Pro_vince:"
-msgstr "Talaith/_Ardal:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-msgid "User name:"
-msgstr "Enw defnyddiwr:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Web _log:"
-msgstr "Gwe_log:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "Wor_k:"
-msgstr "_Gwaith:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid "Work _fax:"
-msgstr "_Ffacs gwaith:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Zip/_Postal code:"
-msgstr "Co_d post/zip:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "_Address:"
-msgstr "_Cyfeiriad:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr "_Adran:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr "_Groupwise:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "_Home page:"
-msgstr "Tudalen _cartref:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "_Home:"
-msgstr "C_artref:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr "_Jabber:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Manager:"
-msgstr "_Rheolwr:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Mobile:"
-msgstr "_Ffôn symudol:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_New password:"
-msgstr "Cyfrinair _newydd:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Profession:"
-msgstr "_Proffesiwn:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Retype new password:"
-msgstr "_Aildeipiwch y cyfrinair newydd:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr "_Talaith/Ardal:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Title:"
-msgstr "_Teitl:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Work:"
-msgstr "_Gwaith:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Zip/Postal code:"
-msgstr "_Cod post/zip:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Applications</b>"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
 msgstr "<b>Rhaglenni</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Support</b>"
-msgstr "<b>Cynhaliaeth</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-"<small><i><b>Noder:</b> Ni fydd newidiadau i'r gosodiad yma yn dod i rym tan "
-"y tro nesa i chi fewngofnodi.</i></small>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technology Preferences"
-msgstr "Hoffterau Technoleg Gynorthwyol"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr "Cau ac _Allgofnodi"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr ""
-"Cychwyn y technolegau cynorthwyol yma bob tro rydych chi'n mewngofnodi:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr "_Galluogi technolegau cynorthwyol"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr "_Chwyddwr"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr "Bysellfwrdd _ar y Sgrin"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Screenreader"
-msgstr "_Darllenydd sgrin"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr "Cynhaliaeth Technoleg Gynorthwyol"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr ""
-"Galluogi cynhaliaeth ar gyfer technolegau cynorthwyol GNOME wrth fewngofnodi"
-
-#: ../capplets/accessibility/at-properties/main.c:60
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Does dim Technoleg Gynorthwyol ar gael ar eich system. Rhaid sefydlu'r pecyn "
-"'gok' ar gyfer cael cynhaliaeth bysell ar sgrin, a'r pecyn 'gnopernicus' ar "
-"gyfer medru sgrînddarllen a chwyddo."
-
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-"Nid yw pob technoleg gynorthwyol wedi eu sefydlu ar eich system. Rhaid "
-"sefydlu'r pecyn 'gok' er mwyn cael bysell ar sgrin."
-
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Nid yw pob technoleg gynorthwyol wedi eu sefydlu ar eich system. Rhaid "
-"sefydlu'r pecyn 'gnopernicus' ar gyfer sgrînddarllen a chwyddo."
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:242
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr "Roedd gwall wrth lansio'r deialog hoffterau llygoden: %s"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:338
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:399
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr "Methu mewnforio gosodiadau AccessX o'r ffeil '%s'"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:436
-msgid "Import Feature Settings File"
-msgstr "Mewnforio Ffeil Gosodiadau Nodweddion"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:440
-msgid "_Import"
-msgstr "_Mewnforio"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Bysellfwrdd"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr "Dewis eich hoffterau hygyrchedd bysellfwrdd"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-"Ymddengys nad yw'r estyniad XKB ar gael ar y system hon. Ni fydd nodweddion "
-"hygyrchedd y bysellfwrdd yn gweithio hebddi."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-#: ../capplets/theme-switcher/theme-install.glade.h:1
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "<b>Galluogi Bysellau Sb_onciog</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "<b>Galluogi Bysellau _Araf</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "<b>Galluogi Bysellau _Llygoden</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "<b>Galluogi Bysellau _Ailadroddus</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "<b>Galluogi Bysellau _Gludiog</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-msgid "<b>Features</b>"
-msgstr "<b>Nodweddion</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr "<b>Bysellau Togl</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "Sylfaenol"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr "Bîp os ni _wrthodir y fysell"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
-msgstr "Bîp wrth droi'r _nodwedd ymlaen neu bant o'r bysellfwrdd"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
-msgstr "Bîp pan mae'r _addasydd yn cael ei wasgu"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr "Bîp pan fo'r LED yn goleuo a dau fîp pan mae'n cael ei ddiffodd."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr "Bîp os yw'r fysell yn:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr "_Oedi:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr "Oedi rhwng gwasgu bysell a symudiad y _pwyntydd:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr "_Analluogi pan mae dwy fysell yn cael eu gwasgu ar yr un pryd"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr "Galluogi Bysellau _Togl"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Hidlau"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr "Anwybyddu a_il-wasgiadau o fewn:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-"Anwybyddu pob gwasgiad dilynol o'r UN fysell os maent yn digwydd o fewn "
-"cyfnod a gall y defnyddiwr ei ddewis."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr "Hoffterau Hygyrchedd Bysellfwrdd (AccessX)"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr "Cyflymdra m_wya'r pwyntydd:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr "Bysellau Llygoden"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr "Hoffterau _Llygoden..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-"Derbyn bysellau dim ond ar ôl iddynt gael eu gwasgu a'u dal am gyfnod gall y "
-"defnyddiwr ei ddewis."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-"Cyflawni nifer o wasgiadau bysell cydamserol gan wasgu dilyniant o fysellau "
-"addasu."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "S_peed:"
-msgstr "Cy_flymder:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr "Amser i gyf_lymu i'r cyflymder mwyaf:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr "Trowch y bysellfwrdd rhifau yn fysellfwrdd rheoli'r llygoden"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr "_Analluogi os na ddefnyddiwyd am:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr "_Galluogi nodweddion hygyrchedd bysellfwrdd"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr "_Mewnforio Gosodiadau Nodweddion..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr "_Derbyn bysell wedi'u dal am:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "_Type to test settings:"
-msgstr "_Teipiwch i arbrofi'r gosodiadau:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr "_derbyniwyd"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr "_gwasgedig"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr "_gwrthodwyd"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr "nodau'r eiliad"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "milliseconds"
-msgstr "milfedau o eiliadau"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr "picseli'r eiliad"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "eiliadau"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-msgid "Change your Desktop Background settings"
-msgstr "Newid gosodiadau eich Cefndir Penbwrdd"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-msgid "Desktop Background"
-msgstr "Cefndir Penbwrdd"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "<b>Papur _Wal Penbwrdd</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-msgid "<b>_Desktop Colors</b>"
-msgstr "<b>_Lliwiau Penbwrdd</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-msgid "Desktop Background Preferences"
-msgstr "Hoffterau Cefndir Penbwrdd"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr "Agorwch ddeialog i ddewis y lliw"
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr "_Ychwanegu Papur Wal"
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-msgid "_Finish"
-msgstr "_Gorffen"
-
-#: ../capplets/background/gnome-background-properties.glade.h:7
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-msgid "_Remove"
-msgstr "_Gwaredu:"
-
-#: ../capplets/background/gnome-background-properties.glade.h:8
-msgid "_Style:"
-msgstr "_Arddull:"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Gwall wrth ddangos cymorth:%s"
-
-#: ../capplets/background/gnome-wp-capplet.c:984
-msgid "Centered"
-msgstr "Wedi ei ganoli"
-
-#: ../capplets/background/gnome-wp-capplet.c:988
-msgid "Fill Screen"
-msgstr "Llenwi'r Sgrin"
-
-#: ../capplets/background/gnome-wp-capplet.c:992
-msgid "Scaled"
-msgstr "Graddio"
-
-#: ../capplets/background/gnome-wp-capplet.c:996
-msgid "Zoom"
-msgstr "Chwyddo"
-
-#: ../capplets/background/gnome-wp-capplet.c:1000
-msgid "Tiled"
-msgstr "Teilsio"
-
-#: ../capplets/background/gnome-wp-capplet.c:1021
-msgid "Solid Color"
-msgstr "Lliw Unffurf"
-
-#: ../capplets/background/gnome-wp-capplet.c:1025
-msgid "Horizontal Gradient"
-msgstr "Graddfa Lorweddol"
-
-#: ../capplets/background/gnome-wp-capplet.c:1029
-msgid "Vertical Gradient"
-msgstr "Graddfa Fertigol"
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1075
-msgid "Add Wallpaper"
-msgstr "Ychwanegu Papur Wal"
-
-#: ../capplets/background/gnome-wp-capplet.c:1092
-msgid "Images"
-msgstr "Delweddau"
-
-#: ../capplets/background/gnome-wp-capplet.c:1096
-msgid "All Files"
-msgstr "Pob Ffeil"
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr "Dim Papur Wal"
-
-#: ../capplets/background/gnome-wp-item.c:343
-#: ../capplets/background/gnome-wp-item.c:345
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "picsel"
-msgstr[1] "bicsel"
-
-#: ../capplets/common/activate-settings-daemon.c:18
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"Methu cychwyn y rheolwr gosodiadau 'gnome-settings-daemon'.\n"
-"Heb i'r rheolydd gosodiadau GNOME fod yn weithgar, mae'n bosib na fydd rhai "
-"hoffterau'n dod i rym. Gall hyn olygu fod problem gyda Bonobo, neu fe all "
-"rheolydd gosodiadau arall (e.e. KDE) fod yn weithgar ac yn creu "
-"anghysondebau gyda rheolydd gosodiadau GNOME."
-
-#: ../capplets/common/capplet-stock-icons.c:92
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "Methu llwytho'r eicon stoc '%s'\n"
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr "Cymhwyso'r gosodiadau a therfynu"
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1016
-#: ../capplets/sound/sound-properties-capplet.c:244
-msgid "Retrieve and store legacy settings"
-msgstr "Nol a chadw'r hen osodiadau"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "Copïo ffeil: %u o %u"
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr "Copïo '%s'"
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr "URI Tarddiad"
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr "URI yn trosglwyddo o"
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr "URI Cyrchiad"
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr "URI yn trosglwyddo i"
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr "Canran wedi'i gwblhau"
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr "Canran y trosglwyddiad wedi'i gwblhau ar hyn o bryd"
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr "Mynegai URI cyfredol"
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr "Mynegai URI cyfredol - mae'n dechrau o 1"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr "Cyfanswm URIau"
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr "Nifer cyflawn URIau"
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr "Copïo ffeiliau"
-
-#: ../capplets/common/file-transfer-dialog.c:345
-msgid "From:"
-msgstr "O:"
-
-#: ../capplets/common/file-transfer-dialog.c:349
-msgid "To:"
-msgstr "I:"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr "Yn cysylltu..."
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Allwedd"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr "Allwedd GConf sy'n cyfateb i'r golygydd priodwedd yma"
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr "Adalwad"
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Galw'r adalwad yma pan newidir gwerth cysylltiedig yr allwedd"
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr "Newid set"
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"Set newid GConf yn cynnwys data i'w anfon ymlaen i'r cleient gconf wrth "
-"gymhwyso"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr "Trosi i adalwad celficyn"
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "Yr adalwad i'w alw pan fo data i'w trosi o GConf i'r teclyn"
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr "Trosi o adalwad teclyn"
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr "Adalwad i alw pan fo data i'w trosi i GConf o'r teclyn"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr "Rheolydd RhD (UI)"
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr "Gwrthrych sy'n rheoli'r briodwedd (celficyn gan amlaf)"
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr "Data gwrthrychol golygydd priodweddau"
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr "Data addasol sy'n anghenraid gan y golygydd priodweddau penodol"
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr "Adalwad rhyddhau data golygydd priodweddau"
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Adalwad i'w alw pan fo data gwrthrychol golygydd priodweddau i'w rhyddhau"
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Methwyd canfod y ffeil '%s'\n"
-"\n"
-"Gwiriwch ei bod yn bodoli a cheisiwch eto, neu dewiswch lun cefndir arall os "
-"gwelwch yn dda."
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Nid ydw i'n deall sut i agor y ffeil '%s'.\n"
-"Efallai ei bod yn fath o lun nas cynhelir eto.\n"
-"\n"
-"Dewiswch lun gwahanol yn ei le, os gwelwch yn dda."
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr "Dewiswch ddelwedd."
-
-#: ../capplets/common/gconf-property-editor.c:1598
-msgid "_Select"
-msgstr "_Dewis"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
 msgstr "Rhaglenni Amgen"
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Dewiswch eich rhaglenni rhagosodedig"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:55
-msgid "Could not display help"
-msgstr "Methu dangos y cymorth"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:57
-#: ../capplets/default-applications/gnome-da-capplet.c:765
-msgid "Please make sure that the applet is properly installed"
-msgstr "Gwnewch yn siwr fod y rhaglennig wedi ei osod yn gywir"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:92
-#: ../capplets/default-applications/gnome-da-capplet.c:125
-#: ../capplets/default-applications/gnome-da-capplet.c:170
-#: ../capplets/default-applications/gnome-da-capplet.c:215
-#: ../capplets/default-applications/gnome-da-capplet.c:269
-#: ../capplets/default-applications/gnome-da-capplet.c:318
-#: ../capplets/default-applications/gnome-da-capplet.c:600
-#: ../capplets/default-applications/gnome-da-capplet.c:621
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "Gwall wrth gadw cyfluniad: %s"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:743
-msgid "Custom"
-msgstr "Addasedig"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:763
-msgid "Could not load the main interface"
-msgstr "Methu llwytho'r prif ryngwyneb"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Debian Sensible Browser"
-msgstr "\"Sensible-Browser\" (Debian)"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Debian Terminal Emulator"
-msgstr "Efelychydd Terfynell Debian"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Encompass"
-msgstr "Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Epiphany Web Browser"
-msgstr "Porwr Gwe Epiphany"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "Evolution Mail Reader"
-msgstr "Y Darllenwr Ebost Evolution"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Evolution Mail Reader 1.4"
-msgstr "Darllenwr Ebost Evolution 1.4"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Evolution Mail Reader 1.5"
-msgstr "Darllenwr Ebost Evolution 1.5"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader 1.6"
-msgstr "Darllenwr Ebost Evolution 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Evolution Mail Reader 2.0"
-msgstr "Darllenwr Ebost Evolution 2.0"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Evolution Mail Reader 2.2"
-msgstr "Darllenwr Ebost Evolution 2.2"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "Evolution Mail Reader 2.4"
-msgstr "Darllenwr Ebost Evolution 2.4"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "Firebird"
-msgstr "Firebird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "GNOME Terminal"
-msgstr "Terfynell GNOME"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "KMail"
-msgstr "KMail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Links Text Browser"
-msgstr "Y Porwr Gwe Links"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Lynx Text Browser"
-msgstr "Y Porwr Gwe Lynx"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "Mozilla Mail"
-msgstr "E-bost Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Netscape Communicator"
-msgstr "Netscape Communicator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Opera"
-msgstr "Opera"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Standard XTerminal"
-msgstr "XTerminal arferol"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "W3M Text Browser"
-msgstr "Y Porwr Gwe W3M"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Audio Player</b>"
-msgstr "<b>Chwaraeydd Sain</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Image Viewer</b>"
-msgstr "<b>Gwelydd Delweddau</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Instant Messenger</b>"
-msgstr "<b>Negesu Chwim</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mail Reader</b>"
-msgstr "<b>Darllenwr E-bost</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>Efelychydd Terfynell</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Text Editor</b>"
-msgstr "<b>Golygydd Testun</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Video Player</b>"
-msgstr "<b>Chwaraewr Fideo</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Web Browser</b>"
-msgstr "<b>Porwr Gwe</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "Fe roddir y cyswllt go iawn yn lle pob %s"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Co_mmand:"
-msgstr "_Gorchymyn:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "E_xecute flag:"
-msgstr "Baner E_xec:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Internet"
-msgstr "Rhyngrwyd"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Multimedia"
-msgstr "Amlgyfrwng"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Open link in new _tab"
-msgstr "Agor cyswllt mewn _tab newydd"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Open link in new _window"
-msgstr "Agor cyswllt mewn _ffenestr newydd"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Open link with web browser _default"
-msgstr "Agor cyswllt gyda'r porwr gwe sy'n _ragosodiad"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Run in t_erminal"
-msgstr "Rhedeg mewn t_erfynell"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "System"
-msgstr "System"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Newid cydraniad y sgrin"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Cydraniad y Sgrin"
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/main.c:448
-msgid "_Resolution:"
-msgstr "_Cydraniad:"
-
-#: ../capplets/display/main.c:467
-msgid "Re_fresh rate:"
-msgstr "Cyfradd _adnewyddu:"
-
-#: ../capplets/display/main.c:488
-msgid "Default Settings"
-msgstr "Gosodiadau Rhagosodedig"
-
-#: ../capplets/display/main.c:490
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr "Gosodiadau Sgrin %d\n"
-
-#: ../capplets/display/main.c:516
-msgid "Screen Resolution Preferences"
-msgstr "Hoffterau Cydraniad y Sgrin"
-
-#: ../capplets/display/main.c:553
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "Gwneud yn rhagosodiad ar gyfer y _cyfrifiadur hwn (%s) yn unig"
-
-#: ../capplets/display/main.c:571
-msgid "Options"
-msgstr "Opsiynau"
-
-#: ../capplets/display/main.c:592
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"Profi'r gosodiadau newydd. Os nad ydych chi'n ymateb o fewn %d eiliad caiff "
-"y gosodiadau blaenorol eu hadfer."
-msgstr[1] ""
-"Profi'r gosodiadau newydd. Os nad ydych chi'n ymateb o fewn %d eiliad caiff "
-"y gosodiadau blaenorol eu hadfer."
-
-#: ../capplets/display/main.c:638
-msgid "Keep Resolution"
-msgstr "Cadw'r Cydraniad"
-
-#: ../capplets/display/main.c:642
-msgid "Do you want to keep this resolution?"
-msgstr "A hoffech gadw'r cyfraniad yma?"
-
-#: ../capplets/display/main.c:667
-msgid "Use _previous resolution"
-msgstr "Defnyddio'r cydraniad _blaenorol"
-
-#: ../capplets/display/main.c:667
-msgid "_Keep resolution"
-msgstr "_Cadw'r cydraniad"
-
-#: ../capplets/display/main.c:818
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"Nid yw'r gweinydd X yn cynnal yr estyniad XRandR. Nid yw'n bosib newid y "
-"cydraniad tra mae'r gweinydd X yn rhedeg."
-
-#: ../capplets/display/main.c:826
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"Mae fersiwn yr estyniad XRandR yn anghytunol gyda'r rhaglen hon. Nid yw'n "
-"bosib newid y cydraniad tra bo'r gweinydd X yn rhedeg."
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Ffont"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr "Dewiswch ffontiau ar gyfer y penbwrdd"
-
-#: ../capplets/font/font-properties.glade.h:1
-msgid "<b>Font Rendering</b>"
-msgstr "<b>Llunio Ffontiau</b>"
-
-#: ../capplets/font/font-properties.glade.h:2
-msgid "<b>Hinting</b>:"
-msgstr "<b>Awgrymu</b>:"
-
-#: ../capplets/font/font-properties.glade.h:3
-msgid "<b>Smoothing</b>:"
-msgstr "<b>Llyfnhau</b>:"
-
-#: ../capplets/font/font-properties.glade.h:4
-msgid "<b>Subpixel order</b>:"
-msgstr "<b>Trefn is-bicsel</b>:"
-
-#: ../capplets/font/font-properties.glade.h:5
-msgid "Best _shapes"
-msgstr "_Siapau gorau"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best co_ntrast"
-msgstr "_Cyferbyniad gorau"
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "D_etails..."
-msgstr "_Manylion..."
-
-#: ../capplets/font/font-properties.glade.h:8
-msgid "Des_ktop font:"
-msgstr "_Ffont y penbwrdd:"
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "Hoffterau Ffont"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr "Manylion Llunio Ffontiau"
-
-#: ../capplets/font/font-properties.glade.h:11
-msgid "Go _to font folder"
-msgstr "_Mynd i'r blygell ffont"
-
-#: ../capplets/font/font-properties.glade.h:12
-msgid "Gra_yscale"
-msgstr "_Graddlwyd"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "_Dim"
-
-#: ../capplets/font/font-properties.glade.h:14
-msgid "R_esolution:"
-msgstr "_Cydraniad:"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr "Is_bicsel (LCDau)"
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "Llyfnu is_bicsel (LCDau)"
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
-msgstr "Ffont _rhaglenni:"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Document font:"
-msgstr "_Ffont y ddogfen:"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Fixed width font:"
-msgstr "_Ffont lled rhagosodedig:"
-
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Full"
-msgstr "_Llawn"
-
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Medium"
-msgstr "_Canolig"
-
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_Monochrome"
-msgstr "_Unlliw"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_None"
-msgstr "_Dim"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Slight"
-msgstr "_Eiddil"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "_Ffont teitl y ffenest:"
-
-#: ../capplets/font/font-properties.glade.h:30
-msgid "dots per inch"
-msgstr "dot y fodfedd"
-
-#: ../capplets/font/main.c:489
-msgid "Font may be too large"
-msgstr "Mae'n bosib fod y ffont rhy fawr"
-
-#: ../capplets/font/main.c:493
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Mae'r ffont a ddewiswyd yn %d pwynt o faint, a gall ei wneud yn anodd "
-"defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
-"maint yn llai na %d."
-msgstr[1] ""
-"Mae'r ffont a ddewiswyd yn %d bwynt o faint, a gall ei wneud yn anodd "
-"defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
-"maint yn llai na %d."
-
-#: ../capplets/font/main.c:506
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Mae'r ffont a ddewiswyd yn %d pwynt o faint, a gall ei wneud yn anodd "
-"defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
-"maint ffont llai."
-msgstr[1] ""
-"Mae'r ffont a ddewiswyd yn %d bwynt o faint, a gall ei wneud yn anodd "
-"defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
-"maint ffont llai."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "Cyflymydd newydd..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Bysell cyflymu"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Addasyddion cyflymu"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Cod bysell cyflymu"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Modd Cyflymu"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Y math o gyflymydd."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:197
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:471
-msgid "Disabled"
-msgstr "Analluogwyd"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:544
-msgid "<Unknown Action>"
-msgstr "<Gweithred Anhysbys>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:565
-msgid "Desktop"
-msgstr "Penbwrdd"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:566
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
-msgstr "Sain"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:570
-msgid "Window Management"
-msgstr "Rheoli Ffenestri"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:676
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become unusable to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time.\n"
-msgstr ""
-"Methu defnyddio'r llwybr byr \"%s\" am y bydd wedyn yn amhosib teipio gyda'r "
-"allweddell yna.\n"
-"Ail-geisiwch gydag allwedd fel Control, Alt or Shift ar yr un pryd.\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:705
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-msgstr ""
-"Defnyddir y byrlwybr \"%s\" eisoes ar gyfer:\n"
-" \"%s\"\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:737
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr "Gwall wrth osod cyflymydd newydd yn y gronfa cyfluniad: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:787
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr "Gwall wrth ddadosod cyflymydd yn y gronfa cyfluniad: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:894
-msgid "Action"
-msgstr "Gweithred"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:918
-msgid "Shortcut"
-msgstr "Byrlwybr"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Llwybrau byr y Bysellfwrdd"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
-msgstr ""
-"I olygu bysell cyflymydd, cliciwch ar y rhes sy'n cyfateb a theipiwch "
-"gyflymydd newydd, neu gwasgwch olnod er mwyn clirio."
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "_Neilltuo bysell byrlwybr â gorchmynion"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
-msgid "Unknown"
-msgstr "Anhysbys"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
-msgid "Layout"
-msgstr "Cyflwyniad"
-
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
-msgid "Default"
-msgstr "Rhagosodiad"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
-msgid "Models"
-msgstr "Modelau"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:109
-#, c-format
-msgid "There was an error launching the keyboard tool: %s"
-msgstr "Roedd gwall wrth gychwyn offer y bysellfwrdd: %s"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
-msgstr "_Hygyrchedd"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:240
-#: ../capplets/sound/sound-properties-capplet.c:242
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-"Cymhwyso'r gosodiadau a therfynu (cydnawsedd yn unig; trinnir gan ellyll "
-"bellach)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
-msgstr "Cychwyn y dudalen gyda'r gosodiadau gorffwys teipio yn dangos"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "..."
-msgstr "..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>Chwincio'r Cyrchydd</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Bysellau Ailadroddus</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<b>_Cloi'r sgrin er mwyn gorfodi'r saib teipio</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Cyflym</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Hir</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Byr</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Araf</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_vailable layouts:"
-msgstr "_Cynlluniau ar gael:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "All_ow postponing of breaks"
-msgstr "_Caniatáu gohirio seibiau"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Gwirio os ceir gohirio seibiau"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "Choose a Keyboard Model"
-msgstr "Dewiswch Fodel Bysellfwrdd"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Choose a Layout"
-msgstr "Dewiswch Gynllun"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
-msgstr "_Mae'r cyrchydd yn chwincio mewn blychau testun a meysydd"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Cursor blinks speed"
-msgstr "Cyflymder chwincio'r cyrchwr"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of the break when typing is disallowed"
-msgstr "Hyd y saib tra mae teipio wedi ei wahardd"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Duration of work before forcing a break"
-msgstr "Hyd y gwaith cyn gorfodi saib"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Key presses _repeat when key is held down"
-msgstr "Bysellau yn _ailadrodd wrth gael eu dal i lawr"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Keyboard Preferences"
-msgstr "Hoffterau Bysellfwrdd"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Keyboard _model:"
-msgstr "Model bysellfwrdd"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Layout Options"
-msgstr "Opsiynau Cynllun:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Layouts"
-msgstr "Cynlluniau"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-"Cloi'r sgrin ar ôl cyfnod penodedig er mwyn cynorthwyo atal anafiadau "
-"defnydd bysellfwrdd ailadroddus"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Microsoft Natural Keyboard"
-msgstr "Bysellfwrdd Naturiol Microsoft"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Preview:"
-msgstr "Rhagolwg:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "Repeat keys speed"
-msgstr "Cyflymder ail-adrodd bysellau"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Reset To De_faults"
-msgstr "_Ailosod i'r dewisiadau rhagosodedig"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Separate _group for each window"
-msgstr "_Grwp ar wahân ar gyfer pob ffenestr"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-msgid "Typing Break"
-msgstr "Gorffwys Teipio"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Accessibility..."
-msgstr "_Hygyrchedd..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Add..."
-msgstr "_Ychwanegu..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "_Break interval lasts:"
-msgstr "_Cyfnod seibio yn para:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Delay:"
-msgstr "_Oediad:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Models:"
-msgstr "_Modelau:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Selected layouts:"
-msgstr "_Cynlluniau dewiswyd:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Speed:"
-msgstr "_Cyflymder:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "_Work interval lasts:"
-msgstr "_Cyfnod gweithio yn para:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "minutes"
-msgstr "munud"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Gosodwch eich hoffterau bysellfwrdd"
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:880
-#, c-format
-msgid "%d milliseconds"
-msgid_plural "%d milliseconds"
-msgstr[0] "%d milfed eiliad"
-msgstr[1] "%d milfedau o eiliadau"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:560
-msgid "Unknown Pointer"
-msgstr "Pwyntydd Anhysbys"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:761
-msgid "Default Pointer"
-msgstr "Pwyntydd Rhagosodedig"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Pointer - Current"
-msgstr "Pwyntydd Rhagosodedig - Cyfredol"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-msgid "The default pointer that ships with X"
-msgstr "Y pwyntydd rhagosodedig a gludir gydag X"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-msgid "White Pointer"
-msgstr "Pwyntydd Gwyn"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Pointer - Current"
-msgstr "Pwyntydd Gwyn - Cyfredol"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-msgid "The default pointer inverted"
-msgstr "Y pwyntydd rhagosodedig wedi'i wrthdroi"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-msgid "Large Pointer"
-msgstr "Pwyntydd Mawr"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Pointer - Current"
-msgstr "Pwyntydd Mawr - Cyfredol"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-msgid "Large version of normal pointer"
-msgstr "Fersiwn mawr o'r pwyntydd arferol"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-msgid "Large White Pointer - Current"
-msgstr "Pwyntydd Mawr Gwyn - Cyfredol"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Pointer"
-msgstr "Pwyntydd Mawr Gwyn"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-msgid "Large version of white pointer"
-msgstr "Fersiwn mawr o'r pwyntydd gwyn"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:970
-msgid "Pointer Theme"
-msgstr "Thema Pwyntydd"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr "<b>Amser Aros am Glic Dwbl</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Llusgo a Gollwng</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Lleoli'r Pwyntydd</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>Cyfeiriadaeth Llygoden</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Speed</b>"
-msgstr "<b>Cyflymder</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>Cyflym</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>Uchel</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>Mawr</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>Isel</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>Araf</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>Bach</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Botymau"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr "Amlygu'r _pwyntydd pan rydych chi'n gwasgu Ctrl"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Large"
-msgstr "Mawr"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Medium"
-msgstr "Canolig"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "Motion"
-msgstr "Symudiad"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-msgid "Mouse Preferences"
-msgstr "Hoffterau Llygoden"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Pointer Size:"
-msgstr "Maint Pwyntydd:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Pointers"
-msgstr "Pwyntyddion"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "Small"
-msgstr "Bach"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
-msgstr "_Cyflymiad:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
-msgstr "_Llygoden lawchwith"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr "_Sensitifrwydd:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr "_Trothwy:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
-msgstr "_Terfyn aros:"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Llygoden"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Gosodwch eich hoffterau llygoden"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Dirprwy Rhwydwaith"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "Gosod eich hoffterau dirprwy rhwydwaith"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>_Cysylltiad Rhyngrwyd uniongyrchol</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
-msgstr "<b>Anwybyddu Rhestr Gwesteiwyr</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>Cyfluniad dirprwy _awtomatig</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>Cyflunio dirprwy â _llaw</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Defnyddio dilysiant</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "Advanced Configuration"
-msgstr "Cyfluniad Uwch"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr "_URL cyfluniad awtomatig:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "Manylion dirprwy HTTP"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "Dirprwy _HTTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Network Proxy Preferences"
-msgstr "Hoffterau Dirprwy Rhwydwaith"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Porth:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "Proxy Configuration"
-msgstr "Cyfluniad Dirprwy"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr "Gweinydd S_ocks:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "U_sername:"
-msgstr "_Enw Defnyddiwr:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_Manylion"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr "Dirprwy _FTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "_Cyfrinair:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr "Dirprwy HTTP _Diogel:"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Galluogi sain a chysylltu seiniau â digwyddiadau"
-
-#: ../capplets/sound/sound-properties-capplet.c:271
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "Sound Preferences"
-msgstr "Hoffterau Sain"
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "E_nable software sound mixing (ESD)"
-msgstr "_Galluogi cymysgu sain o fewn meddalwedd (ESD)"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "Flash _entire screen"
-msgstr "Fflachio'r _sgrin gyfan"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "Flash _window titlebar"
-msgstr "Fflachio bar teitl y _ffenest"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "Sounds"
-msgstr "Seiniau"
-
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "System Beep"
-msgstr "Bîp y System"
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "_Enable system beep"
-msgstr "_Galluogi bîp y system"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "_Play system sounds"
-msgstr "_Chwarae synau'r system"
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "_Visual system beep"
-msgstr "Bîp _gweledol y system"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:368
-msgid "Would you like to remove this theme?"
-msgstr "Hoffech chi dynnu'r thema hon?"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:433
-msgid "Theme deleted succesfully. Please select another theme."
-msgstr "Thema wedi'i ddileu yn llwyddiannus. Dewiswch thema wahanol."
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:442
-msgid "Theme can not be deleted"
-msgstr "Methu dileu'r thema"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:529
-msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
-msgstr ""
-"Ni chanfuwyd unrhyw themâu ar eich system. Mae'n debyg golyga hyn bod eich "
-"deialog \"Hoffterau Thema\" wedi ei osod yn anghywir, neu nad ydych wedi "
-"gosod y pecyn \"gnome-themes\"."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:227
-msgid "This theme is not in a supported format."
-msgstr "Nid yw'r thema mewn ffurf a gynhelir."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:242
-msgid "Failed to create temporary directory"
-msgstr "Methu creu cyfeiriadur dros dro"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:260
-msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
-msgstr ""
-"Methu gosod thema. \n"
-"Nid yw'r rhaglen bzip2 wedi ei osod."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:276
-#: ../capplets/theme-switcher/gnome-theme-installer.c:309
-#: ../capplets/theme-switcher/gnome-theme-installer.c:383
-msgid "Installation Failed"
-msgstr "Methodd Gosodiad"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:294
-msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
-msgstr ""
-"Methu gosod themâu. \n"
-"Nid yw'r rhaglen bzip2 wedi ei osod."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:330
-#, c-format
-msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-"Thema Eicon %s wedi ei gosod yn gywir.\n"
-"Gallwch ei dewis yn y manylion themâu."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:333
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr "Thema Gnome %s wedi ei gosod yn gywir"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:336
-#, c-format
-msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-"Thema Border Ffenest %s wedi ei gosod yn gywir.\n"
-"Gallwch ei dewis yn y manylion themâu."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:339
-#, c-format
-msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-"Thema Rheolyddion %s wedi ei gosod yn gywir.\n"
-"Gallwch ei dewis yn y manylion themâu."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:345
-msgid "The theme is an engine. You need to compile the theme."
-msgstr "Mae'r thema yn injan. Rhaid i chi grynhoi'r thema."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:360
-msgid "The file format is invalid"
-msgstr "Fformat ffeil yn annilys"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:450
-msgid "No theme file location specified to install"
-msgstr "Ni chafodd lleoliad ffeil thema ei bennu ar gyfer ei osod"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:469
-msgid "The theme file location specified to install is invalid"
-msgstr "Roedd y lleoliad ffeil thema a benodwyd i'w osod yn annilys"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:489
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"Caniatadau annigonol i osod y thema yn:\n"
-"%s"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:510
-msgid "The file format is invalid."
-msgstr "Fformat ffeil yn annilys."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:537
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-"%s yw'r llwybr lle fydd y ffeiliau thema wedi ei gosod. Ni ellir dewis hwn "
-"fel lleoliad y ffynhonnell"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:591
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
-msgstr ""
-"Methu gosod thema.\n"
-"Nid yw'r rhaglen tar wedi ei osod ar eich system."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:686
-msgid "Custom theme"
-msgstr "Thema Addasedig"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:686
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr "Gallwch gadw'r thema yma drwy glicio'r botwm Cadw Thema."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1584
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr ""
-"Methwyd canfod y sgemâu thema rhagosodedig ar eich system. Mae hyn yn "
-"awgrymu nad yw metacity wedi ei ymsefydlu gennych, neu fod eich gconf wedi "
-"ei gyflunio'n anghywir."
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:72
-msgid "Theme name must be present"
-msgstr "Rhaid bod enw thema yn bresennol"
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:104
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Mae'r thema'n bodoli eisoes. A hoffech ei newid?"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr "Dewiswch themâu i amryw rannau'r penbwrdd"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "Thema"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Gosod Thema</span>"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:3
-msgid "Theme Installation"
-msgstr "Gosodiad Thema"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:4
-msgid "_Install"
-msgstr "_Gosod"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:5
-msgid "_Location:"
-msgstr "_Lleoliad:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Cadw Thema i Ddisg</span>"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "Apply _Background"
-msgstr "Cymhwyso _Cefndir"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Apply _Font"
-msgstr "Cymhwyso _Ffont"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Controls"
-msgstr "Rheolyddion"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Icons"
-msgstr "Eiconau"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "New themes can also be installed by dragging them into the window."
-msgstr "Gellir gosod themâu newydd drwy ei llusgo i'r ffenestr hefyd"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "Save Theme"
-msgstr "Cadw'r Thema"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-msgid "Select theme for the desktop"
-msgstr "Dewiswch thema ar gyfer y penbwrdd"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-msgid "Short _description:"
-msgstr "_Disgrifiad byr:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-msgid "Theme Details"
-msgstr "Manylion Thema"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "Theme Preferences"
-msgstr "Hoffterau Thema"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "Theme _Details"
-msgstr "_Manylion Thema"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-msgid "This theme does not suggest any particular font or background."
-msgstr "Nid yw'r thema yma yn awgrymu unrhyw ffont neu gefndir penodol"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-msgid "This theme suggests a background:"
-msgstr "Mae'r thema yma yn awgrymu cefndir:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-msgid "This theme suggests a font and a background:"
-msgstr "Mae'r thema yma yn awgrymu ffont a chefndir:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-msgid "This theme suggests a font:"
-msgstr "Mae'r thema yma yn awgrymu ffont:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-msgid "Window Border"
-msgstr "Ymyl Ffenestr"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "_Install Theme..."
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
 msgstr "_Ymsefydlu Thema..."
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-msgid "_Revert"
-msgstr "_Dychwelyd:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-msgid "_Save Theme..."
-msgstr "_Cadw'r thema..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-msgid "_Theme name:"
-msgstr "_Enw thema:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-msgid "theme selection tree"
-msgstr "coeden dewis thema"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
-msgstr "Addasu golwg bariau offer a bariau dewislenni mewn rhaglenni"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "Dewislenni a Bariau Offer"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
-msgstr "<b>Ymddygiad ac Ymddangosiad</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-msgid "<b>Preview</b>"
-msgstr "<b>Rhagolwg</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "T_orri"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-msgid "Icons only"
-msgstr "Eiconau'n unig"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "Hoffterau Dewislen a Bar Offer"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "Ffeil Newydd"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Agor Ffeil"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Cadw Ffeil"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr "Dangos _eiconau mewn dewislenni"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-msgid "Text below icons"
-msgstr "Testun islaw eiconau"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-msgid "Text beside icons"
-msgstr "Testun wrth ochr eiconau"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-msgid "Text only"
-msgstr "Testun yn unig"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
-msgid "Toolbar _button labels:"
-msgstr "Labeli _botymau bar offer:"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_Copïo"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
-msgstr "Barau offer gellir _datgysylltu"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
-msgstr "_Golygu"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
-msgstr "Posib _golygu cyflymwyr dewislen"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "_Ffeil"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_Newydd"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
 msgstr "_Agor"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "_Gludo"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "_Argraffu"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "_Gadael"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "_Cadw"
-
-#: ../capplets/windows/gnome-window-properties.c:385
-#, c-format
-msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
-msgstr ""
-"<b>Methu cychwyn y rhaglen hoffterau ar gyfer eich rheolwr ffenestri</b>\n"
-"\n"
-"%s"
-
-#: ../capplets/windows/gnome-window-properties.c:642
-msgid "C_ontrol"
-msgstr "C_ontrol"
-
-#: ../capplets/windows/gnome-window-properties.c:647
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:653
-msgid "H_yper"
-msgstr "_Goruwch (hyper)"
-
-#: ../capplets/windows/gnome-window-properties.c:660
-msgid "S_uper (or \"Windows logo\")"
-msgstr "_Uwch (neu \"Logo Windows\")"
-
-#: ../capplets/windows/gnome-window-properties.c:667
-msgid "_Meta"
-msgstr "_Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Bysell Symud</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>Gweithred Bar Teitl</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Dewis Ffenestri</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr ""
-"I symud ffenestr, gwasgwch a chydiwch y fysell yma yna cydiwch yn y ffenestr:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Hoffterau Ffenestr"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_Rhoi clic dwbl ar y bar teitl i gyflawni'r weithred hon:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "_Cyfnod cyn codi:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_Codi ffenestri dewisedig ar ôl cyfnod"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Dewis ffenestri pan fo'r llygoden yn symud drostynt"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "Gosod eich priodweddau ffenestr"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "Ffenestri"
-
-#: ../control-center/control-center-categories.c:287
-msgid "Others"
-msgstr "Eraill"
-
-#: ../control-center/control-center.c:93
-msgid "Desktop Preferences"
-msgstr "Hoffterau Penbwrdd"
-
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr "Canolfan Reoli GNOME"
-
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "Yr erfyn cyfluniad GNOME"
-
-#: ../gnome-settings-daemon/actions/acme-fb-level.c:149
-msgid "No '/dev/pmu' device found"
-msgstr "Dim dyfais '/dev/pmu' wedi ei ganfod"
-
-#: ../gnome-settings-daemon/actions/acme-fb-level.c:156
-msgid "Not a powerbook"
-msgstr "Ddim yn 'powerbook'"
-
-#: ../gnome-settings-daemon/actions/acme-fb-level.c:173
-msgid "Wrong permission for '/dev/pmu' device"
-msgstr "Caniatâd anghywir ar gyfer y ddyfais '/dev/pmu'"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "Lefel Sain"
-
-#: ../gnome-settings-daemon/factory.c:66
-msgid "Could not initialize Bonobo"
-msgstr "Methu ymgychwyn Bonobo"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:406
-msgid "Slow Keys Alert"
-msgstr "Rhybudd Bysellau Araf"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:407
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-msgstr ""
-"Rydych newydd ddal lawr y fysell Shift am 8 eiliad. Dyma'r byrlwybr ar gyfer "
-"y nodwedd Bysellau Araf, sy'n effeithio sut mae'ch bysellfwrdd yn gweithio"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:409
-msgid "Do you want to activate Slow Keys?"
-msgstr "Ydych chi eisiau troi Bysellau Araf ymlaen?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Do you want to deactivate Slow Keys?"
-msgstr "Ydych chi eisiau troi Bysellau Araf i ffwrdd?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
-msgid "_Activate"
-msgstr "_Actifadu"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
-msgid "_Deactivate"
-msgstr "_Dad-actifadu"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
-msgid "Do_n't activate"
-msgstr "_Peidio ag actifadu"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
-msgid "Do_n't deactivate"
-msgstr "_Peidio â dad-actifadu"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:421
-msgid "Sticky Keys Alert"
-msgstr "Rhybudd Bysellau Gludiog"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:422
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-"Rydych newydd wasgu'r fysell Shift 5 gwaith mewn rhes. Dyma'r byrlwybr ar "
-"gyfer y nodwedd Bysellau Gludiog, sy'n effeithio sut mae'ch bysellfwrdd yn "
-"gweithio"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:424
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-"Rydych newydd wasgu dwy fysell ar unwaith neu wasgu'r fysell Shift 5 gwaith "
-"mewn rhes. Mae hyn yn troi'r nodwedd Bysedd Gludiog ymlaen, sy'n effeithio "
-"sut mae'ch bysellfwrdd yn gweithio."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:426
-msgid "Do you want to activate Sticky Keys?"
-msgstr "Ydych chi eisiau troi Bysellau Gludiog ymlaen?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:427
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr "Ydych chi eisiau troi Bysellau Gludio i ffwrdd?"
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:74
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing the mouse pointer theme."
-msgstr ""
-"Methu creu'r cyfeiriadur \"%s\".\n"
-"Mae angen hwn i ganiatáu newid thema pwyntydd y llygoden."
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:96
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-"Methu creu'r cyfeiriadur \"%s\".\n"
-"Mae angen hwn i ganiatáu newid cyrchwyr."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:208
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr "Diffinnir gweithred y Rhwymiad Bysell (%s) sawl gwaith\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:221
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr "Diffinnir rhwymiad y Rhwymiad Bysell (%s) sawl gwaith\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:227
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr "Mae'r Rhwymiad Bysell (%s) yn anghyflawn\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:255
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr "Mae'r Rhwymiad Bysell (%s) yn annilys\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:291
-#, c-format
-msgid "It seems that another application already has access to key '%u'."
-msgstr "Mae'n debyg fod gan raglen arall fynediad i'r fysell '%u' eisoes."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:360
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr "Defnyddir y Rhwymiad Bysell (%s) eisoes\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:435
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-"Gwall wrth geisio gweithredu (%s)\n"
-"sy'n rhwym i'r fysell (%s)"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
-#, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-"Gwall wrth gychwyn cyfluniad XKB.\n"
-"Gall nifer o amgylchiadau achosi hyn:\n"
-"- gwall yn llyfrgell libxklavier\n"
-"- gwall yng ngweinydd X (xkbcomp, offer xmodmap)\n"
-"- Gweinydd X gyda gweithrediad libxfile anghyson\n"
-"\n"
-"Gwybodaeth fersiwn gweinydd X:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"Os wnewch chi adrodd nam, a wnewch chi gynnwys:\n"
-"- Canlyniad <b>%s</b>\n"
-"- Canlyniad <b>%s</b>"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-"Rydych chi'n defnyddio XFree 4.3.0.\n"
-"Mae yna broblemau hysbys gyda chyfluniadau XKB cymhleth.\n"
-"Ceisiwch ddefnyddio cyfluniad symlach neu ddefnyddio fersiwn mwy diweddar o "
-"feddalwedd XFree"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:223
-msgid "Do _not show this warning again"
-msgstr "_Peidio â dangos y rhybudd yma eto"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:234
-msgid ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
-msgstr ""
-"Mae gosodiadau bysellfwrdd y system X yn wahanol i'ch gosodiadau bysellfwrdd "
-"GNOME cyfredol. Pa set hoffech ddefnyddio?"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:247
-msgid "Use X settings"
-msgstr "Defnyddio Gosodiadau X"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:249
-msgid "Use GNOME settings"
-msgstr "Defnyddio Gosodiadau GNOME"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
-msgstr ""
-"Methwyd gweithredu'r gorchymyn: %s\n"
-"Gwirio fod y gorchymyn yma'n bodoli."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-"Methwyd rhoi'r peiriant i gysgu.\n"
-"Gwirio fod y peiriant wedi ei gyflunio yn gywir."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:180
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-"Methwyd llwytho ffeil Glade.\n"
-"Gwnewch yn siwr fod y daemon wedi ei osod yn gywir."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:110
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-"Bu gwall wrth gychwyn yr arbedwr sgrin:\n"
-"\n"
-"%s\n"
-"\n"
-"Fydd arbed sgrin ddim yn gweithio yn ystod y sesiwn yma."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:120
-msgid "_Do not show this message again"
-msgstr "_Peidiwch â dangos y neges yma eto"
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:131
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr "Methwyd llwytho ffeil sain %s fel sampl %s"
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:212
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:260
-msgid "Cannot determine user's home directory"
-msgstr "Methwyd canfod cyfeiriadur cartref y defnyddiwr"
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:212
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr "Gosodwyd yr allwedd GConf %s i fath %s ond disgwylid math %s\n"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-msgid "A_vailable files:"
-msgstr "_Ffeiliau ar gael:"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-msgid "Do _not show this warning again."
-msgstr "_Peidio â dangos y rhybudd yma eto."
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
-msgstr "Llwytho ffeiliau modmap"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
-msgstr "Hoffech chi lwytho'r ffeil(iau) modmap?"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr "_Llwytho"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-msgid "_Loaded files:"
-msgstr "_Ffeiliau wedi'u llwytho:"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr "Gwall wrth greu piben signal."
-
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "Math"
-
-#: ../libbackground/applier.c:256
-msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-msgstr ""
-"Math o bg_applier: BG_APPLIER_ROOT ar gyfer y ffenestr gwraidd neu "
-"BG_APPLIER_PREVIEW ar gyfer rhagolwg"
-
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr "Lled Rhagolwg"
-
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr "Lled os yw'r cymhwysydd yn rhagolwg: Rhagosod fel 64"
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr "Uchder y Rhagolwg"
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr "Uchder os yw'r cymhwysydd yn rhagolwg: Rhagosod fel 48"
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Sgrin"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr "Sgrin y dylai BGApplier ddarlunio arni"
-
-#: ../libgswitchit/gswitchit_config.c:1036
-#, c-format
-msgid "There was an error loading an image: %s"
-msgstr "Gwall wrth lwytho delwedd: %s"
-
-#: ../libsounds/sound-view.c:43
-msgid "Login"
-msgstr "Mewngofnodi"
-
-#: ../libsounds/sound-view.c:44
-msgid "Logout"
-msgstr "Allgofnodi"
-
-#: ../libsounds/sound-view.c:45
-msgid "Boing"
-msgstr "Boing"
-
-#: ../libsounds/sound-view.c:46
-msgid "Siren"
-msgstr "Seiren"
-
-#: ../libsounds/sound-view.c:47
-msgid "Clink"
-msgstr "Clinc"
-
-#: ../libsounds/sound-view.c:48
-msgid "Beep"
-msgstr "Bîp"
-
-#: ../libsounds/sound-view.c:49
-msgid "No sound"
-msgstr "Dim sain"
-
-#: ../libsounds/sound-view.c:131
-msgid "Sound not set for this event."
-msgstr "Seiniau heb eu gosod ar gyfer y digwyddiad hwn."
-
-#: ../libsounds/sound-view.c:140
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package for a set of default sounds."
-msgstr ""
-"Nid yw'r ffeil sain ar gyfer y digwyddiad yma'n bodoli.\n"
-"Efallai yr hoffech chi sefydlu'r pecyn gnome-audio er mwyn gael set o "
-"seiniau rhagosodedig."
-
-#: ../libsounds/sound-view.c:151
-msgid "The sound file for this event does not exist."
-msgstr "Nid yw'r ffeil sain i'r digwyddiad yma'n bodoli."
-
-#: ../libsounds/sound-view.c:182
-msgid "Select Sound File"
-msgstr "Dewiswch Ffeil Sain"
-
-#: ../libsounds/sound-view.c:202
-#, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "NId yw'r ffeil %s yn ffeil WAV ddilys"
-
-#: ../libsounds/sound-view.c:359
-msgid "System Sounds"
-msgstr "Synau'r System"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "Nid yw rheolwr ffenestri \"%s\" wedi cofrestru arf cyfluniad\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Ehangu"
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Rholio i fyny"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr "Os yn wir, cedwir y trinwyr testun/plaen a thestun/* yn gydwedd"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr "Trinwyr testun/plaen a thestun/*"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "Brightness down"
-msgstr "Disgleirdeb i lawr"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "Brightness down's shortcut."
-msgstr "Byrlwybr disgleirdeb i lawr."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Brightness up"
-msgstr "Disgleirdeb i fyny"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Brightness up's shortcut."
-msgstr "Byrlwybr disgleirdeb i fyny."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "E-mail"
-msgstr "E-bost"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "E-mail's shortcut."
-msgstr "Byrlwybr E-bost."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Eject"
-msgstr "Allfwrw"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-msgid "Eject's shortcut."
-msgstr "Byrlwybr allfwrw."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-msgid "Home folder"
-msgstr "Plygell cartref"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-msgid "Home folder's shortcut."
-msgstr "Byrlwybr i fy Mhlygell Cartref."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-msgid "Launch help browser"
-msgstr "Lansio'r porwr cymorth"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-msgid "Launch help browser's shortcut."
-msgstr "Byrlwybr i lansio'r porwr cymorth."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-msgid "Launch web browser"
-msgstr "Lansio porwr gwe"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-msgid "Launch web browser's shortcut."
-msgstr "Byrlwybr i lansio porwr gwe."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-msgid "Lock screen"
-msgstr "Cloi'r sgrin"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-msgid "Lock screen's shortcut."
-msgstr "Byrlwybr i gloi'r sgrin."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-msgid "Log out"
-msgstr "Allgofnodi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-msgid "Log out's shortcut."
-msgstr "Byrlwybr i allgofnodi."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Next track key's shortcut."
-msgstr "Byrlwybr bysell trac nesaf."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Pause"
-msgstr "Seibio"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-msgid "Pause key's shortcut."
-msgstr "Byrlwybr y fysell seibio."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Play (or play/pause)"
-msgstr "Chwarae (neu chwarae/seibio)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Play (or play/pause) key's shortcut."
-msgstr "Byrlwybr y fysell chwarae (neu chwarae/seibio)."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Previous track key's shortcut."
-msgstr "Byrlwybr y fysell trac blaenorol."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Manylion Thema"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Chwilio"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-msgid "Search's shortcut."
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Analluogwyd"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_Lleoliad:"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Dangos opsiynau cymorth"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Cymhwyso _Cefndir"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Sgrin"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Dim Papur Wal"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Seiniau"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Byrlwybr"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Llwybrau byr y Bysellfwrdd"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Dim sain"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Math y Rhybudd"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Ffont _rhaglenni:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>E-bost</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Arddull:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Rhagosodiad"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "Cymhwyso _Cefndir"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Cydraniad y Sgrin"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Pwyntydd Mawr Gwyn"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Disgleirdeb i fyny"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Copïo ffeiliau"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Mewnforio"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Ychwanegu..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "_Ffeiliau wedi'u llwytho:"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "_Gwaredu:"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Manylion"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "munud"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Canolig"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "munud"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "munud"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Lliw Unffurf"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Dewis Delwedd"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Dewis"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Dim sain"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_Terfyn aros:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Chwilio"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "_Oedi:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
 msgstr "Byrlwybr chwilio"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Skip to next track"
-msgstr "Neidio i'r trac nesaf"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Skip to previous track"
-msgstr "Neidio i'r trac blaenorol"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-msgid "Sleep"
-msgstr "Cysgu"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-msgid "Sleep's shortcut."
-msgstr "Byrlwybr cysgu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Stop playback key"
-msgstr "Bysell stopio chwarae"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Stop playback key's shortcut."
-msgstr "Byrlwybr y fysell stopio chwarae."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
-msgid "Volume down"
-msgstr "Lefel sain i lawr"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume down's shortcut."
-msgstr "Byrlwybr lefel sain i lawr."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-msgid "Volume mute"
-msgstr "Mudo'r sain"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume mute's shortcut"
-msgstr "Byrlwybr mudo'r sain"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
-msgid "Volume step"
-msgstr "Gris lefel sain"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-msgid "Volume step as percentage of volume."
-msgstr "Gris lefel sain fel canran o'r lefel."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
-msgid "Volume up"
-msgstr "Lefel sain i fyny"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
-msgid "Volume up's shortcut."
-msgstr "Byrlwybr lefel sain i fyny."
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
-msgid "Display a dialog when there are errors running the screensaver"
-msgstr "Dangos deialog pan fo gwallau wrth redeg yr arbedwr sgrin"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-msgid "Run screensaver at login"
-msgstr "Cychwyn yr arbedwr sgrin wrth fewngofnodi"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
-msgstr "Dangos Gwallau Ymgychwyn"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
-msgid "Start screensaver"
-msgstr "Dechrau'r arbedwr sgrin"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
 msgstr ""
-"Casgliad o sgriptiau i'w rhedeg pryd bynnag caiff cyflwr yr allweddell ei "
-"ail-lwytho. Yn ddefnyddiol er mwyn rhoi newidiadau ar waith sy'n seiliedig "
-"ar xmodmap."
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
-msgstr "Rhestr o ffeiliau modmap ar gael yn y cyfeiriadur $HOME."
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
-msgstr "Grwp rhagosodedig, wedi ei neilltuo wrth greu ffenestr"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr "Cadw a rheoli grwp ar wahân am bob ffenestr"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
-msgid "Keyboard Update Handlers"
-msgstr "Trinwyr Diweddariad Bysellfwrdd"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
-msgid "Keyboard layout"
-msgstr "Cynllun bysellfwrdd"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
-msgid "Keyboard model"
-msgstr "Model bysellfwrdd"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
-msgid "Keyboard options"
-msgstr "Dewisiadau bysellfwrdd"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
 msgstr ""
-"Caiff gosodiadau bysellfwrdd o fewn gconf eu trosysgrifo gan y system cyn "
-"gynted â phosib (anghymeradwyir)"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
-msgstr "Cadw/adfer dangoswyr ynghyd â grwpiau cynllun"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
-msgstr "Dangos enwau cynllun yn lle enwau grwp"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
 msgstr ""
-"Dangos enwau gosodiad yn lle enwau grwp (dim ond ar gyfer fersiynau o XFree "
-"sy'n cynnal amryw gynlluniau)"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr "Atal y neges rybudd \"sysconfig X wedi newid\""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
 msgstr ""
-"Yn fuan iawn, bydd gosodiadau bysellfwrdd o fewn gconf yn cael eu "
-"trosysgrifo (gan gyfluniad y system). Mae'r allwedd hon wedi ei "
-"anghymeradwyo ers GNOME 2.12. Dadosodwch yr allweddi model, cynllun ac "
-"opsiynau er mwyn cael cyfluniad rhagosodedig y system."
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
-msgid "keyboard layout"
-msgstr "cynllun bysellfwrdd"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
-msgid "keyboard model"
-msgstr "model bysellfwrdd"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "modmap file list"
-msgstr "Rhestr ffeil modmap"
-
-#: ../typing-break/drw-break-window.c:213
-msgid "_Postpone break"
-msgstr "_Gohirio'r saib"
-
-#: ../typing-break/drw-break-window.c:260
-msgid "Take a break!"
-msgstr "Cymerwch saib!"
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:135
-msgid "/_Preferences"
-msgstr "/_Hoffterau"
-
-#: ../typing-break/drwright.c:136
-msgid "/_About"
-msgstr "/_Ynghylch"
-
-#: ../typing-break/drwright.c:138
-msgid "/_Take a Break"
-msgstr "/_Cymryd Saib"
-
-#: ../typing-break/drwright.c:489
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "%d munud tan y saib nesaf"
-msgstr[1] "%d funud tan y saib nesaf"
-
-#: ../typing-break/drwright.c:493
-msgid "Less than one minute until the next break"
-msgstr "Llai nag un munud tan y saib nesaf"
-
-#: ../typing-break/drwright.c:581
-#, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
 msgstr ""
-"Methwyd codi'r deialog hoffterau gorffwys teipio gyda'r gwall canlynol: %s "
 
-#: ../typing-break/drwright.c:629
-msgid "About GNOME Typing Monitor"
-msgstr "Ynghylch Monitor Teipio GNOME"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Analluogwyd"
 
-#: ../typing-break/drwright.c:653
-msgid "A computer break reminder."
-msgstr "Eich atgoffa i gymryd saib o'r cyfrifiadur."
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
 
-#: ../typing-break/drwright.c:654
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
-msgstr "Ysgrifennwyd gan Richard Hult &lt;richard@imendio.com&gt;"
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
 
-#: ../typing-break/drwright.c:655
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Ychwanegwyd melysion gweledol gan Anders Carlsson"
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
 
-#: ../typing-break/drwright.c:831
-msgid "Break reminder"
-msgstr "Eich atgof seibiau"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../typing-break/eggtrayicon.c:127
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "eiliadau"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "C_alendr:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Newid gosodiadau eich Cefndir Penbwrdd"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "C_alendr:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Rhaglenni Amgen"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Dewiswch eich rhaglenni rhagosodedig"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "_Cymhwyso'r ffont"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
 msgid "Orientation"
 msgstr "Gogwydd"
 
-#: ../typing-break/eggtrayicon.c:128
-msgid "The orientation of the tray."
-msgstr "Gogwydd yr hambwrdd."
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Cydraniad:"
 
-#: ../typing-break/main.c:100
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Cyfradd _adnewyddu:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
 msgstr ""
-"Mae'r arsylwr teipio yn defnyddio'r man hysbysu er mwyn dangos gwybodaeth. "
-"Ymddengys nad oes man hysbysu ar eich panel. Gallwch ychwanegu man hysbysu "
-"gan dde-glicio ar eich panel a dewis 'Ychwanegu at y Panel', dewis 'Man "
-"hysbysu' a chlicio 'Ychwanegu.'"
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "Parciais fy jac codi baw hud llawn dwr ger ty Mabon. 0123456789"
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Graddio"
 
-#: ../vfs-methods/fontilus/font-view.c:276
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Canran wedi'i gwblhau"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "O:"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "munud"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "I:"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Enw:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Math"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Terfynell GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Ffenestri"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "_Enw thema:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_Enw Defnyddiwr:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Ynghylch"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Mudo'r sain"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Lefel sain i lawr"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Lefel sain i fyny"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Chwarae (neu chwarae/seibio)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Bysell stopio chwarae"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Neidio i'r trac blaenorol"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Neidio i'r trac nesaf"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Allfwrw"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "Gorffwys Teipio"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Neidio i'r trac nesaf"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Neidio i'r trac blaenorol"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Lansio porwr gwe"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Lansio'r porwr cymorth"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Gosodiadau Rhagosodedig"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Lansio porwr gwe"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Plygell cartref"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Chwilio"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Allgofnodi"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Cloi'r sgrin"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Hygyrchedd"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "Chwyddo"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Chwyddo"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "Bysellfwrdd _ar y Sgrin"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opsiynau"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Hoffterau"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Cynllun bysellfwrdd"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Gwaredu:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Bysellau Llygoden"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Llwybrau byr y Bysellfwrdd"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Gweithred"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Byrlwybr"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Byrlwybr"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Byrlwybr"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Llwybrau byr y Bysellfwrdd"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Gwaredu:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Enw:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "_Gorchymyn:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Byrlwybr"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Byrlwybr"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_Dim"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_Ailosod i'r dewisiadau rhagosodedig"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Bysellfwrdd"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Gosodwch eich gwybodaeth bersonol"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Gosodiadau Rhagosodedig"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "_Eiddil"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Maint Pwyntydd:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Llygoden"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Bysellau Llygoden"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Cyflymiad:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Cyflymiad:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Ffont _rhaglenni:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Eraill"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Gweithred"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Yn cysylltu..."
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Opsiynau"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Dirprwy Rhwydwaith"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Cyfrinair:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Newid Cyfrinair"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Modd Cyflymu"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Cyflymder chwincio'r cyrchwr"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Cyfeiriad"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Cyfeiriad"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Cyfeiriad"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Pwyntydd Rhagosodedig"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Enw:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Cyfeiriad:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Cyfeiriad:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Analluogwyd"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Cyfeiriad"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Cyfeiriad"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "munud"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Dirprwy Rhwydwaith"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "_Actifadu"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "Cyfeiriad"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Dirprwy Rhwydwaith"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "Dirprwy _HTTP:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "Dirprwy _HTTP:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "Dirprwy _FTP:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Gweinydd S_ocks:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "<b>Anwybyddu Rhestr Gwesteiwyr</b>"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "Dirprwy _HTTP:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "Dirprwy _HTTP:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "Dirprwy _FTP:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "_URL cyfluniad awtomatig:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Dirprwy Rhwydwaith"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Cyfrinair:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Dewisiadau bysellfwrdd"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Defnyddio dilysiant</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "_Enw Defnyddiwr:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Cyfrinair:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "Cyfrinair _newydd:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Fersiwn:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Fersiwn:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Aildeipiwch y cyfrinair newydd:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "<b>_Defnyddio dilysiant</b>"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Math"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Rhagosodiad"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "System"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Lleoliad:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Seiniau"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Byrlwybr i gloi'r sgrin."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Byrlwybr i gloi'r sgrin."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Defnyddio dilysiant</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "munud"
+msgstr[1] "munud"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "munud"
+msgstr[1] "munud"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "munud"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "munud"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "munud"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "munud"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "munud"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "munud"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "munud"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "munud"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Modd Cyflymu"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Llenwi'r Sgrin"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Sgrin"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Oediad:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "Pwyntyddion"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "Pwyntyddion"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Dim sain"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "_Enw Defnyddiwr:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "_Lleoliad:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Methodd Gosodiad"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Dewis"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Opsiynau"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Manylion Llunio Ffontiau"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "_Ailosod i'r dewisiadau rhagosodedig"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Modelau"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Gwnewch yn siwr fod y rhaglennig wedi ei osod yn gywir"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Pwyntyddion"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Pob Ffeil"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Rhagolwg:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "_Adran:"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "Allgofnodi"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Llenwi'r Sgrin"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Gweithred"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Math:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Sgrin"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Cloi'r sgrin"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Sgrin"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Sgrin"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Gosodiadau Sgrin %d\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Dewisiadau bysellfwrdd"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Eraill"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "_Lleoliad:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Ffont _rhaglenni:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Byrlwybr chwilio"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Dirprwy Rhwydwaith"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Penbwrdd"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Gwaredu:"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Cyfrinair:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Penbwrdd"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Rheolydd RhD (UI)"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Copïo"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<b>_Defnyddio dilysiant</b>"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Enw defnyddiwr:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Synau'r System"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Mudo'r sain"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Cyfluniad Dirprwy"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Lefel Sain"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Botymau Rhybudd"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Sain"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Enw:"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "Arddull:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "Math:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "Maint:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "Fersiwn:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "Hawlfraint:"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "Disgrifiad:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:408
-#, c-format
-msgid "usage: %s fontfile\n"
-msgstr "defnydd: %s ffeil_ffont\n"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
-msgstr "Gosod fel y Ffont Rhaglenni"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
-msgid "Sets the default application font"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>Chwincio'r Cyrchydd</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "_Mae'r cyrchydd yn chwincio mewn blychau testun a meysydd"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Cyflymder:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Cyflymder chwincio'r cyrchwr"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Cyflymder chwincio'r cyrchwr"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Byrlwybr"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Oediad:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Byrlwybr"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Trothwy:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Bach"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Mawr"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Bysellau Ailadroddus</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Bysellau yn _ailadrodd wrth gael eu dal i lawr"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Cyflymder ail-adrodd bysellau"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Cyflymder ail-adrodd bysellau"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Rhybudd Bysellau Gludiog"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "_Analluogi pan mae dwy fysell yn cael eu gwasgu ar yr un pryd"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Bîp pan mae'r _addasydd yn cael ei wasgu"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Rhybudd Bysellau Araf"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Byrlwybr"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Bîp pan mae'r _addasydd yn cael ei wasgu"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Bîp os yw'r fysell yn:"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Bîp os ni _wrthodir y fysell"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Bysellau Llygoden"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Anwybyddu a_il-wasgiadau o fewn:"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Byrlwybr"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Hygyrchedd"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Mawr"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "_Darllenydd sgrin"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Seiniau"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Chwyddo"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Bysellfwrdd _ar y Sgrin"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Bysellau Ailadroddus</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Chwincio'r Cyrchydd</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Bysellau Llygoden"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Pwyntydd Mawr"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<b>Amser Aros am Glic Dwbl</b>"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Fflachio'r _sgrin gyfan"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Fflachio'r _sgrin gyfan"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Llenwi'r Sgrin"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Opsiynau"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_Chwyddwr"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "_Chwyddwr"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "_Darllenydd sgrin"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "_Chwyddwr"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Disgleirdeb i fyny"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Cyswllt"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Dim"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Llawn"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "_Peidio â dad-actifadu"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Cyfrinair _newydd:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Dewiswch Ffeil Sain"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Trefnydd Ffenestri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Dim"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Rhagolwg:"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Newid Cyfrinair"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Newid set"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Newid Cyfrinair"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Cyfrinair _newydd:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Newid Cyfrinair"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "Cyfrinair _newydd:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Enw Llawn"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_Golygu"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Rheolyddion"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
 msgstr "Dewis y ffont rhagosodedig ar gyfer rhaglenni"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau OpenType."
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau PCF."
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Eraill"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau TrueType."
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau Type1"
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Dim sain"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
-"cryno o ffontiau OpenType."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
 msgstr ""
-"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
-"cryno o ffontiau PCF."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
-"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
-"cryno o ffontiau TrueType."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
 msgstr ""
-"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
-"cryno o ffontiau Type1."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau OpenType"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau PCF"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau TrueType"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau Type1"
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Botymau"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "A ddylid creu lluniau cryno o ffontiau OpenType"
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "A ddylid creu lluniau cryno o ffontiau PCF"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "A ddylid creu lluniau cryno o ffontiau TrueType"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "A ddylid creu lluniau cryno o ffontiau Type1"
-
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
-msgid "GNOME Font Viewer"
-msgstr "Gwelydd Ffontiau GNOME"
-
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-msgstr "<span weight=\"bold\" size=\"larger\">Cymhwyso'r ffont newydd?</span>"
-
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr "_Peidio cymhwyso'r ffont"
-
-#: ../vfs-methods/themus/apply-font.glade.h:4
+#: panels/wacom/button-mapping.ui:51
 msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"Mae'r thema rydych chi wedi dewis yn awgrymu ffont newydd. Dangosir rhagolwg "
-"o'r ffont isod."
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-msgid "_Apply font"
-msgstr "_Cymhwyso'r ffont"
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
 
-#: ../vfs-methods/themus/theme-method.c:518
-msgid "Themes"
-msgstr "Themâu"
-
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "Disgrifiad"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
-msgstr "Thema rheoli"
-
-#: ../vfs-methods/themus/themus-properties-view.c:139
-msgid "Window border theme"
-msgstr "Thema ymyl ffenestr"
-
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
-msgstr "Thema eiconau"
-
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
-msgstr "ABCDEFG"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-msgid "Apply theme"
-msgstr "Defnyddio thema"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-msgid "Sets the default theme"
-msgstr "Dewis thema ragosodedig"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer themâu sefydledig."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer themâu."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:3
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
 msgstr ""
-"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
-"cryno o themâu sefydledig."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
 msgstr ""
-"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
-"cryno o themâu."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr "Gorchymyn lluniau cryno ar gyfer themâu sefydledig"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr "Gorchymyn lluniau cryno ar gyfer themâu sefydledig"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr "A ddylid creu lluniau cryno o themâu sefydledig"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr "A ddylid creu lluniau cryno o themâu"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Gogwydd"
 
-msgid "Show help options"
-msgstr "Dangos opsiynau cymorth"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Botymau"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botymau"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botymau"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Cyflwyniad"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Wedi ei ganoli"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Ffenestri"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Ffenestri"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Ychwanegu..."
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Cadw"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Manylion Thema"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Dirprwy Rhwydwaith"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Manylion Thema"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Ffôn symudol:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Dirprwy Rhwydwaith"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Dirprwy Rhwydwaith"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Manylion Thema"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Dirprwy Rhwydwaith"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Galluogi Bysellau _Togl"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Yn cysylltu..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Newid set"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Gosodiadau Rhagosodedig"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Gadael"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Chwilio"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Neidio i'r trac blaenorol"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Hoffterau"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgid "Image/label border"
+#~ msgstr "Border delwedd/label"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "Lled y border o amgylch y label a'r ddelwedd yn y ddeialog rhybudd"
+
+#~ msgid "The type of alert"
+#~ msgstr "Y math o rybudd"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Y botymau a ddangosir yn y ddeialog rhybudd"
+
+#~ msgid "Show more _details"
+#~ msgstr "Dangos _mwy o fanylion"
+
+#~ msgid "About Me"
+#~ msgstr "Amdana I"
+
+#~ msgid "No Image"
+#~ msgstr "Dim Delwedd"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Roedd gwall wrth geisio cael gwybodaeth y llyfr cyfeiriadau\n"
+#~ "Fedr Gweinydd Data Evolution ddim delio â'r protocol"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Methu agor y llyfr cyfeiriadau"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr ""
+#~ "ID mewngofnodi anhysbys, gall fod y gronfa ddata o ddefnyddwyr wedi ei "
+#~ "llygru"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "Ynghylch %s"
+
+#~ msgid "Old password is incorrect, please retype it"
+#~ msgstr "Hen gyfrinair yn anghywir, aildeipiwch ef"
+
+#~ msgid "System error has occurred"
+#~ msgstr "Digwyddodd gwall system"
+
+#~ msgid "Could not run /usr/bin/passwd"
+#~ msgstr "Methu rhedeg /usr/bin/passwd"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "Methu lansio'r ochr gefn"
+
+#~ msgid "Unexpected error has occurred"
+#~ msgstr "Digwyddodd gwall anhysbys"
+
+#~ msgid "Password is too short"
+#~ msgstr "Cyfrinair yn rhy fyr"
+
+#~ msgid "Password is too simple"
+#~ msgstr "Cyfrinair yn rhy syml"
+
+#~ msgid "Old and new passwords are too similar"
+#~ msgstr "Mae'r cyfrinair newydd yn rhy debyg i'r hen un"
+
+#~ msgid "Must contain numeric or special character(s)"
+#~ msgstr "Rhaid iddo gynnwys nod(au) arbennig neu rif(au)"
+
+#~ msgid "Old and new password are the same"
+#~ msgstr "Mae'r cyfrinair newydd yr un peth â'r hen un"
+
+#~ msgid "Please type the passwords."
+#~ msgstr "Teipiwch y cyfrineiriau."
+
+#~ msgid "Please type the password again, it is wrong."
+#~ msgstr "Teipiwch y cyfrinair eto: mae'n anghywir."
+
+#~ msgid "Click on Change Password to change the password."
+#~ msgstr "Cliciwch Newid Cyfrinair er mwyn newid y cyfrinair."
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Cartref</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Negesu Chwim</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Swydd</b>"
+
+#~ msgid "<b>Please type the passwords.</b>"
+#~ msgstr "<b>Teipiwch y cyfrineiriau.</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Ffôn</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Gwe</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Gwaith</b>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "_Cyfeiriad:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "_Cynorthwyydd:"
+
+#~ msgid "C_ity:"
+#~ msgstr "_Dinas:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "_Cwmni:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Newid C_yfrinair..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "_Dinas:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "_Gwlad:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "G_wlad:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "_Cartref:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "Old pa_ssword:"
+#~ msgstr "Hen _gyfrinair:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "Blwch _post:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "_Blwch post:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Gwybodaeth Bersonol"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Talaith/_Ardal:"
+
+#~ msgid "Web _log:"
+#~ msgstr "Gwe_log:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_Gwaith:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "_Ffacs gwaith:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "Co_d post/zip:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "Tudalen _cartref:"
+
+#~ msgid "_Home:"
+#~ msgstr "C_artref:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Rheolwr:"
+
+#~ msgid "_Profession:"
+#~ msgstr "_Proffesiwn:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_Talaith/Ardal:"
+
+#~ msgid "_Title:"
+#~ msgstr "_Teitl:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Gwaith:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "_Cod post/zip:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Cynhaliaeth</b>"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>Noder:</b> Ni fydd newidiadau i'r gosodiad yma yn dod i rym "
+#~ "tan y tro nesa i chi fewngofnodi.</i></small>"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Hoffterau Technoleg Gynorthwyol"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Cau ac _Allgofnodi"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr ""
+#~ "Cychwyn y technolegau cynorthwyol yma bob tro rydych chi'n mewngofnodi:"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Galluogi technolegau cynorthwyol"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "Cynhaliaeth Technoleg Gynorthwyol"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr ""
+#~ "Galluogi cynhaliaeth ar gyfer technolegau cynorthwyol GNOME wrth "
+#~ "fewngofnodi"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Does dim Technoleg Gynorthwyol ar gael ar eich system. Rhaid sefydlu'r "
+#~ "pecyn 'gok' ar gyfer cael cynhaliaeth bysell ar sgrin, a'r pecyn "
+#~ "'gnopernicus' ar gyfer medru sgrînddarllen a chwyddo."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Nid yw pob technoleg gynorthwyol wedi eu sefydlu ar eich system. Rhaid "
+#~ "sefydlu'r pecyn 'gok' er mwyn cael bysell ar sgrin."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+#~ msgstr ""
+#~ "Nid yw pob technoleg gynorthwyol wedi eu sefydlu ar eich system. Rhaid "
+#~ "sefydlu'r pecyn 'gnopernicus' ar gyfer sgrînddarllen a chwyddo."
+
+#, c-format
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "Roedd gwall wrth lansio'r deialog hoffterau llygoden: %s"
+
+#, c-format
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Methu mewnforio gosodiadau AccessX o'r ffeil '%s'"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Mewnforio Ffeil Gosodiadau Nodweddion"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Dewis eich hoffterau hygyrchedd bysellfwrdd"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Ymddengys nad yw'r estyniad XKB ar gael ar y system hon. Ni fydd "
+#~ "nodweddion hygyrchedd y bysellfwrdd yn gweithio hebddi."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>Galluogi Bysellau Sb_onciog</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>Galluogi Bysellau _Araf</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Galluogi Bysellau _Llygoden</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>Galluogi Bysellau _Ailadroddus</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>Galluogi Bysellau _Gludiog</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Nodweddion</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Bysellau Togl</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Sylfaenol"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr "Bîp wrth droi'r _nodwedd ymlaen neu bant o'r bysellfwrdd"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "Bîp pan fo'r LED yn goleuo a dau fîp pan mae'n cael ei ddiffodd."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Oedi rhwng gwasgu bysell a symudiad y _pwyntydd:"
+
+#~ msgid "Filters"
+#~ msgstr "Hidlau"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Anwybyddu pob gwasgiad dilynol o'r UN fysell os maent yn digwydd o fewn "
+#~ "cyfnod a gall y defnyddiwr ei ddewis."
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Hoffterau Hygyrchedd Bysellfwrdd (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Cyflymdra m_wya'r pwyntydd:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Hoffterau _Llygoden..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Derbyn bysellau dim ond ar ôl iddynt gael eu gwasgu a'u dal am gyfnod "
+#~ "gall y defnyddiwr ei ddewis."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Cyflawni nifer o wasgiadau bysell cydamserol gan wasgu dilyniant o "
+#~ "fysellau addasu."
+
+#~ msgid "S_peed:"
+#~ msgstr "Cy_flymder:"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Amser i gyf_lymu i'r cyflymder mwyaf:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Trowch y bysellfwrdd rhifau yn fysellfwrdd rheoli'r llygoden"
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Analluogi os na ddefnyddiwyd am:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "_Galluogi nodweddion hygyrchedd bysellfwrdd"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Mewnforio Gosodiadau Nodweddion..."
+
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "_Derbyn bysell wedi'u dal am:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Teipiwch i arbrofi'r gosodiadau:"
+
+#~ msgid "_accepted"
+#~ msgstr "_derbyniwyd"
+
+#~ msgid "_pressed"
+#~ msgstr "_gwasgedig"
+
+#~ msgid "_rejected"
+#~ msgstr "_gwrthodwyd"
+
+#~ msgid "characters/second"
+#~ msgstr "nodau'r eiliad"
+
+#~ msgid "milliseconds"
+#~ msgstr "milfedau o eiliadau"
+
+#~ msgid "pixels/second"
+#~ msgstr "picseli'r eiliad"
+
+#~ msgid "Desktop Background"
+#~ msgstr "Cefndir Penbwrdd"
+
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>Papur _Wal Penbwrdd</b>"
+
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>_Lliwiau Penbwrdd</b>"
+
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Hoffterau Cefndir Penbwrdd"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Agorwch ddeialog i ddewis y lliw"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Ychwanegu Papur Wal"
+
+#~ msgid "_Finish"
+#~ msgstr "_Gorffen"
+
+#~ msgid "_Style:"
+#~ msgstr "_Arddull:"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Gwall wrth ddangos cymorth:%s"
+
+#~ msgid "Tiled"
+#~ msgstr "Teilsio"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Graddfa Lorweddol"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Graddfa Fertigol"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Ychwanegu Papur Wal"
+
+#~ msgid "Images"
+#~ msgstr "Delweddau"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "picsel"
+#~ msgstr[1] "bicsel"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Methu cychwyn y rheolwr gosodiadau 'gnome-settings-daemon'.\n"
+#~ "Heb i'r rheolydd gosodiadau GNOME fod yn weithgar, mae'n bosib na fydd "
+#~ "rhai hoffterau'n dod i rym. Gall hyn olygu fod problem gyda Bonobo, neu "
+#~ "fe all rheolydd gosodiadau arall (e.e. KDE) fod yn weithgar ac yn creu "
+#~ "anghysondebau gyda rheolydd gosodiadau GNOME."
+
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Methu llwytho'r eicon stoc '%s'\n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Cymhwyso'r gosodiadau a therfynu"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Nol a chadw'r hen osodiadau"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Copïo ffeil: %u o %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "Copïo '%s'"
+
+#~ msgid "From URI"
+#~ msgstr "URI Tarddiad"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI yn trosglwyddo o"
+
+#~ msgid "To URI"
+#~ msgstr "URI Cyrchiad"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI yn trosglwyddo i"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Canran y trosglwyddiad wedi'i gwblhau ar hyn o bryd"
+
+#~ msgid "Current URI index"
+#~ msgstr "Mynegai URI cyfredol"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Mynegai URI cyfredol - mae'n dechrau o 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "Cyfanswm URIau"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Nifer cyflawn URIau"
+
+#~ msgid "Key"
+#~ msgstr "Allwedd"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Allwedd GConf sy'n cyfateb i'r golygydd priodwedd yma"
+
+#~ msgid "Callback"
+#~ msgstr "Adalwad"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Galw'r adalwad yma pan newidir gwerth cysylltiedig yr allwedd"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Set newid GConf yn cynnwys data i'w anfon ymlaen i'r cleient gconf wrth "
+#~ "gymhwyso"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Trosi i adalwad celficyn"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "Yr adalwad i'w alw pan fo data i'w trosi o GConf i'r teclyn"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Trosi o adalwad teclyn"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "Adalwad i alw pan fo data i'w trosi i GConf o'r teclyn"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Gwrthrych sy'n rheoli'r briodwedd (celficyn gan amlaf)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Data gwrthrychol golygydd priodweddau"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Data addasol sy'n anghenraid gan y golygydd priodweddau penodol"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Adalwad rhyddhau data golygydd priodweddau"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Adalwad i'w alw pan fo data gwrthrychol golygydd priodweddau i'w rhyddhau"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Methwyd canfod y ffeil '%s'\n"
+#~ "\n"
+#~ "Gwiriwch ei bod yn bodoli a cheisiwch eto, neu dewiswch lun cefndir arall "
+#~ "os gwelwch yn dda."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Nid ydw i'n deall sut i agor y ffeil '%s'.\n"
+#~ "Efallai ei bod yn fath o lun nas cynhelir eto.\n"
+#~ "\n"
+#~ "Dewiswch lun gwahanol yn ei le, os gwelwch yn dda."
+
+#~ msgid "Please select an image."
+#~ msgstr "Dewiswch ddelwedd."
+
+#~ msgid "Could not display help"
+#~ msgstr "Methu dangos y cymorth"
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Gwall wrth gadw cyfluniad: %s"
+
+#~ msgid "Custom"
+#~ msgstr "Addasedig"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Methu llwytho'r prif ryngwyneb"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "\"Sensible-Browser\" (Debian)"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Efelychydd Terfynell Debian"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Porwr Gwe Epiphany"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Y Darllenwr Ebost Evolution"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "Darllenwr Ebost Evolution 1.4"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "Darllenwr Ebost Evolution 1.5"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "Darllenwr Ebost Evolution 1.6"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "Darllenwr Ebost Evolution 2.0"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "Darllenwr Ebost Evolution 2.2"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "Darllenwr Ebost Evolution 2.4"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Y Porwr Gwe Links"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Y Porwr Gwe Lynx"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "E-bost Mozilla"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "XTerminal arferol"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "Y Porwr Gwe W3M"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "<b>Audio Player</b>"
+#~ msgstr "<b>Chwaraeydd Sain</b>"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>Gwelydd Delweddau</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>Negesu Chwim</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>Darllenwr E-bost</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Efelychydd Terfynell</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Golygydd Testun</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Chwaraewr Fideo</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Porwr Gwe</b>"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Fe roddir y cyswllt go iawn yn lle pob %s"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "_Gorchymyn:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "Baner E_xec:"
+
+#~ msgid "Internet"
+#~ msgstr "Rhyngrwyd"
+
+#~ msgid "Multimedia"
+#~ msgstr "Amlgyfrwng"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Agor cyswllt mewn _tab newydd"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Agor cyswllt mewn _ffenestr newydd"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Agor cyswllt gyda'r porwr gwe sy'n _ragosodiad"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Rhedeg mewn t_erfynell"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Newid cydraniad y sgrin"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Hoffterau Cydraniad y Sgrin"
+
+#, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "Gwneud yn rhagosodiad ar gyfer y _cyfrifiadur hwn (%s) yn unig"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Profi'r gosodiadau newydd. Os nad ydych chi'n ymateb o fewn %d eiliad "
+#~ "caiff y gosodiadau blaenorol eu hadfer."
+#~ msgstr[1] ""
+#~ "Profi'r gosodiadau newydd. Os nad ydych chi'n ymateb o fewn %d eiliad "
+#~ "caiff y gosodiadau blaenorol eu hadfer."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Cadw'r Cydraniad"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "A hoffech gadw'r cyfraniad yma?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "Defnyddio'r cydraniad _blaenorol"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Cadw'r cydraniad"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "Nid yw'r gweinydd X yn cynnal yr estyniad XRandR. Nid yw'n bosib newid y "
+#~ "cydraniad tra mae'r gweinydd X yn rhedeg."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Mae fersiwn yr estyniad XRandR yn anghytunol gyda'r rhaglen hon. Nid yw'n "
+#~ "bosib newid y cydraniad tra bo'r gweinydd X yn rhedeg."
+
+#~ msgid "Font"
+#~ msgstr "Ffont"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Dewiswch ffontiau ar gyfer y penbwrdd"
+
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<b>Llunio Ffontiau</b>"
+
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<b>Awgrymu</b>:"
+
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<b>Llyfnhau</b>:"
+
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<b>Trefn is-bicsel</b>:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "_Siapau gorau"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "_Cyferbyniad gorau"
+
+#~ msgid "D_etails..."
+#~ msgstr "_Manylion..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "_Ffont y penbwrdd:"
+
+#~ msgid "Font Preferences"
+#~ msgstr "Hoffterau Ffont"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "_Mynd i'r blygell ffont"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "_Graddlwyd"
+
+#~ msgid "N_one"
+#~ msgstr "_Dim"
+
+#~ msgid "R_esolution:"
+#~ msgstr "_Cydraniad:"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Is_bicsel (LCDau)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Llyfnu is_bicsel (LCDau)"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Ffont y ddogfen:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_Ffont lled rhagosodedig:"
+
+#~ msgid "_Medium"
+#~ msgstr "_Canolig"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Unlliw"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Ffont teitl y ffenest:"
+
+#~ msgid "dots per inch"
+#~ msgstr "dot y fodfedd"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Mae'n bosib fod y ffont rhy fawr"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Mae'r ffont a ddewiswyd yn %d pwynt o faint, a gall ei wneud yn anodd "
+#~ "defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
+#~ "maint yn llai na %d."
+#~ msgstr[1] ""
+#~ "Mae'r ffont a ddewiswyd yn %d bwynt o faint, a gall ei wneud yn anodd "
+#~ "defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
+#~ "maint yn llai na %d."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Mae'r ffont a ddewiswyd yn %d pwynt o faint, a gall ei wneud yn anodd "
+#~ "defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
+#~ "maint ffont llai."
+#~ msgstr[1] ""
+#~ "Mae'r ffont a ddewiswyd yn %d bwynt o faint, a gall ei wneud yn anodd "
+#~ "defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
+#~ "maint ffont llai."
+
+#~ msgid "New accelerator..."
+#~ msgstr "Cyflymydd newydd..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Bysell cyflymu"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Addasyddion cyflymu"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Cod bysell cyflymu"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Y math o gyflymydd."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Gweithred Anhysbys>"
+
+#~ msgid "Window Management"
+#~ msgstr "Rheoli Ffenestri"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become unusable to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time.\n"
+#~ msgstr ""
+#~ "Methu defnyddio'r llwybr byr \"%s\" am y bydd wedyn yn amhosib teipio "
+#~ "gyda'r allweddell yna.\n"
+#~ "Ail-geisiwch gydag allwedd fel Control, Alt or Shift ar yr un pryd.\n"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "Defnyddir y byrlwybr \"%s\" eisoes ar gyfer:\n"
+#~ " \"%s\"\n"
+
+#, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "Gwall wrth osod cyflymydd newydd yn y gronfa cyfluniad: %s\n"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "Gwall wrth ddadosod cyflymydd yn y gronfa cyfluniad: %s\n"
+
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "I olygu bysell cyflymydd, cliciwch ar y rhes sy'n cyfateb a theipiwch "
+#~ "gyflymydd newydd, neu gwasgwch olnod er mwyn clirio."
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "_Neilltuo bysell byrlwybr â gorchmynion"
+
+#~ msgid "Unknown"
+#~ msgstr "Anhysbys"
+
+#, c-format
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "Roedd gwall wrth gychwyn offer y bysellfwrdd: %s"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Cymhwyso'r gosodiadau a therfynu (cydnawsedd yn unig; trinnir gan ellyll "
+#~ "bellach)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Cychwyn y dudalen gyda'r gosodiadau gorffwys teipio yn dangos"
+
+#~ msgid "..."
+#~ msgstr "..."
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>_Cloi'r sgrin er mwyn gorfodi'r saib teipio</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Cyflym</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Hir</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Byr</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Araf</i></small>"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "_Cynlluniau ar gael:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "_Caniatáu gohirio seibiau"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Gwirio os ceir gohirio seibiau"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Dewiswch Fodel Bysellfwrdd"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Dewiswch Gynllun"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Hyd y saib tra mae teipio wedi ei wahardd"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Hyd y gwaith cyn gorfodi saib"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Hoffterau Bysellfwrdd"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Model bysellfwrdd"
+
+#~ msgid "Layout Options"
+#~ msgstr "Opsiynau Cynllun:"
+
+#~ msgid "Layouts"
+#~ msgstr "Cynlluniau"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Cloi'r sgrin ar ôl cyfnod penodedig er mwyn cynorthwyo atal anafiadau "
+#~ "defnydd bysellfwrdd ailadroddus"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Bysellfwrdd Naturiol Microsoft"
+
+#~ msgid "Separate _group for each window"
+#~ msgstr "_Grwp ar wahân ar gyfer pob ffenestr"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Hygyrchedd..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Cyfnod seibio yn para:"
+
+#~ msgid "_Models:"
+#~ msgstr "_Modelau:"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Cynlluniau dewiswyd:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Cyfnod gweithio yn para:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Gosodwch eich hoffterau bysellfwrdd"
+
+#, c-format
+#~ msgid "%d milliseconds"
+#~ msgid_plural "%d milliseconds"
+#~ msgstr[0] "%d milfed eiliad"
+#~ msgstr[1] "%d milfedau o eiliadau"
+
+#~ msgid "Unknown Pointer"
+#~ msgstr "Pwyntydd Anhysbys"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Pwyntydd Rhagosodedig - Cyfredol"
+
+#~ msgid "The default pointer that ships with X"
+#~ msgstr "Y pwyntydd rhagosodedig a gludir gydag X"
+
+#~ msgid "White Pointer"
+#~ msgstr "Pwyntydd Gwyn"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Pwyntydd Gwyn - Cyfredol"
+
+#~ msgid "The default pointer inverted"
+#~ msgstr "Y pwyntydd rhagosodedig wedi'i wrthdroi"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Pwyntydd Mawr - Cyfredol"
+
+#~ msgid "Large version of normal pointer"
+#~ msgstr "Fersiwn mawr o'r pwyntydd arferol"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Pwyntydd Mawr Gwyn - Cyfredol"
+
+#~ msgid "Large version of white pointer"
+#~ msgstr "Fersiwn mawr o'r pwyntydd gwyn"
+
+#~ msgid "Pointer Theme"
+#~ msgstr "Thema Pwyntydd"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Llusgo a Gollwng</b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Lleoli'r Pwyntydd</b>"
+
+#~ msgid "<b>Mouse Orientation</b>"
+#~ msgstr "<b>Cyfeiriadaeth Llygoden</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Cyflymder</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Cyflym</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Uchel</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Mawr</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Isel</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Araf</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Bach</i>"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Amlygu'r _pwyntydd pan rydych chi'n gwasgu Ctrl"
+
+#~ msgid "Motion"
+#~ msgstr "Symudiad"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Hoffterau Llygoden"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Llygoden lawchwith"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Sensitifrwydd:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Gosodwch eich hoffterau llygoden"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Gosod eich hoffterau dirprwy rhwydwaith"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>_Cysylltiad Rhyngrwyd uniongyrchol</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>Cyfluniad dirprwy _awtomatig</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Cyflunio dirprwy â _llaw</b>"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Cyfluniad Uwch"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Manylion dirprwy HTTP"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Hoffterau Dirprwy Rhwydwaith"
+
+#~ msgid "Port:"
+#~ msgstr "Porth:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "Dirprwy HTTP _Diogel:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Galluogi sain a chysylltu seiniau â digwyddiadau"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Hoffterau Sain"
+
+#~ msgid "E_nable software sound mixing (ESD)"
+#~ msgstr "_Galluogi cymysgu sain o fewn meddalwedd (ESD)"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Fflachio bar teitl y _ffenest"
+
+#~ msgid "System Beep"
+#~ msgstr "Bîp y System"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "_Galluogi bîp y system"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "_Chwarae synau'r system"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "Bîp _gweledol y system"
+
+#~ msgid "Would you like to remove this theme?"
+#~ msgstr "Hoffech chi dynnu'r thema hon?"
+
+#~ msgid "Theme deleted succesfully. Please select another theme."
+#~ msgstr "Thema wedi'i ddileu yn llwyddiannus. Dewiswch thema wahanol."
+
+#~ msgid "Theme can not be deleted"
+#~ msgstr "Methu dileu'r thema"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Ni chanfuwyd unrhyw themâu ar eich system. Mae'n debyg golyga hyn bod "
+#~ "eich deialog \"Hoffterau Thema\" wedi ei osod yn anghywir, neu nad ydych "
+#~ "wedi gosod y pecyn \"gnome-themes\"."
+
+#~ msgid "This theme is not in a supported format."
+#~ msgstr "Nid yw'r thema mewn ffurf a gynhelir."
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Methu creu cyfeiriadur dros dro"
+
+#~ msgid ""
+#~ "Can not install theme. \n"
+#~ "The bzip2 utility is not installed."
+#~ msgstr ""
+#~ "Methu gosod thema. \n"
+#~ "Nid yw'r rhaglen bzip2 wedi ei osod."
+
+#~ msgid ""
+#~ "Can not install themes. \n"
+#~ "The gzip utility is not installed."
+#~ msgstr ""
+#~ "Methu gosod themâu. \n"
+#~ "Nid yw'r rhaglen bzip2 wedi ei osod."
+
+#, c-format
+#~ msgid ""
+#~ "Icon Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Thema Eicon %s wedi ei gosod yn gywir.\n"
+#~ "Gallwch ei dewis yn y manylion themâu."
+
+#, c-format
+#~ msgid "Gnome Theme %s correctly installed"
+#~ msgstr "Thema Gnome %s wedi ei gosod yn gywir"
+
+#, c-format
+#~ msgid ""
+#~ "Windows Border Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Thema Border Ffenest %s wedi ei gosod yn gywir.\n"
+#~ "Gallwch ei dewis yn y manylion themâu."
+
+#, c-format
+#~ msgid ""
+#~ "Controls Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Thema Rheolyddion %s wedi ei gosod yn gywir.\n"
+#~ "Gallwch ei dewis yn y manylion themâu."
+
+#~ msgid "The theme is an engine. You need to compile the theme."
+#~ msgstr "Mae'r thema yn injan. Rhaid i chi grynhoi'r thema."
+
+#~ msgid "The file format is invalid"
+#~ msgstr "Fformat ffeil yn annilys"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Ni chafodd lleoliad ffeil thema ei bennu ar gyfer ei osod"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Roedd y lleoliad ffeil thema a benodwyd i'w osod yn annilys"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Caniatadau annigonol i osod y thema yn:\n"
+#~ "%s"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "Fformat ffeil yn annilys."
+
+#, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s yw'r llwybr lle fydd y ffeiliau thema wedi ei gosod. Ni ellir dewis "
+#~ "hwn fel lleoliad y ffynhonnell"
+
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "The tar program is not installed on your system."
+#~ msgstr ""
+#~ "Methu gosod thema.\n"
+#~ "Nid yw'r rhaglen tar wedi ei osod ar eich system."
+
+#~ msgid "Custom theme"
+#~ msgstr "Thema Addasedig"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "Gallwch gadw'r thema yma drwy glicio'r botwm Cadw Thema."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "Methwyd canfod y sgemâu thema rhagosodedig ar eich system. Mae hyn yn "
+#~ "awgrymu nad yw metacity wedi ei ymsefydlu gennych, neu fod eich gconf "
+#~ "wedi ei gyflunio'n anghywir."
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Rhaid bod enw thema yn bresennol"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Mae'r thema'n bodoli eisoes. A hoffech ei newid?"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Dewiswch themâu i amryw rannau'r penbwrdd"
+
+#~ msgid "Theme"
+#~ msgstr "Thema"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Gosod Thema</span>"
+
+#~ msgid "Theme Installation"
+#~ msgstr "Gosodiad Thema"
+
+#~ msgid "_Install"
+#~ msgstr "_Gosod"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Cadw Thema i Ddisg</span>"
+
+#~ msgid "Apply _Font"
+#~ msgstr "Cymhwyso _Ffont"
+
+#~ msgid "Icons"
+#~ msgstr "Eiconau"
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr "Gellir gosod themâu newydd drwy ei llusgo i'r ffenestr hefyd"
+
+#~ msgid "Save Theme"
+#~ msgstr "Cadw'r Thema"
+
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Dewiswch thema ar gyfer y penbwrdd"
+
+#~ msgid "Short _description:"
+#~ msgstr "_Disgrifiad byr:"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "Hoffterau Thema"
+
+#~ msgid "Theme _Details"
+#~ msgstr "_Manylion Thema"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "Nid yw'r thema yma yn awgrymu unrhyw ffont neu gefndir penodol"
+
+#~ msgid "This theme suggests a background:"
+#~ msgstr "Mae'r thema yma yn awgrymu cefndir:"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Mae'r thema yma yn awgrymu ffont a chefndir:"
+
+#~ msgid "This theme suggests a font:"
+#~ msgstr "Mae'r thema yma yn awgrymu ffont:"
+
+#~ msgid "Window Border"
+#~ msgstr "Ymyl Ffenestr"
+
+#~ msgid "_Revert"
+#~ msgstr "_Dychwelyd:"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "_Cadw'r thema..."
+
+#~ msgid "theme selection tree"
+#~ msgstr "coeden dewis thema"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "Addasu golwg bariau offer a bariau dewislenni mewn rhaglenni"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Dewislenni a Bariau Offer"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Ymddygiad ac Ymddangosiad</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Rhagolwg</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "T_orri"
+
+#~ msgid "Icons only"
+#~ msgstr "Eiconau'n unig"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Hoffterau Dewislen a Bar Offer"
+
+#~ msgid "New File"
+#~ msgstr "Ffeil Newydd"
+
+#~ msgid "Open File"
+#~ msgstr "Agor Ffeil"
+
+#~ msgid "Save File"
+#~ msgstr "Cadw Ffeil"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Dangos _eiconau mewn dewislenni"
+
+#~ msgid "Text below icons"
+#~ msgstr "Testun islaw eiconau"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Testun wrth ochr eiconau"
+
+#~ msgid "Text only"
+#~ msgstr "Testun yn unig"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Labeli _botymau bar offer:"
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "Barau offer gellir _datgysylltu"
+
+#~ msgid "_Editable menu accelerators"
+#~ msgstr "Posib _golygu cyflymwyr dewislen"
+
+#~ msgid "_File"
+#~ msgstr "_Ffeil"
+
+#~ msgid "_New"
+#~ msgstr "_Newydd"
+
+#~ msgid "_Paste"
+#~ msgstr "_Gludo"
+
+#~ msgid "_Print"
+#~ msgstr "_Argraffu"
+
+#, c-format
+#~ msgid ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "<b>Methu cychwyn y rhaglen hoffterau ar gyfer eich rheolwr ffenestri</b>\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "C_ontrol"
+#~ msgstr "C_ontrol"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "_Goruwch (hyper)"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "_Uwch (neu \"Logo Windows\")"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Bysell Symud</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Gweithred Bar Teitl</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Dewis Ffenestri</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "I symud ffenestr, gwasgwch a chydiwch y fysell yma yna cydiwch yn y "
+#~ "ffenestr:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Hoffterau Ffenestr"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Rhoi clic dwbl ar y bar teitl i gyflawni'r weithred hon:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Cyfnod cyn codi:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Codi ffenestri dewisedig ar ôl cyfnod"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Dewis ffenestri pan fo'r llygoden yn symud drostynt"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Gosod eich priodweddau ffenestr"
+
+#~ msgid "Desktop Preferences"
+#~ msgstr "Hoffterau Penbwrdd"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Canolfan Reoli GNOME"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Yr erfyn cyfluniad GNOME"
+
+#~ msgid "No '/dev/pmu' device found"
+#~ msgstr "Dim dyfais '/dev/pmu' wedi ei ganfod"
+
+#~ msgid "Not a powerbook"
+#~ msgstr "Ddim yn 'powerbook'"
+
+#~ msgid "Wrong permission for '/dev/pmu' device"
+#~ msgstr "Caniatâd anghywir ar gyfer y ddyfais '/dev/pmu'"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "Methu ymgychwyn Bonobo"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Rydych newydd ddal lawr y fysell Shift am 8 eiliad. Dyma'r byrlwybr ar "
+#~ "gyfer y nodwedd Bysellau Araf, sy'n effeithio sut mae'ch bysellfwrdd yn "
+#~ "gweithio"
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Ydych chi eisiau troi Bysellau Araf ymlaen?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Ydych chi eisiau troi Bysellau Araf i ffwrdd?"
+
+#~ msgid "_Deactivate"
+#~ msgstr "_Dad-actifadu"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "_Peidio ag actifadu"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Rydych newydd wasgu'r fysell Shift 5 gwaith mewn rhes. Dyma'r byrlwybr ar "
+#~ "gyfer y nodwedd Bysellau Gludiog, sy'n effeithio sut mae'ch bysellfwrdd "
+#~ "yn gweithio"
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "Rydych newydd wasgu dwy fysell ar unwaith neu wasgu'r fysell Shift 5 "
+#~ "gwaith mewn rhes. Mae hyn yn troi'r nodwedd Bysedd Gludiog ymlaen, sy'n "
+#~ "effeithio sut mae'ch bysellfwrdd yn gweithio."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Ydych chi eisiau troi Bysellau Gludiog ymlaen?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Ydych chi eisiau troi Bysellau Gludio i ffwrdd?"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "Methu creu'r cyfeiriadur \"%s\".\n"
+#~ "Mae angen hwn i ganiatáu newid thema pwyntydd y llygoden."
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Methu creu'r cyfeiriadur \"%s\".\n"
+#~ "Mae angen hwn i ganiatáu newid cyrchwyr."
+
+#, c-format
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "Diffinnir gweithred y Rhwymiad Bysell (%s) sawl gwaith\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "Diffinnir rhwymiad y Rhwymiad Bysell (%s) sawl gwaith\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Mae'r Rhwymiad Bysell (%s) yn anghyflawn\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Mae'r Rhwymiad Bysell (%s) yn annilys\n"
+
+#, c-format
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr "Mae'n debyg fod gan raglen arall fynediad i'r fysell '%u' eisoes."
+
+#, c-format
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "Defnyddir y Rhwymiad Bysell (%s) eisoes\n"
+
+#, c-format
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Gwall wrth geisio gweithredu (%s)\n"
+#~ "sy'n rhwym i'r fysell (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Gwall wrth gychwyn cyfluniad XKB.\n"
+#~ "Gall nifer o amgylchiadau achosi hyn:\n"
+#~ "- gwall yn llyfrgell libxklavier\n"
+#~ "- gwall yng ngweinydd X (xkbcomp, offer xmodmap)\n"
+#~ "- Gweinydd X gyda gweithrediad libxfile anghyson\n"
+#~ "\n"
+#~ "Gwybodaeth fersiwn gweinydd X:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "Os wnewch chi adrodd nam, a wnewch chi gynnwys:\n"
+#~ "- Canlyniad <b>%s</b>\n"
+#~ "- Canlyniad <b>%s</b>"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "Rydych chi'n defnyddio XFree 4.3.0.\n"
+#~ "Mae yna broblemau hysbys gyda chyfluniadau XKB cymhleth.\n"
+#~ "Ceisiwch ddefnyddio cyfluniad symlach neu ddefnyddio fersiwn mwy diweddar "
+#~ "o feddalwedd XFree"
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "_Peidio â dangos y rhybudd yma eto"
+
+#~ msgid ""
+#~ "The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.  Which set would you like to use?"
+#~ msgstr ""
+#~ "Mae gosodiadau bysellfwrdd y system X yn wahanol i'ch gosodiadau "
+#~ "bysellfwrdd GNOME cyfredol. Pa set hoffech ddefnyddio?"
+
+#~ msgid "Use X settings"
+#~ msgstr "Defnyddio Gosodiadau X"
+
+#~ msgid "Use GNOME settings"
+#~ msgstr "Defnyddio Gosodiadau GNOME"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Methwyd gweithredu'r gorchymyn: %s\n"
+#~ "Gwirio fod y gorchymyn yma'n bodoli."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Methwyd rhoi'r peiriant i gysgu.\n"
+#~ "Gwirio fod y peiriant wedi ei gyflunio yn gywir."
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "Methwyd llwytho ffeil Glade.\n"
+#~ "Gwnewch yn siwr fod y daemon wedi ei osod yn gywir."
+
+#, c-format
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Bu gwall wrth gychwyn yr arbedwr sgrin:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Fydd arbed sgrin ddim yn gweithio yn ystod y sesiwn yma."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Peidiwch â dangos y neges yma eto"
+
+#, c-format
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "Methwyd llwytho ffeil sain %s fel sampl %s"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Methwyd canfod cyfeiriadur cartref y defnyddiwr"
+
+#, c-format
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr "Gosodwyd yr allwedd GConf %s i fath %s ond disgwylid math %s\n"
+
+#~ msgid "A_vailable files:"
+#~ msgstr "_Ffeiliau ar gael:"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "_Peidio â dangos y rhybudd yma eto."
+
+#~ msgid "Load modmap files"
+#~ msgstr "Llwytho ffeiliau modmap"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "Hoffech chi lwytho'r ffeil(iau) modmap?"
+
+#~ msgid "_Load"
+#~ msgstr "_Llwytho"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "Gwall wrth greu piben signal."
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Math o bg_applier: BG_APPLIER_ROOT ar gyfer y ffenestr gwraidd neu "
+#~ "BG_APPLIER_PREVIEW ar gyfer rhagolwg"
+
+#~ msgid "Preview Width"
+#~ msgstr "Lled Rhagolwg"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Lled os yw'r cymhwysydd yn rhagolwg: Rhagosod fel 64"
+
+#~ msgid "Preview Height"
+#~ msgstr "Uchder y Rhagolwg"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Uchder os yw'r cymhwysydd yn rhagolwg: Rhagosod fel 48"
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Sgrin y dylai BGApplier ddarlunio arni"
+
+#, c-format
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Gwall wrth lwytho delwedd: %s"
+
+#~ msgid "Login"
+#~ msgstr "Mewngofnodi"
+
+#~ msgid "Boing"
+#~ msgstr "Boing"
+
+#~ msgid "Siren"
+#~ msgstr "Seiren"
+
+#~ msgid "Clink"
+#~ msgstr "Clinc"
+
+#~ msgid "Beep"
+#~ msgstr "Bîp"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "Seiniau heb eu gosod ar gyfer y digwyddiad hwn."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "Nid yw'r ffeil sain ar gyfer y digwyddiad yma'n bodoli.\n"
+#~ "Efallai yr hoffech chi sefydlu'r pecyn gnome-audio er mwyn gael set o "
+#~ "seiniau rhagosodedig."
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Nid yw'r ffeil sain i'r digwyddiad yma'n bodoli."
+
+#, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "NId yw'r ffeil %s yn ffeil WAV ddilys"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Nid yw rheolwr ffenestri \"%s\" wedi cofrestru arf cyfluniad\n"
+
+#~ msgid "Maximize"
+#~ msgstr "Ehangu"
+
+#~ msgid "Roll up"
+#~ msgstr "Rholio i fyny"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr "Os yn wir, cedwir y trinwyr testun/plaen a thestun/* yn gydwedd"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Trinwyr testun/plaen a thestun/*"
+
+#~ msgid "Brightness down"
+#~ msgstr "Disgleirdeb i lawr"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Byrlwybr disgleirdeb i lawr."
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Byrlwybr disgleirdeb i fyny."
+
+#~ msgid "E-mail"
+#~ msgstr "E-bost"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Byrlwybr E-bost."
+
+#~ msgid "Eject's shortcut."
+#~ msgstr "Byrlwybr allfwrw."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Byrlwybr i fy Mhlygell Cartref."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Byrlwybr i lansio'r porwr cymorth."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Byrlwybr i lansio porwr gwe."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Byrlwybr i allgofnodi."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Byrlwybr bysell trac nesaf."
+
+#~ msgid "Pause"
+#~ msgstr "Seibio"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Byrlwybr y fysell seibio."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Byrlwybr y fysell chwarae (neu chwarae/seibio)."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Byrlwybr y fysell trac blaenorol."
+
+#~ msgid "Sleep"
+#~ msgstr "Cysgu"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Byrlwybr cysgu."
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Byrlwybr y fysell stopio chwarae."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Byrlwybr lefel sain i lawr."
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Byrlwybr mudo'r sain"
+
+#~ msgid "Volume step"
+#~ msgstr "Gris lefel sain"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Gris lefel sain fel canran o'r lefel."
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Byrlwybr lefel sain i fyny."
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "Dangos deialog pan fo gwallau wrth redeg yr arbedwr sgrin"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "Cychwyn yr arbedwr sgrin wrth fewngofnodi"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Dangos Gwallau Ymgychwyn"
+
+#~ msgid "Start screensaver"
+#~ msgstr "Dechrau'r arbedwr sgrin"
+
+#~ msgid ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+#~ msgstr ""
+#~ "Casgliad o sgriptiau i'w rhedeg pryd bynnag caiff cyflwr yr allweddell ei "
+#~ "ail-lwytho. Yn ddefnyddiol er mwyn rhoi newidiadau ar waith sy'n "
+#~ "seiliedig ar xmodmap."
+
+#~ msgid "A list of modmap files available in the $HOME directory."
+#~ msgstr "Rhestr o ffeiliau modmap ar gael yn y cyfeiriadur $HOME."
+
+#~ msgid "Default group, assigned on window creation"
+#~ msgstr "Grwp rhagosodedig, wedi ei neilltuo wrth greu ffenestr"
+
+#~ msgid "Keep and manage separate group per window"
+#~ msgstr "Cadw a rheoli grwp ar wahân am bob ffenestr"
+
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Trinwyr Diweddariad Bysellfwrdd"
+
+#~ msgid "Keyboard model"
+#~ msgstr "Model bysellfwrdd"
+
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr ""
+#~ "Caiff gosodiadau bysellfwrdd o fewn gconf eu trosysgrifo gan y system cyn "
+#~ "gynted â phosib (anghymeradwyir)"
+
+#~ msgid "Save/restore indicators together with layout groups"
+#~ msgstr "Cadw/adfer dangoswyr ynghyd â grwpiau cynllun"
+
+#~ msgid "Show layout names instead of group names"
+#~ msgstr "Dangos enwau cynllun yn lle enwau grwp"
+
+#~ msgid ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+#~ msgstr ""
+#~ "Dangos enwau gosodiad yn lle enwau grwp (dim ond ar gyfer fersiynau o "
+#~ "XFree sy'n cynnal amryw gynlluniau)"
+
+#~ msgid "Suppress the \"X sysconfig changed\" warning message"
+#~ msgstr "Atal y neges rybudd \"sysconfig X wedi newid\""
+
+#~ msgid ""
+#~ "Very soon, keyboard settings in gconf will be overridden (from the system "
+#~ "configuration) This key has been deprecated since GNOME 2.12, please "
+#~ "unset the model, layouts and options keys to get the default system "
+#~ "configuration."
+#~ msgstr ""
+#~ "Yn fuan iawn, bydd gosodiadau bysellfwrdd o fewn gconf yn cael eu "
+#~ "trosysgrifo (gan gyfluniad y system). Mae'r allwedd hon wedi ei "
+#~ "anghymeradwyo ers GNOME 2.12. Dadosodwch yr allweddi model, cynllun ac "
+#~ "opsiynau er mwyn cael cyfluniad rhagosodedig y system."
+
+#~ msgid "keyboard layout"
+#~ msgstr "cynllun bysellfwrdd"
+
+#~ msgid "keyboard model"
+#~ msgstr "model bysellfwrdd"
+
+#~ msgid "modmap file list"
+#~ msgstr "Rhestr ffeil modmap"
+
+#~ msgid "_Postpone break"
+#~ msgstr "_Gohirio'r saib"
+
+#~ msgid "Take a break!"
+#~ msgstr "Cymerwch saib!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Cymryd Saib"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d munud tan y saib nesaf"
+#~ msgstr[1] "%d funud tan y saib nesaf"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Llai nag un munud tan y saib nesaf"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Methwyd codi'r deialog hoffterau gorffwys teipio gyda'r gwall canlynol: "
+#~ "%s "
+
+#~ msgid "About GNOME Typing Monitor"
+#~ msgstr "Ynghylch Monitor Teipio GNOME"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Eich atgoffa i gymryd saib o'r cyfrifiadur."
+
+#~ msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgstr "Ysgrifennwyd gan Richard Hult &lt;richard@imendio.com&gt;"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Ychwanegwyd melysion gweledol gan Anders Carlsson"
+
+#~ msgid "Break reminder"
+#~ msgstr "Eich atgof seibiau"
+
+#~ msgid "The orientation of the tray."
+#~ msgstr "Gogwydd yr hambwrdd."
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Mae'r arsylwr teipio yn defnyddio'r man hysbysu er mwyn dangos "
+#~ "gwybodaeth. Ymddengys nad oes man hysbysu ar eich panel. Gallwch "
+#~ "ychwanegu man hysbysu gan dde-glicio ar eich panel a dewis 'Ychwanegu at "
+#~ "y Panel', dewis 'Man hysbysu' a chlicio 'Ychwanegu.'"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Parciais fy jac codi baw hud llawn dwr ger ty Mabon. 0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Maint:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Hawlfraint:"
+
+#~ msgid "Description:"
+#~ msgstr "Disgrifiad:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "defnydd: %s ffeil_ffont\n"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Gosod fel y Ffont Rhaglenni"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau OpenType."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau PCF."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau TrueType."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau Type1"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+#~ "cryno o ffontiau OpenType."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+#~ "cryno o ffontiau PCF."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+#~ "cryno o ffontiau TrueType."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+#~ "cryno o ffontiau Type1."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau OpenType"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau PCF"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau TrueType"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau Type1"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "A ddylid creu lluniau cryno o ffontiau OpenType"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "A ddylid creu lluniau cryno o ffontiau PCF"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "A ddylid creu lluniau cryno o ffontiau TrueType"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "A ddylid creu lluniau cryno o ffontiau Type1"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "Gwelydd Ffontiau GNOME"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">Cymhwyso'r ffont newydd?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "_Peidio cymhwyso'r ffont"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Mae'r thema rydych chi wedi dewis yn awgrymu ffont newydd. Dangosir "
+#~ "rhagolwg o'r ffont isod."
+
+#~ msgid "Themes"
+#~ msgstr "Themâu"
+
+#~ msgid "Description"
+#~ msgstr "Disgrifiad"
+
+#~ msgid "Control theme"
+#~ msgstr "Thema rheoli"
+
+#~ msgid "Window border theme"
+#~ msgstr "Thema ymyl ffenestr"
+
+#~ msgid "Icon theme"
+#~ msgstr "Thema eiconau"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#~ msgid "Apply theme"
+#~ msgstr "Defnyddio thema"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Dewis thema ragosodedig"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer themâu sefydledig."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer themâu."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+#~ "cryno o themâu sefydledig."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+#~ "cryno o themâu."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Gorchymyn lluniau cryno ar gyfer themâu sefydledig"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Gorchymyn lluniau cryno ar gyfer themâu sefydledig"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "A ddylid creu lluniau cryno o themâu sefydledig"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "A ddylid creu lluniau cryno o themâu"
 
 #~ msgid "Epiphany"
 #~ msgstr "Epiphany"
 
 #~ msgid "Please specify a name and a command for this editor."
 #~ msgstr "Penodi enw a gorchymyn i'r golygydd yma"
-
-#~ msgid "Add..."
-#~ msgstr "Ychwanegu..."
 
 #~ msgid "C_ustom:"
 #~ msgstr "A_ddasedig:"
@@ -3609,12 +7511,3 @@ msgstr "Dangos opsiynau cymorth"
 #~ msgstr ""
 #~ "Defnyddio'r _golygydd yma i agor ffeiliau testun y tu mewn i'r trefnydd "
 #~ "ffeiliau"
-
-#~ msgid "Window Manager"
-#~ msgstr "Trefnydd Ffenestri"
-
-#~ msgid "_Command:"
-#~ msgstr "_Gorchymyn:"
-
-#~ msgid "_Name:"
-#~ msgstr "_Enw:"

--- a/po/cy.po~
+++ b/po/cy.po~
@@ -1,0 +1,3620 @@
+# gnome-control-center yn Gymraeg.
+# www.kyfieithu.co.uk <kyfieithu@kyfieithu.co.uk>, 2003.
+# Dafydd Harries <daf@muse.19inch.net>, 2003.
+# Dafydd Tomos <i10n@da.fydd.org>, 2004.
+# Rhys Jones <rhys@sucs.org>, 2005.
+#
+# Someone needs to check (a) occurrences of key (if GConf, allwedd;
+# if most other things, bysell); (b) occurrences of application(s)
+# rhaglennu or the other one I now can't put my finger on?
+#
+# I think I've caught most of the erroneous "bysell"s. Funnily enough, I
+# changed several occurrences of "bysell" to "allwedd" (GConf context) and
+# several occurrences of "allwedd" to "bysell" (keyboard context). Also
+# replaced "gweithredu" with "cymhwyso" (for "apply") and "wynebfath" with
+# "ffont". I can believe that "wynebfath" is a better word, but I thought it
+# would be better to be consistently wrong for now.
+# - daf
+#
+# [rj] 'Take effect' == 'dod i rym' (cystrawen Saesneg yw 'cymryd effaith')
+# [rj] Wedi gyrru'r cyfan drwy Cysill, 29ain Mai 2005.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2006-03-08 13:45+0000\n"
+"PO-Revision-Date: 2006-03-08 12:53-0000\n"
+"Last-Translator: Rhys Jones <rhys@sucs.org>\n"
+"Language-Team: Cymraeg <gnome-cy@pengwyn.linux.org.uk>\n"
+"Language: cy\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n == 2) ? 1 : 0;\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "Border delwedd/label"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "Lled y border o amgylch y label a'r ddelwedd yn y ddeialog rhybudd"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "Math y Rhybudd"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "Y math o rybudd"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "Botymau Rhybudd"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "Y botymau a ddangosir yn y ddeialog rhybudd"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "Dangos _mwy o fanylion"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "About Me"
+msgstr "Amdana I"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "Gosodwch eich gwybodaeth bersonol"
+
+#: ../capplets/about-me/gnome-about-me.c:604
+msgid "Select Image"
+msgstr "Dewis Delwedd"
+
+#: ../capplets/about-me/gnome-about-me.c:606
+msgid "No Image"
+msgstr "Dim Delwedd"
+
+#: ../capplets/about-me/gnome-about-me.c:769
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"Roedd gwall wrth geisio cael gwybodaeth y llyfr cyfeiriadau\n"
+"Fedr Gweinydd Data Evolution ddim delio â'r protocol"
+
+#: ../capplets/about-me/gnome-about-me.c:790
+msgid "Unable to open address book"
+msgstr "Methu agor y llyfr cyfeiriadau"
+
+#: ../capplets/about-me/gnome-about-me.c:802
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+"ID mewngofnodi anhysbys, gall fod y gronfa ddata o ddefnyddwyr wedi ei llygru"
+
+#: ../capplets/about-me/gnome-about-me.c:833
+#: ../capplets/about-me/gnome-about-me.c:835
+#, c-format
+msgid "About %s"
+msgstr "Ynghylch %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:707
+msgid "Old password is incorrect, please retype it"
+msgstr "Hen gyfrinair yn anghywir, aildeipiwch ef"
+
+#: ../capplets/about-me/gnome-about-me-password.c:127
+msgid "System error has occurred"
+msgstr "Digwyddodd gwall system"
+
+#: ../capplets/about-me/gnome-about-me-password.c:128
+msgid "Could not run /usr/bin/passwd"
+msgstr "Methu rhedeg /usr/bin/passwd"
+
+#: ../capplets/about-me/gnome-about-me-password.c:129
+msgid "Unable to launch backend"
+msgstr "Methu lansio'r ochr gefn"
+
+#: ../capplets/about-me/gnome-about-me-password.c:131
+#: ../capplets/about-me/gnome-about-me-password.c:132
+msgid "Unexpected error has occurred"
+msgstr "Digwyddodd gwall anhysbys"
+
+#: ../capplets/about-me/gnome-about-me-password.c:331
+msgid "Password is too short"
+msgstr "Cyfrinair yn rhy fyr"
+
+#: ../capplets/about-me/gnome-about-me-password.c:334
+#: ../capplets/about-me/gnome-about-me-password.c:337
+msgid "Password is too simple"
+msgstr "Cyfrinair yn rhy syml"
+
+#: ../capplets/about-me/gnome-about-me-password.c:340
+msgid "Old and new passwords are too similar"
+msgstr "Mae'r cyfrinair newydd yn rhy debyg i'r hen un"
+
+#: ../capplets/about-me/gnome-about-me-password.c:343
+msgid "Must contain numeric or special character(s)"
+msgstr "Rhaid iddo gynnwys nod(au) arbennig neu rif(au)"
+
+#: ../capplets/about-me/gnome-about-me-password.c:348
+msgid "Old and new password are the same"
+msgstr "Mae'r cyfrinair newydd yr un peth â'r hen un"
+
+#: ../capplets/about-me/gnome-about-me-password.c:634
+msgid "Please type the passwords."
+msgstr "Teipiwch y cyfrineiriau."
+
+#: ../capplets/about-me/gnome-about-me-password.c:642
+msgid "Please type the password again, it is wrong."
+msgstr "Teipiwch y cyfrinair eto: mae'n anghywir."
+
+#: ../capplets/about-me/gnome-about-me-password.c:645
+msgid "Click on Change Password to change the password."
+msgstr "Cliciwch Newid Cyfrinair er mwyn newid y cyfrinair."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+msgid "    "
+msgstr "    "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Email</b>"
+msgstr "<b>E-bost</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Home</b>"
+msgstr "<b>Cartref</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Negesu Chwim</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Job</b>"
+msgstr "<b>Swydd</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr "<b>Teipiwch y cyfrineiriau.</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<b>Telephone</b>"
+msgstr "<b>Ffôn</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "<b>Web</b>"
+msgstr "<b>Gwe</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "<b>Work</b>"
+msgstr "<b>Gwaith</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "A_ddress:"
+msgstr "_Cyfeiriad:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr "_Cynorthwyydd:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "Address"
+msgstr "Cyfeiriad"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "C_ity:"
+msgstr "_Dinas:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "C_ompany:"
+msgstr "_Cwmni:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Cale_ndar:"
+msgstr "C_alendr:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change Passwo_rd..."
+msgstr "Newid C_yfrinair..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Change Password"
+msgstr "Newid Cyfrinair"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Ci_ty:"
+msgstr "_Dinas:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Co_untry:"
+msgstr "_Gwlad:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Contact"
+msgstr "Cyswllt"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Cou_ntry:"
+msgstr "G_wlad:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr "Enw Llawn"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Hom_e:"
+msgstr "_Cartref:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "Old pa_ssword:"
+msgstr "Hen _gyfrinair:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P.O. _box:"
+msgstr "Blwch _post:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P._O. box:"
+msgstr "_Blwch post:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "Personal Info"
+msgstr "Gwybodaeth Bersonol"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "State/Pro_vince:"
+msgstr "Talaith/_Ardal:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+msgid "User name:"
+msgstr "Enw defnyddiwr:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Web _log:"
+msgstr "Gwe_log:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "Wor_k:"
+msgstr "_Gwaith:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid "Work _fax:"
+msgstr "_Ffacs gwaith:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Zip/_Postal code:"
+msgstr "Co_d post/zip:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "_Address:"
+msgstr "_Cyfeiriad:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr "_Adran:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr "_Groupwise:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "_Home page:"
+msgstr "Tudalen _cartref:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "_Home:"
+msgstr "C_artref:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr "_Jabber:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Manager:"
+msgstr "_Rheolwr:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Mobile:"
+msgstr "_Ffôn symudol:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_New password:"
+msgstr "Cyfrinair _newydd:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Profession:"
+msgstr "_Proffesiwn:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Retype new password:"
+msgstr "_Aildeipiwch y cyfrinair newydd:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr "_Talaith/Ardal:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Title:"
+msgstr "_Teitl:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Work:"
+msgstr "_Gwaith:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Zip/Postal code:"
+msgstr "_Cod post/zip:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Applications</b>"
+msgstr "<b>Rhaglenni</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Support</b>"
+msgstr "<b>Cynhaliaeth</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+"<small><i><b>Noder:</b> Ni fydd newidiadau i'r gosodiad yma yn dod i rym tan "
+"y tro nesa i chi fewngofnodi.</i></small>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technology Preferences"
+msgstr "Hoffterau Technoleg Gynorthwyol"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr "Cau ac _Allgofnodi"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr ""
+"Cychwyn y technolegau cynorthwyol yma bob tro rydych chi'n mewngofnodi:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr "_Galluogi technolegau cynorthwyol"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr "_Chwyddwr"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr "Bysellfwrdd _ar y Sgrin"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Screenreader"
+msgstr "_Darllenydd sgrin"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr "Cynhaliaeth Technoleg Gynorthwyol"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr ""
+"Galluogi cynhaliaeth ar gyfer technolegau cynorthwyol GNOME wrth fewngofnodi"
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Does dim Technoleg Gynorthwyol ar gael ar eich system. Rhaid sefydlu'r pecyn "
+"'gok' ar gyfer cael cynhaliaeth bysell ar sgrin, a'r pecyn 'gnopernicus' ar "
+"gyfer medru sgrînddarllen a chwyddo."
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+"Nid yw pob technoleg gynorthwyol wedi eu sefydlu ar eich system. Rhaid "
+"sefydlu'r pecyn 'gok' er mwyn cael bysell ar sgrin."
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Nid yw pob technoleg gynorthwyol wedi eu sefydlu ar eich system. Rhaid "
+"sefydlu'r pecyn 'gnopernicus' ar gyfer sgrînddarllen a chwyddo."
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:242
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr "Roedd gwall wrth lansio'r deialog hoffterau llygoden: %s"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:338
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:399
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr "Methu mewnforio gosodiadau AccessX o'r ffeil '%s'"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:436
+msgid "Import Feature Settings File"
+msgstr "Mewnforio Ffeil Gosodiadau Nodweddion"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:440
+msgid "_Import"
+msgstr "_Mewnforio"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Bysellfwrdd"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr "Dewis eich hoffterau hygyrchedd bysellfwrdd"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+"Ymddengys nad yw'r estyniad XKB ar gael ar y system hon. Ni fydd nodweddion "
+"hygyrchedd y bysellfwrdd yn gweithio hebddi."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+#: ../capplets/theme-switcher/theme-install.glade.h:1
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "<b>Galluogi Bysellau Sb_onciog</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "<b>Galluogi Bysellau _Araf</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "<b>Galluogi Bysellau _Llygoden</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "<b>Galluogi Bysellau _Ailadroddus</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "<b>Galluogi Bysellau _Gludiog</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+msgid "<b>Features</b>"
+msgstr "<b>Nodweddion</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr "<b>Bysellau Togl</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "Sylfaenol"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr "Bîp os ni _wrthodir y fysell"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr "Bîp wrth droi'r _nodwedd ymlaen neu bant o'r bysellfwrdd"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr "Bîp pan mae'r _addasydd yn cael ei wasgu"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr "Bîp pan fo'r LED yn goleuo a dau fîp pan mae'n cael ei ddiffodd."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr "Bîp os yw'r fysell yn:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr "_Oedi:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr "Oedi rhwng gwasgu bysell a symudiad y _pwyntydd:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr "_Analluogi pan mae dwy fysell yn cael eu gwasgu ar yr un pryd"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr "Galluogi Bysellau _Togl"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Hidlau"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr "Anwybyddu a_il-wasgiadau o fewn:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+"Anwybyddu pob gwasgiad dilynol o'r UN fysell os maent yn digwydd o fewn "
+"cyfnod a gall y defnyddiwr ei ddewis."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr "Hoffterau Hygyrchedd Bysellfwrdd (AccessX)"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr "Cyflymdra m_wya'r pwyntydd:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr "Bysellau Llygoden"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr "Hoffterau _Llygoden..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+"Derbyn bysellau dim ond ar ôl iddynt gael eu gwasgu a'u dal am gyfnod gall y "
+"defnyddiwr ei ddewis."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+"Cyflawni nifer o wasgiadau bysell cydamserol gan wasgu dilyniant o fysellau "
+"addasu."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "S_peed:"
+msgstr "Cy_flymder:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr "Amser i gyf_lymu i'r cyflymder mwyaf:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr "Trowch y bysellfwrdd rhifau yn fysellfwrdd rheoli'r llygoden"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr "_Analluogi os na ddefnyddiwyd am:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr "_Galluogi nodweddion hygyrchedd bysellfwrdd"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr "_Mewnforio Gosodiadau Nodweddion..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr "_Derbyn bysell wedi'u dal am:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "_Type to test settings:"
+msgstr "_Teipiwch i arbrofi'r gosodiadau:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr "_derbyniwyd"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr "_gwasgedig"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr "_gwrthodwyd"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr "nodau'r eiliad"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "milliseconds"
+msgstr "milfedau o eiliadau"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr "picseli'r eiliad"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "eiliadau"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+msgid "Change your Desktop Background settings"
+msgstr "Newid gosodiadau eich Cefndir Penbwrdd"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+msgid "Desktop Background"
+msgstr "Cefndir Penbwrdd"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "<b>Papur _Wal Penbwrdd</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+msgid "<b>_Desktop Colors</b>"
+msgstr "<b>_Lliwiau Penbwrdd</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+msgid "Desktop Background Preferences"
+msgstr "Hoffterau Cefndir Penbwrdd"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr "Agorwch ddeialog i ddewis y lliw"
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr "_Ychwanegu Papur Wal"
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+msgid "_Finish"
+msgstr "_Gorffen"
+
+#: ../capplets/background/gnome-background-properties.glade.h:7
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+msgid "_Remove"
+msgstr "_Gwaredu:"
+
+#: ../capplets/background/gnome-background-properties.glade.h:8
+msgid "_Style:"
+msgstr "_Arddull:"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Gwall wrth ddangos cymorth:%s"
+
+#: ../capplets/background/gnome-wp-capplet.c:984
+msgid "Centered"
+msgstr "Wedi ei ganoli"
+
+#: ../capplets/background/gnome-wp-capplet.c:988
+msgid "Fill Screen"
+msgstr "Llenwi'r Sgrin"
+
+#: ../capplets/background/gnome-wp-capplet.c:992
+msgid "Scaled"
+msgstr "Graddio"
+
+#: ../capplets/background/gnome-wp-capplet.c:996
+msgid "Zoom"
+msgstr "Chwyddo"
+
+#: ../capplets/background/gnome-wp-capplet.c:1000
+msgid "Tiled"
+msgstr "Teilsio"
+
+#: ../capplets/background/gnome-wp-capplet.c:1021
+msgid "Solid Color"
+msgstr "Lliw Unffurf"
+
+#: ../capplets/background/gnome-wp-capplet.c:1025
+msgid "Horizontal Gradient"
+msgstr "Graddfa Lorweddol"
+
+#: ../capplets/background/gnome-wp-capplet.c:1029
+msgid "Vertical Gradient"
+msgstr "Graddfa Fertigol"
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1075
+msgid "Add Wallpaper"
+msgstr "Ychwanegu Papur Wal"
+
+#: ../capplets/background/gnome-wp-capplet.c:1092
+msgid "Images"
+msgstr "Delweddau"
+
+#: ../capplets/background/gnome-wp-capplet.c:1096
+msgid "All Files"
+msgstr "Pob Ffeil"
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr "Dim Papur Wal"
+
+#: ../capplets/background/gnome-wp-item.c:343
+#: ../capplets/background/gnome-wp-item.c:345
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "picsel"
+msgstr[1] "bicsel"
+
+#: ../capplets/common/activate-settings-daemon.c:18
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"Methu cychwyn y rheolwr gosodiadau 'gnome-settings-daemon'.\n"
+"Heb i'r rheolydd gosodiadau GNOME fod yn weithgar, mae'n bosib na fydd rhai "
+"hoffterau'n dod i rym. Gall hyn olygu fod problem gyda Bonobo, neu fe all "
+"rheolydd gosodiadau arall (e.e. KDE) fod yn weithgar ac yn creu "
+"anghysondebau gyda rheolydd gosodiadau GNOME."
+
+#: ../capplets/common/capplet-stock-icons.c:92
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "Methu llwytho'r eicon stoc '%s'\n"
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr "Cymhwyso'r gosodiadau a therfynu"
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1016
+#: ../capplets/sound/sound-properties-capplet.c:244
+msgid "Retrieve and store legacy settings"
+msgstr "Nol a chadw'r hen osodiadau"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "Copïo ffeil: %u o %u"
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr "Copïo '%s'"
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr "URI Tarddiad"
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr "URI yn trosglwyddo o"
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr "URI Cyrchiad"
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr "URI yn trosglwyddo i"
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr "Canran wedi'i gwblhau"
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr "Canran y trosglwyddiad wedi'i gwblhau ar hyn o bryd"
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr "Mynegai URI cyfredol"
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr "Mynegai URI cyfredol - mae'n dechrau o 1"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr "Cyfanswm URIau"
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr "Nifer cyflawn URIau"
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr "Copïo ffeiliau"
+
+#: ../capplets/common/file-transfer-dialog.c:345
+msgid "From:"
+msgstr "O:"
+
+#: ../capplets/common/file-transfer-dialog.c:349
+msgid "To:"
+msgstr "I:"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr "Yn cysylltu..."
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Allwedd"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr "Allwedd GConf sy'n cyfateb i'r golygydd priodwedd yma"
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr "Adalwad"
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Galw'r adalwad yma pan newidir gwerth cysylltiedig yr allwedd"
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr "Newid set"
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"Set newid GConf yn cynnwys data i'w anfon ymlaen i'r cleient gconf wrth "
+"gymhwyso"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr "Trosi i adalwad celficyn"
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "Yr adalwad i'w alw pan fo data i'w trosi o GConf i'r teclyn"
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr "Trosi o adalwad teclyn"
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr "Adalwad i alw pan fo data i'w trosi i GConf o'r teclyn"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr "Rheolydd RhD (UI)"
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr "Gwrthrych sy'n rheoli'r briodwedd (celficyn gan amlaf)"
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr "Data gwrthrychol golygydd priodweddau"
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr "Data addasol sy'n anghenraid gan y golygydd priodweddau penodol"
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr "Adalwad rhyddhau data golygydd priodweddau"
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Adalwad i'w alw pan fo data gwrthrychol golygydd priodweddau i'w rhyddhau"
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Methwyd canfod y ffeil '%s'\n"
+"\n"
+"Gwiriwch ei bod yn bodoli a cheisiwch eto, neu dewiswch lun cefndir arall os "
+"gwelwch yn dda."
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Nid ydw i'n deall sut i agor y ffeil '%s'.\n"
+"Efallai ei bod yn fath o lun nas cynhelir eto.\n"
+"\n"
+"Dewiswch lun gwahanol yn ei le, os gwelwch yn dda."
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr "Dewiswch ddelwedd."
+
+#: ../capplets/common/gconf-property-editor.c:1598
+msgid "_Select"
+msgstr "_Dewis"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr "Rhaglenni Amgen"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Dewiswch eich rhaglenni rhagosodedig"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:55
+msgid "Could not display help"
+msgstr "Methu dangos y cymorth"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:57
+#: ../capplets/default-applications/gnome-da-capplet.c:765
+msgid "Please make sure that the applet is properly installed"
+msgstr "Gwnewch yn siwr fod y rhaglennig wedi ei osod yn gywir"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:92
+#: ../capplets/default-applications/gnome-da-capplet.c:125
+#: ../capplets/default-applications/gnome-da-capplet.c:170
+#: ../capplets/default-applications/gnome-da-capplet.c:215
+#: ../capplets/default-applications/gnome-da-capplet.c:269
+#: ../capplets/default-applications/gnome-da-capplet.c:318
+#: ../capplets/default-applications/gnome-da-capplet.c:600
+#: ../capplets/default-applications/gnome-da-capplet.c:621
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "Gwall wrth gadw cyfluniad: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:743
+msgid "Custom"
+msgstr "Addasedig"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:763
+msgid "Could not load the main interface"
+msgstr "Methu llwytho'r prif ryngwyneb"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Debian Sensible Browser"
+msgstr "\"Sensible-Browser\" (Debian)"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Debian Terminal Emulator"
+msgstr "Efelychydd Terfynell Debian"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Encompass"
+msgstr "Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Epiphany Web Browser"
+msgstr "Porwr Gwe Epiphany"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "Evolution Mail Reader"
+msgstr "Y Darllenwr Ebost Evolution"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Evolution Mail Reader 1.4"
+msgstr "Darllenwr Ebost Evolution 1.4"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Evolution Mail Reader 1.5"
+msgstr "Darllenwr Ebost Evolution 1.5"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader 1.6"
+msgstr "Darllenwr Ebost Evolution 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Evolution Mail Reader 2.0"
+msgstr "Darllenwr Ebost Evolution 2.0"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Evolution Mail Reader 2.2"
+msgstr "Darllenwr Ebost Evolution 2.2"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "Evolution Mail Reader 2.4"
+msgstr "Darllenwr Ebost Evolution 2.4"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "GNOME Terminal"
+msgstr "Terfynell GNOME"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Links Text Browser"
+msgstr "Y Porwr Gwe Links"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Lynx Text Browser"
+msgstr "Y Porwr Gwe Lynx"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "Mozilla Mail"
+msgstr "E-bost Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Netscape Communicator"
+msgstr "Netscape Communicator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Opera"
+msgstr "Opera"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Standard XTerminal"
+msgstr "XTerminal arferol"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "W3M Text Browser"
+msgstr "Y Porwr Gwe W3M"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Audio Player</b>"
+msgstr "<b>Chwaraeydd Sain</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Image Viewer</b>"
+msgstr "<b>Gwelydd Delweddau</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Instant Messenger</b>"
+msgstr "<b>Negesu Chwim</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mail Reader</b>"
+msgstr "<b>Darllenwr E-bost</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>Efelychydd Terfynell</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Text Editor</b>"
+msgstr "<b>Golygydd Testun</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Video Player</b>"
+msgstr "<b>Chwaraewr Fideo</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Web Browser</b>"
+msgstr "<b>Porwr Gwe</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "Fe roddir y cyswllt go iawn yn lle pob %s"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Co_mmand:"
+msgstr "_Gorchymyn:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "E_xecute flag:"
+msgstr "Baner E_xec:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Internet"
+msgstr "Rhyngrwyd"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Multimedia"
+msgstr "Amlgyfrwng"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Open link in new _tab"
+msgstr "Agor cyswllt mewn _tab newydd"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Open link in new _window"
+msgstr "Agor cyswllt mewn _ffenestr newydd"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Open link with web browser _default"
+msgstr "Agor cyswllt gyda'r porwr gwe sy'n _ragosodiad"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Run in t_erminal"
+msgstr "Rhedeg mewn t_erfynell"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "System"
+msgstr "System"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Newid cydraniad y sgrin"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Cydraniad y Sgrin"
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/main.c:448
+msgid "_Resolution:"
+msgstr "_Cydraniad:"
+
+#: ../capplets/display/main.c:467
+msgid "Re_fresh rate:"
+msgstr "Cyfradd _adnewyddu:"
+
+#: ../capplets/display/main.c:488
+msgid "Default Settings"
+msgstr "Gosodiadau Rhagosodedig"
+
+#: ../capplets/display/main.c:490
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr "Gosodiadau Sgrin %d\n"
+
+#: ../capplets/display/main.c:516
+msgid "Screen Resolution Preferences"
+msgstr "Hoffterau Cydraniad y Sgrin"
+
+#: ../capplets/display/main.c:553
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "Gwneud yn rhagosodiad ar gyfer y _cyfrifiadur hwn (%s) yn unig"
+
+#: ../capplets/display/main.c:571
+msgid "Options"
+msgstr "Opsiynau"
+
+#: ../capplets/display/main.c:592
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"Profi'r gosodiadau newydd. Os nad ydych chi'n ymateb o fewn %d eiliad caiff "
+"y gosodiadau blaenorol eu hadfer."
+msgstr[1] ""
+"Profi'r gosodiadau newydd. Os nad ydych chi'n ymateb o fewn %d eiliad caiff "
+"y gosodiadau blaenorol eu hadfer."
+
+#: ../capplets/display/main.c:638
+msgid "Keep Resolution"
+msgstr "Cadw'r Cydraniad"
+
+#: ../capplets/display/main.c:642
+msgid "Do you want to keep this resolution?"
+msgstr "A hoffech gadw'r cyfraniad yma?"
+
+#: ../capplets/display/main.c:667
+msgid "Use _previous resolution"
+msgstr "Defnyddio'r cydraniad _blaenorol"
+
+#: ../capplets/display/main.c:667
+msgid "_Keep resolution"
+msgstr "_Cadw'r cydraniad"
+
+#: ../capplets/display/main.c:818
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"Nid yw'r gweinydd X yn cynnal yr estyniad XRandR. Nid yw'n bosib newid y "
+"cydraniad tra mae'r gweinydd X yn rhedeg."
+
+#: ../capplets/display/main.c:826
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"Mae fersiwn yr estyniad XRandR yn anghytunol gyda'r rhaglen hon. Nid yw'n "
+"bosib newid y cydraniad tra bo'r gweinydd X yn rhedeg."
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Ffont"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr "Dewiswch ffontiau ar gyfer y penbwrdd"
+
+#: ../capplets/font/font-properties.glade.h:1
+msgid "<b>Font Rendering</b>"
+msgstr "<b>Llunio Ffontiau</b>"
+
+#: ../capplets/font/font-properties.glade.h:2
+msgid "<b>Hinting</b>:"
+msgstr "<b>Awgrymu</b>:"
+
+#: ../capplets/font/font-properties.glade.h:3
+msgid "<b>Smoothing</b>:"
+msgstr "<b>Llyfnhau</b>:"
+
+#: ../capplets/font/font-properties.glade.h:4
+msgid "<b>Subpixel order</b>:"
+msgstr "<b>Trefn is-bicsel</b>:"
+
+#: ../capplets/font/font-properties.glade.h:5
+msgid "Best _shapes"
+msgstr "_Siapau gorau"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best co_ntrast"
+msgstr "_Cyferbyniad gorau"
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "D_etails..."
+msgstr "_Manylion..."
+
+#: ../capplets/font/font-properties.glade.h:8
+msgid "Des_ktop font:"
+msgstr "_Ffont y penbwrdd:"
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "Hoffterau Ffont"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr "Manylion Llunio Ffontiau"
+
+#: ../capplets/font/font-properties.glade.h:11
+msgid "Go _to font folder"
+msgstr "_Mynd i'r blygell ffont"
+
+#: ../capplets/font/font-properties.glade.h:12
+msgid "Gra_yscale"
+msgstr "_Graddlwyd"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "_Dim"
+
+#: ../capplets/font/font-properties.glade.h:14
+msgid "R_esolution:"
+msgstr "_Cydraniad:"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr "Is_bicsel (LCDau)"
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "Llyfnu is_bicsel (LCDau)"
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "Ffont _rhaglenni:"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Document font:"
+msgstr "_Ffont y ddogfen:"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Fixed width font:"
+msgstr "_Ffont lled rhagosodedig:"
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Full"
+msgstr "_Llawn"
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Medium"
+msgstr "_Canolig"
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_Monochrome"
+msgstr "_Unlliw"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_None"
+msgstr "_Dim"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Slight"
+msgstr "_Eiddil"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "_Ffont teitl y ffenest:"
+
+#: ../capplets/font/font-properties.glade.h:30
+msgid "dots per inch"
+msgstr "dot y fodfedd"
+
+#: ../capplets/font/main.c:489
+msgid "Font may be too large"
+msgstr "Mae'n bosib fod y ffont rhy fawr"
+
+#: ../capplets/font/main.c:493
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Mae'r ffont a ddewiswyd yn %d pwynt o faint, a gall ei wneud yn anodd "
+"defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
+"maint yn llai na %d."
+msgstr[1] ""
+"Mae'r ffont a ddewiswyd yn %d bwynt o faint, a gall ei wneud yn anodd "
+"defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
+"maint yn llai na %d."
+
+#: ../capplets/font/main.c:506
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Mae'r ffont a ddewiswyd yn %d pwynt o faint, a gall ei wneud yn anodd "
+"defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
+"maint ffont llai."
+msgstr[1] ""
+"Mae'r ffont a ddewiswyd yn %d bwynt o faint, a gall ei wneud yn anodd "
+"defnyddio'r cyfrifiadur yn effeithlon. Argymhellir eich bod chi'n dewis "
+"maint ffont llai."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "Cyflymydd newydd..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Bysell cyflymu"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Addasyddion cyflymu"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Cod bysell cyflymu"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Modd Cyflymu"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Y math o gyflymydd."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:197
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:471
+msgid "Disabled"
+msgstr "Analluogwyd"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:544
+msgid "<Unknown Action>"
+msgstr "<Gweithred Anhysbys>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:565
+msgid "Desktop"
+msgstr "Penbwrdd"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:566
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Sain"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:570
+msgid "Window Management"
+msgstr "Rheoli Ffenestri"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:676
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become unusable to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time.\n"
+msgstr ""
+"Methu defnyddio'r llwybr byr \"%s\" am y bydd wedyn yn amhosib teipio gyda'r "
+"allweddell yna.\n"
+"Ail-geisiwch gydag allwedd fel Control, Alt or Shift ar yr un pryd.\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:705
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+"Defnyddir y byrlwybr \"%s\" eisoes ar gyfer:\n"
+" \"%s\"\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:737
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr "Gwall wrth osod cyflymydd newydd yn y gronfa cyfluniad: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:787
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr "Gwall wrth ddadosod cyflymydd yn y gronfa cyfluniad: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:894
+msgid "Action"
+msgstr "Gweithred"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:918
+msgid "Shortcut"
+msgstr "Byrlwybr"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Llwybrau byr y Bysellfwrdd"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"I olygu bysell cyflymydd, cliciwch ar y rhes sy'n cyfateb a theipiwch "
+"gyflymydd newydd, neu gwasgwch olnod er mwyn clirio."
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "_Neilltuo bysell byrlwybr â gorchmynion"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+msgid "Unknown"
+msgstr "Anhysbys"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+msgid "Layout"
+msgstr "Cyflwyniad"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+msgid "Default"
+msgstr "Rhagosodiad"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+msgid "Models"
+msgstr "Modelau"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:109
+#, c-format
+msgid "There was an error launching the keyboard tool: %s"
+msgstr "Roedd gwall wrth gychwyn offer y bysellfwrdd: %s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr "_Hygyrchedd"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:240
+#: ../capplets/sound/sound-properties-capplet.c:242
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+"Cymhwyso'r gosodiadau a therfynu (cydnawsedd yn unig; trinnir gan ellyll "
+"bellach)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr "Cychwyn y dudalen gyda'r gosodiadau gorffwys teipio yn dangos"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "..."
+msgstr "..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Chwincio'r Cyrchydd</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Bysellau Ailadroddus</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<b>_Cloi'r sgrin er mwyn gorfodi'r saib teipio</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Cyflym</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Hir</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Byr</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Araf</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_vailable layouts:"
+msgstr "_Cynlluniau ar gael:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "All_ow postponing of breaks"
+msgstr "_Caniatáu gohirio seibiau"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Gwirio os ceir gohirio seibiau"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "Choose a Keyboard Model"
+msgstr "Dewiswch Fodel Bysellfwrdd"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Choose a Layout"
+msgstr "Dewiswch Gynllun"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr "_Mae'r cyrchydd yn chwincio mewn blychau testun a meysydd"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Cursor blinks speed"
+msgstr "Cyflymder chwincio'r cyrchwr"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of the break when typing is disallowed"
+msgstr "Hyd y saib tra mae teipio wedi ei wahardd"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Duration of work before forcing a break"
+msgstr "Hyd y gwaith cyn gorfodi saib"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Key presses _repeat when key is held down"
+msgstr "Bysellau yn _ailadrodd wrth gael eu dal i lawr"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Keyboard Preferences"
+msgstr "Hoffterau Bysellfwrdd"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Keyboard _model:"
+msgstr "Model bysellfwrdd"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Layout Options"
+msgstr "Opsiynau Cynllun:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Layouts"
+msgstr "Cynlluniau"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Cloi'r sgrin ar ôl cyfnod penodedig er mwyn cynorthwyo atal anafiadau "
+"defnydd bysellfwrdd ailadroddus"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Microsoft Natural Keyboard"
+msgstr "Bysellfwrdd Naturiol Microsoft"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Preview:"
+msgstr "Rhagolwg:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "Repeat keys speed"
+msgstr "Cyflymder ail-adrodd bysellau"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Reset To De_faults"
+msgstr "_Ailosod i'r dewisiadau rhagosodedig"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Separate _group for each window"
+msgstr "_Grwp ar wahân ar gyfer pob ffenestr"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+msgid "Typing Break"
+msgstr "Gorffwys Teipio"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Accessibility..."
+msgstr "_Hygyrchedd..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Add..."
+msgstr "_Ychwanegu..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "_Break interval lasts:"
+msgstr "_Cyfnod seibio yn para:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Delay:"
+msgstr "_Oediad:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Models:"
+msgstr "_Modelau:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Selected layouts:"
+msgstr "_Cynlluniau dewiswyd:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Speed:"
+msgstr "_Cyflymder:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "_Work interval lasts:"
+msgstr "_Cyfnod gweithio yn para:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "minutes"
+msgstr "munud"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Gosodwch eich hoffterau bysellfwrdd"
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:880
+#, c-format
+msgid "%d milliseconds"
+msgid_plural "%d milliseconds"
+msgstr[0] "%d milfed eiliad"
+msgstr[1] "%d milfedau o eiliadau"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:560
+msgid "Unknown Pointer"
+msgstr "Pwyntydd Anhysbys"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+msgid "Default Pointer"
+msgstr "Pwyntydd Rhagosodedig"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Pointer - Current"
+msgstr "Pwyntydd Rhagosodedig - Cyfredol"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+msgid "The default pointer that ships with X"
+msgstr "Y pwyntydd rhagosodedig a gludir gydag X"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+msgid "White Pointer"
+msgstr "Pwyntydd Gwyn"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Pointer - Current"
+msgstr "Pwyntydd Gwyn - Cyfredol"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+msgid "The default pointer inverted"
+msgstr "Y pwyntydd rhagosodedig wedi'i wrthdroi"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+msgid "Large Pointer"
+msgstr "Pwyntydd Mawr"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Pointer - Current"
+msgstr "Pwyntydd Mawr - Cyfredol"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+msgid "Large version of normal pointer"
+msgstr "Fersiwn mawr o'r pwyntydd arferol"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+msgid "Large White Pointer - Current"
+msgstr "Pwyntydd Mawr Gwyn - Cyfredol"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Pointer"
+msgstr "Pwyntydd Mawr Gwyn"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+msgid "Large version of white pointer"
+msgstr "Fersiwn mawr o'r pwyntydd gwyn"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:970
+msgid "Pointer Theme"
+msgstr "Thema Pwyntydd"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr "<b>Amser Aros am Glic Dwbl</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Llusgo a Gollwng</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Lleoli'r Pwyntydd</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>Cyfeiriadaeth Llygoden</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Speed</b>"
+msgstr "<b>Cyflymder</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>Cyflym</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>Uchel</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>Mawr</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>Isel</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>Araf</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>Bach</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Botymau"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr "Amlygu'r _pwyntydd pan rydych chi'n gwasgu Ctrl"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Large"
+msgstr "Mawr"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Medium"
+msgstr "Canolig"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "Motion"
+msgstr "Symudiad"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+msgid "Mouse Preferences"
+msgstr "Hoffterau Llygoden"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Pointer Size:"
+msgstr "Maint Pwyntydd:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Pointers"
+msgstr "Pwyntyddion"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "Small"
+msgstr "Bach"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr "_Cyflymiad:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr "_Llygoden lawchwith"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr "_Sensitifrwydd:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr "_Trothwy:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr "_Terfyn aros:"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Llygoden"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Gosodwch eich hoffterau llygoden"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Dirprwy Rhwydwaith"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "Gosod eich hoffterau dirprwy rhwydwaith"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>_Cysylltiad Rhyngrwyd uniongyrchol</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr "<b>Anwybyddu Rhestr Gwesteiwyr</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>Cyfluniad dirprwy _awtomatig</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>Cyflunio dirprwy â _llaw</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Defnyddio dilysiant</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "Advanced Configuration"
+msgstr "Cyfluniad Uwch"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr "_URL cyfluniad awtomatig:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "Manylion dirprwy HTTP"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "Dirprwy _HTTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Network Proxy Preferences"
+msgstr "Hoffterau Dirprwy Rhwydwaith"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Porth:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "Proxy Configuration"
+msgstr "Cyfluniad Dirprwy"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr "Gweinydd S_ocks:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "U_sername:"
+msgstr "_Enw Defnyddiwr:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_Manylion"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr "Dirprwy _FTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "_Cyfrinair:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr "Dirprwy HTTP _Diogel:"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Galluogi sain a chysylltu seiniau â digwyddiadau"
+
+#: ../capplets/sound/sound-properties-capplet.c:271
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "Sound Preferences"
+msgstr "Hoffterau Sain"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "E_nable software sound mixing (ESD)"
+msgstr "_Galluogi cymysgu sain o fewn meddalwedd (ESD)"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "Flash _entire screen"
+msgstr "Fflachio'r _sgrin gyfan"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "Flash _window titlebar"
+msgstr "Fflachio bar teitl y _ffenest"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "Sounds"
+msgstr "Seiniau"
+
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "System Beep"
+msgstr "Bîp y System"
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "_Enable system beep"
+msgstr "_Galluogi bîp y system"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "_Play system sounds"
+msgstr "_Chwarae synau'r system"
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "_Visual system beep"
+msgstr "Bîp _gweledol y system"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:368
+msgid "Would you like to remove this theme?"
+msgstr "Hoffech chi dynnu'r thema hon?"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:433
+msgid "Theme deleted succesfully. Please select another theme."
+msgstr "Thema wedi'i ddileu yn llwyddiannus. Dewiswch thema wahanol."
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:442
+msgid "Theme can not be deleted"
+msgstr "Methu dileu'r thema"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:529
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+"Ni chanfuwyd unrhyw themâu ar eich system. Mae'n debyg golyga hyn bod eich "
+"deialog \"Hoffterau Thema\" wedi ei osod yn anghywir, neu nad ydych wedi "
+"gosod y pecyn \"gnome-themes\"."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:227
+msgid "This theme is not in a supported format."
+msgstr "Nid yw'r thema mewn ffurf a gynhelir."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:242
+msgid "Failed to create temporary directory"
+msgstr "Methu creu cyfeiriadur dros dro"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:260
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+"Methu gosod thema. \n"
+"Nid yw'r rhaglen bzip2 wedi ei osod."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:276
+#: ../capplets/theme-switcher/gnome-theme-installer.c:309
+#: ../capplets/theme-switcher/gnome-theme-installer.c:383
+msgid "Installation Failed"
+msgstr "Methodd Gosodiad"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:294
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+"Methu gosod themâu. \n"
+"Nid yw'r rhaglen bzip2 wedi ei osod."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:330
+#, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+"Thema Eicon %s wedi ei gosod yn gywir.\n"
+"Gallwch ei dewis yn y manylion themâu."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:333
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr "Thema Gnome %s wedi ei gosod yn gywir"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:336
+#, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+"Thema Border Ffenest %s wedi ei gosod yn gywir.\n"
+"Gallwch ei dewis yn y manylion themâu."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:339
+#, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+"Thema Rheolyddion %s wedi ei gosod yn gywir.\n"
+"Gallwch ei dewis yn y manylion themâu."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:345
+msgid "The theme is an engine. You need to compile the theme."
+msgstr "Mae'r thema yn injan. Rhaid i chi grynhoi'r thema."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:360
+msgid "The file format is invalid"
+msgstr "Fformat ffeil yn annilys"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:450
+msgid "No theme file location specified to install"
+msgstr "Ni chafodd lleoliad ffeil thema ei bennu ar gyfer ei osod"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:469
+msgid "The theme file location specified to install is invalid"
+msgstr "Roedd y lleoliad ffeil thema a benodwyd i'w osod yn annilys"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:489
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"Caniatadau annigonol i osod y thema yn:\n"
+"%s"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:510
+msgid "The file format is invalid."
+msgstr "Fformat ffeil yn annilys."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:537
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+"%s yw'r llwybr lle fydd y ffeiliau thema wedi ei gosod. Ni ellir dewis hwn "
+"fel lleoliad y ffynhonnell"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:591
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr ""
+"Methu gosod thema.\n"
+"Nid yw'r rhaglen tar wedi ei osod ar eich system."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:686
+msgid "Custom theme"
+msgstr "Thema Addasedig"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:686
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr "Gallwch gadw'r thema yma drwy glicio'r botwm Cadw Thema."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1584
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+"Methwyd canfod y sgemâu thema rhagosodedig ar eich system. Mae hyn yn "
+"awgrymu nad yw metacity wedi ei ymsefydlu gennych, neu fod eich gconf wedi "
+"ei gyflunio'n anghywir."
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:72
+msgid "Theme name must be present"
+msgstr "Rhaid bod enw thema yn bresennol"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:104
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Mae'r thema'n bodoli eisoes. A hoffech ei newid?"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr "Dewiswch themâu i amryw rannau'r penbwrdd"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "Thema"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Gosod Thema</span>"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:3
+msgid "Theme Installation"
+msgstr "Gosodiad Thema"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:4
+msgid "_Install"
+msgstr "_Gosod"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:5
+msgid "_Location:"
+msgstr "_Lleoliad:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Cadw Thema i Ddisg</span>"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "Apply _Background"
+msgstr "Cymhwyso _Cefndir"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Apply _Font"
+msgstr "Cymhwyso _Ffont"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Controls"
+msgstr "Rheolyddion"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Icons"
+msgstr "Eiconau"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "New themes can also be installed by dragging them into the window."
+msgstr "Gellir gosod themâu newydd drwy ei llusgo i'r ffenestr hefyd"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "Save Theme"
+msgstr "Cadw'r Thema"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+msgid "Select theme for the desktop"
+msgstr "Dewiswch thema ar gyfer y penbwrdd"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+msgid "Short _description:"
+msgstr "_Disgrifiad byr:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+msgid "Theme Details"
+msgstr "Manylion Thema"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "Theme Preferences"
+msgstr "Hoffterau Thema"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "Theme _Details"
+msgstr "_Manylion Thema"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+msgid "This theme does not suggest any particular font or background."
+msgstr "Nid yw'r thema yma yn awgrymu unrhyw ffont neu gefndir penodol"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+msgid "This theme suggests a background:"
+msgstr "Mae'r thema yma yn awgrymu cefndir:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+msgid "This theme suggests a font and a background:"
+msgstr "Mae'r thema yma yn awgrymu ffont a chefndir:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+msgid "This theme suggests a font:"
+msgstr "Mae'r thema yma yn awgrymu ffont:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+msgid "Window Border"
+msgstr "Ymyl Ffenestr"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "_Install Theme..."
+msgstr "_Ymsefydlu Thema..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+msgid "_Revert"
+msgstr "_Dychwelyd:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+msgid "_Save Theme..."
+msgstr "_Cadw'r thema..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+msgid "_Theme name:"
+msgstr "_Enw thema:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+msgid "theme selection tree"
+msgstr "coeden dewis thema"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr "Addasu golwg bariau offer a bariau dewislenni mewn rhaglenni"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "Dewislenni a Bariau Offer"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr "<b>Ymddygiad ac Ymddangosiad</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+msgid "<b>Preview</b>"
+msgstr "<b>Rhagolwg</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "T_orri"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+msgid "Icons only"
+msgstr "Eiconau'n unig"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "Hoffterau Dewislen a Bar Offer"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "Ffeil Newydd"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Agor Ffeil"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Cadw Ffeil"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr "Dangos _eiconau mewn dewislenni"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+msgid "Text below icons"
+msgstr "Testun islaw eiconau"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+msgid "Text beside icons"
+msgstr "Testun wrth ochr eiconau"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+msgid "Text only"
+msgstr "Testun yn unig"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+msgid "Toolbar _button labels:"
+msgstr "Labeli _botymau bar offer:"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_Copïo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr "Barau offer gellir _datgysylltu"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_Golygu"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr "Posib _golygu cyflymwyr dewislen"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "_Ffeil"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_Newydd"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "_Agor"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "_Gludo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "_Argraffu"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "_Gadael"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "_Cadw"
+
+#: ../capplets/windows/gnome-window-properties.c:385
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+"<b>Methu cychwyn y rhaglen hoffterau ar gyfer eich rheolwr ffenestri</b>\n"
+"\n"
+"%s"
+
+#: ../capplets/windows/gnome-window-properties.c:642
+msgid "C_ontrol"
+msgstr "C_ontrol"
+
+#: ../capplets/windows/gnome-window-properties.c:647
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:653
+msgid "H_yper"
+msgstr "_Goruwch (hyper)"
+
+#: ../capplets/windows/gnome-window-properties.c:660
+msgid "S_uper (or \"Windows logo\")"
+msgstr "_Uwch (neu \"Logo Windows\")"
+
+#: ../capplets/windows/gnome-window-properties.c:667
+msgid "_Meta"
+msgstr "_Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Bysell Symud</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>Gweithred Bar Teitl</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Dewis Ffenestri</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr ""
+"I symud ffenestr, gwasgwch a chydiwch y fysell yma yna cydiwch yn y ffenestr:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Hoffterau Ffenestr"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_Rhoi clic dwbl ar y bar teitl i gyflawni'r weithred hon:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "_Cyfnod cyn codi:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_Codi ffenestri dewisedig ar ôl cyfnod"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Dewis ffenestri pan fo'r llygoden yn symud drostynt"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "Gosod eich priodweddau ffenestr"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Ffenestri"
+
+#: ../control-center/control-center-categories.c:287
+msgid "Others"
+msgstr "Eraill"
+
+#: ../control-center/control-center.c:93
+msgid "Desktop Preferences"
+msgstr "Hoffterau Penbwrdd"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr "Canolfan Reoli GNOME"
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "Yr erfyn cyfluniad GNOME"
+
+#: ../gnome-settings-daemon/actions/acme-fb-level.c:149
+msgid "No '/dev/pmu' device found"
+msgstr "Dim dyfais '/dev/pmu' wedi ei ganfod"
+
+#: ../gnome-settings-daemon/actions/acme-fb-level.c:156
+msgid "Not a powerbook"
+msgstr "Ddim yn 'powerbook'"
+
+#: ../gnome-settings-daemon/actions/acme-fb-level.c:173
+msgid "Wrong permission for '/dev/pmu' device"
+msgstr "Caniatâd anghywir ar gyfer y ddyfais '/dev/pmu'"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "Lefel Sain"
+
+#: ../gnome-settings-daemon/factory.c:66
+msgid "Could not initialize Bonobo"
+msgstr "Methu ymgychwyn Bonobo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:406
+msgid "Slow Keys Alert"
+msgstr "Rhybudd Bysellau Araf"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:407
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Rydych newydd ddal lawr y fysell Shift am 8 eiliad. Dyma'r byrlwybr ar gyfer "
+"y nodwedd Bysellau Araf, sy'n effeithio sut mae'ch bysellfwrdd yn gweithio"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:409
+msgid "Do you want to activate Slow Keys?"
+msgstr "Ydych chi eisiau troi Bysellau Araf ymlaen?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Do you want to deactivate Slow Keys?"
+msgstr "Ydych chi eisiau troi Bysellau Araf i ffwrdd?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
+msgid "_Activate"
+msgstr "_Actifadu"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
+msgid "_Deactivate"
+msgstr "_Dad-actifadu"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
+msgid "Do_n't activate"
+msgstr "_Peidio ag actifadu"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
+msgid "Do_n't deactivate"
+msgstr "_Peidio â dad-actifadu"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:421
+msgid "Sticky Keys Alert"
+msgstr "Rhybudd Bysellau Gludiog"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:422
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Rydych newydd wasgu'r fysell Shift 5 gwaith mewn rhes. Dyma'r byrlwybr ar "
+"gyfer y nodwedd Bysellau Gludiog, sy'n effeithio sut mae'ch bysellfwrdd yn "
+"gweithio"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:424
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+"Rydych newydd wasgu dwy fysell ar unwaith neu wasgu'r fysell Shift 5 gwaith "
+"mewn rhes. Mae hyn yn troi'r nodwedd Bysedd Gludiog ymlaen, sy'n effeithio "
+"sut mae'ch bysellfwrdd yn gweithio."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:426
+msgid "Do you want to activate Sticky Keys?"
+msgstr "Ydych chi eisiau troi Bysellau Gludiog ymlaen?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:427
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr "Ydych chi eisiau troi Bysellau Gludio i ffwrdd?"
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:74
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing the mouse pointer theme."
+msgstr ""
+"Methu creu'r cyfeiriadur \"%s\".\n"
+"Mae angen hwn i ganiatáu newid thema pwyntydd y llygoden."
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:96
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+"Methu creu'r cyfeiriadur \"%s\".\n"
+"Mae angen hwn i ganiatáu newid cyrchwyr."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:208
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr "Diffinnir gweithred y Rhwymiad Bysell (%s) sawl gwaith\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:221
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr "Diffinnir rhwymiad y Rhwymiad Bysell (%s) sawl gwaith\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:227
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr "Mae'r Rhwymiad Bysell (%s) yn anghyflawn\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:255
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr "Mae'r Rhwymiad Bysell (%s) yn annilys\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:291
+#, c-format
+msgid "It seems that another application already has access to key '%u'."
+msgstr "Mae'n debyg fod gan raglen arall fynediad i'r fysell '%u' eisoes."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:360
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr "Defnyddir y Rhwymiad Bysell (%s) eisoes\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:435
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+"Gwall wrth geisio gweithredu (%s)\n"
+"sy'n rhwym i'r fysell (%s)"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
+#, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+"Gwall wrth gychwyn cyfluniad XKB.\n"
+"Gall nifer o amgylchiadau achosi hyn:\n"
+"- gwall yn llyfrgell libxklavier\n"
+"- gwall yng ngweinydd X (xkbcomp, offer xmodmap)\n"
+"- Gweinydd X gyda gweithrediad libxfile anghyson\n"
+"\n"
+"Gwybodaeth fersiwn gweinydd X:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"Os wnewch chi adrodd nam, a wnewch chi gynnwys:\n"
+"- Canlyniad <b>%s</b>\n"
+"- Canlyniad <b>%s</b>"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+"Rydych chi'n defnyddio XFree 4.3.0.\n"
+"Mae yna broblemau hysbys gyda chyfluniadau XKB cymhleth.\n"
+"Ceisiwch ddefnyddio cyfluniad symlach neu ddefnyddio fersiwn mwy diweddar o "
+"feddalwedd XFree"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:223
+msgid "Do _not show this warning again"
+msgstr "_Peidio â dangos y rhybudd yma eto"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:234
+msgid ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+msgstr ""
+"Mae gosodiadau bysellfwrdd y system X yn wahanol i'ch gosodiadau bysellfwrdd "
+"GNOME cyfredol. Pa set hoffech ddefnyddio?"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:247
+msgid "Use X settings"
+msgstr "Defnyddio Gosodiadau X"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:249
+msgid "Use GNOME settings"
+msgstr "Defnyddio Gosodiadau GNOME"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+"Methwyd gweithredu'r gorchymyn: %s\n"
+"Gwirio fod y gorchymyn yma'n bodoli."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+"Methwyd rhoi'r peiriant i gysgu.\n"
+"Gwirio fod y peiriant wedi ei gyflunio yn gywir."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:180
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+"Methwyd llwytho ffeil Glade.\n"
+"Gwnewch yn siwr fod y daemon wedi ei osod yn gywir."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:110
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+"Bu gwall wrth gychwyn yr arbedwr sgrin:\n"
+"\n"
+"%s\n"
+"\n"
+"Fydd arbed sgrin ddim yn gweithio yn ystod y sesiwn yma."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:120
+msgid "_Do not show this message again"
+msgstr "_Peidiwch â dangos y neges yma eto"
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:131
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr "Methwyd llwytho ffeil sain %s fel sampl %s"
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:212
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:260
+msgid "Cannot determine user's home directory"
+msgstr "Methwyd canfod cyfeiriadur cartref y defnyddiwr"
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:212
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr "Gosodwyd yr allwedd GConf %s i fath %s ond disgwylid math %s\n"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+msgid "A_vailable files:"
+msgstr "_Ffeiliau ar gael:"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+msgid "Do _not show this warning again."
+msgstr "_Peidio â dangos y rhybudd yma eto."
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr "Llwytho ffeiliau modmap"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr "Hoffech chi lwytho'r ffeil(iau) modmap?"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr "_Llwytho"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+msgid "_Loaded files:"
+msgstr "_Ffeiliau wedi'u llwytho:"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr "Gwall wrth greu piben signal."
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Math"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+"Math o bg_applier: BG_APPLIER_ROOT ar gyfer y ffenestr gwraidd neu "
+"BG_APPLIER_PREVIEW ar gyfer rhagolwg"
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr "Lled Rhagolwg"
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr "Lled os yw'r cymhwysydd yn rhagolwg: Rhagosod fel 64"
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr "Uchder y Rhagolwg"
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr "Uchder os yw'r cymhwysydd yn rhagolwg: Rhagosod fel 48"
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Sgrin"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr "Sgrin y dylai BGApplier ddarlunio arni"
+
+#: ../libgswitchit/gswitchit_config.c:1036
+#, c-format
+msgid "There was an error loading an image: %s"
+msgstr "Gwall wrth lwytho delwedd: %s"
+
+#: ../libsounds/sound-view.c:43
+msgid "Login"
+msgstr "Mewngofnodi"
+
+#: ../libsounds/sound-view.c:44
+msgid "Logout"
+msgstr "Allgofnodi"
+
+#: ../libsounds/sound-view.c:45
+msgid "Boing"
+msgstr "Boing"
+
+#: ../libsounds/sound-view.c:46
+msgid "Siren"
+msgstr "Seiren"
+
+#: ../libsounds/sound-view.c:47
+msgid "Clink"
+msgstr "Clinc"
+
+#: ../libsounds/sound-view.c:48
+msgid "Beep"
+msgstr "Bîp"
+
+#: ../libsounds/sound-view.c:49
+msgid "No sound"
+msgstr "Dim sain"
+
+#: ../libsounds/sound-view.c:131
+msgid "Sound not set for this event."
+msgstr "Seiniau heb eu gosod ar gyfer y digwyddiad hwn."
+
+#: ../libsounds/sound-view.c:140
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package for a set of default sounds."
+msgstr ""
+"Nid yw'r ffeil sain ar gyfer y digwyddiad yma'n bodoli.\n"
+"Efallai yr hoffech chi sefydlu'r pecyn gnome-audio er mwyn gael set o "
+"seiniau rhagosodedig."
+
+#: ../libsounds/sound-view.c:151
+msgid "The sound file for this event does not exist."
+msgstr "Nid yw'r ffeil sain i'r digwyddiad yma'n bodoli."
+
+#: ../libsounds/sound-view.c:182
+msgid "Select Sound File"
+msgstr "Dewiswch Ffeil Sain"
+
+#: ../libsounds/sound-view.c:202
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "NId yw'r ffeil %s yn ffeil WAV ddilys"
+
+#: ../libsounds/sound-view.c:359
+msgid "System Sounds"
+msgstr "Synau'r System"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "Nid yw rheolwr ffenestri \"%s\" wedi cofrestru arf cyfluniad\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Ehangu"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Rholio i fyny"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr "Os yn wir, cedwir y trinwyr testun/plaen a thestun/* yn gydwedd"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr "Trinwyr testun/plaen a thestun/*"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "Brightness down"
+msgstr "Disgleirdeb i lawr"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "Brightness down's shortcut."
+msgstr "Byrlwybr disgleirdeb i lawr."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Brightness up"
+msgstr "Disgleirdeb i fyny"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Brightness up's shortcut."
+msgstr "Byrlwybr disgleirdeb i fyny."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "E-mail"
+msgstr "E-bost"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "E-mail's shortcut."
+msgstr "Byrlwybr E-bost."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Eject"
+msgstr "Allfwrw"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+msgid "Eject's shortcut."
+msgstr "Byrlwybr allfwrw."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+msgid "Home folder"
+msgstr "Plygell cartref"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+msgid "Home folder's shortcut."
+msgstr "Byrlwybr i fy Mhlygell Cartref."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+msgid "Launch help browser"
+msgstr "Lansio'r porwr cymorth"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+msgid "Launch help browser's shortcut."
+msgstr "Byrlwybr i lansio'r porwr cymorth."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+msgid "Launch web browser"
+msgstr "Lansio porwr gwe"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+msgid "Launch web browser's shortcut."
+msgstr "Byrlwybr i lansio porwr gwe."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+msgid "Lock screen"
+msgstr "Cloi'r sgrin"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+msgid "Lock screen's shortcut."
+msgstr "Byrlwybr i gloi'r sgrin."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+msgid "Log out"
+msgstr "Allgofnodi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+msgid "Log out's shortcut."
+msgstr "Byrlwybr i allgofnodi."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Next track key's shortcut."
+msgstr "Byrlwybr bysell trac nesaf."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Pause"
+msgstr "Seibio"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Pause key's shortcut."
+msgstr "Byrlwybr y fysell seibio."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Play (or play/pause)"
+msgstr "Chwarae (neu chwarae/seibio)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Play (or play/pause) key's shortcut."
+msgstr "Byrlwybr y fysell chwarae (neu chwarae/seibio)."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Previous track key's shortcut."
+msgstr "Byrlwybr y fysell trac blaenorol."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Search"
+msgstr "Chwilio"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+msgid "Search's shortcut."
+msgstr "Byrlwybr chwilio"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Skip to next track"
+msgstr "Neidio i'r trac nesaf"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Skip to previous track"
+msgstr "Neidio i'r trac blaenorol"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Sleep"
+msgstr "Cysgu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+msgid "Sleep's shortcut."
+msgstr "Byrlwybr cysgu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Stop playback key"
+msgstr "Bysell stopio chwarae"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Stop playback key's shortcut."
+msgstr "Byrlwybr y fysell stopio chwarae."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume down"
+msgstr "Lefel sain i lawr"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume down's shortcut."
+msgstr "Byrlwybr lefel sain i lawr."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume mute"
+msgstr "Mudo'r sain"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume mute's shortcut"
+msgstr "Byrlwybr mudo'r sain"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+msgid "Volume step"
+msgstr "Gris lefel sain"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+msgid "Volume step as percentage of volume."
+msgstr "Gris lefel sain fel canran o'r lefel."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+msgid "Volume up"
+msgstr "Lefel sain i fyny"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
+msgid "Volume up's shortcut."
+msgstr "Byrlwybr lefel sain i fyny."
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr "Dangos deialog pan fo gwallau wrth redeg yr arbedwr sgrin"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+msgid "Run screensaver at login"
+msgstr "Cychwyn yr arbedwr sgrin wrth fewngofnodi"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr "Dangos Gwallau Ymgychwyn"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+msgid "Start screensaver"
+msgstr "Dechrau'r arbedwr sgrin"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+"Casgliad o sgriptiau i'w rhedeg pryd bynnag caiff cyflwr yr allweddell ei "
+"ail-lwytho. Yn ddefnyddiol er mwyn rhoi newidiadau ar waith sy'n seiliedig "
+"ar xmodmap."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr "Rhestr o ffeiliau modmap ar gael yn y cyfeiriadur $HOME."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr "Grwp rhagosodedig, wedi ei neilltuo wrth greu ffenestr"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr "Cadw a rheoli grwp ar wahân am bob ffenestr"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+msgid "Keyboard Update Handlers"
+msgstr "Trinwyr Diweddariad Bysellfwrdd"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+msgid "Keyboard layout"
+msgstr "Cynllun bysellfwrdd"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+msgid "Keyboard model"
+msgstr "Model bysellfwrdd"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+msgid "Keyboard options"
+msgstr "Dewisiadau bysellfwrdd"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr ""
+"Caiff gosodiadau bysellfwrdd o fewn gconf eu trosysgrifo gan y system cyn "
+"gynted â phosib (anghymeradwyir)"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr "Cadw/adfer dangoswyr ynghyd â grwpiau cynllun"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr "Dangos enwau cynllun yn lle enwau grwp"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+"Dangos enwau gosodiad yn lle enwau grwp (dim ond ar gyfer fersiynau o XFree "
+"sy'n cynnal amryw gynlluniau)"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr "Atal y neges rybudd \"sysconfig X wedi newid\""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+"Yn fuan iawn, bydd gosodiadau bysellfwrdd o fewn gconf yn cael eu "
+"trosysgrifo (gan gyfluniad y system). Mae'r allwedd hon wedi ei "
+"anghymeradwyo ers GNOME 2.12. Dadosodwch yr allweddi model, cynllun ac "
+"opsiynau er mwyn cael cyfluniad rhagosodedig y system."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+msgid "keyboard layout"
+msgstr "cynllun bysellfwrdd"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+msgid "keyboard model"
+msgstr "model bysellfwrdd"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "modmap file list"
+msgstr "Rhestr ffeil modmap"
+
+#: ../typing-break/drw-break-window.c:213
+msgid "_Postpone break"
+msgstr "_Gohirio'r saib"
+
+#: ../typing-break/drw-break-window.c:260
+msgid "Take a break!"
+msgstr "Cymerwch saib!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:135
+msgid "/_Preferences"
+msgstr "/_Hoffterau"
+
+#: ../typing-break/drwright.c:136
+msgid "/_About"
+msgstr "/_Ynghylch"
+
+#: ../typing-break/drwright.c:138
+msgid "/_Take a Break"
+msgstr "/_Cymryd Saib"
+
+#: ../typing-break/drwright.c:489
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "%d munud tan y saib nesaf"
+msgstr[1] "%d funud tan y saib nesaf"
+
+#: ../typing-break/drwright.c:493
+msgid "Less than one minute until the next break"
+msgstr "Llai nag un munud tan y saib nesaf"
+
+#: ../typing-break/drwright.c:581
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Methwyd codi'r deialog hoffterau gorffwys teipio gyda'r gwall canlynol: %s "
+
+#: ../typing-break/drwright.c:629
+msgid "About GNOME Typing Monitor"
+msgstr "Ynghylch Monitor Teipio GNOME"
+
+#: ../typing-break/drwright.c:653
+msgid "A computer break reminder."
+msgstr "Eich atgoffa i gymryd saib o'r cyfrifiadur."
+
+#: ../typing-break/drwright.c:654
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr "Ysgrifennwyd gan Richard Hult &lt;richard@imendio.com&gt;"
+
+#: ../typing-break/drwright.c:655
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Ychwanegwyd melysion gweledol gan Anders Carlsson"
+
+#: ../typing-break/drwright.c:831
+msgid "Break reminder"
+msgstr "Eich atgof seibiau"
+
+#: ../typing-break/eggtrayicon.c:127
+msgid "Orientation"
+msgstr "Gogwydd"
+
+#: ../typing-break/eggtrayicon.c:128
+msgid "The orientation of the tray."
+msgstr "Gogwydd yr hambwrdd."
+
+#: ../typing-break/main.c:100
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Mae'r arsylwr teipio yn defnyddio'r man hysbysu er mwyn dangos gwybodaeth. "
+"Ymddengys nad oes man hysbysu ar eich panel. Gallwch ychwanegu man hysbysu "
+"gan dde-glicio ar eich panel a dewis 'Ychwanegu at y Panel', dewis 'Man "
+"hysbysu' a chlicio 'Ychwanegu.'"
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "Parciais fy jac codi baw hud llawn dwr ger ty Mabon. 0123456789"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "Enw:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "Arddull:"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "Math:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "Maint:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "Fersiwn:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "Hawlfraint:"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "Disgrifiad:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "defnydd: %s ffeil_ffont\n"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr "Gosod fel y Ffont Rhaglenni"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+msgid "Sets the default application font"
+msgstr "Dewis y ffont rhagosodedig ar gyfer rhaglenni"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau OpenType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau PCF."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau TrueType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer ffontiau Type1"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+"cryno o ffontiau OpenType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+"cryno o ffontiau PCF."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+"cryno o ffontiau TrueType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+"cryno o ffontiau Type1."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau OpenType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau PCF"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau TrueType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Gorchymyn lluniau cryno ar gyfer ffontiau Type1"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "A ddylid creu lluniau cryno o ffontiau OpenType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "A ddylid creu lluniau cryno o ffontiau PCF"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "A ddylid creu lluniau cryno o ffontiau TrueType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "A ddylid creu lluniau cryno o ffontiau Type1"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+msgid "GNOME Font Viewer"
+msgstr "Gwelydd Ffontiau GNOME"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr "<span weight=\"bold\" size=\"larger\">Cymhwyso'r ffont newydd?</span>"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr "_Peidio cymhwyso'r ffont"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"Mae'r thema rydych chi wedi dewis yn awgrymu ffont newydd. Dangosir rhagolwg "
+"o'r ffont isod."
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+msgid "_Apply font"
+msgstr "_Cymhwyso'r ffont"
+
+#: ../vfs-methods/themus/theme-method.c:518
+msgid "Themes"
+msgstr "Themâu"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "Disgrifiad"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr "Thema rheoli"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+msgid "Window border theme"
+msgstr "Thema ymyl ffenestr"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr "Thema eiconau"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr "ABCDEFG"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+msgid "Apply theme"
+msgstr "Defnyddio thema"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+msgid "Sets the default theme"
+msgstr "Dewis thema ragosodedig"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer themâu sefydledig."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr "Os yn wir, caiff lluniau cryno eu creu ar gyfer themâu."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+"cryno o themâu sefydledig."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+"Gosodwch yr allwedd hon i'r gorchymyn a ddefnyddir er mwyn creu lluniau "
+"cryno o themâu."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr "Gorchymyn lluniau cryno ar gyfer themâu sefydledig"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr "Gorchymyn lluniau cryno ar gyfer themâu sefydledig"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr "A ddylid creu lluniau cryno o themâu sefydledig"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr "A ddylid creu lluniau cryno o themâu"
+
+msgid "Show help options"
+msgstr "Dangos opsiynau cymorth"
+
+#~ msgid "Epiphany"
+#~ msgstr "Epiphany"
+
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "Penodi enw a gorchymyn i'r golygydd yma"
+
+#~ msgid "Add..."
+#~ msgstr "Ychwanegu..."
+
+#~ msgid "C_ustom:"
+#~ msgstr "A_ddasedig:"
+
+#~ msgid "Can open _URIs"
+#~ msgstr "Gall agor _URIau"
+
+#~ msgid "Can open multiple _files"
+#~ msgstr "Gall agor _mwy nag n ffeil"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Priodweddau'r Golygydd Personol"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "Darllenwr E-bost Rhagosodedig"
+
+#~ msgid "Default Terminal"
+#~ msgstr "Terfynell Rhagosodedig"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "Golygydd Testun Arferol"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "Porydd We Arferol"
+
+#~ msgid "Default Window Manager"
+#~ msgstr "Rheolydd Ffenestri Arferol"
+
+#~ msgid "Delete"
+#~ msgstr "Dileu"
+
+#~ msgid "Edit..."
+#~ msgstr "Golygu..."
+
+#~ msgid "Run in a _terminal"
+#~ msgstr "Rhedeg mewn _terfynell"
+
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "Dewiswch eich rheolwr ffenestri. Rhaid i chi wasgu \"Cymhwyso\", "
+#~ "chwifio'r hudlath, a gwneud dawns hudol er mwyn iddo weithio."
+
+#~ msgid "Terminal"
+#~ msgstr "Terfynell"
+
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "Deall _Netscape Remote Control"
+
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr ""
+#~ "Defnyddio'r _golygydd yma i agor ffeiliau testun y tu mewn i'r trefnydd "
+#~ "ffeiliau"
+
+#~ msgid "Window Manager"
+#~ msgstr "Trefnydd Ffenestri"
+
+#~ msgid "_Command:"
+#~ msgstr "_Gorchymyn:"
+
+#~ msgid "_Name:"
+#~ msgstr "_Enw:"

--- a/po/da.po
+++ b/po/da.po
@@ -33,9 +33,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-08-27 12:39+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -46,99 +45,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Systembus"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Fuld adgang"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Sessionsbus"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Enheder"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Fuld adgang til /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Netværk"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Har netværksadgang"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Hjem"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Skrivebeskyttet"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Filsystem"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Indstillinger"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Kan ændre indstillinger"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s har følgende indbyggede rettigheder. De kan ikke ændres. Er du bekymret "
-"over disse rettigheder, så overvej at fjerne programmet."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u fil- og linktype som er åbnet af programmet"
-msgstr[1] "%u fil- og linktyper som er åbnet af programmet"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> bruges til åbning af følgende fil- og linktyper."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s af diskpladsen bruges."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -154,7 +61,6 @@ msgid "Install some…"
 msgstr "Installér nogle …"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Åbn"
 
@@ -178,24 +84,13 @@ msgstr "Søgning"
 msgid "Receive system searches and send results."
 msgstr "Modtag systemsøgninger og send resultater."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Deaktiveret"
 
@@ -361,81 +256,21 @@ msgstr "Ryd cachen …"
 msgid "Control various application permissions and settings"
 msgstr "Kontrollér forskellige programrettigheder og -indstillinger"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "application;program;flatpak;rettighed;indstilling;applikation;tilladelse;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Vælg et billede"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Annullér"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Åbn"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "flere størrelser"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Ingen skrivebordsbaggrund"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Nuværende baggrund"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stil"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Forvalg"
 
@@ -460,7 +295,6 @@ msgstr "Udseende"
 msgid "Change your background image or the UI colors"
 msgstr "Skift dit baggrundsbillede eller brugergrænsefladens farver."
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Tapet;Baggrund;Skærm;Skrivebord;Stil;Lys;Mørk;Udseende;"
@@ -511,9 +345,7 @@ msgstr "Hardwareflytilstand er aktiv"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Sluk for kontakten Flytilstand for at aktivere Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -521,7 +353,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Slå Bluetooth til eller fra og tilslut dine enheder"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "del;deling;bluetooth;obex;"
@@ -554,90 +385,33 @@ msgstr "Ingen programmer har spurgt om adgang til kamera"
 msgid "Protect your pictures"
 msgstr "Beskyt dine billeder"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "kamera;foto;billede;video;webcam;lås;privat;privatliv;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Placér din kalibreringsenhed over firkanten og tryk “Start”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Flyt din kalibreringsenhed til kalibreringspositionen og tryk “Fortsæt”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Flyt din kalibreringsenhed til overfladepositionen og tryk “Fortsæt”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Luk computerens låg"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Der opstod en intern fejl uden mulighed for genoprettelse."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Visse værktøjer er nødvendige for kalibrering men ikke installeret."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Profilen kunne ikke genereres."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Målhvidpunktet kunne ikke opnås."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Fuldført!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrering mislykkedes!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Du kan fjerne kalibreringsenheden."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Rør ikke kalibreringsenheden når den er i gang"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Skærmenhedskalibrering"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Annullér"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -654,140 +428,6 @@ msgstr "_Genoptag"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Færdig"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Skærm for bærbar computer"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Indbygget webkamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s-skærm"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s-skanner"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s-kamera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s-printer"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s-webkamera"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Aktivér farvehåndtering for %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Vis farveprofiler for %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Ikke kalibreret"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Forvalg: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Farverum: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Testprofil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Vælg fil med ICC-profil"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importér"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Understøttede ICC-profiler"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Alle filer"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Skærm"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Gem profil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Gem"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Opret en farveprofil for den valgte enhed"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Måleinstrumentet ikke fundet. Undersøg venligst om det er tændt og korrekt "
-"tilsluttet."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Måleinstrumentet understøtter ikke profilering af printeren."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Enhedstypen er ikke er understøttet for øjeblikket."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -903,13 +543,13 @@ msgstr "Kræver skrivbart medie"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"Du vil måske finde instruktionerne om brug af profilen på systemerne <a href="
-"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> samt <a href="
-"\"windows\">Microsoft Windows</a> nyttige."
+"Du vil måske finde instruktionerne om brug af profilen på systemerne <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> samt <a "
+"href=\"windows\">Microsoft Windows</a> nyttige."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -929,7 +569,6 @@ msgstr "_Importér fil …"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -939,9 +578,7 @@ msgstr "_Tilføj"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "For at farvehåndteres skal hver enhed have en ajourført farveprofil."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Få mere at vide"
 
@@ -1073,82 +710,6 @@ msgstr "D65 (fotografi og grafik)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standardfarverum"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testprofil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatisk"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Lav kvalitet"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Middelkvalitet"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Høj kvalitet"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Standard-RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Standard-CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Standard-grå"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Fabrikskalibreringsdata fra forhandler"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Skærmkorrektion er ikke mulig i fuldskærm med denne profil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Denne profil er måske ikke længere nøjagtig"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Farver"
@@ -1159,14 +720,9 @@ msgid ""
 msgstr ""
 "Kalibrér farver til dine enheder, såsom skærme, kameraer eller printere"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Farve;ICC;Profil;Kalibrer;Printer;Skærm;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Anden …"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1181,13 +737,8 @@ msgid "No languages found"
 msgstr "Ingen sprog fundet"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Flere …"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Lås op for at ændre indstillinger"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1216,151 +767,6 @@ msgstr "Formindsk time"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Formindsk minut"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "I dag"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "I går"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d time"
-msgstr[1] "%d timer"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minut"
-msgstr[1] "%d minutter"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekund"
-msgstr[1] "%d sekunder"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekunder"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-timers"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e. %B %Y, %l:%M"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e. %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1455,17 +861,11 @@ msgstr "Automatisk tids_zone"
 msgid "Requires location services enabled and internet access"
 msgstr "Kræver internetadgang og at placeringstjenester er aktiverede"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Aktiveret"
 
@@ -1473,15 +873,42 @@ msgstr "Aktiveret"
 msgid "Time Z_one"
 msgstr "Tidsz_one"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Lås op"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format for klokkeslæt"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datoer"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekunder"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Kalender"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Tal"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Skift dato og klokkeslæt inklusive tidszone"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Ur;Tidszone;Sted;"
@@ -1527,20 +954,9 @@ msgstr "Standardprogrammer"
 msgid "Configure Default Applications"
 msgstr "Opsætning af standardprogrammer"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "standard;program;applikation;foretrukne;foretrukken;medie;medier;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Afsendelse af rapporter om tekniske problemer hjælper os med at forbedre %s. "
-"Rapporterne sendes anonymt og renses for personlige data. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1558,44 +974,9 @@ msgstr "Diagnostik"
 msgid "Report your problems"
 msgstr "Rapportér dine problemer"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostik;nedbrud;crash;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Slået til"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Slået fra"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Anvend ændringer?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Ændringer kan ikke udføres"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Dette kan skyldes hardwarebegrænsninger."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1649,31 +1030,6 @@ msgstr "Primær skærm"
 msgid "Night Light"
 msgstr "Nattelys"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Landskab"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Portræt højre"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Portræt venstre"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Landskab (omvendt)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1697,6 +1053,17 @@ msgstr "Tilpas tv"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Skalering"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Naturlig rulning"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1792,7 +1159,6 @@ msgstr "Skærme"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Vælg hvordan forbundne skærme og projektorer skal bruges"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1800,76 +1166,6 @@ msgid ""
 msgstr ""
 "Panel;Projektor;xrandr;Skærm;Opløsning;Opdatering;Opdater;Opdatér;Monitor;"
 "Nat;Lys;Blå;rødforskyd;farve;solnedgang;solopgang;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "Sikker opstart er aktiv"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Sikker opstart forhindrer, at skadelig software indlæses, når enheden "
-"starter. Den er i øjeblikket aktiveret og fungerer korrekt."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Sikker opstart har problemer"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Sikker opstart forhindrer, at skadelig software indlæses, når enheden starter."
-" Funktionen er i øjeblikket aktiveret, men virker ikke pga. en ugyldig nøgle."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Problemer med sikker opstart kan ofte løses via din computers UEFI-"
-"firmwareindstillinger (BIOS), og din hardwareproducent kan have oplysninger "
-"om, hvordan du gør dette."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "Kontakt IT-support eller hardwarefabrikanten for at få hjælp."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Sikker opstart er inaktiv"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Sikker opstart forhindrer, at skadelig software indlæses, når enheden "
-"starter. Funktionen er i øjeblikket deaktiveret."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Sikker opstart kan ofte aktiveres i din computers UEFI-firmwareindstillinger "
-"(BIOS). Kontakt IT-support eller hardwarefabrikanten for at få hjælp."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1883,129 +1179,9 @@ msgstr ""
 "\n"
 "Kontakt IT-support eller hardwarefabrikanten for flere oplysninger."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Bestået"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Mislykkedes"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Enheden lever op til HSI-niveau %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "Sikkerhedsniveau 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Denne enhed har ingen beskyttelse mod sikkerhedsproblemer med hardwaren. "
-"Dette kan skyldes et problem med konfigurationen af hardware eller firmware. "
-"Det anbefales, at du kontakter din IT-supportudbyder."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "Sikkerhedsniveau 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Denne enhed har minimal beskyttelse mod sikkerhedsproblemer med hardwaren. "
-"Dette er det laveste sikkerhedsniveau for enheden og giver kun beskyttelse "
-"mod simple sikkerhedstrusler."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "Sikkerhedsniveau 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Denne enhed har grundlæggende beskyttelse mod sikkerhedsproblemer med "
-"hardwaren. Dette giver beskyttelse mod nogle almindelige sikkerhedstrusler."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "Sikkerhedsniveau 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Denne enhed har udvidet beskyttelse mod sikkerhedsproblemer med hardwaren. "
-"Dette er det højeste sikkerhedsniveau for enheden og giver beskyttelse mod "
-"avancerede sikkerhedstrusler."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "Sikkerhedsniveau"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr "Sikkerhedsniveauer er ikke tilgængelige for denne enhed."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Kontakt hardwarefabrikanten for at få hjælp med sikkerhedsopdateringer."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Problemet kan muligvis løses i enhedens UEFI-firmwareindstillinger eller af "
-"en supporttekniker."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr "Problemet kan muligvis løses i enhedens UEFI-firmwareindstillinger."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "En supporttekniker kan måske løse problemet."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2019,338 +1195,9 @@ msgstr "Niveau 2"
 msgid "Level 3"
 msgstr "Niveau 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr "Beskyttet mod ondsindede programmer når enheden starter."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "Sikker opstart har problemer"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "Nogen beskyttelse når enheden startes."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "Sikker opstart er inaktiv"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "Ingen beskyttelse når enheden startes."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Problemet kan skyldes en ændring i UEFI-firmwareindstillingerne, en ændring "
-"af styresystemets konfiguration eller ondsindede programmer på systemet."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Problemet kan skyldes en ændring i UEFI-firmwareindstillingerne eller "
-"ondsindede programmer på systemet."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Problemet kan skyldes en ændring i styresystemets konfiguration eller "
-"ondsindede programmer på systemet."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "Udsat for alvorlige sikkerhedstrusler."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "Begrænset beskyttelse mod simple sikkerhedstrusler."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "Beskyttet mod almindelige sikkerhedstrusler."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "Beskyttet mod en bred vifte af sikkerhedstrusler."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "Omfattende beskyttelse"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Ingen begivenheder"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Skrivebeskyttelse af firmware"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Skrivebeskyttelseslås af firmware"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "BIOS-område i firmware"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "BIOS-deskriptor i firmware"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "DMA-bsekyttelse før opstart"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard-bekræftet opstart"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "ACM-beskyttelse med Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Fejlpolitik for Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard Fuse"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET aktiveret"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET aktiv"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Krypteret RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU-beskyttelse"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linuxkerne-nedlukning"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linuxkerne-bekræftelse"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linuxswap"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Sæt i hvile i RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Sæt i hvile som inaktiv"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI-platformsnøgle"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI sikker opstart"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TPM-platformskonfiguration"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM-rekonstruktion"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel Management Engine: fabrikstilstand"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Intel Management Engine: tilsidesæt"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Intel Management Engine: version"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Firmwareopdateringer"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Attestering af firmware"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Bekræftelse af firmwareopdateringsprogram"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Platformsfejlsøgning"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Sikkerhedstjek af processor"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD Rollback-beskyttelse"
-
-# https://en.wikipedia.org/wiki/Replay_attack
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD-firmwarebeskyttelse mod “replayangreb”"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Skrivebeskyttelse i AMD-firmware"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "“Fused” platform"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Gyldig"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Ugyldig"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Ikke aktiveret"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Låst"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Ikke låst"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Krypteret"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Ikke krypteret"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Forurenet"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Ikke forurenet"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Fundet"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Ikke fundet"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Understøttet"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Ikke understøttet"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2360,7 +1207,6 @@ msgstr "Enhedssikkerhed"
 msgid "Host firmware security status"
 msgstr "Værtsfirmwares sikkerhedsstatus"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2368,49 +1214,6 @@ msgid ""
 msgstr ""
 "skærm;lås;diagnostik;baglås;nedbrud;privat;seneste;midlertidig;tmp;indeks;"
 "navn;netværk;identitet;privatliv;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Ukendt"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Ukendt"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Ikke tilgængelig"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Systemlogo"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2504,11 +1307,6 @@ msgstr "Om"
 msgid "View information about your system"
 msgstr "Vis information om systemet"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2587,6 +1385,12 @@ msgstr "Programstartere"
 msgid "Launch help browser"
 msgstr "Start hjælpefremviser"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Indstillinger"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Start lommeregner"
@@ -2608,7 +1412,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Søg"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "System"
 
@@ -2657,15 +1461,6 @@ msgstr "Formindsk tekststørrelse"
 msgid "High contrast on or off"
 msgstr "Høj kontrast til eller fra"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Ingen indtastningskilder fundet"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Anden"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Tilføj en indtastningskilde"
@@ -2698,106 +1493,9 @@ msgstr "Indstillinger"
 msgid "View Keyboard Layout"
 msgstr "Vis tastaturlayout"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Fjern"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Brugertilpassede genveje"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Tast for alternative tegn"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Tasten til alternative tegn kan bruges til at indtaste yderligere tegn. De "
-"vises nogle gange som en tredje valgmulighed på dit tastatur."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Venstre Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Højre Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Venstre Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Højre Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menutast"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Højre Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Sammensætningstast"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Sammensætningstasten tillader indtastning af mange forskellige tegn. Den "
-"bruges ved at trykke tasten ned efterfulgt af en tegnsekvens. For eksempel "
-"vil sammensætningstasten sammen med <b>C</b> og <b>o</b> give <b>©</b>, og "
-"<b>a</b> efterfulgt af <b>'</b> giver <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Der kan skiftes mellem indtastningskilder med tastaturgenvejen %s.\n"
-"Dette kan ændres i indstillingerne for tastaturgenveje."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2829,45 +1527,21 @@ msgstr ""
 "Metoder til indtastning af symboler og bogstavvarianter med brug af "
 "tastaturet."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tast for alternative tegn"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Sammensætningstast"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Tastaturgenveje"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Gennemse og tilpas genveje"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d ændret"
-msgstr[1] "%d ændrede"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Nulstil alle genveje?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Nulstilling af genvejene kan påvirke dine brugertilpassede genveje. Dette "
-"kan ikke fortrydes."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Annullér"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Nulstil alle"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2905,34 +1579,6 @@ msgstr "Tilføj genvej"
 msgid "No keyboard shortcut found"
 msgstr "Ingen tastaturgenvej fundet"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s bruges allerede som %s. Hvis du erstatter den, vil %s blive slået fra"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Indtast den nye genvej"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Angiv brugertilpasset genvej"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Angiv genvej"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Indtast ny genvejstast for at ændre %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Tilføj brugertilpasset genvej"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Fjern"
@@ -2944,7 +1590,6 @@ msgstr "_Erstat"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "An_giv"
 
@@ -2982,6 +1627,11 @@ msgstr "Ingen"
 msgid "Reset the shortcut to its default value"
 msgstr "Nulstil genvejen til dens standardværdi"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Brug dit kamera"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Tastatur"
@@ -2994,7 +1644,6 @@ msgstr ""
 "Ændr tastaturgenveje og indstil dine indtastningspræferencer og -kilder samt "
 "tastaturlayout"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3036,7 +1685,6 @@ msgstr "Ingen programmer har spurgt om adgang til placering"
 msgid "Protect your location information"
 msgstr "Beskyt din placeringsinformation"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "placering;sted;lokation;gps;privat;privatliv;"
@@ -3070,7 +1718,6 @@ msgstr "Ingen programmer har spurgt om adgang til mikrofon"
 msgid "Protect your conversations"
 msgstr "Beskyt dine samtaler"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofon;optagelse;program;privatliv;"
@@ -3100,81 +1747,140 @@ msgstr "Venstre"
 msgid "Right"
 msgstr "Højre"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Søgesteder"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mus"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Musens hastighed"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Naturlig rulning"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Rul nedad"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Rulning flytter indholdet, ikke visningen."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Rulning flytter indholdet, ikke visningen."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktiv"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Pegeplade"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Pegepladens hastighed"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Tryk for at klikke"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Tryk for at klikke"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Tofingerrulning"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Deaktivér billede"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relativ)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Kantrulning"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Rul nedad"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dobbeltsidet"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Prøv at klikke, dobbeltklikke og at rulle"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Fem klik: GEGL-tid!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dobbeltklik, primær knap"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Enkeltklik, primær knap"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dobbeltklik, midterknap"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Enkeltklik, midterknap"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dobbeltklik, sekundær knap"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Enkeltklik, sekundær knap"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3187,7 +1893,6 @@ msgstr ""
 "Skift følsomhed for din mus eller pegeplade og vælg højre- eller "
 "venstrehåndstilstand"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Pegeplade;Markør;Klik;Prik;Dobbelt;Knap;Trackball;Rul;Rulning;"
@@ -3267,7 +1972,6 @@ msgstr "Multitasking"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Håndtér indstillinger for produktivitet og multitasking"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3275,20 +1979,11 @@ msgstr ""
 "Multitasking;Multitaske;Produktivitet;Tilpas;Skrivebord;Aktivt hjørne;"
 "Arbejdsområder;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Ups, der er gået noget galt. Kontakt venligst din softwareforhandler."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Netværkshåndtering skal køre."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Andre enheder"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3300,59 +1995,16 @@ msgstr "Tilføj forbindelse"
 msgid "Not set up"
 msgstr "Ikke indstillet"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Usikkert netværk (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Sikkert netværk (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Sikkert netværk (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Sikkert netværk (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Sikkert netværk"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Tilsluttet"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Indstillinger …"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Hvis der tændes for hotspottet, så afbrydes forbindelsen til %s, og det vil "
-"ikke være muligt at tilgå internettet gennem wi-fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Der skal være mindst 8 tegn"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3402,20 +2054,6 @@ msgstr "Automatisk genereret adgangskode"
 msgid "_Turn On"
 msgstr "_Tænd"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Stop hotspot og afkobl eventuelle brugere?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Stop hotspot"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Flytilstand"
@@ -3460,89 +2098,13 @@ msgstr "Synlige netværk"
 msgid "NetworkManager needs to be running"
 msgstr "Netværkshåndtering skal køre"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Ups, der er gået noget galt. Kontakt venligst din softwareforhandler."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x-_sikkerhed"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Sikkerhed"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Bevar"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Tilfældig"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabil"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"MAC-adressen, som indtastes her, bruges som hardwareadresse til "
-"netværksenheden, som forbindelsen er aktiveret på. Funktionen kaldes MAC-"
-"kloning eller -spoofing. Eksempel: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Aldrig"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3551,183 +2113,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i dag siden"
 msgstr[1] "%i dage siden"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2,4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2,4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Svag"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "OK"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "God"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Fremragende"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4-adresse"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6-adresse"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP-adresse"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Glem forbindelse"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Fjern forbindelsesprofil"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Fjern VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Detaljer"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatisk"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitet"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Slet adresse"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Slet rute"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit-nøgle (Hex eller ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit-adgangskode"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamisk WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 personlig"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3738,8 +2123,20 @@ msgstr "Signalstyrke"
 msgid "Link speed"
 msgstr "Forbindelseshastighed"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sikkerhed"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4-adresse"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-adresse"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hardwareadresse"
 
@@ -3748,12 +2145,17 @@ msgid "Supported Frequencies"
 msgstr "Understøttede frekvenser"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Standardrute"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3817,7 +2219,7 @@ msgstr "Kun link-lokal"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manuel"
 
@@ -3862,9 +2264,8 @@ msgstr "Gateway"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automatisk"
 
@@ -3917,89 +2318,9 @@ msgstr "Automatisk, kun DHCP"
 msgid "Prefix"
 msgstr "Præfiks"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Kan ikke åbne forbindelsesredigering"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Ny profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Ugyldig indstilling %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Ugyldig indstilling %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importér fra fil …"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Tilføj VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_ikkerhed"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Kan ikke importere VPN-forbindelse"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Filen “%s” kunne ikke læses, eller indeholder ikke genkendelige oplysninger "
-"om VPN-forbindelse\n"
-"\n"
-"Fejl: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Vælg fil at importere"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Der findes allerede en fil med navnet “%s”."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Erstat"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Vil du erstatte %s med den VPN-forbindelse, du er ved at gemme?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Kan ikke eksportere VPN-forbindelse"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN-forbindelsen “%s” kunne ikke eksporteres til %s.\n"
-"\n"
-"Fejl: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Eksportér VPN-forbindelse"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4013,99 +2334,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Netværk"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Angiv hvordan du forbinder til internettet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Netværk;IP;LAN;Proxy;WAN;Bredbånd;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Angiv hvordan du forbinder til trådløse netværk"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Netværk;Trådløs;Wi-fi;Wifi;IP;LAN;Bredbånd;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "aldrig"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "i dag"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "i går"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Sidst brugt"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Kabel"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Tilføj ny forbindelse"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Netværksdetaljer for de valgte netværk inklusive adgangskoder og eventuelt "
-"brugertilpasset konfiguration vil gå tabt."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Glem"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Kendte wi-fi-netværk"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Glem"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Systempolitikken forbyder brug som hotspot"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Trådløs enhed understøtter ikke hotspot-tilstand"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Der bruges autofinding af web-proxyer, når der ikke er givet en "
-"konfigurationsadresse."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Dette anbefales ikke for ubetroede offentlige netværk."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4124,6 +2382,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Leverandør"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adresse"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4208,289 +2470,6 @@ msgstr "Slå wi-fi-hotspot _til …"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Kendte wi-fi-netværk"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Status ukendt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Uhåndteret"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Utilgængelig"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Forbinder"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Godkendelse påkrævet"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Afbryder forbindelse"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Forbindelse mislykkedes"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Status ukendt (mangler)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Konfiguration mislykkedes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP-konfiguration mislykkedes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP-konfigurationen udløb"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Hemmeligheder blev påkrævet men ikke givet"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x-supplikant frakoblede"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Konfiguration af 802.1x-supplikant mislykkedes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x-supplikant fejlede"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x-supplikant brugte for lang tid på at godkende"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP-tjenesten kunne ikke starte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP-tjeneste frakoblede"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP fejlede"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP-klient kunne ikke starte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP-klientfejl"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP-klient fejlede"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Tjenesten for delt forbindelse kunne ikke starte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Tjenesten til delt forbindelse fejlede"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP-tjeneste kunne ikke starte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP-tjenestefejl"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP-tjeneste fejlede"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linjen er optaget"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Ingen ringetone"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Ingen opkobling kunne etableres"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Tidsudløb for opringningsforsøg"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Opringningsforsøg mislykkedes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Initialisering af modem mislykkedes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Kunne ikke vælge den angivne APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Søger ikke efter netværk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Netværksregistrering nægtet"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Tidsudløb ved netværksregistrering"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Kunne ikke registrere hos det forespurgte netværk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN-kontrol mislykkedes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Firmware for enheden mangler måske"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Forbindelse forsvandt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Eksisterende forbindelse blev antaget"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem ikke fundet"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth-forbindelse mislykkedes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM-kort ikke indsat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM-pin påkrævet"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM-puk påkrævet"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM forkert"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Forbindelsesforudsætning mislykkedes"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Firmware mangler"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabel ikke tilsluttet"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "udefineret fejl i 802.1X-sikkerhed (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "ingen fil valgt"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "uspecificeret fejl ved kontrol af eap-metodefil"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Private DER-, PEM-, PKCS#12- eller PGP-nøgler"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER- eller PEM-certifikater"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "mangler EAP-FAST PAC-fil"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC-filer (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4539,14 +2518,6 @@ msgstr "_Indre godkendelse"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Tillad automatisk PAC-pro_visionering"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "mangler EAP-LEAP-brugernavn"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "mangler EAP-LEAP-adgangskode"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4572,15 +2543,6 @@ msgstr "_Adgangskode"
 msgid "Sho_w password"
 msgstr "Vi_s adgangskode"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "ugyldigt CA-certifikat til EAP-PEAP: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "ugyldigt CA-certifikat til EAP-PEAP: intet certifikat angivet"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4602,7 +2564,6 @@ msgid "C_A certificate"
 msgstr "C_A-certifikat"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4617,63 +2578,6 @@ msgstr "Intet CA-certifikat _påkrævet"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP-_version"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "mangler EAP-brugernavn"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "mangler EAP-adgangskode"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "mangler EAP-TLS-identitet"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "ugyldigt CA-certifikat til EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "ugyldigt CA-certifikat til EAP-TLS: intet certifikat angivet"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "ugyldig privat nøgle til EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "ugyldigt brugercertifikat til EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Ukrypterede private nøgler er usikre"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Den valgte private nøgle lader ikke til at være beskyttet med adgangskode. "
-"Dette kan føre til, at dine sikkerhedsakkreditiver kompromitteres. Vælg "
-"venligst en privat nøgle beskyttet med adgangskode.\n"
-"\n"
-"(Du kan bruge openssh til at beskytte din private nøgle med adgangskode)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Vælg dit personlige certifikat"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Vælg din private nøgle"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4690,15 +2594,6 @@ msgstr "Privat _nøgle"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Adgangskode for _privat nøgle"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "ugyldigt CA-certifikat til EAP-TTLS: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "ugyldigt CA-certifikat til EAP-TTLS: intet certifikat angivet"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4721,14 +2616,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domæne"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Ukendt fejl ved validering af 802.1X-sikkerhed"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4756,58 +2652,10 @@ msgstr "Beskyttet EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Godkendelse"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Vælg en fil"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "mangler leap-brugernavn"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "mangler leap-adgangskode"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Adgangskode til wi-fi mangler."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Type"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "mangler web-nøgle"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "ugyldig wep-nøgle: nøgle med længde %zu må kun indeholde hex-cifre"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "ugyldig web-nøgle: nøgle med længde %zu må kun indeholde ascii-tegn"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"ugyldig wep-nøgle: forkert nøglelængde %zu. En nøgle skal have længde 5/13 "
-"(ascii) eller 10/26 (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "ugyldig wep-nøgle: adgangsfrase må ikke være tom"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "ugyldig wep-nøgle: adgangsfrase skal være kortere end 64 tegn"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4832,19 +2680,6 @@ msgstr "_Vis nøgle"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP-inde_ks"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"ugyldig wpa-psk: ugyldig nøglelængde %zu. Skal være [8, 63] byte eller 64 "
-"hex-cifre"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "ugyldig wpa-psk: kan ikke fortolke nøgle med 64 byte som hex"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4899,27 +2734,9 @@ msgstr "Påmindelser for _låst skærm"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Tilpas hvilke påmindelser der vises, og hvad de viser"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Påmindelser;Banner;Besked;Meddelelse;Statusfelt;Status;Pop;Pop-op;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Anden"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s fjernet"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Fejl ved sletning af konto"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4943,17 +2760,6 @@ msgstr "Ingen internetforbindelse — forbind for at sætte nye onlinekonti op"
 msgid "Add an account"
 msgstr "Tilføj en konto"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s-konto"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Fjern konto"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Onlinekonti"
@@ -4963,10 +2769,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Forbind til dine onlinekonti og beslut dig for hvad du vil bruge dem til"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4975,10 +2777,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Internet;Web;Online;Chat;Kalender;Post;E-post;"
 "Mail;Email;E-mail;Kontaktpersoner;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
 "ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Ukendt tid"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4994,13 +2792,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i time"
 msgstr[1] "%i timer"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5012,188 +2803,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
 msgstr[1] "minutter"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s indtil fuldt opladet"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Bemærk: %s tilbage"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s tilbage"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Fuldt opladet"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Oplader ikke"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Tomt"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Oplader"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "På batteri"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Trådløs mus"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Trådløst tastatur"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Uafbrydelig strømforsyning"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Personlig digital assistent"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobiltelefon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Medieafspiller"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tegneplade"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Computer"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Spilinputenhed"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batteri"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Hovedbatteri"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Ekstra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batterier"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Ved _tomgang"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Hvile"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Sluk"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Dvale"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Intet"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Ved batteridrift"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Ved ekstern strøm"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Aldrig"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automatisk hvile"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "Ydelsestilstand midlertidigt deaktiveret pga. for høj temperatur."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Skød detekteret: ydelsestilstand midlertidigt deaktiveret. Flyt enheden til "
-"en stabil overflade for at reaktivere."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Ydelsestilstand midlertidigt deaktiveret."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Lavt batteriniveau: strømsparetilstand aktiveret. Tidligere tilstand vil "
-"blive reaktiveret, når batteriet er tilstrækkeligt opladet."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Strømsparetilstand aktiveret af “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Ydelsestilstand aktiveret af “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5254,6 +2863,15 @@ msgstr "100 minutter"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 timer"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batteri"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Enheder"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5332,33 +2950,6 @@ msgstr "På _batteri"
 msgid "Delay"
 msgstr "Ventetid"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Ydelse"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Høj ydelse og strømforbrug."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Balanceret"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standardydelse og -strømforbrug."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Strømsparetilstand"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Reduceret ydelse og strømforbrug."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Strøm"
@@ -5367,7 +2958,6 @@ msgstr "Strøm"
 msgid "View your battery status and change power saving settings"
 msgstr "Vis din batteristatus og skift indstillinger for strømstyring"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5375,27 +2965,6 @@ msgid ""
 msgstr ""
 "Strøm;Sove;Hvile;Dvale;Batteri;Lysstyrke;Dæmp;Dæmpning;Blank;Sort;Skærm;DPMS;"
 "Tomgang;Inaktiv;Energi;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Printeren “%s” er blevet slettet"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Kunne ikke tilføje den nye printer."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Kunne ikke indlæse brugerfladen: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Lås op for at tilføje printere og ændre indstillinger"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5406,7 +2975,6 @@ msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Tilføj printere, vis udskriftsopgaver og bestem hvordan du vil udskrive"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Kø;Print;Papir;Blæk;Toner;"
@@ -5414,8 +2982,6 @@ msgstr "Printer;Kø;Print;Papir;Blæk;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Tilføj printer"
 
@@ -5456,29 +3022,6 @@ msgstr ""
 msgid "Username"
 msgstr "Brugernavn"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Detaljer for %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Ingen passende driver fundet"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Vælg PPD-fil"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript-printerbeskrivelsesfiler (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Printernavne kan ikke indeholde mellemrum, tabulatorstop, # eller /"
@@ -5487,9 +3030,7 @@ msgstr "Printernavne kan ikke indeholde mellemrum, tabulatorstop, # eller /"
 msgid "Location"
 msgstr "Placering"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Driver"
 
@@ -5517,140 +3058,20 @@ msgstr "Vælg printerdriver"
 msgid "Loading drivers database…"
 msgstr "Indlæser driverdatabase …"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Annullér"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Vælg"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect-printer"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD-printer"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Enkeltsidet"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Lang kant (standard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Kort kant (vendt)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Portræt"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Landskab"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Omvendt landskab"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Omvendt portræt"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Genoptag"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pause"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "I kø"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pause"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Godkendelse påkrævet"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "I gang"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Standset"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Annulleret"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Afbrudt"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Fuldført"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Flyt opgaven til toppen af køen"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u opgave kræver godkendelse"
 msgstr[1] "%u opgaver kræver godkendelse"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — aktive opgaver"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Indtast loginoplysninger for at printe fra %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5678,321 +3099,17 @@ msgstr "_Godkend"
 msgid "No Active Printer Jobs"
 msgstr "Ingen aktive udskriftsopgaver"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Lås printerserver op"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Lås %s op."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Indtast brugernavn og adgangskode for at se printerne på %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Søger efter printere"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Serielport"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Parallelport"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Placering: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adresse: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Serveren kræver godkendelse"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dobbeltsidet"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Papirtype"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Papirkilde"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Udskriftsbakke"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Opløsning"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript-præfiltrering"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Sider pr. ark"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dobbeltsidet"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientering"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Generelt"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Sideopsætning"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Indstillinger for installerbare enheder"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Opgaver"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Billedkvalitet"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Farver"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Færdigbehandling"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avanceret"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testside"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Testside"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Vælg automatisk"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Printers standardindstilling"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Indlejr kun GhostScript-skrifttyper"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Konvertér til PS niveau 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Konvertér til PS niveau 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Ingen præfiltrering"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Producent"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Ingen aktive opgaver"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u opgave"
 msgstr[1] "%u opgaver"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Rens printerhoveder"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Lavt tonerniveau"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Løbet tør for toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Lavt niveau af fremkaldervæske"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Løbet tør for fremkaldervæske"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Markerfarveforsyning lav"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Løbet tør for markerfarve"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Kabinet åbent"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Låge åben"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Lavt papirniveau"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Løbet tør for papir"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Ikke tilsluttet"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Standset"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Affaldsbeholderen er næsten fuld"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Affaldsbeholderen er fuld"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Den optiske billedtromle fungerer snart ikke længere"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Den optiske billedtromle fungerer ikke længere"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Klar"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Accepterer ikke opgaver"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Behandler"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6016,6 +3133,10 @@ msgstr "Rens printerhoveder"
 msgid "Remove Printer"
 msgstr "Fjern printer"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ingen aktive opgaver"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6036,16 +3157,21 @@ msgid "Restart"
 msgstr "Genstart"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Tilføj printer …"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Tilføj en printer …"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Ingen printere"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6053,7 +3179,6 @@ msgstr ""
 "Beklager! Systemets udskriftstjeneste\n"
 "    lader til at være utilgængelig."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formater"
@@ -6081,16 +3206,6 @@ msgstr "Søgninger kan være efter lande eller sprog."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Forhåndsvisning"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Britisk"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrisk"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6128,20 +3243,24 @@ msgstr ""
 "Sprogindstillingen bruges til grænsefladetekst og websider. Formater bruges "
 "til tal, datoer og valutaer."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Din konto"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Sprog"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formater"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Loginskærm"
 
@@ -6153,99 +3272,9 @@ msgstr "Region & sprog"
 msgid "Select your display language and formats"
 msgstr "Vælg sprog og formater"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Sprog;Layout;Tastatur;Input;Inddata;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Spørg hvad der skal gøres"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Gør intet"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Åbn mappe"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Andet medie"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Vælg et program til lyd-cd'er"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Vælg et program til video-dvd'er"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Vælg et program der skal køres, når der tilsluttes en musikafspiller"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Vælg et program der skal køres, når der tilsluttes et kamera"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Vælg et program til software-cd'er"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "lyd-dvd"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "blank Blu-ray-disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "blank cd-disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "blank dvd-disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "blank HD DVD-disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray-videodisk"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "e-bogslæser"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD-videodisk"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Billed-cd"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Supervideo-cd"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video-cd"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windowsprogrammer"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6295,7 +3324,6 @@ msgstr "Flytbare medier"
 msgid "Configure Removable Media settings"
 msgstr "Indstil flytbare medier"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6303,114 +3331,6 @@ msgid ""
 msgstr ""
 "enhed;system;standard;program;foretrukken;cd;dvd;usb;lyd;video;disk;flytbar;"
 "medie;autokørsel;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Skærmen slukker"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekunder"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minut"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 time"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Aldrig"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6449,41 +3369,41 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "Vis _påmindelser på låseskærm"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Påmindelser for _låst skærm"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Forbyd nye _USB-enheder"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr ""
 "Forhindr nye USB-enheder i at interagere med systemet, mens skærmen er låst."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Privatliv på skærmen"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Begræns visningsvinkel"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skærm"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Skærmindstillinger"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "skærm;lås;privat;privatliv;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Vælg sted"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6514,10 +3434,6 @@ msgstr "Andre"
 msgid "Add Location"
 msgstr "Tilføj placering"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Ingen programmer fundet"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Programsøgning"
@@ -6544,93 +3460,13 @@ msgid ""
 msgstr ""
 "Bestem hvilke programmer, der viser søgeresultater i aktivitetsoversigten"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Søg;Find;Indeks;Skjul;Privatliv;Resultater;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Ingen netværk valgt til deling"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Netværk"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Slået til"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Slået fra"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Aktiveret"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktiv"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Vælg en mappe"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Tilføj"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Aktivér mediedeling"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Fildeling lader dig dele mappen Offentligt med andre på dit nuværende "
-"netværk gennem: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Når fjernlogin er slået til, kan fjernbrugere forbinde via ssh-kommandoen "
-"(Secure Shell):\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Aktivér personlig fildeling"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Enhedsnavn kopieret"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Enhedsadresse kopieret"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Brugernavn kopieret"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Adgangskode kopieret"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6762,7 +3598,6 @@ msgstr "Mapper"
 msgid "Control what you want to share with others"
 msgstr "Bestem hvad du vil dele med andre"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6779,10 +3614,6 @@ msgstr "Slå fjernlogin til eller fra"
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Der kræves godkendelse for at kunne aktivere eller deaktivere fjernlogin"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Tilpasset"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6815,11 +3646,6 @@ msgstr "Bagved"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Foran"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Afprøver %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6873,11 +3699,6 @@ msgstr "Lydstyrke"
 msgid "Alert Sound"
 msgstr "Påmindelseslyd"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Lydløs"
@@ -6890,83 +3711,12 @@ msgstr "Lyd"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Skift lydstyrke, input, output samt påmindelseslyde"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Kort;Mikrofon;Volumen;Lydstyrke;Fade;Udtoning;Balance;Bluetooth;"
 "Hovedtelefoner;Lyd;Audio;Output;Input;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Ikke tilsluttet"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Tilslutter"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Tilsluttet"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Fejl ved godkendelse"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Godkender"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Reduceret funktionalitet"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Tilsluttet & godkendt"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Ukendt"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Godkendt:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Tilsluttet:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Registreret:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Kunne ikke godkende enhed: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Kunne ikke glemme enhed: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7000,57 +3750,6 @@ msgstr "Godkend og tilslut"
 msgid "Forget Device"
 msgstr "Glem enhed"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Fejl"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Godkendt"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Thunderbolt-undersystemet (boltd) er ikke installeret eller konfigureret "
-"korrekt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Tillad direkte adgang til enheder såsom dockingstations og eksterne GPU'er."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Kun USB- og Display Port-enheder kan forbindes."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt blev ikke detekteret.\n"
-"Enten mangler systemet understøttelse for Thunderbolt, understøttelsen er "
-"blevet slået fra i BIOS, eller BIOS er indstillet til et sikkerhedsniveau "
-"som ikke understøttes."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Understøttelse for Thunderbolt er blevet slået fra i BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Sikkerhedsniveau for Thunderbolt kunne ikke bestemmes."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Fejl ved skift til direkte tilstand: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Ingen understøttelse af Thunderbolt"
@@ -7062,6 +3761,11 @@ msgstr "Kunne ikke forbinde til Thunderbolt-undersystemet."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Direkte adgang"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Tillad direkte adgang til enheder såsom dockingstations og eksterne GPU'er."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7079,7 +3783,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Håndtér Thunderbolt-enheder"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privatliv;"
@@ -7281,40 +3984,6 @@ msgstr "_Slå til med tastatur"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Slå tilgængelighedsfaciliteter til og fra ved hjælp af tastaturet"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Standard"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Middel"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Stor"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Større"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Størst"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixler"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Vis _altid tilgængelighedsmenu"
@@ -7428,31 +4097,6 @@ msgstr "Blink med hele _skærmen"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Blink med hele _vinduet"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Kort"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ skærm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ skærm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ skærm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Lang"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7609,7 +4253,6 @@ msgstr "Farveeffekter"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Gør det nemmere at se, høre, skrive, pege og klikke"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7622,114 +4265,6 @@ msgstr ""
 "Taster;Langsomme;Rystetaster;Ryste;Mus;Musetaster;Dobbelt;Dobbeltklik;"
 "Ventetid;Forsinkelse;Hastighed;Hjælp;Gentag;Blink;visuel;synlig;høre;hørelse;"
 "indtastning;animationer;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 time"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dag"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dage"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Tøm papirkurven for alle elementer?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Alle elementer i papirkurven vil blive slettet permanent."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Tøm papirkurv"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Slet alle de midlertidige filer?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Alle de midlertidige filer vil blive slettet permanent."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Slet midlertidige filer"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dag"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dage"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dage"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Altid"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7797,64 +4332,12 @@ msgstr "Filhistorik & papirkurv"
 msgid "Don't leave traces"
 msgstr "Efterlad ingen spor"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "brug;nylig;seneste;historik;filer;midlertidig;tmp;privat;privatliv;papirkurv;"
 "tøm;tømning;bevar;behold;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Skal passe med webadressen til din loginudbyder."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Kunne ikke tilføje konto"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Adgangskoderne er ikke ens."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Kunne ikke registrere konto"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Ingen understøttet måde at godkende med dette domæne"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Kunne ikke slutte til domænet"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Det loginnavn virkede ikke.\n"
-"Prøv venligst igen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Adgangskoden for login virkede ikke.\n"
-"Prøv venligst igen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Kunne ikke logge ind på domænet"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Kan ikke finde domænet. Stavede du det forkert?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7906,10 +4389,6 @@ msgstr ""
 "Enterprise-login tillader, at der bruges en eksisterende, centralt håndteret "
 "brugerkonto på denne enhed. Du kan også bruge denne konto til at tilgå "
 "firmaressourcer på internettet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Gennemse flere billeder"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7980,222 +4459,6 @@ msgstr "_Slet fingeraftryk"
 msgid "Fingerprint Enroll"
 msgstr "Registrér fingeraftryk"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "der skal være gjort krav på enheden, før den kan udføre handlingen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "en anden proces har gjort krav på enheden"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "du har ikke tilladelse til at udføre handlingen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "ingen udskrifter er blevet registreret"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Kunne ikke kommunikere med enheden under registrering"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Kunne ikke kommunikere med fingeraftrykslæseren"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Kunne ikke kommunikere med fingeraftryksdæmonen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Kunne ikke vise fingeraftryk: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Kunne ikke slette gemte fingeraftryk: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Venstre tommelfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Venstre langfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Venstre pegefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Venstre ringfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Venstre lillefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Højre tommelfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Højre langfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Højre pegefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Højre ringfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Højre lillefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Ukendt finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Fuldført"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Fingeraftryksenhed frakoblet"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Lageret på fingeraftryksenheden er fyldt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Kunne ikke registrere nyt fingeraftryk"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Kunne ikke påbegynde registrering: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Kunne ikke registrere nyt fingeraftryk"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Kunne ikke stoppe registrering: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Løft og placér din finger gentagne gange på aflæseren for at registrere dit "
-"fingeraftryk"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Registrér fingeren igen …"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Skan nyt fingeraftryk"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Kunne ikke frigive fingeraftryksenheden %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problem ved læsning af enheden"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Kunne ikke få adgang til fingeraftryksenheden %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Kunne ikke hente fingeraftryksenhederne: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Denne uge"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Sidste uge"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Session afsluttet"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Session påbegyndt"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Kontoaktivitet"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Forrige"
@@ -8203,18 +4466,6 @@ msgstr "Forrige"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Næste"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Vælg venligst en anden adgangskode."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Indtast venligst din nuværende adgangskode igen."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Adgangskoden kunne ikke ændres"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8236,6 +4487,10 @@ msgstr "Ny adgangskode"
 msgid "Confirm Password"
 msgstr "Bekræft adgangskode"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Adgangskoderne er ikke ens."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Tillad bruger at vælge adgangskode når der logges ind næste gang"
@@ -8243,136 +4498,6 @@ msgstr "Tillad bruger at vælge adgangskode når der logges ind næste gang"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Angiv en adgangskode nu"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Kan ikke automatisk tilslutte denne type domæne"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Intet sådant domæne eller realm fundet"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Kan ikke logge ind som %s på domænet %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Ugyldig adgangskode; prøv venligst igen"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Kunne ikke forbinde til domænet %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Kunne ikke slette bruger"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Kunne ikke tilbagekalde fjernhåndteret bruger"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Du kan ikke slette din egen konto."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s er stadig logget ind"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Sletning af en bruger, mens denne stadig er logget ind, kan bringe systemet "
-"i en inkonsistent tilstand."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Vil du beholde %ss filer?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Det er muligt at beholde hjemmemappen, postarkivet samt midlertidige filer, "
-"når en brugerkonto slettes."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Slet filer"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Behold filer"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Er du sikker på, at du vil tilbagekalde den fjernhåndterede konto tilhørende "
-"%s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Slet"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Konto deaktiveret"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Vælges ved næste login"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Intet"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Logget ind"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Kunne ikke kontakte kontotjenesten"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Kontrollér venligst at AccountService er installeret og aktiveret."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Panelet skal låses op for at ændre denne indstilling"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Slet den valgte brugerkonto"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Klik først *-ikonet\n"
-"for at slette den valgte brugerkonto"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Lås op for at tilføje brugere og ændre indstillinger"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8400,7 +4525,6 @@ msgid "Full name"
 msgstr "Fulde navn"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Redigér"
 
@@ -8462,7 +4586,6 @@ msgstr "Lås op for at tilføje en brugerkonto."
 msgid "Add or remove users and change your password"
 msgstr "Tilføj eller fjern brugere og skift din adgangskode"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8507,176 +4630,6 @@ msgstr "Håndtér brugerkonti"
 msgid "Authentication is required to change user data"
 msgstr "Godkendelse påkrævet for at kunne ændre brugerdata"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Den nye adgangskode skal være forskellig fra den gamle."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Prøv at ændre nogle bogstaver og tal."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Prøv at ændre adgangskoden lidt mere."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "En adgangskode uden dit brugernavn ville være stærkere."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Prøv at undgå at bruge dit navn i adgangskoden."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Prøv at undgå nogle af ordene i adgangskoden."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Prøv at undgå almindelige ord."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Prøv at undgå at omarrangere eksisterende ord."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Prøv at bruge flere tal."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Prøv at bruge flere store bogstaver."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Prøv at bruge flere små bogstaver."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Prøv at bruge flere specialtegn, f.eks. tegnsætning."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Prøv at bruge en blanding af bogstaver, tal og tegnsætning."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Prøv at undgå at gentage samme tegn."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Prøv at undgå at gentage samme type tegn: Du skal blande bogstaver, tal og "
-"tegnsætning."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Prøv at undgå følger som 1234 eller abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Adgangskoden skal være længere. Prøv at bruge flere bogstaver, tal og andre "
-"tegn."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Bland store og små bogstaver, og brug et par tal."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Flere bogstaver, tal og andre tegn vil gøre adgangskoden stærkere."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Godkendelse mislykkedes"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Den nye adgangskode er for kort"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Den nye adgangskode er for simpel"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Der er for stor lighed mellem gammel og ny adgangskode"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Den nye adgangskode er allerede blevet brugt for nylig."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Den nye adgangskode skal indeholde tal eller specialtegn"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Gammel og ny adgangskode er ens"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Din adgangskode er ændret, siden du først godkendte!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Den nye adgangskode indeholder ikke nok forskellige tegn"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Ukendt fejl"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Brugernavnet består typisk kun af små bogstaver fra a til z, tal og følgende "
-"tegn: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Beklager, men det brugernavn er ikke tilgængeligt. Prøv et andet."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Brugernavnet er for langt."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8711,53 +4664,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Fejlklik detekteret, genstarter …"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Knap %d"
-
-# læser det som "programdefineret handling"
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Programdefineret"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Send tastetryk"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Skift skærm"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Vis hjælp på skærmen"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tegneplade monteret på den bærbares panel"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tegneplade monteret på ekstern skærm"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Ekstern tegnepladeenhed"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Ekstern enhed med tegnepladeknapper"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Alle skærme"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8855,22 +4765,6 @@ msgstr "Klik på højre museknap"
 msgid "Forward"
 msgstr "Fremad"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Airbrushpen med tryk, hældning og integreret skyder"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Airbrushpen med tryk, hældning og rotation"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standardpen med tryk og hældning"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standardpen med tryk"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom-tegneplade"
@@ -8881,54 +4775,96 @@ msgstr ""
 "Angiv tasteafbildninger og justér følsomhed for digital pen til grafiske "
 "tegneplader"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tegneplade;Wacom;Pen;Viskelæder;Mus;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Ny genvej …"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simuleret sekundært klik"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windowsprogrammer"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Lavt tonerniveau"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Sekundær"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windowsprogrammer"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Håndtér indstillinger for produktivitet og multitasking"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Adgangspunkter"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Tilføj"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Gem"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Handling afbrudt"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Fejl:</b> Adgang nægtet til at ændre indstillinger"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Fejl:</b> Fejl med mobilt udstyr"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Ikke registreret"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registreret"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Søger"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Nægtet"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8958,212 +4894,13 @@ msgstr "Eget nummer"
 msgid "Device Details"
 msgstr "Enhedsdetaljer"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Producent"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Firmwareversion"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Kun 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Kun 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Kun 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Kun 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (foretrukken), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (foretrukken), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (foretrukken), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (foretrukken), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (foretrukken), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (foretrukken), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (foretrukken), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (foretrukken), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (foretrukken), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (foretrukken), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (foretrukken), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (foretrukken), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (foretrukken), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (foretrukken), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (foretrukken), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (foretrukken), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (foretrukken)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (foretrukken), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Ukendt"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Lås simkortet op"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Lås op"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Angiv pinkoden til simkortet %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Indtast pinkoden for at låse simkortet op"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Angiv pukkoden til simkortet %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Indtast pukkoden for at låse simkortet op"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9178,26 +4915,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Du har %u forsøg tilbage"
 msgstr[1] "Du har %u forsøg tilbage"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Forkert adgangskode."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Pukkoden skal være på otte tal"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Indtast ny pinkode"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Pinkoden skal være på 4–8 tal"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Låser op …"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9255,95 +4972,6 @@ msgstr "Lås simkort med pinkode"
 msgid "M_odem Details"
 msgstr "Modem_detaljer"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Fejl ved telefon"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Ingen forbindelse til telefonen"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Handling ikke tilladt"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Handling ikke understøttet"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Simkort ikke isat"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Kræver pinkode til simkortet"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Kræver pukkode til simkortet"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Fejl ved simkortet"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Simkortet er optaget"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Forkert adgangskode"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Kræver pin2-kode til simkortet"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Kræver puk2-kode til simkortet"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Ikke fundet"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Ingen netværkstjeneste"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Tidsudløb på netværk"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS-tjenester ikke tilladt"
-
-# Teknisk begreb
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming ikke tilladt i dette lokationsområde"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Uspecificeret GPRS-fejl"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Ingen fejl"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Handling annulleret"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Adgang nægtet"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Ukendt fejl"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Netværkstilstand"
@@ -9359,11 +4987,6 @@ msgstr "Vælg netværk"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Opdatér netværksudbydere"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "Simkort %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9421,7 +5044,6 @@ msgstr "Mobilt netværk"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Indstil telefoni og mobildataforbindelser"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "mobil;wwan;telefoni;sim;simkort;"
@@ -9439,41 +5061,13 @@ msgstr ""
 msgid "The GNOME Project"
 msgstr "GNOME-projektet"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Vis versionsnummer"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Brug uddybende tilstand"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Søg efter strengen"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Vis mulige panelnavne og afslut"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel der skal vises"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT …]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Indstillingskategorier"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privatliv"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Tilgængelige paneler:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9530,7 +5124,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Afbryd søgning"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Indstillinger;Opsætning;"
@@ -9569,8 +5162,6 @@ msgstr ""
 "En tupel som indeholder programvinduets startbredde og -højde samt "
 "maksimeringstilstand."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9578,8 +5169,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u output"
 msgstr[1] "%u outputs"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9587,9 +5176,3114 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u input"
 msgstr[1] "%u inputs"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Systemlyde"
+#~ msgid "System Bus"
+#~ msgstr "Systembus"
+
+#~ msgid "Full access"
+#~ msgstr "Fuld adgang"
+
+#~ msgid "Session Bus"
+#~ msgstr "Sessionsbus"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Fuld adgang til /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Har netværksadgang"
+
+#~ msgid "Home"
+#~ msgstr "Hjem"
+
+#~ msgid "Read-only"
+#~ msgstr "Skrivebeskyttet"
+
+#~ msgid "File System"
+#~ msgstr "Filsystem"
+
+#~ msgid "Can change settings"
+#~ msgstr "Kan ændre indstillinger"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s har følgende indbyggede rettigheder. De kan ikke ændres. Er du "
+#~ "bekymret over disse rettigheder, så overvej at fjerne programmet."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u fil- og linktype som er åbnet af programmet"
+#~ msgstr[1] "%u fil- og linktyper som er åbnet af programmet"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> bruges til åbning af følgende fil- og linktyper."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s af diskpladsen bruges."
+
+#~ msgid "Select a picture"
+#~ msgstr "Vælg et billede"
+
+#~ msgid "_Open"
+#~ msgstr "_Åbn"
+
+#~ msgid "multiple sizes"
+#~ msgstr "flere størrelser"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Ingen skrivebordsbaggrund"
+
+#~ msgid "Current background"
+#~ msgstr "Nuværende baggrund"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Placér din kalibreringsenhed over firkanten og tryk “Start”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Flyt din kalibreringsenhed til kalibreringspositionen og tryk “Fortsæt”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Flyt din kalibreringsenhed til overfladepositionen og tryk “Fortsæt”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Luk computerens låg"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Der opstod en intern fejl uden mulighed for genoprettelse."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Visse værktøjer er nødvendige for kalibrering men ikke installeret."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profilen kunne ikke genereres."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Målhvidpunktet kunne ikke opnås."
+
+#~ msgid "Complete!"
+#~ msgstr "Fuldført!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrering mislykkedes!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Du kan fjerne kalibreringsenheden."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Rør ikke kalibreringsenheden når den er i gang"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Skærm for bærbar computer"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Indbygget webkamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s-skærm"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s-skanner"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s-kamera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s-printer"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s-webkamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Aktivér farvehåndtering for %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Vis farveprofiler for %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Ikke kalibreret"
+
+#~ msgid "Default: "
+#~ msgstr "Forvalg: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Farverum: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testprofil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Vælg fil med ICC-profil"
+
+#~ msgid "_Import"
+#~ msgstr "_Importér"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Understøttede ICC-profiler"
+
+#~ msgid "All files"
+#~ msgstr "Alle filer"
+
+#~ msgid "Save Profile"
+#~ msgstr "Gem profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Opret en farveprofil for den valgte enhed"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Måleinstrumentet ikke fundet. Undersøg venligst om det er tændt og "
+#~ "korrekt tilsluttet."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Måleinstrumentet understøtter ikke profilering af printeren."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Enhedstypen er ikke er understøttet for øjeblikket."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standardfarverum"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testprofil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatisk"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Lav kvalitet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Middelkvalitet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Høj kvalitet"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Standard-RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Standard-CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Standard-grå"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Fabrikskalibreringsdata fra forhandler"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Skærmkorrektion er ikke mulig i fuldskærm med denne profil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Denne profil er måske ikke længere nøjagtig"
+
+#~ msgid "Other…"
+#~ msgstr "Anden …"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Lås op for at ændre indstillinger"
+
+#~ msgid "Today"
+#~ msgstr "I dag"
+
+#~ msgid "Yesterday"
+#~ msgstr "I går"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d time"
+#~ msgstr[1] "%d timer"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minut"
+#~ msgstr[1] "%d minutter"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekund"
+#~ msgstr[1] "%d sekunder"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24-timers"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e. %B %Y, %l:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e. %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Afsendelse af rapporter om tekniske problemer hjælper os med at forbedre "
+#~ "%s. Rapporterne sendes anonymt og renses for personlige data. %s"
+
+#~ msgid "On"
+#~ msgstr "Slået til"
+
+#~ msgid "Off"
+#~ msgstr "Slået fra"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Anvend ændringer?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Ændringer kan ikke udføres"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Dette kan skyldes hardwarebegrænsninger."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Landskab"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portræt højre"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portræt venstre"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Landskab (omvendt)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Sikker opstart er aktiv"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Sikker opstart forhindrer, at skadelig software indlæses, når enheden "
+#~ "starter. Den er i øjeblikket aktiveret og fungerer korrekt."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Sikker opstart har problemer"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Sikker opstart forhindrer, at skadelig software indlæses, når enheden "
+#~ "starter. Funktionen er i øjeblikket aktiveret, men virker ikke pga. en "
+#~ "ugyldig nøgle."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Problemer med sikker opstart kan ofte løses via din computers UEFI-"
+#~ "firmwareindstillinger (BIOS), og din hardwareproducent kan have "
+#~ "oplysninger om, hvordan du gør dette."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr "Kontakt IT-support eller hardwarefabrikanten for at få hjælp."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Sikker opstart er inaktiv"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Sikker opstart forhindrer, at skadelig software indlæses, når enheden "
+#~ "starter. Funktionen er i øjeblikket deaktiveret."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Sikker opstart kan ofte aktiveres i din computers UEFI-"
+#~ "firmwareindstillinger (BIOS). Kontakt IT-support eller "
+#~ "hardwarefabrikanten for at få hjælp."
+
+#~ msgid "Passed"
+#~ msgstr "Bestået"
+
+#~ msgid "Failed"
+#~ msgstr "Mislykkedes"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Enheden lever op til HSI-niveau %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Sikkerhedsniveau 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Denne enhed har ingen beskyttelse mod sikkerhedsproblemer med hardwaren. "
+#~ "Dette kan skyldes et problem med konfigurationen af hardware eller "
+#~ "firmware. Det anbefales, at du kontakter din IT-supportudbyder."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Sikkerhedsniveau 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Denne enhed har minimal beskyttelse mod sikkerhedsproblemer med "
+#~ "hardwaren. Dette er det laveste sikkerhedsniveau for enheden og giver kun "
+#~ "beskyttelse mod simple sikkerhedstrusler."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Sikkerhedsniveau 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Denne enhed har grundlæggende beskyttelse mod sikkerhedsproblemer med "
+#~ "hardwaren. Dette giver beskyttelse mod nogle almindelige "
+#~ "sikkerhedstrusler."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Sikkerhedsniveau 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Denne enhed har udvidet beskyttelse mod sikkerhedsproblemer med "
+#~ "hardwaren. Dette er det højeste sikkerhedsniveau for enheden og giver "
+#~ "beskyttelse mod avancerede sikkerhedstrusler."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Sikkerhedsniveauer er ikke tilgængelige for denne enhed."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Kontakt hardwarefabrikanten for at få hjælp med sikkerhedsopdateringer."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Problemet kan muligvis løses i enhedens UEFI-firmwareindstillinger eller "
+#~ "af en supporttekniker."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr "Problemet kan muligvis løses i enhedens UEFI-firmwareindstillinger."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "En supporttekniker kan måske løse problemet."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Beskyttet mod ondsindede programmer når enheden starter."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Sikker opstart har problemer"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Nogen beskyttelse når enheden startes."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Sikker opstart er inaktiv"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Ingen beskyttelse når enheden startes."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Problemet kan skyldes en ændring i UEFI-firmwareindstillingerne, en "
+#~ "ændring af styresystemets konfiguration eller ondsindede programmer på "
+#~ "systemet."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Problemet kan skyldes en ændring i UEFI-firmwareindstillingerne eller "
+#~ "ondsindede programmer på systemet."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Problemet kan skyldes en ændring i styresystemets konfiguration eller "
+#~ "ondsindede programmer på systemet."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Udsat for alvorlige sikkerhedstrusler."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Begrænset beskyttelse mod simple sikkerhedstrusler."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Beskyttet mod almindelige sikkerhedstrusler."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Beskyttet mod en bred vifte af sikkerhedstrusler."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Omfattende beskyttelse"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Skrivebeskyttelse af firmware"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Skrivebeskyttelseslås af firmware"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "BIOS-område i firmware"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "BIOS-deskriptor i firmware"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "DMA-bsekyttelse før opstart"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard-bekræftet opstart"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "ACM-beskyttelse med Intel BootGuard"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Fejlpolitik for Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard Fuse"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET aktiveret"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET aktiv"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Krypteret RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU-beskyttelse"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linuxkerne-nedlukning"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linuxkerne-bekræftelse"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linuxswap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Sæt i hvile i RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Sæt i hvile som inaktiv"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI-platformsnøgle"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI sikker opstart"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM-platformskonfiguration"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM-rekonstruktion"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine: fabrikstilstand"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine: tilsidesæt"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine: version"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Firmwareopdateringer"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Attestering af firmware"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Bekræftelse af firmwareopdateringsprogram"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Platformsfejlsøgning"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Sikkerhedstjek af processor"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD Rollback-beskyttelse"
+
+# https://en.wikipedia.org/wiki/Replay_attack
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD-firmwarebeskyttelse mod “replayangreb”"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Skrivebeskyttelse i AMD-firmware"
+
+#~ msgid "Fused Platform"
+#~ msgstr "“Fused” platform"
+
+#~ msgid "Valid"
+#~ msgstr "Gyldig"
+
+#~ msgid "Not Valid"
+#~ msgstr "Ugyldig"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Ikke aktiveret"
+
+#~ msgid "Locked"
+#~ msgstr "Låst"
+
+#~ msgid "Not Locked"
+#~ msgstr "Ikke låst"
+
+#~ msgid "Encrypted"
+#~ msgstr "Krypteret"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Ikke krypteret"
+
+#~ msgid "Tainted"
+#~ msgstr "Forurenet"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Ikke forurenet"
+
+#~ msgid "Found"
+#~ msgstr "Fundet"
+
+#~ msgid "Not Found"
+#~ msgstr "Ikke fundet"
+
+#~ msgid "Supported"
+#~ msgstr "Understøttet"
+
+#~ msgid "Not Supported"
+#~ msgstr "Ikke understøttet"
+
+#~ msgid "Unknown"
+#~ msgstr "Ukendt"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Ukendt"
+
+#~ msgid "Not Available"
+#~ msgstr "Ikke tilgængelig"
+
+#~ msgid "System Logo"
+#~ msgstr "Systemlogo"
+
+#~ msgid "No input sources found"
+#~ msgstr "Ingen indtastningskilder fundet"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Anden"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Brugertilpassede genveje"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Tasten til alternative tegn kan bruges til at indtaste yderligere tegn. "
+#~ "De vises nogle gange som en tredje valgmulighed på dit tastatur."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Venstre Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Højre Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Venstre Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Højre Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menutast"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Højre Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Sammensætningstasten tillader indtastning af mange forskellige tegn. Den "
+#~ "bruges ved at trykke tasten ned efterfulgt af en tegnsekvens. For "
+#~ "eksempel vil sammensætningstasten sammen med <b>C</b> og <b>o</b> give "
+#~ "<b>©</b>, og <b>a</b> efterfulgt af <b>'</b> giver <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Der kan skiftes mellem indtastningskilder med tastaturgenvejen %s.\n"
+#~ "Dette kan ændres i indstillingerne for tastaturgenveje."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d ændret"
+#~ msgstr[1] "%d ændrede"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Nulstil alle genveje?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Nulstilling af genvejene kan påvirke dine brugertilpassede genveje. Dette "
+#~ "kan ikke fortrydes."
+
+#~ msgid "Reset All"
+#~ msgstr "Nulstil alle"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s bruges allerede som %s. Hvis du erstatter den, vil %s blive slået fra"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Indtast den nye genvej"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Angiv brugertilpasset genvej"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Angiv genvej"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Indtast ny genvejstast for at ændre %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Tilføj brugertilpasset genvej"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Tofingerrulning"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Fem klik: GEGL-tid!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dobbeltklik, primær knap"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Enkeltklik, primær knap"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dobbeltklik, midterknap"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Enkeltklik, midterknap"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dobbeltklik, sekundær knap"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Enkeltklik, sekundær knap"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Netværkshåndtering skal køre."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Usikkert netværk (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Sikkert netværk (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Sikkert netværk (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Sikkert netværk (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Sikkert netværk"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Hvis der tændes for hotspottet, så afbrydes forbindelsen til %s, og det "
+#~ "vil ikke være muligt at tilgå internettet gennem wi-fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Der skal være mindst 8 tegn"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Stop hotspot og afkobl eventuelle brugere?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Stop hotspot"
+
+#~ msgid "Preserve"
+#~ msgstr "Bevar"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "Tilfældig"
+
+#~ msgid "Stable"
+#~ msgstr "Stabil"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "MAC-adressen, som indtastes her, bruges som hardwareadresse til "
+#~ "netværksenheden, som forbindelsen er aktiveret på. Funktionen kaldes MAC-"
+#~ "kloning eller -spoofing. Eksempel: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "Never"
+#~ msgstr "Aldrig"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2,4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2,4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Svag"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "OK"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "God"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Fremragende"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Glem forbindelse"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Fjern forbindelsesprofil"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Fjern VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detaljer"
+
+#~ msgid "automatic"
+#~ msgstr "automatisk"
+
+#~ msgid "Identity"
+#~ msgstr "Identitet"
+
+#~ msgid "Delete Address"
+#~ msgstr "Slet adresse"
+
+#~ msgid "Delete Route"
+#~ msgstr "Slet rute"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit-nøgle (Hex eller ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit-adgangskode"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamisk WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 personlig"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Kan ikke åbne forbindelsesredigering"
+
+#~ msgid "New Profile"
+#~ msgstr "Ny profil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Ugyldig indstilling %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Ugyldig indstilling %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importér fra fil …"
+
+#~ msgid "Add VPN"
+#~ msgstr "Tilføj VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Kan ikke importere VPN-forbindelse"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Filen “%s” kunne ikke læses, eller indeholder ikke genkendelige "
+#~ "oplysninger om VPN-forbindelse\n"
+#~ "\n"
+#~ "Fejl: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Vælg fil at importere"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Der findes allerede en fil med navnet “%s”."
+
+#~ msgid "_Replace"
+#~ msgstr "_Erstat"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Vil du erstatte %s med den VPN-forbindelse, du er ved at gemme?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Kan ikke eksportere VPN-forbindelse"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN-forbindelsen “%s” kunne ikke eksporteres til %s.\n"
+#~ "\n"
+#~ "Fejl: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Eksportér VPN-forbindelse"
+
+#~ msgid "never"
+#~ msgstr "aldrig"
+
+#~ msgid "today"
+#~ msgstr "i dag"
+
+#~ msgid "yesterday"
+#~ msgstr "i går"
+
+#~ msgid "Last used"
+#~ msgstr "Sidst brugt"
+
+#~ msgid "Add new connection"
+#~ msgstr "Tilføj ny forbindelse"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Netværksdetaljer for de valgte netværk inklusive adgangskoder og "
+#~ "eventuelt brugertilpasset konfiguration vil gå tabt."
+
+#~ msgid "_Forget"
+#~ msgstr "_Glem"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Kendte wi-fi-netværk"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Glem"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Systempolitikken forbyder brug som hotspot"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Trådløs enhed understøtter ikke hotspot-tilstand"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Der bruges autofinding af web-proxyer, når der ikke er givet en "
+#~ "konfigurationsadresse."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Dette anbefales ikke for ubetroede offentlige netværk."
+
+#~ msgid "Status unknown"
+#~ msgstr "Status ukendt"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Uhåndteret"
+
+#~ msgid "Unavailable"
+#~ msgstr "Utilgængelig"
+
+#~ msgid "Connecting"
+#~ msgstr "Forbinder"
+
+#~ msgid "Authentication required"
+#~ msgstr "Godkendelse påkrævet"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Afbryder forbindelse"
+
+#~ msgid "Connection failed"
+#~ msgstr "Forbindelse mislykkedes"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Status ukendt (mangler)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Konfiguration mislykkedes"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP-konfiguration mislykkedes"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP-konfigurationen udløb"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Hemmeligheder blev påkrævet men ikke givet"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x-supplikant frakoblede"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Konfiguration af 802.1x-supplikant mislykkedes"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x-supplikant fejlede"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x-supplikant brugte for lang tid på at godkende"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP-tjenesten kunne ikke starte"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP-tjeneste frakoblede"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP fejlede"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP-klient kunne ikke starte"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP-klientfejl"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-klient fejlede"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Tjenesten for delt forbindelse kunne ikke starte"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Tjenesten til delt forbindelse fejlede"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP-tjeneste kunne ikke starte"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP-tjenestefejl"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP-tjeneste fejlede"
+
+#~ msgid "Line busy"
+#~ msgstr "Linjen er optaget"
+
+#~ msgid "No dial tone"
+#~ msgstr "Ingen ringetone"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Ingen opkobling kunne etableres"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Tidsudløb for opringningsforsøg"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Opringningsforsøg mislykkedes"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Initialisering af modem mislykkedes"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Kunne ikke vælge den angivne APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Søger ikke efter netværk"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Netværksregistrering nægtet"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Tidsudløb ved netværksregistrering"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Kunne ikke registrere hos det forespurgte netværk"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN-kontrol mislykkedes"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firmware for enheden mangler måske"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Forbindelse forsvandt"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Eksisterende forbindelse blev antaget"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem ikke fundet"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth-forbindelse mislykkedes"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM-kort ikke indsat"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM-pin påkrævet"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM-puk påkrævet"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM forkert"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Forbindelsesforudsætning mislykkedes"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Firmware mangler"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel ikke tilsluttet"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "udefineret fejl i 802.1X-sikkerhed (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "ingen fil valgt"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "uspecificeret fejl ved kontrol af eap-metodefil"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Private DER-, PEM-, PKCS#12- eller PGP-nøgler"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER- eller PEM-certifikater"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "mangler EAP-FAST PAC-fil"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC-filer (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "mangler EAP-LEAP-brugernavn"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "mangler EAP-LEAP-adgangskode"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "ugyldigt CA-certifikat til EAP-PEAP: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "ugyldigt CA-certifikat til EAP-PEAP: intet certifikat angivet"
+
+#~ msgid "missing EAP username"
+#~ msgstr "mangler EAP-brugernavn"
+
+#~ msgid "missing EAP password"
+#~ msgstr "mangler EAP-adgangskode"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "mangler EAP-TLS-identitet"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "ugyldigt CA-certifikat til EAP-TLS: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "ugyldigt CA-certifikat til EAP-TLS: intet certifikat angivet"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "ugyldig privat nøgle til EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "ugyldigt brugercertifikat til EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Ukrypterede private nøgler er usikre"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Den valgte private nøgle lader ikke til at være beskyttet med "
+#~ "adgangskode. Dette kan føre til, at dine sikkerhedsakkreditiver "
+#~ "kompromitteres. Vælg venligst en privat nøgle beskyttet med adgangskode.\n"
+#~ "\n"
+#~ "(Du kan bruge openssh til at beskytte din private nøgle med adgangskode)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Vælg dit personlige certifikat"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Vælg din private nøgle"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "ugyldigt CA-certifikat til EAP-TTLS: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "ugyldigt CA-certifikat til EAP-TTLS: intet certifikat angivet"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Ukendt fejl ved validering af 802.1X-sikkerhed"
+
+#~ msgid "Select a file"
+#~ msgstr "Vælg en fil"
+
+#~ msgid "missing leap-username"
+#~ msgstr "mangler leap-brugernavn"
+
+#~ msgid "missing leap-password"
+#~ msgstr "mangler leap-adgangskode"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Adgangskode til wi-fi mangler."
+
+#~ msgid "missing wep-key"
+#~ msgstr "mangler web-nøgle"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr "ugyldig wep-nøgle: nøgle med længde %zu må kun indeholde hex-cifre"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr "ugyldig web-nøgle: nøgle med længde %zu må kun indeholde ascii-tegn"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "ugyldig wep-nøgle: forkert nøglelængde %zu. En nøgle skal have længde "
+#~ "5/13 (ascii) eller 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "ugyldig wep-nøgle: adgangsfrase må ikke være tom"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "ugyldig wep-nøgle: adgangsfrase skal være kortere end 64 tegn"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "ugyldig wpa-psk: ugyldig nøglelængde %zu. Skal være [8, 63] byte eller 64 "
+#~ "hex-cifre"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "ugyldig wpa-psk: kan ikke fortolke nøgle med 64 byte som hex"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Anden"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s fjernet"
+
+#~ msgid "Error removing account"
+#~ msgstr "Fejl ved sletning af konto"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s-konto"
+
+#~ msgid "Remove Account"
+#~ msgstr "Fjern konto"
+
+#~ msgid "Unknown time"
+#~ msgstr "Ukendt tid"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s indtil fuldt opladet"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Bemærk: %s tilbage"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s tilbage"
+
+#~ msgid "Fully charged"
+#~ msgstr "Fuldt opladet"
+
+#~ msgid "Not charging"
+#~ msgstr "Oplader ikke"
+
+#~ msgid "Empty"
+#~ msgstr "Tomt"
+
+#~ msgid "Charging"
+#~ msgstr "Oplader"
+
+#~ msgid "Discharging"
+#~ msgstr "På batteri"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Trådløs mus"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Trådløst tastatur"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Uafbrydelig strømforsyning"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Personlig digital assistent"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobiltelefon"
+
+#~ msgid "Media player"
+#~ msgstr "Medieafspiller"
+
+#~ msgid "Tablet"
+#~ msgstr "Tegneplade"
+
+#~ msgid "Computer"
+#~ msgstr "Computer"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Spilinputenhed"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Hovedbatteri"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Ekstra"
+
+#~ msgid "Batteries"
+#~ msgstr "Batterier"
+
+#~ msgid "When _idle"
+#~ msgstr "Ved _tomgang"
+
+#~ msgid "Suspend"
+#~ msgstr "Hvile"
+
+#~ msgid "Power Off"
+#~ msgstr "Sluk"
+
+#~ msgid "Hibernate"
+#~ msgstr "Dvale"
+
+#~ msgid "Nothing"
+#~ msgstr "Intet"
+
+#~ msgid "When on battery power"
+#~ msgstr "Ved batteridrift"
+
+#~ msgid "When plugged in"
+#~ msgstr "Ved ekstern strøm"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Aldrig"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatisk hvile"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "Ydelsestilstand midlertidigt deaktiveret pga. for høj temperatur."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Skød detekteret: ydelsestilstand midlertidigt deaktiveret. Flyt enheden "
+#~ "til en stabil overflade for at reaktivere."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Ydelsestilstand midlertidigt deaktiveret."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Lavt batteriniveau: strømsparetilstand aktiveret. Tidligere tilstand vil "
+#~ "blive reaktiveret, når batteriet er tilstrækkeligt opladet."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Strømsparetilstand aktiveret af “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Ydelsestilstand aktiveret af “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Ydelse"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Høj ydelse og strømforbrug."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Balanceret"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standardydelse og -strømforbrug."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Strømsparetilstand"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Reduceret ydelse og strømforbrug."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Printeren “%s” er blevet slettet"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Kunne ikke tilføje den nye printer."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Kunne ikke indlæse brugerfladen: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Lås op for at tilføje printere og ændre indstillinger"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detaljer for %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Ingen passende driver fundet"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Vælg PPD-fil"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript-printerbeskrivelsesfiler (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect-printer"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD-printer"
+
+#~ msgid "One Sided"
+#~ msgstr "Enkeltsidet"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Lang kant (standard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kort kant (vendt)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portræt"
+
+#~ msgid "Landscape"
+#~ msgstr "Landskab"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Omvendt landskab"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Omvendt portræt"
+
+#~ msgid "Resume"
+#~ msgstr "Genoptag"
+
+#~ msgid "Pause"
+#~ msgstr "Pause"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "I kø"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pause"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Godkendelse påkrævet"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "I gang"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Standset"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Annulleret"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Afbrudt"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Fuldført"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Flyt opgaven til toppen af køen"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — aktive opgaver"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Indtast loginoplysninger for at printe fra %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Lås printerserver op"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Lås %s op."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Indtast brugernavn og adgangskode for at se printerne på %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Søger efter printere"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serielport"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Parallelport"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Placering: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresse: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Serveren kræver godkendelse"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dobbeltsidet"
+
+#~ msgid "Paper Type"
+#~ msgstr "Papirtype"
+
+#~ msgid "Paper Source"
+#~ msgstr "Papirkilde"
+
+#~ msgid "Output Tray"
+#~ msgstr "Udskriftsbakke"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Opløsning"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript-præfiltrering"
+
+#~ msgid "Pages per side"
+#~ msgstr "Sider pr. ark"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientering"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Generelt"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Sideopsætning"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Indstillinger for installerbare enheder"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Opgaver"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Billedkvalitet"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Farver"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Færdigbehandling"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avanceret"
+
+#~ msgid "Test page"
+#~ msgstr "Testside"
+
+#~ msgid "Auto Select"
+#~ msgstr "Vælg automatisk"
+
+#~ msgid "Printer Default"
+#~ msgstr "Printers standardindstilling"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Indlejr kun GhostScript-skrifttyper"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Konvertér til PS niveau 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Konvertér til PS niveau 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Ingen præfiltrering"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Rens printerhoveder"
+
+#~ msgid "Out of toner"
+#~ msgstr "Løbet tør for toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Lavt niveau af fremkaldervæske"
+
+#~ msgid "Out of developer"
+#~ msgstr "Løbet tør for fremkaldervæske"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Markerfarveforsyning lav"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Løbet tør for markerfarve"
+
+#~ msgid "Open cover"
+#~ msgstr "Kabinet åbent"
+
+#~ msgid "Open door"
+#~ msgstr "Låge åben"
+
+#~ msgid "Low on paper"
+#~ msgstr "Lavt papirniveau"
+
+#~ msgid "Out of paper"
+#~ msgstr "Løbet tør for papir"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Ikke tilsluttet"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Standset"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Affaldsbeholderen er næsten fuld"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Affaldsbeholderen er fuld"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Den optiske billedtromle fungerer snart ikke længere"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Den optiske billedtromle fungerer ikke længere"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Klar"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Accepterer ikke opgaver"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Behandler"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Britisk"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrisk"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Spørg hvad der skal gøres"
+
+#~ msgid "Do nothing"
+#~ msgstr "Gør intet"
+
+#~ msgid "Open folder"
+#~ msgstr "Åbn mappe"
+
+#~ msgid "Other Media"
+#~ msgstr "Andet medie"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Vælg et program til lyd-cd'er"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Vælg et program til video-dvd'er"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Vælg et program der skal køres, når der tilsluttes en musikafspiller"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Vælg et program der skal køres, når der tilsluttes et kamera"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Vælg et program til software-cd'er"
+
+#~ msgid "audio DVD"
+#~ msgstr "lyd-dvd"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "blank Blu-ray-disk"
+
+#~ msgid "blank CD disc"
+#~ msgstr "blank cd-disk"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "blank dvd-disk"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "blank HD DVD-disk"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray-videodisk"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-bogslæser"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD-videodisk"
+
+#~ msgid "Picture CD"
+#~ msgstr "Billed-cd"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Supervideo-cd"
+
+#~ msgid "Video CD"
+#~ msgstr "Video-cd"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Skærmen slukker"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekunder"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minut"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 time"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Aldrig"
+
+#~ msgid "Select Location"
+#~ msgstr "Vælg sted"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Ingen programmer fundet"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Ingen netværk valgt til deling"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Slået til"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Slået fra"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Aktiveret"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktiv"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Vælg en mappe"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Aktivér mediedeling"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Fildeling lader dig dele mappen Offentligt med andre på dit nuværende "
+#~ "netværk gennem: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Når fjernlogin er slået til, kan fjernbrugere forbinde via ssh-kommandoen "
+#~ "(Secure Shell):\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Aktivér personlig fildeling"
+
+#~ msgid "Device name copied"
+#~ msgstr "Enhedsnavn kopieret"
+
+#~ msgid "Device address copied"
+#~ msgstr "Enhedsadresse kopieret"
+
+#~ msgid "Username copied"
+#~ msgstr "Brugernavn kopieret"
+
+#~ msgid "Password copied"
+#~ msgstr "Adgangskode kopieret"
+
+#~ msgid "Custom"
+#~ msgstr "Tilpasset"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Afprøver %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Ikke tilsluttet"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Tilslutter"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Tilsluttet"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Fejl ved godkendelse"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Godkender"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Reduceret funktionalitet"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Tilsluttet & godkendt"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Ukendt"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Godkendt:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Tilsluttet:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Registreret:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Kunne ikke godkende enhed: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Kunne ikke glemme enhed: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Fejl"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Godkendt"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt-undersystemet (boltd) er ikke installeret eller konfigureret "
+#~ "korrekt."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Kun USB- og Display Port-enheder kan forbindes."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt blev ikke detekteret.\n"
+#~ "Enten mangler systemet understøttelse for Thunderbolt, understøttelsen er "
+#~ "blevet slået fra i BIOS, eller BIOS er indstillet til et sikkerhedsniveau "
+#~ "som ikke understøttes."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Understøttelse for Thunderbolt er blevet slået fra i BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Sikkerhedsniveau for Thunderbolt kunne ikke bestemmes."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Fejl ved skift til direkte tilstand: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Standard"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Middel"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Stor"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Større"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Størst"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixler"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kort"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ skærm"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ skærm"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ skærm"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Lang"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 time"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dag"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dage"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dage"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dage"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dage"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dage"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dage"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dage"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dage"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Tøm papirkurven for alle elementer?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Alle elementer i papirkurven vil blive slettet permanent."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Tøm papirkurv"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Slet alle de midlertidige filer?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Alle de midlertidige filer vil blive slettet permanent."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Slet midlertidige filer"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dag"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dage"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dage"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Altid"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Skal passe med webadressen til din loginudbyder."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Kunne ikke tilføje konto"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Kunne ikke registrere konto"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Ingen understøttet måde at godkende med dette domæne"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Kunne ikke slutte til domænet"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Det loginnavn virkede ikke.\n"
+#~ "Prøv venligst igen."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Adgangskoden for login virkede ikke.\n"
+#~ "Prøv venligst igen."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Kunne ikke logge ind på domænet"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Kan ikke finde domænet. Stavede du det forkert?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Gennemse flere billeder"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "der skal være gjort krav på enheden, før den kan udføre handlingen"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "en anden proces har gjort krav på enheden"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "du har ikke tilladelse til at udføre handlingen"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "ingen udskrifter er blevet registreret"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Kunne ikke kommunikere med enheden under registrering"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Kunne ikke kommunikere med fingeraftrykslæseren"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Kunne ikke kommunikere med fingeraftryksdæmonen"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Kunne ikke vise fingeraftryk: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Kunne ikke slette gemte fingeraftryk: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Venstre tommelfinger"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Venstre langfinger"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Venstre pegefinger"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Venstre ringfinger"
+
+#~ msgid "Left little finger"
+#~ msgstr "Venstre lillefinger"
+
+#~ msgid "Right thumb"
+#~ msgstr "Højre tommelfinger"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Højre langfinger"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Højre pegefinger"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Højre ringfinger"
+
+#~ msgid "Right little finger"
+#~ msgstr "Højre lillefinger"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Ukendt finger"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Fuldført"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Fingeraftryksenhed frakoblet"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Lageret på fingeraftryksenheden er fyldt"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Kunne ikke registrere nyt fingeraftryk"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Kunne ikke påbegynde registrering: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Kunne ikke registrere nyt fingeraftryk"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Kunne ikke stoppe registrering: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Løft og placér din finger gentagne gange på aflæseren for at registrere "
+#~ "dit fingeraftryk"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Registrér fingeren igen …"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Skan nyt fingeraftryk"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Kunne ikke frigive fingeraftryksenheden %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problem ved læsning af enheden"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Kunne ikke få adgang til fingeraftryksenheden %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Kunne ikke hente fingeraftryksenhederne: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Denne uge"
+
+#~ msgid "Last Week"
+#~ msgstr "Sidste uge"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Session afsluttet"
+
+#~ msgid "Session Started"
+#~ msgstr "Session påbegyndt"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Kontoaktivitet"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Vælg venligst en anden adgangskode."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Indtast venligst din nuværende adgangskode igen."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Adgangskoden kunne ikke ændres"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Kan ikke automatisk tilslutte denne type domæne"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Intet sådant domæne eller realm fundet"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Kan ikke logge ind som %s på domænet %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Ugyldig adgangskode; prøv venligst igen"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Kunne ikke forbinde til domænet %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Kunne ikke slette bruger"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Kunne ikke tilbagekalde fjernhåndteret bruger"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Du kan ikke slette din egen konto."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s er stadig logget ind"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Sletning af en bruger, mens denne stadig er logget ind, kan bringe "
+#~ "systemet i en inkonsistent tilstand."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Vil du beholde %ss filer?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Det er muligt at beholde hjemmemappen, postarkivet samt midlertidige "
+#~ "filer, når en brugerkonto slettes."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Slet filer"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Behold filer"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Er du sikker på, at du vil tilbagekalde den fjernhåndterede konto "
+#~ "tilhørende %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Slet"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Konto deaktiveret"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Vælges ved næste login"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Intet"
+
+#~ msgid "Logged in"
+#~ msgstr "Logget ind"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Kunne ikke kontakte kontotjenesten"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Kontrollér venligst at AccountService er installeret og aktiveret."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Panelet skal låses op for at ændre denne indstilling"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Slet den valgte brugerkonto"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klik først *-ikonet\n"
+#~ "for at slette den valgte brugerkonto"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Lås op for at tilføje brugere og ændre indstillinger"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Den nye adgangskode skal være forskellig fra den gamle."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Prøv at ændre nogle bogstaver og tal."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Prøv at ændre adgangskoden lidt mere."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "En adgangskode uden dit brugernavn ville være stærkere."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Prøv at undgå at bruge dit navn i adgangskoden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Prøv at undgå nogle af ordene i adgangskoden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Prøv at undgå almindelige ord."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Prøv at undgå at omarrangere eksisterende ord."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Prøv at bruge flere tal."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Prøv at bruge flere store bogstaver."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Prøv at bruge flere små bogstaver."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Prøv at bruge flere specialtegn, f.eks. tegnsætning."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Prøv at bruge en blanding af bogstaver, tal og tegnsætning."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Prøv at undgå at gentage samme tegn."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Prøv at undgå at gentage samme type tegn: Du skal blande bogstaver, tal "
+#~ "og tegnsætning."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Prøv at undgå følger som 1234 eller abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Adgangskoden skal være længere. Prøv at bruge flere bogstaver, tal og "
+#~ "andre tegn."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Bland store og små bogstaver, og brug et par tal."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "Flere bogstaver, tal og andre tegn vil gøre adgangskoden stærkere."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Godkendelse mislykkedes"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Den nye adgangskode er for kort"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Den nye adgangskode er for simpel"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Der er for stor lighed mellem gammel og ny adgangskode"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Den nye adgangskode er allerede blevet brugt for nylig."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Den nye adgangskode skal indeholde tal eller specialtegn"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Gammel og ny adgangskode er ens"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Din adgangskode er ændret, siden du først godkendte!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Den nye adgangskode indeholder ikke nok forskellige tegn"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Ukendt fejl"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Brugernavnet består typisk kun af små bogstaver fra a til z, tal og "
+#~ "følgende tegn: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Beklager, men det brugernavn er ikke tilgængeligt. Prøv et andet."
+
+#~ msgid "The username is too long."
+#~ msgstr "Brugernavnet er for langt."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Knap %d"
+
+# læser det som "programdefineret handling"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Programdefineret"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Send tastetryk"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Skift skærm"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Vis hjælp på skærmen"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tegneplade monteret på den bærbares panel"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tegneplade monteret på ekstern skærm"
+
+#~ msgid "External tablet device"
+#~ msgstr "Ekstern tegnepladeenhed"
+
+#~ msgid "All Displays"
+#~ msgstr "Alle skærme"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Airbrushpen med tryk, hældning og integreret skyder"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Airbrushpen med tryk, hældning og rotation"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standardpen med tryk og hældning"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standardpen med tryk"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Ny genvej …"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Handling afbrudt"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Fejl:</b> Adgang nægtet til at ændre indstillinger"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Fejl:</b> Fejl med mobilt udstyr"
+
+#~ msgid "Not Registered"
+#~ msgstr "Ikke registreret"
+
+#~ msgid "Registered"
+#~ msgstr "Registreret"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Søger"
+
+#~ msgid "Denied"
+#~ msgstr "Nægtet"
+
+#~ msgid "2G Only"
+#~ msgstr "Kun 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Kun 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Kun 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Kun 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (foretrukken)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (foretrukken), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (foretrukken), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (foretrukken), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (foretrukken)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (foretrukken), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (foretrukken), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (foretrukken)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (foretrukken), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (foretrukken), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (foretrukken)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (foretrukken), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (foretrukken), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (foretrukken)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (foretrukken), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (foretrukken), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (foretrukken)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (foretrukken), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (foretrukken)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (foretrukken), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (foretrukken)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (foretrukken), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (foretrukken)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (foretrukken), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (foretrukken)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (foretrukken), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (foretrukken)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (foretrukken), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Ukendt"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Lås simkortet op"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Angiv pinkoden til simkortet %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Indtast pinkoden for at låse simkortet op"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Angiv pukkoden til simkortet %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Indtast pukkoden for at låse simkortet op"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Forkert adgangskode."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Pukkoden skal være på otte tal"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Indtast ny pinkode"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Pinkoden skal være på 4–8 tal"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Låser op …"
+
+#~ msgid "Phone failure"
+#~ msgstr "Fejl ved telefon"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Ingen forbindelse til telefonen"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Handling ikke tilladt"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Handling ikke understøttet"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Simkort ikke isat"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Kræver pinkode til simkortet"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Kræver pukkode til simkortet"
+
+#~ msgid "SIM failure"
+#~ msgstr "Fejl ved simkortet"
+
+#~ msgid "SIM busy"
+#~ msgstr "Simkortet er optaget"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Forkert adgangskode"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Kræver pin2-kode til simkortet"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Kræver puk2-kode til simkortet"
+
+#~ msgid "Not found"
+#~ msgstr "Ikke fundet"
+
+#~ msgid "No network service"
+#~ msgstr "Ingen netværkstjeneste"
+
+#~ msgid "Network timeout"
+#~ msgstr "Tidsudløb på netværk"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS-tjenester ikke tilladt"
+
+# Teknisk begreb
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming ikke tilladt i dette lokationsområde"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Uspecificeret GPRS-fejl"
+
+#~ msgid "No Error"
+#~ msgstr "Ingen fejl"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Handling annulleret"
+
+#~ msgid "Access denied"
+#~ msgstr "Adgang nægtet"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Ukendt fejl"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "Simkort %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Vis versionsnummer"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Brug uddybende tilstand"
+
+#~ msgid "Search for the string"
+#~ msgstr "Søg efter strengen"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Vis mulige panelnavne og afslut"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel der skal vises"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT …]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Tilgængelige paneler:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Systemlyde"
 
 #~ msgid "Light"
 #~ msgstr "Lys"
@@ -9612,9 +8306,6 @@ msgstr "Systemlyde"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER- eller PEM-certifikater (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Tilføj en printer …"
 
 #~ msgid "Bark"
 #~ msgstr "Gø"
@@ -9739,11 +8430,11 @@ msgstr "Systemlyde"
 #~ msgstr "Kan ikke ændres"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "Programmers individuelle rettigheder kan gennemses i <a href=\"privacy"
-#~ "\">privatlivsindstillingerne</a>."
+#~ "Programmers individuelle rettigheder kan gennemses i <a "
+#~ "href=\"privacy\">privatlivsindstillingerne</a>."
 
 #~ msgid "Integration"
 #~ msgstr "Integration"
@@ -9982,9 +8673,6 @@ msgstr "Systemlyde"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tegneplade (absolut)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Touchpad (relativ)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Indstillinger for tegneplade"
 
@@ -10146,9 +8834,6 @@ msgstr "Systemlyde"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Tilgå bluetoothhardware direkte"
-
-#~ msgid "Use your camera"
-#~ msgstr "Brug dit kamera"
 
 #~ msgid "Print documents"
 #~ msgstr "Udskriv dokumenter"
@@ -10979,9 +9664,6 @@ msgstr "Systemlyde"
 #~ msgid "Uni­ver­sal Access"
 #~ msgstr "Til­gæn­ge­lig­hed"
 
-#~ msgid "Disable image"
-#~ msgstr "Deaktivér billede"
-
 #~ msgid "Browse for more pictures…"
 #~ msgstr "Gennemse flere billeder …"
 
@@ -11004,9 +9686,6 @@ msgstr "Systemlyde"
 
 #~ msgid "Mirrored"
 #~ msgstr "Klonede"
-
-#~ msgid "Secondary"
-#~ msgstr "Sekundær"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Arrangér kombinerede skærme"
@@ -11175,9 +9854,6 @@ msgstr "Systemlyde"
 #~ msgid "Mail"
 #~ msgstr "Post"
 
-#~ msgid "Calendar"
-#~ msgstr "Kalender"
-
 #~ msgid "Contacts"
 #~ msgstr "Kontakter"
 
@@ -11329,9 +10005,6 @@ msgstr "Systemlyde"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Rul opad"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Rul nedad"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Rul til højre"

--- a/po/da.po~
+++ b/po/da.po~
@@ -1,0 +1,11487 @@
+# Danish translation of the Gnome Control Center.
+# Copyright (C) 1998-2018
+# This file is distributed under the same license as the gnome-control-center package.
+# Kenneth Christiansen <kenneth@ripen.dk>, 1998-2000.
+# Birger Langkjer <birger.langkjer@image.dk>.
+# Keld Simonsen <keld@dkuug.dk>, 2000.
+# Ole Laursen <olau@hardworking.dk>, 2001, 02, 03, 04, 06.
+# Martin Willemoes Hansen <mwh@sysrq.dk>, 2004, 05.
+# Lasse Bang Mikkelsen <lbm@fatalerror.dk>, 2006.
+# flemming christensen <fc@stromata.dk>, 2011.
+# Kris Thomsen <mail@kristhomsen.dk>, 2014.
+# Ask Hjorth Larsen <asklarsen@gmail.com>, 2007, 08, 09, 10, 11, 12, 13, 14, 15, 16, 17, 18.
+# scootergrisen, 2015-2016, 2019-2020.
+# Alan Mortensen <alanmortensen.am@gmail.com>, 2019-22.
+#
+# Konventioner:
+#
+#   detach -> frigøre
+#   display -> skærm (fysisk)
+#           -> skærmvisning (logisk, når der skal skelnes; ellers skærm)
+#   extension -> endelse (det refererer nemlig som regel til f.eks. '.html')
+#   GL -> 3d
+#   help browser -> hjælpefremviser
+#   properties -> indstillinger
+#   torn off -> frigøre
+#   typing break -> tastepause
+#   toggle key -> skiftetast
+#   modifier key -> modifikationstast
+#   universal access -> tilgængelighed (med mindre nogen kan finde grund til at der bør skelnes)
+#
+# Vær opmærksom på at ordet key bruges både i betydningen nøgle og (genvejs)tast
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"PO-Revision-Date: 2022-08-27 12:39+0200\n"
+"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
+"Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.3\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Systembus"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Fuld adgang"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Sessionsbus"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Enheder"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Fuld adgang til /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Netværk"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Har netværksadgang"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Hjem"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Skrivebeskyttet"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Filsystem"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Indstillinger"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Kan ændre indstillinger"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s har følgende indbyggede rettigheder. De kan ikke ændres. Er du bekymret "
+"over disse rettigheder, så overvej at fjerne programmet."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u fil- og linktype som er åbnet af programmet"
+msgstr[1] "%u fil- og linktyper som er åbnet af programmet"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> bruges til åbning af følgende fil- og linktyper."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s af diskpladsen bruges."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Programmer"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Ingen programmer"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Installér nogle …"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Åbn"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Vis detaljer"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Søgning"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Modtag systemsøgninger og send resultater."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Deaktiveret"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Påmindelser"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Vis systempåmindelser."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Kør i baggrunden"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Tillad aktivitet, når programmet er lukket."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Skærmbilleder"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Tag billeder af skærmen når som helst."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Skift baggrundstapet"
+
+# Jeg går ud fra at disse ikke skal oversættes
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Skift skrivebordets baggrundstapet."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Lyde"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Gengiv lyde."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Forhindr genveje"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Blokér standardtastaturgenveje."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Tag billeder med kameraet."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Optag lyd med mikrofonen."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Placeringstjenester"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Tilgå enhedens placeringsdata."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Indbyggede rettigheder"
+
+# Lignende har afsluttende .
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Systemadgang som kræves af programmet."
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Fil- og linktilknytninger"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Lager"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Ingen resultater fundet"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Prøv en anden søgning"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Fil- og linktilknytninger"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Filtyper"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Linktyper"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Nulstil"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "Hvor meget diskplads dette program med programdata og cache bruger."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Program"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Ryd cachen …"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Kontrollér forskellige programrettigheder og -indstillinger"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"application;program;flatpak;rettighed;indstilling;applikation;tilladelse;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Vælg et billede"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Annullér"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Åbn"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "flere størrelser"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Ingen skrivebordsbaggrund"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Nuværende baggrund"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stil"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Forvalg"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Mørk"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Baggrund"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Tilføj billede …"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Udseende"
+
+# Lignende har .
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Skift dit baggrundsbillede eller brugergrænsefladens farver."
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Tapet;Baggrund;Skærm;Skrivebord;Stil;Lys;Mørk;Udseende;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Aktivér"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Ingen Bluetooth fundet"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Indsæt en dongle for at bruge Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth er slukket"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Tænd for at tilslutte enheder og modtage filoverførsler."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Flytilstand er aktiv"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth er deaktiveret når flytilstand er aktiv."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Deaktivér flytilstand"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Hardwareflytilstand er aktiv"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Sluk for kontakten Flytilstand for at aktivere Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Slå Bluetooth til eller fra og tilslut dine enheder"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "del;deling;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kameraet er slukket"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Ingen programmer kan optage billeder eller video."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Brug af kameraet tillader programmer at optage billeder og videoer. "
+"Deaktiveres kameraet, vil nogle programmer måske ikke virke korrekt.\n"
+"\n"
+"Tillad, at programmerne neden for bruger dit kamera."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Ingen programmer har spurgt om adgang til kamera"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Beskyt dine billeder"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "kamera;foto;billede;video;webcam;lås;privat;privatliv;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Placér din kalibreringsenhed over firkanten og tryk “Start”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Flyt din kalibreringsenhed til kalibreringspositionen og tryk “Fortsæt”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Flyt din kalibreringsenhed til overfladepositionen og tryk “Fortsæt”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Luk computerens låg"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Der opstod en intern fejl uden mulighed for genoprettelse."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Visse værktøjer er nødvendige for kalibrering men ikke installeret."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Profilen kunne ikke genereres."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Målhvidpunktet kunne ikke opnås."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Fuldført!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrering mislykkedes!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Du kan fjerne kalibreringsenheden."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Rør ikke kalibreringsenheden når den er i gang"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Skærmenhedskalibrering"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Start"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Genoptag"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Færdig"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Skærm for bærbar computer"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Indbygget webkamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s-skærm"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s-skanner"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s-kamera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s-printer"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s-webkamera"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Aktivér farvehåndtering for %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Vis farveprofiler for %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Ikke kalibreret"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Forvalg: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Farverum: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Testprofil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Vælg fil med ICC-profil"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importér"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Understøttede ICC-profiler"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Alle filer"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skærm"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Gem profil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Gem"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Opret en farveprofil for den valgte enhed"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Måleinstrumentet ikke fundet. Undersøg venligst om det er tændt og korrekt "
+"tilsluttet."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Måleinstrumentet understøtter ikke profilering af printeren."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Enhedstypen er ikke er understøttet for øjeblikket."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Skærmkalibrering"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibreringskvalitet"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrering vil give en profil, du kan bruge til farvehåndtering for din "
+"skærm. Jo længere du kalibrerer, jo bedre bliver farveprofilen."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Du vil ikke kunne bruge din computer mens kalibreringen finder sted."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kvalitet"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Anslået tidsforbrug"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibreringsenhed"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Vælg den sensorenhed, du vil bruge til kalibreringen."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Type af skærmenhed"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Vælg typen af skærmenhed, der er tilsluttet."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Hvidpunkt for profil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Vælg et målhvidpunkt for skærmenheden. De fleste enheder bør kalibreres til "
+"en D65-illuminant."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Skærmlysstyrke"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Sæt venligst skærmenheden til en lysstyrke, der er typisk for dig. "
+"Farvehåndteringen vil være mest nøjagtig ved dette lysniveau."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativt kan du bruge lysstyrkeniveauet fra en af de andre profiler med "
+"denne enhed."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profilnavn"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Du kan bruge en farveprofil på forskellige computere, eller endda oprette "
+"profiler for forskellige lysbetingelser."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profilnavn:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Sammenfatning"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profilen blev oprettet!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopiér profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Kræver skrivbart medie"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Du vil måske finde instruktionerne om brug af profilen på systemerne <a href="
+"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> samt <a href="
+"\"windows\">Microsoft Windows</a> nyttige."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Tilføj profil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Der er blevet fundet problemer. Profilen vil måske ikke fungere korrekt. <a "
+"href=\"\">Vis detaljer.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importér fil …"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Tilføj"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "For at farvehåndteres skal hver enhed have en ajourført farveprofil."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Få mere at vide"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Få mere at vide om farvehåndtering"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Indstil for alle brugere"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Brug denne profil for alle brugere på denne computer"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Aktivér"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Tilføj profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrér …"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibrér enheden"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Fjern profil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Vis detaljer"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Kan ikke finde nogen enheder, hvortil der kan bruges farvehåndtering"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL-bagbelysning)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED-bagbelysning)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (hvid LED-bagbelysning)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Bred-gamut-LCD (CCFL-bagbelysning)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Bred-gamut-LCD (RGB LED-bagbelysning)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Høj"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutter"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Middel"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutter"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Lav"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutter"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "“Native” der skal vises"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (udskrift og publikation)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografi og grafik)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standardfarverum"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testprofil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatisk"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Lav kvalitet"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Middelkvalitet"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Høj kvalitet"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Standard-RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Standard-CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Standard-grå"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Fabrikskalibreringsdata fra forhandler"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Skærmkorrektion er ikke mulig i fuldskærm med denne profil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Denne profil er måske ikke længere nøjagtig"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Farver"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Kalibrér farver til dine enheder, såsom skærme, kameraer eller printere"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Farve;ICC;Profil;Kalibrer;Printer;Skærm;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Anden …"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Vælg sprog"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Vælg"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Ingen sprog fundet"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Flere …"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Lås op for at ændre indstillinger"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Nogle indstillinger skal låses op for at kunne ændres."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Lås op …"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Forøg time"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Forøg minut"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Klokkeslæt"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Formindsk time"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Formindsk minut"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "I dag"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "I går"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d time"
+msgstr[1] "%d timer"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minut"
+msgstr[1] "%d minutter"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekund"
+msgstr[1] "%d sekunder"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekunder"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-timers"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e. %B %Y, %l:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e. %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Dato & klokkeslæt"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "År"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Måned"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januar"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Marts"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maj"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juni"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juli"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "December"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dag"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Tidszone"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Søg efter en by"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatisk _dato & klokkeslæt"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Kræver internetadgang"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Dato & _klokkeslæt"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automatisk tids_zone"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Kræver internetadgang og at placeringstjenester er aktiverede"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Aktiveret"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Tidsz_one"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Format for klokkeslæt"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Skift dato og klokkeslæt inklusive tidszone"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Ur;Tidszone;Sted;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Skift systemindstillinger for tidspunkt og dato"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Du skal godkende for at kunne ændre indstillinger for tid og dato."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Post"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalender"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Musik"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Billeder"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Standardprogrammer"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Opsætning af standardprogrammer"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "standard;program;applikation;foretrukne;foretrukken;medie;medier;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Afsendelse af rapporter om tekniske problemer hjælper os med at forbedre %s. "
+"Rapporterne sendes anonymt og renses for personlige data. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Problemrapportering"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatisk problemrapportering"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostik"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Rapportér dine problemer"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostik;nedbrud;crash;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Slået til"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Slået fra"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Anvend ændringer?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Ændringer kan ikke udføres"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Dette kan skyldes hardwarebegrænsninger."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Anvend"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Tilbage"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Skærmindstillinger deaktiveret"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Flere skærme"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Side om side"
+
+# scootergrisen: tjek om det skal være Kloning frem for Klon.
+# scootergrisen: både i gnome-shell og gnome-control-center
+# scootergrisen: lader til Kloning er bedst i gnome-control-center
+# scootergrisen: men det ville nok være bedst hvis de var ens
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Klon"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Indeholder toplinjen og Aktiviteter"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Primær skærm"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Nattelys"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Landskab"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portræt højre"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portræt venstre"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Landskab (omvendt)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientering"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Opløsning"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Opdateringsfrekvens"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Tilpas tv"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skalering"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nattelys utilgængeligt"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Det kan skyldes, at grafikdriveren er i brug, eller at skrivebordet bruges "
+"over netværk"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Midlertidigt slået fra indtil i morgen"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Genstart filter"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Nattelys gør skærmfarven varmere. Det kan hjælpe med at forhindre "
+"anstrengelse af øjnene og søvnløshed."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Tidsplan"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Solnedgang til solopgang"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Manuel tidsplan"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Tider"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Fra"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Time"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minut"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Til"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Farvetemperatur"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Skærme"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Vælg hvordan forbundne skærme og projektorer skal bruges"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projektor;xrandr;Skærm;Opløsning;Opdatering;Opdater;Opdatér;Monitor;"
+"Nat;Lys;Blå;rødforskyd;farve;solnedgang;solopgang;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:109
+msgid "Secure Boot is Active"
+msgstr "Sikker opstart er aktiv"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Sikker opstart forhindrer, at skadelig software indlæses, når enheden "
+"starter. Den er i øjeblikket aktiveret og fungerer korrekt."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Sikker opstart har problemer"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Sikker opstart forhindrer, at skadelig software indlæses, når enheden starter."
+" Funktionen er i øjeblikket aktiveret, men virker ikke pga. en ugyldig nøgle."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Problemer med sikker opstart kan ofte løses via din computers UEFI-"
+"firmwareindstillinger (BIOS), og din hardwareproducent kan have oplysninger "
+"om, hvordan du gør dette."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "Kontakt IT-support eller hardwarefabrikanten for at få hjælp."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Sikker opstart er inaktiv"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Sikker opstart forhindrer, at skadelig software indlæses, når enheden "
+"starter. Funktionen er i øjeblikket deaktiveret."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Sikker opstart kan ofte aktiveres i din computers UEFI-firmwareindstillinger "
+"(BIOS). Kontakt IT-support eller hardwarefabrikanten for at få hjælp."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Sikker opstart forhindrer, at skadelig software indlæses, når enheden "
+"starter. \n"
+"\n"
+"Kontakt IT-support eller hardwarefabrikanten for flere oplysninger."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Bestået"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Mislykkedes"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Enheden lever op til HSI-niveau %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:482
+msgid "Security Level 0"
+msgstr "Sikkerhedsniveau 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Denne enhed har ingen beskyttelse mod sikkerhedsproblemer med hardwaren. "
+"Dette kan skyldes et problem med konfigurationen af hardware eller firmware. "
+"Det anbefales, at du kontakter din IT-supportudbyder."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:489
+msgid "Security Level 1"
+msgstr "Sikkerhedsniveau 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Denne enhed har minimal beskyttelse mod sikkerhedsproblemer med hardwaren. "
+"Dette er det laveste sikkerhedsniveau for enheden og giver kun beskyttelse "
+"mod simple sikkerhedstrusler."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:496
+msgid "Security Level 2"
+msgstr "Sikkerhedsniveau 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Denne enhed har grundlæggende beskyttelse mod sikkerhedsproblemer med "
+"hardwaren. Dette giver beskyttelse mod nogle almindelige sikkerhedstrusler."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:503
+msgid "Security Level 3"
+msgstr "Sikkerhedsniveau 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Denne enhed har udvidet beskyttelse mod sikkerhedsproblemer med hardwaren. "
+"Dette er det højeste sikkerhedsniveau for enheden og giver beskyttelse mod "
+"avancerede sikkerhedstrusler."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:518
+msgid "Security Level"
+msgstr "Sikkerhedsniveau"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:519
+msgid "Security levels are not available for this device."
+msgstr "Sikkerhedsniveauer er ikke tilgængelige for denne enhed."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Kontakt hardwarefabrikanten for at få hjælp med sikkerhedsopdateringer."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Problemet kan muligvis løses i enhedens UEFI-firmwareindstillinger eller af "
+"en supporttekniker."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "Problemet kan muligvis løses i enhedens UEFI-firmwareindstillinger."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "En supporttekniker kan måske løse problemet."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Niveau 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Niveau 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Niveau 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:110
+msgid "Protected against malicious software when the device starts."
+msgstr "Beskyttet mod ondsindede programmer når enheden starter."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:116
+msgid "Secure Boot has Problems"
+msgstr "Sikker opstart har problemer"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:117
+msgid "Some protection when the device is started."
+msgstr "Nogen beskyttelse når enheden startes."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:122
+msgid "Secure Boot is Off"
+msgstr "Sikker opstart er inaktiv"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:123
+msgid "No protection when the device is started."
+msgstr "Ingen beskyttelse når enheden startes."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:142
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Problemet kan skyldes en ændring i UEFI-firmwareindstillingerne, en ændring "
+"af styresystemets konfiguration eller ondsindede programmer på systemet."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:150
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Problemet kan skyldes en ændring i UEFI-firmwareindstillingerne eller "
+"ondsindede programmer på systemet."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:157
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Problemet kan skyldes en ændring i styresystemets konfiguration eller "
+"ondsindede programmer på systemet."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:483
+msgid "Exposed to serious security threats."
+msgstr "Udsat for alvorlige sikkerhedstrusler."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:490
+msgid "Limited protection against simple security threats."
+msgstr "Begrænset beskyttelse mod simple sikkerhedstrusler."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:497
+msgid "Protected against common security threats."
+msgstr "Beskyttet mod almindelige sikkerhedstrusler."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:504
+#: panels/firmware-security/cc-firmware-security-panel.c:512
+msgid "Protected against a wide range of security threats."
+msgstr "Beskyttet mod en bred vifte af sikkerhedstrusler."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:511
+msgid "Comprehensive Protection"
+msgstr "Omfattende beskyttelse"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Ingen begivenheder"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Skrivebeskyttelse af firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Skrivebeskyttelseslås af firmware"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "BIOS-område i firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "BIOS-deskriptor i firmware"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "DMA-bsekyttelse før opstart"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard-bekræftet opstart"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "ACM-beskyttelse med Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Fejlpolitik for Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard Fuse"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET aktiveret"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET aktiv"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Krypteret RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU-beskyttelse"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linuxkerne-nedlukning"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linuxkerne-bekræftelse"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linuxswap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Sæt i hvile i RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Sæt i hvile som inaktiv"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI-platformsnøgle"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI sikker opstart"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM-platformskonfiguration"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM-rekonstruktion"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine: fabrikstilstand"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine: tilsidesæt"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine: version"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Firmwareopdateringer"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Attestering af firmware"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Bekræftelse af firmwareopdateringsprogram"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Platformsfejlsøgning"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Sikkerhedstjek af processor"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD Rollback-beskyttelse"
+
+# https://en.wikipedia.org/wiki/Replay_attack
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD-firmwarebeskyttelse mod “replayangreb”"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Skrivebeskyttelse i AMD-firmware"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "“Fused” platform"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Gyldig"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Ugyldig"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Ikke aktiveret"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Låst"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Ikke låst"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Krypteret"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Ikke krypteret"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Forurenet"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Ikke forurenet"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Fundet"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Ikke fundet"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Understøttet"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Ikke understøttet"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Enhedssikkerhed"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Værtsfirmwares sikkerhedsstatus"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"skærm;lås;diagnostik;baglås;nedbrud;privat;seneste;midlertidig;tmp;indeks;"
+"navn;netværk;identitet;privatliv;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Ukendt"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Ukendt"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Ikke tilgængelig"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Systemlogo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Enhedsnavn"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Hardwaremodel"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Hukommelse"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafik"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Diskkapacitet"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Beregner …"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Styresystemets navn"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Styresystems versions-ID"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Styresystemets type"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME-version"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Indlæser …"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Vinduessystem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisering"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Softwareopdateringer"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Omdøb enhed"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Enhedsnavnet bruges til at identificere enheden når den vises på netværket "
+"eller ved parring af Bluetooth-enheder."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Enhedsnavn"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Omdøb"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Om"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Vis information om systemet"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"enhed;system;information;værtsnavn;hukommelse;processor;version;standard;"
+"program;foretrukne;foretrukken;cd;dvd;usb;lyd;video;disk;flytbar;medie;"
+"autokørsel;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Lyd og medie"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Slå lyden til/fra"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Dæmpning af lydstyrken"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Forøg lydstyrken"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Slå mikrofonen til/fra"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Start medieafspiller"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Afspil (eller afspil/pause)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Afspilning på pause"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Stop afspilning"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Forrige spor"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Næste spor"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Skub ud"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Indtastning"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Skift til næste indtastningskilde"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Skift til forrige indtastningskilde"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Programstartere"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Start hjælpefremviser"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Start lommeregner"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Start e-mail-program"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Start webbrowser"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Hjemmemappe"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Søg"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Log ud"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Lås skærm"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Tilgængelighed"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Slå zoom til eller fra"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zoom ind"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Zoom ud"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Slå skærmoplæser til eller fra"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Slå skærmtastatur til eller fra"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Forøg tekststørrelse"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Formindsk tekststørrelse"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Høj kontrast til eller fra"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Ingen indtastningskilder fundet"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Anden"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Tilføj en indtastningskilde"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Indtastningsmetoder kan ikke bruges i loginskærmen"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Ingen indtastningskilder valgt"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Indstillinger"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Flyt op"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Flyt ned"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Indstillinger"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Vis tastaturlayout"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Fjern"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Brugertilpassede genveje"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tast for alternative tegn"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Tasten til alternative tegn kan bruges til at indtaste yderligere tegn. De "
+"vises nogle gange som en tredje valgmulighed på dit tastatur."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Venstre Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Højre Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Venstre Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Højre Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menutast"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Højre Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Sammensætningstast"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Sammensætningstasten tillader indtastning af mange forskellige tegn. Den "
+"bruges ved at trykke tasten ned efterfulgt af en tegnsekvens. For eksempel "
+"vil sammensætningstasten sammen med <b>C</b> og <b>o</b> give <b>©</b>, og "
+"<b>a</b> efterfulgt af <b>'</b> giver <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Der kan skiftes mellem indtastningskilder med tastaturgenvejen %s.\n"
+"Dette kan ændres i indstillingerne for tastaturgenveje."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Indtastningskilder"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Inkluderer tastaturlayout og indtastningsmetoder."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Skift mellem indtastningskilder"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Brug _samme kilde i alle vinduer"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "_Skift indtastningskilder individuelt for hvert vindue"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Indtastning af specialtegn"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Metoder til indtastning af symboler og bogstavvarianter med brug af "
+"tastaturet."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Tastaturgenveje"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Gennemse og tilpas genveje"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d ændret"
+msgstr[1] "%d ændrede"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Nulstil alle genveje?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Nulstilling af genvejene kan påvirke dine brugertilpassede genveje. Dette "
+"kan ikke fortrydes."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Annullér"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Nulstil alle"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Nulstil alle …"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Nulstil alle genveje til deres standardbindinger"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Afsnit"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Genveje"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Tilføj en genvej"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Tilføj brugertilpassede genveje"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "Indstil brugertilpassede genveje til kørsel af programmer, scripts mv."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Tilføj genvej"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Ingen tastaturgenvej fundet"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s bruges allerede som %s. Hvis du erstatter den, vil %s blive slået fra"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Indtast den nye genvej"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Angiv brugertilpasset genvej"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Angiv genvej"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Indtast ny genvejstast for at ændre %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Tilføj brugertilpasset genvej"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Fjern"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Erstat"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "An_giv"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Tryk på Esc for at annullere, eller Tilbagetast for at deaktivere "
+"tastaturgenvejen."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Navn"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Kommando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Genvej"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Angiv genvej …"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ingen"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Nulstil genvejen til dens standardværdi"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatur"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Ændr tastaturgenveje og indstil dine indtastningspræferencer og -kilder samt "
+"tastaturlayout"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Genvej;Arbejdsområde;Vindue;Størrelse;Zoom;Kontrast;Input;Inddata;Kilde;Lås;"
+"Volumen;Lydstyrke;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Placeringstjenester er slået fra"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Ingen programmer kan indhente information om placering."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Placeringstjenester giver programmer mulighed for at kende din placering. "
+"Brug af wi-fi og mobilt bredbånd øger nøjagtigheden.\n"
+"\n"
+"Bruger Mozilla-placeringstjeneste: <a href='https://location.services."
+"mozilla.com/privacy'>Privatlivspolitik</a>\n"
+"\n"
+"Tillad, at programmerne nedenfor fastslår din placering."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Ingen programmer har spurgt om adgang til placering"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Beskyt din placeringsinformation"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "placering;sted;lokation;gps;privat;privatliv;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofonen er slået fra"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Ingen programmer kan optage lyd."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Brug af mikrofonen tillader programmer at optage og lytte til lyd. "
+"Deaktiveres mikrofonen, vil nogle programmer måske ikke virke korrekt.\n"
+"\n"
+"Tillad, at programmerne nedenfor bruger din mikrofon."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Ingen programmer har spurgt om adgang til mikrofon"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Beskyt dine samtaler"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofon;optagelse;program;privatliv;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Afprøv dine indstillinger"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Generelt"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primær knap"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Indstiller rækkefølgen for fysiske knapper på mus og pegeplader."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Venstre"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Højre"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mus"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Musens hastighed"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Naturlig rulning"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Rulning flytter indholdet, ikke visningen."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Pegeplade"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Pegepladens hastighed"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Tryk for at klikke"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Tryk for at klikke"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Tofingerrulning"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Kantrulning"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Prøv at klikke, dobbeltklikke og at rulle"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Fem klik: GEGL-tid!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dobbeltklik, primær knap"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Enkeltklik, primær knap"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dobbeltklik, midterknap"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Enkeltklik, midterknap"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dobbeltklik, sekundær knap"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Enkeltklik, sekundær knap"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mus & pegeplade"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Skift følsomhed for din mus eller pegeplade og vælg højre- eller "
+"venstrehåndstilstand"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Pegeplade;Markør;Klik;Prik;Dobbelt;Knap;Trackball;Rul;Rulning;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Aktivt _hjørne"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Berør det øverste venstre hjørne for at åbne aktivitetsoversigten."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Aktive skærmkanter"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Træk vinduer til øverste, venstre eller højre skærmkanter for at ændre deres "
+"størrelse."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Arbejdsområder"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dynamiske arbejdsområder"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Fjerner automatisk tomme arbejdsområder."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Fast antal arbejdsområder"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Angiv et antal permanente arbejdsområder."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Antal arbejdsområder"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Flere skærme"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Arbejdsområder kun på den _primære skærm"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Arbejdsområder _på alle skærme"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Skift mellem programmer"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "_Medtag programmer fra alle arbejdsområder"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Medtag _kun programmer fra aktuelle arbejdsområde"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitasking"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Håndtér indstillinger for produktivitet og multitasking"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitaske;Produktivitet;Tilpas;Skrivebord;Aktivt hjørne;"
+"Arbejdsområder;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Ups, der er gået noget galt. Kontakt venligst din softwareforhandler."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Netværkshåndtering skal køre."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Andre enheder"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Tilføj forbindelse"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Ikke indstillet"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Usikkert netværk (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Sikkert netværk (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Sikkert netværk (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Sikkert netværk (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Sikkert netværk"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Tilsluttet"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Indstillinger …"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Hvis der tændes for hotspottet, så afbrydes forbindelsen til %s, og det vil "
+"ikke være muligt at tilgå internettet gennem wi-fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Der skal være mindst 8 tegn"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Der må højst være %d tegn"
+msgstr[1] "Der må højst være %d tegn"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Slå wi-fi-hotspot til?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-fi-hotspot giver andre mulighed for at dele din internetforbindelse ved "
+"at oprette et Wi-Fi-netværk, som de kan oprette forbindelse til. For at gøre "
+"det skal du have en internetforbindelse gennem en kilde, som ikke er wi-fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Netværksnavn"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Adgangskode"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Generer tilfældig adgangskode"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Automatisk genereret adgangskode"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Tænd"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Stop hotspot og afkobl eventuelle brugere?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Stop hotspot"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Flytilstand"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Deaktiverer wi-fi, Bluetooth og mobilt bredbånd"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Ingen wi-fi-adaptere fundet"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Sikr dig at du har tilsluttet en wi-fi-adapter, og at den er tændt"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Flytilstand slået til"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Slå fra for at benytte wi-fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-fi-hotspottet er aktivt"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobile enheder kan skanne QR-koden for at forbinde."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Slå wi-fi-hotspot fra …"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Synlige netværk"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Netværkshåndtering skal køre"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x-_sikkerhed"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sikkerhed"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Bevar"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Tilfældig"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabil"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"MAC-adressen, som indtastes her, bruges som hardwareadresse til "
+"netværksenheden, som forbindelsen er aktiveret på. Funktionen kaldes MAC-"
+"kloning eller -spoofing. Eksempel: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Aldrig"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i dag siden"
+msgstr[1] "%i dage siden"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2,4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2,4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Svag"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "OK"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "God"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Fremragende"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4-adresse"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-adresse"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adresse"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Glem forbindelse"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Fjern forbindelsesprofil"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Fjern VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Detaljer"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatisk"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitet"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Slet adresse"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Slet rute"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit-nøgle (Hex eller ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit-adgangskode"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamisk WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 personlig"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signalstyrke"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Forbindelseshastighed"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hardwareadresse"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Understøttede frekvenser"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Standardrute"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Sidst brugt"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Forbind _automatisk"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Gør tilgængelig for _andre brugere"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Forbrugsafregnet forbindelse: Har databegrænsninger eller kan medføre "
+"omkostninger"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Softwareopdateringer og andre større overførsler vil ikke startes automatisk."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Navn"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC-adresse"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonet adresse"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "byte"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4-metode"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatisk (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Kun link-lokal"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manuel"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Deaktivér"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Delt til andre computere"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresser"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Netmaske"
+
+# i mangel af at "(wireless) access point" også kaldes adgangspunkt, så bør vi nok have en anden oversættelse af gateway
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automatisk"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatisk DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS-serveradresser"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Adskil IP-adresser med kommaer"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Ruter"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatiske ruter"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Brug _kun denne forbindelse til ressourcer på dens netværk"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6-metode"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatisk, kun DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Præfiks"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Kan ikke åbne forbindelsesredigering"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Ny profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Ugyldig indstilling %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Ugyldig indstilling %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importér fra fil …"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Tilføj VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_ikkerhed"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Kan ikke importere VPN-forbindelse"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Filen “%s” kunne ikke læses, eller indeholder ikke genkendelige oplysninger "
+"om VPN-forbindelse\n"
+"\n"
+"Fejl: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Vælg fil at importere"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Der findes allerede en fil med navnet “%s”."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Erstat"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Vil du erstatte %s med den VPN-forbindelse, du er ved at gemme?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Kan ikke eksportere VPN-forbindelse"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN-forbindelsen “%s” kunne ikke eksporteres til %s.\n"
+"\n"
+"Fejl: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Eksportér VPN-forbindelse"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Fejl: kan ikke indlæse VPN-forbindelsesredigering)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Angiv hvordan du forbinder til internettet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Netværk;IP;LAN;Proxy;WAN;Bredbånd;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Angiv hvordan du forbinder til trådløse netværk"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Netværk;Trådløs;Wi-fi;Wifi;IP;LAN;Bredbånd;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "aldrig"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "i dag"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "i går"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Sidst brugt"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Kabel"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Tilføj ny forbindelse"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Netværksdetaljer for de valgte netværk inklusive adgangskoder og eventuelt "
+"brugertilpasset konfiguration vil gå tabt."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Glem"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Kendte wi-fi-netværk"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Glem"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Systempolitikken forbyder brug som hotspot"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Trådløs enhed understøtter ikke hotspot-tilstand"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Der bruges autofinding af web-proxyer, når der ikke er givet en "
+"konfigurationsadresse."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Dette anbefales ikke for ubetroede offentlige netværk."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Slå enhed fra"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktiv"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Leverandør"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Netværksproxy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP-proxy"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS-proxy"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP-proxy"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks-vært"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorerede værter"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Port for HTTP-proxy"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Port for HTTPS-proxy"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Port for FTP-proxy"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Port for socks-proxy"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Konfigurationsadresse"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Slå VPN-forbindelse fra"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Netværksnavn"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Sikkerhedstype"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Adgangskode"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Sluk wi-fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Flere indstillinger …"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Forbind til skjult netværk …"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Slå wi-fi-hotspot _til …"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Kendte wi-fi-netværk"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Status ukendt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Uhåndteret"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Utilgængelig"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Forbinder"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Godkendelse påkrævet"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Afbryder forbindelse"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Forbindelse mislykkedes"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Status ukendt (mangler)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Konfiguration mislykkedes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP-konfiguration mislykkedes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP-konfigurationen udløb"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Hemmeligheder blev påkrævet men ikke givet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x-supplikant frakoblede"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Konfiguration af 802.1x-supplikant mislykkedes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x-supplikant fejlede"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x-supplikant brugte for lang tid på at godkende"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP-tjenesten kunne ikke starte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP-tjeneste frakoblede"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP fejlede"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP-klient kunne ikke starte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP-klientfejl"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP-klient fejlede"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Tjenesten for delt forbindelse kunne ikke starte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Tjenesten til delt forbindelse fejlede"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP-tjeneste kunne ikke starte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP-tjenestefejl"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP-tjeneste fejlede"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linjen er optaget"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Ingen ringetone"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Ingen opkobling kunne etableres"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Tidsudløb for opringningsforsøg"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Opringningsforsøg mislykkedes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Initialisering af modem mislykkedes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Kunne ikke vælge den angivne APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Søger ikke efter netværk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Netværksregistrering nægtet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Tidsudløb ved netværksregistrering"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Kunne ikke registrere hos det forespurgte netværk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN-kontrol mislykkedes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Firmware for enheden mangler måske"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Forbindelse forsvandt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Eksisterende forbindelse blev antaget"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem ikke fundet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth-forbindelse mislykkedes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM-kort ikke indsat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM-pin påkrævet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM-puk påkrævet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM forkert"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Forbindelsesforudsætning mislykkedes"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Firmware mangler"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabel ikke tilsluttet"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "udefineret fejl i 802.1X-sikkerhed (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "ingen fil valgt"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "uspecificeret fejl ved kontrol af eap-metodefil"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Private DER-, PEM-, PKCS#12- eller PGP-nøgler"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER- eller PEM-certifikater"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "mangler EAP-FAST PAC-fil"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC-filer (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonym"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Godkendt"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Begge"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "A_nonym identitet"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC-_fil"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Vælg en PAC-fil"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Indre godkendelse"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Tillad automatisk PAC-pro_visionering"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "mangler EAP-LEAP-brugernavn"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "mangler EAP-LEAP-adgangskode"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Brugernavn"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Adgangskode"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Vi_s adgangskode"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "ugyldigt CA-certifikat til EAP-PEAP: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "ugyldigt CA-certifikat til EAP-PEAP: intet certifikat angivet"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A-certifikat"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Vælg certifikat fra certifikatautoritet"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Intet CA-certifikat _påkrævet"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP-_version"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "mangler EAP-brugernavn"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "mangler EAP-adgangskode"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "mangler EAP-TLS-identitet"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "ugyldigt CA-certifikat til EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "ugyldigt CA-certifikat til EAP-TLS: intet certifikat angivet"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "ugyldig privat nøgle til EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "ugyldigt brugercertifikat til EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Ukrypterede private nøgler er usikre"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Den valgte private nøgle lader ikke til at være beskyttet med adgangskode. "
+"Dette kan føre til, at dine sikkerhedsakkreditiver kompromitteres. Vælg "
+"venligst en privat nøgle beskyttet med adgangskode.\n"
+"\n"
+"(Du kan bruge openssh til at beskytte din private nøgle med adgangskode)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Vælg dit personlige certifikat"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Vælg din private nøgle"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitet"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Brugercertifikat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Privat _nøgle"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Adgangskode for _privat nøgle"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "ugyldigt CA-certifikat til EAP-TTLS: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "ugyldigt CA-certifikat til EAP-TTLS: intet certifikat angivet"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (ingen EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domæne"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Ukendt fejl ved validering af 802.1X-sikkerhed"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS gennem tunnel"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Beskyttet EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Godkendelse"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Vælg en fil"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "mangler leap-brugernavn"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "mangler leap-adgangskode"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Adgangskode til wi-fi mangler."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Type"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "mangler web-nøgle"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "ugyldig wep-nøgle: nøgle med længde %zu må kun indeholde hex-cifre"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "ugyldig web-nøgle: nøgle med længde %zu må kun indeholde ascii-tegn"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"ugyldig wep-nøgle: forkert nøglelængde %zu. En nøgle skal have længde 5/13 "
+"(ascii) eller 10/26 (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "ugyldig wep-nøgle: adgangsfrase må ikke være tom"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "ugyldig wep-nøgle: adgangsfrase skal være kortere end 64 tegn"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (forvalg)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Åbent system"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Delt nøgle"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Nøgle"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Vis nøgle"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP-inde_ks"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"ugyldig wpa-psk: ugyldig nøglelængde %zu. Skal være [8, 63] byte eller 64 "
+"hex-cifre"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "ugyldig wpa-psk: kan ikke fortolke nøgle med 64 byte som hex"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Påmindelser"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Påmindelseslyde"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Pop op'er til påmindelser"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Påmindelser vil fortsat blive vist i påmindelseslisten, når pop op'er er "
+"slået fra."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Vis _indhold af meddelelser i pop op'er"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Påmindelser for _låst skærm"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Vis i_ndhold af meddelelser ved låst skærm"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Forstyr ikke"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Påmindelser for _låst skærm"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Tilpas hvilke påmindelser der vises, og hvad de viser"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Påmindelser;Banner;Besked;Meddelelse;Statusfelt;Status;Pop;Pop-op;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Anden"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s fjernet"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Fejl ved sletning af konto"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Fortryd"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Luk påmindelsen"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Forbind til dine data i skyen"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Ingen internetforbindelse — forbind for at sætte nye onlinekonti op"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Tilføj en konto"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s-konto"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Fjern konto"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Onlinekonti"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Forbind til dine onlinekonti og beslut dig for hvad du vil bruge dem til"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Internet;Web;Online;Chat;Kalender;Post;E-post;"
+"Mail;Email;E-mail;Kontaktpersoner;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
+"ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Ukendt tid"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minut"
+msgstr[1] "%i minutter"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i time"
+msgstr[1] "%i timer"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "time"
+msgstr[1] "timer"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minutter"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s indtil fuldt opladet"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Bemærk: %s tilbage"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s tilbage"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Fuldt opladet"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Oplader ikke"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Tomt"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Oplader"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "På batteri"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Trådløs mus"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Trådløst tastatur"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Uafbrydelig strømforsyning"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Personlig digital assistent"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobiltelefon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Medieafspiller"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tegneplade"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Computer"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Spilinputenhed"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batteri"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Hovedbatteri"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Ekstra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batterier"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Ved _tomgang"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Hvile"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Sluk"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Dvale"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Intet"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Ved batteridrift"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Ved ekstern strøm"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Aldrig"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatisk hvile"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "Ydelsestilstand midlertidigt deaktiveret pga. for høj temperatur."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Skød detekteret: ydelsestilstand midlertidigt deaktiveret. Flyt enheden til "
+"en stabil overflade for at reaktivere."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Ydelsestilstand midlertidigt deaktiveret."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Lavt batteriniveau: strømsparetilstand aktiveret. Tidligere tilstand vil "
+"blive reaktiveret, når batteriet er tilstrækkeligt opladet."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Strømsparetilstand aktiveret af “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Ydelsestilstand aktiveret af “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 time"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 timer"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Strømsparetilstand"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Påvirker systemets ydelse og strømforbrug."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Indstillinger for strømbesparelse"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatisk skærmlysstyrke"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Skærmens lysstyrke indstilles efter det omgivende lys."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Dæmp skærm"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Reducerer skærmens lysstyrke, når computeren er inaktiv."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Sort skærm"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Slukker skærmen efter et tidsrum uden aktivitet."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatisk strømsparetilstand"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Aktiverer strømsparetilstand, når batteriet er næsten tomt."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatisk hvile"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Sætter computeren på pause efter et tidsrum uden aktivitet."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Handling for _tænd-/slukknap"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Vis _batteriprocent"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatisk hvile"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Ekstern strøm"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "På _batteri"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Ventetid"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Ydelse"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Høj ydelse og strømforbrug."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Balanceret"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standardydelse og -strømforbrug."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Strømsparetilstand"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Reduceret ydelse og strømforbrug."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Strøm"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Vis din batteristatus og skift indstillinger for strømstyring"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Strøm;Sove;Hvile;Dvale;Batteri;Lysstyrke;Dæmp;Dæmpning;Blank;Sort;Skærm;DPMS;"
+"Tomgang;Inaktiv;Energi;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Printeren “%s” er blevet slettet"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Kunne ikke tilføje den nye printer."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Kunne ikke indlæse brugerfladen: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Lås op for at tilføje printere og ændre indstillinger"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Printere"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Tilføj printere, vis udskriftsopgaver og bestem hvordan du vil udskrive"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Kø;Print;Papir;Blæk;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Tilføj printer"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Lås op"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Ingen printere fundet"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Indtast en netværksadresse eller søg efter en printer"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Godkendelse påkrævet"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Indtast dit brugernavn samt adgangskode for at se tilgængelige printere på "
+"printerserveren."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Brugernavn"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Detaljer for %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Ingen passende driver fundet"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Vælg PPD-fil"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript-printerbeskrivelsesfiler (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Printernavne kan ikke indeholde mellemrum, tabulatorstop, # eller /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Placering"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Søger efter foretrukne drivere …"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Søg efter drivere"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Vælg fra database …"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Angiv PPD-fil …"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Vælg printerdriver"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Indlæser driverdatabase …"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Vælg"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect-printer"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD-printer"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Enkeltsidet"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Lang kant (standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Kort kant (vendt)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portræt"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Landskab"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Omvendt landskab"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Omvendt portræt"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Genoptag"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pause"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "I kø"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pause"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Godkendelse påkrævet"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "I gang"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Standset"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Annulleret"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Afbrudt"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Fuldført"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Flyt opgaven til toppen af køen"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u opgave kræver godkendelse"
+msgstr[1] "%u opgaver kræver godkendelse"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — aktive opgaver"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Indtast loginoplysninger for at printe fra %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domæne"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Godkend"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Ryd alle"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Godkend"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Ingen aktive udskriftsopgaver"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Lås printerserver op"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Lås %s op."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Indtast brugernavn og adgangskode for at se printerne på %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Søger efter printere"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Serielport"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Parallelport"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Placering: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adresse: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Serveren kræver godkendelse"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dobbeltsidet"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Papirtype"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Papirkilde"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Udskriftsbakke"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Opløsning"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript-præfiltrering"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Sider pr. ark"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dobbeltsidet"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientering"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Generelt"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Sideopsætning"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Indstillinger for installerbare enheder"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Opgaver"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Billedkvalitet"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Farver"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Færdigbehandling"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avanceret"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Testside"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Testside"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Vælg automatisk"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Printers standardindstilling"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Indlejr kun GhostScript-skrifttyper"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Konvertér til PS niveau 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Konvertér til PS niveau 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Ingen præfiltrering"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Producent"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ingen aktive opgaver"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u opgave"
+msgstr[1] "%u opgaver"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Rens printerhoveder"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Lavt tonerniveau"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Løbet tør for toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Lavt niveau af fremkaldervæske"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Løbet tør for fremkaldervæske"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Markerfarveforsyning lav"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Løbet tør for markerfarve"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Kabinet åbent"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Låge åben"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Lavt papirniveau"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Løbet tør for papir"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Ikke tilsluttet"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Standset"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Affaldsbeholderen er næsten fuld"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Affaldsbeholderen er fuld"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Den optiske billedtromle fungerer snart ikke længere"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Den optiske billedtromle fungerer ikke længere"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Klar"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Accepterer ikke opgaver"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Behandler"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Udskriftsindstillinger"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Printerdetaljer"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Brug printer som standard"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Rens printerhoveder"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Fjern printer"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Blækniveau"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Genstart venligst, når problemet er løst."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Genstart"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Tilføj printer …"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Ingen printere"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Beklager! Systemets udskriftstjeneste\n"
+"    lader til at være utilgængelig."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formater"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Søg regionaldata …"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Almindelige formater"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Alle formater"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Ingen søgeresultater"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Søgninger kan være efter lande eller sprog."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Forhåndsvisning"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Britisk"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrisk"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datoer"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dato & klokkeslæt"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Tal"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mål"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papir"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Sprog og format ændres efter næste login"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Log ud …"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Sprogindstillingen bruges til grænsefladetekst og websider. Formater bruges "
+"til tal, datoer og valutaer."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Din konto"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Sprog"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formater"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Loginskærm"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Region & sprog"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Vælg sprog og formater"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Sprog;Layout;Tastatur;Input;Inddata;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Spørg hvad der skal gøres"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Gør intet"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Åbn mappe"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Andet medie"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Vælg et program til lyd-cd'er"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Vælg et program til video-dvd'er"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Vælg et program der skal køres, når der tilsluttes en musikafspiller"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Vælg et program der skal køres, når der tilsluttes et kamera"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Vælg et program til software-cd'er"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "lyd-dvd"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "blank Blu-ray-disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "blank cd-disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "blank dvd-disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "blank HD DVD-disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray-videodisk"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "e-bogslæser"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD-videodisk"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Billed-cd"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Supervideo-cd"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video-cd"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windowsprogrammer"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Vælg hvordan medier skal håndteres"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "Cd-_lyd"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_Dvd-video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Musikafspiller"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Programmer"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Andet medie …"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Spørg aldrig, og start aldrig programmer, når der indsættes medier"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Vælg hvordan andre medier skal håndteres"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Handling:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Type:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Flytbare medier"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Indstil flytbare medier"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"enhed;system;standard;program;foretrukken;cd;dvd;usb;lyd;video;disk;flytbar;"
+"medie;autokørsel;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Skærmen slukker"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekunder"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minut"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 time"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Aldrig"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Skærmlåsning"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatisk låsning af skærmen forhindrer andre i at tilgå computeren, mens "
+"du er væk."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Forsinkelse for sort skærm"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Periode med inaktivitet hvorefter skærmen ryddes."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatisk skærm_låsning"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Forsinkelse for automatisk skærm_låsning"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Periode efter skærmen er blevet ryddet hvorefter skærmen automatisk låses."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Vis _påmindelser på låseskærm"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Forbyd nye _USB-enheder"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Forhindr nye USB-enheder i at interagere med systemet, mens skærmen er låst."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Privatliv på skærmen"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Begræns visningsvinkel"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Skærmindstillinger"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "skærm;lås;privat;privatliv;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Vælg sted"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Søgesteder"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Mapper som der søges i af systemprogrammer såsom Filer, Billeder og Videoer."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Steder"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Bogmærker"
+
+# andet end bogmærker, steder
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Andre"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Tilføj placering"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Ingen programmer fundet"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Programsøgning"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Medtag søgeresultater leveret af programmer."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Mapper, der søges i af systemprogrammer."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Søgeresultater"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Resultater vises i henhold til listerækkefølgen."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Bestem hvilke programmer, der viser søgeresultater i aktivitetsoversigten"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Søg;Find;Indeks;Skjul;Privatliv;Resultater;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Ingen netværk valgt til deling"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Netværk"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Slået til"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Slået fra"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Aktiveret"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktiv"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Vælg en mappe"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Tilføj"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Aktivér mediedeling"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Fildeling lader dig dele mappen Offentligt med andre på dit nuværende "
+"netværk gennem: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Når fjernlogin er slået til, kan fjernbrugere forbinde via ssh-kommandoen "
+"(Secure Shell):\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Aktivér personlig fildeling"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Enhedsnavn kopieret"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Enhedsadresse kopieret"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Brugernavn kopieret"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Adgangskode kopieret"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Deling"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Computernavn"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Fildeling"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_Fjernskrivebord"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Mediedeling"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Fjernlogin"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Fildeling"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Kræv adgangskode"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Fjernlogin"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Fjernskrivebord"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Fjernskrivebord tillader visning og kontrol af dit skrivebord fra en anden "
+"computer."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Slå fjernskrivebordsforbindelser til denne computer til eller fra."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Fjernkontrol"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Tillader, at fjernforbindelser styrer skærmen."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Sådan forbinder du"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Forbind til denne computer med brug af enhedens navn eller "
+"fjernskrivebordsadressen."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopiér"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Fjernskrivebordsadresse"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Godkendelse"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Der kræves brugernavn og adgangskode for at forbinde til denne computer."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Brugernavn"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Bekræft kryptering"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Krypteringsfingeraftryk"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Krypteringsfingeraftrykket kan ses i klienter, der forbinder, og bør være "
+"identisk."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Mediedeling"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Del musik, billeder og videoer over netværket."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Mapper"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Bestem hvad du vil dele med andre"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"del;deling;ssh;vært;navn;fjern;skrivebord;medie;lyd;video;billeder;fotos;"
+"film;videoer;server;rendering;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Slå fjernlogin til eller fra"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Der kræves godkendelse for at kunne aktivere eller deaktivere fjernlogin"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Tilpasset"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klik"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Streng"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Svinge"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Brumme"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balance"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Udtoning"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Bagved"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Foran"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Afprøver %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Klik på en højttaler for at afprøve den"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Systemlydstyrke"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Hovedlydstyrke"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Lydstyrkeniveauer"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Output"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Outputenhed"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Test"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Konfiguration"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Input"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Inputenhed"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Lydstyrke"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Påmindelseslyd"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Lydløs"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Lyd"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Skift lydstyrke, input, output samt påmindelseslyde"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kort;Mikrofon;Volumen;Lydstyrke;Fade;Udtoning;Balance;Bluetooth;"
+"Hovedtelefoner;Lyd;Audio;Output;Input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Ikke tilsluttet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Tilslutter"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Tilsluttet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Fejl ved godkendelse"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Godkender"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Reduceret funktionalitet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Tilsluttet & godkendt"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Ukendt"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Godkendt:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Tilsluttet:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Registreret:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Kunne ikke godkende enhed: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Kunne ikke glemme enhed: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Afhænger af %u anden enhed"
+msgstr[1] "Afhænger af %u andre enheder"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Luk påmindelse"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Navn:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Status:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Godkend og tilslut"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Glem enhed"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Fejl"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Godkendt"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Thunderbolt-undersystemet (boltd) er ikke installeret eller konfigureret "
+"korrekt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Tillad direkte adgang til enheder såsom dockingstations og eksterne GPU'er."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Kun USB- og Display Port-enheder kan forbindes."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt blev ikke detekteret.\n"
+"Enten mangler systemet understøttelse for Thunderbolt, understøttelsen er "
+"blevet slået fra i BIOS, eller BIOS er indstillet til et sikkerhedsniveau "
+"som ikke understøttes."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Understøttelse for Thunderbolt er blevet slået fra i BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Sikkerhedsniveau for Thunderbolt kunne ikke bestemmes."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Fejl ved skift til direkte tilstand: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Ingen understøttelse af Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Kunne ikke forbinde til Thunderbolt-undersystemet."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Direkte adgang"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Ventende enheder"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Ingen enheder forbundet"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Håndtér Thunderbolt-enheder"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privatliv;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Markørblink"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Markør blinker i tekstfelter."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Hastighed"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Markørblinkehastighed"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Markørstørrelse"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Markørstørrelsen kan kombineres med zoom for at gøre det nemmere at se "
+"markøren."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Klikhjælp"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simuleret sekundært klik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Udløs et sekundært klik ved at holde den primære tast nede"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Ventetid for _accept:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Ventetid ved sekundært klik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Svæveklik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Udløs et klik når markøren svæver"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "V_entetid:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Bevægelsestærskel:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Lille"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Stor"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Gentagende taster"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Gentag tastetryk når en tast holdes nede."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Ventetid for gentagende taster"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Taste-gentagelseshastighed"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Skrivehjælp"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Klæbetaster"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Behandler en sekvens af modifikationstaster som en tastekombination"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Deaktivér hvis to taster holdes nede samtidig"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Bip når der trykkes på en _modifikationstast"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Langsomme taster"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Indsætter ventetid mellem at en tast trykkes, og at den accepteres"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Ventetid for langsomme taster"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Bip når der try_kkes på en tast"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Bip når en tast _accepteres"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Bip når en tast _afvises"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Rystetaster"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorerer hurtige dobbelte tastetryk"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Ventetid for rystetaster"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Slå til med tastatur"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Slå tilgængelighedsfaciliteter til og fra ved hjælp af tastaturet"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Standard"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Middel"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Stor"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Større"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Størst"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixler"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Vis _altid tilgængelighedsmenu"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Syn"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Høj kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Stor tekst"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "A_ktivér animationer"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Skærm_oplæser"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Skærmlæseren læser den viste tekst, efterhånden som du flytter fokus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Lydtaster"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Bip når Num Lock og Caps Lock slås til eller fra."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Mark_ørstørrelse"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Hørelse"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Visuelle påmindelser"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Skærm_tastatur"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Gentagende taster"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Markør_blink"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Skrivehjælp (_AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Pege og klikke"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Musetaster"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Find markør"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Klikhjælp"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Ventetid for _dobbeltklik"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Ventetid for dobbeltklik"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Visuelle påmindelser"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Test blink"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Brug et visuelt signal når der gives en lydpåmindelse."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Blink med hele _skærmen"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Blink med hele _vinduet"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ skærm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ skærm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ skærm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Fuldskærm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Øverste halvdel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Nederste halvdel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Venstre halvdel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Højre halvdel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Indstillinger for zoom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Forstørrelse:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Position af forstørrelsesglas:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Følg musemarkør"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Skærmdel:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "_Forstørrelsen går ud over skærmkanten"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Behold forstørrelsesmarkøren centreret"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Forstørrelsesmarkøren _skubber indholdet omkring"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Forstørrelsesmarkøren flytter med _indholdet"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Forstørrelsesglas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Sigtekorn:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Overlapper musemarkør"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Tykkelse:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tynd"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Tyk"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Længde:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Farve:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Sigtekorn"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Farveeffekter:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Hvid på sort:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Lysstyrke:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Farve"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Fuld"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Lav"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Høj"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Lav"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Høj"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Farveeffekter"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Gør det nemmere at se, høre, skrive, pege og klikke"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Tastatur;Mus;a11y;Tilgængelighed;Kontrast;Cursor;Markør;Lyd;Zoom;Skærm;"
+"Skærmoplæser;stor;høj;Oplæser;tekst;skrifttype;størrelse;AccessX;Klæbetaster;"
+"Taster;Langsomme;Rystetaster;Ryste;Mus;Musetaster;Dobbelt;Dobbeltklik;"
+"Ventetid;Forsinkelse;Hastighed;Hjælp;Gentag;Blink;visuel;synlig;høre;hørelse;"
+"indtastning;animationer;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 time"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dag"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dage"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Tøm papirkurven for alle elementer?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Alle elementer i papirkurven vil blive slettet permanent."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Tøm papirkurv"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Slet alle de midlertidige filer?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Alle de midlertidige filer vil blive slettet permanent."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Slet midlertidige filer"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dag"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dage"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dage"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Altid"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Filhistorik"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Filhistorikken husker de filer du har brugt. Informationen deles mellem "
+"programmer og gør det let at finde filer som du måske vil bruge."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "_Filhistorik"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "_Varighed for filhistorik"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Ryd historik …"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Papirkurv & midlertidige filer"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Papirkurven og midlertidige filer kan nogle gange indeholde personlig eller "
+"følsom information. Hvis de slettes automatisk, kan det hjælpe med at "
+"beskytte privatlivet."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Automatisk sletning af indholdet i _papirkurven"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automatisk sletning af _midlertidige filer"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Periode for automatisk sletning"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Tøm papirkurv …"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Slet midlertidige filer …"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Filhistorik & papirkurv"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Efterlad ingen spor"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"brug;nylig;seneste;historik;filer;midlertidig;tmp;privat;privatliv;papirkurv;"
+"tøm;tømning;bevar;behold;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Skal passe med webadressen til din loginudbyder."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Kunne ikke tilføje konto"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Adgangskoderne er ikke ens."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Kunne ikke registrere konto"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Ingen understøttet måde at godkende med dette domæne"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Kunne ikke slutte til domænet"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Det loginnavn virkede ikke.\n"
+"Prøv venligst igen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Adgangskoden for login virkede ikke.\n"
+"Prøv venligst igen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Kunne ikke logge ind på domænet"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Kan ikke finde domænet. Stavede du det forkert?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Tilføj bruger"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administratorer kan tilføje og fjerne andre brugere og ændre indstillinger "
+"for alle brugere. Forældrekontrol kan ikke anvendes på administratorer."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Brugeren angiver adgangskode ved første login"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Angiv adgangskode nu"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Bekræft"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Enterprise-login"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Brugerkonti som administreres af et firma eller en organisation."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Du er ikke tilsluttet"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Enterprise-login tillader, at der bruges en eksisterende, centralt håndteret "
+"brugerkonto på denne enhed. Du kan også bruge denne konto til at tilgå "
+"firmaressourcer på internettet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Gennemse flere billeder"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Vælg en fil …"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Håndtering af fingeraftryk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Fingeraftryk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Nej"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Ja"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Ønsker du at slette dine registrerede fingeraftryk, så login med "
+"fingeraftryk er deaktiveret?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Ingen fingeraftryksenhed"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Ingen fingeraftryksenhed"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Sørg for, at enheden er korrekt tilsluttet."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Fingeraftryksenhed"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Vælg den fingeraftryksenhed, du vil konfigurere"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Login med fingeraftryk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Login med fingeraftryk lader dig låse din computer op og logge ind med din "
+"finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Slet fingeraftryk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Registrér fingeraftryk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "der skal være gjort krav på enheden, før den kan udføre handlingen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "en anden proces har gjort krav på enheden"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "du har ikke tilladelse til at udføre handlingen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "ingen udskrifter er blevet registreret"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Kunne ikke kommunikere med enheden under registrering"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Kunne ikke kommunikere med fingeraftrykslæseren"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Kunne ikke kommunikere med fingeraftryksdæmonen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Kunne ikke vise fingeraftryk: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Kunne ikke slette gemte fingeraftryk: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Venstre tommelfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Venstre langfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Venstre pegefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Venstre ringfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Venstre lillefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Højre tommelfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Højre langfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Højre pegefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Højre ringfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Højre lillefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Ukendt finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Fuldført"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Fingeraftryksenhed frakoblet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Lageret på fingeraftryksenheden er fyldt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Kunne ikke registrere nyt fingeraftryk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Kunne ikke påbegynde registrering: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Kunne ikke registrere nyt fingeraftryk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Kunne ikke stoppe registrering: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Løft og placér din finger gentagne gange på aflæseren for at registrere dit "
+"fingeraftryk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Registrér fingeren igen …"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Skan nyt fingeraftryk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Kunne ikke frigive fingeraftryksenheden %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problem ved læsning af enheden"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Kunne ikke få adgang til fingeraftryksenheden %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Kunne ikke hente fingeraftryksenhederne: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Denne uge"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Sidste uge"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Session afsluttet"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Session påbegyndt"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Kontoaktivitet"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Forrige"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Næste"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Vælg venligst en anden adgangskode."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Indtast venligst din nuværende adgangskode igen."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Adgangskoden kunne ikke ændres"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Skift adgangskode"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Skift"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Nuværende adgangskode"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Ny adgangskode"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Bekræft adgangskode"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Tillad bruger at vælge adgangskode når der logges ind næste gang"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Angiv en adgangskode nu"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Kan ikke automatisk tilslutte denne type domæne"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Intet sådant domæne eller realm fundet"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Kan ikke logge ind som %s på domænet %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Ugyldig adgangskode; prøv venligst igen"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Kunne ikke forbinde til domænet %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Kunne ikke slette bruger"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Kunne ikke tilbagekalde fjernhåndteret bruger"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Du kan ikke slette din egen konto."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s er stadig logget ind"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Sletning af en bruger, mens denne stadig er logget ind, kan bringe systemet "
+"i en inkonsistent tilstand."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Vil du beholde %ss filer?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Det er muligt at beholde hjemmemappen, postarkivet samt midlertidige filer, "
+"når en brugerkonto slettes."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Slet filer"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Behold filer"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Er du sikker på, at du vil tilbagekalde den fjernhåndterede konto tilhørende "
+"%s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Slet"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Konto deaktiveret"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Vælges ved næste login"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Intet"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Logget ind"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Kunne ikke kontakte kontotjenesten"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Kontrollér venligst at AccountService er installeret og aktiveret."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Panelet skal låses op for at ændre denne indstilling"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Slet den valgte brugerkonto"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Klik først *-ikonet\n"
+"for at slette den valgte brugerkonto"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Lås op for at tilføje brugere og ændre indstillinger"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Brugere"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Dine sessioner skal genstartes for at ændringerne træder i kraft"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Genstart nu"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Luk"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Redigér profilbillede"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Fulde navn"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Redigér"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Login med _fingeraftryk"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatisk login"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Kontoaktivitet"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administratorer kan tilføje og fjerne andre brugere og ændre indstillinger "
+"for alle brugere."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Forældrekontrol"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Åbn programmet til forældrekontrol."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Fjern bruger …"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Andre brugere"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Tilføj bruger …"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Ingen brugere fundet"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Lås op for at tilføje en brugerkonto."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Tilføj eller fjern brugere og skift din adgangskode"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Navn;Fingeraftryk;Avatar;Logo;Ansigt;Adgangskode;Forældrekontrol;"
+"Skærmtid;Programbegrænsninger;Webbegrænsninger;Forbrug;Forbrugsgrænse;Unge;"
+"Barn;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Tilknyt"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Login for domæneadministrator"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"For at kunne bruge enterprise-logins, skal denne computer\n"
+"være med i domænet. Få venligst din netværksadministrator\n"
+"til at skrive vedkommendes adgangskode her."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Navn på administrator"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Adgangskode for administrator"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Håndtér brugerkonti"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Godkendelse påkrævet for at kunne ændre brugerdata"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Den nye adgangskode skal være forskellig fra den gamle."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Prøv at ændre nogle bogstaver og tal."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Prøv at ændre adgangskoden lidt mere."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "En adgangskode uden dit brugernavn ville være stærkere."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Prøv at undgå at bruge dit navn i adgangskoden."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Prøv at undgå nogle af ordene i adgangskoden."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Prøv at undgå almindelige ord."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Prøv at undgå at omarrangere eksisterende ord."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Prøv at bruge flere tal."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Prøv at bruge flere store bogstaver."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Prøv at bruge flere små bogstaver."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Prøv at bruge flere specialtegn, f.eks. tegnsætning."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Prøv at bruge en blanding af bogstaver, tal og tegnsætning."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Prøv at undgå at gentage samme tegn."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Prøv at undgå at gentage samme type tegn: Du skal blande bogstaver, tal og "
+"tegnsætning."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Prøv at undgå følger som 1234 eller abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Adgangskoden skal være længere. Prøv at bruge flere bogstaver, tal og andre "
+"tegn."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Bland store og små bogstaver, og brug et par tal."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Flere bogstaver, tal og andre tegn vil gøre adgangskoden stærkere."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Godkendelse mislykkedes"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Den nye adgangskode er for kort"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Den nye adgangskode er for simpel"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Der er for stor lighed mellem gammel og ny adgangskode"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Den nye adgangskode er allerede blevet brugt for nylig."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Den nye adgangskode skal indeholde tal eller specialtegn"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Gammel og ny adgangskode er ens"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Din adgangskode er ændret, siden du først godkendte!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Den nye adgangskode indeholder ikke nok forskellige tegn"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Ukendt fejl"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Brugernavnet består typisk kun af små bogstaver fra a til z, tal og følgende "
+"tegn: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Beklager, men det brugernavn er ikke tilgængeligt. Prøv et andet."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Brugernavnet er for langt."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Tildel knapper"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Tildel funktioner til knapper"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Redigér en genvej ved at vælge handlingen “Send tastetryk”, klik på "
+"tastaturgenvejstasten og hold de nye taster nede. Brug slet tilbage-tasten "
+"for at rydde."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Luk"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Rør ved målmarkørerne efterhånden som de vises på skærmen for at kalibrere "
+"tegnepladen."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Fejlklik detekteret, genstarter …"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Knap %d"
+
+# læser det som "programdefineret handling"
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Programdefineret"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Send tastetryk"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Skift skærm"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Vis hjælp på skærmen"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tegneplade monteret på den bærbares panel"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tegneplade monteret på ekstern skærm"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Ekstern tegnepladeenhed"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Ekstern enhed med tegnepladeknapper"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Alle skærme"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Tegnepladetilstand"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Brug absolut placering af pennen"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Venstrehåndet orientering"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tegneplade og Eksprestaster™ er roteret til brug for venstre hånd"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Afbild position på skærm"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Behold højde-breddeforhold"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Brug kun en del af tegnepladens overflade til bevarelse af skærmens højde-"
+"breddeforhold"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibrér"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Ingen tegneplade fundet"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Vær venlig at tilslutte eller tænde din Wacom-tegneplade."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Trykfølsomhed ved spidsen"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Blødt"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pennespidsens tryk"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Fast"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Knap 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Knap 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Knap 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Trykfølsomhed ved viskelæder"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Tryk ved viskelæder"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Midterklik på musen"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Klik på højre museknap"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Fremad"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Airbrushpen med tryk, hældning og integreret skyder"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Airbrushpen med tryk, hældning og rotation"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standardpen med tryk og hældning"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standardpen med tryk"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom-tegneplade"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Angiv tasteafbildninger og justér følsomhed for digital pen til grafiske "
+"tegneplader"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tegneplade;Wacom;Pen;Viskelæder;Mus;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Ny genvej …"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Adgangspunkter"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Handling afbrudt"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Fejl:</b> Adgang nægtet til at ændre indstillinger"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Fejl:</b> Fejl med mobilt udstyr"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Ikke registreret"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registreret"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Søger"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Nægtet"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modemdetaljer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modemstatus"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operatør"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Netværkstype"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Netværksstatus"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Eget nummer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Enhedsdetaljer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Firmwareversion"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Kun 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Kun 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Kun 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Kun 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (foretrukken), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (foretrukken), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (foretrukken), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (foretrukken), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (foretrukken), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (foretrukken), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (foretrukken), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (foretrukken), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (foretrukken), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (foretrukken), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (foretrukken), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (foretrukken), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (foretrukken), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (foretrukken), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (foretrukken), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (foretrukken), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (foretrukken)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (foretrukken), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Ukendt"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Lås simkortet op"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Lås op"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Angiv pinkoden til simkortet %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Indtast pinkoden for at låse simkortet op"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Angiv pukkoden til simkortet %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Indtast pukkoden for at låse simkortet op"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Forkert adgangskode. Du har %1$u forsøg tilbage"
+msgstr[1] "Forkert adgangskode. Du har %1$u forsøg tilbage"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Du har %u forsøg tilbage"
+msgstr[1] "Du har %u forsøg tilbage"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Forkert adgangskode."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Pukkoden skal være på otte tal"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Indtast ny pinkode"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Pinkoden skal være på 4–8 tal"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Låser op …"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Intet simkort"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Isæt et simkort for at bruge modemmet"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "Simkortet er låst"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobildata"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Tilgå data med brug af mobilt netværk"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Dataroaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Brug mobildata under roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Netværkstilstand"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "N_etværk"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avanceret"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "A_dgangspunktnavne"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_Simkortlås"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Lås simkort med pinkode"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Modem_detaljer"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Fejl ved telefon"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Ingen forbindelse til telefonen"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Handling ikke tilladt"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Handling ikke understøttet"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Simkort ikke isat"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Kræver pinkode til simkortet"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Kræver pukkode til simkortet"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Fejl ved simkortet"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Simkortet er optaget"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Forkert adgangskode"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Kræver pin2-kode til simkortet"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Kræver puk2-kode til simkortet"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Ikke fundet"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Ingen netværkstjeneste"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Tidsudløb på netværk"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS-tjenester ikke tilladt"
+
+# Teknisk begreb
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming ikke tilladt i dette lokationsområde"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Uspecificeret GPRS-fejl"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Ingen fejl"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Handling annulleret"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Adgang nægtet"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Ukendt fejl"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Netværkstilstand"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "A_utomatisk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Vælg netværk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Opdatér netværksudbydere"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "Simkort %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Aktivér mobilt netværk"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Ingen WWAN-adapter fundet"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Sikr dig, at du har en trådløs wan-/mobilenhed"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Trådløs wan er deaktiveret når flytilstand er aktiv"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Deaktivér flytilstand"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Dataforbindelse"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Simkort anvendt til internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Simkortlås"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Næste"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Lås simkort med pinkode"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Skift pinkode"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Indtast nuværende pinkode for at skifte indstillinger for simkortlås"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobilt netværk"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Indstil telefoni og mobildataforbindelser"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "mobil;wwan;telefoni;sim;simkort;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Redskab til at konfigurere GNOME-skrivebordet"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+"Indstillinger er den primære grænseflade til konfigurering af dit system."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME-projektet"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Vis versionsnummer"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Brug uddybende tilstand"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Søg efter strengen"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Vis mulige panelnavne og afslut"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel der skal vises"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT …]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Indstillingskategorier"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privatliv"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Tilgængelige paneler:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Alle indstillinger"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Hovedmenu"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Advarsel: Udviklingsversion"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Denne version af Indstillinger bør kun bruges til udvikling. Du kan opleve "
+"fejlagtig opførsel af systemet, datatab og andre uventede problemer. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Hjælp"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Generelt"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Afslut"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Søgning"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneler"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Gå tilbage til forrige panel"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Afbryd søgning"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Indstillinger;Opsætning;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Id for det sidst åbnede indstillingspanel"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Id for det indstillingspanel der sidst blev åbnet. Ukendte værdier "
+"ignoreres, og første panel i listen vælges i stedet."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Vis advarsel ved kørsel af udviklingsversionen af Indstillinger"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Om Indstillinger skal vise en advarsel ved kørsel af en udviklerversion."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Vinduets begyndelsestilstand"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"En tupel som indeholder programvinduets startbredde og -højde samt "
+"maksimeringstilstand."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u output"
+msgstr[1] "%u outputs"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u input"
+msgstr[1] "%u inputs"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Systemlyde"
+
+#~ msgid "Light"
+#~ msgstr "Lys"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "skærm;lås;diagnostik;baglås;nedbrud;privat;seneste;midlertidig;tmp;indeks;"
+#~ "navn;netværk;identitet;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Placering af skærme"
+
+#~ msgid "Set"
+#~ msgstr "Angiv"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Lås din skærm"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER- eller PEM-certifikater (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Tilføj en printer …"
+
+#~ msgid "Bark"
+#~ msgstr "Gø"
+
+#~ msgid "Drip"
+#~ msgstr "Dryp"
+
+#~ msgid "Glass"
+#~ msgstr "Glas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Lydpanel til GNOME Indstillinger"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Mus- og pegepladepanel til GNOME Indstillinger"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Baggrundspanel til GNOME Indstillinger"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Tastaturpanel til GNOME Indstillinger"
+
+#~ msgid "More Warm"
+#~ msgstr "Varmere"
+
+#~ msgid "Less Warm"
+#~ msgstr "Koldere"
+
+#~ msgid "Move up"
+#~ msgstr "Flyt op"
+
+#~ msgid "Move down"
+#~ msgstr "Flyt ned"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Godkend"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Skærmdeling lader fjernbrugere se eller styre din skærm ved at forbinde "
+#~ "til %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Skærmdeling"
+
+#~ msgid "_Password:"
+#~ msgstr "_Adgangskode:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Vis adgangskode"
+
+#~ msgid "Access Options"
+#~ msgstr "Adgangsindstillinger"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Nye forbindelser skal bede om adgang"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Kræv en adgangskode"
+
+#~ msgid "Web Links"
+#~ msgstr "Weblinks"
+
+#~ msgid "Git Links"
+#~ msgstr "Git-links"
+
+#~ msgid "%s Links"
+#~ msgstr "%s-links"
+
+#~ msgid "Unset"
+#~ msgstr "Nulstil"
+
+#~ msgid "Links"
+#~ msgstr "Links"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hypertekstfiler"
+
+#~ msgid "Text Files"
+#~ msgstr "Tekstfiler"
+
+#~ msgid "Image Files"
+#~ msgstr "Billedfiler"
+
+#~ msgid "Font Files"
+#~ msgstr "Skrifttypefiler"
+
+#~ msgid "Archive Files"
+#~ msgstr "Arkivfiler"
+
+#~ msgid "Package Files"
+#~ msgstr "Pakkefiler"
+
+#~ msgid "Audio Files"
+#~ msgstr "Lydfiler"
+
+#~ msgid "Video Files"
+#~ msgstr "Videofiler"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Rettigheder og adgang"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Data og tjenester som dette program har bedt om adgang til og "
+#~ "rettigheder, som det kræver."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Kan ikke ændres"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Programmers individuelle rettigheder kan gennemses i <a href=\"privacy"
+#~ "\">privatlivsindstillingerne</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integration"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Angiv skrivebordsbaggrund"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Standardhåndteringer"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Fil- og linktyper som dette program åbner."
+
+#~ msgid "Usage"
+#~ msgstr "Forbrug"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Hvor mange ressourcer dette program bruger."
+
+#~ msgid "Open in Software"
+#~ msgstr "Åbn i Software"
+
+#~ msgid "Activities"
+#~ msgstr "Aktiviteter"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Giv tilladelse til at programmerne nedenfor må bruge dit kamera."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Kunne ikke sende fil: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profilen er blevet uploadet til:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Skriv denne adresse ned."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Genstart denne computer og start dit normale operativsystem."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Skriv adressen ind i din webbrowser for at hente og installere profilen."
+
+#~ msgid "Upload profile"
+#~ msgstr "Upload profil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Kræver internetforbindelse"
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopiér"
+
+#~ msgid "Select _All"
+#~ msgstr "Vælg _alt"
+
+#~ msgid "Single Display"
+#~ msgstr "Enkelt skærm"
+
+#~ msgid "Join Displays"
+#~ msgstr "Sammenføj skærme"
+
+#~ msgid "Display Mode"
+#~ msgstr "Skærmtilstand"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Træk skærme, så de passer til din fysiske opsætning af skærme. Vælg en "
+#~ "skærm for at ændre dens indstillinger."
+
+#~ msgid "Active Display"
+#~ msgstr "Aktiv skærm"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Gem et skærmbillede i $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Gem et skærmbillede af et vindue i $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Gem et skærmbillede af et område i $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopiér et skærmbillede til udklipsholderen"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopiér et skærmbillede af et vindue til udklipsholderen"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopiér et skærmbillede af et område til udklipsholderen"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Optag en kort skærmvideo"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Placeringstjenester lader programmer vide hvor du er. Brug af wi-fi og "
+#~ "mobilt bredbånd forøger præcisionen."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Bruger Mozillas positionstjeneste: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Privatlivspolitik</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr ""
+#~ "Giv tilladelse til at programmerne nedenfor må fastslå din placering."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Giv tilladelse til at programmerne nedenfor må bruge din mikrofon."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Dobbeltklik-tid"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Hvile- og tænd/sluk-knap"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Skød detekteret: ydelsestilstand utilgængelig"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Høj hardwaretemperatur: ydelsestilstand utilgængelig"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Ydelsestilstand utilgængelig"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Vælg tal-, dato- og valutaformat. Ændringer træder i kraft ved næste "
+#~ "login."
+
+#~ msgid "My Account"
+#~ msgstr "Min konto"
+
+#~ msgid "Language"
+#~ msgstr "Sprog"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Sproget anvendt til tekst i vinduer og på websider."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Genstart sessionen for at få ændringerne til at træde i kraft"
+
+#~ msgid "Restart…"
+#~ msgstr "Genstart …"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Indstillinger for login gælder for alle brugere når de logger ind på "
+#~ "systemet"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Styr hvilke søgeresultater som vises i aktivitetsoversigten. Rækkefølgen "
+#~ "på søgeresultaterne kan også ændres ved at flytte rækkerne i listen."
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Visse tjenester er deaktiveret fordi der ikke er netværksadgang."
+
+#~ msgid "Sound Keys"
+#~ msgstr "Lydtaster"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Skærmoplæser"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Skærmoplæser"
+
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgid "Account _Type"
+#~ msgstr "Konto_type"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Tillad bruger at angive en adgangskode ved næste _login"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Angiv en adgangskode _nu"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Du skal være på nettet for at kunne tilføje enterprise-brugere."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Tag et billede …"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klik først på *-ikonet\n"
+#~ "for at lave ændringer"
+
+#~ msgid "Create a user account"
+#~ msgstr "Opret ny brugerkonto"
+
+#~ msgid "User Icon"
+#~ msgstr "Brugerikon"
+
+#~ msgid "Account Settings"
+#~ msgstr "Kontoindstillinger"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Godkendelse og login"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Dette vil blive brugt til at navngive din hjemmemappe og kan ikke ændres."
+
+#~ msgid "Output:"
+#~ msgstr "Output:"
+
+# "letterbox" er når man beskærer så der kommer en sort rand som på film når fjernsyns- og biografformater ikke passer.  http://en.wikipedia.org/wiki/Letterbox
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Behold højde-/breddeforhold (beskær):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Afbild til enkelt skærm"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d af %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Skærmafbildning"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tegneplade (absolut)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Touchpad (relativ)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Indstillinger for tegneplade"
+
+#~ msgid "_Help"
+#~ msgstr "_Hjælp"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth-indstillinger"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Sporingstilstand"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Tildel knapper …"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Justér museindstillinger"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Justér skærmopløsning"
+
+#~ msgid "No stylus found"
+#~ msgstr "Ingen pen fundet"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Flyt din pen hen til tegnepladen for at konfigurere den"
+
+# der er tre: 'top', 'lower' og 'lowest'.
+#
+# Gæt: Det er nok fordi kun nogle modeller har en tredje (lowest).
+#
+# Muligheder:
+#
+# Øvre, nedre, nederste?
+# Første, anden, tredje?
+# Andet?
+#~ msgid "Top Button"
+#~ msgstr "Øvre knap"
+
+#~ msgid "Lower Button"
+#~ msgstr "Nedre knap"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Underste knap"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Låser op …"
+
+#~ msgid "Left Alt"
+#~ msgstr "Venstre Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Højre Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Venstre Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Højre Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Højre Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Tast for alternative tegn"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Skift til næste kilde med kun modifikatorer"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Menutast"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Hold den nede og skriv for at indtaste andre tegn"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Oplader"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Forsigtig"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Lav"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "God"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Fuldt opladet"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Tomt"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Skærmlysstyrke"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Tastaturlysstyrke"
+
+#~ msgid "_Dim Screen When Inactive"
+#~ msgstr "_Dæmp skærmen ved inaktivitet"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Sort skærm"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wi-fi kan slås fra for at spare strøm."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr "Mobilt bredbånd (LTE, 4G, 3G osv.) kan slås fra for at spare strøm."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth kan slås fra for at spare strøm."
+
+#~ msgid "Add…"
+#~ msgstr "Tilføj …"
+
+#~ msgid "Previous source"
+#~ msgstr "Forrige kilde"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Skift+Mellemrum"
+
+#~ msgid "Next source"
+#~ msgstr "Næste kilde"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Mellemrum"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Venstre+højre Alt"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Login;Navn;Fingeraftryk;Profilbillede;Logo;Ansigt;Adgangskode;"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Tilføj brugerkonti og skift adgangskoder"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Afspil og optag lyd"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Registrer netværksenheder med mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Tilgå bluetoothhardware direkte"
+
+#~ msgid "Use your camera"
+#~ msgstr "Brug dit kamera"
+
+#~ msgid "Print documents"
+#~ msgstr "Udskriv dokumenter"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Brug tilsluttet joystick"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Tillad oprettelse af forbindelse til Docker-tjenesten"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Konfigurér firewall for netværk"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Opsæt og brug priviligerede FUSE-filsystemer"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Opdatér firmware på enheden"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Tilgå hardwareinformation"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Levér entropi til hardwarens tilfældige tal-generator"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Brug hardwaregenererede tilfældige tal"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Tilgå filer i din hjemmemappe"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Tilgå libvirt-tjeneste"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Skift systemsprog og regionsindstillinger"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Skift placeringsindstillinger og -udbydere"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Læs system- og programlogge"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "tilgå tjenesten media-hub"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Brug og konfigurer modemmer"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Læs systemets monteringsinformation og diskkvoter"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Styr musik- og videoafspillere"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Skift netværksindstillinger på lavt niveau"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Tilgå NetworkManager-tjenesten for at læse og skifte netværksindstillinger"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Læseadgang til netværksindstillinger"
+
+#~ msgid "Change network settings"
+#~ msgstr "Skift netværksindstillinger"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Tilgå ofono-tjenesten for at læse og skifte netværksindstillinger for "
+#~ "mobiltelefoni"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Styr Open vSwitch-hardware"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Læs fra cd/dvd"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Læs, tilføj, skift eller fjern gemte adgangskoder"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Tilgå pppd- og ppp-enheder for at konfigurere Point-to-Point Protocol-"
+#~ "forbindelser"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Paus eller afslut en proces på systemet"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Tilgå USB-hardware direkte"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Læs/skriv filer på flytbare lagerenheder"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Forhindr skærmen i at sove/låse"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Tilgå seriel port-hardware"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Genstart eller sluk for enheden"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Installér, fjern og konfigurer software"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Tilgå Storage Framework-tjeneste"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Læs proces- og systeminformation"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Overvåg og styr kørende programmer"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Skift datoen og klokkeslættet"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Skift tidsserverindstillinger"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Skift tidszonen"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr "Tilgå UDisks2-tjenesten for at konfigurere diske og flytbare medier"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Læs/skift delte kalenderbegivenheder i Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Læs/skift delte kontakter i Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Tilgå data om energiforbrug"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Læse-/skriveadgang til U2F-enheder blotlagt"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Indstil baggrund og låseskærm"
+
+#~ msgid "Set Background"
+#~ msgstr "Indstil baggrund"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Indstil låseskærm"
+
+#~ msgid "Remove Background"
+#~ msgstr "Fjern baggrund"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Tilgængelighed"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Slå fra for at forbinde til et wi-fi-netværk"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Adgangskode"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klik først *-ikonet\n"
+#~ "for at oprette en brugerkonto"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Aktivér login med fingeraftryk"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_En anden finger:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Dit fingeraftryk blev gemt. Du bør nu kunne logge ind ved brug af din "
+#~ "fingeraftryksaflæser."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Du har ikke tilladelse til at tilgå enheden. Kontakt din "
+#~ "systemadministrator."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Der opstod en intern fejl."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Slet registrerede fingeraftryk?"
+
+#~ msgid "Done!"
+#~ msgstr "Gjort!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Kunne ikke tilgå “%s”-enheden"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Kunne ikke påbegynde fingermåling på “%s”-enheden"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Kunne ikke tilgå nogen fingeraftryksaflæsere"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Kontakt venligst din systemadministrator for hjælp."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "For at aktivere login med fingeraftryk, skal du gemme et af dine "
+#~ "fingeraftryk ved brug af “%s”-enheden."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Vælg finger"
+
+#~| msgid ""
+#~| "Sending reports of technical problems helps us improve %s. Reports are "
+#~| "sent anonymously and are scrubbed of personal data."
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "Rapporter sendes anonymt og renses for personlige data."
+
+#~| msgid ""
+#~| "Sending reports of technical problems helps us improve %s. Reports are "
+#~| "sent anonymously and are scrubbed of personal data."
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Afsendelse af rapporter om tekniske problemer hjælper os med at forbedre "
+#~ "styresystemet."
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "_Begræns forbruget af data i baggrunden"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Nyttig til forbindelser med begrænsede eller takserede data."
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Pop op'er til påmindelser"
+
+#~ msgid "No regions found"
+#~ msgstr "Ingen regioner fundet"
+
+#~ msgid "Last Login"
+#~ msgstr "Sidste login"
+
+#~ msgid "Version %s"
+#~ msgstr "Version %s"
+
+#~ msgid "OS name"
+#~ msgstr "OS-navn"
+
+#~ msgid "OS type"
+#~ msgstr "OS-type"
+
+#~ msgid "Disk"
+#~ msgstr "Disk"
+
+#~ msgid "Check for updates"
+#~ msgstr "Søg efter opdateringer"
+
+#~ msgid "Network proxy"
+#~ msgstr "Netværksproxy"
+
+#~ msgid "page 1"
+#~ msgstr "side 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Indre _godkendelse"
+
+#~ msgid "page 2"
+#~ msgstr "side 2"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Parsnoet kabel (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Tilslutningsenhedsgrænseflade (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Medieuafhængig grænseflade (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Hvis du tænder for det trådløse hotspot, vil du blive frakoblet <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Det er ikke muligt at tilgå internettet gennem din trådløse forbindelse, "
+#~ "mens hotspottet er aktivt."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Wi-fi-hotspots bruges normalt til at dele en internetforbindelse over wi-"
+#~ "fi."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "_Forbind automatisk"
+
+#~ msgid "details"
+#~ msgstr "detaljer"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Vis _adgangskode"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Gør tilgængelig for andre brugere"
+
+#~ msgid "identity"
+#~ msgstr "identitet"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adresser"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Kun automatiske adresser (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Kun link-lokal"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignorér automatisk fundne ruter"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Klonet MAC-adresse"
+
+#~ msgid "_Reset"
+#~ msgstr "_Nulstil"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Nulstil indstillingerne for denne forbindelse, men husk som foretrukken "
+#~ "forbindelse."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Fjern alle detaljer vedrørende dette netværk, og prøv ikke automatisk at "
+#~ "forbinde til det."
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Nulstil"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Forbundne enheder"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastruktur"
+
+#~ msgid "In use"
+#~ msgstr "I brug"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Slået til"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Slået fra"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Slukket"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Tændt"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Slukket"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Tændt"
+
+#~ msgid "Usage & History"
+#~ msgstr "Brug & historik"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Privatlivspolitik"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Ting bliver nemmere at finde igen hvis din historik huskes. Disse ting "
+#~ "deles aldrig over netværket."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Seneste"
+
+#~ msgid "Retain _History"
+#~ msgstr "Gem _historik"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Skærmlåsningen beskytter dit privatliv når du er væk."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Lås skærmen _efter sort skærm i"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Påmindelser for låst skærm"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Tøm automatisk papirkurven og slet midlertidige filer for at holde din "
+#~ "computer fri for unødvendige private oplysninger."
+
+#~ msgid "Purge _After"
+#~ msgstr "Ryd _efter"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Hvis du sender os informationer om hvilke programmer du bruger, hjælper "
+#~ "du os med at give dig mere nøjagtige anbefalinger. Det hjælper os også "
+#~ "med at forbedre vores programmer.\n"
+#~ "\n"
+#~ "Alle oplysningerne, vi samler sammen, gøres anonym og vi vil aldrig dele "
+#~ "dine data med nogen tredjepart."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Send statistik om softwarebrug"
+
+#~ msgid "_Camera"
+#~ msgstr "_Kamera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Mikrofon"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Placeringstjenester"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Beskyt dine personlige oplysninger og bestem hvad andre kan se"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Blink med vinduets _titellinje"
+
+#~ msgid "_Background"
+#~ msgstr "_Baggrund"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Ændrer sig i løbet af dagen"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Fliser"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrér"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Skalér"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Udfyld"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Udspænd"
+
+#~ msgid "Colors"
+#~ msgstr "Farver"
+
+#~ msgid "Pictures"
+#~ msgstr "Billeder"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Ingen billeder fundet"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Her vises de billeder, du tilføjer til mappen %s"
+
+#~ msgid "_Off"
+#~ msgstr "_Deaktiveret"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automatisk hvile"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Når der trykkes på tænd-/sluk-knappen"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Brugernavnet kan ikke begynde med “-”."
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+# egentlig 'med stjerne'
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Forbindelse/SSID"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+# I strengene både før og efter er display oversat med skærm
+#~ msgid "Drag displays to match your setup."
+#~ msgstr "Træk skærmene for at matche din opstilling."
+
+#~ msgid "_Night Light"
+#~ msgstr "_Nattelys"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Kunne ikke finde skærminformation"
+
+#~ msgid "hardware"
+#~ msgstr "hardware"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Skift til forrige kilde"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Skift til næste kilde"
+
+# ???
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Alternativt skift til næste kilde"
+
+#~ msgid "Add input source"
+#~ msgstr "Tilføj inputkilde"
+
+#~ msgid "Remove input source"
+#~ msgstr "Fjern inputkilde"
+
+#~ msgid "Move input source up"
+#~ msgstr "Flyt inputkilde opad"
+
+#~ msgid "Move input source down"
+#~ msgstr "Flyt inputkilde ned"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Vis tastaturlayout for inputkilde"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Venstre"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Højre"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimum"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maksimum"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Uforstærket"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Afprøv højttalere"
+
+#~ msgid "Peak detect"
+#~ msgstr "Top-bestemmelse"
+
+#~ msgid "Device"
+#~ msgstr "Enhed"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Tester højttaler for %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Vælg en enhed til lydafspilning:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Indstillinger for den valgte enhed:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Optagelydstyrke:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Vælg en enhed til lydoptagelse:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Lydeffekter"
+
+#~ msgid "Built-in"
+#~ msgstr "Indbygget"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Lydindstillinger"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Tester begivenhedslyd"
+
+#~ msgid "From theme"
+#~ msgstr "Fra tema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Vælg en påmindelseslyd:"
+
+#~ msgid "Stop"
+#~ msgstr "Stop"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrator"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME Kontrolcenter"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Kontrolcenteret er GNOMEs hovedgrænseflade til konfiguration af "
+#~ "forskellige aspekter af dit skrivebord."
+
+#~ msgid "Quit"
+#~ msgstr "Afslut"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Engelsk (Storbritannien)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Storbritannien"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Bekræft ny adgangskode"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Adgangskoderne stemmer ikke."
+
+#~ msgid "page 3"
+#~ msgstr "side 3"
+
+#~ msgid "Show the overview"
+#~ msgstr "Vis oversigten"
+
+#~ msgid "Back­ground"
+#~ msgstr "Bag­grund"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blue­tooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Far­ve"
+
+#~ msgid "Overview"
+#~ msgstr "Oversigt"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Standard­program­mer"
+
+#~ msgid "Ab­out"
+#~ msgstr "Om"
+
+#~ msgid "De­tails"
+#~ msgstr "De­tal­jer"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Flyt­bare medier"
+
+#~ msgid "Net­work"
+#~ msgstr "Net­værk"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "På­min­del­ser"
+
+# Fejlen er kun vigtig for længere strenge.  Tak til Kris for oprindeligt at have rapporteret denne!!
+#~ msgid "Po­wer"
+#~ msgstr "Strøm"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Pri­vat­liv"
+
+#~ msgid "Sha­ring"
+#~ msgstr "De­ling"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Til­gæn­ge­lig­hed"
+
+#~ msgid "Disable image"
+#~ msgstr "Deaktivér billede"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Gennemse flere billeder …"
+
+#~ msgid "Used by %s"
+#~ msgstr "Bruges af %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wa­com-tegne­plade"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "System"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Låg lukket"
+
+#~ msgid "Mirrored"
+#~ msgstr "Klonede"
+
+#~ msgid "Secondary"
+#~ msgstr "Sekundær"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Arrangér kombinerede skærme"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Rotér 90° mod uret"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Rotér 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Rotér 90° med uret"
+
+#~ msgid "Size"
+#~ msgstr "Størrelse"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Vis topbjælken og aktivitetsoversigten i denne visning"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Slå denne skærm sammen med en anden for at oprette et ekstra arbejdsområde"
+
+#~ msgid "Presentation"
+#~ msgstr "Præsentation"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Vis kun diasshow og medier"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Brug din eksisterende konfiguration på begge skærme"
+
+#~ msgid "Turn Off"
+#~ msgstr "Sluk"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Brug ikke denne skærm"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Arrangér kombinerede skærme"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (Build-id: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "Basissystem"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Genvej;Gentagelse;Blink;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Tryk Esc for at annullere."
+
+#~ msgid "Server"
+#~ msgstr "Server"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Slet DNS-server"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Gør tilgængelig for andre _brugere"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Firewall-_zone"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Forvalg"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Zonen definerer forbindelsens betroethed"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Nulstil indstillinger for dette netværk inklusive adgangskoder, men husk "
+#~ "det som et foretrukkent netværk"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Fjern alle detaljer vedrørende dette netværk, og prøv ikke automatisk at "
+#~ "forbinde"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Hvis du har en internetforbindelse som ikke er trådløs, kan du indstille "
+#~ "et trådløst hotspot til at dele forbindelsen med andre."
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Tilføj profil …"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manuel"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatisk"
+
+#~ msgid "Group Name"
+#~ msgstr "Gruppenavn"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Brug som hotspot …"
+
+#~ msgid "_History"
+#~ msgstr "_Historik"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Prøv at tilføje flere bogstaver, tal eller symboler."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Styrke: svag"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Styrke: lav"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Styrke: middel"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Styrke: god"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Styrke: høj"
+
+#~ msgid "Add Account"
+#~ msgstr "Tilføj konto"
+
+#~ msgid "Mail"
+#~ msgstr "Post"
+
+#~ msgid "Calendar"
+#~ msgstr "Kalender"
+
+#~ msgid "Contacts"
+#~ msgstr "Kontakter"
+
+#~ msgid "Chat"
+#~ msgstr "Chat"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Konfigurerer"
+
+#~ msgid "Toner Level"
+#~ msgstr "Tonerniveau"
+
+#~ msgid "Supply Level"
+#~ msgstr "Forsyningsniveau"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Installerer"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktiv"
+#~ msgstr[1] "%u aktive"
+
+#~ msgctxt "button"
+#~ msgid "Add"
+#~ msgstr "Tilføj"
+
+#~ msgid "Supply"
+#~ msgstr "Forsyning"
+
+#~ msgid "Jobs"
+#~ msgstr "Job"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Vis _job"
+
+#~ msgid "label"
+#~ msgstr "etiket"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Udskriv _testside"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Påmindelsesbannere"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Påmindelses_bannere"
+
+#~ msgid "Error creating account"
+#~ msgstr "Fejl ved oprettelse af konto"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Er du sikker på, at du vil slette kontoen?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Dette vil ikke slette kontoen på serveren."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Ingen onlinekonti konfigureret"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Tilføjelse af en konto tillader dine programmer at tilgå den for "
+#~ "dokumenter, e-mail, kontakter, kalender, chat med mere."
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Tilføj en ny printer"
+
+#~ msgid "No printers detected."
+#~ msgstr "Ingen printere valgt."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Andre konti"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Op"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Ned"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "Left Ring"
+#~ msgstr "Venstre ring"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Venstre ringtilstand #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Højre ringtilstand #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Venstre berøringsstribe"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Venstre berøringsstribetilstand #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Højre berøringsstribe"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Højre berøringsstribetilstand #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Tilstandsskift for venstre berøringsring"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Tilstandsskift for højre berøringsring"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Tilstandsskift for venstre berøringsstribe"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Tilstandsskift for højre berøringsstribe"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Tilstandsskift #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Venstre knap #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Højre knap #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Øverste knap #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Nederste knap #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Ingen handling"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Venstre museklik"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Rul opad"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Rul nedad"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Rul til højre"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr "Tastaturgenvej for <b>%s</b>. Indtast ny genvej for at ændre."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "En genvejstast ændres ved at klikke på rækken og trykke på den nye tast, "
+#~ "eller trykke tilbagetast for at rydde."
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Fjern genvej"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<ukendt handling>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Genvejen “%s” kan ikke bruges da det derved vil være umuligt at skrive "
+#~ "med denne tast.\n"
+#~ "Prøv venligst med f.eks. Ctrl-, Alt- eller Skift-tasten på samme tid."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Genvejen “%s” bliver allerede benyttet til\n"
+#~ "“%s”"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Hvis du laver genvejen til “%s” om, vil “%s”-genvejen blive deaktiveret."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Omtildel"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Genvejen “%s” er associeret med “%s”-genvejen. Ønsker du at sætte den til "
+#~ "“%s” automatisk?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "“%s” er i øjeblikket associeret med “%s”, denne genvej blive deaktiveret "
+#~ "hvis du vælger at fortsætte."
+
+#~ msgid "_Assign"
+#~ msgstr "_Tildel"
+
+#~ msgid "Bond"
+#~ msgstr "Binding"
+
+#~ msgid "Team"
+#~ msgstr "Hold"
+
+#~ msgid "Bridge"
+#~ msgstr "Bro"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Kunne ikke indlæse VPN-udvidelsesmoduler"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Tilføj netværksforbindelse"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Bindingsslaver"
+
+#~ msgid "(none)"
+#~ msgstr "(intet)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Bro-slaver"
+
+#~ msgid "Team slaves"
+#~ msgstr "Holdslaver"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand-enhed understøtter ikke forbundet tilstand"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Intet certifikat fra certifikatautoritet valgt"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Hvis man ikke bruger et certifikat fra en certifikatautoritet (CA), kan "
+#~ "man komme til at forbinde til usikre, fjendtligtsindede netværk.  Vil du "
+#~ "vælge et certifikat fra en certifikatautoritet?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignorér"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Vælg CA-certifikat"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Sp_ørg efter denne adgangskode hver gang"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "_Advar mig ikke igen"
+
+#~ msgid "Yes"
+#~ msgstr "Ja"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Fejl ved log ind til kontoen"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Akkreditiver udløbet."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Log ind for at aktivere denne konto."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Log ind"
+
+# Flertal med vilje
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Andre"
+
+#~ msgid "_Verify"
+#~ msgstr "_Verificér"
+
+#~ msgid "Login History"
+#~ msgstr "Loginhistorik"
+
+#~ msgid "Add User Account"
+#~ msgstr "Tilføj brugerkonti"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Der findes allerede en bruger med brugernavnet “%s”."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Bruges til at bestemme din geografiske placering"

--- a/po/de.po
+++ b/po/de.po
@@ -28,116 +28,19 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-06 16:35+0000\n"
-"PO-Revision-Date: 2022-09-06 23:07+0200\n"
-"Last-Translator: Jürgen Benvenuti <gastornis@posteo.org>\n"
-"Language-Team: German - Germany <gnome-de@gnome.org>\n"
-"Language: de_DE\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-09-15 21:05+0200\n"
+"Last-Translator: Tim Sabsch <tim@sabsch.com>\n"
+"Language-Team: Germany <gnome-de@gnome.org>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "System-Bus"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Vollständiger Zugriff"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Sitzungs-Bus"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Geräte"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Vollständiger Zugriff auf /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Netzwerk"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Hat Netwerkzugriff"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Persönlicher Ordner"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Nur Lesezugriff"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Dateisystem"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Einstellungen"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Darf Einstellungen ändern"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s hat die folgenden Berechtigungen eingebaut, die nicht geändert werden "
-"können. Falls Sie diesbezüglich Bedenken haben, sollten Sie in Erwägung "
-"ziehen, diese Anwendung zu löschen."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u Datei- und Verknüpfungs-Typ wird von dieser Anwendung geöffnet"
-msgstr[1] ""
-"%u Datei- und Verknüpfungs-Typen werden von dieser Anwendung geöffnet"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> wird verwendet, um die folgenden Datei- und Verknüpfungs-Typen zu "
-"öffnen."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s des Speicherplatzes wird verwendet"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -153,7 +56,6 @@ msgid "Install some…"
 msgstr "Einige installieren …"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Öffnen"
 
@@ -177,24 +79,13 @@ msgstr "Suchen"
 msgid "Receive system searches and send results."
 msgstr "System durchsuchen und Ergebnisse anzeigen."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Deaktiviert"
 
@@ -358,81 +249,21 @@ msgstr "Zwischenspeicher leeren …"
 msgid "Control various application permissions and settings"
 msgstr "Festlegen verschiedener Anwendungs-Berechtigungen und Einstellungen"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "application;anwendung;flatpak;permission;berechtigung;setting;einstellung;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Ein Bild wählen"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "Abbre_chen"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "Ö_ffnen"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "mehrere Größen"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Kein Schreibtisch-Hintergrund"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Aktueller Hintergrund"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stil"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Vorgabe"
 
@@ -456,7 +287,6 @@ msgstr "Erscheinungsbild"
 msgid "Change your background image or the UI colors"
 msgstr "Hintergrundbild oder die Farben der Anwendungsoberflächen ändern"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -510,11 +340,9 @@ msgstr "Hardware-Flugzeugmodus ist aktiviert"
 #: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
-"Schalten Sie den Flugzeugmodusschalter aus, um Bluetooth zu aktivieren."
+"Schalten Sie den Flugzeugmodus-Schalter aus, um Bluetooth zu aktivieren."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -522,7 +350,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Schalten Sie Bluetooth an oder aus und verbinden Sie Ihre Geräte"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "Freigabe;Bluetooth;obex;"
@@ -550,102 +377,41 @@ msgstr ""
 
 #: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
-msgstr "Es hat keine Anwendung um Kamerazugriff gebeten"
+msgstr "Keine Anwendung hat um Kamerazugriff gebeten"
 
 #: panels/camera/gnome-camera-panel.desktop.in.in:4
 msgid "Protect your pictures"
 msgstr "Ihre Bilder schützen"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "camera;photos;video;webcam;lock;private;privacy;Kamera;Fotos;Bilder;Video;"
 "Filme;Webcam;sperren;privat;Datenschutz;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Platzieren Sie Ihr Kalibrierungsgerät über dem Quadrat und wählen Sie »Start«"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Verschieben Sie Ihr Kalibrierungsgerät in die Kalibrierungsposition und "
-"wählen Sie »Fortsetzen«"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Verschieben Sie Ihr Kalibrierungsgerät in die Oberflächenposition und wählen "
-"Sie »Fortsetzen«"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Schließen Sie die Laptop-Klappe"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Ein interner Fehler ist aufgetreten, der nicht behoben werden kann."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Die zur Kalibrierung notwendigen Werkzeuge sind nicht installiert."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Das Profil konnte nicht erstellt werden."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Der gesuchte Weißpunkt konnte nicht ermittelt werden."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Abgeschlossen!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrierung fehlgeschlagen!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Sie dürfen das Kalibrierungsgerät entfernen."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Lassen Sie das Kalibrierungsgerät während des Vorgangs in Ruhe"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Bildschirm-Kalibrierung"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Abbre_chen"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -662,140 +428,6 @@ msgstr "Fo_rtsetzen"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Fertig"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Laptop-Bildschirm"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Eingebaute Webcam"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Bildschirm %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Scanner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Kamera %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Drucker %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webcam %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Aktivieren Sie die Farbverwaltung für %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Farbprofile anzeigen für %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Nicht kalibriert"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Vorgabe: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Farbraum: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Testprofil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "ICC-Farbprofildatei wählen"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importieren"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Importierte ICC-Profile"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Alle Dateien"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Bildschirm"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Profil speichern"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Speichern"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Ein Farbprofil für das ausgewählte Gerät erstellen"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Das Messgerät wurde nicht erkannt. Bitte prüfen Sie, ob es korrekt "
-"angeschlossen und eingeschaltet ist."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Das Messgerät unterstützt die Profilierung von Druckern nicht."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Der Gerätetyp wird im Moment nicht unterstützt."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -940,7 +572,6 @@ msgstr "Datei _importieren …"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -952,9 +583,7 @@ msgstr ""
 "Jedes Gerät benötigt ein aktuelles Farbprofil, um die Farbverwaltung zu "
 "ermöglichen."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Mehr erfahren"
 
@@ -1087,82 +716,6 @@ msgstr "D65 (Fotografie und Grafik)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standard-Farbraum"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testprofil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatisch"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Geringe Qualität"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Mittlere Qualität"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Hohe Qualität"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Standard-RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Standard-CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Standard-Grau"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Vom Hersteller gelieferte Kalibrierungsdaten"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Vollflächige Bildschirmkorrektur ist mit diesem Profil nicht möglich"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Dieses Profil ist möglicherweise nicht mehr ausreichend genau"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Farbe"
@@ -1173,14 +726,9 @@ msgid ""
 msgstr ""
 "Kalibrieren Sie die Farbe Ihrer Geräte wie Monitore, Kameras oder Drucker"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Farbe;ICC;Profil;Kalibrieren;Drucker;Anzeige;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Andere …"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1195,13 +743,8 @@ msgid "No languages found"
 msgstr "Keine Sprachen gefunden"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Mehr …"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Entsperren, um Einstellungen zu ändern"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1230,151 +773,6 @@ msgstr "Stundenzahl verringern"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Minutenzahl verringern"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Heute"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Gestern"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d Stunde"
-msgstr[1] "%d Stunden"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d Minute"
-msgstr[1] "%d Minuten"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d Sekunde"
-msgstr[1] "%d Sekunden"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 Sekunden"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-Stunden"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e. %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e. %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1469,17 +867,11 @@ msgstr "Zeitzone a_utomatisch ermitteln"
 msgid "Requires location services enabled and internet access"
 msgstr "Erfordert aktivierte Ortungsdienste und eine Internetverbindung"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Aktiviert"
 
@@ -1487,15 +879,43 @@ msgstr "Aktiviert"
 msgid "Time Z_one"
 msgstr "_Zeitzone"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Entsperren"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Zeit_format"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Daten"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 Sekunden"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalender"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Zahlen"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Das Datum, die Zeit und die Zeitzone ändern"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Uhr;Zeitzone;Ort;"
@@ -1543,21 +963,9 @@ msgstr "Vorgabe-Anwendungen"
 msgid "Configure Default Applications"
 msgstr "Vorgabe-Anwendungen einrichten"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "Vorgabe;Voreinstellung;Anwendung;bevorzugt;Medien;Medium;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Der Versand von Fehlermeldungen bei technischen Problemen hilft uns, %s zu "
-"verbessern. Diese Meldungen sind frei von personenbezogenen Daten und werden "
-"anonym versendet. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1575,44 +983,9 @@ msgstr "Fehlerdiagnose"
 msgid "Report your problems"
 msgstr "Melden Sie Ihre Probleme"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostics;crash;Fehlerdiagnose;Absturz;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "An"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Aus"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Änderungen anwenden?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Änderungen können nicht angewendet werden"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Das könnte an Einschränkungen der Hardware liegen."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1663,31 +1036,6 @@ msgstr "Primärer Bildschirm"
 msgid "Night Light"
 msgstr "Nachtmodus"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Querformat"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Hochformat rechts gedreht"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Hochformat links gedreht"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Kopfstehendes Querformat"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1711,6 +1059,17 @@ msgstr "Anpassung für TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Skalieren"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Natürlicher Bildlauf"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1807,7 +1166,6 @@ msgstr "Bildschirme"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Legt fest, wie angeschlossene Monitore und Projektoren arbeiten"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1816,81 +1174,6 @@ msgstr ""
 "Panel;Projektor;xrandr;Anzeige;Auflösung;Aktualisieren;Bildschirm;Monitor;"
 "Nacht;Tag;Blau;Rotverschiebung;Farbe;Sonnenuntergang;Sonnenaufgang;"
 
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Gesicherter Sytemstart (secure boot) ist aktiv"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Gesicherter Sytemstart (secure boot) verhindert, dass bösartige Software "
-"beim Gerätestart geladen wird. Er ist aktuell eingeschaltet und arbeitet "
-"vollständig."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Gesicherter Sytemstart (secure boot) meldet Probleme"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Gesicherter Sytemstart (secure boot) verhindert, dass bösartige Software "
-"beim Gerätestart geladen wird. Er ist aktuell eingeschaltet, funktioniert "
-"aber nicht wegen eines ungültigen Schlüssels."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Probleme des gesicherten Sytemstarts (secure boot) lassen sich oft in den "
-"UEFI Firmware-Einstellungen (BIOS) lösen. Ihr Hardware-Hersteller liefert "
-"möglicherweise Hilfeleistung dabei."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Kontaktieren Sie für Unterstützung Ihren Hardware-Hersteller oder die IT-"
-"Hilfe."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Gesicherter Sytemstart (secure boot) ist ausgeschaltet"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Gesicherter Sytemstart (secure boot) verhindert, dass bösartige Software "
-"beim Gerätestart geladen wird. Er ist aktuell ausgeschaltet."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Der gesicherte Sytemstart (secure boot) wird normalerweise in den UEFI "
-"Firmware-Einstellungen (BIOS) eingeschaltet. Ihr Hardware-Hersteller oder "
-"die IT-Hilfe liefern möglicherweise Hilfestellung dabei."
-
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
 "Secure boot prevents malicious software from being loaded when the device "
@@ -1898,120 +1181,14 @@ msgid ""
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
-"Gesicherter Sytemstart (secure boot) verhindert, dass bösartige Software "
+"Gesicherter Systemstart (secure boot) verhindert, dass bösartige Software "
 "beim Gerätestart geladen wird.\n"
 "\n"
 "Erfahren Sie mehr bei Ihrem Hardware-Hersteller oder der IT-Hilfe."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Bestanden"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Fehlgeschlagen"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Das Gerät erfüllt die HSI-Stufe %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Sicherheitsstufe 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Sicherheitsstufe 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Sicherheitsstufe 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Sicherheitsstufe 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Sicherheitsstufe"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Die Sicherheitsstufe ist für dieses Gerät nicht verfügbar"
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2025,355 +1202,9 @@ msgstr "Stufe 2"
 msgid "Level 3"
 msgstr "Stufe 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Keine Ereignisse"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection"
-msgstr "Firmware-Version"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection Lock"
-msgstr "Firmware-Version"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Region"
-msgstr "Firmware-Version"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Descriptor"
-msgstr "Firmware-Version"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr ""
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr ""
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr ""
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr ""
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr ""
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr ""
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-#, fuzzy
-#| msgid "Suspend"
-msgid "Suspend To RAM"
-msgstr "Bereitschaft"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-#, fuzzy
-#| msgid "Suspend"
-msgid "Suspend To Idle"
-msgstr "Bereitschaft"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr ""
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr ""
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-#, fuzzy
-#| msgid "Display Configuration"
-msgid "TPM Platform Configuration"
-msgstr "Bildschirmeinrichtung"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr ""
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Firmware-Aktualisierungen"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware Attestation"
-msgstr "Firmware-Version"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware Updater Verification"
-msgstr "Firmware-Version"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr ""
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "AMD Firmware Replay Protection"
-msgstr "Firmware-Version"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "AMD Firmware Write Protection"
-msgstr "Firmware-Version"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr ""
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Gültig"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Ungültig"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Nicht eingeschaltet"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Gesperrt"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Nicht gesperrt"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Verschlüsselt"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Nicht verschlüsselt"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr ""
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-#, fuzzy
-#| msgid "Not calibrated"
-msgid "Not Tainted"
-msgstr "Nicht kalibriert"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Gefunden"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Nicht gefunden"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Unterstützt"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Nicht unterstützt"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2383,57 +1214,13 @@ msgstr "Gerätesicherheit"
 msgid "Host firmware security status"
 msgstr "Sicherheitsstatus der Geräte-Firmware"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
 "network;identity;privacy;"
 msgstr ""
 "Bildschirm;Sperre;Diagnose;Absturz;Crash;Privat;temporär;Index;Name;Netzwerk;"
-"Identität;Privatsphäre;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Nicht verfügbar"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "System-Logo"
+"Identität;Privatsphäre;Datenschutz;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2527,11 +1314,6 @@ msgstr "Info"
 msgid "View information about your system"
 msgstr "Informationen über Ihr System anzeigen"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2610,6 +1392,12 @@ msgstr "Starter"
 msgid "Launch help browser"
 msgstr "Hilfe-Browser starten"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Einstellungen"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Taschenrechner öffnen"
@@ -2631,7 +1419,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Suchen"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "System"
 
@@ -2680,15 +1468,6 @@ msgstr "Schrift verkleinern"
 msgid "High contrast on or off"
 msgstr "Hohen Kontrast ein-/ausschalten"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Keine Eingabequellen gefunden"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Weitere"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Eine Eingabequelle hinzufügen"
@@ -2721,107 +1500,9 @@ msgstr "Einstellungen"
 msgid "View Keyboard Layout"
 msgstr "Tastaturbelegung anzeigen"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Entfernen"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Eigene Tastenkombinationen"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Taste für alternative Zeichen"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Die Taste für alternative Zeichen kann verwendet werden, um weitere Zeichen "
-"einzugeben. Diese sind gelegentlich als dritte Option auf Ihrer Tastatur "
-"angegeben."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Linke Alt-Taste"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Rechte Alt-Taste"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Linke Super-Taste"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Rechte Super-Taste"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menü-Taste"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Rechte Strg-Taste"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Compose-Taste"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Die Compose-Taste ermöglicht es, eine Vielzahl an Zeichen einzugeben. Um sie "
-"zu nutzen, drücken Sie »Compose« und dann eine Sequenz an Zeichen. »Compose« "
-"gefolgt von <b>C</b> und <b>o</b> resultiert beispielsweise in <b>©</b>, "
-"<b>a</b> gefolgt von <b>'</b> resultiert in <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Feststelltaste"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Rollen"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Druck"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Eingabequellen können mit dem Tastenkürzel %s gewechselt werden.\n"
-"Das kann in den Tastenkürzel-Einstellungen geändert werden."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2849,47 +1530,23 @@ msgstr "Eingabe von Sonderzeichen"
 
 #: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
-msgstr "Methoden, mit der Tastatur Symbole und Zeichenvarianten einzugeben."
+msgstr "Methoden, um mit der Tastatur Symbole und Zeichenvarianten einzugeben."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Taste für alternative Zeichen"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose-Taste"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Tastenkombinationen"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Tastenkombinationen anzeigen und anpassen"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d geändert"
-msgstr[1] "%d geändert"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Alle Tastenkombination zurücksetzen?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Zurücksetzen der Tastaturkürzel kann Ihre persönlichen Tastaturkürzel "
-"beeinflussen. Kann nicht rückgängig gemacht werden."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Alles zurücksetzen"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2918,8 +1575,8 @@ msgstr "Individuelle Tastenkombinationen hinzufügen"
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"Richten Sie eigene Tastenkürzel zum Starten von Anwendungen, Skripten und "
-"mehr ein."
+"Richten Sie eigene Tastenkombinationen zum Starten von Anwendungen, Skripten "
+"und mehr ein."
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
@@ -2928,35 +1585,6 @@ msgstr "Tastenkombination hinzufügen"
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Keine Tastenkombination gefunden"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s wird bereits für %s verwendet. Wenn Sie diese ersetzen, so wird %s "
-"deaktiviert"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Neue Tastenkombination eingeben"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Eigene Tastenkombination festlegen"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Tastenkombination festlegen"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Geben Sie die neue Tastenkombination ein, um %s zu ändern."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Individuelle Tastenkombination hinzufügen"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
@@ -2969,7 +1597,6 @@ msgstr "Erset_zen"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Festlegen"
 
@@ -3007,6 +1634,11 @@ msgstr "Keine"
 msgid "Reset the shortcut to its default value"
 msgstr "Die Tastenkombination auf die Vorgabe zurücksetzen"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Ihre Kamera verwenden"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Tastatur"
@@ -3019,7 +1651,6 @@ msgstr ""
 "Tastenkombinationen ändern sowie individuelle Tastaturbelegungen, "
 "Tastaturlayouts und Eingabequellen einstellen"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3055,13 +1686,12 @@ msgstr ""
 
 #: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
-msgstr "Es hat keine Anwendung um Standortzugriff gebeten"
+msgstr "Keine Anwendung hat um Standortzugriff gebeten"
 
 #: panels/location/gnome-location-panel.desktop.in.in:4
 msgid "Protect your location information"
 msgstr "Ihre Standortinformationen schützen"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "location;gps;private;privacy;Ort;Standort;GPS;privat;Datenschutz;"
@@ -3090,13 +1720,12 @@ msgstr ""
 
 #: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
-msgstr "Es hat keine Anwendung um Mikrofonzugriff gebeten"
+msgstr "Keine Anwendung hat um Mikrofonzugriff gebeten"
 
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:4
 msgid "Protect your conversations"
 msgstr "Ihre Unterhaltungen schützen"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
@@ -3128,85 +1757,139 @@ msgstr "Links"
 msgid "Right"
 msgstr "Rechts"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Orte durchsuchen"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Maus"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Mausgeschwindigkeit"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Natürlicher Bildlauf"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Abschnitt"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Der Bildlauf verschiebt den Inhalt, nicht die Ansicht."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Der Bildlauf verschiebt den Inhalt, nicht die Ansicht."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktiv"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Tastfeld"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Tastfeld-Geschwindigkeit"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Antippen zum Klicken"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Antippen zum Klicken"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Bildlauf mit zwei Fingern"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Tastfeld (relativ)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Bildlauf am Rand"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Rollen"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Zweiseitig"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
-msgstr "Versuchen Sie zu klicken, doppelklicken oder rollen"
-
-# Doof. https://www.reddit.com/r/gnome/comments/1cgjh0/dear_gnome_developers_i_think_what_you_did_is/c9gay98
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Fünf Klicks, GEGL-Zeit!"
-
-# CHECK
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Doppelklick, primäre Taste"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Einfacher Klick, primäre Taste"
-
-# CHECK
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Doppelklick, mittlere Taste"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Einfacher Klick, mittlere Taste"
-
-# CHECK
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Doppelklick, sekundäre Taste"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Einfacher Klick, sekundäre Taste"
+msgstr "Versuchen Sie zu klicken, doppelzuklicken oder zu rollen"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3220,7 +1903,6 @@ msgstr ""
 "oder Linkshänder einstellen"
 
 # Ich vermute »tap« meint einen Mausklick in Form einer kurzen Fingerberührung des Touchpad
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3301,7 +1983,6 @@ msgstr "Multitasking"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Einstellungen für Produktivität und Multitasking verwalten"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3309,22 +1990,11 @@ msgstr ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 "Produktivität;Bearbeiten;Schreibtisch;Funktionale Ecke;Arbeitsumgebungen;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Hoppla, etwas ist schief gegangen. Bitte kontaktieren Sie Ihren Software-"
-"Hersteller."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager muss laufen."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Weitere Geräte"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3336,59 +2006,16 @@ msgstr "Verbindung hinzufügen"
 msgid "Not set up"
 msgstr "Nicht eingerichtet"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Unsicheres Netzwerk (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Sicheres Netzwerk (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Sicheres Netzwerk (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Sicheres Netzwerk (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Netzwerk sichern"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Verbunden"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Optionen …"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Wenn der Hotspot eingeschaltet wird, werden Sie von %s getrennt und können "
-"nicht auf das Internet mittels WLAN zugreifen."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Erfordert mindestens 8 Zeichen"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3439,20 +2066,6 @@ msgstr "Passwort automatisch generieren"
 msgid "_Turn On"
 msgstr "Einschal_ten"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "WLAN"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Den HotSpot anhalten und verbundene Benutzer trennen?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "Hot _Spot anhalten"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Flugzeugmodus"
@@ -3499,90 +2112,15 @@ msgstr "Sichtbare Netzwerke"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager muss laufen"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Hoppla, etwas ist schief gegangen. Bitte kontaktieren Sie Ihren Software-"
+"Hersteller."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x-_Sicherheit"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Sicherheit"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Beibehalten"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Dauerhaft"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Zufällig"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabil"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Die hier eingegebene MAC-Adresse wird als Hardware-Adresse des "
-"Netzwerkgerätes verwendet, für das diese Verbindung aktiviert ist. Dieses "
-"Funktionsmerkmal ist als »MAC-Cloning« oder »MAC-Spoofing« bekannt. "
-"Beispiel: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Erweitertes Öffnen"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Keine"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Nie"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3591,183 +2129,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "Vor %i Tag"
 msgstr[1] "Vor %i Tagen"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mbit/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mbit/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Keines"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Schwach"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "OK"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Gut"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Ausgezeichnet"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4-Adresse"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6-Adresse"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP-Adresse"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Verbindung entfernen"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Verbindungsprofil entfernen"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "VPN entfernen"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Details"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatisch"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identität"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Adresse entfernen"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Route entfernen"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Keine"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-Bit-Schlüssel (Hex oder ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-Bit-Passphrase"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamisches WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA und WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA und WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3778,8 +2139,20 @@ msgstr "Signalstärke"
 msgid "Link speed"
 msgstr "Verbindungsgeschwindigkeit"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sicherheit"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4-Adresse"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-Adresse"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hardware-Adresse"
 
@@ -3788,12 +2161,17 @@ msgid "Supported Frequencies"
 msgstr "Unterstützte Frequenzen"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Vorgaberoute"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3816,8 +2194,8 @@ msgstr ""
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
-"Softwareaktualisierungen und andere große Downloads werden nicht automatisch "
-"gestartet."
+"Software-Aktualisierungen und andere große Downloads werden nicht "
+"automatisch gestartet."
 
 #: panels/network/connection-editor/ethernet-page.ui:21
 #: panels/network/connection-editor/vpn-page.ui:17
@@ -3857,7 +2235,7 @@ msgstr "Nur Link-Local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manuell"
 
@@ -3901,9 +2279,8 @@ msgstr "Gateway"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automatisch"
 
@@ -3956,90 +2333,9 @@ msgstr "Automatisch, nur DHCP"
 msgid "Prefix"
 msgstr "Präfix"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Öffnen des Verbindungseditors schlug fehl"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Neues Profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Ungültige Einstellung %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Ungültige Einstellung %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Aus Datei importieren …"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "VPN hinzufügen"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Sicherheit"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "VPN-Verbindung kann nicht importiert werden"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Die Datei »%s« konnte nicht gelesen werden oder enthält keine gültige VPN-"
-"Verbindung\n"
-"\n"
-"Fehler: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Wählen Sie die Datei zum Importieren"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Eine Datei namens »%s« ist bereits vorhanden."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "E_rsetzen"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-"Wollen Sie %s mit der VPN-Verbindung ersetzen, die Sie gerade speichern?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "VPN-Verbindung kann nicht exportiert werden"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Die VPN-Verbindung »%s« konnte nicht nach %s exportiert werden\n"
-"\n"
-"Fehler: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "VPN-Verbindung exportieren"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4053,100 +2349,37 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Netzwerk"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Legt fest, wie mit dem Internet verbunden wird"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Netzwerk;LAN;IP;Proxy;WAN;Breitband;DSL;Modem;Bluetooth;VPN;Brücke;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "WLAN"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Legt fest, wie mit Funknetzwerken verbunden wird"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Netzwerk;Drahtlos;WLAN;Wifi;IP;LAN;Breitband;Hotspot;DNS;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nie"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "heute"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "gestern"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Zuletzt verwendet"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Kabelgebunden"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Neue Verbindung hinzufügen"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Netzwerkdetails für die gewählten Netzwerke, einschliesslich Passwort und "
-"jegliche benutzerdefinierte Konfiguration, werden verloren gehen."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Vergessen"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Bekannte Funknetzwerke"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Vergessen"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Die Systemeinstellungen verbieten die Nutzung als Hotspot"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Das Drahtlos-Gerät unterstützt keinen Hotspot-Modus"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Automatische Internet-Proxyerkennung wird verwendet, wenn keine "
-"Einrichtungsadresse angegeben wird."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Dies wird für unsichere öffentliche Netzwerke nicht empfohlen."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4165,6 +2398,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Dienstanbieter"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-Adresse"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4249,290 +2486,6 @@ msgstr "WLAN-Ho_tspot einschalten …"
 msgid "_Known Wi-Fi Networks"
 msgstr "Be_kannte Funknetzwerke"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Status unbekannt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Nicht verwaltet"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Nicht verfügbar"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Verbindung wird hergestellt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Legitimierung erforderlich"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Verbindung wird getrennt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Verbindung fehlgeschlagen"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Status unbekannt (fehlt)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Einrichtung ist fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP-Einrichtung ist fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP-Einrichtung ist abgelaufen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Geheimdaten waren erforderlich, wurden aber nicht angegeben"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x-Supplicant getrennt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Einrichten des 802.1x-Supplicant fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x-Supplicant fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x-Supplicant brauchte zu lange für die Legitimierung"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP-Dienst konnte nicht gestartet werden"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP-Dienst getrennt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP-Client konnte nicht gestartet werden"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP-Client-Fehler"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP-Client fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr ""
-"Dienst für gemeinsam verwendete Verbindung konnte nicht gestartet werden"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Dienst für gemeinsam verwendete Verbindung fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Start des AutoIP-Diensts fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Fehler des AutoIP-Diensts"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP-Dienst fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Die Leitung ist belegt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Kein Freizeichen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Es konnte kein Trägersignal aufgebaut werden"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Der Einwahlvorgang benötigte zu viel Zeit"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Der Einwahlversuch ist fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Modeminitialisierung fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Angegebener APN konnte nicht ausgewählt werden"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Es wird nicht nach Netzwerken gesucht"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Netzwerkanmeldung abgelehnt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Netzwerkanmeldung benötigte zu viel Zeit"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Anmeldung an dem angeforderten Netzwerk fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN-Überprüfung fehlgeschlagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Notwendige Firmware des Geräts fehlt möglicherweise"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Unzuverlässige Verbindung"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Es wurde von einer bestehenden Verbindung ausgegangen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem nicht gefunden"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth-Verbindung schlug fehl"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM-Karte ist nicht eingesetzt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM-Pin ist erforderlich"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM-Puk ist erforderlich"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Falsche SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Eine Abhängigkeit der Verbindung ist gescheitert"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Firmware fehlt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabel nicht angeschlossen"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "Nicht definierter Fehler in 802.1X-Sicherheit (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "keine Datei ausgewählt"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "Nicht spezifizierter Fehler beim Überprüfen der eap-method-Datei"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Geheimer DER, PEM, PKCS#12 oder PGP-Schlüssel"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER- oder PEM-Zertifikate"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "PAC-Datei für EAP-FAST fehlt"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC-Dateien (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4581,14 +2534,6 @@ msgstr "_Innere Legitimierung"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Automatische PAC-_Bereitstellung erlauben"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "Benutzername für EAP-LEAP fehlt"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "Passwort für EAP-LEAP fehlt"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4614,15 +2559,6 @@ msgstr "_Passwort"
 msgid "Sho_w password"
 msgstr "Pass_wort zeigen"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "Ungültiges CA-Zertifikat für EAP-PEAP: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "Ungültiges CA-Zertifikat für EAP-PEAP: kein Zertifikat angegeben"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4644,7 +2580,6 @@ msgid "C_A certificate"
 msgstr "_CA-Zertifikat"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4659,63 +2594,6 @@ msgstr "CA-Zertifikat ist nicht e_rforderlich"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP-_Version"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "EAP-Benutzername fehlt"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "EAP-Passwort fehlt"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "EAP-TLS-Identität fehlt"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "Ungültiges CA-Zertifikat für EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "Ungültiges CA-Zertifikat für EAP-TLS: kein Zertifikat angegeben"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "Ungültiger geheimer Schlüssel für EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "Ungültiges Benutzerzertifikat für EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Unverschlüsselte geheime Schlüssel sind unsicher"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Der gewählte Schlüssel scheint nicht durch ein Passwort geschützt zu sein. "
-"Dies gefährdet Ihre Sicherheitsinformationen. Bitte wählen Sie einen durch "
-"ein Passwort geschützten geheimen Schlüssel.\n"
-"\n"
-"(Sie können Ihren Schlüssel mit openssl mit einem Passwort schützen)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Wählen Sie Ihr persönliches Zertifikat"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Wählen Sie Ihren geheimen Schlüssel"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4732,15 +2610,6 @@ msgstr "Geheimer _Schlüssel"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Passwort für geheimen Schlüssel"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "Ungültiges CA-Zertifikat für EAP-TTLS: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "Ungültiges CA-Zertifikat für EAP-TTLS: kein Zertifikat angegeben"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4763,14 +2632,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domäne"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Unbekannter Fehler beim Überprüfen der 802.1X-Sicherheit"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4798,62 +2668,10 @@ msgstr "Geschütztes EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Legitimierung"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Eine Datei wählen"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "Leap-Benutzername fehlt"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "Leap-Passwort fehlt"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "WLAN-Passwort fehlt."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Typ"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "WEP-Schlüssel fehlt"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"Ungültiger WEP-Schlüssel: ein Schlüssel mit der Länge %zu darf nur "
-"Hexadezimalzahlen enthalten"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"Ungültiger WEP-Schlüssel: ein Schlüssel mit der Länge %zu darf nur ASCII-"
-"Zeichen enthalten"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"Ungültiger WEP-Schlüssel: falsche Schlüssellänge %zu. Ein Schlüssel muss "
-"entweder dem Schema 5/13 (ASCII) oder 10/26 (hexadezimal) entsprechen"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "Ungültiger WEP-Schlüssel: Kennwort darf nicht leer sein"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "Ungültiger WEP-Schlüssel: Kennwort muss kürzer als 64 Zeichen sein"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4878,20 +2696,6 @@ msgstr "Schlüssel _zeigen"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP-Inde_x"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"Schlüssellänge %zu für WPA-PSK ist ungültig, muss [8,63] Bytes oder 64 "
-"hexadezimale Stellen haben"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"WPA-PSK-Schlüssel kann nicht als 64 Byte hexadezimal ausgewertet werden"
 
 # Mit weichen Trennzeichen, die die Stelle einen Textumbruch vorschlagen
 #. This is the per application switch for message tray usage.
@@ -4949,27 +2753,9 @@ msgstr "Benachrichtigungen auf dem Sperrbi_ldschirm"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Legt fest, wie Nachrichten angezeigt werden und was diese anzeigen"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Benachrichtigungen;Banner;Nachricht;Popup;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Weitere"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s entfernt"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Fehler beim Entfernen des Kontos"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4988,23 +2774,12 @@ msgstr "Verbinden mit Ihren Daten in der Cloud"
 #: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
-"Keine Internetverbindung - verbinden Sie sich, um neue Online-Konten "
+"Keine Internetverbindung – verbinden Sie sich, um neue Online-Konten "
 "einzurichten"
 
 #: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Ein Konto hinzufügen"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s-Konto"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Konto entfernen"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -5016,10 +2791,6 @@ msgstr ""
 "Verbinden Sie sich mit Ihren Online-Konten und entscheiden Sie, wofür diese "
 "genutzt werden"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5027,10 +2798,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Internet;Online;Chat;Kalendar;Mail;E-Mail;"
 "Kontakte;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Unbekannte Zeit"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5046,13 +2813,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i Stunde"
 msgstr[1] "%i Stunden"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%d %s und %d %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5064,192 +2824,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "Minute"
 msgstr[1] "Minuten"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s bis vollständig geladen"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Vorsicht: %s verbleiben"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s verbleiben"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Vollständig geladen"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Lädt nicht"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Leer"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Lädt"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Wird entladen"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Drahtlose Maus"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Drahtlose Tastatur"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Unterbrechungsfreie Stromversorgung"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Persönlicher digitaler Assistent"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobiltelefon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Medienwiedergabegerät"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Grafiktablett"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Rechner"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Spiel-Eingabegerät"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Akku"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Netz"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Extra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Akku"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Wenn _inaktiv"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Bereitschaft"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Ausschalten"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Ruhezustand"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nichts"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Wenn im Akkubetrieb"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Wenn angeschlossen"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nie"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automatisch in Bereitschaft gehen"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Leistungsmodus aufgrund hoher Betriebstemperaturen vorübergehend nicht "
-"verfügbar."
-
-# Klingt komisch, ist aber so :) https://gitlab.freedesktop.org/hadess/power-profiles-daemon/-/blob/main/src/net.hadess.PowerProfiles.xml
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Schoß erkannt: Der Leistungsmodus ist vorübergehend nicht verfügbar. Bringen "
-"Sie das Gerät auf eine stabile Oberfläche, um in den Leistungsmodus wechseln "
-"zu können."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Leistungsmodus vorübergehend deaktiviert."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Niedriger Akkustand: Energiesparen aktiviert. Der vorherige Modus wird "
-"wieder verwendet, wenn der Akku ausreichend geladen ist."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Energiesparmodus durch »%s« aktiviert."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Leistungsmodus durch »%s« aktiviert."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5310,6 +2884,15 @@ msgstr "100 Minuten"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 Stunden"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akku"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Geräte"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5379,6 +2962,8 @@ msgstr "Automatisch in Bereitschaft gehen"
 msgid "_Plugged In"
 msgstr "Wenn _angeschlossen"
 
+# Ich würde das »Wenn« weglassen.  - jb
+# Es geht darum, unter welchen Bedingungen in Suspend-Modus gegangen werden soll, insofern passt das "Wenn" gut - ts 
 #: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Wenn im _Akkubetrieb"
@@ -5387,33 +2972,6 @@ msgstr "Wenn im _Akkubetrieb"
 #: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Verzögerung"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Leistung"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Hohe Leistung und erhöhter Energieverbrauch."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Ausgeglichen"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Normale Leistung und normaler Energieverbrauch."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Energie sparen"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Reduzierte Leistung und niedriger Energieverbrauch."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -5425,7 +2983,6 @@ msgstr ""
 "Den Status Ihres Akkus anzeigen und die Energiespareinstellungen ändern"
 
 # Ich glaube hier können (beliebig viele) Schlagworte frei gewählt werden
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5433,27 +2990,6 @@ msgid ""
 msgstr ""
 "Energie;Schlafmodus;Bereitschaft;Ruhezustand;Akku;Helligkeit;Abdunkeln;"
 "Abschalten;Bildschirm;DPMS;Energie;Einschaltknopf;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Drucker »%s« wurde gelöscht"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Neuer Drucker konnte nicht hinzugefügt werden."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Die Benutzeroberfläche konnte nicht geladen werden: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Entsperren, um Drucker hinzuzufügen und Einstellungen zu ändern"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5465,7 +3001,6 @@ msgstr ""
 "Drucker hinzufügen, Druckeraufgaben anzeigen und entscheiden, wie Sie "
 "drucken möchten"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Drucker;Warteschlange;Drucken;Papier;Tinte;Toner;Tintenpatrone;"
@@ -5473,8 +3008,6 @@ msgstr "Drucker;Warteschlange;Drucken;Papier;Tinte;Toner;Tintenpatrone;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Drucker hinzufügen"
 
@@ -5517,29 +3050,6 @@ msgstr ""
 msgid "Username"
 msgstr "Benutzername"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Details zu %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Kein passender Treiber gefunden"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Wählen Sie die PPD-Datei"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript-Druckerbeschreibungsdateien (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Druckernamen dürfen kein LEERZEICHEN, TABULATOR, # oder / enthalten"
@@ -5548,9 +3058,7 @@ msgstr "Druckernamen dürfen kein LEERZEICHEN, TABULATOR, # oder / enthalten"
 msgid "Location"
 msgstr "Ort"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Treiber"
 
@@ -5578,143 +3086,20 @@ msgstr "Wählen Sie den Druckertreiber"
 msgid "Loading drivers database…"
 msgstr "Treiber-Datenbank wird geladen …"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Abbrechen"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Auswählen"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect-Drucker"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD-Drucker"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Einseitig"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Langer Rand (Vorgabe)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Kurzer Rand (Umdrehen)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Hochformat"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Querformat"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Kopfstehendes Querformat"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Kopfstehendes Hochformat"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Fortsetzen"
-
-#: panels/printers/pp-job-row.c:55
-#, fuzzy
-#| msgctxt "print job"
-#| msgid "Pause"
-msgid "Pause"
-msgstr "Anhalten"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Ausstehend"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pausiert"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Legitimierung erforderlich"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Verarbeitung läuft"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Angehalten"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Abgebrochen"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Abgebrochen"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Abgeschlossen"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Diesen Auftrag an die Spitze der Warteschlange stellen"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u Auftrag erfordert Legitimierung"
 msgstr[1] "%u Aufträge erfordern Legitimierung"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s – Aktive Druckaufträge"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Geben Sie Ihre Anmeldedaten ein, um auf %s drucken zu können."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5742,323 +3127,17 @@ msgstr "Le_gitimieren"
 msgid "No Active Printer Jobs"
 msgstr "Keine aktiven Druckaufträge"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Druckserver entsperren"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s entsperren."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Geben Sie Ihren Benutzernamen und Ihr Passwort ein, um die verfügbaren "
-"Drucker auf %s anzuzeigen."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Es wird nach Druckern gesucht"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Serielle Schnittstelle"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Parallele Schnittstelle"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Ort: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adresse: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Server erfordert Legitimierung"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Beidseitig"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Papierart"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Papiereinzug"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Ausgabeschacht"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Auflösung"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript-Vorfilterung"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Seiten pro Blatt"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Zweiseitig"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Ausrichtung"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Allgemein"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Seiteneinrichtung"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Installierbare Optionen"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Auftrag"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Bildqualität"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Farbe"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Abschließen"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Erweitert"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testseite"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Testseite"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Automatische Auswahl"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Drucker-Voreinstellung"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Nur GhostScript-Schriften einbinden"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "In PS Level 1 umwandeln"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "In PS Level 2 umwandeln"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Keine Vorfilterung"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Hersteller"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Keine aktiven Druckaufträge"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u Auftrag"
 msgstr[1] "%u Aufträge"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Druckköpfe reinigen"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Wenig Toner"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Toner leer"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Wenig Entwickler"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Entwickler leer"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Einer der Farbspeicher fast leer"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Eine Farbpatrone leer"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Abdeckung offen"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Klappe offen"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Wenig Papier"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Papier leer"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Abgemeldet"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Angehalten"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Der Abfallbehälter ist fast voll"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Der Abfallbehälter ist voll"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Der optische Bildübertrager ist beinahe verbraucht"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Der optische Bildübertrager funktioniert nicht mehr"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Bereit"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Es werden keine Aufträge angenommen"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Verarbeitung läuft"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6082,6 +3161,10 @@ msgstr "Druckköpfe reinigen"
 msgid "Remove Printer"
 msgstr "Drucker entfernen"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Keine aktiven Druckaufträge"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6102,16 +3185,21 @@ msgid "Restart"
 msgstr "Neustart"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Drucker hinzufügen …"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Einen Drucker hinzufügen …"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Keine Drucker"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6119,7 +3207,6 @@ msgstr ""
 "Es scheint, dass der Systemdruckdienst\n"
 "    nicht verfügbar ist."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formate"
@@ -6147,16 +3234,6 @@ msgstr "Es kann nach Ländern oder Sprachen gesucht werden."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Vorschau"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrisch"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6194,20 +3271,24 @@ msgstr ""
 "Die Spracheinstellung wird für den Text auf Oberflächen und Webseiten "
 "verwendet. Das Format wird für Zahlen, Datumsangaben und Währungen verwendet."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Ihr Konto"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Sprache"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formate"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Anmeldebildschirm"
 
@@ -6219,100 +3300,9 @@ msgstr "Region und Sprache"
 msgid "Select your display language and formats"
 msgstr "Wählen Sie Ihre Sprache und Formate"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Sprache;Belegung;Tastatur;Eingabe;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Nachfragen, was geschehen soll"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Nichts tun"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Ordner öffnen"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Andere Medien"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Eine Anwendung für Audio-CDs wählen"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Eine Anwendung für Video-DVDs wählen"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Wählen Sie eine Anwendung, wenn ein Musikabspielgerät angeschlossen wird"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Wählen Sie eine Anwendung, wenn eine Kamera angeschlossen wird"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Eine Anwendung für Software-CDs wählen"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "Audio-DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Leere Blu-ray-Disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "Leere CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "Leere DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "Leere HD-DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray-Video-Disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "E-Book-Reader"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD-DVD-Video-Disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Foto-CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super-Video-CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video-CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows-Software"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6362,7 +3352,6 @@ msgstr "Wechselmedien"
 msgid "Configure Removable Media settings"
 msgstr "Wechselmedien einrichten"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6370,114 +3359,6 @@ msgid ""
 msgstr ""
 "Gerät;System;Information;Speicher;Prozessor;Version;Vorgabe;Anwendung;Ersatz;"
 "bevorzugt;CD;DVD;USB;Audio;Video;Medien;Wechsel;Medien;Autostart;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Bildschirm schaltet ab"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 Sekunden"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 Minute"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 Minuten"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 Minuten"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 Minuten"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 Minuten"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 Stunde"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 Minute"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 Minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 Minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 Minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 Minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 Minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 Minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 Minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 Minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nie"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6517,43 +3398,43 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "_Benachrichtigungen auf Sperrbildschirm anzeigen"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Benachrichtigungen auf dem Sperrbi_ldschirm"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Neue _USB-Geräte untersagen"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr ""
-"Verhindern, dass neue USB-Geräte das System beeinflussen während der "
+"Verhindern, dass neue USB-Geräte das System beeinflussen, während der "
 "Bildschirm gesperrt ist."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Bildschirm-Datenschutz"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Den Ansichtswinkel einschränken"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Bildschirm"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Bildschirm-Einstellungen"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr ""
 "screen;lock;private;privacy;Bildschirm;gesperrt;sperren;privat;Datenschutz;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Ort wählen"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6584,10 +3465,6 @@ msgstr "Weitere"
 msgid "Add Location"
 msgstr "Ort hinzufügen"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Keine Anwendungen gefunden"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Anwendungssuche"
@@ -6615,93 +3492,13 @@ msgstr ""
 "Legen Sie fest, welche Anwendungen Suchergebnisse in der "
 "Aktivitätenübersicht anzeigen"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "Suchen;Finden;Index;Verbergen;Privatsphäre;Ergebnisse;"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Es sind keine Netzwerke zur Freigabe gewählt"
+msgstr "Suchen;Finden;Index;Verbergen;Privatsphäre;Ergebnisse;Datenschutz;"
 
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Netzwerke"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "An"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Aus"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Aktiviert"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktiv"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Wählen Sie einen Ordner"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Hinzufügen"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Medienfreigabe einschalten"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Persönliche Dateifreigabe ermöglicht es Ihnen, Ihren öffentlichen Ordner für "
-"andere in Ihrem Netzwerk freizugeben mit: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Wenn Fernanmeldung aktiviert ist, entfernten Benutzern eine Verbindung mit "
-"folgendem Secure-Shell-Befehl erlauben:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Gerätename wurde kopiert"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Geräteadresse wurde kopiert"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Benutzername wurde kopiert"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Passwort wurde kopiert"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6834,7 +3631,6 @@ msgstr "Ordner"
 msgid "Control what you want to share with others"
 msgstr "Legen Sie fest, was Sie für Andere freigeben möchten"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6853,17 +3649,13 @@ msgstr ""
 "Legitimierung ist erforderlich, um die Fernanmeldung zu aktivieren oder zu "
 "deaktivieren"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Benutzerdefiniert"
-
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
 msgstr "Klick"
 
 #: panels/sound/cc-alert-chooser.ui:20
 msgid "String"
-msgstr "Zeichenkette"
+msgstr "Saite"
 
 #: panels/sound/cc-alert-chooser.ui:28
 msgid "Swing"
@@ -6889,11 +3681,6 @@ msgstr "Hinten"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Vorne"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s wird geprüft"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6947,11 +3734,6 @@ msgstr "Lautstärke"
 msgid "Alert Sound"
 msgstr "Warnton"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Stumm schalten"
@@ -6965,84 +3747,12 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Lautstärke, Ein- und Ausgabequellen und Alarmtöne einstellen"
 
 # Ich glaube hier können (beliebig viele) Schlagworte frei gewählt werden
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Karte;Mikrofon;Lautstärkeregler;Lautstärke;Ausblenden;Balance;Bluetooth;"
 "Headset;Audio;Eingang;Ausgang;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Getrennt"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Verbindungsaufbau"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Verbunden"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Legitimierungsfehler"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Legitimierung"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Eingeschränkte Funktionalität"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Verbunden und legitimiert"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Unbekannt"
-
-# Hm, oder »bei« oder »am« ...?
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Legitimiert auf:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Verbunden um:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Angemeldet um:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Gerät konnte nicht legitimiert werden: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Gerät konnte nicht vergessen werden: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7076,57 +3786,6 @@ msgstr "Legitimieren und verbinden"
 msgid "Forget Device"
 msgstr "Gerät vergessen"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Fehler"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Legitimiert"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Das Thunderbolt-Subsystem (boltd) ist nicht installiert oder wurde nicht "
-"korrekt eingerichtet."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Den direkten Zugriff auf Geräte wie Docks oder externe Grafikkarten erlauben."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Es können nur USB- und Displayport-Geräte angeschlossen werden."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt konnte nicht erkannt werden.\n"
-"Entweder unterstützt das System Thunderbolt nicht, oder es wurde im BIOS "
-"deaktiviert oder wurde im BIOS auf eine nicht unterstützte Sicherheitsstufe "
-"gesetzt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Die Unterstützung für Thunderbolt wurde im BIOS deaktiviert."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Die Sicherheitsstufe von Thunderbolt konnte nicht ermittelt werden."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Fehler beim Wechsel in den Direktmodus: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Keine Thunderbolt-Unterstützung"
@@ -7136,10 +3795,14 @@ msgid "Could not connect to the thunderbolt subsystem."
 msgstr ""
 "Es konnte keine Verbindung zum Thunderbolt-Untersystem hergestellt werden."
 
-# Mit weichen Trennzeichen, die die Stelle einen Textumbruch vorschlagen
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Direktzugriff"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Den direkten Zugriff auf Geräte wie Docks oder externe Grafikkarten erlauben."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7157,18 +3820,17 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Thunderbolt-Geräte verwalten"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
-msgstr "Thunderbolt;Privatsphäre;"
+msgstr "Thunderbolt;Privatsphäre;Datenschutz;"
 
 #: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 msgid "Cursor Blinking"
-msgstr "Blinkender Cursor"
+msgstr "Blinkende Eingabemarke"
 
 #: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
-msgstr "Blinkender Cursor in Textfeldern."
+msgstr "Blinkende Eingabemarke in Textfeldern."
 
 #: panels/universal-access/cc-cursor-blinking-dialog.ui:65
 #: panels/universal-access/cc-repeat-keys-dialog.ui:120
@@ -7177,18 +3839,18 @@ msgstr "Geschwindigkeit"
 
 #: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
-msgstr "Blinkgeschwindigkeit des Cursors"
+msgstr "Blinkgeschwindigkeit der Eingabemarke"
 
 #: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
-msgstr "Größe des Cursors"
+msgstr "Mauszeiger-Größe"
 
 #: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
-"Die Cursorgröße kann mit einer Vergrößerung kombiniert werden, damit der "
-"Cursor leichter auffindbar ist."
+"Die Größe des Mauszeigers kann mit einer Vergrößerung kombiniert werden, "
+"damit der Mauszeiger leichter auffindbar ist."
 
 #: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
@@ -7289,7 +3951,7 @@ msgstr "Erkennt eine Abfolge von Zusatztasten als Tastenkombination"
 
 #: panels/universal-access/cc-typing-dialog.ui:63
 msgid "_Disable if two keys are pressed together"
-msgstr "_Deaktivieren, wenn zwei Tasten zusammen gedrückt werden"
+msgstr "_Deaktivieren, wenn zwei Tasten gleichzeitig gedrückt werden"
 
 #: panels/universal-access/cc-typing-dialog.ui:71
 msgid "Beep when a _modifier key is pressed"
@@ -7359,41 +4021,7 @@ msgstr "Per _Tastatur aktivieren"
 
 #: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
-msgstr "Barrierefreiheitsfunktionen mit der Tastatur ein- bzw. ausschalten"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Vorgabe"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Medium"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Groß"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Größer"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Am größten"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d Pixel"
-msgstr[1] "%d Pixel"
+msgstr "Barrierefreiheits-Funktionen mit der Tastatur ein- bzw. ausschalten"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -7422,7 +4050,7 @@ msgstr "Bildschirmle_ser"
 #: panels/universal-access/cc-ua-panel.ui:71
 msgid "The screen reader reads displayed text as you move the focus."
 msgstr ""
-"Der Bildschirmleser liest den angezeigten Text wenn Sie den Fokus "
+"Der Bildschirmleser liest den angezeigten Text, wenn Sie den Fokus "
 "verschieben."
 
 #: panels/universal-access/cc-ua-panel.ui:83
@@ -7437,7 +4065,7 @@ msgstr ""
 
 #: panels/universal-access/cc-ua-panel.ui:96
 msgid "C_ursor Size"
-msgstr "C_ursorgröße"
+msgstr "Ma_uszeiger-Größe"
 
 #: panels/universal-access/cc-ua-panel.ui:116
 #: panels/universal-access/cc-zoom-options-dialog.ui:82
@@ -7463,7 +4091,7 @@ msgstr "Tast_enwiederholung"
 
 #: panels/universal-access/cc-ua-panel.ui:198
 msgid "Cursor _Blinking"
-msgstr "_Blinkender Cursor"
+msgstr "_Blinkende Eingabemarke"
 
 #: panels/universal-access/cc-ua-panel.ui:218
 msgid "_Typing Assist (AccessX)"
@@ -7512,31 +4140,6 @@ msgstr "Ganzen _Bildschirm blinken lassen"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Ganzes _Fenster blinken lassen"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Kurz"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ Bildschirm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ Bildschirm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ Bildschirm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Lang"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7695,7 +4298,6 @@ msgstr "Farbeffekte"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Sehen, Hören, Tippen, Zeigen und Klicken erleichtern"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7703,118 +4305,10 @@ msgid ""
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
 "audio;typing;animations;"
 msgstr ""
-"Tastatur;Maus;a11y;Barrierefreiheit;Kontrast;Klänge;Ton;Audio;Zoom;"
+"Tastatur;Maus;Cursor;a11y;Barrierefreiheit;Kontrast;Klänge;Ton;Audio;Zoom;"
 "Vergrößern;Bildschirm;Bildschirmleser;Text;Schrift;Größe;AccessX;Klebrige "
 "Tasten;Tasten;Langsam;Springende Tasten;Tastaturmaus;Klick;Verzögerung;"
 "Assistent;Wiederholen;Blinken;Visuell;Tippen;Hören;Audio;Eingabe;Animationen;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 Stunde"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 Tag"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 Tage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 Tage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 Tage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 Tage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 Tage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 Tage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 Tage"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 Tage"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Alle Objekte aus dem Papierkorb löschen?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Alle Objekte im Papierkorb werden dauerhaft gelöscht."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Papierkorb _leeren"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Alle temporären Dateien löschen?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Alle temporären Dateien werden dauerhaft gelöscht."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Temporäre Dateien _löschen"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 Tag"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 Tage"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 Tage"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Für immer"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7883,7 +4377,6 @@ msgstr "Dateichronik und Papierkorb"
 msgid "Don't leave traces"
 msgstr "Keine Spuren hinterlassen"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
@@ -7891,60 +4384,6 @@ msgstr ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 "Verwendung;zuletzt;kürzlich;Verlauf;Dateien;temporär;privat;Datenschutz;"
 "Papierkorb;bereinigen;behalten;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Sollte der Internetadresse Ihres Benutzerkontoanbieters entsprechen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Anlegen des Kontos schlug fehl"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Die Passwörter stimmen nicht überein."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Anlegen des Kontos schlug fehl"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr ""
-"Es gibt keine unterstützte Möglichkeit für eine Legitimierung mit dieser "
-"Domäne"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Beitreten zur Domäne schlug fehl"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Ungültiger Benutzer.\n"
-"Bitte versuchen Sie es erneut."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Ungültiges Passwort.\n"
-"Bitte versuchen Sie es erneut."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Anmelden an der Domäne schlug fehl"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr ""
-"Domäne konnte nicht gefunden werden. Haben Sie sich eventuell vertippt?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7999,10 +4438,6 @@ msgstr ""
 "Unternehmens-Anmeldung erlaubt es, ein zentral verwaltetes Benutzerkonto auf "
 "diesem Gerät zu verwenden. Außerdem können Sie dieses Konto nutzen, um über "
 "das Internet auf Unternehmensressourcen zuzugreifen."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Nach weiteren Bildern suchen"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8073,233 +4508,6 @@ msgstr "Fingerabdrücke _löschen"
 msgid "Fingerprint Enroll"
 msgstr "Registrierung eines Fingerabdrucks"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "Das Gerät muss beansprucht werden, um diese Aktion durchzuführen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "Das Gerät wird bereits von einem anderen Prozess beansprucht"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "Sie haben nicht die erforderlichen Rechte, um diese Aktion auszuführen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "Keine Fingerabdrücke registriert"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Kommunikation mit dem Gerät während der Registrierung fehlgeschlagen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Kommunikation mit dem Fingerabdruck-Scanner fehlgeschlagen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Kommunikation mit dem Fingerabdruck-Dienst fehlgeschlagen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Auflisten der Fingerabdrücke schlug fehl: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Löschen von gespeicherten Fingerabdrücken schlug fehl: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Linker Daumen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Linker Mittelfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Linker Zeigefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Linker Ringfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Linker kleiner Finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Rechter Daumen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Rechter Mittelfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Rechter Zeigefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Rechter Ringfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Rechter kleiner Finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Unbekannter Finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Abgeschlossen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Das Fingerabdruckgerät wurde getrennt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Der Speicher des Fingerabdruckgeräts ist voll"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Die Registrierung eines neuen Fingerabdrucks ist fehlgeschlagen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Starten der Registrierung schlug fehl: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Die Registrierung eines neuen Fingerabdrucks ist fehlgeschlagen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Beenden der Registrierung schlug fehl: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Legen Sie Ihren Finger mehrmals auf den Leser, um Ihren Fingerabdruck zu "
-"registrieren"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Diesen Finger _erneut registrieren …"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Neuen Fingerabdruck einlesen"
-
-# Also das geht so noch nicht. Andere Ideen?
-# --
-# Das Fingerabdruck-Gerät konnte nicht freigegeben werden
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Die Freigabe des Fingerabdruck-Geräts %s schlug fehl: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Probleme beim Ansprechen des Geräts"
-
-# Also das geht so noch nicht. Andere Ideen?
-# --
-# Das Fingerabdruck-Gerät konnte nicht beansprucht werden.
-# (Wobei beanspruchen hier wirklich schwer verständlich ist. Mir fällt aber auch nichts Besseres ein;)
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Die Belegung des Fingerabdruck-Geräts %s schlug fehl: %s"
-
-# Also das geht so noch nicht. Andere Ideen?
-# --
-# Fingerabdruck-Geräte konnten nicht ermittelt werden. // Es konnten keine Fingeradruck-Geräte ermittelt werden. (Vielleicht besser: gefunden? Oder: entdeckt?)
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Ermitteln der Fingerabdruck-Geräte schlug fehl: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Diese Woche"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Letzte Woche"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-# I prefer 07:30 instead of 7:30
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%H:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sitzungsende"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sitzungsbeginn"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Kontoaktivität"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Zurück"
@@ -8307,18 +4515,6 @@ msgstr "Zurück"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Weiter"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Bitte wählen Sie ein anderes Passwort."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Bitte geben Sie Ihr aktuelles Passwort erneut ein."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Passwort konnte nicht geändert werden"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8340,6 +4536,10 @@ msgstr "Neues Passwort"
 msgid "Confirm Password"
 msgstr "Passwort bestätigen"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Die Passwörter stimmen nicht überein."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Benutzern erlauben, bei der nächsten Anmeldung ihr Passwort zu ändern"
@@ -8347,139 +4547,6 @@ msgstr "Benutzern erlauben, bei der nächsten Anmeldung ihr Passwort zu ändern"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Jetzt ein Passwort festlegen"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Diesem Typ von Domäne kann nicht automatisch beigetreten werden"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Es wurde keine solche Domäne oder Realm gefunden"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Anmeldung als %s in der Domäne %s schlug fehl"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Ungültiges Passwort, bitte versuchen Sie es erneut"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Es konnte keine Verbindung mit %s-Domäne hergestellt werden: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Benutzer konnte nicht gelöscht werden"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Entfernt verwalteter Benutzer konnte nicht widerrufen werden"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Sie können Ihr eigenes Konto nicht löschen."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s ist immer noch angemeldet"
-
-# Was genau ein inkonsistenter (= unbeständiger)  Zustand in diesem Zusammenhang bedeutet, wird, finde ich, nicht klar. Nicht durch die Übersetzung, wohlgemerkt, sondern durch das Original. Konkret: Was passiert, wenn ich mich eingeloggt als Nutzer lösche?
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Das Löschen von Benutzern, während sie angemeldet sind, kann das System in "
-"einen inkonsistenten Zustand versetzen."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Wollen Sie die Dateien von %s behalten?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Es ist möglich, den persönlichen Ordner, die Mail-Warteschlange und die "
-"temporären Dateien zu behalten, wenn ein Benutzerkonto gelöscht wird."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Dateien löschen"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "Dateien _behalten"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Sind Sie sicher, dass Sie den entfernt verwalteten Benutzer »%s« widerrufen "
-"möchten?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Löschen"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Konto ist deaktiviert"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Bei der nächsten Anmeldung festlegen"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Keine"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Angemeldet"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Kontendienst konnte nicht kontaktiert werden"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Bitte stellen Sie sicher, dass der Kontendienst korrekt installiert und "
-"aktiviert ist."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Diese Leiste musst entsperrt sein, um diese Einstellung zu ändern"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Das gewählte Benutzerkonto löschen"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Um das gewählte Benutzerkonto zu löschen,\n"
-"klicken Sie zuerst auf das Symbol *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Entsperren, um Nutzer hinzuzufügen und Einstellungen zu ändern"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8507,7 +4574,6 @@ msgid "Full name"
 msgstr "Vollständiger Name"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -8569,7 +4635,6 @@ msgstr "Entsperren, um ein Benutzerkonto zu erstellen."
 msgid "Add or remove users and change your password"
 msgstr "Benutzer hinzufügen oder entfernen und das Passwort ändern"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8616,183 +4681,6 @@ msgstr "Benutzerkonten verwalten"
 msgid "Authentication is required to change user data"
 msgstr "Legitimierung erforderlich"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Das neue Passwort muss sich vom vorherigen unterscheiden."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Versuchen Sie einige Buchstaben und Ziffern zu ändern."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Versuchen Sie das Passwort noch mehr zu ändern."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Ein Passwort ohne Ihren Benutzernamen wäre stärker."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Versuchen Sie Ihren Namen im Passwort nicht zu verwenden."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Versuchen Sie einige der Wörter im Passwort zu vermeiden."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Versuchen Sie gewöhnliche Wörter zu vermeiden."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Versuchen Sie das Anordnen existierender Wörter zu vermeiden."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Versuchen Sie mehr Ziffern zu verwenden."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Versuchen Sie mehr Großbuchstaben zu verwenden."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Versuchen Sie mehr Kleinbuchstaben zu verwenden."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Versuchen Sie mehr Sonderzeichen (z.B. Satzzeichen) zu verwenden."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Versuchen Sie eine Mischung aus Buchstaben, Ziffern und Satzzeichen."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Versuchen Sie die Wiederholung desselben Zeichens zu vermeiden."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Versuchen Sie Wiederholungen von Zeichen derselben Gruppe zu vermeiden. Sie "
-"sollten Buchstaben, Ziffern und Satzzeichen mischen."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Versuchen Sie Sequenzen wie z.B. »1234« oder »abcd« zu vermeiden."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Passwörter müssen länger sein. Fügen Sie weitere Buchstaben, Ziffern und "
-"Satzzeichen hinzu."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Mischen Sie Großbuchstaben und Kleinbuchstaben und verwenden Sie eine Ziffer "
-"oder zwei."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Durch Hinzufügen von Buchstaben, Ziffern und Satzzeichen wird das Passwort "
-"noch besser."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Legitimierung fehlgeschlagen"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Das neue Passwort ist zu kurz"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Das neue Passwort ist zu einfach"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Die alten und neuen Passwörter sind zu ähnlich"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Das neue Passwort wurde kürzlich bereits verwendet."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Das neue Passwort muss numerische oder Sonderzeichen enthalten"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Das neue und das alte Passwort sind gleich"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-"Ihr Passwort wurde geändert, seit Sie sich erstmalig legitimiert haben!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Das neue Passwort enthält nicht genug unterschiedliche Zeichen"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Unbekannter Fehler"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Der Benutzername darf aus Klein- und Großbuchstaben von A bis Z, Ziffern "
-"sowie den Zeichen »-« und »_« bestehen"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Leider ist dieser Benutzername nicht verfügbar. Wählen Sie bitte einen "
-"anderen."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Der Benutzername ist zu lang."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8828,54 +4716,12 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Falscher Klick wurde erkannt, Neustart …"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Knopf %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Festgelegte Anwendung"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Tasteneingabe senden"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Monitor wechseln"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Bildschirmhilfe zeigen"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Am Laptop-Rahmen befestigtes Grafiktablett"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "An externem Bildschirm befestigtes Grafiktablett"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Externes Grafiktablett"
-
+# Woher kommt das Wort »Bedienung«? - jb
+# Dem Quellcode zufolge geht es hier um ein 'Wacom ExpressKey Remote' Gerät, was ich als Bedienung interpretiere - ts
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
-#, fuzzy
-#| msgid "External tablet device"
 msgid "External pad device"
-msgstr "Externes Grafiktablett"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Alle Bildschirme"
+msgstr "Externe Grafiktablett-Bedienung"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8934,7 +4780,7 @@ msgstr "Weich"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:35
 msgid "Stylus tip pressure"
-msgstr "Stylus Kopf-Anpressdruck"
+msgstr "Stylus-Kopf-Anpressdruck"
 
 # Gemeint ist vermutlich ein Eingabestift eines Tabletts
 #: panels/wacom/cc-wacom-stylus-page.ui:41
@@ -8977,22 +4823,6 @@ msgstr "Klick der rechten Maustaste"
 msgid "Forward"
 msgstr "Weiter"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Airbrush-Stylus mit Druck- und Kippsensor sowie integriertem Regler"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Airbrush-Stylus mit Druck-, Kipp- und Drehsensor"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standard-Stylus mit Druck- und Kippsensor"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standard-Stylus mit Drucksensor"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom Grafiktablett"
@@ -9003,56 +4833,98 @@ msgstr ""
 "Knopfzuordnung einstellen und die Empfindlichkeit des Stiftes für "
 "Grafiktabletts einstellen"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablett;Grafiktablett;Wacom;Stylus;Radiergummi;Maus;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Neue Tastenkombination …"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulierter Kontextklick"
+
+# Software von MS Windows
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows-Software"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Wenig Toner"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Verzögerung für Kontextklick"
+
+# Software von MS Windows
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows-Software"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Einstellungen für Produktivität und Multitasking verwalten"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Zugriffspunkte"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Speichern"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Vorgang abgebrochen"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr ""
-"<b>Fehler:</b> Zugriff wurde bei der Änderung der Einstellungen verweigert"
-
-# Scheint eine ganze Reihe an möglichen Fehlern zu geben: https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/e32b67e5c0e75600b4fa5154e137717f82dabf0d/panels/wwan/cc-wwan-errors-private.h#L39
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Fehler:</b> Fehler des Mobilgeräts"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Nicht registriert"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registriert"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Suchen"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Verweigert"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9080,214 +4952,15 @@ msgstr "Eigene Nummer"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:151
 msgid "Device Details"
-msgstr "Geräte-Details"
+msgstr "Gerätedetails"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Hersteller"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Firmware-Version"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Nur 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Nur 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Nur 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Nur 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (bevorzugt), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (bevorzugt), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (bevorzugt), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (bevorzugt), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (bevorzugt), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (bevorzugt), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (bevorzugt), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (bevorzugt), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (bevorzugt), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (bevorzugt), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (bevorzugt), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (bevorzugt), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (bevorzugt), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (bevorzugt), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (bevorzugt), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (bevorzugt), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "3G, 5G (bevorzugt)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "3G (bevorzugt), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "SIM-Karte entsperren"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Entsperren"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Bitte geben Sie den PIN-Code für die SIM-Karte %d an"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "PIN-Code eingeben, um die SIM-Karte zu entsperren"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Bitte geben Sie den PUK-Code für die SIM-Karte %d an"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "PUK-Code eingeben, um die SIM-Karte zu entsperren"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9303,33 +4976,13 @@ msgid_plural "You have %u tries left"
 msgstr[0] "Sie haben %u Versuch übrig"
 msgstr[1] "Sie haben %u Versuche übrig"
 
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Falsches Passwort eingegeben."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Der PUK-Code sollte eine Zahl mit 8 Ziffern sein"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Neuen PIN-Code eingeben"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Der PIN-Code sollte eine Zahl mit 4-8 Ziffern sein"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Wird entsperrt …"
-
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
 msgstr "Keine SIM"
 
 #: panels/wwan/cc-wwan-device-page.ui:19
 msgid "Insert a SIM card to use this modem"
-msgstr "Führen Sie eine SIM-Karte ein, um dieses Modem zu nutzen"
+msgstr "Setzen Sie eine SIM-Karte ein, um dieses Modem zu nutzen"
 
 #: panels/wwan/cc-wwan-device-page.ui:33
 msgid "SIM Locked"
@@ -9379,94 +5032,6 @@ msgstr "SIM mit PIN-Code sperren"
 msgid "M_odem Details"
 msgstr "M_odem-Details"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Telefonfehler"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Keine Verbindung zum Telefon"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Vorgang nicht erlaubt"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Vorgang nicht unterstützt"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM-Karte ist nicht eingesetzt"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "SIM-PIN ist erforderlich"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "SIM-PUK ist erforderlich"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM-Fehler"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM beschäftigt"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Falsches Passwort"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIM-PIN2 ist erforderlich"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIM-PUK2 ist erforderlich"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Nicht gefunden"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Kein Netzwerkdienst"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Netzwerk-Zeitüberschreitung"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS-Dienste nicht erlaubt"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming ist in diesem Gebiet nicht erlaubt"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Unbestimmter GRPS-Fehler"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Kein Fehler"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Aktion abgebrochen"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Zugriff verweigert"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Unbekannter Fehler"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Netzwerk-Modus"
@@ -9482,11 +5047,6 @@ msgstr "Netzwerk auswählen"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Netzwerkanbieter aktualisieren"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9504,7 +5064,7 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
-msgstr "Weitverkehrsfunkverbindungen sind im Flugzeugmodus deaktiviert"
+msgstr "Weitverkehrs-Funkverbindungen sind im Flugzeugmodus deaktiviert"
 
 #: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
@@ -9547,7 +5107,6 @@ msgstr "Mobiles Netzwerk"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Telefonie und mobile Datenverbindungen einrichten"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -9567,41 +5126,13 @@ msgstr ""
 msgid "The GNOME Project"
 msgstr "Das GNOME-Pojekt"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Versionsnummer anzeigen"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Ausführliche Meldungen aktivieren"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Nach der Zeichenkette suchen"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Mögliche Panel-Namen anzeigen und beenden"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Bildschirm für Anzeige"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[LEISTE] [ARGUMENT …]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
-msgstr ""
+msgstr "Einstellungen-Kategorien"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Datenschutz"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Verfügbare Leisten:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9652,14 +5183,13 @@ msgstr "Panels"
 #: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
-msgstr "Zurück zur vorigen Ansicht gehen"
+msgstr "Zurück zur vorigen Ansicht"
 
 #: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Suche abbrechen"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Einstellungen;"
@@ -9674,7 +5204,7 @@ msgid ""
 "will be ignored and the first panel in the list selected."
 msgstr ""
 "Bezeichner des zuletzt geöffneten Einstellungs-Panels. Unzulässige Werte "
-"werden ignoriert und das erste Panel in der Liste ausgewählt."
+"werden ignoriert und das erste Panel in der Liste wird ausgewählt."
 
 #: shell/org.gnome.Settings.gschema.xml:13
 msgid "Show warning when running a development build of Settings"
@@ -9701,8 +5231,6 @@ msgstr ""
 "Ein Tupel, welches die anfängliche Breite und Höhe sowie den "
 "Maximierungszustand des Anwendungsfensters enthält."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9710,8 +5238,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u Ausgang"
 msgstr[1] "%u Ausgänge"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9719,9 +5245,3196 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u Eingang"
 msgstr[1] "%u Eingänge"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Systemklänge"
+#~ msgid "System Bus"
+#~ msgstr "System-Bus"
+
+#~ msgid "Full access"
+#~ msgstr "Vollständiger Zugriff"
+
+#~ msgid "Session Bus"
+#~ msgstr "Sitzungs-Bus"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Vollständiger Zugriff auf /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Hat Netwerkzugriff"
+
+#~ msgid "Home"
+#~ msgstr "Persönlicher Ordner"
+
+#~ msgid "Read-only"
+#~ msgstr "Nur Lesezugriff"
+
+#~ msgid "File System"
+#~ msgstr "Dateisystem"
+
+#~ msgid "Can change settings"
+#~ msgstr "Darf Einstellungen ändern"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s hat die folgenden Berechtigungen eingebaut, die nicht geändert werden "
+#~ "können. Falls Sie diesbezüglich Bedenken haben, sollten Sie in Erwägung "
+#~ "ziehen, diese Anwendung zu löschen."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] ""
+#~ "%u Datei- und Verknüpfungs-Typ wird von dieser Anwendung geöffnet"
+#~ msgstr[1] ""
+#~ "%u Datei- und Verknüpfungs-Typen werden von dieser Anwendung geöffnet"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> wird verwendet, um die folgenden Datei- und Verknüpfungs-Typen "
+#~ "zu öffnen."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s des Speicherplatzes wird verwendet."
+
+#~ msgid "Select a picture"
+#~ msgstr "Ein Bild wählen"
+
+#~ msgid "_Open"
+#~ msgstr "Ö_ffnen"
+
+#~ msgid "multiple sizes"
+#~ msgstr "mehrere Größen"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Kein Schreibtisch-Hintergrund"
+
+#~ msgid "Current background"
+#~ msgstr "Aktueller Hintergrund"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Platzieren Sie Ihr Kalibrierungsgerät über dem Quadrat und wählen Sie "
+#~ "»Start«"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Verschieben Sie Ihr Kalibrierungsgerät in die Kalibrierungsposition und "
+#~ "wählen Sie »Fortsetzen«"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Verschieben Sie Ihr Kalibrierungsgerät in die Oberflächenposition und "
+#~ "wählen Sie »Fortsetzen«"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Schließen Sie den Laptopdeckel"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Ein interner Fehler ist aufgetreten, der nicht behoben werden kann."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Die zur Kalibrierung notwendigen Werkzeuge sind nicht installiert."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Das Profil konnte nicht erstellt werden."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Der gesuchte Weißpunkt konnte nicht ermittelt werden."
+
+#~ msgid "Complete!"
+#~ msgstr "Abgeschlossen!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrierung fehlgeschlagen!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Sie dürfen das Kalibrierungsgerät entfernen."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Lassen Sie das Kalibrierungsgerät während des Vorgangs in Ruhe"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Laptop-Bildschirm"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Eingebaute Webcam"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Bildschirm %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Scanner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Kamera %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Drucker %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webcam %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Aktivieren Sie die Farbverwaltung für %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Farbprofile anzeigen für %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nicht kalibriert"
+
+#~ msgid "Default: "
+#~ msgstr "Vorgabe: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Farbraum: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testprofil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC-Farbprofildatei wählen"
+
+#~ msgid "_Import"
+#~ msgstr "_Importieren"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Importierte ICC-Profile"
+
+#~ msgid "All files"
+#~ msgstr "Alle Dateien"
+
+#~ msgid "Save Profile"
+#~ msgstr "Profil speichern"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Ein Farbprofil für das ausgewählte Gerät erstellen"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Das Messgerät wurde nicht erkannt. Bitte prüfen Sie, ob es korrekt "
+#~ "angeschlossen und eingeschaltet ist."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Das Messgerät unterstützt die Profilierung von Druckern nicht."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Der Gerätetyp wird im Moment nicht unterstützt."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standard-Farbraum"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testprofil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatisch"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Geringe Qualität"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Mittlere Qualität"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Hohe Qualität"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Standard-RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Standard-CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Standard-Grau"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Vom Hersteller gelieferte Kalibrierungsdaten"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "Vollflächige Bildschirmkorrektur ist mit diesem Profil nicht möglich"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Dieses Profil ist möglicherweise nicht mehr ausreichend genau"
+
+#~ msgid "Other…"
+#~ msgstr "Andere …"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Entsperren, um Einstellungen zu ändern"
+
+#~ msgid "Today"
+#~ msgstr "Heute"
+
+#~ msgid "Yesterday"
+#~ msgstr "Gestern"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d Stunde"
+#~ msgstr[1] "%d Stunden"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d Minute"
+#~ msgstr[1] "%d Minuten"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d Sekunde"
+#~ msgstr[1] "%d Sekunden"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24-Stunden"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e. %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e. %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Der Versand von Fehlermeldungen bei technischen Problemen hilft uns, %s "
+#~ "zu verbessern. Diese Meldungen sind frei von personenbezogenen Daten und "
+#~ "werden anonym versendet. %s"
+
+#~ msgid "On"
+#~ msgstr "An"
+
+#~ msgid "Off"
+#~ msgstr "Aus"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Änderungen anwenden?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Änderungen können nicht angewendet werden"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Das könnte an Einschränkungen der Hardware liegen."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Querformat"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Hochformat rechts gedreht"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Hochformat links gedreht"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Kopfstehendes Querformat"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Gesicherter Systemstart (secure boot) ist aktiv"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Gesicherter Systemstart (secure boot) verhindert, dass bösartige Software "
+#~ "beim Gerätestart geladen wird. Er ist aktuell eingeschaltet und arbeitet "
+#~ "vollständig."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Gesicherter Systemstart (secure boot) meldet Probleme"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Gesicherter Systemstart (secure boot) verhindert, dass bösartige Software "
+#~ "beim Gerätestart geladen wird. Er ist aktuell eingeschaltet, funktioniert "
+#~ "aber nicht wegen eines ungültigen Schlüssels."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Probleme des gesicherten Systemstarts (secure boot) lassen sich oft in "
+#~ "den UEFI Firmware-Einstellungen (BIOS) lösen. Ihr Hardware-Hersteller "
+#~ "liefert möglicherweise Hilfeleistung dabei."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Kontaktieren Sie für Unterstützung Ihren Hardware-Hersteller oder die IT-"
+#~ "Hilfe."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Gesicherter Systemstart (secure boot) ist ausgeschaltet"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Gesicherter Systemstart (secure boot) verhindert, dass bösartige Software "
+#~ "beim Gerätestart geladen wird. Er ist aktuell ausgeschaltet."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Der gesicherte Systemstart (secure boot) wird normalerweise in den UEFI "
+#~ "Firmware-Einstellungen (BIOS) eingeschaltet. Ihr Hardware-Hersteller oder "
+#~ "die IT-Hilfe liefern möglicherweise Hilfestellung dabei."
+
+#~ msgid "Passed"
+#~ msgstr "Bestanden"
+
+#~ msgid "Failed"
+#~ msgstr "Fehlgeschlagen"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Das Gerät erfüllt die HSI-Stufe %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Sicherheitsstufe 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Dieses Gerät besitzt keinen Schutz gegen Hardware-Sicherheitslücken. Dies "
+#~ "könnte an der Einrichtung der Hard- oder Firmware liegen. Es wird "
+#~ "empfohlen, Ihre IT-Hilfe zu kontaktieren."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Sicherheitsstufe 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Dieses Gerät besitzt einen geringfügigen Schutz gegen Hardware-"
+#~ "Sicherheitslücken. Dies ist die niedrigste Geräte-Sicherheitsstufe und "
+#~ "bietet nur Schutz vor einfachen Bedrohungen."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Sicherheitsstufe 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Dieses Gerät besitzt einen grundlegenden Schutz gegen Hardware-"
+#~ "Sicherheitslücken. Es bietet Schutz vor herkömmlichen Bedrohungen."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Sicherheitsstufe 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Dieses Gerät besitzt einen erweiterten Schutz gegen Hardware-"
+#~ "Sicherheitslücken. Dies ist die höchste Geräte-Sicherheitsstufe und "
+#~ "bietet auch Schutz vor fortgeschrittenen Bedrohungen."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Die Sicherheitsstufe ist für dieses Gerät nicht verfügbar."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Kontaktieren Sie Ihren Hardware-Hersteller für Unterstützung bei "
+#~ "Sicherheitsaktualisierungen."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Dieses Problem könnte möglicherweise in den UEFI-Firmware-Einstellungen "
+#~ "des Geräts oder durch einen Servicetechniker gelöst werden."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Dieses Problem könnte möglicherweise in den UEFI-Firmware-Einstellungen "
+#~ "des Geräts gelöst werden."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Ein Servicetechniker könnte dieses Problem möglicherweise lösen."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Gegen bösartige Software beim Gerätestart geschützt."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Gesicherter Systemstart (secure boot) meldet Probleme"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Etwas Schutz beim Gerätestart."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Gesicherter Systemstart (secure boot) ist ausgeschaltet"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Kein Schutz beim Gerätestart."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Dieses Problem könnte durch eine Änderung in den UEFI-Firmware-"
+#~ "Einstellungen, eine Änderung in der Einrichtung des Betriebssystems, oder "
+#~ "durch bösartige Software auf diesem System entstanden sein."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Dieses Problem könnte durch eine Änderung in den UEFI-Firmware-"
+#~ "Einstellungen oder durch bösartige Software auf diesem System entstanden "
+#~ "sein."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Dieses Problem könnte durch eine Änderung in der Einrichtung des "
+#~ "Betriebssystems oder durch bösartige Software auf diesem System "
+#~ "entstanden sein."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Anfällig für ernste Sicherheitsbedrohungen."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Eingeschränkter Schutz gegen einfache Sicherheitsbedrohungen."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Gegen herkömmliche Sicherheitsbedrohungen geschützt."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Gegen zahlreiche Sicherheitsbedrohungen geschützt."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Umfassender Schutz"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Firmware-Schreibschutz"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Firmware-Schreibschutz-Schloss"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Firmware-BIOS-Region"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Firmware-BIOS-Deskriptor"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "DMA-Schutz vor dem Systemstart"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard verifizierter Systemstart"
+
+# Direkt übernommen aus fwupd,
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM-geschützt"
+
+# Direkt übernommen aus fwupd
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard-Fehlerrichtlinie"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard-Sicherung"
+
+# Direkt übernommen aus fwupd
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET aktiviert"
+
+# Direkt übernommen aus fwupd
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET aktiv"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+# Direkt übernommen aus fwupd
+#~ msgid "Encrypted RAM"
+#~ msgstr "Verschlüsselter RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU-Schutz"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux-Kernel-Sperrung"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux-Kernel-Verifizierung"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux-Auslagerungsspeicher"
+
+# Direkt übernommen aus fwupd
+#~ msgid "Suspend To RAM"
+#~ msgstr "In Bereitschaft versetzen"
+
+# Direkt übernommen aus fwupd
+#~ msgid "Suspend To Idle"
+#~ msgstr "In Ruhezustand versetzen"
+
+# Direkt übernommen aus fwupd
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI-Plattformschlüssel"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Gesicherter UEFI-Systemstart (secure boot)"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM-Plattformeinrichtung"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM-Wiederaufbau"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+# "Intel Management Engine" ist ein Eigenname.
+# "Manufacturing Mode" übernommen aus fwupd
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel-Management-Engine-Herstellungsmodus"
+
+# "Intel Management Engine" ist ein Eigenname.
+# "Override" übernommen aus fwupd
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine überschreiben"
+
+# "Intel Management Engine" ist ein Eigenname.
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel-Management-Engine-Version"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Firmware-Aktualisierungen"
+
+# Direkt übernommen aus fwupd
+#~ msgid "Firmware Attestation"
+#~ msgstr "Firmware-Beglaubigung"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Firmware-Aktualisierungs-Verifizierung"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Plattform-Fehlerdiagnose"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Prozessor-Sicherheitsprüfungen"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD-Rollback-Schutz"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD-Firmware-Wiedereinspielungsschutz"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD-Firmware-Schreibschutz"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Plattform mit Sicherungen"
+
+#~ msgid "Valid"
+#~ msgstr "Gültig"
+
+#~ msgid "Not Valid"
+#~ msgstr "Ungültig"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Nicht eingeschaltet"
+
+#~ msgid "Locked"
+#~ msgstr "Gesperrt"
+
+#~ msgid "Not Locked"
+#~ msgstr "Nicht gesperrt"
+
+#~ msgid "Encrypted"
+#~ msgstr "Verschlüsselt"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Nicht verschlüsselt"
+
+#~ msgid "Tainted"
+#~ msgstr "Verdorben"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Nicht verdorben"
+
+#~ msgid "Found"
+#~ msgstr "Gefunden"
+
+#~ msgid "Not Found"
+#~ msgstr "Nicht gefunden"
+
+#~ msgid "Supported"
+#~ msgstr "Unterstützt"
+
+#~ msgid "Not Supported"
+#~ msgstr "Nicht unterstützt"
+
+#~ msgid "Unknown"
+#~ msgstr "Unbekannt"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Unbekannt"
+
+#~ msgid "Not Available"
+#~ msgstr "Nicht verfügbar"
+
+#~ msgid "System Logo"
+#~ msgstr "System-Logo"
+
+#~ msgid "No input sources found"
+#~ msgstr "Keine Eingabequellen gefunden"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Weitere"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Eigene Tastenkombinationen"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Die Taste für alternative Zeichen kann verwendet werden, um weitere "
+#~ "Zeichen einzugeben. Diese sind gelegentlich als dritte Option auf Ihrer "
+#~ "Tastatur angegeben."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Linke Alt-Taste"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Rechte Alt-Taste"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Linke Super-Taste"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Rechte Super-Taste"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menü-Taste"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Rechte Strg-Taste"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Die Compose-Taste ermöglicht es, eine Vielzahl an Zeichen einzugeben. Um "
+#~ "sie zu nutzen, drücken Sie »Compose« und dann eine Sequenz an Zeichen. "
+#~ "»Compose« gefolgt von <b>C</b> und <b>o</b> resultiert beispielsweise in "
+#~ "<b>©</b>, <b>a</b> gefolgt von <b>'</b> resultiert in <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Feststelltaste"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Druck"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Eingabequellen können mit dem Tastenkürzel %s gewechselt werden.\n"
+#~ "Das kann in den Tastenkürzel-Einstellungen geändert werden."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d geändert"
+#~ msgstr[1] "%d geändert"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Alle Tastenkombination zurücksetzen?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Zurücksetzen der Tastaturkombinationen kann Ihre persönlichen "
+#~ "Tastaturkombinationen beeinflussen. Kann nicht rückgängig gemacht werden."
+
+#~ msgid "Reset All"
+#~ msgstr "Alles zurücksetzen"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s wird bereits für %s verwendet. Wenn Sie diese ersetzen, so wird %s "
+#~ "deaktiviert"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Neue Tastenkombination eingeben"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Eigene Tastenkombination festlegen"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Tastenkombination festlegen"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Geben Sie die neue Tastenkombination ein, um %s zu ändern."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Individuelle Tastenkombination hinzufügen"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Bildlauf mit zwei Fingern"
+
+# Doof. https://www.reddit.com/r/gnome/comments/1cgjh0/dear_gnome_developers_i_think_what_you_did_is/c9gay98
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Fünf Klicks, GEGL-Zeit!"
+
+# CHECK
+#~ msgid "Double click, primary button"
+#~ msgstr "Doppelklick, primäre Taste"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Einfacher Klick, primäre Taste"
+
+# CHECK
+#~ msgid "Double click, middle button"
+#~ msgstr "Doppelklick, mittlere Taste"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Einfacher Klick, mittlere Taste"
+
+# CHECK
+#~ msgid "Double click, secondary button"
+#~ msgstr "Doppelklick, sekundäre Taste"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Einfacher Klick, sekundäre Taste"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager muss laufen."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Unsicheres Netzwerk (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Sicheres Netzwerk (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Sicheres Netzwerk (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Sicheres Netzwerk (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Netzwerk sichern"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Wenn der Hotspot eingeschaltet wird, werden Sie von %s getrennt und "
+#~ "können nicht auf das Internet mittels WLAN zugreifen."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Erfordert mindestens 8 Zeichen"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Den HotSpot anhalten und verbundene Benutzer trennen?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "Hot _Spot anhalten"
+
+#~ msgid "Preserve"
+#~ msgstr "Beibehalten"
+
+#~ msgid "Permanent"
+#~ msgstr "Dauerhaft"
+
+#~ msgid "Random"
+#~ msgstr "Zufällig"
+
+#~ msgid "Stable"
+#~ msgstr "Stabil"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Die hier eingegebene MAC-Adresse wird als Hardware-Adresse des "
+#~ "Netzwerkgerätes verwendet, für das diese Verbindung aktiviert ist. Dieses "
+#~ "Funktionsmerkmal ist als »MAC-Cloning« oder »MAC-Spoofing« bekannt. "
+#~ "Beispiel: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Erweitertes Öffnen"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Keine"
+
+#~ msgid "Never"
+#~ msgstr "Nie"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mbit/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mbit/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+# Signal Strength: Keine statt Keines? - jb+
+# Hier eher in der kürzeren Variante "Wieviel Signal" - ts
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Keines"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Schwach"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "OK"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Gut"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Ausgezeichnet"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Verbindung entfernen"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Verbindungsprofil entfernen"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN entfernen"
+
+#~ msgid "Details"
+#~ msgstr "Details"
+
+#~ msgid "automatic"
+#~ msgstr "automatisch"
+
+#~ msgid "Identity"
+#~ msgstr "Identität"
+
+#~ msgid "Delete Address"
+#~ msgstr "Adresse entfernen"
+
+#~ msgid "Delete Route"
+#~ msgstr "Route entfernen"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Keine"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-Bit-Schlüssel (Hex oder ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-Bit-Passphrase"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamisches WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA und WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA und WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Öffnen des Verbindungseditors schlug fehl"
+
+#~ msgid "New Profile"
+#~ msgstr "Neues Profil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Ungültige Einstellung %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Ungültige Einstellung %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Aus Datei importieren …"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN hinzufügen"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN-Verbindung kann nicht importiert werden"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Die Datei »%s« konnte nicht gelesen werden oder enthält keine gültige VPN-"
+#~ "Verbindung\n"
+#~ "\n"
+#~ "Fehler: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Wählen Sie die Datei zum Importieren"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Eine Datei namens »%s« ist bereits vorhanden."
+
+#~ msgid "_Replace"
+#~ msgstr "E_rsetzen"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "Wollen Sie %s mit der VPN-Verbindung ersetzen, die Sie gerade speichern?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN-Verbindung kann nicht exportiert werden"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Die VPN-Verbindung »%s« konnte nicht nach %s exportiert werden\n"
+#~ "\n"
+#~ "Fehler: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN-Verbindung exportieren"
+
+#~ msgid "never"
+#~ msgstr "nie"
+
+#~ msgid "today"
+#~ msgstr "heute"
+
+#~ msgid "yesterday"
+#~ msgstr "gestern"
+
+#~ msgid "Last used"
+#~ msgstr "Zuletzt verwendet"
+
+#~ msgid "Add new connection"
+#~ msgstr "Neue Verbindung hinzufügen"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Netzwerkdetails für die gewählten Netzwerke, einschließlich Passwort und "
+#~ "jegliche benutzerdefinierte Konfiguration, werden verloren gehen."
+
+#~ msgid "_Forget"
+#~ msgstr "_Vergessen"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Bekannte Funknetzwerke"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Vergessen"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Die Systemeinstellungen verbieten die Nutzung als Hotspot"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Das Drahtlos-Gerät unterstützt keinen Hotspot-Modus"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Automatische Internet-Proxy-Erkennung wird verwendet, wenn keine "
+#~ "Einrichtungsadresse angegeben wird."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Dies wird für unsichere öffentliche Netzwerke nicht empfohlen."
+
+#~ msgid "Status unknown"
+#~ msgstr "Status unbekannt"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Nicht verwaltet"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nicht verfügbar"
+
+#~ msgid "Connecting"
+#~ msgstr "Verbindung wird hergestellt"
+
+#~ msgid "Authentication required"
+#~ msgstr "Legitimierung erforderlich"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Verbindung wird getrennt"
+
+#~ msgid "Connection failed"
+#~ msgstr "Verbindung fehlgeschlagen"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Status unbekannt (fehlt)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Einrichtung ist fehlgeschlagen"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP-Einrichtung ist fehlgeschlagen"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP-Einrichtung ist abgelaufen"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Geheimdaten waren erforderlich, wurden aber nicht angegeben"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x-Supplicant getrennt"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Einrichten des 802.1x-Supplicant fehlgeschlagen"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x-Supplicant fehlgeschlagen"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x-Supplicant brauchte zu lange für die Legitimierung"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP-Dienst konnte nicht gestartet werden"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP-Dienst getrennt"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP fehlgeschlagen"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP-Client konnte nicht gestartet werden"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP-Client-Fehler"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-Client fehlgeschlagen"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr ""
+#~ "Dienst für gemeinsam verwendete Verbindung konnte nicht gestartet werden"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Dienst für gemeinsam verwendete Verbindung fehlgeschlagen"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Start des AutoIP-Diensts fehlgeschlagen"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Fehler des AutoIP-Diensts"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP-Dienst fehlgeschlagen"
+
+#~ msgid "Line busy"
+#~ msgstr "Die Leitung ist belegt"
+
+#~ msgid "No dial tone"
+#~ msgstr "Kein Freizeichen"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Es konnte kein Trägersignal aufgebaut werden"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Der Einwahlvorgang benötigte zu viel Zeit"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Der Einwahlversuch ist fehlgeschlagen"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Modem-Initialisierung fehlgeschlagen"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Angegebener APN konnte nicht ausgewählt werden"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Es wird nicht nach Netzwerken gesucht"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Netzwerkanmeldung abgelehnt"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Netzwerkanmeldung benötigte zu viel Zeit"
+
+# s. o. - jb
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Anmeldung an dem angeforderten Netzwerk fehlgeschlagen"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN-Überprüfung fehlgeschlagen"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Notwendige Firmware des Geräts fehlt möglicherweise"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Unzuverlässige Verbindung"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Es wurde von einer bestehenden Verbindung ausgegangen"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem nicht gefunden"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth-Verbindung fehlgeschlagen"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM-Karte ist nicht eingesetzt"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM-Pin ist erforderlich"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM-Puk ist erforderlich"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM falsch"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Eine Abhängigkeit der Verbindung ist gescheitert"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Firmware fehlt"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel nicht angeschlossen"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "Nicht definierter Fehler in 802.1X-Sicherheit (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "keine Datei ausgewählt"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "Nicht spezifizierter Fehler beim Überprüfen der eap-method-Datei"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Geheimer DER, PEM, PKCS#12 oder PGP-Schlüssel"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER- oder PEM-Zertifikate"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "PAC-Datei für EAP-FAST fehlt"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC-Dateien (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "Benutzername für EAP-LEAP fehlt"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "Passwort für EAP-LEAP fehlt"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "Ungültiges CA-Zertifikat für EAP-PEAP: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "Ungültiges CA-Zertifikat für EAP-PEAP: kein Zertifikat angegeben"
+
+#~ msgid "missing EAP username"
+#~ msgstr "EAP-Benutzername fehlt"
+
+#~ msgid "missing EAP password"
+#~ msgstr "EAP-Passwort fehlt"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "EAP-TLS-Identität fehlt"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "Ungültiges CA-Zertifikat für EAP-TLS: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "Ungültiges CA-Zertifikat für EAP-TLS: kein Zertifikat angegeben"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "Ungültiger geheimer Schlüssel für EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "Ungültiges Benutzerzertifikat für EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Unverschlüsselte geheime Schlüssel sind unsicher"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Der gewählte Schlüssel scheint nicht durch ein Passwort geschützt zu "
+#~ "sein. Dies gefährdet Ihre Sicherheitsinformationen. Bitte wählen Sie "
+#~ "einen durch ein Passwort geschützten geheimen Schlüssel.\n"
+#~ "\n"
+#~ "(Sie können Ihren Schlüssel mit openssl mit einem Passwort schützen)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Wählen Sie Ihr persönliches Zertifikat"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Wählen Sie Ihren geheimen Schlüssel"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "Ungültiges CA-Zertifikat für EAP-TTLS: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "Ungültiges CA-Zertifikat für EAP-TTLS: kein Zertifikat angegeben"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Unbekannter Fehler beim Überprüfen der 802.1X-Sicherheit"
+
+#~ msgid "Select a file"
+#~ msgstr "Eine Datei wählen"
+
+#~ msgid "missing leap-username"
+#~ msgstr "Leap-Benutzername fehlt"
+
+#~ msgid "missing leap-password"
+#~ msgstr "Leap-Passwort fehlt"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "WLAN-Passwort fehlt."
+
+#~ msgid "missing wep-key"
+#~ msgstr "WEP-Schlüssel fehlt"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "Ungültiger WEP-Schlüssel: ein Schlüssel mit der Länge %zu darf nur "
+#~ "Hexadezimalzahlen enthalten"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "Ungültiger WEP-Schlüssel: ein Schlüssel mit der Länge %zu darf nur ASCII-"
+#~ "Zeichen enthalten"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "Ungültiger WEP-Schlüssel: falsche Schlüssellänge %zu. Ein Schlüssel muss "
+#~ "entweder dem Schema 5/13 (ASCII) oder 10/26 (hexadezimal) entsprechen"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "Ungültiger WEP-Schlüssel: Kennwort darf nicht leer sein"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "Ungültiger WEP-Schlüssel: Kennwort muss kürzer als 64 Zeichen sein"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "Schlüssellänge %zu für WPA-PSK ist ungültig, muss [8,63] Bytes oder 64 "
+#~ "hexadezimale Stellen haben"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "WPA-PSK-Schlüssel kann nicht als 64 Byte hexadezimal ausgewertet werden"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Weitere"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s entfernt"
+
+#~ msgid "Error removing account"
+#~ msgstr "Fehler beim Entfernen des Kontos"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s-Konto"
+
+#~ msgid "Remove Account"
+#~ msgstr "Konto entfernen"
+
+#~ msgid "Unknown time"
+#~ msgstr "Unbekannte Zeit"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%d %s und %d %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s bis vollständig geladen"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Vorsicht: %s verbleiben"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s verbleiben"
+
+#~ msgid "Fully charged"
+#~ msgstr "Vollständig geladen"
+
+#~ msgid "Not charging"
+#~ msgstr "Lädt nicht"
+
+#~ msgid "Empty"
+#~ msgstr "Leer"
+
+#~ msgid "Charging"
+#~ msgstr "Lädt"
+
+#~ msgid "Discharging"
+#~ msgstr "Wird entladen"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Drahtlose Maus"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Drahtlose Tastatur"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Unterbrechungsfreie Stromversorgung"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Persönlicher digitaler Assistent"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobiltelefon"
+
+#~ msgid "Media player"
+#~ msgstr "Medienwiedergabegerät"
+
+#~ msgid "Tablet"
+#~ msgstr "Grafiktablett"
+
+#~ msgid "Computer"
+#~ msgstr "Rechner"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Spiel-Eingabegerät"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Netz"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Extra"
+
+#~ msgid "Batteries"
+#~ msgstr "Akku"
+
+#~ msgid "When _idle"
+#~ msgstr "Wenn _inaktiv"
+
+#~ msgid "Suspend"
+#~ msgstr "Bereitschaft"
+
+#~ msgid "Power Off"
+#~ msgstr "Ausschalten"
+
+#~ msgid "Hibernate"
+#~ msgstr "Ruhezustand"
+
+#~ msgid "Nothing"
+#~ msgstr "Nichts"
+
+#~ msgid "When on battery power"
+#~ msgstr "Wenn im Akkubetrieb"
+
+#~ msgid "When plugged in"
+#~ msgstr "Wenn angeschlossen"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nie"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatisch in Bereitschaft gehen"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Leistungsmodus aufgrund hoher Betriebstemperaturen vorübergehend nicht "
+#~ "verfügbar."
+
+# Klingt komisch, ist aber so :) https://gitlab.freedesktop.org/hadess/power-profiles-daemon/-/blob/main/src/net.hadess.PowerProfiles.xml
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Schoß erkannt: Der Leistungsmodus ist vorübergehend nicht verfügbar. "
+#~ "Bringen Sie das Gerät auf eine stabile Oberfläche, um in den "
+#~ "Leistungsmodus wechseln zu können."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Leistungsmodus vorübergehend deaktiviert."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Niedriger Akkustand: Energiesparen aktiviert. Der vorherige Modus wird "
+#~ "wieder verwendet, wenn der Akku ausreichend geladen ist."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Energiesparmodus durch »%s« aktiviert."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Leistungsmodus durch »%s« aktiviert."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Leistung"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Hohe Leistung und erhöhter Energieverbrauch."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Ausgeglichen"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Normale Leistung und normaler Energieverbrauch."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Energie sparen"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Reduzierte Leistung und niedriger Energieverbrauch."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Drucker »%s« wurde gelöscht"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Neuer Drucker konnte nicht hinzugefügt werden."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Die Benutzeroberfläche konnte nicht geladen werden: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Entsperren, um Drucker hinzuzufügen und Einstellungen zu ändern"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Details zu %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Kein passender Treiber gefunden"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Wählen Sie die PPD-Datei"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript-Druckerbeschreibungsdateien (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+#~ "*.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect-Drucker"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD-Drucker"
+
+#~ msgid "One Sided"
+#~ msgstr "Einseitig"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Langer Rand (Vorgabe)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kurzer Rand (Umdrehen)"
+
+#~ msgid "Portrait"
+#~ msgstr "Hochformat"
+
+#~ msgid "Landscape"
+#~ msgstr "Querformat"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Kopfstehendes Querformat"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Kopfstehendes Hochformat"
+
+#~ msgid "Resume"
+#~ msgstr "Fortsetzen"
+
+#~ msgid "Pause"
+#~ msgstr "Anhalten"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Ausstehend"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pausiert"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Legitimierung erforderlich"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Verarbeitung läuft"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Angehalten"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Abgebrochen"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Abgebrochen"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Abgeschlossen"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Diesen Auftrag an die Spitze der Warteschlange stellen"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Aktive Druckaufträge"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Geben Sie Ihre Anmeldedaten ein, um auf %s drucken zu können."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Druckserver entsperren"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s entsperren."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Geben Sie Ihren Benutzernamen und Ihr Passwort ein, um die verfügbaren "
+#~ "Drucker auf %s anzuzeigen."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Es wird nach Druckern gesucht"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serielle Schnittstelle"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Parallele Schnittstelle"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Ort: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresse: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Server erfordert Legitimierung"
+
+#~ msgid "Two Sided"
+#~ msgstr "Beidseitig"
+
+#~ msgid "Paper Type"
+#~ msgstr "Papierart"
+
+#~ msgid "Paper Source"
+#~ msgstr "Papiereinzug"
+
+#~ msgid "Output Tray"
+#~ msgstr "Ausgabeschacht"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Auflösung"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript-Vorfilterung"
+
+#~ msgid "Pages per side"
+#~ msgstr "Seiten pro Blatt"
+
+#~ msgid "Orientation"
+#~ msgstr "Ausrichtung"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Allgemein"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Seiteneinrichtung"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Installierbare Optionen"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Auftrag"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Bildqualität"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Farbe"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Abschließen"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Erweitert"
+
+#~ msgid "Test page"
+#~ msgstr "Testseite"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatische Auswahl"
+
+#~ msgid "Printer Default"
+#~ msgstr "Drucker-Voreinstellung"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Nur GhostScript-Schriften einbinden"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "In PS Level 1 umwandeln"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "In PS Level 2 umwandeln"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Keine Vorfilterung"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Druckköpfe reinigen"
+
+#~ msgid "Out of toner"
+#~ msgstr "Toner leer"
+
+#~ msgid "Low on developer"
+#~ msgstr "Wenig Entwickler"
+
+#~ msgid "Out of developer"
+#~ msgstr "Entwickler leer"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Einer der Farbspeicher fast leer"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Eine Farbpatrone leer"
+
+#~ msgid "Open cover"
+#~ msgstr "Abdeckung offen"
+
+#~ msgid "Open door"
+#~ msgstr "Klappe offen"
+
+#~ msgid "Low on paper"
+#~ msgstr "Wenig Papier"
+
+#~ msgid "Out of paper"
+#~ msgstr "Papier leer"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Abgemeldet"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Angehalten"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Der Abfallbehälter ist fast voll"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Der Abfallbehälter ist voll"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Der optische Bildübertrager ist beinahe verbraucht"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Der optische Bildübertrager funktioniert nicht mehr"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Bereit"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Es werden keine Aufträge angenommen"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Verarbeitung läuft"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrisch"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Nachfragen, was geschehen soll"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nichts tun"
+
+#~ msgid "Open folder"
+#~ msgstr "Ordner öffnen"
+
+#~ msgid "Other Media"
+#~ msgstr "Andere Medien"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Eine Anwendung für Audio-CDs wählen"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Eine Anwendung für Video-DVDs wählen"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Wählen Sie eine Anwendung, wenn ein Musikabspielgerät angeschlossen wird"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Wählen Sie eine Anwendung, wenn eine Kamera angeschlossen wird"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Eine Anwendung für Software-CDs wählen"
+
+#~ msgid "audio DVD"
+#~ msgstr "Audio-DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Leere Blu-ray-Disc"
+
+#~ msgid "blank CD disc"
+#~ msgstr "Leere CD"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "Leere DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Leere HD-DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray-Video-Disc"
+
+#~ msgid "e-book reader"
+#~ msgstr "E-Book-Reader"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD-DVD-Video-Disc"
+
+#~ msgid "Picture CD"
+#~ msgstr "Foto-CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super-Video-CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video-CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Bildschirm schaltet ab"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 Sekunden"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 Minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 Minuten"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 Minuten"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 Minuten"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 Minuten"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 Stunde"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 Minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 Minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 Minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 Minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 Minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 Minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 Minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 Minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 Minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nie"
+
+#~ msgid "Select Location"
+#~ msgstr "Ort wählen"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Keine Anwendungen gefunden"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Es sind keine Netzwerke zur Freigabe gewählt"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "An"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Aus"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Aktiviert"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktiv"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Wählen Sie einen Ordner"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Medienfreigabe einschalten"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Persönliche Dateifreigabe ermöglicht es Ihnen, Ihren öffentlichen Ordner "
+#~ "für andere in Ihrem Netzwerk freizugeben mit: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Wenn Fernanmeldung aktiviert ist, entfernten Benutzern eine Verbindung "
+#~ "mit folgendem Secure-Shell-Befehl erlauben:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Persönliche Medienfreigabe einschalten"
+
+#~ msgid "Device name copied"
+#~ msgstr "Gerätename wurde kopiert"
+
+#~ msgid "Device address copied"
+#~ msgstr "Geräteadresse wurde kopiert"
+
+#~ msgid "Username copied"
+#~ msgstr "Benutzername wurde kopiert"
+
+#~ msgid "Password copied"
+#~ msgstr "Passwort wurde kopiert"
+
+#~ msgid "Custom"
+#~ msgstr "Benutzerdefiniert"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s wird geprüft"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Getrennt"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Verbindungsaufbau"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Verbunden"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Legitimierungsfehler"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Legitimierung"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Eingeschränkte Funktionalität"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Verbunden und legitimiert"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Unbekannt"
+
+# Zeitpunkt, nicht Datum.
+#~ msgid "Authorized at:"
+#~ msgstr "Legitimiert um:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Verbunden um:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Angemeldet um:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Gerät konnte nicht legitimiert werden: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Gerät konnte nicht vergessen werden: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Fehler"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Legitimiert"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Das Thunderbolt-Subsystem (boltd) ist nicht installiert oder wurde nicht "
+#~ "korrekt eingerichtet."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Es können nur USB- und Displayport-Geräte angeschlossen werden."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt konnte nicht erkannt werden.\n"
+#~ "Entweder unterstützt das System Thunderbolt nicht, oder es wurde im BIOS "
+#~ "deaktiviert oder wurde im BIOS auf eine nicht unterstützte "
+#~ "Sicherheitsstufe gesetzt."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Die Unterstützung für Thunderbolt wurde im BIOS deaktiviert."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Die Sicherheitsstufe von Thunderbolt konnte nicht ermittelt werden."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Fehler beim Wechsel in den Direktmodus: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Vorgabe"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Medium"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Groß"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Größer"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Am größten"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d Pixel"
+#~ msgstr[1] "%d Pixel"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kurz"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ Bildschirm"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ Bildschirm"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ Bildschirm"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Lang"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 Stunde"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 Tag"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 Tage"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 Tage"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 Tage"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 Tage"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 Tage"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 Tage"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 Tage"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 Tage"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Alle Objekte aus dem Papierkorb löschen?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Alle Objekte im Papierkorb werden dauerhaft gelöscht."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Papierkorb _leeren"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Alle temporären Dateien löschen?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Alle temporären Dateien werden dauerhaft gelöscht."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Temporäre Dateien _löschen"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 Tag"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 Tage"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 Tage"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Für immer"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr ""
+#~ "Sollte der Internetadresse Ihres Benutzerkontoanbieters entsprechen."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Anlegen des Kontos fehlgeschlagen"
+
+# s.o. - jb
+#~ msgid "Failed to register account"
+#~ msgstr "Anlegen des Kontos schlug fehl"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr ""
+#~ "Es gibt keine unterstützte Möglichkeit für eine Legitimierung mit dieser "
+#~ "Domäne"
+
+# Manchmal wird das »failed« am Satzende mit »schlug fehl« übersetzt, manchmal mit »fehlgeschlagen«. Sollen wir das angleichen? - jb
+#~ msgid "Failed to join domain"
+#~ msgstr "Beitreten zur Domäne schlug fehl"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ungültiger Benutzer.\n"
+#~ "Bitte versuchen Sie es erneut."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ungültiges Passwort.\n"
+#~ "Bitte versuchen Sie es erneut."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Anmelden an der Domäne schlug fehl"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr ""
+#~ "Domäne konnte nicht gefunden werden. Haben Sie sich eventuell vertippt?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Nach weiteren Bildern suchen"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "Das Gerät muss beansprucht werden, um diese Aktion durchzuführen"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "Das Gerät wird bereits von einem anderen Prozess beansprucht"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr ""
+#~ "Sie haben nicht die erforderlichen Rechte, um diese Aktion auszuführen"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "Keine Fingerabdrücke registriert"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr ""
+#~ "Kommunikation mit dem Gerät während der Registrierung fehlgeschlagen"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Kommunikation mit dem Fingerabdruck-Scanner fehlgeschlagen"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Kommunikation mit dem Fingerabdruck-Dienst fehlgeschlagen"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Auflisten der Fingerabdrücke schlug fehl: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Löschen von gespeicherten Fingerabdrücken schlug fehl: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Linker Daumen"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Linker Mittelfinger"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Linker Zeigefinger"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Linker Ringfinger"
+
+#~ msgid "Left little finger"
+#~ msgstr "Linker kleiner Finger"
+
+#~ msgid "Right thumb"
+#~ msgstr "Rechter Daumen"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Rechter Mittelfinger"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Rechter Zeigefinger"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Rechter Ringfinger"
+
+#~ msgid "Right little finger"
+#~ msgstr "Rechter kleiner Finger"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Unbekannter Finger"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Abgeschlossen"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Das Fingerabdruckgerät wurde getrennt"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Der Speicher des Fingerabdruckgeräts ist voll"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Die Registrierung eines neuen Fingerabdrucks ist fehlgeschlagen"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Starten der Registrierung schlug fehl: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Die Registrierung eines neuen Fingerabdrucks ist fehlgeschlagen"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Beenden der Registrierung schlug fehl: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Legen Sie Ihren Finger mehrmals auf den Leser, um Ihren Fingerabdruck zu "
+#~ "registrieren"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Diesen Finger _erneut registrieren …"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Neuen Fingerabdruck einlesen"
+
+# Also das geht so noch nicht. Andere Ideen?
+# --
+# Das Fingerabdruck-Gerät konnte nicht freigegeben werden
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Die Freigabe des Fingerabdruck-Geräts %s schlug fehl: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Probleme beim Ansprechen des Geräts"
+
+# Also das geht so noch nicht. Andere Ideen?
+# --
+# Das Fingerabdruck-Gerät konnte nicht beansprucht werden.
+# (Wobei beanspruchen hier wirklich schwer verständlich ist. Mir fällt aber auch nichts Besseres ein;)
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Die Belegung des Fingerabdruck-Geräts %s schlug fehl: %s"
+
+# Also das geht so noch nicht. Andere Ideen?
+# --
+# Fingerabdruck-Geräte konnten nicht ermittelt werden. // Es konnten keine Fingeradruck-Geräte ermittelt werden. (Vielleicht besser: gefunden? Oder: entdeckt?)
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Ermitteln der Fingerabdruck-Geräte schlug fehl: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Diese Woche"
+
+#~ msgid "Last Week"
+#~ msgstr "Letzte Woche"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+# I prefer 07:30 instead of 7:30
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%H:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sitzungsende"
+
+#~ msgid "Session Started"
+#~ msgstr "Sitzungsbeginn"
+
+# em dash (gibt es auf Deutsch nicht) - jb
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Kontoaktivität"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Bitte wählen Sie ein anderes Passwort."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Bitte geben Sie Ihr aktuelles Passwort erneut ein."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Passwort konnte nicht geändert werden"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Diesem Typ von Domäne kann nicht automatisch beigetreten werden"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Es wurde keine solche Domäne oder Realm gefunden"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Anmeldung als %s in der Domäne %s schlug fehl"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Ungültiges Passwort, bitte versuchen Sie es erneut"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Es konnte keine Verbindung mit %s-Domäne hergestellt werden: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Benutzer konnte nicht gelöscht werden"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Entfernt verwalteter Benutzer konnte nicht widerrufen werden"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Sie können Ihr eigenes Konto nicht löschen."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ist immer noch angemeldet"
+
+# Was genau ein inkonsistenter (= unbeständiger)  Zustand in diesem Zusammenhang bedeutet, wird, finde ich, nicht klar. Nicht durch die Übersetzung, wohlgemerkt, sondern durch das Original. Konkret: Was passiert, wenn ich mich eingeloggt als Nutzer lösche?
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Das Löschen von Benutzern, während sie angemeldet sind, kann das System "
+#~ "in einen inkonsistenten Zustand versetzen."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Wollen Sie die Dateien von %s behalten?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Es ist möglich, den persönlichen Ordner, die Mail-Warteschlange und die "
+#~ "temporären Dateien zu behalten, wenn ein Benutzerkonto gelöscht wird."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Dateien löschen"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Dateien _behalten"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Sind Sie sicher, dass Sie den entfernt verwalteten Benutzer »%s« "
+#~ "widerrufen möchten?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Löschen"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Konto ist deaktiviert"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Bei der nächsten Anmeldung festlegen"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Keine"
+
+#~ msgid "Logged in"
+#~ msgstr "Angemeldet"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Kontendienst konnte nicht kontaktiert werden"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Bitte stellen Sie sicher, dass der Kontendienst korrekt installiert und "
+#~ "aktiviert ist."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Diese Leiste musst entsperrt sein, um diese Einstellung zu ändern"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Das gewählte Benutzerkonto löschen"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Um das gewählte Benutzerkonto zu löschen,\n"
+#~ "klicken Sie zuerst auf das Symbol *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Entsperren, um Nutzer hinzuzufügen und Einstellungen zu ändern"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Das neue Passwort muss sich vom vorherigen unterscheiden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Versuchen Sie einige Buchstaben und Ziffern zu ändern."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Versuchen Sie das Passwort noch mehr zu ändern."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Ein Passwort ohne Ihren Benutzernamen wäre stärker."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Versuchen Sie Ihren Namen im Passwort nicht zu verwenden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Versuchen Sie einige der Wörter im Passwort zu vermeiden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Versuchen Sie gewöhnliche Wörter zu vermeiden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Versuchen Sie das Anordnen existierender Wörter zu vermeiden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Versuchen Sie mehr Ziffern zu verwenden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Versuchen Sie mehr Großbuchstaben zu verwenden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Versuchen Sie mehr Kleinbuchstaben zu verwenden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Versuchen Sie mehr Sonderzeichen (z.B. Satzzeichen) zu verwenden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Versuchen Sie eine Mischung aus Buchstaben, Ziffern und Satzzeichen."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Versuchen Sie die Wiederholung desselben Zeichens zu vermeiden."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Versuchen Sie Wiederholungen von Zeichen derselben Gruppe zu vermeiden. "
+#~ "Sie sollten Buchstaben, Ziffern und Satzzeichen mischen."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Versuchen Sie Sequenzen wie z.B. »1234« oder »abcd« zu vermeiden."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Passwörter müssen länger sein. Fügen Sie weitere Buchstaben, Ziffern und "
+#~ "Satzzeichen hinzu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Mischen Sie Großbuchstaben und Kleinbuchstaben und verwenden Sie eine "
+#~ "Ziffer oder zwei."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Durch Hinzufügen von Buchstaben, Ziffern und Satzzeichen wird das "
+#~ "Passwort noch besser."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Legitimierung fehlgeschlagen"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Das neue Passwort ist zu kurz"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Das neue Passwort ist zu einfach"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Die alten und neuen Passwörter sind zu ähnlich"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Das neue Passwort wurde kürzlich bereits verwendet."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Das neue Passwort muss numerische oder Sonderzeichen enthalten"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Das neue und das alte Passwort sind gleich"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Ihr Passwort wurde geändert, seitdem Sie sich erstmalig legitimiert haben!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Das neue Passwort enthält nicht genug unterschiedliche Zeichen"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Unbekannter Fehler"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Der Benutzername darf aus Klein- und Großbuchstaben von A bis Z, Ziffern "
+#~ "sowie den Zeichen »-« und »_« bestehen"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Leider ist dieser Benutzername nicht verfügbar. Wählen Sie bitte einen "
+#~ "anderen."
+
+#~ msgid "The username is too long."
+#~ msgstr "Der Benutzername ist zu lang."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Knopf %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Festgelegte Anwendung"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Tasteneingabe senden"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Monitor wechseln"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Bildschirmhilfe zeigen"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Am Laptop-Rahmen befestigtes Grafiktablett"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "An externem Bildschirm befestigtes Grafiktablett"
+
+#~ msgid "External tablet device"
+#~ msgstr "Externes Grafiktablett"
+
+#~ msgid "All Displays"
+#~ msgstr "Alle Bildschirme"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Airbrush-Stylus mit Druck- und Kippsensor sowie integriertem Regler"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Airbrush-Stylus mit Druck-, Kipp- und Drehsensor"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standard-Stylus mit Druck- und Kippsensor"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standard-Stylus mit Drucksensor"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Neue Tastenkombination …"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Vorgang abgebrochen"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr ""
+#~ "<b>Fehler:</b> Zugriff wurde bei der Änderung der Einstellungen verweigert"
+
+# Scheint eine ganze Reihe an möglichen Fehlern zu geben: https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/e32b67e5c0e75600b4fa5154e137717f82dabf0d/panels/wwan/cc-wwan-errors-private.h#L39
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Fehler:</b> Fehler des Mobilgeräts"
+
+#~ msgid "Not Registered"
+#~ msgstr "Nicht registriert"
+
+#~ msgid "Registered"
+#~ msgstr "Registriert"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Suchen"
+
+#~ msgid "Denied"
+#~ msgstr "Verweigert"
+
+#~ msgid "2G Only"
+#~ msgstr "Nur 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Nur 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Nur 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Nur 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (bevorzugt)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (bevorzugt), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (bevorzugt), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (bevorzugt), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (bevorzugt)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (bevorzugt), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (bevorzugt), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (bevorzugt)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (bevorzugt), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (bevorzugt), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (bevorzugt)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (bevorzugt), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (bevorzugt), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (bevorzugt)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (bevorzugt), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (bevorzugt), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (bevorzugt)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (bevorzugt), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (bevorzugt)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (bevorzugt), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (bevorzugt)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (bevorzugt), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (bevorzugt)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (bevorzugt), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (bevorzugt)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (bevorzugt), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "3G, 5G (bevorzugt)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "3G (bevorzugt), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Unbekannt"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "SIM-Karte entsperren"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Bitte geben Sie den PIN-Code für die SIM-Karte %d an"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "PIN-Code eingeben, um die SIM-Karte zu entsperren"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Bitte geben Sie den PUK-Code für die SIM-Karte %d an"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "PUK-Code eingeben, um die SIM-Karte zu entsperren"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Falsches Passwort eingegeben."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Der PUK-Code sollte eine Zahl mit 8 Ziffern sein"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Neuen PIN-Code eingeben"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Der PIN-Code sollte eine Zahl mit 4-8 Ziffern sein"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Wird entsperrt …"
+
+#~ msgid "Phone failure"
+#~ msgstr "Telefonfehler"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Keine Verbindung zum Telefon"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Vorgang nicht erlaubt"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Vorgang nicht unterstützt"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM-Karte ist nicht eingesetzt"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM-PIN ist erforderlich"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM-PUK ist erforderlich"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM-Fehler"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM beschäftigt"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Falsches Passwort"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM-PIN2 ist erforderlich"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM-PUK2 ist erforderlich"
+
+#~ msgid "Not found"
+#~ msgstr "Nicht gefunden"
+
+#~ msgid "No network service"
+#~ msgstr "Kein Netzwerkdienst"
+
+#~ msgid "Network timeout"
+#~ msgstr "Netzwerk-Zeitüberschreitung"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS-Dienste nicht erlaubt"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming ist in diesem Gebiet nicht erlaubt"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Unbestimmter GRPS-Fehler"
+
+#~ msgid "No Error"
+#~ msgstr "Kein Fehler"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Aktion abgebrochen"
+
+#~ msgid "Access denied"
+#~ msgstr "Zugriff verweigert"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Unbekannter Fehler"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Versionsnummer anzeigen"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Ausführliche Meldungen aktivieren"
+
+#~ msgid "Search for the string"
+#~ msgstr "Nach der Zeichenkette suchen"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Mögliche Panel-Namen anzeigen und beenden"
+
+#~ msgid "Panel to display"
+#~ msgstr "Bildschirm für Anzeige"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[LEISTE] [ARGUMENT …]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Verfügbare Leisten:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Systemklänge"
 
 #~ msgid "Light"
 #~ msgstr "Hell"
@@ -9734,9 +8447,6 @@ msgstr "Systemklänge"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER oder PEM-Zertifikate (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Einen Drucker hinzufügen …"
 
 #~ msgid "Drip"
 #~ msgstr "Tropfen"
@@ -10120,9 +8830,6 @@ msgstr "Systemklänge"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablett (absolut)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Tastfeld (relativ)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Tablett-Einstellungen"
 
@@ -10291,9 +8998,6 @@ msgstr "Systemklänge"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Auf Bluetooth-Hardware direkt zugreifen"
-
-#~ msgid "Use your camera"
-#~ msgstr "Ihre Kamera verwenden"
 
 #~ msgid "Print documents"
 #~ msgstr "Dokumente drucken"

--- a/po/de.po~
+++ b/po/de.po~
@@ -1,0 +1,10876 @@
+# German gnome-control-center translation
+# Copyright (C) 1998-2015 Free Software Foundation, Inc.
+#
+#
+# Carsten Schaar <nhadcasc@fs-maphy.uni-hannover.de>, 1998.
+# Karsten Weiss <karsten@addx.au.s.shuttle.de>, 1999.
+# Matthias Warkus <mawa@iname.com>, 1999.
+# Karl Eichwalder <ke@suse.de>, 1999, 2000.
+# Christian Meyer <chrisime@gnome.org>, 2000, 2001, 2002.
+# Christian Neumair <chris@gnome-de.org>, 2002-2004.
+# Hendrik Brandt <heb@gnome-de.org>, 2004-2005.
+# Frank Arnold <frank@scirocco-5v-turbo.de>, 2005.
+# Jens Seidel <jseidel@cvs.gnome.org>, 2005.
+# Christian Kintner <ckintner@gnome-de.org>, 2007.
+# Hendrik Richter <hendrikr@gnome.org>, 2004-2009.
+# Hendrik Knackstedt <kn.hendrik@gmail.com>, 2011.
+# Tobias Endrigkeit <tobiasendrigkeit@googlemail.com>, 2012, 2013.
+# Benjamin Steinwender <b@stbe.at>, 2013-2014.
+# Paul Seyfert <pseyfert@mathphys.fsk.uni-heidelberg.de>, 2015.
+# Wolfgang Stöggl <c72578@yahoo.de>, 2009, 2011, 2012, 2016.
+# Bernd Homuth <dev@hmt.im>, 2014, 2015, 2019.
+# Mario Blättermann <mario.blaettermann@gmail.com>, 2010-2013, 2015-2019.
+# Tim Sabsch <tim@sabsch.com>, 2019-2022.
+# Philipp Kiemle <philipp.kiemle@gmail.com>, 2020-2022.
+# Jürgen Benvenuti <gastornis@posteo.org>, 2022.
+# Christian Kirbach <christian.kirbach@gmail.com>, 2009-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-12 15:11+0000\n"
+"PO-Revision-Date: 2022-09-15 21:05+0200\n"
+"Last-Translator: Tim Sabsch <tim@sabsch.com>\n"
+"Language-Team: Germany <gnome-de@gnome.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "System-Bus"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Vollständiger Zugriff"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Sitzungs-Bus"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Geräte"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Vollständiger Zugriff auf /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Netzwerk"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Hat Netwerkzugriff"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Persönlicher Ordner"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Nur Lesezugriff"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Dateisystem"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Einstellungen"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Darf Einstellungen ändern"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s hat die folgenden Berechtigungen eingebaut, die nicht geändert werden "
+"können. Falls Sie diesbezüglich Bedenken haben, sollten Sie in Erwägung "
+"ziehen, diese Anwendung zu löschen."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u Datei- und Verknüpfungs-Typ wird von dieser Anwendung geöffnet"
+msgstr[1] ""
+"%u Datei- und Verknüpfungs-Typen werden von dieser Anwendung geöffnet"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> wird verwendet, um die folgenden Datei- und Verknüpfungs-Typen zu "
+"öffnen."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s des Speicherplatzes wird verwendet."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Anwendungen"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Keine Anwendungen"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Einige installieren …"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Öffnen"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Details betrachten"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Suchen"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "System durchsuchen und Ergebnisse anzeigen."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Benachrichtigungen"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Systembenachrichtigungen anzeigen."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Im Hintergrund ausführen"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Aktivitäten erlauben, wenn die Anwendung geschlossen ist."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Bildschirmfotos"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Jederzeit Fotos des Bildschirms aufnehmen."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Hintergrund ändern"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Schreibtischhintergrund ändern."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Klänge"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Klänge wiedergeben."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Tastenkombinationen unterdrücken"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "System-Tastenkombinationen unterdrücken."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Fotos mit der Kamera aufnehmen."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Ton mit dem Mikrofon aufnehmen."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Ortungsdienste"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Geräte-Standortdaten abfragen."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Eingebaute Berechtigungen"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Systemberechtigungen, die von dieser Anwendung benötigt werden"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Zuordnungen von Dateien und Verknüpfungen"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Datenspeicher"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Keine Ergebnisse gefunden"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Versuchen Sie eine andere Suchanfrage"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Zuordnungen von Dateien und Verknüpfungen"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Dateitypen"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Verknüpfungstypen"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "Speicher, den diese Anwendung für Zwischenspeicher und Daten belegt."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Anwendung"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Daten"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Zwischenspeicher"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Insgesamt</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Zwischenspeicher leeren …"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Festlegen verschiedener Anwendungs-Berechtigungen und Einstellungen"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"application;anwendung;flatpak;permission;berechtigung;setting;einstellung;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Ein Bild wählen"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Abbre_chen"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "Ö_ffnen"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "mehrere Größen"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Kein Schreibtisch-Hintergrund"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Aktueller Hintergrund"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stil"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Vorgabe"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Dunkel"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Hintergrund"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Bild hinzufügen …"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Erscheinungsbild"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Hintergrundbild oder die Farben der Anwendungsoberflächen ändern"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;Hintergrund;"
+"Hintergrundbild;Bildschirm;Schreibtisch;Stil;Hell;Dunkel;Erscheinungsbild;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Aktivieren"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Kein Bluetooth gefunden"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Schließen Sie einen Adapter an, um Bluetooth verwenden zu können."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth ausgeschaltet"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Aktivieren Sie Bluetooth, um Geräte zu verbinden und Dateiübertragungen zu "
+"empfangen."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Flugzeugmodus ist aktiviert"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth ist im Flugzeugmodus deaktiviert."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Flugzeugmodus ausschalten"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Hardware-Flugzeugmodus ist aktiviert"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+"Schalten Sie den Flugzeugmodus-Schalter aus, um Bluetooth zu aktivieren."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Schalten Sie Bluetooth an oder aus und verbinden Sie Ihre Geräte"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "Freigabe;Bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera ist ausgeschaltet"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Keine Anwendung kann Fotos oder Videos aufnehmen."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Verwendung der Kamera ermöglicht es Anwendungen, Fotos und Videos "
+"aufzunehmen. Deaktivieren der Kamera kann dazu führen, dass einige "
+"Anwendungen nicht wie vorgesehen funktionieren.\n"
+"\n"
+"Den unten gelisteten Anwendungen erlauben, die Kamera zu verwenden."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Keine Anwendung hat um Kamerazugriff gebeten"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Ihre Bilder schützen"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;Kamera;Fotos;Bilder;Video;"
+"Filme;Webcam;sperren;privat;Datenschutz;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Platzieren Sie Ihr Kalibrierungsgerät über dem Quadrat und wählen Sie »Start«"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Verschieben Sie Ihr Kalibrierungsgerät in die Kalibrierungsposition und "
+"wählen Sie »Fortsetzen«"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Verschieben Sie Ihr Kalibrierungsgerät in die Oberflächenposition und wählen "
+"Sie »Fortsetzen«"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Schließen Sie den Laptopdeckel"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Ein interner Fehler ist aufgetreten, der nicht behoben werden kann."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Die zur Kalibrierung notwendigen Werkzeuge sind nicht installiert."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Das Profil konnte nicht erstellt werden."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Der gesuchte Weißpunkt konnte nicht ermittelt werden."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Abgeschlossen!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrierung fehlgeschlagen!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Sie dürfen das Kalibrierungsgerät entfernen."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Lassen Sie das Kalibrierungsgerät während des Vorgangs in Ruhe"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Bildschirm-Kalibrierung"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Starten"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "Fo_rtsetzen"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Fertig"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Laptop-Bildschirm"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Eingebaute Webcam"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Bildschirm %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Scanner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Kamera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Drucker %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webcam %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Aktivieren Sie die Farbverwaltung für %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Farbprofile anzeigen für %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Nicht kalibriert"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Vorgabe: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Farbraum: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Testprofil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "ICC-Farbprofildatei wählen"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importieren"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Importierte ICC-Profile"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Alle Dateien"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Bildschirm"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Profil speichern"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Speichern"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Ein Farbprofil für das ausgewählte Gerät erstellen"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Das Messgerät wurde nicht erkannt. Bitte prüfen Sie, ob es korrekt "
+"angeschlossen und eingeschaltet ist."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Das Messgerät unterstützt die Profilierung von Druckern nicht."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Der Gerätetyp wird im Moment nicht unterstützt."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Bildschirmkalibrierung"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Qualität der Kalibrierung"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Eine Kalibrierung wird ein Profil erstellen, das Sie für die Farbverwaltung "
+"Ihres Bildschirms einsetzen können. Je länger Sie kalibrieren, desto höher "
+"wird die Qualität des Farbprofils."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Sie können Ihren Rechner nicht nutzen, während die Kalibrierung läuft."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Qualität"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Ungefähre Zeit"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibrierungsgerät"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+"Wählen Sie die Art des Sensor-Geräts, welches Sie zum Kalibrieren verwenden "
+"wollen."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Anzeigentyp"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Wählen Sie die Art des angeschlossenen Bildschirms."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profil-Weißpunkt"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Wählen Sie das Anzeigeziel für den Weißpunkt. Die meisten Anzeigen sollten "
+"als D65 eingestellt werden."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Bildschirmhelligkeit"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Bitte stellen Sie den Bildschirm auf eine typische Helligkeitsstufe ein. Die "
+"Farbverwaltung wird auf dieser Stufe die besten Ergebnisse erzielen."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativ können Sie die Helligkeitsstufe einstellen, die mit einem der "
+"anderen Profile für dieses Gerät verwendet wird."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profilname"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Sie können Farbprofile auf verschiedenen Rechnern einsetzen oder sogar "
+"Profile für verschiedenes Umgebungslicht erstellen."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profilname:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Zusammenfassung"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil wurde erfolgreich erstellt!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Profil kopieren"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Erfordert ein schreibbares Speichermedium"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Eventuell sind diese Anweisungen hilfreich, wie ein Profil unter <a href="
+"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> und <a href=\"windows"
+"\">Microsoft Windows</a> eingesetzt wird."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Profil hinzufügen"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Probleme entdeckt. Das Profil funktioniert eventuell nicht richtig. <a href="
+"\"\">Details anzeigen.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "Datei _importieren …"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Hinzufügen"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Jedes Gerät benötigt ein aktuelles Farbprofil, um die Farbverwaltung zu "
+"ermöglichen."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Mehr erfahren"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Erfahren Sie mehr über die Farbverwaltung"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Für alle Benutzer fe_stlegen"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Dieses Profil für alle Benutzer dieses Rechners einrichten"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Aktivieren"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Profil _hinzufügen"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrieren …"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Das Gerät kalibrieren"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Profil _entfernen"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Details betrachten"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Es kann kein Gerät mit Farbverwaltung gefunden werden"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (Kaltkathodenröhren-Hintergrundbeleuchtung)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED-Hintergrundbeleuchtung)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (weiße LED-Hintergrundbeleuchtung)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD mit erhöhtem Farbraum (Kaltkathodenröhren-Hintergrundbeleuchtung)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD mit erhöhtem Farbraum (RGB LED-Hintergrundbeleuchtung)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Hoch"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 Minuten"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Medium"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 Minuten"
+
+# Mausempfindlichkeit
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Niedrig"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 Minuten"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Bildschirmeigen"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Drucken und Veröffentlichen)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografie und Grafik)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standard-Farbraum"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testprofil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatisch"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Geringe Qualität"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Mittlere Qualität"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Hohe Qualität"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Standard-RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Standard-CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Standard-Grau"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Vom Hersteller gelieferte Kalibrierungsdaten"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Vollflächige Bildschirmkorrektur ist mit diesem Profil nicht möglich"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Dieses Profil ist möglicherweise nicht mehr ausreichend genau"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Farbe"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Kalibrieren Sie die Farbe Ihrer Geräte wie Monitore, Kameras oder Drucker"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Farbe;ICC;Profil;Kalibrieren;Drucker;Anzeige;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Andere …"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Sprache wählen"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "A_uswählen"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Keine Sprachen gefunden"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Mehr …"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Entsperren, um Einstellungen zu ändern"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Einige Einstellungen müssen entsperrt werden, um sie ändern zu können."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Entsperren …"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Stundenzahl erhöhen"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Minutenzahl erhöhen"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Uhrzeit"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Stundenzahl verringern"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Minutenzahl verringern"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Heute"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Gestern"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d Stunde"
+msgstr[1] "%d Stunden"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d Minute"
+msgstr[1] "%d Minuten"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d Sekunde"
+msgstr[1] "%d Sekunden"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 Sekunden"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-Stunden"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e. %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e. %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Datum und Zeit"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Jahr"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Monat"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januar"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "März"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mai"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juni"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juli"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Dezember"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Tag"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Zeitzone"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Nach einer Stadt suchen"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Datum und Uhrzeit _automatisch ermitteln"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Erfordert eine Internetverbindung"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Datum und _Zeit"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Zeitzone a_utomatisch ermitteln"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Erfordert aktivierte Ortungsdienste und eine Internetverbindung"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "_Zeitzone"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Zeit_format"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Das Datum, die Zeit und die Zeitzone ändern"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Uhr;Zeitzone;Ort;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Einstellungen für Zeit und Datum ändern"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Um die Einstellungen für Zeit und Datum zu ändern, müssen Sie sich "
+"legitimieren."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_E-Mail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalender"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usik"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "V_ideo"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Vorgabe-Anwendungen"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Vorgabe-Anwendungen einrichten"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "Vorgabe;Voreinstellung;Anwendung;bevorzugt;Medien;Medium;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Der Versand von Fehlermeldungen bei technischen Problemen hilft uns, %s zu "
+"verbessern. Diese Meldungen sind frei von personenbezogenen Daten und werden "
+"anonym versendet. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Problemberichterstattung"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatischer Problembericht"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Fehlerdiagnose"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Melden Sie Ihre Probleme"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;Fehlerdiagnose;Absturz;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "An"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Aus"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Änderungen anwenden?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Änderungen können nicht angewendet werden"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Das könnte an Einschränkungen der Hardware liegen."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "An_wenden"
+
+# CHECK upto line 505
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Zurück"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Bildschirmeinstellungen sind deaktiviert"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Mehrere Bildschirme"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Erweitern"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Spiegeln"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Enthält obere Leiste und »Aktivitäten«"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Primärer Bildschirm"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Nachtmodus"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Querformat"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Hochformat rechts gedreht"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Hochformat links gedreht"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Kopfstehendes Querformat"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Ausrichtung"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Auflösung"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Bildwiederholrate"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Anpassung für TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skalieren"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nachtmodus nicht verfügbar"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Dies könnte von der Verwendung des Grafiktreibers herrühren, oder dass der "
+"Schreibtisch per Fernzugriff verwendet wird"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Vorübergehend bis morgen deaktiviert"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Filter neustarten"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Der Nachtmodus stellt den Bildschirm in wärmeren Farben dar. Dies kann vor "
+"Überanstrengung der Augen und Schlaflosigkeit schützen."
+
+# Gemeint ist das Zeitfenster, in dem der Nachtmodus aktiv ist
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Zeitfenster"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Von Sonnenuntergang bis Sonnenaufgang"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Benutzerdefiniertes Fenster"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Zeiten"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Von"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Stunde"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minute"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Bis"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Farbtemperatur"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Bildschirme"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Legt fest, wie angeschlossene Monitore und Projektoren arbeiten"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projektor;xrandr;Anzeige;Auflösung;Aktualisieren;Bildschirm;Monitor;"
+"Nacht;Tag;Blau;Rotverschiebung;Farbe;Sonnenuntergang;Sonnenaufgang;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Gesicherter Systemstart (secure boot) ist aktiv"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Gesicherter Systemstart (secure boot) verhindert, dass bösartige Software "
+"beim Gerätestart geladen wird. Er ist aktuell eingeschaltet und arbeitet "
+"vollständig."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Gesicherter Systemstart (secure boot) meldet Probleme"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Gesicherter Systemstart (secure boot) verhindert, dass bösartige Software "
+"beim Gerätestart geladen wird. Er ist aktuell eingeschaltet, funktioniert "
+"aber nicht wegen eines ungültigen Schlüssels."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Probleme des gesicherten Systemstarts (secure boot) lassen sich oft in den "
+"UEFI Firmware-Einstellungen (BIOS) lösen. Ihr Hardware-Hersteller liefert "
+"möglicherweise Hilfeleistung dabei."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Kontaktieren Sie für Unterstützung Ihren Hardware-Hersteller oder die IT-"
+"Hilfe."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Gesicherter Systemstart (secure boot) ist ausgeschaltet"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Gesicherter Systemstart (secure boot) verhindert, dass bösartige Software "
+"beim Gerätestart geladen wird. Er ist aktuell ausgeschaltet."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Der gesicherte Systemstart (secure boot) wird normalerweise in den UEFI "
+"Firmware-Einstellungen (BIOS) eingeschaltet. Ihr Hardware-Hersteller oder "
+"die IT-Hilfe liefern möglicherweise Hilfestellung dabei."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Gesicherter Systemstart (secure boot) verhindert, dass bösartige Software "
+"beim Gerätestart geladen wird.\n"
+"\n"
+"Erfahren Sie mehr bei Ihrem Hardware-Hersteller oder der IT-Hilfe."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Bestanden"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Fehlgeschlagen"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Das Gerät erfüllt die HSI-Stufe %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Sicherheitsstufe 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Dieses Gerät besitzt keinen Schutz gegen Hardware-Sicherheitslücken. Dies "
+"könnte an der Einrichtung der Hard- oder Firmware liegen. Es wird empfohlen, "
+"Ihre IT-Hilfe zu kontaktieren."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Sicherheitsstufe 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Dieses Gerät besitzt einen geringfügigen Schutz gegen Hardware-"
+"Sicherheitslücken. Dies ist die niedrigste Geräte-Sicherheitsstufe und "
+"bietet nur Schutz vor einfachen Bedrohungen."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Sicherheitsstufe 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Dieses Gerät besitzt einen grundlegenden Schutz gegen Hardware-"
+"Sicherheitslücken. Es bietet Schutz vor herkömmlichen Bedrohungen."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Sicherheitsstufe 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Dieses Gerät besitzt einen erweiterten Schutz gegen Hardware-"
+"Sicherheitslücken. Dies ist die höchste Geräte-Sicherheitsstufe und bietet "
+"auch Schutz vor fortgeschrittenen Bedrohungen."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Sicherheitsstufe"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Die Sicherheitsstufe ist für dieses Gerät nicht verfügbar."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Kontaktieren Sie Ihren Hardware-Hersteller für Unterstützung bei "
+"Sicherheitsaktualisierungen."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Dieses Problem könnte möglicherweise in den UEFI-Firmware-Einstellungen des "
+"Geräts oder durch einen Servicetechniker gelöst werden."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Dieses Problem könnte möglicherweise in den UEFI-Firmware-Einstellungen des "
+"Geräts gelöst werden."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Ein Servicetechniker könnte dieses Problem möglicherweise lösen."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Stufe 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Stufe 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Stufe 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Gegen bösartige Software beim Gerätestart geschützt."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Gesicherter Systemstart (secure boot) meldet Probleme"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Etwas Schutz beim Gerätestart."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Gesicherter Systemstart (secure boot) ist ausgeschaltet"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Kein Schutz beim Gerätestart."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Dieses Problem könnte durch eine Änderung in den UEFI-Firmware-"
+"Einstellungen, eine Änderung in der Einrichtung des Betriebssystems, oder "
+"durch bösartige Software auf diesem System entstanden sein."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Dieses Problem könnte durch eine Änderung in den UEFI-Firmware-Einstellungen "
+"oder durch bösartige Software auf diesem System entstanden sein."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Dieses Problem könnte durch eine Änderung in der Einrichtung des "
+"Betriebssystems oder durch bösartige Software auf diesem System entstanden "
+"sein."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Anfällig für ernste Sicherheitsbedrohungen."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Eingeschränkter Schutz gegen einfache Sicherheitsbedrohungen."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Gegen herkömmliche Sicherheitsbedrohungen geschützt."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Gegen zahlreiche Sicherheitsbedrohungen geschützt."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Umfassender Schutz"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Keine Ereignisse"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Firmware-Schreibschutz"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Firmware-Schreibschutz-Schloss"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Firmware-BIOS-Region"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Firmware-BIOS-Deskriptor"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "DMA-Schutz vor dem Systemstart"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard verifizierter Systemstart"
+
+# Direkt übernommen aus fwupd,
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM-geschützt"
+
+# Direkt übernommen aus fwupd
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard-Fehlerrichtlinie"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard-Sicherung"
+
+# Direkt übernommen aus fwupd
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET aktiviert"
+
+# Direkt übernommen aus fwupd
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET aktiv"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+# Direkt übernommen aus fwupd
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Verschlüsselter RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU-Schutz"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux-Kernel-Sperrung"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux-Kernel-Verifizierung"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux-Auslagerungsspeicher"
+
+# Direkt übernommen aus fwupd
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "In Bereitschaft versetzen"
+
+# Direkt übernommen aus fwupd
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "In Ruhezustand versetzen"
+
+# Direkt übernommen aus fwupd
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI-Plattformschlüssel"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Gesicherter UEFI-Systemstart (secure boot)"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM-Plattformeinrichtung"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM-Wiederaufbau"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+# "Intel Management Engine" ist ein Eigenname.
+# "Manufacturing Mode" übernommen aus fwupd
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel-Management-Engine-Herstellungsmodus"
+
+# "Intel Management Engine" ist ein Eigenname.
+# "Override" übernommen aus fwupd
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine überschreiben"
+
+# "Intel Management Engine" ist ein Eigenname.
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel-Management-Engine-Version"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Firmware-Aktualisierungen"
+
+# Direkt übernommen aus fwupd
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Firmware-Beglaubigung"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Firmware-Aktualisierungs-Verifizierung"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Plattform-Fehlerdiagnose"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Prozessor-Sicherheitsprüfungen"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD-Rollback-Schutz"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD-Firmware-Wiedereinspielungsschutz"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD-Firmware-Schreibschutz"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Plattform mit Sicherungen"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Gültig"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Ungültig"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Nicht eingeschaltet"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Gesperrt"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Nicht gesperrt"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Verschlüsselt"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Nicht verschlüsselt"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Verdorben"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Nicht verdorben"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Gefunden"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Nicht gefunden"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Unterstützt"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Nicht unterstützt"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Gerätesicherheit"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Sicherheitsstatus der Geräte-Firmware"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"Bildschirm;Sperre;Diagnose;Absturz;Crash;Privat;temporär;Index;Name;Netzwerk;"
+"Identität;Privatsphäre;Datenschutz;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Nicht verfügbar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "System-Logo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Gerätename"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Hardware-Modell"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Speicher"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Prozessor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafik"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Festplattenkapazität"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Berechnung läuft …"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Name des Betriebssystems"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Build-Kennung des Betriebssystems"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Typ des Betriebssystems"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME-Version"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Wird geladen …"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Fenstermanager"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisierung"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Software-Aktualisierungen"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Gerät umbenennen"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Der Gerätename wird verwendet, um das Gerät innerhalb eines Netzwerks oder "
+"bei Bluetooth-Nutzung zu identifizieren."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Gerätename"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Umbenennen"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Info"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Informationen über Ihr System anzeigen"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"Gerät;System;Information;Rechnername;Speicher;Prozessor;Version;Vorgabe;"
+"Anwendung;Ersatz;bevorzugt;CD;DVD;USB;Audio;Video;Medien;Wechsel;Medien;"
+"Autostart;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Ton und Medien"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Stumm schalten/Stummschaltung aufheben"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Leiser"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Lauter"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Mikrofon einschalten/ausschalten"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Medien-Wiedergabe öffnen"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Wiedergabe (bzw. Wiedergabe/Unterbrechen)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Wiedergabe unterbrechen"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Wiedergabe anhalten"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Vorheriger Titel"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Nächster Titel"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Auswerfen"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Texteingabe"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Zur nächsten Quelle wechseln"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Zur vorherigen Quelle wechseln"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Starter"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Hilfe-Browser starten"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Taschenrechner öffnen"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "E-Mail-Programm öffnen"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Webbrowser starten"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Persönlicher Ordner"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Suchen"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Abmelden"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Bildschirm sperren"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Barrierefreiheit"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Vergrößerung ein-/ausschalten"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Vergrößern"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Verkleinern"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Bildschirmleser ein-/ausschalten"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Bildschirmtastatur ein-/ausschalten"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Schrift vergrößern"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Schrift verkleinern"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Hohen Kontrast ein-/ausschalten"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Keine Eingabequellen gefunden"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Weitere"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Eine Eingabequelle hinzufügen"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Eingabequellen können nicht auf dem Anmeldebildschirm genutzt werden"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Keine Eingabequelle gefunden"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Optionen"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Nach oben verschieben"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Nach unten verschieben"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Tastaturbelegung anzeigen"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Entfernen"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Eigene Tastenkombinationen"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Taste für alternative Zeichen"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Die Taste für alternative Zeichen kann verwendet werden, um weitere Zeichen "
+"einzugeben. Diese sind gelegentlich als dritte Option auf Ihrer Tastatur "
+"angegeben."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Linke Alt-Taste"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Rechte Alt-Taste"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Linke Super-Taste"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Rechte Super-Taste"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menü-Taste"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Rechte Strg-Taste"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose-Taste"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Die Compose-Taste ermöglicht es, eine Vielzahl an Zeichen einzugeben. Um sie "
+"zu nutzen, drücken Sie »Compose« und dann eine Sequenz an Zeichen. »Compose« "
+"gefolgt von <b>C</b> und <b>o</b> resultiert beispielsweise in <b>©</b>, "
+"<b>a</b> gefolgt von <b>'</b> resultiert in <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Feststelltaste"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Rollen"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Druck"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Eingabequellen können mit dem Tastenkürzel %s gewechselt werden.\n"
+"Das kann in den Tastenkürzel-Einstellungen geändert werden."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Eingabequellen"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Beinhaltet Tastaturbelegungen und Eingabemethoden."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Eingabequelle wechseln"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Die _selbe Quelle für alle Fenster verwenden"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Eingabequellen für jedes Fenster _individuell wechseln"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Eingabe von Sonderzeichen"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Methoden, um mit der Tastatur Symbole und Zeichenvarianten einzugeben."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Tastenkombinationen"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Tastenkombinationen anzeigen und anpassen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d geändert"
+msgstr[1] "%d geändert"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Alle Tastenkombination zurücksetzen?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Zurücksetzen der Tastaturkombinationen kann Ihre persönlichen "
+"Tastaturkombinationen beeinflussen. Kann nicht rückgängig gemacht werden."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Alles zurücksetzen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Alles zurücksetzen …"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Alle Tastenkombinationen auf die Vorgabe zurücksetzen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Abschnitt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Tastenkombinationen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Tastenkombination hinzufügen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Individuelle Tastenkombinationen hinzufügen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Richten Sie eigene Tastenkombinationen zum Starten von Anwendungen, Skripten "
+"und mehr ein."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Tastenkombination hinzufügen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Keine Tastenkombination gefunden"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s wird bereits für %s verwendet. Wenn Sie diese ersetzen, so wird %s "
+"deaktiviert"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Neue Tastenkombination eingeben"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Eigene Tastenkombination festlegen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Tastenkombination festlegen"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Geben Sie die neue Tastenkombination ein, um %s zu ändern."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Individuelle Tastenkombination hinzufügen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Entfernen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Erset_zen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Festlegen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Drücken Sie Esc zum Abbrechen oder die Rücktaste, um die Tastenkombination "
+"zu deaktivieren."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Name"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Befehl"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Tastenkombination"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Tastenkombination festlegen …"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Keine"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Die Tastenkombination auf die Vorgabe zurücksetzen"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatur"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Tastenkombinationen ändern sowie individuelle Tastaturbelegungen, "
+"Tastaturlayouts und Eingabequellen einstellen"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Kürzel;Arbeitsfläche;Fenster;Vergrößern;Verkleinern;Kontrast;Eingabe;Quelle;"
+"Sperren;Lautstärke;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Ortungsdienste sind ausgeschaltet"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Keine Anwendung darf Standortinformationen abrufen."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Ortungsdienste ermöglichen es Anwendungen, Ihren Standort festzustellen. Die "
+"Nutzung von WLAN und mobilem Breitband erhöht die Genauigkeit.\n"
+"\n"
+"Es wird der Mozilla Ortungsdienst verwendet: <a href='https://location."
+"services.mozilla.com/privacy'>Datenschutzrichtlinie</a>\n"
+"\n"
+"Den unten gelisteten Anwendungen erlauben, Ortungsdienste zu verwenden."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Keine Anwendung hat um Standortzugriff gebeten"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Ihre Standortinformationen schützen"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;Ort;Standort;GPS;privat;Datenschutz;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Das Mikrofon ist ausgeschaltet"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Anwendungen können keine Klänge aufnehmen."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Die Verwendung des Mikrofons erlaubt es Anwendungen, Ton aufzunehmen und "
+"abzuhören. Deaktivieren des Mikrofons kann dazu führen, dass einige "
+"Anwendungen nicht wie vorgesehen funktionieren.\n"
+"\n"
+"Den unten gelisteten Anwendungen erlauben, das Mikrofon zu verwenden."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Keine Anwendung hat um Mikrofonzugriff gebeten"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Ihre Unterhaltungen schützen"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"microphone;recording;application;privacy;Mikrofon;Mikrophon;Aufnahme;"
+"Anwendung;Programm;Datenschutz;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Testen Sie Ihre Einstellungen"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Allgemein"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primäre Taste"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Ändert die Anordnung der physischen Tasten von Maus und Tastfeld."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Links"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Rechts"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Maus"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Mausgeschwindigkeit"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Natürlicher Bildlauf"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Der Bildlauf verschiebt den Inhalt, nicht die Ansicht."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Tastfeld"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Tastfeld-Geschwindigkeit"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Antippen zum Klicken"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Antippen zum Klicken"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Bildlauf mit zwei Fingern"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Bildlauf am Rand"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Versuchen Sie zu klicken, doppelzuklicken oder zu rollen"
+
+# Doof. https://www.reddit.com/r/gnome/comments/1cgjh0/dear_gnome_developers_i_think_what_you_did_is/c9gay98
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Fünf Klicks, GEGL-Zeit!"
+
+# CHECK
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Doppelklick, primäre Taste"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Einfacher Klick, primäre Taste"
+
+# CHECK
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Doppelklick, mittlere Taste"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Einfacher Klick, mittlere Taste"
+
+# CHECK
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Doppelklick, sekundäre Taste"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Einfacher Klick, sekundäre Taste"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Maus und Tastfeld"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Die Empfindlichkeit Ihrer Maus oder Ihres Tastfelds ändern und für Rechts- "
+"oder Linkshänder einstellen"
+
+# Ich vermute »tap« meint einen Mausklick in Form einer kurzen Fingerberührung des Touchpad
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Zeiger;Mauszeiger;Klick;Doppelklick;Maustaste;Trackball;Bildlauf;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Funktionale _Ecke"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Die obere linke Ecke berühren, um die Aktivitäten-Übersicht zu öffnen."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Aktive Bildschirmkanten"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Fenster an den oberen, linken und rechten Bildschirmrand ziehen, um dessen "
+"Größe anzupassen."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Arbeitsflächen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dynamische Arbeitsflächen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Entfernt leere Arbeitsflächen automatisch."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Feste Anzahl an Arbeitsflächen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Anzahl an permanenten Arbeitsflächen angeben."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "An_zahl der Arbeitsflächen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Mehrere Bildschirme"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Arbeitsflächen nur auf dem _primären Bildschirm"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Arbeitsflächen auf _allen Bildschirmen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Anwendungen wechseln"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Anwendungen von allen A_rbeitsflächen anzeigen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Anwendungen nur von der a_ktuellen Arbeitsfläche anzeigen"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitasking"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Einstellungen für Produktivität und Multitasking verwalten"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"Produktivität;Bearbeiten;Schreibtisch;Funktionale Ecke;Arbeitsumgebungen;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Hoppla, etwas ist schief gegangen. Bitte kontaktieren Sie Ihren Software-"
+"Hersteller."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager muss laufen."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Weitere Geräte"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Verbindung hinzufügen"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nicht eingerichtet"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Unsicheres Netzwerk (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Sicheres Netzwerk (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Sicheres Netzwerk (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Sicheres Netzwerk (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Netzwerk sichern"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Verbunden"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Optionen …"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Wenn der Hotspot eingeschaltet wird, werden Sie von %s getrennt und können "
+"nicht auf das Internet mittels WLAN zugreifen."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Erfordert mindestens 8 Zeichen"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Darf höchstens %d Zeichen sein"
+msgstr[1] "Darf höchstens %d Zeichen sein"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "WLAN-Hotspot einschalten?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Ein WLAN-Hotspot erlaubt Ihnen, Ihre Internetverbindung mit anderen zu "
+"teilen, indem Sie ein WLAN-Netzwerk einrichten, mit dem sich andere "
+"verbinden können. Dazu benötigen Sie eine Internetverbindung, die nicht auf "
+"WLAN basiert."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Netzwerkname"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Passwort"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Zufallspasswort generieren"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Passwort automatisch generieren"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "Einschal_ten"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "WLAN"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Den HotSpot anhalten und verbundene Benutzer trennen?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "Hot _Spot anhalten"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Flugzeugmodus"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Deaktiviert Funknetzwerke, Bluetooth und mobiles Breitband"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Kein Funknetzwerkadapter gefunden"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+"Stellen Sie sicher, dass Ihr Funknetzwerkadapter angeschlossen und "
+"eingeschaltet ist"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Flugzeugmodus an"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Ausschalten, um WLAN zu nutzen"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "WLAN-Hotspot aktiv"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobilgeräte können zum Verbinden den QR-Code scannen."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "WLAN-Hotspot ausschalten …"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Sichtbare Netzwerke"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager muss laufen"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x-_Sicherheit"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sicherheit"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Beibehalten"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Dauerhaft"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Zufällig"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabil"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Die hier eingegebene MAC-Adresse wird als Hardware-Adresse des "
+"Netzwerkgerätes verwendet, für das diese Verbindung aktiviert ist. Dieses "
+"Funktionsmerkmal ist als »MAC-Cloning« oder »MAC-Spoofing« bekannt. "
+"Beispiel: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Erweitertes Öffnen"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Keine"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nie"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "Vor %i Tag"
+msgstr[1] "Vor %i Tagen"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mbit/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mbit/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+# Signal Strength: Keine statt Keines? - jb+
+# Hier eher in der kürzeren Variante "Wieviel Signal" - ts
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Keines"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Schwach"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "OK"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Gut"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Ausgezeichnet"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4-Adresse"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-Adresse"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-Adresse"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Verbindung entfernen"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Verbindungsprofil entfernen"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "VPN entfernen"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Details"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatisch"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identität"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Adresse entfernen"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Route entfernen"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Keine"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-Bit-Schlüssel (Hex oder ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-Bit-Passphrase"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamisches WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA und WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA und WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signalstärke"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Verbindungsgeschwindigkeit"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hardware-Adresse"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Unterstützte Frequenzen"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Vorgaberoute"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Zuletzt verwendet"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Automatisch _verbinden"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "_Anderen Benutzern zur Verfügung stellen"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Getaktete Verbindung: Mit beschränktem Datenvolumen oder potentiellen Kosten"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Software-Aktualisierungen und andere große Downloads werden nicht "
+"automatisch gestartet."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Name"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC-Adresse"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Duplizierte Adresse"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "Byte"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4-Methode"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatisch (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Nur Link-Local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manuell"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Deaktivieren"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Für anderen Rechner freigegeben"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adressen"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Netzmaske"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatisch"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatisches DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS-Server-Adresse(n)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "IP-Adressen durch Kommata trennen"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Routen"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatische Routen"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Diese Verbindung nur für Ress_ourcen in deren Netzwerk verwenden"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6-Methode"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatisch, nur DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Präfix"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Öffnen des Verbindungseditors schlug fehl"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Neues Profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Ungültige Einstellung %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Ungültige Einstellung %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Aus Datei importieren …"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "VPN hinzufügen"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_Sicherheit"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "VPN-Verbindung kann nicht importiert werden"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Die Datei »%s« konnte nicht gelesen werden oder enthält keine gültige VPN-"
+"Verbindung\n"
+"\n"
+"Fehler: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Wählen Sie die Datei zum Importieren"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Eine Datei namens »%s« ist bereits vorhanden."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "E_rsetzen"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+"Wollen Sie %s mit der VPN-Verbindung ersetzen, die Sie gerade speichern?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "VPN-Verbindung kann nicht exportiert werden"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Die VPN-Verbindung »%s« konnte nicht nach %s exportiert werden\n"
+"\n"
+"Fehler: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "VPN-Verbindung exportieren"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Fehler: VPN-Verbindungseditor kann nicht geladen werden)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Legt fest, wie mit dem Internet verbunden wird"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Netzwerk;LAN;IP;Proxy;WAN;Breitband;DSL;Modem;Bluetooth;VPN;Brücke;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Legt fest, wie mit Funknetzwerken verbunden wird"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Netzwerk;Drahtlos;WLAN;Wifi;IP;LAN;Breitband;Hotspot;DNS;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nie"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "heute"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "gestern"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Zuletzt verwendet"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Kabelgebunden"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Neue Verbindung hinzufügen"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Netzwerkdetails für die gewählten Netzwerke, einschließlich Passwort und "
+"jegliche benutzerdefinierte Konfiguration, werden verloren gehen."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Vergessen"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Bekannte Funknetzwerke"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Vergessen"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Die Systemeinstellungen verbieten die Nutzung als Hotspot"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Das Drahtlos-Gerät unterstützt keinen Hotspot-Modus"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Automatische Internet-Proxy-Erkennung wird verwendet, wenn keine "
+"Einrichtungsadresse angegeben wird."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Dies wird für unsichere öffentliche Netzwerke nicht empfohlen."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Gerät abschalten"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktiv"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Dienstanbieter"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Netzwerk-Proxy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP-Proxy"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS-Proxy"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP-Proxy"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_SOCKS-Rechner"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "Rechner _ignorieren"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP-Proxy-Port"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS-Proxy-Port"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP-Proxy-Port"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "SOCKS-Proxy-Port"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Einrichtungsadresse"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN-Verbindung abschalten"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Netzwerkname"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Verschlüsselungsart"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Passwort"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "WLAN abschalten"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Weitere Optionen …"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "Mit verborgenem Funknetzwerk _verbinden …"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "WLAN-Ho_tspot einschalten …"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Be_kannte Funknetzwerke"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Status unbekannt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Nicht verwaltet"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Nicht verfügbar"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Verbindung wird hergestellt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Legitimierung erforderlich"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Verbindung wird getrennt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Verbindung fehlgeschlagen"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Status unbekannt (fehlt)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Einrichtung ist fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP-Einrichtung ist fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP-Einrichtung ist abgelaufen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Geheimdaten waren erforderlich, wurden aber nicht angegeben"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x-Supplicant getrennt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Einrichten des 802.1x-Supplicant fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x-Supplicant fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x-Supplicant brauchte zu lange für die Legitimierung"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP-Dienst konnte nicht gestartet werden"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP-Dienst getrennt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP-Client konnte nicht gestartet werden"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP-Client-Fehler"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP-Client fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr ""
+"Dienst für gemeinsam verwendete Verbindung konnte nicht gestartet werden"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Dienst für gemeinsam verwendete Verbindung fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Start des AutoIP-Diensts fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Fehler des AutoIP-Diensts"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP-Dienst fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Die Leitung ist belegt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Kein Freizeichen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Es konnte kein Trägersignal aufgebaut werden"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Der Einwahlvorgang benötigte zu viel Zeit"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Der Einwahlversuch ist fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Modem-Initialisierung fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Angegebener APN konnte nicht ausgewählt werden"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Es wird nicht nach Netzwerken gesucht"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Netzwerkanmeldung abgelehnt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Netzwerkanmeldung benötigte zu viel Zeit"
+
+# s. o. - jb
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Anmeldung an dem angeforderten Netzwerk fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN-Überprüfung fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Notwendige Firmware des Geräts fehlt möglicherweise"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Unzuverlässige Verbindung"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Es wurde von einer bestehenden Verbindung ausgegangen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem nicht gefunden"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth-Verbindung fehlgeschlagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM-Karte ist nicht eingesetzt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM-Pin ist erforderlich"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM-Puk ist erforderlich"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM falsch"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Eine Abhängigkeit der Verbindung ist gescheitert"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Firmware fehlt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabel nicht angeschlossen"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "Nicht definierter Fehler in 802.1X-Sicherheit (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "keine Datei ausgewählt"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "Nicht spezifizierter Fehler beim Überprüfen der eap-method-Datei"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Geheimer DER, PEM, PKCS#12 oder PGP-Schlüssel"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER- oder PEM-Zertifikate"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "PAC-Datei für EAP-FAST fehlt"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC-Dateien (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonym"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Legitimiert"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Beide"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_Anonyme Identität"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC-_Datei"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Wählen Sie eine PAC-Datei"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Innere Legitimierung"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Automatische PAC-_Bereitstellung erlauben"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "Benutzername für EAP-LEAP fehlt"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "Passwort für EAP-LEAP fehlt"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Benutzername"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Passwort"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Pass_wort zeigen"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "Ungültiges CA-Zertifikat für EAP-PEAP: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "Ungültiges CA-Zertifikat für EAP-PEAP: kein Zertifikat angegeben"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "_CA-Zertifikat"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Wählen Sie ein Zertifikat einer Zertifizierungsstelle"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "CA-Zertifikat ist nicht e_rforderlich"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP-_Version"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "EAP-Benutzername fehlt"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "EAP-Passwort fehlt"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "EAP-TLS-Identität fehlt"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "Ungültiges CA-Zertifikat für EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "Ungültiges CA-Zertifikat für EAP-TLS: kein Zertifikat angegeben"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "Ungültiger geheimer Schlüssel für EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "Ungültiges Benutzerzertifikat für EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Unverschlüsselte geheime Schlüssel sind unsicher"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Der gewählte Schlüssel scheint nicht durch ein Passwort geschützt zu sein. "
+"Dies gefährdet Ihre Sicherheitsinformationen. Bitte wählen Sie einen durch "
+"ein Passwort geschützten geheimen Schlüssel.\n"
+"\n"
+"(Sie können Ihren Schlüssel mit openssl mit einem Passwort schützen)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Wählen Sie Ihr persönliches Zertifikat"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Wählen Sie Ihren geheimen Schlüssel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Identität"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Benutzerzertifikat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Geheimer _Schlüssel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Passwort für geheimen Schlüssel"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "Ungültiges CA-Zertifikat für EAP-TTLS: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "Ungültiges CA-Zertifikat für EAP-TTLS: kein Zertifikat angegeben"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (kein EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domäne"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Unbekannter Fehler beim Überprüfen der 802.1X-Sicherheit"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Getunneltes TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Geschütztes EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Legitimierung"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Eine Datei wählen"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "Leap-Benutzername fehlt"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "Leap-Passwort fehlt"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "WLAN-Passwort fehlt."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Typ"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "WEP-Schlüssel fehlt"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"Ungültiger WEP-Schlüssel: ein Schlüssel mit der Länge %zu darf nur "
+"Hexadezimalzahlen enthalten"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"Ungültiger WEP-Schlüssel: ein Schlüssel mit der Länge %zu darf nur ASCII-"
+"Zeichen enthalten"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"Ungültiger WEP-Schlüssel: falsche Schlüssellänge %zu. Ein Schlüssel muss "
+"entweder dem Schema 5/13 (ASCII) oder 10/26 (hexadezimal) entsprechen"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "Ungültiger WEP-Schlüssel: Kennwort darf nicht leer sein"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "Ungültiger WEP-Schlüssel: Kennwort muss kürzer als 64 Zeichen sein"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Vorgabe)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Offenes System"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Gemeinsamer Schlüssel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Schlüssel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Schlüssel _zeigen"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP-Inde_x"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"Schlüssellänge %zu für WPA-PSK ist ungültig, muss [8,63] Bytes oder 64 "
+"hexadezimale Stellen haben"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"WPA-PSK-Schlüssel kann nicht als 64 Byte hexadezimal ausgewertet werden"
+
+# Mit weichen Trennzeichen, die die Stelle einen Textumbruch vorschlagen
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Be_nachrichtigungen"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Kl_anghinweise"
+
+# Mit weichen Trennzeichen, die die Stelle einen Textumbruch vorschlagen
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Be_nachrichtigungsbanner"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Benachrichtigungen werden weiterhin in der Benachrichtigungsliste angezeigt, "
+"auch wenn Einblendungen deaktiviert sind."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Benachrichtigungs_details auf Bannern zeigen"
+
+# Mit weichen Trennzeichen, die die Stelle einen Textumbruch vorschlagen
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Benachrichtigungen auf dem Sperrbi_ldschirm"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Benachrichtigungsdetails auf dem _Sperrbildschirm zeigen"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Nicht stören"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Benachrichtigungen auf dem Sperrbi_ldschirm"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Legt fest, wie Nachrichten angezeigt werden und was diese anzeigen"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Benachrichtigungen;Banner;Nachricht;Popup;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Weitere"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s entfernt"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Fehler beim Entfernen des Kontos"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Rückgängig"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Die Benachrichtigung schließen"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Verbinden mit Ihren Daten in der Cloud"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Keine Internetverbindung – verbinden Sie sich, um neue Online-Konten "
+"einzurichten"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Ein Konto hinzufügen"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s-Konto"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Konto entfernen"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Online-Konten"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Verbinden Sie sich mit Ihren Online-Konten und entscheiden Sie, wofür diese "
+"genutzt werden"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Internet;Online;Chat;Kalendar;Mail;E-Mail;"
+"Kontakte;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Unbekannte Zeit"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i Minute"
+msgstr[1] "%i Minuten"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i Stunde"
+msgstr[1] "%i Stunden"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%d %s und %d %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "Stunde"
+msgstr[1] "Stunden"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "Minute"
+msgstr[1] "Minuten"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s bis vollständig geladen"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Vorsicht: %s verbleiben"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s verbleiben"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Vollständig geladen"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Lädt nicht"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Leer"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Lädt"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Wird entladen"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Drahtlose Maus"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Drahtlose Tastatur"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Unterbrechungsfreie Stromversorgung"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Persönlicher digitaler Assistent"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobiltelefon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Medienwiedergabegerät"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Grafiktablett"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Rechner"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Spiel-Eingabegerät"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akku"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Netz"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Extra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Akku"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Wenn _inaktiv"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Bereitschaft"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Ausschalten"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Ruhezustand"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nichts"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Wenn im Akkubetrieb"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Wenn angeschlossen"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nie"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatisch in Bereitschaft gehen"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Leistungsmodus aufgrund hoher Betriebstemperaturen vorübergehend nicht "
+"verfügbar."
+
+# Klingt komisch, ist aber so :) https://gitlab.freedesktop.org/hadess/power-profiles-daemon/-/blob/main/src/net.hadess.PowerProfiles.xml
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Schoß erkannt: Der Leistungsmodus ist vorübergehend nicht verfügbar. Bringen "
+"Sie das Gerät auf eine stabile Oberfläche, um in den Leistungsmodus wechseln "
+"zu können."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Leistungsmodus vorübergehend deaktiviert."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Niedriger Akkustand: Energiesparen aktiviert. Der vorherige Modus wird "
+"wieder verwendet, wenn der Akku ausreichend geladen ist."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Energiesparmodus durch »%s« aktiviert."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Leistungsmodus durch »%s« aktiviert."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 Minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 Minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 Minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 Minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 Minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 Stunde"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 Minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 Minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 Minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 Stunden"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Energie-Modus"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Beeinflusst Leistungsfähigkeit des Systems und Energieverbrauch."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Energiespareinstellungen"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatische Bildschirmhelligkeit"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Bildschirmhelligkeit passt sich dem Umgebungslicht an."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Bildschirm abdunkeln"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Bildschirmhelligkeit bei Inaktivität reduzieren."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Bildschirm aus_schalten"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Bildschirm bei Inaktivität ausschalten."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatisch Energie sparen"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Energiesparprofil bei niedrigem Akkustand aktivieren."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatisch in Bereitschaft gehen"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Rechner bei Inaktivität in Bereitschaft versetzen."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Auswirkung des _Einschaltknopfs"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "_Prozentsatz der Akkuladung anzeigen"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatisch in Bereitschaft gehen"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Wenn _angeschlossen"
+
+# Ich würde das »Wenn« weglassen.  - jb
+# Es geht darum, unter welchen Bedingungen in Suspend-Modus gegangen werden soll, insofern passt das "Wenn" gut - ts 
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Wenn im _Akkubetrieb"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Verzögerung"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Leistung"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Hohe Leistung und erhöhter Energieverbrauch."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Ausgeglichen"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Normale Leistung und normaler Energieverbrauch."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Energie sparen"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Reduzierte Leistung und niedriger Energieverbrauch."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energie"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Den Status Ihres Akkus anzeigen und die Energiespareinstellungen ändern"
+
+# Ich glaube hier können (beliebig viele) Schlagworte frei gewählt werden
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Energie;Schlafmodus;Bereitschaft;Ruhezustand;Akku;Helligkeit;Abdunkeln;"
+"Abschalten;Bildschirm;DPMS;Energie;Einschaltknopf;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Drucker »%s« wurde gelöscht"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Neuer Drucker konnte nicht hinzugefügt werden."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Die Benutzeroberfläche konnte nicht geladen werden: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Entsperren, um Drucker hinzuzufügen und Einstellungen zu ändern"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Drucker"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Drucker hinzufügen, Druckeraufgaben anzeigen und entscheiden, wie Sie "
+"drucken möchten"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Drucker;Warteschlange;Drucken;Papier;Tinte;Toner;Tintenpatrone;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Drucker hinzufügen"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Entsperren"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Keine Drucker gefunden"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+"Geben Sie entweder eine Netzwerk-Adresse oder den Suchbegriff eines Druckers "
+"ein"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Legitimierung erforderlich"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Geben Sie Ihren Benutzernamen und Ihr Passwort ein, um die verfügbaren "
+"Drucker auf dem Druckserver anzuzeigen."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Benutzername"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Details zu %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Kein passender Treiber gefunden"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Wählen Sie die PPD-Datei"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript-Druckerbeschreibungsdateien (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Druckernamen dürfen kein LEERZEICHEN, TABULATOR, # oder / enthalten"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Ort"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Treiber"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Suchen nach bevorzugten Treibern …"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Nach Treibern suchen"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Aus der Datenbank wählen …"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "PPD-Datei installieren …"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Wählen Sie den Druckertreiber"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Treiber-Datenbank wird geladen …"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Auswählen"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect-Drucker"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD-Drucker"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Einseitig"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Langer Rand (Vorgabe)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Kurzer Rand (Umdrehen)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Hochformat"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Querformat"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Kopfstehendes Querformat"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Kopfstehendes Hochformat"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Fortsetzen"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Anhalten"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Ausstehend"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pausiert"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Legitimierung erforderlich"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Verarbeitung läuft"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Angehalten"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Abgebrochen"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Abgebrochen"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Abgeschlossen"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Diesen Auftrag an die Spitze der Warteschlange stellen"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u Auftrag erfordert Legitimierung"
+msgstr[1] "%u Aufträge erfordern Legitimierung"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Aktive Druckaufträge"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Geben Sie Ihre Anmeldedaten ein, um auf %s drucken zu können."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domäne"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Legitimieren"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Alles leeren"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "Le_gitimieren"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Keine aktiven Druckaufträge"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Druckserver entsperren"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s entsperren."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Geben Sie Ihren Benutzernamen und Ihr Passwort ein, um die verfügbaren "
+"Drucker auf %s anzuzeigen."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Es wird nach Druckern gesucht"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Serielle Schnittstelle"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Parallele Schnittstelle"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Ort: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adresse: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Server erfordert Legitimierung"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Beidseitig"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Papierart"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Papiereinzug"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Ausgabeschacht"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Auflösung"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript-Vorfilterung"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Seiten pro Blatt"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Zweiseitig"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Ausrichtung"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Allgemein"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Seiteneinrichtung"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Installierbare Optionen"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Auftrag"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Bildqualität"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Farbe"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Abschließen"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Erweitert"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Testseite"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Testseite"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Automatische Auswahl"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Drucker-Voreinstellung"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Nur GhostScript-Schriften einbinden"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "In PS Level 1 umwandeln"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "In PS Level 2 umwandeln"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Keine Vorfilterung"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Hersteller"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Keine aktiven Druckaufträge"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u Auftrag"
+msgstr[1] "%u Aufträge"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Druckköpfe reinigen"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Wenig Toner"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Toner leer"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Wenig Entwickler"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Entwickler leer"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Einer der Farbspeicher fast leer"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Eine Farbpatrone leer"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Abdeckung offen"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Klappe offen"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Wenig Papier"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Papier leer"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Abgemeldet"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Angehalten"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Der Abfallbehälter ist fast voll"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Der Abfallbehälter ist voll"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Der optische Bildübertrager ist beinahe verbraucht"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Der optische Bildübertrager funktioniert nicht mehr"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Bereit"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Es werden keine Aufträge angenommen"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Verarbeitung läuft"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Druckoptionen"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Drucker-Details"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Drucker als Vorgabedrucker verwenden"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Druckköpfe reinigen"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Drucker entfernen"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modell"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Tintenfüllstand"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Bitte starten Sie neu, sobald das Problem gelöst ist."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Neustart"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Drucker hinzufügen …"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Keine Drucker"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Es scheint, dass der Systemdruckdienst\n"
+"    nicht verfügbar ist."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formate"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Standorteinstellungen durchsuchen …"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Bekannte Formate"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Alle Formate"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Keine Suchergebnisse"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Es kann nach Ländern oder Sprachen gesucht werden."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Vorschau"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrisch"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Daten"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Datum und Zeit"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Zahlen"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Maßeinheiten"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papier"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Sprache und Format ändern sich mit der nächsten Anmeldung"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Abmelden …"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Die Spracheinstellung wird für den Text auf Oberflächen und Webseiten "
+"verwendet. Das Format wird für Zahlen, Datumsangaben und Währungen verwendet."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Ihr Konto"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Sprache"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formate"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Anmeldebildschirm"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Region und Sprache"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Wählen Sie Ihre Sprache und Formate"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Sprache;Belegung;Tastatur;Eingabe;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Nachfragen, was geschehen soll"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Nichts tun"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Ordner öffnen"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Andere Medien"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Eine Anwendung für Audio-CDs wählen"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Eine Anwendung für Video-DVDs wählen"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Wählen Sie eine Anwendung, wenn ein Musikabspielgerät angeschlossen wird"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Wählen Sie eine Anwendung, wenn eine Kamera angeschlossen wird"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Eine Anwendung für Software-CDs wählen"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "Audio-DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Leere Blu-ray-Disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "Leere CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "Leere DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "Leere HD-DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray-Video-Disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "E-Book-Reader"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD-DVD-Video-Disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Foto-CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super-Video-CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video-CD"
+
+# Software von MS Windows
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows-Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Wählen Sie, wie mit Medien umgegangen werden soll"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD-_Audio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD-Video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Musikwiedergabe"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Andere Medien …"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "Beim _Einlegen von Datenträgern nie nachfragen oder Programme starten"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Wählen Sie, wie mit anderen Medien umgegangen werden soll"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Aktion:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Typ:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Wechselmedien"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Wechselmedien einrichten"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"Gerät;System;Information;Speicher;Prozessor;Version;Vorgabe;Anwendung;Ersatz;"
+"bevorzugt;CD;DVD;USB;Audio;Video;Medien;Wechsel;Medien;Autostart;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Bildschirm schaltet ab"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 Sekunden"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 Minute"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 Minuten"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 Minuten"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 Minuten"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 Minuten"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 Stunde"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 Minute"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 Minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 Minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 Minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 Minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 Minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 Minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 Minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 Minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nie"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Bildschirmsperre"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Die automatische Bildschirmsperre schützt Ihren Rechner vor dem Zugriff "
+"anderer, während Sie abwesend sind."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Verzögerung bis Bildschirmabschaltung"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Dauer an Inaktivität, bis der Bildschirm abgeschaltet wird."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatische _Bildschirmsperre"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Verzögerung bis zur automatischen Bildschirm_sperre"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Dauer an Inaktivität, bis der abgeschaltete Bildschirm automatisch gesperrt "
+"wird."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Benachrichtigungen auf Sperrbildschirm anzeigen"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Neue _USB-Geräte untersagen"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Verhindern, dass neue USB-Geräte das System beeinflussen, während der "
+"Bildschirm gesperrt ist."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Bildschirm-Datenschutz"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Den Ansichtswinkel einschränken"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Bildschirm-Einstellungen"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+"screen;lock;private;privacy;Bildschirm;gesperrt;sperren;privat;Datenschutz;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Ort wählen"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Orte durchsuchen"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Ordner, die von Systemanwendungen durchsucht werden, zum Beispiel Dateien, "
+"Fotos und Videos."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Orte"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Lesezeichen"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Weitere"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Ort hinzufügen"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Keine Anwendungen gefunden"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Anwendungssuche"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Suchergebnisse anzeigen, die von Anwendungen bereitgestellt werden."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Ordner, die von Systemanwendungen durchsucht werden."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Suchergebnisse"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Ergebnisse werden gemäß der Listenreihenfolge angezeigt."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Legen Sie fest, welche Anwendungen Suchergebnisse in der "
+"Aktivitätenübersicht anzeigen"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Suchen;Finden;Index;Verbergen;Privatsphäre;Ergebnisse;Datenschutz;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Es sind keine Netzwerke zur Freigabe gewählt"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Netzwerke"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "An"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Aus"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktiv"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Wählen Sie einen Ordner"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Medienfreigabe einschalten"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Persönliche Dateifreigabe ermöglicht es Ihnen, Ihren öffentlichen Ordner für "
+"andere in Ihrem Netzwerk freizugeben mit: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Wenn Fernanmeldung aktiviert ist, entfernten Benutzern eine Verbindung mit "
+"folgendem Secure-Shell-Befehl erlauben:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Persönliche Medienfreigabe einschalten"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Gerätename wurde kopiert"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Geräteadresse wurde kopiert"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Benutzername wurde kopiert"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Passwort wurde kopiert"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Freigabe"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Re_chnername"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Dateifreigabe"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_Bildschirmfreigabe"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Medienfreigabe"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Fernanmeldung"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Dateifreigabe"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Passwo_rt verlangen"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Fernanmeldung"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Bildschirmfreigabe"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"»Entfernter Schreibtisch« ermöglicht es Ihnen, Ihren Rechner von einem "
+"anderen Computer aus zu betrachten und zu steuern."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Entfernten Bildschirm ein- oder ausschalten."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Fernsteuerung"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Eingehenden Verbindungen das Steuern des Bildschirms erlauben."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "So verbinden Sie sich"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Verbinden Sie sich mit diesem Rechner mithilfe des Rechnernamens oder der "
+"Adresse des entfernten Schreibtischs."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopieren"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Adresse des entfernten Bildschirms"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Legitimierung"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Um sich mit diesem Rechner zu verbinden, sind Benutzername und Passwort "
+"erforderlich."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Benutzername"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Verschlüsselung überprüfen"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Fingerabdruck der Verschlüsselung"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Der Verschlüsselungs-Fingerabdruck kann auf sich verbindenden Clients "
+"angesehen werden und sollte identisch sein."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Medienfreigabe"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Musik, Fotos und Videos über das Netzwerk freigeben."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Ordner"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Legen Sie fest, was Sie für Andere freigeben möchten"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"Freigabe;ssh;Rechner;Name;Entfernt;Arbeitsumgebung;Umgebung;Medien;Audio;"
+"Video;Bilder;Fotos;Filme;Server;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Fernanmeldung ein- oder ausschalten"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Legitimierung ist erforderlich, um die Fernanmeldung zu aktivieren oder zu "
+"deaktivieren"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klick"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Saite"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Schwingen"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Summen"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balance"
+
+# Evtl »Übergang«?
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Ein-/Ausblenden"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Hinten"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Vorne"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s wird geprüft"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Klicken Sie zum Testen auf einen Lautsprecher"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Systemlautstärke"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Hauptlautstärke"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Lautstärkestufen"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Ausgabe"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Ausgabegerät"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Test"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Einrichtung"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Eingang"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Eingabegerät"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Lautstärke"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Warnton"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Stumm schalten"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Audio"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Lautstärke, Ein- und Ausgabequellen und Alarmtöne einstellen"
+
+# Ich glaube hier können (beliebig viele) Schlagworte frei gewählt werden
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Karte;Mikrofon;Lautstärkeregler;Lautstärke;Ausblenden;Balance;Bluetooth;"
+"Headset;Audio;Eingang;Ausgang;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Getrennt"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Verbindungsaufbau"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Verbunden"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Legitimierungsfehler"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Legitimierung"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Eingeschränkte Funktionalität"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Verbunden und legitimiert"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Unbekannt"
+
+# Zeitpunkt, nicht Datum.
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Legitimiert um:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Verbunden um:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Angemeldet um:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Gerät konnte nicht legitimiert werden: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Gerät konnte nicht vergessen werden: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Hängt von %u anderem Gerät ab"
+msgstr[1] "Hängt von %u anderen Geräten ab"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Die Benachrichtigung schließen"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Name:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Status:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Legitimieren und verbinden"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Gerät vergessen"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Fehler"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Legitimiert"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Das Thunderbolt-Subsystem (boltd) ist nicht installiert oder wurde nicht "
+"korrekt eingerichtet."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Den direkten Zugriff auf Geräte wie Docks oder externe Grafikkarten erlauben."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Es können nur USB- und Displayport-Geräte angeschlossen werden."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt konnte nicht erkannt werden.\n"
+"Entweder unterstützt das System Thunderbolt nicht, oder es wurde im BIOS "
+"deaktiviert oder wurde im BIOS auf eine nicht unterstützte Sicherheitsstufe "
+"gesetzt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Die Unterstützung für Thunderbolt wurde im BIOS deaktiviert."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Die Sicherheitsstufe von Thunderbolt konnte nicht ermittelt werden."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Fehler beim Wechsel in den Direktmodus: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Keine Thunderbolt-Unterstützung"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+"Es konnte keine Verbindung zum Thunderbolt-Untersystem hergestellt werden."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Direktzugriff"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Ausstehende Geräte"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Keine Geräte angeschlossen"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Thunderbolt-Geräte verwalten"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;Privatsphäre;Datenschutz;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Blinkende Eingabemarke"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Blinkende Eingabemarke in Textfeldern."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Geschwindigkeit"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Blinkgeschwindigkeit der Eingabemarke"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Mauszeiger-Größe"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Die Größe des Mauszeigers kann mit einer Vergrößerung kombiniert werden, "
+"damit der Mauszeiger leichter auffindbar ist."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Klickassistent"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulierter Kontextklick"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Kontextklick durch Gedrückthalten der primären Maustaste auslösen"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Verzögerung vor _Annahme:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kurz"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Verzögerung für Kontextklick"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lang"
+
+# CHECK
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Sch_webe-Klick"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Klick ausführen, wenn sich der Mauszeiger nicht mehr bewegt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Verzögerung:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kurz"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Schwellenwert der Bewegung:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Klein"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Groß"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Tastenwiederholung"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Tasten wiederholt auslösen, wenn sie gedrückt gehalten werden."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Verzögerung der Tastenwiederholung"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Geschwindigkeit der Tastenwiederholung"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Tippassistent"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Klebrige Tasten"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Erkennt eine Abfolge von Zusatztasten als Tastenkombination"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Deaktivieren, wenn zwei Tasten gleichzeitig gedrückt werden"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Signalton ausgeben, wenn eine _Zusatztaste gedrückt wird"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Tastenver_zögerung"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Setzt eine Verzögerung zwischen dem Drücken und Akzeptieren einer Taste"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kurz"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Wert für Tastenverzögerung"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Signalton ausgeben, wenn eine Zusatztaste ge_drückt wird"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Signalton ausgeben, wenn eine Taste _angenommen wird"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Signalton ausgeben, wenn eine Taste abgewiesen wi_rd"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Springende Tasten"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignoriert schnelle doppelte Tastenanschläge"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kurz"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Verzögerung für springende Tasten"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Per _Tastatur aktivieren"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Barrierefreiheits-Funktionen mit der Tastatur ein- bzw. ausschalten"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Vorgabe"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Medium"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Groß"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Größer"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Am größten"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d Pixel"
+msgstr[1] "%d Pixel"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Immer das Menü zur Barrierefreiheit anzeigen"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Sehen"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Hoher Kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Große Schrift"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "_Animationen aktivieren"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Bildschirmle_ser"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Der Bildschirmleser liest den angezeigten Text, wenn Sie den Fokus "
+"verschieben."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "L_autstärkeregelung"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Beim Einschalten des Ziffernblocks oder der Feststelltaste einen Signalton "
+"ausgeben."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Ma_uszeiger-Größe"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "Ver_größerung"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Gehör"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Visuelle Alarme"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Bildschirm_tastatur"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Tast_enwiederholung"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Blinkende Eingabemarke"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Tippassistent (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Zeigen und Klicken"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Tastatur_maus"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Maus_zeiger finden"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Klickassistent"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Doppelklick-Verzögerung"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Doppelklick-Verzögerung"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Visuelle Alarme"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Blinken _testen"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Eine visuelle Anzeige auslösen, wenn ein Warnklang abgespielt wird."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Ganzen _Bildschirm blinken lassen"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Ganzes _Fenster blinken lassen"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kurz"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ Bildschirm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ Bildschirm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ Bildschirm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Vollbild"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Obere Hälfte"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Untere Hälfte"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Linke Hälfte"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Rechte Hälfte"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Vergrößerungsoptionen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Vergrößerung:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Position der Lupe:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "Dem Mauszeiger _folgen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Bild_schirmteil:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Vergröß_erter Bereich wird außerhalb des Bildschirms verschoben"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Vergrößerten Maus_zeiger mittig halten"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Mauszeiger der Lupe _verschiebt den Inhalt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Mauszeiger der Lupe bewegt sich _mit dem Inhalt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lupe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Faden_kreuz:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Mauszeiger wird über_lappt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Dicke:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Dünn"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Dick"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Länge:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Farbe:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Fadenkreuz"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Farbeffekte:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Weiß auf schwarz:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Helligkeit:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Farbe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Keine"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Voll"
+
+# Mausempfindlichkeit
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Minimum"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Hoch"
+
+# Mausempfindlichkeit
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Niedrig"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Hoch"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Farbeffekte"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Sehen, Hören, Tippen, Zeigen und Klicken erleichtern"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Tastatur;Maus;Cursor;a11y;Barrierefreiheit;Kontrast;Klänge;Ton;Audio;Zoom;"
+"Vergrößern;Bildschirm;Bildschirmleser;Text;Schrift;Größe;AccessX;Klebrige "
+"Tasten;Tasten;Langsam;Springende Tasten;Tastaturmaus;Klick;Verzögerung;"
+"Assistent;Wiederholen;Blinken;Visuell;Tippen;Hören;Audio;Eingabe;Animationen;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 Stunde"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 Tag"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 Tage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 Tage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 Tage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 Tage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 Tage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 Tage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 Tage"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 Tage"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Alle Objekte aus dem Papierkorb löschen?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Alle Objekte im Papierkorb werden dauerhaft gelöscht."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Papierkorb _leeren"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Alle temporären Dateien löschen?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Alle temporären Dateien werden dauerhaft gelöscht."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Temporäre Dateien _löschen"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 Tag"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 Tage"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 Tage"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Für immer"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Dateichronik"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Die Dateichronik merkt sich, welche Dateien Sie verwendet haben. Diese "
+"Information wird zwischen Anwendungen geteilt und erleichtert das Finden von "
+"Dateien, die Sie verwenden möchten."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Dateichronik"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Zeitraum der Dateic_hronik"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Chronik _löschen …"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Papierkorb und temporäre Dateien"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Der Papierkorb sowie temporäre Dateien können persönliche und sensible "
+"Informationen enthalten. Eine automatische Löschung kann dem Erhalt Ihrer "
+"Privatsphäre dienen."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Automatisch den Papierkorb _leeren"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automatisch temporäre _Dateien löschen"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Zeit_raum für automatisches Löschen"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Papierkorb _leeren …"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Temporäre Dateien _löschen …"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Dateichronik und Papierkorb"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Keine Spuren hinterlassen"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"Verwendung;zuletzt;kürzlich;Verlauf;Dateien;temporär;privat;Datenschutz;"
+"Papierkorb;bereinigen;behalten;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Sollte der Internetadresse Ihres Benutzerkontoanbieters entsprechen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Anlegen des Kontos fehlgeschlagen"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Die Passwörter stimmen nicht überein."
+
+# s.o. - jb
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Anlegen des Kontos schlug fehl"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+"Es gibt keine unterstützte Möglichkeit für eine Legitimierung mit dieser "
+"Domäne"
+
+# Manchmal wird das »failed« am Satzende mit »schlug fehl« übersetzt, manchmal mit »fehlgeschlagen«. Sollen wir das angleichen? - jb
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Beitreten zur Domäne schlug fehl"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ungültiger Benutzer.\n"
+"Bitte versuchen Sie es erneut."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ungültiges Passwort.\n"
+"Bitte versuchen Sie es erneut."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Anmelden an der Domäne schlug fehl"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr ""
+"Domäne konnte nicht gefunden werden. Haben Sie sich eventuell vertippt?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Benutzerkonto hinzufügen"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Systemverwalter"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Systemverwalter können Benutzer hinzufügen und entfernen, sowie "
+"Einstellungen für alle Benutzer ändern. Die Kindersicherung greift nicht für "
+"Systemverwalter."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Benutzer legt das Passwort bei der ersten Anmeldung fest"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Jetzt Passwort festlegen"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Anmeldung in Unternehmensumgebung"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+"Benutzerkonten, die von einem Unternehmen oder einer Organisation verwaltet "
+"werden."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Sie sind offline"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Unternehmens-Anmeldung erlaubt es, ein zentral verwaltetes Benutzerkonto auf "
+"diesem Gerät zu verwenden. Außerdem können Sie dieses Konto nutzen, um über "
+"das Internet auf Unternehmensressourcen zuzugreifen."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Nach weiteren Bildern suchen"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Eine Datei wählen …"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Verwaltung der Fingerabdrücke"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Fingerabdruck"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Nein"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Ja"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Wollen Sie Ihre registrierten Fingerabdrücke löschen und so eine Anmeldung "
+"per Fingerabdruck verhindern?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Kein Fingerabdruckgerät"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Kein Fingerabdruckgerät"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Stellen Sie sicher, dass das Gerät richtig angeschlossen ist."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Fingerabdruckgerät"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Wählen Sie das Fingerabdruckgerät, das Sie einrichten möchten"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Anmeldung mit Fingerabdruck"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Eine Fingerabdruck-Anmeldung ermöglicht es Ihnen, sich mit Ihrem Finger am "
+"Rechner anzumelden"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "Fingerabdrücke _löschen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Registrierung eines Fingerabdrucks"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "Das Gerät muss beansprucht werden, um diese Aktion durchzuführen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "Das Gerät wird bereits von einem anderen Prozess beansprucht"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "Sie haben nicht die erforderlichen Rechte, um diese Aktion auszuführen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "Keine Fingerabdrücke registriert"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Kommunikation mit dem Gerät während der Registrierung fehlgeschlagen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Kommunikation mit dem Fingerabdruck-Scanner fehlgeschlagen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Kommunikation mit dem Fingerabdruck-Dienst fehlgeschlagen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Auflisten der Fingerabdrücke schlug fehl: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Löschen von gespeicherten Fingerabdrücken schlug fehl: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Linker Daumen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Linker Mittelfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Linker Zeigefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Linker Ringfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Linker kleiner Finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Rechter Daumen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Rechter Mittelfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Rechter Zeigefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Rechter Ringfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Rechter kleiner Finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Unbekannter Finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Abgeschlossen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Das Fingerabdruckgerät wurde getrennt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Der Speicher des Fingerabdruckgeräts ist voll"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Die Registrierung eines neuen Fingerabdrucks ist fehlgeschlagen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Starten der Registrierung schlug fehl: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Die Registrierung eines neuen Fingerabdrucks ist fehlgeschlagen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Beenden der Registrierung schlug fehl: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Legen Sie Ihren Finger mehrmals auf den Leser, um Ihren Fingerabdruck zu "
+"registrieren"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Diesen Finger _erneut registrieren …"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Neuen Fingerabdruck einlesen"
+
+# Also das geht so noch nicht. Andere Ideen?
+# --
+# Das Fingerabdruck-Gerät konnte nicht freigegeben werden
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Die Freigabe des Fingerabdruck-Geräts %s schlug fehl: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Probleme beim Ansprechen des Geräts"
+
+# Also das geht so noch nicht. Andere Ideen?
+# --
+# Das Fingerabdruck-Gerät konnte nicht beansprucht werden.
+# (Wobei beanspruchen hier wirklich schwer verständlich ist. Mir fällt aber auch nichts Besseres ein;)
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Die Belegung des Fingerabdruck-Geräts %s schlug fehl: %s"
+
+# Also das geht so noch nicht. Andere Ideen?
+# --
+# Fingerabdruck-Geräte konnten nicht ermittelt werden. // Es konnten keine Fingeradruck-Geräte ermittelt werden. (Vielleicht besser: gefunden? Oder: entdeckt?)
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Ermitteln der Fingerabdruck-Geräte schlug fehl: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Diese Woche"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Letzte Woche"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+# I prefer 07:30 instead of 7:30
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%H:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sitzungsende"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sitzungsbeginn"
+
+# em dash (gibt es auf Deutsch nicht) - jb
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Kontoaktivität"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Zurück"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Weiter"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Bitte wählen Sie ein anderes Passwort."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Bitte geben Sie Ihr aktuelles Passwort erneut ein."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Passwort konnte nicht geändert werden"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Passwort ändern"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Ändern"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Aktuelles Passwort"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Neues Passwort"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Passwort bestätigen"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Benutzern erlauben, bei der nächsten Anmeldung ihr Passwort zu ändern"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Jetzt ein Passwort festlegen"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Diesem Typ von Domäne kann nicht automatisch beigetreten werden"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Es wurde keine solche Domäne oder Realm gefunden"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Anmeldung als %s in der Domäne %s schlug fehl"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Ungültiges Passwort, bitte versuchen Sie es erneut"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Es konnte keine Verbindung mit %s-Domäne hergestellt werden: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Benutzer konnte nicht gelöscht werden"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Entfernt verwalteter Benutzer konnte nicht widerrufen werden"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Sie können Ihr eigenes Konto nicht löschen."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ist immer noch angemeldet"
+
+# Was genau ein inkonsistenter (= unbeständiger)  Zustand in diesem Zusammenhang bedeutet, wird, finde ich, nicht klar. Nicht durch die Übersetzung, wohlgemerkt, sondern durch das Original. Konkret: Was passiert, wenn ich mich eingeloggt als Nutzer lösche?
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Das Löschen von Benutzern, während sie angemeldet sind, kann das System in "
+"einen inkonsistenten Zustand versetzen."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Wollen Sie die Dateien von %s behalten?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Es ist möglich, den persönlichen Ordner, die Mail-Warteschlange und die "
+"temporären Dateien zu behalten, wenn ein Benutzerkonto gelöscht wird."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Dateien löschen"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "Dateien _behalten"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Sind Sie sicher, dass Sie den entfernt verwalteten Benutzer »%s« widerrufen "
+"möchten?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Löschen"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Konto ist deaktiviert"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Bei der nächsten Anmeldung festlegen"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Keine"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Angemeldet"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Kontendienst konnte nicht kontaktiert werden"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Bitte stellen Sie sicher, dass der Kontendienst korrekt installiert und "
+"aktiviert ist."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Diese Leiste musst entsperrt sein, um diese Einstellung zu ändern"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Das gewählte Benutzerkonto löschen"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Um das gewählte Benutzerkonto zu löschen,\n"
+"klicken Sie zuerst auf das Symbol *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Entsperren, um Nutzer hinzuzufügen und Einstellungen zu ändern"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Benutzer"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Abmelden, damit die Änderungen wirksam werden"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Jetzt neustarten"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Schließen"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Avatar bearbeiten"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Vollständiger Name"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Anmeldung mit _Fingerabdruck"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatische Anmeldung"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Kontoaktivität"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Systemverwalter"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Systemverwalter können Benutzer hinzufügen und entfernen, sowie "
+"Einstellungen für alle Benutzer ändern."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Kindersicherung"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Die Kindersicherungs-Anwendung öffnen."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Benutzerkonto löschen …"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Andere Benutzer"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Benutzerkonto hinzufügen …"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Keine Benutzer gefunden"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Entsperren, um ein Benutzerkonto zu erstellen."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Benutzer hinzufügen oder entfernen und das Passwort ändern"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Anmeldung;Name;Fingerprint;Fingerabdruck;Avatar;Benutzerbild;Logo;Face;"
+"Gesicht;Password;Passwort;Kennwort;Passphrase;Parental Controls;"
+"Kindersicherung;Screen Time;Bildschirmzeit;App Restrictions;"
+"Anwendungsbeschränkung;Beschränkungen;Web Restrictions;Usage;Nutzung;Usage "
+"Limit;Nutzungseinschränkung;Kid;Child;Kind;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Anmelden"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Anmeldung Domänenverwalter"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Um eine Unternehmens-Anmeldung nutzen zu können, muss dieser Rechner\n"
+"in der Domäne registriert sein. Bitten Sie Ihren Netzwerkverwalter,\n"
+"das Domänen-Passwort hier einzugeben."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Name des Systemverwalters"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Systemverwalter-Passwort"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Benutzerkonten verwalten"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Legitimierung erforderlich"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Das neue Passwort muss sich vom vorherigen unterscheiden."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Versuchen Sie einige Buchstaben und Ziffern zu ändern."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Versuchen Sie das Passwort noch mehr zu ändern."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Ein Passwort ohne Ihren Benutzernamen wäre stärker."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Versuchen Sie Ihren Namen im Passwort nicht zu verwenden."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Versuchen Sie einige der Wörter im Passwort zu vermeiden."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Versuchen Sie gewöhnliche Wörter zu vermeiden."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Versuchen Sie das Anordnen existierender Wörter zu vermeiden."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Versuchen Sie mehr Ziffern zu verwenden."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Versuchen Sie mehr Großbuchstaben zu verwenden."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Versuchen Sie mehr Kleinbuchstaben zu verwenden."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Versuchen Sie mehr Sonderzeichen (z.B. Satzzeichen) zu verwenden."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Versuchen Sie eine Mischung aus Buchstaben, Ziffern und Satzzeichen."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Versuchen Sie die Wiederholung desselben Zeichens zu vermeiden."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Versuchen Sie Wiederholungen von Zeichen derselben Gruppe zu vermeiden. Sie "
+"sollten Buchstaben, Ziffern und Satzzeichen mischen."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Versuchen Sie Sequenzen wie z.B. »1234« oder »abcd« zu vermeiden."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Passwörter müssen länger sein. Fügen Sie weitere Buchstaben, Ziffern und "
+"Satzzeichen hinzu."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Mischen Sie Großbuchstaben und Kleinbuchstaben und verwenden Sie eine Ziffer "
+"oder zwei."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Durch Hinzufügen von Buchstaben, Ziffern und Satzzeichen wird das Passwort "
+"noch besser."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Legitimierung fehlgeschlagen"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Das neue Passwort ist zu kurz"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Das neue Passwort ist zu einfach"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Die alten und neuen Passwörter sind zu ähnlich"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Das neue Passwort wurde kürzlich bereits verwendet."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Das neue Passwort muss numerische oder Sonderzeichen enthalten"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Das neue und das alte Passwort sind gleich"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+"Ihr Passwort wurde geändert, seitdem Sie sich erstmalig legitimiert haben!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Das neue Passwort enthält nicht genug unterschiedliche Zeichen"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Unbekannter Fehler"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Der Benutzername darf aus Klein- und Großbuchstaben von A bis Z, Ziffern "
+"sowie den Zeichen »-« und »_« bestehen"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Leider ist dieser Benutzername nicht verfügbar. Wählen Sie bitte einen "
+"anderen."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Der Benutzername ist zu lang."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Knöpfe zuweisen"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Knöpfen Funktionen zuweisen"
+
+# extrem gekürzt, wirkt sich auf Fensterbreite aus
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Um eine Tastenkombination zu bearbeiten, wählen Sie die »Tastenkombination "
+"senden«-Aktion und drücken Sie die neue Tastenkombination, oder drücken Sie "
+"die Rücktaste, um sie zu löschen."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "S_chließen"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Bitte berühren Sie die Zielmarkierungen auf dem Bildschirm, um das "
+"Grafiktablett zu kalibrieren."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Falscher Klick wurde erkannt, Neustart …"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Knopf %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Festgelegte Anwendung"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Tasteneingabe senden"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Monitor wechseln"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Bildschirmhilfe zeigen"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Am Laptop-Rahmen befestigtes Grafiktablett"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "An externem Bildschirm befestigtes Grafiktablett"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Externes Grafiktablett"
+
+# Woher kommt das Wort »Bedienung«? - jb
+# Dem Quellcode zufolge geht es hier um ein 'Wacom ExpressKey Remote' Gerät, was ich als Bedienung interpretiere - ts
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Externe Grafiktablett-Bedienung"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Alle Bildschirme"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Grafiktablett-Modus"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Absolute Positionierung für den Stift verwenden"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Linkshändige Ausrichtung"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+"Grafiktablett und Express Keys™ sind für die linkshändige Nutzung gedreht"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Bildschirm zuordnen"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Seitenverhältnis beibehalten"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Nur einen Teil der Grafiktablett-Oberfläche nutzen, um das Bildschirm-"
+"Seitenverhältnis beizubehalten"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibrieren"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Kein Grafiktablett erkannt"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+"Bitte schließen Sie Ihr Wacom-Grafiktablett an oder schalten Sie es ein."
+
+# tip pressure - Spitzendruck
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Druckschwelle der Spitze"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Weich"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Stylus-Kopf-Anpressdruck"
+
+# Gemeint ist vermutlich ein Eingabestift eines Tabletts
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Hart"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Knopf 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Knopf 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Knopf 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Druckschwelle des Radiergummis"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Anpressdruck des Radiergummis"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Klick der mittleren Maustaste"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Klick der rechten Maustaste"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Weiter"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Airbrush-Stylus mit Druck- und Kippsensor sowie integriertem Regler"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Airbrush-Stylus mit Druck-, Kipp- und Drehsensor"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standard-Stylus mit Druck- und Kippsensor"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standard-Stylus mit Drucksensor"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom Grafiktablett"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Knopfzuordnung einstellen und die Empfindlichkeit des Stiftes für "
+"Grafiktabletts einstellen"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablett;Grafiktablett;Wacom;Stylus;Radiergummi;Maus;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Neue Tastenkombination …"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Zugriffspunkte"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Vorgang abgebrochen"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr ""
+"<b>Fehler:</b> Zugriff wurde bei der Änderung der Einstellungen verweigert"
+
+# Scheint eine ganze Reihe an möglichen Fehlern zu geben: https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/e32b67e5c0e75600b4fa5154e137717f82dabf0d/panels/wwan/cc-wwan-errors-private.h#L39
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Fehler:</b> Fehler des Mobilgeräts"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Nicht registriert"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registriert"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Suchen"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Verweigert"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modem-Details"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modem-Status"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Anbieter"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Netzwerktyp"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Netzwerk-Status"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Eigene Nummer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Gerätedetails"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Firmware-Version"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Nur 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Nur 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Nur 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Nur 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (bevorzugt), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (bevorzugt), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (bevorzugt), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (bevorzugt), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (bevorzugt), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (bevorzugt), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (bevorzugt), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (bevorzugt), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (bevorzugt), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (bevorzugt), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (bevorzugt), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (bevorzugt), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (bevorzugt), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (bevorzugt), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (bevorzugt), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (bevorzugt), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "3G, 5G (bevorzugt)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "3G (bevorzugt), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "SIM-Karte entsperren"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Entsperren"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Bitte geben Sie den PIN-Code für die SIM-Karte %d an"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "PIN-Code eingeben, um die SIM-Karte zu entsperren"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Bitte geben Sie den PUK-Code für die SIM-Karte %d an"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "PUK-Code eingeben, um die SIM-Karte zu entsperren"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Falsches Passwort eingegeben. Sie haben %1$u Versuch übrig"
+msgstr[1] "Falsches Passwort eingegeben. Sie haben %1$u Versuche übrig"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Sie haben %u Versuch übrig"
+msgstr[1] "Sie haben %u Versuche übrig"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Falsches Passwort eingegeben."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Der PUK-Code sollte eine Zahl mit 8 Ziffern sein"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Neuen PIN-Code eingeben"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Der PIN-Code sollte eine Zahl mit 4-8 Ziffern sein"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Wird entsperrt …"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Keine SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Setzen Sie eine SIM-Karte ein, um dieses Modem zu nutzen"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM gesperrt"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobile Daten"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Daten über das mobile Netzwerk empfangen"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Daten-Roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Mobile Daten beim Roaming verwenden"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Netzwerk-Modus"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "N_etzwerk"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Erweitert"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Zugriffspunkt-Namen"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM-Sperre"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "SIM mit PIN-Code sperren"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "M_odem-Details"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Telefonfehler"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Keine Verbindung zum Telefon"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Vorgang nicht erlaubt"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Vorgang nicht unterstützt"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM-Karte ist nicht eingesetzt"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIM-PIN ist erforderlich"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIM-PUK ist erforderlich"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM-Fehler"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM beschäftigt"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Falsches Passwort"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM-PIN2 ist erforderlich"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM-PUK2 ist erforderlich"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Nicht gefunden"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Kein Netzwerkdienst"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Netzwerk-Zeitüberschreitung"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS-Dienste nicht erlaubt"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming ist in diesem Gebiet nicht erlaubt"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Unbestimmter GRPS-Fehler"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Kein Fehler"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Aktion abgebrochen"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Zugriff verweigert"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Unbekannter Fehler"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Netzwerk-Modus"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatisch"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Netzwerk auswählen"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Netzwerkanbieter aktualisieren"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Mobiles Netzwerk aktivieren"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Kein WWAN-Adapter gefunden"
+
+# https://de.wikipedia.org/wiki/Wireless_Wide_Area_Network
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+"Stellen Sie sicher, dass Sie ein Weitverkehrsfunk/Mobilfunk-Gerät besitzen"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Weitverkehrs-Funkverbindungen sind im Flugzeugmodus deaktiviert"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Flugzeugmodus _ausschalten"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Datenverbindung"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Für Internet genutzte SIM-Karte"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM-Sperre"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Weiter"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "SIM mit PIN-Code _sperren"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "PIN-Code ändern"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+"Aktuellen PIN-Code eingeben, um die Einstellungen zur SIM-Sperre zu ändern"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobiles Netzwerk"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Telefonie und mobile Datenverbindungen einrichten"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+"cellular;wwan;telephony;sim;mobile;Funknetzwerk;Mobilfunk;Weitverkehrsfunk;"
+"Telefonie;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Dienstprogramme zur Einrichtung der GNOME Arbeitsumgebung"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+"Einstellungen ist die wichtigste Komponente zur Einrichtung Ihres Systems."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Das GNOME-Pojekt"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Versionsnummer anzeigen"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Ausführliche Meldungen aktivieren"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Nach der Zeichenkette suchen"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Mögliche Panel-Namen anzeigen und beenden"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Bildschirm für Anzeige"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[LEISTE] [ARGUMENT …]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Einstellungen-Kategorien"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Datenschutz"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Verfügbare Leisten:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Alle Einstellungen"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Primäres Menü"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Warnung: Entwicklerversion"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Diese Version der Einstellungen sollte nur für Entwicklungszwecke verwendet "
+"werden. Die Verwendung kann zu inkorrektem Verhalten des Systems, "
+"Datenverlust und weiteren unerwarteten Ereignissen führen. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Hilfe"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Allgemein"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Beenden"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Suchen"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panels"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Zurück zur vorigen Ansicht"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Suche abbrechen"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Einstellungen;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Bezeichner des zuletzt geöffneten Einstellungs-Panels"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Bezeichner des zuletzt geöffneten Einstellungs-Panels. Unzulässige Werte "
+"werden ignoriert und das erste Panel in der Liste wird ausgewählt."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Warnung anzeigen, wenn eine Entwicklerversion der Einstellungen ausgeführt "
+"wird"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Legt fest, ob eine Warnung angezeigt wird, wenn eine Entwicklerversion der "
+"Einstellungen ausgeführt wird."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Erstzustand des Fensters"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Ein Tupel, welches die anfängliche Breite und Höhe sowie den "
+"Maximierungszustand des Anwendungsfensters enthält."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u Ausgang"
+msgstr[1] "%u Ausgänge"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u Eingang"
+msgstr[1] "%u Eingänge"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Systemklänge"
+
+#~ msgid "Light"
+#~ msgstr "Hell"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Bildschirmanordnung"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Ihren Bildschirm sperren"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER oder PEM-Zertifikate (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Einen Drucker hinzufügen …"
+
+#~ msgid "Drip"
+#~ msgstr "Tropfen"
+
+#~ msgid "Glass"
+#~ msgstr "Glas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "Bildschirm;Sperre;Diagnose;Absturz;Crash;Privat;temporär;Index;Name;"
+#~ "Netzwerk;Identität;"
+
+#~ msgid "Set"
+#~ msgstr "Festlegen"
+
+# CHECK upto line 505
+#~ msgid "Bark"
+#~ msgstr "Bellen"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Klangeinstellungen in GNOME-Einstellungen"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Maus- und Tastfeldeinstellungen in GNOME-Einstellungen"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Hintergrundeinstellungen in GNOME-Einstellungen"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Tastatureinstellungen in GNOME-Einstellungen"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Entfernten Benutzern Ansicht und Steuerung Ihres Bildschirms mit "
+#~ "folgender Verbindung erlauben: %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Bild_schirmfreigabe"
+
+#~ msgid "_Password:"
+#~ msgstr "_Passwort:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Pa_sswort zeigen"
+
+#~ msgid "Access Options"
+#~ msgstr "Zugriffsoptionen"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Neue Verbindungen müssen zum Zugriff berechtigt werden"
+
+#~ msgid "_Require a password"
+#~ msgstr "Passwo_rt verlangen"
+
+#~ msgid "Web Links"
+#~ msgstr "Weblinks"
+
+#~ msgid "Git Links"
+#~ msgstr "Git-Links"
+
+#~ msgid "%s Links"
+#~ msgstr "%s-Links"
+
+#~ msgid "Unset"
+#~ msgstr "Deaktivieren"
+
+#~ msgid "Links"
+#~ msgstr "Links"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hypertext-Dateien"
+
+#~ msgid "Text Files"
+#~ msgstr "Text-Dateien"
+
+#~ msgid "Image Files"
+#~ msgstr "Grafik-Dateien"
+
+#~ msgid "Font Files"
+#~ msgstr "Schrift-Dateien"
+
+#~ msgid "Archive Files"
+#~ msgstr "Archiv-Dateien"
+
+#~ msgid "Package Files"
+#~ msgstr "Paket-Dateien"
+
+#~ msgid "Audio Files"
+#~ msgstr "Audio-Dateien"
+
+#~ msgid "Video Files"
+#~ msgstr "Video-Dateien"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Berechtigungen und Zugriff"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Daten und Dienste, auf die diese Anwendung Zugriff und Berechtigungen "
+#~ "fordert."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Kann nicht geändert werden"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Individuelle Berechtigungen für Anwendungen können in den <a href="
+#~ "\"privacy\">Privatsphäre</a>-Einstellungen eingesehen werden."
+
+#~ msgid "Integration"
+#~ msgstr "Integration"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Schreibtisch-Hintergrund festlegen"
+
+# »Ziele« ist in diesem Kontext vielleicht etwas zu weit hergeholt, aber mir ist nichts Besseres eingefallen. Es geht halt um sowohl Dateitypen als auch Linktypen, da erschien mir »Ziele« leidlich passend.
+#~ msgid "Default Handlers"
+#~ msgstr "Standardziele"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Dateitypen und Links, die diese Anwendung öffnet."
+
+#~ msgid "Usage"
+#~ msgstr "Verbrauch"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Ressourcen, die diese Anwendung verbraucht."
+
+#~ msgid "Open in Software"
+#~ msgstr "In Software öffnen"
+
+#~ msgid "Activities"
+#~ msgstr "Aktivitäten"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Den nachfolgenden Anwendungen Zugriff auf Ihre Kamera erlauben."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Datei konnte nicht hochgeladen werden: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Das Profil wurde hochgeladen zu:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Notieren Sie diese Adresse."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Starten Sie diesen Rechner mit ihrem normalen Betriebssystem neu."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Geben Sie die Adresse in Ihren Browser ein, um das Profil herunterzuladen "
+#~ "und zu installieren."
+
+#~ msgid "Upload profile"
+#~ msgstr "Profil hochladen"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Erfordert eine Internetverbindung"
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopieren"
+
+#~ msgid "Select _All"
+#~ msgstr "Alle au_swählen"
+
+#~ msgid "Single Display"
+#~ msgstr "Einzelner Bildschirm"
+
+#~ msgid "Join Displays"
+#~ msgstr "Bildschirme verketten"
+
+#~ msgid "Display Mode"
+#~ msgstr "Anzeigemodus"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Ziehen Sie Ihre Bildschirme und positionieren Sie diese entsprechend der "
+#~ "realen Anordnung. Wählen Sie einen Bildschirm aus, um dessen "
+#~ "Einstellungen zu ändern."
+
+#~ msgid "Active Display"
+#~ msgstr "Aktiver Bildschirm"
+
+#~ msgid "More Warm"
+#~ msgstr "Wärmer"
+
+#~ msgid "Less Warm"
+#~ msgstr "Kühler"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Ein Bildschirmfoto in $PICTURES speichern"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Ein Bildschirmfoto eines Fensters in $PICTURES speichern"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Ein Bildschirmfoto eines Bildschirmbereichs in $PICTURES speichern"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Ein Bildschirmfoto in die Zwischenablage kopieren"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Ein Bildschirmfoto eines Fensters in die Zwischenablage kopieren"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Ein Bildschirmfoto eines Bereichs in die Zwischenablage kopieren"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Ein kurzes Bildschirmvideo aufzeichnen"
+
+#~ msgid "Move up"
+#~ msgstr "Nach oben verschieben"
+
+#~ msgid "Move down"
+#~ msgstr "Nach unten verschieben"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Ortungsdienste ermöglichen Anwendungen, Ihre geografische Position zu "
+#~ "kennen. Die Verwendung von WLAN oder mobilem Breitband erhöht die "
+#~ "Genauigkeit."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Verwendet den Mozilla-Ortungsdienst: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Regeln zum Schutz der Privatsphäre</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Den nachfolgenden Anwendungen Zugriff auf Ihren Standort erlauben."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Den nachfolgenden Anwendungen Zugriff auf Ihr Mikrofon erlauben."
+
+# CHECK
+#~ msgid "Double-click timeout"
+#~ msgstr "Max. Doppelklickintervall"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Taste für Bereitschaft und Ausschalten"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Laptop erkannt: Leistungsmodus nicht verfügbar"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Hohe Hardware-Temperatur: Leistungsmodus nicht verfügbar"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Leistungsmodus nicht verfügbar"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Legitimieren"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Das Zahlen-, Datums und Währungsformat auswählen. Änderungen treten mit "
+#~ "der nächsten Anmeldung in Kraft."
+
+#~ msgid "My Account"
+#~ msgstr "Mein Konto"
+
+#~ msgid "Language"
+#~ msgstr "Sprache"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Die Sprache zum Anzeigen von Text in Fenstern und Webseiten."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Die Sitzung neu starten, damit die Änderungen wirksam werden"
+
+#~ msgid "Restart…"
+#~ msgstr "Neustart …"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Anmeldeeinstellungen werden für alle Benutzer verwendet, wenn sich diese "
+#~ "am System anmelden"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Legen Sie fest, welche Suchergebnisse in der Aktivitätenübersicht "
+#~ "angezeigt werden. Die Reihenfolge der Suchergebnisse kann auch geändert "
+#~ "werden, indem Zeilen in der Liste verschoben werden."
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "Einige Dienste sind deaktiviert, weil kein Netzwerk-Zugriff möglich ist."
+
+#~ msgid "Sound Keys"
+#~ msgstr "Lautstärkeregelung"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Bildschirmleser"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Bildschirmle_ser"
+
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgid "Account _Type"
+#~ msgstr "Konten_typ"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Bei der nächsten Anme_ldung Passwort wählen"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_Jetzt ein Passwort festlegen"
+
+# I believe that the text field where this string is inserted needs to render the line breaks, not hard-coded "\n
+# characters
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Gehen Sie online, um Unternehmens-Benutzerkonten hinzuzufügen."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Ein Bild aufnehmen …"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Um Änderungen vorzunehmen,\n"
+#~ "klicken Sie zuerst auf das Symbol *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Ein Benutzerkonto erstellen"
+
+#~ msgid "User Icon"
+#~ msgstr "Benutzersymbol"
+
+#~ msgid "Account Settings"
+#~ msgstr "Kontoeinstellungen"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Legitimierung und Anmeldung"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Dieser Eintrag wird für Ihren Benutzerordner verwendet und kann nicht "
+#~ "geändert werden."
+
+#~ msgid "Output:"
+#~ msgstr "Ausgabe:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Einem einzigen Bildschirm zuordnen"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d von %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Zuordnung anzeigen"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablett (absolut)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Tastfeld (relativ)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Tablett-Einstellungen"
+
+#~ msgid "_Help"
+#~ msgstr "_Hilfe"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth-Einstellungen"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Mausverfolgungsmodus"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Knöpfe zuweisen …"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Maus-Einstellungen anpassen"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Die Bildschirmauflösung anpassen"
+
+#~ msgid "No stylus found"
+#~ msgstr "Kein Stylus gefunden"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Bitte bewegen Sie Ihren Stylus in die Nähe des Tablets, um ihn "
+#~ "einzustellen"
+
+#~ msgid "Top Button"
+#~ msgstr "Oberer Knopf"
+
+#~ msgid "Lower Button"
+#~ msgstr "Unterer Knopf"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Unterster Knopf"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Wird entsperrt …"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Anmeldung;Name;Benutzerkonto;Fingerabdruck;Avatar;Benutzerbild;Logo;"
+#~ "Gesicht;Passwort;"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Bildschirmhelligkeit"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Tastaturbeleuchtungshelligkeit"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Bildschirm bei Inaktivität abdunkeln"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "Bildschirm _abschalten"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_WLAN"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "WLAN kann ausgeschaltet werden, um Strom zu sparen."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Mobile Breitband-Geräte (3G, 4G, LTE usw.) können ausgeschaltet werden, "
+#~ "um Strom zu sparen."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth kann ausgeschaltet werden, um Strom zu sparen."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Ausgeglichene Energie"
+
+#~ msgid "Add…"
+#~ msgstr "Hinzufügen …"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Tastenkombination"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Das kann in »Tastenkombinationen anpassen« geändert werden"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Gedrückt halten und tippen, um verschiedene Zeichen einzugeben"
+
+#~ msgid "Previous source"
+#~ msgstr "Vorherige Quelle"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Supertaste+Umschalttaste+Leertaste"
+
+#~ msgid "Next source"
+#~ msgstr "Nächste Quelle"
+
+#~ msgid "Super+Space"
+#~ msgstr "Supertaste+Leertaste"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Links+Rechte Alt-Taste"
+
+#~ msgid "Left Alt"
+#~ msgstr "Linke Alt-Taste"
+
+#~ msgid "Right Alt"
+#~ msgstr "Rechte Alt-Taste"
+
+#~ msgid "Left Super"
+#~ msgstr "Linke Super-Taste"
+
+#~ msgid "Right Super"
+#~ msgstr "Rechte Super-Taste"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Rechte Strg-Taste"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Taste für alternative Zeichen"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Mit Hilfstasten zur nächsten Quelle wechseln"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Menü-Taste"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Lädt"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Achtung"
+
+# Mausempfindlichkeit
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Niedrig"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Gut"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Vollständig geladen"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Leer"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Benutzerkonten hinzufügen und Passwörter ändern"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Klänge aufnehmen und abspielen"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Netzwerkgeräte mit mDNS/DNS-SD (Bonjour/zeroconf) erkennen"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Auf Bluetooth-Hardware direkt zugreifen"
+
+#~ msgid "Use your camera"
+#~ msgstr "Ihre Kamera verwenden"
+
+#~ msgid "Print documents"
+#~ msgstr "Dokumente drucken"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Irgendeinen angeschlossenen Joystick verwenden"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Verbindungen zum Docker-Dienst erlauben"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Netzwerk-Firewall einrichten"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Privilegierte FUSE-Dateisysteme einrichten und verwenden"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Firmware auf diesem Gerät aktualisieren"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Hardware-Informationen abfragen"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Entropie dem Hardware-Zufallszahlengenerator zur Verfügung stellen"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Hardware-Zufallszahlengenerator verwenden"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Auf Dateien in Ihrem persönlichen Ordner zugreifen"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Auf libvirt-Dienst zugreifen"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Einstellungen für Systemsprache und Region ändern"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Standorteinstellungen -dienste ändern"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "System- und Anwendungsprotokolle lesen"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "Auf Media-Hub-Dienst zugreifen"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Modems einrichten und verwenden"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "System-Einhängeinformationen und Datenträgerkontingente lesen"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Musik- und Video-Wiedergabeprogramme steuern"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Detaillierte Netzwerkeinstellungen ändern"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Auf NetworkManager-Dienst zugreifen, um Netzwerkeinstellungen zu lesen "
+#~ "und ändern"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Lesezugriff auf Netzwerkeinstellungen"
+
+#~ msgid "Change network settings"
+#~ msgstr "Netzwerkeinstellungen ändern"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Auf den ofono-Dienst zugreifen, um Netzwerkeinstellungen für "
+#~ "Mobiltelefonie zu lesen und ändern"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Open vSwitch-Hardware steuern"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Von CD/DVD lesen"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Gespeicherte Passwörter lesen, hinzufügen, ändern oder entfernen"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Auf pppd- und ppp-Geräte zugreifen, um Verbindungen mit dem Point-to-"
+#~ "Point-Protokoll einzustellen"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Jeglichen Prozess im System pausieren oder beenden"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Auf USB-Hardware direkt zugreifen"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Dateien auf Wechseldatenträgern lesen/schreiben"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Bildschirmabdunklung bzw. -sperre unterbinden"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Auf serielle Schnittstellenhardware direkt zugreifen"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Gerät neu starten oder herunterfahren"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Software installieren, entfernen und einrichten"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Auf Storage-Framework-Dienst zugreifen"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Prozess- und Systeminformationen lesen"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Alle laufenden Programme überwachen und kontrollieren"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Einstellungen für den Zeitserver ändern"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Zeitzone ändern"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Auf UDisks2-Dienst zugreifen, um Festplatten und Wechseldatenträger "
+#~ "einzurichten"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Geteilte Kalenderevents in Ubuntu Unity 8 lesen/ändern"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Geteilte Kontakte in Ubuntu Unity 8 lesen/ändern"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Energienutzungsdaten abrufen"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Lese-/Schreibzugriff auf offengelegte U2F-Geräte"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Hintergrund und Sperrbildschirm festlegen"
+
+#~ msgid "Set Background"
+#~ msgstr "Hintergrund festlegen"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Sperrbildschirm festlegen"
+
+#~ msgid "Remove Background"
+#~ msgstr "Hintergrund entfernen"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+# Mit weichen Trennzeichen, die die Stelle einen Textumbruch vorschlagen
+#~ msgid "Universal Access"
+#~ msgstr "Barriere­frei­heit"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Ausschalten, um mit einem Funknetzwerk zu verbinden"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Passwort"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Um ein Benutzerkonto anzulegen,\n"
+#~ "klicken Sie zuerst auf das Symbol *"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Anmeldung mit Fingerabdruck freischalten"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Anderer Finger:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Ihr Fingerabdruck wurde erfolgreich gespeichert. Sie sollten sich jetzt "
+#~ "mit Ihrem Fingerlesegerät anmelden können."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Sie sind nicht berechtigt, auf das Gerät zuzugreifen. Kontaktieren Sie "
+#~ "Ihren Systemadministrator."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Ein interner Fehler ist aufgetreten."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Sollen die registrierten Fingerabdrücke gelöscht werden?"
+
+#~ msgid "Done!"
+#~ msgstr "Erledigt."
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Auf Gerät »%s« konnte nicht zugegriffen werden"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Fingerabtastung konnte auf dem Gerät »%s« nicht gestartet werden"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Es konnte auf kein Lesegerät für Fingerabdrücke zugegriffen werden"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Bitte kontaktieren Sie Ihren Systemadministrator für Hilfe."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Zur Freischaltung der Anmeldung mit Fingerabdruck müssen Sie einen "
+#~ "Fingerabdruck mit dem Gerät »%s« hinterlegen."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Finger wird ausgewählt"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Reports sind frei von personenbezogenen Daten und werden anonym versandt."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Der Versand von Reports bei technischen Problemen hilft den GNOME-"
+#~ "Entwicklern, das Betriebssystem zu verbessern."
+
+#~ msgid "Version %s"
+#~ msgstr "Version %s"
+
+#~ msgid "OS name"
+#~ msgstr "Name des Betriebssystems"
+
+#~ msgid "OS type"
+#~ msgstr "Typ des Betriebssystems"
+
+#~ msgid "Disk"
+#~ msgstr "Datenträger"
+
+#~ msgid "Check for updates"
+#~ msgstr "Nach Aktualisierungen suchen"
+
+#~ msgid "Network proxy"
+#~ msgstr "Netzwerk-Proxy"
+
+#~ msgid "page 1"
+#~ msgstr "Seite 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Innere _Legitimierung"
+
+#~ msgid "page 2"
+#~ msgstr "Seite 2"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Verbrauch von _Hintergrunddaten beschränken"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Angemessen für Verbindungen mit Datengebühren oder -limits"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+# http://de.wikipedia.org/wiki/Attachment_Unit_Interface
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+# http://de.wikipedia.org/wiki/Media_Independent_Interface
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mbit/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mbit/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Einschalten des Funknetz-Hotspot führt zur Trennung von <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Es ist nicht möglich, auf das Internet über Ihr Funknetz zuzugreifen, "
+#~ "während der HotSpot aktiv ist."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "WLAN-Hotspots werden üblicherweise dazu genutzt, eine zusätzliche "
+#~ "Internetverbindung über ein Funknetzwerk freizugeben."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Automatisch _verbinden"
+
+#~ msgid "details"
+#~ msgstr "Details"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Pass_wort zeigen"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Anderen Benutzern zur Verfügung stellen"
+
+#~ msgid "identity"
+#~ msgstr "Identität"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adressen"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Nur automatische (DHCP) Adressen"
+
+#~ msgid "Link-local only"
+#~ msgstr "Nur Link-local"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "Automatisch erhaltene Routen _ignorieren"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Duplizierte MAC-Adresse"
+
+#~ msgid "_Reset"
+#~ msgstr "_Zurücksetzen"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Die Einstellungen für diese Verbindung auf Voreinstellung zurücksetzen, "
+#~ "aber als bevorzugte Verbindung beibehalten."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Alle Details dieses Netzwerks löschen und nicht automatisch mit ihm "
+#~ "verbinden."
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Zurücksetzen"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Verbundene Geräte"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastruktur"
+
+# Mit weichen Trennzeichen, die die Stelle einen Textumbruch vorschlagen
+#~ msgid "Notification _Popups"
+#~ msgstr "Be_nachrichtigungen"
+
+#~ msgid "In use"
+#~ msgstr "In Verwendung"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "An"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Aus"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Aus"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "An"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Aus"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "An"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Datenschutzrichtlinie"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Das Behalten der Chronik erleichtert zukünftige Suchen. Die Objekte "
+#~ "werden niemals im Netzwerk freigegeben."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Zuletzt verwendet"
+
+#~ msgid "Retain _History"
+#~ msgstr "_Chronik behalten"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Die Bildschirmsperre schützt Ihre Privatsphäre, solange Sie nicht "
+#~ "anwesend sind."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Bildschirm sperren _nach"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "Benachrichtigungen auf dem Sperrbi_ldschirm"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Automatisch den Papierkorb und temporäre Dateien löschen, um Ihren "
+#~ "Rechner frei von unnötigen sensiblen Daten zu halten."
+
+#~ msgid "Purge _After"
+#~ msgstr "Löschen _nach"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Durch das Senden Ihrer Softwarenutzungsinformationen helfen Sie uns Ihnen "
+#~ "genauere Empfehlungen anzubieten. Außerdem helfen Sie uns unsere Software "
+#~ "zu verbessern.\n"
+#~ "\n"
+#~ "Sämtliche gesammelte Informationen werden anonymisiert und wir werden "
+#~ "Ihre Daten nicht mit Dritten teilen."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Softwarenutzungsstatistiken senden"
+
+#~ msgid "_Camera"
+#~ msgstr "_Kamera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Mikrofon"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Ortungsdienste"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Schützen Sie Ihre persönlichen Informationen und kontrollieren Sie, was "
+#~ "andere sehen können"
+
+#~ msgid "No regions found"
+#~ msgstr "Keine Regionen gefunden"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Fensterleiste _blinken"
+
+#~ msgid "Last Login"
+#~ msgstr "Letzte Anmeldung"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Der Benutzername darf nicht mit einem »-« beginnen."
+
+#~ msgid "_Background"
+#~ msgstr "_Hintergrund"
+
+# Wechselndes Hintergrundbild
+#~ msgid "Changes throughout the day"
+#~ msgstr "Ändert sich im Laufe des Tages"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Kachel"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Vergrößerung"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Zentrieren"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Skalieren"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Füllen"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Spannen"
+
+#~ msgid "Colors"
+#~ msgstr "Farben"
+
+#~ msgid "Pictures"
+#~ msgstr "Bilder"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Keine Bilder gefunden"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Bilder, die Sie zu Ihrem %s-Ordner hinzufügen, werden hier auftauchen"
+
+#~ msgid "_Off"
+#~ msgstr "_Aus"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Verbindung/SSID"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automatisch in Bereitschaft gehen"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Wenn die Ausschalttaste gedrückt wird"

--- a/po/dz.po
+++ b/po/dz.po
@@ -6,3490 +6,7392 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.HEAD.dz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-03-29 00:51+0000\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2008-09-11 11:47+0530\n"
 "Last-Translator: Dawa pemo <daws_403@hotmail.com>\n"
 "Language-Team: DZONGKHA <pgeyleg@dit.gov.bt>\n"
 "Language: dz\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 "X-Poedit-Language: Dzongkha\n"
 "X-Poedit-Country: BHUTAN\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "གཟུགས་བརྙན་/ཁ་ཡིག་གི་མཐའ་མཚམས།"
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "དྲན་བརྡའི་ཌའི་ལོག་ནང་ ཁ་ཡིག་དང་ གཟུགས་བརྙན་གྱི་མཐའ་སྐོར་ལུ་ མཐའ་མཚམས་ཀྱི་རྒྱ་ཚད།"
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr "དྲན་བརྡའི་དབྱེ་བ།"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "དྲན་བརྡའི་དབྱེ་བ།"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "དྲན་བརྡའི་ཨེབ་རྟ་ཚུ།"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "དྲན་བརྡའི་ཌའི་ལོག་ནང་སྟོན་མི་ཨེབ་རྟ་ཚུ།"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "རྒྱས་བཤད་ཧེང་བཀལ་སྟོན།(_d)"
-
-#: ../capplets/about-me/gnome-about-me.c:682
-msgid "Select Image"
-msgstr "གཟུགས་བརྙན་སེལ་འཐུ་འབད།"
-
-#: ../capplets/about-me/gnome-about-me.c:684
-msgid "No Image"
-msgstr "གཟུགས་བརྙན་མིན་འདུག"
-
-#: ../capplets/about-me/gnome-about-me.c:712
-#: ../capplets/appearance/appearance-desktop.c:1130
-msgid "Images"
-msgstr "གཟུགས་བརྙན་ཚུ།"
-
-#: ../capplets/about-me/gnome-about-me.c:716
-#: ../capplets/appearance/theme-installer.c:694
-msgid "All Files"
-msgstr "ཡིག་སྣོད་ཆ་མཉམ།"
-
-#: ../capplets/about-me/gnome-about-me.c:854
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-"ཁ་བྱང་ཀི་དེབ་ཀྱི་ བརྡ་དོན་ལེན་ཐབས་འབད་བའི་སྐབས་ལུ་ འཛོལ་བ་ཅིག་བྱུང་ནུགཨི་བོ་ལུ་ཤཱན་ གནད་སྡུད་སར་བར་"
-"གྱིས་ གནད་སྤེལ་ལམ་ལུགས་ ལེགས་སྐྱོང་འཐབ་མི་ཚུགས་པས།"
-
-#: ../capplets/about-me/gnome-about-me.c:875
-msgid "Unable to open address book"
-msgstr "ཁ་བྱང་ཀི་དེབ་ ཁ་ཕྱེ་མ་ཚུགས།"
-
-#: ../capplets/about-me/gnome-about-me.c:889
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr "མ་ཤེསས་པའི་ ནང་བསྐྱོད་ཨའི་ཌི། ལག་ལེན་པའི་ གཞི་རྟེན་གནད་སྡུད་ ངན་ཅན་ལུ་གྱུར་སོངཔ་འོང་ནི་མས།"
-
-#: ../capplets/about-me/gnome-about-me.c:919
-#: ../capplets/about-me/gnome-about-me.c:921
-#, c-format
-msgid "About %s"
-msgstr "%sསྐོར་ལས།"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "About Me"
-msgstr "ངེད་ཀྱི་སྐོར་ལས།"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "ཁྱོད་རའི་རང་དོན་བརྡ་དོན་ གཞི་སྒྲིག་འབད།"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-msgid "<b>Email</b>"
-msgstr "<i>གློག་འཕྲིན་</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-msgid "<b>Home</b>"
-msgstr "<b>ཁྱིམ་ </b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>འཕྲལ་མྱུར་འཕྲིན་གཏོང་།</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Job</b>"
-msgstr "<b>ལས་གཡོག</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Telephone</b>"
-msgstr "<b>བརྒྱུད་འཕྲིན་</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Web</b>"
-msgstr "<b>ཝེབ་</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Work</b>"
-msgstr "<b>ལཱ་གཡོག་</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">ཁྱོད་རའི་ཆོག་ཡིག་སོར་</span>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "A_IM/iChat:"
-msgstr "ཨེ་ཨའི་ཨེམ/ཨའི་ཅེཊི་:(_I)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "A_ddress:"
-msgstr "ཁ་བྱང་:(_d)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_ssistant:"
-msgstr "ལས་རོགས་:(_s)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "Address"
-msgstr "ཁ་བྱང་།"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "C_ity:"
-msgstr "གྲོང་སྡེ་:(_i)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "C_ompany:"
-msgstr "ཚོང་སྡེ་:(_o)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "Cale_ndar:"
-msgstr "ཟླ་ཐོ་:(_n)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "Change Passwo_rd..."
-msgstr "ཆོག་ཡིག་སོར་...(_r)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Change pa_ssword"
-msgstr "ཆོག་ཡིག་སོར།(_s)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change password"
-msgstr "ཆོག་ཡིག་སོར།"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Ci_ty:"
-msgstr "གྲོང་སྡེ་:(_t)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Co_untry:"
-msgstr "རྒྱལ་ཁབ་:(_u)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Contact"
-msgstr "འབྲེལ་ས"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Cou_ntry:"
-msgstr "རྒྱལ་ཁབ་:(_n)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Current _password:"
-msgstr "ད་ལྟོའི་ཆོག་ཡིག་:(_p)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr "མིང་ཆ་ཚང་།"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Hom_e:"
-msgstr "ཁྱིམ། (_e)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr "ཨའི་སི་ཀིའུ་:(_Q)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr "ཨེམ་ཨེསི་ཨེན་:(_S)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "P.O. _box:"
-msgstr "འགྲེམ་ཁང་ཡིག་སྒྲོམ་:(_b)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P._O. box:"
-msgstr "འགྲེམ་ཁང་ཡིག་སྒྲོམ་:(_O)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "Personal Info"
-msgstr "རང་དོན་བརྡ་དོན།"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-#: ../capplets/about-me/gnome-about-me-password.c:934
-msgid ""
-"Please type your password again in the <b>Retype new password</b> field."
-msgstr ""
-"<b>ཆོག་ཡིག་གསརཔ་ལོག་ཡིག་དཔར་རྐྱབས་</b> ཟེར་མི་ས་སྒོ་ནང་ ཁྱོད་རའི་ཆོག་ཡིག་ ལོག་སྟེ་རང་ཡིག་དཔར་"
-"རྐྱབས།"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "Select your photo"
-msgstr "ཁྱོད་རའི་དཔར་ སེལ་འཐུ་འབད་ "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-msgid "State/Pro_vince:"
-msgstr "མངའ་སྡེ་.མངའ་རིས་:(_v)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid ""
-"To change your password, enter your current password in the field below and "
-"click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for "
-"verification and click <b>Change password</b>."
-msgstr ""
-"ཁྱོད་རའི་ཆོག་ཡིག་སོར་ནི་ལུ་ འོག་གི་སྒོ་ནང་ད་ལྟོའི་ཆོག་ཡིག་ཞིནམ་ལས་ <b>བདེན་བཤད་</b> ལུ་ཨེབ་གཏང་"
-"འབད། བདེན་བཤད་འབད་ཞིནམ་ལས་ ཁྱོད་རའི་ཆོག་ཡིག་གསརཔ་བཙུགས། བདེན་སྦྱོར་གྱི་དོན་ལུ་ ཆོག་ཡིག་དེ་ལོག་སྟེ་"
-"རང་ཚར་ཅིག་ཡིག་དཔར་བརྐྱབས་ཞིནམ་ལས་ <b>ཆོག་ཡིག་སོར་</b> ལུ་ཨེབ་གཏང་འབད།"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid "User name:"
-msgstr "ལག་ལེན་པའི་མིང་:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Web _log:"
-msgstr "ཝེབ་དྲན་དེབ་:(_l)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "Wor_k:"
-msgstr "ལཱ་གཡོག་:(_k)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "Work _fax:"
-msgstr "ལཱ་གི་དཔར་འཕྲིན་:(_f)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "Zip/_Postal code:"
-msgstr "གནས་ཨང་/འགྲེམ་ཨང་:(_p)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "_Address:"
-msgstr "ཁ་བྱང་:(_A)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "_Authenticate"
-msgstr "བདེན་བཤད་འབད།(_A)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Department:"
-msgstr "ལས་ཁུངས་:(_D)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Groupwise:"
-msgstr "སྡེ་རིམ་:(_G)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Home page:"
-msgstr "ཁྱིམ་གྱི་ཤོག་ལེབ་:(_H)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_Home:"
-msgstr "ཁྱིམ་:(_H)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Jabber:"
-msgstr "ཇེབ་བར་:(_J)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Manager:"
-msgstr "འཛིན་སྐྱོང་པ་:(_M)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_Mobile:"
-msgstr "འགྲུལ་འཕྲིན་:(_M)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_New password:"
-msgstr "ཆོག་ཡིག་གསརཔ་:(_N)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Profession:"
-msgstr "ཁྱད་ལས་:(_P)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Retype new password:"
-msgstr "ཆོག་ཡིག་གསརཔ་ལོག་སྟེ་རྐྱབས་:(_R)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_State/Province:"
-msgstr "མངའ་སྡེ་/མངའ་རིས།"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:55
-msgid "_Title:"
-msgstr "གོ་གནས་:(_T)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:56
-msgid "_Work:"
-msgstr "ལཱ་གཡོག་:(_W)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:57
-msgid "_Yahoo:"
-msgstr "ཡ་ཧུ་:(_Y)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:58
-msgid "_Zip/Postal code:"
-msgstr "གནས་ཨང་/འགྲེམ་ཨང་:(_Z)"
-
-#: ../capplets/about-me/gnome-about-me-password.c:162
-msgid "Child exited unexpectedly"
-msgstr "ཆ་ལག་རེ་བ་མེད་པར་ཕྱིར་ཐོན་སོང་ནུག"
-
-#: ../capplets/about-me/gnome-about-me-password.c:297
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr "རྒྱབ་མཐའི་ ཨེསི་ཊི་ཌི་ཨིན་ ཨའི་ཨོ་རྒྱུ་ལམ་:%sསྒོ་བསྡམ་མ་ཚུགས།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:310
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr "རྒྱབ་མཐའི་ ཨེསི་ཊི་ཌི་ཨའུཊི་ཨའི་ཨོ་རྒྱུ་ལམ་:%sསྒོ་བསྡམ་མ་ཚུགས།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:409
-msgid "Authenticated!"
-msgstr "བདེན་བཤད་འབད་ཡོད།"
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:475
-#: ../capplets/about-me/gnome-about-me-password.c:551
-msgid ""
-"Your password has been changed since you initially authenticated! Please re-"
-"authenticate."
-msgstr ""
-"ཁྱོད་ཀྱིས་འགོ་ཐོག་ལུ་ བདེན་བཤད་འབད་ཞིནམ་ལས་ ཁྱོད་ཀྱི་ཆོག་ཡིག་སོར་ནུག སླར་བདེན་བཤད་འབད་གནང་།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:477
-msgid "That password was incorrect."
-msgstr "ཆོག་ཡིག་དེ་བདེན་མེད་ཨིན་པས།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:524
-msgid "Your password has been changed."
-msgstr "ཁྱོད་ཀྱིས་ཆོག་ཡིག་དེ་སོར་ནུག"
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:534
-#, c-format
-msgid "System error: %s."
-msgstr "རིམ་ལུགས་འཛོལ་བ་:%s།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:537
-msgid "The password is too short."
-msgstr "ཆོག་ཡིག་དེ་ཐུང་དྲགས་པས།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:540
-msgid "The password is too simple."
-msgstr "ཆོག་ཡིག་དེ་འཇམ་དྲགས་པས།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:543
-msgid "The old and new passwords are too similar."
-msgstr "ཆོག་ཡིག་རྙིངམ་དང་གསརཔ་འདྲ་བས།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:545
-msgid "The new password must contain numeric or special character(s)."
-msgstr "ཆོག་ཡིག་གསར་པའི་ནང་ཨང་གྲངས་ ཡང་ན་ དམིགས་བསལ་ཡིག་འབྲུ་(ཚུ) ཡོད་དགོ"
-
-#: ../capplets/about-me/gnome-about-me-password.c:548
-msgid "The old and new passwords are the same."
-msgstr "ཆོག་ཡིག་རྙིངམ་དང་གསརཔ་ཅོག་གཅིག་པས།"
-
-#. translators: Unable to launch <program>: <error message>
-#: ../capplets/about-me/gnome-about-me-password.c:818
-#, c-format
-msgid "Unable to launch %s: %s"
-msgstr "%s:%s གསར་བཙུགས་འབད་མ་ཚུགས།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:821
-msgid "Unable to launch backend"
-msgstr "རྒྱབ་མཐའ་གསར་བཚུགས་འབད་མི་བཙུགས་པས།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:822
-msgid "A system error has occurred"
-msgstr "རིམ་ལུགས་ཀྱི་འཛོལ་བ་ཅིག་བྱུང་ནུག"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:842
-msgid "Checking password..."
-msgstr "ཆོག་ཡིག་ཞིབ་དཔྱད་འབད་དོ།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:928
-msgid "Click <b>Change password</b> to change your password."
-msgstr "ཁྱོད་རའི་ཆོག་ཡིག་སོར་ནིའི་དོན་ལུ་<b>ཆོག་ཡིག་སོར་</b> གུ་ཨེབ་གཏང་འབད།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:931
-msgid "Please type your password in the <b>New password</b> field."
-msgstr " <b>ཆོག་ཡིག་གསར་པའི་</b> ས་སྒོ་ནང་ ཁྱོད་རའི་ཆོག་ཡིག་ ཡིག་དཔར་རྐྱབས།"
-
-#: ../capplets/about-me/gnome-about-me-password.c:937
-msgid "The two passwords are not equal."
-msgstr "ཆོག་ཡིག་གཉིསཔོ་དེ་འདྲ་མཉམ་མེན་པས།"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Assistive Technologies</b>"
-msgstr "<b>ཕན་ཐབས་ཅན་གྱི་འཕྲུལ་རིག་ཚུ</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Preferences</b>"
-msgstr "<b>དགའ་གདམ་ཚུ</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid "Accessible Lo_gin"
-msgstr "འཛུལ་སྤྱོད་ནང་བསྐྱོད(_g)"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technologies Preferences"
-msgstr "ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་གི་དགའ་གདམ་ཚུ་ "
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid ""
-"Changes to enable assistive technologies will not take effect until your "
-"next log in."
-msgstr ""
-"འཕྲུལ་རིག་ལྕོགས་ཅན་ཕན་འཐབ་བསྒྱུར་བཅོས་ཚུ་ལུ་ ཤུལ་མའི་ནང་བསྐྱོད་མ་འབད་ཚུན་ཚོད་ ནུས་པ་མི་འོང་།"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Close and _Log Out"
-msgstr "ཁ་བསྡམས་ཏེ་ ཕྱིར་བསྐྱོད་འབད།(_L)"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "Jump to Preferred Applications dialog"
-msgstr "དགའ་གདམ་ཅན་གྱི་འཇུག་སྤྱོད་ཌའི་ལོག་ལུ་མཆོང་"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "Jump to the Accessible Login dialog"
-msgstr "ནང་བསྐྱོད་ཌའི་ལོག་འཛུལ་སྤྱོད་ནང་ལུ་མཆོང་"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "Jump to the Keyboard Accessibility dialog"
-msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད་ཌའི་ལོག་ལུ་མཆོང་"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Enable assistive technologies"
-msgstr "ཕན་ཐབས་ཅན་གྱི་འཕྲུལ་རིག་ཚུ་ ལྕོགས་ཅན་བཟོ།(_E)"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
-msgid "_Keyboard Accessibility"
-msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད(_K)"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
-msgid "_Preferred Applications"
-msgstr "དགའ་གདམ་ཅན་གྱི་འཇུག་སྤྱོད(_P)"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technologies"
-msgstr "ཕན་ཐབས་ཅན་གྱི་འཕྲུལ་རིག་ཚུ་ "
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr "ནང་བསྐྱོད་སྐབས་ལུ་ ཇི་ནོམ་གྱི་ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་ཚུ་གི་དོན་ལུ་ རྒྱབ་སྐྱོར་ལྕོགས་ཅན་བཟོ།"
-
-#: ../capplets/appearance/appearance-desktop.c:1098
-msgid "Add Wallpaper"
-msgstr "གྱང་ཤོག་ཁ་སྐོང་རྐྱབས།"
-
-#: ../capplets/appearance/appearance-desktop.c:1134
-msgid "All files"
-msgstr "ཡིག་སྣོད་ཆ་མཉམ"
-
-#: ../capplets/appearance/appearance-font.c:494
-msgid "Font may be too large"
-msgstr "ཡིག་གཟུགས་ཆེ་དྲགས་ནི་མས།"
-
-#: ../capplets/appearance/appearance-font.c:498
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་%d ཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་ལཱ་"
-"ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་%dལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
-msgstr[1] ""
-"སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་%dཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་ལཱ་"
-"ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་%dལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
-
-#: ../capplets/appearance/appearance-font.c:511
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་%dཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་ལཱ་"
-"ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་ དེ་ལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
-msgstr[1] ""
-"སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་ %dཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་ལཱ་"
-"ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་ དེ་ལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
-
-#: ../capplets/appearance/appearance-font.c:533
-msgid "Use previous font"
-msgstr "ཧེ་མའི་ཡིག་གཟུགས་ ལག་ལེན་འཐབ་"
-
-#: ../capplets/appearance/appearance-font.c:535
-msgid "Use selected font"
-msgstr "སེལ་འཐུ་འབད་ཡོད་པའི་ཡིག་གཟུགས་ལག་ལེན་འཐབ་"
-
-#: ../capplets/appearance/appearance-main.c:108
-msgid "Specify the filename of a theme to install"
-msgstr "གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ བརྗོད་དོན་ཅིག་གི་ ཡིག་སྣོད་མིང་གསལ་བཀོད་འབད་"
-
-#: ../capplets/appearance/appearance-main.c:109
-msgid "filename"
-msgstr "ཡིག་སྣོད་མིང་"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/appearance/appearance-main.c:116
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
-msgstr ""
-"ཤོག་ལེབ་ཀྱི་མིང་སྟོན་ནི་གི་དོན་ལས་གསལ་བཀོད་འབད (བརྗོད་དོན|རྒྱབ་བརྟེན|ཡིག་གཟུགས་ཚུ|ཨིན་ཊར་ཕེའིསི)"
-
-#: ../capplets/appearance/appearance-main.c:117
-msgid "page"
-msgstr "ཤོག་ལེབ"
-
-#: ../capplets/appearance/appearance-main.c:124
-msgid "[WALLPAPER...]"
-msgstr "[WALLPAPER...]"
-
-#: ../capplets/appearance/appearance-style.c:156
-#: ../capplets/common/gnome-theme-info.c:439
-#: ../capplets/common/gnome-theme-info.c:638
-msgid "Default Pointer"
-msgstr "སྔོན་སྒྲིག་དཔག་བྱེད།"
-
-#: ../capplets/appearance/appearance-themes.c:534
-msgid "Apply Background"
-msgstr "རྒྱབ་གཞི་ འཇུག་སྤྱོད་འབད་ "
-
-#: ../capplets/appearance/appearance-themes.c:538
-msgid "Apply Font"
-msgstr "ཡིག་གཟུགས་ འཇུག་སྤྱོད་འབད་ "
-
-#: ../capplets/appearance/appearance-themes.c:563
-msgid "The current theme suggests a background and a font."
-msgstr "ད་ལྟོའི་བརྗོད་དོན་འདི་གིས་ རྒྱབ་གཞི་དང་ཡིག་གཟུགས་ཅིག་གི་ བསམ་འཆར་་བཀོདཔ་མས།"
-
-#: ../capplets/appearance/appearance-themes.c:568
-msgid "The current theme suggests a background."
-msgstr "ད་ལྟོའི་བརྗོད་དོན་འདི་གིས་ རྒྱབ་གཞི་ཅིག་གི་ བསམ་འཆར་་བཀོདཔ་མས།"
-
-#: ../capplets/appearance/appearance-themes.c:573
-msgid "The current theme suggests a font."
-msgstr "ད་ལྟོའི་ བརྗོད་དོན་འདི་གིས་ ཡིག་གཟུགས་ཅིག་གི་ བསམ་འཆར་བཀོདཔ་མས།"
-
-#: ../capplets/appearance/appearance-themes.c:857
-#: ../capplets/default-applications/gnome-da-capplet.c:1080
-#: ../capplets/sound/sound-properties-capplet.c:327
-msgid "Custom"
-msgstr "སྲོལ་སྒྲིག"
-
-#: ../capplets/appearance/data/appearance.glade.h:1
-msgid "<b>C_olors</b>"
-msgstr "<b>ཚོས་གཞི་</b>(_o)"
-
-#. font hinting
-#: ../capplets/appearance/data/appearance.glade.h:3
-msgid "<b>Hinting</b>"
-msgstr "<b>བརྡ་མཚོན་སྟོན་དོ</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:4
-msgid "<b>Menus and Toolbars</b>"
-msgstr "<b>དཀར་ཆག་དང་ ལག་ཆས་ཕྲ་རིང་ཚུ</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:5
-msgid "<b>Preview</b>"
-msgstr "<b>སྔོན་ལྟ་</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:6
-msgid "<b>Rendering</b>"
-msgstr "<b>ལྷག་སྟོན་འབད་དོ་</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:7
-msgid "<b>Smoothing</b>"
-msgstr "<b>ཧུམ་ཁྱུག་བཟོ་དོ</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:8
-msgid "<b>Subpixel Order</b>"
-msgstr "<b>སབ་པིཀ་སེལ་གོ་རིམ</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:9
-msgid "<b>_Wallpaper</b>"
-msgstr "<b>གྱང་ཤོག(_W)</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:10
-msgid "Appearance Preferences"
-msgstr "བརྗོད་དོན་གྱི་དགའ་གདམ་ཚུ"
-
-#: ../capplets/appearance/data/appearance.glade.h:11
-msgid "Background"
-msgstr "རྒྱབ་གཞི་"
-
-#: ../capplets/appearance/data/appearance.glade.h:12
-msgid "Best _shapes"
-msgstr "བཟོ་དབྱིབས་ལེགས་ཤོས།(_s)"
-
-#: ../capplets/appearance/data/appearance.glade.h:13
-msgid "Best co_ntrast"
-msgstr "ཁྱད་པར་ལེགས་ཤོས།(_n)"
-
-#: ../capplets/appearance/data/appearance.glade.h:14
-msgid "C_ustomize..."
-msgstr "སྲོལ་སྒྲིག་འབད་...(_u)"
-
-#: ../capplets/appearance/data/appearance.glade.h:15
-msgid "C_ut"
-msgstr "བཏོག(_C)"
-
-#: ../capplets/appearance/data/appearance.glade.h:16
-msgid ""
-"Centered\n"
-"Fill screen\n"
-"Scaled\n"
-"Zoom\n"
-"Tiled"
-msgstr ""
-"སྦུག་ལུ་ཡོདཔ\n"
-" གསལ་གཞི་གངམ\n"
-"ཚད་འཇལ་ཡོདཔ\n"
-"རྒྱས་ཟུམ\n"
-"ཊ་ཡིལཊི"
-
-#: ../capplets/appearance/data/appearance.glade.h:21
-msgid "Changing your cursor theme takes effect the next time you log in."
-msgstr ""
-"ཁྱོད་རའི་ འོག་རྟགས་ཀྱི་བརྗོད་དོན་ སོར་མི་དེ་གིས་ ཁྱོད་ཤུལ་ལས་ ནང་བསྐྱོད་འབདཝ་ད་ ནུས་པ་ཐོབ་འོང་། "
-
-#: ../capplets/appearance/data/appearance.glade.h:22
-msgid "Colors"
-msgstr "ཚོས་གཞི་ཚུ་"
-
-#: ../capplets/appearance/data/appearance.glade.h:23
-msgid "Controls"
-msgstr "ཚད་འཛིན་ཚུ།"
-
-#: ../capplets/appearance/data/appearance.glade.h:24
-msgid "Customize Theme"
-msgstr "སྲོལ་སྒྲིག་ བརྗོད་དོན"
-
-#: ../capplets/appearance/data/appearance.glade.h:25
-msgid "D_etails..."
-msgstr "རྒྱས་བཤད་...(_e)"
-
-#: ../capplets/appearance/data/appearance.glade.h:26
-msgid "Des_ktop font:"
-msgstr "ཌེཀསི་ཊོཔ་ཡིག་གཟུགས་:(_k)"
-
-#: ../capplets/appearance/data/appearance.glade.h:27
-msgid "Edit"
-msgstr "ཞུན་དག་ "
-
-#: ../capplets/appearance/data/appearance.glade.h:28
-msgid "Font Rendering Details"
-msgstr "ཡིག་གཟུགས་ལྷག་སྟོན་གྱི་རྒྱས་བཤད།"
-
-#: ../capplets/appearance/data/appearance.glade.h:29
-msgid "Fonts"
-msgstr "ཡིག་གཟུགས་ཚུ"
-
-#: ../capplets/appearance/data/appearance.glade.h:30
-msgid "Gra_yscale"
-msgstr "གེརེ་སིཀེལ།(_y)"
-
-#: ../capplets/appearance/data/appearance.glade.h:31
-msgid "Icons"
-msgstr "ངོས་དཔར་ཚུ།"
-
-#: ../capplets/appearance/data/appearance.glade.h:32
-msgid "Interface"
-msgstr "ཨིན་ཊར་་ཕེའིསི"
-
-#: ../capplets/appearance/data/appearance.glade.h:33
-msgid "Large"
-msgstr "ཆེ་བ་ "
-
-#: ../capplets/appearance/data/appearance.glade.h:34
-msgid "N_one"
-msgstr "ཅི་མེད།(_o)"
-
-#: ../capplets/appearance/data/appearance.glade.h:35
-msgid "New File"
-msgstr "ཡིག་སྣོད་གསརཔ།"
-
-#: ../capplets/appearance/data/appearance.glade.h:36
-msgid "Open File"
-msgstr "ཡིག་སྣོད་ཁ་ཕྱེ།"
-
-#: ../capplets/appearance/data/appearance.glade.h:37
-msgid "Open a dialog to specify the color"
-msgstr "ཚོས་གཞི་གསལ་བཀོད་ཀྱི་དོན་ལུ་ ཌའི་ལོག་ཅིག་ཁ་ཕྱེ།"
-
-#: ../capplets/appearance/data/appearance.glade.h:38
-msgid "Pointer"
-msgstr "དཔག་བྱེད"
-
-#: ../capplets/appearance/data/appearance.glade.h:39
-msgid "R_esolution:"
-msgstr "ཧུམ་ཆ་:(_e)"
-
-#: ../capplets/appearance/data/appearance.glade.h:40
-msgid "Save File"
-msgstr "ཡིག་སྣོད་སྲུངས།"
-
-#: ../capplets/appearance/data/appearance.glade.h:41
-msgid "Save Theme As..."
-msgstr "བཟུམ་སྦེ་ བརྗོད་དོན་སྲུངབཞག་འབད་..."
-
-#: ../capplets/appearance/data/appearance.glade.h:42
-msgid "Save _As..."
-msgstr "བཟུམ་སྦེ་ བརྗོད་དོན་སྲུངབཞག་འབད་... (_A)"
-
-#: ../capplets/appearance/data/appearance.glade.h:43
-msgid "Save _background image"
-msgstr "རྒྱབ་གཞི་གཟུགས་བརྙན་སྲུངས་ (_B)"
-
-#: ../capplets/appearance/data/appearance.glade.h:44
-msgid "Show _icons in menus"
-msgstr "དཀར་ཆག་ནང་ ངོས་དཔར་ཚུ་སྟོན།(_i)"
-
-#: ../capplets/appearance/data/appearance.glade.h:45
-msgid "Small"
-msgstr "ཆུང་ཀུ"
-
-#: ../capplets/appearance/data/appearance.glade.h:46
-msgid ""
-"Solid color\n"
-"Horizontal gradient\n"
-"Vertical gradient"
-msgstr ""
-"རགས་པའི་མཚོ་གཞི\n"
-"ཐད་སྙོམ་སྟེགས་རེས\n"
-"ཀེར་ཕྲང་སྟེགས་རེས"
-
-#: ../capplets/appearance/data/appearance.glade.h:49
-msgid "Sub_pixel (LCDs)"
-msgstr "ཡན་ལག་པིཀ་སེལ། (ཨེལ་སི་ཌི་ཨེསི)(_p)"
-
-#: ../capplets/appearance/data/appearance.glade.h:50
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "ཡན་ལག་་པིཀ་སེལ་ ཧུམ་ཁྱུག་བཟོ་དོ། (ཨེལ་སི་ཌི་ཨེསི)(_p)"
-
-#: ../capplets/appearance/data/appearance.glade.h:51
-msgid "Text"
-msgstr "བརྟག་ཞིབ་"
-
-#: ../capplets/appearance/data/appearance.glade.h:52
-msgid ""
-"Text below items\n"
-"Text beside items\n"
-"Icons only\n"
-"Text only"
-msgstr ""
-"ཚིག་ཡིག་རྣམ་གྲངས་ཚུ་གི་འོག་ལུ\n"
-"ཚིག་ཡིག་རྣམ་གྲངས་ཚུ་གི་ཟུར་ཁ་ལུ\n"
-"ངོས་དཔར་རྐྱངམ་ཅིག\n"
-"ཚིག་ཡིག་རྐྱངམ་ཅིག"
-
-#: ../capplets/appearance/data/appearance.glade.h:56
-msgid "The current controls theme does not support color schemes."
-msgstr "ད་ལྟོའི་ཚད་འཛིན་བརྗོད་དོན་འདི་གིས་ ཚོས་གཞིའི་འཆར་ལས་ཚུ་རྒྱབ་སྐྱོར་མི་འབད།"
-
-#: ../capplets/appearance/data/appearance.glade.h:57
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "བརྗོད་དོན་ཚུ།"
-
-#: ../capplets/appearance/data/appearance.glade.h:58
-msgid "Toolbar _button labels:"
-msgstr "ལག་ཆས་ཕྲ་རིང་གི་ ཨེབ་རྟའི་ཁ་ཡིག་ཚུ་:\"(_b)"
-
-#. vertical hinting, pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:60
-msgid "VB_GR"
-msgstr "ཝི་བི་ཇི་ཨར།(_G)"
-
-#: ../capplets/appearance/data/appearance.glade.h:61
-msgid "Window Border"
-msgstr "སྒོ་སྒྲིག་གི་མཐའ་མཚམས།"
-
-#: ../capplets/appearance/data/appearance.glade.h:62
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
-msgid "_Add..."
-msgstr "ཁ་སྐོང་རྐྱབས་...(_A)"
-
-#: ../capplets/appearance/data/appearance.glade.h:63
-msgid "_Application font:"
-msgstr "གློག་རིམ་ཡིག་གཟུགས་:(_A)"
-
-#. pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:65
-msgid "_BGR"
-msgstr "བི་ཇི་ཨར།(_B)"
-
-#: ../capplets/appearance/data/appearance.glade.h:66
-msgid "_Copy"
-msgstr "འདྲ་བཤུས།(_C)"
-
-#: ../capplets/appearance/data/appearance.glade.h:67
-msgid "_Description:"
-msgstr "འགྲེལ་བཤད་:(_D)"
-
-#: ../capplets/appearance/data/appearance.glade.h:68
-msgid "_Document font:"
-msgstr "ཡིག་ཆའི་ཡིག་གཟུགས་:(_D)"
-
-#: ../capplets/appearance/data/appearance.glade.h:69
-msgid "_Editable menu shortcut keys"
-msgstr "ཞུན་དག་འབད་བཏུབ་པའི་ དཀར་ཆག་མགྱོགས་འཕྲུལ་གྱི་ལྡེ་མིག་ཚུ(_E)"
-
-#: ../capplets/appearance/data/appearance.glade.h:70
-msgid "_File"
-msgstr "ཡིག་སྣོད།(_F)"
-
-#: ../capplets/appearance/data/appearance.glade.h:71
-msgid "_Fixed width font:"
-msgstr "རྒྱ་ཚད་གཏན་བཟོས་ཡིག་གཟུགས་:(_F)"
-
-#: ../capplets/appearance/data/appearance.glade.h:72
-msgid "_Full"
-msgstr "གང་།(_F)"
-
-#: ../capplets/appearance/data/appearance.glade.h:73
-msgid "_Input boxes:"
-msgstr "ཨིན་པུཊི་སྒྲོམ་ཚུ་:(_I)"
-
-#: ../capplets/appearance/data/appearance.glade.h:74
-msgid "_Install..."
-msgstr "གཞི་བཙུགས་འབད་...(_I)"
-
-#: ../capplets/appearance/data/appearance.glade.h:75
-msgid "_Medium"
-msgstr "འབྲིང་།(_M)"
-
-#: ../capplets/appearance/data/appearance.glade.h:76
-msgid "_Monochrome"
-msgstr "མོ་ནོ་ཀོརོམ།(_M)"
-
-#: ../capplets/appearance/data/appearance.glade.h:77
-msgid "_Name:"
-msgstr "མིང་:(_N)"
-
-#: ../capplets/appearance/data/appearance.glade.h:78
-msgid "_New"
-msgstr "གསརཔ།(_N)"
-
-#: ../capplets/appearance/data/appearance.glade.h:79
-msgid "_None"
-msgstr "ཅི་མེད།(_N)"
-
-#: ../capplets/appearance/data/appearance.glade.h:80
-msgid "_Open"
-msgstr "ཁ་ཕྱེ།(_O)"
-
-#: ../capplets/appearance/data/appearance.glade.h:81
-msgid "_Paste"
-msgstr "སྦྱར།(_P)"
-
-#: ../capplets/appearance/data/appearance.glade.h:82
-msgid "_Print"
-msgstr "དཔར་བསྐྲུན།(_P)"
-
-#: ../capplets/appearance/data/appearance.glade.h:83
-msgid "_Quit"
-msgstr "སྤངས་།(_Q)"
-
-#. pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:85
-msgid "_RGB"
-msgstr "ཨར་ཇི་བི།(_R)"
-
-#: ../capplets/appearance/data/appearance.glade.h:86
-msgid "_Reset to Defaults"
-msgstr "སྔོན་སྒྲིག་ལུ་ བསྐྱར་སྒྲིག་འབད་ (_R)"
-
-#: ../capplets/appearance/data/appearance.glade.h:87
-msgid "_Save"
-msgstr "སྲུངས།(_S)"
-
-#: ../capplets/appearance/data/appearance.glade.h:88
-msgid "_Selected items:"
-msgstr "སེལ་འཐུ་འབད་མི་ རྣམ་གྲངས་ཚུ་:(_S)"
-
-#: ../capplets/appearance/data/appearance.glade.h:89
-msgid "_Size:"
-msgstr "ཚད་: (_S)"
-
-#: ../capplets/appearance/data/appearance.glade.h:90
-msgid "_Slight"
-msgstr "དུམ་གྲ་ཅིག(_S)"
-
-#: ../capplets/appearance/data/appearance.glade.h:91
-msgid "_Style:"
-msgstr "བཟོ་རྣམ་:(_S)"
-
-#: ../capplets/appearance/data/appearance.glade.h:92
-msgid "_Tooltips:"
-msgstr "ལག་ཆས་ཕན་བསླབ: (_T) "
-
-#. vertical hinting, pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:94
-msgid "_VRGB"
-msgstr "ཝི་ཨར་ཇི་བི།(_V)"
-
-#: ../capplets/appearance/data/appearance.glade.h:95
-msgid "_Window title font:"
-msgstr "སྒོ་སྒྲིག་གི་མགོ་མིང་ཡིག་གཟུགས་:(_W)"
-
-#: ../capplets/appearance/data/appearance.glade.h:96
-msgid "_Windows:"
-msgstr "སྒོ་སྒྲིག་ཚུ: (_W)"
-
-#: ../capplets/appearance/data/appearance.glade.h:97
-msgid "dots per inch"
-msgstr "ཨིནཅ་རེ་ལུ་ ཚག་གྲངས།"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr "འབྱུང་སྣང་"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr "ཌེཀསི་ཊོཔ་གི་མཐོང་སྣང་སྲོལ་སྒྲིག་འབད"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr "ཌེཀསི་ཊོཔ་གི་ ཡན་ལག་སོ་སོའི་དོན་ལུ་ བརྗོད་དོན་གྱི་ཐུམ་སྒྲིལ་ཚུ་ གཞི་བཙུགས་འབད་"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr "བརྗོད་དོན་གཞི་བཙུགས་པ་"
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr "ཇི་ནོམ་བརྗོད་དོན་ཐུམ་སྒྲིལ་"
-
-#: ../capplets/appearance/gnome-wp-info.c:45
-msgid "No Wallpaper"
-msgstr "གྱང་ཤོག་མིན་འདུག"
-
-#: ../capplets/appearance/gnome-wp-item.c:207
-msgid "Slide Show"
-msgstr "བཤུད་བརྙན་ "
-
-#. translators: <b>wallpaper name</b>
-#. * mime type, x pixel(s) by y pixel(s)
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:215
-#, c-format
-msgid ""
-"<b>%s</b>\n"
-"%s, %d %s by %d %s\n"
-"Folder: %s"
-msgstr ""
-"<b>%s</b>\n"
-"%s, %d %s by %d %s\n"
-"སྣོད་འཛིན་: %s"
-
-#: ../capplets/appearance/gnome-wp-item.c:221
-#: ../capplets/appearance/gnome-wp-item.c:223
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "པིག་སེལ།"
-msgstr[1] "པིག་སེལསི།"
-
-#: ../capplets/appearance/theme-installer.c:166
-#: ../capplets/appearance/theme-installer.c:216
-msgid "Cannot install theme"
-msgstr "བརྗོད་དོན་ གཞི་བཙུགས་འབད་མ་ཚུགས་ "
-
-#: ../capplets/appearance/theme-installer.c:168
-#, c-format
-msgid "The %s utility is not installed."
-msgstr "%s སྤྱོད་ཆས་འདི་ གཞི་བཙུགས་མ་འབད་ནུག།"
-
-#: ../capplets/appearance/theme-installer.c:218
-msgid "There was a problem while extracting the theme."
-msgstr "བརྗོད་དོན་འདི་ཕྱིར་འདོན་འབད་བའི་སྐབས་ དཀའ་ངལ་ཅིག་འདུག།"
-
-#: ../capplets/appearance/theme-installer.c:241
-msgid "There was an error installing the selected file"
-msgstr "སེལ་འཐུ་འབད་ཡོད་པའི་ཡིག་སྣོད་ གཞི་བཙུགས་འབད་བའི་སྐབས་ འཛོལ་བ་ཅིག་འབྱུང་ནུག་ "
-
-#: ../capplets/appearance/theme-installer.c:242
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme."
-msgstr "\"%s\" དེ་ ནུས་ཅན་གྱི་བརྗོད་དོན་ཅིག་སྦེ་ མི་འབྱུང་མས། "
-
-#: ../capplets/appearance/theme-installer.c:243
-#, c-format
-msgid ""
-"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
-"you need to compile."
-msgstr ""
-"\"%s\" དེ་ནུས་ཅན་གྱི་བརྗོད་དོན་ཅིག་སྦེ་ མི་འབྱུང་མས། འདི་ཡང་ཅིན་ ཕྱོགས་སྒྲིག་འབད་དགོ་པའི་ བརྗོད་དོན་ "
-"མ་འཕྲུལ་ཅིག་ཨིནམ་འོང་། "
-
-#: ../capplets/appearance/theme-installer.c:282
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "ཇི་ནོམ་བརྗོད་དོན་%s ངེས་བདེན་སྦེ་ གཞི་བཙུགས་འབད་ནུག།"
-
-#: ../capplets/appearance/theme-installer.c:342
-#, c-format
-msgid "Installation for theme \"%s\" failed."
-msgstr "བརྗོད་དོན་ \"%s\" གི་དོན་ལུ་ གཞི་བཙུགས་འཐུས་ཤོར་འབྱུང་ཡོདཔ། "
-
-#: ../capplets/appearance/theme-installer.c:374
-#, c-format
-msgid "The theme \"%s\" has been installed."
-msgstr "བརྗོད་དོན་ \"%s\" འདི་ གཞི་བཙུགས་འབད་ཡོད།"
-
-#: ../capplets/appearance/theme-installer.c:380
-msgid "Would you like to apply it now, or keep your current theme?"
-msgstr "ཁྱོད་ཀྱིས་ད་ལྟོ་འཇུག་སྤྱོད་འབད་ཨིན་ན་ ཡང་ན་ཁྱོད་རའི་ད་ལཏོའི་བརྗོད་དོན་བཞག་ནི་ཨིན་ན?"
-
-#: ../capplets/appearance/theme-installer.c:382
-msgid "Keep Current Theme"
-msgstr "ད་ལྟོའི་བརྗོད་དོན་བཞག།"
-
-#: ../capplets/appearance/theme-installer.c:384
-msgid "Apply New Theme"
-msgstr "བརྗོད་དོན་གསརཔ་འཇུག་སྤྱོད་འབད།"
-
-#: ../capplets/appearance/theme-installer.c:486
-msgid "Failed to create temporary directory"
-msgstr "གནས་སྐབས་ཅིག་གི་སྣོད་ཐོ་ གསར་བསྐྲུན་འབད་མ་ཚུགས།"
-
-#: ../capplets/appearance/theme-installer.c:546
-msgid "New themes have been successfully installed."
-msgstr "བརྗོད་དོན་གསརཔ་ཚུ་ མཐར་འཁྱོལ་ཅན་སྦེ་ གཞི་བཙུགས་འབད་ནུག། "
-
-#: ../capplets/appearance/theme-installer.c:573
-msgid "No theme file location specified to install"
-msgstr "གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ ཡིག་སྣོད་ཀྱི་གནས་ཁོངས་ ངོས་འཛིན་མ་འབད་བས།"
-
-#: ../capplets/appearance/theme-installer.c:593
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"བརྗོད་དོན་གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ གནང་བ་ལངམ་མིན་འདུག\n"
-"%s"
-
-#: ../capplets/appearance/theme-installer.c:615
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-"%sའདི་ བརྗོད་དོན་གྱི་ཡིག་སྣོད་ཚུ་ གཞི་བཙུགས་འབད་སའི་འགྲུལ་ལམ་ཨིན། འདི་འབྱུང་ཁུངས་ཀྱི་ གནས་ཁོངས་འབད་ "
-"སེལ་འཐུ་འབད་མི་ཚུགས།"
-
-#: ../capplets/appearance/theme-installer.c:683
-msgid "Select Theme"
-msgstr "བརྗོད་དོན་སེལ་འཐུ་འབད"
-
-#: ../capplets/appearance/theme-installer.c:687
-msgid "Theme Packages"
-msgstr "བརྗོད་དོན་ཐུམ་སྒྲིལ་ཚུ"
-
-#: ../capplets/appearance/theme-save.c:91
-#, c-format
-msgid "Theme name must be present"
-msgstr "བརྗོད་དོན་གྱི་མིང་ ངེས་པར་ཡོད་དགོ"
-
-#: ../capplets/appearance/theme-save.c:161
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "བརྗོད་དོན་དེ་ ཧེ་མ་ལས་རང་འདུག ཁྱོད་ཀྱིས་དེ་གི་ཚབ་མ་ བཙུགས་ནི་ཨིན་ན།"
-
-#: ../capplets/appearance/theme-save.c:162
-msgid "_Overwrite"
-msgstr "ཚབ་སྲུང་ (_O)"
-
-#: ../capplets/appearance/theme-util.c:69
-msgid "Would you like to delete this theme?"
-msgstr "ཁྱོད་ཀྱིས་ བརྗོད་དོན་འདི་ རྩ་བསྐྲད་གཏང་ནི་ཨིན་ན?"
-
-#: ../capplets/appearance/theme-util.c:121
-msgid "Theme cannot be deleted"
-msgstr "བརྗོད་དོན་བཏོན་གཏང་མི་ཚུགས་པས"
-
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་ ‘ཇི་ནོམ་-གཞི་སྒྲིག་-ཌེ་མཱོན་’ འགོ་བཙུགས་མི་ཚུགས་པས། \n"
-"ཇི་ནོམ་གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་ ལཱ་གཡོག་བཀོལ་ཏེ་མེད་པ་ཅིན་ དགའ་གདམ་ལ་ལོ་ཅིག་ལུ་ ནུས་པ་འཐོབ་མི་ཚུགས། "
-"འདི་གིས་བོ་ནོ་བོ་ལུ་ དཀའ་ངལ་ཅིག་ འབྱུང་སྲིད་ནི་ཨིན་མི་དེ་ཡང་ ཇི་ནོམ་མེན་པའི་ གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་"
-"(དཔེར་ན་ ཀེ་ཌི་ཨི) ལྟ་བུ་ ཤུགས་ལྡན་ཨིན་པའི་ཐོག་ལས་ ཇི་ནོམ་གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་དང་ མི་མཐུནམ་འབྱུང་དོ་"
-"ཡོདཔ་འོང་།"
-
-#: ../capplets/common/capplet-stock-icons.c:67
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "ཅ་མཛོད་ཀྱི་ངོས་དཔར་'%s'མངོན་གསལ་འབད་མ་ཚུགས། \n"
-
-#: ../capplets/common/capplet-util.c:240 ../capplets/common/capplet-util.c:242
-msgid "Just apply settings and quit"
-msgstr "གཞི་སྒྲིག་ཚུ་ འཇུག་སྤྱོད་ཙམ་འབད་དེ་སྤངས་།"
-
-#: ../capplets/common/capplet-util.c:244
-#: ../capplets/keyboard/gnome-keyboard-properties.c:261
-#: ../capplets/sound/sound-properties-capplet.c:1030
-msgid "Retrieve and store legacy settings"
-msgstr "སྔོན་བཤུལ་གྱི་གཞི་སྒྲིག་ཚུ་ སླར་འདྲེན་འབད་དེ་ གསོག་འཇོག་འབད།"
-
-#: ../capplets/common/capplet-util.c:344
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "གྲོགས་རམ་%sབཀྲམ་སྟོན་འབད་ནི་ལུ་ འཛོལ་བ་ཅིག་བྱུང་ནུག"
-
-#: ../capplets/common/file-transfer-dialog.c:84
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "ཡིག་སྣོད་%u ལས་%uའདྲ་བཤུས་རྐྱབ་དོ།"
-
-#: ../capplets/common/file-transfer-dialog.c:132
-#, c-format
-msgid "Copying '%s'"
-msgstr "'%s' འདྲ་བཤུས་རྐྱབ་དོ།"
-
-#: ../capplets/common/file-transfer-dialog.c:172
-#: ../capplets/common/file-transfer-dialog.c:298
-msgid "Copying files"
-msgstr "ཡིག་སྣོད་འདྲ་བཤུས་རྐྱབ་དོ།"
-
-#: ../capplets/common/file-transfer-dialog.c:207
-msgid "Parent Window"
-msgstr "རྩ་ལག་སྒོ་སྒྲིག་"
-
-#: ../capplets/common/file-transfer-dialog.c:208
-msgid "Parent window of the dialog"
-msgstr "ཌའི་ལོག་འདི་གི་ རྩ་ལག་སྒོ་སྒྲིག་"
-
-#: ../capplets/common/file-transfer-dialog.c:214
-msgid "From URI"
-msgstr "ཡུ་ཨར་ཨའི་ལས།"
-
-#: ../capplets/common/file-transfer-dialog.c:215
-msgid "URI currently transferring from"
-msgstr "ཡུ་ཨར་ཨའི་ ད་ལྟོ་ག་ཏེ་ལས་ གནས་སོར་གཏང་དོ།"
-
-#: ../capplets/common/file-transfer-dialog.c:222
-msgid "To URI"
-msgstr "ཡུ་ཨར་ཨའི་ལུ།"
-
-#: ../capplets/common/file-transfer-dialog.c:223
-msgid "URI currently transferring to"
-msgstr "ཡུ་ཨར་ཨའི་ ད་ལྟོ་གནས་སོར་གཏང་ཡུལ།"
-
-#: ../capplets/common/file-transfer-dialog.c:230
-msgid "Fraction completed"
-msgstr "ཆ་ཤས་ཡོངས་སྒྲུབ།"
-
-#: ../capplets/common/file-transfer-dialog.c:231
-msgid "Fraction of transfer currently completed"
-msgstr "གནས་སོར་གྱི་ཆ་ཤས་ ད་ལྟོ་ཡོངས་སྒྲུབ་འབད་ཡི།"
-
-#: ../capplets/common/file-transfer-dialog.c:238
-msgid "Current URI index"
-msgstr "ད་ལྟོའི་ཡུ་ཨར་ཨའི་གི་ཟུར་ཐོ།"
-
-#: ../capplets/common/file-transfer-dialog.c:239
-msgid "Current URI index - starts from 1"
-msgstr "ད་ལྟོའི་ཡུ་ཨར་ཨའི་གི་ཟུར་ཐོ་ - ༡ ལས་འགོ་བཙུགསཔ་ཨིན།"
-
-#: ../capplets/common/file-transfer-dialog.c:246
-msgid "Total URIs"
-msgstr "ཡུ་ཨར་ཨའི་བསྡོམས།"
-
-#: ../capplets/common/file-transfer-dialog.c:247
-msgid "Total number of URIs"
-msgstr "ཡུ་ཨར་ཨའི་གི་གྱངས་ཁ་ཡོངས་བསྡོམས།"
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "ལྡེ་མིག"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr "རྒྱུ་དངོས་ཀྱི་ཞུན་དགཔ་ མཉམ་སྦྲགས་ཡོད་པའི་ ཇི་ཀཱོནཕ་གི་ལྡེ་མིག"
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr "ཀཱལ་བེཀ།"
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "ལྡེ་མིག་དང་མཉམ་འབྲེལ་ཡོད་པའི་བེ་ལུ་དེ་ བསྒྱུར་བཅོས་འགྱོ་བའི་སྐབས་ ཀཱལ་བེཀ་འདི་སྤྲོད།"
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr "་ཆ་ཚན་བསྒྱུར་བཅོས་འབད"
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"ཇི་ཀཱོནཕ་གི་ ཡོངས་འབྲེལ་ཡན་ལག་ འཇུག་སྤྱོད་ལུ་གཏང་ནིའི་ གནད་སྡུད་ཡོད་པའི་ ཇི་ཀཱོནཕ་གི་བསྒྱུར་བཅོས་ཆ་ཚན།"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr "ཝི་གེཊི་ ཀཱལ་བེཀ་ལུ་ གཞི་བསྒྱུར།"
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "གནད་སྡུད་ཚུ་ ཇི་ཀཱོནཕ་ལས་ ཝི་གེཊི་ལུ་ གཞི་བསྒྱུར་འབད་དགོ་པའི་སྐབས་ སྤྲོད་ནིའི་ཀཱལ་བེཀ།"
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr "ཝི་གེཊི་ཀཱལ་བེཀ་ལས་གཞི་བསྒྱུར།"
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"གནད་སྡུད་ཚུ་ ཝི་གེཊི་ནང་ལས་ ཇི་ཀཱོནཕ་ནང་ལུ་ གཞི་བསྒྱུར་འབད་དགོ་པའི་སྐབས་ སྤྲོད་དགོ་པའི་ཀཱལ་བེཀ།"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr "ཡུ་ཨའི་ཚད་འཛིན།"
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr "རྒྱུ་དངོས་ཚད་འཛིན་འབད་མི་དངོས་པོ། (སྤྱིར་བཏང་ལུ་ཝི་གེཊི་ཅིག)"
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr "རྒྱུ་དངོས་ཞུན་དག་པའི་ དངོས་པོའི་གནད་སྡུད།"
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr "དམིགས་བསལ་གྱི་ རྒྱུ་དངོས་ཞུན་དགཔ་ལུ་དགོ་མི་ སྲོལ་སྒྲིག་གི་གནད་སྡུད།།"
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr "རྒྱུ་དངོས་ཞུན་དག་པའི་གནད་སྡུད་ཀྱིས་ ཀཱལ་བེཀ་ཐར་གཏང་པའི་བསྒང་།"
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr "རྒྱུ་དངོས་ཞུན་དག་པའི་ དངོས་པོའི་གནད་སྡུད་ ཐར་དགོ་པའི་སྐབས་ སྤྲོད་ནིའི་ཀཱལ་བེཀ།"
-
-#: ../capplets/common/gconf-property-editor.c:1467
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"ཡིག་སྣོད་'%s'འཚོལ་མ་ཐོབ།\n"
-"\n"
-"ཚར་ཅིག་ཕྱིར་བཏོན་འབད་ཞིནམས་ལས་ ལོག་སྟེ་འབད་རྩོལ་བསྐྱེད་གནང་། ཡང་ཅིན་ རྒྱབ་གཞིའི་པར་ གཞན་མི་ཅིག་ "
-"གདམ་ཁ་རྐྱབས།"
-
-#: ../capplets/common/gconf-property-editor.c:1475
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"ང་གིས་ཡིག་སྣོད་'%s' ཁ་ཕྱེ་མ་ཤེས།\n"
-"རྒྱབ་སྐྱོར་མེད་པའི་པར་ཅིག་ འོང་ནི་འདྲ་བས།\n"
-"\n"
-"དེ་གི་ཚབ་ལུ་ པར་གཞན་མི་ཅིག་སེལ།"
-
-#: ../capplets/common/gconf-property-editor.c:1594
-msgid "Please select an image."
-msgstr "གཟུགས་བརྙན་ཅིག་སེལ་འཐུ་འབད།"
-
-#: ../capplets/common/gconf-property-editor.c:1599
-msgid "_Select"
-msgstr "སེལ་འཐུ་འབད།(_S)"
-
-#: ../capplets/common/gnome-theme-info.c:639
-msgid "Default Pointer - Current"
-msgstr "སྔོན་སྒྲིག་དཔག་བྱེད་-ད་ལྟོའི་།"
-
-#: ../capplets/common/gnome-theme-info.c:643
-msgid "White Pointer"
-msgstr "དཔག་བྱེད་དཀརཔོ།"
-
-#: ../capplets/common/gnome-theme-info.c:644
-msgid "White Pointer - Current"
-msgstr "དཔག་བྱེད་དཀརཔོ་-ད་ལྟོའི་།"
-
-#: ../capplets/common/gnome-theme-info.c:648
-msgid "Large Pointer"
-msgstr "དཔག་བྱེད་ཆེ་བ།"
-
-#: ../capplets/common/gnome-theme-info.c:649
-msgid "Large Pointer - Current"
-msgstr "དཔག་བྱེད་ཆེ་བ་-ད་ལྟོའི།"
-
-#: ../capplets/common/gnome-theme-info.c:653
-msgid "Large White Pointer - Current"
-msgstr "དཔག་བྱེད་དཀརཔོ་ཆེ་བ་-ད་ལྟོའི།"
-
-#: ../capplets/common/gnome-theme-info.c:654
-msgid "Large White Pointer"
-msgstr "དཔག་བྱེད་དཀརཔོ་ཆེ་བ།"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Preferred Applications"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
+msgstr "<b>གློག་རིམ་</b>"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
 msgstr "དགའ་གདམ་ཅན་གྱི་གློག་རིམ།"
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "ཁྱོད་རའི་སྔོན་སྒྲིག་གློག་རིམ་ སེལ་འཐུ་འབད།"
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Start the preferred visual assistive technology"
-msgstr "དགའ་གདམ་བརྐྱབས་ཡོད་པའི་ མཐོང་བའི་ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་གཡོག་བཀོལ་ "
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr "མཐོང་བའི་ ཕན་ཐབས་ "
-
-#: ../capplets/default-applications/gnome-da-capplet.c:80
-#: ../capplets/default-applications/gnome-da-capplet.c:112
-#: ../capplets/default-applications/gnome-da-capplet.c:133
-#: ../capplets/default-applications/gnome-da-capplet.c:177
-#: ../capplets/default-applications/gnome-da-capplet.c:222
-#: ../capplets/default-applications/gnome-da-capplet.c:279
-#: ../capplets/default-applications/gnome-da-capplet.c:330
-#: ../capplets/default-applications/gnome-da-capplet.c:381
-#: ../capplets/default-applications/gnome-da-capplet.c:434
-#: ../capplets/default-applications/gnome-da-capplet.c:484
-#: ../capplets/default-applications/gnome-da-capplet.c:877
-#: ../capplets/default-applications/gnome-da-capplet.c:899
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "རིམ་སྒྲིག་%sབསྲུང་ནི་ལུ་འཛོལ་བ། "
-
-#: ../capplets/default-applications/gnome-da-capplet.c:1100
-msgid "Could not load the main interface"
-msgstr "ངོས་འདྲ་བ་ངོ་མ་ མངོན་གསལ་འབད་མ་ཚུགས།"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:1102
-msgid "Please make sure that the applet is properly installed"
-msgstr "ཨེཔ་ལེཊི་དེ་ ངེས་བདེན་སྦེ་ གཞི་བཙུགས་འབད་ཡོདཔ་ ངེས་གཏན་བཟོ།"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Image Viewer</b>"
-msgstr "<b>གཟུགས་བརྙན་མཐོང་བྱེད་</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Instant Messenger</b>"
-msgstr "<b>འཕྲལ་མྱུར་འཕྲིན་སྐྱེལ་པ།</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Mail Reader</b>"
-msgstr "<b>ཡིག་འཕྲིན་ལྷག་མི་</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mobility</b>"
-msgstr "<b> ལས་གཡོག </b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Multimedia Player</b>"
-msgstr "<b>སྣ་མང་བརྡ་ལམ་གྱི་གཏང་འཕྲུལ་</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>ཊར་མི་ནཱལ་ ནུས་འཕྲུལ་</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Text Editor</b>"
-msgstr "<b>ཚིག་ཡིག་ཞུན་དགཔ་</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Video Player</b>"
-msgstr "<b>ཝི་ཌིའོ་གཏང་འཕྲུལ་</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "<b>Visual</b>"
-msgstr "<i>མཐོང་བའི</i>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "<b>Web Browser</b>"
-msgstr "<b>ཝེབ་ བརའུ་ཟར།</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
-msgid "Accessibility"
-msgstr "འཛུལ་སྤྱོད"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "འབྱུང་བ་%sཆ་མཉམ་གྱི་ཚབ་ལུ་ འབྲེལ་ལམ་ངོ་མ་བཙུགས་ནི་ཨིན།"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "C_ommand:"
-msgstr "བརྡ་བཀོད་:(_O)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Co_mmand:"
-msgstr "བརྡ་བཀོད་:(_m)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "E_xecute flag:"
-msgstr "ཟུར་རྟགས་ལག་ལེན་འཐབ་:(_x)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Internet"
-msgstr "ཨིན་ཊར་ནེཊི།"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Multimedia"
-msgstr "སྣ་མང་བརྡ་ལམ།"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Open link in new _tab"
-msgstr "འབྲེལ་ལམ་མཆོང་ལྡེ་གསར་པའི་ནང་ཁ་ཕྱེ།(_t)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "Open link in new _window"
-msgstr "འབྲེལ་ལམ་སྒོ་སྒྲིག་གསར་པའི་ནང་ཁ་ཕྱེ།(_w)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid "Open link with web browser _default"
-msgstr "འབྲེལ་ལམ་ཝེབ་བརའུ་ཟར་སྔོན་སྒྲིག་ཐོག་ལསཁ་ཕྱེ།"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Run at st_art"
-msgstr "འགོ་བཙུགས་སར་གཡོག་བཀོལ(_a)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Run in t_erminal"
-msgstr "ཊར་མི་ནཱལ་ཅིག་ནང་གཡོག་བཀོལ།(_e)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "System"
-msgstr "རིམ་ལུགས།"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "_Run at start"
-msgstr "འགོ་བཙུགས་སར་གཡོག་བཀོལ  (_R)"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "བཱལ་ས།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr "བཱན་ཤི་སྙན་ཆ་གཏང་་འཕྲུལ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr "ཀལོསི་ ཡིག་འཕྲིན་"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr "ཌེ་ཤར"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr "ཌེ་བི་ཡཱན་ ཚོར་ཅན་གྱི་ བརའུ་ཟར།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr "ཌེ་བི་ཡཱན་ ཊར་མི་ནཱལ་ ནུས་འཕྲུལ།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr "ཨི་ཊམ།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr "བརྒལ་བ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr "ཨི་པི་ཕ་ནི་ ཝེབ་བརའུ་ཟར།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr "ཕའེར་བཌི།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Firefox"
-msgstr "ཕའེར་ཕོགསི།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr "ཇི་ནོམ་ཆེ་ཤེལ་གསལ་གཞི་ལྷག་མི་མེད་པ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr "གསལ་གཞི་ལྡེ་སྒྲོམ་གུ་ཇི་ནོམ།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr "ཇི་ནོམ་ ཊར་མི་ནཱལ།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Galeon"
-msgstr "གེ་ལིའོན།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Gnopernicus"
-msgstr "ཇི་ནོ་པར་་ནི་ཀཱསི"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Gnopernicus with Magnifier"
-msgstr "ཇི་ནོ་པར་་ནི་ཀཱསི་ཆེ་ཤེལ་དང་བཅས"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Iceape"
-msgstr "ཨའིསི་ཨེཔ་ "
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Iceape Mail"
-msgstr "ཨའིསི་ཨེཔ་ ཡིག་འཕྲིན"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Icedove"
-msgstr "ཨའིསི་ཌོབ་"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Iceweasel"
-msgstr "ཨའིསི་ཝི་སེལ་"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr "ཀེ་ཌི་ཨི་ཆེ་ཤེལ་གསལ་གཞི་ལྷག་མི་མེད་པ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr "ཀེ་མེལ།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr "ཀོང་ཀུ་རར།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Konsole"
-msgstr "ཀཱན་སཱོལ་ "
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr "ལའི་ནགསི་གསལ་གཞི་ལྷག་མི"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr "ལའི་ནགསི་གསལ་གཞི་ལྷག་མི་ཆེ་ཤེལ་དང་བཅས"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Midori"
-msgstr "མི་ཌོ་རི་ "
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Mozilla"
-msgstr "མོ་ཛི་ལ།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Mozilla 1.6"
-msgstr "མོ་ཛི་ལ་༡.༦།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Mozilla Mail"
-msgstr "མོ་ཛི་ལ་ ཡིག་འཕྲིན།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Mozilla Thunderbird"
-msgstr "མོ་ཛི་ལ་ ཐཱན་ཌར་བཌི།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Muine Music Player"
-msgstr "མུའིནི་སྙན་ཆ་གཏང་འཕྲུལ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Mutt"
-msgstr "མཱཊི།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "NXterm"
-msgstr "ཨེན་ཨེགསི་ཊམ།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-msgid "Netscape Communicator"
-msgstr "ནེཊི་སིཀེཔ་ བརྡ་སྤྲོད་པ།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Opera"
-msgstr "ཨོ་པི་ར།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Orca"
-msgstr "ཨོར་ཀ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca with Magnifier"
-msgstr "ཆེ་ཤེལ་ཨོར་ཀ་དག་བཅསཔ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "RXVT"
-msgstr "ཨར་ཨེགསི་ཝི་ཊི།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-msgid "Rhythmbox Music Player"
-msgstr "སྒྲ་དབྱངས་སྒྲོམ་གྱི་སྙན་ཆ་གཏང་འཕྲུལ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-msgid "SeaMonkey"
-msgstr "སི་མོན་ཀི"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-msgid "SeaMonkey Mail"
-msgstr "སི་མོན་ཀི་གི་ཡིག་འཕྲིན"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-msgid "Standard XTerminal"
-msgstr "ཚད་ལྡན་གྱི་ ཨེགསི་ཊར་མི་ནཱལ།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Sylpheed"
-msgstr "སིལ་ཕིཊི།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-msgid "Sylpheed-Claws"
-msgstr "སིལ་ཕིཊི་-ཀྭ་ལཱསི།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-msgid "Terminator"
-msgstr "རྩ་གྲོལ་གཏང་མི་ "
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Thunderbird"
-msgstr "ཐཱན་ཌར་བཌི།"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Totem Movie Player"
-msgstr "ཊོ་ཊེམ་གློག་བརྙེན་གཏང་འཕྲུལ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "aterm"
-msgstr "ཨེ་ཊམ།"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "གསལ་གཞིའི་ཧུམ་ཆ་ བསྒྱུར་བཅོས་འབད།"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "གསལ་གཞིའི་ཧུམ་ཆ།"
-
-#: ../capplets/display/main.c:29
-msgid "Normal"
-msgstr "སྤྱིར་བཏང་"
-
-#: ../capplets/display/main.c:30
-msgid "Left"
-msgstr "གཡོན"
-
-#: ../capplets/display/main.c:31
-msgid "Inverted"
-msgstr "གནས་ལོག་འབད་ཡོདཔ"
-
-#: ../capplets/display/main.c:32
-msgid "Right"
-msgstr "གཡས"
-
-#: ../capplets/display/main.c:374
-#, c-format
-msgid "%d Hz"
-msgstr "ཨེཆ་ཛེཌི %d "
-
-#: ../capplets/display/main.c:514
-msgid "_Resolution:"
-msgstr "ཧུམ་ཆ་:(_R)"
-
-#: ../capplets/display/main.c:532
-msgid "Re_fresh rate:"
-msgstr "ཡང་སེལ་གྱི་མགྱོགས་ཚད་:(_f)"
-
-#: ../capplets/display/main.c:550
-msgid "R_otation:"
-msgstr "སྐོར་རྐྱབ་:(_o)"
-
-#: ../capplets/display/main.c:569
-msgid "Default Settings"
-msgstr "སྔོན་སྒྲིག་གཞི་སྒྲིག་ཚུ།"
-
-#: ../capplets/display/main.c:571
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr "གསལ་གཞི་%dགི་ གཞི་སྒྲིག་ཚུ།\n"
-
-#: ../capplets/display/main.c:593
-msgid "Screen Resolution Preferences"
-msgstr "གསལ་གཞི་ཧུམ་ཆའི་དགའ་གདམ་ཚུ།"
-
-#: ../capplets/display/main.c:628
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "གློག་རིག་(%s)འདི་གི་དོན་ལུ་རྐྱངམ་གཅིག་ སྔོན་སྒྲིག་འབད།(_M)"
-
-#: ../capplets/display/main.c:648
-msgid "Options"
-msgstr "གདམ་ཁ་ཚུ།"
-
-#: ../capplets/display/main.c:668
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"གཞི་སྒྲིག་གསརཔ་ཚུ་ལུ་ བརྟག་ཞིབ་འབད་དོ། ཁྱོད་ཀྱིས་སྐར་ཆ་%dགི་ནང་འཁོད་ ངོས་ལན་མ་བྱིན་པ་ཅིན་ ཧེ་མའི་"
-"གཞི་སྒྲིག་ཚུ་ སོར་ཆུད་འབད་འོང་།"
-msgstr[1] ""
-"གཞི་སྒྲིག་གསརཔ་ཚུ་ལུ་ བརྟག་ཞིབ་འབད་དོ། ཁྱོད་ཀྱིས་སྐར་ཆ་%dགི་ནང་འཁོད་ ངོས་ལན་མ་བྱིན་པ་ཅིན་ ཧེ་མའི་"
-"གཞི་སྒྲིག་ཚུ་ སོར་ཆུད་འབད་འོང་།"
-
-#: ../capplets/display/main.c:708
-msgid "Keep Resolution"
-msgstr "ཧུམ་ཆ་བདག་འཛིན་འབད་བཞག"
-
-#: ../capplets/display/main.c:712
-msgid "Do you want to keep this resolution?"
-msgstr "ཁྱོད་ཀྱིས་ཧུམ་ཆ་འདི་ བདག་འཛིན་འབད་བཞག་ནི་ཨིན་ན?"
-
-#: ../capplets/display/main.c:738
-msgid "Use _Previous Resolution"
-msgstr "ཧེ་མའི་ཧུམ་ཆ་ ལག་ལེན་འཐབ་ (_p)"
-
-#: ../capplets/display/main.c:739
-msgid "_Keep Resolution"
-msgstr "ཧུམ་ཆ་ བདག་འཛིན་འབད་བཞག་(_k)"
-
-#: ../capplets/display/main.c:888
-msgid ""
-"The X server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"ཨེགསི་སར་བར་དེ་གིས་ XRandR རྒྱ་བསྐྱེད་ལུ་ རྒྱབ་སྐྱོར་མི་འབད་བས།  གཡོག་བཀོལ་དུས་ཚོད་ཀྱི་ ཧུམ་ཆའི་བསྒྱུར་"
-"བཅོས་ཚུ་ བཀྲམ་སྟོན་འབད་ནིའི་ཚད་གུ་ མི་འཐོབ་པས།"
-
-#: ../capplets/display/main.c:895
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"XRandR རྒྱ་བསྐྱེད་ཀྱི་ཐོན་རིམ་དེ་ ལས་རིམ་འདི་དང་མཐུན་འགྱུར་མིན་འདུག གཡོག་བཀོལ་དུས་ཚོད་ཀྱི་ བསྒྱུར་བཅོས་"
-"ཚུ་ བཀྲམ་སྟོན་འབད་ནིའི་ཚད་གུ་ མི་འཐོབ་པས།"
-
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
-msgstr "སྒྲ་སྐད།"
-
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-msgid "Desktop"
-msgstr "ཌེཀསི་ཊོཔ།"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "མགྱོགས་འཕྲུལ་གསརཔ་..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "མགྱོགས་འཕྲུལ་ལྡེ་མིག"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "མགྱོགས་འཕྲུལ་ལེགས་བཅོས་པ།"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "མགྱོགས་འཕྲུལ་ལྡེ་ཨང་།"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "མགྱོགས་འཕྲུལ་གྱི་ཐབས་ལམ།"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "མགྱོགས་འཕྲུལ་གྱི་དབྱེ་བ།"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:106
-#: ../typing-break/drwright.c:483
-msgid "Disabled"
-msgstr "ལྕོགས་མིན།"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:517
-msgid "<Unknown Action>"
-msgstr "<མ་ཤེས་པའི་བྱ་བ་>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:909
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time.\n"
-msgstr ""
-"མགྱོགས་ཐབས་\"%s\"དེ་ ལག་ལེན་འཐབ་མི་བཏུབ། ག་ཅི་སྦེ་ཟེར་བ་ཅིན་ ལྡེ་མིག་འདི་ལག་ལེན་འཐབ་དང་ ཡིག་"
-"དཔར་བརྐྱབ་མི་འགྱུརཝ་ཨིན།\n"
-"ཚད་འཛིན་ གདམ་ལྡེ་ཡང་ན་ སོར་ལྡེ་ཚུ་ དུས་མཉམ་ལུ་ཨེབ་སྟེ་ འབད་རྩོལ་བསྐྱེད་གནང་།\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:938
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-msgstr ""
-"མགྱོགས་ཐབས་\"%s\" དེ་ ཧེ་མ་ལས་རང་ ལག་ལེན་འཐབ་ནུག\n"
-" \"%s\"\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:970
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr "རིམ་སྒྲིག་གནད་སྡུད་གཞི་རྟེན་ %sནང་ མགྱོགས་འཕྲུལ་གསརཔ་ གཞི་སྒྲིག་འབད་ནི་ལུ་འཛོལ་བ།\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1022
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr "རིམ་སྒྲིག་གནད་སྡུད་གཞི་རྟེན་ %sནང་ མགྱོགས་འཕྲུལ་གསརཔ་ སྒྲིག་བཤོལ་འབད་ནི་ལུ་འཛོལ་བ། \n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1153
-msgid "Action"
-msgstr "བྱ་བ།"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1177
-msgid "Shortcut"
-msgstr "མགྱོགས་ཐབས།"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "ལྡེ་སྒྲོམ་གྱི་མགྱོགས་ཐབས།"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
-msgstr ""
-"མགྱོགས་ཐབས་ཅིག་ ཞུན་དག་བརྐྱབ་ནི་ལུ་ ཆ་མཚུངས་པའི་གྲལ་ཐིག་ལུ་ ཨེབ་གཏང་འབད་ཞིནམས་ལས་ མགྱོགས་འཕྲུལ་"
-"གསརཔ་ཅིག་ ཡིག་དཔར་རྐྱབས། ཡང་ན་ བསལ་་ནིའི་དོན་ལུ་ རྒྱབ་བཤུད་ལུ་ཨེབ།"
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "བརྡ་བཀོད་ཚུ་ལུ་ མགྱོགས་ཐབས་ལྡེ་མིག་ འགན་སྤྲོད་འབད།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:253
-#: ../capplets/keyboard/gnome-keyboard-properties.c:258
-#: ../capplets/sound/sound-properties-capplet.c:1026
-#: ../capplets/sound/sound-properties-capplet.c:1028
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-"གཞི་སྒྲིག་ཙམ་འཇུག་སྤྱོད་འབད་དེ་སྤངས། (མཐུན་འགྱུར་རྐྱངམ་གཅིག་ ད་ལྟོ་ཌེ་མཱོན་གྱིས་ ལེགས་སྐྱོང་འཐབ་ནུག)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:265
-msgid "Start the page with the typing break settings showing"
-msgstr "ཤོག་ལེབ་དེ་ ཡིག་དཔར་བརྐྱབ་ནིའི་བར་མཚམས་གཞི་སྒྲིག་ཚུ་ སྟོནམ་དང་བཅསཔ་སྦེ་ འགོ་བཙུགས།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:270
-msgid "Start the page with the accessibility settings showing"
-msgstr "ཤོག་ལེབ་དེ་ འཛུལ་སྤྱོད་གཞི་སྒྲིག་ཚུ་ སྟོནམ་ཐོག་ལས་ འགོ་བཙུགས།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:279
-msgid "- GNOME Keyboard Preferences"
-msgstr "- ཇི་ནོམ་ལྡེ་སྒྲོམ་གྱི་དགའ་གདམ་ཚུ་"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-msgid "<b>Bounce Keys</b>"
-msgstr "<b>ལྡེ་མིག་ཚུ་ ཡར་འཕར་བཟོ་</b>(_u)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>འོད་རྟགས་འགུལ་སྤར་འབད་དོ་</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "<b>General</b>"
-msgstr "<b>ཡོངས་ཁྱབ་</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>ལྡེ་མིག་ཚུ་ཡང་བསྐྱར་འབད་</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Slow Keys</b>"
-msgstr "<b>Slow Keys</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>Sticky Keys</b>"
-msgstr "<b>སྦྱར་རྩི་ལྡེ་མིག་ཚུ་ </b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<b>ཡིག་དཔར་གྱི་བར་མཚམས་ ལག་ལེན་འཐབ་ནིའི་དོན་ལུ་ གསལ་གཞི་ལྡེ་མིག་རྐྱབས་</b>(_L)"
-
-#. fast acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>མགྱོགས་པར</i></small>"
-
-#. long delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>རིངམོ་</i></small>"
-
-#. short delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>ཐུང་ཀུ་</i></small>"
-
-#. slow acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>ལྷོད་ཆ་</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "A_cceleration:"
-msgstr "མགྱོགས་སྤྱོད་: (_A)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "All_ow postponing of breaks"
-msgstr "བར་མཚམས་ཚུ་ བསྣར་བཞག་འབད་བཅུག(_o)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Beep when _accessibility features are turned on or off"
-msgstr "ཁྱད་རྣམ་དེ་ཚུ་  ཨཱོན་དང་ཨོཕ་འགྱོ་བའི་སྐབས་ བརྡ་སྐད་རྐྱབས།( _F)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Beep when a _modifier key is pressed"
-msgstr "ལེགས་བཅོས་འབད་མི་ལྡེ་མིག་ཅིག་ཨེབ་པའི་སྐབས་ བརྡ་སྐད་རྐྱབས་  (_M)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Beep when a _toggle key is pressed"
-msgstr "སོར་སྟོན་ལྡེ་མིག་ཅིག་ གཡེབ་པའི་སྐབས་ བརྡ་སྐད་སྟོན་(_M)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Beep when a key is pr_essed"
-msgstr "ལྡེ་མིག་ ཨེབ་པའི་སྐབས་ བརྡ་སྐད་རྐྱབས་(_E)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Beep when a key is reje_cted"
-msgstr "ལྡེ་མིག་ལུ་ ངོས་ལེན་མེད་པ་ཅིན་ བརྡ་སྐད་རྐྱབས་(_C)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Beep when key is _accepted"
-msgstr "ལྡེ་མིག་ཨིན་པའི་སྐབས་ བརྡ་སྐད་རྐྱབས་ (_A)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Beep when key is _rejected"
-msgstr "ལྡེ་མིག་ལུ་ ངོས་ལེན་མེད་པ་ཅིན་ བརྡ་སྐད་རྐྱབས་  (_R)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Check if breaks are allowed to be postponed"
-msgstr "བར་མཚམས་ཚུ་ བསྣར་བཞག་འབད་ཆོག་ག་མི་ཆོག་ ཞིབ་དཔྱད་འབད།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Choose a Keyboard Model"
-msgstr "ལྡེ་སྒྲོམ་གྱི་དཔེ་ཅིག་ གདམ་ཁ་རྐྱབས།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Choose a Layout"
-msgstr "སྒྲིག་བཀོད་ཅིག་ གདམ་ཁ་རྐྱབས།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Cursor _blinks in text fields"
-msgstr "འོད་རྟགས་དེ་ ཚིག་ཡིག་ས་སྒོ་ཚུ་ནང་ འགུལ་སྤར་འབདཝ་ཨིན  (_B)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
-msgid "Cursor blinks speed"
-msgstr "འོད་རྟགས་འགུལ་སྤར་གྱི་ཚད།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
-msgid "D_elay:"
-msgstr "ཕྱིར་འགྱངས་:(_E)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Disa_ble sticky keys if two keys are pressed together"
-msgstr "ལྡེ་མིག་གཉིས་གཅིག་ཁར་ཨེབ་པ་ཅིན་ སྦྱར་རྩིས་ལྡེ་མིག་ཚུ་ ལྕོགས་མིན་བཟོཝ་ཨིན་ (_B)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "Duration of the break when typing is disallowed"
-msgstr "ཡིག་དཔར་བརྐྱབ་མ་ཆོག་པའི་སྐབས་ལུ་ བར་མཚམས་ཀྱི་དུས་ཡུན།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Duration of work before forcing a break"
-msgstr "བང་བཙོངས་ཏེ་ བར་མཚམས་ཅིག་  མ་བཞག་པའི་ཧེ་མར་ ལཱ་གཡོག་གི་དུས་ཡུན།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
-msgid "General"
-msgstr "ཡོངས་ཁྱབ་ "
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Key presses _repeat when key is held down"
-msgstr "ལྡེ་མིག་མར་འཆང་སྟེ་ཡོད་པའི་སྐབས་ ལྡེ་མིག་གིས་ ཡང་བསྐྱར་ཨེབ་ཨིན།(_r)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-msgid "Keyboard Accessibility Notifications"
-msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད་ བརྡ་བསྐུལ་ཚུ་"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "Keyboard Layout Options"
-msgstr "ལྡེ་སྒྲོམ་ སྒྲིག་བཀོད་གདམ་ཁ་ཚུ་ "
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "Keyboard Preferences"
-msgstr "ལྡེ་སྒྲོམ་གྱི་དགའ་གདམ་ཚུ།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "Keyboard _model:"
-msgstr "ལྡེ་སྒྲོམ་གྱི་དཔེ་:(_m)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "Layout _Options..."
-msgstr "སྒྲིག་བཀོད་ཀྱི་གདམ་ཁ་ཚུ་་་་་ (_O)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "Layouts"
-msgstr "སྒྲིག་བཀོད་ཚུ།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-"ལྡེ་སྒྲོམ་ལག་ལེན་ལུ་ ཡང་བསྐྱར་གྱི་གནོད་སྐྱོན་ བཀག་ཐབས་ལུ་ དུས་ཡུན་ཧ་ལམ་ཅིག་ལས་ གསལ་གཞི་ལྡེ་མིག་རྐྱབས།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "Mouse Keys"
-msgstr "མཱའུསི་གི་ལྡེ་མིག་ཚུ།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "Preview:"
-msgstr "སྔོན་ལྟ།:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "Repeat keys speed"
-msgstr "ལྡེ་མིག་ཡང་བསྐྱར་གྱི་ཚད།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "Reset to De_faults"
-msgstr "སྔོན་སྒྲིག་ལུ་ བསྐྱར་སྒྲིག་འབད"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
-msgid "S_peed:"
-msgstr "མགྱོགས་ཚད་:(_p)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
-msgid "Separate _layout for each window"
-msgstr "སྒོ་སྒྲིག་རེ་རེའི་དོན་ལུ་ སྒྲིག་བཀོད་སོ་སོ་ (_L)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
-msgid "Typing Break"
-msgstr "ཡིག་དཔར་བརྐྱབ་ནིའི་བར་མཚམས།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
-msgid "_Allow to control the pointer using the keyboard"
-msgstr "ལྡེ་སྒྲོམ་ ལག་ལེན་འཐབ་ཐོག་ལས་ དཔག་བྱེད་ ཚད་འཛིན་འབད་བཅུག་ (_A)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
-msgid "_Allow to turn accessibility features on and off from the keyboard"
-msgstr "ལྡེ་སྒྲོམ་གུ་ལས་ འཛུལ་སྤྱོད་ཁྱད་རྣམ་ཚུ་ ཨོན་དང་ཨོཕ་ འབད་བཅུག་ (_A)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
-msgid "_Break interval lasts:"
-msgstr "བར་མཚམས་གནས་ཡུན་:(_B)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
-msgid "_Delay:"
-msgstr "ཕྱིར་འགྱངས་:(_D)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
-msgid "_Ignore fast duplicate keypresses"
-msgstr "ལྡེ་མིག་ཨེབ་གནོན་ ངོ་བཤུས་ཚུ་ སྣང་མེད་བཞག་ (_I)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
-msgid "_Layouts:"
-msgstr "སྒྲིག་བཀོད་ཚུ:(_L)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
-msgid "_Models:"
-msgstr "དཔེ་ཚུ་:(_M)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
-msgid "_Notifications..."
-msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
-msgid "_Only accept long keypresses"
-msgstr "འཆང་སྟེ་ཡོད་མི་ ལྡེ་མིག་ཚུ་རྐྱངམ་གཅིག་ དང་ལེན་འབད་ (_O)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
-msgid "_Selected layouts:"
-msgstr "སེལ་འཐུ་འབད་མི་ སྒྲིག་བཀོད་ཚུ་:(_S)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
-msgid "_Simulate simultanous keypresses"
-msgstr "དུས་མཉམ་ ལྡེ་མནན་ཚུ་ མཚུངས་པ་བཟོ་ "
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
-msgid "_Speed:"
-msgstr "མགྱོགསཚད་:(_S)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
-msgid "_Type to test settings:"
-msgstr "གཞི་སྒྲིག་: ཚུ་བརྟག་ཞིབ་འབད་ནི་ལུ་ ཡིག་དཔར་རྐྱབས།(_T)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
-msgid "_Variants:"
-msgstr "ཁྱད་དངོས་ཚུ:(_V)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
-msgid "_Vendors:"
-msgstr "བཙོང་མི་ཚུ: (_V)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
-msgid "_Work interval lasts:"
-msgstr "ལཱ་གི་བར་མཚམས་གནས་ཡུན་:(_W)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
-msgid "minutes"
-msgstr "སྐར་མ།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
-msgid "Unknown"
-msgstr "མ་ཤེསཔ།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbltadd.c:211
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:311
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:211
-msgid "Default"
-msgstr "སྔོན་སྒྲིག"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:305
-msgid "Layout"
-msgstr "སྒྲིག་བཀོད།"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
-msgid "Vendors"
-msgstr "བཙོངས་མི་ཚུ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
-msgid "Models"
-msgstr "དཔེ།"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "ལྡེ་སྒྲོམ།"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "ཁྱོད་རའི་ལྡེ་སྒྲོམ་གྱི་དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:89
-msgid "gesture|Move left"
-msgstr "བརྡ་སྟོན་| གཡོན་ཁ་ཐུག་ལུ་ སྤོ་བཤུད་འབད་ "
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:94
-msgid "gesture|Move right"
-msgstr "བརྡ་སྟོན་| གཡས་ཁ་ཐུག་ལུ་སྤོ་བཤུད་འབད་ "
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:99
-msgid "gesture|Move up"
-msgstr "བརྡ་སྟོན་| ཡར་བཤུད་"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:104
-msgid "gesture|Move down"
-msgstr "རྣམ་འགྱུར་| མར་བཤུད་ "
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:109
-msgid "gesture|Disabled"
-msgstr "རྣམ་འགྱུར་| ལྕོགས་མིན་བཟོ་ཡོདཔ་ "
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-msgid "<b>Double-Click Timeout</b>"
-msgstr "<b>ཨེབ་གཏང་ ཐེངས་གཉིས་ཀྱི་ངལ་མཚམས་</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>འདྲུད་དེ་བཀོག་བཞག་</b>"
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Dwell Click</b>"
-msgstr "<b>ཌུའལ་ ཨེབ་གཏང་ </b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>དཔག་བྱེད་ག་ཡོད་བལྟ་</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>མཱའུསི་གི་ཕྱོགས་</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<b>Pointer Speed</b>"
-msgstr "<b>དཔག་བྱེད་ མགྱོགས་ཚད་ </b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<b>Simulated Secondary Click</b>"
-msgstr "<b>མཚུངས་པ་བཟོ་ཡོད་པའི་ གལ་གནད་ཆུང་བའི་ཨེབ་གཏང་</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid ""
-"<i>To test your double-click settings, try to double-click on the light bulb."
-"</i>"
-msgstr ""
-"<i>ཁྱོད་རའི་ཨེབ་གཏང་གཉིས་ལྡན་གཞི་སྒྲིག་ཚུ་ བརྟག་ཞིབ་འབད་ནིའི་དོན་ལུ་ གློག་ཤལ་དེ་གུ་ ཚར་གཉིས་ཨེབ་གཏང་"
-"འབད། </i>"
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid ""
-"<i>You can also use the Dwell Click panel applet to choose the click type.</"
-"i>"
-msgstr ""
-"<i>དེ་མ་ཚད་ ཁྱོད་ཀྱིས་ ཨེབ་གཏང་གི་དབྱེ་བ་ གདམ་ཁ་རྐྱབ་ནིའི་དོན་ལུ་ ཌུའལ་ ཨེབ་གཏང་ པེ་ནཱལ་ ཨེཔ་ལེཊི་"
-"ཡང་ ལག་ལེན་འཐབ་བཏུབ། </i>"
-
-#. high sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "<small><i>High</i></small>"
-msgstr "<small><i>མཐོ་བ་</i></small>"
-
-#. large threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "<small><i>Large</i></small>"
-msgstr "<small><i>ཆེ་བ་</i></small>"
-
-#. low sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "<small><i>Low</i></small>"
-msgstr "<small><i>དམའ་</i></small>"
-
-#. small threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "<small><i>Small</i></small>"
-msgstr "<small><i>ཆུང་ཀུ་</i></small>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
-msgid "Choose type of click _beforehand"
-msgstr "ཨེབ་གཏང་གི་དབྱེ་བ་ སྔ་གོང་ལས་རང་ གདམ་ཁ་རྐྱབས་ (_B)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
-msgid "Choose type of click with mo_use gestures"
-msgstr "ཨེབ་གཏང་གི་དབྱེ་བ་ མཱའིསི་གི་བརྡ་སྟོན་དང་གཅིག་ཁར་ གདམ་ཁ་རྐྱབས་ (_U)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
-msgid "D_ouble click:"
-msgstr " "
-
-#. click to initiate drag-and-drop (like normally click and hold)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
-msgid "D_rag click:"
-msgstr "ཨེབ་གཏང་ འདྲུད: (_R)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
-msgid "Mouse Preferences"
-msgstr "མཱའུསི་གི་དགའ་གདམ་ཚུ།"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
-msgid "Seco_ndary click:"
-msgstr "གལ་གནད་ཆུང་བའི་ཨེབ་གཏང: (_N)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr "ཚད་འཛིན་ ལྡེ་མིག་མནན་ཡོད་པའི་སྐབས་ དཔག་བྱེད་ཀྱི་ གནས་ས་སྟོན་ (_O)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
-msgid "Show click type _window"
-msgstr "ཨེབ་གཏང་དབྱེ་བ་གི་ ཝིན་ཌོ་ སྟོན་ (_W)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
-msgid "Thr_eshold:"
-msgstr "ཐེ་རེཤི་ཧཱོལཌི་: (_T)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
-msgid "_Acceleration:"
-msgstr "མགྱོགས་སྤྱོད་:(_A)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
-msgid "_Initiate click when stopping pointer movement"
-msgstr "དཔག་བྱེད་ཀྱི་ འགུལ་སྤྱོད་བཀག་བཞག་པའི་སྐབས་ ཨེབ་གཏང་འགོ་བཙུགས་ (_I)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
-msgid "_Left-handed"
-msgstr "གཡོན་ལག་(_L)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
-msgid "_Motion threshold:"
-msgstr "མོ་ཤཱན་ ཐེ་རེཤི་ཧཱོལཌི་:(_T)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
-msgid "_Right-handed"
-msgstr "གཡས་ལག་ (_R)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
-msgid "_Sensitivity:"
-msgstr "དྲན་ཚོར་:(_S)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
-msgid "_Single click:"
-msgstr "ཨེབ་གཏང་ རྐྱང་པ: (_S)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
-msgid "_Timeout:"
-msgstr "ངལ་མཚམས་:(_T)"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr "གཞི་རིམ་ཨེབ་གཏང་ འཆང་ཐོག་ལས་ གལ་གནད་ཆུང་བའི་ཨེབ་གཏང་ ལཱ་འབད་བཅུག་ (_T)"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "མཱའུསི།"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "ཁྱོད་རའི་མཱའུསི་གི་ དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "ཡོངས་འབྲེལ་གྱི་ པོརོག་སི།"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "ཁྱོད་རའི་ཡོངས་འབྲེལ་གྱི་ པོརོག་སི་དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>ཨིན་ཊར་ནེཊི་གི་ ཐད་ཀར་མཐུད་ལམ་</b>(_i)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>Ignore Host List</b>"
-msgstr "<b>ཧོསིཊི་ཐོ་ཡིག་ སྣང་མེད་བཞག་</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>རང་བཞིན་པོརོག་སི་རིམ་སྒྲིག་</b>(_A)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>ལག་དེབ་ཀྱི་ པོརོག་སི་རིམ་སྒྲིག་</b>(_M)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Use authentication</b>"
-msgstr "<b>བདེན་བཤད་ལག་ལེན་འཐབ་</b>(_U)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "Advanced Configuration"
-msgstr "མཐོ་རིམ་ཅན་གྱི་རིམ་སྒྲིག"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "Autoconfiguration _URL:"
-msgstr "རང་བཞིན་རིམ་སྒྲིག་ ཡུ་ཨར་ཨེལ།(_U)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "HTTP Proxy Details"
-msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་གི་ རྒྱས་བཤད་ཚུ།"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "H_TTP proxy:"
-msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་:།(_T)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "Network Proxy Preferences"
-msgstr "ཡོངས་འབྲེལ་ པོརོག་སི་གི་དགའ་གདམ་ཚུ།"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Port:"
-msgstr "འདྲེན་ལམ་:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Proxy Configuration"
-msgstr "པོརོག་སི་རིམ་སྒྲིག"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "S_ocks host:"
-msgstr "སོཀསི་ ཧོསིཊི་:(_o)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "U_sername:"
-msgstr "ལག་ལེན་པའི་མིང་:(_s)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "_Details"
-msgstr "རྒྱས་བཤད་ཚུ།(_D)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_FTP proxy:"
-msgstr "ཨེཕ་ཊི་པི་ པོརོག་སི་:(_F)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_Password:"
-msgstr "ཆོག་ཡིག་:(_P)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Secure HTTP proxy:"
-msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་མཐའ་བཙན་བཟོ:(_S)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Use the same proxy for all protocols"
-msgstr "གནད་སྤེལ་ལམ་ལུགས་ཚུ་ཆ་མཉམ་གྱི་དོན་ལུ་ པོརོ་སི་གཅིག་པ་འདི་ལག་ལེན་འཐབ་ (_U)"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "སྒྲ་སྐད་ལྕོགས་ཅན་བཟོ་སྟེ་ བྱུང་ལས་དང་མཉམ་སྦྲགས་འབད།"
-
-#: ../capplets/sound/mixer-support.c:79
-#, c-format
-msgid "Unknown Volume Control %d"
-msgstr "མ་ཤེས་པའི་སྐད་ཤུགས་ཚད་འཛིན་ %d"
-
-#: ../capplets/sound/pipeline-tests.c:84
-#, c-format
-msgid "Failed to construct test pipeline for '%s'"
-msgstr "'%s' གི་དོན་ལུ་ བརྟག་ཞིབ་རྒྱུད་དུང་འབྲེལ་ལམ་ བཟོ་བསྐྲུན་འབད་ནི་འཐུས་ཤོས་འབྱུང་ཡོད་"
-
-#: ../capplets/sound/sound-properties-capplet.c:325
-#: ../capplets/sound/sound-properties-capplet.c:378
-msgid "Not connected"
-msgstr "མ་མཐུད་པས།"
-
-#: ../capplets/sound/sound-properties-capplet.c:661
-msgid "Autodetect"
-msgstr "རང་བཞིན་སྐྱོན་འཛིན་"
-
-#: ../capplets/sound/sound-properties-capplet.c:666
-#: ../capplets/sound/sound-properties-capplet.c:667
-msgid "ALSA - Advanced Linux Sound Architecture"
-msgstr "ཨེ་ཨེལ་ཨེསི་ཨེ་ - མཐོ་རིམ་ལི་ནགསི་སྒྲ་སྐད་བཟོ་བཀོད་"
-
-#: ../capplets/sound/sound-properties-capplet.c:668
-msgid "Artsd - ART Sound Daemon"
-msgstr "ཨརཊི་ཨེསི་ཌི་ - སྒྱུ་རྩལ་སྒྲ་སྐད་ཌེ་མཱོན་"
-
-#: ../capplets/sound/sound-properties-capplet.c:669
-#: ../capplets/sound/sound-properties-capplet.c:670
-msgid "ESD - Enlightened Sound Daemon"
-msgstr "ཨི་ཨེསི་ཌི་ - ཤེས་ཡོན་ཅན་སྒྲ་སྐད་ཌེ་མཱོན་"
-
-#: ../capplets/sound/sound-properties-capplet.c:671
-#: ../capplets/sound/sound-properties-capplet.c:672
-msgid "OSS - Open Sound System"
-msgstr "ཨོ་ཨེསི་ཨེ་ - སྒྲ་སྐད་རིམ་ལུགས་ཁ་ཕྱེ་"
-
-#: ../capplets/sound/sound-properties-capplet.c:673
-#: ../capplets/sound/sound-properties-capplet.c:674
-msgid "PulseAudio Sound Server"
-msgstr "པོ་ལི་པའུ་ཌིའོ་སྒྲ་སྐད་སར་བར"
-
-#: ../capplets/sound/sound-properties-capplet.c:675
-msgid "Test Sound"
-msgstr "བརྟག་ཞིབ་སྒྲ་སྐད་"
-
-#: ../capplets/sound/sound-properties-capplet.c:676
-msgid "Silence"
-msgstr "ཁུ་སིམ་སིམ་"
-
-#: ../capplets/sound/sound-properties-capplet.c:1043
-msgid "- GNOME Sound Preferences"
-msgstr "- ཇི་ནོམ་སྒྲ་སྐད་ཀྱི་དགའ་གདམ་ཚུ་"
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "<b>Audio Conferencing</b>"
-msgstr "<b>རྣར་ཉན་ཞལ་འཛོམས་</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "<b>Default Mixer Tracks</b>"
-msgstr "<b>སྔོན་སྒྲིག་སྦྱོར་འཕྲུལ་གླུ་རིམ་ཚུ་</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "<b>Music and Movies</b>"
-msgstr "<b>སྙན་ཆ་དང་གློག་བརྙན་</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "<b>Sound Events</b>"
-msgstr "<b>སྒྲ་སྐད་བྱུང་ལས་</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
-msgstr "<span weight=\"bold\" size=\"larger\">བརྟག་ཞིབ་འབད་དོ་</span>"
-
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Click OK to finish."
-msgstr "རྫོགས་ནིའི་དོན་ལུ་ བཏུབ་གུ་ཨེབ་གཏང་འབད།"
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "Devices"
-msgstr "ཐབས་འཕྲུལ།"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "E_nable software sound mixing (ESD)"
-msgstr "མཉེན་ཆས་སྒྲ་སྐད་བསྲེ་སྦྱོར་གྱི་ལྕོགས་ཅན་བཟོ།(ཨི་ཨེསི་ཌི)"
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "Flash _entire screen"
-msgstr "གསལ་གཞི་ཧྲིལ་བུ་ རིབ་སྟོན་འབད།(_e)"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "Flash _window titlebar"
-msgstr "སྒོ་སྒྲིག་གི་མགོ་མིང་ཕྲ་རིང་ རིབ་སྟོན་འབད།(_w)"
-
-#: ../capplets/sound/sound-properties.glade.h:11
-msgid "S_ound playback:"
-msgstr "སྒྲ་སྐད་གཏང་ནི་:(_o)"
-
-#: ../capplets/sound/sound-properties.glade.h:12
-msgid ""
-"Select the device and tracks to control with the keyboard. Use the Shift and "
-"Control keys to select multiple tracks if required."
-msgstr ""
-"ལྡེ་སྒྲོམ་དང་གཅིག་ཁར་ཚད་འཛིན་འབད་ནིའི་དོན་ལས་ ཐབས་འཕྲུལ་དང་གླུ་རིམ་ཚུ་སེལ་འཐུ་འབད། དགོས་མཁོ་ཡོདཔ་"
-"ཨིན་པ་ཅིན་ སྣ་མང་གླུ་རིམ་ཚུ་སེལ་འཐུ་འབད་ནིའི་དོན་ལས་ སོར་ལྡེ་དང་ཚད་འཛིན་ལྡེ་མིག་ཚུ་ལག་ལེན་འཐབ།"
-
-#: ../capplets/sound/sound-properties.glade.h:13
-msgid "So_und playback:"
-msgstr "སྒྲ་སྐད་གཏང་ནི་:(_u)"
-
-#: ../capplets/sound/sound-properties.glade.h:14
-msgid "Sou_nd capture:"
-msgstr "སྒྲ་སྐད་འཛིན་བཟུང་:(_n)"
-
-#: ../capplets/sound/sound-properties.glade.h:15
-msgid "Sound Preferences"
-msgstr "སྒྲ་སྐད་ཀྱི་དགའ་གདམ་ཚུ།"
-
-#: ../capplets/sound/sound-properties.glade.h:16
-msgid "Sounds"
-msgstr "སྒྲ་སྐད།"
-
-#: ../capplets/sound/sound-properties.glade.h:17
-msgid "System Beep"
-msgstr "རིམ་ལུགས་བརྡ་སྐད།"
-
-#: ../capplets/sound/sound-properties.glade.h:18
-msgid "Test"
-msgstr "བརྟག་ཞིབ།"
-
-#: ../capplets/sound/sound-properties.glade.h:19
-msgid "Testing Pipeline"
-msgstr "རྒྱུད་དུང་འབྲེལ་ལམ་བརྟག་ཞིབ་འབད་དོ།"
-
-#: ../capplets/sound/sound-properties.glade.h:20
-msgid "_Device:"
-msgstr "ཐབས་འཕྲུལ:(_D)"
-
-#: ../capplets/sound/sound-properties.glade.h:21
-msgid "_Enable system beep"
-msgstr "རིམ་ལུགས་བརྡ་སྐད་ལྕོགས་ཅན་བཟོ།(_E)"
-
-#: ../capplets/sound/sound-properties.glade.h:22
-msgid "_Play system sounds"
-msgstr "རིམ་ལུགས་སྒྲ་སྐད་གཏང་།(_P)"
-
-#: ../capplets/sound/sound-properties.glade.h:23
-msgid "_Sound playback:"
-msgstr "སྒྲ་སྐད་གཏང་ནི་:(_S)"
-
-#: ../capplets/sound/sound-properties.glade.h:24
-msgid "_Visual system beep"
-msgstr "མཐོང་བའི་རིམ་ལུགས་བརྡ་སྐད།(_V)"
-
-#: ../capplets/windows/gnome-window-properties.c:344
-msgid "Cannot start the preferences application for your window manager"
-msgstr "ཁྱོད་ཀྱི་སྒོ་སྒྲིག་འཛིན་སྐྱོང་པའི་དོན་ལུ་ དགའ་གདམ་གྱི་གློག་རིམ་ འགོ་བཙུགས་མི་ཚུགས།"
-
-#. translators: this is the Control key
-#: ../capplets/windows/gnome-window-properties.c:602
-msgid "C_ontrol"
-msgstr "ཚད་འཛིན།(_o)"
-
-#: ../capplets/windows/gnome-window-properties.c:607
-msgid "_Alt"
-msgstr "གདམ་ལྡེ།(_A)"
-
-#: ../capplets/windows/gnome-window-properties.c:613
-msgid "H_yper"
-msgstr "ཧའི་པར།(_y)"
-
-#: ../capplets/windows/gnome-window-properties.c:620
-msgid "S_uper (or \"Windows logo\")"
-msgstr "ཡང་དག (ཡང་ན་ \"Windows logo\")(_u)"
-
-#: ../capplets/windows/gnome-window-properties.c:627
-msgid "_Meta"
-msgstr "མེ་ཊ།(_M)"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>འགུལ་བསྐྱོད་ལྡེ་མིག་</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>མགོ་མིང་ཕྲ་རིང་གི་བྱ་བ་</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>སྒོ་སྒྲིག་གི་སེལ་འཐུ་</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr "སྒོ་སྒྲིག་ཅིག་ སྤོ་བཤུད་འབད་ནི་ལུ་ ལྡེ་མིག་འདི་ཨེབ་སྟེ་འཛིན་ཞིནམ་ལས་ སྒོ་སྒྲིག་དེ་བཟུང་།"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "སྒོ་སྒྲིག་གི་ དགའ་གདམ་ཚུ།"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "བྱ་བ་འདི་བསྒྲུབ་ནི་ལུ་ མགོ་མིང་ཕྲ་རིང་ལུ་ ཨེབ་གཏང་ཚར་གཉིས་འབད།(_D)"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "ཆེར་བསྐྱེད་མ་འབད་བའི་ཧེ་མར་བར་མཚམས་:(_I)"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "སེལ་འཐུ་འབད་མི་ སྒོ་སྒྲིག་ཚུ་ བར་མཚམས་ཅིག་གི་ཤུལ་ལས་ ཆེར་བསྐྱེད་འབད།(_R)"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "མཱའུསི་དེ་ སྒོ་སྒྲིག་ཚུ་གི་གུ་ལས་ཕར་འགྱོཝ་ད་ སྒོ་སྒྲིག་ཚུ་ སེལ་འཐུ་འབད།(_S)"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "སྐར་ཆ་ཚུ།"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "ཁྱོད་རའི་སྒོ་སྒྲིག་གི་རྒྱུ་དངོས་ཚུ་ གཞི་སྒྲིག་འབད།"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "སྒོ་སྒྲིག་ཚུ།"
-
-#. make start action
-#: ../libslab/application-tile.c:369
-#, c-format
-msgid "<b>Start %s</b>"
-msgstr "<b>%s འགོ་བཙུགས་</b>"
-
-#: ../libslab/application-tile.c:388
-msgid "Help"
-msgstr "གྲོགས་རམ་"
-
-#: ../libslab/application-tile.c:435
-msgid "Upgrade"
-msgstr "ཡར་བསྐྱེད་"
-
-#: ../libslab/application-tile.c:450
-msgid "Uninstall"
-msgstr "གཞི་བཙུགས་མ་འབད་"
-
-#: ../libslab/application-tile.c:777 ../libslab/document-tile.c:737
-msgid "Remove from Favorites"
-msgstr "དགའ་མི་ཚུ་ལས་རྩ་བསྐྲད་གཏང་"
-
-#: ../libslab/application-tile.c:779 ../libslab/document-tile.c:739
-msgid "Add to Favorites"
-msgstr "དགའ་མི་ཚུ་ལུ་ཁ་སྐོང་རྐྱབས་"
-
-#: ../libslab/application-tile.c:864
-msgid "Remove from Startup Programs"
-msgstr "འགོ་བཙུགས་ལས་རིམ་ཚུ་ལས་ རྩ་བསྐྲད་གཏང་"
-
-#: ../libslab/application-tile.c:866
-msgid "Add to Startup Programs"
-msgstr "འགོ་བཙུགས་ལས་རིམ་ཚུ་ལུ་ ཁ་སྐོང་རྐྱབས་"
-
-#: ../libslab/app-shell.c:750
-#, c-format
-msgid ""
-"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
-"\n"
-" Your filter \"<b>%s</b>\" does not match any items.</span>"
-msgstr ""
-"<span size=\"large\"><b>མཐུན་མི་ཚུ་མ་འཐོབ།</b> </span><span>\n"
-"\n"
-" ཁྱོད་ཀྱི་ཚགས་མ་ \"<b>%s</b>\" འདི་ རྣམ་གྲངས་ཚུ་ག་དང་གཅིག་ཁར་ཡང་མི་མཐུན་མས།</span>"
-
-#: ../libslab/app-shell.c:900
-msgid "Other"
-msgstr "གཞན་མི་"
-
-#: ../libslab/bookmark-agent.c:1061
-msgid "New Spreadsheet"
-msgstr "ཤོག་ཁྲམ་གསརཔ"
-
-#: ../libslab/bookmark-agent.c:1065
-msgid "New Document"
-msgstr "ཡིག་ཆ་གསརཔ"
-
-#: ../libslab/bookmark-agent.c:1117
-msgid "Home"
-msgstr "ཁྱིམ"
-
-#: ../libslab/bookmark-agent.c:1133
-msgid "File System"
-msgstr "ཡིག་སྣོད་ཀྱི་་རིམ་ལུགས"
-
-#: ../libslab/bookmark-agent.c:1137
-msgid "Network Servers"
-msgstr "ཡོངས་འབྲེལ་གྱི་ སར་་བར"
-
-#: ../libslab/bookmark-agent.c:1166
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "བརྗོད་དོན་གཞི་བཙུགས་འབད་...(_I)"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "ཁ་ཕྱེ།(_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "བརྗོད་དོན་གྱི་རྒྱས་བཤད།"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "འཚོལ་ཞིབ།"
 
-#. make open with default action
-#: ../libslab/directory-tile.c:170
-#, c-format
-msgid "<b>Open</b>"
-msgstr "<b>ཁ་ཕྱེ </b>"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
 
-#. make rename action
-#: ../libslab/directory-tile.c:189 ../libslab/document-tile.c:228
-msgid "Rename..."
-msgstr "བསྐྱར་མིང་བཏགས་..."
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "ལྕོགས་མིན།"
 
-#: ../libslab/directory-tile.c:203 ../libslab/directory-tile.c:212
-#: ../libslab/document-tile.c:242 ../libslab/document-tile.c:251
-msgid "Send To..."
-msgstr "...ལུ་གཏང་"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
 
-#. make move to trash action
-#: ../libslab/directory-tile.c:227 ../libslab/document-tile.c:277
-msgid "Move to Trash"
-msgstr "ཕྱགས་ཧོད་ལུ་སྤོ་"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
 
-#: ../libslab/directory-tile.c:237 ../libslab/directory-tile.c:450
-#: ../libslab/document-tile.c:287 ../libslab/document-tile.c:850
-msgid "Delete"
-msgstr "བཏོན་གཏང་"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "རྒྱབ་གཞི་"
 
-#: ../libslab/directory-tile.c:575 ../libslab/document-tile.c:1022
-#, c-format
-msgid "Are you sure you want to permanently delete \"%s\"?"
-msgstr "ཁྱོད་ཀྱིས་ \"%s\" རྟག་བརྟན་སྦེ་ བཏོན་གཏང་ནི་ངེས་ཏིག་ཨིན་ན?"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
 
-#: ../libslab/directory-tile.c:580 ../libslab/document-tile.c:1026
-msgid "If you delete an item, it is permanently lost."
-msgstr "ཁྱོད་ཀྱིས་ རྣམ་གྲངས་ཅིག་བཏོན་གཏང་པ་ཅིག་ དེ་ རྟག་བརྟན་སྦེ་ བརླག་སྟོར་ཞུགས་འོང་། "
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "གསལ་གཞི།"
 
-#: ../libslab/document-tile.c:189
-#, c-format
-msgid "<b>Open with \"%s\"</b>"
-msgstr "<b> \"%s\" དང་གཅིག་ཁར་ཁ་ཕྱེ་</b>"
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
 
-#: ../libslab/document-tile.c:201
-msgid "Open with Default Application"
-msgstr "སྔོན་སྒྲིག་གློག་རིམ་དང་གཅིག་ཁར་ ཁ་ཕྱེ་"
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "གྱང་ཤོག་མིན་འདུག"
 
-#: ../libslab/document-tile.c:212
-msgid "Open in File Manager"
-msgstr "ཡིག་སྣོད་འཛིན་སྐྱོང་པ་ནང་ ཁ་ཕྱེ་"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
-#: ../libslab/document-tile.c:633
-msgid "?"
-msgstr "?"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "སྒྲ་སྐད།"
 
-#: ../libslab/document-tile.c:640
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: ../libslab/document-tile.c:648
-msgid "Today %l:%M %p"
-msgstr "ད་རིས་ %l:%M %p"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "མགྱོགས་ཐབས།"
 
-#: ../libslab/document-tile.c:658
-msgid "Yesterday %l:%M %p"
-msgstr "ཁ་རྩ་ %l:%M %p"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "ལྡེ་སྒྲོམ་གྱི་མགྱོགས་ཐབས།"
 
-#: ../libslab/document-tile.c:670
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
 
-#: ../libslab/document-tile.c:678
-msgid "%b %d %l:%M %p"
-msgstr "%b %d %l:%M %p"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../libslab/document-tile.c:680
-msgid "%b %d %Y"
-msgstr "%b %d %Y"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
 
-#: ../libslab/libslab-bookmarkfile.c:700 ../libslab/libslab-bookmarkfile.c:777
-#: ../libslab/libslab-bookmarkfile.c:856 ../libslab/libslab-bookmarkfile.c:903
-#, c-format
-msgid "Unexpected attribute '%s' for element '%s'"
-msgstr "རྒྱུ་རྫས་'%s'ལུ་རེ་བ་་མེད་པའི་ཁྱད་ཆོས'%s'"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#: ../libslab/libslab-bookmarkfile.c:711 ../libslab/libslab-bookmarkfile.c:788
-#: ../libslab/libslab-bookmarkfile.c:798 ../libslab/libslab-bookmarkfile.c:914
-#, c-format
-msgid "Attribute '%s' of element '%s' not found"
-msgstr "རྒྱུ་རྫས་'%s'གི་ཁྱད་ཆོས་'%s' མ་ཐོབ"
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
 
-#: ../libslab/libslab-bookmarkfile.c:1087
-#: ../libslab/libslab-bookmarkfile.c:1152
-#: ../libslab/libslab-bookmarkfile.c:1216
-#: ../libslab/libslab-bookmarkfile.c:1226
-#, c-format
-msgid "Unexpected tag '%s', tag '%s' expected"
-msgstr "རེ་བ་མེད་པའི་ངོ་རྟགས '%s', ངོ་རྟགས '%s' རེ་བ་ཡོདཔ"
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
 
-#: ../libslab/libslab-bookmarkfile.c:1112
-#: ../libslab/libslab-bookmarkfile.c:1126
-#: ../libslab/libslab-bookmarkfile.c:1194
-#: ../libslab/libslab-bookmarkfile.c:1246
-#, c-format
-msgid "Unexpected tag '%s' inside '%s'"
-msgstr "རེ་བ་མེད་པའི་ངོ་རྟགས'%s' ནང་ན '%s'"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
 
-#: ../libslab/libslab-bookmarkfile.c:1929
-#, c-format
-msgid "No valid bookmark file found in data dirs"
-msgstr "གནད་སྡུད་ཌའིརསི་ནང་ནུས་ཅན་གྱི་དེབ་རྟགས་ཡིག་སྣོད་མིན་འདུག"
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
 
-#: ../libslab/libslab-bookmarkfile.c:2130
-#, c-format
-msgid "A bookmark for URI '%s' already exists"
-msgstr "ཡུ་ཨར་ཨེལ'%s'དོན་ལུ་དེབ་རྟགས་ཅིག་ཧེ་མ་ལས་འདུག"
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
 
-#: ../libslab/libslab-bookmarkfile.c:2176
-#: ../libslab/libslab-bookmarkfile.c:2333
-#: ../libslab/libslab-bookmarkfile.c:2418
-#: ../libslab/libslab-bookmarkfile.c:2499
-#: ../libslab/libslab-bookmarkfile.c:2584
-#: ../libslab/libslab-bookmarkfile.c:2667
-#: ../libslab/libslab-bookmarkfile.c:2745
-#: ../libslab/libslab-bookmarkfile.c:2824
-#: ../libslab/libslab-bookmarkfile.c:2866
-#: ../libslab/libslab-bookmarkfile.c:2963
-#: ../libslab/libslab-bookmarkfile.c:3089
-#: ../libslab/libslab-bookmarkfile.c:3279
-#: ../libslab/libslab-bookmarkfile.c:3355
-#: ../libslab/libslab-bookmarkfile.c:3508
-#: ../libslab/libslab-bookmarkfile.c:3573
-#: ../libslab/libslab-bookmarkfile.c:3663
-#: ../libslab/libslab-bookmarkfile.c:3790
-#, c-format
-msgid "No bookmark found for URI '%s'"
-msgstr "ཡུ་ཨར་་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་མིན་འདུག"
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
 
-#: ../libslab/libslab-bookmarkfile.c:2508
-#, c-format
-msgid "No MIME type defined in the bookmark for URI '%s'"
-msgstr "ཡུ་ཨར་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་ནང་ཨེམ་ཨའི་ཨེམ་ཨི་གི་དབྱེ་བ་ངེས་འཛིན་འབད་མིན་འདུག"
-
-#: ../libslab/libslab-bookmarkfile.c:2593
-#, c-format
-msgid "No private flag has been defined in bookmark for URI '%s'"
-msgstr "ཡུ་ཨར་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་ནང་སྒེར་གྱི་དར་ངེས་འཛིན་འབད་དེ་མིན་འདུག"
-
-#: ../libslab/libslab-bookmarkfile.c:2972
-#, c-format
-msgid "No groups set in bookmark for URI '%s'"
-msgstr "ཡུ་ཨར་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་ནང་སྡེ་ཚན་ཚུ་གཞི་སྒྲིག་འབད་དེ་མིན་འདུག"
-
-#: ../libslab/libslab-bookmarkfile.c:3373
-#: ../libslab/libslab-bookmarkfile.c:3518
-#, c-format
-msgid "No application with name '%s' registered a bookmark for '%s'"
-msgstr "'%s'དོན་ལུ་དེབ་རྟགས་མིང'%s' ཐོ་བཀོད་དང་བཅསཔ་སྦེ་འཇུག་སྤྱོད་འབད་དེ་མིན་འདུག"
-
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
-msgstr "ད་ལྟོ་འཚོལ་"
-
-#: ../libslab/system-tile.c:128
-#, c-format
-msgid "<b>Open %s</b>"
-msgstr "<b> ཁ་ཕྱེ %s་</b>"
-
-#: ../libslab/system-tile.c:141
-#, c-format
-msgid "Remove from System Items"
-msgstr "རིམ་ལུགས་རྣམ་གྲངས་ལས་རྩ་བསྐྲད་གཏང་"
-
-#: ../libsounds/sound-view.c:44
-msgid "Login"
-msgstr "ནང་བསྐྱོད།"
-
-#: ../libsounds/sound-view.c:45
-msgid "Logout"
-msgstr "ཕྱིར་བསྐྱོད།"
-
-#: ../libsounds/sound-view.c:46
-msgid "Boing"
-msgstr "བོ་ཡིང་།"
-
-#: ../libsounds/sound-view.c:47
-msgid "Siren"
-msgstr "སྒྲ་འཕྲུལ།"
-
-#: ../libsounds/sound-view.c:48
-msgid "Clink"
-msgstr "ཏིང་སྒྲ།"
-
-#: ../libsounds/sound-view.c:49
-msgid "Beep"
-msgstr "བརྡ་སྐད་རྐྱབས།"
-
-#: ../libsounds/sound-view.c:50
-msgid "No sound"
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
 msgstr "སྒྲ་སྐད་མིན་འདུག"
 
-#: ../libsounds/sound-view.c:132
-msgid "Sound not set for this event."
-msgstr "བྱུང་ལས་ཀྱི་དོན་ལུ་སྒྲ་སྐད་གཞི་སྒྲིག་མ་འབད་བས།"
-
-#: ../libsounds/sound-view.c:141
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package for a set of default sounds."
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
 msgstr ""
-"བྱུང་ལས་འདི་གི་དོན་ལུ་ སྒྲ་སྐད་ཡིག་སྣོད་དེ་མིན་འདུག\n"
-"ཁྱོད་ཀྱིས་ སྔོན་སྒྲིག་སྒྲ་སྐད་ཀྱི་ཆ་ཚན་ཅིག་གི་དོན་ལུ་ཇི་ནོམ་རྣར་ཉན་ཐུམ་སྒྲིལ་་དེ་ གཞི་བཙུགས་འབད་ནི་ཨིནམ་"
-"འོང་།"
 
-#: ../libsounds/sound-view.c:152
-msgid "The sound file for this event does not exist."
-msgstr "བྱུང་ལས་འདི་གི་དོན་ལུ་ སྒྲ་སྐད་ཡིག་སྣོད་དེ་མིན་འདུག"
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
 
-#: ../libsounds/sound-view.c:183
-msgid "Select Sound File"
-msgstr "སྒྲ་སྐད་ཡིག་སྣོད་སེལ་འཐུ་འབད།"
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "དྲན་བརྡའི་དབྱེ་བ།"
 
-#: ../libsounds/sound-view.c:210
-#, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "ཡིག་སྣོད་%sདེ་ ནུས་ཅན་གྱི་ ཝེབ་ཡིག་སྣོད་ཅིག་མེན་པས།"
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
 
-#: ../libsounds/sound-view.c:271
-msgid "Select sound file..."
-msgstr "སྒྲ་སྐད་ཡིག་སྣོད་སེལ་འཐུ་འབད་..."
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
 
-#: ../libsounds/sound-view.c:373
-msgid "System Sounds"
-msgstr "རིམ་ལུགས་སྒྲ་སྐད།"
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
 
-#: ../libwindow-settings/gnome-wm-manager.c:318
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "སྒོ་སྒྲིག་འཛིན་སྐྱོང་པ་\"%s\" གིས་ རིམ་སྒྲིག་ལག་ཆས་ཅིག་ ཐོ་འགོད་མ་འབད་བས།\n"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "གློག་རིམ་ཡིག་གཟུགས་:(_A)"
 
-#: ../libwindow-settings/metacity-window-manager.c:390
-msgid "Maximize"
-msgstr "མང་མཐའ་ལུ་སེང་།"
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:391
-msgid "Minimize"
-msgstr "ཆུང་ཀུ་བཟོ་ "
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:392
-msgid "Roll up"
-msgstr "ཡར་བསྒྲིལ"
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<i>གློག་འཕྲིན་</i>"
 
-#: ../libwindow-settings/metacity-window-manager.c:393
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "བཟོ་རྣམ་:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "སྔོན་སྒྲིག"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "རྒྱབ་གཞི་"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "འབྱུང་སྣང་"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "གསལ་གཞིའི་ཧུམ་ཆ།"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "དཔག་བྱེད་དཀརཔོ་ཆེ་བ།"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "དཀར་མདངས་ཡར་སེང་།"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "ཡིག་སྣོད་མིང་"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "ཡིག་སྣོད་མིང་"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "ཡིག་སྣོད་འདྲ་བཤུས་རྐྱབ་དོ།"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "ཡིག་སྣོད་ཆ་མཉམ"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "ནང་འདྲེན།(_I)"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "ཁ་སྐོང་རྐྱབས་...(_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "མངོན་གསལ་འབད་ཡོད་པའི་ཡིག་སྣོད་ཚུ་:(_L)"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "རྩ་བསྐྲད་གཏང་།(_R)"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "རྒྱས་བཤད་ཚུ།(_D)"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "སྐར་མ།"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "འབྲིང་མ་།"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "སྐར་མ།"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "སྐར་མ།"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "ཚོས་གཞི་ཚུ་"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "གཟུགས་བརྙན་སེལ་འཐུ་འབད།"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "སེལ་འཐུ་འབད།(_S)"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "སྒྲ་སྐད་མིན་འདུག"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "ངལ་མཚམས་:(_T)"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "འཚོལ་ཞིབ།"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "ཕྱིར་འགྱངས་:(_E)"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "འཚོལ་ཞིབ་ཀྱི་མགྱོགས་ཐབས།"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "ལྕོགས་མིན།"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "སྐར་ཆ་ཚུ།"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "ཟླ་ཐོ་:(_n)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "ཁྱོད་རའི་ཌེཀསི་ཊོཔ་གི་ རྒྱབ་གཞིའི་གཞི་སྒྲིག་ཚུ་ བསྒྱུར་བཅོས་འབད།"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "ཀེ་མེལ།"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "ཟླ་ཐོ་:(_n)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "སྔོན་སྒྲིག་གློག་རིམ་དང་གཅིག་ཁར་ ཁ་ཕྱེ་"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "སྔོན་སྒྲིག་གློག་རིམ་དང་གཅིག་ཁར་ ཁ་ཕྱེ་"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "ཡིག་གཟུགས་འཇུག་སྤྱོད་འབད།(_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "ཕྱོགས།"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "ཧུམ་ཆ་:(_R)"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "ཡང་སེལ་གྱི་མགྱོགས་ཚད་:(_f)"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "ཆ་ཚད་འཇལ་ཡོདཔ།"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "ཆ་ཤས་ཡོངས་སྒྲུབ།"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "ཚགས་མ་"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "ལས་:"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "སྐར་མ།"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "ལུ་:"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+#, fuzzy
+msgid "No Events"
+msgstr "བྱུང་ལས།"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ཐབས་འཕྲུལ།"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "མིང་:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "དབྱེ་བ།"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "ཇི་ནོམ་ ཊར་མི་ནཱལ།"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "སྒོ་སྒྲིག་ཚུ།"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "ཐབས་འཕྲུལ།"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "ཐབས་འཕྲུལ།"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "བསྐྱར་མིང་བཏགས་..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/ སྐོར་ལས།(_A)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+#, fuzzy
+msgid "View information about your system"
+msgstr "རང་ཉིད་སྐོར་གྱི་བརྡ་དོན།"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "སྐད་མེད།"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "སྐད་ཤུགས་མར་ཕབ།"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "སྐད་ཤུགས་ཡར་སེང་།"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+#, fuzzy
+msgid "Launch media player"
+msgstr "བརྡ་བརྒྱུད་གཏང་འཕྲུལ"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "གཏང་། (ཡང་ན་ གཏང་/ཐེམ)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+#, fuzzy
+msgid "Pause playback"
+msgstr "སྒྲ་སྐད་གཏང་ནི་:(_o)"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "ལོག་གཏང་ནི་ མཚམས་འཇོག་གི་ལྡེ་མི"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "ཧེ་མའི་གླུ་རིམ་ལུ་གོམ་འགྱོ།"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "གླུ་རིམ་གཞན་མི་ལུ་གོམ་འགྱོ།"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "ཕྱིར་བཏོན།"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "ཡིག་དཔར་བརྐྱབ་ནིའི་བར་མཚམས།"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "གླུ་རིམ་གཞན་མི་ལུ་གོམ་འགྱོ།"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "ཧེ་མའི་གླུ་རིམ་ལུ་གོམ་འགྱོ།"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "ཝེབ་བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་འབད"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་འབད།"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "སྔོན་སྒྲིག་གཞི་སྒྲིག་ཚུ།"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "ཝེབ་བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་འབད"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "ཁྱིམ་གྱི་ལེ་སྣོད།"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "འཚོལ་ཞིབ།"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "རིམ་ལུགས།"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "ཕྱིར་བསྐྱོད་འབད།"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "གསལ་གཞི་ལྡེ་མིག་རྐྱབས།"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "འཛུལ་སྤྱོད"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "རྒྱས་ཟུམ།"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "ཕྱིར་བསྐྱོད་འབད།"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "གདམ་ཁ་ཚུ།"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+#, fuzzy
+msgid "Move Down"
+msgstr "རྣམ་འགྱུར་| མར་བཤུད་ "
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/ དགའ་གདམ་ཚུ།(_P)"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "ལྡེ་སྒྲོམ་སྒྲིག་བཀོད།"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "རྩ་བསྐྲད་གཏང་།(_R)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "ཨིན་པུཊི་སྒྲོམ་ཚུ་:(_I)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "གནད་སྤེལ་ལམ་ལུགས་ཚུ་ཆ་མཉམ་གྱི་དོན་ལུ་ པོརོ་སི་གཅིག་པ་འདི་ལག་ལེན་འཐབ་ (_U)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+#, fuzzy
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "ལྡེ་སྒྲོམ་ ལག་ལེན་འཐབ་ཐོག་ལས་ དཔག་བྱེད་ ཚད་འཛིན་འབད་བཅུག་ (_A)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "མཱའུསི་གི་ལྡེ་མིག་ཚུ།"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "ལྡེ་སྒྲོམ་གྱི་མགྱོགས་ཐབས།"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "བྱ་བ།"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "མགྱོགས་ཐབས།"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "མགྱོགས་ཐབས།"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "དགའ་མི་ཚུ་ལུ་ཁ་སྐོང་རྐྱབས་"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "མགྱོགས་ཐབས།"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "ལྡེ་སྒྲོམ་གྱི་མགྱོགས་ཐབས།"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "རྩ་བསྐྲད་གཏང་།(_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "མིང་:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "བརྡ་བཀོད་:(_C)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "མགྱོགས་ཐབས།"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "མགྱོགས་ཐབས།"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "ཅི་མེད་"
 
-#: ../shell/control-center.c:62
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "སྔོན་སྒྲིག་ལུ་ བསྐྱར་སྒྲིག་འབད་ (_R)"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "ལྡེ་སྒྲོམ།"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "ཁྱོད་རའི་རང་དོན་བརྡ་དོན་ གཞི་སྒྲིག་འབད།"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "སྔོན་སྒྲིག་གཞི་སྒྲིག་ཚུ།"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "ཡོངས་ཁྱབ་ "
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "གཡོན"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "གཡས"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "དཔག་བྱེད་ཚད་:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "མཱའུསི།"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "མཱའུསི་གི་ལྡེ་མིག་ཚུ།"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "མགྱོགས་སྤྱོད་:(_A)"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "མགྱོགས་སྤྱོད་:(_A)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "གློག་རིམ་ཡིག་གཟུགས་:(_A)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ཐབས་འཕྲུལ།"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "བྱ་བ།"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "མ་མཐུད་པས།"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "གདམ་ཁ་ཚུ།"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "key not found [%s]\n"
-msgstr "ལྡེ་མིག་མ་འཐོབ་ [%s]\n"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../shell/control-center.c:159
-msgid "Filter"
-msgstr "ཚགས་མ་"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
 
-#: ../shell/control-center.c:159
-msgid "Groups"
-msgstr "སྡེ་ཚན་ཚུ་"
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
 
-#: ../shell/control-center.c:159
-msgid "Common Tasks"
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "ཡོངས་འབྲེལ་གྱི་ སར་་བར"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "ཆོག་ཡིག་:(_P)"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "ད་ལྟོའི་ཆོག་ཡིག་:(_p)"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "མགྱོགས་འཕྲུལ་གྱི་ཐབས་ལམ།"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "འོད་རྟགས་འགུལ་སྤར་གྱི་ཚད།"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "ཁ་བྱང་།"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "ཁ་བྱང་།"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "ཁ་བྱང་།"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "སྔོན་སྒྲིག་དཔག་བྱེད།"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "མིང་:(_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "ཁ་བྱང་:(_A)"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "ཁ་བྱང་:(_A)"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "ལྕོགས་མིན།"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "ཁ་བྱང་།"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ཁ་བྱང་།"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "རང་བཞིན་སྐྱོན་འཛིན་"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "སྐར་མ།"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "ཡོངས་འབྲེལ་གྱི་ པོརོག་སི།"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "ཤུགས་ལྡན་བཟོ།(_A)"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "ཁ་བྱང་།"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "ཡོངས་འབྲེལ་གྱི་ པོརོག་སི།"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་:།(_T)"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་:།(_T)"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "ཨེཕ་ཊི་པི་ པོརོག་སི་:(_F)"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "སོཀསི་ ཧོསིཊི་:(_o)"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "<b>ཧོསིཊི་ཐོ་ཡིག་ སྣང་མེད་བཞག་</b>"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་:།(_T)"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་:།(_T)"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "ཨེཕ་ཊི་པི་ པོརོག་སི་:(_F)"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "རང་བཞིན་རིམ་སྒྲིག་ ཡུ་ཨར་ཨེལ།(_U)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "ཡོངས་འབྲེལ་གྱི་ སར་་བར"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "ཆོག་ཡིག་:(_P)"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "གདམ་ཁ་མིན་འདུག"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "བདེན་བཤད་འབད་ཡོད།"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "ཡིག་སྣོད་ཆ་མཉམ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>བདེན་བཤད་ལག་ལེན་འཐབ་</b>(_U)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "ལག་ལེན་པའི་མིང་:(_s)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "ཆོག་ཡིག་:(_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "ཆོག་ཡིག་གསརཔ་:(_N)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "ཐོན་རིམ་:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "ཐོན་རིམ་:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "བདེན་བཤད་འབད།(_A)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "ཆོག་ཡིག་གསརཔ་ལོག་སྟེ་རྐྱབས་:(_R)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "བདེན་བཤད་འབད།(_A)"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "དབྱེ་བ།"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "སྔོན་སྒྲིག"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "ཡིག་སྣོད་ཀྱི་་རིམ་ལུགས"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "སྒྲ་སྐད་ཡིག་སྣོད།"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "གློག་རིམ་གྱི་དོན་ལུ་ ཡིག་གཟུགས་གཞི་སྒྲིག་འབད།"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "སྐར་མ།"
+msgstr[1] "སྐར་མ།"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "སྐར་མ།"
+msgstr[1] "སྐར་མ།"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "སྐར་མ།"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "སྐར་མ།"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "སྐར་མ།"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "སྐར་མ།"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "སྐར་མ།"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "སྐར་མ།"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "སྐར་མ།"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "སྐར་མ།"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ཐབས་འཕྲུལ།"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "མགྱོགས་འཕྲུལ་གྱི་ཐབས་ལམ།"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "གསལ་གཞི་བཀང་།"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "གསལ་གཞི།"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "ཕྱིར་འགྱངས་:(_D)"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "དཔག་བྱེད་ཚུ།"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "དཔག་བྱེད"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "སྒྲ་སྐད་མིན་འདུག"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "བདེན་བཤད་འབད་ཡོད།"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "ལག་ལེན་པའི་མིང་:(_s)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "བྱ་བ།"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "སེལ་འཐུ་འབད།(_S)"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "བདེན་བཤད་འབད།(_A)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "བདེན་བཤད་འབད།(_A)"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "བརྟག་ཞིབ།"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "གདམ་ཁ་མིན་འདུག"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "ཡིག་གཟུགས་ལྷག་སྟོན་གྱི་རྒྱས་བཤད།"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "སྔོན་སྒྲིག་ལུ་ བསྐྱར་སྒྲིག་འབད་ (_R)"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
+msgstr "དགའ་མི་ཚུ་ལས་རྩ་བསྐྲད་གཏང་"
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "དཔེ།"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "ཨེཔ་ལེཊི་དེ་ ངེས་བདེན་སྦེ་ གཞི་བཙུགས་འབད་ཡོདཔ་ ངེས་གཏན་བཟོ།"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "འགོ་བཙུགས་སར་གཡོག་བཀོལ  (_R)"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "དཔག་བྱེད་ཚུ།"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "སྤྱིར་བཏང་"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
 msgstr "མཐུན་མོང་ལས་ཀ་ཚུ་"
 
-#: ../shell/control-center.c:163 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "ཚད་འཛིན་ལྟེ་བ་"
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "ཡིག་སྣོད་ཆ་མཉམ།"
 
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr "ལས་ཀ་ཤུགས་ལྡན་བཟོ་བའི་སྐབས་སུ་དབུས་ཀྱི་ཚད་འཛིན་ཁ་བསྡམས"
-
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr "ལ་འགན་གྲུབ་ཡོད་པའི་ལ་གཡོག་རྩ་བསྐྲེད་གཏང་་ནི་ཡང་ན་ཁ་སྐོང་བརྐྱབས་ནི་ཕྱིར་ཐོན་ཤལ།"
-
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr "ལ་འགན་འགྲུབ་ཡོད་པའི་བྱ་བ་གྲོགས་རམ་གུ་ཕྱིར་འཐོན་ཤལ"
-
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr "ལཱ་འགན་འགྲུབ་ཡོད་པའི་བྱ་བ་འགོ་བཙུགས་ནི་གུ་ཕྱིར་ཐོན་གྱི་ཤལ"
-
-#: ../shell/control-center.schemas.in.h:5
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr "ཡར་བསྐྱེད་ནི་ཡང་ན་ལཱ་འགན་འགྲུབ་ཡོད་པའི་གཞི་བཙུགས་མ་འབད་བའི་བྱ་བ་གུ་ཕྱིར་ཐོན་གྱི་ཤལ"
-
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed."
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
 msgstr ""
-"གྲོགས་རམ་བྱ་བ་འདི་ ལཱ་འགན་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ ཤལ་ཁ་བསྡམས་ནི་ཨིན་ན་མེན་ན་་བརྡ་སྟོན་འབདཝ་ཨིན། "
 
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed."
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
 msgstr ""
-"འགོ་བཙུགས་བྱ་བ་འདི་ ལཱ་འགན་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ ཤལ་ཁ་བསྡམས་ནི་ཨིན་ན་མེན་ན་ ་བརྡ་སྟོན་འབདཝ་"
-"ཨིན། "
 
-#: ../shell/control-center.schemas.in.h:8
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "སྔོན་ལྟ།:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "ལས་ཁུངས་:(_D)"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "ཕྱིར་བསྐྱོད།"
+
+#: panels/region/cc-region-panel.ui:45
 msgid ""
-"Indicates whether to close the shell when an add or remove action is "
-"performed."
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
 msgstr ""
-"བསྡོམས་ནི་ཡང་ན་བསྐྲེད་གཏང་ ནི་བྱ་བ་འདི་ལཱ་འགན་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ཤ ལ་འདི་ཁ་བསྡམས་ནི་ཨིན་ན་མེན་"
-"ན་བརྡ་སྟོན་འབདཝ་ཨིན། "
 
-#: ../shell/control-center.schemas.in.h:9
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "གསལ་གཞི་བཀང་།"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "བརྡ་བརྒྱུད་གཏང་འཕྲུལ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "བྱ་བ།"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "དབྱེ་བ:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
-"Indicates whether to close the shell when an upgrade or uninstall action is "
-"performed."
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"ཡར་བསྐྱེད་ ཡང་ན་ གཞི་བཙུགས་མ་འབད་བའི་བྱ་བ་འདི་ལཱ་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ ཤལ་འདི་ཁ་བསྡམས་ནི་ཨིན་ན་"
-"མེན་ན་ བརྡ་སྟོན་འབདཝ་ཨིན། "
 
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr "ལས་ཀའི་མིང་དང་འགན་རོགས་ཌེཀསི་ཊོབ་ཡིག་སྣོད་ཚུ"
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "གསལ་གཞི།"
 
-#: ../shell/control-center.schemas.in.h:11
+#: panels/screen/cc-screen-panel.ui:9
 msgid ""
-"The task name to be displayed in the control-center followed by a \";\" "
-"separator then the filename of an associated .desktop file to launch for "
-"that task."
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
 msgstr ""
-"ལས་ཀའི་མིང་འདི་ཚད་འཛིན་དབུས་ལུ་བཀྲམ་སྟོན་འབད་ནི་ དེ་ལས་\";\"དབྱེ་བྱེད་གྲོགས་རམ་གྱི་ ཡིག་སྣོད་ཀྱི་"
-"མིང་ །ལས་ཀ་དེ་གི་དོན་ལས་ཌེཀསི་ཊོབ་ཡིག་སྣོད་གསར་བཙུགས་འབད།"
 
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "གསལ་གཞི་ལྡེ་མིག་རྐྱབས།"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
-"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
-"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
 msgstr ""
-"[ཌེཀསི་ཊོབ་རྒྱབ་བརྟེན་སོར ;རྒྱབ་བརྟེན་ ཌེཀསི་ཊོབ བརྗོད་དོན་སོར ཇིཊི་ཀེ-བརྗོད་དོན་-སེལ་བྱེད ཌེཀསི་ཊོབ་ འཇུག་"
-"སྤྱོད་དགའ་གདམ་གཞི་སྒྲིག་ སྔོན་སྒྲིག་-འཇུག་སྤྱོད།  ཌེཀསི་ཊོབ དཔར་འཕྲུལ་ཁ་སྐོང་བརྐྱབས ཇི་ནོམ-ཀབསི- འཛིན་སྐྱོང་"
-"པ་གིས་ཌེཀསི་ཊོབ]"
 
-#: ../shell/control-center.schemas.in.h:14
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "གསལ་གཞི།"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "གསལ་གཞི།"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "གསལ་གཞི་%dགི་ གཞི་སྒྲིག་ཚུ།\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
-"if true, the control-center will close when a \"Common Task\" is activated."
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
 msgstr ""
-"གལ་སྲིད་བདེན་པ་ཅིན་  \"མཐུན་མོངས་ལས་ཀ་\"ཤུགས་བདེན་བཟོ་བའི་སྐབས་སུ་དབུས་ཀྱི་ཚད་འཛིན་ཁ་བསྡམས་"
-"འོང་། "
 
-#: ../shell/gnomecc.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "ཇི་ནོམ་རིམ་སྒྲིག་ལག་ཆས།"
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
 
-#: ../typing-break/drw-break-window.c:188
-msgid "_Postpone Break"
-msgstr "བར་མཚམས་ ཕར་འགྱངས(_P)"
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
 
-#: ../typing-break/drw-break-window.c:244
-msgid "Take a break!"
-msgstr "བར་མཚམས་ཅིག་ལེན།"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "གཞན་མི་"
 
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#. translators: keep the initial "/"
-#: ../typing-break/drwright.c:129
-msgid "/_Preferences"
-msgstr "/ དགའ་གདམ་ཚུ།(_P)"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "བྱ་བ།"
 
-#: ../typing-break/drwright.c:130
-msgid "/_About"
-msgstr "/ སྐོར་ལས།(_A)"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "གློག་རིམ་ཡིག་གཟུགས་:(_A)"
 
-#: ../typing-break/drwright.c:132
-msgid "/_Take a Break"
-msgstr "/ བར་མཚམས་ལེན།(_T)"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../typing-break/drwright.c:501
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "འཚོལ་ཞིབ་ཀྱི་མགྱོགས་ཐབས།"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "ཡོངས་འབྲེལ་གྱི་ སར་་བར"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "ཌེཀསི་ཊོཔ།"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "བརྡ་བརྒྱུད་གཏང་འཕྲུལ"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "རྩ་བསྐྲད་གཏང་།(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "ཆོག་ཡིག་:(_P)"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "ཌེཀསི་ཊོཔ།"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "ཡུ་ཨའི་ཚད་འཛིན།"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "མ་མཐུད་པས།"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "འདྲ་བཤུས།(_C)"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "བདེན་བཤད་འབད།(_A)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ལག་ལེན་པའི་མིང་:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "བརྡ་བརྒྱུད་གཏང་འཕྲུལ"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "རིམ་ལུགས་སྒྲ་སྐད།"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "སྐད་མེད།"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "ཐབས་འཕྲུལ།"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "བརྟག་ཞིབ།"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "པོརོག་སི་རིམ་སྒྲིག"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "ཐབས་འཕྲུལ།"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "སྐད་ཤུགས"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "བརྟག་ཞིབ་སྒྲ་སྐད་"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "སྒྲ་སྐད།"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "ཤུལ་མའི་བར་མཚམས་ཚུན་ཚོད་སྐར་མ་%d "
-msgstr[1] "ཤུལ་མའི་བར་མཚམས་ཚུན་ཚོད་སྐར་མ་%d"
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../typing-break/drwright.c:505
-#, c-format
-msgid "Less than one minute until the next break"
-msgstr "ཤུལ་མའི་བར་མཚམས་ཚུན་ཚོད་ སྐར་མ་གཅིག་ལས་ཉུངམ་།"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
 
-#: ../typing-break/drwright.c:592
-#, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
-msgstr ""
-"ཡིག་དཔར་བར་མཚམས་རྒྱུ་དངོས་ཀྱི་ ཌའི་ལོག་དེ་ འོག་གི་འཛོལ་བ་དང་གཅིག་ཁར་ འབག་འོང་མ་ཚུགས་: %s"
-
-#: ../typing-break/drwright.c:611
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "བྲིས་མི་ རི་ཅཱཌི་ཧཱལཊི་ <richard@imendio.com>"
-
-#: ../typing-break/drwright.c:612
-msgid "Eye candy added by Anders Carlsson"
-msgstr "ཨེན་ཌརསི་ ཀ་རཱལསི་སཱན་གྱིས་ ཁ་སྐོང་བརྐྱབས་མི་ ཨའི་ཀེན་ཌི།"
-
-#: ../typing-break/drwright.c:621
-msgid "A computer break reminder."
-msgstr "གློག་རིག་བར་མཚམས་ཀྱི་ དྲན་བསྐུལ་ཅིག"
-
-#: ../typing-break/drwright.c:623
-msgid "translator-credits"
-msgstr ""
-"ཨའི་ཌི་ཨར་སི་གི་ མ་དངུལ་རྒྱབ་སྐྱོར་ཐོག་ལས་ བརྡ་དོན་འཕྲུལ་རིག་ལས་ཁུངས་ནང་ སྐད་བསྒྱུར་འབད་ཡི། ཁ་གསལ་"
-"གྱི་དོན་ལུ་ འབྲེལ་བ་འཐབ་ས་: <pema_geyleg@druknet.bt>"
-
-#: ../typing-break/main.c:61
-msgid "Enable debugging code"
-msgstr "རྐྱེན་སེལ་འབད་བའི་ཨང་རྟགས་ལྕོགས་ཅན་བཟོ"
-
-#: ../typing-break/main.c:63
-msgid "Don't check whether the notification area exists"
-msgstr "བརྡ་བསྐུལ་གནས་ཁོངས་ཡོད་ག་མེད་ག་ཞིབ་དཔྱད་མ་འབད"
-
-#: ../typing-break/main.c:89
-msgid "Typing Monitor"
-msgstr "ཡིག་དཔར་བརྐྱབ་ནིའི་ལྟ་རྟོག་པ།"
-
-#: ../typing-break/main.c:105
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
-msgstr ""
-"ཡིག་དཔར་བརྐྱབ་ནིའི་གསལ་གཞི་དེ་གིས་ བརྡ་བསྐུལ་མངའ་ཁོངས་དེ་ བརྡ་དོན་བཀྲམ་སྟོན་གྱི་དོན་ལུ་ ལག་ལེན་འཐབ་"
-"ཨིན། ཁྱོད་ཀྱི་པེ་ནཱལ་གུ་ བརྡ་བསྐུལ་མངའ་ཁོངས་ མེདཔ་བཟུམ་ཅིག་འདུག ཁྱོད་ཀྱིས་ཁྱོད་རའི་པེ་ནཱལ་གུ་ གཡས་ཀྱི་ཨེབ་"
-"གཏང་འབད་དེ་ ‘པེ་ནཱལ་གུ་ཁ་སྐོང་རྐྱབས་’ ཟེར་མི་གདམ་ཁ་བརྐྱབས་པའི་སྒོ་ལས་ བརྡ་བསྐུལ་མངའ་ཁོངས་ སེལ་འཐུ་"
-"འབད་དེ་ ཁ་སྐོང་བརྐྱབ་ནི་ལུ་ ཨེབ་གཏང་འབད་བའི་ཐོག་ལས་ བརྡ་བསྐུལ་མངའ་ཁོངས་ ཁ་སྐོང་བརྐྱབ་ཚུགས།"
-
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
-msgstr "གློག་རིམ་ཡིག་གཟུགས་བཟུམ་སྦེ་ གཞི་སྒྲིག་འབད།"
-
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
-msgid "Sets the default application font"
-msgstr "སྔོན་སྒྲིག་གློག་རིམ་ཡིག་གཟུགས་དེ་ གཞི་སྒྲིག་འབད།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr ""
-"བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་ ཨོ་པཱན་ཊ་ཡིཔ་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་པི་སི་ཨེཕ་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr ""
-"བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་ ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr ""
-"བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་ ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
-msgstr ""
-"ལྡེ་མིག་འདི་ ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ "
-"བརྡ་བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr ""
-"ལྡེ་མིག་འདི་ ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ "
-"བརྡ་བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr ""
-"ལྡེ་མིག་འདི་ ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ བརྡ་"
-"བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr ""
-"ལྡེ་མིག་འདི་ ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ བརྡ་"
-"བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "པི་སི་ཨེཕ་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "པི་སི་ཨེཕ་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
-
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr ""
-"ཨ་ཡིག་དཀར་མཛེས་ལས་འཁྲུངས་ཤེས་བློའི་གཏེར།། ཕས་རྒོལ་ཝ་སྐྱེས་ཟིལ་གནོན་གདོང་ལྔ་བཞིན།། ཆགས་ཐོགས་ཀུན་བྲལ་"
-"མཚུངས་མེད་འཇམ་དབྱངས་མཐུས།། མཧཱ་མཁས་པའི་གཙོ་བོར་ཉིད་གྱུར་ཅིག ༠༡༢༣༤༥༦༧༨༩"
-
-#: ../vfs-methods/fontilus/font-view.c:276
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "མིང་:"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "བཟོ་རྣམ་:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "དབྱེ་བ:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "ཚད་:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "ཐོན་རིམ་:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "ཐབས་འཕྲུལ།"
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "འདྲ་བཤུས་དབང་ཆ་:"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "འགྲེལ་བཤད་:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:408
-#, c-format
-msgid "usage: %s fontfile\n"
-msgstr "ལག་ལེན་: ཡིག་གཟུགས་ཡིག་སྣོད་%s \n"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
 
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
-msgid "Font Viewer"
-msgstr "་ཡིག་གཟུགས་མཐོང་འབྱེད་ "
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "Preview fonts"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "ཐབས་འཕྲུལ།"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "ཐཱན་ཌར་བཌི།"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>འོད་རྟགས་འགུལ་སྤར་འབད་དོ་</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "འོད་རྟགས་དེ་ ཚིག་ཡིག་ས་སྒོ་ཚུ་ནང་ འགུལ་སྤར་འབདཝ་ཨིན  (_B)"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "མགྱོགསཚད་:(_S)"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "འོད་རྟགས་འགུལ་སྤར་གྱི་ཚད།"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "འོད་རྟགས་འགུལ་སྤར་གྱི་ཚད།"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "<b>མཚུངས་པ་བཟོ་ཡོད་པའི་ གལ་གནད་ཆུང་བའི་ཨེབ་གཏང་</b>"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+#, fuzzy
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "གཞི་རིམ་ཨེབ་གཏང་ འཆང་ཐོག་ལས་ གལ་གནད་ཆུང་བའི་ཨེབ་གཏང་ ལཱ་འབད་བཅུག་ (_T)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "མགྱོགས་ཐབས།"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "གལ་གནད་ཆུང་བའི་ཨེབ་གཏང: (_N)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr " "
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+#, fuzzy
+msgid "Trigger a click when the pointer hovers"
+msgstr "དཔག་བྱེད་ཀྱི་ འགུལ་སྤྱོད་བཀག་བཞག་པའི་སྐབས་ ཨེབ་གཏང་འགོ་བཙུགས་ (_I)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "ཕྱིར་འགྱངས་:(_E)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "མགྱོགས་ཐབས།"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "མོ་ཤཱན་ ཐེ་རེཤི་ཧཱོལཌི་:(_T)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "ཆུང་ཀུ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "ཆེ་བ་ "
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>ལྡེ་མིག་ཚུ་ཡང་བསྐྱར་འབད་</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "ལྡེ་མིག་མར་འཆང་སྟེ་ཡོད་པའི་སྐབས་ ལྡེ་མིག་གིས་ ཡང་བསྐྱར་ཨེབ་ཨིན།(_r)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "ལྡེ་མིག་ཡང་བསྐྱར་གྱི་ཚད།"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "ལྡེ་མིག་ཡང་བསྐྱར་གྱི་ཚད།"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "ཡིག་དཔར་བརྐྱབ་ནིའི་ལྟ་རྟོག་པ།"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "སྦྱར་རྩི་ཅན་གྱི་ལྡེ་མིག་དྲན་བརྡ།"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "ལྡེ་མིག་གཉིས་གཅིག་ཁར་ཨེབ་པ་ཅིན་ སྦྱར་རྩིས་ལྡེ་མིག་ཚུ་ ལྕོགས་མིན་བཟོཝ་ཨིན་ (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "ལེགས་བཅོས་འབད་མི་ལྡེ་མིག་ཅིག་ཨེབ་པའི་སྐབས་ བརྡ་སྐད་རྐྱབས་  (_M)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "ལྡེ་མིག་དྲན་བརྡ་ལྷོད།"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "མགྱོགས་ཐབས།"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "ལྡེ་མིག་ ཨེབ་པའི་སྐབས་ བརྡ་སྐད་རྐྱབས་(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "ལྡེ་མིག་ཨིན་པའི་སྐབས་ བརྡ་སྐད་རྐྱབས་ (_A)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "ལྡེ་མིག་ལུ་ ངོས་ལེན་མེད་པ་ཅིན་ བརྡ་སྐད་རྐྱབས་(_C)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "<b>ལྡེ་མིག་ཚུ་ ཡར་འཕར་བཟོ་</b>(_u)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "ལྡེ་མིག་ཨེབ་གནོན་ ངོ་བཤུས་ཚུ་ སྣང་མེད་བཞག་ (_I)"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "མགྱོགས་ཐབས།"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "ལྡེ་སྒྲོམ་གུ་ལས་ འཛུལ་སྤྱོད་ཁྱད་རྣམ་ཚུ་ ཨོན་དང་ཨོཕ་ འབད་བཅུག་ (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད(_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "ཆེ་བ་ "
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "ལའི་ནགསི་གསལ་གཞི་ལྷག་མི"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "སྒྲ་སྐད་ཚུ་:(_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "ཁྱད་རྣམ་དེ་ཚུ་  ཨཱོན་དང་ཨོཕ་འགྱོ་བའི་སྐབས་ བརྡ་སྐད་རྐྱབས།( _F)"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "རྒྱས་ཟུམ།"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "མཐོང་བའི"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "གསལ་གཞི་ལྡེ་སྒྲོམ་གུ་ཇི་ནོམ།"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>ལྡེ་མིག་ཚུ་ཡང་བསྐྱར་འབད་</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>འོད་རྟགས་འགུལ་སྤར་འབད་དོ་</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "མཱའུསི་གི་ལྡེ་མིག་ཚུ།"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "དཔག་བྱེད་ཆེ་བ།"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "<b>ཨེབ་གཏང་ ཐེངས་གཉིས་ཀྱི་ངལ་མཚམས་</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr " "
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+#, fuzzy
+msgid "Visual Alerts"
+msgstr "མཐོང་བའི"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "གསལ་གཞི་ཧྲིལ་བུ་ རིབ་སྟོན་འབད།(_e)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "གསལ་གཞི་ཧྲིལ་བུ་ རིབ་སྟོན་འབད།(_e)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "གསལ་གཞི་བཀང་།"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "གཡོན"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "གཡས"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "གདམ་ཁ་ཚུ།"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "གསལ་གཞི།"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "ཆེ་ཤེལ་ཨོར་ཀ་དག་བཅསཔ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "ཚོས་གཞི་ཚུ་"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "དཀར་མདངས་ཡར་སེང་།"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "འབྲེལ་ས"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "ཅི་མེད་"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "གང་།(_F)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "ཚོས་གཞི་ཚུ་"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ཡིག་སྣོད་ཀྱི་་རིམ་ལུགས"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "ཕྱགས་ཧོད་ལུ་སྤོ་"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "ཤུགས་མེད་མ་བཟོ།(_n)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "རྩ་གྲོལ་གཏང་མི་ "
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "ཆོག་ཡིག་གསརཔ་:(_N)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "སྒྲ་སྐད་ཡིག་སྣོད་སེལ་འཐུ་འབད།"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "སྒོ་སྒྲིག་འཛིན་སྐྱོང་པ།"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "ཅི་མེད།(_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
 msgstr "ཡིག་གཟུགས་ སྔོན་ལྟ་ "
 
-#: ../vfs-methods/fontilus/thumbnailer.c:242
-msgid "Text to thumbnail (default: Aa)"
-msgstr "མཐེ་གཟེར་ལུ་ཚིག་ཡིག་(སྔོན་སྒྲིག: Aa)"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
 
-#: ../vfs-methods/fontilus/thumbnailer.c:242
-msgid "TEXT"
-msgstr "ཚིག་ཡིག"
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "ཆོག་ཡིག་སོར།"
 
-#: ../vfs-methods/fontilus/thumbnailer.c:244
-msgid "Font size (default: 64)"
-msgstr "ཡིག་གཟུགས་ཚད (སྔོན་སྒྲིག: ༦༤)"
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "་ཆ་ཚན་བསྒྱུར་བཅོས་འབད"
 
-#: ../vfs-methods/fontilus/thumbnailer.c:244
-msgid "SIZE"
-msgstr "ཚད"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "ད་ལྟོའི་ཆོག་ཡིག་:(_p)"
 
-#: ../vfs-methods/fontilus/thumbnailer.c:246
-msgid "FONT-FILE OUTPUT-FILE"
-msgstr "ཡིག་གཟུགས་ཡིག་སྣོད་ ཨའུཊི་པུཊི་ཡིག་སྣོད"
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "ཆོག་ཡིག་གསརཔ་:(_N)"
 
-#: ../vfs-methods/fontilus/thumbnailer.c:262
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "ཆོག་ཡིག་སོར།"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "ཆོག་ཡིག་དེ་ཐུང་དྲགས་པས།"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "ཆོག་ཡིག་གསརཔ་:(_N)"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "མིང་ཆ་ཚང་།"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "ཞུན་དག་ "
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "ཚད་འཛིན་ཚུ།"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "གློག་རིམ་གྱི་དོན་ལུ་ ཡིག་གཟུགས་གཞི་སྒྲིག་འབད།"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "གཞན་མི་"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "སྒྲ་སྐད་མིན་འདུག"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "ཨེབ་རྟ་ཚུ།"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "ཕྱོགས།"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "ཡིག་དཔར་བརྐྱབ་ནིའི་ལྟ་རྟོག་པ།"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "ཨེབ་རྟ་ཚུ།"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ཨེབ་རྟ་ཚུ།"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ཨེབ་རྟ་ཚུ།"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "སྒྲིག་བཀོད།"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "རྩ་ལག་སྒོ་སྒྲིག་"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "གལ་གནད་ཆུང་བའི་ཨེབ་གཏང: (_N)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "སྒོ་སྒྲིག་ཚུ།"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "རྫོགས་ནིའི་དོན་ལུ་ བཏུབ་གུ་ཨེབ་གཏང་འབད།"
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "གལ་གནད་ཆུང་བའི་ཨེབ་གཏང: (_N)"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "སྒོ་སྒྲིག་ཚུ།"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "འཛུལ་སྤྱོད་ནང་བསྐྱོད(_g)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "ཁ་སྐོང་རྐྱབས་..."
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "སྲུངས།(_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "བརྗོད་དོན་གྱི་རྒྱས་བཤད།"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "ཡོངས་འབྲེལ་གྱི་ པོརོག་སི།"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "ཡོངས་འབྲེལ་གྱི་ སར་་བར"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "བརྗོད་དོན་གྱི་རྒྱས་བཤད།"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid "Error parsing arguments: %s\n"
-msgstr "སྒྲུབ་རྟགས་མིང་དཔྱད་འབདཝ་ད་འཛོལ་བ : %s\n"
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
-"<span weight=\"bold\" size=\"larger\">ཡིག་གཟུགས་གསརཔ་ འཇུག་སྤྱོད་འབད་ནི་ཨིན་ན?</span>"
 
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "Do _not apply font"
-msgstr "ཡིག་གཟུགས་འཇུག་སྤྱོད་མ་འབད།(_n)"
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:3
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "འགྲུལ་འཕྲིན་:(_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "ཡོངས་འབྲེལ་གྱི་ པོརོག་སི།"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "ཡོངས་འབྲེལ་གྱི་ པོརོག་སི།"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "བརྗོད་དོན་གྱི་རྒྱས་བཤད།"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "ཡོངས་འབྲེལ་གྱི་ པོརོག་སི།"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "བདེན་བཤད་འབད།(_A)"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "ཡོངས་འབྲེལ་གྱི་ སར་་བར"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "སོར་སྟོན་ལྡེ་མིག་ཚུ་ ལྕོགས་ཅན་བཟོ།(_n)"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "མཐུད་དོ་..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "་ཆ་ཚན་བསྒྱུར་བཅོས་འབད"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "སྔོན་སྒྲིག་གཞི་སྒྲིག་ཚུ།"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
 msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
-"ཁྱོད་ཀྱིས་སེལ་འཐུ་འབད་མི་ བརྗོད་དོན་དེ་གིས་ ཡིག་གཟུགས་གསརཔ་ཅིག་གི་ བསམ་འཆར་བཀོདཔ་ཨིན་པས། ཡིག་"
-"གཟུགས་ཀྱི་སྔོན་ལྟ་ཅིག་ འོག་ལུ་སྟོན་ཏེ་ཡོད།"
 
-#: ../vfs-methods/themus/apply-font.glade.h:4
-msgid "_Apply font"
-msgstr "ཡིག་གཟུགས་འཇུག་སྤྱོད་འབད།(_A)"
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "གྲོགས་རམ་"
 
-#: ../vfs-methods/themus/theme-method.c:485
-msgid "Themes"
-msgstr "བརྗོད་དོན་ཚུ།"
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "ཡོངས་ཁྱབ་ "
 
-#: ../vfs-methods/themus/themus-properties-view.c:127
-msgid "Description"
-msgstr "འགྲེལ་བཤད།"
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "སྤངས་།(_Q)"
 
-#: ../vfs-methods/themus/themus-properties-view.c:134
-msgid "Control theme"
-msgstr "ཚད་འཛིན་བརྗོད་དོན།"
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "འཚོལ་ཞིབ།"
 
-#: ../vfs-methods/themus/themus-properties-view.c:140
-msgid "Window border theme"
-msgstr "སྒོ་སྒྲིག་གི་མཐའ་མཚམས་ཀྱི་བརྗོད་དོན།"
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
 
-#: ../vfs-methods/themus/themus-properties-view.c:146
-msgid "Icon theme"
-msgstr "ངོས་དཔར་གྱི་བརྗོད་དོན།"
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "ཧེ་མའི་གླུ་རིམ་ལུ་གོམ་འགྱོ།"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ གཞི་བཙུགས་འབད་མི་བརྗོད་དོན་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ བརྗོད་དོན་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/ དགའ་གདམ་ཚུ།(_P)"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:3
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
 msgstr ""
-"ལྡེ་མིག་འདི་ གཞི་བཙུགས་འབད་དེ་ཡོད་མི་ བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་"
-"འཐབ་མི་ བརྡ་བཀོད་ལུ་གཞི་སྒྲིག་འབད།"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
 msgstr ""
-"ལྡེ་མིག་འདི་ བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ བརྡ་བཀོད་ལུ་གཞི་"
-"སྒྲིག་འབད།"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr "གཞི་བཙུགས་འབད་དེ་ཡོད་པའི་ བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr "བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr "གཞི་བཙུགས་འབད་དེ་ཡོད་པའི་ བརྗོད་དོན་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr "བརྗོད་དོན་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:58
-msgid "ABCDEFG"
-msgstr "ཀ་ཁ་ག་ང་།་ཅ་ཆ་ཇ་ཉ།"
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../vfs-methods/themus/themus-theme-applier.c:84
-msgid "[FILE]"
-msgstr "[ཡིག་སྣོད]"
+#~ msgid "Image/label border"
+#~ msgstr "གཟུགས་བརྙན་/ཁ་ཡིག་གི་མཐའ་མཚམས།"
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-msgid "Apply theme"
-msgstr "བརྗོད་དོན་ལག་ལེན་འཐབ།"
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "དྲན་བརྡའི་ཌའི་ལོག་ནང་ ཁ་ཡིག་དང་ གཟུགས་བརྙན་གྱི་མཐའ་སྐོར་ལུ་ མཐའ་མཚམས་ཀྱི་རྒྱ་ཚད།"
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-msgid "Sets the default theme"
-msgstr "སྔོན་སྒྲིག་བརྗོད་དོན་ གཞི་སྒྲིག་འབད།"
+#~ msgid "The type of alert"
+#~ msgstr "དྲན་བརྡའི་དབྱེ་བ།"
 
-msgid "Show help options"
-msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
+#~ msgid "Alert Buttons"
+#~ msgstr "དྲན་བརྡའི་ཨེབ་རྟ་ཚུ།"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "དྲན་བརྡའི་ཌའི་ལོག་ནང་སྟོན་མི་ཨེབ་རྟ་ཚུ།"
+
+#~ msgid "Show more _details"
+#~ msgstr "རྒྱས་བཤད་ཧེང་བཀལ་སྟོན།(_d)"
+
+#~ msgid "No Image"
+#~ msgstr "གཟུགས་བརྙན་མིན་འདུག"
+
+#~ msgid "Images"
+#~ msgstr "གཟུགས་བརྙན་ཚུ།"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "ཁ་བྱང་ཀི་དེབ་ཀྱི་ བརྡ་དོན་ལེན་ཐབས་འབད་བའི་སྐབས་ལུ་ འཛོལ་བ་ཅིག་བྱུང་ནུགཨི་བོ་ལུ་ཤཱན་ གནད་སྡུད་སར་"
+#~ "བར་གྱིས་ གནད་སྤེལ་ལམ་ལུགས་ ལེགས་སྐྱོང་འཐབ་མི་ཚུགས་པས།"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "ཁ་བྱང་ཀི་དེབ་ ཁ་ཕྱེ་མ་ཚུགས།"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr ""
+#~ "མ་ཤེསས་པའི་ ནང་བསྐྱོད་ཨའི་ཌི། ལག་ལེན་པའི་ གཞི་རྟེན་གནད་སྡུད་ ངན་ཅན་ལུ་གྱུར་སོངཔ་འོང་ནི་མས།"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "%sསྐོར་ལས།"
+
+#~ msgid "About Me"
+#~ msgstr "ངེད་ཀྱི་སྐོར་ལས།"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>ཁྱིམ་ </b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>འཕྲལ་མྱུར་འཕྲིན་གཏོང་།</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>ལས་གཡོག</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>བརྒྱུད་འཕྲིན་</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>ཝེབ་</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>ལཱ་གཡོག་</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">ཁྱོད་རའི་ཆོག་ཡིག་སོར་</span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "ཨེ་ཨའི་ཨེམ/ཨའི་ཅེཊི་:(_I)"
+
+#~ msgid "A_ddress:"
+#~ msgstr "ཁ་བྱང་:(_d)"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "ལས་རོགས་:(_s)"
+
+#~ msgid "C_ity:"
+#~ msgstr "གྲོང་སྡེ་:(_i)"
+
+#~ msgid "C_ompany:"
+#~ msgstr "ཚོང་སྡེ་:(_o)"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "ཆོག་ཡིག་སོར་...(_r)"
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "ཆོག་ཡིག་སོར།(_s)"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "གྲོང་སྡེ་:(_t)"
+
+#~ msgid "Co_untry:"
+#~ msgstr "རྒྱལ་ཁབ་:(_u)"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "རྒྱལ་ཁབ་:(_n)"
+
+#~ msgid "Hom_e:"
+#~ msgstr "ཁྱིམ། (_e)"
+
+#~ msgid "IC_Q:"
+#~ msgstr "ཨའི་སི་ཀིའུ་:(_Q)"
+
+#~ msgid "M_SN:"
+#~ msgstr "ཨེམ་ཨེསི་ཨེན་:(_S)"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "འགྲེམ་ཁང་ཡིག་སྒྲོམ་:(_b)"
+
+#~ msgid "P._O. box:"
+#~ msgstr "འགྲེམ་ཁང་ཡིག་སྒྲོམ་:(_O)"
+
+#~ msgid "Personal Info"
+#~ msgstr "རང་དོན་བརྡ་དོན།"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "<b>ཆོག་ཡིག་གསརཔ་ལོག་ཡིག་དཔར་རྐྱབས་</b> ཟེར་མི་ས་སྒོ་ནང་ ཁྱོད་རའི་ཆོག་ཡིག་ ལོག་སྟེ་རང་ཡིག་དཔར་"
+#~ "རྐྱབས།"
+
+#~ msgid "Select your photo"
+#~ msgstr "ཁྱོད་རའི་དཔར་ སེལ་འཐུ་འབད་ "
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "མངའ་སྡེ་.མངའ་རིས་:(_v)"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "ཁྱོད་རའི་ཆོག་ཡིག་སོར་ནི་ལུ་ འོག་གི་སྒོ་ནང་ད་ལྟོའི་ཆོག་ཡིག་ཞིནམ་ལས་ <b>བདེན་བཤད་</b> ལུ་ཨེབ་གཏང་"
+#~ "འབད། བདེན་བཤད་འབད་ཞིནམ་ལས་ ཁྱོད་རའི་ཆོག་ཡིག་གསརཔ་བཙུགས། བདེན་སྦྱོར་གྱི་དོན་ལུ་ ཆོག་ཡིག་དེ་ལོག་"
+#~ "སྟེ་རང་ཚར་ཅིག་ཡིག་དཔར་བརྐྱབས་ཞིནམ་ལས་ <b>ཆོག་ཡིག་སོར་</b> ལུ་ཨེབ་གཏང་འབད།"
+
+#~ msgid "Web _log:"
+#~ msgstr "ཝེབ་དྲན་དེབ་:(_l)"
+
+#~ msgid "Wor_k:"
+#~ msgstr "ལཱ་གཡོག་:(_k)"
+
+#~ msgid "Work _fax:"
+#~ msgstr "ལཱ་གི་དཔར་འཕྲིན་:(_f)"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "གནས་ཨང་/འགྲེམ་ཨང་:(_p)"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "སྡེ་རིམ་:(_G)"
+
+#~ msgid "_Home page:"
+#~ msgstr "ཁྱིམ་གྱི་ཤོག་ལེབ་:(_H)"
+
+#~ msgid "_Home:"
+#~ msgstr "ཁྱིམ་:(_H)"
+
+#~ msgid "_Jabber:"
+#~ msgstr "ཇེབ་བར་:(_J)"
+
+#~ msgid "_Manager:"
+#~ msgstr "འཛིན་སྐྱོང་པ་:(_M)"
+
+#~ msgid "_Profession:"
+#~ msgstr "ཁྱད་ལས་:(_P)"
+
+#~ msgid "_State/Province:"
+#~ msgstr "མངའ་སྡེ་/མངའ་རིས།"
+
+#~ msgid "_Title:"
+#~ msgstr "གོ་གནས་:(_T)"
+
+#~ msgid "_Work:"
+#~ msgstr "ལཱ་གཡོག་:(_W)"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "ཡ་ཧུ་:(_Y)"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "གནས་ཨང་/འགྲེམ་ཨང་:(_Z)"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "ཆ་ལག་རེ་བ་མེད་པར་ཕྱིར་ཐོན་སོང་ནུག"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "རྒྱབ་མཐའི་ ཨེསི་ཊི་ཌི་ཨིན་ ཨའི་ཨོ་རྒྱུ་ལམ་:%sསྒོ་བསྡམ་མ་ཚུགས།"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "རྒྱབ་མཐའི་ ཨེསི་ཊི་ཌི་ཨའུཊི་ཨའི་ཨོ་རྒྱུ་ལམ་:%sསྒོ་བསྡམ་མ་ཚུགས།"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱིས་འགོ་ཐོག་ལུ་ བདེན་བཤད་འབད་ཞིནམ་ལས་ ཁྱོད་ཀྱི་ཆོག་ཡིག་སོར་ནུག སླར་བདེན་བཤད་འབད་གནང་།"
+
+#~ msgid "That password was incorrect."
+#~ msgstr "ཆོག་ཡིག་དེ་བདེན་མེད་ཨིན་པས།"
+
+#~ msgid "Your password has been changed."
+#~ msgstr "ཁྱོད་ཀྱིས་ཆོག་ཡིག་དེ་སོར་ནུག"
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "རིམ་ལུགས་འཛོལ་བ་:%s།"
+
+#~ msgid "The password is too simple."
+#~ msgstr "ཆོག་ཡིག་དེ་འཇམ་དྲགས་པས།"
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "ཆོག་ཡིག་རྙིངམ་དང་གསརཔ་འདྲ་བས།"
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "ཆོག་ཡིག་གསར་པའི་ནང་ཨང་གྲངས་ ཡང་ན་ དམིགས་བསལ་ཡིག་འབྲུ་(ཚུ) ཡོད་དགོ"
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "ཆོག་ཡིག་རྙིངམ་དང་གསརཔ་ཅོག་གཅིག་པས།"
+
+#, c-format
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%s:%s གསར་བཙུགས་འབད་མ་ཚུགས།"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "རྒྱབ་མཐའ་གསར་བཚུགས་འབད་མི་བཙུགས་པས།"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "རིམ་ལུགས་ཀྱི་འཛོལ་བ་ཅིག་བྱུང་ནུག"
+
+#~ msgid "Checking password..."
+#~ msgstr "ཆོག་ཡིག་ཞིབ་དཔྱད་འབད་དོ།"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "ཁྱོད་རའི་ཆོག་ཡིག་སོར་ནིའི་དོན་ལུ་<b>ཆོག་ཡིག་སོར་</b> གུ་ཨེབ་གཏང་འབད།"
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr " <b>ཆོག་ཡིག་གསར་པའི་</b> ས་སྒོ་ནང་ ཁྱོད་རའི་ཆོག་ཡིག་ ཡིག་དཔར་རྐྱབས།"
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "ཆོག་ཡིག་གཉིསཔོ་དེ་འདྲ་མཉམ་མེན་པས།"
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>ཕན་ཐབས་ཅན་གྱི་འཕྲུལ་རིག་ཚུ</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>དགའ་གདམ་ཚུ</b>"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་གི་དགའ་གདམ་ཚུ་ "
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "འཕྲུལ་རིག་ལྕོགས་ཅན་ཕན་འཐབ་བསྒྱུར་བཅོས་ཚུ་ལུ་ ཤུལ་མའི་ནང་བསྐྱོད་མ་འབད་ཚུན་ཚོད་ ནུས་པ་མི་འོང་།"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "ཁ་བསྡམས་ཏེ་ ཕྱིར་བསྐྱོད་འབད།(_L)"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "དགའ་གདམ་ཅན་གྱི་འཇུག་སྤྱོད་ཌའི་ལོག་ལུ་མཆོང་"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "ནང་བསྐྱོད་ཌའི་ལོག་འཛུལ་སྤྱོད་ནང་ལུ་མཆོང་"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད་ཌའི་ལོག་ལུ་མཆོང་"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "ཕན་ཐབས་ཅན་གྱི་འཕྲུལ་རིག་ཚུ་ ལྕོགས་ཅན་བཟོ།(_E)"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "དགའ་གདམ་ཅན་གྱི་འཇུག་སྤྱོད(_P)"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "ཕན་ཐབས་ཅན་གྱི་འཕྲུལ་རིག་ཚུ་ "
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "ནང་བསྐྱོད་སྐབས་ལུ་ ཇི་ནོམ་གྱི་ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་ཚུ་གི་དོན་ལུ་ རྒྱབ་སྐྱོར་ལྕོགས་ཅན་བཟོ།"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "གྱང་ཤོག་ཁ་སྐོང་རྐྱབས།"
+
+#~ msgid "Font may be too large"
+#~ msgstr "ཡིག་གཟུགས་ཆེ་དྲགས་ནི་མས།"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་%d ཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་"
+#~ "པར་ལཱ་ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་%dལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
+#~ msgstr[1] ""
+#~ "སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་%dཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་"
+#~ "ལཱ་ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་%dལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་%dཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་"
+#~ "ལཱ་ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་ དེ་ལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
+#~ msgstr[1] ""
+#~ "སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་ %dཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་"
+#~ "པར་ལཱ་ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་ དེ་ལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
+
+#~ msgid "Use previous font"
+#~ msgstr "ཧེ་མའི་ཡིག་གཟུགས་ ལག་ལེན་འཐབ་"
+
+#~ msgid "Use selected font"
+#~ msgstr "སེལ་འཐུ་འབད་ཡོད་པའི་ཡིག་གཟུགས་ལག་ལེན་འཐབ་"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ བརྗོད་དོན་ཅིག་གི་ ཡིག་སྣོད་མིང་གསལ་བཀོད་འབད་"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "ཤོག་ལེབ་ཀྱི་མིང་སྟོན་ནི་གི་དོན་ལས་གསལ་བཀོད་འབད (བརྗོད་དོན|རྒྱབ་བརྟེན|ཡིག་གཟུགས་ཚུ|ཨིན་ཊར་ཕེའིསི)"
+
+#~ msgid "page"
+#~ msgstr "ཤོག་ལེབ"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid "Apply Background"
+#~ msgstr "རྒྱབ་གཞི་ འཇུག་སྤྱོད་འབད་ "
+
+#~ msgid "Apply Font"
+#~ msgstr "ཡིག་གཟུགས་ འཇུག་སྤྱོད་འབད་ "
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "ད་ལྟོའི་བརྗོད་དོན་འདི་གིས་ རྒྱབ་གཞི་དང་ཡིག་གཟུགས་ཅིག་གི་ བསམ་འཆར་་བཀོདཔ་མས།"
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "ད་ལྟོའི་བརྗོད་དོན་འདི་གིས་ རྒྱབ་གཞི་ཅིག་གི་ བསམ་འཆར་་བཀོདཔ་མས།"
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "ད་ལྟོའི་ བརྗོད་དོན་འདི་གིས་ ཡིག་གཟུགས་ཅིག་གི་ བསམ་འཆར་བཀོདཔ་མས།"
+
+#~ msgid "Custom"
+#~ msgstr "སྲོལ་སྒྲིག"
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>ཚོས་གཞི་</b>(_o)"
+
+#~ msgid "<b>Hinting</b>"
+#~ msgstr "<b>བརྡ་མཚོན་སྟོན་དོ</b>"
+
+#~ msgid "<b>Menus and Toolbars</b>"
+#~ msgstr "<b>དཀར་ཆག་དང་ ལག་ཆས་ཕྲ་རིང་ཚུ</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>སྔོན་ལྟ་</b>"
+
+#~ msgid "<b>Rendering</b>"
+#~ msgstr "<b>ལྷག་སྟོན་འབད་དོ་</b>"
+
+#~ msgid "<b>Smoothing</b>"
+#~ msgstr "<b>ཧུམ་ཁྱུག་བཟོ་དོ</b>"
+
+#~ msgid "<b>Subpixel Order</b>"
+#~ msgstr "<b>སབ་པིཀ་སེལ་གོ་རིམ</b>"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>གྱང་ཤོག(_W)</b>"
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "བརྗོད་དོན་གྱི་དགའ་གདམ་ཚུ"
+
+#~ msgid "Best _shapes"
+#~ msgstr "བཟོ་དབྱིབས་ལེགས་ཤོས།(_s)"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "ཁྱད་པར་ལེགས་ཤོས།(_n)"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "སྲོལ་སྒྲིག་འབད་...(_u)"
+
+#~ msgid "C_ut"
+#~ msgstr "བཏོག(_C)"
+
+#~ msgid ""
+#~ "Centered\n"
+#~ "Fill screen\n"
+#~ "Scaled\n"
+#~ "Zoom\n"
+#~ "Tiled"
+#~ msgstr ""
+#~ "སྦུག་ལུ་ཡོདཔ\n"
+#~ " གསལ་གཞི་གངམ\n"
+#~ "ཚད་འཇལ་ཡོདཔ\n"
+#~ "རྒྱས་ཟུམ\n"
+#~ "ཊ་ཡིལཊི"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr ""
+#~ "ཁྱོད་རའི་ འོག་རྟགས་ཀྱི་བརྗོད་དོན་ སོར་མི་དེ་གིས་ ཁྱོད་ཤུལ་ལས་ ནང་བསྐྱོད་འབདཝ་ད་ ནུས་པ་ཐོབ་འོང་། "
+
+#~ msgid "Customize Theme"
+#~ msgstr "སྲོལ་སྒྲིག་ བརྗོད་དོན"
+
+#~ msgid "D_etails..."
+#~ msgstr "རྒྱས་བཤད་...(_e)"
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "ཌེཀསི་ཊོཔ་ཡིག་གཟུགས་:(_k)"
+
+#~ msgid "Fonts"
+#~ msgstr "ཡིག་གཟུགས་ཚུ"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "གེརེ་སིཀེལ།(_y)"
+
+#~ msgid "Icons"
+#~ msgstr "ངོས་དཔར་ཚུ།"
+
+#~ msgid "Interface"
+#~ msgstr "ཨིན་ཊར་་ཕེའིསི"
+
+#~ msgid "N_one"
+#~ msgstr "ཅི་མེད།(_o)"
+
+#~ msgid "New File"
+#~ msgstr "ཡིག་སྣོད་གསརཔ།"
+
+#~ msgid "Open File"
+#~ msgstr "ཡིག་སྣོད་ཁ་ཕྱེ།"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "ཚོས་གཞི་གསལ་བཀོད་ཀྱི་དོན་ལུ་ ཌའི་ལོག་ཅིག་ཁ་ཕྱེ།"
+
+#~ msgid "R_esolution:"
+#~ msgstr "ཧུམ་ཆ་:(_e)"
+
+#~ msgid "Save File"
+#~ msgstr "ཡིག་སྣོད་སྲུངས།"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "བཟུམ་སྦེ་ བརྗོད་དོན་སྲུངབཞག་འབད་..."
+
+#~ msgid "Save _As..."
+#~ msgstr "བཟུམ་སྦེ་ བརྗོད་དོན་སྲུངབཞག་འབད་... (_A)"
+
+#~ msgid "Save _background image"
+#~ msgstr "རྒྱབ་གཞི་གཟུགས་བརྙན་སྲུངས་ (_B)"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "དཀར་ཆག་ནང་ ངོས་དཔར་ཚུ་སྟོན།(_i)"
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "རགས་པའི་མཚོ་གཞི\n"
+#~ "ཐད་སྙོམ་སྟེགས་རེས\n"
+#~ "ཀེར་ཕྲང་སྟེགས་རེས"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "ཡན་ལག་པིཀ་སེལ། (ཨེལ་སི་ཌི་ཨེསི)(_p)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "ཡན་ལག་་པིཀ་སེལ་ ཧུམ་ཁྱུག་བཟོ་དོ། (ཨེལ་སི་ཌི་ཨེསི)(_p)"
+
+#~ msgid "Text"
+#~ msgstr "བརྟག་ཞིབ་"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "ཚིག་ཡིག་རྣམ་གྲངས་ཚུ་གི་འོག་ལུ\n"
+#~ "ཚིག་ཡིག་རྣམ་གྲངས་ཚུ་གི་ཟུར་ཁ་ལུ\n"
+#~ "ངོས་དཔར་རྐྱངམ་ཅིག\n"
+#~ "ཚིག་ཡིག་རྐྱངམ་ཅིག"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "ད་ལྟོའི་ཚད་འཛིན་བརྗོད་དོན་འདི་གིས་ ཚོས་གཞིའི་འཆར་ལས་ཚུ་རྒྱབ་སྐྱོར་མི་འབད།"
+
+#~ msgid "Theme"
+#~ msgstr "བརྗོད་དོན་ཚུ།"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "ལག་ཆས་ཕྲ་རིང་གི་ ཨེབ་རྟའི་ཁ་ཡིག་ཚུ་:\"(_b)"
+
+#~ msgid "VB_GR"
+#~ msgstr "ཝི་བི་ཇི་ཨར།(_G)"
+
+#~ msgid "Window Border"
+#~ msgstr "སྒོ་སྒྲིག་གི་མཐའ་མཚམས།"
+
+#~ msgid "_BGR"
+#~ msgstr "བི་ཇི་ཨར།(_B)"
+
+#~ msgid "_Description:"
+#~ msgstr "འགྲེལ་བཤད་:(_D)"
+
+#~ msgid "_Document font:"
+#~ msgstr "ཡིག་ཆའི་ཡིག་གཟུགས་:(_D)"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "ཞུན་དག་འབད་བཏུབ་པའི་ དཀར་ཆག་མགྱོགས་འཕྲུལ་གྱི་ལྡེ་མིག་ཚུ(_E)"
+
+#~ msgid "_File"
+#~ msgstr "ཡིག་སྣོད།(_F)"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "རྒྱ་ཚད་གཏན་བཟོས་ཡིག་གཟུགས་:(_F)"
+
+#~ msgid "_Install..."
+#~ msgstr "གཞི་བཙུགས་འབད་...(_I)"
+
+#~ msgid "_Medium"
+#~ msgstr "འབྲིང་།(_M)"
+
+#~ msgid "_Monochrome"
+#~ msgstr "མོ་ནོ་ཀོརོམ།(_M)"
+
+#~ msgid "_New"
+#~ msgstr "གསརཔ།(_N)"
+
+#~ msgid "_Paste"
+#~ msgstr "སྦྱར།(_P)"
+
+#~ msgid "_Print"
+#~ msgstr "དཔར་བསྐྲུན།(_P)"
+
+#~ msgid "_RGB"
+#~ msgstr "ཨར་ཇི་བི།(_R)"
+
+#~ msgid "_Selected items:"
+#~ msgstr "སེལ་འཐུ་འབད་མི་ རྣམ་གྲངས་ཚུ་:(_S)"
+
+#~ msgid "_Size:"
+#~ msgstr "ཚད་: (_S)"
+
+#~ msgid "_Slight"
+#~ msgstr "དུམ་གྲ་ཅིག(_S)"
+
+#~ msgid "_Style:"
+#~ msgstr "བཟོ་རྣམ་:(_S)"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "ལག་ཆས་ཕན་བསླབ: (_T) "
+
+#~ msgid "_VRGB"
+#~ msgstr "ཝི་ཨར་ཇི་བི།(_V)"
+
+#~ msgid "_Window title font:"
+#~ msgstr "སྒོ་སྒྲིག་གི་མགོ་མིང་ཡིག་གཟུགས་:(_W)"
+
+#~ msgid "_Windows:"
+#~ msgstr "སྒོ་སྒྲིག་ཚུ: (_W)"
+
+#~ msgid "dots per inch"
+#~ msgstr "ཨིནཅ་རེ་ལུ་ ཚག་གྲངས།"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "ཌེཀསི་ཊོཔ་གི་མཐོང་སྣང་སྲོལ་སྒྲིག་འབད"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "ཌེཀསི་ཊོཔ་གི་ ཡན་ལག་སོ་སོའི་དོན་ལུ་ བརྗོད་དོན་གྱི་ཐུམ་སྒྲིལ་ཚུ་ གཞི་བཙུགས་འབད་"
+
+#~ msgid "Theme Installer"
+#~ msgstr "བརྗོད་དོན་གཞི་བཙུགས་པ་"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "ཇི་ནོམ་བརྗོད་དོན་ཐུམ་སྒྲིལ་"
+
+#~ msgid "Slide Show"
+#~ msgstr "བཤུད་བརྙན་ "
+
+#, c-format
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s by %d %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s by %d %s\n"
+#~ "སྣོད་འཛིན་: %s"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "པིག་སེལ།"
+#~ msgstr[1] "པིག་སེལསི།"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "བརྗོད་དོན་ གཞི་བཙུགས་འབད་མ་ཚུགས་ "
+
+#, c-format
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s སྤྱོད་ཆས་འདི་ གཞི་བཙུགས་མ་འབད་ནུག།"
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "བརྗོད་དོན་འདི་ཕྱིར་འདོན་འབད་བའི་སྐབས་ དཀའ་ངལ་ཅིག་འདུག།"
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "སེལ་འཐུ་འབད་ཡོད་པའི་ཡིག་སྣོད་ གཞི་བཙུགས་འབད་བའི་སྐབས་ འཛོལ་བ་ཅིག་འབྱུང་ནུག་ "
+
+#, c-format
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" དེ་ ནུས་ཅན་གྱི་བརྗོད་དོན་ཅིག་སྦེ་ མི་འབྱུང་མས། "
+
+#, c-format
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" དེ་ནུས་ཅན་གྱི་བརྗོད་དོན་ཅིག་སྦེ་ མི་འབྱུང་མས། འདི་ཡང་ཅིན་ ཕྱོགས་སྒྲིག་འབད་དགོ་པའི་ བརྗོད་"
+#~ "དོན་ མ་འཕྲུལ་ཅིག་ཨིནམ་འོང་། "
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "ཇི་ནོམ་བརྗོད་དོན་%s ངེས་བདེན་སྦེ་ གཞི་བཙུགས་འབད་ནུག།"
+
+#, c-format
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "བརྗོད་དོན་ \"%s\" གི་དོན་ལུ་ གཞི་བཙུགས་འཐུས་ཤོར་འབྱུང་ཡོདཔ། "
+
+#, c-format
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "བརྗོད་དོན་ \"%s\" འདི་ གཞི་བཙུགས་འབད་ཡོད།"
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "ཁྱོད་ཀྱིས་ད་ལྟོ་འཇུག་སྤྱོད་འབད་ཨིན་ན་ ཡང་ན་ཁྱོད་རའི་ད་ལཏོའི་བརྗོད་དོན་བཞག་ནི་ཨིན་ན?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "ད་ལྟོའི་བརྗོད་དོན་བཞག།"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "བརྗོད་དོན་གསརཔ་འཇུག་སྤྱོད་འབད།"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "གནས་སྐབས་ཅིག་གི་སྣོད་ཐོ་ གསར་བསྐྲུན་འབད་མ་ཚུགས།"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "བརྗོད་དོན་གསརཔ་ཚུ་ མཐར་འཁྱོལ་ཅན་སྦེ་ གཞི་བཙུགས་འབད་ནུག། "
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ ཡིག་སྣོད་ཀྱི་གནས་ཁོངས་ ངོས་འཛིན་མ་འབད་བས།"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "བརྗོད་དོན་གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ གནང་བ་ལངམ་མིན་འདུག\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%sའདི་ བརྗོད་དོན་གྱི་ཡིག་སྣོད་ཚུ་ གཞི་བཙུགས་འབད་སའི་འགྲུལ་ལམ་ཨིན། འདི་འབྱུང་ཁུངས་ཀྱི་ གནས་ཁོངས་"
+#~ "འབད་ སེལ་འཐུ་འབད་མི་ཚུགས།"
+
+#~ msgid "Select Theme"
+#~ msgstr "བརྗོད་དོན་སེལ་འཐུ་འབད"
+
+#~ msgid "Theme Packages"
+#~ msgstr "བརྗོད་དོན་ཐུམ་སྒྲིལ་ཚུ"
+
+#, c-format
+#~ msgid "Theme name must be present"
+#~ msgstr "བརྗོད་དོན་གྱི་མིང་ ངེས་པར་ཡོད་དགོ"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "བརྗོད་དོན་དེ་ ཧེ་མ་ལས་རང་འདུག ཁྱོད་ཀྱིས་དེ་གི་ཚབ་མ་ བཙུགས་ནི་ཨིན་ན།"
+
+#~ msgid "_Overwrite"
+#~ msgstr "ཚབ་སྲུང་ (_O)"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "ཁྱོད་ཀྱིས་ བརྗོད་དོན་འདི་ རྩ་བསྐྲད་གཏང་ནི་ཨིན་ན?"
+
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "བརྗོད་དོན་བཏོན་གཏང་མི་ཚུགས་པས"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་ ‘ཇི་ནོམ་-གཞི་སྒྲིག་-ཌེ་མཱོན་’ འགོ་བཙུགས་མི་ཚུགས་པས། \n"
+#~ "ཇི་ནོམ་གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་ ལཱ་གཡོག་བཀོལ་ཏེ་མེད་པ་ཅིན་ དགའ་གདམ་ལ་ལོ་ཅིག་ལུ་ ནུས་པ་འཐོབ་མི་"
+#~ "ཚུགས། འདི་གིས་བོ་ནོ་བོ་ལུ་ དཀའ་ངལ་ཅིག་ འབྱུང་སྲིད་ནི་ཨིན་མི་དེ་ཡང་ ཇི་ནོམ་མེན་པའི་ གཞི་སྒྲིག་འཛིན་"
+#~ "སྐྱོང་པ་(དཔེར་ན་ ཀེ་ཌི་ཨི) ལྟ་བུ་ ཤུགས་ལྡན་ཨིན་པའི་ཐོག་ལས་ ཇི་ནོམ་གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་དང་ མི་"
+#~ "མཐུནམ་འབྱུང་དོ་ཡོདཔ་འོང་།"
+
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "ཅ་མཛོད་ཀྱི་ངོས་དཔར་'%s'མངོན་གསལ་འབད་མ་ཚུགས། \n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "གཞི་སྒྲིག་ཚུ་ འཇུག་སྤྱོད་ཙམ་འབད་དེ་སྤངས་།"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "སྔོན་བཤུལ་གྱི་གཞི་སྒྲིག་ཚུ་ སླར་འདྲེན་འབད་དེ་ གསོག་འཇོག་འབད།"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "གྲོགས་རམ་%sབཀྲམ་སྟོན་འབད་ནི་ལུ་ འཛོལ་བ་ཅིག་བྱུང་ནུག"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "ཡིག་སྣོད་%u ལས་%uའདྲ་བཤུས་རྐྱབ་དོ།"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' འདྲ་བཤུས་རྐྱབ་དོ།"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "ཌའི་ལོག་འདི་གི་ རྩ་ལག་སྒོ་སྒྲིག་"
+
+#~ msgid "From URI"
+#~ msgstr "ཡུ་ཨར་ཨའི་ལས།"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "ཡུ་ཨར་ཨའི་ ད་ལྟོ་ག་ཏེ་ལས་ གནས་སོར་གཏང་དོ།"
+
+#~ msgid "To URI"
+#~ msgstr "ཡུ་ཨར་ཨའི་ལུ།"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "ཡུ་ཨར་ཨའི་ ད་ལྟོ་གནས་སོར་གཏང་ཡུལ།"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "གནས་སོར་གྱི་ཆ་ཤས་ ད་ལྟོ་ཡོངས་སྒྲུབ་འབད་ཡི།"
+
+#~ msgid "Current URI index"
+#~ msgstr "ད་ལྟོའི་ཡུ་ཨར་ཨའི་གི་ཟུར་ཐོ།"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "ད་ལྟོའི་ཡུ་ཨར་ཨའི་གི་ཟུར་ཐོ་ - ༡ ལས་འགོ་བཙུགསཔ་ཨིན།"
+
+#~ msgid "Total URIs"
+#~ msgstr "ཡུ་ཨར་ཨའི་བསྡོམས།"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "ཡུ་ཨར་ཨའི་གི་གྱངས་ཁ་ཡོངས་བསྡོམས།"
+
+#~ msgid "Key"
+#~ msgstr "ལྡེ་མིག"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "རྒྱུ་དངོས་ཀྱི་ཞུན་དགཔ་ མཉམ་སྦྲགས་ཡོད་པའི་ ཇི་ཀཱོནཕ་གི་ལྡེ་མིག"
+
+#~ msgid "Callback"
+#~ msgstr "ཀཱལ་བེཀ།"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "ལྡེ་མིག་དང་མཉམ་འབྲེལ་ཡོད་པའི་བེ་ལུ་དེ་ བསྒྱུར་བཅོས་འགྱོ་བའི་སྐབས་ ཀཱལ་བེཀ་འདི་སྤྲོད།"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "ཇི་ཀཱོནཕ་གི་ ཡོངས་འབྲེལ་ཡན་ལག་ འཇུག་སྤྱོད་ལུ་གཏང་ནིའི་ གནད་སྡུད་ཡོད་པའི་ ཇི་ཀཱོནཕ་གི་བསྒྱུར་བཅོས་ཆ་"
+#~ "ཚན།"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "ཝི་གེཊི་ ཀཱལ་བེཀ་ལུ་ གཞི་བསྒྱུར།"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "གནད་སྡུད་ཚུ་ ཇི་ཀཱོནཕ་ལས་ ཝི་གེཊི་ལུ་ གཞི་བསྒྱུར་འབད་དགོ་པའི་སྐབས་ སྤྲོད་ནིའི་ཀཱལ་བེཀ།"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "ཝི་གེཊི་ཀཱལ་བེཀ་ལས་གཞི་བསྒྱུར།"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "གནད་སྡུད་ཚུ་ ཝི་གེཊི་ནང་ལས་ ཇི་ཀཱོནཕ་ནང་ལུ་ གཞི་བསྒྱུར་འབད་དགོ་པའི་སྐབས་ སྤྲོད་དགོ་པའི་ཀཱལ་བེཀ།"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "རྒྱུ་དངོས་ཚད་འཛིན་འབད་མི་དངོས་པོ། (སྤྱིར་བཏང་ལུ་ཝི་གེཊི་ཅིག)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "རྒྱུ་དངོས་ཞུན་དག་པའི་ དངོས་པོའི་གནད་སྡུད།"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "དམིགས་བསལ་གྱི་ རྒྱུ་དངོས་ཞུན་དགཔ་ལུ་དགོ་མི་ སྲོལ་སྒྲིག་གི་གནད་སྡུད།།"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "རྒྱུ་དངོས་ཞུན་དག་པའི་གནད་སྡུད་ཀྱིས་ ཀཱལ་བེཀ་ཐར་གཏང་པའི་བསྒང་།"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "རྒྱུ་དངོས་ཞུན་དག་པའི་ དངོས་པོའི་གནད་སྡུད་ ཐར་དགོ་པའི་སྐབས་ སྤྲོད་ནིའི་ཀཱལ་བེཀ།"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "ཡིག་སྣོད་'%s'འཚོལ་མ་ཐོབ།\n"
+#~ "\n"
+#~ "ཚར་ཅིག་ཕྱིར་བཏོན་འབད་ཞིནམས་ལས་ ལོག་སྟེ་འབད་རྩོལ་བསྐྱེད་གནང་། ཡང་ཅིན་ རྒྱབ་གཞིའི་པར་ གཞན་མི་"
+#~ "ཅིག་ གདམ་ཁ་རྐྱབས།"
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "ང་གིས་ཡིག་སྣོད་'%s' ཁ་ཕྱེ་མ་ཤེས།\n"
+#~ "རྒྱབ་སྐྱོར་མེད་པའི་པར་ཅིག་ འོང་ནི་འདྲ་བས།\n"
+#~ "\n"
+#~ "དེ་གི་ཚབ་ལུ་ པར་གཞན་མི་ཅིག་སེལ།"
+
+#~ msgid "Please select an image."
+#~ msgstr "གཟུགས་བརྙན་ཅིག་སེལ་འཐུ་འབད།"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "སྔོན་སྒྲིག་དཔག་བྱེད་-ད་ལྟོའི་།"
+
+#~ msgid "White Pointer"
+#~ msgstr "དཔག་བྱེད་དཀརཔོ།"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "དཔག་བྱེད་དཀརཔོ་-ད་ལྟོའི་།"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "དཔག་བྱེད་ཆེ་བ་-ད་ལྟོའི།"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "དཔག་བྱེད་དཀརཔོ་ཆེ་བ་-ད་ལྟོའི།"
+
+#~ msgid "Select your default applications"
+#~ msgstr "ཁྱོད་རའི་སྔོན་སྒྲིག་གློག་རིམ་ སེལ་འཐུ་འབད།"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "དགའ་གདམ་བརྐྱབས་ཡོད་པའི་ མཐོང་བའི་ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་གཡོག་བཀོལ་ "
+
+#~ msgid "Visual Assistance"
+#~ msgstr "མཐོང་བའི་ ཕན་ཐབས་ "
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "རིམ་སྒྲིག་%sབསྲུང་ནི་ལུ་འཛོལ་བ། "
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "ངོས་འདྲ་བ་ངོ་མ་ མངོན་གསལ་འབད་མ་ཚུགས།"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>གཟུགས་བརྙན་མཐོང་བྱེད་</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>འཕྲལ་མྱུར་འཕྲིན་སྐྱེལ་པ།</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>ཡིག་འཕྲིན་ལྷག་མི་</b>"
+
+#~ msgid "<b>Mobility</b>"
+#~ msgstr "<b> ལས་གཡོག </b>"
+
+#~ msgid "<b>Multimedia Player</b>"
+#~ msgstr "<b>སྣ་མང་བརྡ་ལམ་གྱི་གཏང་འཕྲུལ་</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>ཊར་མི་ནཱལ་ ནུས་འཕྲུལ་</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>ཚིག་ཡིག་ཞུན་དགཔ་</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>ཝི་ཌིའོ་གཏང་འཕྲུལ་</b>"
+
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<i>མཐོང་བའི</i>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>ཝེབ་ བརའུ་ཟར།</b>"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "འབྱུང་བ་%sཆ་མཉམ་གྱི་ཚབ་ལུ་ འབྲེལ་ལམ་ངོ་མ་བཙུགས་ནི་ཨིན།"
+
+#~ msgid "C_ommand:"
+#~ msgstr "བརྡ་བཀོད་:(_O)"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "བརྡ་བཀོད་:(_m)"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "ཟུར་རྟགས་ལག་ལེན་འཐབ་:(_x)"
+
+#~ msgid "Internet"
+#~ msgstr "ཨིན་ཊར་ནེཊི།"
+
+#~ msgid "Multimedia"
+#~ msgstr "སྣ་མང་བརྡ་ལམ།"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "འབྲེལ་ལམ་མཆོང་ལྡེ་གསར་པའི་ནང་ཁ་ཕྱེ།(_t)"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "འབྲེལ་ལམ་སྒོ་སྒྲིག་གསར་པའི་ནང་ཁ་ཕྱེ།(_w)"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "འབྲེལ་ལམ་ཝེབ་བརའུ་ཟར་སྔོན་སྒྲིག་ཐོག་ལསཁ་ཕྱེ།"
+
+#~ msgid "Run at st_art"
+#~ msgstr "འགོ་བཙུགས་སར་གཡོག་བཀོལ(_a)"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "ཊར་མི་ནཱལ་ཅིག་ནང་གཡོག་བཀོལ།(_e)"
+
+#~ msgid "Balsa"
+#~ msgstr "བཱལ་ས།"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "བཱན་ཤི་སྙན་ཆ་གཏང་་འཕྲུལ"
+
+#~ msgid "Claws Mail"
+#~ msgstr "ཀལོསི་ ཡིག་འཕྲིན་"
+
+#~ msgid "Dasher"
+#~ msgstr "ཌེ་ཤར"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "ཌེ་བི་ཡཱན་ ཚོར་ཅན་གྱི་ བརའུ་ཟར།"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "ཌེ་བི་ཡཱན་ ཊར་མི་ནཱལ་ ནུས་འཕྲུལ།"
+
+#~ msgid "ETerm"
+#~ msgstr "ཨི་ཊམ།"
+
+#~ msgid "Encompass"
+#~ msgstr "བརྒལ་བ"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "ཨི་པི་ཕ་ནི་ ཝེབ་བརའུ་ཟར།"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི།"
+
+#~ msgid "Firebird"
+#~ msgstr "ཕའེར་བཌི།"
+
+#~ msgid "Firefox"
+#~ msgstr "ཕའེར་ཕོགསི།"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "ཇི་ནོམ་ཆེ་ཤེལ་གསལ་གཞི་ལྷག་མི་མེད་པ"
+
+#~ msgid "Galeon"
+#~ msgstr "གེ་ལིའོན།"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "ཇི་ནོ་པར་་ནི་ཀཱསི"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "ཇི་ནོ་པར་་ནི་ཀཱསི་ཆེ་ཤེལ་དང་བཅས"
+
+#~ msgid "Iceape"
+#~ msgstr "ཨའིསི་ཨེཔ་ "
+
+#~ msgid "Iceape Mail"
+#~ msgstr "ཨའིསི་ཨེཔ་ ཡིག་འཕྲིན"
+
+#~ msgid "Icedove"
+#~ msgstr "ཨའིསི་ཌོབ་"
+
+#~ msgid "Iceweasel"
+#~ msgstr "ཨའིསི་ཝི་སེལ་"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "ཀེ་ཌི་ཨི་ཆེ་ཤེལ་གསལ་གཞི་ལྷག་མི་མེད་པ"
+
+#~ msgid "Konqueror"
+#~ msgstr "ཀོང་ཀུ་རར།"
+
+#~ msgid "Konsole"
+#~ msgstr "ཀཱན་སཱོལ་ "
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "ལའི་ནགསི་གསལ་གཞི་ལྷག་མི་ཆེ་ཤེལ་དང་བཅས"
+
+#~ msgid "Midori"
+#~ msgstr "མི་ཌོ་རི་ "
+
+#~ msgid "Mozilla"
+#~ msgstr "མོ་ཛི་ལ།"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "མོ་ཛི་ལ་༡.༦།"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "མོ་ཛི་ལ་ ཡིག་འཕྲིན།"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "མོ་ཛི་ལ་ ཐཱན་ཌར་བཌི།"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "མུའིནི་སྙན་ཆ་གཏང་འཕྲུལ"
+
+#~ msgid "Mutt"
+#~ msgstr "མཱཊི།"
+
+#~ msgid "NXterm"
+#~ msgstr "ཨེན་ཨེགསི་ཊམ།"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "ནེཊི་སིཀེཔ་ བརྡ་སྤྲོད་པ།"
+
+#~ msgid "Opera"
+#~ msgstr "ཨོ་པི་ར།"
+
+#~ msgid "Orca"
+#~ msgstr "ཨོར་ཀ"
+
+#~ msgid "RXVT"
+#~ msgstr "ཨར་ཨེགསི་ཝི་ཊི།"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "སྒྲ་དབྱངས་སྒྲོམ་གྱི་སྙན་ཆ་གཏང་འཕྲུལ"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "སི་མོན་ཀི"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "སི་མོན་ཀི་གི་ཡིག་འཕྲིན"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "ཚད་ལྡན་གྱི་ ཨེགསི་ཊར་མི་ནཱལ།"
+
+#~ msgid "Sylpheed"
+#~ msgstr "སིལ་ཕིཊི།"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "སིལ་ཕིཊི་-ཀྭ་ལཱསི།"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "ཊོ་ཊེམ་གློག་བརྙེན་གཏང་འཕྲུལ"
+
+#~ msgid "aterm"
+#~ msgstr "ཨེ་ཊམ།"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "གསལ་གཞིའི་ཧུམ་ཆ་ བསྒྱུར་བཅོས་འབད།"
+
+#~ msgid "Inverted"
+#~ msgstr "གནས་ལོག་འབད་ཡོདཔ"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "ཨེཆ་ཛེཌི %d "
+
+#~ msgid "R_otation:"
+#~ msgstr "སྐོར་རྐྱབ་:(_o)"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "གསལ་གཞི་ཧུམ་ཆའི་དགའ་གདམ་ཚུ།"
+
+#, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "གློག་རིག་(%s)འདི་གི་དོན་ལུ་རྐྱངམ་གཅིག་ སྔོན་སྒྲིག་འབད།(_M)"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "གཞི་སྒྲིག་གསརཔ་ཚུ་ལུ་ བརྟག་ཞིབ་འབད་དོ། ཁྱོད་ཀྱིས་སྐར་ཆ་%dགི་ནང་འཁོད་ ངོས་ལན་མ་བྱིན་པ་ཅིན་ ཧེ་"
+#~ "མའི་གཞི་སྒྲིག་ཚུ་ སོར་ཆུད་འབད་འོང་།"
+#~ msgstr[1] ""
+#~ "གཞི་སྒྲིག་གསརཔ་ཚུ་ལུ་ བརྟག་ཞིབ་འབད་དོ། ཁྱོད་ཀྱིས་སྐར་ཆ་%dགི་ནང་འཁོད་ ངོས་ལན་མ་བྱིན་པ་ཅིན་ ཧེ་"
+#~ "མའི་གཞི་སྒྲིག་ཚུ་ སོར་ཆུད་འབད་འོང་།"
+
+#~ msgid "Keep Resolution"
+#~ msgstr "ཧུམ་ཆ་བདག་འཛིན་འབད་བཞག"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "ཁྱོད་ཀྱིས་ཧུམ་ཆ་འདི་ བདག་འཛིན་འབད་བཞག་ནི་ཨིན་ན?"
+
+#~ msgid "Use _Previous Resolution"
+#~ msgstr "ཧེ་མའི་ཧུམ་ཆ་ ལག་ལེན་འཐབ་ (_p)"
+
+#~ msgid "_Keep Resolution"
+#~ msgstr "ཧུམ་ཆ་ བདག་འཛིན་འབད་བཞག་(_k)"
+
+#~ msgid ""
+#~ "The X server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "ཨེགསི་སར་བར་དེ་གིས་ XRandR རྒྱ་བསྐྱེད་ལུ་ རྒྱབ་སྐྱོར་མི་འབད་བས།  གཡོག་བཀོལ་དུས་ཚོད་ཀྱི་ ཧུམ་ཆའི་"
+#~ "བསྒྱུར་བཅོས་ཚུ་ བཀྲམ་སྟོན་འབད་ནིའི་ཚད་གུ་ མི་འཐོབ་པས།"
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "XRandR རྒྱ་བསྐྱེད་ཀྱི་ཐོན་རིམ་དེ་ ལས་རིམ་འདི་དང་མཐུན་འགྱུར་མིན་འདུག གཡོག་བཀོལ་དུས་ཚོད་ཀྱི་ བསྒྱུར་"
+#~ "བཅོས་ཚུ་ བཀྲམ་སྟོན་འབད་ནིའི་ཚད་གུ་ མི་འཐོབ་པས།"
+
+#~ msgid "New accelerator..."
+#~ msgstr "མགྱོགས་འཕྲུལ་གསརཔ་..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "མགྱོགས་འཕྲུལ་ལྡེ་མིག"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "མགྱོགས་འཕྲུལ་ལེགས་བཅོས་པ།"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "མགྱོགས་འཕྲུལ་ལྡེ་ཨང་།"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "མགྱོགས་འཕྲུལ་གྱི་དབྱེ་བ།"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<མ་ཤེས་པའི་བྱ་བ་>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time.\n"
+#~ msgstr ""
+#~ "མགྱོགས་ཐབས་\"%s\"དེ་ ལག་ལེན་འཐབ་མི་བཏུབ། ག་ཅི་སྦེ་ཟེར་བ་ཅིན་ ལྡེ་མིག་འདི་ལག་ལེན་འཐབ་དང་ "
+#~ "ཡིག་དཔར་བརྐྱབ་མི་འགྱུརཝ་ཨིན།\n"
+#~ "ཚད་འཛིན་ གདམ་ལྡེ་ཡང་ན་ སོར་ལྡེ་ཚུ་ དུས་མཉམ་ལུ་ཨེབ་སྟེ་ འབད་རྩོལ་བསྐྱེད་གནང་།\n"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "མགྱོགས་ཐབས་\"%s\" དེ་ ཧེ་མ་ལས་རང་ ལག་ལེན་འཐབ་ནུག\n"
+#~ " \"%s\"\n"
+
+#, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "རིམ་སྒྲིག་གནད་སྡུད་གཞི་རྟེན་ %sནང་ མགྱོགས་འཕྲུལ་གསརཔ་ གཞི་སྒྲིག་འབད་ནི་ལུ་འཛོལ་བ།\n"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "རིམ་སྒྲིག་གནད་སྡུད་གཞི་རྟེན་ %sནང་ མགྱོགས་འཕྲུལ་གསརཔ་ སྒྲིག་བཤོལ་འབད་ནི་ལུ་འཛོལ་བ། \n"
+
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "མགྱོགས་ཐབས་ཅིག་ ཞུན་དག་བརྐྱབ་ནི་ལུ་ ཆ་མཚུངས་པའི་གྲལ་ཐིག་ལུ་ ཨེབ་གཏང་འབད་ཞིནམས་ལས་ མགྱོགས་"
+#~ "འཕྲུལ་གསརཔ་ཅིག་ ཡིག་དཔར་རྐྱབས། ཡང་ན་ བསལ་་ནིའི་དོན་ལུ་ རྒྱབ་བཤུད་ལུ་ཨེབ།"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "བརྡ་བཀོད་ཚུ་ལུ་ མགྱོགས་ཐབས་ལྡེ་མིག་ འགན་སྤྲོད་འབད།"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "གཞི་སྒྲིག་ཙམ་འཇུག་སྤྱོད་འབད་དེ་སྤངས། (མཐུན་འགྱུར་རྐྱངམ་གཅིག་ ད་ལྟོ་ཌེ་མཱོན་གྱིས་ ལེགས་སྐྱོང་འཐབ་ནུག)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "ཤོག་ལེབ་དེ་ ཡིག་དཔར་བརྐྱབ་ནིའི་བར་མཚམས་གཞི་སྒྲིག་ཚུ་ སྟོནམ་དང་བཅསཔ་སྦེ་ འགོ་བཙུགས།"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "ཤོག་ལེབ་དེ་ འཛུལ་སྤྱོད་གཞི་སྒྲིག་ཚུ་ སྟོནམ་ཐོག་ལས་ འགོ་བཙུགས།"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- ཇི་ནོམ་ལྡེ་སྒྲོམ་གྱི་དགའ་གདམ་ཚུ་"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>ཡོངས་ཁྱབ་</b>"
+
+#~ msgid "<b>Slow Keys</b>"
+#~ msgstr "<b>Slow Keys</b>"
+
+#~ msgid "<b>Sticky Keys</b>"
+#~ msgstr "<b>སྦྱར་རྩི་ལྡེ་མིག་ཚུ་ </b>"
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>ཡིག་དཔར་གྱི་བར་མཚམས་ ལག་ལེན་འཐབ་ནིའི་དོན་ལུ་ གསལ་གཞི་ལྡེ་མིག་རྐྱབས་</b>(_L)"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>མགྱོགས་པར</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>རིངམོ་</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>ཐུང་ཀུ་</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>ལྷོད་ཆ་</i></small>"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "མགྱོགས་སྤྱོད་: (_A)"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "བར་མཚམས་ཚུ་ བསྣར་བཞག་འབད་བཅུག(_o)"
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "སོར་སྟོན་ལྡེ་མིག་ཅིག་ གཡེབ་པའི་སྐབས་ བརྡ་སྐད་སྟོན་(_M)"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "ལྡེ་མིག་ལུ་ ངོས་ལེན་མེད་པ་ཅིན་ བརྡ་སྐད་རྐྱབས་  (_R)"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "བར་མཚམས་ཚུ་ བསྣར་བཞག་འབད་ཆོག་ག་མི་ཆོག་ ཞིབ་དཔྱད་འབད།"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "ལྡེ་སྒྲོམ་གྱི་དཔེ་ཅིག་ གདམ་ཁ་རྐྱབས།"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "སྒྲིག་བཀོད་ཅིག་ གདམ་ཁ་རྐྱབས།"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "ཡིག་དཔར་བརྐྱབ་མ་ཆོག་པའི་སྐབས་ལུ་ བར་མཚམས་ཀྱི་དུས་ཡུན།"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "བང་བཙོངས་ཏེ་ བར་མཚམས་ཅིག་  མ་བཞག་པའི་ཧེ་མར་ ལཱ་གཡོག་གི་དུས་ཡུན།"
+
+#~ msgid "Keyboard Accessibility Notifications"
+#~ msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད་ བརྡ་བསྐུལ་ཚུ་"
+
+#~ msgid "Keyboard Layout Options"
+#~ msgstr "ལྡེ་སྒྲོམ་ སྒྲིག་བཀོད་གདམ་ཁ་ཚུ་ "
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "ལྡེ་སྒྲོམ་གྱི་དགའ་གདམ་ཚུ།"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "ལྡེ་སྒྲོམ་གྱི་དཔེ་:(_m)"
+
+#~ msgid "Layout _Options..."
+#~ msgstr "སྒྲིག་བཀོད་ཀྱི་གདམ་ཁ་ཚུ་་་་་ (_O)"
+
+#~ msgid "Layouts"
+#~ msgstr "སྒྲིག་བཀོད་ཚུ།"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "ལྡེ་སྒྲོམ་ལག་ལེན་ལུ་ ཡང་བསྐྱར་གྱི་གནོད་སྐྱོན་ བཀག་ཐབས་ལུ་ དུས་ཡུན་ཧ་ལམ་ཅིག་ལས་ གསལ་གཞི་ལྡེ་མིག་"
+#~ "རྐྱབས།"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "སྔོན་སྒྲིག་ལུ་ བསྐྱར་སྒྲིག་འབད"
+
+#~ msgid "S_peed:"
+#~ msgstr "མགྱོགས་ཚད་:(_p)"
+
+#~ msgid "Separate _layout for each window"
+#~ msgstr "སྒོ་སྒྲིག་རེ་རེའི་དོན་ལུ་ སྒྲིག་བཀོད་སོ་སོ་ (_L)"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "བར་མཚམས་གནས་ཡུན་:(_B)"
+
+#~ msgid "_Layouts:"
+#~ msgstr "སྒྲིག་བཀོད་ཚུ:(_L)"
+
+#~ msgid "_Models:"
+#~ msgstr "དཔེ་ཚུ་:(_M)"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "འཆང་སྟེ་ཡོད་མི་ ལྡེ་མིག་ཚུ་རྐྱངམ་གཅིག་ དང་ལེན་འབད་ (_O)"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "སེལ་འཐུ་འབད་མི་ སྒྲིག་བཀོད་ཚུ་:(_S)"
+
+#~ msgid "_Simulate simultanous keypresses"
+#~ msgstr "དུས་མཉམ་ ལྡེ་མནན་ཚུ་ མཚུངས་པ་བཟོ་ "
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "གཞི་སྒྲིག་: ཚུ་བརྟག་ཞིབ་འབད་ནི་ལུ་ ཡིག་དཔར་རྐྱབས།(_T)"
+
+#~ msgid "_Variants:"
+#~ msgstr "ཁྱད་དངོས་ཚུ:(_V)"
+
+#~ msgid "_Vendors:"
+#~ msgstr "བཙོང་མི་ཚུ: (_V)"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "ལཱ་གི་བར་མཚམས་གནས་ཡུན་:(_W)"
+
+#~ msgid "Unknown"
+#~ msgstr "མ་ཤེསཔ།"
+
+#~ msgid "Vendors"
+#~ msgstr "བཙོངས་མི་ཚུ"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "ཁྱོད་རའི་ལྡེ་སྒྲོམ་གྱི་དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "བརྡ་སྟོན་| གཡོན་ཁ་ཐུག་ལུ་ སྤོ་བཤུད་འབད་ "
+
+#~ msgid "gesture|Move right"
+#~ msgstr "བརྡ་སྟོན་| གཡས་ཁ་ཐུག་ལུ་སྤོ་བཤུད་འབད་ "
+
+#~ msgid "gesture|Move up"
+#~ msgstr "བརྡ་སྟོན་| ཡར་བཤུད་"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "རྣམ་འགྱུར་| ལྕོགས་མིན་བཟོ་ཡོདཔ་ "
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>འདྲུད་དེ་བཀོག་བཞག་</b>"
+
+#~ msgid "<b>Dwell Click</b>"
+#~ msgstr "<b>ཌུའལ་ ཨེབ་གཏང་ </b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>དཔག་བྱེད་ག་ཡོད་བལྟ་</b>"
+
+#~ msgid "<b>Mouse Orientation</b>"
+#~ msgstr "<b>མཱའུསི་གི་ཕྱོགས་</b>"
+
+#~ msgid "<b>Pointer Speed</b>"
+#~ msgstr "<b>དཔག་བྱེད་ མགྱོགས་ཚད་ </b>"
+
+#~ msgid ""
+#~ "<i>To test your double-click settings, try to double-click on the light "
+#~ "bulb.</i>"
+#~ msgstr ""
+#~ "<i>ཁྱོད་རའི་ཨེབ་གཏང་གཉིས་ལྡན་གཞི་སྒྲིག་ཚུ་ བརྟག་ཞིབ་འབད་ནིའི་དོན་ལུ་ གློག་ཤལ་དེ་གུ་ ཚར་གཉིས་ཨེབ་"
+#~ "གཏང་འབད། </i>"
+
+#~ msgid ""
+#~ "<i>You can also use the Dwell Click panel applet to choose the click type."
+#~ "</i>"
+#~ msgstr ""
+#~ "<i>དེ་མ་ཚད་ ཁྱོད་ཀྱིས་ ཨེབ་གཏང་གི་དབྱེ་བ་ གདམ་ཁ་རྐྱབ་ནིའི་དོན་ལུ་ ཌུའལ་ ཨེབ་གཏང་ པེ་ནཱལ་ ཨེཔ་"
+#~ "ལེཊི་ཡང་ ལག་ལེན་འཐབ་བཏུབ། </i>"
+
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i>མཐོ་བ་</i></small>"
+
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i>ཆེ་བ་</i></small>"
+
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>དམའ་</i></small>"
+
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i>ཆུང་ཀུ་</i></small>"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "ཨེབ་གཏང་གི་དབྱེ་བ་ སྔ་གོང་ལས་རང་ གདམ་ཁ་རྐྱབས་ (_B)"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "ཨེབ་གཏང་གི་དབྱེ་བ་ མཱའིསི་གི་བརྡ་སྟོན་དང་གཅིག་ཁར་ གདམ་ཁ་རྐྱབས་ (_U)"
+
+#~ msgid "D_rag click:"
+#~ msgstr "ཨེབ་གཏང་ འདྲུད: (_R)"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "མཱའུསི་གི་དགའ་གདམ་ཚུ།"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "ཚད་འཛིན་ ལྡེ་མིག་མནན་ཡོད་པའི་སྐབས་ དཔག་བྱེད་ཀྱི་ གནས་ས་སྟོན་ (_O)"
+
+#~ msgid "Show click type _window"
+#~ msgstr "ཨེབ་གཏང་དབྱེ་བ་གི་ ཝིན་ཌོ་ སྟོན་ (_W)"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "ཐེ་རེཤི་ཧཱོལཌི་: (_T)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "གཡོན་ལག་(_L)"
+
+#~ msgid "_Right-handed"
+#~ msgstr "གཡས་ལག་ (_R)"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "དྲན་ཚོར་:(_S)"
+
+#~ msgid "_Single click:"
+#~ msgstr "ཨེབ་གཏང་ རྐྱང་པ: (_S)"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "ཁྱོད་རའི་མཱའུསི་གི་ དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "ཁྱོད་རའི་ཡོངས་འབྲེལ་གྱི་ པོརོག་སི་དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>ཨིན་ཊར་ནེཊི་གི་ ཐད་ཀར་མཐུད་ལམ་</b>(_i)"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>རང་བཞིན་པོརོག་སི་རིམ་སྒྲིག་</b>(_A)"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>ལག་དེབ་ཀྱི་ པོརོག་སི་རིམ་སྒྲིག་</b>(_M)"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "མཐོ་རིམ་ཅན་གྱི་རིམ་སྒྲིག"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་གི་ རྒྱས་བཤད་ཚུ།"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "ཡོངས་འབྲེལ་ པོརོག་སི་གི་དགའ་གདམ་ཚུ།"
+
+#~ msgid "Port:"
+#~ msgstr "འདྲེན་ལམ་:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་མཐའ་བཙན་བཟོ:(_S)"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "སྒྲ་སྐད་ལྕོགས་ཅན་བཟོ་སྟེ་ བྱུང་ལས་དང་མཉམ་སྦྲགས་འབད།"
+
+#, c-format
+#~ msgid "Unknown Volume Control %d"
+#~ msgstr "མ་ཤེས་པའི་སྐད་ཤུགས་ཚད་འཛིན་ %d"
+
+#, c-format
+#~ msgid "Failed to construct test pipeline for '%s'"
+#~ msgstr "'%s' གི་དོན་ལུ་ བརྟག་ཞིབ་རྒྱུད་དུང་འབྲེལ་ལམ་ བཟོ་བསྐྲུན་འབད་ནི་འཐུས་ཤོས་འབྱུང་ཡོད་"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ཨེ་ཨེལ་ཨེསི་ཨེ་ - མཐོ་རིམ་ལི་ནགསི་སྒྲ་སྐད་བཟོ་བཀོད་"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "ཨརཊི་ཨེསི་ཌི་ - སྒྱུ་རྩལ་སྒྲ་སྐད་ཌེ་མཱོན་"
+
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ཨི་ཨེསི་ཌི་ - ཤེས་ཡོན་ཅན་སྒྲ་སྐད་ཌེ་མཱོན་"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "ཨོ་ཨེསི་ཨེ་ - སྒྲ་སྐད་རིམ་ལུགས་ཁ་ཕྱེ་"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "པོ་ལི་པའུ་ཌིའོ་སྒྲ་སྐད་སར་བར"
+
+#~ msgid "Silence"
+#~ msgstr "ཁུ་སིམ་སིམ་"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "- ཇི་ནོམ་སྒྲ་སྐད་ཀྱི་དགའ་གདམ་ཚུ་"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>རྣར་ཉན་ཞལ་འཛོམས་</b>"
+
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>སྔོན་སྒྲིག་སྦྱོར་འཕྲུལ་གླུ་རིམ་ཚུ་</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>སྙན་ཆ་དང་གློག་བརྙན་</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>སྒྲ་སྐད་བྱུང་ལས་</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">བརྟག་ཞིབ་འབད་དོ་</span>"
+
+#~ msgid "E_nable software sound mixing (ESD)"
+#~ msgstr "མཉེན་ཆས་སྒྲ་སྐད་བསྲེ་སྦྱོར་གྱི་ལྕོགས་ཅན་བཟོ།(ཨི་ཨེསི་ཌི)"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "སྒོ་སྒྲིག་གི་མགོ་མིང་ཕྲ་རིང་ རིབ་སྟོན་འབད།(_w)"
+
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+#~ msgstr ""
+#~ "ལྡེ་སྒྲོམ་དང་གཅིག་ཁར་ཚད་འཛིན་འབད་ནིའི་དོན་ལས་ ཐབས་འཕྲུལ་དང་གླུ་རིམ་ཚུ་སེལ་འཐུ་འབད། དགོས་མཁོ་"
+#~ "ཡོདཔ་ཨིན་པ་ཅིན་ སྣ་མང་གླུ་རིམ་ཚུ་སེལ་འཐུ་འབད་ནིའི་དོན་ལས་ སོར་ལྡེ་དང་ཚད་འཛིན་ལྡེ་མིག་ཚུ་ལག་ལེན་"
+#~ "འཐབ།"
+
+#~ msgid "So_und playback:"
+#~ msgstr "སྒྲ་སྐད་གཏང་ནི་:(_u)"
+
+#~ msgid "Sou_nd capture:"
+#~ msgstr "སྒྲ་སྐད་འཛིན་བཟུང་:(_n)"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "སྒྲ་སྐད་ཀྱི་དགའ་གདམ་ཚུ།"
+
+#~ msgid "System Beep"
+#~ msgstr "རིམ་ལུགས་བརྡ་སྐད།"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "རྒྱུད་དུང་འབྲེལ་ལམ་བརྟག་ཞིབ་འབད་དོ།"
+
+#~ msgid "_Device:"
+#~ msgstr "ཐབས་འཕྲུལ:(_D)"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "རིམ་ལུགས་བརྡ་སྐད་ལྕོགས་ཅན་བཟོ།(_E)"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "རིམ་ལུགས་སྒྲ་སྐད་གཏང་།(_P)"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "སྒྲ་སྐད་གཏང་ནི་:(_S)"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "མཐོང་བའི་རིམ་ལུགས་བརྡ་སྐད།(_V)"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "ཁྱོད་ཀྱི་སྒོ་སྒྲིག་འཛིན་སྐྱོང་པའི་དོན་ལུ་ དགའ་གདམ་གྱི་གློག་རིམ་ འགོ་བཙུགས་མི་ཚུགས།"
+
+#~ msgid "C_ontrol"
+#~ msgstr "ཚད་འཛིན།(_o)"
+
+#~ msgid "_Alt"
+#~ msgstr "གདམ་ལྡེ།(_A)"
+
+#~ msgid "H_yper"
+#~ msgstr "ཧའི་པར།(_y)"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "ཡང་དག (ཡང་ན་ \"Windows logo\")(_u)"
+
+#~ msgid "_Meta"
+#~ msgstr "མེ་ཊ།(_M)"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>འགུལ་བསྐྱོད་ལྡེ་མིག་</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>མགོ་མིང་ཕྲ་རིང་གི་བྱ་བ་</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>སྒོ་སྒྲིག་གི་སེལ་འཐུ་</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "སྒོ་སྒྲིག་ཅིག་ སྤོ་བཤུད་འབད་ནི་ལུ་ ལྡེ་མིག་འདི་ཨེབ་སྟེ་འཛིན་ཞིནམ་ལས་ སྒོ་སྒྲིག་དེ་བཟུང་།"
+
+#~ msgid "Window Preferences"
+#~ msgstr "སྒོ་སྒྲིག་གི་ དགའ་གདམ་ཚུ།"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "བྱ་བ་འདི་བསྒྲུབ་ནི་ལུ་ མགོ་མིང་ཕྲ་རིང་ལུ་ ཨེབ་གཏང་ཚར་གཉིས་འབད།(_D)"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "ཆེར་བསྐྱེད་མ་འབད་བའི་ཧེ་མར་བར་མཚམས་:(_I)"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "སེལ་འཐུ་འབད་མི་ སྒོ་སྒྲིག་ཚུ་ བར་མཚམས་ཅིག་གི་ཤུལ་ལས་ ཆེར་བསྐྱེད་འབད།(_R)"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "མཱའུསི་དེ་ སྒོ་སྒྲིག་ཚུ་གི་གུ་ལས་ཕར་འགྱོཝ་ད་ སྒོ་སྒྲིག་ཚུ་ སེལ་འཐུ་འབད།(_S)"
+
+#~ msgid "Set your window properties"
+#~ msgstr "ཁྱོད་རའི་སྒོ་སྒྲིག་གི་རྒྱུ་དངོས་ཚུ་ གཞི་སྒྲིག་འབད།"
+
+#, c-format
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>%s འགོ་བཙུགས་</b>"
+
+#~ msgid "Upgrade"
+#~ msgstr "ཡར་བསྐྱེད་"
+
+#~ msgid "Uninstall"
+#~ msgstr "གཞི་བཙུགས་མ་འབད་"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "འགོ་བཙུགས་ལས་རིམ་ཚུ་ལས་ རྩ་བསྐྲད་གཏང་"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "འགོ་བཙུགས་ལས་རིམ་ཚུ་ལུ་ ཁ་སྐོང་རྐྱབས་"
+
+#, c-format
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>མཐུན་མི་ཚུ་མ་འཐོབ།</b> </span><span>\n"
+#~ "\n"
+#~ " ཁྱོད་ཀྱི་ཚགས་མ་ \"<b>%s</b>\" འདི་ རྣམ་གྲངས་ཚུ་ག་དང་གཅིག་ཁར་ཡང་མི་མཐུན་མས།</span>"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "ཤོག་ཁྲམ་གསརཔ"
+
+#~ msgid "New Document"
+#~ msgstr "ཡིག་ཆ་གསརཔ"
+
+#~ msgid "Home"
+#~ msgstr "ཁྱིམ"
+
+#, c-format
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>ཁ་ཕྱེ </b>"
+
+#~ msgid "Send To..."
+#~ msgstr "...ལུ་གཏང་"
+
+#~ msgid "Delete"
+#~ msgstr "བཏོན་གཏང་"
+
+#, c-format
+#~ msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgstr "ཁྱོད་ཀྱིས་ \"%s\" རྟག་བརྟན་སྦེ་ བཏོན་གཏང་ནི་ངེས་ཏིག་ཨིན་ན?"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "ཁྱོད་ཀྱིས་ རྣམ་གྲངས་ཅིག་བཏོན་གཏང་པ་ཅིག་ དེ་ རྟག་བརྟན་སྦེ་ བརླག་སྟོར་ཞུགས་འོང་། "
+
+#, c-format
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b> \"%s\" དང་གཅིག་ཁར་ཁ་ཕྱེ་</b>"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "ཡིག་སྣོད་འཛིན་སྐྱོང་པ་ནང་ ཁ་ཕྱེ་"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "ད་རིས་ %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "ཁ་རྩ་ %l:%M %p"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%b %d %l:%M %p"
+
+#~ msgid "%b %d %Y"
+#~ msgstr "%b %d %Y"
+
+#, c-format
+#~ msgid "Unexpected attribute '%s' for element '%s'"
+#~ msgstr "རྒྱུ་རྫས་'%s'ལུ་རེ་བ་་མེད་པའི་ཁྱད་ཆོས'%s'"
+
+#, c-format
+#~ msgid "Attribute '%s' of element '%s' not found"
+#~ msgstr "རྒྱུ་རྫས་'%s'གི་ཁྱད་ཆོས་'%s' མ་ཐོབ"
+
+#, c-format
+#~ msgid "Unexpected tag '%s', tag '%s' expected"
+#~ msgstr "རེ་བ་མེད་པའི་ངོ་རྟགས '%s', ངོ་རྟགས '%s' རེ་བ་ཡོདཔ"
+
+#, c-format
+#~ msgid "Unexpected tag '%s' inside '%s'"
+#~ msgstr "རེ་བ་མེད་པའི་ངོ་རྟགས'%s' ནང་ན '%s'"
+
+#, c-format
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "གནད་སྡུད་ཌའིརསི་ནང་ནུས་ཅན་གྱི་དེབ་རྟགས་ཡིག་སྣོད་མིན་འདུག"
+
+#, c-format
+#~ msgid "A bookmark for URI '%s' already exists"
+#~ msgstr "ཡུ་ཨར་ཨེལ'%s'དོན་ལུ་དེབ་རྟགས་ཅིག་ཧེ་མ་ལས་འདུག"
+
+#, c-format
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "ཡུ་ཨར་་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་མིན་འདུག"
+
+#, c-format
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "ཡུ་ཨར་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་ནང་ཨེམ་ཨའི་ཨེམ་ཨི་གི་དབྱེ་བ་ངེས་འཛིན་འབད་མིན་འདུག"
+
+#, c-format
+#~ msgid "No private flag has been defined in bookmark for URI '%s'"
+#~ msgstr "ཡུ་ཨར་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་ནང་སྒེར་གྱི་དར་ངེས་འཛིན་འབད་དེ་མིན་འདུག"
+
+#, c-format
+#~ msgid "No groups set in bookmark for URI '%s'"
+#~ msgstr "ཡུ་ཨར་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་ནང་སྡེ་ཚན་ཚུ་གཞི་སྒྲིག་འབད་དེ་མིན་འདུག"
+
+#, c-format
+#~ msgid "No application with name '%s' registered a bookmark for '%s'"
+#~ msgstr "'%s'དོན་ལུ་དེབ་རྟགས་མིང'%s' ཐོ་བཀོད་དང་བཅསཔ་སྦེ་འཇུག་སྤྱོད་འབད་དེ་མིན་འདུག"
+
+#~ msgid "Find Now"
+#~ msgstr "ད་ལྟོ་འཚོལ་"
+
+#, c-format
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b> ཁ་ཕྱེ %s་</b>"
+
+#, c-format
+#~ msgid "Remove from System Items"
+#~ msgstr "རིམ་ལུགས་རྣམ་གྲངས་ལས་རྩ་བསྐྲད་གཏང་"
+
+#~ msgid "Login"
+#~ msgstr "ནང་བསྐྱོད།"
+
+#~ msgid "Boing"
+#~ msgstr "བོ་ཡིང་།"
+
+#~ msgid "Siren"
+#~ msgstr "སྒྲ་འཕྲུལ།"
+
+#~ msgid "Clink"
+#~ msgstr "ཏིང་སྒྲ།"
+
+#~ msgid "Beep"
+#~ msgstr "བརྡ་སྐད་རྐྱབས།"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "བྱུང་ལས་ཀྱི་དོན་ལུ་སྒྲ་སྐད་གཞི་སྒྲིག་མ་འབད་བས།"
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "བྱུང་ལས་འདི་གི་དོན་ལུ་ སྒྲ་སྐད་ཡིག་སྣོད་དེ་མིན་འདུག\n"
+#~ "ཁྱོད་ཀྱིས་ སྔོན་སྒྲིག་སྒྲ་སྐད་ཀྱི་ཆ་ཚན་ཅིག་གི་དོན་ལུ་ཇི་ནོམ་རྣར་ཉན་ཐུམ་སྒྲིལ་་དེ་ གཞི་བཙུགས་འབད་ནི་ཨིནམ་"
+#~ "འོང་།"
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "བྱུང་ལས་འདི་གི་དོན་ལུ་ སྒྲ་སྐད་ཡིག་སྣོད་དེ་མིན་འདུག"
+
+#, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "ཡིག་སྣོད་%sདེ་ ནུས་ཅན་གྱི་ ཝེབ་ཡིག་སྣོད་ཅིག་མེན་པས།"
+
+#~ msgid "Select sound file..."
+#~ msgstr "སྒྲ་སྐད་ཡིག་སྣོད་སེལ་འཐུ་འབད་..."
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "སྒོ་སྒྲིག་འཛིན་སྐྱོང་པ་\"%s\" གིས་ རིམ་སྒྲིག་ལག་ཆས་ཅིག་ ཐོ་འགོད་མ་འབད་བས།\n"
+
+#~ msgid "Maximize"
+#~ msgstr "མང་མཐའ་ལུ་སེང་།"
+
+#~ msgid "Minimize"
+#~ msgstr "ཆུང་ཀུ་བཟོ་ "
+
+#~ msgid "Roll up"
+#~ msgstr "ཡར་བསྒྲིལ"
+
+#, c-format
+#~ msgid "key not found [%s]\n"
+#~ msgstr "ལྡེ་མིག་མ་འཐོབ་ [%s]\n"
+
+#~ msgid "Groups"
+#~ msgstr "སྡེ་ཚན་ཚུ་"
+
+#~ msgid "Control Center"
+#~ msgstr "ཚད་འཛིན་ལྟེ་བ་"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "ལས་ཀ་ཤུགས་ལྡན་བཟོ་བའི་སྐབས་སུ་དབུས་ཀྱི་ཚད་འཛིན་ཁ་བསྡམས"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "ལ་འགན་གྲུབ་ཡོད་པའི་ལ་གཡོག་རྩ་བསྐྲེད་གཏང་་ནི་ཡང་ན་ཁ་སྐོང་བརྐྱབས་ནི་ཕྱིར་ཐོན་ཤལ།"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "ལ་འགན་འགྲུབ་ཡོད་པའི་བྱ་བ་གྲོགས་རམ་གུ་ཕྱིར་འཐོན་ཤལ"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "ལཱ་འགན་འགྲུབ་ཡོད་པའི་བྱ་བ་འགོ་བཙུགས་ནི་གུ་ཕྱིར་ཐོན་གྱི་ཤལ"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "ཡར་བསྐྱེད་ནི་ཡང་ན་ལཱ་འགན་འགྲུབ་ཡོད་པའི་གཞི་བཙུགས་མ་འབད་བའི་བྱ་བ་གུ་ཕྱིར་ཐོན་གྱི་ཤལ"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr ""
+#~ "གྲོགས་རམ་བྱ་བ་འདི་ ལཱ་འགན་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ ཤལ་ཁ་བསྡམས་ནི་ཨིན་ན་མེན་ན་་བརྡ་སྟོན་འབདཝ་"
+#~ "ཨིན། "
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr ""
+#~ "འགོ་བཙུགས་བྱ་བ་འདི་ ལཱ་འགན་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ ཤལ་ཁ་བསྡམས་ནི་ཨིན་ན་མེན་ན་ ་བརྡ་སྟོན་འབདཝ་"
+#~ "ཨིན། "
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "བསྡོམས་ནི་ཡང་ན་བསྐྲེད་གཏང་ ནི་བྱ་བ་འདི་ལཱ་འགན་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ཤ ལ་འདི་ཁ་བསྡམས་ནི་ཨིན་ན་"
+#~ "མེན་ན་བརྡ་སྟོན་འབདཝ་ཨིན། "
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "ཡར་བསྐྱེད་ ཡང་ན་ གཞི་བཙུགས་མ་འབད་བའི་བྱ་བ་འདི་ལཱ་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ ཤལ་འདི་ཁ་བསྡམས་ནི་"
+#~ "ཨིན་ན་མེན་ན་ བརྡ་སྟོན་འབདཝ་ཨིན། "
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "ལས་ཀའི་མིང་དང་འགན་རོགས་ཌེཀསི་ཊོབ་ཡིག་སྣོད་ཚུ"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "ལས་ཀའི་མིང་འདི་ཚད་འཛིན་དབུས་ལུ་བཀྲམ་སྟོན་འབད་ནི་ དེ་ལས་\";\"དབྱེ་བྱེད་གྲོགས་རམ་གྱི་ ཡིག་སྣོད་ཀྱི་"
+#~ "མིང་ །ལས་ཀ་དེ་གི་དོན་ལས་ཌེཀསི་ཊོབ་ཡིག་སྣོད་གསར་བཙུགས་འབད།"
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[ཌེཀསི་ཊོབ་རྒྱབ་བརྟེན་སོར ;རྒྱབ་བརྟེན་ ཌེཀསི་ཊོབ བརྗོད་དོན་སོར ཇིཊི་ཀེ-བརྗོད་དོན་-སེལ་བྱེད ཌེཀསི་ཊོབ་ "
+#~ "འཇུག་སྤྱོད་དགའ་གདམ་གཞི་སྒྲིག་ སྔོན་སྒྲིག་-འཇུག་སྤྱོད།  ཌེཀསི་ཊོབ དཔར་འཕྲུལ་ཁ་སྐོང་བརྐྱབས ཇི་ནོམ-ཀབསི- "
+#~ "འཛིན་སྐྱོང་པ་གིས་ཌེཀསི་ཊོབ]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "གལ་སྲིད་བདེན་པ་ཅིན་  \"མཐུན་མོངས་ལས་ཀ་\"ཤུགས་བདེན་བཟོ་བའི་སྐབས་སུ་དབུས་ཀྱི་ཚད་འཛིན་ཁ་བསྡམས་"
+#~ "འོང་། "
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "ཇི་ནོམ་རིམ་སྒྲིག་ལག་ཆས།"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "བར་མཚམས་ ཕར་འགྱངས(_P)"
+
+#~ msgid "Take a break!"
+#~ msgstr "བར་མཚམས་ཅིག་ལེན།"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/ བར་མཚམས་ལེན།(_T)"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "ཤུལ་མའི་བར་མཚམས་ཚུན་ཚོད་སྐར་མ་%d "
+#~ msgstr[1] "ཤུལ་མའི་བར་མཚམས་ཚུན་ཚོད་སྐར་མ་%d"
+
+#, c-format
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "ཤུལ་མའི་བར་མཚམས་ཚུན་ཚོད་ སྐར་མ་གཅིག་ལས་ཉུངམ་།"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "ཡིག་དཔར་བར་མཚམས་རྒྱུ་དངོས་ཀྱི་ ཌའི་ལོག་དེ་ འོག་གི་འཛོལ་བ་དང་གཅིག་ཁར་ འབག་འོང་མ་ཚུགས་: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "བྲིས་མི་ རི་ཅཱཌི་ཧཱལཊི་ <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "ཨེན་ཌརསི་ ཀ་རཱལསི་སཱན་གྱིས་ ཁ་སྐོང་བརྐྱབས་མི་ ཨའི་ཀེན་ཌི།"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "གློག་རིག་བར་མཚམས་ཀྱི་ དྲན་བསྐུལ་ཅིག"
+
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "ཨའི་ཌི་ཨར་སི་གི་ མ་དངུལ་རྒྱབ་སྐྱོར་ཐོག་ལས་ བརྡ་དོན་འཕྲུལ་རིག་ལས་ཁུངས་ནང་ སྐད་བསྒྱུར་འབད་ཡི། ཁ་"
+#~ "གསལ་གྱི་དོན་ལུ་ འབྲེལ་བ་འཐབ་ས་: <pema_geyleg@druknet.bt>"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "རྐྱེན་སེལ་འབད་བའི་ཨང་རྟགས་ལྕོགས་ཅན་བཟོ"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "བརྡ་བསྐུལ་གནས་ཁོངས་ཡོད་ག་མེད་ག་ཞིབ་དཔྱད་མ་འབད"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "ཡིག་དཔར་བརྐྱབ་ནིའི་གསལ་གཞི་དེ་གིས་ བརྡ་བསྐུལ་མངའ་ཁོངས་དེ་ བརྡ་དོན་བཀྲམ་སྟོན་གྱི་དོན་ལུ་ ལག་ལེན་"
+#~ "འཐབ་ཨིན། ཁྱོད་ཀྱི་པེ་ནཱལ་གུ་ བརྡ་བསྐུལ་མངའ་ཁོངས་ མེདཔ་བཟུམ་ཅིག་འདུག ཁྱོད་ཀྱིས་ཁྱོད་རའི་པེ་ནཱལ་གུ་ "
+#~ "གཡས་ཀྱི་ཨེབ་གཏང་འབད་དེ་ ‘པེ་ནཱལ་གུ་ཁ་སྐོང་རྐྱབས་’ ཟེར་མི་གདམ་ཁ་བརྐྱབས་པའི་སྒོ་ལས་ བརྡ་བསྐུལ་"
+#~ "མངའ་ཁོངས་ སེལ་འཐུ་འབད་དེ་ ཁ་སྐོང་བརྐྱབ་ནི་ལུ་ ཨེབ་གཏང་འབད་བའི་ཐོག་ལས་ བརྡ་བསྐུལ་མངའ་ཁོངས་ "
+#~ "ཁ་སྐོང་བརྐྱབ་ཚུགས།"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "གློག་རིམ་ཡིག་གཟུགས་བཟུམ་སྦེ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid "Sets the default application font"
+#~ msgstr "སྔོན་སྒྲིག་གློག་རིམ་ཡིག་གཟུགས་དེ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་ ཨོ་པཱན་ཊ་ཡིཔ་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr ""
+#~ "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་པི་སི་ཨེཕ་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་ ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr ""
+#~ "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་ ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "ལྡེ་མིག་འདི་ ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་"
+#~ "མི་ བརྡ་བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "ལྡེ་མིག་འདི་ ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་"
+#~ "མི་ བརྡ་བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "ལྡེ་མིག་འདི་ ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ "
+#~ "བརྡ་བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "ལྡེ་མིག་འདི་ ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ "
+#~ "བརྡ་བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "པི་སི་ཨེཕ་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "པི་སི་ཨེཕ་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr ""
+#~ "ཨ་ཡིག་དཀར་མཛེས་ལས་འཁྲུངས་ཤེས་བློའི་གཏེར།། ཕས་རྒོལ་ཝ་སྐྱེས་ཟིལ་གནོན་གདོང་ལྔ་བཞིན།། ཆགས་ཐོགས་ཀུན་"
+#~ "བྲལ་མཚུངས་མེད་འཇམ་དབྱངས་མཐུས།། མཧཱ་མཁས་པའི་གཙོ་བོར་ཉིད་གྱུར་ཅིག ༠༡༢༣༤༥༦༧༨༩"
+
+#~ msgid "Size:"
+#~ msgstr "ཚད་:"
+
+#~ msgid "Copyright:"
+#~ msgstr "འདྲ་བཤུས་དབང་ཆ་:"
+
+#~ msgid "Description:"
+#~ msgstr "འགྲེལ་བཤད་:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "ལག་ལེན་: ཡིག་གཟུགས་ཡིག་སྣོད་%s \n"
+
+#~ msgid "Font Viewer"
+#~ msgstr "་ཡིག་གཟུགས་མཐོང་འབྱེད་ "
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "མཐེ་གཟེར་ལུ་ཚིག་ཡིག་(སྔོན་སྒྲིག: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "ཚིག་ཡིག"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "ཡིག་གཟུགས་ཚད (སྔོན་སྒྲིག: ༦༤)"
+
+#~ msgid "SIZE"
+#~ msgstr "ཚད"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "ཡིག་གཟུགས་ཡིག་སྣོད་ ཨའུཊི་པུཊི་ཡིག་སྣོད"
+
+#, c-format
+#~ msgid "Error parsing arguments: %s\n"
+#~ msgstr "སྒྲུབ་རྟགས་མིང་དཔྱད་འབདཝ་ད་འཛོལ་བ : %s\n"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">ཡིག་གཟུགས་གསརཔ་ འཇུག་སྤྱོད་འབད་ནི་ཨིན་ན?</"
+#~ "span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "ཡིག་གཟུགས་འཇུག་སྤྱོད་མ་འབད།(_n)"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱིས་སེལ་འཐུ་འབད་མི་ བརྗོད་དོན་དེ་གིས་ ཡིག་གཟུགས་གསརཔ་ཅིག་གི་ བསམ་འཆར་བཀོདཔ་ཨིན་པས། ཡིག་"
+#~ "གཟུགས་ཀྱི་སྔོན་ལྟ་ཅིག་ འོག་ལུ་སྟོན་ཏེ་ཡོད།"
+
+#~ msgid "Themes"
+#~ msgstr "བརྗོད་དོན་ཚུ།"
+
+#~ msgid "Description"
+#~ msgstr "འགྲེལ་བཤད།"
+
+#~ msgid "Control theme"
+#~ msgstr "ཚད་འཛིན་བརྗོད་དོན།"
+
+#~ msgid "Window border theme"
+#~ msgstr "སྒོ་སྒྲིག་གི་མཐའ་མཚམས་ཀྱི་བརྗོད་དོན།"
+
+#~ msgid "Icon theme"
+#~ msgstr "ངོས་དཔར་གྱི་བརྗོད་དོན།"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr ""
+#~ "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ གཞི་བཙུགས་འབད་མི་བརྗོད་དོན་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ བརྗོད་དོན་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "ལྡེ་མིག་འདི་ གཞི་བཙུགས་འབད་དེ་ཡོད་མི་ བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་"
+#~ "ལེན་འཐབ་མི་ བརྡ་བཀོད་ལུ་གཞི་སྒྲིག་འབད།"
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "ལྡེ་མིག་འདི་ བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ བརྡ་བཀོད་ལུ་"
+#~ "གཞི་སྒྲིག་འབད།"
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "གཞི་བཙུགས་འབད་དེ་ཡོད་པའི་ བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "གཞི་བཙུགས་འབད་དེ་ཡོད་པའི་ བརྗོད་དོན་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "བརྗོད་དོན་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ཀ་ཁ་ག་ང་།་ཅ་ཆ་ཇ་ཉ།"
+
+#~ msgid "[FILE]"
+#~ msgstr "[ཡིག་སྣོད]"
+
+#~ msgid "Apply theme"
+#~ msgstr "བརྗོད་དོན་ལག་ལེན་འཐབ།"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "སྔོན་སྒྲིག་བརྗོད་དོན་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid "Show help options"
+#~ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid " "
 #~ msgstr " "
@@ -3505,9 +7407,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Import Feature Settings File"
 #~ msgstr "ཁྱད་རྣམ་གཞི་སྒྲིག་ཡིག་སྣོད་ ནང་འདྲེན་འབད།"
-
-#~ msgid "_Import"
-#~ msgstr "ནང་འདྲེན།(_I)"
 
 #~ msgid "Set your keyboard accessibility preferences"
 #~ msgstr "ཁྱོད་རའི་ལྡེ་སྒྲོམ་གྱི་ འཛུལ་སྤྱོད་དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
@@ -3540,9 +7439,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Delay between keypress and pointer mo_vement:"
 #~ msgstr "ལྡེ་མིག་ཨེབ་གནོན་དང་ དཔག་བྱེད་སྤོ་བཤུད་ཀྱི་བར་ན་ ཕྱིར་འགྱངས།(_v)"
-
-#~ msgid "E_nable Toggle Keys"
-#~ msgstr "སོར་སྟོན་ལྡེ་མིག་ཚུ་ ལྕོགས་ཅན་བཟོ།(_n)"
 
 #~ msgid "Filters"
 #~ msgstr "ཚགས་མ།"
@@ -3613,9 +7509,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "Go _to Fonts Folder"
 #~ msgstr "ཡིག་གཟུགས་ཀྱི་ཡིག་སྣོད་ལུ་འགྱོ(_t)"
 
-#~ msgid "Theme Details"
-#~ msgstr "བརྗོད་དོན་གྱི་རྒྱས་བཤད།"
-
 #~ msgid "gtk-delete"
 #~ msgstr "ཇི་ཊི་ཀེ་-བཏོན་གཏང་"
 
@@ -3644,9 +7537,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "The file format is invalid."
 #~ msgstr "ཡིག་སྣོད་ཀྱི་རྩ་སྒྲིག་དེ་ ནུས་མེད་ཨིན་པས།"
 
-#~ msgid "Connecting..."
-#~ msgstr "མཐུད་དོ་..."
-
 #~ msgid "Preferred Assistive Technology"
 #~ msgstr "ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་རྒྱབ་སྐྱོར"
 
@@ -3658,9 +7548,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Autostart the preferred AT"
 #~ msgstr "དགའ་གདམ་ཨེ་ཊི་རང་བཞིན་འགོ་བཙུགས"
-
-#~ msgid "Visual"
-#~ msgstr "མཐོང་བའི"
 
 #~ msgid "Evolution Mail Reader 1.4"
 #~ msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི་༡.༤།"
@@ -3751,20 +7638,11 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "<i>Small</i>"
 #~ msgstr "<i>ཆུང་ཀུ་</i>"
 
-#~ msgid "Buttons"
-#~ msgstr "ཨེབ་རྟ་ཚུ།"
-
 #~ msgid "Highlight the _pointer when you press Ctrl"
 #~ msgstr "ཁྱོད་ཀྱིས་ཚད་འཛིན་ཨེབ་ད་ དཔག་བྱེད་དེ་ གཙོ་དམིགས་འབདཝ་ཨིན།(_p)"
 
 #~ msgid "Motion"
 #~ msgstr "འགུལ་བསྐྱོད།"
-
-#~ msgid "Pointer Size:"
-#~ msgstr "དཔག་བྱེད་ཚད་:"
-
-#~ msgid "Pointers"
-#~ msgstr "དཔག་བྱེད་ཚུ།"
 
 #~ msgid ""
 #~ "Small\n"
@@ -3777,12 +7655,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "      "
 #~ msgstr "    "
-
-#~ msgid "Volume"
-#~ msgstr "སྐད་ཤུགས"
-
-#~ msgid "Slow Keys Alert"
-#~ msgstr "ལྡེ་མིག་དྲན་བརྡ་ལྷོད།"
 
 #~ msgid ""
 #~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
@@ -3797,20 +7669,11 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "Do you want to deactivate Slow Keys?"
 #~ msgstr "ལྡེ་མིག་ལྷོད་ཆ་ ཤུགས་མེད་བཟོ་ནི་ཨིན་ན?།"
 
-#~ msgid "_Activate"
-#~ msgstr "ཤུགས་ལྡན་བཟོ།(_A)"
-
 #~ msgid "_Deactivate"
 #~ msgstr "ཤུགས་མེད་བཟོ།(_D)"
 
 #~ msgid "Do_n't activate"
 #~ msgstr "ཤུགས་ལྡན་མ་བཟོ།(_n)"
-
-#~ msgid "Do_n't deactivate"
-#~ msgstr "ཤུགས་མེད་མ་བཟོ།(_n)"
-
-#~ msgid "Sticky Keys Alert"
-#~ msgstr "སྦྱར་རྩི་ཅན་གྱི་ལྡེ་མིག་དྲན་བརྡ།"
 
 #~ msgid ""
 #~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
@@ -4000,14 +7863,8 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "_Load"
 #~ msgstr "མངོན་གསལ་འབད།(_L)"
 
-#~ msgid "_Loaded files:"
-#~ msgstr "མངོན་གསལ་འབད་ཡོད་པའི་ཡིག་སྣོད་ཚུ་:(_L)"
-
 #~ msgid "Error creating signal pipe."
 #~ msgstr "བརྡ་མཚོན་རྒྱུད་དུང་ གསར་བསྐྲུན་འབད་ནི་ལུ་འཛོལ་བ།"
-
-#~ msgid "Type"
-#~ msgstr "དབྱེ་བ།"
 
 #~ msgid ""
 #~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
@@ -4024,9 +7881,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Height if applier is a preview: Defaults to 48."
 #~ msgstr "འཇུག་སྤྱོད་པ་དེ་ སྔོན་ལྟ་ཨིན་པ་ཅིན་ མཐོ་ཚད: ༤༨ ལུ་ སྔོན་སྒྲིག་འབདཝ་ཨིན།"
-
-#~ msgid "Screen"
-#~ msgstr "གསལ་གཞི།"
 
 #~ msgid "Screen on which BGApplier is to draw"
 #~ msgstr "བི་ཇི་འཇུག་སྤྱོད་པ་ འབྲི་སའི་གསལ་གཞི།"
@@ -4049,44 +7903,23 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "E-mail's shortcut."
 #~ msgstr "གློག་འཕྲིན་གྱི་མགྱོགས་ཐབས།"
 
-#~ msgid "Eject"
-#~ msgstr "ཕྱིར་བཏོན།"
-
 #~ msgid "Eject's shortcut."
 #~ msgstr "ཕྱིར་བཏོན་གྱི་མགྱོགས་ཐབས།"
-
-#~ msgid "Home folder"
-#~ msgstr "ཁྱིམ་གྱི་ལེ་སྣོད།"
 
 #~ msgid "Home folder's shortcut."
 #~ msgstr "ཁྱིམ་གྱི་ལེ་སྣོད་ཀྱི་མགྱོགས་ཐབས།"
 
-#~ msgid "Launch help browser"
-#~ msgstr "བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་འབད།"
-
 #~ msgid "Launch help browser's shortcut."
 #~ msgstr "བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་ཀྱི་ མགྱོགས་ཐབས།"
-
-#~ msgid "Launch web browser"
-#~ msgstr "ཝེབ་བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་འབད"
 
 #~ msgid "Launch web browser's shortcut."
 #~ msgstr "ཝེབ་བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་ཀྱི་ མགྱོགས་ཐབས།"
 
-#~ msgid "Lock screen"
-#~ msgstr "གསལ་གཞི་ལྡེ་མིག་རྐྱབས།"
-
 #~ msgid "Lock screen's shortcut."
 #~ msgstr "གསལ་གཞི་ལྡེ་མིག་བརྐྱབ་ནིའི་མགྱོགས་ཐབས།"
 
-#~ msgid "Log out"
-#~ msgstr "ཕྱིར་བསྐྱོད་འབད།"
-
 #~ msgid "Log out's shortcut."
 #~ msgstr "ཕྱིར་བསྐྱོད་མགྱོགས་ཐབས།"
-
-#~ msgid "Media player"
-#~ msgstr "བརྡ་བརྒྱུད་གཏང་འཕྲུལ"
 
 #~ msgid "Media player key's shortcut."
 #~ msgstr "བརྡ་ལམ་གཏང་མི་ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
@@ -4100,23 +7933,11 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "Pause key's shortcut."
 #~ msgstr "ཐེམ་ནིའི་ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
 
-#~ msgid "Play (or play/pause)"
-#~ msgstr "གཏང་། (ཡང་ན་ གཏང་/ཐེམ)"
-
 #~ msgid "Play (or play/pause) key's shortcut."
 #~ msgstr "གཏང་། (ཡང་ན་ ་གཏང་/ཐེམ) ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
 
 #~ msgid "Previous track key's shortcut."
 #~ msgstr "ཧེ་མའི་གླུ་གཞས་ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
-
-#~ msgid "Search's shortcut."
-#~ msgstr "འཚོལ་ཞིབ་ཀྱི་མགྱོགས་ཐབས།"
-
-#~ msgid "Skip to next track"
-#~ msgstr "གླུ་རིམ་གཞན་མི་ལུ་གོམ་འགྱོ།"
-
-#~ msgid "Skip to previous track"
-#~ msgstr "ཧེ་མའི་གླུ་རིམ་ལུ་གོམ་འགྱོ།"
 
 #~ msgid "Sleep"
 #~ msgstr "ཉལ།"
@@ -4124,20 +7945,11 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "Sleep's shortcut."
 #~ msgstr "ཉལ་ནིའི་མགྱོགས་ཐབས།"
 
-#~ msgid "Stop playback key"
-#~ msgstr "ལོག་གཏང་ནི་ མཚམས་འཇོག་གི་ལྡེ་མི"
-
 #~ msgid "Stop playback key's shortcut."
 #~ msgstr "ལོག་གཏང་ནི་མཚམས་འཇོག་གི་ ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
 
-#~ msgid "Volume down"
-#~ msgstr "སྐད་ཤུགས་མར་ཕབ།"
-
 #~ msgid "Volume down's shortcut."
 #~ msgstr "སྐད་ཤུགས་མར་ཕབ་ཀྱི་མགྱོགས་ཐབས།"
-
-#~ msgid "Volume mute"
-#~ msgstr "སྐད་མེད།"
 
 #~ msgid "Volume mute's shortcut."
 #~ msgstr "སྐད་ཤུགས་སྐད་མེད་ཀྱི་མགྱོགས་ཐབས།"
@@ -4147,9 +7959,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Volume step as percentage of volume."
 #~ msgstr "སྐད་ཤུགས་རིམ་པ་ སྐད་ཤུགས་བརྒྱ་ཆའི་ནང་།"
-
-#~ msgid "Volume up"
-#~ msgstr "སྐད་ཤུགས་ཡར་སེང་།"
 
 #~ msgid "Volume up's shortcut."
 #~ msgstr "སྐད་ཤུགས་ཡར་སེང་གི་མགྱོགས་ཐབས།"
@@ -4166,9 +7975,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Start screensaver"
 #~ msgstr "གསལ་གཞི་ཉེན་སྲུང་འགོ་བཙུགས།"
-
-#~ msgid "<b>Applications</b>"
-#~ msgstr "<b>གློག་རིམ་</b>"
 
 #~ msgid "<b>Support</b>"
 #~ msgstr "<b>རྒྱབ་སྐྱོར་</b>"
@@ -4203,9 +8009,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ "གསལ་གཞི་ལྷག་ནི་དང་ ཆེར་བསྐྱེད་ཀྱི་ལྕོགས་གྲུབ་དོན་ལུ་ 'ཨོ་ཨར་སི་ཨེ་་' ཐུམ་སྒྲིལ་དེ་ གཞི་བཙུགས་འབད་"
 #~ "དགོ།"
 
-#~ msgid "Change your Desktop Background settings"
-#~ msgstr "ཁྱོད་རའི་ཌེཀསི་ཊོཔ་གི་ རྒྱབ་གཞིའི་གཞི་སྒྲིག་ཚུ་ བསྒྱུར་བཅོས་འབད།"
-
 #~ msgid "Desktop Background"
 #~ msgstr "ཌེཀསི་་ཊོཔ་གི་རྒྱབ་གཞི།"
 
@@ -4218,20 +8021,8 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "_Finish"
 #~ msgstr "རྫོགས།(_F)"
 
-#~ msgid "_Remove"
-#~ msgstr "རྩ་བསྐྲད་གཏང་།(_R)"
-
 #~ msgid "Centered"
 #~ msgstr "དབུས་སྒྲིག"
-
-#~ msgid "Fill Screen"
-#~ msgstr "གསལ་གཞི་བཀང་།"
-
-#~ msgid "Scaled"
-#~ msgstr "ཆ་ཚད་འཇལ་ཡོདཔ།"
-
-#~ msgid "Zoom"
-#~ msgstr "རྒྱས་ཟུམ།"
 
 #~ msgid "Tiled"
 #~ msgstr "ཊའིལཌི་།"
@@ -4256,9 +8047,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Font Preferences"
 #~ msgstr "ཡིག་གཟུགས་ཀྱི་དགའ་གདམ་ཚུ།"
-
-#~ msgid "Medium"
-#~ msgstr "འབྲིང་མ་།"
 
 #~ msgid "Theme deleted succesfully. Please select another theme."
 #~ msgstr "བརྗོད་དོན་མཐར་འཁྱོལ་སྦེ་བཏོན་བཏང་ཡོད། བརྗོད་དོན་གཞན་ཅིག་སེལ་འཐུ་འབད་གནང་།"
@@ -4299,9 +8087,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "This theme suggests a font and a background:"
 #~ msgstr "བརྗོད་དོན་འདི་གིས་ ཡིག་གཟུགས་ཅིག་དང་ རྒྱབ་གཞི་ཅིག་གི་ བསམ་འཆར་བཀོདཔ་མས།"
-
-#~ msgid "_Install Theme..."
-#~ msgstr "བརྗོད་དོན་གཞི་བཙུགས་འབད་...(_I)"
 
 #~ msgid "_Revert"
 #~ msgstr "རྒྱབ་ལོག་འབད།(_R)"
@@ -4373,12 +8158,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "GNOME Control Center"
 #~ msgstr "ཇི་ནོམ་ཚད་འཛིན་ལྟེ་བ།"
 
-#~ msgid "From:"
-#~ msgstr "ལས་:"
-
-#~ msgid "To:"
-#~ msgstr "ལུ་:"
-
 #~ msgid "Sound & Video Preferences"
 #~ msgstr "སྒྲ་སྐད་དང་ཝི་ཌིའོ་དགའ་གདམ་ཚུ།"
 
@@ -4431,9 +8210,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Keyboard Update Handlers"
 #~ msgstr "ལྡེ་སྒྲོམ་དུས་མཐུན་གྱི་ ལེགས་སྐྱོང་པ།"
-
-#~ msgid "Keyboard layout"
-#~ msgstr "ལྡེ་སྒྲོམ་སྒྲིག་བཀོད།"
 
 #~ msgid "Keyboard model"
 #~ msgstr "ལྡེ་སྒྲོམ་གྱི་དཔེ།"
@@ -4495,9 +8271,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "Break reminder"
 #~ msgstr "བར་མཚམས་ཀྱི་དྲན་བསྐུལ།"
 
-#~ msgid "Orientation"
-#~ msgstr "ཕྱོགས།"
-
 #~ msgid "The orientation of the tray."
 #~ msgstr "ཤོག་སྣོད་ཀྱི་ཕྱོགས།"
 
@@ -4547,9 +8320,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "no layout"
 #~ msgstr "སྒྲིག་བཀོད་མིན་འདུག"
 
-#~ msgid "no options"
-#~ msgstr "གདམ་ཁ་མིན་འདུག"
-
 #~ msgid "Old password is incorrect, please retype it"
 #~ msgstr "ཆོག་ཡིག་རྙིངམ་དེ་ བདེན་པ་མེན་པས། ལོག་ཡིག་དཔར་རྐྱབས།"
 
@@ -4592,9 +8362,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "Brightness down's shortcut."
 #~ msgstr "དཀར་མདངས་མར་ཕབ་ཀྱི་མགྱོགས་ཐབས།"
 
-#~ msgid "Brightness up"
-#~ msgstr "དཀར་མདངས་ཡར་སེང་།"
-
 #~ msgid "Brightness up's shortcut."
 #~ msgstr "དཀར་མདངས་ཡར་སེང་གི་མགྱོགས་ཐབས།"
 
@@ -4603,9 +8370,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Please specify a name and a command for this editor."
 #~ msgstr "ཞུན་དགཔ་དེ་གི་དོན་ལུ་ མིང་ཅིག་དང་བརྡ་བཀོད་ཅིག་ གསལ་བཀོད་འབད་གནང་།"
-
-#~ msgid "Add..."
-#~ msgstr "ཁ་སྐོང་རྐྱབས་..."
 
 #~ msgid "Can open _URIs"
 #~ msgstr "ཡུ་ཨར་ཨའི་ཚུ་ ཁ་ཕྱེ་ཚུགས།(_U)"
@@ -4652,12 +8416,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgstr ""
 #~ "ཡིག་སྣོད་འཛིན་སྐྱོང་པའི་ནང་ན་ ཚིག་ཡིག་ཡིག་སྣོད་ ཁ་ཕྱེ་ནིའི་དོན་ལུ་ ཞུན་དགཔ་འདི་ ལག་ལེན་འཐབ།(_e)"
 
-#~ msgid "Window Manager"
-#~ msgstr "སྒོ་སྒྲིག་འཛིན་སྐྱོང་པ།"
-
-#~ msgid "_Command:"
-#~ msgstr "བརྡ་བཀོད་:(_C)"
-
 #~ msgid "_Properties..."
 #~ msgstr "རྒྱུ་དངོས་...(_P)"
 
@@ -4685,23 +8443,11 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 #~ msgid "Permissions on the file %s are broken\n"
 #~ msgstr "ཡིག་སྣོད་%sགི་གནང་བ་ཚུ་ རྒྱུན་ཆད་སོ་ནུག\n"
 
-#~ msgid "Event"
-#~ msgstr "བྱུང་ལས།"
-
-#~ msgid "Sound File"
-#~ msgstr "སྒྲ་སྐད་ཡིག་སྣོད།"
-
-#~ msgid "_Sounds:"
-#~ msgstr "སྒྲ་སྐད་ཚུ་:(_S)"
-
 #~ msgid "_Play"
 #~ msgstr "གཏང་།(_P)"
 
 #~ msgid "The typing monitor is already running."
 #~ msgstr "ཡིག་དཔར་བརྐྱབ་ནིའི་གསལ་གཞི་དེ་ ཧེ་མ་ལས་རང་ གཡོག་བཀོལ་ཏེ་འདུག"
-
-#~ msgid "Information about myself"
-#~ msgstr "རང་ཉིད་སྐོར་གྱི་བརྡ་དོན།"
 
 #~ msgid "Pick a color"
 #~ msgstr "ཚོས་གཞི་ཅིག་འཐུ།"
@@ -4714,9 +8460,6 @@ msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
 
 #~ msgid "Downloading..."
 #~ msgstr "ཕབ་ལེན་འབད་དོ་..."
-
-#~ msgid "Set the font for applications"
-#~ msgstr "གློག་རིམ་གྱི་དོན་ལུ་ ཡིག་གཟུགས་གཞི་སྒྲིག་འབད།"
 
 #~ msgid "Set the font for the icons on the desktop"
 #~ msgstr "ཌེཀསི་ཊོཔ་གུ་ ངོས་དཔར་གྱི་དོན་ལུ་ ཡིག་གཟུགས་གཞི་སྒྲིག་འབད།"

--- a/po/dz.po~
+++ b/po/dz.po~
@@ -1,0 +1,4744 @@
+# Dzongkha translation of gnome-control-center
+# Copyright @ 2006 Free Software Foundation, Inc.
+# Mindu Dorji
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.HEAD.dz\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2008-03-29 00:51+0000\n"
+"PO-Revision-Date: 2008-09-11 11:47+0530\n"
+"Last-Translator: Dawa pemo <daws_403@hotmail.com>\n"
+"Language-Team: DZONGKHA <pgeyleg@dit.gov.bt>\n"
+"Language: dz\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Poedit-Language: Dzongkha\n"
+"X-Poedit-Country: BHUTAN\n"
+"X-Poedit-SourceCharset: utf-8\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "གཟུགས་བརྙན་/ཁ་ཡིག་གི་མཐའ་མཚམས།"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "དྲན་བརྡའི་ཌའི་ལོག་ནང་ ཁ་ཡིག་དང་ གཟུགས་བརྙན་གྱི་མཐའ་སྐོར་ལུ་ མཐའ་མཚམས་ཀྱི་རྒྱ་ཚད།"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "དྲན་བརྡའི་དབྱེ་བ།"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "དྲན་བརྡའི་དབྱེ་བ།"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "དྲན་བརྡའི་ཨེབ་རྟ་ཚུ།"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "དྲན་བརྡའི་ཌའི་ལོག་ནང་སྟོན་མི་ཨེབ་རྟ་ཚུ།"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "རྒྱས་བཤད་ཧེང་བཀལ་སྟོན།(_d)"
+
+#: ../capplets/about-me/gnome-about-me.c:682
+msgid "Select Image"
+msgstr "གཟུགས་བརྙན་སེལ་འཐུ་འབད།"
+
+#: ../capplets/about-me/gnome-about-me.c:684
+msgid "No Image"
+msgstr "གཟུགས་བརྙན་མིན་འདུག"
+
+#: ../capplets/about-me/gnome-about-me.c:712
+#: ../capplets/appearance/appearance-desktop.c:1130
+msgid "Images"
+msgstr "གཟུགས་བརྙན་ཚུ།"
+
+#: ../capplets/about-me/gnome-about-me.c:716
+#: ../capplets/appearance/theme-installer.c:694
+msgid "All Files"
+msgstr "ཡིག་སྣོད་ཆ་མཉམ།"
+
+#: ../capplets/about-me/gnome-about-me.c:854
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"ཁ་བྱང་ཀི་དེབ་ཀྱི་ བརྡ་དོན་ལེན་ཐབས་འབད་བའི་སྐབས་ལུ་ འཛོལ་བ་ཅིག་བྱུང་ནུགཨི་བོ་ལུ་ཤཱན་ གནད་སྡུད་སར་བར་"
+"གྱིས་ གནད་སྤེལ་ལམ་ལུགས་ ལེགས་སྐྱོང་འཐབ་མི་ཚུགས་པས།"
+
+#: ../capplets/about-me/gnome-about-me.c:875
+msgid "Unable to open address book"
+msgstr "ཁ་བྱང་ཀི་དེབ་ ཁ་ཕྱེ་མ་ཚུགས།"
+
+#: ../capplets/about-me/gnome-about-me.c:889
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr "མ་ཤེསས་པའི་ ནང་བསྐྱོད་ཨའི་ཌི། ལག་ལེན་པའི་ གཞི་རྟེན་གནད་སྡུད་ ངན་ཅན་ལུ་གྱུར་སོངཔ་འོང་ནི་མས།"
+
+#: ../capplets/about-me/gnome-about-me.c:919
+#: ../capplets/about-me/gnome-about-me.c:921
+#, c-format
+msgid "About %s"
+msgstr "%sསྐོར་ལས།"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "About Me"
+msgstr "ངེད་ཀྱི་སྐོར་ལས།"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "ཁྱོད་རའི་རང་དོན་བརྡ་དོན་ གཞི་སྒྲིག་འབད།"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+msgid "<b>Email</b>"
+msgstr "<i>གློག་འཕྲིན་</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+msgid "<b>Home</b>"
+msgstr "<b>ཁྱིམ་ </b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>འཕྲལ་མྱུར་འཕྲིན་གཏོང་།</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Job</b>"
+msgstr "<b>ལས་གཡོག</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Telephone</b>"
+msgstr "<b>བརྒྱུད་འཕྲིན་</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Web</b>"
+msgstr "<b>ཝེབ་</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Work</b>"
+msgstr "<b>ལཱ་གཡོག་</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">ཁྱོད་རའི་ཆོག་ཡིག་སོར་</span>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "A_IM/iChat:"
+msgstr "ཨེ་ཨའི་ཨེམ/ཨའི་ཅེཊི་:(_I)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "A_ddress:"
+msgstr "ཁ་བྱང་:(_d)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_ssistant:"
+msgstr "ལས་རོགས་:(_s)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "Address"
+msgstr "ཁ་བྱང་།"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "C_ity:"
+msgstr "གྲོང་སྡེ་:(_i)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "C_ompany:"
+msgstr "ཚོང་སྡེ་:(_o)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "Cale_ndar:"
+msgstr "ཟླ་ཐོ་:(_n)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "Change Passwo_rd..."
+msgstr "ཆོག་ཡིག་སོར་...(_r)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Change pa_ssword"
+msgstr "ཆོག་ཡིག་སོར།(_s)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change password"
+msgstr "ཆོག་ཡིག་སོར།"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Ci_ty:"
+msgstr "གྲོང་སྡེ་:(_t)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Co_untry:"
+msgstr "རྒྱལ་ཁབ་:(_u)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Contact"
+msgstr "འབྲེལ་ས"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Cou_ntry:"
+msgstr "རྒྱལ་ཁབ་:(_n)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Current _password:"
+msgstr "ད་ལྟོའི་ཆོག་ཡིག་:(_p)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr "མིང་ཆ་ཚང་།"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Hom_e:"
+msgstr "ཁྱིམ། (_e)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr "ཨའི་སི་ཀིའུ་:(_Q)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr "ཨེམ་ཨེསི་ཨེན་:(_S)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "P.O. _box:"
+msgstr "འགྲེམ་ཁང་ཡིག་སྒྲོམ་:(_b)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P._O. box:"
+msgstr "འགྲེམ་ཁང་ཡིག་སྒྲོམ་:(_O)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "Personal Info"
+msgstr "རང་དོན་བརྡ་དོན།"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+#: ../capplets/about-me/gnome-about-me-password.c:934
+msgid ""
+"Please type your password again in the <b>Retype new password</b> field."
+msgstr ""
+"<b>ཆོག་ཡིག་གསརཔ་ལོག་ཡིག་དཔར་རྐྱབས་</b> ཟེར་མི་ས་སྒོ་ནང་ ཁྱོད་རའི་ཆོག་ཡིག་ ལོག་སྟེ་རང་ཡིག་དཔར་"
+"རྐྱབས།"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "Select your photo"
+msgstr "ཁྱོད་རའི་དཔར་ སེལ་འཐུ་འབད་ "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+msgid "State/Pro_vince:"
+msgstr "མངའ་སྡེ་.མངའ་རིས་:(_v)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid ""
+"To change your password, enter your current password in the field below and "
+"click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for "
+"verification and click <b>Change password</b>."
+msgstr ""
+"ཁྱོད་རའི་ཆོག་ཡིག་སོར་ནི་ལུ་ འོག་གི་སྒོ་ནང་ད་ལྟོའི་ཆོག་ཡིག་ཞིནམ་ལས་ <b>བདེན་བཤད་</b> ལུ་ཨེབ་གཏང་"
+"འབད། བདེན་བཤད་འབད་ཞིནམ་ལས་ ཁྱོད་རའི་ཆོག་ཡིག་གསརཔ་བཙུགས། བདེན་སྦྱོར་གྱི་དོན་ལུ་ ཆོག་ཡིག་དེ་ལོག་སྟེ་"
+"རང་ཚར་ཅིག་ཡིག་དཔར་བརྐྱབས་ཞིནམ་ལས་ <b>ཆོག་ཡིག་སོར་</b> ལུ་ཨེབ་གཏང་འབད།"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid "User name:"
+msgstr "ལག་ལེན་པའི་མིང་:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Web _log:"
+msgstr "ཝེབ་དྲན་དེབ་:(_l)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "Wor_k:"
+msgstr "ལཱ་གཡོག་:(_k)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "Work _fax:"
+msgstr "ལཱ་གི་དཔར་འཕྲིན་:(_f)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "Zip/_Postal code:"
+msgstr "གནས་ཨང་/འགྲེམ་ཨང་:(_p)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "_Address:"
+msgstr "ཁ་བྱང་:(_A)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "_Authenticate"
+msgstr "བདེན་བཤད་འབད།(_A)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Department:"
+msgstr "ལས་ཁུངས་:(_D)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Groupwise:"
+msgstr "སྡེ་རིམ་:(_G)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Home page:"
+msgstr "ཁྱིམ་གྱི་ཤོག་ལེབ་:(_H)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_Home:"
+msgstr "ཁྱིམ་:(_H)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Jabber:"
+msgstr "ཇེབ་བར་:(_J)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Manager:"
+msgstr "འཛིན་སྐྱོང་པ་:(_M)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_Mobile:"
+msgstr "འགྲུལ་འཕྲིན་:(_M)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_New password:"
+msgstr "ཆོག་ཡིག་གསརཔ་:(_N)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Profession:"
+msgstr "ཁྱད་ལས་:(_P)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Retype new password:"
+msgstr "ཆོག་ཡིག་གསརཔ་ལོག་སྟེ་རྐྱབས་:(_R)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_State/Province:"
+msgstr "མངའ་སྡེ་/མངའ་རིས།"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:55
+msgid "_Title:"
+msgstr "གོ་གནས་:(_T)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:56
+msgid "_Work:"
+msgstr "ལཱ་གཡོག་:(_W)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:57
+msgid "_Yahoo:"
+msgstr "ཡ་ཧུ་:(_Y)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:58
+msgid "_Zip/Postal code:"
+msgstr "གནས་ཨང་/འགྲེམ་ཨང་:(_Z)"
+
+#: ../capplets/about-me/gnome-about-me-password.c:162
+msgid "Child exited unexpectedly"
+msgstr "ཆ་ལག་རེ་བ་མེད་པར་ཕྱིར་ཐོན་སོང་ནུག"
+
+#: ../capplets/about-me/gnome-about-me-password.c:297
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr "རྒྱབ་མཐའི་ ཨེསི་ཊི་ཌི་ཨིན་ ཨའི་ཨོ་རྒྱུ་ལམ་:%sསྒོ་བསྡམ་མ་ཚུགས།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:310
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr "རྒྱབ་མཐའི་ ཨེསི་ཊི་ཌི་ཨའུཊི་ཨའི་ཨོ་རྒྱུ་ལམ་:%sསྒོ་བསྡམ་མ་ཚུགས།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:409
+msgid "Authenticated!"
+msgstr "བདེན་བཤད་འབད་ཡོད།"
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:475
+#: ../capplets/about-me/gnome-about-me-password.c:551
+msgid ""
+"Your password has been changed since you initially authenticated! Please re-"
+"authenticate."
+msgstr ""
+"ཁྱོད་ཀྱིས་འགོ་ཐོག་ལུ་ བདེན་བཤད་འབད་ཞིནམ་ལས་ ཁྱོད་ཀྱི་ཆོག་ཡིག་སོར་ནུག སླར་བདེན་བཤད་འབད་གནང་།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:477
+msgid "That password was incorrect."
+msgstr "ཆོག་ཡིག་དེ་བདེན་མེད་ཨིན་པས།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:524
+msgid "Your password has been changed."
+msgstr "ཁྱོད་ཀྱིས་ཆོག་ཡིག་དེ་སོར་ནུག"
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:534
+#, c-format
+msgid "System error: %s."
+msgstr "རིམ་ལུགས་འཛོལ་བ་:%s།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:537
+msgid "The password is too short."
+msgstr "ཆོག་ཡིག་དེ་ཐུང་དྲགས་པས།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:540
+msgid "The password is too simple."
+msgstr "ཆོག་ཡིག་དེ་འཇམ་དྲགས་པས།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:543
+msgid "The old and new passwords are too similar."
+msgstr "ཆོག་ཡིག་རྙིངམ་དང་གསརཔ་འདྲ་བས།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:545
+msgid "The new password must contain numeric or special character(s)."
+msgstr "ཆོག་ཡིག་གསར་པའི་ནང་ཨང་གྲངས་ ཡང་ན་ དམིགས་བསལ་ཡིག་འབྲུ་(ཚུ) ཡོད་དགོ"
+
+#: ../capplets/about-me/gnome-about-me-password.c:548
+msgid "The old and new passwords are the same."
+msgstr "ཆོག་ཡིག་རྙིངམ་དང་གསརཔ་ཅོག་གཅིག་པས།"
+
+#. translators: Unable to launch <program>: <error message>
+#: ../capplets/about-me/gnome-about-me-password.c:818
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr "%s:%s གསར་བཙུགས་འབད་མ་ཚུགས།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:821
+msgid "Unable to launch backend"
+msgstr "རྒྱབ་མཐའ་གསར་བཚུགས་འབད་མི་བཙུགས་པས།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:822
+msgid "A system error has occurred"
+msgstr "རིམ་ལུགས་ཀྱི་འཛོལ་བ་ཅིག་བྱུང་ནུག"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:842
+msgid "Checking password..."
+msgstr "ཆོག་ཡིག་ཞིབ་དཔྱད་འབད་དོ།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:928
+msgid "Click <b>Change password</b> to change your password."
+msgstr "ཁྱོད་རའི་ཆོག་ཡིག་སོར་ནིའི་དོན་ལུ་<b>ཆོག་ཡིག་སོར་</b> གུ་ཨེབ་གཏང་འབད།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:931
+msgid "Please type your password in the <b>New password</b> field."
+msgstr " <b>ཆོག་ཡིག་གསར་པའི་</b> ས་སྒོ་ནང་ ཁྱོད་རའི་ཆོག་ཡིག་ ཡིག་དཔར་རྐྱབས།"
+
+#: ../capplets/about-me/gnome-about-me-password.c:937
+msgid "The two passwords are not equal."
+msgstr "ཆོག་ཡིག་གཉིསཔོ་དེ་འདྲ་མཉམ་མེན་པས།"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Assistive Technologies</b>"
+msgstr "<b>ཕན་ཐབས་ཅན་གྱི་འཕྲུལ་རིག་ཚུ</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Preferences</b>"
+msgstr "<b>དགའ་གདམ་ཚུ</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid "Accessible Lo_gin"
+msgstr "འཛུལ་སྤྱོད་ནང་བསྐྱོད(_g)"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technologies Preferences"
+msgstr "ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་གི་དགའ་གདམ་ཚུ་ "
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid ""
+"Changes to enable assistive technologies will not take effect until your "
+"next log in."
+msgstr ""
+"འཕྲུལ་རིག་ལྕོགས་ཅན་ཕན་འཐབ་བསྒྱུར་བཅོས་ཚུ་ལུ་ ཤུལ་མའི་ནང་བསྐྱོད་མ་འབད་ཚུན་ཚོད་ ནུས་པ་མི་འོང་།"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Close and _Log Out"
+msgstr "ཁ་བསྡམས་ཏེ་ ཕྱིར་བསྐྱོད་འབད།(_L)"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "Jump to Preferred Applications dialog"
+msgstr "དགའ་གདམ་ཅན་གྱི་འཇུག་སྤྱོད་ཌའི་ལོག་ལུ་མཆོང་"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "Jump to the Accessible Login dialog"
+msgstr "ནང་བསྐྱོད་ཌའི་ལོག་འཛུལ་སྤྱོད་ནང་ལུ་མཆོང་"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད་ཌའི་ལོག་ལུ་མཆོང་"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Enable assistive technologies"
+msgstr "ཕན་ཐབས་ཅན་གྱི་འཕྲུལ་རིག་ཚུ་ ལྕོགས་ཅན་བཟོ།(_E)"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
+msgid "_Keyboard Accessibility"
+msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད(_K)"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
+msgid "_Preferred Applications"
+msgstr "དགའ་གདམ་ཅན་གྱི་འཇུག་སྤྱོད(_P)"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technologies"
+msgstr "ཕན་ཐབས་ཅན་གྱི་འཕྲུལ་རིག་ཚུ་ "
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr "ནང་བསྐྱོད་སྐབས་ལུ་ ཇི་ནོམ་གྱི་ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་ཚུ་གི་དོན་ལུ་ རྒྱབ་སྐྱོར་ལྕོགས་ཅན་བཟོ།"
+
+#: ../capplets/appearance/appearance-desktop.c:1098
+msgid "Add Wallpaper"
+msgstr "གྱང་ཤོག་ཁ་སྐོང་རྐྱབས།"
+
+#: ../capplets/appearance/appearance-desktop.c:1134
+msgid "All files"
+msgstr "ཡིག་སྣོད་ཆ་མཉམ"
+
+#: ../capplets/appearance/appearance-font.c:494
+msgid "Font may be too large"
+msgstr "ཡིག་གཟུགས་ཆེ་དྲགས་ནི་མས།"
+
+#: ../capplets/appearance/appearance-font.c:498
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་%d ཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་ལཱ་"
+"ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་%dལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
+msgstr[1] ""
+"སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་%dཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་ལཱ་"
+"ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་%dལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
+
+#: ../capplets/appearance/appearance-font.c:511
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་%dཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་ལཱ་"
+"ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་ དེ་ལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
+msgstr[1] ""
+"སེལ་འཐུ་འབད་མི་ཡིག་གཟུགས་དེ་ ཡིག་ཚད་ %dཨིནམ་ལས་ གློག་རིག་ཕན་ནུས་ཅན་སྦེ་ ལག་ལེན་འཐབ་ཚུགས་པར་ལཱ་"
+"ཁག་འོང་། ཁྱོད་ཀྱིས་ཡིག་ཚད་ དེ་ལས་ཆུང་མི་ཅིག་ སེལ་འཐུ་འབད།"
+
+#: ../capplets/appearance/appearance-font.c:533
+msgid "Use previous font"
+msgstr "ཧེ་མའི་ཡིག་གཟུགས་ ལག་ལེན་འཐབ་"
+
+#: ../capplets/appearance/appearance-font.c:535
+msgid "Use selected font"
+msgstr "སེལ་འཐུ་འབད་ཡོད་པའི་ཡིག་གཟུགས་ལག་ལེན་འཐབ་"
+
+#: ../capplets/appearance/appearance-main.c:108
+msgid "Specify the filename of a theme to install"
+msgstr "གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ བརྗོད་དོན་ཅིག་གི་ ཡིག་སྣོད་མིང་གསལ་བཀོད་འབད་"
+
+#: ../capplets/appearance/appearance-main.c:109
+msgid "filename"
+msgstr "ཡིག་སྣོད་མིང་"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/appearance/appearance-main.c:116
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr ""
+"ཤོག་ལེབ་ཀྱི་མིང་སྟོན་ནི་གི་དོན་ལས་གསལ་བཀོད་འབད (བརྗོད་དོན|རྒྱབ་བརྟེན|ཡིག་གཟུགས་ཚུ|ཨིན་ཊར་ཕེའིསི)"
+
+#: ../capplets/appearance/appearance-main.c:117
+msgid "page"
+msgstr "ཤོག་ལེབ"
+
+#: ../capplets/appearance/appearance-main.c:124
+msgid "[WALLPAPER...]"
+msgstr "[WALLPAPER...]"
+
+#: ../capplets/appearance/appearance-style.c:156
+#: ../capplets/common/gnome-theme-info.c:439
+#: ../capplets/common/gnome-theme-info.c:638
+msgid "Default Pointer"
+msgstr "སྔོན་སྒྲིག་དཔག་བྱེད།"
+
+#: ../capplets/appearance/appearance-themes.c:534
+msgid "Apply Background"
+msgstr "རྒྱབ་གཞི་ འཇུག་སྤྱོད་འབད་ "
+
+#: ../capplets/appearance/appearance-themes.c:538
+msgid "Apply Font"
+msgstr "ཡིག་གཟུགས་ འཇུག་སྤྱོད་འབད་ "
+
+#: ../capplets/appearance/appearance-themes.c:563
+msgid "The current theme suggests a background and a font."
+msgstr "ད་ལྟོའི་བརྗོད་དོན་འདི་གིས་ རྒྱབ་གཞི་དང་ཡིག་གཟུགས་ཅིག་གི་ བསམ་འཆར་་བཀོདཔ་མས།"
+
+#: ../capplets/appearance/appearance-themes.c:568
+msgid "The current theme suggests a background."
+msgstr "ད་ལྟོའི་བརྗོད་དོན་འདི་གིས་ རྒྱབ་གཞི་ཅིག་གི་ བསམ་འཆར་་བཀོདཔ་མས།"
+
+#: ../capplets/appearance/appearance-themes.c:573
+msgid "The current theme suggests a font."
+msgstr "ད་ལྟོའི་ བརྗོད་དོན་འདི་གིས་ ཡིག་གཟུགས་ཅིག་གི་ བསམ་འཆར་བཀོདཔ་མས།"
+
+#: ../capplets/appearance/appearance-themes.c:857
+#: ../capplets/default-applications/gnome-da-capplet.c:1080
+#: ../capplets/sound/sound-properties-capplet.c:327
+msgid "Custom"
+msgstr "སྲོལ་སྒྲིག"
+
+#: ../capplets/appearance/data/appearance.glade.h:1
+msgid "<b>C_olors</b>"
+msgstr "<b>ཚོས་གཞི་</b>(_o)"
+
+#. font hinting
+#: ../capplets/appearance/data/appearance.glade.h:3
+msgid "<b>Hinting</b>"
+msgstr "<b>བརྡ་མཚོན་སྟོན་དོ</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:4
+msgid "<b>Menus and Toolbars</b>"
+msgstr "<b>དཀར་ཆག་དང་ ལག་ཆས་ཕྲ་རིང་ཚུ</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:5
+msgid "<b>Preview</b>"
+msgstr "<b>སྔོན་ལྟ་</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:6
+msgid "<b>Rendering</b>"
+msgstr "<b>ལྷག་སྟོན་འབད་དོ་</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:7
+msgid "<b>Smoothing</b>"
+msgstr "<b>ཧུམ་ཁྱུག་བཟོ་དོ</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:8
+msgid "<b>Subpixel Order</b>"
+msgstr "<b>སབ་པིཀ་སེལ་གོ་རིམ</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:9
+msgid "<b>_Wallpaper</b>"
+msgstr "<b>གྱང་ཤོག(_W)</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:10
+msgid "Appearance Preferences"
+msgstr "བརྗོད་དོན་གྱི་དགའ་གདམ་ཚུ"
+
+#: ../capplets/appearance/data/appearance.glade.h:11
+msgid "Background"
+msgstr "རྒྱབ་གཞི་"
+
+#: ../capplets/appearance/data/appearance.glade.h:12
+msgid "Best _shapes"
+msgstr "བཟོ་དབྱིབས་ལེགས་ཤོས།(_s)"
+
+#: ../capplets/appearance/data/appearance.glade.h:13
+msgid "Best co_ntrast"
+msgstr "ཁྱད་པར་ལེགས་ཤོས།(_n)"
+
+#: ../capplets/appearance/data/appearance.glade.h:14
+msgid "C_ustomize..."
+msgstr "སྲོལ་སྒྲིག་འབད་...(_u)"
+
+#: ../capplets/appearance/data/appearance.glade.h:15
+msgid "C_ut"
+msgstr "བཏོག(_C)"
+
+#: ../capplets/appearance/data/appearance.glade.h:16
+msgid ""
+"Centered\n"
+"Fill screen\n"
+"Scaled\n"
+"Zoom\n"
+"Tiled"
+msgstr ""
+"སྦུག་ལུ་ཡོདཔ\n"
+" གསལ་གཞི་གངམ\n"
+"ཚད་འཇལ་ཡོདཔ\n"
+"རྒྱས་ཟུམ\n"
+"ཊ་ཡིལཊི"
+
+#: ../capplets/appearance/data/appearance.glade.h:21
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr ""
+"ཁྱོད་རའི་ འོག་རྟགས་ཀྱི་བརྗོད་དོན་ སོར་མི་དེ་གིས་ ཁྱོད་ཤུལ་ལས་ ནང་བསྐྱོད་འབདཝ་ད་ ནུས་པ་ཐོབ་འོང་། "
+
+#: ../capplets/appearance/data/appearance.glade.h:22
+msgid "Colors"
+msgstr "ཚོས་གཞི་ཚུ་"
+
+#: ../capplets/appearance/data/appearance.glade.h:23
+msgid "Controls"
+msgstr "ཚད་འཛིན་ཚུ།"
+
+#: ../capplets/appearance/data/appearance.glade.h:24
+msgid "Customize Theme"
+msgstr "སྲོལ་སྒྲིག་ བརྗོད་དོན"
+
+#: ../capplets/appearance/data/appearance.glade.h:25
+msgid "D_etails..."
+msgstr "རྒྱས་བཤད་...(_e)"
+
+#: ../capplets/appearance/data/appearance.glade.h:26
+msgid "Des_ktop font:"
+msgstr "ཌེཀསི་ཊོཔ་ཡིག་གཟུགས་:(_k)"
+
+#: ../capplets/appearance/data/appearance.glade.h:27
+msgid "Edit"
+msgstr "ཞུན་དག་ "
+
+#: ../capplets/appearance/data/appearance.glade.h:28
+msgid "Font Rendering Details"
+msgstr "ཡིག་གཟུགས་ལྷག་སྟོན་གྱི་རྒྱས་བཤད།"
+
+#: ../capplets/appearance/data/appearance.glade.h:29
+msgid "Fonts"
+msgstr "ཡིག་གཟུགས་ཚུ"
+
+#: ../capplets/appearance/data/appearance.glade.h:30
+msgid "Gra_yscale"
+msgstr "གེརེ་སིཀེལ།(_y)"
+
+#: ../capplets/appearance/data/appearance.glade.h:31
+msgid "Icons"
+msgstr "ངོས་དཔར་ཚུ།"
+
+#: ../capplets/appearance/data/appearance.glade.h:32
+msgid "Interface"
+msgstr "ཨིན་ཊར་་ཕེའིསི"
+
+#: ../capplets/appearance/data/appearance.glade.h:33
+msgid "Large"
+msgstr "ཆེ་བ་ "
+
+#: ../capplets/appearance/data/appearance.glade.h:34
+msgid "N_one"
+msgstr "ཅི་མེད།(_o)"
+
+#: ../capplets/appearance/data/appearance.glade.h:35
+msgid "New File"
+msgstr "ཡིག་སྣོད་གསརཔ།"
+
+#: ../capplets/appearance/data/appearance.glade.h:36
+msgid "Open File"
+msgstr "ཡིག་སྣོད་ཁ་ཕྱེ།"
+
+#: ../capplets/appearance/data/appearance.glade.h:37
+msgid "Open a dialog to specify the color"
+msgstr "ཚོས་གཞི་གསལ་བཀོད་ཀྱི་དོན་ལུ་ ཌའི་ལོག་ཅིག་ཁ་ཕྱེ།"
+
+#: ../capplets/appearance/data/appearance.glade.h:38
+msgid "Pointer"
+msgstr "དཔག་བྱེད"
+
+#: ../capplets/appearance/data/appearance.glade.h:39
+msgid "R_esolution:"
+msgstr "ཧུམ་ཆ་:(_e)"
+
+#: ../capplets/appearance/data/appearance.glade.h:40
+msgid "Save File"
+msgstr "ཡིག་སྣོད་སྲུངས།"
+
+#: ../capplets/appearance/data/appearance.glade.h:41
+msgid "Save Theme As..."
+msgstr "བཟུམ་སྦེ་ བརྗོད་དོན་སྲུངབཞག་འབད་..."
+
+#: ../capplets/appearance/data/appearance.glade.h:42
+msgid "Save _As..."
+msgstr "བཟུམ་སྦེ་ བརྗོད་དོན་སྲུངབཞག་འབད་... (_A)"
+
+#: ../capplets/appearance/data/appearance.glade.h:43
+msgid "Save _background image"
+msgstr "རྒྱབ་གཞི་གཟུགས་བརྙན་སྲུངས་ (_B)"
+
+#: ../capplets/appearance/data/appearance.glade.h:44
+msgid "Show _icons in menus"
+msgstr "དཀར་ཆག་ནང་ ངོས་དཔར་ཚུ་སྟོན།(_i)"
+
+#: ../capplets/appearance/data/appearance.glade.h:45
+msgid "Small"
+msgstr "ཆུང་ཀུ"
+
+#: ../capplets/appearance/data/appearance.glade.h:46
+msgid ""
+"Solid color\n"
+"Horizontal gradient\n"
+"Vertical gradient"
+msgstr ""
+"རགས་པའི་མཚོ་གཞི\n"
+"ཐད་སྙོམ་སྟེགས་རེས\n"
+"ཀེར་ཕྲང་སྟེགས་རེས"
+
+#: ../capplets/appearance/data/appearance.glade.h:49
+msgid "Sub_pixel (LCDs)"
+msgstr "ཡན་ལག་པིཀ་སེལ། (ཨེལ་སི་ཌི་ཨེསི)(_p)"
+
+#: ../capplets/appearance/data/appearance.glade.h:50
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "ཡན་ལག་་པིཀ་སེལ་ ཧུམ་ཁྱུག་བཟོ་དོ། (ཨེལ་སི་ཌི་ཨེསི)(_p)"
+
+#: ../capplets/appearance/data/appearance.glade.h:51
+msgid "Text"
+msgstr "བརྟག་ཞིབ་"
+
+#: ../capplets/appearance/data/appearance.glade.h:52
+msgid ""
+"Text below items\n"
+"Text beside items\n"
+"Icons only\n"
+"Text only"
+msgstr ""
+"ཚིག་ཡིག་རྣམ་གྲངས་ཚུ་གི་འོག་ལུ\n"
+"ཚིག་ཡིག་རྣམ་གྲངས་ཚུ་གི་ཟུར་ཁ་ལུ\n"
+"ངོས་དཔར་རྐྱངམ་ཅིག\n"
+"ཚིག་ཡིག་རྐྱངམ་ཅིག"
+
+#: ../capplets/appearance/data/appearance.glade.h:56
+msgid "The current controls theme does not support color schemes."
+msgstr "ད་ལྟོའི་ཚད་འཛིན་བརྗོད་དོན་འདི་གིས་ ཚོས་གཞིའི་འཆར་ལས་ཚུ་རྒྱབ་སྐྱོར་མི་འབད།"
+
+#: ../capplets/appearance/data/appearance.glade.h:57
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "བརྗོད་དོན་ཚུ།"
+
+#: ../capplets/appearance/data/appearance.glade.h:58
+msgid "Toolbar _button labels:"
+msgstr "ལག་ཆས་ཕྲ་རིང་གི་ ཨེབ་རྟའི་ཁ་ཡིག་ཚུ་:\"(_b)"
+
+#. vertical hinting, pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:60
+msgid "VB_GR"
+msgstr "ཝི་བི་ཇི་ཨར།(_G)"
+
+#: ../capplets/appearance/data/appearance.glade.h:61
+msgid "Window Border"
+msgstr "སྒོ་སྒྲིག་གི་མཐའ་མཚམས།"
+
+#: ../capplets/appearance/data/appearance.glade.h:62
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
+msgid "_Add..."
+msgstr "ཁ་སྐོང་རྐྱབས་...(_A)"
+
+#: ../capplets/appearance/data/appearance.glade.h:63
+msgid "_Application font:"
+msgstr "གློག་རིམ་ཡིག་གཟུགས་:(_A)"
+
+#. pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:65
+msgid "_BGR"
+msgstr "བི་ཇི་ཨར།(_B)"
+
+#: ../capplets/appearance/data/appearance.glade.h:66
+msgid "_Copy"
+msgstr "འདྲ་བཤུས།(_C)"
+
+#: ../capplets/appearance/data/appearance.glade.h:67
+msgid "_Description:"
+msgstr "འགྲེལ་བཤད་:(_D)"
+
+#: ../capplets/appearance/data/appearance.glade.h:68
+msgid "_Document font:"
+msgstr "ཡིག་ཆའི་ཡིག་གཟུགས་:(_D)"
+
+#: ../capplets/appearance/data/appearance.glade.h:69
+msgid "_Editable menu shortcut keys"
+msgstr "ཞུན་དག་འབད་བཏུབ་པའི་ དཀར་ཆག་མགྱོགས་འཕྲུལ་གྱི་ལྡེ་མིག་ཚུ(_E)"
+
+#: ../capplets/appearance/data/appearance.glade.h:70
+msgid "_File"
+msgstr "ཡིག་སྣོད།(_F)"
+
+#: ../capplets/appearance/data/appearance.glade.h:71
+msgid "_Fixed width font:"
+msgstr "རྒྱ་ཚད་གཏན་བཟོས་ཡིག་གཟུགས་:(_F)"
+
+#: ../capplets/appearance/data/appearance.glade.h:72
+msgid "_Full"
+msgstr "གང་།(_F)"
+
+#: ../capplets/appearance/data/appearance.glade.h:73
+msgid "_Input boxes:"
+msgstr "ཨིན་པུཊི་སྒྲོམ་ཚུ་:(_I)"
+
+#: ../capplets/appearance/data/appearance.glade.h:74
+msgid "_Install..."
+msgstr "གཞི་བཙུགས་འབད་...(_I)"
+
+#: ../capplets/appearance/data/appearance.glade.h:75
+msgid "_Medium"
+msgstr "འབྲིང་།(_M)"
+
+#: ../capplets/appearance/data/appearance.glade.h:76
+msgid "_Monochrome"
+msgstr "མོ་ནོ་ཀོརོམ།(_M)"
+
+#: ../capplets/appearance/data/appearance.glade.h:77
+msgid "_Name:"
+msgstr "མིང་:(_N)"
+
+#: ../capplets/appearance/data/appearance.glade.h:78
+msgid "_New"
+msgstr "གསརཔ།(_N)"
+
+#: ../capplets/appearance/data/appearance.glade.h:79
+msgid "_None"
+msgstr "ཅི་མེད།(_N)"
+
+#: ../capplets/appearance/data/appearance.glade.h:80
+msgid "_Open"
+msgstr "ཁ་ཕྱེ།(_O)"
+
+#: ../capplets/appearance/data/appearance.glade.h:81
+msgid "_Paste"
+msgstr "སྦྱར།(_P)"
+
+#: ../capplets/appearance/data/appearance.glade.h:82
+msgid "_Print"
+msgstr "དཔར་བསྐྲུན།(_P)"
+
+#: ../capplets/appearance/data/appearance.glade.h:83
+msgid "_Quit"
+msgstr "སྤངས་།(_Q)"
+
+#. pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:85
+msgid "_RGB"
+msgstr "ཨར་ཇི་བི།(_R)"
+
+#: ../capplets/appearance/data/appearance.glade.h:86
+msgid "_Reset to Defaults"
+msgstr "སྔོན་སྒྲིག་ལུ་ བསྐྱར་སྒྲིག་འབད་ (_R)"
+
+#: ../capplets/appearance/data/appearance.glade.h:87
+msgid "_Save"
+msgstr "སྲུངས།(_S)"
+
+#: ../capplets/appearance/data/appearance.glade.h:88
+msgid "_Selected items:"
+msgstr "སེལ་འཐུ་འབད་མི་ རྣམ་གྲངས་ཚུ་:(_S)"
+
+#: ../capplets/appearance/data/appearance.glade.h:89
+msgid "_Size:"
+msgstr "ཚད་: (_S)"
+
+#: ../capplets/appearance/data/appearance.glade.h:90
+msgid "_Slight"
+msgstr "དུམ་གྲ་ཅིག(_S)"
+
+#: ../capplets/appearance/data/appearance.glade.h:91
+msgid "_Style:"
+msgstr "བཟོ་རྣམ་:(_S)"
+
+#: ../capplets/appearance/data/appearance.glade.h:92
+msgid "_Tooltips:"
+msgstr "ལག་ཆས་ཕན་བསླབ: (_T) "
+
+#. vertical hinting, pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:94
+msgid "_VRGB"
+msgstr "ཝི་ཨར་ཇི་བི།(_V)"
+
+#: ../capplets/appearance/data/appearance.glade.h:95
+msgid "_Window title font:"
+msgstr "སྒོ་སྒྲིག་གི་མགོ་མིང་ཡིག་གཟུགས་:(_W)"
+
+#: ../capplets/appearance/data/appearance.glade.h:96
+msgid "_Windows:"
+msgstr "སྒོ་སྒྲིག་ཚུ: (_W)"
+
+#: ../capplets/appearance/data/appearance.glade.h:97
+msgid "dots per inch"
+msgstr "ཨིནཅ་རེ་ལུ་ ཚག་གྲངས།"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr "འབྱུང་སྣང་"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr "ཌེཀསི་ཊོཔ་གི་མཐོང་སྣང་སྲོལ་སྒྲིག་འབད"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr "ཌེཀསི་ཊོཔ་གི་ ཡན་ལག་སོ་སོའི་དོན་ལུ་ བརྗོད་དོན་གྱི་ཐུམ་སྒྲིལ་ཚུ་ གཞི་བཙུགས་འབད་"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr "བརྗོད་དོན་གཞི་བཙུགས་པ་"
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr "ཇི་ནོམ་བརྗོད་དོན་ཐུམ་སྒྲིལ་"
+
+#: ../capplets/appearance/gnome-wp-info.c:45
+msgid "No Wallpaper"
+msgstr "གྱང་ཤོག་མིན་འདུག"
+
+#: ../capplets/appearance/gnome-wp-item.c:207
+msgid "Slide Show"
+msgstr "བཤུད་བརྙན་ "
+
+#. translators: <b>wallpaper name</b>
+#. * mime type, x pixel(s) by y pixel(s)
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:215
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %d %s by %d %s\n"
+"Folder: %s"
+msgstr ""
+"<b>%s</b>\n"
+"%s, %d %s by %d %s\n"
+"སྣོད་འཛིན་: %s"
+
+#: ../capplets/appearance/gnome-wp-item.c:221
+#: ../capplets/appearance/gnome-wp-item.c:223
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "པིག་སེལ།"
+msgstr[1] "པིག་སེལསི།"
+
+#: ../capplets/appearance/theme-installer.c:166
+#: ../capplets/appearance/theme-installer.c:216
+msgid "Cannot install theme"
+msgstr "བརྗོད་དོན་ གཞི་བཙུགས་འབད་མ་ཚུགས་ "
+
+#: ../capplets/appearance/theme-installer.c:168
+#, c-format
+msgid "The %s utility is not installed."
+msgstr "%s སྤྱོད་ཆས་འདི་ གཞི་བཙུགས་མ་འབད་ནུག།"
+
+#: ../capplets/appearance/theme-installer.c:218
+msgid "There was a problem while extracting the theme."
+msgstr "བརྗོད་དོན་འདི་ཕྱིར་འདོན་འབད་བའི་སྐབས་ དཀའ་ངལ་ཅིག་འདུག།"
+
+#: ../capplets/appearance/theme-installer.c:241
+msgid "There was an error installing the selected file"
+msgstr "སེལ་འཐུ་འབད་ཡོད་པའི་ཡིག་སྣོད་ གཞི་བཙུགས་འབད་བའི་སྐབས་ འཛོལ་བ་ཅིག་འབྱུང་ནུག་ "
+
+#: ../capplets/appearance/theme-installer.c:242
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme."
+msgstr "\"%s\" དེ་ ནུས་ཅན་གྱི་བརྗོད་དོན་ཅིག་སྦེ་ མི་འབྱུང་མས། "
+
+#: ../capplets/appearance/theme-installer.c:243
+#, c-format
+msgid ""
+"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
+"you need to compile."
+msgstr ""
+"\"%s\" དེ་ནུས་ཅན་གྱི་བརྗོད་དོན་ཅིག་སྦེ་ མི་འབྱུང་མས། འདི་ཡང་ཅིན་ ཕྱོགས་སྒྲིག་འབད་དགོ་པའི་ བརྗོད་དོན་ "
+"མ་འཕྲུལ་ཅིག་ཨིནམ་འོང་། "
+
+#: ../capplets/appearance/theme-installer.c:282
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "ཇི་ནོམ་བརྗོད་དོན་%s ངེས་བདེན་སྦེ་ གཞི་བཙུགས་འབད་ནུག།"
+
+#: ../capplets/appearance/theme-installer.c:342
+#, c-format
+msgid "Installation for theme \"%s\" failed."
+msgstr "བརྗོད་དོན་ \"%s\" གི་དོན་ལུ་ གཞི་བཙུགས་འཐུས་ཤོར་འབྱུང་ཡོདཔ། "
+
+#: ../capplets/appearance/theme-installer.c:374
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr "བརྗོད་དོན་ \"%s\" འདི་ གཞི་བཙུགས་འབད་ཡོད།"
+
+#: ../capplets/appearance/theme-installer.c:380
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr "ཁྱོད་ཀྱིས་ད་ལྟོ་འཇུག་སྤྱོད་འབད་ཨིན་ན་ ཡང་ན་ཁྱོད་རའི་ད་ལཏོའི་བརྗོད་དོན་བཞག་ནི་ཨིན་ན?"
+
+#: ../capplets/appearance/theme-installer.c:382
+msgid "Keep Current Theme"
+msgstr "ད་ལྟོའི་བརྗོད་དོན་བཞག།"
+
+#: ../capplets/appearance/theme-installer.c:384
+msgid "Apply New Theme"
+msgstr "བརྗོད་དོན་གསརཔ་འཇུག་སྤྱོད་འབད།"
+
+#: ../capplets/appearance/theme-installer.c:486
+msgid "Failed to create temporary directory"
+msgstr "གནས་སྐབས་ཅིག་གི་སྣོད་ཐོ་ གསར་བསྐྲུན་འབད་མ་ཚུགས།"
+
+#: ../capplets/appearance/theme-installer.c:546
+msgid "New themes have been successfully installed."
+msgstr "བརྗོད་དོན་གསརཔ་ཚུ་ མཐར་འཁྱོལ་ཅན་སྦེ་ གཞི་བཙུགས་འབད་ནུག། "
+
+#: ../capplets/appearance/theme-installer.c:573
+msgid "No theme file location specified to install"
+msgstr "གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ ཡིག་སྣོད་ཀྱི་གནས་ཁོངས་ ངོས་འཛིན་མ་འབད་བས།"
+
+#: ../capplets/appearance/theme-installer.c:593
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"བརྗོད་དོན་གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ གནང་བ་ལངམ་མིན་འདུག\n"
+"%s"
+
+#: ../capplets/appearance/theme-installer.c:615
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+"%sའདི་ བརྗོད་དོན་གྱི་ཡིག་སྣོད་ཚུ་ གཞི་བཙུགས་འབད་སའི་འགྲུལ་ལམ་ཨིན། འདི་འབྱུང་ཁུངས་ཀྱི་ གནས་ཁོངས་འབད་ "
+"སེལ་འཐུ་འབད་མི་ཚུགས།"
+
+#: ../capplets/appearance/theme-installer.c:683
+msgid "Select Theme"
+msgstr "བརྗོད་དོན་སེལ་འཐུ་འབད"
+
+#: ../capplets/appearance/theme-installer.c:687
+msgid "Theme Packages"
+msgstr "བརྗོད་དོན་ཐུམ་སྒྲིལ་ཚུ"
+
+#: ../capplets/appearance/theme-save.c:91
+#, c-format
+msgid "Theme name must be present"
+msgstr "བརྗོད་དོན་གྱི་མིང་ ངེས་པར་ཡོད་དགོ"
+
+#: ../capplets/appearance/theme-save.c:161
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "བརྗོད་དོན་དེ་ ཧེ་མ་ལས་རང་འདུག ཁྱོད་ཀྱིས་དེ་གི་ཚབ་མ་ བཙུགས་ནི་ཨིན་ན།"
+
+#: ../capplets/appearance/theme-save.c:162
+msgid "_Overwrite"
+msgstr "ཚབ་སྲུང་ (_O)"
+
+#: ../capplets/appearance/theme-util.c:69
+msgid "Would you like to delete this theme?"
+msgstr "ཁྱོད་ཀྱིས་ བརྗོད་དོན་འདི་ རྩ་བསྐྲད་གཏང་ནི་ཨིན་ན?"
+
+#: ../capplets/appearance/theme-util.c:121
+msgid "Theme cannot be deleted"
+msgstr "བརྗོད་དོན་བཏོན་གཏང་མི་ཚུགས་པས"
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་ ‘ཇི་ནོམ་-གཞི་སྒྲིག་-ཌེ་མཱོན་’ འགོ་བཙུགས་མི་ཚུགས་པས། \n"
+"ཇི་ནོམ་གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་ ལཱ་གཡོག་བཀོལ་ཏེ་མེད་པ་ཅིན་ དགའ་གདམ་ལ་ལོ་ཅིག་ལུ་ ནུས་པ་འཐོབ་མི་ཚུགས། "
+"འདི་གིས་བོ་ནོ་བོ་ལུ་ དཀའ་ངལ་ཅིག་ འབྱུང་སྲིད་ནི་ཨིན་མི་དེ་ཡང་ ཇི་ནོམ་མེན་པའི་ གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་"
+"(དཔེར་ན་ ཀེ་ཌི་ཨི) ལྟ་བུ་ ཤུགས་ལྡན་ཨིན་པའི་ཐོག་ལས་ ཇི་ནོམ་གཞི་སྒྲིག་འཛིན་སྐྱོང་པ་དང་ མི་མཐུནམ་འབྱུང་དོ་"
+"ཡོདཔ་འོང་།"
+
+#: ../capplets/common/capplet-stock-icons.c:67
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "ཅ་མཛོད་ཀྱི་ངོས་དཔར་'%s'མངོན་གསལ་འབད་མ་ཚུགས། \n"
+
+#: ../capplets/common/capplet-util.c:240 ../capplets/common/capplet-util.c:242
+msgid "Just apply settings and quit"
+msgstr "གཞི་སྒྲིག་ཚུ་ འཇུག་སྤྱོད་ཙམ་འབད་དེ་སྤངས་།"
+
+#: ../capplets/common/capplet-util.c:244
+#: ../capplets/keyboard/gnome-keyboard-properties.c:261
+#: ../capplets/sound/sound-properties-capplet.c:1030
+msgid "Retrieve and store legacy settings"
+msgstr "སྔོན་བཤུལ་གྱི་གཞི་སྒྲིག་ཚུ་ སླར་འདྲེན་འབད་དེ་ གསོག་འཇོག་འབད།"
+
+#: ../capplets/common/capplet-util.c:344
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "གྲོགས་རམ་%sབཀྲམ་སྟོན་འབད་ནི་ལུ་ འཛོལ་བ་ཅིག་བྱུང་ནུག"
+
+#: ../capplets/common/file-transfer-dialog.c:84
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "ཡིག་སྣོད་%u ལས་%uའདྲ་བཤུས་རྐྱབ་དོ།"
+
+#: ../capplets/common/file-transfer-dialog.c:132
+#, c-format
+msgid "Copying '%s'"
+msgstr "'%s' འདྲ་བཤུས་རྐྱབ་དོ།"
+
+#: ../capplets/common/file-transfer-dialog.c:172
+#: ../capplets/common/file-transfer-dialog.c:298
+msgid "Copying files"
+msgstr "ཡིག་སྣོད་འདྲ་བཤུས་རྐྱབ་དོ།"
+
+#: ../capplets/common/file-transfer-dialog.c:207
+msgid "Parent Window"
+msgstr "རྩ་ལག་སྒོ་སྒྲིག་"
+
+#: ../capplets/common/file-transfer-dialog.c:208
+msgid "Parent window of the dialog"
+msgstr "ཌའི་ལོག་འདི་གི་ རྩ་ལག་སྒོ་སྒྲིག་"
+
+#: ../capplets/common/file-transfer-dialog.c:214
+msgid "From URI"
+msgstr "ཡུ་ཨར་ཨའི་ལས།"
+
+#: ../capplets/common/file-transfer-dialog.c:215
+msgid "URI currently transferring from"
+msgstr "ཡུ་ཨར་ཨའི་ ད་ལྟོ་ག་ཏེ་ལས་ གནས་སོར་གཏང་དོ།"
+
+#: ../capplets/common/file-transfer-dialog.c:222
+msgid "To URI"
+msgstr "ཡུ་ཨར་ཨའི་ལུ།"
+
+#: ../capplets/common/file-transfer-dialog.c:223
+msgid "URI currently transferring to"
+msgstr "ཡུ་ཨར་ཨའི་ ད་ལྟོ་གནས་སོར་གཏང་ཡུལ།"
+
+#: ../capplets/common/file-transfer-dialog.c:230
+msgid "Fraction completed"
+msgstr "ཆ་ཤས་ཡོངས་སྒྲུབ།"
+
+#: ../capplets/common/file-transfer-dialog.c:231
+msgid "Fraction of transfer currently completed"
+msgstr "གནས་སོར་གྱི་ཆ་ཤས་ ད་ལྟོ་ཡོངས་སྒྲུབ་འབད་ཡི།"
+
+#: ../capplets/common/file-transfer-dialog.c:238
+msgid "Current URI index"
+msgstr "ད་ལྟོའི་ཡུ་ཨར་ཨའི་གི་ཟུར་ཐོ།"
+
+#: ../capplets/common/file-transfer-dialog.c:239
+msgid "Current URI index - starts from 1"
+msgstr "ད་ལྟོའི་ཡུ་ཨར་ཨའི་གི་ཟུར་ཐོ་ - ༡ ལས་འགོ་བཙུགསཔ་ཨིན།"
+
+#: ../capplets/common/file-transfer-dialog.c:246
+msgid "Total URIs"
+msgstr "ཡུ་ཨར་ཨའི་བསྡོམས།"
+
+#: ../capplets/common/file-transfer-dialog.c:247
+msgid "Total number of URIs"
+msgstr "ཡུ་ཨར་ཨའི་གི་གྱངས་ཁ་ཡོངས་བསྡོམས།"
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "ལྡེ་མིག"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr "རྒྱུ་དངོས་ཀྱི་ཞུན་དགཔ་ མཉམ་སྦྲགས་ཡོད་པའི་ ཇི་ཀཱོནཕ་གི་ལྡེ་མིག"
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr "ཀཱལ་བེཀ།"
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "ལྡེ་མིག་དང་མཉམ་འབྲེལ་ཡོད་པའི་བེ་ལུ་དེ་ བསྒྱུར་བཅོས་འགྱོ་བའི་སྐབས་ ཀཱལ་བེཀ་འདི་སྤྲོད།"
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr "་ཆ་ཚན་བསྒྱུར་བཅོས་འབད"
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"ཇི་ཀཱོནཕ་གི་ ཡོངས་འབྲེལ་ཡན་ལག་ འཇུག་སྤྱོད་ལུ་གཏང་ནིའི་ གནད་སྡུད་ཡོད་པའི་ ཇི་ཀཱོནཕ་གི་བསྒྱུར་བཅོས་ཆ་ཚན།"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr "ཝི་གེཊི་ ཀཱལ་བེཀ་ལུ་ གཞི་བསྒྱུར།"
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "གནད་སྡུད་ཚུ་ ཇི་ཀཱོནཕ་ལས་ ཝི་གེཊི་ལུ་ གཞི་བསྒྱུར་འབད་དགོ་པའི་སྐབས་ སྤྲོད་ནིའི་ཀཱལ་བེཀ།"
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr "ཝི་གེཊི་ཀཱལ་བེཀ་ལས་གཞི་བསྒྱུར།"
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"གནད་སྡུད་ཚུ་ ཝི་གེཊི་ནང་ལས་ ཇི་ཀཱོནཕ་ནང་ལུ་ གཞི་བསྒྱུར་འབད་དགོ་པའི་སྐབས་ སྤྲོད་དགོ་པའི་ཀཱལ་བེཀ།"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr "ཡུ་ཨའི་ཚད་འཛིན།"
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr "རྒྱུ་དངོས་ཚད་འཛིན་འབད་མི་དངོས་པོ། (སྤྱིར་བཏང་ལུ་ཝི་གེཊི་ཅིག)"
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr "རྒྱུ་དངོས་ཞུན་དག་པའི་ དངོས་པོའི་གནད་སྡུད།"
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr "དམིགས་བསལ་གྱི་ རྒྱུ་དངོས་ཞུན་དགཔ་ལུ་དགོ་མི་ སྲོལ་སྒྲིག་གི་གནད་སྡུད།།"
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr "རྒྱུ་དངོས་ཞུན་དག་པའི་གནད་སྡུད་ཀྱིས་ ཀཱལ་བེཀ་ཐར་གཏང་པའི་བསྒང་།"
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr "རྒྱུ་དངོས་ཞུན་དག་པའི་ དངོས་པོའི་གནད་སྡུད་ ཐར་དགོ་པའི་སྐབས་ སྤྲོད་ནིའི་ཀཱལ་བེཀ།"
+
+#: ../capplets/common/gconf-property-editor.c:1467
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"ཡིག་སྣོད་'%s'འཚོལ་མ་ཐོབ།\n"
+"\n"
+"ཚར་ཅིག་ཕྱིར་བཏོན་འབད་ཞིནམས་ལས་ ལོག་སྟེ་འབད་རྩོལ་བསྐྱེད་གནང་། ཡང་ཅིན་ རྒྱབ་གཞིའི་པར་ གཞན་མི་ཅིག་ "
+"གདམ་ཁ་རྐྱབས།"
+
+#: ../capplets/common/gconf-property-editor.c:1475
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"ང་གིས་ཡིག་སྣོད་'%s' ཁ་ཕྱེ་མ་ཤེས།\n"
+"རྒྱབ་སྐྱོར་མེད་པའི་པར་ཅིག་ འོང་ནི་འདྲ་བས།\n"
+"\n"
+"དེ་གི་ཚབ་ལུ་ པར་གཞན་མི་ཅིག་སེལ།"
+
+#: ../capplets/common/gconf-property-editor.c:1594
+msgid "Please select an image."
+msgstr "གཟུགས་བརྙན་ཅིག་སེལ་འཐུ་འབད།"
+
+#: ../capplets/common/gconf-property-editor.c:1599
+msgid "_Select"
+msgstr "སེལ་འཐུ་འབད།(_S)"
+
+#: ../capplets/common/gnome-theme-info.c:639
+msgid "Default Pointer - Current"
+msgstr "སྔོན་སྒྲིག་དཔག་བྱེད་-ད་ལྟོའི་།"
+
+#: ../capplets/common/gnome-theme-info.c:643
+msgid "White Pointer"
+msgstr "དཔག་བྱེད་དཀརཔོ།"
+
+#: ../capplets/common/gnome-theme-info.c:644
+msgid "White Pointer - Current"
+msgstr "དཔག་བྱེད་དཀརཔོ་-ད་ལྟོའི་།"
+
+#: ../capplets/common/gnome-theme-info.c:648
+msgid "Large Pointer"
+msgstr "དཔག་བྱེད་ཆེ་བ།"
+
+#: ../capplets/common/gnome-theme-info.c:649
+msgid "Large Pointer - Current"
+msgstr "དཔག་བྱེད་ཆེ་བ་-ད་ལྟོའི།"
+
+#: ../capplets/common/gnome-theme-info.c:653
+msgid "Large White Pointer - Current"
+msgstr "དཔག་བྱེད་དཀརཔོ་ཆེ་བ་-ད་ལྟོའི།"
+
+#: ../capplets/common/gnome-theme-info.c:654
+msgid "Large White Pointer"
+msgstr "དཔག་བྱེད་དཀརཔོ་ཆེ་བ།"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Preferred Applications"
+msgstr "དགའ་གདམ་ཅན་གྱི་གློག་རིམ།"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "ཁྱོད་རའི་སྔོན་སྒྲིག་གློག་རིམ་ སེལ་འཐུ་འབད།"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Start the preferred visual assistive technology"
+msgstr "དགའ་གདམ་བརྐྱབས་ཡོད་པའི་ མཐོང་བའི་ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་གཡོག་བཀོལ་ "
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr "མཐོང་བའི་ ཕན་ཐབས་ "
+
+#: ../capplets/default-applications/gnome-da-capplet.c:80
+#: ../capplets/default-applications/gnome-da-capplet.c:112
+#: ../capplets/default-applications/gnome-da-capplet.c:133
+#: ../capplets/default-applications/gnome-da-capplet.c:177
+#: ../capplets/default-applications/gnome-da-capplet.c:222
+#: ../capplets/default-applications/gnome-da-capplet.c:279
+#: ../capplets/default-applications/gnome-da-capplet.c:330
+#: ../capplets/default-applications/gnome-da-capplet.c:381
+#: ../capplets/default-applications/gnome-da-capplet.c:434
+#: ../capplets/default-applications/gnome-da-capplet.c:484
+#: ../capplets/default-applications/gnome-da-capplet.c:877
+#: ../capplets/default-applications/gnome-da-capplet.c:899
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "རིམ་སྒྲིག་%sབསྲུང་ནི་ལུ་འཛོལ་བ། "
+
+#: ../capplets/default-applications/gnome-da-capplet.c:1100
+msgid "Could not load the main interface"
+msgstr "ངོས་འདྲ་བ་ངོ་མ་ མངོན་གསལ་འབད་མ་ཚུགས།"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:1102
+msgid "Please make sure that the applet is properly installed"
+msgstr "ཨེཔ་ལེཊི་དེ་ ངེས་བདེན་སྦེ་ གཞི་བཙུགས་འབད་ཡོདཔ་ ངེས་གཏན་བཟོ།"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Image Viewer</b>"
+msgstr "<b>གཟུགས་བརྙན་མཐོང་བྱེད་</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Instant Messenger</b>"
+msgstr "<b>འཕྲལ་མྱུར་འཕྲིན་སྐྱེལ་པ།</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Mail Reader</b>"
+msgstr "<b>ཡིག་འཕྲིན་ལྷག་མི་</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mobility</b>"
+msgstr "<b> ལས་གཡོག </b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Multimedia Player</b>"
+msgstr "<b>སྣ་མང་བརྡ་ལམ་གྱི་གཏང་འཕྲུལ་</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>ཊར་མི་ནཱལ་ ནུས་འཕྲུལ་</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Text Editor</b>"
+msgstr "<b>ཚིག་ཡིག་ཞུན་དགཔ་</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Video Player</b>"
+msgstr "<b>ཝི་ཌིའོ་གཏང་འཕྲུལ་</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "<b>Visual</b>"
+msgstr "<i>མཐོང་བའི</i>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "<b>Web Browser</b>"
+msgstr "<b>ཝེབ་ བརའུ་ཟར།</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
+msgid "Accessibility"
+msgstr "འཛུལ་སྤྱོད"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "འབྱུང་བ་%sཆ་མཉམ་གྱི་ཚབ་ལུ་ འབྲེལ་ལམ་ངོ་མ་བཙུགས་ནི་ཨིན།"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "C_ommand:"
+msgstr "བརྡ་བཀོད་:(_O)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Co_mmand:"
+msgstr "བརྡ་བཀོད་:(_m)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "E_xecute flag:"
+msgstr "ཟུར་རྟགས་ལག་ལེན་འཐབ་:(_x)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Internet"
+msgstr "ཨིན་ཊར་ནེཊི།"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Multimedia"
+msgstr "སྣ་མང་བརྡ་ལམ།"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Open link in new _tab"
+msgstr "འབྲེལ་ལམ་མཆོང་ལྡེ་གསར་པའི་ནང་ཁ་ཕྱེ།(_t)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "Open link in new _window"
+msgstr "འབྲེལ་ལམ་སྒོ་སྒྲིག་གསར་པའི་ནང་ཁ་ཕྱེ།(_w)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid "Open link with web browser _default"
+msgstr "འབྲེལ་ལམ་ཝེབ་བརའུ་ཟར་སྔོན་སྒྲིག་ཐོག་ལསཁ་ཕྱེ།"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Run at st_art"
+msgstr "འགོ་བཙུགས་སར་གཡོག་བཀོལ(_a)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Run in t_erminal"
+msgstr "ཊར་མི་ནཱལ་ཅིག་ནང་གཡོག་བཀོལ།(_e)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "System"
+msgstr "རིམ་ལུགས།"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "_Run at start"
+msgstr "འགོ་བཙུགས་སར་གཡོག་བཀོལ  (_R)"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "བཱལ་ས།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr "བཱན་ཤི་སྙན་ཆ་གཏང་་འཕྲུལ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr "ཀལོསི་ ཡིག་འཕྲིན་"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr "ཌེ་ཤར"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr "ཌེ་བི་ཡཱན་ ཚོར་ཅན་གྱི་ བརའུ་ཟར།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr "ཌེ་བི་ཡཱན་ ཊར་མི་ནཱལ་ ནུས་འཕྲུལ།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr "ཨི་ཊམ།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr "བརྒལ་བ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr "ཨི་པི་ཕ་ནི་ ཝེབ་བརའུ་ཟར།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr "ཕའེར་བཌི།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Firefox"
+msgstr "ཕའེར་ཕོགསི།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr "ཇི་ནོམ་ཆེ་ཤེལ་གསལ་གཞི་ལྷག་མི་མེད་པ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr "གསལ་གཞི་ལྡེ་སྒྲོམ་གུ་ཇི་ནོམ།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr "ཇི་ནོམ་ ཊར་མི་ནཱལ།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Galeon"
+msgstr "གེ་ལིའོན།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Gnopernicus"
+msgstr "ཇི་ནོ་པར་་ནི་ཀཱསི"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Gnopernicus with Magnifier"
+msgstr "ཇི་ནོ་པར་་ནི་ཀཱསི་ཆེ་ཤེལ་དང་བཅས"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Iceape"
+msgstr "ཨའིསི་ཨེཔ་ "
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Iceape Mail"
+msgstr "ཨའིསི་ཨེཔ་ ཡིག་འཕྲིན"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Icedove"
+msgstr "ཨའིསི་ཌོབ་"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Iceweasel"
+msgstr "ཨའིསི་ཝི་སེལ་"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr "ཀེ་ཌི་ཨི་ཆེ་ཤེལ་གསལ་གཞི་ལྷག་མི་མེད་པ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr "ཀེ་མེལ།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr "ཀོང་ཀུ་རར།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Konsole"
+msgstr "ཀཱན་སཱོལ་ "
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr "ལའི་ནགསི་གསལ་གཞི་ལྷག་མི"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr "ལའི་ནགསི་གསལ་གཞི་ལྷག་མི་ཆེ་ཤེལ་དང་བཅས"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Midori"
+msgstr "མི་ཌོ་རི་ "
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Mozilla"
+msgstr "མོ་ཛི་ལ།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Mozilla 1.6"
+msgstr "མོ་ཛི་ལ་༡.༦།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Mozilla Mail"
+msgstr "མོ་ཛི་ལ་ ཡིག་འཕྲིན།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Mozilla Thunderbird"
+msgstr "མོ་ཛི་ལ་ ཐཱན་ཌར་བཌི།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Muine Music Player"
+msgstr "མུའིནི་སྙན་ཆ་གཏང་འཕྲུལ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Mutt"
+msgstr "མཱཊི།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "NXterm"
+msgstr "ཨེན་ཨེགསི་ཊམ།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+msgid "Netscape Communicator"
+msgstr "ནེཊི་སིཀེཔ་ བརྡ་སྤྲོད་པ།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Opera"
+msgstr "ཨོ་པི་ར།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Orca"
+msgstr "ཨོར་ཀ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca with Magnifier"
+msgstr "ཆེ་ཤེལ་ཨོར་ཀ་དག་བཅསཔ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "RXVT"
+msgstr "ཨར་ཨེགསི་ཝི་ཊི།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+msgid "Rhythmbox Music Player"
+msgstr "སྒྲ་དབྱངས་སྒྲོམ་གྱི་སྙན་ཆ་གཏང་འཕྲུལ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+msgid "SeaMonkey"
+msgstr "སི་མོན་ཀི"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+msgid "SeaMonkey Mail"
+msgstr "སི་མོན་ཀི་གི་ཡིག་འཕྲིན"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+msgid "Standard XTerminal"
+msgstr "ཚད་ལྡན་གྱི་ ཨེགསི་ཊར་མི་ནཱལ།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Sylpheed"
+msgstr "སིལ་ཕིཊི།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+msgid "Sylpheed-Claws"
+msgstr "སིལ་ཕིཊི་-ཀྭ་ལཱསི།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+msgid "Terminator"
+msgstr "རྩ་གྲོལ་གཏང་མི་ "
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Thunderbird"
+msgstr "ཐཱན་ཌར་བཌི།"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Totem Movie Player"
+msgstr "ཊོ་ཊེམ་གློག་བརྙེན་གཏང་འཕྲུལ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "aterm"
+msgstr "ཨེ་ཊམ།"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "གསལ་གཞིའི་ཧུམ་ཆ་ བསྒྱུར་བཅོས་འབད།"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "གསལ་གཞིའི་ཧུམ་ཆ།"
+
+#: ../capplets/display/main.c:29
+msgid "Normal"
+msgstr "སྤྱིར་བཏང་"
+
+#: ../capplets/display/main.c:30
+msgid "Left"
+msgstr "གཡོན"
+
+#: ../capplets/display/main.c:31
+msgid "Inverted"
+msgstr "གནས་ལོག་འབད་ཡོདཔ"
+
+#: ../capplets/display/main.c:32
+msgid "Right"
+msgstr "གཡས"
+
+#: ../capplets/display/main.c:374
+#, c-format
+msgid "%d Hz"
+msgstr "ཨེཆ་ཛེཌི %d "
+
+#: ../capplets/display/main.c:514
+msgid "_Resolution:"
+msgstr "ཧུམ་ཆ་:(_R)"
+
+#: ../capplets/display/main.c:532
+msgid "Re_fresh rate:"
+msgstr "ཡང་སེལ་གྱི་མགྱོགས་ཚད་:(_f)"
+
+#: ../capplets/display/main.c:550
+msgid "R_otation:"
+msgstr "སྐོར་རྐྱབ་:(_o)"
+
+#: ../capplets/display/main.c:569
+msgid "Default Settings"
+msgstr "སྔོན་སྒྲིག་གཞི་སྒྲིག་ཚུ།"
+
+#: ../capplets/display/main.c:571
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr "གསལ་གཞི་%dགི་ གཞི་སྒྲིག་ཚུ།\n"
+
+#: ../capplets/display/main.c:593
+msgid "Screen Resolution Preferences"
+msgstr "གསལ་གཞི་ཧུམ་ཆའི་དགའ་གདམ་ཚུ།"
+
+#: ../capplets/display/main.c:628
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "གློག་རིག་(%s)འདི་གི་དོན་ལུ་རྐྱངམ་གཅིག་ སྔོན་སྒྲིག་འབད།(_M)"
+
+#: ../capplets/display/main.c:648
+msgid "Options"
+msgstr "གདམ་ཁ་ཚུ།"
+
+#: ../capplets/display/main.c:668
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"གཞི་སྒྲིག་གསརཔ་ཚུ་ལུ་ བརྟག་ཞིབ་འབད་དོ། ཁྱོད་ཀྱིས་སྐར་ཆ་%dགི་ནང་འཁོད་ ངོས་ལན་མ་བྱིན་པ་ཅིན་ ཧེ་མའི་"
+"གཞི་སྒྲིག་ཚུ་ སོར་ཆུད་འབད་འོང་།"
+msgstr[1] ""
+"གཞི་སྒྲིག་གསརཔ་ཚུ་ལུ་ བརྟག་ཞིབ་འབད་དོ། ཁྱོད་ཀྱིས་སྐར་ཆ་%dགི་ནང་འཁོད་ ངོས་ལན་མ་བྱིན་པ་ཅིན་ ཧེ་མའི་"
+"གཞི་སྒྲིག་ཚུ་ སོར་ཆུད་འབད་འོང་།"
+
+#: ../capplets/display/main.c:708
+msgid "Keep Resolution"
+msgstr "ཧུམ་ཆ་བདག་འཛིན་འབད་བཞག"
+
+#: ../capplets/display/main.c:712
+msgid "Do you want to keep this resolution?"
+msgstr "ཁྱོད་ཀྱིས་ཧུམ་ཆ་འདི་ བདག་འཛིན་འབད་བཞག་ནི་ཨིན་ན?"
+
+#: ../capplets/display/main.c:738
+msgid "Use _Previous Resolution"
+msgstr "ཧེ་མའི་ཧུམ་ཆ་ ལག་ལེན་འཐབ་ (_p)"
+
+#: ../capplets/display/main.c:739
+msgid "_Keep Resolution"
+msgstr "ཧུམ་ཆ་ བདག་འཛིན་འབད་བཞག་(_k)"
+
+#: ../capplets/display/main.c:888
+msgid ""
+"The X server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"ཨེགསི་སར་བར་དེ་གིས་ XRandR རྒྱ་བསྐྱེད་ལུ་ རྒྱབ་སྐྱོར་མི་འབད་བས།  གཡོག་བཀོལ་དུས་ཚོད་ཀྱི་ ཧུམ་ཆའི་བསྒྱུར་"
+"བཅོས་ཚུ་ བཀྲམ་སྟོན་འབད་ནིའི་ཚད་གུ་ མི་འཐོབ་པས།"
+
+#: ../capplets/display/main.c:895
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"XRandR རྒྱ་བསྐྱེད་ཀྱི་ཐོན་རིམ་དེ་ ལས་རིམ་འདི་དང་མཐུན་འགྱུར་མིན་འདུག གཡོག་བཀོལ་དུས་ཚོད་ཀྱི་ བསྒྱུར་བཅོས་"
+"ཚུ་ བཀྲམ་སྟོན་འབད་ནིའི་ཚད་གུ་ མི་འཐོབ་པས།"
+
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "སྒྲ་སྐད།"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+msgid "Desktop"
+msgstr "ཌེཀསི་ཊོཔ།"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "མགྱོགས་འཕྲུལ་གསརཔ་..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "མགྱོགས་འཕྲུལ་ལྡེ་མིག"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "མགྱོགས་འཕྲུལ་ལེགས་བཅོས་པ།"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "མགྱོགས་འཕྲུལ་ལྡེ་ཨང་།"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "མགྱོགས་འཕྲུལ་གྱི་ཐབས་ལམ།"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "མགྱོགས་འཕྲུལ་གྱི་དབྱེ་བ།"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:106
+#: ../typing-break/drwright.c:483
+msgid "Disabled"
+msgstr "ལྕོགས་མིན།"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:517
+msgid "<Unknown Action>"
+msgstr "<མ་ཤེས་པའི་བྱ་བ་>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:909
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time.\n"
+msgstr ""
+"མགྱོགས་ཐབས་\"%s\"དེ་ ལག་ལེན་འཐབ་མི་བཏུབ། ག་ཅི་སྦེ་ཟེར་བ་ཅིན་ ལྡེ་མིག་འདི་ལག་ལེན་འཐབ་དང་ ཡིག་"
+"དཔར་བརྐྱབ་མི་འགྱུརཝ་ཨིན།\n"
+"ཚད་འཛིན་ གདམ་ལྡེ་ཡང་ན་ སོར་ལྡེ་ཚུ་ དུས་མཉམ་ལུ་ཨེབ་སྟེ་ འབད་རྩོལ་བསྐྱེད་གནང་།\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:938
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+"མགྱོགས་ཐབས་\"%s\" དེ་ ཧེ་མ་ལས་རང་ ལག་ལེན་འཐབ་ནུག\n"
+" \"%s\"\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:970
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr "རིམ་སྒྲིག་གནད་སྡུད་གཞི་རྟེན་ %sནང་ མགྱོགས་འཕྲུལ་གསརཔ་ གཞི་སྒྲིག་འབད་ནི་ལུ་འཛོལ་བ།\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1022
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr "རིམ་སྒྲིག་གནད་སྡུད་གཞི་རྟེན་ %sནང་ མགྱོགས་འཕྲུལ་གསརཔ་ སྒྲིག་བཤོལ་འབད་ནི་ལུ་འཛོལ་བ། \n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1153
+msgid "Action"
+msgstr "བྱ་བ།"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1177
+msgid "Shortcut"
+msgstr "མགྱོགས་ཐབས།"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "ལྡེ་སྒྲོམ་གྱི་མགྱོགས་ཐབས།"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"མགྱོགས་ཐབས་ཅིག་ ཞུན་དག་བརྐྱབ་ནི་ལུ་ ཆ་མཚུངས་པའི་གྲལ་ཐིག་ལུ་ ཨེབ་གཏང་འབད་ཞིནམས་ལས་ མགྱོགས་འཕྲུལ་"
+"གསརཔ་ཅིག་ ཡིག་དཔར་རྐྱབས། ཡང་ན་ བསལ་་ནིའི་དོན་ལུ་ རྒྱབ་བཤུད་ལུ་ཨེབ།"
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "བརྡ་བཀོད་ཚུ་ལུ་ མགྱོགས་ཐབས་ལྡེ་མིག་ འགན་སྤྲོད་འབད།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:253
+#: ../capplets/keyboard/gnome-keyboard-properties.c:258
+#: ../capplets/sound/sound-properties-capplet.c:1026
+#: ../capplets/sound/sound-properties-capplet.c:1028
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+"གཞི་སྒྲིག་ཙམ་འཇུག་སྤྱོད་འབད་དེ་སྤངས། (མཐུན་འགྱུར་རྐྱངམ་གཅིག་ ད་ལྟོ་ཌེ་མཱོན་གྱིས་ ལེགས་སྐྱོང་འཐབ་ནུག)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:265
+msgid "Start the page with the typing break settings showing"
+msgstr "ཤོག་ལེབ་དེ་ ཡིག་དཔར་བརྐྱབ་ནིའི་བར་མཚམས་གཞི་སྒྲིག་ཚུ་ སྟོནམ་དང་བཅསཔ་སྦེ་ འགོ་བཙུགས།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:270
+msgid "Start the page with the accessibility settings showing"
+msgstr "ཤོག་ལེབ་དེ་ འཛུལ་སྤྱོད་གཞི་སྒྲིག་ཚུ་ སྟོནམ་ཐོག་ལས་ འགོ་བཙུགས།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:279
+msgid "- GNOME Keyboard Preferences"
+msgstr "- ཇི་ནོམ་ལྡེ་སྒྲོམ་གྱི་དགའ་གདམ་ཚུ་"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+msgid "<b>Bounce Keys</b>"
+msgstr "<b>ལྡེ་མིག་ཚུ་ ཡར་འཕར་བཟོ་</b>(_u)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>འོད་རྟགས་འགུལ་སྤར་འབད་དོ་</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "<b>General</b>"
+msgstr "<b>ཡོངས་ཁྱབ་</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>ལྡེ་མིག་ཚུ་ཡང་བསྐྱར་འབད་</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Slow Keys</b>"
+msgstr "<b>Slow Keys</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>Sticky Keys</b>"
+msgstr "<b>སྦྱར་རྩི་ལྡེ་མིག་ཚུ་ </b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<b>ཡིག་དཔར་གྱི་བར་མཚམས་ ལག་ལེན་འཐབ་ནིའི་དོན་ལུ་ གསལ་གཞི་ལྡེ་མིག་རྐྱབས་</b>(_L)"
+
+#. fast acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>མགྱོགས་པར</i></small>"
+
+#. long delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>རིངམོ་</i></small>"
+
+#. short delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>ཐུང་ཀུ་</i></small>"
+
+#. slow acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>ལྷོད་ཆ་</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "A_cceleration:"
+msgstr "མགྱོགས་སྤྱོད་: (_A)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "All_ow postponing of breaks"
+msgstr "བར་མཚམས་ཚུ་ བསྣར་བཞག་འབད་བཅུག(_o)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Beep when _accessibility features are turned on or off"
+msgstr "ཁྱད་རྣམ་དེ་ཚུ་  ཨཱོན་དང་ཨོཕ་འགྱོ་བའི་སྐབས་ བརྡ་སྐད་རྐྱབས།( _F)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Beep when a _modifier key is pressed"
+msgstr "ལེགས་བཅོས་འབད་མི་ལྡེ་མིག་ཅིག་ཨེབ་པའི་སྐབས་ བརྡ་སྐད་རྐྱབས་  (_M)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Beep when a _toggle key is pressed"
+msgstr "སོར་སྟོན་ལྡེ་མིག་ཅིག་ གཡེབ་པའི་སྐབས་ བརྡ་སྐད་སྟོན་(_M)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Beep when a key is pr_essed"
+msgstr "ལྡེ་མིག་ ཨེབ་པའི་སྐབས་ བརྡ་སྐད་རྐྱབས་(_E)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Beep when a key is reje_cted"
+msgstr "ལྡེ་མིག་ལུ་ ངོས་ལེན་མེད་པ་ཅིན་ བརྡ་སྐད་རྐྱབས་(_C)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Beep when key is _accepted"
+msgstr "ལྡེ་མིག་ཨིན་པའི་སྐབས་ བརྡ་སྐད་རྐྱབས་ (_A)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Beep when key is _rejected"
+msgstr "ལྡེ་མིག་ལུ་ ངོས་ལེན་མེད་པ་ཅིན་ བརྡ་སྐད་རྐྱབས་  (_R)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Check if breaks are allowed to be postponed"
+msgstr "བར་མཚམས་ཚུ་ བསྣར་བཞག་འབད་ཆོག་ག་མི་ཆོག་ ཞིབ་དཔྱད་འབད།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Choose a Keyboard Model"
+msgstr "ལྡེ་སྒྲོམ་གྱི་དཔེ་ཅིག་ གདམ་ཁ་རྐྱབས།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Choose a Layout"
+msgstr "སྒྲིག་བཀོད་ཅིག་ གདམ་ཁ་རྐྱབས།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Cursor _blinks in text fields"
+msgstr "འོད་རྟགས་དེ་ ཚིག་ཡིག་ས་སྒོ་ཚུ་ནང་ འགུལ་སྤར་འབདཝ་ཨིན  (_B)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
+msgid "Cursor blinks speed"
+msgstr "འོད་རྟགས་འགུལ་སྤར་གྱི་ཚད།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
+msgid "D_elay:"
+msgstr "ཕྱིར་འགྱངས་:(_E)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr "ལྡེ་མིག་གཉིས་གཅིག་ཁར་ཨེབ་པ་ཅིན་ སྦྱར་རྩིས་ལྡེ་མིག་ཚུ་ ལྕོགས་མིན་བཟོཝ་ཨིན་ (_B)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "Duration of the break when typing is disallowed"
+msgstr "ཡིག་དཔར་བརྐྱབ་མ་ཆོག་པའི་སྐབས་ལུ་ བར་མཚམས་ཀྱི་དུས་ཡུན།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Duration of work before forcing a break"
+msgstr "བང་བཙོངས་ཏེ་ བར་མཚམས་ཅིག་  མ་བཞག་པའི་ཧེ་མར་ ལཱ་གཡོག་གི་དུས་ཡུན།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
+msgid "General"
+msgstr "ཡོངས་ཁྱབ་ "
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Key presses _repeat when key is held down"
+msgstr "ལྡེ་མིག་མར་འཆང་སྟེ་ཡོད་པའི་སྐབས་ ལྡེ་མིག་གིས་ ཡང་བསྐྱར་ཨེབ་ཨིན།(_r)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+msgid "Keyboard Accessibility Notifications"
+msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད་ བརྡ་བསྐུལ་ཚུ་"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "Keyboard Layout Options"
+msgstr "ལྡེ་སྒྲོམ་ སྒྲིག་བཀོད་གདམ་ཁ་ཚུ་ "
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "Keyboard Preferences"
+msgstr "ལྡེ་སྒྲོམ་གྱི་དགའ་གདམ་ཚུ།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "Keyboard _model:"
+msgstr "ལྡེ་སྒྲོམ་གྱི་དཔེ་:(_m)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "Layout _Options..."
+msgstr "སྒྲིག་བཀོད་ཀྱི་གདམ་ཁ་ཚུ་་་་་ (_O)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "Layouts"
+msgstr "སྒྲིག་བཀོད་ཚུ།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"ལྡེ་སྒྲོམ་ལག་ལེན་ལུ་ ཡང་བསྐྱར་གྱི་གནོད་སྐྱོན་ བཀག་ཐབས་ལུ་ དུས་ཡུན་ཧ་ལམ་ཅིག་ལས་ གསལ་གཞི་ལྡེ་མིག་རྐྱབས།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "Mouse Keys"
+msgstr "མཱའུསི་གི་ལྡེ་མིག་ཚུ།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "Preview:"
+msgstr "སྔོན་ལྟ།:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "Repeat keys speed"
+msgstr "ལྡེ་མིག་ཡང་བསྐྱར་གྱི་ཚད།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "Reset to De_faults"
+msgstr "སྔོན་སྒྲིག་ལུ་ བསྐྱར་སྒྲིག་འབད"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
+msgid "S_peed:"
+msgstr "མགྱོགས་ཚད་:(_p)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
+msgid "Separate _layout for each window"
+msgstr "སྒོ་སྒྲིག་རེ་རེའི་དོན་ལུ་ སྒྲིག་བཀོད་སོ་སོ་ (_L)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
+msgid "Typing Break"
+msgstr "ཡིག་དཔར་བརྐྱབ་ནིའི་བར་མཚམས།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
+msgid "_Allow to control the pointer using the keyboard"
+msgstr "ལྡེ་སྒྲོམ་ ལག་ལེན་འཐབ་ཐོག་ལས་ དཔག་བྱེད་ ཚད་འཛིན་འབད་བཅུག་ (_A)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
+msgid "_Allow to turn accessibility features on and off from the keyboard"
+msgstr "ལྡེ་སྒྲོམ་གུ་ལས་ འཛུལ་སྤྱོད་ཁྱད་རྣམ་ཚུ་ ཨོན་དང་ཨོཕ་ འབད་བཅུག་ (_A)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
+msgid "_Break interval lasts:"
+msgstr "བར་མཚམས་གནས་ཡུན་:(_B)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
+msgid "_Delay:"
+msgstr "ཕྱིར་འགྱངས་:(_D)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
+msgid "_Ignore fast duplicate keypresses"
+msgstr "ལྡེ་མིག་ཨེབ་གནོན་ ངོ་བཤུས་ཚུ་ སྣང་མེད་བཞག་ (_I)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
+msgid "_Layouts:"
+msgstr "སྒྲིག་བཀོད་ཚུ:(_L)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
+msgid "_Models:"
+msgstr "དཔེ་ཚུ་:(_M)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
+msgid "_Notifications..."
+msgstr "བརྡ་བསྐུལ་ཚུ་... (_N)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
+msgid "_Only accept long keypresses"
+msgstr "འཆང་སྟེ་ཡོད་མི་ ལྡེ་མིག་ཚུ་རྐྱངམ་གཅིག་ དང་ལེན་འབད་ (_O)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
+msgid "_Selected layouts:"
+msgstr "སེལ་འཐུ་འབད་མི་ སྒྲིག་བཀོད་ཚུ་:(_S)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
+msgid "_Simulate simultanous keypresses"
+msgstr "དུས་མཉམ་ ལྡེ་མནན་ཚུ་ མཚུངས་པ་བཟོ་ "
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
+msgid "_Speed:"
+msgstr "མགྱོགསཚད་:(_S)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
+msgid "_Type to test settings:"
+msgstr "གཞི་སྒྲིག་: ཚུ་བརྟག་ཞིབ་འབད་ནི་ལུ་ ཡིག་དཔར་རྐྱབས།(_T)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
+msgid "_Variants:"
+msgstr "ཁྱད་དངོས་ཚུ:(_V)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
+msgid "_Vendors:"
+msgstr "བཙོང་མི་ཚུ: (_V)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
+msgid "_Work interval lasts:"
+msgstr "ལཱ་གི་བར་མཚམས་གནས་ཡུན་:(_W)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
+msgid "minutes"
+msgstr "སྐར་མ།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
+msgid "Unknown"
+msgstr "མ་ཤེསཔ།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbltadd.c:211
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:311
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:211
+msgid "Default"
+msgstr "སྔོན་སྒྲིག"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:305
+msgid "Layout"
+msgstr "སྒྲིག་བཀོད།"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
+msgid "Vendors"
+msgstr "བཙོངས་མི་ཚུ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
+msgid "Models"
+msgstr "དཔེ།"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "ལྡེ་སྒྲོམ།"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "ཁྱོད་རའི་ལྡེ་སྒྲོམ་གྱི་དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:89
+msgid "gesture|Move left"
+msgstr "བརྡ་སྟོན་| གཡོན་ཁ་ཐུག་ལུ་ སྤོ་བཤུད་འབད་ "
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:94
+msgid "gesture|Move right"
+msgstr "བརྡ་སྟོན་| གཡས་ཁ་ཐུག་ལུ་སྤོ་བཤུད་འབད་ "
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:99
+msgid "gesture|Move up"
+msgstr "བརྡ་སྟོན་| ཡར་བཤུད་"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:104
+msgid "gesture|Move down"
+msgstr "རྣམ་འགྱུར་| མར་བཤུད་ "
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:109
+msgid "gesture|Disabled"
+msgstr "རྣམ་འགྱུར་| ལྕོགས་མིན་བཟོ་ཡོདཔ་ "
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+msgid "<b>Double-Click Timeout</b>"
+msgstr "<b>ཨེབ་གཏང་ ཐེངས་གཉིས་ཀྱི་ངལ་མཚམས་</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>འདྲུད་དེ་བཀོག་བཞག་</b>"
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Dwell Click</b>"
+msgstr "<b>ཌུའལ་ ཨེབ་གཏང་ </b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>དཔག་བྱེད་ག་ཡོད་བལྟ་</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>མཱའུསི་གི་ཕྱོགས་</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<b>Pointer Speed</b>"
+msgstr "<b>དཔག་བྱེད་ མགྱོགས་ཚད་ </b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<b>Simulated Secondary Click</b>"
+msgstr "<b>མཚུངས་པ་བཟོ་ཡོད་པའི་ གལ་གནད་ཆུང་བའི་ཨེབ་གཏང་</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid ""
+"<i>To test your double-click settings, try to double-click on the light bulb."
+"</i>"
+msgstr ""
+"<i>ཁྱོད་རའི་ཨེབ་གཏང་གཉིས་ལྡན་གཞི་སྒྲིག་ཚུ་ བརྟག་ཞིབ་འབད་ནིའི་དོན་ལུ་ གློག་ཤལ་དེ་གུ་ ཚར་གཉིས་ཨེབ་གཏང་"
+"འབད། </i>"
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid ""
+"<i>You can also use the Dwell Click panel applet to choose the click type.</"
+"i>"
+msgstr ""
+"<i>དེ་མ་ཚད་ ཁྱོད་ཀྱིས་ ཨེབ་གཏང་གི་དབྱེ་བ་ གདམ་ཁ་རྐྱབ་ནིའི་དོན་ལུ་ ཌུའལ་ ཨེབ་གཏང་ པེ་ནཱལ་ ཨེཔ་ལེཊི་"
+"ཡང་ ལག་ལེན་འཐབ་བཏུབ། </i>"
+
+#. high sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "<small><i>High</i></small>"
+msgstr "<small><i>མཐོ་བ་</i></small>"
+
+#. large threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "<small><i>Large</i></small>"
+msgstr "<small><i>ཆེ་བ་</i></small>"
+
+#. low sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "<small><i>Low</i></small>"
+msgstr "<small><i>དམའ་</i></small>"
+
+#. small threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "<small><i>Small</i></small>"
+msgstr "<small><i>ཆུང་ཀུ་</i></small>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
+msgid "Choose type of click _beforehand"
+msgstr "ཨེབ་གཏང་གི་དབྱེ་བ་ སྔ་གོང་ལས་རང་ གདམ་ཁ་རྐྱབས་ (_B)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
+msgid "Choose type of click with mo_use gestures"
+msgstr "ཨེབ་གཏང་གི་དབྱེ་བ་ མཱའིསི་གི་བརྡ་སྟོན་དང་གཅིག་ཁར་ གདམ་ཁ་རྐྱབས་ (_U)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
+msgid "D_ouble click:"
+msgstr " "
+
+#. click to initiate drag-and-drop (like normally click and hold)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
+msgid "D_rag click:"
+msgstr "ཨེབ་གཏང་ འདྲུད: (_R)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
+msgid "Mouse Preferences"
+msgstr "མཱའུསི་གི་དགའ་གདམ་ཚུ།"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
+msgid "Seco_ndary click:"
+msgstr "གལ་གནད་ཆུང་བའི་ཨེབ་གཏང: (_N)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr "ཚད་འཛིན་ ལྡེ་མིག་མནན་ཡོད་པའི་སྐབས་ དཔག་བྱེད་ཀྱི་ གནས་ས་སྟོན་ (_O)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
+msgid "Show click type _window"
+msgstr "ཨེབ་གཏང་དབྱེ་བ་གི་ ཝིན་ཌོ་ སྟོན་ (_W)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
+msgid "Thr_eshold:"
+msgstr "ཐེ་རེཤི་ཧཱོལཌི་: (_T)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
+msgid "_Acceleration:"
+msgstr "མགྱོགས་སྤྱོད་:(_A)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
+msgid "_Initiate click when stopping pointer movement"
+msgstr "དཔག་བྱེད་ཀྱི་ འགུལ་སྤྱོད་བཀག་བཞག་པའི་སྐབས་ ཨེབ་གཏང་འགོ་བཙུགས་ (_I)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
+msgid "_Left-handed"
+msgstr "གཡོན་ལག་(_L)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
+msgid "_Motion threshold:"
+msgstr "མོ་ཤཱན་ ཐེ་རེཤི་ཧཱོལཌི་:(_T)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
+msgid "_Right-handed"
+msgstr "གཡས་ལག་ (_R)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
+msgid "_Sensitivity:"
+msgstr "དྲན་ཚོར་:(_S)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
+msgid "_Single click:"
+msgstr "ཨེབ་གཏང་ རྐྱང་པ: (_S)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
+msgid "_Timeout:"
+msgstr "ངལ་མཚམས་:(_T)"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr "གཞི་རིམ་ཨེབ་གཏང་ འཆང་ཐོག་ལས་ གལ་གནད་ཆུང་བའི་ཨེབ་གཏང་ ལཱ་འབད་བཅུག་ (_T)"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "མཱའུསི།"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "ཁྱོད་རའི་མཱའུསི་གི་ དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "ཡོངས་འབྲེལ་གྱི་ པོརོག་སི།"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "ཁྱོད་རའི་ཡོངས་འབྲེལ་གྱི་ པོརོག་སི་དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>ཨིན་ཊར་ནེཊི་གི་ ཐད་ཀར་མཐུད་ལམ་</b>(_i)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>Ignore Host List</b>"
+msgstr "<b>ཧོསིཊི་ཐོ་ཡིག་ སྣང་མེད་བཞག་</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>རང་བཞིན་པོརོག་སི་རིམ་སྒྲིག་</b>(_A)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>ལག་དེབ་ཀྱི་ པོརོག་སི་རིམ་སྒྲིག་</b>(_M)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Use authentication</b>"
+msgstr "<b>བདེན་བཤད་ལག་ལེན་འཐབ་</b>(_U)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "Advanced Configuration"
+msgstr "མཐོ་རིམ་ཅན་གྱི་རིམ་སྒྲིག"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "Autoconfiguration _URL:"
+msgstr "རང་བཞིན་རིམ་སྒྲིག་ ཡུ་ཨར་ཨེལ།(_U)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "HTTP Proxy Details"
+msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་གི་ རྒྱས་བཤད་ཚུ།"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "H_TTP proxy:"
+msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་:།(_T)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "Network Proxy Preferences"
+msgstr "ཡོངས་འབྲེལ་ པོརོག་སི་གི་དགའ་གདམ་ཚུ།"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Port:"
+msgstr "འདྲེན་ལམ་:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Proxy Configuration"
+msgstr "པོརོག་སི་རིམ་སྒྲིག"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "S_ocks host:"
+msgstr "སོཀསི་ ཧོསིཊི་:(_o)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "U_sername:"
+msgstr "ལག་ལེན་པའི་མིང་:(_s)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "_Details"
+msgstr "རྒྱས་བཤད་ཚུ།(_D)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_FTP proxy:"
+msgstr "ཨེཕ་ཊི་པི་ པོརོག་སི་:(_F)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_Password:"
+msgstr "ཆོག་ཡིག་:(_P)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Secure HTTP proxy:"
+msgstr "ཨེཆ་ཊི་ཊི་པི་ པོརོག་སི་མཐའ་བཙན་བཟོ:(_S)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Use the same proxy for all protocols"
+msgstr "གནད་སྤེལ་ལམ་ལུགས་ཚུ་ཆ་མཉམ་གྱི་དོན་ལུ་ པོརོ་སི་གཅིག་པ་འདི་ལག་ལེན་འཐབ་ (_U)"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "སྒྲ་སྐད་ལྕོགས་ཅན་བཟོ་སྟེ་ བྱུང་ལས་དང་མཉམ་སྦྲགས་འབད།"
+
+#: ../capplets/sound/mixer-support.c:79
+#, c-format
+msgid "Unknown Volume Control %d"
+msgstr "མ་ཤེས་པའི་སྐད་ཤུགས་ཚད་འཛིན་ %d"
+
+#: ../capplets/sound/pipeline-tests.c:84
+#, c-format
+msgid "Failed to construct test pipeline for '%s'"
+msgstr "'%s' གི་དོན་ལུ་ བརྟག་ཞིབ་རྒྱུད་དུང་འབྲེལ་ལམ་ བཟོ་བསྐྲུན་འབད་ནི་འཐུས་ཤོས་འབྱུང་ཡོད་"
+
+#: ../capplets/sound/sound-properties-capplet.c:325
+#: ../capplets/sound/sound-properties-capplet.c:378
+msgid "Not connected"
+msgstr "མ་མཐུད་པས།"
+
+#: ../capplets/sound/sound-properties-capplet.c:661
+msgid "Autodetect"
+msgstr "རང་བཞིན་སྐྱོན་འཛིན་"
+
+#: ../capplets/sound/sound-properties-capplet.c:666
+#: ../capplets/sound/sound-properties-capplet.c:667
+msgid "ALSA - Advanced Linux Sound Architecture"
+msgstr "ཨེ་ཨེལ་ཨེསི་ཨེ་ - མཐོ་རིམ་ལི་ནགསི་སྒྲ་སྐད་བཟོ་བཀོད་"
+
+#: ../capplets/sound/sound-properties-capplet.c:668
+msgid "Artsd - ART Sound Daemon"
+msgstr "ཨརཊི་ཨེསི་ཌི་ - སྒྱུ་རྩལ་སྒྲ་སྐད་ཌེ་མཱོན་"
+
+#: ../capplets/sound/sound-properties-capplet.c:669
+#: ../capplets/sound/sound-properties-capplet.c:670
+msgid "ESD - Enlightened Sound Daemon"
+msgstr "ཨི་ཨེསི་ཌི་ - ཤེས་ཡོན་ཅན་སྒྲ་སྐད་ཌེ་མཱོན་"
+
+#: ../capplets/sound/sound-properties-capplet.c:671
+#: ../capplets/sound/sound-properties-capplet.c:672
+msgid "OSS - Open Sound System"
+msgstr "ཨོ་ཨེསི་ཨེ་ - སྒྲ་སྐད་རིམ་ལུགས་ཁ་ཕྱེ་"
+
+#: ../capplets/sound/sound-properties-capplet.c:673
+#: ../capplets/sound/sound-properties-capplet.c:674
+msgid "PulseAudio Sound Server"
+msgstr "པོ་ལི་པའུ་ཌིའོ་སྒྲ་སྐད་སར་བར"
+
+#: ../capplets/sound/sound-properties-capplet.c:675
+msgid "Test Sound"
+msgstr "བརྟག་ཞིབ་སྒྲ་སྐད་"
+
+#: ../capplets/sound/sound-properties-capplet.c:676
+msgid "Silence"
+msgstr "ཁུ་སིམ་སིམ་"
+
+#: ../capplets/sound/sound-properties-capplet.c:1043
+msgid "- GNOME Sound Preferences"
+msgstr "- ཇི་ནོམ་སྒྲ་སྐད་ཀྱི་དགའ་གདམ་ཚུ་"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "<b>Audio Conferencing</b>"
+msgstr "<b>རྣར་ཉན་ཞལ་འཛོམས་</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "<b>Default Mixer Tracks</b>"
+msgstr "<b>སྔོན་སྒྲིག་སྦྱོར་འཕྲུལ་གླུ་རིམ་ཚུ་</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "<b>Music and Movies</b>"
+msgstr "<b>སྙན་ཆ་དང་གློག་བརྙན་</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "<b>Sound Events</b>"
+msgstr "<b>སྒྲ་སྐད་བྱུང་ལས་</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+msgstr "<span weight=\"bold\" size=\"larger\">བརྟག་ཞིབ་འབད་དོ་</span>"
+
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Click OK to finish."
+msgstr "རྫོགས་ནིའི་དོན་ལུ་ བཏུབ་གུ་ཨེབ་གཏང་འབད།"
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "Devices"
+msgstr "ཐབས་འཕྲུལ།"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "E_nable software sound mixing (ESD)"
+msgstr "མཉེན་ཆས་སྒྲ་སྐད་བསྲེ་སྦྱོར་གྱི་ལྕོགས་ཅན་བཟོ།(ཨི་ཨེསི་ཌི)"
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "Flash _entire screen"
+msgstr "གསལ་གཞི་ཧྲིལ་བུ་ རིབ་སྟོན་འབད།(_e)"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "Flash _window titlebar"
+msgstr "སྒོ་སྒྲིག་གི་མགོ་མིང་ཕྲ་རིང་ རིབ་སྟོན་འབད།(_w)"
+
+#: ../capplets/sound/sound-properties.glade.h:11
+msgid "S_ound playback:"
+msgstr "སྒྲ་སྐད་གཏང་ནི་:(_o)"
+
+#: ../capplets/sound/sound-properties.glade.h:12
+msgid ""
+"Select the device and tracks to control with the keyboard. Use the Shift and "
+"Control keys to select multiple tracks if required."
+msgstr ""
+"ལྡེ་སྒྲོམ་དང་གཅིག་ཁར་ཚད་འཛིན་འབད་ནིའི་དོན་ལས་ ཐབས་འཕྲུལ་དང་གླུ་རིམ་ཚུ་སེལ་འཐུ་འབད། དགོས་མཁོ་ཡོདཔ་"
+"ཨིན་པ་ཅིན་ སྣ་མང་གླུ་རིམ་ཚུ་སེལ་འཐུ་འབད་ནིའི་དོན་ལས་ སོར་ལྡེ་དང་ཚད་འཛིན་ལྡེ་མིག་ཚུ་ལག་ལེན་འཐབ།"
+
+#: ../capplets/sound/sound-properties.glade.h:13
+msgid "So_und playback:"
+msgstr "སྒྲ་སྐད་གཏང་ནི་:(_u)"
+
+#: ../capplets/sound/sound-properties.glade.h:14
+msgid "Sou_nd capture:"
+msgstr "སྒྲ་སྐད་འཛིན་བཟུང་:(_n)"
+
+#: ../capplets/sound/sound-properties.glade.h:15
+msgid "Sound Preferences"
+msgstr "སྒྲ་སྐད་ཀྱི་དགའ་གདམ་ཚུ།"
+
+#: ../capplets/sound/sound-properties.glade.h:16
+msgid "Sounds"
+msgstr "སྒྲ་སྐད།"
+
+#: ../capplets/sound/sound-properties.glade.h:17
+msgid "System Beep"
+msgstr "རིམ་ལུགས་བརྡ་སྐད།"
+
+#: ../capplets/sound/sound-properties.glade.h:18
+msgid "Test"
+msgstr "བརྟག་ཞིབ།"
+
+#: ../capplets/sound/sound-properties.glade.h:19
+msgid "Testing Pipeline"
+msgstr "རྒྱུད་དུང་འབྲེལ་ལམ་བརྟག་ཞིབ་འབད་དོ།"
+
+#: ../capplets/sound/sound-properties.glade.h:20
+msgid "_Device:"
+msgstr "ཐབས་འཕྲུལ:(_D)"
+
+#: ../capplets/sound/sound-properties.glade.h:21
+msgid "_Enable system beep"
+msgstr "རིམ་ལུགས་བརྡ་སྐད་ལྕོགས་ཅན་བཟོ།(_E)"
+
+#: ../capplets/sound/sound-properties.glade.h:22
+msgid "_Play system sounds"
+msgstr "རིམ་ལུགས་སྒྲ་སྐད་གཏང་།(_P)"
+
+#: ../capplets/sound/sound-properties.glade.h:23
+msgid "_Sound playback:"
+msgstr "སྒྲ་སྐད་གཏང་ནི་:(_S)"
+
+#: ../capplets/sound/sound-properties.glade.h:24
+msgid "_Visual system beep"
+msgstr "མཐོང་བའི་རིམ་ལུགས་བརྡ་སྐད།(_V)"
+
+#: ../capplets/windows/gnome-window-properties.c:344
+msgid "Cannot start the preferences application for your window manager"
+msgstr "ཁྱོད་ཀྱི་སྒོ་སྒྲིག་འཛིན་སྐྱོང་པའི་དོན་ལུ་ དགའ་གདམ་གྱི་གློག་རིམ་ འགོ་བཙུགས་མི་ཚུགས།"
+
+#. translators: this is the Control key
+#: ../capplets/windows/gnome-window-properties.c:602
+msgid "C_ontrol"
+msgstr "ཚད་འཛིན།(_o)"
+
+#: ../capplets/windows/gnome-window-properties.c:607
+msgid "_Alt"
+msgstr "གདམ་ལྡེ།(_A)"
+
+#: ../capplets/windows/gnome-window-properties.c:613
+msgid "H_yper"
+msgstr "ཧའི་པར།(_y)"
+
+#: ../capplets/windows/gnome-window-properties.c:620
+msgid "S_uper (or \"Windows logo\")"
+msgstr "ཡང་དག (ཡང་ན་ \"Windows logo\")(_u)"
+
+#: ../capplets/windows/gnome-window-properties.c:627
+msgid "_Meta"
+msgstr "མེ་ཊ།(_M)"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>འགུལ་བསྐྱོད་ལྡེ་མིག་</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>མགོ་མིང་ཕྲ་རིང་གི་བྱ་བ་</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>སྒོ་སྒྲིག་གི་སེལ་འཐུ་</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr "སྒོ་སྒྲིག་ཅིག་ སྤོ་བཤུད་འབད་ནི་ལུ་ ལྡེ་མིག་འདི་ཨེབ་སྟེ་འཛིན་ཞིནམ་ལས་ སྒོ་སྒྲིག་དེ་བཟུང་།"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "སྒོ་སྒྲིག་གི་ དགའ་གདམ་ཚུ།"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "བྱ་བ་འདི་བསྒྲུབ་ནི་ལུ་ མགོ་མིང་ཕྲ་རིང་ལུ་ ཨེབ་གཏང་ཚར་གཉིས་འབད།(_D)"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "ཆེར་བསྐྱེད་མ་འབད་བའི་ཧེ་མར་བར་མཚམས་:(_I)"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "སེལ་འཐུ་འབད་མི་ སྒོ་སྒྲིག་ཚུ་ བར་མཚམས་ཅིག་གི་ཤུལ་ལས་ ཆེར་བསྐྱེད་འབད།(_R)"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "མཱའུསི་དེ་ སྒོ་སྒྲིག་ཚུ་གི་གུ་ལས་ཕར་འགྱོཝ་ད་ སྒོ་སྒྲིག་ཚུ་ སེལ་འཐུ་འབད།(_S)"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "སྐར་ཆ་ཚུ།"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "ཁྱོད་རའི་སྒོ་སྒྲིག་གི་རྒྱུ་དངོས་ཚུ་ གཞི་སྒྲིག་འབད།"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "སྒོ་སྒྲིག་ཚུ།"
+
+#. make start action
+#: ../libslab/application-tile.c:369
+#, c-format
+msgid "<b>Start %s</b>"
+msgstr "<b>%s འགོ་བཙུགས་</b>"
+
+#: ../libslab/application-tile.c:388
+msgid "Help"
+msgstr "གྲོགས་རམ་"
+
+#: ../libslab/application-tile.c:435
+msgid "Upgrade"
+msgstr "ཡར་བསྐྱེད་"
+
+#: ../libslab/application-tile.c:450
+msgid "Uninstall"
+msgstr "གཞི་བཙུགས་མ་འབད་"
+
+#: ../libslab/application-tile.c:777 ../libslab/document-tile.c:737
+msgid "Remove from Favorites"
+msgstr "དགའ་མི་ཚུ་ལས་རྩ་བསྐྲད་གཏང་"
+
+#: ../libslab/application-tile.c:779 ../libslab/document-tile.c:739
+msgid "Add to Favorites"
+msgstr "དགའ་མི་ཚུ་ལུ་ཁ་སྐོང་རྐྱབས་"
+
+#: ../libslab/application-tile.c:864
+msgid "Remove from Startup Programs"
+msgstr "འགོ་བཙུགས་ལས་རིམ་ཚུ་ལས་ རྩ་བསྐྲད་གཏང་"
+
+#: ../libslab/application-tile.c:866
+msgid "Add to Startup Programs"
+msgstr "འགོ་བཙུགས་ལས་རིམ་ཚུ་ལུ་ ཁ་སྐོང་རྐྱབས་"
+
+#: ../libslab/app-shell.c:750
+#, c-format
+msgid ""
+"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+"\n"
+" Your filter \"<b>%s</b>\" does not match any items.</span>"
+msgstr ""
+"<span size=\"large\"><b>མཐུན་མི་ཚུ་མ་འཐོབ།</b> </span><span>\n"
+"\n"
+" ཁྱོད་ཀྱི་ཚགས་མ་ \"<b>%s</b>\" འདི་ རྣམ་གྲངས་ཚུ་ག་དང་གཅིག་ཁར་ཡང་མི་མཐུན་མས།</span>"
+
+#: ../libslab/app-shell.c:900
+msgid "Other"
+msgstr "གཞན་མི་"
+
+#: ../libslab/bookmark-agent.c:1061
+msgid "New Spreadsheet"
+msgstr "ཤོག་ཁྲམ་གསརཔ"
+
+#: ../libslab/bookmark-agent.c:1065
+msgid "New Document"
+msgstr "ཡིག་ཆ་གསརཔ"
+
+#: ../libslab/bookmark-agent.c:1117
+msgid "Home"
+msgstr "ཁྱིམ"
+
+#: ../libslab/bookmark-agent.c:1133
+msgid "File System"
+msgstr "ཡིག་སྣོད་ཀྱི་་རིམ་ལུགས"
+
+#: ../libslab/bookmark-agent.c:1137
+msgid "Network Servers"
+msgstr "ཡོངས་འབྲེལ་གྱི་ སར་་བར"
+
+#: ../libslab/bookmark-agent.c:1166
+msgid "Search"
+msgstr "འཚོལ་ཞིབ།"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:170
+#, c-format
+msgid "<b>Open</b>"
+msgstr "<b>ཁ་ཕྱེ </b>"
+
+#. make rename action
+#: ../libslab/directory-tile.c:189 ../libslab/document-tile.c:228
+msgid "Rename..."
+msgstr "བསྐྱར་མིང་བཏགས་..."
+
+#: ../libslab/directory-tile.c:203 ../libslab/directory-tile.c:212
+#: ../libslab/document-tile.c:242 ../libslab/document-tile.c:251
+msgid "Send To..."
+msgstr "...ལུ་གཏང་"
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:227 ../libslab/document-tile.c:277
+msgid "Move to Trash"
+msgstr "ཕྱགས་ཧོད་ལུ་སྤོ་"
+
+#: ../libslab/directory-tile.c:237 ../libslab/directory-tile.c:450
+#: ../libslab/document-tile.c:287 ../libslab/document-tile.c:850
+msgid "Delete"
+msgstr "བཏོན་གཏང་"
+
+#: ../libslab/directory-tile.c:575 ../libslab/document-tile.c:1022
+#, c-format
+msgid "Are you sure you want to permanently delete \"%s\"?"
+msgstr "ཁྱོད་ཀྱིས་ \"%s\" རྟག་བརྟན་སྦེ་ བཏོན་གཏང་ནི་ངེས་ཏིག་ཨིན་ན?"
+
+#: ../libslab/directory-tile.c:580 ../libslab/document-tile.c:1026
+msgid "If you delete an item, it is permanently lost."
+msgstr "ཁྱོད་ཀྱིས་ རྣམ་གྲངས་ཅིག་བཏོན་གཏང་པ་ཅིག་ དེ་ རྟག་བརྟན་སྦེ་ བརླག་སྟོར་ཞུགས་འོང་། "
+
+#: ../libslab/document-tile.c:189
+#, c-format
+msgid "<b>Open with \"%s\"</b>"
+msgstr "<b> \"%s\" དང་གཅིག་ཁར་ཁ་ཕྱེ་</b>"
+
+#: ../libslab/document-tile.c:201
+msgid "Open with Default Application"
+msgstr "སྔོན་སྒྲིག་གློག་རིམ་དང་གཅིག་ཁར་ ཁ་ཕྱེ་"
+
+#: ../libslab/document-tile.c:212
+msgid "Open in File Manager"
+msgstr "ཡིག་སྣོད་འཛིན་སྐྱོང་པ་ནང་ ཁ་ཕྱེ་"
+
+#: ../libslab/document-tile.c:633
+msgid "?"
+msgstr "?"
+
+#: ../libslab/document-tile.c:640
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#: ../libslab/document-tile.c:648
+msgid "Today %l:%M %p"
+msgstr "ད་རིས་ %l:%M %p"
+
+#: ../libslab/document-tile.c:658
+msgid "Yesterday %l:%M %p"
+msgstr "ཁ་རྩ་ %l:%M %p"
+
+#: ../libslab/document-tile.c:670
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../libslab/document-tile.c:678
+msgid "%b %d %l:%M %p"
+msgstr "%b %d %l:%M %p"
+
+#: ../libslab/document-tile.c:680
+msgid "%b %d %Y"
+msgstr "%b %d %Y"
+
+#: ../libslab/libslab-bookmarkfile.c:700 ../libslab/libslab-bookmarkfile.c:777
+#: ../libslab/libslab-bookmarkfile.c:856 ../libslab/libslab-bookmarkfile.c:903
+#, c-format
+msgid "Unexpected attribute '%s' for element '%s'"
+msgstr "རྒྱུ་རྫས་'%s'ལུ་རེ་བ་་མེད་པའི་ཁྱད་ཆོས'%s'"
+
+#: ../libslab/libslab-bookmarkfile.c:711 ../libslab/libslab-bookmarkfile.c:788
+#: ../libslab/libslab-bookmarkfile.c:798 ../libslab/libslab-bookmarkfile.c:914
+#, c-format
+msgid "Attribute '%s' of element '%s' not found"
+msgstr "རྒྱུ་རྫས་'%s'གི་ཁྱད་ཆོས་'%s' མ་ཐོབ"
+
+#: ../libslab/libslab-bookmarkfile.c:1087
+#: ../libslab/libslab-bookmarkfile.c:1152
+#: ../libslab/libslab-bookmarkfile.c:1216
+#: ../libslab/libslab-bookmarkfile.c:1226
+#, c-format
+msgid "Unexpected tag '%s', tag '%s' expected"
+msgstr "རེ་བ་མེད་པའི་ངོ་རྟགས '%s', ངོ་རྟགས '%s' རེ་བ་ཡོདཔ"
+
+#: ../libslab/libslab-bookmarkfile.c:1112
+#: ../libslab/libslab-bookmarkfile.c:1126
+#: ../libslab/libslab-bookmarkfile.c:1194
+#: ../libslab/libslab-bookmarkfile.c:1246
+#, c-format
+msgid "Unexpected tag '%s' inside '%s'"
+msgstr "རེ་བ་མེད་པའི་ངོ་རྟགས'%s' ནང་ན '%s'"
+
+#: ../libslab/libslab-bookmarkfile.c:1929
+#, c-format
+msgid "No valid bookmark file found in data dirs"
+msgstr "གནད་སྡུད་ཌའིརསི་ནང་ནུས་ཅན་གྱི་དེབ་རྟགས་ཡིག་སྣོད་མིན་འདུག"
+
+#: ../libslab/libslab-bookmarkfile.c:2130
+#, c-format
+msgid "A bookmark for URI '%s' already exists"
+msgstr "ཡུ་ཨར་ཨེལ'%s'དོན་ལུ་དེབ་རྟགས་ཅིག་ཧེ་མ་ལས་འདུག"
+
+#: ../libslab/libslab-bookmarkfile.c:2176
+#: ../libslab/libslab-bookmarkfile.c:2333
+#: ../libslab/libslab-bookmarkfile.c:2418
+#: ../libslab/libslab-bookmarkfile.c:2499
+#: ../libslab/libslab-bookmarkfile.c:2584
+#: ../libslab/libslab-bookmarkfile.c:2667
+#: ../libslab/libslab-bookmarkfile.c:2745
+#: ../libslab/libslab-bookmarkfile.c:2824
+#: ../libslab/libslab-bookmarkfile.c:2866
+#: ../libslab/libslab-bookmarkfile.c:2963
+#: ../libslab/libslab-bookmarkfile.c:3089
+#: ../libslab/libslab-bookmarkfile.c:3279
+#: ../libslab/libslab-bookmarkfile.c:3355
+#: ../libslab/libslab-bookmarkfile.c:3508
+#: ../libslab/libslab-bookmarkfile.c:3573
+#: ../libslab/libslab-bookmarkfile.c:3663
+#: ../libslab/libslab-bookmarkfile.c:3790
+#, c-format
+msgid "No bookmark found for URI '%s'"
+msgstr "ཡུ་ཨར་་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་མིན་འདུག"
+
+#: ../libslab/libslab-bookmarkfile.c:2508
+#, c-format
+msgid "No MIME type defined in the bookmark for URI '%s'"
+msgstr "ཡུ་ཨར་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་ནང་ཨེམ་ཨའི་ཨེམ་ཨི་གི་དབྱེ་བ་ངེས་འཛིན་འབད་མིན་འདུག"
+
+#: ../libslab/libslab-bookmarkfile.c:2593
+#, c-format
+msgid "No private flag has been defined in bookmark for URI '%s'"
+msgstr "ཡུ་ཨར་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་ནང་སྒེར་གྱི་དར་ངེས་འཛིན་འབད་དེ་མིན་འདུག"
+
+#: ../libslab/libslab-bookmarkfile.c:2972
+#, c-format
+msgid "No groups set in bookmark for URI '%s'"
+msgstr "ཡུ་ཨར་ཨེལ་'%s'དོན་ལུ་དེབ་རྟགས་ནང་སྡེ་ཚན་ཚུ་གཞི་སྒྲིག་འབད་དེ་མིན་འདུག"
+
+#: ../libslab/libslab-bookmarkfile.c:3373
+#: ../libslab/libslab-bookmarkfile.c:3518
+#, c-format
+msgid "No application with name '%s' registered a bookmark for '%s'"
+msgstr "'%s'དོན་ལུ་དེབ་རྟགས་མིང'%s' ཐོ་བཀོད་དང་བཅསཔ་སྦེ་འཇུག་སྤྱོད་འབད་དེ་མིན་འདུག"
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr "ད་ལྟོ་འཚོལ་"
+
+#: ../libslab/system-tile.c:128
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr "<b> ཁ་ཕྱེ %s་</b>"
+
+#: ../libslab/system-tile.c:141
+#, c-format
+msgid "Remove from System Items"
+msgstr "རིམ་ལུགས་རྣམ་གྲངས་ལས་རྩ་བསྐྲད་གཏང་"
+
+#: ../libsounds/sound-view.c:44
+msgid "Login"
+msgstr "ནང་བསྐྱོད།"
+
+#: ../libsounds/sound-view.c:45
+msgid "Logout"
+msgstr "ཕྱིར་བསྐྱོད།"
+
+#: ../libsounds/sound-view.c:46
+msgid "Boing"
+msgstr "བོ་ཡིང་།"
+
+#: ../libsounds/sound-view.c:47
+msgid "Siren"
+msgstr "སྒྲ་འཕྲུལ།"
+
+#: ../libsounds/sound-view.c:48
+msgid "Clink"
+msgstr "ཏིང་སྒྲ།"
+
+#: ../libsounds/sound-view.c:49
+msgid "Beep"
+msgstr "བརྡ་སྐད་རྐྱབས།"
+
+#: ../libsounds/sound-view.c:50
+msgid "No sound"
+msgstr "སྒྲ་སྐད་མིན་འདུག"
+
+#: ../libsounds/sound-view.c:132
+msgid "Sound not set for this event."
+msgstr "བྱུང་ལས་ཀྱི་དོན་ལུ་སྒྲ་སྐད་གཞི་སྒྲིག་མ་འབད་བས།"
+
+#: ../libsounds/sound-view.c:141
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package for a set of default sounds."
+msgstr ""
+"བྱུང་ལས་འདི་གི་དོན་ལུ་ སྒྲ་སྐད་ཡིག་སྣོད་དེ་མིན་འདུག\n"
+"ཁྱོད་ཀྱིས་ སྔོན་སྒྲིག་སྒྲ་སྐད་ཀྱི་ཆ་ཚན་ཅིག་གི་དོན་ལུ་ཇི་ནོམ་རྣར་ཉན་ཐུམ་སྒྲིལ་་དེ་ གཞི་བཙུགས་འབད་ནི་ཨིནམ་"
+"འོང་།"
+
+#: ../libsounds/sound-view.c:152
+msgid "The sound file for this event does not exist."
+msgstr "བྱུང་ལས་འདི་གི་དོན་ལུ་ སྒྲ་སྐད་ཡིག་སྣོད་དེ་མིན་འདུག"
+
+#: ../libsounds/sound-view.c:183
+msgid "Select Sound File"
+msgstr "སྒྲ་སྐད་ཡིག་སྣོད་སེལ་འཐུ་འབད།"
+
+#: ../libsounds/sound-view.c:210
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "ཡིག་སྣོད་%sདེ་ ནུས་ཅན་གྱི་ ཝེབ་ཡིག་སྣོད་ཅིག་མེན་པས།"
+
+#: ../libsounds/sound-view.c:271
+msgid "Select sound file..."
+msgstr "སྒྲ་སྐད་ཡིག་སྣོད་སེལ་འཐུ་འབད་..."
+
+#: ../libsounds/sound-view.c:373
+msgid "System Sounds"
+msgstr "རིམ་ལུགས་སྒྲ་སྐད།"
+
+#: ../libwindow-settings/gnome-wm-manager.c:318
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "སྒོ་སྒྲིག་འཛིན་སྐྱོང་པ་\"%s\" གིས་ རིམ་སྒྲིག་ལག་ཆས་ཅིག་ ཐོ་འགོད་མ་འབད་བས།\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:390
+msgid "Maximize"
+msgstr "མང་མཐའ་ལུ་སེང་།"
+
+#: ../libwindow-settings/metacity-window-manager.c:391
+msgid "Minimize"
+msgstr "ཆུང་ཀུ་བཟོ་ "
+
+#: ../libwindow-settings/metacity-window-manager.c:392
+msgid "Roll up"
+msgstr "ཡར་བསྒྲིལ"
+
+#: ../libwindow-settings/metacity-window-manager.c:393
+msgid "None"
+msgstr "ཅི་མེད་"
+
+#: ../shell/control-center.c:62
+#, c-format
+msgid "key not found [%s]\n"
+msgstr "ལྡེ་མིག་མ་འཐོབ་ [%s]\n"
+
+#: ../shell/control-center.c:159
+msgid "Filter"
+msgstr "ཚགས་མ་"
+
+#: ../shell/control-center.c:159
+msgid "Groups"
+msgstr "སྡེ་ཚན་ཚུ་"
+
+#: ../shell/control-center.c:159
+msgid "Common Tasks"
+msgstr "མཐུན་མོང་ལས་ཀ་ཚུ་"
+
+#: ../shell/control-center.c:163 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "ཚད་འཛིན་ལྟེ་བ་"
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr "ལས་ཀ་ཤུགས་ལྡན་བཟོ་བའི་སྐབས་སུ་དབུས་ཀྱི་ཚད་འཛིན་ཁ་བསྡམས"
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr "ལ་འགན་གྲུབ་ཡོད་པའི་ལ་གཡོག་རྩ་བསྐྲེད་གཏང་་ནི་ཡང་ན་ཁ་སྐོང་བརྐྱབས་ནི་ཕྱིར་ཐོན་ཤལ།"
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr "ལ་འགན་འགྲུབ་ཡོད་པའི་བྱ་བ་གྲོགས་རམ་གུ་ཕྱིར་འཐོན་ཤལ"
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr "ལཱ་འགན་འགྲུབ་ཡོད་པའི་བྱ་བ་འགོ་བཙུགས་ནི་གུ་ཕྱིར་ཐོན་གྱི་ཤལ"
+
+#: ../shell/control-center.schemas.in.h:5
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr "ཡར་བསྐྱེད་ནི་ཡང་ན་ལཱ་འགན་འགྲུབ་ཡོད་པའི་གཞི་བཙུགས་མ་འབད་བའི་བྱ་བ་གུ་ཕྱིར་ཐོན་གྱི་ཤལ"
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed."
+msgstr ""
+"གྲོགས་རམ་བྱ་བ་འདི་ ལཱ་འགན་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ ཤལ་ཁ་བསྡམས་ནི་ཨིན་ན་མེན་ན་་བརྡ་སྟོན་འབདཝ་ཨིན། "
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed."
+msgstr ""
+"འགོ་བཙུགས་བྱ་བ་འདི་ ལཱ་འགན་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ ཤལ་ཁ་བསྡམས་ནི་ཨིན་ན་མེན་ན་ ་བརྡ་སྟོན་འབདཝ་"
+"ཨིན། "
+
+#: ../shell/control-center.schemas.in.h:8
+msgid ""
+"Indicates whether to close the shell when an add or remove action is "
+"performed."
+msgstr ""
+"བསྡོམས་ནི་ཡང་ན་བསྐྲེད་གཏང་ ནི་བྱ་བ་འདི་ལཱ་འགན་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ཤ ལ་འདི་ཁ་བསྡམས་ནི་ཨིན་ན་མེན་"
+"ན་བརྡ་སྟོན་འབདཝ་ཨིན། "
+
+#: ../shell/control-center.schemas.in.h:9
+msgid ""
+"Indicates whether to close the shell when an upgrade or uninstall action is "
+"performed."
+msgstr ""
+"ཡར་བསྐྱེད་ ཡང་ན་ གཞི་བཙུགས་མ་འབད་བའི་བྱ་བ་འདི་ལཱ་འགྲུབ་ཡོད་པའི་སྐབས་ལུ་ ཤལ་འདི་ཁ་བསྡམས་ནི་ཨིན་ན་"
+"མེན་ན་ བརྡ་སྟོན་འབདཝ་ཨིན། "
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr "ལས་ཀའི་མིང་དང་འགན་རོགས་ཌེཀསི་ཊོབ་ཡིག་སྣོད་ཚུ"
+
+#: ../shell/control-center.schemas.in.h:11
+msgid ""
+"The task name to be displayed in the control-center followed by a \";\" "
+"separator then the filename of an associated .desktop file to launch for "
+"that task."
+msgstr ""
+"ལས་ཀའི་མིང་འདི་ཚད་འཛིན་དབུས་ལུ་བཀྲམ་སྟོན་འབད་ནི་ དེ་ལས་\";\"དབྱེ་བྱེད་གྲོགས་རམ་གྱི་ ཡིག་སྣོད་ཀྱི་"
+"མིང་ །ལས་ཀ་དེ་གི་དོན་ལས་ཌེཀསི་ཊོབ་ཡིག་སྣོད་གསར་བཙུགས་འབད།"
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+msgid ""
+"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
+"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+msgstr ""
+"[ཌེཀསི་ཊོབ་རྒྱབ་བརྟེན་སོར ;རྒྱབ་བརྟེན་ ཌེཀསི་ཊོབ བརྗོད་དོན་སོར ཇིཊི་ཀེ-བརྗོད་དོན་-སེལ་བྱེད ཌེཀསི་ཊོབ་ འཇུག་"
+"སྤྱོད་དགའ་གདམ་གཞི་སྒྲིག་ སྔོན་སྒྲིག་-འཇུག་སྤྱོད།  ཌེཀསི་ཊོབ དཔར་འཕྲུལ་ཁ་སྐོང་བརྐྱབས ཇི་ནོམ-ཀབསི- འཛིན་སྐྱོང་"
+"པ་གིས་ཌེཀསི་ཊོབ]"
+
+#: ../shell/control-center.schemas.in.h:14
+msgid ""
+"if true, the control-center will close when a \"Common Task\" is activated."
+msgstr ""
+"གལ་སྲིད་བདེན་པ་ཅིན་  \"མཐུན་མོངས་ལས་ཀ་\"ཤུགས་བདེན་བཟོ་བའི་སྐབས་སུ་དབུས་ཀྱི་ཚད་འཛིན་ཁ་བསྡམས་"
+"འོང་། "
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "ཇི་ནོམ་རིམ་སྒྲིག་ལག་ཆས།"
+
+#: ../typing-break/drw-break-window.c:188
+msgid "_Postpone Break"
+msgstr "བར་མཚམས་ ཕར་འགྱངས(_P)"
+
+#: ../typing-break/drw-break-window.c:244
+msgid "Take a break!"
+msgstr "བར་མཚམས་ཅིག་ལེན།"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#. translators: keep the initial "/"
+#: ../typing-break/drwright.c:129
+msgid "/_Preferences"
+msgstr "/ དགའ་གདམ་ཚུ།(_P)"
+
+#: ../typing-break/drwright.c:130
+msgid "/_About"
+msgstr "/ སྐོར་ལས།(_A)"
+
+#: ../typing-break/drwright.c:132
+msgid "/_Take a Break"
+msgstr "/ བར་མཚམས་ལེན།(_T)"
+
+#: ../typing-break/drwright.c:501
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "ཤུལ་མའི་བར་མཚམས་ཚུན་ཚོད་སྐར་མ་%d "
+msgstr[1] "ཤུལ་མའི་བར་མཚམས་ཚུན་ཚོད་སྐར་མ་%d"
+
+#: ../typing-break/drwright.c:505
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr "ཤུལ་མའི་བར་མཚམས་ཚུན་ཚོད་ སྐར་མ་གཅིག་ལས་ཉུངམ་།"
+
+#: ../typing-break/drwright.c:592
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"ཡིག་དཔར་བར་མཚམས་རྒྱུ་དངོས་ཀྱི་ ཌའི་ལོག་དེ་ འོག་གི་འཛོལ་བ་དང་གཅིག་ཁར་ འབག་འོང་མ་ཚུགས་: %s"
+
+#: ../typing-break/drwright.c:611
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "བྲིས་མི་ རི་ཅཱཌི་ཧཱལཊི་ <richard@imendio.com>"
+
+#: ../typing-break/drwright.c:612
+msgid "Eye candy added by Anders Carlsson"
+msgstr "ཨེན་ཌརསི་ ཀ་རཱལསི་སཱན་གྱིས་ ཁ་སྐོང་བརྐྱབས་མི་ ཨའི་ཀེན་ཌི།"
+
+#: ../typing-break/drwright.c:621
+msgid "A computer break reminder."
+msgstr "གློག་རིག་བར་མཚམས་ཀྱི་ དྲན་བསྐུལ་ཅིག"
+
+#: ../typing-break/drwright.c:623
+msgid "translator-credits"
+msgstr ""
+"ཨའི་ཌི་ཨར་སི་གི་ མ་དངུལ་རྒྱབ་སྐྱོར་ཐོག་ལས་ བརྡ་དོན་འཕྲུལ་རིག་ལས་ཁུངས་ནང་ སྐད་བསྒྱུར་འབད་ཡི། ཁ་གསལ་"
+"གྱི་དོན་ལུ་ འབྲེལ་བ་འཐབ་ས་: <pema_geyleg@druknet.bt>"
+
+#: ../typing-break/main.c:61
+msgid "Enable debugging code"
+msgstr "རྐྱེན་སེལ་འབད་བའི་ཨང་རྟགས་ལྕོགས་ཅན་བཟོ"
+
+#: ../typing-break/main.c:63
+msgid "Don't check whether the notification area exists"
+msgstr "བརྡ་བསྐུལ་གནས་ཁོངས་ཡོད་ག་མེད་ག་ཞིབ་དཔྱད་མ་འབད"
+
+#: ../typing-break/main.c:89
+msgid "Typing Monitor"
+msgstr "ཡིག་དཔར་བརྐྱབ་ནིའི་ལྟ་རྟོག་པ།"
+
+#: ../typing-break/main.c:105
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"ཡིག་དཔར་བརྐྱབ་ནིའི་གསལ་གཞི་དེ་གིས་ བརྡ་བསྐུལ་མངའ་ཁོངས་དེ་ བརྡ་དོན་བཀྲམ་སྟོན་གྱི་དོན་ལུ་ ལག་ལེན་འཐབ་"
+"ཨིན། ཁྱོད་ཀྱི་པེ་ནཱལ་གུ་ བརྡ་བསྐུལ་མངའ་ཁོངས་ མེདཔ་བཟུམ་ཅིག་འདུག ཁྱོད་ཀྱིས་ཁྱོད་རའི་པེ་ནཱལ་གུ་ གཡས་ཀྱི་ཨེབ་"
+"གཏང་འབད་དེ་ ‘པེ་ནཱལ་གུ་ཁ་སྐོང་རྐྱབས་’ ཟེར་མི་གདམ་ཁ་བརྐྱབས་པའི་སྒོ་ལས་ བརྡ་བསྐུལ་མངའ་ཁོངས་ སེལ་འཐུ་"
+"འབད་དེ་ ཁ་སྐོང་བརྐྱབ་ནི་ལུ་ ཨེབ་གཏང་འབད་བའི་ཐོག་ལས་ བརྡ་བསྐུལ་མངའ་ཁོངས་ ཁ་སྐོང་བརྐྱབ་ཚུགས།"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr "གློག་རིམ་ཡིག་གཟུགས་བཟུམ་སྦེ་ གཞི་སྒྲིག་འབད།"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+msgid "Sets the default application font"
+msgstr "སྔོན་སྒྲིག་གློག་རིམ་ཡིག་གཟུགས་དེ་ གཞི་སྒྲིག་འབད།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+"བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་ ཨོ་པཱན་ཊ་ཡིཔ་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་པི་སི་ཨེཕ་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+"བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་ ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+"བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ དེ་ལས་ ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"ལྡེ་མིག་འདི་ ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ "
+"བརྡ་བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+"ལྡེ་མིག་འདི་ ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ "
+"བརྡ་བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"ལྡེ་མིག་འདི་ ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ བརྡ་"
+"བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"ལྡེ་མིག་འདི་ ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཀྱི་དོན་ལས་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ བརྡ་"
+"བཀོད་ལུ་ གཞི་སྒྲིག་འབད།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "པི་སི་ཨེཕ་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཀྱི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "ཨོ་པཱན་ཊ་ཡིབ་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "པི་སི་ཨེཕ་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "ཊུ་ཊ་ཡིབ་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "ཊ་ཡིབ་༡གི་ ཡིག་གཟུགས་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr ""
+"ཨ་ཡིག་དཀར་མཛེས་ལས་འཁྲུངས་ཤེས་བློའི་གཏེར།། ཕས་རྒོལ་ཝ་སྐྱེས་ཟིལ་གནོན་གདོང་ལྔ་བཞིན།། ཆགས་ཐོགས་ཀུན་བྲལ་"
+"མཚུངས་མེད་འཇམ་དབྱངས་མཐུས།། མཧཱ་མཁས་པའི་གཙོ་བོར་ཉིད་གྱུར་ཅིག ༠༡༢༣༤༥༦༧༨༩"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "མིང་:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "བཟོ་རྣམ་:"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "དབྱེ་བ:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "ཚད་:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "ཐོན་རིམ་:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "འདྲ་བཤུས་དབང་ཆ་:"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "འགྲེལ་བཤད་:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "ལག་ལེན་: ཡིག་གཟུགས་ཡིག་སྣོད་%s \n"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+msgid "Font Viewer"
+msgstr "་ཡིག་གཟུགས་མཐོང་འབྱེད་ "
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "Preview fonts"
+msgstr "ཡིག་གཟུགས་ སྔོན་ལྟ་ "
+
+#: ../vfs-methods/fontilus/thumbnailer.c:242
+msgid "Text to thumbnail (default: Aa)"
+msgstr "མཐེ་གཟེར་ལུ་ཚིག་ཡིག་(སྔོན་སྒྲིག: Aa)"
+
+#: ../vfs-methods/fontilus/thumbnailer.c:242
+msgid "TEXT"
+msgstr "ཚིག་ཡིག"
+
+#: ../vfs-methods/fontilus/thumbnailer.c:244
+msgid "Font size (default: 64)"
+msgstr "ཡིག་གཟུགས་ཚད (སྔོན་སྒྲིག: ༦༤)"
+
+#: ../vfs-methods/fontilus/thumbnailer.c:244
+msgid "SIZE"
+msgstr "ཚད"
+
+#: ../vfs-methods/fontilus/thumbnailer.c:246
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr "ཡིག་གཟུགས་ཡིག་སྣོད་ ཨའུཊི་པུཊི་ཡིག་སྣོད"
+
+#: ../vfs-methods/fontilus/thumbnailer.c:262
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr "སྒྲུབ་རྟགས་མིང་དཔྱད་འབདཝ་ད་འཛོལ་བ : %s\n"
+
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr ""
+"<span weight=\"bold\" size=\"larger\">ཡིག་གཟུགས་གསརཔ་ འཇུག་སྤྱོད་འབད་ནི་ཨིན་ན?</span>"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "Do _not apply font"
+msgstr "ཡིག་གཟུགས་འཇུག་སྤྱོད་མ་འབད།(_n)"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"ཁྱོད་ཀྱིས་སེལ་འཐུ་འབད་མི་ བརྗོད་དོན་དེ་གིས་ ཡིག་གཟུགས་གསརཔ་ཅིག་གི་ བསམ་འཆར་བཀོདཔ་ཨིན་པས། ཡིག་"
+"གཟུགས་ཀྱི་སྔོན་ལྟ་ཅིག་ འོག་ལུ་སྟོན་ཏེ་ཡོད།"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid "_Apply font"
+msgstr "ཡིག་གཟུགས་འཇུག་སྤྱོད་འབད།(_A)"
+
+#: ../vfs-methods/themus/theme-method.c:485
+msgid "Themes"
+msgstr "བརྗོད་དོན་ཚུ།"
+
+#: ../vfs-methods/themus/themus-properties-view.c:127
+msgid "Description"
+msgstr "འགྲེལ་བཤད།"
+
+#: ../vfs-methods/themus/themus-properties-view.c:134
+msgid "Control theme"
+msgstr "ཚད་འཛིན་བརྗོད་དོན།"
+
+#: ../vfs-methods/themus/themus-properties-view.c:140
+msgid "Window border theme"
+msgstr "སྒོ་སྒྲིག་གི་མཐའ་མཚམས་ཀྱི་བརྗོད་དོན།"
+
+#: ../vfs-methods/themus/themus-properties-view.c:146
+msgid "Icon theme"
+msgstr "ངོས་དཔར་གྱི་བརྗོད་དོན།"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ གཞི་བཙུགས་འབད་མི་བརྗོད་དོན་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr "བདེན་པ་ལུ་གཞི་སྒྲིག་འབད་བ་ཅིན་ བརྗོད་དོན་ཚུ་ མཐེབ་གཟེར་བརྡབས་ཏེ་སྡོད་འོང་།"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+"ལྡེ་མིག་འདི་ གཞི་བཙུགས་འབད་དེ་ཡོད་མི་ བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་"
+"འཐབ་མི་ བརྡ་བཀོད་ལུ་གཞི་སྒྲིག་འབད།"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+"ལྡེ་མིག་འདི་ བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གསར་བསྐྲུན་འབད་ནི་ལུ་ ལག་ལེན་འཐབ་མི་ བརྡ་བཀོད་ལུ་གཞི་"
+"སྒྲིག་འབད།"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr "གཞི་བཙུགས་འབད་དེ་ཡོད་པའི་ བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr "བརྗོད་དོན་ཚུ་གི་དོན་ལུ་ མཐེབ་གཟེར་གྱི་བརྡ་བཀོད།"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr "གཞི་བཙུགས་འབད་དེ་ཡོད་པའི་ བརྗོད་དོན་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr "བརྗོད་དོན་ཚུ་ལུ་ མཐེབ་གཟེར་བརྡབ་ནི་ཨིན་ན་མེན།"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:58
+msgid "ABCDEFG"
+msgstr "ཀ་ཁ་ག་ང་།་ཅ་ཆ་ཇ་ཉ།"
+
+#: ../vfs-methods/themus/themus-theme-applier.c:84
+msgid "[FILE]"
+msgstr "[ཡིག་སྣོད]"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+msgid "Apply theme"
+msgstr "བརྗོད་དོན་ལག་ལེན་འཐབ།"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+msgid "Sets the default theme"
+msgstr "སྔོན་སྒྲིག་བརྗོད་དོན་ གཞི་སྒྲིག་འབད།"
+
+msgid "Show help options"
+msgstr "གྲོགས་རམ་གདམ་ཁ་ཚུ་སྟོན།"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "མཱའུསི་དགའ་གདམ་གྱི་ ཌའི་ལོག་ %s གསར་བཙུགས་འབདཝ་ད་ འཛོལ་བ་ཅིག་བྱུང་ནུག"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "ཡིག་སྣོད་'%sནང་ལས་ འཛུལ་སྤྱོད་ཨེགསི་གི་གཞི་སྒྲིག་ཚུ་ ནང་འདྲེན་འབད་མ་ཚུགས།"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "ཁྱད་རྣམ་གཞི་སྒྲིག་ཡིག་སྣོད་ ནང་འདྲེན་འབད།"
+
+#~ msgid "_Import"
+#~ msgstr "ནང་འདྲེན།(_I)"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "ཁྱོད་རའི་ལྡེ་སྒྲོམ་གྱི་ འཛུལ་སྤྱོད་དགའ་གདམ་ཚུ་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "རིམ་ལུགས་འདི་ལུ་ ཨེགསི་ཀེ་བི་ རྒྱ་བསྐྱེད་མེདཔ་བཟུམ་ཅིག་འདུག འདི་མེད་པར་ ལྡེ་སྒྲོམ་འདི་གི་ འཛུལ་སྤྱོད་ཁྱད་"
+#~ "རྣམ་གྱིས་ ལཱ་འབད་མི་བཏུབ།"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>མཱའུསི་གི་ལྡེ་མིག་ཚུ་ ལྕོགས་ཅན་བཟོ་</b>(_M)"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>ཡང་བསྐྱར་ལྡེ་མིག་ཚུ་ ལྕོགས་ཅན་བཟོ་</b>(_R)"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>ཁྱད་རྣམ་ཚུ་</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>ལྡེ་མིག་ཚུ་སོར་སྟོན་འབད་</b>"
+
+#~ msgid "Basic"
+#~ msgstr "གཞི་རྩ།"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr ""
+#~ "ཨེལ་ཌི་ཨི་ཅིག་ ཨཱོན་འབདཝ་ད་ བརྡ་སྐད་ཚར་གཅིག་དང་ གཅིག་ཨོཕ་རྐྱབ་ད་ བརྡ་སྐད་ཚར་གཉིས་རྐྱབས།"
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "ལྡེ་མིག་ཨེབ་གནོན་དང་ དཔག་བྱེད་སྤོ་བཤུད་ཀྱི་བར་ན་ ཕྱིར་འགྱངས།(_v)"
+
+#~ msgid "E_nable Toggle Keys"
+#~ msgstr "སོར་སྟོན་ལྡེ་མིག་ཚུ་ ལྕོགས་ཅན་བཟོ།(_n)"
+
+#~ msgid "Filters"
+#~ msgstr "ཚགས་མ།"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "ལག་ལེན་པའི་ སེལ་འཐུ་འབད་བཏུབ་པའི་ དུས་ཚོད་ནང་འཁོད་བྱུང་པ་ཅིན་ ལྡེ་མིག་ཅོག་གཅིགཔ་དེ་ ཤུལ་ལས་"
+#~ "ཨེབ་མི་ཚུ་ཆ་མཉམ་སྣང་མེད་སྦེ་་བཞག"
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད་ཀྱི་ དགའ་གདམ་ཚུ། (འཛུལ་སྤྱོད་ཨགེསི)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "དཔག་བྱེད་ཀྱི་ མགྱོགས་ཚད་མང་མཐའ་:(_x)"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "མཱའུསི་གི་དགའ་གདམ་ཚུ་...(_P)"
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "ལྡེ་མིག་ཚུ་ལུ་ཨེབ་ཞིནམ་ལས་ ལག་ལེན་པ་གིས་ བདེ་སྒྲིག་འབད་ཚུགས་པའི་ དུས་ཚོད་ཀྱི་དོན་ལུ་ འཆང་སྟེ་ཡོད་"
+#~ "པ་ཅིན་རྐྱངམ་གཅིག་ དང་ལེན་འབད།"
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "ལེགས་བཅོས་ཀྱི་ལྡེ་མིག་ཚུ་ གོ་རིམ་བཞིན་ཨེབ་པའི་ཐོག་ལས་ དུས་མཉམ་ལུ་ སྣ་མང་ལྡེ་མིག་ བཀོལ་སྤྱོད་ལག་ལེན་"
+#~ "འཐབ།"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "མགྱོགས་ཚད་ཀྱི་མང་མཐའ་ལུ་ མགྱོགས་བསྐྱོད་འབད་ནིའི་དུས་ཚོད།(_l)"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "ཨང་ཡིག་ལྡེ་མིག་གདན་དེ་ མཱའུསི་ཚད་འཛིན་གདན་ཅིག་ལུ་ བསྒྱུར་བཅོས་འབད།"
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr ":གི་དོན་ལུ་ ལག་ལེན་མ་འཐབ་པར་ཡོད་པ་ཅིན་ ལྕོགས་མིན་བཟོ།(_D)"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "ལྡེ་སྒྲོམ་འཛུལ་སྤྱོད་ཀྱི་ ཁྱད་རྣམ་ཚུ་ ལྕོགས་ཅན་བཟོ།(_E)"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "ཁྱད་རྣམ་གྱི་གཞི་སྒྲིག་ཚུ་ ནང་འདྲེན་འབད་...(_I)"
+
+#~ msgid "_accepted"
+#~ msgstr "དང་ལེན་འབད་ཡོདཔ།(_a)"
+
+#~ msgid "_pressed"
+#~ msgstr "ཨེབ་པ།(_p)"
+
+#~ msgid "_rejected"
+#~ msgstr "དང་ལེན་མེད་པ།(_r)"
+
+#~ msgid "characters/second"
+#~ msgstr "ཡིག་འབྲུ་/སྐར་ཆ།"
+
+#~ msgid "milliseconds"
+#~ msgstr "མི་ལི་སྐར་ཆ།"
+
+#~ msgid "pixels/second"
+#~ msgstr "པིག་སེལསི་/སྐར་ཆ།"
+
+#~ msgid "Go _to Fonts Folder"
+#~ msgstr "ཡིག་གཟུགས་ཀྱི་ཡིག་སྣོད་ལུ་འགྱོ(_t)"
+
+#~ msgid "Theme Details"
+#~ msgstr "བརྗོད་དོན་གྱི་རྒྱས་བཤད།"
+
+#~ msgid "gtk-delete"
+#~ msgstr "ཇི་ཊི་ཀེ་-བཏོན་གཏང་"
+
+#~ msgid ""
+#~ "<big><b>%s</b></big>\n"
+#~ "<b>Width:</b> %d %s\n"
+#~ "<b>Height:</b> %d %s\n"
+#~ "<b>Type:</b> %s\n"
+#~ "<b>Location:</b> %s"
+#~ msgstr ""
+#~ "<big><b>%s</b></big>\n"
+#~ "<b>རྒྱ་ཚད:</b> %d %s\n"
+#~ "<b>མཐོ་ཚད:</b> %d %s\n"
+#~ "<b>དབྱེ་བ:</b> %s\n"
+#~ "<b>གནས་ཁོངས:</b> %s"
+
+#~ msgid "The theme is an engine. You need to compile it."
+#~ msgstr "བརྗོད་དོན་དེ་ མ་འཕྲུལ་ཅིག་ཨིན། ཁྱོད་ཀྱིས་བརྗོད་དོན་དེ་ ཕྱོགས་སྒྲིག་འབད་དགོ།"
+
+#~ msgid "The file format is invalid"
+#~ msgstr "ཡིག་སྣོད་ཀྱི་རྩ་སྒྲིག་དེ་ ནུས་མེད་ཨིན་པས།"
+
+#~ msgid "This theme is not in a supported format."
+#~ msgstr "བརྗོད་དོན་འདི་ རྒྱབ་སྐྱོར་ལྡན་པའི་ རྩ་སྒྲིག་ཅིག་མེན་པས།"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "ཡིག་སྣོད་ཀྱི་རྩ་སྒྲིག་དེ་ ནུས་མེད་ཨིན་པས།"
+
+#~ msgid "Connecting..."
+#~ msgstr "མཐུད་དོ་..."
+
+#~ msgid "Preferred Assistive Technology"
+#~ msgstr "ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་རྒྱབ་སྐྱོར"
+
+#~ msgid "Mobility AT"
+#~ msgstr "འགུལ་སྐྱོད ཨེ་ཊི"
+
+#~ msgid "Run the the preferred GNOME Mobility Assitive Technology"
+#~ msgstr "དགའ་གདམ་བརྐྱབས་ཡོད་པའི་ཇི་ནོམ་འགུལ་སྐྱོད་ཕན་འཐབས་འཕྲུལ་རིག་གཡོག་བཀོལ"
+
+#~ msgid "Autostart the preferred AT"
+#~ msgstr "དགའ་གདམ་ཨེ་ཊི་རང་བཞིན་འགོ་བཙུགས"
+
+#~ msgid "Visual"
+#~ msgstr "མཐོང་བའི"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི་༡.༤།"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི་༡.༥།"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི་༡.༦།"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི་༢.༠།"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི་༢.༢།"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "ཨི་བོ་ལུ་ཤཱན་ ཡིག་འཕྲིན་ལྷག་མི་༢.༤།"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "འབྲེལ་ལམ་ཚིག་ཡིག་གི་ བརའུ་ཟར།"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "ལི་ནེགསི་ཚིག་ཡིག་གི་ བརའུ་ཟར།"
+
+#~ msgid "Simple OnScreen Keyboard"
+#~ msgstr "གསལ་གཞི་ལྡེ་སྒྲོམ་གུ་འཇམ་སམ"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "ཌབ་ལུ་༣ཨེམ་ཚིག་ཡིག་གི་ བརའུ་ཟར།"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "ཧུམ་ཆ་བདག་འཛིན་འབད་བཞག(_K)"
+
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "ལྡེ་སྒྲོམ་ལག་ཆས་ %s གསར་བཙུགས་འབད་ནི་ལུ་ འཛོལ་བ་ཅིག་བྱུང་ནུག"
+
+#~ msgid "_Accessibility"
+#~ msgstr "འཛུལ་སྤྱོད།(_A)"
+
+#~ msgid "Choose..."
+#~ msgstr "གདམ་ཁ་རྐྱབས་..."
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "མའི་ཀོརོ་སོཕཊི་གི་ རང་བཞིན་ལྡེ་སྒྲོམ།"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "འཛུལ་སྤྱོད་...(_A)"
+
+#~ msgid "%d millisecond"
+#~ msgid_plural "%d milliseconds"
+#~ msgstr[0] "མི་ལི་སྐར་ཆ་%d།"
+#~ msgstr[1] "མི་ལི་སྐར་ཆ་%d།"
+
+#~ msgid "Unknown Pointer"
+#~ msgstr "མ་ཤེས་པའི་དཔག་བྱེད།"
+
+#~ msgid "The default pointer that ships with X"
+#~ msgstr "ཨེགསི་དང་གཅིག་ཁར་ སྐྱེལ་འདྲེན་འབད་མི་ སྔོན་སྒྲིག་དཔག་བྱེད།"
+
+#~ msgid "The default pointer inverted"
+#~ msgstr "སྔོན་སྒྲིག་དཔག་བྱེད་གནས་ལོག་ཅན།"
+
+#~ msgid "Large version of normal pointer"
+#~ msgstr "སྤྱིར་བཏང་དཔག་བྱེད་ཀྱི་ཐོན་རིམ་ཆེ་བ།"
+
+#~ msgid "Large version of white pointer"
+#~ msgstr "དཔག་བྱེད་དཀར་པོའི་ ཐོན་རིམ་ཆེ་བ།"
+
+#~ msgid "Pointer Theme"
+#~ msgstr "དཔག་བྱེད་བརྗོད་དོན།"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>མགྱོགས་པར་</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>མཐོ་བ་</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>ཆེ་བ་</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>དམའ་བ་</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>ལྷོད་ཆ་</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>ཆུང་ཀུ་</i>"
+
+#~ msgid "Buttons"
+#~ msgstr "ཨེབ་རྟ་ཚུ།"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "ཁྱོད་ཀྱིས་ཚད་འཛིན་ཨེབ་ད་ དཔག་བྱེད་དེ་ གཙོ་དམིགས་འབདཝ་ཨིན།(_p)"
+
+#~ msgid "Motion"
+#~ msgstr "འགུལ་བསྐྱོད།"
+
+#~ msgid "Pointer Size:"
+#~ msgstr "དཔག་བྱེད་ཚད་:"
+
+#~ msgid "Pointers"
+#~ msgstr "དཔག་བྱེད་ཚུ།"
+
+#~ msgid ""
+#~ "Small\n"
+#~ "Medium\n"
+#~ "Large"
+#~ msgstr ""
+#~ "ཆུང་ཀུ\n"
+#~ "འབྲིང་མ\n"
+#~ "ཆེ་བ"
+
+#~ msgid "      "
+#~ msgstr "    "
+
+#~ msgid "Volume"
+#~ msgstr "སྐད་ཤུགས"
+
+#~ msgid "Slow Keys Alert"
+#~ msgstr "ལྡེ་མིག་དྲན་བརྡ་ལྷོད།"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱིས་སོར་ལྡེ་དེ་ སྐར་ཆ་༨ ཀྱི་རང་ལུ་ཨེབ་བཞག་དགོ ཁྱོད་ཀྱི་ལྡེ་སྒྲོམ་དེ་ ལཱ་འབད་ནི་ལུ་ ཕན་གནོད་ཡོད་"
+#~ "པའི་ ལྡེ་མིག་གི་ལྷོད་ཆའི་ཁྱད་རྣམ་དོན་ལུ་ མགྱོགས་ཐབས་འདི་ཨིན།"
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "ལྡེ་མིག་ལྷོད་ཆ་ ཤུགས་ལྡན་བཟོ་ནི་ཨིན་ན?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "ལྡེ་མིག་ལྷོད་ཆ་ ཤུགས་མེད་བཟོ་ནི་ཨིན་ན?།"
+
+#~ msgid "_Activate"
+#~ msgstr "ཤུགས་ལྡན་བཟོ།(_A)"
+
+#~ msgid "_Deactivate"
+#~ msgstr "ཤུགས་མེད་བཟོ།(_D)"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "ཤུགས་ལྡན་མ་བཟོ།(_n)"
+
+#~ msgid "Do_n't deactivate"
+#~ msgstr "ཤུགས་མེད་མ་བཟོ།(_n)"
+
+#~ msgid "Sticky Keys Alert"
+#~ msgstr "སྦྱར་རྩི་ཅན་གྱི་ལྡེ་མིག་དྲན་བརྡ།"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱིས་སོར་ལྡེ་དེ་ འབྱེལཝ་འབྱེལ་ས་རང་ ཚར་༥ ཨེབ། ཁྱོད་ཀྱི་ལྡེ་སྒྲོམ་དེ་ ལཱ་འབད་ནི་ལུ་ ཕན་གནོད་ཡོད་"
+#~ "པའི་ སྦྱར་རྩི་ལྡེ་མིག་གི་ཁྱད་རྣམ་དོན་ལུ་ མགྱོགས་ཐབས་འདི་ཨིན།"
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱིས་སྟབས་གཅིག་ལུ་ ལྡེ་མིག་གཉིས་ཨེབ་ ཡང་ན་ སོར་ལྡེ་དེ་ འབྱེལཝ་འབྱེལ་ས་རང་ ཚར་༥ཨེབ། འདི་གིས་ "
+#~ "ཁྱོད་ཀྱི་ལྡེ་སྒྲོམ་ལཱ་འབད་ནི་ལུ་ ཕན་གནོད་ཡོད་པའི་ སྦྱར་རྩི་ཅན་གྱི་ལྡེ་མིག་ཁྱད་རྣམ་དེ་ ཨོཕ་རྐྱབ་ཨིན།"
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "ཁྱོད་ཀྱིས་སྦྱར་རྩི་ཅན་གྱི་ ལྡེ་མིག་ཚུ་ ཤུགས་ལྡན་བཟོ་ནི་ཨིན་ན?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "ཁྱོད་ཀྱིས་སྦྱར་རྩི་ཅན་གྱི་ ལྡེ་མིག་ཚུ་ ཤུགས་མེད་བཟོ་ནི་ཨིན་ན?"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "སྣོད་ཐོ་\"%s\"གསར་བསྐྲུན་འབད་མི་ཚུགས་པས།\n"
+#~ "འདི་མཱའུསི་གི་དཔག་བྱེད་བརྗོད་དོན་ བསྒྱུར་བཅོས་འབད་བཅུག་ནི་ལུ་དགོཔ་ཨིན།"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "སྣོད་ཐོ་\"%s\"གསར་བསྐྲུན་འབད་མི་ཚུགས་པས།\n"
+#~ "འདི་འོད་རྟགས་ཚུ བསྒྱུར་བཅོས་འབད་བཅུག་ནི་ལུ་དགོཔ་ཨིན།"
+
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "ཀི་ བའིན་ཌིང་(%s) གིས་ དེ་ཉིད་ཀྱི་བྱ་བ་ ལན་ཐེངས་མང་རབས་ཅིག་ ངེས་འཛིན་འབད་ནུག\n"
+
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "ཀི་ བའིན་ཌིང་(%s) གིས་ དེ་ཉིད་ཀྱི་བཱའིན་ཌིང་ ལན་ཐེངས་མང་རབས་ཅིག་ ངེས་འཛིན་འབད་ནུག\n"
+
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "ཀི་ བའིན་ཌིང་ (%s) ཡོངས་སྒྲུབ་མིན་འདུག\n"
+
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "ཀི་ བའིན་ཌིང་(%s) ནུས་མེད་ཨིན་པས།\n"
+
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr ""
+#~ "གློག་རིམ་གཞན་ཅིག་གིས་ ཧེ་མ་ལས་རང་ ལྡེ་མིག་''%u'ནང་ འཛུལ་སྤྱོད་འབད་འབདཝ་བཟུམ་ཅིག་འདུག"
+
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "ཀི་ བཱའིན་ཌིང་(%s)དེ་ ཧེམ་ལས་རང་ ལག་ལེན་འཐབ་སྟེ་འདུག\n"
+
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "ལྡེ་མིག་(%s)ལུ་འབྲེལ་མཐུད་ཡོད་མི་\n"
+#~ "(%s)གཡོག་བཀོལ་ནིའི་ འབད་རྩོལ་བསྐྱེདཔ་ད་ འཛོལ་བ་ཅིག་བྱུང་ནུག"
+
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "ཨེགསི་ཀེ་བི་ ཤུགས་ལྡན་བཟོ་ནི་ལུ་འཛོལ་བ།\n"
+#~ "འདི་ཆ་རྐྱེན་སྣ་ཚོགས་ཀྱི་ཐོག་ལུ་འབྱུང་མི་དེ་ཡང་།\n"
+#~ "-libxklavier དཔེ་མཛོད་ནང་ རྐྱེན་ཅིག་ཡོད་པའི་སྐབས་དང་།\n"
+#~ "-(xkbcomp, xmodmap utilities) ནང་རྐྱེན་ཅིག་ཡོད་པའི་སྐབས།\n"
+#~ "-ཨེགསི་སར་བར་ མཐུན་འགྱུར་མེད་པའི་ libxkbfile བསྟར་སྤྱོད་འབད་བའི་་སྐབས།\n"
+#~ "\n"
+#~ "ཨེགསི་སར་བར་ཐོན་རིམ་གནད་སྡུད།\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "ཁྱོད་ཀྱིས་གནས་སྟངས་འདི་ རྐྱེན་ཅིག་སྦེ་ སྙན་ཞུ་འབད་བ་ཅིན་ གྲངས་སུ་བཙུགས་གནང་དགོཔ་: \n"
+#~ "-<b>%s</b>གི་གྲུབ་འབྲས།\n"
+#~ "-<b>%s</b>གི་གྲུབ་འབྲས།"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱིས་ཨེགསི་ཕིརི་ ༤.༣.༠.ལག་ལེན་འཐབ་དོ།\n"
+#~ "མགུ་ཐོམས་པའི་ ཨེགསི་ཀེ་བི་ རིམ་སྒྲིག་དང་གཅིག་ཁར་ ཡོངས་གྲགས་ཡོད་པའི་དཀའ་ངལ་ཚུ་ཡོད།\n"
+#~ "རིམ་སྒྲིག་འཇམ་སམ་ཅིག་ ལག་ལེན་འཐབ་ ཡང་ཅིན་ ཨེགསི་ཕིརི་མཉེན་ཆས་ཀྱི་ ཐོན་རིམ་གསརཔ་ཅིག་ ལེན་ཐབས་"
+#~ "འབད་།"
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "ཉེན་བརྡ་འདི་ལོག་སྟེ་མ་སྟོན།(_n)"
+
+#~ msgid ""
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.</b>\n"
+#~ "\n"
+#~ "Expected was %s, but the the following settings were found: %s.\n"
+#~ "\n"
+#~ "Which set would you like to use?"
+#~ msgstr ""
+#~ "<b>ཨེགསི་རིམ་ལུགས་ཀྱི་ ལྡེ་སྒྲོམ་སྒྲིག་སྟངས་ཚུ་ ད་ལྟོ་ཁྱོད་ཀྱི་ ཇི་ནོམ་ལྡེ་སྒྲོམ་གྱི་ སྒྲིག་སྟངས་ཚུ་དང་མི་འདྲ་"
+#~ "བས། </b>\n"
+#~ "\n"
+#~ "རེ་བ་བསྐྱེད་མི་དེ་%sཨིན་རུང་ འོག་གི་སྒྲིག་སྟངས་%sཚུ་འདུག\n"
+#~ "\n"
+#~ "ཆ་ཚན་ག་དེ་ ལག་ལེན་འཐབ་ནི་སྨོ?"
+
+#~ msgid "Use X settings"
+#~ msgstr "ཨེགསི་གཞི་སྒྲིག་ཚུ་ ལག་ལེན་འཐབ།"
+
+#~ msgid "Keep GNOME settings"
+#~ msgstr "ཇི་ནོམ་སྒྲིག་སྟངས་ཚུ་བཞག"
+
+#~ msgid ""
+#~ "Could not get default terminal. Verify that your default terminal command "
+#~ "is set and points to a valid application."
+#~ msgstr ""
+#~ "སྔོན་སྒྲིག་ཊར་མི་ནཱལ་ཐོབ་མ་ཚུགས། ཁྱོད་ཀྱི་སྔོན་སྒྲིག་ཊར་མི་ནཱལ་བརྡ་བཀོད་གཞི་སྒྲིག་འབད་ཡོད་མི་དང་ནུས་ཅན་"
+#~ "འཇུག་སྤྱོད་ལུ་དོན་ཚན་ཚུ་བདེན་སྦྱོར་འབད།"
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this is a valid command."
+#~ msgstr ""
+#~ "བརྡ་བཀོད་ %s ལག་ལེན་འཐབ་མ་ཚུགས། \n"
+#~ "འདི་ནུས་ཅན་བརྡ་བཀོད་ཨིན་ཟེར་བདེན་སྦྱོར་འབད། "
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "གློག་འཕྲུལ་དེ་ གཉིད་ནང་བཙུགས་མ་ཚུགས།\n"
+#~ "གློག་འཕྲུལ་དེ་ངེས་བདེན་སྦེ་ རིམ་སྒྲིག་འབད་མ་འབད་ བདེན་སྦྱོར་འབད།"
+
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "གསལ་གཞི་ཉེན་སྲུང་ འགོ་བཙུགས་ནི་ལུ་ འཛོལ་བ་ཅིག་བྱུང་ནུག \n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "གསལ་གཞི་ཉེན་སྲུང་གི་ ལས་འགན་ཚུ་གིས་ ལཱ་ཡུན་འདི་ནང་ ལཱ་འབད་མི་བཏུབ།"
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "འཕྲིན་དོན་འདི་ ལོག་སྟེ་མ་སྟོན།(_D)"
+
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "སྒྲ་སྐད་ཡིག་སྣོད་%sདེ་ དཔེ་ཚད་%sསྦེ་ མངོན་གསལ་འབད་མ་ཚུགས།"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "ལག་ལེན་པའི་ ཁྱིམ་གྱི་སྣོད་ཐོ་ ངོས་འཛིན་འབད་མི་ཚུགས་པས།"
+
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "ཇི་ཀཱོནཕི་ལྡེ་མིག་%sདེ་ དབྱེ་བ་%sལུ་ གཞི་སྒྲིག་འབད་ནུག དེ་འབདཝ་ད་ རེ་བ་བསྐྱེད་མི་དབྱེ་བ་དེ་%sཨིན་"
+#~ "པས།\n"
+
+#~ msgid "A_vailable files:"
+#~ msgstr "འཐོབ་ཚུགས་པའི་ཡིག་སྣོད་ཚུ།(_v)"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "ཉེན་བརྡ་འདི་ ལོག་སྟེ་མ་སྟོན།(_n)"
+
+#~ msgid "Load modmap files"
+#~ msgstr "མོཌི་མེཔ་ཡིག་སྣོད་ཚུ་ མངོན་གསལ་འབད།"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "ཁྱོད་ཀྱིས་ མོཌི་མེཔ་ཡིག་སྣོད་(ཚུ) མངོན་གསལ་འབད་ནི་ཨིན་ན?"
+
+#~ msgid "_Load"
+#~ msgstr "མངོན་གསལ་འབད།(_L)"
+
+#~ msgid "_Loaded files:"
+#~ msgstr "མངོན་གསལ་འབད་ཡོད་པའི་ཡིག་སྣོད་ཚུ་:(_L)"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "བརྡ་མཚོན་རྒྱུད་དུང་ གསར་བསྐྲུན་འབད་ནི་ལུ་འཛོལ་བ།"
+
+#~ msgid "Type"
+#~ msgstr "དབྱེ་བ།"
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "བི་ཇི་ འཇུག་སྤྱོད་པའི་དབྱེ་བ: རྩ་བའི་སྒོ་སྒྲིག་གི་དོན་ལུ་ བི་ཇི་ ཨེཔ་ལའི་ཡར་ རྩ་བ། ཡང་ཅིན་ སྔོན་ལྟའི་"
+#~ "དོན་ལུ་ བི་ཇི་ འཇུག་སྤྱོད་པ་-སྔོན་ལྟ"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "འཇུག་སྤྱོད་པ་དེ་ སྔོན་ལྟ་ཨིན་པ་ཅིན་ རྒྱ་ཚད: ༦༤ ལུ་ སྔོན་སྒྲིག་འབདཝ་ཨིན།"
+
+#~ msgid "Preview Height"
+#~ msgstr "མཐོ་ཚད་སྔོན་ལྟ་འབད།"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "འཇུག་སྤྱོད་པ་དེ་ སྔོན་ལྟ་ཨིན་པ་ཅིན་ མཐོ་ཚད: ༤༨ ལུ་ སྔོན་སྒྲིག་འབདཝ་ཨིན།"
+
+#~ msgid "Screen"
+#~ msgstr "གསལ་གཞི།"
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "བི་ཇི་འཇུག་སྤྱོད་པ་ འབྲི་སའི་གསལ་གཞི།"
+
+#~ msgid "Edited %m/%d/%Y"
+#~ msgstr "ཞུན་དག་འབད་ཡོད་པའི་ %m/%d/%Y"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "བདེན་པ་ཨིན་པ་ཅིན་ ཚིག་ཡིག་/ཡིག་རྐྱང་དང་ ཚིག་ཡིག་/* གི་དོན་ལུ་ མ་ཡིམ་ལེགས་སྐྱོང་འཐབ་མི་ཚུ་ མིང་"
+#~ "དཔྱད་ནང་བཞག་ནི་ཨིན།"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "ཚིག་ཡིག་/ཡིག་རྐྱང་དང་ ཚིག་ཡིག་/* ལེགས་སྐྱོང་འཐབ་མི་ཚུ་ མིང་དཔྱད་འབད།"
+
+#~ msgid "E-mail"
+#~ msgstr "གློག་འཕྲིན།"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "གློག་འཕྲིན་གྱི་མགྱོགས་ཐབས།"
+
+#~ msgid "Eject"
+#~ msgstr "ཕྱིར་བཏོན།"
+
+#~ msgid "Eject's shortcut."
+#~ msgstr "ཕྱིར་བཏོན་གྱི་མགྱོགས་ཐབས།"
+
+#~ msgid "Home folder"
+#~ msgstr "ཁྱིམ་གྱི་ལེ་སྣོད།"
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "ཁྱིམ་གྱི་ལེ་སྣོད་ཀྱི་མགྱོགས་ཐབས།"
+
+#~ msgid "Launch help browser"
+#~ msgstr "བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་འབད།"
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་ཀྱི་ མགྱོགས་ཐབས།"
+
+#~ msgid "Launch web browser"
+#~ msgstr "ཝེབ་བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་འབད"
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "ཝེབ་བརའུ་ཟར་གྲོགས་རམ་ གསར་བཙུགས་ཀྱི་ མགྱོགས་ཐབས།"
+
+#~ msgid "Lock screen"
+#~ msgstr "གསལ་གཞི་ལྡེ་མིག་རྐྱབས།"
+
+#~ msgid "Lock screen's shortcut."
+#~ msgstr "གསལ་གཞི་ལྡེ་མིག་བརྐྱབ་ནིའི་མགྱོགས་ཐབས།"
+
+#~ msgid "Log out"
+#~ msgstr "ཕྱིར་བསྐྱོད་འབད།"
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "ཕྱིར་བསྐྱོད་མགྱོགས་ཐབས།"
+
+#~ msgid "Media player"
+#~ msgstr "བརྡ་བརྒྱུད་གཏང་འཕྲུལ"
+
+#~ msgid "Media player key's shortcut."
+#~ msgstr "བརྡ་ལམ་གཏང་མི་ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "ཤུལ་མའི་གླུ་གཞས་ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
+
+#~ msgid "Pause"
+#~ msgstr "ཐེམ།"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "ཐེམ་ནིའི་ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
+
+#~ msgid "Play (or play/pause)"
+#~ msgstr "གཏང་། (ཡང་ན་ གཏང་/ཐེམ)"
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "གཏང་། (ཡང་ན་ ་གཏང་/ཐེམ) ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "ཧེ་མའི་གླུ་གཞས་ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
+
+#~ msgid "Search's shortcut."
+#~ msgstr "འཚོལ་ཞིབ་ཀྱི་མགྱོགས་ཐབས།"
+
+#~ msgid "Skip to next track"
+#~ msgstr "གླུ་རིམ་གཞན་མི་ལུ་གོམ་འགྱོ།"
+
+#~ msgid "Skip to previous track"
+#~ msgstr "ཧེ་མའི་གླུ་རིམ་ལུ་གོམ་འགྱོ།"
+
+#~ msgid "Sleep"
+#~ msgstr "ཉལ།"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "ཉལ་ནིའི་མགྱོགས་ཐབས།"
+
+#~ msgid "Stop playback key"
+#~ msgstr "ལོག་གཏང་ནི་ མཚམས་འཇོག་གི་ལྡེ་མི"
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "ལོག་གཏང་ནི་མཚམས་འཇོག་གི་ ལྡེ་མིག་གི་མགྱོགས་ཐབས།"
+
+#~ msgid "Volume down"
+#~ msgstr "སྐད་ཤུགས་མར་ཕབ།"
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "སྐད་ཤུགས་མར་ཕབ་ཀྱི་མགྱོགས་ཐབས།"
+
+#~ msgid "Volume mute"
+#~ msgstr "སྐད་མེད།"
+
+#~ msgid "Volume mute's shortcut."
+#~ msgstr "སྐད་ཤུགས་སྐད་མེད་ཀྱི་མགྱོགས་ཐབས།"
+
+#~ msgid "Volume step"
+#~ msgstr "སྐད་ཤུགས་ཀྱི་རིམ་པ།"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "སྐད་ཤུགས་རིམ་པ་ སྐད་ཤུགས་བརྒྱ་ཆའི་ནང་།"
+
+#~ msgid "Volume up"
+#~ msgstr "སྐད་ཤུགས་ཡར་སེང་།"
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "སྐད་ཤུགས་ཡར་སེང་གི་མགྱོགས་ཐབས།"
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr ""
+#~ "ཨེགསི་གསལ་གཞི་ཉེན་སྲུང་ གཡོག་བཀོལ་ཕའི་སྐབས་ འཛོལ་བ་བྱུང་པ་ཅིན་ ཌའི་ལོག་ཅིག་ བཀྲམ་སྟོན་འབད།"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "ནང་བསྐྱོད་ཀྱི་སྐབས་ལུ་ གསལ་གཞི་ཉེན་སྲུང་ གཡོག་བཀོལ།"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "་འགོ་བཙུགས་ཀྱི་འཛོལ་བ་ཚུ་སྟོན།"
+
+#~ msgid "Start screensaver"
+#~ msgstr "གསལ་གཞི་ཉེན་སྲུང་འགོ་བཙུགས།"
+
+#~ msgid "<b>Applications</b>"
+#~ msgstr "<b>གློག་རིམ་</b>"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>རྒྱབ་སྐྱོར་</b>"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "ཁྱོད་ཀྱིས་ནང་བསྐྱོད་ཚར་རེ་འབདཝ་ད་ ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་འདི་ཚུ་འགོ་བཙུགས།"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱི་རིམ་ལུགས་གུ་ ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་མི་འཐོབ་པས། གསལ་གཞི་གུ་ལྡེ་སྒྲོམ་གྱི་རྒྱབ་སྐྱོར་ འཐོབ་"
+#~ "ནིའི་དོན་ལུ་ 'ཇི་ཨོ་ཀེ་' ཐུམ་སྒྲིལ་དེ་ གཞི་བཙུགས་འབད་དགོ། གསལ་གཞི་ལྷག་ནི་དང་ ཆེར་བསྐྱེད་ཀྱི་ལྕོགས་"
+#~ "གྲུབ་ཀྱི་དོན་ལུ་ 'ཨོ་ཨར་སི་ཨེ་' ཐུམ་སྒྲིལ་དེ་ གཞི་བཙུགས་འབད་དགོ།"
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱི་རིམ་ལུགས་གུ་ འཐོབ་ཚུགས་པའི་ ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་ཚུ་ཆ་མཉམ་ གཞི་བཙུགས་མ་འབད་བས། "
+#~ "གསལ་གཞི་གུའི་ ལྡེ་སྒྲོམ་རྒྱབ་སྐྱོར་ འཐོབ་ཐབས་ནི་ལུ་ ‘ཇི་ཨོ་ཀེ་’ ཐུམ་སྒྲིལ་དེ་ གཞི་བཙུགས་འབད་དགོ"
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱི་རིམ་ལུགས་གུ་ འཐོབ་ཚུགས་པའི་ ཕན་ཐབས་ཅན་གྱི་ འཕྲུལ་རིག་ཚུ་ཆ་མཉམ་ གཞི་བཙུགས་མ་འབད་བས། "
+#~ "གསལ་གཞི་ལྷག་ནི་དང་ ཆེར་བསྐྱེད་ཀྱི་ལྕོགས་གྲུབ་དོན་ལུ་ 'ཨོ་ཨར་སི་ཨེ་་' ཐུམ་སྒྲིལ་དེ་ གཞི་བཙུགས་འབད་"
+#~ "དགོ།"
+
+#~ msgid "Change your Desktop Background settings"
+#~ msgstr "ཁྱོད་རའི་ཌེཀསི་ཊོཔ་གི་ རྒྱབ་གཞིའི་གཞི་སྒྲིག་ཚུ་ བསྒྱུར་བཅོས་འབད།"
+
+#~ msgid "Desktop Background"
+#~ msgstr "ཌེཀསི་་ཊོཔ་གི་རྒྱབ་གཞི།"
+
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "ཌེཀསི་ཊོཔགི་ རྒྱབ་གཞིའི་དགའ་གདམ་ཚུ།"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "གྱང་ཤོག་ཁ་སྐོང་རྐྱབས།(_A)"
+
+#~ msgid "_Finish"
+#~ msgstr "རྫོགས།(_F)"
+
+#~ msgid "_Remove"
+#~ msgstr "རྩ་བསྐྲད་གཏང་།(_R)"
+
+#~ msgid "Centered"
+#~ msgstr "དབུས་སྒྲིག"
+
+#~ msgid "Fill Screen"
+#~ msgstr "གསལ་གཞི་བཀང་།"
+
+#~ msgid "Scaled"
+#~ msgstr "ཆ་ཚད་འཇལ་ཡོདཔ།"
+
+#~ msgid "Zoom"
+#~ msgstr "རྒྱས་ཟུམ།"
+
+#~ msgid "Tiled"
+#~ msgstr "ཊའིལཌི་།"
+
+#~ msgid "Solid Color"
+#~ msgstr "་ཚོས་གཞི་རགས་པ།"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "ཐད་སྙོམས་སྟེགས་རིས།"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "ཀེར་ཕྲང་སྟེགས་རིས།"
+
+#~ msgid "- Desktop Background Preferences"
+#~ msgstr "- ཌེཀསི་ཊོཔགི་ རྒྱབ་གཞིའི་དགའ་གདམ་ཚུ་"
+
+#~ msgid "background size|%s, %d %s x %d %s"
+#~ msgstr "རྒྱབ་གཞི་ཚད་|%s, %d %s x %d %s"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "ཌེཀསི་ཊོཔ་གི་དོན་ལུ་ ཡིག་གཟུགས་སེལ་འཐུ་འབད།"
+
+#~ msgid "Font Preferences"
+#~ msgstr "ཡིག་གཟུགས་ཀྱི་དགའ་གདམ་ཚུ།"
+
+#~ msgid "Medium"
+#~ msgstr "འབྲིང་མ་།"
+
+#~ msgid "Theme deleted succesfully. Please select another theme."
+#~ msgstr "བརྗོད་དོན་མཐར་འཁྱོལ་སྦེ་བཏོན་བཏང་ཡོད། བརྗོད་དོན་གཞན་ཅིག་སེལ་འཐུ་འབད་གནང་།"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "ཁྱོད་ཀྱི་རིམ་ལུགས་ལུ་ བརྗོད་དོན་ག་ནི་ཡང་འཚོལ་མ་ཐོབ། འདི་གི་རྒྱུ་མཚན་ཡང་ ཁྱོད་ཀྱི་\"Theme "
+#~ "Preferences\" ཌའི་ལོག་དེ་ ཚུལ་མིན་འབད་ གཞི་བཙུགས་འབད་ཡོདཔ་འོང་ནི་མས། ཡང་ཅིན་ ཁྱོད་ཀྱིས་ "
+#~ "\"gnome-themes\" ཐུམ་སྒྲིལ་དེ་ གཞི་བཙུགས་མ་འབདཝ་འོང་ནི་མས།"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "གཞི་བཙུགས་འབད་ནིའི་དོན་ལུ་ ཡིག་སྣོད་ཀྱི་གནས་ཁོངས་ ངོས་འཛིན་འབད་མི་དེ་ ནུས་མེད་ཨིན་པས།"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "ཁྱོད་ཀྱིས་བརྗོད་དོན་འདི་ བརྗོད་དོན་བསྲུང་ནིའི་ཨེབ་རྟ་གུ་ ཨེབ་པའི་ཐོག་ལས་བསྲུང་ཚུགས།"
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "སྔོན་སྒྲིག་བརྗོད་དོན་ལས་འཆར་དེ་ ཁྱོད་ཀྱི་རིམ་ལུགས་ནང་ འཚོལ་མ་ཐོབ། དེ་གི་རྒྱུ་མཚན་ཡང་ ཁྱོད་ཀྱིས་མེ་ཊ་"
+#~ "སི་ཊི་ གཞི་བཙུགས་མ་འབདཝ་འོང་ནི་དང་ ཡང་ཅིན་ ཁྱོད་ཀྱི་ཇི་ཀཱོནཕ་དེ་ བདེན་མེད་སྦེ་ གཞི་བཙུགས་འབད་"
+#~ "འབདཝ་འོང་ནི་མས།"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "ཌེཀསི་ཊོཔ་གི་ ཡན་ལག་སོ་སོའི་དོན་ལུ་ བརྗོད་དོན་ཚུ་སེལ་འཐུ་འབད།"
+
+#~ msgid "<b>You do not have permission to change theme settings</b>"
+#~ msgstr "<b>ཁྱོད་ལུ་བརྗོད་དོན་གྱི་སྒྲིག་སྟངས་ བསྒྱུར་བཅོས་འབད་ནི་གི་ གནང་བ་མིན་འདུག།</b>"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr ""
+#~ "བརྗོད་དོན་འདི་གིས་ དམིགས་བསལ་གྱི་ཡིག་གཟུགས་དང་རྒྱབ་གཞིའི་ བསམ་འཆར་ག་ནི་ཡང་ མི་བཀོད་པས།"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "བརྗོད་དོན་འདི་གིས་ ཡིག་གཟུགས་ཅིག་དང་ རྒྱབ་གཞི་ཅིག་གི་ བསམ་འཆར་བཀོདཔ་མས།"
+
+#~ msgid "_Install Theme..."
+#~ msgstr "བརྗོད་དོན་གཞི་བཙུགས་འབད་...(_I)"
+
+#~ msgid "_Revert"
+#~ msgstr "རྒྱབ་ལོག་འབད།(_R)"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "བརྗོད་དོན་སྲུངས་...(_S)"
+
+#~ msgid "theme selection tree"
+#~ msgstr "བརྗོད་དོན་སེལ་འཐུའི་རྩ་འབྲེལ།"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "གློག་རིམ་ཚུ་ནང་ ལག་ཆས་ཕྲ་རིང་དང་ དཀར་ཆག་ཕྲ་རིང་གི་ འབྱུང་སྣང་དེ་ སྲོལ་སྒྲིག་འབད།"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>སྤྱོད་ལམ་དང་འབྱུང་སྣང་b>"
+
+#~ msgid "Icons only"
+#~ msgstr "ངོས་དཔར་ཚུ་རྐྱངམ་གཅིག"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "དཀར་ཆག་དང་ ལག་ཆས་ཕྲ་རིང་གི་ དགའ་གདམ་ཚུ།"
+
+#~ msgid "Text below icons"
+#~ msgstr "ངོས་དཔར་འོག་གི་ ཚིག་ཡིག་ཚུ།"
+
+#~ msgid "Text beside icons"
+#~ msgstr "ངོས་དཔར་ཟུར་ཁའི་ ཚིག་ཡིག་ཚུ།"
+
+#~ msgid "Text only"
+#~ msgstr "ཚིག་ཡིག་རྐྱངམ་གཅིག"
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "འཕྱལ་བཏུབ་པའི་ ལག་ཆས་ཕྲ་རིང་།(_D)"
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "Window Management"
+#~ msgstr "སྒོ་སྒྲིག་འཛིན་སྐྱོང་།"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "འཐོབ་ཚུགས་པའི་སྒྲིག་བཀོད་ཚུ་:(_v)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- ཇི་ནོམ་མཱའུསི་གི་དགའ་གདམ་ཚུ་"
+
+#~ msgid "Save Color Scheme"
+#~ msgstr "ཚོས་གཞིའི་འཆར་ལས་སྲུང་བཞག་འབད་"
+
+#~ msgid "Save color scheme as:"
+#~ msgstr "བཟུམ་སྦེ་ ཚོས་གཞི་འཆར་ལས་སྲུང་བཞག་འབད་"
+
+#~ msgid ""
+#~ " \n"
+#~ "Custom"
+#~ msgstr ""
+#~ " \n"
+#~ "སྲོལ་སྒྲིག"
+
+#~ msgid "S_aved schemes:"
+#~ msgstr "སྲུང་བཞག་འབད་པའི་འཆར་ལས་ཚུ་:(_a)"
+
+#~ msgid "_Enable custom colors"
+#~ msgstr "སྲོལ་སྒྲིག་ཚོས་གཞི་ཚུ་ ལྕོགས་ཅན་བཟོ་ (_E)"
+
+#~ msgid "Help Unavailable"
+#~ msgstr "གྲོགས་རམ་འཐོབ་ཚུགསཔ་མེད་"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "ཇི་ནོམ་ཚད་འཛིན་ལྟེ་བ།"
+
+#~ msgid "From:"
+#~ msgstr "ལས་:"
+
+#~ msgid "To:"
+#~ msgstr "ལུ་:"
+
+#~ msgid "Sound & Video Preferences"
+#~ msgstr "སྒྲ་སྐད་དང་ཝི་ཌིའོ་དགའ་གདམ་ཚུ།"
+
+#~ msgid ""
+#~ "Can not install themes. \n"
+#~ "The gzip utility is not installed."
+#~ msgstr ""
+#~ "བརྗོད་དོན་ཚུ་ གཞི་བཙུགས་འབད་མ་ཚུགས།\n"
+#~ "ཇི་ཛིཔ་གི་སྤྱོད་ཆས་དེ་ གཞི་བཙུགས་མ་འབད་བས།"
+
+#~ msgid ""
+#~ "<span weight=\"bold\" size=\"larger\">The theme \"%s\" has been installed."
+#~ "</span>\n"
+#~ "\n"
+#~ "Would you like to apply it now, or keep your current theme?"
+#~ msgstr ""
+#~ "<ལྗིད་ཚད་=\"bold\" ཚད་=\"larger\"> བརྗོད་དོན་ \"%s\" དེ་གཞི་བཙུགས་འབད་ཡི། </span>\n"
+#~ "\n"
+#~ "ཁྱོད་ཀྱིས་ད་ལྟོ་རང་ འཇུག་སྤྱོད་འབད་ནི་ཨིན་ན ཡང་ན་ ཁྱོད་རའི་ད་ལྟོ་གི་ བརྗོད་དོན་དེ་རང་ བཞག་ནི་ཨིན་"
+#~ "ན?"
+
+#~ msgid "Theme _Details"
+#~ msgstr "བརྗོད་དོན་གྱི་རྒྱས་བཤད་ཚུ།(_D)"
+
+#~ msgid "Desktop Preferences"
+#~ msgstr "ཌེཀསི་ཊོཔ་གི་ དགའ་གདམ་ཚུ།"
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "གེལེཌི་ཡིག་སྣོད་ མངོན་གསལ་འབད་མ་ཚུགས།\n"
+#~ "ཌེ་མཱོན་འདི་ ཚུལ་ལྡན་སྦེ་ གཞི་བཙུགས་འབད་ཡོདཔ་ ངེས་གཏན་བཟོ།"
+
+#~ msgid ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+#~ msgstr ""
+#~ "ལྡེ་སྒྲོམ་གྱི་གནས་ལུགས་དེ་ ཡང་བསྐྱར་མངོན་གསལ་འབད་བའི་སྐབས་ གཡོག་བཀོལ་ནིའི་ ཡིག་ཚུགས་ཀྱི་བསྡུ་གསོག  "
+#~ "ཨེགསི་མོཌི་མེཔ་ལུ་བརྟེན་པའི་ བདེ་སྒྲིག་ཚུ་ ལོག་འཇུག་སྤྱོད་འབད་ནིའི་དོན་ལུ་ ཕན་ཐོགས་ཡོདཔ་ཨིན།"
+
+#~ msgid "A list of modmap files available in the $HOME directory."
+#~ msgstr "$ ཁྱིམ་གྱི་སྣོད་ཐོ་ནང་ འཐོབ་ཚུགས་པའི་ མོཌི་མེཔ་ཡིག་སྣོད་ཚུ་གི་ ཐོ་ཡིག་ཅིག"
+
+#~ msgid "Default group, assigned on window creation"
+#~ msgstr "སྔོན་སྒྲིག་སྡེ་ཚན་ སྒོ་སྒྲིག་གསར་བསྐྲུན་སྐབས་ལུ་ འགན་སྤྲོད་འབད་ཡོདཔ།"
+
+#~ msgid "Keep and manage separate group per window"
+#~ msgstr "སྒོ་སྒྲིག་རེའི་དོན་ལུ་ སྡེ་ཚན་སོ་སོ་བཞག་སྟེ་ འཛིན་སྐྱོང་འཐབ།"
+
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "ལྡེ་སྒྲོམ་དུས་མཐུན་གྱི་ ལེགས་སྐྱོང་པ།"
+
+#~ msgid "Keyboard layout"
+#~ msgstr "ལྡེ་སྒྲོམ་སྒྲིག་བཀོད།"
+
+#~ msgid "Keyboard model"
+#~ msgstr "ལྡེ་སྒྲོམ་གྱི་དཔེ།"
+
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr ""
+#~ "ཇི་ཀཱནོཕ་ནང་ ལྡེ་སྒྲོམ་གྱི་གཞི་སྒྲིག་ཚུ་ རིམ་ལུགས་ཨེ་ཨེསི་ཨེ་པི་(ངོས་ལེན་མེདཔ་)ནང་ལས་ ཟུར་ཁར་བཞག་ནི་"
+#~ "ཨིན།"
+
+#~ msgid "Save/restore indicators together with layout groups"
+#~ msgstr "བརྡ་སྟོན་པ་ཚུ་ སྒྲིག་བཀོད་སྡེ་ཚན་ཚུ་དང་གཅིག་ཁར་ སྲུངས་/སོར་ཆུད་འབད།"
+
+#~ msgid "Show layout names instead of group names"
+#~ msgstr "སྡེ་ཚན་མིང་གི་ཚབ་ལུ་ སྒྲིག་བཀོད་ཀྱི་མིང་ཚུ་སྟོན།"
+
+#~ msgid ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+#~ msgstr ""
+#~ "སྡེ་ཚན་མིང་གི་ཚབ་ལུ་ སྒྲིག་བཀོད་ཀྱི་མིང་ཚུ་སྟོན། (ཨེགསི་ཕིརི་གིས་ རྒྱབ་སྐྱོར་འབད་མི་ སྣ་མང་སྒྲིག་བཀོད་ཀྱི་"
+#~ "ཐོན་རིམ་ཚུ་གི་དོན་ལུ་རྐྱངམ་གཅིག)"
+
+#~ msgid "Suppress the \"X sysconfig changed\" warning message"
+#~ msgstr "\"X sysconfig changed\" གི་ ཉེན་བརྡའི་འཕྲིན་དོན་དེ་ མར་མནོན་འབད།"
+
+#~ msgid "The Keyboard Preview, X offset"
+#~ msgstr "ལྡེ་སྒྲོམ་སྔོན་ལྟ། ཨེགསི་པར་ལེན།"
+
+#~ msgid "The Keyboard Preview, Y offset"
+#~ msgstr "ལྡེ་སྒྲོམ་སྔོན་ལྟ། ཝའི་པར་ལེན།"
+
+#~ msgid "The Keyboard Preview, height"
+#~ msgstr "ལྡེ་སྒྲོམ་སྔོན་ལྟ། མཐོ་ཚད།"
+
+#~ msgid "The Keyboard Preview, width"
+#~ msgstr "ལྡེ་སྒྲོམ་སྔོན་ལྟ། རྒྱ་ཚད།"
+
+#~ msgid ""
+#~ "Very soon, keyboard settings in gconf will be overridden (from the system "
+#~ "configuration) This key has been deprecated since GNOME 2.12, please "
+#~ "unset the model, layouts and options keys to get the default system "
+#~ "configuration."
+#~ msgstr ""
+#~ "མགྱོགས་པ་རང་ ཇི་ཀཱོནཕི་ནང་གི་ ལྡེ་སྒྲོམ་གཞི་སྒྲིག་དེ་ (རིམ་ལུགས་རིམ་སྒྲིག་ནང་ལས་) ཟུར་བཞག་འབད་ནི་"
+#~ "ཨིན། ཇི་ནོམ་༢.༡༢ ལས་ཚུར་ ལྡེ་མིག་འདི་ ནུས་མེད་བཟོ་ཡོདཔ་ལས་ སྔོན་སྒྲིག་རིམ་ལུགས་རིམ་སྒྲིག་ལེན་ནིའི་"
+#~ "དོན་ལུ་ ཐབས་ལམ་དང་ སྒྲིག་བཀོད་ གདམ་ཁའི་ལྡེ་མིག་ཚུ་ སྒྲིག་བཤོལ་འབད་གནང་།"
+
+#~ msgid "keyboard layout"
+#~ msgstr "ལྡེ་སྒྲོམ་སྒྲིག་བཀོད།"
+
+#~ msgid "keyboard model"
+#~ msgstr "ལྡེ་སྒྲོམ་གྱི་དཔེ།"
+
+#~ msgid "modmap file list"
+#~ msgstr "མོཌི་མེཔ་ ཡིག་སྣོད་ཐོ་ཡིག"
+
+#~ msgid "Break reminder"
+#~ msgstr "བར་མཚམས་ཀྱི་དྲན་བསྐུལ།"
+
+#~ msgid "Orientation"
+#~ msgstr "ཕྱོགས།"
+
+#~ msgid "The orientation of the tray."
+#~ msgstr "ཤོག་སྣོད་ཀྱི་ཕྱོགས།"
+
+#~ msgid "..."
+#~ msgstr "..."
+
+#~ msgid ""
+#~ "Icon Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "ངོས་དཔར་བརྗོད་དོན་  %s ངེས་བདེན་སྦེ་ གཞི་བཙུགས་འབད་ནུག\n"
+#~ "དེ་ཁྱོད་ཀྱིས་བརྗོད་དོན་རྒྱས་བཤད་ནང་ལས་ སེལ་འཐུ་འབད་ཚུགས།"
+
+#~ msgid ""
+#~ "Windows Border Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "སྒོ་སྒྲིག་གི་མཐའ་མཚམས་བརྗོད་དོན་ %s ངེས་བདེན་སྦེ་ གཞི་བཙུགས་འབད་ནུག\n"
+#~ "དེ་ཁྱོད་ཀྱིས་བརྗོད་དོན་རྒྱས་བཤད་ནང་ལས་ སེལ་འཐུ་འབད་ཚུགས།"
+
+#~ msgid ""
+#~ "Controls Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "ཚད་འཛིན་གྱི་བརྗོད་དོན་ %s ངེས་བདེན་སྦེ་ གཞི་བཙུགས་འབད་ནུག\n"
+#~ "དེ་ཁྱོད་ཀྱིས་བརྗོད་དོན་རྒྱས་བཤད་ནང་ལས་ སེལ་འཐུ་འབད་ཚུགས།"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "བོ་ནོ་བོ་ འགོ་འབྱེད་འབད་མ་ཚུགས།"
+
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "གཟུགས་བརྙན་་%sམངོན་གསལ་འབད་ནི་ལུ་ འཛོལ་བ་ཅིག་བྱུང་ནུག"
+
+#~ msgid "layout \"%s\""
+#~ msgid_plural "layouts \"%s\""
+#~ msgstr[0] "སྒྲིག་བཀོད་ \"%s\"།"
+#~ msgstr[1] "སྒྲིག་བཀོད་ \"%s\"།"
+
+#~ msgid "option \"%s\""
+#~ msgid_plural "options \"%s\""
+#~ msgstr[0] "གདམ་ཁ་\"%s\"།"
+#~ msgstr[1] "གདམ་ཁ་\"%s\"།"
+
+#~ msgid "model \"%s\", %s and %s"
+#~ msgstr "དཔེ་ \"%s\"དང་ %s ། %s།"
+
+#~ msgid "no layout"
+#~ msgstr "སྒྲིག་བཀོད་མིན་འདུག"
+
+#~ msgid "no options"
+#~ msgstr "གདམ་ཁ་མིན་འདུག"
+
+#~ msgid "Old password is incorrect, please retype it"
+#~ msgstr "ཆོག་ཡིག་རྙིངམ་དེ་ བདེན་པ་མེན་པས། ལོག་ཡིག་དཔར་རྐྱབས།"
+
+#~ msgid "Unexpected error has occurred"
+#~ msgstr "རེ་བ་མེད་པའི་འཚོལ་བ་བྱུང་ནུག"
+
+#~ msgid "Please type the passwords."
+#~ msgstr "ཆོག་ཡིག་ཚུ་ ཡིག་དཔར་རྐྱབས།"
+
+#~ msgid "Old pa_ssword:"
+#~ msgstr "ཆོག་ཡིག་རྙིངམ་:(_s)"
+
+#~ msgid "Could not display help"
+#~ msgstr "གྲོགས་གྲམ་བཀྲམ་སྟོན་འབད་མ་ཚུགས།"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">བརྗོད་དོན་ཅིག་གཞི་བཙུགས་འབད་</span>"
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr "བརྗོད་དོན་གསརཔ་ཚུ་ སྒོ་སྒྲིག་ནང་འདྲུད་པའི་ཐོག་ལས་ གཞི་བཙུགས་འབད་ཚུགས།"
+
+#~ msgid "Short _description:"
+#~ msgstr "འགྲེལ་བཤད་ཐུང་ཀུ:(_d)"
+
+#~ msgid "_Theme name:"
+#~ msgstr "བརྗོད་དོན་གྱི་མིང་:(_T)"
+
+#~ msgid "No '/dev/pmu' device found"
+#~ msgstr "'/dev/pmu' ཐབས་འཕྲུལ་མིན་འདུག"
+
+#~ msgid "Not a powerbook"
+#~ msgstr "པ་ཝར་བུཀ་ཅིག་མེན་པས།"
+
+#~ msgid "Wrong permission for '/dev/pmu' device"
+#~ msgstr "'/dev/pmu' ཐབས་འཕྲུལ་གྱི་གི་དོན་ལུ་ གནང་བ་ཕྱི་འགྱུར།"
+
+#~ msgid "Brightness down"
+#~ msgstr "དཀར་མདངས་མར་ཕབ།"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "དཀར་མདངས་མར་ཕབ་ཀྱི་མགྱོགས་ཐབས།"
+
+#~ msgid "Brightness up"
+#~ msgstr "དཀར་མདངས་ཡར་སེང་།"
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "དཀར་མདངས་ཡར་སེང་གི་མགྱོགས་ཐབས།"
+
+#~ msgid "Epiphany"
+#~ msgstr "ཨི་པི་ཕ་ནི།"
+
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "ཞུན་དགཔ་དེ་གི་དོན་ལུ་ མིང་ཅིག་དང་བརྡ་བཀོད་ཅིག་ གསལ་བཀོད་འབད་གནང་།"
+
+#~ msgid "Add..."
+#~ msgstr "ཁ་སྐོང་རྐྱབས་..."
+
+#~ msgid "Can open _URIs"
+#~ msgstr "ཡུ་ཨར་ཨའི་ཚུ་ ཁ་ཕྱེ་ཚུགས།(_U)"
+
+#~ msgid "Can open multiple _files"
+#~ msgstr "སྣ་མང་ཡིག་སྣོད་ ཁ་ཕྱེ་ཚུགས།(_f)"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "སྲོལ་སྒྲིག་ཞུན་དག་པའི་རྒྱུ་དངོས།"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "སྔོན་སྒྲིག་ཡིག་འཕྲིན་ལྷག་མི།"
+
+#~ msgid "Default Terminal"
+#~ msgstr "སྔོན་སྒྲིག་ཊར་མི་ནཱལ།"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "སྔོན་སྒྲིག་ཚིག་ཡིག་ཞུན་དགཔ།"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "སྔོན་སྒྲིག་ཝེབ་བརའུ་ཟར།"
+
+#~ msgid "Default Window Manager"
+#~ msgstr "སྔོན་སྒྲིག་སྒོ་སྒྲིག་འཛིན་སྐྱོང་པ།"
+
+#~ msgid "Edit..."
+#~ msgstr "ཞུན་དག..."
+
+#~ msgid "Run in a _terminal"
+#~ msgstr "ཊར་མི་ནཱལ་ཅིག་ནང་ ལག་ལེན་འཐབ།(_t)"
+
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "ཁྱོད་ལུ་དགོ་མི་ སྒོ་སྒྲིག་འཛིན་སྐྱོང་པ་ཅིག་ སེལ་འཐུ་འབད། དེ་གིས་ལཱ་འབད་ནིའི་དོན་ལུ་ ཁྱོད་ཀྱིས་འཇུག་སྤྱོད་"
+#~ "གུ་བརྡུང་སྟེ་ མིག་འཕྲུལ་གྱི་ཝེན་དེ་གཡབ། དེ་ལས་ དེ་གི་ལཱ་འབད་ནིའི་དོན་ལུ་ མིག་འཕྲུལ་གྱི་གླུ་གར་ཅིག་འཁྲབ་"
+#~ "དགོ"
+
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "ནེཊི་སིཀེཔ་གི་ ཐག་རིང་ཚད་འཛིན་ ཧ་གོཝ་ཨིན།(_N)"
+
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr ""
+#~ "ཡིག་སྣོད་འཛིན་སྐྱོང་པའི་ནང་ན་ ཚིག་ཡིག་ཡིག་སྣོད་ ཁ་ཕྱེ་ནིའི་དོན་ལུ་ ཞུན་དགཔ་འདི་ ལག་ལེན་འཐབ།(_e)"
+
+#~ msgid "Window Manager"
+#~ msgstr "སྒོ་སྒྲིག་འཛིན་སྐྱོང་པ།"
+
+#~ msgid "_Command:"
+#~ msgstr "བརྡ་བཀོད་:(_C)"
+
+#~ msgid "_Properties..."
+#~ msgstr "རྒྱུ་དངོས་...(_P)"
+
+#~ msgid "_Select:"
+#~ msgstr "སེལ་འཐུ་འབད་...(_S)"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "ཊར་མི་ནཱལ་ཡིག་གཟུགས་:(_T)"
+
+#~ msgid "Large Cursor"
+#~ msgstr "འོད་རྟགས་ཆེ་བ།"
+
+#~ msgid "E_nable sound server startup"
+#~ msgstr "སྒྲ་སྐད་སར་བར་འགོ་བཙུགས་ ལྕོགས་ཅན་བཟོ།(_n)"
+
+#~ msgid "_Sound an audible bell"
+#~ msgstr "རྣར་ཉན་བཏུབ་པའི་ དྲིལ་སྐད་ཅིག་སྟོན།(_S)"
+
+#~ msgid "_Visual feedback:"
+#~ msgstr "མཐོང་བའི་བསམ་ལན་:(_V)"
+
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "བརྗོད་དོན་ལེ་སྣོད་ལུ་འགྱོ།(_G)"
+
+#~ msgid "Permissions on the file %s are broken\n"
+#~ msgstr "ཡིག་སྣོད་%sགི་གནང་བ་ཚུ་ རྒྱུན་ཆད་སོ་ནུག\n"
+
+#~ msgid "Event"
+#~ msgstr "བྱུང་ལས།"
+
+#~ msgid "Sound File"
+#~ msgstr "སྒྲ་སྐད་ཡིག་སྣོད།"
+
+#~ msgid "_Sounds:"
+#~ msgstr "སྒྲ་སྐད་ཚུ་:(_S)"
+
+#~ msgid "_Play"
+#~ msgstr "གཏང་།(_P)"
+
+#~ msgid "The typing monitor is already running."
+#~ msgstr "ཡིག་དཔར་བརྐྱབ་ནིའི་གསལ་གཞི་དེ་ ཧེ་མ་ལས་རང་ གཡོག་བཀོལ་ཏེ་འདུག"
+
+#~ msgid "Information about myself"
+#~ msgstr "རང་ཉིད་སྐོར་གྱི་བརྡ་དོན།"
+
+#~ msgid "Pick a color"
+#~ msgstr "ཚོས་གཞི་ཅིག་འཐུ།"
+
+#~ msgid "%i of %i"
+#~ msgstr "%i གི་%i"
+
+#~ msgid "Transferring: %s"
+#~ msgstr "%sགནས་སོར་གཏང་དོ།"
+
+#~ msgid "Downloading..."
+#~ msgstr "ཕབ་ལེན་འབད་དོ་..."
+
+#~ msgid "Set the font for applications"
+#~ msgstr "གློག་རིམ་གྱི་དོན་ལུ་ ཡིག་གཟུགས་གཞི་སྒྲིག་འབད།"
+
+#~ msgid "Set the font for the icons on the desktop"
+#~ msgstr "ཌེཀསི་ཊོཔ་གུ་ ངོས་དཔར་གྱི་དོན་ལུ་ ཡིག་གཟུགས་གཞི་སྒྲིག་འབད།"
+
+#~ msgid "Set the monospace font for terminals and similar applications"
+#~ msgstr "མཐའ་སྒོ་དང་ དེ་དང་འདྲ་བའི་ གློག་རིམ་ཚུ་གི་དོན་ལུ་ མོ་ནོ་སིཔེསི་ཡིག་གཟུགས་ གཞི་སྒྲིག་འབད།"
+
+#~ msgid "_Use Font"
+#~ msgstr "ཡིག་གཟུགས་ལག་ལེན་འཐབ།(_U)"
+
+#~ msgid ""
+#~ "<i><small><b>Note:</b> Changes to this setting will not take effect until "
+#~ "next time you log in.</small></i>"
+#~ msgstr ""
+#~ "<i><small><b>དྲན་འཛིན་</b>ཁྱོད་ཀྱིས་ཤུལ་ལས་ </small></i>ལུ་ ནང་བསྐྱོད་མ་འབད་ཚུན་ཚོད་ "
+#~ "གཞི་སྒྲིག་འདི་གི་བསྒྱུར་བཅོས་ཚུ་ལུ་ ནུས་པ་མི་འཐོབ"
+
+#~ msgid "Sound preferences"
+#~ msgstr "སྒྲ་སྐད་ཀྱི་དགའ་གདམ་ཚུ།"
+
+#~ msgid ""
+#~ "Very soon, keyboard settings in gconf will be overridden (from the system "
+#~ "configuration)"
+#~ msgstr ""
+#~ "མགྱོགས་པ་རང་ ཇི་ཀཱོནཕ་ནང་གི་ ལྡེ་སྒྲོམ་གཞི་སྒྲིག་ཚུ་ ཆ་མེད་གཏང་ནི་ཨིན། (རིམ་ལུགས་རིམ་སྒྲིག་ནང་ལས)"

--- a/po/el.po
+++ b/po/el.po
@@ -40,115 +40,21 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: el\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
-"PO-Revision-Date: 2022-09-09 13:10+0300\n"
-"Last-Translator: Efstathios Iosifidis <iosifidis@fedoraproject.org>\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-12-30 23:49+0200\n"
+"Last-Translator: Efstathios Iosifidis <eiosifidis@gnome.org>\n"
 "Language-Team: Greek, Modern (1453-) <gnome-el-list@gnome.org>\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.2.2\n"
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Δίαυλος συστήματος"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Πλήρη πρόσβαση"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Δίαυλος συνεδρίας"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Συσκευές"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Πλήρης πρόσβαση στο /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Δίκτυο"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Έχει πρόσβαση δικτύου"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Προσωπικός φάκελος"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Μόνο ανάγνωση"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Σύστημα αρχείων"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Ρυθμίσεις"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Δυνατότητα αλλαγής ρυθμίσεων"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"Το %s έχει ενσωματωμένα τα ακόλουθα δικαιώματα. Αυτά δεν μπορούν να "
-"μεταβληθούν. Αν ανησυχείτε για αυτά τα δικαιώματα, εξετάστε το ενδεχόμενο "
-"κατάργησης αυτής της εφαρμογής."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] ""
-msgstr[1] ""
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr ""
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -164,7 +70,6 @@ msgid "Install some…"
 msgstr "Εγκατάσταση μερικών…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Άνοιγμα"
 
@@ -188,24 +93,13 @@ msgstr "Αναζήτηση"
 msgid "Receive system searches and send results."
 msgstr ""
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Απενεργοποιήθηκε"
 
@@ -215,10 +109,8 @@ msgid "Notifications"
 msgstr "Ειδοποιήσεις"
 
 #: panels/applications/cc-applications-panel.ui:127
-#, fuzzy
-#| msgid "preferences-system-notifications"
 msgid "Show system notifications."
-msgstr "preferences-system-notifications"
+msgstr "Εμφάνιση ειδοποιήσεων συστήματος."
 
 #: panels/applications/cc-applications-panel.ui:133
 msgid "Run in Background"
@@ -237,14 +129,11 @@ msgid "Take pictures of the screen at any time."
 msgstr ""
 
 #: panels/applications/cc-applications-panel.ui:147
-#, fuzzy
-#| msgid "Wallpapers"
 msgid "Change Wallpaper"
-msgstr "Ταπετσαρίες"
+msgstr "Αλλαγή ταπετσαρίας"
 
 #: panels/applications/cc-applications-panel.ui:148
 #, fuzzy
-#| msgid "preferences-desktop-wallpaper"
 msgid "Change the desktop wallpaper."
 msgstr "preferences-desktop-wallpaper"
 
@@ -260,13 +149,11 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.ui:168
 #, fuzzy
-#| msgid "Set Shortcut"
 msgid "Inhibit Shortcuts"
 msgstr "Ορισμός συντόμευσης"
 
 #: panels/applications/cc-applications-panel.ui:169
 #, fuzzy
-#| msgid "Inhibit system keyboard shortcuts"
 msgid "Block standard keyboard shortcuts."
 msgstr "Αναστολή συντομεύσεων πληκτρολογίου συστήματος"
 
@@ -301,7 +188,6 @@ msgstr "Υπηρεσίες τοποθεσίας"
 #: panels/applications/cc-applications-panel.ui:204
 #: panels/applications/cc-applications-panel.ui:211
 #, fuzzy
-#| msgid "Access Options"
 msgid "Access device location data."
 msgstr "Επιλογές πρόσβασης"
 
@@ -312,7 +198,6 @@ msgstr "Ενσωματωμένα δικαιώματα"
 
 #: panels/applications/cc-applications-panel.ui:223
 #, fuzzy
-#| msgid "System features used by this application."
 msgid "System access that is required by the app"
 msgstr "Χαρακτηριστικά συστήματος που χρησιμοποιούνται από αυτήν την εφαρμογή."
 
@@ -385,80 +270,20 @@ msgstr "Εκκαθάριση λανθάνουσας μνήμης…"
 msgid "Control various application permissions and settings"
 msgstr "Ελέγξτε τα διάφορα δικαιώματα και ρυθμίσεις εφαρμογών"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "εφαρμογή;flatpak;άδεια;ρύθμιση;application;flatpak;permission;setting;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Επιλογή εικόνας"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Ακύρωση"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "Άν_οιγμα"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "πολλαπλά μεγέθη"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Επιφάνεια εργασίας χωρίς παρασκήνιο"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Τρέχον παρασκήνιο"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Στυλ"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Προεπιλεγμένη"
 
@@ -480,11 +305,9 @@ msgstr "Εμφάνιση"
 
 #: panels/background/gnome-background-panel.desktop.in.in:4
 #, fuzzy
-#| msgid "Change your background image to a wallpaper or photo"
 msgid "Change your background image or the UI colors"
 msgstr "Αλλάξτε την εικόνα παρασκηνίου με μια ταπετσαρία ή φωτογραφία"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -517,8 +340,6 @@ msgstr ""
 "Ενεργοποιήστε για να συνδέσετε συσκευές και να κάνετε μεταφορές αρχείων."
 
 #: panels/bluetooth/cc-bluetooth-panel.ui:38
-#, fuzzy
-#| msgid "Airplane Mode is on"
 msgid "Airplane Mode is On"
 msgstr "Η λειτουργία αεροπλάνου είναι ενεργή"
 
@@ -533,8 +354,6 @@ msgid "Turn Off Airplane Mode"
 msgstr "Απενεργοποίηση της λειτουργίας αεροπλάνου"
 
 #: panels/bluetooth/cc-bluetooth-panel.ui:56
-#, fuzzy
-#| msgid "Hardware Airplane Mode is on"
 msgid "Hardware Airplane Mode is On"
 msgstr "Η λειτουργία αεροπλάνου είναι ενεργή μέσω του διακόπτη"
 
@@ -544,9 +363,7 @@ msgstr ""
 "Απενεργοποιήστε τον διακόπτη λειτουργίας αεροπλάνου για να ενεργοποιήσετε το "
 "Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -555,14 +372,11 @@ msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 "Ενεργοποιήστε/Απενεργοποιήστε το Bluetooth και συνδεθείτε με τις συσκευές σας"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "κοινή χρήση;κοινόχρηστο;bluetooth;μπλουτούθ;obex;"
 
 #: panels/camera/cc-camera-panel.ui:24
-#, fuzzy
-#| msgid "Camera is turned off"
 msgid "Camera is Turned Off"
 msgstr "Η κάμερα είναι ανενεργή"
 
@@ -572,9 +386,6 @@ msgstr "Καμία εφαρμογή δεν μπορεί να τραβήξει φ
 
 #: panels/camera/cc-camera-panel.ui:39
 #, fuzzy
-#| msgid ""
-#| "Use of the camera allows applications to capture photos and video. "
-#| "Disabling the camera may cause some applications to not function properly."
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
@@ -593,94 +404,33 @@ msgstr "Καμία εφαρμογή δεν ζήτησε πρόσβαση στη�
 msgid "Protect your pictures"
 msgstr "Προστατέψτε τις φωτογραφίες σας"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Τοποθετήστε τη συσκευή βαθμονόμησης πάνω από το τετράγωνο και πατήστε "
-"«Έναρξη»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Μετακινήστε τη συσκευή βαθμονόμησής σας στη θέση βαθμονόμησης και πατήστε "
-"«Συνέχεια»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Μετακινήστε τη συσκευή βαθμονόμησής σας στην επιφάνεια και πατήστε «Συνέχεια»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Κλείστε το καπάκι του φορητού υπολογιστή"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Συνέβη ένα εσωτερικό σφάλμα που δεν μπόρεσε να ανακτηθεί."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Δεν εγκαταστάθηκαν τα απαιτούμενα εργαλεία για βαθμονόμηση."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Αδυναμία δημιουργίας του προφίλ."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Το λευκό σημείο προορισμού δεν ήταν διαθέσιμο."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Ολοκληρώθηκε!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Αποτυχία βαθμονόμησης!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Μπορείτε να αφαιρέσετε τη συσκευή βαθμονόμησης."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Μην διακόπτετε τη συσκευή βαθμονόμησης ενώ δουλεύει"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Βαθμονόμηση οθόνης"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Ακύρωση"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -697,140 +447,6 @@ msgstr "_Συνέχεια"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "Έ_τοιμο"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Οθόνη φορητού υπολογιστή"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Ενσωματωμένη δικτυακή κάμερα"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Οθόνη %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Σαρωτής %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Φωτογραφική μηχανή %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Εκτυπωτής %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Δικτυακή κάμερα %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Ενεργοποίηση της διαχείρισης χρωμάτων για %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Προβολή προφίλ χρώματος για %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Δεν έχει βαθμονομηθεί"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Προεπιλεγμένο: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Χρωματικός χώρος: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Δοκιμαστικό προφίλ: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Επιλογή αρχείου προφίλ ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "Ε_ισαγωγή"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Υποστηριζόμενα προφίλ ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Όλα τα αρχεία"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Οθόνη"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Αποθήκευση προφίλ"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Αποθήκευση"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Δημιουργία προφίλ χρώματος για την επιλεγμένη συσκευή"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Δεν εντοπίστηκε το όργανο μέτρησης. Παρακαλούμε ελέγξτε αν είναι "
-"ενεργοποιημένο και σωστά συνδεδεμένο."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Το όργανο μέτρησης δεν υποστηρίζει δημιουργία προφίλ εκτυπωτών."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Δεν υποστηρίζεται ο τύπος της συσκευής."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -979,7 +595,6 @@ msgstr "Ε_ισαγωγή αρχείου…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -991,9 +606,7 @@ msgstr ""
 "Κάθε συσκευή χρειάζεται ένα ενημερωμένο προφίλ χρωμάτων για χρωματική "
 "διαχείριση."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Μάθετε περισσότερα"
 
@@ -1125,82 +738,6 @@ msgstr "D65 (φωτογραφία και γραφικά)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Κανονικός χώρος"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Δοκιμαστικό προφίλ"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Αυτόματο"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Χαμηλή ποιότητα"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Μεσαία ποιότητα"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Υψηλή ποιότητα"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Προεπιλεγμένο RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Προεπιλεγμένο CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Προεπιλεγμένo γκρίζο"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Τα εργοστασιακά δεδομένα βαθμονόμησης που παρέχονται από τον πωλητή"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Αδύνατη η διόρθωση προβολής πλήρους οθόνης με αυτό το προφίλ"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Αυτό το προφίλ μπορεί να μην είναι πια ακριβές"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Χρώμα"
@@ -1211,16 +748,11 @@ msgid ""
 msgstr ""
 "Βαθμονομήστε το χρώμα των συσκευών σας, όπως οθόνες, κάμερες ή εκτυπωτές"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Χρώμα;ICC;Προφίλ;Βαθμονόμηση;Εκτυπωτής;Οθόνη;Color;Profile;Calibrate;Printer;"
 "Display;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Άλλη…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1235,13 +767,8 @@ msgid "No languages found"
 msgstr "Δε βρέθηκαν γλώσσες"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Περισσότερα…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Ξεκλειδώστε για να αλλάξετε ρυθμίσεις"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1270,151 +797,6 @@ msgstr ""
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr ""
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Σήμερα"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Χθες"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d ώρα"
-msgstr[1] "%d ώρες"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d λεπτό"
-msgstr[1] "%d λεπτά"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d δευτερόλεπτο"
-msgstr[1] "%d δευτερόλεπτα"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 δευτερόλεπτα"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Σημείο πρόσβασης"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24ωρο"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "π.μ / μ.μ"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1491,7 +873,6 @@ msgstr "Αναζήτηση πόλης"
 
 #: panels/datetime/cc-datetime-panel.ui:164
 #, fuzzy
-#| msgid "Automatic _Date & Time"
 msgid "Automatic _Date &amp; Time"
 msgstr "Αυτόματη _ημερομηνία και ώρα"
 
@@ -1501,7 +882,6 @@ msgstr "Απαιτείται πρόσβαση στο διαδίκτυο"
 
 #: panels/datetime/cc-datetime-panel.ui:180
 #, fuzzy
-#| msgid "Date & _Time"
 msgid "Date &amp; _Time"
 msgstr "Ημερομηνία & ώ_ρα"
 
@@ -1514,17 +894,11 @@ msgid "Requires location services enabled and internet access"
 msgstr ""
 "Απαιτεί ενεργοποιημένες υπηρεσίες τοποθεσίας και πρόσβαση στο διαδίκτυο"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Ενεργοποιημένο"
 
@@ -1532,15 +906,42 @@ msgstr "Ενεργοποιημένο"
 msgid "Time Z_one"
 msgstr "Ζώ_νη ώρας"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Ξεκλείδωμα"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Μορφή ώρας"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Ημερομηνίες"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 δευτερόλεπτα"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Ημερολόγιο"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Αριθμοί"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Αλλάξτε την ημερομηνία και ώρα, καθώς και τη ζώνης ώρας"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Ρολόι;Ζώνη ώρας;Τοποθεσία;Clock;Timezone;Location;"
@@ -1587,21 +988,10 @@ msgstr "Προεπιλεγμένες εφαρμογές"
 msgid "Configure Default Applications"
 msgstr "Ρύθμιση προεπιλεγμένων εφαρμογών"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "προεπιλογή;εφαρμογή;προτιμώμενη;μέσα;default;application;preferred;media;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Η αποστολή αναφορών των τεχνικών προβλημάτων μας βοηθά να βελτιώσουμε το %s. "
-"Οι αναφορές στέλνονται ανώνυμα και αφαιρούνται τα προσωπικά δεδομένα. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1619,46 +1009,10 @@ msgstr "Διαγνωστικά"
 msgid "Report your problems"
 msgstr "Αναφορά των προβλημάτων σας"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 #, fuzzy
-#| msgid "Diagnostics"
 msgid "diagnostics;crash;"
 msgstr "Διαγνωστικά"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Ενεργό"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Ανενεργό"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Εφαρμογή αλλαγών;"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Οι αλλαγές δεν μπορούν να εφαρμοστούν"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Αυτό μπορεί να οφείλεται σε περιορισμούς υλικού."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1678,7 +1032,6 @@ msgstr "Πίσω"
 
 #: panels/display/cc-display-panel.ui:100
 #, fuzzy
-#| msgid "Bluetooth is disabled"
 msgid "Display Settings Disabled"
 msgstr "Το Bluetooth είναι απενεργοποιημένο"
 
@@ -1710,31 +1063,6 @@ msgstr "Πρωτεύουσα οθόνη"
 msgid "Night Light"
 msgstr "Λειτουργία νυχτός"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Οριζόντια"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Κάθετα δεξιά"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Κάθετα αριστερά"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Οριζόντια (ανεστραμμένη)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1759,9 +1087,19 @@ msgctxt "display setting"
 msgid "Scale"
 msgstr "Κλιμάκωση"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Φυσική κύλιση"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
 #: panels/display/cc-night-light-page.ui:22
 #, fuzzy
-#| msgid "Night Light"
 msgid "Night Light unavailable"
 msgstr "Λειτουργία νυχτός"
 
@@ -1853,7 +1191,6 @@ msgstr "Οθόνες"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Επιλέξτε τον τρόπο χρήσης συνδεδεμένων οθονών και προβολέων"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1863,67 +1200,6 @@ msgstr ""
 "ανατολή;χρώμα;δύση;Panel;Projector;Screen;Resolution;Refresh;Monitor;Night;"
 "Light;Blue;redshift;color;sunset;sunrise;"
 
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr ""
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr ""
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-#, fuzzy
-#| msgid "Bluetooth Turned Off"
-msgid "Secure Boot is Turned Off"
-msgstr "Το Bluetooth είναι ανενεργό"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
 "Secure boot prevents malicious software from being loaded when the device "
@@ -1932,117 +1208,9 @@ msgid ""
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-#, fuzzy
-#| msgid "Password"
-msgid "Passed"
-msgstr "Κωδικός πρόσβασης"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Απέτυχε"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "Επίπεδο ασφαλείας 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "Επίπεδο ασφαλείας 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "Επίπεδο ασφαλείας 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "Επίπεδο ασφαλείας 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "Επίπεδο ασφαλείας"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr ""
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2056,362 +1224,12 @@ msgstr "Επίπεδο 2"
 msgid "Level 3"
 msgstr "Επίπεδο 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Κανένα συμβάν"
 
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr ""
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-#, fuzzy
-#| msgid "Firmware missing"
-msgid "Firmware BIOS Region"
-msgstr "Λείπει το υλικολογισμικό"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr ""
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr ""
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr ""
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr ""
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr ""
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr ""
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr ""
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-#, fuzzy
-#| msgid "Suspend"
-msgid "Suspend To RAM"
-msgstr "Αναστολή"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-#, fuzzy
-#| msgid "Suspend"
-msgid "Suspend To Idle"
-msgstr "Αναστολή"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr ""
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr ""
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-#, fuzzy
-#| msgid "Display Configuration"
-msgid "TPM Platform Configuration"
-msgstr "Ρυθμίσεις οθόνης"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr ""
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-#, fuzzy
-#| msgid "Software Updates"
-msgid "Firmware Updates"
-msgstr "Ενημερώσεις λογισμικού"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-#, fuzzy
-#| msgid "Firmware missing"
-msgid "Firmware Attestation"
-msgstr "Λείπει το υλικολογισμικό"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr ""
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr ""
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr ""
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Έγκυρο"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-#, fuzzy
-#| msgid "Not calibrated"
-msgid "Not Valid"
-msgstr "Δεν έχει βαθμονομηθεί"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-#, fuzzy
-#| msgid "Enabled"
-msgid "Not Enabled"
-msgstr "Ενεργοποιημένο"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr ""
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-#, fuzzy
-#| msgid "Not connected"
-msgid "Not Locked"
-msgstr "Δεν συνδέθηκε"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr ""
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-#, fuzzy
-#| msgid "Not connected"
-msgid "Not Encrypted"
-msgstr "Δεν συνδέθηκε"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr ""
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-#, fuzzy
-#| msgid "Not calibrated"
-msgid "Not Tainted"
-msgstr "Δεν έχει βαθμονομηθεί"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Ευρέθη"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Δεν βρέθηκε"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-#, fuzzy
-#| msgctxt "print job"
-#| msgid "Aborted"
-msgid "Supported"
-msgstr "Εγκαταλείφθηκε"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-#, fuzzy
-#| msgid "Not connected"
-msgid "Not Supported"
-msgstr "Δεν συνδέθηκε"
-
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "Security"
 msgid "Device Security"
 msgstr "Ασφάλεια"
 
@@ -2419,12 +1237,8 @@ msgstr "Ασφάλεια"
 msgid "Host firmware security status"
 msgstr ""
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 #, fuzzy
-#| msgid ""
-#| "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-#| "network;identity;"
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
 "network;identity;privacy;"
@@ -2433,53 +1247,6 @@ msgstr ""
 "ευρετήριο;όνομα;ταυτότητα;screen;lock;diagnostics;crash;private;recent;"
 "temporary;tmp;index;name;network;identity;"
 
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Άγνωστο"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Άγνωστο"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-#, fuzzy
-#| msgid "No printers available"
-msgid "Not Available"
-msgstr "Δεν υπάρχουν διαθέσιμοι εκτυπωτές"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-#, fuzzy
-#| msgid "System"
-msgid "System Logo"
-msgstr "Σύστημα"
-
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
@@ -2487,7 +1254,6 @@ msgstr "Όνομα συσκευής"
 
 #: panels/info-overview/cc-info-overview-panel.ui:50
 #, fuzzy
-#| msgid "Hardware Address"
 msgid "Hardware Model"
 msgstr "Διεύθυνση υλικού"
 
@@ -2519,7 +1285,6 @@ msgstr "Όνομα OS"
 #. translators: this field contains the distro build ID
 #: panels/info-overview/cc-info-overview-panel.ui:107
 #, fuzzy
-#| msgid "%s; Build ID: %s"
 msgid "OS Build ID"
 msgstr "%s; ΙD δόμησης: %s"
 
@@ -2576,16 +1341,8 @@ msgstr "Περί"
 msgid "View information about your system"
 msgstr "Δείτε πληροφορίες για το σύστημα σας"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 #, fuzzy
-#| msgid ""
-#| "device;system;information;memory;processor;version;default;application;"
-#| "preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
 "application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
@@ -2664,6 +1421,12 @@ msgstr "Εκκινητές"
 msgid "Launch help browser"
 msgstr "Εκκίνηση περιηγητή βοήθειας"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Ρυθμίσεις"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Εκκίνηση αριθμομηχανής"
@@ -2685,7 +1448,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Σύστημα"
 
@@ -2734,15 +1497,6 @@ msgstr "Σμίκρυνση του κειμένου"
 msgid "High contrast on or off"
 msgstr "Εναλλαγή ενεργοποίησης υψηλής αντίθεσης"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Δε βρέθηκαν πηγές εισόδου"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Άλλο"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Προσθήκη πηγής εισόδου"
@@ -2774,114 +1528,12 @@ msgstr "Προτιμήσεις"
 
 #: panels/keyboard/cc-input-row.ui:48
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "View Keyboard Layout"
 msgstr "Συντομεύσεις πληκτρολογίου"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Αφαίρεση"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Προσαρμοσμένες συντομεύσεις"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Εναλλακτικό πλήκτρο χαρακτήρων"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Το πλήκτρο εναλλακτικών χαρακτήρων μπορεί να χρησιμοποιηθεί για την εισαγωγή "
-"πρόσθετων χαρακτήρων. Αυτές εκτυπώνονται μερικές φορές ως τρίτη επιλογή στο "
-"πληκτρολόγιό σας."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Αριστερό Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Δεξιό Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Αριστερό Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Δεξιό Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-#, fuzzy
-#| msgid "Menu key"
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Κλειδί μενού"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Δεξιό Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Σύνθετο πλήκτρο"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-#, fuzzy
-#| msgid "Scroll Left"
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Κύλιση αριστερά"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-#, fuzzy
-#| msgid "Login _Screen"
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Ο_θόνη σύνδεσης"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, fuzzy, c-format
-#| msgid "These keyboard shortcuts can be changed in the keyboard settings"
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Αυτές οι συντομεύσεις πληκτρολογίου μπορούν να αλλάξουν στις ρυθμίσεις του "
-"πληκτρολογίου"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2889,13 +1541,11 @@ msgstr "Πηγές εισόδου"
 
 #: panels/keyboard/cc-keyboard-panel.ui:18
 #, fuzzy
-#| msgid "Choose keyboard layouts or input methods."
 msgid "Includes keyboard layouts and input methods."
 msgstr "Επιλογή γιατάξεων πληκτρολογίου ή μεθόδους εισαγωγής."
 
 #: panels/keyboard/cc-keyboard-panel.ui:28
 #, fuzzy
-#| msgid "Input Source Options"
 msgid "Input Source Switching"
 msgstr "Επιλογές πηγών εισόδου"
 
@@ -2905,7 +1555,6 @@ msgstr "Χρήση της ί_διας πηγής για όλα τα παράθυ
 
 #: panels/keyboard/cc-keyboard-panel.ui:43
 #, fuzzy
-#| msgid "Allow _different sources for each window"
 msgid "Switch input sources _individually for each window"
 msgstr "Να επιτρέπονται _διαφορετικές πηγές για κάθε παράθυρο"
 
@@ -2917,47 +1566,21 @@ msgstr ""
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Εναλλακτικό πλήκτρο χαρακτήρων"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Σύνθετο πλήκτρο"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Συντομεύσεις πληκτρολογίου"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Προβολή και προσαρμογή συντομεύσεων"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, fuzzy, c-format
-#| msgid "%d minute"
-#| msgid_plural "%d minutes"
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d λεπτό"
-msgstr[1] "%d λεπτά"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Επαναφορά όλων των συντομεύσεων;"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Η επαναφορά των συντομεύσεων μπορεί να επηρεάσει τις προσαρμοσμένες σας "
-"συντομεύσεις. Αυτό δεν μπορεί να αναιρεθεί."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Ακύρωση"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Επαναφορά όλων"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2982,7 +1605,6 @@ msgstr "Προσθήκη συντόμευσης"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 #, fuzzy
-#| msgid "Add Custom Shortcut"
 msgid "Add Custom Shortcuts"
 msgstr "Προσθήκη προσαρμοσμένης συντόμευσης"
 
@@ -2998,49 +1620,18 @@ msgstr "Προσθήκη συντόμευσης"
 msgid "No keyboard shortcut found"
 msgstr "Δε βρέθηκε συντόμευση πληκτρολογίου"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"Το %s χρησιμοποιείται ήδη για το %s. Αν το αντικαταστήσετε, θα "
-"απενεργοποιηθεί το %s"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Εισάγετε τη νέα συντόμευση"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Ορισμός προσαρμοσμένης συντομεύσης"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Ορισμός συντόμευσης"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Εισάγετε μια νέα συντόμευση για αλλαγή του %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Προσθήκη προσαρμοσμένης συντόμευσης"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "Α_φαίρεση"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
 #, fuzzy
-#| msgid "Replace"
 msgid "Re_place"
 msgstr "Αντικατάσταση"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr ""
 
@@ -3078,13 +1669,17 @@ msgstr "Κανένα"
 msgid "Reset the shortcut to its default value"
 msgstr "Επαναφορά της συντόμευσης στην προεπιλεγμένη της τιμή"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Χρήση εκτυπωτή από προεπιλογή"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Πληκτρολόγιο"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
 #, fuzzy
-#| msgid "View and change keyboard shortcuts and set your typing preferences"
 msgid ""
 "Change keyboard shortcuts and set your typing preferences, keyboard layouts "
 "and input sources"
@@ -3092,7 +1687,6 @@ msgstr ""
 "Δείτε και αλλάξτε τις συντομεύσεις πληκτρολογίου και ορίστε τις προτιμήσεις "
 "πληκτρολόγησης"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3103,7 +1697,6 @@ msgstr ""
 
 #: panels/location/cc-location-panel.ui:23
 #, fuzzy
-#| msgid "Location services turned off"
 msgid "Location Services Turned Off"
 msgstr "Υπηρεσίες τοποθεσίας απενεργοποιημένες"
 
@@ -3130,14 +1723,12 @@ msgstr "Καμία εφαρμογή δεν ζήτησε να έχει πρόσβ
 msgid "Protect your location information"
 msgstr "Προστατέψτε τις πληροφορίες τοποθεσίας σας"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr ""
 
 #: panels/microphone/cc-microphone-panel.ui:23
 #, fuzzy
-#| msgid "Microphone is turned off"
 msgid "Microphone Turned Off"
 msgstr "Το μικρόφωνο είναι ανενεργό"
 
@@ -3147,10 +1738,6 @@ msgstr "Καμία εφαρμογή δεν μπορεί να εγγράψει ή
 
 #: panels/microphone/cc-microphone-panel.ui:37
 #, fuzzy
-#| msgid ""
-#| "Use of the microphone allows applications to record and listen to audio. "
-#| "Disabling the microphone may cause some applications to not function "
-#| "properly."
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -3170,7 +1757,6 @@ msgstr "Καμία εφαρμογή δεν ζήτησε να έχει πρόσβ
 msgid "Protect your conversations"
 msgstr "Προστατέψτε τις συνομιλίες σας"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
@@ -3201,81 +1787,140 @@ msgstr "Αριστερά"
 msgid "Right"
 msgstr "Δεξιά"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Τοποθεσίες αναζήτησης"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Ποντίκι"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Ταχύτητα ποντικιού"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Φυσική κύλιση"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Κύλιση κάτω"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Η κύλιση μετακινεί το περιεχόμενο, όχι την προβολή."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Η κύλιση μετακινεί το περιεχόμενο, όχι την προβολή."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Ενεργό"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Επιφάνεια αφής"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Ταχύτητα πινακίδας αφής"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Χτύπημα για πάτημα"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Πατήστε για κλικ"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Κύλιση με δύο δάκτυλα"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Απενεργοποίηση κατά την πληκ_τρολόγηση"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Επιφάνεια αφής (σχετικό)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Κύλιση άκρου"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Κύλιση κάτω"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Διπλής όψης"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Δοκιμή κλικ, διπλού κλικ, και κύλισης"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Πέντε κλικ, ώρα του GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Διπλό κλικ, πρωτεύοντος κουμπιού"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Απλό κλικ, πρωτεύοντος κουμπιού"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Διπλό κλικ, μεσαίου κουμπιού"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Μονό κλικ, μεσαίου κουμπιού"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Διπλό κλικ, δευτερεύοντος κουμπιού"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Μονό κλικ, δευτερεύοντος κουμπιού"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3288,7 +1933,6 @@ msgstr ""
 "Αλλάξτε την ευαισθησία του ποντικιού ή της επιφάνειας αφής και επιλέξτε "
 "λειτουργία δεξιόχειρου ή αριστερόχειρου"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3313,10 +1957,8 @@ msgid ""
 msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:70
-#, fuzzy
-#| msgid "Colorspace: "
 msgid "Workspaces"
-msgstr "Χρωματικός χώρος: "
+msgstr "Χώροι εργασίας"
 
 #: panels/multitasking/cc-multitasking-panel.ui:76
 msgid "_Dynamic workspaces"
@@ -3324,7 +1966,6 @@ msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:77
 #, fuzzy
-#| msgid "Automatically Delete Temporary _Files"
 msgid "Automatically removes empty workspaces."
 msgstr "Αυτόματη διαγραφή προσωρινών α_ρχείων"
 
@@ -3342,13 +1983,11 @@ msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:124
 #, fuzzy
-#| msgid "Monitor"
 msgid "Multi-Monitor"
 msgstr "Οθόνη"
 
 #: panels/multitasking/cc-multitasking-panel.ui:130
 #, fuzzy
-#| msgid "Drag to change primary display."
 msgid "Workspaces on _primary display only"
 msgstr "Σύρετε για να αλλάξετε την κύρια οθόνη."
 
@@ -3358,8 +1997,6 @@ msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:184
 #, fuzzy
-#| msgctxt "Wacom action-type"
-#| msgid "Application defined"
 msgid "Application Switching"
 msgstr "Καθορίστηκε εφαρμογή"
 
@@ -3379,28 +2016,16 @@ msgstr ""
 msgid "Manage preferences for productivity and multitasking"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Ωχ, κάτι πήγε στραβά. Παρακαλούμε επικοινωνήστε με τον πωλητή του λογισμικού "
-"σας."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Ο διαχειριστής δικτύου πρέπει να εκτελείται."
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Άλλες συσκευές"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3412,61 +2037,19 @@ msgstr "Προσθήκη σύνδεσης"
 msgid "Not set up"
 msgstr "Δεν είναι ρυθμισμένο"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Μη ασφαλές δίκτυο (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Ασφαλές δίκτυο (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Ασφαλές δίκτυο (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Ασφαλές δίκτυο (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Ασφαλές δίκτυο"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Συνδεδεμένο"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Επιλογές…"
 
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Πρέπει να έχει τουλάχιστον 8 χαρακτήρες"
-
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, fuzzy, c-format
-#| msgid "Must have a minimum of 8 characters"
 msgid "Must have a maximum of %d character"
 msgid_plural "Must have a maximum of %d characters"
 msgstr[0] "Πρέπει να έχει τουλάχιστον 8 χαρακτήρες"
@@ -3509,20 +2092,6 @@ msgstr "Αυτόματη δημιουργία συνθηματικού"
 #: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Ενεργοποίηση"
-
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Διακοπή σημείου πρόσβασης και αποσύνδεση όλων των χρηστών;"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Διακοπή σημείου πρόσβασης"
 
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
@@ -3569,89 +2138,15 @@ msgstr "Ορατά δίκτυα"
 msgid "NetworkManager needs to be running"
 msgstr "Ο διαχειριστής δικτύου πρέπει να εκτελείται"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ωχ, κάτι πήγε στραβά. Παρακαλούμε επικοινωνήστε με τον πωλητή του λογισμικού "
+"σας."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Ασφάλεια 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Ασφάλεια"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Διατήρηση"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Μόνιμο"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Τυχαία"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Σταθερό"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Η διεύθυνση MAC που καταχωρίσατε εδώ θα χρησιμοποιηθεί ως διεύθυνση υλικού "
-"για τη συσκευή δικτύου που ενεργοποιείται αυτή η σύνδεση. Αυτή η δυνατότητα "
-"είναι γνωστή ως MAC cloning ή spoofing. Παράδειγμα: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Προφίλ %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Ενισχυμένο άνοιγμα"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Εταιρική"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Καμία"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Ποτέ"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3660,183 +2155,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i ημέρα πριν"
 msgstr[1] "%i ημέρες πριν"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Καθόλου"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Ασθενές"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Μέτριο"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Καλό"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Εξαιρετικό"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Διεύθυνση IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Διεύθυνση IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Διεύθυνση IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Παράλειψη σύνδεσης"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Αφαίρεση προφίλ σύνδεσης"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Αφαίρεση VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Λεπτομέρειες"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "αυτόματο"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Ταυτότητα"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Διαγραφή διεύθυνσης"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Διαγραφή δρομολογητή"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Κανένα"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Κλειδί WEP 40/128-bit (δεκαεξαδικό ή ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Συνθηματικό WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Δυναμικό WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "Προσωπικό WPA & WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "Εταιρικό WPA & WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "Προσωπικό WPA3"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3847,8 +2165,20 @@ msgstr "Ισχύς σήματος"
 msgid "Link speed"
 msgstr "Ταχύτητα σύνδεσης"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Ασφάλεια"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Διεύθυνση IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Διεύθυνση IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Διεύθυνση υλικού"
 
@@ -3857,12 +2187,17 @@ msgid "Supported Frequencies"
 msgstr "Υποστηριζόμενες συχνότητες"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Προεπιλεγμένος δρομολογητής"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3927,7 +2262,7 @@ msgstr "Μόνο τοπική σύνδεση"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Χειροκίνητο"
 
@@ -3971,9 +2306,8 @@ msgstr "Πύλη δικτύου"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Αυτόματο"
 
@@ -4026,90 +2360,9 @@ msgstr "Αυτόματα, μόνο DHCP"
 msgid "Prefix"
 msgstr "Πρόθεμα"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Αποτυχία ανοίγματος επεξεργαστή σύνδεσης"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Νέο προφίλ"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, fuzzy, c-format
-#| msgid "All Settings"
-msgid "Invalid setting %s"
-msgstr "Ρυθμίσεις"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Εισαγωγή από αρχείο…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Προσθήκη VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Ασ_φάλεια"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Αδυναμία εισαγωγής της σύνδεσης VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Αδύνατη η ανάγνωση του αρχείου «%s», ή το αρχείο δε διαθέτει αναγνωρίσιμες "
-"πληροφορίες σύνδεσης VPN\n"
-"\n"
-"Σφάλμα: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Επιλογή αρχείου για εισαγωγή"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Υπάρχει ήδη ένα αρχείο με όνομα «%s»."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Αντικατάσταση"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Θέλετε να αντικαταστήσετε το %s με την σύνδεση VPN που αποθηκεύετε;"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Αδύνατη η εξαγωγή της σύνδεσης VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Αδύνατη η εξαγωγή της σύνδεσης VPN «%s» στο %s.\n"
-"\n"
-"Σφάλμα: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Εξαγωγή σύνδεσης VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4123,103 +2376,40 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Δίκτυο"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Ελέξτε τον τρόπο σύνδεσης με το διαδίκτυο"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;δίκτυο;IP;LAN;"
 "διαμεσολαβητής;WAN;ευρυζωνικό;Modem;Bluetooth;vpn;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Ελέξτε τον τρόπο σύνδεσης με τα ασύρματα δίκτυα"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Δίκτυο;Ασύρματο;Wi-Fi;Wifi;IP;LAN;Ευρυζωνικό;DNS;\tΣημείο πρόσβασης;Network;"
 "Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "ποτέ"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "σήμερα"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "χθες"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Τελευταία χρησιμοποιημένο"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Ενσύρματη"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Προσθήκη νέας σύνδεσης"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Θα χαθούν οι λεπτομέρειες των επιλεγμένων δικτύων, συμπεριλαμβανομένων των "
-"κωδικών πρόσβασης και των προσαρμοσμένων ρυθμίσεων."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Παράλειψη"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Γνωστά δίκτυα Wi-Fi"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Παράλειψη"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Η πολιτική του συστήματος απαγορεύει τη χρήση ως σημείο πρόσβασης"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Η ασύρματη συσκευή δεν υποστηρίζει λειτουργία με σημείο πρόσβασης"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Η αυτόματη εύρεση διαμεσολαβητή Ιστού χρησιμοποιείται όταν δεν παρέχετε μια "
-"διεύθυνση ρυθμίσεων."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Αυτό δεν το συνιστούμε για δίκτυα τα οποία δεν εμπιστεύεστε."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4238,6 +2428,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Πάροχος"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Διεύθυνση IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4322,293 +2516,6 @@ msgstr "_Ενεργοποίηση σημείου ασύρματης πρόσβα
 msgid "_Known Wi-Fi Networks"
 msgstr "_Γνωστά δίκτυα Wi-Fi"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Άγνωστη κατάσταση"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Χωρίς διαχείριση"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Μη διαθέσιμο"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Γίνεται σύνδεση"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Απαιτείται πιστοποίηση"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Γίνεται αποσύνδεση"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Αποτυχία σύνδεσης"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Άγνωστη κατάσταση (απουσιάζει)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Αποτυχία ρύθμισης"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Αποτυχία ρύθμισης της IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Έληξε η ρυθμίση IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Τα μυστικά απαιτήθηκαν, αλλά δεν προσφέρθηκαν"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "αποσυνδέθηκε η αίτηση του 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Αποτυχία ρύθμισης της αίτησης του 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Αποτυχία της αίτησης του 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Η αίτηση του 802.1x πήρε αρκετή ώρα για να πιστοποιηθεί"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Αποτυχία εκκίνησης της υπηρεσίας PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Αποσυνδέθηκε η υπηρεσία PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Αποτυχία του PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Αποτυχία εκκίνησης του πελάτη DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Σφάλμα πελάτη DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Αποτυχία του πελάτη DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Αποτυχία εκκίνησης της υπηρεσίας κοινόχρηστης σύνδεσης"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Αποτυχία της υπηρεσίας κοινόχρηστης σύνδεσης"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Αποτυχία εκκίνησης της υπηρεσίας AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Σφάλμα υπηρεσίας AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Αποτυχία υπηρεσίας AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Η γραμμή είναι απασχολημένη"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Δεν ακούγεται ο τόνος κλήσης"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Δεν είναι δυνατή η δημιουργία γραμμής"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Έληξε το αίτημα κλήσης"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Απέτυχε η προσπάθεια κλήσης"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Απέτυχε η προετοιμασία του μόντεμ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Απέτυχε η επιλογή του συγκεκριμένου APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Δεν ψάχνει για δίκτυα"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Απερρίφθη η εγγραφή στο δίκτυο"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Έληξε η εγγραφή στο δίκτυο"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Αποτυχία εγγραφής στο ζητούμενο δίκτυο"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Απέτυχε ο έλεγχος του PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Μπορεί να λείπει το υλικολογισμικό για τη συσκευή"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Η σύνδεση χάθηκε"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Θεωρήθηκε πως υπάρχει μια τρέχουσα σύνδεση"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Δεν βρέθηκε μόντεμ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Αποτυχία σύνδεσης του Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Δεν έχει τοποθετηθεί η κάρτα SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Απαιτείται το Pin της SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Απαιτείται το Puk της SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Λάθος SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Απέτυχε η εξάρτηση της σύνδεσης"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Λείπει το υλικολογισμικό"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Το καλώδιο αποσυνδέθηκε"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "μη ορισμένο σφάλμα στην ασφάλεια 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "Δεν έχει επιλεγεί αρχείο"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "ακαθόριστο σφάλμα στην πιστοποίηση του αρχείου eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-#, fuzzy
-#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Ιδιωτικά κλειδιά DER, PEM, ή PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:397
-#, fuzzy
-#| msgid "_User certificate"
-msgid "DER or PEM certificates"
-msgstr "Πιστοποιητικό _χρήστη"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "Λείπει το αρχείο EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Αρχεία PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4657,14 +2564,6 @@ msgstr "_Εσωτερική πιστοποίηση"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Να επιτρέπεται η αυτόματη _παροχή PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "Λείπει το όνομα χρήστη EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "Λείπει ο κωδικός πρόσβασης EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4690,15 +2589,6 @@ msgstr "Κω_δικός πρόσβασης"
 msgid "Sho_w password"
 msgstr "Εμ_φάνιση κωδικού πρόσβασης"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "Άκυρο πιστοποιητικό EAP-PEAP CA: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "Άκυρο πιστοποιητικό EAP-PEAP CA: δεν έχει καθοριστεί πιστοποιητικό"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4720,7 +2610,6 @@ msgid "C_A certificate"
 msgstr "Πιστοποιητικό C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4735,65 +2624,6 @@ msgstr "Δεν α_παιτείται κανένα πιστοποιητικό CA"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "Έκ_δοση PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "Λείπει το όνομα χρήστη EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "Λείπει ο κωδικός πρόσβασης EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "Λείπει η ταυτότητα EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "Άκυρο πιστοποιητικό EAP-TLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "Άκυρο πιστοποιητικό EAP-TLS CA: δεν έχει καθοριστεί πιστοποιητικό"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "Άκυρο ιδιωτικό κλειδί EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "Άκυρο πιστοποιητικό χρήστη EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Τα μη κρυπτογραφημένα ιδιωτικά κλειδιά είναι επισφαλή"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Το επιλεγμένο ιδιωτικό κλειδί δεν φαίνεται να προστατεύεται από ένα "
-"συνθηματικό. Αυτό πιθανόν να επιτρέπει τα διαπιστευτήρια ασφάλειας να "
-"παραβιαστούν. Παρακαλούμε επιλέξτε ένα ιδιωτικό κλειδί που να προστατεύεται "
-"από ένα συνθηματικό.\n"
-"\n"
-"(Μπορείτε να προστατεύσετε με συνθηματικό το ιδιωτικό σας κλειδί με το "
-"openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Επιλέξτε το προσωπικό σας πιστοποιητικό"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Επιλέξτε το ιδιωτικό σας κλειδί"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4810,15 +2640,6 @@ msgstr "Ιδιωτικό κ_λειδί"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Κωδικός πρόσβασης _ιδιωτικού κλειδιού"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "Άκυρο πιστοποιητικό EAP-TTLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "Άκυρο πιστοποιητικό EAP-TTLS CA: δεν έχει καθοριστεί πιστοποιητικό"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4841,14 +2662,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Τομέας"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Άγνωστο σφάλμα κατά την πιστοποίηση της ασφάλειας 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4876,65 +2698,10 @@ msgstr "Προστατευμένο EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Πιστοποίηση"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Επιλογή ενός αρχείου"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "Λείπει το όνομα χρήστη leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "Λείπει το συνθηματικό leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-#, fuzzy
-#| msgid "invalid EAP-TLS password: missing"
-msgid "Wi-Fi password is missing."
-msgstr "Άκυρο πιστοποιητικό EAP-TLS: λείπει"
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Τύπος"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "Λείπει το κλειδί wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"Άκυρο wep-key: το κλειδί με μήκος %zu πρέπει να περιέχει μόνο δεκαεξαδικά "
-"ψηφία"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"Άκυρο wep-key: το κλειδί με μήκος %zu πρέπει να περιέχει μόνο χαρακτήρες "
-"ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"Άκυρο wep-key: λαθεμένο μήκος κλειδιού %zu. Ένα κλειδί πρέπει να έχει μήκος "
-"χαρακτήρων 5/13 (ascii) ή 10/26 (δεκαεξαδικό)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "μη έγκυρο wep-key: το συνθηματικό δεν πρέπει να είναι κενό"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"μη έγκυρο wep-key: το συνθηματικό πρέπει να είναι μικρότερο από 64 χαρακτήρες"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4959,20 +2726,6 @@ msgstr "Εμ_φάνιση κλειδιού"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Δεί_κτης WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"μη έγκυρο wpa-psk:  μη έγκυρο μήκος κλειδιού %zu. Πρέπει να είναι [8,63] "
-"bytes ή 64 δεκαεξαδικά ψηφία"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"μη έγκυρο wpa-psk: αδυναμία μεταγλώττισης κλειδιού με 64 bytes ως δεκαεξαδικό"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -5027,29 +2780,11 @@ msgstr "Ειδοποιήσεις _κλειδώματος οθόνης"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Ελέγξτε ποιες ειδοποιήσεις εμφανίζονται και τι εμφανίζουν"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Ειδοποιήσεις;Τίτλοι;Μήνυμα;Δίσκος;Αναδυόμενο;Notifications;Banner;Message;"
 "Tray;Popup;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Άλλο"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "Ο %s αφαιρέθηκε"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Σφάλμα αφαίρεσης λογαριασμού"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -5059,7 +2794,6 @@ msgstr "Aναίρεση"
 
 #: panels/online-accounts/cc-online-accounts-panel.ui:31
 #, fuzzy
-#| msgid "_Inner authentication"
 msgid "Close the notification"
 msgstr "_Εσωτερική πιστοποίηση"
 
@@ -5077,17 +2811,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Προσθήκη λογαριασμού"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Λογαριασμός %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Αφαίρεση λογαριασμού"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Διαδικτυακοί λογαριασμοί"
@@ -5098,10 +2821,6 @@ msgstr ""
 "Συνδεθείτε με τους δικτυακούς λογαριασμούς σαε και αποφασίστε πού θα τους "
 "χρησιμοποιήσετε"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5110,10 +2829,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Ιστός;Με σύνδεση;Συνομιλία;Ημερολόγιο;"
 "Αλληλογραφία;Επαφές;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;Online;"
 "Chat;Calendar;Mail;Contact;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Άγνωστος χρόνος"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5129,13 +2844,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i ώρα"
 msgstr[1] "%i ώρες"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5147,186 +2855,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "λεπτό"
 msgstr[1] "λεπτά"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s μέχρι την πλήρη φόρτιση"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Προσοχή: απομένει %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "απομένει %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Πλήρης φόρτιση"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Δεν φορτίζεται"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Κενό"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Φορτίζεται"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Εκφορτίζεται"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Ασύρματο ποντίκι"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Ασύρματο πληκτρολόγιο"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Αδιάλειπτη παροχή ρεύματος"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Προσωπικός ψηφιακός βοηθός"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Κινητό τηλέφωνο"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Αναπαραγωγέας πολυμέσων"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Υπολογιστής"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Συσκευή εισαγωγής για παιχνίδια"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Μπαταρία"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Κύριο"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Πρόσθετο"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Μπαταρίες"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Όταν είναι _ανενεργό"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Αναστολή"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Τερματισμός"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Aδρανοποίηση"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Καμία ενέργεια"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Όταν τροφοδοτείται από μπαταρία"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Όταν είναι στην παροχή ρεύματος"
-
-#: panels/power/cc-power-panel.c:856
-#, fuzzy
-#| msgid "Never"
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Ποτέ"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Αυτόματη αναστολή"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr ""
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5388,9 +2916,17 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 ώρες"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Μπαταρία"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Συσκευές"
+
 #: panels/power/cc-power-panel.ui:93
 #, fuzzy
-#| msgid "Power off"
 msgid "Power Mode"
 msgstr "Τερματισμός"
 
@@ -5400,13 +2936,11 @@ msgstr ""
 
 #: panels/power/cc-power-panel.ui:123
 #, fuzzy
-#| msgid "Power Saving"
 msgid "Power Saving Options"
 msgstr "Εξοικονόμηση ενέργειας"
 
 #: panels/power/cc-power-panel.ui:126
 #, fuzzy
-#| msgid "Automatic Brightness"
 msgid "Automatic Screen Brightness"
 msgstr "Αυτόματη φωτεινότητα"
 
@@ -5416,7 +2950,6 @@ msgstr ""
 
 #: panels/power/cc-power-panel.ui:139
 #, fuzzy
-#| msgid "Screen"
 msgid "Dim Screen"
 msgstr "Οθόνη"
 
@@ -5426,7 +2959,6 @@ msgstr ""
 
 #: panels/power/cc-power-panel.ui:151
 #, fuzzy
-#| msgid "Screen _Reader"
 msgid "Screen _Blank"
 msgstr "Ανα_γνώστης οθόνης"
 
@@ -5436,7 +2968,6 @@ msgstr ""
 
 #: panels/power/cc-power-panel.ui:160
 #, fuzzy
-#| msgid "_Automatic Problem Reporting"
 msgid "Automatic Power Saver"
 msgstr "Α_υτόματη αναφορά προβλήματος"
 
@@ -5477,39 +3008,6 @@ msgstr "Με τροφοδοσία _μπαταρίας"
 msgid "Delay"
 msgstr "Καθυστέρηση"
 
-#: panels/power/cc-power-profile-row.c:132
-#, fuzzy
-#| msgid "Permanent"
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Μόνιμο"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:136
-#, fuzzy
-#| msgid "Balance"
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Ισοστάθμιση"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:140
-#, fuzzy
-#| msgid "Power Saving"
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Εξοικονόμηση ενέργειας"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr ""
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Ενέργεια"
@@ -5520,12 +3018,8 @@ msgstr ""
 "Δείτε την κατάστασης της μπαταρίας σας και αλλάξτε τις ρυθμίσεις αποθήκευσης "
 "ενέργειας"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 #, fuzzy
-#| msgid ""
-#| "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;"
-#| "Idle;"
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
@@ -5533,29 +3027,6 @@ msgstr ""
 "Ισχύς;Ενέργεια;Ρεύμα;Ύπνωση;Αναστολή;Αδρανοποίηση;Μπαταρία;Φωτεινότητα;"
 "Αμυδρό;Κενό;Οθόνη;DPMS;Αδρανές;Power;Sleep;Suspend;Hibernate;Battery;"
 "Brightness;Dim;Blank;Monitor;Idle;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Ο εκτυπωτής «%s» έχει διαγραφεί"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Αδυναμία φόρτωσης γραφικού περιβάλλοντος: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-#, fuzzy
-#| msgid "Unlock to Change Settings"
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Ξεκλειδώστε για να αλλάξετε ρυθμίσεις"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5567,7 +3038,6 @@ msgstr ""
 "Προσθέστε εκτυπωτές, δείτες τις εργασίες ενός εκτυπωτή και καθορίστε τον "
 "τρόπο εκτύπωσης"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -5577,8 +3047,6 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Προσθήκη εκτυπωτή"
 
@@ -5619,29 +3087,6 @@ msgstr ""
 msgid "Username"
 msgstr "Όνομα χρήστη"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Λεπτομέρειες %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Δε βρέθηκε κατάλληλος οδηγός"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Επιλεγμένο αρχείο PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Αρχεία περιγραφής εκτυπωτών PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
@@ -5650,9 +3095,7 @@ msgstr ""
 msgid "Location"
 msgstr "Τοποθεσία"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Οδηγός"
 
@@ -5680,140 +3123,20 @@ msgstr "Επιλέξτε τον οδηγό του εκτυπωτή"
 msgid "Loading drivers database…"
 msgstr "Φόρτωση βάσης δεδομένων των οδηγών…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Ακύρωση"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Επιλογή"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Εκτυπωτής JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Εκτυπωτής LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Μονής όψης"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Μακρύ άκρο (κανονικό)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Βραχύ άκρο (αναστροφή)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Κάθετα"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Οριζόντια"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Αντίστροφα οριζόντιο"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Αντίστροφα κάθετο"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Συνέχεια"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Παύση"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Εκκρεμεί"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Σε παύση"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Απαιτείται πιστοποίηση"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Γίνεται επεξεργασία"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Διακόπηκε"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Ακυρώθηκε"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Εγκαταλείφθηκε"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Ολοκληρώθηκε"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr ""
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u εργασία απαιτεί πιστοποίηση"
 msgstr[1] "%u εργασίες απαιτούν πιστοποίηση"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Ενεργές εργασίες"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Εισάγετε διαπιστευτήρια για να εκτυπώσετε από %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5841,323 +3164,17 @@ msgstr "_Πιστοποίηση"
 msgid "No Active Printer Jobs"
 msgstr "Καμία ενεργή εργασία εκτύπωσης"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Ξεκλείδωμα διακομιστή εκτύπωσης"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Ξεκλείδωμα %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Εισάγετε ένα όνομα χρήστη και έναν κωδικό πρόσβασης για να δείτε εκτυπωτές "
-"στο %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Αναζήτηση για εκτυπωτές"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Σειριακή θύρα"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Παράλληλη θύρα"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Τοποθεσία: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Διεύθυνση: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Ο διακομιστής απαιτεί ταυτοποίηση"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Διπλής όψης"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Τύπος χαρτιού"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Πηγή χαρτιού"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Συρτάρι εξόδου"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Ανάλυση"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Προφιλτράρισμα GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Σελίδες ανά φύλλο"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Διπλής όψης"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Προσανατολισμός"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Γενικά"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Ρύθμιση σελίδας"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Εγκαταστάσιμες επιλογές"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Εργασία"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Ποιότητα εικόνας"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Χρώμα"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Ολοκληρώνεται"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Για προχωρημένους"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Δοκιμαστική σελίδα"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Δοκιμαστική σελίδα"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Αυτόματη επιλογή"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Προεπιλογή εκτυπωτή"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Ενσωμάτωση μόνο των γραμματοσειρών GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Μετατροπή σε PS επιπέδου 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Μετατροπή σε PS επιπέδου 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Χωρίς προ-φιλτράρισμα"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Κατασκευαστής"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Χωρίς ενεργές εργασίες"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u εργασία"
 msgstr[1] "%u εργασίες"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Καθαρισμός κεφαλών εκτυπωτή"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Τελειώνει ο γραφίτης"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Άδειος γραφίτης"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Τελειώνει το υγρό εμφάνισης"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Τελείωσε το υγρό εμφάνισης"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Τελειώνει ένα από τα χρώματα"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Τελείωσε ένα από τα χρώματα"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Κάλυμμα ανοικτό"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Πορτάκι ανοικτό"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Τελειώνει το χαρτί"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Τελείωσε το χαρτί"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Αποσυνδεδεμένος"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Διακόπηκε"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Το δοχείο απορριμμάτων σχεδόν γέμισε"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Το δοχείο απορριμμάτων είναι γεμάτο"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Το τύμπανο είναι σχεδόν στο τέλος της ζωής του"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Το τύμπανο δεν δουλεύει πλέον"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Έτοιμο"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Δεν δέχεται εργασίες"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Γίνεται επεξεργασία"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6181,6 +3198,10 @@ msgstr "Καθαρισμός κεφαλών εκτυπωτή"
 msgid "Remove Printer"
 msgstr "Αφαίρεση εκτυπωτή"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Χωρίς ενεργές εργασίες"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6201,20 +3222,22 @@ msgid "Restart"
 msgstr "Επανεκκίνηση"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Προσθήκη εκτυπωτή…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Προσθήκη εκτυπωτή…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Χωρίς εκτυπωτές"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 #, fuzzy
-#| msgid ""
-#| "Sorry! The system printing service\n"
-#| "doesn’t seem to be available."
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6222,14 +3245,12 @@ msgstr ""
 "Συγγνώμη! Η υπηρεσία εκτύπωσης του συστήματος\n"
 "φαίνεται να μην είναι διαθέσιμη."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Μορφές"
 
 #: panels/region/cc-format-chooser.ui:76
 #, fuzzy
-#| msgid "Search locales..."
 msgid "Search locales…"
 msgstr "Αναζήτηση τοπικών ρυθμίσεων..."
 
@@ -6252,16 +3273,6 @@ msgstr "Οι αναζητήσεις μπορούν να γίνουν για χώ
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Προεπισκόπηση"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Αυτοκρατορικό"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Μετρικό"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6297,20 +3308,24 @@ msgid ""
 "used for numbers, dates, and currencies."
 msgstr ""
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Ο λογαριασμός σας"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "Γ_λώσσα"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "Μορ_φοποιήσεις"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Οθόνη σύνδεσης"
 
@@ -6320,109 +3335,13 @@ msgstr "Περιοχή & Γλώσσα"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
 #, fuzzy
-#| msgid ""
-#| "Select your display language, formats, keyboard layouts and input sources"
 msgid "Select your display language and formats"
 msgstr ""
 "Επιλέξτε γλώσσα εμφάνισης, μορφές, διατάξεις πληκτρολογίου και πηγές εισόδου"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Γλώσσα;Διάταξη;Πληκτρολόγιο;Είσοδος;Language;Layout;Keyboard;Input;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Ερώτηση για την ενέργεια"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Καμία ενέργεια"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Άνοιγμα φακέλου"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Άλλα μέσα"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Επιλέξτε μια εφαρμογή για CD ήχου"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Επιλέξτε μια εφαρμογή για DVD βίντεο"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Επιλέξτε την εφαρμογή που θα εκτελείται, όταν θα συνδέεται ένας "
-"αναπαραγωγέας μουσικής"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-"Επιλέξτε την εφαρμογή που θα εκτελείται, όταν θα συνδέεται μια φωτογραφική "
-"μηχανή"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Επιλέξτε μια εφαρμογή για τα CD λογισμικού"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD ήχου"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Κενό Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "Κενό CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "Κενό DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "Κενό HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Δίσκος βίντεο Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "Αναγνώστης ηλεκτρονικών βιβλίων"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Δίσκος βίντεο HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "CD εικόνων"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Λογισμικό Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6474,7 +3393,6 @@ msgstr "Αφαιρούμενα μέσα"
 msgid "Configure Removable Media settings"
 msgstr "Ρύθμιση επιλογών αφαιρούμενων μέσων"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6483,114 +3401,6 @@ msgstr ""
 "συσκευή;σύστημα;προεπιλογή;εφαρμογή;προτιμώμενη;cd;dvd;usb;ήχος;βίντεο;"
 "δίσκος;αφαιρέσιμος;μέσα;αυτόματη εκτέλεση;device;system;default;application;"
 "preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Η οθόνη σβήνει"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 δευτερόλεπτα"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 λεπτό"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 λεπτά"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 λεπτά"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 λεπτά"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 λεπτά"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 ώρα"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 λεπτό"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 λεπτά"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 λεπτά"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 λεπτά"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 λεπτά"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 λεπτά"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 λεπτά"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 λεπτά"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 λεπτά"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Ποτέ"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6628,11 +3438,16 @@ msgstr "Περίοδος μετά το μαύρισμα της οθόνης ότ
 msgid "Show _Notifications on Lock Screen"
 msgstr "Εμφάνιση _ειδοποιήσεων στην οθόνη κλειδώματος"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Ειδοποιήσεις _κλειδώματος οθόνης"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr ""
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6640,32 +3455,26 @@ msgstr ""
 "Αποτρέψτε την αλληλεπίδραση νέων συσκευών USB με το σύστημα όταν η οθόνη "
 "είναι κλειδωμένη."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 #, fuzzy
-#| msgid "Privacy"
 msgid "Screen Privacy"
 msgstr "Ιδιωτικότητα"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Οθόνη"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Ρυθμίσεις οθόνης"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr ""
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Επιλογή περιοχής"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Εντάξει"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6696,13 +3505,8 @@ msgstr "Άλλοι"
 msgid "Add Location"
 msgstr "Προσθήκη τοποθεσίας"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Δε βρέθηκαν εφαρμογές"
-
 #: panels/search/cc-search-panel.ui:10
 #, fuzzy
-#| msgid "Application"
 msgid "Application Search"
 msgstr "Εφαρμογή"
 
@@ -6712,9 +3516,6 @@ msgstr ""
 
 #: panels/search/cc-search-panel.ui:23
 #, fuzzy
-#| msgid ""
-#| "Folders which are searched by system applications, such as Files, Photos "
-#| "and Videos."
 msgid "Folders which are searched by system applications."
 msgstr ""
 "Φάκελοι που αναζητούνται από εφαρμογές συστήματος, όπως Αρχεία, Φωτογραφίες "
@@ -6722,7 +3523,6 @@ msgstr ""
 
 #: panels/search/cc-search-panel.ui:37
 #, fuzzy
-#| msgid "No Search Results"
 msgid "Search Results"
 msgstr "Δε βρέθηκαν αποτελέσματα αναζήτησης"
 
@@ -6737,99 +3537,15 @@ msgstr ""
 "Ελέγξτε ποιες εφαρμογές εμφανίζουν αποτελέσματα αναζήτησης στην επισκόπηση "
 "Δραστηριότητες"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Αναζήτηση;Εύρεση;Ευρετήριο;Απόκρυψη;Ιδιωτικότητα;Αποτελέσματα;Search;Find;"
 "Index;Hide;Privacy;Results;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Δεν έχουν επιλεγεί δίκτυα για κοινή χρήση"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Δίκτυα"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Ενεργό"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Ανενεργό"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Ενεργοποιημένη"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Ενεργή"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Επιλογή φακέλου"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Προσθήκη"
-
-#: panels/sharing/cc-sharing-panel.c:736
-#, fuzzy
-#| msgid "Media Sharing"
-msgid "Enable media sharing"
-msgstr "Κοινή χρήση πολυμέσων"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Η κοινή χρήση αρχείων επιτρέπει να μοιράζεστε τον δημόσιο φάκελό σας με "
-"άλλους, στο υπάρχον δίκτυό σας, χρησιμοποιώντας: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Όταν είναι ενεργοποιημένη η απομακρυσμένη σύνδεση, οι απομακρυσμένοι χρήστες "
-"μπορούν να συνδεθούν χρησιμοποιώντας εντολή ασφαλούς κελύφους (SSH):\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-#, fuzzy
-#| msgid "Personal File Sharing"
-msgid "Enable personal media sharing"
-msgstr "Κοινή χρήση προσωπικών αρχείων"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Αντιγράφηκε το όνομα συσκευής"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Αντιγράφηκε το όνομα χρήστη"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Αντιγράφηκε το συνθηματικό"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6846,7 +3562,6 @@ msgstr "_Κοινή χρήση αρχείων"
 
 #: panels/sharing/cc-sharing-panel.ui:65
 #, fuzzy
-#| msgid "Remote View"
 msgid "Remote _Desktop"
 msgstr "Απομακρυσμένη προβολή"
 
@@ -6874,7 +3589,6 @@ msgstr "Απομακρυσμένη σύνδεση"
 #: panels/sharing/cc-sharing-panel.ui:251
 #: panels/sharing/cc-sharing-panel.ui:270
 #, fuzzy
-#| msgid "Remote View"
 msgid "Remote Desktop"
 msgstr "Απομακρυσμένη προβολή"
 
@@ -6886,7 +3600,6 @@ msgstr ""
 
 #: panels/sharing/cc-sharing-panel.ui:271
 #, fuzzy
-#| msgid "Enable or disable remote login"
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr "Ενεργοποίηση η απενεργοποίηση της απομακρυσμένης σύνδεσης"
 
@@ -6896,13 +3609,11 @@ msgstr "Απομακρυσμένος έλεγχος"
 
 #: panels/sharing/cc-sharing-panel.ui:285
 #, fuzzy
-#| msgid "_Allow connections to control the screen"
 msgid "Allows remote connections to control the screen."
 msgstr "Να επιτ_ρέπεται στις συνδέσεις ο έλεγχος της οθόνης"
 
 #: panels/sharing/cc-sharing-panel.ui:299
 #, fuzzy
-#| msgid "Not connected"
 msgid "How to Connect"
 msgstr "Δεν συνδέθηκε"
 
@@ -6920,7 +3631,6 @@ msgstr "Αντιγραφή"
 
 #: panels/sharing/cc-sharing-panel.ui:331
 #, fuzzy
-#| msgid "Delete Address"
 msgid "Remote Desktop Address"
 msgstr "Διαγραφή διεύθυνσης"
 
@@ -6942,7 +3652,6 @@ msgstr ""
 
 #: panels/sharing/cc-sharing-panel.ui:434
 #, fuzzy
-#| msgid "Fingerprint"
 msgid "Encryption Fingerprint"
 msgstr "Δακτυλικό αποτύπωμα"
 
@@ -6968,7 +3677,6 @@ msgstr "Φάκελοι"
 msgid "Control what you want to share with others"
 msgstr "Ελέγξτε τι θέλετε να μοιράζεστε με τους άλλους"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6988,10 +3696,6 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Απαιτείται πιστοποίηση για την ενεργοποίηση ή απενεργοποίηση της "
 "απομακρυσμένης σύνδεσης"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Προσαρμοσμένη"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -7025,11 +3729,6 @@ msgstr "Πίσω"
 msgid "Front"
 msgstr "Μπροστά"
 
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Δοκιμή του %s"
-
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
 msgstr "Κάντε κλικ στο ηχείο για δοκιμή"
@@ -7040,7 +3739,6 @@ msgstr "Ένταση συστήματος"
 
 #: panels/sound/cc-sound-panel.ui:12
 #, fuzzy
-#| msgid "System Volume"
 msgid "Master volume"
 msgstr "Ένταση συστήματος"
 
@@ -7084,11 +3782,6 @@ msgstr "Ένταση"
 msgid "Alert Sound"
 msgstr "Ήχος ειδοποίησης"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Σίγαση"
@@ -7102,83 +3795,12 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Αλλάξτε την ένταση ήχου, τις εισόδους, εξόδους και τις ηχητικές ειδοποιήσεις"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Κάρτα;Μικρόφωνο;Ένταση;Απόσβεση;Ισορροπία;Bluetooth;Ακουστικά;Ήχος;Έξοδος;"
 "Είσοδος;Card;Microphone;Volume;Fade;Balance;Headset;Audio;Output;Input;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Aποσυνδεδεμένη"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Γίνεται σύνδεση"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Συνδεδεμένη"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Σφάλμα πιστοποίησης"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Γίνεται εξουσιοδότηση"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Μειωμένη λειτουργικότητα"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Συνδεδεμένη & πιστοποιημένη"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Άγνωστο"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Πιστοποιήθηκε την:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Συνδέθηκε:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Εγγραφή σε:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Αποτυχία πιστοποίησης συσκευής: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Αποτυχία παράλειψης συσκευής: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7190,7 +3812,6 @@ msgstr[1] "Εξαρτάται από %u άλλες συσκευές"
 #: panels/thunderbolt/cc-bolt-device-dialog.ui:43
 #: panels/thunderbolt/cc-bolt-panel.ui:41
 #, fuzzy
-#| msgid "Notifications"
 msgid "Close notification"
 msgstr "Ειδοποιήσεις"
 
@@ -7214,72 +3835,25 @@ msgstr "Πιστοποίηση και σύνδεση"
 msgid "Forget Device"
 msgstr "Παράλειψη συσκευής"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Σφάλμα"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Πιστοποιήθηκε"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Το υποσύστημα του Thunderbolt (boltd) δεν έχει εγκατασταθεί ή δεν έχει "
-"ρυθμιστεί σωστά."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Να επιτρέπεται η άμεση πρόσβαση σε συσκευές όπως τα docks και οι εξωτερικές "
-"μονάδες GPU."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Μόνο συσκευές USB και θύρες οθόνης μπορούν να συνδεθούν."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Δεν ήταν δυνατή η ανίχνευση του Thunderbolt.\n"
-"Είτε το σύστημα δεν διαθέτει υποστήριξη Thunderbolt, έχει απενεργοποιηθεί "
-"στο BIOS ή έχει οριστεί σε επίπεδο ασφαλείας μη υποστήριξης στο BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Η υποστήριξη Thunderbolt έχει απενεργοποιηθεί στο BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Δεν ήταν δυνατό να καθοριστεί το επίπεδο ασφάλειας του Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Σφάλμα εναλλαγής άμεσης λειτουργίας: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 #, fuzzy
-#| msgid "No Thunderbolt support"
 msgid "No Thunderbolt Support"
 msgstr "Καμία υποστήριξη για Thunderbolt"
 
 #: panels/thunderbolt/cc-bolt-panel.ui:103
 #, fuzzy
-#| msgid "Couldn’t connect to the %s domain: %s"
 msgid "Could not connect to the thunderbolt subsystem."
 msgstr "Αδυναμία σύνδεσης στον τομέα %s: %s"
 
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Άμεση πρόσβαση"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Να επιτρέπεται η άμεση πρόσβαση σε συσκευές όπως τα docks και οι εξωτερικές "
+"μονάδες GPU."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7297,7 +3871,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Διαχείριση συσκευών Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;ιδιωτικότητα;"
@@ -7502,40 +4075,6 @@ msgstr ""
 "Ενεργοποίηση ή απενεργοποίηση των λειτουργιών προσιτότητας από το "
 "πληκτρολόγιο"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Προεπιλεγμένο"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Μεσαίο"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Μεγάλο"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Μεγαλύτερο"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Μέγιστο"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d εικονοστοιχείο"
-msgstr[1] "%d εικονοστοιχεία"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Να εμφανίζεται πά_ντα το μενού προσβασιμότητας"
@@ -7610,7 +4149,6 @@ msgstr "Βοήθεια πληκ_τρολόγησης (AccessX)"
 
 #: panels/universal-access/cc-ua-panel.ui:240
 #, fuzzy
-#| msgid "Pointing & Clicking"
 msgid "Pointing &amp; Clicking"
 msgstr "Κατάδειξη και πάτημα"
 
@@ -7653,31 +4191,6 @@ msgstr "Αναβόσβημα ολόκληρης της _οθόνης"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Αναβόσβημα ολόκληρου της _παραθύρου"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Σύντομο"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ της οθόνης"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ της οθόνης"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ της οθόνης"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Μακρύ"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7836,14 +4349,8 @@ msgstr ""
 "Κάντε πιο εύκολη την προβολή, την ακρόαση, την πληκτρολόγηση, την κατάδειξη "
 "και το κλικ"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 #, fuzzy
-#| msgid ""
-#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;"
-#| "Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;"
-#| "Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;"
-#| "typing;"
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
@@ -7857,114 +4364,6 @@ msgstr ""
 "Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;big;high;large;text;"
 "font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Speed;"
 "Assist;Repeat;Blink;visual;hearing;audio;typing;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 ώρα"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 ημέρα"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 ημέρες"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 ημέρες"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 ημέρες"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 ημέρες"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 ημέρες"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 ημέρες"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 ημέρες"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 ημέρες"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Διαγραφή όλων των αντικειμένων από τα απορρίμματα;"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Όλα τα αντικείμενα στα απορρίμματα θα διαγραφούν οριστικά."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Ά_δειασμα απορριμμάτων"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Διαγραφή όλων των προσωρινών αρχείων;"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Όλα τα προσωρινά αρχεία θα διαγραφούν μόνιμα."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Εκκαθάριση προσωρινών αρχείων"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 ημέρα"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 ημέρες"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 ημέρες"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Για πάντα"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7994,7 +4393,6 @@ msgstr "Εκκα_θάριση ιστορικού…"
 
 #: panels/usage/cc-usage-panel.ui:63
 #, fuzzy
-#| msgid "Trash & Temporary Files"
 msgid "Trash &amp; Temporary Files"
 msgstr "Κάδος απορριμμάτων & Προσωρινά αρχεία"
 
@@ -8035,62 +4433,10 @@ msgstr "Ιστορικό αρχείου & Κάδος απορριμάτων"
 msgid "Don't leave traces"
 msgstr "Να μην αφήνονται ίχνη"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Πρέπει να ταιριάζει η διεύθυνση ιστού του παρόχου της εισόδου σας."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Αποτυχία προσθήκης λογαριασμού"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Δεν ταιριάζουν οι κωδικοί πρόσβασης."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Αποτυχία εγγραφής του λογαριασμού"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Κανένας υποστηριζόμενος τρόπος πιστοποίησης με αυτόν τον τομέα"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Αποτυχία ένταξης στο τομέα"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Αυτό το όνομα εισόδου δεν δούλεψε.\n"
-"Παρακαλούμε, προσπαθήστε ξανά."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Αυτός ο κωδικός πρόσβασης εισόδου δεν δούλεψε.\n"
-"Παρακαλούμε, προσπαθήστε ξανά."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Αποτυχία σύνδεσης στο τομέα"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Αδύνατη η εύρεση του τομέα. Μήπως τον γράψατε λάθος;"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -8103,9 +4449,6 @@ msgstr "Διαχειριστής"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:132
 #, fuzzy
-#| msgid ""
-#| "Administrators can add and remove other users, and can change settings "
-#| "for all users."
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users. Parental controls cannot be applied to administrators."
@@ -8115,7 +4458,6 @@ msgstr ""
 
 #: panels/user-accounts/cc-add-user-dialog.ui:149
 #, fuzzy
-#| msgid "Allow user to change their password on next login"
 msgid "User sets password on first login"
 msgstr ""
 "Να επιτρέπεται στον χρήστη να αλλάξει τον κωδικό πρόσβασης στην επόμενη "
@@ -8131,7 +4473,6 @@ msgstr "Επιβεβαίωση"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:278
 #, fuzzy
-#| msgid "_Enterprise Login"
 msgid "Enterprise Login"
 msgstr "_Εταιρική σύνδεση"
 
@@ -8153,10 +4494,6 @@ msgstr ""
 "λογαριασμό χρήστη να χρησιμοποιηθεί σε αυτή τη συσκευή. Μπορείτε επίσης να "
 "χρησιμοποιήσετε τον λογαριασμό γι να έχετε πρόσβαση σε πόρους της εταιρείας "
 "στο διαδίκτυο."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Περιηγηθείτε για περισσότερες φωτογραφίες"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8228,242 +4565,6 @@ msgstr "_Διαγραφή αποτυπωμάτων"
 msgid "Fingerprint Enroll"
 msgstr "Εγγραφή δακτυλικού αποτυπώματος"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-#, fuzzy
-#| msgid "The device is already in use."
-msgid "the device is already claimed by another process"
-msgstr "Η συσκευή χρησιμοποιείται ήδη."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-#, fuzzy
-#| msgid "Failed to register with the requested network"
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Αποτυχία εγγραφής στο ζητούμενο δίκτυο"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-#, fuzzy
-#| msgid "Failed to add new printer."
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-#, fuzzy
-#| msgid "Failed to add new printer."
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, fuzzy, c-format
-#| msgid "Failed to apply configuration: %s"
-msgid "Failed to list fingerprints: %s"
-msgstr "Αποτυχία εφαρμογής των ρυθμίσεων: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Αποτυχία διαγραφής αποθηκευμένων δακτυλικών αποτυπωμάτων: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Αριστερός αντίχειρας"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Αριστερό μεσαίο δάκτυλο"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Α_ριστερός δείκτης"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Αριστερός δείκτης"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Αριστερό μικρό δάκτυλο"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Δεξιός αντίχειρας"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Δεξιό μεσαίο δάκτυλο"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Δεξιός _δείκτης"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Δεξιός δείκτης"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Δεξιό μικρό δάκτυλο"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Άγνωστος αποτύπωμα"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Ολοκληρώθηκε"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Αποσυνδέθηκε η συσκευή δακτυλικού αποτυπώματος"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Ο χώρος αποθήκευσης δακτυλικών αποτυπωμάτων είναι πλήρης"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-#, fuzzy
-#| msgid "Failed to add new printer."
-msgid "Failed to enroll new fingerprint"
-msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, fuzzy, c-format
-#| msgid "Failed to upload file: %s"
-msgid "Failed to start enrollment: %s"
-msgstr "Αποτυχία αποστολής αρχείου: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-#, fuzzy
-#| msgid "Failed to add new printer."
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, fuzzy, c-format
-#| msgid "Failed to upload file: %s"
-msgid "Failed to stop enrollment: %s"
-msgstr "Αποτυχία αποστολής αρχείου: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Ανασηκώστε επανειλημμένα και τοποθετήστε το δάχτυλό σας στον αναγνώστη για "
-"να εγγράψετε το δακτυλικό σας αποτύπωμα"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr ""
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Σάρωση νέου δακτυλικού αποτυπώματος"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, fuzzy, c-format
-#| msgid "Failed to forget device: "
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Αποτυχία παράλειψης συσκευής: "
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-#, fuzzy
-#| msgid "Pending Devices"
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Εκκρεμείς συσκευές"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, fuzzy, c-format
-#| msgid "Failed to forget device: "
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Αποτυχία παράλειψης συσκευής: "
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, fuzzy, c-format
-#| msgid "Failed to forget device: "
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Αποτυχία παράλειψης συσκευής: "
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Αυτήν την εβδομάδα"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Την τελευταία εβδομάδα"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Η συνεδρία τελείωσε"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Η συνεδρία άρχισε"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Δραστηριότητα λογαριασμού"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Προηγούμενο"
@@ -8471,18 +4572,6 @@ msgstr "Προηγούμενο"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Επόμενο"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Παρακαλούμε επιλέξτε άλλον κωδικό πρόσβασης."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Παρακαλούμε πληκτρολογήστε ξανά τον τρέχων κωδικό πρόσβασής σας."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Ο κωδικός πρόσβασής σας δεν μπορούσε να αλλαχθεί"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8504,6 +4593,10 @@ msgstr "Νέο συνθηματικό"
 msgid "Confirm Password"
 msgstr "Επιβεβαίωση συνθηματικού"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Δεν ταιριάζουν οι κωδικοί πρόσβασης."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
@@ -8513,140 +4606,6 @@ msgstr ""
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Καθορισμός κωδικού πρόσβασης"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Αδυναμία αυτόματης ένωσης αυτού του τύπου τομέα"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Δεν βρέθηκε τέτοιος τομέας ή realm"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Αδυναμία σύνδεσης ως %s στον τομέα %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Λάθος κωδικός πρόσβασης, παρακαλούμε προσπαθήστε ξανά"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Αδυναμία σύνδεσης στον τομέα %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Αποτυχία διαγραφής χρήστη"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Αποτυχία ανάκλησης απομακρυσμένης διαχείρισης χρήστη"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Δεν μπορείτε να διαγράψετε τον δικό σας λογαριασμό."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s είναι ακόμη συνδεδεμένος"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Η διαγραφή ενός χρήστη ενώ είναι συνδεδεμένος μπορεί να αφήσει το σύστημα σε "
-"ασταθή κατάσταση."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Θέλετε να κρατήσετε τα αρχεία του %s;"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Είναι δυνατόν να διατηρηθεί ο προσωπικός κατάλογος, το αρχείο αλληλογραφίας "
-"και τα προσωρινά αρχεία μετά τη διαγραφή ενός λογαριασμού χρήστη."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Διαγραφή αρχείων"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "Δια_τήρηση αρχείων"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Είστε σίγουροι ότι θέλετε να ανακαλέσετε τον λογαριασμό της απομακρυσμένης "
-"διαχείρισης του %s;"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Διαγραφή"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Απενεργοποιημένος λογαριασμός"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Θα ορισθεί στην επόμενη σύνδεση"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Κανένας"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Συνδεμένος"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Αποτυχία επικοινωνίας με την υπηρεσία λογαριασμών"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Παρακαλούμε βεβαιωθείτε ότι το AccountService έχει εγκατασταθεί και είναι "
-"ενεργοποιημένο."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Διαγραφή του επιλεγμένου λογαριασμού χρήστη"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Για να διαγράψετε τον επιλεγμένο λογαριασμό χρήστη,\n"
-"κάντε πρώτα κλικ στο εικονίδιο *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-#, fuzzy
-#| msgid "Unlock to Change Settings"
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Ξεκλειδώστε για να αλλάξετε ρυθμίσεις"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8674,7 +4633,6 @@ msgid "Full name"
 msgstr "Πλήρες Όνομα"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Eπεξεργασία"
 
@@ -8736,7 +4694,6 @@ msgstr "Ξεκλείδωμα για προσθήκη λογαριασμού χρ
 msgid "Add or remove users and change your password"
 msgstr "Προσθέστε ή διαγράψτε χρήστες και αλλάξτε τον κωδικό πρόσβασης σας"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8780,192 +4737,6 @@ msgstr "Διαχείριση λογαριασμών των χρηστών"
 msgid "Authentication is required to change user data"
 msgstr "Απαιτείται πιστοποίηση για την αλλαγή δεδομένων του χρήστη"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Ο νέος κωδικός πρόσβασης πρέπει να είναι διαφορετικός από τον παλιό."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Προσπαθήστε να αλλάξετε μερικά γράμματα και αριθμούς."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Δοκιμάστε να αλλάξετε τον κωδικό πρόσβασης λίγο περισσότερο."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr ""
-"Ένας κωδικός πρόσβασης χωρίς το όνομα χρήστη πιθανόν να είναι πιο ισχυρός."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr ""
-"Προσπαθήστε να αποφύγετε τη χρήση του ονόματός σας στον κωδικό πρόσβασης."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr ""
-"Προσπαθήστε να αποφύγετε μερικές από τις λέξεις που συμπεριλαμβάνονται στον "
-"κωδικό πρόσβασης."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Προσπαθήστε να αποφύγετε συνηθισμένες λέξεις."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Προσπαθήστε να αποφύγετε αναδιάταξη υπαρχουσών λέξεων."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Προσπαθήστε να χρησιμοποιήσετε περισσότερους αριθμούς."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Προσπαθήστε να χρησιμοποιήσετε περισσότερα κεφαλαία γράμματα."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Προσπαθήστε να χρησιμοποιήσετε περισσότερα πεζά γράμματα."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-"Προσπαθήστε να χρησιμοποιήσετε περισσότερους ειδικούς χαρακτήρες, όπως "
-"σημεία στίξης."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-"Προσπαθήστε να χρησιμοποιήσετε έναν συνδυασμό γραμμάτων, αριθμών και σημείων "
-"στίξης."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Προσπαθήστε να αποφύγετε την επανάληψη του ίδιου χαρακτήρα."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Προσπαθήστε να αποφύγετε την επανάληψη του ίδιου τύπου χαρακτήρα: χρειάζεστε "
-"την ανάμειξη γραμμάτων, αριθμών και σημείων στίξης."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Προσπαθήστε να αποφύγετε ακολουθίες όπως 1234 ή abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Τα συνθηματικά πρέπει να είναι μεγαλύτερα. Προσπαθήστε να προσθέσετε "
-"περισσότερα γράμματα, αριθμούς και σημεία στίξης."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Αναμείξτε κεφαλαία και πεζά γράμματα και χρησιμοποιήστε έναν ή περισσότερους "
-"αριθμούς."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Η προσθήκη περισσότερων γραμμάτων, αριθμών και σημείων στίξης θα κάνει "
-"ισχυρότερο το συνθηματικό."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Αποτυχία πιστοποίησης"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Ο κωδικός πρόσβασης είναι πολύ σύντομος"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Ο κωδικός πρόσβασης είναι πολύ απλός"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Ο παλιός και ο νέος κωδικός πρόσβασης μοιάζουν πολύ"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Ο νέος κωδικός πρόσβασης έχει χρησιμοποιηθεί πρόσφατα."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-"Ο νέος κωδικός πρόσβασης θα πρέπει να περιέχει αριθμητικούς ή ειδικούς "
-"χαρακτήρες"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Ο παλιός και ο νέος κωδικός πρόσβασης είναι οι ίδιοι"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Ο κωδικός πρόσβασης σας έχει αλλάξει από την αρχική σας πιστοποίηση!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Ο νέος κωδικός πρόσβασης δεν περιέχει αρκετά διαφορετικούς χαρακτήρες"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Άγνωστο σφάλμα"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Το όνομα χρήστη συνήθως πρέπει να αποτελείται μόνο από πεζά γράμματα από a-"
-"z, αριθμούς και από τους ακόλουθους χαρακτήρες: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Συγγνώμη, δεν είναι διαθέσιμο το όνομα χρήστη. Παρακαλούμε δοκιμάστε κάποιο "
-"αλλο."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Το όνομα χρήστη είναι πολύ μεγάλο."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -9000,58 +4771,13 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Ανιχνεύθηκε mis-click, γίνεται επανεκκίνηση…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Κουμπί %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Καθορίστηκε εφαρμογή"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Αποστολή πατήματος πλήκτρου"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Αλλαγή οθόνης"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Εμφάνιση βοήθειας στην οθόνη"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:435
-#, fuzzy
-#| msgid "Use bluetooth devices"
-msgid "External tablet device"
-msgstr "Χρήση συσκευών Bluetooth"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr ""
 
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Όλες οι οθόνες"
-
 #: panels/wacom/cc-wacom-page.ui:16
 #, fuzzy
-#| msgid "Tablet"
 msgid "Tablet Mode"
 msgstr "Tablet"
 
@@ -9061,7 +4787,6 @@ msgstr ""
 
 #: panels/wacom/cc-wacom-page.ui:28
 #, fuzzy
-#| msgid "Left-Handed Orientation"
 msgid "Left Hand Orientation"
 msgstr "Προσανατολισμός για αριστερόχειρες"
 
@@ -9071,14 +4796,12 @@ msgstr ""
 
 #: panels/wacom/cc-wacom-page.ui:58
 #, fuzzy
-#| msgid "Map to Monitor…"
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Χαρτογράφηση στην οθόνη…"
 
 #: panels/wacom/cc-wacom-page.ui:64
 #, fuzzy
-#| msgid "Aspect Ratio"
 msgid "Keep Aspect Ratio"
 msgstr "Λόγος θέασης"
 
@@ -9096,7 +4819,6 @@ msgstr "Δεν εντοπίσθηκε tablet"
 
 #: panels/wacom/cc-wacom-panel.ui:57
 #, fuzzy
-#| msgid "Please plug in or turn on your Wacom tablet"
 msgid "Please plug in or turn on your Wacom tablet."
 msgstr "Παρακαλούμε ενεργοποιήστε ή συνδέστε το Wacom tablet"
 
@@ -9139,7 +4861,6 @@ msgstr "Αίσθηση πίεσης σβήστρας"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:96
 #, fuzzy
-#| msgid "Eraser Pressure Feel"
 msgid "Eraser pressure"
 msgstr "Αίσθηση πίεσης σβήστρας"
 
@@ -9155,22 +4876,6 @@ msgstr "Δεξί κλικ κουμπιού του ποντικιού"
 msgid "Forward"
 msgstr "Μπροστά"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr ""
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom Tablet"
@@ -9181,67 +4886,103 @@ msgstr ""
 "Ορίστε τα κουμπιά και ρυθμίστε την ευαισθησία της γραφίδας για ταμπλέτες "
 "γραφικών"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Ταμπλέτα;Wacom;Γραφίδα;Stylus;Σβήστρα;Eraser;Ποντίκι;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Νέα συντόμευση…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Προσομοιωμένο δευτερεύον κλικ"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Λογισμικό Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Τελειώνει ο γραφίτης"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Δευτερεύον"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Λογισμικό Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
-#, fuzzy
-#| msgid "Access Options"
 msgid "Access Points"
-msgstr "Επιλογές πρόσβασης"
+msgstr "Σημεία πρόσβασης"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Προσθήκη"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Αποθήκευση"
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
-#| msgid "VPN"
 msgid "APN"
 msgstr "APN"
 
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Εγγεγραμμένος"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Αναζήτηση"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Απαγορεύεται"
-
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 #, fuzzy
-#| msgid "Details"
 msgid "Modem Details"
 msgstr "Λεπτομέρειες"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:16
 #, fuzzy
-#| msgid "Status:"
 msgid "Modem Status"
 msgstr "Κατάσταση:"
 
@@ -9251,7 +4992,6 @@ msgstr "Πάροχος"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:49
 #, fuzzy
-#| msgid "_Network Time"
 msgid "Network Type"
 msgstr "Ώρα _δικτύου"
 
@@ -9261,7 +5001,6 @@ msgstr "Κατάσταση δικτύου"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:122
 #, fuzzy
-#| msgid "Numbers"
 msgid "Own Number"
 msgstr "Αριθμοί"
 
@@ -9269,212 +5008,13 @@ msgstr "Αριθμοί"
 msgid "Device Details"
 msgstr "Λεπτομέρειες συσκευής"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Κατασκευαστής"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Έκδοση υλικολογισμικού"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Μόνο 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Μόνο 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Μόνο 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Μόνο 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "'Αγνωστη"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Ξεκλείδωμα"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9490,26 +5030,6 @@ msgid_plural "You have %u tries left"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Εισήχθη εσφαλμένο συνθηματικό."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Εισάγετε νέο PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Γίνεται ξεκλείδωμα…"
-
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
 msgstr "Χωρίς SIM"
@@ -9520,11 +5040,10 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:33
 msgid "SIM Locked"
-msgstr ""
+msgstr "Κλειδωμένη SIM"
 
 #: panels/wwan/cc-wwan-device-page.ui:77
 #, fuzzy
-#| msgid "_Mobile Broadband"
 msgid "_Mobile Data"
 msgstr "Ευρυζωνικό _κινητό"
 
@@ -9534,7 +5053,7 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:88
 msgid "_Data Roaming"
-msgstr ""
+msgstr "Περιαγωγή _δεδομένων"
 
 #: panels/wwan/cc-wwan-device-page.ui:89
 msgid "Use mobile data when roaming"
@@ -9542,13 +5061,11 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:115
 #, fuzzy
-#| msgid "_Network Time"
 msgid "_Network Mode"
 msgstr "Ώρα _δικτύου"
 
 #: panels/wwan/cc-wwan-device-page.ui:122
 #, fuzzy
-#| msgid "Network"
 msgid "N_etwork"
 msgstr "Δίκτυο"
 
@@ -9558,13 +5075,11 @@ msgstr "Για προχωρημένους"
 
 #: panels/wwan/cc-wwan-device-page.ui:146
 #, fuzzy
-#| msgid "Access Options"
 msgid "_Access Point Names"
 msgstr "Επιλογές πρόσβασης"
 
 #: panels/wwan/cc-wwan-device-page.ui:155
 #, fuzzy
-#| msgid "Screen Lock"
 msgid "_SIM Lock"
 msgstr "Κλείδωμα οθόνης"
 
@@ -9574,136 +5089,20 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:165
 #, fuzzy
-#| msgid "%s Details"
 msgid "M_odem Details"
 msgstr "Λεπτομέρειες %s"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-#, fuzzy
-#| msgid "PIN check failed"
-msgid "Phone failure"
-msgstr "Απέτυχε ο έλεγχος του PIN"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-#, fuzzy
-#| msgid "Not connected"
-msgid "No connection to phone"
-msgstr "Δεν συνδέθηκε"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-#, fuzzy
-#| msgid "SIM Card not inserted"
-msgid "SIM not inserted"
-msgstr "Δεν έχει τοποθετηθεί η κάρτα SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PIN required"
-msgstr "Απαιτείται το Pin της SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PUK required"
-msgstr "Απαιτείται το Pin της SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Εσφαλμένο συνθηματικό"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PIN2 required"
-msgstr "Απαιτείται το Pin της SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PUK2 required"
-msgstr "Απαιτείται το Pin της SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Δε βρέθηκε"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Δεν υπάρχει υπηρεσία δικτύου"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-#, fuzzy
-#| msgid "_Network Time"
-msgid "Network timeout"
-msgstr "Ώρα _δικτύου"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-#, fuzzy
-#| msgid "AutoIP service failed"
-msgid "GPRS services not allowed"
-msgstr "Αποτυχία υπηρεσίας AutoIP"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Χωρίς σφάλμα"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-#, fuzzy
-#| msgctxt "print job"
-#| msgid "Canceled"
-msgid "Action Cancelled"
-msgstr "Ακυρώθηκε"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Δεν επιτρέπεται η πρόσβαση"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-#, fuzzy
-#| msgid "Unknown error"
-msgid "Unknown Error"
-msgstr "Άγνωστο σφάλμα"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 #, fuzzy
-#| msgid "Network Name"
 msgid "Network Mode"
 msgstr "Όνομα δικτύου"
 
 #: panels/wwan/cc-wwan-network-dialog.ui:38
-#, fuzzy
-#| msgid "Automatic"
 msgid "_Automatic"
-msgstr "Αυτόματο"
+msgstr "_Αυτόματα"
 
 #: panels/wwan/cc-wwan-network-dialog.ui:53
 #, fuzzy
-#| msgid "My Home Network"
 msgid "Choose Network"
 msgstr "Το οικιακό μου δίκτυο"
 
@@ -9711,33 +5110,24 @@ msgstr "Το οικιακό μου δίκτυο"
 msgid "Refresh Network Providers"
 msgstr ""
 
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr ""
-
 #: panels/wwan/cc-wwan-panel.ui:10
 #, fuzzy
-#| msgid "My Home Network"
 msgid "Enable Mobile Network"
 msgstr "Το οικιακό μου δίκτυο"
 
 #: panels/wwan/cc-wwan-panel.ui:61
 #, fuzzy
-#| msgid "No Wi-Fi Adapter Found"
 msgid "No WWAN Adapter Found"
 msgstr "Δε βρέθηκε προσαρμογέας Wi-Fi"
 
 #: panels/wwan/cc-wwan-panel.ui:71
 #, fuzzy
-#| msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr ""
 "Σιγουρευτείτε ότι έχετε συνδέσει και ενεργοποιήσει ένα προσαρμογέα Wi-Fi"
 
 #: panels/wwan/cc-wwan-panel.ui:112
 #, fuzzy
-#| msgid "Bluetooth is disabled when airplane mode is on."
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr ""
 "Το Bluetooth είναι απενεργοποιημένο όταν η λειτουργία αεροπλάνου είναι "
@@ -9745,25 +5135,20 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-panel.ui:120
 #, fuzzy
-#| msgid "Turn Off Airplane Mode"
 msgid "_Turn off Airplane Mode"
 msgstr "Απενεργοποίηση της λειτουργίας αεροπλάνου"
 
 #: panels/wwan/cc-wwan-panel.ui:151
-#, fuzzy
-#| msgid "Forget Connection"
 msgid "Data Connection"
-msgstr "Παράλειψη σύνδεσης"
+msgstr "Σύνδεση δεδομένων"
 
 #: panels/wwan/cc-wwan-panel.ui:152
 #, fuzzy
-#| msgid "SIM Card not inserted"
 msgid "SIM card used for internet"
 msgstr "Δεν έχει τοποθετηθεί η κάρτα SIM"
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
 #, fuzzy
-#| msgid "Screen Lock"
 msgid "SIM Lock"
 msgstr "Κλείδωμα οθόνης"
 
@@ -9784,18 +5169,14 @@ msgid "Enter current PIN to change SIM lock settings"
 msgstr ""
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:3
-#, fuzzy
-#| msgid "My Home Network"
 msgid "Mobile Network"
-msgstr "Το οικιακό μου δίκτυο"
+msgstr "Κινητό δίκτυο"
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:4
 #, fuzzy
-#| msgid "Configure Removable Media settings"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Ρύθμιση επιλογών αφαιρούμενων μέσων"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -9813,41 +5194,13 @@ msgstr ""
 msgid "The GNOME Project"
 msgstr "Το έργο GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Εμφάνιση αριθμού έκδοσης"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Ενεργοποίηση λειτουργίας εμφάνισης λεπτομερειών"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Αναζήτηση συμβολοσειράς"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Λίστα με τα πιθανά ονόματα πίνακα και έξοδος"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Πίνακας για εμφάνιση"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[ΠΙΝΑΚΑΣ] [ΟΡΙΣΜΑ…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Κατηγορίες ρυθμίσεων"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Ιδιωτικότητα"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Διαθέσιμοι πίνακες:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9905,7 +5258,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Ακύρωση αναζήτησης"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Προτιμήσεις;Ρυθμίσεις;Preferences;Settings;"
@@ -9944,8 +5296,6 @@ msgid ""
 "application window."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9953,8 +5303,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "Έξοδος %u"
 msgstr[1] "Έξοδοι %u"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9962,9 +5310,2758 @@ msgid_plural "%u Inputs"
 msgstr[0] "Είσοδος %u"
 msgstr[1] "Είσοδοι %u"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Ήχοι συστήματος"
+#~ msgid "System Bus"
+#~ msgstr "Δίαυλος συστήματος"
+
+#~ msgid "Full access"
+#~ msgstr "Πλήρη πρόσβαση"
+
+#~ msgid "Session Bus"
+#~ msgstr "Δίαυλος συνεδρίας"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Πλήρης πρόσβαση στο /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Έχει πρόσβαση δικτύου"
+
+#~ msgid "Home"
+#~ msgstr "Προσωπικός φάκελος"
+
+#~ msgid "Read-only"
+#~ msgstr "Μόνο ανάγνωση"
+
+#~ msgid "File System"
+#~ msgstr "Σύστημα αρχείων"
+
+#~ msgid "Can change settings"
+#~ msgstr "Δυνατότητα αλλαγής ρυθμίσεων"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "Το %s έχει ενσωματωμένα τα ακόλουθα δικαιώματα. Αυτά δεν μπορούν να "
+#~ "μεταβληθούν. Αν ανησυχείτε για αυτά τα δικαιώματα, εξετάστε το ενδεχόμενο "
+#~ "κατάργησης αυτής της εφαρμογής."
+
+#~ msgid "Select a picture"
+#~ msgstr "Επιλογή εικόνας"
+
+#~ msgid "_Open"
+#~ msgstr "Άν_οιγμα"
+
+#~ msgid "multiple sizes"
+#~ msgstr "πολλαπλά μεγέθη"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Επιφάνεια εργασίας χωρίς παρασκήνιο"
+
+#~ msgid "Current background"
+#~ msgstr "Τρέχον παρασκήνιο"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Τοποθετήστε τη συσκευή βαθμονόμησης πάνω από το τετράγωνο και πατήστε "
+#~ "«Έναρξη»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Μετακινήστε τη συσκευή βαθμονόμησής σας στη θέση βαθμονόμησης και πατήστε "
+#~ "«Συνέχεια»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Μετακινήστε τη συσκευή βαθμονόμησής σας στην επιφάνεια και πατήστε "
+#~ "«Συνέχεια»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Κλείστε το καπάκι του φορητού υπολογιστή"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Συνέβη ένα εσωτερικό σφάλμα που δεν μπόρεσε να ανακτηθεί."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Δεν εγκαταστάθηκαν τα απαιτούμενα εργαλεία για βαθμονόμηση."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Αδυναμία δημιουργίας του προφίλ."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Το λευκό σημείο προορισμού δεν ήταν διαθέσιμο."
+
+#~ msgid "Complete!"
+#~ msgstr "Ολοκληρώθηκε!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Αποτυχία βαθμονόμησης!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Μπορείτε να αφαιρέσετε τη συσκευή βαθμονόμησης."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Μην διακόπτετε τη συσκευή βαθμονόμησης ενώ δουλεύει"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Οθόνη φορητού υπολογιστή"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Ενσωματωμένη δικτυακή κάμερα"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Οθόνη %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Σαρωτής %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Φωτογραφική μηχανή %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Εκτυπωτής %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Δικτυακή κάμερα %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Ενεργοποίηση της διαχείρισης χρωμάτων για %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Προβολή προφίλ χρώματος για %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Δεν έχει βαθμονομηθεί"
+
+#~ msgid "Default: "
+#~ msgstr "Προεπιλεγμένο: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Χρωματικός χώρος: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Δοκιμαστικό προφίλ: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Επιλογή αρχείου προφίλ ICC"
+
+#~ msgid "_Import"
+#~ msgstr "Ε_ισαγωγή"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Υποστηριζόμενα προφίλ ICC"
+
+#~ msgid "All files"
+#~ msgstr "Όλα τα αρχεία"
+
+#~ msgid "Save Profile"
+#~ msgstr "Αποθήκευση προφίλ"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Δημιουργία προφίλ χρώματος για την επιλεγμένη συσκευή"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Δεν εντοπίστηκε το όργανο μέτρησης. Παρακαλούμε ελέγξτε αν είναι "
+#~ "ενεργοποιημένο και σωστά συνδεδεμένο."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Το όργανο μέτρησης δεν υποστηρίζει δημιουργία προφίλ εκτυπωτών."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Δεν υποστηρίζεται ο τύπος της συσκευής."
+
+#~ msgid "Standard Space"
+#~ msgstr "Κανονικός χώρος"
+
+#~ msgid "Test Profile"
+#~ msgstr "Δοκιμαστικό προφίλ"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Αυτόματο"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Χαμηλή ποιότητα"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Μεσαία ποιότητα"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Υψηλή ποιότητα"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Προεπιλεγμένο RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Προεπιλεγμένο CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Προεπιλεγμένo γκρίζο"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Τα εργοστασιακά δεδομένα βαθμονόμησης που παρέχονται από τον πωλητή"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Αδύνατη η διόρθωση προβολής πλήρους οθόνης με αυτό το προφίλ"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Αυτό το προφίλ μπορεί να μην είναι πια ακριβές"
+
+#~ msgid "Other…"
+#~ msgstr "Άλλη…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Ξεκλειδώστε για να αλλάξετε ρυθμίσεις"
+
+#~ msgid "Today"
+#~ msgstr "Σήμερα"
+
+#~ msgid "Yesterday"
+#~ msgstr "Χθες"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d ώρα"
+#~ msgstr[1] "%d ώρες"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d λεπτό"
+#~ msgstr[1] "%d λεπτά"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d δευτερόλεπτο"
+#~ msgstr[1] "%d δευτερόλεπτα"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Σημείο πρόσβασης"
+
+#~ msgid "24-hour"
+#~ msgstr "24ωρο"
+
+#~ msgid "AM / PM"
+#~ msgstr "π.μ / μ.μ"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Η αποστολή αναφορών των τεχνικών προβλημάτων μας βοηθά να βελτιώσουμε το "
+#~ "%s. Οι αναφορές στέλνονται ανώνυμα και αφαιρούνται τα προσωπικά δεδομένα. "
+#~ "%s"
+
+#~ msgid "On"
+#~ msgstr "Ενεργό"
+
+#~ msgid "Off"
+#~ msgstr "Ανενεργό"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Εφαρμογή αλλαγών;"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Οι αλλαγές δεν μπορούν να εφαρμοστούν"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Αυτό μπορεί να οφείλεται σε περιορισμούς υλικού."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Οριζόντια"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Κάθετα δεξιά"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Κάθετα αριστερά"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Οριζόντια (ανεστραμμένη)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#, fuzzy
+#~| msgid "Bluetooth Turned Off"
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Το Bluetooth είναι ανενεργό"
+
+#, fuzzy
+#~| msgid "Password"
+#~ msgid "Passed"
+#~ msgstr "Κωδικός πρόσβασης"
+
+#~ msgid "Failed"
+#~ msgstr "Απέτυχε"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Επίπεδο ασφαλείας 0"
+
+#~ msgid "Security Level 1"
+#~ msgstr "Επίπεδο ασφαλείας 1"
+
+#~ msgid "Security Level 2"
+#~ msgstr "Επίπεδο ασφαλείας 2"
+
+#~ msgid "Security Level 3"
+#~ msgstr "Επίπεδο ασφαλείας 3"
+
+#, fuzzy
+#~| msgid "Firmware missing"
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Λείπει το υλικολογισμικό"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Swap"
+
+#, fuzzy
+#~| msgid "Suspend"
+#~ msgid "Suspend To RAM"
+#~ msgstr "Αναστολή"
+
+#, fuzzy
+#~| msgid "Suspend"
+#~ msgid "Suspend To Idle"
+#~ msgstr "Αναστολή"
+
+#, fuzzy
+#~| msgid "Display Configuration"
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Ρυθμίσεις οθόνης"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#, fuzzy
+#~| msgid "Software Updates"
+#~ msgid "Firmware Updates"
+#~ msgstr "Ενημερώσεις λογισμικού"
+
+#, fuzzy
+#~| msgid "Firmware missing"
+#~ msgid "Firmware Attestation"
+#~ msgstr "Λείπει το υλικολογισμικό"
+
+#~ msgid "Valid"
+#~ msgstr "Έγκυρο"
+
+#~ msgid "Not Valid"
+#~ msgstr "Μη έγκυρο"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Μη ενεργοποιημένο"
+
+#~ msgid "Locked"
+#~ msgstr "Κλειδωμένο"
+
+#, fuzzy
+#~| msgid "Not connected"
+#~ msgid "Not Locked"
+#~ msgstr "Δεν συνδέθηκε"
+
+#~ msgid "Encrypted"
+#~ msgstr "Κρυπτογραφημένο"
+
+#, fuzzy
+#~| msgid "Not connected"
+#~ msgid "Not Encrypted"
+#~ msgstr "Δεν συνδέθηκε"
+
+#, fuzzy
+#~| msgid "Not calibrated"
+#~ msgid "Not Tainted"
+#~ msgstr "Δεν έχει βαθμονομηθεί"
+
+#~ msgid "Found"
+#~ msgstr "Ευρέθη"
+
+#~ msgid "Not Found"
+#~ msgstr "Δεν βρέθηκε"
+
+#, fuzzy
+#~| msgctxt "print job"
+#~| msgid "Aborted"
+#~ msgid "Supported"
+#~ msgstr "Εγκαταλείφθηκε"
+
+#, fuzzy
+#~| msgid "Not connected"
+#~ msgid "Not Supported"
+#~ msgstr "Δεν συνδέθηκε"
+
+#~ msgid "Unknown"
+#~ msgstr "Άγνωστο"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Άγνωστο"
+
+#, fuzzy
+#~| msgid "No printers available"
+#~ msgid "Not Available"
+#~ msgstr "Δεν υπάρχουν διαθέσιμοι εκτυπωτές"
+
+#, fuzzy
+#~| msgid "System"
+#~ msgid "System Logo"
+#~ msgstr "Σύστημα"
+
+#~ msgid "No input sources found"
+#~ msgstr "Δε βρέθηκαν πηγές εισόδου"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Άλλο"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Προσαρμοσμένες συντομεύσεις"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Το πλήκτρο εναλλακτικών χαρακτήρων μπορεί να χρησιμοποιηθεί για την "
+#~ "εισαγωγή πρόσθετων χαρακτήρων. Αυτές εκτυπώνονται μερικές φορές ως τρίτη "
+#~ "επιλογή στο πληκτρολόγιό σας."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Αριστερό Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Δεξιό Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Αριστερό Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Δεξιό Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Πλήκτρο μενού"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Δεξιό Ctrl"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+#, fuzzy
+#~| msgid "Login _Screen"
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Ο_θόνη σύνδεσης"
+
+#, fuzzy, c-format
+#~| msgid "These keyboard shortcuts can be changed in the keyboard settings"
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Αυτές οι συντομεύσεις πληκτρολογίου μπορούν να αλλάξουν στις ρυθμίσεις "
+#~ "του πληκτρολογίου"
+
+#, fuzzy, c-format
+#~| msgid "%d minute"
+#~| msgid_plural "%d minutes"
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d λεπτό"
+#~ msgstr[1] "%d λεπτά"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Επαναφορά όλων των συντομεύσεων;"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Η επαναφορά των συντομεύσεων μπορεί να επηρεάσει τις προσαρμοσμένες σας "
+#~ "συντομεύσεις. Αυτό δεν μπορεί να αναιρεθεί."
+
+#~ msgid "Reset All"
+#~ msgstr "Επαναφορά όλων"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "Το %s χρησιμοποιείται ήδη για το %s. Αν το αντικαταστήσετε, θα "
+#~ "απενεργοποιηθεί το %s"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Εισάγετε τη νέα συντόμευση"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Ορισμός προσαρμοσμένης συντομεύσης"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Ορισμός συντόμευσης"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Εισάγετε μια νέα συντόμευση για αλλαγή του %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Προσθήκη προσαρμοσμένης συντόμευσης"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Κύλιση με δύο δάκτυλα"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Πέντε κλικ, ώρα του GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Διπλό κλικ, πρωτεύοντος κουμπιού"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Απλό κλικ, πρωτεύοντος κουμπιού"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Διπλό κλικ, μεσαίου κουμπιού"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Μονό κλικ, μεσαίου κουμπιού"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Διπλό κλικ, δευτερεύοντος κουμπιού"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Μονό κλικ, δευτερεύοντος κουμπιού"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Ο διαχειριστής δικτύου πρέπει να εκτελείται."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Μη ασφαλές δίκτυο (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Ασφαλές δίκτυο (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Ασφαλές δίκτυο (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Ασφαλές δίκτυο (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Ασφαλές δίκτυο"
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Πρέπει να έχει τουλάχιστον 8 χαρακτήρες"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Διακοπή σημείου πρόσβασης και αποσύνδεση όλων των χρηστών;"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Διακοπή σημείου πρόσβασης"
+
+#~ msgid "Preserve"
+#~ msgstr "Διατήρηση"
+
+#~ msgid "Permanent"
+#~ msgstr "Μόνιμο"
+
+#~ msgid "Random"
+#~ msgstr "Τυχαία"
+
+#~ msgid "Stable"
+#~ msgstr "Σταθερό"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Η διεύθυνση MAC που καταχωρίσατε εδώ θα χρησιμοποιηθεί ως διεύθυνση "
+#~ "υλικού για τη συσκευή δικτύου που ενεργοποιείται αυτή η σύνδεση. Αυτή η "
+#~ "δυνατότητα είναι γνωστή ως MAC cloning ή spoofing. Παράδειγμα: "
+#~ "00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Προφίλ %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Ενισχυμένο άνοιγμα"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Εταιρική"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Καμία"
+
+#~ msgid "Never"
+#~ msgstr "Ποτέ"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Καθόλου"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Ασθενές"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Μέτριο"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Καλό"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Εξαιρετικό"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Παράλειψη σύνδεσης"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Αφαίρεση προφίλ σύνδεσης"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Αφαίρεση VPN"
+
+#~ msgid "Details"
+#~ msgstr "Λεπτομέρειες"
+
+#~ msgid "automatic"
+#~ msgstr "αυτόματο"
+
+#~ msgid "Identity"
+#~ msgstr "Ταυτότητα"
+
+#~ msgid "Delete Address"
+#~ msgstr "Διαγραφή διεύθυνσης"
+
+#~ msgid "Delete Route"
+#~ msgstr "Διαγραφή δρομολογητή"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Κανένα"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Κλειδί WEP 40/128-bit (δεκαεξαδικό ή ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Συνθηματικό WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Δυναμικό WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "Προσωπικό WPA & WPA2"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Εταιρικό WPA & WPA2"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "Προσωπικό WPA3"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Αποτυχία ανοίγματος επεξεργαστή σύνδεσης"
+
+#~ msgid "New Profile"
+#~ msgstr "Νέο προφίλ"
+
+#, fuzzy, c-format
+#~| msgid "All Settings"
+#~ msgid "Invalid setting %s"
+#~ msgstr "Ρυθμίσεις"
+
+#~ msgid "Import from file…"
+#~ msgstr "Εισαγωγή από αρχείο…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Προσθήκη VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Αδυναμία εισαγωγής της σύνδεσης VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Αδύνατη η ανάγνωση του αρχείου «%s», ή το αρχείο δε διαθέτει "
+#~ "αναγνωρίσιμες πληροφορίες σύνδεσης VPN\n"
+#~ "\n"
+#~ "Σφάλμα: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Επιλογή αρχείου για εισαγωγή"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Υπάρχει ήδη ένα αρχείο με όνομα «%s»."
+
+#~ msgid "_Replace"
+#~ msgstr "_Αντικατάσταση"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Θέλετε να αντικαταστήσετε το %s με την σύνδεση VPN που αποθηκεύετε;"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Αδύνατη η εξαγωγή της σύνδεσης VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Αδύνατη η εξαγωγή της σύνδεσης VPN «%s» στο %s.\n"
+#~ "\n"
+#~ "Σφάλμα: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Εξαγωγή σύνδεσης VPN"
+
+#~ msgid "never"
+#~ msgstr "ποτέ"
+
+#~ msgid "today"
+#~ msgstr "σήμερα"
+
+#~ msgid "yesterday"
+#~ msgstr "χθες"
+
+#~ msgid "Last used"
+#~ msgstr "Τελευταία χρησιμοποιημένο"
+
+#~ msgid "Add new connection"
+#~ msgstr "Προσθήκη νέας σύνδεσης"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Θα χαθούν οι λεπτομέρειες των επιλεγμένων δικτύων, συμπεριλαμβανομένων "
+#~ "των κωδικών πρόσβασης και των προσαρμοσμένων ρυθμίσεων."
+
+#~ msgid "_Forget"
+#~ msgstr "_Παράλειψη"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Γνωστά δίκτυα Wi-Fi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Παράλειψη"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Η πολιτική του συστήματος απαγορεύει τη χρήση ως σημείο πρόσβασης"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Η ασύρματη συσκευή δεν υποστηρίζει λειτουργία με σημείο πρόσβασης"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Η αυτόματη εύρεση διαμεσολαβητή Ιστού χρησιμοποιείται όταν δεν παρέχετε "
+#~ "μια διεύθυνση ρυθμίσεων."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Αυτό δεν το συνιστούμε για δίκτυα τα οποία δεν εμπιστεύεστε."
+
+#~ msgid "Status unknown"
+#~ msgstr "Άγνωστη κατάσταση"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Χωρίς διαχείριση"
+
+#~ msgid "Unavailable"
+#~ msgstr "Μη διαθέσιμο"
+
+#~ msgid "Connecting"
+#~ msgstr "Γίνεται σύνδεση"
+
+#~ msgid "Authentication required"
+#~ msgstr "Απαιτείται πιστοποίηση"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Γίνεται αποσύνδεση"
+
+#~ msgid "Connection failed"
+#~ msgstr "Αποτυχία σύνδεσης"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Άγνωστη κατάσταση (απουσιάζει)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Αποτυχία ρύθμισης"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Αποτυχία ρύθμισης της IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Έληξε η ρυθμίση IP"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Τα μυστικά απαιτήθηκαν, αλλά δεν προσφέρθηκαν"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "αποσυνδέθηκε η αίτηση του 802.1x"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Αποτυχία ρύθμισης της αίτησης του 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Αποτυχία της αίτησης του 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Η αίτηση του 802.1x πήρε αρκετή ώρα για να πιστοποιηθεί"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Αποτυχία εκκίνησης της υπηρεσίας PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Αποσυνδέθηκε η υπηρεσία PPP"
+
+#~ msgid "PPP failed"
+#~ msgstr "Αποτυχία του PPP"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Αποτυχία εκκίνησης του πελάτη DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Σφάλμα πελάτη DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Αποτυχία του πελάτη DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Αποτυχία εκκίνησης της υπηρεσίας κοινόχρηστης σύνδεσης"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Αποτυχία της υπηρεσίας κοινόχρηστης σύνδεσης"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Αποτυχία εκκίνησης της υπηρεσίας AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Σφάλμα υπηρεσίας AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Αποτυχία υπηρεσίας AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "Η γραμμή είναι απασχολημένη"
+
+#~ msgid "No dial tone"
+#~ msgstr "Δεν ακούγεται ο τόνος κλήσης"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Δεν είναι δυνατή η δημιουργία γραμμής"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Έληξε το αίτημα κλήσης"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Απέτυχε η προσπάθεια κλήσης"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Απέτυχε η προετοιμασία του μόντεμ"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Απέτυχε η επιλογή του συγκεκριμένου APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Δεν ψάχνει για δίκτυα"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Απερρίφθη η εγγραφή στο δίκτυο"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Έληξε η εγγραφή στο δίκτυο"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Αποτυχία εγγραφής στο ζητούμενο δίκτυο"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Απέτυχε ο έλεγχος του PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Μπορεί να λείπει το υλικολογισμικό για τη συσκευή"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Η σύνδεση χάθηκε"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Θεωρήθηκε πως υπάρχει μια τρέχουσα σύνδεση"
+
+#~ msgid "Modem not found"
+#~ msgstr "Δεν βρέθηκε μόντεμ"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Αποτυχία σύνδεσης του Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Δεν έχει τοποθετηθεί η κάρτα SIM"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Απαιτείται το Pin της SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Απαιτείται το Puk της SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Λάθος SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Απέτυχε η εξάρτηση της σύνδεσης"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Λείπει το υλικολογισμικό"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Το καλώδιο αποσυνδέθηκε"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "μη ορισμένο σφάλμα στην ασφάλεια 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "Δεν έχει επιλεγεί αρχείο"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "ακαθόριστο σφάλμα στην πιστοποίηση του αρχείου eap-method"
+
+#, fuzzy
+#~| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Ιδιωτικά κλειδιά DER, PEM, ή PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#, fuzzy
+#~| msgid "_User certificate"
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Πιστοποιητικό _χρήστη"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "Λείπει το αρχείο EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Αρχεία PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "Λείπει το όνομα χρήστη EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "Λείπει ο κωδικός πρόσβασης EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "Άκυρο πιστοποιητικό EAP-PEAP CA: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "Άκυρο πιστοποιητικό EAP-PEAP CA: δεν έχει καθοριστεί πιστοποιητικό"
+
+#~ msgid "missing EAP username"
+#~ msgstr "Λείπει το όνομα χρήστη EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "Λείπει ο κωδικός πρόσβασης EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "Λείπει η ταυτότητα EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "Άκυρο πιστοποιητικό EAP-TLS CA: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "Άκυρο πιστοποιητικό EAP-TLS CA: δεν έχει καθοριστεί πιστοποιητικό"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "Άκυρο ιδιωτικό κλειδί EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "Άκυρο πιστοποιητικό χρήστη EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Τα μη κρυπτογραφημένα ιδιωτικά κλειδιά είναι επισφαλή"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Το επιλεγμένο ιδιωτικό κλειδί δεν φαίνεται να προστατεύεται από ένα "
+#~ "συνθηματικό. Αυτό πιθανόν να επιτρέπει τα διαπιστευτήρια ασφάλειας να "
+#~ "παραβιαστούν. Παρακαλούμε επιλέξτε ένα ιδιωτικό κλειδί που να "
+#~ "προστατεύεται από ένα συνθηματικό.\n"
+#~ "\n"
+#~ "(Μπορείτε να προστατεύσετε με συνθηματικό το ιδιωτικό σας κλειδί με το "
+#~ "openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Επιλέξτε το προσωπικό σας πιστοποιητικό"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Επιλέξτε το ιδιωτικό σας κλειδί"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "Άκυρο πιστοποιητικό EAP-TTLS CA: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "Άκυρο πιστοποιητικό EAP-TTLS CA: δεν έχει καθοριστεί πιστοποιητικό"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Άγνωστο σφάλμα κατά την πιστοποίηση της ασφάλειας 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Επιλογή ενός αρχείου"
+
+#~ msgid "missing leap-username"
+#~ msgstr "Λείπει το όνομα χρήστη leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "Λείπει το συνθηματικό leap"
+
+#, fuzzy
+#~| msgid "invalid EAP-TLS password: missing"
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Άκυρο πιστοποιητικό EAP-TLS: λείπει"
+
+#~ msgid "missing wep-key"
+#~ msgstr "Λείπει το κλειδί wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "Άκυρο wep-key: το κλειδί με μήκος %zu πρέπει να περιέχει μόνο δεκαεξαδικά "
+#~ "ψηφία"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "Άκυρο wep-key: το κλειδί με μήκος %zu πρέπει να περιέχει μόνο χαρακτήρες "
+#~ "ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "Άκυρο wep-key: λαθεμένο μήκος κλειδιού %zu. Ένα κλειδί πρέπει να έχει "
+#~ "μήκος χαρακτήρων 5/13 (ascii) ή 10/26 (δεκαεξαδικό)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "μη έγκυρο wep-key: το συνθηματικό δεν πρέπει να είναι κενό"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "μη έγκυρο wep-key: το συνθηματικό πρέπει να είναι μικρότερο από 64 "
+#~ "χαρακτήρες"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "μη έγκυρο wpa-psk:  μη έγκυρο μήκος κλειδιού %zu. Πρέπει να είναι [8,63] "
+#~ "bytes ή 64 δεκαεξαδικά ψηφία"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "μη έγκυρο wpa-psk: αδυναμία μεταγλώττισης κλειδιού με 64 bytes ως "
+#~ "δεκαεξαδικό"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Άλλο"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "Ο %s αφαιρέθηκε"
+
+#~ msgid "Error removing account"
+#~ msgstr "Σφάλμα αφαίρεσης λογαριασμού"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Λογαριασμός %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Αφαίρεση λογαριασμού"
+
+#~ msgid "Unknown time"
+#~ msgstr "Άγνωστος χρόνος"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s μέχρι την πλήρη φόρτιση"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Προσοχή: απομένει %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "απομένει %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Πλήρης φόρτιση"
+
+#~ msgid "Not charging"
+#~ msgstr "Δεν φορτίζεται"
+
+#~ msgid "Empty"
+#~ msgstr "Κενό"
+
+#~ msgid "Charging"
+#~ msgstr "Φορτίζεται"
+
+#~ msgid "Discharging"
+#~ msgstr "Εκφορτίζεται"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Ασύρματο ποντίκι"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Ασύρματο πληκτρολόγιο"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Αδιάλειπτη παροχή ρεύματος"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Προσωπικός ψηφιακός βοηθός"
+
+#~ msgid "Cellphone"
+#~ msgstr "Κινητό τηλέφωνο"
+
+#~ msgid "Media player"
+#~ msgstr "Αναπαραγωγέας πολυμέσων"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Υπολογιστής"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Συσκευή εισαγωγής για παιχνίδια"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Κύριο"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Πρόσθετο"
+
+#~ msgid "Batteries"
+#~ msgstr "Μπαταρίες"
+
+#~ msgid "When _idle"
+#~ msgstr "Όταν είναι _ανενεργό"
+
+#~ msgid "Suspend"
+#~ msgstr "Αναστολή"
+
+#~ msgid "Power Off"
+#~ msgstr "Τερματισμός"
+
+#~ msgid "Hibernate"
+#~ msgstr "Aδρανοποίηση"
+
+#~ msgid "Nothing"
+#~ msgstr "Καμία ενέργεια"
+
+#~ msgid "When on battery power"
+#~ msgstr "Όταν τροφοδοτείται από μπαταρία"
+
+#~ msgid "When plugged in"
+#~ msgstr "Όταν είναι στην παροχή ρεύματος"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Ποτέ"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Αυτόματη αναστολή"
+
+#, fuzzy
+#~| msgid "Permanent"
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Μόνιμο"
+
+#, fuzzy
+#~| msgid "Balance"
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Ισοστάθμιση"
+
+#, fuzzy
+#~| msgid "Power Saving"
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Εξοικονόμηση ενέργειας"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Ο εκτυπωτής «%s» έχει διαγραφεί"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Αδυναμία φόρτωσης γραφικού περιβάλλοντος: %s"
+
+#, fuzzy
+#~| msgid "Unlock to Change Settings"
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Ξεκλειδώστε για να αλλάξετε ρυθμίσεις"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Λεπτομέρειες %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Δε βρέθηκε κατάλληλος οδηγός"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Επιλεγμένο αρχείο PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Αρχεία περιγραφής εκτυπωτών PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+#~ "*.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Εκτυπωτής JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Εκτυπωτής LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Μονής όψης"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Μακρύ άκρο (κανονικό)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Βραχύ άκρο (αναστροφή)"
+
+#~ msgid "Portrait"
+#~ msgstr "Κάθετα"
+
+#~ msgid "Landscape"
+#~ msgstr "Οριζόντια"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Αντίστροφα οριζόντιο"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Αντίστροφα κάθετο"
+
+#~ msgid "Resume"
+#~ msgstr "Συνέχεια"
+
+#~ msgid "Pause"
+#~ msgstr "Παύση"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Εκκρεμεί"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Σε παύση"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Απαιτείται πιστοποίηση"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Γίνεται επεξεργασία"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Διακόπηκε"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Ακυρώθηκε"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Εγκαταλείφθηκε"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Ολοκληρώθηκε"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Ενεργές εργασίες"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Εισάγετε διαπιστευτήρια για να εκτυπώσετε από %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Ξεκλείδωμα διακομιστή εκτύπωσης"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Ξεκλείδωμα %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Εισάγετε ένα όνομα χρήστη και έναν κωδικό πρόσβασης για να δείτε "
+#~ "εκτυπωτές στο %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Αναζήτηση για εκτυπωτές"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Σειριακή θύρα"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Παράλληλη θύρα"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Τοποθεσία: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Διεύθυνση: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Ο διακομιστής απαιτεί ταυτοποίηση"
+
+#~ msgid "Two Sided"
+#~ msgstr "Διπλής όψης"
+
+#~ msgid "Paper Type"
+#~ msgstr "Τύπος χαρτιού"
+
+#~ msgid "Paper Source"
+#~ msgstr "Πηγή χαρτιού"
+
+#~ msgid "Output Tray"
+#~ msgstr "Συρτάρι εξόδου"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Ανάλυση"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Προφιλτράρισμα GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Σελίδες ανά φύλλο"
+
+#~ msgid "Orientation"
+#~ msgstr "Προσανατολισμός"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Γενικά"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Ρύθμιση σελίδας"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Εγκαταστάσιμες επιλογές"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Εργασία"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Ποιότητα εικόνας"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Χρώμα"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Ολοκληρώνεται"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Για προχωρημένους"
+
+#~ msgid "Test page"
+#~ msgstr "Δοκιμαστική σελίδα"
+
+#~ msgid "Auto Select"
+#~ msgstr "Αυτόματη επιλογή"
+
+#~ msgid "Printer Default"
+#~ msgstr "Προεπιλογή εκτυπωτή"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Ενσωμάτωση μόνο των γραμματοσειρών GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Μετατροπή σε PS επιπέδου 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Μετατροπή σε PS επιπέδου 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Χωρίς προ-φιλτράρισμα"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Καθαρισμός κεφαλών εκτυπωτή"
+
+#~ msgid "Out of toner"
+#~ msgstr "Άδειος γραφίτης"
+
+#~ msgid "Low on developer"
+#~ msgstr "Τελειώνει το υγρό εμφάνισης"
+
+#~ msgid "Out of developer"
+#~ msgstr "Τελείωσε το υγρό εμφάνισης"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Τελειώνει ένα από τα χρώματα"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Τελείωσε ένα από τα χρώματα"
+
+#~ msgid "Open cover"
+#~ msgstr "Κάλυμμα ανοικτό"
+
+#~ msgid "Open door"
+#~ msgstr "Πορτάκι ανοικτό"
+
+#~ msgid "Low on paper"
+#~ msgstr "Τελειώνει το χαρτί"
+
+#~ msgid "Out of paper"
+#~ msgstr "Τελείωσε το χαρτί"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Αποσυνδεδεμένος"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Διακόπηκε"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Το δοχείο απορριμμάτων σχεδόν γέμισε"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Το δοχείο απορριμμάτων είναι γεμάτο"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Το τύμπανο είναι σχεδόν στο τέλος της ζωής του"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Το τύμπανο δεν δουλεύει πλέον"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Έτοιμο"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Δεν δέχεται εργασίες"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Γίνεται επεξεργασία"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Αυτοκρατορικό"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Μετρικό"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Ερώτηση για την ενέργεια"
+
+#~ msgid "Do nothing"
+#~ msgstr "Καμία ενέργεια"
+
+#~ msgid "Open folder"
+#~ msgstr "Άνοιγμα φακέλου"
+
+#~ msgid "Other Media"
+#~ msgstr "Άλλα μέσα"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Επιλέξτε μια εφαρμογή για CD ήχου"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Επιλέξτε μια εφαρμογή για DVD βίντεο"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Επιλέξτε την εφαρμογή που θα εκτελείται, όταν θα συνδέεται ένας "
+#~ "αναπαραγωγέας μουσικής"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Επιλέξτε την εφαρμογή που θα εκτελείται, όταν θα συνδέεται μια "
+#~ "φωτογραφική μηχανή"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Επιλέξτε μια εφαρμογή για τα CD λογισμικού"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD ήχου"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Κενό Blu-ray"
+
+#~ msgid "blank CD disc"
+#~ msgstr "Κενό CD"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "Κενό DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Κενό HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Δίσκος βίντεο Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "Αναγνώστης ηλεκτρονικών βιβλίων"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Δίσκος βίντεο HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD εικόνων"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Η οθόνη σβήνει"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 δευτερόλεπτα"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 λεπτό"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 λεπτά"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 λεπτά"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 λεπτά"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 λεπτά"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 ώρα"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 λεπτό"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 λεπτά"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 λεπτά"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 λεπτά"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 λεπτά"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 λεπτά"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 λεπτά"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 λεπτά"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 λεπτά"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Ποτέ"
+
+#~ msgid "Select Location"
+#~ msgstr "Επιλογή περιοχής"
+
+#~ msgid "_OK"
+#~ msgstr "_Εντάξει"
+
+#~ msgid "No applications found"
+#~ msgstr "Δε βρέθηκαν εφαρμογές"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Δεν έχουν επιλεγεί δίκτυα για κοινή χρήση"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Ενεργό"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Ανενεργό"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Ενεργοποιημένη"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Ενεργή"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Επιλογή φακέλου"
+
+#, fuzzy
+#~| msgid "Media Sharing"
+#~ msgid "Enable media sharing"
+#~ msgstr "Κοινή χρήση πολυμέσων"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Η κοινή χρήση αρχείων επιτρέπει να μοιράζεστε τον δημόσιο φάκελό σας με "
+#~ "άλλους, στο υπάρχον δίκτυό σας, χρησιμοποιώντας: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Όταν είναι ενεργοποιημένη η απομακρυσμένη σύνδεση, οι απομακρυσμένοι "
+#~ "χρήστες μπορούν να συνδεθούν χρησιμοποιώντας εντολή ασφαλούς κελύφους "
+#~ "(SSH):\n"
+#~ "%s"
+
+#, fuzzy
+#~| msgid "Personal File Sharing"
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Κοινή χρήση προσωπικών αρχείων"
+
+#~ msgid "Device name copied"
+#~ msgstr "Αντιγράφηκε το όνομα συσκευής"
+
+#~ msgid "Username copied"
+#~ msgstr "Αντιγράφηκε το όνομα χρήστη"
+
+#~ msgid "Password copied"
+#~ msgstr "Αντιγράφηκε το συνθηματικό"
+
+#~ msgid "Custom"
+#~ msgstr "Προσαρμοσμένη"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Δοκιμή του %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Aποσυνδεδεμένη"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Γίνεται σύνδεση"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Συνδεδεμένη"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Σφάλμα πιστοποίησης"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Γίνεται εξουσιοδότηση"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Μειωμένη λειτουργικότητα"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Συνδεδεμένη & πιστοποιημένη"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Άγνωστο"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Πιστοποιήθηκε την:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Συνδέθηκε:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Εγγραφή σε:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Αποτυχία πιστοποίησης συσκευής: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Αποτυχία παράλειψης συσκευής: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Σφάλμα"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Πιστοποιήθηκε"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Το υποσύστημα του Thunderbolt (boltd) δεν έχει εγκατασταθεί ή δεν έχει "
+#~ "ρυθμιστεί σωστά."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Μόνο συσκευές USB και θύρες οθόνης μπορούν να συνδεθούν."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Δεν ήταν δυνατή η ανίχνευση του Thunderbolt.\n"
+#~ "Είτε το σύστημα δεν διαθέτει υποστήριξη Thunderbolt, έχει απενεργοποιηθεί "
+#~ "στο BIOS ή έχει οριστεί σε επίπεδο ασφαλείας μη υποστήριξης στο BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Η υποστήριξη Thunderbolt έχει απενεργοποιηθεί στο BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Δεν ήταν δυνατό να καθοριστεί το επίπεδο ασφάλειας του Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Σφάλμα εναλλαγής άμεσης λειτουργίας: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Προεπιλεγμένο"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Μεσαίο"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Μεγάλο"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Μεγαλύτερο"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Μέγιστο"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d εικονοστοιχείο"
+#~ msgstr[1] "%d εικονοστοιχεία"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Σύντομο"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ της οθόνης"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ της οθόνης"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ της οθόνης"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Μακρύ"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 ώρα"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 ημέρα"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 ημέρες"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 ημέρες"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 ημέρες"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 ημέρες"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 ημέρες"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 ημέρες"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 ημέρες"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 ημέρες"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Διαγραφή όλων των αντικειμένων από τα απορρίμματα;"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Όλα τα αντικείμενα στα απορρίμματα θα διαγραφούν οριστικά."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Ά_δειασμα απορριμμάτων"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Διαγραφή όλων των προσωρινών αρχείων;"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Όλα τα προσωρινά αρχεία θα διαγραφούν μόνιμα."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Εκκαθάριση προσωρινών αρχείων"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 ημέρα"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 ημέρες"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 ημέρες"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Για πάντα"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Πρέπει να ταιριάζει η διεύθυνση ιστού του παρόχου της εισόδου σας."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Αποτυχία προσθήκης λογαριασμού"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Αποτυχία εγγραφής του λογαριασμού"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Κανένας υποστηριζόμενος τρόπος πιστοποίησης με αυτόν τον τομέα"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Αποτυχία ένταξης στο τομέα"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Αυτό το όνομα εισόδου δεν δούλεψε.\n"
+#~ "Παρακαλούμε, προσπαθήστε ξανά."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Αυτός ο κωδικός πρόσβασης εισόδου δεν δούλεψε.\n"
+#~ "Παρακαλούμε, προσπαθήστε ξανά."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Αποτυχία σύνδεσης στο τομέα"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Αδύνατη η εύρεση του τομέα. Μήπως τον γράψατε λάθος;"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Περιηγηθείτε για περισσότερες φωτογραφίες"
+
+#, fuzzy
+#~| msgid "The device is already in use."
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "Η συσκευή χρησιμοποιείται ήδη."
+
+#, fuzzy
+#~| msgid "Failed to register with the requested network"
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Αποτυχία εγγραφής στο ζητούμενο δίκτυο"
+
+#, fuzzy
+#~| msgid "Failed to add new printer."
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#, fuzzy
+#~| msgid "Failed to add new printer."
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#, fuzzy, c-format
+#~| msgid "Failed to apply configuration: %s"
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Αποτυχία εφαρμογής των ρυθμίσεων: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Αποτυχία διαγραφής αποθηκευμένων δακτυλικών αποτυπωμάτων: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Αριστερός αντίχειρας"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Αριστερό μεσαίο δάκτυλο"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Α_ριστερός δείκτης"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Αριστερός δείκτης"
+
+#~ msgid "Left little finger"
+#~ msgstr "Αριστερό μικρό δάκτυλο"
+
+#~ msgid "Right thumb"
+#~ msgstr "Δεξιός αντίχειρας"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Δεξιό μεσαίο δάκτυλο"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Δεξιός _δείκτης"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Δεξιός δείκτης"
+
+#~ msgid "Right little finger"
+#~ msgstr "Δεξιό μικρό δάκτυλο"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Άγνωστος αποτύπωμα"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Ολοκληρώθηκε"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Αποσυνδέθηκε η συσκευή δακτυλικού αποτυπώματος"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Ο χώρος αποθήκευσης δακτυλικών αποτυπωμάτων είναι πλήρης"
+
+#, fuzzy
+#~| msgid "Failed to add new printer."
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#, fuzzy, c-format
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Αποτυχία αποστολής αρχείου: %s"
+
+#, fuzzy
+#~| msgid "Failed to add new printer."
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#, fuzzy, c-format
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Αποτυχία αποστολής αρχείου: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Ανασηκώστε επανειλημμένα και τοποθετήστε το δάχτυλό σας στον αναγνώστη "
+#~ "για να εγγράψετε το δακτυλικό σας αποτύπωμα"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Σάρωση νέου δακτυλικού αποτυπώματος"
+
+#, fuzzy, c-format
+#~| msgid "Failed to forget device: "
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Αποτυχία παράλειψης συσκευής: "
+
+#, fuzzy
+#~| msgid "Pending Devices"
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Εκκρεμείς συσκευές"
+
+#, fuzzy, c-format
+#~| msgid "Failed to forget device: "
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Αποτυχία παράλειψης συσκευής: "
+
+#, fuzzy, c-format
+#~| msgid "Failed to forget device: "
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Αποτυχία παράλειψης συσκευής: "
+
+#~ msgid "This Week"
+#~ msgstr "Αυτήν την εβδομάδα"
+
+#~ msgid "Last Week"
+#~ msgstr "Την τελευταία εβδομάδα"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Η συνεδρία τελείωσε"
+
+#~ msgid "Session Started"
+#~ msgstr "Η συνεδρία άρχισε"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Δραστηριότητα λογαριασμού"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Παρακαλούμε επιλέξτε άλλον κωδικό πρόσβασης."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Παρακαλούμε πληκτρολογήστε ξανά τον τρέχων κωδικό πρόσβασής σας."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Ο κωδικός πρόσβασής σας δεν μπορούσε να αλλαχθεί"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Αδυναμία αυτόματης ένωσης αυτού του τύπου τομέα"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Δεν βρέθηκε τέτοιος τομέας ή realm"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Αδυναμία σύνδεσης ως %s στον τομέα %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Λάθος κωδικός πρόσβασης, παρακαλούμε προσπαθήστε ξανά"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Αδυναμία σύνδεσης στον τομέα %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Αποτυχία διαγραφής χρήστη"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Αποτυχία ανάκλησης απομακρυσμένης διαχείρισης χρήστη"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Δεν μπορείτε να διαγράψετε τον δικό σας λογαριασμό."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s είναι ακόμη συνδεδεμένος"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Η διαγραφή ενός χρήστη ενώ είναι συνδεδεμένος μπορεί να αφήσει το σύστημα "
+#~ "σε ασταθή κατάσταση."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Θέλετε να κρατήσετε τα αρχεία του %s;"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Είναι δυνατόν να διατηρηθεί ο προσωπικός κατάλογος, το αρχείο "
+#~ "αλληλογραφίας και τα προσωρινά αρχεία μετά τη διαγραφή ενός λογαριασμού "
+#~ "χρήστη."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Διαγραφή αρχείων"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Δια_τήρηση αρχείων"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Είστε σίγουροι ότι θέλετε να ανακαλέσετε τον λογαριασμό της "
+#~ "απομακρυσμένης διαχείρισης του %s;"
+
+#~ msgid "_Delete"
+#~ msgstr "_Διαγραφή"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Απενεργοποιημένος λογαριασμός"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Θα ορισθεί στην επόμενη σύνδεση"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Κανένας"
+
+#~ msgid "Logged in"
+#~ msgstr "Συνδεμένος"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Αποτυχία επικοινωνίας με την υπηρεσία λογαριασμών"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Παρακαλούμε βεβαιωθείτε ότι το AccountService έχει εγκατασταθεί και είναι "
+#~ "ενεργοποιημένο."
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Διαγραφή του επιλεγμένου λογαριασμού χρήστη"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Για να διαγράψετε τον επιλεγμένο λογαριασμό χρήστη,\n"
+#~ "κάντε πρώτα κλικ στο εικονίδιο *"
+
+#, fuzzy
+#~| msgid "Unlock to Change Settings"
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Ξεκλειδώστε για να αλλάξετε ρυθμίσεις"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr ""
+#~ "Ο νέος κωδικός πρόσβασης πρέπει να είναι διαφορετικός από τον παλιό."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Προσπαθήστε να αλλάξετε μερικά γράμματα και αριθμούς."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Δοκιμάστε να αλλάξετε τον κωδικό πρόσβασης λίγο περισσότερο."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr ""
+#~ "Ένας κωδικός πρόσβασης χωρίς το όνομα χρήστη πιθανόν να είναι πιο ισχυρός."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr ""
+#~ "Προσπαθήστε να αποφύγετε τη χρήση του ονόματός σας στον κωδικό πρόσβασης."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr ""
+#~ "Προσπαθήστε να αποφύγετε μερικές από τις λέξεις που συμπεριλαμβάνονται "
+#~ "στον κωδικό πρόσβασης."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Προσπαθήστε να αποφύγετε συνηθισμένες λέξεις."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Προσπαθήστε να αποφύγετε αναδιάταξη υπαρχουσών λέξεων."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Προσπαθήστε να χρησιμοποιήσετε περισσότερους αριθμούς."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Προσπαθήστε να χρησιμοποιήσετε περισσότερα κεφαλαία γράμματα."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Προσπαθήστε να χρησιμοποιήσετε περισσότερα πεζά γράμματα."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Προσπαθήστε να χρησιμοποιήσετε περισσότερους ειδικούς χαρακτήρες, όπως "
+#~ "σημεία στίξης."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Προσπαθήστε να χρησιμοποιήσετε έναν συνδυασμό γραμμάτων, αριθμών και "
+#~ "σημείων στίξης."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Προσπαθήστε να αποφύγετε την επανάληψη του ίδιου χαρακτήρα."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Προσπαθήστε να αποφύγετε την επανάληψη του ίδιου τύπου χαρακτήρα: "
+#~ "χρειάζεστε την ανάμειξη γραμμάτων, αριθμών και σημείων στίξης."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Προσπαθήστε να αποφύγετε ακολουθίες όπως 1234 ή abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Τα συνθηματικά πρέπει να είναι μεγαλύτερα. Προσπαθήστε να προσθέσετε "
+#~ "περισσότερα γράμματα, αριθμούς και σημεία στίξης."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Αναμείξτε κεφαλαία και πεζά γράμματα και χρησιμοποιήστε έναν ή "
+#~ "περισσότερους αριθμούς."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Η προσθήκη περισσότερων γραμμάτων, αριθμών και σημείων στίξης θα κάνει "
+#~ "ισχυρότερο το συνθηματικό."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Αποτυχία πιστοποίησης"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Ο κωδικός πρόσβασης είναι πολύ σύντομος"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Ο κωδικός πρόσβασης είναι πολύ απλός"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Ο παλιός και ο νέος κωδικός πρόσβασης μοιάζουν πολύ"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Ο νέος κωδικός πρόσβασης έχει χρησιμοποιηθεί πρόσφατα."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr ""
+#~ "Ο νέος κωδικός πρόσβασης θα πρέπει να περιέχει αριθμητικούς ή ειδικούς "
+#~ "χαρακτήρες"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Ο παλιός και ο νέος κωδικός πρόσβασης είναι οι ίδιοι"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Ο κωδικός πρόσβασης σας έχει αλλάξει από την αρχική σας πιστοποίηση!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr ""
+#~ "Ο νέος κωδικός πρόσβασης δεν περιέχει αρκετά διαφορετικούς χαρακτήρες"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Άγνωστο σφάλμα"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Το όνομα χρήστη συνήθως πρέπει να αποτελείται μόνο από πεζά γράμματα από "
+#~ "a-z, αριθμούς και από τους ακόλουθους χαρακτήρες: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Συγγνώμη, δεν είναι διαθέσιμο το όνομα χρήστη. Παρακαλούμε δοκιμάστε "
+#~ "κάποιο αλλο."
+
+#~ msgid "The username is too long."
+#~ msgstr "Το όνομα χρήστη είναι πολύ μεγάλο."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Κουμπί %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Καθορίστηκε εφαρμογή"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Αποστολή πατήματος πλήκτρου"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Αλλαγή οθόνης"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Εμφάνιση βοήθειας στην οθόνη"
+
+#, fuzzy
+#~| msgid "Use bluetooth devices"
+#~ msgid "External tablet device"
+#~ msgstr "Χρήση συσκευών Bluetooth"
+
+#~ msgid "All Displays"
+#~ msgstr "Όλες οι οθόνες"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Νέα συντόμευση…"
+
+#~ msgid "Registered"
+#~ msgstr "Εγγεγραμμένος"
+
+#~ msgid "Roaming"
+#~ msgstr "Περιαγωγή"
+
+#~ msgid "Searching"
+#~ msgstr "Αναζήτηση"
+
+#~ msgid "Denied"
+#~ msgstr "Απαγορεύεται"
+
+#~ msgid "2G Only"
+#~ msgstr "Μόνο 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Μόνο 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Μόνο 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Μόνο 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "'Αγνωστη"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Ξεκλείδωμα κάρτας SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Εισήχθη εσφαλμένο συνθηματικό."
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Εισάγετε νέο PIN"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Γίνεται ξεκλείδωμα…"
+
+#, fuzzy
+#~| msgid "PIN check failed"
+#~ msgid "Phone failure"
+#~ msgstr "Απέτυχε ο έλεγχος του PIN"
+
+#, fuzzy
+#~| msgid "Not connected"
+#~ msgid "No connection to phone"
+#~ msgstr "Δεν συνδέθηκε"
+
+#, fuzzy
+#~| msgid "SIM Card not inserted"
+#~ msgid "SIM not inserted"
+#~ msgstr "Δεν έχει τοποθετηθεί η κάρτα SIM"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PIN required"
+#~ msgstr "Απαιτείται το Pin της SIM"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PUK required"
+#~ msgstr "Απαιτείται το Pin της SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Αποτυχία SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "Η SIM είναι απασχολημένη"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Εσφαλμένο συνθηματικό"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Απαιτείται το Pin της SIM"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Απαιτείται το Pin της SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Δε βρέθηκε"
+
+#~ msgid "No network service"
+#~ msgstr "Δεν υπάρχει υπηρεσία δικτύου"
+
+#, fuzzy
+#~| msgid "_Network Time"
+#~ msgid "Network timeout"
+#~ msgstr "Ώρα _δικτύου"
+
+#, fuzzy
+#~| msgid "AutoIP service failed"
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Αποτυχία υπηρεσίας AutoIP"
+
+#~ msgid "No Error"
+#~ msgstr "Χωρίς σφάλμα"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Η ενέργεια ακυρώθηκε"
+
+#~ msgid "Access denied"
+#~ msgstr "Δεν επιτρέπεται η πρόσβαση"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Άγνωστο σφάλμα"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Εμφάνιση αριθμού έκδοσης"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Ενεργοποίηση λειτουργίας εμφάνισης λεπτομερειών"
+
+#~ msgid "Search for the string"
+#~ msgstr "Αναζήτηση συμβολοσειράς"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Λίστα με τα πιθανά ονόματα πίνακα και έξοδος"
+
+#~ msgid "Panel to display"
+#~ msgstr "Πίνακας για εμφάνιση"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[ΠΙΝΑΚΑΣ] [ΟΡΙΣΜΑ…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Διαθέσιμοι πίνακες:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Ήχοι συστήματος"
 
 #~ msgid "Web Links"
 #~ msgstr "Σύνδεσμοι ιστού"
@@ -10438,9 +8535,6 @@ msgstr "Ήχοι συστήματος"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablet (απόλυτη)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Επιφάνεια αφής (σχετικό)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Προτιμήσεις tablet"
@@ -11233,9 +9327,6 @@ msgstr "Ήχοι συστήματος"
 #~ msgid "Mirrored"
 #~ msgstr "Με κατοπτρισμό"
 
-#~ msgid "Secondary"
-#~ msgstr "Δευτερεύον"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Διάταξη συνδυασμένων οθονών"
 
@@ -11420,9 +9511,6 @@ msgstr "Ήχοι συστήματος"
 #~ msgid "Mail"
 #~ msgstr "Αλληλογραφία"
 
-#~ msgid "Calendar"
-#~ msgstr "Ημερολόγιο"
-
 #~ msgid "Contacts"
 #~ msgstr "Επαφές"
 
@@ -11564,9 +9652,6 @@ msgstr "Ήχοι συστήματος"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Κύλιση πάνω"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Κύλιση κάτω"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Κύλιση δεξιά"
@@ -11860,9 +9945,6 @@ msgstr "Ήχοι συστήματος"
 
 #~ msgid "China"
 #~ msgstr "Κίνα"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Απενεργοποίηση κατά την πληκ_τρολόγηση"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr ""

--- a/po/el.po~
+++ b/po/el.po~
@@ -1,0 +1,12048 @@
+# Greek translation of GNOME Control Center
+# Copyright (C) 2000 ~ 2010, Free Software Foundation, Inc.
+# For screensaver, picked: profilaji o8onis -simos.
+# spyros: initial translation, around 300 messages.
+# Nikos:   one more review 6Sep2003
+# kostas: 15 feb 2004, update
+# Nikos: 30May2004, some fixes.
+# Nikos: 31Jul2004, some fixes.
+# Nikos 17Sep2004, some fixes.
+# simos: 277 messages, 19Aug2000, (24 fuzzy, 40 untranslated).
+# simos: 358 messages, 05Dec2000, updated translation.
+# :  64 messages, 01Aug2002, due to enhancements in application.
+# nikos: 266 messages, 05Aug2002, updated translation.
+# t_p_r: 266 messages, 05Aug2002, reviewed translation.
+# simos: 329 messages, 06Aug2002, updated translation.
+# kostas: 461 messages, 18Oct2002, updated and completed translation.
+# kostas: 535 messages, 10Dec2002, reviewed and updated translation for Gnome 2.1x.
+# kostas: 533 messages, 06Jan2003, one more update.
+# kostas: 537 messages, 26Jan2003, one more update.
+# kostas:  650 messages, 22Jul2003, one more update.
+# kostas:  655 messages, 27Jul2003, one more update.
+# kostas:  674 messages, 10Aug2003, one more update.
+# Nikos:   review, 29Aug03.
+# kostas: 678 messagew,12Nov2003, updates and fixes.
+# kostas: 786 messagew,22Jan2004, updates and fixes.
+# Simos: 723 messages, 20Dec2004, fixes/updates.
+# Spiros Papadimitriou <spapadim+@cs.cmu.edu>, 2000.
+# Nikos Charonitakis <charosn@her.forthnet.gr>, 2002, 2003, 2004, 2005.
+# Τα πάντα ρει <ta_panta_rei@flashmail.com>, 2002.
+# Jennie Petoumenou <epetoumenou@gmail.com>, 2009.
+# Kostas Papadimas <pkst@gnome.org>, 2002,2003, 2004, 2005, 2006, 2007, 2008, 2010, 2011.
+# Theodore Dimitriadis <liakoni@gmail.com>, 2010.
+# Michael Kotsarinis <mk73628@gmail.com>, 2011.
+# Simos Xenitellis <simos@gnome.org>, 2000, 2001, 2002, 2004, 2006, 2011.
+# George Stefanakis <george.stefanakis@gmail.com>, 2011.
+# Dimitris Spingos (Δημήτρης Σπίγγος) <dmtrs32@gmail.com>, 2012, 2013, 2014, 2015.
+# Tom Tryfonidis <tomtryf@gnome.org>, 2019.
+# Efstathios Iosifidis <iosifidis@opensuse.org>, 2013-2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: el\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-12-13 06:55+0000\n"
+"PO-Revision-Date: 2022-12-30 23:49+0200\n"
+"Last-Translator: Efstathios Iosifidis <eiosifidis@gnome.org>\n"
+"Language-Team: Greek, Modern (1453-) <gnome-el-list@gnome.org>\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.2.2\n"
+"X-Poedit-SourceCharset: utf-8\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Δίαυλος συστήματος"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Πλήρη πρόσβαση"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Δίαυλος συνεδρίας"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Συσκευές"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Πλήρης πρόσβαση στο /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Δίκτυο"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Έχει πρόσβαση δικτύου"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Προσωπικός φάκελος"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Μόνο ανάγνωση"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Σύστημα αρχείων"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Ρυθμίσεις"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Δυνατότητα αλλαγής ρυθμίσεων"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"Το %s έχει ενσωματωμένα τα ακόλουθα δικαιώματα. Αυτά δεν μπορούν να "
+"μεταβληθούν. Αν ανησυχείτε για αυτά τα δικαιώματα, εξετάστε το ενδεχόμενο "
+"κατάργησης αυτής της εφαρμογής."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr ""
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Εφαρμογές"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Καμία εφαρμογή"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Εγκατάσταση μερικών…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Άνοιγμα"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Προβολή λεπτομερειών"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Αναζήτηση"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Απενεργοποιήθηκε"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Ειδοποιήσεις"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Εμφάνιση ειδοποιήσεων συστήματος."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Εκτέλεση στο παρασκήνιο"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Στιγμιότυπα οθόνης"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Αλλαγή ταπετσαρίας"
+
+#: panels/applications/cc-applications-panel.ui:148
+#, fuzzy
+#| msgid "preferences-desktop-wallpaper"
+msgid "Change the desktop wallpaper."
+msgstr "preferences-desktop-wallpaper"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Ήχοι"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+#| msgid "Set Shortcut"
+msgid "Inhibit Shortcuts"
+msgstr "Ορισμός συντόμευσης"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+#| msgid "Inhibit system keyboard shortcuts"
+msgid "Block standard keyboard shortcuts."
+msgstr "Αναστολή συντομεύσεων πληκτρολογίου συστήματος"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Κάμερα"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Μικρόφωνο"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Υπηρεσίες τοποθεσίας"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+#, fuzzy
+#| msgid "Access Options"
+msgid "Access device location data."
+msgstr "Επιλογές πρόσβασης"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Ενσωματωμένα δικαιώματα"
+
+#: panels/applications/cc-applications-panel.ui:223
+#, fuzzy
+#| msgid "System features used by this application."
+msgid "System access that is required by the app"
+msgstr "Χαρακτηριστικά συστήματος που χρησιμοποιούνται από αυτήν την εφαρμογή."
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Αποθήκευση"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Δε βρέθηκαν αποτελέσματα"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Δοκιμάστε μια διαφορετική αναζήτηση"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Τύποι αρχείων"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Τύποι συνδέσμων"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Επαναφορά"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Πόσο χώρο στο δίσκο καταλαμβάνει αυτή η εφαρμογή με τα δεδομένα εφαρμογών "
+"και τη λανθάνουσα μνήμη."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Εφαρμογή"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Δεδομένα"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Λανθάνουσα μνήμη"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Σύνολο</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Εκκαθάριση λανθάνουσας μνήμης…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Ελέγξτε τα διάφορα δικαιώματα και ρυθμίσεις εφαρμογών"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "εφαρμογή;flatpak;άδεια;ρύθμιση;application;flatpak;permission;setting;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Επιλογή εικόνας"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Ακύρωση"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "Άν_οιγμα"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "πολλαπλά μεγέθη"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Επιφάνεια εργασίας χωρίς παρασκήνιο"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Τρέχον παρασκήνιο"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Στυλ"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Προεπιλεγμένη"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Σκούρο"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Παρασκήνιο"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Προσθήκη εικόνας…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Εμφάνιση"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Change your background image to a wallpaper or photo"
+msgid "Change your background image or the UI colors"
+msgstr "Αλλάξτε την εικόνα παρασκηνίου με μια ταπετσαρία ή φωτογραφία"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Ενεργοποίηση"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Δεν βρέθηκε Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Συνδέστε έναν προσαρμογέα για να χρησιμοποιήσετε το Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Το Bluetooth είναι ανενεργό"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Ενεργοποιήστε για να συνδέσετε συσκευές και να κάνετε μεταφορές αρχείων."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Η λειτουργία αεροπλάνου είναι ενεργή"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+"Το Bluetooth είναι απενεργοποιημένο όταν η λειτουργία αεροπλάνου είναι "
+"ενεργή."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Απενεργοποίηση της λειτουργίας αεροπλάνου"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Η λειτουργία αεροπλάνου είναι ενεργή μέσω του διακόπτη"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+"Απενεργοποιήστε τον διακόπτη λειτουργίας αεροπλάνου για να ενεργοποιήσετε το "
+"Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+"Ενεργοποιήστε/Απενεργοποιήστε το Bluetooth και συνδεθείτε με τις συσκευές σας"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "κοινή χρήση;κοινόχρηστο;bluetooth;μπλουτούθ;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Η κάμερα είναι ανενεργή"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Καμία εφαρμογή δεν μπορεί να τραβήξει φωτογραφίες ή βίντεο."
+
+#: panels/camera/cc-camera-panel.ui:39
+#, fuzzy
+#| msgid ""
+#| "Use of the camera allows applications to capture photos and video. "
+#| "Disabling the camera may cause some applications to not function properly."
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Η χρήση της κάμερας επιτρέπει στις εφαρμογές να καταγράφουν φωτογραφίες και "
+"βίντεο. Η απενεργοποίηση της κάμερας μπορεί να προκαλέσει τη μη σωστή "
+"λειτουργία ορισμένων εφαρμογών."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Καμία εφαρμογή δεν ζήτησε πρόσβαση στην κάμερα"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Προστατέψτε τις φωτογραφίες σας"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Τοποθετήστε τη συσκευή βαθμονόμησης πάνω από το τετράγωνο και πατήστε "
+"«Έναρξη»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Μετακινήστε τη συσκευή βαθμονόμησής σας στη θέση βαθμονόμησης και πατήστε "
+"«Συνέχεια»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Μετακινήστε τη συσκευή βαθμονόμησής σας στην επιφάνεια και πατήστε «Συνέχεια»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Κλείστε το καπάκι του φορητού υπολογιστή"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Συνέβη ένα εσωτερικό σφάλμα που δεν μπόρεσε να ανακτηθεί."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Δεν εγκαταστάθηκαν τα απαιτούμενα εργαλεία για βαθμονόμηση."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Αδυναμία δημιουργίας του προφίλ."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Το λευκό σημείο προορισμού δεν ήταν διαθέσιμο."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Ολοκληρώθηκε!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Αποτυχία βαθμονόμησης!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Μπορείτε να αφαιρέσετε τη συσκευή βαθμονόμησης."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Μην διακόπτετε τη συσκευή βαθμονόμησης ενώ δουλεύει"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Βαθμονόμηση οθόνης"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Εκκίνηση"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Συνέχεια"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "Έ_τοιμο"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Οθόνη φορητού υπολογιστή"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Ενσωματωμένη δικτυακή κάμερα"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Οθόνη %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Σαρωτής %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Φωτογραφική μηχανή %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Εκτυπωτής %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Δικτυακή κάμερα %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Ενεργοποίηση της διαχείρισης χρωμάτων για %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Προβολή προφίλ χρώματος για %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Δεν έχει βαθμονομηθεί"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Προεπιλεγμένο: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Χρωματικός χώρος: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Δοκιμαστικό προφίλ: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Επιλογή αρχείου προφίλ ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "Ε_ισαγωγή"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Υποστηριζόμενα προφίλ ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Όλα τα αρχεία"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Οθόνη"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Αποθήκευση προφίλ"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Αποθήκευση"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Δημιουργία προφίλ χρώματος για την επιλεγμένη συσκευή"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Δεν εντοπίστηκε το όργανο μέτρησης. Παρακαλούμε ελέγξτε αν είναι "
+"ενεργοποιημένο και σωστά συνδεδεμένο."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Το όργανο μέτρησης δεν υποστηρίζει δημιουργία προφίλ εκτυπωτών."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Δεν υποστηρίζεται ο τύπος της συσκευής."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Βαθμονόμηση οθόνης"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Ποιότητα βαθμονόμησης"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Η βαθμονόμηση θα παράξει ένα προφίλ που μπορείτε να χρησιμοποιήσετε για να "
+"διαχειριστείτε το χρώμα της οθόνης σας. Όσο περισσότερο χρόνο διαθέσετε στη "
+"βαθμονόμηση, τόσο καλύτερη ποιότητα χρωματικού προφίλ θα πάρετε."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Δεν θα μπορείτε να χρησιμοποιήσετε τον υπολογιστή σας όσο συμβαίνει η "
+"βαθμονόμηση."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Ποιότητα"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Κατά προσέγγιση χρόνος"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Συσκευή βαθμονόμησης"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+"Επιλέξτε την επιθυμητή συσκευή αισθητήρα που θα χρησιμοποιήσετε για "
+"βαθμονόμηση."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Τύπος οθόνης"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Επιλέξτε τον τύπο οθόνης που είναι συνδεδεμένος."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Λευκό σημείο προφίλ"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Επιλέξτε ένα λευκό σημείο προορισμού οθόνης. Οι περισσότερες οθόνες πρέπει "
+"να βαθμονομηθούν σε φωτεινότητα D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Φωτεινότητα οθόνης"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Παρακαλούμε ορίστε την οθόνη σε μια φωτεινότητα που είναι τυπική για σας. Η "
+"διαχείριση χρώματος θα είναι περισσότερο ακριβής σε αυτό το επίπεδο "
+"φωτεινότητας."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Εναλλακτικά, μπορείτε να χρησιμοποιήσετε το χρησιμοποιούμενο επίπεδο "
+"φωτεινότητας με ένα από τα άλλα προφίλ για αυτήν τη συσκευή."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Όνομα προφίλ"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Μπορείτε να χρησιμοποιήσετε ένα χρωματικό προφίλ σε διαφορετικούς "
+"υπολογιστές, ή ακόμα να δημιουργήσετε προφίλ σε διαφορετικές συνθήκες "
+"φωτισμού."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Όνομα προφίλ:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Σύνοψη"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Το προφίλ δημιουργήθηκε με επιτυχία!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Αντιγραφή προφίλ"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Απαιτεί εγγράψιμα μέσα"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Μπορεί να βρείτε αυτές τις οδηγίες χρήσης του προφίλ χρήσιμες σε συστήματα "
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> και <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Προσθήκη προφίλ"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Ανιχνεύθηκαν προβλήματα. Το προφίλ μπορεί να μη λειτουργεί σωστά. <a "
+"href=\"\">Δείτε τις λεπτομέρειες.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "Ε_ισαγωγή αρχείου…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "Προσ_θήκη"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Κάθε συσκευή χρειάζεται ένα ενημερωμένο προφίλ χρωμάτων για χρωματική "
+"διαχείριση."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Μάθετε περισσότερα"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Μάθετε περισσότερα για τη διαχείριση χρωμάτων"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Ο_ρισμός για όλους τους χρήστες"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Ορίστε αυτό το προφίλ για όλους τους χρήστες σε αυτόν τον υπολογιστή"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Ενεργοποίηση"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Προσθήκη προφίλ"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "Β_αθμονόμηση…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Βαθμονόμηση συσκευής"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Α_φαίρεση προφίλ"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "Προ_βολή λεπτομερειών"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Αδυναμία ανίχνευσης συσκευών που μπορούν να διαχειριστούν χρωματικά"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Προβολέας"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Πλάσμα"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (πίσω φως CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (πίσω φως RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (λευκό πίσω φως LED)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Ευρύ φάσμα LCD (πίσω φως CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Ευρύ φάσμα LCD (πίσω φως RGB LED)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Υψηλή"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 λεπτά"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Μεσαία"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 λεπτά"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Χαμηλή"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 λεπτά"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Εγγενής εμφάνιση"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (εκτύπωση και δημοσίευση)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (φωτογραφία και γραφικά)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Κανονικός χώρος"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Δοκιμαστικό προφίλ"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Αυτόματο"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Χαμηλή ποιότητα"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Μεσαία ποιότητα"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Υψηλή ποιότητα"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Προεπιλεγμένο RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Προεπιλεγμένο CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Προεπιλεγμένo γκρίζο"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Τα εργοστασιακά δεδομένα βαθμονόμησης που παρέχονται από τον πωλητή"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Αδύνατη η διόρθωση προβολής πλήρους οθόνης με αυτό το προφίλ"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Αυτό το προφίλ μπορεί να μην είναι πια ακριβές"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Χρώμα"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Βαθμονομήστε το χρώμα των συσκευών σας, όπως οθόνες, κάμερες ή εκτυπωτές"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Χρώμα;ICC;Προφίλ;Βαθμονόμηση;Εκτυπωτής;Οθόνη;Color;Profile;Calibrate;Printer;"
+"Display;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Άλλη…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Επιλογή γλώσσας"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "Επι_λογή"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Δε βρέθηκαν γλώσσες"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Περισσότερα…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Ξεκλειδώστε για να αλλάξετε ρυθμίσεις"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Ορισμένες ρυθμίσεις πρέπει να ξεκλειδωθούν πριν μπορέσουν να αλλάξουν."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Ξεκλείδωμα…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Ώρα"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Σήμερα"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Χθες"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d ώρα"
+msgstr[1] "%d ώρες"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d λεπτό"
+msgstr[1] "%d λεπτά"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d δευτερόλεπτο"
+msgstr[1] "%d δευτερόλεπτα"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 δευτερόλεπτα"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Σημείο πρόσβασης"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24ωρο"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "π.μ / μ.μ"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Ημερομηνία & ώρα"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Έτος"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Μήνας"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Ιανουάριος"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Φεβρουάριος"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Μάρτιος"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Απρίλιος"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Μάιος"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Ιούνιος"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Ιούλιος"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Αύγουστος"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Σεπτέμβριος"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Οκτώβριος"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Νοέμβριος"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Δεκέμβριος"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Ημέρα"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Ζώνη ώρας"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Αναζήτηση πόλης"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+#| msgid "Automatic _Date & Time"
+msgid "Automatic _Date &amp; Time"
+msgstr "Αυτόματη _ημερομηνία και ώρα"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Απαιτείται πρόσβαση στο διαδίκτυο"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+#| msgid "Date & _Time"
+msgid "Date &amp; _Time"
+msgstr "Ημερομηνία & ώ_ρα"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Αυτόματη _ζώνη ώρας"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+"Απαιτεί ενεργοποιημένες υπηρεσίες τοποθεσίας και πρόσβαση στο διαδίκτυο"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Ενεργοποιημένο"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Ζώ_νη ώρας"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Μορφή ώρας"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Αλλάξτε την ημερομηνία και ώρα, καθώς και τη ζώνης ώρας"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Ρολόι;Ζώνη ώρας;Τοποθεσία;Clock;Timezone;Location;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Αλλαγή ρυθμίσεων ώρας και ημερομηνίας του συστήματος"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Πρέπει να γίνει πιστοποίηση για να αλλάξετε τις ρυθμίσεις ώρας ή ημερομηνίας."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "Ι_στός"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "Αλληλογρα_φία"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Ημερολόγιο"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Μουσική"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Βίντεο"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Φωτογραφίες"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Προεπιλεγμένες εφαρμογές"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Ρύθμιση προεπιλεγμένων εφαρμογών"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"προεπιλογή;εφαρμογή;προτιμώμενη;μέσα;default;application;preferred;media;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Η αποστολή αναφορών των τεχνικών προβλημάτων μας βοηθά να βελτιώσουμε το %s. "
+"Οι αναφορές στέλνονται ανώνυμα και αφαιρούνται τα προσωπικά δεδομένα. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Αναφορά προβλήματος"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Α_υτόματη αναφορά προβλήματος"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Διαγνωστικά"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Αναφορά των προβλημάτων σας"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#, fuzzy
+#| msgid "Diagnostics"
+msgid "diagnostics;crash;"
+msgstr "Διαγνωστικά"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Ενεργό"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Ανενεργό"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Εφαρμογή αλλαγών;"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Οι αλλαγές δεν μπορούν να εφαρμοστούν"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Αυτό μπορεί να οφείλεται σε περιορισμούς υλικού."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Εφαρμογή"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Πίσω"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+#| msgid "Bluetooth is disabled"
+msgid "Display Settings Disabled"
+msgstr "Το Bluetooth είναι απενεργοποιημένο"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Πολλαπλές οθόνες"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Καθρέφτης"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Πρωτεύουσα οθόνη"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Λειτουργία νυχτός"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Οριζόντια"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Κάθετα δεξιά"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Κάθετα αριστερά"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Οριζόντια (ανεστραμμένη)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Προσανατολισμός"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Ανάλυση"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Ρυθμός ανανέωσης"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Προσαρμογή για τηλεόραση"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Κλιμάκωση"
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+#| msgid "Night Light"
+msgid "Night Light unavailable"
+msgstr "Λειτουργία νυχτός"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Προσωρινή απενεργοποίηση έως αύριο"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Επανεκκίνηση φίλτρου"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Η λειτουργία νυχτός κάνει τα χρώματα της οθόνης σας πιο θερμά. Αυτό μπορεί "
+"να αποτρέψει την καταπόνηση των ματιών καθώς και την αϋπνία."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Πρόγραμμα"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Ανατολή μέχρι τη δύση"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Χειροκίνητο πρόγραμμα"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Ώρες"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Από"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Ώρα"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Λεπτό"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "Π.M."
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "M.M."
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Έως"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Θερμοκρασία χρώματος"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Οθόνες"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Επιλέξτε τον τρόπο χρήσης συνδεδεμένων οθονών και προβολέων"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Πάνελ;Προβολέας;xrandr;Οθόνη;Ανάλυση;Ανανέωση;Παρακολούθηση;νύχτα;νυχτός;"
+"ανατολή;χρώμα;δύση;Panel;Projector;Screen;Resolution;Refresh;Monitor;Night;"
+"Light;Blue;redshift;color;sunset;sunrise;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr ""
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr ""
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+#, fuzzy
+#| msgid "Bluetooth Turned Off"
+msgid "Secure Boot is Turned Off"
+msgstr "Το Bluetooth είναι ανενεργό"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#, fuzzy
+#| msgid "Password"
+msgid "Passed"
+msgstr "Κωδικός πρόσβασης"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Απέτυχε"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Επίπεδο ασφαλείας 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Επίπεδο ασφαλείας 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Επίπεδο ασφαλείας 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Επίπεδο ασφαλείας 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Επίπεδο ασφαλείας"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr ""
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Επίπεδο 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Επίπεδο 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Επίπεδο 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Κανένα συμβάν"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr ""
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+#, fuzzy
+#| msgid "Firmware missing"
+msgid "Firmware BIOS Region"
+msgstr "Λείπει το υλικολογισμικό"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr ""
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr ""
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr ""
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr ""
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr ""
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr ""
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr ""
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr ""
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+#, fuzzy
+#| msgid "Suspend"
+msgid "Suspend To RAM"
+msgstr "Αναστολή"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+#, fuzzy
+#| msgid "Suspend"
+msgid "Suspend To Idle"
+msgstr "Αναστολή"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr ""
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr ""
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+#, fuzzy
+#| msgid "Display Configuration"
+msgid "TPM Platform Configuration"
+msgstr "Ρυθμίσεις οθόνης"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr ""
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+#, fuzzy
+#| msgid "Software Updates"
+msgid "Firmware Updates"
+msgstr "Ενημερώσεις λογισμικού"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+#, fuzzy
+#| msgid "Firmware missing"
+msgid "Firmware Attestation"
+msgstr "Λείπει το υλικολογισμικό"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr ""
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr ""
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr ""
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Έγκυρο"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Μη έγκυρο"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Μη ενεργοποιημένο"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Κλειδωμένο"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+#, fuzzy
+#| msgid "Not connected"
+msgid "Not Locked"
+msgstr "Δεν συνδέθηκε"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Κρυπτογραφημένο"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+#, fuzzy
+#| msgid "Not connected"
+msgid "Not Encrypted"
+msgstr "Δεν συνδέθηκε"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr ""
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+#, fuzzy
+#| msgid "Not calibrated"
+msgid "Not Tainted"
+msgstr "Δεν έχει βαθμονομηθεί"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Ευρέθη"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Δεν βρέθηκε"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+#, fuzzy
+#| msgctxt "print job"
+#| msgid "Aborted"
+msgid "Supported"
+msgstr "Εγκαταλείφθηκε"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+#, fuzzy
+#| msgid "Not connected"
+msgid "Not Supported"
+msgstr "Δεν συνδέθηκε"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "Security"
+msgid "Device Security"
+msgstr "Ασφάλεια"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+#| msgid ""
+#| "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#| "network;identity;"
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"οθόνη;κλείδωμα;διάγνωση;κατάρρευση;ιδιωτικό;πρόσφατο;προσωρινό;προσωρινό;"
+"ευρετήριο;όνομα;ταυτότητα;screen;lock;diagnostics;crash;private;recent;"
+"temporary;tmp;index;name;network;identity;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Άγνωστο"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Άγνωστο"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+#, fuzzy
+#| msgid "No printers available"
+msgid "Not Available"
+msgstr "Δεν υπάρχουν διαθέσιμοι εκτυπωτές"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+#, fuzzy
+#| msgid "System"
+msgid "System Logo"
+msgstr "Σύστημα"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Όνομα συσκευής"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+#| msgid "Hardware Address"
+msgid "Hardware Model"
+msgstr "Διεύθυνση υλικού"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Μνήμη"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Επεξεργαστής"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Γραφικά"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Χωρητικότητα δίσκου"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Υπολογισμός…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Όνομα OS"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+#| msgid "%s; Build ID: %s"
+msgid "OS Build ID"
+msgstr "%s; ΙD δόμησης: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Τύπος OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Έκδοση GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Φορτώνεται…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Σύστημα παραθύρων"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Εικονικοποίηση"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Ενημερώσεις λογισμικού"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Μετονομασία συσκευής"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Το όνομα της συσκευής χρησιμοποιείται για την αναγνώριση αυτής της συσκευής "
+"όταν προβάλλεται μέσω δικτύου ή κατά τη σύζευξη συσκευών Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Όνομα συσκευής"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Μετονομασία"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Περί"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Δείτε πληροφορίες για το σύστημα σας"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+#| msgid ""
+#| "device;system;information;memory;processor;version;default;application;"
+#| "preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"συσκευή;σύστημα;πληροφορίες;μνήμη;επεξεργαστής;έκδοση;προεπιλογή;εφαρμογή;"
+"προτιμώμενη;cd;dvd;usb;ήχος;βίντεο;δίσκος;αφαιρέσιμος;μέσα;αυτόματη εκτέλεση;"
+"device;system;information;memory;processor;version;default;application;"
+"preferred;audio;video;disc;removable;media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Ήχος και πολυμέσα"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Σίγαση/αναίρεση σίγασης  έντασης"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Μείωση έντασης"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Αύξηση έντασης"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Σίγαση/αναίρεση σίγασης μικροφώνου"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Εκκίνηση αναπαραγωγέα πολυμέσων"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Αναπαραγωγή (ή αναπαραγωγή/παύση)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Παύση αναπαραγωγής"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Διακοπή αναπαραγωγής"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Προηγούμενο κομμάτι"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Επόμενο κομμάτι"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Εξαγωγή"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Πληκτρολόγηση"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Αλλαγή στην επόμενη πηγή εισόδου"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Αλλαγή στην προηγούμενη πηγή εισόδου"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Εκκινητές"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Εκκίνηση περιηγητή βοήθειας"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Εκκίνηση αριθμομηχανής"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Εκκίνηση πελάτη ηλ. αλληλογραφίας"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Εκκίνηση περιηγητή ιστοσελίδων"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Προσωπικός φάκελος"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Αναζήτηση"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Σύστημα"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Αποσύνδεση"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Κλείδωμα οθόνης"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Προσβασιμότητα"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Εναλλαγή λειτουργίας εστίασης"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Μεγέθυνση"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Σμίκρυνση"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Εναλλαγή λειτουργίας αναγνώστη οθόνης"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Εναλλαγή λειτουργίας πληκτρολογίου οθόνης"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Μεγέθυνση του κειμένου"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Σμίκρυνση του κειμένου"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Εναλλαγή ενεργοποίησης υψηλής αντίθεσης"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Δε βρέθηκαν πηγές εισόδου"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Άλλο"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Προσθήκη πηγής εισόδου"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+"Οι μέθοδοι εισαγωγής δεν μπορούν να χρησιμοποιηθούν στην οθόνη σύνδεσης"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Δεν επιλέχτηκαν πηγές εισόδου"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Επιλογές"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Μετακίνηση προς τα πάνω"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Μετακίνηση προς τα κάτω"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Προτιμήσεις"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+#| msgid "Keyboard Shortcuts"
+msgid "View Keyboard Layout"
+msgstr "Συντομεύσεις πληκτρολογίου"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Αφαίρεση"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Προσαρμοσμένες συντομεύσεις"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Εναλλακτικό πλήκτρο χαρακτήρων"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Το πλήκτρο εναλλακτικών χαρακτήρων μπορεί να χρησιμοποιηθεί για την εισαγωγή "
+"πρόσθετων χαρακτήρων. Αυτές εκτυπώνονται μερικές φορές ως τρίτη επιλογή στο "
+"πληκτρολόγιό σας."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Αριστερό Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Δεξιό Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Αριστερό Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Δεξιό Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Πλήκτρο μενού"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Δεξιό Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Σύνθετο πλήκτρο"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+#, fuzzy
+#| msgid "Login _Screen"
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Ο_θόνη σύνδεσης"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, fuzzy, c-format
+#| msgid "These keyboard shortcuts can be changed in the keyboard settings"
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Αυτές οι συντομεύσεις πληκτρολογίου μπορούν να αλλάξουν στις ρυθμίσεις του "
+"πληκτρολογίου"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Πηγές εισόδου"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+#, fuzzy
+#| msgid "Choose keyboard layouts or input methods."
+msgid "Includes keyboard layouts and input methods."
+msgstr "Επιλογή γιατάξεων πληκτρολογίου ή μεθόδους εισαγωγής."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+#| msgid "Input Source Options"
+msgid "Input Source Switching"
+msgstr "Επιλογές πηγών εισόδου"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Χρήση της ί_διας πηγής για όλα τα παράθυρα"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+#| msgid "Allow _different sources for each window"
+msgid "Switch input sources _individually for each window"
+msgstr "Να επιτρέπονται _διαφορετικές πηγές για κάθε παράθυρο"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Συντομεύσεις πληκτρολογίου"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Προβολή και προσαρμογή συντομεύσεων"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, fuzzy, c-format
+#| msgid "%d minute"
+#| msgid_plural "%d minutes"
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d λεπτό"
+msgstr[1] "%d λεπτά"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Επαναφορά όλων των συντομεύσεων;"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Η επαναφορά των συντομεύσεων μπορεί να επηρεάσει τις προσαρμοσμένες σας "
+"συντομεύσεις. Αυτό δεν μπορεί να αναιρεθεί."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Ακύρωση"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Επαναφορά όλων"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Επαναφορά όλων…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+"Επαναφορά όλων των συντομεύσεων στους προεπιλεγμένους συνδυασμούς πλήκτρων"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Ενότητα"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Συντομεύσεις"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Προσθήκη συντόμευσης"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+#| msgid "Add Custom Shortcut"
+msgid "Add Custom Shortcuts"
+msgstr "Προσθήκη προσαρμοσμένης συντόμευσης"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Προσθήκη συντόμευσης"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Δε βρέθηκε συντόμευση πληκτρολογίου"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"Το %s χρησιμοποιείται ήδη για το %s. Αν το αντικαταστήσετε, θα "
+"απενεργοποιηθεί το %s"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Εισάγετε τη νέα συντόμευση"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Ορισμός προσαρμοσμένης συντομεύσης"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Ορισμός συντόμευσης"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Εισάγετε μια νέα συντόμευση για αλλαγή του %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Προσθήκη προσαρμοσμένης συντόμευσης"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Α_φαίρεση"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+#| msgid "Replace"
+msgid "Re_place"
+msgstr "Αντικατάσταση"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Πατήστε Esc για ακύρωση ή Backspace για απενεργοποίηση της συντόμευσης "
+"πληκτρολογίου."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Όνομα"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Εντολή"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Συντόμευση"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Ορισμός συντόμευσης…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Κανένα"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Επαναφορά της συντόμευσης στην προεπιλεγμένη της τιμή"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Πληκτρολόγιο"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "View and change keyboard shortcuts and set your typing preferences"
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Δείτε και αλλάξτε τις συντομεύσεις πληκτρολογίου και ορίστε τις προτιμήσεις "
+"πληκτρολόγησης"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Συντόμευση;Χώρος εργασίας;Παράθυρο;Αλλαγή μεγέθους;Εστίαση;Αντίθεση;Εισαγωγή;"
+"Πηγή;Κλείδωμα;Τόμος;Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;"
+"Source;Lock;Volume;"
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+#| msgid "Location services turned off"
+msgid "Location Services Turned Off"
+msgstr "Υπηρεσίες τοποθεσίας απενεργοποιημένες"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Καμία εφαρμογή δεν μπορεί να λάβει πληροφορίες τοποθεσίας."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Καμία εφαρμογή δεν ζήτησε να έχει πρόσβαση στην τοποθεσία"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Προστατέψτε τις πληροφορίες τοποθεσίας σας"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+#| msgid "Microphone is turned off"
+msgid "Microphone Turned Off"
+msgstr "Το μικρόφωνο είναι ανενεργό"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Καμία εφαρμογή δεν μπορεί να εγγράψει ήχο."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+#, fuzzy
+#| msgid ""
+#| "Use of the microphone allows applications to record and listen to audio. "
+#| "Disabling the microphone may cause some applications to not function "
+#| "properly."
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Η χρήση του μικροφώνου επιτρέπει στις εφαρμογές να καταγράφουν και να ακούν "
+"ήχους. Η απενεργοποίηση του μικροφώνου μπορεί να προκαλέσει τη μη σωστή "
+"λειτουργία ορισμένων εφαρμογών."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Καμία εφαρμογή δεν ζήτησε να έχει πρόσβαση στο μικρόφωνο"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Προστατέψτε τις συνομιλίες σας"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Δοκιμή των ρυθμίσεων σας"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Γενικά"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Πρωτεύον κουμπί"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+"Ορίζει τη σειρά των φυσικών πλήκτρων στα ποντίκια και τις πινακίδες αφής."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Αριστερά"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Δεξιά"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Ποντίκι"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Ταχύτητα ποντικιού"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Φυσική κύλιση"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Η κύλιση μετακινεί το περιεχόμενο, όχι την προβολή."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Επιφάνεια αφής"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Ταχύτητα πινακίδας αφής"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Χτύπημα για πάτημα"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Πατήστε για κλικ"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Κύλιση με δύο δάκτυλα"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Κύλιση άκρου"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Δοκιμή κλικ, διπλού κλικ, και κύλισης"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Πέντε κλικ, ώρα του GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Διπλό κλικ, πρωτεύοντος κουμπιού"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Απλό κλικ, πρωτεύοντος κουμπιού"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Διπλό κλικ, μεσαίου κουμπιού"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Μονό κλικ, μεσαίου κουμπιού"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Διπλό κλικ, δευτερεύοντος κουμπιού"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Μονό κλικ, δευτερεύοντος κουμπιού"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Ποντίκι & επιφάνεια αφής"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Αλλάξτε την ευαισθησία του ποντικιού ή της επιφάνειας αφής και επιλέξτε "
+"λειτουργία δεξιόχειρου ή αριστερόχειρου"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Πινακίδα αφής;Δείκτης;Πάτημα;Πληκτρολόγηση;Κουμπί;Ιχνοσφαίρα;κύλιση;Trackpad;"
+"Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Χώροι εργασίας"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+#| msgid "Automatically Delete Temporary _Files"
+msgid "Automatically removes empty workspaces."
+msgstr "Αυτόματη διαγραφή προσωρινών α_ρχείων"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+#| msgid "Monitor"
+msgid "Multi-Monitor"
+msgstr "Οθόνη"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+#| msgid "Drag to change primary display."
+msgid "Workspaces on _primary display only"
+msgstr "Σύρετε για να αλλάξετε την κύρια οθόνη."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+#| msgctxt "Wacom action-type"
+#| msgid "Application defined"
+msgid "Application Switching"
+msgstr "Καθορίστηκε εφαρμογή"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ωχ, κάτι πήγε στραβά. Παρακαλούμε επικοινωνήστε με τον πωλητή του λογισμικού "
+"σας."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Ο διαχειριστής δικτύου πρέπει να εκτελείται."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Άλλες συσκευές"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Προσθήκη σύνδεσης"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Δεν είναι ρυθμισμένο"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Μη ασφαλές δίκτυο (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Ασφαλές δίκτυο (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Ασφαλές δίκτυο (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Ασφαλές δίκτυο (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Ασφαλές δίκτυο"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Συνδεδεμένο"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Επιλογές…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Πρέπει να έχει τουλάχιστον 8 χαρακτήρες"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, fuzzy, c-format
+#| msgid "Must have a minimum of 8 characters"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Πρέπει να έχει τουλάχιστον 8 χαρακτήρες"
+msgstr[1] "Πρέπει να έχει τουλάχιστον 8 χαρακτήρες"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Ενεργοποίηση σημείου ασύρματης πρόσβασης;"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Όνομα δικτύου"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Κωδικός πρόσβασης"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Τυχαία δημιουργία συνθηματικού"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Αυτόματη δημιουργία συνθηματικού"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Ενεργοποίηση"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Διακοπή σημείου πρόσβασης και αποσύνδεση όλων των χρηστών;"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Διακοπή σημείου πρόσβασης"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Λειτουργία αεροπλάνου"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Απενεργοποιεί Wi-Fi, Bluetooth και κινητή ευρυζωνική"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Δε βρέθηκε προσαρμογέας Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+"Σιγουρευτείτε ότι έχετε συνδέσει και ενεργοποιήσει ένα προσαρμογέα Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Λειτουργία αεροπλάνου"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Απενεργοποιήστε για χρήση Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Ενεργό σημείο ασύρματης πρόσβασης"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Οι φορητές συσκευές μπορούν να σαρώσουν τον κωδικό QR για σύνδεση."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Απενεργοποίηση σημείου ασύρματης πρόσβασης…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Ορατά δίκτυα"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Ο διαχειριστής δικτύου πρέπει να εκτελείται"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Ασφάλεια 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Ασφάλεια"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Διατήρηση"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Μόνιμο"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Τυχαία"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Σταθερό"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Η διεύθυνση MAC που καταχωρίσατε εδώ θα χρησιμοποιηθεί ως διεύθυνση υλικού "
+"για τη συσκευή δικτύου που ενεργοποιείται αυτή η σύνδεση. Αυτή η δυνατότητα "
+"είναι γνωστή ως MAC cloning ή spoofing. Παράδειγμα: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Προφίλ %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Ενισχυμένο άνοιγμα"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Εταιρική"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Καμία"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Ποτέ"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i ημέρα πριν"
+msgstr[1] "%i ημέρες πριν"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Καθόλου"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Ασθενές"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Μέτριο"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Καλό"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Εξαιρετικό"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Διεύθυνση IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Διεύθυνση IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Διεύθυνση IP"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Παράλειψη σύνδεσης"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Αφαίρεση προφίλ σύνδεσης"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Αφαίρεση VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Λεπτομέρειες"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "αυτόματο"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Ταυτότητα"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Διαγραφή διεύθυνσης"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Διαγραφή δρομολογητή"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Κανένα"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Κλειδί WEP 40/128-bit (δεκαεξαδικό ή ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Συνθηματικό WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Δυναμικό WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "Προσωπικό WPA & WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "Εταιρικό WPA & WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "Προσωπικό WPA3"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Ισχύς σήματος"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Ταχύτητα σύνδεσης"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Διεύθυνση υλικού"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Υποστηριζόμενες συχνότητες"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Προεπιλεγμένος δρομολογητής"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Τελευταία χρησιμοποιημένο"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Α_υτόματη σύνδεση"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Να είναι διαθέσιμο σε ά_λλους χρήστες"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"Σύνδεση που _μετράται: έχει όρια δεδομένων ή μπορεί να επιβαρυνθεί με "
+"χρεώσεις"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Οι ενημερώσεις λογισμικού και άλλες μεγάλες λήψεις δεν θα ξεκινήσουν "
+"αυτόματα."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "Ό_νομα"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Διεύθυνση _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Κλωνοποιημένη διεύθυνση"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Μέθοδος IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Αυτόματα (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Μόνο τοπική σύνδεση"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Χειροκίνητο"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Απενεργοποίηση"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Κοινή χρήση με άλλους υπολογιστές"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Διευθύνσεις"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Διεύθυνση"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Μάσκα δικτύου"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Πύλη δικτύου"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Αυτόματο"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Αυτόματο DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Διαχωρήστε τις διευθύνσεις IP με κόμματα"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Διαδρομές"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Αυτόματες διαδρομές"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Μετρικό"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Χ_ρήση αυτής της σύνδεσης μόνο για πόρους του δικτύου της"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Μέθοδος IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Αυτόματα, μόνο DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Πρόθεμα"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Αποτυχία ανοίγματος επεξεργαστή σύνδεσης"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Νέο προφίλ"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, fuzzy, c-format
+#| msgid "All Settings"
+msgid "Invalid setting %s"
+msgstr "Ρυθμίσεις"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Εισαγωγή από αρχείο…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Προσθήκη VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Ασ_φάλεια"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Αδυναμία εισαγωγής της σύνδεσης VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Αδύνατη η ανάγνωση του αρχείου «%s», ή το αρχείο δε διαθέτει αναγνωρίσιμες "
+"πληροφορίες σύνδεσης VPN\n"
+"\n"
+"Σφάλμα: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Επιλογή αρχείου για εισαγωγή"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Υπάρχει ήδη ένα αρχείο με όνομα «%s»."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Αντικατάσταση"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Θέλετε να αντικαταστήσετε το %s με την σύνδεση VPN που αποθηκεύετε;"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Αδύνατη η εξαγωγή της σύνδεσης VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Αδύνατη η εξαγωγή της σύνδεσης VPN «%s» στο %s.\n"
+"\n"
+"Σφάλμα: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Εξαγωγή σύνδεσης VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Σφάλμα: αδυναμία φόρτωσης επεξεργαστή σύνδεσης VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Ελέξτε τον τρόπο σύνδεσης με το διαδίκτυο"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;δίκτυο;IP;LAN;"
+"διαμεσολαβητής;WAN;ευρυζωνικό;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Ελέξτε τον τρόπο σύνδεσης με τα ασύρματα δίκτυα"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Δίκτυο;Ασύρματο;Wi-Fi;Wifi;IP;LAN;Ευρυζωνικό;DNS;\tΣημείο πρόσβασης;Network;"
+"Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "ποτέ"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "σήμερα"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "χθες"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Τελευταία χρησιμοποιημένο"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Ενσύρματη"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Προσθήκη νέας σύνδεσης"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Θα χαθούν οι λεπτομέρειες των επιλεγμένων δικτύων, συμπεριλαμβανομένων των "
+"κωδικών πρόσβασης και των προσαρμοσμένων ρυθμίσεων."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Παράλειψη"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Γνωστά δίκτυα Wi-Fi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Παράλειψη"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Η πολιτική του συστήματος απαγορεύει τη χρήση ως σημείο πρόσβασης"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Η ασύρματη συσκευή δεν υποστηρίζει λειτουργία με σημείο πρόσβασης"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Η αυτόματη εύρεση διαμεσολαβητή Ιστού χρησιμοποιείται όταν δεν παρέχετε μια "
+"διεύθυνση ρυθμίσεων."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Αυτό δεν το συνιστούμε για δίκτυα τα οποία δεν εμπιστεύεστε."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Απενεργοποίηση συσκευής"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Ενεργό"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Πάροχος"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Διαμεσολαβητής δικτύου"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Διαμεσολαβητής _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Διαμεσολαβητής H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Διαμεσολαβητής _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Κεντρικός υπολογιστής _Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Παράβλεψη κεντρικών υπολογιστών"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Θύρα διαμεσολαβητή HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Θύρα διαμεσολαβητή HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Θύρα διαμεσολαβητή FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Θύρα διαμεσολαβητή Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "Διεύθυνση _ρυθμίσεων"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Απενεργοποίηση σύνδεσης VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Όνομα δικτύου"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Τύπος ασφάλειας"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Συνθηματικό"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Σβήσιμο Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Περισσότερες επιλογές…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Σύνδεση σε κρυφό δίκτυο…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Ενεργοποίηση σημείου ασύρματης πρόσβασης..."
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Γνωστά δίκτυα Wi-Fi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Άγνωστη κατάσταση"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Χωρίς διαχείριση"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Μη διαθέσιμο"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Γίνεται σύνδεση"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Απαιτείται πιστοποίηση"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Γίνεται αποσύνδεση"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Αποτυχία σύνδεσης"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Άγνωστη κατάσταση (απουσιάζει)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Αποτυχία ρύθμισης"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Αποτυχία ρύθμισης της IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Έληξε η ρυθμίση IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Τα μυστικά απαιτήθηκαν, αλλά δεν προσφέρθηκαν"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "αποσυνδέθηκε η αίτηση του 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Αποτυχία ρύθμισης της αίτησης του 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Αποτυχία της αίτησης του 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Η αίτηση του 802.1x πήρε αρκετή ώρα για να πιστοποιηθεί"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Αποτυχία εκκίνησης της υπηρεσίας PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Αποσυνδέθηκε η υπηρεσία PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Αποτυχία του PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Αποτυχία εκκίνησης του πελάτη DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Σφάλμα πελάτη DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Αποτυχία του πελάτη DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Αποτυχία εκκίνησης της υπηρεσίας κοινόχρηστης σύνδεσης"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Αποτυχία της υπηρεσίας κοινόχρηστης σύνδεσης"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Αποτυχία εκκίνησης της υπηρεσίας AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Σφάλμα υπηρεσίας AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Αποτυχία υπηρεσίας AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Η γραμμή είναι απασχολημένη"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Δεν ακούγεται ο τόνος κλήσης"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Δεν είναι δυνατή η δημιουργία γραμμής"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Έληξε το αίτημα κλήσης"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Απέτυχε η προσπάθεια κλήσης"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Απέτυχε η προετοιμασία του μόντεμ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Απέτυχε η επιλογή του συγκεκριμένου APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Δεν ψάχνει για δίκτυα"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Απερρίφθη η εγγραφή στο δίκτυο"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Έληξε η εγγραφή στο δίκτυο"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Αποτυχία εγγραφής στο ζητούμενο δίκτυο"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Απέτυχε ο έλεγχος του PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Μπορεί να λείπει το υλικολογισμικό για τη συσκευή"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Η σύνδεση χάθηκε"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Θεωρήθηκε πως υπάρχει μια τρέχουσα σύνδεση"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Δεν βρέθηκε μόντεμ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Αποτυχία σύνδεσης του Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Δεν έχει τοποθετηθεί η κάρτα SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Απαιτείται το Pin της SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Απαιτείται το Puk της SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Λάθος SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Απέτυχε η εξάρτηση της σύνδεσης"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Λείπει το υλικολογισμικό"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Το καλώδιο αποσυνδέθηκε"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "μη ορισμένο σφάλμα στην ασφάλεια 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "Δεν έχει επιλεγεί αρχείο"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "ακαθόριστο σφάλμα στην πιστοποίηση του αρχείου eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+#, fuzzy
+#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Ιδιωτικά κλειδιά DER, PEM, ή PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:397
+#, fuzzy
+#| msgid "_User certificate"
+msgid "DER or PEM certificates"
+msgstr "Πιστοποιητικό _χρήστη"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "Λείπει το αρχείο EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Αρχεία PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Ανώνυμος"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Πιστοποιήθηκε"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Και τα δύο"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Α_νώνυμη ταυτότητα"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "Α_ρχείο PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Επιλογή ενός φακέλου PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Εσωτερική πιστοποίηση"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Να επιτρέπεται η αυτόματη _παροχή PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "Λείπει το όνομα χρήστη EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "Λείπει ο κωδικός πρόσβασης EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Όνομα _χρήστη"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "Κω_δικός πρόσβασης"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Εμ_φάνιση κωδικού πρόσβασης"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "Άκυρο πιστοποιητικό EAP-PEAP CA: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "Άκυρο πιστοποιητικό EAP-PEAP CA: δεν έχει καθοριστεί πιστοποιητικό"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Έκδοση 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Έκδοση 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Πιστοποιητικό C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Επιλέξτε ένα πιστοποιητικό αρχής πιστοποίησης"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Δεν α_παιτείται κανένα πιστοποιητικό CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "Έκ_δοση PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "Λείπει το όνομα χρήστη EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "Λείπει ο κωδικός πρόσβασης EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "Λείπει η ταυτότητα EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "Άκυρο πιστοποιητικό EAP-TLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "Άκυρο πιστοποιητικό EAP-TLS CA: δεν έχει καθοριστεί πιστοποιητικό"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "Άκυρο ιδιωτικό κλειδί EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "Άκυρο πιστοποιητικό χρήστη EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Τα μη κρυπτογραφημένα ιδιωτικά κλειδιά είναι επισφαλή"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Το επιλεγμένο ιδιωτικό κλειδί δεν φαίνεται να προστατεύεται από ένα "
+"συνθηματικό. Αυτό πιθανόν να επιτρέπει τα διαπιστευτήρια ασφάλειας να "
+"παραβιαστούν. Παρακαλούμε επιλέξτε ένα ιδιωτικό κλειδί που να προστατεύεται "
+"από ένα συνθηματικό.\n"
+"\n"
+"(Μπορείτε να προστατεύσετε με συνθηματικό το ιδιωτικό σας κλειδί με το "
+"openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Επιλέξτε το προσωπικό σας πιστοποιητικό"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Επιλέξτε το ιδιωτικό σας κλειδί"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Ταυτότητα"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Πιστοποιητικό _χρήστη"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Ιδιωτικό κ_λειδί"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Κωδικός πρόσβασης _ιδιωτικού κλειδιού"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "Άκυρο πιστοποιητικό EAP-TTLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "Άκυρο πιστοποιητικό EAP-TTLS CA: δεν έχει καθοριστεί πιστοποιητικό"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (χωρίς EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Τομέας"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Άγνωστο σφάλμα κατά την πιστοποίηση της ασφάλειας 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Διοχετευμένο TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Προστατευμένο EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Πιστοποίηση"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Επιλογή ενός αρχείου"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "Λείπει το όνομα χρήστη leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "Λείπει το συνθηματικό leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+#, fuzzy
+#| msgid "invalid EAP-TLS password: missing"
+msgid "Wi-Fi password is missing."
+msgstr "Άκυρο πιστοποιητικό EAP-TLS: λείπει"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Τύπος"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "Λείπει το κλειδί wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"Άκυρο wep-key: το κλειδί με μήκος %zu πρέπει να περιέχει μόνο δεκαεξαδικά "
+"ψηφία"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"Άκυρο wep-key: το κλειδί με μήκος %zu πρέπει να περιέχει μόνο χαρακτήρες "
+"ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"Άκυρο wep-key: λαθεμένο μήκος κλειδιού %zu. Ένα κλειδί πρέπει να έχει μήκος "
+"χαρακτήρων 5/13 (ascii) ή 10/26 (δεκαεξαδικό)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "μη έγκυρο wep-key: το συνθηματικό δεν πρέπει να είναι κενό"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"μη έγκυρο wep-key: το συνθηματικό πρέπει να είναι μικρότερο από 64 χαρακτήρες"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Προεπιλογή)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Ανοικτό σύστημα"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Κοινόχρηστο κλειδί"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "Κ_λειδί"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Εμ_φάνιση κλειδιού"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Δεί_κτης WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"μη έγκυρο wpa-psk:  μη έγκυρο μήκος κλειδιού %zu. Πρέπει να είναι [8,63] "
+"bytes ή 64 δεκαεξαδικά ψηφία"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"μη έγκυρο wpa-psk: αδυναμία μεταγλώττισης κλειδιού με 64 bytes ως δεκαεξαδικό"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Ει_δοποιήσεις"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Ηχητικές _ειδοποιήσεις"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Αναδυόμενες ειδ_οποιήσεις"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Οι ειδοποιήσεις θα συνεχίσουν να εμφανίζονται στη λίστα όταν είναι "
+"απενεργοποιημένες οι αναδυόμενες ειδοποιήσεις."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Να εμφανίζεται το πε_ριεχόμενο του μηνύματος σε τίτλους"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Ειδοποιήσεις κ_λειδώματος οθόνης"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Να εμφανίζεται το _περιεχόμενο του μηνύματος στο κλείδωμα οθόνης"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Μην ενοχλείτε"
+
+#. Translators: Whether to show notifications on the lock screen
+#: panels/notifications/cc-notifications-panel.ui:17
+#: panels/screen/cc-screen-panel.ui:69
+msgid "_Lock Screen Notifications"
+msgstr "Ειδοποιήσεις _κλειδώματος οθόνης"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Ελέγξτε ποιες ειδοποιήσεις εμφανίζονται και τι εμφανίζουν"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Ειδοποιήσεις;Τίτλοι;Μήνυμα;Δίσκος;Αναδυόμενο;Notifications;Banner;Message;"
+"Tray;Popup;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Άλλο"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "Ο %s αφαιρέθηκε"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Σφάλμα αφαίρεσης λογαριασμού"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Aναίρεση"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+#| msgid "_Inner authentication"
+msgid "Close the notification"
+msgstr "_Εσωτερική πιστοποίηση"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Συνδεθείτε με τα δεδομένα σας στο cloud"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Χωρίς σύνδεση στο διαδίκτυο — συνδεθείτε για να ρυθμίσετε νέους "
+"διαδικτυακούς λογαριασμούς"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Προσθήκη λογαριασμού"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Λογαριασμός %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Αφαίρεση λογαριασμού"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Διαδικτυακοί λογαριασμοί"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Συνδεθείτε με τους δικτυακούς λογαριασμούς σαε και αποφασίστε πού θα τους "
+"χρησιμοποιήσετε"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Ιστός;Με σύνδεση;Συνομιλία;Ημερολόγιο;"
+"Αλληλογραφία;Επαφές;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;Online;"
+"Chat;Calendar;Mail;Contact;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Άγνωστος χρόνος"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i λεπτό"
+msgstr[1] "%i λεπτά"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ώρα"
+msgstr[1] "%i ώρες"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ώρα"
+msgstr[1] "ώρες"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "λεπτό"
+msgstr[1] "λεπτά"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s μέχρι την πλήρη φόρτιση"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Προσοχή: απομένει %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "απομένει %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Πλήρης φόρτιση"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Δεν φορτίζεται"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Κενό"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Φορτίζεται"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Εκφορτίζεται"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Ασύρματο ποντίκι"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Ασύρματο πληκτρολόγιο"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Αδιάλειπτη παροχή ρεύματος"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Προσωπικός ψηφιακός βοηθός"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Κινητό τηλέφωνο"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Αναπαραγωγέας πολυμέσων"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Υπολογιστής"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Συσκευή εισαγωγής για παιχνίδια"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Μπαταρία"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Κύριο"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Πρόσθετο"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Μπαταρίες"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Όταν είναι _ανενεργό"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Αναστολή"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Τερματισμός"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Aδρανοποίηση"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Καμία ενέργεια"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Όταν τροφοδοτείται από μπαταρία"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Όταν είναι στην παροχή ρεύματος"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Ποτέ"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Αυτόματη αναστολή"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 λεπτά"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 λεπτά"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 λεπτά"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 λεπτά"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 λεπτά"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 ώρα"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 λεπτά"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 λεπτά"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 λεπτά"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 ώρες"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+#| msgid "Power off"
+msgid "Power Mode"
+msgstr "Τερματισμός"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+#| msgid "Power Saving"
+msgid "Power Saving Options"
+msgstr "Εξοικονόμηση ενέργειας"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+#| msgid "Automatic Brightness"
+msgid "Automatic Screen Brightness"
+msgstr "Αυτόματη φωτεινότητα"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+#| msgid "Screen"
+msgid "Dim Screen"
+msgstr "Οθόνη"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+#| msgid "Screen _Reader"
+msgid "Screen _Blank"
+msgstr "Ανα_γνώστης οθόνης"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+#| msgid "_Automatic Problem Reporting"
+msgid "Automatic Power Saver"
+msgstr "Α_υτόματη αναφορά προβλήματος"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Αυτόματη αναστολή"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Συμπεριφορά κουμπιού _τροφοδοσίας"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Εμφάνιση _ποσοστού μπαταρίας"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Αυτόματη αναστολή"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Συνδεμένο"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Με τροφοδοσία _μπαταρίας"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Καθυστέρηση"
+
+#: panels/power/cc-power-profile-row.c:132
+#, fuzzy
+#| msgid "Permanent"
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Μόνιμο"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:136
+#, fuzzy
+#| msgid "Balance"
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Ισοστάθμιση"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:140
+#, fuzzy
+#| msgid "Power Saving"
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Εξοικονόμηση ενέργειας"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Ενέργεια"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Δείτε την κατάστασης της μπαταρίας σας και αλλάξτε τις ρυθμίσεις αποθήκευσης "
+"ενέργειας"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;"
+#| "Idle;"
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Ισχύς;Ενέργεια;Ρεύμα;Ύπνωση;Αναστολή;Αδρανοποίηση;Μπαταρία;Φωτεινότητα;"
+"Αμυδρό;Κενό;Οθόνη;DPMS;Αδρανές;Power;Sleep;Suspend;Hibernate;Battery;"
+"Brightness;Dim;Blank;Monitor;Idle;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Ο εκτυπωτής «%s» έχει διαγραφεί"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Αδυναμία φόρτωσης γραφικού περιβάλλοντος: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+#, fuzzy
+#| msgid "Unlock to Change Settings"
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Ξεκλειδώστε για να αλλάξετε ρυθμίσεις"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Εκτυπωτές"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Προσθέστε εκτυπωτές, δείτες τις εργασίες ενός εκτυπωτή και καθορίστε τον "
+"τρόπο εκτύπωσης"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"Εκτυπωτής;Ουρά;Εκτύπωση;Χαρτί;Μελάνι;Τόνερ;Γραφίτης;Printer;Queue;Print;"
+"Paper;Ink;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Προσθήκη εκτυπωτή"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Ξεκλείδωμα"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Δε βρέθηκαν εκτυπωτές"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Εισάγετε μια διεύθυνση δικτύου ή αναζητήστε έναν εκτυπωτή"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Απαιτείται πιστοποίηση"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Εισάγετε ένα όνομα χρήστη και έναν κωδικό πρόσβασης για να δείτε εκτυπωτές "
+"στο διακομιστή εκτύπωσης."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Όνομα χρήστη"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Λεπτομέρειες %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Δε βρέθηκε κατάλληλος οδηγός"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Επιλεγμένο αρχείο PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Αρχεία περιγραφής εκτυπωτών PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Τοποθεσία"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Οδηγός"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Αναζήτηση για προτιμώμενους οδηγούς…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Αναζήτηση για οδηγούς λογισμικού"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Επιλογή από βάση δεδομένων…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Εγκατάσταση αρχείου PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Επιλέξτε τον οδηγό του εκτυπωτή"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Φόρτωση βάσης δεδομένων των οδηγών…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Επιλογή"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Εκτυπωτής JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Εκτυπωτής LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Μονής όψης"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Μακρύ άκρο (κανονικό)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Βραχύ άκρο (αναστροφή)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Κάθετα"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Οριζόντια"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Αντίστροφα οριζόντιο"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Αντίστροφα κάθετο"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Συνέχεια"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Παύση"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Εκκρεμεί"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Σε παύση"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Απαιτείται πιστοποίηση"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Γίνεται επεξεργασία"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Διακόπηκε"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Ακυρώθηκε"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Εγκαταλείφθηκε"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Ολοκληρώθηκε"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr ""
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u εργασία απαιτεί πιστοποίηση"
+msgstr[1] "%u εργασίες απαιτούν πιστοποίηση"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Ενεργές εργασίες"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Εισάγετε διαπιστευτήρια για να εκτυπώσετε από %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Τομέας"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "Πισ_τοποίηση"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Εκκαθάριση όλων"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Πιστοποίηση"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Καμία ενεργή εργασία εκτύπωσης"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Ξεκλείδωμα διακομιστή εκτύπωσης"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Ξεκλείδωμα %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Εισάγετε ένα όνομα χρήστη και έναν κωδικό πρόσβασης για να δείτε εκτυπωτές "
+"στο %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Αναζήτηση για εκτυπωτές"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Σειριακή θύρα"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Παράλληλη θύρα"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Τοποθεσία: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Διεύθυνση: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Ο διακομιστής απαιτεί ταυτοποίηση"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Διπλής όψης"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Τύπος χαρτιού"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Πηγή χαρτιού"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Συρτάρι εξόδου"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Ανάλυση"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Προφιλτράρισμα GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Σελίδες ανά φύλλο"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Διπλής όψης"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Προσανατολισμός"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Γενικά"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Ρύθμιση σελίδας"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Εγκαταστάσιμες επιλογές"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Εργασία"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Ποιότητα εικόνας"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Χρώμα"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Ολοκληρώνεται"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Για προχωρημένους"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Δοκιμαστική σελίδα"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Δοκιμαστική σελίδα"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Αυτόματη επιλογή"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Προεπιλογή εκτυπωτή"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Ενσωμάτωση μόνο των γραμματοσειρών GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Μετατροπή σε PS επιπέδου 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Μετατροπή σε PS επιπέδου 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Χωρίς προ-φιλτράρισμα"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Κατασκευαστής"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Χωρίς ενεργές εργασίες"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u εργασία"
+msgstr[1] "%u εργασίες"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Καθαρισμός κεφαλών εκτυπωτή"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Τελειώνει ο γραφίτης"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Άδειος γραφίτης"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Τελειώνει το υγρό εμφάνισης"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Τελείωσε το υγρό εμφάνισης"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Τελειώνει ένα από τα χρώματα"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Τελείωσε ένα από τα χρώματα"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Κάλυμμα ανοικτό"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Πορτάκι ανοικτό"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Τελειώνει το χαρτί"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Τελείωσε το χαρτί"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Αποσυνδεδεμένος"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Διακόπηκε"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Το δοχείο απορριμμάτων σχεδόν γέμισε"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Το δοχείο απορριμμάτων είναι γεμάτο"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Το τύμπανο είναι σχεδόν στο τέλος της ζωής του"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Το τύμπανο δεν δουλεύει πλέον"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Έτοιμο"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Δεν δέχεται εργασίες"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Γίνεται επεξεργασία"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Επιλογές εκτύπωσης"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Λεπτομέρειες εκτυπωτή"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Χρήση εκτυπωτή από προεπιλογή"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Καθαρισμός κεφαλών εκτυπωτή"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Αφαίρεση εκτυπωτή"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Μοντέλο"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Επίπεδο μελανιού"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Παρακαλούμε, κάντε μια επανεκκίνηση όταν επιλυθεί το πρόβλημα."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Επανεκκίνηση"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Προσθήκη εκτυπωτή…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Χωρίς εκτυπωτές"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+#, fuzzy
+#| msgid ""
+#| "Sorry! The system printing service\n"
+#| "doesn’t seem to be available."
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Συγγνώμη! Η υπηρεσία εκτύπωσης του συστήματος\n"
+"φαίνεται να μην είναι διαθέσιμη."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Μορφές"
+
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+#| msgid "Search locales..."
+msgid "Search locales…"
+msgstr "Αναζήτηση τοπικών ρυθμίσεων..."
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Κοινές μορφοποιήσεις"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Όλες οι μορφές"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Δε βρέθηκαν αποτελέσματα αναζήτησης"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Οι αναζητήσεις μπορούν να γίνουν για χώρες ή γλώσσες."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Προεπισκόπηση"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Αυτοκρατορικό"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Μετρικό"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Ημερομηνίες"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Ημερομηνία & ώρα"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Αριθμοί"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Μέτρηση"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Χαρτί"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Αποσύνδεση…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Ο λογαριασμός σας"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "Γ_λώσσα"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "Μορ_φοποιήσεις"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Οθόνη σύνδεσης"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Περιοχή & Γλώσσα"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+#| msgid ""
+#| "Select your display language, formats, keyboard layouts and input sources"
+msgid "Select your display language and formats"
+msgstr ""
+"Επιλέξτε γλώσσα εμφάνισης, μορφές, διατάξεις πληκτρολογίου και πηγές εισόδου"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Γλώσσα;Διάταξη;Πληκτρολόγιο;Είσοδος;Language;Layout;Keyboard;Input;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Ερώτηση για την ενέργεια"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Καμία ενέργεια"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Άνοιγμα φακέλου"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Άλλα μέσα"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Επιλέξτε μια εφαρμογή για CD ήχου"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Επιλέξτε μια εφαρμογή για DVD βίντεο"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Επιλέξτε την εφαρμογή που θα εκτελείται, όταν θα συνδέεται ένας "
+"αναπαραγωγέας μουσικής"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+"Επιλέξτε την εφαρμογή που θα εκτελείται, όταν θα συνδέεται μια φωτογραφική "
+"μηχανή"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Επιλέξτε μια εφαρμογή για τα CD λογισμικού"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD ήχου"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Κενό Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "Κενό CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "Κενό DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "Κενό HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Δίσκος βίντεο Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "Αναγνώστης ηλεκτρονικών βιβλίων"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Δίσκος βίντεο HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "CD εικόνων"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Λογισμικό Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Επιλογή τρόπου διαχείρισης μέσων"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD ή_χου"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD βίντεο"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Αναπαραγωγέας μουσικής"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Λογισμικό"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "Ά_λλα μέσα…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Να μη γίνεται ποτέ ερώτηση ή εκκίνηση προγραμμάτων κατά την εισαγωγή "
+"πολυμέσων"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Επιλογή τρόπου διαχείρισης άλλων μέσων"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Ενέργεια:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Τύπος:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Αφαιρούμενα μέσα"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Ρύθμιση επιλογών αφαιρούμενων μέσων"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"συσκευή;σύστημα;προεπιλογή;εφαρμογή;προτιμώμενη;cd;dvd;usb;ήχος;βίντεο;"
+"δίσκος;αφαιρέσιμος;μέσα;αυτόματη εκτέλεση;device;system;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Η οθόνη σβήνει"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 δευτερόλεπτα"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 λεπτό"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 λεπτά"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 λεπτά"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 λεπτά"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 λεπτά"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 ώρα"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 λεπτό"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 λεπτά"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 λεπτά"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 λεπτά"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 λεπτά"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 λεπτά"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 λεπτά"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 λεπτά"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 λεπτά"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Ποτέ"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Κλείδωμα οθόνης"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Το αυτόματο κλείδωμα της οθόνης εμποδίζει την πρόσβαση άλλων ατόμων στον "
+"υπολογιστή ενώ έχετε απομακρυνθεί."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Καθυστέρηση μαύρης οθόνη"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Περίοδος αδράνειας μετά την οποία η οθόνη θα γίνει μαύρη."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Αυτόματο _κλείδωμα οθόνης"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Καθυστέρηση αυτόματου _κλειδώματος οθόνης"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Περίοδος μετά το μαύρισμα της οθόνης όταν κλειδώνει αυτόματα η οθόνη."
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Αποτρέψτε την αλληλεπίδραση νέων συσκευών USB με το σύστημα όταν η οθόνη "
+"είναι κλειδωμένη."
+
+#: panels/screen/cc-screen-panel.ui:108
+#, fuzzy
+#| msgid "Privacy"
+msgid "Screen Privacy"
+msgstr "Ιδιωτικότητα"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Ρυθμίσεις οθόνης"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Επιλογή περιοχής"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Εντάξει"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Τοποθεσίες αναζήτησης"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Φάκελοι που αναζητούνται από εφαρμογές συστήματος, όπως Αρχεία, Φωτογραφίες "
+"και Βίντεο."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Τοποθεσίες"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Σελιδοδείκτες"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Άλλοι"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Προσθήκη τοποθεσίας"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Δε βρέθηκαν εφαρμογές"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+#| msgid "Application"
+msgid "Application Search"
+msgstr "Εφαρμογή"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+#, fuzzy
+#| msgid ""
+#| "Folders which are searched by system applications, such as Files, Photos "
+#| "and Videos."
+msgid "Folders which are searched by system applications."
+msgstr ""
+"Φάκελοι που αναζητούνται από εφαρμογές συστήματος, όπως Αρχεία, Φωτογραφίες "
+"και Βίντεο."
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+#| msgid "No Search Results"
+msgid "Search Results"
+msgstr "Δε βρέθηκαν αποτελέσματα αναζήτησης"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Ελέγξτε ποιες εφαρμογές εμφανίζουν αποτελέσματα αναζήτησης στην επισκόπηση "
+"Δραστηριότητες"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Αναζήτηση;Εύρεση;Ευρετήριο;Απόκρυψη;Ιδιωτικότητα;Αποτελέσματα;Search;Find;"
+"Index;Hide;Privacy;Results;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Δεν έχουν επιλεγεί δίκτυα για κοινή χρήση"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Δίκτυα"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Ενεργό"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Ανενεργό"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Ενεργοποιημένη"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Ενεργή"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Επιλογή φακέλου"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Προσθήκη"
+
+#: panels/sharing/cc-sharing-panel.c:736
+#, fuzzy
+#| msgid "Media Sharing"
+msgid "Enable media sharing"
+msgstr "Κοινή χρήση πολυμέσων"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Η κοινή χρήση αρχείων επιτρέπει να μοιράζεστε τον δημόσιο φάκελό σας με "
+"άλλους, στο υπάρχον δίκτυό σας, χρησιμοποιώντας: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Όταν είναι ενεργοποιημένη η απομακρυσμένη σύνδεση, οι απομακρυσμένοι χρήστες "
+"μπορούν να συνδεθούν χρησιμοποιώντας εντολή ασφαλούς κελύφους (SSH):\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+#, fuzzy
+#| msgid "Personal File Sharing"
+msgid "Enable personal media sharing"
+msgstr "Κοινή χρήση προσωπικών αρχείων"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Αντιγράφηκε το όνομα συσκευής"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Αντιγράφηκε το όνομα χρήστη"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Αντιγράφηκε το συνθηματικό"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Κοινή χρήση"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Όνομα υπολο_γιστή"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Κοινή χρήση αρχείων"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+#| msgid "Remote View"
+msgid "Remote _Desktop"
+msgstr "Απομακρυσμένη προβολή"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Κοινή χρήση πο_λυμέσων"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Απομακρυσμένη σύνδεση"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Κοινή χρήση αρχείων"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Απαιτείται _κωδικός πρόσβασης"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Απομακρυσμένη σύνδεση"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+#| msgid "Remote View"
+msgid "Remote Desktop"
+msgstr "Απομακρυσμένη προβολή"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+#| msgid "Enable or disable remote login"
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Ενεργοποίηση η απενεργοποίηση της απομακρυσμένης σύνδεσης"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Απομακρυσμένος έλεγχος"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+#| msgid "_Allow connections to control the screen"
+msgid "Allows remote connections to control the screen."
+msgstr "Να επιτ_ρέπεται στις συνδέσεις ο έλεγχος της οθόνης"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+#| msgid "Not connected"
+msgid "How to Connect"
+msgstr "Δεν συνδέθηκε"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Αντιγραφή"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+#| msgid "Delete Address"
+msgid "Remote Desktop Address"
+msgstr "Διαγραφή διεύθυνσης"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Αυθεντικοποίηση"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Όνομα χρήστη"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+#| msgid "Fingerprint"
+msgid "Encryption Fingerprint"
+msgstr "Δακτυλικό αποτύπωμα"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Κοινή χρήση πολυμέσων"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Κοινή χρήση μουσικής, φωτογραφιών και βίντεο μέσω δικτύου."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Φάκελοι"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Ελέγξτε τι θέλετε να μοιράζεστε με τους άλλους"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"κοινόχρηστος;κοινή χρήση;ssh;κεντρικός υπολογιστής;όνομα;απομακρυσμένο;"
+"επιφάνεια εργασίας;μέσα;ήχος;βίντεο;εικόνες;φωτογραφίες;ταινίες;διακομιστής;"
+"απεικονιστής;share;sharing;ssh;host;name;remote;desktop;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Ενεργοποίηση η απενεργοποίηση της απομακρυσμένης σύνδεσης"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Απαιτείται πιστοποίηση για την ενεργοποίηση ή απενεργοποίηση της "
+"απομακρυσμένης σύνδεσης"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Προσαρμοσμένη"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Κλικ"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Συμβολοσειρά"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Ισοστάθμιση"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Βαθμιαία μείωση έντασης"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Πίσω"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Μπροστά"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Δοκιμή του %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Κάντε κλικ στο ηχείο για δοκιμή"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Ένταση συστήματος"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+#| msgid "System Volume"
+msgid "Master volume"
+msgstr "Ένταση συστήματος"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Επίπεδα έντασης"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Έξοδος"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Συσκευή εξόδου"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Δοκιμή"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Ρυθμίσεις"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Είσοδος"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Συσκευή εισόδου"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Ένταση"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Ήχος ειδοποίησης"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Σίγαση"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Ήχος"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Αλλάξτε την ένταση ήχου, τις εισόδους, εξόδους και τις ηχητικές ειδοποιήσεις"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Κάρτα;Μικρόφωνο;Ένταση;Απόσβεση;Ισορροπία;Bluetooth;Ακουστικά;Ήχος;Έξοδος;"
+"Είσοδος;Card;Microphone;Volume;Fade;Balance;Headset;Audio;Output;Input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Aποσυνδεδεμένη"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Γίνεται σύνδεση"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Συνδεδεμένη"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Σφάλμα πιστοποίησης"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Γίνεται εξουσιοδότηση"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Μειωμένη λειτουργικότητα"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Συνδεδεμένη & πιστοποιημένη"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Άγνωστο"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Πιστοποιήθηκε την:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Συνδέθηκε:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Εγγραφή σε:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Αποτυχία πιστοποίησης συσκευής: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Αποτυχία παράλειψης συσκευής: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Εξαρτάται από %u άλλη συσκευή"
+msgstr[1] "Εξαρτάται από %u άλλες συσκευές"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+#| msgid "Notifications"
+msgid "Close notification"
+msgstr "Ειδοποιήσεις"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Όνομα:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Κατάσταση:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Πιστοποίηση και σύνδεση"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Παράλειψη συσκευής"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Σφάλμα"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Πιστοποιήθηκε"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Το υποσύστημα του Thunderbolt (boltd) δεν έχει εγκατασταθεί ή δεν έχει "
+"ρυθμιστεί σωστά."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Να επιτρέπεται η άμεση πρόσβαση σε συσκευές όπως τα docks και οι εξωτερικές "
+"μονάδες GPU."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Μόνο συσκευές USB και θύρες οθόνης μπορούν να συνδεθούν."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Δεν ήταν δυνατή η ανίχνευση του Thunderbolt.\n"
+"Είτε το σύστημα δεν διαθέτει υποστήριξη Thunderbolt, έχει απενεργοποιηθεί "
+"στο BIOS ή έχει οριστεί σε επίπεδο ασφαλείας μη υποστήριξης στο BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Η υποστήριξη Thunderbolt έχει απενεργοποιηθεί στο BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Δεν ήταν δυνατό να καθοριστεί το επίπεδο ασφάλειας του Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Σφάλμα εναλλαγής άμεσης λειτουργίας: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+#, fuzzy
+#| msgid "No Thunderbolt support"
+msgid "No Thunderbolt Support"
+msgstr "Καμία υποστήριξη για Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+#| msgid "Couldn’t connect to the %s domain: %s"
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Αδυναμία σύνδεσης στον τομέα %s: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Άμεση πρόσβαση"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Εκκρεμείς συσκευές"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Καμία συνδεδεμένη συσκευή"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Διαχείριση συσκευών Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;ιδιωτικότητα;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Ο δρομέας αναβοσβήνει"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Ο δρομέας αναβοσβήνει σε πεδία κειμένου."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Ταχύτητα"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Ταχύτητα αναβόσβησης του δρομέα"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Μέγεθος δρομέα"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Το μέγεθος του δρομέα μπορεί να συνδυαστεί με την εστίαση για να "
+"διευκολυνθεί ο εντοπισμός του δρομέα."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Βοήθεια κλικ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Προσομοιωμένο δευτερεύον κλικ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Ενεργοποίηση ενός δευτερεύοντος κλικ πατώντας το πρωτεύον κουμπί"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Κα_θυστέρηση αποδοχής:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Σύντομη"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Καθυστέρηση δευτερεύοντος κλικ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Μεγάλη"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Πάτημα με α_ιώρηση"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Ενεργοποίηση ενός κλικ όταν αιωρείται ο δρομέας"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Καθυ_στέρηση:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Σύντομη"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Μεγάλη"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Κατώφλι κίνησης:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Μικρό"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Μεγάλο"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Πλήκτρα επανάληψης"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Επανάληψη πατήματος κατά το κράτημα ενός πλήκτρου."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Καθυστέρηση πλήκτρων επανάληψης"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Ταχύτητα πλήκτρων επανάληψης"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Βοήθεια πληκτρολόγησης"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Κο_λλώδη πλήκτρα"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Αντιμετωπίζει μια ακολουθία ειδικών πλήκτρων ως συνδυασμό"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Α_πενεργοποίηση αν δύο πλήκτρα πατηθούν ταυτόχρονα"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Ήχος κατά το πάτημα πλήκτρου _τροποποίησης"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Αρ_γά πλήκτρα"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Εισάγει καθυστέρηση μεταξύ της πίεσης ενός πλήκτρου και της αποδοχής του"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Σύντομη"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Επιβράδυνση πληκτρολόγησης με τα αργά πλήκτρα"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Μεγάλη"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Ήχος κατά το πά_τημα πλήκτρου"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Ήχος κατά την απο_δοχή πλήκτρου"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Ήχος κατά την απόρρι_ψη πλήκτρου"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Πλήκτρα α_ναπήδησης"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Να αγνοούνται τα γρήγορα διπλά πατήματα πλήκτρων"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Σύντομη"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Επιβράδυνση πληκτρολόγησης με πλήκτρα αναπήδησης"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Μεγάλη"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Ενεργοποίηση με το πληκτρολόγιο"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Ενεργοποίηση ή απενεργοποίηση των λειτουργιών προσιτότητας από το "
+"πληκτρολόγιο"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Προεπιλεγμένο"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Μεσαίο"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Μεγάλο"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Μεγαλύτερο"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Μέγιστο"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d εικονοστοιχείο"
+msgstr[1] "%d εικονοστοιχεία"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Να εμφανίζεται πά_ντα το μενού προσβασιμότητας"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Όραση"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Υψηλή αντίθεση"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Με_γάλο κείμενο"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Ανα_γνώστης οθόνης"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Ο αναγνώστης οθόνης διαβάζει το εμφανιζόμενο κείμενο καθώς μετακινείτε την "
+"εστίαση."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Πλήκτρα ή_χου"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Ήχος κατά την ενεργοποίηση/απενεργοποίηση του Num Lock ή Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Μέγεθος δ_ρομέα"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "Ε_στίαση"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Ακοή"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Ο_πτικές ειδοποιήσεις"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Π_ληκτρολόγιο οθόνης"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Πλήκτρα _επανάληψης"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Ο δρομέας ανα_βοσβήνει"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Βοήθεια πληκ_τρολόγησης (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+#| msgid "Pointing & Clicking"
+msgid "Pointing &amp; Clicking"
+msgstr "Κατάδειξη και πάτημα"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Πλήκτρα _ποντικιού"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Εντοπισμός δείκτη"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Βοήθεια _κλικ"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Καθυστέρηση διπλού κλικ"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Καθυστέρηση διπλού κλικ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Οπτικές ειδοποιήσεις"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Δο_κιμή αναβοσβήματος"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Χρήση οπτικής ένδειξης όταν ακούγεται ήχος προειδοποίησης."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Αναβόσβημα ολόκληρης της _οθόνης"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Αναβόσβημα ολόκληρου της _παραθύρου"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Σύντομο"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ της οθόνης"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ της οθόνης"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ της οθόνης"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Μακρύ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Πλήρης οθόνη"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Πάνω μισό"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Κάτω μισό"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Αριστερό μισό"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Δεξιό μισό"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Επιλογές εστίασης"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Μεγέθυνση:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Θέση μεγεθυντή:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Ακολούθησε το δρομέα του ποντικιού"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Μέ_ρος της οθόνης:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Ο μεγεθυντής _επεκτείνεται έξω από την οθόνη"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Κράτησε επικεντρωμένο το δρομέα του μεγεθυντή"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Ο δρομέας του μεγεθυντή _ωθεί τα περιεχόμενα"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Ο δρομέας του μεγεθυντή κινείται μαζί με τα π_εριεχόμενα"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Μεγεθυντής"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Στόχοι:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Επι_κάλυψη δρομέα του ποντικιού"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "Πά_χος:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Λεπτό"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Παχύ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Διάρκεια:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Χ_ρώμα:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Στόχος"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Εφέ χρώματος:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Μαύρο σε λευκό:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Φωτεινότητα:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Αντίθεση:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Χ_ρώμα"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Κανένα"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Πλήρες"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Χαμηλή"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Υψηλή"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Χαμηλή"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Υψηλή"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Εφέ χρώματος"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"Κάντε πιο εύκολη την προβολή, την ακρόαση, την πληκτρολόγηση, την κατάδειξη "
+"και το κλικ"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;"
+#| "Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;"
+#| "Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;"
+#| "typing;"
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Πληκτρολόγιο;Ποντίκι;a11y;Προσιτότητα;Αντίθεση;Ήχος;Εστίαση;Οθόνη;Αναγνώστης;"
+"μεγάλο;ψηλό;μεγάλο;κείμενο;γραμματοσειρά;μέγεθος;AccessX;Κολλημένο;Πλήκτρα;"
+"Αργά;Αναπήδηση;Ποντίκι;Διπλό;κλικ;Καθυστέρηση;Ταχύτητα;Βοήθεια;Επανάληψη;"
+"Αναβοσμήσιμο;οπτικός;ακρόαση;ήχος;πληκτρολόγηση;Keyboard;Mouse;a11y;"
+"Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;big;high;large;text;"
+"font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Speed;"
+"Assist;Repeat;Blink;visual;hearing;audio;typing;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 ώρα"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 ημέρα"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 ημέρες"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 ημέρες"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 ημέρες"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 ημέρες"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 ημέρες"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 ημέρες"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 ημέρες"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 ημέρες"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Διαγραφή όλων των αντικειμένων από τα απορρίμματα;"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Όλα τα αντικείμενα στα απορρίμματα θα διαγραφούν οριστικά."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Ά_δειασμα απορριμμάτων"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Διαγραφή όλων των προσωρινών αρχείων;"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Όλα τα προσωρινά αρχεία θα διαγραφούν μόνιμα."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Εκκαθάριση προσωρινών αρχείων"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 ημέρα"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 ημέρες"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 ημέρες"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Για πάντα"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Ιστορικό αρχείου"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Το ιστορικό αρχείων διατηρεί ιστορικό των αρχείων που έχετε χρησιμοποιήσει. "
+"Αυτές οι πληροφορίες κοινοποιούνται μεταξύ εφαρμογών και διευκολύνει την "
+"εύρεση αρχείων που ίσως θέλετε να χρησιμοποιήσετε."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Ιστορικό _αρχείου"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Διάρκεια _ιστορικού αρχείων"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Εκκα_θάριση ιστορικού…"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+#| msgid "Trash & Temporary Files"
+msgid "Trash &amp; Temporary Files"
+msgstr "Κάδος απορριμμάτων & Προσωρινά αρχεία"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Ο κάδος απορριμμάτων και τα προσωρινά αρχεία μπορεί μερικές φορές να "
+"περιλαμβάνουν προσωπικές ή ευαίσθητες πληροφορίες. Η αυτόματη διαγραφή τους "
+"μπορεί να συμβάλει στην προστασία του απορρήτου."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Αυτόματη διαγραφή περιεχομένου _απορριμμάτων"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Αυτόματη διαγραφή προσωρινών α_ρχείων"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Αυτόματη διαγραφή _περιόδου"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Άδειασμα α_πορριμμάτων…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Διαγραφή προσωρινών αρχείων…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Ιστορικό αρχείου & Κάδος απορριμάτων"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Να μην αφήνονται ίχνη"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Πρέπει να ταιριάζει η διεύθυνση ιστού του παρόχου της εισόδου σας."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Αποτυχία προσθήκης λογαριασμού"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Δεν ταιριάζουν οι κωδικοί πρόσβασης."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Αποτυχία εγγραφής του λογαριασμού"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Κανένας υποστηριζόμενος τρόπος πιστοποίησης με αυτόν τον τομέα"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Αποτυχία ένταξης στο τομέα"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Αυτό το όνομα εισόδου δεν δούλεψε.\n"
+"Παρακαλούμε, προσπαθήστε ξανά."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Αυτός ο κωδικός πρόσβασης εισόδου δεν δούλεψε.\n"
+"Παρακαλούμε, προσπαθήστε ξανά."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Αποτυχία σύνδεσης στο τομέα"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Αδύνατη η εύρεση του τομέα. Μήπως τον γράψατε λάθος;"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Προσθήκη χρήστη"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Διαχειριστής"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+#, fuzzy
+#| msgid ""
+#| "Administrators can add and remove other users, and can change settings "
+#| "for all users."
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Οι διαχειριστές μπορούν να προσθέσουν και να καταργήσουν άλλους χρήστες και "
+"να αλλάξουν τις ρυθμίσεις για όλους τους χρήστες."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+#| msgid "Allow user to change their password on next login"
+msgid "User sets password on first login"
+msgstr ""
+"Να επιτρέπεται στον χρήστη να αλλάξει τον κωδικό πρόσβασης στην επόμενη "
+"σύνδεση"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Ορισμός συνθηματικού τώρα"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Επιβεβαίωση"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+#| msgid "_Enterprise Login"
+msgid "Enterprise Login"
+msgstr "_Εταιρική σύνδεση"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Αποσυνδεδεμένο"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Η εταιρική σύνδεση επιτρέπει σε έναν υπάρχοντα κεντρικά διαχειριζόμενο "
+"λογαριασμό χρήστη να χρησιμοποιηθεί σε αυτή τη συσκευή. Μπορείτε επίσης να "
+"χρησιμοποιήσετε τον λογαριασμό γι να έχετε πρόσβαση σε πόρους της εταιρείας "
+"στο διαδίκτυο."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Περιηγηθείτε για περισσότερες φωτογραφίες"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Επιλογή αρχείου…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Διαχειριστής δακτυλικού αποτυπώματος"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Δακτυλικό αποτύπωμα"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "Ό_χι"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Ναι"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Επιθυμείτε να διαγράψετε τα καταχωρημένα αποτυπώματα για να απενεργοποιηθεί "
+"η είσοδος με αποτύπωμα;"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Καμία συσκευή δακτυλικού αποτυπώματος"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Καμία συσκευή δακτυλικού αποτυπώματος"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Βεβαιωθείτε ότι η συσκευή είναι σωστά συνδεδεμένη."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Συσκευή δακτυλικού αποτυπώματος"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Επιλέξτε τη συσκευή δακτυλικών αποτυπωμάτων που θέλετε να ρυθμίσετε"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Είσοδος με δακτυλικό αποτύπωμα"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Η είσοδος με χρήση δακτυλικών αποτυπωμάτων σάς επιτρέπει να ξεκλειδώνετε και "
+"να συνδέεστε στον υπολογιστή σας με το δάχτυλό σας"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Διαγραφή αποτυπωμάτων"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Εγγραφή δακτυλικού αποτυπώματος"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+#, fuzzy
+#| msgid "The device is already in use."
+msgid "the device is already claimed by another process"
+msgstr "Η συσκευή χρησιμοποιείται ήδη."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+#, fuzzy
+#| msgid "Failed to register with the requested network"
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Αποτυχία εγγραφής στο ζητούμενο δίκτυο"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+#, fuzzy
+#| msgid "Failed to add new printer."
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+#, fuzzy
+#| msgid "Failed to add new printer."
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, fuzzy, c-format
+#| msgid "Failed to apply configuration: %s"
+msgid "Failed to list fingerprints: %s"
+msgstr "Αποτυχία εφαρμογής των ρυθμίσεων: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Αποτυχία διαγραφής αποθηκευμένων δακτυλικών αποτυπωμάτων: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Αριστερός αντίχειρας"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Αριστερό μεσαίο δάκτυλο"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "Α_ριστερός δείκτης"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Αριστερός δείκτης"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Αριστερό μικρό δάκτυλο"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Δεξιός αντίχειρας"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Δεξιό μεσαίο δάκτυλο"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "Δεξιός _δείκτης"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Δεξιός δείκτης"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Δεξιό μικρό δάκτυλο"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Άγνωστος αποτύπωμα"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Ολοκληρώθηκε"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Αποσυνδέθηκε η συσκευή δακτυλικού αποτυπώματος"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Ο χώρος αποθήκευσης δακτυλικών αποτυπωμάτων είναι πλήρης"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+#, fuzzy
+#| msgid "Failed to add new printer."
+msgid "Failed to enroll new fingerprint"
+msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, fuzzy, c-format
+#| msgid "Failed to upload file: %s"
+msgid "Failed to start enrollment: %s"
+msgstr "Αποτυχία αποστολής αρχείου: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+#, fuzzy
+#| msgid "Failed to add new printer."
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Αποτυχία προσθήκης νέου εκτυπωτή."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, fuzzy, c-format
+#| msgid "Failed to upload file: %s"
+msgid "Failed to stop enrollment: %s"
+msgstr "Αποτυχία αποστολής αρχείου: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Ανασηκώστε επανειλημμένα και τοποθετήστε το δάχτυλό σας στον αναγνώστη για "
+"να εγγράψετε το δακτυλικό σας αποτύπωμα"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr ""
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Σάρωση νέου δακτυλικού αποτυπώματος"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, fuzzy, c-format
+#| msgid "Failed to forget device: "
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Αποτυχία παράλειψης συσκευής: "
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+#, fuzzy
+#| msgid "Pending Devices"
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Εκκρεμείς συσκευές"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, fuzzy, c-format
+#| msgid "Failed to forget device: "
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Αποτυχία παράλειψης συσκευής: "
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, fuzzy, c-format
+#| msgid "Failed to forget device: "
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Αποτυχία παράλειψης συσκευής: "
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Αυτήν την εβδομάδα"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Την τελευταία εβδομάδα"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Η συνεδρία τελείωσε"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Η συνεδρία άρχισε"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Δραστηριότητα λογαριασμού"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Προηγούμενο"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Επόμενο"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Παρακαλούμε επιλέξτε άλλον κωδικό πρόσβασης."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Παρακαλούμε πληκτρολογήστε ξανά τον τρέχων κωδικό πρόσβασής σας."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Ο κωδικός πρόσβασής σας δεν μπορούσε να αλλαχθεί"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Αλλαγή κωδικού πρόσβασης"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Α_λλαγή"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Τρέχων συνθηματικό"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Νέο συνθηματικό"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Επιβεβαίωση συνθηματικού"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Να επιτρέπεται στον χρήστη να αλλάξει τον κωδικό πρόσβασης στην επόμενη "
+"σύνδεση"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Καθορισμός κωδικού πρόσβασης"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Αδυναμία αυτόματης ένωσης αυτού του τύπου τομέα"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Δεν βρέθηκε τέτοιος τομέας ή realm"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Αδυναμία σύνδεσης ως %s στον τομέα %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Λάθος κωδικός πρόσβασης, παρακαλούμε προσπαθήστε ξανά"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Αδυναμία σύνδεσης στον τομέα %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Αποτυχία διαγραφής χρήστη"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Αποτυχία ανάκλησης απομακρυσμένης διαχείρισης χρήστη"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Δεν μπορείτε να διαγράψετε τον δικό σας λογαριασμό."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s είναι ακόμη συνδεδεμένος"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Η διαγραφή ενός χρήστη ενώ είναι συνδεδεμένος μπορεί να αφήσει το σύστημα σε "
+"ασταθή κατάσταση."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Θέλετε να κρατήσετε τα αρχεία του %s;"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Είναι δυνατόν να διατηρηθεί ο προσωπικός κατάλογος, το αρχείο αλληλογραφίας "
+"και τα προσωρινά αρχεία μετά τη διαγραφή ενός λογαριασμού χρήστη."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Διαγραφή αρχείων"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "Δια_τήρηση αρχείων"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Είστε σίγουροι ότι θέλετε να ανακαλέσετε τον λογαριασμό της απομακρυσμένης "
+"διαχείρισης του %s;"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Διαγραφή"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Απενεργοποιημένος λογαριασμός"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Θα ορισθεί στην επόμενη σύνδεση"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Κανένας"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Συνδεμένος"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Αποτυχία επικοινωνίας με την υπηρεσία λογαριασμών"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Παρακαλούμε βεβαιωθείτε ότι το AccountService έχει εγκατασταθεί και είναι "
+"ενεργοποιημένο."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Διαγραφή του επιλεγμένου λογαριασμού χρήστη"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Για να διαγράψετε τον επιλεγμένο λογαριασμό χρήστη,\n"
+"κάντε πρώτα κλικ στο εικονίδιο *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+#, fuzzy
+#| msgid "Unlock to Change Settings"
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Ξεκλειδώστε για να αλλάξετε ρυθμίσεις"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Χρήστες"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Η συνεδρία σας πρέπει να επανεκκινηθεί για να εφαρμοστούν οι αλλαγές"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Επανεκκίνηση τώρα"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Κλείσιμο"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Πλήρες Όνομα"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Eπεξεργασία"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Είσοδος με _δακτυλικό αποτύπωμα"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Α_υτόματη σύνδεση"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Δραστηριότητα λογαριασμού"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Διαχειριστής"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Οι διαχειριστές μπορούν να προσθέσουν και να καταργήσουν άλλους χρήστες και "
+"να αλλάξουν τις ρυθμίσεις για όλους τους χρήστες."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Γονικός έλεγχος"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Αφαίρεση χρήστη…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Άλλοι χρήστες"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Προσθήκη χρήστη…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Δε βρέθηκαν χρήστες"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Ξεκλείδωμα για προσθήκη λογαριασμού χρήστη."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Προσθέστε ή διαγράψτε χρήστες και αλλάξτε τον κωδικό πρόσβασης σας"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Εγγραφή"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Σύνδεση διαχειριστή τομέα"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Για να χρησιμοποιήσετε τις εταιρικές συνδέσεις, αυτός ο υπολογιστής πρέπει "
+"να είναι\n"
+"εγγεγραμμένος στον τομέα. Παρακαλούμε, πείτε τον διαχειριστή του δικτύου "
+"σας\n"
+"να πληκτρολογήσει εδώ τον κωδικό πρόσβασης του τομέα."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Ό_νομα διαχειριστή"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Κωδικός πρόσβασης διαχειριστή"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Διαχείριση λογαριασμών των χρηστών"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Απαιτείται πιστοποίηση για την αλλαγή δεδομένων του χρήστη"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Ο νέος κωδικός πρόσβασης πρέπει να είναι διαφορετικός από τον παλιό."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Προσπαθήστε να αλλάξετε μερικά γράμματα και αριθμούς."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Δοκιμάστε να αλλάξετε τον κωδικό πρόσβασης λίγο περισσότερο."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr ""
+"Ένας κωδικός πρόσβασης χωρίς το όνομα χρήστη πιθανόν να είναι πιο ισχυρός."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr ""
+"Προσπαθήστε να αποφύγετε τη χρήση του ονόματός σας στον κωδικό πρόσβασης."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr ""
+"Προσπαθήστε να αποφύγετε μερικές από τις λέξεις που συμπεριλαμβάνονται στον "
+"κωδικό πρόσβασης."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Προσπαθήστε να αποφύγετε συνηθισμένες λέξεις."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Προσπαθήστε να αποφύγετε αναδιάταξη υπαρχουσών λέξεων."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Προσπαθήστε να χρησιμοποιήσετε περισσότερους αριθμούς."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Προσπαθήστε να χρησιμοποιήσετε περισσότερα κεφαλαία γράμματα."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Προσπαθήστε να χρησιμοποιήσετε περισσότερα πεζά γράμματα."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+"Προσπαθήστε να χρησιμοποιήσετε περισσότερους ειδικούς χαρακτήρες, όπως "
+"σημεία στίξης."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+"Προσπαθήστε να χρησιμοποιήσετε έναν συνδυασμό γραμμάτων, αριθμών και σημείων "
+"στίξης."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Προσπαθήστε να αποφύγετε την επανάληψη του ίδιου χαρακτήρα."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Προσπαθήστε να αποφύγετε την επανάληψη του ίδιου τύπου χαρακτήρα: χρειάζεστε "
+"την ανάμειξη γραμμάτων, αριθμών και σημείων στίξης."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Προσπαθήστε να αποφύγετε ακολουθίες όπως 1234 ή abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Τα συνθηματικά πρέπει να είναι μεγαλύτερα. Προσπαθήστε να προσθέσετε "
+"περισσότερα γράμματα, αριθμούς και σημεία στίξης."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Αναμείξτε κεφαλαία και πεζά γράμματα και χρησιμοποιήστε έναν ή περισσότερους "
+"αριθμούς."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Η προσθήκη περισσότερων γραμμάτων, αριθμών και σημείων στίξης θα κάνει "
+"ισχυρότερο το συνθηματικό."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Αποτυχία πιστοποίησης"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Ο κωδικός πρόσβασης είναι πολύ σύντομος"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Ο κωδικός πρόσβασης είναι πολύ απλός"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Ο παλιός και ο νέος κωδικός πρόσβασης μοιάζουν πολύ"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Ο νέος κωδικός πρόσβασης έχει χρησιμοποιηθεί πρόσφατα."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+"Ο νέος κωδικός πρόσβασης θα πρέπει να περιέχει αριθμητικούς ή ειδικούς "
+"χαρακτήρες"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Ο παλιός και ο νέος κωδικός πρόσβασης είναι οι ίδιοι"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Ο κωδικός πρόσβασης σας έχει αλλάξει από την αρχική σας πιστοποίηση!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Ο νέος κωδικός πρόσβασης δεν περιέχει αρκετά διαφορετικούς χαρακτήρες"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Άγνωστο σφάλμα"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Το όνομα χρήστη συνήθως πρέπει να αποτελείται μόνο από πεζά γράμματα από a-"
+"z, αριθμούς και από τους ακόλουθους χαρακτήρες: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Συγγνώμη, δεν είναι διαθέσιμο το όνομα χρήστη. Παρακαλούμε δοκιμάστε κάποιο "
+"αλλο."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Το όνομα χρήστη είναι πολύ μεγάλο."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Χαρτογράφηση κουμπιών"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Χαρτογράφηση κουμπιών σε συναρτήσεις"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Για να επεξεργαστείτε μια συντόμευση, επιλέξτε την ενέργεια «Αποστολή "
+"πατήματος πλήκτρου», πατήστε στο κουμπί συντόμευσης πληκτρολογίου και "
+"κρατήστε πατημένα τα νέα πλήκτρα ή πατήστε οπισθοδιαγραφή για εκκαθάριση."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Κλείσιμο"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Παρακαλώ πατήστε τους δείκτες όπως αυτοί εμφανίζονται στην οθόνη για να "
+"βαθμονομήσετε το tablet σας."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Ανιχνεύθηκε mis-click, γίνεται επανεκκίνηση…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Κουμπί %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Καθορίστηκε εφαρμογή"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Αποστολή πατήματος πλήκτρου"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Αλλαγή οθόνης"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Εμφάνιση βοήθειας στην οθόνη"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:435
+#, fuzzy
+#| msgid "Use bluetooth devices"
+msgid "External tablet device"
+msgstr "Χρήση συσκευών Bluetooth"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Όλες οι οθόνες"
+
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+#| msgid "Tablet"
+msgid "Tablet Mode"
+msgstr "Tablet"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+#| msgid "Left-Handed Orientation"
+msgid "Left Hand Orientation"
+msgstr "Προσανατολισμός για αριστερόχειρες"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+#| msgid "Map to Monitor…"
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Χαρτογράφηση στην οθόνη…"
+
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+#| msgid "Aspect Ratio"
+msgid "Keep Aspect Ratio"
+msgstr "Λόγος θέασης"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Βαθμονόμηση"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Δεν εντοπίσθηκε tablet"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+#| msgid "Please plug in or turn on your Wacom tablet"
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Παρακαλούμε ενεργοποιήστε ή συνδέστε το Wacom tablet"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Αίσθηση πίεσης μύτης"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Απαλή"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Σφιχτή"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Κουμπί 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Κουμπί 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Κουμπί 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Αίσθηση πίεσης σβήστρας"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+#| msgid "Eraser Pressure Feel"
+msgid "Eraser pressure"
+msgstr "Αίσθηση πίεσης σβήστρας"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Μεσαίο κλικ κουμπιού του ποντικιού"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Δεξί κλικ κουμπιού του ποντικιού"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Μπροστά"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Ορίστε τα κουμπιά και ρυθμίστε την ευαισθησία της γραφίδας για ταμπλέτες "
+"γραφικών"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Ταμπλέτα;Wacom;Γραφίδα;Stylus;Σβήστρα;Eraser;Ποντίκι;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Νέα συντόμευση…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Σημεία πρόσβασης"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Εγγεγραμμένος"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Περιαγωγή"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Αναζήτηση"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Απαγορεύεται"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+#| msgid "Details"
+msgid "Modem Details"
+msgstr "Λεπτομέρειες"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+#| msgid "Status:"
+msgid "Modem Status"
+msgstr "Κατάσταση:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Πάροχος"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+#| msgid "_Network Time"
+msgid "Network Type"
+msgstr "Ώρα _δικτύου"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Κατάσταση δικτύου"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+#| msgid "Numbers"
+msgid "Own Number"
+msgstr "Αριθμοί"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Λεπτομέρειες συσκευής"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Έκδοση υλικολογισμικού"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Μόνο 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Μόνο 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Μόνο 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Μόνο 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "'Αγνωστη"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Ξεκλείδωμα κάρτας SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Ξεκλείδωμα"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Εισήχθη εσφαλμένο συνθηματικό."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Εισάγετε νέο PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Γίνεται ξεκλείδωμα…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Χωρίς SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "Κλειδωμένη SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+#| msgid "_Mobile Broadband"
+msgid "_Mobile Data"
+msgstr "Ευρυζωνικό _κινητό"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "Περιαγωγή _δεδομένων"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+#| msgid "_Network Time"
+msgid "_Network Mode"
+msgstr "Ώρα _δικτύου"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+#| msgid "Network"
+msgid "N_etwork"
+msgstr "Δίκτυο"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Για προχωρημένους"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+#| msgid "Access Options"
+msgid "_Access Point Names"
+msgstr "Επιλογές πρόσβασης"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+#| msgid "Screen Lock"
+msgid "_SIM Lock"
+msgstr "Κλείδωμα οθόνης"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+#| msgid "%s Details"
+msgid "M_odem Details"
+msgstr "Λεπτομέρειες %s"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+#, fuzzy
+#| msgid "PIN check failed"
+msgid "Phone failure"
+msgstr "Απέτυχε ο έλεγχος του PIN"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+#, fuzzy
+#| msgid "Not connected"
+msgid "No connection to phone"
+msgstr "Δεν συνδέθηκε"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+#, fuzzy
+#| msgid "SIM Card not inserted"
+msgid "SIM not inserted"
+msgstr "Δεν έχει τοποθετηθεί η κάρτα SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PIN required"
+msgstr "Απαιτείται το Pin της SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PUK required"
+msgstr "Απαιτείται το Pin της SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Αποτυχία SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Η SIM είναι απασχολημένη"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Εσφαλμένο συνθηματικό"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PIN2 required"
+msgstr "Απαιτείται το Pin της SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PUK2 required"
+msgstr "Απαιτείται το Pin της SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Δε βρέθηκε"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Δεν υπάρχει υπηρεσία δικτύου"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+#, fuzzy
+#| msgid "_Network Time"
+msgid "Network timeout"
+msgstr "Ώρα _δικτύου"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+#, fuzzy
+#| msgid "AutoIP service failed"
+msgid "GPRS services not allowed"
+msgstr "Αποτυχία υπηρεσίας AutoIP"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Χωρίς σφάλμα"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Η ενέργεια ακυρώθηκε"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Δεν επιτρέπεται η πρόσβαση"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Άγνωστο σφάλμα"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+#| msgid "Network Name"
+msgid "Network Mode"
+msgstr "Όνομα δικτύου"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Αυτόματα"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+#| msgid "My Home Network"
+msgid "Choose Network"
+msgstr "Το οικιακό μου δίκτυο"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+#| msgid "My Home Network"
+msgid "Enable Mobile Network"
+msgstr "Το οικιακό μου δίκτυο"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+#| msgid "No Wi-Fi Adapter Found"
+msgid "No WWAN Adapter Found"
+msgstr "Δε βρέθηκε προσαρμογέας Wi-Fi"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+#| msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+"Σιγουρευτείτε ότι έχετε συνδέσει και ενεργοποιήσει ένα προσαρμογέα Wi-Fi"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+#| msgid "Bluetooth is disabled when airplane mode is on."
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+"Το Bluetooth είναι απενεργοποιημένο όταν η λειτουργία αεροπλάνου είναι "
+"ενεργή."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+#| msgid "Turn Off Airplane Mode"
+msgid "_Turn off Airplane Mode"
+msgstr "Απενεργοποίηση της λειτουργίας αεροπλάνου"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Σύνδεση δεδομένων"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+#| msgid "SIM Card not inserted"
+msgid "SIM card used for internet"
+msgstr "Δεν έχει τοποθετηθεί η κάρτα SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+#| msgid "Screen Lock"
+msgid "SIM Lock"
+msgstr "Κλείδωμα οθόνης"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "Επόμε_νο"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Αλλαγή PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Κινητό δίκτυο"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Configure Removable Media settings"
+msgid "Configure Telephony and mobile data connections"
+msgstr "Ρύθμιση επιλογών αφαιρούμενων μέσων"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Εργαλείο για τη ρύθμιση του GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+"Οι ρυθμίσεις είναι η κύρια διεπαφή για τη διαμόρφωση του συστήματός σας."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Το έργο GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Εμφάνιση αριθμού έκδοσης"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Ενεργοποίηση λειτουργίας εμφάνισης λεπτομερειών"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Αναζήτηση συμβολοσειράς"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Λίστα με τα πιθανά ονόματα πίνακα και έξοδος"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Πίνακας για εμφάνιση"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[ΠΙΝΑΚΑΣ] [ΟΡΙΣΜΑ…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Κατηγορίες ρυθμίσεων"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Ιδιωτικότητα"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Διαθέσιμοι πίνακες:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Ρυθμίσεις"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Πρωτεύον μενού"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Προειδοποίηση: Έκδοση υπό ανάπτυξη"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Αυτή η έκδοση των Ρυθμίσεων πρέπει να χρησιμοποιείται μόνο για σκοπούς "
+"ανάπτυξης. Ενδέχεται να αντιμετωπίσετε εσφαλμένη συμπεριφορά συστήματος, "
+"απώλεια δεδομένων και άλλα μη αναμενόμενα ζητήματα. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Βοήθεια"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Γενικά"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Έξοδος"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Αναζήτηση"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Πίνακες"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Επιστροφή στον προηγούμενο πίνακα"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Ακύρωση αναζήτησης"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Προτιμήσεις;Ρυθμίσεις;Preferences;Settings;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Θα ανοίξει το αναγνωριστικό για τον τελευταίο πίνακα Ρυθμίσεων"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Θα ανοίξει το αναγνωριστικό για τον τελευταίο πίνακα Ρυθμίσεων. Οι μη "
+"αναγνωρισμένες τιμές θα αγνοηθούν και θα επιλεγεί το πρώτο πλαίσιο στη λίστα."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Προβολή προειδοποίησης κατά την εκτέλεση των Ρυθμίσεων της έκδοσης ανάπτυξης"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Αν οι Ρυθμίσεις πρέπει να εμφανίζουν μια προειδοποίηση κατά την εκτέλεση "
+"μιας έκδοσης ανάπτυξης."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "Έξοδος %u"
+msgstr[1] "Έξοδοι %u"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "Είσοδος %u"
+msgstr[1] "Είσοδοι %u"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Ήχοι συστήματος"
+
+#~ msgid "Show _Notifications on Lock Screen"
+#~ msgstr "Εμφάνιση _ειδοποιήσεων στην οθόνη κλειδώματος"
+
+#~ msgid "Web Links"
+#~ msgstr "Σύνδεσμοι ιστού"
+
+#~ msgid "Git Links"
+#~ msgstr "Σύνδεσμοι Git"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "%s σύνδεσμοι"
+
+#~ msgid "Unset"
+#~ msgstr "Αναίρεση"
+
+#~ msgid "Links"
+#~ msgstr "Σύνδεσμοι"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Αρχεία υπερκειμένου"
+
+#~ msgid "Text Files"
+#~ msgstr "Αρχεία κειμένου"
+
+#~ msgid "Image Files"
+#~ msgstr "Αρχεία εικόνων"
+
+#~ msgid "Font Files"
+#~ msgstr "Αρχεία γραμματοσειρών"
+
+#~ msgid "Archive Files"
+#~ msgstr "Αρχειοθέτηση αρχείων"
+
+#~ msgid "Package Files"
+#~ msgstr "Πακετάρισμα αρχείων"
+
+#~ msgid "Audio Files"
+#~ msgstr "Αρχεία ήχου"
+
+#~ msgid "Video Files"
+#~ msgstr "Αρχεία βίντεο"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Δικαιώματα & πρόσβαση"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Τα δεδομένα και οι υπηρεσίες που έχει ζητήσει η συγκεκριμένη εφαρμογή για "
+#~ "πρόσβαση και τα δικαιώματα που απαιτεί."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Αδυναμία αλλαγής"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Οι ατομικές άδειες για εφαρμογές μπορούν να αναθεωρηθούν στις Ρυθμίσεις "
+#~ "<a href=\"privacy\">Απορρήτου</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Ενσωμάτωση"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Ορισμός παρασκήνιου επιφάνειας εργασίας"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Προεπιλεγμένοι χειριστές"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Τύποι αρχείων και συνδέσμων που ανοίγει αυτή η εφαρμογή."
+
+#~ msgid "Usage"
+#~ msgstr "Χρήση"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Πόσους πόρους χρησιμοποιεί αυτή η εφαρμογή."
+
+#~ msgid "Open in Software"
+#~ msgstr "Άνοιγμα στο Λογισμικό"
+
+#~ msgid "Activities"
+#~ msgstr "Δραστηριότητες"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Ταπετσαρία;Οθόνη;Επιφάνεια εργασίας;Wallpaper;Screen;Desktop;"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Επιτρέψτε στις παρακάτω εφαρμογές να χρησιμοποιούν την κάμερά σας"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "οθόνη;κλείδωμα;διάγνωση;κατάρρευση;ιδιωτικό;πρόσφατο;προσωρινό;προσωρινό;"
+#~ "ευρετήριο;όνομα;ταυτότητα;screen;lock;diagnostics;crash;private;recent;"
+#~ "temporary;tmp;index;name;network;identity;"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Αποτυχία αποστολής αρχείου: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Το προφίλ απεστάλη στο:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Γράψτε αυτή τη διεύθυνση."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Επανεκκίνηση αυτού του υπολογιστή και εκκίνηση του κανονικού λειτουργικού "
+#~ "σας συστήματος."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Πληκτρολογήστε τη διεύθυνση στον περιηγητή σας, για να κάνετε λήψη και "
+#~ "εγκατάσταση του προφίλ."
+
+#~ msgid "Upload profile"
+#~ msgstr "Αποστολή προφίλ"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Απαιτεί σύνδεση διαδικτύου"
+
+#~ msgid "_Copy"
+#~ msgstr "_Αντιγραφή"
+
+#~ msgid "Select _All"
+#~ msgstr "Επιλογή ό_λων"
+
+#~ msgid "Single Display"
+#~ msgstr "Μονή οθόνη"
+
+#~ msgid "Join Displays"
+#~ msgstr "Ένωση οθονών"
+
+#~ msgid "Display Mode"
+#~ msgstr "Λειτουργία οθόνης"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Σύρετε τις οθόνες ώστε να ταιριάζουν με τη φυσική ρύθμιση εμφάνισης. "
+#~ "Επιλέξτε μια οθόνη για να αλλάξετε τις ρυθμίσεις της."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Διάταξη οθόνης"
+
+#~ msgid "Active Display"
+#~ msgstr "Ενεργή οθόνη"
+
+#~ msgid "More Warm"
+#~ msgstr "Περισσότερο θερμό"
+
+#~ msgid "Less Warm"
+#~ msgstr "Λιγότερο θερμό"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Αποθήκευσης στιγμιότυπου στις $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Αποθήκευση στιγμιότυπου ενός παραθύρου στις $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Αποθήκευση στιγμιότυπου μιας περιοχής στις $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Αντιγραφή ενός στιγμιότυπου στο πρόχειρο"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Αντιγραφή του στιγμιότυπου ενός παραθύρου στο πρόχειρο"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Αντιγραφή του στιγμιότυπου μιας περιοχής στο πρόχειρο"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Καταγραφή ενός σύντομου στιγμιοτύπου οθόνης"
+
+#~ msgid "Left Alt"
+#~ msgstr "Αριστερό Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Δεξιό Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Αριστερό Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Δεξιό Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Δεξιό Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Εναλλακτικό πλήκτρο χαρακτήρων"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Τροποποιητές-μετάβαση μόνο στην επόμενη πηγή"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Κλειδί μενού"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr ""
+#~ "Κρατήστε πατημένο και πληκτρολογήστε για να εισαγάγετε διαφορετικούς "
+#~ "χαρακτήρες"
+
+#~ msgid "Set"
+#~ msgstr "Ορισμός"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Οι υπηρεσίες τοποθεσίας επιτρέπουν στις εφαρμογές να καθορίσουν τη "
+#~ "γεωγραφική σας θέση. Η ακρίβεια αυξάνεται ενεργοποιώντας το Wi-Fi και το "
+#~ "ευρυζωνικό κινητό."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Χρησιμοποιεί την υπηρεσία τοποθεσίας του Mozilla: <a href='https://"
+#~ "location.services.mozilla.com/privacy'>Πολιτική απορρήτου</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr ""
+#~ "Επιτρέψτε στις παρακάτω εφαρμογές να προσδιορίσουν την τοποθεσία σας."
+
+#~ msgid "Lock your screen"
+#~ msgstr "Κλείδωμα οθόνης"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr ""
+#~ "Επιτρέψτε στις παρακάτω εφαρμογές να χρησιμοποιούν το μικρόφωνό σας."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Διάρκεια διπλού κλικ"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Πιστοποιητικά DER ή PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Φορτίζεται"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Προσοχή"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Χαμηλό"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Καλό"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Πλήρης φόρτιση"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Κενό"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Φωτεινότητα _οθόνης"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Φωτεινότητα _πληκτρολογίου"
+
+#~ msgid "_Dim Screen When Inactive"
+#~ msgstr "Α_μυδρή οθόνη όταν είναι ανενεργή"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Κενή οθόνη"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr ""
+#~ "Μπορείτε να απενεργοποιήσετε το ασύρματο δίκτυο για εξοικονόμηση ισχύος."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Μπορείτε να απενεργοποιήσετε την ευρυζωνικότητα του κινητού (LTE, 4G, 3G, "
+#~ "κλπ.) για να εξοικονομήσετε ισχύ."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Μπορείτε να απενεργοποιήσετε το Bluetooth για εξοικονόμηση ισχύος."
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Κουμπί αναστολή & τερματισμός"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Πιστοποίηση"
+
+#~ msgid "Add…"
+#~ msgstr "Προσθήκη…"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Επιλέξτε τη μορφή για αριθμούς, ημερομηνίες και νομίσματα. Οι αλλαγές "
+#~ "ισχύουν για την επόμενη σύνδεση."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr ""
+#~ "Η συνεδρία σας πρέπει να επανεκκινηθεί για να εφαρμοστούν οι αλλαγές"
+
+#~ msgid "Restart…"
+#~ msgstr "Επανεκκίνηση…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Οι ρυθμίσεις σύνδεσης χρησιμοποιούνται από όλους τους χρήστες κατά τη "
+#~ "σύνδεση στο σύστημα"
+
+#~ msgid "Previous source"
+#~ msgstr "Προηγούμενη πηγή"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "Επόμενη πηγή"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+διάστημα"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Αριστερό+δεξιό Alt"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Ελέγξτε ποια αποτελέσματα αναζήτησης εμφανίζονται στην Επισκόπηση "
+#~ "δραστηριοτήτων. Η σειρά των αποτελεσμάτων αναζήτησης μπορεί επίσης να "
+#~ "αλλάξει μετακινώντας τις γραμμές στη λίστα."
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Η κοινή χρήση οθόνης επιτρέπει σε απομακρυσμένους χρήστες να προβάλουν ή "
+#~ "να ελέγχουν την οθόνη σας συνδεόμενοι με %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Κοινή χρήση οθό_νης"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "Μερικές υπηρεσίες είναι ανενεργές λόγω έλλειψης πρόσβασης στο δίκτυο."
+
+#~ msgid "_Password:"
+#~ msgstr "Κω_δικός πρόσβασης:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Ε_μφάνιση κωδικού πρόσβασης"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Οι _νέες συνδέσεις πρέπει να ζητούν πρόσβαση"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Απαιτείται κωδικός πρόσβασης"
+
+#~ msgid "Bark"
+#~ msgstr "Γάβγισμα"
+
+#~ msgid "Drip"
+#~ msgstr "Σταγόνα"
+
+#~ msgid "Glass"
+#~ msgstr "Γυαλί"
+
+#~ msgid "Sonar"
+#~ msgstr "Σόναρ"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Αναγνώστης οθόνης"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Αναγνώστης ο_θόνης"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Πλήκτρα ήχου"
+
+#~ msgid "Standard"
+#~ msgstr "Τυπικός"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Τύπος λογαριασμού"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Να επιτρέπεται στον χρήστη ο ορισμός κωδικού πρόσβασης στην επόμενη "
+#~ "σύν_δεση"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Καθο_ρισμός κωδικού πρόσβασης"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Πρέπει να είστε σε σύνδεση για να προσθέσετε εταιρικούς χρήστες."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Λήψη φωτογραφίας…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Για να κάνετε αλλαγές,\n"
+#~ "κάντε κλικ στο εικονίδιο * πρώτα"
+
+#~ msgid "Create a user account"
+#~ msgstr "Δημιουργία νέου λογαριασμού χρήστη"
+
+#~ msgid "User Icon"
+#~ msgstr "Εικονίδιο χρήστη"
+
+#~ msgid "Account Settings"
+#~ msgstr "Ρυθμίσεις λογαριασμού"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Πιστοποίηση & Είσοδος"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Σύνδεση;Όνομα;Δακτυλικό αποτύπωμα;Avatar;Λογότυπο;Πρόσωπο;Κωδικός "
+#~ "πρόσβασης;Login;Name;Fingerprint;Logo;Face;Password;"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Αυτό θα χρησιμοποιηθεί σαν όνομα για τον προσωπικό σας φάκελο και δεν "
+#~ "μπορεί να αλλαχθεί."
+
+#~ msgid "Output:"
+#~ msgstr "Έξοδος:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Διατήρηση λόγου θέασης (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Χαρτογράφηση σε μια οθόνη"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d από %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Χαρτογράφηση οθόνης"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (απόλυτη)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Επιφάνεια αφής (σχετικό)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Προτιμήσεις tablet"
+
+#~ msgid "_Help"
+#~ msgstr "_Βοήθεια"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Ρυθμίσεις Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Λειτουργία παρακολούθησης"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Χαρτογράφηση κουμπιών…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Προσαρμογή ρυθμίσεων ποντικιού"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Καθορισμός ανάλυσης οθόνης"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Παρακαλούμε μετακινήστε τη γραφίδα σας κοντά στην ταμπλέτα σας για να την "
+#~ "ρυθμίσετε"
+
+#~ msgid "Top Button"
+#~ msgstr "Πάνω κουμπί"
+
+#~ msgid "Lower Button"
+#~ msgstr "Κάτω πλήκτρο"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Χαμηλότερο πλήκτρο"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "Ρυθμίσεις GNOME"
+
+#, fuzzy
+#~| msgid "Add or remove users and change your password"
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Προσθέστε ή διαγράψτε χρήστες και αλλάξτε τον κωδικό πρόσβασης σας"
+
+#~ msgid "Print documents"
+#~ msgstr "Εκτύπωση εγγράφων"
+
+#, fuzzy
+#~| msgid "_Allow connections to control the screen"
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Να επιτ_ρέπεται στις συνδέσεις ο έλεγχος της οθόνης"
+
+#, fuzzy
+#~| msgid "Configure input source"
+#~ msgid "Configure network firewall"
+#~ msgstr "Ρύθμιση πηγή εισόδου"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Αναβάθμιση του firmware σε αυτή τη συσκευή"
+
+#, fuzzy
+#~| msgid "Change system time and date settings"
+#~ msgid "Change system language and region settings"
+#~ msgstr "Αλλαγή ρυθμίσεων ώρας και ημερομηνίας του συστήματος"
+
+#, fuzzy
+#~| msgid "Change system time and date settings"
+#~ msgid "Change low-level network settings"
+#~ msgstr "Αλλαγή ρυθμίσεων ώρας και ημερομηνίας του συστήματος"
+
+#~ msgid "Change network settings"
+#~ msgstr "Αλλαγή ρυθμίσεων δικτύου"
+
+#~ msgid "Read network settings"
+#~ msgstr "Ανάγνωση ρυθμίσεων δικτύου"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Ανάγνωση από το CD/DVD"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Αλλαγή ημερομηνίας και ώρας"
+
+#, fuzzy
+#~| msgid "Change system time and date settings"
+#~ msgid "Change time server settings"
+#~ msgstr "Αλλαγή ρυθμίσεων ώρας και ημερομηνίας του συστήματος"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Αλλάξτε της ζώνης ώρας"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Γενική πρόσβαση"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Απενεργοποίηση για σύνδεση σε δίκτυο Wi-Fi"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Συνθηματικό"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Για να δημιουργήσετε ένα λογαριασμό χρήστη,\n"
+#~ "κάντε πρώτα κλικ στο εικονίδιο *"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Ενεργοποίηση εισόδου με αποτύπωμα"
+
+#~ msgid "_Other finger:"
+#~ msgstr "Ά_λλο δάχτυλο:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Το δακτυλικό σας αποτύπωμα αποθηκεύθηκε επιτυχώς. Θα μπορείτε πλέον να "
+#~ "χρησιμοποιείτε τη συσκευή ανάγνωσης δακτυλικών αποτυπωμάτων για τη "
+#~ "σύνδεσή σας."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Δεν σας επιτρέπεται η πρόσβαση στη συσκευή. Επικοινωνήστε με το "
+#~ "διαχειριστή του συστήματος."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Συνέβη ένα εσωτερικό σφάλμα."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Διαγραφή των καταχωρημένων αποτυπωμάτων;"
+
+#~ msgid "Done!"
+#~ msgstr "Έγινε!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Δεν ήταν δυνατή η πρόσβαση στη συσκευή «%s»"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Αδυναμία εκκίνησης της καταγραφής αποτυπωμάτων στη συσκευή «%s»"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Δεν είναι δυνατή η πρόσβαση σε καμία συσκευή ανάγνωσης αποτυπωμάτων"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr ""
+#~ "Παρακαλούμε επικοινωνήστε με το διαχειριστή του συστήματος για βοήθεια."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Για να ενεργοποιήσετε την είσοδο με αποτύπωμα, πρέπει να αποθηκεύσετε ένα "
+#~ "δακτυλικό σας αποτύπωμα χρησιμοποιώντας τη συσκευή «%s»."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Αριστερός δείκτης"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Ορισμός παρασκηνίου και κλειδώματος οθόνης"
+
+#~ msgid "Set Background"
+#~ msgstr "Ορισμός παρασκηνίου"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Ορισμός κλειδώματος οθόνης"
+
+#~| msgid "Set Background"
+#~ msgid "Remove Background"
+#~ msgstr "Αφαίρεση παρασκηνίου"
+
+#~ msgid "Version %s"
+#~ msgstr "Έκδοση %s"
+
+#~ msgid "OS name"
+#~ msgstr "Όνομα OS"
+
+#~ msgid "OS type"
+#~ msgstr "Τύπος OS"
+
+#~ msgid "Disk"
+#~ msgstr "Δίσκος"
+
+#~ msgid "Check for updates"
+#~ msgstr "Έλεγχος για ενημερώσεις"
+
+#~ msgid "Network proxy"
+#~ msgstr "Διαμεσολαβητής δικτύου"
+
+#~ msgid "page 1"
+#~ msgstr "σελίδα 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Εσωτερική _πιστοποίηση"
+
+#~ msgid "page 2"
+#~ msgstr "σελίδα 2"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "Περιορισμός χρήσης δεδομένων στο παρασκήνιο"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Κατάλληλο για συνδέσεις με χρεώσεις ή όρια δεδομένων."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Συνεστραμμένο ζεύγος (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Διεπαφή μονάδας συνημμένου (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Ανεξάρτητη διεπαφή μέσου (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Η ενεργοποίηση του ασύρματου σημείου πρόσβασης θα σας αποσυνδέσει από το "
+#~ "<b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η πρόσβαση στο διαδίκτυο μέσω του ασυρμάτου σας ενώ "
+#~ "είναι ενεργό το σημείο πρόσβασης."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Τα σημεία ασύρματης πρόσβασης χρησιμοποιούνται συνήθως για να μοιραστείτε "
+#~ "μια επιπλέον σύνδεση στο διαδίκτυο μέσω Wi-Fi."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Αυτόματη _σύνδεση"
+
+#~ msgid "details"
+#~ msgstr "λεπτομέρειες"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Εμφάνιση κ_ωδικού πρόσβασης"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Να είναι διαθέσιμο σε άλλους χρήστες"
+
+#~ msgid "identity"
+#~ msgstr "ταυτότητα"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Διευθύνσεις"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Μόνο αυτόματες διευθύνσεις (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Μόνο τοπική σύνδεση"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Παράβλεψη διαδρομών που ελήφθησαν αυτόματα"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Κλωνοποιημένη διεύθυνση MAC"
+
+#~ msgid "_Reset"
+#~ msgstr "_Επαναφορά"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Να γίνει επαναφορά των ρυθμίσεων αυτής της σύνδεσης στις αρχικές "
+#~ "προεπιλογές, αλλά να αποθηκευθεί ως προτιμώμενη σύνδεση."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Αφαίρεση όλων των λεπτομερειών που σχετίζονται με αυτό το δίκτυο και μη "
+#~ "γίνει προσπάθεια αυτόματης σύνδεσης σε αυτό."
+
+#~ msgid "Hardware"
+#~ msgstr "Υλικό"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Επαναφορά"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Συνδεδεμένες συσκευές"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Υποδομή"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Αναδυόμενη ειδ_οποίηση"
+
+#~ msgid "In use"
+#~ msgstr "Σε χρήση"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Ενεργό"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Ανενεργό"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Ανενεργή"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Ενεργή"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Ανενεργό"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Ενεργό"
+
+#~ msgid "Usage & History"
+#~ msgstr "Χρήση & ιστορικό"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Πολιτική ιδιωτικότητας"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Να θυμάστε ότι το ιστορικό διευκολύνει στην επανεύρεση. Αυτά τα στοιχεία "
+#~ "δεν διαμοιράζονται ποτέ μέσω του δικτύου."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Πρόσφατα χρησιμοποιημένα"
+
+#~ msgid "Retain _History"
+#~ msgstr "Διατήρηση _ιστορικού"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Το κλείδωμα της οθόνης προστατεύει την ιδιωτικότητά σας όταν λείπετε."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Κλείδωμα οθόνης _μετά από κενό για"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Ειδοποιήσεις με κλειδωμένη οθόνη"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Αυτόματη εκκαθάριση των απορριμμάτων και των προσωρινών αρχείων για να "
+#~ "κρατήσετε τον υπολογιστή σας ελεύθερο από περιττές ευαίσθητες πληροφορίες."
+
+#~ msgid "Purge _After"
+#~ msgstr "Εκκαθάριση _μετά από"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Η αποστολή πληροφοριών για το ποιο λογισμικό χρησιμοποιείτε μας βοηθά να "
+#~ "σας παράσχουμε περισσότερο ακριβείς συστάσεις. Επίσης μας βοηθά να "
+#~ "βελτιώσουμε το λογισμικό μας.\n"
+#~ "\n"
+#~ "Όλες οι πληροφορίες που συλλέγουμε είναι ανώνυμες και δεν θα μοιράσουμε "
+#~ "ποτέ τα δεδομένα σας με τρίτους."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "Α_ποστολή στατιστικών χρήσης λογισμικού"
+
+#~ msgid "_Camera"
+#~ msgstr "_Κάμερα"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Μικρόφωνο"
+
+#~ msgid "_Location Services"
+#~ msgstr "Υπηρεσίες τ_οποθεσίας"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Προστατεύστε τις προσωπικές σας πληροφορίες και ελέγξτε τι βλέπουν οι "
+#~ "άλλοι"
+
+#~ msgid "No regions found"
+#~ msgstr "Δε βρέθηκαν περιοχές"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Αναβόσβημα τίτλου πα_ραθύρου"
+
+#~ msgid "Last Login"
+#~ msgstr "Τελευταία σύνδεση"
+
+#~ msgid "Delete Background"
+#~ msgstr "Διαγραφή παρασκηνίου"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Το όνομα χρήστη δεν μπορεί να αρχίζει με «-»."
+
+#~ msgid "_Off"
+#~ msgstr "_Ανενεργό"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Αυτόματη αναστολή"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "Ό_ταν πατιέται το κουμπί τερματισμού"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "_Background"
+#~ msgstr "Πα_ρασκήνιο"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Αλλάζει κατά τη διάρκεια της ημέρας"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Παράθεση"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Εστίαση"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Κεντράρισμα"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Κλιμάκωση"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Συμπλήρωση"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Ανάπτυγμα"
+
+#~ msgid "Colors"
+#~ msgstr "Χρώματα"
+
+#~ msgid "Pictures"
+#~ msgstr "Εικόνες"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Δεν βρέθηκαν εικόνες"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Μπορείτε να προσθέσετε εικόνες στον φάκελο %s και θα εμφανιστούν εδώ"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Σύνδεση/SSID"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "_Night Light"
+#~ msgstr "Λειτουργία νυχτός"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Αδυναμία λήψης πληροφοριών οθόνης"
+
+#~ msgid "Add input source"
+#~ msgstr "Προσθήκη πηγής εισόδου"
+
+#~ msgid "Remove input source"
+#~ msgstr "Αφαίρεση πηγής εισόδου"
+
+#~ msgid "Move input source up"
+#~ msgstr "Μετακίνηση πηγής εισόδου πάνω"
+
+#~ msgid "Move input source down"
+#~ msgstr "Μετακίνηση πηγής εισόδου κάτω"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Εμφάνισης διάταξης πληκτρολογίου της πηγής εισόδου"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Αριστερά"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Δεξιά"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Ελάχιστο"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Μέγιστο"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Χωρίς ενισχυτή"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Προφίλ:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Δοκιμή ηχείων"
+
+#~ msgid "Peak detect"
+#~ msgstr "Εντοπισμός κορύφωσης"
+
+#~ msgid "Device"
+#~ msgstr "Συσκευή"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Δοκιμή ηχείου για %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Επι_λέξτε μια συσκευή για την έξοδο ήχου:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Ρυθμίσεις για την επιλεγμένη συσκευή:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Ένταση ήχου ει_σόδου:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Επιλέ_ξτε μια συσκευή για την είσοδο ήχου:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Ηχητικά εφέ"
+
+#~ msgid "Built-in"
+#~ msgstr "Ενσωματωμένο"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Προτιμήσεις ήχου"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Γίνεται δοκιμή ήχου γεγονότος"
+
+#~ msgid "From theme"
+#~ msgstr "Από θέμα"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Επιλέ_ξτε έναν ήχο ειδοποίησης:"
+
+#~ msgid "Stop"
+#~ msgstr "Διακοπή"
+
+#~ msgid "hardware"
+#~ msgstr "υλικό"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Αλλαγή στην προηγούμενη πηγή"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Αλλαγή στην επόμενη πηγή"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Εναλλακτική αλλαγή στην επόμενη πηγή"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Αγγλικά (Ενωμένο Βασίλειο)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Ενωμένο Βασίλειο"
+
+#~ msgid "_Options"
+#~ msgstr "Επιλ_ογές"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Τυπικός"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Διαχειριστής"
+
+#~ msgid "page 3"
+#~ msgstr "σελίδα 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Κέντρου ελέγχου GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Το κέντρο ελέγχου είναι η κύρια διεπαφή του GNOME για τη ρύθμιση διάφορων "
+#~ "πτυχών της επιφάνειας εργασίας σας."
+
+#~ msgid "Quit"
+#~ msgstr "Έξοδος"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "Back­ground"
+#~ msgstr "Παρασκήνιο"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blue­tooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Χρώμα"
+
+#~ msgid "Overview"
+#~ msgstr "Επισκόπηση"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Προεπιλεγμένες εφαρμογές"
+
+#~ msgid "Ab­out"
+#~ msgstr "Περί"
+
+#~ msgid "De­tails"
+#~ msgstr "Λεπτομέρειες"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Αφαιρούμενα μέσα"
+
+#~ msgid "Net­work"
+#~ msgstr "Δίκτυο"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Ειδοποιήσεις"
+
+#~ msgid "Po­wer"
+#~ msgstr "Ενέργεια"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Ιδιωτικότητα"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Κοινή χρήση"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Γενική πρόσβαση"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "Επα_λήθευση νέου κωδικού πρόσβασης"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Δεν ταιριάζουν οι κωδικοί πρόσβασης."
+
+#~ msgid "Disable image"
+#~ msgstr "Απενεργοποίηση εικόνας"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Περιηγηθείτε για περισσότερες φωτογραφίες…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Χρησιμοποιείται από %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wacom Tablet"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Υλικό"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Σύστημα"
+
+#~ msgid "Show the overview"
+#~ msgstr "Εμφάνιση της επισκόπησης"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Κλειστό κάλυμμα"
+
+#~ msgid "Mirrored"
+#~ msgstr "Με κατοπτρισμό"
+
+#~ msgid "Secondary"
+#~ msgstr "Δευτερεύον"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Διάταξη συνδυασμένων οθονών"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Μεταφορά οθονών για αναδιάταξή τους"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Περιστροφή αριστερόστροφα κατά 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Περιστροφή κατά 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Περιστροφή δεξιόστροφα κατά 90°"
+
+#~ msgid "Size"
+#~ msgstr "Μέγεθος"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr ""
+#~ "Εμφάνιση της πάνω μπάρας και της επισκόπησης ενεργειών σε αυτήν την οθόνη"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Σύνδεση αυτής της οθόνης με μια άλλη για τη δημιουργία ενός πρόσθετου "
+#~ "χώρου εργασίας"
+
+#~ msgid "Presentation"
+#~ msgstr "Παρουσίαση"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Εμφάνιση μόνο διαφανειών και μέσων"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Εμφάνιση της υπάρχουσας προβολής και στις δύο οθόνες"
+
+#~ msgid "Turn Off"
+#~ msgstr "Απενεργοποίηση"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Να μην χρησιμοποιηθεί αυτή η οθόνη"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Διάταξη συνδυασμένων οθονών"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (αναγνωριστικό δόμησης: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "Βασικό σύστημα"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Συντόμευση;Επανάληψη;Αναβόσβησμα;Shortcut;Repeat;Blink;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Πατήστε Esc για ακύρωση"
+
+#~ msgid "Server"
+#~ msgstr "Διακομιστής"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Διαγραφή διακομιστή DNS"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Να είναι διαθέσιμο σε άλλους _χρήστες"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Ζώνη τείχους προστασίας"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Προεπιλογή"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Η ζώνη ορίζει το επίπεδο εμπιστοσύνης της σύνδεσης"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Να γίνει επαναφορά των ρυθμίσεων αυτού του δικτύου, συμπεριλαμβανομένων "
+#~ "των κωδικών πρόσβασης, αλλά να αποθηκευθεί ως προτιμώμενο δίκτυο"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Αφαίρεση όλων των λεπτομερειών που σχετίζονται με αυτό το δίκτυο και μη "
+#~ "γίνει προσπάθεια αυτόματης σύνδεσης"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Αν έχετε άλλη σύνδεση στο διαδίκτυο εκτός της ασύρματης, μπορείτε να "
+#~ "ορίσετε ένα ασύρματο σημείο πρόσβασης για να διαμοιράσετε τη σύνδεση με "
+#~ "άλλους."
+
+#~ msgid "Proxy"
+#~ msgstr "Διαμεσολαβητής"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Προσθήκη προφίλ…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Καμία"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Χειροκίνητο"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Αυτόματο"
+
+#~ msgid "VPN Type"
+#~ msgstr "Τύπος VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "Όνομα ομάδας"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Χρήση ως σημείο πρόσβασης…"
+
+#~ msgid "_History"
+#~ msgstr "_Ιστορικό"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr ""
+#~ "Προσπαθήστε να προσθέσετε περισσότερα γράμματα, αριθμούς και σύμβολα."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Ισχύς: Ασθενής"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Ισχύς: Χαμηλή"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Ισχύς: Μέτρια"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Ισχύς: Καλή"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Ισχύς: Υψηλή"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Τίτλοι ειδοποίησης"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Τίτλοι ει_δοποίησης"
+
+#~ msgid "Add Account"
+#~ msgstr "Προσθήκη λογαριασμού"
+
+#~ msgid "Mail"
+#~ msgstr "Αλληλογραφία"
+
+#~ msgid "Calendar"
+#~ msgstr "Ημερολόγιο"
+
+#~ msgid "Contacts"
+#~ msgstr "Επαφές"
+
+#~ msgid "Chat"
+#~ msgstr "Συνομιλία"
+
+#~ msgid "Error creating account"
+#~ msgstr "Σφάλμα δημιουργίας λογαριασμού"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Είστε σίγουροι ότι θέλετε να αφαιρέσετε το λογαριασμό;"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Ο λογαριασμός σας δε θα διαγραφεί από τον διακομιστή."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Δεν έχουν ρυθμιστεί διαδικτυακοί λογαριασμοί"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Προσθέτοντας ένα λογαριασμό επιτρέπει στις εφαρμογές σας να έχουν "
+#~ "πρόσβαση σε έγγραφα, αλληλογραφία, επαφές, ημερολόγιο, συνομιλία και "
+#~ "πολλά άλλα."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Γίνεται ρύθμιση"
+
+#~ msgid "Toner Level"
+#~ msgstr "Επίπεδο τόνερ"
+
+#~ msgid "Supply Level"
+#~ msgstr "Επίπεδο τροφοδοσίας"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Εγκατάσταση"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u ενεργό"
+#~ msgstr[1] "%u ενεργά"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Προσθήκη νέου εκτυπωτή"
+
+#~ msgid "No printers detected."
+#~ msgstr "Δεν εντοπίστηκαν εκτυπωτές."
+
+#~ msgid "Supply"
+#~ msgstr "Παροχή"
+
+#~ msgid "Jobs"
+#~ msgstr "Εργασίες"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Εμφάνιση _εργασιών"
+
+#~ msgid "label"
+#~ msgstr "ετικέτα"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Εκτύπωση _δοκιμαστικής σελίδας"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Άλλοι λογαριασμοί"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Πάνω"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Κάτω"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Καμία"
+
+#~ msgid "Left Ring"
+#~ msgstr "Αριστερός δακτύλιος"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Λειτουργία αριστερού δακτυλίου #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Λειτουργία δεξιού δακτυλίου #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Αριστερή λουρίδα επαφής"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Λειτουργία αριστερής λωρίδας #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Δεξιά λουρίδα επαφής"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Λειτουργία δεξιάς λουρίδας επαφής #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Λειτουργία διακόπτη αριστερού δακτυλίου"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Λειτουργία διακόπτη δεξιού δακτυλίου"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Λειτουργία διακόπτη αριστερής λουρίδας επαφής"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Λειτουργία διακόπτη δεξιάς λουρίδας επαφής"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Λειτουργία διακόπτη #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Αριστερό κουμπί #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Δεξί κουμπί #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Πάνω κουμπί #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Κάτω κουμπί #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Καμμία ενέργεια"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Αριστερό κλικ κουμπιού του ποντικιού"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Κύλιση πάνω"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Κύλιση κάτω"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Κύλιση δεξιά"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Για να επεξεργασθείτε μια συντόμευση, κάντε κλικ στην αντίστοιχη σειρά "
+#~ "και κρατήστε πατημένα τα νέα πλήκτρα ή πατήστε backspace για εκκαθάριση."
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Σφάλμα σύνδεσης στο λογαριασμό"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Τα διαπιστευτήρια έχουν λήξει."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Συνδεθείτε για την ενεργοποίηση αυτού του λογαριασμού."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Σύνδεση"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Αφαίρεση συντόμευσης"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Άγνωστη ενέργεια>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Η συντόμευση \"%s\" δεν θα χρησιμοποιηθεί γιατί θα επηρεάσει την "
+#~ "πληκτρολόγηση.\n"
+#~ "Χρησιμοποιήστε την σε συνδυασμό με πλήκτρα όπως το Control, Alt ή Shift."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Η συντόμευση \"%s\" χρησιμοποιείται ήδη για:\n"
+#~ " \"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Αν αναθέσετε ξανά τη συντόμευση στο \"%s\", η συντόμευση \"%s\" θα "
+#~ "απενεργοποιηθεί."
+
+#~ msgid "_Reassign"
+#~ msgstr "Ανά_θεση ξανά"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Η συντόμευση \"%s\" έχει μια συνδεόμενη συντόμευση στο \"%s\". Θέλετε να "
+#~ "την ορίσετε αυτόματα στο \"%s\";"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "Η \"%s\" συνδέεται προς το παρόν με την \"%s\" και θα απενεργοποιηθεί αν "
+#~ "προχωρήσετε."
+
+#~ msgid "_Assign"
+#~ msgstr "_Ανάθεση"
+
+#~ msgid "Bond"
+#~ msgstr "Δεσμός"
+
+#~ msgid "Team"
+#~ msgstr "Ομάδα"
+
+#~ msgid "Bridge"
+#~ msgstr "Γέφυρα"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Αδυναμία φόρτωσης προσθέτων VPN"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Προσθήκη σύνδεσης δικτύου"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Υποτελείς δεσμοί"
+
+#~ msgid "(none)"
+#~ msgstr "(κανένας)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Υποτελείς γέφυρες"
+
+#~ msgid "Team slaves"
+#~ msgstr "Υποτελείς ομάδας"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "Η συσκευή InfiniBand δεν υποστηρίζει τη λειτουργία σύνδεσης"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Δεν έχει επιλεχθεί πιστοποιητικό της αρχής πιστοποίησης"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Η έλλειψη χρήσης πιστοποιητικού αρχής πιστοποίησης (CA), μπορεί να "
+#~ "καταλήξει σε συνδέσεις σε επισφαλή και ευάλωτα δίκτυα Wi-Fi. Θέλετε να "
+#~ "επιλέξετε ένα πιστοποιητικό αρχής πιστοποίησης;"
+
+#~ msgid "Ignore"
+#~ msgstr "Παράβλεψη"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Επιλέξτε πιστοποιητικό CA"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Ε_ρώτηση για αυτόν τον κωδικό πρόσβασης κάθε φορά"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Να _μην προειδοποιηθώ ξανά"
+
+#~ msgid "Yes"
+#~ msgstr "Ναι"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Άλλο"
+
+#~ msgid "_Verify"
+#~ msgstr "_Επαλήθευση"
+
+#~ msgid "Login History"
+#~ msgstr "Ιστορικό συνδέσεων"
+
+#~ msgid "Add User Account"
+#~ msgstr "Προσθήκη λογαριασμού χρήστη"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Υπάρχει ήδη ένας χρήστης με όνομα '%s'."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Χρησιμοποιείται για να καθοριστεί η γεωγραφική σας θέση"
+
+#~ msgid "Done"
+#~ msgstr "Έτοιμο"
+
+#~ msgid "Time _Zone"
+#~ msgstr "_Ζώνη ώρας"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Συνέχιση εκτύπωσης"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Παύση εκτύπωσης"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Σε αναμονή"
+
+#~ msgid "Job Title"
+#~ msgstr "Τίτλος εργασίας"
+
+#~ msgid "Job State"
+#~ msgstr "Κατάσταση εργασίας"
+
+#~ msgid "Password:"
+#~ msgstr "Κωδικός πρόσβασης:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "Πλήκτρα επανάλη_ψης"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "Ο _δρομέας αναβοσβήνει"
+
+#~ msgid "Zoom"
+#~ msgstr "Εστίαση"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Χρώμα"
+
+#~ msgid "_Delay:"
+#~ msgstr "Καθυ_στέρηση:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Σύντομη"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Αργή"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Μεγάλη"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Γρήγορη"
+
+#~ msgid "S_peed:"
+#~ msgstr "Τα_χύτητα:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Δοκιμή των ρυθμίσεων σας"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Αργό"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Γρήγορο"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "Αρ_ιστερά"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "Δ_εξιά"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "Ταχύτητα δεί_κτη"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Αργή"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Γρήγορη"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Αργή"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Γρήγορη"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Προσθήκη νέου εκτυπωτή"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Οι ασύρματες συσκευές απαιτούν επιπλέον ισχύ"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Όταν η ισχύς της μπαταρίας είναι _χαμηλή"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Η κοινή χρήση Bluetooth επιτρέπει να μοιραστείτε αρχεία με άλλες ενεργές "
+#~ "συσκευές Bluetooth"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Να γίνεται λήψη μόνο από έμπιστες συσκευές"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Αποθήκευση των ληφθέντων αρχείων στον φάκελο λήψεων"
+
+#~ msgid "Show help options"
+#~ msgstr "Εμφάνιση επιλογών βοήθειας"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Εκτελέστε '%s --help' για να δείτε μια πλήρη λίστα με τις διαθέσιμες "
+#~ "επιλογές της γραμμής εντολών.\n"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Απενεργοποίηση ασύρματων συσκευών"
+
+#~ msgid "United States"
+#~ msgstr "Ηνωμένες Πολιτείες Αμερικής"
+
+#~ msgid "Spain"
+#~ msgstr "Ισπανία"
+
+#~ msgid "China"
+#~ msgstr "Κίνα"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Απενεργοποίηση κατά την πληκ_τρολόγηση"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr ""
+#~ "Οι υπηρεσίες δικτύου του συστήματος δεν είναι συμβατές με αυτή την έκδοση."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Εμφάνιση αναδυόμενων τίτλων"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Εμφάνιση στο κλείδωμα οθόνης"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Εμφάνιση αναδυόμενων τίτλων"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr ""
+#~ "Εισάγετε διεύθυνση ενός εκτυπωτή ή κείμενο για φιλτράρισμα αποτελεσμάτων"
+
+#~ msgid "Sorry"
+#~ msgstr "Συγνώμη"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Διαμοιρασμός μέσων σε αυτό το δίκτυο"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Κοινόχρηστοι φάκελοι"
+
+#~ msgid "column"
+#~ msgstr "στήλη"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Αφαίρεση φακέλου"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Διαμοιρασμός δημόσιου φακέλου σε αυτό το δίκτυο"
+
+#~ msgid "Immediately"
+#~ msgstr "Αμέσως"
+
+#~ msgid "Install Updates"
+#~ msgstr "Εγκατάσταση ενημερώσεων"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Το σύστημα είναι ενημερωμένο"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Αναζήτηση για δικτυακούς εκτυπωτές ή φιλτράρισμα αποτελέσματος"
+
+#~ msgid "_Default"
+#~ msgstr "Προεπι_λογή"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Επικύρωση όλων των συνδέσεων"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Εγκατάσταση νέας συσκευής"
+
+#~ msgid "Paired"
+#~ msgstr "Συζευγμένα"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Ρυθμίσεις ποντικιού & πινακίδας αφής"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Ρυθμίσεις πληκτρολογίου"
+
+#~ msgid "Send Files…"
+#~ msgstr "Αποστολή αρχείων…"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Ορατότητα του “%s”"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Να αφαιρεθεί το '%s' από την λίστα των συσκευών;"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Εάν αφαιρέσετε την συσκευή, θα πρέπει να την ρυθμίσετε ξανά την επόμενη "
+#~ "φορά που θα την χρησιμοποιήσετε."
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Μερισμός δημόσιου φακέλου"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Μερισμός μόνο με έμπιστες συσκευές"
+
+#~ msgid "Device type:"
+#~ msgstr "Τύπος συσκευής:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Κατασκευαστής:"
+
+#~ msgid "Model:"
+#~ msgstr "Μοντέλο:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Τα αρχεία εικόνων μπορούν να μεταφερθούν σε αυτό το παράθυρο για αυτόματη "
+#~ "συμπλήρωση των παραπάνω πεδίων."
+
+#~ msgid "_Region:"
+#~ msgstr "Περιο_χή:"
+
+#~ msgid "_City:"
+#~ msgstr "Πό_λη:"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Ορισμός της ώρας μια ώρα μπροστά."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Ορισμός της ώρας μια ώρα πίσω."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Ορισμός της ώρας ένα λεπτό μπροστά."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Ορισμός της ώρας ένα λεπτό πίσω."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Εναλλαγή μεταξύ ΠΜ και ΑΜ."
+
+#~ msgid "AM/PM"
+#~ msgstr "ΠΜ/ΜΜ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Κανονικό"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Δεξιόστροφα"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 μοίρες"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Επιλέξτε μια οθόνη για να αλλάξετε τις ιδιότητες της· μεταφέρτε την για "
+#~ "να αναδιατάξετε την θέση της."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Αδυναμία αποθήκευσης των ρυθμίσεων της οθόνης"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "Αδυναμία εντοπισμού οθονών"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Ανάλυση"
+
+#~ msgid "R_otation"
+#~ msgstr "Πε_ριστροφή"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Καθρεφτισμός οθονών"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Σημείωση: πιθανότητα μείωσης επιλογών ανάλυσης"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Προτιμήσεις ποντικιού"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Επιλογή διασύνδεσης χρήστη για την νέα υπηρεσία"
+
+#~ msgid "C_reate…"
+#~ msgstr "Δ_ημιουργία…"
+
+#~ msgid "_Interface"
+#~ msgstr "Δ_ιεπαφή"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "Εκτιμώμενη χωρητικότητα μπαταρίας: %s"
+
+#~ msgid "Hidden"
+#~ msgstr "Κρυφό"
+
+#~ msgid "Visible"
+#~ msgstr "Ορατό"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "Όνομα & ορατότητα"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "Έλεγχος εμφάνισης στην οθόνη και το δίκτυο."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "_Πλήρες όνομα οθόνης στην πάνω γραμμή"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "Πλήρες όνομα οθόνης σε _κλείδωμα οθόνης"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "Κατάσταση _απόκρυψης"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Καμία"
+
+#~ msgid "Show Status When _Inactive"
+#~ msgstr "Εμφάνιση κατάστασης όταν είναι α_νενεργό"
+
+#~ msgid "_Login Name"
+#~ msgstr "Όνομα ει_σόδου"
+
+#~ msgid "Login _Password"
+#~ msgstr "Κω_δικός πρόσβασης σύνδεσης"

--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-01-25 23:52-0500\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,3178 +18,4965 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../gnome-control-center.schemas.in.h:1
-msgid "Current network location"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:2
-msgid "More backgrounds URL"
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:3
-msgid "More themes URL"
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:4
-msgid ""
-"Set this to your current location name. This is used to determine the "
-"appropriate network proxy configuration."
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:5
-msgid ""
-"URL for where to get more desktop backgrounds. If set to an empty string the "
-"link will not appear."
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:6
-msgid ""
-"URL for where to get more desktop themes. If set to an empty string the link "
-"will not appear."
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
 msgstr ""
 
-#: ../libgnome-control-center/gconf-property-editor.c:134
-msgid "Key"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#: ../libgnome-control-center/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:141
-msgid "Callback"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:147
-msgid "Change set"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:148
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:154
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:160
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:1406
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:1414
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:1536
-msgid "Please select an image."
-msgstr ""
-
-#: ../libgnome-control-center/gconf-property-editor.c:1541
-msgid "_Select"
-msgstr ""
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
-msgid "Background"
-msgstr ""
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change the background"
-msgstr ""
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;"
-msgstr ""
-
-#: ../panels/background/background.ui.h:1
-msgid "Center"
-msgstr ""
-
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr ""
-
-#: ../panels/background/background.ui.h:4
-msgid "Fill"
-msgstr ""
-
-#: ../panels/background/background.ui.h:5
-msgid "Scale"
-msgstr ""
-
-#: ../panels/background/background.ui.h:6
-msgid "Span"
-msgstr ""
-
-#: ../panels/background/background.ui.h:7
-msgid "Tile"
-msgstr ""
-
-#: ../panels/background/background.ui.h:8
-#: ../panels/universal-access/uap.ui.h:92
-msgid "Zoom"
-msgstr ""
-
-#: ../panels/background/bg-colors-source.c:44
-msgid "Horizontal Gradient"
-msgstr ""
-
-#: ../panels/background/bg-colors-source.c:45
-msgid "Vertical Gradient"
-msgstr ""
-
-#: ../panels/background/bg-colors-source.c:46
-msgid "Solid Color"
-msgstr ""
-
-#: ../panels/background/cc-background-panel.c:747
-msgid "Wallpapers"
-msgstr ""
-
-#: ../panels/background/cc-background-panel.c:755
-msgid "Pictures Folder"
-msgstr ""
-
-#: ../panels/background/cc-background-panel.c:763
-msgid "Colors & Gradients"
-msgstr ""
-
-#: ../panels/background/cc-background-panel.c:772
-msgid "Flickr"
-msgstr ""
-
-#: ../panels/background/cc-background-panel.c:833
-msgid "Current background"
-msgstr ""
-
-#: ../panels/background/gnome-wp-info.c:59
-msgid "No Desktop Background"
-msgstr ""
-
-#: ../panels/background/gnome-wp-item.c:277
-msgid "multiple sizes"
-msgstr ""
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/gnome-wp-item.c:285
-#, c-format
-msgid "%d × %d"
-msgstr ""
-
-#: ../panels/common/gdm-languages.c:709
-msgid "Unspecified"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "16"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "2010"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "22"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "24-Hour Time"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "45"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid ":"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "AM"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "April"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "August"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "City:"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "December"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "February"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:13
-msgid "January"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:14
-msgid "July"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:15
-msgid "June"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:16
-msgid "March"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "May"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Network Time"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "November"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:20
-msgid "October"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:21
-msgid "Region:"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:22
-msgid "September"
-msgstr ""
-
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Clock;Timezone;Location;"
-msgstr ""
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
-msgid "Date and Time"
-msgstr ""
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
-msgid "Date and Time preferences panel"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:1
-#: ../panels/display/xrandr-capplet.c:321
-msgid "Left"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:2
-#: ../panels/display/xrandr-capplet.c:484
-msgid "Monitor"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:3
-#: ../panels/display/xrandr-capplet.c:320
-#: ../panels/display/xrandr-capplet.c:359
-#: ../panels/universal-access/uap.ui.h:58
-msgid "Normal"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:4
-msgid "Note: may limit resolution options"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:5
-msgid "R_otation:"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:6
-#: ../panels/display/xrandr-capplet.c:322
-msgid "Right"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:7
-msgid "Upside-down"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:8
-msgid "_Detect Displays"
-msgstr ""
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:10
-msgid "_Mirror displays"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:11
-msgid "_Resolution:"
-msgstr ""
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Change resolution and position of monitors and projectors"
-msgstr ""
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Displays"
-msgstr ""
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:323
-msgid "Upside Down"
-msgstr ""
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../panels/display/xrandr-capplet.c:460
-msgid "Mirror Displays"
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:593
-#, c-format
-msgid "%d x %d (%s)"
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:595
-#, c-format
-msgid "%d x %d"
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:1505
-msgid "Drag to change primary display."
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:1563
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:1953
-msgid "%a %R"
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:1955
-msgid "%a %l:%M %p"
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:2240
-msgid "Could not save the monitor configuration"
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:2263
-msgid "Could not get session bus while applying display configuration"
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:2308
-msgid "Could not detect displays"
-msgstr ""
-
-#: ../panels/display/xrandr-capplet.c:2516
-msgid "Could not get screen information"
-msgstr ""
-
-#. translators: This is the type of architecture, for example:
-#. * "64-bit" or "32-bit"
-#: ../panels/info/cc-info-panel.c:247
-#, c-format
-msgid "%d-bit"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:261
-#, c-format
-msgid "%u byte"
-msgid_plural "%u bytes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../panels/info/cc-info-panel.c:269
-#, c-format
-msgid "%.1f KB"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:274
-#, c-format
-msgid "%.1f MB"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:279
-#, c-format
-msgid "%.1f GB"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:284
-#, c-format
-msgid "%.1f TB"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:289
-#, c-format
-msgid "%.1f PB"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:294
-#, c-format
-msgid "%.1f EB"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:404
-msgid "Unknown model"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:466
-#, c-format
-msgid "Version %s"
-msgstr ""
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-msgid "System Info"
-msgstr ""
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "System Information"
-msgstr ""
-
-#. Translators: those are keywords for the System Information panel
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid "device;system;information;memory;processor;version;"
-msgstr ""
-
-#: ../panels/info/info.ui.h:1
-msgid "Device name:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:2
-msgid "Disk:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:3
-msgid "Memory:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:4
-msgid "More Info"
-msgstr ""
-
-#: ../panels/info/info.ui.h:5
-msgid "OS type:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:7
-msgid "Update Available"
-msgstr ""
-
-#: ../panels/keyboard/00-multimedia-key.xml.in.h:1
-msgid "Sound and Media"
-msgstr ""
-
-#: ../panels/keyboard/01-desktop-key.xml.in.h:1
-msgid "Launchers and Actions"
-msgstr ""
-
-#: ../panels/keyboard/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr ""
-
-#: ../panels/keyboard/eggcellrendererkeys.c:164
-#: ../panels/keyboard/eggcellrendererkeys.c:165
-msgid "Accelerator key"
-msgstr ""
-
-#: ../panels/keyboard/eggcellrendererkeys.c:174
-#: ../panels/keyboard/eggcellrendererkeys.c:175
-msgid "Accelerator modifiers"
-msgstr ""
-
-#: ../panels/keyboard/eggcellrendererkeys.c:183
-#: ../panels/keyboard/eggcellrendererkeys.c:184
-msgid "Accelerator keycode"
-msgstr ""
-
-#: ../panels/keyboard/eggcellrendererkeys.c:194
-msgid "Accel Mode"
-msgstr ""
-
-#: ../panels/keyboard/eggcellrendererkeys.c:195
-msgid "The type of accelerator."
-msgstr ""
-
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/eggcellrendererkeys.c:243
-#: ../panels/keyboard/keyboard-shortcuts.c:1229
-#: ../panels/sound/gvc-mixer-control.c:1091
-#: ../panels/user-accounts/um-fingerprint-dialog.c:177
-#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Change keyboard settings"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "Keyboard"
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
 msgstr ""
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:736
-#: ../panels/keyboard/keyboard-shortcuts.c:1001
-#: ../panels/keyboard/keyboard-shortcuts.c:1633
-#: ../panels/keyboard/keyboard-shortcuts.c:1637
-msgid "Custom Shortcuts"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:848
-msgid "<Unknown Action>"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1255
-msgid "Error saving the new shortcut"
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1365
-#, c-format
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+"How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1395
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1401
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1409
-msgid "_Reassign"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1529
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s"
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1587
-msgid "Too many custom shortcuts"
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1865
-msgid "Section"
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1909
-msgid "Action"
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1931
-msgid "Shortcut"
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "C_ommand:"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "Cursor Blinking"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "Cursor _blinks in text fields"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-#: ../panels/universal-access/uap.ui.h:28
-msgid "Cursor blinks speed"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "Custom Shortcut"
-msgstr ""
-
-#. fast acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "Fast"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "General"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "Key presses _repeat when key is held down"
-msgstr ""
-
-#. long delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-#: ../panels/universal-access/uap.ui.h:51
-msgid "Long"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgid "Repeat Keys"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgid "S_peed:"
-msgstr ""
-
-#. short delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-#: ../panels/mouse/gnome-mouse-properties.ui.h:24
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Short"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Shortcuts"
-msgstr ""
-
-#. slow acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-#: ../panels/mouse/gnome-mouse-properties.ui.h:26
-msgid "Slow"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "_Delay:"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-msgid "_Name:"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-msgid "_Speed:"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:322
-msgid "Ask what to do"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:326 ../panels/power/power.ui.h:8
-msgid "Do nothing"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:330
-msgid "Open folder"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:441
-msgid "Select an application for audio CDs"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:442
-msgid "Select an application for video DVDs"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:443
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:444
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:445
-msgid "Select an application for software CDs"
-msgstr ""
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, except for fixed capitalization. If the shared-mime-info
-#. * translation works for your language, simply leave this untranslated
-#.
-#: ../panels/media/cc-media-panel.c:456
-msgid "audio DVD"
-msgstr "Audio DVD"
-
-#: ../panels/media/cc-media-panel.c:457
-msgid "blank Blu-ray disc"
-msgstr "Blank Blu-ray disc"
-
-#: ../panels/media/cc-media-panel.c:458
-msgid "blank CD disc"
-msgstr "Blank CD disc"
-
-#: ../panels/media/cc-media-panel.c:459
-msgid "blank DVD disc"
-msgstr "Blank DVD disc"
-
-#: ../panels/media/cc-media-panel.c:460
-msgid "blank HD DVD disc"
-msgstr "Blank HD DVD disc"
-
-#: ../panels/media/cc-media-panel.c:461
-msgid "Blu-ray video disc"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:462
-msgid "e-book reader"
-msgstr "E-book reader"
-
-#: ../panels/media/cc-media-panel.c:463
-msgid "HD DVD video disc"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:464
-msgid "Picture CD"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:465
-msgid "Super Video CD"
-msgstr ""
-
-#: ../panels/media/cc-media-panel.c:466
-msgid "Video CD"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:1
-msgid "Acti_on:"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:2
-msgid "CD _audio:"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:3
-msgid "Media and Autorun"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:4
-msgid "Select how media should be handled"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:5
-msgid "Select how other media should be handled"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:6
-msgid "_DVD video:"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:7
-msgid "_Music player:"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:8
-msgid "_Never prompt or start programs on media insertion"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:9
-msgid "_Other Media..."
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:10
-msgid "_Photos:"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:11
-msgid "_Software:"
-msgstr ""
-
-#: ../panels/media/gnome-media-properties.ui.h:12
-msgid "_Type:"
-msgstr ""
-
-#: ../panels/media/gnome-media-panel.desktop.in.in.h:1
-msgid "Configure media and autorun preferences"
-msgstr ""
-
-#: ../panels/media/gnome-media-panel.desktop.in.in.h:2
-msgid "Removable Media"
-msgstr ""
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:210
-msgid "Low on toner"
-msgstr ""
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:212
-msgid "Out of toner"
-msgstr ""
-
-#. Translators: "Developer" like on photo development context
-#: ../panels/printers/cc-printers-panel.c:214
-msgid "Low on developer"
-msgstr ""
-
-#. Translators: "Developer" like on photo development context
-#: ../panels/printers/cc-printers-panel.c:216
-msgid "Out of developer"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:218
-msgid "Low on a marker supply"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:220
-msgid "Out of a marker supply"
-msgstr ""
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:222
-msgid "Open cover"
-msgstr ""
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:224
-msgid "Open door"
-msgstr ""
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:226
-msgid "Low on paper"
-msgstr ""
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:228
-msgid "Out of paper"
-msgstr ""
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:230
-msgid "Offline"
-msgstr ""
-
-#. Translators: Someone has paused the Printer
-#: ../panels/printers/cc-printers-panel.c:232
-msgid "Paused"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:234
-msgid "Waste receptacle almost full"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:236
-msgid "Waste receptacle full"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:238
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:240
-msgid "The optical photo conductor is no longer functioning"
-msgstr ""
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:329
-msgid "Idle"
-msgstr ""
-
-#. Translators: Printer's state (jobs are processing)
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/cc-printers-panel.c:333
-#: ../panels/printers/cc-printers-panel.c:726
-msgid "Processing"
-msgstr ""
-
-#. Translators: Printer's state (no jobs can be processed)
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/cc-printers-panel.c:337
-#: ../panels/printers/cc-printers-panel.c:730
-msgid "Stopped"
-msgstr ""
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/cc-printers-panel.c:718
-msgid "Pending"
-msgstr ""
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/cc-printers-panel.c:722
-msgid "Held"
-msgstr ""
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/cc-printers-panel.c:734
-msgid "Canceled"
-msgstr ""
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/cc-printers-panel.c:738
-msgid "Aborted"
-msgstr ""
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/cc-printers-panel.c:742
-msgid "Completed"
-msgstr ""
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/cc-printers-panel.c:837
-msgid "Job Title"
-msgstr ""
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/cc-printers-panel.c:845
-msgid "Job State"
-msgstr ""
-
-#. Translators: Name of column showing names of creators of print jobs
-#: ../panels/printers/cc-printers-panel.c:851
-msgid "User"
-msgstr ""
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/cc-printers-panel.c:857
-msgid "Time"
-msgstr ""
-
-#. Translators: Program cannot connect to DBus' system bus
-#: ../panels/printers/cc-printers-panel.c:1047
-#, c-format
-msgid "Could not connect to system bus: %s"
-msgstr ""
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:1657
-msgid "Test page"
-msgstr ""
-
-#. Translators: Name of job which makes printer to clean its heads
-#: ../panels/printers/cc-printers-panel.c:1665
-msgid "Clean print heads"
-msgstr ""
-
-#. Translators: An error has occured during execution of a CUPS maintenance command
-#: ../panels/printers/cc-printers-panel.c:1670
-msgid "An error has occured during a maintenance command."
-msgstr ""
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:1737
-#, c-format
-msgid "Could not load ui: %s"
-msgstr ""
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
-msgid "Change printer settings"
-msgstr ""
-
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
-msgid "Printer;Queue;Print;Paper;Ink;Toner;"
-msgstr ""
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
-msgid "Printers"
-msgstr ""
-
-#: ../panels/printers/printers.ui.h:1
-msgid "---"
-msgstr ""
-
-#. Translators: Cancel selected print job.
-#: ../panels/printers/printers.ui.h:3
-#: ../panels/user-accounts/data/language-chooser.ui.h:1
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-msgid "Cancel"
-msgstr ""
-
-#. Translators: This button executes command which cleans print heads of the printer.
-#: ../panels/printers/printers.ui.h:5
-msgid "Clean Print Heads"
-msgstr ""
-
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:7
-#: ../panels/region/gnome-region-panel-xkbot.c:229
-#: ../panels/sound/gvc-sound-theme-chooser.c:589
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr ""
 
-#. Translators: Description of the printer.
-#: ../panels/printers/printers.ui.h:9
-msgid "Description:"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
 
-#. Translators: This button pauses printer.
-#: ../panels/printers/printers.ui.h:11
-msgid "Disable Printer"
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
 msgstr ""
 
-#. Translators: Pause (hold) selected print job.
-#: ../panels/printers/printers.ui.h:13
-msgid "Hold"
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
 msgstr ""
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:15
-msgid "Location:"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
 msgstr ""
 
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:17
-msgid "Print Test Page"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
 msgstr ""
 
-#. Translators: A widget showing list of print jobs for selected printer.
-#: ../panels/printers/printers.ui.h:19
-msgid "Printer Jobs"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
 
-#. Translators: This shows queue of print jobs.
-#: ../panels/printers/printers.ui.h:21
-msgid "Queue"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
 msgstr ""
 
-#. Translators: Print paused print job.
-#: ../panels/printers/printers.ui.h:23
-msgid "Release"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
 msgstr ""
 
-#. Translators: Users which are allowed to print on this printer.
-#: ../panels/printers/printers.ui.h:25
-msgid "Share with these users:"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:26
-msgid "Show / hide printer's jobs"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
 msgstr ""
 
-#. Translators: Status of the printer.
-#: ../panels/printers/printers.ui.h:28
-msgid "Status:"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:30
-msgid "Supply:"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:31
-msgid "toolbutton1"
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:32
-msgid "toolbutton2"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:1
-msgid "Install languages..."
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:2
-msgid "Keyboard _model:"
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:3
-msgid "Language"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:4
-msgid "Layouts"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:5
-msgid "List of keyboard layouts selected for usage"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:6
-msgid "Move _Down"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:7
-msgid "Move _Up"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:8
-msgid "Move the selected keyboard layout down in the list"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:9
-msgid "Move the selected keyboard layout up in the list"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:10
-msgid "New windows u_se active window's layout"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:11
-msgid "Print a diagram of the selected keyboard layout"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:12
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-msgid "Region and Language"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:13
-msgid "Remove the selected keyboard layout from the list"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:14
-msgid ""
-"Replace the current keyboard layout settings with the\n"
-"default settings"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:16
-msgid "Reset to De_faults"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:17
-msgid "Select a display language"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:18
-msgid "Select a keyboard layout to be added to the list"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:19
-msgid "View and edit keyboard layout options"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:20
-msgid "_Add..."
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:21
-msgid "_Options..."
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:22
-msgid "_Separate layout for each window"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
-msgid "By _country"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
-msgid "By _language"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
-msgid "Choose a Layout"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:4
-msgid "Preview:"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:5
-msgid "_Country:"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:6
-msgid "_Language:"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:7
-msgid "_Variants:"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-model-chooser.ui.h:1
-msgid "Choose a Keyboard Model"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-model-chooser.ui.h:2
-msgid "_Models:"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-model-chooser.ui.h:3
-msgid "_Vendors:"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
-msgid "Keyboard Layout Options"
-msgstr ""
-
-#. TRANSLATORS: device type
-#. TRANSLATORS: AP type
-#: ../panels/region/gnome-region-panel-xkb.c:70
-#: ../panels/network/panel-common.c:65 ../panels/network/panel-common.c:138
-msgid "Unknown"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-xkblt.c:220
-msgid "Layout"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-xkbmc.c:163
-msgid "Vendors"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-xkbmc.c:229
-msgid "Models"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
-msgid "Change your region and language settings"
-msgstr ""
-
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
-msgid "Language;Layout;"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "Disable _touchpad while typing"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-Click Timeout"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Drag and Drop"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "Enable _mouse clicks with touchpad"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Enable h_orizontal scrolling"
-msgstr ""
-
-#. high sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-#: ../panels/universal-access/uap.ui.h:39
-msgid "High"
-msgstr ""
-
-#. large threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-#: ../panels/universal-access/uap.ui.h:48
-msgid "Large"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgid "Locate Pointer"
-msgstr ""
-
-#. low sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Low"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Mouse"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
-msgid "Mouse Orientation"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "Mouse Preferences"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:21
-msgid "Pointer Speed"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:22
-msgid "Scrolling"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:23
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr ""
-
-#. small threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:28
-#: ../panels/universal-access/uap.ui.h:75
-msgid "Small"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:29
-msgid "Thr_eshold:"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:30
-msgid "To test your settings, try to double-click on the face."
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:31
-msgid "Touchpad"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:32
-msgid "Two-_finger scrolling"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:33
-msgid "_Acceleration:"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:34
-msgid "_Disabled"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:35
-msgid "_Edge scrolling"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:36
-msgid "_Left-handed"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:37
-msgid "_Right-handed"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:38
-msgid "_Sensitivity:"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:39
-msgid "_Timeout:"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse and Touchpad"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Set your mouse and touchpad preferences"
-msgstr ""
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:1062
-#: ../panels/network/cc-network-panel.c:1084
-#, c-format
-msgid "%i Mb/s"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:1064
-#, c-format
-msgid "%i Gb/s"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:1082
-#, c-format
-msgid "%i kb/s"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:1739
-msgid "Network proxy"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:1748
-msgid "Set the system proxy settings"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:69
-msgid "Wired"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:73
-msgid "Wireless"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:78
-msgid "Mobile broadband"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:82
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr ""
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:86
-msgid "Mesh"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:142
-msgid "Ad-hoc"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:146
-msgid "Infrastructure"
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:164
-msgid "Status unknown"
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:168
-msgid "Unmanaged"
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:172
-msgid "Unavailable"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:176
-msgid "Disconnected"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:180
-msgid "Preparing connection"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:184
-msgid "Configuring connection"
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:188
-msgid "Authenticating"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:192
-msgid "Getting network address"
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:196
-msgid "Connected"
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:200
-msgid "Failed to connect"
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
 msgstr ""
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-msgid "Network"
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
 msgstr ""
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Network settings"
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
 msgstr ""
 
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid "Network;Wireless;IP;LAN;"
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
 msgstr ""
 
-#: ../panels/network/network.ui.h:1
-msgid "Airplane Mode"
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
 msgstr ""
 
-#: ../panels/network/network.ui.h:2
-msgid "Configuration URL:"
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
 msgstr ""
 
-#: ../panels/network/network.ui.h:3
-msgid "DNS:"
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
 msgstr ""
 
-#: ../panels/network/network.ui.h:4
-msgid "Default Route:"
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
 msgstr ""
 
-#: ../panels/network/network.ui.h:5
-msgid "FTP Proxy:"
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
 msgstr ""
 
-#: ../panels/network/network.ui.h:6
-msgid "Gateway:"
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
 msgstr ""
 
-#: ../panels/network/network.ui.h:7
-msgid "Group Name:"
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
 msgstr ""
 
-#: ../panels/network/network.ui.h:8
-msgid "Group Password:"
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
 msgstr ""
 
-#: ../panels/network/network.ui.h:9
-msgid "HTTP Proxy:"
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
 msgstr ""
 
-#: ../panels/network/network.ui.h:10
-msgid "Hardware Address:"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
 msgstr ""
 
-#: ../panels/network/network.ui.h:11
-msgid "IMEI:"
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
 msgstr ""
 
-#: ../panels/network/network.ui.h:12
-msgid "IP Address:"
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
 msgstr ""
 
-#: ../panels/network/network.ui.h:13
-msgid "IPv4 Address:"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
 msgstr ""
 
-#: ../panels/network/network.ui.h:14
-msgid "IPv6 Address:"
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
 msgstr ""
 
-#: ../panels/network/network.ui.h:15
-msgid "Method:"
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
 msgstr ""
 
-#: ../panels/network/network.ui.h:16
-msgid "Network Name:"
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
 msgstr ""
 
-#: ../panels/network/network.ui.h:17
-msgid "Provider:"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
 msgstr ""
 
-#: ../panels/network/network.ui.h:18
-msgid "Secure HTTP Proxy:"
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
 msgstr ""
 
-#: ../panels/network/network.ui.h:19
-msgid "Security:"
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
 msgstr ""
 
-#: ../panels/network/network.ui.h:20
-msgid "Socks Host:"
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 
-#: ../panels/network/network.ui.h:21
-msgid "Speed:"
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
 msgstr ""
 
-#: ../panels/network/network.ui.h:22
-msgid "Subnet Mask:"
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
 msgstr ""
 
-#: ../panels/network/network.ui.h:23
-#: ../panels/user-accounts/um-lockbutton.c:356
-msgid "Unlock"
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
 msgstr ""
 
-#: ../panels/network/network.ui.h:24
-msgid "Username:"
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
 msgstr ""
 
-#: ../panels/network/network.ui.h:25
-msgctxt "proxy method"
-msgid "Automatic"
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 
-#: ../panels/network/network.ui.h:26
-msgctxt "proxy method"
-msgid "Manual"
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
 msgstr ""
 
-#: ../panels/network/network.ui.h:27
-msgctxt "proxy method"
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+msgid "Seconds"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr ""
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr ""
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr ""
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr ""
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
 msgstr ""
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Power management settings"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
 msgstr ""
 
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid "Power;Sleep;Suspend;Hibernate;"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
 msgstr ""
 
-#: ../panels/power/cc-power-panel.c:151
-msgid "Unknown time"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
 
-#: ../panels/power/cc-power-panel.c:157
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+msgid "Pointer Location"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr ""
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr ""
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr ""
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr ""
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr ""
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr ""
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr ""
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr ""
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/power/cc-power-panel.c:169
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:177
-#, c-format
-msgid "%i %s %i %s"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:178
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/power/cc-power-panel.c:179
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/power/cc-power-panel.c:251
-msgid "Battery charging"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
 msgstr ""
 
-#: ../panels/power/cc-power-panel.c:254
-msgid "Battery discharging"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
 msgstr ""
 
-#: ../panels/power/cc-power-panel.c:265
-msgid "UPS charging"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
 msgstr ""
 
-#: ../panels/power/cc-power-panel.c:268
-msgid "UPS discharging"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:286
-#, c-format
-msgid "%s until charged (%.0lf%%)"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:292
-#, c-format
-msgid "%s until empty (%.0lf%%)"
-msgstr ""
-
-#. TRANSLATORS: %1 is a percentage value. Note: this string is only
-#. * used when we don't have a time value
-#: ../panels/power/cc-power-panel.c:300
-#, c-format
-msgid "%.0lf%% charged"
-msgstr ""
-
-#: ../panels/power/power.ui.h:1 ../panels/screen/screen.ui.h:1
-msgid "1 hour"
-msgstr ""
-
-#: ../panels/power/power.ui.h:2 ../panels/screen/screen.ui.h:3
-msgid "10 minutes"
-msgstr ""
-
-#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr ""
 
-#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:7
-msgid "5 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
 msgstr ""
 
-#: ../panels/power/power.ui.h:5
-msgid "AC power and inactive for:"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
 msgstr ""
 
-#: ../panels/power/power.ui.h:6
-msgid "Ask me"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
 msgstr ""
 
-#: ../panels/power/power.ui.h:7
-msgid "Battery power and inactive for:"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
 msgstr ""
 
-#: ../panels/power/power.ui.h:9
-msgid "Hibernate"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
 msgstr ""
 
-#: ../panels/power/power.ui.h:10
-msgid "Put the computer to sleep when inactive for:"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
 msgstr ""
 
-#: ../panels/power/power.ui.h:11
-msgid "Put the computer to sleep when on:"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
 msgstr ""
 
-#: ../panels/power/power.ui.h:12
-msgid "Shutdown"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
 msgstr ""
 
-#: ../panels/power/power.ui.h:13
-msgid "Suspend"
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
 msgstr ""
 
-#: ../panels/power/power.ui.h:14
-msgid "When power is critically low:"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
 msgstr ""
 
-#: ../panels/power/power.ui.h:15
-msgid "When the power button is pressed:"
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
 msgstr ""
 
-#: ../panels/power/power.ui.h:16
-msgid "When the sleep button is pressed:"
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
 msgstr ""
 
-#. Translators: those are keywords for the brightness and lock control-center panel
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
-msgid "Brightness;Lock;Dim;Blank;"
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
 msgstr ""
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr ""
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr ""
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
 msgid "Screen"
 msgstr ""
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
-msgid "Screen brightness and lock settings"
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:2
-msgid "1 minute"
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:4
-msgid "2 minutes"
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:5
-msgid "3 minutes"
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:8
-msgid "Brightness"
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:9
-msgid "Dim screen to save power"
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:10
-msgid "Don't lock when at home"
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:11
-msgid "Locations..."
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:12 ../panels/user-accounts/um-lockbutton.c:347
-msgid "Lock"
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:13
-msgid "Lock screen after:"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:14
-msgid "Screen turns off"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:15
-msgid "Turn off after:"
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
 msgstr ""
 
-#: ../panels/sound/applet-main.c:49
-msgid "Enable debugging code"
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
 msgstr ""
 
-#: ../panels/sound/applet-main.c:50
-msgid "Version of this application"
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#: ../panels/sound/applet-main.c:62
-msgid " — GNOME Volume Control Applet"
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 
-#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1923
-msgid "Output"
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
 msgstr ""
 
-#: ../panels/sound/gvc-applet.c:278
-msgid "Sound Output Volume"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
 msgstr ""
 
-#: ../panels/sound/gvc-applet.c:282 ../panels/sound/gvc-mixer-dialog.c:1840
-msgid "Input"
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
 msgstr ""
 
-#: ../panels/sound/gvc-applet.c:284
-msgid "Microphone Volume"
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:111
-msgctxt "balance"
-msgid "Left"
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:112
-msgctxt "balance"
-msgid "Right"
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:115
-msgctxt "balance"
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:116
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:119
-msgctxt "balance"
-msgid "Minimum"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:120
-msgctxt "balance"
-msgid "Maximum"
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Balance:"
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:298
-msgid "_Fade:"
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:301
-msgid "_Subwoofer:"
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
 msgstr ""
 
-#: ../panels/sound/gvc-channel-bar.c:602 ../panels/sound/gvc-channel-bar.c:611
-msgctxt "volume"
-msgid "100%"
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
 msgstr ""
 
-#: ../panels/sound/gvc-channel-bar.c:606
-msgctxt "volume"
-msgid "Unamplified"
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
 msgstr ""
 
-#: ../panels/sound/gvc-channel-bar.c:900
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr ""
+
+#: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr ""
 
-#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:1631
-msgid "_Profile:"
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1098
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr ""
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+msgid "Windows Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr ""
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr ""
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1108
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/sound/gvc-mixer-control.c:1406
-msgid "System Sounds"
-msgstr ""
+#~ msgid "audio DVD"
+#~ msgstr "Audio DVD"
 
-#: ../panels/sound/gvc-mixer-dialog.c:317
-#: ../panels/sound/gvc-mixer-dialog.c:618
-msgid "Co_nnector:"
-msgstr ""
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Blank Blu-ray disc"
 
-#: ../panels/sound/gvc-mixer-dialog.c:531
-msgid "Peak detect"
-msgstr ""
+#~ msgid "blank CD disc"
+#~ msgstr "Blank CD disc"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1507
-#: ../panels/sound/gvc-mixer-dialog.c:1719
-#: ../panels/sound/gvc-sound-theme-chooser.c:599
-msgid "Name"
-msgstr ""
+#~ msgid "blank DVD disc"
+#~ msgstr "Blank DVD disc"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1525
-msgid "Device"
-msgstr ""
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Blank HD DVD disc"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1573
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1632
-msgid "Test Speakers"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1763
-msgid "_Output volume: "
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1777
-msgid "Sound Effects"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1784
-msgid "_Alert volume: "
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1797
-msgid "Hardware"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1802
-msgid "C_hoose a device to configure:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1829
-#: ../panels/sound/gvc-mixer-dialog.c:1952
-msgid "Settings for the selected device:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1847
-msgid "_Input volume: "
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1870
-msgid "Input level:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1896
-msgid "C_hoose a device for sound input:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1928
-msgid "C_hoose a device for sound output:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1963
-msgid "Applications"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1967
-msgid "No application is currently playing or recording audio."
-msgstr ""
-
-#: ../panels/sound/gvc-speaker-test.c:221
-msgid "Stop"
-msgstr ""
-
-#: ../panels/sound/gvc-speaker-test.c:221
-#: ../panels/sound/gvc-speaker-test.c:333
-msgid "Test"
-msgstr ""
-
-#: ../panels/sound/gvc-speaker-test.c:229
-msgid "Subwoofer"
-msgstr ""
-
-#: ../panels/sound/gvc-stream-status-icon.c:236
-#, c-format
-msgid "Failed to start Sound Preferences: %s"
-msgstr ""
-
-#: ../panels/sound/gvc-stream-status-icon.c:262
-msgid "_Mute"
-msgstr ""
-
-#: ../panels/sound/gvc-stream-status-icon.c:271
-msgid "_Sound Preferences"
-msgstr ""
-
-#: ../panels/sound/gvc-stream-status-icon.c:455
-msgid "Muted"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:189
-msgid "Built-in"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:459
-#: ../panels/sound/gvc-sound-theme-chooser.c:471
-#: ../panels/sound/gvc-sound-theme-chooser.c:483
-msgid "Sound Preferences"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:462
-#: ../panels/sound/gvc-sound-theme-chooser.c:473
-#: ../panels/sound/gvc-sound-theme-chooser.c:485
-msgid "Testing event sound"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:590
-msgid "From theme"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:778
-msgid "C_hoose an alert sound:"
-msgstr ""
-
-#: ../panels/sound/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr ""
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
-msgid "Show desktop volume control"
-msgstr ""
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
-msgid "Volume Control"
-msgstr ""
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
-msgstr ""
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
-msgid "Change sound volume and sound events"
-msgstr ""
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Sound"
-msgstr ""
-
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr ""
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr ""
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr ""
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr ""
-
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Keyboard;Mouse;a11y;Accessibility;"
-msgstr ""
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
-msgid "Universal Access"
-msgstr ""
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
-msgid "Universal Access Preferences"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:2
-#, no-c-format
-msgid "100%"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:4
-#, no-c-format
-msgid "125%"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:6
-#, no-c-format
-msgid "150%"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:7
-msgid "<span size=\"x-large\">High/Inverse</span>"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:8
-msgid "<span size=\"x-large\">High</span>"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "<span size=\"x-large\">Low</span>"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "<span size=\"x-large\">Normal</span>"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:11
-msgid "Acceptance delay:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Beep when Caps and Num Lock are used"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:13
-msgid "Beep when a key is"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Beep when a key is rejected"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "Beep when a modifer key is pressed"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "Bounce Keys"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Caribou"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "Change contrast:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "Closed Captioning"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Contrast:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Control the pointer using the keypad"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Control the pointer using the video camera."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "Ctrl+Alt+-"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Ctrl+Alt+0"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Ctrl+Alt+4"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Ctrl+Alt+8"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Ctrl+Alt+="
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "D_elay:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "Dasher"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Decrease size:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Disable if two keys are pressed together"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Display"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Display a textual description of speech and sounds"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:35
-msgid "Flash the entire screen"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Flash the window title"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:37
-msgid "GOK"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Hearing"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "High/Inverse"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "HighContrast"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "HighContrastInverse"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:43
-msgid "Hover Click"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Ignores fast duplicate keypresses"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "Increase size:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "Keyboard Settings..."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:49
-msgid "Larger"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:53
-msgid "LowContrast"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:54
-msgid "Mouse Keys"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:55
-msgid "Mouse Settings..."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:56
-msgid "Nomon"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:57
-msgid "None"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:59
-msgid "Off"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:60
-msgid "On"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:61
-msgid "On screen keyboard"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "OnBoard"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "Options..."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:64
-msgid "Pointing and Clicking"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:66
-msgid "Screen Reader"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:67
-msgid "Seeing"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:68
-msgid "Shift+Ctrl+Alt+-"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Shift+Ctrl+Alt+="
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:72
-msgid "Simulated Secondary Click"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:73
-msgid "Slow Keys"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:76
-msgid "Sound Settings..."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:77
-msgid "Sticky Keys"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:78
-msgid "Test flash"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:79
-msgid "Text size:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:80
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:81
-msgid "Trigger a click when the pointer hovers"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:82
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:83
-msgid "Turn on accessibility features from the keyboard"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:84
-msgid "Turn on or off:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:85
-msgid "Type here to test settings"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:86
-msgid "Typing"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:87
-msgid "Typing Assistant"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:88
-msgid "Use a visual indication when an alert sound occurs"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:89
-msgid "Use an alternative form of text input"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:90
-msgid "Video Mouse"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:91
-msgid "Visual Alerts"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:93
-msgid "Zoom in:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:94
-msgid "Zoom out:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:95
-msgid "_Motion threshold:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:96
-msgid "accepted"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:97
-msgid "pressed"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:98
-msgid "rejected"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:426
-msgid "Authentication failed"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:506
-#: ../panels/user-accounts/um-password-dialog.c:375
-#, c-format
-msgid "The new password is too short"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:512
-#, c-format
-msgid "The new password is too simple"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:521
-#, c-format
-msgid "The new password has already been used recently."
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:540
-#, c-format
-msgid "Unknown error"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:78
-msgid "Failed to create user"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:185
-#, c-format
-msgid "A user with the username '%s' already exists"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:189
-#, c-format
-msgid "The username is too long"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:192
-msgid "The username cannot start with a '-'"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:195
-msgid ""
-"The username must consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-type.c:35
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgctxt "Account type"
-msgid "Standard"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-type.c:37
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-msgctxt "Account type"
-msgid "Administrator"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-type.c:39
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgctxt "Account type"
-msgid "Supervised"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:107
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:109
-msgid "The device is already in use."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:111
-msgid "An internal error occurred."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:181
-#: ../panels/user-accounts/um-fingerprint-dialog.c:182
-msgid "Enabled"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:224
-msgid "Delete registered fingerprints?"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:228
-msgid "_Delete Fingerprints"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:235
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:363
-msgid "Done!"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:409
-#: ../panels/user-accounts/um-fingerprint-dialog.c:431
-#, c-format
-msgid "Could not access '%s' device"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:480
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:549
-msgid "Could not access any fingerprint readers"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:550
-msgid "Please contact your system administrator for help."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:587
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Enable Fingerprint Login"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:621
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:629
-#, c-format
-msgid ""
-"Enrolling fingerprints for\n"
-"<b><big>%s</big></b>"
-msgstr ""
-
-#: ../panels/user-accounts/um-language-dialog.c:179
-msgid "Other..."
-msgstr ""
-
-#: ../panels/user-accounts/um-lockbutton.c:365
-msgid "Locked"
-msgstr ""
-
-#: ../panels/user-accounts/um-lockbutton.c:374
-msgid ""
-"Dialog is unlocked.\n"
-"Click to prevent further changes"
-msgstr ""
-
-#: ../panels/user-accounts/um-lockbutton.c:383
-msgid ""
-"Dialog is locked.\n"
-"Click to make changes"
-msgstr ""
-
-#: ../panels/user-accounts/um-lockbutton.c:392
-msgid ""
-"System policy prevents changes.\n"
-"Contact your system administrator"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:179
-msgid "More choices..."
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:285
-msgid "Please choose another password."
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:294
-msgid "Please type your current password again."
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:300
-msgid "Password could not be changed"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:372
-msgid "You need to enter a new password"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:381
-msgid "You need to confirm the password"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:384
-msgid "The passwords do not match"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:390
-msgid "You need to enter your current password"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:393
-msgid "The current password is not correct"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:466
-#: ../panels/user-accounts/um-password-dialog.c:683
-msgctxt "Password strength"
-msgid "Too short"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:469
-#: ../panels/user-accounts/um-password-dialog.c:684
-msgctxt "Password strength"
-msgid "Weak"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:471
-#: ../panels/user-accounts/um-password-dialog.c:685
-msgctxt "Password strength"
-msgid "Fair"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:473
-#: ../panels/user-accounts/um-password-dialog.c:686
-msgctxt "Password strength"
-msgid "Good"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:475
-#: ../panels/user-accounts/um-password-dialog.c:687
-msgctxt "Password strength"
-msgid "Strong"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:514
-msgid "Passwords do not match"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:540
-msgid "Wrong password"
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:97
-#: ../panels/user-accounts/data/language-chooser.ui.h:2
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-msgid "Select"
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:216
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
-msgid "Browse for more pictures"
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:429
-msgid "Disable image"
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:447
-msgid "Take a photo..."
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:465
-msgid "Browse for more pictures..."
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:690
-#, c-format
-msgid "Used by %s"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-manager.c:430
-#, c-format
-msgid "A user with name '%s' already exists."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-manager.c:525
-msgid "This user does not exist."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:359
-msgid "Failed to delete user"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:419
-msgid "You cannot delete your own account."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:428
-#, c-format
-msgid "%s is still logged in"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:432
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:441
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:445
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:448
-msgid "_Delete Files"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:449
-msgid "_Keep Files"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:450
-msgid "_Cancel"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:474
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:483
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:486
-msgctxt "Password mode"
-msgid "None"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:808
-msgid "Failed to contact the accounts service"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:810
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:843
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:881
-msgid "Create a user"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:892
-#: ../panels/user-accounts/um-user-panel.c:1191
-msgid ""
-"To create a user,\n"
-"click the * icon first"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:901
-msgid "Delete the selected user"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:913
-#: ../panels/user-accounts/um-user-panel.c:1196
-msgid ""
-"To delete the selected user,\n"
-"click the * icon first"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1091
-msgid "My Account"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1101
-msgid "Other Accounts"
-msgstr ""
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Add or remove users"
-msgstr ""
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr ""
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "User Accounts"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "Cr_eate"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "Create new account"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "_Account Type:"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-msgid "_Full name:"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-msgid "_Username:"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid ""
-"How to choose a "
-"strong password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-msgid ""
-"<small>This hint may be displayed at the login screen.  It will be visible "
-"to all users of this system.  Do <b>not</b> include the password here.</"
-"small>"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "C_onfirm password:"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "Ch_ange"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Changing password for:"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Choose a generated password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Choose password at next login"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Current _password:"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-msgid "Disable this account"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-msgid "Enable this account"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-msgid "Fair"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-msgid "Log in without a password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid "Set a password now"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-msgid "_Action:"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:15
-msgid "_Hint:"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:16
-msgid "_New password:"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:17
-msgid "_Show password"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-msgid "Browse"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-msgid "Changing photo for:"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-msgid ""
-"Choose a picture that will be shown at the login screen for this account."
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-msgid "Gallery"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-msgid "Take a photograph"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-msgid "Account Information"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account type:"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Automatic Login:"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "Fingerprint Login:"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "Language:"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "Login Options"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "Open"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "Password:"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Restrictions:"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left index finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left little finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left middle finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Left ring finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Left thumb"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Other finger: "
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right index finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-msgid "Right little finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "Right middle finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "Right ring finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "Right thumb"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-
-#: ../shell/control-center.c:47
-msgid "Show the overview"
-msgstr ""
-
-#: ../shell/control-center.c:48
-msgid "Panel to display"
-msgstr ""
-
-#: ../shell/control-center.c:65
-msgid "- System Settings"
-msgstr ""
-
-#: ../shell/control-center.c:72
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
-msgstr ""
-
-#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
-msgid "System Settings"
-msgstr ""
-
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr ""
-
-#: ../shell/shell.ui.h:2
-msgid "_All Settings"
-msgstr ""
+#~ msgid "e-book reader"
+#~ msgstr "E-book reader"

--- a/po/en.po~
+++ b/po/en.po~
@@ -1,0 +1,3195 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2011-01-25 23:52-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../gnome-control-center.schemas.in.h:1
+msgid "Current network location"
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:2
+msgid "More backgrounds URL"
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:3
+msgid "More themes URL"
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:4
+msgid ""
+"Set this to your current location name. This is used to determine the "
+"appropriate network proxy configuration."
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:5
+msgid ""
+"URL for where to get more desktop backgrounds. If set to an empty string the "
+"link will not appear."
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:6
+msgid ""
+"URL for where to get more desktop themes. If set to an empty string the link "
+"will not appear."
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:134
+msgid "Key"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:141
+msgid "Callback"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:147
+msgid "Change set"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:148
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:154
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:160
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:1406
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:1414
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:1536
+msgid "Please select an image."
+msgstr ""
+
+#: ../libgnome-control-center/gconf-property-editor.c:1541
+msgid "_Select"
+msgstr ""
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr ""
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change the background"
+msgstr ""
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;"
+msgstr ""
+
+#: ../panels/background/background.ui.h:1
+msgid "Center"
+msgstr ""
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr ""
+
+#: ../panels/background/background.ui.h:4
+msgid "Fill"
+msgstr ""
+
+#: ../panels/background/background.ui.h:5
+msgid "Scale"
+msgstr ""
+
+#: ../panels/background/background.ui.h:6
+msgid "Span"
+msgstr ""
+
+#: ../panels/background/background.ui.h:7
+msgid "Tile"
+msgstr ""
+
+#: ../panels/background/background.ui.h:8
+#: ../panels/universal-access/uap.ui.h:92
+msgid "Zoom"
+msgstr ""
+
+#: ../panels/background/bg-colors-source.c:44
+msgid "Horizontal Gradient"
+msgstr ""
+
+#: ../panels/background/bg-colors-source.c:45
+msgid "Vertical Gradient"
+msgstr ""
+
+#: ../panels/background/bg-colors-source.c:46
+msgid "Solid Color"
+msgstr ""
+
+#: ../panels/background/cc-background-panel.c:747
+msgid "Wallpapers"
+msgstr ""
+
+#: ../panels/background/cc-background-panel.c:755
+msgid "Pictures Folder"
+msgstr ""
+
+#: ../panels/background/cc-background-panel.c:763
+msgid "Colors & Gradients"
+msgstr ""
+
+#: ../panels/background/cc-background-panel.c:772
+msgid "Flickr"
+msgstr ""
+
+#: ../panels/background/cc-background-panel.c:833
+msgid "Current background"
+msgstr ""
+
+#: ../panels/background/gnome-wp-info.c:59
+msgid "No Desktop Background"
+msgstr ""
+
+#: ../panels/background/gnome-wp-item.c:277
+msgid "multiple sizes"
+msgstr ""
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/gnome-wp-item.c:285
+#, c-format
+msgid "%d × %d"
+msgstr ""
+
+#: ../panels/common/gdm-languages.c:709
+msgid "Unspecified"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "16"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "2010"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "22"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "24-Hour Time"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "45"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid ":"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "AM"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "April"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "August"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "City:"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "December"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "February"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:13
+msgid "January"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "July"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:15
+msgid "June"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "March"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "May"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Network Time"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "November"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "October"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Region:"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "September"
+msgstr ""
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+msgid "Date and Time"
+msgstr ""
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Date and Time preferences panel"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:1
+#: ../panels/display/xrandr-capplet.c:321
+msgid "Left"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:2
+#: ../panels/display/xrandr-capplet.c:484
+msgid "Monitor"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:3
+#: ../panels/display/xrandr-capplet.c:320
+#: ../panels/display/xrandr-capplet.c:359
+#: ../panels/universal-access/uap.ui.h:58
+msgid "Normal"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:4
+msgid "Note: may limit resolution options"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:5
+msgid "R_otation:"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:6
+#: ../panels/display/xrandr-capplet.c:322
+msgid "Right"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:7
+msgid "Upside-down"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:8
+msgid "_Detect Displays"
+msgstr ""
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:10
+msgid "_Mirror displays"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:11
+msgid "_Resolution:"
+msgstr ""
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Change resolution and position of monitors and projectors"
+msgstr ""
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Displays"
+msgstr ""
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:323
+msgid "Upside Down"
+msgstr ""
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../panels/display/xrandr-capplet.c:460
+msgid "Mirror Displays"
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:593
+#, c-format
+msgid "%d x %d (%s)"
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:595
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:1505
+msgid "Drag to change primary display."
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:1563
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:1953
+msgid "%a %R"
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:1955
+msgid "%a %l:%M %p"
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:2240
+msgid "Could not save the monitor configuration"
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:2263
+msgid "Could not get session bus while applying display configuration"
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:2308
+msgid "Could not detect displays"
+msgstr ""
+
+#: ../panels/display/xrandr-capplet.c:2516
+msgid "Could not get screen information"
+msgstr ""
+
+#. translators: This is the type of architecture, for example:
+#. * "64-bit" or "32-bit"
+#: ../panels/info/cc-info-panel.c:247
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:261
+#, c-format
+msgid "%u byte"
+msgid_plural "%u bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/info/cc-info-panel.c:269
+#, c-format
+msgid "%.1f KB"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:274
+#, c-format
+msgid "%.1f MB"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:279
+#, c-format
+msgid "%.1f GB"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:284
+#, c-format
+msgid "%.1f TB"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:289
+#, c-format
+msgid "%.1f PB"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:294
+#, c-format
+msgid "%.1f EB"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:404
+msgid "Unknown model"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:466
+#, c-format
+msgid "Version %s"
+msgstr ""
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+msgid "System Info"
+msgstr ""
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "System Information"
+msgstr ""
+
+#. Translators: those are keywords for the System Information panel
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid "device;system;information;memory;processor;version;"
+msgstr ""
+
+#: ../panels/info/info.ui.h:1
+msgid "Device name:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:2
+msgid "Disk:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:3
+msgid "Memory:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:4
+msgid "More Info"
+msgstr ""
+
+#: ../panels/info/info.ui.h:5
+msgid "OS type:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:7
+msgid "Update Available"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia-key.xml.in.h:1
+msgid "Sound and Media"
+msgstr ""
+
+#: ../panels/keyboard/01-desktop-key.xml.in.h:1
+msgid "Launchers and Actions"
+msgstr ""
+
+#: ../panels/keyboard/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr ""
+
+#: ../panels/keyboard/eggcellrendererkeys.c:164
+#: ../panels/keyboard/eggcellrendererkeys.c:165
+msgid "Accelerator key"
+msgstr ""
+
+#: ../panels/keyboard/eggcellrendererkeys.c:174
+#: ../panels/keyboard/eggcellrendererkeys.c:175
+msgid "Accelerator modifiers"
+msgstr ""
+
+#: ../panels/keyboard/eggcellrendererkeys.c:183
+#: ../panels/keyboard/eggcellrendererkeys.c:184
+msgid "Accelerator keycode"
+msgstr ""
+
+#: ../panels/keyboard/eggcellrendererkeys.c:194
+msgid "Accel Mode"
+msgstr ""
+
+#: ../panels/keyboard/eggcellrendererkeys.c:195
+msgid "The type of accelerator."
+msgstr ""
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/eggcellrendererkeys.c:243
+#: ../panels/keyboard/keyboard-shortcuts.c:1229
+#: ../panels/sound/gvc-mixer-control.c:1091
+#: ../panels/user-accounts/um-fingerprint-dialog.c:177
+#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+msgid "Disabled"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Change keyboard settings"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "Keyboard"
+msgstr ""
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:736
+#: ../panels/keyboard/keyboard-shortcuts.c:1001
+#: ../panels/keyboard/keyboard-shortcuts.c:1633
+#: ../panels/keyboard/keyboard-shortcuts.c:1637
+msgid "Custom Shortcuts"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:848
+msgid "<Unknown Action>"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1255
+msgid "Error saving the new shortcut"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1365
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1395
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1401
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1409
+msgid "_Reassign"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1529
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1587
+msgid "Too many custom shortcuts"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1865
+msgid "Section"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1909
+msgid "Action"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1931
+msgid "Shortcut"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "C_ommand:"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "Cursor Blinking"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "Cursor _blinks in text fields"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Cursor blinks speed"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "Custom Shortcut"
+msgstr ""
+
+#. fast acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "Fast"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "General"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "Key presses _repeat when key is held down"
+msgstr ""
+
+#. long delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+#: ../panels/universal-access/uap.ui.h:51
+msgid "Long"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgid "Repeat Keys"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgid "S_peed:"
+msgstr ""
+
+#. short delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+#: ../panels/mouse/gnome-mouse-properties.ui.h:24
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Short"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Shortcuts"
+msgstr ""
+
+#. slow acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+#: ../panels/mouse/gnome-mouse-properties.ui.h:26
+msgid "Slow"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "_Delay:"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+msgid "_Name:"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+msgid "_Speed:"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:322
+msgid "Ask what to do"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:326 ../panels/power/power.ui.h:8
+msgid "Do nothing"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:330
+msgid "Open folder"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:441
+msgid "Select an application for audio CDs"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:442
+msgid "Select an application for video DVDs"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:443
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:444
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:445
+msgid "Select an application for software CDs"
+msgstr ""
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, except for fixed capitalization. If the shared-mime-info
+#. * translation works for your language, simply leave this untranslated
+#.
+#: ../panels/media/cc-media-panel.c:456
+msgid "audio DVD"
+msgstr "Audio DVD"
+
+#: ../panels/media/cc-media-panel.c:457
+msgid "blank Blu-ray disc"
+msgstr "Blank Blu-ray disc"
+
+#: ../panels/media/cc-media-panel.c:458
+msgid "blank CD disc"
+msgstr "Blank CD disc"
+
+#: ../panels/media/cc-media-panel.c:459
+msgid "blank DVD disc"
+msgstr "Blank DVD disc"
+
+#: ../panels/media/cc-media-panel.c:460
+msgid "blank HD DVD disc"
+msgstr "Blank HD DVD disc"
+
+#: ../panels/media/cc-media-panel.c:461
+msgid "Blu-ray video disc"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:462
+msgid "e-book reader"
+msgstr "E-book reader"
+
+#: ../panels/media/cc-media-panel.c:463
+msgid "HD DVD video disc"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:464
+msgid "Picture CD"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:465
+msgid "Super Video CD"
+msgstr ""
+
+#: ../panels/media/cc-media-panel.c:466
+msgid "Video CD"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:1
+msgid "Acti_on:"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:2
+msgid "CD _audio:"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:3
+msgid "Media and Autorun"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:4
+msgid "Select how media should be handled"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:5
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:6
+msgid "_DVD video:"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:7
+msgid "_Music player:"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:8
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:9
+msgid "_Other Media..."
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:10
+msgid "_Photos:"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:11
+msgid "_Software:"
+msgstr ""
+
+#: ../panels/media/gnome-media-properties.ui.h:12
+msgid "_Type:"
+msgstr ""
+
+#: ../panels/media/gnome-media-panel.desktop.in.in.h:1
+msgid "Configure media and autorun preferences"
+msgstr ""
+
+#: ../panels/media/gnome-media-panel.desktop.in.in.h:2
+msgid "Removable Media"
+msgstr ""
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:210
+msgid "Low on toner"
+msgstr ""
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:212
+msgid "Out of toner"
+msgstr ""
+
+#. Translators: "Developer" like on photo development context
+#: ../panels/printers/cc-printers-panel.c:214
+msgid "Low on developer"
+msgstr ""
+
+#. Translators: "Developer" like on photo development context
+#: ../panels/printers/cc-printers-panel.c:216
+msgid "Out of developer"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:218
+msgid "Low on a marker supply"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:220
+msgid "Out of a marker supply"
+msgstr ""
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:222
+msgid "Open cover"
+msgstr ""
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:224
+msgid "Open door"
+msgstr ""
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:226
+msgid "Low on paper"
+msgstr ""
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:228
+msgid "Out of paper"
+msgstr ""
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:230
+msgid "Offline"
+msgstr ""
+
+#. Translators: Someone has paused the Printer
+#: ../panels/printers/cc-printers-panel.c:232
+msgid "Paused"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:234
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:236
+msgid "Waste receptacle full"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:238
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:240
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:329
+msgid "Idle"
+msgstr ""
+
+#. Translators: Printer's state (jobs are processing)
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/cc-printers-panel.c:333
+#: ../panels/printers/cc-printers-panel.c:726
+msgid "Processing"
+msgstr ""
+
+#. Translators: Printer's state (no jobs can be processed)
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/cc-printers-panel.c:337
+#: ../panels/printers/cc-printers-panel.c:730
+msgid "Stopped"
+msgstr ""
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/cc-printers-panel.c:718
+msgid "Pending"
+msgstr ""
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/cc-printers-panel.c:722
+msgid "Held"
+msgstr ""
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/cc-printers-panel.c:734
+msgid "Canceled"
+msgstr ""
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/cc-printers-panel.c:738
+msgid "Aborted"
+msgstr ""
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/cc-printers-panel.c:742
+msgid "Completed"
+msgstr ""
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/cc-printers-panel.c:837
+msgid "Job Title"
+msgstr ""
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/cc-printers-panel.c:845
+msgid "Job State"
+msgstr ""
+
+#. Translators: Name of column showing names of creators of print jobs
+#: ../panels/printers/cc-printers-panel.c:851
+msgid "User"
+msgstr ""
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/cc-printers-panel.c:857
+msgid "Time"
+msgstr ""
+
+#. Translators: Program cannot connect to DBus' system bus
+#: ../panels/printers/cc-printers-panel.c:1047
+#, c-format
+msgid "Could not connect to system bus: %s"
+msgstr ""
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:1657
+msgid "Test page"
+msgstr ""
+
+#. Translators: Name of job which makes printer to clean its heads
+#: ../panels/printers/cc-printers-panel.c:1665
+msgid "Clean print heads"
+msgstr ""
+
+#. Translators: An error has occured during execution of a CUPS maintenance command
+#: ../panels/printers/cc-printers-panel.c:1670
+msgid "An error has occured during a maintenance command."
+msgstr ""
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:1737
+#, c-format
+msgid "Could not load ui: %s"
+msgstr ""
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Change printer settings"
+msgstr ""
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printers"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:1
+msgid "---"
+msgstr ""
+
+#. Translators: Cancel selected print job.
+#: ../panels/printers/printers.ui.h:3
+#: ../panels/user-accounts/data/language-chooser.ui.h:1
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+msgid "Cancel"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: ../panels/printers/printers.ui.h:5
+msgid "Clean Print Heads"
+msgstr ""
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:7
+#: ../panels/region/gnome-region-panel-xkbot.c:229
+#: ../panels/sound/gvc-sound-theme-chooser.c:589
+msgid "Default"
+msgstr ""
+
+#. Translators: Description of the printer.
+#: ../panels/printers/printers.ui.h:9
+msgid "Description:"
+msgstr ""
+
+#. Translators: This button pauses printer.
+#: ../panels/printers/printers.ui.h:11
+msgid "Disable Printer"
+msgstr ""
+
+#. Translators: Pause (hold) selected print job.
+#: ../panels/printers/printers.ui.h:13
+msgid "Hold"
+msgstr ""
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:15
+msgid "Location:"
+msgstr ""
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:17
+msgid "Print Test Page"
+msgstr ""
+
+#. Translators: A widget showing list of print jobs for selected printer.
+#: ../panels/printers/printers.ui.h:19
+msgid "Printer Jobs"
+msgstr ""
+
+#. Translators: This shows queue of print jobs.
+#: ../panels/printers/printers.ui.h:21
+msgid "Queue"
+msgstr ""
+
+#. Translators: Print paused print job.
+#: ../panels/printers/printers.ui.h:23
+msgid "Release"
+msgstr ""
+
+#. Translators: Users which are allowed to print on this printer.
+#: ../panels/printers/printers.ui.h:25
+msgid "Share with these users:"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:26
+msgid "Show / hide printer's jobs"
+msgstr ""
+
+#. Translators: Status of the printer.
+#: ../panels/printers/printers.ui.h:28
+msgid "Status:"
+msgstr ""
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:30
+msgid "Supply:"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:31
+msgid "toolbutton1"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:32
+msgid "toolbutton2"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:1
+msgid "Install languages..."
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:2
+msgid "Keyboard _model:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:3
+msgid "Language"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:4
+msgid "Layouts"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:5
+msgid "List of keyboard layouts selected for usage"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:6
+msgid "Move _Down"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:7
+msgid "Move _Up"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:8
+msgid "Move the selected keyboard layout down in the list"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:9
+msgid "Move the selected keyboard layout up in the list"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:10
+msgid "New windows u_se active window's layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:11
+msgid "Print a diagram of the selected keyboard layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:12
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Region and Language"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:13
+msgid "Remove the selected keyboard layout from the list"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:14
+msgid ""
+"Replace the current keyboard layout settings with the\n"
+"default settings"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:16
+msgid "Reset to De_faults"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:17
+msgid "Select a display language"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:18
+msgid "Select a keyboard layout to be added to the list"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:19
+msgid "View and edit keyboard layout options"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:20
+msgid "_Add..."
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:21
+msgid "_Options..."
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:22
+msgid "_Separate layout for each window"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
+msgid "By _country"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
+msgid "By _language"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
+msgid "Choose a Layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:4
+msgid "Preview:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:5
+msgid "_Country:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:6
+msgid "_Language:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:7
+msgid "_Variants:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-model-chooser.ui.h:1
+msgid "Choose a Keyboard Model"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-model-chooser.ui.h:2
+msgid "_Models:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-model-chooser.ui.h:3
+msgid "_Vendors:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
+msgid "Keyboard Layout Options"
+msgstr ""
+
+#. TRANSLATORS: device type
+#. TRANSLATORS: AP type
+#: ../panels/region/gnome-region-panel-xkb.c:70
+#: ../panels/network/panel-common.c:65 ../panels/network/panel-common.c:138
+msgid "Unknown"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-xkblt.c:220
+msgid "Layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-xkbmc.c:163
+msgid "Vendors"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-xkbmc.c:229
+msgid "Models"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Change your region and language settings"
+msgstr ""
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
+msgid "Language;Layout;"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "Disable _touchpad while typing"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-Click Timeout"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Drag and Drop"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "Enable _mouse clicks with touchpad"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Enable h_orizontal scrolling"
+msgstr ""
+
+#. high sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+#: ../panels/universal-access/uap.ui.h:39
+msgid "High"
+msgstr ""
+
+#. large threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Large"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgid "Locate Pointer"
+msgstr ""
+
+#. low sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Low"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Mouse"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+msgid "Mouse Orientation"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "Mouse Preferences"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:21
+msgid "Pointer Speed"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:22
+msgid "Scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:23
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr ""
+
+#. small threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:28
+#: ../panels/universal-access/uap.ui.h:75
+msgid "Small"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:29
+msgid "Thr_eshold:"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:30
+msgid "To test your settings, try to double-click on the face."
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:31
+msgid "Touchpad"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:32
+msgid "Two-_finger scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:33
+msgid "_Acceleration:"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:34
+msgid "_Disabled"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:35
+msgid "_Edge scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:36
+msgid "_Left-handed"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:37
+msgid "_Right-handed"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:38
+msgid "_Sensitivity:"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:39
+msgid "_Timeout:"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse and Touchpad"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Set your mouse and touchpad preferences"
+msgstr ""
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:1062
+#: ../panels/network/cc-network-panel.c:1084
+#, c-format
+msgid "%i Mb/s"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:1064
+#, c-format
+msgid "%i Gb/s"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:1082
+#, c-format
+msgid "%i kb/s"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:1739
+msgid "Network proxy"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:1748
+msgid "Set the system proxy settings"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:69
+msgid "Wired"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:73
+msgid "Wireless"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:78
+msgid "Mobile broadband"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:82
+msgid "Bluetooth"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:86
+msgid "Mesh"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:142
+msgid "Ad-hoc"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:146
+msgid "Infrastructure"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:164
+msgid "Status unknown"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:168
+msgid "Unmanaged"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:172
+msgid "Unavailable"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:176
+msgid "Disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:180
+msgid "Preparing connection"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:184
+msgid "Configuring connection"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:188
+msgid "Authenticating"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:192
+msgid "Getting network address"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:196
+msgid "Connected"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:200
+msgid "Failed to connect"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+msgid "Network"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Network settings"
+msgstr ""
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid "Network;Wireless;IP;LAN;"
+msgstr ""
+
+#: ../panels/network/network.ui.h:1
+msgid "Airplane Mode"
+msgstr ""
+
+#: ../panels/network/network.ui.h:2
+msgid "Configuration URL:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:3
+msgid "DNS:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:4
+msgid "Default Route:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:5
+msgid "FTP Proxy:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:6
+msgid "Gateway:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:7
+msgid "Group Name:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:8
+msgid "Group Password:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:9
+msgid "HTTP Proxy:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:10
+msgid "Hardware Address:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:11
+msgid "IMEI:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:12
+msgid "IP Address:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:13
+msgid "IPv4 Address:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:14
+msgid "IPv6 Address:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:15
+msgid "Method:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:16
+msgid "Network Name:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:17
+msgid "Provider:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:18
+msgid "Secure HTTP Proxy:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:19
+msgid "Security:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:20
+msgid "Socks Host:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:21
+msgid "Speed:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:22
+msgid "Subnet Mask:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:23
+#: ../panels/user-accounts/um-lockbutton.c:356
+msgid "Unlock"
+msgstr ""
+
+#: ../panels/network/network.ui.h:24
+msgid "Username:"
+msgstr ""
+
+#: ../panels/network/network.ui.h:25
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr ""
+
+#: ../panels/network/network.ui.h:26
+msgctxt "proxy method"
+msgid "Manual"
+msgstr ""
+
+#: ../panels/network/network.ui.h:27
+msgctxt "proxy method"
+msgid "None"
+msgstr ""
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr ""
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Power management settings"
+msgstr ""
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid "Power;Sleep;Suspend;Hibernate;"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:151
+msgid "Unknown time"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:157
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/power/cc-power-panel.c:169
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:177
+#, c-format
+msgid "%i %s %i %s"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:178
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/power/cc-power-panel.c:179
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/power/cc-power-panel.c:251
+msgid "Battery charging"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:254
+msgid "Battery discharging"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:265
+msgid "UPS charging"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:268
+msgid "UPS discharging"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:286
+#, c-format
+msgid "%s until charged (%.0lf%%)"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:292
+#, c-format
+msgid "%s until empty (%.0lf%%)"
+msgstr ""
+
+#. TRANSLATORS: %1 is a percentage value. Note: this string is only
+#. * used when we don't have a time value
+#: ../panels/power/cc-power-panel.c:300
+#, c-format
+msgid "%.0lf%% charged"
+msgstr ""
+
+#: ../panels/power/power.ui.h:1 ../panels/screen/screen.ui.h:1
+msgid "1 hour"
+msgstr ""
+
+#: ../panels/power/power.ui.h:2 ../panels/screen/screen.ui.h:3
+msgid "10 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
+msgid "30 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:7
+msgid "5 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:5
+msgid "AC power and inactive for:"
+msgstr ""
+
+#: ../panels/power/power.ui.h:6
+msgid "Ask me"
+msgstr ""
+
+#: ../panels/power/power.ui.h:7
+msgid "Battery power and inactive for:"
+msgstr ""
+
+#: ../panels/power/power.ui.h:9
+msgid "Hibernate"
+msgstr ""
+
+#: ../panels/power/power.ui.h:10
+msgid "Put the computer to sleep when inactive for:"
+msgstr ""
+
+#: ../panels/power/power.ui.h:11
+msgid "Put the computer to sleep when on:"
+msgstr ""
+
+#: ../panels/power/power.ui.h:12
+msgid "Shutdown"
+msgstr ""
+
+#: ../panels/power/power.ui.h:13
+msgid "Suspend"
+msgstr ""
+
+#: ../panels/power/power.ui.h:14
+msgid "When power is critically low:"
+msgstr ""
+
+#: ../panels/power/power.ui.h:15
+msgid "When the power button is pressed:"
+msgstr ""
+
+#: ../panels/power/power.ui.h:16
+msgid "When the sleep button is pressed:"
+msgstr ""
+
+#. Translators: those are keywords for the brightness and lock control-center panel
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
+msgid "Brightness;Lock;Dim;Blank;"
+msgstr ""
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
+msgid "Screen"
+msgstr ""
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
+msgid "Screen brightness and lock settings"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:2
+msgid "1 minute"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:4
+msgid "2 minutes"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:5
+msgid "3 minutes"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:8
+msgid "Brightness"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:9
+msgid "Dim screen to save power"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:10
+msgid "Don't lock when at home"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:11
+msgid "Locations..."
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:12 ../panels/user-accounts/um-lockbutton.c:347
+msgid "Lock"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:13
+msgid "Lock screen after:"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:14
+msgid "Screen turns off"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:15
+msgid "Turn off after:"
+msgstr ""
+
+#: ../panels/sound/applet-main.c:49
+msgid "Enable debugging code"
+msgstr ""
+
+#: ../panels/sound/applet-main.c:50
+msgid "Version of this application"
+msgstr ""
+
+#: ../panels/sound/applet-main.c:62
+msgid " — GNOME Volume Control Applet"
+msgstr ""
+
+#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1923
+msgid "Output"
+msgstr ""
+
+#: ../panels/sound/gvc-applet.c:278
+msgid "Sound Output Volume"
+msgstr ""
+
+#: ../panels/sound/gvc-applet.c:282 ../panels/sound/gvc-mixer-dialog.c:1840
+msgid "Input"
+msgstr ""
+
+#: ../panels/sound/gvc-applet.c:284
+msgid "Microphone Volume"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:111
+msgctxt "balance"
+msgid "Left"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:112
+msgctxt "balance"
+msgid "Right"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:115
+msgctxt "balance"
+msgid "Rear"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:116
+msgctxt "balance"
+msgid "Front"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:119
+msgctxt "balance"
+msgid "Minimum"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:120
+msgctxt "balance"
+msgid "Maximum"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Balance:"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:298
+msgid "_Fade:"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:301
+msgid "_Subwoofer:"
+msgstr ""
+
+#: ../panels/sound/gvc-channel-bar.c:602 ../panels/sound/gvc-channel-bar.c:611
+msgctxt "volume"
+msgid "100%"
+msgstr ""
+
+#: ../panels/sound/gvc-channel-bar.c:606
+msgctxt "volume"
+msgid "Unamplified"
+msgstr ""
+
+#: ../panels/sound/gvc-channel-bar.c:900
+msgid "Mute"
+msgstr ""
+
+#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:1631
+msgid "_Profile:"
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1098
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1108
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/sound/gvc-mixer-control.c:1406
+msgid "System Sounds"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:317
+#: ../panels/sound/gvc-mixer-dialog.c:618
+msgid "Co_nnector:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:531
+msgid "Peak detect"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1507
+#: ../panels/sound/gvc-mixer-dialog.c:1719
+#: ../panels/sound/gvc-sound-theme-chooser.c:599
+msgid "Name"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1525
+msgid "Device"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1573
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1632
+msgid "Test Speakers"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1763
+msgid "_Output volume: "
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1777
+msgid "Sound Effects"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1784
+msgid "_Alert volume: "
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1797
+msgid "Hardware"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1802
+msgid "C_hoose a device to configure:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1829
+#: ../panels/sound/gvc-mixer-dialog.c:1952
+msgid "Settings for the selected device:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1847
+msgid "_Input volume: "
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1870
+msgid "Input level:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1896
+msgid "C_hoose a device for sound input:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1928
+msgid "C_hoose a device for sound output:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1963
+msgid "Applications"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1967
+msgid "No application is currently playing or recording audio."
+msgstr ""
+
+#: ../panels/sound/gvc-speaker-test.c:221
+msgid "Stop"
+msgstr ""
+
+#: ../panels/sound/gvc-speaker-test.c:221
+#: ../panels/sound/gvc-speaker-test.c:333
+msgid "Test"
+msgstr ""
+
+#: ../panels/sound/gvc-speaker-test.c:229
+msgid "Subwoofer"
+msgstr ""
+
+#: ../panels/sound/gvc-stream-status-icon.c:236
+#, c-format
+msgid "Failed to start Sound Preferences: %s"
+msgstr ""
+
+#: ../panels/sound/gvc-stream-status-icon.c:262
+msgid "_Mute"
+msgstr ""
+
+#: ../panels/sound/gvc-stream-status-icon.c:271
+msgid "_Sound Preferences"
+msgstr ""
+
+#: ../panels/sound/gvc-stream-status-icon.c:455
+msgid "Muted"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:189
+msgid "Built-in"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:459
+#: ../panels/sound/gvc-sound-theme-chooser.c:471
+#: ../panels/sound/gvc-sound-theme-chooser.c:483
+msgid "Sound Preferences"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:462
+#: ../panels/sound/gvc-sound-theme-chooser.c:473
+#: ../panels/sound/gvc-sound-theme-chooser.c:485
+msgid "Testing event sound"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:590
+msgid "From theme"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:778
+msgid "C_hoose an alert sound:"
+msgstr ""
+
+#: ../panels/sound/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr ""
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
+msgid "Show desktop volume control"
+msgstr ""
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
+msgid "Volume Control"
+msgstr ""
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+msgstr ""
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
+msgid "Change sound volume and sound events"
+msgstr ""
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Sound"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr ""
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Keyboard;Mouse;a11y;Accessibility;"
+msgstr ""
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
+msgid "Universal Access"
+msgstr ""
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid "Universal Access Preferences"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:2
+#, no-c-format
+msgid "100%"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:4
+#, no-c-format
+msgid "125%"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:6
+#, no-c-format
+msgid "150%"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "<span size=\"x-large\">High/Inverse</span>"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "<span size=\"x-large\">High</span>"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "<span size=\"x-large\">Low</span>"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "<span size=\"x-large\">Normal</span>"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Acceptance delay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Beep when Caps and Num Lock are used"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "Beep when a key is"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Beep when a key is rejected"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "Beep when a modifer key is pressed"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "Bounce Keys"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Caribou"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "Change contrast:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "Closed Captioning"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Contrast:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Control the pointer using the keypad"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Control the pointer using the video camera."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "Ctrl+Alt+-"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Ctrl+Alt+0"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Ctrl+Alt+4"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Ctrl+Alt+8"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Ctrl+Alt+="
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "D_elay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "Dasher"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Decrease size:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Disable if two keys are pressed together"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Display"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Display a textual description of speech and sounds"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:35
+msgid "Flash the entire screen"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Flash the window title"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:37
+msgid "GOK"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Hearing"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "High/Inverse"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "HighContrast"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "HighContrastInverse"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:43
+msgid "Hover Click"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "Increase size:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "Keyboard Settings..."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Larger"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:53
+msgid "LowContrast"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "Mouse Keys"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Mouse Settings..."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "Nomon"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:57
+msgid "None"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Off"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:60
+msgid "On"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:61
+msgid "On screen keyboard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "OnBoard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Options..."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "Pointing and Clicking"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:66
+msgid "Screen Reader"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:67
+msgid "Seeing"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Shift+Ctrl+Alt+-"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Shift+Ctrl+Alt+="
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "Simulated Secondary Click"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:73
+msgid "Slow Keys"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:76
+msgid "Sound Settings..."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:77
+msgid "Sticky Keys"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:78
+msgid "Test flash"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:79
+msgid "Text size:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:80
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:81
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:82
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:83
+msgid "Turn on accessibility features from the keyboard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:84
+msgid "Turn on or off:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:85
+msgid "Type here to test settings"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:86
+msgid "Typing"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:87
+msgid "Typing Assistant"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:88
+msgid "Use a visual indication when an alert sound occurs"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:89
+msgid "Use an alternative form of text input"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:90
+msgid "Video Mouse"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:91
+msgid "Visual Alerts"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:93
+msgid "Zoom in:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:94
+msgid "Zoom out:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:95
+msgid "_Motion threshold:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:96
+msgid "accepted"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:97
+msgid "pressed"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:98
+msgid "rejected"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:426
+msgid "Authentication failed"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:506
+#: ../panels/user-accounts/um-password-dialog.c:375
+#, c-format
+msgid "The new password is too short"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:512
+#, c-format
+msgid "The new password is too simple"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:521
+#, c-format
+msgid "The new password has already been used recently."
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:540
+#, c-format
+msgid "Unknown error"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:78
+msgid "Failed to create user"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:185
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:189
+#, c-format
+msgid "The username is too long"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:192
+msgid "The username cannot start with a '-'"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:195
+msgid ""
+"The username must consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-type.c:35
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgctxt "Account type"
+msgid "Standard"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-type.c:37
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+msgctxt "Account type"
+msgid "Administrator"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-type.c:39
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgctxt "Account type"
+msgid "Supervised"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:107
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:109
+msgid "The device is already in use."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:111
+msgid "An internal error occurred."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:181
+#: ../panels/user-accounts/um-fingerprint-dialog.c:182
+msgid "Enabled"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:224
+msgid "Delete registered fingerprints?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:228
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:235
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:363
+msgid "Done!"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:409
+#: ../panels/user-accounts/um-fingerprint-dialog.c:431
+#, c-format
+msgid "Could not access '%s' device"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:480
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:549
+msgid "Could not access any fingerprint readers"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:550
+msgid "Please contact your system administrator for help."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:587
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Enable Fingerprint Login"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:621
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:629
+#, c-format
+msgid ""
+"Enrolling fingerprints for\n"
+"<b><big>%s</big></b>"
+msgstr ""
+
+#: ../panels/user-accounts/um-language-dialog.c:179
+msgid "Other..."
+msgstr ""
+
+#: ../panels/user-accounts/um-lockbutton.c:365
+msgid "Locked"
+msgstr ""
+
+#: ../panels/user-accounts/um-lockbutton.c:374
+msgid ""
+"Dialog is unlocked.\n"
+"Click to prevent further changes"
+msgstr ""
+
+#: ../panels/user-accounts/um-lockbutton.c:383
+msgid ""
+"Dialog is locked.\n"
+"Click to make changes"
+msgstr ""
+
+#: ../panels/user-accounts/um-lockbutton.c:392
+msgid ""
+"System policy prevents changes.\n"
+"Contact your system administrator"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:179
+msgid "More choices..."
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:285
+msgid "Please choose another password."
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:294
+msgid "Please type your current password again."
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:300
+msgid "Password could not be changed"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:372
+msgid "You need to enter a new password"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:381
+msgid "You need to confirm the password"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:384
+msgid "The passwords do not match"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:390
+msgid "You need to enter your current password"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:393
+msgid "The current password is not correct"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:466
+#: ../panels/user-accounts/um-password-dialog.c:683
+msgctxt "Password strength"
+msgid "Too short"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:469
+#: ../panels/user-accounts/um-password-dialog.c:684
+msgctxt "Password strength"
+msgid "Weak"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:471
+#: ../panels/user-accounts/um-password-dialog.c:685
+msgctxt "Password strength"
+msgid "Fair"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:473
+#: ../panels/user-accounts/um-password-dialog.c:686
+msgctxt "Password strength"
+msgid "Good"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:475
+#: ../panels/user-accounts/um-password-dialog.c:687
+msgctxt "Password strength"
+msgid "Strong"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:514
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:540
+msgid "Wrong password"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:97
+#: ../panels/user-accounts/data/language-chooser.ui.h:2
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+msgid "Select"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:216
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+msgid "Browse for more pictures"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:429
+msgid "Disable image"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:447
+msgid "Take a photo..."
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:465
+msgid "Browse for more pictures..."
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:690
+#, c-format
+msgid "Used by %s"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-manager.c:430
+#, c-format
+msgid "A user with name '%s' already exists."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-manager.c:525
+msgid "This user does not exist."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:359
+msgid "Failed to delete user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:419
+msgid "You cannot delete your own account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:428
+#, c-format
+msgid "%s is still logged in"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:432
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:441
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:445
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:448
+msgid "_Delete Files"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:449
+msgid "_Keep Files"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:450
+msgid "_Cancel"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:474
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:483
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:486
+msgctxt "Password mode"
+msgid "None"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:808
+msgid "Failed to contact the accounts service"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:810
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:843
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:881
+msgid "Create a user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:892
+#: ../panels/user-accounts/um-user-panel.c:1191
+msgid ""
+"To create a user,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:901
+msgid "Delete the selected user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:913
+#: ../panels/user-accounts/um-user-panel.c:1196
+msgid ""
+"To delete the selected user,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1091
+msgid "My Account"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1101
+msgid "Other Accounts"
+msgstr ""
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Add or remove users"
+msgstr ""
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr ""
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "User Accounts"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "Cr_eate"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "Create new account"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "_Account Type:"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+msgid "_Full name:"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+msgid "_Username:"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid ""
+"How to choose a "
+"strong password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+msgid ""
+"<small>This hint may be displayed at the login screen.  It will be visible "
+"to all users of this system.  Do <b>not</b> include the password here.</"
+"small>"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "C_onfirm password:"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "Ch_ange"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Changing password for:"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Choose a generated password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Choose password at next login"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Current _password:"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+msgid "Disable this account"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+msgid "Enable this account"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+msgid "Fair"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+msgid "Log in without a password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid "Set a password now"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+msgid "_Action:"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:15
+msgid "_Hint:"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:16
+msgid "_New password:"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:17
+msgid "_Show password"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+msgid "Browse"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+msgid "Changing photo for:"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+msgid ""
+"Choose a picture that will be shown at the login screen for this account."
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+msgid "Gallery"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+msgid "Take a photograph"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+msgid "Account Information"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account type:"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Automatic Login:"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "Fingerprint Login:"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "Language:"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "Login Options"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "Open"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "Password:"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Restrictions:"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left index finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left little finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left middle finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Left ring finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Left thumb"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Other finger: "
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right index finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+msgid "Right little finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "Right middle finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "Right ring finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "Right thumb"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+
+#: ../shell/control-center.c:47
+msgid "Show the overview"
+msgstr ""
+
+#: ../shell/control-center.c:48
+msgid "Panel to display"
+msgstr ""
+
+#: ../shell/control-center.c:65
+msgid "- System Settings"
+msgstr ""
+
+#: ../shell/control-center.c:72
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
+msgid "System Settings"
+msgstr ""
+
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr ""
+
+#: ../shell/shell.ui.h:2
+msgid "_All Settings"
+msgstr ""

--- a/po/en@shaw.po
+++ b/po/en@shaw.po
@@ -4,9 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&component=general\n"
-"POT-Creation-Date: 2010-05-12 22:49+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2010-05-18 10:04 -0400\n"
 "Last-Translator: Thomas Thurman <tthurman@gnome.org>\n"
 "Language-Team: Shavian <ubuntu-l10n-en-shaw@launchpad.net>\n"
@@ -16,3782 +15,7515 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n!=1;\n"
 
-#: ../gnome-control-center.schemas.in.h:1
-msgid "Current network location"
-msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 𐑯𐑧𐑑𐑢𐑻𐑒 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
+msgstr "_𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯 𐑓𐑪𐑯𐑑:"
 
-#: ../gnome-control-center.schemas.in.h:2
-msgid "More backgrounds URL"
-msgstr "𐑥𐑹 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛𐑟 URL"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "- ·𐑜𐑯𐑴𐑥 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
 
-#: ../gnome-control-center.schemas.in.h:3
-msgid "More themes URL"
-msgstr "𐑥𐑹 𐑔𐑰𐑥𐑟 URL"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "𐑦𐑯𐑕𐑑𐑷𐑤𐑛"
 
-#: ../gnome-control-center.schemas.in.h:4
-msgid ""
-"Set this to your current location name. This is used to determine the "
-"appropriate network proxy configuration."
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
 msgstr ""
-"𐑕𐑧𐑑 𐑞𐑦𐑕 𐑑 𐑿𐑼 𐑒𐑳𐑮𐑩𐑯𐑑 𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑯𐑱𐑥. 𐑞𐑦𐑕 𐑦𐑟 𐑿𐑟𐑛 𐑑 𐑛𐑦𐑑𐑻𐑥𐑦𐑯 𐑞 𐑩𐑐𐑮𐑴𐑐𐑮𐑦𐑩𐑑 𐑯𐑧𐑑𐑢𐑻𐑒 "
-"𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯."
 
-#: ../gnome-control-center.schemas.in.h:5
-msgid ""
-"URL for where to get more desktop backgrounds. If set to an empty string the "
-"link will not appear."
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "𐑕𐑻𐑗"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
-"URL 𐑓𐑹 𐑢𐑺 𐑑 𐑜𐑧𐑑 𐑥𐑹 𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛𐑟. 𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑩𐑯 𐑧𐑥𐑐𐑑𐑦 𐑕𐑑𐑮𐑦𐑙 𐑞 𐑤𐑦𐑙𐑒 𐑢𐑦𐑤 𐑯𐑪𐑑 "
-"𐑩𐑐𐑽."
 
-#: ../gnome-control-center.schemas.in.h:6
-msgid ""
-"URL for where to get more desktop themes. If set to an empty string the link "
-"will not appear."
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "𐑤𐑴𐑒𐑱𐑖𐑩𐑯:"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "𐑖𐑴 𐑣𐑧𐑤𐑐 𐑪𐑐𐑖𐑩𐑯𐑟"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
-"URL 𐑓𐑹 𐑢𐑺 𐑑 𐑜𐑧𐑑 𐑥𐑹 𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑔𐑰𐑥𐑟. 𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑩𐑯 𐑧𐑥𐑐𐑑𐑦 𐑕𐑑𐑮𐑦𐑙 𐑞 𐑤𐑦𐑙𐑒 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑩𐑐𐑽."
 
-#: ../capplets/about-me/eel-alert-dialog.c:110
-msgid "Image/label border"
-msgstr "𐑦𐑥𐑦𐑡/𐑤𐑱𐑚𐑩𐑤 𐑚𐑹𐑛𐑼"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:111
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "𐑢𐑦𐑛𐑔 𐑝 𐑚𐑹𐑛𐑼 𐑼𐑬𐑯𐑛 𐑞 𐑤𐑱𐑚𐑩𐑤 𐑯 𐑦𐑥𐑦𐑡 𐑦𐑯 𐑞 𐑩𐑤𐑻𐑑 𐑛𐑲𐑩𐑤𐑪𐑜"
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:120
-msgid "Alert Type"
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "𐑨𐑛 𐑢𐑪𐑤𐑐𐑱𐑐𐑻"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "𐑕𐑬𐑯𐑛"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "_𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑯𐑱𐑥:"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "𐑯𐑴 𐑥𐑨𐑗𐑩𐑟 𐑓𐑬𐑯𐑛."
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
 msgstr "𐑩𐑤𐑻𐑑 𐑑𐑲𐑐"
 
-#: ../capplets/about-me/eel-alert-dialog.c:121
-msgid "The type of alert"
-msgstr "𐑞 𐑑𐑲𐑐 𐑝 𐑩𐑤𐑻𐑑"
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:129
-msgid "Alert Buttons"
-msgstr "𐑩𐑤𐑻𐑑 𐑚𐑳𐑑𐑩𐑯𐑟"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:130
-msgid "The buttons shown in the alert dialog"
-msgstr "𐑞 𐑚𐑳𐑑𐑩𐑯𐑟 𐑖𐑴𐑯 𐑦𐑯 𐑞 𐑩𐑤𐑻𐑑 𐑛𐑲𐑩𐑤𐑪𐑜"
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:194
-msgid "Show more _details"
-msgstr "𐑖𐑴 𐑥𐑹 _𐑛𐑰𐑑𐑱𐑤𐑟"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "_𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯 𐑓𐑪𐑯𐑑:"
 
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Place your left thumb on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Swipe your left thumb on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Place your left index finger on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>𐑴𐑐𐑩𐑯</b>"
 
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Swipe your left index finger on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Place your left middle finger on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Swipe your left middle finger on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Place your left ring finger on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "𐑕𐑑𐑲𐑤:"
 
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Swipe your left ring finger on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "𐑛𐑦𐑓𐑷𐑤𐑑"
 
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Place your left little finger on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Swipe your left little finger on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
 
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Place your right thumb on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Swipe your right thumb on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "𐑩𐑐𐑽𐑩𐑯𐑕"
 
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Place your right index finger on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Swipe your right index finger on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Place your right middle finger on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Swipe your right middle finger on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Place your right ring finger on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Swipe your right ring finger on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Place your right little finger on %s"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Swipe your right little finger on %s"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:72
-#: ../capplets/about-me/fingerprint-strings.h:98
-msgid "Place your finger on the reader again"
-msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 𐑞 𐑮𐑰𐑛𐑼 𐑩𐑜𐑱𐑯"
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:74
-#: ../capplets/about-me/fingerprint-strings.h:100
-msgid "Swipe your finger again"
-msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑩𐑜𐑱𐑯"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:77
-#: ../capplets/about-me/fingerprint-strings.h:103
-msgid "Swipe was too short, try again"
-msgstr "𐑕𐑢𐑲𐑐 𐑢𐑪𐑟 𐑑𐑵 𐑖𐑹𐑑, 𐑑𐑮𐑲 𐑩𐑜𐑱𐑯"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:79
-#: ../capplets/about-me/fingerprint-strings.h:105
-msgid "Your finger was not centered, try swiping your finger again"
-msgstr "𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑢𐑪𐑟 𐑯𐑪𐑑 𐑕𐑧𐑯𐑑𐑼𐑛, 𐑑𐑮𐑲 𐑕𐑢𐑲𐑐𐑦𐑙 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑩𐑜𐑱𐑯"
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:81
-#: ../capplets/about-me/fingerprint-strings.h:107
-msgid "Remove your finger, and try swiping your finger again"
-msgstr "𐑮𐑦𐑥𐑵𐑝 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼, 𐑯 𐑑𐑮𐑲 𐑕𐑢𐑲𐑐𐑦𐑙 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑩𐑜𐑱𐑯"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:716
-msgid "Select Image"
-msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑦𐑥𐑦𐑡"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:718
-msgid "No Image"
-msgstr "𐑯𐑴 𐑦𐑥𐑦𐑡"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:746
-#: ../capplets/appearance/appearance-desktop.c:658
-msgid "Images"
-msgstr "𐑦𐑥𐑦𐑡𐑩𐑟"
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:750
-#: ../capplets/appearance/theme-installer.c:766
-msgid "All Files"
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
+msgstr "𐑕𐑑𐑸𐑑 %s"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "𐑛𐑳𐑯!"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "𐑤𐑸𐑡 𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "𐑓𐑲𐑤𐑯𐑱𐑥"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "𐑓𐑲𐑤𐑯𐑱𐑥"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "𐑒𐑪𐑐𐑦𐑦𐑙 𐑓𐑲𐑤𐑟"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
 msgstr "𐑷𐑤 𐑓𐑲𐑤𐑟"
 
-#: ../capplets/about-me/gnome-about-me.c:890
+#: panels/color/cc-color-panel.ui:373
 msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
 msgstr ""
-"𐑞𐑺 𐑢𐑪𐑟 𐑩𐑯 𐑻𐑼 𐑢𐑲𐑤 𐑑𐑮𐑲𐑦𐑙 𐑑 𐑜𐑧𐑑 𐑞 𐑩𐑛𐑮𐑧𐑕𐑚𐑫𐑒 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯\n"
-"·𐑧𐑝𐑩𐑤𐑵𐑖𐑩𐑯 𐑛𐑱𐑑𐑩 𐑕𐑻𐑝𐑼 𐑒𐑭𐑯𐑑 𐑣𐑨𐑯𐑛𐑩𐑤 𐑞 𐑐𐑮𐑴𐑑𐑩𐑒𐑪𐑤"
 
-#: ../capplets/about-me/gnome-about-me.c:911
-msgid "Unable to open address book"
-msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑴𐑐𐑩𐑯 𐑩𐑛𐑮𐑧𐑕 𐑚𐑫𐑒"
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:934
-#, c-format
-msgid "About %s"
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_𐑨𐑛..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "_𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "𐑮𐑦𐑥𐑵𐑝 𐑓𐑮𐑪𐑥 𐑓𐑱𐑝𐑼𐑦𐑑𐑕"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "𐑣𐑲"
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "_𐑥𐑰𐑛𐑦𐑩𐑥"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#: panels/color/cc-color-panel.ui:640
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "𐑤𐑴"
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "𐑒𐑳𐑤𐑼𐑟"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑦𐑥𐑦𐑡"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "𐑯𐑴 𐑥𐑨𐑗𐑩𐑟 𐑓𐑬𐑯𐑛."
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_𐑑𐑲𐑥𐑬𐑑:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "𐑕𐑻𐑗"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "_𐑛𐑦𐑤𐑱:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "𐑕𐑧𐑒𐑩𐑯𐑛𐑟"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_𐑒𐑨𐑤𐑩𐑯𐑛𐑼:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "·𐑒𐑱𐑥𐑱𐑤"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "_𐑒𐑨𐑤𐑩𐑯𐑛𐑼:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "- ·𐑜𐑯𐑴𐑥 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "𐑴𐑐𐑩𐑯 𐑢𐑦𐑞 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "𐑩𐑐𐑤𐑲 𐑓𐑪𐑯𐑑"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "𐑥𐑳𐑤𐑑𐑦𐑐𐑩𐑤 𐑕𐑲𐑟𐑩𐑟"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+#, fuzzy
+msgid "Mirror"
+msgstr "𐑥𐑦𐑮𐑼 𐑕𐑒𐑮𐑰𐑯𐑟"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "𐑥𐑬𐑕 𐑪𐑮𐑦𐑩𐑯𐑑𐑱𐑖𐑩𐑯"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_𐑮𐑧𐑟𐑩𐑤𐑵𐑖𐑩𐑯:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "_𐑮𐑰𐑓𐑮𐑧𐑖 𐑮𐑱𐑑:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "𐑕𐑒𐑱𐑤"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "𐑓𐑮𐑨𐑒𐑖𐑩𐑯 𐑒𐑩𐑥𐑐𐑤𐑰𐑑𐑩𐑛"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "𐑓𐑦𐑤𐑑𐑼"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "𐑓𐑮𐑪𐑥 URI"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "𐑯𐑱𐑥:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "𐑑𐑲𐑐:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "·𐑜𐑯𐑴𐑥 𐑑𐑻𐑥𐑦𐑯𐑩𐑤"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "𐑢𐑦𐑯𐑛𐑴𐑟"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "𐑓𐑲𐑤𐑯𐑱𐑥"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "𐑮𐑰𐑯𐑱𐑥..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
 msgstr "𐑩𐑚𐑬𐑑 %s"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:1
-#, fuzzy
-msgid "A_IM/iChat:"
-msgstr "_𐑱𐑥/iChat:"
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:2
-msgid "A_ddress:"
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+#, fuzzy
+msgid "Launch media player"
+msgstr "𐑥𐑩𐑤𐑑𐑰𐑥𐑰𐑛𐑰𐑩 𐑐𐑤𐑱𐑼"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+#, fuzzy
+msgid "Launch web browser"
+msgstr "·𐑦𐑐𐑦𐑓𐑩𐑯𐑦 𐑢𐑧𐑚 𐑚𐑮𐑬𐑟𐑼"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "𐑕𐑻𐑗"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "𐑕𐑦𐑕𐑑𐑩𐑥"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "𐑟𐑵𐑥"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "𐑟𐑵𐑥"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "_𐑪𐑐𐑖𐑩𐑯𐑟..."
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+#, fuzzy
+msgid "Move Up"
+msgstr "𐑥𐑵𐑝 _𐑳𐑐"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+#, fuzzy
+msgid "Move Down"
+msgstr "𐑥𐑵𐑝 _𐑛𐑬𐑯"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑪𐑐𐑖𐑩𐑯𐑟"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "_𐑦𐑯𐑐𐑫𐑑 𐑚𐑪𐑒𐑕𐑩𐑟:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "_𐑿𐑕 𐑞 𐑕𐑱𐑥 𐑐𐑮𐑪𐑒𐑕𐑦 𐑓𐑹 𐑷𐑤 𐑐𐑮𐑴𐑑𐑩𐑒𐑪𐑤𐑟"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "𐑥𐑬𐑕 𐑒𐑰𐑟"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "𐑨𐑒𐑖𐑩𐑯"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "𐑯𐑱𐑥:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "_𐑒𐑩𐑥𐑭𐑯𐑛:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "𐑯𐑳𐑯"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_𐑮𐑰𐑕𐑧𐑑 𐑑 𐑛𐑦𐑓𐑷𐑤𐑑𐑕"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑐𐑻𐑕𐑩𐑯𐑩𐑤 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "𐑡𐑧𐑯𐑼𐑩𐑤"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "𐑤𐑧𐑓𐑑"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "𐑮𐑲𐑑"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_𐑛𐑦𐑤𐑰𐑑 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "𐑥𐑬𐑕"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "𐑥𐑬𐑕 𐑒𐑰𐑟"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑖𐑩𐑯:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+#, fuzzy
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤 _touchpad 𐑢𐑲𐑤 𐑑𐑲𐑐𐑦𐑙"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑖𐑩𐑯:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "𐑥𐑪𐑯𐑦𐑑𐑼"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯 𐑓𐑪𐑯𐑑:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "𐑨𐑒𐑖𐑩𐑯"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "_𐑪𐑐𐑖𐑩𐑯𐑟..."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑕𐑻𐑝𐑼𐑟"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 _𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "𐑩𐑒𐑕𐑧𐑤 𐑥𐑴𐑛"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "𐑒𐑻𐑕𐑼 𐑚𐑤𐑦𐑙𐑒𐑕 𐑕𐑐𐑰𐑛"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "𐑩𐑛𐑮𐑧𐑕"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "𐑩𐑛𐑮𐑧𐑕"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "𐑩𐑛𐑮𐑧𐑕"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "𐑛𐑦𐑓𐑷𐑤𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_𐑯𐑱𐑥:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
 msgstr "_𐑩𐑛𐑮𐑧𐑕:"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:3
-msgid "A_ssistant:"
-msgstr "_𐑩𐑕𐑦𐑕𐑑𐑩𐑯𐑑:"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:4
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-msgid "About Me"
-msgstr "𐑩𐑚𐑬𐑑 𐑥𐑰"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_𐑩𐑛𐑮𐑧𐑕:"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:5
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "𐑩𐑛𐑮𐑧𐑕"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "𐑩𐑛𐑮𐑧𐑕"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:6
-msgid "C_ity:"
-msgstr "_𐑕𐑦𐑑𐑦:"
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:7
-msgid "C_ompany:"
-msgstr "_𐑒𐑳𐑥𐑐𐑩𐑯𐑦:"
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:8
-msgid "Cale_ndar:"
-msgstr "_𐑒𐑨𐑤𐑩𐑯𐑛𐑼:"
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:9
-msgid "Change Passwo_rd..."
-msgstr "𐑗𐑱𐑯𐑡 _𐑐𐑭𐑕𐑢𐑼𐑛..."
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:10
-msgid "Ci_ty:"
-msgstr "_𐑕𐑦𐑑𐑦:"
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:11
-msgid "Co_untry:"
-msgstr "_𐑒𐑳𐑯𐑑𐑮𐑰:"
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:12
-msgid "Contact"
-msgstr "𐑒𐑪𐑯𐑑𐑨𐑒𐑑"
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:13
-msgid "Cou_ntry:"
-msgstr "_𐑒𐑳𐑯𐑑𐑮𐑰:"
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:14
-msgid "Disable _Fingerprint Login..."
-msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤 _𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯..."
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:15
-msgid "Email"
-msgstr "𐑰𐑥𐑱𐑤"
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:16
-msgid "Enable _Fingerprint Login..."
-msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 _𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯..."
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:17
-msgid "Full Name"
-msgstr "𐑓𐑫𐑤 𐑯𐑱𐑥"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
 
-#. Home vs Work (phone)
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:19
-msgid "Hom_e:"
-msgstr "Hom_e:"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
 
-#. Home vs Work (address)
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:21
-#: ../libslab/bookmark-agent.c:1135
-msgid "Home"
-msgstr "𐑣𐑴𐑥"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:22
-msgid "IC_Q:"
-msgstr "IC_Q:"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:23
-msgid "Instant Messaging"
-msgstr "𐑦𐑯𐑕𐑑𐑩𐑯𐑑 𐑥𐑧𐑕𐑦𐑡𐑦𐑙"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:24
-msgid "Job"
-msgstr "𐑡𐑪𐑚"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:25
-msgid "M_SN:"
-msgstr "M_SN:"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:26
-msgid "P.O. _box:"
-msgstr "P.O. _𐑚𐑪𐑒𐑕:"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:27
-msgid "P._O. box:"
-msgstr "P._O. 𐑚𐑪𐑒𐑕:"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:28
-msgid "Personal Info"
-msgstr "𐑐𐑻𐑕𐑩𐑯𐑩𐑤 𐑦𐑯𐑓𐑴"
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:29
-msgid "Select your photo"
-msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑿𐑼 𐑓𐑴𐑑𐑴"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:30
-msgid "State/Pro_vince:"
-msgstr "𐑕𐑑𐑱𐑑/_𐑐𐑮𐑪𐑝𐑦𐑯𐑕:"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:31
-msgid "Telephone"
-msgstr "𐑑𐑧𐑤𐑩𐑓𐑴𐑯"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:32
-msgid "User name:"
-msgstr "𐑿𐑟𐑼 𐑯𐑱𐑥:"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:33
-msgid "Web"
-msgstr "𐑢𐑧𐑚"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "𐑨𐑒𐑖𐑩𐑯"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:34
-msgid "Web _log:"
-msgstr "𐑢𐑧𐑚 _𐑤𐑪𐑜:"
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:35
-msgid "Wor_k:"
-msgstr "_𐑢𐑻𐑒:"
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:36
-msgid "Work"
-msgstr "𐑢𐑻𐑒"
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "𐑩𐑛𐑮𐑧𐑕"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:37
-msgid "Work _fax:"
-msgstr "𐑢𐑻𐑒 _𐑓𐑨𐑒𐑕:"
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:38
-msgid "ZIP/_Postal code:"
-msgstr "𐑟𐑦𐑐/_𐑐𐑴𐑕𐑑𐑩𐑤 𐑒𐑴𐑛:"
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "H_TTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:39
-msgid "_Address:"
-msgstr "_𐑩𐑛𐑮𐑧𐑕:"
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "H_TTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:40
-msgid "_Department:"
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "_𐑕𐑪𐑒𐑕 𐑣𐑴𐑕𐑑:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "𐑦𐑜𐑯𐑹𐑛 𐑣𐑴𐑕𐑑𐑕"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "H_TTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "H_TTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Autoconfiguration _·𐑿·𐑮·𐑤:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑕𐑻𐑝𐑼𐑟"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "𐑖𐑴 𐑣𐑧𐑤𐑐 𐑪𐑐𐑖𐑩𐑯𐑟"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛!"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "𐑷𐑤 𐑓𐑲𐑤𐑟"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_𐑿𐑟 𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑖𐑩𐑯</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "_𐑿𐑟𐑼𐑯𐑱𐑥:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "𐑝𐑻𐑠𐑩𐑯:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "𐑝𐑻𐑠𐑩𐑯:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Retype 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "𐑑𐑲𐑐:"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "𐑛𐑦𐑓𐑷𐑤𐑑"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "𐑓𐑲𐑤 𐑕𐑦𐑕𐑑𐑩𐑥"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_𐑮𐑴𐑑𐑱𐑖𐑩𐑯:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "_𐑛𐑦𐑤𐑰𐑑 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "𐑥𐑦𐑯𐑦𐑑𐑕"
+msgstr[1] "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "𐑥𐑦𐑯𐑦𐑑𐑕"
+msgstr[1] "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "𐑩𐑒𐑕𐑧𐑤 𐑥𐑴𐑛"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "𐑥𐑦𐑮𐑼 𐑕𐑒𐑮𐑰𐑯𐑟"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_𐑛𐑦𐑤𐑱:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "𐑐𐑶𐑯𐑑𐑼"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "𐑐𐑶𐑯𐑑𐑼"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "𐑯𐑴 𐑥𐑨𐑗𐑩𐑟 𐑓𐑬𐑯𐑛."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛!"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "_𐑿𐑟𐑼𐑯𐑱𐑥:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "𐑤𐑴𐑒𐑱𐑖𐑩𐑯:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "𐑦𐑯𐑕𐑑𐑷𐑤 𐑓𐑱𐑤𐑛"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑓𐑦𐑙𐑜𐑼"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "𐑤𐑴𐑒𐑱𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "𐑓𐑪𐑯𐑑 𐑮𐑧𐑯𐑛𐑻𐑦𐑙 𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "_𐑮𐑰𐑕𐑧𐑑 𐑑 𐑛𐑦𐑓𐑷𐑤𐑑𐑕"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
+msgstr "𐑤𐑴𐑒𐑱𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "𐑥𐑪𐑛𐑩𐑤𐑟"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "𐑐𐑤𐑰𐑟 𐑥𐑱𐑒 𐑖𐑫𐑼 𐑞𐑨𐑑 𐑞 𐑨𐑐𐑤𐑩𐑑 𐑦𐑟 𐑐𐑮𐑪𐑐𐑼𐑤𐑦 𐑦𐑯𐑕𐑑𐑷𐑤𐑛"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "_𐑮𐑳𐑯 𐑨𐑑 𐑕𐑑𐑸𐑑"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "𐑐𐑶𐑯𐑑𐑼"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "𐑯𐑹𐑥𐑩𐑤"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "𐑒𐑪𐑥𐑩𐑯 𐑑𐑭𐑕𐑒𐑕"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "𐑷𐑤 𐑓𐑲𐑤𐑟"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "𐑐𐑮𐑰𐑝𐑿:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
 msgstr "_𐑛𐑦𐑐𐑸𐑑𐑥𐑩𐑯𐑑:"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:41
-#, fuzzy
-msgid "_GroupWise:"
-msgstr "_GroupWise:"
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:42
-msgid "_Home page:"
-msgstr "_𐑣𐑴𐑥 𐑐𐑱𐑡:"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#. Home vs Work (email)
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:44
-msgid "_Home:"
-msgstr "_𐑣𐑴𐑥:"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:45
-msgid "_Manager:"
-msgstr "_𐑥𐑨𐑯𐑩𐑡𐑼:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:46
-msgid "_Mobile:"
-msgstr "_𐑥𐑴𐑚𐑲𐑤:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:47
-msgid "_Profession:"
-msgstr "_𐑐𐑮𐑩𐑓𐑧𐑖𐑩𐑯:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:48
-msgid "_State/Province:"
-msgstr "_𐑕𐑑𐑱𐑑/𐑐𐑮𐑪𐑝𐑦𐑯𐑕:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:49
-msgid "_Title:"
-msgstr "_𐑑𐑲𐑑𐑩𐑤:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:50
-msgid "_Work:"
-msgstr "_𐑢𐑻𐑒:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:51
-#, fuzzy
-msgid "_XMPP:"
-msgstr "_XMPP:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:52
-msgid "_Yahoo:"
-msgstr "·_𐑘𐑭𐑣𐑵:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:53
-msgid "_ZIP/Postal code:"
-msgstr "_𐑟𐑦𐑐/𐑐𐑴𐑕𐑑𐑩𐑤 𐑒𐑴𐑛:"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑐𐑻𐑕𐑩𐑯𐑩𐑤 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:97
+#: panels/region/cc-region-panel.ui:45
 msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr "𐑿 𐑸 𐑯𐑪𐑑 𐑩𐑤𐑬𐑛 𐑑 𐑨𐑒𐑕𐑧𐑕 𐑞 𐑛𐑦𐑝𐑲𐑕. 𐑒𐑪𐑯𐑑𐑨𐑒𐑑 𐑿𐑼 𐑕𐑦𐑕𐑑𐑩𐑥 𐑩𐑛𐑥𐑦𐑯𐑦𐑕𐑑𐑮𐑱𐑑𐑼."
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
-msgid "The device is already in use."
-msgstr "𐑞 𐑛𐑦𐑝𐑲𐑕 𐑦𐑟 𐑷𐑤𐑮𐑧𐑛𐑦 𐑦𐑯 𐑿𐑕."
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 #, fuzzy
-msgid "An internal error occured"
-msgstr "𐑩𐑯 𐑦𐑯𐑑𐑻𐑯𐑩𐑤 𐑻𐑼 occured"
+msgid "_Language"
+msgstr "_𐑤𐑨𐑙𐑜𐑢𐑩𐑡:"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:218
-msgid "Delete registered fingerprints?"
-msgstr "𐑛𐑦𐑤𐑰𐑑 𐑮𐑧𐑡𐑦𐑕𐑑𐑼𐑛 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕?"
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:221
-msgid "_Delete Fingerprints"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "·𐑤𐑦𐑯𐑩𐑒𐑕 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "Muine 𐑥𐑿𐑟𐑦𐑒 𐑐𐑤𐑱𐑼"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "𐑨𐑒𐑖𐑩𐑯"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "𐑑𐑲𐑐:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+#, fuzzy
+msgid "Screen"
+msgstr "𐑥𐑦𐑮𐑼 𐑕𐑒𐑮𐑰𐑯𐑟"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "𐑯𐑿 𐑤𐑴𐑒𐑱𐑖𐑩𐑯..."
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "𐑳𐑞𐑼"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "𐑤𐑴𐑒𐑱𐑖𐑩𐑯:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯 𐑓𐑪𐑯𐑑:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "𐑕𐑻𐑗"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑕𐑻𐑝𐑼𐑟"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_𐑛𐑦𐑤𐑰𐑑 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "UI 𐑒𐑩𐑯𐑑𐑮𐑴𐑤"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "𐑿𐑟𐑼 𐑯𐑱𐑥:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
 msgstr "_𐑛𐑦𐑤𐑰𐑑 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:228
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+#, fuzzy
+msgid "Enable or disable remote login"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 _𐑣𐑪𐑮𐑦𐑟𐑪𐑯𐑑𐑩𐑤 𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+#, fuzzy
+msgid "Authentication is required to enable or disable remote login"
+msgstr "𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑖𐑩𐑯 𐑦𐑟 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑥𐑩𐑤𐑑𐑰-𐑥𐑪𐑯𐑦𐑑𐑼 𐑕𐑧𐑑𐑦𐑙𐑟 𐑓𐑹 𐑷𐑤 𐑿𐑟𐑼𐑟"
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "𐑛𐑢𐑧𐑤 𐑒𐑤𐑦𐑒"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "𐑕𐑦𐑕𐑑𐑩𐑥"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "𐑩𐑤𐑻𐑑 𐑚𐑳𐑑𐑩𐑯𐑟"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "𐑕𐑬𐑯𐑛"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "𐑥𐑬𐑕 𐑪𐑮𐑦𐑩𐑯𐑑𐑱𐑖𐑩𐑯"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "𐑯𐑱𐑥:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "·𐑔𐑩𐑯𐑛𐑻𐑚𐑻𐑛"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "𐑒𐑻𐑕𐑼 𐑚𐑤𐑦𐑙𐑒𐑦𐑙"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "𐑒𐑻𐑕𐑼 _𐑚𐑤𐑦𐑙𐑒𐑕 𐑦𐑯 𐑑𐑧𐑒𐑕𐑑 𐑓𐑰𐑤𐑛𐑟"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_𐑕𐑐𐑰𐑛:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "𐑒𐑻𐑕𐑼 𐑚𐑤𐑦𐑙𐑒𐑕 𐑕𐑐𐑰𐑛"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "𐑒𐑻𐑕𐑼 𐑚𐑤𐑦𐑙𐑒𐑦𐑙"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "𐑕𐑦𐑥𐑘𐑩𐑤𐑱𐑑𐑦𐑛 𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+#, fuzzy
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "_𐑑𐑮𐑦𐑜𐑻 𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒 𐑚𐑲 𐑣𐑴𐑤𐑛𐑦𐑙 𐑛𐑬𐑯 𐑞 𐑐𐑮𐑲𐑥𐑼𐑦 𐑚𐑳𐑑𐑩𐑯"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "𐑖𐑹𐑑"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "_𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "𐑤𐑪𐑙"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "_𐑛𐑳𐑚𐑩𐑤 𐑒𐑤𐑦𐑒:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+#, fuzzy
+msgid "Trigger a click when the pointer hovers"
+msgstr "_𐑦𐑯𐑦𐑖𐑰𐑱𐑑 𐑒𐑤𐑦𐑒 𐑢𐑧𐑯 𐑕𐑑𐑪𐑐𐑦𐑙 𐑐𐑶𐑯𐑑𐑼 𐑥𐑵𐑝𐑥𐑩𐑯𐑑"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_𐑛𐑦𐑤𐑱:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "𐑖𐑹𐑑"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "𐑤𐑪𐑙"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_𐑥𐑴𐑖𐑩𐑯 𐑔𐑮𐑧𐑖𐑴𐑤𐑛:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "𐑕𐑥𐑷𐑤"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "𐑤𐑸𐑡"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "𐑮𐑦𐑐𐑰𐑑 𐑒𐑰𐑟"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "𐑒𐑰 𐑐𐑮𐑧𐑕𐑩𐑟 _𐑮𐑦𐑐𐑰𐑑 𐑢𐑧𐑯 𐑒𐑰 𐑦𐑟 𐑣𐑧𐑤𐑛 𐑛𐑬𐑯"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "𐑮𐑦𐑐𐑰𐑑 𐑒𐑰𐑟 𐑕𐑐𐑰𐑛"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "𐑮𐑦𐑐𐑰𐑑 𐑒𐑰𐑟 𐑕𐑐𐑰𐑛"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "𐑑𐑲𐑐𐑦𐑙 𐑥𐑪𐑯𐑦𐑑𐑼"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "𐑕𐑑𐑦𐑒𐑦 𐑒𐑰𐑟"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "_𐑛𐑦𐑕𐑱𐑚𐑩𐑤 𐑕𐑑𐑦𐑒𐑦 𐑒𐑰𐑟 𐑦𐑓 𐑑𐑵 𐑒𐑰𐑟 𐑸 𐑐𐑮𐑧𐑕𐑑 𐑑𐑫𐑜𐑧𐑞𐑼"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 _𐑥𐑪𐑛𐑦𐑓𐑲𐑼 𐑒𐑰 𐑦𐑟 𐑐𐑮𐑧𐑕𐑑"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "𐑕𐑤𐑴 𐑒𐑰𐑟"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "𐑖𐑹𐑑"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "𐑤𐑪𐑙"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 𐑒𐑰 𐑦𐑟 pr_essed"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑒𐑰 𐑦𐑟 _𐑨𐑒𐑕𐑧𐑐𐑑𐑩𐑛"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 𐑒𐑰 𐑦𐑟 reje_cted"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "𐑚𐑶𐑯𐑕 𐑒𐑰𐑟"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "_𐑦𐑜𐑯𐑹 𐑓𐑭𐑕𐑑 𐑛𐑿𐑐𐑤𐑦𐑒𐑱𐑑 keypresses"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "𐑖𐑹𐑑"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "𐑤𐑪𐑙"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "_𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑓𐑰𐑗𐑼𐑟 𐑒𐑨𐑯 𐑚𐑰 𐑑𐑪𐑜𐑩𐑤𐑛 𐑢𐑦𐑞 𐑒𐑰𐑚𐑪𐑮𐑛 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_𐑒𐑰𐑚𐑪𐑮𐑛 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "𐑤𐑸𐑡"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "·𐑤𐑦𐑯𐑩𐑒𐑕 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "𐑚𐑶𐑯𐑕 𐑒𐑰𐑟"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 _𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑓𐑰𐑗𐑼𐑟 𐑸 𐑑𐑻𐑯𐑛 𐑪𐑯 𐑹 𐑪𐑓"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "𐑟𐑵𐑥"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+#, fuzzy
+msgid "Hearing"
+msgstr "𐑮𐑧𐑯𐑛𐑻𐑦𐑙"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "·𐑜𐑯𐑴𐑥 𐑭𐑯𐑕𐑒𐑮𐑰𐑯 𐑒𐑰𐑚𐑪𐑮𐑛"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "𐑮𐑦𐑐𐑰𐑑 𐑒𐑰𐑟"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "𐑒𐑻𐑕𐑼 𐑚𐑤𐑦𐑙𐑒𐑦𐑙"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "𐑥𐑬𐑕 𐑒𐑰𐑟"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "𐑤𐑴𐑒𐑱𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑑𐑲𐑥𐑬𐑑"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑑𐑲𐑥𐑬𐑑"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+#, fuzzy
+msgid "Visual Alerts"
+msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "𐑓𐑤𐑨𐑖 𐑧𐑯𐑑𐑲𐑼 _𐑕𐑒𐑮𐑰𐑯"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "𐑓𐑤𐑨𐑖 𐑧𐑯𐑑𐑲𐑼 _𐑕𐑒𐑮𐑰𐑯"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "𐑓𐑫𐑤 𐑯𐑱𐑥"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "𐑤𐑧𐑓𐑑"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "𐑮𐑲𐑑"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "_𐑪𐑐𐑖𐑩𐑯𐑟..."
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "·𐑪𐑮𐑒𐑩 𐑢𐑦𐑞 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "_𐑒𐑳𐑤𐑼𐑟:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "𐑒𐑪𐑯𐑑𐑨𐑒𐑑"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "𐑯𐑳𐑯"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_𐑓𐑫𐑤"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "𐑤𐑴"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "𐑣𐑲"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+#, fuzzy
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "𐑤𐑴"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+#, fuzzy
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "𐑣𐑲"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "𐑒𐑳𐑤𐑼𐑟"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "𐑓𐑲𐑤 𐑕𐑦𐑕𐑑𐑩𐑥"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "𐑥𐑵𐑝 𐑑 𐑑𐑮𐑨𐑖"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "·𐑑𐑻𐑥𐑩𐑯𐑱𐑑𐑻"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑦𐑥𐑦𐑡"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "_𐑛𐑦𐑤𐑰𐑑 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_𐑯𐑳𐑯"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
 msgstr ""
 "𐑛𐑵 𐑿 𐑢𐑪𐑯𐑑 𐑑 𐑛𐑦𐑤𐑰𐑑 𐑿𐑼 𐑮𐑧𐑡𐑦𐑕𐑑𐑼𐑛 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕 𐑕𐑴 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯 𐑦𐑟 𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛?"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:356
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:1
-msgid "Done!"
-msgstr "𐑛𐑳𐑯!"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:402
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:424
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑨𐑒𐑕𐑧𐑕 '%s' 𐑛𐑦𐑝𐑲𐑕"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:473
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑕𐑑𐑸𐑑 𐑓𐑦𐑙𐑜𐑼 𐑒𐑨𐑐𐑗𐑻 𐑪𐑯 '%s' 𐑛𐑦𐑝𐑲𐑕"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:520
-msgid "Could not access any fingerprint readers"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑨𐑒𐑕𐑧𐑕 𐑧𐑯𐑦 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑮𐑰𐑛𐑼𐑟"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:521
-msgid "Please contact your system administrator for help."
-msgstr "𐑐𐑤𐑰𐑟 𐑒𐑪𐑯𐑑𐑨𐑒𐑑 𐑿𐑼 𐑕𐑦𐑕𐑑𐑩𐑥 𐑩𐑛𐑥𐑦𐑯𐑦𐑕𐑑𐑮𐑱𐑑𐑼 𐑓𐑹 𐑣𐑧𐑤𐑐."
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:551
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:2
-msgid "Enable Fingerprint Login"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
 msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:581
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
 msgstr ""
-"𐑑 𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯, 𐑿 𐑯𐑰𐑛 𐑑 𐑕𐑱𐑝 𐑢𐑳𐑯 𐑝 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕, 𐑿𐑟𐑦𐑙 𐑞 '%s' "
-"𐑛𐑦𐑝𐑲𐑕."
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:590
-msgid "Swipe finger on reader"
-msgstr "𐑕𐑢𐑲𐑐 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 𐑮𐑰𐑛𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:592
-msgid "Place finger on reader"
-msgstr "𐑐𐑤𐑱𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 𐑮𐑰𐑛𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:3
-msgid "Left index finger"
-msgstr "𐑤𐑧𐑓𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "𐑤𐑧𐑓𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:5
-msgid "Left middle finger"
-msgstr "𐑤𐑧𐑓𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:6
-msgid "Left ring finger"
-msgstr "𐑤𐑧𐑓𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:7
-msgid "Left thumb"
-msgstr "𐑤𐑧𐑓𐑑 𐑔𐑳𐑥"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:8
-msgid "Other finger: "
-msgstr "𐑳𐑞𐑼 𐑓𐑦𐑙𐑜𐑼: "
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:9
-msgid "Right index finger"
-msgstr "𐑮𐑲𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:10
-msgid "Right little finger"
-msgstr "𐑮𐑲𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:11
-msgid "Right middle finger"
-msgstr "𐑮𐑲𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:12
-msgid "Right ring finger"
-msgstr "𐑮𐑲𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:13
-msgid "Right thumb"
-msgstr "𐑮𐑲𐑑 𐑔𐑳𐑥"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:14
-msgid "Select finger"
-msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑓𐑦𐑙𐑜𐑼"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:15
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"𐑿𐑼 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑢𐑪𐑟 𐑕𐑩𐑒𐑕𐑧𐑕𐑓𐑩𐑤𐑦 𐑕𐑱𐑝𐑛. 𐑿 𐑖𐑫𐑛 𐑯𐑬 𐑚𐑰 𐑱𐑚𐑩𐑤 𐑑 𐑤𐑪𐑜 𐑦𐑯 𐑿𐑟𐑦𐑙 𐑿𐑼 "
-"𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑮𐑰𐑛𐑼."
-
-#: ../capplets/about-me/gnome-about-me-password.c:161
-msgid "Child exited unexpectedly"
-msgstr "𐑗𐑲𐑤𐑛 𐑧𐑜𐑟𐑦𐑑𐑩𐑛 𐑩𐑯𐑦𐑒𐑕𐑐𐑧𐑒𐑑𐑦𐑛𐑤𐑰"
-
-#: ../capplets/about-me/gnome-about-me-password.c:296
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑖𐑩𐑑𐑛𐑶𐑯 backend_stdin IO 𐑗𐑨𐑯𐑩𐑤: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:309
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑖𐑩𐑑𐑛𐑶𐑯 backend_stdout IO 𐑗𐑨𐑯𐑩𐑤: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:408
-msgid "Authenticated!"
-msgstr "𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛!"
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:474
-#: ../capplets/about-me/gnome-about-me-password.c:554
-msgid ""
-"Your password has been changed since you initially authenticated! Please re-"
-"authenticate."
-msgstr "𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑗𐑱𐑯𐑡𐑛 𐑕𐑦𐑯𐑕 𐑿 𐑦𐑯𐑦𐑖𐑩𐑤𐑦 𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛! 𐑐𐑤𐑰𐑟 𐑮𐑰-𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑."
-
-#: ../capplets/about-me/gnome-about-me-password.c:476
-msgid "That password was incorrect."
-msgstr "𐑞𐑨𐑑 𐑐𐑭𐑕𐑢𐑼𐑛 𐑢𐑪𐑟 𐑦𐑯𐑒𐑼𐑧𐑒𐑑."
-
-#: ../capplets/about-me/gnome-about-me-password.c:525
-msgid "Your password has been changed."
-msgstr "𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑗𐑱𐑯𐑡𐑛."
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:535
-#, c-format
-msgid "System error: %s."
-msgstr "𐑕𐑦𐑕𐑑𐑩𐑥 𐑻𐑼: %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:538
-msgid "The password is too short."
-msgstr "𐑞 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑟 𐑑𐑵 𐑖𐑹𐑑."
-
-#: ../capplets/about-me/gnome-about-me-password.c:542
-msgid "The password is too simple."
-msgstr "𐑞 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑟 𐑑𐑵 𐑕𐑦𐑥𐑐𐑩𐑤."
-
-#: ../capplets/about-me/gnome-about-me-password.c:546
-msgid "The old and new passwords are too similar."
-msgstr "𐑞 𐑴𐑤𐑛 𐑯 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛𐑟 𐑸 𐑑𐑵 𐑕𐑦𐑥𐑦𐑤𐑼."
-
-#: ../capplets/about-me/gnome-about-me-password.c:548
-msgid "The new password must contain numeric or special character(s)."
-msgstr "𐑞 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛 𐑥𐑳𐑕𐑑 𐑒𐑩𐑯𐑑𐑱𐑯 𐑯𐑿𐑥𐑧𐑮𐑦𐑒 𐑹 𐑕𐑐𐑧𐑖𐑩𐑤 𐑒𐑸𐑩𐑒𐑑𐑼(𐑕)."
-
-#: ../capplets/about-me/gnome-about-me-password.c:551
-msgid "The old and new passwords are the same."
-msgstr "𐑞 𐑴𐑤𐑛 𐑯 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛𐑟 𐑸 𐑞 𐑕𐑱𐑥."
-
-#. translators: Unable to launch <program>: <error message>
-#: ../capplets/about-me/gnome-about-me-password.c:822
-#, c-format
-msgid "Unable to launch %s: %s"
-msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑤𐑷𐑯𐑗 %s: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:826
-msgid "Unable to launch backend"
-msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑤𐑷𐑯𐑗 𐑚𐑨𐑒𐑧𐑯𐑛"
-
-#: ../capplets/about-me/gnome-about-me-password.c:827
-msgid "A system error has occurred"
-msgstr "𐑩 𐑕𐑦𐑕𐑑𐑩𐑥 𐑻𐑼 𐑣𐑨𐑟 𐑪𐑒𐑻𐑛"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:847
-msgid "Checking password..."
-msgstr "𐑗𐑧𐑒𐑦𐑙 𐑐𐑭𐑕𐑢𐑼𐑛..."
-
-#: ../capplets/about-me/gnome-about-me-password.c:934
-msgid "Click <b>Change password</b> to change your password."
-msgstr "𐑒𐑤𐑦𐑒 <b>𐑗𐑱𐑯𐑡 𐑐𐑭𐑕𐑢𐑼𐑛</b> 𐑑 𐑗𐑱𐑯𐑡 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛."
-
-#: ../capplets/about-me/gnome-about-me-password.c:937
-msgid "Please type your password in the <b>New password</b> field."
-msgstr "𐑐𐑤𐑰𐑟 𐑑𐑲𐑐 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑯 𐑞 <b>𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛</b> 𐑓𐑰𐑤𐑛."
-
-#: ../capplets/about-me/gnome-about-me-password.c:940
-#: ../capplets/about-me/gnome-about-me-password.ui.h:5
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 #, fuzzy
+msgid "Fingerprint Device"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
-"Please type your password again in the <b>Retype new password</b> field."
-msgstr "𐑐𐑤𐑰𐑟 𐑑𐑲𐑐 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑩𐑜𐑱𐑯 𐑦𐑯 𐑞 <𐑚𐑰>Retype 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛</𐑚𐑰> 𐑓𐑰𐑤𐑛."
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-password.c:943
-msgid "The two passwords are not equal."
-msgstr "𐑞 𐑑𐑵 𐑐𐑭𐑕𐑢𐑼𐑛𐑟 𐑸 𐑯𐑪𐑑 𐑰𐑒𐑢𐑩𐑤."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_𐑛𐑦𐑤𐑰𐑑 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕"
 
-#: ../capplets/about-me/gnome-about-me-password.ui.h:1
-msgid "Change pa_ssword"
-msgstr "𐑗𐑱𐑯𐑡 _𐑐𐑭𐑕𐑢𐑼𐑛"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯"
 
-#: ../capplets/about-me/gnome-about-me-password.ui.h:2
-msgid "Change password"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "𐑐𐑮𐑰𐑝𐑿 𐑓𐑪𐑯𐑑𐑕"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
 msgstr "𐑗𐑱𐑯𐑡 𐑐𐑭𐑕𐑢𐑼𐑛"
 
-#: ../capplets/about-me/gnome-about-me-password.ui.h:3
-msgid "Change your password"
-msgstr "𐑗𐑱𐑯𐑡 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:4
-msgid "Current _password:"
-msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 _𐑐𐑭𐑕𐑢𐑼𐑛:"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:6
+#: panels/user-accounts/cc-password-dialog.ui:34
 #, fuzzy
-msgid ""
-"To change your password, enter your current password in the field below and "
-"click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for "
-"verification and click <b>Change password</b>."
-msgstr ""
-"𐑑 𐑗𐑱𐑯𐑡 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛, 𐑧𐑯𐑑𐑼 𐑿𐑼 𐑒𐑳𐑮𐑩𐑯𐑑 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑯 𐑞 𐑓𐑰𐑤𐑛 𐑚𐑩𐑤𐑴 𐑯 𐑒𐑤𐑦𐑒 <𐑚𐑰>𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑</"
-"𐑚𐑰>.\n"
-"𐑭𐑓𐑑𐑼 𐑿 𐑣𐑨𐑝 𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛, 𐑧𐑯𐑑𐑼 𐑿𐑼 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛, retype 𐑦𐑑 𐑓𐑹 𐑝𐑧𐑮𐑩𐑓𐑩𐑒𐑱𐑖𐑩𐑯 𐑯 𐑒𐑤𐑦𐑒 "
-"<𐑚𐑰>𐑗𐑱𐑯𐑡 𐑐𐑭𐑕𐑢𐑼𐑛</𐑚𐑰>."
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:8
-msgid "_Authenticate"
-msgstr "_𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:9
-msgid "_New password:"
-msgstr "_𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛:"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:10
-#, fuzzy
-msgid "_Retype new password:"
-msgstr "_Retype 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:1
-msgid "Accessible Lo_gin"
-msgstr "𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑩𐑤 _𐑤𐑪𐑜𐑦𐑯"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:2
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-#, fuzzy
-msgid "Assistive Technologies"
-msgstr "Assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:3
-#, fuzzy
-msgid "Assistive Technologies Preferences"
-msgstr "Assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:4
-#, fuzzy
-msgid ""
-"Changes to enable assistive technologies will not take effect until your "
-"next log in."
-msgstr ""
-"𐑗𐑱𐑯𐑡𐑩𐑟 𐑑 𐑦𐑯𐑱𐑚𐑩𐑤 assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑑𐑱𐑒 𐑦𐑓𐑧𐑒𐑑 𐑳𐑯𐑑𐑦𐑤 𐑿𐑼 𐑯𐑧𐑒𐑕𐑑 𐑤𐑪𐑜 𐑦𐑯."
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:5
-msgid "Close and _Log Out"
-msgstr "𐑒𐑤𐑴𐑕 𐑯 _𐑤𐑪𐑜 𐑬𐑑"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:6
-msgid "Jump to Preferred Applications dialog"
-msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟 𐑛𐑲𐑩𐑤𐑪𐑜"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:7
-msgid "Jump to the Accessible Login dialog"
-msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑞 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑩𐑤 𐑤𐑪𐑜𐑦𐑯 𐑛𐑲𐑩𐑤𐑪𐑜"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:8
-msgid "Jump to the Keyboard Accessibility dialog"
-msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑞 𐑒𐑰𐑚𐑪𐑮𐑛 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑛𐑲𐑩𐑤𐑪𐑜"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:9
-msgid "Jump to the Mouse Accessibility dialog"
-msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑞 𐑥𐑬𐑕 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑛𐑲𐑩𐑤𐑪𐑜"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:10
-msgid "Preferences"
-msgstr "𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:11
-#, fuzzy
-msgid "_Enable assistive technologies"
-msgstr "_𐑦𐑯𐑱𐑚𐑩𐑤 assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:12
-msgid "_Keyboard Accessibility"
-msgstr "_𐑒𐑰𐑚𐑪𐑮𐑛 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:13
-msgid "_Mouse Accessibility"
-msgstr "_𐑥𐑬𐑕 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:14
-msgid "_Preferred Applications"
-msgstr "_𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Choose which accessibility features to enable when you log in"
-msgstr "𐑗𐑵𐑟 𐑢𐑦𐑗 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑓𐑰𐑗𐑼𐑟 𐑑 𐑦𐑯𐑱𐑚𐑩𐑤 𐑢𐑧𐑯 𐑿 𐑤𐑪𐑜 𐑦𐑯"
-
-#: ../capplets/appearance/appearance-desktop.c:627
-msgid "Add Wallpaper"
-msgstr "𐑨𐑛 𐑢𐑪𐑤𐑐𐑱𐑐𐑻"
-
-#: ../capplets/appearance/appearance-desktop.c:662
-msgid "All files"
-msgstr "𐑷𐑤 𐑓𐑲𐑤𐑟"
-
-#: ../capplets/appearance/appearance-font.c:499
-msgid "Font may be too large"
-msgstr "𐑓𐑪𐑯𐑑 𐑥𐑱 𐑚𐑰 𐑑𐑵 𐑤𐑸𐑡"
-
-#: ../capplets/appearance/appearance-font.c:503
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
-"𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑲𐑟 𐑕𐑥𐑷𐑤𐑼 𐑞𐑨𐑯 %d."
-msgstr[1] ""
-"𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑𐑕 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
-"𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑲𐑟 𐑕𐑥𐑷𐑤𐑼 𐑞𐑨𐑯 %d."
-
-#: ../capplets/appearance/appearance-font.c:516
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
-"𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑥𐑷𐑤𐑼 𐑕𐑲𐑟𐑛 𐑓𐑪𐑯𐑑."
-msgstr[1] ""
-"𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑𐑕 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
-"𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑥𐑷𐑤𐑼 𐑕𐑲𐑟𐑛 𐑓𐑪𐑯𐑑."
-
-#: ../capplets/appearance/appearance-font.c:539
-msgid "Use previous font"
-msgstr "𐑿𐑟 𐑐𐑮𐑰𐑝𐑦𐑩𐑕 𐑓𐑪𐑯𐑑"
-
-#: ../capplets/appearance/appearance-font.c:541
-msgid "Use selected font"
-msgstr "𐑿𐑟 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑓𐑪𐑯𐑑"
-
-#: ../capplets/appearance/appearance-main.c:56
-#, c-format
-msgid "Could not load user interface file: %s"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑤𐑴𐑛 𐑿𐑟𐑼 𐑦𐑯𐑑𐑼𐑓𐑱𐑕 𐑓𐑲𐑤: %s"
-
-#: ../capplets/appearance/appearance-main.c:135
-msgid "Specify the filename of a theme to install"
-msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑓𐑲𐑤𐑯𐑱𐑥 𐑝 𐑩 𐑔𐑰𐑥 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤"
-
-#: ../capplets/appearance/appearance-main.c:136
-msgid "filename"
-msgstr "𐑓𐑲𐑤𐑯𐑱𐑥"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/appearance/appearance-main.c:143
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
-msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑯𐑱𐑥 𐑝 𐑞 𐑐𐑱𐑡 𐑑 𐑖𐑴 (theme|background|fonts|interface)"
-
-#: ../capplets/appearance/appearance-main.c:144
-#: ../capplets/default-applications/gnome-da-capplet.c:960
-#: ../capplets/mouse/gnome-mouse-properties.c:591
-msgid "page"
-msgstr "𐑐𐑱𐑡"
-
-#: ../capplets/appearance/appearance-main.c:151
-msgid "[WALLPAPER...]"
-msgstr "[𐑢𐑪𐑤𐑐𐑱𐑐𐑻...]"
-
-#: ../capplets/appearance/appearance-style.c:172
-#: ../capplets/common/gnome-theme-info.c:446
-#: ../capplets/common/gnome-theme-info.c:638
-msgid "Default Pointer"
-msgstr "𐑛𐑦𐑓𐑷𐑤𐑑 𐑐𐑶𐑯𐑑𐑼"
-
-#: ../capplets/appearance/appearance-style.c:235
-#: ../capplets/appearance/appearance-themes.c:685
-msgid "Install"
-msgstr "𐑦𐑯𐑕𐑑𐑷𐑤"
-
-#: ../capplets/appearance/appearance-style.c:256
-#: ../capplets/common/gnome-theme-info.c:1646
-#, fuzzy
-msgid ""
-"This theme will not look as intended because the required GTK+ theme engine "
-"'%s' is not installed."
-msgstr ""
-"𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 GTK+ 𐑔𐑰𐑥 𐑧𐑯𐑡𐑦𐑯 '%s' 𐑦𐑟 𐑯𐑪𐑑 "
-"𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
-
-#: ../capplets/appearance/appearance-themes.c:673
-msgid "Apply Background"
-msgstr "𐑩𐑐𐑤𐑲 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
-
-#: ../capplets/appearance/appearance-themes.c:677
-msgid "Apply Font"
-msgstr "𐑩𐑐𐑤𐑲 𐑓𐑪𐑯𐑑"
-
-#: ../capplets/appearance/appearance-themes.c:681
-msgid "Revert Font"
-msgstr "𐑮𐑦𐑝𐑻𐑑 𐑓𐑪𐑯𐑑"
-
-#: ../capplets/appearance/appearance-themes.c:712
-msgid ""
-"The current theme suggests a background and a font. Also, the last applied "
-"font suggestion can be reverted."
-msgstr ""
-"𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑯 𐑩 𐑓𐑪𐑯𐑑. 𐑷𐑤𐑕𐑴, 𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 "
-"𐑒𐑨𐑯 𐑚𐑰 𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
-
-#: ../capplets/appearance/appearance-themes.c:714
-msgid ""
-"The current theme suggests a background. Also, the last applied font "
-"suggestion can be reverted."
-msgstr ""
-"𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛. 𐑷𐑤𐑕𐑴, 𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 "
-"𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
-
-#: ../capplets/appearance/appearance-themes.c:716
-msgid "The current theme suggests a background and a font."
-msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑯 𐑩 𐑓𐑪𐑯𐑑."
-
-#: ../capplets/appearance/appearance-themes.c:718
-msgid ""
-"The current theme suggests a font. Also, the last applied font suggestion "
-"can be reverted."
-msgstr ""
-"𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑓𐑪𐑯𐑑. 𐑷𐑤𐑕𐑴, 𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
-
-#: ../capplets/appearance/appearance-themes.c:720
-msgid "The current theme suggests a background."
-msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛."
-
-#: ../capplets/appearance/appearance-themes.c:722
-msgid "The last applied font suggestion can be reverted."
-msgstr "𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
-
-#: ../capplets/appearance/appearance-themes.c:724
-msgid "The current theme suggests a font."
-msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑓𐑪𐑯𐑑."
-
-#: ../capplets/appearance/appearance-themes.c:1046
-#: ../capplets/default-applications/gnome-da-capplet.c:691
-msgid "Custom"
-msgstr "𐑒𐑳𐑕𐑑𐑩𐑥"
-
-#: ../capplets/appearance/data/appearance.ui.h:1
-msgid "Appearance Preferences"
-msgstr "𐑩𐑐𐑽𐑩𐑯𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/appearance/data/appearance.ui.h:2
-msgid "Background"
-msgstr "𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
-
-#: ../capplets/appearance/data/appearance.ui.h:3
-msgid "Best _shapes"
-msgstr "𐑚𐑧𐑕𐑑 _𐑖𐑱𐑐𐑕"
-
-#: ../capplets/appearance/data/appearance.ui.h:4
-msgid "Best co_ntrast"
-msgstr "𐑚𐑧𐑕𐑑 _𐑒𐑪𐑯𐑑𐑮𐑭𐑕𐑑"
-
-#: ../capplets/appearance/data/appearance.ui.h:5
-msgid "C_olors:"
-msgstr "_𐑒𐑳𐑤𐑼𐑟:"
-
-#: ../capplets/appearance/data/appearance.ui.h:6
-msgid "C_ustomize..."
-msgstr "_𐑒𐑩𐑕𐑑𐑩𐑥𐑲𐑟..."
-
-#: ../capplets/appearance/data/appearance.ui.h:7
-msgid "Center"
-msgstr "𐑕𐑧𐑯𐑑𐑼"
-
-#: ../capplets/appearance/data/appearance.ui.h:8
-msgid "Changing your cursor theme takes effect the next time you log in."
-msgstr "𐑗𐑱𐑯𐑡𐑦𐑙 𐑿𐑼 𐑒𐑻𐑕𐑼 𐑔𐑰𐑥 𐑑𐑱𐑒𐑕 𐑦𐑓𐑧𐑒𐑑 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑑𐑲𐑥 𐑿 𐑤𐑪𐑜 𐑦𐑯."
-
-#: ../capplets/appearance/data/appearance.ui.h:9
-msgid "Colors"
-msgstr "𐑒𐑳𐑤𐑼𐑟"
-
-#: ../capplets/appearance/data/appearance.ui.h:10
-msgid "Controls"
-msgstr "𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑟"
-
-#: ../capplets/appearance/data/appearance.ui.h:11
-msgid "Customize Theme"
-msgstr "𐑒𐑩𐑕𐑑𐑩𐑥𐑲𐑟 𐑔𐑰𐑥"
-
-#: ../capplets/appearance/data/appearance.ui.h:12
-msgid "D_etails..."
-msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟..."
-
-#: ../capplets/appearance/data/appearance.ui.h:13
-msgid "Des_ktop font:"
-msgstr "_𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑓𐑪𐑯𐑑:"
-
-#: ../capplets/appearance/data/appearance.ui.h:14
-msgid "Font Rendering Details"
-msgstr "𐑓𐑪𐑯𐑑 𐑮𐑧𐑯𐑛𐑻𐑦𐑙 𐑛𐑰𐑑𐑱𐑤𐑟"
-
-#: ../capplets/appearance/data/appearance.ui.h:15
-msgid "Fonts"
-msgstr "𐑓𐑪𐑯𐑑𐑕"
-
-#: ../capplets/appearance/data/appearance.ui.h:16
-msgid "Get more backgrounds online"
-msgstr "𐑜𐑧𐑑 𐑥𐑹 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛𐑟 𐑪𐑯𐑤𐑲𐑯"
-
-#: ../capplets/appearance/data/appearance.ui.h:17
-msgid "Get more themes online"
-msgstr "𐑜𐑧𐑑 𐑥𐑹 𐑔𐑰𐑥𐑟 𐑪𐑯𐑤𐑲𐑯"
-
-#: ../capplets/appearance/data/appearance.ui.h:18
-msgid "Gra_yscale"
-msgstr "_𐑜𐑮𐑱𐑕𐑒𐑱𐑤"
-
-#. font hinting
-#: ../capplets/appearance/data/appearance.ui.h:20
-msgid "Hinting"
-msgstr "𐑣𐑦𐑯𐑑𐑦𐑙"
-
-#: ../capplets/appearance/data/appearance.ui.h:21
-msgid "Horizontal gradient"
-msgstr "𐑣𐑪𐑮𐑦𐑟𐑪𐑯𐑑𐑩𐑤 𐑜𐑮𐑱𐑛𐑦𐑩𐑯𐑑"
-
-#: ../capplets/appearance/data/appearance.ui.h:22
-msgid "Icons"
-msgstr "𐑲𐑒𐑪𐑯𐑟"
-
-#: ../capplets/appearance/data/appearance.ui.h:23
-msgid "Icons only"
-msgstr "𐑲𐑒𐑪𐑯𐑟 𐑴𐑯𐑤𐑦"
-
-#: ../capplets/appearance/data/appearance.ui.h:24
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:17
-msgid "Large"
-msgstr "𐑤𐑸𐑡"
-
-#: ../capplets/appearance/data/appearance.ui.h:25
-msgid "N_one"
-msgstr "_𐑯𐑳𐑯"
-
-#: ../capplets/appearance/data/appearance.ui.h:26
-msgid "Open a dialog to specify the color"
-msgstr "𐑴𐑐𐑩𐑯 𐑩 𐑛𐑲𐑩𐑤𐑪𐑜 𐑑 𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑒𐑳𐑤𐑼"
-
-#: ../capplets/appearance/data/appearance.ui.h:27
-msgid "Pointer"
-msgstr "𐑐𐑶𐑯𐑑𐑼"
-
-#: ../capplets/appearance/data/appearance.ui.h:28
-msgid "R_esolution:"
-msgstr "_𐑮𐑧𐑟𐑩𐑤𐑵𐑖𐑩𐑯:"
-
-#: ../capplets/appearance/data/appearance.ui.h:29
-msgid "Rendering"
-msgstr "𐑮𐑧𐑯𐑛𐑻𐑦𐑙"
-
-#: ../capplets/appearance/data/appearance.ui.h:30
-msgid "Save Theme As..."
-msgstr "𐑕𐑱𐑝 𐑔𐑰𐑥 𐑨𐑟..."
-
-#: ../capplets/appearance/data/appearance.ui.h:31
-msgid "Save _As..."
-msgstr "𐑕𐑱𐑝 _𐑨𐑟..."
-
-#: ../capplets/appearance/data/appearance.ui.h:32
-msgid "Save _background image"
-msgstr "𐑕𐑱𐑝 _𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑦𐑥𐑦𐑡"
-
-#: ../capplets/appearance/data/appearance.ui.h:33
-msgid "Scale"
-msgstr "𐑕𐑒𐑱𐑤"
-
-#: ../capplets/appearance/data/appearance.ui.h:34
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:31
-msgid "Small"
-msgstr "𐑕𐑥𐑷𐑤"
-
-#: ../capplets/appearance/data/appearance.ui.h:35
-msgid "Smoothing"
-msgstr "𐑕𐑥𐑵𐑞𐑦𐑙"
-
-#: ../capplets/appearance/data/appearance.ui.h:36
-msgid "Solid color"
-msgstr "𐑕𐑪𐑤𐑦𐑛 𐑒𐑳𐑤𐑼"
-
-#: ../capplets/appearance/data/appearance.ui.h:37
-msgid "Span"
-msgstr "𐑕𐑐𐑨𐑯"
-
-#: ../capplets/appearance/data/appearance.ui.h:38
-msgid "Stretch"
-msgstr "𐑕𐑑𐑮𐑧𐑗"
-
-#: ../capplets/appearance/data/appearance.ui.h:39
-#, fuzzy
-msgid "Sub_pixel (LCDs)"
-msgstr "_Subpixel (LCDs)"
-
-#: ../capplets/appearance/data/appearance.ui.h:40
-#, fuzzy
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "_Subpixel 𐑕𐑥𐑵𐑞𐑦𐑙 (LCDs)"
-
-#: ../capplets/appearance/data/appearance.ui.h:41
-#, fuzzy
-msgid "Subpixel Order"
-msgstr "Subpixel 𐑹𐑛𐑼"
-
-#: ../capplets/appearance/data/appearance.ui.h:42
-msgid "Text"
-msgstr "𐑑𐑧𐑒𐑕𐑑"
-
-#: ../capplets/appearance/data/appearance.ui.h:43
-msgid "Text below items"
-msgstr "𐑑𐑧𐑒𐑕𐑑 𐑚𐑩𐑤𐑴 𐑲𐑑𐑩𐑥𐑟"
-
-#: ../capplets/appearance/data/appearance.ui.h:44
-msgid "Text beside items"
-msgstr "𐑑𐑧𐑒𐑕𐑑 𐑚𐑦𐑕𐑲𐑛 𐑲𐑑𐑩𐑥𐑟"
-
-#: ../capplets/appearance/data/appearance.ui.h:45
-msgid "Text only"
-msgstr "𐑑𐑧𐑒𐑕𐑑 𐑴𐑯𐑤𐑦"
-
-#: ../capplets/appearance/data/appearance.ui.h:46
-msgid "The current controls theme does not support color schemes."
-msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑟 𐑔𐑰𐑥 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑕𐑩𐑐𐑹𐑑 𐑒𐑳𐑤𐑼 𐑕𐑒𐑰𐑥𐑟."
-
-#: ../capplets/appearance/data/appearance.ui.h:47
-msgid "Theme"
-msgstr "𐑔𐑰𐑥"
-
-#: ../capplets/appearance/data/appearance.ui.h:48
-msgid "Tile"
-msgstr "𐑑𐑲𐑤"
-
-#. vertical hinting, pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.ui.h:50
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/appearance/data/appearance.ui.h:51
-msgid "Vertical gradient"
-msgstr "𐑝𐑻𐑑𐑦𐑒𐑩𐑤 𐑜𐑮𐑱𐑛𐑦𐑩𐑯𐑑"
-
-#: ../capplets/appearance/data/appearance.ui.h:52
-msgid "Window Border"
-msgstr "𐑢𐑦𐑯𐑛𐑴 𐑚𐑹𐑛𐑼"
-
-#: ../capplets/appearance/data/appearance.ui.h:53
-msgid "Zoom"
-msgstr "𐑟𐑵𐑥"
-
-#: ../capplets/appearance/data/appearance.ui.h:54
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:45
-msgid "_Add..."
-msgstr "_𐑨𐑛..."
-
-#: ../capplets/appearance/data/appearance.ui.h:55
-msgid "_Application font:"
-msgstr "_𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯 𐑓𐑪𐑯𐑑:"
-
-#. pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.ui.h:57
-#, fuzzy
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/appearance/data/appearance.ui.h:58
-msgid "_Description:"
-msgstr "_𐑛𐑦𐑕𐑒𐑮𐑦𐑐𐑖𐑩𐑯:"
-
-#: ../capplets/appearance/data/appearance.ui.h:59
-msgid "_Document font:"
-msgstr "_𐑛𐑪𐑒𐑿𐑥𐑩𐑯𐑑 𐑓𐑪𐑯𐑑:"
-
-#: ../capplets/appearance/data/appearance.ui.h:60
-msgid "_Fixed width font:"
-msgstr "_𐑓𐑦𐑒𐑕𐑑 𐑢𐑦𐑛𐑔 𐑓𐑪𐑯𐑑:"
-
-#: ../capplets/appearance/data/appearance.ui.h:61
-msgid "_Full"
-msgstr "_𐑓𐑫𐑤"
-
-#: ../capplets/appearance/data/appearance.ui.h:62
-msgid "_Input boxes:"
-msgstr "_𐑦𐑯𐑐𐑫𐑑 𐑚𐑪𐑒𐑕𐑩𐑟:"
-
-#: ../capplets/appearance/data/appearance.ui.h:63
-msgid "_Install..."
-msgstr "_𐑦𐑯𐑕𐑑𐑷𐑤..."
-
-#: ../capplets/appearance/data/appearance.ui.h:64
-msgid "_Medium"
-msgstr "_𐑥𐑰𐑛𐑦𐑩𐑥"
-
-#: ../capplets/appearance/data/appearance.ui.h:65
-msgid "_Monochrome"
-msgstr "_𐑥𐑭𐑯𐑩𐑒𐑮𐑴𐑥"
-
-#: ../capplets/appearance/data/appearance.ui.h:66
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:5
-msgid "_Name:"
-msgstr "_𐑯𐑱𐑥:"
-
-#: ../capplets/appearance/data/appearance.ui.h:67
-msgid "_None"
-msgstr "_𐑯𐑳𐑯"
-
-#. pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.ui.h:69
-#, fuzzy
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/appearance/data/appearance.ui.h:70
-msgid "_Reset to Defaults"
-msgstr "_𐑮𐑰𐑕𐑧𐑑 𐑑 𐑛𐑦𐑓𐑷𐑤𐑑𐑕"
-
-#: ../capplets/appearance/data/appearance.ui.h:71
-msgid "_Selected items:"
-msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑲𐑑𐑩𐑥𐑟:"
-
-#: ../capplets/appearance/data/appearance.ui.h:72
-msgid "_Size:"
-msgstr "_𐑕𐑲𐑟:"
-
-#: ../capplets/appearance/data/appearance.ui.h:73
-msgid "_Slight"
-msgstr "_𐑕𐑤𐑲𐑑"
-
-#: ../capplets/appearance/data/appearance.ui.h:74
-msgid "_Style:"
-msgstr "_𐑕𐑑𐑲𐑤:"
-
-#: ../capplets/appearance/data/appearance.ui.h:75
-#, fuzzy
-msgid "_Tooltips:"
-msgstr "_Tooltips:"
-
-#. vertical hinting, pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.ui.h:77
-#, fuzzy
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/appearance/data/appearance.ui.h:78
-msgid "_Window title font:"
-msgstr "_𐑢𐑦𐑯𐑛𐑴 𐑑𐑲𐑑𐑩𐑤 𐑓𐑪𐑯𐑑:"
-
-#: ../capplets/appearance/data/appearance.ui.h:79
-msgid "_Windows:"
-msgstr "_𐑢𐑦𐑯𐑛𐑴𐑟:"
-
-#: ../capplets/appearance/data/appearance.ui.h:80
-msgid "dots per inch"
-msgstr "𐑛𐑪𐑑𐑕 𐑐𐑻 𐑦𐑯𐑗"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr "𐑩𐑐𐑽𐑩𐑯𐑕"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr "𐑒𐑩𐑕𐑑𐑩𐑥𐑲𐑟 𐑞 𐑤𐑫𐑒 𐑝 𐑞 𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr "𐑦𐑯𐑕𐑑𐑷𐑤𐑟 𐑔𐑰𐑥𐑟 𐑐𐑨𐑒𐑦𐑡𐑩𐑟 𐑓𐑹 𐑝𐑺𐑦𐑩𐑕 𐑐𐑸𐑑𐑕 𐑝 𐑞 𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr "𐑔𐑰𐑥 𐑦𐑯𐑕𐑑𐑷𐑤𐑼"
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr "𐑯𐑴𐑥 𐑔𐑰𐑥 𐑐𐑨𐑒𐑦𐑡"
-
-#: ../capplets/appearance/gnome-wp-info.c:50
-msgid "No Desktop Background"
-msgstr "𐑯𐑴 𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
-
-#: ../capplets/appearance/gnome-wp-item.c:261
-msgid "Slide Show"
-msgstr "𐑕𐑤𐑲𐑛 𐑖𐑴"
-
-#: ../capplets/appearance/gnome-wp-item.c:263
-msgid "Image"
-msgstr "𐑦𐑥𐑦𐑡"
-
-#: ../capplets/appearance/gnome-wp-item.c:269
-msgid "multiple sizes"
-msgstr "𐑥𐑳𐑤𐑑𐑦𐑐𐑩𐑤 𐑕𐑲𐑟𐑩𐑟"
-
-#. translators: x pixel(s) by y pixel(s)
-#: ../capplets/appearance/gnome-wp-item.c:272
-#, fuzzy
-msgid "%d %s by %d %s"
-msgstr "%d %s 𐑚𐑲 %d %s"
-
-#: ../capplets/appearance/gnome-wp-item.c:274
-#: ../capplets/appearance/gnome-wp-item.c:276
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "𐑐𐑦𐑒𐑕𐑩𐑤"
-msgstr[1] "𐑐𐑦𐑒𐑕𐑩𐑤𐑟"
-
-#. translators: <b>wallpaper name</b>
-#. * mime type, size
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:284
-#, c-format
-msgid ""
-"<b>%s</b>\n"
-"%s, %s\n"
-"Folder: %s"
-msgstr ""
-"<b>%s</b>\n"
-"%s, %s\n"
-"𐑓𐑴𐑤𐑛𐑼: %s"
-
-#. translators: <b>wallpaper name</b>
-#. * Image missing
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:296
-#, fuzzy
-msgid ""
-"<b>%s</b>\n"
-"%s\n"
-"Folder: %s"
-msgstr ""
-"<𐑚𐑰>%s</𐑚𐑰>\n"
-"%s\n"
-"𐑓𐑴𐑤𐑛𐑼: %s"
-
-#: ../capplets/appearance/gnome-wp-item.c:300
-msgid "Image missing"
-msgstr "𐑦𐑥𐑦𐑡 𐑥𐑦𐑕𐑦𐑙"
-
-#: ../capplets/appearance/theme-installer.c:178
-#: ../capplets/appearance/theme-installer.c:234
-msgid "Cannot install theme"
-msgstr "𐑒𐑨𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑔𐑰𐑥"
-
-#: ../capplets/appearance/theme-installer.c:180
-#, c-format
-msgid "The %s utility is not installed."
-msgstr "𐑞 %s 𐑘𐑵𐑑𐑦𐑤𐑩𐑑𐑰 𐑦𐑟 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
-
-#: ../capplets/appearance/theme-installer.c:236
-msgid "There was a problem while extracting the theme."
-msgstr "𐑞𐑺 𐑢𐑪𐑟 𐑩 𐑐𐑮𐑪𐑚𐑤𐑩𐑥 𐑢𐑲𐑤 𐑦𐑒𐑕𐑑𐑮𐑨𐑒𐑑𐑦𐑙 𐑞 𐑔𐑰𐑥."
-
-#: ../capplets/appearance/theme-installer.c:264
-msgid "There was an error installing the selected file"
-msgstr "𐑞𐑺 𐑢𐑪𐑟 𐑩𐑯 𐑻𐑼 𐑦𐑯𐑕𐑑𐑷𐑤𐑦𐑙 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑓𐑲𐑤"
-
-#: ../capplets/appearance/theme-installer.c:265
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme."
-msgstr "\"%s\" 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑩𐑐𐑽 𐑑 𐑚𐑰 𐑩 𐑝𐑨𐑤𐑦𐑛 𐑔𐑰𐑥."
-
-#: ../capplets/appearance/theme-installer.c:266
-#, c-format
-msgid ""
-"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
-"you need to compile."
-msgstr ""
-"\"%s\" 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑩𐑐𐑽 𐑑 𐑚𐑰 𐑩 𐑝𐑨𐑤𐑦𐑛 𐑔𐑰𐑥. 𐑦𐑑 𐑥𐑱 𐑚𐑰 𐑩 𐑔𐑰𐑥 𐑧𐑯𐑡𐑦𐑯 𐑢𐑦𐑗 𐑿 𐑯𐑰𐑛 𐑑 𐑒𐑪𐑥𐑐𐑲𐑤."
-
-#: ../capplets/appearance/theme-installer.c:372
-#, c-format
-msgid "Installation for theme \"%s\" failed."
-msgstr "𐑦𐑯𐑕𐑑𐑩𐑤𐑱𐑖𐑩𐑯 𐑓𐑹 𐑔𐑰𐑥 \"%s\" 𐑓𐑱𐑤𐑛."
-
-#: ../capplets/appearance/theme-installer.c:411
-#, c-format
-msgid "The theme \"%s\" has been installed."
-msgstr "𐑞 𐑔𐑰𐑥 \"%s\" 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
-
-#: ../capplets/appearance/theme-installer.c:421
-msgid "Would you like to apply it now, or keep your current theme?"
-msgstr "𐑢𐑫𐑛 𐑿 𐑤𐑲𐑒 𐑑 𐑩𐑐𐑤𐑲 𐑦𐑑 𐑯𐑬, 𐑹 𐑒𐑰𐑐 𐑿𐑼 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥?"
-
-#: ../capplets/appearance/theme-installer.c:424
-msgid "Keep Current Theme"
-msgstr "𐑒𐑰𐑐 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥"
-
-#: ../capplets/appearance/theme-installer.c:427
-msgid "Apply New Theme"
-msgstr "𐑩𐑐𐑤𐑲 𐑯𐑿 𐑔𐑰𐑥"
-
-#: ../capplets/appearance/theme-installer.c:471
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "·𐑜𐑯𐑴𐑥 𐑔𐑰𐑥 %s 𐑒𐑼𐑧𐑒𐑑𐑤𐑦 𐑦𐑯𐑕𐑑𐑷𐑤𐑛"
-
-#: ../capplets/appearance/theme-installer.c:533
-msgid "Failed to create temporary directory"
-msgstr "𐑓𐑱𐑤𐑛 𐑑 𐑒𐑮𐑦𐑱𐑑 𐑑𐑧𐑥𐑐𐑼𐑼𐑦 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦"
-
-#: ../capplets/appearance/theme-installer.c:596
-msgid "New themes have been successfully installed."
-msgstr "𐑯𐑿 𐑔𐑰𐑥𐑟 𐑣𐑨𐑝 𐑚𐑰𐑯 𐑕𐑩𐑒𐑕𐑧𐑕𐑓𐑩𐑤𐑦 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
-
-#: ../capplets/appearance/theme-installer.c:646
-msgid "No theme file location specified to install"
-msgstr "𐑯𐑴 𐑔𐑰𐑥 𐑓𐑲𐑤 𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑕𐑐𐑧𐑕𐑦𐑓𐑲𐑛 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤"
-
-#: ../capplets/appearance/theme-installer.c:670
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"𐑦𐑯𐑕𐑩𐑓𐑦𐑖𐑩𐑯𐑑 𐑐𐑻𐑥𐑦𐑖𐑪𐑯𐑟 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑞 𐑔𐑰𐑥 𐑦𐑯:\n"
-"%s"
-
-#: ../capplets/appearance/theme-installer.c:748
-msgid "Select Theme"
-msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑔𐑰𐑥"
-
-#: ../capplets/appearance/theme-installer.c:759
-msgid "Theme Packages"
-msgstr "𐑔𐑰𐑥 𐑐𐑨𐑒𐑦𐑡𐑩𐑟"
-
-#: ../capplets/appearance/theme-save.c:93
-#, c-format
-msgid "Theme name must be present"
-msgstr "𐑔𐑰𐑥 𐑯𐑱𐑥 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑐𐑮𐑩𐑟𐑧𐑯𐑑"
-
-#: ../capplets/appearance/theme-save.c:156
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "𐑞 𐑔𐑰𐑥 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕. 𐑢𐑫𐑛 𐑿 𐑤𐑲𐑒 𐑑 𐑮𐑦𐑐𐑤𐑱𐑕 𐑦𐑑?"
-
-#: ../capplets/appearance/theme-save.c:157
-#: ../capplets/common/file-transfer-dialog.c:451
-msgid "_Overwrite"
-msgstr "_𐑴𐑝𐑼𐑮𐑲𐑑"
-
-#: ../capplets/appearance/theme-util.c:75
-msgid "Would you like to delete this theme?"
-msgstr "𐑢𐑫𐑛 𐑿 𐑤𐑲𐑒 𐑑 𐑛𐑦𐑤𐑰𐑑 𐑞𐑦𐑕 𐑔𐑰𐑥?"
-
-#: ../capplets/appearance/theme-util.c:125
-msgid "Theme cannot be deleted"
-msgstr "𐑔𐑰𐑥 𐑒𐑨𐑯𐑪𐑑 𐑚𐑰 𐑛𐑦𐑤𐑰𐑑𐑩𐑛"
-
-#: ../capplets/appearance/theme-util.c:252
-msgid "Could not install theme engine"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑔𐑰𐑥 𐑧𐑯𐑡𐑦𐑯"
-
-#: ../capplets/common/activate-settings-daemon.c:16
-#, fuzzy
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with DBus, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑕𐑑𐑸𐑑 𐑞 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼 '·𐑯𐑴𐑥-𐑕𐑧𐑑𐑦𐑙𐑟-𐑛𐑰𐑥𐑩𐑯'.\n"
-"𐑢𐑦𐑞𐑬𐑑 𐑞 ·𐑯𐑴𐑥 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼 𐑮𐑳𐑯𐑦𐑙, 𐑕𐑳𐑥 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟 𐑥𐑱 𐑯𐑪𐑑 𐑑𐑱𐑒 𐑦𐑓𐑧𐑒𐑑. 𐑞𐑦𐑕 𐑒𐑫𐑛 "
-"𐑦𐑯𐑛𐑦𐑒𐑱𐑑 𐑩 𐑐𐑮𐑪𐑚𐑤𐑩𐑥 𐑢𐑦𐑞 DBus, 𐑹 𐑩 𐑯𐑪𐑯-·𐑯𐑴𐑥 (𐑧.𐑡𐑰. ·𐑒·𐑛·𐑧) 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼 𐑥𐑱 "
-"𐑷𐑤𐑮𐑧𐑛𐑦 𐑚𐑰 𐑨𐑒𐑑𐑦𐑝 𐑯 𐑒𐑩𐑯𐑓𐑤𐑦𐑒𐑑𐑦𐑙 𐑢𐑦𐑞 𐑞 ·𐑯𐑴𐑥 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼."
-
-#: ../capplets/common/capplet-stock-icons.c:66
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑤𐑴𐑛 𐑕𐑑𐑪𐑒 𐑲𐑒𐑪𐑯 '%s'\n"
-
-#: ../capplets/common/capplet-util.c:88
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "𐑞𐑺 𐑢𐑪𐑟 𐑩𐑯 𐑻𐑼 𐑛𐑦𐑕𐑐𐑤𐑱𐑦𐑙 𐑣𐑧𐑤𐑐: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:98
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "𐑒𐑪𐑐𐑦𐑦𐑙 𐑓𐑲𐑤: %u 𐑝 %u"
-
-#: ../capplets/common/file-transfer-dialog.c:145
-#, c-format
-msgid "Copying '%s'"
-msgstr "𐑒𐑪𐑐𐑦𐑦𐑙 '%s'"
-
-#: ../capplets/common/file-transfer-dialog.c:185
-#: ../capplets/common/file-transfer-dialog.c:313
-msgid "Copying files"
-msgstr "𐑒𐑪𐑐𐑦𐑦𐑙 𐑓𐑲𐑤𐑟"
-
-#: ../capplets/common/file-transfer-dialog.c:224
-msgid "Parent Window"
-msgstr "𐑐𐑺𐑩𐑯𐑑 𐑢𐑦𐑯𐑛𐑴"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Parent window of the dialog"
-msgstr "𐑐𐑺𐑩𐑯𐑑 𐑢𐑦𐑯𐑛𐑴 𐑝 𐑞 𐑛𐑲𐑩𐑤𐑪𐑜"
-
-#: ../capplets/common/file-transfer-dialog.c:231
-msgid "From URI"
-msgstr "𐑓𐑮𐑪𐑥 URI"
-
-#: ../capplets/common/file-transfer-dialog.c:232
-msgid "URI currently transferring from"
-msgstr "URI 𐑒𐑳𐑮𐑩𐑯𐑑𐑤𐑦 𐑑𐑮𐑨𐑯𐑕𐑓𐑻𐑦𐑙 𐑓𐑮𐑪𐑥"
-
-#: ../capplets/common/file-transfer-dialog.c:239
-msgid "To URI"
-msgstr "𐑑 URI"
-
-#: ../capplets/common/file-transfer-dialog.c:240
-msgid "URI currently transferring to"
-msgstr "URI 𐑒𐑳𐑮𐑩𐑯𐑑𐑤𐑦 𐑑𐑮𐑨𐑯𐑕𐑓𐑻𐑦𐑙 𐑑"
-
-#: ../capplets/common/file-transfer-dialog.c:247
-msgid "Fraction completed"
-msgstr "𐑓𐑮𐑨𐑒𐑖𐑩𐑯 𐑒𐑩𐑥𐑐𐑤𐑰𐑑𐑩𐑛"
-
-#: ../capplets/common/file-transfer-dialog.c:248
-msgid "Fraction of transfer currently completed"
-msgstr "𐑓𐑮𐑨𐑒𐑖𐑩𐑯 𐑝 𐑑𐑮𐑭𐑯𐑕𐑓𐑼 𐑒𐑳𐑮𐑩𐑯𐑑𐑤𐑦 𐑒𐑩𐑥𐑐𐑤𐑰𐑑𐑩𐑛"
-
-#: ../capplets/common/file-transfer-dialog.c:255
-msgid "Current URI index"
-msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 URI 𐑦𐑯𐑛𐑧𐑒𐑕"
-
-#: ../capplets/common/file-transfer-dialog.c:256
-msgid "Current URI index - starts from 1"
-msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 URI 𐑦𐑯𐑛𐑧𐑒𐑕 - 𐑕𐑑𐑸𐑑𐑕 𐑓𐑮𐑪𐑥 1"
-
-#: ../capplets/common/file-transfer-dialog.c:263
-#, fuzzy
-msgid "Total URIs"
-msgstr "𐑑𐑴𐑑𐑩𐑤 URIs"
-
-#: ../capplets/common/file-transfer-dialog.c:264
-#, fuzzy
-msgid "Total number of URIs"
-msgstr "𐑑𐑴𐑑𐑩𐑤 𐑯𐑳𐑥𐑚𐑼 𐑝 URIs"
-
-#: ../capplets/common/file-transfer-dialog.c:445
-#, c-format
-msgid "File '%s' already exists. Do you want to overwrite it?"
-msgstr "𐑓𐑲𐑤 '%s' 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕. 𐑛𐑵 𐑿 𐑢𐑪𐑯𐑑 𐑑 𐑴𐑝𐑼𐑮𐑲𐑑 𐑦𐑑?"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "_Skip"
-msgstr "_𐑕𐑒𐑦𐑐"
-
-#: ../capplets/common/file-transfer-dialog.c:449
-msgid "Overwrite _All"
-msgstr "𐑴𐑝𐑼𐑮𐑲𐑑 _𐑷𐑤"
-
-#: ../capplets/common/gconf-property-editor.c:134
-msgid "Key"
-msgstr "𐑒𐑰"
-
-#: ../capplets/common/gconf-property-editor.c:135
-#, fuzzy
-msgid "GConf key to which this property editor is attached"
-msgstr "GConf 𐑒𐑰 𐑑 𐑢𐑦𐑗 𐑞𐑦𐑕 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑦𐑟 𐑩𐑑𐑨𐑗𐑑"
-
-#: ../capplets/common/gconf-property-editor.c:141
-#, fuzzy
-msgid "Callback"
-msgstr "Callback"
-
-#: ../capplets/common/gconf-property-editor.c:142
-#, fuzzy
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "𐑦𐑖𐑵 𐑞𐑦𐑕 callback 𐑢𐑧𐑯 𐑞 𐑝𐑨𐑤𐑿 𐑩𐑕𐑴𐑖𐑦𐑱𐑑𐑩𐑛 𐑢𐑦𐑞 𐑒𐑰 𐑜𐑧𐑑𐑕 𐑗𐑱𐑯𐑡𐑛"
-
-#: ../capplets/common/gconf-property-editor.c:147
-msgid "Change set"
+msgid "Ch_ange"
 msgstr "𐑗𐑱𐑯𐑡 𐑕𐑧𐑑"
 
-#: ../capplets/common/gconf-property-editor.c:148
+#: panels/user-accounts/cc-password-dialog.ui:53
 #, fuzzy
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr "GConf 𐑗𐑱𐑯𐑡 𐑕𐑧𐑑 𐑒𐑩𐑯𐑑𐑱𐑯𐑦𐑙 𐑛𐑱𐑑𐑩 𐑑 𐑚𐑰 𐑓𐑪𐑮𐑢𐑻𐑛𐑦𐑛 𐑑 𐑞 gconf 𐑒𐑤𐑲𐑩𐑯𐑑 𐑪𐑯 𐑩𐑐𐑤𐑲"
+msgid "Current Password"
+msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 _𐑐𐑭𐑕𐑢𐑼𐑛:"
 
-#: ../capplets/common/gconf-property-editor.c:153
+#: panels/user-accounts/cc-password-dialog.ui:68
 #, fuzzy
-msgid "Conversion to widget callback"
-msgstr "𐑒𐑩𐑯𐑝𐑻𐑖𐑩𐑯 𐑑 𐑢𐑦𐑡𐑩𐑑 callback"
+msgid "New Password"
+msgstr "_𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛:"
 
-#: ../capplets/common/gconf-property-editor.c:154
+#: panels/user-accounts/cc-password-dialog.ui:99
 #, fuzzy
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "Callback 𐑑 𐑚𐑰 𐑦𐑖𐑵𐑛 𐑢𐑧𐑯 𐑛𐑱𐑑𐑩 𐑸 𐑑 𐑚𐑰 𐑒𐑩𐑯𐑝𐑻𐑑𐑩𐑛 𐑓𐑮𐑪𐑥 GConf 𐑑 𐑞 𐑢𐑦𐑡𐑩𐑑"
+msgid "Confirm Password"
+msgstr "𐑗𐑱𐑯𐑡 𐑐𐑭𐑕𐑢𐑼𐑛"
 
-#: ../capplets/common/gconf-property-editor.c:159
+#: panels/user-accounts/cc-password-dialog.ui:114
 #, fuzzy
-msgid "Conversion from widget callback"
-msgstr "𐑒𐑩𐑯𐑝𐑻𐑖𐑩𐑯 𐑓𐑮𐑪𐑥 𐑢𐑦𐑡𐑩𐑑 callback"
+msgid "The passwords do not match."
+msgstr "𐑞 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑟 𐑑𐑵 𐑖𐑹𐑑."
 
-#: ../capplets/common/gconf-property-editor.c:160
-#, fuzzy
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr "Callback 𐑑 𐑚𐑰 𐑦𐑖𐑵𐑛 𐑢𐑧𐑯 𐑛𐑱𐑑𐑩 𐑸 𐑑 𐑚𐑰 𐑒𐑩𐑯𐑝𐑻𐑑𐑩𐑛 𐑑 GConf 𐑓𐑮𐑪𐑥 𐑞 𐑢𐑦𐑡𐑩𐑑"
-
-#: ../capplets/common/gconf-property-editor.c:165
-#, fuzzy
-msgid "UI Control"
-msgstr "UI 𐑒𐑩𐑯𐑑𐑮𐑴𐑤"
-
-#: ../capplets/common/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr "𐑩𐑚𐑡𐑧𐑒𐑑 𐑞𐑨𐑑 𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑟 𐑞 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 (𐑯𐑹𐑥𐑩𐑤𐑦 𐑩 𐑢𐑦𐑡𐑩𐑑)"
-
-#: ../capplets/common/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr "𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑩𐑚𐑡𐑧𐑒𐑑 𐑛𐑱𐑑𐑩"
-
-#: ../capplets/common/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑛𐑱𐑑𐑩 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑚𐑲 𐑞 𐑕𐑐𐑩𐑕𐑦𐑓𐑦𐑒 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹"
-
-#: ../capplets/common/gconf-property-editor.c:188
-#, fuzzy
-msgid "Property editor data freeing callback"
-msgstr "𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑛𐑱𐑑𐑩 𐑓𐑮𐑰𐑦𐑙 callback"
-
-#: ../capplets/common/gconf-property-editor.c:189
-#, fuzzy
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr "Callback 𐑑 𐑚𐑰 𐑦𐑖𐑵𐑛 𐑢𐑧𐑯 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑩𐑚𐑡𐑧𐑒𐑑 𐑛𐑱𐑑𐑩 𐑦𐑟 𐑑 𐑚𐑰 𐑓𐑮𐑰𐑛"
-
-#: ../capplets/common/gconf-property-editor.c:1406
-#, fuzzy
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
 msgstr ""
-"𐑒𐑫𐑛𐑯𐑑 𐑓𐑲𐑯𐑛 𐑞 𐑓𐑲𐑤 '%s'.\n"
-"\n"
-"𐑐𐑤𐑰𐑟 𐑥𐑱𐑒 𐑖𐑫𐑼 𐑦𐑑 𐑧𐑒𐑟𐑦𐑕𐑑𐑕 𐑯 𐑑𐑮𐑲 𐑩𐑜𐑱𐑯, 𐑹 𐑗𐑵𐑟 𐑩 𐑛𐑦𐑓𐑼𐑩𐑯𐑑 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑐𐑦𐑒𐑗𐑼."
 
-#: ../capplets/common/gconf-property-editor.c:1414
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
 msgstr ""
-"𐑲 𐑛𐑴𐑯𐑑 𐑯𐑴 𐑣𐑬 𐑑 𐑴𐑐𐑩𐑯 𐑞 𐑓𐑲𐑤 '%s'.\n"
-"𐑐𐑼𐑣𐑨𐑐𐑕 𐑦𐑑'𐑕 𐑩 𐑒𐑲𐑯𐑛 𐑝 𐑐𐑦𐑒𐑗𐑼 𐑞𐑨𐑑 𐑦𐑟 𐑯𐑪𐑑 𐑘𐑧𐑑 𐑕𐑩𐑐𐑹𐑑𐑩𐑛.\n"
-"\n"
-"𐑐𐑤𐑰𐑟 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑛𐑦𐑓𐑼𐑩𐑯𐑑 𐑐𐑦𐑒𐑗𐑼 𐑦𐑯𐑕𐑑𐑧𐑛."
 
-#: ../capplets/common/gconf-property-editor.c:1536
-msgid "Please select an image."
-msgstr "𐑐𐑤𐑰𐑟 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩𐑯 𐑦𐑥𐑦𐑡."
-
-#: ../capplets/common/gconf-property-editor.c:1541
-msgid "_Select"
-msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑"
-
-#: ../capplets/common/gnome-theme-info.c:639
-msgid "Default Pointer - Current"
-msgstr "𐑛𐑦𐑓𐑷𐑤𐑑 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
-
-#: ../capplets/common/gnome-theme-info.c:643
-msgid "White Pointer"
-msgstr "𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼"
-
-#: ../capplets/common/gnome-theme-info.c:644
-msgid "White Pointer - Current"
-msgstr "𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
-
-#: ../capplets/common/gnome-theme-info.c:648
-msgid "Large Pointer"
-msgstr "𐑤𐑸𐑡 𐑐𐑶𐑯𐑑𐑼"
-
-#: ../capplets/common/gnome-theme-info.c:649
-msgid "Large Pointer - Current"
-msgstr "𐑤𐑸𐑡 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
-
-#: ../capplets/common/gnome-theme-info.c:653
-msgid "Large White Pointer - Current"
-msgstr "𐑤𐑸𐑡 𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
-
-#: ../capplets/common/gnome-theme-info.c:654
-msgid "Large White Pointer"
-msgstr "𐑤𐑸𐑡 𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼"
-
-#: ../capplets/common/gnome-theme-info.c:1622
-#, fuzzy
-msgid ""
-"This theme will not look as intended because the required GTK+ theme '%s' is "
-"not installed."
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
-"𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 GTK+ 𐑔𐑰𐑥 '%s' 𐑦𐑟 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
 
-#: ../capplets/common/gnome-theme-info.c:1630
-#, c-format
-msgid ""
-"This theme will not look as intended because the required window manager "
-"theme '%s' is not installed."
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
 msgstr ""
-"𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑢𐑦𐑯𐑛𐑴 𐑥𐑨𐑯𐑩𐑡𐑼 𐑔𐑰𐑥 '%s' 𐑦𐑟 𐑯𐑪𐑑 "
-"𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
 
-#: ../capplets/common/gnome-theme-info.c:1637
-#, c-format
-msgid ""
-"This theme will not look as intended because the required icon theme '%s' is "
-"not installed."
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
 msgstr ""
-"𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑲𐑒𐑪𐑯 𐑔𐑰𐑥 '%s' 𐑦𐑟 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:17
-msgid "Preferred Applications"
-msgstr "𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑿𐑼 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-#, fuzzy
-msgid "Start the preferred visual assistive technology"
-msgstr "𐑕𐑑𐑸𐑑 𐑞 𐑐𐑮𐑦𐑓𐑻𐑛 𐑝𐑦𐑠𐑩𐑢𐑩𐑤 assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰"
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤 𐑩𐑕𐑦𐑕𐑑𐑩𐑯𐑕"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:98
-#: ../capplets/default-applications/gnome-da-capplet.c:362
-#: ../capplets/default-applications/gnome-da-capplet.c:383
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "𐑻𐑼 𐑕𐑱𐑝𐑦𐑙 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯: %s"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:722
-msgid "Could not load the main interface"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑤𐑴𐑛 𐑞 𐑥𐑱𐑯 𐑦𐑯𐑑𐑼𐑓𐑱𐑕"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:724
-msgid "Please make sure that the applet is properly installed"
-msgstr "𐑐𐑤𐑰𐑟 𐑥𐑱𐑒 𐑖𐑫𐑼 𐑞𐑨𐑑 𐑞 𐑨𐑐𐑤𐑩𐑑 𐑦𐑟 𐑐𐑮𐑪𐑐𐑼𐑤𐑦 𐑦𐑯𐑕𐑑𐑷𐑤𐑛"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/default-applications/gnome-da-capplet.c:959
-msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
-msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑯𐑱𐑥 𐑝 𐑞 𐑐𐑱𐑡 𐑑 𐑖𐑴 (internet|multimedia|system|a11y)"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:964
-msgid "- GNOME Default Applications"
-msgstr "- ·𐑜𐑯𐑴𐑥 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:1
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:1
-msgid "Accessibility"
-msgstr "𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:3
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "𐑷𐑤 %s 𐑩𐑒𐑻𐑩𐑯𐑕𐑦𐑟 𐑢𐑦𐑤 𐑚𐑰 𐑮𐑦𐑐𐑤𐑱𐑕𐑑 𐑢𐑦𐑞 𐑨𐑒𐑗𐑫𐑩𐑤 𐑤𐑦𐑙𐑒"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:4
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:1
-msgid "C_ommand:"
-msgstr "_𐑒𐑩𐑥𐑭𐑯𐑛:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:5
-msgid "Co_mmand:"
-msgstr "_𐑒𐑩𐑥𐑭𐑯𐑛:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:6
-msgid "E_xecute flag:"
-msgstr "_𐑧𐑒𐑕𐑩𐑒𐑿𐑑 𐑓𐑤𐑨𐑜:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:7
-msgid "Image Viewer"
-msgstr "𐑦𐑥𐑦𐑡 𐑝𐑿𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:8
-msgid "Instant Messenger"
-msgstr "𐑦𐑯𐑕𐑑𐑩𐑯𐑑 𐑥𐑧𐑕𐑩𐑯𐑡𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:9
-msgid "Internet"
-msgstr "·𐑦𐑯𐑑𐑼𐑯𐑧𐑑"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:10
-msgid "Mail Reader"
-msgstr "𐑥𐑱𐑤 𐑮𐑰𐑛𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:11
-msgid "Mobility"
-msgstr "𐑥𐑴𐑚𐑦𐑤𐑩𐑑𐑰"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:12
-msgid "Multimedia"
-msgstr "𐑥𐑩𐑤𐑑𐑰𐑥𐑰𐑛𐑰𐑩"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:13
-msgid "Multimedia Player"
-msgstr "𐑥𐑩𐑤𐑑𐑰𐑥𐑰𐑛𐑰𐑩 𐑐𐑤𐑱𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:14
-msgid "Open link in new _tab"
-msgstr "𐑴𐑐𐑩𐑯 𐑤𐑦𐑙𐑒 𐑦𐑯 𐑯𐑿 _𐑑𐑨𐑚"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:15
-msgid "Open link in new _window"
-msgstr "𐑴𐑐𐑩𐑯 𐑤𐑦𐑙𐑒 𐑦𐑯 𐑯𐑿 _𐑢𐑦𐑯𐑛𐑴"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:16
-msgid "Open link with web browser _default"
-msgstr "𐑴𐑐𐑩𐑯 𐑤𐑦𐑙𐑒 𐑢𐑦𐑞 𐑢𐑧𐑚 𐑚𐑮𐑬𐑟𐑼 _𐑛𐑦𐑓𐑷𐑤𐑑"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:18
-msgid "Run at st_art"
-msgstr "𐑮𐑳𐑯 𐑨𐑑 _𐑕𐑑𐑸𐑑"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:19
-msgid "Run in t_erminal"
-msgstr "𐑮𐑳𐑯 𐑦𐑯 _𐑑𐑻𐑥𐑦𐑯𐑩𐑤"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:20
-msgid "System"
-msgstr "𐑕𐑦𐑕𐑑𐑩𐑥"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:21
-#, fuzzy
-msgid "Terminal Emulator"
-msgstr "𐑑𐑻𐑥𐑦𐑯𐑩𐑤 Emulator"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:22
-msgid "Text Editor"
-msgstr "𐑑𐑧𐑒𐑕𐑑 𐑧𐑛𐑦𐑑𐑹"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:23
-msgid "Video Player"
-msgstr "𐑝𐑦𐑛𐑦𐑴 𐑐𐑤𐑱𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:24
-msgid "Visual"
-msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:25
-msgid "Web Browser"
-msgstr "𐑢𐑧𐑚 𐑚𐑮𐑬𐑟𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:26
-msgid "_Run at start"
-msgstr "_𐑮𐑳𐑯 𐑨𐑑 𐑕𐑑𐑸𐑑"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "·𐑚𐑪𐑤𐑕𐑩"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr "·𐑚𐑨𐑯𐑖𐑰 𐑥𐑿𐑟𐑦𐑒 𐑐𐑤𐑱𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr "·𐑒𐑤𐑷𐑟 𐑥𐑱𐑤"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr "·𐑛𐑨𐑖𐑻"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-#, fuzzy
-msgid "Debian Sensible Browser"
-msgstr "Debian 𐑕𐑧𐑯𐑕𐑩𐑚𐑩𐑤 𐑚𐑮𐑬𐑟𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-#, fuzzy
-msgid "Debian Terminal Emulator"
-msgstr "Debian 𐑑𐑻𐑥𐑦𐑯𐑩𐑤 Emulator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-#, fuzzy
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr "·𐑦𐑯𐑒𐑳𐑥𐑐𐑩𐑕"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr "·𐑦𐑐𐑦𐑓𐑩𐑯𐑦 𐑢𐑧𐑚 𐑚𐑮𐑬𐑟𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr "·𐑧𐑝𐑩𐑤𐑵𐑖𐑩𐑯 𐑥𐑱𐑤 𐑮𐑰𐑛𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr "·𐑓𐑲𐑻𐑚𐑻𐑛"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-#, fuzzy
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr "·𐑜𐑯𐑴𐑥 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻 𐑢𐑦𐑞𐑬𐑑 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr "·𐑜𐑯𐑴𐑥 𐑭𐑯𐑕𐑒𐑮𐑰𐑯 𐑒𐑰𐑚𐑪𐑮𐑛"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr "·𐑜𐑯𐑴𐑥 𐑑𐑻𐑥𐑦𐑯𐑩𐑤"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-#, fuzzy
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-#, fuzzy
-msgid "Gnopernicus"
-msgstr "Gnopernicus"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-#, fuzzy
-msgid "Gnopernicus with Magnifier"
-msgstr "Gnopernicus 𐑢𐑦𐑞 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-#, fuzzy
-msgid "Iceape"
-msgstr "Iceape"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-#, fuzzy
-msgid "Iceape Mail"
-msgstr "Iceape 𐑥𐑱𐑤"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-#, fuzzy
-msgid "Icedove"
-msgstr "Icedove"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-#, fuzzy
-msgid "Iceweasel"
-msgstr "Iceweasel"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr "KDE 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻 𐑢𐑦𐑞𐑬𐑑 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr "·𐑒𐑱𐑥𐑱𐑤"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr "·𐑒𐑪𐑙𐑒𐑼𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-#, fuzzy
-msgid "Konsole"
-msgstr "Konsole"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr "·𐑤𐑦𐑯𐑩𐑒𐑕 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr "·𐑤𐑦𐑯𐑩𐑒𐑕 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼 𐑢𐑦𐑞 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Listen"
-msgstr "·𐑤𐑦𐑕𐑩𐑯"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-#, fuzzy
-msgid "Midori"
-msgstr "Midori"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-#, fuzzy
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-#, fuzzy
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-#, fuzzy
-msgid "Mozilla Mail"
-msgstr "Mozilla 𐑥𐑱𐑤"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-#, fuzzy
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla 𐑔𐑩𐑯𐑛𐑻𐑚𐑻𐑛"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-#, fuzzy
-msgid "Muine Music Player"
-msgstr "Muine 𐑥𐑿𐑟𐑦𐑒 𐑐𐑤𐑱𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "Mutt"
-msgstr "·𐑥𐑩𐑑"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-#, fuzzy
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Netscape Communicator"
-msgstr "·𐑯𐑧𐑑𐑕𐑒𐑱𐑐 ·𐑒𐑩𐑥𐑘𐑵𐑯𐑩𐑒𐑱𐑑𐑻"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Opera"
-msgstr "·𐑪𐑐𐑼𐑩"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca"
-msgstr "·𐑪𐑮𐑒𐑩"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "Orca with Magnifier"
-msgstr "·𐑪𐑮𐑒𐑩 𐑢𐑦𐑞 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-#, fuzzy
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-#, fuzzy
-msgid "Rhythmbox Music Player"
-msgstr "Rhythmbox 𐑥𐑿𐑟𐑦𐑒 𐑐𐑤𐑱𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-#, fuzzy
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-#, fuzzy
-msgid "SeaMonkey Mail"
-msgstr "SeaMonkey 𐑥𐑱𐑤"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-#, fuzzy
-msgid "Standard XTerminal"
-msgstr "𐑕𐑑𐑨𐑯𐑛𐑼𐑛 XTerminal"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-#, fuzzy
-msgid "Sylpheed"
-msgstr "Sylpheed"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-#, fuzzy
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-𐑒𐑤𐑷𐑟"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Terminator"
-msgstr "·𐑑𐑻𐑥𐑩𐑯𐑱𐑑𐑻"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Thunderbird"
-msgstr "·𐑔𐑩𐑯𐑛𐑻𐑚𐑻𐑛"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "Totem Movie Player"
-msgstr "·𐑑𐑴𐑑𐑩𐑥 𐑥𐑵𐑝𐑰 𐑐𐑤𐑱𐑼"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
-#, fuzzy
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/display/display-capplet.ui.h:1
-msgid "Include _panel"
-msgstr "𐑦𐑯𐑒𐑤𐑵𐑛 _𐑐𐑨𐑯𐑩𐑤"
-
-#: ../capplets/display/display-capplet.ui.h:2
-#: ../capplets/display/xrandr-capplet.c:310
-msgid "Left"
-msgstr "𐑤𐑧𐑓𐑑"
-
-#: ../capplets/display/display-capplet.ui.h:3
-msgid "Make Default"
-msgstr "𐑥𐑱𐑒 𐑛𐑦𐑓𐑷𐑤𐑑"
-
-#: ../capplets/display/display-capplet.ui.h:4
-#: ../capplets/display/xrandr-capplet.c:513
-msgid "Monitor"
-msgstr "𐑥𐑪𐑯𐑦𐑑𐑼"
-
-#: ../capplets/display/display-capplet.ui.h:5
-msgid "Monitor Preferences"
-msgstr "𐑥𐑪𐑯𐑦𐑑𐑼 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/display/display-capplet.ui.h:6
-#: ../capplets/display/xrandr-capplet.c:309
-#: ../capplets/display/xrandr-capplet.c:348
-msgid "Normal"
-msgstr "𐑯𐑹𐑥𐑩𐑤"
-
-#: ../capplets/display/display-capplet.ui.h:7
-msgid "Off"
-msgstr "𐑪𐑓"
-
-#: ../capplets/display/display-capplet.ui.h:8
-msgid "On"
-msgstr "𐑪𐑯"
-
-#: ../capplets/display/display-capplet.ui.h:9
-msgid "Panel icon"
-msgstr "𐑐𐑨𐑯𐑩𐑤 𐑲𐑒𐑪𐑯"
-
-#: ../capplets/display/display-capplet.ui.h:10
-msgid "R_otation:"
-msgstr "_𐑮𐑴𐑑𐑱𐑖𐑩𐑯:"
-
-#: ../capplets/display/display-capplet.ui.h:11
-msgid "Re_fresh rate:"
-msgstr "_𐑮𐑰𐑓𐑮𐑧𐑖 𐑮𐑱𐑑:"
-
-#: ../capplets/display/display-capplet.ui.h:12
-#: ../capplets/display/xrandr-capplet.c:311
-msgid "Right"
-msgstr "𐑮𐑲𐑑"
-
-#: ../capplets/display/display-capplet.ui.h:13
-msgid "Sa_me image in all monitors"
-msgstr "_𐑕𐑱𐑥 𐑦𐑥𐑦𐑡 𐑦𐑯 𐑷𐑤 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
-
-#: ../capplets/display/display-capplet.ui.h:14
-msgid "Upside-down"
-msgstr "𐑳𐑐𐑕𐑲𐑛-𐑛𐑬𐑯"
-
-#: ../capplets/display/display-capplet.ui.h:15
-msgid "_Detect monitors"
-msgstr "_𐑛𐑦𐑑𐑧𐑒𐑑 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
-
-#: ../capplets/display/display-capplet.ui.h:16
-msgid "_Resolution:"
-msgstr "_𐑮𐑧𐑟𐑩𐑤𐑵𐑖𐑩𐑯:"
-
-#: ../capplets/display/display-capplet.ui.h:17
-msgid "_Show monitors in panel"
-msgstr "_𐑖𐑴 𐑥𐑪𐑯𐑦𐑑𐑼𐑟 𐑦𐑯 𐑐𐑨𐑯𐑩𐑤"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change resolution and position of monitors"
-msgstr "𐑗𐑱𐑯𐑡 𐑮𐑧𐑟𐑩𐑤𐑵𐑖𐑩𐑯 𐑯 𐑐𐑩𐑟𐑦𐑖𐑩𐑯 𐑝 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Monitors"
-msgstr "𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:44
-#, fuzzy
-msgid ""
-"Usage: %s SOURCE_FILE DEST_NAME\n"
-"\n"
-"This program installs a RANDR profile for multi-monitor setups into\n"
-"a systemwide location.  The resulting profile will get used when\n"
-"the RANDR plug-in gets run in gnome-settings-daemon.\n"
-"\n"
-"SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
-"xml\n"
-"\n"
-"DEST_NAME - relative name for the installed file.  This will get put in\n"
-"            the systemwide directory for RANDR configurations,\n"
-"            so the result will typically be %s/DEST_NAME\n"
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
 msgstr ""
-"𐑿𐑕𐑦𐑡: %s _SOURCEFILE _DESTNAME\n"
-"\n"
-"𐑞𐑦𐑕 𐑐𐑮𐑴𐑜𐑮𐑨𐑥 𐑦𐑯𐑕𐑑𐑷𐑤𐑟 𐑩 RANDR 𐑐𐑮𐑴𐑓𐑲𐑤 𐑓𐑹 𐑥𐑩𐑤𐑑𐑰-𐑥𐑪𐑯𐑦𐑑𐑼 𐑕𐑧𐑑𐑩𐑐𐑕 𐑦𐑯𐑑𐑫\n"
-"𐑩 𐑕𐑦𐑕𐑑𐑩𐑥𐑢𐑲𐑛 𐑤𐑴𐑒𐑱𐑖𐑩𐑯.  𐑞 𐑮𐑦𐑟𐑳𐑤𐑑𐑦𐑙 𐑐𐑮𐑴𐑓𐑲𐑤 𐑢𐑦𐑤 𐑜𐑧𐑑 𐑿𐑟𐑛 𐑢𐑧𐑯\n"
-"𐑞 RANDR 𐑐𐑤𐑳𐑜-𐑦𐑯 𐑜𐑧𐑑𐑕 𐑮𐑳𐑯 𐑦𐑯 ·𐑯𐑴𐑥-𐑕𐑧𐑑𐑦𐑙𐑟-𐑛𐑰𐑥𐑩𐑯.\n"
-"\n"
-"_SOURCEFILE - 𐑩 𐑓𐑫𐑤 pathname, 𐑑𐑦𐑐𐑦𐑒𐑤𐑰 /𐑣𐑴𐑥/𐑿𐑟𐑼𐑯𐑱𐑥/.𐑒𐑪𐑯𐑓𐑦𐑜/𐑥𐑪𐑯𐑦𐑑𐑼𐑟.·𐑦·𐑥·𐑤\n"
-"\n"
-"_DESTNAME - 𐑮𐑧𐑤𐑩𐑑𐑦𐑝 𐑯𐑱𐑥 𐑓𐑹 𐑞 𐑦𐑯𐑕𐑑𐑷𐑤𐑛 𐑓𐑲𐑤.  𐑞𐑦𐑕 𐑢𐑦𐑤 𐑜𐑧𐑑 𐑐𐑫𐑑 𐑦𐑯\n"
-"            𐑞 𐑕𐑦𐑕𐑑𐑩𐑥𐑢𐑲𐑛 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦 𐑓𐑹 RANDR 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯𐑟,\n"
-"            𐑕𐑴 𐑞 𐑮𐑦𐑟𐑳𐑤𐑑 𐑢𐑦𐑤 𐑑𐑦𐑐𐑦𐑒𐑤𐑰 𐑚𐑰 %s/_DESTNAME\n"
 
-#. Translators: only able to install RANDR profiles as root
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:151
-msgid "This program can only be used by the root user"
-msgstr "𐑞𐑦𐑕 𐑐𐑮𐑴𐑜𐑮𐑨𐑥 𐑒𐑨𐑯 𐑴𐑯𐑤𐑦 𐑚𐑰 𐑿𐑟𐑛 𐑚𐑲 𐑞 𐑮𐑵𐑑 𐑿𐑟𐑼"
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:168
-msgid "The source filename must be absolute"
-msgstr "𐑞 𐑕𐑹𐑕 𐑓𐑲𐑤𐑯𐑱𐑥 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑨𐑚𐑕𐑴𐑤𐑵𐑑"
-
-#. Translators: first %s is a filename; second %s is an error message
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:179
+#: panels/user-accounts/cc-user-panel.ui:152
 #, fuzzy
-msgid "Could not open %s: %s\n"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑴𐑐𐑩𐑯 %s: %s\n"
+msgid "Full name"
+msgstr "𐑓𐑫𐑤 𐑯𐑱𐑥"
 
-#. Translators: first %s is a filename; second %s is an error message
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:188
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
 #, fuzzy
-msgid "Could not get information for %s: %s\n"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑜𐑧𐑑 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯 𐑓𐑹 %s: %s\n"
+msgid "_Fingerprint Login"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯"
 
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:195
-#, fuzzy
-msgid "%s must be a regular file\n"
-msgstr "%s 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑩 𐑮𐑧𐑜𐑘𐑫𐑤𐑼 𐑓𐑲𐑤\n"
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
 
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:204
-#, fuzzy
-msgid "This program must only be run through pkexec(1)"
-msgstr "𐑞𐑦𐑕 𐑐𐑮𐑴𐑜𐑮𐑨𐑥 𐑥𐑳𐑕𐑑 𐑴𐑯𐑤𐑦 𐑚𐑰 𐑮𐑳𐑯 𐑔𐑮𐑵 pkexec(1)"
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
 
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:209
-#, fuzzy
-msgid "PKEXEC_UID must be set to an integer value"
-msgstr "_PKEXECUID 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑕𐑧𐑑 𐑑 𐑩𐑯 𐑦𐑯𐑑𐑩𐑡𐑼 𐑝𐑨𐑤𐑿"
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
 
-#. Translators: we are complaining that a file must be really owned by the user who called this program
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:215
-#, fuzzy
-msgid "%s must be owned by you\n"
-msgstr "%s 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑴𐑯𐑛 𐑚𐑲 𐑿\n"
-
-#. Translators: here we are saying that a plain filename must look like "filename", not like "some_dir/filename"
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:223
-#, fuzzy
-msgid "%s must not have any directory components\n"
-msgstr "%s 𐑥𐑳𐑕𐑑 𐑯𐑪𐑑 𐑣𐑨𐑝 𐑧𐑯𐑦 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦 𐑒𐑩𐑥𐑐𐑴𐑯𐑩𐑯𐑑𐑕\n"
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:231
-#, fuzzy
-msgid "%s must be a directory\n"
-msgstr "%s 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑩 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦\n"
-
-#. Translators: the first %s/%s is a directory/filename; the last %s is an error message
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:242
-#, fuzzy
-msgid "Could not open %s/%s: %s\n"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑴𐑐𐑩𐑯 %s/%s: %s\n"
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:262
-#, fuzzy
-msgid "Could not rename %s to %s: %s\n"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑮𐑰𐑯𐑱𐑥 %s 𐑑 %s: %s\n"
-
-#: ../capplets/display/org.gnome.randr.policy.in.h:1
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"Authentication is required to install multi-monitor settings for all users"
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑟"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "𐑴𐑐𐑩𐑯 𐑢𐑦𐑞 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "𐑳𐑞𐑼 𐑓𐑦𐑙𐑜𐑼: "
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "𐑯𐑴 𐑥𐑨𐑗𐑩𐑟 𐑓𐑬𐑯𐑛."
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+#, fuzzy
+msgid "Authentication is required to change user data"
 msgstr "𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑖𐑩𐑯 𐑦𐑟 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑥𐑩𐑤𐑑𐑰-𐑥𐑪𐑯𐑦𐑑𐑼 𐑕𐑧𐑑𐑦𐑙𐑟 𐑓𐑹 𐑷𐑤 𐑿𐑟𐑼𐑟"
 
-#: ../capplets/display/org.gnome.randr.policy.in.h:2
-msgid "Install multi-monitor settings for the whole system"
-msgstr "𐑦𐑯𐑕𐑑𐑷𐑤 𐑥𐑩𐑤𐑑𐑰-𐑥𐑪𐑯𐑦𐑑𐑼 𐑕𐑧𐑑𐑦𐑙𐑟 𐑓𐑹 𐑞 𐑣𐑴𐑤 𐑕𐑦𐑕𐑑𐑩𐑥"
-
-#: ../capplets/display/xrandr-capplet.c:312
-msgid "Upside Down"
-msgstr "𐑳𐑐𐑕𐑲𐑛 𐑛𐑬𐑯"
-
-#: ../capplets/display/xrandr-capplet.c:354
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 #, fuzzy
-msgid "%d Hz"
-msgstr "%d Hz"
+msgid "Map Buttons"
+msgstr "𐑩𐑤𐑻𐑑 𐑚𐑳𐑑𐑩𐑯𐑟"
 
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../capplets/display/xrandr-capplet.c:502
-#: ../capplets/display/xrandr-capplet.c:1648
-msgid "Mirror Screens"
-msgstr "𐑥𐑦𐑮𐑼 𐑕𐑒𐑮𐑰𐑯𐑟"
-
-#: ../capplets/display/xrandr-capplet.c:504
-#, c-format
-msgid "Monitor: %s"
-msgstr "𐑥𐑪𐑯𐑦𐑑𐑼: %s"
-
-#: ../capplets/display/xrandr-capplet.c:582
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#: ../capplets/display/xrandr-capplet.c:1504
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑥𐑪𐑯𐑦𐑑𐑼 𐑑 𐑗𐑱𐑯𐑡 𐑦𐑑𐑕 𐑐𐑮𐑪𐑐𐑼𐑑𐑦𐑟; 𐑛𐑮𐑨𐑜 𐑦𐑑 𐑑 𐑮𐑰𐑻𐑱𐑯𐑡 𐑦𐑑𐑕 𐑐𐑤𐑱𐑕𐑥𐑩𐑯𐑑."
-
-#: ../capplets/display/xrandr-capplet.c:2069
-msgid "Could not save the monitor configuration"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑕𐑱𐑝 𐑞 𐑥𐑪𐑯𐑦𐑑𐑼 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯"
-
-#: ../capplets/display/xrandr-capplet.c:2091
-msgid "Could not get session bus while applying display configuration"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑜𐑧𐑑 𐑕𐑧𐑖𐑩𐑯 𐑚𐑳𐑕 𐑢𐑲𐑤 𐑩𐑐𐑤𐑲𐑦𐑙 𐑛𐑩𐑕𐑐𐑤𐑱 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯"
-
-#: ../capplets/display/xrandr-capplet.c:2133
-msgid "Could not detect displays"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑛𐑦𐑑𐑧𐑒𐑑 𐑛𐑦𐑕𐑐𐑤𐑱𐑟"
-
-#: ../capplets/display/xrandr-capplet.c:2325
-msgid "The monitor configuration has been saved"
-msgstr "𐑞 𐑥𐑪𐑯𐑦𐑑𐑼 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑕𐑱𐑝𐑛"
-
-#: ../capplets/display/xrandr-capplet.c:2327
-msgid "This configuration will be used the next time someone logs in."
-msgstr "𐑞𐑦𐑕 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑢𐑦𐑤 𐑚𐑰 𐑿𐑟𐑛 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑑𐑲𐑥 𐑕𐑳𐑥𐑢𐑳𐑯 𐑤𐑪𐑜𐑟 𐑦𐑯."
-
-#: ../capplets/display/xrandr-capplet.c:2361
-msgid "Could not set the default configuration for monitors"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑕𐑧𐑑 𐑞 𐑛𐑦𐑓𐑷𐑤𐑑 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑓𐑹 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
-
-#: ../capplets/display/xrandr-capplet.c:2403
-msgid "Could not get screen information"
-msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑜𐑧𐑑 𐑕𐑒𐑮𐑰𐑯 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯"
-
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-msgid "Sound"
-msgstr "𐑕𐑬𐑯𐑛"
-
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-#: ../libslab/bookmark-agent.c:1146
-msgid "Desktop"
-msgstr "𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr "𐑯𐑿 𐑕𐑹𐑑𐑒𐑳𐑑..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 𐑒𐑰"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 𐑥𐑪𐑛𐑦𐑓𐑲𐑼𐑟"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-#, fuzzy
-msgid "Accelerator keycode"
-msgstr "𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 keycode"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "𐑩𐑒𐑕𐑧𐑤 𐑥𐑴𐑛"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "𐑞 𐑑𐑲𐑐 𐑝 𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:119
-#: ../typing-break/drwright.c:498
-msgid "Disabled"
-msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:200
-msgid "<Unknown Action>"
-msgstr "<𐑳𐑯𐑴𐑯 𐑨𐑒𐑖𐑩𐑯>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:950
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1581
-msgid "Custom Shortcuts"
-msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1092
-msgid "Error saving the new shortcut"
-msgstr "𐑻𐑼 𐑕𐑱𐑝𐑦𐑙 𐑞 𐑯𐑿 𐑕𐑹𐑑𐑒𐑳𐑑"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1171
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
 msgstr ""
-"𐑞 𐑕𐑹𐑑𐑒𐑳𐑑 \"%s\" 𐑒𐑨𐑯𐑪𐑑 𐑚𐑰 𐑿𐑟𐑛 𐑚𐑦𐑒𐑪𐑟 𐑦𐑑 𐑢𐑦𐑤 𐑚𐑦𐑒𐑳𐑥 𐑦𐑥𐑐𐑪𐑕𐑩𐑚𐑩𐑤 𐑑 𐑑𐑲𐑐 𐑿𐑟𐑦𐑙 𐑞𐑦𐑕 "
-"𐑒𐑰.\n"
-"𐑐𐑤𐑰𐑟 𐑑𐑮𐑲 𐑢𐑦𐑞 𐑩 𐑒𐑰 𐑕𐑳𐑗 𐑨𐑟 𐑒𐑩𐑯𐑑𐑮𐑴𐑤, 𐑷𐑤𐑑 𐑹 𐑖𐑦𐑓𐑑 𐑨𐑑 𐑞 𐑕𐑱𐑥 𐑑𐑲𐑥."
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1201
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-"𐑞 𐑕𐑹𐑑𐑒𐑳𐑑 \"%s\" 𐑦𐑟 𐑷𐑤𐑮𐑧𐑛𐑦 𐑿𐑕𐑑 𐑓𐑹\n"
-"\"%s\""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1207
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "𐑦𐑓 𐑿 𐑮𐑰𐑩𐑕𐑲𐑯 𐑞 𐑕𐑹𐑑𐑒𐑳𐑑 𐑑 \"%s\", 𐑞 \"%s\" 𐑕𐑹𐑑𐑒𐑳𐑑 𐑢𐑦𐑤 𐑚𐑰 𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛."
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1215
-msgid "_Reassign"
-msgstr "_𐑮𐑰𐑩𐑕𐑲𐑯"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1335
-#, fuzzy
-msgid "Error unsetting accelerator in configuration database: %s"
-msgstr "𐑻𐑼 unsetting 𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 𐑦𐑯 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑛𐑱𐑑𐑩𐑚𐑱𐑕: %s"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1536
-msgid "Too many custom shortcuts"
-msgstr "𐑑𐑵 𐑥𐑧𐑯𐑦 𐑒𐑳𐑕𐑑𐑩𐑥 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1832
-msgid "Action"
-msgstr "𐑨𐑒𐑖𐑩𐑯"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1854
-msgid "Shortcut"
-msgstr "𐑕𐑹𐑑𐑒𐑳𐑑"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:2
-msgid "Custom Shortcut"
-msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑕𐑹𐑑𐑒𐑳𐑑"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:3
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:4
+#: panels/wacom/button-mapping.ui:51
 #, fuzzy
 msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new key "
-"combination, or press backspace to clear."
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 "𐑑 𐑧𐑛𐑦𐑑 𐑩 𐑕𐑹𐑑𐑒𐑳𐑑 𐑒𐑰, 𐑒𐑤𐑦𐑒 𐑪𐑯 𐑞 𐑒𐑪𐑮𐑦𐑐𐑪𐑯𐑛𐑦𐑙 𐑮𐑴 𐑯 𐑑𐑲𐑐 𐑩 𐑯𐑿 𐑒𐑰 𐑒𐑪𐑥𐑚𐑦𐑯𐑱𐑖𐑩𐑯, 𐑹 𐑐𐑮𐑧𐑕 "
 "backspace 𐑑 𐑒𐑤𐑽."
 
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "𐑩𐑕𐑲𐑯 𐑕𐑹𐑑𐑒𐑳𐑑 𐑒𐑰𐑟 𐑑 𐑒𐑩𐑥𐑭𐑯𐑛𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:205
-#: ../capplets/keyboard/gnome-keyboard-properties.c:210
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr "𐑡𐑳𐑕𐑑 𐑩𐑐𐑤𐑲 𐑕𐑧𐑑𐑦𐑙𐑟 𐑯 𐑒𐑢𐑦𐑑 (𐑒𐑩𐑥𐑐𐑨𐑑𐑩𐑚𐑦𐑤𐑩𐑑𐑰 𐑴𐑯𐑤𐑦; 𐑯𐑬 𐑣𐑨𐑯𐑛𐑩𐑤𐑛 𐑚𐑲 𐑛𐑰𐑥𐑩𐑯)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:215
-msgid "Start the page with the typing break settings showing"
-msgstr "𐑕𐑑𐑸𐑑 𐑞 𐑐𐑱𐑡 𐑢𐑦𐑞 𐑞 𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒 𐑕𐑧𐑑𐑦𐑙𐑟 𐑖𐑴𐑦𐑙"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:220
-msgid "Start the page with the accessibility settings showing"
-msgstr "𐑕𐑑𐑸𐑑 𐑞 𐑐𐑱𐑡 𐑢𐑦𐑞 𐑞 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑕𐑧𐑑𐑦𐑙𐑟 𐑖𐑴𐑦𐑙"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:226
-msgid "- GNOME Keyboard Preferences"
-msgstr "- ·𐑜𐑯𐑴𐑥 𐑒𐑰𐑚𐑪𐑮𐑛 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:1
-msgid "Beep when _accessibility features are turned on or off"
-msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 _𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑓𐑰𐑗𐑼𐑟 𐑸 𐑑𐑻𐑯𐑛 𐑪𐑯 𐑹 𐑪𐑓"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:2
-msgid "Beep when a _modifier key is pressed"
-msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 _𐑥𐑪𐑛𐑦𐑓𐑲𐑼 𐑒𐑰 𐑦𐑟 𐑐𐑮𐑧𐑕𐑑"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:3
-msgid "Beep when a _toggle key is pressed"
-msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 _𐑑𐑪𐑜𐑩𐑤 𐑒𐑰 𐑦𐑟 𐑐𐑮𐑧𐑕𐑑"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:4
-msgid "Beep when a key is pr_essed"
-msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 𐑒𐑰 𐑦𐑟 pr_essed"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:5
-msgid "Beep when a key is reje_cted"
-msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 𐑒𐑰 𐑦𐑟 reje_cted"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:6
-msgid "Beep when key is _accepted"
-msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑒𐑰 𐑦𐑟 _𐑨𐑒𐑕𐑧𐑐𐑑𐑩𐑛"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:7
-msgid "Beep when key is _rejected"
-msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑒𐑰 𐑦𐑟 _𐑮𐑦𐑡𐑧𐑒𐑑𐑧𐑛"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:8
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:4
-msgid "Bounce Keys"
-msgstr "𐑚𐑶𐑯𐑕 𐑒𐑰𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:9
-#, fuzzy
-msgid "Flash _window titlebar"
-msgstr "𐑓𐑤𐑨𐑖 _𐑢𐑦𐑯𐑛𐑴 titlebar"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:10
-msgid "Flash entire _screen"
-msgstr "𐑓𐑤𐑨𐑖 𐑧𐑯𐑑𐑲𐑼 _𐑕𐑒𐑮𐑰𐑯"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:11
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:14
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:15
-msgid "General"
-msgstr "𐑡𐑧𐑯𐑼𐑩𐑤"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:12
-msgid "Keyboard Accessibility Audio Feedback"
-msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑷𐑛𐑦𐑴 𐑓𐑰𐑛𐑚𐑨𐑒"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:13
-msgid "Show _visual feedback for the alert sound"
-msgstr "𐑖𐑴 _𐑝𐑦𐑠𐑩𐑢𐑩𐑤 𐑓𐑰𐑛𐑚𐑨𐑒 𐑓𐑹 𐑞 𐑩𐑤𐑻𐑑 𐑕𐑬𐑯𐑛"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:14
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:39
-msgid "Slow Keys"
-msgstr "𐑕𐑤𐑴 𐑒𐑰𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:15
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:40
-msgid "Sticky Keys"
-msgstr "𐑕𐑑𐑦𐑒𐑦 𐑒𐑰𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:16
-msgid "Visual cues for sounds"
-msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤 𐑒𐑘𐑵𐑟 𐑓𐑹 𐑕𐑬𐑯𐑛𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:2
-msgid "All_ow postponing of breaks"
-msgstr "_𐑩𐑤𐑬 𐑐𐑴𐑕𐑑𐑐𐑴𐑯𐑦𐑙 𐑝 𐑚𐑮𐑱𐑒𐑕"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:3
-msgid "Audio _Feedback..."
-msgstr "𐑷𐑛𐑦𐑴 _𐑓𐑰𐑛𐑚𐑨𐑒..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:5
-msgid "Check if breaks are allowed to be postponed"
-msgstr "𐑗𐑧𐑒 𐑦𐑓 𐑚𐑮𐑱𐑒𐑕 𐑸 𐑩𐑤𐑬𐑛 𐑑 𐑚𐑰 𐑐𐑴𐑕𐑑𐑐𐑴𐑯𐑛"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:6
-msgid "Cursor Blinking"
-msgstr "𐑒𐑻𐑕𐑼 𐑚𐑤𐑦𐑙𐑒𐑦𐑙"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:7
-msgid "Cursor _blinks in text fields"
-msgstr "𐑒𐑻𐑕𐑼 _𐑚𐑤𐑦𐑙𐑒𐑕 𐑦𐑯 𐑑𐑧𐑒𐑕𐑑 𐑓𐑰𐑤𐑛𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:8
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:4
-msgid "Cursor blinks speed"
-msgstr "𐑒𐑻𐑕𐑼 𐑚𐑤𐑦𐑙𐑒𐑕 𐑕𐑐𐑰𐑛"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:9
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:5
-msgid "D_elay:"
-msgstr "_𐑛𐑦𐑤𐑱:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:10
-msgid "Disa_ble sticky keys if two keys are pressed together"
-msgstr "_𐑛𐑦𐑕𐑱𐑚𐑩𐑤 𐑕𐑑𐑦𐑒𐑦 𐑒𐑰𐑟 𐑦𐑓 𐑑𐑵 𐑒𐑰𐑟 𐑸 𐑐𐑮𐑧𐑕𐑑 𐑑𐑫𐑜𐑧𐑞𐑼"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:11
-msgid "Duration of the break when typing is disallowed"
-msgstr "𐑛𐑫𐑮𐑱𐑖𐑩𐑯 𐑝 𐑞 𐑚𐑮𐑱𐑒 𐑢𐑧𐑯 𐑑𐑲𐑐𐑦𐑙 𐑦𐑟 𐑛𐑦𐑕𐑩𐑤𐑶𐑛"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:12
-msgid "Duration of work before forcing a break"
-msgstr "𐑛𐑫𐑮𐑱𐑖𐑩𐑯 𐑝 𐑢𐑻𐑒 𐑚𐑦𐑓𐑹 𐑓𐑹𐑕𐑦𐑙 𐑩 𐑚𐑮𐑱𐑒"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:13
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:14
-msgid "Fast"
-msgstr "𐑓𐑭𐑕𐑑"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:15
-msgid "Key presses _repeat when key is held down"
-msgstr "𐑒𐑰 𐑐𐑮𐑧𐑕𐑩𐑟 _𐑮𐑦𐑐𐑰𐑑 𐑢𐑧𐑯 𐑒𐑰 𐑦𐑟 𐑣𐑧𐑤𐑛 𐑛𐑬𐑯"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:16
-msgid "Keyboard Preferences"
-msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:17
-msgid "Keyboard _model:"
-msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 _𐑥𐑪𐑛𐑩𐑤:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:18
-msgid "Layouts"
-msgstr "𐑤𐑱𐑬𐑑𐑕"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:19
-msgid "List of keyboard layouts selected for usage"
-msgstr "𐑤𐑦𐑕𐑑 𐑝 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑𐑕 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑓𐑹 𐑿𐑕𐑦𐑡"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:20
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
 msgstr ""
-"𐑤𐑪𐑒 𐑕𐑒𐑮𐑰𐑯 𐑭𐑓𐑑𐑼 𐑩 𐑕𐑻𐑑𐑩𐑯 𐑛𐑫𐑮𐑱𐑖𐑩𐑯 𐑑 𐑣𐑧𐑤𐑐 𐑐𐑮𐑦𐑝𐑧𐑯𐑑 𐑮𐑦𐑐𐑧𐑑𐑦𐑑𐑦𐑝 𐑒𐑰𐑚𐑪𐑮𐑛 𐑿𐑟 𐑦𐑯𐑡𐑻𐑰𐑟"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:21
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:19
-msgid "Long"
-msgstr "𐑤𐑪𐑙"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:22
-msgid "Mouse Keys"
-msgstr "𐑥𐑬𐑕 𐑒𐑰𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:23
-msgid "Move _Down"
-msgstr "𐑥𐑵𐑝 _𐑛𐑬𐑯"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:24
-msgid "Move _Up"
-msgstr "𐑥𐑵𐑝 _𐑳𐑐"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:25
-msgid "Move the selected keyboard layout down in the list"
-msgstr "𐑥𐑵𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑛𐑬𐑯 𐑦𐑯 𐑞 𐑤𐑦𐑕𐑑"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:26
-msgid "Move the selected keyboard layout up in the list"
-msgstr "𐑥𐑵𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑳𐑐 𐑦𐑯 𐑞 𐑤𐑦𐑕𐑑"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:27
-msgid "New windows u_se active window's layout"
-msgstr "𐑯𐑿 𐑢𐑦𐑯𐑛𐑴𐑟 _𐑿𐑟 𐑨𐑒𐑑𐑦𐑝 𐑢𐑦𐑯𐑛𐑴'𐑟 𐑤𐑱𐑬𐑑"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:28
-msgid "Print a diagram of the selected keyboard layout"
-msgstr "𐑐𐑮𐑦𐑯𐑑 𐑩 𐑛𐑲𐑩𐑜𐑮𐑨𐑥 𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:29
-msgid "Remove the selected keyboard layout from the list"
-msgstr "𐑮𐑦𐑥𐑵𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑓𐑮𐑪𐑥 𐑞 𐑤𐑦𐑕𐑑"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:30
-msgid "Repeat Keys"
-msgstr "𐑮𐑦𐑐𐑰𐑑 𐑒𐑰𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:31
-msgid "Repeat keys speed"
-msgstr "𐑮𐑦𐑐𐑰𐑑 𐑒𐑰𐑟 𐑕𐑐𐑰𐑛"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:32
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
-"Replace the current keyboard layout settings with the\n"
-"default settings"
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
 msgstr ""
-"𐑮𐑦𐑐𐑤𐑱𐑕 𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑕𐑧𐑑𐑦𐑙𐑟 𐑢𐑦𐑞 𐑞\n"
-"𐑛𐑦𐑓𐑷𐑤𐑑 𐑕𐑧𐑑𐑦𐑙𐑟"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:34
-msgid "Reset to De_faults"
-msgstr "𐑮𐑰𐑕𐑧𐑑 𐑑 _𐑛𐑦𐑓𐑷𐑤𐑑𐑕"
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:35
-msgid "S_peed:"
-msgstr "_𐑕𐑐𐑰𐑛:"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:36
-msgid "Select a keyboard layout to be added to the list"
-msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑑 𐑚𐑰 𐑨𐑛𐑩𐑛 𐑑 𐑞 𐑤𐑦𐑕𐑑"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:37
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:27
-msgid "Short"
-msgstr "𐑖𐑹𐑑"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:38
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:30
-msgid "Slow"
-msgstr "𐑕𐑤𐑴"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:41
-msgid "Typing Break"
-msgstr "𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:42
-msgid "View and edit keyboard layout options"
-msgstr "𐑝𐑿 𐑯 𐑧𐑛𐑦𐑑 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑪𐑐𐑖𐑩𐑯𐑟"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:43
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:37
-msgid "_Acceleration:"
-msgstr "_𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑖𐑩𐑯:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:44
-msgid "_Accessibility features can be toggled with keyboard shortcuts"
-msgstr "_𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑓𐑰𐑗𐑼𐑟 𐑒𐑨𐑯 𐑚𐑰 𐑑𐑪𐑜𐑩𐑤𐑛 𐑢𐑦𐑞 𐑒𐑰𐑚𐑪𐑮𐑛 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:46
-msgid "_Break interval lasts:"
-msgstr "_𐑚𐑮𐑱𐑒 𐑦𐑯𐑑𐑼𐑝𐑩𐑤 𐑤𐑨𐑕𐑑𐑕:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:47
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:38
-msgid "_Delay:"
-msgstr "_𐑛𐑦𐑤𐑱:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:48
+#: panels/wacom/cc-wacom-page.ui:28
 #, fuzzy
-msgid "_Ignore fast duplicate keypresses"
-msgstr "_𐑦𐑜𐑯𐑹 𐑓𐑭𐑕𐑑 𐑛𐑿𐑐𐑤𐑦𐑒𐑱𐑑 keypresses"
+msgid "Left Hand Orientation"
+msgstr "𐑥𐑬𐑕 𐑪𐑮𐑦𐑩𐑯𐑑𐑱𐑖𐑩𐑯"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:49
-msgid "_Lock screen to enforce typing break"
-msgstr "_𐑤𐑪𐑒 𐑕𐑒𐑮𐑰𐑯 𐑑 𐑧𐑯𐑓𐑪𐑮𐑕 𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:50
+#: panels/wacom/cc-wacom-page.ui:58
 #, fuzzy
-msgid "_Only accept long keypresses"
-msgstr "_𐑴𐑯𐑤𐑦 𐑨𐑒𐑕𐑧𐑐𐑑 𐑤𐑪𐑙 keypresses"
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "𐑥𐑪𐑯𐑦𐑑𐑼"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:51
-msgid "_Options..."
-msgstr "_𐑪𐑐𐑖𐑩𐑯𐑟..."
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:52
-msgid "_Pointer can be controlled using the keypad"
-msgstr "_𐑐𐑶𐑯𐑑𐑼 𐑒𐑨𐑯 𐑚𐑰 𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑛 𐑿𐑟𐑦𐑙 𐑞 𐑒𐑰𐑐𐑨𐑛"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:53
-msgid "_Separate layout for each window"
-msgstr "_𐑕𐑧𐑐𐑼𐑱𐑑 𐑤𐑱𐑬𐑑 𐑓𐑹 𐑰𐑗 𐑢𐑦𐑯𐑛𐑴"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:54
-#, fuzzy
-msgid "_Simulate simultaneous keypresses"
-msgstr "_𐑕𐑦𐑥𐑘𐑩𐑤𐑩𐑑 𐑕𐑲𐑥𐑩𐑤𐑑𐑱𐑯𐑰𐑩𐑕 keypresses"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:55
-msgid "_Speed:"
-msgstr "_𐑕𐑐𐑰𐑛:"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:56
-msgid "_Type to test settings:"
-msgstr "_𐑑𐑲𐑐 𐑑 𐑑𐑧𐑕𐑑 𐑕𐑧𐑑𐑦𐑙𐑟:"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:57
-msgid "_Work interval lasts:"
-msgstr "_𐑢𐑻𐑒 𐑦𐑯𐑑𐑼𐑝𐑩𐑤 𐑤𐑨𐑕𐑑𐑕:"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:58
-msgid "minutes"
-msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:1
-msgid "By _country"
-msgstr "𐑚𐑲 _𐑒𐑳𐑯𐑑𐑮𐑰"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:2
-msgid "By _language"
-msgstr "𐑚𐑲 _𐑤𐑨𐑙𐑜𐑢𐑩𐑡"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:3
-msgid "Choose a Layout"
-msgstr "𐑗𐑵𐑟 𐑩 𐑤𐑱𐑬𐑑"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:4
-msgid "Preview:"
-msgstr "𐑐𐑮𐑰𐑝𐑿:"
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:5
-msgid "_Country:"
-msgstr "_𐑒𐑳𐑯𐑑𐑮𐑰:"
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:6
-msgid "_Language:"
-msgstr "_𐑤𐑨𐑙𐑜𐑢𐑩𐑡:"
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:7
-msgid "_Variants:"
-msgstr "_𐑝𐑧𐑮𐑰𐑩𐑯𐑑𐑕:"
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:1
-msgid "Choose a Keyboard Model"
-msgstr "𐑗𐑵𐑟 𐑩 𐑒𐑰𐑚𐑪𐑮𐑛 𐑥𐑪𐑛𐑩𐑤"
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:2
-msgid "_Models:"
-msgstr "_𐑥𐑪𐑛𐑩𐑤𐑟:"
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:3
-msgid "_Vendors:"
-msgstr "_𐑝𐑧𐑯𐑛𐑻𐑟:"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-options-dialog.ui.h:1
-msgid "Keyboard Layout Options"
-msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑪𐑐𐑖𐑩𐑯𐑟"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
-msgid "Unknown"
-msgstr "𐑳𐑯𐑴𐑯"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:241
+#: panels/windows/cc-windows-panel.ui:8
 msgid "Layout"
 msgstr "𐑤𐑱𐑬𐑑"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:168
-msgid "Vendors"
-msgstr "𐑝𐑧𐑯𐑛𐑻𐑟"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:234
-msgid "Models"
-msgstr "𐑥𐑪𐑛𐑩𐑤𐑟"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:235
-#: ../capplets/network/gnome-network-properties.c:581
-msgid "Default"
-msgstr "𐑛𐑦𐑓𐑷𐑤𐑑"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "𐑒𐑰𐑚𐑪𐑮𐑛"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑒𐑰𐑚𐑪𐑮𐑛 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:89
-msgid "gesture|Move left"
-msgstr "𐑥𐑵𐑝 𐑤𐑧𐑓𐑑"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:94
-msgid "gesture|Move right"
-msgstr "𐑥𐑵𐑝 𐑮𐑲𐑑"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:99
-msgid "gesture|Move up"
-msgstr "𐑥𐑵𐑝 𐑳𐑐"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:104
-msgid "gesture|Move down"
-msgstr "𐑥𐑵𐑝 𐑛𐑬𐑯"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:109
-msgid "gesture|Disabled"
-msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/mouse/gnome-mouse-properties.c:590
-msgid "Specify the name of the page to show (general|accessibility)"
-msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑯𐑱𐑥 𐑝 𐑞 𐑐𐑱𐑡 𐑑 𐑖𐑴 (general|accessibility)"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:595
-msgid "- GNOME Mouse Preferences"
-msgstr "- ·𐑜𐑯𐑴𐑥 𐑥𐑬𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:2
-msgid "Choose type of click _beforehand"
-msgstr "𐑗𐑵𐑟 𐑑𐑲𐑐 𐑝 𐑒𐑤𐑦𐑒 _𐑚𐑧𐑓𐑹𐑣𐑨𐑯𐑛"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:3
-msgid "Choose type of click with mo_use gestures"
-msgstr "𐑗𐑵𐑟 𐑑𐑲𐑐 𐑝 𐑒𐑤𐑦𐑒 𐑢𐑦𐑞 _𐑥𐑬𐑕 𐑡𐑧𐑕𐑗𐑻𐑟"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:6
-msgid "D_ouble click:"
-msgstr "_𐑛𐑳𐑚𐑩𐑤 𐑒𐑤𐑦𐑒:"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:7
-msgid "D_rag click:"
-msgstr "_𐑛𐑮𐑨𐑜 𐑒𐑤𐑦𐑒:"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:8
+#: panels/windows/cc-windows-panel.ui:75
 #, fuzzy
-msgid "Disable _touchpad while typing"
-msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤 _touchpad 𐑢𐑲𐑤 𐑑𐑲𐑐𐑦𐑙"
+msgid "Center New Windows"
+msgstr "𐑐𐑺𐑩𐑯𐑑 𐑢𐑦𐑯𐑛𐑴"
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:9
-msgid "Double-Click Timeout"
-msgstr "𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑑𐑲𐑥𐑬𐑑"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:10
-msgid "Drag and Drop"
-msgstr "𐑛𐑮𐑨𐑜 𐑯 𐑛𐑮𐑪𐑐"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:11
-msgid "Dwell Click"
-msgstr "𐑛𐑢𐑧𐑤 𐑒𐑤𐑦𐑒"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:12
+#: panels/windows/cc-windows-panel.ui:82
 #, fuzzy
-msgid "Enable _mouse clicks with touchpad"
-msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 _𐑥𐑬𐑕 𐑒𐑤𐑦𐑒𐑕 𐑢𐑦𐑞 touchpad"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:13
-msgid "Enable h_orizontal scrolling"
-msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 _𐑣𐑪𐑮𐑦𐑟𐑪𐑯𐑑𐑩𐑤 𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:16
-msgid "High"
-msgstr "𐑣𐑲"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:18
-msgid "Locate Pointer"
-msgstr "𐑤𐑴𐑒𐑱𐑑 𐑐𐑶𐑯𐑑𐑼"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:20
-msgid "Low"
-msgstr "𐑤𐑴"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:21
-msgid "Mouse Orientation"
-msgstr "𐑥𐑬𐑕 𐑪𐑮𐑦𐑩𐑯𐑑𐑱𐑖𐑩𐑯"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:22
-msgid "Mouse Preferences"
-msgstr "𐑥𐑬𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:23
-msgid "Pointer Speed"
-msgstr "𐑐𐑶𐑯𐑑𐑼 𐑕𐑐𐑰𐑛"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:24
-msgid "Scrolling"
-msgstr "𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:25
-msgid "Seco_ndary click:"
-msgstr "_𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒:"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:26
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr "_𐑖𐑴 𐑐𐑩𐑟𐑦𐑖𐑩𐑯 𐑝 𐑐𐑶𐑯𐑑𐑼 𐑢𐑧𐑯 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤 𐑒𐑰 𐑦𐑟 𐑐𐑮𐑧𐑕𐑑"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:28
-msgid "Show click type _window"
-msgstr "𐑖𐑴 𐑒𐑤𐑦𐑒 𐑑𐑲𐑐 _𐑢𐑦𐑯𐑛𐑴"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:29
-msgid "Simulated Secondary Click"
+msgid "Resize with Secondary Click"
 msgstr "𐑕𐑦𐑥𐑘𐑩𐑤𐑱𐑑𐑦𐑛 𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒"
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:32
-msgid "Thr_eshold:"
-msgstr "_𐑔𐑮𐑧𐑖𐑴𐑤𐑛:"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:33
-msgid ""
-"To test your double-click settings, try to double-click on the light bulb."
-msgstr "𐑑 𐑑𐑧𐑕𐑑 𐑿𐑼 𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑕𐑧𐑑𐑦𐑙𐑟, 𐑑𐑮𐑲 𐑑 𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑪𐑯 𐑞 𐑤𐑲𐑑 𐑚𐑳𐑤𐑚."
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:34
+#: panels/windows/cc-windows-panel.ui:89
 #, fuzzy
-msgid "Touchpad"
-msgstr "Touchpad"
+msgid "Windows Focus"
+msgstr "𐑢𐑦𐑯𐑛𐑴𐑟"
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:35
-msgid "Two-_finger scrolling"
-msgstr "𐑑𐑵-_𐑓𐑦𐑙𐑜𐑼 𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:36
-msgid "You can also use the Dwell Click panel applet to choose the click type."
-msgstr "𐑿 𐑒𐑨𐑯 𐑷𐑤𐑕𐑴 𐑿𐑟 𐑞 𐑛𐑢𐑧𐑤 𐑒𐑤𐑦𐑒 𐑐𐑨𐑯𐑩𐑤 𐑨𐑐𐑤𐑩𐑑 𐑑 𐑗𐑵𐑟 𐑞 𐑒𐑤𐑦𐑒 𐑑𐑲𐑐."
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:39
-msgid "_Disabled"
-msgstr "_𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:40
-msgid "_Edge scrolling"
-msgstr "_𐑧𐑡 𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:41
-msgid "_Initiate click when stopping pointer movement"
-msgstr "_𐑦𐑯𐑦𐑖𐑰𐑱𐑑 𐑒𐑤𐑦𐑒 𐑢𐑧𐑯 𐑕𐑑𐑪𐑐𐑦𐑙 𐑐𐑶𐑯𐑑𐑼 𐑥𐑵𐑝𐑥𐑩𐑯𐑑"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:42
-msgid "_Left-handed"
-msgstr "_𐑤𐑧𐑓𐑑-𐑣𐑨𐑯𐑛𐑧𐑛"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:43
-msgid "_Motion threshold:"
-msgstr "_𐑥𐑴𐑖𐑩𐑯 𐑔𐑮𐑧𐑖𐑴𐑤𐑛:"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:44
-msgid "_Right-handed"
-msgstr "_𐑮𐑲𐑑-𐑣𐑨𐑯𐑛𐑧𐑛"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:45
-msgid "_Sensitivity:"
-msgstr "_𐑕𐑧𐑯𐑕𐑦𐑑𐑦𐑝𐑦𐑑𐑦:"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:46
-msgid "_Single click:"
-msgstr "_𐑕𐑦𐑙𐑜𐑩𐑤 𐑒𐑤𐑦𐑒:"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:47
-msgid "_Timeout:"
-msgstr "_𐑑𐑲𐑥𐑬𐑑:"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:48
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr "_𐑑𐑮𐑦𐑜𐑻 𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒 𐑚𐑲 𐑣𐑴𐑤𐑛𐑦𐑙 𐑛𐑬𐑯 𐑞 𐑐𐑮𐑲𐑥𐑼𐑦 𐑚𐑳𐑑𐑩𐑯"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "𐑥𐑬𐑕"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑥𐑬𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/network/gnome-network-properties.c:699
-#: ../capplets/network/gnome-network-properties.c:850
-msgid "New Location..."
-msgstr "𐑯𐑿 𐑤𐑴𐑒𐑱𐑖𐑩𐑯..."
-
-#: ../capplets/network/gnome-network-properties.c:816
-msgid "Location already exists"
-msgstr "𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕"
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦"
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/network/gnome-network-properties.ui.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>_𐑛𐑲𐑮𐑧𐑒𐑑 ·𐑦𐑯𐑑𐑼𐑯𐑧𐑑 𐑒𐑩𐑯𐑧𐑒𐑖𐑩𐑯</b>"
-
-#: ../capplets/network/gnome-network-properties.ui.h:2
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>_𐑷𐑑𐑴𐑥𐑨𐑑𐑦𐑒 𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯</b>"
-
-#: ../capplets/network/gnome-network-properties.ui.h:3
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>_𐑥𐑨𐑯𐑘𐑫𐑩𐑤 𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯</b>"
-
-#: ../capplets/network/gnome-network-properties.ui.h:4
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_𐑿𐑟 𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑖𐑩𐑯</b>"
-
-#: ../capplets/network/gnome-network-properties.ui.h:5
+#: panels/windows/cc-windows-panel.ui:96
 #, fuzzy
-msgid "Autoconfiguration _URL:"
-msgstr "Autoconfiguration _·𐑿·𐑮·𐑤:"
+msgid "Secondary-Click"
+msgstr "_𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒:"
 
-#: ../capplets/network/gnome-network-properties.ui.h:6
-msgid "C_reate"
-msgstr "_𐑒𐑮𐑦𐑱𐑑"
-
-#: ../capplets/network/gnome-network-properties.ui.h:7
-msgid "Create New Location"
-msgstr "𐑒𐑮𐑦𐑱𐑑 𐑯𐑿 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
-
-#: ../capplets/network/gnome-network-properties.ui.h:8
-msgid "HTTP Proxy Details"
-msgstr "HTTP 𐑐𐑮𐑪𐑒𐑕𐑦 𐑛𐑰𐑑𐑱𐑤𐑟"
-
-#: ../capplets/network/gnome-network-properties.ui.h:9
-msgid "H_TTP proxy:"
-msgstr "H_TTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:10
-msgid "Ignore Host List"
-msgstr "𐑦𐑜𐑯𐑹 𐑣𐑴𐑕𐑑 𐑤𐑦𐑕𐑑"
-
-#: ../capplets/network/gnome-network-properties.ui.h:11
-msgid "Ignored Hosts"
-msgstr "𐑦𐑜𐑯𐑹𐑛 𐑣𐑴𐑕𐑑𐑕"
-
-#: ../capplets/network/gnome-network-properties.ui.h:12
-msgid "Location:"
-msgstr "𐑤𐑴𐑒𐑱𐑖𐑩𐑯:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:13
-msgid "Network Proxy Preferences"
-msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/network/gnome-network-properties.ui.h:14
-msgid "Port:"
-msgstr "𐑐𐑹𐑑:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:15
-msgid "Proxy Configuration"
-msgstr "𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯"
-
-#: ../capplets/network/gnome-network-properties.ui.h:16
-msgid "S_ocks host:"
-msgstr "_𐑕𐑪𐑒𐑕 𐑣𐑴𐑕𐑑:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:17
-msgid "The location already exists."
-msgstr "𐑞 𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕."
-
-#: ../capplets/network/gnome-network-properties.ui.h:18
-msgid "U_sername:"
-msgstr "_𐑿𐑟𐑼𐑯𐑱𐑥:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:19
-msgid "_Delete Location"
-msgstr "_𐑛𐑦𐑤𐑰𐑑 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
-
-#: ../capplets/network/gnome-network-properties.ui.h:20
-msgid "_Details"
-msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟"
-
-#: ../capplets/network/gnome-network-properties.ui.h:21
-#, fuzzy
-msgid "_FTP proxy:"
-msgstr "_FTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:22
-msgid "_Location name:"
-msgstr "_𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑯𐑱𐑥:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:23
-msgid "_Password:"
-msgstr "_𐑐𐑭𐑕𐑢𐑼𐑛:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:24
-msgid "_Secure HTTP proxy:"
-msgstr "_𐑕𐑦𐑒𐑘𐑫𐑼 HTTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:25
-msgid "_Use the same proxy for all protocols"
-msgstr "_𐑿𐑕 𐑞 𐑕𐑱𐑥 𐑐𐑮𐑪𐑒𐑕𐑦 𐑓𐑹 𐑷𐑤 𐑐𐑮𐑴𐑑𐑩𐑒𐑪𐑤𐑟"
-
-#: ../capplets/windows/gnome-window-properties.c:344
-msgid "Cannot start the preferences application for your window manager"
-msgstr "𐑒𐑨𐑯𐑪𐑑 𐑕𐑑𐑸𐑑 𐑞 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯 𐑓𐑹 𐑿𐑼 𐑢𐑦𐑯𐑛𐑴 𐑥𐑨𐑯𐑩𐑡𐑼"
-
-#: ../capplets/windows/gnome-window-properties.c:603
-msgid "_Alt"
-msgstr "_𐑷𐑤𐑑"
-
-#: ../capplets/windows/gnome-window-properties.c:609
-msgid "H_yper"
-msgstr "𐑣_𐑲𐑐𐑼"
-
-#: ../capplets/windows/gnome-window-properties.c:616
-msgid "S_uper (or \"Windows logo\")"
-msgstr "𐑕_𐑵𐑐𐑼 (𐑹 \"·𐑢𐑦𐑯𐑛𐑴𐑟 𐑤𐑴𐑜𐑴\")"
-
-#: ../capplets/windows/gnome-window-properties.c:623
-msgid "_Meta"
-msgstr "_𐑥𐑧𐑑𐑩"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:1
-msgid "Movement Key"
-msgstr "𐑥𐑵𐑝𐑥𐑩𐑯𐑑 𐑒𐑰"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:2
-#, fuzzy
-msgid "Titlebar Action"
-msgstr "Titlebar 𐑨𐑒𐑖𐑩𐑯"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:3
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr "𐑑 𐑥𐑵𐑝 𐑩 𐑢𐑦𐑯𐑛𐑴, 𐑐𐑮𐑧𐑕-𐑯-𐑣𐑴𐑤𐑛 𐑞𐑦𐑕 𐑒𐑰 𐑞𐑧𐑯 𐑜𐑮𐑨𐑚 𐑞 𐑢𐑦𐑯𐑛𐑴:"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:4
-msgid "Window Preferences"
-msgstr "𐑢𐑦𐑯𐑛𐑴 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:5
-msgid "Window Selection"
-msgstr "𐑢𐑦𐑯𐑛𐑴 𐑕𐑦𐑤𐑧𐑒𐑖𐑩𐑯"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:6
-#, fuzzy
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 titlebar 𐑑 𐑐𐑼𐑓𐑹𐑥 𐑞𐑦𐑕 𐑨𐑒𐑖𐑩𐑯:"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:7
-msgid "_Interval before raising:"
-msgstr "_𐑦𐑯𐑑𐑼𐑝𐑩𐑤 𐑚𐑦𐑓𐑹 𐑮𐑱𐑟𐑦𐑙:"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_𐑮𐑱𐑟 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑢𐑦𐑯𐑛𐑴𐑟 𐑭𐑓𐑑𐑼 𐑩𐑯 𐑦𐑯𐑑𐑼𐑝𐑩𐑤"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑 𐑢𐑦𐑯𐑛𐑴𐑟 𐑢𐑧𐑯 𐑞 𐑥𐑬𐑕 𐑥𐑵𐑝𐑟 𐑴𐑝𐑼 𐑞𐑧𐑥"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:10
-msgid "seconds"
-msgstr "𐑕𐑧𐑒𐑩𐑯𐑛𐑟"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑢𐑦𐑯𐑛𐑴 𐑐𐑮𐑪𐑐𐑼𐑑𐑦𐑟"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
 msgid "Windows"
 msgstr "𐑢𐑦𐑯𐑛𐑴𐑟"
 
-#: ../libwindow-settings/gnome-wm-manager.c:316
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "𐑢𐑦𐑯𐑛𐑴 𐑥𐑨𐑯𐑩𐑡𐑼 \"%s\" 𐑣𐑨𐑟 𐑯𐑪𐑑 𐑮𐑧𐑡𐑦𐑕𐑑𐑼𐑛 𐑩 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑑𐑵𐑤\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:404
-msgid "Maximize"
-msgstr "𐑥𐑨𐑒𐑕𐑩𐑥𐑲𐑟"
-
-#: ../libwindow-settings/metacity-window-manager.c:405
-msgid "Maximize Vertically"
-msgstr "𐑥𐑨𐑒𐑕𐑩𐑥𐑲𐑟 𐑝𐑻𐑑𐑦𐑒𐑩𐑤𐑦"
-
-#: ../libwindow-settings/metacity-window-manager.c:406
-msgid "Maximize Horizontally"
-msgstr "𐑥𐑨𐑒𐑕𐑩𐑥𐑲𐑟 𐑣𐑪𐑮𐑦𐑟𐑪𐑯𐑑𐑩𐑤𐑦"
-
-#: ../libwindow-settings/metacity-window-manager.c:407
-msgid "Minimize"
-msgstr "𐑥𐑦𐑯𐑩𐑥𐑲𐑟"
-
-#: ../libwindow-settings/metacity-window-manager.c:408
-msgid "Roll up"
-msgstr "𐑮𐑴𐑤 𐑳𐑐"
-
-#: ../libwindow-settings/metacity-window-manager.c:409
-msgid "None"
-msgstr "𐑯𐑳𐑯"
-
-#: ../shell/control-center.c:49
-#, c-format
-msgid "key not found [%s]\n"
-msgstr "𐑒𐑰 𐑯𐑪𐑑 𐑓𐑬𐑯𐑛 [%s]\n"
-
-#: ../shell/control-center.c:143
-#, fuzzy
-msgid "Hide on start (useful to preload the shell)"
-msgstr "𐑣𐑲𐑛 𐑪𐑯 𐑕𐑑𐑸𐑑 (𐑿𐑕𐑓𐑩𐑤 𐑑 preload 𐑞 𐑖𐑧𐑤)"
-
-#: ../shell/control-center.c:182
-msgid "Filter"
-msgstr "𐑓𐑦𐑤𐑑𐑼"
-
-#: ../shell/control-center.c:182
-msgid "Groups"
-msgstr "𐑜𐑮𐑵𐑐𐑕"
-
-#: ../shell/control-center.c:182
-msgid "Common Tasks"
-msgstr "𐑒𐑪𐑥𐑩𐑯 𐑑𐑭𐑕𐑒𐑕"
-
-#: ../shell/control-center.c:185 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "𐑒𐑩𐑯𐑑𐑮𐑴𐑤 𐑕𐑧𐑯𐑑𐑼"
-
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr "𐑒𐑤𐑴𐑟 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤-𐑕𐑧𐑯𐑑𐑼 𐑢𐑧𐑯 𐑩 𐑑𐑭𐑕𐑒 𐑦𐑟 𐑨𐑒𐑑𐑦𐑝𐑱𐑑𐑩𐑛"
-
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑨𐑛 𐑹 𐑮𐑦𐑥𐑵𐑝 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
-
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑣𐑧𐑤𐑐 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
-
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑕𐑑𐑸𐑑 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
-
-#: ../shell/control-center.schemas.in.h:5
-#, fuzzy
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑳𐑐𐑜𐑮𐑱𐑛 𐑹 uninstall 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
-
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed."
-msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩 𐑣𐑧𐑤𐑐 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
-
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed."
-msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩 𐑕𐑑𐑸𐑑 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
-
-#: ../shell/control-center.schemas.in.h:8
-msgid ""
-"Indicates whether to close the shell when an add or remove action is "
-"performed."
-msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩𐑯 𐑨𐑛 𐑹 𐑮𐑦𐑥𐑵𐑝 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
-
-#: ../shell/control-center.schemas.in.h:9
-#, fuzzy
-msgid ""
-"Indicates whether to close the shell when an upgrade or uninstall action is "
-"performed."
-msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩𐑯 𐑳𐑐𐑜𐑮𐑱𐑛 𐑹 uninstall 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
-
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr "𐑑𐑭𐑕𐑒 𐑯𐑱𐑥𐑟 𐑯 𐑩𐑕𐑴𐑖𐑦𐑱𐑑𐑩𐑛 .desktop 𐑓𐑲𐑤𐑟"
-
-#: ../shell/control-center.schemas.in.h:11
-msgid ""
-"The task name to be displayed in the control-center followed by a \";\" "
-"separator then the filename of an associated .desktop file to launch for "
-"that task."
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
 msgstr ""
-"𐑞 𐑑𐑭𐑕𐑒 𐑯𐑱𐑥 𐑑 𐑚𐑰 𐑛𐑩𐑕𐑐𐑤𐑱𐑛 𐑦𐑯 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤-𐑕𐑧𐑯𐑑𐑼 𐑓𐑪𐑤𐑴𐑛 𐑚𐑲 𐑩 \";\" 𐑕𐑧𐑐𐑼𐑱𐑑𐑼 𐑞𐑧𐑯 𐑞 "
-"𐑓𐑲𐑤𐑯𐑱𐑥 𐑝 𐑩𐑯 𐑩𐑕𐑴𐑖𐑦𐑱𐑑𐑩𐑛 .𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑓𐑲𐑤 𐑑 𐑤𐑷𐑯𐑗 𐑓𐑹 𐑞𐑨𐑑 𐑑𐑭𐑕𐑒."
 
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
-#, fuzzy
-msgid ""
-"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
-"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
 msgstr ""
-"[𐑗𐑱𐑯𐑡 𐑔𐑰𐑥;gtk-𐑔𐑰𐑥-selector.𐑛𐑧𐑕𐑒𐑑𐑪𐑐,𐑕𐑧𐑑 𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟;𐑛𐑦𐑓𐑷𐑤𐑑-𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟."
-"𐑛𐑧𐑕𐑒𐑑𐑪𐑐,𐑨𐑛 𐑐𐑮𐑦𐑯𐑑𐑼;·𐑯𐑴𐑥-𐑒𐑳𐑐𐑕-𐑥𐑨𐑯𐑩𐑡𐑼.𐑛𐑧𐑕𐑒𐑑𐑪𐑐]"
 
-#: ../shell/control-center.schemas.in.h:14
-msgid ""
-"if true, the control-center will close when a \"Common Task\" is activated."
-msgstr "𐑦𐑓 𐑑𐑮𐑵, 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤-𐑕𐑧𐑯𐑑𐑼 𐑢𐑦𐑤 𐑒𐑤𐑴𐑕 𐑢𐑧𐑯 𐑩 \"𐑒𐑪𐑥𐑩𐑯 𐑑𐑭𐑕𐑒\" 𐑦𐑟 𐑨𐑒𐑑𐑦𐑝𐑱𐑑𐑩𐑛."
-
-#: ../shell/gnomecc.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "𐑞 ·𐑜𐑯𐑴𐑥 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑑𐑵𐑤"
-
-#: ../typing-break/drw-break-window.c:194
-msgid "_Postpone Break"
-msgstr "_𐑐𐑴𐑕𐑑𐑐𐑴𐑯 𐑚𐑮𐑱𐑒"
-
-#: ../typing-break/drw-break-window.c:250
-msgid "Take a break!"
-msgstr "𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒!"
-
-#: ../typing-break/drwright.c:136
-msgid "_Take a Break"
-msgstr "_𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒"
-
-#: ../typing-break/drwright.c:507
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
 #, fuzzy
-msgid "Take a break now (next in %dm)"
-msgstr "𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒 𐑯𐑬 (𐑯𐑧𐑒𐑕𐑑 𐑦𐑯 %dm)"
+msgid "Access Points"
+msgstr "𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑩𐑤 _𐑤𐑪𐑜𐑦𐑯"
 
-#: ../typing-break/drwright.c:509
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "%d 𐑥𐑦𐑯𐑩𐑑 𐑳𐑯𐑑𐑦𐑤 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑚𐑮𐑱𐑒"
-msgstr[1] "%d 𐑥𐑦𐑯𐑩𐑑𐑕 𐑳𐑯𐑑𐑦𐑤 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑚𐑮𐑱𐑒"
-
-#: ../typing-break/drwright.c:515
-#, c-format
-msgid "Take a break now (next in less than one minute)"
-msgstr "𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒 𐑯𐑬 (𐑯𐑧𐑒𐑕𐑑 𐑦𐑯 𐑤𐑧𐑕 𐑞𐑨𐑯 𐑢𐑳𐑯 𐑥𐑦𐑯𐑩𐑑)"
-
-#: ../typing-break/drwright.c:517
-#, c-format
-msgid "Less than one minute until the next break"
-msgstr "𐑤𐑧𐑕 𐑞𐑨𐑯 𐑢𐑳𐑯 𐑥𐑦𐑯𐑩𐑑 𐑳𐑯𐑑𐑦𐑤 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑚𐑮𐑱𐑒"
-
-#: ../typing-break/drwright.c:614
-#, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
-msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑚𐑮𐑦𐑙 𐑳𐑐 𐑞 𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒 𐑐𐑮𐑪𐑐𐑼𐑑𐑦𐑟 𐑛𐑲𐑩𐑤𐑪𐑜 𐑢𐑦𐑞 𐑞 𐑓𐑪𐑤𐑴𐑦𐑙 𐑻𐑼: %s"
-
-#: ../typing-break/drwright.c:631
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
 #, fuzzy
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "𐑮𐑦𐑑𐑩𐑯 𐑚𐑲 ·𐑮𐑦𐑗𐑼𐑛 𐑣𐑩𐑤𐑑 <·𐑮𐑦𐑗𐑼𐑛@imendio.𐑒𐑪𐑥>"
+msgid "Add"
+msgstr "𐑩𐑛𐑮𐑧𐑕"
 
-#: ../typing-break/drwright.c:632
-msgid "Eye candy added by Anders Carlsson"
-msgstr "𐑲 𐑒𐑨𐑯𐑛𐑰 𐑨𐑛𐑩𐑛 𐑚𐑲 ·𐑨𐑯𐑛𐑻𐑟 ·𐑒𐑭𐑮𐑤𐑕𐑩𐑯"
-
-#: ../typing-break/drwright.c:641
-msgid "A computer break reminder."
-msgstr "𐑩 𐑒𐑩𐑥𐑐𐑿𐑑𐑼 𐑚𐑮𐑱𐑒 𐑮𐑦𐑥𐑲𐑯𐑛𐑼."
-
-#: ../typing-break/drwright.c:643
-msgid "translator-credits"
-msgstr "·𐑑𐑪𐑥𐑩𐑕 ·𐑔𐑻𐑥𐑩𐑯"
-
-#: ../typing-break/main.c:63
-msgid "Enable debugging code"
-msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑛𐑰𐑚𐑳𐑜𐑦𐑙 𐑒𐑴𐑛"
-
-#: ../typing-break/main.c:65
-msgid "Don't check whether the notification area exists"
-msgstr "𐑛𐑴𐑯𐑑 𐑗𐑧𐑒 𐑢𐑧𐑞𐑼 𐑞 𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩 𐑧𐑒𐑟𐑦𐑕𐑑𐑕"
-
-#: ../typing-break/main.c:91
-msgid "Typing Monitor"
-msgstr "𐑑𐑲𐑐𐑦𐑙 𐑥𐑪𐑯𐑦𐑑𐑼"
-
-#: ../typing-break/main.c:108
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
 msgstr ""
-"𐑞 𐑑𐑲𐑐𐑦𐑙 𐑥𐑪𐑯𐑦𐑑𐑼 𐑿𐑟𐑩𐑟 𐑞 𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩 𐑑 𐑛𐑦𐑕𐑐𐑤𐑱 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯. 𐑿 𐑛𐑴𐑯𐑑 𐑕𐑰𐑥 𐑑 𐑣𐑨𐑝 𐑩 "
-"𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩 𐑪𐑯 𐑿𐑼 𐑐𐑨𐑯𐑩𐑤. 𐑿 𐑒𐑨𐑯 𐑨𐑛 𐑦𐑑 𐑚𐑲 𐑮𐑲𐑑-𐑒𐑤𐑦𐑒𐑦𐑙 𐑪𐑯 𐑿𐑼 𐑐𐑨𐑯𐑩𐑤 𐑯 𐑗𐑵𐑟𐑦𐑙 "
-"'𐑨𐑛 𐑑 𐑐𐑨𐑯𐑩𐑤', 𐑕𐑩𐑤𐑧𐑒𐑑𐑦𐑙 '𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩' 𐑯 𐑒𐑤𐑦𐑒𐑦𐑙 '𐑨𐑛'."
 
-#: ../font-viewer/fontilus.schemas.in.h:1
-#, fuzzy
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 OpenType 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:2
+#: panels/wwan/cc-wwan-details-dialog.ui:5
 #, fuzzy
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 PCF 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+msgid "Modem Details"
+msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟"
 
-#: ../font-viewer/fontilus.schemas.in.h:3
-#, fuzzy
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 TrueType 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:4
-#, fuzzy
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 Type1 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:5
+#: panels/wwan/cc-wwan-details-dialog.ui:49
 #, fuzzy
+msgid "Network Type"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑕𐑻𐑝𐑼𐑟"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_𐑥𐑴𐑚𐑲𐑤:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑕𐑻𐑝𐑼𐑟"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "𐑗𐑱𐑯𐑡 𐑕𐑧𐑑"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr ""
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
 msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
-msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 OpenType 𐑓𐑪𐑯𐑑𐑕."
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:6
-#, fuzzy
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 PCF 𐑓𐑪𐑯𐑑𐑕."
-
-#: ../font-viewer/fontilus.schemas.in.h:7
-#, fuzzy
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 TrueType 𐑓𐑪𐑯𐑑𐑕."
-
-#: ../font-viewer/fontilus.schemas.in.h:8
-#, fuzzy
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 Type1 𐑓𐑪𐑯𐑑𐑕."
-
-#: ../font-viewer/fontilus.schemas.in.h:9
-#, fuzzy
-msgid "Thumbnail command for OpenType fonts"
-msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 OpenType 𐑓𐑪𐑯𐑑𐑕"
-
-#: ../font-viewer/fontilus.schemas.in.h:10
-#, fuzzy
-msgid "Thumbnail command for PCF fonts"
-msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 PCF 𐑓𐑪𐑯𐑑𐑕"
-
-#: ../font-viewer/fontilus.schemas.in.h:11
-#, fuzzy
-msgid "Thumbnail command for TrueType fonts"
-msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 TrueType 𐑓𐑪𐑯𐑑𐑕"
-
-#: ../font-viewer/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 Type1 𐑓𐑪𐑯𐑑𐑕"
-
-#: ../font-viewer/fontilus.schemas.in.h:13
-#, fuzzy
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 OpenType 𐑓𐑪𐑯𐑑𐑕"
-
-#: ../font-viewer/fontilus.schemas.in.h:14
-#, fuzzy
-msgid "Whether to thumbnail PCF fonts"
-msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 PCF 𐑓𐑪𐑯𐑑𐑕"
-
-#: ../font-viewer/fontilus.schemas.in.h:15
-#, fuzzy
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 TrueType 𐑓𐑪𐑯𐑑𐑕"
-
-#: ../font-viewer/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 Type1 𐑓𐑪𐑯𐑑𐑕"
-
-#: ../font-viewer/font-view.c:290
-msgid "Name:"
-msgstr "𐑯𐑱𐑥:"
-
-#: ../font-viewer/font-view.c:293
-msgid "Style:"
-msgstr "𐑕𐑑𐑲𐑤:"
-
-#: ../font-viewer/font-view.c:306
-msgid "Type:"
-msgstr "𐑑𐑲𐑐:"
-
-#: ../font-viewer/font-view.c:310
-msgid "Size:"
-msgstr "𐑕𐑲𐑟:"
-
-#: ../font-viewer/font-view.c:354 ../font-viewer/font-view.c:367
-msgid "Version:"
-msgstr "𐑝𐑻𐑠𐑩𐑯:"
-
-#: ../font-viewer/font-view.c:358 ../font-viewer/font-view.c:369
-msgid "Copyright:"
-msgstr "𐑒𐑪𐑐𐑦𐑮𐑲𐑑:"
-
-#: ../font-viewer/font-view.c:362
-msgid "Description:"
-msgstr "𐑛𐑦𐑕𐑒𐑮𐑦𐑐𐑖𐑩𐑯:"
-
-#: ../font-viewer/font-view.c:442
-msgid "Installed"
-msgstr "𐑦𐑯𐑕𐑑𐑷𐑤𐑛"
-
-#: ../font-viewer/font-view.c:445
-msgid "Install Failed"
-msgstr "𐑦𐑯𐑕𐑑𐑷𐑤 𐑓𐑱𐑤𐑛"
-
-#: ../font-viewer/font-view.c:517
-#, fuzzy
-msgid "usage: %s fontfile\n"
-msgstr "𐑿𐑕𐑦𐑡: %s fontfile\n"
-
-#: ../font-viewer/font-view.c:592
-msgid "I_nstall Font"
-msgstr "_𐑦𐑯𐑕𐑑𐑷𐑤 𐑓𐑪𐑯𐑑"
-
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
-msgid "Font Viewer"
-msgstr "𐑓𐑪𐑯𐑑 𐑝𐑿𐑼"
-
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
-msgid "Preview fonts"
-msgstr "𐑐𐑮𐑰𐑝𐑿 𐑓𐑪𐑯𐑑𐑕"
-
-#: ../font-viewer/font-thumbnailer.c:245
-#, fuzzy
-msgid "Text to thumbnail (default: Aa)"
-msgstr "𐑑𐑧𐑒𐑕𐑑 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 (𐑛𐑦𐑓𐑷𐑤𐑑: Aa)"
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "TEXT"
-msgstr "𐑑𐑧𐑒𐑕𐑑"
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "Font size (default: 64)"
-msgstr "𐑓𐑪𐑯𐑑 𐑕𐑲𐑟 (𐑛𐑦𐑓𐑷𐑤𐑑: 64)"
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "SIZE"
-msgstr "𐑕𐑲𐑟"
-
-#: ../font-viewer/font-thumbnailer.c:249
-msgid "FONT-FILE OUTPUT-FILE"
-msgstr "𐑓𐑪𐑯𐑑-𐑓𐑲𐑤 𐑬𐑑𐑐𐑫𐑑-𐑓𐑲𐑤"
-
-#: ../font-viewer/font-thumbnailer.c:268
-#, c-format
-msgid "Error parsing arguments: %s\n"
-msgstr "𐑻𐑼 𐑐𐑸𐑕𐑦𐑙 𐑸𐑜𐑿𐑥𐑩𐑯𐑑𐑕: %s\n"
-
-#: ../libslab/app-shell.c:754
-#, c-format
-msgid "Your filter \"%s\" does not match any items."
-msgstr "𐑿𐑼 𐑓𐑦𐑤𐑑𐑼 \"%s\" 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑥𐑨𐑗 𐑧𐑯𐑦 𐑲𐑑𐑩𐑥𐑟."
-
-#: ../libslab/app-shell.c:756
-msgid "No matches found."
-msgstr "𐑯𐑴 𐑥𐑨𐑗𐑩𐑟 𐑓𐑬𐑯𐑛."
-
-#: ../libslab/app-shell.c:905
-msgid "Other"
-msgstr "𐑳𐑞𐑼"
-
-#. make start action
-#: ../libslab/application-tile.c:374
-#, c-format
-msgid "Start %s"
-msgstr "𐑕𐑑𐑸𐑑 %s"
-
-#: ../libslab/application-tile.c:395
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "𐑣𐑧𐑤𐑐"
 
-#: ../libslab/application-tile.c:442
-msgid "Upgrade"
-msgstr "𐑳𐑐𐑜𐑮𐑱𐑛"
-
-#: ../libslab/application-tile.c:457
+#: shell/help-overlay.ui:15
 #, fuzzy
-msgid "Uninstall"
-msgstr "Uninstall"
+msgctxt "shortcut window"
+msgid "General"
+msgstr "𐑡𐑧𐑯𐑼𐑩𐑤"
 
-#: ../libslab/application-tile.c:784 ../libslab/document-tile.c:721
-msgid "Remove from Favorites"
-msgstr "𐑮𐑦𐑥𐑵𐑝 𐑓𐑮𐑪𐑥 𐑓𐑱𐑝𐑼𐑦𐑑𐑕"
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
 
-#: ../libslab/application-tile.c:786 ../libslab/document-tile.c:723
-msgid "Add to Favorites"
-msgstr "𐑨𐑛 𐑑 𐑓𐑱𐑝𐑼𐑦𐑑𐑕"
-
-#: ../libslab/application-tile.c:871
-msgid "Remove from Startup Programs"
-msgstr "𐑮𐑦𐑥𐑵𐑝 𐑓𐑮𐑪𐑥 𐑕𐑑𐑸𐑑𐑳𐑐 𐑐𐑮𐑴𐑜𐑮𐑨𐑥𐑟"
-
-#: ../libslab/application-tile.c:873
-msgid "Add to Startup Programs"
-msgstr "𐑨𐑛 𐑑 𐑕𐑑𐑸𐑑𐑳𐑐 𐑐𐑮𐑴𐑜𐑮𐑨𐑥𐑟"
-
-#: ../libslab/bookmark-agent.c:1077
-msgid "New Spreadsheet"
-msgstr "𐑯𐑿 𐑕𐑐𐑮𐑧𐑛𐑖𐑰𐑑"
-
-#: ../libslab/bookmark-agent.c:1082
-msgid "New Document"
-msgstr "𐑯𐑿 𐑛𐑪𐑒𐑿𐑥𐑩𐑯𐑑"
-
-#: ../libslab/bookmark-agent.c:1140
-msgid "Documents"
-msgstr "𐑛𐑪𐑒𐑿𐑥𐑩𐑯𐑑𐑕"
-
-#: ../libslab/bookmark-agent.c:1153
-msgid "File System"
-msgstr "𐑓𐑲𐑤 𐑕𐑦𐑕𐑑𐑩𐑥"
-
-#: ../libslab/bookmark-agent.c:1157
-msgid "Network Servers"
-msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑕𐑻𐑝𐑼𐑟"
-
-#: ../libslab/bookmark-agent.c:1186
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Search"
 msgstr "𐑕𐑻𐑗"
 
-#. make open with default action
-#: ../libslab/directory-tile.c:171
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "𐑐𐑨𐑯𐑩𐑤 𐑲𐑒𐑪𐑯"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
-msgid "<b>Open</b>"
-msgstr "<b>𐑴𐑐𐑩𐑯</b>"
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#. make rename action
-#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:234
-msgid "Rename..."
-msgstr "𐑮𐑰𐑯𐑱𐑥..."
-
-#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
-#: ../libslab/document-tile.c:248 ../libslab/document-tile.c:257
-msgid "Send To..."
-msgstr "𐑕𐑧𐑯𐑛 𐑑..."
-
-#. make move to trash action
-#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:283
-msgid "Move to Trash"
-msgstr "𐑥𐑵𐑝 𐑑 𐑑𐑮𐑨𐑖"
-
-#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
-#: ../libslab/document-tile.c:293 ../libslab/document-tile.c:837
-msgid "Delete"
-msgstr "𐑛𐑦𐑤𐑰𐑑"
-
-#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:985
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
-msgid "Are you sure you want to permanently delete \"%s\"?"
-msgstr "𐑸 𐑿 𐑖𐑫𐑼 𐑿 𐑢𐑪𐑯𐑑 𐑑 𐑐𐑻𐑥𐑩𐑯𐑩𐑯𐑑𐑤𐑦 𐑛𐑦𐑤𐑰𐑑 \"%s\"?"
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:986
-msgid "If you delete an item, it is permanently lost."
-msgstr "𐑦𐑓 𐑿 𐑛𐑦𐑤𐑰𐑑 𐑩𐑯 𐑲𐑑𐑩𐑥, 𐑦𐑑 𐑦𐑟 𐑐𐑻𐑥𐑩𐑯𐑩𐑯𐑑𐑤𐑦 𐑤𐑪𐑕𐑑."
+#~ msgid "Current network location"
+#~ msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 𐑯𐑧𐑑𐑢𐑻𐑒 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
 
-#: ../libslab/document-tile.c:193
+#~ msgid "More backgrounds URL"
+#~ msgstr "𐑥𐑹 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛𐑟 URL"
+
+#~ msgid "More themes URL"
+#~ msgstr "𐑥𐑹 𐑔𐑰𐑥𐑟 URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑑 𐑿𐑼 𐑒𐑳𐑮𐑩𐑯𐑑 𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑯𐑱𐑥. 𐑞𐑦𐑕 𐑦𐑟 𐑿𐑟𐑛 𐑑 𐑛𐑦𐑑𐑻𐑥𐑦𐑯 𐑞 𐑩𐑐𐑮𐑴𐑐𐑮𐑦𐑩𐑑 𐑯𐑧𐑑𐑢𐑻𐑒 "
+#~ "𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "URL 𐑓𐑹 𐑢𐑺 𐑑 𐑜𐑧𐑑 𐑥𐑹 𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛𐑟. 𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑩𐑯 𐑧𐑥𐑐𐑑𐑦 𐑕𐑑𐑮𐑦𐑙 𐑞 𐑤𐑦𐑙𐑒 𐑢𐑦𐑤 "
+#~ "𐑯𐑪𐑑 𐑩𐑐𐑽."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "URL 𐑓𐑹 𐑢𐑺 𐑑 𐑜𐑧𐑑 𐑥𐑹 𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑔𐑰𐑥𐑟. 𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑩𐑯 𐑧𐑥𐑐𐑑𐑦 𐑕𐑑𐑮𐑦𐑙 𐑞 𐑤𐑦𐑙𐑒 𐑢𐑦𐑤 𐑯𐑪𐑑 "
+#~ "𐑩𐑐𐑽."
+
+#~ msgid "Image/label border"
+#~ msgstr "𐑦𐑥𐑦𐑡/𐑤𐑱𐑚𐑩𐑤 𐑚𐑹𐑛𐑼"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "𐑢𐑦𐑛𐑔 𐑝 𐑚𐑹𐑛𐑼 𐑼𐑬𐑯𐑛 𐑞 𐑤𐑱𐑚𐑩𐑤 𐑯 𐑦𐑥𐑦𐑡 𐑦𐑯 𐑞 𐑩𐑤𐑻𐑑 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#~ msgid "The type of alert"
+#~ msgstr "𐑞 𐑑𐑲𐑐 𐑝 𐑩𐑤𐑻𐑑"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "𐑞 𐑚𐑳𐑑𐑩𐑯𐑟 𐑖𐑴𐑯 𐑦𐑯 𐑞 𐑩𐑤𐑻𐑑 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#~ msgid "Show more _details"
+#~ msgstr "𐑖𐑴 𐑥𐑹 _𐑛𐑰𐑑𐑱𐑤𐑟"
+
 #, c-format
-msgid "Open with \"%s\""
-msgstr "𐑴𐑐𐑩𐑯 𐑢𐑦𐑞 \"%s\""
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
 
-#: ../libslab/document-tile.c:207
-msgid "Open with Default Application"
-msgstr "𐑴𐑐𐑩𐑯 𐑢𐑦𐑞 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯"
-
-#: ../libslab/document-tile.c:218
-msgid "Open in File Manager"
-msgstr "𐑴𐑐𐑩𐑯 𐑦𐑯 𐑓𐑲𐑤 𐑥𐑨𐑯𐑩𐑡𐑼"
-
-#: ../libslab/document-tile.c:617
-msgid "?"
-msgstr "?"
-
-#: ../libslab/document-tile.c:624
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#: ../libslab/document-tile.c:632
-msgid "Today %l:%M %p"
-msgstr "𐑑𐑫𐑛𐑱 %l:%M %p"
-
-#: ../libslab/document-tile.c:642
-msgid "Yesterday %l:%M %p"
-msgstr "𐑘𐑧𐑕𐑑𐑼𐑛𐑱 %l:%M %p"
-
-#: ../libslab/document-tile.c:654
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
-
-#: ../libslab/document-tile.c:662
-msgid "%b %d %l:%M %p"
-msgstr "%b %d %l:%M %p"
-
-#: ../libslab/document-tile.c:664
-msgid "%b %d %Y"
-msgstr "%b %d %Y"
-
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
-msgstr "𐑓𐑲𐑯𐑛 𐑯𐑬"
-
-#: ../libslab/system-tile.c:127
 #, c-format
-msgid "<b>Open %s</b>"
-msgstr "<b>𐑴𐑐𐑩𐑯 %s</b>"
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
 
-#: ../libslab/system-tile.c:140
 #, c-format
-msgid "Remove from System Items"
-msgstr "𐑮𐑦𐑥𐑵𐑝 𐑓𐑮𐑪𐑥 𐑕𐑦𐑕𐑑𐑩𐑥 𐑲𐑑𐑩𐑥𐑟"
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
 
-msgid "Show help options"
-msgstr "𐑖𐑴 𐑣𐑧𐑤𐑐 𐑪𐑐𐑖𐑩𐑯𐑟"
+#, c-format
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#, c-format
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 𐑞 𐑮𐑰𐑛𐑼 𐑩𐑜𐑱𐑯"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑩𐑜𐑱𐑯"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑢𐑪𐑟 𐑑𐑵 𐑖𐑹𐑑, 𐑑𐑮𐑲 𐑩𐑜𐑱𐑯"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑢𐑪𐑟 𐑯𐑪𐑑 𐑕𐑧𐑯𐑑𐑼𐑛, 𐑑𐑮𐑲 𐑕𐑢𐑲𐑐𐑦𐑙 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑩𐑜𐑱𐑯"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "𐑮𐑦𐑥𐑵𐑝 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼, 𐑯 𐑑𐑮𐑲 𐑕𐑢𐑲𐑐𐑦𐑙 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑩𐑜𐑱𐑯"
+
+#~ msgid "No Image"
+#~ msgstr "𐑯𐑴 𐑦𐑥𐑦𐑡"
+
+#~ msgid "Images"
+#~ msgstr "𐑦𐑥𐑦𐑡𐑩𐑟"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "𐑞𐑺 𐑢𐑪𐑟 𐑩𐑯 𐑻𐑼 𐑢𐑲𐑤 𐑑𐑮𐑲𐑦𐑙 𐑑 𐑜𐑧𐑑 𐑞 𐑩𐑛𐑮𐑧𐑕𐑚𐑫𐑒 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯\n"
+#~ "·𐑧𐑝𐑩𐑤𐑵𐑖𐑩𐑯 𐑛𐑱𐑑𐑩 𐑕𐑻𐑝𐑼 𐑒𐑭𐑯𐑑 𐑣𐑨𐑯𐑛𐑩𐑤 𐑞 𐑐𐑮𐑴𐑑𐑩𐑒𐑪𐑤"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑴𐑐𐑩𐑯 𐑩𐑛𐑮𐑧𐑕 𐑚𐑫𐑒"
+
+#, fuzzy
+#~ msgid "A_IM/iChat:"
+#~ msgstr "_𐑱𐑥/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "_𐑩𐑛𐑮𐑧𐑕:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "_𐑩𐑕𐑦𐑕𐑑𐑩𐑯𐑑:"
+
+#~ msgid "About Me"
+#~ msgstr "𐑩𐑚𐑬𐑑 𐑥𐑰"
+
+#~ msgid "C_ity:"
+#~ msgstr "_𐑕𐑦𐑑𐑦:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "_𐑒𐑳𐑥𐑐𐑩𐑯𐑦:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "𐑗𐑱𐑯𐑡 _𐑐𐑭𐑕𐑢𐑼𐑛..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "_𐑕𐑦𐑑𐑦:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "_𐑒𐑳𐑯𐑑𐑮𐑰:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "_𐑒𐑳𐑯𐑑𐑮𐑰:"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤 _𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯..."
+
+#~ msgid "Email"
+#~ msgstr "𐑰𐑥𐑱𐑤"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 _𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯..."
+
+#~ msgid "Hom_e:"
+#~ msgstr "Hom_e:"
+
+#~ msgid "Home"
+#~ msgstr "𐑣𐑴𐑥"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "𐑦𐑯𐑕𐑑𐑩𐑯𐑑 𐑥𐑧𐑕𐑦𐑡𐑦𐑙"
+
+#~ msgid "Job"
+#~ msgstr "𐑡𐑪𐑚"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _𐑚𐑪𐑒𐑕:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. 𐑚𐑪𐑒𐑕:"
+
+#~ msgid "Personal Info"
+#~ msgstr "𐑐𐑻𐑕𐑩𐑯𐑩𐑤 𐑦𐑯𐑓𐑴"
+
+#~ msgid "Select your photo"
+#~ msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑿𐑼 𐑓𐑴𐑑𐑴"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "𐑕𐑑𐑱𐑑/_𐑐𐑮𐑪𐑝𐑦𐑯𐑕:"
+
+#~ msgid "Telephone"
+#~ msgstr "𐑑𐑧𐑤𐑩𐑓𐑴𐑯"
+
+#~ msgid "Web"
+#~ msgstr "𐑢𐑧𐑚"
+
+#~ msgid "Web _log:"
+#~ msgstr "𐑢𐑧𐑚 _𐑤𐑪𐑜:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_𐑢𐑻𐑒:"
+
+#~ msgid "Work"
+#~ msgstr "𐑢𐑻𐑒"
+
+#~ msgid "Work _fax:"
+#~ msgstr "𐑢𐑻𐑒 _𐑓𐑨𐑒𐑕:"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "𐑟𐑦𐑐/_𐑐𐑴𐑕𐑑𐑩𐑤 𐑒𐑴𐑛:"
+
+#, fuzzy
+#~ msgid "_GroupWise:"
+#~ msgstr "_GroupWise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_𐑣𐑴𐑥 𐑐𐑱𐑡:"
+
+#~ msgid "_Home:"
+#~ msgstr "_𐑣𐑴𐑥:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_𐑥𐑨𐑯𐑩𐑡𐑼:"
+
+#~ msgid "_Profession:"
+#~ msgstr "_𐑐𐑮𐑩𐑓𐑧𐑖𐑩𐑯:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_𐑕𐑑𐑱𐑑/𐑐𐑮𐑪𐑝𐑦𐑯𐑕:"
+
+#~ msgid "_Title:"
+#~ msgstr "_𐑑𐑲𐑑𐑩𐑤:"
+
+#~ msgid "_Work:"
+#~ msgstr "_𐑢𐑻𐑒:"
+
+#, fuzzy
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "·_𐑘𐑭𐑣𐑵:"
+
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "_𐑟𐑦𐑐/𐑐𐑴𐑕𐑑𐑩𐑤 𐑒𐑴𐑛:"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "𐑿 𐑸 𐑯𐑪𐑑 𐑩𐑤𐑬𐑛 𐑑 𐑨𐑒𐑕𐑧𐑕 𐑞 𐑛𐑦𐑝𐑲𐑕. 𐑒𐑪𐑯𐑑𐑨𐑒𐑑 𐑿𐑼 𐑕𐑦𐑕𐑑𐑩𐑥 𐑩𐑛𐑥𐑦𐑯𐑦𐑕𐑑𐑮𐑱𐑑𐑼."
+
+#~ msgid "The device is already in use."
+#~ msgstr "𐑞 𐑛𐑦𐑝𐑲𐑕 𐑦𐑟 𐑷𐑤𐑮𐑧𐑛𐑦 𐑦𐑯 𐑿𐑕."
+
+#, fuzzy
+#~ msgid "An internal error occured"
+#~ msgstr "𐑩𐑯 𐑦𐑯𐑑𐑻𐑯𐑩𐑤 𐑻𐑼 occured"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "𐑛𐑦𐑤𐑰𐑑 𐑮𐑧𐑡𐑦𐑕𐑑𐑼𐑛 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕?"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑨𐑒𐑕𐑧𐑕 '%s' 𐑛𐑦𐑝𐑲𐑕"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑕𐑑𐑸𐑑 𐑓𐑦𐑙𐑜𐑼 𐑒𐑨𐑐𐑗𐑻 𐑪𐑯 '%s' 𐑛𐑦𐑝𐑲𐑕"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑨𐑒𐑕𐑧𐑕 𐑧𐑯𐑦 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑮𐑰𐑛𐑼𐑟"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "𐑐𐑤𐑰𐑟 𐑒𐑪𐑯𐑑𐑨𐑒𐑑 𐑿𐑼 𐑕𐑦𐑕𐑑𐑩𐑥 𐑩𐑛𐑥𐑦𐑯𐑦𐑕𐑑𐑮𐑱𐑑𐑼 𐑓𐑹 𐑣𐑧𐑤𐑐."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "𐑑 𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯, 𐑿 𐑯𐑰𐑛 𐑑 𐑕𐑱𐑝 𐑢𐑳𐑯 𐑝 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕, 𐑿𐑟𐑦𐑙 𐑞 '%s' "
+#~ "𐑛𐑦𐑝𐑲𐑕."
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "𐑕𐑢𐑲𐑐 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 𐑮𐑰𐑛𐑼"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "𐑐𐑤𐑱𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 𐑮𐑰𐑛𐑼"
+
+#~ msgid "Left index finger"
+#~ msgstr "𐑤𐑧𐑓𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼"
+
+#~ msgid "Left little finger"
+#~ msgstr "𐑤𐑧𐑓𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
+
+#~ msgid "Left middle finger"
+#~ msgstr "𐑤𐑧𐑓𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
+
+#~ msgid "Left ring finger"
+#~ msgstr "𐑤𐑧𐑓𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼"
+
+#~ msgid "Left thumb"
+#~ msgstr "𐑤𐑧𐑓𐑑 𐑔𐑳𐑥"
+
+#~ msgid "Right index finger"
+#~ msgstr "𐑮𐑲𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼"
+
+#~ msgid "Right little finger"
+#~ msgstr "𐑮𐑲𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
+
+#~ msgid "Right middle finger"
+#~ msgstr "𐑮𐑲𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
+
+#~ msgid "Right ring finger"
+#~ msgstr "𐑮𐑲𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼"
+
+#~ msgid "Right thumb"
+#~ msgstr "𐑮𐑲𐑑 𐑔𐑳𐑥"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "𐑿𐑼 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑢𐑪𐑟 𐑕𐑩𐑒𐑕𐑧𐑕𐑓𐑩𐑤𐑦 𐑕𐑱𐑝𐑛. 𐑿 𐑖𐑫𐑛 𐑯𐑬 𐑚𐑰 𐑱𐑚𐑩𐑤 𐑑 𐑤𐑪𐑜 𐑦𐑯 𐑿𐑟𐑦𐑙 𐑿𐑼 "
+#~ "𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑮𐑰𐑛𐑼."
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "𐑗𐑲𐑤𐑛 𐑧𐑜𐑟𐑦𐑑𐑩𐑛 𐑩𐑯𐑦𐑒𐑕𐑐𐑧𐑒𐑑𐑦𐑛𐑤𐑰"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑖𐑩𐑑𐑛𐑶𐑯 backend_stdin IO 𐑗𐑨𐑯𐑩𐑤: %s"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑖𐑩𐑑𐑛𐑶𐑯 backend_stdout IO 𐑗𐑨𐑯𐑩𐑤: %s"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr ""
+#~ "𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑗𐑱𐑯𐑡𐑛 𐑕𐑦𐑯𐑕 𐑿 𐑦𐑯𐑦𐑖𐑩𐑤𐑦 𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛! 𐑐𐑤𐑰𐑟 𐑮𐑰-𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑."
+
+#~ msgid "That password was incorrect."
+#~ msgstr "𐑞𐑨𐑑 𐑐𐑭𐑕𐑢𐑼𐑛 𐑢𐑪𐑟 𐑦𐑯𐑒𐑼𐑧𐑒𐑑."
+
+#~ msgid "Your password has been changed."
+#~ msgstr "𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑗𐑱𐑯𐑡𐑛."
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "𐑕𐑦𐑕𐑑𐑩𐑥 𐑻𐑼: %s."
+
+#~ msgid "The password is too simple."
+#~ msgstr "𐑞 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑟 𐑑𐑵 𐑕𐑦𐑥𐑐𐑩𐑤."
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "𐑞 𐑴𐑤𐑛 𐑯 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛𐑟 𐑸 𐑑𐑵 𐑕𐑦𐑥𐑦𐑤𐑼."
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "𐑞 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛 𐑥𐑳𐑕𐑑 𐑒𐑩𐑯𐑑𐑱𐑯 𐑯𐑿𐑥𐑧𐑮𐑦𐑒 𐑹 𐑕𐑐𐑧𐑖𐑩𐑤 𐑒𐑸𐑩𐑒𐑑𐑼(𐑕)."
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "𐑞 𐑴𐑤𐑛 𐑯 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛𐑟 𐑸 𐑞 𐑕𐑱𐑥."
+
+#, c-format
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑤𐑷𐑯𐑗 %s: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑤𐑷𐑯𐑗 𐑚𐑨𐑒𐑧𐑯𐑛"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "𐑩 𐑕𐑦𐑕𐑑𐑩𐑥 𐑻𐑼 𐑣𐑨𐑟 𐑪𐑒𐑻𐑛"
+
+#~ msgid "Checking password..."
+#~ msgstr "𐑗𐑧𐑒𐑦𐑙 𐑐𐑭𐑕𐑢𐑼𐑛..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "𐑒𐑤𐑦𐑒 <b>𐑗𐑱𐑯𐑡 𐑐𐑭𐑕𐑢𐑼𐑛</b> 𐑑 𐑗𐑱𐑯𐑡 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛."
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "𐑐𐑤𐑰𐑟 𐑑𐑲𐑐 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑯 𐑞 <b>𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛</b> 𐑓𐑰𐑤𐑛."
+
+#, fuzzy
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "𐑐𐑤𐑰𐑟 𐑑𐑲𐑐 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑩𐑜𐑱𐑯 𐑦𐑯 𐑞 <𐑚𐑰>Retype 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛</𐑚𐑰> 𐑓𐑰𐑤𐑛."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "𐑞 𐑑𐑵 𐑐𐑭𐑕𐑢𐑼𐑛𐑟 𐑸 𐑯𐑪𐑑 𐑰𐑒𐑢𐑩𐑤."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "𐑗𐑱𐑯𐑡 _𐑐𐑭𐑕𐑢𐑼𐑛"
+
+#~ msgid "Change your password"
+#~ msgstr "𐑗𐑱𐑯𐑡 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛"
+
+#, fuzzy
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "𐑑 𐑗𐑱𐑯𐑡 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛, 𐑧𐑯𐑑𐑼 𐑿𐑼 𐑒𐑳𐑮𐑩𐑯𐑑 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑯 𐑞 𐑓𐑰𐑤𐑛 𐑚𐑩𐑤𐑴 𐑯 𐑒𐑤𐑦𐑒 "
+#~ "<𐑚𐑰>𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑</𐑚𐑰>.\n"
+#~ "𐑭𐑓𐑑𐑼 𐑿 𐑣𐑨𐑝 𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛, 𐑧𐑯𐑑𐑼 𐑿𐑼 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛, retype 𐑦𐑑 𐑓𐑹 𐑝𐑧𐑮𐑩𐑓𐑩𐑒𐑱𐑖𐑩𐑯 𐑯 "
+#~ "𐑒𐑤𐑦𐑒 <𐑚𐑰>𐑗𐑱𐑯𐑡 𐑐𐑭𐑕𐑢𐑼𐑛</𐑚𐑰>."
+
+#, fuzzy
+#~ msgid "Assistive Technologies"
+#~ msgstr "Assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟"
+
+#, fuzzy
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#, fuzzy
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "𐑗𐑱𐑯𐑡𐑩𐑟 𐑑 𐑦𐑯𐑱𐑚𐑩𐑤 assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑑𐑱𐑒 𐑦𐑓𐑧𐑒𐑑 𐑳𐑯𐑑𐑦𐑤 𐑿𐑼 𐑯𐑧𐑒𐑕𐑑 𐑤𐑪𐑜 "
+#~ "𐑦𐑯."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "𐑒𐑤𐑴𐑕 𐑯 _𐑤𐑪𐑜 𐑬𐑑"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑞 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑩𐑤 𐑤𐑪𐑜𐑦𐑯 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑞 𐑒𐑰𐑚𐑪𐑮𐑛 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑞 𐑥𐑬𐑕 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#, fuzzy
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_𐑦𐑯𐑱𐑚𐑩𐑤 assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "_𐑥𐑬𐑕 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "_𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "𐑗𐑵𐑟 𐑢𐑦𐑗 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑓𐑰𐑗𐑼𐑟 𐑑 𐑦𐑯𐑱𐑚𐑩𐑤 𐑢𐑧𐑯 𐑿 𐑤𐑪𐑜 𐑦𐑯"
+
+#~ msgid "Font may be too large"
+#~ msgstr "𐑓𐑪𐑯𐑑 𐑥𐑱 𐑚𐑰 𐑑𐑵 𐑤𐑸𐑡"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
+#~ "𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑲𐑟 𐑕𐑥𐑷𐑤𐑼 𐑞𐑨𐑯 %d."
+#~ msgstr[1] ""
+#~ "𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑𐑕 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
+#~ "𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑲𐑟 𐑕𐑥𐑷𐑤𐑼 𐑞𐑨𐑯 %d."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
+#~ "𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑥𐑷𐑤𐑼 𐑕𐑲𐑟𐑛 𐑓𐑪𐑯𐑑."
+#~ msgstr[1] ""
+#~ "𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑𐑕 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
+#~ "𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑥𐑷𐑤𐑼 𐑕𐑲𐑟𐑛 𐑓𐑪𐑯𐑑."
+
+#~ msgid "Use previous font"
+#~ msgstr "𐑿𐑟 𐑐𐑮𐑰𐑝𐑦𐑩𐑕 𐑓𐑪𐑯𐑑"
+
+#~ msgid "Use selected font"
+#~ msgstr "𐑿𐑟 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑓𐑪𐑯𐑑"
+
+#, c-format
+#~ msgid "Could not load user interface file: %s"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑤𐑴𐑛 𐑿𐑟𐑼 𐑦𐑯𐑑𐑼𐑓𐑱𐑕 𐑓𐑲𐑤: %s"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑓𐑲𐑤𐑯𐑱𐑥 𐑝 𐑩 𐑔𐑰𐑥 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑯𐑱𐑥 𐑝 𐑞 𐑐𐑱𐑡 𐑑 𐑖𐑴 (theme|background|fonts|interface)"
+
+#~ msgid "page"
+#~ msgstr "𐑐𐑱𐑡"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[𐑢𐑪𐑤𐑐𐑱𐑐𐑻...]"
+
+#~ msgid "Install"
+#~ msgstr "𐑦𐑯𐑕𐑑𐑷𐑤"
+
+#, fuzzy
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 GTK+ 𐑔𐑰𐑥 𐑧𐑯𐑡𐑦𐑯 '%s' 𐑦𐑟 "
+#~ "𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#~ msgid "Apply Background"
+#~ msgstr "𐑩𐑐𐑤𐑲 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
+
+#~ msgid "Revert Font"
+#~ msgstr "𐑮𐑦𐑝𐑻𐑑 𐑓𐑪𐑯𐑑"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑯 𐑩 𐑓𐑪𐑯𐑑. 𐑷𐑤𐑕𐑴, 𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 "
+#~ "𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛. 𐑷𐑤𐑕𐑴, 𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 "
+#~ "𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑯 𐑩 𐑓𐑪𐑯𐑑."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑓𐑪𐑯𐑑. 𐑷𐑤𐑕𐑴, 𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 "
+#~ "𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑓𐑪𐑯𐑑."
+
+#~ msgid "Custom"
+#~ msgstr "𐑒𐑳𐑕𐑑𐑩𐑥"
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "𐑩𐑐𐑽𐑩𐑯𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "Best _shapes"
+#~ msgstr "𐑚𐑧𐑕𐑑 _𐑖𐑱𐑐𐑕"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "𐑚𐑧𐑕𐑑 _𐑒𐑪𐑯𐑑𐑮𐑭𐑕𐑑"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "_𐑒𐑩𐑕𐑑𐑩𐑥𐑲𐑟..."
+
+#~ msgid "Center"
+#~ msgstr "𐑕𐑧𐑯𐑑𐑼"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "𐑗𐑱𐑯𐑡𐑦𐑙 𐑿𐑼 𐑒𐑻𐑕𐑼 𐑔𐑰𐑥 𐑑𐑱𐑒𐑕 𐑦𐑓𐑧𐑒𐑑 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑑𐑲𐑥 𐑿 𐑤𐑪𐑜 𐑦𐑯."
+
+#~ msgid "Customize Theme"
+#~ msgstr "𐑒𐑩𐑕𐑑𐑩𐑥𐑲𐑟 𐑔𐑰𐑥"
+
+#~ msgid "D_etails..."
+#~ msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "_𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑓𐑪𐑯𐑑:"
+
+#~ msgid "Fonts"
+#~ msgstr "𐑓𐑪𐑯𐑑𐑕"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "𐑜𐑧𐑑 𐑥𐑹 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛𐑟 𐑪𐑯𐑤𐑲𐑯"
+
+#~ msgid "Get more themes online"
+#~ msgstr "𐑜𐑧𐑑 𐑥𐑹 𐑔𐑰𐑥𐑟 𐑪𐑯𐑤𐑲𐑯"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "_𐑜𐑮𐑱𐑕𐑒𐑱𐑤"
+
+#~ msgid "Hinting"
+#~ msgstr "𐑣𐑦𐑯𐑑𐑦𐑙"
+
+#~ msgid "Horizontal gradient"
+#~ msgstr "𐑣𐑪𐑮𐑦𐑟𐑪𐑯𐑑𐑩𐑤 𐑜𐑮𐑱𐑛𐑦𐑩𐑯𐑑"
+
+#~ msgid "Icons"
+#~ msgstr "𐑲𐑒𐑪𐑯𐑟"
+
+#~ msgid "Icons only"
+#~ msgstr "𐑲𐑒𐑪𐑯𐑟 𐑴𐑯𐑤𐑦"
+
+#~ msgid "N_one"
+#~ msgstr "_𐑯𐑳𐑯"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "𐑴𐑐𐑩𐑯 𐑩 𐑛𐑲𐑩𐑤𐑪𐑜 𐑑 𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑒𐑳𐑤𐑼"
+
+#~ msgid "R_esolution:"
+#~ msgstr "_𐑮𐑧𐑟𐑩𐑤𐑵𐑖𐑩𐑯:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "𐑕𐑱𐑝 𐑔𐑰𐑥 𐑨𐑟..."
+
+#~ msgid "Save _As..."
+#~ msgstr "𐑕𐑱𐑝 _𐑨𐑟..."
+
+#~ msgid "Save _background image"
+#~ msgstr "𐑕𐑱𐑝 _𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑦𐑥𐑦𐑡"
+
+#~ msgid "Smoothing"
+#~ msgstr "𐑕𐑥𐑵𐑞𐑦𐑙"
+
+#~ msgid "Solid color"
+#~ msgstr "𐑕𐑪𐑤𐑦𐑛 𐑒𐑳𐑤𐑼"
+
+#~ msgid "Span"
+#~ msgstr "𐑕𐑐𐑨𐑯"
+
+#~ msgid "Stretch"
+#~ msgstr "𐑕𐑑𐑮𐑧𐑗"
+
+#, fuzzy
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "_Subpixel (LCDs)"
+
+#, fuzzy
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "_Subpixel 𐑕𐑥𐑵𐑞𐑦𐑙 (LCDs)"
+
+#, fuzzy
+#~ msgid "Subpixel Order"
+#~ msgstr "Subpixel 𐑹𐑛𐑼"
+
+#~ msgid "Text"
+#~ msgstr "𐑑𐑧𐑒𐑕𐑑"
+
+#~ msgid "Text below items"
+#~ msgstr "𐑑𐑧𐑒𐑕𐑑 𐑚𐑩𐑤𐑴 𐑲𐑑𐑩𐑥𐑟"
+
+#~ msgid "Text beside items"
+#~ msgstr "𐑑𐑧𐑒𐑕𐑑 𐑚𐑦𐑕𐑲𐑛 𐑲𐑑𐑩𐑥𐑟"
+
+#~ msgid "Text only"
+#~ msgstr "𐑑𐑧𐑒𐑕𐑑 𐑴𐑯𐑤𐑦"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑟 𐑔𐑰𐑥 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑕𐑩𐑐𐑹𐑑 𐑒𐑳𐑤𐑼 𐑕𐑒𐑰𐑥𐑟."
+
+#~ msgid "Theme"
+#~ msgstr "𐑔𐑰𐑥"
+
+#~ msgid "Tile"
+#~ msgstr "𐑑𐑲𐑤"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "Vertical gradient"
+#~ msgstr "𐑝𐑻𐑑𐑦𐑒𐑩𐑤 𐑜𐑮𐑱𐑛𐑦𐑩𐑯𐑑"
+
+#~ msgid "Window Border"
+#~ msgstr "𐑢𐑦𐑯𐑛𐑴 𐑚𐑹𐑛𐑼"
+
+#, fuzzy
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "_𐑛𐑦𐑕𐑒𐑮𐑦𐑐𐑖𐑩𐑯:"
+
+#~ msgid "_Document font:"
+#~ msgstr "_𐑛𐑪𐑒𐑿𐑥𐑩𐑯𐑑 𐑓𐑪𐑯𐑑:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_𐑓𐑦𐑒𐑕𐑑 𐑢𐑦𐑛𐑔 𐑓𐑪𐑯𐑑:"
+
+#~ msgid "_Install..."
+#~ msgstr "_𐑦𐑯𐑕𐑑𐑷𐑤..."
+
+#~ msgid "_Monochrome"
+#~ msgstr "_𐑥𐑭𐑯𐑩𐑒𐑮𐑴𐑥"
+
+#, fuzzy
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Selected items:"
+#~ msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑲𐑑𐑩𐑥𐑟:"
+
+#~ msgid "_Size:"
+#~ msgstr "_𐑕𐑲𐑟:"
+
+#~ msgid "_Slight"
+#~ msgstr "_𐑕𐑤𐑲𐑑"
+
+#~ msgid "_Style:"
+#~ msgstr "_𐑕𐑑𐑲𐑤:"
+
+#, fuzzy
+#~ msgid "_Tooltips:"
+#~ msgstr "_Tooltips:"
+
+#, fuzzy
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_𐑢𐑦𐑯𐑛𐑴 𐑑𐑲𐑑𐑩𐑤 𐑓𐑪𐑯𐑑:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_𐑢𐑦𐑯𐑛𐑴𐑟:"
+
+#~ msgid "dots per inch"
+#~ msgstr "𐑛𐑪𐑑𐑕 𐑐𐑻 𐑦𐑯𐑗"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "𐑒𐑩𐑕𐑑𐑩𐑥𐑲𐑟 𐑞 𐑤𐑫𐑒 𐑝 𐑞 𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "𐑦𐑯𐑕𐑑𐑷𐑤𐑟 𐑔𐑰𐑥𐑟 𐑐𐑨𐑒𐑦𐑡𐑩𐑟 𐑓𐑹 𐑝𐑺𐑦𐑩𐑕 𐑐𐑸𐑑𐑕 𐑝 𐑞 𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
+
+#~ msgid "Theme Installer"
+#~ msgstr "𐑔𐑰𐑥 𐑦𐑯𐑕𐑑𐑷𐑤𐑼"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "𐑯𐑴𐑥 𐑔𐑰𐑥 𐑐𐑨𐑒𐑦𐑡"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "𐑯𐑴 𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
+
+#~ msgid "Slide Show"
+#~ msgstr "𐑕𐑤𐑲𐑛 𐑖𐑴"
+
+#~ msgid "Image"
+#~ msgstr "𐑦𐑥𐑦𐑡"
+
+#, fuzzy
+#~ msgid "%d %s by %d %s"
+#~ msgstr "%d %s 𐑚𐑲 %d %s"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "𐑐𐑦𐑒𐑕𐑩𐑤"
+#~ msgstr[1] "𐑐𐑦𐑒𐑕𐑩𐑤𐑟"
+
+#, c-format
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "𐑓𐑴𐑤𐑛𐑼: %s"
+
+#, fuzzy
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<𐑚𐑰>%s</𐑚𐑰>\n"
+#~ "%s\n"
+#~ "𐑓𐑴𐑤𐑛𐑼: %s"
+
+#~ msgid "Image missing"
+#~ msgstr "𐑦𐑥𐑦𐑡 𐑥𐑦𐑕𐑦𐑙"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "𐑒𐑨𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑔𐑰𐑥"
+
+#, c-format
+#~ msgid "The %s utility is not installed."
+#~ msgstr "𐑞 %s 𐑘𐑵𐑑𐑦𐑤𐑩𐑑𐑰 𐑦𐑟 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "𐑞𐑺 𐑢𐑪𐑟 𐑩 𐑐𐑮𐑪𐑚𐑤𐑩𐑥 𐑢𐑲𐑤 𐑦𐑒𐑕𐑑𐑮𐑨𐑒𐑑𐑦𐑙 𐑞 𐑔𐑰𐑥."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "𐑞𐑺 𐑢𐑪𐑟 𐑩𐑯 𐑻𐑼 𐑦𐑯𐑕𐑑𐑷𐑤𐑦𐑙 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑓𐑲𐑤"
+
+#, c-format
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑩𐑐𐑽 𐑑 𐑚𐑰 𐑩 𐑝𐑨𐑤𐑦𐑛 𐑔𐑰𐑥."
+
+#, c-format
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑩𐑐𐑽 𐑑 𐑚𐑰 𐑩 𐑝𐑨𐑤𐑦𐑛 𐑔𐑰𐑥. 𐑦𐑑 𐑥𐑱 𐑚𐑰 𐑩 𐑔𐑰𐑥 𐑧𐑯𐑡𐑦𐑯 𐑢𐑦𐑗 𐑿 𐑯𐑰𐑛 𐑑 "
+#~ "𐑒𐑪𐑥𐑐𐑲𐑤."
+
+#, c-format
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "𐑦𐑯𐑕𐑑𐑩𐑤𐑱𐑖𐑩𐑯 𐑓𐑹 𐑔𐑰𐑥 \"%s\" 𐑓𐑱𐑤𐑛."
+
+#, c-format
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "𐑞 𐑔𐑰𐑥 \"%s\" 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "𐑢𐑫𐑛 𐑿 𐑤𐑲𐑒 𐑑 𐑩𐑐𐑤𐑲 𐑦𐑑 𐑯𐑬, 𐑹 𐑒𐑰𐑐 𐑿𐑼 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "𐑒𐑰𐑐 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "𐑩𐑐𐑤𐑲 𐑯𐑿 𐑔𐑰𐑥"
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "·𐑜𐑯𐑴𐑥 𐑔𐑰𐑥 %s 𐑒𐑼𐑧𐑒𐑑𐑤𐑦 𐑦𐑯𐑕𐑑𐑷𐑤𐑛"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "𐑓𐑱𐑤𐑛 𐑑 𐑒𐑮𐑦𐑱𐑑 𐑑𐑧𐑥𐑐𐑼𐑼𐑦 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "𐑯𐑿 𐑔𐑰𐑥𐑟 𐑣𐑨𐑝 𐑚𐑰𐑯 𐑕𐑩𐑒𐑕𐑧𐑕𐑓𐑩𐑤𐑦 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "𐑯𐑴 𐑔𐑰𐑥 𐑓𐑲𐑤 𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑕𐑐𐑧𐑕𐑦𐑓𐑲𐑛 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "𐑦𐑯𐑕𐑩𐑓𐑦𐑖𐑩𐑯𐑑 𐑐𐑻𐑥𐑦𐑖𐑪𐑯𐑟 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑞 𐑔𐑰𐑥 𐑦𐑯:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑔𐑰𐑥"
+
+#~ msgid "Theme Packages"
+#~ msgstr "𐑔𐑰𐑥 𐑐𐑨𐑒𐑦𐑡𐑩𐑟"
+
+#, c-format
+#~ msgid "Theme name must be present"
+#~ msgstr "𐑔𐑰𐑥 𐑯𐑱𐑥 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑐𐑮𐑩𐑟𐑧𐑯𐑑"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "𐑞 𐑔𐑰𐑥 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕. 𐑢𐑫𐑛 𐑿 𐑤𐑲𐑒 𐑑 𐑮𐑦𐑐𐑤𐑱𐑕 𐑦𐑑?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_𐑴𐑝𐑼𐑮𐑲𐑑"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "𐑢𐑫𐑛 𐑿 𐑤𐑲𐑒 𐑑 𐑛𐑦𐑤𐑰𐑑 𐑞𐑦𐑕 𐑔𐑰𐑥?"
+
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "𐑔𐑰𐑥 𐑒𐑨𐑯𐑪𐑑 𐑚𐑰 𐑛𐑦𐑤𐑰𐑑𐑩𐑛"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑔𐑰𐑥 𐑧𐑯𐑡𐑦𐑯"
+
+#, fuzzy
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑕𐑑𐑸𐑑 𐑞 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼 '·𐑯𐑴𐑥-𐑕𐑧𐑑𐑦𐑙𐑟-𐑛𐑰𐑥𐑩𐑯'.\n"
+#~ "𐑢𐑦𐑞𐑬𐑑 𐑞 ·𐑯𐑴𐑥 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼 𐑮𐑳𐑯𐑦𐑙, 𐑕𐑳𐑥 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟 𐑥𐑱 𐑯𐑪𐑑 𐑑𐑱𐑒 𐑦𐑓𐑧𐑒𐑑. 𐑞𐑦𐑕 "
+#~ "𐑒𐑫𐑛 𐑦𐑯𐑛𐑦𐑒𐑱𐑑 𐑩 𐑐𐑮𐑪𐑚𐑤𐑩𐑥 𐑢𐑦𐑞 DBus, 𐑹 𐑩 𐑯𐑪𐑯-·𐑯𐑴𐑥 (𐑧.𐑡𐑰. ·𐑒·𐑛·𐑧) 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼 "
+#~ "𐑥𐑱 𐑷𐑤𐑮𐑧𐑛𐑦 𐑚𐑰 𐑨𐑒𐑑𐑦𐑝 𐑯 𐑒𐑩𐑯𐑓𐑤𐑦𐑒𐑑𐑦𐑙 𐑢𐑦𐑞 𐑞 ·𐑯𐑴𐑥 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼."
+
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑤𐑴𐑛 𐑕𐑑𐑪𐑒 𐑲𐑒𐑪𐑯 '%s'\n"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "𐑞𐑺 𐑢𐑪𐑟 𐑩𐑯 𐑻𐑼 𐑛𐑦𐑕𐑐𐑤𐑱𐑦𐑙 𐑣𐑧𐑤𐑐: %s"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "𐑒𐑪𐑐𐑦𐑦𐑙 𐑓𐑲𐑤: %u 𐑝 %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "𐑒𐑪𐑐𐑦𐑦𐑙 '%s'"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "𐑐𐑺𐑩𐑯𐑑 𐑢𐑦𐑯𐑛𐑴 𐑝 𐑞 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI 𐑒𐑳𐑮𐑩𐑯𐑑𐑤𐑦 𐑑𐑮𐑨𐑯𐑕𐑓𐑻𐑦𐑙 𐑓𐑮𐑪𐑥"
+
+#~ msgid "To URI"
+#~ msgstr "𐑑 URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI 𐑒𐑳𐑮𐑩𐑯𐑑𐑤𐑦 𐑑𐑮𐑨𐑯𐑕𐑓𐑻𐑦𐑙 𐑑"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "𐑓𐑮𐑨𐑒𐑖𐑩𐑯 𐑝 𐑑𐑮𐑭𐑯𐑕𐑓𐑼 𐑒𐑳𐑮𐑩𐑯𐑑𐑤𐑦 𐑒𐑩𐑥𐑐𐑤𐑰𐑑𐑩𐑛"
+
+#~ msgid "Current URI index"
+#~ msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 URI 𐑦𐑯𐑛𐑧𐑒𐑕"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 URI 𐑦𐑯𐑛𐑧𐑒𐑕 - 𐑕𐑑𐑸𐑑𐑕 𐑓𐑮𐑪𐑥 1"
+
+#, fuzzy
+#~ msgid "Total URIs"
+#~ msgstr "𐑑𐑴𐑑𐑩𐑤 URIs"
+
+#, fuzzy
+#~ msgid "Total number of URIs"
+#~ msgstr "𐑑𐑴𐑑𐑩𐑤 𐑯𐑳𐑥𐑚𐑼 𐑝 URIs"
+
+#, c-format
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "𐑓𐑲𐑤 '%s' 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕. 𐑛𐑵 𐑿 𐑢𐑪𐑯𐑑 𐑑 𐑴𐑝𐑼𐑮𐑲𐑑 𐑦𐑑?"
+
+#~ msgid "_Skip"
+#~ msgstr "_𐑕𐑒𐑦𐑐"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "𐑴𐑝𐑼𐑮𐑲𐑑 _𐑷𐑤"
+
+#~ msgid "Key"
+#~ msgstr "𐑒𐑰"
+
+#, fuzzy
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf 𐑒𐑰 𐑑 𐑢𐑦𐑗 𐑞𐑦𐑕 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑦𐑟 𐑩𐑑𐑨𐑗𐑑"
+
+#, fuzzy
+#~ msgid "Callback"
+#~ msgstr "Callback"
+
+#, fuzzy
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "𐑦𐑖𐑵 𐑞𐑦𐑕 callback 𐑢𐑧𐑯 𐑞 𐑝𐑨𐑤𐑿 𐑩𐑕𐑴𐑖𐑦𐑱𐑑𐑩𐑛 𐑢𐑦𐑞 𐑒𐑰 𐑜𐑧𐑑𐑕 𐑗𐑱𐑯𐑡𐑛"
+
+#, fuzzy
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr "GConf 𐑗𐑱𐑯𐑡 𐑕𐑧𐑑 𐑒𐑩𐑯𐑑𐑱𐑯𐑦𐑙 𐑛𐑱𐑑𐑩 𐑑 𐑚𐑰 𐑓𐑪𐑮𐑢𐑻𐑛𐑦𐑛 𐑑 𐑞 gconf 𐑒𐑤𐑲𐑩𐑯𐑑 𐑪𐑯 𐑩𐑐𐑤𐑲"
+
+#, fuzzy
+#~ msgid "Conversion to widget callback"
+#~ msgstr "𐑒𐑩𐑯𐑝𐑻𐑖𐑩𐑯 𐑑 𐑢𐑦𐑡𐑩𐑑 callback"
+
+#, fuzzy
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "Callback 𐑑 𐑚𐑰 𐑦𐑖𐑵𐑛 𐑢𐑧𐑯 𐑛𐑱𐑑𐑩 𐑸 𐑑 𐑚𐑰 𐑒𐑩𐑯𐑝𐑻𐑑𐑩𐑛 𐑓𐑮𐑪𐑥 GConf 𐑑 𐑞 𐑢𐑦𐑡𐑩𐑑"
+
+#, fuzzy
+#~ msgid "Conversion from widget callback"
+#~ msgstr "𐑒𐑩𐑯𐑝𐑻𐑖𐑩𐑯 𐑓𐑮𐑪𐑥 𐑢𐑦𐑡𐑩𐑑 callback"
+
+#, fuzzy
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "Callback 𐑑 𐑚𐑰 𐑦𐑖𐑵𐑛 𐑢𐑧𐑯 𐑛𐑱𐑑𐑩 𐑸 𐑑 𐑚𐑰 𐑒𐑩𐑯𐑝𐑻𐑑𐑩𐑛 𐑑 GConf 𐑓𐑮𐑪𐑥 𐑞 𐑢𐑦𐑡𐑩𐑑"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "𐑩𐑚𐑡𐑧𐑒𐑑 𐑞𐑨𐑑 𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑟 𐑞 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 (𐑯𐑹𐑥𐑩𐑤𐑦 𐑩 𐑢𐑦𐑡𐑩𐑑)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑩𐑚𐑡𐑧𐑒𐑑 𐑛𐑱𐑑𐑩"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑛𐑱𐑑𐑩 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑚𐑲 𐑞 𐑕𐑐𐑩𐑕𐑦𐑓𐑦𐑒 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹"
+
+#, fuzzy
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑛𐑱𐑑𐑩 𐑓𐑮𐑰𐑦𐑙 callback"
+
+#, fuzzy
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "Callback 𐑑 𐑚𐑰 𐑦𐑖𐑵𐑛 𐑢𐑧𐑯 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑩𐑚𐑡𐑧𐑒𐑑 𐑛𐑱𐑑𐑩 𐑦𐑟 𐑑 𐑚𐑰 𐑓𐑮𐑰𐑛"
+
+#, fuzzy
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "𐑒𐑫𐑛𐑯𐑑 𐑓𐑲𐑯𐑛 𐑞 𐑓𐑲𐑤 '%s'.\n"
+#~ "\n"
+#~ "𐑐𐑤𐑰𐑟 𐑥𐑱𐑒 𐑖𐑫𐑼 𐑦𐑑 𐑧𐑒𐑟𐑦𐑕𐑑𐑕 𐑯 𐑑𐑮𐑲 𐑩𐑜𐑱𐑯, 𐑹 𐑗𐑵𐑟 𐑩 𐑛𐑦𐑓𐑼𐑩𐑯𐑑 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑐𐑦𐑒𐑗𐑼."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "𐑲 𐑛𐑴𐑯𐑑 𐑯𐑴 𐑣𐑬 𐑑 𐑴𐑐𐑩𐑯 𐑞 𐑓𐑲𐑤 '%s'.\n"
+#~ "𐑐𐑼𐑣𐑨𐑐𐑕 𐑦𐑑'𐑕 𐑩 𐑒𐑲𐑯𐑛 𐑝 𐑐𐑦𐑒𐑗𐑼 𐑞𐑨𐑑 𐑦𐑟 𐑯𐑪𐑑 𐑘𐑧𐑑 𐑕𐑩𐑐𐑹𐑑𐑩𐑛.\n"
+#~ "\n"
+#~ "𐑐𐑤𐑰𐑟 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑛𐑦𐑓𐑼𐑩𐑯𐑑 𐑐𐑦𐑒𐑗𐑼 𐑦𐑯𐑕𐑑𐑧𐑛."
+
+#~ msgid "Please select an image."
+#~ msgstr "𐑐𐑤𐑰𐑟 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩𐑯 𐑦𐑥𐑦𐑡."
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "𐑛𐑦𐑓𐑷𐑤𐑑 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
+
+#~ msgid "White Pointer"
+#~ msgstr "𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
+
+#~ msgid "Large Pointer"
+#~ msgstr "𐑤𐑸𐑡 𐑐𐑶𐑯𐑑𐑼"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "𐑤𐑸𐑡 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "𐑤𐑸𐑡 𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
+
+#, fuzzy
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 GTK+ 𐑔𐑰𐑥 '%s' 𐑦𐑟 𐑯𐑪𐑑 "
+#~ "𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑢𐑦𐑯𐑛𐑴 𐑥𐑨𐑯𐑩𐑡𐑼 𐑔𐑰𐑥 '%s' 𐑦𐑟 "
+#~ "𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑲𐑒𐑪𐑯 𐑔𐑰𐑥 '%s' 𐑦𐑟 𐑯𐑪𐑑 "
+#~ "𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#~ msgid "Preferred Applications"
+#~ msgstr "𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
+
+#~ msgid "Select your default applications"
+#~ msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑿𐑼 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
+
+#, fuzzy
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "𐑕𐑑𐑸𐑑 𐑞 𐑐𐑮𐑦𐑓𐑻𐑛 𐑝𐑦𐑠𐑩𐑢𐑩𐑤 assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤 𐑩𐑕𐑦𐑕𐑑𐑩𐑯𐑕"
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "𐑻𐑼 𐑕𐑱𐑝𐑦𐑙 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑤𐑴𐑛 𐑞 𐑥𐑱𐑯 𐑦𐑯𐑑𐑼𐑓𐑱𐑕"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑯𐑱𐑥 𐑝 𐑞 𐑐𐑱𐑡 𐑑 𐑖𐑴 (internet|multimedia|system|a11y)"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "𐑷𐑤 %s 𐑩𐑒𐑻𐑩𐑯𐑕𐑦𐑟 𐑢𐑦𐑤 𐑚𐑰 𐑮𐑦𐑐𐑤𐑱𐑕𐑑 𐑢𐑦𐑞 𐑨𐑒𐑗𐑫𐑩𐑤 𐑤𐑦𐑙𐑒"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "_𐑒𐑩𐑥𐑭𐑯𐑛:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "_𐑧𐑒𐑕𐑩𐑒𐑿𐑑 𐑓𐑤𐑨𐑜:"
+
+#~ msgid "Image Viewer"
+#~ msgstr "𐑦𐑥𐑦𐑡 𐑝𐑿𐑼"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "𐑦𐑯𐑕𐑑𐑩𐑯𐑑 𐑥𐑧𐑕𐑩𐑯𐑡𐑼"
+
+#~ msgid "Internet"
+#~ msgstr "·𐑦𐑯𐑑𐑼𐑯𐑧𐑑"
+
+#~ msgid "Mail Reader"
+#~ msgstr "𐑥𐑱𐑤 𐑮𐑰𐑛𐑼"
+
+#~ msgid "Mobility"
+#~ msgstr "𐑥𐑴𐑚𐑦𐑤𐑩𐑑𐑰"
+
+#~ msgid "Multimedia"
+#~ msgstr "𐑥𐑩𐑤𐑑𐑰𐑥𐑰𐑛𐑰𐑩"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "𐑴𐑐𐑩𐑯 𐑤𐑦𐑙𐑒 𐑦𐑯 𐑯𐑿 _𐑑𐑨𐑚"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "𐑴𐑐𐑩𐑯 𐑤𐑦𐑙𐑒 𐑦𐑯 𐑯𐑿 _𐑢𐑦𐑯𐑛𐑴"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "𐑴𐑐𐑩𐑯 𐑤𐑦𐑙𐑒 𐑢𐑦𐑞 𐑢𐑧𐑚 𐑚𐑮𐑬𐑟𐑼 _𐑛𐑦𐑓𐑷𐑤𐑑"
+
+#~ msgid "Run at st_art"
+#~ msgstr "𐑮𐑳𐑯 𐑨𐑑 _𐑕𐑑𐑸𐑑"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "𐑮𐑳𐑯 𐑦𐑯 _𐑑𐑻𐑥𐑦𐑯𐑩𐑤"
+
+#, fuzzy
+#~ msgid "Terminal Emulator"
+#~ msgstr "𐑑𐑻𐑥𐑦𐑯𐑩𐑤 Emulator"
+
+#~ msgid "Text Editor"
+#~ msgstr "𐑑𐑧𐑒𐑕𐑑 𐑧𐑛𐑦𐑑𐑹"
+
+#~ msgid "Video Player"
+#~ msgstr "𐑝𐑦𐑛𐑦𐑴 𐑐𐑤𐑱𐑼"
+
+#~ msgid "Web Browser"
+#~ msgstr "𐑢𐑧𐑚 𐑚𐑮𐑬𐑟𐑼"
+
+#~ msgid "Balsa"
+#~ msgstr "·𐑚𐑪𐑤𐑕𐑩"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "·𐑚𐑨𐑯𐑖𐑰 𐑥𐑿𐑟𐑦𐑒 𐑐𐑤𐑱𐑼"
+
+#~ msgid "Claws Mail"
+#~ msgstr "·𐑒𐑤𐑷𐑟 𐑥𐑱𐑤"
+
+#~ msgid "Dasher"
+#~ msgstr "·𐑛𐑨𐑖𐑻"
+
+#, fuzzy
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian 𐑕𐑧𐑯𐑕𐑩𐑚𐑩𐑤 𐑚𐑮𐑬𐑟𐑼"
+
+#, fuzzy
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian 𐑑𐑻𐑥𐑦𐑯𐑩𐑤 Emulator"
+
+#, fuzzy
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "·𐑦𐑯𐑒𐑳𐑥𐑐𐑩𐑕"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "·𐑧𐑝𐑩𐑤𐑵𐑖𐑩𐑯 𐑥𐑱𐑤 𐑮𐑰𐑛𐑼"
+
+#~ msgid "Firebird"
+#~ msgstr "·𐑓𐑲𐑻𐑚𐑻𐑛"
+
+#, fuzzy
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "·𐑜𐑯𐑴𐑥 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻 𐑢𐑦𐑞𐑬𐑑 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
+
+#, fuzzy
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#, fuzzy
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#, fuzzy
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus 𐑢𐑦𐑞 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻"
+
+#, fuzzy
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#, fuzzy
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape 𐑥𐑱𐑤"
+
+#, fuzzy
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#, fuzzy
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "KDE 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻 𐑢𐑦𐑞𐑬𐑑 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
+
+#~ msgid "Konqueror"
+#~ msgstr "·𐑒𐑪𐑙𐑒𐑼𐑼"
+
+#, fuzzy
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "·𐑤𐑦𐑯𐑩𐑒𐑕 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼 𐑢𐑦𐑞 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻"
+
+#~ msgid "Listen"
+#~ msgstr "·𐑤𐑦𐑕𐑩𐑯"
+
+#, fuzzy
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#, fuzzy
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#, fuzzy
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#, fuzzy
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla 𐑥𐑱𐑤"
+
+#, fuzzy
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla 𐑔𐑩𐑯𐑛𐑻𐑚𐑻𐑛"
+
+#~ msgid "Mutt"
+#~ msgstr "·𐑥𐑩𐑑"
+
+#, fuzzy
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "·𐑯𐑧𐑑𐑕𐑒𐑱𐑐 ·𐑒𐑩𐑥𐑘𐑵𐑯𐑩𐑒𐑱𐑑𐑻"
+
+#~ msgid "Opera"
+#~ msgstr "·𐑪𐑐𐑼𐑩"
+
+#~ msgid "Orca"
+#~ msgstr "·𐑪𐑮𐑒𐑩"
+
+#, fuzzy
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#, fuzzy
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox 𐑥𐑿𐑟𐑦𐑒 𐑐𐑤𐑱𐑼"
+
+#, fuzzy
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#, fuzzy
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey 𐑥𐑱𐑤"
+
+#, fuzzy
+#~ msgid "Standard XTerminal"
+#~ msgstr "𐑕𐑑𐑨𐑯𐑛𐑼𐑛 XTerminal"
+
+#, fuzzy
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#, fuzzy
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-𐑒𐑤𐑷𐑟"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "·𐑑𐑴𐑑𐑩𐑥 𐑥𐑵𐑝𐑰 𐑐𐑤𐑱𐑼"
+
+#, fuzzy
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Include _panel"
+#~ msgstr "𐑦𐑯𐑒𐑤𐑵𐑛 _𐑐𐑨𐑯𐑩𐑤"
+
+#~ msgid "Make Default"
+#~ msgstr "𐑥𐑱𐑒 𐑛𐑦𐑓𐑷𐑤𐑑"
+
+#~ msgid "Monitor Preferences"
+#~ msgstr "𐑥𐑪𐑯𐑦𐑑𐑼 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "Off"
+#~ msgstr "𐑪𐑓"
+
+#~ msgid "On"
+#~ msgstr "𐑪𐑯"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "_𐑕𐑱𐑥 𐑦𐑥𐑦𐑡 𐑦𐑯 𐑷𐑤 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#~ msgid "Upside-down"
+#~ msgstr "𐑳𐑐𐑕𐑲𐑛-𐑛𐑬𐑯"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "_𐑛𐑦𐑑𐑧𐑒𐑑 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#~ msgid "_Show monitors in panel"
+#~ msgstr "_𐑖𐑴 𐑥𐑪𐑯𐑦𐑑𐑼𐑟 𐑦𐑯 𐑐𐑨𐑯𐑩𐑤"
+
+#~ msgid "Change resolution and position of monitors"
+#~ msgstr "𐑗𐑱𐑯𐑡 𐑮𐑧𐑟𐑩𐑤𐑵𐑖𐑩𐑯 𐑯 𐑐𐑩𐑟𐑦𐑖𐑩𐑯 𐑝 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#~ msgid "Monitors"
+#~ msgstr "𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#, fuzzy
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "𐑿𐑕𐑦𐑡: %s _SOURCEFILE _DESTNAME\n"
+#~ "\n"
+#~ "𐑞𐑦𐑕 𐑐𐑮𐑴𐑜𐑮𐑨𐑥 𐑦𐑯𐑕𐑑𐑷𐑤𐑟 𐑩 RANDR 𐑐𐑮𐑴𐑓𐑲𐑤 𐑓𐑹 𐑥𐑩𐑤𐑑𐑰-𐑥𐑪𐑯𐑦𐑑𐑼 𐑕𐑧𐑑𐑩𐑐𐑕 𐑦𐑯𐑑𐑫\n"
+#~ "𐑩 𐑕𐑦𐑕𐑑𐑩𐑥𐑢𐑲𐑛 𐑤𐑴𐑒𐑱𐑖𐑩𐑯.  𐑞 𐑮𐑦𐑟𐑳𐑤𐑑𐑦𐑙 𐑐𐑮𐑴𐑓𐑲𐑤 𐑢𐑦𐑤 𐑜𐑧𐑑 𐑿𐑟𐑛 𐑢𐑧𐑯\n"
+#~ "𐑞 RANDR 𐑐𐑤𐑳𐑜-𐑦𐑯 𐑜𐑧𐑑𐑕 𐑮𐑳𐑯 𐑦𐑯 ·𐑯𐑴𐑥-𐑕𐑧𐑑𐑦𐑙𐑟-𐑛𐑰𐑥𐑩𐑯.\n"
+#~ "\n"
+#~ "_SOURCEFILE - 𐑩 𐑓𐑫𐑤 pathname, 𐑑𐑦𐑐𐑦𐑒𐑤𐑰 /𐑣𐑴𐑥/𐑿𐑟𐑼𐑯𐑱𐑥/.𐑒𐑪𐑯𐑓𐑦𐑜/𐑥𐑪𐑯𐑦𐑑𐑼𐑟.·𐑦·𐑥·𐑤\n"
+#~ "\n"
+#~ "_DESTNAME - 𐑮𐑧𐑤𐑩𐑑𐑦𐑝 𐑯𐑱𐑥 𐑓𐑹 𐑞 𐑦𐑯𐑕𐑑𐑷𐑤𐑛 𐑓𐑲𐑤.  𐑞𐑦𐑕 𐑢𐑦𐑤 𐑜𐑧𐑑 𐑐𐑫𐑑 𐑦𐑯\n"
+#~ "            𐑞 𐑕𐑦𐑕𐑑𐑩𐑥𐑢𐑲𐑛 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦 𐑓𐑹 RANDR 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯𐑟,\n"
+#~ "            𐑕𐑴 𐑞 𐑮𐑦𐑟𐑳𐑤𐑑 𐑢𐑦𐑤 𐑑𐑦𐑐𐑦𐑒𐑤𐑰 𐑚𐑰 %s/_DESTNAME\n"
+
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "𐑞𐑦𐑕 𐑐𐑮𐑴𐑜𐑮𐑨𐑥 𐑒𐑨𐑯 𐑴𐑯𐑤𐑦 𐑚𐑰 𐑿𐑟𐑛 𐑚𐑲 𐑞 𐑮𐑵𐑑 𐑿𐑟𐑼"
+
+#~ msgid "The source filename must be absolute"
+#~ msgstr "𐑞 𐑕𐑹𐑕 𐑓𐑲𐑤𐑯𐑱𐑥 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑨𐑚𐑕𐑴𐑤𐑵𐑑"
+
+#, fuzzy
+#~ msgid "Could not open %s: %s\n"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑴𐑐𐑩𐑯 %s: %s\n"
+
+#, fuzzy
+#~ msgid "Could not get information for %s: %s\n"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑜𐑧𐑑 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯 𐑓𐑹 %s: %s\n"
+
+#, fuzzy
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑩 𐑮𐑧𐑜𐑘𐑫𐑤𐑼 𐑓𐑲𐑤\n"
+
+#, fuzzy
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "𐑞𐑦𐑕 𐑐𐑮𐑴𐑜𐑮𐑨𐑥 𐑥𐑳𐑕𐑑 𐑴𐑯𐑤𐑦 𐑚𐑰 𐑮𐑳𐑯 𐑔𐑮𐑵 pkexec(1)"
+
+#, fuzzy
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "_PKEXECUID 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑕𐑧𐑑 𐑑 𐑩𐑯 𐑦𐑯𐑑𐑩𐑡𐑼 𐑝𐑨𐑤𐑿"
+
+#, fuzzy
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "%s 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑴𐑯𐑛 𐑚𐑲 𐑿\n"
+
+#, fuzzy
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s 𐑥𐑳𐑕𐑑 𐑯𐑪𐑑 𐑣𐑨𐑝 𐑧𐑯𐑦 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦 𐑒𐑩𐑥𐑐𐑴𐑯𐑩𐑯𐑑𐑕\n"
+
+#, fuzzy
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑩 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦\n"
+
+#, fuzzy
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑴𐑐𐑩𐑯 %s/%s: %s\n"
+
+#, fuzzy
+#~ msgid "Could not rename %s to %s: %s\n"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑮𐑰𐑯𐑱𐑥 %s 𐑑 %s: %s\n"
+
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "𐑦𐑯𐑕𐑑𐑷𐑤 𐑥𐑩𐑤𐑑𐑰-𐑥𐑪𐑯𐑦𐑑𐑼 𐑕𐑧𐑑𐑦𐑙𐑟 𐑓𐑹 𐑞 𐑣𐑴𐑤 𐑕𐑦𐑕𐑑𐑩𐑥"
+
+#~ msgid "Upside Down"
+#~ msgstr "𐑳𐑐𐑕𐑲𐑛 𐑛𐑬𐑯"
+
+#, fuzzy
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#, c-format
+#~ msgid "Monitor: %s"
+#~ msgstr "𐑥𐑪𐑯𐑦𐑑𐑼: %s"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑥𐑪𐑯𐑦𐑑𐑼 𐑑 𐑗𐑱𐑯𐑡 𐑦𐑑𐑕 𐑐𐑮𐑪𐑐𐑼𐑑𐑦𐑟; 𐑛𐑮𐑨𐑜 𐑦𐑑 𐑑 𐑮𐑰𐑻𐑱𐑯𐑡 𐑦𐑑𐑕 𐑐𐑤𐑱𐑕𐑥𐑩𐑯𐑑."
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑕𐑱𐑝 𐑞 𐑥𐑪𐑯𐑦𐑑𐑼 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑜𐑧𐑑 𐑕𐑧𐑖𐑩𐑯 𐑚𐑳𐑕 𐑢𐑲𐑤 𐑩𐑐𐑤𐑲𐑦𐑙 𐑛𐑩𐑕𐑐𐑤𐑱 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑛𐑦𐑑𐑧𐑒𐑑 𐑛𐑦𐑕𐑐𐑤𐑱𐑟"
+
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "𐑞 𐑥𐑪𐑯𐑦𐑑𐑼 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑕𐑱𐑝𐑛"
+
+#~ msgid "This configuration will be used the next time someone logs in."
+#~ msgstr "𐑞𐑦𐑕 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑢𐑦𐑤 𐑚𐑰 𐑿𐑟𐑛 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑑𐑲𐑥 𐑕𐑳𐑥𐑢𐑳𐑯 𐑤𐑪𐑜𐑟 𐑦𐑯."
+
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑕𐑧𐑑 𐑞 𐑛𐑦𐑓𐑷𐑤𐑑 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑓𐑹 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑜𐑧𐑑 𐑕𐑒𐑮𐑰𐑯 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯"
+
+#~ msgid "New shortcut..."
+#~ msgstr "𐑯𐑿 𐑕𐑹𐑑𐑒𐑳𐑑..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 𐑒𐑰"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 𐑥𐑪𐑛𐑦𐑓𐑲𐑼𐑟"
+
+#, fuzzy
+#~ msgid "Accelerator keycode"
+#~ msgstr "𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 keycode"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "𐑞 𐑑𐑲𐑐 𐑝 𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<𐑳𐑯𐑴𐑯 𐑨𐑒𐑖𐑩𐑯>"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "𐑻𐑼 𐑕𐑱𐑝𐑦𐑙 𐑞 𐑯𐑿 𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "𐑞 𐑕𐑹𐑑𐑒𐑳𐑑 \"%s\" 𐑒𐑨𐑯𐑪𐑑 𐑚𐑰 𐑿𐑟𐑛 𐑚𐑦𐑒𐑪𐑟 𐑦𐑑 𐑢𐑦𐑤 𐑚𐑦𐑒𐑳𐑥 𐑦𐑥𐑐𐑪𐑕𐑩𐑚𐑩𐑤 𐑑 𐑑𐑲𐑐 𐑿𐑟𐑦𐑙 𐑞𐑦𐑕 "
+#~ "𐑒𐑰.\n"
+#~ "𐑐𐑤𐑰𐑟 𐑑𐑮𐑲 𐑢𐑦𐑞 𐑩 𐑒𐑰 𐑕𐑳𐑗 𐑨𐑟 𐑒𐑩𐑯𐑑𐑮𐑴𐑤, 𐑷𐑤𐑑 𐑹 𐑖𐑦𐑓𐑑 𐑨𐑑 𐑞 𐑕𐑱𐑥 𐑑𐑲𐑥."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "𐑞 𐑕𐑹𐑑𐑒𐑳𐑑 \"%s\" 𐑦𐑟 𐑷𐑤𐑮𐑧𐑛𐑦 𐑿𐑕𐑑 𐑓𐑹\n"
+#~ "\"%s\""
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "𐑦𐑓 𐑿 𐑮𐑰𐑩𐑕𐑲𐑯 𐑞 𐑕𐑹𐑑𐑒𐑳𐑑 𐑑 \"%s\", 𐑞 \"%s\" 𐑕𐑹𐑑𐑒𐑳𐑑 𐑢𐑦𐑤 𐑚𐑰 𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛."
+
+#~ msgid "_Reassign"
+#~ msgstr "_𐑮𐑰𐑩𐑕𐑲𐑯"
+
+#, fuzzy
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "𐑻𐑼 unsetting 𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 𐑦𐑯 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑛𐑱𐑑𐑩𐑚𐑱𐑕: %s"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "𐑑𐑵 𐑥𐑧𐑯𐑦 𐑒𐑳𐑕𐑑𐑩𐑥 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "𐑩𐑕𐑲𐑯 𐑕𐑹𐑑𐑒𐑳𐑑 𐑒𐑰𐑟 𐑑 𐑒𐑩𐑥𐑭𐑯𐑛𐑟"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "𐑡𐑳𐑕𐑑 𐑩𐑐𐑤𐑲 𐑕𐑧𐑑𐑦𐑙𐑟 𐑯 𐑒𐑢𐑦𐑑 (𐑒𐑩𐑥𐑐𐑨𐑑𐑩𐑚𐑦𐑤𐑩𐑑𐑰 𐑴𐑯𐑤𐑦; 𐑯𐑬 𐑣𐑨𐑯𐑛𐑩𐑤𐑛 𐑚𐑲 𐑛𐑰𐑥𐑩𐑯)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "𐑕𐑑𐑸𐑑 𐑞 𐑐𐑱𐑡 𐑢𐑦𐑞 𐑞 𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒 𐑕𐑧𐑑𐑦𐑙𐑟 𐑖𐑴𐑦𐑙"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "𐑕𐑑𐑸𐑑 𐑞 𐑐𐑱𐑡 𐑢𐑦𐑞 𐑞 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑕𐑧𐑑𐑦𐑙𐑟 𐑖𐑴𐑦𐑙"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- ·𐑜𐑯𐑴𐑥 𐑒𐑰𐑚𐑪𐑮𐑛 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 _𐑑𐑪𐑜𐑩𐑤 𐑒𐑰 𐑦𐑟 𐑐𐑮𐑧𐑕𐑑"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑒𐑰 𐑦𐑟 _𐑮𐑦𐑡𐑧𐑒𐑑𐑧𐑛"
+
+#, fuzzy
+#~ msgid "Flash _window titlebar"
+#~ msgstr "𐑓𐑤𐑨𐑖 _𐑢𐑦𐑯𐑛𐑴 titlebar"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑷𐑛𐑦𐑴 𐑓𐑰𐑛𐑚𐑨𐑒"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "𐑖𐑴 _𐑝𐑦𐑠𐑩𐑢𐑩𐑤 𐑓𐑰𐑛𐑚𐑨𐑒 𐑓𐑹 𐑞 𐑩𐑤𐑻𐑑 𐑕𐑬𐑯𐑛"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤 𐑒𐑘𐑵𐑟 𐑓𐑹 𐑕𐑬𐑯𐑛𐑟"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "_𐑩𐑤𐑬 𐑐𐑴𐑕𐑑𐑐𐑴𐑯𐑦𐑙 𐑝 𐑚𐑮𐑱𐑒𐑕"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "𐑷𐑛𐑦𐑴 _𐑓𐑰𐑛𐑚𐑨𐑒..."
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "𐑗𐑧𐑒 𐑦𐑓 𐑚𐑮𐑱𐑒𐑕 𐑸 𐑩𐑤𐑬𐑛 𐑑 𐑚𐑰 𐑐𐑴𐑕𐑑𐑐𐑴𐑯𐑛"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "𐑛𐑫𐑮𐑱𐑖𐑩𐑯 𐑝 𐑞 𐑚𐑮𐑱𐑒 𐑢𐑧𐑯 𐑑𐑲𐑐𐑦𐑙 𐑦𐑟 𐑛𐑦𐑕𐑩𐑤𐑶𐑛"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "𐑛𐑫𐑮𐑱𐑖𐑩𐑯 𐑝 𐑢𐑻𐑒 𐑚𐑦𐑓𐑹 𐑓𐑹𐑕𐑦𐑙 𐑩 𐑚𐑮𐑱𐑒"
+
+#~ msgid "Fast"
+#~ msgstr "𐑓𐑭𐑕𐑑"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 _𐑥𐑪𐑛𐑩𐑤:"
+
+#~ msgid "Layouts"
+#~ msgstr "𐑤𐑱𐑬𐑑𐑕"
+
+#~ msgid "List of keyboard layouts selected for usage"
+#~ msgstr "𐑤𐑦𐑕𐑑 𐑝 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑𐑕 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑓𐑹 𐑿𐑕𐑦𐑡"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "𐑤𐑪𐑒 𐑕𐑒𐑮𐑰𐑯 𐑭𐑓𐑑𐑼 𐑩 𐑕𐑻𐑑𐑩𐑯 𐑛𐑫𐑮𐑱𐑖𐑩𐑯 𐑑 𐑣𐑧𐑤𐑐 𐑐𐑮𐑦𐑝𐑧𐑯𐑑 𐑮𐑦𐑐𐑧𐑑𐑦𐑑𐑦𐑝 𐑒𐑰𐑚𐑪𐑮𐑛 𐑿𐑟 𐑦𐑯𐑡𐑻𐑰𐑟"
+
+#~ msgid "Move the selected keyboard layout down in the list"
+#~ msgstr "𐑥𐑵𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑛𐑬𐑯 𐑦𐑯 𐑞 𐑤𐑦𐑕𐑑"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "𐑥𐑵𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑳𐑐 𐑦𐑯 𐑞 𐑤𐑦𐑕𐑑"
+
+#~ msgid "New windows u_se active window's layout"
+#~ msgstr "𐑯𐑿 𐑢𐑦𐑯𐑛𐑴𐑟 _𐑿𐑟 𐑨𐑒𐑑𐑦𐑝 𐑢𐑦𐑯𐑛𐑴'𐑟 𐑤𐑱𐑬𐑑"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "𐑐𐑮𐑦𐑯𐑑 𐑩 𐑛𐑲𐑩𐑜𐑮𐑨𐑥 𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "𐑮𐑦𐑥𐑵𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑓𐑮𐑪𐑥 𐑞 𐑤𐑦𐑕𐑑"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "𐑮𐑦𐑐𐑤𐑱𐑕 𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑕𐑧𐑑𐑦𐑙𐑟 𐑢𐑦𐑞 𐑞\n"
+#~ "𐑛𐑦𐑓𐑷𐑤𐑑 𐑕𐑧𐑑𐑦𐑙𐑟"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "𐑮𐑰𐑕𐑧𐑑 𐑑 _𐑛𐑦𐑓𐑷𐑤𐑑𐑕"
+
+#~ msgid "S_peed:"
+#~ msgstr "_𐑕𐑐𐑰𐑛:"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑑 𐑚𐑰 𐑨𐑛𐑩𐑛 𐑑 𐑞 𐑤𐑦𐑕𐑑"
+
+#~ msgid "Slow"
+#~ msgstr "𐑕𐑤𐑴"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "𐑝𐑿 𐑯 𐑧𐑛𐑦𐑑 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑪𐑐𐑖𐑩𐑯𐑟"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_𐑚𐑮𐑱𐑒 𐑦𐑯𐑑𐑼𐑝𐑩𐑤 𐑤𐑨𐑕𐑑𐑕:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "_𐑤𐑪𐑒 𐑕𐑒𐑮𐑰𐑯 𐑑 𐑧𐑯𐑓𐑪𐑮𐑕 𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒"
+
+#, fuzzy
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_𐑴𐑯𐑤𐑦 𐑨𐑒𐑕𐑧𐑐𐑑 𐑤𐑪𐑙 keypresses"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "_𐑐𐑶𐑯𐑑𐑼 𐑒𐑨𐑯 𐑚𐑰 𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑛 𐑿𐑟𐑦𐑙 𐑞 𐑒𐑰𐑐𐑨𐑛"
+
+#~ msgid "_Separate layout for each window"
+#~ msgstr "_𐑕𐑧𐑐𐑼𐑱𐑑 𐑤𐑱𐑬𐑑 𐑓𐑹 𐑰𐑗 𐑢𐑦𐑯𐑛𐑴"
+
+#, fuzzy
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_𐑕𐑦𐑥𐑘𐑩𐑤𐑩𐑑 𐑕𐑲𐑥𐑩𐑤𐑑𐑱𐑯𐑰𐑩𐑕 keypresses"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_𐑑𐑲𐑐 𐑑 𐑑𐑧𐑕𐑑 𐑕𐑧𐑑𐑦𐑙𐑟:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_𐑢𐑻𐑒 𐑦𐑯𐑑𐑼𐑝𐑩𐑤 𐑤𐑨𐑕𐑑𐑕:"
+
+#~ msgid "By _country"
+#~ msgstr "𐑚𐑲 _𐑒𐑳𐑯𐑑𐑮𐑰"
+
+#~ msgid "By _language"
+#~ msgstr "𐑚𐑲 _𐑤𐑨𐑙𐑜𐑢𐑩𐑡"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "𐑗𐑵𐑟 𐑩 𐑤𐑱𐑬𐑑"
+
+#~ msgid "_Country:"
+#~ msgstr "_𐑒𐑳𐑯𐑑𐑮𐑰:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_𐑝𐑧𐑮𐑰𐑩𐑯𐑑𐑕:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "𐑗𐑵𐑟 𐑩 𐑒𐑰𐑚𐑪𐑮𐑛 𐑥𐑪𐑛𐑩𐑤"
+
+#~ msgid "_Models:"
+#~ msgstr "_𐑥𐑪𐑛𐑩𐑤𐑟:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_𐑝𐑧𐑯𐑛𐑻𐑟:"
+
+#~ msgid "Unknown"
+#~ msgstr "𐑳𐑯𐑴𐑯"
+
+#~ msgid "Vendors"
+#~ msgstr "𐑝𐑧𐑯𐑛𐑻𐑟"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑒𐑰𐑚𐑪𐑮𐑛 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "𐑥𐑵𐑝 𐑤𐑧𐑓𐑑"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "𐑥𐑵𐑝 𐑮𐑲𐑑"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "𐑥𐑵𐑝 𐑳𐑐"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "𐑥𐑵𐑝 𐑛𐑬𐑯"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑯𐑱𐑥 𐑝 𐑞 𐑐𐑱𐑡 𐑑 𐑖𐑴 (general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- ·𐑜𐑯𐑴𐑥 𐑥𐑬𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "𐑗𐑵𐑟 𐑑𐑲𐑐 𐑝 𐑒𐑤𐑦𐑒 _𐑚𐑧𐑓𐑹𐑣𐑨𐑯𐑛"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "𐑗𐑵𐑟 𐑑𐑲𐑐 𐑝 𐑒𐑤𐑦𐑒 𐑢𐑦𐑞 _𐑥𐑬𐑕 𐑡𐑧𐑕𐑗𐑻𐑟"
+
+#~ msgid "D_rag click:"
+#~ msgstr "_𐑛𐑮𐑨𐑜 𐑒𐑤𐑦𐑒:"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "𐑛𐑮𐑨𐑜 𐑯 𐑛𐑮𐑪𐑐"
+
+#, fuzzy
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 _𐑥𐑬𐑕 𐑒𐑤𐑦𐑒𐑕 𐑢𐑦𐑞 touchpad"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "𐑥𐑬𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "Pointer Speed"
+#~ msgstr "𐑐𐑶𐑯𐑑𐑼 𐑕𐑐𐑰𐑛"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "_𐑖𐑴 𐑐𐑩𐑟𐑦𐑖𐑩𐑯 𐑝 𐑐𐑶𐑯𐑑𐑼 𐑢𐑧𐑯 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤 𐑒𐑰 𐑦𐑟 𐑐𐑮𐑧𐑕𐑑"
+
+#~ msgid "Show click type _window"
+#~ msgstr "𐑖𐑴 𐑒𐑤𐑦𐑒 𐑑𐑲𐑐 _𐑢𐑦𐑯𐑛𐑴"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "_𐑔𐑮𐑧𐑖𐑴𐑤𐑛:"
+
+#~ msgid ""
+#~ "To test your double-click settings, try to double-click on the light bulb."
+#~ msgstr "𐑑 𐑑𐑧𐑕𐑑 𐑿𐑼 𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑕𐑧𐑑𐑦𐑙𐑟, 𐑑𐑮𐑲 𐑑 𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑪𐑯 𐑞 𐑤𐑲𐑑 𐑚𐑳𐑤𐑚."
+
+#~ msgid "Two-_finger scrolling"
+#~ msgstr "𐑑𐑵-_𐑓𐑦𐑙𐑜𐑼 𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr "𐑿 𐑒𐑨𐑯 𐑷𐑤𐑕𐑴 𐑿𐑟 𐑞 𐑛𐑢𐑧𐑤 𐑒𐑤𐑦𐑒 𐑐𐑨𐑯𐑩𐑤 𐑨𐑐𐑤𐑩𐑑 𐑑 𐑗𐑵𐑟 𐑞 𐑒𐑤𐑦𐑒 𐑑𐑲𐑐."
+
+#~ msgid "_Edge scrolling"
+#~ msgstr "_𐑧𐑡 𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_𐑤𐑧𐑓𐑑-𐑣𐑨𐑯𐑛𐑧𐑛"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_𐑮𐑲𐑑-𐑣𐑨𐑯𐑛𐑧𐑛"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_𐑕𐑧𐑯𐑕𐑦𐑑𐑦𐑝𐑦𐑑𐑦:"
+
+#~ msgid "_Single click:"
+#~ msgstr "_𐑕𐑦𐑙𐑜𐑩𐑤 𐑒𐑤𐑦𐑒:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑥𐑬𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "Location already exists"
+#~ msgstr "𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>_𐑛𐑲𐑮𐑧𐑒𐑑 ·𐑦𐑯𐑑𐑼𐑯𐑧𐑑 𐑒𐑩𐑯𐑧𐑒𐑖𐑩𐑯</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>_𐑷𐑑𐑴𐑥𐑨𐑑𐑦𐑒 𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_𐑥𐑨𐑯𐑘𐑫𐑩𐑤 𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯</b>"
+
+#~ msgid "C_reate"
+#~ msgstr "_𐑒𐑮𐑦𐑱𐑑"
+
+#~ msgid "Create New Location"
+#~ msgstr "𐑒𐑮𐑦𐑱𐑑 𐑯𐑿 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP 𐑐𐑮𐑪𐑒𐑕𐑦 𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "𐑦𐑜𐑯𐑹 𐑣𐑴𐑕𐑑 𐑤𐑦𐑕𐑑"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "Port:"
+#~ msgstr "𐑐𐑹𐑑:"
+
+#~ msgid "The location already exists."
+#~ msgstr "𐑞 𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕."
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_𐑕𐑦𐑒𐑘𐑫𐑼 HTTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "𐑒𐑨𐑯𐑪𐑑 𐑕𐑑𐑸𐑑 𐑞 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯 𐑓𐑹 𐑿𐑼 𐑢𐑦𐑯𐑛𐑴 𐑥𐑨𐑯𐑩𐑡𐑼"
+
+#~ msgid "_Alt"
+#~ msgstr "_𐑷𐑤𐑑"
+
+#~ msgid "H_yper"
+#~ msgstr "𐑣_𐑲𐑐𐑼"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "𐑕_𐑵𐑐𐑼 (𐑹 \"·𐑢𐑦𐑯𐑛𐑴𐑟 𐑤𐑴𐑜𐑴\")"
+
+#~ msgid "_Meta"
+#~ msgstr "_𐑥𐑧𐑑𐑩"
+
+#~ msgid "Movement Key"
+#~ msgstr "𐑥𐑵𐑝𐑥𐑩𐑯𐑑 𐑒𐑰"
+
+#, fuzzy
+#~ msgid "Titlebar Action"
+#~ msgstr "Titlebar 𐑨𐑒𐑖𐑩𐑯"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "𐑑 𐑥𐑵𐑝 𐑩 𐑢𐑦𐑯𐑛𐑴, 𐑐𐑮𐑧𐑕-𐑯-𐑣𐑴𐑤𐑛 𐑞𐑦𐑕 𐑒𐑰 𐑞𐑧𐑯 𐑜𐑮𐑨𐑚 𐑞 𐑢𐑦𐑯𐑛𐑴:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "𐑢𐑦𐑯𐑛𐑴 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#~ msgid "Window Selection"
+#~ msgstr "𐑢𐑦𐑯𐑛𐑴 𐑕𐑦𐑤𐑧𐑒𐑖𐑩𐑯"
+
+#, fuzzy
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 titlebar 𐑑 𐑐𐑼𐑓𐑹𐑥 𐑞𐑦𐑕 𐑨𐑒𐑖𐑩𐑯:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_𐑦𐑯𐑑𐑼𐑝𐑩𐑤 𐑚𐑦𐑓𐑹 𐑮𐑱𐑟𐑦𐑙:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_𐑮𐑱𐑟 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑢𐑦𐑯𐑛𐑴𐑟 𐑭𐑓𐑑𐑼 𐑩𐑯 𐑦𐑯𐑑𐑼𐑝𐑩𐑤"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑 𐑢𐑦𐑯𐑛𐑴𐑟 𐑢𐑧𐑯 𐑞 𐑥𐑬𐑕 𐑥𐑵𐑝𐑟 𐑴𐑝𐑼 𐑞𐑧𐑥"
+
+#~ msgid "Set your window properties"
+#~ msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑢𐑦𐑯𐑛𐑴 𐑐𐑮𐑪𐑐𐑼𐑑𐑦𐑟"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "𐑢𐑦𐑯𐑛𐑴 𐑥𐑨𐑯𐑩𐑡𐑼 \"%s\" 𐑣𐑨𐑟 𐑯𐑪𐑑 𐑮𐑧𐑡𐑦𐑕𐑑𐑼𐑛 𐑩 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑑𐑵𐑤\n"
+
+#~ msgid "Maximize"
+#~ msgstr "𐑥𐑨𐑒𐑕𐑩𐑥𐑲𐑟"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "𐑥𐑨𐑒𐑕𐑩𐑥𐑲𐑟 𐑝𐑻𐑑𐑦𐑒𐑩𐑤𐑦"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "𐑥𐑨𐑒𐑕𐑩𐑥𐑲𐑟 𐑣𐑪𐑮𐑦𐑟𐑪𐑯𐑑𐑩𐑤𐑦"
+
+#~ msgid "Minimize"
+#~ msgstr "𐑥𐑦𐑯𐑩𐑥𐑲𐑟"
+
+#~ msgid "Roll up"
+#~ msgstr "𐑮𐑴𐑤 𐑳𐑐"
+
+#, c-format
+#~ msgid "key not found [%s]\n"
+#~ msgstr "𐑒𐑰 𐑯𐑪𐑑 𐑓𐑬𐑯𐑛 [%s]\n"
+
+#, fuzzy
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "𐑣𐑲𐑛 𐑪𐑯 𐑕𐑑𐑸𐑑 (𐑿𐑕𐑓𐑩𐑤 𐑑 preload 𐑞 𐑖𐑧𐑤)"
+
+#~ msgid "Groups"
+#~ msgstr "𐑜𐑮𐑵𐑐𐑕"
+
+#~ msgid "Control Center"
+#~ msgstr "𐑒𐑩𐑯𐑑𐑮𐑴𐑤 𐑕𐑧𐑯𐑑𐑼"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "𐑒𐑤𐑴𐑟 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤-𐑕𐑧𐑯𐑑𐑼 𐑢𐑧𐑯 𐑩 𐑑𐑭𐑕𐑒 𐑦𐑟 𐑨𐑒𐑑𐑦𐑝𐑱𐑑𐑩𐑛"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑨𐑛 𐑹 𐑮𐑦𐑥𐑵𐑝 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑣𐑧𐑤𐑐 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑕𐑑𐑸𐑑 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
+
+#, fuzzy
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑳𐑐𐑜𐑮𐑱𐑛 𐑹 uninstall 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩 𐑣𐑧𐑤𐑐 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩 𐑕𐑑𐑸𐑑 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩𐑯 𐑨𐑛 𐑹 𐑮𐑦𐑥𐑵𐑝 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
+
+#, fuzzy
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩𐑯 𐑳𐑐𐑜𐑮𐑱𐑛 𐑹 uninstall 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "𐑑𐑭𐑕𐑒 𐑯𐑱𐑥𐑟 𐑯 𐑩𐑕𐑴𐑖𐑦𐑱𐑑𐑩𐑛 .desktop 𐑓𐑲𐑤𐑟"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "𐑞 𐑑𐑭𐑕𐑒 𐑯𐑱𐑥 𐑑 𐑚𐑰 𐑛𐑩𐑕𐑐𐑤𐑱𐑛 𐑦𐑯 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤-𐑕𐑧𐑯𐑑𐑼 𐑓𐑪𐑤𐑴𐑛 𐑚𐑲 𐑩 \";\" 𐑕𐑧𐑐𐑼𐑱𐑑𐑼 𐑞𐑧𐑯 𐑞 "
+#~ "𐑓𐑲𐑤𐑯𐑱𐑥 𐑝 𐑩𐑯 𐑩𐑕𐑴𐑖𐑦𐑱𐑑𐑩𐑛 .𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑓𐑲𐑤 𐑑 𐑤𐑷𐑯𐑗 𐑓𐑹 𐑞𐑨𐑑 𐑑𐑭𐑕𐑒."
+
+#, fuzzy
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[𐑗𐑱𐑯𐑡 𐑔𐑰𐑥;gtk-𐑔𐑰𐑥-selector.𐑛𐑧𐑕𐑒𐑑𐑪𐑐,𐑕𐑧𐑑 𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟;𐑛𐑦𐑓𐑷𐑤𐑑-"
+#~ "𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟.𐑛𐑧𐑕𐑒𐑑𐑪𐑐,𐑨𐑛 𐑐𐑮𐑦𐑯𐑑𐑼;·𐑯𐑴𐑥-𐑒𐑳𐑐𐑕-𐑥𐑨𐑯𐑩𐑡𐑼.𐑛𐑧𐑕𐑒𐑑𐑪𐑐]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr "𐑦𐑓 𐑑𐑮𐑵, 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤-𐑕𐑧𐑯𐑑𐑼 𐑢𐑦𐑤 𐑒𐑤𐑴𐑕 𐑢𐑧𐑯 𐑩 \"𐑒𐑪𐑥𐑩𐑯 𐑑𐑭𐑕𐑒\" 𐑦𐑟 𐑨𐑒𐑑𐑦𐑝𐑱𐑑𐑩𐑛."
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "𐑞 ·𐑜𐑯𐑴𐑥 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑑𐑵𐑤"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_𐑐𐑴𐑕𐑑𐑐𐑴𐑯 𐑚𐑮𐑱𐑒"
+
+#~ msgid "Take a break!"
+#~ msgstr "𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒!"
+
+#~ msgid "_Take a Break"
+#~ msgstr "_𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒"
+
+#, fuzzy
+#~ msgid "Take a break now (next in %dm)"
+#~ msgstr "𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒 𐑯𐑬 (𐑯𐑧𐑒𐑕𐑑 𐑦𐑯 %dm)"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d 𐑥𐑦𐑯𐑩𐑑 𐑳𐑯𐑑𐑦𐑤 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑚𐑮𐑱𐑒"
+#~ msgstr[1] "%d 𐑥𐑦𐑯𐑩𐑑𐑕 𐑳𐑯𐑑𐑦𐑤 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑚𐑮𐑱𐑒"
+
+#, c-format
+#~ msgid "Take a break now (next in less than one minute)"
+#~ msgstr "𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒 𐑯𐑬 (𐑯𐑧𐑒𐑕𐑑 𐑦𐑯 𐑤𐑧𐑕 𐑞𐑨𐑯 𐑢𐑳𐑯 𐑥𐑦𐑯𐑩𐑑)"
+
+#, c-format
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "𐑤𐑧𐑕 𐑞𐑨𐑯 𐑢𐑳𐑯 𐑥𐑦𐑯𐑩𐑑 𐑳𐑯𐑑𐑦𐑤 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑚𐑮𐑱𐑒"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑚𐑮𐑦𐑙 𐑳𐑐 𐑞 𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒 𐑐𐑮𐑪𐑐𐑼𐑑𐑦𐑟 𐑛𐑲𐑩𐑤𐑪𐑜 𐑢𐑦𐑞 𐑞 𐑓𐑪𐑤𐑴𐑦𐑙 𐑻𐑼: %s"
+
+#, fuzzy
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "𐑮𐑦𐑑𐑩𐑯 𐑚𐑲 ·𐑮𐑦𐑗𐑼𐑛 𐑣𐑩𐑤𐑑 <·𐑮𐑦𐑗𐑼𐑛@imendio.𐑒𐑪𐑥>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "𐑲 𐑒𐑨𐑯𐑛𐑰 𐑨𐑛𐑩𐑛 𐑚𐑲 ·𐑨𐑯𐑛𐑻𐑟 ·𐑒𐑭𐑮𐑤𐑕𐑩𐑯"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "𐑩 𐑒𐑩𐑥𐑐𐑿𐑑𐑼 𐑚𐑮𐑱𐑒 𐑮𐑦𐑥𐑲𐑯𐑛𐑼."
+
+#~ msgid "translator-credits"
+#~ msgstr "·𐑑𐑪𐑥𐑩𐑕 ·𐑔𐑻𐑥𐑩𐑯"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑛𐑰𐑚𐑳𐑜𐑦𐑙 𐑒𐑴𐑛"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "𐑛𐑴𐑯𐑑 𐑗𐑧𐑒 𐑢𐑧𐑞𐑼 𐑞 𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩 𐑧𐑒𐑟𐑦𐑕𐑑𐑕"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "𐑞 𐑑𐑲𐑐𐑦𐑙 𐑥𐑪𐑯𐑦𐑑𐑼 𐑿𐑟𐑩𐑟 𐑞 𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩 𐑑 𐑛𐑦𐑕𐑐𐑤𐑱 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯. 𐑿 𐑛𐑴𐑯𐑑 𐑕𐑰𐑥 𐑑 "
+#~ "𐑣𐑨𐑝 𐑩 𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩 𐑪𐑯 𐑿𐑼 𐑐𐑨𐑯𐑩𐑤. 𐑿 𐑒𐑨𐑯 𐑨𐑛 𐑦𐑑 𐑚𐑲 𐑮𐑲𐑑-𐑒𐑤𐑦𐑒𐑦𐑙 𐑪𐑯 𐑿𐑼 𐑐𐑨𐑯𐑩𐑤 "
+#~ "𐑯 𐑗𐑵𐑟𐑦𐑙 '𐑨𐑛 𐑑 𐑐𐑨𐑯𐑩𐑤', 𐑕𐑩𐑤𐑧𐑒𐑑𐑦𐑙 '𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩' 𐑯 𐑒𐑤𐑦𐑒𐑦𐑙 '𐑨𐑛'."
+
+#, fuzzy
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 OpenType 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+
+#, fuzzy
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 PCF 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+
+#, fuzzy
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 TrueType 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+
+#, fuzzy
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 Type1 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+
+#, fuzzy
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 OpenType 𐑓𐑪𐑯𐑑𐑕."
+
+#, fuzzy
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 PCF 𐑓𐑪𐑯𐑑𐑕."
+
+#, fuzzy
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 TrueType 𐑓𐑪𐑯𐑑𐑕."
+
+#, fuzzy
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 Type1 𐑓𐑪𐑯𐑑𐑕."
+
+#, fuzzy
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 OpenType 𐑓𐑪𐑯𐑑𐑕"
+
+#, fuzzy
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 PCF 𐑓𐑪𐑯𐑑𐑕"
+
+#, fuzzy
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 TrueType 𐑓𐑪𐑯𐑑𐑕"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 Type1 𐑓𐑪𐑯𐑑𐑕"
+
+#, fuzzy
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 OpenType 𐑓𐑪𐑯𐑑𐑕"
+
+#, fuzzy
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 PCF 𐑓𐑪𐑯𐑑𐑕"
+
+#, fuzzy
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 TrueType 𐑓𐑪𐑯𐑑𐑕"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 Type1 𐑓𐑪𐑯𐑑𐑕"
+
+#~ msgid "Size:"
+#~ msgstr "𐑕𐑲𐑟:"
+
+#~ msgid "Copyright:"
+#~ msgstr "𐑒𐑪𐑐𐑦𐑮𐑲𐑑:"
+
+#~ msgid "Description:"
+#~ msgstr "𐑛𐑦𐑕𐑒𐑮𐑦𐑐𐑖𐑩𐑯:"
+
+#, fuzzy
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "𐑿𐑕𐑦𐑡: %s fontfile\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "_𐑦𐑯𐑕𐑑𐑷𐑤 𐑓𐑪𐑯𐑑"
+
+#~ msgid "Font Viewer"
+#~ msgstr "𐑓𐑪𐑯𐑑 𐑝𐑿𐑼"
+
+#, fuzzy
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "𐑑𐑧𐑒𐑕𐑑 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 (𐑛𐑦𐑓𐑷𐑤𐑑: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "𐑑𐑧𐑒𐑕𐑑"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "𐑓𐑪𐑯𐑑 𐑕𐑲𐑟 (𐑛𐑦𐑓𐑷𐑤𐑑: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "𐑕𐑲𐑟"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "𐑓𐑪𐑯𐑑-𐑓𐑲𐑤 𐑬𐑑𐑐𐑫𐑑-𐑓𐑲𐑤"
+
+#, c-format
+#~ msgid "Error parsing arguments: %s\n"
+#~ msgstr "𐑻𐑼 𐑐𐑸𐑕𐑦𐑙 𐑸𐑜𐑿𐑥𐑩𐑯𐑑𐑕: %s\n"
+
+#, c-format
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "𐑿𐑼 𐑓𐑦𐑤𐑑𐑼 \"%s\" 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑥𐑨𐑗 𐑧𐑯𐑦 𐑲𐑑𐑩𐑥𐑟."
+
+#~ msgid "Upgrade"
+#~ msgstr "𐑳𐑐𐑜𐑮𐑱𐑛"
+
+#, fuzzy
+#~ msgid "Uninstall"
+#~ msgstr "Uninstall"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "𐑨𐑛 𐑑 𐑓𐑱𐑝𐑼𐑦𐑑𐑕"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "𐑮𐑦𐑥𐑵𐑝 𐑓𐑮𐑪𐑥 𐑕𐑑𐑸𐑑𐑳𐑐 𐑐𐑮𐑴𐑜𐑮𐑨𐑥𐑟"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "𐑨𐑛 𐑑 𐑕𐑑𐑸𐑑𐑳𐑐 𐑐𐑮𐑴𐑜𐑮𐑨𐑥𐑟"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "𐑯𐑿 𐑕𐑐𐑮𐑧𐑛𐑖𐑰𐑑"
+
+#~ msgid "New Document"
+#~ msgstr "𐑯𐑿 𐑛𐑪𐑒𐑿𐑥𐑩𐑯𐑑"
+
+#~ msgid "Documents"
+#~ msgstr "𐑛𐑪𐑒𐑿𐑥𐑩𐑯𐑑𐑕"
+
+#~ msgid "Send To..."
+#~ msgstr "𐑕𐑧𐑯𐑛 𐑑..."
+
+#~ msgid "Delete"
+#~ msgstr "𐑛𐑦𐑤𐑰𐑑"
+
+#, c-format
+#~ msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgstr "𐑸 𐑿 𐑖𐑫𐑼 𐑿 𐑢𐑪𐑯𐑑 𐑑 𐑐𐑻𐑥𐑩𐑯𐑩𐑯𐑑𐑤𐑦 𐑛𐑦𐑤𐑰𐑑 \"%s\"?"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "𐑦𐑓 𐑿 𐑛𐑦𐑤𐑰𐑑 𐑩𐑯 𐑲𐑑𐑩𐑥, 𐑦𐑑 𐑦𐑟 𐑐𐑻𐑥𐑩𐑯𐑩𐑯𐑑𐑤𐑦 𐑤𐑪𐑕𐑑."
+
+#, c-format
+#~ msgid "Open with \"%s\""
+#~ msgstr "𐑴𐑐𐑩𐑯 𐑢𐑦𐑞 \"%s\""
+
+#~ msgid "Open in File Manager"
+#~ msgstr "𐑴𐑐𐑩𐑯 𐑦𐑯 𐑓𐑲𐑤 𐑥𐑨𐑯𐑩𐑡𐑼"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "𐑑𐑫𐑛𐑱 %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "𐑘𐑧𐑕𐑑𐑼𐑛𐑱 %l:%M %p"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%b %d %l:%M %p"
+
+#~ msgid "%b %d %Y"
+#~ msgstr "%b %d %Y"
+
+#~ msgid "Find Now"
+#~ msgstr "𐑓𐑲𐑯𐑛 𐑯𐑬"
+
+#, c-format
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>𐑴𐑐𐑩𐑯 %s</b>"
+
+#, c-format
+#~ msgid "Remove from System Items"
+#~ msgstr "𐑮𐑦𐑥𐑵𐑝 𐑓𐑮𐑪𐑥 𐑕𐑦𐑕𐑑𐑩𐑥 𐑲𐑑𐑩𐑥𐑟"

--- a/po/en@shaw.po~
+++ b/po/en@shaw.po~
@@ -1,0 +1,3797 @@
+# Shavian translation for gnome-control-center.
+# Copyright (C) 2009 The Gnome Foundation.
+# Thomas Thurman <tthurman@gnome.org>, 2009.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&component=general\n"
+"POT-Creation-Date: 2010-05-12 22:49+0000\n"
+"PO-Revision-Date: 2010-05-18 10:04 -0400\n"
+"Last-Translator: Thomas Thurman <tthurman@gnome.org>\n"
+"Language-Team: Shavian <ubuntu-l10n-en-shaw@launchpad.net>\n"
+"Language: en@shaw\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n!=1;\n"
+
+#: ../gnome-control-center.schemas.in.h:1
+msgid "Current network location"
+msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 𐑯𐑧𐑑𐑢𐑻𐑒 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
+
+#: ../gnome-control-center.schemas.in.h:2
+msgid "More backgrounds URL"
+msgstr "𐑥𐑹 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛𐑟 URL"
+
+#: ../gnome-control-center.schemas.in.h:3
+msgid "More themes URL"
+msgstr "𐑥𐑹 𐑔𐑰𐑥𐑟 URL"
+
+#: ../gnome-control-center.schemas.in.h:4
+msgid ""
+"Set this to your current location name. This is used to determine the "
+"appropriate network proxy configuration."
+msgstr ""
+"𐑕𐑧𐑑 𐑞𐑦𐑕 𐑑 𐑿𐑼 𐑒𐑳𐑮𐑩𐑯𐑑 𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑯𐑱𐑥. 𐑞𐑦𐑕 𐑦𐑟 𐑿𐑟𐑛 𐑑 𐑛𐑦𐑑𐑻𐑥𐑦𐑯 𐑞 𐑩𐑐𐑮𐑴𐑐𐑮𐑦𐑩𐑑 𐑯𐑧𐑑𐑢𐑻𐑒 "
+"𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯."
+
+#: ../gnome-control-center.schemas.in.h:5
+msgid ""
+"URL for where to get more desktop backgrounds. If set to an empty string the "
+"link will not appear."
+msgstr ""
+"URL 𐑓𐑹 𐑢𐑺 𐑑 𐑜𐑧𐑑 𐑥𐑹 𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛𐑟. 𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑩𐑯 𐑧𐑥𐑐𐑑𐑦 𐑕𐑑𐑮𐑦𐑙 𐑞 𐑤𐑦𐑙𐑒 𐑢𐑦𐑤 𐑯𐑪𐑑 "
+"𐑩𐑐𐑽."
+
+#: ../gnome-control-center.schemas.in.h:6
+msgid ""
+"URL for where to get more desktop themes. If set to an empty string the link "
+"will not appear."
+msgstr ""
+"URL 𐑓𐑹 𐑢𐑺 𐑑 𐑜𐑧𐑑 𐑥𐑹 𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑔𐑰𐑥𐑟. 𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑩𐑯 𐑧𐑥𐑐𐑑𐑦 𐑕𐑑𐑮𐑦𐑙 𐑞 𐑤𐑦𐑙𐑒 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑩𐑐𐑽."
+
+#: ../capplets/about-me/eel-alert-dialog.c:110
+msgid "Image/label border"
+msgstr "𐑦𐑥𐑦𐑡/𐑤𐑱𐑚𐑩𐑤 𐑚𐑹𐑛𐑼"
+
+#: ../capplets/about-me/eel-alert-dialog.c:111
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "𐑢𐑦𐑛𐑔 𐑝 𐑚𐑹𐑛𐑼 𐑼𐑬𐑯𐑛 𐑞 𐑤𐑱𐑚𐑩𐑤 𐑯 𐑦𐑥𐑦𐑡 𐑦𐑯 𐑞 𐑩𐑤𐑻𐑑 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#: ../capplets/about-me/eel-alert-dialog.c:120
+msgid "Alert Type"
+msgstr "𐑩𐑤𐑻𐑑 𐑑𐑲𐑐"
+
+#: ../capplets/about-me/eel-alert-dialog.c:121
+msgid "The type of alert"
+msgstr "𐑞 𐑑𐑲𐑐 𐑝 𐑩𐑤𐑻𐑑"
+
+#: ../capplets/about-me/eel-alert-dialog.c:129
+msgid "Alert Buttons"
+msgstr "𐑩𐑤𐑻𐑑 𐑚𐑳𐑑𐑩𐑯𐑟"
+
+#: ../capplets/about-me/eel-alert-dialog.c:130
+msgid "The buttons shown in the alert dialog"
+msgstr "𐑞 𐑚𐑳𐑑𐑩𐑯𐑟 𐑖𐑴𐑯 𐑦𐑯 𐑞 𐑩𐑤𐑻𐑑 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#: ../capplets/about-me/eel-alert-dialog.c:194
+msgid "Show more _details"
+msgstr "𐑖𐑴 𐑥𐑹 _𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Place your left thumb on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Swipe your left thumb on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Place your left index finger on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Swipe your left index finger on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Place your left middle finger on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Swipe your left middle finger on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Place your left ring finger on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Swipe your left ring finger on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Place your left little finger on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Swipe your left little finger on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑤𐑧𐑓𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Place your right thumb on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Swipe your right thumb on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑔𐑳𐑥 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Place your right index finger on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Swipe your right index finger on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Place your right middle finger on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Swipe your right middle finger on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Place your right ring finger on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Swipe your right ring finger on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Place your right little finger on %s"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑮𐑲𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Swipe your right little finger on %s"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑮𐑲𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 %s"
+
+#: ../capplets/about-me/fingerprint-strings.h:72
+#: ../capplets/about-me/fingerprint-strings.h:98
+msgid "Place your finger on the reader again"
+msgstr "𐑐𐑤𐑱𐑕 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 𐑞 𐑮𐑰𐑛𐑼 𐑩𐑜𐑱𐑯"
+
+#: ../capplets/about-me/fingerprint-strings.h:74
+#: ../capplets/about-me/fingerprint-strings.h:100
+msgid "Swipe your finger again"
+msgstr "𐑕𐑢𐑲𐑐 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑩𐑜𐑱𐑯"
+
+#: ../capplets/about-me/fingerprint-strings.h:77
+#: ../capplets/about-me/fingerprint-strings.h:103
+msgid "Swipe was too short, try again"
+msgstr "𐑕𐑢𐑲𐑐 𐑢𐑪𐑟 𐑑𐑵 𐑖𐑹𐑑, 𐑑𐑮𐑲 𐑩𐑜𐑱𐑯"
+
+#: ../capplets/about-me/fingerprint-strings.h:79
+#: ../capplets/about-me/fingerprint-strings.h:105
+msgid "Your finger was not centered, try swiping your finger again"
+msgstr "𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑢𐑪𐑟 𐑯𐑪𐑑 𐑕𐑧𐑯𐑑𐑼𐑛, 𐑑𐑮𐑲 𐑕𐑢𐑲𐑐𐑦𐑙 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑩𐑜𐑱𐑯"
+
+#: ../capplets/about-me/fingerprint-strings.h:81
+#: ../capplets/about-me/fingerprint-strings.h:107
+msgid "Remove your finger, and try swiping your finger again"
+msgstr "𐑮𐑦𐑥𐑵𐑝 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼, 𐑯 𐑑𐑮𐑲 𐑕𐑢𐑲𐑐𐑦𐑙 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼 𐑩𐑜𐑱𐑯"
+
+#: ../capplets/about-me/gnome-about-me.c:716
+msgid "Select Image"
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑦𐑥𐑦𐑡"
+
+#: ../capplets/about-me/gnome-about-me.c:718
+msgid "No Image"
+msgstr "𐑯𐑴 𐑦𐑥𐑦𐑡"
+
+#: ../capplets/about-me/gnome-about-me.c:746
+#: ../capplets/appearance/appearance-desktop.c:658
+msgid "Images"
+msgstr "𐑦𐑥𐑦𐑡𐑩𐑟"
+
+#: ../capplets/about-me/gnome-about-me.c:750
+#: ../capplets/appearance/theme-installer.c:766
+msgid "All Files"
+msgstr "𐑷𐑤 𐑓𐑲𐑤𐑟"
+
+#: ../capplets/about-me/gnome-about-me.c:890
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"𐑞𐑺 𐑢𐑪𐑟 𐑩𐑯 𐑻𐑼 𐑢𐑲𐑤 𐑑𐑮𐑲𐑦𐑙 𐑑 𐑜𐑧𐑑 𐑞 𐑩𐑛𐑮𐑧𐑕𐑚𐑫𐑒 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯\n"
+"·𐑧𐑝𐑩𐑤𐑵𐑖𐑩𐑯 𐑛𐑱𐑑𐑩 𐑕𐑻𐑝𐑼 𐑒𐑭𐑯𐑑 𐑣𐑨𐑯𐑛𐑩𐑤 𐑞 𐑐𐑮𐑴𐑑𐑩𐑒𐑪𐑤"
+
+#: ../capplets/about-me/gnome-about-me.c:911
+msgid "Unable to open address book"
+msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑴𐑐𐑩𐑯 𐑩𐑛𐑮𐑧𐑕 𐑚𐑫𐑒"
+
+#: ../capplets/about-me/gnome-about-me.c:934
+#, c-format
+msgid "About %s"
+msgstr "𐑩𐑚𐑬𐑑 %s"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:1
+#, fuzzy
+msgid "A_IM/iChat:"
+msgstr "_𐑱𐑥/iChat:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:2
+msgid "A_ddress:"
+msgstr "_𐑩𐑛𐑮𐑧𐑕:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:3
+msgid "A_ssistant:"
+msgstr "_𐑩𐑕𐑦𐑕𐑑𐑩𐑯𐑑:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:4
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+msgid "About Me"
+msgstr "𐑩𐑚𐑬𐑑 𐑥𐑰"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:5
+msgid "Address"
+msgstr "𐑩𐑛𐑮𐑧𐑕"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:6
+msgid "C_ity:"
+msgstr "_𐑕𐑦𐑑𐑦:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:7
+msgid "C_ompany:"
+msgstr "_𐑒𐑳𐑥𐑐𐑩𐑯𐑦:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:8
+msgid "Cale_ndar:"
+msgstr "_𐑒𐑨𐑤𐑩𐑯𐑛𐑼:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:9
+msgid "Change Passwo_rd..."
+msgstr "𐑗𐑱𐑯𐑡 _𐑐𐑭𐑕𐑢𐑼𐑛..."
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:10
+msgid "Ci_ty:"
+msgstr "_𐑕𐑦𐑑𐑦:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:11
+msgid "Co_untry:"
+msgstr "_𐑒𐑳𐑯𐑑𐑮𐑰:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:12
+msgid "Contact"
+msgstr "𐑒𐑪𐑯𐑑𐑨𐑒𐑑"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:13
+msgid "Cou_ntry:"
+msgstr "_𐑒𐑳𐑯𐑑𐑮𐑰:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:14
+msgid "Disable _Fingerprint Login..."
+msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤 _𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯..."
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:15
+msgid "Email"
+msgstr "𐑰𐑥𐑱𐑤"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:16
+msgid "Enable _Fingerprint Login..."
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 _𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯..."
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:17
+msgid "Full Name"
+msgstr "𐑓𐑫𐑤 𐑯𐑱𐑥"
+
+#. Home vs Work (phone)
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:19
+msgid "Hom_e:"
+msgstr "Hom_e:"
+
+#. Home vs Work (address)
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:21
+#: ../libslab/bookmark-agent.c:1135
+msgid "Home"
+msgstr "𐑣𐑴𐑥"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:22
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:23
+msgid "Instant Messaging"
+msgstr "𐑦𐑯𐑕𐑑𐑩𐑯𐑑 𐑥𐑧𐑕𐑦𐑡𐑦𐑙"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:24
+msgid "Job"
+msgstr "𐑡𐑪𐑚"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:25
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:26
+msgid "P.O. _box:"
+msgstr "P.O. _𐑚𐑪𐑒𐑕:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:27
+msgid "P._O. box:"
+msgstr "P._O. 𐑚𐑪𐑒𐑕:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:28
+msgid "Personal Info"
+msgstr "𐑐𐑻𐑕𐑩𐑯𐑩𐑤 𐑦𐑯𐑓𐑴"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:29
+msgid "Select your photo"
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑿𐑼 𐑓𐑴𐑑𐑴"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:30
+msgid "State/Pro_vince:"
+msgstr "𐑕𐑑𐑱𐑑/_𐑐𐑮𐑪𐑝𐑦𐑯𐑕:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:31
+msgid "Telephone"
+msgstr "𐑑𐑧𐑤𐑩𐑓𐑴𐑯"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:32
+msgid "User name:"
+msgstr "𐑿𐑟𐑼 𐑯𐑱𐑥:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:33
+msgid "Web"
+msgstr "𐑢𐑧𐑚"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:34
+msgid "Web _log:"
+msgstr "𐑢𐑧𐑚 _𐑤𐑪𐑜:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:35
+msgid "Wor_k:"
+msgstr "_𐑢𐑻𐑒:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:36
+msgid "Work"
+msgstr "𐑢𐑻𐑒"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:37
+msgid "Work _fax:"
+msgstr "𐑢𐑻𐑒 _𐑓𐑨𐑒𐑕:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:38
+msgid "ZIP/_Postal code:"
+msgstr "𐑟𐑦𐑐/_𐑐𐑴𐑕𐑑𐑩𐑤 𐑒𐑴𐑛:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:39
+msgid "_Address:"
+msgstr "_𐑩𐑛𐑮𐑧𐑕:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:40
+msgid "_Department:"
+msgstr "_𐑛𐑦𐑐𐑸𐑑𐑥𐑩𐑯𐑑:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:41
+#, fuzzy
+msgid "_GroupWise:"
+msgstr "_GroupWise:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:42
+msgid "_Home page:"
+msgstr "_𐑣𐑴𐑥 𐑐𐑱𐑡:"
+
+#. Home vs Work (email)
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:44
+msgid "_Home:"
+msgstr "_𐑣𐑴𐑥:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:45
+msgid "_Manager:"
+msgstr "_𐑥𐑨𐑯𐑩𐑡𐑼:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:46
+msgid "_Mobile:"
+msgstr "_𐑥𐑴𐑚𐑲𐑤:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:47
+msgid "_Profession:"
+msgstr "_𐑐𐑮𐑩𐑓𐑧𐑖𐑩𐑯:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:48
+msgid "_State/Province:"
+msgstr "_𐑕𐑑𐑱𐑑/𐑐𐑮𐑪𐑝𐑦𐑯𐑕:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:49
+msgid "_Title:"
+msgstr "_𐑑𐑲𐑑𐑩𐑤:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:50
+msgid "_Work:"
+msgstr "_𐑢𐑻𐑒:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:51
+#, fuzzy
+msgid "_XMPP:"
+msgstr "_XMPP:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:52
+msgid "_Yahoo:"
+msgstr "·_𐑘𐑭𐑣𐑵:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:53
+msgid "_ZIP/Postal code:"
+msgstr "_𐑟𐑦𐑐/𐑐𐑴𐑕𐑑𐑩𐑤 𐑒𐑴𐑛:"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑐𐑻𐑕𐑩𐑯𐑩𐑤 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:97
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr "𐑿 𐑸 𐑯𐑪𐑑 𐑩𐑤𐑬𐑛 𐑑 𐑨𐑒𐑕𐑧𐑕 𐑞 𐑛𐑦𐑝𐑲𐑕. 𐑒𐑪𐑯𐑑𐑨𐑒𐑑 𐑿𐑼 𐑕𐑦𐑕𐑑𐑩𐑥 𐑩𐑛𐑥𐑦𐑯𐑦𐑕𐑑𐑮𐑱𐑑𐑼."
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
+msgid "The device is already in use."
+msgstr "𐑞 𐑛𐑦𐑝𐑲𐑕 𐑦𐑟 𐑷𐑤𐑮𐑧𐑛𐑦 𐑦𐑯 𐑿𐑕."
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
+#, fuzzy
+msgid "An internal error occured"
+msgstr "𐑩𐑯 𐑦𐑯𐑑𐑻𐑯𐑩𐑤 𐑻𐑼 occured"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:218
+msgid "Delete registered fingerprints?"
+msgstr "𐑛𐑦𐑤𐑰𐑑 𐑮𐑧𐑡𐑦𐑕𐑑𐑼𐑛 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕?"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:221
+msgid "_Delete Fingerprints"
+msgstr "_𐑛𐑦𐑤𐑰𐑑 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:228
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"𐑛𐑵 𐑿 𐑢𐑪𐑯𐑑 𐑑 𐑛𐑦𐑤𐑰𐑑 𐑿𐑼 𐑮𐑧𐑡𐑦𐑕𐑑𐑼𐑛 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕 𐑕𐑴 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯 𐑦𐑟 𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛?"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:356
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:1
+msgid "Done!"
+msgstr "𐑛𐑳𐑯!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:402
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:424
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑨𐑒𐑕𐑧𐑕 '%s' 𐑛𐑦𐑝𐑲𐑕"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:473
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑕𐑑𐑸𐑑 𐑓𐑦𐑙𐑜𐑼 𐑒𐑨𐑐𐑗𐑻 𐑪𐑯 '%s' 𐑛𐑦𐑝𐑲𐑕"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:520
+msgid "Could not access any fingerprint readers"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑨𐑒𐑕𐑧𐑕 𐑧𐑯𐑦 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑮𐑰𐑛𐑼𐑟"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:521
+msgid "Please contact your system administrator for help."
+msgstr "𐑐𐑤𐑰𐑟 𐑒𐑪𐑯𐑑𐑨𐑒𐑑 𐑿𐑼 𐑕𐑦𐑕𐑑𐑩𐑥 𐑩𐑛𐑥𐑦𐑯𐑦𐑕𐑑𐑮𐑱𐑑𐑼 𐑓𐑹 𐑣𐑧𐑤𐑐."
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:551
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:2
+msgid "Enable Fingerprint Login"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:581
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"𐑑 𐑦𐑯𐑱𐑚𐑩𐑤 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑤𐑪𐑜𐑦𐑯, 𐑿 𐑯𐑰𐑛 𐑑 𐑕𐑱𐑝 𐑢𐑳𐑯 𐑝 𐑿𐑼 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑𐑕, 𐑿𐑟𐑦𐑙 𐑞 '%s' "
+"𐑛𐑦𐑝𐑲𐑕."
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:590
+msgid "Swipe finger on reader"
+msgstr "𐑕𐑢𐑲𐑐 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 𐑮𐑰𐑛𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:592
+msgid "Place finger on reader"
+msgstr "𐑐𐑤𐑱𐑕 𐑓𐑦𐑙𐑜𐑼 𐑪𐑯 𐑮𐑰𐑛𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:3
+msgid "Left index finger"
+msgstr "𐑤𐑧𐑓𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "𐑤𐑧𐑓𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:5
+msgid "Left middle finger"
+msgstr "𐑤𐑧𐑓𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:6
+msgid "Left ring finger"
+msgstr "𐑤𐑧𐑓𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:7
+msgid "Left thumb"
+msgstr "𐑤𐑧𐑓𐑑 𐑔𐑳𐑥"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:8
+msgid "Other finger: "
+msgstr "𐑳𐑞𐑼 𐑓𐑦𐑙𐑜𐑼: "
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:9
+msgid "Right index finger"
+msgstr "𐑮𐑲𐑑 𐑦𐑯𐑛𐑧𐑒𐑕 𐑓𐑦𐑙𐑜𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:10
+msgid "Right little finger"
+msgstr "𐑮𐑲𐑑 𐑤𐑦𐑑𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:11
+msgid "Right middle finger"
+msgstr "𐑮𐑲𐑑 𐑥𐑦𐑛𐑩𐑤 𐑓𐑦𐑙𐑜𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:12
+msgid "Right ring finger"
+msgstr "𐑮𐑲𐑑 𐑮𐑦𐑙 𐑓𐑦𐑙𐑜𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:13
+msgid "Right thumb"
+msgstr "𐑮𐑲𐑑 𐑔𐑳𐑥"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:14
+msgid "Select finger"
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑓𐑦𐑙𐑜𐑼"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:15
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"𐑿𐑼 𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑢𐑪𐑟 𐑕𐑩𐑒𐑕𐑧𐑕𐑓𐑩𐑤𐑦 𐑕𐑱𐑝𐑛. 𐑿 𐑖𐑫𐑛 𐑯𐑬 𐑚𐑰 𐑱𐑚𐑩𐑤 𐑑 𐑤𐑪𐑜 𐑦𐑯 𐑿𐑟𐑦𐑙 𐑿𐑼 "
+"𐑓𐑦𐑙𐑜𐑼𐑐𐑮𐑦𐑯𐑑 𐑮𐑰𐑛𐑼."
+
+#: ../capplets/about-me/gnome-about-me-password.c:161
+msgid "Child exited unexpectedly"
+msgstr "𐑗𐑲𐑤𐑛 𐑧𐑜𐑟𐑦𐑑𐑩𐑛 𐑩𐑯𐑦𐑒𐑕𐑐𐑧𐑒𐑑𐑦𐑛𐑤𐑰"
+
+#: ../capplets/about-me/gnome-about-me-password.c:296
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑖𐑩𐑑𐑛𐑶𐑯 backend_stdin IO 𐑗𐑨𐑯𐑩𐑤: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:309
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑖𐑩𐑑𐑛𐑶𐑯 backend_stdout IO 𐑗𐑨𐑯𐑩𐑤: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:408
+msgid "Authenticated!"
+msgstr "𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛!"
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:474
+#: ../capplets/about-me/gnome-about-me-password.c:554
+msgid ""
+"Your password has been changed since you initially authenticated! Please re-"
+"authenticate."
+msgstr "𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑗𐑱𐑯𐑡𐑛 𐑕𐑦𐑯𐑕 𐑿 𐑦𐑯𐑦𐑖𐑩𐑤𐑦 𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛! 𐑐𐑤𐑰𐑟 𐑮𐑰-𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑."
+
+#: ../capplets/about-me/gnome-about-me-password.c:476
+msgid "That password was incorrect."
+msgstr "𐑞𐑨𐑑 𐑐𐑭𐑕𐑢𐑼𐑛 𐑢𐑪𐑟 𐑦𐑯𐑒𐑼𐑧𐑒𐑑."
+
+#: ../capplets/about-me/gnome-about-me-password.c:525
+msgid "Your password has been changed."
+msgstr "𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑗𐑱𐑯𐑡𐑛."
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:535
+#, c-format
+msgid "System error: %s."
+msgstr "𐑕𐑦𐑕𐑑𐑩𐑥 𐑻𐑼: %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:538
+msgid "The password is too short."
+msgstr "𐑞 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑟 𐑑𐑵 𐑖𐑹𐑑."
+
+#: ../capplets/about-me/gnome-about-me-password.c:542
+msgid "The password is too simple."
+msgstr "𐑞 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑟 𐑑𐑵 𐑕𐑦𐑥𐑐𐑩𐑤."
+
+#: ../capplets/about-me/gnome-about-me-password.c:546
+msgid "The old and new passwords are too similar."
+msgstr "𐑞 𐑴𐑤𐑛 𐑯 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛𐑟 𐑸 𐑑𐑵 𐑕𐑦𐑥𐑦𐑤𐑼."
+
+#: ../capplets/about-me/gnome-about-me-password.c:548
+msgid "The new password must contain numeric or special character(s)."
+msgstr "𐑞 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛 𐑥𐑳𐑕𐑑 𐑒𐑩𐑯𐑑𐑱𐑯 𐑯𐑿𐑥𐑧𐑮𐑦𐑒 𐑹 𐑕𐑐𐑧𐑖𐑩𐑤 𐑒𐑸𐑩𐑒𐑑𐑼(𐑕)."
+
+#: ../capplets/about-me/gnome-about-me-password.c:551
+msgid "The old and new passwords are the same."
+msgstr "𐑞 𐑴𐑤𐑛 𐑯 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛𐑟 𐑸 𐑞 𐑕𐑱𐑥."
+
+#. translators: Unable to launch <program>: <error message>
+#: ../capplets/about-me/gnome-about-me-password.c:822
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑤𐑷𐑯𐑗 %s: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:826
+msgid "Unable to launch backend"
+msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑤𐑷𐑯𐑗 𐑚𐑨𐑒𐑧𐑯𐑛"
+
+#: ../capplets/about-me/gnome-about-me-password.c:827
+msgid "A system error has occurred"
+msgstr "𐑩 𐑕𐑦𐑕𐑑𐑩𐑥 𐑻𐑼 𐑣𐑨𐑟 𐑪𐑒𐑻𐑛"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:847
+msgid "Checking password..."
+msgstr "𐑗𐑧𐑒𐑦𐑙 𐑐𐑭𐑕𐑢𐑼𐑛..."
+
+#: ../capplets/about-me/gnome-about-me-password.c:934
+msgid "Click <b>Change password</b> to change your password."
+msgstr "𐑒𐑤𐑦𐑒 <b>𐑗𐑱𐑯𐑡 𐑐𐑭𐑕𐑢𐑼𐑛</b> 𐑑 𐑗𐑱𐑯𐑡 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛."
+
+#: ../capplets/about-me/gnome-about-me-password.c:937
+msgid "Please type your password in the <b>New password</b> field."
+msgstr "𐑐𐑤𐑰𐑟 𐑑𐑲𐑐 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑯 𐑞 <b>𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛</b> 𐑓𐑰𐑤𐑛."
+
+#: ../capplets/about-me/gnome-about-me-password.c:940
+#: ../capplets/about-me/gnome-about-me-password.ui.h:5
+#, fuzzy
+msgid ""
+"Please type your password again in the <b>Retype new password</b> field."
+msgstr "𐑐𐑤𐑰𐑟 𐑑𐑲𐑐 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛 𐑩𐑜𐑱𐑯 𐑦𐑯 𐑞 <𐑚𐑰>Retype 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛</𐑚𐑰> 𐑓𐑰𐑤𐑛."
+
+#: ../capplets/about-me/gnome-about-me-password.c:943
+msgid "The two passwords are not equal."
+msgstr "𐑞 𐑑𐑵 𐑐𐑭𐑕𐑢𐑼𐑛𐑟 𐑸 𐑯𐑪𐑑 𐑰𐑒𐑢𐑩𐑤."
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:1
+msgid "Change pa_ssword"
+msgstr "𐑗𐑱𐑯𐑡 _𐑐𐑭𐑕𐑢𐑼𐑛"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:2
+msgid "Change password"
+msgstr "𐑗𐑱𐑯𐑡 𐑐𐑭𐑕𐑢𐑼𐑛"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:3
+msgid "Change your password"
+msgstr "𐑗𐑱𐑯𐑡 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:4
+msgid "Current _password:"
+msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 _𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:6
+#, fuzzy
+msgid ""
+"To change your password, enter your current password in the field below and "
+"click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for "
+"verification and click <b>Change password</b>."
+msgstr ""
+"𐑑 𐑗𐑱𐑯𐑡 𐑿𐑼 𐑐𐑭𐑕𐑢𐑼𐑛, 𐑧𐑯𐑑𐑼 𐑿𐑼 𐑒𐑳𐑮𐑩𐑯𐑑 𐑐𐑭𐑕𐑢𐑼𐑛 𐑦𐑯 𐑞 𐑓𐑰𐑤𐑛 𐑚𐑩𐑤𐑴 𐑯 𐑒𐑤𐑦𐑒 <𐑚𐑰>𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑</"
+"𐑚𐑰>.\n"
+"𐑭𐑓𐑑𐑼 𐑿 𐑣𐑨𐑝 𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑𐑩𐑛, 𐑧𐑯𐑑𐑼 𐑿𐑼 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛, retype 𐑦𐑑 𐑓𐑹 𐑝𐑧𐑮𐑩𐑓𐑩𐑒𐑱𐑖𐑩𐑯 𐑯 𐑒𐑤𐑦𐑒 "
+"<𐑚𐑰>𐑗𐑱𐑯𐑡 𐑐𐑭𐑕𐑢𐑼𐑛</𐑚𐑰>."
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:8
+msgid "_Authenticate"
+msgstr "_𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑑"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:9
+msgid "_New password:"
+msgstr "_𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:10
+#, fuzzy
+msgid "_Retype new password:"
+msgstr "_Retype 𐑯𐑿 𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:1
+msgid "Accessible Lo_gin"
+msgstr "𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑩𐑤 _𐑤𐑪𐑜𐑦𐑯"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:2
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+#, fuzzy
+msgid "Assistive Technologies"
+msgstr "Assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:3
+#, fuzzy
+msgid "Assistive Technologies Preferences"
+msgstr "Assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:4
+#, fuzzy
+msgid ""
+"Changes to enable assistive technologies will not take effect until your "
+"next log in."
+msgstr ""
+"𐑗𐑱𐑯𐑡𐑩𐑟 𐑑 𐑦𐑯𐑱𐑚𐑩𐑤 assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑑𐑱𐑒 𐑦𐑓𐑧𐑒𐑑 𐑳𐑯𐑑𐑦𐑤 𐑿𐑼 𐑯𐑧𐑒𐑕𐑑 𐑤𐑪𐑜 𐑦𐑯."
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:5
+msgid "Close and _Log Out"
+msgstr "𐑒𐑤𐑴𐑕 𐑯 _𐑤𐑪𐑜 𐑬𐑑"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:6
+msgid "Jump to Preferred Applications dialog"
+msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:7
+msgid "Jump to the Accessible Login dialog"
+msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑞 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑩𐑤 𐑤𐑪𐑜𐑦𐑯 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:8
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑞 𐑒𐑰𐑚𐑪𐑮𐑛 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:9
+msgid "Jump to the Mouse Accessibility dialog"
+msgstr "𐑡𐑳𐑥𐑐 𐑑 𐑞 𐑥𐑬𐑕 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:10
+msgid "Preferences"
+msgstr "𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:11
+#, fuzzy
+msgid "_Enable assistive technologies"
+msgstr "_𐑦𐑯𐑱𐑚𐑩𐑤 assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰𐑟"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:12
+msgid "_Keyboard Accessibility"
+msgstr "_𐑒𐑰𐑚𐑪𐑮𐑛 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:13
+msgid "_Mouse Accessibility"
+msgstr "_𐑥𐑬𐑕 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:14
+msgid "_Preferred Applications"
+msgstr "_𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Choose which accessibility features to enable when you log in"
+msgstr "𐑗𐑵𐑟 𐑢𐑦𐑗 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑓𐑰𐑗𐑼𐑟 𐑑 𐑦𐑯𐑱𐑚𐑩𐑤 𐑢𐑧𐑯 𐑿 𐑤𐑪𐑜 𐑦𐑯"
+
+#: ../capplets/appearance/appearance-desktop.c:627
+msgid "Add Wallpaper"
+msgstr "𐑨𐑛 𐑢𐑪𐑤𐑐𐑱𐑐𐑻"
+
+#: ../capplets/appearance/appearance-desktop.c:662
+msgid "All files"
+msgstr "𐑷𐑤 𐑓𐑲𐑤𐑟"
+
+#: ../capplets/appearance/appearance-font.c:499
+msgid "Font may be too large"
+msgstr "𐑓𐑪𐑯𐑑 𐑥𐑱 𐑚𐑰 𐑑𐑵 𐑤𐑸𐑡"
+
+#: ../capplets/appearance/appearance-font.c:503
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
+"𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑲𐑟 𐑕𐑥𐑷𐑤𐑼 𐑞𐑨𐑯 %d."
+msgstr[1] ""
+"𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑𐑕 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
+"𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑲𐑟 𐑕𐑥𐑷𐑤𐑼 𐑞𐑨𐑯 %d."
+
+#: ../capplets/appearance/appearance-font.c:516
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
+"𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑥𐑷𐑤𐑼 𐑕𐑲𐑟𐑛 𐑓𐑪𐑯𐑑."
+msgstr[1] ""
+"𐑞 𐑓𐑪𐑯𐑑 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑦𐑟 %d 𐑐𐑶𐑯𐑑𐑕 𐑤𐑸𐑡, 𐑯 𐑥𐑱 𐑥𐑱𐑒 𐑦𐑑 𐑛𐑦𐑓𐑦𐑒𐑩𐑤𐑑 𐑑 𐑦𐑓𐑧𐑒𐑑𐑦𐑝𐑤𐑦 𐑿𐑟 𐑞 "
+"𐑒𐑩𐑥𐑐𐑿𐑑𐑼.  𐑦𐑑 𐑦𐑟 𐑮𐑧𐑒𐑩𐑥𐑧𐑯𐑛𐑩𐑛 𐑞𐑨𐑑 𐑿 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑕𐑥𐑷𐑤𐑼 𐑕𐑲𐑟𐑛 𐑓𐑪𐑯𐑑."
+
+#: ../capplets/appearance/appearance-font.c:539
+msgid "Use previous font"
+msgstr "𐑿𐑟 𐑐𐑮𐑰𐑝𐑦𐑩𐑕 𐑓𐑪𐑯𐑑"
+
+#: ../capplets/appearance/appearance-font.c:541
+msgid "Use selected font"
+msgstr "𐑿𐑟 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑓𐑪𐑯𐑑"
+
+#: ../capplets/appearance/appearance-main.c:56
+#, c-format
+msgid "Could not load user interface file: %s"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑤𐑴𐑛 𐑿𐑟𐑼 𐑦𐑯𐑑𐑼𐑓𐑱𐑕 𐑓𐑲𐑤: %s"
+
+#: ../capplets/appearance/appearance-main.c:135
+msgid "Specify the filename of a theme to install"
+msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑓𐑲𐑤𐑯𐑱𐑥 𐑝 𐑩 𐑔𐑰𐑥 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤"
+
+#: ../capplets/appearance/appearance-main.c:136
+msgid "filename"
+msgstr "𐑓𐑲𐑤𐑯𐑱𐑥"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/appearance/appearance-main.c:143
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑯𐑱𐑥 𐑝 𐑞 𐑐𐑱𐑡 𐑑 𐑖𐑴 (theme|background|fonts|interface)"
+
+#: ../capplets/appearance/appearance-main.c:144
+#: ../capplets/default-applications/gnome-da-capplet.c:960
+#: ../capplets/mouse/gnome-mouse-properties.c:591
+msgid "page"
+msgstr "𐑐𐑱𐑡"
+
+#: ../capplets/appearance/appearance-main.c:151
+msgid "[WALLPAPER...]"
+msgstr "[𐑢𐑪𐑤𐑐𐑱𐑐𐑻...]"
+
+#: ../capplets/appearance/appearance-style.c:172
+#: ../capplets/common/gnome-theme-info.c:446
+#: ../capplets/common/gnome-theme-info.c:638
+msgid "Default Pointer"
+msgstr "𐑛𐑦𐑓𐑷𐑤𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#: ../capplets/appearance/appearance-style.c:235
+#: ../capplets/appearance/appearance-themes.c:685
+msgid "Install"
+msgstr "𐑦𐑯𐑕𐑑𐑷𐑤"
+
+#: ../capplets/appearance/appearance-style.c:256
+#: ../capplets/common/gnome-theme-info.c:1646
+#, fuzzy
+msgid ""
+"This theme will not look as intended because the required GTK+ theme engine "
+"'%s' is not installed."
+msgstr ""
+"𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 GTK+ 𐑔𐑰𐑥 𐑧𐑯𐑡𐑦𐑯 '%s' 𐑦𐑟 𐑯𐑪𐑑 "
+"𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#: ../capplets/appearance/appearance-themes.c:673
+msgid "Apply Background"
+msgstr "𐑩𐑐𐑤𐑲 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
+
+#: ../capplets/appearance/appearance-themes.c:677
+msgid "Apply Font"
+msgstr "𐑩𐑐𐑤𐑲 𐑓𐑪𐑯𐑑"
+
+#: ../capplets/appearance/appearance-themes.c:681
+msgid "Revert Font"
+msgstr "𐑮𐑦𐑝𐑻𐑑 𐑓𐑪𐑯𐑑"
+
+#: ../capplets/appearance/appearance-themes.c:712
+msgid ""
+"The current theme suggests a background and a font. Also, the last applied "
+"font suggestion can be reverted."
+msgstr ""
+"𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑯 𐑩 𐑓𐑪𐑯𐑑. 𐑷𐑤𐑕𐑴, 𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 "
+"𐑒𐑨𐑯 𐑚𐑰 𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
+
+#: ../capplets/appearance/appearance-themes.c:714
+msgid ""
+"The current theme suggests a background. Also, the last applied font "
+"suggestion can be reverted."
+msgstr ""
+"𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛. 𐑷𐑤𐑕𐑴, 𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 "
+"𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
+
+#: ../capplets/appearance/appearance-themes.c:716
+msgid "The current theme suggests a background and a font."
+msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑯 𐑩 𐑓𐑪𐑯𐑑."
+
+#: ../capplets/appearance/appearance-themes.c:718
+msgid ""
+"The current theme suggests a font. Also, the last applied font suggestion "
+"can be reverted."
+msgstr ""
+"𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑓𐑪𐑯𐑑. 𐑷𐑤𐑕𐑴, 𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
+
+#: ../capplets/appearance/appearance-themes.c:720
+msgid "The current theme suggests a background."
+msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛."
+
+#: ../capplets/appearance/appearance-themes.c:722
+msgid "The last applied font suggestion can be reverted."
+msgstr "𐑞 𐑤𐑭𐑕𐑑 𐑩𐑐𐑤𐑲𐑛 𐑓𐑪𐑯𐑑 𐑕𐑩𐑡𐑧𐑕𐑗𐑩𐑯 𐑒𐑨𐑯 𐑚𐑰 𐑮𐑦𐑝𐑻𐑑𐑦𐑛."
+
+#: ../capplets/appearance/appearance-themes.c:724
+msgid "The current theme suggests a font."
+msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥 𐑕𐑩𐑡𐑧𐑕𐑑𐑕 𐑩 𐑓𐑪𐑯𐑑."
+
+#: ../capplets/appearance/appearance-themes.c:1046
+#: ../capplets/default-applications/gnome-da-capplet.c:691
+msgid "Custom"
+msgstr "𐑒𐑳𐑕𐑑𐑩𐑥"
+
+#: ../capplets/appearance/data/appearance.ui.h:1
+msgid "Appearance Preferences"
+msgstr "𐑩𐑐𐑽𐑩𐑯𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/appearance/data/appearance.ui.h:2
+msgid "Background"
+msgstr "𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
+
+#: ../capplets/appearance/data/appearance.ui.h:3
+msgid "Best _shapes"
+msgstr "𐑚𐑧𐑕𐑑 _𐑖𐑱𐑐𐑕"
+
+#: ../capplets/appearance/data/appearance.ui.h:4
+msgid "Best co_ntrast"
+msgstr "𐑚𐑧𐑕𐑑 _𐑒𐑪𐑯𐑑𐑮𐑭𐑕𐑑"
+
+#: ../capplets/appearance/data/appearance.ui.h:5
+msgid "C_olors:"
+msgstr "_𐑒𐑳𐑤𐑼𐑟:"
+
+#: ../capplets/appearance/data/appearance.ui.h:6
+msgid "C_ustomize..."
+msgstr "_𐑒𐑩𐑕𐑑𐑩𐑥𐑲𐑟..."
+
+#: ../capplets/appearance/data/appearance.ui.h:7
+msgid "Center"
+msgstr "𐑕𐑧𐑯𐑑𐑼"
+
+#: ../capplets/appearance/data/appearance.ui.h:8
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr "𐑗𐑱𐑯𐑡𐑦𐑙 𐑿𐑼 𐑒𐑻𐑕𐑼 𐑔𐑰𐑥 𐑑𐑱𐑒𐑕 𐑦𐑓𐑧𐑒𐑑 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑑𐑲𐑥 𐑿 𐑤𐑪𐑜 𐑦𐑯."
+
+#: ../capplets/appearance/data/appearance.ui.h:9
+msgid "Colors"
+msgstr "𐑒𐑳𐑤𐑼𐑟"
+
+#: ../capplets/appearance/data/appearance.ui.h:10
+msgid "Controls"
+msgstr "𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑟"
+
+#: ../capplets/appearance/data/appearance.ui.h:11
+msgid "Customize Theme"
+msgstr "𐑒𐑩𐑕𐑑𐑩𐑥𐑲𐑟 𐑔𐑰𐑥"
+
+#: ../capplets/appearance/data/appearance.ui.h:12
+msgid "D_etails..."
+msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟..."
+
+#: ../capplets/appearance/data/appearance.ui.h:13
+msgid "Des_ktop font:"
+msgstr "_𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑓𐑪𐑯𐑑:"
+
+#: ../capplets/appearance/data/appearance.ui.h:14
+msgid "Font Rendering Details"
+msgstr "𐑓𐑪𐑯𐑑 𐑮𐑧𐑯𐑛𐑻𐑦𐑙 𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#: ../capplets/appearance/data/appearance.ui.h:15
+msgid "Fonts"
+msgstr "𐑓𐑪𐑯𐑑𐑕"
+
+#: ../capplets/appearance/data/appearance.ui.h:16
+msgid "Get more backgrounds online"
+msgstr "𐑜𐑧𐑑 𐑥𐑹 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛𐑟 𐑪𐑯𐑤𐑲𐑯"
+
+#: ../capplets/appearance/data/appearance.ui.h:17
+msgid "Get more themes online"
+msgstr "𐑜𐑧𐑑 𐑥𐑹 𐑔𐑰𐑥𐑟 𐑪𐑯𐑤𐑲𐑯"
+
+#: ../capplets/appearance/data/appearance.ui.h:18
+msgid "Gra_yscale"
+msgstr "_𐑜𐑮𐑱𐑕𐑒𐑱𐑤"
+
+#. font hinting
+#: ../capplets/appearance/data/appearance.ui.h:20
+msgid "Hinting"
+msgstr "𐑣𐑦𐑯𐑑𐑦𐑙"
+
+#: ../capplets/appearance/data/appearance.ui.h:21
+msgid "Horizontal gradient"
+msgstr "𐑣𐑪𐑮𐑦𐑟𐑪𐑯𐑑𐑩𐑤 𐑜𐑮𐑱𐑛𐑦𐑩𐑯𐑑"
+
+#: ../capplets/appearance/data/appearance.ui.h:22
+msgid "Icons"
+msgstr "𐑲𐑒𐑪𐑯𐑟"
+
+#: ../capplets/appearance/data/appearance.ui.h:23
+msgid "Icons only"
+msgstr "𐑲𐑒𐑪𐑯𐑟 𐑴𐑯𐑤𐑦"
+
+#: ../capplets/appearance/data/appearance.ui.h:24
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:17
+msgid "Large"
+msgstr "𐑤𐑸𐑡"
+
+#: ../capplets/appearance/data/appearance.ui.h:25
+msgid "N_one"
+msgstr "_𐑯𐑳𐑯"
+
+#: ../capplets/appearance/data/appearance.ui.h:26
+msgid "Open a dialog to specify the color"
+msgstr "𐑴𐑐𐑩𐑯 𐑩 𐑛𐑲𐑩𐑤𐑪𐑜 𐑑 𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑒𐑳𐑤𐑼"
+
+#: ../capplets/appearance/data/appearance.ui.h:27
+msgid "Pointer"
+msgstr "𐑐𐑶𐑯𐑑𐑼"
+
+#: ../capplets/appearance/data/appearance.ui.h:28
+msgid "R_esolution:"
+msgstr "_𐑮𐑧𐑟𐑩𐑤𐑵𐑖𐑩𐑯:"
+
+#: ../capplets/appearance/data/appearance.ui.h:29
+msgid "Rendering"
+msgstr "𐑮𐑧𐑯𐑛𐑻𐑦𐑙"
+
+#: ../capplets/appearance/data/appearance.ui.h:30
+msgid "Save Theme As..."
+msgstr "𐑕𐑱𐑝 𐑔𐑰𐑥 𐑨𐑟..."
+
+#: ../capplets/appearance/data/appearance.ui.h:31
+msgid "Save _As..."
+msgstr "𐑕𐑱𐑝 _𐑨𐑟..."
+
+#: ../capplets/appearance/data/appearance.ui.h:32
+msgid "Save _background image"
+msgstr "𐑕𐑱𐑝 _𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑦𐑥𐑦𐑡"
+
+#: ../capplets/appearance/data/appearance.ui.h:33
+msgid "Scale"
+msgstr "𐑕𐑒𐑱𐑤"
+
+#: ../capplets/appearance/data/appearance.ui.h:34
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:31
+msgid "Small"
+msgstr "𐑕𐑥𐑷𐑤"
+
+#: ../capplets/appearance/data/appearance.ui.h:35
+msgid "Smoothing"
+msgstr "𐑕𐑥𐑵𐑞𐑦𐑙"
+
+#: ../capplets/appearance/data/appearance.ui.h:36
+msgid "Solid color"
+msgstr "𐑕𐑪𐑤𐑦𐑛 𐑒𐑳𐑤𐑼"
+
+#: ../capplets/appearance/data/appearance.ui.h:37
+msgid "Span"
+msgstr "𐑕𐑐𐑨𐑯"
+
+#: ../capplets/appearance/data/appearance.ui.h:38
+msgid "Stretch"
+msgstr "𐑕𐑑𐑮𐑧𐑗"
+
+#: ../capplets/appearance/data/appearance.ui.h:39
+#, fuzzy
+msgid "Sub_pixel (LCDs)"
+msgstr "_Subpixel (LCDs)"
+
+#: ../capplets/appearance/data/appearance.ui.h:40
+#, fuzzy
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "_Subpixel 𐑕𐑥𐑵𐑞𐑦𐑙 (LCDs)"
+
+#: ../capplets/appearance/data/appearance.ui.h:41
+#, fuzzy
+msgid "Subpixel Order"
+msgstr "Subpixel 𐑹𐑛𐑼"
+
+#: ../capplets/appearance/data/appearance.ui.h:42
+msgid "Text"
+msgstr "𐑑𐑧𐑒𐑕𐑑"
+
+#: ../capplets/appearance/data/appearance.ui.h:43
+msgid "Text below items"
+msgstr "𐑑𐑧𐑒𐑕𐑑 𐑚𐑩𐑤𐑴 𐑲𐑑𐑩𐑥𐑟"
+
+#: ../capplets/appearance/data/appearance.ui.h:44
+msgid "Text beside items"
+msgstr "𐑑𐑧𐑒𐑕𐑑 𐑚𐑦𐑕𐑲𐑛 𐑲𐑑𐑩𐑥𐑟"
+
+#: ../capplets/appearance/data/appearance.ui.h:45
+msgid "Text only"
+msgstr "𐑑𐑧𐑒𐑕𐑑 𐑴𐑯𐑤𐑦"
+
+#: ../capplets/appearance/data/appearance.ui.h:46
+msgid "The current controls theme does not support color schemes."
+msgstr "𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑟 𐑔𐑰𐑥 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑕𐑩𐑐𐑹𐑑 𐑒𐑳𐑤𐑼 𐑕𐑒𐑰𐑥𐑟."
+
+#: ../capplets/appearance/data/appearance.ui.h:47
+msgid "Theme"
+msgstr "𐑔𐑰𐑥"
+
+#: ../capplets/appearance/data/appearance.ui.h:48
+msgid "Tile"
+msgstr "𐑑𐑲𐑤"
+
+#. vertical hinting, pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.ui.h:50
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/appearance/data/appearance.ui.h:51
+msgid "Vertical gradient"
+msgstr "𐑝𐑻𐑑𐑦𐑒𐑩𐑤 𐑜𐑮𐑱𐑛𐑦𐑩𐑯𐑑"
+
+#: ../capplets/appearance/data/appearance.ui.h:52
+msgid "Window Border"
+msgstr "𐑢𐑦𐑯𐑛𐑴 𐑚𐑹𐑛𐑼"
+
+#: ../capplets/appearance/data/appearance.ui.h:53
+msgid "Zoom"
+msgstr "𐑟𐑵𐑥"
+
+#: ../capplets/appearance/data/appearance.ui.h:54
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:45
+msgid "_Add..."
+msgstr "_𐑨𐑛..."
+
+#: ../capplets/appearance/data/appearance.ui.h:55
+msgid "_Application font:"
+msgstr "_𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯 𐑓𐑪𐑯𐑑:"
+
+#. pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.ui.h:57
+#, fuzzy
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/appearance/data/appearance.ui.h:58
+msgid "_Description:"
+msgstr "_𐑛𐑦𐑕𐑒𐑮𐑦𐑐𐑖𐑩𐑯:"
+
+#: ../capplets/appearance/data/appearance.ui.h:59
+msgid "_Document font:"
+msgstr "_𐑛𐑪𐑒𐑿𐑥𐑩𐑯𐑑 𐑓𐑪𐑯𐑑:"
+
+#: ../capplets/appearance/data/appearance.ui.h:60
+msgid "_Fixed width font:"
+msgstr "_𐑓𐑦𐑒𐑕𐑑 𐑢𐑦𐑛𐑔 𐑓𐑪𐑯𐑑:"
+
+#: ../capplets/appearance/data/appearance.ui.h:61
+msgid "_Full"
+msgstr "_𐑓𐑫𐑤"
+
+#: ../capplets/appearance/data/appearance.ui.h:62
+msgid "_Input boxes:"
+msgstr "_𐑦𐑯𐑐𐑫𐑑 𐑚𐑪𐑒𐑕𐑩𐑟:"
+
+#: ../capplets/appearance/data/appearance.ui.h:63
+msgid "_Install..."
+msgstr "_𐑦𐑯𐑕𐑑𐑷𐑤..."
+
+#: ../capplets/appearance/data/appearance.ui.h:64
+msgid "_Medium"
+msgstr "_𐑥𐑰𐑛𐑦𐑩𐑥"
+
+#: ../capplets/appearance/data/appearance.ui.h:65
+msgid "_Monochrome"
+msgstr "_𐑥𐑭𐑯𐑩𐑒𐑮𐑴𐑥"
+
+#: ../capplets/appearance/data/appearance.ui.h:66
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:5
+msgid "_Name:"
+msgstr "_𐑯𐑱𐑥:"
+
+#: ../capplets/appearance/data/appearance.ui.h:67
+msgid "_None"
+msgstr "_𐑯𐑳𐑯"
+
+#. pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.ui.h:69
+#, fuzzy
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/appearance/data/appearance.ui.h:70
+msgid "_Reset to Defaults"
+msgstr "_𐑮𐑰𐑕𐑧𐑑 𐑑 𐑛𐑦𐑓𐑷𐑤𐑑𐑕"
+
+#: ../capplets/appearance/data/appearance.ui.h:71
+msgid "_Selected items:"
+msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑲𐑑𐑩𐑥𐑟:"
+
+#: ../capplets/appearance/data/appearance.ui.h:72
+msgid "_Size:"
+msgstr "_𐑕𐑲𐑟:"
+
+#: ../capplets/appearance/data/appearance.ui.h:73
+msgid "_Slight"
+msgstr "_𐑕𐑤𐑲𐑑"
+
+#: ../capplets/appearance/data/appearance.ui.h:74
+msgid "_Style:"
+msgstr "_𐑕𐑑𐑲𐑤:"
+
+#: ../capplets/appearance/data/appearance.ui.h:75
+#, fuzzy
+msgid "_Tooltips:"
+msgstr "_Tooltips:"
+
+#. vertical hinting, pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.ui.h:77
+#, fuzzy
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/appearance/data/appearance.ui.h:78
+msgid "_Window title font:"
+msgstr "_𐑢𐑦𐑯𐑛𐑴 𐑑𐑲𐑑𐑩𐑤 𐑓𐑪𐑯𐑑:"
+
+#: ../capplets/appearance/data/appearance.ui.h:79
+msgid "_Windows:"
+msgstr "_𐑢𐑦𐑯𐑛𐑴𐑟:"
+
+#: ../capplets/appearance/data/appearance.ui.h:80
+msgid "dots per inch"
+msgstr "𐑛𐑪𐑑𐑕 𐑐𐑻 𐑦𐑯𐑗"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr "𐑩𐑐𐑽𐑩𐑯𐑕"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr "𐑒𐑩𐑕𐑑𐑩𐑥𐑲𐑟 𐑞 𐑤𐑫𐑒 𐑝 𐑞 𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr "𐑦𐑯𐑕𐑑𐑷𐑤𐑟 𐑔𐑰𐑥𐑟 𐑐𐑨𐑒𐑦𐑡𐑩𐑟 𐑓𐑹 𐑝𐑺𐑦𐑩𐑕 𐑐𐑸𐑑𐑕 𐑝 𐑞 𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr "𐑔𐑰𐑥 𐑦𐑯𐑕𐑑𐑷𐑤𐑼"
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr "𐑯𐑴𐑥 𐑔𐑰𐑥 𐑐𐑨𐑒𐑦𐑡"
+
+#: ../capplets/appearance/gnome-wp-info.c:50
+msgid "No Desktop Background"
+msgstr "𐑯𐑴 𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛"
+
+#: ../capplets/appearance/gnome-wp-item.c:261
+msgid "Slide Show"
+msgstr "𐑕𐑤𐑲𐑛 𐑖𐑴"
+
+#: ../capplets/appearance/gnome-wp-item.c:263
+msgid "Image"
+msgstr "𐑦𐑥𐑦𐑡"
+
+#: ../capplets/appearance/gnome-wp-item.c:269
+msgid "multiple sizes"
+msgstr "𐑥𐑳𐑤𐑑𐑦𐑐𐑩𐑤 𐑕𐑲𐑟𐑩𐑟"
+
+#. translators: x pixel(s) by y pixel(s)
+#: ../capplets/appearance/gnome-wp-item.c:272
+#, fuzzy
+msgid "%d %s by %d %s"
+msgstr "%d %s 𐑚𐑲 %d %s"
+
+#: ../capplets/appearance/gnome-wp-item.c:274
+#: ../capplets/appearance/gnome-wp-item.c:276
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "𐑐𐑦𐑒𐑕𐑩𐑤"
+msgstr[1] "𐑐𐑦𐑒𐑕𐑩𐑤𐑟"
+
+#. translators: <b>wallpaper name</b>
+#. * mime type, size
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:284
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %s\n"
+"Folder: %s"
+msgstr ""
+"<b>%s</b>\n"
+"%s, %s\n"
+"𐑓𐑴𐑤𐑛𐑼: %s"
+
+#. translators: <b>wallpaper name</b>
+#. * Image missing
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:296
+#, fuzzy
+msgid ""
+"<b>%s</b>\n"
+"%s\n"
+"Folder: %s"
+msgstr ""
+"<𐑚𐑰>%s</𐑚𐑰>\n"
+"%s\n"
+"𐑓𐑴𐑤𐑛𐑼: %s"
+
+#: ../capplets/appearance/gnome-wp-item.c:300
+msgid "Image missing"
+msgstr "𐑦𐑥𐑦𐑡 𐑥𐑦𐑕𐑦𐑙"
+
+#: ../capplets/appearance/theme-installer.c:178
+#: ../capplets/appearance/theme-installer.c:234
+msgid "Cannot install theme"
+msgstr "𐑒𐑨𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑔𐑰𐑥"
+
+#: ../capplets/appearance/theme-installer.c:180
+#, c-format
+msgid "The %s utility is not installed."
+msgstr "𐑞 %s 𐑘𐑵𐑑𐑦𐑤𐑩𐑑𐑰 𐑦𐑟 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#: ../capplets/appearance/theme-installer.c:236
+msgid "There was a problem while extracting the theme."
+msgstr "𐑞𐑺 𐑢𐑪𐑟 𐑩 𐑐𐑮𐑪𐑚𐑤𐑩𐑥 𐑢𐑲𐑤 𐑦𐑒𐑕𐑑𐑮𐑨𐑒𐑑𐑦𐑙 𐑞 𐑔𐑰𐑥."
+
+#: ../capplets/appearance/theme-installer.c:264
+msgid "There was an error installing the selected file"
+msgstr "𐑞𐑺 𐑢𐑪𐑟 𐑩𐑯 𐑻𐑼 𐑦𐑯𐑕𐑑𐑷𐑤𐑦𐑙 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑓𐑲𐑤"
+
+#: ../capplets/appearance/theme-installer.c:265
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme."
+msgstr "\"%s\" 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑩𐑐𐑽 𐑑 𐑚𐑰 𐑩 𐑝𐑨𐑤𐑦𐑛 𐑔𐑰𐑥."
+
+#: ../capplets/appearance/theme-installer.c:266
+#, c-format
+msgid ""
+"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
+"you need to compile."
+msgstr ""
+"\"%s\" 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑩𐑐𐑽 𐑑 𐑚𐑰 𐑩 𐑝𐑨𐑤𐑦𐑛 𐑔𐑰𐑥. 𐑦𐑑 𐑥𐑱 𐑚𐑰 𐑩 𐑔𐑰𐑥 𐑧𐑯𐑡𐑦𐑯 𐑢𐑦𐑗 𐑿 𐑯𐑰𐑛 𐑑 𐑒𐑪𐑥𐑐𐑲𐑤."
+
+#: ../capplets/appearance/theme-installer.c:372
+#, c-format
+msgid "Installation for theme \"%s\" failed."
+msgstr "𐑦𐑯𐑕𐑑𐑩𐑤𐑱𐑖𐑩𐑯 𐑓𐑹 𐑔𐑰𐑥 \"%s\" 𐑓𐑱𐑤𐑛."
+
+#: ../capplets/appearance/theme-installer.c:411
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr "𐑞 𐑔𐑰𐑥 \"%s\" 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#: ../capplets/appearance/theme-installer.c:421
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr "𐑢𐑫𐑛 𐑿 𐑤𐑲𐑒 𐑑 𐑩𐑐𐑤𐑲 𐑦𐑑 𐑯𐑬, 𐑹 𐑒𐑰𐑐 𐑿𐑼 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥?"
+
+#: ../capplets/appearance/theme-installer.c:424
+msgid "Keep Current Theme"
+msgstr "𐑒𐑰𐑐 𐑒𐑳𐑮𐑩𐑯𐑑 𐑔𐑰𐑥"
+
+#: ../capplets/appearance/theme-installer.c:427
+msgid "Apply New Theme"
+msgstr "𐑩𐑐𐑤𐑲 𐑯𐑿 𐑔𐑰𐑥"
+
+#: ../capplets/appearance/theme-installer.c:471
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "·𐑜𐑯𐑴𐑥 𐑔𐑰𐑥 %s 𐑒𐑼𐑧𐑒𐑑𐑤𐑦 𐑦𐑯𐑕𐑑𐑷𐑤𐑛"
+
+#: ../capplets/appearance/theme-installer.c:533
+msgid "Failed to create temporary directory"
+msgstr "𐑓𐑱𐑤𐑛 𐑑 𐑒𐑮𐑦𐑱𐑑 𐑑𐑧𐑥𐑐𐑼𐑼𐑦 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦"
+
+#: ../capplets/appearance/theme-installer.c:596
+msgid "New themes have been successfully installed."
+msgstr "𐑯𐑿 𐑔𐑰𐑥𐑟 𐑣𐑨𐑝 𐑚𐑰𐑯 𐑕𐑩𐑒𐑕𐑧𐑕𐑓𐑩𐑤𐑦 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#: ../capplets/appearance/theme-installer.c:646
+msgid "No theme file location specified to install"
+msgstr "𐑯𐑴 𐑔𐑰𐑥 𐑓𐑲𐑤 𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑕𐑐𐑧𐑕𐑦𐑓𐑲𐑛 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤"
+
+#: ../capplets/appearance/theme-installer.c:670
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"𐑦𐑯𐑕𐑩𐑓𐑦𐑖𐑩𐑯𐑑 𐑐𐑻𐑥𐑦𐑖𐑪𐑯𐑟 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑞 𐑔𐑰𐑥 𐑦𐑯:\n"
+"%s"
+
+#: ../capplets/appearance/theme-installer.c:748
+msgid "Select Theme"
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑔𐑰𐑥"
+
+#: ../capplets/appearance/theme-installer.c:759
+msgid "Theme Packages"
+msgstr "𐑔𐑰𐑥 𐑐𐑨𐑒𐑦𐑡𐑩𐑟"
+
+#: ../capplets/appearance/theme-save.c:93
+#, c-format
+msgid "Theme name must be present"
+msgstr "𐑔𐑰𐑥 𐑯𐑱𐑥 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑐𐑮𐑩𐑟𐑧𐑯𐑑"
+
+#: ../capplets/appearance/theme-save.c:156
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "𐑞 𐑔𐑰𐑥 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕. 𐑢𐑫𐑛 𐑿 𐑤𐑲𐑒 𐑑 𐑮𐑦𐑐𐑤𐑱𐑕 𐑦𐑑?"
+
+#: ../capplets/appearance/theme-save.c:157
+#: ../capplets/common/file-transfer-dialog.c:451
+msgid "_Overwrite"
+msgstr "_𐑴𐑝𐑼𐑮𐑲𐑑"
+
+#: ../capplets/appearance/theme-util.c:75
+msgid "Would you like to delete this theme?"
+msgstr "𐑢𐑫𐑛 𐑿 𐑤𐑲𐑒 𐑑 𐑛𐑦𐑤𐑰𐑑 𐑞𐑦𐑕 𐑔𐑰𐑥?"
+
+#: ../capplets/appearance/theme-util.c:125
+msgid "Theme cannot be deleted"
+msgstr "𐑔𐑰𐑥 𐑒𐑨𐑯𐑪𐑑 𐑚𐑰 𐑛𐑦𐑤𐑰𐑑𐑩𐑛"
+
+#: ../capplets/appearance/theme-util.c:252
+msgid "Could not install theme engine"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑔𐑰𐑥 𐑧𐑯𐑡𐑦𐑯"
+
+#: ../capplets/common/activate-settings-daemon.c:16
+#, fuzzy
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with DBus, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑕𐑑𐑸𐑑 𐑞 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼 '·𐑯𐑴𐑥-𐑕𐑧𐑑𐑦𐑙𐑟-𐑛𐑰𐑥𐑩𐑯'.\n"
+"𐑢𐑦𐑞𐑬𐑑 𐑞 ·𐑯𐑴𐑥 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼 𐑮𐑳𐑯𐑦𐑙, 𐑕𐑳𐑥 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟 𐑥𐑱 𐑯𐑪𐑑 𐑑𐑱𐑒 𐑦𐑓𐑧𐑒𐑑. 𐑞𐑦𐑕 𐑒𐑫𐑛 "
+"𐑦𐑯𐑛𐑦𐑒𐑱𐑑 𐑩 𐑐𐑮𐑪𐑚𐑤𐑩𐑥 𐑢𐑦𐑞 DBus, 𐑹 𐑩 𐑯𐑪𐑯-·𐑯𐑴𐑥 (𐑧.𐑡𐑰. ·𐑒·𐑛·𐑧) 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼 𐑥𐑱 "
+"𐑷𐑤𐑮𐑧𐑛𐑦 𐑚𐑰 𐑨𐑒𐑑𐑦𐑝 𐑯 𐑒𐑩𐑯𐑓𐑤𐑦𐑒𐑑𐑦𐑙 𐑢𐑦𐑞 𐑞 ·𐑯𐑴𐑥 𐑕𐑧𐑑𐑦𐑙𐑟 𐑥𐑨𐑯𐑩𐑡𐑼."
+
+#: ../capplets/common/capplet-stock-icons.c:66
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑤𐑴𐑛 𐑕𐑑𐑪𐑒 𐑲𐑒𐑪𐑯 '%s'\n"
+
+#: ../capplets/common/capplet-util.c:88
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "𐑞𐑺 𐑢𐑪𐑟 𐑩𐑯 𐑻𐑼 𐑛𐑦𐑕𐑐𐑤𐑱𐑦𐑙 𐑣𐑧𐑤𐑐: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:98
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "𐑒𐑪𐑐𐑦𐑦𐑙 𐑓𐑲𐑤: %u 𐑝 %u"
+
+#: ../capplets/common/file-transfer-dialog.c:145
+#, c-format
+msgid "Copying '%s'"
+msgstr "𐑒𐑪𐑐𐑦𐑦𐑙 '%s'"
+
+#: ../capplets/common/file-transfer-dialog.c:185
+#: ../capplets/common/file-transfer-dialog.c:313
+msgid "Copying files"
+msgstr "𐑒𐑪𐑐𐑦𐑦𐑙 𐑓𐑲𐑤𐑟"
+
+#: ../capplets/common/file-transfer-dialog.c:224
+msgid "Parent Window"
+msgstr "𐑐𐑺𐑩𐑯𐑑 𐑢𐑦𐑯𐑛𐑴"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Parent window of the dialog"
+msgstr "𐑐𐑺𐑩𐑯𐑑 𐑢𐑦𐑯𐑛𐑴 𐑝 𐑞 𐑛𐑲𐑩𐑤𐑪𐑜"
+
+#: ../capplets/common/file-transfer-dialog.c:231
+msgid "From URI"
+msgstr "𐑓𐑮𐑪𐑥 URI"
+
+#: ../capplets/common/file-transfer-dialog.c:232
+msgid "URI currently transferring from"
+msgstr "URI 𐑒𐑳𐑮𐑩𐑯𐑑𐑤𐑦 𐑑𐑮𐑨𐑯𐑕𐑓𐑻𐑦𐑙 𐑓𐑮𐑪𐑥"
+
+#: ../capplets/common/file-transfer-dialog.c:239
+msgid "To URI"
+msgstr "𐑑 URI"
+
+#: ../capplets/common/file-transfer-dialog.c:240
+msgid "URI currently transferring to"
+msgstr "URI 𐑒𐑳𐑮𐑩𐑯𐑑𐑤𐑦 𐑑𐑮𐑨𐑯𐑕𐑓𐑻𐑦𐑙 𐑑"
+
+#: ../capplets/common/file-transfer-dialog.c:247
+msgid "Fraction completed"
+msgstr "𐑓𐑮𐑨𐑒𐑖𐑩𐑯 𐑒𐑩𐑥𐑐𐑤𐑰𐑑𐑩𐑛"
+
+#: ../capplets/common/file-transfer-dialog.c:248
+msgid "Fraction of transfer currently completed"
+msgstr "𐑓𐑮𐑨𐑒𐑖𐑩𐑯 𐑝 𐑑𐑮𐑭𐑯𐑕𐑓𐑼 𐑒𐑳𐑮𐑩𐑯𐑑𐑤𐑦 𐑒𐑩𐑥𐑐𐑤𐑰𐑑𐑩𐑛"
+
+#: ../capplets/common/file-transfer-dialog.c:255
+msgid "Current URI index"
+msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 URI 𐑦𐑯𐑛𐑧𐑒𐑕"
+
+#: ../capplets/common/file-transfer-dialog.c:256
+msgid "Current URI index - starts from 1"
+msgstr "𐑒𐑳𐑮𐑩𐑯𐑑 URI 𐑦𐑯𐑛𐑧𐑒𐑕 - 𐑕𐑑𐑸𐑑𐑕 𐑓𐑮𐑪𐑥 1"
+
+#: ../capplets/common/file-transfer-dialog.c:263
+#, fuzzy
+msgid "Total URIs"
+msgstr "𐑑𐑴𐑑𐑩𐑤 URIs"
+
+#: ../capplets/common/file-transfer-dialog.c:264
+#, fuzzy
+msgid "Total number of URIs"
+msgstr "𐑑𐑴𐑑𐑩𐑤 𐑯𐑳𐑥𐑚𐑼 𐑝 URIs"
+
+#: ../capplets/common/file-transfer-dialog.c:445
+#, c-format
+msgid "File '%s' already exists. Do you want to overwrite it?"
+msgstr "𐑓𐑲𐑤 '%s' 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕. 𐑛𐑵 𐑿 𐑢𐑪𐑯𐑑 𐑑 𐑴𐑝𐑼𐑮𐑲𐑑 𐑦𐑑?"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "_Skip"
+msgstr "_𐑕𐑒𐑦𐑐"
+
+#: ../capplets/common/file-transfer-dialog.c:449
+msgid "Overwrite _All"
+msgstr "𐑴𐑝𐑼𐑮𐑲𐑑 _𐑷𐑤"
+
+#: ../capplets/common/gconf-property-editor.c:134
+msgid "Key"
+msgstr "𐑒𐑰"
+
+#: ../capplets/common/gconf-property-editor.c:135
+#, fuzzy
+msgid "GConf key to which this property editor is attached"
+msgstr "GConf 𐑒𐑰 𐑑 𐑢𐑦𐑗 𐑞𐑦𐑕 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑦𐑟 𐑩𐑑𐑨𐑗𐑑"
+
+#: ../capplets/common/gconf-property-editor.c:141
+#, fuzzy
+msgid "Callback"
+msgstr "Callback"
+
+#: ../capplets/common/gconf-property-editor.c:142
+#, fuzzy
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "𐑦𐑖𐑵 𐑞𐑦𐑕 callback 𐑢𐑧𐑯 𐑞 𐑝𐑨𐑤𐑿 𐑩𐑕𐑴𐑖𐑦𐑱𐑑𐑩𐑛 𐑢𐑦𐑞 𐑒𐑰 𐑜𐑧𐑑𐑕 𐑗𐑱𐑯𐑡𐑛"
+
+#: ../capplets/common/gconf-property-editor.c:147
+msgid "Change set"
+msgstr "𐑗𐑱𐑯𐑡 𐑕𐑧𐑑"
+
+#: ../capplets/common/gconf-property-editor.c:148
+#, fuzzy
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr "GConf 𐑗𐑱𐑯𐑡 𐑕𐑧𐑑 𐑒𐑩𐑯𐑑𐑱𐑯𐑦𐑙 𐑛𐑱𐑑𐑩 𐑑 𐑚𐑰 𐑓𐑪𐑮𐑢𐑻𐑛𐑦𐑛 𐑑 𐑞 gconf 𐑒𐑤𐑲𐑩𐑯𐑑 𐑪𐑯 𐑩𐑐𐑤𐑲"
+
+#: ../capplets/common/gconf-property-editor.c:153
+#, fuzzy
+msgid "Conversion to widget callback"
+msgstr "𐑒𐑩𐑯𐑝𐑻𐑖𐑩𐑯 𐑑 𐑢𐑦𐑡𐑩𐑑 callback"
+
+#: ../capplets/common/gconf-property-editor.c:154
+#, fuzzy
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "Callback 𐑑 𐑚𐑰 𐑦𐑖𐑵𐑛 𐑢𐑧𐑯 𐑛𐑱𐑑𐑩 𐑸 𐑑 𐑚𐑰 𐑒𐑩𐑯𐑝𐑻𐑑𐑩𐑛 𐑓𐑮𐑪𐑥 GConf 𐑑 𐑞 𐑢𐑦𐑡𐑩𐑑"
+
+#: ../capplets/common/gconf-property-editor.c:159
+#, fuzzy
+msgid "Conversion from widget callback"
+msgstr "𐑒𐑩𐑯𐑝𐑻𐑖𐑩𐑯 𐑓𐑮𐑪𐑥 𐑢𐑦𐑡𐑩𐑑 callback"
+
+#: ../capplets/common/gconf-property-editor.c:160
+#, fuzzy
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr "Callback 𐑑 𐑚𐑰 𐑦𐑖𐑵𐑛 𐑢𐑧𐑯 𐑛𐑱𐑑𐑩 𐑸 𐑑 𐑚𐑰 𐑒𐑩𐑯𐑝𐑻𐑑𐑩𐑛 𐑑 GConf 𐑓𐑮𐑪𐑥 𐑞 𐑢𐑦𐑡𐑩𐑑"
+
+#: ../capplets/common/gconf-property-editor.c:165
+#, fuzzy
+msgid "UI Control"
+msgstr "UI 𐑒𐑩𐑯𐑑𐑮𐑴𐑤"
+
+#: ../capplets/common/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr "𐑩𐑚𐑡𐑧𐑒𐑑 𐑞𐑨𐑑 𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑟 𐑞 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 (𐑯𐑹𐑥𐑩𐑤𐑦 𐑩 𐑢𐑦𐑡𐑩𐑑)"
+
+#: ../capplets/common/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr "𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑩𐑚𐑡𐑧𐑒𐑑 𐑛𐑱𐑑𐑩"
+
+#: ../capplets/common/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑛𐑱𐑑𐑩 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑚𐑲 𐑞 𐑕𐑐𐑩𐑕𐑦𐑓𐑦𐑒 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹"
+
+#: ../capplets/common/gconf-property-editor.c:188
+#, fuzzy
+msgid "Property editor data freeing callback"
+msgstr "𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑛𐑱𐑑𐑩 𐑓𐑮𐑰𐑦𐑙 callback"
+
+#: ../capplets/common/gconf-property-editor.c:189
+#, fuzzy
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr "Callback 𐑑 𐑚𐑰 𐑦𐑖𐑵𐑛 𐑢𐑧𐑯 𐑐𐑮𐑪𐑐𐑼𐑑𐑦 𐑧𐑛𐑦𐑑𐑹 𐑩𐑚𐑡𐑧𐑒𐑑 𐑛𐑱𐑑𐑩 𐑦𐑟 𐑑 𐑚𐑰 𐑓𐑮𐑰𐑛"
+
+#: ../capplets/common/gconf-property-editor.c:1406
+#, fuzzy
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"𐑒𐑫𐑛𐑯𐑑 𐑓𐑲𐑯𐑛 𐑞 𐑓𐑲𐑤 '%s'.\n"
+"\n"
+"𐑐𐑤𐑰𐑟 𐑥𐑱𐑒 𐑖𐑫𐑼 𐑦𐑑 𐑧𐑒𐑟𐑦𐑕𐑑𐑕 𐑯 𐑑𐑮𐑲 𐑩𐑜𐑱𐑯, 𐑹 𐑗𐑵𐑟 𐑩 𐑛𐑦𐑓𐑼𐑩𐑯𐑑 𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑐𐑦𐑒𐑗𐑼."
+
+#: ../capplets/common/gconf-property-editor.c:1414
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"𐑲 𐑛𐑴𐑯𐑑 𐑯𐑴 𐑣𐑬 𐑑 𐑴𐑐𐑩𐑯 𐑞 𐑓𐑲𐑤 '%s'.\n"
+"𐑐𐑼𐑣𐑨𐑐𐑕 𐑦𐑑'𐑕 𐑩 𐑒𐑲𐑯𐑛 𐑝 𐑐𐑦𐑒𐑗𐑼 𐑞𐑨𐑑 𐑦𐑟 𐑯𐑪𐑑 𐑘𐑧𐑑 𐑕𐑩𐑐𐑹𐑑𐑩𐑛.\n"
+"\n"
+"𐑐𐑤𐑰𐑟 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑛𐑦𐑓𐑼𐑩𐑯𐑑 𐑐𐑦𐑒𐑗𐑼 𐑦𐑯𐑕𐑑𐑧𐑛."
+
+#: ../capplets/common/gconf-property-editor.c:1536
+msgid "Please select an image."
+msgstr "𐑐𐑤𐑰𐑟 𐑕𐑩𐑤𐑧𐑒𐑑 𐑩𐑯 𐑦𐑥𐑦𐑡."
+
+#: ../capplets/common/gconf-property-editor.c:1541
+msgid "_Select"
+msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑"
+
+#: ../capplets/common/gnome-theme-info.c:639
+msgid "Default Pointer - Current"
+msgstr "𐑛𐑦𐑓𐑷𐑤𐑑 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
+
+#: ../capplets/common/gnome-theme-info.c:643
+msgid "White Pointer"
+msgstr "𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#: ../capplets/common/gnome-theme-info.c:644
+msgid "White Pointer - Current"
+msgstr "𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
+
+#: ../capplets/common/gnome-theme-info.c:648
+msgid "Large Pointer"
+msgstr "𐑤𐑸𐑡 𐑐𐑶𐑯𐑑𐑼"
+
+#: ../capplets/common/gnome-theme-info.c:649
+msgid "Large Pointer - Current"
+msgstr "𐑤𐑸𐑡 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
+
+#: ../capplets/common/gnome-theme-info.c:653
+msgid "Large White Pointer - Current"
+msgstr "𐑤𐑸𐑡 𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼 - 𐑒𐑳𐑮𐑩𐑯𐑑"
+
+#: ../capplets/common/gnome-theme-info.c:654
+msgid "Large White Pointer"
+msgstr "𐑤𐑸𐑡 𐑢𐑲𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#: ../capplets/common/gnome-theme-info.c:1622
+#, fuzzy
+msgid ""
+"This theme will not look as intended because the required GTK+ theme '%s' is "
+"not installed."
+msgstr ""
+"𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 GTK+ 𐑔𐑰𐑥 '%s' 𐑦𐑟 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#: ../capplets/common/gnome-theme-info.c:1630
+#, c-format
+msgid ""
+"This theme will not look as intended because the required window manager "
+"theme '%s' is not installed."
+msgstr ""
+"𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑢𐑦𐑯𐑛𐑴 𐑥𐑨𐑯𐑩𐑡𐑼 𐑔𐑰𐑥 '%s' 𐑦𐑟 𐑯𐑪𐑑 "
+"𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#: ../capplets/common/gnome-theme-info.c:1637
+#, c-format
+msgid ""
+"This theme will not look as intended because the required icon theme '%s' is "
+"not installed."
+msgstr ""
+"𐑞𐑦𐑕 𐑔𐑰𐑥 𐑢𐑦𐑤 𐑯𐑪𐑑 𐑤𐑫𐑒 𐑨𐑟 𐑦𐑯𐑑𐑧𐑯𐑛𐑩𐑛 𐑚𐑦𐑒𐑪𐑟 𐑞 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑲𐑒𐑪𐑯 𐑔𐑰𐑥 '%s' 𐑦𐑟 𐑯𐑪𐑑 𐑦𐑯𐑕𐑑𐑷𐑤𐑛."
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:17
+msgid "Preferred Applications"
+msgstr "𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑿𐑼 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+#, fuzzy
+msgid "Start the preferred visual assistive technology"
+msgstr "𐑕𐑑𐑸𐑑 𐑞 𐑐𐑮𐑦𐑓𐑻𐑛 𐑝𐑦𐑠𐑩𐑢𐑩𐑤 assistive 𐑑𐑧𐑒𐑯𐑭𐑤𐑩𐑡𐑰"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤 𐑩𐑕𐑦𐑕𐑑𐑩𐑯𐑕"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:98
+#: ../capplets/default-applications/gnome-da-capplet.c:362
+#: ../capplets/default-applications/gnome-da-capplet.c:383
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "𐑻𐑼 𐑕𐑱𐑝𐑦𐑙 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:722
+msgid "Could not load the main interface"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑤𐑴𐑛 𐑞 𐑥𐑱𐑯 𐑦𐑯𐑑𐑼𐑓𐑱𐑕"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:724
+msgid "Please make sure that the applet is properly installed"
+msgstr "𐑐𐑤𐑰𐑟 𐑥𐑱𐑒 𐑖𐑫𐑼 𐑞𐑨𐑑 𐑞 𐑨𐑐𐑤𐑩𐑑 𐑦𐑟 𐑐𐑮𐑪𐑐𐑼𐑤𐑦 𐑦𐑯𐑕𐑑𐑷𐑤𐑛"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/default-applications/gnome-da-capplet.c:959
+msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑯𐑱𐑥 𐑝 𐑞 𐑐𐑱𐑡 𐑑 𐑖𐑴 (internet|multimedia|system|a11y)"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:964
+msgid "- GNOME Default Applications"
+msgstr "- ·𐑜𐑯𐑴𐑥 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:1
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:1
+msgid "Accessibility"
+msgstr "𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:3
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "𐑷𐑤 %s 𐑩𐑒𐑻𐑩𐑯𐑕𐑦𐑟 𐑢𐑦𐑤 𐑚𐑰 𐑮𐑦𐑐𐑤𐑱𐑕𐑑 𐑢𐑦𐑞 𐑨𐑒𐑗𐑫𐑩𐑤 𐑤𐑦𐑙𐑒"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:4
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:1
+msgid "C_ommand:"
+msgstr "_𐑒𐑩𐑥𐑭𐑯𐑛:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:5
+msgid "Co_mmand:"
+msgstr "_𐑒𐑩𐑥𐑭𐑯𐑛:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:6
+msgid "E_xecute flag:"
+msgstr "_𐑧𐑒𐑕𐑩𐑒𐑿𐑑 𐑓𐑤𐑨𐑜:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:7
+msgid "Image Viewer"
+msgstr "𐑦𐑥𐑦𐑡 𐑝𐑿𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:8
+msgid "Instant Messenger"
+msgstr "𐑦𐑯𐑕𐑑𐑩𐑯𐑑 𐑥𐑧𐑕𐑩𐑯𐑡𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:9
+msgid "Internet"
+msgstr "·𐑦𐑯𐑑𐑼𐑯𐑧𐑑"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:10
+msgid "Mail Reader"
+msgstr "𐑥𐑱𐑤 𐑮𐑰𐑛𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:11
+msgid "Mobility"
+msgstr "𐑥𐑴𐑚𐑦𐑤𐑩𐑑𐑰"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:12
+msgid "Multimedia"
+msgstr "𐑥𐑩𐑤𐑑𐑰𐑥𐑰𐑛𐑰𐑩"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:13
+msgid "Multimedia Player"
+msgstr "𐑥𐑩𐑤𐑑𐑰𐑥𐑰𐑛𐑰𐑩 𐑐𐑤𐑱𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:14
+msgid "Open link in new _tab"
+msgstr "𐑴𐑐𐑩𐑯 𐑤𐑦𐑙𐑒 𐑦𐑯 𐑯𐑿 _𐑑𐑨𐑚"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:15
+msgid "Open link in new _window"
+msgstr "𐑴𐑐𐑩𐑯 𐑤𐑦𐑙𐑒 𐑦𐑯 𐑯𐑿 _𐑢𐑦𐑯𐑛𐑴"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:16
+msgid "Open link with web browser _default"
+msgstr "𐑴𐑐𐑩𐑯 𐑤𐑦𐑙𐑒 𐑢𐑦𐑞 𐑢𐑧𐑚 𐑚𐑮𐑬𐑟𐑼 _𐑛𐑦𐑓𐑷𐑤𐑑"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:18
+msgid "Run at st_art"
+msgstr "𐑮𐑳𐑯 𐑨𐑑 _𐑕𐑑𐑸𐑑"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:19
+msgid "Run in t_erminal"
+msgstr "𐑮𐑳𐑯 𐑦𐑯 _𐑑𐑻𐑥𐑦𐑯𐑩𐑤"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:20
+msgid "System"
+msgstr "𐑕𐑦𐑕𐑑𐑩𐑥"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:21
+#, fuzzy
+msgid "Terminal Emulator"
+msgstr "𐑑𐑻𐑥𐑦𐑯𐑩𐑤 Emulator"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:22
+msgid "Text Editor"
+msgstr "𐑑𐑧𐑒𐑕𐑑 𐑧𐑛𐑦𐑑𐑹"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:23
+msgid "Video Player"
+msgstr "𐑝𐑦𐑛𐑦𐑴 𐑐𐑤𐑱𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:24
+msgid "Visual"
+msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:25
+msgid "Web Browser"
+msgstr "𐑢𐑧𐑚 𐑚𐑮𐑬𐑟𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:26
+msgid "_Run at start"
+msgstr "_𐑮𐑳𐑯 𐑨𐑑 𐑕𐑑𐑸𐑑"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "·𐑚𐑪𐑤𐑕𐑩"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr "·𐑚𐑨𐑯𐑖𐑰 𐑥𐑿𐑟𐑦𐑒 𐑐𐑤𐑱𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr "·𐑒𐑤𐑷𐑟 𐑥𐑱𐑤"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr "·𐑛𐑨𐑖𐑻"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+#, fuzzy
+msgid "Debian Sensible Browser"
+msgstr "Debian 𐑕𐑧𐑯𐑕𐑩𐑚𐑩𐑤 𐑚𐑮𐑬𐑟𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+#, fuzzy
+msgid "Debian Terminal Emulator"
+msgstr "Debian 𐑑𐑻𐑥𐑦𐑯𐑩𐑤 Emulator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+#, fuzzy
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr "·𐑦𐑯𐑒𐑳𐑥𐑐𐑩𐑕"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr "·𐑦𐑐𐑦𐑓𐑩𐑯𐑦 𐑢𐑧𐑚 𐑚𐑮𐑬𐑟𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr "·𐑧𐑝𐑩𐑤𐑵𐑖𐑩𐑯 𐑥𐑱𐑤 𐑮𐑰𐑛𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr "·𐑓𐑲𐑻𐑚𐑻𐑛"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+#, fuzzy
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr "·𐑜𐑯𐑴𐑥 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻 𐑢𐑦𐑞𐑬𐑑 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr "·𐑜𐑯𐑴𐑥 𐑭𐑯𐑕𐑒𐑮𐑰𐑯 𐑒𐑰𐑚𐑪𐑮𐑛"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr "·𐑜𐑯𐑴𐑥 𐑑𐑻𐑥𐑦𐑯𐑩𐑤"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+#, fuzzy
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+#, fuzzy
+msgid "Gnopernicus"
+msgstr "Gnopernicus"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+#, fuzzy
+msgid "Gnopernicus with Magnifier"
+msgstr "Gnopernicus 𐑢𐑦𐑞 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+#, fuzzy
+msgid "Iceape"
+msgstr "Iceape"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+#, fuzzy
+msgid "Iceape Mail"
+msgstr "Iceape 𐑥𐑱𐑤"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+#, fuzzy
+msgid "Icedove"
+msgstr "Icedove"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+#, fuzzy
+msgid "Iceweasel"
+msgstr "Iceweasel"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr "KDE 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻 𐑢𐑦𐑞𐑬𐑑 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr "·𐑒𐑱𐑥𐑱𐑤"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr "·𐑒𐑪𐑙𐑒𐑼𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+#, fuzzy
+msgid "Konsole"
+msgstr "Konsole"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr "·𐑤𐑦𐑯𐑩𐑒𐑕 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr "·𐑤𐑦𐑯𐑩𐑒𐑕 𐑕𐑒𐑮𐑰𐑯 𐑮𐑰𐑛𐑼 𐑢𐑦𐑞 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Listen"
+msgstr "·𐑤𐑦𐑕𐑩𐑯"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+#, fuzzy
+msgid "Midori"
+msgstr "Midori"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+#, fuzzy
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+#, fuzzy
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+#, fuzzy
+msgid "Mozilla Mail"
+msgstr "Mozilla 𐑥𐑱𐑤"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+#, fuzzy
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla 𐑔𐑩𐑯𐑛𐑻𐑚𐑻𐑛"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+#, fuzzy
+msgid "Muine Music Player"
+msgstr "Muine 𐑥𐑿𐑟𐑦𐑒 𐑐𐑤𐑱𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "Mutt"
+msgstr "·𐑥𐑩𐑑"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+#, fuzzy
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Netscape Communicator"
+msgstr "·𐑯𐑧𐑑𐑕𐑒𐑱𐑐 ·𐑒𐑩𐑥𐑘𐑵𐑯𐑩𐑒𐑱𐑑𐑻"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Opera"
+msgstr "·𐑪𐑐𐑼𐑩"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca"
+msgstr "·𐑪𐑮𐑒𐑩"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "Orca with Magnifier"
+msgstr "·𐑪𐑮𐑒𐑩 𐑢𐑦𐑞 𐑥𐑨𐑜𐑯𐑩𐑓𐑲𐑻"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+#, fuzzy
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+#, fuzzy
+msgid "Rhythmbox Music Player"
+msgstr "Rhythmbox 𐑥𐑿𐑟𐑦𐑒 𐑐𐑤𐑱𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+#, fuzzy
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+#, fuzzy
+msgid "SeaMonkey Mail"
+msgstr "SeaMonkey 𐑥𐑱𐑤"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+#, fuzzy
+msgid "Standard XTerminal"
+msgstr "𐑕𐑑𐑨𐑯𐑛𐑼𐑛 XTerminal"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+#, fuzzy
+msgid "Sylpheed"
+msgstr "Sylpheed"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+#, fuzzy
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-𐑒𐑤𐑷𐑟"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Terminator"
+msgstr "·𐑑𐑻𐑥𐑩𐑯𐑱𐑑𐑻"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Thunderbird"
+msgstr "·𐑔𐑩𐑯𐑛𐑻𐑚𐑻𐑛"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "Totem Movie Player"
+msgstr "·𐑑𐑴𐑑𐑩𐑥 𐑥𐑵𐑝𐑰 𐑐𐑤𐑱𐑼"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
+#, fuzzy
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/display/display-capplet.ui.h:1
+msgid "Include _panel"
+msgstr "𐑦𐑯𐑒𐑤𐑵𐑛 _𐑐𐑨𐑯𐑩𐑤"
+
+#: ../capplets/display/display-capplet.ui.h:2
+#: ../capplets/display/xrandr-capplet.c:310
+msgid "Left"
+msgstr "𐑤𐑧𐑓𐑑"
+
+#: ../capplets/display/display-capplet.ui.h:3
+msgid "Make Default"
+msgstr "𐑥𐑱𐑒 𐑛𐑦𐑓𐑷𐑤𐑑"
+
+#: ../capplets/display/display-capplet.ui.h:4
+#: ../capplets/display/xrandr-capplet.c:513
+msgid "Monitor"
+msgstr "𐑥𐑪𐑯𐑦𐑑𐑼"
+
+#: ../capplets/display/display-capplet.ui.h:5
+msgid "Monitor Preferences"
+msgstr "𐑥𐑪𐑯𐑦𐑑𐑼 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/display/display-capplet.ui.h:6
+#: ../capplets/display/xrandr-capplet.c:309
+#: ../capplets/display/xrandr-capplet.c:348
+msgid "Normal"
+msgstr "𐑯𐑹𐑥𐑩𐑤"
+
+#: ../capplets/display/display-capplet.ui.h:7
+msgid "Off"
+msgstr "𐑪𐑓"
+
+#: ../capplets/display/display-capplet.ui.h:8
+msgid "On"
+msgstr "𐑪𐑯"
+
+#: ../capplets/display/display-capplet.ui.h:9
+msgid "Panel icon"
+msgstr "𐑐𐑨𐑯𐑩𐑤 𐑲𐑒𐑪𐑯"
+
+#: ../capplets/display/display-capplet.ui.h:10
+msgid "R_otation:"
+msgstr "_𐑮𐑴𐑑𐑱𐑖𐑩𐑯:"
+
+#: ../capplets/display/display-capplet.ui.h:11
+msgid "Re_fresh rate:"
+msgstr "_𐑮𐑰𐑓𐑮𐑧𐑖 𐑮𐑱𐑑:"
+
+#: ../capplets/display/display-capplet.ui.h:12
+#: ../capplets/display/xrandr-capplet.c:311
+msgid "Right"
+msgstr "𐑮𐑲𐑑"
+
+#: ../capplets/display/display-capplet.ui.h:13
+msgid "Sa_me image in all monitors"
+msgstr "_𐑕𐑱𐑥 𐑦𐑥𐑦𐑡 𐑦𐑯 𐑷𐑤 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#: ../capplets/display/display-capplet.ui.h:14
+msgid "Upside-down"
+msgstr "𐑳𐑐𐑕𐑲𐑛-𐑛𐑬𐑯"
+
+#: ../capplets/display/display-capplet.ui.h:15
+msgid "_Detect monitors"
+msgstr "_𐑛𐑦𐑑𐑧𐑒𐑑 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#: ../capplets/display/display-capplet.ui.h:16
+msgid "_Resolution:"
+msgstr "_𐑮𐑧𐑟𐑩𐑤𐑵𐑖𐑩𐑯:"
+
+#: ../capplets/display/display-capplet.ui.h:17
+msgid "_Show monitors in panel"
+msgstr "_𐑖𐑴 𐑥𐑪𐑯𐑦𐑑𐑼𐑟 𐑦𐑯 𐑐𐑨𐑯𐑩𐑤"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change resolution and position of monitors"
+msgstr "𐑗𐑱𐑯𐑡 𐑮𐑧𐑟𐑩𐑤𐑵𐑖𐑩𐑯 𐑯 𐑐𐑩𐑟𐑦𐑖𐑩𐑯 𐑝 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Monitors"
+msgstr "𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:44
+#, fuzzy
+msgid ""
+"Usage: %s SOURCE_FILE DEST_NAME\n"
+"\n"
+"This program installs a RANDR profile for multi-monitor setups into\n"
+"a systemwide location.  The resulting profile will get used when\n"
+"the RANDR plug-in gets run in gnome-settings-daemon.\n"
+"\n"
+"SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+"xml\n"
+"\n"
+"DEST_NAME - relative name for the installed file.  This will get put in\n"
+"            the systemwide directory for RANDR configurations,\n"
+"            so the result will typically be %s/DEST_NAME\n"
+msgstr ""
+"𐑿𐑕𐑦𐑡: %s _SOURCEFILE _DESTNAME\n"
+"\n"
+"𐑞𐑦𐑕 𐑐𐑮𐑴𐑜𐑮𐑨𐑥 𐑦𐑯𐑕𐑑𐑷𐑤𐑟 𐑩 RANDR 𐑐𐑮𐑴𐑓𐑲𐑤 𐑓𐑹 𐑥𐑩𐑤𐑑𐑰-𐑥𐑪𐑯𐑦𐑑𐑼 𐑕𐑧𐑑𐑩𐑐𐑕 𐑦𐑯𐑑𐑫\n"
+"𐑩 𐑕𐑦𐑕𐑑𐑩𐑥𐑢𐑲𐑛 𐑤𐑴𐑒𐑱𐑖𐑩𐑯.  𐑞 𐑮𐑦𐑟𐑳𐑤𐑑𐑦𐑙 𐑐𐑮𐑴𐑓𐑲𐑤 𐑢𐑦𐑤 𐑜𐑧𐑑 𐑿𐑟𐑛 𐑢𐑧𐑯\n"
+"𐑞 RANDR 𐑐𐑤𐑳𐑜-𐑦𐑯 𐑜𐑧𐑑𐑕 𐑮𐑳𐑯 𐑦𐑯 ·𐑯𐑴𐑥-𐑕𐑧𐑑𐑦𐑙𐑟-𐑛𐑰𐑥𐑩𐑯.\n"
+"\n"
+"_SOURCEFILE - 𐑩 𐑓𐑫𐑤 pathname, 𐑑𐑦𐑐𐑦𐑒𐑤𐑰 /𐑣𐑴𐑥/𐑿𐑟𐑼𐑯𐑱𐑥/.𐑒𐑪𐑯𐑓𐑦𐑜/𐑥𐑪𐑯𐑦𐑑𐑼𐑟.·𐑦·𐑥·𐑤\n"
+"\n"
+"_DESTNAME - 𐑮𐑧𐑤𐑩𐑑𐑦𐑝 𐑯𐑱𐑥 𐑓𐑹 𐑞 𐑦𐑯𐑕𐑑𐑷𐑤𐑛 𐑓𐑲𐑤.  𐑞𐑦𐑕 𐑢𐑦𐑤 𐑜𐑧𐑑 𐑐𐑫𐑑 𐑦𐑯\n"
+"            𐑞 𐑕𐑦𐑕𐑑𐑩𐑥𐑢𐑲𐑛 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦 𐑓𐑹 RANDR 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯𐑟,\n"
+"            𐑕𐑴 𐑞 𐑮𐑦𐑟𐑳𐑤𐑑 𐑢𐑦𐑤 𐑑𐑦𐑐𐑦𐑒𐑤𐑰 𐑚𐑰 %s/_DESTNAME\n"
+
+#. Translators: only able to install RANDR profiles as root
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:151
+msgid "This program can only be used by the root user"
+msgstr "𐑞𐑦𐑕 𐑐𐑮𐑴𐑜𐑮𐑨𐑥 𐑒𐑨𐑯 𐑴𐑯𐑤𐑦 𐑚𐑰 𐑿𐑟𐑛 𐑚𐑲 𐑞 𐑮𐑵𐑑 𐑿𐑟𐑼"
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:168
+msgid "The source filename must be absolute"
+msgstr "𐑞 𐑕𐑹𐑕 𐑓𐑲𐑤𐑯𐑱𐑥 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑨𐑚𐑕𐑴𐑤𐑵𐑑"
+
+#. Translators: first %s is a filename; second %s is an error message
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:179
+#, fuzzy
+msgid "Could not open %s: %s\n"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑴𐑐𐑩𐑯 %s: %s\n"
+
+#. Translators: first %s is a filename; second %s is an error message
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:188
+#, fuzzy
+msgid "Could not get information for %s: %s\n"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑜𐑧𐑑 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯 𐑓𐑹 %s: %s\n"
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:195
+#, fuzzy
+msgid "%s must be a regular file\n"
+msgstr "%s 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑩 𐑮𐑧𐑜𐑘𐑫𐑤𐑼 𐑓𐑲𐑤\n"
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:204
+#, fuzzy
+msgid "This program must only be run through pkexec(1)"
+msgstr "𐑞𐑦𐑕 𐑐𐑮𐑴𐑜𐑮𐑨𐑥 𐑥𐑳𐑕𐑑 𐑴𐑯𐑤𐑦 𐑚𐑰 𐑮𐑳𐑯 𐑔𐑮𐑵 pkexec(1)"
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:209
+#, fuzzy
+msgid "PKEXEC_UID must be set to an integer value"
+msgstr "_PKEXECUID 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑕𐑧𐑑 𐑑 𐑩𐑯 𐑦𐑯𐑑𐑩𐑡𐑼 𐑝𐑨𐑤𐑿"
+
+#. Translators: we are complaining that a file must be really owned by the user who called this program
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:215
+#, fuzzy
+msgid "%s must be owned by you\n"
+msgstr "%s 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑴𐑯𐑛 𐑚𐑲 𐑿\n"
+
+#. Translators: here we are saying that a plain filename must look like "filename", not like "some_dir/filename"
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:223
+#, fuzzy
+msgid "%s must not have any directory components\n"
+msgstr "%s 𐑥𐑳𐑕𐑑 𐑯𐑪𐑑 𐑣𐑨𐑝 𐑧𐑯𐑦 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦 𐑒𐑩𐑥𐑐𐑴𐑯𐑩𐑯𐑑𐑕\n"
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:231
+#, fuzzy
+msgid "%s must be a directory\n"
+msgstr "%s 𐑥𐑳𐑕𐑑 𐑚𐑰 𐑩 𐑛𐑲𐑮𐑧𐑒𐑑𐑼𐑦\n"
+
+#. Translators: the first %s/%s is a directory/filename; the last %s is an error message
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:242
+#, fuzzy
+msgid "Could not open %s/%s: %s\n"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑴𐑐𐑩𐑯 %s/%s: %s\n"
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:262
+#, fuzzy
+msgid "Could not rename %s to %s: %s\n"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑮𐑰𐑯𐑱𐑥 %s 𐑑 %s: %s\n"
+
+#: ../capplets/display/org.gnome.randr.policy.in.h:1
+msgid ""
+"Authentication is required to install multi-monitor settings for all users"
+msgstr "𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑖𐑩𐑯 𐑦𐑟 𐑮𐑦𐑒𐑢𐑲𐑼𐑛 𐑑 𐑦𐑯𐑕𐑑𐑷𐑤 𐑥𐑩𐑤𐑑𐑰-𐑥𐑪𐑯𐑦𐑑𐑼 𐑕𐑧𐑑𐑦𐑙𐑟 𐑓𐑹 𐑷𐑤 𐑿𐑟𐑼𐑟"
+
+#: ../capplets/display/org.gnome.randr.policy.in.h:2
+msgid "Install multi-monitor settings for the whole system"
+msgstr "𐑦𐑯𐑕𐑑𐑷𐑤 𐑥𐑩𐑤𐑑𐑰-𐑥𐑪𐑯𐑦𐑑𐑼 𐑕𐑧𐑑𐑦𐑙𐑟 𐑓𐑹 𐑞 𐑣𐑴𐑤 𐑕𐑦𐑕𐑑𐑩𐑥"
+
+#: ../capplets/display/xrandr-capplet.c:312
+msgid "Upside Down"
+msgstr "𐑳𐑐𐑕𐑲𐑛 𐑛𐑬𐑯"
+
+#: ../capplets/display/xrandr-capplet.c:354
+#, fuzzy
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../capplets/display/xrandr-capplet.c:502
+#: ../capplets/display/xrandr-capplet.c:1648
+msgid "Mirror Screens"
+msgstr "𐑥𐑦𐑮𐑼 𐑕𐑒𐑮𐑰𐑯𐑟"
+
+#: ../capplets/display/xrandr-capplet.c:504
+#, c-format
+msgid "Monitor: %s"
+msgstr "𐑥𐑪𐑯𐑦𐑑𐑼: %s"
+
+#: ../capplets/display/xrandr-capplet.c:582
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#: ../capplets/display/xrandr-capplet.c:1504
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑥𐑪𐑯𐑦𐑑𐑼 𐑑 𐑗𐑱𐑯𐑡 𐑦𐑑𐑕 𐑐𐑮𐑪𐑐𐑼𐑑𐑦𐑟; 𐑛𐑮𐑨𐑜 𐑦𐑑 𐑑 𐑮𐑰𐑻𐑱𐑯𐑡 𐑦𐑑𐑕 𐑐𐑤𐑱𐑕𐑥𐑩𐑯𐑑."
+
+#: ../capplets/display/xrandr-capplet.c:2069
+msgid "Could not save the monitor configuration"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑕𐑱𐑝 𐑞 𐑥𐑪𐑯𐑦𐑑𐑼 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯"
+
+#: ../capplets/display/xrandr-capplet.c:2091
+msgid "Could not get session bus while applying display configuration"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑜𐑧𐑑 𐑕𐑧𐑖𐑩𐑯 𐑚𐑳𐑕 𐑢𐑲𐑤 𐑩𐑐𐑤𐑲𐑦𐑙 𐑛𐑩𐑕𐑐𐑤𐑱 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯"
+
+#: ../capplets/display/xrandr-capplet.c:2133
+msgid "Could not detect displays"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑛𐑦𐑑𐑧𐑒𐑑 𐑛𐑦𐑕𐑐𐑤𐑱𐑟"
+
+#: ../capplets/display/xrandr-capplet.c:2325
+msgid "The monitor configuration has been saved"
+msgstr "𐑞 𐑥𐑪𐑯𐑦𐑑𐑼 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑣𐑨𐑟 𐑚𐑰𐑯 𐑕𐑱𐑝𐑛"
+
+#: ../capplets/display/xrandr-capplet.c:2327
+msgid "This configuration will be used the next time someone logs in."
+msgstr "𐑞𐑦𐑕 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑢𐑦𐑤 𐑚𐑰 𐑿𐑟𐑛 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑑𐑲𐑥 𐑕𐑳𐑥𐑢𐑳𐑯 𐑤𐑪𐑜𐑟 𐑦𐑯."
+
+#: ../capplets/display/xrandr-capplet.c:2361
+msgid "Could not set the default configuration for monitors"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑕𐑧𐑑 𐑞 𐑛𐑦𐑓𐑷𐑤𐑑 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑓𐑹 𐑥𐑪𐑯𐑦𐑑𐑼𐑟"
+
+#: ../capplets/display/xrandr-capplet.c:2403
+msgid "Could not get screen information"
+msgstr "𐑒𐑫𐑛 𐑯𐑪𐑑 𐑜𐑧𐑑 𐑕𐑒𐑮𐑰𐑯 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯"
+
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+msgid "Sound"
+msgstr "𐑕𐑬𐑯𐑛"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+#: ../libslab/bookmark-agent.c:1146
+msgid "Desktop"
+msgstr "𐑛𐑧𐑕𐑒𐑑𐑪𐑐"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr "𐑯𐑿 𐑕𐑹𐑑𐑒𐑳𐑑..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 𐑒𐑰"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 𐑥𐑪𐑛𐑦𐑓𐑲𐑼𐑟"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+#, fuzzy
+msgid "Accelerator keycode"
+msgstr "𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 keycode"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "𐑩𐑒𐑕𐑧𐑤 𐑥𐑴𐑛"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "𐑞 𐑑𐑲𐑐 𐑝 𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:119
+#: ../typing-break/drwright.c:498
+msgid "Disabled"
+msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:200
+msgid "<Unknown Action>"
+msgstr "<𐑳𐑯𐑴𐑯 𐑨𐑒𐑖𐑩𐑯>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:950
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1581
+msgid "Custom Shortcuts"
+msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1092
+msgid "Error saving the new shortcut"
+msgstr "𐑻𐑼 𐑕𐑱𐑝𐑦𐑙 𐑞 𐑯𐑿 𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1171
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"𐑞 𐑕𐑹𐑑𐑒𐑳𐑑 \"%s\" 𐑒𐑨𐑯𐑪𐑑 𐑚𐑰 𐑿𐑟𐑛 𐑚𐑦𐑒𐑪𐑟 𐑦𐑑 𐑢𐑦𐑤 𐑚𐑦𐑒𐑳𐑥 𐑦𐑥𐑐𐑪𐑕𐑩𐑚𐑩𐑤 𐑑 𐑑𐑲𐑐 𐑿𐑟𐑦𐑙 𐑞𐑦𐑕 "
+"𐑒𐑰.\n"
+"𐑐𐑤𐑰𐑟 𐑑𐑮𐑲 𐑢𐑦𐑞 𐑩 𐑒𐑰 𐑕𐑳𐑗 𐑨𐑟 𐑒𐑩𐑯𐑑𐑮𐑴𐑤, 𐑷𐑤𐑑 𐑹 𐑖𐑦𐑓𐑑 𐑨𐑑 𐑞 𐑕𐑱𐑥 𐑑𐑲𐑥."
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1201
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"𐑞 𐑕𐑹𐑑𐑒𐑳𐑑 \"%s\" 𐑦𐑟 𐑷𐑤𐑮𐑧𐑛𐑦 𐑿𐑕𐑑 𐑓𐑹\n"
+"\"%s\""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1207
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "𐑦𐑓 𐑿 𐑮𐑰𐑩𐑕𐑲𐑯 𐑞 𐑕𐑹𐑑𐑒𐑳𐑑 𐑑 \"%s\", 𐑞 \"%s\" 𐑕𐑹𐑑𐑒𐑳𐑑 𐑢𐑦𐑤 𐑚𐑰 𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛."
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1215
+msgid "_Reassign"
+msgstr "_𐑮𐑰𐑩𐑕𐑲𐑯"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1335
+#, fuzzy
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr "𐑻𐑼 unsetting 𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑑𐑼 𐑦𐑯 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑛𐑱𐑑𐑩𐑚𐑱𐑕: %s"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1536
+msgid "Too many custom shortcuts"
+msgstr "𐑑𐑵 𐑥𐑧𐑯𐑦 𐑒𐑳𐑕𐑑𐑩𐑥 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1832
+msgid "Action"
+msgstr "𐑨𐑒𐑖𐑩𐑯"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1854
+msgid "Shortcut"
+msgstr "𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:2
+msgid "Custom Shortcut"
+msgstr "𐑒𐑳𐑕𐑑𐑩𐑥 𐑕𐑹𐑑𐑒𐑳𐑑"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:3
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:4
+#, fuzzy
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new key "
+"combination, or press backspace to clear."
+msgstr ""
+"𐑑 𐑧𐑛𐑦𐑑 𐑩 𐑕𐑹𐑑𐑒𐑳𐑑 𐑒𐑰, 𐑒𐑤𐑦𐑒 𐑪𐑯 𐑞 𐑒𐑪𐑮𐑦𐑐𐑪𐑯𐑛𐑦𐑙 𐑮𐑴 𐑯 𐑑𐑲𐑐 𐑩 𐑯𐑿 𐑒𐑰 𐑒𐑪𐑥𐑚𐑦𐑯𐑱𐑖𐑩𐑯, 𐑹 𐑐𐑮𐑧𐑕 "
+"backspace 𐑑 𐑒𐑤𐑽."
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "𐑩𐑕𐑲𐑯 𐑕𐑹𐑑𐑒𐑳𐑑 𐑒𐑰𐑟 𐑑 𐑒𐑩𐑥𐑭𐑯𐑛𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:205
+#: ../capplets/keyboard/gnome-keyboard-properties.c:210
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr "𐑡𐑳𐑕𐑑 𐑩𐑐𐑤𐑲 𐑕𐑧𐑑𐑦𐑙𐑟 𐑯 𐑒𐑢𐑦𐑑 (𐑒𐑩𐑥𐑐𐑨𐑑𐑩𐑚𐑦𐑤𐑩𐑑𐑰 𐑴𐑯𐑤𐑦; 𐑯𐑬 𐑣𐑨𐑯𐑛𐑩𐑤𐑛 𐑚𐑲 𐑛𐑰𐑥𐑩𐑯)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:215
+msgid "Start the page with the typing break settings showing"
+msgstr "𐑕𐑑𐑸𐑑 𐑞 𐑐𐑱𐑡 𐑢𐑦𐑞 𐑞 𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒 𐑕𐑧𐑑𐑦𐑙𐑟 𐑖𐑴𐑦𐑙"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:220
+msgid "Start the page with the accessibility settings showing"
+msgstr "𐑕𐑑𐑸𐑑 𐑞 𐑐𐑱𐑡 𐑢𐑦𐑞 𐑞 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑕𐑧𐑑𐑦𐑙𐑟 𐑖𐑴𐑦𐑙"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:226
+msgid "- GNOME Keyboard Preferences"
+msgstr "- ·𐑜𐑯𐑴𐑥 𐑒𐑰𐑚𐑪𐑮𐑛 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:1
+msgid "Beep when _accessibility features are turned on or off"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 _𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑓𐑰𐑗𐑼𐑟 𐑸 𐑑𐑻𐑯𐑛 𐑪𐑯 𐑹 𐑪𐑓"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:2
+msgid "Beep when a _modifier key is pressed"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 _𐑥𐑪𐑛𐑦𐑓𐑲𐑼 𐑒𐑰 𐑦𐑟 𐑐𐑮𐑧𐑕𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:3
+msgid "Beep when a _toggle key is pressed"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 _𐑑𐑪𐑜𐑩𐑤 𐑒𐑰 𐑦𐑟 𐑐𐑮𐑧𐑕𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:4
+msgid "Beep when a key is pr_essed"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 𐑒𐑰 𐑦𐑟 pr_essed"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:5
+msgid "Beep when a key is reje_cted"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑩 𐑒𐑰 𐑦𐑟 reje_cted"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:6
+msgid "Beep when key is _accepted"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑒𐑰 𐑦𐑟 _𐑨𐑒𐑕𐑧𐑐𐑑𐑩𐑛"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:7
+msgid "Beep when key is _rejected"
+msgstr "𐑚𐑰𐑐 𐑢𐑧𐑯 𐑒𐑰 𐑦𐑟 _𐑮𐑦𐑡𐑧𐑒𐑑𐑧𐑛"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:8
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:4
+msgid "Bounce Keys"
+msgstr "𐑚𐑶𐑯𐑕 𐑒𐑰𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:9
+#, fuzzy
+msgid "Flash _window titlebar"
+msgstr "𐑓𐑤𐑨𐑖 _𐑢𐑦𐑯𐑛𐑴 titlebar"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:10
+msgid "Flash entire _screen"
+msgstr "𐑓𐑤𐑨𐑖 𐑧𐑯𐑑𐑲𐑼 _𐑕𐑒𐑮𐑰𐑯"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:11
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:14
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:15
+msgid "General"
+msgstr "𐑡𐑧𐑯𐑼𐑩𐑤"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:12
+msgid "Keyboard Accessibility Audio Feedback"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑷𐑛𐑦𐑴 𐑓𐑰𐑛𐑚𐑨𐑒"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:13
+msgid "Show _visual feedback for the alert sound"
+msgstr "𐑖𐑴 _𐑝𐑦𐑠𐑩𐑢𐑩𐑤 𐑓𐑰𐑛𐑚𐑨𐑒 𐑓𐑹 𐑞 𐑩𐑤𐑻𐑑 𐑕𐑬𐑯𐑛"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:14
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:39
+msgid "Slow Keys"
+msgstr "𐑕𐑤𐑴 𐑒𐑰𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:15
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:40
+msgid "Sticky Keys"
+msgstr "𐑕𐑑𐑦𐑒𐑦 𐑒𐑰𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:16
+msgid "Visual cues for sounds"
+msgstr "𐑝𐑦𐑠𐑩𐑢𐑩𐑤 𐑒𐑘𐑵𐑟 𐑓𐑹 𐑕𐑬𐑯𐑛𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:2
+msgid "All_ow postponing of breaks"
+msgstr "_𐑩𐑤𐑬 𐑐𐑴𐑕𐑑𐑐𐑴𐑯𐑦𐑙 𐑝 𐑚𐑮𐑱𐑒𐑕"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:3
+msgid "Audio _Feedback..."
+msgstr "𐑷𐑛𐑦𐑴 _𐑓𐑰𐑛𐑚𐑨𐑒..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:5
+msgid "Check if breaks are allowed to be postponed"
+msgstr "𐑗𐑧𐑒 𐑦𐑓 𐑚𐑮𐑱𐑒𐑕 𐑸 𐑩𐑤𐑬𐑛 𐑑 𐑚𐑰 𐑐𐑴𐑕𐑑𐑐𐑴𐑯𐑛"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:6
+msgid "Cursor Blinking"
+msgstr "𐑒𐑻𐑕𐑼 𐑚𐑤𐑦𐑙𐑒𐑦𐑙"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:7
+msgid "Cursor _blinks in text fields"
+msgstr "𐑒𐑻𐑕𐑼 _𐑚𐑤𐑦𐑙𐑒𐑕 𐑦𐑯 𐑑𐑧𐑒𐑕𐑑 𐑓𐑰𐑤𐑛𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:8
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:4
+msgid "Cursor blinks speed"
+msgstr "𐑒𐑻𐑕𐑼 𐑚𐑤𐑦𐑙𐑒𐑕 𐑕𐑐𐑰𐑛"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:9
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:5
+msgid "D_elay:"
+msgstr "_𐑛𐑦𐑤𐑱:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:10
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr "_𐑛𐑦𐑕𐑱𐑚𐑩𐑤 𐑕𐑑𐑦𐑒𐑦 𐑒𐑰𐑟 𐑦𐑓 𐑑𐑵 𐑒𐑰𐑟 𐑸 𐑐𐑮𐑧𐑕𐑑 𐑑𐑫𐑜𐑧𐑞𐑼"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:11
+msgid "Duration of the break when typing is disallowed"
+msgstr "𐑛𐑫𐑮𐑱𐑖𐑩𐑯 𐑝 𐑞 𐑚𐑮𐑱𐑒 𐑢𐑧𐑯 𐑑𐑲𐑐𐑦𐑙 𐑦𐑟 𐑛𐑦𐑕𐑩𐑤𐑶𐑛"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:12
+msgid "Duration of work before forcing a break"
+msgstr "𐑛𐑫𐑮𐑱𐑖𐑩𐑯 𐑝 𐑢𐑻𐑒 𐑚𐑦𐑓𐑹 𐑓𐑹𐑕𐑦𐑙 𐑩 𐑚𐑮𐑱𐑒"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:13
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:14
+msgid "Fast"
+msgstr "𐑓𐑭𐑕𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:15
+msgid "Key presses _repeat when key is held down"
+msgstr "𐑒𐑰 𐑐𐑮𐑧𐑕𐑩𐑟 _𐑮𐑦𐑐𐑰𐑑 𐑢𐑧𐑯 𐑒𐑰 𐑦𐑟 𐑣𐑧𐑤𐑛 𐑛𐑬𐑯"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:16
+msgid "Keyboard Preferences"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:17
+msgid "Keyboard _model:"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 _𐑥𐑪𐑛𐑩𐑤:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:18
+msgid "Layouts"
+msgstr "𐑤𐑱𐑬𐑑𐑕"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:19
+msgid "List of keyboard layouts selected for usage"
+msgstr "𐑤𐑦𐑕𐑑 𐑝 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑𐑕 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑓𐑹 𐑿𐑕𐑦𐑡"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:20
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"𐑤𐑪𐑒 𐑕𐑒𐑮𐑰𐑯 𐑭𐑓𐑑𐑼 𐑩 𐑕𐑻𐑑𐑩𐑯 𐑛𐑫𐑮𐑱𐑖𐑩𐑯 𐑑 𐑣𐑧𐑤𐑐 𐑐𐑮𐑦𐑝𐑧𐑯𐑑 𐑮𐑦𐑐𐑧𐑑𐑦𐑑𐑦𐑝 𐑒𐑰𐑚𐑪𐑮𐑛 𐑿𐑟 𐑦𐑯𐑡𐑻𐑰𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:21
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:19
+msgid "Long"
+msgstr "𐑤𐑪𐑙"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:22
+msgid "Mouse Keys"
+msgstr "𐑥𐑬𐑕 𐑒𐑰𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:23
+msgid "Move _Down"
+msgstr "𐑥𐑵𐑝 _𐑛𐑬𐑯"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:24
+msgid "Move _Up"
+msgstr "𐑥𐑵𐑝 _𐑳𐑐"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:25
+msgid "Move the selected keyboard layout down in the list"
+msgstr "𐑥𐑵𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑛𐑬𐑯 𐑦𐑯 𐑞 𐑤𐑦𐑕𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:26
+msgid "Move the selected keyboard layout up in the list"
+msgstr "𐑥𐑵𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑳𐑐 𐑦𐑯 𐑞 𐑤𐑦𐑕𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:27
+msgid "New windows u_se active window's layout"
+msgstr "𐑯𐑿 𐑢𐑦𐑯𐑛𐑴𐑟 _𐑿𐑟 𐑨𐑒𐑑𐑦𐑝 𐑢𐑦𐑯𐑛𐑴'𐑟 𐑤𐑱𐑬𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:28
+msgid "Print a diagram of the selected keyboard layout"
+msgstr "𐑐𐑮𐑦𐑯𐑑 𐑩 𐑛𐑲𐑩𐑜𐑮𐑨𐑥 𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:29
+msgid "Remove the selected keyboard layout from the list"
+msgstr "𐑮𐑦𐑥𐑵𐑝 𐑞 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑓𐑮𐑪𐑥 𐑞 𐑤𐑦𐑕𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:30
+msgid "Repeat Keys"
+msgstr "𐑮𐑦𐑐𐑰𐑑 𐑒𐑰𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:31
+msgid "Repeat keys speed"
+msgstr "𐑮𐑦𐑐𐑰𐑑 𐑒𐑰𐑟 𐑕𐑐𐑰𐑛"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:32
+msgid ""
+"Replace the current keyboard layout settings with the\n"
+"default settings"
+msgstr ""
+"𐑮𐑦𐑐𐑤𐑱𐑕 𐑞 𐑒𐑳𐑮𐑩𐑯𐑑 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑕𐑧𐑑𐑦𐑙𐑟 𐑢𐑦𐑞 𐑞\n"
+"𐑛𐑦𐑓𐑷𐑤𐑑 𐑕𐑧𐑑𐑦𐑙𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:34
+msgid "Reset to De_faults"
+msgstr "𐑮𐑰𐑕𐑧𐑑 𐑑 _𐑛𐑦𐑓𐑷𐑤𐑑𐑕"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:35
+msgid "S_peed:"
+msgstr "_𐑕𐑐𐑰𐑛:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:36
+msgid "Select a keyboard layout to be added to the list"
+msgstr "𐑕𐑩𐑤𐑧𐑒𐑑 𐑩 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑑 𐑚𐑰 𐑨𐑛𐑩𐑛 𐑑 𐑞 𐑤𐑦𐑕𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:37
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:27
+msgid "Short"
+msgstr "𐑖𐑹𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:38
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:30
+msgid "Slow"
+msgstr "𐑕𐑤𐑴"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:41
+msgid "Typing Break"
+msgstr "𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:42
+msgid "View and edit keyboard layout options"
+msgstr "𐑝𐑿 𐑯 𐑧𐑛𐑦𐑑 𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑪𐑐𐑖𐑩𐑯𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:43
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:37
+msgid "_Acceleration:"
+msgstr "_𐑨𐑒𐑕𐑧𐑤𐑼𐑱𐑖𐑩𐑯:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:44
+msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgstr "_𐑨𐑒𐑕𐑧𐑕𐑩𐑚𐑦𐑤𐑦𐑑𐑰 𐑓𐑰𐑗𐑼𐑟 𐑒𐑨𐑯 𐑚𐑰 𐑑𐑪𐑜𐑩𐑤𐑛 𐑢𐑦𐑞 𐑒𐑰𐑚𐑪𐑮𐑛 𐑖𐑹𐑑𐑒𐑳𐑑𐑕"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:46
+msgid "_Break interval lasts:"
+msgstr "_𐑚𐑮𐑱𐑒 𐑦𐑯𐑑𐑼𐑝𐑩𐑤 𐑤𐑨𐑕𐑑𐑕:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:47
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:38
+msgid "_Delay:"
+msgstr "_𐑛𐑦𐑤𐑱:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:48
+#, fuzzy
+msgid "_Ignore fast duplicate keypresses"
+msgstr "_𐑦𐑜𐑯𐑹 𐑓𐑭𐑕𐑑 𐑛𐑿𐑐𐑤𐑦𐑒𐑱𐑑 keypresses"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:49
+msgid "_Lock screen to enforce typing break"
+msgstr "_𐑤𐑪𐑒 𐑕𐑒𐑮𐑰𐑯 𐑑 𐑧𐑯𐑓𐑪𐑮𐑕 𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:50
+#, fuzzy
+msgid "_Only accept long keypresses"
+msgstr "_𐑴𐑯𐑤𐑦 𐑨𐑒𐑕𐑧𐑐𐑑 𐑤𐑪𐑙 keypresses"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:51
+msgid "_Options..."
+msgstr "_𐑪𐑐𐑖𐑩𐑯𐑟..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:52
+msgid "_Pointer can be controlled using the keypad"
+msgstr "_𐑐𐑶𐑯𐑑𐑼 𐑒𐑨𐑯 𐑚𐑰 𐑒𐑩𐑯𐑑𐑮𐑴𐑤𐑛 𐑿𐑟𐑦𐑙 𐑞 𐑒𐑰𐑐𐑨𐑛"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:53
+msgid "_Separate layout for each window"
+msgstr "_𐑕𐑧𐑐𐑼𐑱𐑑 𐑤𐑱𐑬𐑑 𐑓𐑹 𐑰𐑗 𐑢𐑦𐑯𐑛𐑴"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:54
+#, fuzzy
+msgid "_Simulate simultaneous keypresses"
+msgstr "_𐑕𐑦𐑥𐑘𐑩𐑤𐑩𐑑 𐑕𐑲𐑥𐑩𐑤𐑑𐑱𐑯𐑰𐑩𐑕 keypresses"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:55
+msgid "_Speed:"
+msgstr "_𐑕𐑐𐑰𐑛:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:56
+msgid "_Type to test settings:"
+msgstr "_𐑑𐑲𐑐 𐑑 𐑑𐑧𐑕𐑑 𐑕𐑧𐑑𐑦𐑙𐑟:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:57
+msgid "_Work interval lasts:"
+msgstr "_𐑢𐑻𐑒 𐑦𐑯𐑑𐑼𐑝𐑩𐑤 𐑤𐑨𐑕𐑑𐑕:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:58
+msgid "minutes"
+msgstr "𐑥𐑦𐑯𐑦𐑑𐑕"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:1
+msgid "By _country"
+msgstr "𐑚𐑲 _𐑒𐑳𐑯𐑑𐑮𐑰"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:2
+msgid "By _language"
+msgstr "𐑚𐑲 _𐑤𐑨𐑙𐑜𐑢𐑩𐑡"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:3
+msgid "Choose a Layout"
+msgstr "𐑗𐑵𐑟 𐑩 𐑤𐑱𐑬𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:4
+msgid "Preview:"
+msgstr "𐑐𐑮𐑰𐑝𐑿:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:5
+msgid "_Country:"
+msgstr "_𐑒𐑳𐑯𐑑𐑮𐑰:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:6
+msgid "_Language:"
+msgstr "_𐑤𐑨𐑙𐑜𐑢𐑩𐑡:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:7
+msgid "_Variants:"
+msgstr "_𐑝𐑧𐑮𐑰𐑩𐑯𐑑𐑕:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:1
+msgid "Choose a Keyboard Model"
+msgstr "𐑗𐑵𐑟 𐑩 𐑒𐑰𐑚𐑪𐑮𐑛 𐑥𐑪𐑛𐑩𐑤"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:2
+msgid "_Models:"
+msgstr "_𐑥𐑪𐑛𐑩𐑤𐑟:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:3
+msgid "_Vendors:"
+msgstr "_𐑝𐑧𐑯𐑛𐑻𐑟:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-options-dialog.ui.h:1
+msgid "Keyboard Layout Options"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛 𐑤𐑱𐑬𐑑 𐑪𐑐𐑖𐑩𐑯𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
+msgid "Unknown"
+msgstr "𐑳𐑯𐑴𐑯"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:241
+msgid "Layout"
+msgstr "𐑤𐑱𐑬𐑑"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:168
+msgid "Vendors"
+msgstr "𐑝𐑧𐑯𐑛𐑻𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:234
+msgid "Models"
+msgstr "𐑥𐑪𐑛𐑩𐑤𐑟"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:235
+#: ../capplets/network/gnome-network-properties.c:581
+msgid "Default"
+msgstr "𐑛𐑦𐑓𐑷𐑤𐑑"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "𐑒𐑰𐑚𐑪𐑮𐑛"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑒𐑰𐑚𐑪𐑮𐑛 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:89
+msgid "gesture|Move left"
+msgstr "𐑥𐑵𐑝 𐑤𐑧𐑓𐑑"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:94
+msgid "gesture|Move right"
+msgstr "𐑥𐑵𐑝 𐑮𐑲𐑑"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:99
+msgid "gesture|Move up"
+msgstr "𐑥𐑵𐑝 𐑳𐑐"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:104
+msgid "gesture|Move down"
+msgstr "𐑥𐑵𐑝 𐑛𐑬𐑯"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:109
+msgid "gesture|Disabled"
+msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/mouse/gnome-mouse-properties.c:590
+msgid "Specify the name of the page to show (general|accessibility)"
+msgstr "𐑕𐑐𐑧𐑕𐑦𐑓𐑲 𐑞 𐑯𐑱𐑥 𐑝 𐑞 𐑐𐑱𐑡 𐑑 𐑖𐑴 (general|accessibility)"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:595
+msgid "- GNOME Mouse Preferences"
+msgstr "- ·𐑜𐑯𐑴𐑥 𐑥𐑬𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:2
+msgid "Choose type of click _beforehand"
+msgstr "𐑗𐑵𐑟 𐑑𐑲𐑐 𐑝 𐑒𐑤𐑦𐑒 _𐑚𐑧𐑓𐑹𐑣𐑨𐑯𐑛"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:3
+msgid "Choose type of click with mo_use gestures"
+msgstr "𐑗𐑵𐑟 𐑑𐑲𐑐 𐑝 𐑒𐑤𐑦𐑒 𐑢𐑦𐑞 _𐑥𐑬𐑕 𐑡𐑧𐑕𐑗𐑻𐑟"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:6
+msgid "D_ouble click:"
+msgstr "_𐑛𐑳𐑚𐑩𐑤 𐑒𐑤𐑦𐑒:"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:7
+msgid "D_rag click:"
+msgstr "_𐑛𐑮𐑨𐑜 𐑒𐑤𐑦𐑒:"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:8
+#, fuzzy
+msgid "Disable _touchpad while typing"
+msgstr "𐑛𐑦𐑕𐑱𐑚𐑩𐑤 _touchpad 𐑢𐑲𐑤 𐑑𐑲𐑐𐑦𐑙"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:9
+msgid "Double-Click Timeout"
+msgstr "𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑑𐑲𐑥𐑬𐑑"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:10
+msgid "Drag and Drop"
+msgstr "𐑛𐑮𐑨𐑜 𐑯 𐑛𐑮𐑪𐑐"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:11
+msgid "Dwell Click"
+msgstr "𐑛𐑢𐑧𐑤 𐑒𐑤𐑦𐑒"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:12
+#, fuzzy
+msgid "Enable _mouse clicks with touchpad"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 _𐑥𐑬𐑕 𐑒𐑤𐑦𐑒𐑕 𐑢𐑦𐑞 touchpad"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:13
+msgid "Enable h_orizontal scrolling"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 _𐑣𐑪𐑮𐑦𐑟𐑪𐑯𐑑𐑩𐑤 𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:16
+msgid "High"
+msgstr "𐑣𐑲"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:18
+msgid "Locate Pointer"
+msgstr "𐑤𐑴𐑒𐑱𐑑 𐑐𐑶𐑯𐑑𐑼"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:20
+msgid "Low"
+msgstr "𐑤𐑴"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:21
+msgid "Mouse Orientation"
+msgstr "𐑥𐑬𐑕 𐑪𐑮𐑦𐑩𐑯𐑑𐑱𐑖𐑩𐑯"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:22
+msgid "Mouse Preferences"
+msgstr "𐑥𐑬𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:23
+msgid "Pointer Speed"
+msgstr "𐑐𐑶𐑯𐑑𐑼 𐑕𐑐𐑰𐑛"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:24
+msgid "Scrolling"
+msgstr "𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:25
+msgid "Seco_ndary click:"
+msgstr "_𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒:"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:26
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr "_𐑖𐑴 𐑐𐑩𐑟𐑦𐑖𐑩𐑯 𐑝 𐑐𐑶𐑯𐑑𐑼 𐑢𐑧𐑯 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤 𐑒𐑰 𐑦𐑟 𐑐𐑮𐑧𐑕𐑑"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:28
+msgid "Show click type _window"
+msgstr "𐑖𐑴 𐑒𐑤𐑦𐑒 𐑑𐑲𐑐 _𐑢𐑦𐑯𐑛𐑴"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:29
+msgid "Simulated Secondary Click"
+msgstr "𐑕𐑦𐑥𐑘𐑩𐑤𐑱𐑑𐑦𐑛 𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:32
+msgid "Thr_eshold:"
+msgstr "_𐑔𐑮𐑧𐑖𐑴𐑤𐑛:"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:33
+msgid ""
+"To test your double-click settings, try to double-click on the light bulb."
+msgstr "𐑑 𐑑𐑧𐑕𐑑 𐑿𐑼 𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑕𐑧𐑑𐑦𐑙𐑟, 𐑑𐑮𐑲 𐑑 𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 𐑪𐑯 𐑞 𐑤𐑲𐑑 𐑚𐑳𐑤𐑚."
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:34
+#, fuzzy
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:35
+msgid "Two-_finger scrolling"
+msgstr "𐑑𐑵-_𐑓𐑦𐑙𐑜𐑼 𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:36
+msgid "You can also use the Dwell Click panel applet to choose the click type."
+msgstr "𐑿 𐑒𐑨𐑯 𐑷𐑤𐑕𐑴 𐑿𐑟 𐑞 𐑛𐑢𐑧𐑤 𐑒𐑤𐑦𐑒 𐑐𐑨𐑯𐑩𐑤 𐑨𐑐𐑤𐑩𐑑 𐑑 𐑗𐑵𐑟 𐑞 𐑒𐑤𐑦𐑒 𐑑𐑲𐑐."
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:39
+msgid "_Disabled"
+msgstr "_𐑛𐑦𐑕𐑱𐑚𐑩𐑤𐑛"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:40
+msgid "_Edge scrolling"
+msgstr "_𐑧𐑡 𐑕𐑒𐑮𐑴𐑤𐑦𐑙"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:41
+msgid "_Initiate click when stopping pointer movement"
+msgstr "_𐑦𐑯𐑦𐑖𐑰𐑱𐑑 𐑒𐑤𐑦𐑒 𐑢𐑧𐑯 𐑕𐑑𐑪𐑐𐑦𐑙 𐑐𐑶𐑯𐑑𐑼 𐑥𐑵𐑝𐑥𐑩𐑯𐑑"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:42
+msgid "_Left-handed"
+msgstr "_𐑤𐑧𐑓𐑑-𐑣𐑨𐑯𐑛𐑧𐑛"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:43
+msgid "_Motion threshold:"
+msgstr "_𐑥𐑴𐑖𐑩𐑯 𐑔𐑮𐑧𐑖𐑴𐑤𐑛:"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:44
+msgid "_Right-handed"
+msgstr "_𐑮𐑲𐑑-𐑣𐑨𐑯𐑛𐑧𐑛"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:45
+msgid "_Sensitivity:"
+msgstr "_𐑕𐑧𐑯𐑕𐑦𐑑𐑦𐑝𐑦𐑑𐑦:"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:46
+msgid "_Single click:"
+msgstr "_𐑕𐑦𐑙𐑜𐑩𐑤 𐑒𐑤𐑦𐑒:"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:47
+msgid "_Timeout:"
+msgstr "_𐑑𐑲𐑥𐑬𐑑:"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:48
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr "_𐑑𐑮𐑦𐑜𐑻 𐑕𐑧𐑒𐑪𐑯𐑛𐑼𐑦 𐑒𐑤𐑦𐑒 𐑚𐑲 𐑣𐑴𐑤𐑛𐑦𐑙 𐑛𐑬𐑯 𐑞 𐑐𐑮𐑲𐑥𐑼𐑦 𐑚𐑳𐑑𐑩𐑯"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "𐑥𐑬𐑕"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑥𐑬𐑕 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/network/gnome-network-properties.c:699
+#: ../capplets/network/gnome-network-properties.c:850
+msgid "New Location..."
+msgstr "𐑯𐑿 𐑤𐑴𐑒𐑱𐑖𐑩𐑯..."
+
+#: ../capplets/network/gnome-network-properties.c:816
+msgid "Location already exists"
+msgstr "𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕"
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦"
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/network/gnome-network-properties.ui.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>_𐑛𐑲𐑮𐑧𐑒𐑑 ·𐑦𐑯𐑑𐑼𐑯𐑧𐑑 𐑒𐑩𐑯𐑧𐑒𐑖𐑩𐑯</b>"
+
+#: ../capplets/network/gnome-network-properties.ui.h:2
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>_𐑷𐑑𐑴𐑥𐑨𐑑𐑦𐑒 𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯</b>"
+
+#: ../capplets/network/gnome-network-properties.ui.h:3
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>_𐑥𐑨𐑯𐑘𐑫𐑩𐑤 𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯</b>"
+
+#: ../capplets/network/gnome-network-properties.ui.h:4
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_𐑿𐑟 𐑷𐑔𐑧𐑯𐑑𐑦𐑒𐑱𐑖𐑩𐑯</b>"
+
+#: ../capplets/network/gnome-network-properties.ui.h:5
+#, fuzzy
+msgid "Autoconfiguration _URL:"
+msgstr "Autoconfiguration _·𐑿·𐑮·𐑤:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:6
+msgid "C_reate"
+msgstr "_𐑒𐑮𐑦𐑱𐑑"
+
+#: ../capplets/network/gnome-network-properties.ui.h:7
+msgid "Create New Location"
+msgstr "𐑒𐑮𐑦𐑱𐑑 𐑯𐑿 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
+
+#: ../capplets/network/gnome-network-properties.ui.h:8
+msgid "HTTP Proxy Details"
+msgstr "HTTP 𐑐𐑮𐑪𐑒𐑕𐑦 𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#: ../capplets/network/gnome-network-properties.ui.h:9
+msgid "H_TTP proxy:"
+msgstr "H_TTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:10
+msgid "Ignore Host List"
+msgstr "𐑦𐑜𐑯𐑹 𐑣𐑴𐑕𐑑 𐑤𐑦𐑕𐑑"
+
+#: ../capplets/network/gnome-network-properties.ui.h:11
+msgid "Ignored Hosts"
+msgstr "𐑦𐑜𐑯𐑹𐑛 𐑣𐑴𐑕𐑑𐑕"
+
+#: ../capplets/network/gnome-network-properties.ui.h:12
+msgid "Location:"
+msgstr "𐑤𐑴𐑒𐑱𐑖𐑩𐑯:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:13
+msgid "Network Proxy Preferences"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑐𐑮𐑪𐑒𐑕𐑦 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/network/gnome-network-properties.ui.h:14
+msgid "Port:"
+msgstr "𐑐𐑹𐑑:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:15
+msgid "Proxy Configuration"
+msgstr "𐑐𐑮𐑪𐑒𐑕𐑦 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯"
+
+#: ../capplets/network/gnome-network-properties.ui.h:16
+msgid "S_ocks host:"
+msgstr "_𐑕𐑪𐑒𐑕 𐑣𐑴𐑕𐑑:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:17
+msgid "The location already exists."
+msgstr "𐑞 𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑷𐑤𐑮𐑧𐑛𐑦 𐑧𐑒𐑟𐑦𐑕𐑑𐑕."
+
+#: ../capplets/network/gnome-network-properties.ui.h:18
+msgid "U_sername:"
+msgstr "_𐑿𐑟𐑼𐑯𐑱𐑥:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:19
+msgid "_Delete Location"
+msgstr "_𐑛𐑦𐑤𐑰𐑑 𐑤𐑴𐑒𐑱𐑖𐑩𐑯"
+
+#: ../capplets/network/gnome-network-properties.ui.h:20
+msgid "_Details"
+msgstr "_𐑛𐑰𐑑𐑱𐑤𐑟"
+
+#: ../capplets/network/gnome-network-properties.ui.h:21
+#, fuzzy
+msgid "_FTP proxy:"
+msgstr "_FTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:22
+msgid "_Location name:"
+msgstr "_𐑤𐑴𐑒𐑱𐑖𐑩𐑯 𐑯𐑱𐑥:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:23
+msgid "_Password:"
+msgstr "_𐑐𐑭𐑕𐑢𐑼𐑛:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:24
+msgid "_Secure HTTP proxy:"
+msgstr "_𐑕𐑦𐑒𐑘𐑫𐑼 HTTP 𐑐𐑮𐑪𐑒𐑕𐑦:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:25
+msgid "_Use the same proxy for all protocols"
+msgstr "_𐑿𐑕 𐑞 𐑕𐑱𐑥 𐑐𐑮𐑪𐑒𐑕𐑦 𐑓𐑹 𐑷𐑤 𐑐𐑮𐑴𐑑𐑩𐑒𐑪𐑤𐑟"
+
+#: ../capplets/windows/gnome-window-properties.c:344
+msgid "Cannot start the preferences application for your window manager"
+msgstr "𐑒𐑨𐑯𐑪𐑑 𐑕𐑑𐑸𐑑 𐑞 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯 𐑓𐑹 𐑿𐑼 𐑢𐑦𐑯𐑛𐑴 𐑥𐑨𐑯𐑩𐑡𐑼"
+
+#: ../capplets/windows/gnome-window-properties.c:603
+msgid "_Alt"
+msgstr "_𐑷𐑤𐑑"
+
+#: ../capplets/windows/gnome-window-properties.c:609
+msgid "H_yper"
+msgstr "𐑣_𐑲𐑐𐑼"
+
+#: ../capplets/windows/gnome-window-properties.c:616
+msgid "S_uper (or \"Windows logo\")"
+msgstr "𐑕_𐑵𐑐𐑼 (𐑹 \"·𐑢𐑦𐑯𐑛𐑴𐑟 𐑤𐑴𐑜𐑴\")"
+
+#: ../capplets/windows/gnome-window-properties.c:623
+msgid "_Meta"
+msgstr "_𐑥𐑧𐑑𐑩"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:1
+msgid "Movement Key"
+msgstr "𐑥𐑵𐑝𐑥𐑩𐑯𐑑 𐑒𐑰"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:2
+#, fuzzy
+msgid "Titlebar Action"
+msgstr "Titlebar 𐑨𐑒𐑖𐑩𐑯"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:3
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr "𐑑 𐑥𐑵𐑝 𐑩 𐑢𐑦𐑯𐑛𐑴, 𐑐𐑮𐑧𐑕-𐑯-𐑣𐑴𐑤𐑛 𐑞𐑦𐑕 𐑒𐑰 𐑞𐑧𐑯 𐑜𐑮𐑨𐑚 𐑞 𐑢𐑦𐑯𐑛𐑴:"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:4
+msgid "Window Preferences"
+msgstr "𐑢𐑦𐑯𐑛𐑴 𐑐𐑮𐑧𐑓𐑼𐑩𐑯𐑕𐑩𐑟"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:5
+msgid "Window Selection"
+msgstr "𐑢𐑦𐑯𐑛𐑴 𐑕𐑦𐑤𐑧𐑒𐑖𐑩𐑯"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:6
+#, fuzzy
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_𐑛𐑳𐑚𐑩𐑤-𐑒𐑤𐑦𐑒 titlebar 𐑑 𐑐𐑼𐑓𐑹𐑥 𐑞𐑦𐑕 𐑨𐑒𐑖𐑩𐑯:"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:7
+msgid "_Interval before raising:"
+msgstr "_𐑦𐑯𐑑𐑼𐑝𐑩𐑤 𐑚𐑦𐑓𐑹 𐑮𐑱𐑟𐑦𐑙:"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_𐑮𐑱𐑟 𐑕𐑩𐑤𐑧𐑒𐑑𐑩𐑛 𐑢𐑦𐑯𐑛𐑴𐑟 𐑭𐑓𐑑𐑼 𐑩𐑯 𐑦𐑯𐑑𐑼𐑝𐑩𐑤"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_𐑕𐑩𐑤𐑧𐑒𐑑 𐑢𐑦𐑯𐑛𐑴𐑟 𐑢𐑧𐑯 𐑞 𐑥𐑬𐑕 𐑥𐑵𐑝𐑟 𐑴𐑝𐑼 𐑞𐑧𐑥"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:10
+msgid "seconds"
+msgstr "𐑕𐑧𐑒𐑩𐑯𐑛𐑟"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "𐑕𐑧𐑑 𐑿𐑼 𐑢𐑦𐑯𐑛𐑴 𐑐𐑮𐑪𐑐𐑼𐑑𐑦𐑟"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "𐑢𐑦𐑯𐑛𐑴𐑟"
+
+#: ../libwindow-settings/gnome-wm-manager.c:316
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "𐑢𐑦𐑯𐑛𐑴 𐑥𐑨𐑯𐑩𐑡𐑼 \"%s\" 𐑣𐑨𐑟 𐑯𐑪𐑑 𐑮𐑧𐑡𐑦𐑕𐑑𐑼𐑛 𐑩 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑑𐑵𐑤\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:404
+msgid "Maximize"
+msgstr "𐑥𐑨𐑒𐑕𐑩𐑥𐑲𐑟"
+
+#: ../libwindow-settings/metacity-window-manager.c:405
+msgid "Maximize Vertically"
+msgstr "𐑥𐑨𐑒𐑕𐑩𐑥𐑲𐑟 𐑝𐑻𐑑𐑦𐑒𐑩𐑤𐑦"
+
+#: ../libwindow-settings/metacity-window-manager.c:406
+msgid "Maximize Horizontally"
+msgstr "𐑥𐑨𐑒𐑕𐑩𐑥𐑲𐑟 𐑣𐑪𐑮𐑦𐑟𐑪𐑯𐑑𐑩𐑤𐑦"
+
+#: ../libwindow-settings/metacity-window-manager.c:407
+msgid "Minimize"
+msgstr "𐑥𐑦𐑯𐑩𐑥𐑲𐑟"
+
+#: ../libwindow-settings/metacity-window-manager.c:408
+msgid "Roll up"
+msgstr "𐑮𐑴𐑤 𐑳𐑐"
+
+#: ../libwindow-settings/metacity-window-manager.c:409
+msgid "None"
+msgstr "𐑯𐑳𐑯"
+
+#: ../shell/control-center.c:49
+#, c-format
+msgid "key not found [%s]\n"
+msgstr "𐑒𐑰 𐑯𐑪𐑑 𐑓𐑬𐑯𐑛 [%s]\n"
+
+#: ../shell/control-center.c:143
+#, fuzzy
+msgid "Hide on start (useful to preload the shell)"
+msgstr "𐑣𐑲𐑛 𐑪𐑯 𐑕𐑑𐑸𐑑 (𐑿𐑕𐑓𐑩𐑤 𐑑 preload 𐑞 𐑖𐑧𐑤)"
+
+#: ../shell/control-center.c:182
+msgid "Filter"
+msgstr "𐑓𐑦𐑤𐑑𐑼"
+
+#: ../shell/control-center.c:182
+msgid "Groups"
+msgstr "𐑜𐑮𐑵𐑐𐑕"
+
+#: ../shell/control-center.c:182
+msgid "Common Tasks"
+msgstr "𐑒𐑪𐑥𐑩𐑯 𐑑𐑭𐑕𐑒𐑕"
+
+#: ../shell/control-center.c:185 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "𐑒𐑩𐑯𐑑𐑮𐑴𐑤 𐑕𐑧𐑯𐑑𐑼"
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr "𐑒𐑤𐑴𐑟 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤-𐑕𐑧𐑯𐑑𐑼 𐑢𐑧𐑯 𐑩 𐑑𐑭𐑕𐑒 𐑦𐑟 𐑨𐑒𐑑𐑦𐑝𐑱𐑑𐑩𐑛"
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑨𐑛 𐑹 𐑮𐑦𐑥𐑵𐑝 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑣𐑧𐑤𐑐 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑕𐑑𐑸𐑑 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
+
+#: ../shell/control-center.schemas.in.h:5
+#, fuzzy
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr "𐑧𐑜𐑟𐑦𐑑 𐑖𐑧𐑤 𐑪𐑯 𐑳𐑐𐑜𐑮𐑱𐑛 𐑹 uninstall 𐑨𐑒𐑖𐑩𐑯 𐑐𐑼𐑓𐑹𐑥𐑛"
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed."
+msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩 𐑣𐑧𐑤𐑐 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed."
+msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩 𐑕𐑑𐑸𐑑 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
+
+#: ../shell/control-center.schemas.in.h:8
+msgid ""
+"Indicates whether to close the shell when an add or remove action is "
+"performed."
+msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩𐑯 𐑨𐑛 𐑹 𐑮𐑦𐑥𐑵𐑝 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
+
+#: ../shell/control-center.schemas.in.h:9
+#, fuzzy
+msgid ""
+"Indicates whether to close the shell when an upgrade or uninstall action is "
+"performed."
+msgstr "𐑦𐑯𐑛𐑦𐑒𐑱𐑑𐑕 𐑢𐑧𐑞𐑼 𐑑 𐑒𐑤𐑴𐑕 𐑞 𐑖𐑧𐑤 𐑢𐑧𐑯 𐑩𐑯 𐑳𐑐𐑜𐑮𐑱𐑛 𐑹 uninstall 𐑨𐑒𐑖𐑩𐑯 𐑦𐑟 𐑐𐑼𐑓𐑹𐑥𐑛."
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr "𐑑𐑭𐑕𐑒 𐑯𐑱𐑥𐑟 𐑯 𐑩𐑕𐑴𐑖𐑦𐑱𐑑𐑩𐑛 .desktop 𐑓𐑲𐑤𐑟"
+
+#: ../shell/control-center.schemas.in.h:11
+msgid ""
+"The task name to be displayed in the control-center followed by a \";\" "
+"separator then the filename of an associated .desktop file to launch for "
+"that task."
+msgstr ""
+"𐑞 𐑑𐑭𐑕𐑒 𐑯𐑱𐑥 𐑑 𐑚𐑰 𐑛𐑩𐑕𐑐𐑤𐑱𐑛 𐑦𐑯 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤-𐑕𐑧𐑯𐑑𐑼 𐑓𐑪𐑤𐑴𐑛 𐑚𐑲 𐑩 \";\" 𐑕𐑧𐑐𐑼𐑱𐑑𐑼 𐑞𐑧𐑯 𐑞 "
+"𐑓𐑲𐑤𐑯𐑱𐑥 𐑝 𐑩𐑯 𐑩𐑕𐑴𐑖𐑦𐑱𐑑𐑩𐑛 .𐑛𐑧𐑕𐑒𐑑𐑪𐑐 𐑓𐑲𐑤 𐑑 𐑤𐑷𐑯𐑗 𐑓𐑹 𐑞𐑨𐑑 𐑑𐑭𐑕𐑒."
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+#, fuzzy
+msgid ""
+"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
+"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+msgstr ""
+"[𐑗𐑱𐑯𐑡 𐑔𐑰𐑥;gtk-𐑔𐑰𐑥-selector.𐑛𐑧𐑕𐑒𐑑𐑪𐑐,𐑕𐑧𐑑 𐑐𐑮𐑦𐑓𐑻𐑛 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟;𐑛𐑦𐑓𐑷𐑤𐑑-𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯𐑟."
+"𐑛𐑧𐑕𐑒𐑑𐑪𐑐,𐑨𐑛 𐑐𐑮𐑦𐑯𐑑𐑼;·𐑯𐑴𐑥-𐑒𐑳𐑐𐑕-𐑥𐑨𐑯𐑩𐑡𐑼.𐑛𐑧𐑕𐑒𐑑𐑪𐑐]"
+
+#: ../shell/control-center.schemas.in.h:14
+msgid ""
+"if true, the control-center will close when a \"Common Task\" is activated."
+msgstr "𐑦𐑓 𐑑𐑮𐑵, 𐑞 𐑒𐑩𐑯𐑑𐑮𐑴𐑤-𐑕𐑧𐑯𐑑𐑼 𐑢𐑦𐑤 𐑒𐑤𐑴𐑕 𐑢𐑧𐑯 𐑩 \"𐑒𐑪𐑥𐑩𐑯 𐑑𐑭𐑕𐑒\" 𐑦𐑟 𐑨𐑒𐑑𐑦𐑝𐑱𐑑𐑩𐑛."
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "𐑞 ·𐑜𐑯𐑴𐑥 𐑒𐑩𐑯𐑓𐑦𐑜𐑘𐑼𐑱𐑖𐑩𐑯 𐑑𐑵𐑤"
+
+#: ../typing-break/drw-break-window.c:194
+msgid "_Postpone Break"
+msgstr "_𐑐𐑴𐑕𐑑𐑐𐑴𐑯 𐑚𐑮𐑱𐑒"
+
+#: ../typing-break/drw-break-window.c:250
+msgid "Take a break!"
+msgstr "𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒!"
+
+#: ../typing-break/drwright.c:136
+msgid "_Take a Break"
+msgstr "_𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒"
+
+#: ../typing-break/drwright.c:507
+#, fuzzy
+msgid "Take a break now (next in %dm)"
+msgstr "𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒 𐑯𐑬 (𐑯𐑧𐑒𐑕𐑑 𐑦𐑯 %dm)"
+
+#: ../typing-break/drwright.c:509
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "%d 𐑥𐑦𐑯𐑩𐑑 𐑳𐑯𐑑𐑦𐑤 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑚𐑮𐑱𐑒"
+msgstr[1] "%d 𐑥𐑦𐑯𐑩𐑑𐑕 𐑳𐑯𐑑𐑦𐑤 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑚𐑮𐑱𐑒"
+
+#: ../typing-break/drwright.c:515
+#, c-format
+msgid "Take a break now (next in less than one minute)"
+msgstr "𐑑𐑱𐑒 𐑩 𐑚𐑮𐑱𐑒 𐑯𐑬 (𐑯𐑧𐑒𐑕𐑑 𐑦𐑯 𐑤𐑧𐑕 𐑞𐑨𐑯 𐑢𐑳𐑯 𐑥𐑦𐑯𐑩𐑑)"
+
+#: ../typing-break/drwright.c:517
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr "𐑤𐑧𐑕 𐑞𐑨𐑯 𐑢𐑳𐑯 𐑥𐑦𐑯𐑩𐑑 𐑳𐑯𐑑𐑦𐑤 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑚𐑮𐑱𐑒"
+
+#: ../typing-break/drwright.c:614
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr "𐑳𐑯𐑱𐑚𐑩𐑤 𐑑 𐑚𐑮𐑦𐑙 𐑳𐑐 𐑞 𐑑𐑲𐑐𐑦𐑙 𐑚𐑮𐑱𐑒 𐑐𐑮𐑪𐑐𐑼𐑑𐑦𐑟 𐑛𐑲𐑩𐑤𐑪𐑜 𐑢𐑦𐑞 𐑞 𐑓𐑪𐑤𐑴𐑦𐑙 𐑻𐑼: %s"
+
+#: ../typing-break/drwright.c:631
+#, fuzzy
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "𐑮𐑦𐑑𐑩𐑯 𐑚𐑲 ·𐑮𐑦𐑗𐑼𐑛 𐑣𐑩𐑤𐑑 <·𐑮𐑦𐑗𐑼𐑛@imendio.𐑒𐑪𐑥>"
+
+#: ../typing-break/drwright.c:632
+msgid "Eye candy added by Anders Carlsson"
+msgstr "𐑲 𐑒𐑨𐑯𐑛𐑰 𐑨𐑛𐑩𐑛 𐑚𐑲 ·𐑨𐑯𐑛𐑻𐑟 ·𐑒𐑭𐑮𐑤𐑕𐑩𐑯"
+
+#: ../typing-break/drwright.c:641
+msgid "A computer break reminder."
+msgstr "𐑩 𐑒𐑩𐑥𐑐𐑿𐑑𐑼 𐑚𐑮𐑱𐑒 𐑮𐑦𐑥𐑲𐑯𐑛𐑼."
+
+#: ../typing-break/drwright.c:643
+msgid "translator-credits"
+msgstr "·𐑑𐑪𐑥𐑩𐑕 ·𐑔𐑻𐑥𐑩𐑯"
+
+#: ../typing-break/main.c:63
+msgid "Enable debugging code"
+msgstr "𐑦𐑯𐑱𐑚𐑩𐑤 𐑛𐑰𐑚𐑳𐑜𐑦𐑙 𐑒𐑴𐑛"
+
+#: ../typing-break/main.c:65
+msgid "Don't check whether the notification area exists"
+msgstr "𐑛𐑴𐑯𐑑 𐑗𐑧𐑒 𐑢𐑧𐑞𐑼 𐑞 𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩 𐑧𐑒𐑟𐑦𐑕𐑑𐑕"
+
+#: ../typing-break/main.c:91
+msgid "Typing Monitor"
+msgstr "𐑑𐑲𐑐𐑦𐑙 𐑥𐑪𐑯𐑦𐑑𐑼"
+
+#: ../typing-break/main.c:108
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"𐑞 𐑑𐑲𐑐𐑦𐑙 𐑥𐑪𐑯𐑦𐑑𐑼 𐑿𐑟𐑩𐑟 𐑞 𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩 𐑑 𐑛𐑦𐑕𐑐𐑤𐑱 𐑦𐑯𐑓𐑼𐑥𐑱𐑖𐑩𐑯. 𐑿 𐑛𐑴𐑯𐑑 𐑕𐑰𐑥 𐑑 𐑣𐑨𐑝 𐑩 "
+"𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩 𐑪𐑯 𐑿𐑼 𐑐𐑨𐑯𐑩𐑤. 𐑿 𐑒𐑨𐑯 𐑨𐑛 𐑦𐑑 𐑚𐑲 𐑮𐑲𐑑-𐑒𐑤𐑦𐑒𐑦𐑙 𐑪𐑯 𐑿𐑼 𐑐𐑨𐑯𐑩𐑤 𐑯 𐑗𐑵𐑟𐑦𐑙 "
+"'𐑨𐑛 𐑑 𐑐𐑨𐑯𐑩𐑤', 𐑕𐑩𐑤𐑧𐑒𐑑𐑦𐑙 '𐑯𐑴𐑑𐑦𐑓𐑦𐑒𐑱𐑖𐑩𐑯 𐑺𐑦𐑩' 𐑯 𐑒𐑤𐑦𐑒𐑦𐑙 '𐑨𐑛'."
+
+#: ../font-viewer/fontilus.schemas.in.h:1
+#, fuzzy
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 OpenType 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+
+#: ../font-viewer/fontilus.schemas.in.h:2
+#, fuzzy
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 PCF 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+
+#: ../font-viewer/fontilus.schemas.in.h:3
+#, fuzzy
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 TrueType 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+
+#: ../font-viewer/fontilus.schemas.in.h:4
+#, fuzzy
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "𐑦𐑓 𐑕𐑧𐑑 𐑑 𐑑𐑮𐑵, 𐑞𐑧𐑯 Type1 𐑓𐑪𐑯𐑑𐑕 𐑢𐑦𐑤 𐑚𐑰 thumbnailed."
+
+#: ../font-viewer/fontilus.schemas.in.h:5
+#, fuzzy
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 OpenType 𐑓𐑪𐑯𐑑𐑕."
+
+#: ../font-viewer/fontilus.schemas.in.h:6
+#, fuzzy
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 PCF 𐑓𐑪𐑯𐑑𐑕."
+
+#: ../font-viewer/fontilus.schemas.in.h:7
+#, fuzzy
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 TrueType 𐑓𐑪𐑯𐑑𐑕."
+
+#: ../font-viewer/fontilus.schemas.in.h:8
+#, fuzzy
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr "𐑕𐑧𐑑 𐑞𐑦𐑕 𐑒𐑰 𐑑 𐑞 𐑒𐑩𐑥𐑭𐑯𐑛 𐑿𐑕𐑑 𐑑 𐑒𐑮𐑦𐑱𐑑 thumbnails 𐑓𐑹 Type1 𐑓𐑪𐑯𐑑𐑕."
+
+#: ../font-viewer/fontilus.schemas.in.h:9
+#, fuzzy
+msgid "Thumbnail command for OpenType fonts"
+msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 OpenType 𐑓𐑪𐑯𐑑𐑕"
+
+#: ../font-viewer/fontilus.schemas.in.h:10
+#, fuzzy
+msgid "Thumbnail command for PCF fonts"
+msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 PCF 𐑓𐑪𐑯𐑑𐑕"
+
+#: ../font-viewer/fontilus.schemas.in.h:11
+#, fuzzy
+msgid "Thumbnail command for TrueType fonts"
+msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 TrueType 𐑓𐑪𐑯𐑑𐑕"
+
+#: ../font-viewer/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "𐑔𐑳𐑥𐑯𐑱𐑤 𐑒𐑩𐑥𐑭𐑯𐑛 𐑓𐑹 Type1 𐑓𐑪𐑯𐑑𐑕"
+
+#: ../font-viewer/fontilus.schemas.in.h:13
+#, fuzzy
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 OpenType 𐑓𐑪𐑯𐑑𐑕"
+
+#: ../font-viewer/fontilus.schemas.in.h:14
+#, fuzzy
+msgid "Whether to thumbnail PCF fonts"
+msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 PCF 𐑓𐑪𐑯𐑑𐑕"
+
+#: ../font-viewer/fontilus.schemas.in.h:15
+#, fuzzy
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 TrueType 𐑓𐑪𐑯𐑑𐑕"
+
+#: ../font-viewer/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "𐑢𐑧𐑞𐑼 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 Type1 𐑓𐑪𐑯𐑑𐑕"
+
+#: ../font-viewer/font-view.c:290
+msgid "Name:"
+msgstr "𐑯𐑱𐑥:"
+
+#: ../font-viewer/font-view.c:293
+msgid "Style:"
+msgstr "𐑕𐑑𐑲𐑤:"
+
+#: ../font-viewer/font-view.c:306
+msgid "Type:"
+msgstr "𐑑𐑲𐑐:"
+
+#: ../font-viewer/font-view.c:310
+msgid "Size:"
+msgstr "𐑕𐑲𐑟:"
+
+#: ../font-viewer/font-view.c:354 ../font-viewer/font-view.c:367
+msgid "Version:"
+msgstr "𐑝𐑻𐑠𐑩𐑯:"
+
+#: ../font-viewer/font-view.c:358 ../font-viewer/font-view.c:369
+msgid "Copyright:"
+msgstr "𐑒𐑪𐑐𐑦𐑮𐑲𐑑:"
+
+#: ../font-viewer/font-view.c:362
+msgid "Description:"
+msgstr "𐑛𐑦𐑕𐑒𐑮𐑦𐑐𐑖𐑩𐑯:"
+
+#: ../font-viewer/font-view.c:442
+msgid "Installed"
+msgstr "𐑦𐑯𐑕𐑑𐑷𐑤𐑛"
+
+#: ../font-viewer/font-view.c:445
+msgid "Install Failed"
+msgstr "𐑦𐑯𐑕𐑑𐑷𐑤 𐑓𐑱𐑤𐑛"
+
+#: ../font-viewer/font-view.c:517
+#, fuzzy
+msgid "usage: %s fontfile\n"
+msgstr "𐑿𐑕𐑦𐑡: %s fontfile\n"
+
+#: ../font-viewer/font-view.c:592
+msgid "I_nstall Font"
+msgstr "_𐑦𐑯𐑕𐑑𐑷𐑤 𐑓𐑪𐑯𐑑"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
+msgid "Font Viewer"
+msgstr "𐑓𐑪𐑯𐑑 𐑝𐑿𐑼"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
+msgid "Preview fonts"
+msgstr "𐑐𐑮𐑰𐑝𐑿 𐑓𐑪𐑯𐑑𐑕"
+
+#: ../font-viewer/font-thumbnailer.c:245
+#, fuzzy
+msgid "Text to thumbnail (default: Aa)"
+msgstr "𐑑𐑧𐑒𐑕𐑑 𐑑 𐑔𐑳𐑥𐑯𐑱𐑤 (𐑛𐑦𐑓𐑷𐑤𐑑: Aa)"
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "TEXT"
+msgstr "𐑑𐑧𐑒𐑕𐑑"
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "Font size (default: 64)"
+msgstr "𐑓𐑪𐑯𐑑 𐑕𐑲𐑟 (𐑛𐑦𐑓𐑷𐑤𐑑: 64)"
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "SIZE"
+msgstr "𐑕𐑲𐑟"
+
+#: ../font-viewer/font-thumbnailer.c:249
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr "𐑓𐑪𐑯𐑑-𐑓𐑲𐑤 𐑬𐑑𐑐𐑫𐑑-𐑓𐑲𐑤"
+
+#: ../font-viewer/font-thumbnailer.c:268
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr "𐑻𐑼 𐑐𐑸𐑕𐑦𐑙 𐑸𐑜𐑿𐑥𐑩𐑯𐑑𐑕: %s\n"
+
+#: ../libslab/app-shell.c:754
+#, c-format
+msgid "Your filter \"%s\" does not match any items."
+msgstr "𐑿𐑼 𐑓𐑦𐑤𐑑𐑼 \"%s\" 𐑛𐑳𐑟 𐑯𐑪𐑑 𐑥𐑨𐑗 𐑧𐑯𐑦 𐑲𐑑𐑩𐑥𐑟."
+
+#: ../libslab/app-shell.c:756
+msgid "No matches found."
+msgstr "𐑯𐑴 𐑥𐑨𐑗𐑩𐑟 𐑓𐑬𐑯𐑛."
+
+#: ../libslab/app-shell.c:905
+msgid "Other"
+msgstr "𐑳𐑞𐑼"
+
+#. make start action
+#: ../libslab/application-tile.c:374
+#, c-format
+msgid "Start %s"
+msgstr "𐑕𐑑𐑸𐑑 %s"
+
+#: ../libslab/application-tile.c:395
+msgid "Help"
+msgstr "𐑣𐑧𐑤𐑐"
+
+#: ../libslab/application-tile.c:442
+msgid "Upgrade"
+msgstr "𐑳𐑐𐑜𐑮𐑱𐑛"
+
+#: ../libslab/application-tile.c:457
+#, fuzzy
+msgid "Uninstall"
+msgstr "Uninstall"
+
+#: ../libslab/application-tile.c:784 ../libslab/document-tile.c:721
+msgid "Remove from Favorites"
+msgstr "𐑮𐑦𐑥𐑵𐑝 𐑓𐑮𐑪𐑥 𐑓𐑱𐑝𐑼𐑦𐑑𐑕"
+
+#: ../libslab/application-tile.c:786 ../libslab/document-tile.c:723
+msgid "Add to Favorites"
+msgstr "𐑨𐑛 𐑑 𐑓𐑱𐑝𐑼𐑦𐑑𐑕"
+
+#: ../libslab/application-tile.c:871
+msgid "Remove from Startup Programs"
+msgstr "𐑮𐑦𐑥𐑵𐑝 𐑓𐑮𐑪𐑥 𐑕𐑑𐑸𐑑𐑳𐑐 𐑐𐑮𐑴𐑜𐑮𐑨𐑥𐑟"
+
+#: ../libslab/application-tile.c:873
+msgid "Add to Startup Programs"
+msgstr "𐑨𐑛 𐑑 𐑕𐑑𐑸𐑑𐑳𐑐 𐑐𐑮𐑴𐑜𐑮𐑨𐑥𐑟"
+
+#: ../libslab/bookmark-agent.c:1077
+msgid "New Spreadsheet"
+msgstr "𐑯𐑿 𐑕𐑐𐑮𐑧𐑛𐑖𐑰𐑑"
+
+#: ../libslab/bookmark-agent.c:1082
+msgid "New Document"
+msgstr "𐑯𐑿 𐑛𐑪𐑒𐑿𐑥𐑩𐑯𐑑"
+
+#: ../libslab/bookmark-agent.c:1140
+msgid "Documents"
+msgstr "𐑛𐑪𐑒𐑿𐑥𐑩𐑯𐑑𐑕"
+
+#: ../libslab/bookmark-agent.c:1153
+msgid "File System"
+msgstr "𐑓𐑲𐑤 𐑕𐑦𐑕𐑑𐑩𐑥"
+
+#: ../libslab/bookmark-agent.c:1157
+msgid "Network Servers"
+msgstr "𐑯𐑧𐑑𐑢𐑻𐑒 𐑕𐑻𐑝𐑼𐑟"
+
+#: ../libslab/bookmark-agent.c:1186
+msgid "Search"
+msgstr "𐑕𐑻𐑗"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:171
+#, c-format
+msgid "<b>Open</b>"
+msgstr "<b>𐑴𐑐𐑩𐑯</b>"
+
+#. make rename action
+#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:234
+msgid "Rename..."
+msgstr "𐑮𐑰𐑯𐑱𐑥..."
+
+#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
+#: ../libslab/document-tile.c:248 ../libslab/document-tile.c:257
+msgid "Send To..."
+msgstr "𐑕𐑧𐑯𐑛 𐑑..."
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:283
+msgid "Move to Trash"
+msgstr "𐑥𐑵𐑝 𐑑 𐑑𐑮𐑨𐑖"
+
+#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
+#: ../libslab/document-tile.c:293 ../libslab/document-tile.c:837
+msgid "Delete"
+msgstr "𐑛𐑦𐑤𐑰𐑑"
+
+#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:985
+#, c-format
+msgid "Are you sure you want to permanently delete \"%s\"?"
+msgstr "𐑸 𐑿 𐑖𐑫𐑼 𐑿 𐑢𐑪𐑯𐑑 𐑑 𐑐𐑻𐑥𐑩𐑯𐑩𐑯𐑑𐑤𐑦 𐑛𐑦𐑤𐑰𐑑 \"%s\"?"
+
+#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:986
+msgid "If you delete an item, it is permanently lost."
+msgstr "𐑦𐑓 𐑿 𐑛𐑦𐑤𐑰𐑑 𐑩𐑯 𐑲𐑑𐑩𐑥, 𐑦𐑑 𐑦𐑟 𐑐𐑻𐑥𐑩𐑯𐑩𐑯𐑑𐑤𐑦 𐑤𐑪𐑕𐑑."
+
+#: ../libslab/document-tile.c:193
+#, c-format
+msgid "Open with \"%s\""
+msgstr "𐑴𐑐𐑩𐑯 𐑢𐑦𐑞 \"%s\""
+
+#: ../libslab/document-tile.c:207
+msgid "Open with Default Application"
+msgstr "𐑴𐑐𐑩𐑯 𐑢𐑦𐑞 𐑛𐑦𐑓𐑷𐑤𐑑 𐑩𐑐𐑤𐑦𐑒𐑱𐑕𐑩𐑯"
+
+#: ../libslab/document-tile.c:218
+msgid "Open in File Manager"
+msgstr "𐑴𐑐𐑩𐑯 𐑦𐑯 𐑓𐑲𐑤 𐑥𐑨𐑯𐑩𐑡𐑼"
+
+#: ../libslab/document-tile.c:617
+msgid "?"
+msgstr "?"
+
+#: ../libslab/document-tile.c:624
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#: ../libslab/document-tile.c:632
+msgid "Today %l:%M %p"
+msgstr "𐑑𐑫𐑛𐑱 %l:%M %p"
+
+#: ../libslab/document-tile.c:642
+msgid "Yesterday %l:%M %p"
+msgstr "𐑘𐑧𐑕𐑑𐑼𐑛𐑱 %l:%M %p"
+
+#: ../libslab/document-tile.c:654
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../libslab/document-tile.c:662
+msgid "%b %d %l:%M %p"
+msgstr "%b %d %l:%M %p"
+
+#: ../libslab/document-tile.c:664
+msgid "%b %d %Y"
+msgstr "%b %d %Y"
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr "𐑓𐑲𐑯𐑛 𐑯𐑬"
+
+#: ../libslab/system-tile.c:127
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr "<b>𐑴𐑐𐑩𐑯 %s</b>"
+
+#: ../libslab/system-tile.c:140
+#, c-format
+msgid "Remove from System Items"
+msgstr "𐑮𐑦𐑥𐑵𐑝 𐑓𐑮𐑪𐑥 𐑕𐑦𐑕𐑑𐑩𐑥 𐑲𐑑𐑩𐑥𐑟"
+
+msgid "Show help options"
+msgstr "𐑖𐑴 𐑣𐑧𐑤𐑐 𐑪𐑐𐑖𐑩𐑯𐑟"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-01-31 20:41-0500\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2005-08-06 19:59-0400\n"
 "Last-Translator: Adam Weinberger <adamw@gnome.org>\n"
 "Language-Team: Canadian English <adamw@gnome.org>\n"
@@ -18,3463 +18,7379 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "Image/label border"
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "Width of border around the label and image in the alert dialogue"
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr "Alert Type"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "The type of alert"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "Alert Buttons"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "The buttons shown in the alert dialogue"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "Show more _details"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "About Me"
-msgstr "About Me"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "Set your personal information"
-
-#: ../capplets/about-me/gnome-about-me.c:604
-msgid "Select Image"
-msgstr "Select Image"
-
-#: ../capplets/about-me/gnome-about-me.c:606
-msgid "No Image"
-msgstr "No Image"
-
-#: ../capplets/about-me/gnome-about-me.c:769
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server cannot handle the protocol"
-
-#: ../capplets/about-me/gnome-about-me.c:790
-msgid "Unable to open address book"
-msgstr "Unable to open address book"
-
-#: ../capplets/about-me/gnome-about-me.c:802
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr "Unknown login ID; the user database might be corrupted"
-
-#: ../capplets/about-me/gnome-about-me.c:833
-#: ../capplets/about-me/gnome-about-me.c:835
-#, c-format
-msgid "About %s"
-msgstr "About %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:707
-msgid "Old password is incorrect, please retype it"
-msgstr "Old password is incorrect; please retype it"
-
-#: ../capplets/about-me/gnome-about-me-password.c:127
-msgid "System error has occurred"
-msgstr "System error has occurred"
-
-#: ../capplets/about-me/gnome-about-me-password.c:128
-msgid "Could not run /usr/bin/passwd"
-msgstr "Could not run /usr/bin/passwd"
-
-#: ../capplets/about-me/gnome-about-me-password.c:129
-msgid "Unable to launch backend"
-msgstr "Unable to launch backend"
-
-#: ../capplets/about-me/gnome-about-me-password.c:131
-#: ../capplets/about-me/gnome-about-me-password.c:132
-msgid "Unexpected error has occurred"
-msgstr "Unexpected error has occurred"
-
-#: ../capplets/about-me/gnome-about-me-password.c:331
-msgid "Password is too short"
-msgstr "Password is too short"
-
-#: ../capplets/about-me/gnome-about-me-password.c:334
-#: ../capplets/about-me/gnome-about-me-password.c:337
-msgid "Password is too simple"
-msgstr "Password is too simple"
-
-#: ../capplets/about-me/gnome-about-me-password.c:340
-msgid "Old and new passwords are too similar"
-msgstr "Old and new passwords are too similar"
-
-#: ../capplets/about-me/gnome-about-me-password.c:343
-msgid "Must contain numeric or special character(s)"
-msgstr "Must contain numeric or special character(s)"
-
-#: ../capplets/about-me/gnome-about-me-password.c:348
-msgid "Old and new password are the same"
-msgstr "Old and new password are the same"
-
-#: ../capplets/about-me/gnome-about-me-password.c:634
-msgid "Please type the passwords."
-msgstr "Please type the passwords."
-
-#: ../capplets/about-me/gnome-about-me-password.c:642
-msgid "Please type the password again, it is wrong."
-msgstr "Incorrect password; please type the password again."
-
-#: ../capplets/about-me/gnome-about-me-password.c:645
-msgid "Click on Change Password to change the password."
-msgstr "Click on \"Change Password\" to change the password."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-msgid "    "
-msgstr "    "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Email</b>"
-msgstr "<b>Email</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Home</b>"
-msgstr "<b>Home</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Instant Messaging</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Job</b>"
-msgstr "<b>Job</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
-msgstr "<b>Please type the passwords.</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<b>Telephone</b>"
-msgstr "<b>Telephone</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "<b>Web</b>"
-msgstr "<b>Web</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "<b>Work</b>"
-msgstr "<b>Work</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "A_ddress:"
-msgstr "A_ddress:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr "A_ssistant:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "Address"
-msgstr "Address"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "C_ity:"
-msgstr "C_ity:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "C_ompany:"
-msgstr "C_ompany:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Cale_ndar:"
-msgstr "Cale_ndar:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change Passwo_rd..."
-msgstr "Change Passwo_rd..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Change Password"
-msgstr "Change Password"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Ci_ty:"
-msgstr "Ci_ty:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Co_untry:"
-msgstr "Co_untry:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Contact"
-msgstr "Contact"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Cou_ntry:"
-msgstr "Cou_ntry:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr "Full Name"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Hom_e:"
-msgstr "Hom_e:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "Old pa_ssword:"
-msgstr "Old pa_ssword:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P.O. _box:"
-msgstr "P.O. _box:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P._O. box:"
-msgstr "P._O. box:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "Personal Info"
-msgstr "Personal Info"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "State/Pro_vince:"
-msgstr "Pro_vince/State:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-msgid "User name:"
-msgstr "User name:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Web _log:"
-msgstr "Web _log:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "Wor_k:"
-msgstr "Wor_k:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid "Work _fax:"
-msgstr "Work _fax:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Zip/_Postal code:"
-msgstr "_Postal/Zip Code:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "_Address:"
-msgstr "_Address:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr "_Department:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr "_Groupwise:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "_Home page:"
-msgstr "_Home page:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "_Home:"
-msgstr "_Home:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr "_Jabber:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Manager:"
-msgstr "_Manager:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Mobile:"
-msgstr "_Mobile:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_New password:"
-msgstr "_New password:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Profession:"
-msgstr "_Profession:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Retype new password:"
-msgstr "_Retype new password:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr "_State/Province:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Title:"
-msgstr "_Title:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Work:"
-msgstr "_Work:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Zip/Postal code:"
-msgstr "Postal/_Zip code:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Applications</b>"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
 msgstr "<b>Applications</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Support</b>"
-msgstr "<b>Support</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technology Preferences"
-msgstr "Assistive Technology Preferences"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr "Close and _Log Out"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr "Start these assistive technologies every time you log in:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr "_Enable assistive technologies"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr "_Magnifier"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr "_On-screen keyboard"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Screenreader"
-msgstr "_Screenreader"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr "Assistive Technology Support"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr "Enable support for GNOME assistive technologies at login"
-
-#: ../capplets/accessibility/at-properties/main.c:60
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:242
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr "There was an error launching the mouse preferences dialogue: %s"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:338
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:399
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr "Unable to import AccessX settings from file '%s'"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:436
-msgid "Import Feature Settings File"
-msgstr "Import Feature Settings File"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:440
-msgid "_Import"
-msgstr "_Import"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Keyboard"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr "Set your keyboard accessibility preferences"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-#: ../capplets/theme-switcher/theme-install.glade.h:1
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "<b>Enable Bo_unce Keys</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "<b>Enable Slo_w Keys</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "<b>Enable _Mouse Keys</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "<b>Enable _Repeat Keys</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "<b>Enable _Sticky Keys</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-msgid "<b>Features</b>"
-msgstr "<b>Features</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr "<b>Toggle Keys</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "Basic"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr "Beep if key is re_jected"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
-msgstr "Beep when _features turned on or off from keyboard"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
-msgstr "Beep when _modifier is pressed"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr "Beep when an LED is turned on and two beeps when one is turned off."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr "Beep when key is:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr "Del_ay:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr "Delay between keypress and pointer mo_vement:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr "Disa_ble if two keys pressed together"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr "E_nable Toggle Keys"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Filters"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr "I_gnore duplicate keypresses within:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr "Keyboard Accessibility Preferences (AccessX)"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr "Ma_ximum pointer speed:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr "Mouse Keys"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr "Mouse _Preferences..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "S_peed:"
-msgstr "S_peed:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr "Time to acce_lerate to maximum speed:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr "Turn the numeric keypad into a mouse control pad."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr "_Disable if unused for:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr "_Enable keyboard accessibility features"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr "_Import Feature Settings..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr "_Only accept keys held for:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "_Type to test settings:"
-msgstr "_Type to test settings:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr "_accepted"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr "_pressed"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr "_rejected"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr "characters/second"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-msgid "milliseconds"
-msgstr "milliseconds"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr "pixels/second"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "seconds"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-msgid "Change your Desktop Background settings"
-msgstr "Change your Desktop Background settings"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-msgid "Desktop Background"
-msgstr "Desktop Background"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "<b>Desktop _Wallpaper</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-msgid "<b>_Desktop Colors</b>"
-msgstr "<b>_Desktop Colours</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-msgid "Desktop Background Preferences"
-msgstr "Desktop Background Preferences"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr "Open a dialogue to specify the colour"
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr "_Add Wallpaper"
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-msgid "_Remove"
-msgstr "_Remove"
-
-#: ../capplets/background/gnome-background-properties.glade.h:7
-msgid "_Style:"
-msgstr "_Style:"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "There was an error displaying help: %s"
-
-#: ../capplets/background/gnome-wp-capplet.c:1046
-msgid "Centered"
-msgstr "Centred"
-
-#: ../capplets/background/gnome-wp-capplet.c:1050
-msgid "Fill Screen"
-msgstr "Fill Screen"
-
-#: ../capplets/background/gnome-wp-capplet.c:1054
-msgid "Scaled"
-msgstr "Scaled"
-
-#: ../capplets/background/gnome-wp-capplet.c:1058
-msgid "Zoom"
-msgstr "Zoom"
-
-#: ../capplets/background/gnome-wp-capplet.c:1062
-msgid "Tiled"
-msgstr "Tiled"
-
-#: ../capplets/background/gnome-wp-capplet.c:1083
-msgid "Solid Color"
-msgstr "Solid Colour"
-
-#: ../capplets/background/gnome-wp-capplet.c:1087
-msgid "Horizontal Gradient"
-msgstr "Horizontal Gradient"
-
-#: ../capplets/background/gnome-wp-capplet.c:1091
-msgid "Vertical Gradient"
-msgstr "Vertical Gradient"
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1137
-msgid "Add Wallpaper"
-msgstr "Add Wallpaper"
-
-#: ../capplets/background/gnome-wp-capplet.c:1154
-msgid "Images"
-msgstr "Images"
-
-#: ../capplets/background/gnome-wp-capplet.c:1158
-msgid "All Files"
-msgstr "All Files"
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr "No Wallpaper"
-
-#: ../capplets/background/gnome-wp-item.c:343
-#: ../capplets/background/gnome-wp-item.c:345
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "pixel"
-msgstr[1] "pixels"
-
-#: ../capplets/common/activate-settings-daemon.c:18
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-
-#: ../capplets/common/capplet-stock-icons.c:92
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "Unable to load stock icon '%s'\n"
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr "Just apply settings and quit"
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1016
-#: ../capplets/sound/sound-properties-capplet.c:244
-msgid "Retrieve and store legacy settings"
-msgstr "Retrieve and store legacy settings"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "Copying file: %u of %u"
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr "Copying '%s'"
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr "From URI"
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr "URI currently transferring from"
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr "To URI"
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr "URI currently transferring to"
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr "Fraction completed"
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr "Fraction of transfer currently completed"
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr "Current URI index"
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr "Current URI index - starts from 1"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr "Total URIs"
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr "Total number of URIs"
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr "Copying files"
-
-#: ../capplets/common/file-transfer-dialog.c:345
-msgid "From:"
-msgstr "From:"
-
-#: ../capplets/common/file-transfer-dialog.c:349
-msgid "To:"
-msgstr "To:"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr "Connecting..."
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Key"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr "GConf key to which this property editor is attached"
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr "Callback"
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Issue this callback when the value associated with key gets changed"
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr "Change set"
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr "Conversion to widget callback"
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr "Conversion from widget callback"
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr "UI Control"
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr "Object that controls the property (normally a widget)"
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr "Property editor object data"
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr "Custom data required by the specific property editor"
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr "Property editor data freeing callback"
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr "Callback to be issued when property editor object data is to be freed"
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Could not find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"I do not know how to open the file '%s'.\n"
-"Perhaps it is a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr "Please select an image."
-
-#: ../capplets/common/gconf-property-editor.c:1598
-msgid "_Select"
-msgstr "_Select"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
 msgstr "Preferred Applications"
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Select your default applications"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:56
-msgid "Could not display help"
-msgstr "Could not display help"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:58
-#: ../capplets/default-applications/gnome-da-capplet.c:689
-msgid "Please make sure that the applet is properly installed"
-msgstr "Please make sure that the applet is properly installed"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:93
-#: ../capplets/default-applications/gnome-da-capplet.c:126
-#: ../capplets/default-applications/gnome-da-capplet.c:185
-#: ../capplets/default-applications/gnome-da-capplet.c:230
-#: ../capplets/default-applications/gnome-da-capplet.c:284
-#: ../capplets/default-applications/gnome-da-capplet.c:333
-#: ../capplets/default-applications/gnome-da-capplet.c:524
-#: ../capplets/default-applications/gnome-da-capplet.c:545
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "Error saving configuration: %s"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:665
-msgid "Custom"
-msgstr "Custom"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:687
-msgid "Could not load the main interface"
-msgstr "Could not load the main interface"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Debian Sensible Browser"
-msgstr "Debian Sensible Browser"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Debian Terminal Emulator"
-msgstr "Debian Terminal Emulator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Encompass"
-msgstr "Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Epiphany Web Browser"
-msgstr "Epiphany Web Browser"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "Evolution Mail Reader"
-msgstr "Evolution Mail Reader"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Evolution Mail Reader 1.4"
-msgstr "Evolution Mail Reader 1.4"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Evolution Mail Reader 1.5"
-msgstr "Evolution Mail Reader 1.5"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader 1.6"
-msgstr "Evolution Mail Reader 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Evolution Mail Reader 2.0"
-msgstr "Evolution Mail Reader 2.0"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Evolution Mail Reader 2.2"
-msgstr "Evolution Mail Reader 2.2"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "Evolution Mail Reader 2.4"
-msgstr "Evolution Mail Reader 2.4"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "Firebird"
-msgstr "Firebird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "GNOME Terminal"
-msgstr "GNOME Terminal"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "KMail"
-msgstr "KMail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Links Text Browser"
-msgstr "Links Text Browser"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Lynx Text Browser"
-msgstr "Lynx Text Browser"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "Mozilla Mail"
-msgstr "Mozilla Mail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Netscape Communicator"
-msgstr "Netscape Communicator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Opera"
-msgstr "Opera"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Standard XTerminal"
-msgstr "Standard XTerminal"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "W3M Text Browser"
-msgstr "W3M Text Browser"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Audio Player</b>"
-msgstr "<b>Audio Player</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Image Viewer</b>"
-msgstr "<b>Image Viewer</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Instant Messenger</b>"
-msgstr "<b>Instant Messenger</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mail Reader</b>"
-msgstr "<b>Mail Reader</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>Terminal Emulator</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Text Editor</b>"
-msgstr "<b>Text Editor</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Video Player</b>"
-msgstr "<b>Video Player</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Web Browser</b>"
-msgstr "<b>Web Browser</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "All %s occurrences will be replaced with actual link"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Co_mmand:"
-msgstr "Co_mmand:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "E_xecute flag:"
-msgstr "E_xecute flag:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Internet"
-msgstr "Internet"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Multimedia"
-msgstr "Multimedia"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Open link in new _tab"
-msgstr "Open link in new _tab"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Open link in new _window"
-msgstr "Open link in new _window"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Open link with web browser _default"
-msgstr "Open link with web browser _default"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Run in t_erminal"
-msgstr "Run in t_erminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "System"
-msgstr "System"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Change screen resolution"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Screen Resolution"
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/main.c:448
-msgid "_Resolution:"
-msgstr "_Resolution:"
-
-#: ../capplets/display/main.c:467
-msgid "Re_fresh rate:"
-msgstr "Re_fresh rate:"
-
-#: ../capplets/display/main.c:488
-msgid "Default Settings"
-msgstr "Default Settings"
-
-#: ../capplets/display/main.c:490
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr "Screen %d Settings\n"
-
-#: ../capplets/display/main.c:516
-msgid "Screen Resolution Preferences"
-msgstr "Screen Resolution Preferences"
-
-#: ../capplets/display/main.c:553
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "_Make default for this computer (%s) only"
-
-#: ../capplets/display/main.c:571
-msgid "Options"
-msgstr "Options"
-
-#: ../capplets/display/main.c:592
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"Testing the new settings. If you do not respond in %d second the previous "
-"settings will be restored."
-msgstr[1] ""
-"Testing the new settings. If you do not respond in %d seconds the previous "
-"settings will be restored."
-
-#: ../capplets/display/main.c:638
-msgid "Keep Resolution"
-msgstr "Keep Resolution"
-
-#: ../capplets/display/main.c:642
-msgid "Do you want to keep this resolution?"
-msgstr "Do you want to keep this resolution?"
-
-#: ../capplets/display/main.c:667
-msgid "Use _previous resolution"
-msgstr "Use _previous resolution"
-
-#: ../capplets/display/main.c:667
-msgid "_Keep resolution"
-msgstr "_Keep resolution"
-
-#: ../capplets/display/main.c:818
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-
-#: ../capplets/display/main.c:826
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Font"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr "Select fonts for the desktop"
-
-#: ../capplets/font/font-properties.glade.h:1
-msgid "<b>Font Rendering</b>"
-msgstr "<b>Font Rendering</b>"
-
-#: ../capplets/font/font-properties.glade.h:2
-msgid "<b>Hinting</b>:"
-msgstr "<b>Hinting</b>:"
-
-#: ../capplets/font/font-properties.glade.h:3
-msgid "<b>Smoothing</b>:"
-msgstr "<b>Smoothing</b>:"
-
-#: ../capplets/font/font-properties.glade.h:4
-msgid "<b>Subpixel order</b>:"
-msgstr "<b>Subpixel order</b>:"
-
-#: ../capplets/font/font-properties.glade.h:5
-msgid "Best _shapes"
-msgstr "Best _shapes"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best co_ntrast"
-msgstr "Best co_ntrast"
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "D_etails..."
-msgstr "D_etails..."
-
-#: ../capplets/font/font-properties.glade.h:8
-msgid "Des_ktop font:"
-msgstr "Des_ktop font:"
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "Font Preferences"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr "Font Rendering Details"
-
-#: ../capplets/font/font-properties.glade.h:11
-msgid "Go _to font folder"
-msgstr "Go _to font folder"
-
-#: ../capplets/font/font-properties.glade.h:12
-msgid "Gra_yscale"
-msgstr "Gre_yscale"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "N_one"
-
-#: ../capplets/font/font-properties.glade.h:14
-msgid "R_esolution:"
-msgstr "R_esolution:"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr "Sub_pixel (LCDs)"
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "Sub_pixel smoothing (LCDs)"
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
-msgstr "_Application font:"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Document font:"
-msgstr "_Document font:"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Fixed width font:"
-msgstr "_Fixed-width font:"
-
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Full"
-msgstr "_Full"
-
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Medium"
-msgstr "_Medium"
-
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_Monochrome"
-msgstr "_Monochrome"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_None"
-msgstr "_None"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Slight"
-msgstr "_Slight"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "_Window title font:"
-
-#: ../capplets/font/font-properties.glade.h:30
-msgid "dots per inch"
-msgstr "dots per inch"
-
-#: ../capplets/font/main.c:489
-msgid "Font may be too large"
-msgstr "Font may be too large"
-
-#: ../capplets/font/main.c:493
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgstr[1] ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-
-#: ../capplets/font/main.c:506
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgstr[1] ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "New accelerator..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Accelerator key"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Accelerator modifiers"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Accelerator keycode"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Accel Mode"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "The type of accelerator."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:197
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:471
-msgid "Disabled"
-msgstr "Disabled"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:544
-msgid "<Unknown Action>"
-msgstr "<Unknown Action>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:565
-msgid "Desktop"
-msgstr "Desktop"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:566
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
-msgstr "Sound"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:570
-msgid "Window Management"
-msgstr "Window Management"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:676
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become unusable to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time.\n"
-msgstr ""
-"The shortcut \"%s\" cannot be used because it will become unusable to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time.\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:705
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-msgstr ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:737
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr "Error setting new accelerator in configuration database: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:787
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr "Error unsetting accelerator in configuration database: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:894
-msgid "Action"
-msgstr "Action"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:918
-msgid "Shortcut"
-msgstr "Shortcut"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Keyboard Shortcuts"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
-msgstr ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Assign shortcut keys to commands"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
-msgid "Unknown"
-msgstr "Unknown"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
-msgid "Layout"
-msgstr "Layout"
-
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
-msgid "Default"
-msgstr "Default"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
-msgid "Models"
-msgstr "Models"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:109
-#, c-format
-msgid "There was an error launching the keyboard tool: %s"
-msgstr "There was an error launching the keyboard tool: %s"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
-msgstr "_Accessibility"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:240
-#: ../capplets/sound/sound-properties-capplet.c:242
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
-msgstr "Start the page with the typing break settings showing"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "..."
-msgstr "..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>Cursor Blinking</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Repeat Keys</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<b>_Lock screen to enforce typing break</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Fast</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Long</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Short</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Slow</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_vailable layouts:"
-msgstr "A_vailable layouts:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "All_ow postponing of breaks"
-msgstr "All_ow postponing of breaks"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Check if breaks are allowed to be postponed"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "Choose a Keyboard Model"
-msgstr "Choose a Keyboard Model"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Choose a Layout"
-msgstr "Choose a Layout"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
-msgstr "Cursor _blinks in text boxes and fields"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Cursor blinks speed"
-msgstr "Cursor blink speed"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of the break when typing is disallowed"
-msgstr "Duration of the break when typing is disallowed"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Duration of work before forcing a break"
-msgstr "Duration of work before forcing a break"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Key presses _repeat when key is held down"
-msgstr "Key presses _repeat when key is held down"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Keyboard Preferences"
-msgstr "Keyboard Preferences"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Keyboard _model:"
-msgstr "Keyboard _model:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Layout Options"
-msgstr "Layout Options"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Layouts"
-msgstr "Layouts"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Microsoft Natural Keyboard"
-msgstr "Microsoft Natural Keyboard"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Preview:"
-msgstr "Preview:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "Repeat keys speed"
-msgstr "Repeat keys speed"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Reset To De_faults"
-msgstr "Reset To De_faults"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Separate _group for each window"
-msgstr "Separate _group for each window"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-msgid "Typing Break"
-msgstr "Typing Break"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Accessibility..."
-msgstr "_Accessibility..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Add..."
-msgstr "_Add..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "_Break interval lasts:"
-msgstr "_Break interval lasts:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Delay:"
-msgstr "_Delay:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Models:"
-msgstr "_Models:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Selected layouts:"
-msgstr "_Selected layouts:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Speed:"
-msgstr "_Speed:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "_Work interval lasts:"
-msgstr "_Work interval lasts:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "minutes"
-msgstr "minutes"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Set your keyboard preferences"
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:880
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "microseconds"
-msgstr "microseconds"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:560
-msgid "Unknown Pointer"
-msgstr "Unknown Pointer"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:761
-msgid "Default Pointer"
-msgstr "Default Pointer"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Pointer - Current"
-msgstr "Default Pointer - Current"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-msgid "The default pointer that ships with X"
-msgstr "The default pointer that ships with X"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-msgid "White Pointer"
-msgstr "White Pointer"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Pointer - Current"
-msgstr "White Pointer - Current"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-msgid "The default pointer inverted"
-msgstr "The default pointer inverted"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-msgid "Large Pointer"
-msgstr "Large Pointer"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Pointer - Current"
-msgstr "Large Pointer - Current"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-msgid "Large version of normal pointer"
-msgstr "Large version of normal pointer"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-msgid "Large White Pointer - Current"
-msgstr "Large White Pointer - Current"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Pointer"
-msgstr "Large White Pointer"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-msgid "Large version of white pointer"
-msgstr "Large version of white pointer"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:970
-msgid "Pointer Theme"
-msgstr "Pointer Theme"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr "<b>Double-Click Timeout </b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Drag and Drop</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Locate Pointer</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>Mouse Orientation</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Speed</b>"
-msgstr "<b>Speed</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>Fast</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>High</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>Large</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>Low</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>Slow</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>Small</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Buttons"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr "Highlight the _pointer when you press Ctrl"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Large"
-msgstr "Large"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Medium"
-msgstr "Medium"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "Motion"
-msgstr "Motion"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-msgid "Mouse Preferences"
-msgstr "Mouse Preferences"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Pointer Size:"
-msgstr "Pointer Size:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Pointers"
-msgstr "Pointers"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "Small"
-msgstr "Small"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
-msgstr "_Acceleration:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
-msgstr "_Left-handed mouse"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr "_Sensitivity:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr "_Threshold:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
-msgstr "_Timeout:"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Mouse"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Set your mouse preferences"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Network Proxy"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "Set your network proxy preferences"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>Di_rect internet connection</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
-msgstr "<b>Ignore Host List</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>_Automatic proxy configuration</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>_Manual proxy configuration</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Use authentication</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "Advanced Configuration"
-msgstr "Advanced Configuration"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr "Autoconfiguration _URL:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "HTTP Proxy Details"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "H_TTP proxy:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Network Proxy Preferences"
-msgstr "Network Proxy Preferences"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Port:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "Proxy Configuration"
-msgstr "Proxy Configuration"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr "S_ocks host:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "U_sername:"
-msgstr "U_sername:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_Details"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr "_FTP proxy:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "_Password:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr "_Secure HTTP proxy:"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Enable sound and associate sounds with events"
-
-#: ../capplets/sound/sound-properties-capplet.c:271
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "Sound Preferences"
-msgstr "Sound Preferences"
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "E_nable software sound mixing (ESD)"
-msgstr "E_nable software sound mixing (ESD)"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "Flash _entire screen"
-msgstr "Flash _entire screen"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "Flash _window titlebar"
-msgstr "Flash _window titlebar"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "Sounds"
-msgstr "Sounds"
-
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "System Beep"
-msgstr "System Beep"
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "_Enable system beep"
-msgstr "_Enable system beep"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "_Play system sounds"
-msgstr "_Play system sounds"
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "_Visual system beep"
-msgstr "_Visual system beep"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:368
-msgid "Would you like to remove this theme?"
-msgstr "Would you like to remove this theme?"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:433
-msgid "Theme deleted succesfully. Please select another theme."
-msgstr "Theme deleted succesfully. Please select another theme."
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:442
-msgid "Theme can not be deleted"
-msgstr "Theme cannot be deleted"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:529
-msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
-msgstr ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialogue was improperly installed, or you have not "
-"installed the \"gnome-themes\" package."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:227
-msgid "This theme is not in a supported format."
-msgstr "This theme is not in a supported format."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:242
-msgid "Failed to create temporary directory"
-msgstr "Failed to create temporary directory"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:260
-msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
-msgstr ""
-"Cannot install theme. \n"
-"The bzip2 utility is not installed."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:276
-#: ../capplets/theme-switcher/gnome-theme-installer.c:309
-#: ../capplets/theme-switcher/gnome-theme-installer.c:383
-msgid "Installation Failed"
-msgstr "Installation Failed"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:294
-msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
-msgstr ""
-"Cannot install themes. \n"
-"The gzip utility is not installed."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:330
-#, c-format
-msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:333
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr "Gnome Theme %s correctly installed"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:336
-#, c-format
-msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:339
-#, c-format
-msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:345
-msgid "The theme is an engine. You need to compile the theme."
-msgstr "The theme is an engine. You need to compile the theme."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:360
-msgid "The file format is invalid"
-msgstr "The file format is invalid"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:450
-msgid "No theme file location specified to install"
-msgstr "No theme file location specified to install"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:469
-msgid "The theme file location specified to install is invalid"
-msgstr "The theme file location specified to install is invalid"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:489
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:510
-msgid "The file format is invalid."
-msgstr "The file format is invalid."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:537
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:591
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
-msgstr ""
-"Cannot install theme.\n"
-"The tar(1) program is not installed on your system."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:686
-msgid "Custom theme"
-msgstr "Custom theme"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:686
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr "You can save this theme by pressing the Save Theme button."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1584
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably do not have metacity installed, or that your gconf is "
-"configured incorrectly."
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:72
-msgid "Theme name must be present"
-msgstr "Theme name must be present"
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:104
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "The theme already exists. Would you like to replace it?"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr "Select themes for various parts of the desktop"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "Theme"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:3
-msgid "Theme Installation"
-msgstr "Theme Installation"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:4
-msgid "_Install"
-msgstr "_Install"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:5
-msgid "_Location:"
-msgstr "_Location:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "Apply _Background"
-msgstr "Apply _Background"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Apply _Font"
-msgstr "Apply _Font"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Controls"
-msgstr "Controls"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Icons"
-msgstr "Icons"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "New themes can also be installed by dragging them into the window."
-msgstr "New themes can also be installed by dragging them into the window."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "Save Theme"
-msgstr "Save Theme"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-msgid "Select theme for the desktop"
-msgstr "Select theme for the desktop"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-msgid "Short _description:"
-msgstr "Short _description:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-msgid "Theme Details"
-msgstr "Theme Details"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "Theme Preferences"
-msgstr "Theme Preferences"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "Theme _Details"
-msgstr "Theme _Details"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-msgid "This theme does not suggest any particular font or background."
-msgstr "This theme does not suggest any particular font or background."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-msgid "This theme suggests a background:"
-msgstr "This theme suggests a background:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-msgid "This theme suggests a font and a background:"
-msgstr "This theme suggests a font and a background:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-msgid "This theme suggests a font:"
-msgstr "This theme suggests a font:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-msgid "Window Border"
-msgstr "Window Border"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "_Install Theme..."
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
 msgstr "_Install Theme..."
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-msgid "_Revert"
-msgstr "_Revert"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-msgid "_Save Theme..."
-msgstr "_Save Theme..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-msgid "_Theme name:"
-msgstr "_Theme name:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-msgid "theme selection tree"
-msgstr "theme selection tree"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
-msgstr "Customize the appearance of toolbars and menubars in applications"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "Menus & Toolbars"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
-msgstr "<b>Behaviour and Appearance</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-msgid "<b>Preview</b>"
-msgstr "<b>Preview</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "C_ut"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-msgid "Icons only"
-msgstr "Icons only"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "Menu and Toolbar Preferences"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "New File"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Open File"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Save File"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr "Show _icons in menus"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-msgid "Text below icons"
-msgstr "Text below icons"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-msgid "Text beside icons"
-msgstr "Text beside icons"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-msgid "Text only"
-msgstr "Text only"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
-msgid "Toolbar _button labels:"
-msgstr "Toolbar _button labels:"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_Copy"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
-msgstr "_Detachable toolbars"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
-msgstr "_Edit"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
-msgstr "_Editable menu accelerators"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "_File"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_New"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
 msgstr "_Open"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "_Paste"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "_Print"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "_Quit"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "_Save"
-
-#: ../capplets/windows/gnome-window-properties.c:385
-#, c-format
-msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
-msgstr ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
-
-#: ../capplets/windows/gnome-window-properties.c:642
-msgid "C_ontrol"
-msgstr "C_ontrol"
-
-#: ../capplets/windows/gnome-window-properties.c:647
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:653
-msgid "H_yper"
-msgstr "H_yper"
-
-#: ../capplets/windows/gnome-window-properties.c:660
-msgid "S_uper (or \"Windows logo\")"
-msgstr "S_uper (or \"Windows logo\")"
-
-#: ../capplets/windows/gnome-window-properties.c:667
-msgid "_Meta"
-msgstr "_Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Movement Key</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>Titlebar Action</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Window Selection</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr "To move a window, press-and-hold this key then grab the window:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Window Preferences"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_Double-click titlebar to perform this action:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "_Interval before raising:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_Raise selected windows after an interval"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Select windows when the mouse moves over them"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "Set your window properties"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "Windows"
-
-#: ../control-center/control-center-categories.c:287
-msgid "Others"
-msgstr "Others"
-
-#: ../control-center/control-center.c:93
-msgid "Desktop Preferences"
-msgstr "Desktop Preferences"
-
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr "GNOME Control Centre"
-
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "The GNOME configuration tool"
-
-#: ../gnome-settings-daemon/actions/acme-fb-level.c:149
-msgid "No '/dev/pmu' device found"
-msgstr "No '/dev/pmu' device found"
-
-#: ../gnome-settings-daemon/actions/acme-fb-level.c:156
-msgid "Not a powerbook"
-msgstr "Not a PowerBook"
-
-#: ../gnome-settings-daemon/actions/acme-fb-level.c:173
-msgid "Wrong permission for '/dev/pmu' device"
-msgstr "Wrong permission for '/dev/pmu' device"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "Volume"
-
-#: ../gnome-settings-daemon/factory.c:37
-msgid "Could not initialize Bonobo"
-msgstr "Could not initialize Bonobo"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:406
-msgid "Slow Keys Alert"
-msgstr "Slow Keys Alert"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:407
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-msgstr ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:409
-msgid "Do you want to activate Slow Keys?"
-msgstr "Do you want to activate Slow Keys?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Do you want to deactivate Slow Keys?"
-msgstr "Do you want to deactivate Slow Keys?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
-msgid "_Activate"
-msgstr "_Activate"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
-msgid "_Deactivate"
-msgstr "_Deactivate"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
-msgid "Do_n't activate"
-msgstr "Do_n't activate"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
-msgid "Do_n't deactivate"
-msgstr "Do_n't deactivate"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:421
-msgid "Sticky Keys Alert"
-msgstr "Sticky Keys Alert"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:422
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:424
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:426
-msgid "Do you want to activate Sticky Keys?"
-msgstr "Do you want to activate Sticky Keys?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:427
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr "Do you want to deactivate Sticky Keys?"
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:74
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing the mouse pointer theme."
-msgstr ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing the mouse pointer theme."
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:96
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:208
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr "Key Binding (%s) has its action defined multiple times\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:221
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr "Key Binding (%s) has its binding defined multiple times\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:227
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr "Key Binding (%s) is incomplete\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:255
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr "Key Binding (%s) is invalid\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:291
-#, c-format
-msgid "It seems that another application already has access to key '%u'."
-msgstr "It seems that another application already has access to key '%u'."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:360
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr "Key Binding (%s) is already in use\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:435
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
-#, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-"Error activating XKB configuration.\n"
-"This can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or using a newer version of XFree software."
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:223
-msgid "Do _not show this warning again"
-msgstr "Do _not show this warning again"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:234
-msgid ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
-msgstr ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:247
-msgid "Use X settings"
-msgstr "Use X settings"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:249
-msgid "Use GNOME settings"
-msgstr "Use GNOME settings"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
-msgstr ""
-"Could not execute command: %s\n"
-"Verify that this command exists."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-"Could not put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:180
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-"Could not load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:110
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:120
-msgid "_Do not show this message again"
-msgstr "_Do not show this message again"
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:150
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr "Could not load sound file %s as sample %s"
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:212
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:260
-msgid "Cannot determine user's home directory"
-msgstr "Cannot determine user's home directory"
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:212
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr "GConf key %s set to type %s but its expected type was %s\n"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-msgid "A_vailable files:"
-msgstr "A_vailable files:"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-msgid "Do _not show this warning again."
-msgstr "Do _not show this warning again."
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
-msgstr "Load modmap files"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
-msgstr "Would you like to load the modmap file(s)?"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr "_Load"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-msgid "_Loaded files:"
-msgstr "_Loaded files:"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr "Error creating signal pipe."
-
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "Type"
-
-#: ../libbackground/applier.c:256
-msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-msgstr ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr "Preview Width"
-
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr "Width if applier is a preview: Defaults to 64."
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr "Preview Height"
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr "Height if applier is a preview: Defaults to 48."
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Screen"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr "Screen on which BGApplier is to draw"
-
-#: ../libgswitchit/gswitchit_config.c:1036
-#, c-format
-msgid "There was an error loading an image: %s"
-msgstr "There was an error loading an image: %s"
-
-#: ../libsounds/sound-view.c:115
-msgid "Sound not set for this event."
-msgstr "Sound not set for this event."
-
-#: ../libsounds/sound-view.c:124
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package for a set of default sounds."
-msgstr ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package for a set of default sounds."
-
-#: ../libsounds/sound-view.c:135
-msgid "The sound file for this event does not exist."
-msgstr "The sound file for this event does not exist."
-
-#: ../libsounds/sound-view.c:166
-msgid "Select Sound File"
-msgstr "Select Sound File"
-
-#: ../libsounds/sound-view.c:186
-#, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "The file %s is not a valid wav file"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "Window manager \"%s\" has not registered a configuration tool\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Maximize"
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Roll up"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr "Sync text/plain and text/* handlers"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "Brightness down"
-msgstr "Brightness down"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "Brightness down's shortcut."
-msgstr "Brightness down's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Brightness up"
-msgstr "Brightness up"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Brightness up's shortcut."
-msgstr "Brightness up's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "E-mail"
-msgstr "E-mail"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "E-mail's shortcut."
-msgstr "E-mail's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Eject"
-msgstr "Eject"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-msgid "Eject's shortcut."
-msgstr "Eject's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-msgid "Home folder"
-msgstr "Home folder"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-msgid "Home folder's shortcut."
-msgstr "Home folder's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-msgid "Launch help browser"
-msgstr "Launch help browser"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-msgid "Launch help browser's shortcut."
-msgstr "Launch help browser's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-msgid "Launch web browser"
-msgstr "Launch web browser"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-msgid "Launch web browser's shortcut."
-msgstr "Launch web browser's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-msgid "Lock screen"
-msgstr "Lock screen"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-msgid "Lock screen's shortcut."
-msgstr "Lock screen's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-msgid "Log out"
-msgstr "Log out"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-msgid "Log out's shortcut."
-msgstr "Log out's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Next track key's shortcut."
-msgstr "Next track key's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Pause"
-msgstr "Pause"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-msgid "Pause key's shortcut."
-msgstr "Pause key's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Play (or play/pause)"
-msgstr "Play (or play/pause)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Play (or play/pause) key's shortcut."
-msgstr "Play (or play/pause) key's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Previous track key's shortcut."
-msgstr "Previous track key's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Theme Details"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Search"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-msgid "Search's shortcut."
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Disabled"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_Location:"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Show help options"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Apply _Background"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Screen"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "No Wallpaper"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sounds"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Shortcut"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Keyboard Shortcuts"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Alert Type"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "_Application font:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Email</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Style:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Default"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "Apply _Background"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Screen Resolution"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Large White Pointer"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Brightness up"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Copying files"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Import"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Add..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "_Loaded files:"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "_Remove"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Details"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "minutes"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Medium"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "minutes"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "minutes"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Solid Colour"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Select Image"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Select"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_Timeout:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Search"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "Del_ay:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
 msgstr "Search's shortcut."
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Skip to next track"
-msgstr "Skip to next track"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Skip to previous track"
-msgstr "Skip to previous track"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-msgid "Sleep"
-msgstr "Sleep"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-msgid "Sleep's shortcut."
-msgstr "Sleep's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Stop playback key"
-msgstr "Stop playback key"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Stop playback key's shortcut."
-msgstr "Stop playback key's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
-msgid "Volume down"
-msgstr "Volume down"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume down's shortcut."
-msgstr "Volume down's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-msgid "Volume mute"
-msgstr "Volume mute"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume mute's shortcut"
-msgstr "Volume mute's shortcut"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
-msgid "Volume step"
-msgstr "Volume step"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-msgid "Volume step as percentage of volume."
-msgstr "Volume step as percentage of volume."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
-msgid "Volume up"
-msgstr "Volume up"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
-msgid "Volume up's shortcut."
-msgstr "Volume up's shortcut."
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
-msgid "Display a dialog when there are errors running the screensaver"
-msgstr "Display a dialogue when there are errors running the screensaver"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-msgid "Run screensaver at login"
-msgstr "Run screensaver at login"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
-msgstr "Show Startup Errors"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
-msgid "Start screensaver"
-msgstr "Start screensaver"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
 msgstr ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap-based adjustments"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
-msgstr "A list of modmap files available in the $HOME directory."
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
-msgstr "Default group, assigned on window creation"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr "Keep and manage separate group per window"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
-msgid "Keyboard Update Handlers"
-msgstr "Keyboard Update Handlers"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
-msgid "Keyboard layout"
-msgstr "Keyboard layout"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
-msgid "Keyboard model"
-msgstr "Keyboard model"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
-msgid "Keyboard options"
-msgstr "Keyboard options"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
 msgstr ""
-"Keyboard settings in GConf will be overridden from the system ASAP "
-"(deprecated)"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
-msgstr "Save/restore indicators together with layout groups"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
-msgstr "Show layout names instead of group names"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
 msgstr ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr "Suppress the \"X sysconfig changed\" warning message"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
 msgstr ""
-"Very soon, keyboard settings in GConf will be overridden (from the system "
-"configuration). This key has been deprecated since GNOME 2.12. Please unset "
-"the model, layouts and options keys to get the default system configuration."
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
-msgid "keyboard layout"
-msgstr "keyboard layout"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
-msgid "keyboard model"
-msgstr "keyboard model"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "modmap file list"
-msgstr "modmap file list"
-
-#: ../typing-break/drw-break-window.c:213
-msgid "_Postpone break"
-msgstr "_Postpone break"
-
-#: ../typing-break/drw-break-window.c:260
-msgid "Take a break!"
-msgstr "Take a break!"
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:135
-msgid "/_Preferences"
-msgstr "/_Preferences"
-
-#: ../typing-break/drwright.c:136
-msgid "/_About"
-msgstr "/_About"
-
-#: ../typing-break/drwright.c:138
-msgid "/_Take a Break"
-msgstr "/_Take a Break"
-
-#: ../typing-break/drwright.c:489
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "%d minute until the next break"
-msgstr[1] "%d minutes until the next break"
-
-#: ../typing-break/drwright.c:493
-msgid "Less than one minute until the next break"
-msgstr "Less than one minute until the next break"
-
-#: ../typing-break/drwright.c:581
-#, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
 msgstr ""
-"Unable to bring up the typing break properties dialogue with the following "
-"error: %s"
 
-#: ../typing-break/drwright.c:629
-msgid "About GNOME Typing Monitor"
-msgstr "About GNOME Typing Monitor"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Disabled"
 
-#: ../typing-break/drwright.c:653
-msgid "A computer break reminder."
-msgstr "A computer break reminder."
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
 
-#: ../typing-break/drwright.c:654
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
-msgstr "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
 
-#: ../typing-break/drwright.c:655
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Eye candy added by Anders Carlsson"
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
 
-#: ../typing-break/drwright.c:831
-msgid "Break reminder"
-msgstr "Break reminder"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../typing-break/eggtrayicon.c:127
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "seconds"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Cale_ndar:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Change your Desktop Background settings"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Cale_ndar:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Preferred Applications"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Select your default applications"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "_Apply font"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
 msgid "Orientation"
 msgstr "Orientation"
 
-#: ../typing-break/eggtrayicon.c:128
-msgid "The orientation of the tray."
-msgstr "The orientation of the tray."
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Resolution:"
 
-#: ../typing-break/main.c:100
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Re_fresh rate:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
 msgstr ""
-"The typing monitor uses the notification area to display information. You do "
-"not seem to have a notification area on your panel. You can add it by right-"
-"clicking on your panel and choosing 'Add to panel', selecting 'Notification "
-"area' and clicking 'Add'."
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "The quick brown fox jumps over the lazy dog. 0123456789"
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Scaled"
 
-#: ../vfs-methods/fontilus/font-view.c:276
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Fraction completed"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "From:"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "minutes"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "To:"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Name:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Type"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME Terminal"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "_Theme name:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "U_sername:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_About"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Volume mute"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Volume down"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Volume up"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Play (or play/pause)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Stop playback key"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Skip to previous track"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Skip to next track"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Eject"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "Typing Break"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Skip to next track"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Skip to previous track"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Launch web browser"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Launch help browser"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Default Settings"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Launch web browser"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Home folder"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Search"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Log out"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Lock screen"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Accessibility"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "Zoom"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Zoom"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "_On-screen keyboard"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Options"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Preferences"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Keyboard layout"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Remove"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Mouse Keys"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Keyboard Shortcuts"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Action"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Keyboard Shortcuts"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Remove"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Name:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Co_mmand:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_None"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Reset To De_faults"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Keyboard"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Set your personal information"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Default Settings"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "_Slight"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Pointer Size:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Mouse"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Mouse Keys"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Acceleration:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Acceleration:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_Application font:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Others"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Action"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Connecting..."
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Options"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Network Proxy"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Password:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Change Password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Accel Mode"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Cursor blink speed"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Address"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Address"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Address"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Default Pointer"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "Name:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Address:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Address:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Disabled"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Address"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Address"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "minutes"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Network Proxy"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "_Activate"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "Address"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Network Proxy"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "H_TTP proxy:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "H_TTP proxy:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP proxy:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "S_ocks host:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "<b>Ignore Host List</b>"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "H_TTP proxy:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "H_TTP proxy:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP proxy:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Autoconfiguration _URL:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Network Proxy"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Password:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Keyboard options"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Use authentication</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "U_sername:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Password:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_New password:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Version:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Version:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Retype new password:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "<b>_Use authentication</b>"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Type"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Default"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "System"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Location:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Sounds"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Lock screen's shortcut."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Lock screen's shortcut."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Use authentication</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "minutes"
+msgstr[1] "minutes"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minutes"
+msgstr[1] "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Accel Mode"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Fill Screen"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Screen"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Delay:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "Pointers"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "Pointers"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "U_sername:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "_Location:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Installation Failed"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Select"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Options"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Font Rendering Details"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Reset To De_faults"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Models"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Please make sure that the applet is properly installed"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Pointers"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "All Files"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Preview:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "_Department:"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Fill Screen"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Action"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Type:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Screen"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Lock screen"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Screen"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Screen"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Screen %d Settings\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Keyboard options"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Others"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "_Location:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_Application font:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Search's shortcut."
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Network Proxy"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Desktop"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Remove"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Password:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Desktop"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "UI Control"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Copy"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<b>_Use authentication</b>"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "User name:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "System Beep"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Volume mute"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Proxy Configuration"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volume"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Alert Buttons"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Sound"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Name:"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "Style:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "Type:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "Size:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "Version:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "Copyright:"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "Description:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:408
-#, c-format
-msgid "usage: %s fontfile\n"
-msgstr "usage: %s fontfile\n"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
-msgstr "Set as Application Font"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
-msgid "Sets the default application font"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>Cursor Blinking</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Cursor _blinks in text boxes and fields"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Speed:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Cursor blink speed"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Cursor blink speed"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Shortcut"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Delay:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Shortcut"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Threshold:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Small"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Large"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Repeat Keys</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Key presses _repeat when key is held down"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Repeat keys speed"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Repeat keys speed"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Sticky Keys Alert"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Disa_ble if two keys pressed together"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Beep when _modifier is pressed"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Slow Keys Alert"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Shortcut"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Beep when _modifier is pressed"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Beep when key is:"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Beep if key is re_jected"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Mouse Keys"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "I_gnore duplicate keypresses within:"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Shortcut"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Accessibility"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Large"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "_Screenreader"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Sounds"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "_On-screen keyboard"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Repeat Keys</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Cursor Blinking</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Mouse Keys"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Large Pointer"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<b>Double-Click Timeout </b>"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Flash _entire screen"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Flash _entire screen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Fill Screen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Options"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_Magnifier"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "_Magnifier"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "_Screenreader"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "_Magnifier"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Brightness up"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Contact"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_None"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Full"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "Do_n't deactivate"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_New password:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Select Sound File"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_None"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Preview:"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Change Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Change set"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Change Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_New password:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Change Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_New password:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Full Name"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_Edit"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Controls"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
 msgstr "Sets the default application font"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "If set to true, then OpenType fonts will be thumbnailed."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "If set to true, then PCF fonts will be thumbnailed."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "If set to true, then TrueType fonts will be thumbnailed."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "If set to true, then Type1 fonts will be thumbnailed."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
 msgstr ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr "Set this key to the command used to create thumbnails for PCF fonts."
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Others"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
 msgstr ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr "Set this key to the command used to create thumbnails for Type1 fonts."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "Thumbnail command for OpenType fonts"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "Thumbnail command for PCF fonts"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "Thumbnail command for TrueType fonts"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Thumbnail command for Type1 fonts"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "Whether to thumbnail OpenType fonts"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "Whether to thumbnail PCF fonts"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "Whether to thumbnail TrueType fonts"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "Whether to thumbnail Type1 fonts"
-
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
-msgid "GNOME Font Viewer"
-msgstr "GNOME Font Viewer"
-
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-msgstr "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr "Do _not apply font"
-
-#: ../vfs-methods/themus/apply-font.glade.h:4
-msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
 msgstr ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-msgid "_Apply font"
-msgstr "_Apply font"
-
-#: ../vfs-methods/themus/theme-method.c:518
-msgid "Themes"
-msgstr "Themes"
-
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "Description"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
-msgstr "Control theme"
-
-#: ../vfs-methods/themus/themus-properties-view.c:139
-msgid "Window border theme"
-msgstr "Window border theme"
-
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
-msgstr "Icon theme"
-
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
-msgstr "ABCDEFG"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-msgid "Apply theme"
-msgstr "Apply theme"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-msgid "Sets the default theme"
-msgstr "Sets the default theme"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr "If set to true, then installed themes will be thumbnailed."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr "If set to true, then themes will be thumbnailed."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:3
-msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
 msgstr ""
-"Set this key to the command used to create thumbnails for installed themes."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
-msgstr "Set this key to the command used to create thumbnails for themes."
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr "Thumbnail command for installed themes"
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr "Thumbnail command for themes"
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr "Whether to thumbnail installed themes"
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr "Whether to thumbnail themes"
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
 
-msgid "Show help options"
-msgstr "Show help options"
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Buttons"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Orientation"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Buttons"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Buttons"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Buttons"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Layout"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Centred"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Address"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Save"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Theme Details"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Network Proxy"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Theme Details"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Mobile:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Network Proxy"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Network Proxy"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Theme Details"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Network Proxy"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "E_nable Toggle Keys"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Connecting..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Change set"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Default Settings"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Quit"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Search"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Skip to previous track"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Preferences"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgid "Image/label border"
+#~ msgstr "Image/label border"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "Width of border around the label and image in the alert dialogue"
+
+#~ msgid "The type of alert"
+#~ msgstr "The type of alert"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "The buttons shown in the alert dialogue"
+
+#~ msgid "Show more _details"
+#~ msgstr "Show more _details"
+
+#~ msgid "About Me"
+#~ msgstr "About Me"
+
+#~ msgid "No Image"
+#~ msgstr "No Image"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server cannot handle the protocol"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Unable to open address book"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "Unknown login ID; the user database might be corrupted"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "About %s"
+
+#~ msgid "Old password is incorrect, please retype it"
+#~ msgstr "Old password is incorrect; please retype it"
+
+#~ msgid "System error has occurred"
+#~ msgstr "System error has occurred"
+
+#~ msgid "Could not run /usr/bin/passwd"
+#~ msgstr "Could not run /usr/bin/passwd"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "Unable to launch backend"
+
+#~ msgid "Unexpected error has occurred"
+#~ msgstr "Unexpected error has occurred"
+
+#~ msgid "Password is too short"
+#~ msgstr "Password is too short"
+
+#~ msgid "Password is too simple"
+#~ msgstr "Password is too simple"
+
+#~ msgid "Old and new passwords are too similar"
+#~ msgstr "Old and new passwords are too similar"
+
+#~ msgid "Must contain numeric or special character(s)"
+#~ msgstr "Must contain numeric or special character(s)"
+
+#~ msgid "Old and new password are the same"
+#~ msgstr "Old and new password are the same"
+
+#~ msgid "Please type the passwords."
+#~ msgstr "Please type the passwords."
+
+#~ msgid "Please type the password again, it is wrong."
+#~ msgstr "Incorrect password; please type the password again."
+
+#~ msgid "Click on Change Password to change the password."
+#~ msgstr "Click on \"Change Password\" to change the password."
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Home</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Instant Messaging</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Job</b>"
+
+#~ msgid "<b>Please type the passwords.</b>"
+#~ msgstr "<b>Please type the passwords.</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Telephone</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Web</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Work</b>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "A_ddress:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "A_ssistant:"
+
+#~ msgid "C_ity:"
+#~ msgstr "C_ity:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "C_ompany:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Change Passwo_rd..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Ci_ty:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "Co_untry:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "Cou_ntry:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "Hom_e:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "Old pa_ssword:"
+#~ msgstr "Old pa_ssword:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _box:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. box:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Personal Info"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Pro_vince/State:"
+
+#~ msgid "Web _log:"
+#~ msgstr "Web _log:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "Wor_k:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "Work _fax:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "_Postal/Zip Code:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Home page:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Home:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Manager:"
+
+#~ msgid "_Profession:"
+#~ msgstr "_Profession:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_State/Province:"
+
+#~ msgid "_Title:"
+#~ msgstr "_Title:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Work:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "Postal/_Zip code:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Support</b>"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Assistive Technology Preferences"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Close and _Log Out"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Start these assistive technologies every time you log in:"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Enable assistive technologies"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "Assistive Technology Support"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "Enable support for GNOME assistive technologies at login"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+#~ msgstr ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+
+#, c-format
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "There was an error launching the mouse preferences dialogue: %s"
+
+#, c-format
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Unable to import AccessX settings from file '%s'"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Import Feature Settings File"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Set your keyboard accessibility preferences"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>Enable Bo_unce Keys</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>Enable Slo_w Keys</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Enable _Mouse Keys</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>Enable _Repeat Keys</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>Enable _Sticky Keys</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Features</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Toggle Keys</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Basic"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr "Beep when _features turned on or off from keyboard"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "Beep when an LED is turned on and two beeps when one is turned off."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Delay between keypress and pointer mo_vement:"
+
+#~ msgid "Filters"
+#~ msgstr "Filters"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Keyboard Accessibility Preferences (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Ma_ximum pointer speed:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Mouse _Preferences..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+
+#~ msgid "S_peed:"
+#~ msgstr "S_peed:"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Time to acce_lerate to maximum speed:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Turn the numeric keypad into a mouse control pad."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Disable if unused for:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "_Enable keyboard accessibility features"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Import Feature Settings..."
+
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "_Only accept keys held for:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Type to test settings:"
+
+#~ msgid "_accepted"
+#~ msgstr "_accepted"
+
+#~ msgid "_pressed"
+#~ msgstr "_pressed"
+
+#~ msgid "_rejected"
+#~ msgstr "_rejected"
+
+#~ msgid "characters/second"
+#~ msgstr "characters/second"
+
+#~ msgid "milliseconds"
+#~ msgstr "milliseconds"
+
+#~ msgid "pixels/second"
+#~ msgstr "pixels/second"
+
+#~ msgid "Desktop Background"
+#~ msgstr "Desktop Background"
+
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>Desktop _Wallpaper</b>"
+
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>_Desktop Colours</b>"
+
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Desktop Background Preferences"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Open a dialogue to specify the colour"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Add Wallpaper"
+
+#~ msgid "_Style:"
+#~ msgstr "_Style:"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "There was an error displaying help: %s"
+
+#~ msgid "Tiled"
+#~ msgstr "Tiled"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Horizontal Gradient"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Vertical Gradient"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Add Wallpaper"
+
+#~ msgid "Images"
+#~ msgstr "Images"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "pixel"
+#~ msgstr[1] "pixels"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Unable to load stock icon '%s'\n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Just apply settings and quit"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Retrieve and store legacy settings"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Copying file: %u of %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "Copying '%s'"
+
+#~ msgid "From URI"
+#~ msgstr "From URI"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI currently transferring from"
+
+#~ msgid "To URI"
+#~ msgstr "To URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI currently transferring to"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Fraction of transfer currently completed"
+
+#~ msgid "Current URI index"
+#~ msgstr "Current URI index"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Current URI index - starts from 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "Total URIs"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Total number of URIs"
+
+#~ msgid "Key"
+#~ msgstr "Key"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf key to which this property editor is attached"
+
+#~ msgid "Callback"
+#~ msgstr "Callback"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Issue this callback when the value associated with key gets changed"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Conversion to widget callback"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Conversion from widget callback"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Object that controls the property (normally a widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Property editor object data"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Custom data required by the specific property editor"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Property editor data freeing callback"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Callback to be issued when property editor object data is to be freed"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Could not find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "I do not know how to open the file '%s'.\n"
+#~ "Perhaps it is a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+
+#~ msgid "Please select an image."
+#~ msgstr "Please select an image."
+
+#~ msgid "Could not display help"
+#~ msgstr "Could not display help"
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Error saving configuration: %s"
+
+#~ msgid "Custom"
+#~ msgstr "Custom"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Could not load the main interface"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian Sensible Browser"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian Terminal Emulator"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Epiphany Web Browser"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution Mail Reader"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "Evolution Mail Reader 1.4"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "Evolution Mail Reader 1.5"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "Evolution Mail Reader 1.6"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "Evolution Mail Reader 2.0"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "Evolution Mail Reader 2.2"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "Evolution Mail Reader 2.4"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Links Text Browser"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Lynx Text Browser"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Standard XTerminal"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M Text Browser"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "<b>Audio Player</b>"
+#~ msgstr "<b>Audio Player</b>"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>Image Viewer</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>Instant Messenger</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>Mail Reader</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Terminal Emulator</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Text Editor</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Video Player</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Web Browser</b>"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "All %s occurrences will be replaced with actual link"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "E_xecute flag:"
+
+#~ msgid "Internet"
+#~ msgstr "Internet"
+
+#~ msgid "Multimedia"
+#~ msgstr "Multimedia"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Open link in new _tab"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Open link in new _window"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Open link with web browser _default"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Run in t_erminal"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Change screen resolution"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Screen Resolution Preferences"
+
+#, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Make default for this computer (%s) only"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Testing the new settings. If you do not respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgstr[1] ""
+#~ "Testing the new settings. If you do not respond in %d seconds the "
+#~ "previous settings will be restored."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Keep Resolution"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Do you want to keep this resolution?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "Use _previous resolution"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Keep resolution"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+
+#~ msgid "Font"
+#~ msgstr "Font"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Select fonts for the desktop"
+
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<b>Font Rendering</b>"
+
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<b>Hinting</b>:"
+
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<b>Smoothing</b>:"
+
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<b>Subpixel order</b>:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Best _shapes"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Best co_ntrast"
+
+#~ msgid "D_etails..."
+#~ msgstr "D_etails..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Des_ktop font:"
+
+#~ msgid "Font Preferences"
+#~ msgstr "Font Preferences"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "Go _to font folder"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Gre_yscale"
+
+#~ msgid "N_one"
+#~ msgstr "N_one"
+
+#~ msgid "R_esolution:"
+#~ msgstr "R_esolution:"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sub_pixel (LCDs)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Sub_pixel smoothing (LCDs)"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Document font:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_Fixed-width font:"
+
+#~ msgid "_Medium"
+#~ msgstr "_Medium"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Monochrome"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Window title font:"
+
+#~ msgid "dots per inch"
+#~ msgstr "dots per inch"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Font may be too large"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[1] ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgstr[1] ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+
+#~ msgid "New accelerator..."
+#~ msgstr "New accelerator..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Accelerator key"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Accelerator modifiers"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Accelerator keycode"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "The type of accelerator."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Unknown Action>"
+
+#~ msgid "Window Management"
+#~ msgstr "Window Management"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become unusable to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time.\n"
+#~ msgstr ""
+#~ "The shortcut \"%s\" cannot be used because it will become unusable to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time.\n"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+
+#, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "Error setting new accelerator in configuration database: %s\n"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "Error unsetting accelerator in configuration database: %s\n"
+
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Assign shortcut keys to commands"
+
+#~ msgid "Unknown"
+#~ msgstr "Unknown"
+
+#, c-format
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "There was an error launching the keyboard tool: %s"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Start the page with the typing break settings showing"
+
+#~ msgid "..."
+#~ msgstr "..."
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>_Lock screen to enforce typing break</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Fast</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Long</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Short</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Slow</i></small>"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "A_vailable layouts:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "All_ow postponing of breaks"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Check if breaks are allowed to be postponed"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Choose a Keyboard Model"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Choose a Layout"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Duration of the break when typing is disallowed"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Duration of work before forcing a break"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Keyboard Preferences"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Keyboard _model:"
+
+#~ msgid "Layout Options"
+#~ msgstr "Layout Options"
+
+#~ msgid "Layouts"
+#~ msgstr "Layouts"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Microsoft Natural Keyboard"
+
+#~ msgid "Separate _group for each window"
+#~ msgstr "Separate _group for each window"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Accessibility..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Break interval lasts:"
+
+#~ msgid "_Models:"
+#~ msgstr "_Models:"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Selected layouts:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Work interval lasts:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Set your keyboard preferences"
+
+#~ msgid "microseconds"
+#~ msgstr "microseconds"
+
+#~ msgid "Unknown Pointer"
+#~ msgstr "Unknown Pointer"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Default Pointer - Current"
+
+#~ msgid "The default pointer that ships with X"
+#~ msgstr "The default pointer that ships with X"
+
+#~ msgid "White Pointer"
+#~ msgstr "White Pointer"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "White Pointer - Current"
+
+#~ msgid "The default pointer inverted"
+#~ msgstr "The default pointer inverted"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Large Pointer - Current"
+
+#~ msgid "Large version of normal pointer"
+#~ msgstr "Large version of normal pointer"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Large White Pointer - Current"
+
+#~ msgid "Large version of white pointer"
+#~ msgstr "Large version of white pointer"
+
+#~ msgid "Pointer Theme"
+#~ msgstr "Pointer Theme"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Drag and Drop</b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Locate Pointer</b>"
+
+#~ msgid "<b>Mouse Orientation</b>"
+#~ msgstr "<b>Mouse Orientation</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Speed</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Fast</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>High</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Large</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Low</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Slow</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Small</i>"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Highlight the _pointer when you press Ctrl"
+
+#~ msgid "Motion"
+#~ msgstr "Motion"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Mouse Preferences"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Left-handed mouse"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Sensitivity:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Set your mouse preferences"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Set your network proxy preferences"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Di_rect internet connection</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>_Automatic proxy configuration</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_Manual proxy configuration</b>"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Advanced Configuration"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP Proxy Details"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Network Proxy Preferences"
+
+#~ msgid "Port:"
+#~ msgstr "Port:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Secure HTTP proxy:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Enable sound and associate sounds with events"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Sound Preferences"
+
+#~ msgid "E_nable software sound mixing (ESD)"
+#~ msgstr "E_nable software sound mixing (ESD)"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Flash _window titlebar"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "_Enable system beep"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "_Play system sounds"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "_Visual system beep"
+
+#~ msgid "Would you like to remove this theme?"
+#~ msgstr "Would you like to remove this theme?"
+
+#~ msgid "Theme deleted succesfully. Please select another theme."
+#~ msgstr "Theme deleted succesfully. Please select another theme."
+
+#~ msgid "Theme can not be deleted"
+#~ msgstr "Theme cannot be deleted"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialogue was improperly installed, or you have not "
+#~ "installed the \"gnome-themes\" package."
+
+#~ msgid "This theme is not in a supported format."
+#~ msgstr "This theme is not in a supported format."
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Failed to create temporary directory"
+
+#~ msgid ""
+#~ "Can not install theme. \n"
+#~ "The bzip2 utility is not installed."
+#~ msgstr ""
+#~ "Cannot install theme. \n"
+#~ "The bzip2 utility is not installed."
+
+#~ msgid ""
+#~ "Can not install themes. \n"
+#~ "The gzip utility is not installed."
+#~ msgstr ""
+#~ "Cannot install themes. \n"
+#~ "The gzip utility is not installed."
+
+#, c-format
+#~ msgid ""
+#~ "Icon Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Icon Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+
+#, c-format
+#~ msgid "Gnome Theme %s correctly installed"
+#~ msgstr "Gnome Theme %s correctly installed"
+
+#, c-format
+#~ msgid ""
+#~ "Windows Border Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Windows Border Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+
+#, c-format
+#~ msgid ""
+#~ "Controls Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Controls Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+
+#~ msgid "The theme is an engine. You need to compile the theme."
+#~ msgstr "The theme is an engine. You need to compile the theme."
+
+#~ msgid "The file format is invalid"
+#~ msgstr "The file format is invalid"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "No theme file location specified to install"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "The theme file location specified to install is invalid"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "The file format is invalid."
+
+#, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "The tar program is not installed on your system."
+#~ msgstr ""
+#~ "Cannot install theme.\n"
+#~ "The tar(1) program is not installed on your system."
+
+#~ msgid "Custom theme"
+#~ msgstr "Custom theme"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "You can save this theme by pressing the Save Theme button."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably do not have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Theme name must be present"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "The theme already exists. Would you like to replace it?"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Select themes for various parts of the desktop"
+
+#~ msgid "Theme"
+#~ msgstr "Theme"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+
+#~ msgid "Theme Installation"
+#~ msgstr "Theme Installation"
+
+#~ msgid "_Install"
+#~ msgstr "_Install"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+
+#~ msgid "Apply _Font"
+#~ msgstr "Apply _Font"
+
+#~ msgid "Icons"
+#~ msgstr "Icons"
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr "New themes can also be installed by dragging them into the window."
+
+#~ msgid "Save Theme"
+#~ msgstr "Save Theme"
+
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Select theme for the desktop"
+
+#~ msgid "Short _description:"
+#~ msgstr "Short _description:"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "Theme Preferences"
+
+#~ msgid "Theme _Details"
+#~ msgstr "Theme _Details"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "This theme does not suggest any particular font or background."
+
+#~ msgid "This theme suggests a background:"
+#~ msgstr "This theme suggests a background:"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "This theme suggests a font and a background:"
+
+#~ msgid "This theme suggests a font:"
+#~ msgstr "This theme suggests a font:"
+
+#~ msgid "Window Border"
+#~ msgstr "Window Border"
+
+#~ msgid "_Revert"
+#~ msgstr "_Revert"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "_Save Theme..."
+
+#~ msgid "theme selection tree"
+#~ msgstr "theme selection tree"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "Customize the appearance of toolbars and menubars in applications"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Menus & Toolbars"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Behaviour and Appearance</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Preview</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "C_ut"
+
+#~ msgid "Icons only"
+#~ msgstr "Icons only"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Menu and Toolbar Preferences"
+
+#~ msgid "New File"
+#~ msgstr "New File"
+
+#~ msgid "Open File"
+#~ msgstr "Open File"
+
+#~ msgid "Save File"
+#~ msgstr "Save File"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Show _icons in menus"
+
+#~ msgid "Text below icons"
+#~ msgstr "Text below icons"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Text beside icons"
+
+#~ msgid "Text only"
+#~ msgstr "Text only"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Toolbar _button labels:"
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "_Detachable toolbars"
+
+#~ msgid "_Editable menu accelerators"
+#~ msgstr "_Editable menu accelerators"
+
+#~ msgid "_File"
+#~ msgstr "_File"
+
+#~ msgid "_New"
+#~ msgstr "_New"
+
+#~ msgid "_Paste"
+#~ msgstr "_Paste"
+
+#~ msgid "_Print"
+#~ msgstr "_Print"
+
+#, c-format
+#~ msgid ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "C_ontrol"
+#~ msgstr "C_ontrol"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "S_uper (or \"Windows logo\")"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Movement Key</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Titlebar Action</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Window Selection</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "To move a window, press-and-hold this key then grab the window:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Window Preferences"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Double-click titlebar to perform this action:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Interval before raising:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Raise selected windows after an interval"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Select windows when the mouse moves over them"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Set your window properties"
+
+#~ msgid "Desktop Preferences"
+#~ msgstr "Desktop Preferences"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME Control Centre"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "The GNOME configuration tool"
+
+#~ msgid "No '/dev/pmu' device found"
+#~ msgstr "No '/dev/pmu' device found"
+
+#~ msgid "Not a powerbook"
+#~ msgstr "Not a PowerBook"
+
+#~ msgid "Wrong permission for '/dev/pmu' device"
+#~ msgstr "Wrong permission for '/dev/pmu' device"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "Could not initialize Bonobo"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Do you want to activate Slow Keys?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Do you want to deactivate Slow Keys?"
+
+#~ msgid "_Deactivate"
+#~ msgstr "_Deactivate"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "Do_n't activate"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Do you want to activate Sticky Keys?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Do you want to deactivate Sticky Keys?"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+
+#, c-format
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "Key Binding (%s) has its action defined multiple times\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "Key Binding (%s) has its binding defined multiple times\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Key Binding (%s) is incomplete\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Key Binding (%s) is invalid\n"
+
+#, c-format
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr "It seems that another application already has access to key '%u'."
+
+#, c-format
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "Key Binding (%s) is already in use\n"
+
+#, c-format
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Error activating XKB configuration.\n"
+#~ "This can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or using a newer version of XFree "
+#~ "software."
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "Do _not show this warning again"
+
+#~ msgid ""
+#~ "The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.  Which set would you like to use?"
+#~ msgstr ""
+#~ "The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.  Which set would you like to use?"
+
+#~ msgid "Use X settings"
+#~ msgstr "Use X settings"
+
+#~ msgid "Use GNOME settings"
+#~ msgstr "Use GNOME settings"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Could not execute command: %s\n"
+#~ "Verify that this command exists."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Could not put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "Could not load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+
+#, c-format
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Do not show this message again"
+
+#, c-format
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "Could not load sound file %s as sample %s"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Cannot determine user's home directory"
+
+#, c-format
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr "GConf key %s set to type %s but its expected type was %s\n"
+
+#~ msgid "A_vailable files:"
+#~ msgstr "A_vailable files:"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "Do _not show this warning again."
+
+#~ msgid "Load modmap files"
+#~ msgstr "Load modmap files"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "Would you like to load the modmap file(s)?"
+
+#~ msgid "_Load"
+#~ msgstr "_Load"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "Error creating signal pipe."
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+
+#~ msgid "Preview Width"
+#~ msgstr "Preview Width"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Width if applier is a preview: Defaults to 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Preview Height"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Height if applier is a preview: Defaults to 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Screen on which BGApplier is to draw"
+
+#, c-format
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "There was an error loading an image: %s"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "Sound not set for this event."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "The sound file for this event does not exist."
+
+#, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "The file %s is not a valid wav file"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Window manager \"%s\" has not registered a configuration tool\n"
+
+#~ msgid "Maximize"
+#~ msgstr "Maximize"
+
+#~ msgid "Roll up"
+#~ msgstr "Roll up"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Sync text/plain and text/* handlers"
+
+#~ msgid "Brightness down"
+#~ msgstr "Brightness down"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Brightness down's shortcut."
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Brightness up's shortcut."
+
+#~ msgid "E-mail"
+#~ msgstr "E-mail"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "E-mail's shortcut."
+
+#~ msgid "Eject's shortcut."
+#~ msgstr "Eject's shortcut."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Home folder's shortcut."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Launch help browser's shortcut."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Launch web browser's shortcut."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Log out's shortcut."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Next track key's shortcut."
+
+#~ msgid "Pause"
+#~ msgstr "Pause"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Pause key's shortcut."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Play (or play/pause) key's shortcut."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Previous track key's shortcut."
+
+#~ msgid "Sleep"
+#~ msgstr "Sleep"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Sleep's shortcut."
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Stop playback key's shortcut."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Volume down's shortcut."
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Volume mute's shortcut"
+
+#~ msgid "Volume step"
+#~ msgstr "Volume step"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Volume step as percentage of volume."
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Volume up's shortcut."
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "Display a dialogue when there are errors running the screensaver"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "Run screensaver at login"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Show Startup Errors"
+
+#~ msgid "Start screensaver"
+#~ msgstr "Start screensaver"
+
+#~ msgid ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+#~ msgstr ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap-based adjustments"
+
+#~ msgid "A list of modmap files available in the $HOME directory."
+#~ msgstr "A list of modmap files available in the $HOME directory."
+
+#~ msgid "Default group, assigned on window creation"
+#~ msgstr "Default group, assigned on window creation"
+
+#~ msgid "Keep and manage separate group per window"
+#~ msgstr "Keep and manage separate group per window"
+
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Keyboard Update Handlers"
+
+#~ msgid "Keyboard model"
+#~ msgstr "Keyboard model"
+
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr ""
+#~ "Keyboard settings in GConf will be overridden from the system ASAP "
+#~ "(deprecated)"
+
+#~ msgid "Save/restore indicators together with layout groups"
+#~ msgstr "Save/restore indicators together with layout groups"
+
+#~ msgid "Show layout names instead of group names"
+#~ msgstr "Show layout names instead of group names"
+
+#~ msgid ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+#~ msgstr ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+
+#~ msgid "Suppress the \"X sysconfig changed\" warning message"
+#~ msgstr "Suppress the \"X sysconfig changed\" warning message"
+
+#~ msgid ""
+#~ "Very soon, keyboard settings in gconf will be overridden (from the system "
+#~ "configuration) This key has been deprecated since GNOME 2.12, please "
+#~ "unset the model, layouts and options keys to get the default system "
+#~ "configuration."
+#~ msgstr ""
+#~ "Very soon, keyboard settings in GConf will be overridden (from the system "
+#~ "configuration). This key has been deprecated since GNOME 2.12. Please "
+#~ "unset the model, layouts and options keys to get the default system "
+#~ "configuration."
+
+#~ msgid "keyboard layout"
+#~ msgstr "keyboard layout"
+
+#~ msgid "keyboard model"
+#~ msgstr "keyboard model"
+
+#~ msgid "modmap file list"
+#~ msgstr "modmap file list"
+
+#~ msgid "_Postpone break"
+#~ msgstr "_Postpone break"
+
+#~ msgid "Take a break!"
+#~ msgstr "Take a break!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Take a Break"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d minute until the next break"
+#~ msgstr[1] "%d minutes until the next break"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Less than one minute until the next break"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Unable to bring up the typing break properties dialogue with the "
+#~ "following error: %s"
+
+#~ msgid "About GNOME Typing Monitor"
+#~ msgstr "About GNOME Typing Monitor"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "A computer break reminder."
+
+#~ msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgstr "Written by Richard Hult &lt;richard@imendio.com&gt;"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Eye candy added by Anders Carlsson"
+
+#~ msgid "Break reminder"
+#~ msgstr "Break reminder"
+
+#~ msgid "The orientation of the tray."
+#~ msgstr "The orientation of the tray."
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "do not seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "The quick brown fox jumps over the lazy dog. 0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Size:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Copyright:"
+
+#~ msgid "Description:"
+#~ msgstr "Description:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "usage: %s fontfile\n"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Set as Application Font"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "If set to true, then OpenType fonts will be thumbnailed."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "If set to true, then PCF fonts will be thumbnailed."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "If set to true, then TrueType fonts will be thumbnailed."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "If set to true, then Type1 fonts will be thumbnailed."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for PCF fonts."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Thumbnail command for OpenType fonts"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Thumbnail command for PCF fonts"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Thumbnail command for TrueType fonts"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Thumbnail command for Type1 fonts"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Whether to thumbnail OpenType fonts"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Whether to thumbnail PCF fonts"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Whether to thumbnail TrueType fonts"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Whether to thumbnail Type1 fonts"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "GNOME Font Viewer"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Do _not apply font"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+
+#~ msgid "Themes"
+#~ msgstr "Themes"
+
+#~ msgid "Description"
+#~ msgstr "Description"
+
+#~ msgid "Control theme"
+#~ msgstr "Control theme"
+
+#~ msgid "Window border theme"
+#~ msgstr "Window border theme"
+
+#~ msgid "Icon theme"
+#~ msgstr "Icon theme"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#~ msgid "Apply theme"
+#~ msgstr "Apply theme"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Sets the default theme"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "If set to true, then installed themes will be thumbnailed."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "If set to true, then themes will be thumbnailed."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr "Set this key to the command used to create thumbnails for themes."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Thumbnail command for installed themes"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Thumbnail command for themes"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Whether to thumbnail installed themes"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Whether to thumbnail themes"

--- a/po/en_CA.po~
+++ b/po/en_CA.po~
@@ -1,0 +1,3480 @@
+# English/Canada translation of gnome-control-center.
+# Copyright (C) 2004-2006 Adam Weinberger and the GNOME Foundation
+# This file is distributed under the same licence as the gnome-control-center package.
+# Adam Weinberger <adamw@gnome.org>, 2004, 2005, 2006.
+#
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2006-01-31 20:41-0500\n"
+"PO-Revision-Date: 2005-08-06 19:59-0400\n"
+"Last-Translator: Adam Weinberger <adamw@gnome.org>\n"
+"Language-Team: Canadian English <adamw@gnome.org>\n"
+"Language: en_CA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "Image/label border"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "Width of border around the label and image in the alert dialogue"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "Alert Type"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "The type of alert"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "Alert Buttons"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "The buttons shown in the alert dialogue"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "Show more _details"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "About Me"
+msgstr "About Me"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "Set your personal information"
+
+#: ../capplets/about-me/gnome-about-me.c:604
+msgid "Select Image"
+msgstr "Select Image"
+
+#: ../capplets/about-me/gnome-about-me.c:606
+msgid "No Image"
+msgstr "No Image"
+
+#: ../capplets/about-me/gnome-about-me.c:769
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server cannot handle the protocol"
+
+#: ../capplets/about-me/gnome-about-me.c:790
+msgid "Unable to open address book"
+msgstr "Unable to open address book"
+
+#: ../capplets/about-me/gnome-about-me.c:802
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr "Unknown login ID; the user database might be corrupted"
+
+#: ../capplets/about-me/gnome-about-me.c:833
+#: ../capplets/about-me/gnome-about-me.c:835
+#, c-format
+msgid "About %s"
+msgstr "About %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:707
+msgid "Old password is incorrect, please retype it"
+msgstr "Old password is incorrect; please retype it"
+
+#: ../capplets/about-me/gnome-about-me-password.c:127
+msgid "System error has occurred"
+msgstr "System error has occurred"
+
+#: ../capplets/about-me/gnome-about-me-password.c:128
+msgid "Could not run /usr/bin/passwd"
+msgstr "Could not run /usr/bin/passwd"
+
+#: ../capplets/about-me/gnome-about-me-password.c:129
+msgid "Unable to launch backend"
+msgstr "Unable to launch backend"
+
+#: ../capplets/about-me/gnome-about-me-password.c:131
+#: ../capplets/about-me/gnome-about-me-password.c:132
+msgid "Unexpected error has occurred"
+msgstr "Unexpected error has occurred"
+
+#: ../capplets/about-me/gnome-about-me-password.c:331
+msgid "Password is too short"
+msgstr "Password is too short"
+
+#: ../capplets/about-me/gnome-about-me-password.c:334
+#: ../capplets/about-me/gnome-about-me-password.c:337
+msgid "Password is too simple"
+msgstr "Password is too simple"
+
+#: ../capplets/about-me/gnome-about-me-password.c:340
+msgid "Old and new passwords are too similar"
+msgstr "Old and new passwords are too similar"
+
+#: ../capplets/about-me/gnome-about-me-password.c:343
+msgid "Must contain numeric or special character(s)"
+msgstr "Must contain numeric or special character(s)"
+
+#: ../capplets/about-me/gnome-about-me-password.c:348
+msgid "Old and new password are the same"
+msgstr "Old and new password are the same"
+
+#: ../capplets/about-me/gnome-about-me-password.c:634
+msgid "Please type the passwords."
+msgstr "Please type the passwords."
+
+#: ../capplets/about-me/gnome-about-me-password.c:642
+msgid "Please type the password again, it is wrong."
+msgstr "Incorrect password; please type the password again."
+
+#: ../capplets/about-me/gnome-about-me-password.c:645
+msgid "Click on Change Password to change the password."
+msgstr "Click on \"Change Password\" to change the password."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+msgid "    "
+msgstr "    "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Email</b>"
+msgstr "<b>Email</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Home</b>"
+msgstr "<b>Home</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Instant Messaging</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Job</b>"
+msgstr "<b>Job</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr "<b>Please type the passwords.</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<b>Telephone</b>"
+msgstr "<b>Telephone</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "<b>Web</b>"
+msgstr "<b>Web</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "<b>Work</b>"
+msgstr "<b>Work</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "A_ddress:"
+msgstr "A_ddress:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr "A_ssistant:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "Address"
+msgstr "Address"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "C_ity:"
+msgstr "C_ity:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "C_ompany:"
+msgstr "C_ompany:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Cale_ndar:"
+msgstr "Cale_ndar:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change Passwo_rd..."
+msgstr "Change Passwo_rd..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Change Password"
+msgstr "Change Password"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Ci_ty:"
+msgstr "Ci_ty:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Co_untry:"
+msgstr "Co_untry:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Contact"
+msgstr "Contact"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Cou_ntry:"
+msgstr "Cou_ntry:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr "Full Name"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Hom_e:"
+msgstr "Hom_e:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "Old pa_ssword:"
+msgstr "Old pa_ssword:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P.O. _box:"
+msgstr "P.O. _box:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P._O. box:"
+msgstr "P._O. box:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "Personal Info"
+msgstr "Personal Info"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "State/Pro_vince:"
+msgstr "Pro_vince/State:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+msgid "User name:"
+msgstr "User name:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Web _log:"
+msgstr "Web _log:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "Wor_k:"
+msgstr "Wor_k:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid "Work _fax:"
+msgstr "Work _fax:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Zip/_Postal code:"
+msgstr "_Postal/Zip Code:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "_Address:"
+msgstr "_Address:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr "_Department:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr "_Groupwise:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "_Home page:"
+msgstr "_Home page:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "_Home:"
+msgstr "_Home:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr "_Jabber:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Manager:"
+msgstr "_Manager:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Mobile:"
+msgstr "_Mobile:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_New password:"
+msgstr "_New password:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Profession:"
+msgstr "_Profession:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Retype new password:"
+msgstr "_Retype new password:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr "_State/Province:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Title:"
+msgstr "_Title:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Work:"
+msgstr "_Work:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Zip/Postal code:"
+msgstr "Postal/_Zip code:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Applications</b>"
+msgstr "<b>Applications</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Support</b>"
+msgstr "<b>Support</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technology Preferences"
+msgstr "Assistive Technology Preferences"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr "Close and _Log Out"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr "Start these assistive technologies every time you log in:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr "_Enable assistive technologies"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr "_Magnifier"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr "_On-screen keyboard"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Screenreader"
+msgstr "_Screenreader"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr "Assistive Technology Support"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr "Enable support for GNOME assistive technologies at login"
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:242
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr "There was an error launching the mouse preferences dialogue: %s"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:338
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:399
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr "Unable to import AccessX settings from file '%s'"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:436
+msgid "Import Feature Settings File"
+msgstr "Import Feature Settings File"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:440
+msgid "_Import"
+msgstr "_Import"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Keyboard"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr "Set your keyboard accessibility preferences"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+#: ../capplets/theme-switcher/theme-install.glade.h:1
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "<b>Enable Bo_unce Keys</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "<b>Enable Slo_w Keys</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "<b>Enable _Mouse Keys</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "<b>Enable _Repeat Keys</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "<b>Enable _Sticky Keys</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+msgid "<b>Features</b>"
+msgstr "<b>Features</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr "<b>Toggle Keys</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "Basic"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr "Beep if key is re_jected"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr "Beep when _features turned on or off from keyboard"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr "Beep when _modifier is pressed"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr "Beep when an LED is turned on and two beeps when one is turned off."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr "Beep when key is:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr "Del_ay:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr "Delay between keypress and pointer mo_vement:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr "Disa_ble if two keys pressed together"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr "E_nable Toggle Keys"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Filters"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr "I_gnore duplicate keypresses within:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr "Keyboard Accessibility Preferences (AccessX)"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr "Ma_ximum pointer speed:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr "Mouse Keys"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr "Mouse _Preferences..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "S_peed:"
+msgstr "S_peed:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr "Time to acce_lerate to maximum speed:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr "Turn the numeric keypad into a mouse control pad."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr "_Disable if unused for:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr "_Enable keyboard accessibility features"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr "_Import Feature Settings..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr "_Only accept keys held for:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "_Type to test settings:"
+msgstr "_Type to test settings:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr "_accepted"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr "_pressed"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr "_rejected"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr "characters/second"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+msgid "milliseconds"
+msgstr "milliseconds"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr "pixels/second"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "seconds"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+msgid "Change your Desktop Background settings"
+msgstr "Change your Desktop Background settings"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+msgid "Desktop Background"
+msgstr "Desktop Background"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "<b>Desktop _Wallpaper</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+msgid "<b>_Desktop Colors</b>"
+msgstr "<b>_Desktop Colours</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+msgid "Desktop Background Preferences"
+msgstr "Desktop Background Preferences"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr "Open a dialogue to specify the colour"
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr "_Add Wallpaper"
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+msgid "_Remove"
+msgstr "_Remove"
+
+#: ../capplets/background/gnome-background-properties.glade.h:7
+msgid "_Style:"
+msgstr "_Style:"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "There was an error displaying help: %s"
+
+#: ../capplets/background/gnome-wp-capplet.c:1046
+msgid "Centered"
+msgstr "Centred"
+
+#: ../capplets/background/gnome-wp-capplet.c:1050
+msgid "Fill Screen"
+msgstr "Fill Screen"
+
+#: ../capplets/background/gnome-wp-capplet.c:1054
+msgid "Scaled"
+msgstr "Scaled"
+
+#: ../capplets/background/gnome-wp-capplet.c:1058
+msgid "Zoom"
+msgstr "Zoom"
+
+#: ../capplets/background/gnome-wp-capplet.c:1062
+msgid "Tiled"
+msgstr "Tiled"
+
+#: ../capplets/background/gnome-wp-capplet.c:1083
+msgid "Solid Color"
+msgstr "Solid Colour"
+
+#: ../capplets/background/gnome-wp-capplet.c:1087
+msgid "Horizontal Gradient"
+msgstr "Horizontal Gradient"
+
+#: ../capplets/background/gnome-wp-capplet.c:1091
+msgid "Vertical Gradient"
+msgstr "Vertical Gradient"
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1137
+msgid "Add Wallpaper"
+msgstr "Add Wallpaper"
+
+#: ../capplets/background/gnome-wp-capplet.c:1154
+msgid "Images"
+msgstr "Images"
+
+#: ../capplets/background/gnome-wp-capplet.c:1158
+msgid "All Files"
+msgstr "All Files"
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr "No Wallpaper"
+
+#: ../capplets/background/gnome-wp-item.c:343
+#: ../capplets/background/gnome-wp-item.c:345
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "pixel"
+msgstr[1] "pixels"
+
+#: ../capplets/common/activate-settings-daemon.c:18
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+
+#: ../capplets/common/capplet-stock-icons.c:92
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "Unable to load stock icon '%s'\n"
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr "Just apply settings and quit"
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1016
+#: ../capplets/sound/sound-properties-capplet.c:244
+msgid "Retrieve and store legacy settings"
+msgstr "Retrieve and store legacy settings"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "Copying file: %u of %u"
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr "Copying '%s'"
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr "From URI"
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr "URI currently transferring from"
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr "To URI"
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr "URI currently transferring to"
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr "Fraction completed"
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr "Fraction of transfer currently completed"
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr "Current URI index"
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr "Current URI index - starts from 1"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr "Total URIs"
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr "Total number of URIs"
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr "Copying files"
+
+#: ../capplets/common/file-transfer-dialog.c:345
+msgid "From:"
+msgstr "From:"
+
+#: ../capplets/common/file-transfer-dialog.c:349
+msgid "To:"
+msgstr "To:"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr "Connecting..."
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Key"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr "GConf key to which this property editor is attached"
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr "Callback"
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Issue this callback when the value associated with key gets changed"
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr "Change set"
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr "Conversion to widget callback"
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr "Conversion from widget callback"
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr "UI Control"
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr "Object that controls the property (normally a widget)"
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr "Property editor object data"
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr "Custom data required by the specific property editor"
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr "Property editor data freeing callback"
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr "Callback to be issued when property editor object data is to be freed"
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Could not find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"I do not know how to open the file '%s'.\n"
+"Perhaps it is a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr "Please select an image."
+
+#: ../capplets/common/gconf-property-editor.c:1598
+msgid "_Select"
+msgstr "_Select"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr "Preferred Applications"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Select your default applications"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:56
+msgid "Could not display help"
+msgstr "Could not display help"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:58
+#: ../capplets/default-applications/gnome-da-capplet.c:689
+msgid "Please make sure that the applet is properly installed"
+msgstr "Please make sure that the applet is properly installed"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:93
+#: ../capplets/default-applications/gnome-da-capplet.c:126
+#: ../capplets/default-applications/gnome-da-capplet.c:185
+#: ../capplets/default-applications/gnome-da-capplet.c:230
+#: ../capplets/default-applications/gnome-da-capplet.c:284
+#: ../capplets/default-applications/gnome-da-capplet.c:333
+#: ../capplets/default-applications/gnome-da-capplet.c:524
+#: ../capplets/default-applications/gnome-da-capplet.c:545
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "Error saving configuration: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:665
+msgid "Custom"
+msgstr "Custom"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:687
+msgid "Could not load the main interface"
+msgstr "Could not load the main interface"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Debian Sensible Browser"
+msgstr "Debian Sensible Browser"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Debian Terminal Emulator"
+msgstr "Debian Terminal Emulator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Encompass"
+msgstr "Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Epiphany Web Browser"
+msgstr "Epiphany Web Browser"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "Evolution Mail Reader"
+msgstr "Evolution Mail Reader"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Evolution Mail Reader 1.4"
+msgstr "Evolution Mail Reader 1.4"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Evolution Mail Reader 1.5"
+msgstr "Evolution Mail Reader 1.5"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader 1.6"
+msgstr "Evolution Mail Reader 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Evolution Mail Reader 2.0"
+msgstr "Evolution Mail Reader 2.0"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Evolution Mail Reader 2.2"
+msgstr "Evolution Mail Reader 2.2"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "Evolution Mail Reader 2.4"
+msgstr "Evolution Mail Reader 2.4"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "GNOME Terminal"
+msgstr "GNOME Terminal"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Links Text Browser"
+msgstr "Links Text Browser"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Lynx Text Browser"
+msgstr "Lynx Text Browser"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "Mozilla Mail"
+msgstr "Mozilla Mail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Netscape Communicator"
+msgstr "Netscape Communicator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Opera"
+msgstr "Opera"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Standard XTerminal"
+msgstr "Standard XTerminal"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "W3M Text Browser"
+msgstr "W3M Text Browser"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Audio Player</b>"
+msgstr "<b>Audio Player</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Image Viewer</b>"
+msgstr "<b>Image Viewer</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Instant Messenger</b>"
+msgstr "<b>Instant Messenger</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mail Reader</b>"
+msgstr "<b>Mail Reader</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>Terminal Emulator</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Text Editor</b>"
+msgstr "<b>Text Editor</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Video Player</b>"
+msgstr "<b>Video Player</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Web Browser</b>"
+msgstr "<b>Web Browser</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "All %s occurrences will be replaced with actual link"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Co_mmand:"
+msgstr "Co_mmand:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "E_xecute flag:"
+msgstr "E_xecute flag:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Internet"
+msgstr "Internet"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Multimedia"
+msgstr "Multimedia"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Open link in new _tab"
+msgstr "Open link in new _tab"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Open link in new _window"
+msgstr "Open link in new _window"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Open link with web browser _default"
+msgstr "Open link with web browser _default"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Run in t_erminal"
+msgstr "Run in t_erminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "System"
+msgstr "System"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Change screen resolution"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Screen Resolution"
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/main.c:448
+msgid "_Resolution:"
+msgstr "_Resolution:"
+
+#: ../capplets/display/main.c:467
+msgid "Re_fresh rate:"
+msgstr "Re_fresh rate:"
+
+#: ../capplets/display/main.c:488
+msgid "Default Settings"
+msgstr "Default Settings"
+
+#: ../capplets/display/main.c:490
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr "Screen %d Settings\n"
+
+#: ../capplets/display/main.c:516
+msgid "Screen Resolution Preferences"
+msgstr "Screen Resolution Preferences"
+
+#: ../capplets/display/main.c:553
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "_Make default for this computer (%s) only"
+
+#: ../capplets/display/main.c:571
+msgid "Options"
+msgstr "Options"
+
+#: ../capplets/display/main.c:592
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"Testing the new settings. If you do not respond in %d second the previous "
+"settings will be restored."
+msgstr[1] ""
+"Testing the new settings. If you do not respond in %d seconds the previous "
+"settings will be restored."
+
+#: ../capplets/display/main.c:638
+msgid "Keep Resolution"
+msgstr "Keep Resolution"
+
+#: ../capplets/display/main.c:642
+msgid "Do you want to keep this resolution?"
+msgstr "Do you want to keep this resolution?"
+
+#: ../capplets/display/main.c:667
+msgid "Use _previous resolution"
+msgstr "Use _previous resolution"
+
+#: ../capplets/display/main.c:667
+msgid "_Keep resolution"
+msgstr "_Keep resolution"
+
+#: ../capplets/display/main.c:818
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+
+#: ../capplets/display/main.c:826
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Font"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr "Select fonts for the desktop"
+
+#: ../capplets/font/font-properties.glade.h:1
+msgid "<b>Font Rendering</b>"
+msgstr "<b>Font Rendering</b>"
+
+#: ../capplets/font/font-properties.glade.h:2
+msgid "<b>Hinting</b>:"
+msgstr "<b>Hinting</b>:"
+
+#: ../capplets/font/font-properties.glade.h:3
+msgid "<b>Smoothing</b>:"
+msgstr "<b>Smoothing</b>:"
+
+#: ../capplets/font/font-properties.glade.h:4
+msgid "<b>Subpixel order</b>:"
+msgstr "<b>Subpixel order</b>:"
+
+#: ../capplets/font/font-properties.glade.h:5
+msgid "Best _shapes"
+msgstr "Best _shapes"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best co_ntrast"
+msgstr "Best co_ntrast"
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "D_etails..."
+msgstr "D_etails..."
+
+#: ../capplets/font/font-properties.glade.h:8
+msgid "Des_ktop font:"
+msgstr "Des_ktop font:"
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "Font Preferences"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr "Font Rendering Details"
+
+#: ../capplets/font/font-properties.glade.h:11
+msgid "Go _to font folder"
+msgstr "Go _to font folder"
+
+#: ../capplets/font/font-properties.glade.h:12
+msgid "Gra_yscale"
+msgstr "Gre_yscale"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "N_one"
+
+#: ../capplets/font/font-properties.glade.h:14
+msgid "R_esolution:"
+msgstr "R_esolution:"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr "Sub_pixel (LCDs)"
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "Sub_pixel smoothing (LCDs)"
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "_Application font:"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Document font:"
+msgstr "_Document font:"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Fixed width font:"
+msgstr "_Fixed-width font:"
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Full"
+msgstr "_Full"
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Medium"
+msgstr "_Medium"
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_Monochrome"
+msgstr "_Monochrome"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_None"
+msgstr "_None"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Slight"
+msgstr "_Slight"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "_Window title font:"
+
+#: ../capplets/font/font-properties.glade.h:30
+msgid "dots per inch"
+msgstr "dots per inch"
+
+#: ../capplets/font/main.c:489
+msgid "Font may be too large"
+msgstr "Font may be too large"
+
+#: ../capplets/font/main.c:493
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgstr[1] ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+
+#: ../capplets/font/main.c:506
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgstr[1] ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "New accelerator..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Accelerator key"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Accelerator modifiers"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Accelerator keycode"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Accel Mode"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "The type of accelerator."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:197
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:471
+msgid "Disabled"
+msgstr "Disabled"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:544
+msgid "<Unknown Action>"
+msgstr "<Unknown Action>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:565
+msgid "Desktop"
+msgstr "Desktop"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:566
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Sound"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:570
+msgid "Window Management"
+msgstr "Window Management"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:676
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become unusable to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time.\n"
+msgstr ""
+"The shortcut \"%s\" cannot be used because it will become unusable to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time.\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:705
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:737
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr "Error setting new accelerator in configuration database: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:787
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr "Error unsetting accelerator in configuration database: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:894
+msgid "Action"
+msgstr "Action"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:918
+msgid "Shortcut"
+msgstr "Shortcut"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Keyboard Shortcuts"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Assign shortcut keys to commands"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+msgid "Unknown"
+msgstr "Unknown"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+msgid "Layout"
+msgstr "Layout"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+msgid "Default"
+msgstr "Default"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+msgid "Models"
+msgstr "Models"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:109
+#, c-format
+msgid "There was an error launching the keyboard tool: %s"
+msgstr "There was an error launching the keyboard tool: %s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr "_Accessibility"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:240
+#: ../capplets/sound/sound-properties-capplet.c:242
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr "Start the page with the typing break settings showing"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "..."
+msgstr "..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Cursor Blinking</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Repeat Keys</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<b>_Lock screen to enforce typing break</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Fast</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Long</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Short</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Slow</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_vailable layouts:"
+msgstr "A_vailable layouts:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "All_ow postponing of breaks"
+msgstr "All_ow postponing of breaks"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Check if breaks are allowed to be postponed"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "Choose a Keyboard Model"
+msgstr "Choose a Keyboard Model"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Choose a Layout"
+msgstr "Choose a Layout"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr "Cursor _blinks in text boxes and fields"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Cursor blinks speed"
+msgstr "Cursor blink speed"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of the break when typing is disallowed"
+msgstr "Duration of the break when typing is disallowed"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Duration of work before forcing a break"
+msgstr "Duration of work before forcing a break"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Key presses _repeat when key is held down"
+msgstr "Key presses _repeat when key is held down"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Keyboard Preferences"
+msgstr "Keyboard Preferences"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Keyboard _model:"
+msgstr "Keyboard _model:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Layout Options"
+msgstr "Layout Options"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Layouts"
+msgstr "Layouts"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Microsoft Natural Keyboard"
+msgstr "Microsoft Natural Keyboard"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Preview:"
+msgstr "Preview:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "Repeat keys speed"
+msgstr "Repeat keys speed"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Reset To De_faults"
+msgstr "Reset To De_faults"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Separate _group for each window"
+msgstr "Separate _group for each window"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+msgid "Typing Break"
+msgstr "Typing Break"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Accessibility..."
+msgstr "_Accessibility..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Add..."
+msgstr "_Add..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "_Break interval lasts:"
+msgstr "_Break interval lasts:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Delay:"
+msgstr "_Delay:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Models:"
+msgstr "_Models:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Selected layouts:"
+msgstr "_Selected layouts:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Speed:"
+msgstr "_Speed:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "_Work interval lasts:"
+msgstr "_Work interval lasts:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "minutes"
+msgstr "minutes"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Set your keyboard preferences"
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:880
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "microseconds"
+msgstr "microseconds"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:560
+msgid "Unknown Pointer"
+msgstr "Unknown Pointer"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+msgid "Default Pointer"
+msgstr "Default Pointer"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Pointer - Current"
+msgstr "Default Pointer - Current"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+msgid "The default pointer that ships with X"
+msgstr "The default pointer that ships with X"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+msgid "White Pointer"
+msgstr "White Pointer"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Pointer - Current"
+msgstr "White Pointer - Current"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+msgid "The default pointer inverted"
+msgstr "The default pointer inverted"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+msgid "Large Pointer"
+msgstr "Large Pointer"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Pointer - Current"
+msgstr "Large Pointer - Current"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+msgid "Large version of normal pointer"
+msgstr "Large version of normal pointer"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+msgid "Large White Pointer - Current"
+msgstr "Large White Pointer - Current"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Pointer"
+msgstr "Large White Pointer"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+msgid "Large version of white pointer"
+msgstr "Large version of white pointer"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:970
+msgid "Pointer Theme"
+msgstr "Pointer Theme"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr "<b>Double-Click Timeout </b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Drag and Drop</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Locate Pointer</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>Mouse Orientation</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Speed</b>"
+msgstr "<b>Speed</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>Fast</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>High</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>Large</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>Low</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>Slow</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>Small</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Buttons"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr "Highlight the _pointer when you press Ctrl"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Large"
+msgstr "Large"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Medium"
+msgstr "Medium"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "Motion"
+msgstr "Motion"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+msgid "Mouse Preferences"
+msgstr "Mouse Preferences"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Pointer Size:"
+msgstr "Pointer Size:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Pointers"
+msgstr "Pointers"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "Small"
+msgstr "Small"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr "_Acceleration:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr "_Left-handed mouse"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr "_Sensitivity:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr "_Threshold:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr "_Timeout:"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Mouse"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Set your mouse preferences"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Network Proxy"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "Set your network proxy preferences"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>Di_rect internet connection</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr "<b>Ignore Host List</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>_Automatic proxy configuration</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>_Manual proxy configuration</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Use authentication</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "Advanced Configuration"
+msgstr "Advanced Configuration"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr "Autoconfiguration _URL:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "HTTP Proxy Details"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "H_TTP proxy:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Network Proxy Preferences"
+msgstr "Network Proxy Preferences"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Port:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "Proxy Configuration"
+msgstr "Proxy Configuration"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr "S_ocks host:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "U_sername:"
+msgstr "U_sername:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_Details"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr "_FTP proxy:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "_Password:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr "_Secure HTTP proxy:"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Enable sound and associate sounds with events"
+
+#: ../capplets/sound/sound-properties-capplet.c:271
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "Sound Preferences"
+msgstr "Sound Preferences"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "E_nable software sound mixing (ESD)"
+msgstr "E_nable software sound mixing (ESD)"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "Flash _entire screen"
+msgstr "Flash _entire screen"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "Flash _window titlebar"
+msgstr "Flash _window titlebar"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "Sounds"
+msgstr "Sounds"
+
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "System Beep"
+msgstr "System Beep"
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "_Enable system beep"
+msgstr "_Enable system beep"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "_Play system sounds"
+msgstr "_Play system sounds"
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "_Visual system beep"
+msgstr "_Visual system beep"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:368
+msgid "Would you like to remove this theme?"
+msgstr "Would you like to remove this theme?"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:433
+msgid "Theme deleted succesfully. Please select another theme."
+msgstr "Theme deleted succesfully. Please select another theme."
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:442
+msgid "Theme can not be deleted"
+msgstr "Theme cannot be deleted"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:529
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialogue was improperly installed, or you have not "
+"installed the \"gnome-themes\" package."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:227
+msgid "This theme is not in a supported format."
+msgstr "This theme is not in a supported format."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:242
+msgid "Failed to create temporary directory"
+msgstr "Failed to create temporary directory"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:260
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+"Cannot install theme. \n"
+"The bzip2 utility is not installed."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:276
+#: ../capplets/theme-switcher/gnome-theme-installer.c:309
+#: ../capplets/theme-switcher/gnome-theme-installer.c:383
+msgid "Installation Failed"
+msgstr "Installation Failed"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:294
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+"Cannot install themes. \n"
+"The gzip utility is not installed."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:330
+#, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:333
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr "Gnome Theme %s correctly installed"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:336
+#, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:339
+#, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:345
+msgid "The theme is an engine. You need to compile the theme."
+msgstr "The theme is an engine. You need to compile the theme."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:360
+msgid "The file format is invalid"
+msgstr "The file format is invalid"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:450
+msgid "No theme file location specified to install"
+msgstr "No theme file location specified to install"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:469
+msgid "The theme file location specified to install is invalid"
+msgstr "The theme file location specified to install is invalid"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:489
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:510
+msgid "The file format is invalid."
+msgstr "The file format is invalid."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:537
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:591
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr ""
+"Cannot install theme.\n"
+"The tar(1) program is not installed on your system."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:686
+msgid "Custom theme"
+msgstr "Custom theme"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:686
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr "You can save this theme by pressing the Save Theme button."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1584
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably do not have metacity installed, or that your gconf is "
+"configured incorrectly."
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:72
+msgid "Theme name must be present"
+msgstr "Theme name must be present"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:104
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "The theme already exists. Would you like to replace it?"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr "Select themes for various parts of the desktop"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "Theme"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:3
+msgid "Theme Installation"
+msgstr "Theme Installation"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:4
+msgid "_Install"
+msgstr "_Install"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:5
+msgid "_Location:"
+msgstr "_Location:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "Apply _Background"
+msgstr "Apply _Background"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Apply _Font"
+msgstr "Apply _Font"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Controls"
+msgstr "Controls"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Icons"
+msgstr "Icons"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "New themes can also be installed by dragging them into the window."
+msgstr "New themes can also be installed by dragging them into the window."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "Save Theme"
+msgstr "Save Theme"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+msgid "Select theme for the desktop"
+msgstr "Select theme for the desktop"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+msgid "Short _description:"
+msgstr "Short _description:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+msgid "Theme Details"
+msgstr "Theme Details"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "Theme Preferences"
+msgstr "Theme Preferences"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "Theme _Details"
+msgstr "Theme _Details"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+msgid "This theme does not suggest any particular font or background."
+msgstr "This theme does not suggest any particular font or background."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+msgid "This theme suggests a background:"
+msgstr "This theme suggests a background:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+msgid "This theme suggests a font and a background:"
+msgstr "This theme suggests a font and a background:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+msgid "This theme suggests a font:"
+msgstr "This theme suggests a font:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+msgid "Window Border"
+msgstr "Window Border"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "_Install Theme..."
+msgstr "_Install Theme..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+msgid "_Revert"
+msgstr "_Revert"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+msgid "_Save Theme..."
+msgstr "_Save Theme..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+msgid "_Theme name:"
+msgstr "_Theme name:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+msgid "theme selection tree"
+msgstr "theme selection tree"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr "Customize the appearance of toolbars and menubars in applications"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "Menus & Toolbars"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr "<b>Behaviour and Appearance</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+msgid "<b>Preview</b>"
+msgstr "<b>Preview</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "C_ut"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+msgid "Icons only"
+msgstr "Icons only"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "Menu and Toolbar Preferences"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "New File"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Open File"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Save File"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr "Show _icons in menus"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+msgid "Text below icons"
+msgstr "Text below icons"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+msgid "Text beside icons"
+msgstr "Text beside icons"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+msgid "Text only"
+msgstr "Text only"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+msgid "Toolbar _button labels:"
+msgstr "Toolbar _button labels:"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_Copy"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr "_Detachable toolbars"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_Edit"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr "_Editable menu accelerators"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "_File"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_New"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "_Open"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "_Paste"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "_Print"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "_Quit"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "_Save"
+
+#: ../capplets/windows/gnome-window-properties.c:385
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+
+#: ../capplets/windows/gnome-window-properties.c:642
+msgid "C_ontrol"
+msgstr "C_ontrol"
+
+#: ../capplets/windows/gnome-window-properties.c:647
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:653
+msgid "H_yper"
+msgstr "H_yper"
+
+#: ../capplets/windows/gnome-window-properties.c:660
+msgid "S_uper (or \"Windows logo\")"
+msgstr "S_uper (or \"Windows logo\")"
+
+#: ../capplets/windows/gnome-window-properties.c:667
+msgid "_Meta"
+msgstr "_Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Movement Key</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>Titlebar Action</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Window Selection</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr "To move a window, press-and-hold this key then grab the window:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Window Preferences"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_Double-click titlebar to perform this action:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "_Interval before raising:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_Raise selected windows after an interval"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Select windows when the mouse moves over them"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "Set your window properties"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Windows"
+
+#: ../control-center/control-center-categories.c:287
+msgid "Others"
+msgstr "Others"
+
+#: ../control-center/control-center.c:93
+msgid "Desktop Preferences"
+msgstr "Desktop Preferences"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr "GNOME Control Centre"
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "The GNOME configuration tool"
+
+#: ../gnome-settings-daemon/actions/acme-fb-level.c:149
+msgid "No '/dev/pmu' device found"
+msgstr "No '/dev/pmu' device found"
+
+#: ../gnome-settings-daemon/actions/acme-fb-level.c:156
+msgid "Not a powerbook"
+msgstr "Not a PowerBook"
+
+#: ../gnome-settings-daemon/actions/acme-fb-level.c:173
+msgid "Wrong permission for '/dev/pmu' device"
+msgstr "Wrong permission for '/dev/pmu' device"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "Volume"
+
+#: ../gnome-settings-daemon/factory.c:37
+msgid "Could not initialize Bonobo"
+msgstr "Could not initialize Bonobo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:406
+msgid "Slow Keys Alert"
+msgstr "Slow Keys Alert"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:407
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:409
+msgid "Do you want to activate Slow Keys?"
+msgstr "Do you want to activate Slow Keys?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Do you want to deactivate Slow Keys?"
+msgstr "Do you want to deactivate Slow Keys?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
+msgid "_Activate"
+msgstr "_Activate"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
+msgid "_Deactivate"
+msgstr "_Deactivate"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
+msgid "Do_n't activate"
+msgstr "Do_n't activate"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
+msgid "Do_n't deactivate"
+msgstr "Do_n't deactivate"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:421
+msgid "Sticky Keys Alert"
+msgstr "Sticky Keys Alert"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:422
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:424
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:426
+msgid "Do you want to activate Sticky Keys?"
+msgstr "Do you want to activate Sticky Keys?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:427
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr "Do you want to deactivate Sticky Keys?"
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:74
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing the mouse pointer theme."
+msgstr ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing the mouse pointer theme."
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:96
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:208
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr "Key Binding (%s) has its action defined multiple times\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:221
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr "Key Binding (%s) has its binding defined multiple times\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:227
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr "Key Binding (%s) is incomplete\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:255
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr "Key Binding (%s) is invalid\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:291
+#, c-format
+msgid "It seems that another application already has access to key '%u'."
+msgstr "It seems that another application already has access to key '%u'."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:360
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr "Key Binding (%s) is already in use\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:435
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
+#, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+"Error activating XKB configuration.\n"
+"This can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or using a newer version of XFree software."
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:223
+msgid "Do _not show this warning again"
+msgstr "Do _not show this warning again"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:234
+msgid ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+msgstr ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:247
+msgid "Use X settings"
+msgstr "Use X settings"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:249
+msgid "Use GNOME settings"
+msgstr "Use GNOME settings"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+"Could not execute command: %s\n"
+"Verify that this command exists."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+"Could not put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:180
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+"Could not load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:110
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:120
+msgid "_Do not show this message again"
+msgstr "_Do not show this message again"
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:150
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr "Could not load sound file %s as sample %s"
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:212
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:260
+msgid "Cannot determine user's home directory"
+msgstr "Cannot determine user's home directory"
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:212
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr "GConf key %s set to type %s but its expected type was %s\n"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+msgid "A_vailable files:"
+msgstr "A_vailable files:"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+msgid "Do _not show this warning again."
+msgstr "Do _not show this warning again."
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr "Load modmap files"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr "Would you like to load the modmap file(s)?"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr "_Load"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+msgid "_Loaded files:"
+msgstr "_Loaded files:"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr "Error creating signal pipe."
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Type"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr "Preview Width"
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr "Width if applier is a preview: Defaults to 64."
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr "Preview Height"
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr "Height if applier is a preview: Defaults to 48."
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Screen"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr "Screen on which BGApplier is to draw"
+
+#: ../libgswitchit/gswitchit_config.c:1036
+#, c-format
+msgid "There was an error loading an image: %s"
+msgstr "There was an error loading an image: %s"
+
+#: ../libsounds/sound-view.c:115
+msgid "Sound not set for this event."
+msgstr "Sound not set for this event."
+
+#: ../libsounds/sound-view.c:124
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package for a set of default sounds."
+msgstr ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package for a set of default sounds."
+
+#: ../libsounds/sound-view.c:135
+msgid "The sound file for this event does not exist."
+msgstr "The sound file for this event does not exist."
+
+#: ../libsounds/sound-view.c:166
+msgid "Select Sound File"
+msgstr "Select Sound File"
+
+#: ../libsounds/sound-view.c:186
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "The file %s is not a valid wav file"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "Window manager \"%s\" has not registered a configuration tool\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Maximize"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Roll up"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr "Sync text/plain and text/* handlers"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "Brightness down"
+msgstr "Brightness down"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "Brightness down's shortcut."
+msgstr "Brightness down's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Brightness up"
+msgstr "Brightness up"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Brightness up's shortcut."
+msgstr "Brightness up's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "E-mail"
+msgstr "E-mail"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "E-mail's shortcut."
+msgstr "E-mail's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Eject"
+msgstr "Eject"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+msgid "Eject's shortcut."
+msgstr "Eject's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+msgid "Home folder"
+msgstr "Home folder"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+msgid "Home folder's shortcut."
+msgstr "Home folder's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+msgid "Launch help browser"
+msgstr "Launch help browser"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+msgid "Launch help browser's shortcut."
+msgstr "Launch help browser's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+msgid "Launch web browser"
+msgstr "Launch web browser"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+msgid "Launch web browser's shortcut."
+msgstr "Launch web browser's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+msgid "Lock screen"
+msgstr "Lock screen"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+msgid "Lock screen's shortcut."
+msgstr "Lock screen's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+msgid "Log out"
+msgstr "Log out"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+msgid "Log out's shortcut."
+msgstr "Log out's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Next track key's shortcut."
+msgstr "Next track key's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Pause"
+msgstr "Pause"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Pause key's shortcut."
+msgstr "Pause key's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Play (or play/pause)"
+msgstr "Play (or play/pause)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Play (or play/pause) key's shortcut."
+msgstr "Play (or play/pause) key's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Previous track key's shortcut."
+msgstr "Previous track key's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Search"
+msgstr "Search"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+msgid "Search's shortcut."
+msgstr "Search's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Skip to next track"
+msgstr "Skip to next track"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Skip to previous track"
+msgstr "Skip to previous track"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Sleep"
+msgstr "Sleep"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+msgid "Sleep's shortcut."
+msgstr "Sleep's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Stop playback key"
+msgstr "Stop playback key"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Stop playback key's shortcut."
+msgstr "Stop playback key's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume down"
+msgstr "Volume down"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume down's shortcut."
+msgstr "Volume down's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume mute"
+msgstr "Volume mute"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume mute's shortcut"
+msgstr "Volume mute's shortcut"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+msgid "Volume step"
+msgstr "Volume step"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+msgid "Volume step as percentage of volume."
+msgstr "Volume step as percentage of volume."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+msgid "Volume up"
+msgstr "Volume up"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
+msgid "Volume up's shortcut."
+msgstr "Volume up's shortcut."
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr "Display a dialogue when there are errors running the screensaver"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+msgid "Run screensaver at login"
+msgstr "Run screensaver at login"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr "Show Startup Errors"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+msgid "Start screensaver"
+msgstr "Start screensaver"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap-based adjustments"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr "A list of modmap files available in the $HOME directory."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr "Default group, assigned on window creation"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr "Keep and manage separate group per window"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+msgid "Keyboard Update Handlers"
+msgstr "Keyboard Update Handlers"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+msgid "Keyboard layout"
+msgstr "Keyboard layout"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+msgid "Keyboard model"
+msgstr "Keyboard model"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+msgid "Keyboard options"
+msgstr "Keyboard options"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr ""
+"Keyboard settings in GConf will be overridden from the system ASAP "
+"(deprecated)"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr "Save/restore indicators together with layout groups"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr "Show layout names instead of group names"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr "Suppress the \"X sysconfig changed\" warning message"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+"Very soon, keyboard settings in GConf will be overridden (from the system "
+"configuration). This key has been deprecated since GNOME 2.12. Please unset "
+"the model, layouts and options keys to get the default system configuration."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+msgid "keyboard layout"
+msgstr "keyboard layout"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+msgid "keyboard model"
+msgstr "keyboard model"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "modmap file list"
+msgstr "modmap file list"
+
+#: ../typing-break/drw-break-window.c:213
+msgid "_Postpone break"
+msgstr "_Postpone break"
+
+#: ../typing-break/drw-break-window.c:260
+msgid "Take a break!"
+msgstr "Take a break!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:135
+msgid "/_Preferences"
+msgstr "/_Preferences"
+
+#: ../typing-break/drwright.c:136
+msgid "/_About"
+msgstr "/_About"
+
+#: ../typing-break/drwright.c:138
+msgid "/_Take a Break"
+msgstr "/_Take a Break"
+
+#: ../typing-break/drwright.c:489
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "%d minute until the next break"
+msgstr[1] "%d minutes until the next break"
+
+#: ../typing-break/drwright.c:493
+msgid "Less than one minute until the next break"
+msgstr "Less than one minute until the next break"
+
+#: ../typing-break/drwright.c:581
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Unable to bring up the typing break properties dialogue with the following "
+"error: %s"
+
+#: ../typing-break/drwright.c:629
+msgid "About GNOME Typing Monitor"
+msgstr "About GNOME Typing Monitor"
+
+#: ../typing-break/drwright.c:653
+msgid "A computer break reminder."
+msgstr "A computer break reminder."
+
+#: ../typing-break/drwright.c:654
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr "Written by Richard Hult &lt;richard@imendio.com&gt;"
+
+#: ../typing-break/drwright.c:655
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Eye candy added by Anders Carlsson"
+
+#: ../typing-break/drwright.c:831
+msgid "Break reminder"
+msgstr "Break reminder"
+
+#: ../typing-break/eggtrayicon.c:127
+msgid "Orientation"
+msgstr "Orientation"
+
+#: ../typing-break/eggtrayicon.c:128
+msgid "The orientation of the tray."
+msgstr "The orientation of the tray."
+
+#: ../typing-break/main.c:100
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"The typing monitor uses the notification area to display information. You do "
+"not seem to have a notification area on your panel. You can add it by right-"
+"clicking on your panel and choosing 'Add to panel', selecting 'Notification "
+"area' and clicking 'Add'."
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "The quick brown fox jumps over the lazy dog. 0123456789"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "Name:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "Style:"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "Type:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "Size:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "Version:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "Description:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "usage: %s fontfile\n"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr "Set as Application Font"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+msgid "Sets the default application font"
+msgstr "Sets the default application font"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "If set to true, then OpenType fonts will be thumbnailed."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "If set to true, then PCF fonts will be thumbnailed."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "If set to true, then TrueType fonts will be thumbnailed."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "If set to true, then Type1 fonts will be thumbnailed."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr "Set this key to the command used to create thumbnails for PCF fonts."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr "Set this key to the command used to create thumbnails for Type1 fonts."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "Thumbnail command for OpenType fonts"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "Thumbnail command for PCF fonts"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "Thumbnail command for TrueType fonts"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Thumbnail command for Type1 fonts"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "Whether to thumbnail OpenType fonts"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "Whether to thumbnail PCF fonts"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "Whether to thumbnail TrueType fonts"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "Whether to thumbnail Type1 fonts"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+msgid "GNOME Font Viewer"
+msgstr "GNOME Font Viewer"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr "Do _not apply font"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+msgid "_Apply font"
+msgstr "_Apply font"
+
+#: ../vfs-methods/themus/theme-method.c:518
+msgid "Themes"
+msgstr "Themes"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "Description"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr "Control theme"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+msgid "Window border theme"
+msgstr "Window border theme"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr "Icon theme"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr "ABCDEFG"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+msgid "Apply theme"
+msgstr "Apply theme"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+msgid "Sets the default theme"
+msgstr "Sets the default theme"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr "If set to true, then installed themes will be thumbnailed."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr "If set to true, then themes will be thumbnailed."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+"Set this key to the command used to create thumbnails for installed themes."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr "Set this key to the command used to create thumbnails for themes."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr "Thumbnail command for installed themes"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr "Thumbnail command for themes"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr "Whether to thumbnail installed themes"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr "Whether to thumbnail themes"
+
+msgid "Show help options"
+msgstr "Show help options"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -10,9 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-04 22:24+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-05 10:21+0100\n"
 "Last-Translator: Bruce Cowan <bruce@bcowan.me.uk>\n"
 "Language-Team: English - United Kingdom <en@li.org>\n"
@@ -29,99 +28,7 @@ msgstr ""
 "X-DL-Domain: po\n"
 "X-DL-State: Translating\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "System Bus"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Full access"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Session Bus"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Devices"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Full access to /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Network"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Has network access"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Home"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Read-only"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "File System"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Settings"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Can change settings"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u file and link type that is opened by the app"
-msgstr[1] "%u file and link types that are opened by the app"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> is used to open the following types of files and links."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s of disk space used."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -137,7 +44,6 @@ msgid "Install some…"
 msgstr "Install some…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Open"
 
@@ -161,24 +67,13 @@ msgstr "Search"
 msgid "Receive system searches and send results."
 msgstr "Receive system searches and send results."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Disabled"
 
@@ -343,80 +238,20 @@ msgstr "Clear Cache…"
 msgid "Control various application permissions and settings"
 msgstr "Control various application permissions and settings"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "application;flatpak;permission;setting;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Select a picture"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Cancel"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Open"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "multiple sizes"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "No Desktop Background"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Current background"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Style"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Default"
 
@@ -440,7 +275,6 @@ msgstr "Appearance"
 msgid "Change your background image or the UI colors"
 msgstr "Change your background image or the UI colours"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
@@ -491,9 +325,7 @@ msgstr "Hardware Aeroplane Mode is On"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Turn off the Aeroplane mode switch to enable Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -501,7 +333,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Turn Bluetooth on and off and connect your devices"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;"
@@ -534,91 +365,33 @@ msgstr "No Applications Have Asked for Camera Access"
 msgid "Protect your pictures"
 msgstr "Protect your pictures"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "camera;photos;video;webcam;lock;private;privacy;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Place your calibration device over the square and press “Start”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Move your calibration device to the calibrate position and press “Continue”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Move your calibration device to the surface position and press “Continue”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Shut the laptop lid"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "An internal error occurred that could not be recovered."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Tools required for calibration are not installed."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "The profile could not be generated."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "The target whitepoint was not obtainable."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Complete!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Calibration failed!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "You can remove the calibration device."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Do not disturb the calibration device while in progress"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Display Calibration"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancel"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -635,140 +408,6 @@ msgstr "_Resume"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Done"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Laptop Screen"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Built-in Webcam"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s Monitor"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s Scanner"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s Camera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s Printer"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s Webcam"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Enable colour management for %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Show colour profiles for %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Not calibrated"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Default: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Colourspace: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Test profile: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Select ICC Profile File"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Import"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Supported ICC profiles"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "All files"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Screen"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Save Profile"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Save"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Create a colour profile for the selected device"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "The measuring instrument does not support printer profiling."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "The device type is not currently supported."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -886,13 +525,13 @@ msgstr "Requires writeable media"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -912,7 +551,6 @@ msgstr "_Import File…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -922,9 +560,7 @@ msgstr "_Add"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "Each device needs an up to date colour profile to be colour managed."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Learn more"
 
@@ -1056,82 +692,6 @@ msgstr "D65 (Photography and graphics)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standard Space"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Test Profile"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatic"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Low Quality"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Medium Quality"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "High Quality"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Default RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Default CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Default Grey"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Vendor supplied factory calibration data"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Full-screen display correction not possible with this profile"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "This profile may no longer be accurate"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Colour"
@@ -1142,14 +702,9 @@ msgid ""
 msgstr ""
 "Calibrate the colour of your devices, such as displays, cameras or printers"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Colour;ICC;Profile;Calibrate;Printer;Display;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Other…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1164,13 +719,8 @@ msgid "No languages found"
 msgstr "No languages found"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "More…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Unlock to Change Settings"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1199,151 +749,6 @@ msgstr "Decrement Hour"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Decrement Minute"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Today"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Yesterday"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d hour"
-msgstr[1] "%d hours"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minute"
-msgstr[1] "%d minutes"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d second"
-msgstr[1] "%d seconds"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 seconds"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-hour"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM/PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%H:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1438,17 +843,11 @@ msgstr "Automatic Time _Zone"
 msgid "Requires location services enabled and internet access"
 msgstr "Requires location services enabled and internet access"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Enabled"
 
@@ -1456,15 +855,42 @@ msgstr "Enabled"
 msgid "Time Z_one"
 msgstr "Time Z_one"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Unlock"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Time _Format"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dates"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 seconds"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Calendar"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Numbers"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Change the date and time, including time zone"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;"
@@ -1510,20 +936,9 @@ msgstr "Default Applications"
 msgid "Configure Default Applications"
 msgstr "Configure Default Applications"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "default;application;preferred;media;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1541,44 +956,9 @@ msgstr "Diagnostics"
 msgid "Report your problems"
 msgstr "Report your problems"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostics;crash;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "On"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Off"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Apply Changes?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Changes Cannot be Applied"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "This could be due to hardware limitations."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1628,31 +1008,6 @@ msgstr "Primary Display"
 msgid "Night Light"
 msgstr "Night Light"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Landscape"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Portrait Right"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Portrait Left"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Landscape (flipped)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1676,6 +1031,17 @@ msgstr "Adjust for TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Scale"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Natural Scrolling"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1771,7 +1137,6 @@ msgstr "Displays"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Choose how to use connected monitors and projectors"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1779,78 +1144,6 @@ msgid ""
 msgstr ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;colour;sunset;sunrise;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Secure Boot is Active"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Secure Boot Has Problems"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "For help, contact your hardware manufacturer or IT support provider."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Secure Boot is Turned Off"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1864,130 +1157,9 @@ msgstr ""
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Passed"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Failed"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Device conforms to HSI level %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Security Level 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Security Level 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Security Level 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Security Level 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Security Level"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Security levels are not available for this device."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr "Contact your hardware manufacturer for help with security updates."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "It might be possible for a support technician to resolve this issue."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2001,338 +1173,9 @@ msgstr "Level 2"
 msgid "Level 3"
 msgstr "Level 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Protected against malicious software when the device starts."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Secure Boot has Problems"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Some protection when the device is started."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Secure Boot is Off"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "No protection when the device is started."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Exposed to serious security threats."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Limited protection against simple security threats."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Protected against common security threats."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Protected against a wide range of security threats."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Comprehensive Protection"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "No Events"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Firmware Write Protection"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Firmware Write Protection Lock"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Firmware BIOS Region"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Firmware BIOS Descriptor"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Pre-boot DMA Protection"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard Verified Boot"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM Protected"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard Error Policy"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard Fuse"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET Enabled"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET Active"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Encrypted RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU Protection"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux Kernel Lockdown"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linux Kernel Verification"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux Swap"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Suspend To RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Suspend To Idle"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI Platform Key"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI Secure Boot"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TPM Platform Configuration"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM Reconstruction"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel Management Engine Manufacturing Mode"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Intel Management Engine Override"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Intel Management Engine Version"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Firmware Updates"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Firmware Attestation"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Firmware Updater Verification"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Platform Debugging"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Processor Security Checks"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD Rollback Protection"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD Firmware Replay Protection"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "AMD Firmware Write Protection"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Fused Platform"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Valid"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Not Valid"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Not Enabled"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Locked"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Not Locked"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Encrypted"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Not Encrypted"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Tainted"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Not Tainted"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Found"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Not Found"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Supported"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Not Supported"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2342,7 +1185,6 @@ msgstr "Device Security"
 msgid "Host firmware security status"
 msgstr "Host firmware security status"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2350,49 +1192,6 @@ msgid ""
 msgstr ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
 "network;identity;privacy;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Unknown"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Unknown"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Not Available"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "System Logo"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2486,11 +1285,6 @@ msgstr "About"
 msgid "View information about your system"
 msgstr "View information about your system"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2568,6 +1362,12 @@ msgstr "Launchers"
 msgid "Launch help browser"
 msgstr "Launch help browser"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Settings"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Launch calculator"
@@ -2589,7 +1389,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Search"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "System"
 
@@ -2638,15 +1438,6 @@ msgstr "Decrease text size"
 msgid "High contrast on or off"
 msgstr "High contrast on or off"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "No input sources found"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Other"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Add an Input Source"
@@ -2679,106 +1470,9 @@ msgstr "Preferences"
 msgid "View Keyboard Layout"
 msgstr "View Keyboard Layout"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Remove"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Custom Shortcuts"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Alternative Characters Key"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Left Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Right Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Left Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Right Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menu key"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Right Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Compose Key"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2808,45 +1502,21 @@ msgstr "Special Character Entry"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Methods for entering symbols and letter variants using the keyboard."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternative Characters Key"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose Key"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Keyboard Shortcuts"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "View and Customise Shortcuts"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modified"
-msgstr[1] "%d modified"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Reset All Shortcuts?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Cancel"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Reset All"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2884,34 +1554,6 @@ msgstr "Add Shortcut"
 msgid "No keyboard shortcut found"
 msgstr "No keyboard shortcut found"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s is already being used for %s. If you replace it, %s will be disabled"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Enter the new shortcut"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Set Custom Shortcuts"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Set Shortcut"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Enter new shortcut to change %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Add Custom Shortcut"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Remove"
@@ -2923,7 +1565,6 @@ msgstr "Re_place"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Set"
 
@@ -2959,6 +1600,11 @@ msgstr "None"
 msgid "Reset the shortcut to its default value"
 msgstr "Reset the shortcut to its default value"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_Reset to Defaults"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Keyboard"
@@ -2971,7 +1617,6 @@ msgstr ""
 "Change keyboard shortcuts and set your typing preferences, keyboard layouts "
 "and input sources"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3012,7 +1657,6 @@ msgstr "No Applications Have Asked for Location Access"
 msgid "Protect your location information"
 msgstr "Protect your location information"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "location;gps;private;privacy;"
@@ -3047,7 +1691,6 @@ msgstr "No Applications Have Asked for Microphone Access"
 msgid "Protect your conversations"
 msgstr "Protect your conversations"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "microphone;recording;application;privacy;"
@@ -3077,81 +1720,141 @@ msgstr "Left"
 msgid "Right"
 msgstr "Right"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Search Locations"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mouse"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Mouse Speed"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Natural Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Scroll Down"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Scrolling moves the content, not the view."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Scrolling moves the content, not the view."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Acceleration:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Active"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Touchpad Speed"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Tap to Click"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Tap to click"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Two-finger Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Disable while _typing"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relative)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Edge Scrolling"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Down"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Two-sided"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Try clicking, double clicking, scrolling"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Five clicks, GEGL time!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Double click, primary button"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Single click, primary button"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Double click, middle button"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Single click, middle button"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Double click, secondary button"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Single click, secondary button"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3163,7 +1866,6 @@ msgid ""
 msgstr ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;Touchpad;"
@@ -3242,7 +1944,6 @@ msgstr "Multitasking"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Manage preferences for productivity and multitasking"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3250,20 +1951,11 @@ msgstr ""
 "Multitasking;Multitask;Productivity;Customize;Customise;Desktop;Hot Corner;"
 "Workspaces;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Oops, something has gone wrong. Please contact your software vendor."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager needs to be running."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Other Devices"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3275,59 +1967,16 @@ msgstr "Add connection"
 msgid "Not set up"
 msgstr "Not set up"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Insecure network (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Secure network (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Secure network (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Secure network (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Secure network"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Connected"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Options…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Must have a minimum of 8 characters"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3377,20 +2026,6 @@ msgstr "Autogenerate Password"
 msgid "_Turn On"
 msgstr "_Turn On"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Stop hotspot and disconnect any users?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Stop Hotspot"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Aeroplane Mode"
@@ -3435,89 +2070,13 @@ msgstr "Visible Networks"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager needs to be running"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Oops, something has gone wrong. Please contact your software vendor."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _Security"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Security"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Preserve"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Random"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stable"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profile %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "None"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Never"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3526,183 +2085,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i day ago"
 msgstr[1] "%i days ago"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "None"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Weak"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Good"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excellent"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 Address"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 Address"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP Address"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Forget Connection"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Remove Connection Profile"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Remove VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Details"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatic"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identity"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Delete Address"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Delete Route"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "None"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit Key (Hex or ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit Passphrase"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamic WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3713,8 +2095,20 @@ msgstr "Signal Strength"
 msgid "Link speed"
 msgstr "Link speed"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Security"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 Address"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 Address"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hardware Address"
 
@@ -3723,12 +2117,17 @@ msgid "Supported Frequencies"
 msgstr "Supported Frequencies"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Default Route"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3790,7 +2189,7 @@ msgstr "Link-Local Only"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
@@ -3834,9 +2233,8 @@ msgstr "Gateway"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automatic"
 
@@ -3889,89 +2287,9 @@ msgstr "Automatic, DHCP only"
 msgid "Prefix"
 msgstr "Prefix"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Unable to open connection editor"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "New Profile"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Invalid setting %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Invalid setting %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Import from file…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Add VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_ecurity"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Cannot import VPN connection"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"The file “%s” could not be read or does not contain recognised VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Select file to import"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "A file named “%s” already exists."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Replace"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Do you want to replace %s with the VPN connection you are saving?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Cannot export VPN connection"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Export VPN connection"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3985,100 +2303,38 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Network"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Control how you connect to the Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
 "DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Control how you connect to Wi-Fi networks"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "never"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "today"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "yesterday"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Last used"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Wired"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Add new connection"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Forget"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Known Wi-Fi Networks"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Forget"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "System policy prohibits use as a Hotspot"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Wireless device does not support Hotspot mode"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "This is not recommended for untrusted public networks."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4097,6 +2353,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Provider"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP Address"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4181,289 +2441,6 @@ msgstr "_Turn On Wi-Fi Hotspot…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Known Wi-Fi Networks"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Status unknown"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Unmanaged"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Unavailable"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Connecting"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Authentication required"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Disconnecting"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Connection failed"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Status unknown (missing)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Configuration failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP configuration failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP configuration expired"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Secrets were required, but not provided"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x supplicant disconnected"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x supplicant configuration failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x supplicant failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant took too long to authenticate"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP service failed to start"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP service disconnected"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP client failed to start"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP client error"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP client failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Shared connection service failed to start"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Shared connection service failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP service failed to start"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP service error"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP service failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Line busy"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "No dial tone"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "No carrier could be established"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Dialing request timed out"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Dialing attempt failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Modem initialisation failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Failed to select the specified APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Not searching for networks"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Network registration denied"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Network registration timed out"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Failed to register with the requested network"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN check failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Firmware for the device may be missing"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Connection disappeared"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Existing connection was assumed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem not found"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth connection failed"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM Card not inserted"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM Pin required"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM Puk required"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM wrong"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Connection dependency failed"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Firmware missing"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Cable unplugged"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "undefined error in 802.1X security (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "no file selected"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "unspecified error validating eap-method file"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12, or PGP private keys"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER or PEM certificates"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "missing EAP-FAST PAC file"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC files (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4512,14 +2489,6 @@ msgstr "_Inner authentication"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Allow automatic PAC pro_visioning"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "missing EAP-LEAP username"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "missing EAP-LEAP password"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4545,15 +2514,6 @@ msgstr "_Password"
 msgid "Sho_w password"
 msgstr "Sho_w password"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "invalid EAP-PEAP CA certificate: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "invalid EAP-PEAP CA certificate: no certificate specified"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4575,7 +2535,6 @@ msgid "C_A certificate"
 msgstr "C_A certificate"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4590,63 +2549,6 @@ msgstr "No CA certificate is _required"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _version"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "missing EAP username"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "missing EAP password"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "missing EAP-TLS identity"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "invalid EAP-TLS CA certificate: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "invalid EAP-TLS CA certificate: no certificate specified"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "invalid EAP-TLS private-key: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "invalid EAP-TLS user-certificate: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Unencrypted private keys are insecure"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Choose your personal certificate"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Choose your private key"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4663,15 +2565,6 @@ msgstr "Private _key"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Private key password"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "invalid EAP-TTLS CA certificate: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "invalid EAP-TTLS CA certificate: no certificate specified"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4694,14 +2587,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domain"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Unknown error validating 802.1X security"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4729,59 +2623,10 @@ msgstr "Protected EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "Au_thentication"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Select a file"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "missing leap-username"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "missing leap-password"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Wi-Fi password is missing."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Type"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "missing wep-key"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "invalid wep-key: key with a length of %zu must contain only hex-digits"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "invalid wep-key: passphrase must be non-empty"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "invalid wep-key: passphrase must be shorter than 64 characters"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4806,19 +2651,6 @@ msgstr "Sho_w key"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP inde_x"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4873,27 +2705,9 @@ msgstr "_Lock Screen Notifications"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Control which notifications are displayed and what they show"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifications;Banner;Message;Tray;Popup;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Other"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s removed"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Error removing account"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4917,17 +2731,6 @@ msgstr "No internet connection — connect to set up new online accounts"
 msgid "Add an account"
 msgstr "Add an account"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s Account"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Remove Account"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Online Accounts"
@@ -4936,10 +2739,6 @@ msgstr "Online Accounts"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Connect to your online accounts and decide what to use them for"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4947,10 +2746,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Unknown time"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4966,13 +2761,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i hour"
 msgstr[1] "%i hours"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4984,189 +2772,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minute"
 msgstr[1] "minutes"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s until fully charged"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Caution: %s remaining"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s remaining"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Fully charged"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Not charging"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Empty"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Charging"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Discharging"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Wireless mouse"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Wireless keyboard"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Uninterruptible power supply"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Personal digital assistant"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobile phone"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Media player"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Computer"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Gaming input device"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Battery"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Main"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Extra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batteries"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "When _idle"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Suspend"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Power Off"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hibernate"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nothing"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "When on battery power"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "When plugged in"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Never"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automatic suspend"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Performance mode temporarily disabled due to high operating temperature."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Performance mode temporarily disabled."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Power Saver mode activated by “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Performance mode activated by “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5227,6 +2832,15 @@ msgstr "100 minutes"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 hours"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Battery"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Devices"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5305,33 +2919,6 @@ msgstr "On _Battery Power"
 msgid "Delay"
 msgstr "Delay"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Performance"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "High performance and power usage."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Balanced"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standard performance and power usage."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Power Saver"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Reduced performance and power usage."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Power"
@@ -5340,7 +2927,6 @@ msgstr "Power"
 msgid "View your battery status and change power saving settings"
 msgstr "View your battery status and change power saving settings"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5348,27 +2934,6 @@ msgid ""
 msgstr ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Printer “%s” has been deleted"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Failed to add new printer."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Could not load ui: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Unlock to Add Printers and Change Settings"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5378,7 +2943,6 @@ msgstr "Printers"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Add printers, view printer jobs and decide how you want to print"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
@@ -5386,8 +2950,6 @@ msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Add Printer"
 
@@ -5426,29 +2988,6 @@ msgstr "Enter username and password to view printers on Print Server."
 msgid "Username"
 msgstr "Username"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s Details"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "No suitable driver found"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Select PPD File"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Printer names cannot contain SPACE, TAB, #, or /"
@@ -5457,9 +2996,7 @@ msgstr "Printer names cannot contain SPACE, TAB, #, or /"
 msgid "Location"
 msgstr "Location"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Driver"
 
@@ -5487,140 +3024,20 @@ msgstr "Select Printer Driver"
 msgid "Loading drivers database…"
 msgstr "Loading drivers database…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Cancel"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Select"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect Printer"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD Printer"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "One Sided"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Long Edge (Standard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Short Edge (Flip)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Portrait"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Landscape"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Reverse landscape"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Reverse portrait"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Resume"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pause"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Pending"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Paused"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Authentication required"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Processing"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Stopped"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Cancelled"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Aborted"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Completed"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Move this job to the top of the queue"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u Job Requires Authentication"
 msgstr[1] "%u Jobs Require Authentication"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Active Jobs"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Enter credentials to print from %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5648,321 +3065,17 @@ msgstr "_Authenticate"
 msgid "No Active Printer Jobs"
 msgstr "No Active Printer Jobs"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Unlock Print Server"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Unlock %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Enter username and password to view printers on %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Searching for Printers"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Serial Port"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Parallel Port"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Location: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Address: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Server requires authentication"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Two Sided"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Paper Type"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Paper Source"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Output Tray"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolution"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript pre-filtering"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Pages per side"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Two-sided"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientation"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "General"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Page Setup"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Installable Options"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Job"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Image Quality"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Colour"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Finishing"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Advanced"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Test Page"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Test page"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Auto Select"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Printer Default"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Embed GhostScript fonts only"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Convert to PS level 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Convert to PS level 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "No pre-filtering"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Manufacturer"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "No Active Jobs"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u Job"
 msgstr[1] "%u Jobs"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Clean print heads"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Low on toner"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Out of toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Low on developer"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Out of developer"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Low on a marker supply"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Out of a marker supply"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Open cover"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Open door"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Low on paper"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Out of paper"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Offline"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Stopped"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Waste receptacle almost full"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Waste receptacle full"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "The optical photo conductor is near end of life"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "The optical photo conductor is no longer functioning"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Ready"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Does not accept jobs"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Processing"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5986,6 +3099,10 @@ msgstr "Clean Print Heads"
 msgid "Remove Printer"
 msgstr "Remove Printer"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "No Active Jobs"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6006,16 +3123,21 @@ msgid "Restart"
 msgstr "Restart"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Add Printer…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Add a Printer…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "No printers"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6023,7 +3145,6 @@ msgstr ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formats"
@@ -6051,16 +3172,6 @@ msgstr "Searches can be for countries or languages."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Preview"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metric"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6098,20 +3209,25 @@ msgstr ""
 "The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Install languages…"
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Your Account"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Language"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formats"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Login Screen"
 
@@ -6123,99 +3239,9 @@ msgstr "Region & Language"
 msgid "Select your display language and formats"
 msgstr "Select your display language and formats"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Ask what to do"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Do nothing"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Open folder"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Other Media"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Select an application for audio CDs"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Select an application for video DVDs"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Select an application to run when a music player is connected"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Select an application to run when a camera is connected"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Select an application for software CDs"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "audio DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "blank Blu-ray disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "blank CD disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "blank DVD disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "blank HD DVD disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "e-book reader"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD video disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows software"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6265,7 +3291,6 @@ msgstr "Removable Media"
 msgid "Configure Removable Media settings"
 msgstr "Configure Removable Media settings"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6273,114 +3298,6 @@ msgid ""
 msgstr ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Screen Turns Off"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 seconds"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minute"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 hour"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minute"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Never"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6419,11 +3336,16 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "Show _Notifications on Lock Screen"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Lock Screen Notifications"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Forbid new _USB devices"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6431,30 +3353,25 @@ msgstr ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Screen Privacy"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Restrict Viewing Angle"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Screen"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Screen Settings"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "screen;lock;private;privacy;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Select Location"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6485,10 +3402,6 @@ msgstr "Others"
 msgid "Add Location"
 msgstr "Add Location"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "No applications found"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Application Search"
@@ -6515,93 +3428,13 @@ msgid ""
 msgstr ""
 "Control which applications show search results in the Activities Overview"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Search;Find;Index;Hide;Privacy;Results;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "No networks selected for sharing"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Networks"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "On"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Off"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Enabled"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Active"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Choose a Folder"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Add"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Enable media sharing"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Enable personal media sharing"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Device name copied"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Device address copied"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Username copied"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Password copied"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6731,7 +3564,6 @@ msgstr "Folders"
 msgid "Control what you want to share with others"
 msgstr "Control what you want to share with others"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6747,10 +3579,6 @@ msgstr "Enable or disable remote login"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Authentication is required to enable or disable remote login"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Custom"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6783,11 +3611,6 @@ msgstr "Rear"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Front"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Testing %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6841,11 +3664,6 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Alert Sound"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Mute"
@@ -6858,82 +3676,11 @@ msgstr "Sound"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Change sound levels, inputs, outputs, and alert sounds"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Disconnected"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Connecting"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Connected"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Authorisation Error"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Authorising"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Reduced Functionality"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Connected & Authorised"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Unknown"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Authorised at:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Connected at:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Enrolled at:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Failed to authorise device: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Failed to forget device: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6967,54 +3714,6 @@ msgstr "Authorise and Connect"
 msgid "Forget Device"
 msgstr "Forget Device"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Error"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Authorised"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Allow direct access to devices such as docks and external GPUs."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Only USB and Display Port devices can attach."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt support has been disabled in the BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Thunderbolt security level could not be determined."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Error switching direct mode: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "No Thunderbolt Support"
@@ -7026,6 +3725,10 @@ msgstr "Could not connect to the thunderbolt subsystem."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Direct Access"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Allow direct access to devices such as docks and external GPUs."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7043,7 +3746,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Manage Thunderbolt devices"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;"
@@ -7244,40 +3946,6 @@ msgstr "_Enable by Keyboard"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Turn accessibility features on and off using the keyboard"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Default"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Medium"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Large"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Larger"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Largest"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixels"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Always Show Accessibility Menu"
@@ -7391,31 +4059,6 @@ msgstr "Flash the entire _screen"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Flash the entire _window"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Short"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ Screen"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ Screen"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ Screen"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Long"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7572,7 +4215,6 @@ msgstr "Colour Effects"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Make it easier to see, hear, type, point and click"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7584,114 +4226,6 @@ msgstr ""
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
 "audio;typing;animations;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 hour"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 day"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 days"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 days"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 days"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 days"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 days"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 days"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 days"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 days"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Empty all items from Wastebasket?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "All items in the Wastebasket will be permanently deleted."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Empty Wastebasket"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Delete all the temporary files?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "All the temporary files will be permanently deleted."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Purge Temporary Files"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 day"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 days"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 days"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Forever"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7760,64 +4294,12 @@ msgstr "File History & Wastebasket"
 msgid "Don't leave traces"
 msgstr "Don't leave traces"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;wastebasket;"
 "purge;retain;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Should match the web address of your login provider."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Failed to add account"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "The passwords do not match."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Failed to register account"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "No supported way to authenticate with this domain"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Failed to join domain"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"That login name didn’t work.\n"
-"Please try again."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"That login password didn’t work.\n"
-"Please try again."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Failed to log into domain"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Unable to find the domain. Maybe you misspelled it?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7869,10 +4351,6 @@ msgstr ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
 "resources on the internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Browse for more pictures"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7943,222 +4421,6 @@ msgstr "_Delete Fingerprints"
 msgid "Fingerprint Enroll"
 msgstr "Fingerprint Enroll"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "the device needs to be claimed to perform this action"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "the device is already claimed by another process"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "you do not have permission to perform the action"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "no prints have been enrolled"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Failed to communicate with the device during enrollment"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Failed to communicate with the fingerprint reader"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Failed to communicate with the fingerprint daemon"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Failed to list fingerprints: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Failed to delete saved fingerprints: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Left thumb"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Left middle finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Left index finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Left ring finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Left little finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Right thumb"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Right middle finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Right index finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Right ring finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Right little finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Unknown Finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Complete"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Fingerprint device disconnected"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Fingerprint device storage is full"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Failed to enroll new fingerprint"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Failed to start enrollment: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Failed to enroll new fingerprint"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Failed to stop enrollment: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Re-enroll this finger…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Scan new fingerprint"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Failed to release fingerprint device %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problem Reading Device"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Failed to claim fingerprint device %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Failed to get fingerprint devices: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "This Week"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Last Week"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Session Ended"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Session Started"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Account Activity"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Previous"
@@ -8166,18 +4428,6 @@ msgstr "Previous"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Next"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Please choose another password."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Please type your current password again."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Password could not be changed"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8199,6 +4449,10 @@ msgstr "New Password"
 msgid "Confirm Password"
 msgstr "Confirm Password"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "The passwords do not match."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Allow user to change their password on next login"
@@ -8206,134 +4460,6 @@ msgstr "Allow user to change their password on next login"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Set a password now"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Cannot automatically join this type of domain"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "No such domain or realm found"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Cannot log in as %s at the %s domain"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Invalid password, please try again"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Couldn’t connect to the %s domain: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Failed to delete user"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Failed to revoke remotely managed user"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "You cannot delete your own account."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s is still logged in"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Do you want to keep %s’s files?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Delete Files"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Keep Files"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Are you sure you want to revoke remotely managed %s’s account?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Delete"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Account disabled"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "To be set at next login"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "None"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Logged in"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Failed to contact the accounts service"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Please make sure that the AccountService is installed and enabled."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "This panel must be unlocked to change this setting"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Delete the selected user account"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"To delete the selected user account,\n"
-"click the * icon first"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Unlock to Add Users and Change Settings"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8361,7 +4487,6 @@ msgid "Full name"
 msgstr "Full name"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Edit"
 
@@ -8423,7 +4548,6 @@ msgstr "Unlock to add a user account."
 msgid "Add or remove users and change your password"
 msgstr "Add or remove users and change your password"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8467,177 +4591,6 @@ msgstr "Manage user accounts"
 msgid "Authentication is required to change user data"
 msgstr "Authentication is required to change user data"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "The new password needs to be different from the old one."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Try changing some letters and numbers."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Try changing the password a bit more."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "A password without your username would be stronger."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Try to avoid using your name in the password."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Try to avoid some of the words included in the password."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Try to avoid common words."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Try to avoid reordering existing words."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Try to use more numbers."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Try to use more uppercase letters."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Try to use more lowercase letters."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Try to use more special characters, like punctuation."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Try to use a mixture of letters, numbers and punctuation."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Try to avoid repeating the same character."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Try to avoid sequences like 1234 or abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Mix uppercase and lowercase and try to use a number or two."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Authentication failed"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "The new password is too short"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "The new password is too simple"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "The old and new passwords are too similar"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "The new password has already been used recently."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "The new password must contain numeric or special characters"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "The old and new passwords are the same"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Your password has been changed since you initially authenticated!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "The new password does not contain enough different characters"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Unknown error"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Sorry, that user name isn’t available. Please try another."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "The username is too long."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8671,52 +4624,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Mis-click detected, restarting…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Button %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Application defined"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Send Keystroke"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Switch Monitor"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Show On-Screen Help"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tablet mounted on laptop panel"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tablet mounted on external display"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "External tablet device"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "External pad device"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "All Displays"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8812,22 +4723,6 @@ msgstr "Right Mouse Button Click"
 msgid "Forward"
 msgstr "Forward"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Airbrush stylus with pressure, tilt, and integrated slider"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Airbrush stylus with pressure, tilt, and rotation"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standard stylus with pressure and tilt"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standard stylus with pressure"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom Tablet"
@@ -8836,54 +4731,97 @@ msgstr "Wacom Tablet"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Set button mappings and adjust stylus sensitivity for graphics tablets"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "New shortcut…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Layout"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Parent Window"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulated Secondary Click"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Click OK to finish."
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Low on toner"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Secondary"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Manage preferences for productivity and multitasking"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Access Points"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Add"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Save"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operation Cancelled"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Error:</b> Access denied changing settings"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Error:</b> Mobile Equipment Error"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Not Registered"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registered"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Searching"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Denied"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8913,212 +4851,13 @@ msgstr "Own Number"
 msgid "Device Details"
 msgstr "Device Details"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Manufacturer"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Firmware Version"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G Only"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G Only"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G Only"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "5G Only"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (Preferred), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (Preferred), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (Preferred), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Preferred), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Preferred), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (Preferred), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (Preferred), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (Preferred), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (Preferred), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (Preferred), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (Preferred), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (Preferred), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (Preferred), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (Preferred), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (Preferred), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (Preferred), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (Preferred)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (Preferred), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Unknown"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Unlock SIM card"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Unlock"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Please provide PIN code for SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Enter PIN to unlock your SIM card"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Please provide PUK code for SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Enter PUK to unlock your SIM card"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9133,26 +4872,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "You have %u try left"
 msgstr[1] "You have %u tries left"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Wrong password entered."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK code should be an 8 digit number"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Enter New PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN code should be a 4-8 digit number"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Unlocking…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9210,94 +4929,6 @@ msgstr "Lock SIM with PIN"
 msgid "M_odem Details"
 msgstr "M_odem Details"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Phone failure"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "No connection to phone"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operation not allowed"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operation not supported"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM not inserted"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "SIM PIN required"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "SIM PUK required"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM failure"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM busy"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Incorrect password"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIM PIN2 required"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIM PUK2 required"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Not found"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "No network service"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Network timeout"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS services not allowed"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming not allowed in this location area"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Unspecified GPRS error"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "No Error"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Action Cancelled"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Access denied"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Unknown Error"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Network Mode"
@@ -9313,11 +4944,6 @@ msgstr "Choose Network"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Refresh Network Providers"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9375,7 +5001,6 @@ msgstr "Mobile Network"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configure Telephony and mobile data connections"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;wwan;telephony;sim;mobile;"
@@ -9392,41 +5017,13 @@ msgstr "Settings is the primary interface for configuring your system."
 msgid "The GNOME Project"
 msgstr "The GNOME Project"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Display version number"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Enable verbose mode"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Search for the string"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "List possible panel names and exit"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel to display"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Settings categories"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacy"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Available panels:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9484,7 +5081,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Cancel search"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;Settings;"
@@ -9523,8 +5119,6 @@ msgstr ""
 "A tuple containing the initial width, height and maximised state of the "
 "application window."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9532,8 +5126,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u Output"
 msgstr[1] "%u Outputs"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9541,9 +5133,3118 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u Input"
 msgstr[1] "%u Inputs"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "System Sounds"
+#~ msgid "System Bus"
+#~ msgstr "System Bus"
+
+#~ msgid "Full access"
+#~ msgstr "Full access"
+
+#~ msgid "Session Bus"
+#~ msgstr "Session Bus"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Full access to /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Has network access"
+
+#~ msgid "Home"
+#~ msgstr "Home"
+
+#~ msgid "Read-only"
+#~ msgstr "Read-only"
+
+#~ msgid "File System"
+#~ msgstr "File System"
+
+#~ msgid "Can change settings"
+#~ msgstr "Can change settings"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u file and link type that is opened by the app"
+#~ msgstr[1] "%u file and link types that are opened by the app"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> is used to open the following types of files and links."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s of disk space used."
+
+#~ msgid "Select a picture"
+#~ msgstr "Select a picture"
+
+#~ msgid "_Open"
+#~ msgstr "_Open"
+
+#~ msgid "multiple sizes"
+#~ msgstr "multiple sizes"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "No Desktop Background"
+
+#~ msgid "Current background"
+#~ msgstr "Current background"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Place your calibration device over the square and press “Start”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Shut the laptop lid"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "An internal error occurred that could not be recovered."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Tools required for calibration are not installed."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "The profile could not be generated."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "The target whitepoint was not obtainable."
+
+#~ msgid "Complete!"
+#~ msgstr "Complete!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Calibration failed!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "You can remove the calibration device."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Do not disturb the calibration device while in progress"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Laptop Screen"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Built-in Webcam"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s Monitor"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s Scanner"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s Camera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s Printer"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s Webcam"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Enable colour management for %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Show colour profiles for %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Not calibrated"
+
+#~ msgid "Default: "
+#~ msgstr "Default: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Colourspace: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Test profile: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Select ICC Profile File"
+
+#~ msgid "_Import"
+#~ msgstr "_Import"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Supported ICC profiles"
+
+#~ msgid "All files"
+#~ msgstr "All files"
+
+#~ msgid "Save Profile"
+#~ msgstr "Save Profile"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Create a colour profile for the selected device"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "The measuring instrument does not support printer profiling."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "The device type is not currently supported."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standard Space"
+
+#~ msgid "Test Profile"
+#~ msgstr "Test Profile"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatic"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Low Quality"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Medium Quality"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "High Quality"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Default RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Default CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Default Grey"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Vendor supplied factory calibration data"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Full-screen display correction not possible with this profile"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "This profile may no longer be accurate"
+
+#~ msgid "Other…"
+#~ msgstr "Other…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Unlock to Change Settings"
+
+#~ msgid "Today"
+#~ msgstr "Today"
+
+#~ msgid "Yesterday"
+#~ msgstr "Yesterday"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d hour"
+#~ msgstr[1] "%d hours"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minute"
+#~ msgstr[1] "%d minutes"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d second"
+#~ msgstr[1] "%d seconds"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24-hour"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM/PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%H:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+
+#~ msgid "On"
+#~ msgstr "On"
+
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Apply Changes?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Changes Cannot be Applied"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "This could be due to hardware limitations."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Landscape"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portrait Right"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portrait Left"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Landscape (flipped)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Secure Boot is Active"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Secure Boot Has Problems"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "For help, contact your hardware manufacturer or IT support provider."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Secure Boot is Turned Off"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+
+#~ msgid "Passed"
+#~ msgstr "Passed"
+
+#~ msgid "Failed"
+#~ msgstr "Failed"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Device conforms to HSI level %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Security Level 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Security Level 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Security Level 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Security Level 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Security levels are not available for this device."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr "Contact your hardware manufacturer for help with security updates."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "It might be possible for a support technician to resolve this issue."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Protected against malicious software when the device starts."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Secure Boot has Problems"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Some protection when the device is started."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Secure Boot is Off"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "No protection when the device is started."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Exposed to serious security threats."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Limited protection against simple security threats."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Protected against common security threats."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Protected against a wide range of security threats."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Comprehensive Protection"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Firmware Write Protection"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Firmware Write Protection Lock"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Firmware BIOS Region"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Firmware BIOS Descriptor"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Pre-boot DMA Protection"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard Verified Boot"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM Protected"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard Error Policy"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard Fuse"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET Enabled"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET Active"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Encrypted RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU Protection"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux Kernel Lockdown"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux Kernel Verification"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Suspend To RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Suspend To Idle"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI Platform Key"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI Secure Boot"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM Platform Configuration"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM Reconstruction"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine Manufacturing Mode"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine Override"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine Version"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Firmware Updates"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Firmware Attestation"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Firmware Updater Verification"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Platform Debugging"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Processor Security Checks"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD Rollback Protection"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD Firmware Replay Protection"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD Firmware Write Protection"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Fused Platform"
+
+#~ msgid "Valid"
+#~ msgstr "Valid"
+
+#~ msgid "Not Valid"
+#~ msgstr "Not Valid"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Not Enabled"
+
+#~ msgid "Locked"
+#~ msgstr "Locked"
+
+#~ msgid "Not Locked"
+#~ msgstr "Not Locked"
+
+#~ msgid "Encrypted"
+#~ msgstr "Encrypted"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Not Encrypted"
+
+#~ msgid "Tainted"
+#~ msgstr "Tainted"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Not Tainted"
+
+#~ msgid "Found"
+#~ msgstr "Found"
+
+#~ msgid "Not Found"
+#~ msgstr "Not Found"
+
+#~ msgid "Supported"
+#~ msgstr "Supported"
+
+#~ msgid "Not Supported"
+#~ msgstr "Not Supported"
+
+#~ msgid "Unknown"
+#~ msgstr "Unknown"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Unknown"
+
+#~ msgid "Not Available"
+#~ msgstr "Not Available"
+
+#~ msgid "System Logo"
+#~ msgstr "System Logo"
+
+#~ msgid "No input sources found"
+#~ msgstr "No input sources found"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Other"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Custom Shortcuts"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Left Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Right Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Left Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Right Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menu key"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Right Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modified"
+#~ msgstr[1] "%d modified"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Reset All Shortcuts?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+
+#~ msgid "Reset All"
+#~ msgstr "Reset All"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Enter the new shortcut"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Set Custom Shortcuts"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Set Shortcut"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Enter new shortcut to change %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Add Custom Shortcut"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Two-finger Scrolling"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Five clicks, GEGL time!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Double click, primary button"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Single click, primary button"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Double click, middle button"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Single click, middle button"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Double click, secondary button"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Single click, secondary button"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager needs to be running."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Insecure network (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Secure network (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Secure network (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Secure network (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Secure network"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Must have a minimum of 8 characters"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Stop hotspot and disconnect any users?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Stop Hotspot"
+
+#~ msgid "Preserve"
+#~ msgstr "Preserve"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "Random"
+
+#~ msgid "Stable"
+#~ msgstr "Stable"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profile %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "None"
+
+#~ msgid "Never"
+#~ msgstr "Never"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "None"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Weak"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Good"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excellent"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Forget Connection"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Remove Connection Profile"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Remove VPN"
+
+#~ msgid "Details"
+#~ msgstr "Details"
+
+#~ msgid "automatic"
+#~ msgstr "automatic"
+
+#~ msgid "Identity"
+#~ msgstr "Identity"
+
+#~ msgid "Delete Address"
+#~ msgstr "Delete Address"
+
+#~ msgid "Delete Route"
+#~ msgstr "Delete Route"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "None"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit Passphrase"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamic WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Unable to open connection editor"
+
+#~ msgid "New Profile"
+#~ msgstr "New Profile"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Invalid setting %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Invalid setting %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Import from file…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Add VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Cannot import VPN connection"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "The file “%s” could not be read or does not contain recognised VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Select file to import"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "A file named “%s” already exists."
+
+#~ msgid "_Replace"
+#~ msgstr "_Replace"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Do you want to replace %s with the VPN connection you are saving?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Cannot export VPN connection"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Export VPN connection"
+
+#~ msgid "never"
+#~ msgstr "never"
+
+#~ msgid "today"
+#~ msgstr "today"
+
+#~ msgid "yesterday"
+#~ msgstr "yesterday"
+
+#~ msgid "Last used"
+#~ msgstr "Last used"
+
+#~ msgid "Add new connection"
+#~ msgstr "Add new connection"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+
+#~ msgid "_Forget"
+#~ msgstr "_Forget"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Known Wi-Fi Networks"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Forget"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "System policy prohibits use as a Hotspot"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Wireless device does not support Hotspot mode"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "This is not recommended for untrusted public networks."
+
+#~ msgid "Status unknown"
+#~ msgstr "Status unknown"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Unmanaged"
+
+#~ msgid "Unavailable"
+#~ msgstr "Unavailable"
+
+#~ msgid "Connecting"
+#~ msgstr "Connecting"
+
+#~ msgid "Authentication required"
+#~ msgstr "Authentication required"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Disconnecting"
+
+#~ msgid "Connection failed"
+#~ msgstr "Connection failed"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Status unknown (missing)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Configuration failed"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP configuration failed"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP configuration expired"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Secrets were required, but not provided"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x supplicant disconnected"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x supplicant configuration failed"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x supplicant failed"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant took too long to authenticate"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP service failed to start"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP service disconnected"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP failed"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP client failed to start"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP client error"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP client failed"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Shared connection service failed to start"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Shared connection service failed"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP service failed to start"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP service error"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP service failed"
+
+#~ msgid "Line busy"
+#~ msgstr "Line busy"
+
+#~ msgid "No dial tone"
+#~ msgstr "No dial tone"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "No carrier could be established"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Dialing request timed out"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Dialing attempt failed"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Modem initialisation failed"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Failed to select the specified APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Not searching for networks"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Network registration denied"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Network registration timed out"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Failed to register with the requested network"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN check failed"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firmware for the device may be missing"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Connection disappeared"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Existing connection was assumed"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem not found"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth connection failed"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM Card not inserted"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM Pin required"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk required"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM wrong"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Connection dependency failed"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Firmware missing"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cable unplugged"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "undefined error in 802.1X security (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "no file selected"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "unspecified error validating eap-method file"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12, or PGP private keys"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER or PEM certificates"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "missing EAP-FAST PAC file"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC files (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "missing EAP-LEAP username"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "missing EAP-LEAP password"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "invalid EAP-PEAP CA certificate: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "invalid EAP-PEAP CA certificate: no certificate specified"
+
+#~ msgid "missing EAP username"
+#~ msgstr "missing EAP username"
+
+#~ msgid "missing EAP password"
+#~ msgstr "missing EAP password"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "missing EAP-TLS identity"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "invalid EAP-TLS CA certificate: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "invalid EAP-TLS CA certificate: no certificate specified"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "invalid EAP-TLS private-key: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "invalid EAP-TLS user-certificate: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Unencrypted private keys are insecure"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Choose your personal certificate"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Choose your private key"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "invalid EAP-TTLS CA certificate: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "invalid EAP-TTLS CA certificate: no certificate specified"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Unknown error validating 802.1X security"
+
+#~ msgid "Select a file"
+#~ msgstr "Select a file"
+
+#~ msgid "missing leap-username"
+#~ msgstr "missing leap-username"
+
+#~ msgid "missing leap-password"
+#~ msgstr "missing leap-password"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Wi-Fi password is missing."
+
+#~ msgid "missing wep-key"
+#~ msgstr "missing wep-key"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "invalid wep-key: passphrase must be non-empty"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "invalid wep-key: passphrase must be shorter than 64 characters"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Other"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s removed"
+
+#~ msgid "Error removing account"
+#~ msgstr "Error removing account"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s Account"
+
+#~ msgid "Remove Account"
+#~ msgstr "Remove Account"
+
+#~ msgid "Unknown time"
+#~ msgstr "Unknown time"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s until fully charged"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Caution: %s remaining"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s remaining"
+
+#~ msgid "Fully charged"
+#~ msgstr "Fully charged"
+
+#~ msgid "Not charging"
+#~ msgstr "Not charging"
+
+#~ msgid "Empty"
+#~ msgstr "Empty"
+
+#~ msgid "Charging"
+#~ msgstr "Charging"
+
+#~ msgid "Discharging"
+#~ msgstr "Discharging"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Wireless mouse"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Wireless keyboard"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Uninterruptible power supply"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Personal digital assistant"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobile phone"
+
+#~ msgid "Media player"
+#~ msgstr "Media player"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Computer"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Gaming input device"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Main"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Extra"
+
+#~ msgid "Batteries"
+#~ msgstr "Batteries"
+
+#~ msgid "When _idle"
+#~ msgstr "When _idle"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspend"
+
+#~ msgid "Power Off"
+#~ msgstr "Power Off"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernate"
+
+#~ msgid "Nothing"
+#~ msgstr "Nothing"
+
+#~ msgid "When on battery power"
+#~ msgstr "When on battery power"
+
+#~ msgid "When plugged in"
+#~ msgstr "When plugged in"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Never"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatic suspend"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Performance mode temporarily disabled."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Power Saver mode activated by “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Performance mode activated by “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Performance"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "High performance and power usage."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Balanced"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standard performance and power usage."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Power Saver"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Reduced performance and power usage."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Printer “%s” has been deleted"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Failed to add new printer."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Could not load ui: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Unlock to Add Printers and Change Settings"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s Details"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "No suitable driver found"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Select PPD File"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect Printer"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD Printer"
+
+#~ msgid "One Sided"
+#~ msgstr "One Sided"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Long Edge (Standard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Short Edge (Flip)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portrait"
+
+#~ msgid "Landscape"
+#~ msgstr "Landscape"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Reverse landscape"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Reverse portrait"
+
+#~ msgid "Resume"
+#~ msgstr "Resume"
+
+#~ msgid "Pause"
+#~ msgstr "Pause"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Pending"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Paused"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Authentication required"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Processing"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Stopped"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Cancelled"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Aborted"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Completed"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Move this job to the top of the queue"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Active Jobs"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Enter credentials to print from %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Unlock Print Server"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Unlock %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Enter username and password to view printers on %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Searching for Printers"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serial Port"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Parallel Port"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Location: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Address: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Server requires authentication"
+
+#~ msgid "Two Sided"
+#~ msgstr "Two Sided"
+
+#~ msgid "Paper Type"
+#~ msgstr "Paper Type"
+
+#~ msgid "Paper Source"
+#~ msgstr "Paper Source"
+
+#~ msgid "Output Tray"
+#~ msgstr "Output Tray"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolution"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript pre-filtering"
+
+#~ msgid "Pages per side"
+#~ msgstr "Pages per side"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientation"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "General"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Page Setup"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Installable Options"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Job"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Image Quality"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Colour"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Finishing"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Advanced"
+
+#~ msgid "Test page"
+#~ msgstr "Test page"
+
+#~ msgid "Auto Select"
+#~ msgstr "Auto Select"
+
+#~ msgid "Printer Default"
+#~ msgstr "Printer Default"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Embed GhostScript fonts only"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Convert to PS level 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Convert to PS level 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "No pre-filtering"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Clean print heads"
+
+#~ msgid "Out of toner"
+#~ msgstr "Out of toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Low on developer"
+
+#~ msgid "Out of developer"
+#~ msgstr "Out of developer"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Low on a marker supply"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Out of a marker supply"
+
+#~ msgid "Open cover"
+#~ msgstr "Open cover"
+
+#~ msgid "Open door"
+#~ msgstr "Open door"
+
+#~ msgid "Low on paper"
+#~ msgstr "Low on paper"
+
+#~ msgid "Out of paper"
+#~ msgstr "Out of paper"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Offline"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Stopped"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Waste receptacle almost full"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Waste receptacle full"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "The optical photo conductor is near end of life"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "The optical photo conductor is no longer functioning"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Ready"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Does not accept jobs"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Processing"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metric"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Ask what to do"
+
+#~ msgid "Do nothing"
+#~ msgstr "Do nothing"
+
+#~ msgid "Open folder"
+#~ msgstr "Open folder"
+
+#~ msgid "Other Media"
+#~ msgstr "Other Media"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Select an application for audio CDs"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Select an application for video DVDs"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Select an application to run when a music player is connected"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Select an application to run when a camera is connected"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Select an application for software CDs"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "blank Blu-ray disc"
+
+#~ msgid "blank CD disc"
+#~ msgstr "blank CD disc"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "blank DVD disc"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "blank HD DVD disc"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video disc"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-book reader"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video disc"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "Windows software"
+#~ msgstr "Windows software"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Screen Turns Off"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 seconds"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 hour"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Never"
+
+#~ msgid "Select Location"
+#~ msgstr "Select Location"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "No applications found"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "No networks selected for sharing"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "On"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Enabled"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Active"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Choose a Folder"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Enable media sharing"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Enable personal media sharing"
+
+#~ msgid "Device name copied"
+#~ msgstr "Device name copied"
+
+#~ msgid "Device address copied"
+#~ msgstr "Device address copied"
+
+#~ msgid "Username copied"
+#~ msgstr "Username copied"
+
+#~ msgid "Password copied"
+#~ msgstr "Password copied"
+
+#~ msgid "Custom"
+#~ msgstr "Custom"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Testing %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Disconnected"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Connecting"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Connected"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Authorisation Error"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Authorising"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Reduced Functionality"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Connected & Authorised"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Unknown"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Authorised at:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Connected at:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Enrolled at:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Failed to authorise device: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Failed to forget device: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Error"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Authorised"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Only USB and Display Port devices can attach."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt support has been disabled in the BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Thunderbolt security level could not be determined."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Error switching direct mode: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Default"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Medium"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Large"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Larger"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Largest"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixels"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Short"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ Screen"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ Screen"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ Screen"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Long"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 hour"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 day"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 days"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 days"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 days"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 days"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 days"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 days"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 days"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 days"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Empty all items from Wastebasket?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "All items in the Wastebasket will be permanently deleted."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Empty Wastebasket"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Delete all the temporary files?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "All the temporary files will be permanently deleted."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Purge Temporary Files"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 day"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 days"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 days"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Forever"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Should match the web address of your login provider."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Failed to add account"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Failed to register account"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "No supported way to authenticate with this domain"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Failed to join domain"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Failed to log into domain"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Unable to find the domain. Maybe you misspelled it?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Browse for more pictures"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "the device needs to be claimed to perform this action"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "the device is already claimed by another process"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "you do not have permission to perform the action"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "no prints have been enrolled"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Failed to communicate with the device during enrollment"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Failed to communicate with the fingerprint reader"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Failed to communicate with the fingerprint daemon"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Failed to list fingerprints: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Failed to delete saved fingerprints: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Left thumb"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Left middle finger"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Left index finger"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Left ring finger"
+
+#~ msgid "Left little finger"
+#~ msgstr "Left little finger"
+
+#~ msgid "Right thumb"
+#~ msgstr "Right thumb"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Right middle finger"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Right index finger"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Right ring finger"
+
+#~ msgid "Right little finger"
+#~ msgstr "Right little finger"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Unknown Finger"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Complete"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Fingerprint device disconnected"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Fingerprint device storage is full"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Failed to enroll new fingerprint"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Failed to start enrollment: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Failed to enroll new fingerprint"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Failed to stop enrollment: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Re-enroll this finger…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Scan new fingerprint"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Failed to release fingerprint device %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problem Reading Device"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Failed to claim fingerprint device %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Failed to get fingerprint devices: %s"
+
+#~ msgid "This Week"
+#~ msgstr "This Week"
+
+#~ msgid "Last Week"
+#~ msgstr "Last Week"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Session Ended"
+
+#~ msgid "Session Started"
+#~ msgstr "Session Started"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Account Activity"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Please choose another password."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Please type your current password again."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Password could not be changed"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Cannot automatically join this type of domain"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "No such domain or realm found"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Cannot log in as %s at the %s domain"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Invalid password, please try again"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Couldn’t connect to the %s domain: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Failed to delete user"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Failed to revoke remotely managed user"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "You cannot delete your own account."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s is still logged in"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Do you want to keep %s’s files?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Delete Files"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Keep Files"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Are you sure you want to revoke remotely managed %s’s account?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Delete"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Account disabled"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "To be set at next login"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "None"
+
+#~ msgid "Logged in"
+#~ msgstr "Logged in"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Failed to contact the accounts service"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Please make sure that the AccountService is installed and enabled."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "This panel must be unlocked to change this setting"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Delete the selected user account"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Unlock to Add Users and Change Settings"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "The new password needs to be different from the old one."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Try changing some letters and numbers."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Try changing the password a bit more."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "A password without your username would be stronger."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Try to avoid using your name in the password."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Try to avoid some of the words included in the password."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Try to avoid common words."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Try to avoid reordering existing words."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Try to use more numbers."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Try to use more uppercase letters."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Try to use more lowercase letters."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Try to use more special characters, like punctuation."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Try to use a mixture of letters, numbers and punctuation."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Try to avoid repeating the same character."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Try to avoid sequences like 1234 or abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Mix uppercase and lowercase and try to use a number or two."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Authentication failed"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "The new password is too short"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "The new password is too simple"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "The old and new passwords are too similar"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "The new password has already been used recently."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "The new password must contain numeric or special characters"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "The old and new passwords are the same"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Your password has been changed since you initially authenticated!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "The new password does not contain enough different characters"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Unknown error"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Sorry, that user name isn’t available. Please try another."
+
+#~ msgid "The username is too long."
+#~ msgstr "The username is too long."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Button %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Application defined"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Send Keystroke"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Switch Monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Show On-Screen Help"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tablet mounted on laptop panel"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tablet mounted on external display"
+
+#~ msgid "External tablet device"
+#~ msgstr "External tablet device"
+
+#~ msgid "All Displays"
+#~ msgstr "All Displays"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Airbrush stylus with pressure, tilt, and integrated slider"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Airbrush stylus with pressure, tilt, and rotation"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standard stylus with pressure and tilt"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standard stylus with pressure"
+
+#~ msgid "New shortcut…"
+#~ msgstr "New shortcut…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operation Cancelled"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Error:</b> Access denied changing settings"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Error:</b> Mobile Equipment Error"
+
+#~ msgid "Not Registered"
+#~ msgstr "Not Registered"
+
+#~ msgid "Registered"
+#~ msgstr "Registered"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Searching"
+
+#~ msgid "Denied"
+#~ msgstr "Denied"
+
+#~ msgid "2G Only"
+#~ msgstr "2G Only"
+
+#~ msgid "3G Only"
+#~ msgstr "3G Only"
+
+#~ msgid "4G Only"
+#~ msgstr "4G Only"
+
+#~ msgid "5G Only"
+#~ msgstr "5G Only"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (Preferred)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (Preferred), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (Preferred), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (Preferred), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Preferred)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Preferred), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Preferred), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (Preferred)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (Preferred), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (Preferred), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (Preferred)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (Preferred), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (Preferred), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (Preferred)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (Preferred), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (Preferred), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Preferred)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Preferred), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Preferred)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Preferred), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Preferred)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Preferred), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (Preferred)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (Preferred), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Preferred)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (Preferred), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (Preferred)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (Preferred), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Unknown"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Unlock SIM card"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Please provide PIN code for SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Enter PIN to unlock your SIM card"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Please provide PUK code for SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Enter PUK to unlock your SIM card"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Wrong password entered."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK code should be an 8 digit number"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Enter New PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN code should be a 4-8 digit number"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Unlocking…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Phone failure"
+
+#~ msgid "No connection to phone"
+#~ msgstr "No connection to phone"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operation not allowed"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operation not supported"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM not inserted"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM PIN required"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM PUK required"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM failure"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM busy"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Incorrect password"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM PIN2 required"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM PUK2 required"
+
+#~ msgid "Not found"
+#~ msgstr "Not found"
+
+#~ msgid "No network service"
+#~ msgstr "No network service"
+
+#~ msgid "Network timeout"
+#~ msgstr "Network timeout"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS services not allowed"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming not allowed in this location area"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Unspecified GPRS error"
+
+#~ msgid "No Error"
+#~ msgstr "No Error"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Action Cancelled"
+
+#~ msgid "Access denied"
+#~ msgstr "Access denied"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Unknown Error"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Display version number"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Enable verbose mode"
+
+#~ msgid "Search for the string"
+#~ msgstr "Search for the string"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "List possible panel names and exit"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel to display"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Available panels:"
+
+#~ msgid "System Sounds"
+#~ msgstr "System Sounds"
 
 #~| msgid "Right"
 #~ msgid "Light"
@@ -9567,9 +8268,6 @@ msgstr "System Sounds"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Add a Printer…"
 
 #~ msgid "Bark"
 #~ msgstr "Bark"
@@ -9636,11 +8334,11 @@ msgstr "System Sounds"
 #~ msgstr "Cannot be changed"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 
 #~ msgid "Integration"
 #~ msgstr "Integration"
@@ -9925,9 +8623,6 @@ msgstr "System Sounds"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablet (absolute)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Touchpad (relative)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Tablet Preferences"
@@ -10952,9 +9647,6 @@ msgstr "System Sounds"
 #~ msgid "Mirrored"
 #~ msgstr "Mirrored"
 
-#~ msgid "Secondary"
-#~ msgstr "Secondary"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Arrange Combined Displays"
 
@@ -11115,9 +9807,6 @@ msgstr "System Sounds"
 
 #~ msgid "Mail"
 #~ msgstr "Mail"
-
-#~ msgid "Calendar"
-#~ msgstr "Calendar"
 
 #~ msgid "Contacts"
 #~ msgstr "Contacts"
@@ -11286,9 +9975,6 @@ msgstr "System Sounds"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Scroll Up"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Scroll Down"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Scroll Right"
@@ -11492,9 +10178,6 @@ msgstr "System Sounds"
 #~ msgctxt "touchpad pointer, speed"
 #~ msgid "Fast"
 #~ msgstr "Fast"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Disable while _typing"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "The system network services are not compatible with this version."
@@ -12367,9 +11050,6 @@ msgstr "System Sounds"
 #~ msgid "Remove Language"
 #~ msgstr "Remove Language"
 
-#~ msgid "Install languages..."
-#~ msgstr "Install languages…"
-
 #~ msgid "Select a region (change will be applied the next time you log in)"
 #~ msgstr "Select a region (change will be applied the next time you log in)"
 
@@ -12678,9 +11358,6 @@ msgstr "System Sounds"
 #~ msgid "Layouts"
 #~ msgstr "Layouts"
 
-#~ msgid "Layout"
-#~ msgstr "Layout"
-
 #~ msgid "Dasher"
 #~ msgstr "Dasher"
 
@@ -12947,9 +11624,6 @@ msgstr "System Sounds"
 
 #~ msgid "Use previous window's layout in new windows"
 #~ msgstr "Use previous window's layout in new windows"
-
-#~ msgid "_Acceleration:"
-#~ msgstr "_Acceleration:"
 
 #~ msgid "On AC power:"
 #~ msgstr "On AC power:"
@@ -14249,9 +12923,6 @@ msgstr "System Sounds"
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "_Reset to Defaults"
-
 #~ msgid "_Selected items:"
 #~ msgstr "_Selected items:"
 
@@ -14408,9 +13079,6 @@ msgstr "System Sounds"
 #~ msgid "Copying '%s'"
 #~ msgstr "Copying '%s'"
 
-#~ msgid "Parent Window"
-#~ msgstr "Parent Window"
-
 #~ msgid "Parent window of the dialog"
 #~ msgstr "Parent window of the dialogue"
 
@@ -14558,9 +13226,6 @@ msgstr "System Sounds"
 
 #~ msgid "Set your window properties"
 #~ msgstr "Set your window properties"
-
-#~ msgid "Windows"
-#~ msgstr "Windows"
 
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr "Window manager \"%s\" has not registered a configuration tool\n"
@@ -14972,9 +13637,6 @@ msgstr "System Sounds"
 
 #~ msgid "<b>Sound Theme</b>"
 #~ msgstr "<b>Sound Theme</b>"
-
-#~ msgid "Click OK to finish."
-#~ msgstr "Click OK to finish."
 
 #~ msgid "Play _sound effects when buttons are clicked"
 #~ msgstr "Play _sound effects when buttons are clicked"

--- a/po/en_GB.po~
+++ b/po/en_GB.po~
@@ -1,0 +1,16152 @@
+# English (British)
+# Copyright (C) 1999 Free Software Foundation, Inc.
+# Robert Brady <rwb197@ecs.soton.ac.uk>
+# Gareth Owen <gowen72@yahoo.com>, David Lodge <dave@cirt.net>, 2004.
+# Philip Withnall <philip@tecnocode.co.uk>, 2010, 2013.
+# Chris Leonard <cjl@laptop.org>, 2012.
+# Zander Brown <zbrown@gnome.org>, 2019-2020.
+# Bruce Cowan <bruce@bcowan.me.uk>, 2009-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-04 22:24+0000\n"
+"PO-Revision-Date: 2022-09-05 10:21+0100\n"
+"Last-Translator: Bruce Cowan <bruce@bcowan.me.uk>\n"
+"Language-Team: English - United Kingdom <en@li.org>\n"
+"Language: en_GB\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Gtranslator 42.0\n"
+"X-Project-Style: gnome\n"
+"X-DL-Team: en_GB\n"
+"X-DL-Module: gnome-control-center\n"
+"X-DL-Branch: master\n"
+"X-DL-Domain: po\n"
+"X-DL-State: Translating\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "System Bus"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Full access"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Session Bus"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Devices"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Full access to /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Network"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Has network access"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Home"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Read-only"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "File System"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Settings"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Can change settings"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u file and link type that is opened by the app"
+msgstr[1] "%u file and link types that are opened by the app"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> is used to open the following types of files and links."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s of disk space used."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Applications"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "No applications"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Install some…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Open"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "View Details"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Search"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Receive system searches and send results."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Disabled"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notifications"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Show system notifications."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Run in Background"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Allow activity when the app is closed."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Screenshots"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Take pictures of the screen at any time."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Change Wallpaper"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Change the desktop wallpaper."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sounds"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reproduce sounds."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Inhibit Shortcuts"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Block standard keyboard shortcuts."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Camera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Take pictures with the camera."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microphone"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Record audio with the microphone."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Location Services"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Access device location data."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Built-in Permissions"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "System access that is required by the app"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "File &amp; Link Associations"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Storage"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "No results found"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Try a different search"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "File & Link Associations"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "File Types"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Link Types"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Reset"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"How much disk space this application is occupying with app data and caches."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Application"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Clear Cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Control various application permissions and settings"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "application;flatpak;permission;setting;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Select a picture"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancel"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Open"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "multiple sizes"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "No Desktop Background"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Current background"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Style"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Default"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Dark"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Background"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Add Picture…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Appearance"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Change your background image or the UI colours"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Enable"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "No Bluetooth Found"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Plug in a dongle to use Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth Turned Off"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Turn on to connect devices and receive file transfers."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Aeroplane Mode is On"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth is disabled when aeroplane mode is on."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Turn Off Aeroplane Mode"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Hardware Aeroplane Mode is On"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Turn off the Aeroplane mode switch to enable Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Turn Bluetooth on and off and connect your devices"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Camera is Turned Off"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "No applications can capture photos or video."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "No Applications Have Asked for Camera Access"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Protect your pictures"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "camera;photos;video;webcam;lock;private;privacy;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Place your calibration device over the square and press “Start”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Move your calibration device to the calibrate position and press “Continue”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Move your calibration device to the surface position and press “Continue”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Shut the laptop lid"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "An internal error occurred that could not be recovered."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Tools required for calibration are not installed."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "The profile could not be generated."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "The target whitepoint was not obtainable."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Complete!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Calibration failed!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "You can remove the calibration device."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Do not disturb the calibration device while in progress"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Display Calibration"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Start"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Resume"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Done"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Laptop Screen"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Built-in Webcam"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s Monitor"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s Scanner"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s Camera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s Printer"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s Webcam"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Enable colour management for %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Show colour profiles for %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Not calibrated"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Default: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Colourspace: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Test profile: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Select ICC Profile File"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Import"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Supported ICC profiles"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "All files"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Screen"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Save Profile"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Save"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Create a colour profile for the selected device"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "The measuring instrument does not support printer profiling."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "The device type is not currently supported."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Screen Calibration"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Calibration Quality"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Calibration will produce a profile that you can use to colour manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"colour profile."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"You will not be able to use your computer while calibration takes place."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Quality"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Approximate Time"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Calibration Device"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Select the sensor device you want to use for calibration."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Display Type"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Select the type of display that is connected."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profile Whitepoint"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Display Brightness"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Please set the display to a brightness that is typical for you. Colour "
+"management will be most accurate at this brightness level."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profile Name"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"You can use a colour profile on different computers, or even create profiles "
+"for different lighting conditions."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profile Name:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Summary"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profile successfully created!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copy profile"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Requires writeable media"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Add Profile"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Import File…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Add"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "Each device needs an up to date colour profile to be colour managed."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Learn more"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Learn more about colour management"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Set for all users"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Set this profile for all users on this computer"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Enable"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Add profile"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibrate…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibrate the device"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Remove profile"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_View details"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Unable to detect any devices that can be colour managed"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projector"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL backlight)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED backlight)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (white LED backlight)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Wide gamut LCD (CCFL backlight)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Wide gamut LCD (RGB LED backlight)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "High"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutes"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Medium"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Low"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Native to display"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Printing and publishing)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Photography and graphics)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standard Space"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Test Profile"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatic"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Low Quality"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Medium Quality"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "High Quality"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Default RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Default CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Default Grey"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Vendor supplied factory calibration data"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Full-screen display correction not possible with this profile"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "This profile may no longer be accurate"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Colour"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibrate the colour of your devices, such as displays, cameras or printers"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Colour;ICC;Profile;Calibrate;Printer;Display;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Other…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Select Language"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Select"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "No languages found"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "More…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Unlock to Change Settings"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Some settings must be unlocked before they can be changed."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Unlock…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Increment Hour"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Increment Minute"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Time"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Decrement Hour"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Decrement Minute"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Today"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Yesterday"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hour"
+msgstr[1] "%d hours"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minute"
+msgstr[1] "%d minutes"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d second"
+msgstr[1] "%d seconds"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 seconds"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-hour"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM/PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%H:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Date & Time"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Year"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Month"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "January"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "February"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "March"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "May"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "June"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "July"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "October"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "December"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Day"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Time Zone"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Search for a city"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatic _Date &amp; Time"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Requires internet access"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Date &amp; _Time"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automatic Time _Zone"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Requires location services enabled and internet access"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Enabled"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Time Z_one"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Time _Format"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Change the date and time, including time zone"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Change system time and date settings"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "To change time or date settings, you need to authenticate."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Mail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendar"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usic"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Photos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Default Applications"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configure Default Applications"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Problem Reporting"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatic Problem Reporting"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostics"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Report your problems"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "On"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Off"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Apply Changes?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Changes Cannot be Applied"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "This could be due to hardware limitations."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Apply"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Back"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Display Settings Disabled"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Multiple Displays"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Join"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Mirror"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Contains top bar and Activities"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Primary Display"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Night Light"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Landscape"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portrait Right"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portrait Left"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Landscape (flipped)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientation"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolution"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Refresh Rate"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Adjust for TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Scale"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Night Light unavailable"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Temporarily Disabled Until Tomorrow"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Restart Filter"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Night light makes the screen colour warmer. This can help to prevent eye "
+"strain and sleeplessness."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Schedule"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Sunset to Sunrise"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Manual Schedule"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Times"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "From"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hour"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minute"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "To"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Colour Temperature"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Displays"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Choose how to use connected monitors and projectors"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;colour;sunset;sunrise;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Secure Boot is Active"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Secure Boot Has Problems"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "For help, contact your hardware manufacturer or IT support provider."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Secure Boot is Turned Off"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Passed"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Failed"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Device conforms to HSI level %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Security Level 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Security Level 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Security Level 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Security Level 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Security Level"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Security levels are not available for this device."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr "Contact your hardware manufacturer for help with security updates."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "It might be possible for a support technician to resolve this issue."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Level 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Level 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Level 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Protected against malicious software when the device starts."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Secure Boot has Problems"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Some protection when the device is started."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Secure Boot is Off"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "No protection when the device is started."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Exposed to serious security threats."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Limited protection against simple security threats."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Protected against common security threats."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Protected against a wide range of security threats."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Comprehensive Protection"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "No Events"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Firmware Write Protection"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Firmware Write Protection Lock"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Firmware BIOS Region"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Firmware BIOS Descriptor"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Pre-boot DMA Protection"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard Verified Boot"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM Protected"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard Error Policy"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard Fuse"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET Enabled"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET Active"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Encrypted RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU Protection"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux Kernel Lockdown"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux Kernel Verification"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Suspend To RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Suspend To Idle"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI Platform Key"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI Secure Boot"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM Platform Configuration"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM Reconstruction"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine Manufacturing Mode"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine Override"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine Version"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Firmware Updates"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Firmware Attestation"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Firmware Updater Verification"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Platform Debugging"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Processor Security Checks"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD Rollback Protection"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD Firmware Replay Protection"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD Firmware Write Protection"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Fused Platform"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Valid"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Not Valid"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Not Enabled"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Locked"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Not Locked"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Encrypted"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Not Encrypted"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Tainted"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Not Tainted"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Found"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Not Found"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Supported"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Not Supported"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Device Security"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Host firmware security status"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Unknown"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Unknown"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Not Available"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "System Logo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Device Name"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Hardware Model"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memory"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Graphics"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Disk Capacity"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calculating…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "OS Name"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "OS Build ID"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "OS Type"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME Version"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Loading…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Windowing System"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisation"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Software Updates"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Rename Device"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Device name"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Rename"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "About"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "View information about your system"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Sound and Media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Volume mute/unmute"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Volume down"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Volume up"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Microphone mute/unmute"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Launch media player"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Play (or play/pause)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pause playback"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Stop playback"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Previous track"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Next track"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Eject"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Typing"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Switch to next input source"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Switch to previous input source"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Launchers"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Launch help browser"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Launch calculator"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Launch e-mail client"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Launch web browser"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Home folder"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Search"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Log out"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Lock screen"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accessibility"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Turn zoom on or off"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zoom in"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Zoom out"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Turn screen reader on or off"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Turn on-screen keyboard on or off"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Increase text size"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Decrease text size"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "High contrast on or off"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "No input sources found"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Other"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Add an Input Source"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Input methods can’t be used on the login screen"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "No input source selected"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Options"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Move Up"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Move Down"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferences"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "View Keyboard Layout"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Remove"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Custom Shortcuts"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternative Characters Key"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Left Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Right Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Left Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Right Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menu key"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Right Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose Key"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Input Sources"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Includes keyboard layouts and input methods."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Input Source Switching"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Use the _same source for all windows"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Switch input sources _individually for each window"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Special Character Entry"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Methods for entering symbols and letter variants using the keyboard."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Keyboard Shortcuts"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "View and Customise Shortcuts"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modified"
+msgstr[1] "%d modified"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Reset All Shortcuts?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Cancel"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Reset All"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Reset All…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Reset all shortcuts to their default keybindings"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Section"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Shortcuts"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Add a shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Add Custom Shortcuts"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "Set up custom shortcuts for launching apps, running scripts, and more."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Add Shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "No keyboard shortcut found"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s is already being used for %s. If you replace it, %s will be disabled"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Enter the new shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Set Custom Shortcuts"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Set Shortcut"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Enter new shortcut to change %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Add Custom Shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Remove"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Re_place"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Set"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Name"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Command"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Shortcut"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Set Shortcut…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "None"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Reset the shortcut to its default value"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Keyboard"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Location Services Turned Off"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "No applications can obtain location information."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "No Applications Have Asked for Location Access"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Protect your location information"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Microphone Turned Off"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "No applications can record sound."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "No Applications Have Asked for Microphone Access"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Protect your conversations"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "microphone;recording;application;privacy;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Test Your _Settings"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "General"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primary Button"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Sets the order of physical buttons on mice and touchpads."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Left"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Right"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mouse"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Mouse Speed"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Natural Scrolling"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Scrolling moves the content, not the view."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Touchpad Speed"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Tap to Click"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Tap to click"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Two-finger Scrolling"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Edge Scrolling"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Try clicking, double clicking, scrolling"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Five clicks, GEGL time!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Double click, primary button"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Single click, primary button"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Double click, middle button"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Single click, middle button"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Double click, secondary button"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Single click, secondary button"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mouse & Touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;Touchpad;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Hot Corner"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Touch the top-left corner to open the Activities Overview."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Active Screen Edges"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Drag windows against the top, left, and right screen edges to resize them."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Workspaces"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dynamic workspaces"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Automatically removes empty workspaces."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Fixed number of workspaces"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Specify a number of permanent workspaces."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Number of Workspaces"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multi-Monitor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Workspaces on _primary display only"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Workspaces on all d_isplays"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Application Switching"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Include applications from all _workspaces"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Include applications from the _current workspace only"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitasking"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Manage preferences for productivity and multitasking"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Customise;Desktop;Hot Corner;"
+"Workspaces;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Oops, something has gone wrong. Please contact your software vendor."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager needs to be running."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Other Devices"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Add connection"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Not set up"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Insecure network (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Secure network (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Secure network (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Secure network (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Secure network"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Connected"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Options…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Must have a minimum of 8 characters"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Must have a maximum of %d character"
+msgstr[1] "Must have a maximum of %d characters"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Turn On Wi-Fi Hotspot?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Network Name"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Generate Random Password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Autogenerate Password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Turn On"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Stop hotspot and disconnect any users?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Stop Hotspot"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Aeroplane Mode"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Disables Wi-Fi, Bluetooth and mobile broadband"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "No Wi-Fi Adapter Found"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Make sure you have a Wi-Fi adapter plugged and turned on"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Aeroplane Mode On"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Turn off to use Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi Hotspot Active"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobile devices can scan the QR code to connect."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Turn Off Hotspot…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Visible Networks"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager needs to be running"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x _Security"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Security"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Preserve"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Random"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stable"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profile %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "None"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Never"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i day ago"
+msgstr[1] "%i days ago"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "None"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Weak"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Good"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excellent"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 Address"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 Address"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP Address"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Forget Connection"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Remove Connection Profile"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Remove VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Details"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatic"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identity"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Delete Address"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Delete Route"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "None"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit Passphrase"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamic WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signal Strength"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Link speed"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hardware Address"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Supported Frequencies"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Default Route"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Last Used"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Connect _automatically"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Make available to _other users"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "_Metered connection: has data limits or can incur charges"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Software updates and other large downloads will not be started automatically."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Name"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC Address"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Cloned Address"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 Method"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatic (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Link-Local Only"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Disable"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Shared to other computers"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Addresses"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Address"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Netmask"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatic"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatic DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS server address(es)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Separate IP addresses with commas"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Routes"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatic Routes"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Use this connection _only for resources on its network"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 Method"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatic, DHCP only"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefix"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Unable to open connection editor"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "New Profile"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Invalid setting %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Invalid setting %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Import from file…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Add VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_ecurity"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Cannot import VPN connection"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"The file “%s” could not be read or does not contain recognised VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Select file to import"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "A file named “%s” already exists."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Replace"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Do you want to replace %s with the VPN connection you are saving?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Cannot export VPN connection"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Export VPN connection"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Error: unable to load VPN connection editor)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Control how you connect to the Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Control how you connect to Wi-Fi networks"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "never"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "today"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "yesterday"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Last used"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Wired"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Add new connection"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Forget"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Known Wi-Fi Networks"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Forget"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "System policy prohibits use as a Hotspot"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Wireless device does not support Hotspot mode"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "This is not recommended for untrusted public networks."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Turn device off"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Active"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Provider"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Network Proxy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP Proxy"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS Proxy"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP Proxy"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks Host"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignore Hosts"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP proxy port"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS proxy port"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP proxy port"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks proxy port"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Configuration URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Turn VPN connection off"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Network Name"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Security type"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Password"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Turn Wi-Fi off"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "More options…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Connect to Hidden Network…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Turn On Wi-Fi Hotspot…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Known Wi-Fi Networks"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Status unknown"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Unmanaged"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Unavailable"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Connecting"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Authentication required"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Disconnecting"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Connection failed"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Status unknown (missing)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Configuration failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP configuration failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP configuration expired"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Secrets were required, but not provided"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x supplicant disconnected"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x supplicant configuration failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x supplicant failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant took too long to authenticate"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP service failed to start"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP service disconnected"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP client failed to start"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP client error"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP client failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Shared connection service failed to start"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Shared connection service failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP service failed to start"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP service error"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP service failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Line busy"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "No dial tone"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "No carrier could be established"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Dialing request timed out"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Dialing attempt failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Modem initialisation failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Failed to select the specified APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Not searching for networks"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Network registration denied"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Network registration timed out"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Failed to register with the requested network"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN check failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Firmware for the device may be missing"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Connection disappeared"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Existing connection was assumed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem not found"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth connection failed"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM Card not inserted"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM Pin required"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM Puk required"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM wrong"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Connection dependency failed"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Firmware missing"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Cable unplugged"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "undefined error in 802.1X security (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "no file selected"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "unspecified error validating eap-method file"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12, or PGP private keys"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER or PEM certificates"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "missing EAP-FAST PAC file"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC files (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonymous"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Authenticated"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Both"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anony_mous identity"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _file"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Choose a PAC file"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Inner authentication"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Allow automatic PAC pro_visioning"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "missing EAP-LEAP username"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "missing EAP-LEAP password"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Username"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Password"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Sho_w password"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "invalid EAP-PEAP CA certificate: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "invalid EAP-PEAP CA certificate: no certificate specified"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A certificate"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Choose a Certificate Authority certificate"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "No CA certificate is _required"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP _version"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "missing EAP username"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "missing EAP password"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "missing EAP-TLS identity"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "invalid EAP-TLS CA certificate: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "invalid EAP-TLS CA certificate: no certificate specified"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "invalid EAP-TLS private-key: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "invalid EAP-TLS user-certificate: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Unencrypted private keys are insecure"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Choose your personal certificate"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Choose your private key"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentity"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_User certificate"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Private _key"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Private key password"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "invalid EAP-TTLS CA certificate: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "invalid EAP-TTLS CA certificate: no certificate specified"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domain"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Unknown error validating 802.1X security"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunnelled TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Protected EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_thentication"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Select a file"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "missing leap-username"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "missing leap-password"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Wi-Fi password is missing."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Type"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "missing wep-key"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "invalid wep-key: key with a length of %zu must contain only hex-digits"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "invalid wep-key: passphrase must be non-empty"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "invalid wep-key: passphrase must be shorter than 64 characters"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Default)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Open System"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Shared Key"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Key"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Sho_w key"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP inde_x"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notifications"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Sound _Alerts"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Notification _Popups"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Show Message _Content in Popups"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Lock Screen Notifications"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Show Message C_ontent on Lock Screen"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Do Not Disturb"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Lock Screen Notifications"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Control which notifications are displayed and what they show"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Banner;Message;Tray;Popup;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Other"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s removed"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Error removing account"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Undo"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Close the notification"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Connect to your data in the cloud"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "No internet connection — connect to set up new online accounts"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Add an account"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s Account"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Remove Account"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Online Accounts"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Connect to your online accounts and decide what to use them for"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Unknown time"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minute"
+msgstr[1] "%i minutes"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hour"
+msgstr[1] "%i hours"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hour"
+msgstr[1] "hours"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minute"
+msgstr[1] "minutes"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s until fully charged"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Caution: %s remaining"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s remaining"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Fully charged"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Not charging"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Empty"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Charging"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Discharging"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Wireless mouse"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Wireless keyboard"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Uninterruptible power supply"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Personal digital assistant"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobile phone"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Media player"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Computer"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Gaming input device"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Battery"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Main"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Extra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batteries"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "When _idle"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Suspend"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Power Off"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernate"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nothing"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "When on battery power"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "When plugged in"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Never"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatic suspend"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Performance mode temporarily disabled due to high operating temperature."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Performance mode temporarily disabled."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Power Saver mode activated by “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Performance mode activated by “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hour"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 hours"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Power Mode"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Affects system performance and power usage."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Power Saving Options"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatic Screen Brightness"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Screen brightness adjusts to the surrounding light."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Dim Screen"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Reduces the screen brightness when the computer is inactive."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Screen _Blank"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Turns the screen off after a period of inactivity."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatic Power Saver"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Enables power saver mode when battery is low."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatic Suspend"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pauses the computer after a period of inactivity."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Po_wer Button Behaviour"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Show Battery _Percentage"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatic Suspend"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Plugged In"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "On _Battery Power"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Delay"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Performance"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "High performance and power usage."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Balanced"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standard performance and power usage."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Power Saver"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Reduced performance and power usage."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Power"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "View your battery status and change power saving settings"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Printer “%s” has been deleted"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Failed to add new printer."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Could not load ui: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Unlock to Add Printers and Change Settings"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Printers"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Add printers, view printer jobs and decide how you want to print"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Add Printer"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Unlock"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "No Printers Found"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Enter a network address or search for a printer"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Authentication Required"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr "Enter username and password to view printers on Print Server."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Username"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s Details"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "No suitable driver found"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Select PPD File"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Printer names cannot contain SPACE, TAB, #, or /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Location"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Searching for preferred drivers…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Search for Drivers"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Select from Database…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Install PPD File…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Select Printer Driver"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Loading drivers database…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Select"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect Printer"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD Printer"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "One Sided"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Long Edge (Standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Short Edge (Flip)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portrait"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Landscape"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Reverse landscape"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Reverse portrait"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Resume"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pause"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Pending"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Paused"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Authentication required"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Processing"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Stopped"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Cancelled"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Aborted"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Completed"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Move this job to the top of the queue"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u Job Requires Authentication"
+msgstr[1] "%u Jobs Require Authentication"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Active Jobs"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Enter credentials to print from %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domain"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_uthenticate"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Clear All"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Authenticate"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "No Active Printer Jobs"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Unlock Print Server"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Unlock %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Enter username and password to view printers on %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Searching for Printers"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Serial Port"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Parallel Port"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Location: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Address: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Server requires authentication"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Two Sided"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Paper Type"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Paper Source"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Output Tray"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolution"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript pre-filtering"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Pages per side"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Two-sided"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientation"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "General"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Page Setup"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Installable Options"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Job"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Image Quality"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Colour"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Finishing"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Advanced"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Test Page"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Test page"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Auto Select"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Printer Default"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Embed GhostScript fonts only"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Convert to PS level 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Convert to PS level 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "No pre-filtering"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Manufacturer"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "No Active Jobs"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u Job"
+msgstr[1] "%u Jobs"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Clean print heads"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Low on toner"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Out of toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Low on developer"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Out of developer"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Low on a marker supply"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Out of a marker supply"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Open cover"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Open door"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Low on paper"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Out of paper"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Offline"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Stopped"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Waste receptacle almost full"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Waste receptacle full"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "The optical photo conductor is near end of life"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "The optical photo conductor is no longer functioning"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Ready"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Does not accept jobs"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Processing"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Printing Options"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Printer Details"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Use Printer by Default"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Clean Print Heads"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Remove Printer"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Ink Level"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Please restart when the problem is resolved."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Restart"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Add Printer…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "No printers"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formats"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Search locales…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Common Formats"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "All Formats"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "No Search Results"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Searches can be for countries or languages."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Preview"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Dates"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dates & Times"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Numbers"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Measurement"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Paper"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Language and format will be changed after next login"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Logout…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Your Account"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Language"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formats"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Login Screen"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Region & Language"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Select your display language and formats"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Ask what to do"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Do nothing"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Open folder"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Other Media"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Select an application for audio CDs"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Select an application for video DVDs"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Select an application to run when a music player is connected"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Select an application to run when a camera is connected"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Select an application for software CDs"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "audio DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "blank Blu-ray disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "blank CD disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "blank DVD disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "blank HD DVD disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "e-book reader"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD video disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Select how media should be handled"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _audio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Music player"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Other Media…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Never prompt or start programs on media insertion"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Select how other media should be handled"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Action:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Type:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Removable Media"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configure Removable Media settings"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Screen Turns Off"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 seconds"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minute"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 hour"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minute"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Never"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Screen Lock"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Blank Screen Delay"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Period of inactivity after which the screen will go blank."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatic Screen _Lock"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Automatic _Screen Lock Delay"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Period after the screen blanks when the screen is automatically locked."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Show _Notifications on Lock Screen"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Forbid new _USB devices"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Screen Privacy"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Restrict Viewing Angle"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Screen Settings"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Select Location"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Search Locations"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Places"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Bookmarks"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Others"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Add Location"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "No applications found"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Application Search"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Include application-provided search results."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Folders which are searched by system applications."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Search Results"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Results are displayed according to the list order."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Control which applications show search results in the Activities Overview"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "No networks selected for sharing"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Networks"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "On"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Off"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Enabled"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Active"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Choose a Folder"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Add"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Enable media sharing"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Enable personal media sharing"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Device name copied"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Device address copied"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Username copied"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Password copied"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Sharing"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Computer Name"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_File Sharing"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Remote _Desktop"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Media Sharing"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Remote Login"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "File Sharing"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Require Password"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Remote Login"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Remote Desktop"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Enable or disable remote desktop connections to this computer."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Remote Control"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Allows remote connections to control the screen."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "How to Connect"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Connect to this computer using the device name or remote desktop address."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copy"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Remote Desktop Address"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Authentication"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "The user name and password are required to connect to this computer."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "User Name"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Verify Encryption"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Encryption Fingerprint"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Media Sharing"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Share music, photos and videos over the network."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Folders"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Control what you want to share with others"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Enable or disable remote login"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Authentication is required to enable or disable remote login"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Custom"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Click"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "String"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Swing"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Hum"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balance"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Fade"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Rear"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Front"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Testing %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Click a speaker to test"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "System Volume"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Master volume"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Volume Levels"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Output"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Output Device"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Test"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuration"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Input"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Input Device"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volume"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Alert Sound"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Mute"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Sound"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Change sound levels, inputs, outputs, and alert sounds"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Disconnected"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Connecting"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Connected"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Authorisation Error"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Authorising"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Reduced Functionality"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Connected & Authorised"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Unknown"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Authorised at:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Connected at:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Enrolled at:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Failed to authorise device: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Failed to forget device: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Depends on %u other device"
+msgstr[1] "Depends on %u other devices"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Close notification"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Name:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Status:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Authorise and Connect"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Forget Device"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Error"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Authorised"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Allow direct access to devices such as docks and external GPUs."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Only USB and Display Port devices can attach."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt support has been disabled in the BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Thunderbolt security level could not be determined."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Error switching direct mode: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "No Thunderbolt Support"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Could not connect to the thunderbolt subsystem."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Direct Access"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Pending Devices"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "No devices attached"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Manage Thunderbolt devices"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Cursor Blinking"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Cursor blinks in text fields."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Speed"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Cursor blinking speed"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Cursor Size"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Click Assist"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulated Secondary Click"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Trigger a secondary click by holding down the primary button"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "A_cceptance delay:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Short"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Secondary click delay"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Hover Click"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Trigger a click when the pointer hovers"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "D_elay:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Short"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Motion _threshold:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Small"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Large"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repeat Keys"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Key presses repeat when key is held down."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Repeat keys delay"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Repeat keys speed"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Typing Assist"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Sticky Keys"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Treats a sequence of modifier keys as a key combination"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Disable if two keys are pressed together"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Beep when a _modifier key is pressed"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "S_low Keys"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Puts a delay between when a key is pressed and when it is accepted"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Short"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Slow keys typing delay"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Beep when a key is pr_essed"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Beep when a key is _accepted"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Beep when a key is _rejected"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Bounce Keys"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignores fast duplicate keypresses"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Short"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Bounce keys typing delay"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Enable by Keyboard"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Turn accessibility features on and off using the keyboard"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Default"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Medium"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Large"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Larger"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Largest"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixels"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Always Show Accessibility Menu"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Seeing"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_High Contrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Large Text"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Enable A_nimations"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Screen _Reader"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "The screen reader reads displayed text as you move the focus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Sound Keys"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Beep when Num Lock or Caps Lock are turned on or off."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "C_ursor Size"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Hearing"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Visual Alerts"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Screen _Keyboard"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "R_epeat Keys"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Cursor _Blinking"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Typing Assist (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Pointing &amp; Clicking"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Mouse Keys"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Locate Pointer"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Click Assist"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Double-Click Delay"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Double-Click Delay"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Visual Alerts"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Test flash"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Use a visual indication when an alert sound occurs."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Flash the entire _screen"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Flash the entire _window"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Short"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ Screen"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ Screen"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ Screen"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Full Screen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Top Half"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Bottom Half"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Left Half"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Right Half"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Zoom Options"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Magnification:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Magnifier Position:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Follow mouse cursor"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Screen part:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Magnifier _extends outside of screen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Keep magnifier cursor centered"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Magnifier cursor _pushes contents around"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Magnifier cursor moves with _contents"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Magnifier"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Crosshairs:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Overlaps mouse cursor"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Thickness:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Thin"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Thick"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Length:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Co_lour:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Crosshairs"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Colour Effects:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_White on black:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Brightness:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Co_lour"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "None"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Full"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Low"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "High"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Low"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "High"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Colour Effects"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Make it easier to see, hear, type, point and click"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 hour"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 day"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 days"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 days"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 days"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 days"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 days"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 days"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 days"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 days"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Empty all items from Wastebasket?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "All items in the Wastebasket will be permanently deleted."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Empty Wastebasket"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Delete all the temporary files?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "All the temporary files will be permanently deleted."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Purge Temporary Files"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 day"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 days"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 days"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Forever"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "File History"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "File H_istory"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "File _History Duration"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Clear History…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Wastebasket &amp; Temporary Files"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"The Wastebasket and temporary files can sometimes include personal or "
+"sensitive information. Automatically deleting them can help to protect "
+"privacy."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Automatically Empty _Wastebasket"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automatically Delete Temporary _Files"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Automatically Empty _Wastebasket"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Empty Wastebasket…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Delete Temporary Files…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "File History & Wastebasket"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Don't leave traces"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;wastebasket;"
+"purge;retain;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Should match the web address of your login provider."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Failed to add account"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "The passwords do not match."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Failed to register account"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "No supported way to authenticate with this domain"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Failed to join domain"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"That login name didn’t work.\n"
+"Please try again."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"That login password didn’t work.\n"
+"Please try again."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Failed to log into domain"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Unable to find the domain. Maybe you misspelled it?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Add User"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "User sets password on first login"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Set password now"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirm"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Enterprise Login"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "User accounts which are managed by a company or organisation."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "You are Offline"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Browse for more pictures"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Select a File…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Fingerprint Manager"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Fingerprint"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_No"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Yes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "No fingerprint device"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "No Fingerprint device"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Ensure the device is properly connected."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Fingerprint Device"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Choose the fingerprint device you want to configure"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Fingerprint Login"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Delete Fingerprints"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Fingerprint Enroll"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "the device needs to be claimed to perform this action"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "the device is already claimed by another process"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "you do not have permission to perform the action"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "no prints have been enrolled"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Failed to communicate with the device during enrollment"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Failed to communicate with the fingerprint reader"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Failed to communicate with the fingerprint daemon"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Failed to list fingerprints: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Failed to delete saved fingerprints: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Left thumb"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Left middle finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Left index finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Left ring finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Left little finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Right thumb"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Right middle finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Right index finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Right ring finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Right little finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Unknown Finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Complete"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Fingerprint device disconnected"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Fingerprint device storage is full"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Failed to enroll new fingerprint"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Failed to start enrollment: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Failed to enroll new fingerprint"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Failed to stop enrollment: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Re-enroll this finger…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Scan new fingerprint"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Failed to release fingerprint device %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problem Reading Device"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Failed to claim fingerprint device %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Failed to get fingerprint devices: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "This Week"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Last Week"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Session Ended"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Session Started"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Account Activity"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Previous"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Next"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Please choose another password."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Please type your current password again."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Password could not be changed"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Change Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Ch_ange"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Current Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "New Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Confirm Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Allow user to change their password on next login"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Set a password now"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Cannot automatically join this type of domain"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "No such domain or realm found"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Cannot log in as %s at the %s domain"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Invalid password, please try again"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Couldn’t connect to the %s domain: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Failed to delete user"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Failed to revoke remotely managed user"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "You cannot delete your own account."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s is still logged in"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Do you want to keep %s’s files?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Delete Files"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Keep Files"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Are you sure you want to revoke remotely managed %s’s account?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Delete"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Account disabled"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "To be set at next login"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "None"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Logged in"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Failed to contact the accounts service"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Please make sure that the AccountService is installed and enabled."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "This panel must be unlocked to change this setting"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Delete the selected user account"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"To delete the selected user account,\n"
+"click the * icon first"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Unlock to Add Users and Change Settings"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Users"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Your session needs to be restarted for changes to take effect"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Restart Now"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Close"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Edit avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Full name"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Edit"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Fingerprint Login"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatic Login"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Account Activity"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Parental Controls"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Open the Parental Controls application."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Remove User…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Other Users"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Add User…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "No Users Found"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Unlock to add a user account."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Add or remove users and change your password"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Enroll"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Domain Administrator Login"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Administrator _Name"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Administrator Password"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Manage user accounts"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Authentication is required to change user data"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "The new password needs to be different from the old one."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Try changing some letters and numbers."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Try changing the password a bit more."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "A password without your username would be stronger."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Try to avoid using your name in the password."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Try to avoid some of the words included in the password."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Try to avoid common words."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Try to avoid reordering existing words."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Try to use more numbers."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Try to use more uppercase letters."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Try to use more lowercase letters."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Try to use more special characters, like punctuation."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Try to use a mixture of letters, numbers and punctuation."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Try to avoid repeating the same character."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Try to avoid sequences like 1234 or abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Mix uppercase and lowercase and try to use a number or two."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Authentication failed"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "The new password is too short"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "The new password is too simple"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "The old and new passwords are too similar"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "The new password has already been used recently."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "The new password must contain numeric or special characters"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "The old and new passwords are the same"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Your password has been changed since you initially authenticated!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "The new password does not contain enough different characters"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Unknown error"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Sorry, that user name isn’t available. Please try another."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "The username is too long."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Map Buttons"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Map buttons to functions"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Close"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Mis-click detected, restarting…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Button %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Application defined"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Send Keystroke"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Switch Monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Show On-Screen Help"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tablet mounted on laptop panel"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tablet mounted on external display"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "External tablet device"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "External pad device"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "All Displays"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Tablet Mode"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Use absolute positioning for the pen"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Left Hand Orientation"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tablet and Express Keys™ are rotated for left hand use"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Map to Monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Keep Aspect Ratio"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "Only use a portion of the tablet surface to keep monitor aspect ratio"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Calibrate"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "No tablet detected"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Please plug in or turn on your Wacom tablet."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Tip Pressure Feel"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Soft"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Stylus tip pressure"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firm"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Button 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Button 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Button 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Eraser Pressure Feel"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Eraser pressure"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Middle Mouse Button Click"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Right Mouse Button Click"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Forward"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Airbrush stylus with pressure, tilt, and integrated slider"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Airbrush stylus with pressure, tilt, and rotation"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standard stylus with pressure and tilt"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standard stylus with pressure"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Set button mappings and adjust stylus sensitivity for graphics tablets"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "New shortcut…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Access Points"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operation Cancelled"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Error:</b> Access denied changing settings"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Error:</b> Mobile Equipment Error"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Not Registered"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registered"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Searching"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Denied"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modem Details"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modem Status"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Carrier"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Network Type"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Network Status"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Own Number"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Device Details"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Firmware Version"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G Only"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G Only"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G Only"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "5G Only"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (Preferred), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (Preferred), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (Preferred), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Preferred), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Preferred), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (Preferred), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (Preferred), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (Preferred), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (Preferred), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (Preferred), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (Preferred), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (Preferred), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (Preferred), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (Preferred), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (Preferred), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (Preferred), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (Preferred)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (Preferred), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Unknown"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Unlock SIM card"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Unlock"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Please provide PIN code for SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Enter PIN to unlock your SIM card"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Please provide PUK code for SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Enter PUK to unlock your SIM card"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Wrong password entered. You have %1$u try left"
+msgstr[1] "Wrong password entered. You have %1$u tries left"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "You have %u try left"
+msgstr[1] "You have %u tries left"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Wrong password entered."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK code should be an 8 digit number"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Enter New PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN code should be a 4-8 digit number"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Unlocking…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "No SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Insert a SIM card to use this modem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM Locked"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobile Data"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Access data using mobile network"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Data Roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Use mobile data when roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Network Mode"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "N_etwork"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Advanced"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Access Point Names"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM Lock"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Lock SIM with PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "M_odem Details"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Phone failure"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "No connection to phone"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operation not allowed"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operation not supported"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM not inserted"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIM PIN required"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIM PUK required"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM failure"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM busy"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Incorrect password"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM PIN2 required"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM PUK2 required"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Not found"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "No network service"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Network timeout"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS services not allowed"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming not allowed in this location area"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Unspecified GPRS error"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "No Error"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Action Cancelled"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Access denied"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Unknown Error"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Network Mode"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatic"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Choose Network"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Refresh Network Providers"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Enable Mobile Network"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "No WWAN Adapter Found"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Make sure you have a Wireless Wan/Mobile device"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Wireless Wan is disabled when aeroplane mode is on"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Turn off Aeroplane Mode"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Data Connection"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM card used for internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM Lock"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Next"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Lock SIM with PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Change PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Enter current PIN to change SIM lock settings"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobile Network"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configure Telephony and mobile data connections"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;wwan;telephony;sim;mobile;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utility to configure the GNOME desktop"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Settings is the primary interface for configuring your system."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "The GNOME Project"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Display version number"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Enable verbose mode"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Search for the string"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "List possible panel names and exit"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel to display"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Settings categories"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privacy"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Available panels:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "All Settings"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Primary Menu"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Warning: Development Version"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behaviour, data loss, and other unexpected "
+"issues. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Help"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "General"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Quit"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Search"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panels"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Go back to previous panel"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Cancel search"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "The identifier for the last Settings panel to be opened"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Show warning when running a development build of Settings"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Whether Settings should show a warning when running a development build."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Initial state of the window"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"A tuple containing the initial width, height and maximised state of the "
+"application window."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u Output"
+msgstr[1] "%u Outputs"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u Input"
+msgstr[1] "%u Inputs"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "System Sounds"
+
+#~| msgid "Right"
+#~ msgid "Light"
+#~ msgstr "Light"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Display Arrangement"
+
+#~ msgid "Set"
+#~ msgstr "Set"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Lock your screen"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Add a Printer…"
+
+#~ msgid "Bark"
+#~ msgstr "Bark"
+
+#~ msgid "Drip"
+#~ msgstr "Drip"
+
+#~ msgid "Glass"
+#~ msgstr "Glass"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "Web Links"
+#~ msgstr "Web Links"
+
+#~ msgid "Git Links"
+#~ msgstr "Git Links"
+
+#~ msgid "%s Links"
+#~ msgstr "%s Links"
+
+#~ msgid "Unset"
+#~ msgstr "Unset"
+
+#~ msgid "Links"
+#~ msgstr "Links"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hypertext Files"
+
+#~ msgid "Text Files"
+#~ msgstr "Text Files"
+
+#~ msgid "Image Files"
+#~ msgstr "Image Files"
+
+#~ msgid "Font Files"
+#~ msgstr "Font Files"
+
+#~ msgid "Archive Files"
+#~ msgstr "Archive Files"
+
+#~ msgid "Package Files"
+#~ msgstr "Package Files"
+
+#~ msgid "Audio Files"
+#~ msgstr "Audio Files"
+
+#~ msgid "Video Files"
+#~ msgstr "Video Files"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permissions & Access"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Cannot be changed"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+
+#~ msgid "Integration"
+#~ msgstr "Integration"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Set Desktop Background"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Default Handlers"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Types of files and links that this application opens."
+
+#~ msgid "Usage"
+#~ msgstr "Usage"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "How much resources this application is using."
+
+#~ msgid "Open in Software"
+#~ msgstr "Open in Software"
+
+#~ msgid "Activities"
+#~ msgstr "Activities"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Allow the applications below to use your camera."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Failed to upload file: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "The profile has been uploaded to:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Write down this URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Restart this computer and boot your normal operating system."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Type the URL into your browser to download and install the profile."
+
+#~ msgid "Upload profile"
+#~ msgstr "Upload profile"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Requires Internet connection"
+
+#~ msgid "_Copy"
+#~ msgstr "_Copy"
+
+#~ msgid "Select _All"
+#~ msgstr "Select _All"
+
+#~ msgid "Single Display"
+#~ msgstr "Single Display"
+
+#~ msgid "Join Displays"
+#~ msgstr "Join Displays"
+
+#~ msgid "Display Mode"
+#~ msgstr "Display Mode"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+
+#~ msgid "Active Display"
+#~ msgstr "Active Display"
+
+#~ msgid "More Warm"
+#~ msgstr "More Warm"
+
+#~ msgid "Less Warm"
+#~ msgstr "Less Warm"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Save a screenshot to $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Save a screenshot of a window to $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Save a screenshot of an area to $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copy a screenshot to clipboard"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copy a screenshot of a window to clipboard"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copy a screenshot of an area to clipboard"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Record a short screencast"
+
+#~ msgid "Move up"
+#~ msgstr "Move up"
+
+#~ msgid "Move down"
+#~ msgstr "Move down"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Allow the applications below to determine your location."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Allow the applications below to use your microphone."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Double-click timeout"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Suspend & Power Button"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Lap detected: performance mode unavailable"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "High hardware temperature: performance mode unavailable"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Performance mode unavailable"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Authenticate"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+
+#~| msgid "%s Account"
+#~ msgid "My Account"
+#~ msgstr "My Account"
+
+#~ msgid "Language"
+#~ msgstr "Language"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "The language used for text in windows and web pages."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Restart the session for changes to take effect"
+
+#~ msgid "Restart…"
+#~ msgstr "Restart…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "Login settings are used by all users when logging into the system"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Screen Sharing"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Some services are disabled because of no network access."
+
+#~ msgid "_Password:"
+#~ msgstr "_Password:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Show Password"
+
+#~ msgid "Access Options"
+#~ msgstr "Access Options"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_New connections must ask for access"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Require a password"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Sound Keys"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Screen Reader"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Screen Reader"
+
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgid "Account _Type"
+#~ msgstr "Account _Type"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Allow user to set a password when they next _login"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Set a password _now"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "You must be online in order to add enterprise users."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Take a Picture…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+
+#~ msgid "Create a user account"
+#~ msgstr "Create a user account"
+
+#~ msgid "User Icon"
+#~ msgstr "User Icon"
+
+#~ msgid "Account Settings"
+#~ msgstr "Account Settings"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Authentication & Login"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "This will be used to name your home folder and can’t be changed."
+
+#~ msgid "Output:"
+#~ msgstr "Output:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Keep aspect ratio (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Map to single monitor"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d of %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Display Mapping"
+
+#~ msgid "Stylus"
+#~ msgstr "Stylus"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (absolute)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Touchpad (relative)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Tablet Preferences"
+
+#~ msgid "_Help"
+#~ msgstr "_Help"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth Settings"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Tracking Mode"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Map Buttons…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Adjust mouse settings"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Adjust display resolution"
+
+#~ msgid "No stylus found"
+#~ msgstr "No stylus found"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+
+#~ msgid "Top Button"
+#~ msgstr "Top Button"
+
+#~ msgid "Lower Button"
+#~ msgstr "Lower Button"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Lowest Button"
+
+#~| msgid "Unlock %s."
+#~ msgid "Unlocking..."
+#~ msgstr "Unlocking..."
+
+#~ msgid "GNOME Settings"
+#~ msgstr "GNOME Settings"
+
+#~| msgid "Keyboard Shortcuts"
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Keyboard Shortcut"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "This can be changed in Customise Shortcuts"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Hold down and type to enter different characters"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Screen Brightness"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Keyboard Brightness"
+
+#~| msgid "_Dim Screen When Inactive"
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Dim Screen When Inactive"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Blank Screen"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wi-Fi can be turned off to save power."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth can be turned off to save power."
+
+#~| msgid "Balance"
+#~ msgid "Balanced Power"
+#~ msgstr "Balanced Power"
+
+#~ msgid "Add…"
+#~ msgstr "Add…"
+
+#~ msgid "Left Alt"
+#~ msgstr "Left Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Right Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Left Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Right Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Right Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Alternative Characters Key"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Modifiers-only switch to next source"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Menu Key"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Charging"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Caution"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Low"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Good"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Fully charged"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Empty"
+
+#~ msgid "Previous source"
+#~ msgstr "Previous source"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "Next source"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Left+Right Alt"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Add user accounts and change passwords"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Play and record sound"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Access bluetooth hardware directly"
+
+#~ msgid "Use your camera"
+#~ msgstr "Use your camera"
+
+#~ msgid "Print documents"
+#~ msgstr "Print documents"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Use any connected joystick"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Allow connecting to the Docker service"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Configure network firewall"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Setup and use privileged FUSE filesystems"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Update firmware on this device"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Access hardware information"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Provide entropy to hardware random number generator"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Use hardware-generated random numbers"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Access files in your home folder"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Access libvirt service"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Change system language and region settings"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Change location settings and providers"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Read system and application logs"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "access the media-hub service"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Use and configure modems"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Read system mount information and disk quotas"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Control music and video players"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Change low-level network settings"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Access the NetworkManager service to read and change network settings"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Read access to network settings"
+
+#~ msgid "Change network settings"
+#~ msgstr "Change network settings"
+
+#~ msgid "Read network settings"
+#~ msgstr "Read network settings"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Control Open vSwitch hardware"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Read from CD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Read, add, change, or remove saved passwords"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Pause or end any process on the system"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Access USB hardware directly"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Read/write files on removable storage devices"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Prevent screen sleep/lock"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Access serial port hardware"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Restart or power off the device"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Install, remove and configure software"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Access Storage Framework service"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Read process and system information"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Monitor and control any running program"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Change the date and time"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Change time server settings"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Change the time zone"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Access the UDisks2 service for configuring disks and removable media"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Read/change shared calendar events in Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Read/change shared contacts in Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Access energy usage data"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Read/write access to U2F devices exposed"
+
+#~ msgid "∶"
+#~ msgstr ":"
+
+#~ msgid "Universal Access"
+#~ msgstr "Universal Access"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Switch off to connect to a Wi-Fi network"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Password"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Enable Fingerprint Login"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Other finger:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "An internal error occurred."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Delete registered fingerprints?"
+
+#~ msgid "Done!"
+#~ msgstr "Done!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Could not access “%s” device"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Could not start finger capture on “%s” device"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Could not access any fingerprint readers"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Please contact your system administrator for help."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Selecting finger"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Set Background and Lock Screen"
+
+#~ msgid "Set Background"
+#~ msgstr "Set Background"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Set Lock Screen"
+
+#~ msgid "Remove Background"
+#~ msgstr "Remove Background"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "Reports are sent anonymously and are scrubbed of personal data."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Notification _Popups"
+
+#~ msgid "Last Login"
+#~ msgstr "Last Login"
+
+#~ msgid "Version %s"
+#~ msgstr "Version %s"
+
+#~ msgid "OS name"
+#~ msgstr "OS name"
+
+#~ msgid "OS type"
+#~ msgstr "OS type"
+
+#~ msgid "Disk"
+#~ msgstr "Disk"
+
+#~ msgid "Check for updates"
+#~ msgstr "Check for updates"
+
+#~ msgid "Network proxy"
+#~ msgstr "Network proxy"
+
+#~ msgid "page 1"
+#~ msgstr "page 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Inner _authentication"
+
+#~ msgid "page 2"
+#~ msgstr "page 2"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "Restrict background data usage"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Appropriate for connections that have data charges or limits."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Automatic _Connect"
+
+#~ msgid "details"
+#~ msgstr "details"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Show P_assword"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Make available to other users"
+
+#~ msgid "identity"
+#~ msgstr "identity"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Addresses"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Automatic (DHCP) addresses only"
+
+#~ msgid "Link-local only"
+#~ msgstr "Link-local only"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignore automatically obtained routes"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Cloned MAC Address"
+
+#~ msgid "_Reset"
+#~ msgstr "_Reset"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Reset"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Connected Devices"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastructure"
+
+#~ msgid "In use"
+#~ msgstr "In use"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "On"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "On"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "On"
+
+#~ msgid "Usage & History"
+#~ msgstr "Usage & History"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Privacy Policy"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Recently Used"
+
+#~ msgid "Retain _History"
+#~ msgstr "Retain _History"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "The Screen Lock protects your privacy when you are away."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Lock screen _after blank for"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "Lock Screen _Notifications"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Automatically purge the Wastebasket and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+
+#~ msgid "Purge _After"
+#~ msgstr "Purge _After"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Send software usage statistics"
+
+#~ msgid "_Camera"
+#~ msgstr "_Camera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Microphone"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Location Services"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Protect your personal information and control what others might see"
+
+#~ msgid "No regions found"
+#~ msgstr "No regions found"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Flash the _window title"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "The username cannot start with a “-”."
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "_Background"
+#~ msgstr "_Background"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Changes throughout the day"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Tile"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centre"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Scale"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Fill"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Span"
+
+#~ msgid "Colors"
+#~ msgstr "Colours"
+
+#~ msgid "Pictures"
+#~ msgstr "Pictures"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "No Pictures Found"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "You can add images to your %s folder and they will show up here"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "_Off"
+#~ msgstr "_Off"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~| msgid "Connecting"
+#~ msgid "Connection/SSID"
+#~ msgstr "Connection/SSID"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automatic suspend"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_When the Power Button is pressed"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~| msgid "Brightness Settings"
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Night Light"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Could not get screen information"
+
+#~ msgid "hardware"
+#~ msgstr "hardware"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Switch to previous source"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Switch to next source"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Alternative switch to next source"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "English (United Kingdom)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "United Kingdom"
+
+#~ msgid "_Options"
+#~ msgstr "_Options"
+
+#~ msgid "Add input source"
+#~ msgstr "Add input source"
+
+#~ msgid "Remove input source"
+#~ msgstr "Remove input source"
+
+#~ msgid "Move input source up"
+#~ msgstr "Move input source up"
+
+#~ msgid "Move input source down"
+#~ msgstr "Move input source down"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Show input source keyboard layout"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Left"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Right"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimum"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maximum"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profile:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Test Speakers"
+
+#~ msgid "Peak detect"
+#~ msgstr "Peak detect"
+
+#~ msgid "Device"
+#~ msgstr "Device"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Speaker Testing for %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "C_hoose a device for sound output:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Settings for the selected device:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Input volume:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "C_hoose a device for sound input:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Sound Effects"
+
+#~ msgid "_Alert volume:"
+#~ msgstr "_Alert volume:"
+
+#~ msgid "Built-in"
+#~ msgstr "Built-in"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Sound Preferences"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Testing event sound"
+
+#~ msgid "From theme"
+#~ msgstr "From theme"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "C_hoose an alert sound:"
+
+#~ msgid "Stop"
+#~ msgstr "Stop"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrator"
+
+#~ msgid "page 3"
+#~ msgstr "page 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME Control Center"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "The control centre is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+
+#~ msgid "Quit"
+#~ msgstr "Quit"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Verify New Password"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Passwords do not match."
+
+#~ msgid "Show the overview"
+#~ msgstr "Show the overview"
+
+#~ msgid "Back­ground"
+#~ msgstr "Back­ground"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blue­tooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Colour"
+
+#~ msgid "Overview"
+#~ msgstr "Overview"
+
+#~| msgid "Default Applications"
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Defa­ult Applications"
+
+#~ msgid "Ab­out"
+#~ msgstr "Ab­out"
+
+#~ msgid "De­tails"
+#~ msgstr "De­tails"
+
+#~| msgid "Removable Media"
+#~ msgid "Remo­vable Media"
+#~ msgstr "Remo­vable Media"
+
+#~ msgid "Net­work"
+#~ msgstr "Net­work"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "No­ti­fi­ca­tions"
+
+#~ msgid "Po­wer"
+#~ msgstr "Po­wer"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Pri­va­cy"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Sha­ring"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Uni­ver­sal Access"
+
+#~ msgid "Disable image"
+#~ msgstr "Disable image"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Browse for more pictures…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Used by %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wa­com Tab­let"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "System"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Lid Closed"
+
+#~ msgid "Mirrored"
+#~ msgstr "Mirrored"
+
+#~ msgid "Secondary"
+#~ msgstr "Secondary"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Arrange Combined Displays"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Drag displays to rearrange them"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Rotate anticlockwise by 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Rotate by 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Rotate clockwise by 90°"
+
+#~ msgid "Size"
+#~ msgstr "Size"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Show the top bar and Activities Overview on this display"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Join this display with another to create an extra workspace"
+
+#~ msgid "Presentation"
+#~ msgstr "Presentation"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Show slideshows and media only"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Show your existing view on both displays"
+
+#~ msgid "Turn Off"
+#~ msgstr "Turn Off"
+
+#~ msgid "Don't use this display"
+#~ msgstr "Don't use this display"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Arrange Combined Displays"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (Build ID: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "Base system"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Press Esc to cancel."
+
+#~ msgid "Server"
+#~ msgstr "Server"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Delete DNS Server"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Make available to other _users"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Firewall _Zone"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Default"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "The zone defines the trust level of the connection"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Add Profile…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "None"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manual"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatic"
+
+#~ msgid "Add Device"
+#~ msgstr "Add Device"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN Type"
+
+#~ msgid "Group Name"
+#~ msgstr "Group Name"
+
+#~ msgid "Group Password"
+#~ msgstr "Group Password"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Use as Hotspot…"
+
+#~ msgid "_History"
+#~ msgstr "_History"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Notification _Banners"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Notification _Banners"
+
+#~ msgid "Add Account"
+#~ msgstr "Add Account"
+
+#~ msgid "Mail"
+#~ msgstr "Mail"
+
+#~ msgid "Calendar"
+#~ msgstr "Calendar"
+
+#~ msgid "Contacts"
+#~ msgstr "Contacts"
+
+#~ msgid "Chat"
+#~ msgstr "Chat"
+
+#~ msgid "Error creating account"
+#~ msgstr "Error creating account"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Are you sure you want to remove the account?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "This will not remove the account on the server."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "No online accounts configured"
+
+#~ msgid "Add an online account"
+#~ msgstr "Add an online account"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Configuring"
+
+#~ msgid "Toner Level"
+#~ msgstr "Toner Level"
+
+#~ msgid "Supply Level"
+#~ msgstr "Supply Level"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Installing"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u active"
+#~ msgstr[1] "%u active"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Add a New Printer"
+
+#~ msgid "No printers detected."
+#~ msgstr "No printers detected."
+
+#~ msgid "Supply"
+#~ msgstr "Supply"
+
+#~ msgid "Jobs"
+#~ msgstr "Jobs"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Show _Jobs"
+
+#~ msgid "label"
+#~ msgstr "label"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Print _Test Page"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Try to add more letters, numbers and symbols."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Strength: Weak"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Strength: Low"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Strength: Medium"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Strength: Good"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Strength: High"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s–%s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Other Accounts"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Up"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Down"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "None"
+
+#~ msgid "Left Ring"
+#~ msgstr "Left Ring"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Left Ring Mode #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Right Ring Mode #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Left Touchstrip"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Left Touchstrip Mode #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Right Touchstrip"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Right Touchstrip Mode #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Left Touchring Mode Switch"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Right Touchring Mode Switch"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Left Touchstrip Mode Switch"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Right Touchstrip Mode Switch"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Mode Switch #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Left Button #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Right Button #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Top Button #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Bottom Button #%d"
+
+#~ msgid "No Action"
+#~ msgstr "No Action"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Left Mouse Button Click"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Scroll Up"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Scroll Down"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Scroll Right"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Set Up New Device"
+
+#~ msgid "Paired"
+#~ msgstr "Paired"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Mouse & Touchpad Settings"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Keyboard Settings"
+
+#~ msgid "Send Files…"
+#~ msgstr "Send Files…"
+
+#~ msgid "Yes"
+#~ msgstr "Yes"
+
+#~ msgid "Visibility"
+#~ msgstr "Visibility"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Visibility of “%s”"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Remove ‘%s’ from the list of devices?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+
+#~ msgid "Done"
+#~ msgstr "Done"
+
+#~ msgid "Device type:"
+#~ msgstr "Device type:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Manufacturer:"
+
+#~ msgid "Model:"
+#~ msgstr "Model:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+
+#~ msgid "United States"
+#~ msgstr "United States"
+
+#~ msgid "Germany"
+#~ msgstr "Germany"
+
+#~ msgid "France"
+#~ msgstr "France"
+
+#~ msgid "Spain"
+#~ msgstr "Spain"
+
+#~ msgid "China"
+#~ msgstr "China"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Switch between AM and PM."
+
+#~ msgid "Time _Zone"
+#~ msgstr "Time _Zone"
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "Show your primary display on this screen also"
+
+#~ msgid "Combine"
+#~ msgstr "Combine"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "Join with the primary display to create an extra space"
+
+#~ msgid "Install Updates"
+#~ msgstr "Install Updates"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "System Up-To-Date"
+
+#~ msgid "C_ommand:"
+#~ msgstr "C_ommand:"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Delay:"
+
+#~ msgid "_Speed:"
+#~ msgstr "_Speed:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Short"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Slow"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Long"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Fast"
+
+#~ msgid "S_peed:"
+#~ msgstr "S_peed:"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Remove Shortcut"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Unknown Action>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Reassign"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Test Your Settings"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Mouse Preferences"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Slow"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Fast"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Left"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Right"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Pointer speed"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Slow"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Fast"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Slow"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Fast"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Disable while _typing"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "The system network services are not compatible with this version."
+
+#~ msgid "Bond"
+#~ msgstr "Bond"
+
+#~ msgid "Bridge"
+#~ msgstr "Bridge"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Could not load VPN plugins"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Add Network Connection"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Bond slaves"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Bridge slaves"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Select the interface to use for the new service"
+
+#~ msgid "C_reate…"
+#~ msgstr "C_reate…"
+
+#~ msgid "_Interface"
+#~ msgstr "_Interface"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand device does not support connected mode"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "No Certificate Authority certificate chosen"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignore"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Choose CA Certificate"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "As_k for this password every time"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Don’t _warn me again"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Show Popup Banners"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "View in Lock Screen"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Show Pop Up Banners"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Error logging into the account"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Credentials have expired."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Sign in to enable this account."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Sign In"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "Estimated battery capacity: %s"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Turns off wireless devices"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "When battery power is _critical"
+
+#~ msgid "No printers available"
+#~ msgstr "No printers available"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Resume Printing"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Pause Printing"
+
+#~ msgid "Cancel Print Job"
+#~ msgstr "Cancel Print Job"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Search for network printers or filter result"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Enter address of a printer or a text to filter results"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Held"
+
+#~ msgid "Job Title"
+#~ msgstr "Job Title"
+
+#~ msgid "Job State"
+#~ msgstr "Job State"
+
+#~ msgid "_Default"
+#~ msgstr "_Default"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Add New Printer"
+
+#~ msgid "Immediately"
+#~ msgstr "Immediately"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "None"
+
+#~ msgid "Sorry"
+#~ msgstr "Sorry"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Other"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Share Public Folder"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Only Receive From Trusted Devices"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Save Received Files to Downloads Folder"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Only share with Trusted Devices"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Share Media On This Network"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Shared Folders"
+
+#~ msgid "column"
+#~ msgstr "column"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Remove Folder"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Share Public Folder On This Network"
+
+#~ msgid "Remote View"
+#~ msgstr "Remote View"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Approve All Connections"
+
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Colour"
+
+#~ msgid "_Verify"
+#~ msgstr "_Verify"
+
+#~ msgid "Login History"
+#~ msgstr "Login History"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Changing photo for:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+
+#~ msgid "Gallery"
+#~ msgstr "Gallery"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Take a photograph"
+
+#~ msgid "Browse"
+#~ msgstr "Browse"
+
+#~ msgid "Photograph"
+#~ msgstr "Photograph"
+
+#~ msgid "Add User Account"
+#~ msgstr "Add User Account"
+
+#~ msgid "A user with the username '%s' already exists"
+#~ msgstr "A user with the username ‘%s’ already exists"
+
+#~ msgid "Show help options"
+#~ msgstr "Show help options"
+
+#~ msgid "- Settings"
+#~ msgstr "- Settings"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Run ‘%s --help’ to see a full list of available command line options.\n"
+
+#~ msgid "Export"
+#~ msgstr "Export"
+
+#~ msgid "Left Shift"
+#~ msgstr "Left Shift"
+
+#~ msgid "Right Shift"
+#~ msgstr "Right Shift"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Left Alt+Shift"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Right Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Left Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Right Ctrl+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Left+Right Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Left+Right Ctrl"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "_Region:"
+#~ msgstr "_Region:"
+
+#~ msgid "_City:"
+#~ msgstr "_City:"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Set the time one hour ahead."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Set the time one hour back."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Set the time one minute ahead."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Set the time one minute back."
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Clockwise"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 Degrees"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %H:%M"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Could not save the monitor configuration"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Resolution"
+
+#~ msgid "R_otation"
+#~ msgstr "R_otation"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Mirror displays"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Note: may limit resolution options"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "Slow"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "Fast"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "C_ontent sticks to fingers"
+
+#~ msgid "_Options…"
+#~ msgstr "_Options…"
+
+#~ msgid "blablabla"
+#~ msgstr "blablabla"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "Hidden"
+#~ msgstr "Hidden"
+
+#~ msgid "Visible"
+#~ msgstr "Visible"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "Name & Visibility"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "Control how you appear on the screen and the network."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "Display _full name in top bar"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "Display full name in _lock screen"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "_Stealth Mode"
+
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "None"
+
+#~ msgid "No shortcut set"
+#~ msgstr "No shortcut set"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "High/Inverse"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "On-screen keyboard"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Beep on Caps and Num Lock"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "Turn on or off:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Zoom in:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Zoom out:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "Closed Captioning"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Display a textual description of speech and sounds"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "On Screen Keyboard"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "Short"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "Long"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Beep when a key is"
+
+#~ msgid "pressed"
+#~ msgstr "pressed"
+
+#~ msgid "accepted"
+#~ msgstr "accepted"
+
+#~ msgid "rejected"
+#~ msgstr "rejected"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "Acc_eptance delay:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Control the pointer using the keypad"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Video Mouse"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Control the pointer using the video camera."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "Small"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "Large"
+
+#~ msgid "_Local Account"
+#~ msgstr "_Local Account"
+
+#~ msgid "_Login Name"
+#~ msgstr "_Login Name"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "Tip: Enterprise domain or realm name"
+
+#~ msgid "C_ontinue"
+#~ msgstr "C_ontinue"
+
+#~ msgid "Next Week"
+#~ msgstr "Next Week"
+
+#~ msgid "Next week"
+#~ msgstr "Next week"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Log in without a password"
+
+#~ msgid "Disable this account"
+#~ msgstr "Disable this account"
+
+#~ msgid "Enable this account"
+#~ msgstr "Enable this account"
+
+#~ msgid "_Action"
+#~ msgstr "_Action"
+
+#~ msgid "_Show password"
+#~ msgstr "_Show password"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "How to choose a strong password"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Too short"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "Not good enough"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Weak"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Fair"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Good"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Strong"
+
+#~ msgid "_Generate a password"
+#~ msgstr "_Generate a password"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "You need to enter a new password"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "The new password is not strong enough"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "You need to confirm the password"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "You need to enter your current password"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "The current password is not correct"
+
+#~ msgid "Switch Modes"
+#~ msgstr "Switch Modes"
+
+#~ msgid "Action"
+#~ msgstr "Action"
+
+#~ msgid "Browse Files..."
+#~ msgstr "Browse Files…"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Create virtual device"
+#~ msgstr "Create virtual device"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Available Profiles for Displays"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Available Profiles for Scanners"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Available Profiles for Printers"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Available Profiles for Cameras"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Available Profiles for Webcams"
+
+#~ msgid "Available Profiles"
+#~ msgstr "Available Profiles"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i year"
+#~ msgstr[1] "%i years"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i month"
+#~ msgstr[1] "%i months"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i week"
+#~ msgstr[1] "%i weeks"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "Less than 1 week"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "This device is not colour managed."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "This device is using manufacturing calibrated data."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "This device does not have a profile suitable for whole-screen colour "
+#~ "correction."
+
+#~ msgid "Not specified"
+#~ msgstr "Not specified"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "No devices supporting colour management detected"
+
+#~ msgid "Add device"
+#~ msgstr "Add device"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "Add a virtual device"
+
+#~ msgid "Color management settings"
+#~ msgstr "Colour management settings"
+
+#~ msgid "English"
+#~ msgstr "English"
+
+#~ msgid "British English"
+#~ msgstr "British English"
+
+#~ msgid "French"
+#~ msgstr "French"
+
+#~ msgid "Spanish"
+#~ msgstr "Spanish"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chinese (simplified)"
+
+#~ msgid "Russian"
+#~ msgstr "Russian"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabic"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Date and Time preferences panel"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "Unknown model"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "The next login will attempt to use the standard experience."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Fallback"
+
+#~ msgid "_Other Media..."
+#~ msgstr "_Other Media…"
+
+#~ msgid "Experience"
+#~ msgstr "Experience"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "Forced _Fallback Mode"
+
+#~ msgid "Layout Settings"
+#~ msgstr "Layout Settings"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Set your mouse and touchpad preferences"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "Network;Wireless;IP;LAN;Proxy;"
+
+#~ msgid "Out of range"
+#~ msgstr "Out of range"
+
+#~ msgid "_Options..."
+#~ msgstr "_Options…"
+
+#~ msgid "C_reate..."
+#~ msgstr "C_reate…"
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "Wireless Hotspot"
+
+#~ msgid "Wireless"
+#~ msgstr "Wireless"
+
+#~ msgid "_Disconnect"
+#~ msgstr "_Disconnect"
+
+#~ msgid "_Connect"
+#~ msgstr "_Connect"
+
+#~ msgid "Mesh"
+#~ msgstr "Mesh"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "Carrier/link changed"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "Expired credentials. Please log in again."
+
+#~ msgid "_Log In"
+#~ msgstr "_Log In"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "Manage online accounts"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "Caution low battery, %s remaining"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "Using battery power - %s remaining"
+
+#~ msgid "Using battery power"
+#~ msgstr "Using battery power"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "Charging - fully charged"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "Using UPS power - %s remaining"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "Caution low UPS"
+
+#~ msgid "Using UPS power"
+#~ msgstr "Using UPS power"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "Your secondary battery is fully charged"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "Your secondary battery is empty"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "Charging - fully charged"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+
+#~ msgid "Power management settings"
+#~ msgstr "Power management settings"
+
+#~ msgid "Don't suspend"
+#~ msgstr "Don't suspend"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "Suspend when inactive for"
+
+#~ msgid "Manufacturers"
+#~ msgstr "Manufacturers"
+
+#~ msgid "Drivers"
+#~ msgstr "Drivers"
+
+#~ msgid "_Show"
+#~ msgstr "_Show"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "Change your region and language settings"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "Select an input source to add"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+
+#~ msgid "Copy Settings"
+#~ msgstr "Copy Settings"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "Copy Settings…"
+
+#~ msgid "Region and Language"
+#~ msgstr "Region and Language"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Select a display language (change will be applied next time you log in)"
+
+#~ msgid "Add Language"
+#~ msgstr "Add Language"
+
+#~ msgid "Remove Language"
+#~ msgstr "Remove Language"
+
+#~ msgid "Install languages..."
+#~ msgstr "Install languages…"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "Select a region (change will be applied the next time you log in)"
+
+#~ msgid "Add Region"
+#~ msgstr "Add Region"
+
+#~ msgid "Currency"
+#~ msgstr "Currency"
+
+#~ msgid "Examples"
+#~ msgstr "Examples"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "Select keyboards or other input sources"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "Shortcut Settings"
+
+#~ msgid "Input source:"
+#~ msgstr "Input source:"
+
+#~ msgid "Format:"
+#~ msgstr "Format:"
+
+#~ msgid "Your settings"
+#~ msgstr "Your settings"
+
+#~ msgid "System settings"
+#~ msgstr "System settings"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "Brightness & Lock"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Brightness;Lock;Dim;Blank;Monitor;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "_Dim screen to save power"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "Don't lock when at home"
+
+#~ msgid "Locations..."
+#~ msgstr "Locations…"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Enable debugging code"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME Volume Control Applet"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Show desktop volume control"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Sound Output Volume"
+
+#~ msgid "_Mute"
+#~ msgstr "_Mute"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "_Sound Preferences"
+
+#~ msgid "Muted"
+#~ msgstr "Muted"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Universal Access Preferences"
+
+#~ msgid "Options..."
+#~ msgstr "Options…"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "Colour"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "None"
+
+#~ msgid "User Accounts"
+#~ msgstr "User Accounts"
+
+#~ msgid "_Hint"
+#~ msgstr "_Hint"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+
+#~ msgid "Fair"
+#~ msgstr "Fair"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Browse for more pictures…"
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "No user with the name '%s' exists."
+
+#~ msgid "This user does not exist."
+#~ msgstr "This user does not exist."
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Set your Wacom tablet preferences"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "Map Buttons…"
+
+#~ msgid "Calibrate..."
+#~ msgstr "Calibrate…"
+
+#~ msgid "- System Settings"
+#~ msgstr "- System Settings"
+
+#~ msgid "System Settings"
+#~ msgstr "System Settings"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "Subnet Mask"
+
+#~ msgid "_Search by Address"
+#~ msgstr "_Search by Address"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "Local"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "Network"
+
+#~ msgid "Device types"
+#~ msgstr "Device types"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "Automatic configuration"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "Opening firewall for mDNS connections"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Opening firewall for Samba connections"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "Opening firewall for IPP connections"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "Add wallpaper"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "Remove wallpaper"
+
+#~ msgid "Swap colors"
+#~ msgstr "Swap colours"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Horizontal Gradient"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Vertical Gradient"
+
+#~ msgid "Solid Color"
+#~ msgstr "Solid Colour"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "Colours & Gradients"
+
+#~ msgid "Acti_on:"
+#~ msgstr "Acti_on:"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Take a screenshot"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_Right-handed"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Left-handed"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Sh_ow position of pointer when the Control key is pressed"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "A_cceleration:"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Sensitivity:"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "Drag and Drop"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "Thr_eshold:"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "Drag Threshold"
+
+#~ msgid "_Timeout:"
+#~ msgstr "_Timeout:"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "To test your settings, try to double-click on the face."
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "Enable _mouse clicks with touchpad"
+
+#~ msgid "_Disabled"
+#~ msgstr "_Disabled"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "Other…"
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "Create the hotspot anyway?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "Disconnect from %s and create a new hotspot?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "This is your only connection to the internet."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "Create _Hotspot"
+
+#~ msgid "_Network Name"
+#~ msgstr "_Network Name"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "_Stop Hotspot…"
+
+#~ msgid "Disable VPN"
+#~ msgstr "Disable VPN"
+
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP Port"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "HTTPS Port"
+
+#~ msgid "FTP Port"
+#~ msgstr "FTP Port"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "To add a new account, first select the account type"
+
+#~ msgid "_Add..."
+#~ msgstr "_Add…"
+
+#~ msgid "Select an account"
+#~ msgstr "Select an account"
+
+#~ msgid "Tip:"
+#~ msgstr "Tip:"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "affect how much power is used"
+
+#~ msgid "_Back"
+#~ msgstr "_Back"
+
+#~ msgid "Allowed users"
+#~ msgstr "Allowed users"
+
+#~ msgid "Add Layout"
+#~ msgstr "Add Layout"
+
+#~ msgid "Remove Layout"
+#~ msgstr "Remove Layout"
+
+#~ msgid "Preview Layout"
+#~ msgstr "Preview Layout"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "New windows use the default layout"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "New windows use the previous window's layout"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "View and edit keyboard layout options"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "Reset to De_faults"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+
+#~ msgid "Layouts"
+#~ msgstr "Layouts"
+
+#~ msgid "Layout"
+#~ msgstr "Layout"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~ msgid "Change contrast:"
+#~ msgstr "Change contrast:"
+
+#~ msgid "_Text size:"
+#~ msgstr "_Text size:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "Type here to test settings"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 Screen"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 Screen"
+
+#~ msgid "Create new account"
+#~ msgstr "Create new account"
+
+#~ msgid "_Account Type"
+#~ msgstr "_Account Type"
+
+#~ msgid "Cr_eate"
+#~ msgstr "Cr_eate"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "Choose a generated password"
+
+#~ msgid "Account _type"
+#~ msgstr "Account _type"
+
+#~ msgid "More choices..."
+#~ msgstr "More choices…"
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Wacom Graphics Tablet"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "Could not get session bus while applying display configuration"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "Toggle contrast"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "Toggle magnifier"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "Toggle screen reader"
+
+#~ msgid "Accelerator key"
+#~ msgstr "Accelerator key"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Accelerator modifiers"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Accelerator keycode"
+
+#~ msgid "Accel Mode"
+#~ msgstr "Accel Mode"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "The type of accelerator."
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Too many custom shortcuts"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "Media and Autorun"
+
+#~ msgid "_Photos:"
+#~ msgstr "_Photos:"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "Configure media and autorun preferences"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "cd;dvd;usb;audio;video;disc;"
+
+#~ msgid "Battery discharging"
+#~ msgstr "Battery discharging"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s until charged (%.0lf%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s until empty (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% charged"
+
+#~ msgid "Ask me"
+#~ msgstr "Ask me"
+
+#~ msgid "Shutdown"
+#~ msgstr "Shutdown"
+
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr ""
+#~ "Only profiles that are compatible with the device will be listed above."
+
+#~ msgid "_Turn off after:"
+#~ msgstr "_Turn off after:"
+
+#~ msgid "Key"
+#~ msgstr "Key"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf key to which this property editor is attached"
+
+#~ msgid "Callback"
+#~ msgstr "Callback"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Issue this callback when the value associated with key gets changed"
+
+#~ msgid "Change set"
+#~ msgstr "Change set"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Conversion to widget callback"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Conversion from widget callback"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+
+#~ msgid "UI Control"
+#~ msgstr "UI Control"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Object that controls the property (normally a widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Property editor object data"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Custom data required by the specific property editor"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Property editor data freeing callback"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Callback to be issued when property editor object data is to be freed"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+
+#~ msgid "Please select an image."
+#~ msgstr "Please select an image."
+
+#~ msgid "Create a user"
+#~ msgstr "Create a user"
+
+#~ msgid "Upside-down"
+#~ msgstr "Upside-down"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "Dialogue is unlocked.\n"
+#~ "Click to prevent further changes"
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "Dialogue is locked.\n"
+#~ "Click to make changes"
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+
+#~ msgid "24-Hour Time"
+#~ msgstr "24-Hour Time"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f KB"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f MB"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f GB"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TB"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PB"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EB"
+
+#~ msgid "Photos"
+#~ msgstr "Photos"
+
+#~ msgid "Web"
+#~ msgstr "Web"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "Use default layout in new windows"
+
+#~ msgid "Use previous window's layout in new windows"
+#~ msgstr "Use previous window's layout in new windows"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "_Acceleration:"
+
+#~ msgid "On AC power:"
+#~ msgstr "On AC power:"
+
+#~ msgid "When the sleep button is pressed:"
+#~ msgstr "When the sleep button is pressed:"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "Keyboard;Mouse;a11y;Accessibility;"
+
+#~ msgid "Beep when a modifer key is pressed"
+#~ msgstr "Beep when a modifer key is pressed"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">High/Inverse</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">High</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">Low</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">Normal</span>"
+
+#~ msgid "Current network location"
+#~ msgstr "Current network location"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "More backgrounds URL"
+
+#~ msgid "More themes URL"
+#~ msgstr "More themes URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+
+#~ msgid "16"
+#~ msgstr "16"
+
+#~ msgid "2010"
+#~ msgstr "2010"
+
+#~ msgid "An error has occured during a maintenance command."
+#~ msgstr "An error has occurred during a maintenance command."
+
+#~ msgid "Info"
+#~ msgstr "Info"
+
+#~ msgid "Set the system proxy settings"
+#~ msgstr "Set the system proxy settings"
+
+#~ msgid "The running NetworkManager version is not compatible (too new)."
+#~ msgstr "The running NetworkManager version is not compatible (too new)."
+
+#~ msgid "The running NetworkManager version is not compatible (too old)."
+#~ msgstr "The running NetworkManager version is not compatible (too old)."
+
+#~ msgid "IP Address:"
+#~ msgstr "IP Address:"
+
+#~ msgid "Secure HTTP Proxy:"
+#~ msgstr "Secure HTTP Proxy:"
+
+#~ msgid "Preparing connection"
+#~ msgstr "Preparing connection"
+
+#~ msgctxt "Account type"
+#~ msgid "Supervised"
+#~ msgstr "Supervised"
+
+#~ msgid "More Info"
+#~ msgstr "More Info"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "Error unsetting accelerator in configuration database: %s"
+
+#~ msgctxt "printer state"
+#~ msgid "Idle"
+#~ msgstr "Idle"
+
+#~ msgid "%i kb/s"
+#~ msgstr "%i kb/s"
+
+#~ msgid "Ctrl+Alt+0"
+#~ msgstr "Ctrl+Alt+0"
+
+#~ msgid "Ctrl+Alt+4"
+#~ msgstr "Ctrl+Alt+4"
+
+#~ msgid "Ctrl+Alt+8"
+#~ msgstr "Ctrl+Alt+8"
+
+#~ msgid "Ctrl+Alt+="
+#~ msgstr "Ctrl+Alt+="
+
+#~ msgid "LowContrast"
+#~ msgstr "LowContrast"
+
+#~ msgid "Shift+Ctrl+Alt+-"
+#~ msgstr "Shift+Ctrl+Alt+-"
+
+#~ msgid "Shift+Ctrl+Alt+="
+#~ msgstr "Shift+Ctrl+Alt+="
+
+#~ msgid "Use an alternative form of text input"
+#~ msgstr "Use an alternative form of text input"
+
+#~ msgid "Language:"
+#~ msgstr "Language:"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "Preferred Applications"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "Start the preferred visual assistive technology"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "Visual Assistance"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Could not load the main interface"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "All %s occurrences will be replaced with actual link"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Co_mmand:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "E_xecute flag:"
+
+#~ msgid "Image Viewer"
+#~ msgstr "Image Viewer"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "Instant Messenger"
+
+#~ msgid "Internet"
+#~ msgstr "Internet"
+
+#~ msgid "Mail Reader"
+#~ msgstr "Mail Reader"
+
+#~ msgid "Mobility"
+#~ msgstr "Mobility"
+
+#~ msgid "Multimedia"
+#~ msgstr "Multimedia"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Open link in new _tab"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Open link in new _window"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Open link with web browser _default"
+
+#~ msgid "Run at st_art"
+#~ msgstr "Run at st_art"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Run in t_erminal"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "Terminal Emulator"
+
+#~ msgid "Text Editor"
+#~ msgstr "Text Editor"
+
+#~ msgid "Visual"
+#~ msgstr "Visual"
+
+#~ msgid "_Run at start"
+#~ msgstr "_Run at start"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee Music Player"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian Sensible Browser"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian Terminal Emulator"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Epiphany Web Browser"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution Mail Reader"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "GNOME Magnifier without Screen Reader"
+
+#~ msgid "GNOME OnScreen Keyboard"
+#~ msgstr "GNOME OnScreen Keyboard"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus with Magnifier"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape Mail"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "KDE Magnifier without Screen Reader"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Linux Screen Reader"
+#~ msgstr "Linux Screen Reader"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Linux Screen Reader with Magnifier"
+
+#~ msgid "Listen"
+#~ msgstr "Listen"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "Muine Music Player"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "Orca with Magnifier"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox Music Player"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey Mail"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem Movie Player"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Include _panel"
+#~ msgstr "Include _panel"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "Sa_me image in all monitors"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "_Detect monitors"
+
+#~ msgid "Monitors"
+#~ msgstr "Monitors"
+
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "This program can only be used by the root user"
+
+#~ msgid "The source filename must be absolute"
+#~ msgstr "The source filename must be absolute"
+
+#~ msgid "Could not get information for %s: %s\n"
+#~ msgstr "Could not get information for %s: %s\n"
+
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s must be a regular file\n"
+
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "This program must only be run through pkexec(1)"
+
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "PKEXEC_UID must be set to an integer value"
+
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "%s must be owned by you\n"
+
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s must not have any directory components\n"
+
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s must be a directory\n"
+
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "Could not open %s/%s: %s\n"
+
+#~ msgid ""
+#~ "Authentication is required to install multi-monitor settings for all users"
+#~ msgstr ""
+#~ "Authentication is required to install multi-monitor settings for all users"
+
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "Install multi-monitor settings for the whole system"
+
+#~ msgid "Upside Down"
+#~ msgstr "Upside Down"
+
+#~ msgid "Mirror Screens"
+#~ msgstr "Mirror Screens"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "Monitor: %s"
+
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "The monitor configuration has been saved"
+
+#~ msgid "This configuration will be used the next time someone logs in."
+#~ msgstr "This configuration will be used the next time someone logs in."
+
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "Could not set the default configuration for monitors"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Assign shortcut keys to commands"
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "Beep when a _toggle key is pressed"
+
+#~ msgid "Beep when a key is reje_cted"
+#~ msgstr "Beep when a key is reje_cted"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Beep when key is _rejected"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Flash _window titlebar"
+
+#~ msgid "Flash entire _screen"
+#~ msgstr "Flash entire _screen"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Keyboard Accessibility Audio Feedback"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "Show _visual feedback for the alert sound"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "Visual cues for sounds"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "All_ow postponing of breaks"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Audio _Feedback…"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Check if breaks are allowed to be postponed"
+
+#~ msgid "Disa_ble sticky keys if two keys are pressed together"
+#~ msgstr "Disa_ble sticky keys if two keys are pressed together"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Duration of the break when typing is disallowed"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Duration of work before forcing a break"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Keyboard _model:"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "Move the selected keyboard layout up in the list"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "Print a diagram of the selected keyboard layout"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "Remove the selected keyboard layout from the list"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "Select a keyboard layout to be added to the list"
+
+#~ msgid "Typing Break"
+#~ msgstr "Typing Break"
+
+#~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#~ msgstr "_Accessibility features can be toggled with keyboard shortcuts"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Break interval lasts:"
+
+#~ msgid "_Ignore fast duplicate keypresses"
+#~ msgstr "_Ignore fast duplicate keypresses"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "_Lock screen to enforce typing break"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_Only accept long keypresses"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "_Pointer can be controlled using the keypad"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Simulate simultaneous keypresses"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Type to test settings:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Work interval lasts:"
+
+#~ msgid "By _language"
+#~ msgstr "By _language"
+
+#~ msgid "Preview:"
+#~ msgstr "Preview:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variants:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Choose a Keyboard Model"
+
+#~ msgid "_Models:"
+#~ msgstr "_Models:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_Vendors:"
+
+#~ msgid "Vendors"
+#~ msgstr "Vendors"
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Unable to load stock icon '%s'\n"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "Move left"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "Move right"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "Move up"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "Move down"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "Disabled"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Choose type of click _beforehand"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "Choose type of click with mo_use gestures"
+
+#~ msgid "D_rag click:"
+#~ msgstr "D_rag click:"
+
+#~ msgid "Dwell Click"
+#~ msgstr "Dwell Click"
+
+#~ msgid "Show click type _window"
+#~ msgstr "Show click type _window"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "_Initiate click when stopping pointer movement"
+
+#~ msgid "_Single click:"
+#~ msgstr "_Single click:"
+
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr "_Trigger secondary click by holding down the primary button"
+
+#~ msgid "Location already exists"
+#~ msgstr "Location already exists"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Set your network proxy preferences"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_Manual proxy configuration</b>"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP Proxy Details"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "Ignore Host List"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Network Proxy Preferences"
+
+#~ msgid "The location already exists."
+#~ msgstr "The location already exists."
+
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "_Use the same proxy for all protocols"
+
+#~ msgid ""
+#~ "Accessibility features can be turned on or off with keyboard shortcuts"
+#~ msgstr ""
+#~ "Accessibility features can be turned on or off with keyboard shortcuts"
+
+#~ msgid "I need assistance with:"
+#~ msgstr "I need assistance with:"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "The GNOME configuration tool"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_Postpone Break"
+
+#~ msgid "_Take a Break"
+#~ msgstr "_Take a Break"
+
+#~ msgid "Take a break now (next in %dm)"
+#~ msgstr "Take a break now (next in %dm)"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d minute until the next break"
+#~ msgstr[1] "%d minutes until the next break"
+
+#~ msgid "Take a break now (next in less than one minute)"
+#~ msgstr "Take a break now (next in less than one minute)"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Less than one minute until the next break"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Unable to bring up the typing break properties dialogue with the "
+#~ "following error: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Written by Richard Hult <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Eye candy added by Anders Carlsson"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "A computer break reminder."
+
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "David Lodge <dave@cirt.net>\n"
+#~ "Philip Withnall <philip@tecnocode.co.uk>\n"
+#~ "Bruce Cowan <bruce@bcowan.me.uk>"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Don't check whether the notification area exists"
+
+#~ msgid "Typing Monitor"
+#~ msgstr "Typing Monitor"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "If set to true, then OpenType fonts will be thumbnailed."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "If set to true, then PCF fonts will be thumbnailed."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "If set to true, then TrueType fonts will be thumbnailed."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "If set to true, then Type1 fonts will be thumbnailed."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for PCF fonts."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Thumbnail command for OpenType fonts"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Thumbnail command for PCF fonts"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Thumbnail command for TrueType fonts"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Thumbnail command for Type1 fonts"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Whether to thumbnail OpenType fonts"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Whether to thumbnail PCF fonts"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Whether to thumbnail TrueType fonts"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Whether to thumbnail Type1 fonts"
+
+#~ msgid "Copyright:"
+#~ msgstr "Copyright:"
+
+#~ msgid "Description:"
+#~ msgstr "Description:"
+
+#~ msgid "Installed"
+#~ msgstr "Installed"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "usage: %s fontfile\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "I_nstall Font"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Text to thumbnail (default: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Font size (default: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "Example preferences panel"
+#~ msgstr "Example preferences panel"
+
+#~ msgid "Image/label border"
+#~ msgstr "Image/label border"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "Width of border around the label and image in the alert dialogue"
+
+#~ msgid "The type of alert"
+#~ msgstr "The type of alert"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "The buttons shown in the alert dialogue"
+
+#~ msgid "Show more _details"
+#~ msgstr "Show more _details"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "Place your left thumb on %s"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "Swipe your left thumb on %s"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "Place your left index finger on %s"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "Swipe your left index finger on %s"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "Place your left middle finger on %s"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "Swipe your left middle finger on %s"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "Place your left ring finger on %s"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "Swipe your left ring finger on %s"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "Place your left little finger on %s"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "Swipe your left little finger on %s"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "Place your right thumb on %s"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "Swipe your right thumb on %s"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "Place your right index finger on %s"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "Swipe your right index finger on %s"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "Place your right middle finger on %s"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "Swipe your right middle finger on %s"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "Place your right ring finger on %s"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "Swipe your right ring finger on %s"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "Place your right little finger on %s"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "Swipe your right little finger on %s"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "Place your finger on the reader again"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "Swipe your finger again"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "Swipe was too short, try again"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "Your finger was not centred, try swiping your finger again"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "Remove your finger, and try swiping your finger again"
+
+#~ msgid "No Image"
+#~ msgstr "No Image"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Unable to open address book"
+
+#~ msgid "About %s"
+#~ msgstr "About %s"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "About Me"
+#~ msgstr "About Me"
+
+#~ msgid "C_ompany:"
+#~ msgstr "C_ompany:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Change Passwo_rd…"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Ci_ty:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "Co_untry:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "Cou_ntry:"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "Disable _Fingerprint Login…"
+
+#~ msgid "Email"
+#~ msgstr "E-mail"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "Enable _Fingerprint Login…"
+
+#~ msgid "Hom_e:"
+#~ msgstr "Hom_e:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "Instant Messaging"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _box:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. box:"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Co_unty:"
+
+#~ msgid "Web _log:"
+#~ msgstr "Web _log:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "Wor_k:"
+
+#~ msgid "Work"
+#~ msgstr "Work"
+
+#~ msgid "Work _fax:"
+#~ msgstr "Work _fax:"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "_Post code:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Home page:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Home:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Manager:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_County:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Work:"
+
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "_Post code:"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "Swipe finger on reader"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "Place finger on reader"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "Child exited unexpectedly"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "Could not shutdown backend_stdin IO channel: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "Could not shutdown backend_stdout IO channel: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "System error: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "Unable to launch %s: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "Unable to launch backend"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "A system error has occurred"
+
+#~ msgid "Checking password..."
+#~ msgstr "Checking password…"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "Click <b>Change password</b> to change your password."
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "The two passwords are not equal."
+
+#~ msgid "Change your password"
+#~ msgstr "Change your password"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "Accessible Lo_gin"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "Assistive Technologies"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Assistive Technologies Preferences"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Close and _Log Out"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Jump to Preferred Applications dialogue"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "Jump to the Accessible Login dialogue"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "Jump to the Keyboard Accessibility dialogue"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Jump to the Mouse Accessibility dialogue"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Enable assistive technologies"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "_Mouse Accessibility"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "_Preferred Applications"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "Choose which accessibility features to enable when you log in"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Font may be too large"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[1] ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgstr[1] ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+
+#~ msgid "Use previous font"
+#~ msgstr "Use previous font"
+
+#~ msgid "Use selected font"
+#~ msgstr "Use selected font"
+
+#~ msgid "Could not load user interface file: %s"
+#~ msgstr "Could not load user interface file: %s"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Specify the filename of a theme to install"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER…]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+
+#~ msgid "Apply Background"
+#~ msgstr "Apply Background"
+
+#~ msgid "Apply Font"
+#~ msgstr "Apply Font"
+
+#~ msgid "Revert Font"
+#~ msgstr "Revert Font"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "The current theme suggests a background and a font."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "The current theme suggests a background."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "The last applied font suggestion can be reverted."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "The current theme suggests a font."
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "Appearance Preferences"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Best _shapes"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Best co_ntrast"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "C_ustomise…"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "Changing your cursor theme takes effect the next time you log in."
+
+#~ msgid "Controls"
+#~ msgstr "Controls"
+
+#~ msgid "Customize Theme"
+#~ msgstr "Customise Theme"
+
+#~ msgid "D_etails..."
+#~ msgstr "D_etails…"
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Des_ktop font:"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "Font Rendering Details"
+
+#~ msgid "Fonts"
+#~ msgstr "Fonts"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "Get more backgrounds online"
+
+#~ msgid "Get more themes online"
+#~ msgstr "Get more themes online"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Gre_yscale"
+
+#~ msgid "Icons"
+#~ msgstr "Icons"
+
+#~ msgid "Icons only"
+#~ msgstr "Icons only"
+
+#~ msgid "N_one"
+#~ msgstr "N_one"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Open a dialogue to specify the colour"
+
+#~ msgid "R_esolution:"
+#~ msgstr "R_esolution:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "Save Theme As…"
+
+#~ msgid "Save _As..."
+#~ msgstr "Save _As…"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sub_pixel (LCDs)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Sub_pixel smoothing (LCDs)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "Subpixel Order"
+
+#~ msgid "Text"
+#~ msgstr "Text"
+
+#~ msgid "Text below items"
+#~ msgstr "Text below items"
+
+#~ msgid "Text beside items"
+#~ msgstr "Text beside items"
+
+#~ msgid "Text only"
+#~ msgstr "Text only"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "The current controls theme does not support colour schemes."
+
+#~ msgid "Theme"
+#~ msgstr "Theme"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "_Description:"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Document font:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_Fixed width font:"
+
+#~ msgid "_Install..."
+#~ msgstr "_Install…"
+
+#~ msgid "_Medium"
+#~ msgstr "_Medium"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Monochrome"
+
+#~ msgid "_None"
+#~ msgstr "_None"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "_Reset to Defaults"
+
+#~ msgid "_Selected items:"
+#~ msgstr "_Selected items:"
+
+#~ msgid "_Size:"
+#~ msgstr "_Size:"
+
+#~ msgid "_Slight"
+#~ msgstr "_Slight"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "_Tooltips:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Window title font:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Windows:"
+
+#~ msgid "dots per inch"
+#~ msgstr "dots per inch"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Customise the look of the desktop"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Installs themes packages for various parts of the desktop"
+
+#~ msgid "Theme Installer"
+#~ msgstr "Theme Installer"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Gnome Theme Package"
+
+#~ msgid "Slide Show"
+#~ msgstr "Slide Show"
+
+#~ msgid "Image"
+#~ msgstr "Image"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "Cannot install theme"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "The %s utility is not installed."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "There was a problem while extracting the theme."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "There was an error installing the selected file"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" does not appear to be a valid theme."
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "Installation for theme \"%s\" failed."
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "The theme \"%s\" has been installed."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "Would you like to apply it now, or keep your current theme?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Keep Current Theme"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Apply New Theme"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME Theme %s correctly installed"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "New themes have been successfully installed."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "No theme file location specified to install"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "Select Theme"
+
+#~ msgid "Theme Packages"
+#~ msgstr "Theme Packages"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Theme name must be present"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "The theme already exists. Would you like to replace it?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_Overwrite"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Would you like to delete this theme?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "Could not install theme engine"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "There was an error displaying help: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Copying file: %u of %u"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "Copying '%s'"
+
+#~ msgid "Parent Window"
+#~ msgstr "Parent Window"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "Parent window of the dialogue"
+
+#~ msgid "From URI"
+#~ msgstr "From URI"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI currently transferring from"
+
+#~ msgid "To URI"
+#~ msgstr "To URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI currently transferring to"
+
+#~ msgid "Fraction completed"
+#~ msgstr "Fraction completed"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Fraction of transfer currently completed"
+
+#~ msgid "Current URI index"
+#~ msgstr "Current URI index"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Current URI index — starts from 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "Total URIs"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Total number of URIs"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "File '%s' already exists. Do you want to overwrite it?"
+
+#~ msgid "_Skip"
+#~ msgstr "_Skip"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "Overwrite _All"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Default Pointer — Current"
+
+#~ msgid "White Pointer"
+#~ msgstr "White Pointer"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "White Pointer — Current"
+
+#~ msgid "Large Pointer"
+#~ msgstr "Large Pointer"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Large Pointer — Current"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Large White Pointer — Current"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+
+#~ msgid "Monitor Preferences"
+#~ msgstr "Monitor Preferences"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Start the page with the typing break settings showing"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Start the page with the accessibility settings showing"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- GNOME Keyboard Preferences"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "Specify the name of the page to show (general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- GNOME Mouse Preferences"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "Cannot start the preferences application for your window manager"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "S_uper (or \"Windows logo\")"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "Titlebar Action"
+#~ msgstr "Titlebar Action"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "To move a window, press-and-hold this key then grab the window:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Window Preferences"
+
+#~ msgid "Window Selection"
+#~ msgstr "Window Selection"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Interval before raising:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Raise selected windows after an interval"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Select windows when the mouse moves over them"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Set your window properties"
+
+#~ msgid "Windows"
+#~ msgstr "Windows"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Window manager \"%s\" has not registered a configuration tool\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "Maximise Vertically"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Maximise Horizontally"
+
+#~ msgid "Roll up"
+#~ msgstr "Roll up"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "Hide on start (useful to preload the shell)"
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Groups"
+#~ msgstr "Groups"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Close the control-centre when a task is activated"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "Exit shell on add or remove action performed"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Exit shell on help action performed"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Exit shell on start action performed"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "Exit shell on upgrade or uninstall action performed"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr ""
+#~ "Indicates whether to close the shell when a help action is performed."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr ""
+#~ "Indicates whether to close the shell when a start action is performed."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "Task names and associated .desktop files"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "The task name to be displayed in the control-centre followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "if true, the control-centre will close when a \"Common Task\" is "
+#~ "activated."
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "Your filter \"%s\" does not match any items."
+
+#~ msgid "Upgrade"
+#~ msgstr "Upgrade"
+
+#~ msgid "Uninstall"
+#~ msgstr "Uninstall"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "Add to Favourites"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Remove from Startup Programs"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Add to Startup Programs"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "New Spreadsheet"
+
+#~ msgid "New Document"
+#~ msgstr "New Document"
+
+#~ msgctxt "Home folder"
+#~ msgid "Home"
+#~ msgstr "Home"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Open</b>"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "If you delete an item, it is permanently lost."
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "Open with \"%s\""
+
+#~ msgid "Open in File Manager"
+#~ msgstr "Open in File Manager"
+
+#~ msgid "Remove from recent menu"
+#~ msgstr "Remove from recent menu"
+
+#~ msgid "Purge all the recent items"
+#~ msgstr "Purge all the recent items"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Today %H:%M"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "Yesterday %H:%M"
+
+#~ msgid "Find Now"
+#~ msgstr "Find Now"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Open %s</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "Remove from System Items"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "Display Preferences"
+#~ msgstr "Display Preferences"
+
+#~ msgid "Drag the monitors to set their place"
+#~ msgstr "Drag the monitors to set their place"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Change screen resolution"
+
+#~ msgid "Menus and Toolbars"
+#~ msgstr "Menus and Toolbars"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Show _icons in menus"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Toolbar _button labels:"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "_Editable menu shortcut keys"
+
+#~ msgid "_File"
+#~ msgstr "_File"
+
+#~ msgid "Layout _Options..."
+#~ msgstr "Layout _Options…"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Selected layouts:"
+
+#~ msgid "C_ontrol"
+#~ msgstr "C_ontrol"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "The quick brown fox jumps over the lazy dog. 0123456789"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "Unknown login ID, the user database might be corrupted"
+
+#~ msgid ""
+#~ "Left thumb\n"
+#~ "Left middle finger\n"
+#~ "Left ring finger\n"
+#~ "Left little finger\n"
+#~ "Right thumb\n"
+#~ "Right middle finger\n"
+#~ "Right ring finger\n"
+#~ "Right little finger"
+#~ msgstr ""
+#~ "Left thumb\n"
+#~ "Left middle finger\n"
+#~ "Left ring finger\n"
+#~ "Left little finger\n"
+#~ "Right thumb\n"
+#~ "Right middle finger\n"
+#~ "Right ring finger\n"
+#~ "Right little finger"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Home</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Job</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Web</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Work</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>Assistive Technologies</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>Preferences</b>"
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>C_olours</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Preview</b>"
+
+#~ msgid "<b>_Desktop Background</b>"
+#~ msgstr "<b>_Desktop Background</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "C_ut"
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "Solid colour\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centred\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+
+#~ msgid "_New"
+#~ msgstr "_New"
+
+#~ msgid "_Print"
+#~ msgstr "_Print"
+
+#~ msgid "<b>Mobility</b>"
+#~ msgstr "<b>Mobility</b>"
+
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b>Visual</b>"
+
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+
+#~ msgid "Could not apply the selected configuration"
+#~ msgstr "Could not apply the selected configuration"
+
+#~ msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+#~ msgstr "Could not get org.gnome.SettingsDaemon.XRANDR"
+
+#~ msgid "<b>Bounce Keys</b>"
+#~ msgstr "<b>Bounce Keys</b>"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>General</b>"
+
+#~ msgid "<b>Slow Keys</b>"
+#~ msgstr "<b>Slow Keys</b>"
+
+#~ msgid "<b>Sticky Keys</b>"
+#~ msgstr "<b>Sticky Keys</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Fast</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Long</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Short</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Slow</i></small>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Locate Pointer</b>"
+
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i>High</i></small>"
+
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i>Large</i></small>"
+
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>Low</i></small>"
+
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i>Small</i></small>"
+
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>Ignore Host List</b>"
+
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>_Wallpaper</b>"
+
+#~ msgid "Monitor Resolution Settings"
+#~ msgstr "Monitor Resolution Settings"
+
+#~ msgid "Screen Resolution"
+#~ msgstr "Screen Resolution"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Retrieve and store legacy settings"
+
+#~ msgid "Unknown Volume Control %d"
+#~ msgstr "Unknown Volume Control %d"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - Advanced Linux Sound Architecture"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART Sound Daemon"
+
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ESD - Enlightened Sound Daemon"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - Open Sound System"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "PulseAudio Sound Server"
+
+#~ msgid "Silence"
+#~ msgstr "Silence"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "- GNOME Sound Preferences"
+
+#~ msgid "<b>Alerts and Sound Effects</b>"
+#~ msgstr "<b>Alerts and Sound Effects</b>"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>Audio Conferencing</b>"
+
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>Default Mixer Tracks</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Music and Movies</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>Sound Events</b>"
+
+#~ msgid "<b>Sound Theme</b>"
+#~ msgstr "<b>Sound Theme</b>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "Click OK to finish."
+
+#~ msgid "Play _sound effects when buttons are clicked"
+#~ msgstr "Play _sound effects when buttons are clicked"
+
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+#~ msgstr ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+
+#~ msgid "So_und playback:"
+#~ msgstr "So_und playback:"
+
+#~ msgid "Sou_nd capture:"
+#~ msgstr "Sou_nd capture:"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "Testing Pipeline"
+
+#~ msgid "_Play alerts and sound effects"
+#~ msgstr "_Play alerts and sound effects"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "_Sound playback:"
+
+#~ msgctxt "Sound event"
+#~ msgid "Windows and Buttons"
+#~ msgstr "Windows and Buttons"
+
+#~ msgctxt "Sound event"
+#~ msgid "Button clicked"
+#~ msgstr "Button clicked"
+
+#~ msgctxt "Sound event"
+#~ msgid "Toggle button clicked"
+#~ msgstr "Toggle button clicked"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window maximized"
+#~ msgstr "Window maximised"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window unmaximized"
+#~ msgstr "Window unmaximised"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window minimised"
+#~ msgstr "Window minimised"
+
+#~ msgctxt "Sound event"
+#~ msgid "Desktop"
+#~ msgstr "Desktop"
+
+#~ msgctxt "Sound event"
+#~ msgid "Logout"
+#~ msgstr "Logout"
+
+#~ msgctxt "Sound event"
+#~ msgid "New e-mail"
+#~ msgstr "New e-mail"
+
+#~ msgctxt "Sound event"
+#~ msgid "Long action completed (download, CD burning, etc.)"
+#~ msgstr "Long action completed (download, CD burning, etc.)"
+
+#~ msgctxt "Sound event"
+#~ msgid "Alerts"
+#~ msgstr "Alerts"
+
+#~ msgctxt "Sound event"
+#~ msgid "Information or question"
+#~ msgstr "Information or question"
+
+#~ msgctxt "Sound event"
+#~ msgid "Warning"
+#~ msgstr "Warning"
+
+#~ msgid "Custom..."
+#~ msgstr "Custom…"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "Enable support for GNOME assistive technologies at login"
+
+#~ msgid ""
+#~ "Centered\n"
+#~ "Fill screen\n"
+#~ "Scaled\n"
+#~ "Zoom\n"
+#~ "Tiled"
+#~ msgstr ""
+#~ "Centred\n"
+#~ "Fill screen\n"
+#~ "Scaled\n"
+#~ "Zoom\n"
+#~ "Tiled"
+
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Just apply settings and quit"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Screen Resolution Preferences"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Make default for this computer (%s) only"
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgstr[1] ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Keep Resolution"
+
+#~ msgid "Use _Previous Resolution"
+#~ msgstr "Use _Previous Resolution"
+
+#~ msgid "_Keep Resolution"
+#~ msgstr "_Keep Resolution"
+
+#~ msgid ""
+#~ "The X server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "The X server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+
+#~ msgid "New accelerator..."
+#~ msgstr "New accelerator…"
+
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "Error setting new accelerator in configuration database: %s\n"
+
+#~ msgid "Keyboard Accessibility Notifications"
+#~ msgstr "Keyboard Accessibility Notifications"
+
+#~ msgid "_Layouts:"
+#~ msgstr "_Layouts:"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Advanced Configuration"
+
+#~ msgid "E_nable software sound mixing (ESD)"
+#~ msgstr "E_nable software sound mixing (ESD)"
+
+#~ msgid "System Beep"
+#~ msgstr "System Beep"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "_Enable system beep"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "_Visual system beep"
+
+#~ msgid "Unexpected attribute '%s' for element '%s'"
+#~ msgstr "Unexpected attribute '%s' for element '%s'"
+
+#~ msgid "Attribute '%s' of element '%s' not found"
+#~ msgstr "Attribute '%s' of element '%s' not found"
+
+#~ msgid "Unexpected tag '%s', tag '%s' expected"
+#~ msgstr "Unexpected tag '%s', tag '%s' expected"
+
+#~ msgid "Unexpected tag '%s' inside '%s'"
+#~ msgstr "Unexpected tag '%s' inside '%s'"
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "No valid bookmark file found in data dirs"
+
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "No bookmark found for URI '%s'"
+
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "No MIME type defined in the bookmark for URI '%s'"
+
+#~ msgid "No private flag has been defined in bookmark for URI '%s'"
+#~ msgstr "No private flag has been defined in bookmark for URI '%s'"
+
+#~ msgid "No groups set in bookmark for URI '%s'"
+#~ msgstr "No groups set in bookmark for URI '%s'"
+
+#~ msgid "No application with name '%s' registered a bookmark for '%s'"
+#~ msgstr "No application with name '%s' registered a bookmark for '%s'"
+
+#~ msgid "Siren"
+#~ msgstr "Siren"
+
+#~ msgid "Clink"
+#~ msgstr "Clink"
+
+#~ msgid "Beep"
+#~ msgstr "Beep"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "Sound not set for this event."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "The file %s is not a valid wav file"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Do _not apply font"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+
+#~ msgid "Themes"
+#~ msgstr "Themes"
+
+#~ msgid "Description"
+#~ msgstr "Description"
+
+#~ msgid "Control theme"
+#~ msgstr "Control theme"
+
+#~ msgid "Window border theme"
+#~ msgstr "Window border theme"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "If set to true, then installed themes will be thumbnailed."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "If set to true, then themes will be thumbnailed."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr "Set this key to the command used to create thumbnails for themes."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Thumbnail command for installed themes"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Thumbnail command for themes"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Whether to thumbnail installed themes"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Whether to thumbnail themes"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#~ msgid "[FILE]"
+#~ msgstr "[FILE]"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Sets the default theme"
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "There was an error launching the mouse preferences dialogue: %s"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Unable to import AccessX settings from file '%s'"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Import Feature Settings File"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Set your keyboard accessibility preferences"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Enable _Mouse Keys</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>Enable _Repeat Keys</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Features</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Toggle Keys</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Basic"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "Beep when an LED is turned on and two beeps when one is turned off."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Delay between keypress and pointer mo_vement:"
+
+#~ msgid "E_nable Toggle Keys"
+#~ msgstr "E_nable Toggle Keys"
+
+#~ msgid "Filters"
+#~ msgstr "Filters"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Keyboard Accessibility Preferences (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Ma_ximum pointer speed:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Mouse _Preferences…"
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Time to acce_lerate to maximum speed:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Turn the numeric keypad into a mouse control pad."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Disable if unused for:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "_Enable keyboard accessibility features"
+
+#~ msgid "characters/second"
+#~ msgstr "characters/second"
+
+#~ msgid "milliseconds"
+#~ msgstr "milliseconds"
+
+#~ msgid "pixels/second"
+#~ msgstr "pixels/second"
+
+#~ msgid "Go _to Fonts Folder"
+#~ msgstr "Go _to Fonts Folder"
+
+#~ msgid "The theme is an engine. You need to compile it."
+#~ msgstr "The theme is an engine. You need to compile it."
+
+#~ msgid "The file format is invalid"
+#~ msgstr "The file format is invalid"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "The file format is invalid."
+
+#~ msgid "Autostart the preferred AT"
+#~ msgstr "Autostart the preferred AT"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "Evolution Mail Reader 1.4"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "Evolution Mail Reader 1.5"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "Evolution Mail Reader 1.6"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "Evolution Mail Reader 2.0"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "Evolution Mail Reader 2.2"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "Evolution Mail Reader 2.4"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Links Text Browser"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Lynx Text Browser"
+
+#~ msgid "Simple OnScreen Keyboard"
+#~ msgstr "Simple OnScreen Keyboard"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M Text Browser"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Keep resolution"
+
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "There was an error launching the keyboard tool: %s"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Microsoft Natural Keyboard"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Fast</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>High</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Large</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Low</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Slow</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Small</i>"
+
+#~ msgid "Motion"
+#~ msgstr "Motion"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Do you want to activate Slow Keys?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Do you want to deactivate Slow Keys?"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "Do_n't activate"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Do you want to activate Sticky Keys?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Do you want to deactivate Sticky Keys?"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "Key Binding (%s) has its action defined multiple times\n"
+
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "Key Binding (%s) has its binding defined multiple times\n"
+
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Key Binding (%s) is incomplete\n"
+
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Key Binding (%s) is invalid\n"
+
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr "It seems that another application already has access to key '%u'."
+
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "Do _not show this warning again"
+
+#~ msgid ""
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.</b>\n"
+#~ "\n"
+#~ "Expected was %s, but the the following settings were found: %s.\n"
+#~ "\n"
+#~ "Which set would you like to use?"
+#~ msgstr ""
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.</b>\n"
+#~ "\n"
+#~ "Expected was %s, but the the following settings were found: %s.\n"
+#~ "\n"
+#~ "Which set would you like to use?"
+
+#~ msgid ""
+#~ "Could not get default terminal. Verify that your default terminal command "
+#~ "is set and points to a valid application."
+#~ msgstr ""
+#~ "Could not get default terminal. Verify that your default terminal command "
+#~ "is set and points to a valid application."
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this is a valid command."
+#~ msgstr ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this is a valid command."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Do not show this message again"
+
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "Couldn't load sound file %s as sample %s"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Cannot determine user's home directory"
+
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr "GConf key %s set to type %s but its expected type was %s\n"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "Do _not show this warning again."
+
+#~ msgid "Load modmap files"
+#~ msgstr "Load modmap files"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "Would you like to load the modmap file(s)?"
+
+#~ msgid "_Load"
+#~ msgstr "_Load"
+
+#~ msgid "_Loaded files:"
+#~ msgstr "_Loaded files:"
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Width if applier is a preview: Defaults to 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Preview Height"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Height if applier is a preview: Defaults to 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Screen on which BGApplier is to draw"
+
+#~ msgid "Edited %m/%d/%Y"
+#~ msgstr "Edited %d/%m/%Y"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Sync text/plain and text/* handlers"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Shortcut for e-mail."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Shortcut for home folder."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Shortcut for Launch help browser."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "shortcut for launch web browser."
+
+#~ msgid "Lock screen's shortcut."
+#~ msgstr "Shortcut for lock screen."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "shortcut for log out."
+
+#~ msgid "Media player key's shortcut."
+#~ msgstr "Shortcut key for media player."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Shortcut for next track key."
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Shortcut for the pause kay."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Shortcut for the play (or play/pause) key."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Shortcut for the previous track key."
+
+#~ msgid "Search's shortcut."
+#~ msgstr "Shortcut for search."
+
+#~ msgid "Sleep"
+#~ msgstr "Sleep"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Sleep's shortcut."
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Shortcut for the stop playback key."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Shortcut for volume down."
+
+#~ msgid "Volume mute's shortcut."
+#~ msgstr "Shortcut for volume mute."
+
+#~ msgid "Volume step"
+#~ msgstr "Volume step"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Volume step as percentage of volume."
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Shortcut for volume up."
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "Display a dialogue when there are errors running the screensaver"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "Run screensaver at login"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Show Startup Errors"
+
+#~ msgid "Start screensaver"
+#~ msgstr "Start screensaver"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Add Wallpaper"
+
+#~ msgid "- Desktop Background Preferences"
+#~ msgstr "- Desktop Background Preferences"
+
+#~ msgid "background size|%s, %d %s x %d %s"
+#~ msgstr "%s, %d %s x %d %s"
+
+#~ msgid "Preferred Assistive Technology"
+#~ msgstr "Preferred Assistive Technology"
+
+#~ msgid "Run the the preferred GNOME Mobility Assitive Technology"
+#~ msgstr "Run the the preferred GNOME Mobility Assitive Technology"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Select fonts for the desktop"
+
+#~ msgid "The default pointer that ships with X"
+#~ msgstr "The default pointer that ships with X"
+
+#~ msgid "The default pointer inverted"
+#~ msgstr "The default pointer inverted"
+
+#~ msgid "Large version of normal pointer"
+#~ msgstr "Large version of normal pointer"
+
+#~ msgid "Large version of white pointer"
+#~ msgstr "Large version of white pointer"
+
+#~ msgid "Pointer Theme"
+#~ msgstr "Pointer Theme"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Highlight the _pointer when you press Ctrl"
+
+#~ msgid "Pointer Size:"
+#~ msgstr "Pointer Size:"
+
+#~ msgid ""
+#~ "Small\n"
+#~ "Medium\n"
+#~ "Large"
+#~ msgstr ""
+#~ "Small\n"
+#~ "Medium\n"
+#~ "Large"
+
+#~ msgid "Theme deleted succesfully. Please select another theme."
+#~ msgstr "Theme deleted succesfully. Please select another theme."
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialogue was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "The theme file location specified to install is invalid"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "You can save this theme by pressing the Save Theme button."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Select themes for various parts of the desktop"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "This theme does not suggest any particular font or background."
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "This theme suggests a font and a background:"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "_Save Theme…"
+
+#~ msgid "theme selection tree"
+#~ msgstr "theme selection tree"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "Customise the appearance of toolbars and menubars in applications"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Behaviour and Appearance</b>"
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "_Detachable toolbars"
+
+#~ msgid "Accessible Login"
+#~ msgstr "Accessible Login"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Support</b>"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Start these assistive technologies every time you log in:"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "A_vailable layouts:"
+
+#~ msgid "Sound & Video Preferences"
+#~ msgstr "Sound & Video Preferences"
+
+#~ msgid "Save Color Scheme"
+#~ msgstr "Save Colour Scheme"
+
+#~ msgid "Save color scheme as:"
+#~ msgstr "Save colour scheme as:"
+
+#~ msgid ""
+#~ " \n"
+#~ "Custom"
+#~ msgstr ""
+#~ " \n"
+#~ "Custom"
+
+#~ msgid "S_aved schemes:"
+#~ msgstr "S_aved schemes:"
+
+#~ msgid "_Enable custom colors"
+#~ msgstr "_Enable custom colours"
+
+#~ msgid ""
+#~ "<span weight=\"bold\" size=\"larger\">The theme \"%s\" has been installed."
+#~ "</span>\n"
+#~ "\n"
+#~ "Would you like to apply it now, or keep your current theme?"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">The theme \"%s\" has been installed."
+#~ "</span>\n"
+#~ "\n"
+#~ "Would you like to apply it now, or keep your current theme?"
+
+#~ msgid "Keyboard Indicator Test (%s)"
+#~ msgstr "Keyboard Indicator Test (%s)"
+
+#~ msgid "Indicator:"
+#~ msgstr "Indicator:"
+
+#~ msgid "layout \"%s\""
+#~ msgid_plural "layouts \"%s\""
+#~ msgstr[0] "layout \"%s\""
+#~ msgstr[1] "layouts \"%s\""
+
+#~ msgid "option \"%s\""
+#~ msgid_plural "options \"%s\""
+#~ msgstr[0] "option \"%s\""
+#~ msgstr[1] "options \"%s\""
+
+#~ msgid "model \"%s\", %s and %s"
+#~ msgstr "model \"%s\", %s and %s"
+
+#~ msgid "no layout"
+#~ msgstr "no layout"
+
+#~ msgid "No description."
+#~ msgstr "No description."
+
+#~ msgid "Keyboard Indicator plugins"
+#~ msgstr "Keyboard Indicator plugins"
+
+#~ msgid "Activate more plugins"
+#~ msgstr "Activate more plugins"
+
+#~ msgid "Configure the selected plugin"
+#~ msgstr "Configure the selected plugin"
+
+#~ msgid "Decrease the plugin priority"
+#~ msgstr "Decrease the plugin priority"
+
+#~ msgid "Increase the plugin priority"
+#~ msgstr "Increase the plugin priority"
+
+#~ msgid "Keyboard Indicator Plugins"
+#~ msgstr "Keyboard Indicator Plugins"
+
+#~ msgid "The list of active plugins"
+#~ msgstr "The list of active plugins"
+
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "_Password:"
+
+#~ msgid "Epiphany"
+#~ msgstr "Epiphany"
+
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "Please specify a name and a command for this editor."
+
+#~ msgid "C_ustom:"
+#~ msgstr "C_ustom:"
+
+#~ msgid "Can open _URIs"
+#~ msgstr "Can open _URIs"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Custom Editor Properties"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "Default Mail Reader"
+
+#~ msgid "Default Terminal"
+#~ msgstr "Default Terminal"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "Default Text Editor"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "Default Web Browser"
+
+#~ msgid "Edit..."
+#~ msgstr "Edit…"
+
+#~ msgid "Run in a _terminal"
+#~ msgstr "Run in a _terminal"
+
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "Understands _Netscape Remote Control"
+
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr "Use this _editor to open text files in the file manager"
+
+#~ msgid "Window Manager"
+#~ msgstr "Window Manager"
+
+#~ msgid "_Select:"
+#~ msgstr "_Select:"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "_Terminal font:"
+
+#~ msgid "..."
+#~ msgstr "…"
+
+#~ msgid "Large Cursor"
+#~ msgstr "Large Cursor"
+
+#~ msgid "E_nable sound server startup"
+#~ msgstr "E_nable sound server startup"
+
+#~ msgid "_Sound an audible bell"
+#~ msgstr "_Sound an audible bell"
+
+#~ msgid "_Visual feedback:"
+#~ msgstr "_Visual feedback:"
+
+#~ msgid ""
+#~ "Can not install themes. \n"
+#~ "The gzip utility is not installed."
+#~ msgstr ""
+#~ "Can not install themes. \n"
+#~ "The gzip utility is not installed."
+
+#~ msgid ""
+#~ "Icon Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Icon Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+
+#~ msgid ""
+#~ "Windows Border Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Windows Border Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+
+#~ msgid ""
+#~ "Controls Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Controls Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr "New themes can also be installed by dragging them into the window."
+
+#~ msgid "Short _description:"
+#~ msgstr "Short _description:"
+
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "_Go To Theme Folder"
+
+#~ msgid "_Theme name:"
+#~ msgstr "_Theme name:"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "Could not initialise Bonobo"
+
+#~ msgid "Permissions on the file %s are broken\n"
+#~ msgstr "Permissions on the file %s are broken\n"
+
+#, fuzzy
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "There was an error displaying help: %s"
+
+#~ msgid "_Play"
+#~ msgstr "_Play"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Brightness down's shortcut."
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Brightness up's shortcut."
+
+#~ msgid ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+#~ msgstr ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+
+#~ msgid "A list of modmap files available in the $HOME directory."
+#~ msgstr "A list of modmap files available in the $HOME directory."
+
+#~ msgid "Default group, assigned on window creation"
+#~ msgstr "Default group, assigned on window creation"
+
+#~ msgid "Keep and manage separate group per window"
+#~ msgstr "Keep and manage separate group per window"
+
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Keyboard Update Handlers"
+
+#~ msgid "Keyboard model"
+#~ msgstr "Keyboard model"
+
+#, fuzzy
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr "Keyboard settings in gconf will be overridden from the system ASAP"
+
+#~ msgid "Save/restore indicators together with layout groups"
+#~ msgstr "Save/restore indicators together with layout groups"
+
+#~ msgid "Show layout names instead of group names"
+#~ msgstr "Show layout names instead of group names"
+
+#~ msgid ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+#~ msgstr ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+
+#~ msgid "Suppress the \"X sysconfig changed\" warning message"
+#~ msgstr "Suppress the \"X sysconfig changed\" warning message"
+
+#~ msgid "keyboard model"
+#~ msgstr "keyboard model"
+
+#~ msgid "modmap file list"
+#~ msgstr "modmap file list"
+
+#~ msgid "Break reminder"
+#~ msgstr "Break reminder"
+
+#~ msgid "The typing monitor is already running."
+#~ msgstr "The typing monitor is already running."

--- a/po/eo.po
+++ b/po/eo.po
@@ -16,9 +16,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2021-04-02 13:09+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2021-03-29 18:34+0200\n"
 "Last-Translator: Carmen Bianca BAKKER <carmen@carmenbianca.eu>\n"
 "Language-Team: Esperanto <gnome-eo-list@gnome.org>\n"
@@ -30,317 +29,221 @@ msgstr ""
 "X-Generator: Gtranslator 3.38.0\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:823
-msgid "System Bus"
-msgstr "Sistembuso"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-#: panels/applications/cc-applications-panel.c:838
-#: panels/applications/cc-applications-panel.c:843
-msgid "Full access"
-msgstr "Plena aliro"
-
-#: panels/applications/cc-applications-panel.c:825
-msgid "Session Bus"
-msgstr "Seanca buso"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/power/cc-power-panel.c:1790 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525
-msgid "Devices"
-msgstr "Aparatoj"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Full access to /dev"
-msgstr "Plena aliro al /dev"
-
-#: panels/applications/cc-applications-panel.c:833
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:288
-msgid "Network"
-msgstr "Reto"
-
-#: panels/applications/cc-applications-panel.c:833
-msgid "Has network access"
-msgstr "Havas retaliron"
-
-#: panels/applications/cc-applications-panel.c:838
-#: panels/applications/cc-applications-panel.c:840
-#: panels/search/cc-search-locations-dialog.c:362
-msgid "Home"
-msgstr "Hejmo"
-
-#: panels/applications/cc-applications-panel.c:840
-#: panels/applications/cc-applications-panel.c:845
-msgid "Read-only"
-msgstr "Nurlega"
-
-#: panels/applications/cc-applications-panel.c:843
-#: panels/applications/cc-applications-panel.c:845
-msgid "File System"
-msgstr "Dosiersistemo"
-
-#: panels/applications/cc-applications-panel.c:849
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:279
-#: shell/cc-window.c:933 shell/cc-window.ui:121
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr "Agordoj"
-
-#: panels/applications/cc-applications-panel.c:849
-msgid "Can change settings"
-msgstr "Rajtas ŝanĝi agordojn"
-
-#: panels/applications/cc-applications-panel.c:851
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s havas la sekvajn fiksitajn permesojn. Oni ne povas ŝanĝi ilin. Se vi "
-"zorgas pri ĉi tiuj permesoj, pripensu forigon de la aplikaĵo."
-
-#: panels/applications/cc-applications-panel.c:1024
-msgid "Web Links"
-msgstr "Retligiloj"
-
-#: panels/applications/cc-applications-panel.c:1034
-msgid "Git Links"
-msgstr "Gitligiloj"
-
-#: panels/applications/cc-applications-panel.c:1040
-#, c-format
-msgid "%s Links"
-msgstr "%s-ligiloj"
-
-#: panels/applications/cc-applications-panel.c:1048
-#: panels/applications/cc-applications-panel.c:1084
-msgid "Unset"
-msgstr "Ne agordita"
-
-#: panels/applications/cc-applications-panel.c:1139
-msgid "Links"
-msgstr "Ligiloj"
-
-#: panels/applications/cc-applications-panel.c:1147
-msgid "Hypertext Files"
-msgstr "Hipertekstaj dosieroj"
-
-#: panels/applications/cc-applications-panel.c:1161
-msgid "Text Files"
-msgstr "Tekstaj dosieroj"
-
-#: panels/applications/cc-applications-panel.c:1175
-msgid "Image Files"
-msgstr "Bildo-dosieroj"
-
-#: panels/applications/cc-applications-panel.c:1191
-msgid "Font Files"
-msgstr "Tipar-dosieroj"
-
-#: panels/applications/cc-applications-panel.c:1252
-msgid "Archive Files"
-msgstr "Arĥiv-dosieroj"
-
-#: panels/applications/cc-applications-panel.c:1272
-msgid "Package Files"
-msgstr "Pak-dosieroj"
-
-#: panels/applications/cc-applications-panel.c:1295
-msgid "Audio Files"
-msgstr "Son-dosieroj"
-
-#: panels/applications/cc-applications-panel.c:1312
-msgid "Video Files"
-msgstr "Video-dosieroj"
-
-#: panels/applications/cc-applications-panel.c:1320
-msgid "Other Files"
-msgstr "Aliaj dosieroj"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1660
-#: panels/applications/cc-applications-panel.ui:416
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:79
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr "Aplikaĵoj"
 
-#: panels/applications/cc-applications-panel.ui:43
+#: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
 msgstr "Neniuj aplikaĵoj"
 
-#: panels/applications/cc-applications-panel.ui:57
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr "Instali kelkajn…"
 
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Malfermi"
+
 #: panels/applications/cc-applications-panel.ui:94
-msgid "Permissions & Access"
-msgstr "Permesoj & aliro"
+#, fuzzy
+msgid "View Details"
+msgstr "_Montri detalojn"
 
-#: panels/applications/cc-applications-panel.ui:106
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-"Datumoj kaj servoj, al kiuj ĉi tiu aplikaĵo demandis atingon, kaj ĝiaj "
-"necesaj permesoj."
-
-#: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:127
-#: panels/camera/gnome-camera-panel.desktop.in.in:3
-msgid "Camera"
-msgstr "Kamerao"
-
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:128
-#: panels/applications/cc-applications-panel.ui:140
-#: panels/applications/cc-applications-panel.ui:152
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:262
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:85
-#: panels/keyboard/cc-xkb-modifier-dialog.c:355
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:129
-#: panels/user-accounts/cc-user-panel.c:843
-#: panels/user-accounts/cc-user-panel.c:938
-#: subprojects/gvc/gvc-mixer-control.c:1900
-msgid "Disabled"
-msgstr "Malŝaltita"
-
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:139
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
-msgid "Microphone"
-msgstr "Mikrofono"
-
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:151
-#: panels/location/gnome-location-panel.desktop.in.in:3
-msgid "Location Services"
-msgstr "Lokado-servoj"
-
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:499
-msgid "Built-in Permissions"
-msgstr "Fiksitaj permesoj"
-
-#: panels/applications/cc-applications-panel.ui:158
-msgid "Cannot be changed"
-msgstr "Ne eblas ŝanĝi"
-
-#: panels/applications/cc-applications-panel.ui:175
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-"Individuajm permesojm por alikaĵoj oni povas kontroli en la <a href=\"privacy"
-"\">Privateco</a>-agordoj."
-
-#: panels/applications/cc-applications-panel.ui:199
-msgid "Integration"
-msgstr "Integrigo"
-
-#: panels/applications/cc-applications-panel.ui:211
-msgid "System features used by this application."
-msgstr "Sistemfunkcioj, kiujn uzas ĉi tiu aplikaĵo."
-
-#: panels/applications/cc-applications-panel.ui:225
-#: panels/applications/cc-applications-panel.ui:231
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:151
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Serĉo"
 
-#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Malŝaltita"
+
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr "Sciigoj"
 
-#: panels/applications/cc-applications-panel.ui:243
-msgid "Run in background"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "preferences-system-notifications"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "Ruli fone"
 
-#: panels/applications/cc-applications-panel.ui:249
-msgid "Set Desktop Background"
-msgstr "Agordi labortablan fonon"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:255
-#: panels/applications/cc-applications-panel.ui:261
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Ekrankopioj"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Ekranfonoj"
+
+#: panels/applications/cc-applications-panel.ui:148
+#, fuzzy
+msgid "Change the desktop wallpaper."
+msgstr "preferences-desktop-wallpaper"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Sonoj"
 
-#: panels/applications/cc-applications-panel.ui:267
-msgid "Inhibit system keyboard shortcuts"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Klavkombinoj"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
 msgstr "Malpermesi sistemajn klavkombinojn"
 
-#: panels/applications/cc-applications-panel.ui:300
-msgid "Default Handlers"
-msgstr "Implicitaj traktiloj"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamerao"
 
-#: panels/applications/cc-applications-panel.ui:312
-msgid "Types of files and links that this application opens."
-msgstr "Specoj de dosieroj kaj ligiloj, kiujn ĉi tiu aplikaĵo malfermas."
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:328
-msgid "Reset"
-msgstr "Reagordi"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofono"
 
-#: panels/applications/cc-applications-panel.ui:364
-msgid "Usage"
-msgstr "Uzado"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:376
-msgid "How much resources this application is using."
-msgstr "Kiom da risurcoj ĉi tiu aplikaĵo uzas."
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Lokado-servoj"
 
-#: panels/applications/cc-applications-panel.ui:391
-#: panels/applications/cc-applications-panel.ui:536
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+#, fuzzy
+msgid "Access device location data."
+msgstr "Atingi vian lokon"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Fiksitaj permesoj"
+
+#: panels/applications/cc-applications-panel.ui:223
+#, fuzzy
+msgid "System access that is required by the app"
+msgstr "Sistemfunkcioj, kiujn uzas ĉi tiu aplikaĵo."
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Konservejo"
 
-#: panels/applications/cc-applications-panel.ui:423
-msgid "Open in Software"
-msgstr "Malfermi en Programaro"
-
-#: panels/applications/cc-applications-panel.ui:473 shell/cc-panel-list.ui:121
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Neniu rezulto troviĝis"
 
-#: panels/applications/cc-applications-panel.ui:484
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:177
-#: shell/cc-panel-list.ui:132
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Provu alian serĉon"
 
-#: panels/applications/cc-applications-panel.ui:554
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Dosiersistemo"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Ligita rapido"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Reagordi"
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Kiom da diskospaco ĉi tiu aplikaĵo okpuas per apdatumoj kaj kaŝmemoroj."
 
-#: panels/applications/cc-applications-panel.ui:563
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Aplikaĵo"
 
-#: panels/applications/cc-applications-panel.ui:569
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Datumo"
 
-#: panels/applications/cc-applications-panel.ui:575
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Kaŝmemoro"
 
-#: panels/applications/cc-applications-panel.ui:581
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Totalo</b>"
 
-#: panels/applications/cc-applications-panel.ui:598
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Vakigi kaŝmemoron…"
 
@@ -348,132 +251,99 @@ msgstr "Vakigi kaŝmemoron…"
 msgid "Control various application permissions and settings"
 msgstr "Kontroli diversajn aplikaĵajn permesojn kaj agordojn"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplikaĵo;flatpak;permeso;agordo;"
 
-#: panels/background/cc-background-chooser.c:345
-msgid "Select a picture"
-msgstr "Elekti bildon"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "_Stilo:"
 
-#: panels/background/cc-background-chooser.c:348
-#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:238
-#: panels/color/cc-color-panel.c:886 panels/color/cc-color-panel.ui:657
-#: panels/common/cc-language-chooser.ui:25
-#: panels/display/cc-display-panel.c:1003
-#: panels/info-overview/cc-info-overview-panel.ui:242
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:122
-#: panels/network/cc-wifi-panel.c:866
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:176
-#: panels/network/connection-editor/vpn-helpers.c:299
-#: panels/network/net-device-wifi.c:854
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:235
-#: panels/region/cc-format-chooser.ui:28
-#: panels/search/cc-search-locations-dialog.c:639
-#: panels/sharing/cc-sharing-panel.c:396 panels/usage/cc-usage-panel.c:133
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:105
-#: panels/user-accounts/cc-avatar-chooser.c:223
-#: panels/user-accounts/cc-fingerprint-dialog.ui:36
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:633
-#: panels/user-accounts/cc-user-panel.c:651
-#: panels/user-accounts/data/join-dialog.ui:20
-msgid "_Cancel"
-msgstr "_Nuligi"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Implicita"
 
-#: panels/background/cc-background-chooser.c:349
-#: panels/network/connection-editor/vpn-helpers.c:177
-#: panels/printers/pp-details-dialog.c:236
-#: panels/sharing/cc-sharing-panel.c:397
-#: panels/user-accounts/cc-avatar-chooser.c:224
-msgid "_Open"
-msgstr "_Malfermi"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#: panels/background/cc-background-item.c:140
-msgid "multiple sizes"
-msgstr "pluraj grandoj"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:144
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:282
-msgid "No Desktop Background"
-msgstr "Neniu labortabla fono"
-
-#: panels/background/cc-background-panel.c:112
-msgid "Current background"
-msgstr "Aktuala fono"
-
-#: panels/background/cc-background-panel.ui:55
-msgid "Add Picture…"
-msgstr "Aldoni bildon…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Agoj"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Fono"
 
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Aldoni bildon…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aspekto"
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Ŝanĝi vian fonan bildon al ekranfono aŭ foto"
 
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Ekranfono;Ekrano;Labortablo;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "Ŝa_lti"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Ne trovis Bludenton"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Konektu ricevilon por uzi Bludenton."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:69
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bludento estas malŝaltita"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:80
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Ŝaltu por konekti aparatojn kaj ricevi transmetadon de dosieroj."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:107
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "Aviadila reĝimo estas ŝaltita"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:118
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bludento estas malŝaltita dum aviadila reĝimo."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:124
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Malŝalti aviadilan reĝimon"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:154
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
 msgstr "Aparata aviadila reĝimo estas ŝaltita"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:165
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Malŝaltu aviadilan reĝimon por ŝalti Bludenton."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1595
 msgid "Bluetooth"
 msgstr "Bludento"
 
@@ -481,32 +351,31 @@ msgstr "Bludento"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Ŝalti kaj malŝalti Bludenton kaj konekti viajn aparatojn"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "kunhavigi;kunhavigado;bludento;obex;"
 
-#: panels/camera/cc-camera-panel.ui:34
-msgid "Camera is turned off"
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
 msgstr "Kamerao malŝaltita"
 
-#: panels/camera/cc-camera-panel.ui:43
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Neniu aplikaĵo povas registri fotojn aŭ filmojn."
 
-#: panels/camera/cc-camera-panel.ui:75
+#: panels/camera/cc-camera-panel.ui:39
+#, fuzzy
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 "Uzado de la kamerao permesas al aplikaĵoj fari fotojn kaj registri videojn. "
 "Malŝaltado de la kamerao povus kaŭzi, ke kelkaj aplikaĵoj ne funkcias taŭge."
 
-#: panels/camera/cc-camera-panel.ui:85
-msgid "Allow the applications below to use your camera."
-msgstr "Permesi, ke la subaj aplikaĵoj povu uzi vian kameraon."
-
-#: panels/camera/cc-camera-panel.ui:105
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Neniu aplikaĵo petis atingon al via kamerao"
 
@@ -514,279 +383,59 @@ msgstr "Neniu aplikaĵo petis atingon al via kamerao"
 msgid "Protect your pictures"
 msgstr "Protekti viajn bildoj"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"ekrano;ŝlosi;ŝloso;diagnozo;kraŝo;privata;lastatempa;provizora;tmp;indekso;"
-"reto;identeco;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Metu vian laŭnormigan aparaton super la kvadraton kaj premu “Komenci”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Movu vian laŭnormigan aparaton al la laŭnormiga pozicio kaj premu “Daŭrigi”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Movu vian laŭnormigan aparaton al la supraĵa pozicio kaj premu “Daŭrigi”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Fermu la kovrilon de la klapkomputilo"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Okazis interna eraro, kiun ne eblis riparigi."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Necesaj iloj por laŭnormigo ne estas instalitaj."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Ne eblis generi la profilon."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "La cela blankpunkto ne akireblis."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Plenumita!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Laŭnormigo malsukcesis!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Vi povas forigi la laŭnormigan aparaton."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ne interrompu la laŭnormigan aparaton dum plenumado"
-
-#: panels/color/cc-color-calibrate.ui:7
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Ekran-laŭnormigo"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Nuligi"
+
 #. This starts the calibration process
-#: panels/color/cc-color-calibrate.ui:40
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "_Komenci"
 
 #. This resumes the calibration process
-#: panels/color/cc-color-calibrate.ui:54
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "Daŭ_rigi"
 
 #. This button returns the user back to the color control panel
-#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
-#: panels/user-accounts/cc-fingerprint-dialog.ui:73
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Plenumita"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Ekrano de klapkomputilo"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Fiksita retkamerao"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s Ekrano"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s Skanilo"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s Kamerao"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s Presilo"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s Retkamerao"
-
-#: panels/color/cc-color-device.c:90
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Ŝalti kolormastrumadon por %s"
-
-#: panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Montri kolorprofilojn por %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Nelaŭnormigita"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:167
-msgid "Default: "
-msgstr "Implicita: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:175
-msgid "Colorspace: "
-msgstr "Kolorspaco: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:182
-msgid "Test profile: "
-msgstr "Testprofilo: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:236
-msgid "Select ICC Profile File"
-msgstr "Elekti ICC-profildosieron"
-
-#: panels/color/cc-color-panel.c:239
-msgid "_Import"
-msgstr "E_nporti"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:250
-msgid "Supported ICC profiles"
-msgstr "Subtenataj ICC-profiloj"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:257
-#: panels/network/wireless-security/eap-method-fast.c:356
-msgid "All files"
-msgstr "Ĉiuj dosieroj"
-
-#: panels/color/cc-color-panel.c:549
-msgid "Screen"
-msgstr "Ekrano"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:839
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Malsukcesis alŝuti dosieron: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:851
-msgid "The profile has been uploaded to:"
-msgstr "La profilo estas alŝutita al:"
-
-# Ĉu estas imperativo? --Carmen
-#: panels/color/cc-color-panel.c:853
-msgid "Write down this URL."
-msgstr "Noti tiun ret-adreson."
-
-# Ĉu estas imperativo? --Carmen
-#: panels/color/cc-color-panel.c:854
-msgid "Restart this computer and boot your normal operating system."
-msgstr "Restartigi ĉi tiun komputilon kaj startigi vian normalan operaciumon."
-
-#: panels/color/cc-color-panel.c:855
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-"Tajpu la retadreson en via retumilo por elŝutu kaj instalu la profilon."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:883
-msgid "Save Profile"
-msgstr "Konservi profilon"
-
-#: panels/color/cc-color-panel.c:887
-#: panels/network/connection-editor/vpn-helpers.c:300
-msgid "_Save"
-msgstr "Kon_servi"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1196
-msgid "Create a color profile for the selected device"
-msgstr "Krei kolorprofilon por la elektita aparato"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1211 panels/color/cc-color-panel.c:1235
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"La mezurilo ne estas detektita. Bonvolu kontroli ĉu ĝi estas ŝaltita kaj "
-"korekte konektita."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1245
-msgid "The measuring instrument does not support printer profiling."
-msgstr "La mezurilo ne subtenas presilprofiladon."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1256
-msgid "The device type is not currently supported."
-msgstr "La aparatspeco ne estas aktuale subtenita."
-
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Ekran-laŭnormigo"
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Laŭnormigo-kvalito"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -795,42 +444,42 @@ msgstr ""
 "Laŭnormigo generos profilon, kiun vi povas uzi por administri koloron de via "
 "ekrano. Ju pli da laŭnormigdaŭro, des pli bona kvalito de la kolorprofilo."
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "Vi ne povos uzi vian komputilon dum laŭnormigado."
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Kvalito"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Proksimuma tempo"
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr "Laŭnormigo-kvalito"
-
-#: panels/color/cc-color-panel.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Elektu la sentilan aparaton, kiun vi volas uzi por laŭnormigo."
-
-#: panels/color/cc-color-panel.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Laŭnormigo-aparato"
 
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
-msgstr "Elektu la tipon de la konektita ekrano."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Elektu la sentilan aparaton, kiun vi volas uzi por laŭnormigo."
 
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Ekranspeco"
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Elektu la tipon de la konektita ekrano."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profila blanko-punkto"
+
+#: panels/color/cc-color-panel.ui:160
 #, fuzzy
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
@@ -839,11 +488,11 @@ msgstr ""
 "Elektu la ekranan celon por montri la blankpunkton. La plej multaj ekranoj "
 "bezonas la agordon D65."
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
-msgstr "Profila blanko-punkto"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Heleco de ekrano"
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -851,7 +500,7 @@ msgstr ""
 "Bonvolu fiksi la helecon de la ekrano je normala nivelo por vi. "
 "Koloradministro estos tre akurata je ĉi tiun nivelon."
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -859,11 +508,11 @@ msgstr ""
 "Alternative, vi povas uzi la heleconivelon uzita je alia profilo por tiu ĉi "
 "aparato."
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr "Heleco de ekrano"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profilnomo"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -871,287 +520,196 @@ msgstr ""
 "Vi povas uzi kolorprofilon en malsamaj komputiloj, aŭ eĉ krei profilojn por "
 "malsamaj lumaj kondiĉoj."
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Profilnomo:"
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "Profilnomo"
-
-#: panels/color/cc-color-panel.ui:392
-msgid "Profile successfully created!"
-msgstr "Sukcese kreis profilon!"
-
-#: panels/color/cc-color-panel.ui:443
-msgid "Copy profile"
-msgstr "Kopii profilon"
-
-#: panels/color/cc-color-panel.ui:456
-msgid "Requires writable media"
-msgstr "Necesas skribeblan datumportilon"
-
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr "Alŝuti profilon"
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr "Necesas interretan konekton"
-
-#: panels/color/cc-color-panel.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"Ĉi tiujn instrukciojn pri uzado de la profilo je la sistemoj <a href=\"linux"
-"\">GNU/Linukso</a>, <a href=\"osx\">Apple OS X</a> kaj <a href=\"windows"
-"\">Microsoft Vindozo</a> vi eble taksas utilaj."
-
-#: panels/color/cc-color-panel.ui:607
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Resumo"
 
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Sukcese kreis profilon!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopii profilon"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Necesas skribeblan datumportilon"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Ĉi tiujn instrukciojn pri uzado de la profilo je la sistemoj <a "
+"href=\"linux\">GNU/Linukso</a>, <a href=\"osx\">Apple OS X</a> kaj <a "
+"href=\"windows\">Microsoft Vindozo</a> vi eble taksas utilaj."
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "Aldoni profilon"
 
-#: panels/color/cc-color-panel.ui:643
-msgid "_Import File…"
-msgstr "E_nporti dosieron…"
-
-#: panels/color/cc-color-panel.ui:672 panels/keyboard/cc-input-chooser.ui:20
-#: panels/network/connection-editor/net-connection-editor.c:504
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr "_Aldoni"
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Detektis problemojn. La profilo eble ne funkcios korekte. <a href="
-"\"\">Montri detalojn.</a>"
+"Detektis problemojn. La profilo eble ne funkcios korekte. <a "
+"href=\"\">Montri detalojn.</a>"
 
-#: panels/color/cc-color-panel.ui:788
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "E_nporti dosieron…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Aldoni"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Ĉiu aparato necesas ĝisdatigan kolorprofilon antaŭ ol oni povas "
 "kolormastrumi ĝin."
 
-#. translators: Text used in link to privacy policy
-#: panels/color/cc-color-panel.ui:810
-#: panels/diagnostics/cc-diagnostics-panel.c:143
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Lernu pli"
 
-#: panels/color/cc-color-panel.ui:815
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Lernu pli pri kolormastrumado"
 
-#: panels/color/cc-color-panel.ui:863
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "_Agordi por ĉiuj uzantoj"
 
-#: panels/color/cc-color-panel.ui:867 panels/color/cc-color-panel.ui:882
-#: panels/color/cc-color-panel.ui:883
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Agordi ĉi tiun profilon por ĉiuj uzantoj de tiu ĉi komputilo"
 
-#: panels/color/cc-color-panel.ui:878
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "Ŝa_lti"
 
-#: panels/color/cc-color-panel.ui:909
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "_Aldoni profilon"
 
-#: panels/color/cc-color-panel.ui:922
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "_Laŭnormigi…"
 
-#: panels/color/cc-color-panel.ui:926
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Laŭnormigi la aparaton"
 
-#: panels/color/cc-color-panel.ui:937
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "Fo_rigi profilon"
 
-#: panels/color/cc-color-panel.ui:950
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "_Montri detalojn"
 
-#: panels/color/cc-color-panel.ui:986
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "Oni ne povas detekti kolormastrumeblan aparaton"
 
-#: panels/color/cc-color-panel.ui:1030
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/cc-color-panel.ui:1035
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/cc-color-panel.ui:1040
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "KRT"
 
-#: panels/color/cc-color-panel.ui:1045
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Projekciilo"
 
-#: panels/color/cc-color-panel.ui:1050
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plasmo"
 
-#: panels/color/cc-color-panel.ui:1055
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL-a fonlumo)"
 
-#: panels/color/cc-color-panel.ui:1060
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RVB-LED-a fonlumo)"
 
-#: panels/color/cc-color-panel.ui:1065
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (blanka LED fonlumo)"
 
-#: panels/color/cc-color-panel.ui:1070
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "LCD de larĝa gamo (CCFL-a fonlumo)"
 
-#: panels/color/cc-color-panel.ui:1075
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "LCD de larĝa gamo (RVB-LED-a fonlumo)"
 
-#: panels/color/cc-color-panel.ui:1092
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Alta"
 
-#: panels/color/cc-color-panel.ui:1093
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 minutoj"
 
-#: panels/color/cc-color-panel.ui:1097
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Meza"
 
-#: panels/color/cc-color-panel.ui:1098
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 minutoj"
 
-#: panels/color/cc-color-panel.ui:1102
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Malalta"
 
-#: panels/color/cc-color-panel.ui:1103
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 minutoj"
 
-#: panels/color/cc-color-panel.ui:1125
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Indiĝena al ekrano"
 
-#: panels/color/cc-color-panel.ui:1129
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Presado kaj eldonado)"
 
-#: panels/color/cc-color-panel.ui:1133
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/cc-color-panel.ui:1137
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Fotografio kaj grafiko)"
 
-#: panels/color/cc-color-panel.ui:1141
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Norma spaco"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testprofilo"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Aŭtomate"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Malalta kvalito"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Meza kvalito"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Alta kvalito"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Implicita RVB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Implicita CMFN"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Implicita grizo"
-
-# Mi supozas, ke ĝi devus diri "vendor-supplied". --Carmen
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Fabrikajn laŭnormig-datumojn provizigita de vendisto"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Tutekrana ekran-ĝustigo ne eblas je ĉi tiu profilo"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "La profilo eble ne plu estas akurata"
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1163,14 +721,9 @@ msgid ""
 msgstr ""
 "Laŭnormigi la koloron de viaj aparatoj, kiel ekranoj, fotiloj aŭ presiloj"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Koloro;ICC;Profilo;Laŭnormigi;Presilo;Ekrano;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Alia…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1180,305 +733,186 @@ msgstr "Elekti lingvon"
 msgid "_Select"
 msgstr "_Elekti"
 
-#: panels/common/cc-language-chooser.ui:69
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Neniuj lingvoj trovitaj"
 
-#: panels/common/cc-language-chooser.ui:82
-#: panels/keyboard/cc-input-chooser.c:178
+#: panels/common/cc-language-chooser.ui:69
 msgid "More…"
 msgstr "Pli…"
 
-#: panels/common/cc-permission-infobar.c:107
-msgid "Unlock to Change Settings"
-msgstr "Malŝlosi por ŝanĝi agordojn"
-
-#: panels/common/cc-permission-infobar.ui:20
-msgid "Unlock…"
-msgstr "Malŝlosi…"
-
-#: panels/common/cc-permission-infobar.ui:56
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "Oni devas malŝlosi kelkajn agordojn antaŭ ol ili ŝanĝeblas."
 
-#: panels/common/cc-time-editor.ui:33
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Malŝlosi…"
+
+#: panels/common/cc-time-editor.ui:25
 msgid "Increment Hour"
 msgstr "Alkrementi horon"
 
-#: panels/common/cc-time-editor.ui:65
+#: panels/common/cc-time-editor.ui:53
 msgid "Increment Minute"
 msgstr "Alkrementi minuton"
 
-#: panels/common/cc-time-editor.ui:80
+#: panels/common/cc-time-editor.ui:73
 msgid "Time"
 msgstr "Horo"
 
-#: panels/common/cc-time-editor.ui:113
+#: panels/common/cc-time-editor.ui:94
 msgid "Decrement Hour"
 msgstr "Dekrementi horon"
 
-#: panels/common/cc-time-editor.ui:145
+#: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Dekrementi minuton"
 
-#: panels/common/cc-time-entry.c:219
-msgid "_Copy"
-msgstr "_Kopii"
-
-#: panels/common/cc-time-entry.c:225
-msgid "Select _All"
-msgstr "Elekti ĉ_iujn"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:160
-msgid "Today"
-msgstr "Hodiaŭ"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Yesterday"
-msgstr "Hieraŭ"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%-e-a de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%-e-a de %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d horo"
-msgstr[1] "%d horoj"
-
-#: panels/common/cc-util.c:166
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuto"
-msgstr[1] "%d minutoj"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekundo"
-msgstr[1] "%d sekundoj"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekundoj"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Retkaptejo"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:262
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%-e-a de %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:267
-msgid "%e %B %Y, %R"
-msgstr "%-e-a de %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:449
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:476
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:483
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:488
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:493
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:498
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "January"
-msgstr "Januaro"
-
-#: panels/datetime/cc-datetime-panel.ui:46
-msgid "February"
-msgstr "Februaro"
-
-#: panels/datetime/cc-datetime-panel.ui:54
-msgid "March"
-msgstr "Marto"
-
-#: panels/datetime/cc-datetime-panel.ui:62
-msgid "April"
-msgstr "Aprilo"
-
-#: panels/datetime/cc-datetime-panel.ui:70
-msgid "May"
-msgstr "Majo"
-
-#: panels/datetime/cc-datetime-panel.ui:78
-msgid "June"
-msgstr "Junio"
-
-#: panels/datetime/cc-datetime-panel.ui:86
-msgid "July"
-msgstr "Julio"
-
-#: panels/datetime/cc-datetime-panel.ui:94
-msgid "August"
-msgstr "Aŭgusto"
-
-#: panels/datetime/cc-datetime-panel.ui:102
-msgid "September"
-msgstr "Septembro"
-
-#: panels/datetime/cc-datetime-panel.ui:110
-msgid "October"
-msgstr "Oktobro"
-
-#: panels/datetime/cc-datetime-panel.ui:118
-msgid "November"
-msgstr "Novembro"
-
-#: panels/datetime/cc-datetime-panel.ui:126
-msgid "December"
-msgstr "Decembro"
-
-#: panels/datetime/cc-datetime-panel.ui:136
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Dato & horo"
 
-#: panels/datetime/cc-datetime-panel.ui:187
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "Jaro"
 
-#: panels/datetime/cc-datetime-panel.ui:220
+#: panels/datetime/cc-datetime-panel.ui:66
 msgid "Month"
 msgstr "Monato"
 
-#: panels/datetime/cc-datetime-panel.ui:257
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januaro"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februaro"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Marto"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Aprilo"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Majo"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Junio"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Julio"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Aŭgusto"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Septembro"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktobro"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembro"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Decembro"
+
+#: panels/datetime/cc-datetime-panel.ui:92
 msgid "Day"
 msgstr "Tago"
 
-#: panels/datetime/cc-datetime-panel.ui:286
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Horzono"
 
-#: panels/datetime/cc-datetime-panel.ui:307
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Serĉi urbon"
 
-#: panels/datetime/cc-datetime-panel.ui:378
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "Aŭtomata _dato & horo"
 
-#: panels/datetime/cc-datetime-panel.ui:379
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Bezonas interretan atingon"
 
-#: panels/datetime/cc-datetime-panel.ui:399
-msgid "Date & _Time"
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
 msgstr "Dato & _horo"
 
-#: panels/datetime/cc-datetime-panel.ui:438
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Aŭtomata hor_zono"
 
-#: panels/datetime/cc-datetime-panel.ui:439
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "Bezonas lokado-servojn kaj interretan atingon"
 
-#: panels/datetime/cc-datetime-panel.ui:454
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Ŝaltita"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Horz_ono"
 
-#: panels/datetime/cc-datetime-panel.ui:494
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Dekstrume"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Tempo-_formo"
 
-#: panels/datetime/cc-datetime-panel.ui:503
-msgid "24-hour"
-msgstr "24-hora"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:504
-msgid "AM / PM"
-msgstr "ATM / PTM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datoj"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekundoj"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalendaro"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Numeroj"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Ŝanĝi la aktualan tempon, inkluzivante horzonon"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Horloĝo;Horo;Horzono;Loko;"
@@ -1491,28 +925,28 @@ msgstr "Ŝanĝi sistemajn agordoj pri horo kaj dato"
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Por ŝanĝi tempajn aŭ datajn agordojn, vi devas aŭtentigi."
 
-#: panels/default-apps/cc-default-apps-panel.ui:31
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "_Reto"
 
-#: panels/default-apps/cc-default-apps-panel.ui:43
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "Ret_poŝto"
 
-#: panels/default-apps/cc-default-apps-panel.ui:59
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "_Kalendaro"
 
-#: panels/default-apps/cc-default-apps-panel.ui:75
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "M_uziko"
 
-#: panels/default-apps/cc-default-apps-panel.ui:91
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "_Video"
 
-#: panels/default-apps/cc-default-apps-panel.ui:162
-#: panels/removable-media/cc-removable-media-panel.ui:162
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "_Fotoj"
 
@@ -1524,26 +958,15 @@ msgstr "Implicitaj aplikaĵoj"
 msgid "Configure Default Applications"
 msgstr "Agordi implicitajn aplikaĵojn"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "implicita;aplikaĵo;preferita;datumportilo;"
 
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:145
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Sendado de raportoj de teĥnikaj problemoj helpas al ni plibonigi %s. "
-"Raportoj sendiĝas sennome kaj personaj datumoj estas viŝitaj. %s"
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:28
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
 msgstr "Problemraportado"
 
-#: panels/diagnostics/cc-diagnostics-panel.ui:65
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
 msgid "_Automatic Problem Reporting"
 msgstr "_Aŭtomata problemraportado"
 
@@ -1555,159 +978,118 @@ msgstr "Diagnozo"
 msgid "Report your problems"
 msgstr "Raporti viajn problemojn"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"ekrano;ŝlosi;ŝloso;diagnozo;kraŝo;privata;lastatempa;provizora;tmp;indekso;"
-"nomo;reto;identeco;privateco;"
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "Diagnozo"
 
-#: panels/display/cc-display-panel.c:1014
-#: panels/network/connection-editor/connection-editor.ui:27
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Apliki"
 
-#: panels/display/cc-display-panel.c:1035
-msgid "Apply Changes?"
-msgstr "Ĉu apliki ŝanĝojn?"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Reen"
 
-#: panels/display/cc-display-panel.c:1040
-msgid "Changes Cannot be Applied"
-msgstr "Ne eblas apliki ŝanĝojn"
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Bludento estas elŝaltite"
 
-#: panels/display/cc-display-panel.c:1041
-msgid "This could be due to hardware limitations."
-msgstr "Ĉi tiu eblus pro aparataj limigoj."
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Apartigi ekranon"
 
-#: panels/display/cc-display-panel.ui:89
-msgid "Single Display"
-msgstr "Unuobla ekrano"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
 
-#: panels/display/cc-display-panel.ui:108
-#: panels/display/cc-display-panel.ui:310
-msgid "Join Displays"
-msgstr "Kunigi ekranojn"
-
-#: panels/display/cc-display-panel.ui:126
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Speguli"
 
-#: panels/display/cc-display-panel.ui:151
-msgid "Display Mode"
-msgstr "Reĝimo de ekrano"
-
-#: panels/display/cc-display-panel.ui:220
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Enhavas supran breton kaj Agojn"
 
-#: panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Ĉefa ekrano"
 
-#: panels/display/cc-display-panel.ui:243
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
-msgstr ""
-"Tiru ekranojn por kongrui vian fizikan ekranaranĝon. Elektu ekranon por "
-"ŝanĝi ĝiajn agordojn."
-
-#: panels/display/cc-display-panel.ui:250
-msgid "Display Arrangement"
-msgstr "Aranĝo de ekranoj"
-
-#: panels/display/cc-display-panel.ui:374
-msgid "Active Display"
-msgstr "Aktiva ekrano"
-
-#: panels/display/cc-display-panel.ui:421
-msgid "Display Configuration"
-msgstr "Ekran-agordoj"
-
-#: panels/display/cc-display-panel.ui:440
-#: panels/display/gnome-display-panel.desktop.in.in:3
-msgid "Displays"
-msgstr "Ekranoj"
-
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:451
-#: panels/display/cc-night-light-page.ui:111
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Noktlumo"
 
-#: panels/display/cc-display-settings.c:103
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Pejzaĝo"
-
-#: panels/display/cc-display-settings.c:106
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Portreto dekstra"
-
-#: panels/display/cc-display-settings.c:109
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Portreto maldekstra"
-
-#: panels/display/cc-display-settings.c:112
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Pejzaĝo (renversita)"
-
-#: panels/display/cc-display-settings.c:186
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:15
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Orientiĝo"
 
-#: panels/display/cc-display-settings.ui:24
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Distingo"
 
-#: panels/display/cc-display-settings.ui:33
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Ofteco de aktualigo"
 
-#: panels/display/cc-display-settings.ui:42
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Ĝustigi por televizio"
 
-#: panels/display/cc-display-settings.ui:59
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Skali"
 
-#: panels/display/cc-night-light-page.c:627
-msgid "More Warm"
-msgstr "Pli varma"
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Natura rulumado"
 
-#: panels/display/cc-night-light-page.c:639
-msgid "Less Warm"
-msgstr "Malpli varma"
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:28
-msgid "Restart Filter"
-msgstr "Restartigi filtrilon"
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Noktlumo"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:61
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Provizore malŝaltita ĝis morgaŭ"
 
-#: panels/display/cc-night-light-page.ui:88
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Restartigi filtrilon"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1715,67 +1097,70 @@ msgstr ""
 "Noktlumo varmigas la koloron de la ekrano. Ĉi tiu povas antaŭmalhelpi "
 "streĉiĝon de okuloj kaj sendormecon."
 
-#: panels/display/cc-night-light-page.ui:127
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Tempoplano"
 
-#: panels/display/cc-night-light-page.ui:136
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "De sunsubiro ĝis sunleviĝo"
 
-#: panels/display/cc-night-light-page.ui:137
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Permana tempoplano"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/region/cc-format-preview.ui:40
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Horoj"
 
-#: panels/display/cc-night-light-page.ui:165
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "De"
 
-#: panels/display/cc-night-light-page.ui:194
-#: panels/display/cc-night-light-page.ui:297
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Horo"
 
-#: panels/display/cc-night-light-page.ui:203
-#: panels/display/cc-night-light-page.ui:306
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:222
-#: panels/display/cc-night-light-page.ui:325
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Minuto"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:234
-#: panels/display/cc-night-light-page.ui:337
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "ATM"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:247
-#: panels/display/cc-night-light-page.ui:350
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PTM"
 
-#: panels/display/cc-night-light-page.ui:267
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Al"
 
-#: panels/display/cc-night-light-page.ui:374
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Kolora temperaturo"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ekranoj"
 
 #: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Elekti kiel uzi konektitajn ekranojn kaj projekciilojn"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1784,106 +1169,126 @@ msgstr ""
 "Panelo;Projekciilo;xrandr;Ekrano;Distingivo;Aktualigi;Ekrano;Nokto;Lumo;Blua;"
 "redshift;koloro;sunsubiro;sunleviĝo;"
 
-#: panels/info-overview/cc-info-overview-panel.c:418
-#: panels/info-overview/cc-info-overview-panel.c:433
-#: panels/info-overview/cc-info-overview-panel.c:445
-#: panels/info-overview/cc-info-overview-panel.c:491
-#: panels/info-overview/cc-info-overview-panel.c:521
-msgid "Unknown"
-msgstr "Nekonata"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:453
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; Versio-ID: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Speco de sekureco"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:468
-#, c-format
-msgid "64-bit"
-msgstr "64-bita"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Nivelo de inko"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:471
-#, c-format
-msgid "32-bit"
-msgstr "32-bita"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Nivelo de inko"
 
-#: panels/info-overview/cc-info-overview-panel.c:728
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Nivelo de inko"
 
-#: panels/info-overview/cc-info-overview-panel.c:732
-msgid "Wayland"
-msgstr "Vejlando"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:734
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Nekonata"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Sekureco"
 
-#: panels/info-overview/cc-info-overview-panel.ui:51
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ekrano;ŝlosi;ŝloso;diagnozo;kraŝo;privata;lastatempa;provizora;tmp;indekso;"
+"nomo;reto;identeco;privateco;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Aparatnomo"
 
-#: panels/info-overview/cc-info-overview-panel.ui:73
+#: panels/info-overview/cc-info-overview-panel.ui:50
 msgid "Hardware Model"
 msgstr "Aparatara modelo"
 
-#: panels/info-overview/cc-info-overview-panel.ui:82
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "Memoro"
 
-#: panels/info-overview/cc-info-overview-panel.ui:91
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "Procezoro"
 
-#: panels/info-overview/cc-info-overview-panel.ui:100
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "Grafikoj"
 
-#: panels/info-overview/cc-info-overview-panel.ui:109
+#: panels/info-overview/cc-info-overview-panel.ui:82
 msgid "Disk Capacity"
 msgstr "Diskospaco"
 
-#: panels/info-overview/cc-info-overview-panel.ui:110
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "Kalkulanta…"
 
 #. translators: this field contains the distro name and version
-#: panels/info-overview/cc-info-overview-panel.ui:132
+#: panels/info-overview/cc-info-overview-panel.ui:98
 msgid "OS Name"
 msgstr "Nomo de operaciumo"
 
-#: panels/info-overview/cc-info-overview-panel.ui:141
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; Versio-ID: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Speco de operaciumo"
 
-#: panels/info-overview/cc-info-overview-panel.ui:150
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Versio de GNOME"
 
-#: panels/info-overview/cc-info-overview-panel.ui:160
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Ŝarĝante opciojn…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Fenestrado-sistemo"
 
-#: panels/info-overview/cc-info-overview-panel.ui:168
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Virtualigado"
 
-#: panels/info-overview/cc-info-overview-panel.ui:177
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Programaraj ĝisdatigoj"
 
-#: panels/info-overview/cc-info-overview-panel.ui:198
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Alinomi aparaton"
 
-#: panels/info-overview/cc-info-overview-panel.ui:215
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1891,7 +1296,12 @@ msgstr ""
 "Oni uzas la aparatnomon por ke aliaj aparatoj povas rete identigi ĝin, kaj "
 "dum parigo de Bludentaj aparatoj."
 
-#: panels/info-overview/cc-info-overview-panel.ui:233
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Aparatnomo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "_Alinomi"
 
@@ -1903,11 +1313,6 @@ msgstr "Pri"
 msgid "View information about your system"
 msgstr "Montri informon pri via sistemo"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1966,7 +1371,7 @@ msgid "Eject"
 msgstr "Elĵeti"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:542
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Tajpado"
 
@@ -1985,6 +1390,12 @@ msgstr "Lanĉiloj"
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Lanĉi helpfoliumilon"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Agordoj"
 
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -2007,39 +1418,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Serĉi"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "Ekrankopioj"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "Konservi ekrankopion al $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Konservi ekrankopion de fenestro al $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Konservi ekrankopion de areo al $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "Kopii ekrankopion al tondujo"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Kopii ekrankopion de fenestro al tondujo"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Kopii ekrankopion de areo al tondujo"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "Registri mallongan ekranreĝistraĵon"
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistemo"
 
@@ -2088,316 +1467,194 @@ msgstr "Malpligrandigi la tekston"
 msgid "High contrast on or off"
 msgstr "Ŝalti aŭ malŝalti altan kontraston"
 
-#: panels/keyboard/cc-input-chooser.c:193
-msgid "No input sources found"
-msgstr "Neniuj enigaj fontoj trovitaj"
-
-#: panels/keyboard/cc-input-chooser.c:964
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Alia"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Aldoni enigan fonton"
 
-#: panels/keyboard/cc-input-chooser.ui:77
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Enigaj metodoj ne uzeblas ĉe saluta ekrano"
 
-#: panels/keyboard/cc-input-list-box.ui:20
+#: panels/keyboard/cc-input-list-box.ui:24
 msgid "No input source selected"
 msgstr "Neniu eniga fonto elektita"
 
-#: panels/keyboard/cc-input-row.ui:75
-msgid "Move up"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Agordoj"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
 msgstr "Movi supren"
 
-#: panels/keyboard/cc-input-row.ui:86
-msgid "Move down"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
 msgstr "Movi malsupren"
 
-#: panels/keyboard/cc-input-row.ui:103
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Agordoj"
 
-#: panels/keyboard/cc-input-row.ui:120
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Montri klavararanĝon"
 
-#: panels/keyboard/cc-input-row.ui:137
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:286
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Forigi"
 
-#: panels/keyboard/cc-keyboard-manager.c:486
-#: panels/keyboard/cc-keyboard-manager.c:494
-#: panels/keyboard/cc-keyboard-manager.c:779
-msgid "Custom Shortcuts"
-msgstr "Propraj klavkombinoj"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.ui:179
-msgid "Alternate Characters Key"
-msgstr "Klavo de alternativaj signoj"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"La klavom de alternativaj signoj oni povas uzi por enigi ceterajn signojn. "
-"Foje ili estas presitaj kiel tria opcio sur via klavaro."
-
-#: panels/keyboard/cc-keyboard-panel.c:74
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Maldekstra alt-klavo"
-
-#: panels/keyboard/cc-keyboard-panel.c:75
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Dekstra alt-klavo"
-
-#: panels/keyboard/cc-keyboard-panel.c:76
-#: panels/keyboard/cc-keyboard-panel.c:94
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Meldekstra super-klavo"
-
-#: panels/keyboard/cc-keyboard-panel.c:77
-#: panels/keyboard/cc-keyboard-panel.c:95
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Dekstra super-klavo"
-
-#: panels/keyboard/cc-keyboard-panel.c:78
-#: panels/keyboard/cc-keyboard-panel.c:96
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menu-klavo"
-
-#: panels/keyboard/cc-keyboard-panel.c:79
-#: panels/keyboard/cc-keyboard-panel.c:97
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Dekstra stirklavo"
-
-#: panels/keyboard/cc-keyboard-panel.c:87
-#: panels/keyboard/cc-keyboard-panel.ui:204
-msgid "Compose Key"
-msgstr "Kompona klavo"
-
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"La kompona klavo permesas enigon de vasta kvanto de signoj. Por uzi ĝin, "
-"premu la komponan klavon kaj sekve enigu sekvencon de signoj. Ekzemple, la "
-"sekvenco <b>kompona klavo</b>, <b>G</b>, kaj <b>^</b> enigas <b>Ĝ</b>, kaj "
-"la sekvenco <b>kompona klavo</b>, <b>C</b>, kaj <b>o</b> enigas <b>©</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:98
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Majuskla baskulo"
-
-#: panels/keyboard/cc-keyboard-panel.c:99
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Ruluma baskulo"
-
-#: panels/keyboard/cc-keyboard-panel.c:100
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Ekrankopio"
-
-#: panels/keyboard/cc-keyboard-panel.ui:43
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "Enigaj fontoj"
 
-#: panels/keyboard/cc-keyboard-panel.ui:66
+#: panels/keyboard/cc-keyboard-panel.ui:18
+#, fuzzy
+msgid "Includes keyboard layouts and input methods."
+msgstr "Elekti klavararanĝojn aŭ enigajn metodojn."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
 msgid "Input Source Switching"
 msgstr "Ŝanĝi inter enigaj fontoj"
 
-#: panels/keyboard/cc-keyboard-panel.ui:99
+#: panels/keyboard/cc-keyboard-panel.ui:31
 msgid "Use the _same source for all windows"
 msgstr "Uzi la _saman fonton por ĉiuj fenestroj"
 
-#: panels/keyboard/cc-keyboard-panel.ui:126
+#: panels/keyboard/cc-keyboard-panel.ui:43
 msgid "Switch input sources _individually for each window"
 msgstr "Ŝanĝi inter enigaj fontoj _individue por ĉiu fenestro"
 
-#: panels/keyboard/cc-keyboard-panel.ui:138
-msgid "Keyboard Shortcut"
-msgstr "Klavkombino"
-
-#: panels/keyboard/cc-keyboard-panel.ui:139
-msgid "This can be changed in Customize Shortcuts"
-msgstr "Oni povas ŝanĝi ĉi tion en Agordi klavkombinojn"
-
-#: panels/keyboard/cc-keyboard-panel.ui:157
-msgid "Type Special Characters"
+#: panels/keyboard/cc-keyboard-panel.ui:59
+#, fuzzy
+msgid "Special Character Entry"
 msgstr "Tajpado de specialaj signoj"
 
-#: panels/keyboard/cc-keyboard-panel.ui:180
-msgid "Hold down and type to enter different characters"
-msgstr "Daŭre premu kaj tajpu por enigi aliajn signojn"
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:232
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:301
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:317 shell/cc-window.ui:326
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Klavo de alternativaj signoj"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Kompona klavo"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Klavkombinoj"
 
-#: panels/keyboard/cc-keyboard-panel.ui:253
-msgid "Customize Shortcuts"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
 msgstr "Agordi klavkombinojn"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:281
-msgid "modified"
-msgstr "modifita"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Reagordi ĉiujn…"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:423
-msgid "Reset All Shortcuts?"
-msgstr "Ĉu reagordi ĉiujn klavkombinojn?"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Reagordi ĉiujn klavkombinojn al ĝiaj implicitaj klavkombinoj"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:426
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Reagordado de klavkombinoj povus aliigi viajn proprajn klavkombinojn. Ĉi tiu "
-"ne estas malfarebla."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sekcio"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:430
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:275
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-msgid "Cancel"
-msgstr "Nuligi"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Klavkombinoj"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:431
-msgid "Reset All"
-msgstr "Reagordi ĉiujn"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Aldoni klavkombinon"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:115
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Aldoni proprajn klavkombinojn"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:124
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "Agordi proprajn klavkombinojn por lanĉi aplikaĵojn, ruli skriptetojn, kaj "
 "tiel plu."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Aldoni klavkombinon"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:166
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Ne povis trovi klavkombinon"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:211
-#: panels/region/cc-format-chooser.ui:48
-#: panels/user-accounts/cc-fingerprint-dialog.ui:53
-#: panels/wacom/wacom-stylus-page.ui:37 shell/cc-window.ui:230
-msgid "Back"
-msgstr "Reen"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "Forigi"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:235
-msgid "Reset All…"
-msgstr "Reagordi ĉiujn…"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "Anstataŭigi"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:236
-msgid "Reset all shortcuts to their default keybindings"
-msgstr "Reagordi ĉiujn klavkombinojn al ĝiaj implicitaj klavkombinoj"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:391
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s jam estas uzata por %s. Se vi anstataŭas ĝin, %s estos malŝaltita"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:535
-msgid "Enter the new shortcut"
-msgstr "Entajpu novan klavkombinon"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
-msgid "Set Custom Shortcut"
-msgstr "Agordi propran klavkombinon"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
-msgid "Set Shortcut"
-msgstr "Agordi klavkombinon"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:561
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Enmetu novan klavkombinon por ŝanĝi %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:987
-msgid "Add Custom Shortcut"
-msgstr "Aldoni propran klavkombinon"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:60
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Premu eskapan klavon por nuligi aŭ retropaŝan klavon por reagordi la "
 "klavkombinon."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:135
-#: panels/printers/pp-details-dialog.ui:40
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Nomo"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:147
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Komando"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:159
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Klavkombino"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:238
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Agordi klavkombinon…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Neniu"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:296
-msgid "Add"
-msgstr "Aldoni"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:311
-msgid "Replace"
-msgstr "Anstataŭigi"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:325
-msgid "Set"
-msgstr "Agordi"
-
-#: panels/keyboard/cc-keyboard-shortcut-row.ui:27
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Reŝargi la klavkombinon al ĝia implicita valoro"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_Reagordi al la defaŭltoj"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Klavaro"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr "Montru kaj ŝanĝu klavkombinojn kaj agordu viajn tajpadajn preferojn"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2405,35 +1662,27 @@ msgstr ""
 "Klavkombino;Laborspaco;Fenestro;Aligrandigi;Zomi;Kontrasto;Enigo;Fonto;Ŝlosi;"
 "Laŭteco;"
 
-#: panels/location/cc-location-panel.ui:31
-msgid "Location services turned off"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
 msgstr "Lokado-servoj malŝaltitaj"
 
-#: panels/location/cc-location-panel.ui:40
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Neniu aplikaĵo povas obteni lokajn informojn."
 
-#: panels/location/cc-location-panel.ui:72
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"Lokado-servoj permesas al aplikaĵoj scii vian lokon. Uzado de vifio kaj "
-"portebla larĝkapacita konekto plialtigas ekzaktecon."
-
-#: panels/location/cc-location-panel.ui:81
-msgid ""
+"mobile broadband increases accuracy.\n"
+"\n"
 "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
-"Uzas Mozilla Lokado-Servon: <a href='https://location.services.mozilla.com/"
-"privacy'>Privateco Politiko</a>"
 
-#: panels/location/cc-location-panel.ui:94
-msgid "Allow the applications below to determine your location."
-msgstr "Permesi, ke la subaj aplikaĵoj povu scii vian lokon."
-
-#: panels/location/cc-location-panel.ui:114
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Neniu aplikaĵo petis atingon al via loko"
 
@@ -2441,190 +1690,32 @@ msgstr "Neniu aplikaĵo petis atingon al via loko"
 msgid "Protect your location information"
 msgstr "Protekti viajn lokajn informojn"
 
-#. FIXME
-#: panels/lock/cc-lock-panel.ui:27
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"Aŭtomata ŝlosado de la ekrano malhelpas ke aliuloj povu aliri vian "
-"komputilon dum via foresto."
 
-#: panels/lock/cc-lock-panel.ui:44
-msgid "Blank Screen Delay"
-msgstr "Malfruo antaŭ ol malplena ekrano"
-
-#: panels/lock/cc-lock-panel.ui:45
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Paŭzo post kiu la ekrano malpleniĝas."
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Automatic Screen _Lock"
-msgstr "Aŭtomata ekrana ŝ_loso"
-
-#: panels/lock/cc-lock-panel.ui:82
-msgid "Automatic _Screen Lock Delay"
-msgstr "Malfruo _antaŭ ol ekrana ŝloso"
-
-#: panels/lock/cc-lock-panel.ui:83
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "Paŭzo inter la malpleniĝo de la ekrano kaj ĝia ŝlosado."
-
-#: panels/lock/cc-lock-panel.ui:103
-msgid "Show _Notifications on Lock Screen"
-msgstr "Montri _sciigojn sur ŝlosa ekrano"
-
-#: panels/lock/cc-lock-panel.ui:120
-msgid "Forbid new _USB devices"
-msgstr "Malpermesi novajn _USB-aparatojn."
-
-#: panels/lock/cc-lock-panel.ui:121
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Malhelpi ke novaj USB-aparatoj interagu kun la sistemo dum la ekrano estas "
-"ŝlosita."
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:166
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "La ekrano malŝaltas"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:170
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekundoj"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:174
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:178
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutoj"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:182
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutoj"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:186
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutoj"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:190
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutoj"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:194
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 horo"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:209 panels/power/cc-power-panel.ui:63
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:213 panels/power/cc-power-panel.ui:67
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutoj"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:217 panels/power/cc-power-panel.ui:71
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutoj"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:221 panels/power/cc-power-panel.ui:75
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutoj"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:225 panels/power/cc-power-panel.ui:79
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutoj"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:229 panels/power/cc-power-panel.ui:83
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutoj"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:233 panels/power/cc-power-panel.ui:87
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutoj"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:237 panels/power/cc-power-panel.ui:91
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutoj"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:241 panels/power/cc-power-panel.ui:95
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutoj"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:245 panels/power/cc-power-panel.ui:99
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Neniam"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Ekrana ŝloso"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Ŝlosi vian ekranon"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:34
-msgid "Microphone is turned off"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
 msgstr "Mikrofono malŝaltita"
 
-#: panels/microphone/cc-microphone-panel.ui:43
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Neniu aplikaĵo povas registri sonon."
 
-#: panels/microphone/cc-microphone-panel.ui:75
+#: panels/microphone/cc-microphone-panel.ui:37
+#, fuzzy
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
-"properly."
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
 msgstr ""
 "Uzado de la mikrofono permesas al aplikaĵoj registri kaj aŭskulti sonojn. "
 "Malŝaltado de la mikrofono povus kaŭzi, ke kelkaj aplikaĵoj ne funkciu taŭge."
 
-#: panels/microphone/cc-microphone-panel.ui:85
-msgid "Allow the applications below to use your microphone."
-msgstr "Permesi, ke la subaj aplikaĵoj povu uzi vian mikrofonon."
-
-#: panels/microphone/cc-microphone-panel.ui:105
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Neniu aplikaĵo petis atingon al via mikrofono"
 
@@ -2632,104 +1723,171 @@ msgstr "Neniu aplikaĵo petis atingon al via mikrofono"
 msgid "Protect your conversations"
 msgstr "Protekti viajn konversaciojn"
 
-#. FIXME
-#: panels/mouse/cc-mouse-panel.ui:37
-msgid "General"
-msgstr "Ĝenerala"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:75
-msgid "Primary Button"
-msgstr "Ĉefa butono"
-
-#: panels/mouse/cc-mouse-panel.ui:94
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "Agordas la ordon de fizikaj butonoj sur musoj kaj tuŝplatoj."
-
-#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
-msgid "Left"
-msgstr "Maldekstra"
-
-#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
-msgid "Right"
-msgstr "Dekstra"
-
-#: panels/mouse/cc-mouse-panel.ui:169
-msgid "Mouse"
-msgstr "Muso"
-
-#: panels/mouse/cc-mouse-panel.ui:208
-msgid "Mouse Speed"
-msgstr "Musa rapideco"
-
-#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
-msgid "Double-click timeout"
-msgstr "Tempolimo de duobla klako"
-
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
-msgid "Natural Scrolling"
-msgstr "Natura rulumado"
-
-#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
-msgid "Scrolling moves the content, not the view."
-msgstr "Rulumado movas la enhavon, ne la vidon."
-
-#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
-msgid "Touchpad"
-msgstr "Tuŝplato"
-
-#: panels/mouse/cc-mouse-panel.ui:501
-msgid "Touchpad Speed"
-msgstr "Tuŝplata rapideco"
-
-#: panels/mouse/cc-mouse-panel.ui:560
-msgid "Tap to Click"
-msgstr "Frapeti por alklaki"
-
-#: panels/mouse/cc-mouse-panel.ui:612
-msgid "Two-finger Scrolling"
-msgstr "Dufingra rulumado"
-
-#: panels/mouse/cc-mouse-panel.ui:665
-msgid "Edge Scrolling"
-msgstr "Flanka rulumado"
-
-#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:441
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Testi viajn _agordojn"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:25
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Ĝenerala"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Ĉefa butono"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Agordas la ordon de fizikaj butonoj sur musoj kaj tuŝplatoj."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Maldekstra"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Dekstra"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Serĉaj lokoj"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Muso"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "Musa rapideco"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Rulumi suben"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "Rulumado movas la enhavon, ne la vidon."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Rulumado movas la enhavon, ne la vidon."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "Ak_celado:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktiva"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Tuŝplato"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "Tuŝplata rapideco"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "Frapeti por alklaki"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Frapeti por alklaki"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Elŝalti _tuŝplaton dum tajpado"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Tuŝplato (relativa)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Flanka rulumado"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Rulumi suben"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Duflanka"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Provu klakadon, duoblan klakadon, rulumadon"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Kvin alklakoj, GEGL-tempo!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Duobla klako, ĉefa butono"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Unuobla klako, ĉefa butono"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Duobla klako, meza butono"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Unuobla klako, meza butono"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Duobla klako, duaranga butono"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Unuobla klako, duaranga butono"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2742,91 +1900,133 @@ msgstr ""
 "Ŝanĝu vian musan aŭ tuŝplatan sentivecon kaj elektu dekstra- aŭ "
 "maldekstramana"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Tuŝplato;Musmontrilo;Alklako;Frapeto;Butono;Stirglobo;Rulumi;"
 
-#: panels/network/cc-network-panel.c:661 panels/network/cc-wifi-panel.ui:307
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Ups, io fiaskis. Bonvolu kontakti vian programaran vendiston."
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: panels/network/cc-network-panel.c:667
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager devas esti rulanta."
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: panels/network/cc-network-panel.ui:66
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Kolorspaco: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "Aŭtomate forigi provizorajn _dosierojn"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Monitoroj"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Trenu por ŝanĝi unuarangan ekranon."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Aplikaĵo definita"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Aliaj aparatoj"
 
-#: panels/network/cc-network-panel.ui:107
-#: panels/network/connection-editor/net-connection-editor.c:587
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPR"
 
-#: panels/network/cc-network-panel.ui:151
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Aldoni novan konekton"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Ne agordita"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:208
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:268
-msgid "Insecure network (WEP)"
-msgstr "Nesekura reto (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:273
-msgid "Secure network (WPA)"
-msgstr "Sekura reto (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:278
-msgid "Secure network (WPA2)"
-msgstr "Sekura reto (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA3)"
-msgstr "Sekura reto (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:288
-msgid "Secure network"
-msgstr "Sekura reto"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:68 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Konektita"
 
-#: panels/network/cc-wifi-connection-row.ui:100
-#: panels/network/net-device-ethernet.c:327
-#: panels/network/network-bluetooth.ui:76
-#: panels/network/network-ethernet.ui:111 panels/network/network-mobile.ui:450
-#: panels/network/network-vpn.ui:77
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Agordoj…"
 
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:134
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Ŝaltado de retkaptejo malkonektos vian komputilon de %s, kaj ne eblos atingi "
-"interreton tra vifio."
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, fuzzy, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Devas havi malpleje 8 signojn"
+msgstr[1] "Devas havi malpleje 8 signojn"
 
-#: panels/network/cc-wifi-hotspot-dialog.c:265
-msgid "Must have a minimum of 8 characters"
-msgstr "Devas havi malpleje 8 signojn"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:479
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
 msgid "Turn On Wi-Fi Hotspot?"
 msgstr "Ĉu ŝalti vifian retkaptejon?"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:19
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
 "Wi-Fi hotspot allows others to share your internet connection, by creating a "
 "Wi-Fi network that they can connect to. To do this, you must have an "
@@ -2836,1119 +2036,446 @@ msgstr ""
 "reton al kiu ili povas konekti. Por fari tion, necesas ke vi havu "
 "retkonekton tra alia fonto ol vifio."
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:44
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
 msgstr "Retnomo"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:69
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:389
-#: panels/printers/pp-jobs-dialog.ui:70
-#: panels/user-accounts/cc-add-user-dialog.ui:249
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Pasvorto"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:83
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Generi hazardan pasvorton"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:84
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Aŭtomate generi pasvorton"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:130
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "Ŝ_alti"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:53
-msgid "Wi-Fi"
-msgstr "Vifio"
-
-#: panels/network/cc-wifi-panel.c:864
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Ĉu haltigi retkaptejon kaj malkonektiĝi ĉiujn uzantojn?"
-
-#: panels/network/cc-wifi-panel.c:867
-msgid "_Stop Hotspot"
-msgstr "Halti_gi retkaptejon"
-
-#: panels/network/cc-wifi-panel.ui:46
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Aviadila reĝimo"
 
-#: panels/network/cc-wifi-panel.ui:47
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Malŝaltas vifion, Bludenton kaj porteblan larĝkapacitan konekton"
 
-#: panels/network/cc-wifi-panel.ui:87
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Neniu vifia adaptilo estas trovita"
 
-#: panels/network/cc-wifi-panel.ui:99
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Certigu, ke vi vifia adaptilo estas konektita kaj ŝaltita"
 
-#: panels/network/cc-wifi-panel.ui:134
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Aviadila reĝimo estas ŝaltita"
 
-#: panels/network/cc-wifi-panel.ui:146
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Malŝalti por uzi vifion"
 
-#: panels/network/cc-wifi-panel.ui:184
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Vifia retkaptejo estas ŝaltita"
 
-#: panels/network/cc-wifi-panel.ui:195
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Porteblaj aparatoj povas skani la QR-kodon por konekti."
 
-#: panels/network/cc-wifi-panel.ui:205
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Malŝalti retkaptejon…"
 
-#: panels/network/cc-wifi-panel.ui:227
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Videblaj retoj"
 
-#: panels/network/cc-wifi-panel.ui:296
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager devas esti rulanta"
 
-#: panels/network/connection-editor/8021x-security-page.ui:20
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Ups, io fiaskis. Bonvolu kontakti vian programaran vendiston."
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _sekureco"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:112
-#: panels/network/connection-editor/ce-page-security.c:424
-#: panels/network/connection-editor/details-page.ui:90
-msgid "Security"
-msgstr "Sekureco"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Porĉiama"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Hazarda"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabila"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profilo %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:95
-#: panels/network/net-device-wifi.c:228
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:99
-#: panels/network/net-device-wifi.c:233
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:105
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:110
-#: panels/network/connection-editor/ce-page-security.c:279
-msgid "Enhanced Open"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:117
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:123
-msgid "Enterprise"
-msgstr "Enterpreno"
-
-#: panels/network/connection-editor/ce-page-details.c:128
-#: panels/network/net-device-wifi.c:218
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Neniu"
-
-#: panels/network/connection-editor/ce-page-details.c:149
-msgid "Never"
-msgstr "Neniam"
-
-#: panels/network/connection-editor/ce-page-details.c:164
-#: panels/network/net-device-ethernet.c:107
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "Antaŭ %i tago"
 msgstr[1] "Antaŭ %i tagoj"
 
-#: panels/network/connection-editor/ce-page-details.c:291
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:293
-#: panels/network/net-device-ethernet.c:214
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:306
-msgid "2.4 GHz / 5 GHz"
-msgstr "2,4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:308
-msgid "2.4 GHz"
-msgstr "2,4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:330
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nenia"
-
-#: panels/network/connection-editor/ce-page-details.c:332
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Malforta"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Sufiĉa"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Bona"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Bonega"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:108
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-mobile.c:447
-msgid "IPv4 Address"
-msgstr "IPv4-adreso"
-
-#: panels/network/connection-editor/ce-page-details.c:411
-#: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:150
-#: panels/network/net-device-mobile.c:448 panels/network/network-mobile.ui:218
-msgid "IPv6 Address"
-msgstr "IPv6-adreso"
-
-#: panels/network/connection-editor/ce-page-details.c:414
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/net-device-ethernet.c:152
-#: panels/network/net-device-ethernet.c:154
-#: panels/network/net-device-mobile.c:451
-#: panels/network/net-device-mobile.c:452 panels/network/network-mobile.ui:201
-msgid "IP Address"
-msgstr "IP-adreso"
-
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:163
-#: panels/network/net-device-mobile.c:456
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/net-device-ethernet.c:164
-#: panels/network/net-device-mobile.c:457
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/connection-editor/details-page.ui:199
-#: panels/network/connection-editor/details-page.ui:218
-#: panels/network/connection-editor/ip4-page.ui:211
-#: panels/network/connection-editor/ip6-page.ui:225
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-ethernet.c:168
-#: panels/network/net-device-mobile.c:459
-#: panels/network/net-device-mobile.c:460 panels/network/network-mobile.ui:253
-#: panels/network/network-mobile.ui:271
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:457
-msgid "Forget Connection"
-msgstr "Forgesi konekton"
-
-#: panels/network/connection-editor/ce-page-details.c:459
-msgid "Remove Connection Profile"
-msgstr "Forigi profilon de konekto"
-
-#: panels/network/connection-editor/ce-page-details.c:461
-msgid "Remove VPN"
-msgstr "Forigi VPR-on"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Details"
-msgstr "Detaloj"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "aŭtomata"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:150
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identeco"
-
-#: panels/network/connection-editor/ce-page-ip4.c:244
-#: panels/network/connection-editor/ce-page-ip6.c:225
-msgid "Delete Address"
-msgstr "Forigi adreson"
-
-#: panels/network/connection-editor/ce-page-ip4.c:399
-#: panels/network/connection-editor/ce-page-ip6.c:369
-msgid "Delete Route"
-msgstr "Forigi kurson"
-
-#: panels/network/connection-editor/ce-page-ip4.c:750
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:722
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:268
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Neniu"
-
-#: panels/network/connection-editor/ce-page-security.c:303
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bita ŝlosilo (Deksesuma aŭ ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:313
-msgid "WEP 128-bit Passphrase"
-msgstr "128-bita WEP-pasfrazo"
-
-#: panels/network/connection-editor/ce-page-security.c:326
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:339
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dinamika WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:353
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 por personoj"
-
-#: panels/network/connection-editor/ce-page-security.c:367
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 por enterprenoj"
-
-#: panels/network/connection-editor/ce-page-security.c:381
-msgid "WPA3 Personal"
-msgstr "WPA3 por personoj"
-
-#: panels/network/connection-editor/details-page.ui:18
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Signala forteco"
 
-#: panels/network/connection-editor/details-page.ui:54
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Ligita rapido"
 
-#: panels/network/connection-editor/details-page.ui:144
-#: panels/network/net-device-ethernet.c:157
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sekureco"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4-adreso"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-adreso"
+
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Aparatara adreso"
 
-#: panels/network/connection-editor/details-page.ui:162
+#: panels/network/connection-editor/details-page.ui:142
 msgid "Supported Frequencies"
 msgstr "Subtenataj oftecoj"
 
-#: panels/network/connection-editor/details-page.ui:180
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/network-mobile.ui:235
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Defaŭlta kurso"
 
-#: panels/network/connection-editor/details-page.ui:236
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Laste uzita"
 
-#: panels/network/connection-editor/details-page.ui:415
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "Konekti _aŭtomate"
 
-#: panels/network/connection-editor/details-page.ui:434
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Disponebligi por _aliaj uzantoj"
 
-#: panels/network/connection-editor/details-page.ui:467
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:478
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:25
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Nomo"
 
-#: panels/network/connection-editor/ethernet-page.ui:54
-#: panels/network/connection-editor/wifi-page.ui:67
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "_MAC-adreso"
 
-#: panels/network/connection-editor/ethernet-page.ui:105
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: panels/network/connection-editor/ethernet-page.ui:122
-#: panels/network/connection-editor/wifi-page.ui:102
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "_Klonita adreso"
 
-#: panels/network/connection-editor/ethernet-page.ui:137
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "bajtoj"
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "IPv_4-metodo"
 
-#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "Aŭtomata (DHCP)"
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "Nur ligi-loke"
 
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:118
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Permane"
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "Malŝalti"
 
-#: panels/network/connection-editor/ip4-page.ui:97
-#: panels/network/connection-editor/ip6-page.ui:111
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
 msgid "Shared to other computers"
 msgstr "Kunhavigita kun aliaj komputiloj"
 
-#: panels/network/connection-editor/ip4-page.ui:125
-#: panels/network/connection-editor/ip6-page.ui:139
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "Adresoj"
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
-#: panels/printers/pp-details-dialog.ui:95
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Adreso"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Retmasko"
 
-#: panels/network/connection-editor/ip4-page.ui:171
-#: panels/network/connection-editor/ip4-page.ui:355
-#: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:369
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Kluzo"
 
-#: panels/network/connection-editor/ip4-page.ui:223
-#: panels/network/connection-editor/ip4-page.ui:291
-#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/connection-editor/ip6-page.ui:305
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:107
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "Aŭtomata"
 
-#: panels/network/connection-editor/ip4-page.ui:234
-#: panels/network/connection-editor/ip6-page.ui:248
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "Aŭtomata DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:258
-#: panels/network/connection-editor/ip6-page.ui:272
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "IP-adresoj apartigitaj per komoj"
 
-#: panels/network/connection-editor/ip4-page.ui:279
-#: panels/network/connection-editor/ip6-page.ui:293
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Kursoj"
 
-#: panels/network/connection-editor/ip4-page.ui:302
-#: panels/network/connection-editor/ip6-page.ui:316
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Aŭtomataj kursoj"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:368
-#: panels/network/connection-editor/ip6-page.ui:382
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metriko"
 
-#: panels/network/connection-editor/ip4-page.ui:398
-#: panels/network/connection-editor/ip6-page.ui:412
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Uzi ĉi tiun konekton _nur por risurcoj rekte sur la sama reto"
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "IPv_6-metodo"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "Aŭtomata, nur DHCP"
 
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Prefikso"
 
-#: panels/network/connection-editor/net-connection-editor.c:280
-msgid "Unable to open connection editor"
-msgstr "Ne eblas malfermi konektan redaktilon"
-
-#: panels/network/connection-editor/net-connection-editor.c:296
-msgid "New Profile"
-msgstr "Nova profilo"
-
-#: panels/network/connection-editor/net-connection-editor.c:731
-msgid "Import from file…"
-msgstr "Enporti el dosiero…"
-
-#: panels/network/connection-editor/net-connection-editor.c:763
-msgid "Add VPN"
-msgstr "Aldoni VPR-on"
-
-#: panels/network/connection-editor/security-page.ui:20
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_ekureco"
 
-#: panels/network/connection-editor/vpn-helpers.c:139
-msgid "Cannot import VPN connection"
-msgstr "Ne eblas enporti VPR-konekton"
-
-#: panels/network/connection-editor/vpn-helpers.c:141
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"La dosiero “%s” ne estis legebla aŭ ne entenas rekonitajn VPR-konektajn "
-"informojn\n"
-"\n"
-"Eraro: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:173
-msgid "Select file to import"
-msgstr "Elekti enportendan dosieron"
-
-#: panels/network/connection-editor/vpn-helpers.c:225
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Dosiero nomita “%s” jam ekzistas."
-
-#: panels/network/connection-editor/vpn-helpers.c:227
-msgid "_Replace"
-msgstr "_Anstataŭigi"
-
-#: panels/network/connection-editor/vpn-helpers.c:229
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Ĉu vi volas anstataŭigi %s per la VPR-konekto, kiun vi konservas?"
-
-#: panels/network/connection-editor/vpn-helpers.c:264
-msgid "Cannot export VPN connection"
-msgstr "Ne eblas elporti VPR-konekton"
-
-#: panels/network/connection-editor/vpn-helpers.c:266
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"La VPR-konekto “%s” ne povas esti elportita al %s.\n"
-"\n"
-"Eraro: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:296
-msgid "Export VPN connection"
-msgstr "Elporti VPR-konekton"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(Eraro: ne eblas ŝargi VPR-an konekton redaktilo)"
 
-#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Reto"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Regi kiel vi konektas al la interreto"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Reto;Vifio;IP;LAN;Prokurilo;WAN;Larĝkapacita;Modemo;Bludento;VPR;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Vifio"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Regu kiel vi konektas al vifiaj retoj"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Reto;Sendrata;Vifio;IP;LAN;Larĝkapacita;DNS;Retkaptejo;"
 
-#: panels/network/net-device-ethernet.c:95
-msgid "never"
-msgstr "neniam"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "today"
-msgstr "hodiaŭ"
-
-#: panels/network/net-device-ethernet.c:105
-msgid "yesterday"
-msgstr "hieraŭ"
-
-#: panels/network/net-device-ethernet.c:174
-msgid "Last used"
-msgstr "Laste uzita"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:261
-#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Drata"
 
-#: panels/network/net-device-mobile.c:209
-msgid "Add new connection"
-msgstr "Aldoni novan konekton"
-
-#: panels/network/net-device-wifi.c:851
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Retaj detaloj por la elektitaj retoj, inkludante pasvortojn kaj iujn ajn "
-"proprajn agordojn, perdiĝos."
-
-#: panels/network/net-device-wifi.c:855
-msgid "_Forget"
-msgstr "_Forgesi"
-
-#: panels/network/net-device-wifi.c:1034 panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Konataj vifiaj retoj"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1076
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Forgesi"
-
-#: panels/network/net-device-wifi.c:1217
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Sistema politiko malebligas uzon kiel retkaptejo"
-
-#: panels/network/net-device-wifi.c:1220
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Sendrata aparato ne subtenas retkapteja reĝimo"
-
-#: panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:266
-#: panels/power/cc-power-panel.c:1133 panels/power/cc-power-panel.c:1144
-#: panels/universal-access/cc-ua-panel.c:328
-#: panels/universal-access/cc-ua-panel.c:603
-#: panels/universal-access/cc-ua-panel.c:613
-#: panels/universal-access/cc-ua-panel.c:625
-#: panels/universal-access/cc-ua-panel.c:668
-#: panels/universal-access/cc-ua-panel.ui:300
-#: panels/universal-access/cc-ua-panel.ui:346
-#: panels/universal-access/cc-ua-panel.ui:392
-#: panels/universal-access/cc-ua-panel.ui:498
-#: panels/universal-access/cc-ua-panel.ui:651
-#: panels/universal-access/cc-ua-panel.ui:697
-#: panels/universal-access/cc-ua-panel.ui:743
-#: panels/universal-access/cc-ua-panel.ui:927
-msgid "Off"
-msgstr "Malŝaltita"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Aŭtomata malkovro de retaj prokuriloj estas uzata kiam agord-URL ne estas "
-"provizita."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Tio ne estas rekomendita por nefidindaj publikaj retoj."
-
-#. update title
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/net-vpn.c:65 panels/network/net-vpn.c:158
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPR"
-
-#: panels/network/network-bluetooth.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Malŝalti aparaton"
 
-#: panels/network/network-mobile.ui:29
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Aktiva"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
-#: panels/network/network-mobile.ui:47
+#: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Provizanto"
 
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:96
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adreso"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Retprokurilo"
 
-#: panels/network/network-proxy.ui:180
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP-prokurilo"
 
-#: panels/network/network-proxy.ui:199
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "H_TTPS-prokurilo"
 
-#: panels/network/network-proxy.ui:218
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "_FTP-prokurilo"
 
-#: panels/network/network-proxy.ui:237
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "_SOCKS-Gastigilo"
 
-#: panels/network/network-proxy.ui:256
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "_Ne uzi por"
 
-#: panels/network/network-proxy.ui:294
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Pordo de HTTP-prokurilo"
 
-#: panels/network/network-proxy.ui:371
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Pordo de HTTPS-prokurilo"
 
-#: panels/network/network-proxy.ui:392
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Pordo de FTP-prokurilo"
 
-#: panels/network/network-proxy.ui:413
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Pordo de SOCKS-prokurilo"
 
-#: panels/network/network-proxy.ui:442
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "_Agordaradreso"
 
-#: panels/network/network-vpn.ui:56
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "Malaktivigi VPN-an konekton"
 
-#: panels/network/network-wifi.ui:22
+#: panels/network/network-wifi.ui:34
 msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Retnomo"
 
-#: panels/network/network-wifi.ui:28
+#: panels/network/network-wifi.ui:40
 msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Speco de sekureco"
 
-#: panels/network/network-wifi.ui:34
+#: panels/network/network-wifi.ui:46
 msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Pasvorto"
 
-#: panels/network/network-wifi.ui:84
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Malŝalti vifion"
 
-#: panels/network/network-wifi.ui:116
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Ŝarĝante opciojn…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Konekti al kaŝita reto…"
 
-#: panels/network/network-wifi.ui:127
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Ŝ_alti retkaptejon…"
 
-#: panels/network/network-wifi.ui:138
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Konataj vifiaj retoj"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Nekonata stato"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Nemastrumita"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/network/panel-common.c:45 panels/user-accounts/cc-user-panel.c:928
-msgid "Unavailable"
-msgstr "Nedisponeble"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Konektante"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Aŭtentigo necesas"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Malkontaktante"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Konekto malsukcesis"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Nekonata stato (mankanta)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Agordo malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP-agordo malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP-agordo senvalidiĝis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Sekretoj estis bezonitaj, sed ne provizitaj"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x provizanto malkonektitas"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Agordo de 802.1x provizanto malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x provizanto malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x provizanto estis tro malrapida por aŭtentigi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP-servilo malsukcesis starti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP-servilo malkonektis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP-kliento malsukcesis starti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Eraro de la DHCP-kliento"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP-kliento malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Kunhavigita konekta servilo malsukcesis starti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Kunhavigita konekta servilo malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP-servilo malsukcesis starti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP-serva eraro"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP-servilo malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Lineo okupita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Neniu voktono"
-
-# carrier = mobile network carrier? --Carmen
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Neniu provizanto povus esti trovita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Numeruma peto eltempiĝis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Numeruma peto malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Pravalorizo de modemo malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Malsukcesis elekti specifitan APN-on"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Ne serĉanta por retoj"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Reta registriĝo neis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Reta registriĝo eltempiĝis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Registriĝo por la petita reto malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN-kontrolo malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Firma programaro por la aparato eble mankas"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Konekto malaperis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Ekzistanta konekto supozintis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modemo ne trovita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bludenta konekto malsukcesis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM-karto ne enmetita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM-karto PIN bezonita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM-karto PUK bezonita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252
-msgid "SIM wrong"
-msgstr "SIM-karto malĝusta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Konekta dependeco malsukcesis"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Mikroprogramaro mankas"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kablo ne konektita"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "nedifinita eraro en 802.1X-sekureco (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:195
-msgid "no file selected"
-msgstr "neniu elektita dosiero"
-
-#: panels/network/wireless-security/eap-method.c:222
-msgid "unspecified error validating eap-method file"
-msgstr "nespecifita eraro dum validigado de eap-method-dosiero"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr ""
-"Privataj ŝlosiloj de specoj DER, PEM aŭ PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:400
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER- aŭ PEM-atestiloj (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:87
-msgid "missing EAP-FAST PAC file"
-msgstr "mankanta EAP-FAST PAC dosiero"
-
-#: panels/network/wireless-security/eap-method-fast.c:347
-msgid "Choose a PAC file"
-msgstr "Elekti PAC-dosieron"
-
-#: panels/network/wireless-security/eap-method-fast.c:352
-msgid "PAC files (*.pac)"
-msgstr "PAC-dosieroj (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -3974,77 +2501,54 @@ msgstr "Aŭtentokontrolata"
 msgid "Both"
 msgstr "Ambaŭ"
 
-#: panels/network/wireless-security/eap-method-fast.ui:49
-#: panels/network/wireless-security/eap-method-peap.ui:52
-#: panels/network/wireless-security/eap-method-ttls.ui:51
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
 msgid "Anony_mous identity"
 msgstr "Senno_ma identeco"
 
-#: panels/network/wireless-security/eap-method-fast.ui:75
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "PAC-_dosiero"
 
-#: panels/network/wireless-security/eap-method-fast.ui:115
-#: panels/network/wireless-security/eap-method-peap.ui:150
-#: panels/network/wireless-security/eap-method-ttls.ui:143
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Elekti PAC-dosieron"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "_Ena aŭtentigo"
 
-#: panels/network/wireless-security/eap-method-fast.ui:144
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Permesi aŭtomatan pro_vizadon de PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "mankanta EAP-LEAP uzantonomo"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "mankanta EAP-LEAP pasvorto"
-
-#: panels/network/wireless-security/eap-method-leap.ui:17
-#: panels/network/wireless-security/eap-method-simple.ui:17
-#: panels/network/wireless-security/ws-leap.ui:18
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_Uzantonomo"
 
-#: panels/network/wireless-security/eap-method-leap.ui:31
-#: panels/network/wireless-security/eap-method-simple.ui:31
-#: panels/network/wireless-security/ws-leap.ui:32
-#: panels/network/wireless-security/ws-sae.ui:14
-#: panels/network/wireless-security/ws-wpa-psk.ui:14
-#: panels/sharing/cc-sharing-panel.ui:202
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:478
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Pasvorto"
 
-#: panels/network/wireless-security/eap-method-leap.ui:55
-#: panels/network/wireless-security/eap-method-simple.ui:73
-#: panels/network/wireless-security/eap-method-tls.ui:157
-#: panels/network/wireless-security/ws-leap.ui:56
-#: panels/network/wireless-security/ws-sae.ui:54
-#: panels/network/wireless-security/ws-wpa-psk.ui:64
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Montri pasvorton"
-
-#: panels/network/wireless-security/eap-method-peap.c:87
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "nevalida EAP-PEAP CA-atestilo: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:96
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "nevalida EAP-PEAP CA-atestilo: neniu atestilo estas specifita"
-
-#: panels/network/wireless-security/eap-method-peap.c:328
-#: panels/network/wireless-security/eap-method-tls.c:513
-#: panels/network/wireless-security/eap-method-ttls.c:336
-msgid "Choose a Certificate Authority certificate"
-msgstr "Elekti atestilon de Atestilaŭtoritato"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4060,104 +2564,43 @@ msgstr "Versio 0"
 msgid "Version 1"
 msgstr "Versio 1"
 
-#: panels/network/wireless-security/eap-method-peap.ui:78
-#: panels/network/wireless-security/eap-method-tls.ui:68
-#: panels/network/wireless-security/eap-method-ttls.ui:102
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "C_A-atestilo"
 
-#: panels/network/wireless-security/eap-method-peap.ui:100
-#: panels/network/wireless-security/eap-method-tls.ui:90
-#: panels/network/wireless-security/eap-method-ttls.ui:125
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Elekti atestilon de Atestilaŭtoritato"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "Neniu CA-atestilo estas _bezonata"
 
-#: panels/network/wireless-security/eap-method-peap.ui:118
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP-_versiono"
 
-# Ĉu «EAP uzantonomo, kiu estas mankanta» aŭ «EAP uzantonomo estas mankanta»? --Carmen
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "mankanta EAP uzantonomo"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "mankanta EAP pasvorto"
-
-#: panels/network/wireless-security/eap-method-tls.c:92
-msgid "missing EAP-TLS identity"
-msgstr "mankanta EAP-TLS identeco"
-
-#: panels/network/wireless-security/eap-method-tls.c:102
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "nevalida EAP-TLS CA-atestilo: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:112
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "nevalida EAP-TLS CA-atestilo: neniu atestilo estas specifita"
-
-#: panels/network/wireless-security/eap-method-tls.c:129
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "nevalida EAP-TLS privata ŝlosilo: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:139
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "nevalida EAP-TLS atestilo de uzanto: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:272
-msgid "Unencrypted private keys are insecure"
-msgstr "Neĉifritaj privataj ŝlosiloj estas nesekuraj"
-
-#: panels/network/wireless-security/eap-method-tls.c:275
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Ŝajne la elektita privata ŝlosilo ne estas protektata per pasvorto. Tio "
-"povas kaŭzi la forlikon de viaj sekurecinformoj. Bonvolu elekti pasvort-"
-"protektitan privatan ŝlosilon.\n"
-"\n"
-"(Vi povas pasvort-protekti vian privatan ŝlosilon per openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:506
-msgid "Choose your personal certificate"
-msgstr "Elekti vian personan atestilon"
-
-#: panels/network/wireless-security/eap-method-tls.c:520
-msgid "Choose your private key"
-msgstr "Elekti vian privatan ŝlosilon"
-
-#: panels/network/wireless-security/eap-method-tls.ui:17
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "I_denteco"
 
-#: panels/network/wireless-security/eap-method-tls.ui:43
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "Atestilo de _uzanto"
 
-#: panels/network/wireless-security/eap-method-tls.ui:108
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "Privata ŝ_losilo"
 
-#: panels/network/wireless-security/eap-method-tls.ui:133
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Privata ŝlosila pasvorto"
-
-#: panels/network/wireless-security/eap-method-ttls.c:98
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "nevalida EAP-TTLS CA-atestilo: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:106
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "nevalida EAP-TTLS CA-atestilo: neniu atestilo estas specifita"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4175,20 +2618,20 @@ msgstr "MSCHAPv2 (ne EAP)"
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.ui:76
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
 msgid "_Domain"
 msgstr "_Domajno"
-
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Nekonata eraro dum validigado de 802.1X-sekureco"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4210,63 +2653,16 @@ msgstr "Tunelita TLS"
 msgid "Protected EAP (PEAP)"
 msgstr "Protektita EAP (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:56
-#: panels/network/wireless-security/ws-wep-key.ui:102
-#: panels/network/wireless-security/ws-wpa-eap.ui:61
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Aŭ_tentigo"
 
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "mankanta leap-username"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "mankanta leap-password"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Vifia pasvorto mankas."
-
-#: panels/network/wireless-security/ws-sae.ui:42
-#: panels/network/wireless-security/ws-wpa-psk.ui:42
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Speco"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "mankanta wep-key"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"nevalida wep-key: ŝlosilo kun longo de %zu devas enhavi nur deksesumajn "
-"ciferojn"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"nevalida wep-key: ŝlosilo kun longo de %zu devas enhavi nur ascii-signoj"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"nevalida wep-key: malĝusta longo de ŝlosilo %zu. Longo de ŝlosilo devas esti "
-"aŭ 5/13 (ascii) aŭ 10/26 (deksesuma)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "nevalida wep-key: pasfrazo devas esti ne-malplena"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "nevalida wep-key: pasfrazo devas esti pli mallonga ol 64 signoj"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4280,50 +2676,36 @@ msgstr "Malferma sistemo"
 msgid "Shared Key"
 msgstr "Kunhavigita ŝlosilo"
 
-#: panels/network/wireless-security/ws-wep-key.ui:48
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "Ŝ_losilo"
 
-#: panels/network/wireless-security/ws-wep-key.ui:84
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "_Montri ŝlosilon"
 
-#: panels/network/wireless-security/ws-wep-key.ui:134
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP-inde_kso"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"nevalida wpa-psk: nevalida longo de ŝlosilo %zu. Devas esti [8,63] bajtoj aŭ "
-"64 deksesumaj ciferoj"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"nevalida wpa-psk: ne povas interpreti ŝlosilon kun 64 bajtoj kiel deksesuma"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:60
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "_Sciigoj"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:112
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "Sonaj _avertoj"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:168
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "Ŝ_prucaj sciigoj"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:184
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
@@ -4331,36 +2713,26 @@ msgstr ""
 "Sciigoj daŭrigos aperi en la listo de sciigoj kiam ŝprucoj estas malŝaltitaj."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:249
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "Montri _enhavon de mesaĝo en ŝprucoj"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:300
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "Sciigoj sur ŝ_losa ekrano"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:351
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "Motri enhav_on de mesaĝo en ŝlosa ekrano"
 
-#: panels/notifications/cc-notifications-panel.c:266
-#: panels/power/cc-power-panel.c:1139 panels/power/cc-power-panel.c:1146
-#: panels/universal-access/cc-ua-panel.c:328
-#: panels/universal-access/cc-ua-panel.c:603
-#: panels/universal-access/cc-ua-panel.c:613
-#: panels/universal-access/cc-ua-panel.c:625
-#: panels/universal-access/cc-ua-panel.c:668
-msgid "On"
-msgstr "Ŝaltita"
-
-#: panels/notifications/cc-notifications-panel.ui:48
+#: panels/notifications/cc-notifications-panel.ui:10
 msgid "_Do Not Disturb"
 msgstr "_Ne interrompu"
 
-#: panels/notifications/cc-notifications-panel.ui:56
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr "Sciigoj sur ŝ_losa ekrano"
 
@@ -4368,34 +2740,32 @@ msgstr "Sciigoj sur ŝ_losa ekrano"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Regu kiuj sciigoj estas montrita kaj kion ili montros"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Sciigoj;Mesaĝo;Pleto;Ŝpruco;"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:150
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Alia"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Malfari"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:622
-#, c-format
-msgid "%s Account"
-msgstr "%s konto"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "_Ena aŭtentigo"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:916
-msgid "Error removing account"
-msgstr "Eraro dum forigado de konto"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Konekti al viaj datumoj en la nubo"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:982
-#, c-format
-msgid "%s removed"
-msgstr "%s forigita"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Neniu interreta konekto — konektu por agordi novajn retajn kontojn"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Aldoni konton"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4405,10 +2775,6 @@ msgstr "Retaj kontoj"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Konektu al viajn retajn kontojn kaj elektu kiel uzi ilin"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4417,31 +2783,6 @@ msgstr ""
 "Google;Guglo;Facebook;Fejsbuko;Vizaĝlibro;Twitter;Tvitero;Yahoo;Jahuo;Reto;"
 "Konektite;Retbabili;Kalendaro;Retpoŝto;Kontaktoj;ownCloud;Kerberos;IMAP;SMTP;"
 "Pocket;ReadItLater;"
-
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:61
-msgid "Undo"
-msgstr "Malfari"
-
-#: panels/online-accounts/online-accounts.ui:94
-msgid "Connect to your data in the cloud"
-msgstr "Konekti al viaj datumoj en la nubo"
-
-#: panels/online-accounts/online-accounts.ui:109
-msgid "No internet connection — connect to set up new online accounts"
-msgstr "Neniu interreta konekto — konektu por agordi novajn retajn kontojn"
-
-#: panels/online-accounts/online-accounts.ui:134
-msgid "Add an account"
-msgstr "Aldoni konton"
-
-#: panels/online-accounts/online-accounts.ui:238
-msgid "Remove Account"
-msgstr "Forigi konton"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Nekonata tempo"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4457,13 +2798,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i horo"
 msgstr[1] "%i horoj"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4476,333 +2810,157 @@ msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minutoj"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s ĝis tute ŝargita"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Averto: %s restanta"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s restanta"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Tute ŝargita"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Ne ŝargante"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Malplena"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Ŝargante"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Malŝargante"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Sendrata muso"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Sendrata klavaro"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Vicnutrila baterio"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Persona cifereca asistanto"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Poŝtelefono"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Medioludilo"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209 panels/wacom/cc-wacom-panel.c:728
-msgid "Tablet"
-msgstr "Tabulkomputilo"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Komputilo"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Luda enigaparato"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:413
-#: panels/power/cc-power-panel.c:1780
-msgid "Battery"
-msgstr "Baterio"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Ĉefa"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Ekstra"
-
-#: panels/power/cc-power-panel.c:411
-msgid "Batteries"
-msgstr "Baterioj"
-
-#: panels/power/cc-power-panel.c:632
-msgid "When _idle"
-msgstr "Dum _senokupo"
-
-#: panels/power/cc-power-panel.c:1081
-msgid "Suspend"
-msgstr "Halteti"
-
-#: panels/power/cc-power-panel.c:1082
-msgid "Power Off"
-msgstr "Malŝalti"
-
-#: panels/power/cc-power-panel.c:1083
-msgid "Hibernate"
-msgstr "Pasivumigi"
-
-#: panels/power/cc-power-panel.c:1084
-msgid "Nothing"
-msgstr "Nenio"
-
-#: panels/power/cc-power-panel.c:1135
-msgid "When on battery power"
-msgstr "Dum bateria elektro"
-
-#: panels/power/cc-power-panel.c:1137
-msgid "When plugged in"
-msgstr "Kiam konektita"
-
-#: panels/power/cc-power-panel.c:1277
-msgid "Automatic suspend"
-msgstr "Aŭtomata haltetado"
-
-#: panels/power/cc-power-panel.c:1800
-msgid "Power Mode"
-msgstr "Elektro-reĝimo"
-
-#: panels/power/cc-power-panel.c:1810
-msgid "Power Saving"
-msgstr "Elektroŝparo"
-
-#: panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Button"
-msgstr "Halteta & ŝalta butono"
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "15 minutoj"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "20 minutoj"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "25 minutoj"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 minutoj"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 minutoj"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 horo"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 minutoj"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 minutoj"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 minutoj"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 horoj"
 
-#: panels/power/cc-power-panel.ui:227
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterio"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Aparatoj"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Elektro-reĝimo"
+
+#: panels/power/cc-power-panel.ui:94
 msgid "Affects system performance and power usage."
 msgstr "Afekcias sisteman rendimenton kaj elektro-uzadon."
 
-#: panels/power/cc-power-panel.ui:297
-msgid "_Screen Brightness"
-msgstr "Heleco de _ekrano"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Elektroŝparo"
 
-#: panels/power/cc-power-panel.ui:346
-msgid "Automatic Brightness"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
 msgstr "Aŭtomata heleco"
 
-#: panels/power/cc-power-panel.ui:382
-msgid "_Keyboard Brightness"
-msgstr "Heleco de _klavaro"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Ekranheleco kaj ŝlosagordoj"
 
-#: panels/power/cc-power-panel.ui:431
-msgid "Dim Screen When Inactive"
-msgstr "Malheligi ekranon kiam neaktiva"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Ekrano"
 
-#: panels/power/cc-power-panel.ui:466
-msgid "_Blank Screen"
-msgstr "M_alplena ekrano"
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
 
-#: panels/power/cc-power-panel.ui:502
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Ek_ranlegilo"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Elektroŝparado"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "_Aŭtomata haltetado"
 
-#: panels/power/cc-power-panel.ui:547
-msgid "_Wi-Fi"
-msgstr "_Vifio"
-
-#: panels/power/cc-power-panel.ui:559
-msgid "Wi-Fi can be turned off to save power."
-msgstr "Vifio malŝalteblas por ŝpari elektron."
-
-#: panels/power/cc-power-panel.ui:609
-msgid "_Mobile Broadband"
-msgstr "_Portebla larĝkapacita reto"
-
-#: panels/power/cc-power-panel.ui:621
-msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
 msgstr ""
-"Portebla larĝkapacita reto (LTE, 4G, 3G, ktp.) malŝalteblas por ŝpari "
-"elektron."
 
-#: panels/power/cc-power-panel.ui:671
-msgid "_Bluetooth"
-msgstr "_Bludento"
-
-#: panels/power/cc-power-panel.ui:683
-msgid "Bluetooth can be turned off to save power."
-msgstr "Bludento malŝalteblas por ŝpari elektron."
-
-#: panels/power/cc-power-panel.ui:759
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Konduto de ŝaltbutono"
 
-#: panels/power/cc-power-panel.ui:797
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Montri baterian elcenton"
 
-#: panels/power/cc-power-panel.ui:872
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Aŭtomata haltetado"
 
-#: panels/power/cc-power-panel.ui:897
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_Konektita"
 
-#: panels/power/cc-power-panel.ui:913
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Je _bateria elektro"
 
-#: panels/power/cc-power-panel.ui:958 panels/power/cc-power-panel.ui:1018
-#: panels/universal-access/cc-repeat-keys-dialog.ui:74
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Prokrasto"
-
-#: panels/power/cc-power-profile-row.c:62
-msgid "Lap detected: performance mode unavailable"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:64
-msgid "High hardware temperature: performance mode unavailable"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:65
-msgid "Performance mode unavailable"
-msgstr "Rendimenta reĝimo nedisponeblas"
-
-#: panels/power/cc-power-profile-row.c:87
-#: panels/power/cc-power-profile-row.c:187
-msgid "High performance and power usage."
-msgstr "Alta rendimento kaj elektro-uzado."
-
-#: panels/power/cc-power-profile-row.c:186
-msgid "Performance"
-msgstr "Rendimento"
-
-#: panels/power/cc-power-profile-row.c:192
-msgid "Balanced Power"
-msgstr "Ekvilibra"
-
-#: panels/power/cc-power-profile-row.c:193
-msgid "Standard performance and power usage."
-msgstr "Normala rendimento kaj elektro-uzado."
-
-#: panels/power/cc-power-profile-row.c:198
-msgid "Power Saver"
-msgstr "Elektroŝparado"
-
-#: panels/power/cc-power-profile-row.c:199
-msgid "Reduced performance and power usage."
-msgstr "Malalta rendimento kaj elektro-uzado."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4812,7 +2970,6 @@ msgstr "Elektro"
 msgid "View your battery status and change power saving settings"
 msgstr "Vidu vian baterian staton kaj elektu elektroŝparajn funkciojn"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4820,43 +2977,6 @@ msgid ""
 msgstr ""
 "Kurento;Elektro;Dormeti;Pasivumigi;Baterio;Heleco;Malheligi;Malplena;Ekrano;"
 "DPMS;Senokupo;"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "Aŭtentigi"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/new-printer-dialog.ui:366
-#: panels/printers/pp-jobs-dialog.ui:57
-msgid "Username"
-msgstr "Uzantonomo"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:339
-msgid "Authentication Required"
-msgstr "Aŭtentigo necesas"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:682
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Presilo “%s” estas forigita"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:930
-msgid "Failed to add new printer."
-msgstr "Aldono de nova presilo malsukcesis."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1209
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Ne eblas ŝargi fasadon: %s"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4866,866 +2986,349 @@ msgstr "Presiloj"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Aldonu presilojn, montru presajn taskojn kaj regu kiel vi volas presi"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Presilo;Atendovico;Presi;Papero;Inko;Inkopulvoro;"
 
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:344
-#: panels/printers/pp-new-printer-dialog.c:401
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Aldoni presilon"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Malŝlosi"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Neniuj presiloj estas trovitaj"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Entajpu retadreson aŭ serĉu presilon"
 
-#: panels/printers/new-printer-dialog.ui:356
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Aŭtentigo necesas"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr "Enigu uzantonomon kaj pasvorton por vidi presilojn je presila servilo."
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:351
-#, c-format
-msgid "%s Details"
-msgstr "%s detaloj"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Uzantonomo"
 
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Neniu taŭga pelilon trovita"
-
-#: panels/printers/pp-details-dialog.c:232
-msgid "Select PPD File"
-msgstr "Elekti PPD-dosieron"
-
-#: panels/printers/pp-details-dialog.c:241
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"PostScript presilo-priskribaj dosieroj (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
 
-#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Loko"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:122
-#: panels/printers/pp-ppd-selection-dialog.c:239
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Pelilo"
 
-#: panels/printers/pp-details-dialog.ui:162
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Serĉante por preferitaj pelilojn…"
 
-#: panels/printers/pp-details-dialog.ui:183
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Serĉi petilojn"
 
-#: panels/printers/pp-details-dialog.ui:192
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Elektu el datumbazo…"
 
-#: panels/printers/pp-details-dialog.ui:201
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Instali PPD-dosieron…"
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "Elekti presil-pelilon"
-
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:107
-msgid "Select"
-msgstr "Elekti"
 
 #: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "Ŝargante pelilan datumbazon…"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect presilo"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Nuligi"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD-presilo"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Elekti"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Unuflanka"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Longa flanko (norma)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Mallonga flanko (renversa)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Portreto"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Pejzaĝo"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Renversita pejzaĝo"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Renversita portreto"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:106
-msgctxt "print job"
-msgid "Pending"
-msgstr "Atendante"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:112
-msgctxt "print job"
-msgid "Paused"
-msgstr "Paŭzita"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:117
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Aŭtentigo necesas"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:122
-msgctxt "print job"
-msgid "Processing"
-msgstr "Traktado"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:126
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Haltigita"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:130
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Nuligita"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Rompita"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:138
-msgctxt "print job"
-msgid "Completed"
-msgstr "Plenumita"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:249
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u tasko bezonas aŭtentigon"
 msgstr[1] "%u taskoj bezonas aŭtentigon"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:401
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Aktivaj taskoj"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:405
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Entajpu akreditaĵojn por presi el %s."
-
 #. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/pp-jobs-dialog.ui:44
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
 msgid "Domain"
 msgstr "Domajno"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:129
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "_Aŭtentigi"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:169
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Vakigi ĉion"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:232
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Aŭtentigi"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:358
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Neniu aktiva presa tasko"
 
-#: panels/printers/pp-new-printer-dialog.c:359
-msgid "Unlock Print Server"
-msgstr "Malŝlosi presservilon"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:363
-#, c-format
-msgid "Unlock %s."
-msgstr "Malŝlosi %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:367
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Enigu uzantonomon kaj pasvorton por vidi presilojn je %s."
-
-#: panels/printers/pp-new-printer-dialog.c:790
-msgid "Searching for Printers"
-msgstr "Serĉante presilojn"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1578
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1583
-msgid "Serial Port"
-msgstr "Seria pordo"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1590
-msgid "Parallel Port"
-msgstr "Paralela pordo"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1632
-#, c-format
-msgid "Location: %s"
-msgstr "Loko: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1637
-#, c-format
-msgid "Address: %s"
-msgstr "Adreso: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1664
-msgid "Server requires authentication"
-msgstr "Servilo necesas aŭtentigon"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Duflanka"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Speco de papero"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Papera fonto"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Eliga pleto"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Distingivo"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript-antaŭfiltrado"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:530
-msgid "Pages per side"
-msgstr "Paĝoj po flanko"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:542
-msgid "Two-sided"
-msgstr "Duflanka"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:554
-msgid "Orientation"
-msgstr "Orientiĝo"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:651
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Ĝenerala"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Paĝ-agordo"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Instaleblaj opcioj"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Tasko"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Bild-kvalito"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Koloro"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Finigante"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Altnivela"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:857
-#: panels/printers/pp-options-dialog.ui:18
+#: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testpaĝo"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:870
-msgid "Test page"
-msgstr "Testpaĝo"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Elekti aŭtomate"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Implicita agordo de presilo"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Enkorpigi nur GhostScript-ajn tiparojn"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Konverti al PS-nivelo 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Konverti al PS-nivelo 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Neniu antaŭfiltrado"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:223
-msgid "Manufacturer"
-msgstr "Fabrikanto"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:523 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr "Neniuj aktivaj taskoj"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:528
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u tasko"
 msgstr[1] "%u taskoj"
 
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:648
-msgid "Clean print heads"
-msgstr "Purigi presilajn kapetojn"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:713
-msgid "Low on toner"
-msgstr "Malmulte da inko"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:715
-msgid "Out of toner"
-msgstr "Neniu inko"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:718
-msgid "Low on developer"
-msgstr "Malmulte da fotokreilkemiaĵo"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of developer"
-msgstr "Neniu fotokreilkemiaĵo"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:723
-msgid "Low on a marker supply"
-msgstr "Malmulte da inkpulvora provizo"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:725
-msgid "Out of a marker supply"
-msgstr "Neniu inkpulvora provizo"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:727
-msgid "Open cover"
-msgstr "Malfermi kovrilon"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:729
-msgid "Open door"
-msgstr "Malfermi pordon"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:731
-msgid "Low on paper"
-msgstr "Malmulte da papero"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:733
-msgid "Out of paper"
-msgstr "Neniu papero"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:735
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Nekonektita"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:737
-#: panels/printers/pp-printer-entry.c:880
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Haltigita"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:739
-msgid "Waste receptacle almost full"
-msgstr "Forĵetaĵulo preskaŭ plena"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:741
-msgid "Waste receptacle full"
-msgstr "Forĵetaĵujo plena"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:743
-msgid "The optical photo conductor is near end of life"
-msgstr "La optika fotokonduktilo apudas al fino de vivo"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:745
-msgid "The optical photo conductor is no longer functioning"
-msgstr "La optika fotokonduktilo ne plu funkcias"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:866
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Prete"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:871
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Ne akceptas taskojn"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:876
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Traktado"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "Presilaj agordoj"
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "Presilaj detaloj"
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "Agordi presilon kiel implicita"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "Purigi presilajn kapetojn"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Forigi presilon"
 
-#: panels/printers/printer-entry.ui:193
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Neniuj aktivaj taskoj"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Modelo"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Nivelo de inko"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:313
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Bonvolu restartigi kiam la problemo malaperis."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:320
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Restartigi"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:12
-msgid "Add…"
-msgstr "Aldoni…"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Aldoni presilon…"
 
-#: panels/printers/printers.ui:187
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Aldoni presilon…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Neniuj presiloj"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:201
-msgid "Add a Printer…"
-msgstr "Aldoni presilon…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:233
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Pardonon! Ŝajnas, ke la sistema\n"
 "presservilo ne disponeblas."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:189
-#: panels/region/cc-format-chooser.ui:6 panels/region/cc-region-panel.ui:159
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formoj"
 
-#: panels/region/cc-format-chooser.ui:101
-msgid ""
-"Choose the format for numbers, dates and currencies. Changes take effect on "
-"next login."
-msgstr ""
-"Elektu formon por numeroj, datoj, kaj valutoj. Ŝanĝoj efektiviĝas post via "
-"sekva saluto."
-
-#: panels/region/cc-format-chooser.ui:117
-msgid "Search locales..."
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
 msgstr "Serĉi lokaĵarojn…"
 
-#: panels/region/cc-format-chooser.ui:158
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Oftaj formoj"
 
-#: panels/region/cc-format-chooser.ui:189
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Ciuj formoj"
 
-#: panels/region/cc-format-chooser.ui:242
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Neniu rezulto troviĝis"
 
-#: panels/region/cc-format-chooser.ui:255
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Oni povas serĉi kaj landojn kaj lingvojn."
 
-#: panels/region/cc-format-chooser.ui:300
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Antaŭrigardo"
 
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperia"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metra"
-
-#: panels/region/cc-format-preview.ui:18
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Datoj"
 
-#: panels/region/cc-format-preview.ui:62
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "Datoj & tempoj"
 
-#: panels/region/cc-format-preview.ui:84
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Numeroj"
 
-#: panels/region/cc-format-preview.ui:106
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Mezuro"
 
-#: panels/region/cc-format-preview.ui:128
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Papero"
 
-#: panels/region/cc-region-panel.c:740
-msgid "Login _Screen"
-msgstr "Ensaluta _ekrano"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#: panels/region/cc-region-panel.ui:34
-msgid "Language"
-msgstr "Lingvo"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
 #: panels/region/cc-region-panel.ui:45
-msgid "The language used for text in windows and web pages."
-msgstr "La lingvo kiun oni uzas por teksto en fenestroj kaj retpaĝoj."
+#, fuzzy
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr "La formo kiun oni uzas por numeroj, datoj, kaj valutoj."
 
-#: panels/region/cc-region-panel.ui:85
-#: panels/user-accounts/cc-user-panel.ui:406
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Instali lingvojn..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Via konto"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Lingvo"
 
-#: panels/region/cc-region-panel.ui:120
-msgid "Restart the session for changes to take effect"
-msgstr "Restartigi la seancon por ke la ŝanĝoj efektiviĝas"
-
-#: panels/region/cc-region-panel.ui:135
-msgid "Restart…"
-msgstr "Restartigi…"
-
-#: panels/region/cc-region-panel.ui:170
-msgid "The format used for numbers, dates, and currencies."
-msgstr "La formo kiun oni uzas por numeroj, datoj, kaj valutoj."
-
-#: panels/region/cc-region-panel.ui:204
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formoj"
 
-#: panels/region/cc-region-panel.ui:231
-msgid "Login settings are used by all users when logging into the system"
-msgstr "Salutaj agordoj estas uzataj de ĉiuj uzantoj kiam salutante sistemen"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Ensaluta _ekrano"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Regiono & lingvo"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr ""
 "Elektu vian montran lingvon, formojn, klavararanĝojn kaj enigajn fontojn"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Lingvo;Klavararanĝo;Klavaro;Enigo;"
 
-#: panels/removable-media/cc-removable-media-panel.c:267
-msgid "Ask what to do"
-msgstr "Demandi kion fari"
-
-#: panels/removable-media/cc-removable-media-panel.c:271
-msgid "Do nothing"
-msgstr "Fari nenion"
-
-#: panels/removable-media/cc-removable-media-panel.c:275
-msgid "Open folder"
-msgstr "Malfermi dosierujon"
-
-#: panels/removable-media/cc-removable-media-panel.c:341
-msgid "Other Media"
-msgstr "Aliaj datumportiloj"
-
-#: panels/removable-media/cc-removable-media-panel.c:362
-msgid "Select an application for audio CDs"
-msgstr "Elekti aplikaĵon por son-KDj"
-
-#: panels/removable-media/cc-removable-media-panel.c:363
-msgid "Select an application for video DVDs"
-msgstr "Elekti aplikaĵon por video-DVDj"
-
-#: panels/removable-media/cc-removable-media-panel.c:364
-msgid "Select an application to run when a music player is connected"
-msgstr "Elektu rulendan aplikaĵon kiam muzikludilo estas konektita"
-
-#: panels/removable-media/cc-removable-media-panel.c:365
-msgid "Select an application to run when a camera is connected"
-msgstr "Elektu rulendan aplikaĵon kiam kamerao estas konektita"
-
-#: panels/removable-media/cc-removable-media-panel.c:366
-msgid "Select an application for software CDs"
-msgstr "Elekti aplikaĵon por programar-KDj"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "audio DVD"
-msgstr "son-DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "blank Blu-ray disc"
-msgstr "malplena Blu-radia disko"
-
-#: panels/removable-media/cc-removable-media-panel.c:380
-msgid "blank CD disc"
-msgstr "malplena KD-disko"
-
-#: panels/removable-media/cc-removable-media-panel.c:381
-msgid "blank DVD disc"
-msgstr "malplena DVD-disko"
-
-#: panels/removable-media/cc-removable-media-panel.c:382
-msgid "blank HD DVD disc"
-msgstr "malplena HD-DVD-disko"
-
-#: panels/removable-media/cc-removable-media-panel.c:383
-msgid "Blu-ray video disc"
-msgstr "Blu-radia videodisko"
-
-#: panels/removable-media/cc-removable-media-panel.c:384
-msgid "e-book reader"
-msgstr "retlibrolegilo"
-
-#: panels/removable-media/cc-removable-media-panel.c:385
-msgid "HD DVD video disc"
-msgstr "HD-DVD-videodisko"
-
-#: panels/removable-media/cc-removable-media-panel.c:386
-msgid "Picture CD"
-msgstr "Bild-KD"
-
-#: panels/removable-media/cc-removable-media-panel.c:387
-msgid "Super Video CD"
-msgstr "Super-Video-KD"
-
-#: panels/removable-media/cc-removable-media-panel.c:388
-msgid "Video CD"
-msgstr "Video-KD"
-
-#: panels/removable-media/cc-removable-media-panel.c:389
-msgid "Windows software"
-msgstr "Windows-programaro"
-
-#: panels/removable-media/cc-removable-media-panel.ui:44
+#: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
 msgstr "Elektu kiel datumportiloj estu traktitaj"
 
-#: panels/removable-media/cc-removable-media-panel.ui:75
+#: panels/removable-media/cc-removable-media-panel.ui:52
 msgid "CD _audio"
 msgstr "_Son-KD"
 
-#: panels/removable-media/cc-removable-media-panel.ui:92
+#: panels/removable-media/cc-removable-media-panel.ui:67
 msgid "_DVD video"
 msgstr "_DVD-video"
 
-#: panels/removable-media/cc-removable-media-panel.ui:133
+#: panels/removable-media/cc-removable-media-panel.ui:102
 msgid "_Music player"
 msgstr "_Muzikludilo"
 
-#: panels/removable-media/cc-removable-media-panel.ui:191
+#: panels/removable-media/cc-removable-media-panel.ui:152
 msgid "_Software"
 msgstr "_Programaro"
 
-#: panels/removable-media/cc-removable-media-panel.ui:229
+#: panels/removable-media/cc-removable-media-panel.ui:178
 msgid "_Other Media…"
 msgstr "_Aliaj datumportiloj…"
 
-#: panels/removable-media/cc-removable-media-panel.ui:288
+#: panels/removable-media/cc-removable-media-panel.ui:195
 msgid "_Never prompt or start programs on media insertion"
 msgstr "_Neniam lanĉi programarojn dum enmeto de datumportilo"
 
-#: panels/removable-media/cc-removable-media-panel.ui:342
+#: panels/removable-media/cc-removable-media-panel.ui:225
 msgid "Select how other media should be handled"
 msgstr "Elektu kiel aliaj datumportiloj estu traktitaj"
 
-#: panels/removable-media/cc-removable-media-panel.ui:389
+#: panels/removable-media/cc-removable-media-panel.ui:259
 msgid "_Action:"
 msgstr "_Ago:"
 
-#: panels/removable-media/cc-removable-media-panel.ui:412
+#: panels/removable-media/cc-removable-media-panel.ui:278
 msgid "_Type:"
 msgstr "_Speco:"
 
@@ -5737,7 +3340,6 @@ msgstr "Demetebla datumportilo"
 msgid "Configure Removable Media settings"
 msgstr "Agordi demeteblajn datumportilojn"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5746,22 +3348,87 @@ msgstr ""
 "aparato;sistemo;implicita;aplikaĵo;preferita;kd;dvd;usb;sono;video;disko;"
 "demetebla;datumportilo;aŭtomata;lanĉo;"
 
-#: panels/search/cc-search-locations-dialog.c:636
-msgid "Select Location"
-msgstr "Elekti lokon"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Ekrana ŝloso"
 
-#: panels/search/cc-search-locations-dialog.c:640
-msgid "_OK"
-msgstr "_Bone"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Aŭtomata ŝlosado de la ekrano malhelpas ke aliuloj povu aliri vian "
+"komputilon dum via foresto."
 
-#: panels/search/cc-search-locations-dialog.ui:9
-#: panels/search/cc-search-panel.ui:59
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Malfruo antaŭ ol malplena ekrano"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Paŭzo post kiu la ekrano malpleniĝas."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Aŭtomata ekrana ŝ_loso"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Malfruo _antaŭ ol ekrana ŝloso"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Paŭzo inter la malpleniĝo de la ekrano kaj ĝia ŝlosado."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Montri _sciigojn sur ŝlosa ekrano"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Sciigoj sur ŝ_losa ekrano"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Malpermesi novajn _USB-aparatojn."
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Malhelpi ke novaj USB-aparatoj interagu kun la sistemo dum la ekrano estas "
+"ŝlosita."
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Privateco"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekrano"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Ekran-kunhavigado"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "Serĉaj lokoj"
 
-#: panels/search/cc-search-locations-dialog.ui:32
-#: panels/search/cc-search-locations-dialog.ui:69
-#: panels/search/cc-search-locations-dialog.ui:107
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
@@ -5769,34 +3436,47 @@ msgstr ""
 "Disierujoj kiujn serĉas sistemaj aplikaĵoj kiel Dosieroj, Fotoj, kaj "
 "Videaĵoj."
 
-#: panels/search/cc-search-locations-dialog.ui:52
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr "Lokoj"
 
-#: panels/search/cc-search-locations-dialog.ui:91
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Legosignoj"
 
-#: panels/search/cc-search-locations-dialog.ui:156
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Alia"
 
-#: panels/search/cc-search-panel.c:152
-msgid "No applications found"
-msgstr "Neniuj aplikaĵoj trovitaj"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Loko"
 
-#: panels/search/cc-search-panel-row.ui:92
-msgid "Move Up"
-msgstr "Movi supren"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Aplikaĵo"
 
-#: panels/search/cc-search-panel-row.ui:102
-msgid "Move Down"
-msgstr "Movi malsupren"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: panels/search/cc-search-panel.ui:31
-msgid ""
-"Control which search results are shown in the Activities Overview. The order "
-"of search results can also be changed by moving rows in the list."
+#: panels/search/cc-search-panel.ui:23
+#, fuzzy
+msgid "Folders which are searched by system applications."
+msgstr ""
+"Disierujoj kiujn serĉas sistemaj aplikaĵoj kiel Dosieroj, Fotoj, kaj "
+"Videaĵoj."
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Neniu rezulto troviĝis"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
 msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
@@ -5806,162 +3486,140 @@ msgstr ""
 "Difini por kiuj aplikaĵoj montri serĉajn rezultojn en la Aktivecoj-"
 "Superrigardo"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Serĉi;Trovi;Indeksi;Kaŝi;Privateco;Rezultoj;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:306
-msgid "No networks selected for sharing"
-msgstr "Neniuj retoj estas elektitaj por kunhavigado"
-
-#: panels/sharing/cc-sharing-networks.ui:19
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Retoj"
 
-#: panels/sharing/cc-sharing-panel.c:289
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Ŝaltita"
-
-#: panels/sharing/cc-sharing-panel.c:291 panels/sharing/cc-sharing-panel.c:318
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Malŝaltita"
-
-#: panels/sharing/cc-sharing-panel.c:321
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Ŝaltita"
-
-#: panels/sharing/cc-sharing-panel.c:324
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktiva"
-
-#: panels/sharing/cc-sharing-panel.c:393
-msgid "Choose a Folder"
-msgstr "Elektu dosierujon"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:696
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Dosier-kunhavigado permesas al vi kunhavigi vian Publikan dosieron kun aliaj "
-"ĉe via ĉimomenta reto uzante: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:702
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Kiam defora salutado estas ŝaltita, deforaj uzantoj povas konekti uzante la "
-"sekuran ŝelan komando:\n"
-"%s"
-
-#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:708
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to %s"
-msgstr ""
-"Ekran-kunhavigado permesas al deforaj uzantoj vidi aŭ regi vian ekranon per "
-"konekti al %s"
-
-#: panels/sharing/cc-sharing-panel.c:813
-msgid "Copy"
-msgstr "Kopii"
-
-#: panels/sharing/cc-sharing-panel.c:1203
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Kunhavigo"
 
-#: panels/sharing/cc-sharing-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr "_Komputila nomo"
 
-#: panels/sharing/cc-sharing-panel.ui:79
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr "_Dosier-kunhavigado"
 
-#: panels/sharing/cc-sharing-panel.ui:87
-msgid "_Screen Sharing"
-msgstr "_Ekran-kunhavigado"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Labortablo"
 
-#: panels/sharing/cc-sharing-panel.ui:95
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr "_Aŭdovid-kunhavigado"
 
-#: panels/sharing/cc-sharing-panel.ui:103
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr "_Defora salutado"
 
-#: panels/sharing/cc-sharing-panel.ui:119
-msgid "Some services are disabled because of no network access."
-msgstr "Kelkaj servoj estas malŝaltitaj pro manko de retaliro."
-
-#: panels/sharing/cc-sharing-panel.ui:137
-#: panels/sharing/cc-sharing-panel.ui:264
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr "Dosier-kunhavigado"
 
-#: panels/sharing/cc-sharing-panel.ui:184
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr "_Bezonas pasvorton"
 
-#: panels/sharing/cc-sharing-panel.ui:275
-#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "Defora salutado"
 
-#: panels/sharing/cc-sharing-panel.ui:368
-#: panels/sharing/cc-sharing-panel.ui:590
-msgid "Screen Sharing"
-msgstr "Ekran-kunhavigado"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Labortablo"
 
-#: panels/sharing/cc-sharing-panel.ui:422
-msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Ŝalti aŭ malŝalti deforan salutadon"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Laŭtecregilo"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
 msgstr "_Permesi al konektoj regi la ekranon"
 
-#: panels/sharing/cc-sharing-panel.ui:447
-msgid "_Password:"
-msgstr "_Pasvorto:"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Ne konekita"
 
-#: panels/sharing/cc-sharing-panel.ui:477
-msgid "_Show Password"
-msgstr "_Montri pasvorton"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:508
-msgid "Access Options"
-msgstr "Aliro-agordoj"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopii"
 
-#: panels/sharing/cc-sharing-panel.ui:522
-msgid "_New connections must ask for access"
-msgstr "_Novaj konektoj devas peti aliron"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Forigi adreson"
 
-#: panels/sharing/cc-sharing-panel.ui:540
-msgid "_Require a password"
-msgstr "_Bezonas pasvorton"
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Aŭ_tentigo"
 
-#: panels/sharing/cc-sharing-panel.ui:601
-#: panels/sharing/cc-sharing-panel.ui:695
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Uzantonomo:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Fingropremo"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Aŭdovid-kunhavigado"
 
-#: panels/sharing/cc-sharing-panel.ui:634
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Kunhavigi muzikon, fotojn kaj videojn sur la reto."
 
-#: panels/sharing/cc-sharing-panel.ui:649
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Dosierujoj"
 
@@ -5969,7 +3627,6 @@ msgstr "Dosierujoj"
 msgid "Control what you want to share with others"
 msgstr "Regi kion vi volas kunhavigi kun aliaj"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -5987,99 +3644,96 @@ msgstr "Ŝalti aŭ malŝalti deforan salutadon"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Aŭtentigo necesas por ŝalti aŭ malŝalti deforan salutadon"
 
-#: panels/sound/cc-alert-chooser.c:151
-msgid "Custom"
-msgstr "Propra"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Bojo"
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
 
-#: panels/sound/cc-alert-chooser.ui:19
-msgid "Drip"
-msgstr "Guto"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Kunhavigo"
 
-#: panels/sound/cc-alert-chooser.ui:26
-msgid "Glass"
-msgstr "Vitro"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:33
-msgid "Sonar"
-msgstr "Sonaro"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
-msgid "Rear"
-msgstr "Malantaŭa"
-
-#: panels/sound/cc-fade-slider.ui:15
-msgid "Front"
-msgstr "Antaŭa"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Testante %s"
-
-#: panels/sound/cc-output-test-dialog.ui:127
-msgid "Click a speaker to test"
-msgstr "Alklaku laŭtparolilon por testi"
-
-#: panels/sound/cc-sound-panel.ui:27
-msgid "System Volume"
-msgstr "Sistemlaŭteco"
-
-#: panels/sound/cc-sound-panel.ui:43
-msgid "Volume Levels"
-msgstr "Laŭtecaj niveloj"
-
-#: panels/sound/cc-sound-panel.ui:65
-msgid "Output"
-msgstr "Eligo"
-
-#: panels/sound/cc-sound-panel.ui:92
-msgid "Output Device"
-msgstr "Eliga aparato"
-
-#: panels/sound/cc-sound-panel.ui:115
-msgid "Test"
-msgstr "Testi"
-
-#: panels/sound/cc-sound-panel.ui:146 panels/sound/cc-sound-panel.ui:323
-msgid "Configuration"
-msgstr "Agordoj"
-
-#: panels/sound/cc-sound-panel.ui:179
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 msgid "Balance"
 msgstr "Ekvilibro"
 
-#: panels/sound/cc-sound-panel.ui:206
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 msgid "Fade"
 msgstr "Dissolvo"
 
-#: panels/sound/cc-sound-panel.ui:233
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Malantaŭa"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Antaŭa"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Alklaku laŭtparolilon por testi"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Sistemlaŭteco"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Sistemlaŭteco"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Laŭtecaj niveloj"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Eligo"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Eliga aparato"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testi"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Agordoj"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Bas-laŭtparolilo"
 
-#: panels/sound/cc-sound-panel.ui:255
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Enigo"
 
-#: panels/sound/cc-sound-panel.ui:282
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Eniga aparato"
 
-#: panels/sound/cc-sound-panel.ui:356
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Laŭteco"
 
-#: panels/sound/cc-sound-panel.ui:378
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Laŭteco por avertoj"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Silentigi"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6089,7 +3743,6 @@ msgstr "Sono"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Ŝanĝi sonan laŭtecon, enigojn, eligojn, kaj avertajn sonojn"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6097,164 +3750,62 @@ msgstr ""
 "Karto;Mikrofono;Laŭteco;Dissolvo;Ekvilibro;Bludento;Kapaŭskultilo;Sono;Enigo;"
 "Eliro;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Malkonektita"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Konektante"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Konektita"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Aŭtentiga eraro"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Aŭtentigante"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Malpliigita funkciado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Konektita & aŭtentigita"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Nekonata"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr "Aŭtentigita je:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-msgid "Connected at:"
-msgstr "Konektita je:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-msgid "Enrolled at:"
-msgstr "Aligita je:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-msgid "Failed to authorize device: "
-msgstr "Malsukcesis aŭtentigi aparaton: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-msgid "Failed to forget device: "
-msgstr "Malsukcesis forgesi aparaton: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] "Dependas je %u alia aparato"
 msgstr[1] "Dependas je %u aliaj aparatoj"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Sciigoj"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Nomo:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Stato:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Aŭtentigi kaj konekti"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Forgesi aparaton"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Eraro"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Aŭtentigita"
-
-#: panels/thunderbolt/cc-bolt-panel.c:175
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"La Thunderbolt subsistemo (boltd) ne estas instalita aŭ ne estas ĝuste "
-"agordigita."
-
-#: panels/thunderbolt/cc-bolt-panel.c:468
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Ne povis trovi Thunderbolt.\n"
-"Aŭ la sistemo malhavas Thunderbolt subtenon, aŭ la subteno estas malŝaltita "
-"en la BIOS, aŭ ĝi estas agordita je nesubtenita sekureca nivelo en la BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:512
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt subteno estas malŝaltita en la BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:516
-msgid "Thunderbolt security level could not be determined."
-msgstr "Ne eblis difini Thunderbolt sekurecan nivelon."
-
-#: panels/thunderbolt/cc-bolt-panel.c:621
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Eraro dum ŝanĝi direktan reĝimon: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+#, fuzzy
+msgid "No Thunderbolt Support"
 msgstr "Neniu Thunderbolt subteno"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:246
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Ne eblis koneti al la %s domajno: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Rekta atingo"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr "Permeti rektan atingon al aparatoj kiel dokoj kaj eksteraj vidkartoj."
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr "Nur USB kaj Display Port aparatoj povas alfiksi."
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Atendantaj aparatoj"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Neniu aparatoj estas alfiksitaj"
 
@@ -6266,389 +3817,321 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Mastrumi Thunderbolt aparatojn"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privateco;"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:7
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 msgid "Cursor Blinking"
 msgstr "Pulsanta tajpmontrilo"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:37
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Tajpmontrilo pulsas en tekstkampo."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:74
-#: panels/universal-access/cc-repeat-keys-dialog.ui:145
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Rapideco"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:101
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Tajpmontrila pulsrapideco"
 
-#: panels/universal-access/cc-cursor-size-dialog.ui:7
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr "Grando de musmontrilo"
 
-#: panels/universal-access/cc-cursor-size-dialog.ui:29
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 "Grando de musmontrilo povas esti kombinita kun zomo por plifaciligi vidadon "
 "de musmontrilon."
 
-#: panels/universal-access/cc-pointing-dialog.ui:7
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "Alklaka asisto"
 
-#: panels/universal-access/cc-pointing-dialog.ui:43
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "_Simulita duaranĝa alklako"
 
-#: panels/universal-access/cc-pointing-dialog.ui:56
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "Fari duaranĝan alklakon per premteni la ĉefa butono"
 
-#: panels/universal-access/cc-pointing-dialog.ui:79
-#: panels/universal-access/cc-typing-dialog.ui:158
-#: panels/universal-access/cc-typing-dialog.ui:307
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
 msgid "A_cceptance delay:"
 msgstr "Antaŭak_cepta prokrasto:"
 
-#: panels/universal-access/cc-pointing-dialog.ui:95
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Mallonga"
 
-#: panels/universal-access/cc-pointing-dialog.ui:110
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "Duaranĝa-alklaka prokrasto"
 
-#: panels/universal-access/cc-pointing-dialog.ui:120
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Longa"
 
-#: panels/universal-access/cc-pointing-dialog.ui:157
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "Ŝ_veba alklako"
 
-#: panels/universal-access/cc-pointing-dialog.ui:170
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "Fari alklakon kiam la musmontrilo ŝvebas"
 
-#: panels/universal-access/cc-pointing-dialog.ui:193
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "_Prokrasto:"
 
-#: panels/universal-access/cc-pointing-dialog.ui:210
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Mallonga"
 
-#: panels/universal-access/cc-pointing-dialog.ui:232
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Longa"
 
-#: panels/universal-access/cc-pointing-dialog.ui:253
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "_Mov-sojlo:"
 
-#: panels/universal-access/cc-pointing-dialog.ui:270
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Malgranda"
 
-#: panels/universal-access/cc-pointing-dialog.ui:292
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Granda"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:7
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
 msgid "Repeat Keys"
 msgstr "Ripeti klavojn"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:37
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Klavpremoj ripetas kiam klavo estas tenata malsupre."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:102
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Ripetklava prokrasto"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:174
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Ripetklava rapido"
 
-#: panels/universal-access/cc-sound-keys-dialog.ui:7
-msgid "Sound Keys"
-msgstr "Son-klavoj"
-
-#: panels/universal-access/cc-sound-keys-dialog.ui:25
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "Pepi kiam majuskla kaj nombra baskuloj estas ŝaltita aŭ malŝaltita."
-
-#: panels/universal-access/cc-sound-keys-dialog.ui:45
-#: panels/universal-access/cc-ua-panel.ui:374
-msgid "_Sound Keys"
-msgstr "_Son-klavoj"
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:7
-msgid "Screen Reader"
-msgstr "Ekranlegilo"
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:24
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "La ekranlegilo legas vidigan tekston, kiun vi fokusas."
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:52
-msgid "_Screen Reader"
-msgstr "_Ekranlegilo"
-
-#: panels/universal-access/cc-typing-dialog.ui:7
+#: panels/universal-access/cc-typing-dialog.ui:4
 msgid "Typing Assist"
 msgstr "Tajpada asisto"
 
-#: panels/universal-access/cc-typing-dialog.ui:46
+#: panels/universal-access/cc-typing-dialog.ui:41
 msgid "_Sticky Keys"
 msgstr "Fik_saj klavoj"
 
-#: panels/universal-access/cc-typing-dialog.ui:58
+#: panels/universal-access/cc-typing-dialog.ui:51
 msgid "Treats a sequence of modifier keys as a key combination"
 msgstr "Traktas sinsekvon de modifaj klavoj kiel klavkombino"
 
-#: panels/universal-access/cc-typing-dialog.ui:72
+#: panels/universal-access/cc-typing-dialog.ui:63
 msgid "_Disable if two keys are pressed together"
 msgstr "_Malŝalti se du klavoj estas kune premitaj"
 
-#: panels/universal-access/cc-typing-dialog.ui:85
+#: panels/universal-access/cc-typing-dialog.ui:71
 msgid "Beep when a _modifier key is pressed"
 msgstr "Pepi se _modifa klavo estas premata"
 
-#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:96
 msgid "S_low Keys"
 msgstr "_Malrapidaj klavoj"
 
-#: panels/universal-access/cc-typing-dialog.ui:135
+#: panels/universal-access/cc-typing-dialog.ui:106
 msgid "Puts a delay between when a key is pressed and when it is accepted"
 msgstr "Enigas prokraston inter klavpremo kaj ties akcepto"
 
-#: panels/universal-access/cc-typing-dialog.ui:175
+#: panels/universal-access/cc-typing-dialog.ui:135
 msgctxt "slow keys delay"
 msgid "Short"
 msgstr "Mallonga"
 
-#: panels/universal-access/cc-typing-dialog.ui:190
+#: panels/universal-access/cc-typing-dialog.ui:147
 msgid "Slow keys typing delay"
 msgstr "Malrapidklava tajpada prokrasto"
 
-#: panels/universal-access/cc-typing-dialog.ui:200
+#: panels/universal-access/cc-typing-dialog.ui:154
 msgctxt "slow keys delay"
 msgid "Long"
 msgstr "Longa"
 
-#: panels/universal-access/cc-typing-dialog.ui:212
+#: panels/universal-access/cc-typing-dialog.ui:166
 msgid "Beep when a key is pr_essed"
 msgstr "Pepi se klavo estas pr_emata"
 
-#: panels/universal-access/cc-typing-dialog.ui:224
+#: panels/universal-access/cc-typing-dialog.ui:173
 msgid "Beep when a key is _accepted"
 msgstr "Pepi se klavo estas _akceptita"
 
-#: panels/universal-access/cc-typing-dialog.ui:236
-#: panels/universal-access/cc-typing-dialog.ui:361
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
 msgid "Beep when a key is _rejected"
 msgstr "Pepi kiam klavo estas malak_ceptita"
 
-#: panels/universal-access/cc-typing-dialog.ui:272
+#: panels/universal-access/cc-typing-dialog.ui:203
 msgid "_Bounce Keys"
 msgstr "_Saltaj klavoj"
 
-#: panels/universal-access/cc-typing-dialog.ui:284
+#: panels/universal-access/cc-typing-dialog.ui:213
 msgid "Ignores fast duplicate keypresses"
 msgstr "Malatenti rapidajn duoblajn klavpremojn"
 
-#: panels/universal-access/cc-typing-dialog.ui:324
+#: panels/universal-access/cc-typing-dialog.ui:242
 msgctxt "bounce keys delay"
 msgid "Short"
 msgstr "Mallonga"
 
-#: panels/universal-access/cc-typing-dialog.ui:339
+#: panels/universal-access/cc-typing-dialog.ui:254
 msgid "Bounce keys typing delay"
 msgstr "Saltklava tajpada prokrasto"
 
-#: panels/universal-access/cc-typing-dialog.ui:349
+#: panels/universal-access/cc-typing-dialog.ui:261
 msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Longa"
 
-#: panels/universal-access/cc-typing-dialog.ui:437
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "Ŝalti p_er klavaro"
 
-#: panels/universal-access/cc-typing-dialog.ui:449
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Ŝalti kaj malŝalti funkciojn por universala aliro per la klavaro"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:348
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Implicita"
-
-#: panels/universal-access/cc-ua-panel.c:351
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Meza"
-
-#: panels/universal-access/cc-ua-panel.c:354
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Granda"
-
-#: panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Pli granda"
-
-#: panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Plej granda"
-
-#: panels/universal-access/cc-ua-panel.c:364
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d bildero"
-msgstr[1] "%d bilderoj"
-
-#: panels/universal-access/cc-ua-panel.ui:55
+#: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Ĉi_am montri la menuon de alirebleco"
 
-#: panels/universal-access/cc-ua-panel.ui:97
+#: panels/universal-access/cc-ua-panel.ui:31
 msgid "Seeing"
 msgstr "Vidi"
 
-#: panels/universal-access/cc-ua-panel.ui:143
+#: panels/universal-access/cc-ua-panel.ui:34
 msgid "_High Contrast"
 msgstr "_Alta kontrasto"
 
-#: panels/universal-access/cc-ua-panel.ui:190
+#: panels/universal-access/cc-ua-panel.ui:46
 msgid "_Large Text"
 msgstr "_Granda teksto"
 
-#: panels/universal-access/cc-ua-panel.ui:235
-msgid "C_ursor Size"
-msgstr "_Grando de musmontrilo"
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:282
-#: panels/universal-access/cc-zoom-options-dialog.ui:91
-msgid "_Zoom"
-msgstr "_Zomo"
-
-#: panels/universal-access/cc-ua-panel.ui:328
+#: panels/universal-access/cc-ua-panel.ui:70
 msgid "Screen _Reader"
 msgstr "Ek_ranlegilo"
 
-#: panels/universal-access/cc-ua-panel.ui:436
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "La ekranlegilo legas vidigan tekston, kiun vi fokusas."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Son-klavoj"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pepi kiam majuskla kaj nombra baskuloj estas ŝaltita aŭ malŝaltita."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "_Grando de musmontrilo"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zomo"
+
+#: panels/universal-access/cc-ua-panel.ui:138
 msgid "Hearing"
 msgstr "Aŭdado"
 
-#: panels/universal-access/cc-ua-panel.ui:480
-#: panels/universal-access/cc-visual-alerts-dialog.ui:68
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
 msgid "_Visual Alerts"
 msgstr "_Videblaj avertoj"
 
-#: panels/universal-access/cc-ua-panel.ui:588
+#: panels/universal-access/cc-ua-panel.ui:166
 msgid "Screen _Keyboard"
 msgstr "Ekran_klavaro"
 
-#: panels/universal-access/cc-ua-panel.ui:633
+#: panels/universal-access/cc-ua-panel.ui:178
 msgid "R_epeat Keys"
 msgstr "Rip_eti klavojn"
 
-#: panels/universal-access/cc-ua-panel.ui:679
+#: panels/universal-access/cc-ua-panel.ui:198
 msgid "Cursor _Blinking"
 msgstr "_Pulsado de tajpmontrilo"
 
-#: panels/universal-access/cc-ua-panel.ui:725
+#: panels/universal-access/cc-ua-panel.ui:218
 msgid "_Typing Assist (AccessX)"
 msgstr "_Tajpada asisto (AccessX)"
 
-#: panels/universal-access/cc-ua-panel.ui:786
-msgid "Pointing & Clicking"
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
 msgstr "Indiki & klaki"
 
-#: panels/universal-access/cc-ua-panel.ui:832
+#: panels/universal-access/cc-ua-panel.ui:243
 msgid "_Mouse Keys"
 msgstr "_Musklavoj"
 
-#: panels/universal-access/cc-ua-panel.ui:877
+#: panels/universal-access/cc-ua-panel.ui:255
 msgid "_Locate Pointer"
 msgstr "_Lokigi indikilon"
 
-#: panels/universal-access/cc-ua-panel.ui:909
+#: panels/universal-access/cc-ua-panel.ui:267
 msgid "_Click Assist"
 msgstr "_Alklaka asisto"
 
-#: panels/universal-access/cc-ua-panel.ui:955
+#: panels/universal-access/cc-ua-panel.ui:287
 msgid "_Double-Click Delay"
 msgstr "_Duobla-klaka prokrasto"
 
-#: panels/universal-access/cc-ua-panel.ui:975
+#: panels/universal-access/cc-ua-panel.ui:297
 msgid "Double-Click Delay"
 msgstr "Duobla-klaka prokrasto"
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:15
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
 msgid "Visual Alerts"
 msgstr "Vidaj avertoj"
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:19
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
 msgid "_Test flash"
 msgstr "_Provi fulmadon"
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:48
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
 msgid "Use a visual indication when an alert sound occurs."
 msgstr "Uzi vidan indikon kiam averta sono okazas."
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:94
-msgid "Flash the entire _window"
-msgstr "Fulmi la tutan _fenestron"
-
-#: panels/universal-access/cc-visual-alerts-dialog.ui:112
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
 msgid "Flash the entire _screen"
 msgstr "Fulmi la tutan _ekranon"
 
-#: panels/universal-access/cc-zoom-options-dialog.c:303
-msgctxt "Distance"
-msgid "Short"
-msgstr "Mallonga"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:304
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ekrano"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:305
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ekrano"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ekrano"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "Long"
-msgstr "Longa"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Fulmi la tutan _fenestron"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6670,134 +4153,134 @@ msgstr "Maldekstra duono"
 msgid "Right Half"
 msgstr "Dekstra duono"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:70
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "Zomagordoj"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:151
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
 msgstr "_Pligrandigo:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:201
-msgid "_Follow mouse cursor"
-msgstr "_Sekvi musmontrilon"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:221
-msgid "_Screen part:"
-msgstr "_Parto de ekrano:"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:278
-msgid "Magnifier _extends outside of screen"
-msgstr "Pligrandigilo _etendas ekster la ekranon"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:292
-msgid "_Keep magnifier cursor centered"
-msgstr "_Teni pligrandigilan musmontrilon en la centro"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:307
-msgid "Magnifier cursor _pushes contents around"
-msgstr "Pligrandigila mustmontrilo _movas ĉirkaŭan enhavon"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:322
-msgid "Magnifier cursor moves with _contents"
-msgstr "Pligrandigila kursoro movas kune kun _enhavo"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:347
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "Pligrandigila pozicio:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:362
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Sekvi musmontrilon"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Parto de ekrano:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Pligrandigilo _etendas ekster la ekranon"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Teni pligrandigilan musmontrilon en la centro"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Pligrandigila mustmontrilo _movas ĉirkaŭan enhavon"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Pligrandigila kursoro movas kune kun _enhavo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Pligrandigilo"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:410
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Celiloj:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Surmetas musm_ontrilon"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
 msgstr "_Dikeco:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:436
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "Maldika"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:458
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Dika"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:479
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
 msgstr "_Longo:"
 
 #. The color of the accessibility crosshair
-#: panels/universal-access/cc-zoom-options-dialog.ui:523
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
 msgstr "Ko_loro:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:577
-msgid "_Crosshairs:"
-msgstr "_Celiloj:"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:610
-msgid "_Overlaps mouse cursor"
-msgstr "Surmetas musm_ontrilon"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:634
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "Celiloj"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:683
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Kolorefektoj:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
 msgstr "_Blanko sur nigro:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:703
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
 msgstr "_Heleco:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:724
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
 msgstr "_Kontrasto:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/cc-zoom-options-dialog.ui:744
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
 msgid "Co_lor"
 msgstr "Ko_loro"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:769
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Neniu"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:791
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Plena"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:844
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Malalta"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:867
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Alta"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:893
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Malalta"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:916
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Alta"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:942
-msgid "Color Effects:"
-msgstr "Kolorefektoj:"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:958
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "Kolorefektoj"
 
@@ -6805,47 +4288,23 @@ msgstr "Kolorefektoj"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Fari ĝin pli facila por vidi, aŭdi, tajpi, fingromontri kaj alklaki"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
-"audio;typing;"
+"audio;typing;animations;"
 msgstr ""
 "Klavaro;Muso;a11y;Alirebleco;Kontrasto;Zomi;Ekrano;Legilo;teksto;tiparo;"
 "grando;AccessX;Fiksaj;Klavoj;Salti;Muso;Duobla;klaki;alklaki;Malfruo;"
 "Prokrasto;Asisto;Helpo;Ripeti;Pulsi;vida;aŭda;tajpi;-"
 
-#: panels/usage/cc-usage-panel.c:154
-msgid "Empty all items from Trash?"
-msgstr "Ĉu vakigi ĉiujn erojn de la rubujo?"
-
-#: panels/usage/cc-usage-panel.c:155
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Ĉiuj eroj en la rubujo forigitos daŭre."
-
-#: panels/usage/cc-usage-panel.c:156
-msgid "_Empty Trash"
-msgstr "_Malplenigi rubujon"
-
-#: panels/usage/cc-usage-panel.c:177
-msgid "Delete all the temporary files?"
-msgstr "Ĉu forigi ĉiujn provizorajn dosierojn?"
-
-#: panels/usage/cc-usage-panel.c:178
-msgid "All the temporary files will be permanently deleted."
-msgstr "Ĉiuj provizoraj dosieroj forigitos daŭre."
-
-#: panels/usage/cc-usage-panel.c:179
-msgid "_Purge Temporary Files"
-msgstr "_Senrubigi provizorajn dosierojn"
-
-#: panels/usage/cc-usage-panel.ui:29
+#: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
 msgstr "Dosierhistorio"
 
-#: panels/usage/cc-usage-panel.ui:41
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
 "File history keeps a record of files that you have used. This information is "
 "shared between applications, and makes it easier to find files that you "
@@ -6855,133 +4314,49 @@ msgstr ""
 "povas atingi ĉi tiujn informojn, kaj ĉi tio helpas vin trovi tiujn dosierojn "
 "kiujn vi ŝatus uzi."
 
-#: panels/usage/cc-usage-panel.ui:56
+#: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
 msgstr "Dosierh_istorio"
 
-#: panels/usage/cc-usage-panel.ui:78
+#: panels/usage/cc-usage-panel.ui:25
 msgid "File _History Duration"
 msgstr "Daŭro de dosier_historio"
 
-#: panels/usage/cc-usage-panel.ui:119
+#: panels/usage/cc-usage-panel.ui:48
 msgid "_Clear History…"
 msgstr "_Vakigi historion…"
 
-#: panels/usage/cc-usage-panel.ui:135
-msgid "Trash & Temporary Files"
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
 msgstr "Rubujo & provizoraj dosieroj"
 
-#: panels/usage/cc-usage-panel.ui:145
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:159
+#: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
 msgstr "Aŭtomate forigi _rubaĵojn"
 
-#: panels/usage/cc-usage-panel.ui:174
+#: panels/usage/cc-usage-panel.ui:79
 msgid "Automatically Delete Temporary _Files"
 msgstr "Aŭtomate forigi provizorajn _dosierojn"
 
-#: panels/usage/cc-usage-panel.ui:196
+#: panels/usage/cc-usage-panel.ui:91
 #, fuzzy
-#| msgid "Automatically empty _Trash"
 msgid "Automatically Delete _Period"
 msgstr "Aŭtomate malplenigi _rubujon"
 
-#: panels/usage/cc-usage-panel.ui:238
+#: panels/usage/cc-usage-panel.ui:115
 msgid "_Empty Trash…"
 msgstr "_Malplenigi rubujon…"
 
-#: panels/usage/cc-usage-panel.ui:250
+#: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
 msgstr "Forigi _provizorajn dosierojn…"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:278
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 horo"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:282
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 tago"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:286
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 tagoj"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:290
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 tagoj"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:294
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 tagoj"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:298
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 tagoj"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:302
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 tagoj"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:306
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 tagoj"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:310
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 tagoj"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:314
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 tagoj"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:329
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 tago"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:333
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 tagoj"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:337
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 tagoj"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:341
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Por ĉiam"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
@@ -6991,93 +4366,58 @@ msgstr "Dosierhistorio & rubujo"
 msgid "Don't leave traces"
 msgstr "Ne lasi ŝpurojn"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "Devus akordi al la retadredo de via salut-provizanto."
-
-#: panels/user-accounts/cc-add-user-dialog.c:204
-msgid "Failed to add account"
-msgstr "Malsukcesis aldoni konton"
-
-#: panels/user-accounts/cc-add-user-dialog.c:661
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "La pasvortoj ne kongruas."
-
-#: panels/user-accounts/cc-add-user-dialog.c:875
-#: panels/user-accounts/cc-add-user-dialog.c:914
-#: panels/user-accounts/cc-add-user-dialog.c:932
-msgid "Failed to register account"
-msgstr "Malsukcesis registri konton"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1047
-msgid "No supported way to authenticate with this domain"
-msgstr "Ne valida maniero por aŭtentigi per tiu ĉi domajno"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1111
-msgid "Failed to join domain"
-msgstr "Malsukcesis aliĝi al domajno"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1166
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Tiu salutnomo ne funkciis.\n"
-"Bonvolu provi denove."
 
-#: panels/user-accounts/cc-add-user-dialog.c:1173
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Tiu salut-pasvorto ne funkciis.\n"
-"Bonvolu provi denove."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid "Failed to log into domain"
-msgstr "Malsukcesis salutado en domajno"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1236
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Ne eblas trovi la domajnon. Ĉu vi eble misliterumis ĝin?"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Aldoni uzanton"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr "_Tuta nomo"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-msgid "Standard"
-msgstr "Norma"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "Administranto"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-msgid "Account _Type"
-msgstr "Konto_speco"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+#, fuzzy
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administrantoj povas aldoni kaj forigi aliajn uzantojn, kaj povas ŝanĝi "
+"agordojn por ĉiuj uzantoj."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-msgid "Allow user to set a password when they next _login"
-msgstr "Permesi al uzanto agordi pasvorton kiam ri venonte _salutas"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Permesi al uzanto ŝanĝi rian pasvorton dum venontan salutadon"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
-msgid "Set a password _now"
-msgstr "Agordi pasvorton _nun"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Agordi pasvorton nun"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "_Konfirmi"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_Entreprena salutado"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Vi estas nekonektite"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7087,27 +4427,7 @@ msgstr ""
 "uzantokonto sur ĉi tiu aparato. Vi povas ankaŭ uzi tiun konto por aliri "
 "firmaajn risurcojn sur la interreto."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:732
-msgid "You are Offline"
-msgstr "Vi estas nekonektite"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-msgid "You must be online in order to add enterprise users."
-msgstr "Vi devas esti konektite por aldoni entreprenajn uzantojn."
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "_Entreprena salutado"
-
-#: panels/user-accounts/cc-avatar-chooser.c:220
-msgid "Browse for more pictures"
-msgstr "Foliumi por pliaj bildoj"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:39
-msgid "Take a Picture…"
-msgstr "Fari foton…"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:46
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "Elekti dosieron…"
 
@@ -7115,19 +4435,19 @@ msgstr "Elekti dosieron…"
 msgid "Fingerprint Manager"
 msgstr "Fingropremo-mastrumilo"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:23
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
 msgid "Fingerprint"
 msgstr "Fingropremo"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:118
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_Ne"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:128
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Jes"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:155
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7135,28 +4455,32 @@ msgstr ""
 "Ĉu vi volas forigi viajn registritajn fingropremojn tiel, ke fingroprema "
 "salutado estas malŝaltita?"
 
-#. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
-msgid "No Fingerprint device"
-msgstr "Neniu fingroprema aparato"
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:259
-msgid "Ensure the device is properly connected."
-msgstr "Certigu ke la aparato estas konektita."
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:264
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Neniu fingroprema aparato"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:280
-msgid "Choose the fingerprint device you want to configure"
-msgstr "Elektu la fingropreman aparaton kiun vi uzas agordi"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Neniu fingroprema aparato"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:309
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Certigu ke la aparato estas konektita."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Fingroprema aparato"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:322
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Elektu la fingropreman aparaton kiun vi uzas agordi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Fingroprema salutado"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7164,474 +4488,106 @@ msgstr ""
 "Fingroprema salutado permesas al vi malŝlosi kaj saluti je via komputilo per "
 "via fingro"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:352
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "_Forigi fingropremojn"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:363
-msgid "Fingerprint Login"
-msgstr "Fingroprema salutado"
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:412
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Enigo de fingropremo"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:436
-msgid "_Re-enroll this finger…"
-msgstr "_Re-enigu ĉi tiun fingron…"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:236
+#: panels/user-accounts/cc-login-history-dialog.ui:30
 #, fuzzy
-#| msgid "_Double-click titlebar to perform this action:"
-msgid "the device needs to be claimed to perform this action"
-msgstr "_Duoble alklaki titolbreton por plenumi ĉi tiun agon:"
+msgid "Previous"
+msgstr "Antaŭa trako"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:238
-#, fuzzy
-#| msgid "The device is already in use."
-msgid "the device is already claimed by another process"
-msgstr "La aparato jam estas uzata."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:240
-msgid "you do not have permission to perform the action"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:242
-msgid "no prints have been enrolled"
-msgstr "eniĝis neniu fingropremo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:251
-#, fuzzy
-#| msgid "Failed to register with the requested network"
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Registriĝo por la petita reto malsukcesis"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:255
-#, fuzzy
-#| msgid "Could not access any fingerprint readers"
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Ne eblis aliri al iu fingropremlegilo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:257
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:585
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Malsukcesis listigi fingropremojn: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:652
-#, fuzzy, c-format
-#| msgid "Failed to delete user"
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Malsukcesis forigi uzanton"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:683
-msgid "Left thumb"
-msgstr "Maldekstra dikfingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:685
-msgid "Left middle finger"
-msgstr "Maldeksta mezfingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:687
-msgid "_Left index finger"
-msgstr "_Maldekstra montrofingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:689
-msgid "Left ring finger"
-msgstr "Maldeksta ringfingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:691
-msgid "Left little finger"
-msgstr "Maldeksta etfingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:693
-msgid "Right thumb"
-msgstr "Dekstra dikfingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:695
-msgid "Right middle finger"
-msgstr "Deksta mezfingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:697
-msgid "_Right index finger"
-msgstr "_Deksta montrofingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:699
-msgid "Right ring finger"
-msgstr "Deksta ringfingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:701
-msgid "Right little finger"
-msgstr "Deksta etfingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:703
-msgid "Unknown Finger"
-msgstr "Nekonata fingro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:837
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Plenumita"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:848
-#, fuzzy
-#| msgid "PPP service disconnected"
-msgid "Fingerprint device disconnected"
-msgstr "PPP-servilo malkonektis"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:854
-msgid "Fingerprint device storage is full"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:858
-#, fuzzy
-#| msgid "Failed to add new printer."
-msgid "Failed to enroll new fingerprint"
-msgstr "Aldono de nova presilo malsukcesis."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:889
-#, fuzzy, c-format
-#| msgid "Failed to start Sound Preferences: %s"
-msgid "Failed to start enrollment: %s"
-msgstr "Startado de sonagordoj malsukcesis: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:897
-#, fuzzy
-#| msgid "Failed to add new printer."
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Aldono de nova presilo malsukcesis."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-#, fuzzy, c-format
-#| msgid "Failed to start Sound Preferences: %s"
-msgid "Failed to stop enrollment: %s"
-msgstr "Startado de sonagordoj malsukcesis: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:974
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1118
-#, fuzzy
-#| msgid "Enrolling fingerprints"
-msgid "Scan new fingerprint"
-msgstr "Konservante fingropremojn"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1157
-#, fuzzy, c-format
-#| msgid "Failed to forget device: "
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Malsukcesis forgesi aparaton: "
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1229
-#, fuzzy
-#| msgid "Pending Devices"
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Atendantaj aparatoj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1264
-#, fuzzy, c-format
-#| msgid "Failed to forget device: "
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Malsukcesis forgesi aparaton: "
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1413
-#, fuzzy, c-format
-#| msgid "Failed to forget device: "
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Malsukcesis forgesi aparaton: "
-
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "Ĉi tiu semajno"
-
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
-msgstr "Pasinta semajno"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%-e-a de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%-e-a de %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:766
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:770
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr "Seanco finis"
-
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr "Seanco komencis"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Aktiveco de konto"
-
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr "Bonvole elektu alian pasvorton."
-
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
-msgstr "Bonvolu tajpi vian aktualan pasvorton denove."
-
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
-msgstr "Ne eblis ŝanĝi pasvorton"
-
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Ŝanĝi pasvorton"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "Ŝ_anĝi"
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr "_Konfirmi novan pasvorton"
-
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr "_Nova pasvorto"
-
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "Nuna _pasvorto"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Nova pasvorto"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "_Konfirmi novan pasvorton"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "La pasvortoj ne kongruas."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Permesi al uzanto ŝanĝi rian pasvorton dum venontan salutadon"
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Agordi pasvorton nun"
 
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Ne povas aŭtomate aliĝi al ĉi tiu domajnspeco"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Uzantoj"
 
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Ne trovis tian domajnon aŭ regnon"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Ne eblas saluti kiel %s en la %s domajno"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Nevalida pasvorto, bonvolu provi denove"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Ne eblis koneti al la %s domajno: %s"
-
-#: panels/user-accounts/cc-user-panel.c:222
-msgid "Your account"
-msgstr "Via konto"
-
-#: panels/user-accounts/cc-user-panel.c:397
-msgid "Failed to delete user"
-msgstr "Malsukcesis forigi uzanton"
-
-#: panels/user-accounts/cc-user-panel.c:452
-#: panels/user-accounts/cc-user-panel.c:507
-#: panels/user-accounts/cc-user-panel.c:553
-msgid "Failed to revoke remotely managed user"
-msgstr "Malsukcesis senvalidigi defore mastrumitan uzanton"
-
-#: panels/user-accounts/cc-user-panel.c:602
-msgid "You cannot delete your own account."
-msgstr "Vi ne povas forigi vian propran konton."
-
-#: panels/user-accounts/cc-user-panel.c:611
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s jam estas salutite"
-
-#: panels/user-accounts/cc-user-panel.c:615
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"La forigo de uzanto kiu estas ankoraŭ salutita, povas rezulti en "
-"nekonsekvencan sistemon."
-
-#: panels/user-accounts/cc-user-panel.c:624
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Ĉu vi volas teni la dosierojn de %s?"
-
-#: panels/user-accounts/cc-user-panel.c:628
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Eblas teni la hejmdosierujon, retpoŝtmandrenon kaj provizorajn dosierojn "
-"ĉirkaŭe dum forigante uzantkonton."
-
-#: panels/user-accounts/cc-user-panel.c:631
-msgid "_Delete Files"
-msgstr "_Forigi dosierojn"
-
-#: panels/user-accounts/cc-user-panel.c:632
-msgid "_Keep Files"
-msgstr "_Konservi dosierojn"
-
-#: panels/user-accounts/cc-user-panel.c:646
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Ĉu vi certe volas senvalidigi la defore mastrumita konto de %s?"
-
-#: panels/user-accounts/cc-user-panel.c:650
-msgid "_Delete"
-msgstr "_Forigi"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Konto estas malŝaltita"
-
-#: panels/user-accounts/cc-user-panel.c:708
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Agordota dum venonta salutado"
-
-#: panels/user-accounts/cc-user-panel.c:711
-msgctxt "Password mode"
-msgid "None"
-msgstr "Neniu"
-
-#: panels/user-accounts/cc-user-panel.c:754
-msgid "Logged in"
-msgstr "Salutita"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:841
-#: panels/user-accounts/cc-user-panel.c:935
-msgid "Enabled"
-msgstr "Ŝaltita"
-
-#: panels/user-accounts/cc-user-panel.c:1254
-msgid "Failed to contact the accounts service"
-msgstr "Malsukcesis konekti la kontoservon"
-
-#: panels/user-accounts/cc-user-panel.c:1256
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Bonvolu certigi ke la AccountService estas instalita kaj ŝaltita."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1288
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Por fari ŝanĝojn,\n"
-"alklaku unue la *-piktogramon"
-
-#: panels/user-accounts/cc-user-panel.c:1361
-msgid "Delete the selected user account"
-msgstr "Forigi la elektitan uzantkonton"
-
-#: panels/user-accounts/cc-user-panel.c:1373
-#: panels/user-accounts/cc-user-panel.c:1492
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Por forigi la elektitan uzantkonton,\n"
-"klaku unue la *-piktogramon"
-
-#: panels/user-accounts/cc-user-panel.c:1545
-#, fuzzy
-#| msgid "Unlock to Change Settings"
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Malŝlosi por ŝanĝi agordojn"
-
-#: panels/user-accounts/cc-user-panel.ui:6
-msgid "_Add User…"
-msgstr "_Aldoni uzanton…"
-
-#: panels/user-accounts/cc-user-panel.ui:9
-msgid "Create a user account"
-msgstr "Krei uzantkonton"
-
-#: panels/user-accounts/cc-user-panel.ui:64
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "Via seanco devas esti restartigita por ke la ŝanĝoj efektiviĝas"
 
-#: panels/user-accounts/cc-user-panel.ui:72
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Restarti nun"
 
-#: panels/user-accounts/cc-user-panel.ui:153
-#: panels/user-accounts/cc-user-panel.ui:169
-msgid "User Icon"
-msgstr "Uzanta bildsimbolo"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Fermi"
 
-#: panels/user-accounts/cc-user-panel.ui:245
-msgid "Account Settings"
-msgstr "Kontaj agordoj"
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:272
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Tuta nomo"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Fingroprema salutado"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Aŭtomata salutado"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Aktiveco de konto"
+
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Administranto"
 
-#: panels/user-accounts/cc-user-panel.ui:301
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7639,66 +4595,57 @@ msgstr ""
 "Administrantoj povas aldoni kaj forigi aliajn uzantojn, kaj povas ŝanĝi "
 "agordojn por ĉiuj uzantoj."
 
-#: panels/user-accounts/cc-user-panel.ui:333
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "Ge_patraj kontroliloj"
 
-#: panels/user-accounts/cc-user-panel.ui:377
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:452
-msgid "Authentication & Login"
-msgstr "Aŭtentigo & saluto"
-
-#: panels/user-accounts/cc-user-panel.ui:521
-msgid "_Fingerprint Login"
-msgstr "_Fingroprema salutado"
-
-#: panels/user-accounts/cc-user-panel.ui:563
-msgid "A_utomatic Login"
-msgstr "_Aŭtomata salutado"
-
-#: panels/user-accounts/cc-user-panel.ui:593
-msgid "Account Activity"
-msgstr "Aktiveco de konto"
-
-#: panels/user-accounts/cc-user-panel.ui:634
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Forigi uzanton…"
 
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Aliaj dosieroj"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "_Aldoni uzanton…"
+
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:673
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Neniuj uzantoj estas trovitaj"
 
-#: panels/user-accounts/cc-user-panel.ui:683
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Malŝlosi por krei uzantokonton."
-
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
-msgid "Users"
-msgstr "Uzantoj"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "Aldoni aŭ forigi uzantojn kaj ŝanĝi vian pasvorton"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Salutado;Nomo;Fingropremo;Avataro;Logobildo;Vizaĵo;Pasvorto;"
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Aligi"
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Salutado de domajna administranto"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -7708,11 +4655,11 @@ msgstr ""
 "aligita en la domajno. Bonvolu igi vian retadministranton\n"
 "tajpi rian domajnpasvorton ĉi tie."
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "Administranto-_nomo"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Administranto-pasvorto"
 
@@ -7724,195 +4671,16 @@ msgstr "Mastrumi uzanto-kontojn"
 msgid "Authentication is required to change user data"
 msgstr "Aŭtentigo necesas por ŝanĝi uzanto-datumojn"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "La nova pasvorta devas esti malsama al la malnova."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Provu ŝanĝi kelkajn leterojn kaj nombrojn."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Provu ŝanĝi la pasvorton iom pli."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Pasvorto sen via uzantonomo estus pli forta."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Klopodu eviti vian uzantonomon en la pasvorto."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Klopodu eviti kelkajn vortojn, jam inkluditaj en la pasvorto."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Klopodu eviti komunajn vortojn."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Klopodu eviti reordon de jamaj vortoj."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Klopodu uzi pli da ciferoj."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Klopodu uzi pli da majusklaj literoj."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Klopodu uzi pli da minusklaj literoj."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Klopodu uzi pli da specialaj signoj, kiel interpunkcio."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Klopodu uzi kunmeton de literoj, ciferoj kaj interpunkcio."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Klopodu eviti ripeto de la sama signo."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Klopodu eviti ripeto de la sama signo: vi kunmetu literojn, ciferojn kaj "
-"interpunkcion."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Klopodu eviti sekvencojn kiel 1234 aŭ abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Pasvorto devas esti pli longa. Klopodu aldoni pli da literoj, ciferoj kaj "
-"interpunkcioj."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Kunmetu majusklojn kaj minusklojn, kaj uzu almenaŭ unu ciferon."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Aldonado de pli da literoj, ciferoj kaj interpunkcio plifortigos la "
-"pasvorton."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Aŭtentigo malsukcesis"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "La pasvorto estas tro mallonga"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "La pasvorto estas tro simpla"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "La malnova kaj nova pasvortoj tro similaj"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "La nova pasvorto jam estis uzata."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "La nova pasvorto devas enhavi ciferajn aŭ specialan signojn"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "La malnova kaj nova pasvortoj estas identaj"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Via pasvorto estas ŝanĝita ekde kiam vi unuafoje aŭtentiĝis!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "La nova pasvorto ne enhavas sufiĉe da diversaj signoj"
-
-#: panels/user-accounts/run-passwd.c:526
-#, c-format
-msgid "Unknown error"
-msgstr "Nekonata eraro"
-
-#: panels/user-accounts/user-utils.c:432
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"La uzantonomo rajtas nur konsisti el minusklaj literoj de a-z, ciferoj, kaj "
-"la jenaj signoj: . - _"
-
-#: panels/user-accounts/user-utils.c:436
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Pardonon, tiu uzantonomo ne estas disponebla. Bonvolu klopodi alian."
-
-#: panels/user-accounts/user-utils.c:478
-msgid "The username is too long."
-msgstr "La uzantonomo estas tro longa."
-
-#: panels/user-accounts/user-utils.c:537
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr "Tiu ĉi nomos vian hejmdosierujon kaj oni ne povas ŝanĝi ĝin."
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Mapobutonoj"
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "_Fermi"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Mapi butonojn al funkcioj"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -7921,7 +4689,11 @@ msgstr ""
 "klavkombina butono, kaj premu la novajn klavojn, aŭ premu la retropaŝan "
 "klavon por vakigi."
 
-#: panels/wacom/calibrator/calibrator.ui:61
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Fermi"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -7929,69 +4701,121 @@ msgstr ""
 "Bonvolu bateti la celajn indikilojn kiam ili aperas sur la ekrano por "
 "laŭnormigi la tabulkomputilo."
 
-#: panels/wacom/calibrator/calibrator.ui:78
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "Misalklako dekektita, restartante…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Butono %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "Krei virtualan aparaton"
 
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplikaĵo definita"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tabulkomputilo"
 
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Sendi klavofrapon"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Ŝanĝi ekranon"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Maldekstramano orientiĝo"
 
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Montri ekranhelpon"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:245
-msgid "Output:"
-msgstr "Eligo:"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapi al ekrano…"
 
-# Mi supozas, ke "letterbox" signifas "horizontala orientiĝo". --Carmen
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:257
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Teni proporcion (pejzaĝo):"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Aspekta rilatumo"
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:268
-msgid "Map to single monitor"
-msgstr "Mapi al unuobla ekrano"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
-msgstr "%d de %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Laŭnormigi…"
 
-#: panels/wacom/cc-wacom-page.c:516
-msgid "Display Mapping"
-msgstr "Ekrana mapado"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Detektiĝis neniu tabuleto"
 
-#: panels/wacom/cc-wacom-panel.c:725 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
-msgstr "Grifelo"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Bonvolu konekti aŭ ŝalti vian Wacom tabuleton"
 
-#: panels/wacom/cc-wacom-stylus-page.c:357
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Konduto de pinta premo"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Milda"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firma"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Butono"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Butono"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Butono"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Konduto de gumpremo"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Konduto de gumpremo"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Alklako per meza musklavo"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Alklako per dekstra musklavo"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Antaŭen"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr "Tabuleto de Wacom"
 
@@ -8000,189 +4824,343 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Agordi butonaj mapoj kaj ĝustigi grifelan sentemon por grafikaj tabuletoj"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tabuleto;Wacom;Grifelo;Gumo;Muso;"
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "Tabuleto (absoluta)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Aranĝo"
 
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
-msgstr "Tuŝplato (relativa)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "Agordoj de tabuleto"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "_Helpo"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
-msgstr "Detektiĝis neniu tabuleto"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Bonvolu konekti aŭ ŝalti vian Wacom tabuleton"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
-msgstr "Agordoj de Bludento"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
-msgstr "Ĉasreĝimo"
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Gepatra fenestro"
 
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
-msgstr "Maldekstramano orientiĝo"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulita duaranĝa alklako"
 
-#: panels/wacom/gnome-wacom-properties.ui:296
-#: panels/wacom/gnome-wacom-properties.ui:401
-msgid "Map to Monitor…"
-msgstr "Mapi al ekrano…"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Fenestroj"
 
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
-msgstr "Map-butonoj…"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
-msgstr "Laŭnormigi…"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Malmulte da inko"
 
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
-msgstr "Agordi musagordojn"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Kroma"
 
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
-msgstr "Ĝustigi ekranan distingivon"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Fenestroj"
 
-#: panels/wacom/gnome-wacom-properties.ui:376
-msgid "Decouple Display"
-msgstr "Apartigi ekranon"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr "Nova klavkombino…"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "Implicita"
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Aliro-agordoj"
 
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "Alklako per meza musklavo"
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Aldoni"
 
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "Alklako per dekstra musklavo"
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "Kon_servi"
 
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "Antaŭen"
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPR"
 
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
-msgstr "Neniu grifelo estas trovita"
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Detaloj"
 
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr "Bonvolu movi vian grifelon apud via tabuleto por agordi ĝin"
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+msgid "Modem Status"
+msgstr "Stato:"
 
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
-msgstr "Konduto de gumpremo"
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
-msgid "Soft"
-msgstr "Milda"
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_Rethoro"
 
-#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
-msgid "Firm"
-msgstr "Firma"
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Retoj"
 
-#: panels/wacom/wacom-stylus-page.ui:234
-msgid "Top Button"
-msgstr "Supra butono"
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Numeroj"
 
-#: panels/wacom/wacom-stylus-page.ui:263
-msgid "Lower Button"
-msgstr "Suba butono"
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Aparattipoj"
 
-#: panels/wacom/wacom-stylus-page.ui:292
-msgid "Lowest Button"
-msgstr "Plej suba butono"
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabrikanto"
 
-#: panels/wacom/wacom-stylus-page.ui:321
-msgid "Tip Pressure Feel"
-msgstr "Konduto de pinta premo"
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Mikroprogramaro mankas"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Settings"
-msgstr "GNOME Agordoj"
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "Ŝlosite"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Portebla larĝkapacita reto"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_Rethoro"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Reto"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Altnivela"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Aliro-agordoj"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Ekrana ŝloso"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "%s detaloj"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Retnomo"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Aŭtomata"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Mia hejma reto"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Mia hejma reto"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Neniu vifia adaptilo estas trovita"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Certigu, ke vi vifia adaptilo estas konektita kaj ŝaltita"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Bludento estas malŝaltita dum aviadila reĝimo."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Malŝalti aviadilan reĝimon"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Forgesi konekton"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM-karto ne enmetita"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Ekrana ŝloso"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Ŝ_anĝi"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Mia hejma reto"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "Agordi demeteblajn datumportilojn"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
 msgstr "Ilo por agordi la labortablon de GNOME"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr "Agordoj estas la ĉefa fasado por agordi vian sistemon."
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:20
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "La GNOME Projekto"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Montri versionumeron"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "Metante novan pelilon…"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Ŝalti adan reĝimon"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Serĉi la ĉenon"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Listigi eblajn panelnomojn kaj eliri"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panelo por montri"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANELO] [ARGUMENTO…]"
-
-#: shell/cc-panel-list.ui:45 shell/cc-window.c:275
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privateco"
 
-#: shell/cc-panel-loader.c:288
-msgid "Available panels:"
-msgstr "Disponeblaj paneloj:"
-
-#: shell/cc-window.ui:136
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Ĉiuj agordoj"
 
-#: shell/cc-window.ui:174
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr "Ĉefa menuo"
 
-#: shell/cc-window.ui:318
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr "Averto: Programista versio"
 
-#: shell/cc-window.ui:319
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
@@ -8192,14 +5170,9 @@ msgstr ""
 "Vi spertus neĝustan sistemkonduton, datumperdon, kaj aliajn neanticipitajn "
 "problemojn. "
 
-#: shell/cc-window.ui:330
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Helpo"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "Preferoj;Agordoj;"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -8231,6 +5204,10 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Nuligi serĉon"
 
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferoj;Agordoj;"
+
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
 msgstr "La identifilo por la stircentra panelo, kiu malfermendiĝas laste"
@@ -8254,27 +5231,2811 @@ msgid ""
 msgstr ""
 "Ĉu la stircentro devus montri averton kiam rulante programistan version."
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u eligo"
 msgstr[1] "%u eligoj"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u enigo"
 msgstr[1] "%u enigoj"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "Sistemsonoj"
+#~ msgid "System Bus"
+#~ msgstr "Sistembuso"
+
+#~ msgid "Full access"
+#~ msgstr "Plena aliro"
+
+#~ msgid "Session Bus"
+#~ msgstr "Seanca buso"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Plena aliro al /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Havas retaliron"
+
+#~ msgid "Home"
+#~ msgstr "Hejmo"
+
+#~ msgid "Read-only"
+#~ msgstr "Nurlega"
+
+#~ msgid "Can change settings"
+#~ msgstr "Rajtas ŝanĝi agordojn"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s havas la sekvajn fiksitajn permesojn. Oni ne povas ŝanĝi ilin. Se vi "
+#~ "zorgas pri ĉi tiuj permesoj, pripensu forigon de la aplikaĵo."
+
+#~ msgid "Web Links"
+#~ msgstr "Retligiloj"
+
+#~ msgid "Git Links"
+#~ msgstr "Gitligiloj"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "%s-ligiloj"
+
+#~ msgid "Unset"
+#~ msgstr "Ne agordita"
+
+#~ msgid "Links"
+#~ msgstr "Ligiloj"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hipertekstaj dosieroj"
+
+#~ msgid "Text Files"
+#~ msgstr "Tekstaj dosieroj"
+
+#~ msgid "Image Files"
+#~ msgstr "Bildo-dosieroj"
+
+#~ msgid "Font Files"
+#~ msgstr "Tipar-dosieroj"
+
+#~ msgid "Archive Files"
+#~ msgstr "Arĥiv-dosieroj"
+
+#~ msgid "Package Files"
+#~ msgstr "Pak-dosieroj"
+
+#~ msgid "Audio Files"
+#~ msgstr "Son-dosieroj"
+
+#~ msgid "Video Files"
+#~ msgstr "Video-dosieroj"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permesoj & aliro"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Datumoj kaj servoj, al kiuj ĉi tiu aplikaĵo demandis atingon, kaj ĝiaj "
+#~ "necesaj permesoj."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Ne eblas ŝanĝi"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Individuajm permesojm por alikaĵoj oni povas kontroli en la <a "
+#~ "href=\"privacy\">Privateco</a>-agordoj."
+
+#~ msgid "Integration"
+#~ msgstr "Integrigo"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Agordi labortablan fonon"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Implicitaj traktiloj"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Specoj de dosieroj kaj ligiloj, kiujn ĉi tiu aplikaĵo malfermas."
+
+#~ msgid "Usage"
+#~ msgstr "Uzado"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Kiom da risurcoj ĉi tiu aplikaĵo uzas."
+
+#~ msgid "Open in Software"
+#~ msgstr "Malfermi en Programaro"
+
+#~ msgid "Select a picture"
+#~ msgstr "Elekti bildon"
+
+#~ msgid "multiple sizes"
+#~ msgstr "pluraj grandoj"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Neniu labortabla fono"
+
+#~ msgid "Current background"
+#~ msgstr "Aktuala fono"
+
+#~ msgid "Activities"
+#~ msgstr "Agoj"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Ekranfono;Ekrano;Labortablo;"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Permesi, ke la subaj aplikaĵoj povu uzi vian kameraon."
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "ekrano;ŝlosi;ŝloso;diagnozo;kraŝo;privata;lastatempa;provizora;tmp;"
+#~ "indekso;reto;identeco;"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Metu vian laŭnormigan aparaton super la kvadraton kaj premu “Komenci”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Movu vian laŭnormigan aparaton al la laŭnormiga pozicio kaj premu "
+#~ "“Daŭrigi”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Movu vian laŭnormigan aparaton al la supraĵa pozicio kaj premu “Daŭrigi”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Fermu la kovrilon de la klapkomputilo"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Okazis interna eraro, kiun ne eblis riparigi."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Necesaj iloj por laŭnormigo ne estas instalitaj."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Ne eblis generi la profilon."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "La cela blankpunkto ne akireblis."
+
+#~ msgid "Complete!"
+#~ msgstr "Plenumita!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Laŭnormigo malsukcesis!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Vi povas forigi la laŭnormigan aparaton."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ne interrompu la laŭnormigan aparaton dum plenumado"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Ekrano de klapkomputilo"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Fiksita retkamerao"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s Ekrano"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s Skanilo"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s Kamerao"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s Presilo"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s Retkamerao"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Ŝalti kolormastrumadon por %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Montri kolorprofilojn por %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nelaŭnormigita"
+
+#~ msgid "Default: "
+#~ msgstr "Implicita: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testprofilo: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Elekti ICC-profildosieron"
+
+#~ msgid "_Import"
+#~ msgstr "E_nporti"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Subtenataj ICC-profiloj"
+
+#~ msgid "All files"
+#~ msgstr "Ĉiuj dosieroj"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Malsukcesis alŝuti dosieron: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "La profilo estas alŝutita al:"
+
+# Ĉu estas imperativo? --Carmen
+#~ msgid "Write down this URL."
+#~ msgstr "Noti tiun ret-adreson."
+
+# Ĉu estas imperativo? --Carmen
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Restartigi ĉi tiun komputilon kaj startigi vian normalan operaciumon."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Tajpu la retadreson en via retumilo por elŝutu kaj instalu la profilon."
+
+#~ msgid "Save Profile"
+#~ msgstr "Konservi profilon"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Krei kolorprofilon por la elektita aparato"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "La mezurilo ne estas detektita. Bonvolu kontroli ĉu ĝi estas ŝaltita kaj "
+#~ "korekte konektita."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "La mezurilo ne subtenas presilprofiladon."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "La aparatspeco ne estas aktuale subtenita."
+
+#~ msgid "Upload profile"
+#~ msgstr "Alŝuti profilon"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Necesas interretan konekton"
+
+#~ msgid "Standard Space"
+#~ msgstr "Norma spaco"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testprofilo"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Aŭtomate"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Malalta kvalito"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Meza kvalito"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Alta kvalito"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Implicita RVB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Implicita CMFN"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Implicita grizo"
+
+# Mi supozas, ke ĝi devus diri "vendor-supplied". --Carmen
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Fabrikajn laŭnormig-datumojn provizigita de vendisto"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Tutekrana ekran-ĝustigo ne eblas je ĉi tiu profilo"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "La profilo eble ne plu estas akurata"
+
+#~ msgid "Other…"
+#~ msgstr "Alia…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Malŝlosi por ŝanĝi agordojn"
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopii"
+
+#~ msgid "Select _All"
+#~ msgstr "Elekti ĉ_iujn"
+
+#~ msgid "Today"
+#~ msgstr "Hodiaŭ"
+
+#~ msgid "Yesterday"
+#~ msgstr "Hieraŭ"
+
+#~ msgid "%b %e"
+#~ msgstr "%-e-a de %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-e-a de %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d horo"
+#~ msgstr[1] "%d horoj"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuto"
+#~ msgstr[1] "%d minutoj"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekundo"
+#~ msgstr[1] "%d sekundoj"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Retkaptejo"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%-e-a de %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%-e-a de %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "24-hour"
+#~ msgstr "24-hora"
+
+#~ msgid "AM / PM"
+#~ msgstr "ATM / PTM"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Sendado de raportoj de teĥnikaj problemoj helpas al ni plibonigi %s. "
+#~ "Raportoj sendiĝas sennome kaj personaj datumoj estas viŝitaj. %s"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Ĉu apliki ŝanĝojn?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Ne eblas apliki ŝanĝojn"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Ĉi tiu eblus pro aparataj limigoj."
+
+#~ msgid "Single Display"
+#~ msgstr "Unuobla ekrano"
+
+#~ msgid "Join Displays"
+#~ msgstr "Kunigi ekranojn"
+
+#~ msgid "Display Mode"
+#~ msgstr "Reĝimo de ekrano"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Tiru ekranojn por kongrui vian fizikan ekranaranĝon. Elektu ekranon por "
+#~ "ŝanĝi ĝiajn agordojn."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Aranĝo de ekranoj"
+
+#~ msgid "Active Display"
+#~ msgstr "Aktiva ekrano"
+
+#~ msgid "Display Configuration"
+#~ msgstr "Ekran-agordoj"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Pejzaĝo"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portreto dekstra"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portreto maldekstra"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Pejzaĝo (renversita)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "More Warm"
+#~ msgstr "Pli varma"
+
+#~ msgid "Less Warm"
+#~ msgstr "Malpli varma"
+
+#~ msgid "Unknown"
+#~ msgstr "Nekonata"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bita"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bita"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Vejlando"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Nekonata"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Konservi ekrankopion al $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Konservi ekrankopion de fenestro al $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Konservi ekrankopion de areo al $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopii ekrankopion al tondujo"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopii ekrankopion de fenestro al tondujo"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopii ekrankopion de areo al tondujo"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Registri mallongan ekranreĝistraĵon"
+
+#~ msgid "No input sources found"
+#~ msgstr "Neniuj enigaj fontoj trovitaj"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Alia"
+
+#~ msgid "Move up"
+#~ msgstr "Movi supren"
+
+#~ msgid "Move down"
+#~ msgstr "Movi malsupren"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Propraj klavkombinoj"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "La klavom de alternativaj signoj oni povas uzi por enigi ceterajn "
+#~ "signojn. Foje ili estas presitaj kiel tria opcio sur via klavaro."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Maldekstra alt-klavo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Dekstra alt-klavo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Meldekstra super-klavo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Dekstra super-klavo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menu-klavo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Dekstra stirklavo"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "La kompona klavo permesas enigon de vasta kvanto de signoj. Por uzi ĝin, "
+#~ "premu la komponan klavon kaj sekve enigu sekvencon de signoj. Ekzemple, "
+#~ "la sekvenco <b>kompona klavo</b>, <b>G</b>, kaj <b>^</b> enigas <b>Ĝ</b>, "
+#~ "kaj la sekvenco <b>kompona klavo</b>, <b>C</b>, kaj <b>o</b> enigas <b>©</"
+#~ "b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Majuskla baskulo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Ruluma baskulo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Ekrankopio"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Klavkombino"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Oni povas ŝanĝi ĉi tion en Agordi klavkombinojn"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Daŭre premu kaj tajpu por enigi aliajn signojn"
+
+#~ msgid "modified"
+#~ msgstr "modifita"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Ĉu reagordi ĉiujn klavkombinojn?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Reagordado de klavkombinoj povus aliigi viajn proprajn klavkombinojn. Ĉi "
+#~ "tiu ne estas malfarebla."
+
+#~ msgid "Reset All"
+#~ msgstr "Reagordi ĉiujn"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s jam estas uzata por %s. Se vi anstataŭas ĝin, %s estos malŝaltita"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Entajpu novan klavkombinon"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Agordi propran klavkombinon"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Agordi klavkombinon"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Enmetu novan klavkombinon por ŝanĝi %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Aldoni propran klavkombinon"
+
+#~ msgid "Set"
+#~ msgstr "Agordi"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Lokado-servoj permesas al aplikaĵoj scii vian lokon. Uzado de vifio kaj "
+#~ "portebla larĝkapacita konekto plialtigas ekzaktecon."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Uzas Mozilla Lokado-Servon: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privateco Politiko</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Permesi, ke la subaj aplikaĵoj povu scii vian lokon."
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "La ekrano malŝaltas"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekundoj"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutoj"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutoj"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutoj"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutoj"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 horo"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutoj"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutoj"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutoj"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutoj"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutoj"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutoj"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutoj"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutoj"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Neniam"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Ŝlosi vian ekranon"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Permesi, ke la subaj aplikaĵoj povu uzi vian mikrofonon."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Tempolimo de duobla klako"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Dufingra rulumado"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Kvin alklakoj, GEGL-tempo!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Duobla klako, ĉefa butono"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Unuobla klako, ĉefa butono"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Duobla klako, meza butono"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Unuobla klako, meza butono"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Duobla klako, duaranga butono"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Unuobla klako, duaranga butono"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager devas esti rulanta."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Nesekura reto (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Sekura reto (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Sekura reto (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Sekura reto (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Sekura reto"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Ŝaltado de retkaptejo malkonektos vian komputilon de %s, kaj ne eblos "
+#~ "atingi interreton tra vifio."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Ĉu haltigi retkaptejon kaj malkonektiĝi ĉiujn uzantojn?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "Halti_gi retkaptejon"
+
+#~ msgid "Permanent"
+#~ msgstr "Porĉiama"
+
+#~ msgid "Random"
+#~ msgstr "Hazarda"
+
+#~ msgid "Stable"
+#~ msgstr "Stabila"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profilo %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterpreno"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Neniu"
+
+#~ msgid "Never"
+#~ msgstr "Neniam"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2,4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2,4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nenia"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Malforta"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Sufiĉa"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bona"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Bonega"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Forigi profilon de konekto"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Forigi VPR-on"
+
+#~ msgid "automatic"
+#~ msgstr "aŭtomata"
+
+#~ msgid "Identity"
+#~ msgstr "Identeco"
+
+#~ msgid "Delete Route"
+#~ msgstr "Forigi kurson"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Neniu"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bita ŝlosilo (Deksesuma aŭ ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "128-bita WEP-pasfrazo"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dinamika WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 por personoj"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 por enterprenoj"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 por personoj"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Ne eblas malfermi konektan redaktilon"
+
+#~ msgid "New Profile"
+#~ msgstr "Nova profilo"
+
+#~ msgid "Import from file…"
+#~ msgstr "Enporti el dosiero…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Aldoni VPR-on"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Ne eblas enporti VPR-konekton"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "La dosiero “%s” ne estis legebla aŭ ne entenas rekonitajn VPR-konektajn "
+#~ "informojn\n"
+#~ "\n"
+#~ "Eraro: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Elekti enportendan dosieron"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Dosiero nomita “%s” jam ekzistas."
+
+#~ msgid "_Replace"
+#~ msgstr "_Anstataŭigi"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Ĉu vi volas anstataŭigi %s per la VPR-konekto, kiun vi konservas?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Ne eblas elporti VPR-konekton"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "La VPR-konekto “%s” ne povas esti elportita al %s.\n"
+#~ "\n"
+#~ "Eraro: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Elporti VPR-konekton"
+
+#~ msgid "never"
+#~ msgstr "neniam"
+
+#~ msgid "today"
+#~ msgstr "hodiaŭ"
+
+#~ msgid "yesterday"
+#~ msgstr "hieraŭ"
+
+#~ msgid "Last used"
+#~ msgstr "Laste uzita"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Retaj detaloj por la elektitaj retoj, inkludante pasvortojn kaj iujn ajn "
+#~ "proprajn agordojn, perdiĝos."
+
+#~ msgid "_Forget"
+#~ msgstr "_Forgesi"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Konataj vifiaj retoj"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Forgesi"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Sistema politiko malebligas uzon kiel retkaptejo"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Sendrata aparato ne subtenas retkapteja reĝimo"
+
+#~ msgid "Off"
+#~ msgstr "Malŝaltita"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Aŭtomata malkovro de retaj prokuriloj estas uzata kiam agord-URL ne estas "
+#~ "provizita."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Tio ne estas rekomendita por nefidindaj publikaj retoj."
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPR"
+
+#~ msgid "Status unknown"
+#~ msgstr "Nekonata stato"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Nemastrumita"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nedisponeble"
+
+#~ msgid "Connecting"
+#~ msgstr "Konektante"
+
+#~ msgid "Authentication required"
+#~ msgstr "Aŭtentigo necesas"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Malkontaktante"
+
+#~ msgid "Connection failed"
+#~ msgstr "Konekto malsukcesis"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Nekonata stato (mankanta)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Agordo malsukcesis"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP-agordo malsukcesis"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP-agordo senvalidiĝis"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Sekretoj estis bezonitaj, sed ne provizitaj"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x provizanto malkonektitas"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Agordo de 802.1x provizanto malsukcesis"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x provizanto malsukcesis"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x provizanto estis tro malrapida por aŭtentigi"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP-servilo malsukcesis starti"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP-servilo malkonektis"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP malsukcesis"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP-kliento malsukcesis starti"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Eraro de la DHCP-kliento"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-kliento malsukcesis"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Kunhavigita konekta servilo malsukcesis starti"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Kunhavigita konekta servilo malsukcesis"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP-servilo malsukcesis starti"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP-serva eraro"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP-servilo malsukcesis"
+
+#~ msgid "Line busy"
+#~ msgstr "Lineo okupita"
+
+#~ msgid "No dial tone"
+#~ msgstr "Neniu voktono"
+
+# carrier = mobile network carrier? --Carmen
+#~ msgid "No carrier could be established"
+#~ msgstr "Neniu provizanto povus esti trovita"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Numeruma peto eltempiĝis"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Numeruma peto malsukcesis"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Pravalorizo de modemo malsukcesis"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Malsukcesis elekti specifitan APN-on"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Ne serĉanta por retoj"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Reta registriĝo neis"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Reta registriĝo eltempiĝis"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Registriĝo por la petita reto malsukcesis"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN-kontrolo malsukcesis"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firma programaro por la aparato eble mankas"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Konekto malaperis"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Ekzistanta konekto supozintis"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modemo ne trovita"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bludenta konekto malsukcesis"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM-karto PIN bezonita"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM-karto PUK bezonita"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM-karto malĝusta"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Konekta dependeco malsukcesis"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kablo ne konektita"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "nedifinita eraro en 802.1X-sekureco (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "neniu elektita dosiero"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "nespecifita eraro dum validigado de eap-method-dosiero"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr ""
+#~ "Privataj ŝlosiloj de specoj DER, PEM aŭ PKCS#12 (*.der, *.pem, *.p12, *."
+#~ "key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER- aŭ PEM-atestiloj (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "mankanta EAP-FAST PAC dosiero"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC-dosieroj (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "mankanta EAP-LEAP uzantonomo"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "mankanta EAP-LEAP pasvorto"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "nevalida EAP-PEAP CA-atestilo: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "nevalida EAP-PEAP CA-atestilo: neniu atestilo estas specifita"
+
+# Ĉu «EAP uzantonomo, kiu estas mankanta» aŭ «EAP uzantonomo estas mankanta»? --Carmen
+#~ msgid "missing EAP username"
+#~ msgstr "mankanta EAP uzantonomo"
+
+#~ msgid "missing EAP password"
+#~ msgstr "mankanta EAP pasvorto"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "mankanta EAP-TLS identeco"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "nevalida EAP-TLS CA-atestilo: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "nevalida EAP-TLS CA-atestilo: neniu atestilo estas specifita"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "nevalida EAP-TLS privata ŝlosilo: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "nevalida EAP-TLS atestilo de uzanto: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Neĉifritaj privataj ŝlosiloj estas nesekuraj"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Ŝajne la elektita privata ŝlosilo ne estas protektata per pasvorto. Tio "
+#~ "povas kaŭzi la forlikon de viaj sekurecinformoj. Bonvolu elekti pasvort-"
+#~ "protektitan privatan ŝlosilon.\n"
+#~ "\n"
+#~ "(Vi povas pasvort-protekti vian privatan ŝlosilon per openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Elekti vian personan atestilon"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Elekti vian privatan ŝlosilon"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "nevalida EAP-TTLS CA-atestilo: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "nevalida EAP-TTLS CA-atestilo: neniu atestilo estas specifita"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Nekonata eraro dum validigado de 802.1X-sekureco"
+
+#~ msgid "missing leap-username"
+#~ msgstr "mankanta leap-username"
+
+#~ msgid "missing leap-password"
+#~ msgstr "mankanta leap-password"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Vifia pasvorto mankas."
+
+#~ msgid "missing wep-key"
+#~ msgstr "mankanta wep-key"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "nevalida wep-key: ŝlosilo kun longo de %zu devas enhavi nur deksesumajn "
+#~ "ciferojn"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "nevalida wep-key: ŝlosilo kun longo de %zu devas enhavi nur ascii-signoj"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "nevalida wep-key: malĝusta longo de ŝlosilo %zu. Longo de ŝlosilo devas "
+#~ "esti aŭ 5/13 (ascii) aŭ 10/26 (deksesuma)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "nevalida wep-key: pasfrazo devas esti ne-malplena"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "nevalida wep-key: pasfrazo devas esti pli mallonga ol 64 signoj"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "nevalida wpa-psk: nevalida longo de ŝlosilo %zu. Devas esti [8,63] bajtoj "
+#~ "aŭ 64 deksesumaj ciferoj"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "nevalida wpa-psk: ne povas interpreti ŝlosilon kun 64 bajtoj kiel "
+#~ "deksesuma"
+
+#~ msgid "On"
+#~ msgstr "Ŝaltita"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Alia"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s konto"
+
+#~ msgid "Error removing account"
+#~ msgstr "Eraro dum forigado de konto"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s forigita"
+
+#~ msgid "Remove Account"
+#~ msgstr "Forigi konton"
+
+#~ msgid "Unknown time"
+#~ msgstr "Nekonata tempo"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s ĝis tute ŝargita"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Averto: %s restanta"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s restanta"
+
+#~ msgid "Fully charged"
+#~ msgstr "Tute ŝargita"
+
+#~ msgid "Not charging"
+#~ msgstr "Ne ŝargante"
+
+#~ msgid "Empty"
+#~ msgstr "Malplena"
+
+#~ msgid "Charging"
+#~ msgstr "Ŝargante"
+
+#~ msgid "Discharging"
+#~ msgstr "Malŝargante"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Sendrata muso"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Sendrata klavaro"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Vicnutrila baterio"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Persona cifereca asistanto"
+
+#~ msgid "Cellphone"
+#~ msgstr "Poŝtelefono"
+
+#~ msgid "Media player"
+#~ msgstr "Medioludilo"
+
+#~ msgid "Computer"
+#~ msgstr "Komputilo"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Luda enigaparato"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Ĉefa"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Ekstra"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterioj"
+
+#~ msgid "When _idle"
+#~ msgstr "Dum _senokupo"
+
+#~ msgid "Suspend"
+#~ msgstr "Halteti"
+
+#~ msgid "Power Off"
+#~ msgstr "Malŝalti"
+
+#~ msgid "Hibernate"
+#~ msgstr "Pasivumigi"
+
+#~ msgid "Nothing"
+#~ msgstr "Nenio"
+
+#~ msgid "When on battery power"
+#~ msgstr "Dum bateria elektro"
+
+#~ msgid "When plugged in"
+#~ msgstr "Kiam konektita"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Aŭtomata haltetado"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Halteta & ŝalta butono"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Heleco de _ekrano"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Heleco de _klavaro"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Malheligi ekranon kiam neaktiva"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "M_alplena ekrano"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Vifio"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Vifio malŝalteblas por ŝpari elektron."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Portebla larĝkapacita reto (LTE, 4G, 3G, ktp.) malŝalteblas por ŝpari "
+#~ "elektron."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bludento"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bludento malŝalteblas por ŝpari elektron."
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Rendimenta reĝimo nedisponeblas"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Alta rendimento kaj elektro-uzado."
+
+#~ msgid "Performance"
+#~ msgstr "Rendimento"
+
+#~ msgid "Balanced Power"
+#~ msgstr "Ekvilibra"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Normala rendimento kaj elektro-uzado."
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Malalta rendimento kaj elektro-uzado."
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Aŭtentigi"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Presilo “%s” estas forigita"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Aldono de nova presilo malsukcesis."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Ne eblas ŝargi fasadon: %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Neniu taŭga pelilon trovita"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Elekti PPD-dosieron"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript presilo-priskribaj dosieroj (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+#~ "*.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect presilo"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD-presilo"
+
+#~ msgid "One Sided"
+#~ msgstr "Unuflanka"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Longa flanko (norma)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Mallonga flanko (renversa)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portreto"
+
+#~ msgid "Landscape"
+#~ msgstr "Pejzaĝo"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Renversita pejzaĝo"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Renversita portreto"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Atendante"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Paŭzita"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Aŭtentigo necesas"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Traktado"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Haltigita"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Nuligita"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Rompita"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Plenumita"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Aktivaj taskoj"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Entajpu akreditaĵojn por presi el %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Malŝlosi presservilon"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Malŝlosi %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Enigu uzantonomon kaj pasvorton por vidi presilojn je %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Serĉante presilojn"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Seria pordo"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralela pordo"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Loko: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adreso: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Servilo necesas aŭtentigon"
+
+#~ msgid "Two Sided"
+#~ msgstr "Duflanka"
+
+#~ msgid "Paper Type"
+#~ msgstr "Speco de papero"
+
+#~ msgid "Paper Source"
+#~ msgstr "Papera fonto"
+
+#~ msgid "Output Tray"
+#~ msgstr "Eliga pleto"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Distingivo"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript-antaŭfiltrado"
+
+#~ msgid "Pages per side"
+#~ msgstr "Paĝoj po flanko"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientiĝo"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Ĝenerala"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Paĝ-agordo"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Instaleblaj opcioj"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Tasko"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Bild-kvalito"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Koloro"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Finigante"
+
+#~ msgid "Test page"
+#~ msgstr "Testpaĝo"
+
+#~ msgid "Auto Select"
+#~ msgstr "Elekti aŭtomate"
+
+#~ msgid "Printer Default"
+#~ msgstr "Implicita agordo de presilo"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Enkorpigi nur GhostScript-ajn tiparojn"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Konverti al PS-nivelo 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Konverti al PS-nivelo 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Neniu antaŭfiltrado"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Purigi presilajn kapetojn"
+
+#~ msgid "Out of toner"
+#~ msgstr "Neniu inko"
+
+#~ msgid "Low on developer"
+#~ msgstr "Malmulte da fotokreilkemiaĵo"
+
+#~ msgid "Out of developer"
+#~ msgstr "Neniu fotokreilkemiaĵo"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Malmulte da inkpulvora provizo"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Neniu inkpulvora provizo"
+
+#~ msgid "Open cover"
+#~ msgstr "Malfermi kovrilon"
+
+#~ msgid "Open door"
+#~ msgstr "Malfermi pordon"
+
+#~ msgid "Low on paper"
+#~ msgstr "Malmulte da papero"
+
+#~ msgid "Out of paper"
+#~ msgstr "Neniu papero"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Nekonektita"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Haltigita"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Forĵetaĵulo preskaŭ plena"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Forĵetaĵujo plena"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "La optika fotokonduktilo apudas al fino de vivo"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "La optika fotokonduktilo ne plu funkcias"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Prete"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Ne akceptas taskojn"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Traktado"
+
+#~ msgid "Add…"
+#~ msgstr "Aldoni…"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Elektu formon por numeroj, datoj, kaj valutoj. Ŝanĝoj efektiviĝas post "
+#~ "via sekva saluto."
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperia"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metra"
+
+#~ msgid "Language"
+#~ msgstr "Lingvo"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "La lingvo kiun oni uzas por teksto en fenestroj kaj retpaĝoj."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Restartigi la seancon por ke la ŝanĝoj efektiviĝas"
+
+#~ msgid "Restart…"
+#~ msgstr "Restartigi…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Salutaj agordoj estas uzataj de ĉiuj uzantoj kiam salutante sistemen"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Demandi kion fari"
+
+#~ msgid "Do nothing"
+#~ msgstr "Fari nenion"
+
+#~ msgid "Open folder"
+#~ msgstr "Malfermi dosierujon"
+
+#~ msgid "Other Media"
+#~ msgstr "Aliaj datumportiloj"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Elekti aplikaĵon por son-KDj"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Elekti aplikaĵon por video-DVDj"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Elektu rulendan aplikaĵon kiam muzikludilo estas konektita"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Elektu rulendan aplikaĵon kiam kamerao estas konektita"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Elekti aplikaĵon por programar-KDj"
+
+#~ msgid "audio DVD"
+#~ msgstr "son-DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "malplena Blu-radia disko"
+
+#~ msgid "blank CD disc"
+#~ msgstr "malplena KD-disko"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "malplena DVD-disko"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "malplena HD-DVD-disko"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-radia videodisko"
+
+#~ msgid "e-book reader"
+#~ msgstr "retlibrolegilo"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD-DVD-videodisko"
+
+#~ msgid "Picture CD"
+#~ msgstr "Bild-KD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super-Video-KD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video-KD"
+
+#~ msgid "Windows software"
+#~ msgstr "Windows-programaro"
+
+#~ msgid "Select Location"
+#~ msgstr "Elekti lokon"
+
+#~ msgid "_OK"
+#~ msgstr "_Bone"
+
+#~ msgid "No applications found"
+#~ msgstr "Neniuj aplikaĵoj trovitaj"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Neniuj retoj estas elektitaj por kunhavigado"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Ŝaltita"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Malŝaltita"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Ŝaltita"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Elektu dosierujon"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Dosier-kunhavigado permesas al vi kunhavigi vian Publikan dosieron kun "
+#~ "aliaj ĉe via ĉimomenta reto uzante: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kiam defora salutado estas ŝaltita, deforaj uzantoj povas konekti uzante "
+#~ "la sekuran ŝelan komando:\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Ekran-kunhavigado permesas al deforaj uzantoj vidi aŭ regi vian ekranon "
+#~ "per konekti al %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Ekran-kunhavigado"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Kelkaj servoj estas malŝaltitaj pro manko de retaliro."
+
+#~ msgid "_Password:"
+#~ msgstr "_Pasvorto:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Montri pasvorton"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Novaj konektoj devas peti aliron"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Bezonas pasvorton"
+
+#~ msgid "Custom"
+#~ msgstr "Propra"
+
+#~ msgid "Bark"
+#~ msgstr "Bojo"
+
+#~ msgid "Drip"
+#~ msgstr "Guto"
+
+#~ msgid "Glass"
+#~ msgstr "Vitro"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonaro"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Testante %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Malkonektita"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Konektante"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Konektita"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Aŭtentiga eraro"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Aŭtentigante"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Malpliigita funkciado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Konektita & aŭtentigita"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Nekonata"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Aŭtentigita je:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Konektita je:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Aligita je:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Malsukcesis aŭtentigi aparaton: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Malsukcesis forgesi aparaton: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Eraro"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Aŭtentigita"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "La Thunderbolt subsistemo (boltd) ne estas instalita aŭ ne estas ĝuste "
+#~ "agordigita."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Ne povis trovi Thunderbolt.\n"
+#~ "Aŭ la sistemo malhavas Thunderbolt subtenon, aŭ la subteno estas "
+#~ "malŝaltita en la BIOS, aŭ ĝi estas agordita je nesubtenita sekureca "
+#~ "nivelo en la BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt subteno estas malŝaltita en la BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Ne eblis difini Thunderbolt sekurecan nivelon."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Eraro dum ŝanĝi direktan reĝimon: %s"
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Nur USB kaj Display Port aparatoj povas alfiksi."
+
+#~ msgid "Sound Keys"
+#~ msgstr "Son-klavoj"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Ekranlegilo"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Ekranlegilo"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Implicita"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Meza"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Granda"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Pli granda"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Plej granda"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d bildero"
+#~ msgstr[1] "%d bilderoj"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Mallonga"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ekrano"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ekrano"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ekrano"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Longa"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Ĉu vakigi ĉiujn erojn de la rubujo?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Ĉiuj eroj en la rubujo forigitos daŭre."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Malplenigi rubujon"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Ĉu forigi ĉiujn provizorajn dosierojn?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Ĉiuj provizoraj dosieroj forigitos daŭre."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Senrubigi provizorajn dosierojn"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 horo"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 tago"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 tagoj"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 tagoj"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 tagoj"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 tagoj"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 tagoj"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 tagoj"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 tagoj"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 tagoj"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 tago"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 tagoj"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 tagoj"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Por ĉiam"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Devus akordi al la retadredo de via salut-provizanto."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Malsukcesis aldoni konton"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Malsukcesis registri konton"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Ne valida maniero por aŭtentigi per tiu ĉi domajno"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Malsukcesis aliĝi al domajno"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Tiu salutnomo ne funkciis.\n"
+#~ "Bonvolu provi denove."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Tiu salut-pasvorto ne funkciis.\n"
+#~ "Bonvolu provi denove."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Malsukcesis salutado en domajno"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Ne eblas trovi la domajnon. Ĉu vi eble misliterumis ĝin?"
+
+#~ msgid "Standard"
+#~ msgstr "Norma"
+
+#~ msgid "Account _Type"
+#~ msgstr "Konto_speco"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Permesi al uzanto agordi pasvorton kiam ri venonte _salutas"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Agordi pasvorton _nun"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Vi devas esti konektite por aldoni entreprenajn uzantojn."
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Foliumi por pliaj bildoj"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Fari foton…"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Re-enigu ĉi tiun fingron…"
+
+#, fuzzy
+#~| msgid "_Double-click titlebar to perform this action:"
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "_Duoble alklaki titolbreton por plenumi ĉi tiun agon:"
+
+#, fuzzy
+#~| msgid "The device is already in use."
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "La aparato jam estas uzata."
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "eniĝis neniu fingropremo"
+
+#, fuzzy
+#~| msgid "Failed to register with the requested network"
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Registriĝo por la petita reto malsukcesis"
+
+#, fuzzy
+#~| msgid "Could not access any fingerprint readers"
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Ne eblis aliri al iu fingropremlegilo"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Malsukcesis listigi fingropremojn: %s"
+
+#, fuzzy, c-format
+#~| msgid "Failed to delete user"
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Malsukcesis forigi uzanton"
+
+#~ msgid "Left thumb"
+#~ msgstr "Maldekstra dikfingro"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Maldeksta mezfingro"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Maldekstra montrofingro"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Maldeksta ringfingro"
+
+#~ msgid "Left little finger"
+#~ msgstr "Maldeksta etfingro"
+
+#~ msgid "Right thumb"
+#~ msgstr "Dekstra dikfingro"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Deksta mezfingro"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Deksta montrofingro"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Deksta ringfingro"
+
+#~ msgid "Right little finger"
+#~ msgstr "Deksta etfingro"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Nekonata fingro"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Plenumita"
+
+#, fuzzy
+#~| msgid "PPP service disconnected"
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "PPP-servilo malkonektis"
+
+#, fuzzy
+#~| msgid "Failed to add new printer."
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Aldono de nova presilo malsukcesis."
+
+#, fuzzy, c-format
+#~| msgid "Failed to start Sound Preferences: %s"
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Startado de sonagordoj malsukcesis: %s"
+
+#, fuzzy
+#~| msgid "Failed to add new printer."
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Aldono de nova presilo malsukcesis."
+
+#, fuzzy, c-format
+#~| msgid "Failed to start Sound Preferences: %s"
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Startado de sonagordoj malsukcesis: %s"
+
+#, fuzzy
+#~| msgid "Enrolling fingerprints"
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Konservante fingropremojn"
+
+#, fuzzy, c-format
+#~| msgid "Failed to forget device: "
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Malsukcesis forgesi aparaton: "
+
+#, fuzzy
+#~| msgid "Pending Devices"
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Atendantaj aparatoj"
+
+#, fuzzy, c-format
+#~| msgid "Failed to forget device: "
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Malsukcesis forgesi aparaton: "
+
+#, fuzzy, c-format
+#~| msgid "Failed to forget device: "
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Malsukcesis forgesi aparaton: "
+
+#~ msgid "This Week"
+#~ msgstr "Ĉi tiu semajno"
+
+#~ msgid "Last Week"
+#~ msgstr "Pasinta semajno"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%-e-a de %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-e-a de %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Seanco finis"
+
+#~ msgid "Session Started"
+#~ msgstr "Seanco komencis"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Aktiveco de konto"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Bonvole elektu alian pasvorton."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Bonvolu tajpi vian aktualan pasvorton denove."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Ne eblis ŝanĝi pasvorton"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Ne povas aŭtomate aliĝi al ĉi tiu domajnspeco"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Ne trovis tian domajnon aŭ regnon"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Ne eblas saluti kiel %s en la %s domajno"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Nevalida pasvorto, bonvolu provi denove"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Malsukcesis forigi uzanton"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Malsukcesis senvalidigi defore mastrumitan uzanton"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Vi ne povas forigi vian propran konton."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s jam estas salutite"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "La forigo de uzanto kiu estas ankoraŭ salutita, povas rezulti en "
+#~ "nekonsekvencan sistemon."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Ĉu vi volas teni la dosierojn de %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Eblas teni la hejmdosierujon, retpoŝtmandrenon kaj provizorajn dosierojn "
+#~ "ĉirkaŭe dum forigante uzantkonton."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Forigi dosierojn"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Konservi dosierojn"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Ĉu vi certe volas senvalidigi la defore mastrumita konto de %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Forigi"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Konto estas malŝaltita"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Agordota dum venonta salutado"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Neniu"
+
+#~ msgid "Logged in"
+#~ msgstr "Salutita"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Malsukcesis konekti la kontoservon"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Bonvolu certigi ke la AccountService estas instalita kaj ŝaltita."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Por fari ŝanĝojn,\n"
+#~ "alklaku unue la *-piktogramon"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Forigi la elektitan uzantkonton"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Por forigi la elektitan uzantkonton,\n"
+#~ "klaku unue la *-piktogramon"
+
+#, fuzzy
+#~| msgid "Unlock to Change Settings"
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Malŝlosi por ŝanĝi agordojn"
+
+#~ msgid "Create a user account"
+#~ msgstr "Krei uzantkonton"
+
+#~ msgid "User Icon"
+#~ msgstr "Uzanta bildsimbolo"
+
+#~ msgid "Account Settings"
+#~ msgstr "Kontaj agordoj"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Aŭtentigo & saluto"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Salutado;Nomo;Fingropremo;Avataro;Logobildo;Vizaĵo;Pasvorto;"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "La nova pasvorta devas esti malsama al la malnova."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Provu ŝanĝi kelkajn leterojn kaj nombrojn."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Provu ŝanĝi la pasvorton iom pli."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Pasvorto sen via uzantonomo estus pli forta."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Klopodu eviti vian uzantonomon en la pasvorto."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Klopodu eviti kelkajn vortojn, jam inkluditaj en la pasvorto."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Klopodu eviti komunajn vortojn."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Klopodu eviti reordon de jamaj vortoj."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Klopodu uzi pli da ciferoj."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Klopodu uzi pli da majusklaj literoj."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Klopodu uzi pli da minusklaj literoj."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Klopodu uzi pli da specialaj signoj, kiel interpunkcio."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Klopodu uzi kunmeton de literoj, ciferoj kaj interpunkcio."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Klopodu eviti ripeto de la sama signo."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Klopodu eviti ripeto de la sama signo: vi kunmetu literojn, ciferojn kaj "
+#~ "interpunkcion."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Klopodu eviti sekvencojn kiel 1234 aŭ abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Pasvorto devas esti pli longa. Klopodu aldoni pli da literoj, ciferoj kaj "
+#~ "interpunkcioj."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Kunmetu majusklojn kaj minusklojn, kaj uzu almenaŭ unu ciferon."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Aldonado de pli da literoj, ciferoj kaj interpunkcio plifortigos la "
+#~ "pasvorton."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Aŭtentigo malsukcesis"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "La pasvorto estas tro mallonga"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "La pasvorto estas tro simpla"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "La malnova kaj nova pasvortoj tro similaj"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "La nova pasvorto jam estis uzata."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "La nova pasvorto devas enhavi ciferajn aŭ specialan signojn"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "La malnova kaj nova pasvortoj estas identaj"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Via pasvorto estas ŝanĝita ekde kiam vi unuafoje aŭtentiĝis!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "La nova pasvorto ne enhavas sufiĉe da diversaj signoj"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Nekonata eraro"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "La uzantonomo rajtas nur konsisti el minusklaj literoj de a-z, ciferoj, "
+#~ "kaj la jenaj signoj: . - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Pardonon, tiu uzantonomo ne estas disponebla. Bonvolu klopodi alian."
+
+#~ msgid "The username is too long."
+#~ msgstr "La uzantonomo estas tro longa."
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "Tiu ĉi nomos vian hejmdosierujon kaj oni ne povas ŝanĝi ĝin."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Butono %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Sendi klavofrapon"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Ŝanĝi ekranon"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Montri ekranhelpon"
+
+#~ msgid "Output:"
+#~ msgstr "Eligo:"
+
+# Mi supozas, ke "letterbox" signifas "horizontala orientiĝo". --Carmen
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Teni proporcion (pejzaĝo):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapi al unuobla ekrano"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Ekrana mapado"
+
+#~ msgid "Stylus"
+#~ msgstr "Grifelo"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tabuleto (absoluta)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Agordoj de tabuleto"
+
+#~ msgid "_Help"
+#~ msgstr "_Helpo"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Agordoj de Bludento"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Ĉasreĝimo"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Map-butonoj…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Agordi musagordojn"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Ĝustigi ekranan distingivon"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nova klavkombino…"
+
+#~ msgid "No stylus found"
+#~ msgstr "Neniu grifelo estas trovita"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Bonvolu movi vian grifelon apud via tabuleto por agordi ĝin"
+
+#~ msgid "Top Button"
+#~ msgstr "Supra butono"
+
+#~ msgid "Lower Button"
+#~ msgstr "Suba butono"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Plej suba butono"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "GNOME Agordoj"
+
+#~ msgid "Display version number"
+#~ msgstr "Montri versionumeron"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Ŝalti adan reĝimon"
+
+#~ msgid "Search for the string"
+#~ msgstr "Serĉi la ĉenon"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Listigi eblajn panelnomojn kaj eliri"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panelo por montri"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANELO] [ARGUMENTO…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Disponeblaj paneloj:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sistemsonoj"
 
 #~ msgid "Add user accounts and change passwords"
 #~ msgstr "Aldoni uzantokontojn kaj ŝanĝi pasvortojn"
@@ -8332,9 +8093,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Change location settings and providers"
 #~ msgstr "Ŝanĝi lokajn agordojn kaj provizantojn"
-
-#~ msgid "Access your location"
-#~ msgstr "Atingi vian lokon"
 
 #~ msgid "Read system and application logs"
 #~ msgstr "Legi sistemajn kaj aplikaĵajn protokolojn"
@@ -8506,9 +8264,6 @@ msgstr "Sistemsonoj"
 #~ msgid "Empty"
 #~ msgstr "Malplena"
 
-#~ msgid "Choose keyboard layouts or input methods."
-#~ msgstr "Elekti klavararanĝojn aŭ enigajn metodojn."
-
 #~ msgid "Previous source"
 #~ msgstr "Antaŭa fonto"
 
@@ -8636,9 +8391,6 @@ msgstr "Sistemsonoj"
 #~ msgctxt "background, style"
 #~ msgid "Span"
 #~ msgstr "Etendi"
-
-#~ msgid "Wallpapers"
-#~ msgstr "Ekranfonoj"
 
 #~ msgid "Colors"
 #~ msgstr "Koloroj"
@@ -8802,9 +8554,6 @@ msgstr "Sistemsonoj"
 #~ msgid "Infrastructure"
 #~ msgstr "Infrastrukturo"
 
-#~ msgid "Not connected"
-#~ msgstr "Ne konekita"
-
 #~ msgid "_Automatic suspend"
 #~ msgstr "_Aŭtomata haltetado"
 
@@ -8917,9 +8666,6 @@ msgstr "Sistemsonoj"
 #~ msgid "application-x-executable"
 #~ msgstr "application-x-executable"
 
-#~ msgid "preferences-desktop-wallpaper"
-#~ msgstr "preferences-desktop-wallpaper"
-
 #~ msgid "bluetooth"
 #~ msgstr "bluetooth"
 
@@ -8952,9 +8698,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "network-wireless"
 #~ msgstr "network-wireless"
-
-#~ msgid "preferences-system-notifications"
-#~ msgstr "preferences-system-notifications"
 
 #~ msgid "goa-panel"
 #~ msgstr "goa-panel"
@@ -9128,9 +8871,6 @@ msgstr "Sistemsonoj"
 #~ msgid "Blue­tooth"
 #~ msgstr "Bludento"
 
-#~ msgid "Section"
-#~ msgstr "Sekcio"
-
 #~ msgid "Overview"
 #~ msgstr "Superrigardo"
 
@@ -9148,9 +8888,6 @@ msgstr "Sistemsonoj"
 #~| msgid "Removable Media"
 #~ msgid "Remo­vable Media"
 #~ msgstr "Demetebla datumportilo"
-
-#~ msgid "My Home Network"
-#~ msgstr "Mia hejma reto"
 
 #, fuzzy
 #~| msgid "Network"
@@ -9215,9 +8952,6 @@ msgstr "Sistemsonoj"
 #~ msgid "Show the overview"
 #~ msgstr "Montri la superrigardon"
 
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "Bludento estas elŝaltite"
-
 #~ msgid "Done"
 #~ msgstr "Farite"
 
@@ -9229,9 +8963,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Mirrored"
 #~ msgstr "Spegulata"
-
-#~ msgid "Secondary"
-#~ msgstr "Kroma"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Aranĝi kombinitajn ekranojn"
@@ -9247,9 +8978,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Size"
 #~ msgstr "Grando"
-
-#~ msgid "Aspect Ratio"
-#~ msgstr "Aspekta rilatumo"
 
 #~ msgid "Show the top bar and Activities Overview on this display"
 #~ msgstr "Montri la supran breton kaj Aktivecoj-Superrigardon ĉi ekrane"
@@ -9315,9 +9043,6 @@ msgstr "Sistemsonoj"
 #~ msgstr ""
 #~ "Por redakti klavkombinon, alklaku la vicon kaj premu la novajn klavojn aŭ "
 #~ "premu la retropaŝan klavon por vakigi."
-
-#~ msgid "Shortcuts"
-#~ msgstr "Klavkombinoj"
 
 #~ msgid "<Unknown Action>"
 #~ msgstr "<Nekonata ago>"
@@ -9627,9 +9352,6 @@ msgstr "Sistemsonoj"
 #~ msgstr[0] "%u aktiva"
 #~ msgstr[1] "%u aktivaj"
 
-#~ msgid "Close"
-#~ msgstr "Fermi"
-
 #~ msgid "Resume Printing"
 #~ msgstr "Daŭrigi preson"
 
@@ -9641,9 +9363,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "No printers detected."
 #~ msgstr "Detektis neniun presilon."
-
-#~ msgid "Loading options…"
-#~ msgstr "Ŝarĝante opciojn…"
 
 #, fuzzy
 #~ msgctxt "print job"
@@ -9668,9 +9387,6 @@ msgstr "Sistemsonoj"
 #~ msgid "label"
 #~ msgstr "etikedo"
 
-#~ msgid "Setting new driver…"
-#~ msgstr "Metante novan pelilon…"
-
 #~ msgid "Print _Test Page"
 #~ msgstr "Presi _testpaĝon"
 
@@ -9679,9 +9395,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Used to determine your geographical location"
 #~ msgstr "Uzita por determini vian geografian lokon"
-
-#~ msgid "Options"
-#~ msgstr "Agordoj"
 
 #~ msgctxt "Search Location"
 #~ msgid "Other"
@@ -9699,10 +9412,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Save Received Files to Downloads Folder"
 #~ msgstr "Konservi ricevitajn dosierojn en la dosierujo de elŝutoj"
-
-#, fuzzy
-#~ msgid "Allow Remote Control"
-#~ msgstr "Laŭtecregilo"
 
 #~ msgid "Password:"
 #~ msgstr "Pasvorto:"
@@ -9826,9 +9535,6 @@ msgstr "Sistemsonoj"
 #~ msgid "Scroll Up"
 #~ msgstr "Rulumi supren"
 
-#~ msgid "Scroll Down"
-#~ msgstr "Rulumi suben"
-
 #~ msgid "Scroll Right"
 #~ msgstr "Rulumi dekstren"
 
@@ -9845,9 +9551,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Turns off wireless devices"
 #~ msgstr "Elŝalti sendratajn aparatojn"
-
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "Agordi novan aparaton"
@@ -9899,10 +9602,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "System Up-To-Date"
 #~ msgstr "Ĝisdata sistemo"
-
-#, fuzzy
-#~ msgid "Disable while _typing"
-#~ msgstr "Elŝalti _tuŝplaton dum tajpado"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "La sistemaj retservoj ne kongruas kun ĉi tiu versio."
@@ -10034,9 +9733,6 @@ msgstr "Sistemsonoj"
 #~ msgid "Bluetooth"
 #~ msgstr "Bludento"
 
-#~ msgid "Create virtual device"
-#~ msgstr "Krei virtualan aparaton"
-
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "Disponeblaj profiloj por ekranoj"
 
@@ -10120,9 +9816,6 @@ msgstr "Sistemsonoj"
 #~ msgid "_City:"
 #~ msgstr "_Urbo:"
 
-#~ msgid "_Network Time"
-#~ msgstr "_Rethoro"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "Aldoni unu horon al tempo."
 
@@ -10149,18 +9842,11 @@ msgstr "Sistemsonoj"
 #~ msgstr "Normale"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "Dekstrume"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 gradoj"
 
 #~ msgid "%d x %d"
 #~ msgstr "%d x %d"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "Trenu por ŝanĝi unuarangan ekranon."
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -10229,9 +9915,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Sh_ow position of pointer when the Control key is pressed"
 #~ msgstr "M_ontri montrilan pozicion kiam la stirklavo estas premata"
-
-#~ msgid "A_cceleration:"
-#~ msgstr "Ak_celado:"
 
 #~ msgid "_Sensitivity:"
 #~ msgstr "_Sentemo:"
@@ -10346,9 +10029,6 @@ msgstr "Sistemsonoj"
 #~ msgid "Network"
 #~ msgstr "Reto"
 
-#~ msgid "Device types"
-#~ msgstr "Aparattipoj"
-
 #~ msgid "Automatic configuration"
 #~ msgstr "Aŭtomata agordo"
 
@@ -10399,9 +10079,6 @@ msgstr "Sistemsonoj"
 #~ "Select a display language (change will be applied next time you log in)"
 #~ msgstr ""
 #~ "Elektu vidigitan lingvon (ŝanĝoj estos aplikitaj dum sekva ensalutado)"
-
-#~ msgid "Install languages..."
-#~ msgstr "Instali lingvojn..."
 
 #~ msgid "Add Language"
 #~ msgstr "Aldoni lingvon"
@@ -10458,14 +10135,8 @@ msgstr "Sistemsonoj"
 #~ msgid "System settings"
 #~ msgstr "Sistemagordoj"
 
-#~ msgid "Layout"
-#~ msgstr "Aranĝo"
-
 #~ msgid "Brightness and Lock"
 #~ msgstr "Heleco kaj ŝlosado"
-
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "Ekranheleco kaj ŝlosagordoj"
 
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "Heleco;Ŝlosi;Malheligo;Malplenigo;Ekrano;"
@@ -10829,9 +10500,6 @@ msgstr "Sistemsonoj"
 #~ msgid "Shutdown"
 #~ msgstr "Elŝalti"
 
-#~ msgid "Mute"
-#~ msgstr "Silentigi"
-
 #~ msgid "Keyboard;Mouse;a11y;Accessibility;"
 #~ msgstr "Klavaro;Muso;a11y;Alireblo;"
 
@@ -10867,9 +10535,6 @@ msgstr "Sistemsonoj"
 #~ msgstr ""
 #~ "Adreso kie eblas akiri pli da etosoj. Se estas malplena ĉeno, la ligilo "
 #~ "ne estos montrata."
-
-#~ msgid "Locked"
-#~ msgstr "Ŝlosite"
 
 #~ msgid ""
 #~ "System policy prevents changes.\n"
@@ -10959,9 +10624,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "State/Pro_vince:"
 #~ msgstr "Ŝtato/pro_vinco:"
-
-#~ msgid "User name:"
-#~ msgstr "Uzantonomo:"
 
 #~ msgid "Web"
 #~ msgstr "Reto"
@@ -11353,9 +11015,6 @@ msgstr "Sistemsonoj"
 #~ msgid "_RGB"
 #~ msgstr "_RVB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "_Reagordi al la defaŭltoj"
-
 #~ msgid "_Selected items:"
 #~ msgstr "E_lektitaj elementoj:"
 
@@ -11364,9 +11023,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "_Slight"
 #~ msgstr "_Iomete"
-
-#~ msgid "_Style:"
-#~ msgstr "_Stilo:"
 
 #~ msgid "_Tooltips:"
 #~ msgstr "Ŝ_pruchelpilo:"
@@ -11382,9 +11038,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "dots per inch"
 #~ msgstr "punktoj je colo"
-
-#~ msgid "Appearance"
-#~ msgstr "Aspekto"
 
 #~ msgid "Customize the look of the desktop"
 #~ msgstr "Alpropigi la aspekton de la labortablo"
@@ -11519,9 +11172,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Copying files"
 #~ msgstr "Kopiante dosierojn"
-
-#~ msgid "Parent Window"
-#~ msgstr "Gepatra fenestro"
 
 #~ msgid "Parent window of the dialog"
 #~ msgstr "Gepatra fenestro de la dialogo"
@@ -11711,9 +11361,6 @@ msgstr "Sistemsonoj"
 #~ msgid "_Detect monitors"
 #~ msgstr "_Detekti ekranojn"
 
-#~ msgid "Monitors"
-#~ msgstr "Monitoroj"
-
 #~ msgid ""
 #~ "Usage: %s SOURCE_FILE DEST_NAME\n"
 #~ "\n"
@@ -11792,9 +11439,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Could not set the default configuration for monitors"
 #~ msgstr "Ne eblas agordi la defaŭltajn agordojn por la ekranoj"
-
-#~ msgid "Desktop"
-#~ msgstr "Labortablo"
 
 #~ msgid "Error unsetting accelerator in configuration database: %s"
 #~ msgstr "Eraro dum malagordado de akceliloj en agorddatumbazo: %s"
@@ -11984,9 +11628,6 @@ msgstr "Sistemsonoj"
 
 #~ msgid "Set your window properties"
 #~ msgstr "Agordi viajn fenestrajn atributojn"
-
-#~ msgid "Windows"
-#~ msgstr "Fenestroj"
 
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr "Fenestroadministrilo \"%s\" ne registris agordilon\n"

--- a/po/eo.po~
+++ b/po/eo.po~
@@ -1,0 +1,12253 @@
+# Esperanto translation for gnome-control-center.
+# Copyright (C) 2006 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+# Joop EGGEN <joop_eggen@yahoo.de>, 2006.
+# Ed GLEZ < >, 2006.
+# Brian CROOM < >, 2008.
+# Olivier WEB < >, 2008.
+# Michael MORONI < >, 2011.
+# Samir Ribić < >, 2011.
+# Tiffany ANTOPOLSKI < >, 2012.
+# Ryan LORTIE <desrt@desrt.ca>, 2013.
+# Daniel PUENTES <blatberk@openmailbox.org>, 2015.
+# Kristjan SCHMIDT <kristjan.schmidt@googlemail.com>, 2010-2020.
+# Carmen Bianca BAKKER <carmen@carmenbianca.eu>, 2018-2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2021-04-02 13:09+0000\n"
+"PO-Revision-Date: 2021-03-29 18:34+0200\n"
+"Last-Translator: Carmen Bianca BAKKER <carmen@carmenbianca.eu>\n"
+"Language-Team: Esperanto <gnome-eo-list@gnome.org>\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Gtranslator 3.38.0\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:823
+msgid "System Bus"
+msgstr "Sistembuso"
+
+#: panels/applications/cc-applications-panel.c:823
+#: panels/applications/cc-applications-panel.c:825
+#: panels/applications/cc-applications-panel.c:838
+#: panels/applications/cc-applications-panel.c:843
+msgid "Full access"
+msgstr "Plena aliro"
+
+#: panels/applications/cc-applications-panel.c:825
+msgid "Session Bus"
+msgstr "Seanca buso"
+
+#: panels/applications/cc-applications-panel.c:829
+#: panels/power/cc-power-panel.c:1790 panels/thunderbolt/cc-bolt-panel.ui:466
+#: panels/thunderbolt/cc-bolt-panel.ui:525
+msgid "Devices"
+msgstr "Aparatoj"
+
+#: panels/applications/cc-applications-panel.c:829
+msgid "Full access to /dev"
+msgstr "Plena aliro al /dev"
+
+#: panels/applications/cc-applications-panel.c:833
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:288
+msgid "Network"
+msgstr "Reto"
+
+#: panels/applications/cc-applications-panel.c:833
+msgid "Has network access"
+msgstr "Havas retaliron"
+
+#: panels/applications/cc-applications-panel.c:838
+#: panels/applications/cc-applications-panel.c:840
+#: panels/search/cc-search-locations-dialog.c:362
+msgid "Home"
+msgstr "Hejmo"
+
+#: panels/applications/cc-applications-panel.c:840
+#: panels/applications/cc-applications-panel.c:845
+msgid "Read-only"
+msgstr "Nurlega"
+
+#: panels/applications/cc-applications-panel.c:843
+#: panels/applications/cc-applications-panel.c:845
+msgid "File System"
+msgstr "Dosiersistemo"
+
+#: panels/applications/cc-applications-panel.c:849
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:279
+#: shell/cc-window.c:933 shell/cc-window.ui:121
+#: shell/gnome-control-center.desktop.in.in:3
+msgid "Settings"
+msgstr "Agordoj"
+
+#: panels/applications/cc-applications-panel.c:849
+msgid "Can change settings"
+msgstr "Rajtas ŝanĝi agordojn"
+
+#: panels/applications/cc-applications-panel.c:851
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s havas la sekvajn fiksitajn permesojn. Oni ne povas ŝanĝi ilin. Se vi "
+"zorgas pri ĉi tiuj permesoj, pripensu forigon de la aplikaĵo."
+
+#: panels/applications/cc-applications-panel.c:1024
+msgid "Web Links"
+msgstr "Retligiloj"
+
+#: panels/applications/cc-applications-panel.c:1034
+msgid "Git Links"
+msgstr "Gitligiloj"
+
+#: panels/applications/cc-applications-panel.c:1040
+#, c-format
+msgid "%s Links"
+msgstr "%s-ligiloj"
+
+#: panels/applications/cc-applications-panel.c:1048
+#: panels/applications/cc-applications-panel.c:1084
+msgid "Unset"
+msgstr "Ne agordita"
+
+#: panels/applications/cc-applications-panel.c:1139
+msgid "Links"
+msgstr "Ligiloj"
+
+#: panels/applications/cc-applications-panel.c:1147
+msgid "Hypertext Files"
+msgstr "Hipertekstaj dosieroj"
+
+#: panels/applications/cc-applications-panel.c:1161
+msgid "Text Files"
+msgstr "Tekstaj dosieroj"
+
+#: panels/applications/cc-applications-panel.c:1175
+msgid "Image Files"
+msgstr "Bildo-dosieroj"
+
+#: panels/applications/cc-applications-panel.c:1191
+msgid "Font Files"
+msgstr "Tipar-dosieroj"
+
+#: panels/applications/cc-applications-panel.c:1252
+msgid "Archive Files"
+msgstr "Arĥiv-dosieroj"
+
+#: panels/applications/cc-applications-panel.c:1272
+msgid "Package Files"
+msgstr "Pak-dosieroj"
+
+#: panels/applications/cc-applications-panel.c:1295
+msgid "Audio Files"
+msgstr "Son-dosieroj"
+
+#: panels/applications/cc-applications-panel.c:1312
+msgid "Video Files"
+msgstr "Video-dosieroj"
+
+#: panels/applications/cc-applications-panel.c:1320
+msgid "Other Files"
+msgstr "Aliaj dosieroj"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1660
+#: panels/applications/cc-applications-panel.ui:416
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:79
+msgid "Applications"
+msgstr "Aplikaĵoj"
+
+#: panels/applications/cc-applications-panel.ui:43
+msgid "No applications"
+msgstr "Neniuj aplikaĵoj"
+
+#: panels/applications/cc-applications-panel.ui:57
+msgid "Install some…"
+msgstr "Instali kelkajn…"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "Permissions & Access"
+msgstr "Permesoj & aliro"
+
+#: panels/applications/cc-applications-panel.ui:106
+msgid ""
+"Data and services that this app has asked for access to and permissions that "
+"it requires."
+msgstr ""
+"Datumoj kaj servoj, al kiuj ĉi tiu aplikaĵo demandis atingon, kaj ĝiaj "
+"necesaj permesoj."
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:127
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamerao"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:128
+#: panels/applications/cc-applications-panel.ui:140
+#: panels/applications/cc-applications-panel.ui:152
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:262
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:85
+#: panels/keyboard/cc-xkb-modifier-dialog.c:355
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:129
+#: panels/user-accounts/cc-user-panel.c:843
+#: panels/user-accounts/cc-user-panel.c:938
+#: subprojects/gvc/gvc-mixer-control.c:1900
+msgid "Disabled"
+msgstr "Malŝaltita"
+
+#: panels/applications/cc-applications-panel.ui:133
+#: panels/applications/cc-applications-panel.ui:139
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofono"
+
+#: panels/applications/cc-applications-panel.ui:145
+#: panels/applications/cc-applications-panel.ui:151
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Lokado-servoj"
+
+#: panels/applications/cc-applications-panel.ui:157
+#: panels/applications/cc-applications-panel.ui:499
+msgid "Built-in Permissions"
+msgstr "Fiksitaj permesoj"
+
+#: panels/applications/cc-applications-panel.ui:158
+msgid "Cannot be changed"
+msgstr "Ne eblas ŝanĝi"
+
+#: panels/applications/cc-applications-panel.ui:175
+msgid ""
+"Individual permissions for applications can be reviewed in the <a href="
+"\"privacy\">Privacy</a> Settings."
+msgstr ""
+"Individuajm permesojm por alikaĵoj oni povas kontroli en la <a href=\"privacy"
+"\">Privateco</a>-agordoj."
+
+#: panels/applications/cc-applications-panel.ui:199
+msgid "Integration"
+msgstr "Integrigo"
+
+#: panels/applications/cc-applications-panel.ui:211
+msgid "System features used by this application."
+msgstr "Sistemfunkcioj, kiujn uzas ĉi tiu aplikaĵo."
+
+#: panels/applications/cc-applications-panel.ui:225
+#: panels/applications/cc-applications-panel.ui:231
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:151
+msgid "Search"
+msgstr "Serĉo"
+
+#: panels/applications/cc-applications-panel.ui:237
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Sciigoj"
+
+#: panels/applications/cc-applications-panel.ui:243
+msgid "Run in background"
+msgstr "Ruli fone"
+
+#: panels/applications/cc-applications-panel.ui:249
+msgid "Set Desktop Background"
+msgstr "Agordi labortablan fonon"
+
+#: panels/applications/cc-applications-panel.ui:255
+#: panels/applications/cc-applications-panel.ui:261
+msgid "Sounds"
+msgstr "Sonoj"
+
+#: panels/applications/cc-applications-panel.ui:267
+msgid "Inhibit system keyboard shortcuts"
+msgstr "Malpermesi sistemajn klavkombinojn"
+
+#: panels/applications/cc-applications-panel.ui:300
+msgid "Default Handlers"
+msgstr "Implicitaj traktiloj"
+
+#: panels/applications/cc-applications-panel.ui:312
+msgid "Types of files and links that this application opens."
+msgstr "Specoj de dosieroj kaj ligiloj, kiujn ĉi tiu aplikaĵo malfermas."
+
+#: panels/applications/cc-applications-panel.ui:328
+msgid "Reset"
+msgstr "Reagordi"
+
+#: panels/applications/cc-applications-panel.ui:364
+msgid "Usage"
+msgstr "Uzado"
+
+#: panels/applications/cc-applications-panel.ui:376
+msgid "How much resources this application is using."
+msgstr "Kiom da risurcoj ĉi tiu aplikaĵo uzas."
+
+#: panels/applications/cc-applications-panel.ui:391
+#: panels/applications/cc-applications-panel.ui:536
+msgid "Storage"
+msgstr "Konservejo"
+
+#: panels/applications/cc-applications-panel.ui:423
+msgid "Open in Software"
+msgstr "Malfermi en Programaro"
+
+#: panels/applications/cc-applications-panel.ui:473 shell/cc-panel-list.ui:121
+msgid "No results found"
+msgstr "Neniu rezulto troviĝis"
+
+#: panels/applications/cc-applications-panel.ui:484
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:177
+#: shell/cc-panel-list.ui:132
+msgid "Try a different search"
+msgstr "Provu alian serĉon"
+
+#: panels/applications/cc-applications-panel.ui:554
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Kiom da diskospaco ĉi tiu aplikaĵo okpuas per apdatumoj kaj kaŝmemoroj."
+
+#: panels/applications/cc-applications-panel.ui:563
+msgid "Application"
+msgstr "Aplikaĵo"
+
+#: panels/applications/cc-applications-panel.ui:569
+msgid "Data"
+msgstr "Datumo"
+
+#: panels/applications/cc-applications-panel.ui:575
+msgid "Cache"
+msgstr "Kaŝmemoro"
+
+#: panels/applications/cc-applications-panel.ui:581
+msgid "<b>Total</b>"
+msgstr "<b>Totalo</b>"
+
+#: panels/applications/cc-applications-panel.ui:598
+msgid "Clear Cache…"
+msgstr "Vakigi kaŝmemoron…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Kontroli diversajn aplikaĵajn permesojn kaj agordojn"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplikaĵo;flatpak;permeso;agordo;"
+
+#: panels/background/cc-background-chooser.c:345
+msgid "Select a picture"
+msgstr "Elekti bildon"
+
+#: panels/background/cc-background-chooser.c:348
+#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:238
+#: panels/color/cc-color-panel.c:886 panels/color/cc-color-panel.ui:657
+#: panels/common/cc-language-chooser.ui:25
+#: panels/display/cc-display-panel.c:1003
+#: panels/info-overview/cc-info-overview-panel.ui:242
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/network/cc-wifi-hotspot-dialog.ui:122
+#: panels/network/cc-wifi-panel.c:866
+#: panels/network/connection-editor/connection-editor.ui:17
+#: panels/network/connection-editor/vpn-helpers.c:176
+#: panels/network/connection-editor/vpn-helpers.c:299
+#: panels/network/net-device-wifi.c:854
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:235
+#: panels/region/cc-format-chooser.ui:28
+#: panels/search/cc-search-locations-dialog.c:639
+#: panels/sharing/cc-sharing-panel.c:396 panels/usage/cc-usage-panel.c:133
+#: panels/user-accounts/cc-add-user-dialog.ui:28
+#: panels/user-accounts/cc-avatar-chooser.c:105
+#: panels/user-accounts/cc-avatar-chooser.c:223
+#: panels/user-accounts/cc-fingerprint-dialog.ui:36
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:633
+#: panels/user-accounts/cc-user-panel.c:651
+#: panels/user-accounts/data/join-dialog.ui:20
+msgid "_Cancel"
+msgstr "_Nuligi"
+
+#: panels/background/cc-background-chooser.c:349
+#: panels/network/connection-editor/vpn-helpers.c:177
+#: panels/printers/pp-details-dialog.c:236
+#: panels/sharing/cc-sharing-panel.c:397
+#: panels/user-accounts/cc-avatar-chooser.c:224
+msgid "_Open"
+msgstr "_Malfermi"
+
+#: panels/background/cc-background-item.c:140
+msgid "multiple sizes"
+msgstr "pluraj grandoj"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:144
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:282
+msgid "No Desktop Background"
+msgstr "Neniu labortabla fono"
+
+#: panels/background/cc-background-panel.c:112
+msgid "Current background"
+msgstr "Aktuala fono"
+
+#: panels/background/cc-background-panel.ui:55
+msgid "Add Picture…"
+msgstr "Aldoni bildon…"
+
+#: panels/background/cc-background-preview.ui:55
+msgid "Activities"
+msgstr "Agoj"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "Fono"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Ŝanĝi vian fonan bildon al ekranfono aŭ foto"
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Ekranfono;Ekrano;Labortablo;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "No Bluetooth Found"
+msgstr "Ne trovis Bludenton"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Konektu ricevilon por uzi Bludenton."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:69
+msgid "Bluetooth Turned Off"
+msgstr "Bludento estas malŝaltita"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:80
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Ŝaltu por konekti aparatojn kaj ricevi transmetadon de dosieroj."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:107
+msgid "Airplane Mode is on"
+msgstr "Aviadila reĝimo estas ŝaltita"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:118
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bludento estas malŝaltita dum aviadila reĝimo."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:124
+msgid "Turn Off Airplane Mode"
+msgstr "Malŝalti aviadilan reĝimon"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:154
+msgid "Hardware Airplane Mode is on"
+msgstr "Aparata aviadila reĝimo estas ŝaltita"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:165
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Malŝaltu aviadilan reĝimon por ŝalti Bludenton."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1595
+msgid "Bluetooth"
+msgstr "Bludento"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Ŝalti kaj malŝalti Bludenton kaj konekti viajn aparatojn"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "kunhavigi;kunhavigado;bludento;obex;"
+
+#: panels/camera/cc-camera-panel.ui:34
+msgid "Camera is turned off"
+msgstr "Kamerao malŝaltita"
+
+#: panels/camera/cc-camera-panel.ui:43
+msgid "No applications can capture photos or video."
+msgstr "Neniu aplikaĵo povas registri fotojn aŭ filmojn."
+
+#: panels/camera/cc-camera-panel.ui:75
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly."
+msgstr ""
+"Uzado de la kamerao permesas al aplikaĵoj fari fotojn kaj registri videojn. "
+"Malŝaltado de la kamerao povus kaŭzi, ke kelkaj aplikaĵoj ne funkcias taŭge."
+
+#: panels/camera/cc-camera-panel.ui:85
+msgid "Allow the applications below to use your camera."
+msgstr "Permesi, ke la subaj aplikaĵoj povu uzi vian kameraon."
+
+#: panels/camera/cc-camera-panel.ui:105
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Neniu aplikaĵo petis atingon al via kamerao"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Protekti viajn bildoj"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"ekrano;ŝlosi;ŝloso;diagnozo;kraŝo;privata;lastatempa;provizora;tmp;indekso;"
+"reto;identeco;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Metu vian laŭnormigan aparaton super la kvadraton kaj premu “Komenci”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Movu vian laŭnormigan aparaton al la laŭnormiga pozicio kaj premu “Daŭrigi”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Movu vian laŭnormigan aparaton al la supraĵa pozicio kaj premu “Daŭrigi”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Fermu la kovrilon de la klapkomputilo"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Okazis interna eraro, kiun ne eblis riparigi."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Necesaj iloj por laŭnormigo ne estas instalitaj."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Ne eblis generi la profilon."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "La cela blankpunkto ne akireblis."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Plenumita!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Laŭnormigo malsukcesis!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Vi povas forigi la laŭnormigan aparaton."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ne interrompu la laŭnormigan aparaton dum plenumado"
+
+#: panels/color/cc-color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr "Ekran-laŭnormigo"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:40
+msgid "_Start"
+msgstr "_Komenci"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:54
+msgid "_Resume"
+msgstr "Daŭ_rigi"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
+#: panels/user-accounts/cc-fingerprint-dialog.ui:73
+msgid "_Done"
+msgstr "_Plenumita"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Ekrano de klapkomputilo"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Fiksita retkamerao"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s Ekrano"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s Skanilo"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s Kamerao"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s Presilo"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s Retkamerao"
+
+#: panels/color/cc-color-device.c:90
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Ŝalti kolormastrumadon por %s"
+
+#: panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Montri kolorprofilojn por %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Nelaŭnormigita"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:167
+msgid "Default: "
+msgstr "Implicita: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:175
+msgid "Colorspace: "
+msgstr "Kolorspaco: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:182
+msgid "Test profile: "
+msgstr "Testprofilo: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:236
+msgid "Select ICC Profile File"
+msgstr "Elekti ICC-profildosieron"
+
+#: panels/color/cc-color-panel.c:239
+msgid "_Import"
+msgstr "E_nporti"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:250
+msgid "Supported ICC profiles"
+msgstr "Subtenataj ICC-profiloj"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:257
+#: panels/network/wireless-security/eap-method-fast.c:356
+msgid "All files"
+msgstr "Ĉiuj dosieroj"
+
+#: panels/color/cc-color-panel.c:549
+msgid "Screen"
+msgstr "Ekrano"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:839
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Malsukcesis alŝuti dosieron: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:851
+msgid "The profile has been uploaded to:"
+msgstr "La profilo estas alŝutita al:"
+
+# Ĉu estas imperativo? --Carmen
+#: panels/color/cc-color-panel.c:853
+msgid "Write down this URL."
+msgstr "Noti tiun ret-adreson."
+
+# Ĉu estas imperativo? --Carmen
+#: panels/color/cc-color-panel.c:854
+msgid "Restart this computer and boot your normal operating system."
+msgstr "Restartigi ĉi tiun komputilon kaj startigi vian normalan operaciumon."
+
+#: panels/color/cc-color-panel.c:855
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+"Tajpu la retadreson en via retumilo por elŝutu kaj instalu la profilon."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:883
+msgid "Save Profile"
+msgstr "Konservi profilon"
+
+#: panels/color/cc-color-panel.c:887
+#: panels/network/connection-editor/vpn-helpers.c:300
+msgid "_Save"
+msgstr "Kon_servi"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1196
+msgid "Create a color profile for the selected device"
+msgstr "Krei kolorprofilon por la elektita aparato"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1211 panels/color/cc-color-panel.c:1235
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"La mezurilo ne estas detektita. Bonvolu kontroli ĉu ĝi estas ŝaltita kaj "
+"korekte konektita."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1245
+msgid "The measuring instrument does not support printer profiling."
+msgstr "La mezurilo ne subtenas presilprofiladon."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1256
+msgid "The device type is not currently supported."
+msgstr "La aparatspeco ne estas aktuale subtenita."
+
+#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+msgid "Screen Calibration"
+msgstr "Ekran-laŭnormigo"
+
+#: panels/color/cc-color-panel.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Laŭnormigo generos profilon, kiun vi povas uzi por administri koloron de via "
+"ekrano. Ju pli da laŭnormigdaŭro, des pli bona kvalito de la kolorprofilo."
+
+#: panels/color/cc-color-panel.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Vi ne povos uzi vian komputilon dum laŭnormigado."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:58
+msgid "Quality"
+msgstr "Kvalito"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:75
+msgid "Approximate Time"
+msgstr "Proksimuma tempo"
+
+#: panels/color/cc-color-panel.ui:121
+msgid "Calibration Quality"
+msgstr "Laŭnormigo-kvalito"
+
+#: panels/color/cc-color-panel.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Elektu la sentilan aparaton, kiun vi volas uzi por laŭnormigo."
+
+#: panels/color/cc-color-panel.ui:174
+msgid "Calibration Device"
+msgstr "Laŭnormigo-aparato"
+
+#: panels/color/cc-color-panel.ui:189
+msgid "Select the type of display that is connected."
+msgstr "Elektu la tipon de la konektita ekrano."
+
+#: panels/color/cc-color-panel.ui:226
+msgid "Display Type"
+msgstr "Ekranspeco"
+
+#: panels/color/cc-color-panel.ui:241
+#, fuzzy
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Elektu la ekranan celon por montri la blankpunkton. La plej multaj ekranoj "
+"bezonas la agordon D65."
+
+#: panels/color/cc-color-panel.ui:278
+msgid "Profile Whitepoint"
+msgstr "Profila blanko-punkto"
+
+#: panels/color/cc-color-panel.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Bonvolu fiksi la helecon de la ekrano je normala nivelo por vi. "
+"Koloradministro estos tre akurata je ĉi tiun nivelon."
+
+#: panels/color/cc-color-panel.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternative, vi povas uzi la heleconivelon uzita je alia profilo por tiu ĉi "
+"aparato."
+
+#: panels/color/cc-color-panel.ui:318
+msgid "Display Brightness"
+msgstr "Heleco de ekrano"
+
+#: panels/color/cc-color-panel.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Vi povas uzi kolorprofilon en malsamaj komputiloj, aŭ eĉ krei profilojn por "
+"malsamaj lumaj kondiĉoj."
+
+#: panels/color/cc-color-panel.ui:348
+msgid "Profile Name:"
+msgstr "Profilnomo:"
+
+#: panels/color/cc-color-panel.ui:377
+msgid "Profile Name"
+msgstr "Profilnomo"
+
+#: panels/color/cc-color-panel.ui:392
+msgid "Profile successfully created!"
+msgstr "Sukcese kreis profilon!"
+
+#: panels/color/cc-color-panel.ui:443
+msgid "Copy profile"
+msgstr "Kopii profilon"
+
+#: panels/color/cc-color-panel.ui:456
+msgid "Requires writable media"
+msgstr "Necesas skribeblan datumportilon"
+
+#: panels/color/cc-color-panel.ui:519
+msgid "Upload profile"
+msgstr "Alŝuti profilon"
+
+#: panels/color/cc-color-panel.ui:532
+msgid "Requires Internet connection"
+msgstr "Necesas interretan konekton"
+
+#: panels/color/cc-color-panel.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Ĉi tiujn instrukciojn pri uzado de la profilo je la sistemoj <a href=\"linux"
+"\">GNU/Linukso</a>, <a href=\"osx\">Apple OS X</a> kaj <a href=\"windows"
+"\">Microsoft Vindozo</a> vi eble taksas utilaj."
+
+#: panels/color/cc-color-panel.ui:607
+msgid "Summary"
+msgstr "Resumo"
+
+#: panels/color/cc-color-panel.ui:621
+msgid "Add Profile"
+msgstr "Aldoni profilon"
+
+#: panels/color/cc-color-panel.ui:643
+msgid "_Import File…"
+msgstr "E_nporti dosieron…"
+
+#: panels/color/cc-color-panel.ui:672 panels/keyboard/cc-input-chooser.ui:20
+#: panels/network/connection-editor/net-connection-editor.c:504
+#: panels/printers/new-printer-dialog.ui:80
+#: panels/user-accounts/cc-add-user-dialog.ui:47
+msgid "_Add"
+msgstr "_Aldoni"
+
+#: panels/color/cc-color-panel.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Detektis problemojn. La profilo eble ne funkcios korekte. <a href="
+"\"\">Montri detalojn.</a>"
+
+#: panels/color/cc-color-panel.ui:788
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Ĉiu aparato necesas ĝisdatigan kolorprofilon antaŭ ol oni povas "
+"kolormastrumi ĝin."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:810
+#: panels/diagnostics/cc-diagnostics-panel.c:143
+msgid "Learn more"
+msgstr "Lernu pli"
+
+#: panels/color/cc-color-panel.ui:815
+msgid "Learn more about color management"
+msgstr "Lernu pli pri kolormastrumado"
+
+#: panels/color/cc-color-panel.ui:863
+msgid "_Set for all users"
+msgstr "_Agordi por ĉiuj uzantoj"
+
+#: panels/color/cc-color-panel.ui:867 panels/color/cc-color-panel.ui:882
+#: panels/color/cc-color-panel.ui:883
+msgid "Set this profile for all users on this computer"
+msgstr "Agordi ĉi tiun profilon por ĉiuj uzantoj de tiu ĉi komputilo"
+
+#: panels/color/cc-color-panel.ui:878
+msgid "_Enable"
+msgstr "Ŝa_lti"
+
+#: panels/color/cc-color-panel.ui:909
+msgid "_Add profile"
+msgstr "_Aldoni profilon"
+
+#: panels/color/cc-color-panel.ui:922
+msgid "_Calibrate…"
+msgstr "_Laŭnormigi…"
+
+#: panels/color/cc-color-panel.ui:926
+msgid "Calibrate the device"
+msgstr "Laŭnormigi la aparaton"
+
+#: panels/color/cc-color-panel.ui:937
+msgid "_Remove profile"
+msgstr "Fo_rigi profilon"
+
+#: panels/color/cc-color-panel.ui:950
+msgid "_View details"
+msgstr "_Montri detalojn"
+
+#: panels/color/cc-color-panel.ui:986
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Oni ne povas detekti kolormastrumeblan aparaton"
+
+#: panels/color/cc-color-panel.ui:1030
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:1035
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:1040
+msgid "CRT"
+msgstr "KRT"
+
+#: panels/color/cc-color-panel.ui:1045
+msgid "Projector"
+msgstr "Projekciilo"
+
+#: panels/color/cc-color-panel.ui:1050
+msgid "Plasma"
+msgstr "Plasmo"
+
+#: panels/color/cc-color-panel.ui:1055
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL-a fonlumo)"
+
+#: panels/color/cc-color-panel.ui:1060
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RVB-LED-a fonlumo)"
+
+#: panels/color/cc-color-panel.ui:1065
+msgid "LCD (white LED backlight)"
+msgstr "LCD (blanka LED fonlumo)"
+
+#: panels/color/cc-color-panel.ui:1070
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD de larĝa gamo (CCFL-a fonlumo)"
+
+#: panels/color/cc-color-panel.ui:1075
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD de larĝa gamo (RVB-LED-a fonlumo)"
+
+#: panels/color/cc-color-panel.ui:1092
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alta"
+
+#: panels/color/cc-color-panel.ui:1093
+msgid "40 minutes"
+msgstr "40 minutoj"
+
+#: panels/color/cc-color-panel.ui:1097
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Meza"
+
+#: panels/color/cc-color-panel.ui:1098
+msgid "30 minutes"
+msgstr "30 minutoj"
+
+#: panels/color/cc-color-panel.ui:1102
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Malalta"
+
+#: panels/color/cc-color-panel.ui:1103
+msgid "15 minutes"
+msgstr "15 minutoj"
+
+#: panels/color/cc-color-panel.ui:1125
+msgid "Native to display"
+msgstr "Indiĝena al ekrano"
+
+#: panels/color/cc-color-panel.ui:1129
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Presado kaj eldonado)"
+
+#: panels/color/cc-color-panel.ui:1133
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:1137
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografio kaj grafiko)"
+
+#: panels/color/cc-color-panel.ui:1141
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Norma spaco"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testprofilo"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Aŭtomate"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Malalta kvalito"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Meza kvalito"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Alta kvalito"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Implicita RVB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Implicita CMFN"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Implicita grizo"
+
+# Mi supozas, ke ĝi devus diri "vendor-supplied". --Carmen
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Fabrikajn laŭnormig-datumojn provizigita de vendisto"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Tutekrana ekran-ĝustigo ne eblas je ĉi tiu profilo"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "La profilo eble ne plu estas akurata"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Koloro"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Laŭnormigi la koloron de viaj aparatoj, kiel ekranoj, fotiloj aŭ presiloj"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Koloro;ICC;Profilo;Laŭnormigi;Presilo;Ekrano;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Alia…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Elekti lingvon"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Elekti"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "No languages found"
+msgstr "Neniuj lingvoj trovitaj"
+
+#: panels/common/cc-language-chooser.ui:82
+#: panels/keyboard/cc-input-chooser.c:178
+msgid "More…"
+msgstr "Pli…"
+
+#: panels/common/cc-permission-infobar.c:107
+msgid "Unlock to Change Settings"
+msgstr "Malŝlosi por ŝanĝi agordojn"
+
+#: panels/common/cc-permission-infobar.ui:20
+msgid "Unlock…"
+msgstr "Malŝlosi…"
+
+#: panels/common/cc-permission-infobar.ui:56
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Oni devas malŝlosi kelkajn agordojn antaŭ ol ili ŝanĝeblas."
+
+#: panels/common/cc-time-editor.ui:33
+msgid "Increment Hour"
+msgstr "Alkrementi horon"
+
+#: panels/common/cc-time-editor.ui:65
+msgid "Increment Minute"
+msgstr "Alkrementi minuton"
+
+#: panels/common/cc-time-editor.ui:80
+msgid "Time"
+msgstr "Horo"
+
+#: panels/common/cc-time-editor.ui:113
+msgid "Decrement Hour"
+msgstr "Dekrementi horon"
+
+#: panels/common/cc-time-editor.ui:145
+msgid "Decrement Minute"
+msgstr "Dekrementi minuton"
+
+#: panels/common/cc-time-entry.c:219
+msgid "_Copy"
+msgstr "_Kopii"
+
+#: panels/common/cc-time-entry.c:225
+msgid "Select _All"
+msgstr "Elekti ĉ_iujn"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:160
+msgid "Today"
+msgstr "Hodiaŭ"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:162
+msgid "Yesterday"
+msgstr "Hieraŭ"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%-e-a de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%-e-a de %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d horo"
+msgstr[1] "%d horoj"
+
+#: panels/common/cc-util.c:166
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuto"
+msgstr[1] "%d minutoj"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekundo"
+msgstr[1] "%d sekundoj"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekundoj"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Retkaptejo"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:262
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%-e-a de %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:267
+msgid "%e %B %Y, %R"
+msgstr "%-e-a de %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:449
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:476
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:483
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:488
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:493
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:498
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:38
+msgid "January"
+msgstr "Januaro"
+
+#: panels/datetime/cc-datetime-panel.ui:46
+msgid "February"
+msgstr "Februaro"
+
+#: panels/datetime/cc-datetime-panel.ui:54
+msgid "March"
+msgstr "Marto"
+
+#: panels/datetime/cc-datetime-panel.ui:62
+msgid "April"
+msgstr "Aprilo"
+
+#: panels/datetime/cc-datetime-panel.ui:70
+msgid "May"
+msgstr "Majo"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "June"
+msgstr "Junio"
+
+#: panels/datetime/cc-datetime-panel.ui:86
+msgid "July"
+msgstr "Julio"
+
+#: panels/datetime/cc-datetime-panel.ui:94
+msgid "August"
+msgstr "Aŭgusto"
+
+#: panels/datetime/cc-datetime-panel.ui:102
+msgid "September"
+msgstr "Septembro"
+
+#: panels/datetime/cc-datetime-panel.ui:110
+msgid "October"
+msgstr "Oktobro"
+
+#: panels/datetime/cc-datetime-panel.ui:118
+msgid "November"
+msgstr "Novembro"
+
+#: panels/datetime/cc-datetime-panel.ui:126
+msgid "December"
+msgstr "Decembro"
+
+#: panels/datetime/cc-datetime-panel.ui:136
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Dato & horo"
+
+#: panels/datetime/cc-datetime-panel.ui:187
+msgid "Year"
+msgstr "Jaro"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Month"
+msgstr "Monato"
+
+#: panels/datetime/cc-datetime-panel.ui:257
+msgid "Day"
+msgstr "Tago"
+
+#: panels/datetime/cc-datetime-panel.ui:286
+msgid "Time Zone"
+msgstr "Horzono"
+
+#: panels/datetime/cc-datetime-panel.ui:307
+msgid "Search for a city"
+msgstr "Serĉi urbon"
+
+#: panels/datetime/cc-datetime-panel.ui:378
+msgid "Automatic _Date & Time"
+msgstr "Aŭtomata _dato & horo"
+
+#: panels/datetime/cc-datetime-panel.ui:379
+msgid "Requires internet access"
+msgstr "Bezonas interretan atingon"
+
+#: panels/datetime/cc-datetime-panel.ui:399
+msgid "Date & _Time"
+msgstr "Dato & _horo"
+
+#: panels/datetime/cc-datetime-panel.ui:438
+msgid "Automatic Time _Zone"
+msgstr "Aŭtomata hor_zono"
+
+#: panels/datetime/cc-datetime-panel.ui:439
+msgid "Requires location services enabled and internet access"
+msgstr "Bezonas lokado-servojn kaj interretan atingon"
+
+#: panels/datetime/cc-datetime-panel.ui:454
+msgid "Time Z_one"
+msgstr "Horz_ono"
+
+#: panels/datetime/cc-datetime-panel.ui:494
+msgid "Time _Format"
+msgstr "Tempo-_formo"
+
+#: panels/datetime/cc-datetime-panel.ui:503
+msgid "24-hour"
+msgstr "24-hora"
+
+#: panels/datetime/cc-datetime-panel.ui:504
+msgid "AM / PM"
+msgstr "ATM / PTM"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Ŝanĝi la aktualan tempon, inkluzivante horzonon"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Horloĝo;Horo;Horzono;Loko;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Ŝanĝi sistemajn agordoj pri horo kaj dato"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Por ŝanĝi tempajn aŭ datajn agordojn, vi devas aŭtentigi."
+
+#: panels/default-apps/cc-default-apps-panel.ui:31
+msgid "_Web"
+msgstr "_Reto"
+
+#: panels/default-apps/cc-default-apps-panel.ui:43
+msgid "_Mail"
+msgstr "Ret_poŝto"
+
+#: panels/default-apps/cc-default-apps-panel.ui:59
+msgid "_Calendar"
+msgstr "_Kalendaro"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "M_usic"
+msgstr "M_uziko"
+
+#: panels/default-apps/cc-default-apps-panel.ui:91
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:162
+#: panels/removable-media/cc-removable-media-panel.ui:162
+msgid "_Photos"
+msgstr "_Fotoj"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Implicitaj aplikaĵoj"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Agordi implicitajn aplikaĵojn"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "implicita;aplikaĵo;preferita;datumportilo;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:145
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Sendado de raportoj de teĥnikaj problemoj helpas al ni plibonigi %s. "
+"Raportoj sendiĝas sennome kaj personaj datumoj estas viŝitaj. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:28
+msgid "Problem Reporting"
+msgstr "Problemraportado"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:65
+msgid "_Automatic Problem Reporting"
+msgstr "_Aŭtomata problemraportado"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnozo"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Raporti viajn problemojn"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ekrano;ŝlosi;ŝloso;diagnozo;kraŝo;privata;lastatempa;provizora;tmp;indekso;"
+"nomo;reto;identeco;privateco;"
+
+#: panels/display/cc-display-panel.c:1014
+#: panels/network/connection-editor/connection-editor.ui:27
+msgid "_Apply"
+msgstr "_Apliki"
+
+#: panels/display/cc-display-panel.c:1035
+msgid "Apply Changes?"
+msgstr "Ĉu apliki ŝanĝojn?"
+
+#: panels/display/cc-display-panel.c:1040
+msgid "Changes Cannot be Applied"
+msgstr "Ne eblas apliki ŝanĝojn"
+
+#: panels/display/cc-display-panel.c:1041
+msgid "This could be due to hardware limitations."
+msgstr "Ĉi tiu eblus pro aparataj limigoj."
+
+#: panels/display/cc-display-panel.ui:89
+msgid "Single Display"
+msgstr "Unuobla ekrano"
+
+#: panels/display/cc-display-panel.ui:108
+#: panels/display/cc-display-panel.ui:310
+msgid "Join Displays"
+msgstr "Kunigi ekranojn"
+
+#: panels/display/cc-display-panel.ui:126
+msgid "Mirror"
+msgstr "Speguli"
+
+#: panels/display/cc-display-panel.ui:151
+msgid "Display Mode"
+msgstr "Reĝimo de ekrano"
+
+#: panels/display/cc-display-panel.ui:220
+msgid "Contains top bar and Activities"
+msgstr "Enhavas supran breton kaj Agojn"
+
+#: panels/display/cc-display-panel.ui:221
+msgid "Primary Display"
+msgstr "Ĉefa ekrano"
+
+#: panels/display/cc-display-panel.ui:243
+msgid ""
+"Drag displays to match your physical display setup. Select a display to "
+"change its settings."
+msgstr ""
+"Tiru ekranojn por kongrui vian fizikan ekranaranĝon. Elektu ekranon por "
+"ŝanĝi ĝiajn agordojn."
+
+#: panels/display/cc-display-panel.ui:250
+msgid "Display Arrangement"
+msgstr "Aranĝo de ekranoj"
+
+#: panels/display/cc-display-panel.ui:374
+msgid "Active Display"
+msgstr "Aktiva ekrano"
+
+#: panels/display/cc-display-panel.ui:421
+msgid "Display Configuration"
+msgstr "Ekran-agordoj"
+
+#: panels/display/cc-display-panel.ui:440
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ekranoj"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:451
+#: panels/display/cc-night-light-page.ui:111
+msgid "Night Light"
+msgstr "Noktlumo"
+
+#: panels/display/cc-display-settings.c:103
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Pejzaĝo"
+
+#: panels/display/cc-display-settings.c:106
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portreto dekstra"
+
+#: panels/display/cc-display-settings.c:109
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portreto maldekstra"
+
+#: panels/display/cc-display-settings.c:112
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Pejzaĝo (renversita)"
+
+#: panels/display/cc-display-settings.c:186
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:15
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientiĝo"
+
+#: panels/display/cc-display-settings.ui:24
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Distingo"
+
+#: panels/display/cc-display-settings.ui:33
+msgid "Refresh Rate"
+msgstr "Ofteco de aktualigo"
+
+#: panels/display/cc-display-settings.ui:42
+msgid "Adjust for TV"
+msgstr "Ĝustigi por televizio"
+
+#: panels/display/cc-display-settings.ui:59
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skali"
+
+#: panels/display/cc-night-light-page.c:627
+msgid "More Warm"
+msgstr "Pli varma"
+
+#: panels/display/cc-night-light-page.c:639
+msgid "Less Warm"
+msgstr "Malpli varma"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:28
+msgid "Restart Filter"
+msgstr "Restartigi filtrilon"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:61
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Provizore malŝaltita ĝis morgaŭ"
+
+#: panels/display/cc-night-light-page.ui:88
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Noktlumo varmigas la koloron de la ekrano. Ĉi tiu povas antaŭmalhelpi "
+"streĉiĝon de okuloj kaj sendormecon."
+
+#: panels/display/cc-night-light-page.ui:127
+msgid "Schedule"
+msgstr "Tempoplano"
+
+#: panels/display/cc-night-light-page.ui:136
+msgid "Sunset to Sunrise"
+msgstr "De sunsubiro ĝis sunleviĝo"
+
+#: panels/display/cc-night-light-page.ui:137
+msgid "Manual Schedule"
+msgstr "Permana tempoplano"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/region/cc-format-preview.ui:40
+msgid "Times"
+msgstr "Horoj"
+
+#: panels/display/cc-night-light-page.ui:165
+msgid "From"
+msgstr "De"
+
+#: panels/display/cc-night-light-page.ui:194
+#: panels/display/cc-night-light-page.ui:297
+msgid "Hour"
+msgstr "Horo"
+
+#: panels/display/cc-night-light-page.ui:203
+#: panels/display/cc-night-light-page.ui:306
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:222
+#: panels/display/cc-night-light-page.ui:325
+msgid "Minute"
+msgstr "Minuto"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:234
+#: panels/display/cc-night-light-page.ui:337
+msgid "AM"
+msgstr "ATM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:247
+#: panels/display/cc-night-light-page.ui:350
+msgid "PM"
+msgstr "PTM"
+
+#: panels/display/cc-night-light-page.ui:267
+msgid "To"
+msgstr "Al"
+
+#: panels/display/cc-night-light-page.ui:374
+msgid "Color Temperature"
+msgstr "Kolora temperaturo"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Elekti kiel uzi konektitajn ekranojn kaj projekciilojn"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panelo;Projekciilo;xrandr;Ekrano;Distingivo;Aktualigi;Ekrano;Nokto;Lumo;Blua;"
+"redshift;koloro;sunsubiro;sunleviĝo;"
+
+#: panels/info-overview/cc-info-overview-panel.c:418
+#: panels/info-overview/cc-info-overview-panel.c:433
+#: panels/info-overview/cc-info-overview-panel.c:445
+#: panels/info-overview/cc-info-overview-panel.c:491
+#: panels/info-overview/cc-info-overview-panel.c:521
+msgid "Unknown"
+msgstr "Nekonata"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:453
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; Versio-ID: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:468
+#, c-format
+msgid "64-bit"
+msgstr "64-bita"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:471
+#, c-format
+msgid "32-bit"
+msgstr "32-bita"
+
+#: panels/info-overview/cc-info-overview-panel.c:728
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:732
+msgid "Wayland"
+msgstr "Vejlando"
+
+#: panels/info-overview/cc-info-overview-panel.c:734
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Nekonata"
+
+#: panels/info-overview/cc-info-overview-panel.ui:51
+msgid "Device Name"
+msgstr "Aparatnomo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:73
+msgid "Hardware Model"
+msgstr "Aparatara modelo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Memory"
+msgstr "Memoro"
+
+#: panels/info-overview/cc-info-overview-panel.ui:91
+msgid "Processor"
+msgstr "Procezoro"
+
+#: panels/info-overview/cc-info-overview-panel.ui:100
+msgid "Graphics"
+msgstr "Grafikoj"
+
+#: panels/info-overview/cc-info-overview-panel.ui:109
+msgid "Disk Capacity"
+msgstr "Diskospaco"
+
+#: panels/info-overview/cc-info-overview-panel.ui:110
+msgid "Calculating…"
+msgstr "Kalkulanta…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:132
+msgid "OS Name"
+msgstr "Nomo de operaciumo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "OS Type"
+msgstr "Speco de operaciumo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "GNOME Version"
+msgstr "Versio de GNOME"
+
+#: panels/info-overview/cc-info-overview-panel.ui:160
+msgid "Windowing System"
+msgstr "Fenestrado-sistemo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:168
+msgid "Virtualization"
+msgstr "Virtualigado"
+
+#: panels/info-overview/cc-info-overview-panel.ui:177
+msgid "Software Updates"
+msgstr "Programaraj ĝisdatigoj"
+
+#: panels/info-overview/cc-info-overview-panel.ui:198
+msgid "Rename Device"
+msgstr "Alinomi aparaton"
+
+#: panels/info-overview/cc-info-overview-panel.ui:215
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Oni uzas la aparatnomon por ke aliaj aparatoj povas rete identigi ĝin, kaj "
+"dum parigo de Bludentaj aparatoj."
+
+#: panels/info-overview/cc-info-overview-panel.ui:233
+msgid "_Rename"
+msgstr "_Alinomi"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Pri"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Montri informon pri via sistemo"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"aparato;sistemo;informoj;aparatnomo;gastignomo;memoro;procezoro;versio;"
+"implicita;aplikaĵo;ŝatata;preferita;kd;dvd;usb;sono;video;disko;demetebla;"
+"datumportilo;aŭtomata;lanĉo;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Sono kaj aŭdvidaĵoj"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Silentigi/malsilentigi"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Malplilaŭtigi"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Plilaŭtigi"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Silentigi/malsilentigi mikrofonon"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Lanĉi medioludilon"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Ludi (aŭ ludi/paŭzigi)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Paŭzigi ludadon"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Haltigi ludadon"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Antaŭa trako"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Sekva trako"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Elĵeti"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:542
+msgid "Typing"
+msgstr "Tajpado"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Ŝanĝi al sekva eniga fonto"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Ŝanĝi al antaŭa eniga fonto"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lanĉiloj"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Lanĉi helpfoliumilon"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Lanĉi kalkulilon"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Lanĉi retpoŝtilon"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Lanĉi retumilon"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Hejmdosierujo"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Serĉi"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "Ekrankopioj"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr "Konservi ekrankopion al $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Konservi ekrankopion de fenestro al $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Konservi ekrankopion de areo al $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "Kopii ekrankopion al tondujo"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Kopii ekrankopion de fenestro al tondujo"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Kopii ekrankopion de areo al tondujo"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr "Registri mallongan ekranreĝistraĵon"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistemo"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Adiaŭi"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Ŝlosi ekranon"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Alirebleco"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Ŝalti aŭ malŝalti zomon"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zomi"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Malzomi"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Ŝalti aŭ malŝalti la ekranlegilon"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Ŝalti aŭ malŝalti la ekranklavaron"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Pligrandigi la tekston"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Malpligrandigi la tekston"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Ŝalti aŭ malŝalti altan kontraston"
+
+#: panels/keyboard/cc-input-chooser.c:193
+msgid "No input sources found"
+msgstr "Neniuj enigaj fontoj trovitaj"
+
+#: panels/keyboard/cc-input-chooser.c:964
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Alia"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Aldoni enigan fonton"
+
+#: panels/keyboard/cc-input-chooser.ui:77
+msgid "Input methods can’t be used on the login screen"
+msgstr "Enigaj metodoj ne uzeblas ĉe saluta ekrano"
+
+#: panels/keyboard/cc-input-list-box.ui:20
+msgid "No input source selected"
+msgstr "Neniu eniga fonto elektita"
+
+#: panels/keyboard/cc-input-row.ui:75
+msgid "Move up"
+msgstr "Movi supren"
+
+#: panels/keyboard/cc-input-row.ui:86
+msgid "Move down"
+msgstr "Movi malsupren"
+
+#: panels/keyboard/cc-input-row.ui:103
+msgid "Preferences"
+msgstr "Agordoj"
+
+#: panels/keyboard/cc-input-row.ui:120
+msgid "View Keyboard Layout"
+msgstr "Montri klavararanĝon"
+
+#: panels/keyboard/cc-input-row.ui:137
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:286
+msgid "Remove"
+msgstr "Forigi"
+
+#: panels/keyboard/cc-keyboard-manager.c:486
+#: panels/keyboard/cc-keyboard-manager.c:494
+#: panels/keyboard/cc-keyboard-manager.c:779
+msgid "Custom Shortcuts"
+msgstr "Propraj klavkombinoj"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.ui:179
+msgid "Alternate Characters Key"
+msgstr "Klavo de alternativaj signoj"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"La klavom de alternativaj signoj oni povas uzi por enigi ceterajn signojn. "
+"Foje ili estas presitaj kiel tria opcio sur via klavaro."
+
+#: panels/keyboard/cc-keyboard-panel.c:74
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Maldekstra alt-klavo"
+
+#: panels/keyboard/cc-keyboard-panel.c:75
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Dekstra alt-klavo"
+
+#: panels/keyboard/cc-keyboard-panel.c:76
+#: panels/keyboard/cc-keyboard-panel.c:94
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Meldekstra super-klavo"
+
+#: panels/keyboard/cc-keyboard-panel.c:77
+#: panels/keyboard/cc-keyboard-panel.c:95
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Dekstra super-klavo"
+
+#: panels/keyboard/cc-keyboard-panel.c:78
+#: panels/keyboard/cc-keyboard-panel.c:96
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menu-klavo"
+
+#: panels/keyboard/cc-keyboard-panel.c:79
+#: panels/keyboard/cc-keyboard-panel.c:97
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Dekstra stirklavo"
+
+#: panels/keyboard/cc-keyboard-panel.c:87
+#: panels/keyboard/cc-keyboard-panel.ui:204
+msgid "Compose Key"
+msgstr "Kompona klavo"
+
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"La kompona klavo permesas enigon de vasta kvanto de signoj. Por uzi ĝin, "
+"premu la komponan klavon kaj sekve enigu sekvencon de signoj. Ekzemple, la "
+"sekvenco <b>kompona klavo</b>, <b>G</b>, kaj <b>^</b> enigas <b>Ĝ</b>, kaj "
+"la sekvenco <b>kompona klavo</b>, <b>C</b>, kaj <b>o</b> enigas <b>©</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:98
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Majuskla baskulo"
+
+#: panels/keyboard/cc-keyboard-panel.c:99
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Ruluma baskulo"
+
+#: panels/keyboard/cc-keyboard-panel.c:100
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Ekrankopio"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Input Sources"
+msgstr "Enigaj fontoj"
+
+#: panels/keyboard/cc-keyboard-panel.ui:66
+msgid "Input Source Switching"
+msgstr "Ŝanĝi inter enigaj fontoj"
+
+#: panels/keyboard/cc-keyboard-panel.ui:99
+msgid "Use the _same source for all windows"
+msgstr "Uzi la _saman fonton por ĉiuj fenestroj"
+
+#: panels/keyboard/cc-keyboard-panel.ui:126
+msgid "Switch input sources _individually for each window"
+msgstr "Ŝanĝi inter enigaj fontoj _individue por ĉiu fenestro"
+
+#: panels/keyboard/cc-keyboard-panel.ui:138
+msgid "Keyboard Shortcut"
+msgstr "Klavkombino"
+
+#: panels/keyboard/cc-keyboard-panel.ui:139
+msgid "This can be changed in Customize Shortcuts"
+msgstr "Oni povas ŝanĝi ĉi tion en Agordi klavkombinojn"
+
+#: panels/keyboard/cc-keyboard-panel.ui:157
+msgid "Type Special Characters"
+msgstr "Tajpado de specialaj signoj"
+
+#: panels/keyboard/cc-keyboard-panel.ui:180
+msgid "Hold down and type to enter different characters"
+msgstr "Daŭre premu kaj tajpu por enigi aliajn signojn"
+
+#: panels/keyboard/cc-keyboard-panel.ui:232
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:301
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:317 shell/cc-window.ui:326
+msgid "Keyboard Shortcuts"
+msgstr "Klavkombinoj"
+
+#: panels/keyboard/cc-keyboard-panel.ui:253
+msgid "Customize Shortcuts"
+msgstr "Agordi klavkombinojn"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:281
+msgid "modified"
+msgstr "modifita"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:423
+msgid "Reset All Shortcuts?"
+msgstr "Ĉu reagordi ĉiujn klavkombinojn?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:426
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Reagordado de klavkombinoj povus aliigi viajn proprajn klavkombinojn. Ĉi tiu "
+"ne estas malfarebla."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:430
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:275
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+msgid "Cancel"
+msgstr "Nuligi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:431
+msgid "Reset All"
+msgstr "Reagordi ĉiujn"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:115
+msgid "Add Custom Shortcuts"
+msgstr "Aldoni proprajn klavkombinojn"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:124
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Agordi proprajn klavkombinojn por lanĉi aplikaĵojn, ruli skriptetojn, kaj "
+"tiel plu."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:131
+msgid "Add Shortcut"
+msgstr "Aldoni klavkombinon"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:166
+msgid "No keyboard shortcut found"
+msgstr "Ne povis trovi klavkombinon"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:211
+#: panels/region/cc-format-chooser.ui:48
+#: panels/user-accounts/cc-fingerprint-dialog.ui:53
+#: panels/wacom/wacom-stylus-page.ui:37 shell/cc-window.ui:230
+msgid "Back"
+msgstr "Reen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:235
+msgid "Reset All…"
+msgstr "Reagordi ĉiujn…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:236
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Reagordi ĉiujn klavkombinojn al ĝiaj implicitaj klavkombinoj"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:391
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s jam estas uzata por %s. Se vi anstataŭas ĝin, %s estos malŝaltita"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:535
+msgid "Enter the new shortcut"
+msgstr "Entajpu novan klavkombinon"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
+msgid "Set Custom Shortcut"
+msgstr "Agordi propran klavkombinon"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
+msgid "Set Shortcut"
+msgstr "Agordi klavkombinon"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:561
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Enmetu novan klavkombinon por ŝanĝi %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:987
+msgid "Add Custom Shortcut"
+msgstr "Aldoni propran klavkombinon"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:60
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Premu eskapan klavon por nuligi aŭ retropaŝan klavon por reagordi la "
+"klavkombinon."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:135
+#: panels/printers/pp-details-dialog.ui:40
+msgid "Name"
+msgstr "Nomo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:147
+msgid "Command"
+msgstr "Komando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:159
+msgid "Shortcut"
+msgstr "Klavkombino"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:238
+msgid "Set Shortcut…"
+msgstr "Agordi klavkombinon…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "Neniu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:296
+msgid "Add"
+msgstr "Aldoni"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:311
+msgid "Replace"
+msgstr "Anstataŭigi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:325
+msgid "Set"
+msgstr "Agordi"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:27
+msgid "Reset the shortcut to its default value"
+msgstr "Reŝargi la klavkombinon al ĝia implicita valoro"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klavaro"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "Montru kaj ŝanĝu klavkombinojn kaj agordu viajn tajpadajn preferojn"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Klavkombino;Laborspaco;Fenestro;Aligrandigi;Zomi;Kontrasto;Enigo;Fonto;Ŝlosi;"
+"Laŭteco;"
+
+#: panels/location/cc-location-panel.ui:31
+msgid "Location services turned off"
+msgstr "Lokado-servoj malŝaltitaj"
+
+#: panels/location/cc-location-panel.ui:40
+msgid "No applications can obtain location information."
+msgstr "Neniu aplikaĵo povas obteni lokajn informojn."
+
+#: panels/location/cc-location-panel.ui:72
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"Lokado-servoj permesas al aplikaĵoj scii vian lokon. Uzado de vifio kaj "
+"portebla larĝkapacita konekto plialtigas ekzaktecon."
+
+#: panels/location/cc-location-panel.ui:81
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+"Uzas Mozilla Lokado-Servon: <a href='https://location.services.mozilla.com/"
+"privacy'>Privateco Politiko</a>"
+
+#: panels/location/cc-location-panel.ui:94
+msgid "Allow the applications below to determine your location."
+msgstr "Permesi, ke la subaj aplikaĵoj povu scii vian lokon."
+
+#: panels/location/cc-location-panel.ui:114
+msgid "No Applications Have Asked for Location Access"
+msgstr "Neniu aplikaĵo petis atingon al via loko"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Protekti viajn lokajn informojn"
+
+#. FIXME
+#: panels/lock/cc-lock-panel.ui:27
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Aŭtomata ŝlosado de la ekrano malhelpas ke aliuloj povu aliri vian "
+"komputilon dum via foresto."
+
+#: panels/lock/cc-lock-panel.ui:44
+msgid "Blank Screen Delay"
+msgstr "Malfruo antaŭ ol malplena ekrano"
+
+#: panels/lock/cc-lock-panel.ui:45
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Paŭzo post kiu la ekrano malpleniĝas."
+
+#: panels/lock/cc-lock-panel.ui:65
+msgid "Automatic Screen _Lock"
+msgstr "Aŭtomata ekrana ŝ_loso"
+
+#: panels/lock/cc-lock-panel.ui:82
+msgid "Automatic _Screen Lock Delay"
+msgstr "Malfruo _antaŭ ol ekrana ŝloso"
+
+#: panels/lock/cc-lock-panel.ui:83
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Paŭzo inter la malpleniĝo de la ekrano kaj ĝia ŝlosado."
+
+#: panels/lock/cc-lock-panel.ui:103
+msgid "Show _Notifications on Lock Screen"
+msgstr "Montri _sciigojn sur ŝlosa ekrano"
+
+#: panels/lock/cc-lock-panel.ui:120
+msgid "Forbid new _USB devices"
+msgstr "Malpermesi novajn _USB-aparatojn."
+
+#: panels/lock/cc-lock-panel.ui:121
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Malhelpi ke novaj USB-aparatoj interagu kun la sistemo dum la ekrano estas "
+"ŝlosita."
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:166
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "La ekrano malŝaltas"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:170
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekundoj"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:174
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:178
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutoj"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:182
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutoj"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:186
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutoj"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:190
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutoj"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:194
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 horo"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:209 panels/power/cc-power-panel.ui:63
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:213 panels/power/cc-power-panel.ui:67
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutoj"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:217 panels/power/cc-power-panel.ui:71
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutoj"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:221 panels/power/cc-power-panel.ui:75
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutoj"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:225 panels/power/cc-power-panel.ui:79
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutoj"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:229 panels/power/cc-power-panel.ui:83
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutoj"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:233 panels/power/cc-power-panel.ui:87
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutoj"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:237 panels/power/cc-power-panel.ui:91
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutoj"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:241 panels/power/cc-power-panel.ui:95
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutoj"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:245 panels/power/cc-power-panel.ui:99
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Neniam"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "Ekrana ŝloso"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr "Ŝlosi vian ekranon"
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid "Microphone is turned off"
+msgstr "Mikrofono malŝaltita"
+
+#: panels/microphone/cc-microphone-panel.ui:43
+msgid "No applications can record sound."
+msgstr "Neniu aplikaĵo povas registri sonon."
+
+#: panels/microphone/cc-microphone-panel.ui:75
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly."
+msgstr ""
+"Uzado de la mikrofono permesas al aplikaĵoj registri kaj aŭskulti sonojn. "
+"Malŝaltado de la mikrofono povus kaŭzi, ke kelkaj aplikaĵoj ne funkciu taŭge."
+
+#: panels/microphone/cc-microphone-panel.ui:85
+msgid "Allow the applications below to use your microphone."
+msgstr "Permesi, ke la subaj aplikaĵoj povu uzi vian mikrofonon."
+
+#: panels/microphone/cc-microphone-panel.ui:105
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Neniu aplikaĵo petis atingon al via mikrofono"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Protekti viajn konversaciojn"
+
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:37
+msgid "General"
+msgstr "Ĝenerala"
+
+#: panels/mouse/cc-mouse-panel.ui:75
+msgid "Primary Button"
+msgstr "Ĉefa butono"
+
+#: panels/mouse/cc-mouse-panel.ui:94
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Agordas la ordon de fizikaj butonoj sur musoj kaj tuŝplatoj."
+
+#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Maldekstra"
+
+#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Dekstra"
+
+#: panels/mouse/cc-mouse-panel.ui:169
+msgid "Mouse"
+msgstr "Muso"
+
+#: panels/mouse/cc-mouse-panel.ui:208
+msgid "Mouse Speed"
+msgstr "Musa rapideco"
+
+#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
+msgid "Double-click timeout"
+msgstr "Tempolimo de duobla klako"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
+msgid "Natural Scrolling"
+msgstr "Natura rulumado"
+
+#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
+msgid "Scrolling moves the content, not the view."
+msgstr "Rulumado movas la enhavon, ne la vidon."
+
+#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
+msgid "Touchpad"
+msgstr "Tuŝplato"
+
+#: panels/mouse/cc-mouse-panel.ui:501
+msgid "Touchpad Speed"
+msgstr "Tuŝplata rapideco"
+
+#: panels/mouse/cc-mouse-panel.ui:560
+msgid "Tap to Click"
+msgstr "Frapeti por alklaki"
+
+#: panels/mouse/cc-mouse-panel.ui:612
+msgid "Two-finger Scrolling"
+msgstr "Dufingra rulumado"
+
+#: panels/mouse/cc-mouse-panel.ui:665
+msgid "Edge Scrolling"
+msgstr "Flanka rulumado"
+
+#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:441
+msgid "Test Your _Settings"
+msgstr "Testi viajn _agordojn"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:25
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Provu klakadon, duoblan klakadon, rulumadon"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Kvin alklakoj, GEGL-tempo!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Duobla klako, ĉefa butono"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Unuobla klako, ĉefa butono"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Duobla klako, meza butono"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Unuobla klako, meza butono"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Duobla klako, duaranga butono"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Unuobla klako, duaranga butono"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Muso & tuŝplato"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Ŝanĝu vian musan aŭ tuŝplatan sentivecon kaj elektu dekstra- aŭ "
+"maldekstramana"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Tuŝplato;Musmontrilo;Alklako;Frapeto;Butono;Stirglobo;Rulumi;"
+
+#: panels/network/cc-network-panel.c:661 panels/network/cc-wifi-panel.ui:307
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Ups, io fiaskis. Bonvolu kontakti vian programaran vendiston."
+
+#: panels/network/cc-network-panel.c:667
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager devas esti rulanta."
+
+#: panels/network/cc-network-panel.ui:66
+msgid "Other Devices"
+msgstr "Aliaj aparatoj"
+
+#: panels/network/cc-network-panel.ui:107
+#: panels/network/connection-editor/net-connection-editor.c:587
+msgid "VPN"
+msgstr "VPR"
+
+#: panels/network/cc-network-panel.ui:151
+msgid "Not set up"
+msgstr "Ne agordita"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:208
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:268
+msgid "Insecure network (WEP)"
+msgstr "Nesekura reto (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:273
+msgid "Secure network (WPA)"
+msgstr "Sekura reto (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:278
+msgid "Secure network (WPA2)"
+msgstr "Sekura reto (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA3)"
+msgstr "Sekura reto (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:288
+msgid "Secure network"
+msgstr "Sekura reto"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:68 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Konektita"
+
+#: panels/network/cc-wifi-connection-row.ui:100
+#: panels/network/net-device-ethernet.c:327
+#: panels/network/network-bluetooth.ui:76
+#: panels/network/network-ethernet.ui:111 panels/network/network-mobile.ui:450
+#: panels/network/network-vpn.ui:77
+msgid "Options…"
+msgstr "Agordoj…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:134
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Ŝaltado de retkaptejo malkonektos vian komputilon de %s, kaj ne eblos atingi "
+"interreton tra vifio."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:265
+msgid "Must have a minimum of 8 characters"
+msgstr "Devas havi malpleje 8 signojn"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:479
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Ĉu ŝalti vifian retkaptejon?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:19
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Vifia retkaptejo permesas al laiaj kunhavi vian retkonekton, tra krei vifian "
+"reton al kiu ili povas konekti. Por fari tion, necesas ke vi havu "
+"retkonekton tra alia fonto ol vifio."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:44
+msgid "Network Name"
+msgstr "Retnomo"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:69
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:389
+#: panels/printers/pp-jobs-dialog.ui:70
+#: panels/user-accounts/cc-add-user-dialog.ui:249
+msgid "Password"
+msgstr "Pasvorto"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:83
+msgid "Generate Random Password"
+msgstr "Generi hazardan pasvorton"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:84
+msgid "Autogenerate Password"
+msgstr "Aŭtomate generi pasvorton"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:130
+msgid "_Turn On"
+msgstr "Ŝ_alti"
+
+#: panels/network/cc-wifi-panel.c:544
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:53
+msgid "Wi-Fi"
+msgstr "Vifio"
+
+#: panels/network/cc-wifi-panel.c:864
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Ĉu haltigi retkaptejon kaj malkonektiĝi ĉiujn uzantojn?"
+
+#: panels/network/cc-wifi-panel.c:867
+msgid "_Stop Hotspot"
+msgstr "Halti_gi retkaptejon"
+
+#: panels/network/cc-wifi-panel.ui:46
+msgid "Airplane Mode"
+msgstr "Aviadila reĝimo"
+
+#: panels/network/cc-wifi-panel.ui:47
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Malŝaltas vifion, Bludenton kaj porteblan larĝkapacitan konekton"
+
+#: panels/network/cc-wifi-panel.ui:87
+msgid "No Wi-Fi Adapter Found"
+msgstr "Neniu vifia adaptilo estas trovita"
+
+#: panels/network/cc-wifi-panel.ui:99
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Certigu, ke vi vifia adaptilo estas konektita kaj ŝaltita"
+
+#: panels/network/cc-wifi-panel.ui:134
+msgid "Airplane Mode On"
+msgstr "Aviadila reĝimo estas ŝaltita"
+
+#: panels/network/cc-wifi-panel.ui:146
+msgid "Turn off to use Wi-Fi"
+msgstr "Malŝalti por uzi vifion"
+
+#: panels/network/cc-wifi-panel.ui:184
+msgid "Wi-Fi Hotspot Active"
+msgstr "Vifia retkaptejo estas ŝaltita"
+
+#: panels/network/cc-wifi-panel.ui:195
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Porteblaj aparatoj povas skani la QR-kodon por konekti."
+
+#: panels/network/cc-wifi-panel.ui:205
+msgid "Turn Off Hotspot…"
+msgstr "Malŝalti retkaptejon…"
+
+#: panels/network/cc-wifi-panel.ui:227
+msgid "Visible Networks"
+msgstr "Videblaj retoj"
+
+#: panels/network/cc-wifi-panel.ui:296
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager devas esti rulanta"
+
+#: panels/network/connection-editor/8021x-security-page.ui:20
+msgid "802.1x _Security"
+msgstr "802.1x _sekureco"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:112
+#: panels/network/connection-editor/ce-page-security.c:424
+#: panels/network/connection-editor/details-page.ui:90
+msgid "Security"
+msgstr "Sekureco"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Porĉiama"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Hazarda"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabila"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profilo %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:95
+#: panels/network/net-device-wifi.c:228
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:99
+#: panels/network/net-device-wifi.c:233
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:105
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:110
+#: panels/network/connection-editor/ce-page-security.c:279
+msgid "Enhanced Open"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:117
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:123
+msgid "Enterprise"
+msgstr "Enterpreno"
+
+#: panels/network/connection-editor/ce-page-details.c:128
+#: panels/network/net-device-wifi.c:218
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Neniu"
+
+#: panels/network/connection-editor/ce-page-details.c:149
+msgid "Never"
+msgstr "Neniam"
+
+#: panels/network/connection-editor/ce-page-details.c:164
+#: panels/network/net-device-ethernet.c:107
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "Antaŭ %i tago"
+msgstr[1] "Antaŭ %i tagoj"
+
+#: panels/network/connection-editor/ce-page-details.c:291
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:293
+#: panels/network/net-device-ethernet.c:214
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:306
+msgid "2.4 GHz / 5 GHz"
+msgstr "2,4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:308
+msgid "2.4 GHz"
+msgstr "2,4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:330
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nenia"
+
+#: panels/network/connection-editor/ce-page-details.c:332
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Malforta"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Sufiĉa"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bona"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Bonega"
+
+#: panels/network/connection-editor/ce-page-details.c:410
+#: panels/network/connection-editor/details-page.ui:108
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-mobile.c:447
+msgid "IPv4 Address"
+msgstr "IPv4-adreso"
+
+#: panels/network/connection-editor/ce-page-details.c:411
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:150
+#: panels/network/net-device-mobile.c:448 panels/network/network-mobile.ui:218
+msgid "IPv6 Address"
+msgstr "IPv6-adreso"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/net-device-ethernet.c:152
+#: panels/network/net-device-ethernet.c:154
+#: panels/network/net-device-mobile.c:451
+#: panels/network/net-device-mobile.c:452 panels/network/network-mobile.ui:201
+msgid "IP Address"
+msgstr "IP-adreso"
+
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:163
+#: panels/network/net-device-mobile.c:456
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:420
+#: panels/network/net-device-ethernet.c:164
+#: panels/network/net-device-mobile.c:457
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/details-page.ui:199
+#: panels/network/connection-editor/details-page.ui:218
+#: panels/network/connection-editor/ip4-page.ui:211
+#: panels/network/connection-editor/ip6-page.ui:225
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-ethernet.c:168
+#: panels/network/net-device-mobile.c:459
+#: panels/network/net-device-mobile.c:460 panels/network/network-mobile.ui:253
+#: panels/network/network-mobile.ui:271
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:457
+msgid "Forget Connection"
+msgstr "Forgesi konekton"
+
+#: panels/network/connection-editor/ce-page-details.c:459
+msgid "Remove Connection Profile"
+msgstr "Forigi profilon de konekto"
+
+#: panels/network/connection-editor/ce-page-details.c:461
+msgid "Remove VPN"
+msgstr "Forigi VPR-on"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Details"
+msgstr "Detaloj"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "aŭtomata"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:150
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identeco"
+
+#: panels/network/connection-editor/ce-page-ip4.c:244
+#: panels/network/connection-editor/ce-page-ip6.c:225
+msgid "Delete Address"
+msgstr "Forigi adreson"
+
+#: panels/network/connection-editor/ce-page-ip4.c:399
+#: panels/network/connection-editor/ce-page-ip6.c:369
+msgid "Delete Route"
+msgstr "Forigi kurson"
+
+#: panels/network/connection-editor/ce-page-ip4.c:750
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:722
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:268
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Neniu"
+
+#: panels/network/connection-editor/ce-page-security.c:303
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bita ŝlosilo (Deksesuma aŭ ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:313
+msgid "WEP 128-bit Passphrase"
+msgstr "128-bita WEP-pasfrazo"
+
+#: panels/network/connection-editor/ce-page-security.c:326
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:339
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dinamika WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:353
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 por personoj"
+
+#: panels/network/connection-editor/ce-page-security.c:367
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 por enterprenoj"
+
+#: panels/network/connection-editor/ce-page-security.c:381
+msgid "WPA3 Personal"
+msgstr "WPA3 por personoj"
+
+#: panels/network/connection-editor/details-page.ui:18
+msgid "Signal Strength"
+msgstr "Signala forteco"
+
+#: panels/network/connection-editor/details-page.ui:54
+msgid "Link speed"
+msgstr "Ligita rapido"
+
+#: panels/network/connection-editor/details-page.ui:144
+#: panels/network/net-device-ethernet.c:157
+msgid "Hardware Address"
+msgstr "Aparatara adreso"
+
+#: panels/network/connection-editor/details-page.ui:162
+msgid "Supported Frequencies"
+msgstr "Subtenataj oftecoj"
+
+#: panels/network/connection-editor/details-page.ui:180
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/network-mobile.ui:235
+msgid "Default Route"
+msgstr "Defaŭlta kurso"
+
+#: panels/network/connection-editor/details-page.ui:236
+msgid "Last Used"
+msgstr "Laste uzita"
+
+#: panels/network/connection-editor/details-page.ui:415
+msgid "Connect _automatically"
+msgstr "Konekti _aŭtomate"
+
+#: panels/network/connection-editor/details-page.ui:434
+msgid "Make available to _other users"
+msgstr "Disponebligi por _aliaj uzantoj"
+
+#: panels/network/connection-editor/details-page.ui:467
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:478
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "_Nomo"
+
+#: panels/network/connection-editor/ethernet-page.ui:54
+#: panels/network/connection-editor/wifi-page.ui:67
+msgid "_MAC Address"
+msgstr "_MAC-adreso"
+
+#: panels/network/connection-editor/ethernet-page.ui:105
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:122
+#: panels/network/connection-editor/wifi-page.ui:102
+msgid "_Cloned Address"
+msgstr "_Klonita adreso"
+
+#: panels/network/connection-editor/ethernet-page.ui:137
+msgid "bytes"
+msgstr "bajtoj"
+
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr "IPv_4-metodo"
+
+#: panels/network/connection-editor/ip4-page.ui:42
+msgid "Automatic (DHCP)"
+msgstr "Aŭtomata (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr "Nur ligi-loke"
+
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:118
+msgid "Manual"
+msgstr "Permane"
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr "Malŝalti"
+
+#: panels/network/connection-editor/ip4-page.ui:97
+#: panels/network/connection-editor/ip6-page.ui:111
+msgid "Shared to other computers"
+msgstr "Kunhavigita kun aliaj komputiloj"
+
+#: panels/network/connection-editor/ip4-page.ui:125
+#: panels/network/connection-editor/ip6-page.ui:139
+msgid "Addresses"
+msgstr "Adresoj"
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/printers/pp-details-dialog.ui:95
+msgid "Address"
+msgstr "Adreso"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+msgid "Netmask"
+msgstr "Retmasko"
+
+#: panels/network/connection-editor/ip4-page.ui:171
+#: panels/network/connection-editor/ip4-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:369
+msgid "Gateway"
+msgstr "Kluzo"
+
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:291
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/connection-editor/ip6-page.ui:305
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:107
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Aŭtomata"
+
+#: panels/network/connection-editor/ip4-page.ui:234
+#: panels/network/connection-editor/ip6-page.ui:248
+msgid "Automatic DNS"
+msgstr "Aŭtomata DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Separate IP addresses with commas"
+msgstr "IP-adresoj apartigitaj per komoj"
+
+#: panels/network/connection-editor/ip4-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:293
+msgid "Routes"
+msgstr "Kursoj"
+
+#: panels/network/connection-editor/ip4-page.ui:302
+#: panels/network/connection-editor/ip6-page.ui:316
+msgid "Automatic Routes"
+msgstr "Aŭtomataj kursoj"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:368
+#: panels/network/connection-editor/ip6-page.ui:382
+msgid "Metric"
+msgstr "Metriko"
+
+#: panels/network/connection-editor/ip4-page.ui:398
+#: panels/network/connection-editor/ip6-page.ui:412
+msgid "Use this connection _only for resources on its network"
+msgstr "Uzi ĉi tiun konekton _nur por risurcoj rekte sur la sama reto"
+
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr "IPv_6-metodo"
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr "Aŭtomata, nur DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Prefix"
+msgstr "Prefikso"
+
+#: panels/network/connection-editor/net-connection-editor.c:280
+msgid "Unable to open connection editor"
+msgstr "Ne eblas malfermi konektan redaktilon"
+
+#: panels/network/connection-editor/net-connection-editor.c:296
+msgid "New Profile"
+msgstr "Nova profilo"
+
+#: panels/network/connection-editor/net-connection-editor.c:731
+msgid "Import from file…"
+msgstr "Enporti el dosiero…"
+
+#: panels/network/connection-editor/net-connection-editor.c:763
+msgid "Add VPN"
+msgstr "Aldoni VPR-on"
+
+#: panels/network/connection-editor/security-page.ui:20
+msgid "S_ecurity"
+msgstr "S_ekureco"
+
+#: panels/network/connection-editor/vpn-helpers.c:139
+msgid "Cannot import VPN connection"
+msgstr "Ne eblas enporti VPR-konekton"
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"La dosiero “%s” ne estis legebla aŭ ne entenas rekonitajn VPR-konektajn "
+"informojn\n"
+"\n"
+"Eraro: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:173
+msgid "Select file to import"
+msgstr "Elekti enportendan dosieron"
+
+#: panels/network/connection-editor/vpn-helpers.c:225
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Dosiero nomita “%s” jam ekzistas."
+
+#: panels/network/connection-editor/vpn-helpers.c:227
+msgid "_Replace"
+msgstr "_Anstataŭigi"
+
+#: panels/network/connection-editor/vpn-helpers.c:229
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Ĉu vi volas anstataŭigi %s per la VPR-konekto, kiun vi konservas?"
+
+#: panels/network/connection-editor/vpn-helpers.c:264
+msgid "Cannot export VPN connection"
+msgstr "Ne eblas elporti VPR-konekton"
+
+#: panels/network/connection-editor/vpn-helpers.c:266
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"La VPR-konekto “%s” ne povas esti elportita al %s.\n"
+"\n"
+"Eraro: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:296
+msgid "Export VPN connection"
+msgstr "Elporti VPR-konekton"
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Eraro: ne eblas ŝargi VPR-an konekton redaktilo)"
+
+#: panels/network/connection-editor/wifi-page.ui:20
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:36
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Regi kiel vi konektas al la interreto"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Reto;Vifio;IP;LAN;Prokurilo;WAN;Larĝkapacita;Modemo;Bludento;VPR;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Regu kiel vi konektas al vifiaj retoj"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Reto;Sendrata;Vifio;IP;LAN;Larĝkapacita;DNS;Retkaptejo;"
+
+#: panels/network/net-device-ethernet.c:95
+msgid "never"
+msgstr "neniam"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "today"
+msgstr "hodiaŭ"
+
+#: panels/network/net-device-ethernet.c:105
+msgid "yesterday"
+msgstr "hieraŭ"
+
+#: panels/network/net-device-ethernet.c:174
+msgid "Last used"
+msgstr "Laste uzita"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:261
+#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+msgid "Wired"
+msgstr "Drata"
+
+#: panels/network/net-device-mobile.c:209
+msgid "Add new connection"
+msgstr "Aldoni novan konekton"
+
+#: panels/network/net-device-wifi.c:851
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Retaj detaloj por la elektitaj retoj, inkludante pasvortojn kaj iujn ajn "
+"proprajn agordojn, perdiĝos."
+
+#: panels/network/net-device-wifi.c:855
+msgid "_Forget"
+msgstr "_Forgesi"
+
+#: panels/network/net-device-wifi.c:1034 panels/network/net-device-wifi.c:1041
+msgid "Known Wi-Fi Networks"
+msgstr "Konataj vifiaj retoj"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1076
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Forgesi"
+
+#: panels/network/net-device-wifi.c:1217
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Sistema politiko malebligas uzon kiel retkaptejo"
+
+#: panels/network/net-device-wifi.c:1220
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Sendrata aparato ne subtenas retkapteja reĝimo"
+
+#: panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:266
+#: panels/power/cc-power-panel.c:1133 panels/power/cc-power-panel.c:1144
+#: panels/universal-access/cc-ua-panel.c:328
+#: panels/universal-access/cc-ua-panel.c:603
+#: panels/universal-access/cc-ua-panel.c:613
+#: panels/universal-access/cc-ua-panel.c:625
+#: panels/universal-access/cc-ua-panel.c:668
+#: panels/universal-access/cc-ua-panel.ui:300
+#: panels/universal-access/cc-ua-panel.ui:346
+#: panels/universal-access/cc-ua-panel.ui:392
+#: panels/universal-access/cc-ua-panel.ui:498
+#: panels/universal-access/cc-ua-panel.ui:651
+#: panels/universal-access/cc-ua-panel.ui:697
+#: panels/universal-access/cc-ua-panel.ui:743
+#: panels/universal-access/cc-ua-panel.ui:927
+msgid "Off"
+msgstr "Malŝaltita"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Aŭtomata malkovro de retaj prokuriloj estas uzata kiam agord-URL ne estas "
+"provizita."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Tio ne estas rekomendita por nefidindaj publikaj retoj."
+
+#. update title
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/net-vpn.c:65 panels/network/net-vpn.c:158
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPR"
+
+#: panels/network/network-bluetooth.ui:50
+msgid "Turn device off"
+msgstr "Malŝalti aparaton"
+
+#: panels/network/network-mobile.ui:29
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:47
+msgid "Provider"
+msgstr "Provizanto"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:96
+msgid "Network Proxy"
+msgstr "Retprokurilo"
+
+#: panels/network/network-proxy.ui:180
+msgid "_HTTP Proxy"
+msgstr "_HTTP-prokurilo"
+
+#: panels/network/network-proxy.ui:199
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS-prokurilo"
+
+#: panels/network/network-proxy.ui:218
+msgid "_FTP Proxy"
+msgstr "_FTP-prokurilo"
+
+#: panels/network/network-proxy.ui:237
+msgid "_Socks Host"
+msgstr "_SOCKS-Gastigilo"
+
+#: panels/network/network-proxy.ui:256
+msgid "_Ignore Hosts"
+msgstr "_Ne uzi por"
+
+#: panels/network/network-proxy.ui:294
+msgid "HTTP proxy port"
+msgstr "Pordo de HTTP-prokurilo"
+
+#: panels/network/network-proxy.ui:371
+msgid "HTTPS proxy port"
+msgstr "Pordo de HTTPS-prokurilo"
+
+#: panels/network/network-proxy.ui:392
+msgid "FTP proxy port"
+msgstr "Pordo de FTP-prokurilo"
+
+#: panels/network/network-proxy.ui:413
+msgid "Socks proxy port"
+msgstr "Pordo de SOCKS-prokurilo"
+
+#: panels/network/network-proxy.ui:442
+msgid "_Configuration URL"
+msgstr "_Agordaradreso"
+
+#: panels/network/network-vpn.ui:56
+msgid "Turn VPN connection off"
+msgstr "Malaktivigi VPN-an konekton"
+
+#: panels/network/network-wifi.ui:22
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Retnomo"
+
+#: panels/network/network-wifi.ui:28
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Speco de sekureco"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Pasvorto"
+
+#: panels/network/network-wifi.ui:84
+msgid "Turn Wi-Fi off"
+msgstr "Malŝalti vifion"
+
+#: panels/network/network-wifi.ui:116
+msgid "_Connect to Hidden Network…"
+msgstr "_Konekti al kaŝita reto…"
+
+#: panels/network/network-wifi.ui:127
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Ŝ_alti retkaptejon…"
+
+#: panels/network/network-wifi.ui:138
+msgid "_Known Wi-Fi Networks"
+msgstr "_Konataj vifiaj retoj"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Nekonata stato"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Nemastrumita"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/network/panel-common.c:45 panels/user-accounts/cc-user-panel.c:928
+msgid "Unavailable"
+msgstr "Nedisponeble"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Konektante"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Aŭtentigo necesas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Malkontaktante"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Konekto malsukcesis"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Nekonata stato (mankanta)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Agordo malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP-agordo malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP-agordo senvalidiĝis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Sekretoj estis bezonitaj, sed ne provizitaj"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x provizanto malkonektitas"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Agordo de 802.1x provizanto malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x provizanto malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x provizanto estis tro malrapida por aŭtentigi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP-servilo malsukcesis starti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP-servilo malkonektis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP-kliento malsukcesis starti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Eraro de la DHCP-kliento"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP-kliento malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Kunhavigita konekta servilo malsukcesis starti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Kunhavigita konekta servilo malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP-servilo malsukcesis starti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP-serva eraro"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP-servilo malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Lineo okupita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Neniu voktono"
+
+# carrier = mobile network carrier? --Carmen
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Neniu provizanto povus esti trovita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Numeruma peto eltempiĝis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Numeruma peto malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Pravalorizo de modemo malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Malsukcesis elekti specifitan APN-on"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Ne serĉanta por retoj"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Reta registriĝo neis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Reta registriĝo eltempiĝis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Registriĝo por la petita reto malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN-kontrolo malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Firma programaro por la aparato eble mankas"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Konekto malaperis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Ekzistanta konekto supozintis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modemo ne trovita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bludenta konekto malsukcesis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM-karto ne enmetita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM-karto PIN bezonita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM-karto PUK bezonita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252
+msgid "SIM wrong"
+msgstr "SIM-karto malĝusta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Konekta dependeco malsukcesis"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Mikroprogramaro mankas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kablo ne konektita"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "nedifinita eraro en 802.1X-sekureco (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:195
+msgid "no file selected"
+msgstr "neniu elektita dosiero"
+
+#: panels/network/wireless-security/eap-method.c:222
+msgid "unspecified error validating eap-method file"
+msgstr "nespecifita eraro dum validigado de eap-method-dosiero"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr ""
+"Privataj ŝlosiloj de specoj DER, PEM aŭ PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:400
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER- aŭ PEM-atestiloj (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:87
+msgid "missing EAP-FAST PAC file"
+msgstr "mankanta EAP-FAST PAC dosiero"
+
+#: panels/network/wireless-security/eap-method-fast.c:347
+msgid "Choose a PAC file"
+msgstr "Elekti PAC-dosieron"
+
+#: panels/network/wireless-security/eap-method-fast.c:352
+msgid "PAC files (*.pac)"
+msgstr "PAC-dosieroj (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Sennoma"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Aŭtentokontrolata"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ambaŭ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:49
+#: panels/network/wireless-security/eap-method-peap.ui:52
+#: panels/network/wireless-security/eap-method-ttls.ui:51
+msgid "Anony_mous identity"
+msgstr "Senno_ma identeco"
+
+#: panels/network/wireless-security/eap-method-fast.ui:75
+msgid "PAC _file"
+msgstr "PAC-_dosiero"
+
+#: panels/network/wireless-security/eap-method-fast.ui:115
+#: panels/network/wireless-security/eap-method-peap.ui:150
+#: panels/network/wireless-security/eap-method-ttls.ui:143
+msgid "_Inner authentication"
+msgstr "_Ena aŭtentigo"
+
+#: panels/network/wireless-security/eap-method-fast.ui:144
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Permesi aŭtomatan pro_vizadon de PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "mankanta EAP-LEAP uzantonomo"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "mankanta EAP-LEAP pasvorto"
+
+#: panels/network/wireless-security/eap-method-leap.ui:17
+#: panels/network/wireless-security/eap-method-simple.ui:17
+#: panels/network/wireless-security/ws-leap.ui:18
+#: panels/user-accounts/cc-add-user-dialog.ui:146
+#: panels/user-accounts/cc-add-user-dialog.ui:527
+msgid "_Username"
+msgstr "_Uzantonomo"
+
+#: panels/network/wireless-security/eap-method-leap.ui:31
+#: panels/network/wireless-security/eap-method-simple.ui:31
+#: panels/network/wireless-security/ws-leap.ui:32
+#: panels/network/wireless-security/ws-sae.ui:14
+#: panels/network/wireless-security/ws-wpa-psk.ui:14
+#: panels/sharing/cc-sharing-panel.ui:202
+#: panels/user-accounts/cc-add-user-dialog.ui:310
+#: panels/user-accounts/cc-add-user-dialog.ui:547
+#: panels/user-accounts/cc-user-panel.ui:478
+msgid "_Password"
+msgstr "_Pasvorto"
+
+#: panels/network/wireless-security/eap-method-leap.ui:55
+#: panels/network/wireless-security/eap-method-simple.ui:73
+#: panels/network/wireless-security/eap-method-tls.ui:157
+#: panels/network/wireless-security/ws-leap.ui:56
+#: panels/network/wireless-security/ws-sae.ui:54
+#: panels/network/wireless-security/ws-wpa-psk.ui:64
+msgid "Sho_w password"
+msgstr "_Montri pasvorton"
+
+#: panels/network/wireless-security/eap-method-peap.c:87
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "nevalida EAP-PEAP CA-atestilo: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:96
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "nevalida EAP-PEAP CA-atestilo: neniu atestilo estas specifita"
+
+#: panels/network/wireless-security/eap-method-peap.c:328
+#: panels/network/wireless-security/eap-method-tls.c:513
+#: panels/network/wireless-security/eap-method-ttls.c:336
+msgid "Choose a Certificate Authority certificate"
+msgstr "Elekti atestilon de Atestilaŭtoritato"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versio 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versio 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:78
+#: panels/network/wireless-security/eap-method-tls.ui:68
+#: panels/network/wireless-security/eap-method-ttls.ui:102
+msgid "C_A certificate"
+msgstr "C_A-atestilo"
+
+#: panels/network/wireless-security/eap-method-peap.ui:100
+#: panels/network/wireless-security/eap-method-tls.ui:90
+#: panels/network/wireless-security/eap-method-ttls.ui:125
+msgid "No CA certificate is _required"
+msgstr "Neniu CA-atestilo estas _bezonata"
+
+#: panels/network/wireless-security/eap-method-peap.ui:118
+msgid "PEAP _version"
+msgstr "PEAP-_versiono"
+
+# Ĉu «EAP uzantonomo, kiu estas mankanta» aŭ «EAP uzantonomo estas mankanta»? --Carmen
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "mankanta EAP uzantonomo"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "mankanta EAP pasvorto"
+
+#: panels/network/wireless-security/eap-method-tls.c:92
+msgid "missing EAP-TLS identity"
+msgstr "mankanta EAP-TLS identeco"
+
+#: panels/network/wireless-security/eap-method-tls.c:102
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "nevalida EAP-TLS CA-atestilo: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:112
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "nevalida EAP-TLS CA-atestilo: neniu atestilo estas specifita"
+
+#: panels/network/wireless-security/eap-method-tls.c:129
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "nevalida EAP-TLS privata ŝlosilo: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:139
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "nevalida EAP-TLS atestilo de uzanto: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:272
+msgid "Unencrypted private keys are insecure"
+msgstr "Neĉifritaj privataj ŝlosiloj estas nesekuraj"
+
+#: panels/network/wireless-security/eap-method-tls.c:275
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Ŝajne la elektita privata ŝlosilo ne estas protektata per pasvorto. Tio "
+"povas kaŭzi la forlikon de viaj sekurecinformoj. Bonvolu elekti pasvort-"
+"protektitan privatan ŝlosilon.\n"
+"\n"
+"(Vi povas pasvort-protekti vian privatan ŝlosilon per openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:506
+msgid "Choose your personal certificate"
+msgstr "Elekti vian personan atestilon"
+
+#: panels/network/wireless-security/eap-method-tls.c:520
+msgid "Choose your private key"
+msgstr "Elekti vian privatan ŝlosilon"
+
+#: panels/network/wireless-security/eap-method-tls.ui:17
+msgid "I_dentity"
+msgstr "I_denteco"
+
+#: panels/network/wireless-security/eap-method-tls.ui:43
+msgid "_User certificate"
+msgstr "Atestilo de _uzanto"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "Private _key"
+msgstr "Privata ŝ_losilo"
+
+#: panels/network/wireless-security/eap-method-tls.ui:133
+msgid "_Private key password"
+msgstr "_Privata ŝlosila pasvorto"
+
+#: panels/network/wireless-security/eap-method-ttls.c:98
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "nevalida EAP-TTLS CA-atestilo: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:106
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "nevalida EAP-TTLS CA-atestilo: neniu atestilo estas specifita"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (ne EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:76
+#: panels/user-accounts/cc-add-user-dialog.ui:507
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "_Domajno"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Nekonata eraro dum validigado de 802.1X-sekureco"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "Pasvorto"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunelita TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Protektita EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:102
+#: panels/network/wireless-security/ws-wpa-eap.ui:61
+msgid "Au_thentication"
+msgstr "Aŭ_tentigo"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "mankanta leap-username"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "mankanta leap-password"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Vifia pasvorto mankas."
+
+#: panels/network/wireless-security/ws-sae.ui:42
+#: panels/network/wireless-security/ws-wpa-psk.ui:42
+msgid "_Type"
+msgstr "_Speco"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "mankanta wep-key"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"nevalida wep-key: ŝlosilo kun longo de %zu devas enhavi nur deksesumajn "
+"ciferojn"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"nevalida wep-key: ŝlosilo kun longo de %zu devas enhavi nur ascii-signoj"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"nevalida wep-key: malĝusta longo de ŝlosilo %zu. Longo de ŝlosilo devas esti "
+"aŭ 5/13 (ascii) aŭ 10/26 (deksesuma)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "nevalida wep-key: pasfrazo devas esti ne-malplena"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "nevalida wep-key: pasfrazo devas esti pli mallonga ol 64 signoj"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Implicita)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Malferma sistemo"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Kunhavigita ŝlosilo"
+
+#: panels/network/wireless-security/ws-wep-key.ui:48
+msgid "_Key"
+msgstr "Ŝ_losilo"
+
+#: panels/network/wireless-security/ws-wep-key.ui:84
+msgid "Sho_w key"
+msgstr "_Montri ŝlosilon"
+
+#: panels/network/wireless-security/ws-wep-key.ui:134
+msgid "WEP inde_x"
+msgstr "WEP-inde_kso"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"nevalida wpa-psk: nevalida longo de ŝlosilo %zu. Devas esti [8,63] bajtoj aŭ "
+"64 deksesumaj ciferoj"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"nevalida wpa-psk: ne povas interpreti ŝlosilon kun 64 bajtoj kiel deksesuma"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:60
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Sciigoj"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:112
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Sonaj _avertoj"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:168
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Ŝ_prucaj sciigoj"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:184
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Sciigoj daŭrigos aperi en la listo de sciigoj kiam ŝprucoj estas malŝaltitaj."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:249
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Montri _enhavon de mesaĝo en ŝprucoj"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:300
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Sciigoj sur ŝ_losa ekrano"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:351
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Motri enhav_on de mesaĝo en ŝlosa ekrano"
+
+#: panels/notifications/cc-notifications-panel.c:266
+#: panels/power/cc-power-panel.c:1139 panels/power/cc-power-panel.c:1146
+#: panels/universal-access/cc-ua-panel.c:328
+#: panels/universal-access/cc-ua-panel.c:603
+#: panels/universal-access/cc-ua-panel.c:613
+#: panels/universal-access/cc-ua-panel.c:625
+#: panels/universal-access/cc-ua-panel.c:668
+msgid "On"
+msgstr "Ŝaltita"
+
+#: panels/notifications/cc-notifications-panel.ui:48
+msgid "_Do Not Disturb"
+msgstr "_Ne interrompu"
+
+#: panels/notifications/cc-notifications-panel.ui:56
+msgid "_Lock Screen Notifications"
+msgstr "Sciigoj sur ŝ_losa ekrano"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Regu kiuj sciigoj estas montrita kaj kion ili montros"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Sciigoj;Mesaĝo;Pleto;Ŝpruco;"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:150
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Alia"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:622
+#, c-format
+msgid "%s Account"
+msgstr "%s konto"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:916
+msgid "Error removing account"
+msgstr "Eraro dum forigado de konto"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:982
+#, c-format
+msgid "%s removed"
+msgstr "%s forigita"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Retaj kontoj"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Konektu al viajn retajn kontojn kaj elektu kiel uzi ilin"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Guglo;Facebook;Fejsbuko;Vizaĝlibro;Twitter;Tvitero;Yahoo;Jahuo;Reto;"
+"Konektite;Retbabili;Kalendaro;Retpoŝto;Kontaktoj;ownCloud;Kerberos;IMAP;SMTP;"
+"Pocket;ReadItLater;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:61
+msgid "Undo"
+msgstr "Malfari"
+
+#: panels/online-accounts/online-accounts.ui:94
+msgid "Connect to your data in the cloud"
+msgstr "Konekti al viaj datumoj en la nubo"
+
+#: panels/online-accounts/online-accounts.ui:109
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Neniu interreta konekto — konektu por agordi novajn retajn kontojn"
+
+#: panels/online-accounts/online-accounts.ui:134
+msgid "Add an account"
+msgstr "Aldoni konton"
+
+#: panels/online-accounts/online-accounts.ui:238
+msgid "Remove Account"
+msgstr "Forigi konton"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Nekonata tempo"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuto"
+msgstr[1] "%i minutoj"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i horo"
+msgstr[1] "%i horoj"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "horo"
+msgstr[1] "horoj"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuto"
+msgstr[1] "minutoj"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s ĝis tute ŝargita"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Averto: %s restanta"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s restanta"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Tute ŝargita"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Ne ŝargante"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Malplena"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Ŝargante"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Malŝargante"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Sendrata muso"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Sendrata klavaro"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Vicnutrila baterio"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Persona cifereca asistanto"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Poŝtelefono"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Medioludilo"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209 panels/wacom/cc-wacom-panel.c:728
+msgid "Tablet"
+msgstr "Tabulkomputilo"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Komputilo"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Luda enigaparato"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:413
+#: panels/power/cc-power-panel.c:1780
+msgid "Battery"
+msgstr "Baterio"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Ĉefa"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Ekstra"
+
+#: panels/power/cc-power-panel.c:411
+msgid "Batteries"
+msgstr "Baterioj"
+
+#: panels/power/cc-power-panel.c:632
+msgid "When _idle"
+msgstr "Dum _senokupo"
+
+#: panels/power/cc-power-panel.c:1081
+msgid "Suspend"
+msgstr "Halteti"
+
+#: panels/power/cc-power-panel.c:1082
+msgid "Power Off"
+msgstr "Malŝalti"
+
+#: panels/power/cc-power-panel.c:1083
+msgid "Hibernate"
+msgstr "Pasivumigi"
+
+#: panels/power/cc-power-panel.c:1084
+msgid "Nothing"
+msgstr "Nenio"
+
+#: panels/power/cc-power-panel.c:1135
+msgid "When on battery power"
+msgstr "Dum bateria elektro"
+
+#: panels/power/cc-power-panel.c:1137
+msgid "When plugged in"
+msgstr "Kiam konektita"
+
+#: panels/power/cc-power-panel.c:1277
+msgid "Automatic suspend"
+msgstr "Aŭtomata haltetado"
+
+#: panels/power/cc-power-panel.c:1800
+msgid "Power Mode"
+msgstr "Elektro-reĝimo"
+
+#: panels/power/cc-power-panel.c:1810
+msgid "Power Saving"
+msgstr "Elektroŝparo"
+
+#: panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Button"
+msgstr "Halteta & ŝalta butono"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:13
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutoj"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:17
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutoj"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:21
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutoj"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:25
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutoj"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:29
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutoj"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:33
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 horo"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:37
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutoj"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:41
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutoj"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:45
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutoj"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:49
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 horoj"
+
+#: panels/power/cc-power-panel.ui:227
+msgid "Affects system performance and power usage."
+msgstr "Afekcias sisteman rendimenton kaj elektro-uzadon."
+
+#: panels/power/cc-power-panel.ui:297
+msgid "_Screen Brightness"
+msgstr "Heleco de _ekrano"
+
+#: panels/power/cc-power-panel.ui:346
+msgid "Automatic Brightness"
+msgstr "Aŭtomata heleco"
+
+#: panels/power/cc-power-panel.ui:382
+msgid "_Keyboard Brightness"
+msgstr "Heleco de _klavaro"
+
+#: panels/power/cc-power-panel.ui:431
+msgid "Dim Screen When Inactive"
+msgstr "Malheligi ekranon kiam neaktiva"
+
+#: panels/power/cc-power-panel.ui:466
+msgid "_Blank Screen"
+msgstr "M_alplena ekrano"
+
+#: panels/power/cc-power-panel.ui:502
+msgid "_Automatic Suspend"
+msgstr "_Aŭtomata haltetado"
+
+#: panels/power/cc-power-panel.ui:547
+msgid "_Wi-Fi"
+msgstr "_Vifio"
+
+#: panels/power/cc-power-panel.ui:559
+msgid "Wi-Fi can be turned off to save power."
+msgstr "Vifio malŝalteblas por ŝpari elektron."
+
+#: panels/power/cc-power-panel.ui:609
+msgid "_Mobile Broadband"
+msgstr "_Portebla larĝkapacita reto"
+
+#: panels/power/cc-power-panel.ui:621
+msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+msgstr ""
+"Portebla larĝkapacita reto (LTE, 4G, 3G, ktp.) malŝalteblas por ŝpari "
+"elektron."
+
+#: panels/power/cc-power-panel.ui:671
+msgid "_Bluetooth"
+msgstr "_Bludento"
+
+#: panels/power/cc-power-panel.ui:683
+msgid "Bluetooth can be turned off to save power."
+msgstr "Bludento malŝalteblas por ŝpari elektron."
+
+#: panels/power/cc-power-panel.ui:759
+msgid "Po_wer Button Behavior"
+msgstr "Konduto de ŝaltbutono"
+
+#: panels/power/cc-power-panel.ui:797
+msgid "Show Battery _Percentage"
+msgstr "Montri baterian elcenton"
+
+#: panels/power/cc-power-panel.ui:872
+msgid "Automatic Suspend"
+msgstr "Aŭtomata haltetado"
+
+#: panels/power/cc-power-panel.ui:897
+msgid "_Plugged In"
+msgstr "_Konektita"
+
+#: panels/power/cc-power-panel.ui:913
+msgid "On _Battery Power"
+msgstr "Je _bateria elektro"
+
+#: panels/power/cc-power-panel.ui:958 panels/power/cc-power-panel.ui:1018
+#: panels/universal-access/cc-repeat-keys-dialog.ui:74
+msgid "Delay"
+msgstr "Prokrasto"
+
+#: panels/power/cc-power-profile-row.c:62
+msgid "Lap detected: performance mode unavailable"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:64
+msgid "High hardware temperature: performance mode unavailable"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:65
+msgid "Performance mode unavailable"
+msgstr "Rendimenta reĝimo nedisponeblas"
+
+#: panels/power/cc-power-profile-row.c:87
+#: panels/power/cc-power-profile-row.c:187
+msgid "High performance and power usage."
+msgstr "Alta rendimento kaj elektro-uzado."
+
+#: panels/power/cc-power-profile-row.c:186
+msgid "Performance"
+msgstr "Rendimento"
+
+#: panels/power/cc-power-profile-row.c:192
+msgid "Balanced Power"
+msgstr "Ekvilibra"
+
+#: panels/power/cc-power-profile-row.c:193
+msgid "Standard performance and power usage."
+msgstr "Normala rendimento kaj elektro-uzado."
+
+#: panels/power/cc-power-profile-row.c:198
+msgid "Power Saver"
+msgstr "Elektroŝparado"
+
+#: panels/power/cc-power-profile-row.c:199
+msgid "Reduced performance and power usage."
+msgstr "Malalta rendimento kaj elektro-uzado."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Elektro"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Vidu vian baterian staton kaj elektu elektroŝparajn funkciojn"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Kurento;Elektro;Dormeti;Pasivumigi;Baterio;Heleco;Malheligi;Malplena;Ekrano;"
+"DPMS;Senokupo;"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "Aŭtentigi"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/new-printer-dialog.ui:366
+#: panels/printers/pp-jobs-dialog.ui:57
+msgid "Username"
+msgstr "Uzantonomo"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:339
+msgid "Authentication Required"
+msgstr "Aŭtentigo necesas"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:682
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Presilo “%s” estas forigita"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:930
+msgid "Failed to add new printer."
+msgstr "Aldono de nova presilo malsukcesis."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1209
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Ne eblas ŝargi fasadon: %s"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Presiloj"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Aldonu presilojn, montru presajn taskojn kaj regu kiel vi volas presi"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Presilo;Atendovico;Presi;Papero;Inko;Inkopulvoro;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:344
+#: panels/printers/pp-new-printer-dialog.c:401
+msgid "Add Printer"
+msgstr "Aldoni presilon"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+msgid "_Unlock"
+msgstr "_Malŝlosi"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:211
+msgid "No Printers Found"
+msgstr "Neniuj presiloj estas trovitaj"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:284
+msgid "Enter a network address or search for a printer"
+msgstr "Entajpu retadreson aŭ serĉu presilon"
+
+#: panels/printers/new-printer-dialog.ui:356
+msgid "Enter username and password to view printers on Print Server."
+msgstr "Enigu uzantonomon kaj pasvorton por vidi presilojn je presila servilo."
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:351
+#, c-format
+msgid "%s Details"
+msgstr "%s detaloj"
+
+#: panels/printers/pp-details-dialog.c:101
+msgid "No suitable driver found"
+msgstr "Neniu taŭga pelilon trovita"
+
+#: panels/printers/pp-details-dialog.c:232
+msgid "Select PPD File"
+msgstr "Elekti PPD-dosieron"
+
+#: panels/printers/pp-details-dialog.c:241
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript presilo-priskribaj dosieroj (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "Loko"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:122
+#: panels/printers/pp-ppd-selection-dialog.c:239
+msgid "Driver"
+msgstr "Pelilo"
+
+#: panels/printers/pp-details-dialog.ui:162
+msgid "Searching for preferred drivers…"
+msgstr "Serĉante por preferitaj pelilojn…"
+
+#: panels/printers/pp-details-dialog.ui:183
+msgid "Search for Drivers"
+msgstr "Serĉi petilojn"
+
+#: panels/printers/pp-details-dialog.ui:192
+msgid "Select from Database…"
+msgstr "Elektu el datumbazo…"
+
+#: panels/printers/pp-details-dialog.ui:201
+msgid "Install PPD File…"
+msgstr "Instali PPD-dosieron…"
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr "Elekti presil-pelilon"
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/cc-avatar-chooser.c:107
+msgid "Select"
+msgstr "Elekti"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Ŝargante pelilan datumbazon…"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect presilo"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD-presilo"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Unuflanka"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Longa flanko (norma)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Mallonga flanko (renversa)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portreto"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Pejzaĝo"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Renversita pejzaĝo"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Renversita portreto"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:106
+msgctxt "print job"
+msgid "Pending"
+msgstr "Atendante"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:112
+msgctxt "print job"
+msgid "Paused"
+msgstr "Paŭzita"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:117
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Aŭtentigo necesas"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:122
+msgctxt "print job"
+msgid "Processing"
+msgstr "Traktado"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:126
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Haltigita"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:130
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Nuligita"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:134
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Rompita"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:138
+msgctxt "print job"
+msgid "Completed"
+msgstr "Plenumita"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:249
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u tasko bezonas aŭtentigon"
+msgstr[1] "%u taskoj bezonas aŭtentigon"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:401
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Aktivaj taskoj"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:405
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Entajpu akreditaĵojn por presi el %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:44
+msgid "Domain"
+msgstr "Domajno"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:129
+msgid "A_uthenticate"
+msgstr "_Aŭtentigi"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:169
+msgid "Clear All"
+msgstr "Vakigi ĉion"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:232
+msgid "_Authenticate"
+msgstr "_Aŭtentigi"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:358
+msgid "No Active Printer Jobs"
+msgstr "Neniu aktiva presa tasko"
+
+#: panels/printers/pp-new-printer-dialog.c:359
+msgid "Unlock Print Server"
+msgstr "Malŝlosi presservilon"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:363
+#, c-format
+msgid "Unlock %s."
+msgstr "Malŝlosi %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:367
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Enigu uzantonomon kaj pasvorton por vidi presilojn je %s."
+
+#: panels/printers/pp-new-printer-dialog.c:790
+msgid "Searching for Printers"
+msgstr "Serĉante presilojn"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1578
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1583
+msgid "Serial Port"
+msgstr "Seria pordo"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1590
+msgid "Parallel Port"
+msgstr "Paralela pordo"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1632
+#, c-format
+msgid "Location: %s"
+msgstr "Loko: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1637
+#, c-format
+msgid "Address: %s"
+msgstr "Adreso: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1664
+msgid "Server requires authentication"
+msgstr "Servilo necesas aŭtentigon"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Duflanka"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Speco de papero"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Papera fonto"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Eliga pleto"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Distingivo"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript-antaŭfiltrado"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:530
+msgid "Pages per side"
+msgstr "Paĝoj po flanko"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:542
+msgid "Two-sided"
+msgstr "Duflanka"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:554
+msgid "Orientation"
+msgstr "Orientiĝo"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:651
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Ĝenerala"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Paĝ-agordo"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Instaleblaj opcioj"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Tasko"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Bild-kvalito"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Koloro"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Finigante"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Altnivela"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:857
+#: panels/printers/pp-options-dialog.ui:18
+msgid "Test Page"
+msgstr "Testpaĝo"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:870
+msgid "Test page"
+msgstr "Testpaĝo"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Elekti aŭtomate"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Implicita agordo de presilo"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Enkorpigi nur GhostScript-ajn tiparojn"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Konverti al PS-nivelo 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Konverti al PS-nivelo 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Neniu antaŭfiltrado"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:223
+msgid "Manufacturer"
+msgstr "Fabrikanto"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:523 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr "Neniuj aktivaj taskoj"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:528
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u tasko"
+msgstr[1] "%u taskoj"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:648
+msgid "Clean print heads"
+msgstr "Purigi presilajn kapetojn"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:713
+msgid "Low on toner"
+msgstr "Malmulte da inko"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:715
+msgid "Out of toner"
+msgstr "Neniu inko"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:718
+msgid "Low on developer"
+msgstr "Malmulte da fotokreilkemiaĵo"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of developer"
+msgstr "Neniu fotokreilkemiaĵo"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:723
+msgid "Low on a marker supply"
+msgstr "Malmulte da inkpulvora provizo"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:725
+msgid "Out of a marker supply"
+msgstr "Neniu inkpulvora provizo"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:727
+msgid "Open cover"
+msgstr "Malfermi kovrilon"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:729
+msgid "Open door"
+msgstr "Malfermi pordon"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:731
+msgid "Low on paper"
+msgstr "Malmulte da papero"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:733
+msgid "Out of paper"
+msgstr "Neniu papero"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:735
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Nekonektita"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:737
+#: panels/printers/pp-printer-entry.c:880
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Haltigita"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:739
+msgid "Waste receptacle almost full"
+msgstr "Forĵetaĵulo preskaŭ plena"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:741
+msgid "Waste receptacle full"
+msgstr "Forĵetaĵujo plena"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:743
+msgid "The optical photo conductor is near end of life"
+msgstr "La optika fotokonduktilo apudas al fino de vivo"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:745
+msgid "The optical photo conductor is no longer functioning"
+msgstr "La optika fotokonduktilo ne plu funkcias"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:866
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Prete"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:871
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Ne akceptas taskojn"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:876
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Traktado"
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr "Presilaj agordoj"
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr "Presilaj detaloj"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr "Agordi presilon kiel implicita"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr "Purigi presilajn kapetojn"
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "Forigi presilon"
+
+#: panels/printers/printer-entry.ui:193
+msgid "Model"
+msgstr "Modelo"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr "Nivelo de inko"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:313
+msgid "Please restart when the problem is resolved."
+msgstr "Bonvolu restartigi kiam la problemo malaperis."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:320
+msgid "Restart"
+msgstr "Restartigi"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:12
+msgid "Add…"
+msgstr "Aldoni…"
+
+#: panels/printers/printers.ui:187
+msgid "No printers"
+msgstr "Neniuj presiloj"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:201
+msgid "Add a Printer…"
+msgstr "Aldoni presilon…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:233
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"Pardonon! Ŝajnas, ke la sistema\n"
+"presservilo ne disponeblas."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:189
+#: panels/region/cc-format-chooser.ui:6 panels/region/cc-region-panel.ui:159
+msgid "Formats"
+msgstr "Formoj"
+
+#: panels/region/cc-format-chooser.ui:101
+msgid ""
+"Choose the format for numbers, dates and currencies. Changes take effect on "
+"next login."
+msgstr ""
+"Elektu formon por numeroj, datoj, kaj valutoj. Ŝanĝoj efektiviĝas post via "
+"sekva saluto."
+
+#: panels/region/cc-format-chooser.ui:117
+msgid "Search locales..."
+msgstr "Serĉi lokaĵarojn…"
+
+#: panels/region/cc-format-chooser.ui:158
+msgid "Common Formats"
+msgstr "Oftaj formoj"
+
+#: panels/region/cc-format-chooser.ui:189
+msgid "All Formats"
+msgstr "Ciuj formoj"
+
+#: panels/region/cc-format-chooser.ui:242
+msgid "No Search Results"
+msgstr "Neniu rezulto troviĝis"
+
+#: panels/region/cc-format-chooser.ui:255
+msgid "Searches can be for countries or languages."
+msgstr "Oni povas serĉi kaj landojn kaj lingvojn."
+
+#: panels/region/cc-format-chooser.ui:300
+msgid "Preview"
+msgstr "Antaŭrigardo"
+
+#: panels/region/cc-format-preview.c:135
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperia"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metra"
+
+#: panels/region/cc-format-preview.ui:18
+msgid "Dates"
+msgstr "Datoj"
+
+#: panels/region/cc-format-preview.ui:62
+msgid "Dates & Times"
+msgstr "Datoj & tempoj"
+
+#: panels/region/cc-format-preview.ui:84
+msgid "Numbers"
+msgstr "Numeroj"
+
+#: panels/region/cc-format-preview.ui:106
+msgid "Measurement"
+msgstr "Mezuro"
+
+#: panels/region/cc-format-preview.ui:128
+msgid "Paper"
+msgstr "Papero"
+
+#: panels/region/cc-region-panel.c:740
+msgid "Login _Screen"
+msgstr "Ensaluta _ekrano"
+
+#: panels/region/cc-region-panel.ui:34
+msgid "Language"
+msgstr "Lingvo"
+
+#: panels/region/cc-region-panel.ui:45
+msgid "The language used for text in windows and web pages."
+msgstr "La lingvo kiun oni uzas por teksto en fenestroj kaj retpaĝoj."
+
+#: panels/region/cc-region-panel.ui:85
+#: panels/user-accounts/cc-user-panel.ui:406
+msgid "_Language"
+msgstr "_Lingvo"
+
+#: panels/region/cc-region-panel.ui:120
+msgid "Restart the session for changes to take effect"
+msgstr "Restartigi la seancon por ke la ŝanĝoj efektiviĝas"
+
+#: panels/region/cc-region-panel.ui:135
+msgid "Restart…"
+msgstr "Restartigi…"
+
+#: panels/region/cc-region-panel.ui:170
+msgid "The format used for numbers, dates, and currencies."
+msgstr "La formo kiun oni uzas por numeroj, datoj, kaj valutoj."
+
+#: panels/region/cc-region-panel.ui:204
+msgid "_Formats"
+msgstr "_Formoj"
+
+#: panels/region/cc-region-panel.ui:231
+msgid "Login settings are used by all users when logging into the system"
+msgstr "Salutaj agordoj estas uzataj de ĉiuj uzantoj kiam salutante sistemen"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Regiono & lingvo"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"Elektu vian montran lingvon, formojn, klavararanĝojn kaj enigajn fontojn"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Lingvo;Klavararanĝo;Klavaro;Enigo;"
+
+#: panels/removable-media/cc-removable-media-panel.c:267
+msgid "Ask what to do"
+msgstr "Demandi kion fari"
+
+#: panels/removable-media/cc-removable-media-panel.c:271
+msgid "Do nothing"
+msgstr "Fari nenion"
+
+#: panels/removable-media/cc-removable-media-panel.c:275
+msgid "Open folder"
+msgstr "Malfermi dosierujon"
+
+#: panels/removable-media/cc-removable-media-panel.c:341
+msgid "Other Media"
+msgstr "Aliaj datumportiloj"
+
+#: panels/removable-media/cc-removable-media-panel.c:362
+msgid "Select an application for audio CDs"
+msgstr "Elekti aplikaĵon por son-KDj"
+
+#: panels/removable-media/cc-removable-media-panel.c:363
+msgid "Select an application for video DVDs"
+msgstr "Elekti aplikaĵon por video-DVDj"
+
+#: panels/removable-media/cc-removable-media-panel.c:364
+msgid "Select an application to run when a music player is connected"
+msgstr "Elektu rulendan aplikaĵon kiam muzikludilo estas konektita"
+
+#: panels/removable-media/cc-removable-media-panel.c:365
+msgid "Select an application to run when a camera is connected"
+msgstr "Elektu rulendan aplikaĵon kiam kamerao estas konektita"
+
+#: panels/removable-media/cc-removable-media-panel.c:366
+msgid "Select an application for software CDs"
+msgstr "Elekti aplikaĵon por programar-KDj"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "audio DVD"
+msgstr "son-DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "blank Blu-ray disc"
+msgstr "malplena Blu-radia disko"
+
+#: panels/removable-media/cc-removable-media-panel.c:380
+msgid "blank CD disc"
+msgstr "malplena KD-disko"
+
+#: panels/removable-media/cc-removable-media-panel.c:381
+msgid "blank DVD disc"
+msgstr "malplena DVD-disko"
+
+#: panels/removable-media/cc-removable-media-panel.c:382
+msgid "blank HD DVD disc"
+msgstr "malplena HD-DVD-disko"
+
+#: panels/removable-media/cc-removable-media-panel.c:383
+msgid "Blu-ray video disc"
+msgstr "Blu-radia videodisko"
+
+#: panels/removable-media/cc-removable-media-panel.c:384
+msgid "e-book reader"
+msgstr "retlibrolegilo"
+
+#: panels/removable-media/cc-removable-media-panel.c:385
+msgid "HD DVD video disc"
+msgstr "HD-DVD-videodisko"
+
+#: panels/removable-media/cc-removable-media-panel.c:386
+msgid "Picture CD"
+msgstr "Bild-KD"
+
+#: panels/removable-media/cc-removable-media-panel.c:387
+msgid "Super Video CD"
+msgstr "Super-Video-KD"
+
+#: panels/removable-media/cc-removable-media-panel.c:388
+msgid "Video CD"
+msgstr "Video-KD"
+
+#: panels/removable-media/cc-removable-media-panel.c:389
+msgid "Windows software"
+msgstr "Windows-programaro"
+
+#: panels/removable-media/cc-removable-media-panel.ui:44
+msgid "Select how media should be handled"
+msgstr "Elektu kiel datumportiloj estu traktitaj"
+
+#: panels/removable-media/cc-removable-media-panel.ui:75
+msgid "CD _audio"
+msgstr "_Son-KD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:92
+msgid "_DVD video"
+msgstr "_DVD-video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:133
+msgid "_Music player"
+msgstr "_Muzikludilo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:191
+msgid "_Software"
+msgstr "_Programaro"
+
+#: panels/removable-media/cc-removable-media-panel.ui:229
+msgid "_Other Media…"
+msgstr "_Aliaj datumportiloj…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:288
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Neniam lanĉi programarojn dum enmeto de datumportilo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:342
+msgid "Select how other media should be handled"
+msgstr "Elektu kiel aliaj datumportiloj estu traktitaj"
+
+#: panels/removable-media/cc-removable-media-panel.ui:389
+msgid "_Action:"
+msgstr "_Ago:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:412
+msgid "_Type:"
+msgstr "_Speco:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Demetebla datumportilo"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Agordi demeteblajn datumportilojn"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"aparato;sistemo;implicita;aplikaĵo;preferita;kd;dvd;usb;sono;video;disko;"
+"demetebla;datumportilo;aŭtomata;lanĉo;"
+
+#: panels/search/cc-search-locations-dialog.c:636
+msgid "Select Location"
+msgstr "Elekti lokon"
+
+#: panels/search/cc-search-locations-dialog.c:640
+msgid "_OK"
+msgstr "_Bone"
+
+#: panels/search/cc-search-locations-dialog.ui:9
+#: panels/search/cc-search-panel.ui:59
+msgid "Search Locations"
+msgstr "Serĉaj lokoj"
+
+#: panels/search/cc-search-locations-dialog.ui:32
+#: panels/search/cc-search-locations-dialog.ui:69
+#: panels/search/cc-search-locations-dialog.ui:107
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Disierujoj kiujn serĉas sistemaj aplikaĵoj kiel Dosieroj, Fotoj, kaj "
+"Videaĵoj."
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Places"
+msgstr "Lokoj"
+
+#: panels/search/cc-search-locations-dialog.ui:91
+msgid "Bookmarks"
+msgstr "Legosignoj"
+
+#: panels/search/cc-search-locations-dialog.ui:156
+msgid "Other"
+msgstr "Alia"
+
+#: panels/search/cc-search-panel.c:152
+msgid "No applications found"
+msgstr "Neniuj aplikaĵoj trovitaj"
+
+#: panels/search/cc-search-panel-row.ui:92
+msgid "Move Up"
+msgstr "Movi supren"
+
+#: panels/search/cc-search-panel-row.ui:102
+msgid "Move Down"
+msgstr "Movi malsupren"
+
+#: panels/search/cc-search-panel.ui:31
+msgid ""
+"Control which search results are shown in the Activities Overview. The order "
+"of search results can also be changed by moving rows in the list."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Difini por kiuj aplikaĵoj montri serĉajn rezultojn en la Aktivecoj-"
+"Superrigardo"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Serĉi;Trovi;Indeksi;Kaŝi;Privateco;Rezultoj;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:306
+msgid "No networks selected for sharing"
+msgstr "Neniuj retoj estas elektitaj por kunhavigado"
+
+#: panels/sharing/cc-sharing-networks.ui:19
+msgid "Networks"
+msgstr "Retoj"
+
+#: panels/sharing/cc-sharing-panel.c:289
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Ŝaltita"
+
+#: panels/sharing/cc-sharing-panel.c:291 panels/sharing/cc-sharing-panel.c:318
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Malŝaltita"
+
+#: panels/sharing/cc-sharing-panel.c:321
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Ŝaltita"
+
+#: panels/sharing/cc-sharing-panel.c:324
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktiva"
+
+#: panels/sharing/cc-sharing-panel.c:393
+msgid "Choose a Folder"
+msgstr "Elektu dosierujon"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:696
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Dosier-kunhavigado permesas al vi kunhavigi vian Publikan dosieron kun aliaj "
+"ĉe via ĉimomenta reto uzante: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:702
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Kiam defora salutado estas ŝaltita, deforaj uzantoj povas konekti uzante la "
+"sekuran ŝelan komando:\n"
+"%s"
+
+#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:708
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to %s"
+msgstr ""
+"Ekran-kunhavigado permesas al deforaj uzantoj vidi aŭ regi vian ekranon per "
+"konekti al %s"
+
+#: panels/sharing/cc-sharing-panel.c:813
+msgid "Copy"
+msgstr "Kopii"
+
+#: panels/sharing/cc-sharing-panel.c:1203
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Kunhavigo"
+
+#: panels/sharing/cc-sharing-panel.ui:32
+msgid "_Computer Name"
+msgstr "_Komputila nomo"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_File Sharing"
+msgstr "_Dosier-kunhavigado"
+
+#: panels/sharing/cc-sharing-panel.ui:87
+msgid "_Screen Sharing"
+msgstr "_Ekran-kunhavigado"
+
+#: panels/sharing/cc-sharing-panel.ui:95
+msgid "_Media Sharing"
+msgstr "_Aŭdovid-kunhavigado"
+
+#: panels/sharing/cc-sharing-panel.ui:103
+msgid "_Remote Login"
+msgstr "_Defora salutado"
+
+#: panels/sharing/cc-sharing-panel.ui:119
+msgid "Some services are disabled because of no network access."
+msgstr "Kelkaj servoj estas malŝaltitaj pro manko de retaliro."
+
+#: panels/sharing/cc-sharing-panel.ui:137
+#: panels/sharing/cc-sharing-panel.ui:264
+msgid "File Sharing"
+msgstr "Dosier-kunhavigado"
+
+#: panels/sharing/cc-sharing-panel.ui:184
+msgid "_Require Password"
+msgstr "_Bezonas pasvorton"
+
+#: panels/sharing/cc-sharing-panel.ui:275
+#: panels/sharing/cc-sharing-panel.ui:345
+msgid "Remote Login"
+msgstr "Defora salutado"
+
+#: panels/sharing/cc-sharing-panel.ui:368
+#: panels/sharing/cc-sharing-panel.ui:590
+msgid "Screen Sharing"
+msgstr "Ekran-kunhavigado"
+
+#: panels/sharing/cc-sharing-panel.ui:422
+msgid "_Allow connections to control the screen"
+msgstr "_Permesi al konektoj regi la ekranon"
+
+#: panels/sharing/cc-sharing-panel.ui:447
+msgid "_Password:"
+msgstr "_Pasvorto:"
+
+#: panels/sharing/cc-sharing-panel.ui:477
+msgid "_Show Password"
+msgstr "_Montri pasvorton"
+
+#: panels/sharing/cc-sharing-panel.ui:508
+msgid "Access Options"
+msgstr "Aliro-agordoj"
+
+#: panels/sharing/cc-sharing-panel.ui:522
+msgid "_New connections must ask for access"
+msgstr "_Novaj konektoj devas peti aliron"
+
+#: panels/sharing/cc-sharing-panel.ui:540
+msgid "_Require a password"
+msgstr "_Bezonas pasvorton"
+
+#: panels/sharing/cc-sharing-panel.ui:601
+#: panels/sharing/cc-sharing-panel.ui:695
+msgid "Media Sharing"
+msgstr "Aŭdovid-kunhavigado"
+
+#: panels/sharing/cc-sharing-panel.ui:634
+msgid "Share music, photos and videos over the network."
+msgstr "Kunhavigi muzikon, fotojn kaj videojn sur la reto."
+
+#: panels/sharing/cc-sharing-panel.ui:649
+msgid "Folders"
+msgstr "Dosierujoj"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Regi kion vi volas kunhavigi kun aliaj"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"kunhavigi;kunhavigado;sekurŝelo;ssu;gastigo;nomo;fora;defora;labortablo;"
+"medio;aŭdo;vido;video;filmoj;aŭdovida;bildoj;fotoj;kinofilmoj;servilo;"
+"bildigilo;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Ŝalti aŭ malŝalti deforan salutadon"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Aŭtentigo necesas por ŝalti aŭ malŝalti deforan salutadon"
+
+#: panels/sound/cc-alert-chooser.c:151
+msgid "Custom"
+msgstr "Propra"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr "Bojo"
+
+#: panels/sound/cc-alert-chooser.ui:19
+msgid "Drip"
+msgstr "Guto"
+
+#: panels/sound/cc-alert-chooser.ui:26
+msgid "Glass"
+msgstr "Vitro"
+
+#: panels/sound/cc-alert-chooser.ui:33
+msgid "Sonar"
+msgstr "Sonaro"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "Malantaŭa"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "Antaŭa"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Testante %s"
+
+#: panels/sound/cc-output-test-dialog.ui:127
+msgid "Click a speaker to test"
+msgstr "Alklaku laŭtparolilon por testi"
+
+#: panels/sound/cc-sound-panel.ui:27
+msgid "System Volume"
+msgstr "Sistemlaŭteco"
+
+#: panels/sound/cc-sound-panel.ui:43
+msgid "Volume Levels"
+msgstr "Laŭtecaj niveloj"
+
+#: panels/sound/cc-sound-panel.ui:65
+msgid "Output"
+msgstr "Eligo"
+
+#: panels/sound/cc-sound-panel.ui:92
+msgid "Output Device"
+msgstr "Eliga aparato"
+
+#: panels/sound/cc-sound-panel.ui:115
+msgid "Test"
+msgstr "Testi"
+
+#: panels/sound/cc-sound-panel.ui:146 panels/sound/cc-sound-panel.ui:323
+msgid "Configuration"
+msgstr "Agordoj"
+
+#: panels/sound/cc-sound-panel.ui:179
+msgid "Balance"
+msgstr "Ekvilibro"
+
+#: panels/sound/cc-sound-panel.ui:206
+msgid "Fade"
+msgstr "Dissolvo"
+
+#: panels/sound/cc-sound-panel.ui:233
+msgid "Subwoofer"
+msgstr "Bas-laŭtparolilo"
+
+#: panels/sound/cc-sound-panel.ui:255
+msgid "Input"
+msgstr "Enigo"
+
+#: panels/sound/cc-sound-panel.ui:282
+msgid "Input Device"
+msgstr "Eniga aparato"
+
+#: panels/sound/cc-sound-panel.ui:356
+msgid "Volume"
+msgstr "Laŭteco"
+
+#: panels/sound/cc-sound-panel.ui:378
+msgid "Alert Sound"
+msgstr "Laŭteco por avertoj"
+
+#: panels/sound/cc-volume-slider.c:117
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Sono"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Ŝanĝi sonan laŭtecon, enigojn, eligojn, kaj avertajn sonojn"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Karto;Mikrofono;Laŭteco;Dissolvo;Ekvilibro;Bludento;Kapaŭskultilo;Sono;Enigo;"
+"Eliro;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:94
+#: panels/thunderbolt/cc-bolt-device-entry.c:125
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Malkonektita"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:97
+#: panels/thunderbolt/cc-bolt-device-entry.c:128
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Konektante"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:100
+#: panels/thunderbolt/cc-bolt-device-entry.c:132
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Konektita"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:103
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Aŭtentiga eraro"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:106
+#: panels/thunderbolt/cc-bolt-device-entry.c:138
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Aŭtentigante"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Malpliigita funkciado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:115
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Konektita & aŭtentigita"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:121
+#: panels/thunderbolt/cc-bolt-device-entry.c:152
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Nekonata"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:177
+msgid "Authorized at:"
+msgstr "Aŭtentigita je:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:183
+msgid "Connected at:"
+msgstr "Konektita je:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:190
+msgid "Enrolled at:"
+msgstr "Aligita je:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:264
+msgid "Failed to authorize device: "
+msgstr "Malsukcesis aŭtentigi aparaton: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:333
+msgid "Failed to forget device: "
+msgstr "Malsukcesis forgesi aparaton: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Dependas je %u alia aparato"
+msgstr[1] "Dependas je %u aliaj aparatoj"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+msgid "Name:"
+msgstr "Nomo:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "Status:"
+msgstr "Stato:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+msgid "Authorize and Connect"
+msgstr "Aŭtentigi kaj konekti"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+msgid "Forget Device"
+msgstr "Forgesi aparaton"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:135
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Eraro"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:146
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Aŭtentigita"
+
+#: panels/thunderbolt/cc-bolt-panel.c:175
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"La Thunderbolt subsistemo (boltd) ne estas instalita aŭ ne estas ĝuste "
+"agordigita."
+
+#: panels/thunderbolt/cc-bolt-panel.c:468
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Ne povis trovi Thunderbolt.\n"
+"Aŭ la sistemo malhavas Thunderbolt subtenon, aŭ la subteno estas malŝaltita "
+"en la BIOS, aŭ ĝi estas agordita je nesubtenita sekureca nivelo en la BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:512
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt subteno estas malŝaltita en la BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:516
+msgid "Thunderbolt security level could not be determined."
+msgstr "Ne eblis difini Thunderbolt sekurecan nivelon."
+
+#: panels/thunderbolt/cc-bolt-panel.c:621
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Eraro dum ŝanĝi direktan reĝimon: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:143
+msgid "No Thunderbolt support"
+msgstr "Neniu Thunderbolt subteno"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:246
+msgid "Direct Access"
+msgstr "Rekta atingo"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:269
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Permeti rektan atingon al aparatoj kiel dokoj kaj eksteraj vidkartoj."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:289
+msgid "Only USB and Display Port devices can attach."
+msgstr "Nur USB kaj Display Port aparatoj povas alfiksi."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:397
+msgid "Pending Devices"
+msgstr "Atendantaj aparatoj"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:535
+msgid "No devices attached"
+msgstr "Neniu aparatoj estas alfiksitaj"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Mastrumi Thunderbolt aparatojn"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privateco;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:7
+msgid "Cursor Blinking"
+msgstr "Pulsanta tajpmontrilo"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:37
+msgid "Cursor blinks in text fields."
+msgstr "Tajpmontrilo pulsas en tekstkampo."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:74
+#: panels/universal-access/cc-repeat-keys-dialog.ui:145
+msgid "Speed"
+msgstr "Rapideco"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:101
+msgid "Cursor blinking speed"
+msgstr "Tajpmontrila pulsrapideco"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:7
+msgid "Cursor Size"
+msgstr "Grando de musmontrilo"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:29
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Grando de musmontrilo povas esti kombinita kun zomo por plifaciligi vidadon "
+"de musmontrilon."
+
+#: panels/universal-access/cc-pointing-dialog.ui:7
+msgid "Click Assist"
+msgstr "Alklaka asisto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:43
+msgid "_Simulated Secondary Click"
+msgstr "_Simulita duaranĝa alklako"
+
+#: panels/universal-access/cc-pointing-dialog.ui:56
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Fari duaranĝan alklakon per premteni la ĉefa butono"
+
+#: panels/universal-access/cc-pointing-dialog.ui:79
+#: panels/universal-access/cc-typing-dialog.ui:158
+#: panels/universal-access/cc-typing-dialog.ui:307
+msgid "A_cceptance delay:"
+msgstr "Antaŭak_cepta prokrasto:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:95
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Mallonga"
+
+#: panels/universal-access/cc-pointing-dialog.ui:110
+msgid "Secondary click delay"
+msgstr "Duaranĝa-alklaka prokrasto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:120
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Longa"
+
+#: panels/universal-access/cc-pointing-dialog.ui:157
+msgid "_Hover Click"
+msgstr "Ŝ_veba alklako"
+
+#: panels/universal-access/cc-pointing-dialog.ui:170
+msgid "Trigger a click when the pointer hovers"
+msgstr "Fari alklakon kiam la musmontrilo ŝvebas"
+
+#: panels/universal-access/cc-pointing-dialog.ui:193
+msgid "D_elay:"
+msgstr "_Prokrasto:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:210
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Mallonga"
+
+#: panels/universal-access/cc-pointing-dialog.ui:232
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Longa"
+
+#: panels/universal-access/cc-pointing-dialog.ui:253
+msgid "Motion _threshold:"
+msgstr "_Mov-sojlo:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:270
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Malgranda"
+
+#: panels/universal-access/cc-pointing-dialog.ui:292
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Granda"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:7
+msgid "Repeat Keys"
+msgstr "Ripeti klavojn"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:37
+msgid "Key presses repeat when key is held down."
+msgstr "Klavpremoj ripetas kiam klavo estas tenata malsupre."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:102
+msgid "Repeat keys delay"
+msgstr "Ripetklava prokrasto"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:174
+msgid "Repeat keys speed"
+msgstr "Ripetklava rapido"
+
+#: panels/universal-access/cc-sound-keys-dialog.ui:7
+msgid "Sound Keys"
+msgstr "Son-klavoj"
+
+#: panels/universal-access/cc-sound-keys-dialog.ui:25
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pepi kiam majuskla kaj nombra baskuloj estas ŝaltita aŭ malŝaltita."
+
+#: panels/universal-access/cc-sound-keys-dialog.ui:45
+#: panels/universal-access/cc-ua-panel.ui:374
+msgid "_Sound Keys"
+msgstr "_Son-klavoj"
+
+#: panels/universal-access/cc-screen-reader-dialog.ui:7
+msgid "Screen Reader"
+msgstr "Ekranlegilo"
+
+#: panels/universal-access/cc-screen-reader-dialog.ui:24
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "La ekranlegilo legas vidigan tekston, kiun vi fokusas."
+
+#: panels/universal-access/cc-screen-reader-dialog.ui:52
+msgid "_Screen Reader"
+msgstr "_Ekranlegilo"
+
+#: panels/universal-access/cc-typing-dialog.ui:7
+msgid "Typing Assist"
+msgstr "Tajpada asisto"
+
+#: panels/universal-access/cc-typing-dialog.ui:46
+msgid "_Sticky Keys"
+msgstr "Fik_saj klavoj"
+
+#: panels/universal-access/cc-typing-dialog.ui:58
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Traktas sinsekvon de modifaj klavoj kiel klavkombino"
+
+#: panels/universal-access/cc-typing-dialog.ui:72
+msgid "_Disable if two keys are pressed together"
+msgstr "_Malŝalti se du klavoj estas kune premitaj"
+
+#: panels/universal-access/cc-typing-dialog.ui:85
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pepi se _modifa klavo estas premata"
+
+#: panels/universal-access/cc-typing-dialog.ui:123
+msgid "S_low Keys"
+msgstr "_Malrapidaj klavoj"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Enigas prokraston inter klavpremo kaj ties akcepto"
+
+#: panels/universal-access/cc-typing-dialog.ui:175
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Mallonga"
+
+#: panels/universal-access/cc-typing-dialog.ui:190
+msgid "Slow keys typing delay"
+msgstr "Malrapidklava tajpada prokrasto"
+
+#: panels/universal-access/cc-typing-dialog.ui:200
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Longa"
+
+#: panels/universal-access/cc-typing-dialog.ui:212
+msgid "Beep when a key is pr_essed"
+msgstr "Pepi se klavo estas pr_emata"
+
+#: panels/universal-access/cc-typing-dialog.ui:224
+msgid "Beep when a key is _accepted"
+msgstr "Pepi se klavo estas _akceptita"
+
+#: panels/universal-access/cc-typing-dialog.ui:236
+#: panels/universal-access/cc-typing-dialog.ui:361
+msgid "Beep when a key is _rejected"
+msgstr "Pepi kiam klavo estas malak_ceptita"
+
+#: panels/universal-access/cc-typing-dialog.ui:272
+msgid "_Bounce Keys"
+msgstr "_Saltaj klavoj"
+
+#: panels/universal-access/cc-typing-dialog.ui:284
+msgid "Ignores fast duplicate keypresses"
+msgstr "Malatenti rapidajn duoblajn klavpremojn"
+
+#: panels/universal-access/cc-typing-dialog.ui:324
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Mallonga"
+
+#: panels/universal-access/cc-typing-dialog.ui:339
+msgid "Bounce keys typing delay"
+msgstr "Saltklava tajpada prokrasto"
+
+#: panels/universal-access/cc-typing-dialog.ui:349
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Longa"
+
+#: panels/universal-access/cc-typing-dialog.ui:437
+msgid "_Enable by Keyboard"
+msgstr "Ŝalti p_er klavaro"
+
+#: panels/universal-access/cc-typing-dialog.ui:449
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Ŝalti kaj malŝalti funkciojn por universala aliro per la klavaro"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:348
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Implicita"
+
+#: panels/universal-access/cc-ua-panel.c:351
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Meza"
+
+#: panels/universal-access/cc-ua-panel.c:354
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Granda"
+
+#: panels/universal-access/cc-ua-panel.c:357
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Pli granda"
+
+#: panels/universal-access/cc-ua-panel.c:360
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Plej granda"
+
+#: panels/universal-access/cc-ua-panel.c:364
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d bildero"
+msgstr[1] "%d bilderoj"
+
+#: panels/universal-access/cc-ua-panel.ui:55
+msgid "_Always Show Accessibility Menu"
+msgstr "Ĉi_am montri la menuon de alirebleco"
+
+#: panels/universal-access/cc-ua-panel.ui:97
+msgid "Seeing"
+msgstr "Vidi"
+
+#: panels/universal-access/cc-ua-panel.ui:143
+msgid "_High Contrast"
+msgstr "_Alta kontrasto"
+
+#: panels/universal-access/cc-ua-panel.ui:190
+msgid "_Large Text"
+msgstr "_Granda teksto"
+
+#: panels/universal-access/cc-ua-panel.ui:235
+msgid "C_ursor Size"
+msgstr "_Grando de musmontrilo"
+
+#: panels/universal-access/cc-ua-panel.ui:282
+#: panels/universal-access/cc-zoom-options-dialog.ui:91
+msgid "_Zoom"
+msgstr "_Zomo"
+
+#: panels/universal-access/cc-ua-panel.ui:328
+msgid "Screen _Reader"
+msgstr "Ek_ranlegilo"
+
+#: panels/universal-access/cc-ua-panel.ui:436
+msgid "Hearing"
+msgstr "Aŭdado"
+
+#: panels/universal-access/cc-ua-panel.ui:480
+#: panels/universal-access/cc-visual-alerts-dialog.ui:68
+msgid "_Visual Alerts"
+msgstr "_Videblaj avertoj"
+
+#: panels/universal-access/cc-ua-panel.ui:588
+msgid "Screen _Keyboard"
+msgstr "Ekran_klavaro"
+
+#: panels/universal-access/cc-ua-panel.ui:633
+msgid "R_epeat Keys"
+msgstr "Rip_eti klavojn"
+
+#: panels/universal-access/cc-ua-panel.ui:679
+msgid "Cursor _Blinking"
+msgstr "_Pulsado de tajpmontrilo"
+
+#: panels/universal-access/cc-ua-panel.ui:725
+msgid "_Typing Assist (AccessX)"
+msgstr "_Tajpada asisto (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:786
+msgid "Pointing & Clicking"
+msgstr "Indiki & klaki"
+
+#: panels/universal-access/cc-ua-panel.ui:832
+msgid "_Mouse Keys"
+msgstr "_Musklavoj"
+
+#: panels/universal-access/cc-ua-panel.ui:877
+msgid "_Locate Pointer"
+msgstr "_Lokigi indikilon"
+
+#: panels/universal-access/cc-ua-panel.ui:909
+msgid "_Click Assist"
+msgstr "_Alklaka asisto"
+
+#: panels/universal-access/cc-ua-panel.ui:955
+msgid "_Double-Click Delay"
+msgstr "_Duobla-klaka prokrasto"
+
+#: panels/universal-access/cc-ua-panel.ui:975
+msgid "Double-Click Delay"
+msgstr "Duobla-klaka prokrasto"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:15
+msgid "Visual Alerts"
+msgstr "Vidaj avertoj"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:19
+msgid "_Test flash"
+msgstr "_Provi fulmadon"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:48
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Uzi vidan indikon kiam averta sono okazas."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:94
+msgid "Flash the entire _window"
+msgstr "Fulmi la tutan _fenestron"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:112
+msgid "Flash the entire _screen"
+msgstr "Fulmi la tutan _ekranon"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:303
+msgctxt "Distance"
+msgid "Short"
+msgstr "Mallonga"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:304
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ekrano"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:305
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ekrano"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ekrano"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "Long"
+msgstr "Longa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Plena ekrano"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Supra duono"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Malsupra duono"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Maldekstra duono"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Dekstra duono"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:70
+msgid "Zoom Options"
+msgstr "Zomagordoj"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:151
+msgid "_Magnification:"
+msgstr "_Pligrandigo:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:201
+msgid "_Follow mouse cursor"
+msgstr "_Sekvi musmontrilon"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:221
+msgid "_Screen part:"
+msgstr "_Parto de ekrano:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:278
+msgid "Magnifier _extends outside of screen"
+msgstr "Pligrandigilo _etendas ekster la ekranon"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:292
+msgid "_Keep magnifier cursor centered"
+msgstr "_Teni pligrandigilan musmontrilon en la centro"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:307
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Pligrandigila mustmontrilo _movas ĉirkaŭan enhavon"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:322
+msgid "Magnifier cursor moves with _contents"
+msgstr "Pligrandigila kursoro movas kune kun _enhavo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:347
+msgid "Magnifier Position:"
+msgstr "Pligrandigila pozicio:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:362
+msgid "Magnifier"
+msgstr "Pligrandigilo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:410
+msgid "_Thickness:"
+msgstr "_Dikeco:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:436
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Maldika"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:458
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Dika"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:479
+msgid "_Length:"
+msgstr "_Longo:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:523
+msgid "Co_lor:"
+msgstr "Ko_loro:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:577
+msgid "_Crosshairs:"
+msgstr "_Celiloj:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:610
+msgid "_Overlaps mouse cursor"
+msgstr "Surmetas musm_ontrilon"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:634
+msgid "Crosshairs"
+msgstr "Celiloj"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:683
+msgid "_White on black:"
+msgstr "_Blanko sur nigro:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:703
+msgid "_Brightness:"
+msgstr "_Heleco:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:724
+msgid "_Contrast:"
+msgstr "_Kontrasto:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:744
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Ko_loro"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:769
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Neniu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:791
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Plena"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:844
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Malalta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:867
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:893
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Malalta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:916
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:942
+msgid "Color Effects:"
+msgstr "Kolorefektoj:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:958
+msgid "Color Effects"
+msgstr "Kolorefektoj"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Fari ĝin pli facila por vidi, aŭdi, tajpi, fingromontri kaj alklaki"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;"
+msgstr ""
+"Klavaro;Muso;a11y;Alirebleco;Kontrasto;Zomi;Ekrano;Legilo;teksto;tiparo;"
+"grando;AccessX;Fiksaj;Klavoj;Salti;Muso;Duobla;klaki;alklaki;Malfruo;"
+"Prokrasto;Asisto;Helpo;Ripeti;Pulsi;vida;aŭda;tajpi;-"
+
+#: panels/usage/cc-usage-panel.c:154
+msgid "Empty all items from Trash?"
+msgstr "Ĉu vakigi ĉiujn erojn de la rubujo?"
+
+#: panels/usage/cc-usage-panel.c:155
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Ĉiuj eroj en la rubujo forigitos daŭre."
+
+#: panels/usage/cc-usage-panel.c:156
+msgid "_Empty Trash"
+msgstr "_Malplenigi rubujon"
+
+#: panels/usage/cc-usage-panel.c:177
+msgid "Delete all the temporary files?"
+msgstr "Ĉu forigi ĉiujn provizorajn dosierojn?"
+
+#: panels/usage/cc-usage-panel.c:178
+msgid "All the temporary files will be permanently deleted."
+msgstr "Ĉiuj provizoraj dosieroj forigitos daŭre."
+
+#: panels/usage/cc-usage-panel.c:179
+msgid "_Purge Temporary Files"
+msgstr "_Senrubigi provizorajn dosierojn"
+
+#: panels/usage/cc-usage-panel.ui:29
+msgid "File History"
+msgstr "Dosierhistorio"
+
+#: panels/usage/cc-usage-panel.ui:41
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Dosierhistorio tenas registron de dosieroj kiujn vi uzis. Aliaj aplikaĵoj "
+"povas atingi ĉi tiujn informojn, kaj ĉi tio helpas vin trovi tiujn dosierojn "
+"kiujn vi ŝatus uzi."
+
+#: panels/usage/cc-usage-panel.ui:56
+msgid "File H_istory"
+msgstr "Dosierh_istorio"
+
+#: panels/usage/cc-usage-panel.ui:78
+msgid "File _History Duration"
+msgstr "Daŭro de dosier_historio"
+
+#: panels/usage/cc-usage-panel.ui:119
+msgid "_Clear History…"
+msgstr "_Vakigi historion…"
+
+#: panels/usage/cc-usage-panel.ui:135
+msgid "Trash & Temporary Files"
+msgstr "Rubujo & provizoraj dosieroj"
+
+#: panels/usage/cc-usage-panel.ui:145
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:159
+msgid "Automatically Delete _Trash Content"
+msgstr "Aŭtomate forigi _rubaĵojn"
+
+#: panels/usage/cc-usage-panel.ui:174
+msgid "Automatically Delete Temporary _Files"
+msgstr "Aŭtomate forigi provizorajn _dosierojn"
+
+#: panels/usage/cc-usage-panel.ui:196
+#, fuzzy
+#| msgid "Automatically empty _Trash"
+msgid "Automatically Delete _Period"
+msgstr "Aŭtomate malplenigi _rubujon"
+
+#: panels/usage/cc-usage-panel.ui:238
+msgid "_Empty Trash…"
+msgstr "_Malplenigi rubujon…"
+
+#: panels/usage/cc-usage-panel.ui:250
+msgid "_Delete Temporary Files…"
+msgstr "Forigi _provizorajn dosierojn…"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:278
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 horo"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:282
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 tago"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:286
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 tagoj"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:290
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 tagoj"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:294
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 tagoj"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:298
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 tagoj"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:302
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 tagoj"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:306
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 tagoj"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:310
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 tagoj"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:314
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 tagoj"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:329
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 tago"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:333
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 tagoj"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:337
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 tagoj"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:341
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Por ĉiam"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Dosierhistorio & rubujo"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Ne lasi ŝpurojn"
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "Devus akordi al la retadredo de via salut-provizanto."
+
+#: panels/user-accounts/cc-add-user-dialog.c:204
+msgid "Failed to add account"
+msgstr "Malsukcesis aldoni konton"
+
+#: panels/user-accounts/cc-add-user-dialog.c:661
+#: panels/user-accounts/cc-password-dialog.c:261
+msgid "The passwords do not match."
+msgstr "La pasvortoj ne kongruas."
+
+#: panels/user-accounts/cc-add-user-dialog.c:875
+#: panels/user-accounts/cc-add-user-dialog.c:914
+#: panels/user-accounts/cc-add-user-dialog.c:932
+msgid "Failed to register account"
+msgstr "Malsukcesis registri konton"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1047
+msgid "No supported way to authenticate with this domain"
+msgstr "Ne valida maniero por aŭtentigi per tiu ĉi domajno"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1111
+msgid "Failed to join domain"
+msgstr "Malsukcesis aliĝi al domajno"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1166
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Tiu salutnomo ne funkciis.\n"
+"Bonvolu provi denove."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1173
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Tiu salut-pasvorto ne funkciis.\n"
+"Bonvolu provi denove."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid "Failed to log into domain"
+msgstr "Malsukcesis salutado en domajno"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1236
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Ne eblas trovi la domajnon. Ĉu vi eble misliterumis ĝin?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "Aldoni uzanton"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:180
+msgid "_Full Name"
+msgstr "_Tuta nomo"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:206
+msgid "Standard"
+msgstr "Norma"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:216
+msgid "Administrator"
+msgstr "Administranto"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:232
+msgid "Account _Type"
+msgstr "Konto_speco"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:269
+msgid "Allow user to set a password when they next _login"
+msgstr "Permesi al uzanto agordi pasvorton kiam ri venonte _salutas"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:283
+msgid "Set a password _now"
+msgstr "Agordi pasvorton _nun"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:405
+msgid "_Confirm"
+msgstr "_Konfirmi"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:485
+#: panels/user-accounts/cc-add-user-dialog.ui:692
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Entreprena salutado permesas uzadon de ekzistanta, centre mastrumata "
+"uzantokonto sur ĉi tiu aparato. Vi povas ankaŭ uzi tiun konto por aliri "
+"firmaajn risurcojn sur la interreto."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:732
+msgid "You are Offline"
+msgstr "Vi estas nekonektite"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:751
+msgid "You must be online in order to add enterprise users."
+msgstr "Vi devas esti konektite por aldoni entreprenajn uzantojn."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:782
+msgid "_Enterprise Login"
+msgstr "_Entreprena salutado"
+
+#: panels/user-accounts/cc-avatar-chooser.c:220
+msgid "Browse for more pictures"
+msgstr "Foliumi por pliaj bildoj"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:39
+msgid "Take a Picture…"
+msgstr "Fari foton…"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:46
+msgid "Select a File…"
+msgstr "Elekti dosieron…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Fingropremo-mastrumilo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:23
+msgid "Fingerprint"
+msgstr "Fingropremo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:118
+msgid "_No"
+msgstr "_Ne"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:128
+msgid "_Yes"
+msgstr "_Jes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:155
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Ĉu vi volas forigi viajn registritajn fingropremojn tiel, ke fingroprema "
+"salutado estas malŝaltita?"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid "No Fingerprint device"
+msgstr "Neniu fingroprema aparato"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:259
+msgid "Ensure the device is properly connected."
+msgstr "Certigu ke la aparato estas konektita."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:264
+msgid "No fingerprint device"
+msgstr "Neniu fingroprema aparato"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:280
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Elektu la fingropreman aparaton kiun vi uzas agordi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:309
+msgid "Fingerprint Device"
+msgstr "Fingroprema aparato"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:322
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Fingroprema salutado permesas al vi malŝlosi kaj saluti je via komputilo per "
+"via fingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:352
+msgid "_Delete Fingerprints"
+msgstr "_Forigi fingropremojn"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:363
+msgid "Fingerprint Login"
+msgstr "Fingroprema salutado"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:412
+msgid "Fingerprint Enroll"
+msgstr "Enigo de fingropremo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:436
+msgid "_Re-enroll this finger…"
+msgstr "_Re-enigu ĉi tiun fingron…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:236
+#, fuzzy
+#| msgid "_Double-click titlebar to perform this action:"
+msgid "the device needs to be claimed to perform this action"
+msgstr "_Duoble alklaki titolbreton por plenumi ĉi tiun agon:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:238
+#, fuzzy
+#| msgid "The device is already in use."
+msgid "the device is already claimed by another process"
+msgstr "La aparato jam estas uzata."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:240
+msgid "you do not have permission to perform the action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:242
+msgid "no prints have been enrolled"
+msgstr "eniĝis neniu fingropremo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:251
+#, fuzzy
+#| msgid "Failed to register with the requested network"
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Registriĝo por la petita reto malsukcesis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:255
+#, fuzzy
+#| msgid "Could not access any fingerprint readers"
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Ne eblis aliri al iu fingropremlegilo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:257
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:585
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Malsukcesis listigi fingropremojn: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:652
+#, fuzzy, c-format
+#| msgid "Failed to delete user"
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Malsukcesis forigi uzanton"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:683
+msgid "Left thumb"
+msgstr "Maldekstra dikfingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:685
+msgid "Left middle finger"
+msgstr "Maldeksta mezfingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:687
+msgid "_Left index finger"
+msgstr "_Maldekstra montrofingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:689
+msgid "Left ring finger"
+msgstr "Maldeksta ringfingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:691
+msgid "Left little finger"
+msgstr "Maldeksta etfingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:693
+msgid "Right thumb"
+msgstr "Dekstra dikfingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:695
+msgid "Right middle finger"
+msgstr "Deksta mezfingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:697
+msgid "_Right index finger"
+msgstr "_Deksta montrofingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:699
+msgid "Right ring finger"
+msgstr "Deksta ringfingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:701
+msgid "Right little finger"
+msgstr "Deksta etfingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:703
+msgid "Unknown Finger"
+msgstr "Nekonata fingro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:837
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Plenumita"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:848
+#, fuzzy
+#| msgid "PPP service disconnected"
+msgid "Fingerprint device disconnected"
+msgstr "PPP-servilo malkonektis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:854
+msgid "Fingerprint device storage is full"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:858
+#, fuzzy
+#| msgid "Failed to add new printer."
+msgid "Failed to enroll new fingerprint"
+msgstr "Aldono de nova presilo malsukcesis."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:889
+#, fuzzy, c-format
+#| msgid "Failed to start Sound Preferences: %s"
+msgid "Failed to start enrollment: %s"
+msgstr "Startado de sonagordoj malsukcesis: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:897
+#, fuzzy
+#| msgid "Failed to add new printer."
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Aldono de nova presilo malsukcesis."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+#, fuzzy, c-format
+#| msgid "Failed to start Sound Preferences: %s"
+msgid "Failed to stop enrollment: %s"
+msgstr "Startado de sonagordoj malsukcesis: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:974
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1118
+#, fuzzy
+#| msgid "Enrolling fingerprints"
+msgid "Scan new fingerprint"
+msgstr "Konservante fingropremojn"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1157
+#, fuzzy, c-format
+#| msgid "Failed to forget device: "
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Malsukcesis forgesi aparaton: "
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1229
+#, fuzzy
+#| msgid "Pending Devices"
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Atendantaj aparatoj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1264
+#, fuzzy, c-format
+#| msgid "Failed to forget device: "
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Malsukcesis forgesi aparaton: "
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1413
+#, fuzzy, c-format
+#| msgid "Failed to forget device: "
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Malsukcesis forgesi aparaton: "
+
+#: panels/user-accounts/cc-login-history-dialog.c:69
+msgid "This Week"
+msgstr "Ĉi tiu semajno"
+
+#: panels/user-accounts/cc-login-history-dialog.c:72
+msgid "Last Week"
+msgstr "Pasinta semajno"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:82
+#: panels/user-accounts/cc-login-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%-e-a de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:91
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%-e-a de %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:96
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:173
+#: panels/user-accounts/cc-user-panel.c:766
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:176
+#: panels/user-accounts/cc-user-panel.c:770
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:243
+msgid "Session Ended"
+msgstr "Seanco finis"
+
+#: panels/user-accounts/cc-login-history-dialog.c:249
+msgid "Session Started"
+msgstr "Seanco komencis"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:343
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Aktiveco de konto"
+
+#: panels/user-accounts/cc-password-dialog.c:125
+msgid "Please choose another password."
+msgstr "Bonvole elektu alian pasvorton."
+
+#: panels/user-accounts/cc-password-dialog.c:134
+msgid "Please type your current password again."
+msgstr "Bonvolu tajpi vian aktualan pasvorton denove."
+
+#: panels/user-accounts/cc-password-dialog.c:140
+msgid "Password could not be changed"
+msgstr "Ne eblis ŝanĝi pasvorton"
+
+#: panels/user-accounts/cc-password-dialog.ui:7
+msgid "Change Password"
+msgstr "Ŝanĝi pasvorton"
+
+#: panels/user-accounts/cc-password-dialog.ui:37
+msgid "Ch_ange"
+msgstr "Ŝ_anĝi"
+
+#: panels/user-accounts/cc-password-dialog.ui:145
+msgid "_Confirm New Password"
+msgstr "_Konfirmi novan pasvorton"
+
+#: panels/user-accounts/cc-password-dialog.ui:162
+msgid "_New Password"
+msgstr "_Nova pasvorto"
+
+#: panels/user-accounts/cc-password-dialog.ui:216
+msgid "Current _Password"
+msgstr "Nuna _pasvorto"
+
+#: panels/user-accounts/cc-password-dialog.ui:254
+msgid "Allow user to change their password on next login"
+msgstr "Permesi al uzanto ŝanĝi rian pasvorton dum venontan salutadon"
+
+#: panels/user-accounts/cc-password-dialog.ui:267
+msgid "Set a password now"
+msgstr "Agordi pasvorton nun"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Ne povas aŭtomate aliĝi al ĉi tiu domajnspeco"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Ne trovis tian domajnon aŭ regnon"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Ne eblas saluti kiel %s en la %s domajno"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Nevalida pasvorto, bonvolu provi denove"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Ne eblis koneti al la %s domajno: %s"
+
+#: panels/user-accounts/cc-user-panel.c:222
+msgid "Your account"
+msgstr "Via konto"
+
+#: panels/user-accounts/cc-user-panel.c:397
+msgid "Failed to delete user"
+msgstr "Malsukcesis forigi uzanton"
+
+#: panels/user-accounts/cc-user-panel.c:452
+#: panels/user-accounts/cc-user-panel.c:507
+#: panels/user-accounts/cc-user-panel.c:553
+msgid "Failed to revoke remotely managed user"
+msgstr "Malsukcesis senvalidigi defore mastrumitan uzanton"
+
+#: panels/user-accounts/cc-user-panel.c:602
+msgid "You cannot delete your own account."
+msgstr "Vi ne povas forigi vian propran konton."
+
+#: panels/user-accounts/cc-user-panel.c:611
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s jam estas salutite"
+
+#: panels/user-accounts/cc-user-panel.c:615
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"La forigo de uzanto kiu estas ankoraŭ salutita, povas rezulti en "
+"nekonsekvencan sistemon."
+
+#: panels/user-accounts/cc-user-panel.c:624
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Ĉu vi volas teni la dosierojn de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:628
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Eblas teni la hejmdosierujon, retpoŝtmandrenon kaj provizorajn dosierojn "
+"ĉirkaŭe dum forigante uzantkonton."
+
+#: panels/user-accounts/cc-user-panel.c:631
+msgid "_Delete Files"
+msgstr "_Forigi dosierojn"
+
+#: panels/user-accounts/cc-user-panel.c:632
+msgid "_Keep Files"
+msgstr "_Konservi dosierojn"
+
+#: panels/user-accounts/cc-user-panel.c:646
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Ĉu vi certe volas senvalidigi la defore mastrumita konto de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:650
+msgid "_Delete"
+msgstr "_Forigi"
+
+#: panels/user-accounts/cc-user-panel.c:700
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Konto estas malŝaltita"
+
+#: panels/user-accounts/cc-user-panel.c:708
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Agordota dum venonta salutado"
+
+#: panels/user-accounts/cc-user-panel.c:711
+msgctxt "Password mode"
+msgid "None"
+msgstr "Neniu"
+
+#: panels/user-accounts/cc-user-panel.c:754
+msgid "Logged in"
+msgstr "Salutita"
+
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:841
+#: panels/user-accounts/cc-user-panel.c:935
+msgid "Enabled"
+msgstr "Ŝaltita"
+
+#: panels/user-accounts/cc-user-panel.c:1254
+msgid "Failed to contact the accounts service"
+msgstr "Malsukcesis konekti la kontoservon"
+
+#: panels/user-accounts/cc-user-panel.c:1256
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Bonvolu certigi ke la AccountService estas instalita kaj ŝaltita."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/cc-user-panel.c:1288
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Por fari ŝanĝojn,\n"
+"alklaku unue la *-piktogramon"
+
+#: panels/user-accounts/cc-user-panel.c:1361
+msgid "Delete the selected user account"
+msgstr "Forigi la elektitan uzantkonton"
+
+#: panels/user-accounts/cc-user-panel.c:1373
+#: panels/user-accounts/cc-user-panel.c:1492
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Por forigi la elektitan uzantkonton,\n"
+"klaku unue la *-piktogramon"
+
+#: panels/user-accounts/cc-user-panel.c:1545
+#, fuzzy
+#| msgid "Unlock to Change Settings"
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Malŝlosi por ŝanĝi agordojn"
+
+#: panels/user-accounts/cc-user-panel.ui:6
+msgid "_Add User…"
+msgstr "_Aldoni uzanton…"
+
+#: panels/user-accounts/cc-user-panel.ui:9
+msgid "Create a user account"
+msgstr "Krei uzantkonton"
+
+#: panels/user-accounts/cc-user-panel.ui:64
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Via seanco devas esti restartigita por ke la ŝanĝoj efektiviĝas"
+
+#: panels/user-accounts/cc-user-panel.ui:72
+msgid "Restart Now"
+msgstr "Restarti nun"
+
+#: panels/user-accounts/cc-user-panel.ui:153
+#: panels/user-accounts/cc-user-panel.ui:169
+msgid "User Icon"
+msgstr "Uzanta bildsimbolo"
+
+#: panels/user-accounts/cc-user-panel.ui:245
+msgid "Account Settings"
+msgstr "Kontaj agordoj"
+
+#: panels/user-accounts/cc-user-panel.ui:272
+msgid "_Administrator"
+msgstr "_Administranto"
+
+#: panels/user-accounts/cc-user-panel.ui:301
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administrantoj povas aldoni kaj forigi aliajn uzantojn, kaj povas ŝanĝi "
+"agordojn por ĉiuj uzantoj."
+
+#: panels/user-accounts/cc-user-panel.ui:333
+msgid "_Parental Controls"
+msgstr "Ge_patraj kontroliloj"
+
+#: panels/user-accounts/cc-user-panel.ui:377
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:452
+msgid "Authentication & Login"
+msgstr "Aŭtentigo & saluto"
+
+#: panels/user-accounts/cc-user-panel.ui:521
+msgid "_Fingerprint Login"
+msgstr "_Fingroprema salutado"
+
+#: panels/user-accounts/cc-user-panel.ui:563
+msgid "A_utomatic Login"
+msgstr "_Aŭtomata salutado"
+
+#: panels/user-accounts/cc-user-panel.ui:593
+msgid "Account Activity"
+msgstr "Aktiveco de konto"
+
+#: panels/user-accounts/cc-user-panel.ui:634
+msgid "Remove User…"
+msgstr "Forigi uzanton…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:673
+msgid "No Users Found"
+msgstr "Neniuj uzantoj estas trovitaj"
+
+#: panels/user-accounts/cc-user-panel.ui:683
+msgid "Unlock to add a user account."
+msgstr "Malŝlosi por krei uzantokonton."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Uzantoj"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Aldoni aŭ forigi uzantojn kaj ŝanĝi vian pasvorton"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Salutado;Nomo;Fingropremo;Avataro;Logobildo;Vizaĵo;Pasvorto;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr "_Aligi"
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "Salutado de domajna administranto"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Por uzi entreprenan salutadon, ĉi tiu komputilo devas esti\n"
+"aligita en la domajno. Bonvolu igi vian retadministranton\n"
+"tajpi rian domajnpasvorton ĉi tie."
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "Administranto-_nomo"
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "Administranto-pasvorto"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Mastrumi uzanto-kontojn"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Aŭtentigo necesas por ŝanĝi uzanto-datumojn"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "La nova pasvorta devas esti malsama al la malnova."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Provu ŝanĝi kelkajn leterojn kaj nombrojn."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Provu ŝanĝi la pasvorton iom pli."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Pasvorto sen via uzantonomo estus pli forta."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Klopodu eviti vian uzantonomon en la pasvorto."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Klopodu eviti kelkajn vortojn, jam inkluditaj en la pasvorto."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Klopodu eviti komunajn vortojn."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Klopodu eviti reordon de jamaj vortoj."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Klopodu uzi pli da ciferoj."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Klopodu uzi pli da majusklaj literoj."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Klopodu uzi pli da minusklaj literoj."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Klopodu uzi pli da specialaj signoj, kiel interpunkcio."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Klopodu uzi kunmeton de literoj, ciferoj kaj interpunkcio."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Klopodu eviti ripeto de la sama signo."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Klopodu eviti ripeto de la sama signo: vi kunmetu literojn, ciferojn kaj "
+"interpunkcion."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Klopodu eviti sekvencojn kiel 1234 aŭ abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Pasvorto devas esti pli longa. Klopodu aldoni pli da literoj, ciferoj kaj "
+"interpunkcioj."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Kunmetu majusklojn kaj minusklojn, kaj uzu almenaŭ unu ciferon."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Aldonado de pli da literoj, ciferoj kaj interpunkcio plifortigos la "
+"pasvorton."
+
+#: panels/user-accounts/run-passwd.c:413
+msgid "Authentication failed"
+msgstr "Aŭtentigo malsukcesis"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The new password is too short"
+msgstr "La pasvorto estas tro mallonga"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password is too simple"
+msgstr "La pasvorto estas tro simpla"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "La malnova kaj nova pasvortoj tro similaj"
+
+#: panels/user-accounts/run-passwd.c:507
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "La nova pasvorto jam estis uzata."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "La nova pasvorto devas enhavi ciferajn aŭ specialan signojn"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "La malnova kaj nova pasvortoj estas identaj"
+
+#: panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Via pasvorto estas ŝanĝita ekde kiam vi unuafoje aŭtentiĝis!"
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "La nova pasvorto ne enhavas sufiĉe da diversaj signoj"
+
+#: panels/user-accounts/run-passwd.c:526
+#, c-format
+msgid "Unknown error"
+msgstr "Nekonata eraro"
+
+#: panels/user-accounts/user-utils.c:432
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"La uzantonomo rajtas nur konsisti el minusklaj literoj de a-z, ciferoj, kaj "
+"la jenaj signoj: . - _"
+
+#: panels/user-accounts/user-utils.c:436
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Pardonon, tiu uzantonomo ne estas disponebla. Bonvolu klopodi alian."
+
+#: panels/user-accounts/user-utils.c:478
+msgid "The username is too long."
+msgstr "La uzantonomo estas tro longa."
+
+#: panels/user-accounts/user-utils.c:537
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr "Tiu ĉi nomos vian hejmdosierujon kaj oni ne povas ŝanĝi ĝin."
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr "Mapobutonoj"
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "_Fermi"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr "Mapi butonojn al funkcioj"
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Por redakti klavkombinon, elektu la “Sendi klavofrapon” agon, premu la "
+"klavkombina butono, kaj premu la novajn klavojn, aŭ premu la retropaŝan "
+"klavon por vakigi."
+
+#: panels/wacom/calibrator/calibrator.ui:61
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Bonvolu bateti la celajn indikilojn kiam ili aperas sur la ekrano por "
+"laŭnormigi la tabulkomputilo."
+
+#: panels/wacom/calibrator/calibrator.ui:78
+msgid "Mis-click detected, restarting…"
+msgstr "Misalklako dekektita, restartante…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Butono %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplikaĵo definita"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Sendi klavofrapon"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Ŝanĝi ekranon"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Montri ekranhelpon"
+
+#: panels/wacom/cc-wacom-mapping-panel.c:245
+msgid "Output:"
+msgstr "Eligo:"
+
+# Mi supozas, ke "letterbox" signifas "horizontala orientiĝo". --Carmen
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:257
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Teni proporcion (pejzaĝo):"
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:268
+msgid "Map to single monitor"
+msgstr "Mapi al unuobla ekrano"
+
+#: panels/wacom/cc-wacom-nav-button.c:84
+#, c-format
+msgid "%d of %d"
+msgstr "%d de %d"
+
+#: panels/wacom/cc-wacom-page.c:516
+msgid "Display Mapping"
+msgstr "Ekrana mapado"
+
+#: panels/wacom/cc-wacom-panel.c:725 panels/wacom/wacom-stylus-page.ui:119
+msgid "Stylus"
+msgstr "Grifelo"
+
+#: panels/wacom/cc-wacom-stylus-page.c:357
+msgid "Button"
+msgstr "Butono"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:200
+msgid "Wacom Tablet"
+msgstr "Tabuleto de Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Agordi butonaj mapoj kaj ĝustigi grifelan sentemon por grafikaj tabuletoj"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tabuleto;Wacom;Grifelo;Gumo;Muso;"
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr "Tabuleto (absoluta)"
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr "Tuŝplato (relativa)"
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr "Agordoj de tabuleto"
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "_Helpo"
+
+#: panels/wacom/gnome-wacom-properties.ui:125
+msgid "No tablet detected"
+msgstr "Detektiĝis neniu tabuleto"
+
+#: panels/wacom/gnome-wacom-properties.ui:141
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Bonvolu konekti aŭ ŝalti vian Wacom tabuleton"
+
+#: panels/wacom/gnome-wacom-properties.ui:161
+msgid "Bluetooth Settings"
+msgstr "Agordoj de Bludento"
+
+#: panels/wacom/gnome-wacom-properties.ui:238
+msgid "Tracking Mode"
+msgstr "Ĉasreĝimo"
+
+#: panels/wacom/gnome-wacom-properties.ui:266
+msgid "Left-Handed Orientation"
+msgstr "Maldekstramano orientiĝo"
+
+#: panels/wacom/gnome-wacom-properties.ui:296
+#: panels/wacom/gnome-wacom-properties.ui:401
+msgid "Map to Monitor…"
+msgstr "Mapi al ekrano…"
+
+#: panels/wacom/gnome-wacom-properties.ui:309
+msgid "Map Buttons…"
+msgstr "Map-butonoj…"
+
+#: panels/wacom/gnome-wacom-properties.ui:322
+msgid "Calibrate…"
+msgstr "Laŭnormigi…"
+
+#: panels/wacom/gnome-wacom-properties.ui:340
+msgid "Adjust mouse settings"
+msgstr "Agordi musagordojn"
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Adjust display resolution"
+msgstr "Ĝustigi ekranan distingivon"
+
+#: panels/wacom/gnome-wacom-properties.ui:376
+msgid "Decouple Display"
+msgstr "Apartigi ekranon"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
+msgid "New shortcut…"
+msgstr "Nova klavkombino…"
+
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "Implicita"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr "Alklako per meza musklavo"
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr "Alklako per dekstra musklavo"
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "Antaŭen"
+
+#: panels/wacom/wacom-stylus-page.ui:79
+msgid "No stylus found"
+msgstr "Neniu grifelo estas trovita"
+
+#: panels/wacom/wacom-stylus-page.ui:93
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr "Bonvolu movi vian grifelon apud via tabuleto por agordi ĝin"
+
+#: panels/wacom/wacom-stylus-page.ui:159
+msgid "Eraser Pressure Feel"
+msgstr "Konduto de gumpremo"
+
+#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
+msgid "Soft"
+msgstr "Milda"
+
+#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
+msgid "Firm"
+msgstr "Firma"
+
+#: panels/wacom/wacom-stylus-page.ui:234
+msgid "Top Button"
+msgstr "Supra butono"
+
+#: panels/wacom/wacom-stylus-page.ui:263
+msgid "Lower Button"
+msgstr "Suba butono"
+
+#: panels/wacom/wacom-stylus-page.ui:292
+msgid "Lowest Button"
+msgstr "Plej suba butono"
+
+#: panels/wacom/wacom-stylus-page.ui:321
+msgid "Tip Pressure Feel"
+msgstr "Konduto de pinta premo"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+msgid "GNOME Settings"
+msgstr "GNOME Agordoj"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Ilo por agordi la labortablon de GNOME"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Agordoj estas la ĉefa fasado por agordi vian sistemon."
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:20
+msgid "The GNOME Project"
+msgstr "La GNOME Projekto"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Montri versionumeron"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Ŝalti adan reĝimon"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Serĉi la ĉenon"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Listigi eblajn panelnomojn kaj eliri"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panelo por montri"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANELO] [ARGUMENTO…]"
+
+#: shell/cc-panel-list.ui:45 shell/cc-window.c:275
+msgid "Privacy"
+msgstr "Privateco"
+
+#: shell/cc-panel-loader.c:288
+msgid "Available panels:"
+msgstr "Disponeblaj paneloj:"
+
+#: shell/cc-window.ui:136
+msgid "All Settings"
+msgstr "Ĉiuj agordoj"
+
+#: shell/cc-window.ui:174
+msgid "Primary Menu"
+msgstr "Ĉefa menuo"
+
+#: shell/cc-window.ui:318
+msgid "Warning: Development Version"
+msgstr "Averto: Programista versio"
+
+#: shell/cc-window.ui:319
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Ĉi tiu versio de la stircentro devus nur esti uzata por programistaj celoj. "
+"Vi spertus neĝustan sistemkonduton, datumperdon, kaj aliajn neanticipitajn "
+"problemojn. "
+
+#: shell/cc-window.ui:330
+msgid "Help"
+msgstr "Helpo"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferoj;Agordoj;"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Ĝenerala"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Ĉesi"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Serĉo"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneloj"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Reiri al antaŭa panelo"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Nuligi serĉon"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "La identifilo por la stircentra panelo, kiu malfermendiĝas laste"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"La identifilo por la stircentra panelo, kiu malfermendiĝas laste. "
+"Nerekonataj valoroj estos malatentita kaj la unua panelo en la listo estos "
+"elektita."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Montri averton kiam rulante programistan version de la stircentro"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Ĉu la stircentro devus montri averton kiam rulante programistan version."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1907
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u eligo"
+msgstr[1] "%u eligoj"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1917
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u enigo"
+msgstr[1] "%u enigoj"
+
+#: subprojects/gvc/gvc-mixer-control.c:2867
+msgid "System Sounds"
+msgstr "Sistemsonoj"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Aldoni uzantokontojn kaj ŝanĝi pasvortojn"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Ludi kaj registri sonon"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Detekti retaparatojn uzante mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Atingi bludentan aparataron rekte"
+
+#~ msgid "Use bluetooth devices"
+#~ msgstr "Uzi bludentajn aparatojn"
+
+#~ msgid "Use your camera"
+#~ msgstr "Uzi vian kameraon"
+
+#~ msgid "Print documents"
+#~ msgstr "Presi dokumentojn"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Uzi konektitan stirstangon"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Permesi konektadon al la Docker-servo"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Agordi retan fajroŝirmilon"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Agordi kaj uzi privelegiajn FUSE-dosiersistemojn"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Ĝisdatigi mikroprogramaron sur ĉi tiu aparato"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Atingi aparatarajn informojn"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Provizu entropion por la aparatara hazarda numera generilo"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Uzu hazardajn numerojn generitajn per aparataro"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Atingi dosierojn en via hejma dosierujo"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Atingi libvirt-servon"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Ŝanĝi sistemlingvon kaj regionagordojn"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Ŝanĝi lokajn agordojn kaj provizantojn"
+
+#~ msgid "Access your location"
+#~ msgstr "Atingi vian lokon"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Legi sistemajn kaj aplikaĵajn protokolojn"
+
+#~ msgid "Access LXD service"
+#~ msgstr "Atingi LXD-servon"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "atingi la media-hub-servon"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Uzi kaj agordi modemojn"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Legi sistemajn surmetajn informojn kaj diskajn kvotojn"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Mastrumi muzikajn kaj videajn ludilojn"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Ŝanĝi malaltnivelajn retajn agordojn"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr "Atingi la NetworkManager-servon por legi kaj ŝanĝi retagordojn"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Leg-atingo al retagordoj"
+
+#~ msgid "Change network settings"
+#~ msgstr "Ŝanĝi retagordojn"
+
+#~ msgid "Read network settings"
+#~ msgstr "Legi retagordojn"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Atingi la ofono-servon por legi kaj ŝanĝi la retagordojn por portebla "
+#~ "telefonado"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Mastrumi Open vSwitch aparataron"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Legi el KD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Legi, aldoni, ŝanĝi, aŭ forigi konservitajn pasvortojn"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Paŭzigi aŭ ĉesigi ajnan procezon sur la sistemo"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Atingi USB-programaron rekte"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Legi/skribi dosierojn sur demeteblaj datumportiloj"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Malhelpi ekranan malpleniĝon kaj ŝlosadon"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Restartigi aŭ malŝalti la aparaton"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Instali, forigi kaj agordi programaron"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Legi procezajn kaj sistemajn informojn"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Montri kaj mastrumi ajnan rulantan programon"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Ŝanĝi la daton kaj horon"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Ŝanĝi temposervilajn agordojn"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Ŝanĝi la horzonon"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Atingi la UDisks2-servon por agordi diskojn kaj demeteblajn datumportilojn"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Legi/ŝanĝi kunhavigitajn kalendar-eventojn en Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Legi/ŝanĝi kunhavigitajn kontaktojn en Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Atingi datumojn de elektra uzado"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Elekti fonon kaj ŝlosekranon"
+
+#~ msgid "Set Background"
+#~ msgstr "Elekti fonon"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Elekti ŝlosekranon"
+
+#~ msgid "Remove Background"
+#~ msgstr "Forigi fonon"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Alirebleco"
+
+#~ msgid "Left Alt"
+#~ msgstr "Maldekstra alt-klavo"
+
+#~ msgid "Right Alt"
+#~ msgstr "Dekstra alt-klavo"
+
+#~ msgid "Left Super"
+#~ msgstr "Maldekstra super-klavo"
+
+#~ msgid "Right Super"
+#~ msgstr "Dekstra super-klavo"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Dekstra stirklavo"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Klavo de alternativaj signoj"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Ŝanĝi al sekva fonto per nur modifaj klavoj"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Menu-klavo"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Malŝalti por konekti al sendrata reto"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Pasvorto"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Ŝargante"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Averto"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Malalta"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Bona"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Plene ŝargita"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Malplena"
+
+#~ msgid "Choose keyboard layouts or input methods."
+#~ msgstr "Elekti klavararanĝojn aŭ enigajn metodojn."
+
+#~ msgid "Previous source"
+#~ msgstr "Antaŭa fonto"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Maj+Spaceto"
+
+#~ msgid "Next source"
+#~ msgstr "Sekva fonto"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Spaceto"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Maldekstra+Dekstra Alt"
+
+#~ msgid "These keyboard shortcuts can be changed in the keyboard settings"
+#~ msgstr "Vi povas ŝanĝi ĉi tiujn klavkombinojn en la klavaraj agordoj"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Por krei uzantkonton,\n"
+#~ "alklaku unue la *-piktogramon"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Ŝalti fingropreman salutadon"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Alia fingro:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Via fingropremo estas sukcese konservita. Vi nun eblus saluti per via "
+#~ "fingropremlegilon."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Vi ne havas permeson aliri la aparaton. Kontaktu vian "
+#~ "sistemadministranton."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Interna eraro okazis."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Ĉu forigi registritajn fingropremojn?"
+
+#~ msgid "Done!"
+#~ msgstr "Farita!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Ne eblis aliri la “%s” aparaton"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Ne eblis komenci preni fingropremojn per “%s” aparato"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Bonvole kontaktu vian sistemadministranton por helpo."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Por ŝalti fingropreman ensaluton, vi konservu unu el viaj fingropremoj "
+#~ "per la aparato “%s”."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Elektante fingron"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "Raportoj sendiĝas sennome kaj personaj datumoj estas viŝitaj."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Sendado de raportoj de teĥnikaj problemoj helpas al ni plibonigi ĉi tiun "
+#~ "operaciumon."
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Ŝ_prucaj sciigoj"
+
+#~ msgid "Last Login"
+#~ msgstr "Pasinta salutado"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Limigi _fonan uzadon de datumo"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Konvena por konektoj, kiuj havas kostpagojn aŭ limojn por datumo."
+
+#~ msgid "No regions found"
+#~ msgstr "Neniuj regionoj trovitaj"
+
+#~ msgid "_Background"
+#~ msgstr "_Fono"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Ŝanĝas dum la tago"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Kaheligi"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zomi"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrigi"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Skali"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Plenigi"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Etendi"
+
+#~ msgid "Wallpapers"
+#~ msgstr "Ekranfonoj"
+
+#~ msgid "Colors"
+#~ msgstr "Koloroj"
+
+#~ msgid "Pictures"
+#~ msgstr "Bildoj"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Neniuj bildoj trovitaj"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Vi povas aldoni bildojn al via %s dosierujo kaj ili montriĝos ĉi tie"
+
+#~ msgid "_Off"
+#~ msgstr "_Malŝaltita"
+
+#~ msgid "Version %s"
+#~ msgstr "Versio %s"
+
+#~ msgid "OS name"
+#~ msgstr "Nomo de operaciumo"
+
+#~ msgid "OS type"
+#~ msgstr "Tipo de operaciumo"
+
+#~ msgid "Disk"
+#~ msgstr "Disko"
+
+#~ msgid "Check for updates"
+#~ msgstr "Serĉi por ĝisdatigoj"
+
+#~ msgid "Network proxy"
+#~ msgstr "Retprokurilo"
+
+#~ msgid "page 1"
+#~ msgstr "paĝo 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Ena _aŭtentigo"
+
+#~ msgid "page 2"
+#~ msgstr "paĝo 2"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Tordita Paro (TP)"
+
+#, fuzzy
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#, fuzzy
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Se vi ŝaltas la sendratan retkaptejon, vi malkonektos de <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Ne eblas atingi la interreton tra via sendrata aparato dum la retkaptejo "
+#~ "estas ŝaltita."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Vifiaj retkaptejoj kutime estas uzata por kunhavigi ceteran interretan "
+#~ "konekton per vifio."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "_Aŭtomate konekti"
+
+#~ msgid "details"
+#~ msgstr "detaloj"
+
+#~ msgid "Show P_assword"
+#~ msgstr "_Montri pasvorton"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Disponebligi por aliaj uzantoj"
+
+#~ msgid "identity"
+#~ msgstr "identeco"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adresoj"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Nur aŭtomataj adresoj (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Nur logi-loke"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Malatenti aŭtomate ricevitajn kursojn"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Klonita MAC-adreso"
+
+#~ msgid "_Reset"
+#~ msgstr "_Reagordi"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Reagordi la agordojn por ĉi tiu konekto al ĝiaj implicitaj agordoj, sed "
+#~ "memori ĝin kiel preferita reto."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Forigi ĉiujn detalojn de ĉi tiu reto kaj ne klopodi aŭtomate konekti "
+#~ "denove."
+
+#~ msgid "Hardware"
+#~ msgstr "Aparataro"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Reagordi"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Konektitaj aparatoj"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Porokaza"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastrukturo"
+
+#~ msgid "Not connected"
+#~ msgstr "Ne konekita"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Aŭtomata haltetado"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Kiam la ŝaltbutono estas premita"
+
+#~ msgid "In use"
+#~ msgstr "Uzata"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Ŝaltita"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Malŝaltita"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Malŝaltita"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Ŝaltita"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Malŝaltita"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Ŝaltita"
+
+#~ msgid "Usage & History"
+#~ msgstr "Uzado & historio"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Privateca politiko"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Memori vian historion plifaciligas trovi aĵojn denove. Ĉi eroj estas "
+#~ "neniam kunhavigitaj tra la reto."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Lastaj uzitaj"
+
+#~ msgid "Retain _History"
+#~ msgstr "Teni _historion"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "La ekrana ŝloso protektas vian privatecon kiam vi estas fora."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Ŝ_losi ekranon post ekrano estas malplena por"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "Sciigoj sur ŝ_losa ekrano"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Aŭtomate vakigi la rubujon kaj provizorajn dosierojn por helpi forigi "
+#~ "nebezonitan konfidencan informon de via komputilo."
+
+#~ msgid "Purge _After"
+#~ msgstr "Vakigi _post"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Sendado de informo pri kiujn programojn vi uzas helpas nin provizi al vi "
+#~ "pli taŭgajn rekomendojn. Ĝi ankaŭ helpas nin plibonigi nian programaron.\n"
+#~ "\n"
+#~ "Ĉiuj informojn, kiujn ni kolektas, sennomiĝas, kaj ni neniam kunhavigos "
+#~ "viajn datumojn al eksteraj liverantoj."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Sendi statistikojn pri uzado de programaro"
+
+#~ msgid "_Camera"
+#~ msgstr "_Kamerao"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Mikrofono"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Lokado-servoj"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Protekti viajn personan informon kaj regi kion aliaj povas vidi"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Fulmi la _fenestran titolon"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "La uzantonomo ne povas komenci per “-”."
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Konekto/SSID"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "preferences-desktop-wallpaper"
+#~ msgstr "preferences-desktop-wallpaper"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "preferences-system-notifications"
+#~ msgstr "preferences-system-notifications"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Noktlumo"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Ne eblis akiri informojn pri ekrano"
+
+#~ msgid "Add input source"
+#~ msgstr "Aldoni enigan fonton"
+
+#~ msgid "Remove input source"
+#~ msgstr "Forigi enigan fonton"
+
+#~ msgid "Move input source up"
+#~ msgstr "Movi enigan fonton supren"
+
+#~ msgid "Move input source down"
+#~ msgstr "Movi enigan fonton malsupren"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Montri enigan fontan klavararanĝon"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Maldekstra"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Dekstra"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimuma"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maksimuma"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Bas-laŭparolilo:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profilo:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Testi laŭtparolilojn"
+
+#~ msgid "Peak detect"
+#~ msgstr "Detektado de sonpintoj"
+
+#~ msgid "Device"
+#~ msgstr "Aparato"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Laŭtparolila testo por %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Elektu aparaton por soneligo:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Agordoj de la elektita aparato:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "E_niga laŭteco:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Elektu aparaton por sonenigo:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Sonefektoj"
+
+#~ msgid "Built-in"
+#~ msgstr "Fiksita"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Sonagordoj"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Testanta soneventon"
+
+#~ msgid "From theme"
+#~ msgstr "El haŭto"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Elekti avertsonon:"
+
+#~ msgid "Stop"
+#~ msgstr "Halti"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME Stircentro"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "La stircentro estas la ĉefa interfaco de GNOME por agordado de diversaj "
+#~ "ecoj de via labortablo."
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Ŝanĝi al lasta fonto"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Ŝanĝi al sekva fonto"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Alternativa ŝanĝo al sekva fonto"
+
+#~ msgid "_Options"
+#~ msgstr "_Agordoj"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Norma"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administranto"
+
+#~ msgid "Quit"
+#~ msgstr "Ĉesi"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~| msgid "Background"
+#~ msgid "Back­ground"
+#~ msgstr "Fono"
+
+#, fuzzy
+#~| msgid "Bluetooth"
+#~ msgid "Blue­tooth"
+#~ msgstr "Bludento"
+
+#~ msgid "Section"
+#~ msgstr "Sekcio"
+
+#~ msgid "Overview"
+#~ msgstr "Superrigardo"
+
+#, fuzzy
+#~| msgid "Default Applications"
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Defaŭltaj aplikaĵoj"
+
+#, fuzzy
+#~| msgid "Details"
+#~ msgid "De­tails"
+#~ msgstr "Detaloj"
+
+#, fuzzy
+#~| msgid "Removable Media"
+#~ msgid "Remo­vable Media"
+#~ msgstr "Demetebla datumportilo"
+
+#~ msgid "My Home Network"
+#~ msgstr "Mia hejma reto"
+
+#, fuzzy
+#~| msgid "Network"
+#~ msgid "Net­work"
+#~ msgstr "Reto"
+
+#~ msgid "hardware"
+#~ msgstr "aparataro"
+
+#, fuzzy
+#~| msgid "Notifications"
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Sciigoj"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Angla (Unuiĝinta Reĝlando)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Unuiĝinta Reĝlando"
+
+#, fuzzy
+#~| msgid "Sharing"
+#~ msgid "Sha­ring"
+#~ msgstr "Kunhavigo"
+
+#, fuzzy
+#~| msgid "Universal Access"
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Alirebleco"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Kontroli novan pasvorton"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "La pasvortoj ne kongruas."
+
+#~ msgid "Disable image"
+#~ msgstr "Elŝalti bildon"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Foliumi por pliaj bildoj…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Uzate de %s"
+
+#, fuzzy
+#~| msgid "Wacom Tablet"
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Tabuleto de Wacom"
+
+#~ msgid "page 3"
+#~ msgstr "paĝo 3"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Aparataro"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistemo"
+
+#~ msgid "Show the overview"
+#~ msgstr "Montri la superrigardon"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "Bludento estas elŝaltite"
+
+#~ msgid "Done"
+#~ msgstr "Farite"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Hor_zono"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Kovrilo ferma"
+
+#~ msgid "Mirrored"
+#~ msgstr "Spegulata"
+
+#~ msgid "Secondary"
+#~ msgstr "Kroma"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Aranĝi kombinitajn ekranojn"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Ŝovu ekranojn por rearanĝi"
+
+#, fuzzy
+#~| msgctxt "display panel, rotation"
+#~| msgid "Counterclockwise"
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Turni maldekstrumen laŭ 90°"
+
+#~ msgid "Size"
+#~ msgstr "Grando"
+
+#~ msgid "Aspect Ratio"
+#~ msgstr "Aspekta rilatumo"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Montri la supran breton kaj Aktivecoj-Superrigardon ĉi ekrane"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Kunmeti ĉi ekranon kun alia por krei ekstran laborspacon"
+
+#~ msgid "Presentation"
+#~ msgstr "Prezento"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Montri nur lumbildojn kaj aŭdvidaĵon"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Montri vian ekzistantan vidon per ambaŭ ekranoj"
+
+#~ msgid "Turn Off"
+#~ msgstr "Elŝalti"
+
+#~ msgid "Don't use this display"
+#~ msgstr "Ne uzi ĉi ekranon"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Aranĝi kombinitajn ekranojn"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bita"
+
+#~ msgid "Base system"
+#~ msgstr "Baza sistemo"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Klavkombino;Ripeto;Pulso;"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Prokrasto:"
+
+#~ msgid "_Speed:"
+#~ msgstr "_Rapido:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Mallonge"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Malrapide"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Longe"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapide"
+
+#~ msgid "S_peed:"
+#~ msgstr "Ra_pido:"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Por redakti klavkombinon, alklaku la vicon kaj premu la novajn klavojn aŭ "
+#~ "premu la retropaŝan klavon por vakigi."
+
+#~ msgid "Shortcuts"
+#~ msgstr "Klavkombinoj"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Nekonata ago>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "La klavkombino \"%s\" ne povas esti uzata ĉar ĝi ne ebloj tajpi per ĉi "
+#~ "tiu klavo.\n"
+#~ "Bonvou reprovi per klavo kiel stirklavo, alt-klavo aŭ majuskliga klavo "
+#~ "samtempe."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "La klavkombino \"%s\" estas jam uzata por\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Se vi reatribuas la klavkombinon al \"%s\", la klavkombino \"%s\" estos "
+#~ "elŝaltita."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Reatribui"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "La \"%s\"-fulmoklavo jam havas asocigitan \"%s\"-fulmoklavon. Ĉu vi volas "
+#~ "aŭtomate difini ĝin al \"%s\"?"
+
+#, fuzzy
+#~| msgid ""
+#~| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~| "disabled."
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "Se vi reatribuas la klavkombinon al \"%s\", la klavkombino \"%s\" estos "
+#~ "elŝaltita."
+
+#~ msgid "_Assign"
+#~ msgstr "_Atribui"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Testi viajn agordojn"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Malrapide"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapide"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "Ma_ldekstre"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "Dekst_re"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Indikilrapido"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Malrapide"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapide"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Malrapide"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapide"
+
+#~ msgid "Server"
+#~ msgstr "Servilo"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Forigi nomservilon"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Disponebligi kun aliaj _uzantoj"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Fajroŝirmila _zono"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Defaŭlta"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "La zono definas la fidindecan nivelon de la konekto"
+
+#~ msgid "Bond"
+#~ msgstr "Bindo"
+
+#~ msgid "Team"
+#~ msgstr "Teamo"
+
+#~ msgid "Bridge"
+#~ msgstr "Ponto"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Ne eblas ŝargi VPN-an etendojn"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Aldoni retan konekton"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Vakigi la agordojn por ĉi reto, inkludante pasvortojn, sed memori ĝin "
+#~ "kiel preferita reto"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr "Forigi ĉiujn detalojn de ĉi reto kaj ne klopodi aŭtomate konekti"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Bindaj sklavoj"
+
+#~ msgid "(none)"
+#~ msgstr "(neniu)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Pontaj sklavoj"
+
+#, fuzzy
+#~| msgid "Bridge slaves"
+#~ msgid "Team slaves"
+#~ msgstr "Pontaj sklavoj"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Se vi havas konekton al la interreto krom sendrata, vi povas agordi "
+#~ "sendratan retkaptejon por kunhavi la konekton kun aliaj."
+
+#~ msgid "Proxy"
+#~ msgstr "Prokurilo"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Aldoni profilon…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Neniu"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Permane"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Aŭtomate"
+
+#~ msgid "Add Device"
+#~ msgstr "Aldoni aparaton"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN-tipo"
+
+#~ msgid "Group Name"
+#~ msgstr "Grupnomo"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Uzi kiel retkaptejo…"
+
+#~ msgid "_History"
+#~ msgstr "_Historio"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand aparato ne subtenas konektitan reĝimon"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Neniu atestilo de Atestilaŭtoritato elektita"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Se vi ne uzas atestilaŭtoritatan (CA) atestilon tiam vi povas konekti al "
+#~ "nesekuraj, friponaj sendrataj retoj.  Ĉu vi volas elekti "
+#~ "atestilaŭtoritatan atestilon?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignori"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Elekti CA-atestilon"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Ĉiam _postuli la pasvorton"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Ne _averti min denove"
+
+#~ msgid "Yes"
+#~ msgstr "Jes"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#, fuzzy
+#~| msgctxt "notifications"
+#~| msgid "Notifications"
+#~ msgctxt "notifications"
+#~ msgid "Notification Banners"
+#~ msgstr "Sciigoj"
+
+#~ msgid "Add Account"
+#~ msgstr "Aldoni konton"
+
+#~ msgid "Mail"
+#~ msgstr "Retpoŝto"
+
+#~ msgid "Contacts"
+#~ msgstr "Kontaktaro"
+
+#~ msgid "Chat"
+#~ msgstr "Retbabilado"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Eraro dum ensalutado"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Ensalutiloj senvalidiĝis."
+
+#, fuzzy
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Aliĝi por enŝalti tiun konton."
+
+#~ msgid "_Sign In"
+#~ msgstr "En_saluti"
+
+#~ msgid "Error creating account"
+#~ msgstr "Eraro dum kreado de konto"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Ĉu vi certe volas forigi la konton?"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Neniuj retkontoj estas agorditaj"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Aldoninte konton, permesas al viaj aplikaĵoj atingi dokumentojn, "
+#~ "retpoŝton, kontaktojn, kalendaro, retbabiladon kaj plu."
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Sendrataj aparatoj bezonas kroman energion"
+
+#, fuzzy
+#~ msgid "When battery power is _critical"
+#~ msgstr "Kiam kurento estas _kritike malalta"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Agordante"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nivelo de inkopulvoro"
+
+#~ msgid "Supply Level"
+#~ msgstr "Proviza nivelo"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Instalante"
+
+#~ msgid "No printers available"
+#~ msgstr "Neniu presilo disponebla"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktiva"
+#~ msgstr[1] "%u aktivaj"
+
+#~ msgid "Close"
+#~ msgstr "Fermi"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Daŭrigi preson"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Paŭzigi presadon"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Aldoni novan presilon"
+
+#~ msgid "No printers detected."
+#~ msgstr "Detektis neniun presilon."
+
+#~ msgid "Loading options…"
+#~ msgstr "Ŝarĝante opciojn…"
+
+#, fuzzy
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Paŭzigita"
+
+#~ msgid "Job Title"
+#~ msgstr "Tasktitolo"
+
+#~ msgid "Job State"
+#~ msgstr "Taskstato"
+
+#~ msgid "Supply"
+#~ msgstr "Provizo"
+
+#~ msgid "Jobs"
+#~ msgstr "Taskoj"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Montri _taskojn"
+
+#~ msgid "label"
+#~ msgstr "etikedo"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "Metante novan pelilon…"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Presi _testpaĝon"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Aldoni novan presilon"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Uzita por determini vian geografian lokon"
+
+#~ msgid "Options"
+#~ msgstr "Agordoj"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Alia"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Bludenta komunigo permesas al vi komunigi dosierojn kun aliaj aparatoj "
+#~ "Bludento-aktivaj"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Nur ricevi el fidindaj aparatoj"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Konservi ricevitajn dosierojn en la dosierujo de elŝutoj"
+
+#, fuzzy
+#~ msgid "Allow Remote Control"
+#~ msgstr "Laŭtecregilo"
+
+#~ msgid "Password:"
+#~ msgstr "Pasvorto:"
+
+#~ msgid "Zoom"
+#~ msgstr "Zomi"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Koloro"
+
+#~ msgid "_Verify"
+#~ msgstr "_Kontroli"
+
+#~ msgid "Login History"
+#~ msgstr "Ensaluthistorio"
+
+#~ msgid "Add User Account"
+#~ msgstr "Aldoni uzantokonton"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Klopodu aldoni pli da leteroj, nombroj kaj simboloj."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Forteco: malforte"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Forto: malalte"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Forteco: meze"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Forteco: bone"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Forteco: alte"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Aliaj kontoj"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Uzanto kun la uzantonomo '%s' jam ekzistas."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Supren"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Suben"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Neniu"
+
+#~ msgid "Left Ring"
+#~ msgstr "Maldekstra ringo"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Maldekstra-ringa reĝimo #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Dekstra-ringa reĝimo #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Maldekstra tuŝostrio"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Maldekstra-tuŝostria reĝimo #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Dekstra tuŝostrio"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Dekstra-tuŝostrio reĝimo #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Ŝaltilo de maldekstra-tuŝoringa reĝimo"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Ŝaltilo de dekstra-tuŝoringa reĝimo"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Ŝaltilo de maldekstra tuŝostria reĝimo"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Ŝaltilo de dekstra tuŝostria reĝimo"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Reĝima ŝaltilo #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Maldekstra butono #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Dekstra butono #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Supra butono #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Malsupra butono #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Neniu ago"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Alklako per maldekstra musklavo"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Rulumi supren"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Rulumi suben"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Rulumi dekstren"
+
+#~ msgid "Show help options"
+#~ msgstr "Vidigi helpajn opciojn"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Rulu '%s --help' por vidi kompletan liston de disponeblaj komandliniaj "
+#~ "opcioj.\n"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Elŝalti sendratajn aparatojn"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Agordi novan aparaton"
+
+#~ msgid "Paired"
+#~ msgstr "Parigite"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Agordoj de muso kaj tuŝplato"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Klavaragordoj"
+
+#~ msgid "Send Files…"
+#~ msgstr "Sendi doierojn…"
+
+#~ msgid "Visibility"
+#~ msgstr "Videbleco"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Videbleco de \"%s\""
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Ĉu forigi na '%s' de la listo de aparatoj?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Se vi forigas la aparaton, vi devos agordi ĝin denove antaŭ la sekva uzo."
+
+#~ msgid "United States"
+#~ msgstr "Usono"
+
+#~ msgid "Germany"
+#~ msgstr "Germanujo"
+
+#~ msgid "France"
+#~ msgstr "Francujo"
+
+#~ msgid "Spain"
+#~ msgstr "Hispanujo"
+
+#~ msgid "China"
+#~ msgstr "Ĉinujo"
+
+#~ msgid "Install Updates"
+#~ msgstr "Instali ĝisdatigojn"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Ĝisdata sistemo"
+
+#, fuzzy
+#~ msgid "Disable while _typing"
+#~ msgstr "Elŝalti _tuŝplaton dum tajpado"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "La sistemaj retservoj ne kongruas kun ĉi tiu versio."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Montri sciigojn"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Montri en ŝlosa ekrano"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Montri sciigojn"
+
+#~ msgid "_Default"
+#~ msgstr "_Defaŭlte"
+
+#~ msgid "Immediately"
+#~ msgstr "Tuj"
+
+#~ msgid "Sorry"
+#~ msgstr "Pardonu"
+
+#, fuzzy
+#~ msgid "Shared Folders"
+#~ msgstr "Bilddosierujo"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Forigi dosierujon"
+
+#, fuzzy
+#~ msgid "Remote View"
+#~ msgstr "Forigi aparaton"
+
+#, fuzzy
+#~ msgid "Approve All Connections"
+#~ msgstr "Konekto"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Neniu"
+
+#~ msgid "Device type:"
+#~ msgstr "Aparattipo:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Produktinto:"
+
+#~ msgid "Model:"
+#~ msgstr "Modelo:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Eblas ŝovi bildojn sur ĉi tiun fenestron por aŭtomate plenigi la suprajn "
+#~ "kampojn."
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "Montri vian ĉefan zonon ĉi ekrane, ankaŭ"
+
+#~ msgid "Combine"
+#~ msgstr "Kombini"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "Kunmeti kun la ĉefa ekrano por krei ekstran spacon"
+
+#~ msgid "Don't use the display"
+#~ msgstr "Ne uzi la ekranon"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Musagordoj"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Elektu la uzendan interfacon por la nova servo"
+
+#~ msgid "C_reate…"
+#~ msgstr "_Krei…"
+
+#~ msgid "_Interface"
+#~ msgstr "_Interfaco"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Ŝanĝi fotaĵon de:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Elekti bildon kiu estos montrata dum la ensalutekrano de ĉi tiu konto."
+
+#~ msgid "Gallery"
+#~ msgstr "Galerio"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Fari fotaĵon"
+
+#~ msgid "Browse"
+#~ msgstr "Foliumi"
+
+#~ msgid "Photograph"
+#~ msgstr "Fotaĵo"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "Aldoni ekranfonon"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "Forigi ekranfonon"
+
+#~ msgid "Swap colors"
+#~ msgstr "Ŝanĝi kolorojn"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Horizontala kolortransiro"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Vertikala kolortransiro"
+
+#~ msgid "Solid Color"
+#~ msgstr "Solida koloro"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "Koloroj kaj kolortransiroj"
+
+#~ msgid "Browse Files..."
+#~ msgstr "Foliumi dosierojn..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bludento"
+
+#~ msgid "Create virtual device"
+#~ msgstr "Krei virtualan aparaton"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Disponeblaj profiloj por ekranoj"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Disponeblaj profiloj por skaniloj"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Disponeblaj profiloj por presiloj"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Disponeblaj profiloj por kameraojn"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Disponeblaj profiloj por retkameraoj"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i jaro"
+#~ msgstr[1] "%i jaroj"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i monato"
+#~ msgstr[1] "%i monatoj"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i jaro"
+#~ msgstr[1] "%i semajnoj"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "Malpli ol unu semajno"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "Tiu aparato ne estas kolor-mastrumata."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "Tiu aparato estas uzanta originalajn kalibratajn datumojn"
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "Tiu aparato ne havas taŭgan profilon por tutekrana kolorkorekto."
+
+#~ msgid "Not specified"
+#~ msgstr "Nespecifite"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "Neniuj aparatoj subtenantaj kolormastrumadon detektitaj"
+
+#~ msgid "Add device"
+#~ msgstr "Aldoni aparaton"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "Aldoni virtualan aparaton"
+
+#~ msgid "Color management settings"
+#~ msgstr "Ŝanĝi administrad-agordojn"
+
+#~ msgid "English"
+#~ msgstr "Angla"
+
+#~ msgid "British English"
+#~ msgstr "Angla (britio)"
+
+#~ msgid "French"
+#~ msgstr "Franca"
+
+#~ msgid "Spanish"
+#~ msgstr "Hispana"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Ĉina (simpligite)"
+
+#~ msgid "Unspecified"
+#~ msgstr "Nedifinite"
+
+#~ msgid "_Region:"
+#~ msgstr "_Regiono:"
+
+#~ msgid "_City:"
+#~ msgstr "_Urbo:"
+
+#~ msgid "_Network Time"
+#~ msgstr "_Rethoro"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Aldoni unu horon al tempo."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Forigi unu horon al tempo."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Aldoni unu minuton al tempo."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Forigi unu minuton al tempo."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Ŝalti inter 24-hora kaj 12-hora tempo."
+
+#~ msgid "AM/PM"
+#~ msgstr "ATM/PTM"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Agordoj de la panelo pri dato kaj horo"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Normale"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Dekstrume"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 gradoj"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "Trenu por ŝanĝi unuarangan ekranon."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Elekti ekranon por ŝanĝi siajn ecojn; treni ĝin por rearanĝi sian lokon"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Ne eblis konservi la ekranagordojn"
+
+#~ msgid "R_otation"
+#~ msgstr "R_otacio"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Speguli ekranojn"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Notu: tio eble limigas opciojn pri distingivo"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "Nekonata modelo"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "Dum la sekva ensaluto ĝi klopodos uzi la norman sperton."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "Dum la sekva ensaluto ĝi uzos la retropaŝan reĝimon celitan por "
+#~ "nesubtenataj grafikaj aparataroj."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Retropaŝo"
+
+#~ msgid "Acti_on:"
+#~ msgstr "Ag_o:"
+
+#~ msgid "Experience"
+#~ msgstr "Spertoj"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "Per_forti retropaŝan reĝimon"
+
+#~ msgid "Action"
+#~ msgstr "Ago"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Agordi viajn muson kaj tuŝplaton"
+
+#~ msgid "_Right-handed"
+#~ msgstr "De_kstra-mana"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Maldesktra-mana"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "M_ontri montrilan pozicion kiam la stirklavo estas premata"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "Ak_celado:"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Sentemo:"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "Ŝovi kaj demeti"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "_Sojlo:"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "Ŝova sojlo"
+
+#~ msgid "_Timeout:"
+#~ msgstr "_Tempolimo:"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "Por testi viajn agordojn, klopodu duoble alklaki sur la vizaĵo."
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "Ebligi _musklakojn per tuŝplato"
+
+#~ msgid "_Disabled"
+#~ msgstr "_Elŝaltite"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "Alia..."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "Ĉu krei retkaptejon ĉiukaze?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "Ĉu malkonektiĝi de %s kaj krei novan retkaptejon?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "Tio estas via sola konekto al interreto."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "Krei ret_kaptejon"
+
+#~ msgid "Create..."
+#~ msgstr "Krei..."
+
+#~ msgid "Subnet Mask"
+#~ msgstr "Subreta masko"
+
+#~ msgid "_Options..."
+#~ msgstr "_Opcioj..."
+
+#~ msgid "_Network Name"
+#~ msgstr "_Retnomo"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "Halti_gi retkaptejon..."
+
+#~ msgid "Disable VPN"
+#~ msgstr "Elŝalti na VPN"
+
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP-pordo"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "HTTPS-pordo"
+
+#~ msgid "FTP Port"
+#~ msgstr "FTP-pordo"
+
+#~ msgid "Wireless"
+#~ msgstr "Sendrate"
+
+#, fuzzy
+#~ msgid "Mesh"
+#~ msgstr "Meŝa"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "Ensalutiloj eksvalidiĝis. Bonvolu ensaluti denove."
+
+#~ msgid "_Log In"
+#~ msgstr "Ensa_luti"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "Por aldoni novan konton, unue elektu la konttipon"
+
+#~ msgid "_Add..."
+#~ msgstr "_Aldoni..."
+
+#~ msgid "Using battery power"
+#~ msgstr "Uzante akumulatoran energion"
+
+#~ msgid "Tip:"
+#~ msgstr "Konsileto:"
+
+#~ msgid "Power management settings"
+#~ msgstr "Kurentmastumadaj agordoj"
+
+#~ msgid "_Search by Address"
+#~ msgstr "Ŝerĉi laŭ _adreso"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD ne estas rulanta. Detektado de retpresiloj necesas servojn "
+#~ "mdns, ipp, ipp-client kaj samba-client enŝaltitaj en fajrŝirmilo."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "Loka"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "Reto"
+
+#~ msgid "Device types"
+#~ msgstr "Aparattipoj"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "Aŭtomata agordo"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "Malfermanta fajroŝirmilon por mDNS-konektojn"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Malfermante fajroŝirmilon por Samba-konektojn"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "Malfermante fajroŝirmilon por IPP-konektojn"
+
+#~ msgid "_Show"
+#~ msgstr "_Montri"
+
+#~ msgid "_Back"
+#~ msgstr "_Reen"
+
+#~ msgid "Allowed users"
+#~ msgstr "Permesitaj uzantoj"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "Ŝanĝi vian regionon kaj lingvajn agordojn"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "La ensalutadekrano, sistemaj kontoj kaj kontoj de novaj uzantoj uzas la "
+#~ "tutsistemajn agordojn pri regiono kaj lingvo."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "La ensalutadekrano, sistemaj kontoj kaj kontoj de novaj uzantoj uzas la "
+#~ "tutsistemajn agordojn pri regiono kaj lingvo. Vi povus ŝanĝi la sistemajn "
+#~ "agordojn por kongruigi viajn."
+
+#~ msgid "Copy Settings"
+#~ msgstr "Kopii agordojn"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "Kopii agordojn..."
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Elektu vidigitan lingvon (ŝanĝoj estos aplikitaj dum sekva ensalutado)"
+
+#~ msgid "Install languages..."
+#~ msgstr "Instali lingvojn..."
+
+#~ msgid "Add Language"
+#~ msgstr "Aldoni lingvon"
+
+#~ msgid "Remove Language"
+#~ msgstr "Forigi lingvon"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "Elekti regionon (ŝanĝoj aplikigos kiam vi sekvfoje ensalutos)"
+
+#~ msgid "Add Region"
+#~ msgstr "Aldoni regionon"
+
+#~ msgid "Currency"
+#~ msgstr "Valuto"
+
+#~ msgid "Examples"
+#~ msgstr "Ekzemploj"
+
+#~ msgid "Add Layout"
+#~ msgstr "Aldoni aranĝon"
+
+#~ msgid "Remove Layout"
+#~ msgstr "Forigi aranĝon"
+
+#~ msgid "Preview Layout"
+#~ msgstr "Antaŭrigardi aranĝon"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "Novaj fenestroj uzas la defaŭltan fasonon"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "Novaj fenestroj uzas la antaŭan aranĝon de fenestro"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "Vidi kaj redakti klavararanĝajn opciojn"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "Reagordi al la de_faŭltoj"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Anstataŭigi la aktualajn klavararanĝajn agordojn per la\n"
+#~ "defaŭltaj agordoj"
+
+#~ msgid "Layouts"
+#~ msgstr "Aranĝoj"
+
+#~ msgid "Format:"
+#~ msgstr "Formo:"
+
+#~ msgid "System settings"
+#~ msgstr "Sistemagordoj"
+
+#~ msgid "Layout"
+#~ msgstr "Aranĝo"
+
+#~ msgid "Brightness and Lock"
+#~ msgstr "Heleco kaj ŝlosado"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "Ekranheleco kaj ŝlosagordoj"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Heleco;Ŝlosi;Malheligo;Malplenigo;Ekrano;"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "Ne ŝlosu kiam hejme"
+
+#~ msgid "Locations..."
+#~ msgstr "Lokoj..."
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Enŝalti sencimigan kodon"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — Laŭtecregilo-aplikaĵeto de GNOME"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Montri labortablan laŭtecregilon"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Laŭteco de soneligo"
+
+#~ msgid "_Mute"
+#~ msgstr "_Silentigi"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "_Sonagordoj"
+
+#~ msgid "Muted"
+#~ msgstr "Silentigite"
+
+#~ msgid "No shortcut set"
+#~ msgstr "Neniu klavkombino estas agordite"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Universalaj aliragordoj"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Ekranklavaro"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomono"
+
+#~ msgid "Caribou"
+#~ msgstr "Karibuo"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Small"
+#~ msgstr "Malgranda"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Normala"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Large"
+#~ msgstr "Granda"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Change contrast:"
+#~ msgstr "Ŝanĝi kontraston:"
+
+#~ msgid "_Text size:"
+#~ msgstr "_Tekstgrando:"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Enzomi:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Elzomi:"
+
+#~ msgid "Options..."
+#~ msgstr "Agordoj..."
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "Zomi"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Montri tekstan priskribon de parolado kaj sonoj"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "Fermita apudskribado"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Pepi kiam klavo estas"
+
+#~ msgid "pressed"
+#~ msgstr "premite"
+
+#~ msgid "accepted"
+#~ msgstr "akceptite"
+
+#~ msgid "rejected"
+#~ msgstr "malakceptite"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "Antaŭakc_epta prokrasto:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Stiri la musmontrilon per cifera klavaro"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Stiri la musmontrilo per videokamerao."
+
+#~ msgid "Video Mouse"
+#~ msgstr "Videomuso"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Normale"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Alta/Inversa"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 ekrano"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 ekrano"
+
+#~ msgid "Create new account"
+#~ msgstr "Krei novan konton"
+
+#~ msgid "_Account Type"
+#~ msgstr "_Kontotipo"
+
+#~ msgid "Cr_eate"
+#~ msgstr "Kr_ei"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Ensaluti sen pasvorto"
+
+#~ msgid "Disable this account"
+#~ msgstr "Elŝalti tiun konton"
+
+#~ msgid "_Hint"
+#~ msgstr "_Helpindiko"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "Ĉi tiu konsileto rajtas esti montrata en la ensaluta ekrano. Ĝi estos "
+#~ "videbla al ĉiuj uzantoj de ĉi tiu sistemo. Do <b>ne</b> inkluzivu la "
+#~ "pasvorton tie ĉi."
+
+#~ msgid "Fair"
+#~ msgstr "Akcepteble"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Kiel elekti fortan pasvorton"
+
+#~ msgid "Account _type"
+#~ msgstr "Konto_tipo"
+
+#~ msgid "More choices..."
+#~ msgstr "Pliaj elektoj..."
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "Vi devas enigi novan pasvorton"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "Vi devas konfirmi la pasvorton"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "Vi devas enigi vian nuna pasvorton"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "La nuna pasvorto estas nekorekta."
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Tro mallonge"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Akcepteble"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Bone"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Foliumi por pliaj bildoj..."
+
+#~ msgid "This user does not exist."
+#~ msgstr "Tiu uzanto ne ekzistas."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Porgrafika tabuleto de Wacom"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Agordi vian tabuleton de Wacom"
+
+#~ msgid "Calibrate..."
+#~ msgstr "Kalibri..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- Sistemagordoj"
+
+#~ msgid "System Settings"
+#~ msgstr "Sistemagordoj"
+
+#~ msgid "Key"
+#~ msgstr "Ŝlosilo"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf-ŝlosilo al kiu ĉi tiu atributoredaktilo estas ligata"
+
+#~ msgid "Callback"
+#~ msgstr "Revoko"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Efiki ĉi tiun revokon kiam la valoro asociata kun la ŝlosilo ŝanĝiĝas"
+
+#~ msgid "Change set"
+#~ msgstr "Ŝanĝi agordon"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf-ŝanĝaro enhavanta datumojn por plusendi al la gconf-kliento je "
+#~ "apliko"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Konverto al komponanta revoko"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Revoko plenumata kiam datumoj estas konvertendaj de GConf al la komponanto"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Konverto de komponantorevoko"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Revoko plenumenda kiam datumoj estas konvertendaj al GConf de la "
+#~ "komponanto"
+
+#~ msgid "UI Control"
+#~ msgstr "UI-regilo"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Objekto kiu regas la atributon (ordinare komponanto)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Atributredaktilaj objektaj datumoj"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Propraj datumoj bezonataj de la specifa atributredaktilo"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Revoko por liberigi atributredaktilajn datumojn"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Revoko plenumenda kiam atributredaktilaj objektdatumoj estas liberigendaj"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Ne eblis trovi la dosieron '%s'.\n"
+#~ "\n"
+#~ "Bonvolu certiĝi, ke ĝi ekzistas kaj reprovu denove aŭ elektu malsaman "
+#~ "fonan bildon."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Mi ne scias kiel malfermi la dosieron '%s'.\n"
+#~ "Eble tiu bilda tipo ankoraŭ ne estas subtenata.\n"
+#~ "\n"
+#~ "Bonvolu elekti alian malsaman bildon."
+
+#~ msgid "Please select an image."
+#~ msgstr "Bonvolu elekti bildon."
+
+#~ msgid "Upside-down"
+#~ msgstr "Renversite"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "Ne eblis akiri seanco-buson dum aplikado de ekranagordoj"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f KB"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f MB"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f GB"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TB"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PB"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EB"
+
+#~ msgid "System Info"
+#~ msgstr "Sisteminformo"
+
+#~ msgid "Updates Available"
+#~ msgstr "Ĝisdatigoj disponeblas"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "Baskuligi kontraston"
+
+#~ msgid "Accelerator key"
+#~ msgstr "Akcela klavo"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Akcelaj modifiloj"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Akcela klavkodo"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "La tipo de la akcelilo."
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Troaj personaj klavkombinoj"
+
+#~ msgid "_Photos:"
+#~ msgstr "_Fotaĵoj:"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "kd;dvd;usb;sono;video;disko;"
+
+#~ msgid "Ask me"
+#~ msgstr "Demandi min"
+
+#~ msgid "Shutdown"
+#~ msgstr "Elŝalti"
+
+#~ msgid "Mute"
+#~ msgstr "Silentigi"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "Klavaro;Muso;a11y;Alireblo;"
+
+#~ msgid "Create a user"
+#~ msgstr "Krei uzanton"
+
+#~ msgid "Current network location"
+#~ msgstr "Aktuala loko en la reto"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "Adreso por pli da ekranfonoj"
+
+#~ msgid "More themes URL"
+#~ msgstr "Adreso por pli da etosoj"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "Agordi ĉi tion kiel nomo de via aktuala loko. Ĉi tiu estas uzata por "
+#~ "determini la taŭgan agordon por la reta prokurilo."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "Adreso kie eblas akiri pli da ekranfonoj. Se estas malplena ĉeno, la "
+#~ "ligilo ne estos montrata."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "Adreso kie eblas akiri pli da etosoj. Se estas malplena ĉeno, la ligilo "
+#~ "ne estos montrata."
+
+#~ msgid "Locked"
+#~ msgstr "Ŝlosite"
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "Sistempolitiko preventas ŝanĝojn.\n"
+#~ "Kontaktu vian sistemadministranton"
+
+#~ msgid "Photos"
+#~ msgstr "Fotaĵoj"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#~ msgid "Printing..."
+#~ msgstr "Presante..."
+
+#~ msgid "Image/label border"
+#~ msgstr "Bilda/etikeda bordero"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "Borderlarĝo ĉirkaŭ etikedo kaj bildo en la averto-dialogo"
+
+#~ msgid "The type of alert"
+#~ msgstr "La tipo de la averto"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "La montrataj butonoj en la averto-dialogo"
+
+#~ msgid "No Image"
+#~ msgstr "Neniu bildo"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Eraro okazis dum klopodo ricevi la adresarinformojn\n"
+#~ "La datumservilo de Evolucio ne povas trakti la protokolon"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "About Me"
+#~ msgstr "Pri mi"
+
+#~ msgid "C_ompany:"
+#~ msgstr "K_ompanio:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Ŝanĝi pasvo_rton..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Ur_bo:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "_Lando:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "La_ndo:"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "Elŝalti _fingropreman ensaluton..."
+
+#~ msgid "Email"
+#~ msgstr "Retpoŝto"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "Enŝalti _fingropreman ensaluton..."
+
+#~ msgid "Hom_e:"
+#~ msgstr "H_ejmo:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "Tujmesaĝilo"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "Poŝt_kesto:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P_oŝtkesto:"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Ŝtato/pro_vinco:"
+
+#~ msgid "User name:"
+#~ msgstr "Uzantonomo:"
+
+#~ msgid "Web"
+#~ msgstr "Reto"
+
+#~ msgid "Web _log:"
+#~ msgstr "TTT-_protokolo:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_Laborejo:"
+
+#~ msgid "Work"
+#~ msgstr "Laborejo"
+
+#~ msgid "Work _fax:"
+#~ msgstr "Labor_faksilo:"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "ZIP/_Poŝtkodo:"
+
+#~ msgid "_GroupWise:"
+#~ msgstr "_GroupWise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Hejmpaĝo:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Hejmo:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Manaĝero:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "Ŝ_tato/provinco:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Laborejo:"
+
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "_ZIP/Poŝtkodo:"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "Glitigi la fingron sur la legilo"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "Meti la fingron sur la legilo"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "Ido finiĝis neatendite"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "Ne eblis elŝalti eneligan kanalon de backend_stdin: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "Ne eblis elŝalti eneligan kanalon de backend_stdout: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "Sistemeraro: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "Ne eblas lanĉado de %s: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "Ne eblas lanĉi malantaŭan sistemon"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "Sistemeraro okazis"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "Alklaku <b>Ŝanĝi pasvorton</b> por ŝanĝi vian pasvorton."
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "Bonvolu denove tajpi vian pasvorton en la kampo <b>Retajpu novan "
+#~ "pasvorton</b>."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "La du pasvortoj ne estas egalaj."
+
+#~ msgid "Change your password"
+#~ msgstr "Ŝanĝi vian pasvorton"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "Por ŝanĝi vian pasvorton, entajpu vian nunan pasvorton en la kampo sube "
+#~ "kaj alklaku <b>Aŭtentigi</b>.\n"
+#~ "Post via aŭtentiĝo, entajpu vian novan pasvorton, retajpu ĝin por "
+#~ "kontrolo kaj alklaku <b>Ŝanĝi la pasvorton</b>."
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "Alirebla _ensaluto"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "Helpaj teknikoj"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Agordoj pri helpaj teknikoj"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "Ŝanĝoj por enŝalti helpajn teknikojn ne efektiviĝos ĝis via sekva "
+#~ "ensaluto."
+
+#~ msgid "Changes to visual system bell take effect immediately."
+#~ msgstr "Ŝanĝoj al vida sistempepo tuj efektiviĝas."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Fermi kaj e_lsaluti"
+
+#~ msgid "Enable _visual system bell"
+#~ msgstr "Enŝalti vidan sistempepon"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Salti al la dialogo pri preferataj aplikaĵoj"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "Salti al la dialogon por alirebla ensaluto"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "Salti al la dialogo por klavaralireblo"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Salti al la dialogo por musalireblo"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Enŝaltu asistajn t_eknologiojn"
+
+#~ msgid "_Password dialogs as normal windows"
+#~ msgstr "_Pasvortdialogoj kiel ordinaraj fenestroj"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "_Preferataj aplikaĵoj"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "Elekti kiuj alireblofunkcioj estas enŝaltataj kiam vi ensalutas"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Tiparo eble estas tro granda"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "La elektita tiparo estas tro granda je %d punkto, kaj ĝi povas "
+#~ "malfaciligi eficiente uzi la komputilon. Estas rekomendite ke vi elektu "
+#~ "grandon malpli altan ol %d."
+#~ msgstr[1] ""
+#~ "La elektita tiparo estas tro granda je %d punktoj, kaj ĝi povas "
+#~ "malfaciligi eficiente uzi la komputilon. Estas rekomendite ke vi elektu "
+#~ "grandon malpli altan ol %d."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "La elektita tiparo estas tro granda je %d punkto, kaj ĝi povas "
+#~ "malfaciligi eficiente uzi la komputilon. Estas rekomendite ke vi elektu "
+#~ "malpli grandan tiparon."
+#~ msgstr[1] ""
+#~ "La elektita tiparo estas tro granda je %d punktoj, kaj ĝi povas "
+#~ "malfaciligi eficiente uzi la komputilon. Estas rekomendite ke vi elektu "
+#~ "malpli grandan tiparon."
+
+#~ msgid "Use selected font"
+#~ msgstr "Uzi elektitan tiparon"
+
+#~ msgid "Could not load user interface file: %s"
+#~ msgstr "Ne eblis ŝargi uzantinterfacan dosieron: %s"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Agordi la dosiernomon de instalenda etoso"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "Specifi la nomon de la montrota paĝo (theme|background|fonts|interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[EKRANFONO...]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "Ĉi tiu etoso ne aspektos kiel intencite ĉar la bezonata GTK+-etosmaŝino "
+#~ "'%s' ne estas instalita."
+
+#~ msgid "Apply Background"
+#~ msgstr "Apliki ekranfonon"
+
+#~ msgid "Apply Font"
+#~ msgstr "Apliki tiparon"
+
+#~ msgid "Revert Font"
+#~ msgstr "Malfari tiparon"
+
+#~ msgid ""
+#~ "The current theme suggests a background, a font and a button layout. "
+#~ "Also, the last applied font and button layout suggestion can be reverted."
+#~ msgstr ""
+#~ "La nuna etoso proponas fonon, tiparon kaj butonstrukturon. Krome, la "
+#~ "laste aplikita propono de tiparo kaj butonstrukturo povas esti malfarata."
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "La nuna etoso proponas fonon kaj tiparon. Krome, la laste aplikita "
+#~ "tiparpropono povas estas malfarata."
+
+#~ msgid ""
+#~ "The current theme suggests a background, a font and a button layout. "
+#~ "Also, the last applied button layout suggestion can be reverted."
+#~ msgstr ""
+#~ "La nuna etoso proponas fonon, tiparon kaj butonstrukturon. Krome, la "
+#~ "laste aplikita propono de butonstrukturo povas esti malfarata."
+
+#~ msgid ""
+#~ "The current theme suggests a background and a button layout. Also, the "
+#~ "last applied font and button layout suggestion can be reverted."
+#~ msgstr ""
+#~ "La nuna etoso proponas fonon kaj butonstrukturon. Krome, la laste "
+#~ "aplikita propono de tiparo kaj butonstrukturo povas esti malfarata."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "La nuna etoso proponas fonon. Krome, la laste aplikita tiparpropono povas "
+#~ "esti malfarata."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "La nuna etoso proponas fonon kaj tiparon."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "La nuna etoso proponas tiparon. Krome, la laste aplikita tiparpropono "
+#~ "povas esti malfarata."
+
+#~ msgid ""
+#~ "The current theme suggests a font and a button layout. Also, the last "
+#~ "applied button_layout suggestion can be reverted."
+#~ msgstr ""
+#~ "La nuna etoso proponas tiparon kaj butonstrukturon. Krome, _la laste "
+#~ "aplikita propono de butonstrukturo povas esti malfarata."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "La nuna etoso proponas fonon."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "La laste aplikita tiparpropono povas esti malfarata."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "La nuna etoso proponas tiparon."
+
+#~ msgid ""
+#~ "The current theme suggests a button layout. Also, the last button layout "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "La nuna etoso proponas butonstrukturon. Krome, lasta aplikita propono de "
+#~ "butonstrukturo povas esti malfarata."
+
+#~ msgid "Best _shapes"
+#~ msgstr "Plej bonaj _formoj"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "Personigi..."
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "Ŝanĝo de indikiletoso efektiviĝos kiam vi sekve ensalutas."
+
+#~ msgid "Customize Theme"
+#~ msgstr "Personigi etoson"
+
+#~ msgid "D_etails..."
+#~ msgstr "D_etaloj..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "_Labortabla tiparo:"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "Detaloj pri tipara pentrado"
+
+#~ msgid "Fonts"
+#~ msgstr "Tiparoj"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "Akiri pli da ekranfonoj rete"
+
+#~ msgid "Get more themes online"
+#~ msgstr "Akiri pli da etosoj rete"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Gr_izoskalo"
+
+#~ msgid "Icons"
+#~ msgstr "Piktogramoj"
+
+#~ msgid "Icons only"
+#~ msgstr "Nur piktogramoj"
+
+#~ msgid "N_one"
+#~ msgstr "N_eniu"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Malfermi dialogfenestron por difini la koloron"
+
+#~ msgid "R_esolution:"
+#~ msgstr "_Distingivo:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "Konservi etoson kiel..."
+
+#~ msgid "Save _As..."
+#~ msgstr "_Konservi kiel..."
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sub_bildere (LCD-ekranoj)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Sub_bildera glatigado (LDC-ekranoj)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "Subbildera ordo"
+
+#~ msgid "Text"
+#~ msgstr "Teksto"
+
+#~ msgid "Text below items"
+#~ msgstr "Teksto sub eroj"
+
+#~ msgid "Text beside items"
+#~ msgstr "Teksto apud eroj"
+
+#~ msgid "Text only"
+#~ msgstr "Nur teksto"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "La aktuala kontroliletoso ne subtenas kolorskemojn."
+
+#~ msgid "Theme"
+#~ msgstr "Etoso"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_VR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BVR"
+
+#~ msgid "_Description:"
+#~ msgstr "_Priskribo:"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Dokumenta tiparo:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_Fikslarĝa tiparo:"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Unukolore"
+
+#~ msgid "_None"
+#~ msgstr "_Neniu"
+
+#~ msgid "_RGB"
+#~ msgstr "_RVB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "_Reagordi al la defaŭltoj"
+
+#~ msgid "_Selected items:"
+#~ msgstr "E_lektitaj elementoj:"
+
+#~ msgid "_Size:"
+#~ msgstr "_Grando:"
+
+#~ msgid "_Slight"
+#~ msgstr "_Iomete"
+
+#~ msgid "_Style:"
+#~ msgstr "_Stilo:"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "Ŝ_pruchelpilo:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRVB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Fenestra titola tiparo:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Fenestroj:"
+
+#~ msgid "dots per inch"
+#~ msgstr "punktoj je colo"
+
+#~ msgid "Appearance"
+#~ msgstr "Aspekto"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Alpropigi la aspekton de la labortablo"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Instalas etospakaĵojn por diversaj partoj de la labortablo."
+
+#~ msgid "Theme Installer"
+#~ msgstr "Etosa instalilo"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "GNOME-a etospakaĵo"
+
+#~ msgid "Slide Show"
+#~ msgstr "Bildserio"
+
+#~ msgid "Image"
+#~ msgstr "Bildo"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Dosierujo: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Dosierujo: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "Ne eblas instali la etoson"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "La utilaĵo %s ne estas instalita."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "Problemo okazis dum la eltirado de la etoso."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "Eraro okazis dum la instalado de la elektita dosiero"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "Ŝajnas, ke \"%s\" ne estas valida etoso."
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "Ŝajnas, ke \"%s\" ne estas valida etoso. Eble ĝi estas etosmodulo, kiun "
+#~ "vi necesas kompili."
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "Instalado de la etoso \"%s\" malsuckesis."
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "La etoso \"%s\" estas instalita."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "Ĉu vi deziras nun apliki ĝin aŭ teni vian nunan etoson?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Lasi la nunan etoson"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Apliki la novan etoson"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME-a etoso %s korekte instalita"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "La novaj etosoj estas sukcese instalita."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Neniu etosdosiera situo specifita por instali"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nesufiĉaj permesoj por instali la etoson en:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "Elekti etoson"
+
+#~ msgid "Theme Packages"
+#~ msgstr "Etospakaĵoj"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Etosa nomo ĉeestu."
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "La etoso jam ekzistas. Ĉu vi ŝatus anstataŭigi ĝin?"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Ĉu vi volas forigi tiun ĉi etoson?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "Ne eblis instali la etos-modulon"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Neeblas starti la agordmastrumilon 'gnome-settings-daemon'.\n"
+#~ "Sen la rulanta GNOME-agordmastrumilo, kelkaj agordoj eble ne efektiviĝos. "
+#~ "Ĉi tio eble signifas problemon de DBus aŭ ne-GNOME-agordmastrumilo (ekz. "
+#~ "KDE) eble estas rulanta kaj konfliktanta kun GNOME-agordmastrumilo."
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Ne eblas ŝargi standardan piktogramon '%s'\n"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Eraro okazis dum montrado de helpo: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Kopianta dosieron: %u el %u"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "Kopianta '%s'"
+
+#~ msgid "Copying files"
+#~ msgstr "Kopiante dosierojn"
+
+#~ msgid "Parent Window"
+#~ msgstr "Gepatra fenestro"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "Gepatra fenestro de la dialogo"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI el kiu aktuale transmetanta"
+
+#~ msgid "To URI"
+#~ msgstr "Al URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI-o al kiu aktuale transportante"
+
+#~ msgid "Fraction completed"
+#~ msgstr "Parto finita"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Parto de la transmeto aktuale plenumita"
+
+#~ msgid "Current URI index"
+#~ msgstr "Altuala URI-indekso"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Altuala URI-indekso - komencas je 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "Tutaj URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Tuta nombro de URI"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "Dosiero '%s' jam ekzistas. Ĉu vi volas anstataŭigi ĝin?"
+
+#~ msgid "_Skip"
+#~ msgstr "_Ignori"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "Anstataŭigi ĉi_ujn"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Defaŭlta indikilo - aktuala"
+
+#~ msgid "White Pointer"
+#~ msgstr "Blanka indikilo"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Blanka indikilo - aktuala"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Granda indikilo - aktuala"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Granda blanka indikilo - aktuala"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Ĉi tiu etoso ne ŝajnas kiel intenciite ĉar la necesata GTK+-etoso '%s' ne "
+#~ "estas instalita."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "Ĉi tiu etoso ne ŝajnas kiel intenciite ĉar la necesata fenestrmastrumila "
+#~ "etoso '%s' ne estas instalita."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Ĉi tiu etoso ne ŝajnas kiel intenciite ĉar la necesata piktogrametoso "
+#~ "'%s' ne estas instalita."
+
+#~ msgid "Preferred Applications"
+#~ msgstr "Preferitaj aplikaĵoj"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "Starti la preferitan vidan helpan teknologion"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "Vida helpo"
+
+#~ msgid "Error setting default browser: %s"
+#~ msgstr "Eraro dum agordado de la defaŭlta retumilo: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Ne eblis ŝargi la ĉefan interfacon"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "Specifi la nomon de la montrenda paĝo (internet|multimedia|system|a11y)"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Ĉiuj aperoj %s estos anstataŭigataj per efektiva ligilo"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Ko_mando:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "R_ula flago:"
+
+#~ msgid "Image Viewer"
+#~ msgstr "Bildorigardilo"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "Tujmesaĝilo"
+
+#~ msgid "Mail Reader"
+#~ msgstr "Mesaĝlegilo"
+
+#~ msgid "Mobility"
+#~ msgstr "Movebleco"
+
+#~ msgid "Multimedia"
+#~ msgstr "Plurmediaĵoj"
+
+#~ msgid "Run at st_art"
+#~ msgstr "Lanĉi dum st_arto"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Lanĉi en t_erminalo"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "Terminal-imitilo"
+
+#~ msgid "Text Editor"
+#~ msgstr "Tekstredaktilo"
+
+#~ msgid "_Run at start"
+#~ msgstr "_Ruli dum starto"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Muzikludilo Banŝio"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "Pligrandigilo de GNOME sen ekranlegilo"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnoperniko"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnoperniko kun pligrandigilo"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "Pligrandigilo de KDE sen ekranlegilo"
+
+#~ msgid "Konsole"
+#~ msgstr "Konzolo"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Linuksa ekranlegilo kun pligrandigilo"
+
+#~ msgid "Listen"
+#~ msgstr "Aŭskulti"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Orca"
+#~ msgstr "Orko"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Muzikludilo Rhythmbox"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Filmludilo Totemo"
+
+#~ msgid "Include _panel"
+#~ msgstr "Inkluzivi _panelon"
+
+#~ msgid "Monitor Preferences"
+#~ msgstr "Ekranoagordoj"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "Sa_ma bildo en ĉiuj ekranoj"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "_Detekti ekranojn"
+
+#~ msgid "Monitors"
+#~ msgstr "Monitoroj"
+
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "Uzado: %s FONTA_DOSIERO CELA_NOMO\n"
+#~ "\n"
+#~ "Ĉi tiu programaro instalas RANDR-profilon por plurekranaj agordoj en\n"
+#~ "tutsistema loko. La rezulta profilo kutimiĝos kiam\n"
+#~ "la RANDR-kromprogramo rulas en gnome-settings-daemon.\n"
+#~ "\n"
+#~ "FONTA_DOSIERO - plenpada nomo, kutime /home/uzantonomo/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "CELA_NOMO - relativa nomo por la instalita dosiero.  Ĉi tio estos metita "
+#~ "en\n"
+#~ "            la tutsistema dosierujo por RANDR-agordoj,\n"
+#~ "            tiel la rezulto kutime estos %s/CELA_NOMO\n"
+
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "Ĉi tiu programaro povas esti uzata nur de ĉefuzanto"
+
+#~ msgid "The source filename must be absolute"
+#~ msgstr "La fonta dosiernomo estu absoluta"
+
+#~ msgid "Could not get information for %s: %s\n"
+#~ msgstr "Ne eblis obteni informojn por %s: %s\n"
+
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s estu regulara dosiero\n"
+
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "Ĉi tiu programaro estu rulata nur per pkexec(1)"
+
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "PKEXEC_UID estu agordita per entjera valoro"
+
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "%s estu posedita de vi\n"
+
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s ne havu iujn dosierujkomponantojn\n"
+
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s estu dosierujo\n"
+
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "Ne eblas malfermi %s/%s: %s\n"
+
+#~ msgid "Could not rename %s to %s: %s\n"
+#~ msgstr "Ne eblas alinomi %s al %s: %s\n"
+
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "Instali plurekranajn agordojn por la tuta sistemo"
+
+#~ msgid "Upside Down"
+#~ msgstr "Renversita"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "Ekrano: %s"
+
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "La ekranagordoj estas konservitaj"
+
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "Ne eblas agordi la defaŭltajn agordojn por la ekranoj"
+
+#~ msgid "Desktop"
+#~ msgstr "Labortablo"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "Eraro dum malagordado de akceliloj en agorddatumbazo: %s"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Atribui klavkombinojn al komandojn"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Nur apliki agordojn kaj fini (nur pro kongrueco; nun traktite de demono)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Komenci la paĝon per montrado de la tajppaŭza agordaro"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Komenci la paĝon per montrado de la alirebleca agordaro"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- Klavaragordoj de GNOME"
+
+#~ msgid "Beep when _accessibility features are turned on or off"
+#~ msgstr "Pepi kiam _alireblectrajto estas ŝaltita"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Pepi kiam klavo estas malakceptita"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Sonsondo pri klavaralirebleco"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "Montri _vidan sondon pri la avertsono"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "Vidaj signaloj por sonoj"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Permesi pr_okraston de paŭzojn"
+
+#~ msgid "Apply System-Wide..."
+#~ msgstr "Apliki tut-sisteme..."
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Sona prisondo..."
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Kontroli ĉu paŭzoj estas permesataj esti prokrastataj"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Daŭro de la paŭzo kiam tajpado estas malpermesata"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Daŭro de tasko antaŭ devigi paŭzon"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Klavara _modelo:"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Ŝlosi ekranon post certa daŭro por helpi preventi sanajn damaĝojn pro "
+#~ "ripeta klavara uzo"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "Movi la elektitan klavararanĝon supren en la listo"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "Presi grafikon de elektita klavararanĝo"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "Forigi la elektitan klavararanĝon el la listo"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "Elekti aldonendan klavararanĝon el la listo"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "Paŭza intervalo daŭras:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "Ŝ_losi la ekranon por devigi tajpopaŭzojn"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_Akcepti nur longajn klavpremojn"
+
+#~ msgid "_Separate layout for each window"
+#~ msgstr "_Separita fasono por ĉiu fenestro"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Simuli samtempajn klavpremojn"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Labora intervalo daŭras:"
+
+#~ msgid "_Country:"
+#~ msgstr "L_ando:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variaĵoj:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Elekti klavaran modelon"
+
+#~ msgid "_Models:"
+#~ msgstr "_Modeloj:"
+
+#~ msgid "Vendors"
+#~ msgstr "Vendistoj"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "Movi maldekstren"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "Movi dekstren"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "Movi supren"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "Movi malsupren"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "Elŝaltite"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- Musagordoj de GNOME"
+
+#~ msgid "D_rag click:"
+#~ msgstr "T_ren-klako:"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr ""
+#~ "Vi povas uzi ankaŭ la panelaplikaĵeton 'Postatenda klako' por elekti la "
+#~ "klaktipon."
+
+#~ msgid "_Single click:"
+#~ msgstr "_Unuopa klako:"
+
+#~ msgid "Location already exists"
+#~ msgstr "Loko jam ekzistas"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Agordi viajn retan prokurilon"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Per_mana prokurila agordo</b>"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP-prokurilaj detaloj"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Retaj prokurilaj agordoj"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Sekura HTTP-prokurilo:"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "Ne eblas lanĉi la agordoaplikaĵon por via fenestroadministrilo"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_iper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "S_uper (aŭ \"Vindoza klavo\")"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "Por movi fenestron, premadu ĉi tiun klavon kaj prenu la fenestron:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Fenestroagordoj"
+
+#~ msgid "Window Selection"
+#~ msgstr "Fenestroelekto"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Intervalo antaŭ al levi:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Levi elektitajn fenestrojn post intervalo"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "Elekti fene_strojn kiam la muso moviĝas super ili"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Agordi viajn fenestrajn atributojn"
+
+#~ msgid "Windows"
+#~ msgstr "Fenestroj"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Fenestroadministrilo \"%s\" ne registris agordilon\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "Maksimumigi vertikale"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Maksimumigi horizontale"
+
+#~ msgid "Roll up"
+#~ msgstr "Rulumi supren"
+
+#~ msgid "Filter"
+#~ msgstr "Filtri"
+
+#~ msgid "Groups"
+#~ msgstr "Grupoj"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Fermi la stircentron kiam tasko estas aktivigata"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "Ĉesi la ŝelon kiam aldona aŭ foriga ago estas plenumata"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Ĉesi la ŝelon kiam helpago estas plenumata"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Ĉesi la ŝelon je plenumo de lanĉa ago"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "Ĉesi la ŝelon je plenumo de promocia aŭ malinstala ago"
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "Tasknomoj kaj asociataj .desktop-dosieroj"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "La agordilo de GNOME"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_Prokrasti paŭzon"
+
+#~ msgid "_Take a Break"
+#~ msgstr "_Fari paŭzon"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d minuto ĝis la sekva paŭzo"
+#~ msgstr[1] "%d minutoj ĝis la sekva paŭzo"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Malpli ol unu minuto ĝis la sekva paŭzo"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr "Neeblas aperigi la dialogon de tajpa paŭzo kun la jena eraro: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Verkite de Richard HULT <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Vidindaĵo aldonate de Anders CARLSON"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Komputila paŭzo-rememorigo."
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Ne kontroli ĉu la atentigareo ekzistas"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "La tajpadmonitoro uzas la atentigareon por vidigi informojn. Ŝajnas ke vi "
+#~ "ne havas atentigareon sur via panelo. Vi povas aldoni ĝin per dekstra "
+#~ "alklako sur via panelo kaj elekto de 'Aldoni al panelo', elektante "
+#~ "'Atentigareo' kaj alklakante 'Aldoni'."
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "Se agordata al vera, tiam OpenType-tiparoj estos miniaturigataj."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Se agordata al vera, tiam PCF-tiparoj estos miniaturigataj."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "Se agordata al vera, tiam TrueType-tiparoj estos miniaturigataj."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Se agordata al vera, tiam Type1-tiparoj estos miniaturigataj."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Agordi ĉi tiun ŝlosilon al la komando uzata por krei miniaturojn por "
+#~ "OpenType-tiparoj."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Agordi ĉi tiun ŝlosilon al la komando uzata por krei miniaturojn por PCF-"
+#~ "tiparoj."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Agordi ĉi tiun ŝlosilon al la komando uzata por krei miniaturojn por "
+#~ "TrueType-tiparoj."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Agordi ĉi tiun ŝlosilon al la komando uzata por krei miniaturojn por "
+#~ "Type1-tiparoj."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Miniatura komando por OpenType-tiparoj"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Miniatura komando por PCF-tiparoj"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Miniatura komando por TrueType-tiparoj"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Miniatura komando por Type1-tiparoj"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Ĉu miniaturigi OpenType-tiparojn?"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Ĉu miniaturigi PCF-tiparojn?"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Ĉu miniaturigi la TrueType-tiparojn?"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Ĉu miniaturigi la Type1-tiparojn?"
+
+#~ msgid "Copyright:"
+#~ msgstr "Kopirajto:"
+
+#~ msgid "Description:"
+#~ msgstr "Priskribo:"
+
+#~ msgid "Installed"
+#~ msgstr "Instalite"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "uzado: %s-tipara dosiero\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "I_nstali tiparon"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Teksto al miniaturo (defaŭlte: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEKSTO"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Tipargrando (defaŭlte: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "GRANDO"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "TIPAR-DOSIERO ELIG-DOSIERO"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "Via filtrilo \"%s\" ne trovas iun eron."
+
+#~ msgid "Upgrade"
+#~ msgstr "Promocii"
+
+#~ msgid "Uninstall"
+#~ msgstr "Malinstali"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "Aldoni al favoritoj"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Forigi de eklanĉaj programoj"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Aldoni al eklanĉaj programoj"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "Nova kalkultabelo"
+
+#~ msgid "New Document"
+#~ msgstr "Nova dokumento"
+
+#~ msgctxt "Home folder"
+#~ msgid "Home"
+#~ msgstr "Hejmo"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "Se vi forigos eron, ĝi malaperos por ĉiam."
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "Malfermi per \"%s\""
+
+#~ msgid "Open in File Manager"
+#~ msgstr "Malfermi en dosieradministrilo"
+
+#~ msgid "Remove from recent menu"
+#~ msgstr "Forigi el freŝaj eroj"
+
+#~ msgid "Purge all the recent items"
+#~ msgstr "Vakigi ĉiujn freŝajn erojn"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Hodiaŭ %l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "Serĉi nun"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Malfermi %s</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "Forigi el sistemeroj"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Malfermi ligilon en nova _tabo"
+
+#~ msgid ""
+#~ "<b>_None:</b> Provides a simple desktop environment without any effects."
+#~ msgstr "<b>_Neniu:</b> Donas simplan labortablan medion sen iaj efektaĵoj."
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolucio-Retpoŝta Legilo"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Malfermi ligilon per TTT-foliumila _defaŭlta ago."
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Testante la novan agordaron. Se vi ne reagas post %d sekundo la antaŭa "
+#~ "agordaro estos restarigataj."
+#~ msgstr[1] ""
+#~ "Testante la novan agordaron. Se vi ne reagas post %d sekundoj la antaŭa "
+#~ "agordaro estos restarigataj."
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Malfermi ligilon en nova _fenestro"
+
+#~ msgid ""
+#~ "<b>E_xtra:</b> Provides more aesthetically pleasing set of effects. "
+#~ "Requires faster graphics card."
+#~ msgstr ""
+#~ "<b>_Ekstra:</b> Provizas pli estetike plaĉan aron da efektoj. Postulas "
+#~ "pli rapidan grafikan karton."
+
+#~ msgid "<b>C_ustom:</b> Uses custom set of effects."
+#~ msgstr "<b>_Propra:</b> Uzas propran aron da efektoj."

--- a/po/es.po
+++ b/po/es.po
@@ -15,117 +15,24 @@
 # Jorge González <jorgegonz@svn.gnome.org>, 2007, 2008, 2009, 2010, 2011.
 # Daniel Mustieles <daniel.mustieles@gmail.com>, 2010-2021.
 # Daniel Mustieles García <daniel.mustieles@gmail.com>, 2021-2022.
+# leo <daniel.mustieles@gmail.com>, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
-"PO-Revision-Date: 2022-08-26 09:49+0200\n"
-"Last-Translator: Daniel Mustieles García <daniel.mustieles@gmail.com>\n"
-"Language-Team: Spanish - Spain <gnome-es-list@gnome.org>\n"
-"Language: es_ES\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-11-08 18:03+0100\n"
+"Last-Translator: leo <daniel.mustieles@gmail.com>\n"
+"Language-Team: Español; Castellano <gnome-es-list@gnome.org>\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Gtranslator 42.0\n"
-
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Bus del sistema"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Acceso completo"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Bus de sesión"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Dispositivos"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Acceso completo a /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Red"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Tiene acceso a la red"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Carpeta personal"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Sólo lectura"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Sistema de achivos"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Configuración"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Puede cambiar la configuración"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s tiene los siguientes permisos integrados y no se pueden modificar. Si "
-"esto le preocupa considere la opción de quitar esta aplicación."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u tipo de archivo y enlace abierto por esta aplicación"
-msgstr[1] "%u tipos de archivos y enlaces abiertos por esta aplicación"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> se usa para abrir los siguientes tipos de archivos y enlaces."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s de espacio de disco usado."
+"X-Generator: Gtranslator 3.38.0\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -141,9 +48,8 @@ msgid "Install some…"
 msgstr "Instalar algunas…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
-msgstr "Abierta"
+msgstr "Abrir"
 
 #: panels/applications/cc-applications-panel.ui:94
 msgid "View Details"
@@ -165,24 +71,13 @@ msgstr "Buscar"
 msgid "Receive system searches and send results."
 msgstr "Recibir búsquedas del sistema y enviar os resultados."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Desactivado"
 
@@ -348,80 +243,20 @@ msgstr "Limpiar la caché…"
 msgid "Control various application permissions and settings"
 msgstr "Controlar la configuración y los permisos de varias aplicaciones"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplicación;flatpak;permisos;configuración;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Seleccionar una imagen"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Cancelar"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Abrir"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "tamaños múltiples"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Sin fondo de escritorio"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Fondo actual"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Estilo"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Predeterminado"
 
@@ -445,7 +280,6 @@ msgstr "Apariencia"
 msgid "Change your background image or the UI colors"
 msgstr "Cambiar la imagen de fondo de escritorio o los colores de la IU"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -498,9 +332,7 @@ msgstr "El hardware en modo avión está activado"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Apague el modo avión para activar el Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -508,7 +340,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Activar y desactivar Bluetooth y conectar sus dispositivos"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "compartir;compartición;bluetooth;obex;"
@@ -541,94 +372,33 @@ msgstr "Ninguna aplicación ha solicitado acceso a la cámara"
 msgid "Protect your pictures"
 msgstr "Proteger sus imágenes"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "cámara;fotos;vídeo;webcam;web;bloqueo;privado;privacidad;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Coloque su dispositivo de calibración sobre el cuadrado y pulse «Iniciar»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Mueva su dispositivo de calibración a la posición de calibrado y pulse "
-"«Continuar»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Mueva su dispositivo de calibración a la posición de la superficie y pulse "
-"«Continuar»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Apagar la tapa del portátil"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Ocurrió un error interno y no se pudo recuperar."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Las herramientas requeridas para la calibración no están instaladas."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "No se puede generar el perfil."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "No se pudo obtener el punto blanco del objetivo."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Completado"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Falló la configuración."
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Puede quitar el dispositivo de calibración."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "No interrumpir al dispositivo de calibración cuando está en progreso"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibración de la pantalla"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancelar"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -645,140 +415,6 @@ msgstr "_Reanudar"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Hecho"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Pantalla del portátil"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Cámara web integrada"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Escáner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Cámara %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Impresora %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Cámara web %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Activar la gestión de color para %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Mostrar perfiles de color para %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Sin calibrar"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Predeterminado: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Espacio de color: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Perfil de color: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Seleccionar archivo de perfil ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importar"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Perfiles ICC soportados"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Todos los archivos"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Pantalla"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Guardar perfil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Guardar"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Crear un perfil de color para el dispositivo seleccionado"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"No se detectó el instrumento de medida. Compruebe que está encendido y "
-"correctamente conectado."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "El instrumento de medida no soporta perfilado de impresoras."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "El tipo de dispositivo actualmente no está soportado."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -895,13 +531,13 @@ msgstr "Requiere un medio escribible"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Puede encontrar instrucciones útiles sobre cómo usar el perfil en sistemas "
-"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> y <a href="
-"\"windows\">Microsoft Windows</a>."
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> y <a "
+"href=\"windows\">Microsoft Windows</a>."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -921,7 +557,6 @@ msgstr "_Importar archivo…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -933,9 +568,7 @@ msgstr ""
 "Cada dispositivo necesita un perfil de color actualizado para poder "
 "gestionar el color."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Aprender más"
 
@@ -1067,84 +700,6 @@ msgstr "D65 (Fotografía y gráficos)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Espacio estándar"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Perfil de prueba"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automático"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Calidad baja"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Calidad media"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Calidad alta"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB predeterminado"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK predeterminado"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Gris predeterminado"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Datos de calibración de fábrica proporcionados por el vendedor"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-"La corrección de la pantalla en modo a pantalla completa no es posible con "
-"este perfil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Este perfil ya no es preciso."
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Color"
@@ -1155,14 +710,9 @@ msgid ""
 msgstr ""
 "Calibrar el color de sus dispositivos, como pantallas, cámaras o impresoras"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Color;ICC;Perfil;Calibrado;Impresora;Pantalla;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Otro…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1177,13 +727,8 @@ msgid "No languages found"
 msgstr "No se han encontrado idiomas"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Más…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Desbloquear para cambiar la configuración"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1212,151 +757,6 @@ msgstr "Reducir hora"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Reducir minuto"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Hoy"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Ayer"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e de %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d hora"
-msgstr[1] "%d horas"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuto"
-msgstr[1] "%d minutos"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d segundo"
-msgstr[1] "%d segundos"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 seconds"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 horas"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%d/%b/%Y, %I:%M"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%d/%b/%Y, %H:%M"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%H:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1451,17 +851,11 @@ msgstr "_Zona horaria automática"
 msgid "Requires location services enabled and internet access"
 msgstr "Requiere activar los servicios de ubicación y el acceso a Internet"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Activada"
 
@@ -1469,15 +863,42 @@ msgstr "Activada"
 msgid "Time Z_one"
 msgstr "Z_ona horaria"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desbloquear"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Formato de _fecha"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Fechas"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 seconds"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Calendario"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Números"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Cambiar la fecha y la hora, incluyendo la zona horaria"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Reloj;Zona horaria;Ubicación;"
@@ -1524,20 +945,9 @@ msgstr "Aplicaciones predeterminadas"
 msgid "Configure Default Applications"
 msgstr "Configurar aplicaciones predeterminadas"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "predeterminado;aplicación;preferida;medios;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Enviar informes de problemas técnicos ayuda a mejorar %s. Los informes se "
-"envían anónimamente y no contienen datos personales. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1555,44 +965,9 @@ msgstr "Diagnósticos"
 msgid "Report your problems"
 msgstr "Informar de problemas"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnósticos;fallo;error;crash;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Encendido"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Apagado"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "¿Aplicar los cambios?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "No se pueden aplicar los cambios"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Esto puede deber a limitaciones hardware."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1642,31 +1017,6 @@ msgstr "Pantalla primaria"
 msgid "Night Light"
 msgstr "Luz nocturna"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Horizontal"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Vertical derecha"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Vertical izquierda"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Horizontal (dada la vuelta)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1690,6 +1040,17 @@ msgstr "Ajustes para TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Escala"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Desplazamiento natural"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1785,7 +1146,6 @@ msgstr "Pantallas"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Elegir cómo usar las pantallas y los proyectores conectados"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1793,80 +1153,6 @@ msgid ""
 msgstr ""
 "Panel;Proyector;xranrd;Pantalla;Resolución;Actualizar;Monitor;Noche;Luz;Azul;"
 "color;amanecer;atardecer;ocaso;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "Secure Boot está activado"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"El arranque seguro evita que se cargue software malicioso cuando se inicia "
-"el dispositivo. Actualmente está activo y funcionando correctamente."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "El arranque seguro tiene problemas"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"El arranque seguro evita que se cargue software malicioso cuando se inicia "
-"el dispositivo. Actualmente está activo pero no funcionará debido a que "
-"tiene una clave no válida."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Los problemas del arranque seguro se pueden resolver a menudo desde la "
-"configuración del firmware UEFI del equipo (BIOS) y su fabricante puede "
-"proporcionar información sobre cómo hacerlo."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Para obtener ayuda contacte con el fabricante del hardware o su proveedor de "
-"TI."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "El arranque seguro está apagado"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"El arranque seguro evita que se cargue software malicioso cuando se inicia "
-"el dispositivo. Actualmente está apagado."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"El arranque seguro se puede activar desde la configuración del firmware UEFI "
-"del equipo (BIOS). Para obtener ayuda contacte con el fabricante del "
-"hardware o su proveedor de TI."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1881,134 +1167,9 @@ msgstr ""
 "Para obtener más información contacte con el fabricante del hardware o su "
 "proveedor de TI."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Correcta"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Falló"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "El dispositivo cumple con el nivel %d de HSI"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "Nivel de seguridad 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Este dispositivo no tiene protección contra problemas de seguridad de "
-"hardware. Esto podría deberse a un problema de configuración de hardware o "
-"firmware. Se recomienda ponerse en contacto con su proveedor de soporte de "
-"TI."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "Nivel de seguridad 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Este dispositivo tiene una protección mínima contra problemas de seguridad "
-"de hardware. Este es el nivel de seguridad más bajo del dispositivo y solo "
-"brinda protección contra amenazas de seguridad simples."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "Nivel de seguridad 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Este dispositivo tiene protección básica contra problemas de seguridad de "
-"hardware. Esto proporciona protección contra algunas amenazas de seguridad "
-"comunes."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "Nivel de seguridad 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Este dispositivo tiene protección extendida contra problemas de seguridad de "
-"hardware. Este es el nivel más alto de seguridad del dispositivo y brinda "
-"protección contra amenazas de seguridad avanzadas."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "Nivel de seguridad"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr "Los niveles de seguridad no están disponibles para este dispositivo."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Contacte con el fabricante del hardware para solicitar ayuda sobre las "
-"actualizaciones de seguridad."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Es posible resolver este problema en la configuración del firmware UEFI del "
-"dispositivo o con un soporte técnico."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Es posible resolver este problema en la configuración del firmware UEFI del "
-"dispositivo."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Es posible resolver este problema con un soporte técnico."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2022,338 +1183,9 @@ msgstr "Nivel 2"
 msgid "Level 3"
 msgstr "Nivel 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr "Protegido frente a software malicioso cuando se inicia el dispositivo."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "Secure Boot tiene problemas"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "Alguna protección cuando se inicia el dispositivo."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "El arranque seguro está apagado"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "Sin protección cuando se inicia el dispositivo."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Este problema puede haberlo causado un cambio en la configuración del "
-"firmware UEFI, en el sistema operativo o deberse a software malicioso en el "
-"sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Este problema puede haberlo causado un cambio en la configuración del "
-"firmware UEFI o deberse a software malicioso en el sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Este problema puede haberlo causado un cambio en el sistema operativo o "
-"deberse a software malicioso en el sistema."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "Expuesto a amenazas de seguridad serias."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "Protección limitada frente a amenazas de seguridad sencillas."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "Protegido contra amenazas de seguridad habituales."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "Protegido contra una amplia variedad de amenazas de seguridad."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "Protección integral"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "No hay eventos"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Protección de escritura del firmware"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Bloqueo de protección de escritura del firmware"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Región del firmware de la BIOS"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Descriptor del firmware de la BIOS"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Protección de pre-arranque DMA"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Arranque verificado por Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "ACM protegido por Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Error de política de Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Fusible Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET activado"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET activado"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "RAM cifrada"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Protección IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Bloqueo del núcleo Linux"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Verificación del núcleo Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Intercambio de Linux"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Suspender a RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Suspender a inactividad"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Clave de la plataforma UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Arranque seguro UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Configuración de la plataforma TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Reconstrucción de TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Modo de fabricación del motor Intel Management"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Omitir motor Intel Management"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Versión del motor de Intel Management"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Actualizaciones de firmware"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Comprobación de firmware"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Verificación del actualizador de firmware"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Depurado de la plataforma"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Comprobaciones de seguridad del procesador"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Protección de marcha atrás de AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Protección de reproducción de firmware de AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Protección de escritura de firmware de AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Plataforma fusionada"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Válido"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "No válido"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "No activada"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Bloqueada"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "No bloqueada"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Cifrado"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "No cifrado"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Envenenado"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "No envenenado"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Encontrada"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "No encontrada"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Soportada"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "No soportada"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2363,7 +1195,6 @@ msgstr "Seguridad del dispositivo"
 msgid "Host firmware security status"
 msgstr "Estado de la seguridad del firmware del equipo"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2371,49 +1202,6 @@ msgid ""
 msgstr ""
 "pantalla;bloqueo;diagnóstico;error;privado;reciente;temporal;tmp;índice;"
 "nombre;red;identidad;privacidad;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Desconocido"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64 bits"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32 bits"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Desconocido"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "No disponible"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo del sistema"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2507,11 +1295,6 @@ msgstr "Acerca de"
 msgid "View information about your system"
 msgstr "Ver información sobre su sistema"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2590,6 +1373,12 @@ msgstr "Lanzadores"
 msgid "Launch help browser"
 msgstr "Lanzar el visor de ayuda"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Configuración"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Lanzar la calculadora"
@@ -2611,7 +1400,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Buscar"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
@@ -2660,15 +1449,6 @@ msgstr "Reducir el tamaño del texto:"
 msgid "High contrast on or off"
 msgstr "Contraste alto activado o desactivado"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "No se han encontrado fuentes de entrada"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Otra"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Añadir una fuente de entrada"
@@ -2702,106 +1482,9 @@ msgstr "Preferencias"
 msgid "View Keyboard Layout"
 msgstr "Ver la distribución de teclado"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Quitar"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Atajo personalizado"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Tecla de caracteres alternativos"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"La tecla de caracteres alternativos se puede usar para introducir caracteres "
-"adicionales. A veces se muestran como una tercera opción en el teclado."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt izquierdo"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt derecha"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Súper izquierdo"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Súper derecho"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tecla de menú"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl derecho"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Tecla de composición"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"La tecla de composición le permite escribir una amplia variedad de "
-"caracteres. Para usarla pulse esa tecla y una secuencia de caracteres. Por "
-"ejemplo, la tecla de composición seguida de <b>C</b> y <b>o</b> escribirá "
-"<b>©</b>, <b>a</b> seguida <b>'</b> escribirá <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Bloq. Mayús."
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Bloq. Despl."
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Impr. Pant."
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Las fuentes de entrada se puede cambiar usando el atajo del teclado %s.\n"
-"Puede cambiar este atajo en la configuración del teclado"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2832,45 +1515,21 @@ msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Métodos para introducir símbolos y variantes de letras usando el teclado."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de caracteres alternativos"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composición"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Atajos del teclado"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Ver y personalizar atajos"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modificado"
-msgstr[1] "%d modificados"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "¿Restablecer todos los atajos?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Restablecer todos los atajos puede afectar a sus atajos personalizados. Esto "
-"no se puede deshacer."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Restablecer todo"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2910,33 +1569,6 @@ msgstr "Añadir atajo"
 msgid "No keyboard shortcut found"
 msgstr "No se ha encontrado un atajo del teclado"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s ya está en uso por %s. Si lo reemplaza, %s se desactivará"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Introduzca el atajo nuevo"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Establecer atajo personalizado"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Establecer atajo"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Introduzca el nuevo atajo para cambiar %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Añadir un atajo personalizado"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Quitar"
@@ -2948,7 +1580,6 @@ msgstr "Reem_plazar"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Establecer"
 
@@ -2985,6 +1616,11 @@ msgstr "Ninguna"
 msgid "Reset the shortcut to its default value"
 msgstr "Restablecer el valor predeterminado del atajo"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_Restablecer valores predeterminados"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Teclado"
@@ -2997,7 +1633,6 @@ msgstr ""
 "Cambiar los atajos del teclado y establecer sus preferencias de escritura, "
 "teclado y fuentes de entrada"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3039,7 +1674,6 @@ msgstr "Ninguna aplicación ha solicitado acceso a su ubicación"
 msgid "Protect your location information"
 msgstr "Proteger la información sobre su ubicación"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "ubicación;gps;privado;privacidad;"
@@ -3074,7 +1708,6 @@ msgstr "Ninguna aplicación ha solicitado acceso al micrófono"
 msgid "Protect your conversations"
 msgstr "Proteger sus conversaciones"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "micrófono;grabación;privado;privacidad;"
@@ -3105,82 +1738,143 @@ msgstr "Izquierda"
 msgid "Right"
 msgstr "Derecha"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Buscar ubicaciones"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Ratón"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Velocidad del ratón"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Desplazamiento natural"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Desplazar hacia abajo"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "El desplazamiento mueve la vista, no el contenido."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "El desplazamiento mueve la vista, no el contenido."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Aceleración:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Activar"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Panel táctil"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Velocidad del panel táctil"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Método"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Tocar para pulsar"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Tocar para pulsar"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Desplazamiento con dos dedos"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Desac_tivar al escribir"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Panel táctil (relativo)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Desplazamiento en el borde"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Desplazar hacia abajo"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dos caras"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr ""
 "Pruebe a pulsar una vez, dos veces o a desplazarse con la rueda del ratón"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinco pulsaciones, es tiempo de GEGL."
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Doble pulsación, botón primario"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Una sola pulsación, botón primario"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Doble pulsación, botón central"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Una sola pulsación, botón central"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Doble pulsación, botón secundario"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Una sola pulsación, botón secundario"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3193,7 +1887,6 @@ msgstr ""
 "Cambiar la sensibilidad de su ratón o su panel táctil y configurarlos para "
 "zurdos o diestros"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3274,7 +1967,6 @@ msgstr "Multitarea"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Gestionar las preferencias para productividad y multitarea"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3282,20 +1974,11 @@ msgstr ""
 "multitarea;productividad;personalizar;escritorio;esquina activa;áreas de "
 "trabajo;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Algo ha fallado. Contacte con el fabricante del software."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager debe estar en ejecución."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Otros dispositivos"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3307,59 +1990,16 @@ msgstr "Añadir conexión"
 msgid "Not set up"
 msgstr "No configurada"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Red insegura (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Red segura (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Red segura (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Red segura (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Red segura"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Conectado"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opciones…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Activar el punto de acceso hará que se desconecte de %s y no será posible "
-"acceder a Internet mediante Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Debe tener un mínimo de 8 caracteres"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3410,20 +2050,6 @@ msgstr "Generar una contraseña automáticamente"
 msgid "_Turn On"
 msgstr "_Activar"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Inalámbrica"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "¿Detener el «hotspot» y desconectar a los usuarios?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Detener «hotspot»"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Modo avión"
@@ -3468,89 +2094,13 @@ msgstr "Redes visibles"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager debe estar en ejecución"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Algo ha fallado. Contacte con el fabricante del software."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Seguridad 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Seguridad"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Mantener"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanente"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Aleatorio"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Estable"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"La dirección MAC introducida aquí se usará como dirección hardware para el "
-"dispositivo de red en el que se active esta conexión. Esto se conoce como "
-"clonado de MAC o «spoofing». Ejemplo: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Perfil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Empresa"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ninguna"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Nunca"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3559,183 +2109,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "hace %i día"
 msgstr[1] "hace %i días"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Ninguna"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Débil"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Aceptar"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Buena"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excelente"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Dirección IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Dirección IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Dirección IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Olvidar conexión"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Eliminar perfil de conexión"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Quitar VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Detalles"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automático"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identidad"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Eliminar dirección"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Eliminar ruta"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ninguna"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Clave WEP 40/128-bit (Hexadecimal o ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Frase de paso WEP de 128 bits"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinámica (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA y WPA2 personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA y WPA2 enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 personal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3746,8 +2119,20 @@ msgstr "Fortaleza de la señal"
 msgid "Link speed"
 msgstr "Velocidad de conexión"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguridad"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Dirección IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Dirección IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Dirección física"
 
@@ -3756,12 +2141,17 @@ msgid "Supported Frequencies"
 msgstr "Frecuencias soportadas"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Ruta predeterminada"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3824,7 +2214,7 @@ msgstr "Sólo enlace local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
@@ -3868,9 +2258,8 @@ msgstr "Puerta de enlace"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automático"
 
@@ -3923,89 +2312,9 @@ msgstr "Automático, DHCP únicamente"
 msgid "Prefix"
 msgstr "Prefijo"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "No se pudo abrir el editor de conexiones"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Perfil nuevo"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Ajuste %s no válido: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Ajuste no válido %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importar desde un archivo…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Añadir VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_eguridad"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "No se puede importar la conexión VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"No se pudo leer el archivo «%s» o no contiene información de una conexión "
-"VPN que se pueda reconocer\n"
-"\n"
-"Error: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Seleccione el archivo que importar"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Ya existe un archivo llamado «%s»."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Reemplazar"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "¿Quiere reemplazar %s con la conexión VP que está guardando?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "No se puede exportar la conexión VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Exportar conexión VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4019,100 +2328,37 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Red"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controlar cómo se conecta a Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Red;IP;LAN;Proxy;WAN;Banda;ancha;Módem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Inalámbrica"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controlar cómo se conecta a redes inalámbricas"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Red;Inalámbrica;Wireless;Wi-Fi;Wifi;IP;LAN;Banda;ancha;DNS;punto;acceso;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nunca"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "hoy"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "ayer"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Usada última vez"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Cableada"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Añadir una conexión nueva"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Se perderán los detalles de las redes seleccionadas, incluyendo la "
-"contraseña y cualquier configuración personalizada."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Olvidar"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Redes inalámbricas conocidas"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Olvidar"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "La política del sistema prohíbe usarlo como punto de acceso"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "El dispositivo inalámbrico no soporta el modo de punto de acceso"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Se usa el autodiscubrimiento del proxy web cuando no se proporciona un URL "
-"de configuración."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "No se recomienda para redes públicas en las que no se confía."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4131,6 +2377,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Proveedor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Dirección IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4215,289 +2465,6 @@ msgstr "_Activar el punto de acceso inalámbrico…"
 msgid "_Known Wi-Fi Networks"
 msgstr "Redes inalámbricas _conocidas"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Estado desconocido"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Sin gestionar"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "No disponible"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Conectando"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Se necesita autenticación"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Desconectando"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Falló la conexión"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Estado desconocido (ausente)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Falló la configuración"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Falló la configuración IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "La configuración IP ha expirado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Se necesitan secretos, pero no se han proporcionado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Suplicante de 802.1x desconectado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Falló la configuración del suplicante de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Falló el suplicante de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "El suplicante de 802.1x tardó mucho tiempo en autenticarse"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Falló al iniciar el servicio de PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Servicio PPP desconectado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP falló"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Falló al iniciar el cliente de DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Error del cliente de DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Falló el cliente de DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Falló al iniciar el servicio de conexión compartida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Falló el servicio de conexión compartida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Falló al iniciar el servicio de AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Error del servicio de AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Falló el servicio AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Línea ocupada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "No hay tono de llamada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "No se pudo establecer el portador"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Expiró el tiempo de solicitud de llamada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Intento de llamada fallido"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Falló la inicialización del módem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Falló al seleccionar el NPA especificado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "No se están buscando redes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Registro de la red denegado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Expiró el tiempo de registro de la red"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Falló al registrarse con la red solicitada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Falló la comprobación de l PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Es posible que falte el firmware del dispositivo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "La conexión ha desaparecido"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Se asumió una conexión existente"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Módem no encontrado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Falló la conexión Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Tarjeta SIM no insertada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Se necesita el PIN de la SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Se necesita el PUK de la SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM errónea"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Falló la dependencia de la conexión"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "falta el «firmware»"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Cable desconectado"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "error no definido en la seguridad 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "no se ha seleccionado ningún archivo"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "error no especificado al validar el archivo del método eap"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12, o claves privadas PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Certificados DER o PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "falta el archivo PAC de EAP-FAST"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Archivos PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4546,14 +2513,6 @@ msgstr "Autenticación i_nterna"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Permitir pro_visión PAC automática"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "falta el nombre de usuario de EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "falta la contraseña de EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4579,16 +2538,6 @@ msgstr "_Contraseña"
 msgid "Sho_w password"
 msgstr "_Mostrar la contraseña"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "CA del certificado EAP-PEAP no válida: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-"CA del certificado EAP-PEAP no válida: no se ha especificado el certificado"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4610,7 +2559,6 @@ msgid "C_A certificate"
 msgstr "Certificado C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4625,64 +2573,6 @@ msgstr "No se necesita la CA del ce_rtificado"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "Versión _PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "falta el nombre de usuario de EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "falta la contraseña EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "falta la identidad EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "CA del certificado EAP-TLS no válida: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-"CA del certificado EAP-TLS no válida: no se ha especificado el certificado"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "clave privada EAP-TLS no válida: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "usuario del certificado EAP-TLS no válido: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Las claves privadas sin cifrar son inseguras"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"La clave privada seleccionada no parece estar protegida por una contraseña. "
-"Esto podría permitir que sus credenciales de seguridad se comprometiesen. "
-"Seleccione una clave privada protegida por contraseña.\n"
-"\n"
-"(Puede proteger su clave privada con una contraseña con openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Elija su certificado personal"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Elija su clave privada"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4699,16 +2589,6 @@ msgstr "Clave pri_vada"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Contraseña de clave pri_vada"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "CA del certificado EAP-TTLS no válida: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-"CA del certificado EAP-TTLS no válida: no se ha especificado el certificado"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4731,14 +2611,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Dominio"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Error desconocido al validar la seguridad 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4766,63 +2647,10 @@ msgstr "EAP protegido (PEAP)"
 msgid "Au_thentication"
 msgstr "_Autenticación"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Seleccione un archivo"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "falta el nombre de usuario leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "falta la contraseña leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Falta la contraseña de la red inalámbrica."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipo"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "falta la clave wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"clave wep no válida: una clave de longitud %zu sólo puede contener dígitos "
-"hexadecimales"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"clave wep no válida: una clave de longitud %zu sólo debe contener caracteres "
-"ASCII"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"clave wep no válida: longitud de clave %zu incorrecta. La clave debe ser de "
-"5/13 (ascii) o 10/26 (hexadecimal)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "clave wep no válida: la frase de paso no puede estar vacía"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"clave wep no válida: la frase de paso debe ser inferior a 64 caracteres"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4847,21 +2675,6 @@ msgstr "_Mostrar la clave"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Ín_dice WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"clave wpa-psk no válida: longitud %zu de la clave no válida. Debe ser de "
-"[8,63] bytes o 64 dígitos hexadecimales"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"clave wpa-psk no válida: no se puede interpretar una clave de 64 bytes como "
-"hexadecimal"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4916,27 +2729,9 @@ msgstr "_Notificaciones de la pantalla de bloqueo"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controlar qué notificaciones se muestran"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "notificaciones;banner;mensaje;bandeja;emergente;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Otra"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s eliminado"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Error al quitar la cuenta"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4961,17 +2756,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Añadir una cuenta"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Cuenta de %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Quitar cuenta"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Cuentas en línea"
@@ -4980,10 +2764,6 @@ msgstr "Cuentas en línea"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Conectarse a sus cuentas en línea y decidir para qué usarlas"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4991,10 +2771,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;en línea;Chat;Calendario;Correo-e;Contacto;"
 "ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Tiempo desconocido"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5010,13 +2786,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i hora"
 msgstr[1] "%i horas"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5028,190 +2797,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minutos"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s hasta que se cargue del todo"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Advertencia: quedan %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s restante"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Cargada completamente"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "No está cargando"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Vacía"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Cargando"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Descargando"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Ratón inalámbrico"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Teclado inalámbrico"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Fuente de alimentación no interrumplible"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Asistente digital personal"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Teléfono móvil"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Reproductor multimedia"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tableta"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Equipo"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Mando de juegos"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batería"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principal"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Adicional"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Baterías"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Cuando esté _inactivo"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Suspender"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Apagar"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hibernar"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nada"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "En modo batería"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Cuando está conectado a la red"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nunca"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Suspender automáticamente"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Modo rendimiento desactivado temporalmente debido a la alta temperatura de "
-"operación."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Portátil detectado: modo rendimiento desactivado temporalmente. Mueva el "
-"dispositivo a una superficie estable para restaurarlo."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Modo de rendimiento desactivado temporalmente."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Batería baja: ahorro de energía activado. El modo anterior se restaurará "
-"cuando la batería esté suficientemente cargada."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Modo de ahorro de energía activado por «%s»."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Modo de rendimiento activado por «%s»."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5272,6 +2857,15 @@ msgstr "100 minutos"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 horas"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batería"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositivos"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5350,33 +2944,6 @@ msgstr "Usando _batería"
 msgid "Delay"
 msgstr "Retardo"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Rendimiento"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Alto rendimiento y uso de energía"
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Balanceado"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Rendimiento estándar y uso de energía."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Ahorro de energía"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Reduce el rendimiento y el uso de energía."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Energía"
@@ -5386,7 +2953,6 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Ver el estado de la batería y cambiar la configuración de ahorro de energía"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5394,27 +2960,6 @@ msgid ""
 msgstr ""
 "Energía;Dormir;Suspender;Hibernar;Batería;Brillo;Apagar;Monitor;DPMS;"
 "inactivo;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Se ha eliminado la impresora «%s»"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Falló al añadir una impresora nueva."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "No se pudo cargar la IU: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Desbloquear para añadir impresoras y cambiar la configuración"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5426,7 +2971,6 @@ msgstr ""
 "Añadir impresoras, ver los trabajos de la impresora y decidir cuál quiere "
 "imprimir"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Impresora;Cola;Imprimir;Papel;Tinta;Tóner;"
@@ -5434,8 +2978,6 @@ msgstr "Impresora;Cola;Imprimir;Papel;Tinta;Tóner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Añadir impresora"
 
@@ -5476,29 +3018,6 @@ msgstr ""
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Detalles de %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "No se ha encontrado ningún controlador adecuado"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Seleccionar archivo PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Archivos de descripción de impresora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
-"PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
@@ -5508,9 +3027,7 @@ msgstr ""
 msgid "Location"
 msgstr "Ubicación"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Controlador"
 
@@ -5538,140 +3055,20 @@ msgstr "Seleccionar el controlador de la impresora"
 msgid "Loading drivers database…"
 msgstr "Cargando base de datos de controladores…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Cancelar"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Seleccionar"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Impresora JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Impresora LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Una cara"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Margen largo (estándar)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Margen corto (girar)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Vertical"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Apaisado"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Apaisado invertido"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Vertical invertido"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Reanudar"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pausar"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Pendiente"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pausado"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Autenticación requerida"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Procesando"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Detenido"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Cancelado"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Abortado"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Completado"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Mover este trabajo al principio de la cola"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u trabajo requiere autenticación"
 msgstr[1] "%u trabajos requieren autenticación"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - trabajos activos"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Introduzca las credenciales para imprimir desde %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5699,323 +3096,17 @@ msgstr "_Autenticar"
 msgid "No Active Printer Jobs"
 msgstr "No hay trabajos de impresión activos"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Desbloquear servidor de impresión"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Desbloquear %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Introduzca su nombre de usuario y su contraseña para ver las impresoras en "
-"%s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Buscando impresoras"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Puerto serie"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Puerto paralelo"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Ubicación: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Dirección: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "El servidor requiere autenticación"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dos caras"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Tipo de papel"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Fuente de papel"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Bandeja de salida"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolución"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Prefiltrado GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Páginas por cara"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dos caras"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientación"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "General"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Configuración de página"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opciones instalables"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Trabajo"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Calidad de la imagen"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Color"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Terminando"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avanzado"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Página de prueba"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Página de prueba"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Seleccionar automáticamente"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Impresora predeterminada"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Sólo empotrar tipografías GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Convertir a PS nivel 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Convertir a PS nivel 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Sin prefiltrado"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Fabricante"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "No hay trabajos activos"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u trabajo"
 msgstr[1] "%u trabajos"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Limpiar cabezales de la impresora"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Tóner bajo"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Sin tóner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Nivel de revelador bajo"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Sin revelador"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Marcador bajo"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Sin marcador"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Abrir cubierta"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Abrir puerta"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Nivel de papel bajo"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Sin papel"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Desconectada"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Detenida"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Recipiente de residuos casi lleno"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Receptáculo de residuos lleno"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "El conductor óptico está cerca del final de su vida"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "El conductor óptico ya no funciona"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Preparada"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "No aceptar trabajos"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Procesando"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6039,6 +3130,10 @@ msgstr "Limpiar cabezales de impresión"
 msgid "Remove Printer"
 msgstr "Quitar impresora"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "No hay trabajos activos"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6059,16 +3154,21 @@ msgid "Restart"
 msgstr "Reiniciar"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Añadir impresora…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Añadir una impresora…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "No hay impresoras"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6076,7 +3176,6 @@ msgstr ""
 "El servicio del sistema de impresión\n"
 "    parece no estar disponible."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formatos"
@@ -6104,16 +3203,6 @@ msgstr "Se pueden hacer búsquedas de países o idiomas."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Vista previa"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Métrico"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6151,20 +3240,25 @@ msgstr ""
 "La configuración del idioma se usa para el texto de la interfaz y las "
 "páginas web. Los formatos se usan para números, fechas y monedas."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Instalar idiomas…"
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Su cuenta"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Idioma"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formatos"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Pantalla de inicio de sesión"
 
@@ -6176,101 +3270,9 @@ msgstr "Región e idioma"
 msgid "Select your display language and formats"
 msgstr "Seleccionar el idioma que mostrar y los formatos"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Distribución;Teclado;Entrada;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Preguntar qué hacer"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "No hacer nada"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Abrir carpeta"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Otros soportes"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Seleccionar una aplicación para CD de sonido"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Seleccionar una aplicación para DVD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Seleccionar una aplicación que ejecutar cuando se conecta un reproductor de "
-"música"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Seleccionar una aplicación que ejecutar cuando se conecta una cámara"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Seleccionar una aplicación para CD de software"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD de sonido"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "disco Blu-ray virgen"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "CD virgen"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "DVD virgen"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "disco HD DVD virgen"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Disco Blu-ray de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "lector de libros electrónicos"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Disco HD DVD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "CD de imágenes"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Software de Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6320,7 +3322,6 @@ msgstr "Soportes extraíbles"
 msgid "Configure Removable Media settings"
 msgstr "Configurar soportes extraíbles"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6328,114 +3329,6 @@ msgid ""
 msgstr ""
 "dispositivo;sistema;predeterminado;aplicación;preferido;cd;dvd;usb;sonido;"
 "vídeo;disco;extraíble;medio;autoejecutar;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Se apaga la pantalla"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 segundos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nunca"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6473,11 +3366,16 @@ msgstr "Período después de apagar la pantalla para bloquearla automáticamente
 msgid "Show _Notifications on Lock Screen"
 msgstr "Mostrar _notificaciones en la pantalla de bloqueo"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Notificaciones de la pantalla de bloqueo"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Prohibir usar nuevos dispositivos _USB"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6485,30 +3383,25 @@ msgstr ""
 "Evitar que los nuevos dispositivos USB interactúen con el sistema cuando la "
 "pantalla está bloqueada."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Privacidad de la pantalla"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Restringir el ángulo de visión"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantalla"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Configuración de la pantalla"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "pantalla;bloqueo;privado;privacidad;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Seleccionar ubicación"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Aceptar"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6539,10 +3432,6 @@ msgstr "Otras"
 msgid "Add Location"
 msgstr "Añadir ubicación"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "No se han encontrado aplicaciones"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Búsqueda de aplicaciones"
@@ -6570,93 +3459,13 @@ msgstr ""
 "Controlar qué aplicaciones muestran resultados de búsqueda en la vista de "
 "actividades"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "buscar;búsqueda;índice;ocultar;privacidad;resultados;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "No se han seleccionado redes para compartir"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Redes"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Encendido"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Apagado"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Activado"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Activo"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Elija una carpeta"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Añadir"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Activar la compartición multimedia"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Compartir archivos personales le permite compartir su carpeta «Público» con "
-"otros en su red actual usando: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Cuando el inicio de sesión remoto está activado, los usuarios remotos pueden "
-"conectarse usando el comando de shell segura:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Activar la compartición de archivos personales"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Nombre del dispositivo copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Dirección del dispositivo copiada"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Nombre de usuario copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Contraseña copiada"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6789,7 +3598,6 @@ msgstr "Carpetas"
 msgid "Control what you want to share with others"
 msgstr "Controla qué quiere compartir con otros"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6807,10 +3615,6 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Se requiere autenticación para activar o desactivar el inicio de sesión "
 "remota"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Personalizado"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6843,11 +3647,6 @@ msgstr "Trasero"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Frontal"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Probando %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6901,11 +3700,6 @@ msgstr "Volumen"
 msgid "Alert Sound"
 msgstr "Sonido de alerta"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Silenciar"
@@ -6918,83 +3712,12 @@ msgstr "Sonido"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Cambiar el volumen de entrada y salida de sonido y las alertas sonoras"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "tarjeta;micrófono;volumen;desvanecer;balance;bluetooth;cascos;auriculares;"
 "sonido;entrada;salida;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Desconectado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Conectando"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Conectado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Error de autorización"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autorizando"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Funcionalidad reducida"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Conectado y autorizado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Desconocido"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autorizado a las:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Conectado a las:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Unido a las:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Falló al autorizar el dispositivo: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Falló al olvidar el dispositivo: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7028,55 +3751,6 @@ msgstr "Autorizar y conectar"
 msgid "Forget Device"
 msgstr "Olvidar dispositivo"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Error"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorizado"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"El subsistema de Thunderbolt (boltd) no está instalado o no se ha "
-"configurado correctamente."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Permitir el acceso a dispositivos como soportes y GPU externas."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Sólo se pueden conectar dispositivos USB y Display Port"
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"No se pudo detectar Thunderbolt.\n"
-"El sistema carece de soporte para Thunderbolt, se ha desactivado en la BIOS "
-"o se ha configurado con un nivel de seguridad no soportado en la BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "El soporte de Thunderbolt se ha desactivado en la BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "No se puede determinar el nivel de seguridad de Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Error al cambiar al modo directo: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Sin soporte para Thunderbolt"
@@ -7088,6 +3762,10 @@ msgstr "No se pudo conectar al subsistema thunderbolt."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Acceso directo"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Permitir el acceso a dispositivos como soportes y GPU externas."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7105,7 +3783,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Gestionar dispositivos Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacidad;"
@@ -7309,40 +3986,6 @@ msgstr "_Activar por teclado"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Activar las características de accesibilidad usando el teclado"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Predeterminado"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Mediano"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Grande"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Más grande"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "El más grande"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d píxel"
-msgstr[1] "%d píxeles"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Mostrar siempre el menú de accesibilidad"
@@ -7457,31 +4100,6 @@ msgstr "De_stello de la pantalla completa"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "De_stello de la pantalla completa"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Corta"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ de pantalla"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ pantalla"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ de pantalla"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Larga"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7638,7 +4256,6 @@ msgstr "Efectos de color"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Hacer más sencillo de ver, escuchar, escribir y apuntar y pulsar"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7650,114 +4267,6 @@ msgstr ""
 "Ampliación;Pantalla;Lector;grande;alto;texto;tipografía;AccesoX;persistentes;"
 "teclas;rechazo;ratón;doble;pulsación;retardo;velocidad;asistente;repetir;"
 "parpadeo;visual;audición;escritura;animaciones;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 día"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 días"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "¿Quiere vaciar todos los elementos de la papelera?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Todos los elementos de la papelera se eliminarán de manera permanente."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Vaciar papelera"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "¿Quiere eliminar todos los archivos temporales?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Todos los archivos temporales se eliminarán de manera permanente."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Limpiar archivos temporales"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 día"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 días"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 días"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Para siempre"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7826,64 +4335,12 @@ msgstr "Histórico de archivos y papelera"
 msgid "Don't leave traces"
 msgstr "No dejar trazas"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "uso;reciente;histórico;archivos;temporal;tmp;privado;privacidad;papelera;"
 "vaciado;retener;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Debe coincidir con la dirección web del proveedor de la cuenta."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Falló al añadir la cuenta"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Las contraseñas no coinciden."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Falló al registrar la cuenta"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "No hay una manera soportada de autenticar con este dominio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Falló al unirse al dominio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"El nombre de inicio de sesión no ha funcionado.\n"
-"Inténtelo de nuevo."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"La contraseña de inicio de sesión no ha funcionado.\n"
-"Inténtelo de nuevo."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Falló al iniciar sesión en el dominio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "No se pudo encontrar el dominio. ¿Está bien escrito?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7936,10 +4393,6 @@ msgstr ""
 "El inicio de sesión corporativo permite que se use una cuenta de usuario "
 "gestionada de manera centralizada en este dispositivo. También puede usar "
 "esta cuenta para acceder a recursos de la compañía en Internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Examinar para buscar más imágenes"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8010,222 +4463,6 @@ msgstr "_Eliminar huellas"
 msgid "Fingerprint Enroll"
 msgstr "Alta de huella dactilar"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "es necesario reclamar el dispositivo para realizar esta acción"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "otro proceso ha solicitado el dispositivo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "no tiene permisos para realizar esta acción"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "no se han registrado impresiones"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Falló al comunicarse con el dispositivo durante el registro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Falló al comunicarse con el lector de huellas catilares"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Falló al comunicarse con el demonio de huella dactilar"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Falló al listas las huellas guardadas: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Falló al eliminar las huellas guardadas: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Pulgar izquierdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Dedo corazón izquierdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Dedo índice _izquierdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Dedo anular izquierdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Dedo meñique izquierdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Pulgar derecho"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Dedo corazón derecho"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Dedo índice derecho"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Dedo anular derecho"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Dedo meñique derecho"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Dedo desconocido"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Terminado"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Dispositivo de huella dactilar desconectado"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "El dispositivo de almacenamiento de huellas dactilares está lleno"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Falló al dar de alta la nueva huella dactilar"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Falló al iniciar el alta: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Falló al dar de alta una nueva huella dactilar"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Falló al detener el alta: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Levante y coloque su dedo repetidamente en el lector para dar de alta su "
-"huella."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Volver a dar de alta este dedo…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Analizar una huella dactilar nueva"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Falló al liberar el dispositivo de huella dactilar %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problema al leer el dispositivo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Falló al solicitar el dispositivo de huella dactilar %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Falló al obtener los dispositivos de huella dactilar: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Esta semana"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Última semana"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e de %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sesión terminada"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sesión iniciada"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s - Actividad de la cuenta"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Anterior"
@@ -8233,18 +4470,6 @@ msgstr "Anterior"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Siguiente"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Elija otra contraseña."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Escriba de nuevo su contraseña actual."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "No se pudo cambiar la contraseña"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8266,6 +4491,10 @@ msgstr "Contraseña nueva"
 msgid "Confirm Password"
 msgstr "Confirmar contraseña"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Las contraseñas no coinciden."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
@@ -8274,135 +4503,6 @@ msgstr ""
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Establecer una contraseña ahora"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "No se puede unir automáticamente a este tipo de dominio"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "No existe el dominio o no se ha encontrado el reino"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "No se puede iniciar sesión como %s en el dominio %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Contraseña no válida, inténtelo de nuevo"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "No se pudo conectar al dominio %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Falló al eliminar el usuario"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Falló al revocar remotamente el usuario gestionado"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "No puede eliminar su propia cuenta."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s aún está registrado en el sistema"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Eliminar un usuario mientras está registrado en el sistema puede dejar el "
-"sistema en un estado inconsistente."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "¿Quiere mantener los archivos de %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Es posible mantener la carpeta personal, el «spool» del correo y los "
-"archivos temporales al eliminar una cuenta de usuario."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Eliminar archivos"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Mantener archivos"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"¿Está seguro de que quiere revocar remotamente la cuenta gestionada de %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Eliminar"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Cuenta desactivada"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Para configurar en el siguiente inicio de sesión"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ninguno"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Sesión iniciada"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Falló al contactar con el servicio de cuentas"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Asegúrese de que el servicio de cuentas está instalado y activado."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Se debe desbloquear este panel para cambiar esta opción"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Quitar la cuenta de usuario seleccionada"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Para eliminar la cuenta de usuario seleccionada\n"
-"pulse primero el icono *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Desbloquear para añadir usuarios y cambiar la configuración"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8430,7 +4530,6 @@ msgid "Full name"
 msgstr "Nombre completo"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Editar"
 
@@ -8492,7 +4591,6 @@ msgstr "Desbloquear para añadir una cuenta de usuario."
 msgid "Add or remove users and change your password"
 msgstr "Añadir o quitar usuarios y cambiar su contraseña"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8537,178 +4635,6 @@ msgstr "Gestionar cuentas de usuario"
 msgid "Authentication is required to change user data"
 msgstr "Se requiere autenticación para cambiar los datos del usuario"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "La contraseña nueva debe ser diferente de la antigua."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Pruebe a cambiar algunas letras y números."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Pruebe a cambiar la contraseña un poco más."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Una contraseña sin su nombre de usuario será más robusta."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Evite usar su nombre en la contraseña."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Evite algunas de las palabras incluidas en la contraseña."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Trate de evitar palabras comunes."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Evite reordenar las palabras existentes."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Pruebe a usar más números."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Pruebe a usar más letras en mayúscula."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Pruebe a usar más letras en minúscula."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Pruebe a usar más caracteres especiales, como signos de puntuación."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Pruebe a usar una mezcla de letras, números y signos de puntuación."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Evite repetir el mismo carácter."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Evite repetir el mismo tipo de carácter: debe mezclar letras, números y "
-"signos de puntuación."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Evite secuencias como 1234 o abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"La contraseña debe ser más larga. Pruebe a añadir más letras, números y "
-"signos de puntuación."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Mezcle letras mayúsculas y minúsculas y use uno o dos números."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Añadir más letras, números y signos de puntuación hará que la contraseña sea "
-"más robusta."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Falló la autenticación"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "La contraseña nueva es demasiado corta"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "La contraseña nueva es demasiado simple"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "La contraseña antigua y la nueva son demasiado similares"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "La contraseña nueva ya se ha usado recientemente."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "La contraseña nueva debe contener caracteres numéricos o especiales"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "La contraseña nueva y la antigua son la misma"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Se ha cambiado su contraseña desde que se autenticó inicialmente."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "La contraseña nueva no contiene suficientes caracteres diferentes"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Error desconocido"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"El nombre de usuario debe constar solamente de letras minúsculas de la «a» a "
-"la «z», dígitos y cualquiera de los caracteres: «-» o «_»"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "El nombre de usuario no está disponible. Pruebe con otro."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "El nombre de usuario es demasiado largo."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8743,52 +4669,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Pulsación errónea detectada, reiniciando…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Botón %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplicación definida"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Enviar pulsación de tecla"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Cambiar monitor"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Mostrar la ayuda en pantalla"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tableta montada en el panel del portátil"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tableta montada en una pantalla externa"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Tableta externa"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Tableta externa"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Todas las pantallas"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8886,22 +4770,6 @@ msgstr "Pulsación del botón del medio del ratón"
 msgid "Forward"
 msgstr "Adelante"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Lápiz aerógrafo con presión, inclinación y deslizador integrado"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Lápiz aerógrafo con presión, inclinación y rotación"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Lápiz estándar con presión e inclinación"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Lápiz estándar con presión"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tableta Wacom"
@@ -8912,54 +4780,97 @@ msgstr ""
 "Establecer el mapeado de botones y ajustar la sensibilidad del lápiz para "
 "tabletas gráficas"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tableta;Wacom;Stylus;Borrador;Ratón;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Atajo nuevo..."
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Distribución"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Ventana raíz"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Pulsación secundaria _simulada"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Ventanas"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Pulse «Aceptar» para terminar."
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Tóner bajo"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Secundaria"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Ventanas"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Gestionar las preferencias para productividad y multitarea"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Puntos de acceso"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Añadir"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Guardar"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operación cancelada"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Error:</b> acceso denegado para modificar la configuración"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Error:</b> error del equipo móvil"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "No registrado"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registrado"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Itinerancia"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Buscando"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Denegado"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8989,212 +4900,13 @@ msgstr "Número del propietaro"
 msgid "Device Details"
 msgstr "Detalles del dispositivos"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricante"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Versión de firmware"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G sólo"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G sólo"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G sólo"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "5G sólo"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (preferido), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (preferido), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (preferido), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (preferido), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (preferido), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (preferido), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (preferido), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (preferido), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (preferido), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (preferido), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Desconocido"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Desbloquear tarjeta SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Desbloquear"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Proporcione el código PIN para la SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Introduzca el PIN para desbloquear su tarjeta SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Proporcione el código PUK para la SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Introduzca el PUK para desbloquear su tarjeta SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9209,26 +4921,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Le queda %u intento"
 msgstr[1] "Le quedan %u intentos"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Contraseña incorrecta."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "El código PUK debe ser un número de 8 cifras"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Introduzca un nuevo PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "El código PIN debe ser un número de 4-8 cifras"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Desbloqueando…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9286,94 +4978,6 @@ msgstr "Bloquear SIM con PIN"
 msgid "M_odem Details"
 msgstr "Detalles del mód_em"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Falló del teléfono"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "No hay conexión con el teléfono"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operación no permitida"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operación no soportada"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Tarjeta SIM no insertada"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Se necesita el PIN de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Se necesita el PUK de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Fallo de la tarjeta SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Tarjeta SIM ocupada"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Contraseña incorrecta"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Se necesita el PIN2 de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Se necesita el PUK2 de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "No encontrado"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "No hay servicio de red"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Tiempo de expiración de la red"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Servicios GPRS no permitidos"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Itinerancia no permitida en esta área"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Error GPRS no especificado"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Sin error"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Acción cancelada"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Acceso denegado"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Error desconocido"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Modo de red"
@@ -9389,11 +4993,6 @@ msgstr "Elegir red"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Actualizar proveedores de red"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9452,7 +5051,6 @@ msgstr "Red móvil"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configurar telefonía y conexiones de datos móviles"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "teléfono;wwan;telefonía;sim;móvil;"
@@ -9469,41 +5067,13 @@ msgstr "Configuración es la interfaz principal para configurar su sistema."
 msgid "The GNOME Project"
 msgstr "El Proyecto GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Mostrar el número de versión"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Activar el modo detallado"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Buscar la cadena"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Listar todos los nombres de paneles posibles y salir"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel que mostrar"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENTO…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Categorías de configuración"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacidad"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Paneles disponibles:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9561,7 +5131,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Cancelar búsqueda"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferencias;Configuración;"
@@ -9602,8 +5171,6 @@ msgstr ""
 "Una tupla que contiene la anchura y altura iniciales y el estado maximizado "
 "de la ventana de la aplicación."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9611,8 +5178,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u salida"
 msgstr[1] "%u salidas"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9620,9 +5185,3151 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u entrada"
 msgstr[1] "%u entradas"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sonidos del sistema"
+#~ msgid "System Bus"
+#~ msgstr "Bus del sistema"
+
+#~ msgid "Full access"
+#~ msgstr "Acceso completo"
+
+#~ msgid "Session Bus"
+#~ msgstr "Bus de sesión"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Acceso completo a /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Tiene acceso a la red"
+
+#~ msgid "Home"
+#~ msgstr "Carpeta personal"
+
+#~ msgid "Read-only"
+#~ msgstr "Sólo lectura"
+
+#~ msgid "File System"
+#~ msgstr "Sistema de achivos"
+
+#~ msgid "Can change settings"
+#~ msgstr "Puede cambiar la configuración"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s tiene los siguientes permisos integrados y no se pueden modificar. Si "
+#~ "esto le preocupa considere la opción de quitar esta aplicación."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u tipo de archivo y enlace abierto por esta aplicación"
+#~ msgstr[1] "%u tipos de archivos y enlaces abiertos por esta aplicación"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> se usa para abrir los siguientes tipos de archivos y enlaces."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s de espacio de disco usado."
+
+#~ msgid "Select a picture"
+#~ msgstr "Seleccionar una imagen"
+
+#~ msgid "_Open"
+#~ msgstr "_Abrir"
+
+#~ msgid "multiple sizes"
+#~ msgstr "tamaños múltiples"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Sin fondo de escritorio"
+
+#~ msgid "Current background"
+#~ msgstr "Fondo actual"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Coloque su dispositivo de calibración sobre el cuadrado y pulse «Iniciar»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Mueva su dispositivo de calibración a la posición de calibrado y pulse "
+#~ "«Continuar»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Mueva su dispositivo de calibración a la posición de la superficie y "
+#~ "pulse «Continuar»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Apagar la tapa del portátil"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Ocurrió un error interno y no se pudo recuperar."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr ""
+#~ "Las herramientas requeridas para la calibración no están instaladas."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "No se puede generar el perfil."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "No se pudo obtener el punto blanco del objetivo."
+
+#~ msgid "Complete!"
+#~ msgstr "Completado"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Falló la configuración."
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Puede quitar el dispositivo de calibración."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr ""
+#~ "No interrumpir al dispositivo de calibración cuando está en progreso"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Pantalla del portátil"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Cámara web integrada"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Escáner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Cámara %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Impresora %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Cámara web %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Activar la gestión de color para %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Mostrar perfiles de color para %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Sin calibrar"
+
+#~ msgid "Default: "
+#~ msgstr "Predeterminado: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Espacio de color: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Perfil de color: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Seleccionar archivo de perfil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importar"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Perfiles ICC soportados"
+
+#~ msgid "All files"
+#~ msgstr "Todos los archivos"
+
+#~ msgid "Save Profile"
+#~ msgstr "Guardar perfil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Crear un perfil de color para el dispositivo seleccionado"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "No se detectó el instrumento de medida. Compruebe que está encendido y "
+#~ "correctamente conectado."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "El instrumento de medida no soporta perfilado de impresoras."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "El tipo de dispositivo actualmente no está soportado."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espacio estándar"
+
+#~ msgid "Test Profile"
+#~ msgstr "Perfil de prueba"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automático"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Calidad baja"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Calidad media"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Calidad alta"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB predeterminado"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK predeterminado"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Gris predeterminado"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Datos de calibración de fábrica proporcionados por el vendedor"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "La corrección de la pantalla en modo a pantalla completa no es posible "
+#~ "con este perfil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Este perfil ya no es preciso."
+
+#~ msgid "Other…"
+#~ msgstr "Otro…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Desbloquear para cambiar la configuración"
+
+#~ msgid "Today"
+#~ msgstr "Hoy"
+
+#~ msgid "Yesterday"
+#~ msgstr "Ayer"
+
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d hora"
+#~ msgstr[1] "%d horas"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuto"
+#~ msgstr[1] "%d minutos"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d segundo"
+#~ msgstr[1] "%d segundos"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24 horas"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%d/%b/%Y, %I:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%d/%b/%Y, %H:%M"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%H:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Enviar informes de problemas técnicos ayuda a mejorar %s. Los informes se "
+#~ "envían anónimamente y no contienen datos personales. %s"
+
+#~ msgid "On"
+#~ msgstr "Encendido"
+
+#~ msgid "Off"
+#~ msgstr "Apagado"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "¿Aplicar los cambios?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "No se pueden aplicar los cambios"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Esto puede deber a limitaciones hardware."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Horizontal"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Vertical derecha"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Vertical izquierda"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Horizontal (dada la vuelta)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Secure Boot está activado"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "El arranque seguro evita que se cargue software malicioso cuando se "
+#~ "inicia el dispositivo. Actualmente está activo y funcionando "
+#~ "correctamente."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "El arranque seguro tiene problemas"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "El arranque seguro evita que se cargue software malicioso cuando se "
+#~ "inicia el dispositivo. Actualmente está activo pero no funcionará debido "
+#~ "a que tiene una clave no válida."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Los problemas del arranque seguro se pueden resolver a menudo desde la "
+#~ "configuración del firmware UEFI del equipo (BIOS) y su fabricante puede "
+#~ "proporcionar información sobre cómo hacerlo."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Para obtener ayuda contacte con el fabricante del hardware o su proveedor "
+#~ "de TI."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "El arranque seguro está apagado"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "El arranque seguro evita que se cargue software malicioso cuando se "
+#~ "inicia el dispositivo. Actualmente está apagado."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "El arranque seguro se puede activar desde la configuración del firmware "
+#~ "UEFI del equipo (BIOS). Para obtener ayuda contacte con el fabricante del "
+#~ "hardware o su proveedor de TI."
+
+#~ msgid "Passed"
+#~ msgstr "Correcta"
+
+#~ msgid "Failed"
+#~ msgstr "Falló"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "El dispositivo cumple con el nivel %d de HSI"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Nivel de seguridad 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Este dispositivo no tiene protección contra problemas de seguridad de "
+#~ "hardware. Esto podría deberse a un problema de configuración de hardware "
+#~ "o firmware. Se recomienda ponerse en contacto con su proveedor de soporte "
+#~ "de TI."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Nivel de seguridad 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Este dispositivo tiene una protección mínima contra problemas de "
+#~ "seguridad de hardware. Este es el nivel de seguridad más bajo del "
+#~ "dispositivo y solo brinda protección contra amenazas de seguridad simples."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Nivel de seguridad 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Este dispositivo tiene protección básica contra problemas de seguridad de "
+#~ "hardware. Esto proporciona protección contra algunas amenazas de "
+#~ "seguridad comunes."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Nivel de seguridad 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Este dispositivo tiene protección extendida contra problemas de seguridad "
+#~ "de hardware. Este es el nivel más alto de seguridad del dispositivo y "
+#~ "brinda protección contra amenazas de seguridad avanzadas."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr ""
+#~ "Los niveles de seguridad no están disponibles para este dispositivo."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Contacte con el fabricante del hardware para solicitar ayuda sobre las "
+#~ "actualizaciones de seguridad."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Es posible resolver este problema en la configuración del firmware UEFI "
+#~ "del dispositivo o con un soporte técnico."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Es posible resolver este problema en la configuración del firmware UEFI "
+#~ "del dispositivo."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Es posible resolver este problema con un soporte técnico."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr ""
+#~ "Protegido frente a software malicioso cuando se inicia el dispositivo."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Secure Boot tiene problemas"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Alguna protección cuando se inicia el dispositivo."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "El arranque seguro está apagado"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Sin protección cuando se inicia el dispositivo."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Este problema puede haberlo causado un cambio en la configuración del "
+#~ "firmware UEFI, en el sistema operativo o deberse a software malicioso en "
+#~ "el sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Este problema puede haberlo causado un cambio en la configuración del "
+#~ "firmware UEFI o deberse a software malicioso en el sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Este problema puede haberlo causado un cambio en el sistema operativo o "
+#~ "deberse a software malicioso en el sistema."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Expuesto a amenazas de seguridad serias."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Protección limitada frente a amenazas de seguridad sencillas."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Protegido contra amenazas de seguridad habituales."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Protegido contra una amplia variedad de amenazas de seguridad."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Protección integral"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Protección de escritura del firmware"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Bloqueo de protección de escritura del firmware"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Región del firmware de la BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Descriptor del firmware de la BIOS"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Protección de pre-arranque DMA"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Arranque verificado por Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "ACM protegido por Intel BootGuard"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Error de política de Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Fusible Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET activado"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET activado"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "RAM cifrada"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Protección IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Bloqueo del núcleo Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Verificación del núcleo Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Intercambio de Linux"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Suspender a RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Suspender a inactividad"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Clave de la plataforma UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Arranque seguro UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Configuración de la plataforma TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Reconstrucción de TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Modo de fabricación del motor Intel Management"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Omitir motor Intel Management"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Versión del motor de Intel Management"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Actualizaciones de firmware"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Comprobación de firmware"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Verificación del actualizador de firmware"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Depurado de la plataforma"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Comprobaciones de seguridad del procesador"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Protección de marcha atrás de AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Protección de reproducción de firmware de AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Protección de escritura de firmware de AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Plataforma fusionada"
+
+#~ msgid "Valid"
+#~ msgstr "Válido"
+
+#~ msgid "Not Valid"
+#~ msgstr "No válido"
+
+#~ msgid "Not Enabled"
+#~ msgstr "No activada"
+
+#~ msgid "Locked"
+#~ msgstr "Bloqueada"
+
+#~ msgid "Not Locked"
+#~ msgstr "No bloqueada"
+
+#~ msgid "Encrypted"
+#~ msgstr "Cifrado"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "No cifrado"
+
+#~ msgid "Tainted"
+#~ msgstr "Envenenado"
+
+#~ msgid "Not Tainted"
+#~ msgstr "No envenenado"
+
+#~ msgid "Found"
+#~ msgstr "Encontrada"
+
+#~ msgid "Not Found"
+#~ msgstr "No encontrada"
+
+#~ msgid "Supported"
+#~ msgstr "Soportada"
+
+#~ msgid "Not Supported"
+#~ msgstr "No soportada"
+
+#~ msgid "Unknown"
+#~ msgstr "Desconocido"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 bits"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 bits"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Desconocido"
+
+#~ msgid "Not Available"
+#~ msgstr "No disponible"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo del sistema"
+
+#~ msgid "No input sources found"
+#~ msgstr "No se han encontrado fuentes de entrada"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Otra"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Atajo personalizado"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "La tecla de caracteres alternativos se puede usar para introducir "
+#~ "caracteres adicionales. A veces se muestran como una tercera opción en el "
+#~ "teclado."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt izquierdo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt derecha"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Súper izquierdo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Súper derecho"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tecla de menú"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl derecho"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "La tecla de composición le permite escribir una amplia variedad de "
+#~ "caracteres. Para usarla pulse esa tecla y una secuencia de caracteres. "
+#~ "Por ejemplo, la tecla de composición seguida de <b>C</b> y <b>o</b> "
+#~ "escribirá <b>©</b>, <b>a</b> seguida <b>'</b> escribirá <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Bloq. Mayús."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Bloq. Despl."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Impr. Pant."
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Las fuentes de entrada se puede cambiar usando el atajo del teclado %s.\n"
+#~ "Puede cambiar este atajo en la configuración del teclado"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificado"
+#~ msgstr[1] "%d modificados"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "¿Restablecer todos los atajos?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Restablecer todos los atajos puede afectar a sus atajos personalizados. "
+#~ "Esto no se puede deshacer."
+
+#~ msgid "Reset All"
+#~ msgstr "Restablecer todo"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s ya está en uso por %s. Si lo reemplaza, %s se desactivará"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Introduzca el atajo nuevo"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Establecer atajo personalizado"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Establecer atajo"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Introduzca el nuevo atajo para cambiar %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Añadir un atajo personalizado"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Desplazamiento con dos dedos"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinco pulsaciones, es tiempo de GEGL."
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Doble pulsación, botón primario"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Una sola pulsación, botón primario"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Doble pulsación, botón central"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Una sola pulsación, botón central"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Doble pulsación, botón secundario"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Una sola pulsación, botón secundario"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager debe estar en ejecución."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Red insegura (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Red segura (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Red segura (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Red segura (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Red segura"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Activar el punto de acceso hará que se desconecte de %s y no será posible "
+#~ "acceder a Internet mediante Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Debe tener un mínimo de 8 caracteres"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "¿Detener el «hotspot» y desconectar a los usuarios?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Detener «hotspot»"
+
+#~ msgid "Preserve"
+#~ msgstr "Mantener"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanente"
+
+#~ msgid "Random"
+#~ msgstr "Aleatorio"
+
+#~ msgid "Stable"
+#~ msgstr "Estable"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "La dirección MAC introducida aquí se usará como dirección hardware para "
+#~ "el dispositivo de red en el que se active esta conexión. Esto se conoce "
+#~ "como clonado de MAC o «spoofing». Ejemplo: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Perfil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Empresa"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ninguna"
+
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Ninguna"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Débil"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Aceptar"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Buena"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excelente"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Olvidar conexión"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Eliminar perfil de conexión"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Quitar VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detalles"
+
+#~ msgid "automatic"
+#~ msgstr "automático"
+
+#~ msgid "Identity"
+#~ msgstr "Identidad"
+
+#~ msgid "Delete Address"
+#~ msgstr "Eliminar dirección"
+
+#~ msgid "Delete Route"
+#~ msgstr "Eliminar ruta"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ninguna"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Clave WEP 40/128-bit (Hexadecimal o ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Frase de paso WEP de 128 bits"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinámica (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA y WPA2 personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA y WPA2 enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "No se pudo abrir el editor de conexiones"
+
+#~ msgid "New Profile"
+#~ msgstr "Perfil nuevo"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Ajuste %s no válido: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Ajuste no válido %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importar desde un archivo…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Añadir VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "No se puede importar la conexión VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "No se pudo leer el archivo «%s» o no contiene información de una conexión "
+#~ "VPN que se pueda reconocer\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Seleccione el archivo que importar"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Ya existe un archivo llamado «%s»."
+
+#~ msgid "_Replace"
+#~ msgstr "_Reemplazar"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "¿Quiere reemplazar %s con la conexión VP que está guardando?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "No se puede exportar la conexión VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportar conexión VPN"
+
+#~ msgid "never"
+#~ msgstr "nunca"
+
+#~ msgid "today"
+#~ msgstr "hoy"
+
+#~ msgid "yesterday"
+#~ msgstr "ayer"
+
+#~ msgid "Last used"
+#~ msgstr "Usada última vez"
+
+#~ msgid "Add new connection"
+#~ msgstr "Añadir una conexión nueva"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Se perderán los detalles de las redes seleccionadas, incluyendo la "
+#~ "contraseña y cualquier configuración personalizada."
+
+#~ msgid "_Forget"
+#~ msgstr "_Olvidar"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Redes inalámbricas conocidas"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Olvidar"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "La política del sistema prohíbe usarlo como punto de acceso"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "El dispositivo inalámbrico no soporta el modo de punto de acceso"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Se usa el autodiscubrimiento del proxy web cuando no se proporciona un "
+#~ "URL de configuración."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "No se recomienda para redes públicas en las que no se confía."
+
+#~ msgid "Status unknown"
+#~ msgstr "Estado desconocido"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Sin gestionar"
+
+#~ msgid "Unavailable"
+#~ msgstr "No disponible"
+
+#~ msgid "Connecting"
+#~ msgstr "Conectando"
+
+#~ msgid "Authentication required"
+#~ msgstr "Se necesita autenticación"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Desconectando"
+
+#~ msgid "Connection failed"
+#~ msgstr "Falló la conexión"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Estado desconocido (ausente)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Falló la configuración"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Falló la configuración IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "La configuración IP ha expirado"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Se necesitan secretos, pero no se han proporcionado"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Suplicante de 802.1x desconectado"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Falló la configuración del suplicante de 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Falló el suplicante de 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "El suplicante de 802.1x tardó mucho tiempo en autenticarse"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Falló al iniciar el servicio de PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Servicio PPP desconectado"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP falló"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Falló al iniciar el cliente de DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Error del cliente de DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Falló el cliente de DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Falló al iniciar el servicio de conexión compartida"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Falló el servicio de conexión compartida"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Falló al iniciar el servicio de AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Error del servicio de AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Falló el servicio AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "Línea ocupada"
+
+#~ msgid "No dial tone"
+#~ msgstr "No hay tono de llamada"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "No se pudo establecer el portador"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Expiró el tiempo de solicitud de llamada"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Intento de llamada fallido"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Falló la inicialización del módem"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Falló al seleccionar el NPA especificado"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "No se están buscando redes"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Registro de la red denegado"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Expiró el tiempo de registro de la red"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Falló al registrarse con la red solicitada"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Falló la comprobación de l PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Es posible que falte el firmware del dispositivo"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "La conexión ha desaparecido"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Se asumió una conexión existente"
+
+#~ msgid "Modem not found"
+#~ msgstr "Módem no encontrado"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Falló la conexión Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Tarjeta SIM no insertada"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Se necesita el PIN de la SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Se necesita el PUK de la SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM errónea"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Falló la dependencia de la conexión"
+
+#~ msgid "Firmware missing"
+#~ msgstr "falta el «firmware»"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cable desconectado"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "error no definido en la seguridad 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "no se ha seleccionado ningún archivo"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "error no especificado al validar el archivo del método eap"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12, o claves privadas PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certificados DER o PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "falta el archivo PAC de EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Archivos PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "falta el nombre de usuario de EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "falta la contraseña de EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "CA del certificado EAP-PEAP no válida: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "CA del certificado EAP-PEAP no válida: no se ha especificado el "
+#~ "certificado"
+
+#~ msgid "missing EAP username"
+#~ msgstr "falta el nombre de usuario de EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "falta la contraseña EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "falta la identidad EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "CA del certificado EAP-TLS no válida: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "CA del certificado EAP-TLS no válida: no se ha especificado el certificado"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "clave privada EAP-TLS no válida: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "usuario del certificado EAP-TLS no válido: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Las claves privadas sin cifrar son inseguras"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "La clave privada seleccionada no parece estar protegida por una "
+#~ "contraseña. Esto podría permitir que sus credenciales de seguridad se "
+#~ "comprometiesen. Seleccione una clave privada protegida por contraseña.\n"
+#~ "\n"
+#~ "(Puede proteger su clave privada con una contraseña con openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Elija su certificado personal"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Elija su clave privada"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "CA del certificado EAP-TTLS no válida: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "CA del certificado EAP-TTLS no válida: no se ha especificado el "
+#~ "certificado"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Error desconocido al validar la seguridad 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Seleccione un archivo"
+
+#~ msgid "missing leap-username"
+#~ msgstr "falta el nombre de usuario leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "falta la contraseña leap"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Falta la contraseña de la red inalámbrica."
+
+#~ msgid "missing wep-key"
+#~ msgstr "falta la clave wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "clave wep no válida: una clave de longitud %zu sólo puede contener "
+#~ "dígitos hexadecimales"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "clave wep no válida: una clave de longitud %zu sólo debe contener "
+#~ "caracteres ASCII"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "clave wep no válida: longitud de clave %zu incorrecta. La clave debe ser "
+#~ "de 5/13 (ascii) o 10/26 (hexadecimal)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "clave wep no válida: la frase de paso no puede estar vacía"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "clave wep no válida: la frase de paso debe ser inferior a 64 caracteres"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "clave wpa-psk no válida: longitud %zu de la clave no válida. Debe ser de "
+#~ "[8,63] bytes o 64 dígitos hexadecimales"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "clave wpa-psk no válida: no se puede interpretar una clave de 64 bytes "
+#~ "como hexadecimal"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Otra"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s eliminado"
+
+#~ msgid "Error removing account"
+#~ msgstr "Error al quitar la cuenta"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Cuenta de %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Quitar cuenta"
+
+#~ msgid "Unknown time"
+#~ msgstr "Tiempo desconocido"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s hasta que se cargue del todo"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Advertencia: quedan %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s restante"
+
+#~ msgid "Fully charged"
+#~ msgstr "Cargada completamente"
+
+#~ msgid "Not charging"
+#~ msgstr "No está cargando"
+
+#~ msgid "Empty"
+#~ msgstr "Vacía"
+
+#~ msgid "Charging"
+#~ msgstr "Cargando"
+
+#~ msgid "Discharging"
+#~ msgstr "Descargando"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Ratón inalámbrico"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Teclado inalámbrico"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Fuente de alimentación no interrumplible"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Asistente digital personal"
+
+#~ msgid "Cellphone"
+#~ msgstr "Teléfono móvil"
+
+#~ msgid "Media player"
+#~ msgstr "Reproductor multimedia"
+
+#~ msgid "Tablet"
+#~ msgstr "Tableta"
+
+#~ msgid "Computer"
+#~ msgstr "Equipo"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Mando de juegos"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principal"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Adicional"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterías"
+
+#~ msgid "When _idle"
+#~ msgstr "Cuando esté _inactivo"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspender"
+
+#~ msgid "Power Off"
+#~ msgstr "Apagar"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernar"
+
+#~ msgid "Nothing"
+#~ msgstr "Nada"
+
+#~ msgid "When on battery power"
+#~ msgstr "En modo batería"
+
+#~ msgid "When plugged in"
+#~ msgstr "Cuando está conectado a la red"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Suspender automáticamente"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Modo rendimiento desactivado temporalmente debido a la alta temperatura "
+#~ "de operación."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Portátil detectado: modo rendimiento desactivado temporalmente. Mueva el "
+#~ "dispositivo a una superficie estable para restaurarlo."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Modo de rendimiento desactivado temporalmente."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Batería baja: ahorro de energía activado. El modo anterior se restaurará "
+#~ "cuando la batería esté suficientemente cargada."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Modo de ahorro de energía activado por «%s»."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Modo de rendimiento activado por «%s»."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Rendimiento"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Alto rendimiento y uso de energía"
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Balanceado"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Rendimiento estándar y uso de energía."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Ahorro de energía"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Reduce el rendimiento y el uso de energía."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Se ha eliminado la impresora «%s»"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Falló al añadir una impresora nueva."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "No se pudo cargar la IU: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Desbloquear para añadir impresoras y cambiar la configuración"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detalles de %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "No se ha encontrado ningún controlador adecuado"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Seleccionar archivo PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Archivos de descripción de impresora PostScript (*.ppd, *.PPD, *.ppd.gz, "
+#~ "*.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Impresora JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Impresora LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Una cara"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Margen largo (estándar)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Margen corto (girar)"
+
+#~ msgid "Portrait"
+#~ msgstr "Vertical"
+
+#~ msgid "Landscape"
+#~ msgstr "Apaisado"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Apaisado invertido"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Vertical invertido"
+
+#~ msgid "Resume"
+#~ msgstr "Reanudar"
+
+#~ msgid "Pause"
+#~ msgstr "Pausar"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Pendiente"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pausado"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autenticación requerida"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Procesando"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Detenido"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Cancelado"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Abortado"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Completado"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Mover este trabajo al principio de la cola"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - trabajos activos"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Introduzca las credenciales para imprimir desde %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Desbloquear servidor de impresión"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Desbloquear %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Introduzca su nombre de usuario y su contraseña para ver las impresoras "
+#~ "en %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Buscando impresoras"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Puerto serie"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Puerto paralelo"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Ubicación: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Dirección: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "El servidor requiere autenticación"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dos caras"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tipo de papel"
+
+#~ msgid "Paper Source"
+#~ msgstr "Fuente de papel"
+
+#~ msgid "Output Tray"
+#~ msgstr "Bandeja de salida"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolución"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Prefiltrado GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Páginas por cara"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientación"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "General"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Configuración de página"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opciones instalables"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Trabajo"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Calidad de la imagen"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Terminando"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avanzado"
+
+#~ msgid "Test page"
+#~ msgstr "Página de prueba"
+
+#~ msgid "Auto Select"
+#~ msgstr "Seleccionar automáticamente"
+
+#~ msgid "Printer Default"
+#~ msgstr "Impresora predeterminada"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Sólo empotrar tipografías GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Convertir a PS nivel 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Convertir a PS nivel 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Sin prefiltrado"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Limpiar cabezales de la impresora"
+
+#~ msgid "Out of toner"
+#~ msgstr "Sin tóner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Nivel de revelador bajo"
+
+#~ msgid "Out of developer"
+#~ msgstr "Sin revelador"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Marcador bajo"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Sin marcador"
+
+#~ msgid "Open cover"
+#~ msgstr "Abrir cubierta"
+
+#~ msgid "Open door"
+#~ msgstr "Abrir puerta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Nivel de papel bajo"
+
+#~ msgid "Out of paper"
+#~ msgstr "Sin papel"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Desconectada"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Detenida"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Recipiente de residuos casi lleno"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Receptáculo de residuos lleno"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "El conductor óptico está cerca del final de su vida"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "El conductor óptico ya no funciona"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Preparada"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "No aceptar trabajos"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Procesando"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Métrico"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Preguntar qué hacer"
+
+#~ msgid "Do nothing"
+#~ msgstr "No hacer nada"
+
+#~ msgid "Open folder"
+#~ msgstr "Abrir carpeta"
+
+#~ msgid "Other Media"
+#~ msgstr "Otros soportes"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Seleccionar una aplicación para CD de sonido"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Seleccionar una aplicación para DVD de vídeo"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Seleccionar una aplicación que ejecutar cuando se conecta un reproductor "
+#~ "de música"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Seleccionar una aplicación que ejecutar cuando se conecta una cámara"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Seleccionar una aplicación para CD de software"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD de sonido"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "disco Blu-ray virgen"
+
+#~ msgid "blank CD disc"
+#~ msgstr "CD virgen"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "DVD virgen"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "disco HD DVD virgen"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disco Blu-ray de vídeo"
+
+#~ msgid "e-book reader"
+#~ msgstr "lector de libros electrónicos"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disco HD DVD de vídeo"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD de imágenes"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "Windows software"
+#~ msgstr "Software de Windows"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Se apaga la pantalla"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 segundos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#~ msgid "Select Location"
+#~ msgstr "Seleccionar ubicación"
+
+#~ msgid "_OK"
+#~ msgstr "_Aceptar"
+
+#~ msgid "No applications found"
+#~ msgstr "No se han encontrado aplicaciones"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "No se han seleccionado redes para compartir"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Encendido"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Apagado"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Activado"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Activo"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Elija una carpeta"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Activar la compartición multimedia"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Compartir archivos personales le permite compartir su carpeta «Público» "
+#~ "con otros en su red actual usando: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Cuando el inicio de sesión remoto está activado, los usuarios remotos "
+#~ "pueden conectarse usando el comando de shell segura:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Activar la compartición de archivos personales"
+
+#~ msgid "Device name copied"
+#~ msgstr "Nombre del dispositivo copiado"
+
+#~ msgid "Device address copied"
+#~ msgstr "Dirección del dispositivo copiada"
+
+#~ msgid "Username copied"
+#~ msgstr "Nombre de usuario copiado"
+
+#~ msgid "Password copied"
+#~ msgstr "Contraseña copiada"
+
+#~ msgid "Custom"
+#~ msgstr "Personalizado"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Probando %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Desconectado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Conectando"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Conectado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Error de autorización"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autorizando"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Funcionalidad reducida"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Conectado y autorizado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Desconocido"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorizado a las:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Conectado a las:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Unido a las:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Falló al autorizar el dispositivo: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Falló al olvidar el dispositivo: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Error"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorizado"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "El subsistema de Thunderbolt (boltd) no está instalado o no se ha "
+#~ "configurado correctamente."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Sólo se pueden conectar dispositivos USB y Display Port"
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "No se pudo detectar Thunderbolt.\n"
+#~ "El sistema carece de soporte para Thunderbolt, se ha desactivado en la "
+#~ "BIOS o se ha configurado con un nivel de seguridad no soportado en la "
+#~ "BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "El soporte de Thunderbolt se ha desactivado en la BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "No se puede determinar el nivel de seguridad de Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Error al cambiar al modo directo: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Predeterminado"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Mediano"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Grande"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Más grande"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "El más grande"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d píxel"
+#~ msgstr[1] "%d píxeles"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Corta"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ de pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Larga"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 día"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 días"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "¿Quiere vaciar todos los elementos de la papelera?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr ""
+#~ "Todos los elementos de la papelera se eliminarán de manera permanente."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Vaciar papelera"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "¿Quiere eliminar todos los archivos temporales?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Todos los archivos temporales se eliminarán de manera permanente."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Limpiar archivos temporales"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 día"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 días"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 días"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Para siempre"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Debe coincidir con la dirección web del proveedor de la cuenta."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Falló al añadir la cuenta"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Falló al registrar la cuenta"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "No hay una manera soportada de autenticar con este dominio"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Falló al unirse al dominio"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "El nombre de inicio de sesión no ha funcionado.\n"
+#~ "Inténtelo de nuevo."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "La contraseña de inicio de sesión no ha funcionado.\n"
+#~ "Inténtelo de nuevo."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Falló al iniciar sesión en el dominio"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "No se pudo encontrar el dominio. ¿Está bien escrito?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Examinar para buscar más imágenes"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "es necesario reclamar el dispositivo para realizar esta acción"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "otro proceso ha solicitado el dispositivo"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "no tiene permisos para realizar esta acción"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "no se han registrado impresiones"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Falló al comunicarse con el dispositivo durante el registro"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Falló al comunicarse con el lector de huellas catilares"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Falló al comunicarse con el demonio de huella dactilar"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Falló al listas las huellas guardadas: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Falló al eliminar las huellas guardadas: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Pulgar izquierdo"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Dedo corazón izquierdo"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Dedo índice _izquierdo"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Dedo anular izquierdo"
+
+#~ msgid "Left little finger"
+#~ msgstr "Dedo meñique izquierdo"
+
+#~ msgid "Right thumb"
+#~ msgstr "Pulgar derecho"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Dedo corazón derecho"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Dedo índice derecho"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Dedo anular derecho"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dedo meñique derecho"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Dedo desconocido"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Terminado"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Dispositivo de huella dactilar desconectado"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "El dispositivo de almacenamiento de huellas dactilares está lleno"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Falló al dar de alta la nueva huella dactilar"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Falló al iniciar el alta: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Falló al dar de alta una nueva huella dactilar"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Falló al detener el alta: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Levante y coloque su dedo repetidamente en el lector para dar de alta su "
+#~ "huella."
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Volver a dar de alta este dedo…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Analizar una huella dactilar nueva"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Falló al liberar el dispositivo de huella dactilar %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problema al leer el dispositivo"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Falló al solicitar el dispositivo de huella dactilar %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Falló al obtener los dispositivos de huella dactilar: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Esta semana"
+
+#~ msgid "Last Week"
+#~ msgstr "Última semana"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sesión terminada"
+
+#~ msgid "Session Started"
+#~ msgstr "Sesión iniciada"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s - Actividad de la cuenta"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Elija otra contraseña."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Escriba de nuevo su contraseña actual."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "No se pudo cambiar la contraseña"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "No se puede unir automáticamente a este tipo de dominio"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "No existe el dominio o no se ha encontrado el reino"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "No se puede iniciar sesión como %s en el dominio %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Contraseña no válida, inténtelo de nuevo"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "No se pudo conectar al dominio %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Falló al eliminar el usuario"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Falló al revocar remotamente el usuario gestionado"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "No puede eliminar su propia cuenta."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s aún está registrado en el sistema"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Eliminar un usuario mientras está registrado en el sistema puede dejar el "
+#~ "sistema en un estado inconsistente."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "¿Quiere mantener los archivos de %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Es posible mantener la carpeta personal, el «spool» del correo y los "
+#~ "archivos temporales al eliminar una cuenta de usuario."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Eliminar archivos"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Mantener archivos"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "¿Está seguro de que quiere revocar remotamente la cuenta gestionada de %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Eliminar"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Cuenta desactivada"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Para configurar en el siguiente inicio de sesión"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ninguno"
+
+#~ msgid "Logged in"
+#~ msgstr "Sesión iniciada"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Falló al contactar con el servicio de cuentas"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Asegúrese de que el servicio de cuentas está instalado y activado."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Se debe desbloquear este panel para cambiar esta opción"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Quitar la cuenta de usuario seleccionada"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para eliminar la cuenta de usuario seleccionada\n"
+#~ "pulse primero el icono *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Desbloquear para añadir usuarios y cambiar la configuración"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "La contraseña nueva debe ser diferente de la antigua."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Pruebe a cambiar algunas letras y números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Pruebe a cambiar la contraseña un poco más."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Una contraseña sin su nombre de usuario será más robusta."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Evite usar su nombre en la contraseña."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Evite algunas de las palabras incluidas en la contraseña."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Trate de evitar palabras comunes."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Evite reordenar las palabras existentes."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Pruebe a usar más números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Pruebe a usar más letras en mayúscula."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Pruebe a usar más letras en minúscula."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Pruebe a usar más caracteres especiales, como signos de puntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Pruebe a usar una mezcla de letras, números y signos de puntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Evite repetir el mismo carácter."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Evite repetir el mismo tipo de carácter: debe mezclar letras, números y "
+#~ "signos de puntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Evite secuencias como 1234 o abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "La contraseña debe ser más larga. Pruebe a añadir más letras, números y "
+#~ "signos de puntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Mezcle letras mayúsculas y minúsculas y use uno o dos números."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Añadir más letras, números y signos de puntuación hará que la contraseña "
+#~ "sea más robusta."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Falló la autenticación"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "La contraseña nueva es demasiado corta"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "La contraseña nueva es demasiado simple"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "La contraseña antigua y la nueva son demasiado similares"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "La contraseña nueva ya se ha usado recientemente."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "La contraseña nueva debe contener caracteres numéricos o especiales"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "La contraseña nueva y la antigua son la misma"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Se ha cambiado su contraseña desde que se autenticó inicialmente."
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "La contraseña nueva no contiene suficientes caracteres diferentes"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Error desconocido"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "El nombre de usuario debe constar solamente de letras minúsculas de la "
+#~ "«a» a la «z», dígitos y cualquiera de los caracteres: «-» o «_»"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "El nombre de usuario no está disponible. Pruebe con otro."
+
+#~ msgid "The username is too long."
+#~ msgstr "El nombre de usuario es demasiado largo."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Botón %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Aplicación definida"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Enviar pulsación de tecla"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Cambiar monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Mostrar la ayuda en pantalla"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tableta montada en el panel del portátil"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tableta montada en una pantalla externa"
+
+#~ msgid "External tablet device"
+#~ msgstr "Tableta externa"
+
+#~ msgid "All Displays"
+#~ msgstr "Todas las pantallas"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Lápiz aerógrafo con presión, inclinación y deslizador integrado"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Lápiz aerógrafo con presión, inclinación y rotación"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Lápiz estándar con presión e inclinación"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Lápiz estándar con presión"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Atajo nuevo..."
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operación cancelada"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Error:</b> acceso denegado para modificar la configuración"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Error:</b> error del equipo móvil"
+
+#~ msgid "Not Registered"
+#~ msgstr "No registrado"
+
+#~ msgid "Registered"
+#~ msgstr "Registrado"
+
+#~ msgid "Roaming"
+#~ msgstr "Itinerancia"
+
+#~ msgid "Searching"
+#~ msgstr "Buscando"
+
+#~ msgid "Denied"
+#~ msgstr "Denegado"
+
+#~ msgid "2G Only"
+#~ msgstr "2G sólo"
+
+#~ msgid "3G Only"
+#~ msgstr "3G sólo"
+
+#~ msgid "4G Only"
+#~ msgstr "4G sólo"
+
+#~ msgid "5G Only"
+#~ msgstr "5G sólo"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (preferido)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (preferido), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (preferido), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (preferido), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (preferido)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (preferido), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (preferido), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (preferido)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (preferido), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (preferido), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (preferido)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (preferido), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (preferido), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (preferido)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (preferido), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (preferido), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (preferido)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (preferido), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (preferido)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (preferido), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (preferido)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (preferido), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (preferido)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (preferido), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (preferido)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (preferido), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (preferido)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (preferido), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Desconocido"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Desbloquear tarjeta SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Proporcione el código PIN para la SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Introduzca el PIN para desbloquear su tarjeta SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Proporcione el código PUK para la SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Introduzca el PUK para desbloquear su tarjeta SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Contraseña incorrecta."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "El código PUK debe ser un número de 8 cifras"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Introduzca un nuevo PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "El código PIN debe ser un número de 4-8 cifras"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Desbloqueando…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Falló del teléfono"
+
+#~ msgid "No connection to phone"
+#~ msgstr "No hay conexión con el teléfono"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operación no permitida"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operación no soportada"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Tarjeta SIM no insertada"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Se necesita el PIN de la SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Se necesita el PUK de la SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Fallo de la tarjeta SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "Tarjeta SIM ocupada"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Contraseña incorrecta"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Se necesita el PIN2 de la SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Se necesita el PUK2 de la SIM"
+
+#~ msgid "Not found"
+#~ msgstr "No encontrado"
+
+#~ msgid "No network service"
+#~ msgstr "No hay servicio de red"
+
+#~ msgid "Network timeout"
+#~ msgstr "Tiempo de expiración de la red"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Servicios GPRS no permitidos"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Itinerancia no permitida en esta área"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Error GPRS no especificado"
+
+#~ msgid "No Error"
+#~ msgstr "Sin error"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Acción cancelada"
+
+#~ msgid "Access denied"
+#~ msgstr "Acceso denegado"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Error desconocido"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Mostrar el número de versión"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Activar el modo detallado"
+
+#~ msgid "Search for the string"
+#~ msgstr "Buscar la cadena"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Listar todos los nombres de paneles posibles y salir"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel que mostrar"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENTO…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Paneles disponibles:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sonidos del sistema"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Error: no se puede determinar el nivel de HSI."
@@ -9632,9 +8339,6 @@ msgstr "Sonidos del sistema"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "Certificados DER o PEM (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Añadir una impresora…"
 
 #~ msgid "Drip"
 #~ msgstr "Goteo"
@@ -9892,9 +8596,6 @@ msgstr "Sonidos del sistema"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tableta (absoluto)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Panel táctil (relativo)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Preferencias de la tableta"
 
@@ -10014,8 +8715,8 @@ msgstr "Sonidos del sistema"
 #~ msgstr "No se puede cambiar"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Se pueden revisar los permisos individuales de cada aplicación en la "
 #~ "configuración de la <a href=\"privacy\">Privacidad</a>."
@@ -11394,9 +10095,6 @@ msgstr "Sonidos del sistema"
 #~ msgid "Mirrored"
 #~ msgstr "En espejo"
 
-#~ msgid "Secondary"
-#~ msgstr "Secundaria"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Ordenar las pantallas combinadas"
 
@@ -11469,9 +10167,6 @@ msgstr "Sonidos del sistema"
 #~ msgctxt "proxy method"
 #~ msgid "Automatic"
 #~ msgstr "Automático"
-
-#~ msgid "_Method"
-#~ msgstr "_Método"
 
 #~ msgid "Add Device"
 #~ msgstr "Añadir dispositivo"
@@ -11586,9 +10281,6 @@ msgstr "Sonidos del sistema"
 
 #~ msgid "Mail"
 #~ msgstr "Correo"
-
-#~ msgid "Calendar"
-#~ msgstr "Calendario"
 
 #~ msgid "Contacts"
 #~ msgstr "Contactos"
@@ -11740,9 +10432,6 @@ msgstr "Sonidos del sistema"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Desplazar hacia arriba"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Desplazar hacia abajo"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Desplazar hacia la derecha"
@@ -12063,9 +10752,6 @@ msgstr "Sonidos del sistema"
 
 #~ msgid "Turns off wireless devices"
 #~ msgstr "Apaga los dispositivos inalámbricos"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Desac_tivar al escribir"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr ""
@@ -12954,9 +11640,6 @@ msgstr "Sonidos del sistema"
 #~ "Seleccionar un idioma para mostrar (el cambio se aplicará la próxima vez "
 #~ "que inicie sesión)"
 
-#~ msgid "Install languages..."
-#~ msgstr "Instalar idiomas…"
-
 #~ msgid "Brightness & Lock"
 #~ msgstr "Brillo y bloqueo"
 
@@ -13249,9 +11932,6 @@ msgstr "Sonidos del sistema"
 
 #~ msgid "Layouts"
 #~ msgstr "Distribuciones"
-
-#~ msgid "Layout"
-#~ msgstr "Distribución"
 
 #~ msgid "1/4 Screen"
 #~ msgstr "1/4 de pantalla"
@@ -13604,9 +12284,6 @@ msgstr "Sonidos del sistema"
 
 #~ msgid "Photos"
 #~ msgstr "Fotos"
-
-#~ msgid "_Acceleration:"
-#~ msgstr "_Aceleración:"
 
 #~ msgid "Beep when a modifer key is pressed"
 #~ msgstr "Pitar al pulsar una tecla modificadora"
@@ -15072,9 +13749,6 @@ msgstr "Sonidos del sistema"
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "_Restablecer valores predeterminados"
-
 #~ msgid "_Selected items:"
 #~ msgstr "Elementos _seleccionados:"
 
@@ -15211,9 +13885,6 @@ msgstr "Sonidos del sistema"
 
 #~ msgid "Copying files"
 #~ msgstr "Copiando archivos"
-
-#~ msgid "Parent Window"
-#~ msgstr "Ventana raíz"
 
 #~ msgid "Parent window of the dialog"
 #~ msgstr "Ventana raíz del diálogo"
@@ -15419,9 +14090,6 @@ msgstr "Sonidos del sistema"
 
 #~ msgid "Set your window properties"
 #~ msgstr "Establezca sus propiedades de ventana"
-
-#~ msgid "Windows"
-#~ msgstr "Ventanas"
 
 #~ msgid "Hide on start (useful to preload the shell)"
 #~ msgstr "Ocultar al inicio (útil para precargar la consola)"
@@ -15702,9 +14370,6 @@ msgstr "Sonidos del sistema"
 
 #~ msgid "<b>Music and Movies</b>"
 #~ msgstr "<b>Música y películas</b>"
-
-#~ msgid "Click OK to finish."
-#~ msgstr "Pulse «Aceptar» para terminar."
 
 #~ msgid "Play _sound effects when buttons are clicked"
 #~ msgstr "Reproducir efectos de _sonido al pulsar botones"

--- a/po/es.po~
+++ b/po/es.po~
@@ -1,0 +1,15791 @@
+# translation of gnome-control-center.master.po to Español
+# Copyright © 1999-2002, 2006, 2007, 2008 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Pablo Saratxaga <srtxg@chanae.alphanet.ch>, 1998-2001.
+# Carlos Perelló Marín <carlos@gnome-db.org>, 2001.
+# Héctor García Álvarez <hector@scouts-es.org>, 2001.
+# Germán Poo Caamaño <gpoo@ubiobio.cl>, 2002 (Revisor).
+# Lucas Di Pentima <lucas@lunix.com.ar>, 2002.
+# Pablo Gonzalo del Campo <pablodc@bigfoot.com>, 2002,2003.
+# Francisco Javier F. Serrador <serrador@cvs.gnome.org>, 2003, 2004, 2005, 2006.
+# Claudio Saavedra <csaavedra@alumnos.utalca.cl>, 2007.
+#
+#
+# Jorge González <jorgegonz@svn.gnome.org>, 2007, 2008, 2009, 2010, 2011.
+# Daniel Mustieles <daniel.mustieles@gmail.com>, 2010-2021.
+# Daniel Mustieles García <daniel.mustieles@gmail.com>, 2021-2022.
+# leo <daniel.mustieles@gmail.com>, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-10-25 14:38+0000\n"
+"PO-Revision-Date: 2022-11-08 18:03+0100\n"
+"Last-Translator: leo <daniel.mustieles@gmail.com>\n"
+"Language-Team: Español; Castellano <gnome-es-list@gnome.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Gtranslator 3.38.0\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Bus del sistema"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Acceso completo"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Bus de sesión"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositivos"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Acceso completo a /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Red"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Tiene acceso a la red"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Carpeta personal"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Sólo lectura"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Sistema de achivos"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Configuración"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Puede cambiar la configuración"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s tiene los siguientes permisos integrados y no se pueden modificar. Si "
+"esto le preocupa considere la opción de quitar esta aplicación."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u tipo de archivo y enlace abierto por esta aplicación"
+msgstr[1] "%u tipos de archivos y enlaces abiertos por esta aplicación"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> se usa para abrir los siguientes tipos de archivos y enlaces."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s de espacio de disco usado."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicaciones"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "No hay aplicaciones"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Instalar algunas…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Abrir"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Ver detalles"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Buscar"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Recibir búsquedas del sistema y enviar os resultados."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Desactivado"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificaciones"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Mostrar notificaciones del sistema"
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Ejecutar en segundo plano"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Permitir la actividad cuando la aplicación está cerrada."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Capturas de pantalla"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Hacer fotos de la pantalla en cualquier momento."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Cambiar el fondo"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Cambiar el fondo del escritorio."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sonidos"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reproducir sonidos."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Inhibir atajos"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Bloquear los atajos estándar del teclado."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Cámara"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Hacer fotos con la cámara."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Micrófono"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Grabar sonido con el micrófono."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Servicios de ubicación"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Acceder a datos de la ubicación del dispositivo."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Permisos integrados"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Acceso al sistema requerido por esta aplicación"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Asociaciones de archivos y enlaces"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Almacenamiento"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "No se han encontrado resultados"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Pruebe una búsqueda diferente"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Asociaciones de archivos y enlaces"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Tipos de archivos"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Tipos de enlaces"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Reiniciar"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Cuánto espacio en disco está usando esta aplicación incluyendo los datos de "
+"la aplicación y las cachés."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplicación"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Datos"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Caché"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Limpiar la caché…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Controlar la configuración y los permisos de varias aplicaciones"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplicación;flatpak;permisos;configuración;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Seleccionar una imagen"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancelar"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Abrir"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "tamaños múltiples"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Sin fondo de escritorio"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Fondo actual"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Estilo"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Predeterminado"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Oscuro"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Fondo"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Añadir imagen…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Apariencia"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Cambiar la imagen de fondo de escritorio o los colores de la IU"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Fondo;Pantalla;Escritorio;Estilo;Oscuro;Claro;Estilo;Oscuro;Claro;Apariencia;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Activar"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "No se encontraron adaptadores Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Conectar a un dongle para usar el Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth apagado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Encender para conectar dispositivos y recibir transferencias de archivos."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "El modo avión está activado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "El Bluetooth está apagado cuando el modo avión está activado."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Apagar el modo avión"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "El hardware en modo avión está activado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Apague el modo avión para activar el Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Activar y desactivar Bluetooth y conectar sus dispositivos"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "compartir;compartición;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "La cámara está apagada"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Ninguna aplicación puede capturar fotos o vídeo."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"El uso de la cámara permite a las aplicaciones capturar fotos y vídeo. "
+"Desactivarla puede hacer que algunas aplicaciones no funcionen "
+"correctamente.\n"
+"Permita a la siguientes aplicaciones usar la cámara."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Ninguna aplicación ha solicitado acceso a la cámara"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Proteger sus imágenes"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "cámara;fotos;vídeo;webcam;web;bloqueo;privado;privacidad;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Coloque su dispositivo de calibración sobre el cuadrado y pulse «Iniciar»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Mueva su dispositivo de calibración a la posición de calibrado y pulse "
+"«Continuar»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Mueva su dispositivo de calibración a la posición de la superficie y pulse "
+"«Continuar»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Apagar la tapa del portátil"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Ocurrió un error interno y no se pudo recuperar."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Las herramientas requeridas para la calibración no están instaladas."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "No se puede generar el perfil."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "No se pudo obtener el punto blanco del objetivo."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Completado"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Falló la configuración."
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Puede quitar el dispositivo de calibración."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "No interrumpir al dispositivo de calibración cuando está en progreso"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Calibración de la pantalla"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Empezar"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Reanudar"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Hecho"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Pantalla del portátil"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Cámara web integrada"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Escáner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Cámara %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Impresora %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Cámara web %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Activar la gestión de color para %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Mostrar perfiles de color para %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Sin calibrar"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Predeterminado: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Espacio de color: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Perfil de color: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Seleccionar archivo de perfil ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importar"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Perfiles ICC soportados"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Todos los archivos"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantalla"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Guardar perfil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Guardar"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Crear un perfil de color para el dispositivo seleccionado"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"No se detectó el instrumento de medida. Compruebe que está encendido y "
+"correctamente conectado."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "El instrumento de medida no soporta perfilado de impresoras."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "El tipo de dispositivo actualmente no está soportado."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Calibración de la pantalla"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Calidad de la calibración"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"La calibración generará un perfil que puede usar para gestionar su pantalla. "
+"Cuanto más tiempo invierta en la calibración, mejor será la calidad del "
+"perfil de color."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "No podrá usar su equipo mientras se realiza la calibración."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Calidad"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Duración aproximada"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Calibración del dispositivo"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Seleccione el sensor que quiere usar para la calibración."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tipo de pantalla"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Seleccionar el tipo de pantalla que está conectada."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Puntero blanco del perfil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Seleccionar el punto blanco objetivo de la pantalla. La mayoría de las "
+"pantallas se deben calibrar con una luminancia D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Brillo de la pantalla"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Configure el brillo de la pantalla a un valor que le resulte cómodo. La "
+"gestión del color será más precisa usando este nivel de brillo."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativamente, puede usar el nivel de brillo usado con uno de los otros "
+"perfiles para este dispositivo."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nombre del perfil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Puede usar un perfil de color en diferentes equipos, o incluso crear "
+"perfiles para diferentes condiciones de luz."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nombre del perfil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Resumen"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Perfil creado correctamente."
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copiar perfil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Requiere un medio escribible"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Puede encontrar instrucciones útiles sobre cómo usar el perfil en sistemas "
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> y <a href="
+"\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Añadir perfil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Se han encontrado problemas. El perfil puede no funciona correctamente. <a "
+"href=\"\">Mostrar detalles.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importar archivo…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Añadir"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Cada dispositivo necesita un perfil de color actualizado para poder "
+"gestionar el color."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Aprender más"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Aprenda más acerca de la gestión de color"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Establecer para todos los usuarios"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Establecer este perfil para todos los usuarios de este equipo"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Activar"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Añadir perfil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibrar…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibrar el dispositivo"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Quitar perfil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Ver detalles"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "No se han detectado dispositivos que se puedan gestionar por color"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Proyector"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL retroiluminado)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED retroiluminado)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (LED blanco retroiluminado)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Gama LCD amplio (CCFL retroiluminado)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Gama LCD amplio (RGB LED retroiluminado)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alta"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutos"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Media"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Baja"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Nativo de la pantalla"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Impresiones y publicaciones)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografía y gráficos)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Espacio estándar"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Perfil de prueba"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automático"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Calidad baja"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Calidad media"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Calidad alta"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB predeterminado"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK predeterminado"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Gris predeterminado"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Datos de calibración de fábrica proporcionados por el vendedor"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+"La corrección de la pantalla en modo a pantalla completa no es posible con "
+"este perfil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Este perfil ya no es preciso."
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Color"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibrar el color de sus dispositivos, como pantallas, cámaras o impresoras"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Perfil;Calibrado;Impresora;Pantalla;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Otro…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Seleccionar idioma"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Seleccionar"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "No se han encontrado idiomas"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Más…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Desbloquear para cambiar la configuración"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Algunos ajustes se deben desbloquear antes de poder cambiarlos."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Desbloquear…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Incrementar hora"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Incrementar minuto"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Hora"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Reducir hora"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Reducir minuto"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Hoy"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Ayer"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e de %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hora"
+msgstr[1] "%d horas"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuto"
+msgstr[1] "%d minutos"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d segundo"
+msgstr[1] "%d segundos"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 seconds"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 horas"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%d/%b/%Y, %I:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%d/%b/%Y, %H:%M"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%H:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Fecha y hora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Año"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mes"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "enero"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "febrero"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "marzo"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "abril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mayo"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "junio"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "julio"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "agosto"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "septiembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "octubre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "noviembre"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "diciembre"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Día"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Zona horaria"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Buscar una ciudad"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Fecha y _hora automáticas"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Requiere conexión a Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Fecha y _hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "_Zona horaria automática"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Requiere activar los servicios de ubicación y el acceso a Internet"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Activada"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Z_ona horaria"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Formato de _fecha"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Cambiar la fecha y la hora, incluyendo la zona horaria"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Reloj;Zona horaria;Ubicación;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Cambiar la configuración de la hora y la fecha del sistema"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Para cambiar la configuración de la fecha o de la hora, debe autenticarse."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "Co_rreo"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendario"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Música"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Vídeo"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicaciones predeterminadas"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configurar aplicaciones predeterminadas"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "predeterminado;aplicación;preferida;medios;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Enviar informes de problemas técnicos ayuda a mejorar %s. Los informes se "
+"envían anónimamente y no contienen datos personales. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Informar de un error"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Informar de un problema _automáticamente"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnósticos"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Informar de problemas"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnósticos;fallo;error;crash;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Encendido"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Apagado"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "¿Aplicar los cambios?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "No se pueden aplicar los cambios"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Esto puede deber a limitaciones hardware."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Aplicar"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Atrás"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Configuración de pantalla desactivada"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Varias pantalla"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Unir"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Espejo"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Contiene la barra superior y de Actividades"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Pantalla primaria"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Luz nocturna"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Horizontal"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Vertical derecha"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Vertical izquierda"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Horizontal (dada la vuelta)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientación"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolución"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Tasa de refresco"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Ajustes para TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Escala"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Luz nocturna no disponible"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Esto puede ser el resultado de que se esté usando el controlado de la "
+"tardeta gráfica o de que se esté usando el escritorio en remoto"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Desactivado temporalmente hasta mañana"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Reiniciar filtro"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"La luz nocturna hace que los colores de la pantalla sean más cálidos. Esto "
+"puede ayudar a prevenir la fatiga visual y el insomnio."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Programar"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Desde la puesta de sol hasta el amanecer"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Programación manual"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Horas"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "De"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hora"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuto"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Hasta"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura del color"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Pantallas"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Elegir cómo usar las pantallas y los proyectores conectados"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Proyector;xranrd;Pantalla;Resolución;Actualizar;Monitor;Noche;Luz;Azul;"
+"color;amanecer;atardecer;ocaso;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Secure Boot está activado"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"El arranque seguro evita que se cargue software malicioso cuando se inicia "
+"el dispositivo. Actualmente está activo y funcionando correctamente."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "El arranque seguro tiene problemas"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"El arranque seguro evita que se cargue software malicioso cuando se inicia "
+"el dispositivo. Actualmente está activo pero no funcionará debido a que "
+"tiene una clave no válida."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Los problemas del arranque seguro se pueden resolver a menudo desde la "
+"configuración del firmware UEFI del equipo (BIOS) y su fabricante puede "
+"proporcionar información sobre cómo hacerlo."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Para obtener ayuda contacte con el fabricante del hardware o su proveedor de "
+"TI."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "El arranque seguro está apagado"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"El arranque seguro evita que se cargue software malicioso cuando se inicia "
+"el dispositivo. Actualmente está apagado."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"El arranque seguro se puede activar desde la configuración del firmware UEFI "
+"del equipo (BIOS). Para obtener ayuda contacte con el fabricante del "
+"hardware o su proveedor de TI."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"El arranque seguro evita que se cargue software malicioso cuando se inicia "
+"el dispositivo.\n"
+"\n"
+"Para obtener más información contacte con el fabricante del hardware o su "
+"proveedor de TI."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Correcta"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Falló"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "El dispositivo cumple con el nivel %d de HSI"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Nivel de seguridad 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Este dispositivo no tiene protección contra problemas de seguridad de "
+"hardware. Esto podría deberse a un problema de configuración de hardware o "
+"firmware. Se recomienda ponerse en contacto con su proveedor de soporte de "
+"TI."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Nivel de seguridad 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Este dispositivo tiene una protección mínima contra problemas de seguridad "
+"de hardware. Este es el nivel de seguridad más bajo del dispositivo y solo "
+"brinda protección contra amenazas de seguridad simples."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Nivel de seguridad 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Este dispositivo tiene protección básica contra problemas de seguridad de "
+"hardware. Esto proporciona protección contra algunas amenazas de seguridad "
+"comunes."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Nivel de seguridad 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Este dispositivo tiene protección extendida contra problemas de seguridad de "
+"hardware. Este es el nivel más alto de seguridad del dispositivo y brinda "
+"protección contra amenazas de seguridad avanzadas."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Nivel de seguridad"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Los niveles de seguridad no están disponibles para este dispositivo."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Contacte con el fabricante del hardware para solicitar ayuda sobre las "
+"actualizaciones de seguridad."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Es posible resolver este problema en la configuración del firmware UEFI del "
+"dispositivo o con un soporte técnico."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Es posible resolver este problema en la configuración del firmware UEFI del "
+"dispositivo."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Es posible resolver este problema con un soporte técnico."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nivel 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nivel 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nivel 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Protegido frente a software malicioso cuando se inicia el dispositivo."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Secure Boot tiene problemas"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Alguna protección cuando se inicia el dispositivo."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "El arranque seguro está apagado"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Sin protección cuando se inicia el dispositivo."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Este problema puede haberlo causado un cambio en la configuración del "
+"firmware UEFI, en el sistema operativo o deberse a software malicioso en el "
+"sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Este problema puede haberlo causado un cambio en la configuración del "
+"firmware UEFI o deberse a software malicioso en el sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Este problema puede haberlo causado un cambio en el sistema operativo o "
+"deberse a software malicioso en el sistema."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Expuesto a amenazas de seguridad serias."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Protección limitada frente a amenazas de seguridad sencillas."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Protegido contra amenazas de seguridad habituales."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Protegido contra una amplia variedad de amenazas de seguridad."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Protección integral"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "No hay eventos"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Protección de escritura del firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Bloqueo de protección de escritura del firmware"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Región del firmware de la BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Descriptor del firmware de la BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Protección de pre-arranque DMA"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Arranque verificado por Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "ACM protegido por Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Error de política de Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Fusible Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET activado"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET activado"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "RAM cifrada"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Protección IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Bloqueo del núcleo Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Verificación del núcleo Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Intercambio de Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Suspender a RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Suspender a inactividad"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Clave de la plataforma UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Arranque seguro UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Configuración de la plataforma TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Reconstrucción de TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Modo de fabricación del motor Intel Management"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Omitir motor Intel Management"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Versión del motor de Intel Management"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Actualizaciones de firmware"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Comprobación de firmware"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Verificación del actualizador de firmware"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Depurado de la plataforma"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Comprobaciones de seguridad del procesador"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Protección de marcha atrás de AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Protección de reproducción de firmware de AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Protección de escritura de firmware de AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Plataforma fusionada"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Válido"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "No válido"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "No activada"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Bloqueada"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "No bloqueada"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Cifrado"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "No cifrado"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Envenenado"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "No envenenado"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Encontrada"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "No encontrada"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Soportada"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "No soportada"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Seguridad del dispositivo"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Estado de la seguridad del firmware del equipo"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"pantalla;bloqueo;diagnóstico;error;privado;reciente;temporal;tmp;índice;"
+"nombre;red;identidad;privacidad;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Desconocido"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64 bits"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32 bits"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Desconocido"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "No disponible"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo del sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nombre del dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Modelo de hardware"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memoria"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesador"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Gráficos"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacidad del disco"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calculando…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nombre del SO"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID de construcción de SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tipo de SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Versión de GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Cargando…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Sistema de ventanas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualización"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Actualizaciones de software"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "renombrar un dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"El nombre del dispositivo se usa para identificarlo cuando se ve en la red o "
+"al emparejar dispositivos Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nombre del dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Renombrar"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Acerca de"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Ver información sobre su sistema"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;información;equipo;memoria;procesador;versión;"
+"predeterminado;aplicación;preferido;cd;dvd;usb;sonido;vídeo;disco;extraíble;"
+"medio;autoejecutar;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Sonido y medios"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Silenciar o no el volumen"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Bajar volumen"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Subir volumen"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Silenciar o no el micrófono"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Lanzar el reproductor multimedia"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Reproducir (o reproducir/pausar)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pausar la reproducción"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Detener la reproducción"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Pista anterior"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Siguiente pista"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Expulsar"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Escritura"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Cambiar a la siguiente fuente de entrada"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Cambiar a la fuente de entrada anterior"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lanzadores"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Lanzar el visor de ayuda"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Lanzar la calculadora"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Lanzar el cliente de correo-e"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Lanzar navegador web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Carpeta personal"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Buscar"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Cerrar la sesión"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Bloquear la pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accesibilidad"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Activar o desactivar la ampliación"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Ampliar"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Reducir"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Activar o desactivar el lector de pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Activar o desactivar el teclado en pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Aumentar el tamaño del texto:"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Reducir el tamaño del texto:"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Contraste alto activado o desactivado"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "No se han encontrado fuentes de entrada"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Otra"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Añadir una fuente de entrada"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+"Los métodos de entrada no se pueden usar en la pantalla de inicio de sesión"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "No se ha seleccionado ninguna fuente de entrada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opciones"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Subir"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Bajar"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Ver la distribución de teclado"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Quitar"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Atajo personalizado"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de caracteres alternativos"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"La tecla de caracteres alternativos se puede usar para introducir caracteres "
+"adicionales. A veces se muestran como una tercera opción en el teclado."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt izquierdo"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt derecha"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Súper izquierdo"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Súper derecho"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tecla de menú"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl derecho"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composición"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"La tecla de composición le permite escribir una amplia variedad de "
+"caracteres. Para usarla pulse esa tecla y una secuencia de caracteres. Por "
+"ejemplo, la tecla de composición seguida de <b>C</b> y <b>o</b> escribirá "
+"<b>©</b>, <b>a</b> seguida <b>'</b> escribirá <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Bloq. Mayús."
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Bloq. Despl."
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Impr. Pant."
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Las fuentes de entrada se puede cambiar usando el atajo del teclado %s.\n"
+"Puede cambiar este atajo en la configuración del teclado"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Fuente de entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Incluye distribuciones del teclado y métodos de entrada."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Cambiar fuentes de entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Usar la _misma fuente para todas las ventanas"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Cambiar entre fuentes de entrada _individualmente para cada ventana"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Entrada de caracteres especiales"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Métodos para introducir símbolos y variantes de letras usando el teclado."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Atajos del teclado"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Ver y personalizar atajos"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificado"
+msgstr[1] "%d modificados"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "¿Restablecer todos los atajos?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Restablecer todos los atajos puede afectar a sus atajos personalizados. Esto "
+"no se puede deshacer."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Restablecer todo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Restablecer todo…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Restablecer todos los atajos a sus valores predeterminados"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sección"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Atajos"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Añadir un atajo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Añadir atajos personalizados"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Establecer atajos personalizados para lanzar aplicaciones, ejecutar scripts, "
+"etc."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Añadir atajo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "No se ha encontrado un atajo del teclado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s ya está en uso por %s. Si lo reemplaza, %s se desactivará"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Introduzca el atajo nuevo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Establecer atajo personalizado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Establecer atajo"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Introduzca el nuevo atajo para cambiar %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Añadir un atajo personalizado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Quitar"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Reem_plazar"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Establecer"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Pulse Esc para cancelar o Retroceso para desactivar el atajo del teclado."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nombre"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Comando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Atajo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Establecer atajo…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ninguna"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Restablecer el valor predeterminado del atajo"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Teclado"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Cambiar los atajos del teclado y establecer sus preferencias de escritura, "
+"teclado y fuentes de entrada"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"atajo;área;trabajo;ventana:redimensionar;ampliación;contraste;fuente;entrada;"
+"bloqueo;volumen;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Servicios de ubicación apagados"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Ninguna aplicación puede obtener información sobre la ubicación."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Los servicios de ubicación permiten a las aplicaciones conocer su ubicación. "
+"Usando las redes inalámbrica y de banda ancha se aumenta la precisión.\n"
+"\n"
+"Usa el servicio de ubicación de Mozilla: <a href='https://location.services."
+"mozilla.com/privacy'>Política de privacidad</a>\n"
+"\n"
+"Permita a las siguientes aplicaciones determinar su ubicación."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Ninguna aplicación ha solicitado acceso a su ubicación"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Proteger la información sobre su ubicación"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "ubicación;gps;privado;privacidad;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Micrófono está apagado"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Ninguna aplicación puede grabar sonidos."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"El uso del micrófono permite a las aplicaciones capturar y escuchar sonidos. "
+"Desactivarlo puede hacer que algunas aplicaciones no funcionen "
+"correctamente.\n"
+"\n"
+"Permita a las siguientes aplicaciones usar su micrófono."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Ninguna aplicación ha solicitado acceso al micrófono"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Proteger sus conversaciones"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "micrófono;grabación;privado;privacidad;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Probar su configuración"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "General"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Botón primario"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+"Establece el orden de los botones físicos en ratones y paneles táctiles."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Izquierda"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Derecha"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Ratón"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Velocidad del ratón"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Desplazamiento natural"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "El desplazamiento mueve la vista, no el contenido."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Panel táctil"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Velocidad del panel táctil"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Tocar para pulsar"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Tocar para pulsar"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Desplazamiento con dos dedos"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Desplazamiento en el borde"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+"Pruebe a pulsar una vez, dos veces o a desplazarse con la rueda del ratón"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinco pulsaciones, es tiempo de GEGL."
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Doble pulsación, botón primario"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Una sola pulsación, botón primario"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Doble pulsación, botón central"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Una sola pulsación, botón central"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Doble pulsación, botón secundario"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Una sola pulsación, botón secundario"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Ratón y panel táctil"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Cambiar la sensibilidad de su ratón o su panel táctil y configurarlos para "
+"zurdos o diestros"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"trackpad;puntero;pulsar;pulsación;doble;botón;trackball;desplazamiento;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Esquina activa"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Toque la esquina superior izquierda para abrir la vista de Actividades"
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Activar bordes de la pantalla"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Arrastre ventanas a los bordes superior, izquierdo y derecho para "
+"redimensionarlas."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Áreas de trabajo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "Áreas de trabajo _dinámicas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Quita las áreas de trabajo vacías automáticamente"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "Número _fijo de áreas de trabajo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Especifique un número de áreas de trabajo permanentes."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Número de áreas de trabajo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multi-pantalla"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Áreas de trabajo sólo en la pantalla _primaria"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Áreas de trabajo en todas las pa_ntallas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Cambio de aplicaciones"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Incluir aplicaciones de todas las áreas de trabajo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Incluir aplicaciones sólo del área de trabajo a_ctual"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitarea"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Gestionar las preferencias para productividad y multitarea"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"multitarea;productividad;personalizar;escritorio;esquina activa;áreas de "
+"trabajo;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Algo ha fallado. Contacte con el fabricante del software."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager debe estar en ejecución."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Otros dispositivos"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Añadir conexión"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "No configurada"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Red insegura (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Red segura (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Red segura (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Red segura (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Red segura"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Conectado"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opciones…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Activar el punto de acceso hará que se desconecte de %s y no será posible "
+"acceder a Internet mediante Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Debe tener un mínimo de 8 caracteres"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Debe tener un máximo de %d carácter"
+msgstr[1] "Debe tener un máximo de %d caracteres"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "¿Activar el punto de acceso inalámbrico?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Un punto de acceso inalámbrico le permite compartir su conexión a Internet "
+"con otros creando una red inalámbrica a la que pueden conectarse. Para hacer "
+"esto debe tener una conexión a Internet por otro medio que no sea la "
+"conexión inalámbrica."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nombre de red"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Contraseña"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Generar una contraseña aleatoria"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Generar una contraseña automáticamente"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Activar"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Inalámbrica"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "¿Detener el «hotspot» y desconectar a los usuarios?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Detener «hotspot»"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Modo avión"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Desactiva la red inalámbrica, el Bluetooth y la red de banda ancha"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "No se han encontrado ningún adaptador inalámbrico"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Asegúrese de que tiene un adaptador inalámbrico conectado y activado"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Modo avión activado"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Apagar para usar la Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Punto de acceso Wi-Fi activo"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Los dispositivos móviles pueden leer el código QR para conectarse."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Apagar el punto de acceso inalámbrico…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Redes visibles"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager debe estar en ejecución"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Seguridad 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguridad"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Mantener"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanente"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Aleatorio"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Estable"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"La dirección MAC introducida aquí se usará como dirección hardware para el "
+"dispositivo de red en el que se active esta conexión. Esto se conoce como "
+"clonado de MAC o «spoofing». Ejemplo: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Perfil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Empresa"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ninguna"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "hace %i día"
+msgstr[1] "hace %i días"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Ninguna"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Débil"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Aceptar"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Buena"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excelente"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Dirección IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Dirección IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Dirección IP"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Olvidar conexión"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Eliminar perfil de conexión"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Quitar VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Detalles"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automático"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identidad"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Eliminar dirección"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Eliminar ruta"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ninguna"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Clave WEP 40/128-bit (Hexadecimal o ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Frase de paso WEP de 128 bits"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinámica (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA y WPA2 personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA y WPA2 enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Fortaleza de la señal"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Velocidad de conexión"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Dirección física"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Frecuencias soportadas"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Ruta predeterminada"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Usada por última vez"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Conectar _automáticamente"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Hacer disponible para _otros usuarios"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "Conexión _medida: tiene límite de datos o puede incurrir en cargos"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Las actualizaciones de software y otras descargas grandes no se iniciarán "
+"automáticamente."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nombre"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Dirección _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Dirección _clonada"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Método IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automático (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Sólo enlace local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Desactivar"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Compartida con otros equipos"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Direcciones"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Dirección"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Máscara de red"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Puerta de enlace"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automático"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automático"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Direcciones de servidores DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Direcciones IP separadas por comas"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rutas"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Rutas automáticas"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Métrica"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Usar esta c_onexión sólo para los recursos en su red"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Método IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automático, DHCP únicamente"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefijo"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "No se pudo abrir el editor de conexiones"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Perfil nuevo"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Ajuste %s no válido: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Ajuste no válido %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importar desde un archivo…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Añadir VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_eguridad"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "No se puede importar la conexión VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"No se pudo leer el archivo «%s» o no contiene información de una conexión "
+"VPN que se pueda reconocer\n"
+"\n"
+"Error: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Seleccione el archivo que importar"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Ya existe un archivo llamado «%s»."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Reemplazar"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "¿Quiere reemplazar %s con la conexión VP que está guardando?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "No se puede exportar la conexión VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exportar conexión VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Error: no se pudo cargar el editor de conexiones VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Controlar cómo se conecta a Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Red;IP;LAN;Proxy;WAN;Banda;ancha;Módem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controlar cómo se conecta a redes inalámbricas"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Red;Inalámbrica;Wireless;Wi-Fi;Wifi;IP;LAN;Banda;ancha;DNS;punto;acceso;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nunca"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "hoy"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "ayer"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Usada última vez"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Cableada"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Añadir una conexión nueva"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Se perderán los detalles de las redes seleccionadas, incluyendo la "
+"contraseña y cualquier configuración personalizada."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Olvidar"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Redes inalámbricas conocidas"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Olvidar"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "La política del sistema prohíbe usarlo como punto de acceso"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "El dispositivo inalámbrico no soporta el modo de punto de acceso"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Se usa el autodiscubrimiento del proxy web cuando no se proporciona un URL "
+"de configuración."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "No se recomienda para redes públicas en las que no se confía."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Apagar dispositivo"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Activar"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Proveedor"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy de la red"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy para _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy para H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy para _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Servidor socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorar anfitriones"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Puerto para proxy HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Puerto para proxy HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Puerto para proxy FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Puerto para proxy Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuración"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Cerrar la conexión VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nombre de la red"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tipo de seguridad"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Contraseña"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Apagar la Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Más opciones…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "Conectar a una red oculta…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Activar el punto de acceso inalámbrico…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Redes inalámbricas _conocidas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Estado desconocido"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Sin gestionar"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "No disponible"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Conectando"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Se necesita autenticación"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Desconectando"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Falló la conexión"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Estado desconocido (ausente)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Falló la configuración"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Falló la configuración IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "La configuración IP ha expirado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Se necesitan secretos, pero no se han proporcionado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Suplicante de 802.1x desconectado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Falló la configuración del suplicante de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Falló el suplicante de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "El suplicante de 802.1x tardó mucho tiempo en autenticarse"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Falló al iniciar el servicio de PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Servicio PPP desconectado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP falló"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Falló al iniciar el cliente de DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Error del cliente de DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Falló el cliente de DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Falló al iniciar el servicio de conexión compartida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Falló el servicio de conexión compartida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Falló al iniciar el servicio de AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Error del servicio de AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Falló el servicio AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Línea ocupada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "No hay tono de llamada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "No se pudo establecer el portador"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Expiró el tiempo de solicitud de llamada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Intento de llamada fallido"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Falló la inicialización del módem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Falló al seleccionar el NPA especificado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "No se están buscando redes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Registro de la red denegado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Expiró el tiempo de registro de la red"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Falló al registrarse con la red solicitada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Falló la comprobación de l PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Es posible que falte el firmware del dispositivo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "La conexión ha desaparecido"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Se asumió una conexión existente"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Módem no encontrado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Falló la conexión Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Tarjeta SIM no insertada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Se necesita el PIN de la SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Se necesita el PUK de la SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM errónea"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Falló la dependencia de la conexión"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "falta el «firmware»"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Cable desconectado"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "error no definido en la seguridad 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "no se ha seleccionado ningún archivo"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "error no especificado al validar el archivo del método eap"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12, o claves privadas PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certificados DER o PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "falta el archivo PAC de EAP-FAST"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Archivos PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anónimo"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autenticado"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ambos"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identidad anóni_ma"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "Archivo _PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Elegir un archivo PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autenticación i_nterna"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Permitir pro_visión PAC automática"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "falta el nombre de usuario de EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "falta la contraseña de EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nombre de _usuario"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Contraseña"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Mostrar la contraseña"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "CA del certificado EAP-PEAP no válida: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+"CA del certificado EAP-PEAP no válida: no se ha especificado el certificado"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versión 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versión 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificado C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Elija un certificado CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "No se necesita la CA del ce_rtificado"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "Versión _PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "falta el nombre de usuario de EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "falta la contraseña EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "falta la identidad EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "CA del certificado EAP-TLS no válida: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+"CA del certificado EAP-TLS no válida: no se ha especificado el certificado"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "clave privada EAP-TLS no válida: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "usuario del certificado EAP-TLS no válido: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Las claves privadas sin cifrar son inseguras"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"La clave privada seleccionada no parece estar protegida por una contraseña. "
+"Esto podría permitir que sus credenciales de seguridad se comprometiesen. "
+"Seleccione una clave privada protegida por contraseña.\n"
+"\n"
+"(Puede proteger su clave privada con una contraseña con openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Elija su certificado personal"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Elija su clave privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentidad"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificado del _usuario"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Clave pri_vada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Contraseña de clave pri_vada"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "CA del certificado EAP-TTLS no válida: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+"CA del certificado EAP-TTLS no válida: no se ha especificado el certificado"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Dominio"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Error desconocido al validar la seguridad 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS a través de túnel"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP protegido (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Autenticación"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Seleccione un archivo"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "falta el nombre de usuario leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "falta la contraseña leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Falta la contraseña de la red inalámbrica."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipo"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "falta la clave wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"clave wep no válida: una clave de longitud %zu sólo puede contener dígitos "
+"hexadecimales"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"clave wep no válida: una clave de longitud %zu sólo debe contener caracteres "
+"ASCII"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"clave wep no válida: longitud de clave %zu incorrecta. La clave debe ser de "
+"5/13 (ascii) o 10/26 (hexadecimal)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "clave wep no válida: la frase de paso no puede estar vacía"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"clave wep no válida: la frase de paso debe ser inferior a 64 caracteres"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (predeterminado)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistema abierto"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Clave compartida"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Clave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Mostrar la clave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Ín_dice WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"clave wpa-psk no válida: longitud %zu de la clave no válida. Debe ser de "
+"[8,63] bytes o 64 dígitos hexadecimales"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"clave wpa-psk no válida: no se puede interpretar una clave de 64 bytes como "
+"hexadecimal"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificaciones"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alertas sonoras"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Notificaciones emergentes"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Las notificaciones seguirán apareciendo en la lista de notificaciones cuando "
+"las ventanas emergentes estén desactivadas."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Mostrar el _contenido del mensaje en las ventanas emergentes"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notificaciones de la pantalla de _bloqueo"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Mostrar el c_ontenido del mensaje en la pantalla de bloqueo"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_No molestar"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Notificaciones de la pantalla de bloqueo"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controlar qué notificaciones se muestran"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "notificaciones;banner;mensaje;bandeja;emergente;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Otra"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s eliminado"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Error al quitar la cuenta"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Deshacer"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Cerrar la notificación"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Conectarse a sus datos en la nube"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"No hay conexión a Internet; conéctese para configurar nuevas cuentas en línea"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Añadir una cuenta"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Cuenta de %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Quitar cuenta"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Cuentas en línea"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Conectarse a sus cuentas en línea y decidir para qué usarlas"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;en línea;Chat;Calendario;Correo-e;Contacto;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Tiempo desconocido"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuto"
+msgstr[1] "%i minutos"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hora"
+msgstr[1] "%i horas"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hora"
+msgstr[1] "horas"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuto"
+msgstr[1] "minutos"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s hasta que se cargue del todo"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Advertencia: quedan %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s restante"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Cargada completamente"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "No está cargando"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Vacía"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Cargando"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Descargando"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Ratón inalámbrico"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Teclado inalámbrico"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Fuente de alimentación no interrumplible"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Asistente digital personal"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Teléfono móvil"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Reproductor multimedia"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tableta"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Equipo"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Mando de juegos"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batería"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principal"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Adicional"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Baterías"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Cuando esté _inactivo"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Suspender"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Apagar"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernar"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nada"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "En modo batería"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Cuando está conectado a la red"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Suspender automáticamente"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Modo rendimiento desactivado temporalmente debido a la alta temperatura de "
+"operación."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Portátil detectado: modo rendimiento desactivado temporalmente. Mueva el "
+"dispositivo a una superficie estable para restaurarlo."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Modo de rendimiento desactivado temporalmente."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Batería baja: ahorro de energía activado. El modo anterior se restaurará "
+"cuando la batería esté suficientemente cargada."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Modo de ahorro de energía activado por «%s»."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Modo de rendimiento activado por «%s»."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 horas"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Modo de energía"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Afecta al rendimiento del sistema y el uso de energía."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opciones de ahorro de energía"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Brillo de pantalla automático"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "El brillo de la pantalla se ajusta a la luz ambiental."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Oscurecer la pantalla"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Reduce el brillo de la pantalla cuando el equipo no está activo."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Apagar la pantalla"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Apaga la pantalla después de un período de inactividad."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Ahorro de energía automático"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Activa el modo de ahorro de energía cuando la batería está baja."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "Suspender _automáticamente"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pausa el equipo después de un período de inactividad."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Comportamiento del botón de _encendido"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Mostrar _porcentaje de la batería"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Suspender automáticamente"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Enchufado"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Usando _batería"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Retardo"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Rendimiento"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Alto rendimiento y uso de energía"
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Balanceado"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Rendimiento estándar y uso de energía."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Ahorro de energía"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Reduce el rendimiento y el uso de energía."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energía"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Ver el estado de la batería y cambiar la configuración de ahorro de energía"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Energía;Dormir;Suspender;Hibernar;Batería;Brillo;Apagar;Monitor;DPMS;"
+"inactivo;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Se ha eliminado la impresora «%s»"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Falló al añadir una impresora nueva."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "No se pudo cargar la IU: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Desbloquear para añadir impresoras y cambiar la configuración"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Impresoras"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Añadir impresoras, ver los trabajos de la impresora y decidir cuál quiere "
+"imprimir"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Impresora;Cola;Imprimir;Papel;Tinta;Tóner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Añadir impresora"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "Desbloq_uear"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "No se han encontrado impresoras"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Introduzca una dirección de red o busque una impresora"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Se requiere autenticación"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Introduzca su nombre de usuario y su contraseña para ver las impresoras "
+"disponibles en el servidor de impresión."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nombre de usuario"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Detalles de %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "No se ha encontrado ningún controlador adecuado"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Seleccionar archivo PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Archivos de descripción de impresora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
+"PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+"Los nombres de las impresoras no pueden contener espacios, tabuladores, # o /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Ubicación"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Controlador"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Buscando controladores preferidos…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Buscar controladores"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Seleccionar de la base de datos…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instalar archivo PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Seleccionar el controlador de la impresora"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Cargando base de datos de controladores…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Seleccionar"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Impresora JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Impresora LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Una cara"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Margen largo (estándar)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Margen corto (girar)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Vertical"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Apaisado"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Apaisado invertido"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Vertical invertido"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Reanudar"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pausar"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Pendiente"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pausado"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autenticación requerida"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Procesando"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Detenido"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Cancelado"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Abortado"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Completado"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Mover este trabajo al principio de la cola"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u trabajo requiere autenticación"
+msgstr[1] "%u trabajos requieren autenticación"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - trabajos activos"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Introduzca las credenciales para imprimir desde %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Dominio"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utenticar"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Limpiar todos"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autenticar"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "No hay trabajos de impresión activos"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Desbloquear servidor de impresión"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Desbloquear %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Introduzca su nombre de usuario y su contraseña para ver las impresoras en "
+"%s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Buscando impresoras"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Puerto serie"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Puerto paralelo"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Ubicación: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Dirección: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "El servidor requiere autenticación"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dos caras"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tipo de papel"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Fuente de papel"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Bandeja de salida"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolución"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Prefiltrado GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Páginas por cara"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dos caras"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientación"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "General"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Configuración de página"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opciones instalables"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Trabajo"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Calidad de la imagen"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Color"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Terminando"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avanzado"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Página de prueba"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Página de prueba"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Seleccionar automáticamente"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Impresora predeterminada"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Sólo empotrar tipografías GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Convertir a PS nivel 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Convertir a PS nivel 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Sin prefiltrado"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricante"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "No hay trabajos activos"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u trabajo"
+msgstr[1] "%u trabajos"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Limpiar cabezales de la impresora"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Tóner bajo"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Sin tóner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Nivel de revelador bajo"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Sin revelador"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Marcador bajo"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Sin marcador"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Abrir cubierta"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Abrir puerta"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Nivel de papel bajo"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Sin papel"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Desconectada"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Detenida"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Recipiente de residuos casi lleno"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Receptáculo de residuos lleno"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "El conductor óptico está cerca del final de su vida"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "El conductor óptico ya no funciona"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Preparada"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "No aceptar trabajos"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Procesando"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Opciones de impresión"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Detalles de la impresora"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Impresora de usuario predeterminada"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Limpiar cabezales de impresión"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Quitar impresora"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modelo"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nivel de tinta"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Reinicie cuando se haya resuelto el problema."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Reiniciar"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Añadir impresora…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "No hay impresoras"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"El servicio del sistema de impresión\n"
+"    parece no estar disponible."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Buscar configuraciones regionales…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Formatos comunes"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Todos los formatos"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "No se han encontrado resultados"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Se pueden hacer búsquedas de países o idiomas."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Vista previa"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Métrico"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Fechas"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Fecha y hora"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Números"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Medida"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papel"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "El idioma y el formato se cambiarán tras el próximo inicio de sesión"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Cerrar sesión…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"La configuración del idioma se usa para el texto de la interfaz y las "
+"páginas web. Los formatos se usan para números, fechas y monedas."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Su cuenta"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Idioma"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formatos"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Pantalla de inicio de sesión"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Región e idioma"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Seleccionar el idioma que mostrar y los formatos"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Idioma;Distribución;Teclado;Entrada;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Preguntar qué hacer"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "No hacer nada"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Abrir carpeta"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Otros soportes"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Seleccionar una aplicación para CD de sonido"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Seleccionar una aplicación para DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Seleccionar una aplicación que ejecutar cuando se conecta un reproductor de "
+"música"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Seleccionar una aplicación que ejecutar cuando se conecta una cámara"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Seleccionar una aplicación para CD de software"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD de sonido"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "disco Blu-ray virgen"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "CD virgen"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "DVD virgen"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "disco HD DVD virgen"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Disco Blu-ray de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "lector de libros electrónicos"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Disco HD DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "CD de imágenes"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Software de Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Seleccionar cómo se deben manejar los soportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD de _sonido"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Reproductor de _música"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "Soft_ware"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Otros soportes…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nunca preguntar ni iniciar programas al introducir soportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Seleccionar cómo se deben manejar otros soportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Acción:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipo:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Soportes extraíbles"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configurar soportes extraíbles"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;predeterminado;aplicación;preferido;cd;dvd;usb;sonido;"
+"vídeo;disco;extraíble;medio;autoejecutar;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Se apaga la pantalla"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 segundos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Bloqueo de pantalla"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Bloquear la pantalla automáticamente evita que otros puedan acceder al "
+"equipo cuando no está delante."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Retardo para apagar la pantalla"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Período de inactividad después del que se apagará la pantalla."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Bloque de pantalla automático"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Retardo para _bloquear la pantalla automáticamente"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Período después de apagar la pantalla para bloquearla automáticamente."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Mostrar _notificaciones en la pantalla de bloqueo"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Prohibir usar nuevos dispositivos _USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Evitar que los nuevos dispositivos USB interactúen con el sistema cuando la "
+"pantalla está bloqueada."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Privacidad de la pantalla"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Restringir el ángulo de visión"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Configuración de la pantalla"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "pantalla;bloqueo;privado;privacidad;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Seleccionar ubicación"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Aceptar"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Buscar ubicaciones"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Carpetas en las que buscan las aplicaciones del sistema, como Archivos, "
+"Fotos y Vídeos."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Lugares"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Otras"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Añadir ubicación"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "No se han encontrado aplicaciones"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Búsqueda de aplicaciones"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Incluir resultados de búsqueda proporcionados por las aplicaciones."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Carpetas en las que buscan las aplicaciones del sistema."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Resultados de la búsqueda"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Los resultados se muestran siguiendo el orden de la lista."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controlar qué aplicaciones muestran resultados de búsqueda en la vista de "
+"actividades"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "buscar;búsqueda;índice;ocultar;privacidad;resultados;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "No se han seleccionado redes para compartir"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Redes"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Encendido"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Apagado"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Activado"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Activo"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Elija una carpeta"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Añadir"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Activar la compartición multimedia"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Compartir archivos personales le permite compartir su carpeta «Público» con "
+"otros en su red actual usando: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Cuando el inicio de sesión remoto está activado, los usuarios remotos pueden "
+"conectarse usando el comando de shell segura:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Activar la compartición de archivos personales"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Nombre del dispositivo copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Dirección del dispositivo copiada"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Nombre de usuario copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Contraseña copiada"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Compartir"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Nombre del _equipo"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Compartición de _archivos"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Escritorio _remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Compartición _multimedia"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Inicio de sesión _remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Compartición de archivos"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Solicitar contraseña"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Inicio de sesión remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Escritorio remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"El escritor remoto permite ver y controlar su escritorio desde otro equipo."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Activar o desactivar las conexiones de escritorio remoto para este equipo."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Control remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Permitir conexiones para controlar la pantalla"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Cómo conectarse"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Conectarse a este equipo usando el nombre del dispositivo o la dirección del "
+"escritorio remoto."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copiar"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Dirección del escritorio remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autenticación"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"El nombre de usuario y la contraseña requeridos para conectarse a este "
+"equipo."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nombre de usuario"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Verificar cifrado"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Cifrado de huella dactilar"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"El cifrado de huella dactilar se puede ver en los clientes que se conectan y "
+"debe ser idéntica."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Compartición multimedia"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Compartir música, fotos y vídeos mediante la red."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Carpetas"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controla qué quiere compartir con otros"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"compartir;compartición;ssh;equipo;remoto;escritorio:bluetooth;obex;"
+"multimedia;sonido:vídeo;imágenes;fotos;películas;servidor;renderizador;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Activar o desactivar el inicio de sesión remota"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Se requiere autenticación para activar o desactivar el inicio de sesión "
+"remota"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Personalizado"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Click"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Cadena"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Swing"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Hum"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balance"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Desvanecer"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Trasero"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Frontal"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Probando %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Pulse para probar un altavoz"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volumen del sistema"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Volumen maestro"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Niveles de volumen"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Salida"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Dispositivo de salida"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Probar"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuración"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Entrada"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Dispositivo de entrada"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volumen"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Sonido de alerta"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Silenciar"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Sonido"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Cambiar el volumen de entrada y salida de sonido y las alertas sonoras"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"tarjeta;micrófono;volumen;desvanecer;balance;bluetooth;cascos;auriculares;"
+"sonido;entrada;salida;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Desconectado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Conectando"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Conectado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Error de autorización"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autorizando"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Funcionalidad reducida"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Conectado y autorizado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Desconocido"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autorizado a las:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Conectado a las:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Unido a las:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Falló al autorizar el dispositivo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Falló al olvidar el dispositivo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Depende de %u otro dispositivo"
+msgstr[1] "Depende de %u otros dispositivos"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Cerrar notificación"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nombre:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Estado:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autorizar y conectar"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Olvidar dispositivo"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Error"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorizado"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"El subsistema de Thunderbolt (boltd) no está instalado o no se ha "
+"configurado correctamente."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Permitir el acceso a dispositivos como soportes y GPU externas."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Sólo se pueden conectar dispositivos USB y Display Port"
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"No se pudo detectar Thunderbolt.\n"
+"El sistema carece de soporte para Thunderbolt, se ha desactivado en la BIOS "
+"o se ha configurado con un nivel de seguridad no soportado en la BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "El soporte de Thunderbolt se ha desactivado en la BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "No se puede determinar el nivel de seguridad de Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Error al cambiar al modo directo: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Sin soporte para Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "No se pudo conectar al subsistema thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Acceso directo"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Dispositivos pendientes"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "No hay dispositivos conectados"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Gestionar dispositivos Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacidad;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Parpadeo del cursor"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "El cursor parpadea en los campos de texto."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocidad"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Velocidad de parpadeo del cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Tamaño del cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"El tamaño del cursor se puede combinar con la ampliación para hacer que sea "
+"más fácil verlo."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Asistente de pulsación"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Pulsación secundaria _simulada"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+"Disparar una pulsación secundaria al mantener pulsado el botón primario"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "R_etardo de aceptación:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Corto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Retardo de la pulsación secundaria"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Largo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Pulsación al pasar por _encima"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Iniciar una pulsación al posicionar el puntero"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "R_etardo:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Corto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Largo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Umbral de _movimiento:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Pequeño"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetición de teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+"La pulsaciones de teclas se repiten cuando la tecla se mantiene pulsada."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Retardo de repetición de teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocidad de repetición de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Asistente de escritura"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Teclas persistente_s"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Trata una secuencia de teclas modificadoras como un atajo del teclado"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desactivar si se pulsan dos teclas a la vez"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pitar al pulsar una tecla _modificadora"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Teclas _lentas"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introduce un retardo al pulsar una tecla y cuando esta se acepta"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Corto"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Retardo de las teclas lentas al escribir"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Largo"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Pitar al pul_sar una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Pitar cuando la tecla se _acepte"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Pitar al _rechazar una tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Rechazo de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorar pulsaciones duplicadas rápidas"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Corto"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Retraso de pulsación del rechazo de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Largo"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Activar por teclado"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Activar las características de accesibilidad usando el teclado"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Predeterminado"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Mediano"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Más grande"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "El más grande"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d píxel"
+msgstr[1] "%d píxeles"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Mostrar siempre el menú de accesibilidad"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Visión"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Alto _contraste"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Texto grande"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Activar a_nimaciones"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Lecto_r de pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"El lector de pantalla lee el texto mostrado a medida que mueve el foco."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Teclas _sonoras"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pitar cuando se activen o desactiven las teclas Bloq Num o Bloq Mayús."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "T_amaño del cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Ampliación"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audición"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Alertas visuales"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Te_clado en pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Repetición de teclas"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Parpadeo del cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Asistente de escri_tura (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Apuntar y pulsar"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Teclas del _ratón"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Localizar puntero"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Asistente de pulsación"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Retardo de la _doble pulsación"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Retardo de la pulsación doble"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alertas visuales"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Probar destellos"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Usar una indicación visual cuando ocurra una alerta de sonido."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "De_stello de la pantalla completa"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "De_stello de la pantalla completa"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Corta"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ de pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ de pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Larga"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Pantalla completa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Mitad superior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Mitad inferior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Mitad izquierda"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Mitad derecha"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Opciones de ampliación"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Magnificación:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posición del magnificador:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Seguir el cursor del ratón"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Parte de la pantalla:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "El magnificador se _extiende fuera de la pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Mantener centrado el cursor del magnificador"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "El cursor del magnificador _empuja el contenido a su alrededor"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "El cursor del magnificador se mueve con el _contenido"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Magnificador"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Cruces:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Solapa el cursor del ratón"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Grosor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Fino"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Grueso"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Longitud:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Co_lor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Cruces"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efectos de color:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Blanco sobre negro:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Brillo:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contraste:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Co_lor"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ninguno"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Completo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Bajo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alto"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Bajo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alto"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efectos de color"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Hacer más sencillo de ver, escuchar, escribir y apuntar y pulsar"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Teclado;Ratón;a11y;Accesibilidad;Acceso universal;Contraste;Cursor;Sonido;"
+"Ampliación;Pantalla;Lector;grande;alto;texto;tipografía;AccesoX;persistentes;"
+"teclas;rechazo;ratón;doble;pulsación;retardo;velocidad;asistente;repetir;"
+"parpadeo;visual;audición;escritura;animaciones;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 día"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 días"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "¿Quiere vaciar todos los elementos de la papelera?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Todos los elementos de la papelera se eliminarán de manera permanente."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Vaciar papelera"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "¿Quiere eliminar todos los archivos temporales?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Todos los archivos temporales se eliminarán de manera permanente."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Limpiar archivos temporales"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 día"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 días"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 días"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Para siempre"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Histórico de archivos"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"El histórico de archivos mantiene un registro de los archivos que ha "
+"utilizado. Esta información se comparte entre aplicaciones y hace que sea "
+"más fácil encontrar los archivos que quiere usar."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "H_istórico de archivos"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Duración del _histórico de archivos"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Limpiar el históri_co…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Papelera y archivos temporales"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"La papelera y los archivos temporales pueden en ocasiones incluir "
+"información personal o sensible. Eliminarlos automáticamente puede ayudar a "
+"proteger su privacidad."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Eliminar el contenido la papelera automá_ticamente"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Eliminar los a_rchivos temporales automáticamente"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Período para eliminar automáticamente"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Vaciar papelera…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Eliminar archivos temporales…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Histórico de archivos y papelera"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "No dejar trazas"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"uso;reciente;histórico;archivos;temporal;tmp;privado;privacidad;papelera;"
+"vaciado;retener;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Debe coincidir con la dirección web del proveedor de la cuenta."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Falló al añadir la cuenta"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Las contraseñas no coinciden."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Falló al registrar la cuenta"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "No hay una manera soportada de autenticar con este dominio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Falló al unirse al dominio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"El nombre de inicio de sesión no ha funcionado.\n"
+"Inténtelo de nuevo."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"La contraseña de inicio de sesión no ha funcionado.\n"
+"Inténtelo de nuevo."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Falló al iniciar sesión en el dominio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "No se pudo encontrar el dominio. ¿Está bien escrito?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Añadir usuario"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrador"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Los administradores pueden añadir o quitar a otros usuarios y cambiar la "
+"configuración de las cuenta. Los controles parentales no se pueden aplicar a "
+"los administradores."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "El usuario establece su contraseña en el primer inicio de sesión"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Establecer una contraseña ahora"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Inicio de sesión corporativo"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Cuentas de usuario gestionadas por una empresa u organización."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Está desconectado"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"El inicio de sesión corporativo permite que se use una cuenta de usuario "
+"gestionada de manera centralizada en este dispositivo. También puede usar "
+"esta cuenta para acceder a recursos de la compañía en Internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Examinar para buscar más imágenes"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Seleccionar un archivo…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Gestor de huellas dactilares"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Huella dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_No"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Sí"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"¿Quiere eliminar sus huellas registradas y así desactivar el inicio de "
+"sesión con huella?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "No hay ningún dispositivo de huella dactilar"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "No hay ningún dispositivo de huella dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Asegúrese de que el dispositivo está conectado correctamente."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Dispositivo de huella dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Elija el dispositivo de huella dactilar que quiere configurar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Inicio de sesión con huella dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"El inicio con huella dactilar le permite desbloquear su equipo e iniciar "
+"sesión en él con su dedo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Eliminar huellas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Alta de huella dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "es necesario reclamar el dispositivo para realizar esta acción"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "otro proceso ha solicitado el dispositivo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "no tiene permisos para realizar esta acción"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "no se han registrado impresiones"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Falló al comunicarse con el dispositivo durante el registro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Falló al comunicarse con el lector de huellas catilares"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Falló al comunicarse con el demonio de huella dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Falló al listas las huellas guardadas: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Falló al eliminar las huellas guardadas: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Pulgar izquierdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Dedo corazón izquierdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "Dedo índice _izquierdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Dedo anular izquierdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Dedo meñique izquierdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Pulgar derecho"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Dedo corazón derecho"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "_Dedo índice derecho"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Dedo anular derecho"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Dedo meñique derecho"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Dedo desconocido"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Terminado"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Dispositivo de huella dactilar desconectado"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "El dispositivo de almacenamiento de huellas dactilares está lleno"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Falló al dar de alta la nueva huella dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Falló al iniciar el alta: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Falló al dar de alta una nueva huella dactilar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Falló al detener el alta: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Levante y coloque su dedo repetidamente en el lector para dar de alta su "
+"huella."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "_Volver a dar de alta este dedo…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Analizar una huella dactilar nueva"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Falló al liberar el dispositivo de huella dactilar %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problema al leer el dispositivo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Falló al solicitar el dispositivo de huella dactilar %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Falló al obtener los dispositivos de huella dactilar: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Esta semana"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Última semana"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e de %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sesión terminada"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sesión iniciada"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s - Actividad de la cuenta"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Anterior"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Siguiente"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Elija otra contraseña."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Escriba de nuevo su contraseña actual."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "No se pudo cambiar la contraseña"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Cambiar contraseña"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Cam_biar"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Contraseña actual"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Contraseña nueva"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Confirmar contraseña"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Permitir al usuario cambiar su contraseña en el siguiente inicio de sesión"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Establecer una contraseña ahora"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "No se puede unir automáticamente a este tipo de dominio"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "No existe el dominio o no se ha encontrado el reino"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "No se puede iniciar sesión como %s en el dominio %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Contraseña no válida, inténtelo de nuevo"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "No se pudo conectar al dominio %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Falló al eliminar el usuario"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Falló al revocar remotamente el usuario gestionado"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "No puede eliminar su propia cuenta."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s aún está registrado en el sistema"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Eliminar un usuario mientras está registrado en el sistema puede dejar el "
+"sistema en un estado inconsistente."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "¿Quiere mantener los archivos de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Es posible mantener la carpeta personal, el «spool» del correo y los "
+"archivos temporales al eliminar una cuenta de usuario."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Eliminar archivos"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Mantener archivos"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"¿Está seguro de que quiere revocar remotamente la cuenta gestionada de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Eliminar"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Cuenta desactivada"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Para configurar en el siguiente inicio de sesión"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ninguno"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Sesión iniciada"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Falló al contactar con el servicio de cuentas"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Asegúrese de que el servicio de cuentas está instalado y activado."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Se debe desbloquear este panel para cambiar esta opción"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Quitar la cuenta de usuario seleccionada"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Para eliminar la cuenta de usuario seleccionada\n"
+"pulse primero el icono *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Desbloquear para añadir usuarios y cambiar la configuración"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Usuarios"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Debe reiniciar la sesión para que se apliquen los cambios"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Reiniciar ahora"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Cerrar"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Editar avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Nombre completo"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Editar"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Inicio de sesión con _huella"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Inicio de sesión automático"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Actividad de la cuenta"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrador"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Los administradores pueden añadir o quitar a otros usuarios y cambiar la "
+"configuración de las cuenta."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "Controles _parentales"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Abrir la aplicación de control parental."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Quitar usuario…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Otros usuarios"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Añadir usuario…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "No se han encontrado usuarios"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Desbloquear para añadir una cuenta de usuario."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Añadir o quitar usuarios y cambiar su contraseña"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Inicio de sesión;Nombre;Avatar;Logo;Cara;Contraseña;Control parental;Tiempo "
+"de pantalla;Restricciones de aplicaciones; Restricciones web;Uso;Límite de "
+"uso;Niños;Hijos;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Unir"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Inicio de sesión del administrador del dominio"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Para usar inicios de sesión corporativos, este equipo necesita\n"
+"formar parte de un dominio. Pida al administrador de su\n"
+"sistema que escriba aquí la contraseña del dominio."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nombre del administrador"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Contraseña de administrador"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Gestionar cuentas de usuario"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Se requiere autenticación para cambiar los datos del usuario"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "La contraseña nueva debe ser diferente de la antigua."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Pruebe a cambiar algunas letras y números."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Pruebe a cambiar la contraseña un poco más."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Una contraseña sin su nombre de usuario será más robusta."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Evite usar su nombre en la contraseña."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Evite algunas de las palabras incluidas en la contraseña."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Trate de evitar palabras comunes."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Evite reordenar las palabras existentes."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Pruebe a usar más números."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Pruebe a usar más letras en mayúscula."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Pruebe a usar más letras en minúscula."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Pruebe a usar más caracteres especiales, como signos de puntuación."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Pruebe a usar una mezcla de letras, números y signos de puntuación."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Evite repetir el mismo carácter."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Evite repetir el mismo tipo de carácter: debe mezclar letras, números y "
+"signos de puntuación."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Evite secuencias como 1234 o abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"La contraseña debe ser más larga. Pruebe a añadir más letras, números y "
+"signos de puntuación."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Mezcle letras mayúsculas y minúsculas y use uno o dos números."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Añadir más letras, números y signos de puntuación hará que la contraseña sea "
+"más robusta."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Falló la autenticación"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "La contraseña nueva es demasiado corta"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "La contraseña nueva es demasiado simple"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "La contraseña antigua y la nueva son demasiado similares"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "La contraseña nueva ya se ha usado recientemente."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "La contraseña nueva debe contener caracteres numéricos o especiales"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "La contraseña nueva y la antigua son la misma"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Se ha cambiado su contraseña desde que se autenticó inicialmente."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "La contraseña nueva no contiene suficientes caracteres diferentes"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Error desconocido"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"El nombre de usuario debe constar solamente de letras minúsculas de la «a» a "
+"la «z», dígitos y cualquiera de los caracteres: «-» o «_»"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "El nombre de usuario no está disponible. Pruebe con otro."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "El nombre de usuario es demasiado largo."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Mapear botones"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Mapear botones a funciones"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Para editar un atajo, elija la acción «Enviar pulsación de teclas», pulse el "
+"atajo del teclado y mantenga pulsadas las teclas nuevas o pulse Retroceso "
+"para eliminarlo."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Cerrar"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Pulse los marcadores objetivo a medida que aparecen en la pantalla para "
+"calibrar la tableta."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Pulsación errónea detectada, reiniciando…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Botón %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplicación definida"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Enviar pulsación de tecla"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Cambiar monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Mostrar la ayuda en pantalla"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tableta montada en el panel del portátil"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tableta montada en una pantalla externa"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Tableta externa"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Tableta externa"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Todas las pantallas"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Modo tableta"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Usa posicionamiento absoluto para el lápiz"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientación para zurdos"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tableta y teclas Express ™ rotadas para el uso por zurdos"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapa que monitorizar"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Mantener proporción de aspecto"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Usar sólo una parte de la superficie de la tableta para mantener la relación "
+"de aspecto"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Calibrar"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "No se ha detectado ninguna tableta"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Conecte o encienda su tableta Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensibilidad de presión del lápiz"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Suave"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Presión del lápiz"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Botón 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botón 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botón1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilidad de presión del borrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Presión del borrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Pulsación del botón derecho del ratón"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Pulsación del botón del medio del ratón"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Adelante"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Lápiz aerógrafo con presión, inclinación y deslizador integrado"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Lápiz aerógrafo con presión, inclinación y rotación"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Lápiz estándar con presión e inclinación"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Lápiz estándar con presión"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tableta Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Establecer el mapeado de botones y ajustar la sensibilidad del lápiz para "
+"tabletas gráficas"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tableta;Wacom;Stylus;Borrador;Ratón;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Atajo nuevo..."
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Puntos de acceso"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operación cancelada"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Error:</b> acceso denegado para modificar la configuración"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Error:</b> error del equipo móvil"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "No registrado"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registrado"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Itinerancia"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Buscando"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Denegado"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Detalles del módem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Estado del módem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operador"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tipo de red"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Estado de la red"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Número del propietaro"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Detalles del dispositivos"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Versión de firmware"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G sólo"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G sólo"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G sólo"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "5G sólo"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (preferido), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (preferido), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (preferido), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (preferido), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (preferido), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (preferido), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (preferido), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (preferido), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (preferido), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (preferido), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Desbloquear tarjeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Desbloquear"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Proporcione el código PIN para la SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Introduzca el PIN para desbloquear su tarjeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Proporcione el código PUK para la SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Introduzca el PUK para desbloquear su tarjeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Contraseña introducida incorrecta. Le queda %1$u intento"
+msgstr[1] "Contraseña introducida incorrecta. Le quedan %1$u intentos"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Le queda %u intento"
+msgstr[1] "Le quedan %u intentos"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Contraseña incorrecta."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "El código PUK debe ser un número de 8 cifras"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Introduzca un nuevo PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "El código PIN debe ser un número de 4-8 cifras"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Desbloqueando…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "No hay tarjeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Inserte una tarjeta SIM para usar éste módem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM bloqueada"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "Datos _móviles"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Acceso a datos usando la red móvil"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Datos de itinerancia"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Usar datos móviles en itinerancia"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Modo de red"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "R_ed"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Nombres de puntos de _acceso"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Bloquear _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Bloquear SIM con PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Detalles del mód_em"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Falló del teléfono"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "No hay conexión con el teléfono"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operación no permitida"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operación no soportada"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Tarjeta SIM no insertada"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Se necesita el PIN de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Se necesita el PUK de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Fallo de la tarjeta SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Tarjeta SIM ocupada"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Contraseña incorrecta"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Se necesita el PIN2 de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Se necesita el PUK2 de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "No encontrado"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "No hay servicio de red"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Tiempo de expiración de la red"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Servicios GPRS no permitidos"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Itinerancia no permitida en esta área"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Error GPRS no especificado"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Sin error"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Acción cancelada"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Acceso denegado"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Error desconocido"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Modo de red"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automática"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Elegir red"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Actualizar proveedores de red"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Activar red móvil"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "No se han encontrado ningún adaptador WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Asegúrese de que tiene un adaptador inalámbrico o móvil"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "La red WWAN está desactivada cuando el modo avión está activado"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Apagar el modo avión"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Conexión de datos"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Tarjeta SIM usada para Internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Bloqueo de SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "Siguie_nte"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Bloquear tarjeta SIM con PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Cambiar PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+"Introduzca el PIN actual para cambiar la configuración de bloqueo de la SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Red móvil"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configurar telefonía y conexiones de datos móviles"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "teléfono;wwan;telefonía;sim;móvil;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilidad para configurar el escritorio GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Configuración es la interfaz principal para configurar su sistema."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "El Proyecto GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Mostrar el número de versión"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Activar el modo detallado"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Buscar la cadena"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Listar todos los nombres de paneles posibles y salir"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel que mostrar"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENTO…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categorías de configuración"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privacidad"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Paneles disponibles:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Todas las configuraciones"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menú primario"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Advertencia: versión de desarrollo"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Esta versión de Configuración sólo debe usarse con propósitos de desarrollo. "
+"Puede experimentar un comportamiento incorrecto del sistema, pérdida de "
+"datos y otros problemas inesperados."
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Ayuda"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "General"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Salir"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Buscar"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneles"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Volver al panel anterior"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Cancelar búsqueda"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferencias;Configuración;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "El identificador del último panel de Configuración que abrir"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"El identificador del último panel de Configuración que abrir. Los valores no "
+"reconocidos se ignorarán y se seleccionará el primer panel de la lista."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Mostrar advertencia al ejecutar una versión de desarrollo de Configuración"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Indica si Configuración debe mostrar advertencia al ejecutar una versión de "
+"desarrollo de Configuración."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Estado inicial de la ventana"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Una tupla que contiene la anchura y altura iniciales y el estado maximizado "
+"de la ventana de la aplicación."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u salida"
+msgstr[1] "%u salidas"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrada"
+msgstr[1] "%u entradas"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sonidos del sistema"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Error: no se puede determinar el nivel de HSI."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Error: no se puede determinar el nivel de HSI Incorrecto."
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificados DER o PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Añadir una impresora…"
+
+#~ msgid "Drip"
+#~ msgstr "Goteo"
+
+#~ msgid "Glass"
+#~ msgstr "Vaso"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Distribución de las pantallas"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "Secure Boot está desactivado"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Protección básica"
+
+#~ msgid "Extended Protection"
+#~ msgstr "Protección extendida"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Protección de seguridad básica"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Protección de seguridad extendida"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "Región de la BIOS SPI"
+
+#, fuzzy
+#~| msgid "Suspend"
+#~ msgid "Suspend-to-ram"
+#~ msgstr "Suspender"
+
+#, fuzzy
+#~| msgid "Manufacturer"
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "Fabricante"
+
+#~ msgid "MEI version"
+#~ msgstr "Versión MEI"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "Complementos de fwupd"
+
+#~ msgid "Intel DCI debugger"
+#~ msgstr "Depurador Intel DCI"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "Protección IOMMU del dispositivo activada"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "Protección IOMMU del dispositivo desactivada"
+
+#~ msgid "Kernel is no longer tainted"
+#~ msgstr "El núcleo ya no está envenenado"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "El núcleo se ha envenenado"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "Secure Boot desactivado"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "Secure Boot activado"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Bloquear la pantalla"
+
+#~ msgid "Light"
+#~ msgstr "Claro"
+
+#~ msgid "Set"
+#~ msgstr "Establecer"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "pantalla;bloqueo;diagnóstico;error;privado;reciente;temporal;tmp;índice;"
+#~ "nombre;red;identidad;"
+
+#~ msgid "Bark"
+#~ msgstr "Ladrido"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Panel de configuración de sonido de GNOME"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Panel de configuración de ratón y panel táctil de GNOME"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Panel de configuración de segundo plano de GNOME"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Panel de configuración del teclado de GNOME"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autenticar"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Compartir pantalla permite a los usuarios remotos ver o controlar su "
+#~ "pantalla conectándose a %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Compartición de la pa_ntalla"
+
+#~ msgid "_Password:"
+#~ msgstr "_Contraseña:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Mo_strar contraseña"
+
+#~ msgid "Access Options"
+#~ msgstr "Opciones de acceso"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Las conexiones _nuevas deben solicitar acceso"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Solicitar una contraseña"
+
+#~ msgid "More Warm"
+#~ msgstr "Más cálido"
+
+#~ msgid "Less Warm"
+#~ msgstr "Menos cálido"
+
+#~ msgid "Show the screenshot UI"
+#~ msgstr "Mostrar la IU de captura de pantalla"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Capturar la pantalla"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "Capturar una ventana"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "Mostrar la IU de grabación de pantalla"
+
+#~ msgid "Move up"
+#~ msgstr "Subir"
+
+#~ msgid "Move down"
+#~ msgstr "Bajar"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Permitir a las siguientes aplicaciones usar el micrófono."
+
+#~ msgid "%s VPN"
+#~ msgstr "VPN «%s»"
+
+#~ msgid "Standard"
+#~ msgstr "Estándar"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Tipo de cuenta"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Permitir al usuario establecer una contraseña en el siguiente _inicio de "
+#~ "sesión"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_Establecer una contraseña ahora"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Debe estar conectado para añadir usuarios corporativos."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Hacer una foto…"
+
+#~ msgid "_Confirm New Password"
+#~ msgstr "_Confirmar la contraseña nueva"
+
+#~ msgid "Your account"
+#~ msgstr "Su cuenta"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para realizar los cambios\n"
+#~ "pulse primero el icono *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Crear una cuenta de usuario"
+
+#~ msgid "User Icon"
+#~ msgstr "Icono de usuario"
+
+#~ msgid "Account Settings"
+#~ msgstr "Configuración de la cuenta"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autenticación e inicio de sesión"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Esto se usará para nombrar su carpeta personal y no se puede cambiar."
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Elija el formato de los números, fechas y monedas. Los cambios se "
+#~ "aplicarán en el siguiente inicio de sesión."
+
+#~ msgid "My Account"
+#~ msgstr "Mi cuenta"
+
+#~ msgid "Language"
+#~ msgstr "Idioma"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "El idioma usado para el texto de las ventanas y las páginas web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Reiniciar la sesión para que se apliquen los cambios"
+
+#~ msgid "Restart…"
+#~ msgstr "Reiniciar…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "La configuración de inicio de sesión la usan todos los usuarios cuando "
+#~ "inician sesión en el sistema"
+
+#~ msgid "Output:"
+#~ msgstr "Salida:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Mantener relación de aspecto («letterbox»):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapear una única pantalla"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Mostrar mapeo"
+
+#~ msgid "Stylus"
+#~ msgstr "Stylus"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tableta (absoluto)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Panel táctil (relativo)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferencias de la tableta"
+
+#~ msgid "_Help"
+#~ msgstr "_Ayuda"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Configuración de Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Modo de seguimiento"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Mapear botones…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Ajustar la configuración del ratón"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Ajustar la resolución de la pantalla"
+
+#~ msgid "Decouple Display"
+#~ msgstr "Desacoplar pantalla"
+
+#~ msgid "No stylus found"
+#~ msgstr "No se ha encontrado ninguna tableta"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Mueva el lápiz cerca de la tableta para configurarlo"
+
+#~ msgid "Top Button"
+#~ msgstr "Botón superior"
+
+#~ msgid "Lower Button"
+#~ msgstr "Botón inferior"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Botón inferior"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Guardar una captura de pantalla en $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Guardar la captura de un área en $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copiar una captura de pantalla al portapapeles"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copiar una captura de pantalla de una ventana al portapapeles"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copiar una captura de pantalla de un área al portapapeles"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Hacer una grabación corta del escritorio"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Controla qué resultados de búsqueda se muestran en la Vista de "
+#~ "actividades. El orden de los resultados de la búsqueda se puede cambiar "
+#~ "moviendo las filas en la lista."
+
+#~ msgid "Web Links"
+#~ msgstr "Enlaces de Web"
+
+#~ msgid "Git Links"
+#~ msgstr "Enlaces de Git"
+
+#~ msgid "%s Links"
+#~ msgstr "Enlaces de %s"
+
+#~ msgid "Unset"
+#~ msgstr "Sin asignar"
+
+#~ msgid "Links"
+#~ msgstr "Enlaces"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Archivos de hipertexto"
+
+#~ msgid "Text Files"
+#~ msgstr "Archivos de texto"
+
+#~ msgid "Image Files"
+#~ msgstr "Archivos de imágenes"
+
+#~ msgid "Font Files"
+#~ msgstr "Archivos de tipografías"
+
+#~ msgid "Archive Files"
+#~ msgstr "Archivos comprimidos"
+
+#~ msgid "Package Files"
+#~ msgstr "Archivos de paquetes"
+
+#~ msgid "Audio Files"
+#~ msgstr "Archivo de sonido"
+
+#~ msgid "Video Files"
+#~ msgstr "Archivos de vídeo"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permisos y acceso"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Datos y servicios para los que esta aplicación ha solicitado el acceso y "
+#~ "los permisos que necesita."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "No se puede cambiar"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Se pueden revisar los permisos individuales de cada aplicación en la "
+#~ "configuración de la <a href=\"privacy\">Privacidad</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integración"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Establecer fondo de escritorio"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Manejadores predeterminados"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Tipos de archivos y enlaces que abre esta aplicación."
+
+#~ msgid "Usage"
+#~ msgstr "Uso"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Cuántos recursos está usando esta aplicación."
+
+#~ msgid "Open in Software"
+#~ msgstr "Abrir en Software"
+
+#~ msgid "Activities"
+#~ msgstr "Actividades"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Permitir a las siguientes aplicaciones usar su cámara."
+
+#~ msgid "Display Mode"
+#~ msgstr "Modo de la pantalla"
+
+#~ msgid "Join Displays"
+#~ msgstr "Unir pantallas"
+
+#~ msgid "Single Display"
+#~ msgstr "Pantalla única"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Arrastre las pantallas para que coincidan con su configuración. "
+#~ "Seleccione una pantalla para modificar su configuración."
+
+#~ msgid "Active Display"
+#~ msgstr "Pantalla activa"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Los servicios de ubicación permiten a las aplicaciones determinar su "
+#~ "posición geográfica. La precisión se incrementa activando la Wi-Fi y la "
+#~ "red de banda ancha móvil."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Usa el servicio de ubicación de Mozilla: <a href='https://location."
+#~ "services.mozilla.com/privacy'>política de privacidad</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Permitir a las siguientes aplicaciones determinar su ubicación."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Portátil detectado: modo de rendimiento no disponible"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Alta temperatura del hardware: modo de rendimiento no disponible"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Modo de rendimiento no disponible"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Teclas sonoras"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Lector de pantalla"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Lector de pantalla"
+
+#~ msgid "_Copy"
+#~ msgstr "_Copiar"
+
+#~ msgid "Select _All"
+#~ msgstr "Seleccionar _todo"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Tiempo de espera de la pulsación doble"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Botón de suspender y apagar"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Se han desactivado algunos servicios porque no hay acceso a la red."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Falló al subir el archivo: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "El perfil se ha subido a:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Anote este URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Reinicie el equipo y arranque su sistema operativo normal."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Escriba el URL en su navegador para descargar e instalar el perfil."
+
+#~ msgid "Upload profile"
+#~ msgstr "Subir perfil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Requiere conexión a Internet"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Desbloqueando..."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "inicio;sesión;nombre;huella;avatar;logo;cara;contraseña;"
+
+#~ msgid ""
+#~ "Select your display language, formats, keyboard layouts and input sources"
+#~ msgstr ""
+#~ "Seleccione su idioma, formatos, distribuciones de teclado y fuentes de "
+#~ "entrada"
+
+#~| msgid "SIM Pin required"
+#~ msgid "PH-SIM PIN required"
+#~ msgstr "Se necesita el PIN de la PH-SIM"
+
+#~| msgid "SIM Pin required"
+#~ msgid "PH-FSIM PIN required"
+#~ msgstr "Se necesita el PIN de la PH-FSIM"
+
+#~| msgid "SIM Pin required"
+#~ msgid "PH-FSIM PUK required"
+#~ msgstr "Se necesita el PUK de la PH-FSIM"
+
+#~| msgid "Memory"
+#~ msgid "Memory full"
+#~ msgstr "Memoria llena"
+
+#~ msgid "Invalid index"
+#~ msgstr "Índice no válido"
+
+#~| msgid "Memory"
+#~ msgid "Memory failure"
+#~ msgstr "Fallo de la memoria"
+
+#, fuzzy
+#~| msgid "Network registration denied"
+#~ msgid "Network personalization PIN required"
+#~ msgstr "Registro de la red denegado"
+
+#, fuzzy
+#~| msgid "Network registration denied"
+#~ msgid "Network personalization PUK required"
+#~ msgstr "Registro de la red denegado"
+
+#, fuzzy
+#~| msgid "Network registration denied"
+#~ msgid "Network subset personalization PIN required"
+#~ msgstr "Registro de la red denegado"
+
+#, fuzzy
+#~| msgid "Network registration denied"
+#~ msgid "Network subset personalization PUK required"
+#~ msgstr "Registro de la red denegado"
+
+#~ msgid "Illegal MS"
+#~ msgstr "MS ilegal"
+
+#~ msgid "Illegal ME"
+#~ msgstr "ME ilegal"
+
+#~ msgid "PLMN not allowed"
+#~ msgstr "PLMN no permitido"
+
+#, fuzzy
+#~| msgid "Location already exists"
+#~ msgid "Location area not allowed"
+#~ msgstr "El lugar ya existe"
+
+#~| msgid "The device type is not currently supported."
+#~ msgid "Service option not supported"
+#~ msgstr "Opción de servicio no soportada"
+
+#~| msgid "Authentication failed"
+#~ msgid "PDP authentication failure"
+#~ msgstr "Falló la autenticación PDP"
+
+#~ msgid "Invalid mobile class"
+#~ msgstr "Clase de móvil no válida"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Brillo de la pantalla"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Brillo del teclado"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Oscurecer la pantalla cuando esté inactiva"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Apagar la pantalla"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Se puede apagar la Wi-Fi para ahorrar energía."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Se puede apagar la banda ancha móvil (3G, 4G, LTE, etc.) para ahorrar "
+#~ "energía."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Se puede apagar el Bluetooth para ahorrar energía."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Balanceo de energía"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Atajo del teclado"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Esto se puede cambiar en Atajos personalizados"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Manténgala pulsada y escriba para introducir diferentes caracteres"
+
+#~ msgid "Add…"
+#~ msgstr "Añadir…"
+
+#~ msgid "Previous source"
+#~ msgstr "Fuente anterior"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Súper+Mayús+Espacio"
+
+#~ msgid "Next source"
+#~ msgstr "Siguiente fuente"
+
+#~ msgid "Super+Space"
+#~ msgstr "Súper+Espacio"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Izquierda+Alt derecha"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Tecla de caracteres alternativos"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Sólo los modificadores cambian a la fuente siguiente"
+
+#~ msgid "Left Alt"
+#~ msgstr "Alt izquierdo"
+
+#~ msgid "Right Alt"
+#~ msgstr "Alt derecho"
+
+#~ msgid "Left Super"
+#~ msgstr "Súper izquierdo"
+
+#~ msgid "Right Super"
+#~ msgstr "Súper derecho"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl derecho"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Tecla de menú"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Cargando"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Precaución"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Baja"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Bien"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Cargada completamente"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Vacía"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Apagar para conectarse a una red inalámbrica"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Contraseña"
+
+#~ msgid "Universal Access"
+#~ msgstr "Acceso universal"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Activar el inicio de sesión con huella"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Otro dedo:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Su huella dactilar se guardó correctamente. Ahora debería poder iniciar "
+#~ "sesión usando su lector de huellas dactilares."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "No le está permitido acceder al dispositivo. Contacte con el "
+#~ "administrador de su sistema."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Ocurrió un error interno."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "¿Eliminar las huellas registradas?"
+
+#~ msgid "Done!"
+#~ msgstr "Hecho"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "No se pudo acceder al dispositivo «%s»"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "No se pudo iniciar la captura de dedo en el dispositivo «%s»"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "No se pudo acceder a ninguna lectura de huellas"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Contacte con el administrador de su sistema para obtener ayuda."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Para activar el inicio de sesión con huella debe guardar una de sus "
+#~ "huellas usando el dispositivo «%s»."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Seleccionando dedo"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para crear un usuario\n"
+#~ "pulse primero el icono *"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Añadir cuentas de usuario y cambiar contraseñas"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Reproducir y grabar sonido"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Detectar dispositivos de red usando mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Acceder a hardware Bluetooth directamente"
+
+#~ msgid "Use your camera"
+#~ msgstr "Usar su cámara"
+
+#~ msgid "Print documents"
+#~ msgstr "Imprimir documentos"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Usar cualquier joystick conectado"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Permitir conexiones al servicio Docker"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Configurar el cortafuegos de la red"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Configurar y usar sistemas de archivos FUSE privilegiados"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Actualizar el firmware en este dispositivo"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Acceder a información del hardware"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Proporcionar entropía al generador hardware de números aleatorios"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Usar números aleatorios generados por hardware"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Acceder a archivos en su carpeta personal"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Acceder al servicio libvirt"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Cambiar la configuración del idioma y la región"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Cambiar la configuración de ubicación y proveedores"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Leer registros del sistema y de aplicaciones"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "acceder al servicio de media-hub"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Usar y configurar módems"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Leer información de montaje del sistema y cuotas de disco"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Controlar los reproductores música y vídeo"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Cambiar la configuración de la red a bajo nivel"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Acceder al servicio NetworkManager para leer y modificar la configuración "
+#~ "del a red"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Leer la configuración de acceso a la red"
+
+#~ msgid "Change network settings"
+#~ msgstr "Modificar la configuración de la red"
+
+#~ msgid "Read network settings"
+#~ msgstr "Leer la configuración de la red"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Acceder al servicio ofono para leer y modificar la configuración de la "
+#~ "red para teléfonos móviles"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Controlar hardware Open vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Leer de un CD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Leer, añadir, modificar o quitar contraseñas guardadas"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Acceder a dispositivos pppd y ppp para configurar conexiones de protocolo "
+#~ "punto a punto (PPP)"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Pausar o finalizar un proceso en el sistema"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Acceder a hardware USB directamente"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Leer/escribir archivos en dispositivos de almacenamiento extraíbles"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Evitar suspensión/bloqueo de la pantalla"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Acceder a hardware por puerto serie"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Reiniciar o apagar el dispositivo"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Instalar, quitar y configurar software"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Acceder al servicio de entorno de trabajo de almacenamiento"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Leer información del sistema de procesos"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Monitorizar y controlar cualquier programa en ejecución"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Modificar la fecha y la hora"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Modificar la configuración del servidor de hora"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Modificar la zona horaria"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Acceder al servicio UDisks2 para configurar discos y medios extraíbles"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr ""
+#~ "Leer/modificar los eventos compartidos en el calendario en Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Leer/modificar los contactos compartidos en Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Acceder a datos de uso de energía"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Acceso de lectura/escritura a dispositivos U2F expuestos"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Establecer fondo y pantalla de bloqueo"
+
+#~ msgid "Set Background"
+#~ msgstr "Establecer fondo"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Establecer pantalla de bloqueo"
+
+#~ msgid "Remove Background"
+#~ msgstr "Quitar fondo"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Los informes se envían anónimamente y no contienen datos personales."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Enviar informes de problemas técnicos nos ayuda a mejorar este sistema "
+#~ "operativo."
+
+#~ msgid "Last Login"
+#~ msgstr "Último inicio de sesión"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Notificaciones emergentes"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Restringir el uso de datos en _segundo plano"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Adecuado para conexiones que consumen o limitan los datos."
+
+#~ msgid "No regions found"
+#~ msgstr "No se han encontrado regiones"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Destello de la barra de título de la _ventana"
+
+#~ msgid "Network proxy"
+#~ msgstr "Proxy de la red"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Autenticación i_nterna"
+
+#~ msgid "In use"
+#~ msgstr "En uso"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Activado"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Desactivado"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Apagada"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Encendida"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Apagado"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Encendido"
+
+#~ msgid "Usage & History"
+#~ msgstr "Uso e histórico"
+
+#~ msgid "Software Usage"
+#~ msgstr "Uso de software"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Política de privacidad"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Recordar su histórico hace que sea más sencillo buscar las cosas de "
+#~ "nuevo. Estos elementos nunca se comparten en la red."
+
+#~ msgid "_Recently Used"
+#~ msgstr "Usados _recientemente"
+
+#~ msgid "Retain _History"
+#~ msgstr "Recordar _histórico"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "La pantalla de bloqueo protege."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "B_loquear la pantalla después de"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Notificaciones de la pantalla de bloqueo"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Limpiar automáticamente los archivos temporales y de la Papelera para "
+#~ "ayudarle a mantener su equipo libre de información sensible."
+
+#~ msgid "Purge _After"
+#~ msgstr "Limpiar _después de"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Enviar información sobre el software que usa nos ayuda a proporcionarle "
+#~ "recomendaciones más precisas. También nos ayuda a mejorar nuestro "
+#~ "software.\n"
+#~ "\n"
+#~ "Toda la información recopilada es anónima y sus datos nunca se "
+#~ "compartirán con terceras partes."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Enviar estadísticas de uso de software"
+
+#~ msgid "_Camera"
+#~ msgstr "_Cámara"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Micrófono"
+
+#~ msgid "_Location Services"
+#~ msgstr "Servicios de ubicación"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Proteger su información personal y controlar qué pueden ver otros"
+
+#~ msgid "Version %s"
+#~ msgstr "Versión %s"
+
+#~ msgid "OS name"
+#~ msgstr "Nombre del SO"
+
+#~ msgid "OS type"
+#~ msgstr "Tipo de SO"
+
+#~ msgid "Disk"
+#~ msgstr "Disco"
+
+#~ msgid "Check for updates"
+#~ msgstr "Comprobar si hay actualizaciones"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Par trenzado (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Interfaz de unidad de acoplamiento (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Interfaz independiente de medios (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "_Conectar automáticamente"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Mostrar contr_aseña"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Hacer disponible para el resto de usuarios"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Direcciones"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Sólo direcciones automáticas (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Solo enlace local"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignorar rutas obtenidas automáticamente"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Dirección MAC _clonada"
+
+#~ msgid "_Reset"
+#~ msgstr "_Reiniciar"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Restablecer la configuración de esta conexión a sus valores "
+#~ "predeterminados, pero recordarla como una conexión favorita."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Quitar todos los detalles relativos a esta red y no volver a intentar "
+#~ "conectarse automáticamente a ella."
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Reiniciar"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Dispositivos conectados"
+
+#~ msgid "page 1"
+#~ msgstr "página 1"
+
+#~ msgid "page 2"
+#~ msgstr "página 2"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Cambiar al «hotspot» inalámbrico le desconectará de <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "No es posible acceder a Internet usando la conexión inalámbrica mientras "
+#~ "el «hotspot» está activado."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Los puntos de acceso inalámbricos se usan habitualmente para compartir "
+#~ "una conexión a Internet adicional mediante Wi-Fi."
+
+#~ msgid "details"
+#~ msgstr "detalles"
+
+#~ msgid "identity"
+#~ msgstr "indentidad"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infraestructura"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "El nombre de usuario no puede comenzar por «-»."
+
+#~ msgid "Delete Background"
+#~ msgstr "Eliminar fondo"
+
+#~ msgid "_Off"
+#~ msgstr "_Apagar"
+
+#~ msgid "_Mobile broadband"
+#~ msgstr "Banda ancha _móvil"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "Suspender _automáticamente"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "Al pulsar el b_otón de encendido"
+
+#~ msgid "_Background"
+#~ msgstr "_Fondo"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Cambia a lo largo del día"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Mosaico"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Ampliación"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrar"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Escalar"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Rellenar"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Expandir"
+
+#~ msgid "Colors"
+#~ msgstr "Colores"
+
+#~ msgid "Pictures"
+#~ msgstr "Imágenes"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "No se han encontrado imágenes"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Puede añadir imágenes a su carpeta %s y se mostrarán aquí"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Conexión/SSID"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "Drag displays to match your setup."
+#~ msgstr "Arrastre las pantallas que coincidan con su configuración."
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Izquierda"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Derecha"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Mínimo"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Máximo"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Perfil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Probar los altavoces"
+
+#~ msgid "Peak detect"
+#~ msgstr "Detección de picos"
+
+#~ msgid "Device"
+#~ msgstr "Dispositivo"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Prueba de altavoces para %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Elegir un dispositivo para la salida de sonido:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Configuración para el dispositivo seleccionado:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Volumen de _entrada:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Elegir un dispositivo para la entrada de sonido:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Efectos de sonido"
+
+#~ msgid "_Alert volume:"
+#~ msgstr "Volumen de _alerta:"
+
+#~ msgid "Built-in"
+#~ msgstr "Integrado"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferencias de sonido"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Comprobando el sonido de evento"
+
+#~ msgid "From theme"
+#~ msgstr "Del tema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Elegir un sonido de alerta:"
+
+#~ msgid "Stop"
+#~ msgstr "Detener"
+
+#~ msgid "_Night Light"
+#~ msgstr "Luz _nocturna"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "No se pudo obtener la información de la pantalla"
+
+#~ msgid "Add input source"
+#~ msgstr "Añadir fuente de entrada"
+
+#~ msgid "Remove input source"
+#~ msgstr "Quitar fuente de entrada"
+
+#~ msgid "Move input source up"
+#~ msgstr "Subir la fuente de entrada"
+
+#~ msgid "Move input source down"
+#~ msgstr "Bajar la fuente de entrada"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Mostrar la distribución del teclado de la fuente de entrada"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Centro de control de GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "El centro de control es la interfaz principal de GNOME para la "
+#~ "configuración de diversos aspectos de su escritorio."
+
+#~ msgid "hardware"
+#~ msgstr "hardware"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Cambiar a la fuente anterior"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Cambiar a la fuente siguiente"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Cambio alternativo a la fuente siguiente"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Inglés (Reino Unido)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Reino Unido"
+
+#~ msgid "_Options"
+#~ msgstr "_Opciones"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Estándar"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrador"
+
+#~ msgid "page 3"
+#~ msgstr "página 3"
+
+#~ msgid "Quit"
+#~ msgstr "Salir"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Verificar la contraseña nueva"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Las contraseñas no coinciden."
+
+#~ msgid "Show the overview"
+#~ msgstr "Mostrar la visión general"
+
+#~| msgid "Place your finger on the reader again"
+#~ msgid "Place your finger on the fingerprint reader"
+#~ msgstr "Ponga su dedo en el lector de huellas digitales"
+
+#~| msgid "Place your left ring finger on %s"
+#~ msgid "Place your finger on %s"
+#~ msgstr "Ponga su dedo en %s"
+
+#~| msgid "Could not access any fingerprint readers"
+#~ msgid "Swipe your finger across the fingerprint reader"
+#~ msgstr "Pase su dedo por el lector de huellas digitales"
+
+#~| msgid "Swipe your finger again"
+#~ msgid "Swipe your finger across %s"
+#~ msgstr "Pase su dedo por %s"
+
+#~| msgid "Place your left little finger on %s"
+#~ msgid "Place your left thumb on the fingerprint reader"
+#~ msgstr "Ponga su dedo pulgar izquierdo en el lector de huellas digitales"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "Ponga su pulgar izquierdo en %s"
+
+#~| msgid "Could not access any fingerprint readers"
+#~ msgid "Swipe your left thumb across the fingerprint reader"
+#~ msgstr "Pase su dedo pulgar derecho por el lector de huellas digitales"
+
+#~| msgid "Swipe your left thumb on %s"
+#~ msgid "Swipe your left thumb across %s"
+#~ msgstr "Pase su pulgar izquierdo sobre %s"
+
+#~| msgid "Place your left index finger on %s"
+#~ msgid "Place your left index finger on the fingerprint reader"
+#~ msgstr "Ponga su dedo índice izquierdo en el lector de huellas digitales"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "Ponga su dedo índice izquierdo en %s"
+
+#~| msgid "Swipe your left index finger on %s"
+#~ msgid "Swipe your left index finger across the fingerprint reader"
+#~ msgstr "Pase su dedo índice izquierdo por el lector de huellas digitales"
+
+#~| msgid "Swipe your left index finger on %s"
+#~ msgid "Swipe your left index finger across %s"
+#~ msgstr "Pase su dedo índice izquierdo sobre %s"
+
+#~| msgid "Place your left middle finger on %s"
+#~ msgid "Place your left middle finger on the fingerprint reader"
+#~ msgstr "Ponga su dedo corazón izquierdo en el lector de huellas digitales"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "Ponga su dedo corazón izquierdo en %s"
+
+#~| msgid "Swipe your left middle finger on %s"
+#~ msgid "Swipe your left middle finger across the fingerprint reader"
+#~ msgstr "Pase su dedo corazón izquierdo por el lector de huellas digitales"
+
+#~| msgid "Swipe your left middle finger on %s"
+#~ msgid "Swipe your left middle finger across %s"
+#~ msgstr "Pase su dedo corazón izquierdo sobre %s"
+
+#~| msgid "Place your left ring finger on %s"
+#~ msgid "Place your left ring finger on the fingerprint reader"
+#~ msgstr "Ponga su dedo anular izquierdo en el lector de huellas digitales"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "Ponga su dedo anular izquierdo en %s"
+
+#~| msgid "Swipe your left ring finger on %s"
+#~ msgid "Swipe your left ring finger across the fingerprint reader"
+#~ msgstr "Pase su dedo anular izquierdo por el lector de huellas digitales"
+
+#~| msgid "Swipe your left ring finger on %s"
+#~ msgid "Swipe your left ring finger across %s"
+#~ msgstr "Pase su dedo anular izquierdo sobre %s"
+
+#~| msgid "Place your left little finger on %s"
+#~ msgid "Place your left little finger on the fingerprint reader"
+#~ msgstr "Ponga su dedo meñique izquierdo en el lector de huellas digitales"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "Ponga su dedo meñique izquierdo en %s"
+
+#~| msgid "Swipe your left little finger on %s"
+#~ msgid "Swipe your left little finger across the fingerprint reader"
+#~ msgstr "Pase su dedo meñique izquierdo por el lector de huellas digitales"
+
+#~| msgid "Swipe your left little finger on %s"
+#~ msgid "Swipe your left little finger across %s"
+#~ msgstr "Pase su dedo meñique izquierdo sobre %s"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "Ponga su pulgar derecho en %s"
+
+#~| msgid "Swipe your right little finger on %s"
+#~ msgid "Swipe your right thumb across the fingerprint reader"
+#~ msgstr "Pase su dedo pulgar derecho por el lector de huellas digitales"
+
+#~| msgid "Swipe your right thumb on %s"
+#~ msgid "Swipe your right thumb across %s"
+#~ msgstr "Pase su pulgar derecho sobre %s"
+
+#~| msgid "Place your right index finger on %s"
+#~ msgid "Place your right index finger on the fingerprint reader"
+#~ msgstr "Ponga su dedo índice derecho en el lector de huellas digitales"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "Ponga su dedo índice derecho en %s"
+
+#~| msgid "Swipe your right index finger on %s"
+#~ msgid "Swipe your right index finger across the fingerprint reader"
+#~ msgstr "Pase su dedo índice derecho por el lector de huellas digitales"
+
+#~| msgid "Swipe your right index finger on %s"
+#~ msgid "Swipe your right index finger across %s"
+#~ msgstr "Pase su dedo índice derecho sobre %s"
+
+#~| msgid "Place your right middle finger on %s"
+#~ msgid "Place your right middle finger on the fingerprint reader"
+#~ msgstr "Ponga su dedo corazón derecho en el lector de huellas digitales"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "Ponga su dedo corazón derecho en %s"
+
+#~| msgid "Swipe your right middle finger on %s"
+#~ msgid "Swipe your right middle finger across the fingerprint reader"
+#~ msgstr "Pase su dedo corazón derecho por el lector de huellas digitales"
+
+#~| msgid "Swipe your right middle finger on %s"
+#~ msgid "Swipe your right middle finger across %s"
+#~ msgstr "Pase su dedo corazón derecho sobre %s"
+
+#~| msgid "Place your right ring finger on %s"
+#~ msgid "Place your right ring finger on the fingerprint reader"
+#~ msgstr "Ponga su dedo anular derecho en el lector de huellas digitales"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "Ponga su dedo anular derecho en %s"
+
+#~| msgid "Swipe your right ring finger on %s"
+#~ msgid "Swipe your right ring finger across the fingerprint reader"
+#~ msgstr "Pase su dedo anular derecho por el lector de huellas digitales"
+
+#~| msgid "Swipe your right ring finger on %s"
+#~ msgid "Swipe your right ring finger across %s"
+#~ msgstr "Pase su dedo anular derecho sobre %s"
+
+#~| msgid "Place your right little finger on %s"
+#~ msgid "Place your right little finger on the fingerprint reader"
+#~ msgstr "Ponga su dedo meñique derecho en el lector de huellas digitales"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "Ponga su dedo meñique derecho en %s"
+
+#~| msgid "Swipe your right little finger on %s"
+#~ msgid "Swipe your right little finger across the fingerprint reader"
+#~ msgstr "Pase su dedo meñique derecho por el lector de huellas digitales"
+
+#~| msgid "Swipe your right little finger on %s"
+#~ msgid "Swipe your right little finger across %s"
+#~ msgstr "Pase su dedo meñique derecho sobre %s"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "Ponga de nuevo su dedo en el lector"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "Pase su dedo de nuevo"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "La pasada fue demasiado corta, inténtelo de nuevo"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "Su dedo no estaba centrado, intente pasar su dedo de nuevo"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "Quite su dedo e intente pasar su dedo de nuevo"
+
+#~ msgid "Swipe was too short; try again"
+#~ msgstr "La pasada fue demasiado corta, inténtelo de nuevo"
+
+#~ msgid "Your finger was not centered; try swiping your finger again"
+#~ msgstr "Su dedo no estaba centrado, intente pasarlo de nuevo"
+
+#~ msgid "Remove your finger and try swiping it again"
+#~ msgstr "Quite su dedo e intente pasarlo de nuevo"
+
+#~ msgid "Disable image"
+#~ msgstr "Desactivar imagen"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Examinar para buscar más imágenes…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Usada por %s"
+
+#~ msgid "Back­ground"
+#~ msgstr "Fondo"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Co­lor"
+
+#~ msgid "Overview"
+#~ msgstr "Visión general"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Aplicaciones predeterminadas"
+
+#~ msgid "Ab­out"
+#~ msgstr "Acerca de"
+
+#~ msgid "De­tails"
+#~ msgstr "Detalles"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Soportes extraíbles"
+
+#~ msgid "Net­work"
+#~ msgstr "Red"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Notificaciones"
+
+#~ msgid "Po­wer"
+#~ msgstr "Energía"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Privacidad"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Compartición"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Acceso universal"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Tableta Wacom"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistema"
+
+#~| msgid "_Apply"
+#~ msgid "Apply"
+#~ msgstr "Aplicar"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Tapa cerrada"
+
+#~ msgid "Mirrored"
+#~ msgstr "En espejo"
+
+#~ msgid "Secondary"
+#~ msgstr "Secundaria"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Ordenar las pantallas combinadas"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Rotar 90° en sentido antihorario"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Rotar 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Rotar 90° en sentido antihorario"
+
+#~ msgid "Size"
+#~ msgstr "Tamaño"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr ""
+#~ "Mostrar la barra superior y la vista de actividades en esta pantalla"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Unir esta pantalla a otra para crear un área de trabajo adicional"
+
+#~ msgid "Presentation"
+#~ msgstr "Presentación"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Mostrar sólo diapositivas y multimedia"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Mostrar la vista existente en ambas pantallas"
+
+#~ msgid "Turn Off"
+#~ msgstr "Apagar"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "No usar esta pantalla"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Ordenar las pantallas combinadas"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "Modo a_vión"
+
+#~ msgid "Server"
+#~ msgstr "Servidor"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Eliminar servidor DNS"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Añadir perfil…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Ninguno"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manual"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automático"
+
+#~ msgid "_Method"
+#~ msgstr "_Método"
+
+#~ msgid "Add Device"
+#~ msgstr "Añadir dispositivo"
+
+#~ msgid "VPN Type"
+#~ msgstr "Tipo de VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "Nombre del grupo"
+
+#~ msgid "Group Password"
+#~ msgstr "Contraseña del grupo"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Usar como «hotspot»…"
+
+#~ msgid "_History"
+#~ msgstr "_Histórico"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Hacer disponible para _otros usuarios"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Restablecer la configuración para esta red, incluyendo las contraseñas, "
+#~ "pero recordarla como una red preferida."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Quitar todos los detalles relativos a esta red y no volver a intentar "
+#~ "conectarse automáticamente a ella."
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Pulse Esc para cancelar."
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Si tiene otra conexión a Internet aparte de la inalámbrica, puede "
+#~ "configurar un «hotspot» inalámbrico para compartir su conexión a Internet "
+#~ "con otros."
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (ID de construcción: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "Sistema base"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Pruebe a añadir más letras, números y signos de puntuación."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Fortaleza: débil"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Fortaleza: baja"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Fortaleza: media"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Fortaleza: buena"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Fortaleza: alta"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Atajo;Repetir;Parpadear;"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Zona del cortafuegos"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Predeterminada"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "La zona define el nivel de confianza de la conexión"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "0"
+#~ msgstr "0"
+
+#~| msgid "<small><i>Short</i></small>"
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Su cuenta</small>"
+
+#~ msgid "Add Account"
+#~ msgstr "Añadir cuenta"
+
+#~ msgid "Mail"
+#~ msgstr "Correo"
+
+#~ msgid "Calendar"
+#~ msgstr "Calendario"
+
+#~ msgid "Contacts"
+#~ msgstr "Contactos"
+
+#~ msgid "Chat"
+#~ msgstr "Chat"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Configurando"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nivel de tóner"
+
+#~ msgid "Supply Level"
+#~ msgstr "Nivel del suministro"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Instalando"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u activo"
+#~ msgstr[1] "%u activos"
+
+#~| msgid "Add"
+#~ msgctxt "button"
+#~ msgid "Add"
+#~ msgstr "Añadir"
+
+#~ msgid "Supply"
+#~ msgstr "Suministro"
+
+#~ msgid "Jobs"
+#~ msgstr "Trabajos"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Mostrar _tareas"
+
+#~ msgid "label"
+#~ msgstr "etiqueta"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "I_mprimir página de prueba"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Otras cuentas"
+
+#~ msgctxt "button"
+#~ msgid "Add Printer"
+#~ msgstr "Añadir impresora"
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Establecer atajo"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Banners de notificación"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "_Banners de notificación"
+
+#~ msgid "Error creating account"
+#~ msgstr "Error al crear la cuenta"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "¿Está seguro de que quiere quitar la cuenta?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Esto no quitará la cuenta en el servidor."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "No hay cuentas en línea configuradas"
+
+#~ msgid "Add an online account"
+#~ msgstr "Añadir una cuenta en línea"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "añadir una cuenta permite que sus aplicaciones accedan a documentos, "
+#~ "correo-e, contactos, calendario, chat y más."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Arriba"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Abajo"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Ninguna"
+
+#~ msgid "Left Ring"
+#~ msgstr "Anillo izquierdo"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Modo del anillo izquierdo nº %d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Modo del anillo derecho nº %d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Banda táctil izquierda"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Modo de la banda táctil izquierda nº %d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Banda táctil derecha"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Modo de la banda táctil derecha nº %d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Modo de cambio del anillo táctil izquierdo"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Modo de cambio del anillo táctil derecho"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Modo de cambio de la banda táctil izquierda"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Modo de cambio de la banda táctil derecha"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Modo de cambio nº %d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Botón izquierdo nº %d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Botón derecho nº %d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Botón superior nº %d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Botón inferior nº %d"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Pulsación del botón izquierdo del ratón"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Desplazar hacia arriba"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Desplazar hacia abajo"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Desplazar hacia la derecha"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Añadir una impresora nueva"
+
+#~ msgid "No printers detected."
+#~ msgstr "No se ha detectado ninguna impresora."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr ""
+#~ "Atajo de teclado para <b>%s</b>. Introduzca el atajo nuevo para cambiarlo."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Para editar un atajo nuevo pulse en la fila y mantenga pulsadas las "
+#~ "teclas nuevas, o pulse Retroceso para eliminarla."
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Error al iniciar sesión en la cuenta"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Las credenciales han caducado."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Firme para activar esta cuenta."
+
+#~ msgid "_Sign In"
+#~ msgstr "Iniciar _sesión"
+
+#~ msgid "C_ommand:"
+#~ msgstr "C_omando:"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Quitar atajo"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Acción desconocida>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "No se puede usar la combinación de teclas «%s» porque se haría imposible "
+#~ "escribir usando esta tecla.\n"
+#~ "Por favor, inténtelo con una tecla como Control, Alt o Mayús. al mismo "
+#~ "tiempo."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "La combinación «%s» ya se está usando para\n"
+#~ "«%s»"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Si reasigna la combinación a «%s» se desactivará la combinación «%s»."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Reasignar"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "El atajo «%s» tiene un atajo «%s» asociado. ¿Quiere establecerlo "
+#~ "automáticamente a «%s»?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "«%s» está actualmente asociado con «%s», este atajo se desactivará si "
+#~ "continúa."
+
+#~ msgid "_Assign"
+#~ msgstr "_Asignar"
+
+#~ msgid "Add User Account"
+#~ msgstr "Añadir cuenta de usuario"
+
+#~ msgid "Login History"
+#~ msgstr "Histórico de inicio de sesión"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Añadir conexión de red"
+
+#~ msgid "Welcome to the Control Center"
+#~ msgstr "Bienvenido/a al centro de control"
+
+#~ msgid "Select a panel in the sidelist to see the available options"
+#~ msgstr ""
+#~ "Seleccione un panel en la lista lateral para ver las opciones disponibles"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "No se ha elegido ningún certificado CA"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "No usar un certificado de Certificate Authority (CA) puede dar lugar a "
+#~ "conexiones inseguras a redes inalámbricas promiscuas. ¿Quiere elegir un "
+#~ "certificado Certificate Authority?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignorar"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Elija un certificado CA"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "_Preguntar esta contraseña cada vez"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "No a_visarme de nuevo"
+
+#~ msgid "Yes"
+#~ msgstr "Sí"
+
+#~ msgid "Bond"
+#~ msgstr "Bond"
+
+#~ msgid "Team"
+#~ msgstr "Equipo"
+
+#~ msgid "Bridge"
+#~ msgstr "Puente"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "No se pudieron cargar los complementos de VPN"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Asociar esclavos"
+
+#~ msgid "(none)"
+#~ msgstr "(ninguno)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Asociar esclavos"
+
+#~ msgid "Team slaves"
+#~ msgstr "Esclavos del equipo"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "El dispositivo InfiniBand no soporta el modo conectado"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Otra"
+
+#~ msgid "_Verify"
+#~ msgstr "_Verificar"
+
+#~ msgid "Login Options"
+#~ msgstr "Opciones de inicio de sesión"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Ya existe un nombre de usuario con el nombre «%s»."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Usados para determinar su ubicación geográfica"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Reanudar la impresión"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Pausar la impresión"
+
+#~ msgid "Cancel Print Job"
+#~ msgstr "Cancelar trabajo de impresión"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Retenido"
+
+#~ msgid "Job Title"
+#~ msgstr "Título del trabajo"
+
+#~ msgid "Job State"
+#~ msgstr "Estado del trabajo"
+
+#~ msgid "Done"
+#~ msgstr "Hecho"
+
+#~ msgid "Time _Zone"
+#~ msgstr "_Zona horaria"
+
+#~ msgid "Password:"
+#~ msgstr "Contraseña:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "_Repetición de teclas"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "Parpadeo del _cursor"
+
+#~ msgid "Zoom"
+#~ msgstr "Ampliación"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Retardo:"
+
+#~ msgid "_Speed:"
+#~ msgstr "Ve_locidad:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Corto"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Largo"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Rápida"
+
+#~ msgid "S_peed:"
+#~ msgstr "Ve_locidad:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Probar su configuración"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Rápida"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Izquierdo"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Derecho"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Velocidad del puntero"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lento"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rápido"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lento"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rápido"
+
+#~ msgid "No printers available"
+#~ msgstr "No hay impresoras disponibles"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Añadir impresora nueva"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Los dispositivos inalámbricos requieren electricidad adicional"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "La compartición por Bluetooth le permite compartir archivos con otros "
+#~ "dispositivos con Bluetooth activado"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Recibir sólo de dispositivos de confianza"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Guardar los archivos recibidos en la carpeta de descargas"
+
+#~ msgid "Show help options"
+#~ msgstr "Mostrar opciones de ayuda"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Ejecutar «%s --help» para ver una lista completa de las opciones de "
+#~ "comando disponibles.\n"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "_Cuando la carga está críticamente baja"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Apaga los dispositivos inalámbricos"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Desac_tivar al escribir"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr ""
+#~ "Los servicios de red del sistema no son compatibles con esta versión."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Mostrar banners emergentes"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Ver en la pantalla de bloqueo"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Mostrar los banners emergentes"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr ""
+#~ "Introducir la dirección de una impresa o un texto para filtrar los "
+#~ "resultados"
+
+#~ msgid "Sorry"
+#~ msgstr "Disculpe"
+
+#~ msgid "United States"
+#~ msgstr "Estados Unidos"
+
+#~ msgid "Germany"
+#~ msgstr "Alemania"
+
+#~ msgid "France"
+#~ msgstr "Francia"
+
+#~ msgid "Spain"
+#~ msgstr "España"
+
+#~ msgid "China"
+#~ msgstr "China"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Compartir multimedia en esta red"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Carpetas compartidas"
+
+#~ msgid "column"
+#~ msgstr "columna"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Quitar carpeta"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Compartir la carpeta pública en esta red"
+
+#~ msgid "Immediately"
+#~ msgstr "Inmediatamente"
+
+#~ msgid "Remote View"
+#~ msgstr "Vista remota"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Aprobar todas las conexiones"
+
+#~ msgid "Install Updates"
+#~ msgstr "Instalar actualizaciones"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Sistema al día"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Buscar impresoras de red o filtrar resultados"
+
+#~ msgid "_Default"
+#~ msgstr "_Predeterminada"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Configurar un dispositivo nuevo"
+
+#~ msgid "Paired"
+#~ msgstr "Emparejado"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Configuración del ratón y del panel táctil"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Configuración del teclado"
+
+#~ msgid "Send Files…"
+#~ msgstr "Enviar archivos…"
+
+#~ msgid "Visibility"
+#~ msgstr "Visibilidad"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Visibilidad de «%s»"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "¿Quitar «%s» de la lista de dispositivos?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Si quita el dispositivo, deberá configurarlo otra vez antes de usarlo "
+#~ "nuevamente."
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Compartir carpeta pública"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Compartir sólo con dispositivos de confianza"
+
+#~ msgid "Device type:"
+#~ msgstr "Tipo de dispositivo:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Fabricante:"
+
+#~ msgid "Model:"
+#~ msgstr "Modelo:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Se pueden arrastrar archivos de imagen en esta ventana para autocompletar "
+#~ "los campos superiores."
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "Mostrar su pantalla primaria también en este monitor"
+
+#~ msgid "Combine"
+#~ msgstr "Combinar"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "Unir a la pantalla primaria para crear un espacio adicional"
+
+#~ msgid "Don't use the display"
+#~ msgstr "No usar la pantalla"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Preferencias del ratón"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Seleccionar la interfaz que usar para el servicio nuevo"
+
+#~ msgid "C_reate…"
+#~ msgstr "C_rear…"
+
+#~ msgid "_Interface"
+#~ msgstr "_Interfaz"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Ninguno"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Cambiando la foto para:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Elegir una imagen que se mostrará en la pantalla de inicio de sesión para "
+#~ "esta cuenta."
+
+#~ msgid "Gallery"
+#~ msgstr "Colección"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Tomar una fotografía"
+
+#~ msgid "Browse"
+#~ msgstr "Examinar"
+
+#~ msgid "Photograph"
+#~ msgstr "Fotografía"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Alternar entre AM y PM"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "Capacidad estimada de la batería: %s"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Horario"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 grados"
+
+#~ msgid "Mirrored Displays"
+#~ msgstr "Pantallas en espejo"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Seleccionar un monitor para cambiar sus propiedades; arrastrarlo lo "
+#~ "reubica."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %H:%M"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "No se pudieron detectar las pantallas"
+
+#~ msgid ""
+#~ "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+#~ "ownCloud;"
+#~ msgstr ""
+#~ "Google;Facebook;Twitter;Yahoo;Web;En línea;Chat;Calendario;Correo-e;"
+#~ "Contacto;ownCloud;"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Resolución"
+
+#~ msgid "R_otation"
+#~ msgstr "R_otación"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Espejar pantallas"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Nota: puede limitar las opciones de resolución"
+
+#~ msgid "_Region:"
+#~ msgstr "_Región:"
+
+#~ msgid "_City:"
+#~ msgstr "_Ciudad:"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Ajustar la hora una hora hacia adelante."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Ajustar la hora una hora hacia atrás."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Ajustar la hora un minuto hacia adelante."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Ajustar la hora un minuto hacia atrás."
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgid "Hidden"
+#~ msgstr "Oculto"
+
+#~ msgid "Visible"
+#~ msgstr "Visible"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "Nombre y visibilidad"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "Controla cómo aparece en la pantalla y en la red."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "Mostrar el nombre _completo en la barra superior"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "Mostrar el nombre completo en la pantalla de b_loqueo"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "Modo _silencioso"
+
+#~ msgid "Show Status When _Inactive"
+#~ msgstr "Mostrar el estado cuando esté _inactivo"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "No se pudo guardar la configuración del monitor"
+
+#~ msgid "_Login Name"
+#~ msgstr "Nombre de _inicio de sesión"
+
+#~ msgid "Login _Password"
+#~ msgstr "_Contraseña de inicio de sesión"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "Las contraseñas no coinciden"
+
+#~ msgid ""
+#~ "Login not recognized.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Inicio de sesión no reconocido.\n"
+#~ "Inténtelo de nuevo."
+
+#~ msgid "Domain not found."
+#~ msgstr "Dominio no encontrado."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more characters."
+#~ msgstr "Pruebe añadiendo más caracteres."
+
+#~ msgid "Switch Modes"
+#~ msgstr "Cambiar modos"
+
+#~ msgid "Action"
+#~ msgstr "Acción"
+
+#~ msgid "No shortcut set"
+#~ msgstr "No existe ningún atajo configurado"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Alto/invertido"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Teclado en pantalla"
+
+#~ msgid "OnBoard"
+#~ msgstr "EnPantalla"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Pitar al usar Bloq. Num. y Bloq. Mayús."
+
+#~ msgid "Turn on or off:"
+#~ msgstr "Activar o desactivar:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Ampliación"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Ampliar:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Reducir:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "GOP cerrado"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Mostrar una descripción textual de la voz y los sonidos"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "Teclado en pantalla"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "Corto"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "Largo"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Pitar cuando la tecla es"
+
+#~ msgid "pressed"
+#~ msgstr "pulsada"
+
+#~ msgid "accepted"
+#~ msgstr "aceptada"
+
+#~ msgid "rejected"
+#~ msgstr "rechazada"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "R_etardo de aceptación:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Controlar el puntero usando el teclado numérico"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Ratón de vídeo"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Controlar el puntero usando la cámara de vídeo."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "Pequeño"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "Grande"
+
+#~ msgid "Next Week"
+#~ msgstr "Siguiente semana"
+
+#~ msgid "Next week"
+#~ msgstr "La semana que viene"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "El c_ontenido se adhiere a los dedos"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Iniciar sesión sin contraseña"
+
+#~ msgid "Disable this account"
+#~ msgstr "Desactivar esta cuenta"
+
+#~ msgid "Enable this account"
+#~ msgstr "Activar esta cuenta"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "C_onfirmar contraseña"
+
+#~ msgid "_Action"
+#~ msgstr "_Acción"
+
+#~ msgid "Changing password for"
+#~ msgstr "Cambiando la contraseña para"
+
+#~ msgid "_Show password"
+#~ msgstr "_Mostrar contraseña"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Cómo elegir una contraseña fuerte"
+
+#~ msgid "_Generate a password"
+#~ msgstr "_Generar una contraseña"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "Debe introducir una contraseña"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "La contraseña nueva no es suficientemente segura"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "Debe confirmar la contraseña"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "Debe introducir su contraseña actual"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "La contraseña actual no es correcta"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Demasiado corta"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Débil"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Regular"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Buena"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Fuerte"
+
+#~ msgid "_Local Account"
+#~ msgstr "Cuenta _local"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "Consejo: dominio de la empresa o nombre real"
+
+#~ msgid "C_ontinue"
+#~ msgstr "C_ontinuar"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "No es suficientemente buena"
+
+#~ msgid "Left Shift"
+#~ msgstr "Mayús izquierda"
+
+#~ msgid "Right Shift"
+#~ msgstr "Mayús derecha"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Alt izquierda+Mayús"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Alt derecha+Mayús"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Ctrl izquierdo +Mayús"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Ctrl derecha+Mayús"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Izquierda+Mayús derecha"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Izquierda+Ctrl derecho"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Mayús"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Mayús"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Mayús+Bloq. Mayús."
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Bloq. Mayús."
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Bloq. Mayús."
+
+#~ msgid "Export"
+#~ msgstr "Exportar"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "Rápida"
+
+#~ msgid "_Options…"
+#~ msgstr "_Opciones…"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "Las credenciales han expirado. Inicie sesión de nuevo."
+
+#~ msgid "_Log In"
+#~ msgstr "_Iniciar sesión"
+
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "Ninguna"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Color management settings"
+#~ msgstr "Configuración de gestión de color"
+
+#~ msgid "British English"
+#~ msgstr "Inglés británico"
+
+#~ msgid "Spanish"
+#~ msgstr "Español"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chino (simplificado)"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Panel de preferencias de la fecha y hora"
+
+#~ msgid "Layout Settings"
+#~ msgstr "Configuración de la distribución"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Establecer sus preferencias del ratón y del panel táctil"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "Gestionar cuentas en línea"
+
+#~ msgid "Power management settings"
+#~ msgstr "Gestión de energía"
+
+#~ msgid "Manufacturers"
+#~ msgstr "Fabricantes"
+
+#~ msgid "Drivers"
+#~ msgstr "Controladores"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "Cambiar su configuración de región e idioma"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "La pantalla de inicio de sesión, las cuentas del sistema y las cuentas de "
+#~ "los usuarios nuevos usan la configuración de «Región e idioma» del sistema"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "La pantalla de inicio de sesión, las cuentas del sistema y las cuentas de "
+#~ "los usuarios nuevos usan la configuración de «Región e idioma» del "
+#~ "sistema. Puede cambiar la configuración del sistema para que coincida con "
+#~ "la suya."
+
+#~ msgid "Copy Settings"
+#~ msgstr "Copiar configuración"
+
+#~ msgid "Copy Settings…"
+#~ msgstr "Copiar configuración…"
+
+#~ msgid "Region and Language"
+#~ msgstr "Región e idioma"
+
+#~ msgid "Add Language"
+#~ msgstr "Añadir idioma"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr ""
+#~ "Seleccionar una región (el cambio se aplicará la próxima vez que inicie "
+#~ "sesión)"
+
+#~ msgid "Add Region"
+#~ msgstr "Añadir región"
+
+#~ msgid "Remove Region"
+#~ msgstr "Quitar región"
+
+#~ msgid "Currency"
+#~ msgstr "Divisa"
+
+#~ msgid "Examples"
+#~ msgstr "Ejemplos"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "Seleccionar teclados u otras fuentes de entrada"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Espacio"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "Configuración de atajos"
+
+#~ msgid "Input source:"
+#~ msgstr "Fuente de entrada:"
+
+#~ msgid "Format:"
+#~ msgstr "Formato:"
+
+#~ msgid "Your settings"
+#~ msgstr "Su configuración"
+
+#~ msgid "System settings"
+#~ msgstr "Configuración del sistema"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Preferencias del acceso universal"
+
+#~ msgid "_Hint"
+#~ msgstr "C_onsejo"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "Este consejo se puede mostrar en la pantalla de inicio. Será visible a "
+#~ "todos los usuarios de este sistema. <b>No</b> incluya aquí la contraseña."
+
+#~ msgid "Fair"
+#~ msgstr "Regular"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Establezca las preferencias de su tableta Wacom"
+
+#~ msgid "Mesh"
+#~ msgstr "Malla"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "Ha cambiado el portador/enlace"
+
+#~ msgid "_Mark As Inactive After"
+#~ msgstr "_Marcar como inactivo después de"
+
+#~ msgid "Don't retain history"
+#~ msgstr "No recordar el histórico"
+
+#~ msgid "Out of range"
+#~ msgstr "Fuera de rango"
+
+#~ msgid "_Disconnect"
+#~ msgstr "_Desconectar"
+
+#~ msgid "_Connect"
+#~ msgstr "_Conectar"
+
+#~ msgid "_Settings…"
+#~ msgstr "_Configuración…"
+
+#, fuzzy
+#~| msgid "<b>Locate Pointer</b>"
+#~ msgid "<b>Remote Login</b>"
+#~ msgstr "<b>Localizar el puntero</b>"
+
+#~ msgid "Browse Files..."
+#~ msgstr "Examinar archivos…"
+
+#~ msgid "Create virtual device"
+#~ msgstr "Crear un dispositivo virtual"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Perfiles disponibles para pantallas"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Perfiles disponibles para escáneres"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Perfiles disponibles para impresoras"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Perfiles disponibles para cámaras"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Perfiles disponibles para cámaras web"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i año"
+#~ msgstr[1] "%i años"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i mes"
+#~ msgstr[1] "%i meses"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i semana"
+#~ msgstr[1] "%i semanas"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "Menos de una semana"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "Este dispositivo no tiene gestión de color."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr ""
+#~ "Este dispositivo está usando los datos de calibración de fabricación."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "Este dispositivo no tiene un perfil apto para corrección de color en toda "
+#~ "la pantalla."
+
+#~ msgid "Not specified"
+#~ msgstr "Sin especificar"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "No se ha detectado ningún dispositivo que tenga gestión de color"
+
+#~ msgid "Add device"
+#~ msgstr "Añadir dispositivo"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "Añadir un dispositivo virtual"
+
+#~ msgid "English"
+#~ msgstr "Inglés"
+
+#~ msgid "French"
+#~ msgstr "Francés"
+
+#~ msgid "Russian"
+#~ msgstr "Ruso"
+
+#~ msgid "Arabic"
+#~ msgstr "Árabe"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "Modelo desconocido"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr ""
+#~ "El siguiente inicio de sesión intentará usar la decoración estándar."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "El siguiente inicio de sesión usará el modo alternativo, pensado para "
+#~ "hardware de gráficos no soportado."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Alternativo"
+
+#~ msgid "_Other Media..."
+#~ msgstr "_Otros soportes…"
+
+#~ msgid "Experience"
+#~ msgstr "Decoración"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "_Forzar modo alternativo"
+
+#~ msgid "_Options..."
+#~ msgstr "_Opciones…"
+
+#~ msgid "C_reate..."
+#~ msgstr "C_rear…"
+
+#~ msgid "_Settings..."
+#~ msgstr "C_onfiguración…"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "Batería baja, quedan %s"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "Usando la batería: quedan %s"
+
+#~ msgid "Using battery power"
+#~ msgstr "Usando la batería"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "Cargando: carga completada"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "Usando el SAI: quedan %s"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "SAI bajo"
+
+#~ msgid "Using UPS power"
+#~ msgstr "Usando el SAI"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "La batería está cargada completamente"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "La batería secundaria está vacía"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "Cargando: cargada completamente"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "Consejo: el <a href=\"screen\">brillo de la pantalla</a> influye en la "
+#~ "cantidad de energía que se usa"
+
+#~ msgid "Don't suspend"
+#~ msgstr "No suspender"
+
+#~ msgid "_Show"
+#~ msgstr "Mo_strar"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "Copiar configuración…"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Seleccionar un idioma para mostrar (el cambio se aplicará la próxima vez "
+#~ "que inicie sesión)"
+
+#~ msgid "Install languages..."
+#~ msgstr "Instalar idiomas…"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "Brillo y bloqueo"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Brillo;Bloquear;Oscurecer;Iluminar;Pantalla;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "_Oscurecer la pantalla para ahorrar energía"
+
+#~ msgid "_Turn screen off when inactive for:"
+#~ msgstr "_Apagar la pantalla tras una inactividad de:"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "No bloquear cuando esté en casa"
+
+#~ msgid "Locations..."
+#~ msgstr "Ubicaciones…"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Activar el código de depuración"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " : Miniaplicación Control de volumen de GNOME"
+
+#~ msgid "Volume Control"
+#~ msgstr "Control de volumen"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Mostrar el control de volumen del escritorio"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Volumen de salida del sonido"
+
+#~ msgid "_Mute"
+#~ msgstr "_Silenciar"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "Prefere_ncias de sonido"
+
+#~ msgid "Muted"
+#~ msgstr "Silenciado"
+
+#~ msgid "Options..."
+#~ msgstr "Opciones…"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Examinar para buscar más imágenes…"
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "No existe ningún usuario con el nombre «%s»"
+
+#~ msgid "This user does not exist."
+#~ msgstr "Este usuario no existe."
+
+#~ msgid "Map Buttons..."
+#~ msgstr "Mapear botones…"
+
+#~ msgid "Calibrate..."
+#~ msgstr "Calibrar…"
+
+#~ msgid "- System Settings"
+#~ msgstr ": Configuración del sistema"
+
+#~ msgid "System Settings"
+#~ msgstr "Configuración del sistema"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "Red;Inalámbrica;IP;LAN;Proxy;"
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "Punto de acceso inalámbrico"
+
+#~ msgid "Wireless"
+#~ msgstr "Inalámbrica"
+
+#~ msgid "Remove Language"
+#~ msgstr "Quitar idioma"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "Ninguna"
+
+#~ msgid "Security Key"
+#~ msgstr "Clave de seguridad"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "Máscara de subred"
+
+#~ msgid "_Search by Address"
+#~ msgstr "Bu_scar por dirección"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD no está en ejecución. La detección de impresoras de red "
+#~ "necesita que los servicios  mdns, ipp, ipp-client y samba-client estén "
+#~ "activados en el cortafuegos."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "Local"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "De red"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "Configuración automática"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "Abrir el cortafuegos para conexiones mDNS"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Abrir el cortafuegos para conexiones Samba"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "Abrir el cortafuegos para conexiones IPP"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr ""
+#~ "Para probar su configuración pruebe a pulsar dos veces sobre la cara."
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_Diestro"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Zurdo"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "M_ostrar la posición del puntero al pulsar la tecla Control"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "A_celeración:"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Sensibilidad:"
+
+#~ msgctxt "Mouse sensitivity"
+#~ msgid "Low"
+#~ msgstr "Baja"
+
+#~ msgctxt "Mouse sensitivity"
+#~ msgid "High"
+#~ msgstr "Alta"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "Arrastrar y soltar"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "U_mbral:"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "Umbral de arrastre"
+
+#~ msgid "_Timeout:"
+#~ msgstr "_Tiempo de espera:"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "Activar pul_saciones del ratón con el touchpad"
+
+#~ msgid "_Disabled"
+#~ msgstr "_Desactivado"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "Añadir fondo"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "Quitar fondo"
+
+#~ msgid "Swap colors"
+#~ msgstr "Intercambiar colores"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Gradiente horizontal"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Gradiente vertical"
+
+#~ msgid "Solid Color"
+#~ msgstr "Color sólido"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "Colores y gradientes"
+
+#~ msgid "_Back"
+#~ msgstr "_Atrás"
+
+#~ msgid "Allowed users"
+#~ msgstr "Usuarios permitidos"
+
+#~ msgid "Acti_on:"
+#~ msgstr "_Acción:"
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "¿Crear el «hotspot» de todas formas?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "¿Desconectarse de %s y crear un «hotspot» nuevo?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "Esta es su única conexión a Internet."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "Crear «_hotspot»"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "Otra…"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "_Detener «hotspot»…"
+
+#~ msgid "_Network Name"
+#~ msgstr "_Nombre de red"
+
+#~ msgid "Disable VPN"
+#~ msgstr "Desactivar VPN"
+
+#~ msgid "HTTP Port"
+#~ msgstr "Puerto HTTP"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "Puerto HTTPS"
+
+#~ msgid "FTP Port"
+#~ msgstr "Puerto FTP"
+
+#~ msgid "Select an account"
+#~ msgstr "Seleccionar una cuenta"
+
+#~ msgid "Tip:"
+#~ msgstr "Consejo:"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "afecta a cuánta energía se usa"
+
+#~ msgid "Create new account"
+#~ msgstr "Crear una cuenta nueva"
+
+#~ msgid "Cr_eate"
+#~ msgstr "Cr_ear"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "Para añadir una cuenta nueva, seleccione primero el tipo de cuenta"
+
+#~ msgid "Account Type:"
+#~ msgstr "Tipo de cuenta:"
+
+#~ msgid "_Add..."
+#~ msgstr "_Añadir…"
+
+#~ msgid "Add Layout"
+#~ msgstr "Añadir distribución"
+
+#~ msgid "Remove Layout"
+#~ msgstr "Quitar distribución"
+
+#~ msgid "Preview Layout"
+#~ msgstr "Vista previa de la distribución"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "Las ventanas nuevas usan la distribución predeterminada"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "Las ventanas nuevas usan la distribución de la ventana activa"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "Restablecer valores _predeterminados"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Reemplazar la configuración de distribución de teclado actual\n"
+#~ "con la configuración predeterminada"
+
+#~ msgid "Layouts"
+#~ msgstr "Distribuciones"
+
+#~ msgid "Layout"
+#~ msgstr "Distribución"
+
+#~ msgid "1/4 Screen"
+#~ msgstr "1/4 de pantalla"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 de pantalla"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 de pantalla"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "Elegir una contraseña generada"
+
+#~ msgid "More choices..."
+#~ msgstr "Más opciones…"
+
+#~ msgid "Change contrast:"
+#~ msgstr "Cambiar contraste:"
+
+#~ msgid "_Text size:"
+#~ msgstr "_Tamaño del texto:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "Ampliación"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "Teclear aquí para probar la configuración"
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Tableta gráfica Wacom"
+
+#~ msgid "Display Mapping..."
+#~ msgstr "Mostrar mapeo…"
+
+#~ msgid "Battery discharging"
+#~ msgstr "La batería se está descargando"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s hasta cargarse (%.0lf%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s hasta descargarse (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% cargado"
+
+#~ msgid "Always"
+#~ msgstr "Siempre"
+
+#~ msgid "Color and Opacity"
+#~ msgstr "Color y opacidad"
+
+#~ msgid "Image moves with the mouse pointer"
+#~ msgstr "La imagen se mueve con el puntero del ratón"
+
+#~ msgid "Image scrolls at screen edges"
+#~ msgstr "La imagen se desliza en los bordes de la pantalla"
+
+#~ msgid "Moveable lens - magnified view follows mouse movements"
+#~ msgstr ""
+#~ "Lentes movibles: la vista magnificada sigue los movimientos del ratón"
+
+#~ msgid "Position of magnified view on screen"
+#~ msgstr "Posición de la vista magnificada en la pantalla"
+
+#~ msgid "Push"
+#~ msgstr "Empujar"
+
+#~ msgid "Show"
+#~ msgstr "Mostrar"
+
+#~ msgid "Show crosshairs intersection"
+#~ msgstr "Mostrar la intersección de las cruces"
+
+#~ msgid "To keep the pointer centered"
+#~ msgstr "Mantener el puntero centrado"
+
+#~ msgid "To keep the pointer visible"
+#~ msgstr "Mantener el puntero visible"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr ""
+#~ "No se pudo obtener la sesión del bus al aplicar la configuración de la "
+#~ "pantalla"
+
+#~ msgid "_Photos:"
+#~ msgstr "_Fotos:"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Demasiadas combinaciones personalizadas"
+
+#~ msgid "Key"
+#~ msgstr "Clave"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Clave de gconf a la que está asociado este editor de propiedades"
+
+#~ msgid "Callback"
+#~ msgstr "Retorno de llamada"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Emitir este retorno de llamada cuando cambie el valor asociado con la "
+#~ "clave"
+
+#~ msgid "Change set"
+#~ msgstr "Conjunto de cambios"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Conjunto de cambios de gconf que contiene datos que deben remitirse al "
+#~ "cliente de gconf cuando se apliquen"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Conversión a retorno de llamada del widget"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Retorno de llamada que se debe emitir cuando se vayan a convertir datos "
+#~ "de gconf al widget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Conversión desde el retorno de llamada del widget"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Retorno de llamada que se debe emitir cuando se vayan a convertir datos "
+#~ "del widget a gconf"
+
+#~ msgid "UI Control"
+#~ msgstr "Control de IU"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Objeto que controla la propiedad (generalmente, un widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Datos de objeto del editor de propiedades"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr ""
+#~ "Datos personalizados requeridos por el editor de propiedades específico"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Retorno de llamada de liberación de datos del editor de propiedades"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Retorno de llamada que se debe emitir cuando se vayan a liberar datos de "
+#~ "objeto del editor de propiedades"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "No se ha podido encontrar el archivo «%s».\n"
+#~ "\n"
+#~ "Compruebe si existe y vuelva a intentarlo o elija una imagen de fondo "
+#~ "distinta."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "No es posible  abrir el archivo «%s».\n"
+#~ "Puede que se trate de un tipo de imagen que aún no se admite.\n"
+#~ "\n"
+#~ "Seleccione una imagen distinta."
+
+#~ msgid "Please select an image."
+#~ msgstr "Seleccione una imagen."
+
+#~ msgid "Toggle contrast"
+#~ msgstr "Cambiar contraste"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "Conmutar el magnificador"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "Conmutar el lector de pantalla"
+
+#~ msgid "Accelerator key"
+#~ msgstr "Tecla de la combinación"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Modificadores de la combinación"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Código de tecla de la combinación"
+
+#~ msgid "Accel Mode"
+#~ msgstr "Modo de la combinación"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "El tipo de combinación."
+
+#~ msgid "Create a user"
+#~ msgstr "Crear un usuario"
+
+#~ msgid "Ask me"
+#~ msgstr "Preguntarme"
+
+#~ msgid "Shutdown"
+#~ msgstr "Apagar"
+
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr "Debajo sólo se listarán perfiles compatibles con el dispositivo."
+
+#~ msgid "Upside-down"
+#~ msgstr "Hacia abajo"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "Soportes y autoejecución"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "Configurar los soportes y preferencias de autoejecución"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "cd;dvd;usb;sonido;vídeo;disco;"
+
+#~ msgid "On AC _power:"
+#~ msgstr "_Con adaptador de corriente:"
+
+#~ msgid "_Turn off after:"
+#~ msgstr "_Apagar después de:"
+
+#~ msgid "Wacom"
+#~ msgstr "Wacom"
+
+#~ msgid "When the _sleep button is pressed:"
+#~ msgstr "Al pulsar el botón de _suspensión:"
+
+#~ msgid "24-_Hour Time"
+#~ msgstr "Formato 24 _horas"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "teclado;ratón;accesibilidad;a11y;"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f KiB"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f MiB"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f GiB"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TiB"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PiB"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EiB"
+
+#~ msgid "<b>Example</b>"
+#~ msgstr "<b>Ejemplo</b>"
+
+#~ msgid "<b>System settings</b>"
+#~ msgstr "<b>Configuración del sistema</b>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">Alto/invertido</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">Alto</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">Bajo</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">Normal</span>"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "Usar la distribución predeterminada en las ventanas nuevas"
+
+#~ msgid "Use previous window's layout in new windows"
+#~ msgstr "Usar la distribución de la ventana anterior en las ventanas nuevas"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#~ msgid "Current network location"
+#~ msgstr "Ubicación de red actual"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "URL para más fondos"
+
+#~ msgid "More themes URL"
+#~ msgstr "URL para más temas"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "Establézcalo al nombre de su ubicación actual. Se usa para determinar la "
+#~ "configuración apropiada del proxy de red."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "URL donde obtener más fondos para el escritorio. Si se establece a una "
+#~ "cadena vacía el enlace no aparecerá."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "URL donde obtener más temas para el escritorio. Si se establece a una "
+#~ "cadena vacía el enlace no aparecerá."
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "El diálogo está desbloqueado.\n"
+#~ "Pulse para prevenir cambios en él."
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "El diálogo está bloqueado.\n"
+#~ "Pulse para realizar cambios."
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "La política del sistema impide los cambios.\n"
+#~ "Contacte con su administrador de sistemas."
+
+#~ msgid "Photos"
+#~ msgstr "Fotos"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "_Aceleración:"
+
+#~ msgid "Beep when a modifer key is pressed"
+#~ msgstr "Pitar al pulsar una tecla modificadora"
+
+#~ msgid "An error has occured during a maintenance command."
+#~ msgstr "Ocurrió un error durante un comando de mantenimiento."
+
+#~ msgid "DSL"
+#~ msgstr "DSL"
+
+#~ msgid "Info"
+#~ msgstr "Información"
+
+#~ msgid "16"
+#~ msgstr "16"
+
+#~ msgid "2010"
+#~ msgstr "2010"
+
+#~ msgid "Set the system proxy settings"
+#~ msgstr "Configurar los ajustes del proxy del sistema"
+
+#~ msgid "Virtual private network"
+#~ msgstr "Red privada virtual"
+
+#~ msgid "The running NetworkManager version is not compatible (too new)."
+#~ msgstr ""
+#~ "La versión de NetworkManager en ejecución no es compatible (muy reciente)"
+
+#~ msgid "The running NetworkManager version is not compatible (too old)."
+#~ msgstr ""
+#~ "La versión de NetworkManager en ejecución no es compatible (muy antigua)"
+
+#~ msgid "IP Address:"
+#~ msgstr "Dirección IP:"
+
+#~ msgid "Preparing connection"
+#~ msgstr "Preparando la conexión"
+
+#~ msgid "Preparing"
+#~ msgstr "Preparando"
+
+#~ msgctxt "Account type"
+#~ msgid "Supervised"
+#~ msgstr "Supervisado"
+
+#~ msgid "Secure HTTP Proxy:"
+#~ msgstr "Proxy para HTTP seguro:"
+
+#~ msgid "LowContrast"
+#~ msgstr "ContrasteBajo"
+
+#~ msgid "Ctrl+Alt+0"
+#~ msgstr "Ctrl+Alt+0"
+
+#~ msgid "Ctrl+Alt+4"
+#~ msgstr "Ctrl+Alt+4"
+
+#~ msgid "Ctrl+Alt+8"
+#~ msgstr "Ctrl+Alt+8"
+
+#~ msgid "Ctrl+Alt+="
+#~ msgstr "Ctrl+Alt+="
+
+#~ msgid "Shift+Ctrl+Alt+-"
+#~ msgstr "Shift+Ctrl+Alt+-"
+
+#~ msgid "Shift+Ctrl+Alt+="
+#~ msgstr "Shift+Ctrl+Alt+="
+
+#~ msgid "Use an alternative form of text input"
+#~ msgstr "Usar una forma alternativa de entrada de texto"
+
+#~ msgid "Language:"
+#~ msgstr "Idioma:"
+
+#~ msgid "%i kb/s"
+#~ msgstr "%i kb/s"
+
+#~ msgid "Graphics:"
+#~ msgstr "Gráficos:"
+
+#, fuzzy
+#~ msgid "Always use fallback:"
+#~ msgstr "Usar siempre reserva:"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr ""
+#~ "Error al borrar una combinación de teclas en la base de datos de "
+#~ "configuración: %s"
+
+#~ msgid "More Info"
+#~ msgstr "Más información"
+
+#~ msgid "Idle"
+#~ msgstr "Inactiva"
+
+#~ msgid "By _country"
+#~ msgstr "Por _país"
+
+#~ msgid "By _language"
+#~ msgstr "Por _idioma"
+
+#~ msgid "Preview:"
+#~ msgstr "Vista previa:"
+
+#~ msgid "_Country:"
+#~ msgstr "_País:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variantes:"
+
+#~ msgid "Upside Down"
+#~ msgstr "Hacia abajo"
+
+#~ msgid "\t"
+#~ msgstr "\t"
+
+#~ msgid "Description:"
+#~ msgstr "Descripción:"
+
+#~ msgid "Queue"
+#~ msgstr "Cola"
+
+#~ msgid "Show / hide printer's jobs"
+#~ msgstr "Mostrar / ocultar trabajos de la impresora"
+
+#~ msgid "Battery power and inactive for:"
+#~ msgstr "Alimentación con batería e inactividad para:"
+
+#~ msgid "Put the computer to sleep when on:"
+#~ msgstr "Poner el equipo en reposo cuando:"
+
+#~ msgid "pause-toolbutton"
+#~ msgstr "pause-toolbutton"
+
+#~ msgid "resume-toolbutton"
+#~ msgstr "resume-toolbutton"
+
+#~ msgid "stop-toolbutton"
+#~ msgstr "stop-toolbutton"
+
+#~ msgid "toolbutton1"
+#~ msgstr "toolbutton1"
+
+#~ msgid "toolbutton2"
+#~ msgstr "toolbutton2"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "_Modelo del teclado:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Elija un modelo de teclado"
+
+#~ msgid "_Models:"
+#~ msgstr "_Modelos:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_Fabricantes:"
+
+#~ msgid "Vendors"
+#~ msgstr "Fabricantes"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "Mover arriba, en la lista, la distribución de teclado seleccionada"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "Imprimir un diagrama de las distribuciones de teclado seleccionadas"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "Quitar de la lista la distribución de teclado seleccionada"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "Seleccionar una distribución de teclado para añadir a la lista"
+
+#~ msgid "Hold"
+#~ msgstr "Mantener"
+
+#~ msgid "Release"
+#~ msgstr "Publicación"
+
+#~ msgid ""
+#~ "A guest account will allow anyone to temporarily log in to this computer "
+#~ "without a password.  For security, remote logins to this account are not "
+#~ "allowed.\n"
+#~ "\n"
+#~ "                    <b>When the guest user logs out, all files and data "
+#~ "associated with the account will be deleted.</b>"
+#~ msgstr ""
+#~ "Una cuenta de invitado permitirá que cualquiera inicie sesión "
+#~ "temporalmente en este equipo sin contraseña. Por razones de seguridad no "
+#~ "se permiten inicios de sesión remotos con esta cuenta.\n"
+#~ "\n"
+#~ "                    <b>Cuando el usuario invitado sale de la sesión, "
+#~ "todos los archivos y datos asociados con la cuenta se eliminan.</b>"
+
+#~ msgid "Accounts"
+#~ msgstr "Cuentas"
+
+#~ msgid "Address Book Card:"
+#~ msgstr "Tarjeta de la libreta de direcciones:"
+
+#~ msgid "Allow guests to log in to this computer"
+#~ msgstr "Permitir a invitados que inicien sesión en este equipo"
+
+#~ msgid "E-mail address:"
+#~ msgstr "Dirección de correo-e:"
+
+#~ msgid "Show Shutdown, Suspend and Restart actions"
+#~ msgstr "Acciones de Apagar, Suspender y Reiniciar"
+
+#~ msgid "Show list of users"
+#~ msgstr "Mostrar la lista de usuarios"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "Permitir controlar el _puntero usando el teclado numérico"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Teclee para probar la configuración:"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Elegir el tipo de pulsación de an_temano"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "Elegir el tipo de pulsación con gestos del rató_n"
+
+#~ msgid "D_rag click:"
+#~ msgstr "Pulsación de _arrastre:"
+
+#~ msgid "Dwell Click"
+#~ msgstr "Pulsación al posarse"
+
+#~ msgid "Show click type _window"
+#~ msgstr "Mostrar la _ventana del tipo de pulsación"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr ""
+#~ "También puede usar el panel de la miniaplicación Pulsación al posarse "
+#~ "para elegir el tipo de pulsación."
+
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "_Iniciar la pulsación cuando se pare el movimiento del puntero"
+
+#~ msgid "_Single click:"
+#~ msgstr "Pulsación _simple:"
+
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr ""
+#~ "_Disparar la pulsación secundaria al mantener pulsado el botón primario"
+
+#~ msgid "Example preferences panel"
+#~ msgstr "Preferencias del panel de ejemplo"
+
+#~ msgid "Foo;Bar;Baz;"
+#~ msgstr "foo;bar:baz;"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "Aplicaciones preferidas"
+
+#~ msgid "Select your default applications"
+#~ msgstr "Seleccione sus aplicaciones predeterminadas"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "Iniciar la tecnología de asistencia visual preferida"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "Asistencia visual"
+
+#~ msgid "Error setting default browser: %s"
+#~ msgstr "Error al establecer el navegador predeterminado: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "No es posible cargar el interfaz principal"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Todas las apariciones de %s se reemplazarán por el enlace actual"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Co_mando:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "Opción de e_jecución:"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "Mensajería instantánea"
+
+#~ msgid "Mail Reader"
+#~ msgstr "Lector de correo"
+
+#~ msgid "Mobility"
+#~ msgstr "Movilidad"
+
+#~ msgid "Run at st_art"
+#~ msgstr "Ejecutar al _inicio"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Ejecutar en un t_erminal"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "Emulador de terminal"
+
+#~ msgid "Text Editor"
+#~ msgstr "Editor de textos"
+
+#~ msgid "Visual"
+#~ msgstr "Visual"
+
+#~ msgid "Web Browser"
+#~ msgstr "Navegador web"
+
+#~ msgid "_Run at start"
+#~ msgstr "Ejecutar al _inicio"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Reproductor de música Banshee"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Emulador de terminal de Debian"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "Magnificador de GNOME sin lector de pantalla"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus con magnificador"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "Magnificador de KDE sin lector de pantalla"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Linux Screen Reader"
+#~ msgstr "Lector de pantalla de Linux"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Lector de pantalla de Linux con magnificador"
+
+#~ msgid "Listen"
+#~ msgstr "Listen"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "Reproductor de música Muine"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "Orca con magnificador"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Reproductor de música Rhythmbox"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Terminal X estándar"
+
+#~ msgid "Terminator"
+#~ msgstr "Terminator"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Reproductor de películas Totem"
+
+#~ msgid "12 hour format"
+#~ msgstr "Formato 12 horas"
+
+#~ msgid "24 hour format"
+#~ msgstr "Formato 24 horas"
+
+#~ msgid "Orange"
+#~ msgstr "Naranja"
+
+#~ msgid "Chameleon"
+#~ msgstr "Camaleón"
+
+#~ msgid "Plum"
+#~ msgstr "Ciruela"
+
+#~ msgid "Aluminium"
+#~ msgstr "Aluminio"
+
+#~ msgid "Slide Show"
+#~ msgstr "Mostrar diapositivas"
+
+#~ msgid "Image"
+#~ msgstr "Imagen"
+
+#~ msgid "%d %s by %d %s"
+#~ msgstr "%d %s por %d %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Carpeta: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Carpeta: %s"
+
+#~ msgid "Image missing"
+#~ msgstr "Falta una imagen"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "_Detectar monitores"
+
+#~ msgid "_Mirror Screens"
+#~ msgstr "_Espejar pantallas"
+
+#~ msgid "Mirror Screens"
+#~ msgstr "Espejar pantallas"
+
+#~ msgid "Open %s"
+#~ msgstr "Abrir %s"
+
+#~ msgid "Could not run application"
+#~ msgstr "No se pudo ejecutar la aplicación"
+
+#~ msgid "Could not find '%s'"
+#~ msgstr "No se pudo encontrar «%s»"
+
+#~ msgid "Could not find application"
+#~ msgstr "No se pudo encontrar la aplicación"
+
+#~ msgid "Could not add application to the application database: %s"
+#~ msgstr ""
+#~ "No se pudo añadir la aplicación a la base de datos de aplicaciones: %s"
+
+#, fuzzy
+#~ msgid "Could not set application as the default: %s"
+#~ msgstr "No se pudo obtener la información para %s: %s\n"
+
+#, fuzzy
+#~ msgid "Could not set as default application"
+#~ msgstr "Seleccione sus aplicaciones predeterminadas"
+
+#, fuzzy
+#~ msgid "Open With"
+#~ msgstr "Abrir con «%s»"
+
+#, fuzzy
+#~ msgid "Open %s with:"
+#~ msgstr "Abrir con «%s»"
+
+#, fuzzy
+#~ msgid "Add Application"
+#~ msgstr "Aplicaciones"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Establezca sus preferencias del proxy de la red"
+
+#, fuzzy
+#~ msgid "Web;Location;"
+#~ msgstr "Lugar:"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Configuración _manual del proxy</b>"
+
+#~ msgid "Create New Location"
+#~ msgstr "Crear una ubicación nueva"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Detalles del proxy HTTP"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "Lista de anfitriones ignorados"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Preferencias del proxy de la red"
+
+#~ msgid "The location already exists."
+#~ msgstr "El lugar ya existe."
+
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "_Usar el mismo proxy para todos los protocolos"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Navegador sensible de Debian"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Navegador web Epiphany"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Lector de correo Evolution"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Correo Iceape"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "Correo SeaMonkey"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "_Include Top Menu Bar"
+#~ msgstr "_Incluir barra de menú superior"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "Monitor: %s"
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "No se puede cargar el icono de fábrica «%s»\n"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "Mover a la izquierda"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "Mover a la derecha"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "Mover arriba"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "Mover abajo"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "Desactivado"
+
+#~ msgid "Waiting for sound system to respond"
+#~ msgstr "Esperando a que el sistema de sonido responda"
+
+#~ msgid "Sound _theme:"
+#~ msgstr "_Tema de sonido:"
+
+#~ msgid "Enable _window and button sounds"
+#~ msgstr "Activar sonidos de _ventanas y botones"
+
+#~ msgctxt "Sound event"
+#~ msgid "Windows and Buttons"
+#~ msgstr "Ventanas y botones"
+
+#~ msgctxt "Sound event"
+#~ msgid "Button clicked"
+#~ msgstr "Botón pulsado"
+
+#~ msgctxt "Sound event"
+#~ msgid "Toggle button clicked"
+#~ msgstr "Botón conmutador pulsado"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window maximized"
+#~ msgstr "Ventana maximizada"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window unmaximized"
+#~ msgstr "Ventana desmaximizada"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window minimised"
+#~ msgstr "Ventana minimizada"
+
+#~ msgctxt "Sound event"
+#~ msgid "Desktop"
+#~ msgstr "Escritorio"
+
+#~ msgctxt "Sound event"
+#~ msgid "Long action completed (download, CD burning, etc.)"
+#~ msgstr "Acción larga completada (descarga, grabación de CD, etc.)"
+
+#~ msgctxt "Sound event"
+#~ msgid "Alerts"
+#~ msgstr "Alarmas"
+
+#~ msgctxt "Sound event"
+#~ msgid "Information or question"
+#~ msgstr "Información o pregunta"
+
+#~ msgctxt "Sound event"
+#~ msgid "Warning"
+#~ msgstr "Advertencia"
+
+#~ msgid "Custom…"
+#~ msgstr "Personalizado…"
+
+#~ msgid "Sound Theme:"
+#~ msgstr "Tema de sonido:"
+
+#~ msgid "Enable window and button sounds"
+#~ msgstr "Activar sonidos de ventanas y botones"
+
+#~ msgid "I need assistance with:"
+#~ msgstr "Necesito asistencia con:"
+
+#~ msgid "Monitors"
+#~ msgstr "Monitores"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Asigne una combinación de teclas a comandos"
+
+#~ msgid "Beep when _accessibility features are turned on or off"
+#~ msgstr ""
+#~ "Pitar cuando se activen o desactiven las características de _accesibilidad"
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "Pitar al pulsar una _tecla conmutable"
+
+#~ msgid "Beep when a key is reje_cted"
+#~ msgstr "Pitar si se recha_za la tecla"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Pitar si se _rechaza la tecla"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Destello de la barra de título de la _ventana"
+
+#~ msgid "Flash entire _screen"
+#~ msgstr "Destello de la pantalla _completa"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Comentarios sobre los sonidos de accesibilidad del teclado"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "Mostrar respuesta _visual para las alertas de sonido"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "Entradas visuales para sonidos"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Co_mentarios sobre el sonido..."
+
+#~ msgid "Disa_ble sticky keys if two keys are pressed together"
+#~ msgstr ""
+#~ "_Desactivar las teclas persistentes si se pulsan dos teclas a la vez"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Preferencias del teclado"
+
+#~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#~ msgstr ""
+#~ "Permitir conmutar las características de _accesibilidad desde "
+#~ "combinaciones de teclas"
+
+#~ msgid "_Ignore fast duplicate keypresses"
+#~ msgstr "_Ignorar pulsaciones duplicadas rápidas"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "S_ólo aceptar teclas pulsadas durante cierto tiempo"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Simular pulsaciones de múltiples teclas"
+
+#~ msgid ""
+#~ "Accessibility features can be turned on or off with keyboard shortcuts"
+#~ msgstr ""
+#~ "Las características de accesibilidad se pueden activar y desactivar con "
+#~ "combinaciones de teclas"
+
+#~ msgid "Test:"
+#~ msgstr "Probar:"
+
+#~ msgid "Image Viewer"
+#~ msgstr "Visor de imágenes"
+
+#~ msgid "Multimedia"
+#~ msgstr "Multimedia"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Abrir enlace en una pesta_ña nueva"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Abrir enlace en una _ventana nueva"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Abrir enlace con el navegador web _predeterminado"
+
+#~ msgid "Include _panel"
+#~ msgstr "Incluir pa_nel"
+
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "Uso: %s ARCHIVO_ORIGEN NOMBRE_DESTINO\n"
+#~ "\n"
+#~ "Este programa instala un perfil RANDR para configuraciones multimonitor\n"
+#~ "en todo el sistema. El perfil resultante se usará cuando el complemento\n"
+#~ "RANRD se ejecute en gnome-settings.daemon.\n"
+#~ "\n"
+#~ "ARCHIVO_ORIGEN: una ruta completa, generalmente /home/username/.config/"
+#~ "monitors.xml\n"
+#~ "\n"
+#~ "NOMBRE_DESTINO: nombre relativo para el archivo instalado. Esto\n"
+#~ "                pondrá las configuraciones RANDR en el directorio del "
+#~ "sistema\n"
+#~ "                de tal forma que el resultado generalmente será %s/"
+#~ "NOMBRE_DESTINO\n"
+
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "Sólo el usuario «root» puede usar este programa"
+
+#~ msgid "The source filename must be absolute"
+#~ msgstr "El origen del nombre del archivo debe ser absoluto"
+
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s debe ser un archivo regular\n"
+
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "Este programa sólo se debe ejecutar a través de pkexec(1)"
+
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "Se debe establecer PKEXEC_UID a un valor entero"
+
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "Debe ser el propietario de %s\n"
+
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s no debe tener ningún componente de directorio\n"
+
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s debe ser un directorio\n"
+
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "No se pudo abrir %s/%s: %s\n"
+
+#~ msgid ""
+#~ "Authentication is required to install multi-monitor settings for all users"
+#~ msgstr ""
+#~ "Se requiere autenticación para instalar la configuración multimonitor "
+#~ "para todos los usuarios"
+
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "Instalar la configuración multimonitor para todo el sistema"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Permitir p_osponer los descansos"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Comprobar si se permite posponer los descansos"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Duración del descanso cuando la escritura no está permitida"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Duración del trabajo antes de forzar un descanso"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Bloquea la pantalla después de un cierto intervalo para ayudar a prevenir "
+#~ "las lesiones por el uso repetitivo del teclado"
+
+#~ msgid "Typing Break"
+#~ msgstr "Descanso de escritura"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "D_uración del intervalo de descanso:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "B_loquear la pantalla para forzar un descanso de escritura"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "D_uración del intervalo de trabajo:"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_Posponer el descanso"
+
+#~ msgid "_Take a Break"
+#~ msgstr "_Tomar un descanso"
+
+#~ msgid "Take a break now (next in %dm)"
+#~ msgstr "Descansar ahora (el siguiente en %dm)"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d minuto hasta su siguiente descanso"
+#~ msgstr[1] "%d minutos hasta su siguiente descanso"
+
+#~ msgid "Take a break now (next in less than one minute)"
+#~ msgstr "Descansar ahora (el siguiente en menos de un minuto)"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Menos de un minuto hasta su siguiente descanso"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "No se puede mostrar el diálogo de las propiedades del descanso de "
+#~ "escritura por el siguiente error: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Escrito por Richard Hult <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Vistosidad agregada por Anders Carlsson"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Un recordatorio para los descansos frente a la computadora."
+
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "Jorge González <jorgegonz@svn.gnome.org>, 2007, 2010\n"
+#~ "Traductores anteriores:\n"
+#~ "Claudio Saavedra <csaavedra@alumnos.utalca.cl>, 2007\n"
+#~ "Francisco Javier F. Serrador <serrador@cvs.gnome.org>, 2003, 2004, 2005, "
+#~ "2006\n"
+#~ "Pablo Saratxaga <srtxg@chanae.alphanet.ch>, 1998-2001\n"
+#~ "Carlos Perelló Marín <carlos@gnome-db.org>, 2001\n"
+#~ "Héctor García Álvarez <hector@scouts-es.org>, 2001\n"
+#~ "QA: Germán Poo Caamaño <gpoo@ubiobio.cl>, 2002\n"
+#~ "Lucas Di Pentima <lucas@lunix.com.ar>, 2002\n"
+#~ "Pablo Gonzalo del Campo <pablodc@bigfoot.com>, 2002, 2003"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "No comprobar si existe el área de notificación"
+
+#~ msgid "Typing Monitor"
+#~ msgstr "Monitor de tecleo"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "El monitor de tecleo utiliza el área de notificación para mostrar "
+#~ "información. Parece que usted no tiene el área de notificación en su "
+#~ "panel. Puede añadirla pulsando con el botón derecho sobre el panel y "
+#~ "seleccionando «Añadir al panel», seleccionando «Área de notificación» y "
+#~ "pulsando en «Añadir»."
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "La _misma imagen en todos los monitores"
+
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "Se guardó la configuración del monitor"
+
+#~ msgid "This configuration will be used the next time someone logs in."
+#~ msgstr ""
+#~ "La próxima vez que alguien inicie sesión se usará esta configuración"
+
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr ""
+#~ "No se pudo establecer la configuración predeterminada para los monitores"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Cierra el centro de control cuando se activa una tarea"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr ""
+#~ "Abandona la consola cuando se ha realizado una acción de añadido o "
+#~ "eliminación"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Abandona la consola cuando se ha realizado una acción de ayuda"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Abandona la consola cuando se ha realizado una acción de inicio"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr ""
+#~ "Abandona la consola cuando se ha realizado una acción de actualización o "
+#~ "desinstalación"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr ""
+#~ "Indica si debe cerrarse la consola cuando se ha ejecutado una acción de "
+#~ "ayuda."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr ""
+#~ "Indica si debe cerrarse la consola cuando se ha ejecutado una acción de "
+#~ "inicio."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "Indica si debe cerrarse la consola cuando se ha ejecutado una acción de "
+#~ "añadido o eliminación."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "Indica si debe cerrarse la consola cuando se ha ejecutado una acción de "
+#~ "actualización o desinstalación."
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "Nombres de tareas y archivos .desktop asociados"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "El nombre de la tarea que desplegar en el centro de control seguido por "
+#~ "un separador «;» y luego el nombre de un archivo .desktop asociado que "
+#~ "lanzar para esa tarea."
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[Cambiar el tema;gtk-theme-selector.desktop,Establecer las aplicaciones "
+#~ "preferidas;default-applications.desktop,Añadir impresora;gnome-cups-"
+#~ "manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "Si es verdadero, el centro de control se cerrará cuando se active una "
+#~ "«Tarea común»."
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "La herramienta de configuración de GNOME"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Si está establecido a «true», entonces las tipografías OpenType se "
+#~ "miniaturizarán."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Si está establecido a «true», entonces las tipografías PFC se "
+#~ "miniaturizarán."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Si está establecido a «true», entonces las tipografías TrueType se "
+#~ "miniaturizarán."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Si está establecido a «true», entonces las tipografías Type1 se "
+#~ "miniaturizarán."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Establezca en esta clave el comando que se debe usar para crear "
+#~ "miniaturas de las tipografías OpenType."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Establezca en esta clave el comando que se debe usar para crear "
+#~ "miniaturas de las tipografías PCF."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Establezca en esta clave el comando que se debe usar para crear "
+#~ "miniaturas de las tipografías TrueType."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Establezca en esta clave el comando que se debe usar para crear "
+#~ "miniaturas de las tipografías Type1."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Comando para miniaturizar las tipografías OpenType"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Comando para miniaturizar las tipografías PCF"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Comando para miniaturizar las tipografías TrueType"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Comando para miniaturizar las tipografías Type1"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Indica si debe miniaturizar las tipografías OpenType"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Indica si debe miniaturizar las tipografías PCF"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Indica si debe miniaturizar las tipografías TrueType"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Indica si debe miniaturizar las tipografías Type1"
+
+#~ msgid "Copyright:"
+#~ msgstr "Copyright:"
+
+#~ msgid "Installed"
+#~ msgstr "Instalado"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "uso: %s archivo de tipografías\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "I_nstalar tipografía"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Texto a miniaturizar (predeterminado: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXTO"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Tamaño de la tipografía (predeterminado: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "TAMAÑO"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "ARCHIVO-DE-TIPOGRAFÍA ARCHIVO-DE-SALIDA"
+
+#~ msgid "Image/label border"
+#~ msgstr "Imagen/borde de la etiqueta"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr ""
+#~ "Anchura del borde alrededor de la etiqueta y la imagen en el diálogo de "
+#~ "alerta"
+
+#~ msgid "The type of alert"
+#~ msgstr "El tipo de alerta"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Los botones mostrados en el diálogo de alerta"
+
+#~ msgid "Show more _details"
+#~ msgstr "Mostrar más _detalles"
+
+#~ msgid "No Image"
+#~ msgstr "Sin imagen"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Hubo un error al intentar obtener la información de la libreta de "
+#~ "direcciones\n"
+#~ "Evolution Data Server no puede manipular el protocolo"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Imposible abrir la libreta de direcciones"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "_Secretario/a:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "C_ompañía:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Cambiar _contraseña…"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "_Ciudad:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "_País:"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "Desactivar el inicio de sesión con _huella..."
+
+#~ msgid "Email"
+#~ msgstr "Correo-e"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "Activar el inicio de sesión con _huella..."
+
+#~ msgid "Hom_e:"
+#~ msgstr "_Domicilio:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "Mensajería instantánea"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "A_pdo. de correos:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "_Apdo. de correos:"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Estado/Pro_vincia:"
+
+#~ msgid "Web _log:"
+#~ msgstr "_Diario web:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_Trabajo:"
+
+#~ msgid "Work"
+#~ msgstr "Trabajo"
+
+#~ msgid "Work _fax:"
+#~ msgstr "_Fax del trabajo:"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "ZIP/_Código postal:"
+
+#~ msgid "_Home page:"
+#~ msgstr "Página _personal:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Domicilio:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "E_stado/Provincia:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Trabajo:"
+
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "_ZIP/Código postal:"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "Pase el dedo sobre el lector"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "Ponga el dedo en el lector"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "El hijo salió inesperadamente"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "No es posible apagar el canal de E/S backend_stdin: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "No es posible apagar el canal de E/S backend_stdout: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "Error del sistema: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "No se puede lanzar %s: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "Imposible lanzar el backend"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "Ha ocurrido un error del sistema"
+
+#~ msgid "Checking password..."
+#~ msgstr "Comprobando contraseña…"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "Pulse en <b>Cambiar contraseña</b> para cambiar su contraseña."
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "Por favor, teclee la contraseña de nuevo en el campo <b>Teclee la "
+#~ "contraseña nueva otra vez</b>."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "Las dos contraseñas no son iguales."
+
+#~ msgid "Change your password"
+#~ msgstr "Cambiar su contraseña"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "Para cambiar su contraseña, introduzca su contraseña actual en el campo "
+#~ "de abajo y pulse <b>Autenticar</b>.\n"
+#~ "Después de haberse autenticado, introduzca su contraseña nueva, "
+#~ "reescríbala para verificación y pulse <b>Cambiar contraseña</b>."
+
+#~ msgid "Font may be too large"
+#~ msgstr "La tipografía quizá sea demasiado grande"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "La tipografía seleccionada es %d punto de grande, y puede hacer difícil "
+#~ "usar el equipo. Se recomienda que seleccione un tamaño menor de %d."
+#~ msgstr[1] ""
+#~ "La tipografía seleccionada es %d puntos de grande, y puede hacer difícil "
+#~ "usar el equipo. Se recomienda que seleccione un tamaño menor de %d."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "La tipografía seleccionada es %d punto de grande, y puede hacer difícil "
+#~ "usar el equipo. Se recomienda que seleccione una tipografía de tamaño "
+#~ "menor."
+#~ msgstr[1] ""
+#~ "La tipografía seleccionada es %d puntos de grande, y puede hacer difícil "
+#~ "usar el equipo. Se recomienda que seleccione una tipografía de tamaño "
+#~ "menor."
+
+#~ msgid "Use previous font"
+#~ msgstr "Usar la tipografía anterior"
+
+#~ msgid "Use selected font"
+#~ msgstr "Usar la tipografía seleccionada"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Especifique el nombre de archivo del tema a instalar"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "Especifique el nombre de la página para mostrar (theme|background|fonts|"
+#~ "interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[Fondo…]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "Este tema no se mostrará como se pretende porque el motor de temas GTK+ "
+#~ "necesario «%s» no está instalado."
+
+#~ msgid "Apply Background"
+#~ msgstr "Aplicar fondo"
+
+#~ msgid "Apply Font"
+#~ msgstr "Aplicar tipografía"
+
+#~ msgid "Revert Font"
+#~ msgstr "Revertir la tipografía"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "El tema actual sugiere un fondo y una tipografía. Además, se puede "
+#~ "revertir la última sugerencia de tipografía aplicada."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "El tema actual sugiere un fondo. Además, se puede revertir la última "
+#~ "sugerencia de tipografía aplicada."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "El tema actual sugiere un fondo y una tipografía."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "El tema actual sugiere una tipografía. Además, se puede revertir la "
+#~ "última sugerencia de tipografía aplicada."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "El tema actual sugiere un fondo."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "Se puede revertir la última sugerencia de tipografía aplicada."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "El tema actual sugiere una tipografía."
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "Preferencias de la apariencia"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Mejores _formas"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Mejor co_ntraste"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "_Personalizar…"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr ""
+#~ "El cambio del tema de cursor no tendrá efecto hasta que salga e inicie "
+#~ "sesión nuevamente."
+
+#~ msgid "Customize Theme"
+#~ msgstr "Personalizar tema"
+
+#~ msgid "D_etails..."
+#~ msgstr "_Detalles…"
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Tipografía para el _escritorio:"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "Detalles del renderizado de la tipografía"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "Obtener más fondos en línea"
+
+#~ msgid "Get more themes online"
+#~ msgstr "Obtener más temas en línea"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Escala de g_rises"
+
+#~ msgid "Icons"
+#~ msgstr "Iconos"
+
+#~ msgid "Icons only"
+#~ msgstr "Sólo iconos"
+
+#~ msgid "N_one"
+#~ msgstr "Ningun_o"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Abre un diálogo para especificar el color"
+
+#~ msgid "R_esolution:"
+#~ msgstr "R_esolución:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "Guardar tema como…"
+
+#~ msgid "Save _As..."
+#~ msgstr "Guardar _como…"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sub_píxel (LCD)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Suavizado de sub_píxel (LCD)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "Orden del subpíxel"
+
+#~ msgid "Text"
+#~ msgstr "Texto"
+
+#~ msgid "Text below items"
+#~ msgstr "Texto debajo de los iconos"
+
+#~ msgid "Text beside items"
+#~ msgstr "Texto junto a los iconos"
+
+#~ msgid "Text only"
+#~ msgstr "Sólo texto"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "El tema actual de controles no soporta esquemas de colores."
+
+#~ msgid "Theme"
+#~ msgstr "Tema"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Document font:"
+#~ msgstr "Tipografía para los _documentos:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "Tipografía de ancho _fijo:"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Monocromo"
+
+#~ msgid "_None"
+#~ msgstr "_Ninguno"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "_Restablecer valores predeterminados"
+
+#~ msgid "_Selected items:"
+#~ msgstr "Elementos _seleccionados:"
+
+#~ msgid "_Size:"
+#~ msgstr "_Tamaño:"
+
+#~ msgid "_Slight"
+#~ msgstr "Le_ve"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "_Consejos:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "Tipografía del título de la _ventana:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Ventanas:"
+
+#~ msgid "dots per inch"
+#~ msgstr "puntos por pulgada"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Personalice la apariencia del escritorio"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Instala paquetes de temas para varias partes del escritorio"
+
+#~ msgid "Theme Installer"
+#~ msgstr "Instalador de temas"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Paquete de tema GNOME"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "No se puede instalar el tema"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "La utilidad %s no está instalada."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "Hubo un problema al extraer el tema."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "Hubo un error al instalar el archivo seleccionado"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "«%s» no parece ser un tema válido."
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "«%s» no parece ser un tema válido. Puede ser un motor de temas que debe "
+#~ "compilar."
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "La instalación del tema «%s» falló."
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "Se ha instalado el tema «%s»."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "¿Desea aplicarlo ahora, o mantener su tema actual?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Mantener el tema actual"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Aplicar el nuevo tema"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "El tema de GNOME %s se instaló correctamente"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "Los nuevos temas se han instalado con éxito."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr ""
+#~ "No se ha especificado ninguna ubicación del archivo del tema para instalar"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Permisos insuficientes para instalar el tema en:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "Seleccionar un tema"
+
+#~ msgid "Theme Packages"
+#~ msgstr "Paquetes de temas"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "El nombre del tema debe estar presente"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "El tema ya existe. ¿Quiere reemplazarlo?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_Sobrescribir"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "¿Quiere eliminar este tema?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "No se pudo instalar el motor del tema"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "No se puede iniciar el gestor de configuración «gnome-settings-daemon».\n"
+#~ "Si el gestor de configuración de GNOME no se está ejecutando, es posible "
+#~ "que algunas de las preferencias no surtan efecto. Esto puede ser el "
+#~ "síntoma de un problema con DBus o que un gestor de configuración que no "
+#~ "es de GNOME (por ejemplo KDE) ya esté activo y en conflicto con el gestor "
+#~ "de configuración de GNOME."
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Hubo un error al mostrar la ayuda: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Copiando archivo: %u de %u"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "Copiando «%s»"
+
+#~ msgid "Copying files"
+#~ msgstr "Copiando archivos"
+
+#~ msgid "Parent Window"
+#~ msgstr "Ventana raíz"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "Ventana raíz del diálogo"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "Transfiriendo desde la URI"
+
+#~ msgid "To URI"
+#~ msgstr "A la URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "Transfiriendo a la URI"
+
+#~ msgid "Fraction completed"
+#~ msgstr "Fracción completada"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Fracción de la transferencia actualmente completada"
+
+#~ msgid "Current URI index"
+#~ msgstr "Índice URI actual"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Índice URI actual - comienza desde 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "Total de URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Número total de URI"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "El archivo «%s» ya existe. ¿Quiere sobrescribirlo?"
+
+#~ msgid "_Skip"
+#~ msgstr "_Saltar"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "Sobrescribir _todo"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Puntero predeterminado - Actual"
+
+#~ msgid "White Pointer"
+#~ msgstr "Puntero blanco"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Puntero blanco - Actual"
+
+#~ msgid "Large Pointer"
+#~ msgstr "Puntero grande"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Puntero grande - Actual"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Puntero blanco grande - Actual"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Este tema no se mostrará como se pretende porque eltema GTK+ necesario "
+#~ "«%s» no está instalado."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "Este tema no se mostrará como se pretende porque el tema del gestor de "
+#~ "ventanas necesario «%s» no está instalado."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Este tema no se mostrará como se pretende porque el tema de iconos "
+#~ "necesario «%s» no está instalado."
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "El gestor de ventanas «%s» no ha registrado una herramienta de "
+#~ "configuración\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "Maximizar verticalmente"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Maximizar horizontalmente"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "_Inicio de sesión accesible"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "Tecnologías de asistencia"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Preferencias de las tecnologías de asistencia"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "Los cambios para activar las tecnologías de asistencia no tendrán efecto "
+#~ "hasta que salga e inicie sesión nuevamente."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Cerrar y de_sconectarse"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Saltar al diálogo de Aplicaciones preferidas"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "Saltar al diálogo de Inicio de sesión accesible"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "Saltar al diálogo de Accesibilidad del teclado"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Saltar al diálogo de Accesibilidad del ratón"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Activar las tecnologías de asistencia"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "Aplicaciones _preferidas"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr ""
+#~ "Elija qué características de accesibilidad activar al iniciar sesión"
+
+#~ msgid "Monitor Preferences"
+#~ msgstr "Preferencias del monitor"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "Especifique el nombre de la página para mostrar (internet|multimedia|"
+#~ "system|a11y)"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Tan sólo aplicar la configuración y salir (sólo por compatibilidad; "
+#~ "manipulado ahora por un demonio)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr ""
+#~ "Iniciar la página mostrando la configuración del descanso de escritura"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Iniciar la página mostrando la configuración de accesibilidad"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- Preferencias del teclado de GNOME"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr ""
+#~ "Especifique el nombre de la página para mostrar (general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- Preferencias del ratón de GNOME"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr ""
+#~ "No se puede iniciar la aplicación de preferencias para su gestor de "
+#~ "ventanas"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "_Hiper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "_Super (o «Logo de Windows»)"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "Titlebar Action"
+#~ msgstr "Acción de la barra de título"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Para mover una ventana, mantenga pulsada esta tecla y luego arrastre la "
+#~ "ventana:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Preferencias de ventanas"
+
+#~ msgid "Window Selection"
+#~ msgstr "Selección de ventana"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Intervalo antes de elevar:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Elevar las ventanas seleccionadas tras un intervalo"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Seleccionar las ventanas cuando el ratón se mueve sobre ellas"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Establezca sus propiedades de ventana"
+
+#~ msgid "Windows"
+#~ msgstr "Ventanas"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "Ocultar al inicio (útil para precargar la consola)"
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Groups"
+#~ msgstr "Grupos"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "Su filtro «%s» no coincide con ningún elemento."
+
+#~ msgid "Upgrade"
+#~ msgstr "Actualizar"
+
+#~ msgid "Uninstall"
+#~ msgstr "Desinstalar"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "Añadir a favoritos"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Quitar de los programas de inicio"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Añadir a los programas de inicio"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "Hoja de cálculo nueva"
+
+#~ msgid "New Document"
+#~ msgstr "Documento nuevo"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Abrir</b>"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "Si borra un elemento se pierde para siempre."
+
+#~ msgid "Open in File Manager"
+#~ msgstr "Abrir en el gestor de archivos"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Hoy %H:%M"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "Ayer %H:%M"
+
+#~ msgid "Find Now"
+#~ msgstr "Buscar ahora"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Abrir %s</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "Quitar de los elementos del sistema"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Cambie la resolución de la pantalla"
+
+#~ msgid "Display Preferences"
+#~ msgstr "Preferencias de la pantalla"
+
+#~ msgid "Drag the monitors to set their place"
+#~ msgstr "Arrastre los monitores para ajustar su ubicación"
+
+#~ msgid "C_ontrol"
+#~ msgstr "_Ctrl"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr ""
+#~ "El veloz murciélago hindú comía feliz cardillo y kiwi. La cigüeña tocaba "
+#~ "el saxofón detrás del palenque de paja. 0123456789"
+
+#~ msgid "Menus and Toolbars"
+#~ msgstr "Menús y barras de herramientas"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Mostrar _iconos en los menús"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Etiquetas de los _botones de la barra de herramientas:"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "Aceleradores de menú _editables"
+
+#~ msgid "New windows get layout \"foobar\""
+#~ msgstr "Las nuevas ventanas obtienen la distribución «foobar»"
+
+#~ msgid "Selected _layouts:"
+#~ msgstr "Distribuciones _seleccionadas:"
+
+#~ msgid "_Desktop Background"
+#~ msgstr "_Fondo del escritorio"
+
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>No se encontraron coincidencias.</b></"
+#~ "span><span>\n"
+#~ "\n"
+#~ " Su filtro «<b>%s</b>» no coincide con ningún elemento.</span>"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr ""
+#~ "ID de inicio desconocido, la base de datos de usuarios quizá esté corrupta"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Web</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Trabajo</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Cambie su contraseña</span>"
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>Tecnologías de asistencia</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>Preferencias</b>"
+
+#~ msgid "<b>_Desktop Background</b>"
+#~ msgstr "<b>_Fondo del escritorio</b>"
+
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b>Visual</b>"
+
+#~ msgid "<b>Bounce Keys</b>"
+#~ msgstr "<b>Rechazo de teclas</b>"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>General</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Rápida</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Largo</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Lenta</i></small>"
+
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i>Alta</i></small>"
+
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i>Grande</i></small>"
+
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>Baja</i></small>"
+
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i>Pequeño</i></small>"
+
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>Lista de anfitriones ignorados</b>"
+
+#~ msgid ""
+#~ "Left thumb\n"
+#~ "Left middle finger\n"
+#~ "Left ring finger\n"
+#~ "Left little finger\n"
+#~ "Right thumb\n"
+#~ "Right middle finger\n"
+#~ "Right ring finger\n"
+#~ "Right little finger"
+#~ msgstr ""
+#~ "Pulgar izquierdo\n"
+#~ "Dedo corazón izquierdo\n"
+#~ "Dedo anular izquierdo\n"
+#~ "Dedo meñique izquierdo\n"
+#~ "Pulgar derecho\n"
+#~ "Dedo corazón derecho\n"
+#~ "Dedo anular derecho\n"
+#~ "Dedo meñique derecho"
+
+#~ msgid "C_ut"
+#~ msgstr "Co_rtar"
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "Color sólido\n"
+#~ "Degradado horizontal\n"
+#~ "Degradado vertical"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "Texto debajo de los iconos\n"
+#~ "Texto junto a los iconos\n"
+#~ "Sólo iconos\n"
+#~ "Sólo texto"
+
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "Mosaico\n"
+#~ "Ampliación\n"
+#~ "Centrado\n"
+#~ "Escalado\n"
+#~ "Rellenar la pantalla"
+
+#~ msgid "_New"
+#~ msgstr "_Nuevo"
+
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "Normal\n"
+#~ "Izquierda\n"
+#~ "Derecha\n"
+#~ "Hacia abajo\n"
+
+#~ msgid "Could not apply the selected configuration"
+#~ msgstr "No se pudo aplicar la configuración seleccionada"
+
+#~ msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+#~ msgstr "No se pudo obtener org.gnome.SettingsDaemin.XRANDR"
+
+#~ msgid "Screen Resolution"
+#~ msgstr "Resolución de la pantalla"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>_Tapiz</b>"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - Advanced Linux Sound Architecture"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART Sound Daemon"
+
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ESD - Enlightened Sound Daemon"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - Open Sound System"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "PulseAudio Sound Server"
+
+#~ msgid "Silence"
+#~ msgstr "Silencio"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "- Preferencias de sonido de GNOME"
+
+#~ msgid "<b>Alerts and Sound Effects</b>"
+#~ msgstr "<b>Alertas y efectos de sonido</b>"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>Conferencia de sonido</b>"
+
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>Pistas predeterminadas del mezclador</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Música y películas</b>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "Pulse «Aceptar» para terminar."
+
+#~ msgid "Play _sound effects when buttons are clicked"
+#~ msgstr "Reproducir efectos de _sonido al pulsar botones"
+
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+#~ msgstr ""
+#~ "Seleccione el dispositivo y las pistas a controlar con el teclado. Use "
+#~ "las teclas Mayús. y Control para seleccionar múltiples pistas si es "
+#~ "necesario."
+
+#~ msgid "So_und playback:"
+#~ msgstr "Reprod_ucción de sonido:"
+
+#~ msgid "Sou_nd capture:"
+#~ msgstr "Captura de so_nido:"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "Probar pipeline"
+
+#~ msgid "_Play alerts and sound effects"
+#~ msgstr "_Reproducir alertas y efectos de sonido"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "Reproducción de _sonido:"
+
+#~ msgid "Custom..."
+#~ msgstr "Personalizado…"
+
+#~ msgid "Monitor Resolution Settings"
+#~ msgstr "Ajustes de resolución del monitor"
+
+#~ msgid ""
+#~ "The X server does not support the XRANDR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "El servidor X no soporta la extensión XRANDR. Los cambios inmediatos "
+#~ "sobre el tamaño de la pantalla no están disponibles."
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Obtener y almacenar configuración heredada"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr ""
+#~ "Active el soporte para las tecnologías de asistencia de GNOME durante el "
+#~ "inicio"
+
+#~ msgid "New accelerator..."
+#~ msgstr "Combinación nueva…"
+
+#~ msgid "Unexpected attribute '%s' for element '%s'"
+#~ msgstr "Atributo «%s» inesperado para el elemento «%s»"
+
+#~ msgid "Attribute '%s' of element '%s' not found"
+#~ msgstr "No se encontró el atributo «%s» del elemento «%s»"
+
+#~ msgid "Unexpected tag '%s', tag '%s' expected"
+#~ msgstr "Etiqueta «%s» inesperada, se esperaba la etiqueta «%s»"
+
+#~ msgid "Unexpected tag '%s' inside '%s'"
+#~ msgstr "Etiqueta «%s» inesperada dentro de «%s»"
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr ""
+#~ "No se encontró un archivo de marcadores válido en los directorios de datos"
+
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "No se encontró un marcador para la URI «%s»"
+
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "No hay un tipo MIME definido en el marcador para la URI «%s»"
+
+#~ msgid "No private flag has been defined in bookmark for URI '%s'"
+#~ msgstr ""
+#~ "No se ha definido una bandera privada en el marcador para la URI «%s»"
+
+#~ msgid "No groups set in bookmark for URI '%s'"
+#~ msgstr "No hay establecido ningún grupo para el URI «%s»"
+
+#~ msgid "No application with name '%s' registered a bookmark for '%s'"
+#~ msgstr ""
+#~ "Ninguna aplicación con el nombre «%s» registró un marcador para «%s»"

--- a/po/et.po
+++ b/po/et.po
@@ -15,9 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Control Center MASTER\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-05-13 06:26+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-05-13 10:38+0300\n"
 "Last-Translator: Mattias Põldaru <mahfiaz@gmail.com>\n"
 "Language-Team: Estonian <gnome-et@linux.ee>\n"
@@ -28,394 +27,424 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 "X-Generator: Poedit 1.5.4\n"
 
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Rakendused"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Rakendusi ei leitud"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Paigalda uuendused"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Ava"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Vaata üksikasju"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Otsi"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Välja lülitatud"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Teated"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Teateid _näidatakse"
+
 # paistab välimuse eelistuste all ühevärvilise tausta tooltip'ina
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Taust"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Ekraanipildid"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Taustapildid"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Heli"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Välksõrmised"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Kiirklahvid"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s kaamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "Asukoht: %s"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Sisseehitatud veebikaamera"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Regioone ei leitud"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Kuva liik"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Ühenduse kiirus"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Lähtesta"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Rakendused"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Kirjapulk"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Vaikimisi"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+# paistab välimuse eelistuste all ühevärvilise tausta tooltip'ina
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Taust"
 
-#. This refers to a slideshow background
-msgid "Changes throughout the day"
-msgstr "Muutub pidevalt"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "_Lisa profiil…"
 
-#. To translators: This is a noun, not a verb
-msgid "Lock Screen"
-msgstr "Ekraani lukustamine"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "Prantsusmaa"
 
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Korduv"
-
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Ekraan täidetud"
-
-msgctxt "background, style"
-msgid "Center"
-msgstr "Keskel"
-
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Kogu pilt nähtaval"
-
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Üle ekraani"
-
-msgctxt "background, style"
-msgid "Span"
-msgstr "Üle mitme ekraani"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-msgid "Select Background"
-msgstr "Tausta valimine"
-
-msgid "Wallpapers"
-msgstr "Taustapildid"
-
-msgid "Pictures"
-msgstr "Pildid"
-
-msgid "Colors"
-msgstr "Värvid"
-
-#. translators: No pictures were found
-msgid "No Pictures Found"
-msgstr "Ühtegi pilti ei leitud"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-msgid "Home"
-msgstr "Kodukataloog"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "Pildid, mille lisad kausta %s, ilmuvad siia"
-
-msgid "_Cancel"
-msgstr "_Loobu"
-
-msgid "Select"
-msgstr "Vali"
-
-msgid "multiple sizes"
-msgstr "mitmes suuruses"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-# paistab välimuse eelistuste all ühevärvilise tausta tooltip'ina
-msgid "No Desktop Background"
-msgstr "Ilma taustapildita töölaud"
-
-msgid "Current background"
-msgstr "Praegune taustapilt"
-
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Taustapildi muutmine, foto või tapeedi kasutamine"
 
-#. Translators: those are keywords for the background control-center panel
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Taustapilt;Tapeet;Ekraan;Töölaud;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-msgid "Bluetooth is disabled"
-msgstr "Bluetooth on väljas"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Lubatud"
 
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "Bluetooth seadmeid ei leitud"
 
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Bluetoothi jagamine"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "_Lennukirežiim"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth on füüsilisest lülitist välja lülitatud"
 
-#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "_Lennukirežiim"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "_Lennukirežiim"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Bluetoothi sisse- ja väljalülitamine ning seadmete ühendamine"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "Aseta kalibreerimisseade ruudu kohale ja vajuta 'Alusta'"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
-msgstr "Liiguta kalibreerimisseade uude asukohta ja vajuta 'Jätka'"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr "Liiguta kalibreerimisseade pinnaasendisse ja vajuta 'Jätka'"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-msgid "Shut the laptop lid"
-msgstr "Sulge sülearvuti kaas"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-msgid "An internal error occurred that could not be recovered."
-msgstr "Tekkis sisemine viga, millest pole võimalik taastuda."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-msgid "Tools required for calibration are not installed."
-msgstr "Kalibreerimise jaoks vajalikud tööriistad pole paigaldatud."
-
-#. TRANSLATORS: The profile failed for some reason
-msgid "The profile could not be generated."
-msgstr "Profiili pole võimalik genereerida."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-msgid "The target whitepoint was not obtainable."
-msgstr "Soovitud valgepunkt pole saavutatav."
-
-#. TRANSLATORS: the display calibration process is finished
-msgid "Complete!"
-msgstr "Valmis!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-msgid "Calibration failed!"
-msgstr "Seadistamine nurjus!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-msgid "You can remove the calibration device."
-msgstr "Sa võid kalibreerimisseadme nüüd eemaldada."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Palun ära häiri töötamise ajal kalibreerimisseadet"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-msgid "Laptop Screen"
-msgstr "Sülearvuti ekraan"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-msgid "Built-in Webcam"
-msgstr "Sisseehitatud veebikaamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#, c-format
-msgid "%s Monitor"
-msgstr "%s kuvar"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#, c-format
-msgid "%s Scanner"
-msgstr "%s skanner"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#, c-format
-msgid "%s Camera"
-msgstr "%s kaamera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#, c-format
-msgid "%s Printer"
-msgstr "%s printer"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#, c-format
-msgid "%s Webcam"
-msgstr "%s veebikaamera"
-
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Värvihalduse lubamine %s jaoks"
-
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s värviprofiilide näitamine"
-
-#. not calibrated
-msgid "Not calibrated"
-msgstr "Kalibreerimata"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-msgid "Default: "
-msgstr "Vaikimisi: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-msgid "Colorspace: "
-msgstr "Värviruum: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-msgid "Test profile: "
-msgstr "Katseprofiil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-msgid "Select ICC Profile File"
-msgstr "ICC profiili valimine"
-
-msgid "_Import"
-msgstr "_Impordi"
-
-#. TRANSLATORS: filter name on the file->open dialog
-msgid "Supported ICC profiles"
-msgstr "Teotatud ICC profiilid"
-
-#. TRANSLATORS: filter name on the file->open dialog
-msgid "All files"
-msgstr "Kõik failid"
-
-msgid "Screen"
-msgstr "Ekraan"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Faili üleslaadimine nurjus: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-msgid "The profile has been uploaded to:"
-msgstr "Profiil laaditi üles asukohta:"
-
-msgid "Write down this URL."
-msgstr "Kirjuta see URL üles."
-
-msgid "Restart this computer and boot your normal operating system."
-msgstr "Taaskäivita arvuti ja mine tavalisse operatsioonisüsteemi."
-
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "Sisesta brauserisse URL, et profiil allalaadida ja salvestada."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-msgid "Save Profile"
-msgstr "Profiili salvestamine"
-
-msgid "_Save"
-msgstr "_Salvesta"
-
-#. TRANSLATORS: this is when the button is sensitive
-msgid "Create a color profile for the selected device"
-msgstr "Valitud seadmele värviporfiili loomine"
-
-#. TRANSLATORS: this is when the button is insensitive
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
-"Mõõteriista ei tuvastatud. Palun veendu, et see on sisse lülitatud ja "
-"õigesti ühendatud."
 
-#. TRANSLATORS: this is when the button is insensitive
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Mõõteriist ei toeta printeri profiilimist."
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-msgid "The device type is not currently supported."
-msgstr "Seda seadmetüüpi hetkel ei toetata."
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Mitte ükski rakendus ei esita ega lindista praegu heli."
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-msgid "Standard Space"
-msgstr "Standardruum"
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-msgid "Test Profile"
-msgstr "Katseprofiil:"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automaatne"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Sirvi teisi pilte"
 
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Halb kvaliteet"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: the profile quality
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Keskmine kvaliteet"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Hea kvaliteet"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Vaikimisi RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Vaikimisi CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Vaikimisi halltoonid"
-
-msgid "Vendor supplied factory calibration data"
-msgstr "Tootja pakutavad kalibreerimise tehaseandmed"
-
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Täisekraani värviparandus pole selle profiiliga võimalik"
-
-msgid "This profile may no longer be accurate"
-msgstr "See profiil ei pruugi olla enam täpne"
-
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kuva kalibreerimine"
 
-msgid "Cancel"
-msgstr "Loobu"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Loobu"
 
 #. This starts the calibration process
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "Alusta"
 
 #. This resumes the calibration process
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "Jätka"
 
 #. This button returns the user back to the color control panel
-msgid "Done"
-msgstr "Valmis"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Valmis"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Ekraani kalibreerimine"
 
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibreerimise kvaliteet"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -425,33 +454,42 @@ msgstr ""
 "värvihalduse jaoks. Mida kauem kestab kalibreerimine, seda parema "
 "kvaliteediga profiil saadakse."
 
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "Kalibreerimise ajal arvutit kasutada ei saa."
 
 #. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Kvaliteet"
 
 #. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Hinnanguline aeg"
 
-msgid "Calibration Quality"
-msgstr "Kalibreerimise kvaliteet"
-
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Vali sensorseade, mida kalibreerimiseks kasutada."
-
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Kalibreerimise seade"
 
-msgid "Select the type of display that is connected."
-msgstr "Vali ühendatud kuvari liik."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Vali sensorseade, mida kalibreerimiseks kasutada."
 
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Kuva liik"
 
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Vali ühendatud kuvari liik."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profiili valgepunkt"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -459,9 +497,11 @@ msgstr ""
 "Vali kuva soovitud valgepunkt. Enamik kuvasid tuleks kalibreerida D65 "
 "valgustuse järgi."
 
-msgid "Profile Whitepoint"
-msgstr "Profiili valgepunkt"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Kuva heledus"
 
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -469,15 +509,18 @@ msgstr ""
 "Palun vali oma kuvari tavaline heledus. Värvid on siis kõige täpsemad just "
 "sellel heledustasemel."
 
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
 "Võib kasutada ka heledustaset, mida kasutavad selle seadme teised profiilid."
 
-msgid "Display Brightness"
-msgstr "Kuva heledus"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profiili nimi"
 
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -485,42 +528,42 @@ msgstr ""
 "Seda profiili võib kasutada ka teistel arvutitel või luua erinevad profiilid "
 "erineva valgustuse jaoks."
 
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Profiili nimi:"
 
-msgid "Profile Name"
-msgstr "Profiili nimi"
-
-msgid "Profile successfully created!"
-msgstr "Profiil on edukalt loodud!"
-
-msgid "Copy profile"
-msgstr "Kopeeri profiil"
-
-msgid "Requires writable media"
-msgstr "Vajalik on kirjutatav meedia"
-
-msgid "Upload profile"
-msgstr "Laadi profiil üles"
-
-msgid "Requires Internet connection"
-msgstr "Vajalik on internetiühendus"
-
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"Kasulikuks võib osutuda juhend nende profiilide kasutamise kohta <a href="
-"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> või <a href=\"windows"
-"\">Microsoft Windows</a> süsteemidel."
-
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Kokkuvõte"
 
-msgid "Import File…"
-msgstr "Faili importimine…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profiil on edukalt loodud!"
 
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopeeri profiil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Vajalik on kirjutatav meedia"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Kasulikuks võib osutuda juhend nende profiilide kasutamise kohta <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> või <a "
+"href=\"windows\">Microsoft Windows</a> süsteemidel."
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Lisa profiil"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
@@ -528,2127 +571,2280 @@ msgstr ""
 "Tuvastati probleeme. Profiilid ei pruugi õigesti töötada. <a href=\"\">Näita "
 "üksikasju.</a>"
 
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "Faili importimine…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Lisa"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "Iga värvihaldusega seadme jaoks on vaja värsket värviprofiili."
 
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Rohkem teavet"
 
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Rohkem teavet värvihalduse kohta"
 
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "Määra kõigile kasutajaile"
 
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Määrata see profiil kõigile selle arvuti kasutajatele"
 
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "Lubatud"
 
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "Lisa profiil"
 
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "Kalibreerimine..."
 
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Seadme kalibreerimine"
 
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "Eemalda profiil"
 
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "Vaata üksikasju"
 
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "Ei tuvastatud ühtegi seadet, millele oleks võimalik värvihaldust teha"
 
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Projektor"
 
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plasma"
 
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL taustvalgus)"
 
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED taustvalgus)"
 
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (valge LED taustvalgus)"
 
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Laia vahemikuga LCD (CCFL taustvalgus)"
 
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Laia vahemikuga LCD (RGB LED taustvalgus)"
 
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Hea"
 
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 minutit"
 
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Keskmine"
 
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 minutit"
 
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Halb"
 
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 minutit"
 
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Kuvale loomulik"
 
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (trükkimine)"
 
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (fotograafia ja graafika)"
 
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Värvid"
 
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Seadmete värvide kalibreerimine kuvaritel, kaameratel ja printeritel"
 
-#. Translators: those are keywords for the color control-center panel
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Värv;ICC;Profiil;Kalibreerimine;Printer;Kuva;Ekraan;Monitor;"
 
-#. Add some common regions
-msgid "United States"
-msgstr "Ameerika Ühendriigid"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Keel"
 
-msgid "Germany"
-msgstr "Saksamaa"
+#: panels/common/cc-language-chooser.ui:13
+#, fuzzy
+msgid "_Select"
+msgstr "Vali"
 
-msgid "France"
-msgstr "Prantsusmaa"
-
-msgid "Spain"
-msgstr "Hispaania"
-
-msgid "China"
-msgstr "Hiina"
-
-msgid "Other…"
-msgstr "Muu profiil…"
-
-msgid "More…"
-msgstr "Veel…"
-
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Keeli ei leitud"
 
-msgid "Language"
-msgstr "Keel"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Veel…"
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e. %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-msgid "%e %B %Y, %R"
-msgstr "%e. %B %Y, %R"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Translators: This is the time format used in 24-hour mode.
-msgid "%R"
-msgstr "%R"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Aeg"
 
-msgid "January"
-msgstr "Jaanuar"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-msgid "February"
-msgstr "Veebruar"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-msgid "March"
-msgstr "Märts"
-
-msgid "April"
-msgstr "Aprill"
-
-msgid "May"
-msgstr "Mai"
-
-msgid "June"
-msgstr "Juuni"
-
-msgid "July"
-msgstr "Juuli"
-
-msgid "August"
-msgstr "August"
-
-msgid "September"
-msgstr "September"
-
-msgid "October"
-msgstr "Oktoober"
-
-msgid "November"
-msgstr "November"
-
-msgid "December"
-msgstr "Detsember"
-
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Kuupäev ja kellaaeg"
 
-msgid "Hour"
-msgstr "Tund"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-msgid "∶"
-msgstr "∶"
-
-msgid "Minute"
-msgstr "Minut"
-
-msgid "Day"
-msgstr "Päev"
-
-msgid "Month"
-msgstr "Kuu"
-
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "Aasta"
 
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Kuu"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Jaanuar"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Veebruar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Märts"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Aprill"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mai"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juuni"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juuli"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktoober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Detsember"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Päev"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Ajavöönd"
 
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Linna otsing"
 
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "Automaatne _kuupäev ja kellaaeg"
 
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Vajalik on internetiühendus"
 
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Kuupäev ja _kellaaeg"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "_Automaatne ajavöönd"
 
-msgid "Date & _Time"
-msgstr "Kuupäev ja _kellaaeg"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "Vajalik on internetiühendus"
 
-msgid "Time _Zone"
-msgstr "_Ajavöönd"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Lubatud"
 
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "Ajavöönd"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Päripäeva"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Aja _vorming"
 
-msgid "24-hour"
-msgstr "24 tundi"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-msgid "AM / PM"
-msgstr "EL / PL"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Kuupäevad"
 
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "Teisene"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalender"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Arvud"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Kuupäeva, kella ja ajavööndi muutmine"
 
-#. Translators: those are keywords for the date and time control-center panel
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Kell;Ajavöönd;Asukoht;"
 
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "Süsteemi kella ja kuupäeva muutmine"
 
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Kella või kuupäeva muutmiseks pead end autentima."
 
-msgid "Lid Closed"
-msgstr "Ekraan suletud"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Veeb"
 
-#. translators: "Mirrored" describes when both displays show the same view
-msgid "Mirrored"
-msgstr "Peegeldatud"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Meil"
 
-msgid "Primary"
-msgstr "Peamine"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalender"
 
-msgid "Off"
-msgstr "Väljas"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_uusika"
 
-msgid "Secondary"
-msgstr "Teisene"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
 
-msgid "Arrange Combined Displays"
-msgstr "Kombineeritud ekraanide paigutus"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotod:"
 
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Vaikimisi rakendused"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Vaikimisi rakendused"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Rakenda"
 
-msgid "Drag displays to rearrange them"
-msgstr "Ekraanide ümberpaigutamiseks lohista."
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Tagasi"
 
-msgid "Size"
-msgstr "Suurus"
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Bluetooth on väljas"
 
-#. aspect ratio
-msgid "Aspect Ratio"
-msgstr "Külgede suhe"
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "_Tuvasta kuvad"
 
-msgid "Resolution"
-msgstr "Eraldusvõime"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
 
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "Ülemist riba ja tegevuste ülevaadet kuvatakse sellel ekraanil"
-
-msgid "Secondary Display"
-msgstr "Teisene ekraan"
-
-msgid "Join this display with another to create an extra workspace"
-msgstr "Ühenda see kuva mõne teisega, et luua lisatööala"
-
-msgid "Presentation"
-msgstr "Esitlus"
-
-msgid "Show slideshows and media only"
-msgstr "Näidatakse ainult slaidiesitlusi ja meediat"
-
-#. translators: "Mirror" describes when both displays show the same view
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Peegeldatud"
 
-msgid "Show your existing view on both displays"
-msgstr "Näidatakse sama pilti mõlemal ekraanil"
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
 
-msgid "Turn Off"
-msgstr "Lülita välja"
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Teisene ekraan"
 
-msgid "Don't use this display"
-msgstr "Seda ekraani ei kasutata"
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "Parem ratas"
 
-msgid "Could not get screen information"
-msgstr "Ekraani andmeid pole võimalik hankida"
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Suund"
 
-msgid "_Arrange Combined Displays"
-msgstr "_Paiguta kombineeritud ekraanid"
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Eraldusvõime"
 
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Värskendussagedus"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Kogu pilt nähtaval"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Ühtegi printerit pole saadaval"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Taaskäivita kohe"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Kellaajad"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Tund"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minut"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
 msgid "Displays"
 msgstr "Kuvad"
 
+#: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Kuvarite ja projektorite kasutuse muutmine"
 
-#. Translators: those are keywords for the display control-center panel
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
 msgstr ""
 "Paneel;Projektor;xrandr;Ekraan;Resolutsioon;Eraldusvõime;Lahutusvõime;"
 "Värskendamissagedus;"
 
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. TRANSLATORS: AP type
-msgid "Unknown"
-msgstr "Tundmatu"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Turvaklahv"
 
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s, %d-bitine"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Tindi kogus"
 
-#, c-format
-msgid "%d-bit"
-msgstr "%d-bitine"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Tindi kogus"
 
-msgid "Ask what to do"
-msgstr "Küsitakse, mida teha"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Tindi kogus"
 
-msgid "Do nothing"
-msgstr "Ära tee midagi"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-msgid "Open folder"
-msgstr "Ava kataloog"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Turvalisus"
 
-msgid "Other Media"
-msgstr "Muu meedia"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
 
-msgid "Select an application for audio CDs"
-msgstr "Audio-CD jaoks kasutatava rakenduse valimine"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ekraan;lukk;diagnostika;privaatsus;privaatne;hiljutine;ajutine;tmp;temp;"
+"indeks;nimi;nimed;võrk;ühendus;identiteet;"
 
-msgid "Select an application for video DVDs"
-msgstr "Video-DVD jaoks kasutatava rakenduse valimine"
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Seadme nimi"
 
-msgid "Select an application to run when a music player is connected"
-msgstr "Vali rakendus, mis tuleb käivitada muusikamängija ühendamisel"
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Riistvaraline aadress"
 
-msgid "Select an application to run when a camera is connected"
-msgstr "Vali rakendus, mis tuleb käivitada kaamera ühendamisel"
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Mälu"
 
-msgid "Select an application for software CDs"
-msgstr "Tarkvara CD-de jaoks rakenduse valimine"
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Protsessor"
 
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-msgid "audio DVD"
-msgstr "audio-DVD"
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Graafika"
 
-msgid "blank Blu-ray disc"
-msgstr "tühi Blu-ray plaat"
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
 
-msgid "blank CD disc"
-msgstr "tühi CD-plaat"
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Arvutamine…"
 
-msgid "blank DVD disc"
-msgstr "tühi DVD-plaat"
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Nimi"
 
-msgid "blank HD DVD disc"
-msgstr "tühi HD DVD plaat"
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
 
-msgid "Blu-ray video disc"
-msgstr "Blu-ray videoplaat"
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Tüüp"
 
-msgid "e-book reader"
-msgstr "e-raamatu lugeja"
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Versioon 0"
 
-msgid "HD DVD video disc"
-msgstr "HD DVD videoplaat"
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Valikute laadimine…"
 
-msgid "Picture CD"
-msgstr "Pildi-CD"
-
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-msgid "Video CD"
-msgstr "Video-CD"
-
-msgid "Windows software"
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
 msgstr "Windowsi tarkvara"
 
-msgid "Section"
-msgstr "Sektsioon"
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualiseerimine"
 
-msgid "Overview"
-msgstr "Ülevaade"
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Tarkvarakasutus"
 
-msgid "Default Applications"
-msgstr "Vaikimisi rakendused"
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Seadme eemaldamine"
 
-msgid "Removable Media"
-msgstr "Eemaldatav meedium"
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
 
-#, c-format
-msgid "Version %s"
-msgstr "Versioon %s"
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Seadme nimi"
 
-msgid "Details"
-msgstr "Üksikasjad"
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_Kasutajanimi"
 
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr "Süsteemi andmete kuvamine"
 
-#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "seade;seadmed;süsteem;andmed;info;mälu;protsessor;versioon;vaikimisi;"
 "rakendus;eelistatud;eelis;cd;dvd;usb;audio;heli;video;plaat;eemaldatav;"
 "meedia;isekäivituv;automaatkäivitus;"
 
-msgid "Select how other media should be handled"
-msgstr "Ülejäänud meediumile käsitlemismeetodi valimine"
-
-msgid "_Action:"
-msgstr "_Tegevus:"
-
-msgid "_Type:"
-msgstr "_Liik:"
-
-msgid "Device name"
-msgstr "Seadme nimi"
-
-msgid "Memory"
-msgstr "Mälu"
-
-msgid "Processor"
-msgstr "Protsessor"
-
-#. To translators: this field contains the distro name, version and type
-msgid "Base system"
-msgstr "Baassüsteem"
-
-msgid "Disk"
-msgstr "Ketas"
-
-msgid "Calculating…"
-msgstr "Arvutamine…"
-
-msgid "Graphics"
-msgstr "Graafika"
-
-msgid "Virtualization"
-msgstr "Virtualiseerimine"
-
-msgid "Check for updates"
-msgstr "Uuenduste küsimine"
-
-msgid "_Web"
-msgstr "_Veeb"
-
-msgid "_Mail"
-msgstr "_Meil"
-
-msgid "_Calendar"
-msgstr "_Kalender"
-
-msgid "M_usic"
-msgstr "M_uusika"
-
-msgid "_Video"
-msgstr "_Video"
-
-msgid "_Photos"
-msgstr "_Fotod:"
-
-msgid "Select how media should be handled"
-msgstr "Meediumile käsitlemismeetodi valimine"
-
-msgid "CD _audio"
-msgstr "CD-_audio"
-
-msgid "_DVD video"
-msgstr "_DVD-video"
-
-msgid "_Music player"
-msgstr "_Muusikaesitaja"
-
-msgid "_Software"
-msgstr "_Tarkvara"
-
-msgid "_Other Media…"
-msgstr "_Muu meedia…"
-
-msgid "_Never prompt or start programs on media insertion"
-msgstr "_Meedia sisestamisel ei küsita kunagi rakenduste käivitamise kohta"
-
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "Heli ja meedia"
 
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Heli tummaks"
 
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Heli vaiksemaks"
 
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Heli valjemaks"
 
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Meediaesitaja käivitamine"
 
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Esitamine (või esita/pausi)"
 
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Taasesituse pausimine"
 
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Taasesituse peatamine"
 
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Eelmine lugu"
 
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Järgmine lugu"
 
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Väljasta"
 
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Tippimine"
 
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "Järgmisele sisendile vahetamine"
 
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "Eelmisele sisendile vahetamine"
 
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "Käivitajad"
 
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Abi sirvija käivitamine"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Sätted"
+
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Kalkulaatori käivitamine"
 
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "E-posti kliendi käivitamine"
 
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "Veebibrauseri käivitamine"
 
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "Kodukataloog"
 
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "Otsing"
 
-msgid "Screenshots"
-msgstr "Ekraanipildid"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-msgid "Save a screenshot to $PICTURES"
-msgstr "Ekraanipildi salvestamine $PICTURES kausta"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Aknast tehtud ekraanipildi salvestamine $PICTURES kausta"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Alast tehtud ekraanipildi salvestamine $PICTURES kausta"
-
-msgid "Copy a screenshot to clipboard"
-msgstr "Ekraanipildi kopeerimine lõikepuhvrisse"
-
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Akna ekraanipildi kopeerimine lõikepuhvrisse"
-
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Ala ekraanipildi kopeerimine lõikepuhvrisse"
-
-msgid "Record a short screencast"
-msgstr "Lühikese ekraanisalvestuse lindistamine"
-
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Süsteem"
 
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "Logi välja"
 
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "Ekraani lukustamine"
 
-msgid "Universal Access"
-msgstr "Pärssimata juurdepääs"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "Nähtavus"
 
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "Luubi sisse või välja lülitamine"
 
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "Suurendamine"
 
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "Vähendamine"
 
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "Ekraanilugeja sisse või välja lülitamine"
 
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "Ekraaniklaviatuuri sisse või välja lülitamine"
 
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "Teksti suuruse suurendamine"
 
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "Teksti suuruse vähendamine"
 
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "Kõrge kontrast sisse või välja"
 
-#. translators:
-#. * The device has been disabled
-msgid "Disabled"
-msgstr "Välja lülitatud"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Sisendseadme lisamine"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-msgid "Alternative Characters Key"
-msgstr "Alternatiivne märgiklahv"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "Sisestusmeetodeid pole võimalik sisselogimisekraanil kasutada"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-msgid "Compose Key"
-msgstr "Koosteklahv (compse)"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Ühtegi sisendseadet pole valitud"
 
-msgid "Modifiers-only switch to next source"
-msgstr "Ainult modifikaatoritega järgmisele allikale lülitumine"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Valikud"
 
-msgid "Keyboard"
-msgstr "Klaviatuur"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Liiguta üles"
 
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr ""
-"Kiirklahvide vaatamine ja muutmine ning sisestamise eelistuste muutmine"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Liiguta alla"
 
-#. Translators: those are keywords for the keyboard control-center panel
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Kiirklahv;Kordus;Vilkumine;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Eelistused"
 
-msgid "Custom Shortcut"
-msgstr "Kohandatud kiirklahv"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Kiirklahvid"
 
-msgid "_Add"
-msgstr "_Lisa"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Eemalda"
 
-msgid "_Name:"
-msgstr "_Nimi:"
-
-msgid "C_ommand:"
-msgstr "Kä_sk:"
-
-msgid "Repeat Keys"
-msgstr "Klahvide kordamine"
-
-msgid "Key presses _repeat when key is held down"
-msgstr "Klahvivajutus k_ordub, kui klahvi hoitakse all"
-
-msgid "_Delay:"
-msgstr "_Viivitus:"
-
-msgid "_Speed:"
-msgstr "Kii_rus:"
-
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "Lühike"
-
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "Aeglane"
-
-msgid "Repeat keys speed"
-msgstr "Klahvide kordamise kiirus"
-
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "Pikk"
-
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "Kiire"
-
-msgid "Cursor Blinking"
-msgstr "Kursori vilkumine"
-
-msgid "Cursor _blinks in text fields"
-msgstr "Kursor _vilgub tekstiväljadel"
-
-msgid "S_peed:"
-msgstr "_Kiirus:"
-
-msgid "Cursor blink speed"
-msgstr "Kursori vilkumiskiirus"
-
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "Sisendseadmed"
 
-msgid "Add Shortcut"
-msgstr "Välksõrmise lisamine"
-
-msgid "Remove Shortcut"
-msgstr "Eemalda välksõrmis"
-
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"Välksõrmise muutmiseks klõpsa vastaval real ja määra uus sõrmis. Nullimiseks "
-"vajuta Backspace klahvi."
 
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Sisendseadme valikud"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "_Sama paigutuse kasutamine kõigil akendel"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "Iga akna jaoks _oma paigutuse lubamine"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "Alternatiivne märgiklahv"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Koosteklahv (compse)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Kiirklahvid"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Kohandatud kiirklahvid"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sektsioon"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "Välksõrmised"
 
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Välksõrmise lisamine"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "Kohandatud kiirklahvid"
 
-msgid "<Unknown Action>"
-msgstr "<tundmatu tegevus>"
-
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"Kiirklahvi \"%s\" pole võimalik kasutada, kuna see teeb selle klahvi "
-"kasutamise tavaolukorras võimatuks.\n"
-"Palun proovi klahvi kombineerida klahvidega Control, Alt või Shift."
 
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Välksõrmise lisamine"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Kiirklahvid"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Eemalda"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "_Asenda"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"Kiirklahvi \"%s\" juba kasutatakse järgneva tegevuse jaoks:\n"
-"\"%s\""
 
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"Kui sa määrad selle kiirklahvi tegevusele \"%s\", siis tegevuse \"%s\" "
-"kiirklahv keelatakse."
 
-msgid "_Reassign"
-msgstr "_Määra"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nimi"
 
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Kä_sk:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+#, fuzzy
+msgid "Shortcut"
+msgstr "Välksõrmised"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Uus kiirklahv…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Pole"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klaviatuur"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Kiirklahvide vaatamine ja muutmine ning sisestamise eelistuste muutmine"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Mitte ükski rakendus ei esita ega lindista praegu heli."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Ekraani väljalülitumisel"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Rakendusi ei leitud"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "_Proovi oma sätteid"
 
-msgid "Test Your Settings"
-msgstr "Proovi oma sätteid"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Üldine"
 
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "Peamine _nupp"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Vasak"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Parem"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Otsingu asukohad"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Hiir"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "_Hiire klahvid"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Alla kerimine"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Luubi kursor liigub koos sisuga"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Puutepadi"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Puutepadi"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Meetod"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "_Klõpsamiseks koputa"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "_Klõpsamiseks koputa"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_Tippimise ajal on puutepadi keelatud"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Puutepadi (suhteline)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Paremale kerimine"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Vasakule kerimine"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Kahepoolne"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Proovi klõpsamist, topeltklõpsu ja kerimist"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "Hiir ja puutepadi"
 
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "Hiire või puutepadja tundlikkuse ja käelisuse muutmine"
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Puutepadi;Kursor;Klõps;Topelt;Nupp;Kerimine;"
 
-msgid "General"
-msgstr "Üldine"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "Aeglane"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-msgid "Double-click timeout"
-msgstr "Topeltklõpsu ajapiirang"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "Kiire"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-msgid "_Double-click"
-msgstr "_Topeltklõps"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Värviruum: "
 
-msgid "Primary _button"
-msgstr "Peamine _nupp"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "_Vasak"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "_Prügikasti automaatne tühjendamine"
 
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "_Parem"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-msgid "Mouse"
-msgstr "Hiir"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-msgid "_Pointer speed"
-msgstr "_Kursori kiirus"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "Aeglane"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Kuvar"
 
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "Kiire"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Lohista peakuva muutmiseks."
 
-msgid "Touchpad"
-msgstr "Puutepadi"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "Aeglane"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Rakendused"
 
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "Kiire"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-msgid "Disable while _typing"
-msgstr "_Tippimise ajal on puutepadi keelatud"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-msgid "Tap to _click"
-msgstr "_Klõpsamiseks koputa"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-msgid "Two _finger scroll"
-msgstr "_Kahe sõrmega kerimine"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-msgid "_Natural scrolling"
-msgstr "_Loomulik kerimine"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-msgid "Try clicking, double clicking, scrolling"
-msgstr "Proovi klõpsamist, topeltklõpsu ja kerimist"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Seadmed"
 
-msgid "Five clicks, GEGL time!"
-msgstr "Viis klõpsu GEGL-i kord!"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-msgid "Double click, primary button"
-msgstr "Topeltklõps, peamine nupp"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Uue ühenduse lisamine"
 
-msgid "Single click, primary button"
-msgstr "Üks klõps, peamine nupp"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-msgid "Double click, middle button"
-msgstr "Topeltklõps, keskmine nupp"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Ühendatud"
 
-msgid "Single click, middle button"
-msgstr "Üks klõps, keskmine nupp"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Valikud…"
 
-msgid "Double click, secondary button"
-msgstr "Topeltklõps, teine nupp"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-msgid "Single click, secondary button"
-msgstr "Üks klõps, teine nupp"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi tugijaam (hotspot)"
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-msgid "Air_plane Mode"
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "_Võrgu nimi"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Parool"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Grupi parool"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Praegune _parool"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Lülita sisse"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
 msgstr "_Lennukirežiim"
 
-msgid "Network proxy"
-msgstr "Võrgu proksi"
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Ühtegi pilti ei leitud"
 
-#. TRANSLATORS: the user is running a NM that is not API compatible
-msgid "The system network services are not compatible with this version."
-msgstr "Süsteemi võrguteenused ei sobi selle versiooniga."
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
 
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "_Lennukirežiim"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi tugijaam (hotspot)"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Kasuta hotspotina..."
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Võrk"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _turvalisus"
 
-msgid "page 1"
-msgstr "leht 1"
-
-msgid "Anony_mous identity"
-msgstr "_Anonüümne identiteet"
-
-msgid "Inner _authentication"
-msgstr "Sisemine _autentimine"
-
-msgid "page 2"
-msgstr "leht 2"
-
-msgid "Security"
-msgstr "Turvalisus"
-
-msgid "automatic"
-msgstr "automaatne"
-
-#. TRANSLATORS: this WEP WiFi security
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-msgid "Enterprise"
-msgstr "Ettevõtte"
-
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Puudub"
-
-msgid "Never"
-msgstr "Mitte kunagi"
-
-msgid "Today"
-msgstr "Täna"
-
-msgid "Yesterday"
-msgstr "Eile"
-
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i päev tagasi"
 msgstr[1] "%i päeva tagasi"
 
-#. Translators: network device speed
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Puudub"
-
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Nõrk"
-
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Piisav"
-
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Tugev"
-
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Suurepärane"
-
-msgid "Identity"
-msgstr "Identiteet"
-
-msgid "Address"
-msgstr "Aadress"
-
-msgid "Netmask"
-msgstr "Võrgumask"
-
-msgid "Gateway"
-msgstr "Lüüs"
-
-msgid "Delete Address"
-msgstr "Kustuta aadress"
-
-msgid "Add"
-msgstr "Lisa"
-
-msgid "Server"
-msgstr "Server"
-
-msgid "Delete DNS Server"
-msgstr "Kustuta DNS server"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "Meetrika"
-
-msgid "Delete Route"
-msgstr "Kustuta marsruut"
-
-msgid "Automatic (DHCP)"
-msgstr "Automaatne (DHCP)"
-
-msgid "Manual"
-msgstr "Käsitsi"
-
-msgid "Link-Local Only"
-msgstr "Ainult kohalik võrk (link-local)"
-
-msgid "IPv4"
-msgstr "IPv4"
-
-msgid "Prefix"
-msgstr "Prefiks"
-
-msgid "Automatic"
-msgstr "Automaatne"
-
-msgid "Automatic, DHCP only"
-msgstr "Automaatne, ainult DHCP"
-
-msgid "IPv6"
-msgstr "IPv6"
-
-msgid "Reset"
-msgstr "Lähtesta"
-
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Puudub"
-
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-biti võti (Hex või ASCII)"
-
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-biti parool"
-
-msgid "LEAP"
-msgstr "LEAP"
-
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dünaamiline WEP (802.1x)"
-
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 isiklik"
-
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 ettevõtte"
-
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Signaali tugevus"
 
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Ühenduse kiirus"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Turvalisus"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4-aadress"
 
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6-aadress"
 
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Riistvaraline aadress"
 
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Teotatud ICC profiilid"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Vaikimisi marsruut"
 
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Viimati kasutatud"
 
-msgid "Twisted Pair (TP)"
-msgstr "Pööratud paar (TP)"
-
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Attachment Unit Interface (AUI)"
-
-msgid "BNC"
-msgstr "BNC"
-
-msgid "Media Independent Interface (MII)"
-msgstr "Meediumist sõltumatu liides (MII)"
-
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-msgid "_Name"
-msgstr "_Nimi"
-
-msgid "_MAC Address"
-msgstr "_MAC-aadress"
-
-msgid "M_TU"
-msgstr "M_TU"
-
-msgid "_Cloned Address"
-msgstr "_Kloonitud aadress"
-
-msgid "bytes"
-msgstr "baiti"
-
-msgid "Make available to other _users"
-msgstr "Saadaval teistele _kasutajatele"
-
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "_Automaane ühendumine"
 
-msgid "Firewall _Zone"
-msgstr "Tulemüüri _tsoon"
-
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "Vaikimisi"
-
-msgid "The zone defines the trust level of the connection"
-msgstr "Tsoon määrab ühenduse usaldusväärsuse"
-
-msgid "IPv_4"
-msgstr "IPv_4"
-
-msgid "_Addresses"
-msgstr "_Aadressid"
-
-msgid "Automatic DNS"
-msgstr "Automaatne DNS"
-
-msgid "Routes"
-msgstr "Marsruudid"
-
-msgid "Automatic Routes"
-msgstr "Automaatsed marsruudid"
-
-msgid "Use this connection _only for resources on its network"
-msgstr "Seda ühendust kasutatakse _ainult võrgu ressursside jaoks"
-
-msgid "IPv_6"
-msgstr "IPv_6"
-
-msgid "Unable to open connection editor"
-msgstr "Ühenduse redaktori avamine polnud võimalik"
-
-msgid "New Profile"
-msgstr "Uus profiil"
-
-msgid "VPN"
-msgstr "VPN"
-
-msgid "Bond"
-msgstr "Side"
-
-msgid "Team"
-msgstr "Meeskond"
-
-msgid "Bridge"
-msgstr "Sild"
-
-msgid "VLAN"
-msgstr "VLAN"
-
-msgid "Could not load VPN plugins"
-msgstr "VPN pluginaid polnud võimalik laadida"
-
-msgid "Import from file…"
-msgstr "Failist importimine…"
-
-msgid "Add Network Connection"
-msgstr "Uue ühenduse lisamine"
-
-msgid "_Reset"
-msgstr "_Lähtesta"
-
-msgid "_Forget"
-msgstr "_Unusta"
-
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"Lähtestakse selle võrgu sätted, sealhulgas paroolid, aga see jäetakse "
-"eelistatud võrguks"
-
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"Eemaldatakse kõik selle võrgu üksiksasjad ning sellesse võrku ei püüta "
-"hiljem ühenduda"
-
-msgid "S_ecurity"
-msgstr "_Turvalisus"
-
-msgid "Cannot import VPN connection"
-msgstr "VPN ühendust pole võimalik importida"
-
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Faili '%s' pole võimalik lugeda või see ei sisalda äratuntavaid andmeid VPN "
-"ühenduse kohta\n"
-"\n"
-"Viga: %s."
-
-msgid "Select file to import"
-msgstr "Importimiseks faili valimine"
-
-msgid "_Open"
-msgstr "_Ava"
-
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "Fail nimega '%s' on juba olemas."
-
-msgid "_Replace"
-msgstr "_Asenda"
-
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Kas tahad asendada %s praegu salvestatava VPN ühendusega?"
-
-msgid "Cannot export VPN connection"
-msgstr "VPN ühendust pole võimalik eksportida"
-
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN ühendust '%s' pole võimalik eksportida faili %s.\n"
-"\n"
-"Viga: %s."
-
-msgid "Export VPN connection..."
-msgstr "VPN ühenduse eksportimine..."
-
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(viga: VPN ühenduse redaktorit ei leitud)"
-
-msgid "_SSID"
-msgstr "_SSID"
-
-msgid "_BSSID"
-msgstr "_BSSID"
-
-msgid "My Home Network"
-msgstr "Minu koduvõrk"
-
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Saadaval _kõigile kasutajatele"
 
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nimi"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC-aadress"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Kloonitud aadress"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "baiti"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "_Meetod"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automaatne (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Ainult kohalik võrk (link-local)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Käsitsi"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Välja lülitatud"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "Jagatud teiste arvutitega"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_Aadressid"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Aadress"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Võrgumask"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Lüüs"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Automaatne"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automaatne DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Marsruudid"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automaatsed marsruudid"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "Meetrika"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Seda ühendust kasutatakse _ainult võrgu ressursside jaoks"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "_Meetod"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automaatne, ainult DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefiks"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_Turvalisus"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(viga: VPN ühenduse redaktorit ei leitud)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "Võrk"
 
+#: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Internetiga ühendumise viisi muutmine"
 
-#. Translators: those are keywords for the network control-center panel
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "võrk;kohtvõrk;ühendus;juhtmeta;juhtmevaba;traadita;Wi-Fi;WiFi;IP;LAN;proksi;"
 "WAN;mobiiliühendus;modem;Bluetooth;VPN;VLAN;sild;sillatud;ühendatud;"
 
-msgid "Bond slaves"
-msgstr "Sideme alamad"
-
-msgid "(none)"
-msgstr "(pole)"
-
-msgid "Bridge slaves"
-msgstr "Silla alamad"
-
-msgid "never"
-msgstr "mitte kunagi"
-
-msgid "today"
-msgstr "täna"
-
-msgid "yesterday"
-msgstr "eile"
-
-msgid "IP Address"
-msgstr "IP-aadress"
-
-msgid "Last used"
-msgstr "Viimati kasutatud"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-msgid "Wired"
-msgstr "Juhtmega"
-
-msgid "Options…"
-msgstr "Valikud…"
-
-#, c-format
-msgid "Profile %d"
-msgstr "Profiil %d"
-
-msgid "Add new connection"
-msgstr "Uue ühenduse lisamine"
-
-msgid "Team slaves"
-msgstr "Meeskonna alamad"
-
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-"Kui su internetiühendus ei tule juhtmeta võrgu kaudu, võid kasutada juhtmeta "
-"võrku teistele internetiühenduse jagamiseks."
-
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-"Juhtmeta võrgu kaudu jagamise (hotspot) sisselülitamine katkestab ühenduse "
-"võrguga <b>%s</b>."
-
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"Pole võimalik ühenduda internetti juhtmeta võrgu kaudu, kuni hotspot on "
-"aktiivne."
-
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Kas seisata tugijaam ja ühendada kasutajad lahti?"
-
-msgid "_Stop Hotspot"
-msgstr "_Seiska tugijaam"
-
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Süsteemireegel keelab Hotspotina kasutamine"
-
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Juhtmevaba seade ei toeta Hotspot režiimi"
-
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Valitud võrkude andmed, sealhulgas parool ja eriseadistused, lähevad kaotsi."
-
-msgid "History"
-msgstr "Ajalugu"
-
-msgid "_Close"
-msgstr "_Sulge"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Unusta"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Veebiproksi isetuvastust kasutatakse siis, kui seadistamise URL pole "
-"määratud."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-msgid "This is not recommended for untrusted public networks."
-msgstr "See ei ole mitteusaldatavates avalikes võrkudes soovitatav."
-
-msgid "Proxy"
-msgstr "Proksi"
-
-msgid "_Add Profile…"
-msgstr "_Lisa profiil…"
-
-msgid "IMEI"
-msgstr "IMEI"
-
-msgid "Provider"
-msgstr "Teenusepakkuja"
-
-msgctxt "proxy method"
-msgid "None"
-msgstr "Puudub"
-
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "Käsitsi"
-
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "Automaatne"
-
-msgid "_Method"
-msgstr "_Meetod"
-
-msgid "_Configuration URL"
-msgstr "_Seadistuste URL"
-
-msgid "_HTTP Proxy"
-msgstr "_HTTP proksi"
-
-msgid "H_TTPS Proxy"
-msgstr "H_TTPS proksi"
-
-msgid "_FTP Proxy"
-msgstr "_FTP proksi"
-
-msgid "_Socks Host"
-msgstr "_Socks host"
-
-msgid "_Ignore Hosts"
-msgstr "_Hostide ignoreerimine"
-
-msgid "HTTP proxy port"
-msgstr "HTTP proksi port"
-
-msgid "HTTPS proxy port"
-msgstr "HTTPS proksi port"
-
-msgid "FTP proxy port"
-msgstr "FTP proksi port"
-
-msgid "Socks proxy port"
-msgstr "Socks proksi port"
-
-msgid "Turn device off"
-msgstr "Lülita seade välja"
-
-msgid "Add Device"
-msgstr "Lisa seade"
-
-msgid "Remove Device"
-msgstr "Seadme eemaldamine"
-
-msgid "VPN Type"
-msgstr "VPNi tüüp"
-
-msgid "Group Name"
-msgstr "Grupi nimi"
-
-msgid "Group Password"
-msgstr "Grupi parool"
-
-msgid "Username"
-msgstr "Kasutajanimi"
-
-msgid "Turn VPN connection off"
-msgstr "Lülita VPN ühendus välja"
-
-msgid "Automatic _Connect"
-msgstr "_Automaatne ühendumine"
-
-msgid "details"
-msgstr "üksikasjad"
-
-msgid "_Password"
-msgstr "_Parool"
-
-msgid "None"
-msgstr "Pole"
-
-msgid "Show P_assword"
-msgstr "_Parooli näitamine"
-
-msgid "Make available to other users"
-msgstr "Saadaval teistele kasutajatele"
-
-msgid "identity"
-msgstr "identiteet"
-
-msgid "Automatic (DHCP) addresses only"
-msgstr "Automaatselt ainult (DHCP) aadressid"
-
-msgid "Link-local only"
-msgstr "Ainult kohalik võrk (link-local)"
-
-msgid "Shared with other computers"
-msgstr "Jagatud teiste arvutitega"
-
-msgid "_Ignore automatically obtained routes"
-msgstr "_Automaatselt hangitud marsruutide eiramine"
-
-msgid "ipv4"
-msgstr "ipv4"
-
-msgid "ipv6"
-msgstr "ipv6"
-
-msgid "_Cloned MAC Address"
-msgstr "_Kloonitud MAC aadress"
-
-msgid "hardware"
-msgstr "riistvara"
-
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"Lähtestakse selle võrgu sätted, sealhulgas paroolid, aga see jäetakse "
-"eelistatud võrguks."
-
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"Eemaldatakse kõik selle võrgu üksiksasjad ning sellesse võrku ei püüta "
-"hiljem ühenduda."
-
-msgid "reset"
-msgstr "lähtesta"
-
-msgid "Hardware"
-msgstr "Riistvara"
-
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi tugijaam (hotspot)"
-
-msgid "_Turn On"
-msgstr "_Lülita sisse"
-
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-msgid "Turn Wi-Fi off"
-msgstr "Lülita Wi-Fi välja"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Internetiga ühendumise viisi muutmine"
 
-msgid "_Use as Hotspot…"
-msgstr "_Kasuta hotspotina..."
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"võrk;kohtvõrk;ühendus;juhtmeta;juhtmevaba;traadita;Wi-Fi;WiFi;IP;LAN;proksi;"
+"WAN;mobiiliühendus;modem;Bluetooth;VPN;VLAN;sild;sillatud;ühendatud;"
 
-msgid "_Connect to Hidden Network…"
-msgstr "_Ühendu varjatud võrguga..."
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Juhtmega"
 
-msgid "_History"
-msgstr "_Ajalugu"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Lülita seade välja"
 
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Wi-Fi võrguga ühendumiseks lülita välja"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Aktiivsed printimistööd"
 
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Teenusepakkuja"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-aadress"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Võrgu proksi"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP proksi"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS proksi"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP proksi"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks host"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Hostide ignoreerimine"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP proksi port"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS proksi port"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP proksi port"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks proksi port"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Seadistuste URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Lülita VPN ühendus välja"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "_Võrgu nimi"
 
-msgid "Connected Devices"
-msgstr "Ühendatud seadmed"
-
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Turvaliik"
 
-msgid "Security key"
-msgstr "Turvaklahv"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Parool"
 
-#. TRANSLATORS: AP type
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Lülita Wi-Fi välja"
 
-#. TRANSLATORS: AP type
-msgid "Infrastructure"
-msgstr "Infrastruktuur"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Valikute laadimine…"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-msgid "Status unknown"
-msgstr "Olek teadmata"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Ühendu varjatud võrguga..."
 
-#. TRANSLATORS: device status
-msgid "Unmanaged"
-msgstr "Haldamata"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi tugijaam (hotspot)"
 
-#. TRANSLATORS: device status
-msgid "Unavailable"
-msgstr "Pole saadaval"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-msgid "Connecting"
-msgstr "Ühendumine"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-msgid "Authentication required"
-msgstr "Autentimine on vajalik"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-msgid "Connected"
-msgstr "Ühendatud"
-
-#. TRANSLATORS: device status
-msgid "Disconnecting"
-msgstr "Ühenduse katkestamine"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-msgid "Connection failed"
-msgstr "Ühendumine nurjus"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-msgid "Status unknown (missing)"
-msgstr "Olek teadmata (puudub)"
-
-#. TRANSLATORS: VPN status
-msgid "Not connected"
-msgstr "Pole ühendatud"
-
-#. TRANSLATORS: device status reason
-msgid "Configuration failed"
-msgstr "Seadistamine nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "IP configuration failed"
-msgstr "IP seadistamine nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "IP configuration expired"
-msgstr "IP seadistus aegus"
-
-#. TRANSLATORS: device status reason
-msgid "Secrets were required, but not provided"
-msgstr "Vajalik on parool, aga seda ei antud"
-
-#. TRANSLATORS: device status reason
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x supplicant-iga katkes ühendus"
-
-#. TRANSLATORS: device status reason
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x supplicant-i seadistus nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "802.1x supplicant failed"
-msgstr "802.1x supplicant nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant-il läks autentimiseks liiga kaua"
-
-#. TRANSLATORS: device status reason
-msgid "PPP service failed to start"
-msgstr "PPP teenuse käivitamine nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "PPP service disconnected"
-msgstr "PPP teenuse ühendus katkes"
-
-#. TRANSLATORS: device status reason
-msgid "PPP failed"
-msgstr "PPP nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "DHCP client failed to start"
-msgstr "DHCP kliendi käivitamine nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "DHCP client error"
-msgstr "DHCP kliendi viga"
-
-#. TRANSLATORS: device status reason
-msgid "DHCP client failed"
-msgstr "DHCP kliendi päring nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "Shared connection service failed to start"
-msgstr "Jagatud ühenduse teenuse käivitamine nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "Shared connection service failed"
-msgstr "Jagatud ühenduse teenus nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "AutoIP service failed to start"
-msgstr "AutoIP teenuse käivitamine nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "AutoIP service error"
-msgstr "AutoIP teenuse viga"
-
-#. TRANSLATORS: device status reason
-msgid "AutoIP service failed"
-msgstr "AutoIP teenus nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "Line busy"
-msgstr "Liin on hõivatud"
-
-#. TRANSLATORS: device status reason
-msgid "No dial tone"
-msgstr "Tooni pole"
-
-#. TRANSLATORS: device status reason
-msgid "No carrier could be established"
-msgstr "Kandjat polnud võimalik luua"
-
-#. TRANSLATORS: device status reason
-msgid "Dialing request timed out"
-msgstr "Valimise katse aegus"
-
-#. TRANSLATORS: device status reason
-msgid "Dialing attempt failed"
-msgstr "Valimise katse nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "Modem initialization failed"
-msgstr "Modemi lähtestamine nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "Failed to select the specified APN"
-msgstr "Määratud APN-i valimine nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "Not searching for networks"
-msgstr "Võrke ei otsita"
-
-#. TRANSLATORS: device status reason
-msgid "Network registration denied"
-msgstr "Võrgu registreerimine on keelatud"
-
-#. TRANSLATORS: device status reason
-msgid "Network registration timed out"
-msgstr "Võrgu registreerimine aegus"
-
-#. TRANSLATORS: device status reason
-msgid "Failed to register with the requested network"
-msgstr "Valitud võrku registreerimine nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "PIN check failed"
-msgstr "PIN-i kontroll nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "Firmware for the device may be missing"
-msgstr "Selle seadme püsivara (firmware) võib olla puudu"
-
-#. TRANSLATORS: device status reason
-msgid "Connection disappeared"
-msgstr "Ühendus kadus"
-
-#. TRANSLATORS: device status reason
-msgid "Existing connection was assumed"
-msgstr "Olemasolev ühendus on eeldatav"
-
-#. TRANSLATORS: device status reason
-msgid "Modem not found"
-msgstr "Modemit ei leitud"
-
-#. TRANSLATORS: device status reason
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth ühendus nurjus"
-
-#. TRANSLATORS: device status reason
-msgid "SIM Card not inserted"
-msgstr "SIM kaart ei ole sees"
-
-#. TRANSLATORS: device status reason
-msgid "SIM Pin required"
-msgstr "Vajalik on SIM-kaardi PIN-kood"
-
-#. TRANSLATORS: device status reason
-msgid "SIM Puk required"
-msgstr "Vajalik on SIM-kaardi PUK-kood"
-
-#. TRANSLATORS: device status reason
-msgid "SIM wrong"
-msgstr "Vale SIM"
-
-#. TRANSLATORS: device status reason
-msgid "InfiniBand device does not support connected mode"
-msgstr "InfiniBand seade ei toeta seda ühenduse režiimi"
-
-#. TRANSLATORS: device status reason
-msgid "Connection dependency failed"
-msgstr "Ühenduse sõltuvus nurjus"
-
-#. TRANSLATORS: device status
-msgid "Firmware missing"
-msgstr "Püsivara puudub"
-
-#. TRANSLATORS: device status
-msgid "Cable unplugged"
-msgstr "Juhe eemaldatud"
-
-msgid "No Certificate Authority certificate chosen"
-msgstr "Ühtegi sertifitseerimiskeskuse serti pole valitud"
-
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"Sertifitseerimiskeskuse (SK) serdi mittekasutamine võib võimaldada ühendusi "
-"ebaturvaliste, halbade Wi-Fi võrkudega. Kas tahaksid siiski valida "
-"sertifitseerimiskeskuse serdi?"
 
-msgid "Ignore"
-msgstr "Eira"
-
-msgid "Choose CA Certificate"
-msgstr "Vali SK sertifikaat"
-
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM või PKCS#12 privaatvõtmed (*.der, *.pem, *.p12)"
-
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER või PEM sertifikaadid (*.der, *.pem, *.crt, *.cer)"
-
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-msgid "Choose a PAC file..."
-msgstr "PAC faili valimine..."
-
-msgid "PAC files (*.pac)"
-msgstr "PAC failid (*.pac)"
-
-msgid "PAC _file"
-msgstr "PAC _fail"
-
-msgid "_Inner authentication"
-msgstr "_Sisemine autentimine"
-
-msgid "PAC pro_visioning"
-msgstr "PAC _tingimused"
-
-msgid " "
-msgstr " "
-
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "Anonüümne"
 
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "Autenditud"
 
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "Mõlemad"
 
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_Anonüümne identiteet"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _fail"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+#, fuzzy
+msgid "Choose a PAC file"
+msgstr "PAC faili valimine..."
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Sisemine autentimine"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC _tingimused"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_Kasutajanimi"
 
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Parool"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Parooli näitamine"
 
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-msgid "Choose a Certificate Authority certificate..."
-msgstr "Vali sertifitseerimiskeskuse sert..."
-
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "Versioon 0"
 
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "Versioon 1"
 
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "_SK sert"
 
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+#, fuzzy
+msgid "Choose a Certificate Authority certificate"
+msgstr "Vali sertifitseerimiskeskuse sert..."
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Autentimine on vajalik"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _versioon"
 
-msgid "As_k for this password every time"
-msgstr "_Seda parooli küsitakse iga kord"
-
-msgid "Unencrypted private keys are insecure"
-msgstr "Krüpteerimata privaatvõtmed pole turvalised"
-
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Valitud privaatvõti ei ole parooliga kaitstud. Seetõttu võivad turvatõendid "
-"saada kompromiteeritud. Palun vali parooliga kaitstud privaatvõti.\n"
-"\n"
-"(sa võid privaatvõtme parooliga kaitsta openssl abiga)"
-
-msgid "Choose your personal certificate..."
-msgstr "Vali oma isiklik sertifikaat..."
-
-msgid "Choose your private key..."
-msgstr "Vali oma privaatvõti..."
-
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "I_dentiteet"
 
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "_Kasutaja sertifikaat"
 
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "_Privaatvõti"
 
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Privaatvõtme parool"
 
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-msgid "Don't _warn me again"
-msgstr "_Rohkem ei hoiatata"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domeen"
 
-msgid "No"
-msgstr "Ei"
-
-msgid "Yes"
-msgstr "Jah"
-
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "Tunnelis TLS"
 
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "Kaitstud EAP (PEAP)"
 
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "_Autentimine"
 
-msgid "1 (Default)"
-msgstr "1 (vaikimisi)"
-
-msgid "2"
-msgstr "2"
-
-msgid "3"
-msgstr "3"
-
-msgid "4"
-msgstr "4"
-
-msgid "Open System"
-msgstr "Avatud süsteem"
-
-msgid "Shared Key"
-msgstr "Jagatud võti"
-
-msgid "_Key"
-msgstr "_Võti"
-
-msgid "Sho_w key"
-msgstr "_Võtit näidatakse"
-
-msgid "WEP inde_x"
-msgstr "WEP _indeks"
-
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Liik"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (vaikimisi)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Avatud süsteem"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Jagatud võti"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Võti"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Võtit näidatakse"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP _indeks"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "Teated"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "Heliteated"
 
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "Hüpikbännerite kuvamine"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "Bänneritel üksikasjade kuvamine"
-
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "Näidatakse lukustamise ekraanil"
-
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "Lukustusekraanil üksikasjade kuvamine"
-
-msgid "On"
-msgstr "Sees"
-
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "Teated"
 
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Teated"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Lukustusekraanil üksikasjade kuvamine"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Teated"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "Teadete kuvamine ja nende sisu"
 
-#. Translators: those are keywords for the notifications control-center panel
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "teated;bänner;sõnumid;teateala;hüpikaken;hüpikteade;"
 
-msgid "Show Pop Up Banners"
-msgstr "Hüpikbännerite kuvamine"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-msgid "Show in Lock Screen"
-msgstr "Näidatakse lukustamise ekraanil"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Sisemine _autentimine"
 
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Muu"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-msgid "Add Account"
-msgstr "Konto lisamine"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
 
-msgid "Mail"
-msgstr "E-post"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Netikonto lisamine"
 
-msgid "Contacts"
-msgstr "Kontaktid"
-
-msgid "Chat"
-msgstr "Vestlus"
-
-msgid "Resources"
-msgstr "Ressursid"
-
-msgid "Error logging into the account"
-msgstr "Tõrge kontole sisselogimisel"
-
-msgid "Credentials have expired."
-msgstr "Turvatõendid on aegunud."
-
-msgid "Sign in to enable this account."
-msgstr "Selle konto lubamiseks logi sisse."
-
-msgid "_Sign In"
-msgstr "_Logi sisse"
-
-msgid "Error creating account"
-msgstr "Tõrge konto loomisel"
-
-msgid "Error removing account"
-msgstr "Tõrge konto eemaldamisel"
-
-msgid "Are you sure you want to remove the account?"
-msgstr "Oled sa kindel, et soovid konto eemaldada?"
-
-msgid "This will not remove the account on the server."
-msgstr "See ei eemalda serveris olevat kontot."
-
-msgid "_Remove"
-msgstr "_Eemalda"
-
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Netikontod"
 
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Veebikontodega ühendumine ja määramine, milleks neid kasutatakse"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -2656,1779 +2852,1970 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;veeb;onlain;vestlus;kalender;meil;e-post;e-"
 "kiri;kontaktid;ownCloud;Kerberos;IMAP;SMTP;ReadItLater;"
 
-msgid "No online accounts configured"
-msgstr "Ühtegi netikontot pole seadistatud"
-
-msgid "Remove Account"
-msgstr "Konto eemaldamine"
-
-msgid "Add an online account"
-msgstr "Netikonto lisamine"
-
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"Konto lisamine võimaldab rakendustele ligipääsu dokumentidele, meilile, "
-"kontaktidele, kalendrile, vestlusele ja muule."
-
-msgid "Unknown time"
-msgstr "Tundmatu aeg"
-
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i minut"
 msgstr[1] "%i minutit"
 
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i tund"
 msgstr[1] "%i tundi"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "tund"
 msgstr[1] "tundi"
 
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
 msgstr[1] "minutit"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s täislaadimiseni"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutit"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Hoiatus: %s jäänud"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 minutit"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#, c-format
-msgid "%s remaining"
-msgstr "%s jäänud"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 minutit"
 
-#. TRANSLATORS: primary battery
-msgid "Fully charged"
-msgstr "Täis laetud"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutit"
 
-#. TRANSLATORS: primary battery
-msgid "Empty"
-msgstr "Tühi"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutit"
 
-#. TRANSLATORS: primary battery
-msgid "Charging"
-msgstr "Laadimine"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 tund"
 
-#. TRANSLATORS: primary battery
-msgid "Discharging"
-msgstr "Tühjenemine"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutit"
 
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Peamine"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutit"
 
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Ekstra"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutit"
 
-#. TRANSLATORS: secondary battery
-msgid "Wireless mouse"
-msgstr "Juhtmeta hiir"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 tundi"
 
-#. TRANSLATORS: secondary battery
-msgid "Wireless keyboard"
-msgstr "Juhtmeta klaviatuur"
-
-#. TRANSLATORS: secondary battery
-msgid "Uninterruptible power supply"
-msgstr "Katkestuseta toite allikas (UPS)"
-
-#. TRANSLATORS: secondary battery
-msgid "Personal digital assistant"
-msgstr "Isiklik digitaalassistent"
-
-#. TRANSLATORS: secondary battery
-msgid "Cellphone"
-msgstr "Mobiiltelefon"
-
-#. TRANSLATORS: secondary battery
-msgid "Media player"
-msgstr "Muusikaesitaja"
-
-#. TRANSLATORS: secondary battery
-msgid "Tablet"
-msgstr "Digitaallaud"
-
-#. TRANSLATORS: secondary battery
-msgid "Computer"
-msgstr "Arvuti"
-
-#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-power-panel.ui:58
 msgid "Battery"
 msgstr "Aku"
 
-#. TRANSLATORS: secondary battery
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Laadimine"
-
-#. TRANSLATORS: secondary battery
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Hoiatus"
-
-#. TRANSLATORS: secondary battery
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Vähe"
-
-#. TRANSLATORS: secondary battery
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Hea"
-
-#. TRANSLATORS: primary battery
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Täis laetud"
-
-#. TRANSLATORS: primary battery
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Tühi"
-
-msgid "Batteries"
-msgstr "Akud"
-
-msgid "When _idle"
-msgstr "Kui _jõude"
-
-msgid "Power Saving"
-msgstr "Voolusääst"
-
-msgid "_Screen brightness"
-msgstr "_Ekraani heledus"
-
-msgid "_Keyboard brightness"
-msgstr "_Klaviatuuri heledus"
-
-msgid "_Dim screen when inactive"
-msgstr "_Ekraan tumeneb, kui tegevust pole"
-
-msgid "_Blank screen"
-msgstr "_Tühi ekraan"
-
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-msgid "Turns off wireless devices"
-msgstr "Lülitab juhtmevabad seadmed välja"
-
-msgid "_Mobile broadband"
-msgstr "_Mobiiliühendus"
-
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "Mobiiliühenduse seadmete (3G, 4G, WiMax jt) väljalülitamine"
-
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-msgid "When on battery power"
-msgstr "Akutoitel"
-
-msgid "When plugged in"
-msgstr "Võrgutoitel"
-
-msgid "Suspend & Power Off"
-msgstr "Uinak ja väljalülitamine"
-
-msgid "_Automatic suspend"
-msgstr "_Automaatne uinumine"
-
-msgid "When battery power is _critical"
-msgstr "Kui aku on _väga tühi"
-
-msgid "Power Off"
-msgstr "Lülitatakse välja"
-
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
 msgid "Devices"
 msgstr "Seadmed"
 
+# "Kui aku on väga tühi: Talveuni/Lülitab välja
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Lülitab välja"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Voolusääst"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "_Ekraani heledus"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Ekraan"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "_Ekraanilugeja"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Automaatsed marsruudid"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Automaatne uinak"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Alumine nupp"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automaatne uinak"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Võrgutoitel"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "_Akutoitel"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Viivitus"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Vooluhaldus"
 
+#: panels/power/gnome-power-panel.desktop.in.in:4
 msgid "View your battery status and change power saving settings"
 msgstr "Aku oleku vaatamine ja voolusäästu sätete muutmine"
 
-#. Translators: those are keywords for the power control-center panel
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "vool;uni;uinak;talveuni;talveuinak;aku;hiberneerimine;peatamine;heledus;"
 "monitor;kuvar;ekraan;DPMS;jõudeolek;seisak;"
 
-msgid "Hibernate"
-msgstr "Talveuni"
-
-# "Kui aku on väga tühi: Talveuni/Lülitab välja
-msgid "Power off"
-msgstr "Lülitab välja"
-
-msgid "45 minutes"
-msgstr "45 minutit"
-
-msgid "1 hour"
-msgstr "1 tund"
-
-msgid "80 minutes"
-msgstr "80 minutit"
-
-msgid "90 minutes"
-msgstr "90 minutit"
-
-msgid "100 minutes"
-msgstr "100 minutit"
-
-msgid "2 hours"
-msgstr "2 tundi"
-
-msgid "1 minute"
-msgstr "1 minut"
-
-msgid "2 minutes"
-msgstr "2 minutit"
-
-msgid "3 minutes"
-msgstr "3 minutit"
-
-msgid "4 minutes"
-msgstr "4 minutit"
-
-msgid "5 minutes"
-msgstr "5 minutit"
-
-msgid "8 minutes"
-msgstr "8 minutit"
-
-msgid "10 minutes"
-msgstr "10 minutit"
-
-msgid "12 minutes"
-msgstr "12 minutit"
-
-msgid "Automatic Suspend"
-msgstr "Automaatne uinak"
-
-msgid "_Plugged In"
-msgstr "_Võrgutoitel"
-
-msgid "On _Battery Power"
-msgstr "_Akutoitel"
-
-msgid "Delay"
-msgstr "Viivitus"
-
-msgid "Authenticate"
-msgstr "Autentimine"
-
-msgid "Password"
-msgstr "Parool"
-
-msgid "Authentication Required"
-msgstr "Autentimine on vajalik"
-
-#. Translators: The printer is low on toner
-msgid "Low on toner"
-msgstr "Tooner on otsakorral"
-
-#. Translators: The printer has no toner left
-msgid "Out of toner"
-msgstr "Tooner on otsas"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-msgid "Low on developer"
-msgstr "Ilmuti on otsakorral"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-msgid "Out of developer"
-msgstr "Ilmuti on otsas"
-
-#. Translators: "marker" is one color bin of the printer
-msgid "Low on a marker supply"
-msgstr "Värv on otsakorral"
-
-#. Translators: "marker" is one color bin of the printer
-msgid "Out of a marker supply"
-msgstr "Värv on otsas"
-
-#. Translators: One or more covers on the printer are open
-msgid "Open cover"
-msgstr "Kaas on avatud"
-
-#. Translators: One or more doors on the printer are open
-msgid "Open door"
-msgstr "Luuk on avatud"
-
-#. Translators: At least one input tray is low on media
-msgid "Low on paper"
-msgstr "Paber on otsakorral"
-
-#. Translators: At least one input tray is empty
-msgid "Out of paper"
-msgstr "Paber on otsas"
-
-#. Translators: The printer is offline
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Pole võrgus"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Seisma jäetud"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-msgid "Waste receptacle almost full"
-msgstr "Prügimahuti on peaaegu täis"
-
-#. Translators: The printer marker supply waste receptacle is full
-msgid "Waste receptacle full"
-msgstr "Prügimahuti on täis"
-
-#. Translators: Optical photo conductors are used in laser printers
-msgid "The optical photo conductor is near end of life"
-msgstr "Fotosilma eluiga on lõppemas"
-
-#. Translators: Optical photo conductors are used in laser printers
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Fotosilm enam ei tööta"
-
-#. Translators: Printer's state (printer is being configured right now)
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "Seadistamine"
-
-#. Translators: Printer's state (can start new job without waiting)
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Valmis"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Töid vastu ei võeta"
-
-#. Translators: Printer's state (jobs are processing)
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Töötlemine"
-
-#. Translators: Toner supply
-msgid "Toner Level"
-msgstr "Tooneri kogus"
-
-#. Translators: Ink supply
-msgid "Ink Level"
-msgstr "Tindi kogus"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-msgid "Supply Level"
-msgstr "Kuluvahendi kogus"
-
-#. Translators: Printer's state (printer is being installed right now)
-msgctxt "printer state"
-msgid "Installing"
-msgstr "Paigaldamine"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-msgid "No printers available"
-msgstr "Ühtegi printerit pole saadaval"
-
-#. Translators: there is n active print jobs on this printer
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u aktiivne"
-msgstr[1] "%u aktiivset"
-
-#. Translators: Addition of the new printer failed.
-msgid "Failed to add new printer."
-msgstr "Tõrge uue printeri lisamisel."
-
-msgid "Select PPD File"
-msgstr "PPD faili valimine"
-
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PPD PostScript printeri kirjelduse failid (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD.GZ)"
-
-msgid "No suitable driver found"
-msgstr "Ühtegi sobivat draiverit ei leitud"
-
-msgid "Searching for preferred drivers…"
-msgstr "Eelistatud draiverite otsimine…"
-
-msgid "Select from database…"
-msgstr "Valimine andmebaasist…"
-
-msgid "Provide PPD File…"
-msgstr "Anna PPD fail…"
-
-#. Translators: Name of job which makes printer to print test page
-msgid "Test page"
-msgstr "Testleht"
-
-#. Translators: The XML file containing user interface can not be loaded
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Kasutajaliidest pole võimalik laadida: %s"
-
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "Printerid"
 
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Printerite lisamine ja seadistamine, printimistööde kuvamine"
 
-#. Translators: those are keywords for the printing control-center panel
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
 "Printer;Printimine;Printimisjärjekord;Trükkimine;Trükkimisjärjekord;Paber;"
 "Tint;Tooner;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-msgid "Active Jobs"
-msgstr "Aktiivsed printimistööd"
-
-msgid "Close"
-msgstr "Sulge"
-
-msgid "Resume Printing"
-msgstr "Jätka printimist"
-
-msgid "Pause Printing"
-msgstr "Peata printimine"
-
-msgid "Cancel Print Job"
-msgstr "Prinditöö katkestamine"
-
-msgid "Add a New Printer"
-msgstr "Uue printeri lisamine"
-
-#. Translators: This button opens authentication dialog for selected server.
-msgid "A_uthenticate"
-msgstr "_Autendi"
-
-#. Translators: No printers were found
-msgid "No printers detected."
-msgstr "Ühtegi printerit ei tuvastatud."
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-msgid "Enter address of a printer or a text to filter results"
-msgstr "Tulemuste filtreerimiseks sisesta printeri aadress või nimi"
-
-msgid "Loading options…"
-msgstr "Valikute laadimine…"
-
-msgid "Select Printer Driver"
-msgstr "Printeri draiveri valimine"
-
-msgid "Loading drivers database..."
-msgstr "Draiverite andmebaasi laadimine..."
-
-#. Translators: this is an option of "Two Sided"
-msgid "One Sided"
-msgstr "Ühepoolne"
-
-#. Translators: this is an option of "Two Sided"
-msgid "Long Edge (Standard)"
-msgstr "Ümber pika külje (tavaline)"
-
-#. Translators: this is an option of "Two Sided"
-msgid "Short Edge (Flip)"
-msgstr "Ümber lühikese külje (pööratud)"
-
-#. Translators: this is an option of "Orientation"
-msgid "Portrait"
-msgstr "Portree"
-
-#. Translators: this is an option of "Orientation"
-msgid "Landscape"
-msgstr "Maastik"
-
-#. Translators: this is an option of "Orientation"
-msgid "Reverse landscape"
-msgstr "Pööratud maastik"
-
-#. Translators: this is an option of "Orientation"
-msgid "Reverse portrait"
-msgstr "Pööratud portree"
-
-#. Translators: Job's state (job is waiting to be printed)
-msgctxt "print job"
-msgid "Pending"
-msgstr "Ootel"
-
-#. Translators: Job's state (job is held for printing)
-msgctxt "print job"
-msgid "Held"
-msgstr "Hoitakse kinni"
-
-#. Translators: Job's state (job is currently printing)
-msgctxt "print job"
-msgid "Processing"
-msgstr "Töötluses"
-
-#. Translators: Job's state (job has been stopped)
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Peatatud"
-
-#. Translators: Job's state (job has been canceled)
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Katkestatud"
-
-#. Translators: Job's state (job has aborted due to error)
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Loobutud"
-
-#. Translators: Job's state (job has completed successfully)
-msgctxt "print job"
-msgid "Completed"
-msgstr "Valmis"
-
-#. Translators: Name of column showing titles of print jobs
-msgid "Job Title"
-msgstr "Töö pealkiri"
-
-#. Translators: Name of column showing statuses of print jobs
-msgid "Job State"
-msgstr "Töö seisund"
-
-#. Translators: Name of column showing times of creation of print jobs
-msgid "Time"
-msgstr "Aeg"
-
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s aktiivset printimistööd"
-
-#. Translators: The found device is a printer connected via USB
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-msgid "Serial Port"
-msgstr "Jadaport"
-
-#. Translators: The found device is a printer connected via parallel port
-msgid "Parallel Port"
-msgstr "Paralleelport"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#, c-format
-msgid "Location: %s"
-msgstr "Asukoht: %s"
-
-#. Translators: Network address of found printer
-#, c-format
-msgid "Address: %s"
-msgstr "Aadress: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-msgid "Server requires authentication"
-msgstr "Server nõuab autentimist"
-
-msgid "Two Sided"
-msgstr "Kahepoolne"
-
-msgid "Paper Type"
-msgstr "Paberi liik"
-
-msgid "Paper Source"
-msgstr "Paberi allikas"
-
-msgid "Output Tray"
-msgstr "Väljundsalv"
-
-msgid "GhostScript pre-filtering"
-msgstr "GhostScripti eelfilter"
-
-#. Translators: This option sets number of pages printed on one sheet
-msgid "Pages per side"
-msgstr "Lehekülgi lehele"
-
-#. Translators: This option sets whether to print on both sides of paper
-msgid "Two-sided"
-msgstr "Kahepoolne"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-msgid "Orientation"
-msgstr "Suund"
-
-#. Translators: "General" tab contains general printer options
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Üldine"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Lehe seadistus"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Paigaldatavad valikud"
-
-#. Translators: "Job" tab contains settings for jobs
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Töö"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Pildi kvaliteet"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Värvid"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Lõpetamine"
-
-#. Translators: "Advanced" tab contains all others settings
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Laiendatud"
-
-#. Translators: this is an option of "Paper Source"
-msgid "Auto Select"
-msgstr "Automaatne valik"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-msgid "Printer Default"
-msgstr "Printeri vaikimisi"
-
-#. Translators: this is an option of "GhostScript"
-msgid "Embed GhostScript fonts only"
-msgstr "Kaasatakse ainult GhostScripti fondid"
-
-#. Translators: this is an option of "GhostScript"
-msgid "Convert to PS level 1"
-msgstr "Teisendamine keelde PS level 1"
-
-#. Translators: this is an option of "GhostScript"
-msgid "Convert to PS level 2"
-msgstr "Teisendamine keelde PS level 2"
-
-#. Translators: this is an option of "GhostScript"
-msgid "No pre-filtering"
-msgstr "Eelfilter puudub"
-
-#. Translators: Name of column showing printer manufacturers
-msgid "Manufacturer"
-msgstr "Tootja"
-
-#. Translators: Name of column showing printer drivers
-msgid "Driver"
-msgstr "Draiver"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-"Sisesta kasutajanimi ja parool, et näha masinas %s saadaolevaid printereid."
-
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Printeri lisamine"
 
-msgid "Remove Printer"
-msgstr "Eemalda printer"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-msgid "Supply"
-msgstr "Varu"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Ühtegi pilti ei leitud"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autentimine on vajalik"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Sisesta kasutajanimi ja parool, et näha masinas %s saadaolevaid printereid."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Kasutajanimi"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Asukoht"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-msgid "_Default printer"
-msgstr "_Vaikimisi printer"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Draiver"
 
-msgid "Jobs"
-msgstr "Tööd"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Eelistatud draiverite otsimine…"
 
-#. Translators: Opens a dialog containing printer's jobs
-msgid "Show _Jobs"
-msgstr "_Tööde kuvamine"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "Linna otsing"
 
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "Valimine andmebaasist…"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Anna PPD fail…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Printeri draiveri valimine"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "Draiverite andmebaasi laadimine..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Loobu"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Vali"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "Server nõuab autentimist"
+msgstr[1] "Server nõuab autentimist"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "_Domeen"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Autendi"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Autentimine"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s aktiivset printimistööd"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Testleht"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Sisselogimise valikud"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Printeri vaikimisi"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Printeri vaikimisi"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "Prinditöö katkestamine"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Eemalda printer"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Aktiivsed printimistööd"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Mudel"
 
-msgid "label"
-msgstr "silt"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Tindi kogus"
 
-msgid "Setting new driver…"
-msgstr "Uue draiveri seadistamine…"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-msgid "page 3"
-msgstr "leht 3"
-
-#. Translators: This button executes command which prints test page.
-msgid "Print _Test Page"
-msgstr "_Prindi proovilehekülg"
-
-#. Translators: This button opens printer's options tab
-msgid "_Options"
-msgstr "_Valikud"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "Taaskäivita kohe"
 
 #. Translators: This button adds new printer.
-msgid "Add New Printer"
-msgstr "Uue printeri lisamine"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Printeri lisamine"
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Printerid"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Vabandust! Tundub, et süsteemi\n"
 "printimisteenus pole saadaval."
 
-msgid "Screen Lock"
-msgstr "Ekraanilukk"
-
-msgid "Usage & History"
-msgstr "Kasutus ja ajalugu"
-
-msgid "Empty all items from Trash?"
-msgstr "Kas tühjendada prügikast?"
-
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Kõik asjad prügikastis kustutatakse jäädavalt."
-
-msgid "_Empty Trash"
-msgstr "_Tühjenda prügikast"
-
-msgid "Delete all the temporary files?"
-msgstr "Kas kustutada kõik ajutised failid?"
-
-msgid "All the temporary files will be permanently deleted."
-msgstr "Kõik ajutised failid kustutatakse jäädavalt."
-
-msgid "_Purge Temporary Files"
-msgstr "_Hävita ajutised failid"
-
-msgid "Purge Trash & Temporary Files"
-msgstr "Puhasta prügikast ja ajutised failid"
-
-msgid "Software Usage"
-msgstr "Tarkvarakasutus"
-
-msgid "Privacy"
-msgstr "Privaatsus"
-
-msgid "Protect your personal information and control what others might see"
-msgstr "Kaitse oma isiklikke andmeid ja muuda, mida teised näevad"
-
-#. Translators: those are keywords for the privacy control-center panel
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"ekraan;lukk;diagnostika;privaatsus;privaatne;hiljutine;ajutine;tmp;temp;"
-"indeks;nimi;nimed;võrk;ühendus;identiteet;"
-
-msgid "Screen Turns Off"
-msgstr "Ekraani väljalülitumisel"
-
-msgid "30 seconds"
-msgstr "30 sekundit"
-
-msgid "1 day"
-msgstr "1 päev"
-
-msgid "2 days"
-msgstr "2 päeva"
-
-msgid "3 days"
-msgstr "3 päeva"
-
-msgid "4 days"
-msgstr "4 päeva"
-
-msgid "5 days"
-msgstr "5 päeva"
-
-msgid "6 days"
-msgstr "6 päeva"
-
-msgid "7 days"
-msgstr "7 päeva"
-
-msgid "14 days"
-msgstr "14 päeva"
-
-msgid "30 days"
-msgstr "30 päeva"
-
-msgid "Forever"
-msgstr "Igavesti"
-
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"Ajaloo mäletamine teeb hiljem asjade leidmise lihtsamaks. Neid kirjeid ei "
-"jagata kunagi üle võrgu."
-
-msgid "_Recently Used"
-msgstr "_Hiljuti kasutatud"
-
-msgid "Retain _History"
-msgstr "Säilita _ajalugu"
-
-msgid "Cl_ear Recent History"
-msgstr "_Puhasta hiljutine ajalugu"
-
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "Ekraanilukk kaitseb sinu privaatsust, kuni sa ära oled."
-
-msgid "Automatic Screen _Lock"
-msgstr "Automaatne ekraani_lukk"
-
-msgid "Lock screen _after blank for"
-msgstr "Ekraan lukustatakse _pärast pimenemist"
-
-msgid "Show _Notifications"
-msgstr "Teateid _näidatakse"
-
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"Automaatselt tühjenda prügikast ja viska ära ajutised failid, et hoida "
-"arvuti puhas ebavajalikust tundlikust infost."
-
-msgid "Automatically empty _Trash"
-msgstr "_Prügikasti automaatne tühjendamine"
-
-msgid "Automatically purge Temporary _Files"
-msgstr "Ajutiste _failide automaatne hävitamine"
-
-msgid "Purge _After"
-msgstr "Tühjendatakse _pärast"
-
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"Kui saadad meile infot tarkvara kohta, mida kasutad, on meil võimalik "
-"pakkuda sulle täpsemaid soovitusi. Samuti aitab see just õiget tarkvara "
-"arendada.\n"
-"\n"
-"Kõik meie kogutavad andmed tehakse anonüümseks ning me ei jaga sinu andmeid "
-"mitte kunagi kellegi kolmandaga."
-
-msgid "_Send software usage statistics"
-msgstr "_Tarkvarakasutuse statistika saatmine"
-
-msgid "Privacy Policy"
-msgstr "Privaatsuse tagamine"
-
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Briti mõõdustik"
-
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Meetermõõdustik"
-
-msgid "No regions found"
-msgstr "Regioone ei leitud"
-
-msgid "No input sources found"
-msgstr "Ühtegi sisendseadet ei leitud"
-
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Muu"
-
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "Sinu seanss tuleb muudatuste jõustumiseks uuesti käivitada"
-
-msgid "Restart Now"
-msgstr "Taaskäivita kohe"
-
-msgid "No input source selected"
-msgstr "Ühtegi sisendseadet pole valitud"
-
-msgid "Sorry"
-msgstr "Vabandust"
-
-msgid "Input methods can't be used on the login screen"
-msgstr "Sisestusmeetodeid pole võimalik sisselogimisekraanil kasutada"
-
-msgid "Login Screen"
-msgstr "Sisselogimisekraan"
-
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Vormingud"
 
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Otsingu asukohad"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Vormingud"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Vormingud"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Eelvaade"
 
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Kuupäevad"
 
-msgid "Times"
-msgstr "Kellaajad"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Kuupäev ja kellaaeg"
 
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Arvud"
 
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Mõõtühikud"
 
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Paber"
 
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Minu konto"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Keel:"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "Vormingud"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "Sisselogimisekraan"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Piirkond ja keel"
 
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr "Vali kuva keel, vormingud, klaviatuuripaigutused ja sisendid"
 
-#. Translators: those are keywords for the region control-center panel
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Keel;Paigutus;Klaviatuur;Sisend;Sisestamine;"
 
-msgid "Add an Input Source"
-msgstr "Sisendseadme lisamine"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Meediumile käsitlemismeetodi valimine"
 
-msgid "Input Source Options"
-msgstr "Sisendseadme valikud"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD-_audio"
 
-msgid "Use the _same source for all windows"
-msgstr "_Sama paigutuse kasutamine kõigil akendel"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD-video"
 
-msgid "Allow _different sources for each window"
-msgstr "Iga akna jaoks _oma paigutuse lubamine"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Muusikaesitaja"
 
-msgid "Keyboard Shortcuts"
-msgstr "Kiirklahvid"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Tarkvara"
 
-msgid "Switch to previous source"
-msgstr "Eelmisele sisendile lülitumine"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Muu meedia…"
 
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Meedia sisestamisel ei küsita kunagi rakenduste käivitamise kohta"
 
-msgid "Switch to next source"
-msgstr "Lülitu järgmisele allikale"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Ülejäänud meediumile käsitlemismeetodi valimine"
 
-msgid "Super+Space"
-msgstr "Super+Tühik"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Tegevus:"
 
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "Neid kiirklahve saab muuta klaviatuuri sätete alt"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Liik:"
 
-msgid "Alternative switch to next source"
-msgstr "Järgmisele sisendile vahetamise alternatiiv"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Eemaldatav meedium"
 
-msgid "Left+Right Alt"
-msgstr "Vasak+parem Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Eemaldatav meedium"
 
-msgid "English (United Kingdom)"
-msgstr "Inglise (Suurbritannia)"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"seade;seadmed;süsteem;andmed;info;mälu;protsessor;versioon;vaikimisi;"
+"rakendus;eelistatud;eelis;cd;dvd;usb;audio;heli;video;plaat;eemaldatav;"
+"meedia;isekäivituv;automaatkäivitus;"
 
-msgid "United Kingdom"
-msgstr "Suurbritannia"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Ekraanilukk"
 
-msgid "Options"
-msgstr "Valikud"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
 
-msgid "Login settings are used by all users when logging into the system"
-msgstr "Sisselogimissätteid mõjuvatad sisselogimisel kõik kasutajad"
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "_Tühi ekraan"
 
-msgctxt "Search Location"
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automaatne ekraani_lukk"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "Automaatne ekraani_lukk"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Lukustusekraanil üksikasjade kuvamine"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Ekraani lukustamine"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Privaatsus"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekraan"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Heliseaded"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Otsingu asukohad"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
 msgid "Places"
 msgstr "Asukohad"
 
-msgctxt "Search Location"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
 msgid "Bookmarks"
 msgstr "Järjehoidjad"
 
-msgctxt "Search Location"
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Muu"
 
-msgid "Select Location"
-msgstr "Asukoha valimine"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Asukoht"
 
-msgid "_OK"
-msgstr "_Olgu"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Rakendused"
 
-msgid "No applications found"
-msgstr "Rakendusi ei leitud"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-msgid "Search"
-msgstr "Otsi"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Otsingu asukohad"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 "Määra, milliste rakenduste otsingutulemused on näha tegevuste ülevaates"
 
-#. Translators: those are keywords for the search control-center panel
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "otsing;leia;leidmine;indeks;peida;peitmine;varjamine;privaatsus;tulemused;"
 
-msgid "Search Locations"
-msgstr "Otsingu asukohad"
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Võrk"
 
-msgid "Move Up"
-msgstr "Liiguta üles"
-
-msgid "Move Down"
-msgstr "Liiguta alla"
-
-msgid "Preferences"
-msgstr "Eelistused"
-
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Sees"
-
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Väljas"
-
-msgid "Choose a Folder"
-msgstr "Kausta valimine"
-
-msgid "Copy"
-msgstr "Kopeeri"
-
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Jagamine"
 
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
+msgstr "Arvuti nimi"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Isiklike failide jagamine"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Kaugvaade"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "Meedia jagamine"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "Kauglogimine"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Jagamine"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "Parool nõutud"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Kauglogimine"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Kaugvaade"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Kauglogimise lubamine või keelamine"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Kaugjuhtimine lubatud"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Pole ühendatud"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopeeri"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Kustuta aadress"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Autentimine"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Kasutajanimi"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Sõrmejälje sisestamine"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Meedia jagamine"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+#, fuzzy
+msgid "Share music, photos and videos over the network."
+msgstr "Muusika, fotode ja videote jagamine teistega selles võrgus."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+#, fuzzy
+msgid "Folders"
+msgstr "Kataloogi lisamine"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
 msgstr "Kontrolli, mida teistega jagatakse"
 
-#. Translators: those are keywords for the sharing control-center panel
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 msgstr ""
 "jagamine;ssh;host;nimi;kaugtöölaud;kaugühendus;bluetooth;obex;meedia;audio;"
 "heli;muusika;videod;pildid;fotod;filmid;server;renderdaja;"
 
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
 msgstr "Kauglogimise lubamine või keelamine"
 
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Autentimine on vajalik kauglogimise lubamiseks või keelamiseks"
 
-msgid "Bluetooth Sharing"
-msgstr "Bluetoothi jagamine"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
 
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Jagamine"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
-"Bluetoothi jagamine võimaldab jagada faile teiste Bluetoothi seadmetega"
 
-msgid "Only Receive From Trusted Devices"
-msgstr "Ainult usaldatud seadmetelt vastuvõtmine"
-
-msgid "Save Received Files to Downloads Folder"
-msgstr "Vastuvõetud failide salvestamine allalaadimiste kausta"
-
-msgid "Computer Name"
-msgstr "Arvuti nimi"
-
-msgid "Personal File Sharing"
-msgstr "Isiklike failide jagamine"
-
-msgid "Screen Sharing"
-msgstr "Ekraani jagamine"
-
-msgid "Media Sharing"
-msgstr "Meedia jagamine"
-
-msgid "Remote Login"
-msgstr "Kauglogimine"
-
-msgid "Some services are disabled because of no network access."
-msgstr "Mõned teenused on võrguühenduse puudumise tõttu keelatud."
-
-msgid "Share Music, Photos and Videos with others on the current network."
-msgstr "Muusika, fotode ja videote jagamine teistega selles võrgus."
-
-msgid "Share Media On This Network"
-msgstr "Meedia jagamine sellesse võrku"
-
-msgid "Shared Folders"
-msgstr "Jagatud kataloogid"
-
-msgid "column"
-msgstr "tulp"
-
-msgid "Add Folder"
-msgstr "Kataloogi lisamine"
-
-msgid "Remove Folder"
-msgstr "Kataloogi eemaldamine"
-
-#, no-c-format
-msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
 msgstr ""
-"Isiklike failide jagamine võimaldab avaliku ja teiste kaustade jagamist "
-"praegusesse võrku, kasutades aadressi: <a href=\"dav://%s\">dav://%s</a>"
 
-msgid "Share Public Folder On This Network"
-msgstr "Avaliku kausta jagamine sellesse võrku"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Tasakaal:"
 
-msgid "Require Password"
-msgstr "Parool nõutud"
+# või on esimeste/tagumiste vahel jaotamise mõttes?
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Hajumine:"
 
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
+msgid "Rear"
+msgstr "Tagumised"
+
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
+msgid "Front"
+msgstr "Esimesed"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
 msgstr ""
-"Kaugkasutajad võivad ühenduda kasutades SSH käsku:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
 
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Süsteemsed helid"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "_Hoiatuse valjus"
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Heli tummaks"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Väljund"
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "_Väljundi valjus"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testi"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "_Seadistuste URL"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Bassikõlar"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Sisend"
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Sisendtase:"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Heli valjemaks"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "_Hoiatuse valjus"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
 msgstr ""
-"Kaugkasutajad saavad sinu ekraani kasutada, ühendudes aadressil: <a href="
-"\"vnc://%s\">vnc://%s</a>"
 
-msgid "Allow Remote Control"
-msgstr "Kaugjuhtimine lubatud"
-
-msgid "Password:"
-msgstr "Parool:"
-
-msgid "Show Password"
-msgstr "Parooli näitamine"
-
-msgid "Access Options"
-msgstr "Ligipääsu valikud"
-
-# Või uued kontaktid?
-msgid "New connections must ask for access"
-msgstr "Uued ühendused peavad küsima luba"
-
-msgid "Require a password"
-msgstr "Parool nõutud"
-
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
 msgstr "Heli"
 
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Helivaljuse, sisendite, väljundite ja sündmuste helide muutmine"
 
-#. Translators: those are keywords for the sound control-center panel
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Helikaart;Mikrofon;Helivaljus;Valjus;Balanss;Tasakaal;Bluetooth;Sinihammas;"
 "Peakomplekt;Audio;Heli;"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-msgid "Bark"
-msgstr "Haukumine"
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-msgid "Drip"
-msgstr "Tilkumine"
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-msgid "Glass"
-msgstr "Klaas"
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-msgid "Sonar"
-msgstr "Sonar"
-
-msgctxt "balance"
-msgid "Left"
-msgstr "Vasak"
-
-msgctxt "balance"
-msgid "Right"
-msgstr "Parem"
-
-msgctxt "balance"
-msgid "Rear"
-msgstr "Tagumised"
-
-msgctxt "balance"
-msgid "Front"
-msgstr "Esimesed"
-
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Minimaalne"
-
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Maksimaalne"
-
-msgid "_Balance:"
-msgstr "_Tasakaal:"
-
-# või on esimeste/tagumiste vahel jaotamise mõttes?
-msgid "_Fade:"
-msgstr "_Hajumine:"
-
-msgid "_Subwoofer:"
-msgstr "_Bassikõlar:"
-
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Võimendamata"
-
-msgid "_Profile:"
-msgstr "_Profiil:"
-
-#. translators:
-#. * The number of sound outputs on a particular device
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u väljund"
-msgstr[1] "%u väljundit"
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u sisend"
-msgstr[1] "%u sisendid"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Teated"
 
-msgid "System Sounds"
-msgstr "Süsteemsed helid"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Nimi:"
 
-msgid "_Test Speakers"
-msgstr "_Kõlarite kontroll"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-msgid "Peak detect"
-msgstr "Tipu tuvastamine"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-msgid "Name"
-msgstr "Nimi"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "_Automaatne ühendumine"
 
-msgid "Device"
-msgstr "Seade"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Seadme eemaldamine"
 
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s kõlarite testimine"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-msgid "_Output volume:"
-msgstr "_Väljundi valjus"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Pole võimalik ühenduda %s domeenile: %s"
 
-msgid "Output"
-msgstr "Väljund"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Pärssimata juurdepääs"
 
-msgid "C_hoose a device for sound output:"
-msgstr "_Vali heliväljundi seade:"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-msgid "Settings for the selected device:"
-msgstr "Valitud seadme sätted:"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Lisa seade"
 
-msgid "Input"
-msgstr "Sisend"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-msgid "_Input volume:"
-msgstr "_Sisendi valjus"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-msgid "Input level:"
-msgstr "Sisendtase:"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-msgid "C_hoose a device for sound input:"
-msgstr "_Vali helisisendi seade:"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-msgid "Sound Effects"
-msgstr "Heliefektid"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Kursori vilkumine"
 
-msgid "_Alert volume:"
-msgstr "_Hoiatuse valjus"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Kursor _vilgub tekstiväljadel"
 
-msgid "Applications"
-msgstr "Rakendused"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "Kii_rus:"
 
-msgid "No application is currently playing or recording audio."
-msgstr "Mitte ükski rakendus ei esita ega lindista praegu heli."
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Kursori vilkumiskiirus"
 
-msgid "Built-in"
-msgstr "Sisseehitatud"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Kursori vilkumiskiirus"
 
-msgid "Sound Preferences"
-msgstr "Helieelistused"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-msgid "Testing event sound"
-msgstr "Sündmuse heli testimine"
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Klõpsamise abiline"
 
-msgid "Default"
-msgstr "Vaikimisi"
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simuleeritud paremklõps"
 
-msgid "From theme"
-msgstr "Teemast"
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Peamise nupu allhoidmisel tehakse teisene klõps"
 
-msgid "C_hoose an alert sound:"
-msgstr "_Vali teadaande heli:"
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Nõustumise viivitus:"
 
-msgid "Stop"
-msgstr "Peata"
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Lühike"
 
-msgid "Test"
-msgstr "Testi"
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Teisese klõpsu viivitus "
 
-msgid "Subwoofer"
-msgstr "Bassikõlar"
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Pikk"
 
-msgid "Custom"
-msgstr "Kohandatud"
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Hiirega üleliikumisel klõps"
 
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Kursori üleliikumisel tehakse hiireklõps"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "V_iivitus:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Lühike"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Pikk"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Liikumise lävi:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Väike"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Suur"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Klahvide kordamine"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Klahvivajutus k_ordub, kui klahvi hoitakse all"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Klahvide kordamise kiirus"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Klahvide kordamise kiirus"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Tippimisabiline"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Kleepuvad klahvid"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Tõlgendab muuteklahvide järjestust klahvikombinatsioonina"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Kahe klahvi koosvajutamisel keelatakse"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "_Muuteklahvi vajutamisel tehakse piiks"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Aeglased klahvid"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Määrab viivituse klahvi vajutamise ja sellega nõustumise vahele"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Lühike"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Aeglaste klahvide sisestusviivitus"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Pikk"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "_Klahvi vajutamisel tehakse piiks"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Klahviga _nõustumisel tehakse piiks"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Klahvist _loobumisel tehakse piiks"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Põrkeklahvid"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Klahvi kiire korduvvajutuse eiramine"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Lühike"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Põrkeklahvide tuvastamise viivitus"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Pikk"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Lülitatakse sisse klaviatuurilt"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Hõlbustusvahendite sisse- ja väljalülitamine klaviatuuri abil"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Alati kuvatakse pärssimata juurdepääsu menüüd"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Nägemine"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Kõrgkontrastne"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Suur tekst"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Ekraanilugeja"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Ekraanilugeja loeb teksti ette fookuse muutmisel."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Klahvide heli"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Piiksumine, kui Num Lock (numbrilukk) või Caps Lock (tõstulukk) on sisse "
+"lülitatud."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Kursori vilkumiskiirus"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Suurendus"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Kuulmine"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Visuaalsed märguanded"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Ekraaniklaviatuur"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Klahvide kordamine"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Kursori vilkumine"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Tippimisabiline"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Osutamine ja klõpsamine"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Hiire klahvid"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Eemalda printer"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Klõpsamise abiline"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "_Topeltklõps"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "_Topeltklõps"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Visuaalsed märguanded"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Proovi _välku"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Hoiatusheliga koos hoiatatakse ka visuaalselt"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Kogu ekraani _vilgutamine"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Kogu ekraani _vilgutamine"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Täisekraan"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Ülemine osa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Alumine pool"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Vasak pool"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Parem pool"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Suurenduse valikud"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "Suurendus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Luubi asukoht:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Liigub koos hiirekursoriga"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Ekraani osa:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "Luup liigub üle ekraani serva"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "Hiir asub luubi keskkohas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Luubi kursor liigutab sisu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "Luubi kursor liigub koos sisuga"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Luup"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "Sihik:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "Asendab hiirekursorit"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
+msgstr "Jämedus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Peenike"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Jäme"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
+msgstr "Pikkus:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
+msgstr "Värvid:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Sihik"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Värviefektid:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
+msgstr "Valge mustal:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Heledus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Puudub"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Täielik"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Tume"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Hele"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Madal"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Kõrge"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Värviefektid"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Nägemise, kuulmise, sisestamise ning klõpsamise lihtsustamine"
 
-#. Translators: those are keywords for the universal access control-center panel
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
 "Klaviatuur;Klaver;Hiir;a11y;Hõlbustused;Ligipääsetavus;Kontrast;Suurendus;"
 "Suum;Ekraanilugeja;tekst;font;suurus;AccessX;Kleepuvad klahvid;Aeglased;"
 "Aeglane;Põrkeklahvid;Hiir;"
 
-msgid "_Always Show Universal Access Menu"
-msgstr "_Alati kuvatakse pärssimata juurdepääsu menüüd"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Ajalugu"
 
-msgid "Seeing"
-msgstr "Nägemine"
-
-msgid "_High Contrast"
-msgstr "_Kõrgkontrastne"
-
-msgid "_Large Text"
-msgstr "_Suur tekst"
-
-msgid "_Zoom"
-msgstr "_Suurendus"
-
-msgid "Screen _Reader"
-msgstr "_Ekraanilugeja"
-
-msgid "_Sound Keys"
-msgstr "_Klahvide heli"
-
-msgid "Hearing"
-msgstr "Kuulmine"
-
-msgid "_Visual Alerts"
-msgstr "_Visuaalsed märguanded"
-
-msgid "Screen _Keyboard"
-msgstr "_Ekraaniklaviatuur"
-
-msgid "_Typing Assist (AccessX)"
-msgstr "_Tippimisabiline"
-
-msgid "Pointing & Clicking"
-msgstr "Osutamine ja klõpsamine"
-
-msgid "_Mouse Keys"
-msgstr "_Hiire klahvid"
-
-msgid "_Click Assist"
-msgstr "_Klõpsamise abiline"
-
-msgid "Screen Reader"
-msgstr "Ekraanilugeja"
-
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "Ekraanilugeja loeb teksti ette fookuse muutmisel."
-
-msgid "_Screen Reader"
-msgstr "_Ekraanilugeja"
-
-msgid "Sound Keys"
-msgstr "Klahvide heli"
-
-msgid "Beep when Num Lock or Caps Lock are turned on."
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"Piiksumine, kui Num Lock (numbrilukk) või Caps Lock (tõstulukk) on sisse "
-"lülitatud."
 
-msgid "Visual Alerts"
-msgstr "Visuaalsed märguanded"
-
-msgid "_Test flash"
-msgstr "Proovi _välku"
-
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "Hoiatusheliga koos hoiatatakse ka visuaalselt"
-
-msgid "Flash the _window title"
-msgstr "_Akna pealkirja vilgutamine"
-
-msgid "Flash the entire _screen"
-msgstr "Kogu ekraani _vilgutamine"
-
-msgid "Typing Assist"
-msgstr "Tippimisabiline"
-
-msgid "_Sticky Keys"
-msgstr "_Kleepuvad klahvid"
-
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "Tõlgendab muuteklahvide järjestust klahvikombinatsioonina"
-
-msgid "_Disable if two keys are pressed together"
-msgstr "Kahe klahvi koosvajutamisel keelatakse"
-
-msgid "Beep when a _modifer key is pressed"
-msgstr "_Muuteklahvi vajutamisel tehakse piiks"
-
-msgid "S_low Keys"
-msgstr "_Aeglased klahvid"
-
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "Määrab viivituse klahvi vajutamise ja sellega nõustumise vahele"
-
-msgid "A_cceptance delay:"
-msgstr "Nõustumise viivitus:"
-
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Lühike"
-
-msgid "Slow keys typing delay"
-msgstr "Aeglaste klahvide sisestusviivitus"
-
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Pikk"
-
-msgid "Beep when a key is pr_essed"
-msgstr "_Klahvi vajutamisel tehakse piiks"
-
-msgid "Beep when a key is _accepted"
-msgstr "Klahviga _nõustumisel tehakse piiks"
-
-msgid "Beep when a key is _rejected"
-msgstr "Klahvist _loobumisel tehakse piiks"
-
-msgid "_Bounce Keys"
-msgstr "_Põrkeklahvid"
-
-msgid "Ignores fast duplicate keypresses"
-msgstr "Klahvi kiire korduvvajutuse eiramine"
-
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Lühike"
-
-msgid "Bounce keys typing delay"
-msgstr "Põrkeklahvide tuvastamise viivitus"
-
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Pikk"
-
-msgid "_Enable by Keyboard"
-msgstr "_Lülitatakse sisse klaviatuurilt"
-
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "Hõlbustusvahendite sisse- ja väljalülitamine klaviatuuri abil"
-
-msgid "Click Assist"
-msgstr "Klõpsamise abiline"
-
-msgid "_Simulated Secondary Click"
-msgstr "_Simuleeritud paremklõps"
-
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "Peamise nupu allhoidmisel tehakse teisene klõps"
-
-msgctxt "secondary click"
-msgid "Short"
-msgstr "Lühike"
-
-msgid "Secondary click delay"
-msgstr "Teisese klõpsu viivitus "
-
-msgctxt "secondary click delay"
-msgid "Long"
-msgstr "Pikk"
-
-msgid "_Hover Click"
-msgstr "_Hiirega üleliikumisel klõps"
-
-msgid "Trigger a click when the pointer hovers"
-msgstr "Kursori üleliikumisel tehakse hiireklõps"
-
-msgid "D_elay:"
-msgstr "V_iivitus:"
-
-msgctxt "dwell click delay"
-msgid "Short"
-msgstr "Lühike"
-
-msgctxt "dwell click delay"
-msgid "Long"
-msgstr "Pikk"
-
-msgid "Motion _threshold:"
-msgstr "_Liikumise lävi:"
-
-msgctxt "dwell click threshold"
-msgid "Small"
-msgstr "Väike"
-
-msgctxt "dwell click threshold"
-msgid "Large"
-msgstr "Suur"
-
-msgctxt "Distance"
-msgid "Short"
-msgstr "Lühike"
-
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ekraani"
-
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ekraani"
-
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ekraani"
-
-msgctxt "Distance"
-msgid "Long"
-msgstr "Pikk"
-
-msgid "Full Screen"
-msgstr "Täisekraan"
-
-msgid "Top Half"
-msgstr "Ülemine osa"
-
-msgid "Bottom Half"
-msgstr "Alumine pool"
-
-msgid "Left Half"
-msgstr "Vasak pool"
-
-msgid "Right Half"
-msgstr "Parem pool"
-
-msgid "Zoom Options"
-msgstr "Suurenduse valikud"
-
-msgid "Zoom"
-msgstr "Ekraan täidetud"
-
-msgid "Magnification:"
-msgstr "Suurendus:"
-
-msgid "Follow mouse cursor"
-msgstr "Liigub koos hiirekursoriga"
-
-msgid "Screen part:"
-msgstr "Ekraani osa:"
-
-msgid "Magnifier extends outside of screen"
-msgstr "Luup liigub üle ekraani serva"
-
-msgid "Keep magnifier cursor centered"
-msgstr "Hiir asub luubi keskkohas"
-
-msgid "Magnifier cursor pushes contents around"
-msgstr "Luubi kursor liigutab sisu"
-
-msgid "Magnifier cursor moves with contents"
-msgstr "Luubi kursor liigub koos sisuga"
-
-msgid "Magnifier Position:"
-msgstr "Luubi asukoht:"
-
-msgid "Magnifier"
-msgstr "Luup"
-
-msgid "Thickness:"
-msgstr "Jämedus:"
-
-msgctxt "universal access, thickness"
-msgid "Thin"
-msgstr "Peenike"
-
-msgctxt "universal access, thickness"
-msgid "Thick"
-msgstr "Jäme"
-
-msgid "Length:"
-msgstr "Pikkus:"
-
-#. The color of the accessibility crosshair
-msgid "Color:"
-msgstr "Värvid:"
-
-msgid "Crosshairs:"
-msgstr "Sihik:"
-
-msgid "Overlaps mouse cursor"
-msgstr "Asendab hiirekursorit"
-
-msgid "Crosshairs"
-msgstr "Sihik"
-
-msgid "White on black:"
-msgstr "Valge mustal:"
-
-msgid "Brightness:"
-msgstr "Heledus:"
-
-msgid "Contrast:"
-msgstr "Kontrast:"
-
-#. The contrast scale goes from Color to None (grayscale)
-msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "Värvid"
-
-msgctxt "universal access, color"
-msgid "None"
-msgstr "Puudub"
-
-msgctxt "universal access, color"
-msgid "Full"
-msgstr "Täielik"
-
-msgctxt "universal access, brightness"
-msgid "Low"
-msgstr "Tume"
-
-msgctxt "universal access, brightness"
-msgid "High"
-msgstr "Hele"
-
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "Madal"
-
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "Kõrge"
-
-msgid "Color Effects:"
-msgstr "Värviefektid:"
-
-msgid "Color Effects"
-msgstr "Värviefektid"
-
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Tavaline"
-
-msgctxt "Account type"
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "Ajalugu"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "_Puhasta hiljutine ajalugu"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "Puhasta prügikast ja ajutised failid"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "_Prügikasti automaatne tühjendamine"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Ajutiste _failide automaatne hävitamine"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "_Prügikasti automaatne tühjendamine"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "_Tühjenda prügikast"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Hävita ajutised failid"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Lisa kasutaja"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
 msgid "Administrator"
 msgstr "Administraator"
 
-msgid "_Full Name"
-msgstr "_Täisnimi"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-msgid "Account _Type"
-msgstr "Konto _liik"
-
-msgid "Allow user to set a password when they next login"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
 msgstr "Kasutajal lubatakse järgmisel sisselogimisel parooli valida"
 
-msgid "Set a password now"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
 msgstr "Parooli kohene muutmine"
 
-msgid "_Verify"
-msgstr "_Kontrolli"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "Seadistamine"
 
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Sisselogimine _ettevõtte serverisse"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Pole võrgus"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
 "Ettevõtte sisselogimiskonto kasutamine võimaldab sel masinal kasutada "
 "kasutajakontode keskhaldust."
 
-msgid "_Domain"
-msgstr "_Domeen"
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PPD faili valimine"
 
-msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Sisselogimine _sõrmejäljega"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Sisselogimine _sõrmejäljega"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Ei"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
 msgstr ""
-"Ühendu internetti, et lisada\n"
-"ettevõtte sisselogimiskontosid."
 
-msgid "Add User"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Kas sa tahad kustutada registreeritud sõrmejäljed, sellega keelatakse "
+"sõrmejäljega sisselogimine?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Ühtegi printerit ei tuvastatud."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Sisselogimine _sõrmejäljega"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Sisselogimine _sõrmejäljega"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Sisselogimine _sõrmejäljega"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Kustuta sõrmejäljed"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Sisselogimine _sõrmejäljega"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Eelmine lugu"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Parooli muutmine"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Muuda"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Praegune _parool"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Uus parool"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Parooli muutmine"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Paroolid ei klapi."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "Kasutajal lubatakse järgmisel sisselogimisel parooli valida"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Parooli kohene muutmine"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Kasutajad"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Sinu seanss tuleb muudatuste jõustumiseks uuesti käivitada"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Taaskäivita kohe"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Sulge"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Täisnimi"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Sisselogimine _sõrmejäljega"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomaatne sisselogimine"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "Konto _liik"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Administraator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Eemalda kasutajakonto"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Muu sõrm:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
 msgstr "Lisa kasutaja"
 
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Ühtegi pilti ei leitud"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "Kasutajakonto loomine"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Kasutajate lisamine ja eemaldamine ning parooli muutmine"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Registreeri"
 
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Domeenihalduri sisselogimine"
 
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -4438,888 +4825,3277 @@ msgstr ""
 "lisatud domeeni. Palun lase oma võrguhalduril sisestada siia\n"
 "oma domeeni parool."
 
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "Administraatori _nimi"
 
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Administraatori parool"
 
-msgid "Left thumb"
-msgstr "Vasak pöial"
-
-msgid "Left middle finger"
-msgstr "Vasak keskmine sõrm"
-
-msgid "Left ring finger"
-msgstr "Vasak nimetu sõrm"
-
-msgid "Left little finger"
-msgstr "Vasak väike sõrm"
-
-msgid "Right thumb"
-msgstr "Parem pöial"
-
-msgid "Right middle finger"
-msgstr "Parem keskmine sõrm"
-
-msgid "Right ring finger"
-msgstr "Parem nimetu sõrm"
-
-msgid "Right little finger"
-msgstr "Parem väike sõrm"
-
-msgid "Enable Fingerprint Login"
-msgstr "Sõrmejäljega logimise lubamine"
-
-msgid "_Right index finger"
-msgstr "_Parema käe nimetissõrm"
-
-msgid "_Left index finger"
-msgstr "_Vasaku käe nimetissõrm"
-
-msgid "_Other finger:"
-msgstr "_Muu sõrm:"
-
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"Sinu sõrmejälg on edukalt salvestatud. Sul peaks olema nüüd võimalik "
-"sõrmejäljelugeja abil sisse logida."
-
-msgid "Users"
-msgstr "Kasutajad"
-
-msgid "Add or remove users and change your password"
-msgstr "Kasutajate lisamine ja eemaldamine ning parooli muutmine"
-
-#. Translators: those are keywords for the user accounts control-center panel
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Sisselogimine;Nimi;Sõrmejälg;Avatar;Logo;Nägu;Parool;Salasõna;"
-
-msgid "Login History"
-msgstr "Sisselogimiste ajalugu"
-
-msgid "Change Password"
-msgstr "Parooli muutmine"
-
-msgid "Ch_ange"
-msgstr "_Muuda"
-
-msgid "_Verify New Password"
-msgstr "_Kinnita uus parool"
-
-msgid "_New Password"
-msgstr "_Uus parool"
-
-msgid "Current _Password"
-msgstr "Praegune _parool"
-
-msgid "Add User Account"
-msgstr "Lisa kasutajakonto"
-
-msgid "Remove User Account"
-msgstr "Eemalda kasutajakonto"
-
-msgid "Login Options"
-msgstr "Sisselogimise valikud"
-
-msgid "A_utomatic Login"
-msgstr "A_utomaatne sisselogimine"
-
-msgid "_Fingerprint Login"
-msgstr "Sisselogimine _sõrmejäljega"
-
-msgid "User Icon"
-msgstr "Kasutajaikoon"
-
-msgid "_Language"
-msgstr "_Keel:"
-
-msgid "Last Login"
-msgstr "Viimane sisselogimine"
-
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "Kasutajakontode haldamine"
 
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "Autentimine on vajalik kasutaja andmete muutmiseks"
 
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Uus parool ei tohi olla sama nagu eelmine."
-
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Proovi mõnede tähtede ja numbrite muutmist."
-
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Muuda parooli veel natukene."
-
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Ilma kasutajanimeta parool peaks olema tugevam."
-
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Ära kasuta oma kasutajanime parooli sees."
-
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Ära kasuta parooli sees tuntud sõnu."
-
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Ära kasuta tavalisi sõnu."
-
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Ära vaheta olemasolevate sõnade järjekorda."
-
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Kasuta rohkem numbreid."
-
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Kasuta rohkem suurtähti."
-
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Kasuta rohkem väiketähti."
-
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Kasuta mõnd erimärki nagu näiteks punkt."
-
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Kasuta kombinatsiooni tähtedest, numbritest ja kirjavahemärkidest."
-
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Väldi sama märgi kordamist."
-
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Hoidu sama liiki märgi kordamisest. Sul on vaja kombinatsiooni tähtedest, "
-"numbritest ja kirjavahemärkidest."
-
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Väldi järgnevusi nagu1234 või abcd."
-
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "Püüa lisada veel tähti, numbreid ja sümboleid."
-
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr "Kasuta vaheldumisi suur- ja väiketähti ning lisa paar numbrit."
-
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-"Hea parool! Tähtede, numbrite ja kirjavahemärkide lisamine teeks seda "
-"tugevamaks."
-
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "Tugevus: väga nõrk"
-
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "Tugevus: nõrk"
-
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "Tugevus: keskmine"
-
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "Tugevus: piisav"
-
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "Tugevus: eriti tugev"
-
-msgid "Authentication failed"
-msgstr "Autentimine ei õnnestunud"
-
-#, c-format
-msgid "The new password is too short"
-msgstr "Uus parool on liiga lühike"
-
-#, c-format
-msgid "The new password is too simple"
-msgstr "Uus parool on liiga lihtne"
-
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Vana ja uus parool on liiga sarnased"
-
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Uus parool on hiljuti kasutusel olnud."
-
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Uus parool peab sisaldama numbreid või erimärke"
-
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Vana ja uus parool on ühesugused"
-
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Sinu parool on pärast algset autentimist muutunud!"
-
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Uus parool ei sisalda piisaval hulgal erinevaid märke"
-
-#, c-format
-msgid "Unknown error"
-msgstr "Tundmatu viga"
-
-msgid "Should match the web address of your account provider."
-msgstr "Peaks vastama sinu kontopakkuja veebiaadressile."
-
-msgid "Failed to add account"
-msgstr "Konto lisamine nurjus"
-
-msgid "Passwords do not match."
-msgstr "Paroolid ei klapi."
-
-msgid "Failed to register account"
-msgstr "Konto registreerimine nurjus"
-
-msgid "No supported way to authenticate with this domain"
-msgstr "Pole ühtegi toetatud viisi selle domeeniga autentimiseks"
-
-msgid "Failed to join domain"
-msgstr "Domeeniga ühendumine nurjus"
-
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"Kasutajanimi pole õige.\n"
-"Palun proovi uuesti."
-
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"Parool ei olnud õige.\n"
-"Palun proovi uuesti."
-
-msgid "Failed to log into domain"
-msgstr "Domeeni sisselogimine nurjus"
-
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "Domeeni ei leitud. Võib-olla kirjutasid selle valest?"
-
-#. Create enterprise toggle button.
-msgid "_Enterprise Login"
-msgstr "Sisselogimine _ettevõtte serverisse"
-
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"Sul pole õigust sellele seadmele ligi pääseda. Ligipääsu jaoks võta palun "
-"ühendust oma süsteemiadministraatoriga."
-
-msgid "The device is already in use."
-msgstr "Seade on juba kasutusel."
-
-msgid "An internal error occurred."
-msgstr "Tekkis sisemine viga."
-
-msgid "Enabled"
-msgstr "Lubatud"
-
-msgid "Delete registered fingerprints?"
-msgstr "Kas kustutada registreeritud sõrmejäljed?"
-
-msgid "_Delete Fingerprints"
-msgstr "_Kustuta sõrmejäljed"
-
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"Kas sa tahad kustutada registreeritud sõrmejäljed, sellega keelatakse "
-"sõrmejäljega sisselogimine?"
-
-msgid "Done!"
-msgstr "Valmis!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "Seadmele '%s' puudub ligipääs"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "Ei suudetud alustada sõrmejälje salvestamist seadmel '%s'"
-
-msgid "Could not access any fingerprint readers"
-msgstr "Ühelegi sõrmejäljelugejale pole võimalik ligi pääseda"
-
-msgid "Please contact your system administrator for help."
-msgstr "Abi saamiseks võta palun ühendust oma süsteemiadministraatoriga."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"Sõrmejäljega sisselogimise kasutamiseks pead salvestama '%s' seadmega "
-"vähemalt ühe sõrmejälje."
-
-msgid "Selecting finger"
-msgstr "Sõrme valimine"
-
-msgid "Enrolling fingerprints"
-msgstr "Sõrmejälje sisestamine"
-
-msgid "This Week"
-msgstr "See nädal"
-
-msgid "Last Week"
-msgstr "Eelmine nädal"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-msgid "Session Ended"
-msgstr "Seanss lõppes"
-
-msgid "Session Started"
-msgstr "Seanss algas"
-
-msgid "Please choose another password."
-msgstr "Palun vali mõni muu parool."
-
-msgid "Please type your current password again."
-msgstr "Palun sisesta oma praegune parool uuesti."
-
-msgid "Password could not be changed"
-msgstr "Parooli pole võimalik muuta"
-
-msgid "The passwords do not match."
-msgstr "Paroolid ei klapi."
-
-msgid "Browse for more pictures"
-msgstr "Sirvi teisi pilte"
-
-msgid "Disable image"
-msgstr "Keela pilt"
-
-msgid "Take a photo…"
-msgstr "Pildista…"
-
-msgid "Browse for more pictures…"
-msgstr "Sirvi teisi pilte…"
-
-#, c-format
-msgid "Used by %s"
-msgstr "Seda kasutab %s"
-
-msgid "Cannot automatically join this type of domain"
-msgstr "Seda liiki domeeniga pole võimalik automaatselt ühenduda"
-
-#, c-format
-msgid "No such domain or realm found"
-msgstr "Sellist domeeni või valdust (realm) ei leitud"
-
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Pole võimalik sisse logida kasutajana %s domeenile %s"
-
-msgid "Invalid password, please try again"
-msgstr "Sobimatu parool, proovi uuesti"
-
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "Pole võimalik ühenduda %s domeenile: %s"
-
-msgid "Other Accounts"
-msgstr "Teised kontod"
-
-msgid "Failed to delete user"
-msgstr "Tõrge kasutaja kustutamisel"
-
-msgid "You cannot delete your own account."
-msgstr "Oma kontot pole võimalik kustutada."
-
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s on ikka veel sisse logitud"
-
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Kasutaja kustutamine tema sisselogimise ajal võib jätta süsteemi ohtlikusse "
-"seisu."
-
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "Kas tahad säilitada kasutaja %s failid?"
-
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Kodukataloogi, meilide ja ajutiste failide säilitamine on võimalik ka "
-"kasutajakonto kustutamisel."
-
-msgid "_Delete Files"
-msgstr "_Kustuta failid"
-
-msgid "_Keep Files"
-msgstr "_Säilita failid"
-
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Konto on keelatud"
-
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Määratakse järgmisel sisselogimisel"
-
-msgctxt "Password mode"
-msgid "None"
-msgstr "Puudub"
-
-msgid "Logged in"
-msgstr "Sisse logitud"
-
-msgid "Failed to contact the accounts service"
-msgstr "Tõrge kontoteenusega ühenduse võtmisel"
-
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Palun veendu, et AccountService on paigaldatud ja lubatud."
-
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Muutuste tegemiseks\n"
-"klõpsa esiteks ikoonil *"
-
-msgid "Create a user account"
-msgstr "Kasutajakonto loomine"
-
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Kasutaja loomiseks\n"
-"klõpsa esiteks * ikoonil"
-
-msgid "Delete the selected user account"
-msgstr "Valitud kasutajakonto kustutamine"
-
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Valitud kasutaja kustutamiseks\n"
-"klõpsa esiteks * ikoonil"
-
-msgid "My Account"
-msgstr "Minu konto"
-
-#, c-format
-msgid "A user with the username '%s' already exists."
-msgstr "Kasutajanimi '%s' on juba kasutusel."
-
-#, c-format
-msgid "The username is too long."
-msgstr "Kasutajanimi on liiga pikk."
-
-msgid "The username cannot start with a '-'."
-msgstr "Kasutajanimi ei tohi alata märgiga '-'."
-
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"Kasutajanimi peaks koosnema ladina suur- ja väiketähtedest, numbritest ning "
-"märkidest '.', '-' ja '_'."
-
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-"Seda kasutatakse kodukausta nimena ning seda pole võimalik hiljem muuta."
-
-#. Translators: This is a date format string in the style of "Feb 24".
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-msgid "%b %e, %Y"
-msgstr "%e. %b %Y"
-
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Nuppude ühendamine"
 
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Nuppude ühendamine tegevustega"
 
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 "Välksõrmise muutmiseks vali \"Saada klahvivajutus\", klõpsa vastaval real ja "
 "määra uus sõrmis või vajuta nullimiseks Backspace (kustutamise) klahvi."
 
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Sulge"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
 "Tahvli kalibreerimiseks vajuta markeritele seal, kus need ekraanile ilmuvad."
 
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "Tuvastati vale klõps. Alustatakse uuesti..."
 
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "Üles"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "Alla"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Digitaallaud"
 
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "Puudub"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Klaviatuurivajutuse saatmine"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Vasaku- või paremakäeliste hiir"
 
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Monitori vahetamine"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Abi kuvamine ekraanil"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Monitoriga ühendamine…"
 
-msgid "Output:"
-msgstr "Väljund:"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Külgede suhe"
 
-#. Keep ratio switch
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Külgede suhte säilitamine:"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#. Whole-desktop checkbox
-msgid "Map to single monitor"
-msgstr "Määratud ühele monitorile"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Kalibreerimine..."
 
-#, c-format
-msgid "%d of %d"
-msgstr "%d / %d"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Digitaallauda ei leitud"
 
-msgid "Display Mapping"
-msgstr "Kuvade ühendamine"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Ühenda või lülita sisse oma Wacom'i digitaallaud"
 
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Otsa survetundlikkus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Pehme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Tugev"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Nupp"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Nupp"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Nupp"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Kustutaja survetundlikkus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Kustutaja survetundlikkus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Keskmise hiirenupu klõps"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Parema hiirenupu klõps"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Edasi"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacomi digitaallaud"
 
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Digitaallaudade nuppude vastavuse ja kirjapulga tundlikkuse muutmine"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 "Tablet;Digitaallaud;Wacom;Stylus;Stiilus;Kirjapulk;Kustutaja;Kustukumm;Hiir;"
 
-msgid "Tablet (absolute)"
-msgstr "Digitaallaud (absoluutne)"
-
-msgid "Touchpad (relative)"
-msgstr "Puutepadi (suhteline)"
-
-msgid "Tablet Preferences"
-msgstr "Digitaallaua eelistused"
-
-msgid "No tablet detected"
-msgstr "Digitaallauda ei leitud"
-
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Ühenda või lülita sisse oma Wacom'i digitaallaud"
-
-msgid "Bluetooth Settings"
-msgstr "Bluetoothi seaded"
-
-msgid "Map to Monitor…"
-msgstr "Monitoriga ühendamine…"
-
-msgid "Map Buttons…"
-msgstr "Nuppude ühendamine…"
-
-msgid "Adjust display resolution"
-msgstr "Kuvari eraldusvõime muutmine"
-
-msgid "Adjust mouse settings"
-msgstr "Hiireseadete muutmine"
-
-msgid "Tracking Mode"
-msgstr "Jälitamise režiim"
-
-msgid "Left-Handed Orientation"
-msgstr "Vasaku- või paremakäeliste hiir"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-msgid "Left Ring"
-msgstr "Vasak ratas"
-
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "Vasaku ratta režiim %d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-msgid "Right Ring"
-msgstr "Parem ratas"
-
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "Parema ratta režiim %d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-msgid "Left Touchstrip"
-msgstr "Vasak puuteriba"
-
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "Vasak puuteriba režiim %d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-msgid "Right Touchstrip"
-msgstr "Parem puuteriba"
-
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "Parem puuteriba režiim %d"
-
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "Vasaku puuteringi režiimi lüliti"
-
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "Parema puuteringi režiimi lüliti"
-
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "Vasaku puuteriba režiimi lüliti"
-
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "Parema puuteriba režiimi lüliti"
-
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "Režiimilüliti %d"
-
-#, c-format
-msgid "Left Button #%d"
-msgstr "Vasak nupp %d"
-
-#, c-format
-msgid "Right Button #%d"
-msgstr "Parem nupp %d"
-
-#, c-format
-msgid "Top Button #%d"
-msgstr "Ülemine nupp %d"
-
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "Alumine nupp %d"
-
-msgid "New shortcut…"
-msgstr "Uus kiirklahv…"
-
-msgid "No Action"
-msgstr "Tegevus puudub"
-
-msgid "Left Mouse Button Click"
-msgstr "Vasaku hiirenupu klõps"
-
-msgid "Middle Mouse Button Click"
-msgstr "Keskmise hiirenupu klõps"
-
-msgid "Right Mouse Button Click"
-msgstr "Parema hiirenupu klõps"
-
-msgid "Scroll Up"
-msgstr "Üles kerimine"
-
-msgid "Scroll Down"
-msgstr "Alla kerimine"
-
-msgid "Scroll Left"
-msgstr "Vasakule kerimine"
-
-msgid "Scroll Right"
-msgstr "Paremale kerimine"
-
-msgid "Back"
-msgstr "Tagasi"
-
-msgid "Forward"
-msgstr "Edasi"
-
-msgid "Stylus"
-msgstr "Kirjapulk"
-
-msgid "Eraser Pressure Feel"
-msgstr "Kustutaja survetundlikkus"
-
-msgid "Soft"
-msgstr "Pehme"
-
-msgid "Firm"
-msgstr "Tugev"
-
-msgid "Top Button"
-msgstr "Ülemine nupp"
-
-msgid "Lower Button"
-msgstr "Alumine nupp"
-
-msgid "Tip Pressure Feel"
-msgstr "Otsa survetundlikkus"
-
-msgid "Enable verbose mode"
-msgstr "Jutuka režiimi lubamine"
-
-msgid "Show the overview"
-msgstr "Ülevaate näitamine"
-
-msgid "Search for the string"
-msgstr "Teksti otsimine"
-
-msgid "List possible panel names and exit"
-msgstr "Võimalike paneelinimed kuvamine ja väljumine"
-
-msgid "Show help options"
-msgstr "Abiteabe võtmete näitamine"
-
-msgid "Panel to display"
-msgstr "Kuvatav paneel"
-
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEEL] [ARGUMENT…]"
-
-msgid "- Settings"
-msgstr "- sätted"
-
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
 msgstr ""
-"%s\n"
-"Kõigi saadaolevate käsureavõtmete vaatamiseks käivita '%s --help'.\n"
 
-msgid "Available panels:"
-msgstr "Saadaolevad paneelid:"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-msgid "Help"
-msgstr "Abi"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-msgid "Quit"
-msgstr "Lõpeta"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simuleeritud paremklõps"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windowsi tarkvara"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Tooner on otsakorral"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Teisene"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windowsi tarkvara"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Ligipääsu valikud"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Lisa"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salvesta"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Üksikasjad"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_Võrguaeg"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "_Võrgu nimi"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Arvud"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Vaata üksikasju"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Tootja"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Püsivara puudub"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Mobiiliühendus"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_Võrguaeg"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Võrk"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Laiendatud"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Ligipääsu valikud"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Ekraanilukk"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Üksikasjad"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "_Võrgu nimi"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Automaatne"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Minu koduvõrk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Minu koduvõrk"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Bluetooth seadmeid ei leitud"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "_Lennukirežiim"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Ühendus"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM kaart ei ole sees"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Ekraanilukk"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "_Muuda"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Minu koduvõrk"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "Uue draiveri seadistamine…"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "Privaatsus"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Kõik seaded"
 
-#. Add categories
-msgctxt "category"
-msgid "Personal"
-msgstr "Isiklik"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Peamine"
 
-msgctxt "category"
-msgid "Hardware"
-msgstr "Riistvara"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-msgctxt "category"
-msgid "System"
-msgstr "Süsteem"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-msgid "Settings"
-msgstr "Sätted"
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Abi"
 
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Üldine"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Lõpeta"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Otsi"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Eelmisele sisendile lülitumine"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Katkestatud"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Eelistused;Sätted;Seaded;Seadistused;"
 
-#~ msgid "_Done"
-#~ msgstr "_Valmis"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u väljund"
+msgstr[1] "%u väljundit"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u sisend"
+msgstr[1] "%u sisendid"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Muutub pidevalt"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Korduv"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Ekraan täidetud"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Keskel"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Üle ekraani"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Üle mitme ekraani"
+
+#~ msgid "Select Background"
+#~ msgstr "Tausta valimine"
+
+#~ msgid "Pictures"
+#~ msgstr "Pildid"
+
+#~ msgid "Colors"
+#~ msgstr "Värvid"
+
+#~ msgid "Home"
+#~ msgstr "Kodukataloog"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Pildid, mille lisad kausta %s, ilmuvad siia"
+
+#~ msgid "multiple sizes"
+#~ msgstr "mitmes suuruses"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+# paistab välimuse eelistuste all ühevärvilise tausta tooltip'ina
+#~ msgid "No Desktop Background"
+#~ msgstr "Ilma taustapildita töölaud"
+
+#~ msgid "Current background"
+#~ msgstr "Praegune taustapilt"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Taustapilt;Tapeet;Ekraan;Töölaud;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "Aseta kalibreerimisseade ruudu kohale ja vajuta 'Alusta'"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "Liiguta kalibreerimisseade uude asukohta ja vajuta 'Jätka'"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "Liiguta kalibreerimisseade pinnaasendisse ja vajuta 'Jätka'"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Sulge sülearvuti kaas"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Tekkis sisemine viga, millest pole võimalik taastuda."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Kalibreerimise jaoks vajalikud tööriistad pole paigaldatud."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profiili pole võimalik genereerida."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Soovitud valgepunkt pole saavutatav."
+
+#~ msgid "Complete!"
+#~ msgstr "Valmis!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Seadistamine nurjus!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Sa võid kalibreerimisseadme nüüd eemaldada."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Palun ära häiri töötamise ajal kalibreerimisseadet"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Sülearvuti ekraan"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s kuvar"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s skanner"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s printer"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s veebikaamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Värvihalduse lubamine %s jaoks"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s värviprofiilide näitamine"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Kalibreerimata"
+
+#~ msgid "Default: "
+#~ msgstr "Vaikimisi: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Katseprofiil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC profiili valimine"
+
+#~ msgid "_Import"
+#~ msgstr "_Impordi"
+
+#~ msgid "All files"
+#~ msgstr "Kõik failid"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Faili üleslaadimine nurjus: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profiil laaditi üles asukohta:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Kirjuta see URL üles."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Taaskäivita arvuti ja mine tavalisse operatsioonisüsteemi."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Sisesta brauserisse URL, et profiil allalaadida ja salvestada."
+
+#~ msgid "Save Profile"
+#~ msgstr "Profiili salvestamine"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Valitud seadmele värviporfiili loomine"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Mõõteriista ei tuvastatud. Palun veendu, et see on sisse lülitatud ja "
+#~ "õigesti ühendatud."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Mõõteriist ei toeta printeri profiilimist."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Seda seadmetüüpi hetkel ei toetata."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standardruum"
+
+#~ msgid "Test Profile"
+#~ msgstr "Katseprofiil:"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automaatne"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Halb kvaliteet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Keskmine kvaliteet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Hea kvaliteet"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Vaikimisi RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Vaikimisi CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Vaikimisi halltoonid"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Tootja pakutavad kalibreerimise tehaseandmed"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Täisekraani värviparandus pole selle profiiliga võimalik"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "See profiil ei pruugi olla enam täpne"
+
+#~ msgid "Done"
+#~ msgstr "Valmis"
+
+#~ msgid "Upload profile"
+#~ msgstr "Laadi profiil üles"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Vajalik on internetiühendus"
+
+#~ msgid "United States"
+#~ msgstr "Ameerika Ühendriigid"
+
+#~ msgid "Germany"
+#~ msgstr "Saksamaa"
+
+#~ msgid "Spain"
+#~ msgstr "Hispaania"
+
+#~ msgid "China"
+#~ msgstr "Hiina"
+
+#~ msgid "Other…"
+#~ msgstr "Muu profiil…"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e. %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e. %B %Y, %R"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "_Ajavöönd"
+
+#~ msgid "24-hour"
+#~ msgstr "24 tundi"
+
+#~ msgid "AM / PM"
+#~ msgstr "EL / PL"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Ekraan suletud"
+
+#~ msgid "Mirrored"
+#~ msgstr "Peegeldatud"
+
+#~ msgid "Off"
+#~ msgstr "Väljas"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Kombineeritud ekraanide paigutus"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Ekraanide ümberpaigutamiseks lohista."
+
+#~ msgid "Size"
+#~ msgstr "Suurus"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Ülemist riba ja tegevuste ülevaadet kuvatakse sellel ekraanil"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Ühenda see kuva mõne teisega, et luua lisatööala"
+
+#~ msgid "Presentation"
+#~ msgstr "Esitlus"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Näidatakse ainult slaidiesitlusi ja meediat"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Näidatakse sama pilti mõlemal ekraanil"
+
+#~ msgid "Turn Off"
+#~ msgstr "Lülita välja"
+
+#~ msgid "Don't use this display"
+#~ msgstr "Seda ekraani ei kasutata"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Ekraani andmeid pole võimalik hankida"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Paiguta kombineeritud ekraanid"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "Unknown"
+#~ msgstr "Tundmatu"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s, %d-bitine"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-bitine"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Küsitakse, mida teha"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ära tee midagi"
+
+#~ msgid "Open folder"
+#~ msgstr "Ava kataloog"
+
+#~ msgid "Other Media"
+#~ msgstr "Muu meedia"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Audio-CD jaoks kasutatava rakenduse valimine"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Video-DVD jaoks kasutatava rakenduse valimine"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Vali rakendus, mis tuleb käivitada muusikamängija ühendamisel"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Vali rakendus, mis tuleb käivitada kaamera ühendamisel"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Tarkvara CD-de jaoks rakenduse valimine"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio-DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "tühi Blu-ray plaat"
+
+#~ msgid "blank CD disc"
+#~ msgstr "tühi CD-plaat"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "tühi DVD-plaat"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "tühi HD DVD plaat"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray videoplaat"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-raamatu lugeja"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD videoplaat"
+
+#~ msgid "Picture CD"
+#~ msgstr "Pildi-CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video-CD"
+
+#~ msgid "Overview"
+#~ msgstr "Ülevaade"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "Versioon %s"
+
+#~ msgid "Base system"
+#~ msgstr "Baassüsteem"
+
+#~ msgid "Disk"
+#~ msgstr "Ketas"
+
+#~ msgid "Check for updates"
+#~ msgstr "Uuenduste küsimine"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Ekraanipildi salvestamine $PICTURES kausta"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Aknast tehtud ekraanipildi salvestamine $PICTURES kausta"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Alast tehtud ekraanipildi salvestamine $PICTURES kausta"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Ekraanipildi kopeerimine lõikepuhvrisse"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Akna ekraanipildi kopeerimine lõikepuhvrisse"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Ala ekraanipildi kopeerimine lõikepuhvrisse"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Lühikese ekraanisalvestuse lindistamine"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Ainult modifikaatoritega järgmisele allikale lülitumine"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Kiirklahv;Kordus;Vilkumine;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Kohandatud kiirklahv"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Viivitus:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Lühike"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Aeglane"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Pikk"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Kiire"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Kiirus:"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Eemalda välksõrmis"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Välksõrmise muutmiseks klõpsa vastaval real ja määra uus sõrmis. "
+#~ "Nullimiseks vajuta Backspace klahvi."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<tundmatu tegevus>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Kiirklahvi \"%s\" pole võimalik kasutada, kuna see teeb selle klahvi "
+#~ "kasutamise tavaolukorras võimatuks.\n"
+#~ "Palun proovi klahvi kombineerida klahvidega Control, Alt või Shift."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Kiirklahvi \"%s\" juba kasutatakse järgneva tegevuse jaoks:\n"
+#~ "\"%s\""
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Kui sa määrad selle kiirklahvi tegevusele \"%s\", siis tegevuse \"%s\" "
+#~ "kiirklahv keelatakse."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Määra"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Proovi oma sätteid"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Aeglane"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Topeltklõpsu ajapiirang"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Kiire"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Vasak"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Parem"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Kursori kiirus"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Aeglane"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Kiire"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Aeglane"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Kiire"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "_Kahe sõrmega kerimine"
+
+#~ msgid "_Natural scrolling"
+#~ msgstr "_Loomulik kerimine"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Viis klõpsu GEGL-i kord!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Topeltklõps, peamine nupp"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Üks klõps, peamine nupp"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Topeltklõps, keskmine nupp"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Üks klõps, keskmine nupp"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Topeltklõps, teine nupp"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Üks klõps, teine nupp"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Süsteemi võrguteenused ei sobi selle versiooniga."
+
+#~ msgid "page 1"
+#~ msgstr "leht 1"
+
+#~ msgid "page 2"
+#~ msgstr "leht 2"
+
+#~ msgid "automatic"
+#~ msgstr "automaatne"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Ettevõtte"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Puudub"
+
+#~ msgid "Never"
+#~ msgstr "Mitte kunagi"
+
+#~ msgid "Today"
+#~ msgstr "Täna"
+
+#~ msgid "Yesterday"
+#~ msgstr "Eile"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Puudub"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Nõrk"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Piisav"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Tugev"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Suurepärane"
+
+#~ msgid "Identity"
+#~ msgstr "Identiteet"
+
+#~ msgid "Server"
+#~ msgstr "Server"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Kustuta DNS server"
+
+#~ msgid "Delete Route"
+#~ msgstr "Kustuta marsruut"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Puudub"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-biti võti (Hex või ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-biti parool"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dünaamiline WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 isiklik"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 ettevõtte"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Pööratud paar (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Meediumist sõltumatu liides (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Saadaval teistele _kasutajatele"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Tulemüüri _tsoon"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Vaikimisi"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Tsoon määrab ühenduse usaldusväärsuse"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Ühenduse redaktori avamine polnud võimalik"
+
+#~ msgid "New Profile"
+#~ msgstr "Uus profiil"
+
+#~ msgid "Bond"
+#~ msgstr "Side"
+
+#~ msgid "Team"
+#~ msgstr "Meeskond"
+
+#~ msgid "Bridge"
+#~ msgstr "Sild"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN pluginaid polnud võimalik laadida"
+
+#~ msgid "Import from file…"
+#~ msgstr "Failist importimine…"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Uue ühenduse lisamine"
+
+#~ msgid "_Reset"
+#~ msgstr "_Lähtesta"
+
+#~ msgid "_Forget"
+#~ msgstr "_Unusta"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Lähtestakse selle võrgu sätted, sealhulgas paroolid, aga see jäetakse "
+#~ "eelistatud võrguks"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Eemaldatakse kõik selle võrgu üksiksasjad ning sellesse võrku ei püüta "
+#~ "hiljem ühenduda"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN ühendust pole võimalik importida"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Faili '%s' pole võimalik lugeda või see ei sisalda äratuntavaid andmeid "
+#~ "VPN ühenduse kohta\n"
+#~ "\n"
+#~ "Viga: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Importimiseks faili valimine"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "Fail nimega '%s' on juba olemas."
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Kas tahad asendada %s praegu salvestatava VPN ühendusega?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN ühendust pole võimalik eksportida"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN ühendust '%s' pole võimalik eksportida faili %s.\n"
+#~ "\n"
+#~ "Viga: %s."
+
+#~ msgid "Export VPN connection..."
+#~ msgstr "VPN ühenduse eksportimine..."
+
+#~ msgid "Bond slaves"
+#~ msgstr "Sideme alamad"
+
+#~ msgid "(none)"
+#~ msgstr "(pole)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Silla alamad"
+
+#~ msgid "never"
+#~ msgstr "mitte kunagi"
+
+#~ msgid "today"
+#~ msgstr "täna"
+
+#~ msgid "yesterday"
+#~ msgstr "eile"
+
+#~ msgid "Last used"
+#~ msgstr "Viimati kasutatud"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profiil %d"
+
+#~ msgid "Team slaves"
+#~ msgstr "Meeskonna alamad"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Kui su internetiühendus ei tule juhtmeta võrgu kaudu, võid kasutada "
+#~ "juhtmeta võrku teistele internetiühenduse jagamiseks."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Juhtmeta võrgu kaudu jagamise (hotspot) sisselülitamine katkestab "
+#~ "ühenduse võrguga <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Pole võimalik ühenduda internetti juhtmeta võrgu kaudu, kuni hotspot on "
+#~ "aktiivne."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Kas seisata tugijaam ja ühendada kasutajad lahti?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Seiska tugijaam"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Süsteemireegel keelab Hotspotina kasutamine"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Juhtmevaba seade ei toeta Hotspot režiimi"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Valitud võrkude andmed, sealhulgas parool ja eriseadistused, lähevad "
+#~ "kaotsi."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Unusta"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Veebiproksi isetuvastust kasutatakse siis, kui seadistamise URL pole "
+#~ "määratud."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "See ei ole mitteusaldatavates avalikes võrkudes soovitatav."
+
+#~ msgid "Proxy"
+#~ msgstr "Proksi"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Puudub"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Käsitsi"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automaatne"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPNi tüüp"
+
+#~ msgid "Group Name"
+#~ msgstr "Grupi nimi"
+
+#~ msgid "details"
+#~ msgstr "üksikasjad"
+
+#~ msgid "Show P_assword"
+#~ msgstr "_Parooli näitamine"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Saadaval teistele kasutajatele"
+
+#~ msgid "identity"
+#~ msgstr "identiteet"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Automaatselt ainult (DHCP) aadressid"
+
+#~ msgid "Link-local only"
+#~ msgstr "Ainult kohalik võrk (link-local)"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Automaatselt hangitud marsruutide eiramine"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Kloonitud MAC aadress"
+
+#~ msgid "hardware"
+#~ msgstr "riistvara"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Lähtestakse selle võrgu sätted, sealhulgas paroolid, aga see jäetakse "
+#~ "eelistatud võrguks."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Eemaldatakse kõik selle võrgu üksiksasjad ning sellesse võrku ei püüta "
+#~ "hiljem ühenduda."
+
+#~ msgid "reset"
+#~ msgstr "lähtesta"
+
+#~ msgid "Hardware"
+#~ msgstr "Riistvara"
+
+#~ msgid "_History"
+#~ msgstr "_Ajalugu"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Wi-Fi võrguga ühendumiseks lülita välja"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Ühendatud seadmed"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastruktuur"
+
+#~ msgid "Status unknown"
+#~ msgstr "Olek teadmata"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Haldamata"
+
+#~ msgid "Unavailable"
+#~ msgstr "Pole saadaval"
+
+#~ msgid "Connecting"
+#~ msgstr "Ühendumine"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Ühenduse katkestamine"
+
+#~ msgid "Connection failed"
+#~ msgstr "Ühendumine nurjus"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Olek teadmata (puudub)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Seadistamine nurjus"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP seadistamine nurjus"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP seadistus aegus"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Vajalik on parool, aga seda ei antud"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x supplicant-iga katkes ühendus"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x supplicant-i seadistus nurjus"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x supplicant nurjus"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant-il läks autentimiseks liiga kaua"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP teenuse käivitamine nurjus"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP teenuse ühendus katkes"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP nurjus"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP kliendi käivitamine nurjus"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP kliendi viga"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP kliendi päring nurjus"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Jagatud ühenduse teenuse käivitamine nurjus"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Jagatud ühenduse teenus nurjus"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP teenuse käivitamine nurjus"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP teenuse viga"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP teenus nurjus"
+
+#~ msgid "Line busy"
+#~ msgstr "Liin on hõivatud"
+
+#~ msgid "No dial tone"
+#~ msgstr "Tooni pole"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Kandjat polnud võimalik luua"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Valimise katse aegus"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Valimise katse nurjus"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Modemi lähtestamine nurjus"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Määratud APN-i valimine nurjus"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Võrke ei otsita"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Võrgu registreerimine on keelatud"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Võrgu registreerimine aegus"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Valitud võrku registreerimine nurjus"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN-i kontroll nurjus"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Selle seadme püsivara (firmware) võib olla puudu"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Ühendus kadus"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Olemasolev ühendus on eeldatav"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modemit ei leitud"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth ühendus nurjus"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Vajalik on SIM-kaardi PIN-kood"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Vajalik on SIM-kaardi PUK-kood"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Vale SIM"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand seade ei toeta seda ühenduse režiimi"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Ühenduse sõltuvus nurjus"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Juhe eemaldatud"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Ühtegi sertifitseerimiskeskuse serti pole valitud"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Sertifitseerimiskeskuse (SK) serdi mittekasutamine võib võimaldada "
+#~ "ühendusi ebaturvaliste, halbade Wi-Fi võrkudega. Kas tahaksid siiski "
+#~ "valida sertifitseerimiskeskuse serdi?"
+
+#~ msgid "Ignore"
+#~ msgstr "Eira"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Vali SK sertifikaat"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM või PKCS#12 privaatvõtmed (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER või PEM sertifikaadid (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC failid (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "_Seda parooli küsitakse iga kord"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Krüpteerimata privaatvõtmed pole turvalised"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Valitud privaatvõti ei ole parooliga kaitstud. Seetõttu võivad "
+#~ "turvatõendid saada kompromiteeritud. Palun vali parooliga kaitstud "
+#~ "privaatvõti.\n"
+#~ "\n"
+#~ "(sa võid privaatvõtme parooliga kaitsta openssl abiga)"
+
+#~ msgid "Choose your personal certificate..."
+#~ msgstr "Vali oma isiklik sertifikaat..."
+
+#~ msgid "Choose your private key..."
+#~ msgstr "Vali oma privaatvõti..."
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "_Rohkem ei hoiatata"
+
+#~ msgid "Yes"
+#~ msgstr "Jah"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Hüpikbännerite kuvamine"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "Bänneritel üksikasjade kuvamine"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Näidatakse lukustamise ekraanil"
+
+#~ msgid "On"
+#~ msgstr "Sees"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Hüpikbännerite kuvamine"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "Näidatakse lukustamise ekraanil"
+
+#~ msgid "Add Account"
+#~ msgstr "Konto lisamine"
+
+#~ msgid "Mail"
+#~ msgstr "E-post"
+
+#~ msgid "Contacts"
+#~ msgstr "Kontaktid"
+
+#~ msgid "Chat"
+#~ msgstr "Vestlus"
+
+#~ msgid "Resources"
+#~ msgstr "Ressursid"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Tõrge kontole sisselogimisel"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Turvatõendid on aegunud."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Selle konto lubamiseks logi sisse."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Logi sisse"
+
+#~ msgid "Error creating account"
+#~ msgstr "Tõrge konto loomisel"
+
+#~ msgid "Error removing account"
+#~ msgstr "Tõrge konto eemaldamisel"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Oled sa kindel, et soovid konto eemaldada?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "See ei eemalda serveris olevat kontot."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Ühtegi netikontot pole seadistatud"
+
+#~ msgid "Remove Account"
+#~ msgstr "Konto eemaldamine"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Konto lisamine võimaldab rakendustele ligipääsu dokumentidele, meilile, "
+#~ "kontaktidele, kalendrile, vestlusele ja muule."
+
+#~ msgid "Unknown time"
+#~ msgstr "Tundmatu aeg"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s täislaadimiseni"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Hoiatus: %s jäänud"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s jäänud"
+
+#~ msgid "Fully charged"
+#~ msgstr "Täis laetud"
+
+#~ msgid "Empty"
+#~ msgstr "Tühi"
+
+#~ msgid "Charging"
+#~ msgstr "Laadimine"
+
+#~ msgid "Discharging"
+#~ msgstr "Tühjenemine"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Peamine"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Ekstra"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Juhtmeta hiir"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Juhtmeta klaviatuur"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Katkestuseta toite allikas (UPS)"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Isiklik digitaalassistent"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobiiltelefon"
+
+#~ msgid "Media player"
+#~ msgstr "Muusikaesitaja"
+
+#~ msgid "Computer"
+#~ msgstr "Arvuti"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Laadimine"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Hoiatus"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Vähe"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Hea"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Täis laetud"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Tühi"
+
+#~ msgid "Batteries"
+#~ msgstr "Akud"
+
+#~ msgid "When _idle"
+#~ msgstr "Kui _jõude"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "_Klaviatuuri heledus"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "_Ekraan tumeneb, kui tegevust pole"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Lülitab juhtmevabad seadmed välja"
+
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "Mobiiliühenduse seadmete (3G, 4G, WiMax jt) väljalülitamine"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "When on battery power"
+#~ msgstr "Akutoitel"
+
+#~ msgid "When plugged in"
+#~ msgstr "Võrgutoitel"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "Uinak ja väljalülitamine"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automaatne uinumine"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Kui aku on _väga tühi"
+
+#~ msgid "Power Off"
+#~ msgstr "Lülitatakse välja"
+
+#~ msgid "Hibernate"
+#~ msgstr "Talveuni"
+
+#~ msgid "1 minute"
+#~ msgstr "1 minut"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 minutit"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 minutit"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 minutit"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 minutit"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 minutit"
+
+#~ msgid "Out of toner"
+#~ msgstr "Tooner on otsas"
+
+#~ msgid "Low on developer"
+#~ msgstr "Ilmuti on otsakorral"
+
+#~ msgid "Out of developer"
+#~ msgstr "Ilmuti on otsas"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Värv on otsakorral"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Värv on otsas"
+
+#~ msgid "Open cover"
+#~ msgstr "Kaas on avatud"
+
+#~ msgid "Open door"
+#~ msgstr "Luuk on avatud"
+
+#~ msgid "Low on paper"
+#~ msgstr "Paber on otsakorral"
+
+#~ msgid "Out of paper"
+#~ msgstr "Paber on otsas"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Seisma jäetud"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Prügimahuti on peaaegu täis"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Prügimahuti on täis"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Fotosilma eluiga on lõppemas"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Fotosilm enam ei tööta"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Valmis"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Töid vastu ei võeta"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Töötlemine"
+
+#~ msgid "Toner Level"
+#~ msgstr "Tooneri kogus"
+
+#~ msgid "Supply Level"
+#~ msgstr "Kuluvahendi kogus"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Paigaldamine"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktiivne"
+#~ msgstr[1] "%u aktiivset"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Tõrge uue printeri lisamisel."
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PPD PostScript printeri kirjelduse failid (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+#~ "gz, *.PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Ühtegi sobivat draiverit ei leitud"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Kasutajaliidest pole võimalik laadida: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Jätka printimist"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Peata printimine"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Uue printeri lisamine"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Tulemuste filtreerimiseks sisesta printeri aadress või nimi"
+
+#~ msgid "One Sided"
+#~ msgstr "Ühepoolne"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Ümber pika külje (tavaline)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Ümber lühikese külje (pööratud)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portree"
+
+#~ msgid "Landscape"
+#~ msgstr "Maastik"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Pööratud maastik"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Pööratud portree"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Ootel"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Hoitakse kinni"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Töötluses"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Peatatud"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Loobutud"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Valmis"
+
+#~ msgid "Job Title"
+#~ msgstr "Töö pealkiri"
+
+#~ msgid "Job State"
+#~ msgstr "Töö seisund"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Jadaport"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralleelport"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Aadress: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "Kahepoolne"
+
+#~ msgid "Paper Type"
+#~ msgstr "Paberi liik"
+
+#~ msgid "Paper Source"
+#~ msgstr "Paberi allikas"
+
+#~ msgid "Output Tray"
+#~ msgstr "Väljundsalv"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScripti eelfilter"
+
+#~ msgid "Pages per side"
+#~ msgstr "Lehekülgi lehele"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Üldine"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Lehe seadistus"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Paigaldatavad valikud"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Töö"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Pildi kvaliteet"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Värvid"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Lõpetamine"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automaatne valik"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Kaasatakse ainult GhostScripti fondid"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Teisendamine keelde PS level 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Teisendamine keelde PS level 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Eelfilter puudub"
+
+#~ msgid "Supply"
+#~ msgstr "Varu"
+
+#~ msgid "_Default printer"
+#~ msgstr "_Vaikimisi printer"
+
+#~ msgid "Jobs"
+#~ msgstr "Tööd"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "_Tööde kuvamine"
+
+#~ msgid "label"
+#~ msgstr "silt"
+
+#~ msgid "page 3"
+#~ msgstr "leht 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "_Prindi proovilehekülg"
+
+#~ msgid "_Options"
+#~ msgstr "_Valikud"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Uue printeri lisamine"
+
+#~ msgid "Usage & History"
+#~ msgstr "Kasutus ja ajalugu"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Kas tühjendada prügikast?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Kõik asjad prügikastis kustutatakse jäädavalt."
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Kas kustutada kõik ajutised failid?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Kõik ajutised failid kustutatakse jäädavalt."
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Kaitse oma isiklikke andmeid ja muuda, mida teised näevad"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 sekundit"
+
+#~ msgid "1 day"
+#~ msgstr "1 päev"
+
+#~ msgid "2 days"
+#~ msgstr "2 päeva"
+
+#~ msgid "3 days"
+#~ msgstr "3 päeva"
+
+#~ msgid "4 days"
+#~ msgstr "4 päeva"
+
+#~ msgid "5 days"
+#~ msgstr "5 päeva"
+
+#~ msgid "6 days"
+#~ msgstr "6 päeva"
+
+#~ msgid "7 days"
+#~ msgstr "7 päeva"
+
+#~ msgid "14 days"
+#~ msgstr "14 päeva"
+
+#~ msgid "30 days"
+#~ msgstr "30 päeva"
+
+#~ msgid "Forever"
+#~ msgstr "Igavesti"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Ajaloo mäletamine teeb hiljem asjade leidmise lihtsamaks. Neid kirjeid ei "
+#~ "jagata kunagi üle võrgu."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Hiljuti kasutatud"
+
+#~ msgid "Retain _History"
+#~ msgstr "Säilita _ajalugu"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Ekraanilukk kaitseb sinu privaatsust, kuni sa ära oled."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Ekraan lukustatakse _pärast pimenemist"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Automaatselt tühjenda prügikast ja viska ära ajutised failid, et hoida "
+#~ "arvuti puhas ebavajalikust tundlikust infost."
+
+#~ msgid "Purge _After"
+#~ msgstr "Tühjendatakse _pärast"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Kui saadad meile infot tarkvara kohta, mida kasutad, on meil võimalik "
+#~ "pakkuda sulle täpsemaid soovitusi. Samuti aitab see just õiget tarkvara "
+#~ "arendada.\n"
+#~ "\n"
+#~ "Kõik meie kogutavad andmed tehakse anonüümseks ning me ei jaga sinu "
+#~ "andmeid mitte kunagi kellegi kolmandaga."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Tarkvarakasutuse statistika saatmine"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Privaatsuse tagamine"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Briti mõõdustik"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Meetermõõdustik"
+
+#~ msgid "No input sources found"
+#~ msgstr "Ühtegi sisendseadet ei leitud"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Muu"
+
+#~ msgid "Sorry"
+#~ msgstr "Vabandust"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Lülitu järgmisele allikale"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Tühik"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "Neid kiirklahve saab muuta klaviatuuri sätete alt"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Järgmisele sisendile vahetamise alternatiiv"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Vasak+parem Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Inglise (Suurbritannia)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Suurbritannia"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "Sisselogimissätteid mõjuvatad sisselogimisel kõik kasutajad"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Muu"
+
+#~ msgid "Select Location"
+#~ msgstr "Asukoha valimine"
+
+#~ msgid "_OK"
+#~ msgstr "_Olgu"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Sees"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Väljas"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Kausta valimine"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Bluetoothi jagamine võimaldab jagada faile teiste Bluetoothi seadmetega"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Ainult usaldatud seadmetelt vastuvõtmine"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Vastuvõetud failide salvestamine allalaadimiste kausta"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "Ekraani jagamine"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Mõned teenused on võrguühenduse puudumise tõttu keelatud."
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Meedia jagamine sellesse võrku"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Jagatud kataloogid"
+
+#~ msgid "column"
+#~ msgstr "tulp"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Kataloogi eemaldamine"
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "Isiklike failide jagamine võimaldab avaliku ja teiste kaustade jagamist "
+#~ "praegusesse võrku, kasutades aadressi: <a href=\"dav://%s\">dav://%s</a>"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Avaliku kausta jagamine sellesse võrku"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "Kaugkasutajad võivad ühenduda kasutades SSH käsku:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "Kaugkasutajad saavad sinu ekraani kasutada, ühendudes aadressil: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "Password:"
+#~ msgstr "Parool:"
+
+#~ msgid "Show Password"
+#~ msgstr "Parooli näitamine"
+
+# Või uued kontaktid?
+#~ msgid "New connections must ask for access"
+#~ msgstr "Uued ühendused peavad küsima luba"
+
+#~ msgid "Require a password"
+#~ msgstr "Parool nõutud"
+
+#~ msgid "Bark"
+#~ msgstr "Haukumine"
+
+#~ msgid "Drip"
+#~ msgstr "Tilkumine"
+
+#~ msgid "Glass"
+#~ msgstr "Klaas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimaalne"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maksimaalne"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Bassikõlar:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Võimendamata"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profiil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Kõlarite kontroll"
+
+#~ msgid "Peak detect"
+#~ msgstr "Tipu tuvastamine"
+
+#~ msgid "Device"
+#~ msgstr "Seade"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s kõlarite testimine"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Vali heliväljundi seade:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Valitud seadme sätted:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Sisendi valjus"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Vali helisisendi seade:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Heliefektid"
+
+#~ msgid "Built-in"
+#~ msgstr "Sisseehitatud"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Helieelistused"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Sündmuse heli testimine"
+
+#~ msgid "From theme"
+#~ msgstr "Teemast"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Vali teadaande heli:"
+
+#~ msgid "Stop"
+#~ msgstr "Peata"
+
+#~ msgid "Custom"
+#~ msgstr "Kohandatud"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Ekraanilugeja"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Ekraanilugeja"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Klahvide heli"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "_Akna pealkirja vilgutamine"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Lühike"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ekraani"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ekraani"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ekraani"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Pikk"
+
+#~ msgid "Zoom"
+#~ msgstr "Ekraan täidetud"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Värvid"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Tavaline"
+
+#~ msgid "_Verify"
+#~ msgstr "_Kontrolli"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "Ühendu internetti, et lisada\n"
+#~ "ettevõtte sisselogimiskontosid."
+
+#~ msgid "Left thumb"
+#~ msgstr "Vasak pöial"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Vasak keskmine sõrm"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Vasak nimetu sõrm"
+
+#~ msgid "Left little finger"
+#~ msgstr "Vasak väike sõrm"
+
+#~ msgid "Right thumb"
+#~ msgstr "Parem pöial"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Parem keskmine sõrm"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Parem nimetu sõrm"
+
+#~ msgid "Right little finger"
+#~ msgstr "Parem väike sõrm"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Sõrmejäljega logimise lubamine"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Parema käe nimetissõrm"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Vasaku käe nimetissõrm"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Sinu sõrmejälg on edukalt salvestatud. Sul peaks olema nüüd võimalik "
+#~ "sõrmejäljelugeja abil sisse logida."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Sisselogimine;Nimi;Sõrmejälg;Avatar;Logo;Nägu;Parool;Salasõna;"
+
+#~ msgid "Login History"
+#~ msgstr "Sisselogimiste ajalugu"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Kinnita uus parool"
+
+#~ msgid "Add User Account"
+#~ msgstr "Lisa kasutajakonto"
+
+#~ msgid "User Icon"
+#~ msgstr "Kasutajaikoon"
+
+#~ msgid "Last Login"
+#~ msgstr "Viimane sisselogimine"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Uus parool ei tohi olla sama nagu eelmine."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Proovi mõnede tähtede ja numbrite muutmist."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Muuda parooli veel natukene."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Ilma kasutajanimeta parool peaks olema tugevam."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Ära kasuta oma kasutajanime parooli sees."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Ära kasuta parooli sees tuntud sõnu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Ära kasuta tavalisi sõnu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Ära vaheta olemasolevate sõnade järjekorda."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Kasuta rohkem numbreid."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Kasuta rohkem suurtähti."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Kasuta rohkem väiketähti."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Kasuta mõnd erimärki nagu näiteks punkt."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Kasuta kombinatsiooni tähtedest, numbritest ja kirjavahemärkidest."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Väldi sama märgi kordamist."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Hoidu sama liiki märgi kordamisest. Sul on vaja kombinatsiooni tähtedest, "
+#~ "numbritest ja kirjavahemärkidest."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Väldi järgnevusi nagu1234 või abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Püüa lisada veel tähti, numbreid ja sümboleid."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr "Kasuta vaheldumisi suur- ja väiketähti ning lisa paar numbrit."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr ""
+#~ "Hea parool! Tähtede, numbrite ja kirjavahemärkide lisamine teeks seda "
+#~ "tugevamaks."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Tugevus: väga nõrk"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Tugevus: nõrk"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Tugevus: keskmine"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Tugevus: piisav"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Tugevus: eriti tugev"
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autentimine ei õnnestunud"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Uus parool on liiga lühike"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Uus parool on liiga lihtne"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Vana ja uus parool on liiga sarnased"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Uus parool on hiljuti kasutusel olnud."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Uus parool peab sisaldama numbreid või erimärke"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Vana ja uus parool on ühesugused"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Sinu parool on pärast algset autentimist muutunud!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Uus parool ei sisalda piisaval hulgal erinevaid märke"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Tundmatu viga"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "Peaks vastama sinu kontopakkuja veebiaadressile."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Konto lisamine nurjus"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Paroolid ei klapi."
+
+#~ msgid "Failed to register account"
+#~ msgstr "Konto registreerimine nurjus"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Pole ühtegi toetatud viisi selle domeeniga autentimiseks"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Domeeniga ühendumine nurjus"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Kasutajanimi pole õige.\n"
+#~ "Palun proovi uuesti."
+
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Parool ei olnud õige.\n"
+#~ "Palun proovi uuesti."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Domeeni sisselogimine nurjus"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "Domeeni ei leitud. Võib-olla kirjutasid selle valest?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Sul pole õigust sellele seadmele ligi pääseda. Ligipääsu jaoks võta palun "
+#~ "ühendust oma süsteemiadministraatoriga."
+
+#~ msgid "The device is already in use."
+#~ msgstr "Seade on juba kasutusel."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Tekkis sisemine viga."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Kas kustutada registreeritud sõrmejäljed?"
+
+#~ msgid "Done!"
+#~ msgstr "Valmis!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "Seadmele '%s' puudub ligipääs"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "Ei suudetud alustada sõrmejälje salvestamist seadmel '%s'"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Ühelegi sõrmejäljelugejale pole võimalik ligi pääseda"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Abi saamiseks võta palun ühendust oma süsteemiadministraatoriga."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "Sõrmejäljega sisselogimise kasutamiseks pead salvestama '%s' seadmega "
+#~ "vähemalt ühe sõrmejälje."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Sõrme valimine"
+
+#~ msgid "This Week"
+#~ msgstr "See nädal"
+
+#~ msgid "Last Week"
+#~ msgstr "Eelmine nädal"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Seanss lõppes"
+
+#~ msgid "Session Started"
+#~ msgstr "Seanss algas"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Palun vali mõni muu parool."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Palun sisesta oma praegune parool uuesti."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Parooli pole võimalik muuta"
+
+#~ msgid "Disable image"
+#~ msgstr "Keela pilt"
+
+#~ msgid "Take a photo…"
+#~ msgstr "Pildista…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Sirvi teisi pilte…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "Seda kasutab %s"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Seda liiki domeeniga pole võimalik automaatselt ühenduda"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "Sellist domeeni või valdust (realm) ei leitud"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Pole võimalik sisse logida kasutajana %s domeenile %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Sobimatu parool, proovi uuesti"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Teised kontod"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Tõrge kasutaja kustutamisel"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Oma kontot pole võimalik kustutada."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s on ikka veel sisse logitud"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Kasutaja kustutamine tema sisselogimise ajal võib jätta süsteemi "
+#~ "ohtlikusse seisu."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "Kas tahad säilitada kasutaja %s failid?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Kodukataloogi, meilide ja ajutiste failide säilitamine on võimalik ka "
+#~ "kasutajakonto kustutamisel."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Kustuta failid"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Säilita failid"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Konto on keelatud"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Määratakse järgmisel sisselogimisel"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Puudub"
+
+#~ msgid "Logged in"
+#~ msgstr "Sisse logitud"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Tõrge kontoteenusega ühenduse võtmisel"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Palun veendu, et AccountService on paigaldatud ja lubatud."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Muutuste tegemiseks\n"
+#~ "klõpsa esiteks ikoonil *"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Kasutaja loomiseks\n"
+#~ "klõpsa esiteks * ikoonil"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Valitud kasutajakonto kustutamine"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Valitud kasutaja kustutamiseks\n"
+#~ "klõpsa esiteks * ikoonil"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Kasutajanimi '%s' on juba kasutusel."
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "Kasutajanimi on liiga pikk."
+
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "Kasutajanimi ei tohi alata märgiga '-'."
+
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "Kasutajanimi peaks koosnema ladina suur- ja väiketähtedest, numbritest "
+#~ "ning märkidest '.', '-' ja '_'."
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr ""
+#~ "Seda kasutatakse kodukausta nimena ning seda pole võimalik hiljem muuta."
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Üles"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Alla"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Puudub"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Klaviatuurivajutuse saatmine"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Monitori vahetamine"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Abi kuvamine ekraanil"
+
+#~ msgid "Output:"
+#~ msgstr "Väljund:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Külgede suhte säilitamine:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Määratud ühele monitorile"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d / %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Kuvade ühendamine"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Digitaallaud (absoluutne)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Digitaallaua eelistused"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetoothi seaded"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Nuppude ühendamine…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Kuvari eraldusvõime muutmine"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Hiireseadete muutmine"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Jälitamise režiim"
+
+#~ msgid "Left Ring"
+#~ msgstr "Vasak ratas"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Vasaku ratta režiim %d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Parema ratta režiim %d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Vasak puuteriba"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Vasak puuteriba režiim %d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Parem puuteriba"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Parem puuteriba režiim %d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Vasaku puuteringi režiimi lüliti"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Parema puuteringi režiimi lüliti"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Vasaku puuteriba režiimi lüliti"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Parema puuteriba režiimi lüliti"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Režiimilüliti %d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "Vasak nupp %d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "Parem nupp %d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "Ülemine nupp %d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Alumine nupp %d"
+
+#~ msgid "No Action"
+#~ msgstr "Tegevus puudub"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Vasaku hiirenupu klõps"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Üles kerimine"
+
+#~ msgid "Top Button"
+#~ msgstr "Ülemine nupp"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Jutuka režiimi lubamine"
+
+#~ msgid "Show the overview"
+#~ msgstr "Ülevaate näitamine"
+
+#~ msgid "Search for the string"
+#~ msgstr "Teksti otsimine"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Võimalike paneelinimed kuvamine ja väljumine"
+
+#~ msgid "Show help options"
+#~ msgstr "Abiteabe võtmete näitamine"
+
+#~ msgid "Panel to display"
+#~ msgstr "Kuvatav paneel"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEEL] [ARGUMENT…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- sätted"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Kõigi saadaolevate käsureavõtmete vaatamiseks käivita '%s --help'.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "Saadaolevad paneelid:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Isiklik"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Riistvara"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Süsteem"
 
 #~ msgid "Immediately"
 #~ msgstr "Koheselt"
-
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
-
-#~ msgid "Install Updates"
-#~ msgstr "Paigalda uuendused"
 
 #~ msgid "System Up-To-Date"
 #~ msgstr "Süsteem on värske"
@@ -5330,38 +8106,23 @@ msgstr "Eelistused;Sätted;Seaded;Seadistused;"
 #~ msgid "_Default"
 #~ msgstr "_Vaikimisi"
 
-#~ msgid "Remote View"
-#~ msgstr "Kaugvaade"
-
 #~ msgid "Approve All Connections"
 #~ msgstr "Kõigi ühenduste heakskiitmine"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "Uue seadme seadistamine"
 
-#~ msgid "Connection"
-#~ msgstr "Ühendus"
-
 #~ msgid "Paired"
 #~ msgstr "Paaris"
 
-#~ msgid "Type"
-#~ msgstr "Tüüp"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "Hiire ja puutepadja seaded"
-
-#~ msgid "Sound Settings"
-#~ msgstr "Heliseaded"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "Klahvistiku seaded"
 
 #~ msgid "Send Files…"
 #~ msgstr "Saada faile…"
-
-#~ msgid "Visibility"
-#~ msgstr "Nähtavus"
 
 #~ msgid "Visibility of “%s”"
 #~ msgstr "“%s” nähtavus"
@@ -5401,9 +8162,6 @@ msgstr "Eelistused;Sätted;Seaded;Seadistused;"
 
 #~ msgid "Don't use the display"
 #~ msgstr "Seda ekraani ei kasutata"
-
-#~ msgid "Refresh Rate"
-#~ msgstr "Värskendussagedus"
 
 #~ msgid "Mouse Preferences"
 #~ msgstr "Hiire-eelistused"
@@ -5521,12 +8279,6 @@ msgstr "Eelistused;Sätted;Seaded;Seadistused;"
 #~ msgid "_City:"
 #~ msgstr "_Linn:"
 
-#~ msgid "_Network Time"
-#~ msgstr "_Võrguaeg"
-
-#~ msgid ":"
-#~ msgstr ":"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "Keera kell üks tund ette."
 
@@ -5551,18 +8303,8 @@ msgstr "Eelistused;Sätted;Seaded;Seadistused;"
 #~ msgstr "Vastupäeva"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "Päripäeva"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 kraadi"
-
-#~ msgid "Monitor"
-#~ msgstr "Kuvar"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "Lohista peakuva muutmiseks."
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -5588,9 +8330,6 @@ msgstr "Eelistused;Sätted;Seaded;Seadistused;"
 
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "Märkus: võib piirata eraldusvõime valikuid"
-
-#~ msgid "_Detect Displays"
-#~ msgstr "_Tuvasta kuvad"
 
 #~ msgctxt "mouse, speed"
 #~ msgid "Slow"

--- a/po/et.po~
+++ b/po/et.po~
@@ -1,0 +1,5714 @@
+# GNOME juhtimiskeskuse eesti keele tõlge.
+# Estonian translation of GNOME Control Center.
+#
+# Copyright (C) 1999, 2002, 2003, 2005, 2006 Free Software Foundation, Inc.
+# Copyright (C) 2007–2011 The Gnome Project.
+# This file is distributed under the same license as the gnome-control-center
+# package.
+#
+# Lauris Kaplinski <lauris ariman ee>, 1999.
+# Tõivo Leedjärv <toivo linux ee>, 2002, 2003.
+# Ivar Smolin <okul linux ee>, 2005–2011.
+# Priit Laes <plaes+gi18n plaes org>, 2005, 2006, 2008.
+# Mattias Põldaru <mahfiaz@gmail.com>, 2009, 2010, 2011, 2012, 2013.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: GNOME Control Center MASTER\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-05-13 06:26+0000\n"
+"PO-Revision-Date: 2014-05-13 10:38+0300\n"
+"Last-Translator: Mattias Põldaru <mahfiaz@gmail.com>\n"
+"Language-Team: Estonian <gnome-et@linux.ee>\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Generator: Poedit 1.5.4\n"
+
+# paistab välimuse eelistuste all ühevärvilise tausta tooltip'ina
+msgid "Background"
+msgstr "Taust"
+
+#. This refers to a slideshow background
+msgid "Changes throughout the day"
+msgstr "Muutub pidevalt"
+
+#. To translators: This is a noun, not a verb
+msgid "Lock Screen"
+msgstr "Ekraani lukustamine"
+
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Korduv"
+
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Ekraan täidetud"
+
+msgctxt "background, style"
+msgid "Center"
+msgstr "Keskel"
+
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Kogu pilt nähtaval"
+
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Üle ekraani"
+
+msgctxt "background, style"
+msgid "Span"
+msgstr "Üle mitme ekraani"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+msgid "Select Background"
+msgstr "Tausta valimine"
+
+msgid "Wallpapers"
+msgstr "Taustapildid"
+
+msgid "Pictures"
+msgstr "Pildid"
+
+msgid "Colors"
+msgstr "Värvid"
+
+#. translators: No pictures were found
+msgid "No Pictures Found"
+msgstr "Ühtegi pilti ei leitud"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+msgid "Home"
+msgstr "Kodukataloog"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "Pildid, mille lisad kausta %s, ilmuvad siia"
+
+msgid "_Cancel"
+msgstr "_Loobu"
+
+msgid "Select"
+msgstr "Vali"
+
+msgid "multiple sizes"
+msgstr "mitmes suuruses"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+# paistab välimuse eelistuste all ühevärvilise tausta tooltip'ina
+msgid "No Desktop Background"
+msgstr "Ilma taustapildita töölaud"
+
+msgid "Current background"
+msgstr "Praegune taustapilt"
+
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Taustapildi muutmine, foto või tapeedi kasutamine"
+
+#. Translators: those are keywords for the background control-center panel
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Taustapilt;Tapeet;Ekraan;Töölaud;"
+
+msgid "Bluetooth is disabled"
+msgstr "Bluetooth on väljas"
+
+msgid "No Bluetooth adapters found"
+msgstr "Bluetooth seadmeid ei leitud"
+
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "Bluetooth on füüsilisest lülitist välja lülitatud"
+
+#. Translators: The found device is a printer connected via Bluetooth
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Bluetoothi sisse- ja väljalülitamine ning seadmete ühendamine"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "Aseta kalibreerimisseade ruudu kohale ja vajuta 'Alusta'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr "Liiguta kalibreerimisseade uude asukohta ja vajuta 'Jätka'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr "Liiguta kalibreerimisseade pinnaasendisse ja vajuta 'Jätka'"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+msgid "Shut the laptop lid"
+msgstr "Sulge sülearvuti kaas"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+msgid "An internal error occurred that could not be recovered."
+msgstr "Tekkis sisemine viga, millest pole võimalik taastuda."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+msgid "Tools required for calibration are not installed."
+msgstr "Kalibreerimise jaoks vajalikud tööriistad pole paigaldatud."
+
+#. TRANSLATORS: The profile failed for some reason
+msgid "The profile could not be generated."
+msgstr "Profiili pole võimalik genereerida."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+msgid "The target whitepoint was not obtainable."
+msgstr "Soovitud valgepunkt pole saavutatav."
+
+#. TRANSLATORS: the display calibration process is finished
+msgid "Complete!"
+msgstr "Valmis!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+msgid "Calibration failed!"
+msgstr "Seadistamine nurjus!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+msgid "You can remove the calibration device."
+msgstr "Sa võid kalibreerimisseadme nüüd eemaldada."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Palun ära häiri töötamise ajal kalibreerimisseadet"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+msgid "Laptop Screen"
+msgstr "Sülearvuti ekraan"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+msgid "Built-in Webcam"
+msgstr "Sisseehitatud veebikaamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#, c-format
+msgid "%s Monitor"
+msgstr "%s kuvar"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#, c-format
+msgid "%s Scanner"
+msgstr "%s skanner"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#, c-format
+msgid "%s Camera"
+msgstr "%s kaamera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#, c-format
+msgid "%s Printer"
+msgstr "%s printer"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#, c-format
+msgid "%s Webcam"
+msgstr "%s veebikaamera"
+
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Värvihalduse lubamine %s jaoks"
+
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s värviprofiilide näitamine"
+
+#. not calibrated
+msgid "Not calibrated"
+msgstr "Kalibreerimata"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+msgid "Default: "
+msgstr "Vaikimisi: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+msgid "Colorspace: "
+msgstr "Värviruum: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+msgid "Test profile: "
+msgstr "Katseprofiil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+msgid "Select ICC Profile File"
+msgstr "ICC profiili valimine"
+
+msgid "_Import"
+msgstr "_Impordi"
+
+#. TRANSLATORS: filter name on the file->open dialog
+msgid "Supported ICC profiles"
+msgstr "Teotatud ICC profiilid"
+
+#. TRANSLATORS: filter name on the file->open dialog
+msgid "All files"
+msgstr "Kõik failid"
+
+msgid "Screen"
+msgstr "Ekraan"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Faili üleslaadimine nurjus: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+msgid "The profile has been uploaded to:"
+msgstr "Profiil laaditi üles asukohta:"
+
+msgid "Write down this URL."
+msgstr "Kirjuta see URL üles."
+
+msgid "Restart this computer and boot your normal operating system."
+msgstr "Taaskäivita arvuti ja mine tavalisse operatsioonisüsteemi."
+
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "Sisesta brauserisse URL, et profiil allalaadida ja salvestada."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+msgid "Save Profile"
+msgstr "Profiili salvestamine"
+
+msgid "_Save"
+msgstr "_Salvesta"
+
+#. TRANSLATORS: this is when the button is sensitive
+msgid "Create a color profile for the selected device"
+msgstr "Valitud seadmele värviporfiili loomine"
+
+#. TRANSLATORS: this is when the button is insensitive
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Mõõteriista ei tuvastatud. Palun veendu, et see on sisse lülitatud ja "
+"õigesti ühendatud."
+
+#. TRANSLATORS: this is when the button is insensitive
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Mõõteriist ei toeta printeri profiilimist."
+
+#. TRANSLATORS: this is when the button is insensitive
+msgid "The device type is not currently supported."
+msgstr "Seda seadmetüüpi hetkel ei toetata."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+msgid "Standard Space"
+msgstr "Standardruum"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+msgid "Test Profile"
+msgstr "Katseprofiil:"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automaatne"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Halb kvaliteet"
+
+#. TRANSLATORS: the profile quality
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Keskmine kvaliteet"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Hea kvaliteet"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Vaikimisi RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Vaikimisi CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Vaikimisi halltoonid"
+
+msgid "Vendor supplied factory calibration data"
+msgstr "Tootja pakutavad kalibreerimise tehaseandmed"
+
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Täisekraani värviparandus pole selle profiiliga võimalik"
+
+msgid "This profile may no longer be accurate"
+msgstr "See profiil ei pruugi olla enam täpne"
+
+msgid "Display Calibration"
+msgstr "Kuva kalibreerimine"
+
+msgid "Cancel"
+msgstr "Loobu"
+
+#. This starts the calibration process
+msgid "Start"
+msgstr "Alusta"
+
+#. This resumes the calibration process
+msgid "Resume"
+msgstr "Jätka"
+
+#. This button returns the user back to the color control panel
+msgid "Done"
+msgstr "Valmis"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+msgid "Screen Calibration"
+msgstr "Ekraani kalibreerimine"
+
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibreerimise käigus luuakse profiil, mida võib kasutada ekraani "
+"värvihalduse jaoks. Mida kauem kestab kalibreerimine, seda parema "
+"kvaliteediga profiil saadakse."
+
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Kalibreerimise ajal arvutit kasutada ei saa."
+
+#. This is the approximate time it takes to calibrate the display.
+msgid "Quality"
+msgstr "Kvaliteet"
+
+#. This is the approximate time it takes to calibrate the display.
+msgid "Approximate Time"
+msgstr "Hinnanguline aeg"
+
+msgid "Calibration Quality"
+msgstr "Kalibreerimise kvaliteet"
+
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Vali sensorseade, mida kalibreerimiseks kasutada."
+
+msgid "Calibration Device"
+msgstr "Kalibreerimise seade"
+
+msgid "Select the type of display that is connected."
+msgstr "Vali ühendatud kuvari liik."
+
+msgid "Display Type"
+msgstr "Kuva liik"
+
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Vali kuva soovitud valgepunkt. Enamik kuvasid tuleks kalibreerida D65 "
+"valgustuse järgi."
+
+msgid "Profile Whitepoint"
+msgstr "Profiili valgepunkt"
+
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Palun vali oma kuvari tavaline heledus. Värvid on siis kõige täpsemad just "
+"sellel heledustasemel."
+
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Võib kasutada ka heledustaset, mida kasutavad selle seadme teised profiilid."
+
+msgid "Display Brightness"
+msgstr "Kuva heledus"
+
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Seda profiili võib kasutada ka teistel arvutitel või luua erinevad profiilid "
+"erineva valgustuse jaoks."
+
+msgid "Profile Name:"
+msgstr "Profiili nimi:"
+
+msgid "Profile Name"
+msgstr "Profiili nimi"
+
+msgid "Profile successfully created!"
+msgstr "Profiil on edukalt loodud!"
+
+msgid "Copy profile"
+msgstr "Kopeeri profiil"
+
+msgid "Requires writable media"
+msgstr "Vajalik on kirjutatav meedia"
+
+msgid "Upload profile"
+msgstr "Laadi profiil üles"
+
+msgid "Requires Internet connection"
+msgstr "Vajalik on internetiühendus"
+
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Kasulikuks võib osutuda juhend nende profiilide kasutamise kohta <a href="
+"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> või <a href=\"windows"
+"\">Microsoft Windows</a> süsteemidel."
+
+msgid "Summary"
+msgstr "Kokkuvõte"
+
+msgid "Import File…"
+msgstr "Faili importimine…"
+
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Tuvastati probleeme. Profiilid ei pruugi õigesti töötada. <a href=\"\">Näita "
+"üksikasju.</a>"
+
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "Iga värvihaldusega seadme jaoks on vaja värsket värviprofiili."
+
+msgid "Learn more"
+msgstr "Rohkem teavet"
+
+msgid "Learn more about color management"
+msgstr "Rohkem teavet värvihalduse kohta"
+
+msgid "Set for all users"
+msgstr "Määra kõigile kasutajaile"
+
+msgid "Set this profile for all users on this computer"
+msgstr "Määrata see profiil kõigile selle arvuti kasutajatele"
+
+msgid "Enable"
+msgstr "Lubatud"
+
+msgid "Add profile"
+msgstr "Lisa profiil"
+
+msgid "Calibrate…"
+msgstr "Kalibreerimine..."
+
+msgid "Calibrate the device"
+msgstr "Seadme kalibreerimine"
+
+msgid "Remove profile"
+msgstr "Eemalda profiil"
+
+msgid "View details"
+msgstr "Vaata üksikasju"
+
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Ei tuvastatud ühtegi seadet, millele oleks võimalik värvihaldust teha"
+
+msgid "LCD"
+msgstr "LCD"
+
+msgid "LED"
+msgstr "LED"
+
+msgid "CRT"
+msgstr "CRT"
+
+msgid "Projector"
+msgstr "Projektor"
+
+msgid "Plasma"
+msgstr "Plasma"
+
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL taustvalgus)"
+
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED taustvalgus)"
+
+msgid "LCD (white LED backlight)"
+msgstr "LCD (valge LED taustvalgus)"
+
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Laia vahemikuga LCD (CCFL taustvalgus)"
+
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Laia vahemikuga LCD (RGB LED taustvalgus)"
+
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Hea"
+
+msgid "40 minutes"
+msgstr "40 minutit"
+
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Keskmine"
+
+msgid "30 minutes"
+msgstr "30 minutit"
+
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Halb"
+
+msgid "15 minutes"
+msgstr "15 minutit"
+
+msgid "Native to display"
+msgstr "Kuvale loomulik"
+
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (trükkimine)"
+
+msgid "D55"
+msgstr "D55"
+
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotograafia ja graafika)"
+
+msgid "D75"
+msgstr "D75"
+
+msgid "Color"
+msgstr "Värvid"
+
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Seadmete värvide kalibreerimine kuvaritel, kaameratel ja printeritel"
+
+#. Translators: those are keywords for the color control-center panel
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Värv;ICC;Profiil;Kalibreerimine;Printer;Kuva;Ekraan;Monitor;"
+
+#. Add some common regions
+msgid "United States"
+msgstr "Ameerika Ühendriigid"
+
+msgid "Germany"
+msgstr "Saksamaa"
+
+msgid "France"
+msgstr "Prantsusmaa"
+
+msgid "Spain"
+msgstr "Hispaania"
+
+msgid "China"
+msgstr "Hiina"
+
+msgid "Other…"
+msgstr "Muu profiil…"
+
+msgid "More…"
+msgstr "Veel…"
+
+msgid "No languages found"
+msgstr "Keeli ei leitud"
+
+msgid "Language"
+msgstr "Keel"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e. %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+msgid "%e %B %Y, %R"
+msgstr "%e. %B %Y, %R"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+msgid "%R"
+msgstr "%R"
+
+msgid "January"
+msgstr "Jaanuar"
+
+msgid "February"
+msgstr "Veebruar"
+
+msgid "March"
+msgstr "Märts"
+
+msgid "April"
+msgstr "Aprill"
+
+msgid "May"
+msgstr "Mai"
+
+msgid "June"
+msgstr "Juuni"
+
+msgid "July"
+msgstr "Juuli"
+
+msgid "August"
+msgstr "August"
+
+msgid "September"
+msgstr "September"
+
+msgid "October"
+msgstr "Oktoober"
+
+msgid "November"
+msgstr "November"
+
+msgid "December"
+msgstr "Detsember"
+
+msgid "Date & Time"
+msgstr "Kuupäev ja kellaaeg"
+
+msgid "Hour"
+msgstr "Tund"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+msgid "∶"
+msgstr "∶"
+
+msgid "Minute"
+msgstr "Minut"
+
+msgid "Day"
+msgstr "Päev"
+
+msgid "Month"
+msgstr "Kuu"
+
+msgid "Year"
+msgstr "Aasta"
+
+msgid "Time Zone"
+msgstr "Ajavöönd"
+
+msgid "Search for a city"
+msgstr "Linna otsing"
+
+msgid "Automatic _Date & Time"
+msgstr "Automaatne _kuupäev ja kellaaeg"
+
+msgid "Requires internet access"
+msgstr "Vajalik on internetiühendus"
+
+msgid "Automatic Time _Zone"
+msgstr "_Automaatne ajavöönd"
+
+msgid "Date & _Time"
+msgstr "Kuupäev ja _kellaaeg"
+
+msgid "Time _Zone"
+msgstr "_Ajavöönd"
+
+msgid "Time _Format"
+msgstr "Aja _vorming"
+
+msgid "24-hour"
+msgstr "24 tundi"
+
+msgid "AM / PM"
+msgstr "EL / PL"
+
+msgid "Change the date and time, including time zone"
+msgstr "Kuupäeva, kella ja ajavööndi muutmine"
+
+#. Translators: those are keywords for the date and time control-center panel
+msgid "Clock;Timezone;Location;"
+msgstr "Kell;Ajavöönd;Asukoht;"
+
+msgid "Change system time and date settings"
+msgstr "Süsteemi kella ja kuupäeva muutmine"
+
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Kella või kuupäeva muutmiseks pead end autentima."
+
+msgid "Lid Closed"
+msgstr "Ekraan suletud"
+
+#. translators: "Mirrored" describes when both displays show the same view
+msgid "Mirrored"
+msgstr "Peegeldatud"
+
+msgid "Primary"
+msgstr "Peamine"
+
+msgid "Off"
+msgstr "Väljas"
+
+msgid "Secondary"
+msgstr "Teisene"
+
+msgid "Arrange Combined Displays"
+msgstr "Kombineeritud ekraanide paigutus"
+
+msgid "_Apply"
+msgstr "_Rakenda"
+
+msgid "Drag displays to rearrange them"
+msgstr "Ekraanide ümberpaigutamiseks lohista."
+
+msgid "Size"
+msgstr "Suurus"
+
+#. aspect ratio
+msgid "Aspect Ratio"
+msgstr "Külgede suhe"
+
+msgid "Resolution"
+msgstr "Eraldusvõime"
+
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "Ülemist riba ja tegevuste ülevaadet kuvatakse sellel ekraanil"
+
+msgid "Secondary Display"
+msgstr "Teisene ekraan"
+
+msgid "Join this display with another to create an extra workspace"
+msgstr "Ühenda see kuva mõne teisega, et luua lisatööala"
+
+msgid "Presentation"
+msgstr "Esitlus"
+
+msgid "Show slideshows and media only"
+msgstr "Näidatakse ainult slaidiesitlusi ja meediat"
+
+#. translators: "Mirror" describes when both displays show the same view
+msgid "Mirror"
+msgstr "Peegeldatud"
+
+msgid "Show your existing view on both displays"
+msgstr "Näidatakse sama pilti mõlemal ekraanil"
+
+msgid "Turn Off"
+msgstr "Lülita välja"
+
+msgid "Don't use this display"
+msgstr "Seda ekraani ei kasutata"
+
+msgid "Could not get screen information"
+msgstr "Ekraani andmeid pole võimalik hankida"
+
+msgid "_Arrange Combined Displays"
+msgstr "_Paiguta kombineeritud ekraanid"
+
+msgid "Displays"
+msgstr "Kuvad"
+
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Kuvarite ja projektorite kasutuse muutmine"
+
+#. Translators: those are keywords for the display control-center panel
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr ""
+"Paneel;Projektor;xrandr;Ekraan;Resolutsioon;Eraldusvõime;Lahutusvõime;"
+"Värskendamissagedus;"
+
+msgid "Wayland"
+msgstr "Wayland"
+
+#. TRANSLATORS: AP type
+msgid "Unknown"
+msgstr "Tundmatu"
+
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s, %d-bitine"
+
+#, c-format
+msgid "%d-bit"
+msgstr "%d-bitine"
+
+msgid "Ask what to do"
+msgstr "Küsitakse, mida teha"
+
+msgid "Do nothing"
+msgstr "Ära tee midagi"
+
+msgid "Open folder"
+msgstr "Ava kataloog"
+
+msgid "Other Media"
+msgstr "Muu meedia"
+
+msgid "Select an application for audio CDs"
+msgstr "Audio-CD jaoks kasutatava rakenduse valimine"
+
+msgid "Select an application for video DVDs"
+msgstr "Video-DVD jaoks kasutatava rakenduse valimine"
+
+msgid "Select an application to run when a music player is connected"
+msgstr "Vali rakendus, mis tuleb käivitada muusikamängija ühendamisel"
+
+msgid "Select an application to run when a camera is connected"
+msgstr "Vali rakendus, mis tuleb käivitada kaamera ühendamisel"
+
+msgid "Select an application for software CDs"
+msgstr "Tarkvara CD-de jaoks rakenduse valimine"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+msgid "audio DVD"
+msgstr "audio-DVD"
+
+msgid "blank Blu-ray disc"
+msgstr "tühi Blu-ray plaat"
+
+msgid "blank CD disc"
+msgstr "tühi CD-plaat"
+
+msgid "blank DVD disc"
+msgstr "tühi DVD-plaat"
+
+msgid "blank HD DVD disc"
+msgstr "tühi HD DVD plaat"
+
+msgid "Blu-ray video disc"
+msgstr "Blu-ray videoplaat"
+
+msgid "e-book reader"
+msgstr "e-raamatu lugeja"
+
+msgid "HD DVD video disc"
+msgstr "HD DVD videoplaat"
+
+msgid "Picture CD"
+msgstr "Pildi-CD"
+
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+msgid "Video CD"
+msgstr "Video-CD"
+
+msgid "Windows software"
+msgstr "Windowsi tarkvara"
+
+msgid "Section"
+msgstr "Sektsioon"
+
+msgid "Overview"
+msgstr "Ülevaade"
+
+msgid "Default Applications"
+msgstr "Vaikimisi rakendused"
+
+msgid "Removable Media"
+msgstr "Eemaldatav meedium"
+
+#, c-format
+msgid "Version %s"
+msgstr "Versioon %s"
+
+msgid "Details"
+msgstr "Üksikasjad"
+
+msgid "View information about your system"
+msgstr "Süsteemi andmete kuvamine"
+
+#. sure that you use the same "translation" for those keywords
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"seade;seadmed;süsteem;andmed;info;mälu;protsessor;versioon;vaikimisi;"
+"rakendus;eelistatud;eelis;cd;dvd;usb;audio;heli;video;plaat;eemaldatav;"
+"meedia;isekäivituv;automaatkäivitus;"
+
+msgid "Select how other media should be handled"
+msgstr "Ülejäänud meediumile käsitlemismeetodi valimine"
+
+msgid "_Action:"
+msgstr "_Tegevus:"
+
+msgid "_Type:"
+msgstr "_Liik:"
+
+msgid "Device name"
+msgstr "Seadme nimi"
+
+msgid "Memory"
+msgstr "Mälu"
+
+msgid "Processor"
+msgstr "Protsessor"
+
+#. To translators: this field contains the distro name, version and type
+msgid "Base system"
+msgstr "Baassüsteem"
+
+msgid "Disk"
+msgstr "Ketas"
+
+msgid "Calculating…"
+msgstr "Arvutamine…"
+
+msgid "Graphics"
+msgstr "Graafika"
+
+msgid "Virtualization"
+msgstr "Virtualiseerimine"
+
+msgid "Check for updates"
+msgstr "Uuenduste küsimine"
+
+msgid "_Web"
+msgstr "_Veeb"
+
+msgid "_Mail"
+msgstr "_Meil"
+
+msgid "_Calendar"
+msgstr "_Kalender"
+
+msgid "M_usic"
+msgstr "M_uusika"
+
+msgid "_Video"
+msgstr "_Video"
+
+msgid "_Photos"
+msgstr "_Fotod:"
+
+msgid "Select how media should be handled"
+msgstr "Meediumile käsitlemismeetodi valimine"
+
+msgid "CD _audio"
+msgstr "CD-_audio"
+
+msgid "_DVD video"
+msgstr "_DVD-video"
+
+msgid "_Music player"
+msgstr "_Muusikaesitaja"
+
+msgid "_Software"
+msgstr "_Tarkvara"
+
+msgid "_Other Media…"
+msgstr "_Muu meedia…"
+
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Meedia sisestamisel ei küsita kunagi rakenduste käivitamise kohta"
+
+msgid "Sound and Media"
+msgstr "Heli ja meedia"
+
+msgid "Volume mute"
+msgstr "Heli tummaks"
+
+msgid "Volume down"
+msgstr "Heli vaiksemaks"
+
+msgid "Volume up"
+msgstr "Heli valjemaks"
+
+msgid "Launch media player"
+msgstr "Meediaesitaja käivitamine"
+
+msgid "Play (or play/pause)"
+msgstr "Esitamine (või esita/pausi)"
+
+msgid "Pause playback"
+msgstr "Taasesituse pausimine"
+
+msgid "Stop playback"
+msgstr "Taasesituse peatamine"
+
+msgid "Previous track"
+msgstr "Eelmine lugu"
+
+msgid "Next track"
+msgstr "Järgmine lugu"
+
+msgid "Eject"
+msgstr "Väljasta"
+
+msgid "Typing"
+msgstr "Tippimine"
+
+msgid "Switch to next input source"
+msgstr "Järgmisele sisendile vahetamine"
+
+msgid "Switch to previous input source"
+msgstr "Eelmisele sisendile vahetamine"
+
+msgid "Launchers"
+msgstr "Käivitajad"
+
+msgid "Launch help browser"
+msgstr "Abi sirvija käivitamine"
+
+msgid "Launch calculator"
+msgstr "Kalkulaatori käivitamine"
+
+msgid "Launch email client"
+msgstr "E-posti kliendi käivitamine"
+
+msgid "Launch web browser"
+msgstr "Veebibrauseri käivitamine"
+
+msgid "Home folder"
+msgstr "Kodukataloog"
+
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Otsing"
+
+msgid "Screenshots"
+msgstr "Ekraanipildid"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+msgid "Save a screenshot to $PICTURES"
+msgstr "Ekraanipildi salvestamine $PICTURES kausta"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Aknast tehtud ekraanipildi salvestamine $PICTURES kausta"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Alast tehtud ekraanipildi salvestamine $PICTURES kausta"
+
+msgid "Copy a screenshot to clipboard"
+msgstr "Ekraanipildi kopeerimine lõikepuhvrisse"
+
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Akna ekraanipildi kopeerimine lõikepuhvrisse"
+
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Ala ekraanipildi kopeerimine lõikepuhvrisse"
+
+msgid "Record a short screencast"
+msgstr "Lühikese ekraanisalvestuse lindistamine"
+
+msgid "System"
+msgstr "Süsteem"
+
+msgid "Log out"
+msgstr "Logi välja"
+
+msgid "Lock screen"
+msgstr "Ekraani lukustamine"
+
+msgid "Universal Access"
+msgstr "Pärssimata juurdepääs"
+
+msgid "Turn zoom on or off"
+msgstr "Luubi sisse või välja lülitamine"
+
+msgid "Zoom in"
+msgstr "Suurendamine"
+
+msgid "Zoom out"
+msgstr "Vähendamine"
+
+msgid "Turn screen reader on or off"
+msgstr "Ekraanilugeja sisse või välja lülitamine"
+
+msgid "Turn on-screen keyboard on or off"
+msgstr "Ekraaniklaviatuuri sisse või välja lülitamine"
+
+msgid "Increase text size"
+msgstr "Teksti suuruse suurendamine"
+
+msgid "Decrease text size"
+msgstr "Teksti suuruse vähendamine"
+
+msgid "High contrast on or off"
+msgstr "Kõrge kontrast sisse või välja"
+
+#. translators:
+#. * The device has been disabled
+msgid "Disabled"
+msgstr "Välja lülitatud"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+msgid "Alternative Characters Key"
+msgstr "Alternatiivne märgiklahv"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+msgid "Compose Key"
+msgstr "Koosteklahv (compse)"
+
+msgid "Modifiers-only switch to next source"
+msgstr "Ainult modifikaatoritega järgmisele allikale lülitumine"
+
+msgid "Keyboard"
+msgstr "Klaviatuur"
+
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"Kiirklahvide vaatamine ja muutmine ning sisestamise eelistuste muutmine"
+
+#. Translators: those are keywords for the keyboard control-center panel
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Kiirklahv;Kordus;Vilkumine;"
+
+msgid "Custom Shortcut"
+msgstr "Kohandatud kiirklahv"
+
+msgid "_Add"
+msgstr "_Lisa"
+
+msgid "_Name:"
+msgstr "_Nimi:"
+
+msgid "C_ommand:"
+msgstr "Kä_sk:"
+
+msgid "Repeat Keys"
+msgstr "Klahvide kordamine"
+
+msgid "Key presses _repeat when key is held down"
+msgstr "Klahvivajutus k_ordub, kui klahvi hoitakse all"
+
+msgid "_Delay:"
+msgstr "_Viivitus:"
+
+msgid "_Speed:"
+msgstr "Kii_rus:"
+
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "Lühike"
+
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "Aeglane"
+
+msgid "Repeat keys speed"
+msgstr "Klahvide kordamise kiirus"
+
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "Pikk"
+
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "Kiire"
+
+msgid "Cursor Blinking"
+msgstr "Kursori vilkumine"
+
+msgid "Cursor _blinks in text fields"
+msgstr "Kursor _vilgub tekstiväljadel"
+
+msgid "S_peed:"
+msgstr "_Kiirus:"
+
+msgid "Cursor blink speed"
+msgstr "Kursori vilkumiskiirus"
+
+msgid "Input Sources"
+msgstr "Sisendseadmed"
+
+msgid "Add Shortcut"
+msgstr "Välksõrmise lisamine"
+
+msgid "Remove Shortcut"
+msgstr "Eemalda välksõrmis"
+
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"Välksõrmise muutmiseks klõpsa vastaval real ja määra uus sõrmis. Nullimiseks "
+"vajuta Backspace klahvi."
+
+msgid "Shortcuts"
+msgstr "Välksõrmised"
+
+msgid "Custom Shortcuts"
+msgstr "Kohandatud kiirklahvid"
+
+msgid "<Unknown Action>"
+msgstr "<tundmatu tegevus>"
+
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"Kiirklahvi \"%s\" pole võimalik kasutada, kuna see teeb selle klahvi "
+"kasutamise tavaolukorras võimatuks.\n"
+"Palun proovi klahvi kombineerida klahvidega Control, Alt või Shift."
+
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"Kiirklahvi \"%s\" juba kasutatakse järgneva tegevuse jaoks:\n"
+"\"%s\""
+
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"Kui sa määrad selle kiirklahvi tegevusele \"%s\", siis tegevuse \"%s\" "
+"kiirklahv keelatakse."
+
+msgid "_Reassign"
+msgstr "_Määra"
+
+msgid "Test Your _Settings"
+msgstr "_Proovi oma sätteid"
+
+msgid "Test Your Settings"
+msgstr "Proovi oma sätteid"
+
+msgid "Mouse & Touchpad"
+msgstr "Hiir ja puutepadi"
+
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "Hiire või puutepadja tundlikkuse ja käelisuse muutmine"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Puutepadi;Kursor;Klõps;Topelt;Nupp;Kerimine;"
+
+msgid "General"
+msgstr "Üldine"
+
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "Aeglane"
+
+msgid "Double-click timeout"
+msgstr "Topeltklõpsu ajapiirang"
+
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "Kiire"
+
+msgid "_Double-click"
+msgstr "_Topeltklõps"
+
+msgid "Primary _button"
+msgstr "Peamine _nupp"
+
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "_Vasak"
+
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "_Parem"
+
+msgid "Mouse"
+msgstr "Hiir"
+
+msgid "_Pointer speed"
+msgstr "_Kursori kiirus"
+
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "Aeglane"
+
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "Kiire"
+
+msgid "Touchpad"
+msgstr "Puutepadi"
+
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "Aeglane"
+
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "Kiire"
+
+msgid "Disable while _typing"
+msgstr "_Tippimise ajal on puutepadi keelatud"
+
+msgid "Tap to _click"
+msgstr "_Klõpsamiseks koputa"
+
+msgid "Two _finger scroll"
+msgstr "_Kahe sõrmega kerimine"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+msgid "_Natural scrolling"
+msgstr "_Loomulik kerimine"
+
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Proovi klõpsamist, topeltklõpsu ja kerimist"
+
+msgid "Five clicks, GEGL time!"
+msgstr "Viis klõpsu GEGL-i kord!"
+
+msgid "Double click, primary button"
+msgstr "Topeltklõps, peamine nupp"
+
+msgid "Single click, primary button"
+msgstr "Üks klõps, peamine nupp"
+
+msgid "Double click, middle button"
+msgstr "Topeltklõps, keskmine nupp"
+
+msgid "Single click, middle button"
+msgstr "Üks klõps, keskmine nupp"
+
+msgid "Double click, secondary button"
+msgstr "Topeltklõps, teine nupp"
+
+msgid "Single click, secondary button"
+msgstr "Üks klõps, teine nupp"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+msgid "Air_plane Mode"
+msgstr "_Lennukirežiim"
+
+msgid "Network proxy"
+msgstr "Võrgu proksi"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+msgid "The system network services are not compatible with this version."
+msgstr "Süsteemi võrguteenused ei sobi selle versiooniga."
+
+msgid "802.1x _Security"
+msgstr "802.1x _turvalisus"
+
+msgid "page 1"
+msgstr "leht 1"
+
+msgid "Anony_mous identity"
+msgstr "_Anonüümne identiteet"
+
+msgid "Inner _authentication"
+msgstr "Sisemine _autentimine"
+
+msgid "page 2"
+msgstr "leht 2"
+
+msgid "Security"
+msgstr "Turvalisus"
+
+msgid "automatic"
+msgstr "automaatne"
+
+#. TRANSLATORS: this WEP WiFi security
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+msgid "Enterprise"
+msgstr "Ettevõtte"
+
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Puudub"
+
+msgid "Never"
+msgstr "Mitte kunagi"
+
+msgid "Today"
+msgstr "Täna"
+
+msgid "Yesterday"
+msgstr "Eile"
+
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i päev tagasi"
+msgstr[1] "%i päeva tagasi"
+
+#. Translators: network device speed
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Puudub"
+
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Nõrk"
+
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Piisav"
+
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Tugev"
+
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Suurepärane"
+
+msgid "Identity"
+msgstr "Identiteet"
+
+msgid "Address"
+msgstr "Aadress"
+
+msgid "Netmask"
+msgstr "Võrgumask"
+
+msgid "Gateway"
+msgstr "Lüüs"
+
+msgid "Delete Address"
+msgstr "Kustuta aadress"
+
+msgid "Add"
+msgstr "Lisa"
+
+msgid "Server"
+msgstr "Server"
+
+msgid "Delete DNS Server"
+msgstr "Kustuta DNS server"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "Meetrika"
+
+msgid "Delete Route"
+msgstr "Kustuta marsruut"
+
+msgid "Automatic (DHCP)"
+msgstr "Automaatne (DHCP)"
+
+msgid "Manual"
+msgstr "Käsitsi"
+
+msgid "Link-Local Only"
+msgstr "Ainult kohalik võrk (link-local)"
+
+msgid "IPv4"
+msgstr "IPv4"
+
+msgid "Prefix"
+msgstr "Prefiks"
+
+msgid "Automatic"
+msgstr "Automaatne"
+
+msgid "Automatic, DHCP only"
+msgstr "Automaatne, ainult DHCP"
+
+msgid "IPv6"
+msgstr "IPv6"
+
+msgid "Reset"
+msgstr "Lähtesta"
+
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Puudub"
+
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-biti võti (Hex või ASCII)"
+
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-biti parool"
+
+msgid "LEAP"
+msgstr "LEAP"
+
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dünaamiline WEP (802.1x)"
+
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 isiklik"
+
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 ettevõtte"
+
+msgid "Signal Strength"
+msgstr "Signaali tugevus"
+
+msgid "Link speed"
+msgstr "Ühenduse kiirus"
+
+msgid "IPv4 Address"
+msgstr "IPv4-aadress"
+
+msgid "IPv6 Address"
+msgstr "IPv6-aadress"
+
+msgid "Hardware Address"
+msgstr "Riistvaraline aadress"
+
+msgid "Default Route"
+msgstr "Vaikimisi marsruut"
+
+msgid "DNS"
+msgstr "DNS"
+
+msgid "Last Used"
+msgstr "Viimati kasutatud"
+
+msgid "Twisted Pair (TP)"
+msgstr "Pööratud paar (TP)"
+
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Attachment Unit Interface (AUI)"
+
+msgid "BNC"
+msgstr "BNC"
+
+msgid "Media Independent Interface (MII)"
+msgstr "Meediumist sõltumatu liides (MII)"
+
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+msgid "_Name"
+msgstr "_Nimi"
+
+msgid "_MAC Address"
+msgstr "_MAC-aadress"
+
+msgid "M_TU"
+msgstr "M_TU"
+
+msgid "_Cloned Address"
+msgstr "_Kloonitud aadress"
+
+msgid "bytes"
+msgstr "baiti"
+
+msgid "Make available to other _users"
+msgstr "Saadaval teistele _kasutajatele"
+
+msgid "Connect _automatically"
+msgstr "_Automaane ühendumine"
+
+msgid "Firewall _Zone"
+msgstr "Tulemüüri _tsoon"
+
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "Vaikimisi"
+
+msgid "The zone defines the trust level of the connection"
+msgstr "Tsoon määrab ühenduse usaldusväärsuse"
+
+msgid "IPv_4"
+msgstr "IPv_4"
+
+msgid "_Addresses"
+msgstr "_Aadressid"
+
+msgid "Automatic DNS"
+msgstr "Automaatne DNS"
+
+msgid "Routes"
+msgstr "Marsruudid"
+
+msgid "Automatic Routes"
+msgstr "Automaatsed marsruudid"
+
+msgid "Use this connection _only for resources on its network"
+msgstr "Seda ühendust kasutatakse _ainult võrgu ressursside jaoks"
+
+msgid "IPv_6"
+msgstr "IPv_6"
+
+msgid "Unable to open connection editor"
+msgstr "Ühenduse redaktori avamine polnud võimalik"
+
+msgid "New Profile"
+msgstr "Uus profiil"
+
+msgid "VPN"
+msgstr "VPN"
+
+msgid "Bond"
+msgstr "Side"
+
+msgid "Team"
+msgstr "Meeskond"
+
+msgid "Bridge"
+msgstr "Sild"
+
+msgid "VLAN"
+msgstr "VLAN"
+
+msgid "Could not load VPN plugins"
+msgstr "VPN pluginaid polnud võimalik laadida"
+
+msgid "Import from file…"
+msgstr "Failist importimine…"
+
+msgid "Add Network Connection"
+msgstr "Uue ühenduse lisamine"
+
+msgid "_Reset"
+msgstr "_Lähtesta"
+
+msgid "_Forget"
+msgstr "_Unusta"
+
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"Lähtestakse selle võrgu sätted, sealhulgas paroolid, aga see jäetakse "
+"eelistatud võrguks"
+
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"Eemaldatakse kõik selle võrgu üksiksasjad ning sellesse võrku ei püüta "
+"hiljem ühenduda"
+
+msgid "S_ecurity"
+msgstr "_Turvalisus"
+
+msgid "Cannot import VPN connection"
+msgstr "VPN ühendust pole võimalik importida"
+
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Faili '%s' pole võimalik lugeda või see ei sisalda äratuntavaid andmeid VPN "
+"ühenduse kohta\n"
+"\n"
+"Viga: %s."
+
+msgid "Select file to import"
+msgstr "Importimiseks faili valimine"
+
+msgid "_Open"
+msgstr "_Ava"
+
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "Fail nimega '%s' on juba olemas."
+
+msgid "_Replace"
+msgstr "_Asenda"
+
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Kas tahad asendada %s praegu salvestatava VPN ühendusega?"
+
+msgid "Cannot export VPN connection"
+msgstr "VPN ühendust pole võimalik eksportida"
+
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN ühendust '%s' pole võimalik eksportida faili %s.\n"
+"\n"
+"Viga: %s."
+
+msgid "Export VPN connection..."
+msgstr "VPN ühenduse eksportimine..."
+
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(viga: VPN ühenduse redaktorit ei leitud)"
+
+msgid "_SSID"
+msgstr "_SSID"
+
+msgid "_BSSID"
+msgstr "_BSSID"
+
+msgid "My Home Network"
+msgstr "Minu koduvõrk"
+
+msgid "Make available to _other users"
+msgstr "Saadaval _kõigile kasutajatele"
+
+msgid "Network"
+msgstr "Võrk"
+
+msgid "Control how you connect to the Internet"
+msgstr "Internetiga ühendumise viisi muutmine"
+
+#. Translators: those are keywords for the network control-center panel
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;"
+msgstr ""
+"võrk;kohtvõrk;ühendus;juhtmeta;juhtmevaba;traadita;Wi-Fi;WiFi;IP;LAN;proksi;"
+"WAN;mobiiliühendus;modem;Bluetooth;VPN;VLAN;sild;sillatud;ühendatud;"
+
+msgid "Bond slaves"
+msgstr "Sideme alamad"
+
+msgid "(none)"
+msgstr "(pole)"
+
+msgid "Bridge slaves"
+msgstr "Silla alamad"
+
+msgid "never"
+msgstr "mitte kunagi"
+
+msgid "today"
+msgstr "täna"
+
+msgid "yesterday"
+msgstr "eile"
+
+msgid "IP Address"
+msgstr "IP-aadress"
+
+msgid "Last used"
+msgstr "Viimati kasutatud"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+msgid "Wired"
+msgstr "Juhtmega"
+
+msgid "Options…"
+msgstr "Valikud…"
+
+#, c-format
+msgid "Profile %d"
+msgstr "Profiil %d"
+
+msgid "Add new connection"
+msgstr "Uue ühenduse lisamine"
+
+msgid "Team slaves"
+msgstr "Meeskonna alamad"
+
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"Kui su internetiühendus ei tule juhtmeta võrgu kaudu, võid kasutada juhtmeta "
+"võrku teistele internetiühenduse jagamiseks."
+
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+"Juhtmeta võrgu kaudu jagamise (hotspot) sisselülitamine katkestab ühenduse "
+"võrguga <b>%s</b>."
+
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"Pole võimalik ühenduda internetti juhtmeta võrgu kaudu, kuni hotspot on "
+"aktiivne."
+
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Kas seisata tugijaam ja ühendada kasutajad lahti?"
+
+msgid "_Stop Hotspot"
+msgstr "_Seiska tugijaam"
+
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Süsteemireegel keelab Hotspotina kasutamine"
+
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Juhtmevaba seade ei toeta Hotspot režiimi"
+
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Valitud võrkude andmed, sealhulgas parool ja eriseadistused, lähevad kaotsi."
+
+msgid "History"
+msgstr "Ajalugu"
+
+msgid "_Close"
+msgstr "_Sulge"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Unusta"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Veebiproksi isetuvastust kasutatakse siis, kui seadistamise URL pole "
+"määratud."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+msgid "This is not recommended for untrusted public networks."
+msgstr "See ei ole mitteusaldatavates avalikes võrkudes soovitatav."
+
+msgid "Proxy"
+msgstr "Proksi"
+
+msgid "_Add Profile…"
+msgstr "_Lisa profiil…"
+
+msgid "IMEI"
+msgstr "IMEI"
+
+msgid "Provider"
+msgstr "Teenusepakkuja"
+
+msgctxt "proxy method"
+msgid "None"
+msgstr "Puudub"
+
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "Käsitsi"
+
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "Automaatne"
+
+msgid "_Method"
+msgstr "_Meetod"
+
+msgid "_Configuration URL"
+msgstr "_Seadistuste URL"
+
+msgid "_HTTP Proxy"
+msgstr "_HTTP proksi"
+
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS proksi"
+
+msgid "_FTP Proxy"
+msgstr "_FTP proksi"
+
+msgid "_Socks Host"
+msgstr "_Socks host"
+
+msgid "_Ignore Hosts"
+msgstr "_Hostide ignoreerimine"
+
+msgid "HTTP proxy port"
+msgstr "HTTP proksi port"
+
+msgid "HTTPS proxy port"
+msgstr "HTTPS proksi port"
+
+msgid "FTP proxy port"
+msgstr "FTP proksi port"
+
+msgid "Socks proxy port"
+msgstr "Socks proksi port"
+
+msgid "Turn device off"
+msgstr "Lülita seade välja"
+
+msgid "Add Device"
+msgstr "Lisa seade"
+
+msgid "Remove Device"
+msgstr "Seadme eemaldamine"
+
+msgid "VPN Type"
+msgstr "VPNi tüüp"
+
+msgid "Group Name"
+msgstr "Grupi nimi"
+
+msgid "Group Password"
+msgstr "Grupi parool"
+
+msgid "Username"
+msgstr "Kasutajanimi"
+
+msgid "Turn VPN connection off"
+msgstr "Lülita VPN ühendus välja"
+
+msgid "Automatic _Connect"
+msgstr "_Automaatne ühendumine"
+
+msgid "details"
+msgstr "üksikasjad"
+
+msgid "_Password"
+msgstr "_Parool"
+
+msgid "None"
+msgstr "Pole"
+
+msgid "Show P_assword"
+msgstr "_Parooli näitamine"
+
+msgid "Make available to other users"
+msgstr "Saadaval teistele kasutajatele"
+
+msgid "identity"
+msgstr "identiteet"
+
+msgid "Automatic (DHCP) addresses only"
+msgstr "Automaatselt ainult (DHCP) aadressid"
+
+msgid "Link-local only"
+msgstr "Ainult kohalik võrk (link-local)"
+
+msgid "Shared with other computers"
+msgstr "Jagatud teiste arvutitega"
+
+msgid "_Ignore automatically obtained routes"
+msgstr "_Automaatselt hangitud marsruutide eiramine"
+
+msgid "ipv4"
+msgstr "ipv4"
+
+msgid "ipv6"
+msgstr "ipv6"
+
+msgid "_Cloned MAC Address"
+msgstr "_Kloonitud MAC aadress"
+
+msgid "hardware"
+msgstr "riistvara"
+
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"Lähtestakse selle võrgu sätted, sealhulgas paroolid, aga see jäetakse "
+"eelistatud võrguks."
+
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"Eemaldatakse kõik selle võrgu üksiksasjad ning sellesse võrku ei püüta "
+"hiljem ühenduda."
+
+msgid "reset"
+msgstr "lähtesta"
+
+msgid "Hardware"
+msgstr "Riistvara"
+
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi tugijaam (hotspot)"
+
+msgid "_Turn On"
+msgstr "_Lülita sisse"
+
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+msgid "Turn Wi-Fi off"
+msgstr "Lülita Wi-Fi välja"
+
+msgid "_Use as Hotspot…"
+msgstr "_Kasuta hotspotina..."
+
+msgid "_Connect to Hidden Network…"
+msgstr "_Ühendu varjatud võrguga..."
+
+msgid "_History"
+msgstr "_Ajalugu"
+
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Wi-Fi võrguga ühendumiseks lülita välja"
+
+msgid "Network Name"
+msgstr "_Võrgu nimi"
+
+msgid "Connected Devices"
+msgstr "Ühendatud seadmed"
+
+msgid "Security type"
+msgstr "Turvaliik"
+
+msgid "Security key"
+msgstr "Turvaklahv"
+
+#. TRANSLATORS: AP type
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+msgid "Infrastructure"
+msgstr "Infrastruktuur"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+msgid "Status unknown"
+msgstr "Olek teadmata"
+
+#. TRANSLATORS: device status
+msgid "Unmanaged"
+msgstr "Haldamata"
+
+#. TRANSLATORS: device status
+msgid "Unavailable"
+msgstr "Pole saadaval"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+msgid "Connecting"
+msgstr "Ühendumine"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+msgid "Authentication required"
+msgstr "Autentimine on vajalik"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+msgid "Connected"
+msgstr "Ühendatud"
+
+#. TRANSLATORS: device status
+msgid "Disconnecting"
+msgstr "Ühenduse katkestamine"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+msgid "Connection failed"
+msgstr "Ühendumine nurjus"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+msgid "Status unknown (missing)"
+msgstr "Olek teadmata (puudub)"
+
+#. TRANSLATORS: VPN status
+msgid "Not connected"
+msgstr "Pole ühendatud"
+
+#. TRANSLATORS: device status reason
+msgid "Configuration failed"
+msgstr "Seadistamine nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "IP configuration failed"
+msgstr "IP seadistamine nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "IP configuration expired"
+msgstr "IP seadistus aegus"
+
+#. TRANSLATORS: device status reason
+msgid "Secrets were required, but not provided"
+msgstr "Vajalik on parool, aga seda ei antud"
+
+#. TRANSLATORS: device status reason
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x supplicant-iga katkes ühendus"
+
+#. TRANSLATORS: device status reason
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x supplicant-i seadistus nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "802.1x supplicant failed"
+msgstr "802.1x supplicant nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant-il läks autentimiseks liiga kaua"
+
+#. TRANSLATORS: device status reason
+msgid "PPP service failed to start"
+msgstr "PPP teenuse käivitamine nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "PPP service disconnected"
+msgstr "PPP teenuse ühendus katkes"
+
+#. TRANSLATORS: device status reason
+msgid "PPP failed"
+msgstr "PPP nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "DHCP client failed to start"
+msgstr "DHCP kliendi käivitamine nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "DHCP client error"
+msgstr "DHCP kliendi viga"
+
+#. TRANSLATORS: device status reason
+msgid "DHCP client failed"
+msgstr "DHCP kliendi päring nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "Shared connection service failed to start"
+msgstr "Jagatud ühenduse teenuse käivitamine nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "Shared connection service failed"
+msgstr "Jagatud ühenduse teenus nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "AutoIP service failed to start"
+msgstr "AutoIP teenuse käivitamine nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "AutoIP service error"
+msgstr "AutoIP teenuse viga"
+
+#. TRANSLATORS: device status reason
+msgid "AutoIP service failed"
+msgstr "AutoIP teenus nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "Line busy"
+msgstr "Liin on hõivatud"
+
+#. TRANSLATORS: device status reason
+msgid "No dial tone"
+msgstr "Tooni pole"
+
+#. TRANSLATORS: device status reason
+msgid "No carrier could be established"
+msgstr "Kandjat polnud võimalik luua"
+
+#. TRANSLATORS: device status reason
+msgid "Dialing request timed out"
+msgstr "Valimise katse aegus"
+
+#. TRANSLATORS: device status reason
+msgid "Dialing attempt failed"
+msgstr "Valimise katse nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "Modem initialization failed"
+msgstr "Modemi lähtestamine nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "Failed to select the specified APN"
+msgstr "Määratud APN-i valimine nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "Not searching for networks"
+msgstr "Võrke ei otsita"
+
+#. TRANSLATORS: device status reason
+msgid "Network registration denied"
+msgstr "Võrgu registreerimine on keelatud"
+
+#. TRANSLATORS: device status reason
+msgid "Network registration timed out"
+msgstr "Võrgu registreerimine aegus"
+
+#. TRANSLATORS: device status reason
+msgid "Failed to register with the requested network"
+msgstr "Valitud võrku registreerimine nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "PIN check failed"
+msgstr "PIN-i kontroll nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "Firmware for the device may be missing"
+msgstr "Selle seadme püsivara (firmware) võib olla puudu"
+
+#. TRANSLATORS: device status reason
+msgid "Connection disappeared"
+msgstr "Ühendus kadus"
+
+#. TRANSLATORS: device status reason
+msgid "Existing connection was assumed"
+msgstr "Olemasolev ühendus on eeldatav"
+
+#. TRANSLATORS: device status reason
+msgid "Modem not found"
+msgstr "Modemit ei leitud"
+
+#. TRANSLATORS: device status reason
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth ühendus nurjus"
+
+#. TRANSLATORS: device status reason
+msgid "SIM Card not inserted"
+msgstr "SIM kaart ei ole sees"
+
+#. TRANSLATORS: device status reason
+msgid "SIM Pin required"
+msgstr "Vajalik on SIM-kaardi PIN-kood"
+
+#. TRANSLATORS: device status reason
+msgid "SIM Puk required"
+msgstr "Vajalik on SIM-kaardi PUK-kood"
+
+#. TRANSLATORS: device status reason
+msgid "SIM wrong"
+msgstr "Vale SIM"
+
+#. TRANSLATORS: device status reason
+msgid "InfiniBand device does not support connected mode"
+msgstr "InfiniBand seade ei toeta seda ühenduse režiimi"
+
+#. TRANSLATORS: device status reason
+msgid "Connection dependency failed"
+msgstr "Ühenduse sõltuvus nurjus"
+
+#. TRANSLATORS: device status
+msgid "Firmware missing"
+msgstr "Püsivara puudub"
+
+#. TRANSLATORS: device status
+msgid "Cable unplugged"
+msgstr "Juhe eemaldatud"
+
+msgid "No Certificate Authority certificate chosen"
+msgstr "Ühtegi sertifitseerimiskeskuse serti pole valitud"
+
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"Sertifitseerimiskeskuse (SK) serdi mittekasutamine võib võimaldada ühendusi "
+"ebaturvaliste, halbade Wi-Fi võrkudega. Kas tahaksid siiski valida "
+"sertifitseerimiskeskuse serdi?"
+
+msgid "Ignore"
+msgstr "Eira"
+
+msgid "Choose CA Certificate"
+msgstr "Vali SK sertifikaat"
+
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM või PKCS#12 privaatvõtmed (*.der, *.pem, *.p12)"
+
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER või PEM sertifikaadid (*.der, *.pem, *.crt, *.cer)"
+
+msgid "GTC"
+msgstr "GTC"
+
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+msgid "Choose a PAC file..."
+msgstr "PAC faili valimine..."
+
+msgid "PAC files (*.pac)"
+msgstr "PAC failid (*.pac)"
+
+msgid "PAC _file"
+msgstr "PAC _fail"
+
+msgid "_Inner authentication"
+msgstr "_Sisemine autentimine"
+
+msgid "PAC pro_visioning"
+msgstr "PAC _tingimused"
+
+msgid " "
+msgstr " "
+
+msgid "Anonymous"
+msgstr "Anonüümne"
+
+msgid "Authenticated"
+msgstr "Autenditud"
+
+msgid "Both"
+msgstr "Mõlemad"
+
+msgid "_Username"
+msgstr "_Kasutajanimi"
+
+msgid "Sho_w password"
+msgstr "_Parooli näitamine"
+
+msgid "MD5"
+msgstr "MD5"
+
+msgid "Choose a Certificate Authority certificate..."
+msgstr "Vali sertifitseerimiskeskuse sert..."
+
+msgid "Version 0"
+msgstr "Versioon 0"
+
+msgid "Version 1"
+msgstr "Versioon 1"
+
+msgid "C_A certificate"
+msgstr "_SK sert"
+
+msgid "PEAP _version"
+msgstr "PEAP _versioon"
+
+msgid "As_k for this password every time"
+msgstr "_Seda parooli küsitakse iga kord"
+
+msgid "Unencrypted private keys are insecure"
+msgstr "Krüpteerimata privaatvõtmed pole turvalised"
+
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Valitud privaatvõti ei ole parooliga kaitstud. Seetõttu võivad turvatõendid "
+"saada kompromiteeritud. Palun vali parooliga kaitstud privaatvõti.\n"
+"\n"
+"(sa võid privaatvõtme parooliga kaitsta openssl abiga)"
+
+msgid "Choose your personal certificate..."
+msgstr "Vali oma isiklik sertifikaat..."
+
+msgid "Choose your private key..."
+msgstr "Vali oma privaatvõti..."
+
+msgid "I_dentity"
+msgstr "I_dentiteet"
+
+msgid "_User certificate"
+msgstr "_Kasutaja sertifikaat"
+
+msgid "Private _key"
+msgstr "_Privaatvõti"
+
+msgid "_Private key password"
+msgstr "_Privaatvõtme parool"
+
+msgid "PAP"
+msgstr "PAP"
+
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+msgid "CHAP"
+msgstr "CHAP"
+
+msgid "Don't _warn me again"
+msgstr "_Rohkem ei hoiatata"
+
+msgid "No"
+msgstr "Ei"
+
+msgid "Yes"
+msgstr "Jah"
+
+msgid "TLS"
+msgstr "TLS"
+
+msgid "FAST"
+msgstr "FAST"
+
+msgid "Tunneled TLS"
+msgstr "Tunnelis TLS"
+
+msgid "Protected EAP (PEAP)"
+msgstr "Kaitstud EAP (PEAP)"
+
+msgid "Au_thentication"
+msgstr "_Autentimine"
+
+msgid "1 (Default)"
+msgstr "1 (vaikimisi)"
+
+msgid "2"
+msgstr "2"
+
+msgid "3"
+msgstr "3"
+
+msgid "4"
+msgstr "4"
+
+msgid "Open System"
+msgstr "Avatud süsteem"
+
+msgid "Shared Key"
+msgstr "Jagatud võti"
+
+msgid "_Key"
+msgstr "_Võti"
+
+msgid "Sho_w key"
+msgstr "_Võtit näidatakse"
+
+msgid "WEP inde_x"
+msgstr "WEP _indeks"
+
+msgid "_Type"
+msgstr "_Liik"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "Teated"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "Heliteated"
+
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "Hüpikbännerite kuvamine"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "Bänneritel üksikasjade kuvamine"
+
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "Näidatakse lukustamise ekraanil"
+
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "Lukustusekraanil üksikasjade kuvamine"
+
+msgid "On"
+msgstr "Sees"
+
+msgid "Notifications"
+msgstr "Teated"
+
+msgid "Control which notifications are displayed and what they show"
+msgstr "Teadete kuvamine ja nende sisu"
+
+#. Translators: those are keywords for the notifications control-center panel
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "teated;bänner;sõnumid;teateala;hüpikaken;hüpikteade;"
+
+msgid "Show Pop Up Banners"
+msgstr "Hüpikbännerite kuvamine"
+
+msgid "Show in Lock Screen"
+msgstr "Näidatakse lukustamise ekraanil"
+
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Muu"
+
+#. translators: This is the title of the "Add Account" dialog.
+msgid "Add Account"
+msgstr "Konto lisamine"
+
+msgid "Mail"
+msgstr "E-post"
+
+msgid "Contacts"
+msgstr "Kontaktid"
+
+msgid "Chat"
+msgstr "Vestlus"
+
+msgid "Resources"
+msgstr "Ressursid"
+
+msgid "Error logging into the account"
+msgstr "Tõrge kontole sisselogimisel"
+
+msgid "Credentials have expired."
+msgstr "Turvatõendid on aegunud."
+
+msgid "Sign in to enable this account."
+msgstr "Selle konto lubamiseks logi sisse."
+
+msgid "_Sign In"
+msgstr "_Logi sisse"
+
+msgid "Error creating account"
+msgstr "Tõrge konto loomisel"
+
+msgid "Error removing account"
+msgstr "Tõrge konto eemaldamisel"
+
+msgid "Are you sure you want to remove the account?"
+msgstr "Oled sa kindel, et soovid konto eemaldada?"
+
+msgid "This will not remove the account on the server."
+msgstr "See ei eemalda serveris olevat kontot."
+
+msgid "_Remove"
+msgstr "_Eemalda"
+
+msgid "Online Accounts"
+msgstr "Netikontod"
+
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Veebikontodega ühendumine ja määramine, milleks neid kasutatakse"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;veeb;onlain;vestlus;kalender;meil;e-post;e-"
+"kiri;kontaktid;ownCloud;Kerberos;IMAP;SMTP;ReadItLater;"
+
+msgid "No online accounts configured"
+msgstr "Ühtegi netikontot pole seadistatud"
+
+msgid "Remove Account"
+msgstr "Konto eemaldamine"
+
+msgid "Add an online account"
+msgstr "Netikonto lisamine"
+
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"Konto lisamine võimaldab rakendustele ligipääsu dokumentidele, meilile, "
+"kontaktidele, kalendrile, vestlusele ja muule."
+
+msgid "Unknown time"
+msgstr "Tundmatu aeg"
+
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minut"
+msgstr[1] "%i minutit"
+
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i tund"
+msgstr[1] "%i tundi"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "tund"
+msgstr[1] "tundi"
+
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minutit"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s täislaadimiseni"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Hoiatus: %s jäänud"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#, c-format
+msgid "%s remaining"
+msgstr "%s jäänud"
+
+#. TRANSLATORS: primary battery
+msgid "Fully charged"
+msgstr "Täis laetud"
+
+#. TRANSLATORS: primary battery
+msgid "Empty"
+msgstr "Tühi"
+
+#. TRANSLATORS: primary battery
+msgid "Charging"
+msgstr "Laadimine"
+
+#. TRANSLATORS: primary battery
+msgid "Discharging"
+msgstr "Tühjenemine"
+
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Peamine"
+
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Ekstra"
+
+#. TRANSLATORS: secondary battery
+msgid "Wireless mouse"
+msgstr "Juhtmeta hiir"
+
+#. TRANSLATORS: secondary battery
+msgid "Wireless keyboard"
+msgstr "Juhtmeta klaviatuur"
+
+#. TRANSLATORS: secondary battery
+msgid "Uninterruptible power supply"
+msgstr "Katkestuseta toite allikas (UPS)"
+
+#. TRANSLATORS: secondary battery
+msgid "Personal digital assistant"
+msgstr "Isiklik digitaalassistent"
+
+#. TRANSLATORS: secondary battery
+msgid "Cellphone"
+msgstr "Mobiiltelefon"
+
+#. TRANSLATORS: secondary battery
+msgid "Media player"
+msgstr "Muusikaesitaja"
+
+#. TRANSLATORS: secondary battery
+msgid "Tablet"
+msgstr "Digitaallaud"
+
+#. TRANSLATORS: secondary battery
+msgid "Computer"
+msgstr "Arvuti"
+
+#. TRANSLATORS: secondary battery, misc
+msgid "Battery"
+msgstr "Aku"
+
+#. TRANSLATORS: secondary battery
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Laadimine"
+
+#. TRANSLATORS: secondary battery
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Hoiatus"
+
+#. TRANSLATORS: secondary battery
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Vähe"
+
+#. TRANSLATORS: secondary battery
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Hea"
+
+#. TRANSLATORS: primary battery
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Täis laetud"
+
+#. TRANSLATORS: primary battery
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Tühi"
+
+msgid "Batteries"
+msgstr "Akud"
+
+msgid "When _idle"
+msgstr "Kui _jõude"
+
+msgid "Power Saving"
+msgstr "Voolusääst"
+
+msgid "_Screen brightness"
+msgstr "_Ekraani heledus"
+
+msgid "_Keyboard brightness"
+msgstr "_Klaviatuuri heledus"
+
+msgid "_Dim screen when inactive"
+msgstr "_Ekraan tumeneb, kui tegevust pole"
+
+msgid "_Blank screen"
+msgstr "_Tühi ekraan"
+
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+msgid "Turns off wireless devices"
+msgstr "Lülitab juhtmevabad seadmed välja"
+
+msgid "_Mobile broadband"
+msgstr "_Mobiiliühendus"
+
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "Mobiiliühenduse seadmete (3G, 4G, WiMax jt) väljalülitamine"
+
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+msgid "When on battery power"
+msgstr "Akutoitel"
+
+msgid "When plugged in"
+msgstr "Võrgutoitel"
+
+msgid "Suspend & Power Off"
+msgstr "Uinak ja väljalülitamine"
+
+msgid "_Automatic suspend"
+msgstr "_Automaatne uinumine"
+
+msgid "When battery power is _critical"
+msgstr "Kui aku on _väga tühi"
+
+msgid "Power Off"
+msgstr "Lülitatakse välja"
+
+msgid "Devices"
+msgstr "Seadmed"
+
+msgid "Power"
+msgstr "Vooluhaldus"
+
+msgid "View your battery status and change power saving settings"
+msgstr "Aku oleku vaatamine ja voolusäästu sätete muutmine"
+
+#. Translators: those are keywords for the power control-center panel
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"vool;uni;uinak;talveuni;talveuinak;aku;hiberneerimine;peatamine;heledus;"
+"monitor;kuvar;ekraan;DPMS;jõudeolek;seisak;"
+
+msgid "Hibernate"
+msgstr "Talveuni"
+
+# "Kui aku on väga tühi: Talveuni/Lülitab välja
+msgid "Power off"
+msgstr "Lülitab välja"
+
+msgid "45 minutes"
+msgstr "45 minutit"
+
+msgid "1 hour"
+msgstr "1 tund"
+
+msgid "80 minutes"
+msgstr "80 minutit"
+
+msgid "90 minutes"
+msgstr "90 minutit"
+
+msgid "100 minutes"
+msgstr "100 minutit"
+
+msgid "2 hours"
+msgstr "2 tundi"
+
+msgid "1 minute"
+msgstr "1 minut"
+
+msgid "2 minutes"
+msgstr "2 minutit"
+
+msgid "3 minutes"
+msgstr "3 minutit"
+
+msgid "4 minutes"
+msgstr "4 minutit"
+
+msgid "5 minutes"
+msgstr "5 minutit"
+
+msgid "8 minutes"
+msgstr "8 minutit"
+
+msgid "10 minutes"
+msgstr "10 minutit"
+
+msgid "12 minutes"
+msgstr "12 minutit"
+
+msgid "Automatic Suspend"
+msgstr "Automaatne uinak"
+
+msgid "_Plugged In"
+msgstr "_Võrgutoitel"
+
+msgid "On _Battery Power"
+msgstr "_Akutoitel"
+
+msgid "Delay"
+msgstr "Viivitus"
+
+msgid "Authenticate"
+msgstr "Autentimine"
+
+msgid "Password"
+msgstr "Parool"
+
+msgid "Authentication Required"
+msgstr "Autentimine on vajalik"
+
+#. Translators: The printer is low on toner
+msgid "Low on toner"
+msgstr "Tooner on otsakorral"
+
+#. Translators: The printer has no toner left
+msgid "Out of toner"
+msgstr "Tooner on otsas"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+msgid "Low on developer"
+msgstr "Ilmuti on otsakorral"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+msgid "Out of developer"
+msgstr "Ilmuti on otsas"
+
+#. Translators: "marker" is one color bin of the printer
+msgid "Low on a marker supply"
+msgstr "Värv on otsakorral"
+
+#. Translators: "marker" is one color bin of the printer
+msgid "Out of a marker supply"
+msgstr "Värv on otsas"
+
+#. Translators: One or more covers on the printer are open
+msgid "Open cover"
+msgstr "Kaas on avatud"
+
+#. Translators: One or more doors on the printer are open
+msgid "Open door"
+msgstr "Luuk on avatud"
+
+#. Translators: At least one input tray is low on media
+msgid "Low on paper"
+msgstr "Paber on otsakorral"
+
+#. Translators: At least one input tray is empty
+msgid "Out of paper"
+msgstr "Paber on otsas"
+
+#. Translators: The printer is offline
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Pole võrgus"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Seisma jäetud"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+msgid "Waste receptacle almost full"
+msgstr "Prügimahuti on peaaegu täis"
+
+#. Translators: The printer marker supply waste receptacle is full
+msgid "Waste receptacle full"
+msgstr "Prügimahuti on täis"
+
+#. Translators: Optical photo conductors are used in laser printers
+msgid "The optical photo conductor is near end of life"
+msgstr "Fotosilma eluiga on lõppemas"
+
+#. Translators: Optical photo conductors are used in laser printers
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Fotosilm enam ei tööta"
+
+#. Translators: Printer's state (printer is being configured right now)
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "Seadistamine"
+
+#. Translators: Printer's state (can start new job without waiting)
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Valmis"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Töid vastu ei võeta"
+
+#. Translators: Printer's state (jobs are processing)
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Töötlemine"
+
+#. Translators: Toner supply
+msgid "Toner Level"
+msgstr "Tooneri kogus"
+
+#. Translators: Ink supply
+msgid "Ink Level"
+msgstr "Tindi kogus"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+msgid "Supply Level"
+msgstr "Kuluvahendi kogus"
+
+#. Translators: Printer's state (printer is being installed right now)
+msgctxt "printer state"
+msgid "Installing"
+msgstr "Paigaldamine"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+msgid "No printers available"
+msgstr "Ühtegi printerit pole saadaval"
+
+#. Translators: there is n active print jobs on this printer
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u aktiivne"
+msgstr[1] "%u aktiivset"
+
+#. Translators: Addition of the new printer failed.
+msgid "Failed to add new printer."
+msgstr "Tõrge uue printeri lisamisel."
+
+msgid "Select PPD File"
+msgstr "PPD faili valimine"
+
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PPD PostScript printeri kirjelduse failid (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD.GZ)"
+
+msgid "No suitable driver found"
+msgstr "Ühtegi sobivat draiverit ei leitud"
+
+msgid "Searching for preferred drivers…"
+msgstr "Eelistatud draiverite otsimine…"
+
+msgid "Select from database…"
+msgstr "Valimine andmebaasist…"
+
+msgid "Provide PPD File…"
+msgstr "Anna PPD fail…"
+
+#. Translators: Name of job which makes printer to print test page
+msgid "Test page"
+msgstr "Testleht"
+
+#. Translators: The XML file containing user interface can not be loaded
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Kasutajaliidest pole võimalik laadida: %s"
+
+msgid "Printers"
+msgstr "Printerid"
+
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Printerite lisamine ja seadistamine, printimistööde kuvamine"
+
+#. Translators: those are keywords for the printing control-center panel
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"Printer;Printimine;Printimisjärjekord;Trükkimine;Trükkimisjärjekord;Paber;"
+"Tint;Tooner;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+msgid "Active Jobs"
+msgstr "Aktiivsed printimistööd"
+
+msgid "Close"
+msgstr "Sulge"
+
+msgid "Resume Printing"
+msgstr "Jätka printimist"
+
+msgid "Pause Printing"
+msgstr "Peata printimine"
+
+msgid "Cancel Print Job"
+msgstr "Prinditöö katkestamine"
+
+msgid "Add a New Printer"
+msgstr "Uue printeri lisamine"
+
+#. Translators: This button opens authentication dialog for selected server.
+msgid "A_uthenticate"
+msgstr "_Autendi"
+
+#. Translators: No printers were found
+msgid "No printers detected."
+msgstr "Ühtegi printerit ei tuvastatud."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+msgid "Enter address of a printer or a text to filter results"
+msgstr "Tulemuste filtreerimiseks sisesta printeri aadress või nimi"
+
+msgid "Loading options…"
+msgstr "Valikute laadimine…"
+
+msgid "Select Printer Driver"
+msgstr "Printeri draiveri valimine"
+
+msgid "Loading drivers database..."
+msgstr "Draiverite andmebaasi laadimine..."
+
+#. Translators: this is an option of "Two Sided"
+msgid "One Sided"
+msgstr "Ühepoolne"
+
+#. Translators: this is an option of "Two Sided"
+msgid "Long Edge (Standard)"
+msgstr "Ümber pika külje (tavaline)"
+
+#. Translators: this is an option of "Two Sided"
+msgid "Short Edge (Flip)"
+msgstr "Ümber lühikese külje (pööratud)"
+
+#. Translators: this is an option of "Orientation"
+msgid "Portrait"
+msgstr "Portree"
+
+#. Translators: this is an option of "Orientation"
+msgid "Landscape"
+msgstr "Maastik"
+
+#. Translators: this is an option of "Orientation"
+msgid "Reverse landscape"
+msgstr "Pööratud maastik"
+
+#. Translators: this is an option of "Orientation"
+msgid "Reverse portrait"
+msgstr "Pööratud portree"
+
+#. Translators: Job's state (job is waiting to be printed)
+msgctxt "print job"
+msgid "Pending"
+msgstr "Ootel"
+
+#. Translators: Job's state (job is held for printing)
+msgctxt "print job"
+msgid "Held"
+msgstr "Hoitakse kinni"
+
+#. Translators: Job's state (job is currently printing)
+msgctxt "print job"
+msgid "Processing"
+msgstr "Töötluses"
+
+#. Translators: Job's state (job has been stopped)
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Peatatud"
+
+#. Translators: Job's state (job has been canceled)
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Katkestatud"
+
+#. Translators: Job's state (job has aborted due to error)
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Loobutud"
+
+#. Translators: Job's state (job has completed successfully)
+msgctxt "print job"
+msgid "Completed"
+msgstr "Valmis"
+
+#. Translators: Name of column showing titles of print jobs
+msgid "Job Title"
+msgstr "Töö pealkiri"
+
+#. Translators: Name of column showing statuses of print jobs
+msgid "Job State"
+msgstr "Töö seisund"
+
+#. Translators: Name of column showing times of creation of print jobs
+msgid "Time"
+msgstr "Aeg"
+
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s aktiivset printimistööd"
+
+#. Translators: The found device is a printer connected via USB
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+msgid "Serial Port"
+msgstr "Jadaport"
+
+#. Translators: The found device is a printer connected via parallel port
+msgid "Parallel Port"
+msgstr "Paralleelport"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#, c-format
+msgid "Location: %s"
+msgstr "Asukoht: %s"
+
+#. Translators: Network address of found printer
+#, c-format
+msgid "Address: %s"
+msgstr "Aadress: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+msgid "Server requires authentication"
+msgstr "Server nõuab autentimist"
+
+msgid "Two Sided"
+msgstr "Kahepoolne"
+
+msgid "Paper Type"
+msgstr "Paberi liik"
+
+msgid "Paper Source"
+msgstr "Paberi allikas"
+
+msgid "Output Tray"
+msgstr "Väljundsalv"
+
+msgid "GhostScript pre-filtering"
+msgstr "GhostScripti eelfilter"
+
+#. Translators: This option sets number of pages printed on one sheet
+msgid "Pages per side"
+msgstr "Lehekülgi lehele"
+
+#. Translators: This option sets whether to print on both sides of paper
+msgid "Two-sided"
+msgstr "Kahepoolne"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+msgid "Orientation"
+msgstr "Suund"
+
+#. Translators: "General" tab contains general printer options
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Üldine"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Lehe seadistus"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Paigaldatavad valikud"
+
+#. Translators: "Job" tab contains settings for jobs
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Töö"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Pildi kvaliteet"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Värvid"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Lõpetamine"
+
+#. Translators: "Advanced" tab contains all others settings
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Laiendatud"
+
+#. Translators: this is an option of "Paper Source"
+msgid "Auto Select"
+msgstr "Automaatne valik"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+msgid "Printer Default"
+msgstr "Printeri vaikimisi"
+
+#. Translators: this is an option of "GhostScript"
+msgid "Embed GhostScript fonts only"
+msgstr "Kaasatakse ainult GhostScripti fondid"
+
+#. Translators: this is an option of "GhostScript"
+msgid "Convert to PS level 1"
+msgstr "Teisendamine keelde PS level 1"
+
+#. Translators: this is an option of "GhostScript"
+msgid "Convert to PS level 2"
+msgstr "Teisendamine keelde PS level 2"
+
+#. Translators: this is an option of "GhostScript"
+msgid "No pre-filtering"
+msgstr "Eelfilter puudub"
+
+#. Translators: Name of column showing printer manufacturers
+msgid "Manufacturer"
+msgstr "Tootja"
+
+#. Translators: Name of column showing printer drivers
+msgid "Driver"
+msgstr "Draiver"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"Sisesta kasutajanimi ja parool, et näha masinas %s saadaolevaid printereid."
+
+msgid "Add Printer"
+msgstr "Printeri lisamine"
+
+msgid "Remove Printer"
+msgstr "Eemalda printer"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+msgid "Supply"
+msgstr "Varu"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+msgid "Location"
+msgstr "Asukoht"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+msgid "_Default printer"
+msgstr "_Vaikimisi printer"
+
+msgid "Jobs"
+msgstr "Tööd"
+
+#. Translators: Opens a dialog containing printer's jobs
+msgid "Show _Jobs"
+msgstr "_Tööde kuvamine"
+
+msgid "Model"
+msgstr "Mudel"
+
+msgid "label"
+msgstr "silt"
+
+msgid "Setting new driver…"
+msgstr "Uue draiveri seadistamine…"
+
+msgid "page 3"
+msgstr "leht 3"
+
+#. Translators: This button executes command which prints test page.
+msgid "Print _Test Page"
+msgstr "_Prindi proovilehekülg"
+
+#. Translators: This button opens printer's options tab
+msgid "_Options"
+msgstr "_Valikud"
+
+#. Translators: This button adds new printer.
+msgid "Add New Printer"
+msgstr "Uue printeri lisamine"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"Vabandust! Tundub, et süsteemi\n"
+"printimisteenus pole saadaval."
+
+msgid "Screen Lock"
+msgstr "Ekraanilukk"
+
+msgid "Usage & History"
+msgstr "Kasutus ja ajalugu"
+
+msgid "Empty all items from Trash?"
+msgstr "Kas tühjendada prügikast?"
+
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Kõik asjad prügikastis kustutatakse jäädavalt."
+
+msgid "_Empty Trash"
+msgstr "_Tühjenda prügikast"
+
+msgid "Delete all the temporary files?"
+msgstr "Kas kustutada kõik ajutised failid?"
+
+msgid "All the temporary files will be permanently deleted."
+msgstr "Kõik ajutised failid kustutatakse jäädavalt."
+
+msgid "_Purge Temporary Files"
+msgstr "_Hävita ajutised failid"
+
+msgid "Purge Trash & Temporary Files"
+msgstr "Puhasta prügikast ja ajutised failid"
+
+msgid "Software Usage"
+msgstr "Tarkvarakasutus"
+
+msgid "Privacy"
+msgstr "Privaatsus"
+
+msgid "Protect your personal information and control what others might see"
+msgstr "Kaitse oma isiklikke andmeid ja muuda, mida teised näevad"
+
+#. Translators: those are keywords for the privacy control-center panel
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"ekraan;lukk;diagnostika;privaatsus;privaatne;hiljutine;ajutine;tmp;temp;"
+"indeks;nimi;nimed;võrk;ühendus;identiteet;"
+
+msgid "Screen Turns Off"
+msgstr "Ekraani väljalülitumisel"
+
+msgid "30 seconds"
+msgstr "30 sekundit"
+
+msgid "1 day"
+msgstr "1 päev"
+
+msgid "2 days"
+msgstr "2 päeva"
+
+msgid "3 days"
+msgstr "3 päeva"
+
+msgid "4 days"
+msgstr "4 päeva"
+
+msgid "5 days"
+msgstr "5 päeva"
+
+msgid "6 days"
+msgstr "6 päeva"
+
+msgid "7 days"
+msgstr "7 päeva"
+
+msgid "14 days"
+msgstr "14 päeva"
+
+msgid "30 days"
+msgstr "30 päeva"
+
+msgid "Forever"
+msgstr "Igavesti"
+
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"Ajaloo mäletamine teeb hiljem asjade leidmise lihtsamaks. Neid kirjeid ei "
+"jagata kunagi üle võrgu."
+
+msgid "_Recently Used"
+msgstr "_Hiljuti kasutatud"
+
+msgid "Retain _History"
+msgstr "Säilita _ajalugu"
+
+msgid "Cl_ear Recent History"
+msgstr "_Puhasta hiljutine ajalugu"
+
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "Ekraanilukk kaitseb sinu privaatsust, kuni sa ära oled."
+
+msgid "Automatic Screen _Lock"
+msgstr "Automaatne ekraani_lukk"
+
+msgid "Lock screen _after blank for"
+msgstr "Ekraan lukustatakse _pärast pimenemist"
+
+msgid "Show _Notifications"
+msgstr "Teateid _näidatakse"
+
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"Automaatselt tühjenda prügikast ja viska ära ajutised failid, et hoida "
+"arvuti puhas ebavajalikust tundlikust infost."
+
+msgid "Automatically empty _Trash"
+msgstr "_Prügikasti automaatne tühjendamine"
+
+msgid "Automatically purge Temporary _Files"
+msgstr "Ajutiste _failide automaatne hävitamine"
+
+msgid "Purge _After"
+msgstr "Tühjendatakse _pärast"
+
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"Kui saadad meile infot tarkvara kohta, mida kasutad, on meil võimalik "
+"pakkuda sulle täpsemaid soovitusi. Samuti aitab see just õiget tarkvara "
+"arendada.\n"
+"\n"
+"Kõik meie kogutavad andmed tehakse anonüümseks ning me ei jaga sinu andmeid "
+"mitte kunagi kellegi kolmandaga."
+
+msgid "_Send software usage statistics"
+msgstr "_Tarkvarakasutuse statistika saatmine"
+
+msgid "Privacy Policy"
+msgstr "Privaatsuse tagamine"
+
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Briti mõõdustik"
+
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Meetermõõdustik"
+
+msgid "No regions found"
+msgstr "Regioone ei leitud"
+
+msgid "No input sources found"
+msgstr "Ühtegi sisendseadet ei leitud"
+
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Muu"
+
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Sinu seanss tuleb muudatuste jõustumiseks uuesti käivitada"
+
+msgid "Restart Now"
+msgstr "Taaskäivita kohe"
+
+msgid "No input source selected"
+msgstr "Ühtegi sisendseadet pole valitud"
+
+msgid "Sorry"
+msgstr "Vabandust"
+
+msgid "Input methods can't be used on the login screen"
+msgstr "Sisestusmeetodeid pole võimalik sisselogimisekraanil kasutada"
+
+msgid "Login Screen"
+msgstr "Sisselogimisekraan"
+
+msgid "Formats"
+msgstr "Vormingud"
+
+msgid "Preview"
+msgstr "Eelvaade"
+
+msgid "Dates"
+msgstr "Kuupäevad"
+
+msgid "Times"
+msgstr "Kellaajad"
+
+msgid "Numbers"
+msgstr "Arvud"
+
+msgid "Measurement"
+msgstr "Mõõtühikud"
+
+msgid "Paper"
+msgstr "Paber"
+
+msgid "Region & Language"
+msgstr "Piirkond ja keel"
+
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr "Vali kuva keel, vormingud, klaviatuuripaigutused ja sisendid"
+
+#. Translators: those are keywords for the region control-center panel
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Keel;Paigutus;Klaviatuur;Sisend;Sisestamine;"
+
+msgid "Add an Input Source"
+msgstr "Sisendseadme lisamine"
+
+msgid "Input Source Options"
+msgstr "Sisendseadme valikud"
+
+msgid "Use the _same source for all windows"
+msgstr "_Sama paigutuse kasutamine kõigil akendel"
+
+msgid "Allow _different sources for each window"
+msgstr "Iga akna jaoks _oma paigutuse lubamine"
+
+msgid "Keyboard Shortcuts"
+msgstr "Kiirklahvid"
+
+msgid "Switch to previous source"
+msgstr "Eelmisele sisendile lülitumine"
+
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+msgid "Switch to next source"
+msgstr "Lülitu järgmisele allikale"
+
+msgid "Super+Space"
+msgstr "Super+Tühik"
+
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "Neid kiirklahve saab muuta klaviatuuri sätete alt"
+
+msgid "Alternative switch to next source"
+msgstr "Järgmisele sisendile vahetamise alternatiiv"
+
+msgid "Left+Right Alt"
+msgstr "Vasak+parem Alt"
+
+msgid "English (United Kingdom)"
+msgstr "Inglise (Suurbritannia)"
+
+msgid "United Kingdom"
+msgstr "Suurbritannia"
+
+msgid "Options"
+msgstr "Valikud"
+
+msgid "Login settings are used by all users when logging into the system"
+msgstr "Sisselogimissätteid mõjuvatad sisselogimisel kõik kasutajad"
+
+msgctxt "Search Location"
+msgid "Places"
+msgstr "Asukohad"
+
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "Järjehoidjad"
+
+msgctxt "Search Location"
+msgid "Other"
+msgstr "Muu"
+
+msgid "Select Location"
+msgstr "Asukoha valimine"
+
+msgid "_OK"
+msgstr "_Olgu"
+
+msgid "No applications found"
+msgstr "Rakendusi ei leitud"
+
+msgid "Search"
+msgstr "Otsi"
+
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Määra, milliste rakenduste otsingutulemused on näha tegevuste ülevaates"
+
+#. Translators: those are keywords for the search control-center panel
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"otsing;leia;leidmine;indeks;peida;peitmine;varjamine;privaatsus;tulemused;"
+
+msgid "Search Locations"
+msgstr "Otsingu asukohad"
+
+msgid "Move Up"
+msgstr "Liiguta üles"
+
+msgid "Move Down"
+msgstr "Liiguta alla"
+
+msgid "Preferences"
+msgstr "Eelistused"
+
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Sees"
+
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Väljas"
+
+msgid "Choose a Folder"
+msgstr "Kausta valimine"
+
+msgid "Copy"
+msgstr "Kopeeri"
+
+msgid "Sharing"
+msgstr "Jagamine"
+
+msgid "Control what you want to share with others"
+msgstr "Kontrolli, mida teistega jagatakse"
+
+#. Translators: those are keywords for the sharing control-center panel
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"jagamine;ssh;host;nimi;kaugtöölaud;kaugühendus;bluetooth;obex;meedia;audio;"
+"heli;muusika;videod;pildid;fotod;filmid;server;renderdaja;"
+
+msgid "Enable or disable remote login"
+msgstr "Kauglogimise lubamine või keelamine"
+
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Autentimine on vajalik kauglogimise lubamiseks või keelamiseks"
+
+msgid "Bluetooth Sharing"
+msgstr "Bluetoothi jagamine"
+
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"Bluetoothi jagamine võimaldab jagada faile teiste Bluetoothi seadmetega"
+
+msgid "Only Receive From Trusted Devices"
+msgstr "Ainult usaldatud seadmetelt vastuvõtmine"
+
+msgid "Save Received Files to Downloads Folder"
+msgstr "Vastuvõetud failide salvestamine allalaadimiste kausta"
+
+msgid "Computer Name"
+msgstr "Arvuti nimi"
+
+msgid "Personal File Sharing"
+msgstr "Isiklike failide jagamine"
+
+msgid "Screen Sharing"
+msgstr "Ekraani jagamine"
+
+msgid "Media Sharing"
+msgstr "Meedia jagamine"
+
+msgid "Remote Login"
+msgstr "Kauglogimine"
+
+msgid "Some services are disabled because of no network access."
+msgstr "Mõned teenused on võrguühenduse puudumise tõttu keelatud."
+
+msgid "Share Music, Photos and Videos with others on the current network."
+msgstr "Muusika, fotode ja videote jagamine teistega selles võrgus."
+
+msgid "Share Media On This Network"
+msgstr "Meedia jagamine sellesse võrku"
+
+msgid "Shared Folders"
+msgstr "Jagatud kataloogid"
+
+msgid "column"
+msgstr "tulp"
+
+msgid "Add Folder"
+msgstr "Kataloogi lisamine"
+
+msgid "Remove Folder"
+msgstr "Kataloogi eemaldamine"
+
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"Isiklike failide jagamine võimaldab avaliku ja teiste kaustade jagamist "
+"praegusesse võrku, kasutades aadressi: <a href=\"dav://%s\">dav://%s</a>"
+
+msgid "Share Public Folder On This Network"
+msgstr "Avaliku kausta jagamine sellesse võrku"
+
+msgid "Require Password"
+msgstr "Parool nõutud"
+
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"Kaugkasutajad võivad ühenduda kasutades SSH käsku:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"Kaugkasutajad saavad sinu ekraani kasutada, ühendudes aadressil: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+
+msgid "Allow Remote Control"
+msgstr "Kaugjuhtimine lubatud"
+
+msgid "Password:"
+msgstr "Parool:"
+
+msgid "Show Password"
+msgstr "Parooli näitamine"
+
+msgid "Access Options"
+msgstr "Ligipääsu valikud"
+
+# Või uued kontaktid?
+msgid "New connections must ask for access"
+msgstr "Uued ühendused peavad küsima luba"
+
+msgid "Require a password"
+msgstr "Parool nõutud"
+
+msgid "Sound"
+msgstr "Heli"
+
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Helivaljuse, sisendite, väljundite ja sündmuste helide muutmine"
+
+#. Translators: those are keywords for the sound control-center panel
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr ""
+"Helikaart;Mikrofon;Helivaljus;Valjus;Balanss;Tasakaal;Bluetooth;Sinihammas;"
+"Peakomplekt;Audio;Heli;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+msgid "Bark"
+msgstr "Haukumine"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+msgid "Drip"
+msgstr "Tilkumine"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+msgid "Glass"
+msgstr "Klaas"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+msgid "Sonar"
+msgstr "Sonar"
+
+msgctxt "balance"
+msgid "Left"
+msgstr "Vasak"
+
+msgctxt "balance"
+msgid "Right"
+msgstr "Parem"
+
+msgctxt "balance"
+msgid "Rear"
+msgstr "Tagumised"
+
+msgctxt "balance"
+msgid "Front"
+msgstr "Esimesed"
+
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Minimaalne"
+
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Maksimaalne"
+
+msgid "_Balance:"
+msgstr "_Tasakaal:"
+
+# või on esimeste/tagumiste vahel jaotamise mõttes?
+msgid "_Fade:"
+msgstr "_Hajumine:"
+
+msgid "_Subwoofer:"
+msgstr "_Bassikõlar:"
+
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Võimendamata"
+
+msgid "_Profile:"
+msgstr "_Profiil:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u väljund"
+msgstr[1] "%u väljundit"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u sisend"
+msgstr[1] "%u sisendid"
+
+msgid "System Sounds"
+msgstr "Süsteemsed helid"
+
+msgid "_Test Speakers"
+msgstr "_Kõlarite kontroll"
+
+msgid "Peak detect"
+msgstr "Tipu tuvastamine"
+
+msgid "Name"
+msgstr "Nimi"
+
+msgid "Device"
+msgstr "Seade"
+
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s kõlarite testimine"
+
+msgid "_Output volume:"
+msgstr "_Väljundi valjus"
+
+msgid "Output"
+msgstr "Väljund"
+
+msgid "C_hoose a device for sound output:"
+msgstr "_Vali heliväljundi seade:"
+
+msgid "Settings for the selected device:"
+msgstr "Valitud seadme sätted:"
+
+msgid "Input"
+msgstr "Sisend"
+
+msgid "_Input volume:"
+msgstr "_Sisendi valjus"
+
+msgid "Input level:"
+msgstr "Sisendtase:"
+
+msgid "C_hoose a device for sound input:"
+msgstr "_Vali helisisendi seade:"
+
+msgid "Sound Effects"
+msgstr "Heliefektid"
+
+msgid "_Alert volume:"
+msgstr "_Hoiatuse valjus"
+
+msgid "Applications"
+msgstr "Rakendused"
+
+msgid "No application is currently playing or recording audio."
+msgstr "Mitte ükski rakendus ei esita ega lindista praegu heli."
+
+msgid "Built-in"
+msgstr "Sisseehitatud"
+
+msgid "Sound Preferences"
+msgstr "Helieelistused"
+
+msgid "Testing event sound"
+msgstr "Sündmuse heli testimine"
+
+msgid "Default"
+msgstr "Vaikimisi"
+
+msgid "From theme"
+msgstr "Teemast"
+
+msgid "C_hoose an alert sound:"
+msgstr "_Vali teadaande heli:"
+
+msgid "Stop"
+msgstr "Peata"
+
+msgid "Test"
+msgstr "Testi"
+
+msgid "Subwoofer"
+msgstr "Bassikõlar"
+
+msgid "Custom"
+msgstr "Kohandatud"
+
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Nägemise, kuulmise, sisestamise ning klõpsamise lihtsustamine"
+
+#. Translators: those are keywords for the universal access control-center panel
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"Klaviatuur;Klaver;Hiir;a11y;Hõlbustused;Ligipääsetavus;Kontrast;Suurendus;"
+"Suum;Ekraanilugeja;tekst;font;suurus;AccessX;Kleepuvad klahvid;Aeglased;"
+"Aeglane;Põrkeklahvid;Hiir;"
+
+msgid "_Always Show Universal Access Menu"
+msgstr "_Alati kuvatakse pärssimata juurdepääsu menüüd"
+
+msgid "Seeing"
+msgstr "Nägemine"
+
+msgid "_High Contrast"
+msgstr "_Kõrgkontrastne"
+
+msgid "_Large Text"
+msgstr "_Suur tekst"
+
+msgid "_Zoom"
+msgstr "_Suurendus"
+
+msgid "Screen _Reader"
+msgstr "_Ekraanilugeja"
+
+msgid "_Sound Keys"
+msgstr "_Klahvide heli"
+
+msgid "Hearing"
+msgstr "Kuulmine"
+
+msgid "_Visual Alerts"
+msgstr "_Visuaalsed märguanded"
+
+msgid "Screen _Keyboard"
+msgstr "_Ekraaniklaviatuur"
+
+msgid "_Typing Assist (AccessX)"
+msgstr "_Tippimisabiline"
+
+msgid "Pointing & Clicking"
+msgstr "Osutamine ja klõpsamine"
+
+msgid "_Mouse Keys"
+msgstr "_Hiire klahvid"
+
+msgid "_Click Assist"
+msgstr "_Klõpsamise abiline"
+
+msgid "Screen Reader"
+msgstr "Ekraanilugeja"
+
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Ekraanilugeja loeb teksti ette fookuse muutmisel."
+
+msgid "_Screen Reader"
+msgstr "_Ekraanilugeja"
+
+msgid "Sound Keys"
+msgstr "Klahvide heli"
+
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr ""
+"Piiksumine, kui Num Lock (numbrilukk) või Caps Lock (tõstulukk) on sisse "
+"lülitatud."
+
+msgid "Visual Alerts"
+msgstr "Visuaalsed märguanded"
+
+msgid "_Test flash"
+msgstr "Proovi _välku"
+
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Hoiatusheliga koos hoiatatakse ka visuaalselt"
+
+msgid "Flash the _window title"
+msgstr "_Akna pealkirja vilgutamine"
+
+msgid "Flash the entire _screen"
+msgstr "Kogu ekraani _vilgutamine"
+
+msgid "Typing Assist"
+msgstr "Tippimisabiline"
+
+msgid "_Sticky Keys"
+msgstr "_Kleepuvad klahvid"
+
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Tõlgendab muuteklahvide järjestust klahvikombinatsioonina"
+
+msgid "_Disable if two keys are pressed together"
+msgstr "Kahe klahvi koosvajutamisel keelatakse"
+
+msgid "Beep when a _modifer key is pressed"
+msgstr "_Muuteklahvi vajutamisel tehakse piiks"
+
+msgid "S_low Keys"
+msgstr "_Aeglased klahvid"
+
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Määrab viivituse klahvi vajutamise ja sellega nõustumise vahele"
+
+msgid "A_cceptance delay:"
+msgstr "Nõustumise viivitus:"
+
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Lühike"
+
+msgid "Slow keys typing delay"
+msgstr "Aeglaste klahvide sisestusviivitus"
+
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Pikk"
+
+msgid "Beep when a key is pr_essed"
+msgstr "_Klahvi vajutamisel tehakse piiks"
+
+msgid "Beep when a key is _accepted"
+msgstr "Klahviga _nõustumisel tehakse piiks"
+
+msgid "Beep when a key is _rejected"
+msgstr "Klahvist _loobumisel tehakse piiks"
+
+msgid "_Bounce Keys"
+msgstr "_Põrkeklahvid"
+
+msgid "Ignores fast duplicate keypresses"
+msgstr "Klahvi kiire korduvvajutuse eiramine"
+
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Lühike"
+
+msgid "Bounce keys typing delay"
+msgstr "Põrkeklahvide tuvastamise viivitus"
+
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Pikk"
+
+msgid "_Enable by Keyboard"
+msgstr "_Lülitatakse sisse klaviatuurilt"
+
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Hõlbustusvahendite sisse- ja väljalülitamine klaviatuuri abil"
+
+msgid "Click Assist"
+msgstr "Klõpsamise abiline"
+
+msgid "_Simulated Secondary Click"
+msgstr "_Simuleeritud paremklõps"
+
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Peamise nupu allhoidmisel tehakse teisene klõps"
+
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Lühike"
+
+msgid "Secondary click delay"
+msgstr "Teisese klõpsu viivitus "
+
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Pikk"
+
+msgid "_Hover Click"
+msgstr "_Hiirega üleliikumisel klõps"
+
+msgid "Trigger a click when the pointer hovers"
+msgstr "Kursori üleliikumisel tehakse hiireklõps"
+
+msgid "D_elay:"
+msgstr "V_iivitus:"
+
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Lühike"
+
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Pikk"
+
+msgid "Motion _threshold:"
+msgstr "_Liikumise lävi:"
+
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Väike"
+
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Suur"
+
+msgctxt "Distance"
+msgid "Short"
+msgstr "Lühike"
+
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ekraani"
+
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ekraani"
+
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ekraani"
+
+msgctxt "Distance"
+msgid "Long"
+msgstr "Pikk"
+
+msgid "Full Screen"
+msgstr "Täisekraan"
+
+msgid "Top Half"
+msgstr "Ülemine osa"
+
+msgid "Bottom Half"
+msgstr "Alumine pool"
+
+msgid "Left Half"
+msgstr "Vasak pool"
+
+msgid "Right Half"
+msgstr "Parem pool"
+
+msgid "Zoom Options"
+msgstr "Suurenduse valikud"
+
+msgid "Zoom"
+msgstr "Ekraan täidetud"
+
+msgid "Magnification:"
+msgstr "Suurendus:"
+
+msgid "Follow mouse cursor"
+msgstr "Liigub koos hiirekursoriga"
+
+msgid "Screen part:"
+msgstr "Ekraani osa:"
+
+msgid "Magnifier extends outside of screen"
+msgstr "Luup liigub üle ekraani serva"
+
+msgid "Keep magnifier cursor centered"
+msgstr "Hiir asub luubi keskkohas"
+
+msgid "Magnifier cursor pushes contents around"
+msgstr "Luubi kursor liigutab sisu"
+
+msgid "Magnifier cursor moves with contents"
+msgstr "Luubi kursor liigub koos sisuga"
+
+msgid "Magnifier Position:"
+msgstr "Luubi asukoht:"
+
+msgid "Magnifier"
+msgstr "Luup"
+
+msgid "Thickness:"
+msgstr "Jämedus:"
+
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Peenike"
+
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Jäme"
+
+msgid "Length:"
+msgstr "Pikkus:"
+
+#. The color of the accessibility crosshair
+msgid "Color:"
+msgstr "Värvid:"
+
+msgid "Crosshairs:"
+msgstr "Sihik:"
+
+msgid "Overlaps mouse cursor"
+msgstr "Asendab hiirekursorit"
+
+msgid "Crosshairs"
+msgstr "Sihik"
+
+msgid "White on black:"
+msgstr "Valge mustal:"
+
+msgid "Brightness:"
+msgstr "Heledus:"
+
+msgid "Contrast:"
+msgstr "Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "Värvid"
+
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Puudub"
+
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Täielik"
+
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Tume"
+
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Hele"
+
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Madal"
+
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Kõrge"
+
+msgid "Color Effects:"
+msgstr "Värviefektid:"
+
+msgid "Color Effects"
+msgstr "Värviefektid"
+
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Tavaline"
+
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Administraator"
+
+msgid "_Full Name"
+msgstr "_Täisnimi"
+
+msgid "Account _Type"
+msgstr "Konto _liik"
+
+msgid "Allow user to set a password when they next login"
+msgstr "Kasutajal lubatakse järgmisel sisselogimisel parooli valida"
+
+msgid "Set a password now"
+msgstr "Parooli kohene muutmine"
+
+msgid "_Verify"
+msgstr "_Kontrolli"
+
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"Ettevõtte sisselogimiskonto kasutamine võimaldab sel masinal kasutada "
+"kasutajakontode keskhaldust."
+
+msgid "_Domain"
+msgstr "_Domeen"
+
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"Ühendu internetti, et lisada\n"
+"ettevõtte sisselogimiskontosid."
+
+msgid "Add User"
+msgstr "Lisa kasutaja"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+msgid "_Enroll"
+msgstr "_Registreeri"
+
+msgid "Domain Administrator Login"
+msgstr "Domeenihalduri sisselogimine"
+
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Et kasutada ettevõtte sisselogimist, peab see arvuti olema\n"
+"lisatud domeeni. Palun lase oma võrguhalduril sisestada siia\n"
+"oma domeeni parool."
+
+msgid "Administrator _Name"
+msgstr "Administraatori _nimi"
+
+msgid "Administrator Password"
+msgstr "Administraatori parool"
+
+msgid "Left thumb"
+msgstr "Vasak pöial"
+
+msgid "Left middle finger"
+msgstr "Vasak keskmine sõrm"
+
+msgid "Left ring finger"
+msgstr "Vasak nimetu sõrm"
+
+msgid "Left little finger"
+msgstr "Vasak väike sõrm"
+
+msgid "Right thumb"
+msgstr "Parem pöial"
+
+msgid "Right middle finger"
+msgstr "Parem keskmine sõrm"
+
+msgid "Right ring finger"
+msgstr "Parem nimetu sõrm"
+
+msgid "Right little finger"
+msgstr "Parem väike sõrm"
+
+msgid "Enable Fingerprint Login"
+msgstr "Sõrmejäljega logimise lubamine"
+
+msgid "_Right index finger"
+msgstr "_Parema käe nimetissõrm"
+
+msgid "_Left index finger"
+msgstr "_Vasaku käe nimetissõrm"
+
+msgid "_Other finger:"
+msgstr "_Muu sõrm:"
+
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"Sinu sõrmejälg on edukalt salvestatud. Sul peaks olema nüüd võimalik "
+"sõrmejäljelugeja abil sisse logida."
+
+msgid "Users"
+msgstr "Kasutajad"
+
+msgid "Add or remove users and change your password"
+msgstr "Kasutajate lisamine ja eemaldamine ning parooli muutmine"
+
+#. Translators: those are keywords for the user accounts control-center panel
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Sisselogimine;Nimi;Sõrmejälg;Avatar;Logo;Nägu;Parool;Salasõna;"
+
+msgid "Login History"
+msgstr "Sisselogimiste ajalugu"
+
+msgid "Change Password"
+msgstr "Parooli muutmine"
+
+msgid "Ch_ange"
+msgstr "_Muuda"
+
+msgid "_Verify New Password"
+msgstr "_Kinnita uus parool"
+
+msgid "_New Password"
+msgstr "_Uus parool"
+
+msgid "Current _Password"
+msgstr "Praegune _parool"
+
+msgid "Add User Account"
+msgstr "Lisa kasutajakonto"
+
+msgid "Remove User Account"
+msgstr "Eemalda kasutajakonto"
+
+msgid "Login Options"
+msgstr "Sisselogimise valikud"
+
+msgid "A_utomatic Login"
+msgstr "A_utomaatne sisselogimine"
+
+msgid "_Fingerprint Login"
+msgstr "Sisselogimine _sõrmejäljega"
+
+msgid "User Icon"
+msgstr "Kasutajaikoon"
+
+msgid "_Language"
+msgstr "_Keel:"
+
+msgid "Last Login"
+msgstr "Viimane sisselogimine"
+
+msgid "Manage user accounts"
+msgstr "Kasutajakontode haldamine"
+
+msgid "Authentication is required to change user data"
+msgstr "Autentimine on vajalik kasutaja andmete muutmiseks"
+
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Uus parool ei tohi olla sama nagu eelmine."
+
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Proovi mõnede tähtede ja numbrite muutmist."
+
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Muuda parooli veel natukene."
+
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Ilma kasutajanimeta parool peaks olema tugevam."
+
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Ära kasuta oma kasutajanime parooli sees."
+
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Ära kasuta parooli sees tuntud sõnu."
+
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Ära kasuta tavalisi sõnu."
+
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Ära vaheta olemasolevate sõnade järjekorda."
+
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Kasuta rohkem numbreid."
+
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Kasuta rohkem suurtähti."
+
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Kasuta rohkem väiketähti."
+
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Kasuta mõnd erimärki nagu näiteks punkt."
+
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Kasuta kombinatsiooni tähtedest, numbritest ja kirjavahemärkidest."
+
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Väldi sama märgi kordamist."
+
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Hoidu sama liiki märgi kordamisest. Sul on vaja kombinatsiooni tähtedest, "
+"numbritest ja kirjavahemärkidest."
+
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Väldi järgnevusi nagu1234 või abcd."
+
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "Püüa lisada veel tähti, numbreid ja sümboleid."
+
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr "Kasuta vaheldumisi suur- ja väiketähti ning lisa paar numbrit."
+
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+"Hea parool! Tähtede, numbrite ja kirjavahemärkide lisamine teeks seda "
+"tugevamaks."
+
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "Tugevus: väga nõrk"
+
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "Tugevus: nõrk"
+
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "Tugevus: keskmine"
+
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "Tugevus: piisav"
+
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "Tugevus: eriti tugev"
+
+msgid "Authentication failed"
+msgstr "Autentimine ei õnnestunud"
+
+#, c-format
+msgid "The new password is too short"
+msgstr "Uus parool on liiga lühike"
+
+#, c-format
+msgid "The new password is too simple"
+msgstr "Uus parool on liiga lihtne"
+
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Vana ja uus parool on liiga sarnased"
+
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Uus parool on hiljuti kasutusel olnud."
+
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Uus parool peab sisaldama numbreid või erimärke"
+
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Vana ja uus parool on ühesugused"
+
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Sinu parool on pärast algset autentimist muutunud!"
+
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Uus parool ei sisalda piisaval hulgal erinevaid märke"
+
+#, c-format
+msgid "Unknown error"
+msgstr "Tundmatu viga"
+
+msgid "Should match the web address of your account provider."
+msgstr "Peaks vastama sinu kontopakkuja veebiaadressile."
+
+msgid "Failed to add account"
+msgstr "Konto lisamine nurjus"
+
+msgid "Passwords do not match."
+msgstr "Paroolid ei klapi."
+
+msgid "Failed to register account"
+msgstr "Konto registreerimine nurjus"
+
+msgid "No supported way to authenticate with this domain"
+msgstr "Pole ühtegi toetatud viisi selle domeeniga autentimiseks"
+
+msgid "Failed to join domain"
+msgstr "Domeeniga ühendumine nurjus"
+
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"Kasutajanimi pole õige.\n"
+"Palun proovi uuesti."
+
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"Parool ei olnud õige.\n"
+"Palun proovi uuesti."
+
+msgid "Failed to log into domain"
+msgstr "Domeeni sisselogimine nurjus"
+
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "Domeeni ei leitud. Võib-olla kirjutasid selle valest?"
+
+#. Create enterprise toggle button.
+msgid "_Enterprise Login"
+msgstr "Sisselogimine _ettevõtte serverisse"
+
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"Sul pole õigust sellele seadmele ligi pääseda. Ligipääsu jaoks võta palun "
+"ühendust oma süsteemiadministraatoriga."
+
+msgid "The device is already in use."
+msgstr "Seade on juba kasutusel."
+
+msgid "An internal error occurred."
+msgstr "Tekkis sisemine viga."
+
+msgid "Enabled"
+msgstr "Lubatud"
+
+msgid "Delete registered fingerprints?"
+msgstr "Kas kustutada registreeritud sõrmejäljed?"
+
+msgid "_Delete Fingerprints"
+msgstr "_Kustuta sõrmejäljed"
+
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Kas sa tahad kustutada registreeritud sõrmejäljed, sellega keelatakse "
+"sõrmejäljega sisselogimine?"
+
+msgid "Done!"
+msgstr "Valmis!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "Seadmele '%s' puudub ligipääs"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "Ei suudetud alustada sõrmejälje salvestamist seadmel '%s'"
+
+msgid "Could not access any fingerprint readers"
+msgstr "Ühelegi sõrmejäljelugejale pole võimalik ligi pääseda"
+
+msgid "Please contact your system administrator for help."
+msgstr "Abi saamiseks võta palun ühendust oma süsteemiadministraatoriga."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"Sõrmejäljega sisselogimise kasutamiseks pead salvestama '%s' seadmega "
+"vähemalt ühe sõrmejälje."
+
+msgid "Selecting finger"
+msgstr "Sõrme valimine"
+
+msgid "Enrolling fingerprints"
+msgstr "Sõrmejälje sisestamine"
+
+msgid "This Week"
+msgstr "See nädal"
+
+msgid "Last Week"
+msgstr "Eelmine nädal"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+msgid "Session Ended"
+msgstr "Seanss lõppes"
+
+msgid "Session Started"
+msgstr "Seanss algas"
+
+msgid "Please choose another password."
+msgstr "Palun vali mõni muu parool."
+
+msgid "Please type your current password again."
+msgstr "Palun sisesta oma praegune parool uuesti."
+
+msgid "Password could not be changed"
+msgstr "Parooli pole võimalik muuta"
+
+msgid "The passwords do not match."
+msgstr "Paroolid ei klapi."
+
+msgid "Browse for more pictures"
+msgstr "Sirvi teisi pilte"
+
+msgid "Disable image"
+msgstr "Keela pilt"
+
+msgid "Take a photo…"
+msgstr "Pildista…"
+
+msgid "Browse for more pictures…"
+msgstr "Sirvi teisi pilte…"
+
+#, c-format
+msgid "Used by %s"
+msgstr "Seda kasutab %s"
+
+msgid "Cannot automatically join this type of domain"
+msgstr "Seda liiki domeeniga pole võimalik automaatselt ühenduda"
+
+#, c-format
+msgid "No such domain or realm found"
+msgstr "Sellist domeeni või valdust (realm) ei leitud"
+
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Pole võimalik sisse logida kasutajana %s domeenile %s"
+
+msgid "Invalid password, please try again"
+msgstr "Sobimatu parool, proovi uuesti"
+
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "Pole võimalik ühenduda %s domeenile: %s"
+
+msgid "Other Accounts"
+msgstr "Teised kontod"
+
+msgid "Failed to delete user"
+msgstr "Tõrge kasutaja kustutamisel"
+
+msgid "You cannot delete your own account."
+msgstr "Oma kontot pole võimalik kustutada."
+
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s on ikka veel sisse logitud"
+
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Kasutaja kustutamine tema sisselogimise ajal võib jätta süsteemi ohtlikusse "
+"seisu."
+
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "Kas tahad säilitada kasutaja %s failid?"
+
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Kodukataloogi, meilide ja ajutiste failide säilitamine on võimalik ka "
+"kasutajakonto kustutamisel."
+
+msgid "_Delete Files"
+msgstr "_Kustuta failid"
+
+msgid "_Keep Files"
+msgstr "_Säilita failid"
+
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Konto on keelatud"
+
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Määratakse järgmisel sisselogimisel"
+
+msgctxt "Password mode"
+msgid "None"
+msgstr "Puudub"
+
+msgid "Logged in"
+msgstr "Sisse logitud"
+
+msgid "Failed to contact the accounts service"
+msgstr "Tõrge kontoteenusega ühenduse võtmisel"
+
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Palun veendu, et AccountService on paigaldatud ja lubatud."
+
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Muutuste tegemiseks\n"
+"klõpsa esiteks ikoonil *"
+
+msgid "Create a user account"
+msgstr "Kasutajakonto loomine"
+
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Kasutaja loomiseks\n"
+"klõpsa esiteks * ikoonil"
+
+msgid "Delete the selected user account"
+msgstr "Valitud kasutajakonto kustutamine"
+
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Valitud kasutaja kustutamiseks\n"
+"klõpsa esiteks * ikoonil"
+
+msgid "My Account"
+msgstr "Minu konto"
+
+#, c-format
+msgid "A user with the username '%s' already exists."
+msgstr "Kasutajanimi '%s' on juba kasutusel."
+
+#, c-format
+msgid "The username is too long."
+msgstr "Kasutajanimi on liiga pikk."
+
+msgid "The username cannot start with a '-'."
+msgstr "Kasutajanimi ei tohi alata märgiga '-'."
+
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"Kasutajanimi peaks koosnema ladina suur- ja väiketähtedest, numbritest ning "
+"märkidest '.', '-' ja '_'."
+
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+"Seda kasutatakse kodukausta nimena ning seda pole võimalik hiljem muuta."
+
+#. Translators: This is a date format string in the style of "Feb 24".
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+msgid "%b %e, %Y"
+msgstr "%e. %b %Y"
+
+msgid "Map Buttons"
+msgstr "Nuppude ühendamine"
+
+msgid "Map buttons to functions"
+msgstr "Nuppude ühendamine tegevustega"
+
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Välksõrmise muutmiseks vali \"Saada klahvivajutus\", klõpsa vastaval real ja "
+"määra uus sõrmis või vajuta nullimiseks Backspace (kustutamise) klahvi."
+
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Tahvli kalibreerimiseks vajuta markeritele seal, kus need ekraanile ilmuvad."
+
+msgid "Mis-click detected, restarting..."
+msgstr "Tuvastati vale klõps. Alustatakse uuesti..."
+
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "Üles"
+
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "Alla"
+
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "Puudub"
+
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Klaviatuurivajutuse saatmine"
+
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Monitori vahetamine"
+
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Abi kuvamine ekraanil"
+
+msgid "Output:"
+msgstr "Väljund:"
+
+#. Keep ratio switch
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Külgede suhte säilitamine:"
+
+#. Whole-desktop checkbox
+msgid "Map to single monitor"
+msgstr "Määratud ühele monitorile"
+
+#, c-format
+msgid "%d of %d"
+msgstr "%d / %d"
+
+msgid "Display Mapping"
+msgstr "Kuvade ühendamine"
+
+msgid "Button"
+msgstr "Nupp"
+
+msgid "Wacom Tablet"
+msgstr "Wacomi digitaallaud"
+
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Digitaallaudade nuppude vastavuse ja kirjapulga tundlikkuse muutmine"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+"Tablet;Digitaallaud;Wacom;Stylus;Stiilus;Kirjapulk;Kustutaja;Kustukumm;Hiir;"
+
+msgid "Tablet (absolute)"
+msgstr "Digitaallaud (absoluutne)"
+
+msgid "Touchpad (relative)"
+msgstr "Puutepadi (suhteline)"
+
+msgid "Tablet Preferences"
+msgstr "Digitaallaua eelistused"
+
+msgid "No tablet detected"
+msgstr "Digitaallauda ei leitud"
+
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Ühenda või lülita sisse oma Wacom'i digitaallaud"
+
+msgid "Bluetooth Settings"
+msgstr "Bluetoothi seaded"
+
+msgid "Map to Monitor…"
+msgstr "Monitoriga ühendamine…"
+
+msgid "Map Buttons…"
+msgstr "Nuppude ühendamine…"
+
+msgid "Adjust display resolution"
+msgstr "Kuvari eraldusvõime muutmine"
+
+msgid "Adjust mouse settings"
+msgstr "Hiireseadete muutmine"
+
+msgid "Tracking Mode"
+msgstr "Jälitamise režiim"
+
+msgid "Left-Handed Orientation"
+msgstr "Vasaku- või paremakäeliste hiir"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+msgid "Left Ring"
+msgstr "Vasak ratas"
+
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "Vasaku ratta režiim %d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+msgid "Right Ring"
+msgstr "Parem ratas"
+
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "Parema ratta režiim %d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+msgid "Left Touchstrip"
+msgstr "Vasak puuteriba"
+
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "Vasak puuteriba režiim %d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+msgid "Right Touchstrip"
+msgstr "Parem puuteriba"
+
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "Parem puuteriba režiim %d"
+
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "Vasaku puuteringi režiimi lüliti"
+
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "Parema puuteringi režiimi lüliti"
+
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "Vasaku puuteriba režiimi lüliti"
+
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "Parema puuteriba režiimi lüliti"
+
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "Režiimilüliti %d"
+
+#, c-format
+msgid "Left Button #%d"
+msgstr "Vasak nupp %d"
+
+#, c-format
+msgid "Right Button #%d"
+msgstr "Parem nupp %d"
+
+#, c-format
+msgid "Top Button #%d"
+msgstr "Ülemine nupp %d"
+
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "Alumine nupp %d"
+
+msgid "New shortcut…"
+msgstr "Uus kiirklahv…"
+
+msgid "No Action"
+msgstr "Tegevus puudub"
+
+msgid "Left Mouse Button Click"
+msgstr "Vasaku hiirenupu klõps"
+
+msgid "Middle Mouse Button Click"
+msgstr "Keskmise hiirenupu klõps"
+
+msgid "Right Mouse Button Click"
+msgstr "Parema hiirenupu klõps"
+
+msgid "Scroll Up"
+msgstr "Üles kerimine"
+
+msgid "Scroll Down"
+msgstr "Alla kerimine"
+
+msgid "Scroll Left"
+msgstr "Vasakule kerimine"
+
+msgid "Scroll Right"
+msgstr "Paremale kerimine"
+
+msgid "Back"
+msgstr "Tagasi"
+
+msgid "Forward"
+msgstr "Edasi"
+
+msgid "Stylus"
+msgstr "Kirjapulk"
+
+msgid "Eraser Pressure Feel"
+msgstr "Kustutaja survetundlikkus"
+
+msgid "Soft"
+msgstr "Pehme"
+
+msgid "Firm"
+msgstr "Tugev"
+
+msgid "Top Button"
+msgstr "Ülemine nupp"
+
+msgid "Lower Button"
+msgstr "Alumine nupp"
+
+msgid "Tip Pressure Feel"
+msgstr "Otsa survetundlikkus"
+
+msgid "Enable verbose mode"
+msgstr "Jutuka režiimi lubamine"
+
+msgid "Show the overview"
+msgstr "Ülevaate näitamine"
+
+msgid "Search for the string"
+msgstr "Teksti otsimine"
+
+msgid "List possible panel names and exit"
+msgstr "Võimalike paneelinimed kuvamine ja väljumine"
+
+msgid "Show help options"
+msgstr "Abiteabe võtmete näitamine"
+
+msgid "Panel to display"
+msgstr "Kuvatav paneel"
+
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEEL] [ARGUMENT…]"
+
+msgid "- Settings"
+msgstr "- sätted"
+
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"Kõigi saadaolevate käsureavõtmete vaatamiseks käivita '%s --help'.\n"
+
+msgid "Available panels:"
+msgstr "Saadaolevad paneelid:"
+
+msgid "Help"
+msgstr "Abi"
+
+msgid "Quit"
+msgstr "Lõpeta"
+
+msgid "All Settings"
+msgstr "Kõik seaded"
+
+#. Add categories
+msgctxt "category"
+msgid "Personal"
+msgstr "Isiklik"
+
+msgctxt "category"
+msgid "Hardware"
+msgstr "Riistvara"
+
+msgctxt "category"
+msgid "System"
+msgstr "Süsteem"
+
+msgid "Settings"
+msgstr "Sätted"
+
+msgid "Preferences;Settings;"
+msgstr "Eelistused;Sätted;Seaded;Seadistused;"
+
+#~ msgid "_Done"
+#~ msgstr "_Valmis"
+
+#~ msgid "Immediately"
+#~ msgstr "Koheselt"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Install Updates"
+#~ msgstr "Paigalda uuendused"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Süsteem on värske"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Võrguprinterite või filtrite otsimine"
+
+#~ msgid "_Default"
+#~ msgstr "_Vaikimisi"
+
+#~ msgid "Remote View"
+#~ msgstr "Kaugvaade"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Kõigi ühenduste heakskiitmine"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Uue seadme seadistamine"
+
+#~ msgid "Connection"
+#~ msgstr "Ühendus"
+
+#~ msgid "Paired"
+#~ msgstr "Paaris"
+
+#~ msgid "Type"
+#~ msgstr "Tüüp"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Hiire ja puutepadja seaded"
+
+#~ msgid "Sound Settings"
+#~ msgstr "Heliseaded"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Klahvistiku seaded"
+
+#~ msgid "Send Files…"
+#~ msgstr "Saada faile…"
+
+#~ msgid "Visibility"
+#~ msgstr "Nähtavus"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” nähtavus"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Kas eemaldada '%s' seadmete nimekirjast?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Kui eemaldad seadme, siis pead sa selle enne järgmist kasutamist uuesti "
+#~ "seadistama."
+
+#~ msgid "Device type:"
+#~ msgstr "Seadme tüüp:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Tootja:"
+
+#~ msgid "Model:"
+#~ msgstr "Mudel:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "Ülalolevate väljade täitmiseks saab siia aknasse pilte lohistada."
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "Sellel ekraanil näidatakse ka sinu peamist kuva"
+
+#~ msgid "Combine"
+#~ msgstr "Kombineeritud"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "Ühendatud peamise ekraaniga, et luua lisaruum"
+
+#~ msgid "Don't use the display"
+#~ msgstr "Seda ekraani ei kasutata"
+
+#~ msgid "Refresh Rate"
+#~ msgstr "Värskendussagedus"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Hiire-eelistused"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Vali uue teenuse jaoks liides"
+
+#~ msgid "C_reate…"
+#~ msgstr "_Loo…"
+
+#~ msgid "_Interface"
+#~ msgstr "_Liides"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Pole"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Avaliku kausta jagamine"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Ainult usaldatud seadmetega jagamine"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Kasutaja foto vahetamine:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "Vali pilt, mida kuvatakse sisselogimise aknas selle konto jaoks."
+
+#~ msgid "Gallery"
+#~ msgstr "Galerii"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Pildista"
+
+#~ msgid "Browse"
+#~ msgstr "Lehitse"
+
+#~ msgid "Photograph"
+#~ msgstr "Foto"
+
+#~ msgid "Account Information"
+#~ msgstr "Konto andmed"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Vaheta EL ja PL vahel."
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "Hinnanguline aku mahutavus: %s"
+
+#~ msgid "Export"
+#~ msgstr "Eksport"
+
+#~ msgid "Left Shift"
+#~ msgstr "Vasak Shift"
+
+#~ msgid "Left Alt"
+#~ msgstr "Vasak Alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "Vasak Ctrl"
+
+#~ msgid "Right Shift"
+#~ msgstr "Parem Shift"
+
+#~ msgid "Right Alt"
+#~ msgstr "Parem Alt"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Parem Ctrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Vasak Alt+Shift"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Parem Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Vasak Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Parem Ctrl+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Vasak+parem Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Vasak+parem Ctrl"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "Caps"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "_Region:"
+#~ msgstr "Piirkond:"
+
+#~ msgid "_City:"
+#~ msgstr "_Linn:"
+
+#~ msgid "_Network Time"
+#~ msgstr "_Võrguaeg"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Keera kell üks tund ette."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Keera kell üks tund taha."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Keera kell üks minut ette."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Keera kell üks minut taha."
+
+#~ msgid "AM/PM"
+#~ msgstr "EL/PL"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Tavaline"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "Vastupäeva"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Päripäeva"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 kraadi"
+
+#~ msgid "Monitor"
+#~ msgstr "Kuvar"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "Lohista peakuva muutmiseks."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Omaduste muutmiseks vali kuvar. Asukoha muutmiseks lohista see uuele "
+#~ "asukohale."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Kuvari sätteid pole võimalik salvestada"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Eraldusvõime"
+
+#~ msgid "R_otation"
+#~ msgstr "_Pööramine:"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "Kuvad on pee_geldatud"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Märkus: võib piirata eraldusvõime valikuid"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "_Tuvasta kuvad"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "Aeglane"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "Kiire"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "_Sisu kleepub sõrmede külge"
+
+#~ msgid "blablabla"
+#~ msgstr "blablabla"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "Aadressi\n"
+#~ "sekstioon\n"
+#~ "tuleb\n"
+#~ "siia"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNSi\n"
+#~ "sekstioon\n"
+#~ "tuleb\n"
+#~ "siia"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "Marsruutide\n"
+#~ "sekstioon\n"
+#~ "tuleb\n"
+#~ "siia"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "Hidden"
+#~ msgstr "Varjatud"
+
+#~ msgid "Visible"
+#~ msgstr "Nähtav"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "Nimi ja nähtavus"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "Muuda, kuidas sind kuvatakse ekraanil ja võrgus."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "Ülemisel ribal  _kogu nime kuvamine"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "Lukustusekraanil _kogu nime kuvamine"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "_Varjatud režiim"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Tavaline"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Kõrge/pööratud värvidega"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Ekraaniklaviatuur"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Tavaline"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "Suurem"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Piiksumine Caps Lock / Num Lock kasutamisel"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "Lülita sisse või välja:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Suurendus"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Suurendamine:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Vähendamine:"

--- a/po/eu.po
+++ b/po/eu.po
@@ -8,9 +8,10 @@
 # Asier Sarasua Garmendia <asiersarasua@ni.eus>, 2013, 2019, 2020, 2021, 2022.
 #
 msgid ""
-msgstr "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issues\n"
-"POT-Creation-Date: 2022-08-28 14:52+0000\n"
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-08-31 14:00+0100\n"
 "Last-Translator: Asier Sarasua Garmendia <asiersarasua@ni.eus>\n"
 "Language-Team: Basque <librezale@librezale.eus>\n"
@@ -20,97 +21,7 @@ msgstr "Project-Id-Version: gnome-control-center master\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Sistemaren bus-a"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Sarbide osoa"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Saioaren bus-a"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Gailuak"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Sarbide osoa /dev direktoriora"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Sarea"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Sarea atzitu dezake"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Karpeta nagusia"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Irakurtzeko soilik"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Fitxategi-sistema"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Ezarpenak"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Ezarpenak aldatu ditzake"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr "%s aplikazioak honako baimenak ditu integratuta. Baimen horiek ezin dira aldatu. Baimen horien inguruko kezkaren bat baduzu, beharbada aplikazio hori kendu beharko zenuke."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "Aplikazioak irekitzen dituen %u fitxategi eta esteka mota"
-msgstr[1] "Aplikazioak irekitzen dituen %u fitxategi eta esteka motak"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> hurrengo fitxategi motak eta estekak irekitzeko erabiltzen da."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "Erabilitako disko-espazioa: %s."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -126,7 +37,6 @@ msgid "Install some…"
 msgstr "Instalatu zenbait…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Ireki"
 
@@ -150,24 +60,13 @@ msgstr "Bilatu"
 msgid "Receive system searches and send results."
 msgstr "Jaso sistemaren bilaketak eta bidali emaitzak."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Desgaituta"
 
@@ -305,7 +204,8 @@ msgstr "Berrezarri"
 #: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
-msgstr "Diskoko zenbat espazio betetzen ari den aplikazio hau datuekin eta cacheekin."
+msgstr ""
+"Diskoko zenbat espazio betetzen ari den aplikazio hau datuekin eta cacheekin."
 
 #: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
@@ -331,80 +231,20 @@ msgstr "Garbitu cachea…"
 msgid "Control various application permissions and settings"
 msgstr "Kontrolatu aplikazioen baimenak eta ezarpenak"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplikazioa;flatpack;baimena;ezarpena;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Hautatu argazki bat"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Utzi"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Ireki"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "hainbat tamaina"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Mahaigaineko atzeko planorik ez"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Uneko atzeko planoa"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Estiloa"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Lehenetsia"
 
@@ -428,10 +268,10 @@ msgstr "Itxura"
 msgid "Change your background image or the UI colors"
 msgstr "Aldatu atzeko planoko irudia edo interfazearen koloreak"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
-msgstr "Atzeko planoa;Horma-papera;Pantaila;Mahaigaina;Estiloa;Argia;Iluna;Itxura;"
+msgstr ""
+"Atzeko planoa;Horma-papera;Pantaila;Mahaigaina;Estiloa;Argia;Iluna;Itxura;"
 
 #: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
 #: panels/datetime/cc-datetime-panel.ui:172
@@ -479,9 +319,7 @@ msgstr "Hardwarearen hegazkin modua piztuta dago"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Itzali hegazkin modua Bluetooth-a gaitzeko."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -489,7 +327,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Aktibatu eta desaktibatu Bluetooth eta konektatu gailuak"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "partekatu;partekatzea;bluetooth;obex;"
@@ -508,7 +345,10 @@ msgid ""
 "the camera may cause some applications to not function properly.\n"
 "\n"
 "Allow the applications below to use your camera."
-msgstr "Kamera erabilita, aplikazioek argazkiak eta bideoak kaptura ditzakete. Kamera desgaitzen bada, beharbada zenbait aplikaziok ez dute behar den moduan funtzionatuko.\n"
+msgstr ""
+"Kamera erabilita, aplikazioek argazkiak eta bideoak kaptura ditzakete. "
+"Kamera desgaitzen bada, beharbada zenbait aplikaziok ez dute behar den "
+"moduan funtzionatuko.\n"
 "\n"
 "Baimendu beheko aplikazioei zure kamera erabiltzea."
 
@@ -520,89 +360,33 @@ msgstr "Ez dago aplikaziorik kamera erabiltzeko baimena eskatu duenik"
 msgid "Protect your pictures"
 msgstr "Babestu zure irudiak"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "kamera;argazkiak;bideoa;webkamera;blokeatu;pribatua;pribatutasuna;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Jarri kalibrazioaren gailua karratuaren gainean eta egin klik \"Hasi\" botoian"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "Mugitu kalibrazioaren gailua posizioa kalibratzeko eta egin klik  \"Jarraitu\" botoian"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Mugitu kalibrazioaren gailua gainazalaren posiziora eta egin klik  \"Jarraitu\" botoian"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Itxi eramangarriaren estalkia"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Berreskura ezin daitekeen barneko errorea gertatu da."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Kalibratzeko behar diren tresnak ez daude instalatuta."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Ezin izan da profila sortu."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Ez da helburuko puntu zuria eskuratu."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Osatuta!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrazioak huts egin du."
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Kalibrazioaren gailua ken dezakezu."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ez mugitu kalibrazioaren gailua lanean ari den bitartean"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Pantailaren kalibrazioa"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Utzi"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -620,138 +404,6 @@ msgstr "_Jarraitu"
 msgid "_Done"
 msgstr "_Eginda"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Eramangarriaren pantaila"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Web-kamera integratuta"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s pantaila"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s eskanerra"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s kamera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s inprimagailua"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s web-kamera"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Gaitu '%s'(r)en kolore-kudeaketa"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Erakutsi '%s'(r)en kolore-profilak"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Kalibratu gabea"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Lehenetsia: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Kolore-espazioa: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Probako profila: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Hautatu ICC profilaren fitxategia"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Inportatu"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Onartutako ICC profilak"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Fitxategi denak"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Pantaila"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Gorde profila"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Gorde"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Sortu kolore-profil bat hautatutako gailuarentzako"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "Ez da neurgailurik detektatu. Ziurtatu zaitez piztuta eta ongi konektatuta dagoela."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Neurgailuak ez du inprimagailuaren profilarik onartzen"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Gailu mota ez dago oraingoz onartuta."
-
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Pantailaren kalibrazioa"
@@ -765,7 +417,10 @@ msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
-msgstr "Kalibrazioak profil bat sortuko du pantailaren kolorea kudeatzeko. Kalibrazioa zenbat eta sakonagoa izan, kolore-profilaren kalitatea hobea izango da."
+msgstr ""
+"Kalibrazioak profil bat sortuko du pantailaren kolorea kudeatzeko. "
+"Kalibrazioa zenbat eta sakonagoa izan, kolore-profilaren kalitatea hobea "
+"izango da."
 
 #: panels/color/cc-color-panel.ui:28
 msgid ""
@@ -806,7 +461,9 @@ msgstr "Profilaren puntu zuria"
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
-msgstr "Hautatu helburuko pantailaren puntu zuria. Pantaila gehienak D65 argitasunera doitu beharko lirateke."
+msgstr ""
+"Hautatu helburuko pantailaren puntu zuria. Pantaila gehienak D65 "
+"argitasunera doitu beharko lirateke."
 
 #: panels/color/cc-color-panel.ui:187
 msgid "Display Brightness"
@@ -816,13 +473,17 @@ msgstr "Pantailaren distira"
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
-msgstr "Ezarri pantailan zuretzako ohikoa den distira. Kolorearen kudeaketa zehatzagoa izango da distiraren maila horretan."
+msgstr ""
+"Ezarri pantailan zuretzako ohikoa den distira. Kolorearen kudeaketa "
+"zehatzagoa izango da distiraren maila horretan."
 
 #: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
-msgstr "Bestela, gailu honen beste profiletariko batekin erabilitako distiraren maila erabil dezakezu"
+msgstr ""
+"Bestela, gailu honen beste profiletariko batekin erabilitako distiraren "
+"maila erabil dezakezu"
 
 #: panels/color/cc-color-panel.ui:214
 msgid "Profile Name"
@@ -832,7 +493,9 @@ msgstr "Profilaren izena"
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
-msgstr "KOlore-profila bat erabil dezakezu ordenagailu desberdinetan, edo argitasun baldintza desberdinetarako profilak sor ditzakezu baita ere."
+msgstr ""
+"KOlore-profila bat erabil dezakezu ordenagailu desberdinetan, edo argitasun "
+"baldintza desberdinetarako profilak sor ditzakezu baita ere."
 
 #: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
@@ -856,10 +519,14 @@ msgstr "Euskarri idazgarria behar da"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr "You may find these instructions on how to use the profile on Profila <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> eta <a href=\"windows\">Microsoft Windows</a> sistemetan nola erabil daitekeen buruzko informazioa lagungarri gerta dakizuke."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"You may find these instructions on how to use the profile on Profila <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> eta <a "
+"href=\"windows\">Microsoft Windows</a> sistemetan nola erabil daitekeen "
+"buruzko informazioa lagungarri gerta dakizuke."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -869,7 +536,9 @@ msgstr "Gehitu profila"
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
-msgstr "Arazoak aurkitu dira. Baliteke profilak ongi ez funtzionatzea. <a href=\"\">Erakutsi xehetasunak.</a>"
+msgstr ""
+"Arazoak aurkitu dira. Baliteke profilak ongi ez funtzionatzea. <a "
+"href=\"\">Erakutsi xehetasunak.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -877,7 +546,6 @@ msgstr "_Inportatu fitxategia…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -885,11 +553,10 @@ msgstr "_Gehitu"
 
 #: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
-msgstr "Gailu bakoitzak koloreen profilaren eguneratzea behar du koloreak kudeatzeko."
+msgstr ""
+"Gailu bakoitzak koloreen profilaren eguneratzea behar du koloreak kudeatzeko."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Ikasi gehiago"
 
@@ -1021,82 +688,6 @@ msgstr "D65 (argazki eta grafikoak)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Espazio estandarrak"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Probako profila"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatikoa"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Kalitate baxua"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Tarteko kalitatea"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Kalitate altua"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "GBU lehenetsia"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK lehenetsia"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Grisa lehenetsia"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Saltzaileak emandako kalibrazioaren fabrikako datuak"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Pantaila osoko zuzenketa ezinezkoa da profila honekin"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Profila hau ezingo da gehiago zehatza izan"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Kolorea"
@@ -1106,14 +697,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Kalibratu pantaila, kamera edo inprimagailuak bezalako gailuen kolorea"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Kolorea;ICC;Profila;Kalibratu;Inprimagailua;Pantaila;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Bestelakoa…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1128,13 +714,8 @@ msgid "No languages found"
 msgstr "Ez da hizkuntzarik aurkitu"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Gehiago…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Desblokeatu ezarpenak aldatzeko"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1163,151 +744,6 @@ msgstr "Gutxitu orduak"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Gutxitu minutuak"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Gaur"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Atzo"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b/%e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%Y/%b/%e"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "ordu %d"
-msgstr[1] "%d ordu"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "minutu %d"
-msgstr[1] "%d minutu"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "segundo %d"
-msgstr[1] "%d segundo"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 segundo"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Wifigunea"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 ordu"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%Y/%B/%e, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%Y/%B/%e, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1400,19 +836,15 @@ msgstr "Ordu-_zona automatikoa"
 
 #: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
-msgstr "Kokaleku-zerbitzuek gaituta egon behar dute eta Interneterako sarbide eduki behar da"
+msgstr ""
+"Kokaleku-zerbitzuek gaituta egon behar dute eta Interneterako sarbide eduki "
+"behar da"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Gaituta"
 
@@ -1420,15 +852,43 @@ msgstr "Gaituta"
 msgid "Time Z_one"
 msgstr "Ordu-_zona"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desblokeatu"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Orduaren _formatua"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datak"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 segundo"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Egutegia"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Zenbakiak"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Aldatu data eta ordua, ordu-zona barne"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Erlojua;Ordu-zona;Kokalekua;"
@@ -1439,7 +899,9 @@ msgstr "Aldatu sistemaren ordua eta dataren ezarpenak"
 
 #: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
-msgstr "Sistemaren ordua eta dataren ezarpenak aldatzeko, autentifikatu egin behar zara."
+msgstr ""
+"Sistemaren ordua eta dataren ezarpenak aldatzeko, autentifikatu egin behar "
+"zara."
 
 #: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
@@ -1474,18 +936,9 @@ msgstr "Aplikazio lehenetsiak"
 msgid "Configure Default Applications"
 msgstr "Konfiguratu aplikazio lehenetsiak"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "lehenetsia;aplikazioa;hobetsia;euskarria;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr "Arazo teknikoei buruzko txostenak bidaltzean %s hobetzen laguntzen diguzu. Txostenak modu anonimoan bidaltzen dira eta ez dute datu pertsonalik. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1503,44 +956,9 @@ msgstr "Diagnostikoa"
 msgid "Report your problems"
 msgstr "Eman zure arazoen berri"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostikoak;kraskadura;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Aktibatuta"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Desaktibatuta"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Aplikatu aldaketak?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Aldaketak ezin dira aplikatu"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Hardwarearen mugen erruz izan daiteke."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1590,31 +1008,6 @@ msgstr "Pantaila nagusia"
 msgid "Night Light"
 msgstr "Gaueko argia"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Horizontala"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Bertikala eskuinera"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Bertikala ezkerrera"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Horizontala (iraulita)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1639,6 +1032,17 @@ msgctxt "display setting"
 msgid "Scale"
 msgstr "Eskalatu"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Korritze naturala"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
 msgstr "“Gaueko argia” ez dago erabilgarri"
@@ -1647,7 +1051,9 @@ msgstr "“Gaueko argia” ez dago erabilgarri"
 msgid ""
 "This could be the result of the graphics driver being used, or the desktop "
 "being used remotely"
-msgstr "Gailuak duen txartel grafikoaren emaitza izan daiteke, edo urrunean erabiltzen ari den mahaigainaren ondorioz"
+msgstr ""
+"Gailuak duen txartel grafikoaren emaitza izan daiteke, edo urrunean "
+"erabiltzen ari den mahaigainaren ondorioz"
 
 #. Inhibit the redshift functionality until the next day starts
 #: panels/display/cc-night-light-page.ui:58
@@ -1663,7 +1069,9 @@ msgstr "Berrabiarazi iragazkia"
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
-msgstr "Gaueko argiaren moduak pantailaren kolorea epeltzen du. Horrek begien estresa eta lo arazoak saihesten lagun dezake."
+msgstr ""
+"Gaueko argiaren moduak pantailaren kolorea epeltzen du. Horrek begien "
+"estresa eta lo arazoak saihesten lagun dezake."
 
 #: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
@@ -1729,71 +1137,13 @@ msgstr "Pantailak"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Aldatu konektatutako pantaila eta proiektagailuak nola erabiliko diren"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
-msgstr "Panela;Proiektagailua;xrandr;Pantaila;Bereizmena;Freskatu;Monitorea;Gaua;Argia;Urdina;kolorea;egunsentia;ilunabarra;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Abio segurua aktibatuta dago"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria kargatu dadin. Une honetan aktibatuta dago eta ongi funtzionatzen du."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Abio seguruak arazoak ditu"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria kargatu dadin. Une honetan aktibatuta dago, baina ez du funtzionatuko gako baliogabea duelako."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr "Abio seguruaren arazoak sarritan ordenagailuaren UEFI firmwarearen ezarpenak (BIOS) aldatuz konpontzen dira. Hardwarearen fabrikatzaileak horri buruzko informazio gehiago eman diezazuke."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "Laguntza jasotzeko, jarri harremanetan zure hardwarearen fabrikatzailearekin edo laguntza informatikoa ematen dizunarekin."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Abio segurua desaktibatuta dago"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria kargatu dadin. Une honetan desaktibatuta dago."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr "Abio segurua sarritan ordenagailuaren UEFI firmware-ezarpenetan (BIOS) aktibatu daiteke. Laguntza jasotzeko, hitz egin zure hardwarearen fabrikatzailearekin edo laguntza informatikoa ematen dizunarekin."
+msgstr ""
+"Panela;Proiektagailua;xrandr;Pantaila;Bereizmena;Freskatu;Monitorea;Gaua;"
+"Argia;Urdina;kolorea;egunsentia;ilunabarra;"
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1801,119 +1151,16 @@ msgid ""
 "starts.\n"
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
-msgstr "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria kargatu dadin.\n"
+msgstr ""
+"Abio seguruak eragozten du gailua abiarazten denean software kaltegarria "
+"kargatu dadin.\n"
 "\n"
-"Informazio gehiagorako, jarri harremanetan hardwarearen fabrikatzailearekin edo informatikako teknikariekin."
+"Informazio gehiagorako, jarri harremanetan hardwarearen fabrikatzailearekin "
+"edo informatikako teknikariekin."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Pasatu da"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Huts egin du"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Gailuak HSI %d maila betetzen du"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:485
-msgid "Security Level 0"
-msgstr "Segurtasun-maila: 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr "Gailu honek ez du babesik hardwareko segurtasun-arazoen aurrean. Hardareko edo firmwareko konfigurazio-arazo baten ondorioa izan daiteke hori. Zure informatikako teknikariekin hitz egin dezazun gomendatzen dizugu."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:492
-msgid "Security Level 1"
-msgstr "Segurtasun-maila: 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr "Gailu honek guxieneko babesa du hardwareko segurtasun-arazoen aurrean. Gailuaren segurtasun-mailarik txikiena da eta segurtasun-arrisku sinpleen aurkako babesa soilik eskaintzen du."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:499
-msgid "Security Level 2"
-msgstr "Segurtasun-maila: 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr "Gailu honek oinarrizko babesa du hardwareko segurtasun-arazoen aurrean. Horrek segurtasun-arrisku arruntenen aurkako babesa eskaintzen du."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:506
-msgid "Security Level 3"
-msgstr "Segurtasun-maila: 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr "Gailu honek babes hedatua du hardwareko segurtasun-arazoen aurrean. Gailuaren segurtasun-mailarik altuena da eta segurtasun-arrisku aurreratuen aurkako babesa eskaintzen du."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:521
 msgid "Security Level"
 msgstr "Segurtasun-maila"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:522
-msgid "Security levels are not available for this device."
-msgstr "Segurtasun-mailak ez daude erabilgarri gailu honetarako."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr "Jarri harremanetan zure hardwarearen fabrikatzailearekin segurtasun-eguneratzeei buruzko laguntza jasotzeko."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr "Agian arazo hori gailuaren UEFI firmware-ezarpenetan konpondu daiteke, edo informatikako teknikariaren laguntzarekin."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr "Agia arazo hori gailuaren UEFI firmware-ezarpenetan konpondu daiteke."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Agian zure informatikako teknikariak lagundu ahal dizu arazoa konpontzen."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -1927,331 +1174,9 @@ msgstr "2. maila"
 msgid "Level 3"
 msgstr "3. maila"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Software kaltegarriaren aurka babestua gailua abiarazten denean,"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Abio seguruak arazoak ditu"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Nolabaiteko babesa gailua abiarazten denean."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Abio segurua desaktibatuta dago"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Babesik ez gailua abiarazten denean."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr "Arazoa UEFI firmware-ezarpenetan aldaketa bat egon delako sortu da agian, edo sistema eragilearen konfigurazio-aldaketa bat egon delako edo software kaltegarria sartu delako sisteman."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr "Arazoa UEFI firmware-ezarpenetan aldaketa bat egon delako sortu da agian, edo software kaltegarria sartu delako sisteman."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr "Arazoa sistema eragilearen konfigurazio-aldaketa bat egon delako sortu da agian, edo software kaltegarria sartu delako sisteman."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Exposed to serious security threats."
-msgstr "Segurtasun-arriskuen aurrean kaltebera."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Limited protection against simple security threats."
-msgstr "Babes mugatua segurtasun-arrisku sinpleen aurrean."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Protected against common security threats."
-msgstr "Babestua segurtasun-arrisku arrunten aurrean."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Protected against a wide range of security threats."
-msgstr "Babestua segurtasun-arrikus asktoren aurrean."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:514
-msgid "Comprehensive Protection"
-msgstr "Babes osoa"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Gertaerarik ez"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Firmwarearen idazketa-babesa"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Firmwarearen idazketa-babesaren blokeoa"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Firmwarearen BIOS eskualdea"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Firmwarearen BIOS deskribatzailea"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Abio aurreko DMA babesa"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard abio egiaztatua"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM babestua"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard errore-politika"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard fusiblea"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET gaituta"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET aktibo"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Zifratutako RAMa"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU babesa"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux kernelaren blokeoa"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linux kernelaren egiaztatzea"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux trukatze-espazioa"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Eseki RAMera"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Eseki inaktibora"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI plataforma-gakoa"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI abio segurua"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TMP plataformaren konfigurazioa"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM berreraikuntza"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel kudeaketa-motorraren manufaktura modua"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Intel kudeaketa-motorraren indargabetzea"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Intel Management Engine bertsioa"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Firmwarearen eguneratzeak"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Firmwarearen egiaztatzea"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Firmware-eguneratzailearen egiaztatzea"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Plataforma-arazketa"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Prozesadore-segurtasunaren egiaztatzeak"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMDren desinstalazio-babesa"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD firmwarearen errepikapen-babesa"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "AMD firmwarearen idazketa-babesa"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Fusionatutako plataforma"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Baliozkoa"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Ez baliozkoa"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Ez gaitua"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Blokeatua"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Ez blokeatua"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Zifratua"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Ez zifratua"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Kutsatua"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Ez kutsatua"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Aurkitua"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Ez aurkitua"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Onartua"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Ez onartua"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2261,55 +1186,13 @@ msgstr "Gailu-segurtasuna"
 msgid "Host firmware security status"
 msgstr "Ostalari-firmwarearen segurtasun-egoera"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
 "network;identity;privacy;"
-msgstr "pantaila;blokeoa;diagnostikoa;kraskadura;pribatua;azkena;aldi baterakoa;tmp;indizea;izena;sarea;identitatea;pribatutasuna;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Ezezaguna"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64 bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32 bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Ezezaguna"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Ez dago erabilgarri"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Sistemaren logoa"
+msgstr ""
+"pantaila;blokeoa;diagnostikoa;kraskadura;pribatua;azkena;aldi baterakoa;tmp;"
+"indizea;izena;sarea;identitatea;pribatutasuna;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2383,7 +1266,9 @@ msgstr "Aldatu gailuaren izena"
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
-msgstr "Gailuaren izena hura identifikatzeko erabiltzen da sarean barrena bistaratzen denean, edo Bluetooth gailuekin parekatzen denean."
+msgstr ""
+"Gailuaren izena hura identifikatzeko erabiltzen da sarean barrena "
+"bistaratzen denean, edo Bluetooth gailuekin parekatzen denean."
 
 #: panels/info-overview/cc-info-overview-panel.ui:196
 msgid "Device name"
@@ -2401,16 +1286,14 @@ msgstr "Honi buruz"
 msgid "View information about your system"
 msgstr "Ikusi sistemari buruzko informazioa"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
 "application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr "gailua;sistema;informazioa;ostalari-izena;memoria;prozesadorea;bertsioa;lehenetsia;aplikazioa;hobetsia;cd;dvd;usb;audioa;bideoa;diskoa;aldagarria;euskarria;auto-exekuzioa;"
+msgstr ""
+"gailua;sistema;informazioa;ostalari-izena;memoria;prozesadorea;bertsioa;"
+"lehenetsia;aplikazioa;hobetsia;cd;dvd;usb;audioa;bideoa;diskoa;aldagarria;"
+"euskarria;auto-exekuzioa;"
 
 #: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
@@ -2481,6 +1364,12 @@ msgstr "Abiarazleak"
 msgid "Launch help browser"
 msgstr "Abiatu laguntza-arakatzailea"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Ezarpenak"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Abiarazi kalkulagailua"
@@ -2502,7 +1391,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Bilatu"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
@@ -2551,15 +1440,6 @@ msgstr "Txikiagotu testuaren tamaina"
 msgid "High contrast on or off"
 msgstr "Gaitu edo desgaitu kontraste altua"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Ez da sarrerako iturbururik aurkitu"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Bestelakoa"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Gehitu sarrerako iturburua"
@@ -2592,99 +1472,9 @@ msgstr "Hobespenak"
 msgid "View Keyboard Layout"
 msgstr "Bistaratu teklatuaren diseinua"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Kendu"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Laster-tekla pertsonalizatuak"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Ordezko karaktereen tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr "Ordezko karaktereen tekla karaktere gehigarriak sartzeko erabil daiteke. Batzuetan hirugarren aukera gisa inprimatuta ageri dira zure teklatuan."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Ezkerreko Alt tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Eskuineko Alt tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Ezkerreko Super tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Eskuineko Super tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menu tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Eskuineko Ctrl tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Compose tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr "Compose teklak mota askotako karaktereak sartzea ahalbidetzen du. Hura erabiltzeko, sakatu Compose tekla eta, ondoren, karaktereen sekuentzia bat. Adibidez, Compose tekla sakatuta, eta ondoren <b>C</b> eta <b>o</b> erabilita, <b>©</b> sartuko du; <b>a</b> eta ondoren <b>'</b> erabilita, <b>á</b> sartuko du."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Maiuskulak blokeatzeko tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Korritzea blokeatzeko tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Pantaila inprimatzeko tekla"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr "Sarrerako iturburuak %s lasterbidea erabilita txandakatu daitezke.\n"
-"Lasterbide hori ezarpenetan aldatu daiteke."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2714,43 +1504,21 @@ msgstr "Karaktere bereziaren sarrera"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Teklatuaren bidez ikurrak eta letren aldaerak sartzeko metodoak."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Ordezko karaktereen tekla"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose tekla"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Laster-teklak"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Ikusi eta pertsonalizatu laster-teklak"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d aldatu da"
-msgstr[1] "%d aldatu da"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Berrezarri lasterbide guztiak?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr "Lasterbideak berrezartzeak zure lasterbide pertsonalizatuei eragin diezaieke. Hori ezin da desegin."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Utzi"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Berrezarri dena"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2778,7 +1546,9 @@ msgstr "Gehitu laster-tekla pertsonalizatuak"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
-msgstr "Konfiguratu laster-tekla pertsonalizatuak aplikazioak abiarazteko, scriptak exekutatzeko eta gehiagorako."
+msgstr ""
+"Konfiguratu laster-tekla pertsonalizatuak aplikazioak abiarazteko, scriptak "
+"exekutatzeko eta gehiagorako."
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
@@ -2787,33 +1557,6 @@ msgstr "Gehitu laster-tekla"
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Ez da teklatuaren laster-teklarik aurkitu"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s dagoeneko erabilia izaten ari da %s(e)rako. Hura ordezten baduzu, %s desgaitu egingo da"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Sartu laster-tekla berria"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Ezarri laster-tekla pertsonalizatua"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Ezarri laster-tekla"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Sartu laster-tekla berria %s aldatzeko."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Gehitu laster-tekla pertsonalizatua"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
@@ -2826,13 +1569,14 @@ msgstr "O_rdeztu"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "E_zarri"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
-msgstr "Sakatu Esc tekla laster-tekla bertan behera uzteko edo atzera-tekla desgaitzeko."
+msgstr ""
+"Sakatu Esc tekla laster-tekla bertan behera uzteko edo atzera-tekla "
+"desgaitzeko."
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
@@ -2862,6 +1606,11 @@ msgstr "Bat ere ez"
 msgid "Reset the shortcut to its default value"
 msgstr "Leheneratu laster-tekla bere balio lehenetsira"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Erabili zure kamera"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Teklatua"
@@ -2870,13 +1619,16 @@ msgstr "Teklatua"
 msgid ""
 "Change keyboard shortcuts and set your typing preferences, keyboard layouts "
 "and input sources"
-msgstr "Aldatu teklatuko lasterbideak eta ezarri idazte-hobespenak, teklatu-diseinuak eta sarrerako iturburuak"
+msgstr ""
+"Aldatu teklatuko lasterbideak eta ezarri idazte-hobespenak, teklatu-"
+"diseinuak eta sarrerako iturburuak"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
-msgstr "Laster-tekla;Laneko area;Leihoa;Tamaina aldatzea;Zooma;Kontrastea;Sarrera;Iturburua;Blokeatu;Bolumena;"
+msgstr ""
+"Laster-tekla;Laneko area;Leihoa;Tamaina aldatzea;Zooma;Kontrastea;Sarrera;"
+"Iturburua;Blokeatu;Bolumena;"
 
 #: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
@@ -2895,9 +1647,13 @@ msgid ""
 "com/privacy'>Privacy Policy</a>\n"
 "\n"
 "Allow the applications below to determine your location."
-msgstr "Kokaleku-zerbitzuek aplikazioek zure kokalekua ezagutzea baimentzen dute. Haririk gabekoa eta mugikorren banda zabala erabiltzeak zehaztasuna handiagotzen du.\n"
+msgstr ""
+"Kokaleku-zerbitzuek aplikazioek zure kokalekua ezagutzea baimentzen dute. "
+"Haririk gabekoa eta mugikorren banda zabala erabiltzeak zehaztasuna "
+"handiagotzen du.\n"
 "\n"
-"Mozilla Location Service erabiltzen du: <a href='https://location.services.mozilla.com/privacy'>Pribatutasun-politika</a>\n"
+"Mozilla Location Service erabiltzen du: <a href='https://location.services."
+"mozilla.com/privacy'>Pribatutasun-politika</a>\n"
 "\n"
 "Baimendu beheko aplikazioei zure kokalekua ezagutu dezaten."
 
@@ -2909,7 +1665,6 @@ msgstr "Ez dago aplikaziorik kokalekua erabiltzea eskatu duenik"
 msgid "Protect your location information"
 msgstr "Babestu zure kokalekuaren informazioa"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "kokalekua;gps;pribatua;pribatutasuna;"
@@ -2929,7 +1684,10 @@ msgid ""
 "properly.\n"
 "\n"
 "Allow the applications below to use your microphone."
-msgstr "Mikrofonoa erabilita, aplikazioek audioa grabatu dezakete. Mikrofonoa desgaitzen bada, beharbada zenbait aplikaziok ez dute behar den moduan funtzionatuko.\n"
+msgstr ""
+"Mikrofonoa erabilita, aplikazioek audioa grabatu dezakete. Mikrofonoa "
+"desgaitzen bada, beharbada zenbait aplikaziok ez dute behar den moduan "
+"funtzionatuko.\n"
 "\n"
 "Baimendu beheko aplikazioei zure kamera erabiltzea."
 
@@ -2941,7 +1699,6 @@ msgstr "Ez dago aplikaziorik mikrofonoa erabiltzea eskatu duenik"
 msgid "Protect your conversations"
 msgstr "Babestu zure hizketaldiak"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofonoa;grabazioa;aplikazioa;pribatutasuna;"
@@ -2971,81 +1728,139 @@ msgstr "Ezkerrean"
 msgid "Right"
 msgstr "Eskuinean"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Bilatu kokalekuak"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Sagua"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Saguaren abiadura"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Korritze naturala"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Babesik ez"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Korritzeak edukia mugitzen du, ez ikuspegia."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Korritzeak edukia mugitzen du, ez ikuspegia."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktibo"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Ukipen-panela"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Ukipen-panelaren abiadura"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Ukitu klik egiteko"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Ukitu klik egiteko"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Bi hatzeko korritzea"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Ukipen-panela (erlatiboa)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Ertzaren korritzea"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Korritzea blokeatzeko tekla"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Alde bietatik"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Saiatu klik, klik bikoitza egiten, korritzen"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Bost klik, GEGL garaia!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Klik bikoitza, botoi nagusia"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Klik bakuna, botoi nagusia"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Klik bikoitza, erdiko botoia"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Klik bakuna, erdiko botoia"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Klik bikoitza, bigarren mailako botoia"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Klik bakuna, bigarren mailako botoia"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3054,9 +1869,10 @@ msgstr "Sagua eta ukipen-panela"
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr "Aldatu saguaren edo ukipen-panelaren sentikortasuna eta hautatu eskuin edo ezkerreko eskuarekin erabiltzea"
+msgstr ""
+"Aldatu saguaren edo ukipen-panelaren sentikortasuna eta hautatu eskuin edo "
+"ezkerreko eskuarekin erabiltzea"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Trackpad;Erakuslea;Klik;Sakatu;Bikoitza;Botoia;Trackball;Korritu;"
@@ -3076,7 +1892,9 @@ msgstr "Pantailaren ertz _aktiboak"
 #: panels/multitasking/cc-multitasking-panel.ui:43
 msgid ""
 "Drag windows against the top, left, and right screen edges to resize them."
-msgstr "Arrastatu leihoak pantailaren goiko, ezkerreko eta eskuineko ertzetara haien tamaina aldatzeko."
+msgstr ""
+"Arrastatu leihoak pantailaren goiko, ezkerreko eta eskuineko ertzetara haien "
+"tamaina aldatzeko."
 
 #: panels/multitasking/cc-multitasking-panel.ui:70
 msgid "Workspaces"
@@ -3134,26 +1952,18 @@ msgstr "Aldi bereko zereginak"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Kudeatu hobespenak produktibitaterako eta aldi bereko zereginetarako"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
-msgstr "Aldi bereko zereginak;Produktibitatea:Pertsonalizazioa;Mahaigaina;Izkina beroa;Laneko area;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Zerbait gaizki joan da. Jar zaitez harremanetan softwarearen sortzailearekin."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager exekutatzen egon behar da."
+msgstr ""
+"Aldi bereko zereginak;Produktibitatea:Pertsonalizazioa;Mahaigaina;Izkina "
+"beroa;Laneko area;"
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Beste gailuak"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPNa"
 
@@ -3165,57 +1975,16 @@ msgstr "Gehitu konexioa"
 msgid "Not set up"
 msgstr "Konfiguratu gabe"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Sare ez-segurua (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Sare segurua (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Sare segurua (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Sare segurua (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Sare segurua"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Konektatuta"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Aukerak…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr "Wifigunea aktibatzen bada, gailua %s saretik deskonektatuko da eta ezin izango da internetera sartu wifi bidez."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Gutxienez 8 karaktere izan behar ditu"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3233,7 +2002,10 @@ msgid ""
 "Wi-Fi hotspot allows others to share your internet connection, by creating a "
 "Wi-Fi network that they can connect to. To do this, you must have an "
 "internet connection through a source other than Wi-Fi."
-msgstr "Wifiguneari esker, zure internet-konexioa beste batzuekin partekatuko duzu, haiek konektatu ahal izango diren wifi-sare bat sortuko baituzu. Hori egiteko, wifi bidezkoa ez den interneteko konexio bat izan behar duzu."
+msgstr ""
+"Wifiguneari esker, zure internet-konexioa beste batzuekin partekatuko duzu, "
+"haiek konektatu ahal izango diren wifi-sare bat sortuko baituzu. Hori "
+"egiteko, wifi bidezkoa ez den interneteko konexio bat izan behar duzu."
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
@@ -3262,20 +2034,6 @@ msgstr "Sortu pasahitza automatikoki"
 msgid "_Turn On"
 msgstr "_Piztu"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wifia"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Gelditu wifigunea eta deskonektatu edozein erabiltzaile?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Gelditu wifigunea"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Hegazkin modua"
@@ -3290,7 +2048,8 @@ msgstr "Ez da haririk gabeko moldagailurik aurkitu"
 
 #: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
-msgstr "Ziurtatu zaitez haririk gabeko moldagailua entxufatuta eta piztuta edukitzeaz"
+msgstr ""
+"Ziurtatu zaitez haririk gabeko moldagailua entxufatuta eta piztuta edukitzeaz"
 
 #: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
@@ -3320,86 +2079,14 @@ msgstr "Sare ikusgaiak"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager exekutatzen egon behar da"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Zerbait gaizki joan da. Jar zaitez harremanetan softwarearen sortzailearekin."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x segurtasuna"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Segurtasuna"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Mantendu"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Betiko"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Ausazkoa"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Egonkorra"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr "Hemen sartutako MAC helbidea erabiliko da konexio hau aktibatzen den sareko gailuaren hardwarearen helbide gisa. Eginbide hau MAC helbidea klonatzea edo iruzurtzea bezala ezagutzen da. Adibidea: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "%d. profila"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Irekitze hobetua"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Bat ere ez"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Inoiz ere ez"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3408,183 +2095,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "orain dela egun %i"
 msgstr[1] "orain dela %i egun"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Bat ere ez"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Ahula"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ados"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Ona"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Oso ona"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 helbidea"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 helbidea"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP helbidea"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNSa"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Ahaztu konexioa"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Kendu konexioaren profila"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Kendu VPNa"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Xehetasunak"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatikoa"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitatea"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Ezabatu helbidea"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Ezabatu bidea"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Bat ere ez"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128 bit-eko gakoa (hamaseitarra edo ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128 bit-eko pasaesaldia"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinamikoa (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA eta WPA2 pertsonala"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA eta WPA2 enpresa"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 pertsonala"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3595,8 +2105,20 @@ msgstr "Seinalearen sendotasuna"
 msgid "Link speed"
 msgstr "Esteka-abiadura"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Segurtasuna"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 helbidea"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 helbidea"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hardwarearen helbidea"
 
@@ -3605,12 +2127,17 @@ msgid "Supported Frequencies"
 msgstr "Onartutako maiztasunak"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Ibilbide lehenetsia"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNSa"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3626,12 +2153,15 @@ msgstr "Egin erabilgarri beste _erabiltzaileentzako"
 
 #: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
-msgstr "_Neurtutako konexioa: datu-mugak ditu edo ordainketaren bat eragin dezake"
+msgstr ""
+"_Neurtutako konexioa: datu-mugak ditu edo ordainketaren bat eragin dezake"
 
 #: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
-msgstr "Software eguneratzeak eta beste deskarga handi batzuk ez dira automatikoki abiaraziko."
+msgstr ""
+"Software eguneratzeak eta beste deskarga handi batzuk ez dira automatikoki "
+"abiaraziko."
 
 #: panels/network/connection-editor/ethernet-page.ui:21
 #: panels/network/connection-editor/vpn-page.ui:17
@@ -3671,7 +2201,7 @@ msgstr "Esteka lokalak soilik"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Eskuz"
 
@@ -3715,9 +2245,8 @@ msgstr "Atebidea"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automatikoa"
 
@@ -3770,86 +2299,9 @@ msgstr "Automatikoa (DHCP soilik)"
 msgid "Prefix"
 msgstr "Aurrizkia"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Ezin da konexioaren editorea ireki"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Profil berria"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "%s ezarpen baliogabea: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "%s ezarpen baliogabea"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Inportatu fitxategitik…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Gehitu VPNa"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Segurtasuna"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Ezin da VPN konexioa inportatu"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr "Ezin izan da “%s” fitxategia irakurri, edo ez dauka VPN konexioaren informazio ezagunik.\n"
-"\n"
-"Errorea: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Hautatu fitxategia inportatzeko"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "“%s” izeneko fitxategia badago lehendik ere."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Ordeztu"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Nahi duzu %s gordetzen ari zaren VPN konexioarekin ordeztea?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Ezin da VPN konexioa esportatu"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr "The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Esportatu VPN konexioa"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3863,95 +2315,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Sarea"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Kontrolatu nola konektatzen zaren Internetera"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Sarea;IPa;LANa;Proxy-a;WANa;Bandazabala;Modema;Bluetooth-aa;VPNa;DNSa;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wifia"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Kontrolatu haririk gabeko sareetara nola konektatuko zaren"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Sarea;Haririk gabea;Wi-Fia;Wifia;IPa;LANa;Bandazabala;DNSa;Wifigunea;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "inoiz ere ez"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "gaur"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "atzo"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Erabilitako azkena"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Hariduna"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Gehitu konexio berria"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr "Hautatutako sareen xehetasunak, pasahitzak eta konfigurazio pertsonalizatuak barne, galdu egingo dira."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Ahaztu"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Haririk gabeko sare ezagunak"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Ahaztu"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Sistemaren arauek wifigune gisa erabiltzea debekatzen dute"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Haririk gabeko gailuak ez du wifigunearen modua onartzen"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "Webeko proxy-autoaurkitzailea erabiltzen da konfigurazioaren URLa ez denean ematen."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Hau ez da gomendatzen sare publiko ez-fidagarrietan."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -3970,6 +2363,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Hornitzailea"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP helbidea"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4054,289 +2451,6 @@ msgstr "_Aktibatu wifigunea…"
 msgid "_Known Wi-Fi Networks"
 msgstr "Haririk gabeko sare _ezagunak"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Egoera ezezaguna"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Kudeatu gabea"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Ez dago erabilgarri"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Konektatzen"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Autentifikazioa behar da"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Deskonektatzen"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Konexioak huts egin du"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Egoera ezezaguna (falta da)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Konexioak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IParen konfigurazioak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IParen konfigurazioa iraungi da"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Ezkutukoak behar dira, baina ez dira eman"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x-ren eskatzailea deskonektatuta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x-ren eskatzailearen konfigurazioak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x-ren eskatzaileak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x-ren eskatzailea gehiegi luzatu da autentifikatzean"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP zerbitzuak huts egin du abiatzean"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP zerbitzua deskonektatuta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP-ek huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP-ren bezeroak huts egin du abiatzean"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP-ren bezeroaren errorea"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP-ren bezeroak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Partekatutako konexioaren zerbitzuak huts egin du abiatzean"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Partekatutako konexioaren zerbitzuak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "IP automatikoaren zerbitzuak huts egin du abiatzean"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "IP automatikoaren zerbitzuaren errorea"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "IP automatikoaren zerbitzuak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linea lanpetuta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Ez dago markatze-tonurik"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Ezin izan da garraiatzailerik ezarri"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Markatze-eskaeraren denbora iraungituta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Markatze-saiakerak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Modemaren hasieratzeak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Huts egin du zehaztutako APNa hautatzean"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Ez da sarerik bilatzen ari"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Sarea erregistratzea ukatuta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Sarea erregistratzearen denbora iraungituta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Huts egin du eskatutako sarearekin erregistratzean"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PINaren egiaztaketak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Agian gailuaren firmwarea falta da"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Konexioa desagertu da"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Existitzen den konexioa hartu da"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Ez da modemik aurkitu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth konexioak huts egin du"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Ez da SIM txartelik sartu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIMaren PINa behar da"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIMaren PUKa behar da"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM arazoa"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Konexio-mendekotasunak huts egin du"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Firmwarea falta da"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kablea deskonektatuta"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "definitu gabeko errorea 802.1x segurtasunean (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "ez da fitxategirik hautatu"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "zehaztugabeko errorea eap metodoaren fitxategia egiaztatzean"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12 edo PGP gako pribatuak"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER edo PEM ziurtagiriak"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "EAP-FAST PAC fitxategia falta da"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC fitxategiak (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4385,14 +2499,6 @@ msgstr "_Barneko autentifikazioa"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Baimendu PAC automatikoki _hornitzea"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "EAP-LEAPren erabiltzaile-izena falta da"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "EAP-LEAPren pasahitza falta da"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4418,15 +2524,6 @@ msgstr "_Pasahitza"
 msgid "Sho_w password"
 msgstr "Erakutsi _pasahitza"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "EAP-PEAPren baliogabeko ZE ziurtagiria: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "EAP-PEAPren baliogabeko ZE ziurtagiria: ez da ziurtagirik zehaztu"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4448,7 +2545,6 @@ msgid "C_A certificate"
 msgstr "_ZE ziurtagiria"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4463,60 +2559,6 @@ msgstr "Ez da ZE ziurtagirik _behar"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _bertsioa"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "EAPren erabiltzaile-izena falta da"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "EAPren pasahitza falta da"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "EAP-TLSren erabiltzaile-izena falta da"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "EAP-TLSren baliogabeko ZE ziurtagiria: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "EAP-TLSren baliogabeko ZE ziurtagiria: ez da ziurtagirik zehaztu"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "EAP-TLSren baliogabeko gako pribatua: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "EAP-TLSren baliogabeko erabiltzaile-ziurtagiria: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Zifratu gabeko gako pribatuak ez dira seguruak"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr "Hautatutako gako pribatua ez dirudi pasahitz batekin babestuta dagoenik. Horrek zure segurtasun-kredentzialak arriskuan jar ditzake. Hautatu pasahitzarekin babestutako gako pribatu bat.\n"
-"\n"
-"(Zure gako pribatua pasahitz batekin babes dezakezu openssl-rekin)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Aukeratu zure ziurtagiri pertsonala"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Aukeratu zure gako pribatua"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4533,15 +2575,6 @@ msgstr "_Gako pribatua"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Gako _pribatuaren pasahitza"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "EAP-TTLSren baliogabeko ZE ziurtagiria: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "EAP-TTLSren baliogabeko ZE ziurtagiria: ez da ziurtagirik zehaztu"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4564,14 +2597,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domeinua"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Errore ezezaguna 802.1X segurtasuna egiaztatzean"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4599,56 +2633,10 @@ msgstr "Babestutako EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Autentifikazioa"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Hautatu fitxategi bat"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "'leap'en erabiltzaile-izena falta da"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "'leap'en pasahitza falta da"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Haririk gabekoaren pasahitza falta da."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Mota"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "wep gakoa falta da"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "baliogabeko wep gakoa: %zu luzera duen gakoak soilik digitu hamaseitarrak eduki ditzake"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "baliogabeko wep gakoa: %zu luzera duen gakoak soilik ascii karaktereak eduki ditzake"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr "baliogabeko wep gakoa: gakoak okerreko %zu luzera du. Gako baten luzerak 5/13 (ascii) edo 10/26 (hamaseitarra) izan behar du"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "baliogabeko wep gakoa: pasaesaldia ezin da hutsik egon behar"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "baliogabeko wep gakoa: pasaesaldiak 64 karaktere baino gutxiago izan behar ditu"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4674,17 +2662,6 @@ msgstr "E_rakutsi gakoa"
 msgid "WEP inde_x"
 msgstr "WEP _indizea"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr "baliogabeko wpa-psk: gakoaren %zu luzera baliogabea. [8,63] byte edo 64 digitu hamaseitarrekoa izan behar du"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "baliogabeko wepwpa-psk: ezin da hamaseitar gisa 64 byte dituen gakoa interpretatu"
-
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
@@ -4706,7 +2683,9 @@ msgstr "_Jakinarazpenen laster-leihoak"
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
-msgstr "Jakinarazpenak jakinarazpenen zerrendan agertzen jarraituko dute laster-leihoak desgaituta daudenean."
+msgstr ""
+"Jakinarazpenak jakinarazpenen zerrendan agertzen jarraituko dute laster-"
+"leihoak desgaituta daudenean."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
 #: panels/notifications/cc-app-notifications-dialog.ui:56
@@ -4734,29 +2713,12 @@ msgstr "Pantaila b_lokeatzearen jakinarazpenak"
 
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
-msgstr "Kontrolatu jakinarazpenak nola bistaratzen diren eta zer erakusten duten"
+msgstr ""
+"Kontrolatu jakinarazpenak nola bistaratzen diren eta zer erakusten duten"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "jakinarazpenak;iragarkia;mezua;erretilua;laster-leihoa;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Bestelakoa"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s kendu da"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Errorea kontua kentzean"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4774,22 +2736,13 @@ msgstr "Konektatu zure datuak lainoan"
 
 #: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
-msgstr "Ez dago Interneteko konexiorik — konektatu lineako kontu berriak konfiguratzeko"
+msgstr ""
+"Ez dago Interneteko konexiorik — konektatu lineako kontu berriak "
+"konfiguratzeko"
 
 #: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Gehitu kontua"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s kontua"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Kendu kontua"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4797,21 +2750,16 @@ msgstr "Lineako kontuak"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
-msgstr "Konektatu lineako zure kontuetara eta erabaki zertarako erabiliko dituzun"
+msgstr ""
+"Konektatu lineako zure kontuetara eta erabaki zertarako erabiliko dituzun"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-msgstr "Google;Facebook;Twitter;Yahoo;Weba;Linean;Berriketa;Egutegia;Posta;Kontaktua;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Denbora ezezaguna"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Weba;Linean;Berriketa;Egutegia;Posta;Kontaktua;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4827,13 +2775,6 @@ msgid_plural "%i hours"
 msgstr[0] "Ordu %i"
 msgstr[1] "%i ordu"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4845,184 +2786,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minutu"
 msgstr[1] "minutu"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s erabat kargatu arte"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Kontuz: %s falta"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s falta"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Erabat kargatuta"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Kargarik ez"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Hutsa"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Kargatzen"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Deskargatzen"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Haririk gabeko sagua"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Haririk gabeko teklatua"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Etenik gabeko energia hornidura"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Laguntzaile digital pertsonala"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Telefono mugikorra"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Multimedia-erreproduzigailua"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Taula"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Ordenagailua"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Jokoetarako sarrerako gailua"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Bateria"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Nagusia"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Gehigarria"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Bateriak"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "_Inaktibo dagoenean"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Eseki"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Itzali"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hibernatu"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Ezer ez"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Bateriaren energiarekin"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Entxufea konektatutakoan"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Inoiz ere ez"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Eseki automatikoki"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "Errendimendu modua desgaitu egin da aldi batez laneko tenperatura asko igo delako."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr "Eramangarria detektatu da: errendimendu modua ez dago erabilgarri momentu honetan. Eraman gailua gainazal egonkor batera hura leheneratzeko."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Errendimendu modua desgaitu egin da aldi batez."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr "Bateria gutxi: energia aurrezteko modua gaitu da. Bateria nahiko kargatuta dagoenean aurreko modua leheneratuko da."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Energia aurrezteko modua aktibatuta: “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Errendimendu modua aktibatuta: “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5084,6 +2847,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 ordu"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bateria"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Gailuak"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Energiaren modua"
@@ -5134,7 +2906,8 @@ msgstr "Eseki _automatikoki"
 
 #: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
-msgstr "Ordenagailua pausatzen du aktibitaterik gabe denbora batez egon ondoren."
+msgstr ""
+"Ordenagailua pausatzen du aktibitaterik gabe denbora batez egon ondoren."
 
 #: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
@@ -5161,33 +2934,6 @@ msgstr "_Bateriaren energiarekin"
 msgid "Delay"
 msgstr "Atzerapena"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Errendimendua"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Errendimendu eta energiaren erabilera altua."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Orekatua"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Errendimendu eta energiaren erabilera estandarra"
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Energiaren aurrezpena"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Errendimendu eta energiaren erabilera murritza."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Energia"
@@ -5196,33 +2942,13 @@ msgstr "Energia"
 msgid "View your battery status and change power saving settings"
 msgstr "Ikusi bateriaren egoera eta aldatu energia aurrezteko ezarpenak"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
-msgstr "Argindarra;Lo egin;Eseki;Hibernatu;Bateria;Distira;Itzali;Belztu;Monitorea;DPMS;Inaktibo;Energia;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "\"%s” inprimagailua ezabatu da"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Huts egin du inprimagailu berria gehitzean."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Ezin izan da interfazea kargatu: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Desblokeatu inprimagailuak gehitzeko eta ezarpenak aldatzeko"
+msgstr ""
+"Argindarra;Lo egin;Eseki;Hibernatu;Bateria;Distira;Itzali;Belztu;Monitorea;"
+"DPMS;Inaktibo;Energia;"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5230,9 +2956,10 @@ msgstr "Inprimagailuak"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
-msgstr "Gehitu inprimagailuak, ikusi inprimatze-lanak eta erabaki zer inprimatzea nahi duzun"
+msgstr ""
+"Gehitu inprimagailuak, ikusi inprimatze-lanak eta erabaki zer inprimatzea "
+"nahi duzun"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Inprimagailua;Ilara;Inprimatu;Papera;Tinta;Tonerra;"
@@ -5240,8 +2967,6 @@ msgstr "Inprimagailua;Ilara;Inprimatu;Papera;Tinta;Tonerra;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Gehitu inprimagailua"
 
@@ -5280,38 +3005,17 @@ msgstr "Sartu zure erabiltzaile-izena eta pasahitza inprimatze-zerbitzarian."
 msgid "Username"
 msgstr "Erabiltzaile-izena"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s - Xehetasunak"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Ez da kontrolatzaile egokirik aurkitu"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Hautatu PPD fitxategia"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr "PostScript Printer Description fitxategiak (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
-msgstr "Inprimagailu-izenek ezin dituzte zuriuneak, tabulazioak, traolak edo alderantzizko barrak eduki"
+msgstr ""
+"Inprimagailu-izenek ezin dituzte zuriuneak, tabulazioak, traolak edo "
+"alderantzizko barrak eduki"
 
 #: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Kokalekua"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Kontrolatzailea"
 
@@ -5339,140 +3043,20 @@ msgstr "Hautatu inprimagailuaren kontrolatzailea"
 msgid "Loading drivers database…"
 msgstr "Kontrolatzaileen datu-basea kargatzen…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Utzi"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Hautatu"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect inprimagailua"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD inprimagailua"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Alde batetik"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Marjina luzea (estandarra)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Marjina laburra (iraulia)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Bertikala"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Horizontala"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Alderantzizko horizontala"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Alderantzizko bertikala"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Berrekin"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pausatu"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Zain"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pausatuta"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Autentifikazioa behar da"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Prozesatzen"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Geldituta"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Bertan behera utzita"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Abortatuta"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Osatuta"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Eraman lan hau ilararen goialdera"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "Lan %uek autentifikazioa behar du"
 msgstr[1] "%u lanek autentifikazioa behar dute"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Lan aktiboak"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Sartu kredentzialak %s(e)tik inprimatzeko."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5500,321 +3084,17 @@ msgstr "_Autentifikatu"
 msgid "No Active Printer Jobs"
 msgstr "Inprimagailuaren lan aktiborik ez"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Desblokeatu inprimatze-zerbitzaria"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Desblokeatu %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Sartu zure erabiltzaile-izena eta pasahitza %s kokalekuan dauden inprimagailuak ikusteko."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Inprimagailuak bilatzen"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Serieko ataka"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Ataka paraleloa"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Kokalekua: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Helbidea: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Zerbitzariak autentifikazioa eskatzen du"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Alde bietatik"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Paper mota"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Paper-iturria"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Irteerako erretilua"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Bereizmena"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript aurre-iragazketa"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Orrialdeak aldeko"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Alde bietatik"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientazioa"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Orokorra"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Orrialdearen konfigurazioa"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Aukera instalagarriak"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Lana"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Irudiaren kalitatea"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Kolorea"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Amaierakoak"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Aurreratua"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Probako orria"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Probako orria"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Hautapen automatikoa"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Inprimagailu lehenetsia"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Kapsulatutako GhostScript letra-tipoak soilik"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "BIhurtu PS 1. mailara"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "BIhurtu PS 2. mailara"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Aurre-iragazketarik ez"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Fabrikatzailea"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Ez dago lan aktiborik"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "lan %u"
 msgstr[1] "%u lan"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Garbitu inprimagailuaren buruak"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Toner gutxi"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Tonerra hutsik"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Errebelatzaile gutxi"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Errebelatzailea hutsik"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Markatzaile gutxi"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Markatzailerik gabe"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Estalkia irekita"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Atea irekita"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Paper gutxi"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Paperik ez"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Deskonektatuta"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Geldituta"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Hondakinen ontzia ia beteta"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Hondakinen ontzia beteta"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Argazki-eroale optikoa bere amaierara iristear dago"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Argazki-eroale optikoak ez du gehiago funtzionatuko"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Prest"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Ez du lanik onartzen"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Prozesatzen"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5838,6 +3118,10 @@ msgstr "Garbitu inprimagailuaren buruak"
 msgid "Remove Printer"
 msgstr "Kendu inprimagailua"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ez dago lan aktiborik"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -5858,23 +3142,28 @@ msgid "Restart"
 msgstr "Berrabiarazi"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Gehitu inprimagailua…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Gehitu inprimagailua…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Inprimagailurik ez"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
-msgstr "Badirudi sistemako inprimatzeko\n"
+msgstr ""
+"Badirudi sistemako inprimatzeko\n"
 "    zerbitzua ez dagoela erabilgarri."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formatuak"
@@ -5902,16 +3191,6 @@ msgstr "Bilaketan herrialdeak edo hizkuntzak bilatu daitezke."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Aurrebista"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Inperiala"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrika"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5945,22 +3224,28 @@ msgstr "Amaitu saioa…"
 msgid ""
 "The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
-msgstr "Hizkuntza-ezarpena interfazearen testuan eta web-orrietan erabiliko da. Formatuak zenbakietarako, datetarako eta monetetarako erabiliko da."
+msgstr ""
+"Hizkuntza-ezarpena interfazearen testuan eta web-orrietan erabiliko da. "
+"Formatuak zenbakietarako, datetarako eta monetetarako erabiliko da."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Zure kontua"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Hizkuntza"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formatuak"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Saio-hasierako pantaila"
 
@@ -5972,99 +3257,9 @@ msgstr "Eskualdea eta hizkuntza"
 msgid "Select your display language and formats"
 msgstr "Hautatu bistaratze-hizkuntza eta -formatuak"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Hizkuntza;Diseinua;Teklatua;Sarrera;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Galdetu zer egin"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Ez egin ezer"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Ireki karpeta"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Bestelako euskarria"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Hautatu aplikazioa audio CDentzako"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Hautatu aplikazioa bideo DVDentzako"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Hautatu aplikazio bat exekutatzeko musika erreproduzigailu bat konektatzean"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Hautatu aplikazio bat exekutatzeko kamera bat konektatzean"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Hautatu aplikazioa softwaredun Audio CDentzako"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "Audio DVDa"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Blu-Ray disko hutsa"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "CD disko hutsa"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "DVD disko hutsa"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "HD DVD disko hutsa"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-Ray bideo diskoa"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "liburu elektronikoen irakurlea"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD bideo diskoa"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Argazkien CDa"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CDa"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Bideo CDa"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows softwarea"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6114,120 +3309,13 @@ msgstr "Euskarri aldagarria"
 msgid "Configure Removable Media settings"
 msgstr "Konfiguratu euskarri aldagarriaren ezarpenak"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;"
-msgstr "gailua;sistema;lehenetsia;aplikazioa;hobetsia;cd;dvd;usb;audioa;bideoa;diskoa;aldagarria;euskarria;exekuzioa;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Pantaila itzaltzen da"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 segundo"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "minutu 1"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutu"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutu"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutu"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutu"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "Ordu 1"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "minutu 1"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutu"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutu"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutu"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutu"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutu"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutu"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutu"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutu"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Inoiz ere ez"
+msgstr ""
+"gailua;sistema;lehenetsia;aplikazioa;hobetsia;cd;dvd;usb;audioa;bideoa;"
+"diskoa;aldagarria;euskarria;exekuzioa;"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6237,7 +3325,9 @@ msgstr "Pantailaren blokeoa"
 msgid ""
 "Automatically locking the screen prevents others from accessing the computer "
 "while you're away."
-msgstr "Pantaila automatikoki blokeatuta, beste batzuk zure ordenagailura sar daitezen eragozten da zu kanpoan zauden bitartean."
+msgstr ""
+"Pantaila automatikoki blokeatuta, beste batzuk zure ordenagailura sar "
+"daitezen eragozten da zu kanpoan zauden bitartean."
 
 #: panels/screen/cc-screen-panel.ui:14
 msgid "Blank Screen Delay"
@@ -6257,46 +3347,50 @@ msgstr "Pantailaren blokeo _automatikoaren atzerapena"
 
 #: panels/screen/cc-screen-panel.ui:51
 msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "Pantaila automatikoki blokeatuta dagoenean pantaila belzteko igaroko den denbora-tartea."
+msgstr ""
+"Pantaila automatikoki blokeatuta dagoenean pantaila belzteko igaroko den "
+"denbora-tartea."
 
 #: panels/screen/cc-screen-panel.ui:69
 msgid "Show _Notifications on Lock Screen"
 msgstr "Erakutsi _jakinarazpenak blokeo-pantailan"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Pantaila b_lokeatzearen jakinarazpenak"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Debekatu _USB gailu berriak"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
-msgstr "Eragotzi USB gailu berriek sistemarekin lan egin dezaten pantaila blokeatuta dagoenean."
+msgstr ""
+"Eragotzi USB gailu berriek sistemarekin lan egin dezaten pantaila blokeatuta "
+"dagoenean."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Pantaila-pribatutasuna"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Mugatu bistaratze-angelua"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantaila"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Pantaila-ezarpenak"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "pantaila;blokeatu;pribatua;pribatutasuna;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Hautatu kokalekua"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Ados"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6307,7 +3401,9 @@ msgstr "Bilatu kokalekuak"
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
-msgstr "Sistema-aplikazioek zein karpetetan egingo dituzten bilaketak, adibidez 'Fitxategiak', 'Argazkiak' eta 'Bideoak' karpetetan"
+msgstr ""
+"Sistema-aplikazioek zein karpetetan egingo dituzten bilaketak, adibidez "
+"'Fitxategiak', 'Argazkiak' eta 'Bideoak' karpetetan"
 
 #: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
@@ -6324,10 +3420,6 @@ msgstr "Bestelakoak"
 #: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Gehitu kokalekua"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Ez da aplikaziorik aurkitu"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -6352,91 +3444,17 @@ msgstr "Emaitzak zerrenda-ordenaren arabera bistaratuko dira."
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
-msgstr "Kontrolatu zer aplikaziok erakusten dituzten bilaketen emaitzak Jardueren ikuspegian"
+msgstr ""
+"Kontrolatu zer aplikaziok erakusten dituzten bilaketen emaitzak Jardueren "
+"ikuspegian"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Bilaketa;Bilatu;Indizea;Ezkutatu;Pribatua;Emaitzak;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Ez da sarerik hautatu partekatzeko"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Sareak"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Aktibatuta"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Desaktibatuta"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Gaituta"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktibo"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Aukeratu karpeta"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Gehitu"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Gaitu multimedia partekatzea"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr "Fitxategiak partekatzeak zure uneko sareko beste erabiltzaileek zure 'Publikoa' karpeta ikustea ahalbidetzen du honakoa erabilita: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr "Urruneko saio-hasiera gaituta dagoenean, urruneko erabiltzaileek konekta daitezke Shell Seguruko komandoa erabiliz: \n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Gaitu multimedia pertsonalen partekatzea"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Gailuaren izena kopiatu da"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Gailuaren helbidea kopiatu da"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Erabiltzaile-izena kopiatu da"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Pasahitza kopiatu da"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6485,7 +3503,9 @@ msgstr "Urruneko mahaigaina"
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
-msgstr "Urruneko mahaigainari esker, zure mahaigaina beste ordenagailu batetik kontrolatu dezakezu."
+msgstr ""
+"Urruneko mahaigainari esker, zure mahaigaina beste ordenagailu batetik "
+"kontrolatu dezakezu."
 
 #: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
@@ -6506,7 +3526,9 @@ msgstr "Nola konektatu"
 #: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
-msgstr "Konektatu ordenagailu honekin gailuaren izena edo urruneko mahaigainaren helbidea erabilita."
+msgstr ""
+"Konektatu ordenagailu honekin gailuaren izena edo urruneko mahaigainaren "
+"helbidea erabilita."
 
 #: panels/sharing/cc-sharing-panel.ui:318
 #: panels/sharing/cc-sharing-panel.ui:345
@@ -6525,7 +3547,8 @@ msgstr "Autentifikazioa"
 
 #: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
-msgstr "Erabiltzaile-izena eta pasahitza behar dira ordenagailu honekin konektatzeko."
+msgstr ""
+"Erabiltzaile-izena eta pasahitza behar dira ordenagailu honekin konektatzeko."
 
 #: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
@@ -6543,7 +3566,9 @@ msgstr "Zifratzearen hatz-marka"
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
 "identical."
-msgstr "Zifratzearen hatz-marka bezeroak konektatzean ikusten da eta berdina izan behar du."
+msgstr ""
+"Zifratzearen hatz-marka bezeroak konektatzean ikusten da eta berdina izan "
+"behar du."
 
 #: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
@@ -6561,12 +3586,13 @@ msgstr "Karpetak"
 msgid "Control what you want to share with others"
 msgstr "Kontrolatu besteekin zer partekatzea nahi duzun"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
 "movies;server;renderer;"
-msgstr "partekatu;partekatzea;ssh;ostalaria;izena;urrunekoa;mahaigaina;multimedia;bideoa;irudiak;argazkiak;filmak;zerbitzaria;errendatzea;"
+msgstr ""
+"partekatu;partekatzea;ssh;ostalaria;izena;urrunekoa;mahaigaina;multimedia;"
+"bideoa;irudiak;argazkiak;filmak;zerbitzaria;errendatzea;"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
@@ -6575,10 +3601,6 @@ msgstr "Gaitu edo desgaitu urruneko saio-hasiera"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Autentifikazioa behar da urruneko saioa gaitu edo desgaitzeko"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Pertsonalizatua"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6611,11 +3633,6 @@ msgstr "Atzealdea"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Aurrealdea"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s probatzen"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6669,11 +3686,6 @@ msgstr "Bolumena"
 msgid "Alert Sound"
 msgstr "Alertako soinua"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "% 100"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Mututu"
@@ -6686,81 +3698,12 @@ msgstr "Soinua"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Aldatu soinuaren bolumena, sarrerak, irteerak eta eta alerten soinuak"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
-msgstr "Txartela;Mikrofonoa;Bolumena;Iraungi;Balantzea;Bluetooth-a;Entzungailua;Audioa;Irteera;Sarrera;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Deskonektatuta"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Konektatzen"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Konektatuta"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Baimen-errorea"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Baimentzen"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Funtzionaltasun murriztua"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Konektatua eta baimendua"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Ezezaguna"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Baimendua hemen:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Konektatua hemen:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Erregistratua hemen:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Ezin izan da gailua baimendu: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Ezin izan da gailua ahaztu: "
+msgstr ""
+"Txartela;Mikrofonoa;Bolumena;Iraungi;Balantzea;Bluetooth-a;Entzungailua;"
+"Audioa;Irteera;Sarrera;"
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6794,51 +3737,6 @@ msgstr "Baimendu eta konektatu"
 msgid "Forget Device"
 msgstr "Ahaztu gailua"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Errorea"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Baimendua"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr "Thunderbolt azpisistema (boltd) ez dago instalatuta edo gaizki konfiguratuta dago."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Sarbide zuzena baimentzen du atrakeak eta kanpoko GPUak bezalako gailuetara."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "USB eta Display Port gailuak soilik erantsi daitezke."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr "Thunderbolt ezin izan da detektatu.\n"
-"Sistemak ez dauka Thunderbolt euskarririk, BIOSean desgaitu egin da edo onartzen ez den segurtasun-maila batean ezarri da BIOSean."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt euskarria desgaitu egin da BIOSean."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Thunderbolten segurtasun-maila ezin izan da zehaztu."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Errorea modu zuzena aldatzean: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Ez dago Thunderbolt euskarririk"
@@ -6850,6 +3748,11 @@ msgstr "Ezin izan da Thunderbolt azpisistemarekin konektatu"
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Sarbide zuzena"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Sarbide zuzena baimentzen du atrakeak eta kanpoko GPUak bezalako gailuetara."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -6867,7 +3770,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Kudeatu Thunderbolt gailuak"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;pribatutasuna;"
@@ -6896,7 +3798,9 @@ msgstr "Kurtsorearen tamaina"
 #: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
-msgstr "Kurtsorearen tamaina zoomarekin erabil daiteke kurtsorea errazago ikus ahal izateko."
+msgstr ""
+"Kurtsorearen tamaina zoomarekin erabil daiteke kurtsorea errazago ikus ahal "
+"izateko."
 
 #: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
@@ -6972,7 +3876,8 @@ msgstr "Errepikatze-teklak"
 
 #: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
-msgstr "Tekla sakatuta dagoen bitartean, tekla hori behin eta berriz errepikatzen da."
+msgstr ""
+"Tekla sakatuta dagoen bitartean, tekla hori behin eta berriz errepikatzen da."
 
 #: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
@@ -7067,40 +3972,6 @@ msgstr "_Gaitu teklatuaren bidez"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Aktibatu erabilgarritasunaren funtzionalitatea teklatutik"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Lehenetsia"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Tartekoa"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Handia"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Oso handia"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Oso oso handia"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixel"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Erakutsi _beti erabilerraztasunaren menua"
@@ -7127,7 +3998,9 @@ msgstr "Pantaila _irakurlea"
 
 #: panels/universal-access/cc-ua-panel.ui:71
 msgid "The screen reader reads displayed text as you move the focus."
-msgstr "Pantailaren irakurleak bistaratutako testua irakurtzen du fokua mugitzen duzun arabera."
+msgstr ""
+"Pantailaren irakurleak bistaratutako testua irakurtzen du fokua mugitzen "
+"duzun arabera."
 
 #: panels/universal-access/cc-ua-panel.ui:83
 msgid "_Sound Keys"
@@ -7135,7 +4008,9 @@ msgstr "_Teklak soinuarekin"
 
 #: panels/universal-access/cc-ua-panel.ui:84
 msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "Jo soinua zenbakiak blokeatzeko edo maiuskulak blokeatzeko teklak aktibatzen edo desaktibatzen direnean."
+msgstr ""
+"Jo soinua zenbakiak blokeatzeko edo maiuskulak blokeatzeko teklak aktibatzen "
+"edo desaktibatzen direnean."
 
 #: panels/universal-access/cc-ua-panel.ui:96
 msgid "C_ursor Size"
@@ -7214,31 +4089,6 @@ msgstr "Distiratu _pantaila osoa"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Distiratu _leiho osoa"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Laburra"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "Pantailaren ¼"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "Pantailaren ½"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "Pantailaren ¾"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Luzea"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7393,124 +4243,21 @@ msgstr "Kolore-efektuak"
 
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
 msgid "Make it easier to see, hear, type, point and click"
-msgstr "Egin errazagoa ikusteko, entzuteko, idazteko, kokatzeko eta klik egiteko"
+msgstr ""
+"Egin errazagoa ikusteko, entzuteko, idazteko, kokatzeko eta klik egiteko"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
 "audio;typing;animations;"
-msgstr "Teklatua;Sagua;a11y;Irisgarritasuna;Irisgarritasun Unibertsala;Kontrastea;Kurtsorea;Soinua;Zooma;Pantaila;Irakurgailua;handia;altua;handia;testua;letra-tipoa;tamaina;AccessX;Itsaskorra;Teklak;Geldoa;Errebotea;Sagua;Bikoitza;klik;Atzerapena;Abiadura;Lagundu;Errepikatu;Keinua;bisuala;entzumena;audioa;idazketa;animazioak;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "Ordu 1"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "Egun 1"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 egun"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 egun"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 egun"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 egun"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 egun"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 egun"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 egun"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 egun"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Hustu zakarrontziko elementu guztiak?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Zakarrontziko elementu guztiak betirako ezabatuko dira."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Hustu _zakarrontzia"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Ezabatu aldi baterako fitxategi guztiak?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Aldi baterako fitxategi guztiak betirako ezabatuko dira."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Ezabatu aldi baterako fitxategiak"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "Egun 1"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 egun"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 egun"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Beti"
+msgstr ""
+"Teklatua;Sagua;a11y;Irisgarritasuna;Irisgarritasun Unibertsala;Kontrastea;"
+"Kurtsorea;Soinua;Zooma;Pantaila;Irakurgailua;handia;altua;handia;testua;"
+"letra-tipoa;tamaina;AccessX;Itsaskorra;Teklak;Geldoa;Errebotea;Sagua;"
+"Bikoitza;klik;Atzerapena;Abiadura;Lagundu;Errepikatu;Keinua;bisuala;"
+"entzumena;audioa;idazketa;animazioak;"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7521,7 +4268,10 @@ msgid ""
 "File history keeps a record of files that you have used. This information is "
 "shared between applications, and makes it easier to find files that you "
 "might want to use."
-msgstr "Fitxategien historiak zuk erabilitako fitxategien erregistro bat gordetzen du. Informazio hori aplikazioen artean partekatzen da, eta errazago bihurtzen du erabili nahi dituzun fitxategiak aurkitzeko lana."
+msgstr ""
+"Fitxategien historiak zuk erabilitako fitxategien erregistro bat gordetzen "
+"du. Informazio hori aplikazioen artean partekatzen da, eta errazago "
+"bihurtzen du erabili nahi dituzun fitxategiak aurkitzeko lana."
 
 #: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
@@ -7543,7 +4293,10 @@ msgstr "Zakarrontziko eta aldi baterako fitxategiak"
 msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
-msgstr "Zakarrontziko eta aldi baterako fitxategiek zenbaitetan informazio pertsonala edo sentikorra izan dezakete. Automatikoki ezabatzen badira, pribatutasuna babesten lagundu dezakete."
+msgstr ""
+"Zakarrontziko eta aldi baterako fitxategiek zenbaitetan informazio "
+"pertsonala edo sentikorra izan dezakete. Automatikoki ezabatzen badira, "
+"pribatutasuna babesten lagundu dezakete."
 
 #: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
@@ -7573,60 +4326,12 @@ msgstr "Fitxategien historia eta zakarrontzia"
 msgid "Don't leave traces"
 msgstr "Ez utzi aztarnarik"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
-msgstr "erabilera;azken aldikoa;historia;fitxategiak;aldi batekoa;tmp;pribatua;pribatutasuna;zakarrontzia;ezabatu;mantendu;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Zure kontuaren hornitzailearen web helbidearekin bat etorri behar du."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Huts egin du kontua gehitzean"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Pasahitzak ez datoz bat."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Huts egin du kontua erregistratzean"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Ez dago modurik onartuta domeinu honekin autentifikatzeko"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Huts egin du domeinuarekin elkartzean"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr "Saioaren hasierako izenak ez du funtzionatzen.\n"
-"Saiatu berriro."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr "Saioaren hasierako pasahitzak ez du funtzionatzen.\n"
-"Saiatu berriro."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Huts egin du domeinuan saioa hastean"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Ezin da domeinua aurkitu. Ongi idatzi duzu?"
+msgstr ""
+"erabilera;azken aldikoa;historia;fitxategiak;aldi batekoa;tmp;pribatua;"
+"pribatutasuna;zakarrontzia;ezabatu;mantendu;"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7641,7 +4346,10 @@ msgstr "Administratzailea"
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users. Parental controls cannot be applied to administrators."
-msgstr "Administratzaileek beste erabiltzaile batzuk gehitu edo kendu ditzakete, eta erabiltzaile guztien ezarpenak aldatu ditzakete. Administratzaileei ezin zaizkie guraso-kontrolak aplikatu."
+msgstr ""
+"Administratzaileek beste erabiltzaile batzuk gehitu edo kendu ditzakete, eta "
+"erabiltzaile guztien ezarpenak aldatu ditzakete. Administratzaileei ezin "
+"zaizkie guraso-kontrolak aplikatu."
 
 #: panels/user-accounts/cc-add-user-dialog.ui:149
 msgid "User sets password on first login"
@@ -7672,11 +4380,10 @@ msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
 "resources on the internet."
-msgstr "Enpresako saio-hasieran baimenduta dago erabiltzaileen kontu zentralizatua erabiltzea gailu honetan. Kontu hau enpresaren interneteko baliabideak atzitzeko ere erabil dezakezu."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Arakatu irudi gehiago"
+msgstr ""
+"Enpresako saio-hasieran baimenduta dago erabiltzaileen kontu zentralizatua "
+"erabiltzea gailu honetan. Kontu hau enpresaren interneteko baliabideak "
+"atzitzeko ere erabil dezakezu."
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7702,7 +4409,9 @@ msgstr "_Bai"
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
-msgstr "Erregistratutako zure hatz-markak ezabatze nahi duzu, hatz-marken bidezko saio-hasiera desgaituz?"
+msgstr ""
+"Erregistratutako zure hatz-markak ezabatze nahi duzu, hatz-marken bidezko "
+"saio-hasiera desgaituz?"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
@@ -7733,7 +4442,9 @@ msgstr "Hatz-marken bidezko saio-hasiera"
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
-msgstr "Hatz-marken bidezko saio-hasierak hatza erabilita ordenagailua desblokeatzea eta saioa hastea ahalbidetzen du."
+msgstr ""
+"Hatz-marken bidezko saio-hasierak hatza erabilita ordenagailua desblokeatzea "
+"eta saioa hastea ahalbidetzen du."
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
@@ -7743,220 +4454,6 @@ msgstr "_Ezabatu hatz-markak"
 msgid "Fingerprint Enroll"
 msgstr "Hatz-marken erregistroa"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "gailua galdegin behar da ekintza hau gauzatu baino lehen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "beste prozesu batek galdegin du gailua"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "ez duzu ekintza gauzatzeko baimenik"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "ez da inprimagailurik erregistratu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Huts egin du erregistroan zehar gailuarekin komunikatzeak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Huts egin du hatz-marken irakurgailuarekin komunikatzeak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Huts egin du hatz-marken daemonarekin komunikatzeak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Huts egin du hatz-markak zerrendatzeak: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Huts egin du gordetako hatz-markak ezabatzeak: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Ezkerreko hatz potoloa"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Ezkerreko erdiko hatza"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "E_zkerreko hatz erakuslea"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Ezkerreko hatz nagia"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Ezkerreko hatz txikia"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Eskuineko hatz potoloa"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Eskuineko erdiko hatza"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "E_skuineko hatz erakuslea"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Eskuineko hatz nagia"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Eskuineko hatz txikia"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Hatz-marka ezezaguna"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Eginda"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Hatz-marken gailua deskonektatu da"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Hatz-marken gailuen biltegiratzea beteta dago"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Huts egin du hatz-marka berria erregistratzeak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Huts egin du erregistroa abiarazteak: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Huts egin du hatz-marka berria erregistratzeak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Huts egin du erregistroa gelditzeak: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr "Altxatu eta kokatu hatza irakurgailuan behin eta berriro, zure hatz-marka erregistratzeko"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Erregistratu berriro hatz hau…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Eskaneatu hatz-marka berria"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Huts egin du hatz-marken %s gailua askatzeak: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Arazoa gailua irakurtzean"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Huts egin du hatz-marken %s gailuaren jabetza galdegiteak: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Huts egin du hatz-marken gailuak eskuratzeak: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Aste honetan"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Pasa den astean"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Saioa amaituta"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Saioa hasita"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Kontuaren jarduera"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Aurrekoa"
@@ -7964,18 +4461,6 @@ msgstr "Aurrekoa"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Hurrengoa"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Aukeratu beste pasahitz bat."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Idatzi zure uneko pasahitza berriro."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Pasahitza ezin izan da aldatu"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -7997,136 +4482,18 @@ msgstr "Pasahitz berria"
 msgid "Confirm Password"
 msgstr "Berretsi pasahitza"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Pasahitzak ez datoz bat."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
-msgstr "Baimendu erabiltzaileei hurrengo saio-hasieran haien pasahitzak ezartzea"
+msgstr ""
+"Baimendu erabiltzaileei hurrengo saio-hasieran haien pasahitzak ezartzea"
 
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Ezarri pasahitza orain"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Ezin da automatikoki honelako domeinu motarekin elkartu"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Ez da halako domeinurik aurkitu"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Ezin da %s gisa saioa-hasi %s domeinuan"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Baliogabeko pasahitza, saiatu berriro"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Ezin izan da %s domeinuarekin konektatu: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Huts egin du erabiltzailea ezabatzean"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Huts egin du urrunetik kudeatzeko erabiltzailea errebokatzean"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Ezin duzu zeure kontua ezabatu."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s oraindik saioan sartuta dago"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "Erabiltzailea ezabatzen bada saioan sartuta dagoen bitartean, sistema egoera inkoherentean utz daiteke."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "%s(r)en fitxategiak mantentzea nahi dituzu?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr "Karpeta nagusia, postaren ilara eta aldi baterako fitxategiak gordetzeko aukera dago erabiltzaile baten kontua ezabatzean."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Ezabatu fitxategiak"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Mantendu fitxategiak"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Ziur zaude urrunetik kudeatutako “%s”(r)en kontua errebokatzea nahi duzula?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "Ez_abatu"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Kontua desgaituta"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Hurrengo saioan ezartzeko"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Bat ere ez"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Saioan sartuta"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Huts egin du kontuaren zerbitzuarekin kontaktatzean"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Ziurtatu zaitez kontuen zerbitzua instalatuta eta gaituta dagoela."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Panel hau desblokeatu behar da ezarpen hori aldatzeko"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Ezabatu hautatutako erabiltzailearen kontua"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr "Hautatutako erabiltzailearen kontua ezabatzeko\n"
-"aurrenik egin klik * ikonoan"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Desblokeatu erabiltzaileak gehitzeko eta ezarpenak aldatzeko"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8154,7 +4521,6 @@ msgid "Full name"
 msgstr "Izen osoa"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Editatu"
 
@@ -8179,7 +4545,9 @@ msgstr "_Administratzailea"
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
-msgstr "Administratzaileek beste erabiltzaile batzuk gehitu edo kendu ditzakete, eta erabiltzaile guztien ezarpenak aldatu ditzakete."
+msgstr ""
+"Administratzaileek beste erabiltzaile batzuk gehitu edo kendu ditzakete, eta "
+"erabiltzaile guztien ezarpenak aldatu ditzakete."
 
 #: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
@@ -8214,12 +4582,14 @@ msgstr "Desblokeatu erabiltzaile-kontu bat gehitzeko."
 msgid "Add or remove users and change your password"
 msgstr "Gehitu edo kendu erabiltzaileak eta aldatu zure pasahitza"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
 "Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
-msgstr "Saio-hasiera;Izena;Hatz-marka;Avatarra;Logotipoa;Aurpegia;Pasahitza;Guraso-kontrolak;Pantaila-denbora;Aplikazio-mugak;Web mugak;Erabilera;Erabilera-muga;Gaztea;Haurra;"
+msgstr ""
+"Saio-hasiera;Izena;Hatz-marka;Avatarra;Logotipoa;Aurpegia;Pasahitza;Guraso-"
+"kontrolak;Pantaila-denbora;Aplikazio-mugak;Web mugak;Erabilera;Erabilera-"
+"muga;Gaztea;Haurra;"
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
 #: panels/user-accounts/data/join-dialog.ui:30
@@ -8235,7 +4605,8 @@ msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here."
-msgstr "Enpresako saioa erabil ahal izateko, ordenagailu honek\n"
+msgstr ""
+"Enpresako saioa erabil ahal izateko, ordenagailu honek\n"
 "domeinun erregistratuta egon behar du. Eskatu iezaiozu sareko\n"
 "administratzaileari domeinuaren bere pasahitza idazteko hemen."
 
@@ -8255,170 +4626,6 @@ msgstr "Kudeatu erabiltzaileen kontuak"
 msgid "Authentication is required to change user data"
 msgstr "Autentifikazioa behar da erabiltzailearen datuak aldatzeko"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Pasahitz berriak zaharrarengandik desberdina izan behar du."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Saiatu hizki eta zenbaki batzuk aldatzen."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Saiatu pasahitza piska bat gehiago aldatzen."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Zure erabiltzaile-izenik gabeko pasahitz bat askoz ere sendoagoa litzateke."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Saiatu zure izena pasahitzean erabiltzea saihestea."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Saiatu pasahitzean sartutako hitz batzuk saihestea."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Saiatu hitz arruntak saihestea."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Saiatu dauden hitzen berrantolaketa saihestea."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Saiatu zenbaki gehiago erabiltzea."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Saiatu hizki maiuskulak gehiago erabiltzea."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Saiatu hizki minuskulak gehiago erabiltzea."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Saiatu karaktere berezi gehiago erabiltzea, harridura ikurra bezalakoak."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Saiatu hizki, zenbaki eta ikurren arteko nahasketa batekin."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Saiatu karaktere berdina errepikatzea saihestea."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr "Saiatu karaktere mota berdina errepikatzea saihestea: hizki, zenbaki eta ikurrak nahastu behar dituzu."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Saiatu 1234 edo abc bezalako sekuentziak saihestea."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr "Pasahitzak luzeagoa izan behar du. Saiatu hizki, zenbaki eta ikurren arteko nahasketa gehiagorekin."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Nahastu hizki maiuskulak eta minuskulak eta erabili zenbaki bat edo bi."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Hizki, zenbaki eta ikur gehiago gehitzeak sendoagoa egingo du."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Autentifikazioak huts egin du"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Pasahitza laburregia da"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Pasahitza sinpleegia da"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Pasahitz zaharra eta berria oso antzekoak dira"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Pasahitz berria azken aldian erabilia izan da."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Pasahitz berriak karaktere numeriko edo berezia(k) eduki behar ditu"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Pasahitz zaharra eta berria berdinak dira"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Pasahitza aldatu egin da hasieran autentifikatu zinenetik"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Pasahitz berriak ez dauzka nahikoa karaktere desberdin"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Errore ezezaguna"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr "Erabiltzaile-izenak honako karaktereak soilik eduki ditzake:  alfabetoko a-z arteko hizki minuskulak, digituak eta '.', '-' eta '_' karaktereak."
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Erabiltzaile-izen hori ez dago erabilgarri. Saiatu beste batekin."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Erabiltzaile-izena luzeegia da."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8432,7 +4639,10 @@ msgstr "Mapatu botoiak funtzioetara"
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
-msgstr "Laster-tekla bat editatzeko: aukeratu \"Bidali tekla sakatzea\" ekintza, sakatu teklatuaren laster-teklaren botoia eta eduki sakatuta tekla berriak edo sakatu Atzera-tekla garbitzeko."
+msgstr ""
+"Laster-tekla bat editatzeko: aukeratu \"Bidali tekla sakatzea\" ekintza, "
+"sakatu teklatuaren laster-teklaren botoia eta eduki sakatuta tekla berriak "
+"edo sakatu Atzera-tekla garbitzeko."
 
 #: panels/wacom/button-mapping.ui:66
 msgid "_Close"
@@ -8442,58 +4652,18 @@ msgstr "It_xi"
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
-msgstr "Ukitu helburuko markatzaileak pantailan agertzen diren ordenan taula kalibratzeko."
+msgstr ""
+"Ukitu helburuko markatzaileak pantailan agertzen diren ordenan taula "
+"kalibratzeko."
 
 #: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "Okerreko klik detektatuta, berrabiarazten…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "%d. botoia"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplikazioan definituta"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Bidali tekla sakatzea"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Aldatu monitorea"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Erakutsi pantailako laguntza"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Eramangarriaren panelean muntatutako tableta"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Kanpoko pantailan muntatutako tableta"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Kanpoko tableta-gailua"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Kanpoko teklatu-gailua"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Pantaila guztiak"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8522,7 +4692,9 @@ msgstr "Mantendu aspektu-erlazioa"
 
 #: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
-msgstr "Erabili tableta-gainazalaren zati bat soilik, pantailaren aspektu-erlazioa mantentzeko"
+msgstr ""
+"Erabili tableta-gainazalaren zati bat soilik, pantailaren aspektu-erlazioa "
+"mantentzeko"
 
 #: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
@@ -8589,78 +4761,106 @@ msgstr "Saguaren eskuineko botoiarekin klik egitea"
 msgid "Forward"
 msgstr "Aurrera"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Airbrush stylus gailua presioarekin, inklinazioarekin eta integratutako graduatzailearekin"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Airbrush stylus gailua presioarekin, inklinazioarekin eta biraketarekin"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Airbrush stylus gailua presioarekin eta inklinazioarekin"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Airbrush stylus gailua presioarekin"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom taula"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr "Ezarri botoi-mapatzea eta doitu arkatzaren sentikortasuna taula grafikoentzako"
+msgstr ""
+"Ezarri botoi-mapatzea eta doitu arkatzaren sentikortasuna taula "
+"grafikoentzako"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Taula;Wacom;Estiloa;Borragoma;Sagua;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Laster-tekla berria…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_2. mailako klik simulatua"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows softwarea"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Toner gutxi"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "2. mailako klik egitearen atzerapena"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows softwarea"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Kudeatu hobespenak produktibitaterako eta aldi bereko zereginetarako"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Sarbide-puntuak"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Gehitu"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Gorde"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Eragiketa bertan behera utzi da"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Errorea:</b> Sarbidea ukatu da ezarpenak aldatzean"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Error:</b> Ekipamendu mugikorraren errorea"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Erregistratu gabea"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Erregistratua"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Ibiltaritza"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Bilatzen"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Ukatua"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8690,212 +4890,13 @@ msgstr "Zenbaki propioa"
 msgid "Device Details"
 msgstr "Gailuaren xehetasunak"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabrikatzailea"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Firmwarearen bertsioa"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G soilik"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G soilik"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G soilik"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "5G soilik"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (hobetsia), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (hobetsia), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (hobetsia), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (hobetsia), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (hobetsia), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (hobetsia), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (hobetsia), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (hobetsia), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (hobetsia), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (hobetsia), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (hobetsia), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (hobetsia), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (hobetsia), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (hobetsia), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (hobetsia), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (hobetsia), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (hobetsia)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (hobetsia), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Ezezaguna"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Desblokeatu SIM txartela"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Desblokeatu"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Sartu %d SIM txartelaren PIN kodea"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Sartu PIN kodea zure SIM txartela desblokeatzeko"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Sartu %d SIM txartelaren PUK kodea"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Sartu PUK kodea a zure SIM txartela desblokeatzeko"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8910,26 +4911,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Aukera %u geratzen zaizu"
 msgstr[1] "%u aukera geratzen zaizkizu"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Pasahitz okerra sartu da."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK kodea 8 digituko zenbakia da"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Sartu PIN berria"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN kodeak 4-8 digitu zenbakia izan behar du"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Desblokeatzen…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -8987,94 +4968,6 @@ msgstr "Blokeatu SIM txartela PINarekin"
 msgid "M_odem Details"
 msgstr "M_odemaren xehetasunak"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Akatsa telefonoan"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Ez dago konexiorik telefonoarekin"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Eragiketa ez dago baimenduta"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Eragiketa ez dago onartuta"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIMa ez dago txertatuta"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "SIMaren PINa behar da"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "SIMaren PUKa behar da"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIMak huts egin du"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIMa lanpetuta dago"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Pasahitz okerra"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIMaren PIN2a behar da"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIMaren PUK2a behar da"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Ez da aurkitu"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Ez dago sareko zerbitzurik"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Sarea denbora-mugara iritsi da"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS zerbitzuak ez dira onartzen"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Ibiltaritza ez da onartzen kokaleku-area honetan"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Zehaztu gabeko GPRS errorea"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Errorerik ez"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Ekintza bertan behera geratu da"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Sarbidea ukatu da"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Errore ezezaguna"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Sareko modua"
@@ -9090,11 +4983,6 @@ msgstr "Aukeratu sarea"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Freskatu sare-hornitzaileak"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "%d SIMa"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9152,7 +5040,6 @@ msgstr "Sare mugikorra"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Konfiguratu telefoniako eta datu mugikorreko konexioak"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "telefonoa;wwan;telefonia;sim;mugikorra;"
@@ -9169,41 +5056,13 @@ msgstr "Ezarpenak zure sistema konfiguratzeko interfaze nagusia da."
 msgid "The GNOME Project"
 msgstr "GNOME proiektua"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Erakutsi bertsio-zenbakia"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Gaitu modu xehea"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Bilatu katea"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Zerrendatu panel posibleen izenak eta irten"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panela bistaratzeko"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANELA] [ARGUMENTUA…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Ezarpenen kategoriak"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Pribatutasuna"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Panel erabilgarriak:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9222,7 +5081,10 @@ msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
 "issues. "
-msgstr "Ezarpenen bertsio hau garapenerako soilik erabili beharko litzateke. Sistemaren portaera okerra, datuen galera eta espero gabeko beste arazo batzuk gerta daitezke. "
+msgstr ""
+"Ezarpenen bertsio hau garapenerako soilik erabili beharko litzateke. "
+"Sistemaren portaera okerra, datuen galera eta espero gabeko beste arazo "
+"batzuk gerta daitezke. "
 
 #: shell/cc-window.ui:164
 msgid "Help"
@@ -9258,7 +5120,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Utzi bilaketa"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Hobespenak;Ezarpenak;"
@@ -9271,7 +5132,9 @@ msgstr "Irekiko den ezarpenen azken panelaren identifikatzailea"
 msgid ""
 "The identifier for the last Settings panel to be opened. Unrecognised values "
 "will be ignored and the first panel in the list selected."
-msgstr "Irekiko den ezarpenen azken panelaren identifikatzailea. Ezagutzen ez diren balioak ezikusi egingo dira eta zerrendako lehen panela hautatuko da."
+msgstr ""
+"Irekiko den ezarpenen azken panelaren identifikatzailea. Ezagutzen ez diren "
+"balioak ezikusi egingo dira eta zerrendako lehen panela hautatuko da."
 
 #: shell/org.gnome.Settings.gschema.xml:13
 msgid "Show warning when running a development build of Settings"
@@ -9280,7 +5143,9 @@ msgstr "Erakutsi abisu bat ezarpenen garapen-bertsio bat exekutatzean"
 #: shell/org.gnome.Settings.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
-msgstr "Ezarpenek abisu bat erakutsi behar duen ala ez garapen-bertsio bat exekutatzen denean."
+msgstr ""
+"Ezarpenek abisu bat erakutsi behar duen ala ez garapen-bertsio bat "
+"exekutatzen denean."
 
 #: shell/org.gnome.Settings.gschema.xml:20
 msgid "Initial state of the window"
@@ -9290,10 +5155,10 @@ msgstr "Leihoaren hasierako egoera"
 msgid ""
 "A tuple containing the initial width, height and maximized state of the "
 "application window."
-msgstr "Aplikazio-leihoaren hasierako zabalera, altuera eta egoera maximizatua dituen tuplea."
+msgstr ""
+"Aplikazio-leihoaren hasierako zabalera, altuera eta egoera maximizatua "
+"dituen tuplea."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9301,8 +5166,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "Irteera %u"
 msgstr[1] "%u irteera"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9310,9 +5173,3141 @@ msgid_plural "%u Inputs"
 msgstr[0] "Sarrera %u"
 msgstr[1] "%u sarrera"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sistemaren soinuak"
+#~ msgid "System Bus"
+#~ msgstr "Sistemaren bus-a"
+
+#~ msgid "Full access"
+#~ msgstr "Sarbide osoa"
+
+#~ msgid "Session Bus"
+#~ msgstr "Saioaren bus-a"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Sarbide osoa /dev direktoriora"
+
+#~ msgid "Has network access"
+#~ msgstr "Sarea atzitu dezake"
+
+#~ msgid "Home"
+#~ msgstr "Karpeta nagusia"
+
+#~ msgid "Read-only"
+#~ msgstr "Irakurtzeko soilik"
+
+#~ msgid "File System"
+#~ msgstr "Fitxategi-sistema"
+
+#~ msgid "Can change settings"
+#~ msgstr "Ezarpenak aldatu ditzake"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s aplikazioak honako baimenak ditu integratuta. Baimen horiek ezin dira "
+#~ "aldatu. Baimen horien inguruko kezkaren bat baduzu, beharbada aplikazio "
+#~ "hori kendu beharko zenuke."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "Aplikazioak irekitzen dituen %u fitxategi eta esteka mota"
+#~ msgstr[1] "Aplikazioak irekitzen dituen %u fitxategi eta esteka motak"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> hurrengo fitxategi motak eta estekak irekitzeko erabiltzen da."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "Erabilitako disko-espazioa: %s."
+
+#~ msgid "Select a picture"
+#~ msgstr "Hautatu argazki bat"
+
+#~ msgid "_Open"
+#~ msgstr "_Ireki"
+
+#~ msgid "multiple sizes"
+#~ msgstr "hainbat tamaina"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Mahaigaineko atzeko planorik ez"
+
+#~ msgid "Current background"
+#~ msgstr "Uneko atzeko planoa"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Jarri kalibrazioaren gailua karratuaren gainean eta egin klik \"Hasi\" "
+#~ "botoian"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Mugitu kalibrazioaren gailua posizioa kalibratzeko eta egin klik  "
+#~ "\"Jarraitu\" botoian"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Mugitu kalibrazioaren gailua gainazalaren posiziora eta egin klik  "
+#~ "\"Jarraitu\" botoian"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Itxi eramangarriaren estalkia"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Berreskura ezin daitekeen barneko errorea gertatu da."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Kalibratzeko behar diren tresnak ez daude instalatuta."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Ezin izan da profila sortu."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Ez da helburuko puntu zuria eskuratu."
+
+#~ msgid "Complete!"
+#~ msgstr "Osatuta!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrazioak huts egin du."
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Kalibrazioaren gailua ken dezakezu."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ez mugitu kalibrazioaren gailua lanean ari den bitartean"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Eramangarriaren pantaila"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Web-kamera integratuta"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s pantaila"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s eskanerra"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s kamera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s inprimagailua"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s web-kamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Gaitu '%s'(r)en kolore-kudeaketa"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Erakutsi '%s'(r)en kolore-profilak"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Kalibratu gabea"
+
+#~ msgid "Default: "
+#~ msgstr "Lehenetsia: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Kolore-espazioa: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Probako profila: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Hautatu ICC profilaren fitxategia"
+
+#~ msgid "_Import"
+#~ msgstr "_Inportatu"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Onartutako ICC profilak"
+
+#~ msgid "All files"
+#~ msgstr "Fitxategi denak"
+
+#~ msgid "Save Profile"
+#~ msgstr "Gorde profila"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Sortu kolore-profil bat hautatutako gailuarentzako"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Ez da neurgailurik detektatu. Ziurtatu zaitez piztuta eta ongi "
+#~ "konektatuta dagoela."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Neurgailuak ez du inprimagailuaren profilarik onartzen"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Gailu mota ez dago oraingoz onartuta."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espazio estandarrak"
+
+#~ msgid "Test Profile"
+#~ msgstr "Probako profila"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatikoa"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Kalitate baxua"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Tarteko kalitatea"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Kalitate altua"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "GBU lehenetsia"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK lehenetsia"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Grisa lehenetsia"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Saltzaileak emandako kalibrazioaren fabrikako datuak"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Pantaila osoko zuzenketa ezinezkoa da profila honekin"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Profila hau ezingo da gehiago zehatza izan"
+
+#~ msgid "Other…"
+#~ msgstr "Bestelakoa…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Desblokeatu ezarpenak aldatzeko"
+
+#~ msgid "Today"
+#~ msgstr "Gaur"
+
+#~ msgid "Yesterday"
+#~ msgstr "Atzo"
+
+#~ msgid "%b %e"
+#~ msgstr "%b/%e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y/%b/%e"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "ordu %d"
+#~ msgstr[1] "%d ordu"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "minutu %d"
+#~ msgstr[1] "%d minutu"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "segundo %d"
+#~ msgstr[1] "%d segundo"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Wifigunea"
+
+#~ msgid "24-hour"
+#~ msgstr "24 ordu"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%Y/%B/%e, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%Y/%B/%e, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Arazo teknikoei buruzko txostenak bidaltzean %s hobetzen laguntzen "
+#~ "diguzu. Txostenak modu anonimoan bidaltzen dira eta ez dute datu "
+#~ "pertsonalik. %s"
+
+#~ msgid "On"
+#~ msgstr "Aktibatuta"
+
+#~ msgid "Off"
+#~ msgstr "Desaktibatuta"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Aplikatu aldaketak?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Aldaketak ezin dira aplikatu"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Hardwarearen mugen erruz izan daiteke."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Horizontala"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Bertikala eskuinera"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Bertikala ezkerrera"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Horizontala (iraulita)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Abio segurua aktibatuta dago"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria "
+#~ "kargatu dadin. Une honetan aktibatuta dago eta ongi funtzionatzen du."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Abio seguruak arazoak ditu"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria "
+#~ "kargatu dadin. Une honetan aktibatuta dago, baina ez du funtzionatuko "
+#~ "gako baliogabea duelako."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Abio seguruaren arazoak sarritan ordenagailuaren UEFI firmwarearen "
+#~ "ezarpenak (BIOS) aldatuz konpontzen dira. Hardwarearen fabrikatzaileak "
+#~ "horri buruzko informazio gehiago eman diezazuke."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Laguntza jasotzeko, jarri harremanetan zure hardwarearen "
+#~ "fabrikatzailearekin edo laguntza informatikoa ematen dizunarekin."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Abio segurua desaktibatuta dago"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria "
+#~ "kargatu dadin. Une honetan desaktibatuta dago."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Abio segurua sarritan ordenagailuaren UEFI firmware-ezarpenetan (BIOS) "
+#~ "aktibatu daiteke. Laguntza jasotzeko, hitz egin zure hardwarearen "
+#~ "fabrikatzailearekin edo laguntza informatikoa ematen dizunarekin."
+
+#~ msgid "Passed"
+#~ msgstr "Pasatu da"
+
+#~ msgid "Failed"
+#~ msgstr "Huts egin du"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Gailuak HSI %d maila betetzen du"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Segurtasun-maila: 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Gailu honek ez du babesik hardwareko segurtasun-arazoen aurrean. "
+#~ "Hardareko edo firmwareko konfigurazio-arazo baten ondorioa izan daiteke "
+#~ "hori. Zure informatikako teknikariekin hitz egin dezazun gomendatzen "
+#~ "dizugu."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Segurtasun-maila: 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Gailu honek guxieneko babesa du hardwareko segurtasun-arazoen aurrean. "
+#~ "Gailuaren segurtasun-mailarik txikiena da eta segurtasun-arrisku sinpleen "
+#~ "aurkako babesa soilik eskaintzen du."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Segurtasun-maila: 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Gailu honek oinarrizko babesa du hardwareko segurtasun-arazoen aurrean. "
+#~ "Horrek segurtasun-arrisku arruntenen aurkako babesa eskaintzen du."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Segurtasun-maila: 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Gailu honek babes hedatua du hardwareko segurtasun-arazoen aurrean. "
+#~ "Gailuaren segurtasun-mailarik altuena da eta segurtasun-arrisku "
+#~ "aurreratuen aurkako babesa eskaintzen du."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Segurtasun-mailak ez daude erabilgarri gailu honetarako."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Jarri harremanetan zure hardwarearen fabrikatzailearekin segurtasun-"
+#~ "eguneratzeei buruzko laguntza jasotzeko."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Agian arazo hori gailuaren UEFI firmware-ezarpenetan konpondu daiteke, "
+#~ "edo informatikako teknikariaren laguntzarekin."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Agia arazo hori gailuaren UEFI firmware-ezarpenetan konpondu daiteke."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Agian zure informatikako teknikariak lagundu ahal dizu arazoa konpontzen."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Software kaltegarriaren aurka babestua gailua abiarazten denean,"
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Abio seguruak arazoak ditu"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Nolabaiteko babesa gailua abiarazten denean."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Abio segurua desaktibatuta dago"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Babesik ez gailua abiarazten denean."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Arazoa UEFI firmware-ezarpenetan aldaketa bat egon delako sortu da agian, "
+#~ "edo sistema eragilearen konfigurazio-aldaketa bat egon delako edo "
+#~ "software kaltegarria sartu delako sisteman."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Arazoa UEFI firmware-ezarpenetan aldaketa bat egon delako sortu da agian, "
+#~ "edo software kaltegarria sartu delako sisteman."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Arazoa sistema eragilearen konfigurazio-aldaketa bat egon delako sortu da "
+#~ "agian, edo software kaltegarria sartu delako sisteman."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Segurtasun-arriskuen aurrean kaltebera."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Babes mugatua segurtasun-arrisku sinpleen aurrean."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Babestua segurtasun-arrisku arrunten aurrean."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Babestua segurtasun-arrikus asktoren aurrean."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Babes osoa"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Firmwarearen idazketa-babesa"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Firmwarearen idazketa-babesaren blokeoa"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Firmwarearen BIOS eskualdea"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Firmwarearen BIOS deskribatzailea"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Abio aurreko DMA babesa"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard abio egiaztatua"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM babestua"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard errore-politika"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard fusiblea"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET gaituta"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET aktibo"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Zifratutako RAMa"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU babesa"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux kernelaren blokeoa"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux kernelaren egiaztatzea"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux trukatze-espazioa"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Eseki RAMera"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Eseki inaktibora"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI plataforma-gakoa"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI abio segurua"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TMP plataformaren konfigurazioa"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM berreraikuntza"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel kudeaketa-motorraren manufaktura modua"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel kudeaketa-motorraren indargabetzea"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine bertsioa"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Firmwarearen eguneratzeak"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Firmwarearen egiaztatzea"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Firmware-eguneratzailearen egiaztatzea"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Plataforma-arazketa"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Prozesadore-segurtasunaren egiaztatzeak"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMDren desinstalazio-babesa"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD firmwarearen errepikapen-babesa"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD firmwarearen idazketa-babesa"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Fusionatutako plataforma"
+
+#~ msgid "Valid"
+#~ msgstr "Baliozkoa"
+
+#~ msgid "Not Valid"
+#~ msgstr "Ez baliozkoa"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Ez gaitua"
+
+#~ msgid "Locked"
+#~ msgstr "Blokeatua"
+
+#~ msgid "Not Locked"
+#~ msgstr "Ez blokeatua"
+
+#~ msgid "Encrypted"
+#~ msgstr "Zifratua"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Ez zifratua"
+
+#~ msgid "Tainted"
+#~ msgstr "Kutsatua"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Ez kutsatua"
+
+#~ msgid "Found"
+#~ msgstr "Aurkitua"
+
+#~ msgid "Not Found"
+#~ msgstr "Ez aurkitua"
+
+#~ msgid "Supported"
+#~ msgstr "Onartua"
+
+#~ msgid "Not Supported"
+#~ msgstr "Ez onartua"
+
+#~ msgid "Unknown"
+#~ msgstr "Ezezaguna"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Ezezaguna"
+
+#~ msgid "Not Available"
+#~ msgstr "Ez dago erabilgarri"
+
+#~ msgid "System Logo"
+#~ msgstr "Sistemaren logoa"
+
+#~ msgid "No input sources found"
+#~ msgstr "Ez da sarrerako iturbururik aurkitu"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Bestelakoa"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Laster-tekla pertsonalizatuak"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Ordezko karaktereen tekla karaktere gehigarriak sartzeko erabil daiteke. "
+#~ "Batzuetan hirugarren aukera gisa inprimatuta ageri dira zure teklatuan."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Ezkerreko Alt tekla"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Eskuineko Alt tekla"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Ezkerreko Super tekla"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Eskuineko Super tekla"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menu tekla"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Eskuineko Ctrl tekla"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Compose teklak mota askotako karaktereak sartzea ahalbidetzen du. Hura "
+#~ "erabiltzeko, sakatu Compose tekla eta, ondoren, karaktereen sekuentzia "
+#~ "bat. Adibidez, Compose tekla sakatuta, eta ondoren <b>C</b> eta <b>o</b> "
+#~ "erabilita, <b>©</b> sartuko du; <b>a</b> eta ondoren <b>'</b> erabilita, "
+#~ "<b>á</b> sartuko du."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Maiuskulak blokeatzeko tekla"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Pantaila inprimatzeko tekla"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Sarrerako iturburuak %s lasterbidea erabilita txandakatu daitezke.\n"
+#~ "Lasterbide hori ezarpenetan aldatu daiteke."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d aldatu da"
+#~ msgstr[1] "%d aldatu da"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Berrezarri lasterbide guztiak?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Lasterbideak berrezartzeak zure lasterbide pertsonalizatuei eragin "
+#~ "diezaieke. Hori ezin da desegin."
+
+#~ msgid "Reset All"
+#~ msgstr "Berrezarri dena"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s dagoeneko erabilia izaten ari da %s(e)rako. Hura ordezten baduzu, %s "
+#~ "desgaitu egingo da"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Sartu laster-tekla berria"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Ezarri laster-tekla pertsonalizatua"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Ezarri laster-tekla"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Sartu laster-tekla berria %s aldatzeko."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Gehitu laster-tekla pertsonalizatua"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Bi hatzeko korritzea"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Bost klik, GEGL garaia!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Klik bikoitza, botoi nagusia"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Klik bakuna, botoi nagusia"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Klik bikoitza, erdiko botoia"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Klik bakuna, erdiko botoia"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Klik bikoitza, bigarren mailako botoia"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Klik bakuna, bigarren mailako botoia"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager exekutatzen egon behar da."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Sare ez-segurua (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Sare segurua (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Sare segurua (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Sare segurua (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Sare segurua"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Wifigunea aktibatzen bada, gailua %s saretik deskonektatuko da eta ezin "
+#~ "izango da internetera sartu wifi bidez."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Gutxienez 8 karaktere izan behar ditu"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Gelditu wifigunea eta deskonektatu edozein erabiltzaile?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Gelditu wifigunea"
+
+#~ msgid "Preserve"
+#~ msgstr "Mantendu"
+
+#~ msgid "Permanent"
+#~ msgstr "Betiko"
+
+#~ msgid "Random"
+#~ msgstr "Ausazkoa"
+
+#~ msgid "Stable"
+#~ msgstr "Egonkorra"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Hemen sartutako MAC helbidea erabiliko da konexio hau aktibatzen den "
+#~ "sareko gailuaren hardwarearen helbide gisa. Eginbide hau MAC helbidea "
+#~ "klonatzea edo iruzurtzea bezala ezagutzen da. Adibidea: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "%d. profila"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Irekitze hobetua"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Bat ere ez"
+
+#~ msgid "Never"
+#~ msgstr "Inoiz ere ez"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Bat ere ez"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Ahula"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ados"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Ona"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Oso ona"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Ahaztu konexioa"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Kendu konexioaren profila"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Kendu VPNa"
+
+#~ msgid "Details"
+#~ msgstr "Xehetasunak"
+
+#~ msgid "automatic"
+#~ msgstr "automatikoa"
+
+#~ msgid "Identity"
+#~ msgstr "Identitatea"
+
+#~ msgid "Delete Address"
+#~ msgstr "Ezabatu helbidea"
+
+#~ msgid "Delete Route"
+#~ msgstr "Ezabatu bidea"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Bat ere ez"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128 bit-eko gakoa (hamaseitarra edo ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128 bit-eko pasaesaldia"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinamikoa (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA eta WPA2 pertsonala"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA eta WPA2 enpresa"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 pertsonala"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Ezin da konexioaren editorea ireki"
+
+#~ msgid "New Profile"
+#~ msgstr "Profil berria"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "%s ezarpen baliogabea: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "%s ezarpen baliogabea"
+
+#~ msgid "Import from file…"
+#~ msgstr "Inportatu fitxategitik…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Gehitu VPNa"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Ezin da VPN konexioa inportatu"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Ezin izan da “%s” fitxategia irakurri, edo ez dauka VPN konexioaren "
+#~ "informazio ezagunik.\n"
+#~ "\n"
+#~ "Errorea: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Hautatu fitxategia inportatzeko"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "“%s” izeneko fitxategia badago lehendik ere."
+
+#~ msgid "_Replace"
+#~ msgstr "_Ordeztu"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Nahi duzu %s gordetzen ari zaren VPN konexioarekin ordeztea?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Ezin da VPN konexioa esportatu"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Esportatu VPN konexioa"
+
+#~ msgid "never"
+#~ msgstr "inoiz ere ez"
+
+#~ msgid "today"
+#~ msgstr "gaur"
+
+#~ msgid "yesterday"
+#~ msgstr "atzo"
+
+#~ msgid "Last used"
+#~ msgstr "Erabilitako azkena"
+
+#~ msgid "Add new connection"
+#~ msgstr "Gehitu konexio berria"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Hautatutako sareen xehetasunak, pasahitzak eta konfigurazio "
+#~ "pertsonalizatuak barne, galdu egingo dira."
+
+#~ msgid "_Forget"
+#~ msgstr "_Ahaztu"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Haririk gabeko sare ezagunak"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Ahaztu"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Sistemaren arauek wifigune gisa erabiltzea debekatzen dute"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Haririk gabeko gailuak ez du wifigunearen modua onartzen"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Webeko proxy-autoaurkitzailea erabiltzen da konfigurazioaren URLa ez "
+#~ "denean ematen."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Hau ez da gomendatzen sare publiko ez-fidagarrietan."
+
+#~ msgid "Status unknown"
+#~ msgstr "Egoera ezezaguna"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Kudeatu gabea"
+
+#~ msgid "Unavailable"
+#~ msgstr "Ez dago erabilgarri"
+
+#~ msgid "Connecting"
+#~ msgstr "Konektatzen"
+
+#~ msgid "Authentication required"
+#~ msgstr "Autentifikazioa behar da"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Deskonektatzen"
+
+#~ msgid "Connection failed"
+#~ msgstr "Konexioak huts egin du"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Egoera ezezaguna (falta da)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Konexioak huts egin du"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IParen konfigurazioak huts egin du"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IParen konfigurazioa iraungi da"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Ezkutukoak behar dira, baina ez dira eman"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x-ren eskatzailea deskonektatuta"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x-ren eskatzailearen konfigurazioak huts egin du"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x-ren eskatzaileak huts egin du"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x-ren eskatzailea gehiegi luzatu da autentifikatzean"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP zerbitzuak huts egin du abiatzean"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP zerbitzua deskonektatuta"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP-ek huts egin du"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP-ren bezeroak huts egin du abiatzean"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP-ren bezeroaren errorea"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-ren bezeroak huts egin du"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Partekatutako konexioaren zerbitzuak huts egin du abiatzean"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Partekatutako konexioaren zerbitzuak huts egin du"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "IP automatikoaren zerbitzuak huts egin du abiatzean"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "IP automatikoaren zerbitzuaren errorea"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "IP automatikoaren zerbitzuak huts egin du"
+
+#~ msgid "Line busy"
+#~ msgstr "Linea lanpetuta"
+
+#~ msgid "No dial tone"
+#~ msgstr "Ez dago markatze-tonurik"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Ezin izan da garraiatzailerik ezarri"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Markatze-eskaeraren denbora iraungituta"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Markatze-saiakerak huts egin du"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Modemaren hasieratzeak huts egin du"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Huts egin du zehaztutako APNa hautatzean"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Ez da sarerik bilatzen ari"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Sarea erregistratzea ukatuta"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Sarea erregistratzearen denbora iraungituta"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Huts egin du eskatutako sarearekin erregistratzean"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PINaren egiaztaketak huts egin du"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Agian gailuaren firmwarea falta da"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Konexioa desagertu da"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Existitzen den konexioa hartu da"
+
+#~ msgid "Modem not found"
+#~ msgstr "Ez da modemik aurkitu"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth konexioak huts egin du"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Ez da SIM txartelik sartu"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIMaren PINa behar da"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIMaren PUKa behar da"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM arazoa"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Konexio-mendekotasunak huts egin du"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Firmwarea falta da"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kablea deskonektatuta"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "definitu gabeko errorea 802.1x segurtasunean (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "ez da fitxategirik hautatu"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "zehaztugabeko errorea eap metodoaren fitxategia egiaztatzean"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 edo PGP gako pribatuak"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER edo PEM ziurtagiriak"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "EAP-FAST PAC fitxategia falta da"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC fitxategiak (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "EAP-LEAPren erabiltzaile-izena falta da"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "EAP-LEAPren pasahitza falta da"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "EAP-PEAPren baliogabeko ZE ziurtagiria: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "EAP-PEAPren baliogabeko ZE ziurtagiria: ez da ziurtagirik zehaztu"
+
+#~ msgid "missing EAP username"
+#~ msgstr "EAPren erabiltzaile-izena falta da"
+
+#~ msgid "missing EAP password"
+#~ msgstr "EAPren pasahitza falta da"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "EAP-TLSren erabiltzaile-izena falta da"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "EAP-TLSren baliogabeko ZE ziurtagiria: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "EAP-TLSren baliogabeko ZE ziurtagiria: ez da ziurtagirik zehaztu"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "EAP-TLSren baliogabeko gako pribatua: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "EAP-TLSren baliogabeko erabiltzaile-ziurtagiria: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Zifratu gabeko gako pribatuak ez dira seguruak"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Hautatutako gako pribatua ez dirudi pasahitz batekin babestuta dagoenik. "
+#~ "Horrek zure segurtasun-kredentzialak arriskuan jar ditzake. Hautatu "
+#~ "pasahitzarekin babestutako gako pribatu bat.\n"
+#~ "\n"
+#~ "(Zure gako pribatua pasahitz batekin babes dezakezu openssl-rekin)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Aukeratu zure ziurtagiri pertsonala"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Aukeratu zure gako pribatua"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "EAP-TTLSren baliogabeko ZE ziurtagiria: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "EAP-TTLSren baliogabeko ZE ziurtagiria: ez da ziurtagirik zehaztu"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Errore ezezaguna 802.1X segurtasuna egiaztatzean"
+
+#~ msgid "Select a file"
+#~ msgstr "Hautatu fitxategi bat"
+
+#~ msgid "missing leap-username"
+#~ msgstr "'leap'en erabiltzaile-izena falta da"
+
+#~ msgid "missing leap-password"
+#~ msgstr "'leap'en pasahitza falta da"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Haririk gabekoaren pasahitza falta da."
+
+#~ msgid "missing wep-key"
+#~ msgstr "wep gakoa falta da"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "baliogabeko wep gakoa: %zu luzera duen gakoak soilik digitu hamaseitarrak "
+#~ "eduki ditzake"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "baliogabeko wep gakoa: %zu luzera duen gakoak soilik ascii karaktereak "
+#~ "eduki ditzake"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "baliogabeko wep gakoa: gakoak okerreko %zu luzera du. Gako baten luzerak "
+#~ "5/13 (ascii) edo 10/26 (hamaseitarra) izan behar du"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "baliogabeko wep gakoa: pasaesaldia ezin da hutsik egon behar"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "baliogabeko wep gakoa: pasaesaldiak 64 karaktere baino gutxiago izan "
+#~ "behar ditu"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "baliogabeko wpa-psk: gakoaren %zu luzera baliogabea. [8,63] byte edo 64 "
+#~ "digitu hamaseitarrekoa izan behar du"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "baliogabeko wepwpa-psk: ezin da hamaseitar gisa 64 byte dituen gakoa "
+#~ "interpretatu"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Bestelakoa"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s kendu da"
+
+#~ msgid "Error removing account"
+#~ msgstr "Errorea kontua kentzean"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s kontua"
+
+#~ msgid "Remove Account"
+#~ msgstr "Kendu kontua"
+
+#~ msgid "Unknown time"
+#~ msgstr "Denbora ezezaguna"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s erabat kargatu arte"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Kontuz: %s falta"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s falta"
+
+#~ msgid "Fully charged"
+#~ msgstr "Erabat kargatuta"
+
+#~ msgid "Not charging"
+#~ msgstr "Kargarik ez"
+
+#~ msgid "Empty"
+#~ msgstr "Hutsa"
+
+#~ msgid "Charging"
+#~ msgstr "Kargatzen"
+
+#~ msgid "Discharging"
+#~ msgstr "Deskargatzen"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Haririk gabeko sagua"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Haririk gabeko teklatua"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Etenik gabeko energia hornidura"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Laguntzaile digital pertsonala"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telefono mugikorra"
+
+#~ msgid "Media player"
+#~ msgstr "Multimedia-erreproduzigailua"
+
+#~ msgid "Tablet"
+#~ msgstr "Taula"
+
+#~ msgid "Computer"
+#~ msgstr "Ordenagailua"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Jokoetarako sarrerako gailua"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Nagusia"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Gehigarria"
+
+#~ msgid "Batteries"
+#~ msgstr "Bateriak"
+
+#~ msgid "When _idle"
+#~ msgstr "_Inaktibo dagoenean"
+
+#~ msgid "Suspend"
+#~ msgstr "Eseki"
+
+#~ msgid "Power Off"
+#~ msgstr "Itzali"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernatu"
+
+#~ msgid "Nothing"
+#~ msgstr "Ezer ez"
+
+#~ msgid "When on battery power"
+#~ msgstr "Bateriaren energiarekin"
+
+#~ msgid "When plugged in"
+#~ msgstr "Entxufea konektatutakoan"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Inoiz ere ez"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Eseki automatikoki"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Errendimendu modua desgaitu egin da aldi batez laneko tenperatura asko "
+#~ "igo delako."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Eramangarria detektatu da: errendimendu modua ez dago erabilgarri momentu "
+#~ "honetan. Eraman gailua gainazal egonkor batera hura leheneratzeko."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Errendimendu modua desgaitu egin da aldi batez."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Bateria gutxi: energia aurrezteko modua gaitu da. Bateria nahiko "
+#~ "kargatuta dagoenean aurreko modua leheneratuko da."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Energia aurrezteko modua aktibatuta: “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Errendimendu modua aktibatuta: “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Errendimendua"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Errendimendu eta energiaren erabilera altua."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Orekatua"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Errendimendu eta energiaren erabilera estandarra"
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Energiaren aurrezpena"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Errendimendu eta energiaren erabilera murritza."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "\"%s” inprimagailua ezabatu da"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Huts egin du inprimagailu berria gehitzean."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Ezin izan da interfazea kargatu: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Desblokeatu inprimagailuak gehitzeko eta ezarpenak aldatzeko"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s - Xehetasunak"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Ez da kontrolatzaile egokirik aurkitu"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Hautatu PPD fitxategia"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript Printer Description fitxategiak (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+#~ "gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect inprimagailua"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD inprimagailua"
+
+#~ msgid "One Sided"
+#~ msgstr "Alde batetik"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Marjina luzea (estandarra)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Marjina laburra (iraulia)"
+
+#~ msgid "Portrait"
+#~ msgstr "Bertikala"
+
+#~ msgid "Landscape"
+#~ msgstr "Horizontala"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Alderantzizko horizontala"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Alderantzizko bertikala"
+
+#~ msgid "Resume"
+#~ msgstr "Berrekin"
+
+#~ msgid "Pause"
+#~ msgstr "Pausatu"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Zain"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pausatuta"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autentifikazioa behar da"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Prozesatzen"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Geldituta"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Bertan behera utzita"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Abortatuta"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Osatuta"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Eraman lan hau ilararen goialdera"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Lan aktiboak"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Sartu kredentzialak %s(e)tik inprimatzeko."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Desblokeatu inprimatze-zerbitzaria"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Desblokeatu %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Sartu zure erabiltzaile-izena eta pasahitza %s kokalekuan dauden "
+#~ "inprimagailuak ikusteko."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Inprimagailuak bilatzen"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serieko ataka"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Ataka paraleloa"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Kokalekua: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Helbidea: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Zerbitzariak autentifikazioa eskatzen du"
+
+#~ msgid "Two Sided"
+#~ msgstr "Alde bietatik"
+
+#~ msgid "Paper Type"
+#~ msgstr "Paper mota"
+
+#~ msgid "Paper Source"
+#~ msgstr "Paper-iturria"
+
+#~ msgid "Output Tray"
+#~ msgstr "Irteerako erretilua"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Bereizmena"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript aurre-iragazketa"
+
+#~ msgid "Pages per side"
+#~ msgstr "Orrialdeak aldeko"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientazioa"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Orokorra"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Orrialdearen konfigurazioa"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Aukera instalagarriak"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Lana"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Irudiaren kalitatea"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Kolorea"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Amaierakoak"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Aurreratua"
+
+#~ msgid "Test page"
+#~ msgstr "Probako orria"
+
+#~ msgid "Auto Select"
+#~ msgstr "Hautapen automatikoa"
+
+#~ msgid "Printer Default"
+#~ msgstr "Inprimagailu lehenetsia"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Kapsulatutako GhostScript letra-tipoak soilik"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "BIhurtu PS 1. mailara"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "BIhurtu PS 2. mailara"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Aurre-iragazketarik ez"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Garbitu inprimagailuaren buruak"
+
+#~ msgid "Out of toner"
+#~ msgstr "Tonerra hutsik"
+
+#~ msgid "Low on developer"
+#~ msgstr "Errebelatzaile gutxi"
+
+#~ msgid "Out of developer"
+#~ msgstr "Errebelatzailea hutsik"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Markatzaile gutxi"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Markatzailerik gabe"
+
+#~ msgid "Open cover"
+#~ msgstr "Estalkia irekita"
+
+#~ msgid "Open door"
+#~ msgstr "Atea irekita"
+
+#~ msgid "Low on paper"
+#~ msgstr "Paper gutxi"
+
+#~ msgid "Out of paper"
+#~ msgstr "Paperik ez"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Deskonektatuta"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Geldituta"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Hondakinen ontzia ia beteta"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Hondakinen ontzia beteta"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Argazki-eroale optikoa bere amaierara iristear dago"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Argazki-eroale optikoak ez du gehiago funtzionatuko"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Prest"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Ez du lanik onartzen"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Prozesatzen"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Inperiala"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrika"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Galdetu zer egin"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ez egin ezer"
+
+#~ msgid "Open folder"
+#~ msgstr "Ireki karpeta"
+
+#~ msgid "Other Media"
+#~ msgstr "Bestelako euskarria"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Hautatu aplikazioa audio CDentzako"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Hautatu aplikazioa bideo DVDentzako"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Hautatu aplikazio bat exekutatzeko musika erreproduzigailu bat "
+#~ "konektatzean"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Hautatu aplikazio bat exekutatzeko kamera bat konektatzean"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Hautatu aplikazioa softwaredun Audio CDentzako"
+
+#~ msgid "audio DVD"
+#~ msgstr "Audio DVDa"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Blu-Ray disko hutsa"
+
+#~ msgid "blank CD disc"
+#~ msgstr "CD disko hutsa"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "DVD disko hutsa"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "HD DVD disko hutsa"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-Ray bideo diskoa"
+
+#~ msgid "e-book reader"
+#~ msgstr "liburu elektronikoen irakurlea"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD bideo diskoa"
+
+#~ msgid "Picture CD"
+#~ msgstr "Argazkien CDa"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CDa"
+
+#~ msgid "Video CD"
+#~ msgstr "Bideo CDa"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Pantaila itzaltzen da"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 segundo"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "minutu 1"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutu"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutu"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutu"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutu"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "Ordu 1"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "minutu 1"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutu"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutu"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutu"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutu"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutu"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutu"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutu"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutu"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Inoiz ere ez"
+
+#~ msgid "Select Location"
+#~ msgstr "Hautatu kokalekua"
+
+#~ msgid "_OK"
+#~ msgstr "_Ados"
+
+#~ msgid "No applications found"
+#~ msgstr "Ez da aplikaziorik aurkitu"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Ez da sarerik hautatu partekatzeko"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Aktibatuta"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Desaktibatuta"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Gaituta"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktibo"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Aukeratu karpeta"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Gaitu multimedia partekatzea"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Fitxategiak partekatzeak zure uneko sareko beste erabiltzaileek zure "
+#~ "'Publikoa' karpeta ikustea ahalbidetzen du honakoa erabilita: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Urruneko saio-hasiera gaituta dagoenean, urruneko erabiltzaileek konekta "
+#~ "daitezke Shell Seguruko komandoa erabiliz: \n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Gaitu multimedia pertsonalen partekatzea"
+
+#~ msgid "Device name copied"
+#~ msgstr "Gailuaren izena kopiatu da"
+
+#~ msgid "Device address copied"
+#~ msgstr "Gailuaren helbidea kopiatu da"
+
+#~ msgid "Username copied"
+#~ msgstr "Erabiltzaile-izena kopiatu da"
+
+#~ msgid "Password copied"
+#~ msgstr "Pasahitza kopiatu da"
+
+#~ msgid "Custom"
+#~ msgstr "Pertsonalizatua"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s probatzen"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "% 100"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Deskonektatuta"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Konektatzen"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Konektatuta"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Baimen-errorea"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Baimentzen"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Funtzionaltasun murriztua"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Konektatua eta baimendua"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Ezezaguna"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Baimendua hemen:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Konektatua hemen:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Erregistratua hemen:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Ezin izan da gailua baimendu: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Ezin izan da gailua ahaztu: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Errorea"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Baimendua"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt azpisistema (boltd) ez dago instalatuta edo gaizki "
+#~ "konfiguratuta dago."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "USB eta Display Port gailuak soilik erantsi daitezke."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt ezin izan da detektatu.\n"
+#~ "Sistemak ez dauka Thunderbolt euskarririk, BIOSean desgaitu egin da edo "
+#~ "onartzen ez den segurtasun-maila batean ezarri da BIOSean."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt euskarria desgaitu egin da BIOSean."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Thunderbolten segurtasun-maila ezin izan da zehaztu."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Errorea modu zuzena aldatzean: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Lehenetsia"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Tartekoa"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Handia"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Oso handia"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Oso oso handia"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixel"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Laburra"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "Pantailaren ¼"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "Pantailaren ½"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "Pantailaren ¾"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Luzea"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "Ordu 1"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "Egun 1"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 egun"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 egun"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 egun"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 egun"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 egun"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 egun"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 egun"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 egun"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Hustu zakarrontziko elementu guztiak?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Zakarrontziko elementu guztiak betirako ezabatuko dira."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Hustu _zakarrontzia"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Ezabatu aldi baterako fitxategi guztiak?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Aldi baterako fitxategi guztiak betirako ezabatuko dira."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Ezabatu aldi baterako fitxategiak"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "Egun 1"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 egun"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 egun"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Beti"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr ""
+#~ "Zure kontuaren hornitzailearen web helbidearekin bat etorri behar du."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Huts egin du kontua gehitzean"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Huts egin du kontua erregistratzean"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Ez dago modurik onartuta domeinu honekin autentifikatzeko"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Huts egin du domeinuarekin elkartzean"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Saioaren hasierako izenak ez du funtzionatzen.\n"
+#~ "Saiatu berriro."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Saioaren hasierako pasahitzak ez du funtzionatzen.\n"
+#~ "Saiatu berriro."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Huts egin du domeinuan saioa hastean"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Ezin da domeinua aurkitu. Ongi idatzi duzu?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Arakatu irudi gehiago"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "gailua galdegin behar da ekintza hau gauzatu baino lehen"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "beste prozesu batek galdegin du gailua"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "ez duzu ekintza gauzatzeko baimenik"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "ez da inprimagailurik erregistratu"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Huts egin du erregistroan zehar gailuarekin komunikatzeak"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Huts egin du hatz-marken irakurgailuarekin komunikatzeak"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Huts egin du hatz-marken daemonarekin komunikatzeak"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Huts egin du hatz-markak zerrendatzeak: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Huts egin du gordetako hatz-markak ezabatzeak: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Ezkerreko hatz potoloa"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Ezkerreko erdiko hatza"
+
+#~ msgid "_Left index finger"
+#~ msgstr "E_zkerreko hatz erakuslea"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Ezkerreko hatz nagia"
+
+#~ msgid "Left little finger"
+#~ msgstr "Ezkerreko hatz txikia"
+
+#~ msgid "Right thumb"
+#~ msgstr "Eskuineko hatz potoloa"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Eskuineko erdiko hatza"
+
+#~ msgid "_Right index finger"
+#~ msgstr "E_skuineko hatz erakuslea"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Eskuineko hatz nagia"
+
+#~ msgid "Right little finger"
+#~ msgstr "Eskuineko hatz txikia"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Hatz-marka ezezaguna"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Eginda"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Hatz-marken gailua deskonektatu da"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Hatz-marken gailuen biltegiratzea beteta dago"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Huts egin du hatz-marka berria erregistratzeak"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Huts egin du erregistroa abiarazteak: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Huts egin du hatz-marka berria erregistratzeak"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Huts egin du erregistroa gelditzeak: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Altxatu eta kokatu hatza irakurgailuan behin eta berriro, zure hatz-marka "
+#~ "erregistratzeko"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Erregistratu berriro hatz hau…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Eskaneatu hatz-marka berria"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Huts egin du hatz-marken %s gailua askatzeak: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Arazoa gailua irakurtzean"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Huts egin du hatz-marken %s gailuaren jabetza galdegiteak: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Huts egin du hatz-marken gailuak eskuratzeak: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Aste honetan"
+
+#~ msgid "Last Week"
+#~ msgstr "Pasa den astean"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Saioa amaituta"
+
+#~ msgid "Session Started"
+#~ msgstr "Saioa hasita"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Kontuaren jarduera"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Aukeratu beste pasahitz bat."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Idatzi zure uneko pasahitza berriro."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Pasahitza ezin izan da aldatu"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Ezin da automatikoki honelako domeinu motarekin elkartu"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Ez da halako domeinurik aurkitu"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Ezin da %s gisa saioa-hasi %s domeinuan"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Baliogabeko pasahitza, saiatu berriro"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Ezin izan da %s domeinuarekin konektatu: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Huts egin du erabiltzailea ezabatzean"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Huts egin du urrunetik kudeatzeko erabiltzailea errebokatzean"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Ezin duzu zeure kontua ezabatu."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s oraindik saioan sartuta dago"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Erabiltzailea ezabatzen bada saioan sartuta dagoen bitartean, sistema "
+#~ "egoera inkoherentean utz daiteke."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "%s(r)en fitxategiak mantentzea nahi dituzu?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Karpeta nagusia, postaren ilara eta aldi baterako fitxategiak gordetzeko "
+#~ "aukera dago erabiltzaile baten kontua ezabatzean."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Ezabatu fitxategiak"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Mantendu fitxategiak"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Ziur zaude urrunetik kudeatutako “%s”(r)en kontua errebokatzea nahi "
+#~ "duzula?"
+
+#~ msgid "_Delete"
+#~ msgstr "Ez_abatu"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Kontua desgaituta"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Hurrengo saioan ezartzeko"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Bat ere ez"
+
+#~ msgid "Logged in"
+#~ msgstr "Saioan sartuta"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Huts egin du kontuaren zerbitzuarekin kontaktatzean"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Ziurtatu zaitez kontuen zerbitzua instalatuta eta gaituta dagoela."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Panel hau desblokeatu behar da ezarpen hori aldatzeko"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Ezabatu hautatutako erabiltzailearen kontua"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Hautatutako erabiltzailearen kontua ezabatzeko\n"
+#~ "aurrenik egin klik * ikonoan"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Desblokeatu erabiltzaileak gehitzeko eta ezarpenak aldatzeko"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Pasahitz berriak zaharrarengandik desberdina izan behar du."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Saiatu hizki eta zenbaki batzuk aldatzen."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Saiatu pasahitza piska bat gehiago aldatzen."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr ""
+#~ "Zure erabiltzaile-izenik gabeko pasahitz bat askoz ere sendoagoa "
+#~ "litzateke."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Saiatu zure izena pasahitzean erabiltzea saihestea."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Saiatu pasahitzean sartutako hitz batzuk saihestea."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Saiatu hitz arruntak saihestea."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Saiatu dauden hitzen berrantolaketa saihestea."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Saiatu zenbaki gehiago erabiltzea."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Saiatu hizki maiuskulak gehiago erabiltzea."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Saiatu hizki minuskulak gehiago erabiltzea."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Saiatu karaktere berezi gehiago erabiltzea, harridura ikurra bezalakoak."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Saiatu hizki, zenbaki eta ikurren arteko nahasketa batekin."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Saiatu karaktere berdina errepikatzea saihestea."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Saiatu karaktere mota berdina errepikatzea saihestea: hizki, zenbaki eta "
+#~ "ikurrak nahastu behar dituzu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Saiatu 1234 edo abc bezalako sekuentziak saihestea."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Pasahitzak luzeagoa izan behar du. Saiatu hizki, zenbaki eta ikurren "
+#~ "arteko nahasketa gehiagorekin."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Nahastu hizki maiuskulak eta minuskulak eta erabili zenbaki bat edo bi."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "Hizki, zenbaki eta ikur gehiago gehitzeak sendoagoa egingo du."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autentifikazioak huts egin du"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Pasahitza laburregia da"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Pasahitza sinpleegia da"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Pasahitz zaharra eta berria oso antzekoak dira"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Pasahitz berria azken aldian erabilia izan da."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Pasahitz berriak karaktere numeriko edo berezia(k) eduki behar ditu"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Pasahitz zaharra eta berria berdinak dira"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Pasahitza aldatu egin da hasieran autentifikatu zinenetik"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Pasahitz berriak ez dauzka nahikoa karaktere desberdin"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Errore ezezaguna"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Erabiltzaile-izenak honako karaktereak soilik eduki ditzake:  alfabetoko "
+#~ "a-z arteko hizki minuskulak, digituak eta '.', '-' eta '_' karaktereak."
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Erabiltzaile-izen hori ez dago erabilgarri. Saiatu beste batekin."
+
+#~ msgid "The username is too long."
+#~ msgstr "Erabiltzaile-izena luzeegia da."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "%d. botoia"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Aplikazioan definituta"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Bidali tekla sakatzea"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Aldatu monitorea"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Erakutsi pantailako laguntza"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Eramangarriaren panelean muntatutako tableta"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Kanpoko pantailan muntatutako tableta"
+
+#~ msgid "External tablet device"
+#~ msgstr "Kanpoko tableta-gailua"
+
+#~ msgid "All Displays"
+#~ msgstr "Pantaila guztiak"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Airbrush stylus gailua presioarekin, inklinazioarekin eta integratutako "
+#~ "graduatzailearekin"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr ""
+#~ "Airbrush stylus gailua presioarekin, inklinazioarekin eta biraketarekin"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Airbrush stylus gailua presioarekin eta inklinazioarekin"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Airbrush stylus gailua presioarekin"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Laster-tekla berria…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Eragiketa bertan behera utzi da"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Errorea:</b> Sarbidea ukatu da ezarpenak aldatzean"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Error:</b> Ekipamendu mugikorraren errorea"
+
+#~ msgid "Not Registered"
+#~ msgstr "Erregistratu gabea"
+
+#~ msgid "Registered"
+#~ msgstr "Erregistratua"
+
+#~ msgid "Roaming"
+#~ msgstr "Ibiltaritza"
+
+#~ msgid "Searching"
+#~ msgstr "Bilatzen"
+
+#~ msgid "Denied"
+#~ msgstr "Ukatua"
+
+#~ msgid "2G Only"
+#~ msgstr "2G soilik"
+
+#~ msgid "3G Only"
+#~ msgstr "3G soilik"
+
+#~ msgid "4G Only"
+#~ msgstr "4G soilik"
+
+#~ msgid "5G Only"
+#~ msgstr "5G soilik"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (hobetsia)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (hobetsia), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (hobetsia), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (hobetsia), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (hobetsia)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (hobetsia), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (hobetsia), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (hobetsia)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (hobetsia), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (hobetsia), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (hobetsia)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (hobetsia), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (hobetsia), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (hobetsia)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (hobetsia), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (hobetsia), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (hobetsia)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (hobetsia), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (hobetsia)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (hobetsia), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (hobetsia)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (hobetsia), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (hobetsia)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (hobetsia), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (hobetsia)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (hobetsia), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (hobetsia)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (hobetsia), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Ezezaguna"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Desblokeatu SIM txartela"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Sartu %d SIM txartelaren PIN kodea"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Sartu PIN kodea zure SIM txartela desblokeatzeko"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Sartu %d SIM txartelaren PUK kodea"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Sartu PUK kodea a zure SIM txartela desblokeatzeko"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Pasahitz okerra sartu da."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK kodea 8 digituko zenbakia da"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Sartu PIN berria"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN kodeak 4-8 digitu zenbakia izan behar du"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Desblokeatzen…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Akatsa telefonoan"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Ez dago konexiorik telefonoarekin"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Eragiketa ez dago baimenduta"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Eragiketa ez dago onartuta"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIMa ez dago txertatuta"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIMaren PINa behar da"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIMaren PUKa behar da"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIMak huts egin du"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIMa lanpetuta dago"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Pasahitz okerra"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIMaren PIN2a behar da"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIMaren PUK2a behar da"
+
+#~ msgid "Not found"
+#~ msgstr "Ez da aurkitu"
+
+#~ msgid "No network service"
+#~ msgstr "Ez dago sareko zerbitzurik"
+
+#~ msgid "Network timeout"
+#~ msgstr "Sarea denbora-mugara iritsi da"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS zerbitzuak ez dira onartzen"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Ibiltaritza ez da onartzen kokaleku-area honetan"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Zehaztu gabeko GPRS errorea"
+
+#~ msgid "No Error"
+#~ msgstr "Errorerik ez"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Ekintza bertan behera geratu da"
+
+#~ msgid "Access denied"
+#~ msgstr "Sarbidea ukatu da"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Errore ezezaguna"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "%d SIMa"
+
+#~ msgid "Display version number"
+#~ msgstr "Erakutsi bertsio-zenbakia"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Gaitu modu xehea"
+
+#~ msgid "Search for the string"
+#~ msgstr "Bilatu katea"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Zerrendatu panel posibleen izenak eta irten"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panela bistaratzeko"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANELA] [ARGUMENTUA…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Panel erabilgarriak:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sistemaren soinuak"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Errorea: ezin izan da HSI maila zehaztu."
@@ -9323,9 +8318,6 @@ msgstr "Sistemaren soinuak"
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER edo PEM ziurtagiriak (*.der, *.pem, *.crt, *.cer)"
 
-#~ msgid "Add a Printer…"
-#~ msgstr "Gehitu inprimagailua…"
-
 #~ msgid "Drip"
 #~ msgstr "Ura"
 
@@ -9334,9 +8326,6 @@ msgstr "Sistemaren soinuak"
 
 #~ msgid "Sonar"
 #~ msgstr "Sonarra"
-
-#~ msgid "No Protection"
-#~ msgstr "Babesik ez"
 
 #~ msgid "Minimal Protection"
 #~ msgstr "Gutxieneko babesa"
@@ -9652,8 +8641,8 @@ msgstr "Sistemaren soinuak"
 #~ msgstr "Ezin dira aldatu"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Aplikazioen banakako baimenak <a href=\"privacy\">Pribatutasuna</a> "
 #~ "ezarpenetan berrikusi daitezke."
@@ -9781,9 +8770,6 @@ msgstr "Sistemaren soinuak"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Taula (absolutua)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Ukipen-panela (erlatiboa)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Taularen hobespenak"
@@ -10068,9 +9054,6 @@ msgstr "Sistemaren soinuak"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Atzitu Bluetooth hardwarea zuzenean"
-
-#~ msgid "Use your camera"
-#~ msgstr "Erabili zure kamera"
 
 #~ msgid "Print documents"
 #~ msgstr "Inprimatu dokumentuak"

--- a/po/eu.po~
+++ b/po/eu.po~
@@ -1,0 +1,10570 @@
+# Basque translation of gnome-control-center.
+# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER.
+#
+# Hizkuntza Politikarako Sailburuordetza <hizkpol@ej-gv.es>, 2004, 2005.
+# Iñaki Larrañaga Murgoitio <dooteo@zundan.com>, 2004, 2005, 2006, 2007, 2008, 2009, 2010.
+# Iñaki Larrañaga Murgoitio <dooteo@zundan.com>, 2011, 2012, 2013, 2014, 2015, 2016, 2017.
+# Asier Sarasua Garmendia <asiersarasua@ni.eus>, 2013, 2019, 2020, 2021, 2022.
+#
+msgid ""
+msgstr "Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issues\n"
+"POT-Creation-Date: 2022-08-28 14:52+0000\n"
+"PO-Revision-Date: 2022-08-31 14:00+0100\n"
+"Last-Translator: Asier Sarasua Garmendia <asiersarasua@ni.eus>\n"
+"Language-Team: Basque <librezale@librezale.eus>\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Sistemaren bus-a"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Sarbide osoa"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Saioaren bus-a"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Gailuak"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Sarbide osoa /dev direktoriora"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Sarea"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Sarea atzitu dezake"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Karpeta nagusia"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Irakurtzeko soilik"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Fitxategi-sistema"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Ezarpenak"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Ezarpenak aldatu ditzake"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr "%s aplikazioak honako baimenak ditu integratuta. Baimen horiek ezin dira aldatu. Baimen horien inguruko kezkaren bat baduzu, beharbada aplikazio hori kendu beharko zenuke."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "Aplikazioak irekitzen dituen %u fitxategi eta esteka mota"
+msgstr[1] "Aplikazioak irekitzen dituen %u fitxategi eta esteka motak"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> hurrengo fitxategi motak eta estekak irekitzeko erabiltzen da."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "Erabilitako disko-espazioa: %s."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplikazioak"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Aplikaziorik ez"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Instalatu zenbait…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Ireki"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Ikusi xehetasunak"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Bilatu"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Jaso sistemaren bilaketak eta bidali emaitzak."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Desgaituta"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Jakinarazpenak"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Erakutsi sistemaren jakinarazpenak."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Exekutatu atzeko planoan"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Onartu jarduera aplikazioa itxita dagoenean."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Pantaila-argazkiak"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Egin pantailaren argazkiak nahieran."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Aldatu horma-papera"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Aldatu mahaigainaren horma-papera."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Soinuak"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Erreproduzitu soinuak."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Galarazi lasterbideak"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Bloketau teklatuko lasterbide estandarrak."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Sortu irudiak kamerarekin."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofonoa"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Grabatu audioa mikrofonoarekin."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Kokalekuaren zerbitzuak"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Atzitu gailuaren kokaleku-datuak."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Integratutako baimenak"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Aplikazioak behar duen sistema-sarbidea"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Fitxategi- &amp; esteka-elkarketak"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Biltegiratzea"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Ez da emaitzarik aurkitu"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Saiatu bestelako bilaketa"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Fitxategi- eta esteka-elkarketak"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Fitxategi motak"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Esteka motak"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Berrezarri"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "Diskoko zenbat espazio betetzen ari den aplikazio hau datuekin eta cacheekin."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplikazioa"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Datuak"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cachea"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Guztira</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Garbitu cachea…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Kontrolatu aplikazioen baimenak eta ezarpenak"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplikazioa;flatpack;baimena;ezarpena;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Hautatu argazki bat"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Utzi"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Ireki"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "hainbat tamaina"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Mahaigaineko atzeko planorik ez"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Uneko atzeko planoa"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Estiloa"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Lehenetsia"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Iluna"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Atzeko planoa"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Gehitu argazkia…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Itxura"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Aldatu atzeko planoko irudia edo interfazearen koloreak"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Atzeko planoa;Horma-papera;Pantaila;Mahaigaina;Estiloa;Argia;Iluna;Itxura;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Gaitu"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Ez da Bluetooth-ik aurkitu"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Konektatu Bluetooth gailua erabiltzeko"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth-a itzalita"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Piztu gailuak konektatzean eta hartu fitxategien transferentziak."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Hegazkin modua piztuta dago"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth-a desaktibatuta dago hegazkinaren modua piztuta agoenean."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Itzali hegazkin modua"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Hardwarearen hegazkin modua piztuta dago"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Itzali hegazkin modua Bluetooth-a gaitzeko."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Aktibatu eta desaktibatu Bluetooth eta konektatu gailuak"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "partekatu;partekatzea;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera itzalita dago"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Aplikazioek ezin dituzte argazkiak edo bideoa kapturatu."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr "Kamera erabilita, aplikazioek argazkiak eta bideoak kaptura ditzakete. Kamera desgaitzen bada, beharbada zenbait aplikaziok ez dute behar den moduan funtzionatuko.\n"
+"\n"
+"Baimendu beheko aplikazioei zure kamera erabiltzea."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Ez dago aplikaziorik kamera erabiltzeko baimena eskatu duenik"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Babestu zure irudiak"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "kamera;argazkiak;bideoa;webkamera;blokeatu;pribatua;pribatutasuna;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Jarri kalibrazioaren gailua karratuaren gainean eta egin klik \"Hasi\" botoian"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "Mugitu kalibrazioaren gailua posizioa kalibratzeko eta egin klik  \"Jarraitu\" botoian"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Mugitu kalibrazioaren gailua gainazalaren posiziora eta egin klik  \"Jarraitu\" botoian"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Itxi eramangarriaren estalkia"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Berreskura ezin daitekeen barneko errorea gertatu da."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Kalibratzeko behar diren tresnak ez daude instalatuta."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Ezin izan da profila sortu."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Ez da helburuko puntu zuria eskuratu."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Osatuta!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrazioak huts egin du."
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Kalibrazioaren gailua ken dezakezu."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ez mugitu kalibrazioaren gailua lanean ari den bitartean"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Pantailaren kalibrazioa"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Hasi"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Jarraitu"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Eginda"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Eramangarriaren pantaila"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Web-kamera integratuta"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s pantaila"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s eskanerra"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s kamera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s inprimagailua"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s web-kamera"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Gaitu '%s'(r)en kolore-kudeaketa"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Erakutsi '%s'(r)en kolore-profilak"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Kalibratu gabea"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Lehenetsia: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Kolore-espazioa: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Probako profila: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Hautatu ICC profilaren fitxategia"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Inportatu"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Onartutako ICC profilak"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Fitxategi denak"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantaila"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Gorde profila"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Gorde"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Sortu kolore-profil bat hautatutako gailuarentzako"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "Ez da neurgailurik detektatu. Ziurtatu zaitez piztuta eta ongi konektatuta dagoela."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Neurgailuak ez du inprimagailuaren profilarik onartzen"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Gailu mota ez dago oraingoz onartuta."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Pantailaren kalibrazioa"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibrazioaren kalitatea"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr "Kalibrazioak profil bat sortuko du pantailaren kolorea kudeatzeko. Kalibrazioa zenbat eta sakonagoa izan, kolore-profilaren kalitatea hobea izango da."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Ezingo duzu ordenagailua erabili kalibratzen ari den bitartean."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kalitatea"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Estimatutako denbora"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibrazioaren gailua"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Hautatu kalibrazioan erabiltzea nahi duzun sentsore-gailua."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Pantaila mota"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Hautatu konektatuta dagoen pantaila mota."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profilaren puntu zuria"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr "Hautatu helburuko pantailaren puntu zuria. Pantaila gehienak D65 argitasunera doitu beharko lirateke."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Pantailaren distira"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr "Ezarri pantailan zuretzako ohikoa den distira. Kolorearen kudeaketa zehatzagoa izango da distiraren maila horretan."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr "Bestela, gailu honen beste profiletariko batekin erabilitako distiraren maila erabil dezakezu"
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profilaren izena"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr "KOlore-profila bat erabil dezakezu ordenagailu desberdinetan, edo argitasun baldintza desberdinetarako profilak sor ditzakezu baita ere."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profilaren izena:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Laburpena"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profila ongi sortu da."
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopiatu profila"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Euskarri idazgarria behar da"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr "You may find these instructions on how to use the profile on Profila <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> eta <a href=\"windows\">Microsoft Windows</a> sistemetan nola erabil daitekeen buruzko informazioa lagungarri gerta dakizuke."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Gehitu profila"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr "Arazoak aurkitu dira. Baliteke profilak ongi ez funtzionatzea. <a href=\"\">Erakutsi xehetasunak.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Inportatu fitxategia…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Gehitu"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "Gailu bakoitzak koloreen profilaren eguneratzea behar du koloreak kudeatzeko."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Ikasi gehiago"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Ikasi kolore-kudeaketari buruz gehiago"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Ezarri erabiltzaile guztientzako"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Ezarri profila hau ordenagailuko erabiltzaile guztientzako"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Gaitu"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Gehitu profila"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibratu…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibratu gailua"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Kendu _profila"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "Ikusi _xehetasunak"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Ezin da koloreak kudea ditzakeen gailurik detektatu"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Proiektagailua"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCDa (atzeko CCFL argia)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCDa (atzeko LED RGB argia)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCDa (LED argi zuria)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Kolore-gama zabaleko LCDa (atzeko CCFL argia)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Kolore-gama zabaleko LCDa (atzeko LED GBU argia)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Altua"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutu"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Tartekoa"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutu"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Baxua"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutu"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Pantailarekiko jatorrizkoa"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (inprimazioa eta argitalpena)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (argazki eta grafikoak)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Espazio estandarrak"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Probako profila"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatikoa"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Kalitate baxua"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Tarteko kalitatea"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Kalitate altua"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "GBU lehenetsia"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK lehenetsia"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Grisa lehenetsia"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Saltzaileak emandako kalibrazioaren fabrikako datuak"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Pantaila osoko zuzenketa ezinezkoa da profila honekin"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Profila hau ezingo da gehiago zehatza izan"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Kolorea"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Kalibratu pantaila, kamera edo inprimagailuak bezalako gailuen kolorea"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Kolorea;ICC;Profila;Kalibratu;Inprimagailua;Pantaila;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Bestelakoa…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Hautatu hizkuntza"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Hautatu"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Ez da hizkuntzarik aurkitu"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Gehiago…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Desblokeatu ezarpenak aldatzeko"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Zenbait ezarpen desblokeatu egin behar dira aldatu ahal izateko."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Desblokeatu…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Gehitu orduak"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Gehitu minutuak"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Ordua"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Gutxitu orduak"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Gutxitu minutuak"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Gaur"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Atzo"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b/%e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%Y/%b/%e"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "ordu %d"
+msgstr[1] "%d ordu"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "minutu %d"
+msgstr[1] "%d minutu"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "segundo %d"
+msgstr[1] "%d segundo"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 segundo"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Wifigunea"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 ordu"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%Y/%B/%e, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%Y/%B/%e, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data eta ordua"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Urtea"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Hila"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Urtarrila"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Otsaila"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Martxoa"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Apirila"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maiatza"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Ekaina"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Uztaila"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Abuztua"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Iraila"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Urria"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Azaroa"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Abendua"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Eguna"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Ordu-zona"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Bilatu herria"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Data eta ordu automatikoa"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Interneteko konexioa behar da"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Data eta _ordua"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Ordu-_zona automatikoa"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Kokaleku-zerbitzuek gaituta egon behar dute eta Interneterako sarbide eduki behar da"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Gaituta"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Ordu-_zona"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Orduaren _formatua"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Aldatu data eta ordua, ordu-zona barne"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Erlojua;Ordu-zona;Kokalekua;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Aldatu sistemaren ordua eta dataren ezarpenak"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Sistemaren ordua eta dataren ezarpenak aldatzeko, autentifikatu egin behar zara."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Weba"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Mezua"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Egutegia"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usika"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Bideoa"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Argazkiak"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplikazio lehenetsiak"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Konfiguratu aplikazio lehenetsiak"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "lehenetsia;aplikazioa;hobetsia;euskarria;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr "Arazo teknikoei buruzko txostenak bidaltzean %s hobetzen laguntzen diguzu. Txostenak modu anonimoan bidaltzen dira eta ez dute datu pertsonalik. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Arazoaren berri ematea"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Arazoei buruz txostena automatikoki bidali"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostikoa"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Eman zure arazoen berri"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostikoak;kraskadura;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Aktibatuta"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Desaktibatuta"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Aplikatu aldaketak?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Aldaketak ezin dira aplikatu"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Hardwarearen mugen erruz izan daiteke."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Aplikatu"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Atzera"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Pantaila-ezarpenak desgaituta"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Pantaila anitz"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Elkartu"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Ispilutu"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Goiko barra eta 'Jarduerak' ditu"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Pantaila nagusia"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Gaueko argia"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Horizontala"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Bertikala eskuinera"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Bertikala ezkerrera"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Horizontala (iraulita)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientazioa"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Bereizmena"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Freskatze-tasa"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Doitu telebistarako"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Eskalatu"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "“Gaueko argia” ez dago erabilgarri"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr "Gailuak duen txartel grafikoaren emaitza izan daiteke, edo urrunean erabiltzen ari den mahaigainaren ondorioz"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Denbora baterako desgaituta bihar arte"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Berrabiarazi iragazkia"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr "Gaueko argiaren moduak pantailaren kolorea epeltzen du. Horrek begien estresa eta lo arazoak saihesten lagun dezake."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Antolaketa"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Egunsentitik ilunabarrera"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Eskuzko programazioa"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Orduak"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Nondik"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Ordua"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minutua"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Nora"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Kolore-tenperatura"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Pantailak"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Aldatu konektatutako pantaila eta proiektagailuak nola erabiliko diren"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Panela;Proiektagailua;xrandr;Pantaila;Bereizmena;Freskatu;Monitorea;Gaua;Argia;Urdina;kolorea;egunsentia;ilunabarra;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Abio segurua aktibatuta dago"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria kargatu dadin. Une honetan aktibatuta dago eta ongi funtzionatzen du."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Abio seguruak arazoak ditu"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria kargatu dadin. Une honetan aktibatuta dago, baina ez du funtzionatuko gako baliogabea duelako."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr "Abio seguruaren arazoak sarritan ordenagailuaren UEFI firmwarearen ezarpenak (BIOS) aldatuz konpontzen dira. Hardwarearen fabrikatzaileak horri buruzko informazio gehiago eman diezazuke."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "Laguntza jasotzeko, jarri harremanetan zure hardwarearen fabrikatzailearekin edo laguntza informatikoa ematen dizunarekin."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Abio segurua desaktibatuta dago"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria kargatu dadin. Une honetan desaktibatuta dago."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr "Abio segurua sarritan ordenagailuaren UEFI firmware-ezarpenetan (BIOS) aktibatu daiteke. Laguntza jasotzeko, hitz egin zure hardwarearen fabrikatzailearekin edo laguntza informatikoa ematen dizunarekin."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr "Abio seguruak eragozten du gailua abiarazten denean software kaltegarria kargatu dadin.\n"
+"\n"
+"Informazio gehiagorako, jarri harremanetan hardwarearen fabrikatzailearekin edo informatikako teknikariekin."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Pasatu da"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Huts egin du"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Gailuak HSI %d maila betetzen du"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Segurtasun-maila: 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr "Gailu honek ez du babesik hardwareko segurtasun-arazoen aurrean. Hardareko edo firmwareko konfigurazio-arazo baten ondorioa izan daiteke hori. Zure informatikako teknikariekin hitz egin dezazun gomendatzen dizugu."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Segurtasun-maila: 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr "Gailu honek guxieneko babesa du hardwareko segurtasun-arazoen aurrean. Gailuaren segurtasun-mailarik txikiena da eta segurtasun-arrisku sinpleen aurkako babesa soilik eskaintzen du."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Segurtasun-maila: 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr "Gailu honek oinarrizko babesa du hardwareko segurtasun-arazoen aurrean. Horrek segurtasun-arrisku arruntenen aurkako babesa eskaintzen du."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Segurtasun-maila: 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr "Gailu honek babes hedatua du hardwareko segurtasun-arazoen aurrean. Gailuaren segurtasun-mailarik altuena da eta segurtasun-arrisku aurreratuen aurkako babesa eskaintzen du."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Segurtasun-maila"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Segurtasun-mailak ez daude erabilgarri gailu honetarako."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr "Jarri harremanetan zure hardwarearen fabrikatzailearekin segurtasun-eguneratzeei buruzko laguntza jasotzeko."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr "Agian arazo hori gailuaren UEFI firmware-ezarpenetan konpondu daiteke, edo informatikako teknikariaren laguntzarekin."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "Agia arazo hori gailuaren UEFI firmware-ezarpenetan konpondu daiteke."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Agian zure informatikako teknikariak lagundu ahal dizu arazoa konpontzen."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "1. maila"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "2. maila"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "3. maila"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Software kaltegarriaren aurka babestua gailua abiarazten denean,"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Abio seguruak arazoak ditu"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Nolabaiteko babesa gailua abiarazten denean."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Abio segurua desaktibatuta dago"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Babesik ez gailua abiarazten denean."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr "Arazoa UEFI firmware-ezarpenetan aldaketa bat egon delako sortu da agian, edo sistema eragilearen konfigurazio-aldaketa bat egon delako edo software kaltegarria sartu delako sisteman."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr "Arazoa UEFI firmware-ezarpenetan aldaketa bat egon delako sortu da agian, edo software kaltegarria sartu delako sisteman."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr "Arazoa sistema eragilearen konfigurazio-aldaketa bat egon delako sortu da agian, edo software kaltegarria sartu delako sisteman."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Segurtasun-arriskuen aurrean kaltebera."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Babes mugatua segurtasun-arrisku sinpleen aurrean."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Babestua segurtasun-arrisku arrunten aurrean."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Babestua segurtasun-arrikus asktoren aurrean."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Babes osoa"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Gertaerarik ez"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Firmwarearen idazketa-babesa"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Firmwarearen idazketa-babesaren blokeoa"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Firmwarearen BIOS eskualdea"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Firmwarearen BIOS deskribatzailea"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Abio aurreko DMA babesa"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard abio egiaztatua"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM babestua"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard errore-politika"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard fusiblea"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET gaituta"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET aktibo"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Zifratutako RAMa"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU babesa"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux kernelaren blokeoa"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux kernelaren egiaztatzea"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux trukatze-espazioa"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Eseki RAMera"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Eseki inaktibora"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI plataforma-gakoa"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI abio segurua"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TMP plataformaren konfigurazioa"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM berreraikuntza"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel kudeaketa-motorraren manufaktura modua"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel kudeaketa-motorraren indargabetzea"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine bertsioa"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Firmwarearen eguneratzeak"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Firmwarearen egiaztatzea"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Firmware-eguneratzailearen egiaztatzea"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Plataforma-arazketa"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Prozesadore-segurtasunaren egiaztatzeak"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMDren desinstalazio-babesa"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD firmwarearen errepikapen-babesa"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD firmwarearen idazketa-babesa"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Fusionatutako plataforma"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Baliozkoa"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Ez baliozkoa"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Ez gaitua"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Blokeatua"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Ez blokeatua"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Zifratua"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Ez zifratua"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Kutsatua"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Ez kutsatua"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Aurkitua"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Ez aurkitua"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Onartua"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Ez onartua"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Gailu-segurtasuna"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Ostalari-firmwarearen segurtasun-egoera"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr "pantaila;blokeoa;diagnostikoa;kraskadura;pribatua;azkena;aldi baterakoa;tmp;indizea;izena;sarea;identitatea;pribatutasuna;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64 bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32 bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Ez dago erabilgarri"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Sistemaren logoa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Gailuaren izena"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Hardware-eredua"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memoria"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Prozesadorea"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafikoak"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Diskoaren ahalmena"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Kalkulatzen…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "SE izena"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "SE eraikuntzaren IDa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "SE mota"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME bertsioa"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Kargatzen…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Leiho-sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Birtualizazioa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Software-eguneratzeak"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Aldatu gailuaren izena"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr "Gailuaren izena hura identifikatzeko erabiltzen da sarean barrena bistaratzen denean, edo Bluetooth gailuekin parekatzen denean."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Gailuaren izena"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Aldatu izena"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Honi buruz"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Ikusi sistemari buruzko informazioa"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr "gailua;sistema;informazioa;ostalari-izena;memoria;prozesadorea;bertsioa;lehenetsia;aplikazioa;hobetsia;cd;dvd;usb;audioa;bideoa;diskoa;aldagarria;euskarria;auto-exekuzioa;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Soinua eta multimedia"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Bolumena mututu/mututasuna eten"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Jaitsi bolumena"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Igo bolumena"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Mikrofonoa mututu/mututasuna eten"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Abiarazi multimedia-erreproduzitzailea"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Erreproduzitu (edo erreproduzitu/pausarazi)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pausarazi erreprodukzioa"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Gelditu erreprodukzioa"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Aurreko pista"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Hurrengo pista"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Egotzi"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Idazketa"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Aldatu hurrengo sarrerako iturburura"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Aldatu aurreko sarrerako iturburura"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Abiarazleak"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Abiatu laguntza-arakatzailea"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Abiarazi kalkulagailua"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Abiarazi posta-bezeroa"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Abiatu web arakatzailea"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Karpeta nagusia"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Bilatu"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Amaitu saioa"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Blokeatu pantaila"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Erabilerraztasuna"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Aktibatu edo desaktibatu zooma"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Handiagotu"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Txikiagotu"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Aktibatu edo desaktibatu pantailako irakurlea"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Aktibatu edo desaktibatu pantailako teklatua"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Handiagotu testuaren tamaina"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Txikiagotu testuaren tamaina"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Gaitu edo desgaitu kontraste altua"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Ez da sarrerako iturbururik aurkitu"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Bestelakoa"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Gehitu sarrerako iturburua"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Ezin dira sarrerako metodoak erabili saio-hasierako pantailan"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Ez da sarrerako iturbururik hautatu"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Aukerak"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Eraman gora"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Eraman behera"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Hobespenak"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Bistaratu teklatuaren diseinua"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Kendu"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Laster-tekla pertsonalizatuak"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Ordezko karaktereen tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr "Ordezko karaktereen tekla karaktere gehigarriak sartzeko erabil daiteke. Batzuetan hirugarren aukera gisa inprimatuta ageri dira zure teklatuan."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Ezkerreko Alt tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Eskuineko Alt tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Ezkerreko Super tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Eskuineko Super tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menu tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Eskuineko Ctrl tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr "Compose teklak mota askotako karaktereak sartzea ahalbidetzen du. Hura erabiltzeko, sakatu Compose tekla eta, ondoren, karaktereen sekuentzia bat. Adibidez, Compose tekla sakatuta, eta ondoren <b>C</b> eta <b>o</b> erabilita, <b>©</b> sartuko du; <b>a</b> eta ondoren <b>'</b> erabilita, <b>á</b> sartuko du."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Maiuskulak blokeatzeko tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Korritzea blokeatzeko tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Pantaila inprimatzeko tekla"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr "Sarrerako iturburuak %s lasterbidea erabilita txandakatu daitezke.\n"
+"Lasterbide hori ezarpenetan aldatu daiteke."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Sarrerako iturburuak"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Teklatuaren diseinuak eta sarrerako metodoak ere hartzen ditu."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Sarrerako iturburua aldatzea"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Erabili iturburu _bera leiho guztietan"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Aldatu sarrerako iturburua ba_naka leiho bakoitzean"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Karaktere bereziaren sarrera"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Teklatuaren bidez ikurrak eta letren aldaerak sartzeko metodoak."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Laster-teklak"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Ikusi eta pertsonalizatu laster-teklak"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d aldatu da"
+msgstr[1] "%d aldatu da"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Berrezarri lasterbide guztiak?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr "Lasterbideak berrezartzeak zure lasterbide pertsonalizatuei eragin diezaieke. Hori ezin da desegin."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Utzi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Berrezarri dena"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Berrezarri dena…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Berrezarri laster-tekla guztiak beraien laster-tekla lehenetsira"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Atala"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Lasterbideak"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Gehitu lasterbide bat"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Gehitu laster-tekla pertsonalizatuak"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "Konfiguratu laster-tekla pertsonalizatuak aplikazioak abiarazteko, scriptak exekutatzeko eta gehiagorako."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Gehitu laster-tekla"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Ez da teklatuaren laster-teklarik aurkitu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s dagoeneko erabilia izaten ari da %s(e)rako. Hura ordezten baduzu, %s desgaitu egingo da"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Sartu laster-tekla berria"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Ezarri laster-tekla pertsonalizatua"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Ezarri laster-tekla"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Sartu laster-tekla berria %s aldatzeko."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Gehitu laster-tekla pertsonalizatua"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Kendu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "O_rdeztu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "E_zarri"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Sakatu Esc tekla laster-tekla bertan behera uzteko edo atzera-tekla desgaitzeko."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Izena"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Komandoa"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Laster-tekla"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Ezarri laster-tekla…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Bat ere ez"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Leheneratu laster-tekla bere balio lehenetsira"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Teklatua"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "Aldatu teklatuko lasterbideak eta ezarri idazte-hobespenak, teklatu-diseinuak eta sarrerako iturburuak"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr "Laster-tekla;Laneko area;Leihoa;Tamaina aldatzea;Zooma;Kontrastea;Sarrera;Iturburua;Blokeatu;Bolumena;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Kokaleku-zerbitzuak itzalita"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Aplikazioek ezin dute kokalekuaren informazioa eskuratu."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr "Kokaleku-zerbitzuek aplikazioek zure kokalekua ezagutzea baimentzen dute. Haririk gabekoa eta mugikorren banda zabala erabiltzeak zehaztasuna handiagotzen du.\n"
+"\n"
+"Mozilla Location Service erabiltzen du: <a href='https://location.services.mozilla.com/privacy'>Pribatutasun-politika</a>\n"
+"\n"
+"Baimendu beheko aplikazioei zure kokalekua ezagutu dezaten."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Ez dago aplikaziorik kokalekua erabiltzea eskatu duenik"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Babestu zure kokalekuaren informazioa"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "kokalekua;gps;pribatua;pribatutasuna;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofonoa itzalita"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Aplikazioek ezin dute soinua grabatu."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr "Mikrofonoa erabilita, aplikazioek audioa grabatu dezakete. Mikrofonoa desgaitzen bada, beharbada zenbait aplikaziok ez dute behar den moduan funtzionatuko.\n"
+"\n"
+"Baimendu beheko aplikazioei zure kamera erabiltzea."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Ez dago aplikaziorik mikrofonoa erabiltzea eskatu duenik"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Babestu zure hizketaldiak"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofonoa;grabazioa;aplikazioa;pribatutasuna;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Probatu zure _ezarpenak"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Orokorra"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Botoi nagusia"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Saguaren eta ukipen-panelaren botoi fisikoen ordena ezartzen du."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Ezkerrean"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Eskuinean"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Sagua"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Saguaren abiadura"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Korritze naturala"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Korritzeak edukia mugitzen du, ez ikuspegia."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Ukipen-panela"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Ukipen-panelaren abiadura"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Ukitu klik egiteko"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Ukitu klik egiteko"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Bi hatzeko korritzea"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Ertzaren korritzea"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Saiatu klik, klik bikoitza egiten, korritzen"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Bost klik, GEGL garaia!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Klik bikoitza, botoi nagusia"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Klik bakuna, botoi nagusia"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Klik bikoitza, erdiko botoia"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Klik bakuna, erdiko botoia"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Klik bikoitza, bigarren mailako botoia"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Klik bakuna, bigarren mailako botoia"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Sagua eta ukipen-panela"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "Aldatu saguaren edo ukipen-panelaren sentikortasuna eta hautatu eskuin edo ezkerreko eskuarekin erabiltzea"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Erakuslea;Klik;Sakatu;Bikoitza;Botoia;Trackball;Korritu;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Izkina _beroa"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Ukitu goiko ezkerreko izkina jardueren ikuspegi orokorra irekitzeko."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Pantailaren ertz _aktiboak"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr "Arrastatu leihoak pantailaren goiko, ezkerreko eta eskuineko ertzetara haien tamaina aldatzeko."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Laneko areak"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "Laneko area _dinamikoak"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Laneko area hutsak automatikoki kentzen ditu."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "Laneko areen kopuru _finkoa"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Zehaztu laneko area iraunkorren kopuru bat."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "Laneko areen _kopurua"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Monitore anitz"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Laneko areak monitore _nagusian soilik"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Laneko areak pantaila _guztietan"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Aplikazioen txandakatzea"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Sartu _laneko area guztietako aplikazioak"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Sartu _uneko laneko areako aplikazioak soilik"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Aldi bereko zereginak"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Kudeatu hobespenak produktibitaterako eta aldi bereko zereginetarako"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr "Aldi bereko zereginak;Produktibitatea:Pertsonalizazioa;Mahaigaina;Izkina beroa;Laneko area;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Zerbait gaizki joan da. Jar zaitez harremanetan softwarearen sortzailearekin."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager exekutatzen egon behar da."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Beste gailuak"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPNa"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Gehitu konexioa"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Konfiguratu gabe"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Sare ez-segurua (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Sare segurua (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Sare segurua (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Sare segurua (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Sare segurua"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Konektatuta"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Aukerak…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr "Wifigunea aktibatzen bada, gailua %s saretik deskonektatuko da eta ezin izango da internetera sartu wifi bidez."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Gutxienez 8 karaktere izan behar ditu"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Gehienez karaktere %d izan behar du"
+msgstr[1] "Gehienez %d karaktere izan behar ditu"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Aktibatu wifigunea?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr "Wifiguneari esker, zure internet-konexioa beste batzuekin partekatuko duzu, haiek konektatu ahal izango diren wifi-sare bat sortuko baituzu. Hori egiteko, wifi bidezkoa ez den interneteko konexio bat izan behar duzu."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Sarearen izena"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Pasahitza"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Sortu ausazko pasahitza"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Sortu pasahitza automatikoki"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Piztu"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wifia"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Gelditu wifigunea eta deskonektatu edozein erabiltzaile?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Gelditu wifigunea"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Hegazkin modua"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Haririk gabea, Bluetooth eta mugikorren banda zabala desgaitzen du"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Ez da haririk gabeko moldagailurik aurkitu"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Ziurtatu zaitez haririk gabeko moldagailua entxufatuta eta piztuta edukitzeaz"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Hegazkin modua piztuta"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Desaktibatu haririk gabekoa erabiltzeko"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wifigunea aktibo"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Gailu mugikorrek QR kodea eskaneatu dezakete konektatzeko."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Desaktibatu wifigunea…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Sare ikusgaiak"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager exekutatzen egon behar da"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x segurtasuna"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Segurtasuna"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Mantendu"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Betiko"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Ausazkoa"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Egonkorra"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr "Hemen sartutako MAC helbidea erabiliko da konexio hau aktibatzen den sareko gailuaren hardwarearen helbide gisa. Eginbide hau MAC helbidea klonatzea edo iruzurtzea bezala ezagutzen da. Adibidea: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "%d. profila"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Irekitze hobetua"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Bat ere ez"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Inoiz ere ez"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "orain dela egun %i"
+msgstr[1] "orain dela %i egun"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Bat ere ez"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Ahula"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ados"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Ona"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Oso ona"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 helbidea"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 helbidea"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP helbidea"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNSa"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Ahaztu konexioa"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Kendu konexioaren profila"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Kendu VPNa"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Xehetasunak"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatikoa"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitatea"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Ezabatu helbidea"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Ezabatu bidea"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Bat ere ez"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128 bit-eko gakoa (hamaseitarra edo ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128 bit-eko pasaesaldia"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinamikoa (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA eta WPA2 pertsonala"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA eta WPA2 enpresa"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 pertsonala"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Seinalearen sendotasuna"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Esteka-abiadura"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hardwarearen helbidea"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Onartutako maiztasunak"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Ibilbide lehenetsia"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Erabilitako azkena"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Konektatu _automatikoki"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Egin erabilgarri beste _erabiltzaileentzako"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "_Neurtutako konexioa: datu-mugak ditu edo ordainketaren bat eragin dezake"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr "Software eguneratzeak eta beste deskarga handi batzuk ez dira automatikoki abiaraziko."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Izena"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC helbidea"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "MT_U"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonatutako helbidea"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "byte"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 metodoa"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatikoa (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Esteka lokalak soilik"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Eskuz"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Desgaitu"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Beste ordenagailuekin partekatua"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Helbideak"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Helbidea"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Sare-maskara"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Atebidea"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automatikoa"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automatikoa"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS zerbitzari-helbidea(k)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Bereiztu IP helbideak komaz"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Bideak"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Bide automatikoa"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrika"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Erabili _konexio hau soilik bere sareko baliabideentzako"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 metodoa"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatikoa (DHCP soilik)"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Aurrizkia"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Ezin da konexioaren editorea ireki"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Profil berria"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "%s ezarpen baliogabea: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "%s ezarpen baliogabea"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Inportatu fitxategitik…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Gehitu VPNa"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_Segurtasuna"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Ezin da VPN konexioa inportatu"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr "Ezin izan da “%s” fitxategia irakurri, edo ez dauka VPN konexioaren informazio ezagunik.\n"
+"\n"
+"Errorea: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Hautatu fitxategia inportatzeko"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "“%s” izeneko fitxategia badago lehendik ere."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Ordeztu"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Nahi duzu %s gordetzen ari zaren VPN konexioarekin ordeztea?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Ezin da VPN konexioa esportatu"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr "The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Esportatu VPN konexioa"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Errorea: ezin da VPN konexioaren editorea kargatu)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Kontrolatu nola konektatzen zaren Internetera"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Sarea;IPa;LANa;Proxy-a;WANa;Bandazabala;Modema;Bluetooth-aa;VPNa;DNSa;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Kontrolatu haririk gabeko sareetara nola konektatuko zaren"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Sarea;Haririk gabea;Wi-Fia;Wifia;IPa;LANa;Bandazabala;DNSa;Wifigunea;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "inoiz ere ez"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "gaur"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "atzo"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Erabilitako azkena"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Hariduna"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Gehitu konexio berria"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr "Hautatutako sareen xehetasunak, pasahitzak eta konfigurazio pertsonalizatuak barne, galdu egingo dira."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Ahaztu"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Haririk gabeko sare ezagunak"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Ahaztu"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Sistemaren arauek wifigune gisa erabiltzea debekatzen dute"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Haririk gabeko gailuak ez du wifigunearen modua onartzen"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "Webeko proxy-autoaurkitzailea erabiltzen da konfigurazioaren URLa ez denean ematen."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Hau ez da gomendatzen sare publiko ez-fidagarrietan."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Desaktibatu gailua"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktibo"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Hornitzailea"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Sareko proxy-a"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP proxy-a"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "_HTTPS proxy-a"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP proxy-a"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Sock-en ostalaria"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ezikusi egin ostalariei"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP proxy-aren ataka"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS proxy-aren ataka"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP proxy-aren ataka"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks proxy-aren ataka"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Konfigurazioaren URLa"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Desaktibatu VPN konexioa"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Sarearen izena"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Segurtasun mota"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Pasahitza"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Desaktibatu wifia"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Aukera gehiago…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Konektatu ezkutuko sarera…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Aktibatu wifigunea…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Haririk gabeko sare _ezagunak"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Egoera ezezaguna"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Kudeatu gabea"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Ez dago erabilgarri"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Konektatzen"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Autentifikazioa behar da"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Deskonektatzen"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Konexioak huts egin du"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Egoera ezezaguna (falta da)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Konexioak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IParen konfigurazioak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IParen konfigurazioa iraungi da"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Ezkutukoak behar dira, baina ez dira eman"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x-ren eskatzailea deskonektatuta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x-ren eskatzailearen konfigurazioak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x-ren eskatzaileak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x-ren eskatzailea gehiegi luzatu da autentifikatzean"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP zerbitzuak huts egin du abiatzean"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP zerbitzua deskonektatuta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP-ek huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP-ren bezeroak huts egin du abiatzean"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP-ren bezeroaren errorea"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP-ren bezeroak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Partekatutako konexioaren zerbitzuak huts egin du abiatzean"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Partekatutako konexioaren zerbitzuak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "IP automatikoaren zerbitzuak huts egin du abiatzean"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "IP automatikoaren zerbitzuaren errorea"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "IP automatikoaren zerbitzuak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linea lanpetuta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Ez dago markatze-tonurik"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Ezin izan da garraiatzailerik ezarri"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Markatze-eskaeraren denbora iraungituta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Markatze-saiakerak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Modemaren hasieratzeak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Huts egin du zehaztutako APNa hautatzean"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Ez da sarerik bilatzen ari"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Sarea erregistratzea ukatuta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Sarea erregistratzearen denbora iraungituta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Huts egin du eskatutako sarearekin erregistratzean"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PINaren egiaztaketak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Agian gailuaren firmwarea falta da"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Konexioa desagertu da"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Existitzen den konexioa hartu da"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Ez da modemik aurkitu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth konexioak huts egin du"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Ez da SIM txartelik sartu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIMaren PINa behar da"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIMaren PUKa behar da"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM arazoa"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Konexio-mendekotasunak huts egin du"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Firmwarea falta da"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kablea deskonektatuta"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "definitu gabeko errorea 802.1x segurtasunean (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "ez da fitxategirik hautatu"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "zehaztugabeko errorea eap metodoaren fitxategia egiaztatzean"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 edo PGP gako pribatuak"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER edo PEM ziurtagiriak"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "EAP-FAST PAC fitxategia falta da"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC fitxategiak (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonimoa"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autentifikatuta"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Biak"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Nortasun _anonimoa"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _fitxategia"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Aukeratu PAC fitxategia"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Barneko autentifikazioa"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Baimendu PAC automatikoki _hornitzea"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "EAP-LEAPren erabiltzaile-izena falta da"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "EAP-LEAPren pasahitza falta da"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Erabiltzaile-izena:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Pasahitza"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Erakutsi _pasahitza"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "EAP-PEAPren baliogabeko ZE ziurtagiria: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "EAP-PEAPren baliogabeko ZE ziurtagiria: ez da ziurtagirik zehaztu"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "0 bertsioa"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "1 bertsioa"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "_ZE ziurtagiria"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Aukeratu Ziurtagiri-Emailearen ziurtagiria"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Ez da ZE ziurtagirik _behar"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP _bertsioa"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "EAPren erabiltzaile-izena falta da"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "EAPren pasahitza falta da"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "EAP-TLSren erabiltzaile-izena falta da"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "EAP-TLSren baliogabeko ZE ziurtagiria: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "EAP-TLSren baliogabeko ZE ziurtagiria: ez da ziurtagirik zehaztu"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "EAP-TLSren baliogabeko gako pribatua: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "EAP-TLSren baliogabeko erabiltzaile-ziurtagiria: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Zifratu gabeko gako pribatuak ez dira seguruak"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr "Hautatutako gako pribatua ez dirudi pasahitz batekin babestuta dagoenik. Horrek zure segurtasun-kredentzialak arriskuan jar ditzake. Hautatu pasahitzarekin babestutako gako pribatu bat.\n"
+"\n"
+"(Zure gako pribatua pasahitz batekin babes dezakezu openssl-rekin)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Aukeratu zure ziurtagiri pertsonala"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Aukeratu zure gako pribatua"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Identitatea"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Erabiltzailearen ziurtagiria"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Gako pribatua"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Gako _pribatuaren pasahitza"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "EAP-TTLSren baliogabeko ZE ziurtagiria: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "EAP-TTLSren baliogabeko ZE ziurtagiria: ez da ziurtagirik zehaztu"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (EAP gabe)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domeinua"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Errore ezezaguna 802.1X segurtasuna egiaztatzean"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tuneldun TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Babestutako EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Autentifikazioa"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Hautatu fitxategi bat"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "'leap'en erabiltzaile-izena falta da"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "'leap'en pasahitza falta da"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Haririk gabekoaren pasahitza falta da."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Mota"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "wep gakoa falta da"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "baliogabeko wep gakoa: %zu luzera duen gakoak soilik digitu hamaseitarrak eduki ditzake"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "baliogabeko wep gakoa: %zu luzera duen gakoak soilik ascii karaktereak eduki ditzake"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr "baliogabeko wep gakoa: gakoak okerreko %zu luzera du. Gako baten luzerak 5/13 (ascii) edo 10/26 (hamaseitarra) izan behar du"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "baliogabeko wep gakoa: pasaesaldia ezin da hutsik egon behar"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "baliogabeko wep gakoa: pasaesaldiak 64 karaktere baino gutxiago izan behar ditu"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (lehenetsia)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistema irekia"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Partekatutako gakoa"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Gakoa"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "E_rakutsi gakoa"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP _indizea"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr "baliogabeko wpa-psk: gakoaren %zu luzera baliogabea. [8,63] byte edo 64 digitu hamaseitarrekoa izan behar du"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "baliogabeko wepwpa-psk: ezin da hamaseitar gisa 64 byte dituen gakoa interpretatu"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Jakinarazpenak"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Soinu-a_bisuak"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Jakinarazpenen laster-leihoak"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr "Jakinarazpenak jakinarazpenen zerrendan agertzen jarraituko dute laster-leihoak desgaituta daudenean."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Erakutsi mezuen ed_ukia laster-leihoetan"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Pantaila b_lokeatzearen jakinarazpenak"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Erakutsi mezuen e_dukia pantaila blokeatzean"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Ez _gogaitu"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Pantaila b_lokeatzearen jakinarazpenak"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Kontrolatu jakinarazpenak nola bistaratzen diren eta zer erakusten duten"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "jakinarazpenak;iragarkia;mezua;erretilua;laster-leihoa;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Bestelakoa"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s kendu da"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Errorea kontua kentzean"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Desegin"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Itxi jakinarazpena"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Konektatu zure datuak lainoan"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Ez dago Interneteko konexiorik — konektatu lineako kontu berriak konfiguratzeko"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Gehitu kontua"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s kontua"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Kendu kontua"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Lineako kontuak"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Konektatu lineako zure kontuetara eta erabaki zertarako erabiliko dituzun"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr "Google;Facebook;Twitter;Yahoo;Weba;Linean;Berriketa;Egutegia;Posta;Kontaktua;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Denbora ezezaguna"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "minutu %i"
+msgstr[1] "%i minutu"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "Ordu %i"
+msgstr[1] "%i ordu"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ordu"
+msgstr[1] "ordu"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minutu"
+msgstr[1] "minutu"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s erabat kargatu arte"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Kontuz: %s falta"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s falta"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Erabat kargatuta"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Kargarik ez"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Hutsa"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Kargatzen"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Deskargatzen"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Haririk gabeko sagua"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Haririk gabeko teklatua"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Etenik gabeko energia hornidura"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Laguntzaile digital pertsonala"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Telefono mugikorra"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Multimedia-erreproduzigailua"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Taula"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Ordenagailua"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Jokoetarako sarrerako gailua"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bateria"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Nagusia"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Gehigarria"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Bateriak"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "_Inaktibo dagoenean"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Eseki"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Itzali"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernatu"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ezer ez"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Bateriaren energiarekin"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Entxufea konektatutakoan"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Inoiz ere ez"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Eseki automatikoki"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "Errendimendu modua desgaitu egin da aldi batez laneko tenperatura asko igo delako."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr "Eramangarria detektatu da: errendimendu modua ez dago erabilgarri momentu honetan. Eraman gailua gainazal egonkor batera hura leheneratzeko."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Errendimendu modua desgaitu egin da aldi batez."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr "Bateria gutxi: energia aurrezteko modua gaitu da. Bateria nahiko kargatuta dagoenean aurreko modua leheneratuko da."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Energia aurrezteko modua aktibatuta: “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Errendimendu modua aktibatuta: “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "Ordu 1"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 ordu"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Energiaren modua"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Sistemaren errendimenduan eta energiaren erabileran eragina du."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Energia aurrezteko aukerak"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Pantailaren distira automatikoa"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Pantailaren distira inguruko argiaren arabera doituko da."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Ilundu pantaila"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Pantailaren distira murrizten du ordenagailua aktibo ez dagoenean."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "I_tzali pantaila"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Pantaila itzaltzen du aktibitaterik gabe denbora batez egon ondoren."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Energiaren aurrezte automatikoa"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Energia aurrezteko modua gaitzen du bateria baxu dagoenean."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "Eseki _automatikoki"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Ordenagailua pausatzen du aktibitaterik gabe denbora batez egon ondoren."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Pi_zteko botoiaren portaera"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Erakutsi bateriaren _ehunekoa"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Esekitze automatikoa"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Entxufea konektatutakoan"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "_Bateriaren energiarekin"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Atzerapena"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Errendimendua"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Errendimendu eta energiaren erabilera altua."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Orekatua"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Errendimendu eta energiaren erabilera estandarra"
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Energiaren aurrezpena"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Errendimendu eta energiaren erabilera murritza."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energia"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Ikusi bateriaren egoera eta aldatu energia aurrezteko ezarpenak"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "Argindarra;Lo egin;Eseki;Hibernatu;Bateria;Distira;Itzali;Belztu;Monitorea;DPMS;Inaktibo;Energia;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "\"%s” inprimagailua ezabatu da"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Huts egin du inprimagailu berria gehitzean."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Ezin izan da interfazea kargatu: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Desblokeatu inprimagailuak gehitzeko eta ezarpenak aldatzeko"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Inprimagailuak"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Gehitu inprimagailuak, ikusi inprimatze-lanak eta erabaki zer inprimatzea nahi duzun"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Inprimagailua;Ilara;Inprimatu;Papera;Tinta;Tonerra;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Gehitu inprimagailua"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Desblokeatu"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Ez da inprimakirik aurkitu"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Sartu sareko helbidea edo bilatu inprimagailu bat"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autentifikazioa behar da"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr "Sartu zure erabiltzaile-izena eta pasahitza inprimatze-zerbitzarian."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Erabiltzaile-izena"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s - Xehetasunak"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Ez da kontrolatzaile egokirik aurkitu"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Hautatu PPD fitxategia"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr "PostScript Printer Description fitxategiak (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Inprimagailu-izenek ezin dituzte zuriuneak, tabulazioak, traolak edo alderantzizko barrak eduki"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Kokalekua"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Kontrolatzailea"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Kontrolatzaile hobetsiak bilatzen…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Bilatu kontrolatzaileak"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Hautatu datu-basetik…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instalatu PPD fitxategia…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Hautatu inprimagailuaren kontrolatzailea"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Kontrolatzaileen datu-basea kargatzen…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Hautatu"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect inprimagailua"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD inprimagailua"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Alde batetik"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Marjina luzea (estandarra)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Marjina laburra (iraulia)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Bertikala"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Horizontala"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Alderantzizko horizontala"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Alderantzizko bertikala"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Berrekin"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pausatu"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Zain"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pausatuta"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autentifikazioa behar da"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Prozesatzen"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Geldituta"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Bertan behera utzita"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Abortatuta"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Osatuta"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Eraman lan hau ilararen goialdera"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "Lan %uek autentifikazioa behar du"
+msgstr[1] "%u lanek autentifikazioa behar dute"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Lan aktiboak"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Sartu kredentzialak %s(e)tik inprimatzeko."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domeinua"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Autentifikatu"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Garbitu denak"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autentifikatu"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Inprimagailuaren lan aktiborik ez"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Desblokeatu inprimatze-zerbitzaria"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Desblokeatu %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Sartu zure erabiltzaile-izena eta pasahitza %s kokalekuan dauden inprimagailuak ikusteko."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Inprimagailuak bilatzen"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Serieko ataka"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Ataka paraleloa"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Kokalekua: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Helbidea: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Zerbitzariak autentifikazioa eskatzen du"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Alde bietatik"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Paper mota"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Paper-iturria"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Irteerako erretilua"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Bereizmena"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript aurre-iragazketa"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Orrialdeak aldeko"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Alde bietatik"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientazioa"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Orokorra"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Orrialdearen konfigurazioa"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Aukera instalagarriak"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Lana"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Irudiaren kalitatea"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Kolorea"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Amaierakoak"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Aurreratua"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Probako orria"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Probako orria"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Hautapen automatikoa"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Inprimagailu lehenetsia"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Kapsulatutako GhostScript letra-tipoak soilik"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "BIhurtu PS 1. mailara"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "BIhurtu PS 2. mailara"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Aurre-iragazketarik ez"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabrikatzailea"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ez dago lan aktiborik"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "lan %u"
+msgstr[1] "%u lan"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Garbitu inprimagailuaren buruak"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Toner gutxi"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Tonerra hutsik"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Errebelatzaile gutxi"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Errebelatzailea hutsik"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Markatzaile gutxi"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Markatzailerik gabe"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Estalkia irekita"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Atea irekita"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Paper gutxi"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Paperik ez"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Deskonektatuta"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Geldituta"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Hondakinen ontzia ia beteta"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Hondakinen ontzia beteta"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Argazki-eroale optikoa bere amaierara iristear dago"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Argazki-eroale optikoak ez du gehiago funtzionatuko"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Prest"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Ez du lanik onartzen"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Prozesatzen"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Inprimatze-aukerak"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Inprimagailuaren xehetasunak"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Erabili inprimagailu lehenetsia"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Garbitu inprimagailuaren buruak"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Kendu inprimagailua"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modeloa"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Tintaren maila"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Berrabiarazi arazoa konpondutakoan."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Berrabiarazi"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Gehitu inprimagailua…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Inprimagailurik ez"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr "Badirudi sistemako inprimatzeko\n"
+"    zerbitzua ez dagoela erabilgarri."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formatuak"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Bilatu hizkuntzak…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Formatu arruntak"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Formatu guztiak"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Bilaketak ez du emaitzarik"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Bilaketan herrialdeak edo hizkuntzak bilatu daitezke."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Aurrebista"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Inperiala"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrika"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datak"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Data eta ordua"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Zenbakiak"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Neurria"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papera"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Hizkuntza eta formatua hurrengo saio-hasieran aldatuko da"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Amaitu saioa…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr "Hizkuntza-ezarpena interfazearen testuan eta web-orrietan erabiliko da. Formatuak zenbakietarako, datetarako eta monetetarako erabiliko da."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Zure kontua"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Hizkuntza"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formatuak"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Saio-hasierako pantaila"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Eskualdea eta hizkuntza"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Hautatu bistaratze-hizkuntza eta -formatuak"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Hizkuntza;Diseinua;Teklatua;Sarrera;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Galdetu zer egin"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Ez egin ezer"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Ireki karpeta"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Bestelako euskarria"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Hautatu aplikazioa audio CDentzako"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Hautatu aplikazioa bideo DVDentzako"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Hautatu aplikazio bat exekutatzeko musika erreproduzigailu bat konektatzean"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Hautatu aplikazio bat exekutatzeko kamera bat konektatzean"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Hautatu aplikazioa softwaredun Audio CDentzako"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "Audio DVDa"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Blu-Ray disko hutsa"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "CD disko hutsa"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "DVD disko hutsa"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "HD DVD disko hutsa"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-Ray bideo diskoa"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "liburu elektronikoen irakurlea"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD bideo diskoa"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Argazkien CDa"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CDa"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Bideo CDa"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows softwarea"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Hautatu euskarria nola kudeatuko den"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _audioa"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD bideoa"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Musika-erreproduzitzailea"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Softwarea"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Bestelako euskarria…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Inoiz ez galdetu edo abiarazi programak euskarria sartzean"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Hautatu bestelako euskarria nola kudeatuko den"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Ekintza:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Mota:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Euskarri aldagarria"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Konfiguratu euskarri aldagarriaren ezarpenak"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr "gailua;sistema;lehenetsia;aplikazioa;hobetsia;cd;dvd;usb;audioa;bideoa;diskoa;aldagarria;euskarria;exekuzioa;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Pantaila itzaltzen da"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 segundo"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "minutu 1"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutu"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutu"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutu"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutu"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "Ordu 1"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "minutu 1"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutu"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutu"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutu"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutu"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutu"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutu"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutu"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutu"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Inoiz ere ez"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Pantailaren blokeoa"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr "Pantaila automatikoki blokeatuta, beste batzuk zure ordenagailura sar daitezen eragozten da zu kanpoan zauden bitartean."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Pantaila beltzaren atzerapena"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Pantaila belzteko igaroko den inaktibotasun-tartea."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Pantailaren _blokeo automatikoa"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Pantailaren blokeo _automatikoaren atzerapena"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Pantaila automatikoki blokeatuta dagoenean pantaila belzteko igaroko den denbora-tartea."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Erakutsi _jakinarazpenak blokeo-pantailan"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Debekatu _USB gailu berriak"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "Eragotzi USB gailu berriek sistemarekin lan egin dezaten pantaila blokeatuta dagoenean."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Pantaila-pribatutasuna"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Mugatu bistaratze-angelua"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Pantaila-ezarpenak"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "pantaila;blokeatu;pribatua;pribatutasuna;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Hautatu kokalekua"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Ados"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Bilatu kokalekuak"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr "Sistema-aplikazioek zein karpetetan egingo dituzten bilaketak, adibidez 'Fitxategiak', 'Argazkiak' eta 'Bideoak' karpetetan"
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Lekuak"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Laster-markak"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Bestelakoak"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Gehitu kokalekua"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Ez da aplikaziorik aurkitu"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Aplikazioen bilaketa"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Sartu aplikazioak eskainitako bilaketa-emaitzak."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Sistema-aplikazioek arakatutako karpetak."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Bilaketaren emaitzak"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Emaitzak zerrenda-ordenaren arabera bistaratuko dira."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "Kontrolatu zer aplikaziok erakusten dituzten bilaketen emaitzak Jardueren ikuspegian"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Bilaketa;Bilatu;Indizea;Ezkutatu;Pribatua;Emaitzak;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Ez da sarerik hautatu partekatzeko"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Sareak"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Aktibatuta"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Desaktibatuta"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Gaituta"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktibo"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Aukeratu karpeta"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Gehitu"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Gaitu multimedia partekatzea"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr "Fitxategiak partekatzeak zure uneko sareko beste erabiltzaileek zure 'Publikoa' karpeta ikustea ahalbidetzen du honakoa erabilita: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr "Urruneko saio-hasiera gaituta dagoenean, urruneko erabiltzaileek konekta daitezke Shell Seguruko komandoa erabiliz: \n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Gaitu multimedia pertsonalen partekatzea"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Gailuaren izena kopiatu da"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Gailuaren helbidea kopiatu da"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Erabiltzaile-izena kopiatu da"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Pasahitza kopiatu da"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Partekatzea"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Ordenagailuaren _izena"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Fitxategiak partekatzea"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "U_rruneko mahaigaina"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Multimedia partekatzea"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Urruneko saioa"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Fitxategiak partekatzea"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Eskatu pasahitza"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Urruneko saioa"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Urruneko mahaigaina"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr "Urruneko mahaigainari esker, zure mahaigaina beste ordenagailu batetik kontrolatu dezakezu."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Gaitu edo urruneko mahaigaineko konexioa ordenagailu honekin."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Urruneko kontrola"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Baimendu urruneko konexioek pantaila kontrolatzea"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Nola konektatu"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr "Konektatu ordenagailu honekin gailuaren izena edo urruneko mahaigainaren helbidea erabilita."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopiatu"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Urruneko mahaigainaren helbidea"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autentifikazioa"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "Erabiltzaile-izena eta pasahitza behar dira ordenagailu honekin konektatzeko."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Erabiltzaile-izena"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Egiaztatu zifratzea"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Zifratzearen hatz-marka"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr "Zifratzearen hatz-marka bezeroak konektatzean ikusten da eta berdina izan behar du."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Multimedia partekatzea"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Partekatu musika, argazkiak eta bideoak sarean zehar."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Karpetak"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Kontrolatu besteekin zer partekatzea nahi duzun"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr "partekatu;partekatzea;ssh;ostalaria;izena;urrunekoa;mahaigaina;multimedia;bideoa;irudiak;argazkiak;filmak;zerbitzaria;errendatzea;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Gaitu edo desgaitu urruneko saio-hasiera"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Autentifikazioa behar da urruneko saioa gaitu edo desgaitzeko"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Pertsonalizatua"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klika"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Haria"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Zabua"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Burrunba"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balantzea"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Iraungi"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Atzealdea"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Aurrealdea"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s probatzen"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Egin klik bozgorailu batean hura probatzeko"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Sistemaren bolumena"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Bolumen maisua"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Bolumen-mailak"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Irteera"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Irteerako gailua"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Probatu"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Konfigurazioa"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Sarrera"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Sarrerako gailua"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Bolumena"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Alertako soinua"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "% 100"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Mututu"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Soinua"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Aldatu soinuaren bolumena, sarrerak, irteerak eta eta alerten soinuak"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "Txartela;Mikrofonoa;Bolumena;Iraungi;Balantzea;Bluetooth-a;Entzungailua;Audioa;Irteera;Sarrera;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Deskonektatuta"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Konektatzen"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Konektatuta"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Baimen-errorea"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Baimentzen"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Funtzionaltasun murriztua"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Konektatua eta baimendua"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Baimendua hemen:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Konektatua hemen:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Erregistratua hemen:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Ezin izan da gailua baimendu: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Ezin izan da gailua ahaztu: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Beste gailu %uen mendekoa da"
+msgstr[1] "Beste %u gailuren mendekoa da"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Itxi jakinarazpena"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Izena:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Egoera:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUIDa:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Baimendu eta konektatu"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Ahaztu gailua"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Errorea"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Baimendua"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr "Thunderbolt azpisistema (boltd) ez dago instalatuta edo gaizki konfiguratuta dago."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Sarbide zuzena baimentzen du atrakeak eta kanpoko GPUak bezalako gailuetara."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "USB eta Display Port gailuak soilik erantsi daitezke."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr "Thunderbolt ezin izan da detektatu.\n"
+"Sistemak ez dauka Thunderbolt euskarririk, BIOSean desgaitu egin da edo onartzen ez den segurtasun-maila batean ezarri da BIOSean."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt euskarria desgaitu egin da BIOSean."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Thunderbolten segurtasun-maila ezin izan da zehaztu."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Errorea modu zuzena aldatzean: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Ez dago Thunderbolt euskarririk"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Ezin izan da Thunderbolt azpisistemarekin konektatu"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Sarbide zuzena"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Zain dauden gailuak"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Ez dago gailurik erantsita"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Kudeatu Thunderbolt gailuak"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;pribatutasuna;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Kurtsore keinukaria"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Kurtsorea keinuka testu-eremuetan."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Abiadura"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Kurtsore-keinuaren abiadura"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Kurtsorearen tamaina"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "Kurtsorearen tamaina zoomarekin erabil daiteke kurtsorea errazago ikus ahal izateko."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Klik egitearen laguntzailea"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_2. mailako klik simulatua"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Abiarazi 2. mailako klik egitea botoi nagusia sakatuta edukitzean"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Onarpenaren atzerapena:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Laburra"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "2. mailako klik egitearen atzerapena"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Luzea"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Egin klik gainetik igarotzean"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Abiarazi klika erakuslea gainean kokatzean"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Atzerapena:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Laburra"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Luzea"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Mugimenduaren atalasea:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Txikia"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Handia"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Errepikatze-teklak"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Tekla sakatuta dagoen bitartean, tekla hori behin eta berriz errepikatzen da."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Tekla-errepikatzeen atzerapena"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Tekla-errepikatzeen abiadura"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Idazketaren laguntzailea"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Tekla _itsaskorrak"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Tratatu tekla aldatzaileen sekuentzia bat tekla konbinazio bat bezala"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desgaitu bi tekla batera sakatzen badira"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Jo soinua _tekla aldatzailea sakatzean"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Tekla _motelak"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Jarri atzerapena tekla bat sakatzen denetik onartu bitartekoa"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Laburra"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Tekla motelak sakatzearen atzerapena"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Luzea"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Jo soinua _tekla bat sakatzean"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Jo soinua tekla bat _onartzean"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Jo soinua tekla bat e_zesten bada"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Errebote-teklak"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ez ikusi egin azkar sakatutako bikoiztutako teklei"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Laburra"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Errebote-teklak sakatzearen atzerapena"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Luzea"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Gaitu teklatuaren bidez"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Aktibatu erabilgarritasunaren funtzionalitatea teklatutik"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Lehenetsia"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Tartekoa"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Handia"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Oso handia"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Oso oso handia"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixel"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Erakutsi _beti erabilerraztasunaren menua"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Ikusmena"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Kontraste _altua"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Testu _handia"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Gaitu a_nimazioak"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Pantaila _irakurlea"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Pantailaren irakurleak bistaratutako testua irakurtzen du fokua mugitzen duzun arabera."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Teklak soinuarekin"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Jo soinua zenbakiak blokeatzeko edo maiuskulak blokeatzeko teklak aktibatzen edo desaktibatzen direnean."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Kurtsorearen _tamaina"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zooma"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Entzumena"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Abisu _bisualak"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Pantailako _teklatua"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "E_rrepikatze-teklak"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Kurtsore _keinukaria"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Idazketaren laguntzailea (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Erakuslea eta klik egitea"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Sagu-teklak"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Aurkitu erakuslea"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Klik egitearen laguntzailea"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Klik bikoitzaren atzerapena"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Klik bikoitzaren atzerapena"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Abisu bisualak"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Probatu distira"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Erabili adierazle bisuala soinuaren abisua gertatzean."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Distiratu _pantaila osoa"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Distiratu _leiho osoa"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Laburra"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "Pantailaren ¼"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "Pantailaren ½"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "Pantailaren ¾"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Luzea"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Pantaila osoa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Goiko erdia"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Beheko erdia"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Ezkerreko erdia"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Eskuineko erdia"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Zoomaren aukerak"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Lupa:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Luparen posizioa:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Jarraitu saguaren kurtsoreari"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Pantaila-_zatia:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Lupa pantailaren kanpoaldean _zabaltzen da"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Mantendu luparen kurtsorea zentratuta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Luparen kurtsorea edukia inguruan _bultzatzen du"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Luparen kurtsorea edukiarekin _mugitzen da"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Gurutzaguneak:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Saguaren kurtsorea _teilakatzen du"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "L_odiera:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Mehea"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Lodia"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "L_uzera:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Kolorea:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Gurutzaguneak"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Kolore-efektuak:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Zuria beltzaren gainean:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Distira:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrastea:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Kolorea"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Bat ere ez"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Osoa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Baxua"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Altua"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Baxua"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Altua"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Kolore-efektuak"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Egin errazagoa ikusteko, entzuteko, idazteko, kokatzeko eta klik egiteko"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr "Teklatua;Sagua;a11y;Irisgarritasuna;Irisgarritasun Unibertsala;Kontrastea;Kurtsorea;Soinua;Zooma;Pantaila;Irakurgailua;handia;altua;handia;testua;letra-tipoa;tamaina;AccessX;Itsaskorra;Teklak;Geldoa;Errebotea;Sagua;Bikoitza;klik;Atzerapena;Abiadura;Lagundu;Errepikatu;Keinua;bisuala;entzumena;audioa;idazketa;animazioak;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "Ordu 1"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "Egun 1"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 egun"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 egun"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 egun"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 egun"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 egun"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 egun"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 egun"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 egun"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Hustu zakarrontziko elementu guztiak?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Zakarrontziko elementu guztiak betirako ezabatuko dira."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Hustu _zakarrontzia"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Ezabatu aldi baterako fitxategi guztiak?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Aldi baterako fitxategi guztiak betirako ezabatuko dira."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Ezabatu aldi baterako fitxategiak"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "Egun 1"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 egun"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 egun"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Beti"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Fitxategien historia"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr "Fitxategien historiak zuk erabilitako fitxategien erregistro bat gordetzen du. Informazio hori aplikazioen artean partekatzen da, eta errazago bihurtzen du erabili nahi dituzun fitxategiak aurkitzeko lana."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Fitxategien h_istoria"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Fitxategien _historiaren iraupena"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Garbitu historia…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Zakarrontziko eta aldi baterako fitxategiak"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr "Zakarrontziko eta aldi baterako fitxategiek zenbaitetan informazio pertsonala edo sentikorra izan dezakete. Automatikoki ezabatzen badira, pribatutasuna babesten lagundu dezakete."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Ezabatu za_karrontziko edukia automatikoki"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Ezabatu aldi _baterako fitxategiak automatikoki"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Ezabatze automatikoaren _tartea"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Hustu _zakarrontzia…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Ezabatu aldi baterako fitxategiak…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Fitxategien historia eta zakarrontzia"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Ez utzi aztarnarik"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr "erabilera;azken aldikoa;historia;fitxategiak;aldi batekoa;tmp;pribatua;pribatutasuna;zakarrontzia;ezabatu;mantendu;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Zure kontuaren hornitzailearen web helbidearekin bat etorri behar du."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Huts egin du kontua gehitzean"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Pasahitzak ez datoz bat."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Huts egin du kontua erregistratzean"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Ez dago modurik onartuta domeinu honekin autentifikatzeko"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Huts egin du domeinuarekin elkartzean"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr "Saioaren hasierako izenak ez du funtzionatzen.\n"
+"Saiatu berriro."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr "Saioaren hasierako pasahitzak ez du funtzionatzen.\n"
+"Saiatu berriro."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Huts egin du domeinuan saioa hastean"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Ezin da domeinua aurkitu. Ongi idatzi duzu?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Gehitu erabiltzailea"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administratzailea"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr "Administratzaileek beste erabiltzaile batzuk gehitu edo kendu ditzakete, eta erabiltzaile guztien ezarpenak aldatu ditzakete. Administratzaileei ezin zaizkie guraso-kontrolak aplikatu."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Erabiltzaileak pasahitza ezarriko du lehen saioa hastean"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Ezarri pasahitza orain"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Berretsi"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Enpresako saio-hasiera"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Enpresa edo erakunde batek kudeatzen dituen erabiltzaile-kontuak."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Deskonektatuta zaude"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr "Enpresako saio-hasieran baimenduta dago erabiltzaileen kontu zentralizatua erabiltzea gailu honetan. Kontu hau enpresaren interneteko baliabideak atzitzeko ere erabil dezakezu."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Arakatu irudi gehiago"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Hautatu fitxategia…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Hatz-marken kudeatzailea"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Hatz-marka"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Ez"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Bai"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "Erregistratutako zure hatz-markak ezabatze nahi duzu, hatz-marken bidezko saio-hasiera desgaituz?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Ez dago hatz-marken gailurik"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Ez dago hatz-marken gailurik"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Ziurtatu gailua ongi konektatuta dagoela."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Hatz-marken gailua"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Aukeratu konfiguratu nahi duzun hatz-marken gailua"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Hatz-marken bidezko saio-hasiera"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr "Hatz-marken bidezko saio-hasierak hatza erabilita ordenagailua desblokeatzea eta saioa hastea ahalbidetzen du."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Ezabatu hatz-markak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Hatz-marken erregistroa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "gailua galdegin behar da ekintza hau gauzatu baino lehen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "beste prozesu batek galdegin du gailua"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "ez duzu ekintza gauzatzeko baimenik"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "ez da inprimagailurik erregistratu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Huts egin du erregistroan zehar gailuarekin komunikatzeak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Huts egin du hatz-marken irakurgailuarekin komunikatzeak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Huts egin du hatz-marken daemonarekin komunikatzeak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Huts egin du hatz-markak zerrendatzeak: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Huts egin du gordetako hatz-markak ezabatzeak: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Ezkerreko hatz potoloa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Ezkerreko erdiko hatza"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "E_zkerreko hatz erakuslea"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Ezkerreko hatz nagia"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Ezkerreko hatz txikia"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Eskuineko hatz potoloa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Eskuineko erdiko hatza"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "E_skuineko hatz erakuslea"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Eskuineko hatz nagia"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Eskuineko hatz txikia"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Hatz-marka ezezaguna"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Eginda"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Hatz-marken gailua deskonektatu da"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Hatz-marken gailuen biltegiratzea beteta dago"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Huts egin du hatz-marka berria erregistratzeak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Huts egin du erregistroa abiarazteak: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Huts egin du hatz-marka berria erregistratzeak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Huts egin du erregistroa gelditzeak: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr "Altxatu eta kokatu hatza irakurgailuan behin eta berriro, zure hatz-marka erregistratzeko"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Erregistratu berriro hatz hau…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Eskaneatu hatz-marka berria"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Huts egin du hatz-marken %s gailua askatzeak: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Arazoa gailua irakurtzean"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Huts egin du hatz-marken %s gailuaren jabetza galdegiteak: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Huts egin du hatz-marken gailuak eskuratzeak: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Aste honetan"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Pasa den astean"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Saioa amaituta"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Saioa hasita"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Kontuaren jarduera"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Aurrekoa"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Hurrengoa"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Aukeratu beste pasahitz bat."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Idatzi zure uneko pasahitza berriro."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Pasahitza ezin izan da aldatu"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Aldatu pasahitza"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Aldatu"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Uneko pasahitza"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Pasahitz berria"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Berretsi pasahitza"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Baimendu erabiltzaileei hurrengo saio-hasieran haien pasahitzak ezartzea"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Ezarri pasahitza orain"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Ezin da automatikoki honelako domeinu motarekin elkartu"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Ez da halako domeinurik aurkitu"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Ezin da %s gisa saioa-hasi %s domeinuan"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Baliogabeko pasahitza, saiatu berriro"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Ezin izan da %s domeinuarekin konektatu: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Huts egin du erabiltzailea ezabatzean"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Huts egin du urrunetik kudeatzeko erabiltzailea errebokatzean"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Ezin duzu zeure kontua ezabatu."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s oraindik saioan sartuta dago"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "Erabiltzailea ezabatzen bada saioan sartuta dagoen bitartean, sistema egoera inkoherentean utz daiteke."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "%s(r)en fitxategiak mantentzea nahi dituzu?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr "Karpeta nagusia, postaren ilara eta aldi baterako fitxategiak gordetzeko aukera dago erabiltzaile baten kontua ezabatzean."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Ezabatu fitxategiak"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Mantendu fitxategiak"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Ziur zaude urrunetik kudeatutako “%s”(r)en kontua errebokatzea nahi duzula?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "Ez_abatu"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Kontua desgaituta"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Hurrengo saioan ezartzeko"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Bat ere ez"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Saioan sartuta"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Huts egin du kontuaren zerbitzuarekin kontaktatzean"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Ziurtatu zaitez kontuen zerbitzua instalatuta eta gaituta dagoela."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Panel hau desblokeatu behar da ezarpen hori aldatzeko"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Ezabatu hautatutako erabiltzailearen kontua"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr "Hautatutako erabiltzailearen kontua ezabatzeko\n"
+"aurrenik egin klik * ikonoan"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Desblokeatu erabiltzaileak gehitzeko eta ezarpenak aldatzeko"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Erabiltzaileak"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Amaitu saioa aldaketek eragina izan dezaten"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Berrabiarazi orain"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Itxi"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Editatu avatarra"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Izen osoa"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Editatu"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Hatz-markarekin saioa-hastea"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Saio-hasiera _automatikoa"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Kontuaren jarduera"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administratzailea"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr "Administratzaileek beste erabiltzaile batzuk gehitu edo kendu ditzakete, eta erabiltzaile guztien ezarpenak aldatu ditzakete."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Gurasoen kontrola"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Ireki gurasoen kontrolerako aplikazioa."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Kendu erabiltzailea…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Beste erabiltzaileak"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Gehitu erabiltzailea…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Ez da erabiltzailerik aurkitu"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Desblokeatu erabiltzaile-kontu bat gehitzeko."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Gehitu edo kendu erabiltzaileak eta aldatu zure pasahitza"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr "Saio-hasiera;Izena;Hatz-marka;Avatarra;Logotipoa;Aurpegia;Pasahitza;Guraso-kontrolak;Pantaila-denbora;Aplikazio-mugak;Web mugak;Erabilera;Erabilera-muga;Gaztea;Haurra;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Elkartu"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Domeinuaren administratzailearen saio-hasiera"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr "Enpresako saioa erabil ahal izateko, ordenagailu honek\n"
+"domeinun erregistratuta egon behar du. Eskatu iezaiozu sareko\n"
+"administratzaileari domeinuaren bere pasahitza idazteko hemen."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Administratzailearen _izena"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Administratzailearen pasahitza"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Kudeatu erabiltzaileen kontuak"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Autentifikazioa behar da erabiltzailearen datuak aldatzeko"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Pasahitz berriak zaharrarengandik desberdina izan behar du."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Saiatu hizki eta zenbaki batzuk aldatzen."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Saiatu pasahitza piska bat gehiago aldatzen."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Zure erabiltzaile-izenik gabeko pasahitz bat askoz ere sendoagoa litzateke."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Saiatu zure izena pasahitzean erabiltzea saihestea."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Saiatu pasahitzean sartutako hitz batzuk saihestea."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Saiatu hitz arruntak saihestea."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Saiatu dauden hitzen berrantolaketa saihestea."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Saiatu zenbaki gehiago erabiltzea."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Saiatu hizki maiuskulak gehiago erabiltzea."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Saiatu hizki minuskulak gehiago erabiltzea."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Saiatu karaktere berezi gehiago erabiltzea, harridura ikurra bezalakoak."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Saiatu hizki, zenbaki eta ikurren arteko nahasketa batekin."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Saiatu karaktere berdina errepikatzea saihestea."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr "Saiatu karaktere mota berdina errepikatzea saihestea: hizki, zenbaki eta ikurrak nahastu behar dituzu."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Saiatu 1234 edo abc bezalako sekuentziak saihestea."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr "Pasahitzak luzeagoa izan behar du. Saiatu hizki, zenbaki eta ikurren arteko nahasketa gehiagorekin."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Nahastu hizki maiuskulak eta minuskulak eta erabili zenbaki bat edo bi."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Hizki, zenbaki eta ikur gehiago gehitzeak sendoagoa egingo du."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Autentifikazioak huts egin du"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Pasahitza laburregia da"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Pasahitza sinpleegia da"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Pasahitz zaharra eta berria oso antzekoak dira"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Pasahitz berria azken aldian erabilia izan da."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Pasahitz berriak karaktere numeriko edo berezia(k) eduki behar ditu"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Pasahitz zaharra eta berria berdinak dira"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Pasahitza aldatu egin da hasieran autentifikatu zinenetik"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Pasahitz berriak ez dauzka nahikoa karaktere desberdin"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Errore ezezaguna"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr "Erabiltzaile-izenak honako karaktereak soilik eduki ditzake:  alfabetoko a-z arteko hizki minuskulak, digituak eta '.', '-' eta '_' karaktereak."
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Erabiltzaile-izen hori ez dago erabilgarri. Saiatu beste batekin."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Erabiltzaile-izena luzeegia da."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Mapatu botoiak"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Mapatu botoiak funtzioetara"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr "Laster-tekla bat editatzeko: aukeratu \"Bidali tekla sakatzea\" ekintza, sakatu teklatuaren laster-teklaren botoia eta eduki sakatuta tekla berriak edo sakatu Atzera-tekla garbitzeko."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "It_xi"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "Ukitu helburuko markatzaileak pantailan agertzen diren ordenan taula kalibratzeko."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Okerreko klik detektatuta, berrabiarazten…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "%d. botoia"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplikazioan definituta"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Bidali tekla sakatzea"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Aldatu monitorea"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Erakutsi pantailako laguntza"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Eramangarriaren panelean muntatutako tableta"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Kanpoko pantailan muntatutako tableta"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Kanpoko tableta-gailua"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Kanpoko teklatu-gailua"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Pantaila guztiak"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Tableta-modua"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Erabili arkatzaren kokatze absolutua"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Ezkertiarrentzako orientazioa"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tableta eta Express Keys™ ezkertiarrentzat biratzen dira"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapa monitorera"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Mantendu aspektu-erlazioa"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "Erabili tableta-gainazalaren zati bat soilik, pantailaren aspektu-erlazioa mantentzeko"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibratu"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Ez da taularik aurkitu"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Konektatu edo piztu Wacom taula."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Puntaren presioaren sentikortasuna"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Biguna"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Arkatzaren puntaren presioa"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Irmoa"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "1. botoia"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "2. botoia"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "3. botoia"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Borragomaren presioaren sentikortasuna"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Borragomaren presioa"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Saguaren erdiko botoiarekin klik egitea"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Saguaren eskuineko botoiarekin klik egitea"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Aurrera"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Airbrush stylus gailua presioarekin, inklinazioarekin eta integratutako graduatzailearekin"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Airbrush stylus gailua presioarekin, inklinazioarekin eta biraketarekin"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Airbrush stylus gailua presioarekin eta inklinazioarekin"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Airbrush stylus gailua presioarekin"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom taula"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Ezarri botoi-mapatzea eta doitu arkatzaren sentikortasuna taula grafikoentzako"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Taula;Wacom;Estiloa;Borragoma;Sagua;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Laster-tekla berria…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Sarbide-puntuak"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Eragiketa bertan behera utzi da"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Errorea:</b> Sarbidea ukatu da ezarpenak aldatzean"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Error:</b> Ekipamendu mugikorraren errorea"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Erregistratu gabea"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Erregistratua"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Ibiltaritza"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Bilatzen"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Ukatua"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modemaren xehetasunak"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modemaren egoera"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Garraiatzailea"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Sare mota"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Sareaen egoera"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Zenbaki propioa"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Gailuaren xehetasunak"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Firmwarearen bertsioa"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G soilik"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G soilik"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G soilik"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "5G soilik"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (hobetsia), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (hobetsia), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (hobetsia), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (hobetsia), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (hobetsia), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (hobetsia), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (hobetsia), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (hobetsia), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (hobetsia), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (hobetsia), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (hobetsia), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (hobetsia), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (hobetsia), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (hobetsia), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (hobetsia), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (hobetsia), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (hobetsia)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (hobetsia), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Desblokeatu SIM txartela"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Desblokeatu"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Sartu %d SIM txartelaren PIN kodea"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Sartu PIN kodea zure SIM txartela desblokeatzeko"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Sartu %d SIM txartelaren PUK kodea"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Sartu PUK kodea a zure SIM txartela desblokeatzeko"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Pasahitz okerra sartu da. Aukera %1$u geratzen zaizu"
+msgstr[1] "Pasahitz okerra sartu da. %1$u aukera geratzen zaizkizu"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Aukera %u geratzen zaizu"
+msgstr[1] "%u aukera geratzen zaizkizu"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Pasahitz okerra sartu da."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK kodea 8 digituko zenbakia da"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Sartu PIN berria"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN kodeak 4-8 digitu zenbakia izan behar du"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Desblokeatzen…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "SIMik ez"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Txertatu SIM txartela modem hau erabiltzeko"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIMa blokeatuta"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "Datu _mugikorrak"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Atzitu datuak sare mugikorra erabilita"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Datu-ibiltaritza"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Erabili datu mugikorrak ibiltaritzan"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Sareko modua"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "S_area"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Aurreratua"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Sa_rbide-puntuen izenak"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM blokeoa"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Blokeatu SIM txartela PINarekin"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "M_odemaren xehetasunak"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Akatsa telefonoan"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Ez dago konexiorik telefonoarekin"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Eragiketa ez dago baimenduta"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Eragiketa ez dago onartuta"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIMa ez dago txertatuta"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIMaren PINa behar da"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIMaren PUKa behar da"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIMak huts egin du"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIMa lanpetuta dago"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Pasahitz okerra"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIMaren PIN2a behar da"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIMaren PUK2a behar da"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Ez da aurkitu"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Ez dago sareko zerbitzurik"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Sarea denbora-mugara iritsi da"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS zerbitzuak ez dira onartzen"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Ibiltaritza ez da onartzen kokaleku-area honetan"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Zehaztu gabeko GPRS errorea"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Errorerik ez"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Ekintza bertan behera geratu da"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Sarbidea ukatu da"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Errore ezezaguna"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Sareko modua"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatikoa"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Aukeratu sarea"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Freskatu sare-hornitzaileak"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "%d SIMa"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Gaitu sare mugikorra"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Ez da WWAN moldagailurik aurkitu"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Ziurtatu haririk gabeko WAN/Cellular gailua daukazula"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Haririk gabeko WANa desgaitu egiten da hegazkin moduan piztean"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Itzali hegazkin modua"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Datu-konexioa"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Interneterako erabilitako SIM txartela"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM blokeoa"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Hurrengoa"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Blokeatu SIMa PINarekin"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Aldatu PINa"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Sartu uneko PINa SIM blokeoaren ezarpenak aldatzeko"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Sare mugikorra"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Konfiguratu telefoniako eta datu mugikorreko konexioak"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "telefonoa;wwan;telefonia;sim;mugikorra;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "GNOME mahaigaina konfiguratzeko utilitatea"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Ezarpenak zure sistema konfiguratzeko interfaze nagusia da."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME proiektua"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Erakutsi bertsio-zenbakia"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Gaitu modu xehea"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Bilatu katea"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Zerrendatu panel posibleen izenak eta irten"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panela bistaratzeko"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANELA] [ARGUMENTUA…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Ezarpenen kategoriak"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Pribatutasuna"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Panel erabilgarriak:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Ezarpen guztiak"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menu nagusia"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Abisua: garapen-bertsioa"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr "Ezarpenen bertsio hau garapenerako soilik erabili beharko litzateke. Sistemaren portaera okerra, datuen galera eta espero gabeko beste arazo batzuk gerta daitezke. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Laguntza"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Orokorra"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Irten"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Bilatu"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panelak"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Itzuli aurreko panelera"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Utzi bilaketa"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Hobespenak;Ezarpenak;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Irekiko den ezarpenen azken panelaren identifikatzailea"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr "Irekiko den ezarpenen azken panelaren identifikatzailea. Ezagutzen ez diren balioak ezikusi egingo dira eta zerrendako lehen panela hautatuko da."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Erakutsi abisu bat ezarpenen garapen-bertsio bat exekutatzean"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "Ezarpenek abisu bat erakutsi behar duen ala ez garapen-bertsio bat exekutatzen denean."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Leihoaren hasierako egoera"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr "Aplikazio-leihoaren hasierako zabalera, altuera eta egoera maximizatua dituen tuplea."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "Irteera %u"
+msgstr[1] "%u irteera"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "Sarrera %u"
+msgstr[1] "%u sarrera"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sistemaren soinuak"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Errorea: ezin izan da HSI maila zehaztu."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Errorea: ezin izan da HSI miala okerra zehaztu."
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER edo PEM ziurtagiriak (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Gehitu inprimagailua…"
+
+#~ msgid "Drip"
+#~ msgstr "Ura"
+
+#~ msgid "Glass"
+#~ msgstr "Basoa"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonarra"
+
+#~ msgid "No Protection"
+#~ msgstr "Babesik ez"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "Gutxieneko babesa"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Oinarrizko babesa"
+
+#~ msgid "Extended Protection"
+#~ msgstr "Bebes hedatua"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "Gutxieneko segurtasun-babesa"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Oinarrizko segurtasun-babesa"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Segurtasun-babes hedatua"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Pantailen antolaketa"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "Abio segurua desaktibatuta dago"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI idatzi"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI blokeoa"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "SPI BIOS eskualdea"
+
+#~ msgid "Pre-boot DMA protection is"
+#~ msgstr "Abio aurreko DMA babesa honakoa da:"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "Kutsatutako kernela"
+
+#~ msgid "Suspend-to-ram"
+#~ msgstr "Eseki RAMera"
+
+#~ msgid "All TPM PCRs are"
+#~ msgstr "TPM PCR guztiak honakoak dira"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "MEI manufaktura modua"
+
+#~ msgid "MEI override"
+#~ msgstr "MEI indargabetzea"
+
+#~ msgid "MEI version"
+#~ msgstr "MEI bertsioa"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "fwupd pluginak"
+
+#~ msgid "Intel DCI debugger"
+#~ msgstr "Intel DCI araztailea"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "IOMMU gailu-babesa gaituta"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "IOMMU gailu-babesa desgaituta"
+
+#~ msgid "Kernel is no longer tainted"
+#~ msgstr "Kernela ez dago jadanik kutsatuta"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "Kernela kutsatuta dago"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "Kernelaren blokeoa desgaitu da"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "Kernelaren blokeoa gaitu da"
+
+#~ msgid "Pre-boot DMA protection is disabled"
+#~ msgstr "Abio aurreko DMA babesa desgaituta dago"
+
+#~ msgid "Pre-boot DMA protection is enabled"
+#~ msgstr "Abio aurreko DMA babesa gaituta dago"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "Abio segurua desgaituta"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "Abio segurua gaituta"
+
+#~ msgid "All TPM PCRs are valid"
+#~ msgstr "TPM PCR guztiak baliozkoak dira"
+
+#~ msgid "All TPM PCRs are now valid"
+#~ msgstr "TPM PCR guztiak baliozkoak dira orain"
+
+#~ msgid "A TPM PCR is now an invalid value"
+#~ msgstr "TPM PCR bat orain baliogabea da"
+
+#~ msgid "TPM PCR0 reconstruction is invalid"
+#~ msgstr "TPM PCR0 berreraikuntza baliogabea da"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Blokeatu zure pantaila"
+
+#~ msgid "Light"
+#~ msgstr "Argia"
+
+#~ msgid "Set"
+#~ msgstr "Ezarri"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "pantaila;blokeoa;diagnostikoa;kraskadura;pribatua;azkena;aldi baterako;"
+#~ "tmp;izena;sarea;identitatea;"
+
+#~ msgid "Bark"
+#~ msgstr "Zaunka"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "GNOMEren ezarpenen soinu-panela"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "GNOMEren ezarpenen ukipen-panelaren eta saguaren panela"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "GNOMEren ezarpenen atzeko planoaren panela"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "GNOMEren ezarpenen teklatuaren panela"
+
+#~ msgid "More Warm"
+#~ msgstr "Beroago"
+
+#~ msgid "Less Warm"
+#~ msgstr "Hotzago"
+
+#~ msgid "Move up"
+#~ msgstr "Eraman gora"
+
+#~ msgid "Move down"
+#~ msgstr "Eraman behera"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPNa"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autentifikatu"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Urruneko pantaila partekatzeak urruneko erabiltzaileek zure pantaila "
+#~ "ikustea edo kontrolatzea baimentzen du hona konektatuz: %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "P_antaila partekatzea"
+
+#~ msgid "_Password:"
+#~ msgstr "_Pasahitza:"
+
+#~ msgid "_Show Password"
+#~ msgstr "E_rakutsi pasahitza"
+
+#~ msgid "Access Options"
+#~ msgstr "Sarbide-aukerak"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Konexio _berriek sarbidea eskatu behar dute"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Eskatu pasahitza"
+
+#~ msgid "Show the screenshot UI"
+#~ msgstr "Erakutsi pantaila-argazkiaren interfazea"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Atera pantaila-argazki bat"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "Atera leiho baten pantaila-argazkia"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "Erakutsi pantaila grabatzeko interfazea"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Onartu beheko aplikazioek zure mikrofonoa erabili dezaten."
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Aukeratu zenbakietarako, datetarako eta monetetarako formatuak. Aldaketak "
+#~ "hurrengo saioa hastean sartuko dira indarrean."
+
+#~ msgid "My Account"
+#~ msgstr "Nire kontua"
+
+#~ msgid "Language"
+#~ msgstr "Hizkuntza"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Leihoetako eta web orrietako testuan erabiliko den hizkuntza."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Amaitu saioa aldaketek eragina izan dezaten"
+
+#~ msgid "Restart…"
+#~ msgstr "Berrabiarazi…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Erabiltzaile guztiek saio-hasierako ezarpenak darabilte sisteman saioa "
+#~ "hastean"
+
+#~ msgid "Standard"
+#~ msgstr "Arrunta"
+
+#~ msgid "Account _Type"
+#~ msgstr "Kontu _mota"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Baimendu erabiltzaileei _hurrengo saio-hasieran pasahitza ezartzea"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Ezarri pasahitza _orain"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Konektatu zaitez enpresako erabiltzaileak gehitzeko."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Atera argazki bat…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Aldaketak egiteko\n"
+#~ "aurrenik egin klik * ikonoan"
+
+#~ msgid "Create a user account"
+#~ msgstr "Sortu erabiltzailearen kontua"
+
+#~ msgid "User Icon"
+#~ msgstr "Erabiltzailearen ikonoa"
+
+#~ msgid "Account Settings"
+#~ msgstr "Kontuaren ezarpenak"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autentifikazioa eta saioa hastea"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "Zure karpeta nagusia izendatzeko erabiliko da, eta ezin da aldatu."
+
+#~ msgid "Web Links"
+#~ msgstr "Web estekak"
+
+#~ msgid "Git Links"
+#~ msgstr "Git estekak"
+
+#~ msgid "%s Links"
+#~ msgstr "%s estekak"
+
+#~ msgid "Unset"
+#~ msgstr "Ezarri gabe"
+
+#~ msgid "Links"
+#~ msgstr "Estekak"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hipertestu-fitxategiak"
+
+#~ msgid "Text Files"
+#~ msgstr "Testu-fitxategiak"
+
+#~ msgid "Image Files"
+#~ msgstr "Irudi-fitxategiak"
+
+#~ msgid "Font Files"
+#~ msgstr "Letra-tipoen fitxategiak"
+
+#~ msgid "Archive Files"
+#~ msgstr "Artxibo-fitxategiak"
+
+#~ msgid "Package Files"
+#~ msgstr "Pakete-fitxategiak"
+
+#~ msgid "Audio Files"
+#~ msgstr "Audio-fitxategiak"
+
+#~ msgid "Video Files"
+#~ msgstr "Bideo-fitxategiak"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Baimenak eta sarbidea"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Aplikazio honek atzitu nahi dituen datuak eta zerbitzuak eta horrek behar "
+#~ "dituen baimenak."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Ezin dira aldatu"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Aplikazioen banakako baimenak <a href=\"privacy\">Pribatutasuna</a> "
+#~ "ezarpenetan berrikusi daitezke."
+
+#~ msgid "Integration"
+#~ msgstr "Integrazioa"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Ezarri mahaigainaren atzeko planoa"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Maneiatzaile lehenetsiak"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Aplikazio honek irekitzen dituen fitxategi eta esteka motak."
+
+#~ msgid "Usage"
+#~ msgstr "Erabilera"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Aplikazio honek zenbat baliabide darabiltzan."
+
+#~ msgid "Open in Software"
+#~ msgstr "Ireki Software aplikazioan"
+
+#~ msgid "Activities"
+#~ msgstr "Jarduerak"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Onartu beheko aplikazioek zure kamera erabili dezaten."
+
+#~ msgid "Display Mode"
+#~ msgstr "Bistaratze-modua"
+
+#~ msgid "Join Displays"
+#~ msgstr "Batu pantailak"
+
+#~ msgid "Single Display"
+#~ msgstr "Pantaila bakarra"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Arrastatu pantailak zure pantaila fisikoaren konfigurazioarekin bat egin "
+#~ "dezaten. Hautatu pantaila bat haren ezarpenak aldatzeko."
+
+#~ msgid "Active Display"
+#~ msgstr "Pantaila aktiboa"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Gorde pantaila-argazkia hemen: $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Gorde area baten pantaila-argazkia hemen: $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopiatu pantailaren argazkia arbelean"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopiatu leihoaren pantaila-argazkia arbelean"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopiatu area baten pantaila-argazkia arbelean"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Grabatu pantailaren bideo labur bat"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Kokaleku-zerbitzuek aplikazioek zure kokalekua ezagutzea baimentzen dute. "
+#~ "Haririk gabekoa eta mugikorren banda zabala erabiltzeak zehaztasuna "
+#~ "handiagotzen du."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Mozilla Location Service erabiltzen du: <a href='https://location."
+#~ "services.mozilla.com/privacy'>Pribatutasun-politika</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Onartu beheko aplikazioek zure kokalekua ezagutu dezaten."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Eramangarria detektatu da: errendimendu modua ez dago erabilgarri"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr ""
+#~ "Hardwarearen tenperatura altua: errendimendu modua ez dago erabilgarri"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Errendimendu modua ez dago erabilgarri"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Jardueren ikuspegi orokorrean zein emaitza erakutsiko den kontrolatzen "
+#~ "du. Bilaketa-emaitzen ordena ere aldatu daiteke zerrendako errenkadak "
+#~ "mugituta."
+
+#~ msgid "Sound Keys"
+#~ msgstr "Teklak soinuarekin"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Pantaila irakurlea"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Pantaila _irakurlea"
+
+#~ msgid "Output:"
+#~ msgstr "Irteera:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapatu monitore bakarrera"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d / %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Bistaratu mapaketa"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Taula (absolutua)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Ukipen-panela (erlatiboa)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Taularen hobespenak"
+
+#~ msgid "_Help"
+#~ msgstr "_Laguntza"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth ezarpenak"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Jarraipenaren modua"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Mapatu botoiak.."
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Doitu saguaren ezarpenak"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Doitu pantailaren bereizmena"
+
+#~ msgid "No stylus found"
+#~ msgstr "Ez da estilorik aurkitu"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Hurbildu zure stylus gailua tabletaren ingurura hura konfiguratzeko"
+
+#~ msgid "Top Button"
+#~ msgstr "Goiko botoia"
+
+#~ msgid "Lower Button"
+#~ msgstr "Beheko botoia"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Botoirik baxuena"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Huts egin du fitxategia kargatzean: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profila hona igo da:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Idatzi URL hau."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Berrabiarazi ordenagailu hau eta abiatu sistema eragile arrunta."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Idatzi URLa zure web arakatzailean profila deskargatzeko eta instalatzeko"
+
+#~ msgid "Upload profile"
+#~ msgstr "Igo profila"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Interneteko konexio berria"
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopiatu"
+
+#~ msgid "Select _All"
+#~ msgstr "Hautatu _dena"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Klik bikoitzaren denbora-muga"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Esekitzeko eta itzaltzeko botoia"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Zerbitzu batzuk desgaituta daude ez dagoelako sarerako sarbiderik."
+
+#~ msgid "Unlocking..."
+#~ msgstr "Desblokeatzen..."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Erabiltzaile-izena;Izena;Hatz-marka;Avatarra;Logotipoa;Aurpegia;Pasahitza;"
+
+#~ msgid "Phone-adaptor link reserved"
+#~ msgstr "Telefonoa-moldagailua esteka erreserbatuta"
+
+#~ msgid "PH-SIM PIN required"
+#~ msgstr "PH-SIMaren PINa behar da"
+
+#~ msgid "PH-FSIM PIN required"
+#~ msgstr "PH-FSIMaren PINa behar da"
+
+#~ msgid "PH-FSIM PUK required"
+#~ msgstr "PH-FSIMaren PUKa behar da"
+
+#~ msgid "Memory full"
+#~ msgstr "Memoria beteta dago"
+
+#~ msgid "Memory failure"
+#~ msgstr "Memoriaren hutsegitea"
+
+#~ msgid "Network not allowed - emergency calls only"
+#~ msgstr "Sarea ez dago onartuta - larrialdiko deiak soilik"
+
+#~ msgid "Network personalization PIN required"
+#~ msgstr "Sarearen pertsonalizaziorako PINa behar da"
+
+#~ msgid "Network personalization PUK required"
+#~ msgstr "Sarearen pertsonalizaziorako PUKa behar da"
+
+#~ msgid "Network subset personalization PIN required"
+#~ msgstr "Sarearen azpimultzoaren pertsonalizaziorako PINa behar da"
+
+#~ msgid "Network subset personalization PUK required"
+#~ msgstr "Sarearen azpimultzoaren pertsonalizaziorako PUKa behar da"
+
+#~ msgid "Service provider personalization PIN required"
+#~ msgstr "Sarearen hornitzailearen pertsonalizaziorako PINa behar da"
+
+#~ msgid "Service provider personalization PUK required"
+#~ msgstr "Sarearen hornitzailearen pertsonalizaziorako PUKa behar da"
+
+#~ msgid "Corporate personalization PIN required"
+#~ msgstr "Enpresaren pertsonalizaziorako PINa behar da"
+
+#~ msgid "Corporate personalization PUK required"
+#~ msgstr "Enpresaren pertsonalizaziorako PUKa behar da"
+
+#~ msgid "Illegal MS"
+#~ msgstr "MS ilegala"
+
+#~ msgid "Illegal ME"
+#~ msgstr "ME ilegala"
+
+#~ msgid "PLMN not allowed"
+#~ msgstr "PLMN ez da onartzen"
+
+#~ msgid "Location area not allowed"
+#~ msgstr "Kokaleku-area ez da onartzen"
+
+#~ msgid "Service option not supported"
+#~ msgstr "Zerbitzu-aukera ez da onartzen"
+
+#~ msgid "Requested service option not subscribed"
+#~ msgstr "Eskatutako zerbitzu-aukera ez da harpidetu"
+
+#~ msgid "Service option temporarily out of order"
+#~ msgstr "Zerbitzu-aukera bertan behera geratu da aldi batez"
+
+#~ msgid "PDP authentication failure"
+#~ msgstr "PDP autentifikazioaren hutsegitea"
+
+#~ msgid "Invalid mobile class"
+#~ msgstr "Mugikor-klase baliogabea"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Laster-tekla"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "'Pertsonalizatu laster-teklak' atalean aldatu daiteke hori"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Eutsi sakatuta eta idatzi, beste karaktere batzuk sartzeko"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Pantailaren distira"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Teklatuaren distira"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Ilundu pantaila inaktibo dagoenean"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Belztu pantaila"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wifia"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Haririk gabekoa itzali egin daiteke energia aurrezteko."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Banda zabala mugikorra (LTE, 4G, 3G eta abar) itzali egin daiteke energia "
+#~ "aurrezteko."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth-a itzali egin daiteke energia aurrezteko."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Energia orekatua"
+
+#~ msgid "Add…"
+#~ msgstr "Gehitu…"
+
+#~ msgid "Left Alt"
+#~ msgstr "Ezkerreko Alt tekla"
+
+#~ msgid "Right Alt"
+#~ msgstr "Eskuineko Alt tekla"
+
+#~ msgid "Left Super"
+#~ msgstr "Ezkerreko Super tekla"
+
+#~ msgid "Right Super"
+#~ msgstr "Eskuineko Super tekla"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Eskuineko Ctrl tekla"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Ordezko karaktereen tekla"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Aldatzaileak soilik aldatu hurrengo iturburura"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Menu tekla"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Kargatzen"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Kontuz"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Baxua"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Ona"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Erabat kargatuta"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Hutsa"
+
+#~ msgid "Previous source"
+#~ msgstr "Aurreko iturburua"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Maius+Zuriunea"
+
+#~ msgid "Next source"
+#~ msgstr "Hurrengo iturburua"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Zuriunea"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Ezker+Eskuineko Alt"
+
+#~ msgid "Universal Access"
+#~ msgstr "Sarbide unibertsala"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Itzali haririk gabeko sarera konektatzeko"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Pasahitza"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Gehitu erabiltzaile-kontuak eta aldatu pasahitzak"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Erreproduzitu eta grabatu soinua"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Detektatu sareko gailuak mDNS/DNS-SD (Bonjour/zeroconf) erabilita"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Atzitu Bluetooth hardwarea zuzenean"
+
+#~ msgid "Use your camera"
+#~ msgstr "Erabili zure kamera"
+
+#~ msgid "Print documents"
+#~ msgstr "Inprimatu dokumentuak"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Erabili konektatutako edozein kontrol-palanka"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Baimendu Docker zerbitzuarekin konektatzea"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Konfiguratu sareko suebakia"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Konfiguratu eta erabili prbilegiodun FUSE fitxategi-sistemak"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Eguneratu firmwarea gailu honetan"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Atzitu hardware-informazioa"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Eman entropia hardwarearen ausazko zenbakien sortzaileari"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Erabili hardwareak sortutako ausazko zenbakiak"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Atzitu karpeta nagusiko fitxategiak"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Atzitu libvirt zerbitzu"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Aldatu sistemaren hizkuntza eta eskualde-ezarpenak"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Aldatu kokapenaren ezarpenak eta hornitzaleak"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Irakurri sistemaren eta aplikazioen egunkariak"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "Atzitu media-hub zerbitzua"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Erabili eta konfiguratu modemak"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Irakurri sistemaren muntatze-informazioa eta disko-kuotak"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Kontrolatu musikaren eta bideoen erreproduzigailuak"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Aldatu maila baxuko sarearen ezarpenak"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Atzitu NetworkManager zerbitzua sarearen ezarpenak irakurri eta aldatzeko"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Sareko ezarpenak irakurtzeko atzitzea"
+
+#~ msgid "Change network settings"
+#~ msgstr "Aldatu sarearen ezarpenak"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Atzitu ofono zerbitzuak telefonia mugikorreko sarearen ezarpenak irakurri "
+#~ "eta aldatzeko"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Kontrolatu Open vSwitch hardwarea"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Irakurri CD/DVDtik"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Irakurri, gehitu, aldatu edo kendu gordetako pasahitzak"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Atzitu pppd eta ppp gailuak puntutik punturako protokoloaren konexioak "
+#~ "konfiguratzeko"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Pausatu edo amaitu sistemaren edozein prozesu"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Atzitu USB hardwarea zuzenean"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Irakurri/idatzi biltegiratze-gailu aldagarrietako fitxategiak"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Eragotzi pantailaren loa/blokeoa"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Atzitu serieko ataketako hardwarea"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Berrabiarazi edo itzali gailua"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Instalatu, kendu eta konfiguratu softwarea"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Atzitu biltegiratzeko lan-markoaren zerbitzua"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Irakurri prozesuen eta sistemaren informazioa"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Monitorizatu eta kontrolatu exekutatzen ari den edozein programa"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Aldatu ordu-zerbitzariaren ezarpenak"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Aldatu ordu-zona"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Atzitu UDisks2 zerbitzua diskoak eta euskarri aldagarriak konfiguratzeko"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr ""
+#~ "Irakurri/aldatu partekatutako egutegi-gertaerak Ubuntu Unity 8 aplikazioan"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Irakurri/aldatu partekatutako kontaktuak Ubuntu Unity 8 aplikazioan"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Atzitu energia-erabileraren datuak"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Irakurtzeko/idazteko atzipena U2F gailuetan"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Erabiltzailearen kontu bat sortzeko\n"
+#~ "aurrenik egin klik * ikonoan"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Gaitu hatz-markarekin saioa-hastea"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Beste hatza:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Zure hatz-markak ongi gorde dira. Orain hatz-marken irakurgailua "
+#~ "erabilita has dezakezu saioa."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Ez duzu baimenik gailua atzitzeko. Jar zaitez harremanetan "
+#~ "administratzailearekin."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Barneko errorea gertatu da."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Ezabatu erregistratutako hatz-markak?"
+
+#~ msgid "Done!"
+#~ msgstr "Eginda!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Ezin izan da “%s” gailua atzitu"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Ezin izan da hatz-marken kaptura abiarazi “%s” gailuan"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Ezin izan da inolako hatz-marken irakurgailua atzitu"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr ""
+#~ "Jar zaitez sistemaren administratzailearekin harremanetan laguntza "
+#~ "eskuratzeko."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Hatz-markarekin saioa-hastea gaitzeko zure hatz-markak gorde behar dituzu "
+#~ "aurrenik, “%s” gailua erabiliz."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Hatzaren hautapena"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Ezarri atzeko planoa eta blokeo-pantaila"
+
+#~ msgid "Set Background"
+#~ msgstr "Ezarri atzeko planoa"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Ezarri blokeo-pantaila"
+
+#~ msgid "Remove Background"
+#~ msgstr "Kendu atzeko planoa"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Txostenak modu anonimoan bidaltzen dira eta ez dute datu pertsonalik."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Arazo teknikoei buruzko txostenak bidaltzean sistema eragile hau hobetzen "
+#~ "laguntzen diguzu."
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Mugatu atzeko _planoko datuen erabilera"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr ""
+#~ "Datu gehigarriak ordaindu behar direnean edo mugak dituzunean erabiltzeko "
+#~ "egokia."
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Jakinarazpenen laster-leihoak"
+
+#~ msgid "Last Login"
+#~ msgstr "Azken saio-hasiera"
+
+#~ msgid "No regions found"
+#~ msgstr "Ez da eskualderik aurkitu"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Distiratu _leihoaren titulu-barra"
+
+#~ msgid "Version %s"
+#~ msgstr "%s bertsioa"
+
+#~ msgid "OS name"
+#~ msgstr "SE izena"
+
+#~ msgid "OS type"
+#~ msgstr "SE mota"
+
+#~ msgid "Disk"
+#~ msgstr "Diskoa"
+
+#~ msgid "Check for updates"
+#~ msgstr "Egiaztatu eguneratzeak dauden"
+
+#~ msgid "Network proxy"
+#~ msgstr "Sareko proxy-a"
+
+#~ msgid "page 1"
+#~ msgstr "1. orrialdea"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Barneko _autentifikazioa"
+
+#~ msgid "page 2"
+#~ msgstr "2. orrialdea"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Pare bihurritua (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Interfaze-unitate erantsia (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Euskarri independenteen interfazea (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Haririk gabeko wifigunea aktibatzean <b>%s</b>(e)tik deskonektatuko zara."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Ezin da Internetera sartu zure haririk gabekoaren bitartez wifigunea "
+#~ "aktibo dagoen bitartean."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Wifigunea interneterako konexioa haririk gabeko konexioarekin "
+#~ "partekatzeko erabili ohi da."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Konexio _automatikoa"
+
+#~ msgid "details"
+#~ msgstr "xehetasunak"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Erakutsi _pasahitza"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Egin erabilgarri beste erabiltzaileentzako"
+
+#~ msgid "identity"
+#~ msgstr "identitatea"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Helbidea"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Helbide automatikoak soilik (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Esteka lokalak soilik"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ez ikusi egin automatikoki lortutako bideei"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Klonatutako MAC helbidea"
+
+#~ msgid "_Reset"
+#~ msgstr "_Berrezarri"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Berrezarri sare honen ezarpenak balio lehenetsiekin, baina gogoratu sare "
+#~ "hobetsi gisa."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Kendu sare honekin zerikusia duten xehetasun guztiak, eta ez saiatu "
+#~ "honekin automatikoki konektatzen."
+
+#~ msgid "Hardware"
+#~ msgstr "Hardwarea"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Berrezarri"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Konektatutako gailuak"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Azpiegitura"
+
+#~ msgid "In use"
+#~ msgstr "Erabiltzen"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Aktibatuta"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Desaktibatuta"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Desaktibatuta"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Aktibatuta"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Desaktibatuta"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Aktibatuta"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Pribatutasunaren araua"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Zure historia gogoratzeak gauzak berriro aurkitzea errazten du. Elementu "
+#~ "horiek ez dira inoiz sarean zehar partekatzen."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Duela gutxi erabilita"
+
+#~ msgid "Retain _History"
+#~ msgstr "Gorde _historia"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Pantailaren blokeoak zure pribatutasuna babesten du kanpoan zaudenean."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Blokeatu pantaila honen _ondoren"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "Blokeatu pantailaren _jakinarazpenak"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Borratu betiko automatikoki Zakarrontzia eta aldi baterako fitxategiak "
+#~ "ordenagailua beharrezkoak ez diren informazio sentsitibotik aske "
+#~ "mantentzeko."
+
+#~ msgid "Purge _After"
+#~ msgstr "Borratu betiko honen _ondoren"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Erabilten duzun softwareari buruzko informazioa bidaltzen diguzunean, "
+#~ "zuri gomendio zehatzenak eskaintzen laguntzen gaitu. Gainera, gure "
+#~ "softwarea hobetzen laguntzen digu.\n"
+#~ "\n"
+#~ "Bildutako informatu guztia anonimoa da, eta zure datuak ez ditugu inoiz "
+#~ "ere hirugarren batekin partekatuko."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Bidali softwarearen erabilpenaren estatistikak"
+
+#~ msgid "_Camera"
+#~ msgstr "_Kamera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Mikrofonoa"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Kokaleku-zerbitzuak"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Babestu zure informazio pertsonala eta kontrolatu besteek zer ikus "
+#~ "dezaketen"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Erabiltzaile-izena ezin da \"-\" karakterearekin hasi."
+
+#~ msgid "Delete Background"
+#~ msgstr "Ezabatu atzeko planoa"

--- a/po/fa.po
+++ b/po/fa.po
@@ -10,8 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: procman\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issues\n"
-"POT-Creation-Date: 2022-09-12 15:11+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-14 17:01+0430\n"
 "Last-Translator: Danial Behzadi <dani.behzi@ubuntu.com>\n"
 "Language-Team: Persian\n"
@@ -24,99 +24,7 @@ msgstr ""
 "X-DamnedLies-Scope: partial\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "گذرگاه سامانه"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "دسترسی کامل"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "گذرگاه نشست"
-
-#: panels/applications/cc-applications-panel.c:828 panels/power/cc-power-panel.ui:75
-#: panels/thunderbolt/cc-bolt-panel.ui:265 panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "افزاره‌ها"
-
-# در این رشته از نویسه LRM استفاده شده است
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "دسترسی کامل به ‎/dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "شبکه"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "دسترسی شبکه دارد"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "خانه"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "فقط‌خواندنی"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "سامانه پرونده"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "تنظیمات"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "می‌تواند تنظیمات را تغییر دهد"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you are "
-"concerned about these permissions, consider removing this application."
-msgstr ""
-"%s این اجازه‌ها را به صورت توکار دارد و نمی‌توان تغییرش داد. در صورتی که نگران این "
-"اجازه‌هایید، حذف این برنامه را در نظر بگیرید."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%Iu گونهٔ پرونده و پیوند که به دست کاره گشوده شده"
-msgstr[1] "%Iu گونهٔ پرونده و پیوند که به دست کاره گشوده شده"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "برای گشودن گونه‌های پرونده و پیوند زیر از <b>%s</b> استفاده شده."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s از فضای دیسک استفاده شده."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -132,7 +40,6 @@ msgid "Install some…"
 msgstr "نصب…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "گشودن"
 
@@ -142,9 +49,11 @@ msgstr "نمایش جزییات"
 
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
-#: panels/keyboard/01-launchers.xml.in:16 panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
-#: panels/printers/new-printer-dialog.ui:252 panels/region/cc-format-chooser.ui:82
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "جست‌وجو"
@@ -154,22 +63,13 @@ msgstr "جست‌وجو"
 msgid "Receive system searches and send results."
 msgstr "گرفتن جست‌وجوهای سامانه و فرستادن نتیجه‌ها."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804 panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478 subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "از کار افتاده"
 
@@ -280,7 +180,8 @@ msgid "No results found"
 msgstr "هیچ نتیجه‌ای پیدا نشد"
 
 #: panels/applications/cc-applications-panel.ui:311
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210 shell/cc-panel-list.ui:117
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "جست‌وجویی دیگر را بیازمایید"
 
@@ -304,7 +205,8 @@ msgid "Reset"
 msgstr "بازنشانی"
 
 #: panels/applications/cc-applications-panel.ui:417
-msgid "How much disk space this application is occupying with app data and caches."
+msgid ""
+"How much disk space this application is occupying with app data and caches."
 msgstr "مقدار فضای دیسکی که این برنامه با داده‌های کاره و انباره‌ها اشغال می‌کند."
 
 #: panels/applications/cc-applications-panel.ui:420
@@ -331,75 +233,22 @@ msgstr "پاک‌سازی انباره…"
 msgid "Control various application permissions and settings"
 msgstr "واپایش اجازه‌ها و تنظیمات برنامه‌های مختلف"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
-"کاره;برنامه;فلت‌پک;اجازه;مجوز;دسترسی;تنظیمات;application;flatpak;permission;setting;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "گزینش یک عکس"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125 panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866 panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269 panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594 panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17 panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_لغو"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270 panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_گشودن"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "اندازه‌های چندگانه"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%Id × %Id"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "بدون تصویر پس‌زمینه"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "تصویر پس‌زمینه کنونی"
+"کاره;برنامه;فلت‌پک;اجازه;مجوز;دسترسی;تنظیمات;application;flatpak;permission;"
+"setting;"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "سبک"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "پیش‌گزیده"
 
@@ -423,7 +272,6 @@ msgstr "ظاهر"
 msgid "Change your background image or the UI colors"
 msgstr "تغییر تصویر پس‌زمینه یا رنگ‌های رابط کاربریتان"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -476,9 +324,7 @@ msgstr "حالت هواپیمای سخت‌افزاری روشن است"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "برای به کار انداختن بلوتوث حالت هواپیما را خاموش کنید."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "بلوتوث"
 
@@ -486,7 +332,6 @@ msgstr "بلوتوث"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "بلوتوث را خاموش و روشن کنید و به افزاره‌های خود متّصل شوید"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;اشتراک;هم‌رسانی;بلوتوث;هم‌رسانی;"
@@ -501,13 +346,13 @@ msgstr "هیچ برنامه‌ای نمی‌تواند عکس یا فیلم بگ
 
 #: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Use of the camera allows applications to capture photos and video. Disabling the "
-"camera may cause some applications to not function properly.\n"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
 "\n"
 "Allow the applications below to use your camera."
 msgstr ""
-"استفاده از دوربین می‌گذارد برنامه‌ها عکس و ویدیو بگیرند. ممکن است از کار انداختن "
-"دوربین باعث کارکرد نادرست برخی برنامه‌ها شود.\n"
+"استفاده از دوربین می‌گذارد برنامه‌ها عکس و ویدیو بگیرند. ممکن است از کار "
+"انداختن دوربین باعث کارکرد نادرست برخی برنامه‌ها شود.\n"
 "\n"
 "اجازه به برنامه‌های زیر برای استفاده از دوربینتان."
 
@@ -519,89 +364,35 @@ msgstr "هیچ برنامه‌ای برای دسترسی به دوربین در�
 msgid "Protect your pictures"
 msgstr "محافظت از عکس‌هایتان"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"camera;photos;video;webcam;lock;private;privacy;دوربین;عکس;ویدیو;وبکم;قفل;شخصی;"
-"خصوصی;محرمانگی;حریم;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "افزارهٔ واسنجیتان را روی مربع قرار داده و «شروع» را بزنید"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid "Move your calibration device to the calibrate position and press “Continue”"
-msgstr "افزارهٔ واسنجیتان را به موقعیت واسنجی منتقل کرده و «ادامه» را بزنید"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid "Move your calibration device to the surface position and press “Continue”"
-msgstr "افزارهٔ واسنجیتان را به موقعیت سطح منتقل کرده و «ادامه» را بزنید"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "در لپ‌تاپ را ببندید"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "یک خطای داخلی رخ داد و امکان بازسازی وجود ندارد."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "ابزارهای مورد نیاز برای واسنجی نصب نشده‌اند."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "نمایه نتوانست ایجاد شود."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "نقطهٔ سفید هدف قابل دسترسی نبود."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "تمام!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "واسنجی شکست خورد!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "می‌توانید افزارهٔ واسنجی را بردارید."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "مزاحم افزارهٔ واسنجی در هنگام کار نشوید"
+"camera;photos;video;webcam;lock;private;privacy;دوربین;عکس;ویدیو;وبکم;قفل;"
+"شخصی;خصوصی;محرمانگی;حریم;"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "واسنجی نمایشگر"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_لغو"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -619,138 +410,6 @@ msgstr "از _سر گیری"
 msgid "_Done"
 msgstr "_انجام شد"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "صفحه‌نمایش لپ‌تاپ"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "وب‌کم توکار"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "صفحه‌نمایش %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "پویشگر %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "دوربین %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "چاپگر %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "وب‌کم %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "به کار انداختن مدیریت رنگ برای %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "نمایش نمایه‌های رنگی برای %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "واسنجی نشده"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "پیش‌گزیده: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "فاصله‌رنگ (Colorspace): "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "آزمایش نمایه: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "انتخاب پروندهٔ نمایهٔ ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_درون‌ریزی"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "نمایه‌های ICC پشتیبانی شده"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "همهٔ پرونده‌ها"
-
-#: panels/color/cc-color-panel.c:586 panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "صفحه‌نمایش"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "ذخیرهٔ نمایه"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "ذخیره"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "ایجاد یک نمایهٔ رنگی برای افزارهٔ گزیده"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"ابزار اندازه‌گیری پیدا نشد. لطفاً بررسی کنید که روشن باشد و بدرستی نصب شده است."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "ابزار اندازه‌گیری از profiling پشتیبانی نمی‌کند."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "این گونه افزاره در حال حاضر پشتیبانی نمی‌شود."
-
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "واسنجی صفحه‌نمایش"
@@ -761,14 +420,17 @@ msgstr "کیفیت واسنجی"
 
 #: panels/color/cc-color-panel.ui:21
 msgid ""
-"Calibration will produce a profile that you can use to color manage your screen. "
-"The longer you spend on calibration, the better the quality of the color profile."
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
 msgstr ""
-"واسنجی، نمایه‌ای ایجاد خواهد کرد که می‌توانید از آن برای مدیریت رنگ صفحه‌تان استفاده "
-"کنید. هر چه زمان بیش‌تری برای واسنجی بگذارید، کیفت نمایهٔ رنگیتان بیش‌تر خواهد بود."
+"واسنجی، نمایه‌ای ایجاد خواهد کرد که می‌توانید از آن برای مدیریت رنگ صفحه‌تان "
+"استفاده کنید. هر چه زمان بیش‌تری برای واسنجی بگذارید، کیفت نمایهٔ رنگیتان "
+"بیش‌تر خواهد بود."
 
 #: panels/color/cc-color-panel.ui:28
-msgid "You will not be able to use your computer while calibration takes place."
+msgid ""
+"You will not be able to use your computer while calibration takes place."
 msgstr "تا پایان واسنجی نمی‌توانید از رایانه‌تان استفاده کنید."
 
 #. This is the approximate time it takes to calibrate the display.
@@ -803,11 +465,11 @@ msgstr "نقطه‌سفید نمایه"
 
 #: panels/color/cc-color-panel.ui:160
 msgid ""
-"Select a display target white point. Most displays should be calibrated to a D65 "
-"illuminant."
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
 msgstr ""
-"نقطهٔ سفید هدفی در نمایشگر برگزینید. بیش‌تر نمایشگرها باید با یک منبع نور D65 واسنجی "
-"شوند."
+"نقطهٔ سفید هدفی در نمایشگر برگزینید. بیش‌تر نمایشگرها باید با یک منبع نور D65 "
+"واسنجی شوند."
 
 #: panels/color/cc-color-panel.ui:187
 msgid "Display Brightness"
@@ -815,11 +477,11 @@ msgstr "روشنایی نمایشگر"
 
 #: panels/color/cc-color-panel.ui:195
 msgid ""
-"Please set the display to a brightness that is typical for you. Color management "
-"will be most accurate at this brightness level."
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
 msgstr ""
-"لطفاً روشنایی صفحه‌نمایش را به میزانی که برای شما مناسب است تنظیم کنید. مدیریت رنگ "
-"در این سطح روشنایی دقیق‌تر خواهد بود."
+"لطفاً روشنایی صفحه‌نمایش را به میزانی که برای شما مناسب است تنظیم کنید. مدیریت "
+"رنگ در این سطح روشنایی دقیق‌تر خواهد بود."
 
 #: panels/color/cc-color-panel.ui:202
 msgid ""
@@ -834,11 +496,11 @@ msgstr "نام نمایه"
 
 #: panels/color/cc-color-panel.ui:222
 msgid ""
-"You can use a color profile on different computers, or even create profiles for "
-"different lighting conditions."
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
 msgstr ""
-"می‌توانید از یک نمایهٔ رنگی روی رایانه‌های مختلف استفاده کرده یا حتا برای حالت‌های "
-"روشنایی متفاوت، نمایه بسازید."
+"می‌توانید از یک نمایهٔ رنگی روی رایانه‌های مختلف استفاده کرده یا حتا برای "
+"حالت‌های روشنایی متفاوت، نمایه بسازید."
 
 #: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
@@ -862,13 +524,13 @@ msgstr "نیاز به یک رسانهٔ قابل نوشتن دارد"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux\">GNU/"
-"Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows\">Microsoft "
-"Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"ممکن است این راهنماهای ساخت نمایه روی سامانه‌های <a href=\"linux\">گنو/لینوکس</a>، "
-"<a href=\"osx\">اواس ده اپل</a> و <a href=\"windows\">ویندوز مایکروسافت</a> مفید "
-"باشند."
+"ممکن است این راهنماهای ساخت نمایه روی سامانه‌های <a href=\"linux\">گنو/"
+"لینوکس</a>، <a href=\"osx\">اواس ده اپل</a> و <a href=\"windows\">ویندوز "
+"مایکروسافت</a> مفید باشند."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -876,10 +538,11 @@ msgstr "افزودن نمایه"
 
 #: panels/color/cc-color-panel.ui:373
 msgid ""
-"Problems detected. The profile may not work correctly. <a href=\"\">Show details.</"
-"a>"
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
 msgstr ""
-"مشکلاتی شناسایی شدند. ممکن است نمایه درست کار نکند. <a href=\"\">نمایش جزییات.</a>"
+"مشکلاتی شناسایی شدند. ممکن است نمایه درست کار نکند. <a href=\"\">نمایش "
+"جزییات.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -887,7 +550,6 @@ msgstr "درون‌ریزی _پرونده…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -897,8 +559,7 @@ msgstr "_افزودن"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "هر افزاره برای مدیریت رنگ، نیاز به یک نمایهٔ رنگی دارد."
 
-#. translators: Text used in link to privacy policy
-#: panels/color/cc-color-panel.ui:434 panels/diagnostics/cc-diagnostics-panel.c:137
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "بیشتر بدانید"
 
@@ -1030,98 +691,19 @@ msgstr "D65 (عکسبرداری و گرافیک)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "فضای استاندارد"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "آزمایش نمایه"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "خودکار"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "کیفیت پایین"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "کیفیت متوسّط"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "کیفیت بالا"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "پیش‌گزیده RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "پیش‌گزیده CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "پیش‌گزیده Gray"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "داده‌های واسنجی کارخانه‌ای فراهم شده به دست سازنده"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "اصلاح نمایش تمام‌صفحه با این نمایه ممکن نیست"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "ممکن است این نمایه دیگر دقیق نباشد"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "رنگ"
 
 #: panels/color/gnome-color-panel.desktop.in.in:4
-msgid "Calibrate the color of your devices, such as displays, cameras or printers"
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "رنگ افزاره‌هایتان نظیر نمایشگرها، دوربین‌ها یا چاپگرها را واسنجی کنید"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
-msgstr "Color;ICC;Profile;Calibrate;Printer;Display;رنگ;نمایه;واسنجی;چاپگر;نمایشگر;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "دیگر…"
+msgstr ""
+"Color;ICC;Profile;Calibrate;Printer;Display;رنگ;نمایه;واسنجی;چاپگر;نمایشگر;"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1135,13 +717,9 @@ msgstr "_انتخاب"
 msgid "No languages found"
 msgstr "هیچ زبانی پیدا نشد"
 
-#: panels/common/cc-language-chooser.ui:69 panels/keyboard/cc-input-chooser.c:173
+#: panels/common/cc-language-chooser.ui:69
 msgid "More…"
 msgstr "بیش‌تر…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "قفل‌گشایی برای تغییر تنظیمات"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1170,153 +748,6 @@ msgstr "ساعت کاهش"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "دقیقهٔ کاهش"
-
-#: panels/common/cc-util.c:127 panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "امروز"
-
-#: panels/common/cc-util.c:131 panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "دیروز"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%Oe %B"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%Oe %B، %OY"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%Id ساعت"
-msgstr[1] "%Id ساعت"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%Id دقیقه"
-msgstr[1] "%Id دقیقه"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%Id ثانیه"
-msgstr[1] "%Id ثانیه"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s و %s و %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s و %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s و %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "۰ ثانیه"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "نقطهٔ داغ"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "۲۴ ساعته"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "صبح / عصر"
-
-# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%Oe %B %OY، ⁦%Ol:%OM⁩ %p"
-
-# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%Oe %B %OY، ⁦%OH:%OM⁩"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s، %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "⁦%Ol∶%OM⁩ %p"
-
-# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "⁦%OH:%OM⁩"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1411,15 +842,11 @@ msgstr "_منطقه زمانی خودکار"
 msgid "Requires location services enabled and internet access"
 msgstr "نیاز به خدمت مکان‌یابی به کار افتاده و دسترسی به اینترنت"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/datetime/cc-datetime-panel.ui:212 panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802 panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "فعَال"
 
@@ -1427,15 +854,43 @@ msgstr "فعَال"
 msgid "Time Z_one"
 msgstr "منطقه ز_مانی"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "قفل‌گشایی"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_قالب زمان"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "تاریخ‌ها"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "۰ ثانیه"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_تقویم"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "عددها"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "تغییر ساعت و تاریخ، شامل منطقه زمانی"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "سایت;منطقهٔ زمانی;مکان;"
@@ -1481,20 +936,9 @@ msgstr "برنامه‌های پیش‌گزیده"
 msgid "Configure Default Applications"
 msgstr "پیکربندی برنامه‌های پیش‌گزیده"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "default;application;preferred;media;پیش‌گزیده;پیش‌گزیده;ترجیح;رسانه;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"ارسال گزارش‌های مشکلات فنی، به بهبود %s  کمک می‌کند. گزارش‌ها به صورت ناشناس ارسال "
-"شده و عاری از اطّلاعات شخصیند. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1512,44 +956,9 @@ msgstr "عیب‌یابی"
 msgid "Report your problems"
 msgstr "گزارش مشکلاتتان"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostics;crash;تشخیص;عیب‌یابی;فروپاشی;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "روشن"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "خاموش"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "اعمال تغییرات؟"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "نمی‌توان تغییرات را اعمال کرد"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "می‌تواند به دلیلی محدودیت‌های سخت‌افزار باشد."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1558,9 +967,11 @@ msgstr "_اِعمال"
 
 #: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
 #: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
-#: panels/printers/new-printer-dialog.ui:64 panels/region/cc-format-chooser.ui:37
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
 #: panels/user-accounts/cc-fingerprint-dialog.ui:44
-#: panels/user-accounts/cc-user-panel.ui:31 panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
 #: panels/wwan/cc-wwan-apn-dialog.ui:21
 msgid "Back"
 msgstr "برگشت"
@@ -1591,35 +1002,11 @@ msgid "Primary Display"
 msgstr "نمایشگر اصلی"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:177 panels/display/cc-display-panel.ui:228
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
 #: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "نور شب"
-
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "افقی"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "عمودی راست"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "عمودی چپ"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "افقی (معکوس)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf هرتز"
 
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
@@ -1639,10 +1026,22 @@ msgstr "آهنگ نوسازی"
 msgid "Adjust for TV"
 msgstr "تنظیم برای تلویزیون"
 
-#: panels/display/cc-display-settings.ui:78 panels/display/cc-display-settings.ui:93
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "مقیاس"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "لغرش طبیعی"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1650,8 +1049,8 @@ msgstr "نور شب موجود نیست"
 
 #: panels/display/cc-night-light-page.ui:33
 msgid ""
-"This could be the result of the graphics driver being used, or the desktop being "
-"used remotely"
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
 msgstr "می‌تواند نتیجهٔ راه‌انداز گرافیکی یا میزکار دوردست استفاده شده باشد"
 
 #. Inhibit the redshift functionality until the next day starts
@@ -1666,11 +1065,11 @@ msgstr "انجام دوباره صافی"
 
 #: panels/display/cc-night-light-page.ui:95
 msgid ""
-"Night light makes the screen color warmer. This can help to prevent eye strain and "
-"sleeplessness."
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
 msgstr ""
-"نور شب رنگ صفحه را گرم‌تر می‌کند. این کار به پیش‌گیری از آسیب چشمی و بی‌خوابی کمک می "
-"کند."
+"نور شب رنگ صفحه را گرم‌تر می‌کند. این کار به پیش‌گیری از آسیب چشمی و بی‌خوابی "
+"کمک می کند."
 
 #: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
@@ -1684,7 +1083,8 @@ msgstr "غروب تا طلوع"
 msgid "Manual Schedule"
 msgstr "زمان‌بندی دستی"
 
-#: panels/display/cc-night-light-page.ui:154 panels/region/cc-format-preview.ui:35
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "زمان‌ها"
 
@@ -1735,86 +1135,19 @@ msgstr "نمایشگرها"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "نحوهٔ استفاده از نمایشگرها و پروژکتورهای متّصل را انتخاب کنید"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
-"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;"
-"color;sunset;sunrise;"
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
 msgstr ""
-"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;"
-"color;sunset;sunrise;تابلو;پروژکتور;صفحه;مانیتور;نمایشگر;تفکیک;شب;نور;آبی;رنگ;غروب;"
-"طلوع;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "راه‌اندازی امن فعّال است"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device starts. "
-"It is currently turned on and is functioning correctly."
-msgstr ""
-"راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار افزاره "
-"می‌گیرد. در حال حاضر روشن است و به درستی کار می‌کند."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "راه‌اندازی امن مشکلاتی دارد"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device starts. "
-"It is currently turned on, but will not work due to having an invalid key."
-msgstr ""
-"راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار افزاره "
-"می‌گیرد. در حال حاضر روشن است؛ ولی به خاطر داشتن کلیدی نامعتبر، کار نخواهد کرد."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI firmware "
-"settings (BIOS) and your hardware manufacturer may provide information on how to "
-"do this."
-msgstr ""
-"مشکلات راه‌اندازی امن اغلب می‌توانند از تنظیمات ثابت‌افزار UEFIتان (بایوس) حل شوند و "
-"ممکن است سازندهٔ سخت‌افزارتان اطّلاعاتی در مورد چکونگی انجامشان فراهم کرده باشد."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "برای راهنمایی، با سازندهٔ سخت‌افزار یا فراهم کنندهٔ پشتیبانی ITتان تماس بگیرید."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "راه‌اندازی امن خاموش شده است"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device starts. "
-"It is currently turned off."
-msgstr ""
-"راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار افزاره "
-"می‌گیرد. در حال حاضر خاموش است."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware settings "
-"(BIOS). For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"راه‌اندازی امن اغلب می‌تواند از تنظیمات ثابت‌افزار UEFIتان (بایوس) خاموش شود. برای "
-"راهنمایی، با سازندهٔ سخت‌افزار یا فراهم کنندهٔ پشتیبانی ITتان تماس بگیرید."
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;تابلو;پروژکتور;صفحه;مانیتور;نمایشگر;تفکیک;شب;"
+"نور;آبی;رنگ;غروب;طلوع;"
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
-"Secure boot prevents malicious software from being loaded when the device starts.\n"
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
@@ -1823,125 +1156,9 @@ msgstr ""
 "\n"
 "برای اطّلاعات بیش تر با سازندهٔ سخت‌افزار یا پشیبانی IT تماس بگیرید."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "قبول شده"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "شکست خورده"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "افزاره مطابق سطح %Id از HSI"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "سطح امنیتی ۰"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could be "
-"because of a hardware or firmware configuration issue. It is recommended to "
-"contact your IT support provider."
-msgstr ""
-"این افزاره دربرابر مشکلات امنیتی سخت‌افزاری هیچ محافظتی ندارد. این امر می‌تواند به "
-"خاطر مشکل پیکربندی سخت‌افزار یا ثابت‌افزار باشد. پیشنهاد می‌شود با فراهم‌کنندهٔ "
-"پشتیبانی IT تماس بگیرید."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "سطح امنیتی ۱"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is the "
-"lowest device security level and only provides protection against simple security "
-"threats."
-msgstr ""
-"این افزاره در برابر مشکلات امنیتی سخت‌افزاری، کمینهٔ محافظت را دارد. این محافظت، "
-"پایین‌ترین سطح امنیت افزاره بوده و در برابر تهدیدهای امنیتی ساده مقاوم است."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "سطح امنیتی ۲"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This provides "
-"protection against some common security threats."
-msgstr ""
-"این افزاره در برابر مشکلات امنیتی سخت‌افزاری محافظت پایه‌ای دارد. این محافظت در "
-"برابر برخی تهدیدهای امنیتی معمول مقاوم است."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "سطح امنیتی ۳"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This is the "
-"highest device security level and provides protection against advanced security "
-"threats."
-msgstr ""
-"این افزاره در برابر مشکلات امنیتی سخت‌افزاری، محافظت گسترده دارد. این محافظت، "
-"بالاترین سطح امنیتی افزاره بوده و در برابر تهدیدهای امنیتی پیشرفته مقاوم است."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "سطح امنیت"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "سطوح امنیتی برای این افزاره موجود نیست."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"برای راهنمایی در بارهٔ به‌روز رسانی‌های امنیتی با سازندهٔ سخت‌افزارتان تماس بگیرید."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware settings, "
-"or by a support technician."
-msgstr ""
-"ممکن است رفع این مشکل در تنظیمات ثابت‌افزار UEFI یا به دست یک پشتیبان فنی ممکن باشد."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware settings."
-msgstr "ممکن است رفع این مشکل در تنظیمات ثابت‌افزار UEFI ممکن باشد."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "ممکن است یک پشتیبان فنی بتواند این مشکل را رفع کند."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -1955,337 +1172,9 @@ msgstr "سطح ۲"
 msgid "Level 3"
 msgstr "سطح ۳"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "محافظت در برابر نرم‌افزارهای مخرّب هنگام آغاز به کار افزاره."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "راه‌اندازی امن مشکلاتی دارد"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "برخی محافظت‌ها هنگام آغاز به کار افزاره."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "راه‌اندازی امن خاموش است"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "بدون محافظت هنگام آغاز به کار افزاره."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on this "
-"system."
-msgstr ""
-"ممکن است مشکل ناشی از تغییری در تنظیمات ثابت‌افزار UEFI، تغییری در پیکربندی "
-"سیستم‌عامل یا نرم‌افزاری مخرّب روی این سامانه باشد."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, or "
-"because of malicious software on this system."
-msgstr ""
-"ممکن است مشکل ناشی از تغییری در تنظیمات ثابت‌افزار UEFI یا نرم‌افزاری مخرّب روی این "
-"سامانه باشد."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration change, or "
-"because of malicious software on this system."
-msgstr ""
-"ممکن است مشکل ناشی از تغییری در پیکربندی سیستم‌عامل یا نرم‌افزاری مخرّب روی این "
-"سامانه باشد."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "در معرض تهدیدهای جدّی امنیتی."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "محافظت محدود در برابر تهدیدهای امنیتی ساده."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "محافظت شده در برابر تهدیدهای امنیتی معمول."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "محافظت شده در برابر بازهٔ وسیعی از تهدیدهای امنیتی."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "محافظت همه‌جانبه"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "بدون رویداد"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "محافظت نوشتن ثابت‌افزار"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "قفل محافظت نوشتن ثابت‌افزار"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "ناحیهٔ BIOS ثابت‌افزار"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "شرح‌دهندهٔ BIOS ثابت‌افزار"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "بوت‌گارد اینتل"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "راه‌اندازی تأیید شدهٔ بوت‌گارد اینتل"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "بوت‌گارد اینتل محافظت شده با ACM"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "سیاست خطای بوت‌گارد اینتل"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "فیوز بوت‌گارد اینتل"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "کت اینتل به کار افتاده"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "کت اینتل فعّال"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "جلوگیری از دسترسی حالت ناظر اینتل"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "حافظهٔ رمزگذاشته"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "محافظت IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "قرنطینهٔ کرنل لینوکس"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "تأیید کرنل لینوکس"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "مبادلهٔ لینوکس"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "تعلیق به رم"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "تعلیق به بی‌کار"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "کلید بن‌سازهٔ UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "راه‌اندازی امن UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "پیکربندی بن‌سازهٔ TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "بازسازی TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "نگارش ۲٫۰ TPM"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "حالت سازندهٔ موتور مدیریت اینتل"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "پایمالی موتور مدیریت اینتل"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "نگارش موتور مدیریت اینتل"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "به‌روز رسانی‌های ثابت‌افزار"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "تصدیق ثابت‌افزار"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "تصدیق به‌روز رسان ثابت‌افزار"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "اشکال‌زدایی بن‌سازه"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "بررسی‌های امنیتی پردازنده"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "محافظت از بازگشت AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "محافظت از بازپخش ثابت‌افزار AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "محافظت از نوشتن ثابت‌افزار AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "بن‌سازهٔ فیوز شده"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "معتبر"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "نامعتبر"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "به کار نیفتاده"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "قفل شده"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "قفل نشده"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "رمز شده"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "رمز نشده"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "آلوده شده"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "آلوده نشده"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "پیدا شده"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "پیدا نشده"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "پشتیبانی شده"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "پشتیبانی نشده"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2295,58 +1184,14 @@ msgstr "امنیت افزاره"
 msgid "Host firmware security status"
 msgstr "وضعیت امنیتی ثابت‌افزار میزبان"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
-"identity;privacy;"
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
 msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
-"identity;privacy;صفحه;قفل;کرش;خصوصی;اخیر;موقت;نمایه;نام;شبکه;هویت;محرمانگی\"حریم "
-"شخصی;حریم خصوصی;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "ناشناخته"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "۶۴ بیتی"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "۳۲ بیتی"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "زورگ"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "وی‌لند"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "ناشناخته"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "ناموجود"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "نشان سامانه"
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;صفحه;قفل;کرش;خصوصی;اخیر;موقت;نمایه;نام;شبکه;هویت;"
+"محرمانگی\"حریم شخصی;حریم خصوصی;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2421,8 +1266,8 @@ msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
 msgstr ""
-"نام افزاره برای تشخیص این افزاره هنگام دیده شدن روی شبکه یا جفت شدن افزاره‌های "
-"بلوتوثی استفاده می‌شود."
+"نام افزاره برای تشخیص این افزاره هنگام دیده شدن روی شبکه یا جفت شدن "
+"افزاره‌های بلوتوثی استفاده می‌شود."
 
 #: panels/info-overview/cc-info-overview-panel.ui:196
 msgid "Device name"
@@ -2440,20 +1285,16 @@ msgstr "درباره"
 msgid "View information about your system"
 msgstr "دیدن اطّلاعات دربارهٔ سامانه‌تان"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
-"device;system;information;hostname;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
-"device;system;information;hostname;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;دستگاه;افزاره;سیستم;"
-"سامانه;اطّلاعات;نام دامنه;حافظه;پردازشگر;نسخه;پیش‌گزیده;برنامه;یدکی;ترجیح‌شده;سی‌دی;"
-"دی‌وی‌دی;یواس‌بی;صوت;ویدیو;دیسک;قابل حذف;رسانه;اجرای خودکار;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"دستگاه;افزاره;سیستم;سامانه;اطّلاعات;نام دامنه;حافظه;پردازشگر;نسخه;پیش‌گزیده;"
+"برنامه;یدکی;ترجیح‌شده;سی‌دی;دی‌وی‌دی;یواس‌بی;صوت;ویدیو;دیسک;قابل حذف;رسانه;اجرای "
+"خودکار;"
 
 #: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
@@ -2524,6 +1365,12 @@ msgstr "راه‌اندازها"
 msgid "Launch help browser"
 msgstr "راه‌اندازی مرورگر راهنما"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "تنظیمات"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "راه‌اندازی ماشین حساب"
@@ -2545,7 +1392,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "جست‌وجو"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "سامانه"
 
@@ -2594,15 +1441,6 @@ msgstr "کاهش اندازهٔ متن"
 msgid "High contrast on or off"
 msgstr "روشن یا خاموش کردن سایه‌روشن بالا"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "هیچ منبع ورودی پیدا نشد"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "موارد دیگر"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "افزودن یک منبع ورودی"
@@ -2635,98 +1473,9 @@ msgstr "ترجیحات"
 msgid "View Keyboard Layout"
 msgstr "نمایش چیدمان صفحه‌کلید"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "برداشتن"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "میان‌برهای سفارشی"
-
-#: panels/keyboard/cc-keyboard-panel.c:64 panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "کلید نویسه‌های جایگزین"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. These are "
-"sometimes printed as a third-option on your keyboard."
-msgstr ""
-"کلید نویسهٔ جایگزین می‌تواند برای ورود نویسه‌های اضافی استفاده شود. گاهی به عنوان "
-"گزینهٔ سوم روی صفحه‌کلیدتان چاپ شده‌اند."
-
-#: panels/keyboard/cc-keyboard-panel.c:67 panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "دگرساز چپ"
-
-#: panels/keyboard/cc-keyboard-panel.c:68 panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "دگرساز راست"
-
-#: panels/keyboard/cc-keyboard-panel.c:69 panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "سوپر چپ"
-
-#: panels/keyboard/cc-keyboard-panel.c:70 panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "سوپر راست"
-
-#: panels/keyboard/cc-keyboard-panel.c:71 panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "کلید فهرست"
-
-#: panels/keyboard/cc-keyboard-panel.c:72 panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "مهار راست"
-
-#: panels/keyboard/cc-keyboard-panel.c:80 panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "کلید ایجاد"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use it, "
-"press compose then a sequence of characters.  For example, compose key followed by "
-"<b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by <b>'</b> will "
-"enter <b>á</b>."
-msgstr ""
-"دکمهٔ ایجاد، امکان ورود طیف وسیعی از نویسه‌ها را می‌دهد. برای استفاده از آن، ایجاد و "
-"به دنبالش، دنباله‌ای از نویسه‌ها را بفشارید.  برای مثال، کلید ایجاد به همراه <b>C</"
-"b> و <b>o</b>، نویسهٔ <b>©</b> و <b>a</b> به همراه <b>'</b>، نویسهٔ <b>á</b> را وارد "
-"می‌کند."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "قفل تبدیل"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "قفل لغزش"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "نماگرفت"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"منابع ورودی می‌توانند با استفاده از میان‌بر صفحه‌کلید %s تعویض شوند.\n"
-"این میان‌بر می‌تواند در تنظیمات میان‌برهای صفحه‌کلید عوض شود."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2756,43 +1505,21 @@ msgstr "ورود نویسهٔ خاص"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "روش‌های ورود نشانه‌ها و دگرگونه‌های حروف با استفاده از صفحه‌کلید."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "کلید نویسه‌های جایگزین"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "کلید ایجاد"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "میان‌برهای صفحه‌کلید"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "نمایش و سفارشی سازی میان‌برها"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%Id تغییریافته"
-msgstr[1] "%Id تغییریافته"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "بازنشانی تمام میان‌برها؟"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be undone."
-msgstr ""
-"ممکن است بازنشانی میان‌برها روی میان‌برهای شخصیتان اثر بگذارد. این کار قابل بازگشت "
-"نیست."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83 panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "لغو"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "بازنشانی همه"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2830,34 +1557,6 @@ msgstr "افزودن میان‌بر"
 msgid "No keyboard shortcut found"
 msgstr "هیچ میان‌بر صفحه‌کلیدی پیدا نشد"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"کلید %s از پیش برای %s استفاده می‌شد. اگر جایگزینش کنید، %s از کار خواهد افتاد"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "میان‌بر جدید را وارد کنید"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "تنظیم میان‌بر سفارشی"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "تنظیم میان‌بر"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "برای تغییر %s میان‌بر جدید را وارد کنید."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "افزودن میان‌بر سفارشی"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_برداشتن"
@@ -2867,8 +1566,8 @@ msgid "Re_place"
 msgstr "_جایگزینی"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
-#: panels/wwan/cc-wwan-mode-dialog.ui:39 panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
 msgid "_Set"
 msgstr "_تنظیم"
 
@@ -2879,7 +1578,8 @@ msgstr "فشردن گریز برای لغو یا پس‌بر برای از کا�
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:137 panels/wwan/cc-wwan-apn-dialog.ui:96
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "نام"
 
@@ -2903,23 +1603,29 @@ msgstr "هیچ"
 msgid "Reset the shortcut to its default value"
 msgstr "بازنشانی میان‌بر به مقدار پیش‌گزیدهش"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "استفاده از چاپگر به صورت پیش‌گزیده"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "صفحه‌کلید"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
 msgid ""
-"Change keyboard shortcuts and set your typing preferences, keyboard layouts and "
-"input sources"
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
-"تغییر میان‌برهای صفحه‌کلید و تنظیم ترجیحات نوشتن، چینش‌های صفحه‌کلید و منبع‌های ورودیتان"
+"تغییر میان‌برهای صفحه‌کلید و تنظیم ترجیحات نوشتن، چینش‌های صفحه‌کلید و منبع‌های "
+"ورودیتان"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
-msgid "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
-"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;میانبر;"
-"میان‌بر;فضای کاری;پنجره;اندازه;بزرگ‌نمایی;تضاد;ورودی;منبع;قفل;صدا;"
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+"میانبر;میان‌بر;فضای کاری;پنجره;اندازه;بزرگ‌نمایی;تضاد;ورودی;منبع;قفل;صدا;"
 
 #: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
@@ -2931,19 +1637,19 @@ msgstr "هیچ برنامه‌ای نمی‌تواند اطّلاعات موقع
 
 #: panels/location/cc-location-panel.ui:38
 msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and mobile "
-"broadband increases accuracy.\n"
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
 "\n"
-"Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/"
-"privacy'>Privacy Policy</a>\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
 "\n"
 "Allow the applications below to determine your location."
 msgstr ""
 "خدمات مکانی می‌گذارند برنامه‌ها مکانتان را بدانند. استفاده از وای‌فای و پهن‌باند "
 "همراه، دقّت را بالا می‌برد.\n"
 "\n"
-"از خدمت مکان موزیلا استفاده می‌شود: <a href='https://location.services.mozilla.com/"
-"privacy'>سیاست محرمانگی</a>\n"
+"از خدمت مکان موزیلا استفاده می‌شود: <a href='https://location.services."
+"mozilla.com/privacy'>سیاست محرمانگی</a>\n"
 "\n"
 "اجازه به برنامه‌های زیر برای تشخیص مکانتان."
 
@@ -2955,7 +1661,6 @@ msgstr "هیچ برنامه‌ای برای دسترسی به مکان درخو�
 msgid "Protect your location information"
 msgstr "محافظت از اطّلاعات مکانتان"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "location;gps;private;privacy;مکان;موقعیت;خصوصی;محرمانگی;حریم شخصی;"
@@ -2970,13 +1675,14 @@ msgstr "هیچ برنامه‌ای نمی‌تواند صدا ضبط کند."
 
 #: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
-"Use of the microphone allows applications to record and listen to audio. Disabling "
-"the microphone may cause some applications to not function properly.\n"
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
 "\n"
 "Allow the applications below to use your microphone."
 msgstr ""
-"استفاده از میکروفون به برنامه‌ها اجازه می‌دهد که صدا را ضبط و به آن گوش کنند. از کار "
-"انداختن میکروفون ممکن است باعث کارکرد نادرست برخی برنامه‌ها شود.\n"
+"استفاده از میکروفون به برنامه‌ها اجازه می‌دهد که صدا را ضبط و به آن گوش کنند. "
+"از کار انداختن میکروفون ممکن است باعث کارکرد نادرست برخی برنامه‌ها شود.\n"
 "\n"
 "اجازه به برنامه‌های زیر برای استفاده از میکروفونتان."
 
@@ -2988,18 +1694,18 @@ msgstr "هیچ برنامه‌ای برای دسترسی به میکروفون �
 msgid "Protect your conversations"
 msgstr "محافظت از گفت‌وگوهایتان"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
-"microphone;recording;application;privacy;میکروفون;ضبط;برنامه;محرمانگی;حریم شخصی;"
-"خصوصی;"
+"microphone;recording;application;privacy;میکروفون;ضبط;برنامه;محرمانگی;حریم "
+"شخصی;خصوصی;"
 
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "آزمودن _تنظیماتتان"
 
-#: panels/mouse/cc-mouse-panel.ui:23 panels/multitasking/cc-multitasking-panel.ui:9
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
 msgid "General"
 msgstr "عمومی"
 
@@ -3019,96 +1725,154 @@ msgstr "چپ"
 msgid "Right"
 msgstr "راست"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "جست‌وجوی مکان‌ها"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "موشی"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "سرعت موشی"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "لغرش طبیعی"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "بدون محافظت"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "لغزش، محتوا را جابه‌جا می‌کند، نه نما را."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "لغزش، محتوا را جابه‌جا می‌کند، نه نما را."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "فعّال"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "صفحه ‌لمسی"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "سرعت صفحه ‌لمسی"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "ضربه برای کلیک"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "ضربه برای کلیک"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "لغزش دو انگشتی"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "صفحه‌لمسی (وابسته)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "لغزش در گوشه‌ها"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "قفل لغزش"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "دو طرفه"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "کلیک، دوبار کلیک و لغزش را بیازمایید"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "پنج کلیک، زمان GEGL است!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "دوبار کلیک، دکمهٔ اصلی"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "تک کلیک، دکمهٔ اصلی"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "دوبار کلیک، دکمهٔ وسط"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "تک کلیک، دکمهٔ وسط"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "دوباره کلیک، دکمهٔ دوم"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "تک کلیک، دکمهٔ دوم"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "موشی و صفحه‌لمسی"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:4
-msgid "Change your mouse or touchpad sensitivity and select right or left-handed"
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "تغییر میزان حساسیت موشی یا صفحه‌لمسی و انتخاب راست‌دست یا چپ‌دست بودن"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
-"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;صفحه‌جهت‌ده;نشانگر;کلیک;"
-"ضربه;دوبار;دکمه;صفحه ردیاب;لغزش;"
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;صفحه‌جهت‌ده;نشانگر;"
+"کلیک;ضربه;دوبار;دکمه;صفحه ردیاب;لغزش;"
 
 #: panels/multitasking/cc-multitasking-panel.ui:15
 msgid "_Hot Corner"
@@ -3123,7 +1887,8 @@ msgid "_Active Screen Edges"
 msgstr "لبه‌های صفحهٔ _فعّال"
 
 #: panels/multitasking/cc-multitasking-panel.ui:43
-msgid "Drag windows against the top, left, and right screen edges to resize them."
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
 msgstr "کشیدن پنجره‌ها مقابل لبه‌های بالا، راست و چپ صفحه برای تغییر اندازه‌شان."
 
 #: panels/multitasking/cc-multitasking-panel.ui:70
@@ -3182,27 +1947,18 @@ msgstr "چندوظیفگی"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "مدیریت ترجیحات برای بهره‌وری و چندوظیفگی"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 "چندوظیفگی;بهره‌وری;شخصی‌سازی;میزکار;گوشه‌ها;فضا;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "آخ، مشکلی پیش آمد. لطفاً با تولید کننده نرم‌افزار خود تماس بگیرید."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "باید NetworkManager در حال اجرا باشد."
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "دیگر افزاره‌ها"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "وی‌پی‌ان"
 
@@ -3214,58 +1970,16 @@ msgstr "افزودن اتّصال"
 msgid "Not set up"
 msgstr "برپا نشده"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "شبکهٔ ناامن (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "شبکهٔ امن (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "شبکهٔ امن (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "شبکهٔ امن (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "شبکهٔ امن"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "متّصل"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325 panels/network/network-bluetooth.ui:22
-#: panels/network/network-ethernet.ui:56 panels/network/network-mobile.ui:329
-#: panels/network/network-proxy.ui:62 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "گزینه‌ها…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible to "
-"access the internet through Wi-Fi."
-msgstr ""
-"روشن کردن نقطهٔ داغ، موجب قطع شدن از %s شده و قادر به دسترسی به اینترنت از طریق "
-"وای‌فای نیستید."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "باید کمینهٔ ۸ نویسه را داشته باشد"
 
 # "I" in "%Id" is for showing persian number.
 #: panels/network/cc-wifi-hotspot-dialog.c:271
@@ -3281,12 +1995,13 @@ msgstr "روشن کردن نقطهٔ داغ بی‌سیم؟"
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
-"Wi-Fi hotspot allows others to share your internet connection, by creating a Wi-Fi "
-"network that they can connect to. To do this, you must have an internet connection "
-"through a source other than Wi-Fi."
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
 msgstr ""
-"نقطهٔ داغ وای‌فای با ایجاد یک شبکهٔ وای‌فای، به دیگران اجازهٔ هم‌رسانی اتّصال اینترنتتان "
-"را می‌دهد. برای این کار باید اتّصال اینترنتی از منبعی غیر از وای‌فای داشته باشید."
+"نقطهٔ داغ وای‌فای با ایجاد یک شبکهٔ وای‌فای، به دیگران اجازهٔ هم‌رسانی اتّصال "
+"اینترنتتان را می‌دهد. برای این کار باید اتّصال اینترنتی از منبعی غیر از وای‌فای "
+"داشته باشید."
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
@@ -3294,8 +2009,8 @@ msgstr "نام شبکه"
 
 #. Translators: This is a password needed for printing.
 #: panels/network/cc-wifi-hotspot-dialog.ui:75
-#: panels/printers/new-printer-dialog.ui:338 panels/printers/pp-jobs-dialog.ui:54
-#: panels/sharing/cc-sharing-panel.ui:384
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
 #: panels/user-accounts/cc-add-user-dialog.ui:364
@@ -3314,19 +2029,6 @@ msgstr "گذرواژهٔ ایجاد شده به صورت خودکار"
 #: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_روشن کردن"
-
-#: panels/network/cc-wifi-panel.c:549 panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "وای‌فای"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "توقّف نقطهٔ داغ و قطع ارتباط همهٔ کاربران؟"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_توقّف نقطهٔ داغ"
 
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
@@ -3372,89 +2074,13 @@ msgstr "شبکه‌های آشکار"
 msgid "NetworkManager needs to be running"
 msgstr "لازم است NetworkManager در حال اجرا باشد"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "آخ، مشکلی پیش آمد. لطفاً با تولید کننده نرم‌افزار خود تماس بگیرید."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_امنیت 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "امنیت"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "حفظ"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "همیشگی"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "تصادفی"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "پایدار"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the network "
-"device this connection is activated on. This feature is known as MAC cloning or "
-"spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"نشانی مک وارد شده در این‌جا به عنوان نشانی سخت‌افزاری برای افزارهٔ شبکه‌ای که این "
-"اتّصال رویش فعّال است استفاده خواهد شد. این ویژگی به نام MAC cloning یا spoofing "
-"شناخته می‌شود. مثال: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "نمایهٔ %Id"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "گشودن بهبودیافته"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "تجاری"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "هیچ"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "هرگز"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3463,177 +2089,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%Ii روز پیش"
 msgstr[1] "%Ii روز پیش"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%Id مگابیت/ثانیه (%I1.1f گیگاهرتز)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%Id مگابیت/ثانیه"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "۲.۴ گیگاهرتز / ۵ گیگاهرتز"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "۲.۴ گیگاهرتز"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "۵ گیگاهرتز"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "هیچ"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "ضعیف"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "کافی"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "خوب"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "عالی"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144 panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "نشانی IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146 panels/network/net-device-mobile.c:442
-#: panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "نشانی IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149 panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445 panels/network/net-device-mobile.c:446
-#: panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "نشانی IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166 panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "ساناد۴"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167 panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "ساناد۶"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169 panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453 panels/network/net-device-mobile.c:454
-#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "ساناد"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "فراموشی اتّصال"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "برداشتن نمایهٔ اتّصال"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "برداشتن وی‌پی‌ان"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "جزییات"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "خودکار"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "هویت"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "حذف آدرس"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "حذف مسیر"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "هیچ"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "کلید ۴۰/۱۲۸ بیتیWEP (Hex یا ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "عبارت‌عبور ۱۲۸ بیتی WEP"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "‫WEP پویا (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "‫WPA و WPA2 شخصی"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA و WPA2 تجاری"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 شخصی"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3644,8 +2099,20 @@ msgstr "قدرت سیگنال"
 msgid "Link speed"
 msgstr "سرعت پیوند"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "امنیت"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "نشانی IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "نشانی IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "نشانی سخت‌افزاری"
 
@@ -3654,10 +2121,17 @@ msgid "Supported Frequencies"
 msgstr "بسامدهای پشتیبانی شده"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158 panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162 panels/network/network-mobile.ui:191
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "بسامدهای پشتیبانی شده"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "ساناد"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3676,9 +2150,11 @@ msgid "_Metered connection: has data limits or can incur charges"
 msgstr "اتّصال _اندازه‌گیری‌شده: دارای محدویت داده یا هزینه"
 
 #: panels/network/connection-editor/details-page.ui:423
-msgid "Software updates and other large downloads will not be started automatically."
+msgid ""
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
-"به‌روز رسانی‌های نرم‌افزاری و دیگر بارگیری‌های بزرگ به صورت خودکار شروع نخواهند شد."
+"به‌روز رسانی‌های نرم‌افزاری و دیگر بارگیری‌های بزرگ به صورت خودکار شروع نخواهند "
+"شد."
 
 #: panels/network/connection-editor/ethernet-page.ui:21
 #: panels/network/connection-editor/vpn-page.ui:17
@@ -3717,7 +2193,7 @@ msgid "Link-Local Only"
 msgstr "فقط Link-Local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:65 panels/network/net-proxy.c:71
+#: panels/network/connection-editor/ip6-page.ui:65
 #: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "دستی"
@@ -3761,10 +2237,9 @@ msgstr "دروازه"
 #: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:237 panels/network/net-proxy.c:73
+#: panels/network/connection-editor/ip6-page.ui:237
 #: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "خودکار"
 
@@ -3817,90 +2292,9 @@ msgstr "خودکار، فقط DHCP"
 msgid "Prefix"
 msgstr "پیشوند"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "نمی‌توان ویرایشگر اتّصال را باز کرد"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "نمایهٔ جدید"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "تنظیم نامعتبر %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "تنظیم نامعتبر %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "درون ریزی از پرونده…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "افزودن وی‌پی‌ان"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_امنیت"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "نمی‌توان اتّصال وی‌پی‌ان را درون‌ریزی کرد"
-
-# در این رشته از نویسه ایزوله اولین نویسهٔ قوی استفاده شده است
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN connection "
-"information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"پروندهٔ «⁨%s⁩» نمی‌تواند خوانده شود یا حاوی اطّلاعات اتّصال شناخته‌شدهٔ وی‌پی‌ان نیست\n"
-"\n"
-"خطا: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "گزینش پرونده برای درون‌ریزی"
-
-# در این رشته از نویسه ایزوله اولین نویسهٔ قوی استفاده شده است
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "پرونده‌ای با نام «⁨%s⁩» از پیش وجود دارد."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_جایگزینی"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "می‌خواهید %s را با اتّصال وی‌پی‌انی که دارید ذخیره‌اش می‌کنید جایگزین کنید؟"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "نمی‌توان اتّصال وی‌پی‌ان را برون‌ریزی کرد"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"اتّصال وی‌پی‌ان «%s» را نمی‌توان به %s صادر کرد.\n"
-"\n"
-"خطا: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "برون‌ریزی اتّصال وی‌پی‌ان"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3914,99 +2308,40 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "شبکه"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "واپایش شیوهٔ اتّصال به اینترنت"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
-"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;شبکه;آی پی;لن;پیشکار;"
-"پروکسی;ون;پهن‌باند;مودم;بلوتوث;وی پی ان;دی ان اس;ساناد;"
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;شبکه;آی پی;لن;"
+"پیشکار;پروکسی;ون;پهن‌باند;مودم;بلوتوث;وی پی ان;دی ان اس;ساناد;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "وای‌فای"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "واپایش شیوهٔ اتّصال به شبکه‌های وای‌فای"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;شبکه;بی سیم;وای فای;آی پی;"
-"لن;پروکسی;پهن‌باند;دی ان اس;ساناد;هات اسپات;"
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;شبکه;بی سیم;وای فای;"
+"آی پی;لن;پروکسی;پهن‌باند;دی ان اس;ساناد;هات اسپات;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "هرگز"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "امروز"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "دیروز"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "آخرین استفاده"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264 panels/network/network-bluetooth.ui:5
-#: panels/network/network-ethernet.ui:5
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "سیمی"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "افزودن اتّصال جدید"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any custom "
-"configuration will be lost."
-msgstr ""
-"جزییات شبکه‌های گزیده، شامل گذرواژه‌ها و هر پیکربندی سفارشی‌ای از دست خواهند رفت."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_فراموشی"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "شبکه‌های وای‌فای آشنا"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_فراموشی"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "سیاست سامانه استفاده از نقطهٔ داغ را منع کرده است"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "افزارهٔ بی‌سیم از حالت نقطهٔ داغ پشتیبانی نمی‌کند"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "کشف خودکار پیشکار وب زمانی که URL فراهم نشده باشد استفاده می‌شود."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "برای شبکه‌های عمومی نامطمئن توصیه نمی‌شود."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4017,13 +2352,18 @@ msgstr "خاموش کردن افزاره"
 msgid "Active"
 msgstr "فعّال"
 
-#: panels/network/network-mobile.ui:27 panels/wwan/cc-wwan-details-dialog.ui:237
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "فراهم‌کننده"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "نشانی IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4108,289 +2448,6 @@ msgstr "روشن کردن نقطهٔ داغ بی‌سیم…"
 msgid "_Known Wi-Fi Networks"
 msgstr "شبکه‌های آشنا"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "وضعیت ناشناس"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "مدیریت نشده"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "ناموجود"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "در حال وصل شدن"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "تصدیق هویت شکست خورد"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "در حال قطع شدن"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "اتّصال شکست خورد"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "وضعیت ناشناس (ناپیدا)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "پیکربندی شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "پیکربندی IP شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "پیکربندی IP منقضی شد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "رمزها لازم بودند، اما فراهم نشدند"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "درخواست کننده 802.1x قطع شد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "تنظیمات پیکربندی درخواست کننده 802.1x شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "درخواست کننده 802.1x شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "تصدیق‌هویت دروخواست کننده 802.1x مدت زیادی طول کشید"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "شروع کارساز PPP شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "سرویس PPP قطع شد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "شکست در شروع کارخواه DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "خطا کارخواه DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "کارخواه DHCP شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "شکست در شروع خدمت اتّصالِ هم‌رسانده"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "سرویس اتّصال هم‌رسانی شده شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "شروع سرویس AutoIP شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "خطا سرویس AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "سرویس AutoIP شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "خطِ مشغول"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "بوق شماره‌گیری وجود ندارد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "اتّصال به هیچ فراهم‌کننده‌ای امکان‌پذیر نبود"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "مهلت درخواست شماره‌گیری تمام شد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "تلاش برای شماره‌گیری شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "مقداردهی اولیه مودم شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "انتخاب APN مشخص شده شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "جست‌وجو نکردن برای شبکه‌ها"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "ثبت شبکه رد شد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "مهلت ثبت شبکه تمام شد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "ثبت از طریق شبکه درخواست شده شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "بررسی پین شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "ممکن است ثابت‌افزار افزاره موجود نباشد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "اتّصال محو شد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "اتّصال فعلی استفاده شد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "مودم پیدا نشد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "اتّصال بلوتوث شکست خورد"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "سیم‌کارت وارد نشده است"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "پین سیم‌کارت لازم است"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "پوک سیم‌کارت لازم است"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "سیم‌کارت نادرست"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "نیازمندی‌های اتّصال شکست خورد"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "ثابت‌افزار موجود نیست"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "کابل قطع شد"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "خطای تعریف نشده در امنیت 802.1x (‫wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "هیچ پرونده‌ای انتخاب نشد"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "خطای نامشخّص در تأیید اعتبار پروندهٔ eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "کلیدهای خصوصی PGP، DER، PEM یا PKCS#12"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "گواهینامه‌های DER یا PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "پرونده EAP-FAST PAC فراهم نشده"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "پرونده‌های PAC شامل ‪(*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4439,14 +2496,6 @@ msgstr "تأیید هویت _داخلی"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "اجازه دادن برای آ_ماده‌سازی خودکار PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "نام‌کاربری EAP-LEAP فراهم نشده"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "گذرواژه EAP-LEAP فراهم نشده"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4458,7 +2507,8 @@ msgstr "نام _کاربری"
 #: panels/network/wireless-security/ws-leap.ui:23
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
-#: panels/sharing/cc-sharing-panel.ui:152 panels/user-accounts/cc-user-panel.ui:182
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_گذرواژه"
 
@@ -4470,15 +2520,6 @@ msgstr "_گذرواژه"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_نمایش گذرواژه"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "گواهینامه EAP-PEAP CA نامعتبر است: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "گواهینامه EAP-PEAP CA نامعتبر است: هیچ گواهینامه‌ای مشخص نشده"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4501,7 +2542,6 @@ msgid "C_A certificate"
 msgstr "گواهینامه C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4516,63 +2556,6 @@ msgstr "به گواهینامه CA _نیازی نیست"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_نسخه PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "نام‌کاربری EAP فراهم نشده"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "گذرواژه EAP وارد نشده"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "شناسه EAP-TLS فراهم نشده"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "گواهینامه EAP-TLS CA نامعتبر است: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "گواهینامه EAP-TLS CA نامعتبر است: هیچ گواهینامه‌ای فراهم نشده"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "کلید خصوصی EAP-TLS نامعتبر است: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "گواهینامه کاربر EAP-TLS نامعتبر است: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "کلیدهای خصوصی رمزنگاری نشده ناامن هستند"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This could "
-"allow your security credentials to be compromised. Please select a password-"
-"protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"به‌نظر نمی‌رسد کلید خصوصی انتخاب شده با گذرواژه محافظت شده باشد. این امر ممکن است "
-"موجب به خطر افتادن اطّلاعات حساس شما شود. لطفاً یک کلید خصوصی محافظت شده با گذرواژه "
-"انتخاب کنید.\n"
-"\n"
-"(می‌توانید با openssl روی کلیدتان گذرواژه بگذارید)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "گواهینامهٔ شخصی خود را انتخاب کنید"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "کلید خصوصی خود را انتخاب کنید"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4589,15 +2572,6 @@ msgstr "_کلید خصوصی"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "گذرواژهٔ کلید _خصوصی"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "گواهینامهٔ EAP-TTLS CA نامعتبر: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "گواهینامهٔ EAP-TTLS CA نامعتبر: هیچ گواهینامه‌ای فراهم نشده"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4620,14 +2594,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_دامنه"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "خطای ناشناخته در تأیید اعتبار امنیت 802.1x"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4655,57 +2630,10 @@ msgstr "‫EAP محافظت شده (PEAP)"
 msgid "Au_thentication"
 msgstr "تأیید_هویت"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "گزینش یک پرونده"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "گزینه leap-username فراهم نشده است"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "گذرواژه leap وارد نشده"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "گذرواژهٔ وای‌فای مفقود است."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_گونه"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "گزینه wep-key فراهم نشده است"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "گزینه wep-key نامعتبر است: کلیدی با طول %zu تنها باید شامل hex-digit باشد"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "گزینه hex-digits نامعتبر است: کلیدی با طول %zu باید شامل نویسه‌های ascii باشد"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 (ascii) "
-"or 10/26 (hex)"
-msgstr ""
-"گزینه wep-key نامعتبر: طول کلید نامعتبر %zu. یک کلید یا باید طول 5/13 (ascii) یا "
-"10/26 (hex) داشته باشد."
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "گزینه wep-key نامعتبر: عبارت‌رمز نباید خالی باشد"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "گزینه wep-key نامعتبر: عبارت‌رمز باید کمتر از ۶۴ نویسه باشد"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4731,17 +2659,6 @@ msgstr "_نمایش کلید"
 msgid "WEP inde_x"
 msgstr "_فهرست WEP"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex digits"
-msgstr ""
-"گزینه wpa-psk نامعتبر: طول کلید نامعتبر %zu.باید یا [8,63] باید یا ۶۴ رقم hex باشد"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "گزینه wpa-psk نامعتبر است: نمی‌توان کلید ۶۴ بایتی را به عنوان hex تفسیر کرد"
-
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
@@ -4761,10 +2678,11 @@ msgstr "واشوهای ا_علان"
 
 #: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
-"Notifications will continue to appear in the notification list when popups are "
-"disabled."
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
 msgstr ""
-"هنگام از کار افتادن واشوها، آگاهی‌ها به ظاهر شدن در فهرست آگاهی‌ها ادامه می‌دهند."
+"هنگام از کار افتادن واشوها، آگاهی‌ها به ظاهر شدن در فهرست آگاهی‌ها ادامه "
+"می‌دهند."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
 #: panels/notifications/cc-app-notifications-dialog.ui:56
@@ -4794,27 +2712,9 @@ msgstr "آگاهی‌های صفحهٔ _قفل"
 msgid "Control which notifications are displayed and what they show"
 msgstr "واپایش آگاهی‌های نمایش داده شده و آن‌چه نشان می‌دهند"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifications;Banner;Message;Tray;Popup;آگاهیها;بنر;پیام;سینی;واشو;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "موارد دیگر"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s حذف شد"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "خطای برداشتن حساب"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4838,17 +2738,6 @@ msgstr "بدون اتّصال اینترنتی — برای برپایی حسا�
 msgid "Add an account"
 msgstr "افزودن یک حساب"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "حساب %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "برداشتن حساب"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "حساب‌های برخط"
@@ -4857,21 +2746,13 @@ msgstr "حساب‌های برخط"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "به حساب‌های برخطتان وصل شده و تصمیم بگیرید از آن‌ها برای چه استفاده‌ کنید"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-"گوگل;فیس بوک;تویتر;یاهو;وب;برخط;گپ;تقویم;پست‌الکترونیکی;آشنا;ownCloud;Kerberos;IMAP;"
-"SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "زمان نامعلوم"
+"گوگل;فیس بوک;تویتر;یاهو;وب;برخط;گپ;تقویم;پست‌الکترونیکی;آشنا;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4887,13 +2768,6 @@ msgid_plural "%i hours"
 msgstr[0] "%Ii ساعت"
 msgstr[1] "%Ii ساعت"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%Ii %s %Ii %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4905,187 +2779,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "دقیقه"
 msgstr[1] "دقیقه"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "‫%s تا شارژ کامل"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "هشدار: %s مانده"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s مانده"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "شارژ کامل"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "شارژ نمی‌شود"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "خالی"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "در حال شارژ شدن"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "در حال تخلیه"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "موشی بی‌سیم"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "صفحه‌کلید بی‌سیم"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "منبع تغذیهٔ غیرقابل وقفه‌اندازی"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "دستیار دیجیتال شخصی"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "تلفن‌همراه"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "پخش‌کنندهٔ رسانه"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "رایانک"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "رایانه"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "افزارهٔ ورودی بازی"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "باتری"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "اصلی"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "اضافی"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "باتری‌ها"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "هنگام _بیکاری"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "تعلیق"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "خاموش کردن"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "خواب زمستانی"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "هیچکدام"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "هنگام استفاده از باتری"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "هنگام اتّصال به برق"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "هرگز"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "تعلیق خودکار"
-
-#: panels/power/cc-power-panel.c:1033
-msgid "Performance mode temporarily disabled due to high operating temperature."
-msgstr "حالت کارایی به خاطر دمای عملیاتی بالا، به صورت موقّتی از کار افتاده."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"روی زانو: حالت کارایی به صورت موقّتی موجود نیست. برای بازیابی، افزاره را به سطحی "
-"پایدار جابه‌جا کنید."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "حالت کارایی به صورت موقّتی از کار افتاده."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when battery is "
-"sufficiently charged."
-msgstr ""
-"باتری کم: ذخیره‌ساز نیرو به کار افتاد. حالت پیشین هنگامی که باتری به قدر کافی شارژ "
-"شد، برخواهد گشت."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "حالت ذخیرهٔ نیرو به دست «%s» فعّال شد."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "حالت کارایی به دست «%s» فعّال شد."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5146,6 +2839,15 @@ msgstr "۱۰۰ دقیقه"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "۲ ساعت"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "باتری"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "افزاره‌ها"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5224,33 +2926,6 @@ msgstr "روی نیروی _باتری"
 msgid "Delay"
 msgstr "تأخیر"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "کارایی"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "استفاده از انرژی و کارایی بالا."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "تعادل"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "استفاده از انرژی و کارایی استاندارد."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "ذخیرهٔ انرژی"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "استفاده از انرژی و کارایی کاهش‌یافته."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "نیرو"
@@ -5259,35 +2934,14 @@ msgstr "نیرو"
 msgid "View your battery status and change power saving settings"
 msgstr "وضعیت باتری خود را دیده و تنظیمات ذخیرهٔ انرژی را تغییر دهید"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
 msgstr ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-"Energy;نیرو;انرژی;خواب;تعلیق;باتری;روشنایی;تاریکی;نمایشگر;مانیتور;مونیتور;صفحه;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "چاپگر «%s» حذف شد"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "شکست در افزودن چاپگر جدید."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ناتوان در گشودن واسط کاربری: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "قفل‌گشایی برای افزودن چاپگرها و تغییر تنظیمات"
+"Energy;نیرو;انرژی;خواب;تعلیق;باتری;روشنایی;تاریکی;نمایشگر;مانیتور;مونیتور;"
+"صفحه;"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5297,22 +2951,21 @@ msgstr "چاپگرها"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "افزودن چاپگر، دیدن کارهای چاپگر و تصمیم برای چگونگی چاپ"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Queue;Print;Paper;Ink;Toner;چاپگر;صف;چاپ;کاغذ;جوهر;"
 
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:28 panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "افزودن چاپگر"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
 #: panels/printers/new-printer-dialog.ui:103
-#: panels/printers/new-printer-dialog.ui:118 panels/wwan/cc-wwan-device-page.ui:38
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_قفل‌گشایی"
 
@@ -5335,31 +2988,13 @@ msgid "Enter username and password to view printers on Print Server."
 msgstr "برای دیدن چاپگرهای روی کارساز چاپ، نام‌کاربری و گذرواژه را وارد کنید."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:317 panels/printers/pp-jobs-dialog.ui:42
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
 #: panels/user-accounts/cc-add-user-dialog.ui:343
 #: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "نام کاربری"
-
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76 panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "جزییات %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "هیچ راه‌انداز مناسبی پیدا نشد"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "انتخاب پروندهٔ PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-msgstr "پرونده‌های تفسیری پست‌اسکریپت (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
 
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
@@ -5369,9 +3004,7 @@ msgstr "نام‌های چاپگر نمی‌توانند شامل فاصله، �
 msgid "Location"
 msgstr "موقعیت"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "راه‌انداز"
 
@@ -5399,140 +3032,20 @@ msgstr "انتخاب راه‌انداز چاپگر"
 msgid "Loading drivers database…"
 msgstr "بار کردن پایگاه دادهٔ راه‌اندازها…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "لغو"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "انتخاب"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "چاپگر JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "چاپگر LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "یک طرفه"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "گوشه بلند (استاندارد)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "گوشه کوتاه (معکوس)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "عمودی"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "افقی"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "افقی برعکس"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "عمودی برعکس"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "از سر گیری"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "مکث"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "معلق"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "مکث شده"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "تصدیق هویت شکست خورد"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "در حال پردازش"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "متوقف شده"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "لغو شده"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "بی‌نتیجه‌مانده"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "کامل شده"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "جابه‌جایی این کار به بالای صف"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%Iu کار نیاز به تصدیق هویت دارد"
 msgstr[1] "%Iu کار نیاز به تصدیق هویت دارند"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — کار فعّال"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "برای چاپ از %s مشخّصات را وارد کنید."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5560,319 +3073,17 @@ msgstr "_تصدیق هویت"
 msgid "No Active Printer Jobs"
 msgstr "هیچ کار فعّالی برای چاپگر موجود نیست"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "قفل‌گشایی کارساز چاپ"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "قفل‌گشایی %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "برای مشاهدهٔ چاپگرهای روی %s نام کاربری و گذرواژه را وارد کنید."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "در حال جست‌وجو برای چاپگرها"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "درگاه سریال"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "درگاه موازی"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "موقعیت: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "نشانی: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "کارساز نیاز به تصدیق هویت دارد"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "دو طرفه"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "نوع کاغذ"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "منبع کاغذ"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "سینی خروجی"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "تفکیک‌پذیری"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "پیش‌پالایش GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "صفحه‌ها در هر طرف"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "دو طرفه"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "جهت"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "عمومی"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "تنطیمات صفحه"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "گزینه‌های قابل نصب"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "کارها"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "کیفیت تصویر"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "رنگ"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "در حال پایان"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "پیشرفته"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844 panels/printers/pp-options-dialog.ui:14
+#: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "صفحهٔ آزمایشی"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "صفحهٔ آزمایشی"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "انتخاب خودکار"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "پیش‌گزیده چاپگر"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "تنها توکار قراردادن قلم‌های GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "تبدیل به سطح ۱ PS"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "تبدیل به سطح ۲ PS"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "بدون پیش‌پالایش"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "تولیدکننده"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "بدون کار فعّال"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%Iu کار"
 msgstr[1] "%Iu کار"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "پاک‌سازی سرهای چاپ"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "تونر کم است"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "عدم وجود تونر"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "کمبود در سازنده"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "عدم وجود سازنده"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "کمبود ذخیره محفظه رنگ"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "عدم وجود ذخیره محفظه رنگ"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "گشودن پوشش"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "در را باز کن"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "کمبود کاغذ"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "عدم وجود کاغذ"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "برون‌خط"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743 panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "متوقف شده"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "محفظه مواد زائد تقریبا پُر است"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "محفظه مواد زائد پُر است"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "راهنمایِ نوریِ تصویر، نزدیک به اتمام است"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "راهنمای نوری تصویر، دیگر عملکردی ندارد"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "آماده"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "کاری قبول نمی‌کند"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "در حال پردازش"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5896,7 +3107,12 @@ msgstr "پاک‌سازی سرهای چاپ"
 msgid "Remove Printer"
 msgstr "برداشتن چاپگر"
 
-#: panels/printers/printer-entry.ui:183 panels/wwan/cc-wwan-details-dialog.ui:184
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "بدون کار فعّال"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "مدل"
 
@@ -5915,16 +3131,21 @@ msgid "Restart"
 msgstr "آغاز دوباره"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "افزودن چاپگر…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "افزودن یک چاپگر…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "هیچ چاپگری نیست"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5932,7 +3153,6 @@ msgstr ""
 "متأسّفانه به نظر می‌رسد خدمت چاپ\n"
 "   سامانه در دسترس نیست."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "قالب‌ها"
@@ -5960,16 +3180,6 @@ msgstr "جست‌وجوها می‌توانند برای کشورها یا زب�
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "پیش‌نمایش"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "امپریال"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "متریک"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6001,26 +3211,30 @@ msgstr "خروج…"
 
 #: panels/region/cc-region-panel.ui:45
 msgid ""
-"The language setting is used for interface text and web pages. Formats are used "
-"for numbers, dates, and currencies."
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
 msgstr ""
-"تنظیمات زبان برای متن‌ها و صفحه‌های وب استفاده می‌شود. قالب‌ها برای عددها، تاریخ‌ها و "
-"ارزها استفاده می‌شود."
+"تنظیمات زبان برای متن‌ها و صفحه‌های وب استفاده می‌شود. قالب‌ها برای عددها، "
+"تاریخ‌ها و ارزها استفاده می‌شود."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "حسابتان"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_زبان"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_قالب‌ها"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "صفحهٔ ورود"
 
@@ -6032,99 +3246,9 @@ msgstr "ناحیه و زبان"
 msgid "Select your display language and formats"
 msgstr "گزینش قالب‌ها و زبان نمایشیتان"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "زبان;چیدمان;صفحه‌کلید؛ورودی;Language;Layout;Keyboard;Input;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "بپرس چه باید کرد"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "کاری نکن"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "گشودن پوشه"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "رسانه‌های دیگر"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "یک برنامه‌ برای پخش سی‌دی‌های صوتی انتخاب کن"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "یک برنامه‌ برای پخش دی‌وی‌دی‌های ویدیویی انتخاب کن"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "یک برنامه برای اجرا جهت زمانی که یک پخش‌کننده موسیقی متّصل می‌شود، انتخاب کنید"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "یک برنامه برای اجرا جهت زمانی که یک دوربین متّصل می‌شود، انتخاب کنید"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "یک برنامه‌ برای سی‌دی‌های نرم‌افزار انتخاب کن"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "دی‌وی‌دی صوتی"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "دیسک بلو-ری خالی"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "دیسک سی‌دی خالی"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "دیسک دی‌وی‌دی خالی"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "دیسک دی‌وی‌دی اچ‌دی خالی"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "دیسک ویدیویی بلو-ری خالی"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "کتاب الکترونیکی خوان"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "دیسک ویدیویی دی‌وی‌دی اچ‌دی"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "سی‌دی تصویر"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "سی‌دی ویدئویی برتر"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "سی‌دی ویدیویی"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "نرم‌افزار ویندوزی"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6174,123 +3298,15 @@ msgstr "رسانه‌های جداشدنی"
 msgid "Configure Removable Media settings"
 msgstr "پیکربندی تنظیمات رسانه‌های جداشدنی"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;"
-"media;autorun;"
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;"
-"media;autorun;دستگاه;افزاره;سامانه;سیستم;اطّلاعات;حافظه;پردازشگر;نسخه;پیش‌گزیده;"
-"برنامه;یدکی;ترجیح‌شده;سی‌دی;دی‌وی‌دی;یواس‌بی;صوت;ویدئو;دیسک;قابل حذف;رسانه;اجرا خودکار;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "خاموش شدن صفحه"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "۳۰ ثانیه"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "۱ دقیقه"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "۲ دقیقه"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "۳ دقیقه"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "۵ دقیقه"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "۳۰ دقیقه"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "۱ ساعت"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "۱ دقیقه"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "۲ دقیقه"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "۳ دقیقه"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "۴ دقیقه"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "۵ دقیقه"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "۸ دقیقه"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "۱۰ دقیقه"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "۱۲ دقیقه"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "۱۵ دقیقه"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "هرگز"
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;دستگاه;افزاره;سامانه;سیستم;اطّلاعات;حافظه;پردازشگر;"
+"نسخه;پیش‌گزیده;برنامه;یدکی;ترجیح‌شده;سی‌دی;دی‌وی‌دی;یواس‌بی;صوت;ویدئو;دیسک;قابل "
+"حذف;رسانه;اجرا خودکار;"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6298,9 +3314,10 @@ msgstr "قفل صفحه"
 
 #: panels/screen/cc-screen-panel.ui:9
 msgid ""
-"Automatically locking the screen prevents others from accessing the computer while "
-"you're away."
-msgstr "قفل خودکار صفحه از دسترسی دیگران به رایانه هنگام نبودنتان جلوگیری می‌کند."
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"قفل خودکار صفحه از دسترسی دیگران به رایانه هنگام نبودنتان جلوگیری می‌کند."
 
 #: panels/screen/cc-screen-panel.ui:14
 msgid "Blank Screen Delay"
@@ -6326,41 +3343,44 @@ msgstr "دورهٔ پس از سیاه شدن صفحه که پس از آن صفح
 msgid "Show _Notifications on Lock Screen"
 msgstr "نمایش _آگاهی‌ها روی صفحهٔ قفل"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "آگاهی‌های صفحهٔ _قفل"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "ممنوعیت افزاره‌های _یواس‌بی جدید"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
-"Prevent new USB devices from interacting with the system when the screen is locked."
-msgstr "جلوگیری از افزاره‌های یواس‌بی جدید برای تعامل با سامانه هنگام قفل بودن صفحه."
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"جلوگیری از افزاره‌های یواس‌بی جدید برای تعامل با سامانه هنگام قفل بودن صفحه."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "محرمانگی صفحه"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "محدودیت زاویهٔ دید"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "صفحه‌نمایش"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "تنظیمات صفحه"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "screen;lock;private;privacy;صفحه;نمایش;خصوصی;محرمانگی;حریم شخصی;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "گزینش مکان"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_تأیید"
-
-#: panels/search/cc-search-locations-dialog.ui:8 panels/search/cc-search-panel.ui:22
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "جست‌وجوی مکان‌ها"
 
@@ -6369,7 +3389,8 @@ msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
 msgstr ""
-"شاخه‌هایی که توسّط برنامه‌های سامانه‌ای مانند پرونده‌ها، عکس‌ها و ویدیوها جست‌وجو می‌شوند."
+"شاخه‌هایی که توسّط برنامه‌های سامانه‌ای مانند پرونده‌ها، عکس‌ها و ویدیوها جست‌وجو "
+"می‌شوند."
 
 #: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
@@ -6386,10 +3407,6 @@ msgstr "دیگران"
 #: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "افزودن مکان"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "هیچ برنامه‌ای پیدا نشد"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -6412,98 +3429,19 @@ msgid "Results are displayed according to the list order."
 msgstr "نتیجه‌ها با توجّه به ترتیب سیاهه نمایش داده شده‌اند."
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
-msgid "Control which applications show search results in the Activities Overview"
+msgid ""
+"Control which applications show search results in the Activities Overview"
 msgstr "واپایش برنامه‌های کاربردی‌ای که در نمای کلّی فعّالیت‌ها، نتیجه نشان می‌دهند"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
-"Search;Find;Index;Hide;Privacy;Results;جست‌وجو;پیدا;فهرست;مخفی; حریم خصوصی;محرمانگی;"
-"نتایج;"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "هیچ شبکه‌ای برای هم‌رسانی انتخاب نشده"
+"Search;Find;Index;Hide;Privacy;Results;جست‌وجو;پیدا;فهرست;مخفی; حریم خصوصی;"
+"محرمانگی;نتایج;"
 
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "شبکه‌ها"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "روشن"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "خاموش"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "فعَال"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "فعّال"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "گزینش یک شاخه"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "افزودن"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "به کار انداختن هم‌رسانی رسانه"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your current "
-"network using: %s"
-msgstr ""
-"هم‌رسانی پرونده، می‌گذارد شاخهٔ عمومیتان را با استفاده از این پیوند روی شبکهٔ جاریتان "
-"با دیگران هم‌رسانی کنید: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure Shell "
-"command:\n"
-"%s"
-msgstr ""
-"هنگام به کار افتادن ورود دوردست، کاربران دوردست می‌توانند با استفاده از این فرمان "
-"پوستهٔ امن متّصل شوند:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "به کار انداختن هم‌رسانی رسانهٔ شخصی"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "نام افزاره رونوشت شد"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "نشانی افزاره رونوشت شد"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "نام کاربری رونوشت شد"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "گذرواژه رونوشت شد"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6538,18 +3476,22 @@ msgstr "هم‌رسانی پرونده"
 msgid "_Require Password"
 msgstr "گذرواژه _لازم است"
 
-#: panels/sharing/cc-sharing-panel.ui:195 panels/sharing/cc-sharing-panel.ui:231
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "ورود دوردست"
 
-#: panels/sharing/cc-sharing-panel.ui:251 panels/sharing/cc-sharing-panel.ui:270
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "میزکار دوردست"
 
 #: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Remote desktop allows viewing and controlling your desktop from another computer."
-msgstr "میزکار دوردست می‌گذارد میزکارتان را از رایانه‌ای دیگر دیده و واپایش کنید."
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"میزکار دوردست می‌گذارد میزکارتان را از رایانه‌ای دیگر دیده و واپایش کنید."
 
 #: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
@@ -6568,11 +3510,14 @@ msgid "How to Connect"
 msgstr "چگونگی وصل شدن"
 
 #: panels/sharing/cc-sharing-panel.ui:300
-msgid "Connect to this computer using the device name or remote desktop address."
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
 msgstr "وصل شدن به این رایانه با استفاده از نام افزاره یا نشانی میزکار دوردست."
 
-#: panels/sharing/cc-sharing-panel.ui:318 panels/sharing/cc-sharing-panel.ui:345
-#: panels/sharing/cc-sharing-panel.ui:372 panels/sharing/cc-sharing-panel.ui:390
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
 msgid "Copy"
 msgstr "رونوشت"
 
@@ -6604,7 +3549,8 @@ msgstr "اثر انگشت رمزنگاری"
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
 "identical."
-msgstr "اثرانگشت رمزنگاری می‌تواند در کارخواه‌های وصل شده دیده شود و باید یکتا باشد."
+msgstr ""
+"اثرانگشت رمزنگاری می‌تواند در کارخواه‌های وصل شده دیده شود و باید یکتا باشد."
 
 #: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
@@ -6622,15 +3568,14 @@ msgstr "پوشه‌ها"
 msgid "Control what you want to share with others"
 msgstr "واپایش چیزهایی که می‌خواهید با دیگران هم‌رسانی کنید"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
 "movies;server;renderer;"
 msgstr ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
-"movies;server;renderer;هم‌رسانی;اشتراک;میزبان;نام;دور;میزکار;ریانه;صدا;آهنگ;ویدیو;"
-"فیلم;عکس;تصویر;کارساز;سرور;"
+"movies;server;renderer;هم‌رسانی;اشتراک;میزبان;نام;دور;میزکار;ریانه;صدا;آهنگ;"
+"ویدیو;فیلم;عکس;تصویر;کارساز;سرور;"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
@@ -6639,10 +3584,6 @@ msgstr "به یا از کار انداختن ورود دوردست"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "برای به یا از کار انداختن ورود دوردست، تأیید هویت لازم است"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "سفارشی"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6675,11 +3616,6 @@ msgstr "عقب"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "جلو"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "آزمودن %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6733,11 +3669,6 @@ msgstr "حجم صدا"
 msgid "Alert Sound"
 msgstr "صدای هشدار"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "۱۰۰٪"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "بی‌صدا"
@@ -6750,82 +3681,12 @@ msgstr "صدا"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "تغییر بلندی صدا، ورودی‌ها، خروجی‌ها و رویدادهای صوتی"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
-"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;کارت;"
-"میکروفون;بلندی صدا;محو شدن;بالانس;بلوتوث;گوشی;صوت;صدا;ورودی;خروجی;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "قطع شده"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "در حال وصل شدن"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "متّصل"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "شکست در تصدیق هویت"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "در حال تأیید"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "عملکرد کاسته‌شده"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "وصل و تصدیق هویت شده"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "ناشناخته"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "تأیید شده در:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "وصل شده در:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "ثبت شده در:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "شکست در تصدیق افزاره: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "شکست در فراموشی افزاره: "
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+"کارت;میکروفون;بلندی صدا;محو شدن;بالانس;بلوتوث;گوشی;صوت;صدا;ورودی;خروجی;"
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6859,52 +3720,6 @@ msgstr "تصدیق و اتّصال"
 msgid "Forget Device"
 msgstr "فراموشی افزاره"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "خطا"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "تصدیق هویت شده"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr "زیرسامانهٔ تاندربولت (boltd) نصب یا به درستی پیکربندی نشده است."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425 panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"به افزاره‌هایی نظیر داک‌ها و شتاب‌دهنده‌های گرافیکی خارجی، اجازهٔ دسترسی مستقیم می‌دهد."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "فقط افزاره‌های یواس‌بی و دیسپلی‌پورت می‌توانند وصل شوند."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the BIOS or "
-"is set to an unsupported security level in the BIOS."
-msgstr ""
-"تاندربولت تشخیص داده نشد.\n"
-"یا سامانه فاقد پشتیبانی تاندربولت است، یا در بایوس از کار افتاده یا روی سطح امنیتی "
-"پشتیبانی نشده‌ای تنظیم شده."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "پشتیبانی تاندربولت در بایوس از کار افتاده است."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "نمی‌توان سطح امنیتی تاندربولت را تعیین کرد."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "خطا در تعویض حالت مستقیم: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "بدون پشتیبانی تاندربولت"
@@ -6916,6 +3731,12 @@ msgstr "نتوانست به زیرسامانهٔ تاندربولت وصل شو�
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "دسترسی مستقیم"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"به افزاره‌هایی نظیر داک‌ها و شتاب‌دهنده‌های گرافیکی خارجی، اجازهٔ دسترسی مستقیم "
+"می‌دهد."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -6933,7 +3754,6 @@ msgstr "تاندربولت"
 msgid "Manage Thunderbolt devices"
 msgstr "مدیریت افزاره‌های تاندربولت"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;Privacy;تاندربولت;محرمانگی;حریم شخصی;حریم خصوصی;"
@@ -6960,8 +3780,10 @@ msgid "Cursor Size"
 msgstr "اندازهٔ نشانگر"
 
 #: panels/universal-access/cc-cursor-size-dialog.ui:22
-msgid "Cursor size can be combined with zoom to make it easier to see the cursor."
-msgstr "اندازهٔ نشانگر می‌تواند با بزرگنمایی ترکیب شده تا دیدن نشانگر را راحت‌تر کند."
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"اندازهٔ نشانگر می‌تواند با بزرگنمایی ترکیب شده تا دیدن نشانگر را راحت‌تر کند."
 
 #: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
@@ -7132,40 +3954,6 @@ msgstr "_‌به کار اندازی با صفحه‌کلید"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "روشن و خاموش کردن امکانات دسترسی‌پذیری از طریق صفحه‌کلید"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "پیش‌گزیده"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "متوسّط"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "بزرگ"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "بزرگ‌تر"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "بزرگ‌ترین"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%Id نقطه"
-msgstr[1] "%Id نقطه"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "نمایش _همیشگی فهرست دسترسی‌پذیری"
@@ -7279,31 +4067,6 @@ msgstr "درخشش لحظه‌ای تمام _صفحه"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "درخشش لحظه‌ای تمام _پنجره"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "کوتاه"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ صفحه‌نمایش"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ صفحه‌نمایش"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ صفحه‌نمایش"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "بلند"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7460,128 +4223,20 @@ msgstr "جلوه‌های رنگی"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "ساده‌تر کردن دیدن، شنیدن، نوشتن، نشانه‌روی و کلیک"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;Zoom;"
-"Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
-"Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
-"animations;"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;Zoom;"
-"Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
-"Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
-"animations;صفحه‌کلید;موشی;دسترسی‌پذیری;سایه روشن;نشانگر;صدا;بزرگ‌نمایی;صفحه‌نمایش خوان;"
-"متن;قلم;اندازه;کلیدهای چسبان;کلیدهای آرام;کلیدهای پرشی;کلیدهای موشی;چشمک;سرعت;"
-"بینایی;شنوایی;صدا;تایپ;نوشتن;پویانمای‌ها;انیمیشن‌ها;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "۱ ساعت"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "۱ روز"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "۲ روز"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "۳ روز"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "۴ روز"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "۵ روز"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "۶ روز"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "۷ روز"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "۱۴ روز"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "۳۰ روز"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "تمام موارد از زباله‌دان تخلیه شوند؟"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "تمام موارد موجود در زباله‌دان برای همیشه پاک می‌شوند."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_خالی کردن زباله‌دان"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "حذف تمام پرونده‌های موقت؟"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "تمام پرونده‌های موقت برای همیشه حذف خواهند شد."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_پاکسازی پرونده‌های موقت"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "۱ روز"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "۷ روز"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "۳۰ روز"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "برای همیشه"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;صفحه‌کلید;موشی;دسترسی‌پذیری;سایه روشن;نشانگر;صدا;"
+"بزرگ‌نمایی;صفحه‌نمایش خوان;متن;قلم;اندازه;کلیدهای چسبان;کلیدهای آرام;کلیدهای "
+"پرشی;کلیدهای موشی;چشمک;سرعت;بینایی;شنوایی;صدا;تایپ;نوشتن;پویانمای‌ها;"
+"انیمیشن‌ها;"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7590,12 +4245,12 @@ msgstr "تاریخچهٔ پرونده"
 #: panels/usage/cc-usage-panel.ui:10
 msgid ""
 "File history keeps a record of files that you have used. This information is "
-"shared between applications, and makes it easier to find files that you might want "
-"to use."
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"تاریخچهٔ پرونده، گزارشی از پرونده‌هایی که استفاده کرده‌اید نگه می‌دارد. این اطّلاعات "
-"بین برنامه‌ها هم‌رسانی شده و یافتن پرونده‌هایی که ممکن است بخواهید استفاده کنید را "
-"آسان‌تر می‌کند."
+"تاریخچهٔ پرونده، گزارشی از پرونده‌هایی که استفاده کرده‌اید نگه می‌دارد. این "
+"اطّلاعات بین برنامه‌ها هم‌رسانی شده و یافتن پرونده‌هایی که ممکن است بخواهید "
+"استفاده کنید را آسان‌تر می‌کند."
 
 #: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
@@ -7615,8 +4270,8 @@ msgstr "پرونده‌های موقّتی و زباله‌دان"
 
 #: panels/usage/cc-usage-panel.ui:64
 msgid ""
-"Trash and temporary files can sometimes include personal or sensitive information. "
-"Automatically deleting them can help to protect privacy."
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
 msgstr ""
 "پرونده‌های موقّت و زباله‌دان گاهی می‌توانند شامل داده‌های حسّاس یا شخصی باشند. حذف "
 "خودکارشان می‌تواند به حفاظت از محرمانگی کمک کند."
@@ -7649,63 +4304,13 @@ msgstr "تاریخچهٔ پرونده و زباله‌دان"
 msgid "Don't leave traces"
 msgstr "برجا نگذاشتن اثر"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
-"استفاده;مصرف;اخیر;تاریخچه;پرونده‌ها;موقتی;خصوصی;محرمانگی;حریم شخصی;زباله‌دان;آشغال;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "باید با آدرس اینترنتی فراهم‌کننده‌ٔ حساب شما یکسان باشد."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "افزودن حساب شکست خورد"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "گذرواژه‌ها برابر نیستند."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "ثبت حساب شکست خورد"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "هیچ راه پیشتیبانی شده‌ای برای تصدیق‌هویت با این دامنه وجود ندارد"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "پیوستن به دامنه شکست خورد"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"نام ورود کار نکرد.\n"
-"لطفاً دوباره تلاش کنید."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"گذواژهٔ ورود کار نکرد.\n"
-"لطفاً دوباره تلاش کنید."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "ورود به دامنه شکست خورد"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "ناتوان در یافتن دامنه. شاید اشتباه نوشته‌اید؟"
+"استفاده;مصرف;اخیر;تاریخچه;پرونده‌ها;موقتی;خصوصی;محرمانگی;حریم شخصی;زباله‌دان;"
+"آشغال;"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7718,11 +4323,11 @@ msgstr "مدیر"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:132
 msgid ""
-"Administrators can add and remove other users, and can change settings for all "
-"users. Parental controls cannot be applied to administrators."
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"مدیران می‌توانند دیگر کاربران را افزوده، برداشته و تنظیمات همهٔ کاربران را تغییر "
-"دهند. واپایش‌های والدین نمی‌توانند به مدیران اعمال شوند."
+"مدیران می‌توانند دیگر کاربران را افزوده، برداشته و تنظیمات همهٔ کاربران را "
+"تغییر دهند. واپایش‌های والدین نمی‌توانند به مدیران اعمال شوند."
 
 #: panels/user-accounts/cc-add-user-dialog.ui:149
 msgid "User sets password on first login"
@@ -7750,16 +4355,12 @@ msgstr "شما برون‌خط هستید"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
-"Enterprise login allows an existing centrally managed user account to be used on "
-"this device. You can also use this account to access company resources on the "
-"internet."
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
 "ورود تجاری می‌گذارد حساب کاربری مدیریت شدهٔ متمرکزی در این افزاره استفاده شود. "
 "همچنین از این حساب می‌توان برای دسترسی به منابع شرکت در اینترنت استفاده کرد."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "مرور برای عکس‌های بیشتر"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7815,10 +4416,11 @@ msgstr "ورود با اثر انگشت"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
-"Fingerprint login allows you to unlock and log into your computer with your finger"
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
 msgstr ""
-"ورود با اثر انگشت می‌گذارد با اثر انگشتتان، رایانه را قفل‌گشایی کرده و به آن وارد "
-"شوید"
+"ورود با اثر انگشت می‌گذارد با اثر انگشتتان، رایانه را قفل‌گشایی کرده و به آن "
+"وارد شوید"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
@@ -7828,219 +4430,6 @@ msgstr "_حذف اثرانگشت‌ها"
 msgid "Fingerprint Enroll"
 msgstr "ثبت اثر انگشت"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "پیش از انجام این کنش،‌ افزاره باید درخواست شود"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "افزاره به دست فرایندی دیگر درخواست شده است"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "اجازهٔ انجام این کنش را ندارید"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "هیچ اثر انگشتی ثبت نشده"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "شکست در ارتباط با افزاره هنگام ثبت"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "شکست در ارتباط با خوانندهٔ اثر انگشت"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "شکست در ارتباط با خدمت اثر انگشت"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "شکست در فهرست اثر انگشت‌ها: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "شکست در حذف اثر انگشت‌های ذخیره‌شده: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "شصت چپ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "انگشت وسط چپ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "انگشت اشاره _چپ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "انگشت حلقه چپ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "انگشت کوچک چپ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "شصت راست"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "انگشت وسط راست"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "انگشت اشاره _راست"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "انگشت حلقه راست"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "انگشت کوچک راست"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "اثر انگشت نامشخّص"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "تمام"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "افزارهٔ اثر انگشت قطع شد"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "فضای ذخیرهٔ افزارهٔ اثر انگشتتان پر است"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "شکست در ثبت اثر انگشت جدید"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "شکست در آغاز ثبت: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "شکست در ثبت اثر انگشت جدید"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "شکست در توقّف ثبت: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your fingerprint"
-msgstr "برایثبت انگشتتان، چند بار بلندش کرده و روی حسگر بگذارید"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "ثبت _دوبارهٔ این انگشت…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "پویش اثر انگشت جدید"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "شکست در آزاد کردن افزارهٔ اثر انگشت %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "مشکل در خواندن از افزاره"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "شکست در درخواست افزارهٔ اثر انگشت %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "شکست در گرفتن افزارهٔ اثر انگشت: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "این هفته"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "هفتهٔ پیش"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%Oe %B"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%Oe %B، %OY"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%OH:%OM"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s، %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "نشست پایان یافت"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "نشست آغاز شد"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — فعّالیت حساب"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "پیشین"
@@ -8048,18 +4437,6 @@ msgstr "پیشین"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "بعدی"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "لطفاً گذرواژهٔ دیگری انتخاب کنید."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "لطفاً گذرواژهٔ فعلی خود را دوباره وارد کنید."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "گذرواژه قابل تغییر نبود"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8081,6 +4458,10 @@ msgstr "گذرواژهٔ جدید"
 msgid "Confirm Password"
 msgstr "تأیید گذرواژه"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "گذرواژه‌ها برابر نیستند."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "اجازه می‌دهد تا کاربران در زمان ورود بعدی گذرواژه خود را تغییر دهند"
@@ -8088,132 +4469,6 @@ msgstr "اجازه می‌دهد تا کاربران در زمان ورود بع
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "هم‌اکنون یک گذرواژه تنظیم کنید"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "نمی‌توان به‌طور خودکار به این نوع از دامنه پیوست"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "چنین دامنه یا محدوده‌ای پیدا نشد"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "نمی توان به عنوان %s وارد دامنهٔ %s شد"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "گذرواژهٔ نادرست، لطفاً دوباره تلاش کنید"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "نمی‌توان به دامنهٔ %s وصل شد: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "شکست در حذف کاربر"
-
-#: panels/user-accounts/cc-user-panel.c:413 panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "شکست در لغو دسترسی کاربرِ مدیریت شده از راه دور"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "شما نمی‌توانید حساب خودتان را حذف کنید."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "کاربر %s هم‌چنان وارد است"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an inconsistent "
-"state."
-msgstr ""
-"حذف یک کاربر در حالی که وارد بودن ممکن است سامانه را در حالتی متناقض قرار دهد."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "می‌خواهید پرونده‌های «%s» را نگه دارید؟"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files around "
-"when deleting a user account."
-msgstr ""
-"هنگام حذف یک حساب کاربری، نگهداری از شاخه خانه، رایانامه و پرونده‌های موقتش "
-"امکان‌پذیر است."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_حذف پرونده‌ها"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_نگه‌داری پرونده‌ها"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "مطمئنید که می‌خواهید دسترسی حساب مدیریت از راه دور %s را لغو کنید؟"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_حذف"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "حساب از کار افتاد"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "در ورود بعدی تنظیم می‌شود"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "هیچ"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "وارد شده"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "ارتباط با سرویس حساب شکست خورد"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "لطفاً مطمئن شوید که AccountService نصب و به کار افتاده است."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "برای تغییر این تنظیمات باید قفل این تابلو گشوده باشد"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "حذف حساب کاربر انتخاب شده"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"برای حذف حساب کاربر انتخاب شده،\n"
-"ابتدا بر روی شمایل * کلیک کنید"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "قفل‌گشایی برای افزودن کاربران و تغییر تنظیمات"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8240,7 +4495,7 @@ msgstr "ویرایش چهرک"
 msgid "Full name"
 msgstr "نام کامل"
 
-#: panels/user-accounts/cc-user-panel.ui:171 panels/wwan/cc-wwan-apn-dialog.c:295
+#: panels/user-accounts/cc-user-panel.ui:171
 msgid "Edit"
 msgstr "ویرایش"
 
@@ -8263,11 +4518,11 @@ msgstr "_مدیر"
 
 #: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"Administrators can add and remove other users, and can change settings for all "
-"users."
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
-"مدیران می‌توانند دیگر کاربران را افزوده، برداشته و تنظیمات همهٔ کاربران را تغییر "
-"دهند."
+"مدیران می‌توانند دیگر کاربران را افزوده، برداشته و تنظیمات همهٔ کاربران را "
+"تغییر دهند."
 
 #: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
@@ -8302,15 +4557,15 @@ msgstr "برای افزودن حساب کاربری، قفل‌گشایی کنی
 msgid "Add or remove users and change your password"
 msgstr "افزودن یا برداشتنن کاربرها و تعویض گذرواژه‌تان"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen Time;App "
-"Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen Time;App "
-"Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;ورود;نام;اثر انگشت;چهرک;"
-"آواتار;لوگو;نشنان;صورت;گذرواژه;رمز;محدودیت;والدین;زمان;وب;کاره;استفاده;بچه;کودک;"
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;ورود;نام;"
+"اثر انگشت;چهرک;آواتار;لوگو;نشنان;صورت;گذرواژه;رمز;محدودیت;والدین;زمان;وب;"
+"کاره;استفاده;بچه;کودک;"
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
 #: panels/user-accounts/data/join-dialog.ui:30
@@ -8347,170 +4602,6 @@ msgstr "مدیریت حساب‌های کاربر"
 msgid "Authentication is required to change user data"
 msgstr "جهت تغییر اطّلاعات کاربر تصدیق‌هویت لازم است"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "لازم گذرواژهٔ جدید با گذرواژهٔ قبلی تفاوت داشته باشد."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "سعی کنید تعداد بیشتری از اعداد و حروف را عوض کنید."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "سعی کنید گذرواژه را کمی بیشتر تغییر دهید."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "یک گذرواژه بدون استفاده از نام کاربری قوی‌تر خواهد بود."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "سعی کنید از استفاده از نام خود در گذرواژه خودداری کنید."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "سعی کنید از تعدادی از کلمه‌های موجود در گذرواژه خودداری کنید."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "سعی کنید از انتخاب کلمه‌های عمومی خودداری کنید."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "سعی کنید از تغییر چینش کلمه‌های موجود خودداری کنید."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "سعی کنید تعداد بیشتری عدد استفاده کنید."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "سعی کنید تعداد بیشتری حروف بزرگ استفاده کنید."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "سعی کنید تعداد بیشتری حروف کوچک استفاده کنید."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "سعی کنید از تعداد بیشتری نویسه خاص، مثل نقطه‌گذاری‌ها استفاده کنید."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "سعی کنید از تلفیق تعدادی حرف، عدد و نقطه‌گذاری استفاده کنید."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "سعی کنید از تکرار یک نویسه خودداری کنید."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up letters, "
-"numbers and punctuation."
-msgstr ""
-"سعی کنید از تکرار یک نوع نویسه خودداری کنید: شما باید تلفیقی از حروف، اعداد و "
-"نقطه‌گذاری‌ها را بکار ببرید."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "سعی کنید از رشته‌های متوالی مثل ۱۲۳۴ یا abcd استفاده نکنید."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and punctuation."
-msgstr "گذرواژه‌ها باید بلندتر باشند. تلاش کنید حروف، اعداد و علائم بیش‌تری بیفزایید."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "حروف بزرگ و کوچک را ادغام کنید و از یک یا چند عدد هم استفاده کنید."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid "Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "افزودن حروف، اعداد و علائم بیش‌تر، گذرواژه را قوی‌تر می‌کند."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "تصدیق شکست خورد"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "گذرواژه خیلی کوتاه است"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "گذرواژه خیلی ساده است"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "گذرواژه‌های قدیمی و جدید خیلی شبیه هم هستند"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "گذرواژهٔ جدید تازگی مورد استفاده قرار گرفته است."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "گذرواژهٔ جدید باید شامل اعداد و نویسه‌های خاص باشد"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "گذرواژه‌های قدیمی و جدید همانند هستند"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "گذرواژه شما از زمانی تأیید هویت شده‌اید، تغییر کرده است!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "گذرواژهٔ جدید به اندازه کافی شامل نویسه‌های متفاوت نیست"
-
-#: panels/user-accounts/run-passwd.c:514 panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "خطای ناشناخته"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, digits "
-"and the following characters: - _"
-msgstr ""
-"نام کاربری تنها باید شامل حرف کوچک در بازهٔ a-z، رقم‌ها و نویسه‌های مقابل باشد: . - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "متأسفیم، نام‌کاربری انتخاب شده در دسترس نیست. لطفاً نامی دیگر را امتحان کنید."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "نام کاربری خیلی بلند است."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8525,8 +4616,9 @@ msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"برای ویرایش یک میان‌بر، کنش «ارسال ضربهٔ کلید» را انتخاب کنید، دکمهٔ کلید میان‌بر را "
-"فشار دهید و کلیدهای جدید را بگیرید یا اینکه کلید پس‌بر را برای پاک‌سازی فشار دهید."
+"برای ویرایش یک میان‌بر، کنش «ارسال ضربهٔ کلید» را انتخاب کنید، دکمهٔ کلید "
+"میان‌بر را فشار دهید و کلیدهای جدید را بگیرید یا اینکه کلید پس‌بر را برای "
+"پاک‌سازی فشار دهید."
 
 #: panels/wacom/button-mapping.ui:66
 msgid "_Close"
@@ -8534,59 +4626,18 @@ msgstr "_بستن"
 
 #: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
-"Please tap the target markers as they appear on screen to calibrate the tablet."
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
 msgstr "به محض ظاهر شدن نشانه‌ها روی نمایشگر، رویشان زده تا رایانک واسنجی شود."
 
 #: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "کلیک اشتباهی شناسایی شد، شروع دوباره…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "دکمهٔ %Id"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "تعریف شده با برنامه"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "ارسال ضربه کلید"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "تعویض نمایشگر"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "نمایش راهنمای روی-صفحه"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "رایانک سوار شده روی تابلوی لپ‌تاپ"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "رایانک سوار شده روی نمایشگر خارجی"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "افزارهٔ رایانک خارجی"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "افزارهٔ صفحهٔ خارجی"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "تمامی نمایشگرها"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8633,7 +4684,8 @@ msgstr "لطفاً رایانک وکومتان را روشن یا وصل کنی�
 msgid "Tip Pressure Feel"
 msgstr "حساسیت فشار ضربه"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:21 panels/wacom/cc-wacom-stylus-page.ui:82
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
 msgid "Soft"
 msgstr "نرم"
 
@@ -8641,7 +4693,8 @@ msgstr "نرم"
 msgid "Stylus tip pressure"
 msgstr "فشار سر قلم"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:41 panels/wacom/cc-wacom-stylus-page.ui:102
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
 msgid "Firm"
 msgstr "سفت"
 
@@ -8680,22 +4733,6 @@ msgstr "کلیک دکمه راست موشی"
 msgid "Forward"
 msgstr "جلو"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "قلم ایربراش با فشار، شیب و لغزندهٔ یکپارچه"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "قلم ایربراش با فشار، شیب و چرخش"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "قلم استاندارد با فشار و شیب"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "قلم استاندارد با فشار"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "رایانک وکوم"
@@ -8704,54 +4741,98 @@ msgstr "رایانک وکوم"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "تنظیم هدایت کلیدها و تنظیم حساسیت قلم برای رایانک‌های گرافیکی"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;رایانک;تبلت;Wa­com;استایلوس;پاک‌کن;موشی;"
+msgstr ""
+"Tablet;Wacom;Stylus;Eraser;Mouse;رایانک;تبلت;Wa­com;استایلوس;پاک‌کن;موشی;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "میان‌بر جدید…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+#, fuzzy
+msgid "Behaviour"
+msgstr "رفتار"
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "کلیک دومین _شبیه‌سازی شده"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "نرم‌افزار ویندوزی"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "تونر کم است"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "وقفه کلیک دوم"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "نرم‌افزار ویندوزی"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "مدیریت ترجیحات برای بهره‌وری و چندوظیفگی"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "نقطه‌های دسترسی"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "افزودن"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "ذخیره"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "ای‌پی‌ان"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "عملیات لغو شد"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>خطا:</b> دسترسی به تغییر تنظیمات رد شد"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>خطا:</b> خطای تجهیزات همراه"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "ثبت نشده"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "ثبت‌شده"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "فراگردی"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "جست‌وجو کردن"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "ردشده"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8781,212 +4862,13 @@ msgstr "شمارهٔ شخصی"
 msgid "Device Details"
 msgstr "جزییات افزاره"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "تولیدکننده"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "نگارش ثابت‌افزار"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "فقط نسل ۲"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "فقط نسل ۳"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "فقط نسل ۴"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "فقط نسل ۵"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "نسل ۲، ۳، ۴ و ۵ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "نسل ۲، ۳، ۴ (ترجیحی) و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "نسل ۲، ۳ (ترجیحی)، ۴ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "نسل ۲ (ترجیحی)، ۳، ۴ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "نسل ۲، ۳، ۴ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "نسل ۲، ۳ و ۴ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "نسل ۲، ۳ (ترجیحی) و ۴"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "نسل ۲ (ترجیحی)، ۳ و ۴"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "نسل ۲، ۳ و ۴"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "نسل ۳، ۴ و ۵ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "نسل ۳، ۴ (ترجیحی) و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "نسل ۳ (ترجیحی)، ۴ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "نسل ۳، ۴ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "نسل ۲، ۴ و ۵ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "نسل ۲، ۴ (ترجیحی) و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "نسل ۲ (ترجیحی)، ۴ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "نسل ۲، ۴ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "نسل ۲، ۳ و ۵ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "نسل ۲، ۳ (ترجیحی) و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "نسل ۲ (ترجیحی)، ۳ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "نسل ۲، ۳ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "نسل ۳ و ۴ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "نسل ۳ (ترجیحی) و ۴"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "نسل ۳ و ۴"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "نسل ۲ و ۴ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "نسل ۲ (ترجیحی) و ۴"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "نسل ۲ و ۴"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "نسل ۲ و ۳ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "نسل ۲ (ترجیحی) و ۳"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "نسل ۲ و ۳"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "نسل ۲ و ۵ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "نسل ۲ (ترجیحی) و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "نسل ۲ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "نسل ۳ و ۵ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "نسل ۳ (ترجیحی) و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "نسل ۳ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "نسل ۴ و ۵ (ترجیحی)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "نسل ۴ (ترجیحی) و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "نسل ۴ و ۵"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "نامعلوم"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "قفل‌گشای سیم‌کارت"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "قفل‌گشایی"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "لطفاً رمز پین برای سیم‌کارت %Id را وارد کنید"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "برای قفل‌گشایی از سیم‌کارتتان، پین را وارد کنید"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "لطفاً رمز پوک برای سیم‌کارت %Id را وارد کنید"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "برای قفل‌گشایی از سیم‌کارتتان، پوک را وارد کنید"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9001,26 +4883,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "%1$u تلاش مانده"
 msgstr[1] "%1$u تلاش مانده"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "گذرواژهٔ اشتباه وارد شد."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "رمز پوک باید عددی ۸ رقمی باشد"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "پین جدید را وارد کنید"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "رمز پین باید عددی ۴ تا ۸ رقمی باشد"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "قفل‌گشایی…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9078,94 +4940,6 @@ msgstr "قفل سیم‌کارت با پین"
 msgid "M_odem Details"
 msgstr "جزییات مو_دم"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "شکست تلفن"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "بدون اتّصال به تلفن"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "عملیات مجاز نیست"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "عملیات پشتیبانی نمی‌شود"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "سیم‌کارت وارد نشده"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "نیازمند پین سیم‌کارت"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "نیازمند پوک سیم‌کارت"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "شکست سیم‌کارت"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "سیم‌کارت اشغال"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "گذرواژهٔ نادرست"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "نیازمند پین۲ سیم‌کارت"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "نیازمند پوک۲ سیم‌کارت"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "پیدا نشد"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "بدون خدمت شبکه"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "اتمام زمان شبکه"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "خدمت جی‌پی‌آراس مجاز نیست"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "فراگردی در این ناحیهٔ مکانی مجاز نیست"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "خطای نامشخّص جی‌پی‌آراس"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "بدون خطا"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "کنش لغو شد"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "دسترسی رد شد"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "خطای ناشناخته"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "گونهٔ شبکه"
@@ -9181,11 +4955,6 @@ msgstr "گزینش شبکه"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "تازه‌سازی فراهم‌کنندگان شبکه"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "سیم‌کارت %Id"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9243,7 +5012,6 @@ msgstr "شبکهٔ همراه"
 msgid "Configure Telephony and mobile data connections"
 msgstr "پیکربندی اتّصال‌های دادهٔ همراه و تلفن"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;wwan;telephony;sim;mobile;موبایل;تلفن;همراه;سیم‌کارت;"
@@ -9260,41 +5028,13 @@ msgstr "تنظیمات، واسط اصلی برای پیکربندی سامان�
 msgid "The GNOME Project"
 msgstr "پروژهٔ گنوم"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "نمایش شمارهٔ نگارش"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "به کار انداختن حالت پرگو"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "جست‌وجو برای رشته"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "نام تابلوهای ممکن را فهرست کن و خارج شو"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "تابلو برای نمایش"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "دسته‌های تنظیمات"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "محرمانگی"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "تابلوهای موجود:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9310,11 +5050,12 @@ msgstr "هشدار: نگارش در حال توسعه"
 
 #: shell/cc-window.ui:153
 msgid ""
-"This version of Settings should only be used for development purposes. You may "
-"experience incorrect system behavior, data loss, and other unexpected issues. "
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
-"این نگارش از تنظیمات باید فقط برای مقاصد توسعه استفاده شود. ممکن است با رفتار "
-"نادرست سامانه، از دست رفتن داده یا دیگر مشکلات غیرمنتظره برخورد کنید. "
+"این نگارش از تنظیمات باید فقط برای مقاصد توسعه استفاده شود. ممکن است با "
+"رفتار نادرست سامانه، از دست رفتن داده یا دیگر مشکلات غیرمنتظره برخورد کنید. "
 
 #: shell/cc-window.ui:164
 msgid "Help"
@@ -9350,7 +5091,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "لغو جست‌وجو"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;Settings;ترجیحات;تنظیمات;"
@@ -9361,18 +5101,19 @@ msgstr "برگشت به تابلوی پیشین"
 
 #: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
-"The identifier for the last Settings panel to be opened. Unrecognised values will "
-"be ignored and the first panel in the list selected."
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
 msgstr ""
-"شناسهٔ آخرین تابلوی تنظیمات برای گشودن. مقادیر ناشناخته درنظر گرفته نشده و نخستین "
-"تابلو در فهرست گزیده خواهد شد."
+"شناسهٔ آخرین تابلوی تنظیمات برای گشودن. مقادیر ناشناخته درنظر گرفته نشده و "
+"نخستین تابلو در فهرست گزیده خواهد شد."
 
 #: shell/org.gnome.Settings.gschema.xml:13
 msgid "Show warning when running a development build of Settings"
 msgstr "نمایش هشدار هنگام اجرای یک ساخت در حال توسعه از تنظیمات"
 
 #: shell/org.gnome.Settings.gschema.xml:14
-msgid "Whether Settings should show a warning when running a development build."
+msgid ""
+"Whether Settings should show a warning when running a development build."
 msgstr "تنظیمات آب‌وهوا باید هنگام اجرای یک ساخت در حال توسعه، هشداری نشان دهد."
 
 #: shell/org.gnome.Settings.gschema.xml:20
@@ -9385,8 +5126,6 @@ msgid ""
 "application window."
 msgstr "یک چندتایی شامل پهنا، درازا و بیشینهٔ وضعیت پنجرهٔ برنامه است."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9394,8 +5133,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%Iu خروجی"
 msgstr[1] "%Iu خروجی"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9403,18 +5140,3118 @@ msgid_plural "%u Inputs"
 msgstr[0] "%Iu ورودی"
 msgstr[1] "%Iu ورودی"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "صداهای سامانه"
+#~ msgid "System Bus"
+#~ msgstr "گذرگاه سامانه"
+
+#~ msgid "Full access"
+#~ msgstr "دسترسی کامل"
+
+#~ msgid "Session Bus"
+#~ msgstr "گذرگاه نشست"
+
+# در این رشته از نویسه LRM استفاده شده است
+#~ msgid "Full access to /dev"
+#~ msgstr "دسترسی کامل به ‎/dev"
+
+#~ msgid "Has network access"
+#~ msgstr "دسترسی شبکه دارد"
+
+#~ msgid "Home"
+#~ msgstr "خانه"
+
+#~ msgid "Read-only"
+#~ msgstr "فقط‌خواندنی"
+
+#~ msgid "File System"
+#~ msgstr "سامانه پرونده"
+
+#~ msgid "Can change settings"
+#~ msgstr "می‌تواند تنظیمات را تغییر دهد"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s این اجازه‌ها را به صورت توکار دارد و نمی‌توان تغییرش داد. در صورتی که "
+#~ "نگران این اجازه‌هایید، حذف این برنامه را در نظر بگیرید."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%Iu گونهٔ پرونده و پیوند که به دست کاره گشوده شده"
+#~ msgstr[1] "%Iu گونهٔ پرونده و پیوند که به دست کاره گشوده شده"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "برای گشودن گونه‌های پرونده و پیوند زیر از <b>%s</b> استفاده شده."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s از فضای دیسک استفاده شده."
+
+#~ msgid "Select a picture"
+#~ msgstr "گزینش یک عکس"
+
+#~ msgid "_Open"
+#~ msgstr "_گشودن"
+
+#~ msgid "multiple sizes"
+#~ msgstr "اندازه‌های چندگانه"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%Id × %Id"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "بدون تصویر پس‌زمینه"
+
+#~ msgid "Current background"
+#~ msgstr "تصویر پس‌زمینه کنونی"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "افزارهٔ واسنجیتان را روی مربع قرار داده و «شروع» را بزنید"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "افزارهٔ واسنجیتان را به موقعیت واسنجی منتقل کرده و «ادامه» را بزنید"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "افزارهٔ واسنجیتان را به موقعیت سطح منتقل کرده و «ادامه» را بزنید"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "در لپ‌تاپ را ببندید"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "یک خطای داخلی رخ داد و امکان بازسازی وجود ندارد."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "ابزارهای مورد نیاز برای واسنجی نصب نشده‌اند."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "نمایه نتوانست ایجاد شود."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "نقطهٔ سفید هدف قابل دسترسی نبود."
+
+#~ msgid "Complete!"
+#~ msgstr "تمام!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "واسنجی شکست خورد!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "می‌توانید افزارهٔ واسنجی را بردارید."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "مزاحم افزارهٔ واسنجی در هنگام کار نشوید"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "صفحه‌نمایش لپ‌تاپ"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "وب‌کم توکار"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "صفحه‌نمایش %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "پویشگر %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "دوربین %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "چاپگر %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "وب‌کم %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "به کار انداختن مدیریت رنگ برای %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "نمایش نمایه‌های رنگی برای %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "واسنجی نشده"
+
+#~ msgid "Default: "
+#~ msgstr "پیش‌گزیده: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "فاصله‌رنگ (Colorspace): "
+
+#~ msgid "Test profile: "
+#~ msgstr "آزمایش نمایه: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "انتخاب پروندهٔ نمایهٔ ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_درون‌ریزی"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "نمایه‌های ICC پشتیبانی شده"
+
+#~ msgid "All files"
+#~ msgstr "همهٔ پرونده‌ها"
+
+#~ msgid "Save Profile"
+#~ msgstr "ذخیرهٔ نمایه"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "ایجاد یک نمایهٔ رنگی برای افزارهٔ گزیده"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "ابزار اندازه‌گیری پیدا نشد. لطفاً بررسی کنید که روشن باشد و بدرستی نصب شده "
+#~ "است."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "ابزار اندازه‌گیری از profiling پشتیبانی نمی‌کند."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "این گونه افزاره در حال حاضر پشتیبانی نمی‌شود."
+
+#~ msgid "Standard Space"
+#~ msgstr "فضای استاندارد"
+
+#~ msgid "Test Profile"
+#~ msgstr "آزمایش نمایه"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "خودکار"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "کیفیت پایین"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "کیفیت متوسّط"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "کیفیت بالا"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "پیش‌گزیده RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "پیش‌گزیده CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "پیش‌گزیده Gray"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "داده‌های واسنجی کارخانه‌ای فراهم شده به دست سازنده"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "اصلاح نمایش تمام‌صفحه با این نمایه ممکن نیست"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "ممکن است این نمایه دیگر دقیق نباشد"
+
+#~ msgid "Other…"
+#~ msgstr "دیگر…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "قفل‌گشایی برای تغییر تنظیمات"
+
+#~ msgid "Today"
+#~ msgstr "امروز"
+
+#~ msgid "Yesterday"
+#~ msgstr "دیروز"
+
+#~ msgid "%b %e"
+#~ msgstr "%Oe %B"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Oe %B، %OY"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%Id ساعت"
+#~ msgstr[1] "%Id ساعت"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%Id دقیقه"
+#~ msgstr[1] "%Id دقیقه"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%Id ثانیه"
+#~ msgstr[1] "%Id ثانیه"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s و %s و %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s و %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s و %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "نقطهٔ داغ"
+
+#~ msgid "24-hour"
+#~ msgstr "۲۴ ساعته"
+
+#~ msgid "AM / PM"
+#~ msgstr "صبح / عصر"
+
+# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%Oe %B %OY، ⁦%Ol:%OM⁩ %p"
+
+# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%Oe %B %OY، ⁦%OH:%OM⁩"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s، %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
+#~ msgid "%l:%M %p"
+#~ msgstr "⁦%Ol∶%OM⁩ %p"
+
+# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
+#~ msgid "%R"
+#~ msgstr "⁦%OH:%OM⁩"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "ارسال گزارش‌های مشکلات فنی، به بهبود %s  کمک می‌کند. گزارش‌ها به صورت ناشناس "
+#~ "ارسال شده و عاری از اطّلاعات شخصیند. %s"
+
+#~ msgid "On"
+#~ msgstr "روشن"
+
+#~ msgid "Off"
+#~ msgstr "خاموش"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "اعمال تغییرات؟"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "نمی‌توان تغییرات را اعمال کرد"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "می‌تواند به دلیلی محدودیت‌های سخت‌افزار باشد."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "افقی"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "عمودی راست"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "عمودی چپ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "افقی (معکوس)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf هرتز"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "راه‌اندازی امن فعّال است"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار "
+#~ "افزاره می‌گیرد. در حال حاضر روشن است و به درستی کار می‌کند."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "راه‌اندازی امن مشکلاتی دارد"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار "
+#~ "افزاره می‌گیرد. در حال حاضر روشن است؛ ولی به خاطر داشتن کلیدی نامعتبر، کار "
+#~ "نخواهد کرد."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "مشکلات راه‌اندازی امن اغلب می‌توانند از تنظیمات ثابت‌افزار UEFIتان (بایوس) "
+#~ "حل شوند و ممکن است سازندهٔ سخت‌افزارتان اطّلاعاتی در مورد چکونگی انجامشان "
+#~ "فراهم کرده باشد."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "برای راهنمایی، با سازندهٔ سخت‌افزار یا فراهم کنندهٔ پشتیبانی ITتان تماس "
+#~ "بگیرید."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "راه‌اندازی امن خاموش شده است"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار "
+#~ "افزاره می‌گیرد. در حال حاضر خاموش است."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "راه‌اندازی امن اغلب می‌تواند از تنظیمات ثابت‌افزار UEFIتان (بایوس) خاموش "
+#~ "شود. برای راهنمایی، با سازندهٔ سخت‌افزار یا فراهم کنندهٔ پشتیبانی ITتان تماس "
+#~ "بگیرید."
+
+#~ msgid "Passed"
+#~ msgstr "قبول شده"
+
+#~ msgid "Failed"
+#~ msgstr "شکست خورده"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "افزاره مطابق سطح %Id از HSI"
+
+#~ msgid "Security Level 0"
+#~ msgstr "سطح امنیتی ۰"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "این افزاره دربرابر مشکلات امنیتی سخت‌افزاری هیچ محافظتی ندارد. این امر "
+#~ "می‌تواند به خاطر مشکل پیکربندی سخت‌افزار یا ثابت‌افزار باشد. پیشنهاد می‌شود "
+#~ "با فراهم‌کنندهٔ پشتیبانی IT تماس بگیرید."
+
+#~ msgid "Security Level 1"
+#~ msgstr "سطح امنیتی ۱"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "این افزاره در برابر مشکلات امنیتی سخت‌افزاری، کمینهٔ محافظت را دارد. این "
+#~ "محافظت، پایین‌ترین سطح امنیت افزاره بوده و در برابر تهدیدهای امنیتی ساده "
+#~ "مقاوم است."
+
+#~ msgid "Security Level 2"
+#~ msgstr "سطح امنیتی ۲"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "این افزاره در برابر مشکلات امنیتی سخت‌افزاری محافظت پایه‌ای دارد. این "
+#~ "محافظت در برابر برخی تهدیدهای امنیتی معمول مقاوم است."
+
+#~ msgid "Security Level 3"
+#~ msgstr "سطح امنیتی ۳"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "این افزاره در برابر مشکلات امنیتی سخت‌افزاری، محافظت گسترده دارد. این "
+#~ "محافظت، بالاترین سطح امنیتی افزاره بوده و در برابر تهدیدهای امنیتی "
+#~ "پیشرفته مقاوم است."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "سطوح امنیتی برای این افزاره موجود نیست."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "برای راهنمایی در بارهٔ به‌روز رسانی‌های امنیتی با سازندهٔ سخت‌افزارتان تماس "
+#~ "بگیرید."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "ممکن است رفع این مشکل در تنظیمات ثابت‌افزار UEFI یا به دست یک پشتیبان فنی "
+#~ "ممکن باشد."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr "ممکن است رفع این مشکل در تنظیمات ثابت‌افزار UEFI ممکن باشد."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "ممکن است یک پشتیبان فنی بتواند این مشکل را رفع کند."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "محافظت در برابر نرم‌افزارهای مخرّب هنگام آغاز به کار افزاره."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "راه‌اندازی امن مشکلاتی دارد"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "برخی محافظت‌ها هنگام آغاز به کار افزاره."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "راه‌اندازی امن خاموش است"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "بدون محافظت هنگام آغاز به کار افزاره."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "ممکن است مشکل ناشی از تغییری در تنظیمات ثابت‌افزار UEFI، تغییری در "
+#~ "پیکربندی سیستم‌عامل یا نرم‌افزاری مخرّب روی این سامانه باشد."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "ممکن است مشکل ناشی از تغییری در تنظیمات ثابت‌افزار UEFI یا نرم‌افزاری مخرّب "
+#~ "روی این سامانه باشد."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "ممکن است مشکل ناشی از تغییری در پیکربندی سیستم‌عامل یا نرم‌افزاری مخرّب روی "
+#~ "این سامانه باشد."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "در معرض تهدیدهای جدّی امنیتی."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "محافظت محدود در برابر تهدیدهای امنیتی ساده."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "محافظت شده در برابر تهدیدهای امنیتی معمول."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "محافظت شده در برابر بازهٔ وسیعی از تهدیدهای امنیتی."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "محافظت همه‌جانبه"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "محافظت نوشتن ثابت‌افزار"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "قفل محافظت نوشتن ثابت‌افزار"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "ناحیهٔ BIOS ثابت‌افزار"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "شرح‌دهندهٔ BIOS ثابت‌افزار"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "بوت‌گارد اینتل"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "راه‌اندازی تأیید شدهٔ بوت‌گارد اینتل"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "بوت‌گارد اینتل محافظت شده با ACM"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "سیاست خطای بوت‌گارد اینتل"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "فیوز بوت‌گارد اینتل"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "کت اینتل به کار افتاده"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "کت اینتل فعّال"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "جلوگیری از دسترسی حالت ناظر اینتل"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "حافظهٔ رمزگذاشته"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "محافظت IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "قرنطینهٔ کرنل لینوکس"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "تأیید کرنل لینوکس"
+
+#~ msgid "Linux Swap"
+#~ msgstr "مبادلهٔ لینوکس"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "تعلیق به رم"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "تعلیق به بی‌کار"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "کلید بن‌سازهٔ UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "راه‌اندازی امن UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "پیکربندی بن‌سازهٔ TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "بازسازی TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "نگارش ۲٫۰ TPM"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "حالت سازندهٔ موتور مدیریت اینتل"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "پایمالی موتور مدیریت اینتل"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "نگارش موتور مدیریت اینتل"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "به‌روز رسانی‌های ثابت‌افزار"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "تصدیق ثابت‌افزار"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "تصدیق به‌روز رسان ثابت‌افزار"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "اشکال‌زدایی بن‌سازه"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "بررسی‌های امنیتی پردازنده"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "محافظت از بازگشت AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "محافظت از بازپخش ثابت‌افزار AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "محافظت از نوشتن ثابت‌افزار AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "بن‌سازهٔ فیوز شده"
+
+#~ msgid "Valid"
+#~ msgstr "معتبر"
+
+#~ msgid "Not Valid"
+#~ msgstr "نامعتبر"
+
+#~ msgid "Not Enabled"
+#~ msgstr "به کار نیفتاده"
+
+#~ msgid "Locked"
+#~ msgstr "قفل شده"
+
+#~ msgid "Not Locked"
+#~ msgstr "قفل نشده"
+
+#~ msgid "Encrypted"
+#~ msgstr "رمز شده"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "رمز نشده"
+
+#~ msgid "Tainted"
+#~ msgstr "آلوده شده"
+
+#~ msgid "Not Tainted"
+#~ msgstr "آلوده نشده"
+
+#~ msgid "Found"
+#~ msgstr "پیدا شده"
+
+#~ msgid "Not Found"
+#~ msgstr "پیدا نشده"
+
+#~ msgid "Supported"
+#~ msgstr "پشتیبانی شده"
+
+#~ msgid "Not Supported"
+#~ msgstr "پشتیبانی نشده"
+
+#~ msgid "Unknown"
+#~ msgstr "ناشناخته"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "۶۴ بیتی"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "۳۲ بیتی"
+
+#~ msgid "X11"
+#~ msgstr "زورگ"
+
+#~ msgid "Wayland"
+#~ msgstr "وی‌لند"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "ناشناخته"
+
+#~ msgid "Not Available"
+#~ msgstr "ناموجود"
+
+#~ msgid "System Logo"
+#~ msgstr "نشان سامانه"
+
+#~ msgid "No input sources found"
+#~ msgstr "هیچ منبع ورودی پیدا نشد"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "موارد دیگر"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "میان‌برهای سفارشی"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "کلید نویسهٔ جایگزین می‌تواند برای ورود نویسه‌های اضافی استفاده شود. گاهی به "
+#~ "عنوان گزینهٔ سوم روی صفحه‌کلیدتان چاپ شده‌اند."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "دگرساز چپ"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "دگرساز راست"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "سوپر چپ"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "سوپر راست"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "کلید فهرست"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "مهار راست"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "دکمهٔ ایجاد، امکان ورود طیف وسیعی از نویسه‌ها را می‌دهد. برای استفاده از آن، "
+#~ "ایجاد و به دنبالش، دنباله‌ای از نویسه‌ها را بفشارید.  برای مثال، کلید ایجاد "
+#~ "به همراه <b>C</b> و <b>o</b>، نویسهٔ <b>©</b> و <b>a</b> به همراه <b>'</"
+#~ "b>، نویسهٔ <b>á</b> را وارد می‌کند."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "قفل تبدیل"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "نماگرفت"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "منابع ورودی می‌توانند با استفاده از میان‌بر صفحه‌کلید %s تعویض شوند.\n"
+#~ "این میان‌بر می‌تواند در تنظیمات میان‌برهای صفحه‌کلید عوض شود."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%Id تغییریافته"
+#~ msgstr[1] "%Id تغییریافته"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "بازنشانی تمام میان‌برها؟"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "ممکن است بازنشانی میان‌برها روی میان‌برهای شخصیتان اثر بگذارد. این کار قابل "
+#~ "بازگشت نیست."
+
+#~ msgid "Reset All"
+#~ msgstr "بازنشانی همه"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "کلید %s از پیش برای %s استفاده می‌شد. اگر جایگزینش کنید، %s از کار خواهد "
+#~ "افتاد"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "میان‌بر جدید را وارد کنید"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "تنظیم میان‌بر سفارشی"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "تنظیم میان‌بر"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "برای تغییر %s میان‌بر جدید را وارد کنید."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "افزودن میان‌بر سفارشی"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "لغزش دو انگشتی"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "پنج کلیک، زمان GEGL است!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "دوبار کلیک، دکمهٔ اصلی"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "تک کلیک، دکمهٔ اصلی"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "دوبار کلیک، دکمهٔ وسط"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "تک کلیک، دکمهٔ وسط"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "دوباره کلیک، دکمهٔ دوم"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "تک کلیک، دکمهٔ دوم"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "باید NetworkManager در حال اجرا باشد."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "شبکهٔ ناامن (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "شبکهٔ امن (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "شبکهٔ امن (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "شبکهٔ امن (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "شبکهٔ امن"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "روشن کردن نقطهٔ داغ، موجب قطع شدن از %s شده و قادر به دسترسی به اینترنت از "
+#~ "طریق وای‌فای نیستید."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "باید کمینهٔ ۸ نویسه را داشته باشد"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "توقّف نقطهٔ داغ و قطع ارتباط همهٔ کاربران؟"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_توقّف نقطهٔ داغ"
+
+#~ msgid "Preserve"
+#~ msgstr "حفظ"
+
+#~ msgid "Permanent"
+#~ msgstr "همیشگی"
+
+#~ msgid "Random"
+#~ msgstr "تصادفی"
+
+#~ msgid "Stable"
+#~ msgstr "پایدار"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "نشانی مک وارد شده در این‌جا به عنوان نشانی سخت‌افزاری برای افزارهٔ شبکه‌ای که "
+#~ "این اتّصال رویش فعّال است استفاده خواهد شد. این ویژگی به نام MAC cloning یا "
+#~ "spoofing شناخته می‌شود. مثال: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "نمایهٔ %Id"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "گشودن بهبودیافته"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "تجاری"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "هیچ"
+
+#~ msgid "Never"
+#~ msgstr "هرگز"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%Id مگابیت/ثانیه (%I1.1f گیگاهرتز)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%Id مگابیت/ثانیه"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "۲.۴ گیگاهرتز / ۵ گیگاهرتز"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "۲.۴ گیگاهرتز"
+
+#~ msgid "5 GHz"
+#~ msgstr "۵ گیگاهرتز"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "هیچ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "ضعیف"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "کافی"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "خوب"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "عالی"
+
+#~ msgid "DNS4"
+#~ msgstr "ساناد۴"
+
+#~ msgid "DNS6"
+#~ msgstr "ساناد۶"
+
+#~ msgid "Forget Connection"
+#~ msgstr "فراموشی اتّصال"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "برداشتن نمایهٔ اتّصال"
+
+#~ msgid "Remove VPN"
+#~ msgstr "برداشتن وی‌پی‌ان"
+
+#~ msgid "Details"
+#~ msgstr "جزییات"
+
+#~ msgid "automatic"
+#~ msgstr "خودکار"
+
+#~ msgid "Identity"
+#~ msgstr "هویت"
+
+#~ msgid "Delete Address"
+#~ msgstr "حذف آدرس"
+
+#~ msgid "Delete Route"
+#~ msgstr "حذف مسیر"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "هیچ"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "کلید ۴۰/۱۲۸ بیتیWEP (Hex یا ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "عبارت‌عبور ۱۲۸ بیتی WEP"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "‫WEP پویا (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "‫WPA و WPA2 شخصی"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA و WPA2 تجاری"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 شخصی"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "نمی‌توان ویرایشگر اتّصال را باز کرد"
+
+#~ msgid "New Profile"
+#~ msgstr "نمایهٔ جدید"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "تنظیم نامعتبر %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "تنظیم نامعتبر %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "درون ریزی از پرونده…"
+
+#~ msgid "Add VPN"
+#~ msgstr "افزودن وی‌پی‌ان"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "نمی‌توان اتّصال وی‌پی‌ان را درون‌ریزی کرد"
+
+# در این رشته از نویسه ایزوله اولین نویسهٔ قوی استفاده شده است
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "پروندهٔ «⁨%s⁩» نمی‌تواند خوانده شود یا حاوی اطّلاعات اتّصال شناخته‌شدهٔ وی‌پی‌ان "
+#~ "نیست\n"
+#~ "\n"
+#~ "خطا: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "گزینش پرونده برای درون‌ریزی"
+
+# در این رشته از نویسه ایزوله اولین نویسهٔ قوی استفاده شده است
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "پرونده‌ای با نام «⁨%s⁩» از پیش وجود دارد."
+
+#~ msgid "_Replace"
+#~ msgstr "_جایگزینی"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "می‌خواهید %s را با اتّصال وی‌پی‌انی که دارید ذخیره‌اش می‌کنید جایگزین کنید؟"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "نمی‌توان اتّصال وی‌پی‌ان را برون‌ریزی کرد"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "اتّصال وی‌پی‌ان «%s» را نمی‌توان به %s صادر کرد.\n"
+#~ "\n"
+#~ "خطا: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "برون‌ریزی اتّصال وی‌پی‌ان"
+
+#~ msgid "never"
+#~ msgstr "هرگز"
+
+#~ msgid "today"
+#~ msgstr "امروز"
+
+#~ msgid "yesterday"
+#~ msgstr "دیروز"
+
+#~ msgid "Last used"
+#~ msgstr "آخرین استفاده"
+
+#~ msgid "Add new connection"
+#~ msgstr "افزودن اتّصال جدید"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "جزییات شبکه‌های گزیده، شامل گذرواژه‌ها و هر پیکربندی سفارشی‌ای از دست خواهند "
+#~ "رفت."
+
+#~ msgid "_Forget"
+#~ msgstr "_فراموشی"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "شبکه‌های وای‌فای آشنا"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_فراموشی"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "سیاست سامانه استفاده از نقطهٔ داغ را منع کرده است"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "افزارهٔ بی‌سیم از حالت نقطهٔ داغ پشتیبانی نمی‌کند"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "کشف خودکار پیشکار وب زمانی که URL فراهم نشده باشد استفاده می‌شود."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "برای شبکه‌های عمومی نامطمئن توصیه نمی‌شود."
+
+#~ msgid "Status unknown"
+#~ msgstr "وضعیت ناشناس"
+
+#~ msgid "Unmanaged"
+#~ msgstr "مدیریت نشده"
+
+#~ msgid "Unavailable"
+#~ msgstr "ناموجود"
+
+#~ msgid "Connecting"
+#~ msgstr "در حال وصل شدن"
+
+#~ msgid "Authentication required"
+#~ msgstr "تصدیق هویت شکست خورد"
+
+#~ msgid "Disconnecting"
+#~ msgstr "در حال قطع شدن"
+
+#~ msgid "Connection failed"
+#~ msgstr "اتّصال شکست خورد"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "وضعیت ناشناس (ناپیدا)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "پیکربندی شکست خورد"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "پیکربندی IP شکست خورد"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "پیکربندی IP منقضی شد"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "رمزها لازم بودند، اما فراهم نشدند"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "درخواست کننده 802.1x قطع شد"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "تنظیمات پیکربندی درخواست کننده 802.1x شکست خورد"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "درخواست کننده 802.1x شکست خورد"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "تصدیق‌هویت دروخواست کننده 802.1x مدت زیادی طول کشید"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "شروع کارساز PPP شکست خورد"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "سرویس PPP قطع شد"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP شکست خورد"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "شکست در شروع کارخواه DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "خطا کارخواه DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "کارخواه DHCP شکست خورد"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "شکست در شروع خدمت اتّصالِ هم‌رسانده"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "سرویس اتّصال هم‌رسانی شده شکست خورد"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "شروع سرویس AutoIP شکست خورد"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "خطا سرویس AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "سرویس AutoIP شکست خورد"
+
+#~ msgid "Line busy"
+#~ msgstr "خطِ مشغول"
+
+#~ msgid "No dial tone"
+#~ msgstr "بوق شماره‌گیری وجود ندارد"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "اتّصال به هیچ فراهم‌کننده‌ای امکان‌پذیر نبود"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "مهلت درخواست شماره‌گیری تمام شد"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "تلاش برای شماره‌گیری شکست خورد"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "مقداردهی اولیه مودم شکست خورد"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "انتخاب APN مشخص شده شکست خورد"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "جست‌وجو نکردن برای شبکه‌ها"
+
+#~ msgid "Network registration denied"
+#~ msgstr "ثبت شبکه رد شد"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "مهلت ثبت شبکه تمام شد"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "ثبت از طریق شبکه درخواست شده شکست خورد"
+
+#~ msgid "PIN check failed"
+#~ msgstr "بررسی پین شکست خورد"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "ممکن است ثابت‌افزار افزاره موجود نباشد"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "اتّصال محو شد"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "اتّصال فعلی استفاده شد"
+
+#~ msgid "Modem not found"
+#~ msgstr "مودم پیدا نشد"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "اتّصال بلوتوث شکست خورد"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "سیم‌کارت وارد نشده است"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "پین سیم‌کارت لازم است"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "پوک سیم‌کارت لازم است"
+
+#~ msgid "SIM wrong"
+#~ msgstr "سیم‌کارت نادرست"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "نیازمندی‌های اتّصال شکست خورد"
+
+#~ msgid "Firmware missing"
+#~ msgstr "ثابت‌افزار موجود نیست"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "کابل قطع شد"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "خطای تعریف نشده در امنیت 802.1x (‫wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "هیچ پرونده‌ای انتخاب نشد"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "خطای نامشخّص در تأیید اعتبار پروندهٔ eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "کلیدهای خصوصی PGP، DER، PEM یا PKCS#12"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "گواهینامه‌های DER یا PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "پرونده EAP-FAST PAC فراهم نشده"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "پرونده‌های PAC شامل ‪(*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "نام‌کاربری EAP-LEAP فراهم نشده"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "گذرواژه EAP-LEAP فراهم نشده"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "گواهینامه EAP-PEAP CA نامعتبر است: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "گواهینامه EAP-PEAP CA نامعتبر است: هیچ گواهینامه‌ای مشخص نشده"
+
+#~ msgid "missing EAP username"
+#~ msgstr "نام‌کاربری EAP فراهم نشده"
+
+#~ msgid "missing EAP password"
+#~ msgstr "گذرواژه EAP وارد نشده"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "شناسه EAP-TLS فراهم نشده"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "گواهینامه EAP-TLS CA نامعتبر است: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "گواهینامه EAP-TLS CA نامعتبر است: هیچ گواهینامه‌ای فراهم نشده"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "کلید خصوصی EAP-TLS نامعتبر است: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "گواهینامه کاربر EAP-TLS نامعتبر است: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "کلیدهای خصوصی رمزنگاری نشده ناامن هستند"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "به‌نظر نمی‌رسد کلید خصوصی انتخاب شده با گذرواژه محافظت شده باشد. این امر "
+#~ "ممکن است موجب به خطر افتادن اطّلاعات حساس شما شود. لطفاً یک کلید خصوصی "
+#~ "محافظت شده با گذرواژه انتخاب کنید.\n"
+#~ "\n"
+#~ "(می‌توانید با openssl روی کلیدتان گذرواژه بگذارید)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "گواهینامهٔ شخصی خود را انتخاب کنید"
+
+#~ msgid "Choose your private key"
+#~ msgstr "کلید خصوصی خود را انتخاب کنید"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "گواهینامهٔ EAP-TTLS CA نامعتبر: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "گواهینامهٔ EAP-TTLS CA نامعتبر: هیچ گواهینامه‌ای فراهم نشده"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "خطای ناشناخته در تأیید اعتبار امنیت 802.1x"
+
+#~ msgid "Select a file"
+#~ msgstr "گزینش یک پرونده"
+
+#~ msgid "missing leap-username"
+#~ msgstr "گزینه leap-username فراهم نشده است"
+
+#~ msgid "missing leap-password"
+#~ msgstr "گذرواژه leap وارد نشده"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "گذرواژهٔ وای‌فای مفقود است."
+
+#~ msgid "missing wep-key"
+#~ msgstr "گزینه wep-key فراهم نشده است"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "گزینه wep-key نامعتبر است: کلیدی با طول %zu تنها باید شامل hex-digit باشد"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "گزینه hex-digits نامعتبر است: کلیدی با طول %zu باید شامل نویسه‌های ascii "
+#~ "باشد"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "گزینه wep-key نامعتبر: طول کلید نامعتبر %zu. یک کلید یا باید طول 5/13 "
+#~ "(ascii) یا 10/26 (hex) داشته باشد."
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "گزینه wep-key نامعتبر: عبارت‌رمز نباید خالی باشد"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "گزینه wep-key نامعتبر: عبارت‌رمز باید کمتر از ۶۴ نویسه باشد"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "گزینه wpa-psk نامعتبر: طول کلید نامعتبر %zu.باید یا [8,63] باید یا ۶۴ رقم "
+#~ "hex باشد"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "گزینه wpa-psk نامعتبر است: نمی‌توان کلید ۶۴ بایتی را به عنوان hex تفسیر کرد"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "موارد دیگر"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s حذف شد"
+
+#~ msgid "Error removing account"
+#~ msgstr "خطای برداشتن حساب"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "حساب %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "برداشتن حساب"
+
+#~ msgid "Unknown time"
+#~ msgstr "زمان نامعلوم"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%Ii %s %Ii %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "‫%s تا شارژ کامل"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "هشدار: %s مانده"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s مانده"
+
+#~ msgid "Fully charged"
+#~ msgstr "شارژ کامل"
+
+#~ msgid "Not charging"
+#~ msgstr "شارژ نمی‌شود"
+
+#~ msgid "Empty"
+#~ msgstr "خالی"
+
+#~ msgid "Charging"
+#~ msgstr "در حال شارژ شدن"
+
+#~ msgid "Discharging"
+#~ msgstr "در حال تخلیه"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "موشی بی‌سیم"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "صفحه‌کلید بی‌سیم"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "منبع تغذیهٔ غیرقابل وقفه‌اندازی"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "دستیار دیجیتال شخصی"
+
+#~ msgid "Cellphone"
+#~ msgstr "تلفن‌همراه"
+
+#~ msgid "Media player"
+#~ msgstr "پخش‌کنندهٔ رسانه"
+
+#~ msgid "Tablet"
+#~ msgstr "رایانک"
+
+#~ msgid "Computer"
+#~ msgstr "رایانه"
+
+#~ msgid "Gaming input device"
+#~ msgstr "افزارهٔ ورودی بازی"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "اصلی"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "اضافی"
+
+#~ msgid "Batteries"
+#~ msgstr "باتری‌ها"
+
+#~ msgid "When _idle"
+#~ msgstr "هنگام _بیکاری"
+
+#~ msgid "Suspend"
+#~ msgstr "تعلیق"
+
+#~ msgid "Power Off"
+#~ msgstr "خاموش کردن"
+
+#~ msgid "Hibernate"
+#~ msgstr "خواب زمستانی"
+
+#~ msgid "Nothing"
+#~ msgstr "هیچکدام"
+
+#~ msgid "When on battery power"
+#~ msgstr "هنگام استفاده از باتری"
+
+#~ msgid "When plugged in"
+#~ msgstr "هنگام اتّصال به برق"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "هرگز"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "تعلیق خودکار"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "حالت کارایی به خاطر دمای عملیاتی بالا، به صورت موقّتی از کار افتاده."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "روی زانو: حالت کارایی به صورت موقّتی موجود نیست. برای بازیابی، افزاره را "
+#~ "به سطحی پایدار جابه‌جا کنید."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "حالت کارایی به صورت موقّتی از کار افتاده."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "باتری کم: ذخیره‌ساز نیرو به کار افتاد. حالت پیشین هنگامی که باتری به قدر "
+#~ "کافی شارژ شد، برخواهد گشت."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "حالت ذخیرهٔ نیرو به دست «%s» فعّال شد."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "حالت کارایی به دست «%s» فعّال شد."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "کارایی"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "استفاده از انرژی و کارایی بالا."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "تعادل"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "استفاده از انرژی و کارایی استاندارد."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "ذخیرهٔ انرژی"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "استفاده از انرژی و کارایی کاهش‌یافته."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "چاپگر «%s» حذف شد"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "شکست در افزودن چاپگر جدید."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ناتوان در گشودن واسط کاربری: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "قفل‌گشایی برای افزودن چاپگرها و تغییر تنظیمات"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "جزییات %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "هیچ راه‌انداز مناسبی پیدا نشد"
+
+#~ msgid "Select PPD File"
+#~ msgstr "انتخاب پروندهٔ PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "پرونده‌های تفسیری پست‌اسکریپت (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "چاپگر JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "چاپگر LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "یک طرفه"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "گوشه بلند (استاندارد)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "گوشه کوتاه (معکوس)"
+
+#~ msgid "Portrait"
+#~ msgstr "عمودی"
+
+#~ msgid "Landscape"
+#~ msgstr "افقی"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "افقی برعکس"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "عمودی برعکس"
+
+#~ msgid "Resume"
+#~ msgstr "از سر گیری"
+
+#~ msgid "Pause"
+#~ msgstr "مکث"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "معلق"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "مکث شده"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "تصدیق هویت شکست خورد"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "در حال پردازش"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "متوقف شده"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "لغو شده"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "بی‌نتیجه‌مانده"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "کامل شده"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "جابه‌جایی این کار به بالای صف"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — کار فعّال"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "برای چاپ از %s مشخّصات را وارد کنید."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "قفل‌گشایی کارساز چاپ"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "قفل‌گشایی %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "برای مشاهدهٔ چاپگرهای روی %s نام کاربری و گذرواژه را وارد کنید."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "در حال جست‌وجو برای چاپگرها"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "درگاه سریال"
+
+#~ msgid "Parallel Port"
+#~ msgstr "درگاه موازی"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "موقعیت: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "نشانی: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "کارساز نیاز به تصدیق هویت دارد"
+
+#~ msgid "Two Sided"
+#~ msgstr "دو طرفه"
+
+#~ msgid "Paper Type"
+#~ msgstr "نوع کاغذ"
+
+#~ msgid "Paper Source"
+#~ msgstr "منبع کاغذ"
+
+#~ msgid "Output Tray"
+#~ msgstr "سینی خروجی"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "تفکیک‌پذیری"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "پیش‌پالایش GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "صفحه‌ها در هر طرف"
+
+#~ msgid "Orientation"
+#~ msgstr "جهت"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "عمومی"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "تنطیمات صفحه"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "گزینه‌های قابل نصب"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "کارها"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "کیفیت تصویر"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "رنگ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "در حال پایان"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "پیشرفته"
+
+#~ msgid "Test page"
+#~ msgstr "صفحهٔ آزمایشی"
+
+#~ msgid "Auto Select"
+#~ msgstr "انتخاب خودکار"
+
+#~ msgid "Printer Default"
+#~ msgstr "پیش‌گزیده چاپگر"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "تنها توکار قراردادن قلم‌های GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "تبدیل به سطح ۱ PS"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "تبدیل به سطح ۲ PS"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "بدون پیش‌پالایش"
+
+#~ msgid "Clean print heads"
+#~ msgstr "پاک‌سازی سرهای چاپ"
+
+#~ msgid "Out of toner"
+#~ msgstr "عدم وجود تونر"
+
+#~ msgid "Low on developer"
+#~ msgstr "کمبود در سازنده"
+
+#~ msgid "Out of developer"
+#~ msgstr "عدم وجود سازنده"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "کمبود ذخیره محفظه رنگ"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "عدم وجود ذخیره محفظه رنگ"
+
+#~ msgid "Open cover"
+#~ msgstr "گشودن پوشش"
+
+#~ msgid "Open door"
+#~ msgstr "در را باز کن"
+
+#~ msgid "Low on paper"
+#~ msgstr "کمبود کاغذ"
+
+#~ msgid "Out of paper"
+#~ msgstr "عدم وجود کاغذ"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "برون‌خط"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "متوقف شده"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "محفظه مواد زائد تقریبا پُر است"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "محفظه مواد زائد پُر است"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "راهنمایِ نوریِ تصویر، نزدیک به اتمام است"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "راهنمای نوری تصویر، دیگر عملکردی ندارد"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "آماده"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "کاری قبول نمی‌کند"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "در حال پردازش"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "امپریال"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "متریک"
+
+#~ msgid "Ask what to do"
+#~ msgstr "بپرس چه باید کرد"
+
+#~ msgid "Do nothing"
+#~ msgstr "کاری نکن"
+
+#~ msgid "Open folder"
+#~ msgstr "گشودن پوشه"
+
+#~ msgid "Other Media"
+#~ msgstr "رسانه‌های دیگر"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "یک برنامه‌ برای پخش سی‌دی‌های صوتی انتخاب کن"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "یک برنامه‌ برای پخش دی‌وی‌دی‌های ویدیویی انتخاب کن"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "یک برنامه برای اجرا جهت زمانی که یک پخش‌کننده موسیقی متّصل می‌شود، انتخاب "
+#~ "کنید"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "یک برنامه برای اجرا جهت زمانی که یک دوربین متّصل می‌شود، انتخاب کنید"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "یک برنامه‌ برای سی‌دی‌های نرم‌افزار انتخاب کن"
+
+#~ msgid "audio DVD"
+#~ msgstr "دی‌وی‌دی صوتی"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "دیسک بلو-ری خالی"
+
+#~ msgid "blank CD disc"
+#~ msgstr "دیسک سی‌دی خالی"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "دیسک دی‌وی‌دی خالی"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "دیسک دی‌وی‌دی اچ‌دی خالی"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "دیسک ویدیویی بلو-ری خالی"
+
+#~ msgid "e-book reader"
+#~ msgstr "کتاب الکترونیکی خوان"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "دیسک ویدیویی دی‌وی‌دی اچ‌دی"
+
+#~ msgid "Picture CD"
+#~ msgstr "سی‌دی تصویر"
+
+#~ msgid "Super Video CD"
+#~ msgstr "سی‌دی ویدئویی برتر"
+
+#~ msgid "Video CD"
+#~ msgstr "سی‌دی ویدیویی"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "خاموش شدن صفحه"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "۳۰ ثانیه"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "۱ دقیقه"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "۲ دقیقه"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "۳ دقیقه"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "۵ دقیقه"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "۳۰ دقیقه"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "۱ ساعت"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "۱ دقیقه"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "۲ دقیقه"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "۳ دقیقه"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "۴ دقیقه"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "۵ دقیقه"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "۸ دقیقه"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "۱۰ دقیقه"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "۱۲ دقیقه"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "۱۵ دقیقه"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "هرگز"
+
+#~ msgid "Select Location"
+#~ msgstr "گزینش مکان"
+
+#~ msgid "_OK"
+#~ msgstr "_تأیید"
+
+#~ msgid "No applications found"
+#~ msgstr "هیچ برنامه‌ای پیدا نشد"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "هیچ شبکه‌ای برای هم‌رسانی انتخاب نشده"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "روشن"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "خاموش"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "فعَال"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "فعّال"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "گزینش یک شاخه"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "به کار انداختن هم‌رسانی رسانه"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "هم‌رسانی پرونده، می‌گذارد شاخهٔ عمومیتان را با استفاده از این پیوند روی شبکهٔ "
+#~ "جاریتان با دیگران هم‌رسانی کنید: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "هنگام به کار افتادن ورود دوردست، کاربران دوردست می‌توانند با استفاده از "
+#~ "این فرمان پوستهٔ امن متّصل شوند:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "به کار انداختن هم‌رسانی رسانهٔ شخصی"
+
+#~ msgid "Device name copied"
+#~ msgstr "نام افزاره رونوشت شد"
+
+#~ msgid "Device address copied"
+#~ msgstr "نشانی افزاره رونوشت شد"
+
+#~ msgid "Username copied"
+#~ msgstr "نام کاربری رونوشت شد"
+
+#~ msgid "Password copied"
+#~ msgstr "گذرواژه رونوشت شد"
+
+#~ msgid "Custom"
+#~ msgstr "سفارشی"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "آزمودن %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "۱۰۰٪"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "قطع شده"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "در حال وصل شدن"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "متّصل"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "شکست در تصدیق هویت"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "در حال تأیید"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "عملکرد کاسته‌شده"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "وصل و تصدیق هویت شده"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "ناشناخته"
+
+#~ msgid "Authorized at:"
+#~ msgstr "تأیید شده در:"
+
+#~ msgid "Connected at:"
+#~ msgstr "وصل شده در:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "ثبت شده در:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "شکست در تصدیق افزاره: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "شکست در فراموشی افزاره: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "خطا"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "تصدیق هویت شده"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr "زیرسامانهٔ تاندربولت (boltd) نصب یا به درستی پیکربندی نشده است."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "فقط افزاره‌های یواس‌بی و دیسپلی‌پورت می‌توانند وصل شوند."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "تاندربولت تشخیص داده نشد.\n"
+#~ "یا سامانه فاقد پشتیبانی تاندربولت است، یا در بایوس از کار افتاده یا روی "
+#~ "سطح امنیتی پشتیبانی نشده‌ای تنظیم شده."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "پشتیبانی تاندربولت در بایوس از کار افتاده است."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "نمی‌توان سطح امنیتی تاندربولت را تعیین کرد."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "خطا در تعویض حالت مستقیم: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "پیش‌گزیده"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "متوسّط"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "بزرگ"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "بزرگ‌تر"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "بزرگ‌ترین"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%Id نقطه"
+#~ msgstr[1] "%Id نقطه"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "کوتاه"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ صفحه‌نمایش"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ صفحه‌نمایش"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ صفحه‌نمایش"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "بلند"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "۱ ساعت"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "۱ روز"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "۲ روز"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "۳ روز"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "۴ روز"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "۵ روز"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "۶ روز"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "۷ روز"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "۱۴ روز"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "۳۰ روز"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "تمام موارد از زباله‌دان تخلیه شوند؟"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "تمام موارد موجود در زباله‌دان برای همیشه پاک می‌شوند."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_خالی کردن زباله‌دان"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "حذف تمام پرونده‌های موقت؟"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "تمام پرونده‌های موقت برای همیشه حذف خواهند شد."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_پاکسازی پرونده‌های موقت"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "۱ روز"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "۷ روز"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "۳۰ روز"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "برای همیشه"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "باید با آدرس اینترنتی فراهم‌کننده‌ٔ حساب شما یکسان باشد."
+
+#~ msgid "Failed to add account"
+#~ msgstr "افزودن حساب شکست خورد"
+
+#~ msgid "Failed to register account"
+#~ msgstr "ثبت حساب شکست خورد"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "هیچ راه پیشتیبانی شده‌ای برای تصدیق‌هویت با این دامنه وجود ندارد"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "پیوستن به دامنه شکست خورد"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "نام ورود کار نکرد.\n"
+#~ "لطفاً دوباره تلاش کنید."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "گذواژهٔ ورود کار نکرد.\n"
+#~ "لطفاً دوباره تلاش کنید."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "ورود به دامنه شکست خورد"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "ناتوان در یافتن دامنه. شاید اشتباه نوشته‌اید؟"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "مرور برای عکس‌های بیشتر"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "پیش از انجام این کنش،‌ افزاره باید درخواست شود"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "افزاره به دست فرایندی دیگر درخواست شده است"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "اجازهٔ انجام این کنش را ندارید"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "هیچ اثر انگشتی ثبت نشده"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "شکست در ارتباط با افزاره هنگام ثبت"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "شکست در ارتباط با خوانندهٔ اثر انگشت"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "شکست در ارتباط با خدمت اثر انگشت"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "شکست در فهرست اثر انگشت‌ها: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "شکست در حذف اثر انگشت‌های ذخیره‌شده: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "شصت چپ"
+
+#~ msgid "Left middle finger"
+#~ msgstr "انگشت وسط چپ"
+
+#~ msgid "_Left index finger"
+#~ msgstr "انگشت اشاره _چپ"
+
+#~ msgid "Left ring finger"
+#~ msgstr "انگشت حلقه چپ"
+
+#~ msgid "Left little finger"
+#~ msgstr "انگشت کوچک چپ"
+
+#~ msgid "Right thumb"
+#~ msgstr "شصت راست"
+
+#~ msgid "Right middle finger"
+#~ msgstr "انگشت وسط راست"
+
+#~ msgid "_Right index finger"
+#~ msgstr "انگشت اشاره _راست"
+
+#~ msgid "Right ring finger"
+#~ msgstr "انگشت حلقه راست"
+
+#~ msgid "Right little finger"
+#~ msgstr "انگشت کوچک راست"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "اثر انگشت نامشخّص"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "تمام"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "افزارهٔ اثر انگشت قطع شد"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "فضای ذخیرهٔ افزارهٔ اثر انگشتتان پر است"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "شکست در ثبت اثر انگشت جدید"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "شکست در آغاز ثبت: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "شکست در ثبت اثر انگشت جدید"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "شکست در توقّف ثبت: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr "برایثبت انگشتتان، چند بار بلندش کرده و روی حسگر بگذارید"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "ثبت _دوبارهٔ این انگشت…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "پویش اثر انگشت جدید"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "شکست در آزاد کردن افزارهٔ اثر انگشت %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "مشکل در خواندن از افزاره"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "شکست در درخواست افزارهٔ اثر انگشت %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "شکست در گرفتن افزارهٔ اثر انگشت: %s"
+
+#~ msgid "This Week"
+#~ msgstr "این هفته"
+
+#~ msgid "Last Week"
+#~ msgstr "هفتهٔ پیش"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%Oe %B"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Oe %B، %OY"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%OH:%OM"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s، %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "نشست پایان یافت"
+
+#~ msgid "Session Started"
+#~ msgstr "نشست آغاز شد"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — فعّالیت حساب"
+
+#~ msgid "Please choose another password."
+#~ msgstr "لطفاً گذرواژهٔ دیگری انتخاب کنید."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "لطفاً گذرواژهٔ فعلی خود را دوباره وارد کنید."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "گذرواژه قابل تغییر نبود"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "نمی‌توان به‌طور خودکار به این نوع از دامنه پیوست"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "چنین دامنه یا محدوده‌ای پیدا نشد"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "نمی توان به عنوان %s وارد دامنهٔ %s شد"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "گذرواژهٔ نادرست، لطفاً دوباره تلاش کنید"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "نمی‌توان به دامنهٔ %s وصل شد: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "شکست در حذف کاربر"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "شکست در لغو دسترسی کاربرِ مدیریت شده از راه دور"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "شما نمی‌توانید حساب خودتان را حذف کنید."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "کاربر %s هم‌چنان وارد است"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "حذف یک کاربر در حالی که وارد بودن ممکن است سامانه را در حالتی متناقض قرار "
+#~ "دهد."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "می‌خواهید پرونده‌های «%s» را نگه دارید؟"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "هنگام حذف یک حساب کاربری، نگهداری از شاخه خانه، رایانامه و پرونده‌های "
+#~ "موقتش امکان‌پذیر است."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_حذف پرونده‌ها"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_نگه‌داری پرونده‌ها"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "مطمئنید که می‌خواهید دسترسی حساب مدیریت از راه دور %s را لغو کنید؟"
+
+#~ msgid "_Delete"
+#~ msgstr "_حذف"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "حساب از کار افتاد"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "در ورود بعدی تنظیم می‌شود"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "هیچ"
+
+#~ msgid "Logged in"
+#~ msgstr "وارد شده"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "ارتباط با سرویس حساب شکست خورد"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "لطفاً مطمئن شوید که AccountService نصب و به کار افتاده است."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "برای تغییر این تنظیمات باید قفل این تابلو گشوده باشد"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "حذف حساب کاربر انتخاب شده"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "برای حذف حساب کاربر انتخاب شده،\n"
+#~ "ابتدا بر روی شمایل * کلیک کنید"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "قفل‌گشایی برای افزودن کاربران و تغییر تنظیمات"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "لازم گذرواژهٔ جدید با گذرواژهٔ قبلی تفاوت داشته باشد."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "سعی کنید تعداد بیشتری از اعداد و حروف را عوض کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "سعی کنید گذرواژه را کمی بیشتر تغییر دهید."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "یک گذرواژه بدون استفاده از نام کاربری قوی‌تر خواهد بود."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "سعی کنید از استفاده از نام خود در گذرواژه خودداری کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "سعی کنید از تعدادی از کلمه‌های موجود در گذرواژه خودداری کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "سعی کنید از انتخاب کلمه‌های عمومی خودداری کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "سعی کنید از تغییر چینش کلمه‌های موجود خودداری کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "سعی کنید تعداد بیشتری عدد استفاده کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "سعی کنید تعداد بیشتری حروف بزرگ استفاده کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "سعی کنید تعداد بیشتری حروف کوچک استفاده کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "سعی کنید از تعداد بیشتری نویسه خاص، مثل نقطه‌گذاری‌ها استفاده کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "سعی کنید از تلفیق تعدادی حرف، عدد و نقطه‌گذاری استفاده کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "سعی کنید از تکرار یک نویسه خودداری کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "سعی کنید از تکرار یک نوع نویسه خودداری کنید: شما باید تلفیقی از حروف، "
+#~ "اعداد و نقطه‌گذاری‌ها را بکار ببرید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "سعی کنید از رشته‌های متوالی مثل ۱۲۳۴ یا abcd استفاده نکنید."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "گذرواژه‌ها باید بلندتر باشند. تلاش کنید حروف، اعداد و علائم بیش‌تری "
+#~ "بیفزایید."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "حروف بزرگ و کوچک را ادغام کنید و از یک یا چند عدد هم استفاده کنید."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "افزودن حروف، اعداد و علائم بیش‌تر، گذرواژه را قوی‌تر می‌کند."
+
+#~ msgid "Authentication failed"
+#~ msgstr "تصدیق شکست خورد"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "گذرواژه خیلی کوتاه است"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "گذرواژه خیلی ساده است"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "گذرواژه‌های قدیمی و جدید خیلی شبیه هم هستند"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "گذرواژهٔ جدید تازگی مورد استفاده قرار گرفته است."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "گذرواژهٔ جدید باید شامل اعداد و نویسه‌های خاص باشد"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "گذرواژه‌های قدیمی و جدید همانند هستند"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "گذرواژه شما از زمانی تأیید هویت شده‌اید، تغییر کرده است!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "گذرواژهٔ جدید به اندازه کافی شامل نویسه‌های متفاوت نیست"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "خطای ناشناخته"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "نام کاربری تنها باید شامل حرف کوچک در بازهٔ a-z، رقم‌ها و نویسه‌های مقابل "
+#~ "باشد: . - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "متأسفیم، نام‌کاربری انتخاب شده در دسترس نیست. لطفاً نامی دیگر را امتحان "
+#~ "کنید."
+
+#~ msgid "The username is too long."
+#~ msgstr "نام کاربری خیلی بلند است."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "دکمهٔ %Id"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "تعریف شده با برنامه"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "ارسال ضربه کلید"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "تعویض نمایشگر"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "نمایش راهنمای روی-صفحه"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "رایانک سوار شده روی تابلوی لپ‌تاپ"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "رایانک سوار شده روی نمایشگر خارجی"
+
+#~ msgid "External tablet device"
+#~ msgstr "افزارهٔ رایانک خارجی"
+
+#~ msgid "All Displays"
+#~ msgstr "تمامی نمایشگرها"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "قلم ایربراش با فشار، شیب و لغزندهٔ یکپارچه"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "قلم ایربراش با فشار، شیب و چرخش"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "قلم استاندارد با فشار و شیب"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "قلم استاندارد با فشار"
+
+#~ msgid "New shortcut…"
+#~ msgstr "میان‌بر جدید…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "عملیات لغو شد"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>خطا:</b> دسترسی به تغییر تنظیمات رد شد"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>خطا:</b> خطای تجهیزات همراه"
+
+#~ msgid "Not Registered"
+#~ msgstr "ثبت نشده"
+
+#~ msgid "Registered"
+#~ msgstr "ثبت‌شده"
+
+#~ msgid "Roaming"
+#~ msgstr "فراگردی"
+
+#~ msgid "Searching"
+#~ msgstr "جست‌وجو کردن"
+
+#~ msgid "Denied"
+#~ msgstr "ردشده"
+
+#~ msgid "2G Only"
+#~ msgstr "فقط نسل ۲"
+
+#~ msgid "3G Only"
+#~ msgstr "فقط نسل ۳"
+
+#~ msgid "4G Only"
+#~ msgstr "فقط نسل ۴"
+
+#~ msgid "5G Only"
+#~ msgstr "فقط نسل ۵"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "نسل ۲، ۳، ۴ و ۵ (ترجیحی)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "نسل ۲، ۳، ۴ (ترجیحی) و ۵"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "نسل ۲، ۳ (ترجیحی)، ۴ و ۵"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "نسل ۲ (ترجیحی)، ۳، ۴ و ۵"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "نسل ۲، ۳، ۴ و ۵"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "نسل ۲، ۳ و ۴ (ترجیحی)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "نسل ۲، ۳ (ترجیحی) و ۴"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "نسل ۲ (ترجیحی)، ۳ و ۴"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "نسل ۲، ۳ و ۴"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "نسل ۳، ۴ و ۵ (ترجیحی)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "نسل ۳، ۴ (ترجیحی) و ۵"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "نسل ۳ (ترجیحی)، ۴ و ۵"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "نسل ۳، ۴ و ۵"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "نسل ۲، ۴ و ۵ (ترجیحی)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "نسل ۲، ۴ (ترجیحی) و ۵"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "نسل ۲ (ترجیحی)، ۴ و ۵"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "نسل ۲، ۴ و ۵"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "نسل ۲، ۳ و ۵ (ترجیحی)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "نسل ۲، ۳ (ترجیحی) و ۵"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "نسل ۲ (ترجیحی)، ۳ و ۵"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "نسل ۲، ۳ و ۵"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "نسل ۳ و ۴ (ترجیحی)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "نسل ۳ (ترجیحی) و ۴"
+
+#~ msgid "3G, 4G"
+#~ msgstr "نسل ۳ و ۴"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "نسل ۲ و ۴ (ترجیحی)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "نسل ۲ (ترجیحی) و ۴"
+
+#~ msgid "2G, 4G"
+#~ msgstr "نسل ۲ و ۴"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "نسل ۲ و ۳ (ترجیحی)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "نسل ۲ (ترجیحی) و ۳"
+
+#~ msgid "2G, 3G"
+#~ msgstr "نسل ۲ و ۳"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "نسل ۲ و ۵ (ترجیحی)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "نسل ۲ (ترجیحی) و ۵"
+
+#~ msgid "2G, 5G"
+#~ msgstr "نسل ۲ و ۵"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "نسل ۳ و ۵ (ترجیحی)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "نسل ۳ (ترجیحی) و ۵"
+
+#~ msgid "3G, 5G"
+#~ msgstr "نسل ۳ و ۵"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "نسل ۴ و ۵ (ترجیحی)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "نسل ۴ (ترجیحی) و ۵"
+
+#~ msgid "4G, 5G"
+#~ msgstr "نسل ۴ و ۵"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "نامعلوم"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "قفل‌گشای سیم‌کارت"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "لطفاً رمز پین برای سیم‌کارت %Id را وارد کنید"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "برای قفل‌گشایی از سیم‌کارتتان، پین را وارد کنید"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "لطفاً رمز پوک برای سیم‌کارت %Id را وارد کنید"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "برای قفل‌گشایی از سیم‌کارتتان، پوک را وارد کنید"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "گذرواژهٔ اشتباه وارد شد."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "رمز پوک باید عددی ۸ رقمی باشد"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "پین جدید را وارد کنید"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "رمز پین باید عددی ۴ تا ۸ رقمی باشد"
+
+#~ msgid "Unlocking…"
+#~ msgstr "قفل‌گشایی…"
+
+#~ msgid "Phone failure"
+#~ msgstr "شکست تلفن"
+
+#~ msgid "No connection to phone"
+#~ msgstr "بدون اتّصال به تلفن"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "عملیات مجاز نیست"
+
+#~ msgid "Operation not supported"
+#~ msgstr "عملیات پشتیبانی نمی‌شود"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "سیم‌کارت وارد نشده"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "نیازمند پین سیم‌کارت"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "نیازمند پوک سیم‌کارت"
+
+#~ msgid "SIM failure"
+#~ msgstr "شکست سیم‌کارت"
+
+#~ msgid "SIM busy"
+#~ msgstr "سیم‌کارت اشغال"
+
+#~ msgid "Incorrect password"
+#~ msgstr "گذرواژهٔ نادرست"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "نیازمند پین۲ سیم‌کارت"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "نیازمند پوک۲ سیم‌کارت"
+
+#~ msgid "Not found"
+#~ msgstr "پیدا نشد"
+
+#~ msgid "No network service"
+#~ msgstr "بدون خدمت شبکه"
+
+#~ msgid "Network timeout"
+#~ msgstr "اتمام زمان شبکه"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "خدمت جی‌پی‌آراس مجاز نیست"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "فراگردی در این ناحیهٔ مکانی مجاز نیست"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "خطای نامشخّص جی‌پی‌آراس"
+
+#~ msgid "No Error"
+#~ msgstr "بدون خطا"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "کنش لغو شد"
+
+#~ msgid "Access denied"
+#~ msgstr "دسترسی رد شد"
+
+#~ msgid "Unknown Error"
+#~ msgstr "خطای ناشناخته"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "سیم‌کارت %Id"
+
+#~ msgid "Display version number"
+#~ msgstr "نمایش شمارهٔ نگارش"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "به کار انداختن حالت پرگو"
+
+#~ msgid "Search for the string"
+#~ msgstr "جست‌وجو برای رشته"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "نام تابلوهای ممکن را فهرست کن و خارج شو"
+
+#~ msgid "Panel to display"
+#~ msgstr "تابلو برای نمایش"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "تابلوهای موجود:"
+
+#~ msgid "System Sounds"
+#~ msgstr "صداهای سامانه"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "خطا: ناتوان در تشخیص سطح HSI."
 
 #~ msgid "Error: unable to determine Incorrect HSI level."
 #~ msgstr "خطا: ناتوان در تشخیص سطح HSI نادرست."
-
-#~ msgid "Add a Printer…"
-#~ msgstr "افزودن یک چاپگر…"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "گواهینامه‌های DER یا PEM شامل ‪(*.der, *.pem, *.crt, *.cer)"
@@ -9430,9 +8267,6 @@ msgstr "صداهای سامانه"
 
 #~ msgid "Take screenshots of application windows and the desktop."
 #~ msgstr "ضبط نماگرفت از میزکار و پنجره‌های برنامه."
-
-#~ msgid "No Protection"
-#~ msgstr "بدون محافظت"
 
 #~ msgid "Minimal Protection"
 #~ msgstr "محافظت کمینه"
@@ -9507,10 +8341,12 @@ msgstr "صداهای سامانه"
 #~ msgstr "قرنطینهٔ کرنل به کار افتاده"
 
 #~ msgid "Pre-boot DMA protection is disabled"
-#~ msgstr "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی از کار افتاده"
+#~ msgstr ""
+#~ "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی از کار افتاده"
 
 #~ msgid "Pre-boot DMA protection is enabled"
-#~ msgstr "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی به کار افتاده"
+#~ msgstr ""
+#~ "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی به کار افتاده"
 
 #~ msgid "Secure Boot disabled"
 #~ msgstr "راه‌اندازی امن از کار افتاده"
@@ -9546,11 +8382,11 @@ msgstr "صداهای سامانه"
 #~ msgstr "تنظیم"
 
 #~ msgid ""
-#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
-#~ "identity;"
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
 #~ msgstr ""
-#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
-#~ "identity;صفحه;قفل;کرش;خصوصی;اخیر;موقت;نمایه;نام;شبکه;هویت;"
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;صفحه;قفل;کرش;خصوصی;اخیر;موقت;نمایه;نام;شبکه;هویت;"
 
 #~ msgid "Bark"
 #~ msgstr "پارس"
@@ -9574,11 +8410,11 @@ msgstr "صداهای سامانه"
 #~ msgstr "تصدیق هویت"
 
 #~ msgid ""
-#~ "Screen sharing allows remote users to view or control your screen by connecting "
-#~ "to %s"
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
 #~ msgstr ""
-#~ "هم‌رسانی صفحه به کاربران دوردست اجازه می‌دهد تا صفحه‌نمایشتان را با وصل شدن به این "
-#~ "پیوند واپایش کنند: %s"
+#~ "هم‌رسانی صفحه به کاربران دوردست اجازه می‌دهد تا صفحه‌نمایشتان را با وصل شدن "
+#~ "به این پیوند واپایش کنند: %s"
 
 #~ msgid "_Screen Sharing"
 #~ msgstr "هم‌رسانی _صفحه"
@@ -9638,10 +8474,11 @@ msgstr "صداهای سامانه"
 #~ msgstr "وی‌پی‌ان %s"
 
 #~ msgid ""
-#~ "Choose the format for numbers, dates and currencies. Changes take effect on "
-#~ "next login."
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
 #~ msgstr ""
-#~ "قالب عددها، تاریخ‌ها و ارزها را برگزینید. تغییرات در ورود بعدی اعمال می‌شوند."
+#~ "قالب عددها، تاریخ‌ها و ارزها را برگزینید. تغییرات در ورود بعدی اعمال "
+#~ "می‌شوند."
 
 #~ msgid "My Account"
 #~ msgstr "حسابم"
@@ -9659,14 +8496,15 @@ msgstr "صداهای سامانه"
 #~ msgstr "آغاز دوباره…"
 
 #~ msgid "Login settings are used by all users when logging into the system"
-#~ msgstr "تنظیمات ورود، به دست تمام کاربران هنگام ورود به سامانه استفاده می‌شود"
+#~ msgstr ""
+#~ "تنظیمات ورود، به دست تمام کاربران هنگام ورود به سامانه استفاده می‌شود"
 
 #~ msgid ""
-#~ "Control which search results are shown in the Activities Overview. The order of "
-#~ "search results can also be changed by moving rows in the list."
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
 #~ msgstr ""
-#~ "واپایش نتایج جست‌وجویی که در نمای کلّی فعّالیت‌ها، نتیجه نشان داده می‌شوند. ترتیب "
-#~ "نتایج جست‌وجو نیز می‌تواند با جابه‌جایی ردیف‌ها در فهرست تغییر کند."
+#~ "واپایش نتایج جست‌وجویی که در نمای کلّی فعّالیت‌ها، نتیجه نشان داده می‌شوند. "
+#~ "ترتیب نتایج جست‌وجو نیز می‌تواند با جابه‌جایی ردیف‌ها در فهرست تغییر کند."
 
 #~ msgid "Standard"
 #~ msgstr "استاندارد"
@@ -9706,7 +8544,8 @@ msgstr "صداهای سامانه"
 #~ msgstr "تأیید هویت و ورود"
 
 #~ msgid "This will be used to name your home folder and can’t be changed."
-#~ msgstr "این نام برای نام‌گذاری پوشه خانگی شما استفاده می‌شود و قابل تغییر نیست."
+#~ msgstr ""
+#~ "این نام برای نام‌گذاری پوشه خانگی شما استفاده می‌شود و قابل تغییر نیست."
 
 #~ msgid "Output:"
 #~ msgstr "خروجی:"
@@ -9725,9 +8564,6 @@ msgstr "صداهای سامانه"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "تبلت (مطلق)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "صفحه‌لمسی (وابسته)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "ترجیحات تبلت"
@@ -9756,7 +8592,8 @@ msgstr "صداهای سامانه"
 #~ msgid "No stylus found"
 #~ msgstr "هیچ استایلوسی پیدا نشد"
 
-#~ msgid "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
 #~ msgstr "لطفاً برای پیکربندی، استایلوستان را به مجاورت تبلت ببرید"
 
 #~ msgid "Top Button"
@@ -9811,11 +8648,11 @@ msgstr "صداهای سامانه"
 #~ msgstr "اجازه‌ها و دسترسی"
 
 #~ msgid ""
-#~ "Data and services that this app has asked for access to and permissions that it "
-#~ "requires."
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
 #~ msgstr ""
-#~ "داده‌ها و خدماتی که این کاره برای دسترسی به آن‌ها درخواست کرده و اجازه‌هایی که "
-#~ "نیاز دارد."
+#~ "داده‌ها و خدماتی که این کاره برای دسترسی به آن‌ها درخواست کرده و اجازه‌هایی "
+#~ "که نیاز دارد."
 
 #~ msgid "Cannot be changed"
 #~ msgstr "قابل تغییر نیست"
@@ -9824,8 +8661,8 @@ msgstr "صداهای سامانه"
 #~ "Individual permissions for applications can be reviewed in the <a "
 #~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "اجازه‌های تکّی برای برنامه‌ها می‌توانند در تنظیمات <a href=\"privacy\">محرمانگی</a> "
-#~ "بازبینی شوند."
+#~ "اجازه‌های تکّی برای برنامه‌ها می‌توانند در تنظیمات <a "
+#~ "href=\"privacy\">محرمانگی</a> بازبینی شوند."
 
 #~ msgid "Integration"
 #~ msgstr "یکپارچگی"
@@ -9858,11 +8695,11 @@ msgstr "صداهای سامانه"
 #~ msgstr "نمایشگر تکی"
 
 #~ msgid ""
-#~ "Drag displays to match your physical display setup. Select a display to change "
-#~ "its settings."
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
 #~ msgstr ""
-#~ "نمایشگرها را برای تطبیق با وضعیت واقعی بکشید. برای تغییر تنظیمات یک نمایشگر، "
-#~ "برگزینیدش."
+#~ "نمایشگرها را برای تطبیق با وضعیت واقعی بکشید. برای تغییر تنظیمات یک "
+#~ "نمایشگر، برگزینیدش."
 
 #~ msgid "Active Display"
 #~ msgstr "نمایشگر فعّال"
@@ -9871,18 +8708,18 @@ msgstr "صداهای سامانه"
 #~ msgstr "اجازه به برنامه‌های زیر برای استفاده از دوربینتان."
 
 #~ msgid ""
-#~ "Location services allow applications to know your location. Using Wi-Fi and "
-#~ "mobile broadband increases accuracy."
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
 #~ msgstr ""
-#~ "خدمات مکان‌یابی می‌گذارند برنامه‌ها مکانتان را بدانند. استفاده از Wi-Fi یا پهن‌باند "
-#~ "همراه، دقّت را افزایش می‌دهد."
+#~ "خدمات مکان‌یابی می‌گذارند برنامه‌ها مکانتان را بدانند. استفاده از Wi-Fi یا "
+#~ "پهن‌باند همراه، دقّت را افزایش می‌دهد."
 
 #~ msgid ""
-#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/"
-#~ "privacy'>Privacy Policy</a>"
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
 #~ msgstr ""
-#~ "از خدمات مکان‌یابی موزیلا استفاده می‌کند: <a href='https://location.services."
-#~ "mozilla.com/privacy'>سیاست محرمانگی</a>"
+#~ "از خدمات مکان‌یابی موزیلا استفاده می‌کند: <a href='https://location."
+#~ "services.mozilla.com/privacy'>سیاست محرمانگی</a>"
 
 #~ msgid "Allow the applications below to determine your location."
 #~ msgstr "اجازه به برنامه‌های زیر برای تشخیص مکانتان."
@@ -9949,8 +8786,8 @@ msgstr "صداهای سامانه"
 
 #~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
 #~ msgstr ""
-#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;نام ورود;نام;اثرانگشت;آواتار;"
-#~ "نشان;تصویرصورت;گذرواژه;"
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;نام ورود;نام;اثرانگشت;"
+#~ "آواتار;نشان;تصویرصورت;گذرواژه;"
 
 #~ msgid "Phone-adaptor link reserved"
 #~ msgstr "پیوند سازوارگر تلفن محفوظ است"
@@ -10045,8 +8882,10 @@ msgstr "صداهای سامانه"
 #~ msgid "Wi-Fi can be turned off to save power."
 #~ msgstr "برای ذخیرهٔ نیرو می‌توان وای‌فای را خاموش کرد."
 
-#~ msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
-#~ msgstr "برای ذخیرهٔ نیرو می‌توان پهن‌باند همراه (3G، 4G، LTE و...) را خاموش کرد."
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "برای ذخیرهٔ نیرو می‌توان پهن‌باند همراه (3G، 4G، LTE و...) را خاموش کرد."
 
 #~ msgid "_Bluetooth"
 #~ msgstr "_بلوتوث"
@@ -10082,36 +8921,37 @@ msgstr "صداهای سامانه"
 
 #~ msgid "Monitor;System;Process;CPU;Memory;Network;History;Usage;"
 #~ msgstr ""
-#~ "Monitor;System;Process;CPU;Memory;Network;History;Usage;نمایشگر;سامانه;پردازش;"
-#~ "حافظه;شبکه;تاریخچه;استفاده;"
+#~ "Monitor;System;Process;CPU;Memory;Network;History;Usage;نمایشگر;سامانه;"
+#~ "پردازش;حافظه;شبکه;تاریخچه;استفاده;"
 
 #~ msgid "View and manage system resources"
 #~ msgstr "نمایش و مدیریت منابع سامانه"
 
 #~ msgid ""
-#~ "System Monitor is a process viewer and system monitor with an attractive, easy-"
-#~ "to-use interface."
+#~ "System Monitor is a process viewer and system monitor with an attractive, "
+#~ "easy-to-use interface."
 #~ msgstr ""
-#~ "پایشگر سامانه، یک نمایشگر فرایندها و یک پایشگر سامانه، با یک واسط کاربری جذاب و "
-#~ "ساده است."
+#~ "پایشگر سامانه، یک نمایشگر فرایندها و یک پایشگر سامانه، با یک واسط کاربری "
+#~ "جذاب و ساده است."
 
 #~ msgid ""
-#~ "System Monitor can help you find out what applications are using the processor "
-#~ "or the memory of your computer, can manage the running applications, force stop "
-#~ "processes not responding, and change the state or priority of existing "
-#~ "processes."
+#~ "System Monitor can help you find out what applications are using the "
+#~ "processor or the memory of your computer, can manage the running "
+#~ "applications, force stop processes not responding, and change the state "
+#~ "or priority of existing processes."
 #~ msgstr ""
-#~ "پایشگر سامانه این امکان را می‌دهد که بفهمید چه برنامه‌هایی در حال استفاده از "
-#~ "پردازشگر یا حافظهٔ رایانه‌تانند، بتوانید برنامه‌های درحال اجرا را مدیریت کرده، "
-#~ "فرایندهای ناپاسخگو را مجبور به توقف کنید و الویت یا وضعیت فرایندهای موجود را "
-#~ "تغییر دهید."
+#~ "پایشگر سامانه این امکان را می‌دهد که بفهمید چه برنامه‌هایی در حال استفاده "
+#~ "از پردازشگر یا حافظهٔ رایانه‌تانند، بتوانید برنامه‌های درحال اجرا را مدیریت "
+#~ "کرده، فرایندهای ناپاسخگو را مجبور به توقف کنید و الویت یا وضعیت فرایندهای "
+#~ "موجود را تغییر دهید."
 
 #~ msgid ""
-#~ "The resource graphs feature shows you a quick overview of what is going on with "
-#~ "your computer displaying recent network, memory and processor usage."
+#~ "The resource graphs feature shows you a quick overview of what is going "
+#~ "on with your computer displaying recent network, memory and processor "
+#~ "usage."
 #~ msgstr ""
-#~ "امکان نمایش نمودار منابع‌، نمایی کلی از آن‌چه روی رایانه‌تان رخ می‌دهد را با نمایش "
-#~ "میزان استفاده از شبکه، حافظه و پردازشگر، به شما می‌دهد."
+#~ "امکان نمایش نمودار منابع‌، نمایی کلی از آن‌چه روی رایانه‌تان رخ می‌دهد را با "
+#~ "نمایش میزان استفاده از شبکه، حافظه و پردازشگر، به شما می‌دهد."
 
 #~ msgid "Process list view"
 #~ msgstr "نمای فهرست پردازش"
@@ -10263,9 +9103,6 @@ msgstr "صداهای سامانه"
 #~ msgid "_Kill"
 #~ msgstr "_کشتن"
 
-#~ msgid "Behavior"
-#~ msgstr "رفتار"
-
 #~ msgid "_Update Interval in Seconds"
 #~ msgstr "دورهٔ به‌روز رسانی به ثانیه"
 
@@ -10324,11 +9161,11 @@ msgstr "صداهای سامانه"
 #~ msgstr "مقدار _نایس:"
 
 #~ msgid ""
-#~ "<small><i><b>Note:</b> The priority of a process is given by its nice value. A "
-#~ "lower nice value corresponds to a higher priority.</i></small>"
+#~ "<small><i><b>Note:</b> The priority of a process is given by its nice "
+#~ "value. A lower nice value corresponds to a higher priority.</i></small>"
 #~ msgstr ""
-#~ "<small><i><b>نکته:</b> اولویت یک فرایند با مقدار نایس آن تعیین می‌شود. هرچه "
-#~ "میزان نایس پایین‌تر باشد، الویت بیشتری دارد.</i></small>"
+#~ "<small><i><b>نکته:</b> اولویت یک فرایند با مقدار نایس آن تعیین می‌شود. "
+#~ "هرچه میزان نایس پایین‌تر باشد، الویت بیشتری دارد.</i></small>"
 
 #~ msgid "A simple process and system monitor."
 #~ msgstr "یک پایشگر‌ سادهٔ فرایند و شبکه."
@@ -10460,7 +9297,8 @@ msgstr "صداهای سامانه"
 #~ msgid "_Files opened by process “%s” (PID %u):"
 #~ msgstr "_پرونده‌های گشوده با فرایند «%s» (شناسه %Iu):"
 
-#~ msgid "Main window size and position in the form (width, height, xpos, ypos)"
+#~ msgid ""
+#~ "Main window size and position in the form (width, height, xpos, ypos)"
 #~ msgstr "اندازه و مکان پنجرهٔ اصلی در شکل (width, height, xpos, ypos)"
 
 #~ msgid "Main Window should open maximized"
@@ -10473,12 +9311,13 @@ msgstr "صداهای سامانه"
 #~ msgstr "حالت سولاریس برای درصد پردازنده"
 
 #~ msgid ""
-#~ "If TRUE, system-monitor operates in “Solaris mode” where a task’s CPU usage is "
-#~ "divided by the total number of CPUs. Otherwise, it operates in “Irix mode”."
+#~ "If TRUE, system-monitor operates in “Solaris mode” where a task’s CPU "
+#~ "usage is divided by the total number of CPUs. Otherwise, it operates in "
+#~ "“Irix mode”."
 #~ msgstr ""
 #~ "اگر درست باشد، پایشگر سامانه در «حالت سولاریس» اجرا می‌شود که در آن مصرف "
-#~ "پردازندهٔ یک تکلیف، بر تعداد کل پردازنده‌ها تقسیم می‌شود. در غیر این‌صورت در «حالت "
-#~ "ایریکس» عمل می‌کند."
+#~ "پردازندهٔ یک تکلیف، بر تعداد کل پردازنده‌ها تقسیم می‌شود. در غیر این‌صورت در "
+#~ "«حالت ایریکس» عمل می‌کند."
 
 #~ msgid "Enable/Disable smooth refresh"
 #~ msgstr "به/از کار انداختن تازه‌سازی نرم"
@@ -10496,12 +9335,13 @@ msgstr "صداهای سامانه"
 #~ msgstr "این که باید اطّلاعات تمام سامانه پرونده‌ها نشان داده شود یا نه"
 
 #~ msgid ""
-#~ "Whether to display information about all file systems (including types like "
-#~ "“autofs” and “procfs”). Useful for getting a list of all currently mounted file "
-#~ "systems."
+#~ "Whether to display information about all file systems (including types "
+#~ "like “autofs” and “procfs”). Useful for getting a list of all currently "
+#~ "mounted file systems."
 #~ msgstr ""
-#~ "این که اطّلاعات تمام سامانه پرونده‌ها (از جمله گونه‌هایی چون autofs و procfs) نشان "
-#~ "داده شود یا نه . مفید برای گرفتن فهرستی از تمام سامانه پرونده‌های سوار‌شدهٔ جاری."
+#~ "این که اطّلاعات تمام سامانه پرونده‌ها (از جمله گونه‌هایی چون autofs و "
+#~ "procfs) نشان داده شود یا نه . مفید برای گرفتن فهرستی از تمام سامانه "
+#~ "پرونده‌های سوار‌شدهٔ جاری."
 
 #~ msgid "Time in milliseconds between updates of the devices list"
 #~ msgstr "زمان بین به‌روزرسانی‌های فهرست افزاره‌ها بر حسب میلی‌ثانیه"
@@ -10534,26 +9374,27 @@ msgstr "صداهای سامانه"
 #~ msgstr "نمایش مجموع شبکه بر حسب بیت"
 
 #~ msgid ""
-#~ "If TRUE, system-monitor shows the CPU chart as a stacked area chart instead of "
-#~ "a line chart."
+#~ "If TRUE, system-monitor shows the CPU chart as a stacked area chart "
+#~ "instead of a line chart."
 #~ msgstr ""
-#~ "اگر درست باشد، پایشگر سامانه نمودار پردازنده را به‌جای نمودار خطی، به شکل نمودار "
-#~ "پشته‌ای نمایش می‌دهد."
+#~ "اگر درست باشد، پایشگر سامانه نمودار پردازنده را به‌جای نمودار خطی، به شکل "
+#~ "نمودار پشته‌ای نمایش می‌دهد."
 
 #~ msgid "Show CPU chart as stacked area chart"
 #~ msgstr "نمایش نمودار پردازنده به شکل پشته‌ای"
 
-#~ msgid "Show CPU, Memory, and Network charts as smooth graphs using Bezier curves"
+#~ msgid ""
+#~ "Show CPU, Memory, and Network charts as smooth graphs using Bezier curves"
 #~ msgstr ""
-#~ "نمایش نمودارهای پردازنده، حافظه و شبکه به شکل نمودار نرم با استفاده از منحنی‌های "
-#~ "بزیه"
+#~ "نمایش نمودارهای پردازنده، حافظه و شبکه به شکل نمودار نرم با استفاده از "
+#~ "منحنی‌های بزیه"
 
 #~ msgid ""
-#~ "If TRUE, system-monitor shows the CPU, Memory, and Network charts as smoothed "
-#~ "graphs, otherwise as line charts."
+#~ "If TRUE, system-monitor shows the CPU, Memory, and Network charts as "
+#~ "smoothed graphs, otherwise as line charts."
 #~ msgstr ""
-#~ "اگر درست باشد، پایشگر سامانه، نمودارهای پردازنده، حافظه و شبکه را به‌جای نمودار "
-#~ "خطی، به شکل نمودار نرم نمایش می‌دهد."
+#~ "اگر درست باشد، پایشگر سامانه، نمودارهای پردازنده، حافظه و شبکه را به‌جای "
+#~ "نمودار خطی، به شکل نمودار نرم نمایش می‌دهد."
 
 #~ msgid "Show memory and swap in IEC"
 #~ msgstr "نمایش حافظه و مبادله در IEC"
@@ -10826,11 +9667,11 @@ msgstr "صداهای سامانه"
 #~ msgstr[1] "مطمئنید می‌خواهید %Id فرایند گزیده را متوقّف کنید؟"
 
 #~ msgid ""
-#~ "Killing a process may destroy data, break the session or introduce a security "
-#~ "risk. Only unresponsive processes should be killed."
+#~ "Killing a process may destroy data, break the session or introduce a "
+#~ "security risk. Only unresponsive processes should be killed."
 #~ msgstr ""
-#~ "کشتن یک فرایند می‌تواند باعث از بین رفتن داده، خرابی نشست، یا ایجاد خطری امنیتی "
-#~ "شود. تنها فرایند‌های ناپاسخگو باید کشته شوند."
+#~ "کشتن یک فرایند می‌تواند باعث از بین رفتن داده، خرابی نشست، یا ایجاد خطری "
+#~ "امنیتی شود. تنها فرایند‌های ناپاسخگو باید کشته شوند."
 
 #~ msgid "_Kill Process"
 #~ msgid_plural "_Kill Processes"
@@ -10838,18 +9679,18 @@ msgstr "صداهای سامانه"
 #~ msgstr[1] "_کشتن فرایندها"
 
 #~ msgid ""
-#~ "Ending a process may destroy data, break the session or introduce a security "
-#~ "risk. Only unresponsive processes should be ended."
+#~ "Ending a process may destroy data, break the session or introduce a "
+#~ "security risk. Only unresponsive processes should be ended."
 #~ msgstr ""
-#~ "پایام یک فرایند می‌تواند باعث از بین رفتن داده، خرابی نشست، یا ایجاد خطری امنیتی "
-#~ "شود. تنها فرایند‌های ناپاسخگو باید پایان یابند."
+#~ "پایام یک فرایند می‌تواند باعث از بین رفتن داده، خرابی نشست، یا ایجاد خطری "
+#~ "امنیتی شود. تنها فرایند‌های ناپاسخگو باید پایان یابند."
 
 #~ msgid ""
-#~ "Stopping a process may destroy data, break the session or introduce a security "
-#~ "risk. Only unresponsive processes should be stopped."
+#~ "Stopping a process may destroy data, break the session or introduce a "
+#~ "security risk. Only unresponsive processes should be stopped."
 #~ msgstr ""
-#~ "نوقّف یک فرایند می‌تواند باعث از بین رفتن داده، خرابی نشست، یا ایجاد خطری امنیتی "
-#~ "شود. تنها فرایند‌های ناپاسخگو باید متوقّف شوند."
+#~ "نوقّف یک فرایند می‌تواند باعث از بین رفتن داده، خرابی نشست، یا ایجاد خطری "
+#~ "امنیتی شود. تنها فرایند‌های ناپاسخگو باید متوقّف شوند."
 
 #~ msgid "Change Priority of Process “%s” (PID: %u)"
 #~ msgstr "تغییر الویت فرایند «%s» (شناسه: %Iu)"
@@ -10866,8 +9707,8 @@ msgstr "صداهای سامانه"
 #~ "The priority of a process is given by its nice value. A lower nice value "
 #~ "corresponds to a higher priority."
 #~ msgstr ""
-#~ "اولویت یک فرایند با مقدار نایس آن تعیین می‌شود. هرچه میزان نایس پایین‌تر باشد، "
-#~ "الویت بیشتری دارد."
+#~ "اولویت یک فرایند با مقدار نایس آن تعیین می‌شود. هرچه میزان نایس پایین‌تر "
+#~ "باشد، الویت بیشتری دارد."
 
 #~ msgid "N/A"
 #~ msgstr "نامعلوم"
@@ -11075,17 +9916,18 @@ msgstr "صداهای سامانه"
 #~ msgstr "مکان Y پنجره اصلی"
 
 #~ msgid ""
-#~ "Determines which processes to show by default. 0 is All, 1 is user, and 2 is "
-#~ "active"
+#~ "Determines which processes to show by default. 0 is All, 1 is user, and 2 "
+#~ "is active"
 #~ msgstr ""
-#~ "مشخص می‌کند که چه فراروند‌هایی به طور پیش‌فرض نشان داده شوند. ۰ برای همه، ۱ برای "
-#~ "کاربر، و ۲ برای فعال"
+#~ "مشخص می‌کند که چه فراروند‌هایی به طور پیش‌فرض نشان داده شوند. ۰ برای همه، ۱ "
+#~ "برای کاربر، و ۲ برای فعال"
 
 #~ msgid ""
-#~ "0 for the System Info, 1 for the processes list, 2 for the resources and 3 for "
-#~ "the disks list"
+#~ "0 for the System Info, 1 for the processes list, 2 for the resources and "
+#~ "3 for the disks list"
 #~ msgstr ""
-#~ "۰ برای اطلاعات سیستم، ۱ برای فهرست فراروند‌ها، ۲ برای منابع و ۳ برای فهرست دیسک‌ها"
+#~ "۰ برای اطلاعات سیستم، ۱ برای فهرست فراروند‌ها، ۲ برای منابع و ۳ برای فهرست "
+#~ "دیسک‌ها"
 
 #~ msgid "Load averages for the last 1, 5, 15 minutes: %0.2f, %0.2f, %0.2f"
 #~ msgstr "میانگین بار کردن در ۱، ۵، ۱۵ دقیقه‌ی گذشته: %I0.2f، %I0.2f، %I0.2f"
@@ -11115,7 +9957,8 @@ msgstr "صداهای سامانه"
 #~ msgstr "در زمان راه اندازی ستون «نشانوند‌ها»ی فراروند نشان داده شود."
 
 #~ msgid "Show process 'estimated memory usage' column on startup"
-#~ msgstr "در زمان راه‌اندازی ستون «حافظه‌ی استفاده‌ شده‌ی تخمینی» فراروند نشان داده شود"
+#~ msgstr ""
+#~ "در زمان راه‌اندازی ستون «حافظه‌ی استفاده‌ شده‌ی تخمینی» فراروند نشان داده شود"
 
 #~ msgid "Width of process 'arguments' column"
 #~ msgstr "عرض ستون «نشان‌وند‌ها»ی فراروند"

--- a/po/fa.po~
+++ b/po/fa.po~
@@ -1,0 +1,11178 @@
+# Persian translation of procman.
+# Copyright (C) 2010, 2011 Iranian Free Software Users Group (IFSUG.org)translation team
+# Copyright (C) 2003 The FarsiWeb Project Group
+# This file is distributed under the same license as the gnome-system-monitor package.
+# Roozbeh Pournader <roozbeh@sharif.edu>, 2003
+# Mahyar Moghimi <mahyar.moqimi@gmail.com>, 2010
+# Arash Mousavi <mousavi.arash@gmail.com>, 2011-2015, 2017.
+# Danial Behzadi <dani.behzi@ubuntu.com>, 2018-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: procman\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issues\n"
+"POT-Creation-Date: 2022-09-12 15:11+0000\n"
+"PO-Revision-Date: 2022-09-14 17:01+0430\n"
+"Last-Translator: Danial Behzadi <dani.behzi@ubuntu.com>\n"
+"Language-Team: Persian\n"
+"Language: fa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.1.1\n"
+"X-DamnedLies-Scope: partial\n"
+"X-Poedit-SourceCharset: utf-8\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "گذرگاه سامانه"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "دسترسی کامل"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "گذرگاه نشست"
+
+#: panels/applications/cc-applications-panel.c:828 panels/power/cc-power-panel.ui:75
+#: panels/thunderbolt/cc-bolt-panel.ui:265 panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "افزاره‌ها"
+
+# در این رشته از نویسه LRM استفاده شده است
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "دسترسی کامل به ‎/dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "شبکه"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "دسترسی شبکه دارد"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "خانه"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "فقط‌خواندنی"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "سامانه پرونده"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "تنظیمات"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "می‌تواند تنظیمات را تغییر دهد"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you are "
+"concerned about these permissions, consider removing this application."
+msgstr ""
+"%s این اجازه‌ها را به صورت توکار دارد و نمی‌توان تغییرش داد. در صورتی که نگران این "
+"اجازه‌هایید، حذف این برنامه را در نظر بگیرید."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%Iu گونهٔ پرونده و پیوند که به دست کاره گشوده شده"
+msgstr[1] "%Iu گونهٔ پرونده و پیوند که به دست کاره گشوده شده"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "برای گشودن گونه‌های پرونده و پیوند زیر از <b>%s</b> استفاده شده."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s از فضای دیسک استفاده شده."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "برنامه‌های کاربردی"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "بدون برنامه"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "نصب…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "گشودن"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "نمایش جزییات"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16 panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252 panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "جست‌وجو"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "گرفتن جست‌وجوهای سامانه و فرستادن نتیجه‌ها."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804 panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478 subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "از کار افتاده"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "آگاهی‌ها"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "نمایش آگاهی‌های سامانه."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "اجرا در پس‌زمینه"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "اجازهٔ فعّالیت هنگام بسته بودن کاره."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "نماگرفت‌ها"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "گرفتن عکس از صفحه در هر زمانی."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "دگرگونی کاغذدیواری"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "دگرگونی کاغذدیواری میزکار."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "صداها"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "بازتولید صداها."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "جلوگیری از میان‌برها"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "انسداد میان‌برهای صفحه‌کلید استاندارد."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "دوربین"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "گرفتن عکس با دوربین."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "میکروفون"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "ضبط صدا با میکروفون."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "خدمات مکان‌یابی"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "دسترسی به داده‌های مکانی افزاره."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "اجازه‌های توکار"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "دسترسی‌های سامانه‌ای مورد نیاز کاره"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "پیوستگی‌های پرونده و پیوند"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "ذخیره‌سازی"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "هیچ نتیجه‌ای پیدا نشد"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210 shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "جست‌وجویی دیگر را بیازمایید"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "پیوستگی‌های پرونده و پیوند"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "گونه‌های پرونده"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "گونه‌های پیوند"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "بازنشانی"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid "How much disk space this application is occupying with app data and caches."
+msgstr "مقدار فضای دیسکی که این برنامه با داده‌های کاره و انباره‌ها اشغال می‌کند."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "برنامهٔ کاربردی"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "داده"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "انباره"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>مجموع</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "پاک‌سازی انباره…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "واپایش اجازه‌ها و تنظیمات برنامه‌های مختلف"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"کاره;برنامه;فلت‌پک;اجازه;مجوز;دسترسی;تنظیمات;application;flatpak;permission;setting;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "گزینش یک عکس"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125 panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866 panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269 panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594 panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17 panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_لغو"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270 panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_گشودن"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "اندازه‌های چندگانه"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%Id × %Id"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "بدون تصویر پس‌زمینه"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "تصویر پس‌زمینه کنونی"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "سبک"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "پیش‌گزیده"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "تیره"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "پس‌زمینه"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "افزودن عکس…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "ظاهر"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "تغییر تصویر پس‌زمینه یا رنگ‌های رابط کاربریتان"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;پس‌زمینه;صفحه;"
+"رومیزی;کاغذدیواری;میزکار;سبک;روشن;تاریک;تیره;ظاهر;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "به کار انداختن"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "هیچ بلوتوثی پیدا نشد"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "برای استفاده بلوتوث یک دانگل متّصل کنید."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "بلوتوث خاموش شد"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "برای وصل شدن به افزاره‌ها و دریافت پرونده‌ها، روشن کنید."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "حالت هواپیما روشن است"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "بلوتوث هنگام روشن بودن حالت هواپیما از کار می‌افتد."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "خاموش کردن حالت هواپیما"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "حالت هواپیمای سخت‌افزاری روشن است"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "برای به کار انداختن بلوتوث حالت هواپیما را خاموش کنید."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "بلوتوث"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "بلوتوث را خاموش و روشن کنید و به افزاره‌های خود متّصل شوید"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;اشتراک;هم‌رسانی;بلوتوث;هم‌رسانی;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "دوربین خاموش شده است"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "هیچ برنامه‌ای نمی‌تواند عکس یا فیلم بگیرد."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling the "
+"camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"استفاده از دوربین می‌گذارد برنامه‌ها عکس و ویدیو بگیرند. ممکن است از کار انداختن "
+"دوربین باعث کارکرد نادرست برخی برنامه‌ها شود.\n"
+"\n"
+"اجازه به برنامه‌های زیر برای استفاده از دوربینتان."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "هیچ برنامه‌ای برای دسترسی به دوربین درخواست نکرده است"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "محافظت از عکس‌هایتان"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;دوربین;عکس;ویدیو;وبکم;قفل;شخصی;"
+"خصوصی;محرمانگی;حریم;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "افزارهٔ واسنجیتان را روی مربع قرار داده و «شروع» را بزنید"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid "Move your calibration device to the calibrate position and press “Continue”"
+msgstr "افزارهٔ واسنجیتان را به موقعیت واسنجی منتقل کرده و «ادامه» را بزنید"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid "Move your calibration device to the surface position and press “Continue”"
+msgstr "افزارهٔ واسنجیتان را به موقعیت سطح منتقل کرده و «ادامه» را بزنید"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "در لپ‌تاپ را ببندید"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "یک خطای داخلی رخ داد و امکان بازسازی وجود ندارد."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "ابزارهای مورد نیاز برای واسنجی نصب نشده‌اند."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "نمایه نتوانست ایجاد شود."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "نقطهٔ سفید هدف قابل دسترسی نبود."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "تمام!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "واسنجی شکست خورد!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "می‌توانید افزارهٔ واسنجی را بردارید."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "مزاحم افزارهٔ واسنجی در هنگام کار نشوید"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "واسنجی نمایشگر"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_شروع"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "از _سر گیری"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_انجام شد"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "صفحه‌نمایش لپ‌تاپ"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "وب‌کم توکار"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "صفحه‌نمایش %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "پویشگر %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "دوربین %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "چاپگر %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "وب‌کم %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "به کار انداختن مدیریت رنگ برای %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "نمایش نمایه‌های رنگی برای %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "واسنجی نشده"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "پیش‌گزیده: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "فاصله‌رنگ (Colorspace): "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "آزمایش نمایه: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "انتخاب پروندهٔ نمایهٔ ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_درون‌ریزی"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "نمایه‌های ICC پشتیبانی شده"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "همهٔ پرونده‌ها"
+
+#: panels/color/cc-color-panel.c:586 panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "صفحه‌نمایش"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "ذخیرهٔ نمایه"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "ذخیره"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "ایجاد یک نمایهٔ رنگی برای افزارهٔ گزیده"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"ابزار اندازه‌گیری پیدا نشد. لطفاً بررسی کنید که روشن باشد و بدرستی نصب شده است."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "ابزار اندازه‌گیری از profiling پشتیبانی نمی‌کند."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "این گونه افزاره در حال حاضر پشتیبانی نمی‌شود."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "واسنجی صفحه‌نمایش"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "کیفیت واسنجی"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your screen. "
+"The longer you spend on calibration, the better the quality of the color profile."
+msgstr ""
+"واسنجی، نمایه‌ای ایجاد خواهد کرد که می‌توانید از آن برای مدیریت رنگ صفحه‌تان استفاده "
+"کنید. هر چه زمان بیش‌تری برای واسنجی بگذارید، کیفت نمایهٔ رنگیتان بیش‌تر خواهد بود."
+
+#: panels/color/cc-color-panel.ui:28
+msgid "You will not be able to use your computer while calibration takes place."
+msgstr "تا پایان واسنجی نمی‌توانید از رایانه‌تان استفاده کنید."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "کیفیت"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "زمان تقریبی"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "افزارهٔ واسنجی"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "حسگری را که می‌خواهید برای واسنجی استفاده کنید، برگزینید."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "گونهٔ نمایشگر"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "گونهٔ نمایشگری که متّصل شده است را برگزینید."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "نقطه‌سفید نمایه"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a D65 "
+"illuminant."
+msgstr ""
+"نقطهٔ سفید هدفی در نمایشگر برگزینید. بیش‌تر نمایشگرها باید با یک منبع نور D65 واسنجی "
+"شوند."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "روشنایی نمایشگر"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color management "
+"will be most accurate at this brightness level."
+msgstr ""
+"لطفاً روشنایی صفحه‌نمایش را به میزانی که برای شما مناسب است تنظیم کنید. مدیریت رنگ "
+"در این سطح روشنایی دقیق‌تر خواهد بود."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"هم‌چنین، می‌توانید از سطح روشنایی یکی دیگر از نمایه‌های این افزاره استفاده کنید."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "نام نمایه"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles for "
+"different lighting conditions."
+msgstr ""
+"می‌توانید از یک نمایهٔ رنگی روی رایانه‌های مختلف استفاده کرده یا حتا برای حالت‌های "
+"روشنایی متفاوت، نمایه بسازید."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "نام نمایه:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "خلاصه"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "نمایه با موفقیت ساخته شد!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "رونوشت از نمایه"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "نیاز به یک رسانهٔ قابل نوشتن دارد"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux\">GNU/"
+"Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows\">Microsoft "
+"Windows</a> systems useful."
+msgstr ""
+"ممکن است این راهنماهای ساخت نمایه روی سامانه‌های <a href=\"linux\">گنو/لینوکس</a>، "
+"<a href=\"osx\">اواس ده اپل</a> و <a href=\"windows\">ویندوز مایکروسافت</a> مفید "
+"باشند."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "افزودن نمایه"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show details.</"
+"a>"
+msgstr ""
+"مشکلاتی شناسایی شدند. ممکن است نمایه درست کار نکند. <a href=\"\">نمایش جزییات.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "درون‌ریزی _پرونده…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_افزودن"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "هر افزاره برای مدیریت رنگ، نیاز به یک نمایهٔ رنگی دارد."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434 panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "بیشتر بدانید"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "درباره مدیریت رنگ بیشتر بدانید"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_تنظیم برای تمام کاربران"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "تنظیم این نمایه برای تمام کاربران روی این رایانه"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_به کار انداختن"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "افزودن نمایه"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_واسنجی…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "واسنجی افزاره"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_برداشتن نمایه"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "نمایش _جزییات"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "هیچگونه افزاره‌ای که بتواند مدیریت رنگ شود پیدا نشد"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "سی‌آرتی"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "پروژکتور"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "پلاسما"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL backlight)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED backlight)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (white LED backlight)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Wide gamut LCD (CCFL backlight)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Wide gamut LCD (RGB LED backlight)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "بالا"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "۴۰ دقیقه"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "متوسّط"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "۳۰ دقیقه"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "کم"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "۱۵ دقیقه"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "محلی برای نمایشگر"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "‫D50 (چاپ و انتشار)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (عکسبرداری و گرافیک)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "فضای استاندارد"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "آزمایش نمایه"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "خودکار"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "کیفیت پایین"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "کیفیت متوسّط"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "کیفیت بالا"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "پیش‌گزیده RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "پیش‌گزیده CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "پیش‌گزیده Gray"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "داده‌های واسنجی کارخانه‌ای فراهم شده به دست سازنده"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "اصلاح نمایش تمام‌صفحه با این نمایه ممکن نیست"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "ممکن است این نمایه دیگر دقیق نباشد"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "رنگ"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid "Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "رنگ افزاره‌هایتان نظیر نمایشگرها، دوربین‌ها یا چاپگرها را واسنجی کنید"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Profile;Calibrate;Printer;Display;رنگ;نمایه;واسنجی;چاپگر;نمایشگر;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "دیگر…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "گزینش زبان"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_انتخاب"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "هیچ زبانی پیدا نشد"
+
+#: panels/common/cc-language-chooser.ui:69 panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "بیش‌تر…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "قفل‌گشایی برای تغییر تنظیمات"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "برخی تنظیمات باید پیش از تغییر، قفل‌گشایی شوند."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "قفل‌گشایی…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "ساعت افزایش"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "دقیقهٔ افزایش"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "زمان"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "ساعت کاهش"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "دقیقهٔ کاهش"
+
+#: panels/common/cc-util.c:127 panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "امروز"
+
+#: panels/common/cc-util.c:131 panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "دیروز"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%Oe %B"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%Oe %B، %OY"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%Id ساعت"
+msgstr[1] "%Id ساعت"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%Id دقیقه"
+msgstr[1] "%Id دقیقه"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%Id ثانیه"
+msgstr[1] "%Id ثانیه"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s و %s و %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s و %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s و %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "۰ ثانیه"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "نقطهٔ داغ"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "۲۴ ساعته"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "صبح / عصر"
+
+# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%Oe %B %OY، ⁦%Ol:%OM⁩ %p"
+
+# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%Oe %B %OY، ⁦%OH:%OM⁩"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s، %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "⁦%Ol∶%OM⁩ %p"
+
+# در این رشته از نویسه‌های ایزوله چپ‌به‌راست استفاده شده است
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "⁦%OH:%OM⁩"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "تاریخ و زمان"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "سال"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "ماه"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "ژانویه"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "فوریه"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "مارس"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "آوریل"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "می"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "ژوئن"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "ژوئیه"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "اوت"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "سپتامبر"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "اکتبر"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "نوامبر"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "دسامبر"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "روز"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "منطقه زمانی"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "جست‌وجو برای یک شهر"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_تاریخ و زمان خودکار"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "احتیاج به دسترسی به اینترنت دارد"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "تاریخ و _زمان"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "_منطقه زمانی خودکار"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "نیاز به خدمت مکان‌یابی به کار افتاده و دسترسی به اینترنت"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212 panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802 panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "فعَال"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "منطقه ز_مانی"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_قالب زمان"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "تغییر ساعت و تاریخ، شامل منطقه زمانی"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "سایت;منطقهٔ زمانی;مکان;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "تغییر تنظیمات تاریخ و زمان سامانه"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "برای تغییر تنظیمات تاریخ و ساعت، احتیاج به تصدیق هویت دارید."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_وب"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_رایانامه"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_تقویم"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_آهنگ"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_ویدیو"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_عکس‌ها"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "برنامه‌های پیش‌گزیده"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "پیکربندی برنامه‌های پیش‌گزیده"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;پیش‌گزیده;پیش‌گزیده;ترجیح;رسانه;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"ارسال گزارش‌های مشکلات فنی، به بهبود %s  کمک می‌کند. گزارش‌ها به صورت ناشناس ارسال "
+"شده و عاری از اطّلاعات شخصیند. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "گزارش اشکال"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_گزارش خودکار اشکالات"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "عیب‌یابی"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "گزارش مشکلاتتان"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;تشخیص;عیب‌یابی;فروپاشی;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "روشن"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "خاموش"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "اعمال تغییرات؟"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "نمی‌توان تغییرات را اعمال کرد"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "می‌تواند به دلیلی محدودیت‌های سخت‌افزار باشد."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_اِعمال"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64 panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31 panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "برگشت"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "تنظیمات نمایش از کار افتاده"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "چندین نمایشگر"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "پیوستن"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "آینه"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "شامل نوار بالا و فعّالیت‌ها"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "نمایشگر اصلی"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177 panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "نور شب"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "افقی"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "عمودی راست"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "عمودی چپ"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "افقی (معکوس)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf هرتز"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "جهت"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "تفکیک‌پذیری"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "آهنگ نوسازی"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "تنظیم برای تلویزیون"
+
+#: panels/display/cc-display-settings.ui:78 panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "مقیاس"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "نور شب موجود نیست"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop being "
+"used remotely"
+msgstr "می‌تواند نتیجهٔ راه‌انداز گرافیکی یا میزکار دوردست استفاده شده باشد"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "تا فردا از کار بیفتد"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "انجام دوباره صافی"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye strain and "
+"sleeplessness."
+msgstr ""
+"نور شب رنگ صفحه را گرم‌تر می‌کند. این کار به پیش‌گیری از آسیب چشمی و بی‌خوابی کمک می "
+"کند."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "زمان‌بندی"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "غروب تا طلوع"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "زمان‌بندی دستی"
+
+#: panels/display/cc-night-light-page.ui:154 panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "زمان‌ها"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "از"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "ساعت"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "دقیقه"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "ص"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "ع"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "به"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "دمای رنگ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "نمایشگرها"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "نحوهٔ استفاده از نمایشگرها و پروژکتورهای متّصل را انتخاب کنید"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;"
+"color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;"
+"color;sunset;sunrise;تابلو;پروژکتور;صفحه;مانیتور;نمایشگر;تفکیک;شب;نور;آبی;رنگ;غروب;"
+"طلوع;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "راه‌اندازی امن فعّال است"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts. "
+"It is currently turned on and is functioning correctly."
+msgstr ""
+"راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار افزاره "
+"می‌گیرد. در حال حاضر روشن است و به درستی کار می‌کند."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "راه‌اندازی امن مشکلاتی دارد"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts. "
+"It is currently turned on, but will not work due to having an invalid key."
+msgstr ""
+"راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار افزاره "
+"می‌گیرد. در حال حاضر روشن است؛ ولی به خاطر داشتن کلیدی نامعتبر، کار نخواهد کرد."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI firmware "
+"settings (BIOS) and your hardware manufacturer may provide information on how to "
+"do this."
+msgstr ""
+"مشکلات راه‌اندازی امن اغلب می‌توانند از تنظیمات ثابت‌افزار UEFIتان (بایوس) حل شوند و "
+"ممکن است سازندهٔ سخت‌افزارتان اطّلاعاتی در مورد چکونگی انجامشان فراهم کرده باشد."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "برای راهنمایی، با سازندهٔ سخت‌افزار یا فراهم کنندهٔ پشتیبانی ITتان تماس بگیرید."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "راه‌اندازی امن خاموش شده است"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts. "
+"It is currently turned off."
+msgstr ""
+"راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار افزاره "
+"می‌گیرد. در حال حاضر خاموش است."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware settings "
+"(BIOS). For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"راه‌اندازی امن اغلب می‌تواند از تنظیمات ثابت‌افزار UEFIتان (بایوس) خاموش شود. برای "
+"راهنمایی، با سازندهٔ سخت‌افزار یا فراهم کنندهٔ پشتیبانی ITتان تماس بگیرید."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"راه‌اندازی امن جلوی نرم‌افزارهای مخرّب را برای بار شدن هنگام شروع به کار افزاره "
+"می‌گیرد.\n"
+"\n"
+"برای اطّلاعات بیش تر با سازندهٔ سخت‌افزار یا پشیبانی IT تماس بگیرید."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "قبول شده"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "شکست خورده"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "افزاره مطابق سطح %Id از HSI"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "سطح امنیتی ۰"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could be "
+"because of a hardware or firmware configuration issue. It is recommended to "
+"contact your IT support provider."
+msgstr ""
+"این افزاره دربرابر مشکلات امنیتی سخت‌افزاری هیچ محافظتی ندارد. این امر می‌تواند به "
+"خاطر مشکل پیکربندی سخت‌افزار یا ثابت‌افزار باشد. پیشنهاد می‌شود با فراهم‌کنندهٔ "
+"پشتیبانی IT تماس بگیرید."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "سطح امنیتی ۱"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is the "
+"lowest device security level and only provides protection against simple security "
+"threats."
+msgstr ""
+"این افزاره در برابر مشکلات امنیتی سخت‌افزاری، کمینهٔ محافظت را دارد. این محافظت، "
+"پایین‌ترین سطح امنیت افزاره بوده و در برابر تهدیدهای امنیتی ساده مقاوم است."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "سطح امنیتی ۲"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This provides "
+"protection against some common security threats."
+msgstr ""
+"این افزاره در برابر مشکلات امنیتی سخت‌افزاری محافظت پایه‌ای دارد. این محافظت در "
+"برابر برخی تهدیدهای امنیتی معمول مقاوم است."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "سطح امنیتی ۳"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This is the "
+"highest device security level and provides protection against advanced security "
+"threats."
+msgstr ""
+"این افزاره در برابر مشکلات امنیتی سخت‌افزاری، محافظت گسترده دارد. این محافظت، "
+"بالاترین سطح امنیتی افزاره بوده و در برابر تهدیدهای امنیتی پیشرفته مقاوم است."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "سطح امنیت"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "سطوح امنیتی برای این افزاره موجود نیست."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"برای راهنمایی در بارهٔ به‌روز رسانی‌های امنیتی با سازندهٔ سخت‌افزارتان تماس بگیرید."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware settings, "
+"or by a support technician."
+msgstr ""
+"ممکن است رفع این مشکل در تنظیمات ثابت‌افزار UEFI یا به دست یک پشتیبان فنی ممکن باشد."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware settings."
+msgstr "ممکن است رفع این مشکل در تنظیمات ثابت‌افزار UEFI ممکن باشد."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "ممکن است یک پشتیبان فنی بتواند این مشکل را رفع کند."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "سطح ۱"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "سطح ۲"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "سطح ۳"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "محافظت در برابر نرم‌افزارهای مخرّب هنگام آغاز به کار افزاره."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "راه‌اندازی امن مشکلاتی دارد"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "برخی محافظت‌ها هنگام آغاز به کار افزاره."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "راه‌اندازی امن خاموش است"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "بدون محافظت هنگام آغاز به کار افزاره."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on this "
+"system."
+msgstr ""
+"ممکن است مشکل ناشی از تغییری در تنظیمات ثابت‌افزار UEFI، تغییری در پیکربندی "
+"سیستم‌عامل یا نرم‌افزاری مخرّب روی این سامانه باشد."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, or "
+"because of malicious software on this system."
+msgstr ""
+"ممکن است مشکل ناشی از تغییری در تنظیمات ثابت‌افزار UEFI یا نرم‌افزاری مخرّب روی این "
+"سامانه باشد."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration change, or "
+"because of malicious software on this system."
+msgstr ""
+"ممکن است مشکل ناشی از تغییری در پیکربندی سیستم‌عامل یا نرم‌افزاری مخرّب روی این "
+"سامانه باشد."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "در معرض تهدیدهای جدّی امنیتی."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "محافظت محدود در برابر تهدیدهای امنیتی ساده."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "محافظت شده در برابر تهدیدهای امنیتی معمول."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "محافظت شده در برابر بازهٔ وسیعی از تهدیدهای امنیتی."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "محافظت همه‌جانبه"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "بدون رویداد"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "محافظت نوشتن ثابت‌افزار"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "قفل محافظت نوشتن ثابت‌افزار"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "ناحیهٔ BIOS ثابت‌افزار"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "شرح‌دهندهٔ BIOS ثابت‌افزار"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "بوت‌گارد اینتل"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "راه‌اندازی تأیید شدهٔ بوت‌گارد اینتل"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "بوت‌گارد اینتل محافظت شده با ACM"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "سیاست خطای بوت‌گارد اینتل"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "فیوز بوت‌گارد اینتل"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "کت اینتل به کار افتاده"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "کت اینتل فعّال"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "جلوگیری از دسترسی حالت ناظر اینتل"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "حافظهٔ رمزگذاشته"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "محافظت IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "قرنطینهٔ کرنل لینوکس"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "تأیید کرنل لینوکس"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "مبادلهٔ لینوکس"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "تعلیق به رم"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "تعلیق به بی‌کار"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "کلید بن‌سازهٔ UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "راه‌اندازی امن UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "پیکربندی بن‌سازهٔ TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "بازسازی TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "نگارش ۲٫۰ TPM"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "حالت سازندهٔ موتور مدیریت اینتل"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "پایمالی موتور مدیریت اینتل"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "نگارش موتور مدیریت اینتل"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "به‌روز رسانی‌های ثابت‌افزار"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "تصدیق ثابت‌افزار"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "تصدیق به‌روز رسان ثابت‌افزار"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "اشکال‌زدایی بن‌سازه"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "بررسی‌های امنیتی پردازنده"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "محافظت از بازگشت AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "محافظت از بازپخش ثابت‌افزار AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "محافظت از نوشتن ثابت‌افزار AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "بن‌سازهٔ فیوز شده"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "معتبر"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "نامعتبر"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "به کار نیفتاده"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "قفل شده"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "قفل نشده"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "رمز شده"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "رمز نشده"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "آلوده شده"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "آلوده نشده"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "پیدا شده"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "پیدا نشده"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "پشتیبانی شده"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "پشتیبانی نشده"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "امنیت افزاره"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "وضعیت امنیتی ثابت‌افزار میزبان"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
+"identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
+"identity;privacy;صفحه;قفل;کرش;خصوصی;اخیر;موقت;نمایه;نام;شبکه;هویت;محرمانگی\"حریم "
+"شخصی;حریم خصوصی;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "ناشناخته"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "۶۴ بیتی"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "۳۲ بیتی"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "زورگ"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "وی‌لند"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "ناشناخته"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "ناموجود"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "نشان سامانه"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "نام افزاره"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "مدل سخت‌افزار"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "حافظه"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "پردازنده"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "گرافیک"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "ظرفیت دیسک"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "محاسبه کردن…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "نام سیستم‌عامل"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "شناسهٔ ساخت سیستم‌عامل"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "گونهٔ سیستم‌عامل"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "نگارش گنوم"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "بار کردن…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "سامانهٔ پنجره"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "مجازی‌سازی"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "به‌روز رسانی‌های نرم‌افزاری"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "تغییر نام افزاره"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"نام افزاره برای تشخیص این افزاره هنگام دیده شدن روی شبکه یا جفت شدن افزاره‌های "
+"بلوتوثی استفاده می‌شود."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "نام افزاره"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_تغییر نام"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "درباره"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "دیدن اطّلاعات دربارهٔ سامانه‌تان"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;hostname;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;دستگاه;افزاره;سیستم;"
+"سامانه;اطّلاعات;نام دامنه;حافظه;پردازشگر;نسخه;پیش‌گزیده;برنامه;یدکی;ترجیح‌شده;سی‌دی;"
+"دی‌وی‌دی;یواس‌بی;صوت;ویدیو;دیسک;قابل حذف;رسانه;اجرای خودکار;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "صدا و رسانه"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "خموشی/ناخموشی صدا"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "کاهش حجم صدا"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "افزایش حجم صدا"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "خموشی/ناخموشی میکروفون"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "اجرای پخش‌کنندهٔ رسانه"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "پخش (یا پخش/مکث)‏"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "مکث پخش"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "توقف پخش"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "قطعهٔ پیشین"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "قطعهٔ بعدی"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "بیرون دادن"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "نوشتن"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "تعویض به منبع ورودی بعدی"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "تعویض به منبع ورودی پیشین"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "راه‌اندازها"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "راه‌اندازی مرورگر راهنما"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "راه‌اندازی ماشین حساب"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "راه‌اندازی کارخواه رایانامه"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "راه‌اندازی مرورگر وب"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "پوشه‌ٔ خانه"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "جست‌وجو"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "سامانه"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "خروج"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "صفحهٔ قفل"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "دسترسی‌پذیری"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "خاموش یا روشن کردن بزرگنمایی"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "بزرگ‌نمایی"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "بزرگ‌نمایی به خارج"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "خاموش یا روشن کردن صفحه‌نمایش‌خوان"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "روشن یا خاموش کردن صفحه‌کلید مجازی"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "افزایش اندازهٔ متن"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "کاهش اندازهٔ متن"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "روشن یا خاموش کردن سایه‌روشن بالا"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "هیچ منبع ورودی پیدا نشد"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "موارد دیگر"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "افزودن یک منبع ورودی"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "روش‌های ورودی نمی‌توانند در صفحهٔ ورود استفاده شوند"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "هیچ منبع ورودی‌ای انتخاب نشد"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "گزینه‌ها"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "جابه‌جایی به بالا"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "جابه‌جایی به پایین"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "ترجیحات"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "نمایش چیدمان صفحه‌کلید"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "برداشتن"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "میان‌برهای سفارشی"
+
+#: panels/keyboard/cc-keyboard-panel.c:64 panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "کلید نویسه‌های جایگزین"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. These are "
+"sometimes printed as a third-option on your keyboard."
+msgstr ""
+"کلید نویسهٔ جایگزین می‌تواند برای ورود نویسه‌های اضافی استفاده شود. گاهی به عنوان "
+"گزینهٔ سوم روی صفحه‌کلیدتان چاپ شده‌اند."
+
+#: panels/keyboard/cc-keyboard-panel.c:67 panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "دگرساز چپ"
+
+#: panels/keyboard/cc-keyboard-panel.c:68 panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "دگرساز راست"
+
+#: panels/keyboard/cc-keyboard-panel.c:69 panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "سوپر چپ"
+
+#: panels/keyboard/cc-keyboard-panel.c:70 panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "سوپر راست"
+
+#: panels/keyboard/cc-keyboard-panel.c:71 panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "کلید فهرست"
+
+#: panels/keyboard/cc-keyboard-panel.c:72 panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "مهار راست"
+
+#: panels/keyboard/cc-keyboard-panel.c:80 panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "کلید ایجاد"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use it, "
+"press compose then a sequence of characters.  For example, compose key followed by "
+"<b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by <b>'</b> will "
+"enter <b>á</b>."
+msgstr ""
+"دکمهٔ ایجاد، امکان ورود طیف وسیعی از نویسه‌ها را می‌دهد. برای استفاده از آن، ایجاد و "
+"به دنبالش، دنباله‌ای از نویسه‌ها را بفشارید.  برای مثال، کلید ایجاد به همراه <b>C</"
+"b> و <b>o</b>، نویسهٔ <b>©</b> و <b>a</b> به همراه <b>'</b>، نویسهٔ <b>á</b> را وارد "
+"می‌کند."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "قفل تبدیل"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "قفل لغزش"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "نماگرفت"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"منابع ورودی می‌توانند با استفاده از میان‌بر صفحه‌کلید %s تعویض شوند.\n"
+"این میان‌بر می‌تواند در تنظیمات میان‌برهای صفحه‌کلید عوض شود."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "منابع ورودی"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "شامل چینش‌های صفحه‌کلید و روش‌های ورودی."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "تغییر منبع ورودی"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "از _یک منبع در همه پنجره‌ها استفاده کن"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "تغییر منابع ورودی به صورت _جداگانه برای هر پنجره"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "ورود نویسهٔ خاص"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "روش‌های ورود نشانه‌ها و دگرگونه‌های حروف با استفاده از صفحه‌کلید."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "میان‌برهای صفحه‌کلید"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "نمایش و سفارشی سازی میان‌برها"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%Id تغییریافته"
+msgstr[1] "%Id تغییریافته"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "بازنشانی تمام میان‌برها؟"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be undone."
+msgstr ""
+"ممکن است بازنشانی میان‌برها روی میان‌برهای شخصیتان اثر بگذارد. این کار قابل بازگشت "
+"نیست."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83 panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "لغو"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "بازنشانی همه"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "بازشانی همه…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "بازنشانی همهٔ میان‌برها به ترکیب کلید پیش‌گزیده"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "بخش"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "میان‌برها"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "افزودن میان‌بر"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "افزودن میان‌برهای سفارشی"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "برپایی میان‌های سفارشی برای اجرای کاره‌ها، اجرای کدنوشته‌ها و بیش‌تر."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "افزودن میان‌بر"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "هیچ میان‌بر صفحه‌کلیدی پیدا نشد"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"کلید %s از پیش برای %s استفاده می‌شد. اگر جایگزینش کنید، %s از کار خواهد افتاد"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "میان‌بر جدید را وارد کنید"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "تنظیم میان‌بر سفارشی"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "تنظیم میان‌بر"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "برای تغییر %s میان‌بر جدید را وارد کنید."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "افزودن میان‌بر سفارشی"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_برداشتن"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_جایگزینی"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39 panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_تنظیم"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "فشردن گریز برای لغو یا پس‌بر برای از کار انداختن میان‌بر صفحه‌کلید."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137 panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "نام"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "فرمان"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "میان‌بر"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "تنظیم میان‌بر…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "هیچ"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "بازنشانی میان‌بر به مقدار پیش‌گزیدهش"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "صفحه‌کلید"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts and "
+"input sources"
+msgstr ""
+"تغییر میان‌برهای صفحه‌کلید و تنظیم ترجیحات نوشتن، چینش‌های صفحه‌کلید و منبع‌های ورودیتان"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;میانبر;"
+"میان‌بر;فضای کاری;پنجره;اندازه;بزرگ‌نمایی;تضاد;ورودی;منبع;قفل;صدا;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "خدمات مکان‌یابی خاموش شده"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "هیچ برنامه‌ای نمی‌تواند اطّلاعات موقعیت را به دست آورد."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and mobile "
+"broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/"
+"privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"خدمات مکانی می‌گذارند برنامه‌ها مکانتان را بدانند. استفاده از وای‌فای و پهن‌باند "
+"همراه، دقّت را بالا می‌برد.\n"
+"\n"
+"از خدمت مکان موزیلا استفاده می‌شود: <a href='https://location.services.mozilla.com/"
+"privacy'>سیاست محرمانگی</a>\n"
+"\n"
+"اجازه به برنامه‌های زیر برای تشخیص مکانتان."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "هیچ برنامه‌ای برای دسترسی به مکان درخواست نکرده است"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "محافظت از اطّلاعات مکانتان"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;مکان;موقعیت;خصوصی;محرمانگی;حریم شخصی;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "میکروفون خاموش شده"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "هیچ برنامه‌ای نمی‌تواند صدا ضبط کند."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. Disabling "
+"the microphone may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"استفاده از میکروفون به برنامه‌ها اجازه می‌دهد که صدا را ضبط و به آن گوش کنند. از کار "
+"انداختن میکروفون ممکن است باعث کارکرد نادرست برخی برنامه‌ها شود.\n"
+"\n"
+"اجازه به برنامه‌های زیر برای استفاده از میکروفونتان."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "هیچ برنامه‌ای برای دسترسی به میکروفون درخواست نکرده است"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "محافظت از گفت‌وگوهایتان"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"microphone;recording;application;privacy;میکروفون;ضبط;برنامه;محرمانگی;حریم شخصی;"
+"خصوصی;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "آزمودن _تنظیماتتان"
+
+#: panels/mouse/cc-mouse-panel.ui:23 panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "عمومی"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "دکمهٔ اصلی"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "ترتیب کلیدهای فیزیکی روی موشی‌ها و صفحات لمسی را تنظیم می‌کند."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "چپ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "راست"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "موشی"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "سرعت موشی"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "لغرش طبیعی"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "لغزش، محتوا را جابه‌جا می‌کند، نه نما را."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "صفحه ‌لمسی"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "سرعت صفحه ‌لمسی"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "ضربه برای کلیک"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "ضربه برای کلیک"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "لغزش دو انگشتی"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "لغزش در گوشه‌ها"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "کلیک، دوبار کلیک و لغزش را بیازمایید"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "پنج کلیک، زمان GEGL است!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "دوبار کلیک، دکمهٔ اصلی"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "تک کلیک، دکمهٔ اصلی"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "دوبار کلیک، دکمهٔ وسط"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "تک کلیک، دکمهٔ وسط"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "دوباره کلیک، دکمهٔ دوم"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "تک کلیک، دکمهٔ دوم"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "موشی و صفحه‌لمسی"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid "Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "تغییر میزان حساسیت موشی یا صفحه‌لمسی و انتخاب راست‌دست یا چپ‌دست بودن"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;صفحه‌جهت‌ده;نشانگر;کلیک;"
+"ضربه;دوبار;دکمه;صفحه ردیاب;لغزش;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_گوشهٔ داغ"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "لمس گوشهٔ راست بالا برای گشودن نمای کلّی فعّالیت‌ها."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "لبه‌های صفحهٔ _فعّال"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid "Drag windows against the top, left, and right screen edges to resize them."
+msgstr "کشیدن پنجره‌ها مقابل لبه‌های بالا، راست و چپ صفحه برای تغییر اندازه‌شان."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "فضاهای کاری"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "فضاهای کاری _پویا"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "برداشتن خودکار فضاهای کاری خالی."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "تعداد _ثابت برای فضاهای کاری"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "تعیین تعدادی فضای کاری ثابت."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_تعداد فضاهای کاری"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "چندنمایشگره"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "فضاهای کاری فقط روی نمایشگر _اصلی"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "فضاهای کاری روی _تمامی نمایشگرها"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "تعویض برنامه"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "شامل برنامه‌ها از تمامی _فضاهای کاری"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "شامل برنامه‌ها فقط از فضای کاری _کنونی"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "چندوظیفگی"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "مدیریت ترجیحات برای بهره‌وری و چندوظیفگی"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"چندوظیفگی;بهره‌وری;شخصی‌سازی;میزکار;گوشه‌ها;فضا;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "آخ، مشکلی پیش آمد. لطفاً با تولید کننده نرم‌افزار خود تماس بگیرید."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "باید NetworkManager در حال اجرا باشد."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "دیگر افزاره‌ها"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "وی‌پی‌ان"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "افزودن اتّصال"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "برپا نشده"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "شبکهٔ ناامن (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "شبکهٔ امن (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "شبکهٔ امن (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "شبکهٔ امن (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "شبکهٔ امن"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "متّصل"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325 panels/network/network-bluetooth.ui:22
+#: panels/network/network-ethernet.ui:56 panels/network/network-mobile.ui:329
+#: panels/network/network-proxy.ui:62 panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "گزینه‌ها…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible to "
+"access the internet through Wi-Fi."
+msgstr ""
+"روشن کردن نقطهٔ داغ، موجب قطع شدن از %s شده و قادر به دسترسی به اینترنت از طریق "
+"وای‌فای نیستید."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "باید کمینهٔ ۸ نویسه را داشته باشد"
+
+# "I" in "%Id" is for showing persian number.
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "باید بیشینه %Id نویسه داشته باشد"
+msgstr[1] "باید بیشینه %Id نویسه داشته باشد"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "روشن کردن نقطهٔ داغ بی‌سیم؟"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a Wi-Fi "
+"network that they can connect to. To do this, you must have an internet connection "
+"through a source other than Wi-Fi."
+msgstr ""
+"نقطهٔ داغ وای‌فای با ایجاد یک شبکهٔ وای‌فای، به دیگران اجازهٔ هم‌رسانی اتّصال اینترنتتان "
+"را می‌دهد. برای این کار باید اتّصال اینترنتی از منبعی غیر از وای‌فای داشته باشید."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "نام شبکه"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338 panels/printers/pp-jobs-dialog.ui:54
+#: panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "گذرواژه"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "تولید یک گذرواژهٔ تصادفی"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "گذرواژهٔ ایجاد شده به صورت خودکار"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_روشن کردن"
+
+#: panels/network/cc-wifi-panel.c:549 panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "وای‌فای"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "توقّف نقطهٔ داغ و قطع ارتباط همهٔ کاربران؟"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_توقّف نقطهٔ داغ"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "حالت هواپیما"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "وای‌فای، بلوتوث و پهن‌باند همراه را از کار می‌اندازد"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "هیچ سازوارگر وای‌فایی پیدا نشد"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "مطمئن شوید یک سازوارگر وای‌فای وصل‌شده و روشن دارید"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "حالت هواپیما روشن"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "خاموش کردن برای استفاده از وای‌فای"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "نقطهٔ داغ وای‌فای فعّال"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "افزاره‌های همراه می‌توانند برای اتّصال، رمز QR را بپویند."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "خاموش کردن نقطهٔ داغ…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "شبکه‌های آشکار"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "لازم است NetworkManager در حال اجرا باشد"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_امنیت 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "امنیت"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "حفظ"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "همیشگی"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "تصادفی"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "پایدار"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the network "
+"device this connection is activated on. This feature is known as MAC cloning or "
+"spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"نشانی مک وارد شده در این‌جا به عنوان نشانی سخت‌افزاری برای افزارهٔ شبکه‌ای که این "
+"اتّصال رویش فعّال است استفاده خواهد شد. این ویژگی به نام MAC cloning یا spoofing "
+"شناخته می‌شود. مثال: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "نمایهٔ %Id"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "گشودن بهبودیافته"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "تجاری"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "هیچ"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "هرگز"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%Ii روز پیش"
+msgstr[1] "%Ii روز پیش"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%Id مگابیت/ثانیه (%I1.1f گیگاهرتز)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%Id مگابیت/ثانیه"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "۲.۴ گیگاهرتز / ۵ گیگاهرتز"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "۲.۴ گیگاهرتز"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "۵ گیگاهرتز"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "هیچ"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "ضعیف"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "کافی"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "خوب"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "عالی"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144 panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "نشانی IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146 panels/network/net-device-mobile.c:442
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "نشانی IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149 panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445 panels/network/net-device-mobile.c:446
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "نشانی IP"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166 panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "ساناد۴"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167 panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "ساناد۶"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169 panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453 panels/network/net-device-mobile.c:454
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "ساناد"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "فراموشی اتّصال"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "برداشتن نمایهٔ اتّصال"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "برداشتن وی‌پی‌ان"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "جزییات"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "خودکار"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "هویت"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "حذف آدرس"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "حذف مسیر"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "هیچ"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "کلید ۴۰/۱۲۸ بیتیWEP (Hex یا ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "عبارت‌عبور ۱۲۸ بیتی WEP"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "‫WEP پویا (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "‫WPA و WPA2 شخصی"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA و WPA2 تجاری"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 شخصی"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "قدرت سیگنال"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "سرعت پیوند"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "نشانی سخت‌افزاری"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "بسامدهای پشتیبانی شده"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158 panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162 panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "بسامدهای پشتیبانی شده"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "آخرین استفاده"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "اتّصال _خودکار"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "در دسترس قراردادن برای _دیگر کاربران"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "اتّصال _اندازه‌گیری‌شده: دارای محدویت داده یا هزینه"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid "Software updates and other large downloads will not be started automatically."
+msgstr ""
+"به‌روز رسانی‌های نرم‌افزاری و دیگر بارگیری‌های بزرگ به صورت خودکار شروع نخواهند شد."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_نام"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "نشانی _مک"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "آدرس _کلون شده"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "بایت"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "_روش IPv4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "خودکار (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "فقط Link-Local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65 panels/network/net-proxy.c:71
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "دستی"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "از کار انداختن"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "هم‌رسانی شده با دیگر رایانه‌ها"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "نشانی‌ها"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "آدرس"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "ماسک شبکه"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "دروازه"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237 panels/network/net-proxy.c:73
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "خودکار"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "ساناد خودکار"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "نشانی کارساز(های) ساناد"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "نشانی‌های IP را با کاما (,) جدا کنید"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "مسیرها"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "مسیرهای خودکار"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "متریک"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "استفاده از این اتّصال _تنها برای منابع روی شبکه‌اش"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "روش IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "خودکار، فقط DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "پیشوند"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "نمی‌توان ویرایشگر اتّصال را باز کرد"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "نمایهٔ جدید"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "تنظیم نامعتبر %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "تنظیم نامعتبر %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "درون ریزی از پرونده…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "افزودن وی‌پی‌ان"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_امنیت"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "نمی‌توان اتّصال وی‌پی‌ان را درون‌ریزی کرد"
+
+# در این رشته از نویسه ایزوله اولین نویسهٔ قوی استفاده شده است
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN connection "
+"information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"پروندهٔ «⁨%s⁩» نمی‌تواند خوانده شود یا حاوی اطّلاعات اتّصال شناخته‌شدهٔ وی‌پی‌ان نیست\n"
+"\n"
+"خطا: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "گزینش پرونده برای درون‌ریزی"
+
+# در این رشته از نویسه ایزوله اولین نویسهٔ قوی استفاده شده است
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "پرونده‌ای با نام «⁨%s⁩» از پیش وجود دارد."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_جایگزینی"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "می‌خواهید %s را با اتّصال وی‌پی‌انی که دارید ذخیره‌اش می‌کنید جایگزین کنید؟"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "نمی‌توان اتّصال وی‌پی‌ان را برون‌ریزی کرد"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"اتّصال وی‌پی‌ان «%s» را نمی‌توان به %s صادر کرد.\n"
+"\n"
+"خطا: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "برون‌ریزی اتّصال وی‌پی‌ان"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(خطا: نمی‌توان ویرایشگر اتّصال وی‌پی‌ان را بار کرد)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "واپایش شیوهٔ اتّصال به اینترنت"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;شبکه;آی پی;لن;پیشکار;"
+"پروکسی;ون;پهن‌باند;مودم;بلوتوث;وی پی ان;دی ان اس;ساناد;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "واپایش شیوهٔ اتّصال به شبکه‌های وای‌فای"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;شبکه;بی سیم;وای فای;آی پی;"
+"لن;پروکسی;پهن‌باند;دی ان اس;ساناد;هات اسپات;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "هرگز"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "امروز"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "دیروز"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "آخرین استفاده"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264 panels/network/network-bluetooth.ui:5
+#: panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "سیمی"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "افزودن اتّصال جدید"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any custom "
+"configuration will be lost."
+msgstr ""
+"جزییات شبکه‌های گزیده، شامل گذرواژه‌ها و هر پیکربندی سفارشی‌ای از دست خواهند رفت."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_فراموشی"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "شبکه‌های وای‌فای آشنا"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_فراموشی"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "سیاست سامانه استفاده از نقطهٔ داغ را منع کرده است"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "افزارهٔ بی‌سیم از حالت نقطهٔ داغ پشتیبانی نمی‌کند"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "کشف خودکار پیشکار وب زمانی که URL فراهم نشده باشد استفاده می‌شود."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "برای شبکه‌های عمومی نامطمئن توصیه نمی‌شود."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "خاموش کردن افزاره"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "فعّال"
+
+#: panels/network/network-mobile.ui:27 panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "فراهم‌کننده"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "پیشکار شبکه"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "پیشکار _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "پیشکار H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "پیشکار _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_میزبان Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "میزبان‌های _نادیده گرفته شده"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "درگاه پیشکار HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "درگاه پیشکار HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "درگاه پیشکار FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "درگاه پیشکار Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_پیکربندی URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "خاموش کردن اتّصال وی‌پی‌ان"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "نام شبکه"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "گونهٔ امنیت"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "گذرواژه"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "خاموش کردن وای‌فای"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "گزینه‌های بیش‌تر…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "وصل شدن به شبکهٔ مخفی…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "روشن کردن نقطهٔ داغ بی‌سیم…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "شبکه‌های آشنا"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "وضعیت ناشناس"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "مدیریت نشده"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "ناموجود"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "در حال وصل شدن"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "تصدیق هویت شکست خورد"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "در حال قطع شدن"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "اتّصال شکست خورد"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "وضعیت ناشناس (ناپیدا)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "پیکربندی شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "پیکربندی IP شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "پیکربندی IP منقضی شد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "رمزها لازم بودند، اما فراهم نشدند"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "درخواست کننده 802.1x قطع شد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "تنظیمات پیکربندی درخواست کننده 802.1x شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "درخواست کننده 802.1x شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "تصدیق‌هویت دروخواست کننده 802.1x مدت زیادی طول کشید"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "شروع کارساز PPP شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "سرویس PPP قطع شد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "شکست در شروع کارخواه DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "خطا کارخواه DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "کارخواه DHCP شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "شکست در شروع خدمت اتّصالِ هم‌رسانده"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "سرویس اتّصال هم‌رسانی شده شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "شروع سرویس AutoIP شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "خطا سرویس AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "سرویس AutoIP شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "خطِ مشغول"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "بوق شماره‌گیری وجود ندارد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "اتّصال به هیچ فراهم‌کننده‌ای امکان‌پذیر نبود"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "مهلت درخواست شماره‌گیری تمام شد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "تلاش برای شماره‌گیری شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "مقداردهی اولیه مودم شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "انتخاب APN مشخص شده شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "جست‌وجو نکردن برای شبکه‌ها"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "ثبت شبکه رد شد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "مهلت ثبت شبکه تمام شد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "ثبت از طریق شبکه درخواست شده شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "بررسی پین شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "ممکن است ثابت‌افزار افزاره موجود نباشد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "اتّصال محو شد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "اتّصال فعلی استفاده شد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "مودم پیدا نشد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "اتّصال بلوتوث شکست خورد"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "سیم‌کارت وارد نشده است"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "پین سیم‌کارت لازم است"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "پوک سیم‌کارت لازم است"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "سیم‌کارت نادرست"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "نیازمندی‌های اتّصال شکست خورد"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "ثابت‌افزار موجود نیست"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "کابل قطع شد"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "خطای تعریف نشده در امنیت 802.1x (‫wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "هیچ پرونده‌ای انتخاب نشد"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "خطای نامشخّص در تأیید اعتبار پروندهٔ eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "کلیدهای خصوصی PGP، DER، PEM یا PKCS#12"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "گواهینامه‌های DER یا PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "پرونده EAP-FAST PAC فراهم نشده"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "پرونده‌های PAC شامل ‪(*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "ناشناس"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "ناشناس"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "هردو"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "هویت _ناشناس"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_پرونده PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "یک پرونده PAC انتخاب کنید"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "تأیید هویت _داخلی"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "اجازه دادن برای آ_ماده‌سازی خودکار PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "نام‌کاربری EAP-LEAP فراهم نشده"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "گذرواژه EAP-LEAP فراهم نشده"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "نام _کاربری"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152 panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_گذرواژه"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_نمایش گذرواژه"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "گواهینامه EAP-PEAP CA نامعتبر است: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "گواهینامه EAP-PEAP CA نامعتبر است: هیچ گواهینامه‌ای مشخص نشده"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "نسخه ۰"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "نسخه ۱"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "گواهینامه C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "یک گواهینامهٔ مرجع گواهینامه (CA) انتخاب کنید"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "به گواهینامه CA _نیازی نیست"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_نسخه PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "نام‌کاربری EAP فراهم نشده"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "گذرواژه EAP وارد نشده"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "شناسه EAP-TLS فراهم نشده"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "گواهینامه EAP-TLS CA نامعتبر است: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "گواهینامه EAP-TLS CA نامعتبر است: هیچ گواهینامه‌ای فراهم نشده"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "کلید خصوصی EAP-TLS نامعتبر است: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "گواهینامه کاربر EAP-TLS نامعتبر است: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "کلیدهای خصوصی رمزنگاری نشده ناامن هستند"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This could "
+"allow your security credentials to be compromised. Please select a password-"
+"protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"به‌نظر نمی‌رسد کلید خصوصی انتخاب شده با گذرواژه محافظت شده باشد. این امر ممکن است "
+"موجب به خطر افتادن اطّلاعات حساس شما شود. لطفاً یک کلید خصوصی محافظت شده با گذرواژه "
+"انتخاب کنید.\n"
+"\n"
+"(می‌توانید با openssl روی کلیدتان گذرواژه بگذارید)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "گواهینامهٔ شخصی خود را انتخاب کنید"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "کلید خصوصی خود را انتخاب کنید"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_هویت"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "گواهینامهٔ _کاربر"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_کلید خصوصی"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "گذرواژهٔ کلید _خصوصی"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "گواهینامهٔ EAP-TTLS CA نامعتبر: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "گواهینامهٔ EAP-TTLS CA نامعتبر: هیچ گواهینامه‌ای فراهم نشده"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_دامنه"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "خطای ناشناخته در تأیید اعتبار امنیت 802.1x"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "‫TLS تونل شده"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "‫EAP محافظت شده (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "تأیید_هویت"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "گزینش یک پرونده"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "گزینه leap-username فراهم نشده است"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "گذرواژه leap وارد نشده"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "گذرواژهٔ وای‌فای مفقود است."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_گونه"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "گزینه wep-key فراهم نشده است"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "گزینه wep-key نامعتبر است: کلیدی با طول %zu تنها باید شامل hex-digit باشد"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "گزینه hex-digits نامعتبر است: کلیدی با طول %zu باید شامل نویسه‌های ascii باشد"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 (ascii) "
+"or 10/26 (hex)"
+msgstr ""
+"گزینه wep-key نامعتبر: طول کلید نامعتبر %zu. یک کلید یا باید طول 5/13 (ascii) یا "
+"10/26 (hex) داشته باشد."
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "گزینه wep-key نامعتبر: عبارت‌رمز نباید خالی باشد"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "گزینه wep-key نامعتبر: عبارت‌رمز باید کمتر از ۶۴ نویسه باشد"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "۱ (پیش‌گزیده)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "سامانهٔ باز"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "کلید مشترک"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_کلید"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_نمایش کلید"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "_فهرست WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex digits"
+msgstr ""
+"گزینه wpa-psk نامعتبر: طول کلید نامعتبر %zu.باید یا [8,63] باید یا ۶۴ رقم hex باشد"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "گزینه wpa-psk نامعتبر است: نمی‌توان کلید ۶۴ بایتی را به عنوان hex تفسیر کرد"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "ا_علان‌ها"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "هشدارهای _صوتی"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "واشوهای ا_علان"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups are "
+"disabled."
+msgstr ""
+"هنگام از کار افتادن واشوها، آگاهی‌ها به ظاهر شدن در فهرست آگاهی‌ها ادامه می‌دهند."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "نمایش _محتوای پیام در واشو"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "آگاهی‌های صفحهٔ _قفل"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "نمایش م_حتوای پیام در صفحهٔ قفل"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_مزاحم نشوید"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "آگاهی‌های صفحهٔ _قفل"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "واپایش آگاهی‌های نمایش داده شده و آن‌چه نشان می‌دهند"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Banner;Message;Tray;Popup;آگاهیها;بنر;پیام;سینی;واشو;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "موارد دیگر"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s حذف شد"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "خطای برداشتن حساب"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "برگردان"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "بستن آگاهی"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "وصل شدن به داده‌هایتان در ابرواره"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "بدون اتّصال اینترنتی — برای برپایی حساب‌های برخط جدید وصل شوید"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "افزودن یک حساب"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "حساب %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "برداشتن حساب"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "حساب‌های برخط"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "به حساب‌های برخطتان وصل شده و تصمیم بگیرید از آن‌ها برای چه استفاده‌ کنید"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"گوگل;فیس بوک;تویتر;یاهو;وب;برخط;گپ;تقویم;پست‌الکترونیکی;آشنا;ownCloud;Kerberos;IMAP;"
+"SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "زمان نامعلوم"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%Ii دقیقه"
+msgstr[1] "%Ii دقیقه"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%Ii ساعت"
+msgstr[1] "%Ii ساعت"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%Ii %s %Ii %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ساعت"
+msgstr[1] "ساعت"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "دقیقه"
+msgstr[1] "دقیقه"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "‫%s تا شارژ کامل"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "هشدار: %s مانده"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s مانده"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "شارژ کامل"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "شارژ نمی‌شود"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "خالی"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "در حال شارژ شدن"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "در حال تخلیه"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "موشی بی‌سیم"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "صفحه‌کلید بی‌سیم"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "منبع تغذیهٔ غیرقابل وقفه‌اندازی"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "دستیار دیجیتال شخصی"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "تلفن‌همراه"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "پخش‌کنندهٔ رسانه"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "رایانک"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "رایانه"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "افزارهٔ ورودی بازی"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "باتری"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "اصلی"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "اضافی"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "باتری‌ها"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "هنگام _بیکاری"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "تعلیق"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "خاموش کردن"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "خواب زمستانی"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "هیچکدام"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "هنگام استفاده از باتری"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "هنگام اتّصال به برق"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "هرگز"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "تعلیق خودکار"
+
+#: panels/power/cc-power-panel.c:1033
+msgid "Performance mode temporarily disabled due to high operating temperature."
+msgstr "حالت کارایی به خاطر دمای عملیاتی بالا، به صورت موقّتی از کار افتاده."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"روی زانو: حالت کارایی به صورت موقّتی موجود نیست. برای بازیابی، افزاره را به سطحی "
+"پایدار جابه‌جا کنید."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "حالت کارایی به صورت موقّتی از کار افتاده."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when battery is "
+"sufficiently charged."
+msgstr ""
+"باتری کم: ذخیره‌ساز نیرو به کار افتاد. حالت پیشین هنگامی که باتری به قدر کافی شارژ "
+"شد، برخواهد گشت."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "حالت ذخیرهٔ نیرو به دست «%s» فعّال شد."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "حالت کارایی به دست «%s» فعّال شد."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "۱۵ دقیقه"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "۲۰ دقیقه"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "۲۵ دقیقه"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "۳۰ دقیقه"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "۴۵ دقیقه"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "۱ ساعت"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "۸۰ دقیقه"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "۹۰ دقیقه"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "۱۰۰ دقیقه"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "۲ ساعت"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "حالت انرژی"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "روی کارایی سامانه و استفادهٔ انرژی اثر می‌گذارد."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "گزینه‌های ذخیرهٔ انرژی"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "روشنایی خودکار صفحه"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "روشنایی صفحه با نور محیط هماهنگ می‌شود."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "تاریکی صفحه"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "روشنایی صفحه هنگام غیرفعّال بودن رایانه کاهش می‌یابد."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_سیاهی صفحه"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "صفحه پس از مدّتی غیرفعّال بودن، خاموش می‌شود."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "ذخیره‌ساز انرژی خودکار"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "هنگام کم بودن باتری، حالات ذخیرهٔ نیرو به کار می‌افتد."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_تعلیق خودکار"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "رایانه پس از مدّتی غیرفعّال بودن، مکث می‌شود."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "عمل دکمهٔ _خاموش"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "نمایش _درصد باتری"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "تعلیق خودکار"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_متصّل به برق"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "روی نیروی _باتری"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "تأخیر"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "کارایی"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "استفاده از انرژی و کارایی بالا."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "تعادل"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "استفاده از انرژی و کارایی استاندارد."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "ذخیرهٔ انرژی"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "استفاده از انرژی و کارایی کاهش‌یافته."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "نیرو"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "وضعیت باتری خود را دیده و تنظیمات ذخیرهٔ انرژی را تغییر دهید"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;نیرو;انرژی;خواب;تعلیق;باتری;روشنایی;تاریکی;نمایشگر;مانیتور;مونیتور;صفحه;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "چاپگر «%s» حذف شد"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "شکست در افزودن چاپگر جدید."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ناتوان در گشودن واسط کاربری: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "قفل‌گشایی برای افزودن چاپگرها و تغییر تنظیمات"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "چاپگرها"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "افزودن چاپگر، دیدن کارهای چاپگر و تصمیم برای چگونگی چاپ"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;چاپگر;صف;چاپ;کاغذ;جوهر;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28 panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "افزودن چاپگر"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118 panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_قفل‌گشایی"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "هیچ چاپگری پیدا نشد"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "یک نشانی شبکه وارد کرده یا برای چاپگر جست‌وجو کنید"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "تصدیق هویت لازم است"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr "برای دیدن چاپگرهای روی کارساز چاپ، نام‌کاربری و گذرواژه را وارد کنید."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317 panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "نام کاربری"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76 panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "جزییات %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "هیچ راه‌انداز مناسبی پیدا نشد"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "انتخاب پروندهٔ PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+msgstr "پرونده‌های تفسیری پست‌اسکریپت (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "نام‌های چاپگر نمی‌توانند شامل فاصله، جهش، # یا / باشند"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "موقعیت"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "راه‌انداز"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "جست‌وجو برای راه‌اندازهای ترجیحی…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "جست‌وجو برای راه‌اندازها"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "انتخاب از پایگاه داده…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "نصب پروندهء PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "انتخاب راه‌انداز چاپگر"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "بار کردن پایگاه دادهٔ راه‌اندازها…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "انتخاب"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "چاپگر JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "چاپگر LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "یک طرفه"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "گوشه بلند (استاندارد)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "گوشه کوتاه (معکوس)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "عمودی"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "افقی"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "افقی برعکس"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "عمودی برعکس"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "از سر گیری"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "مکث"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "معلق"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "مکث شده"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "تصدیق هویت شکست خورد"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "در حال پردازش"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "متوقف شده"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "لغو شده"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "بی‌نتیجه‌مانده"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "کامل شده"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "جابه‌جایی این کار به بالای صف"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%Iu کار نیاز به تصدیق هویت دارد"
+msgstr[1] "%Iu کار نیاز به تصدیق هویت دارند"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — کار فعّال"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "برای چاپ از %s مشخّصات را وارد کنید."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "دامنه"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_تأیید هویت"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "پاک‌سازی همه"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_تصدیق هویت"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "هیچ کار فعّالی برای چاپگر موجود نیست"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "قفل‌گشایی کارساز چاپ"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "قفل‌گشایی %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "برای مشاهدهٔ چاپگرهای روی %s نام کاربری و گذرواژه را وارد کنید."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "در حال جست‌وجو برای چاپگرها"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "درگاه سریال"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "درگاه موازی"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "موقعیت: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "نشانی: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "کارساز نیاز به تصدیق هویت دارد"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "دو طرفه"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "نوع کاغذ"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "منبع کاغذ"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "سینی خروجی"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "تفکیک‌پذیری"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "پیش‌پالایش GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "صفحه‌ها در هر طرف"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "دو طرفه"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "جهت"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "عمومی"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "تنطیمات صفحه"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "گزینه‌های قابل نصب"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "کارها"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "کیفیت تصویر"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "رنگ"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "در حال پایان"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "پیشرفته"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844 panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "صفحهٔ آزمایشی"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "صفحهٔ آزمایشی"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "انتخاب خودکار"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "پیش‌گزیده چاپگر"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "تنها توکار قراردادن قلم‌های GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "تبدیل به سطح ۱ PS"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "تبدیل به سطح ۲ PS"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "بدون پیش‌پالایش"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "تولیدکننده"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "بدون کار فعّال"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%Iu کار"
+msgstr[1] "%Iu کار"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "پاک‌سازی سرهای چاپ"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "تونر کم است"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "عدم وجود تونر"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "کمبود در سازنده"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "عدم وجود سازنده"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "کمبود ذخیره محفظه رنگ"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "عدم وجود ذخیره محفظه رنگ"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "گشودن پوشش"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "در را باز کن"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "کمبود کاغذ"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "عدم وجود کاغذ"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "برون‌خط"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743 panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "متوقف شده"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "محفظه مواد زائد تقریبا پُر است"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "محفظه مواد زائد پُر است"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "راهنمایِ نوریِ تصویر، نزدیک به اتمام است"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "راهنمای نوری تصویر، دیگر عملکردی ندارد"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "آماده"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "کاری قبول نمی‌کند"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "در حال پردازش"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "گزینه‌های چاپ"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "جزییات چاپگر"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "استفاده از چاپگر به صورت پیش‌گزیده"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "پاک‌سازی سرهای چاپ"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "برداشتن چاپگر"
+
+#: panels/printers/printer-entry.ui:183 panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "مدل"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "سطح جوهر"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "لطفاً پس از رفع مشکل، دوباره آغاز کنید."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "آغاز دوباره"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "افزودن چاپگر…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "هیچ چاپگری نیست"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"متأسّفانه به نظر می‌رسد خدمت چاپ\n"
+"   سامانه در دسترس نیست."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "قالب‌ها"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "جست‌وجوی موقعیت‌ها…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "قالب‌های معمول"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "تمام قالب‌ها"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "بدون نتایج جست‌وجو"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "جست‌وجوها می‌توانند برای کشورها یا زبان‌ها باشند."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "پیش‌نمایش"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "امپریال"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "متریک"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "تاریخ‌ها"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "تاریخ‌ها و زمان‌ها"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "عددها"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "اندازه‌گیری"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "کاغذ"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "زبان و قالب پس از ورود بعدی تغییر خواهند کرد"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "خروج…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are used "
+"for numbers, dates, and currencies."
+msgstr ""
+"تنظیمات زبان برای متن‌ها و صفحه‌های وب استفاده می‌شود. قالب‌ها برای عددها، تاریخ‌ها و "
+"ارزها استفاده می‌شود."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "حسابتان"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_زبان"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_قالب‌ها"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "صفحهٔ ورود"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "ناحیه و زبان"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "گزینش قالب‌ها و زبان نمایشیتان"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "زبان;چیدمان;صفحه‌کلید؛ورودی;Language;Layout;Keyboard;Input;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "بپرس چه باید کرد"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "کاری نکن"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "گشودن پوشه"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "رسانه‌های دیگر"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "یک برنامه‌ برای پخش سی‌دی‌های صوتی انتخاب کن"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "یک برنامه‌ برای پخش دی‌وی‌دی‌های ویدیویی انتخاب کن"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "یک برنامه برای اجرا جهت زمانی که یک پخش‌کننده موسیقی متّصل می‌شود، انتخاب کنید"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "یک برنامه برای اجرا جهت زمانی که یک دوربین متّصل می‌شود، انتخاب کنید"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "یک برنامه‌ برای سی‌دی‌های نرم‌افزار انتخاب کن"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "دی‌وی‌دی صوتی"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "دیسک بلو-ری خالی"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "دیسک سی‌دی خالی"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "دیسک دی‌وی‌دی خالی"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "دیسک دی‌وی‌دی اچ‌دی خالی"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "دیسک ویدیویی بلو-ری خالی"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "کتاب الکترونیکی خوان"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "دیسک ویدیویی دی‌وی‌دی اچ‌دی"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "سی‌دی تصویر"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "سی‌دی ویدئویی برتر"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "سی‌دی ویدیویی"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "نرم‌افزار ویندوزی"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "نرم‌افزار ویندوزی"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "سی‌دی _صوتی"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_دی‌وی‌دی ویدیویی"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "پخش‌کنندهٔ _آهنگ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_نرم‌افزار"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "دیگر _رسانه‌ها…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_عدم پرسش یا شروع برنامه‌ها هنگام ورود رسانه"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "انتخاب شیوهٔ رفتار با دیگر رسانه‌ها"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_کنش:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_نوع:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "رسانه‌های جداشدنی"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "پیکربندی تنظیمات رسانه‌های جداشدنی"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;"
+"media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;"
+"media;autorun;دستگاه;افزاره;سامانه;سیستم;اطّلاعات;حافظه;پردازشگر;نسخه;پیش‌گزیده;"
+"برنامه;یدکی;ترجیح‌شده;سی‌دی;دی‌وی‌دی;یواس‌بی;صوت;ویدئو;دیسک;قابل حذف;رسانه;اجرا خودکار;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "خاموش شدن صفحه"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "۳۰ ثانیه"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "۱ دقیقه"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "۲ دقیقه"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "۳ دقیقه"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "۵ دقیقه"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "۳۰ دقیقه"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "۱ ساعت"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "۱ دقیقه"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "۲ دقیقه"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "۳ دقیقه"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "۴ دقیقه"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "۵ دقیقه"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "۸ دقیقه"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "۱۰ دقیقه"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "۱۲ دقیقه"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "۱۵ دقیقه"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "هرگز"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "قفل صفحه"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer while "
+"you're away."
+msgstr "قفل خودکار صفحه از دسترسی دیگران به رایانه هنگام نبودنتان جلوگیری می‌کند."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "تأخیر صفحهٔ خالی"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "دورهٔ غیرفعّال بودنی که پس از آن صفحه سیاه خواهد شد."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_قفل صفحهٔ خودکار"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "تأخیر _قفل صفحهٔ خودکار"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "دورهٔ پس از سیاه شدن صفحه که پس از آن صفحه به صورت خودکار قفل خواهد شد."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "نمایش _آگاهی‌ها روی صفحهٔ قفل"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "ممنوعیت افزاره‌های _یواس‌بی جدید"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is locked."
+msgstr "جلوگیری از افزاره‌های یواس‌بی جدید برای تعامل با سامانه هنگام قفل بودن صفحه."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "محرمانگی صفحه"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "محدودیت زاویهٔ دید"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "تنظیمات صفحه"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;صفحه;نمایش;خصوصی;محرمانگی;حریم شخصی;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "گزینش مکان"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_تأیید"
+
+#: panels/search/cc-search-locations-dialog.ui:8 panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "جست‌وجوی مکان‌ها"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"شاخه‌هایی که توسّط برنامه‌های سامانه‌ای مانند پرونده‌ها، عکس‌ها و ویدیوها جست‌وجو می‌شوند."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "مکان‌ها"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "نشانک‌ها"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "دیگران"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "افزودن مکان"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "هیچ برنامه‌ای پیدا نشد"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "جست‌وجوی برنامه"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "شامل نتیجه‌های جست‌وجوی فراهم شده به دست برنامه‌ها."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "شاخه‌هایی که به دست برنامه‌های سامانه‌ای جست‌وجو می‌شوند."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "نتایج جست‌وجو"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "نتیجه‌ها با توجّه به ترتیب سیاهه نمایش داده شده‌اند."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid "Control which applications show search results in the Activities Overview"
+msgstr "واپایش برنامه‌های کاربردی‌ای که در نمای کلّی فعّالیت‌ها، نتیجه نشان می‌دهند"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Find;Index;Hide;Privacy;Results;جست‌وجو;پیدا;فهرست;مخفی; حریم خصوصی;محرمانگی;"
+"نتایج;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "هیچ شبکه‌ای برای هم‌رسانی انتخاب نشده"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "شبکه‌ها"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "روشن"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "خاموش"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "فعَال"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "فعّال"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "گزینش یک شاخه"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "افزودن"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "به کار انداختن هم‌رسانی رسانه"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your current "
+"network using: %s"
+msgstr ""
+"هم‌رسانی پرونده، می‌گذارد شاخهٔ عمومیتان را با استفاده از این پیوند روی شبکهٔ جاریتان "
+"با دیگران هم‌رسانی کنید: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure Shell "
+"command:\n"
+"%s"
+msgstr ""
+"هنگام به کار افتادن ورود دوردست، کاربران دوردست می‌توانند با استفاده از این فرمان "
+"پوستهٔ امن متّصل شوند:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "به کار انداختن هم‌رسانی رسانهٔ شخصی"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "نام افزاره رونوشت شد"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "نشانی افزاره رونوشت شد"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "نام کاربری رونوشت شد"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "گذرواژه رونوشت شد"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "هم‌رسانی"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "نام _رایانه"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "هم‌رسانی _پرونده"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_میزکار دوردست"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "هم‌رسانی _رسانه"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "ورود  _دوردست"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "هم‌رسانی پرونده"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "گذرواژه _لازم است"
+
+#: panels/sharing/cc-sharing-panel.ui:195 panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "ورود دوردست"
+
+#: panels/sharing/cc-sharing-panel.ui:251 panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "میزکار دوردست"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another computer."
+msgstr "میزکار دوردست می‌گذارد میزکارتان را از رایانه‌ای دیگر دیده و واپایش کنید."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "به یا از کار انداختن اتّصال‌های میزکار دوردست به این رایانه."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "واپایش دوردست"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "اجازه به اتّصال‌ها برای واپایش صفحه."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "چگونگی وصل شدن"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid "Connect to this computer using the device name or remote desktop address."
+msgstr "وصل شدن به این رایانه با استفاده از نام افزاره یا نشانی میزکار دوردست."
+
+#: panels/sharing/cc-sharing-panel.ui:318 panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372 panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "رونوشت"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "نشانی میزکار دوردست"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "تأیید هویت"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "برای وصل شدن به این رایانه نیاز به نام کاربری و گذرواژه است."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "نام کاربری"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "تأیید رمزنگاری"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "اثر انگشت رمزنگاری"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr "اثرانگشت رمزنگاری می‌تواند در کارخواه‌های وصل شده دیده شود و باید یکتا باشد."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "هم‌رسانی رسانه"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "هم‌رسانی آهنگ‌ها، عکس‌ها و ویدیوها روی شبکه."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "پوشه‌ها"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "واپایش چیزهایی که می‌خواهید با دیگران هم‌رسانی کنید"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;هم‌رسانی;اشتراک;میزبان;نام;دور;میزکار;ریانه;صدا;آهنگ;ویدیو;"
+"فیلم;عکس;تصویر;کارساز;سرور;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "به یا از کار انداختن ورود دوردست"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "برای به یا از کار انداختن ورود دوردست، تأیید هویت لازم است"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "سفارشی"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "کلیک"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "فنر"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "تاب"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "هوم"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "تعادل"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "محوی"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "عقب"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "جلو"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "آزمودن %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "برای آزمون، روی بلندگویی کلیک کنید"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "حجم صدای سامانه"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "حجم اصلی"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "سطوح حجم صدا"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "خروجی"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "افزارهٔ خروجی"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "آزمایش"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "پیکربندی"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "ساب ووفر"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "ورودی"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "افزارهٔ ورودی"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "حجم صدا"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "صدای هشدار"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "۱۰۰٪"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "بی‌صدا"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "صدا"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "تغییر بلندی صدا، ورودی‌ها، خروجی‌ها و رویدادهای صوتی"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;کارت;"
+"میکروفون;بلندی صدا;محو شدن;بالانس;بلوتوث;گوشی;صوت;صدا;ورودی;خروجی;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "قطع شده"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "در حال وصل شدن"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "متّصل"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "شکست در تصدیق هویت"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "در حال تأیید"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "عملکرد کاسته‌شده"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "وصل و تصدیق هویت شده"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "ناشناخته"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "تأیید شده در:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "وصل شده در:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "ثبت شده در:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "شکست در تصدیق افزاره: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "شکست در فراموشی افزاره: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "وابسته به %Iu افزارهٔ دیگر"
+msgstr[1] "وابسته به %Iu افزارهٔ دیگر"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "بستن آگاهی"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "نام:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "وضعیت:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "شناسهٔ یکتا:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "تصدیق و اتّصال"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "فراموشی افزاره"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "خطا"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "تصدیق هویت شده"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr "زیرسامانهٔ تاندربولت (boltd) نصب یا به درستی پیکربندی نشده است."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425 panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"به افزاره‌هایی نظیر داک‌ها و شتاب‌دهنده‌های گرافیکی خارجی، اجازهٔ دسترسی مستقیم می‌دهد."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "فقط افزاره‌های یواس‌بی و دیسپلی‌پورت می‌توانند وصل شوند."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the BIOS or "
+"is set to an unsupported security level in the BIOS."
+msgstr ""
+"تاندربولت تشخیص داده نشد.\n"
+"یا سامانه فاقد پشتیبانی تاندربولت است، یا در بایوس از کار افتاده یا روی سطح امنیتی "
+"پشتیبانی نشده‌ای تنظیم شده."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "پشتیبانی تاندربولت در بایوس از کار افتاده است."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "نمی‌توان سطح امنیتی تاندربولت را تعیین کرد."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "خطا در تعویض حالت مستقیم: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "بدون پشتیبانی تاندربولت"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "نتوانست به زیرسامانهٔ تاندربولت وصل شود."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "دسترسی مستقیم"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "افزاره‌های در انتظار"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "هیچ افزاره‌ای وصل نشده"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "تاندربولت"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "مدیریت افزاره‌های تاندربولت"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;Privacy;تاندربولت;محرمانگی;حریم شخصی;حریم خصوصی;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "چشمک‌زدن مکان‌نما"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "مکان‌نما در جعبه‌های متنی چشمک می‌زند."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "سرعت"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "سرعت چشمک زدن مکان‌نما"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "اندازهٔ نشانگر"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid "Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "اندازهٔ نشانگر می‌تواند با بزرگنمایی ترکیب شده تا دیدن نشانگر را راحت‌تر کند."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "همکار کلیک"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "کلیک دومین _شبیه‌سازی شده"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "راه‌انداختن کلیک دوم با نگاه داشتن کلید اصلی"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "وقفه _پذیرش:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "کوتاه"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "وقفه کلیک دوم"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "بلند"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "کلیک _شناور"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "راه‌انداختن یک کلیک در زمان شناور شدن نشانگر"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "تأ_خیر:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "کوتاه"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "بلند"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "آ_ستانهٔ حرکت:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "کوچک"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "بزرگ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "تکرار کلیدها"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "تکرار کلید وقتی کلید فشرده نگه داشته شود."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "سرعت تکرار کلیدها"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "سرعت تکرار کلیدها"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "همکار تایپ"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "کلیدهای _چسبان"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "برخورد با رشته‌ای از کلیدهای تغییردهنده به عنوان یک کلید ترکیبی"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_از کار افتادن در صورت فشردن همزمان دو کلید با هم"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "هنگام فشرده شدن یک کلید _تغییر‌دهنده بوق زده شود"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "کلیدهای آ_هسته"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "یک وقفه بین زمان فشردن کلید تا زمان پذیرفتن آن قرار می‌دهد"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "کوتاه"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "وقفه تایپ کلیدهای آرام"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "بلند"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "هنگام _فشرده شدن یک کلید بوق بزن"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "هنگام _پذیرفتن کلید، بوق بزن"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "هنگام _نپذیرفتن یک کلید بوق بزن"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "کلید‌های _پرشی"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "نادیده گرفتن دوبار فشرده شدن یک کلید، در زمان کوتاه"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "کوتاه"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "وقفه بین کلیدها جهشی"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "بلند"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_‌به کار اندازی با صفحه‌کلید"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "روشن و خاموش کردن امکانات دسترسی‌پذیری از طریق صفحه‌کلید"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "پیش‌گزیده"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "متوسّط"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "بزرگ"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "بزرگ‌تر"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "بزرگ‌ترین"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%Id نقطه"
+msgstr[1] "%Id نقطه"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "نمایش _همیشگی فهرست دسترسی‌پذیری"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "بینایی"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_سایه‌روشن بالا"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "متن _بزرگ"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "به کار انداختن _پویانمایی‌ها"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_صفحه‌خوان"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "صفحه‌نمایش خوان همینطور که شما تمرکز را تغییر می‌دهید، متن‌ها را می‌خواند."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_کلیدهای صوتی"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "هنگامی که قفل اعداد و قفل تبدیل روشن است، بوق بزن."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "_اندازهٔ نشانگر"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_بزرگ‌نمایی"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "شنوایی"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "خطاهای _دیداری"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_صفحه‌کلید مجازی"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_تکرار کلیدها"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "چشمک‌زدن _نشانگر"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "همیار _تایپ (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "نشانه و کلیک"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "کلید‌های _موشی"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "مکان‌یابی _اشاره‌گر"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_همیار کلیک"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_تأخیر دوبار کلیک"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "تأخیر دوبار کلیک"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "خطاهای دیداری"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "آزمایشِ _خاموش روشن"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "نمایش یک نشانهٔ تصویری، هنگامی که یک هشدار صوتی رخ می‌دهد."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "درخشش لحظه‌ای تمام _صفحه"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "درخشش لحظه‌ای تمام _پنجره"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "کوتاه"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ صفحه‌نمایش"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ صفحه‌نمایش"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ صفحه‌نمایش"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "بلند"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "تمام صفحه"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "نیمهٔ بالایی"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "نیمهٔ پایینی"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "نیمهٔ چپ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "نیمهٔ راست"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "گزینه‌های بزرگ‌نمایی"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_درشت‌نمایی:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "مکان ذره‌بین:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_تعقیب نشانگر موشی"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "بخش _صفحه:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "ذره‌بین تا خارج از صفحه‌نمایش _گسترش می‌یابد"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "نشانگر ذره‌بین را در مرکز _نگه‌دار"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "نشان‌گر ذره‌بین محتویات را به اطراف _هل می‌دهد"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "نشان‌گر ذره‌بین با _محتویات حرکت می‌کند"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "ذره‌بین"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_ضربدرها:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_همپوشانی بر روی نشانگر موشی"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_ضخامت:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "کوتاه"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "ضخیم"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_طول:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "ر_نگ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "ضربدرها"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "جلوه‌های رنگی:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_سفید روی سیاه:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_روشنایی:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "سایه _روشن:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "ر_نگ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "هیچ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "پُر"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "کم"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "بالا"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "کم"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "بالا"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "جلوه‌های رنگی"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "ساده‌تر کردن دیدن، شنیدن، نوشتن، نشانه‌روی و کلیک"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;Zoom;"
+"Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+"animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;Zoom;"
+"Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+"animations;صفحه‌کلید;موشی;دسترسی‌پذیری;سایه روشن;نشانگر;صدا;بزرگ‌نمایی;صفحه‌نمایش خوان;"
+"متن;قلم;اندازه;کلیدهای چسبان;کلیدهای آرام;کلیدهای پرشی;کلیدهای موشی;چشمک;سرعت;"
+"بینایی;شنوایی;صدا;تایپ;نوشتن;پویانمای‌ها;انیمیشن‌ها;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "۱ ساعت"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "۱ روز"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "۲ روز"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "۳ روز"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "۴ روز"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "۵ روز"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "۶ روز"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "۷ روز"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "۱۴ روز"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "۳۰ روز"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "تمام موارد از زباله‌دان تخلیه شوند؟"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "تمام موارد موجود در زباله‌دان برای همیشه پاک می‌شوند."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_خالی کردن زباله‌دان"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "حذف تمام پرونده‌های موقت؟"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "تمام پرونده‌های موقت برای همیشه حذف خواهند شد."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_پاکسازی پرونده‌های موقت"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "۱ روز"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "۷ روز"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "۳۰ روز"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "برای همیشه"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "تاریخچهٔ پرونده"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you might want "
+"to use."
+msgstr ""
+"تاریخچهٔ پرونده، گزارشی از پرونده‌هایی که استفاده کرده‌اید نگه می‌دارد. این اطّلاعات "
+"بین برنامه‌ها هم‌رسانی شده و یافتن پرونده‌هایی که ممکن است بخواهید استفاده کنید را "
+"آسان‌تر می‌کند."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "_تاریخچهٔ پرونده"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "مدّت تاریخچهٔ پرونده"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_پاک‌سازی تاریخچه…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "پرونده‌های موقّتی و زباله‌دان"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive information. "
+"Automatically deleting them can help to protect privacy."
+msgstr ""
+"پرونده‌های موقّت و زباله‌دان گاهی می‌توانند شامل داده‌های حسّاس یا شخصی باشند. حذف "
+"خودکارشان می‌تواند به حفاظت از محرمانگی کمک کند."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "حذف خودکار محتویات _زباله‌دان"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "حذف خودکار _پرونده‌های موقت"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_دورهٔ حذف خودکار"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_خالی کردن زباله‌دان…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_حذف پرونده‌های موقت…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "تاریخچهٔ پرونده و زباله‌دان"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "برجا نگذاشتن اثر"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"استفاده;مصرف;اخیر;تاریخچه;پرونده‌ها;موقتی;خصوصی;محرمانگی;حریم شخصی;زباله‌دان;آشغال;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "باید با آدرس اینترنتی فراهم‌کننده‌ٔ حساب شما یکسان باشد."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "افزودن حساب شکست خورد"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "گذرواژه‌ها برابر نیستند."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "ثبت حساب شکست خورد"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "هیچ راه پیشتیبانی شده‌ای برای تصدیق‌هویت با این دامنه وجود ندارد"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "پیوستن به دامنه شکست خورد"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"نام ورود کار نکرد.\n"
+"لطفاً دوباره تلاش کنید."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"گذواژهٔ ورود کار نکرد.\n"
+"لطفاً دوباره تلاش کنید."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "ورود به دامنه شکست خورد"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "ناتوان در یافتن دامنه. شاید اشتباه نوشته‌اید؟"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "افزودن کاربر"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "مدیر"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for all "
+"users. Parental controls cannot be applied to administrators."
+msgstr ""
+"مدیران می‌توانند دیگر کاربران را افزوده، برداشته و تنظیمات همهٔ کاربران را تغییر "
+"دهند. واپایش‌های والدین نمی‌توانند به مدیران اعمال شوند."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "کاربران گذرواژه را در نخستین ورود تنظیم می‌کنند"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "تنظیم گذرواژه هم‌اکنون"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "تأیید"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "ورود تجاری"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "حساب‌های کاربری که به دست یک شرکت یا سازمان مدیریت می‌شوند."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "شما برون‌خط هستید"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be used on "
+"this device. You can also use this account to access company resources on the "
+"internet."
+msgstr ""
+"ورود تجاری می‌گذارد حساب کاربری مدیریت شدهٔ متمرکزی در این افزاره استفاده شود. "
+"همچنین از این حساب می‌توان برای دسترسی به منابع شرکت در اینترنت استفاده کرد."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "مرور برای عکس‌های بیشتر"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "گزینش پرونده…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "ورود با اثر انگشت"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "اثر انگشت"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_نه"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_بله"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"مایلید تمام اثرانگشت‌های ثبت شده را حذف کنید تا ورود با اثرانگشت از کار بیفتد؟"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "افزارهٔ اثر انگشتی نیست"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "افزارهٔ اثر انگشتی نیست"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "مطمين شوید افزاره به درستی وصل شده."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "افزارهٔ اثر انگشت"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "افزارهٔ اثر انگشتی را که می‌خواهید پیکربندی کنید برگزینید"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "ورود با اثر انگشت"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your finger"
+msgstr ""
+"ورود با اثر انگشت می‌گذارد با اثر انگشتتان، رایانه را قفل‌گشایی کرده و به آن وارد "
+"شوید"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_حذف اثرانگشت‌ها"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "ثبت اثر انگشت"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "پیش از انجام این کنش،‌ افزاره باید درخواست شود"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "افزاره به دست فرایندی دیگر درخواست شده است"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "اجازهٔ انجام این کنش را ندارید"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "هیچ اثر انگشتی ثبت نشده"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "شکست در ارتباط با افزاره هنگام ثبت"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "شکست در ارتباط با خوانندهٔ اثر انگشت"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "شکست در ارتباط با خدمت اثر انگشت"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "شکست در فهرست اثر انگشت‌ها: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "شکست در حذف اثر انگشت‌های ذخیره‌شده: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "شصت چپ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "انگشت وسط چپ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "انگشت اشاره _چپ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "انگشت حلقه چپ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "انگشت کوچک چپ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "شصت راست"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "انگشت وسط راست"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "انگشت اشاره _راست"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "انگشت حلقه راست"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "انگشت کوچک راست"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "اثر انگشت نامشخّص"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "تمام"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "افزارهٔ اثر انگشت قطع شد"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "فضای ذخیرهٔ افزارهٔ اثر انگشتتان پر است"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "شکست در ثبت اثر انگشت جدید"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "شکست در آغاز ثبت: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "شکست در ثبت اثر انگشت جدید"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "شکست در توقّف ثبت: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your fingerprint"
+msgstr "برایثبت انگشتتان، چند بار بلندش کرده و روی حسگر بگذارید"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "ثبت _دوبارهٔ این انگشت…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "پویش اثر انگشت جدید"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "شکست در آزاد کردن افزارهٔ اثر انگشت %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "مشکل در خواندن از افزاره"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "شکست در درخواست افزارهٔ اثر انگشت %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "شکست در گرفتن افزارهٔ اثر انگشت: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "این هفته"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "هفتهٔ پیش"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%Oe %B"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%Oe %B، %OY"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%OH:%OM"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s، %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "نشست پایان یافت"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "نشست آغاز شد"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — فعّالیت حساب"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "پیشین"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "بعدی"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "لطفاً گذرواژهٔ دیگری انتخاب کنید."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "لطفاً گذرواژهٔ فعلی خود را دوباره وارد کنید."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "گذرواژه قابل تغییر نبود"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "تغییر گذرواژه"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "تع_ویض"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "گذرواژهٔ کنونی"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "گذرواژهٔ جدید"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "تأیید گذرواژه"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "اجازه می‌دهد تا کاربران در زمان ورود بعدی گذرواژه خود را تغییر دهند"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "هم‌اکنون یک گذرواژه تنظیم کنید"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "نمی‌توان به‌طور خودکار به این نوع از دامنه پیوست"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "چنین دامنه یا محدوده‌ای پیدا نشد"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "نمی توان به عنوان %s وارد دامنهٔ %s شد"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "گذرواژهٔ نادرست، لطفاً دوباره تلاش کنید"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "نمی‌توان به دامنهٔ %s وصل شد: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "شکست در حذف کاربر"
+
+#: panels/user-accounts/cc-user-panel.c:413 panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "شکست در لغو دسترسی کاربرِ مدیریت شده از راه دور"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "شما نمی‌توانید حساب خودتان را حذف کنید."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "کاربر %s هم‌چنان وارد است"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an inconsistent "
+"state."
+msgstr ""
+"حذف یک کاربر در حالی که وارد بودن ممکن است سامانه را در حالتی متناقض قرار دهد."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "می‌خواهید پرونده‌های «%s» را نگه دارید؟"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files around "
+"when deleting a user account."
+msgstr ""
+"هنگام حذف یک حساب کاربری، نگهداری از شاخه خانه، رایانامه و پرونده‌های موقتش "
+"امکان‌پذیر است."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_حذف پرونده‌ها"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_نگه‌داری پرونده‌ها"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "مطمئنید که می‌خواهید دسترسی حساب مدیریت از راه دور %s را لغو کنید؟"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_حذف"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "حساب از کار افتاد"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "در ورود بعدی تنظیم می‌شود"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "هیچ"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "وارد شده"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "ارتباط با سرویس حساب شکست خورد"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "لطفاً مطمئن شوید که AccountService نصب و به کار افتاده است."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "برای تغییر این تنظیمات باید قفل این تابلو گشوده باشد"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "حذف حساب کاربر انتخاب شده"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"برای حذف حساب کاربر انتخاب شده،\n"
+"ابتدا بر روی شمایل * کلیک کنید"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "قفل‌گشایی برای افزودن کاربران و تغییر تنظیمات"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "کاربرها"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "لازم است نشست شما مجددا راه‌اندازی شود تا تغییرات اعمال شوند"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "اکنون راه‌اندازی مجدد کن"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "بستن"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "ویرایش چهرک"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "نام کامل"
+
+#: panels/user-accounts/cc-user-panel.ui:171 panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "ویرایش"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "ورود با اثر _انگشت"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "ورود _خودکار"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "فعّالیت حساب"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_مدیر"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for all "
+"users."
+msgstr ""
+"مدیران می‌توانند دیگر کاربران را افزوده، برداشته و تنظیمات همهٔ کاربران را تغییر "
+"دهند."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "واپایش‌های _والدین"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "گشودن برنامهٔ واپایش‌های والدین."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "حذف کاربر…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "دیگر کاربران"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "افزودن کاربر…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "هیچ کاربری پیدا نشد"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "برای افزودن حساب کاربری، قفل‌گشایی کنید."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "افزودن یا برداشتنن کاربرها و تعویض گذرواژه‌تان"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen Time;App "
+"Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen Time;App "
+"Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;ورود;نام;اثر انگشت;چهرک;"
+"آواتار;لوگو;نشنان;صورت;گذرواژه;رمز;محدودیت;والدین;زمان;وب;کاره;استفاده;بچه;کودک;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_ثبت"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "ورود مدیر دامنه"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"بری استفاده از ورود سازمانی، لازم است این رایانه\n"
+"در دامنه ثبت‌شده باشد. لطفاً از مدیر شبکه‌تان بخواهید\n"
+"گذرواژه‌اش را اینجا بنویسد."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_نام مدیر"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "گذرواژه مدیر"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "مدیریت حساب‌های کاربر"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "جهت تغییر اطّلاعات کاربر تصدیق‌هویت لازم است"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "لازم گذرواژهٔ جدید با گذرواژهٔ قبلی تفاوت داشته باشد."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "سعی کنید تعداد بیشتری از اعداد و حروف را عوض کنید."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "سعی کنید گذرواژه را کمی بیشتر تغییر دهید."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "یک گذرواژه بدون استفاده از نام کاربری قوی‌تر خواهد بود."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "سعی کنید از استفاده از نام خود در گذرواژه خودداری کنید."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "سعی کنید از تعدادی از کلمه‌های موجود در گذرواژه خودداری کنید."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "سعی کنید از انتخاب کلمه‌های عمومی خودداری کنید."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "سعی کنید از تغییر چینش کلمه‌های موجود خودداری کنید."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "سعی کنید تعداد بیشتری عدد استفاده کنید."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "سعی کنید تعداد بیشتری حروف بزرگ استفاده کنید."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "سعی کنید تعداد بیشتری حروف کوچک استفاده کنید."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "سعی کنید از تعداد بیشتری نویسه خاص، مثل نقطه‌گذاری‌ها استفاده کنید."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "سعی کنید از تلفیق تعدادی حرف، عدد و نقطه‌گذاری استفاده کنید."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "سعی کنید از تکرار یک نویسه خودداری کنید."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up letters, "
+"numbers and punctuation."
+msgstr ""
+"سعی کنید از تکرار یک نوع نویسه خودداری کنید: شما باید تلفیقی از حروف، اعداد و "
+"نقطه‌گذاری‌ها را بکار ببرید."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "سعی کنید از رشته‌های متوالی مثل ۱۲۳۴ یا abcd استفاده نکنید."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and punctuation."
+msgstr "گذرواژه‌ها باید بلندتر باشند. تلاش کنید حروف، اعداد و علائم بیش‌تری بیفزایید."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "حروف بزرگ و کوچک را ادغام کنید و از یک یا چند عدد هم استفاده کنید."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid "Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "افزودن حروف، اعداد و علائم بیش‌تر، گذرواژه را قوی‌تر می‌کند."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "تصدیق شکست خورد"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "گذرواژه خیلی کوتاه است"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "گذرواژه خیلی ساده است"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "گذرواژه‌های قدیمی و جدید خیلی شبیه هم هستند"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "گذرواژهٔ جدید تازگی مورد استفاده قرار گرفته است."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "گذرواژهٔ جدید باید شامل اعداد و نویسه‌های خاص باشد"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "گذرواژه‌های قدیمی و جدید همانند هستند"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "گذرواژه شما از زمانی تأیید هویت شده‌اید، تغییر کرده است!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "گذرواژهٔ جدید به اندازه کافی شامل نویسه‌های متفاوت نیست"
+
+#: panels/user-accounts/run-passwd.c:514 panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "خطای ناشناخته"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, digits "
+"and the following characters: - _"
+msgstr ""
+"نام کاربری تنها باید شامل حرف کوچک در بازهٔ a-z، رقم‌ها و نویسه‌های مقابل باشد: . - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "متأسفیم، نام‌کاربری انتخاب شده در دسترس نیست. لطفاً نامی دیگر را امتحان کنید."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "نام کاربری خیلی بلند است."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "نگاشت کلیدها"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "نگاشت دکمه‌ها به عملکردها"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"برای ویرایش یک میان‌بر، کنش «ارسال ضربهٔ کلید» را انتخاب کنید، دکمهٔ کلید میان‌بر را "
+"فشار دهید و کلیدهای جدید را بگیرید یا اینکه کلید پس‌بر را برای پاک‌سازی فشار دهید."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_بستن"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the tablet."
+msgstr "به محض ظاهر شدن نشانه‌ها روی نمایشگر، رویشان زده تا رایانک واسنجی شود."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "کلیک اشتباهی شناسایی شد، شروع دوباره…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "دکمهٔ %Id"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "تعریف شده با برنامه"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "ارسال ضربه کلید"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "تعویض نمایشگر"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "نمایش راهنمای روی-صفحه"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "رایانک سوار شده روی تابلوی لپ‌تاپ"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "رایانک سوار شده روی نمایشگر خارجی"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "افزارهٔ رایانک خارجی"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "افزارهٔ صفحهٔ خارجی"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "تمامی نمایشگرها"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "حالت رایانک"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "استفاده از موقعیت‌یابی صریح برای قلم"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "جهت دست چپ"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "رایانک و دکمه‌های اکسپرس™ برای استفاده با دست چپ چرخیده‌اند"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "نگاشت به نمایشگر"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "نگه داشتن نسبت ابعاد"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "استفاده از فقط بخشی از سطح رایانک برای نگه داشتن نسبت ابعاد نمایشگر"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "واسنجی"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "هیچ رایانگی پیدا نشد"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "لطفاً رایانک وکومتان را روشن یا وصل کنید."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "حساسیت فشار ضربه"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21 panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "نرم"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "فشار سر قلم"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41 panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "سفت"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "دکمهٔ ۱"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "دکمهٔ ۲"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "دکمهٔ ۳"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "حساسیت فشار پاک‌کن"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "فشار پاک‌کن"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "کلیک دکمه وسط موشی"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "کلیک دکمه راست موشی"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "جلو"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "قلم ایربراش با فشار، شیب و لغزندهٔ یکپارچه"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "قلم ایربراش با فشار، شیب و چرخش"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "قلم استاندارد با فشار و شیب"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "قلم استاندارد با فشار"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "رایانک وکوم"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "تنظیم هدایت کلیدها و تنظیم حساسیت قلم برای رایانک‌های گرافیکی"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;رایانک;تبلت;Wa­com;استایلوس;پاک‌کن;موشی;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "میان‌بر جدید…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "نقطه‌های دسترسی"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "ای‌پی‌ان"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "عملیات لغو شد"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>خطا:</b> دسترسی به تغییر تنظیمات رد شد"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>خطا:</b> خطای تجهیزات همراه"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "ثبت نشده"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "ثبت‌شده"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "فراگردی"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "جست‌وجو کردن"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "ردشده"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "جزییات مودم"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "وضعیت مودم"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "اپراتور"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "گونهٔ شبکه"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "وضعیت شبکه"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "شمارهٔ شخصی"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "جزییات افزاره"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "نگارش ثابت‌افزار"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "فقط نسل ۲"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "فقط نسل ۳"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "فقط نسل ۴"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "فقط نسل ۵"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "نسل ۲، ۳، ۴ و ۵ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "نسل ۲، ۳، ۴ (ترجیحی) و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "نسل ۲، ۳ (ترجیحی)، ۴ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "نسل ۲ (ترجیحی)، ۳، ۴ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "نسل ۲، ۳، ۴ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "نسل ۲، ۳ و ۴ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "نسل ۲، ۳ (ترجیحی) و ۴"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "نسل ۲ (ترجیحی)، ۳ و ۴"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "نسل ۲، ۳ و ۴"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "نسل ۳، ۴ و ۵ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "نسل ۳، ۴ (ترجیحی) و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "نسل ۳ (ترجیحی)، ۴ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "نسل ۳، ۴ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "نسل ۲، ۴ و ۵ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "نسل ۲، ۴ (ترجیحی) و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "نسل ۲ (ترجیحی)، ۴ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "نسل ۲، ۴ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "نسل ۲، ۳ و ۵ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "نسل ۲، ۳ (ترجیحی) و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "نسل ۲ (ترجیحی)، ۳ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "نسل ۲، ۳ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "نسل ۳ و ۴ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "نسل ۳ (ترجیحی) و ۴"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "نسل ۳ و ۴"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "نسل ۲ و ۴ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "نسل ۲ (ترجیحی) و ۴"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "نسل ۲ و ۴"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "نسل ۲ و ۳ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "نسل ۲ (ترجیحی) و ۳"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "نسل ۲ و ۳"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "نسل ۲ و ۵ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "نسل ۲ (ترجیحی) و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "نسل ۲ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "نسل ۳ و ۵ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "نسل ۳ (ترجیحی) و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "نسل ۳ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "نسل ۴ و ۵ (ترجیحی)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "نسل ۴ (ترجیحی) و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "نسل ۴ و ۵"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "نامعلوم"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "قفل‌گشای سیم‌کارت"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "قفل‌گشایی"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "لطفاً رمز پین برای سیم‌کارت %Id را وارد کنید"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "برای قفل‌گشایی از سیم‌کارتتان، پین را وارد کنید"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "لطفاً رمز پوک برای سیم‌کارت %Id را وارد کنید"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "برای قفل‌گشایی از سیم‌کارتتان، پوک را وارد کنید"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "گذرواژهٔ اشتباه وارد شد. %1$u تلاش مانده"
+msgstr[1] "گذرواژهٔ اشتباه وارد شد. %1$u تلاش مانده"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "%1$u تلاش مانده"
+msgstr[1] "%1$u تلاش مانده"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "گذرواژهٔ اشتباه وارد شد."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "رمز پوک باید عددی ۸ رقمی باشد"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "پین جدید را وارد کنید"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "رمز پین باید عددی ۴ تا ۸ رقمی باشد"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "قفل‌گشایی…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "بدون سیم‌کارت"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "برای استفاده از این موردم، سیم‌کارتی وارد کنید"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "سیم‌کارت قفل شد"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "دادهٔ _همراه"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "دسترسی به داده با استفاده از شبکهٔ همراه"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "فراگردی _داده"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "استفاده از دادهٔ همراه هنگام فراگردی"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "گونهٔ _شبکه"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "ش_بکه"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "پیش‌رفته"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "نام‌های نقطهٔ دسترسی"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "قفل _سیم‌کارت"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "قفل سیم‌کارت با پین"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "جزییات مو_دم"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "شکست تلفن"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "بدون اتّصال به تلفن"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "عملیات مجاز نیست"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "عملیات پشتیبانی نمی‌شود"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "سیم‌کارت وارد نشده"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "نیازمند پین سیم‌کارت"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "نیازمند پوک سیم‌کارت"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "شکست سیم‌کارت"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "سیم‌کارت اشغال"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "گذرواژهٔ نادرست"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "نیازمند پین۲ سیم‌کارت"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "نیازمند پوک۲ سیم‌کارت"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "پیدا نشد"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "بدون خدمت شبکه"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "اتمام زمان شبکه"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "خدمت جی‌پی‌آراس مجاز نیست"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "فراگردی در این ناحیهٔ مکانی مجاز نیست"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "خطای نامشخّص جی‌پی‌آراس"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "بدون خطا"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "کنش لغو شد"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "دسترسی رد شد"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "خطای ناشناخته"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "گونهٔ شبکه"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_خودکار"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "گزینش شبکه"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "تازه‌سازی فراهم‌کنندگان شبکه"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "سیم‌کارت %Id"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "به کار اندازی شبکهٔ همراه"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "هیچ سازوارگر شبکهٔ گستردهٔ بی‌سیمی پیدا نشد"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "مطمئن شوید یک افزارهٔ سلولی یا شبکهٔ گستردهٔ بی‌سیم دارید"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "شبکهٔ گستردهٔ بی‌سیم، هنگام روشن بودن حالت هواپیما از کار می‌افتد"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_خاموش کردن حالت هواپیما"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "اتّصال داده"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "سیم‌کارت استفاده شده برای اینترنت"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "قفل سیم"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_بعدی"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_قفل سیم‌کارت با پین"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "تغییر پین"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "برای تغییر تنظیمات سیم‌کارت، پین کنونی را وارد کنید"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "شبکهٔ همراه"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "پیکربندی اتّصال‌های دادهٔ همراه و تلفن"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;wwan;telephony;sim;mobile;موبایل;تلفن;همراه;سیم‌کارت;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "ابزاری برای پیکربندی میزکار گنوم"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "تنظیمات، واسط اصلی برای پیکربندی سامانه‌تان است."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "پروژهٔ گنوم"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "نمایش شمارهٔ نگارش"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "به کار انداختن حالت پرگو"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "جست‌وجو برای رشته"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "نام تابلوهای ممکن را فهرست کن و خارج شو"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "تابلو برای نمایش"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "دسته‌های تنظیمات"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "محرمانگی"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "تابلوهای موجود:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "تمام تنظیمات"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "فهرست اصلی"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "هشدار: نگارش در حال توسعه"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You may "
+"experience incorrect system behavior, data loss, and other unexpected issues. "
+msgstr ""
+"این نگارش از تنظیمات باید فقط برای مقاصد توسعه استفاده شود. ممکن است با رفتار "
+"نادرست سامانه، از دست رفتن داده یا دیگر مشکلات غیرمنتظره برخورد کنید. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "راهنما"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "عمومی"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "خروج"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "جست‌وجو"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "تابلوها"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "برگشت به تابلوی پیشین"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "لغو جست‌وجو"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;ترجیحات;تنظیمات;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "برگشت به تابلوی پیشین"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values will "
+"be ignored and the first panel in the list selected."
+msgstr ""
+"شناسهٔ آخرین تابلوی تنظیمات برای گشودن. مقادیر ناشناخته درنظر گرفته نشده و نخستین "
+"تابلو در فهرست گزیده خواهد شد."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "نمایش هشدار هنگام اجرای یک ساخت در حال توسعه از تنظیمات"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid "Whether Settings should show a warning when running a development build."
+msgstr "تنظیمات آب‌وهوا باید هنگام اجرای یک ساخت در حال توسعه، هشداری نشان دهد."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "وضعیت اولیه پنجره"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr "یک چندتایی شامل پهنا، درازا و بیشینهٔ وضعیت پنجرهٔ برنامه است."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%Iu خروجی"
+msgstr[1] "%Iu خروجی"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%Iu ورودی"
+msgstr[1] "%Iu ورودی"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "صداهای سامانه"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "خطا: ناتوان در تشخیص سطح HSI."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "خطا: ناتوان در تشخیص سطح HSI نادرست."
+
+#~ msgid "Add a Printer…"
+#~ msgstr "افزودن یک چاپگر…"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "گواهینامه‌های DER یا PEM شامل ‪(*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Drip"
+#~ msgstr "چکّه"
+
+#~ msgid "Glass"
+#~ msgstr "شیشه"
+
+#~ msgid "Sonar"
+#~ msgstr "سونار"
+
+#~ msgid "Take screenshots of application windows and the desktop."
+#~ msgstr "ضبط نماگرفت از میزکار و پنجره‌های برنامه."
+
+#~ msgid "No Protection"
+#~ msgstr "بدون محافظت"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "محافظت کمینه"
+
+#~ msgid "Basic Protection"
+#~ msgstr "محافظت پایه‌ای"
+
+#~ msgid "Extended Protection"
+#~ msgstr "محافظت گسترده"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "محافظت‌های امنیتی کمینه"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "محافظت‌های امنیتی پایه"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "محافظت‌های امنیتی گسترده"
+
+#~ msgid "SPI write"
+#~ msgstr "نوشتن SPI"
+
+#~ msgid "SPI lock"
+#~ msgstr "قفل SPI"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "ناحیهٔ بایوس SPI"
+
+#~ msgid "Pre-boot DMA protection is"
+#~ msgstr "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "کرنل آلوده شده"
+
+#~ msgid "Suspend-to-ram"
+#~ msgstr "تعلیق به حافظه"
+
+#~ msgid "All TPM PCRs are"
+#~ msgstr "تمامی PCRهای TPM"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "حالت ساخت موتور مدیریت اینتل"
+
+#~ msgid "MEI override"
+#~ msgstr "رونویسی موتور مدیریت اینتل"
+
+#~ msgid "MEI version"
+#~ msgstr "نگارش موتور مدیریت اینتل"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "افزایه‌های fwupd"
+
+#~ msgid "Intel DCI debugger"
+#~ msgstr "اشکال‌زدای واسط اتّصال مستقیم (DCI) اینتل"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "محافظت افزارهٔ IOMMU به کار افتاده"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "محافظت افزارهٔ IOMMU از کار افتاده"
+
+#~ msgid "Kernel is no longer tainted"
+#~ msgstr "کرنل دیگر آلوده نیست"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "کرنل آلوده شده است"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "قرنطینهٔ کرنل از کار افتاده"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "قرنطینهٔ کرنل به کار افتاده"
+
+#~ msgid "Pre-boot DMA protection is disabled"
+#~ msgstr "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی از کار افتاده"
+
+#~ msgid "Pre-boot DMA protection is enabled"
+#~ msgstr "محافظت از دسترسی مستقیم به حافظه (DMA) پیش از راه‌اندازی به کار افتاده"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "راه‌اندازی امن از کار افتاده"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "راه‌اندازی امن به کار افتاده"
+
+#~ msgid "All TPM PCRs are valid"
+#~ msgstr "تمامی PCRهای TPM معتبرند"
+
+#~ msgid "All TPM PCRs are now valid"
+#~ msgstr "تمامی PCRهای TPM اکنون معتبرند"
+
+#~ msgid "A TPM PCR is now an invalid value"
+#~ msgstr "یکی از PCRهای TPM مقدار نامعتبری دارد"
+
+#~ msgid "TPM PCR0 reconstruction is invalid"
+#~ msgstr "بازسازی PCR صفر TPM نامعتبر است"
+
+#~ msgid "Lock your screen"
+#~ msgstr "قفل صفحه‌تان"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "آرایش نمایشگر"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "راه‌اندازی امن غیرفعّال است"
+
+#~ msgid "Light"
+#~ msgstr "روشن"
+
+#~ msgid "Set"
+#~ msgstr "تنظیم"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
+#~ "identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
+#~ "identity;صفحه;قفل;کرش;خصوصی;اخیر;موقت;نمایه;نام;شبکه;هویت;"
+
+#~ msgid "Bark"
+#~ msgstr "پارس"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "تابلوی صدای تنظیمات گنوم"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "تابلوی موشی و صفحه‌لمسی تنظیمات گنوم"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "تابلوی پس‌زمینهٔ تنظیمات گنوم"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "تابلوی صفحه‌کلید تنظیمات گنوم"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "تصدیق هویت"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by connecting "
+#~ "to %s"
+#~ msgstr ""
+#~ "هم‌رسانی صفحه به کاربران دوردست اجازه می‌دهد تا صفحه‌نمایشتان را با وصل شدن به این "
+#~ "پیوند واپایش کنند: %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "هم‌رسانی _صفحه"
+
+#~ msgid "_Password:"
+#~ msgstr "_گذرواژه:"
+
+#~ msgid "_Show Password"
+#~ msgstr "نمایش _گذرواژه"
+
+#~ msgid "Access Options"
+#~ msgstr "گزینه‌های دسترسی"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "اتّصال‌های _جدید باید برای دسترسی اجازه بگیرند"
+
+#~ msgid "_Require a password"
+#~ msgstr "گذرواژه _لازم است"
+
+#~ msgid "More Warm"
+#~ msgstr "گرم‌تر"
+
+#~ msgid "Less Warm"
+#~ msgstr "سردتر"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "ذخیرهٔ یک نماگرفت در $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "ذخیرهٔ نماگرفت از یک پنجره در $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "ذخیرهٔ نماگرفت از یک محدوده در $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "رونوشت یک نماگرفت در حافظه"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "رونوشت نماگرفتی از یک پنجره در حافظه"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "رونوشت نماگرفتی از یک محدوده در حافظه"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "ضبط فیلم از نمایشگر"
+
+#~ msgid "Move up"
+#~ msgstr "جابه‌جایی به بالا"
+
+#~ msgid "Move down"
+#~ msgstr "جابه‌جایی به پایین"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "اجازه به برنامه‌های زیر برای استفاده از میکروفونتان."
+
+#~ msgid "%s VPN"
+#~ msgstr "وی‌پی‌ان %s"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect on "
+#~ "next login."
+#~ msgstr ""
+#~ "قالب عددها، تاریخ‌ها و ارزها را برگزینید. تغییرات در ورود بعدی اعمال می‌شوند."
+
+#~ msgid "My Account"
+#~ msgstr "حسابم"
+
+#~ msgid "Language"
+#~ msgstr "زبان"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "زبان استفاده‌شده برای متن در پنجره‌ها و صفحه‌های وب."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "برای اعمال تغییرات، نشست را دوباره آغاز کنید"
+
+#~ msgid "Restart…"
+#~ msgstr "آغاز دوباره…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "تنظیمات ورود، به دست تمام کاربران هنگام ورود به سامانه استفاده می‌شود"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The order of "
+#~ "search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "واپایش نتایج جست‌وجویی که در نمای کلّی فعّالیت‌ها، نتیجه نشان داده می‌شوند. ترتیب "
+#~ "نتایج جست‌وجو نیز می‌تواند با جابه‌جایی ردیف‌ها در فهرست تغییر کند."
+
+#~ msgid "Standard"
+#~ msgstr "استاندارد"
+
+#~ msgid "Account _Type"
+#~ msgstr "_گونهٔ حساب"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "می‌گذارد کاربر هنگام _ورود بعدی، گذرواژه‌ای برگزینند"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_هم‌اکنون گذرواژه‌ای تنظیم کنید"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "برای ایجاد کاربران سازمانی، باید برخط باشید."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "عکس گرفتن…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "برای ایجاد تغییرات،\n"
+#~ "ابتدا بر روی نقشک * کلیک کنید"
+
+#~ msgid "Create a user account"
+#~ msgstr "ساخت یک حساب کاربری"
+
+#~ msgid "User Icon"
+#~ msgstr "شمایل کاربر"
+
+#~ msgid "Account Settings"
+#~ msgstr "تنظیمات حساب"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "تأیید هویت و ورود"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "این نام برای نام‌گذاری پوشه خانگی شما استفاده می‌شود و قابل تغییر نیست."
+
+#~ msgid "Output:"
+#~ msgstr "خروجی:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "نگاشت به تک‌نمایشگره"
+
+#~ msgid "%d of %d"
+#~ msgstr "%Id از %Id"
+
+#~ msgid "Display Mapping"
+#~ msgstr "نگاشت نمایشگر"
+
+#~ msgid "Stylus"
+#~ msgstr "استایلوس"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "تبلت (مطلق)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "صفحه‌لمسی (وابسته)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "ترجیحات تبلت"
+
+#~ msgid "_Help"
+#~ msgstr "_راهنما"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "تنظیمات بلوتوث"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "حالت ردیابی"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "نگاشت کلیدها…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "تنظیم تنظیمات موشی"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "تنظیم تفکیک‌پذیری نمایشگر"
+
+#~ msgid "Decouple Display"
+#~ msgstr "ناجفت کردن _نمایشگرها"
+
+#~ msgid "No stylus found"
+#~ msgstr "هیچ استایلوسی پیدا نشد"
+
+#~ msgid "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "لطفاً برای پیکربندی، استایلوستان را به مجاورت تبلت ببرید"
+
+#~ msgid "Top Button"
+#~ msgstr "دکمه بالایی"
+
+#~ msgid "Lower Button"
+#~ msgstr "دکمه پایینی"
+
+#~ msgid "Lowest Button"
+#~ msgstr "پایین‌ترین دکمه"
+
+#~ msgid "Web Links"
+#~ msgstr "پیوندهای وب"
+
+#~ msgid "Git Links"
+#~ msgstr "پیوندهای گیت"
+
+#~ msgid "%s Links"
+#~ msgstr "پیوندهای %s"
+
+#~ msgid "Unset"
+#~ msgstr "ناتنظیم"
+
+#~ msgid "Links"
+#~ msgstr "پیوندها"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "پرونده‌های ابرمتنی"
+
+#~ msgid "Text Files"
+#~ msgstr "پرونده‌های متنی"
+
+#~ msgid "Image Files"
+#~ msgstr "پرونده‌های تصویری"
+
+#~ msgid "Font Files"
+#~ msgstr "پرونده‌های قلم"
+
+#~ msgid "Archive Files"
+#~ msgstr "پرونده‌های بایگانی"
+
+#~ msgid "Package Files"
+#~ msgstr "پرونده‌های بسته"
+
+#~ msgid "Audio Files"
+#~ msgstr "پرونده‌های صوتی"
+
+#~ msgid "Video Files"
+#~ msgstr "پرونده‌های ویدیویی"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "اجازه‌ها و دسترسی"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions that it "
+#~ "requires."
+#~ msgstr ""
+#~ "داده‌ها و خدماتی که این کاره برای دسترسی به آن‌ها درخواست کرده و اجازه‌هایی که "
+#~ "نیاز دارد."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "قابل تغییر نیست"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "اجازه‌های تکّی برای برنامه‌ها می‌توانند در تنظیمات <a href=\"privacy\">محرمانگی</a> "
+#~ "بازبینی شوند."
+
+#~ msgid "Integration"
+#~ msgstr "یکپارچگی"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "تنظیم پس‌زمینهٔ میزکار"
+
+#~ msgid "Default Handlers"
+#~ msgstr "گرداننده‌های پیش‌گزیده"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "گونه‌های پرونده‌ها و پیوندهایی که این برنامه می‌گشاید."
+
+#~ msgid "Usage"
+#~ msgstr "استفاده"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "مقدار منابع مورد استفادهٔ این برنامه."
+
+#~ msgid "Open in Software"
+#~ msgstr "_گشودن در نرم‌افزارها"
+
+#~ msgid "Display Mode"
+#~ msgstr "نوع نمایشگر"
+
+#~ msgid "Join Displays"
+#~ msgstr "پیوند نمایشگرها"
+
+#~ msgid "Single Display"
+#~ msgstr "نمایشگر تکی"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to change "
+#~ "its settings."
+#~ msgstr ""
+#~ "نمایشگرها را برای تطبیق با وضعیت واقعی بکشید. برای تغییر تنظیمات یک نمایشگر، "
+#~ "برگزینیدش."
+
+#~ msgid "Active Display"
+#~ msgstr "نمایشگر فعّال"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "اجازه به برنامه‌های زیر برای استفاده از دوربینتان."
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi and "
+#~ "mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "خدمات مکان‌یابی می‌گذارند برنامه‌ها مکانتان را بدانند. استفاده از Wi-Fi یا پهن‌باند "
+#~ "همراه، دقّت را افزایش می‌دهد."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/"
+#~ "privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "از خدمات مکان‌یابی موزیلا استفاده می‌کند: <a href='https://location.services."
+#~ "mozilla.com/privacy'>سیاست محرمانگی</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "اجازه به برنامه‌های زیر برای تشخیص مکانتان."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "تشخیص پا: حالت کارایی موجود نیست"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "دمای سخت‌افزار بالا: حالت کارایی موجود نیست"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "حالت کارایی موجود نیست"
+
+#~ msgid "Activities"
+#~ msgstr "فعّالیت‌ها"
+
+#~ msgid "_Copy"
+#~ msgstr "_رونوشت"
+
+#~ msgid "Select _All"
+#~ msgstr "گزینش _همه"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "پایان زمان دوبار کلیک"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "دکمهٔ تعلیق و روشن"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "تعدادی از خدمت‌ها به‌دلیل در دسترس نبودن شبکه، از کار افتاده‌اند."
+
+#~ msgid "Sound Keys"
+#~ msgstr "کلید‌های صدا"
+
+#~ msgid "Screen Reader"
+#~ msgstr "صفحه‌خوان"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_صفحه‌خوان"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "بارگذاری پرونده شکست خورد: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "نمایه بارگذاری شد روی:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "این آدرس را یادداشت کنید."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "شروع دوبارهٔ این رایانه و راه‌اندازی سیستم‌عامل عادیتان."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "برای بارگیری و نصب نمایه، نشانی را در مرورگرتان بنویسید."
+
+#~ msgid "Upload profile"
+#~ msgstr "بارگذاری نمایه"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "به اتّصال اینترنت احتیاج دارد"
+
+#~ msgid "Unlocking..."
+#~ msgstr "گشودن قفل…"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;نام ورود;نام;اثرانگشت;آواتار;"
+#~ "نشان;تصویرصورت;گذرواژه;"
+
+#~ msgid "Phone-adaptor link reserved"
+#~ msgstr "پیوند سازوارگر تلفن محفوظ است"
+
+#~ msgid "PH-SIM PIN required"
+#~ msgstr "نیازمند پین PH-SIM"
+
+#~ msgid "PH-FSIM PIN required"
+#~ msgstr "نیازمند پین PH-FSIM"
+
+#~ msgid "PH-FSIM PUK required"
+#~ msgstr "نیازمند پوک PH-FSIM"
+
+#~ msgid "Memory full"
+#~ msgstr "حافظه پر"
+
+#~ msgid "Memory failure"
+#~ msgstr "شکست حافظه"
+
+#~ msgid "Network not allowed - emergency calls only"
+#~ msgstr "شبکه مجاز نیست - فقط تماس‌های اضطراری"
+
+#~ msgid "Network personalization PIN required"
+#~ msgstr "نیازمند پین فردی‌سازی شبکه"
+
+#~ msgid "Network personalization PUK required"
+#~ msgstr "نیازمند پوک فردی‌سازی شبکه"
+
+#~ msgid "Network subset personalization PIN required"
+#~ msgstr "نیازمند پین فردی‌سازی زیرمجموعهٔ شبکه"
+
+#~ msgid "Network subset personalization PUK required"
+#~ msgstr "نیازمند پوک فردی‌سازی زیرمجموعهٔ شبکه"
+
+#~ msgid "Service provider personalization PIN required"
+#~ msgstr "نیازمند پین فردی‌سازی فراهم‌کنندهٔ خدمت"
+
+#~ msgid "Service provider personalization PUK required"
+#~ msgstr "نیازمند پوک فردی‌سازی فراهم‌کنندهٔ خدمت"
+
+#~ msgid "Corporate personalization PIN required"
+#~ msgstr "نیازمند پین فردی‌سازی شرکتی"
+
+#~ msgid "Corporate personalization PUK required"
+#~ msgstr "نیازمند پوک فردی‌سازی شرکتی"
+
+#~ msgid "Illegal MS"
+#~ msgstr "ام‌اس غیرقانونی"
+
+#~ msgid "Illegal ME"
+#~ msgstr "ام‌ای غیرقانونی"
+
+#~ msgid "PLMN not allowed"
+#~ msgstr "PLMN مجاز نیست"
+
+#~ msgid "Location area not allowed"
+#~ msgstr "ناحیهٔ مکانی مجاز نیست"
+
+#~ msgid "Service option not supported"
+#~ msgstr "گزینهٔ خدمت پشتیبانی نمی‌شود"
+
+#~ msgid "Requested service option not subscribed"
+#~ msgstr "مشترک گزینهٔ خدمت درخواستی نیست"
+
+#~ msgid "Service option temporarily out of order"
+#~ msgstr "گزینهٔ خدمت به طور موقّتی خارج از دسترس است"
+
+#~ msgid "PDP authentication failure"
+#~ msgstr "شکست تآیید هویت پی‌دی‌پی"
+
+#~ msgid "Invalid mobile class"
+#~ msgstr "کلاس همراه نامعتبر"
+
+#~ msgid "Balanced Power"
+#~ msgstr "تعادل انرژی"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "روشنایی _صفحه"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "روشنایی _صفحه‌کلید"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "کم‌نور کردن صفحه هنگام بیکاری"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "صفحه _خالی"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_وای‌فای"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "برای ذخیرهٔ نیرو می‌توان وای‌فای را خاموش کرد."
+
+#~ msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr "برای ذخیرهٔ نیرو می‌توان پهن‌باند همراه (3G، 4G، LTE و...) را خاموش کرد."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_بلوتوث"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "برای ذخیرهٔ نیرو می‌توان بلوتوث را خاموش کرد."
+
+#~ msgid "Add…"
+#~ msgstr "افزودن…"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "میان‌بر صفحه‌کلید"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "می‌تواند در میان‌برهای سفارشی تغییر کند"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "برای ورود نویسه‌های مختلف، نگه داشته و تایپ کنید"
+
+#~ msgid "View current processes and monitor system state"
+#~ msgstr "دیدن فرایند‌های جاری و پایش حالت سامانه"
+
+#~ msgid ""
+#~ "Monitor;System;Process;CPU;Memory;Network;History;Usage;Performance;Task;"
+#~ "Manager;Activity;"
+#~ msgstr ""
+#~ "Monitor;System;Process;CPU;Memory;Network;History;Usage;Performance;Task;"
+#~ "Manager;Activity;پایش;سامانه;پردازش;حافظه;شبکه;تاریخچه;استفاده;CPU;کارایی;"
+#~ "مدیریت;وظایف;"
+
+#~ msgid "GNOME System Monitor"
+#~ msgstr "پایشگر سامانه‌ٔ گنوم"
+
+#~ msgid "Monitor;System;Process;CPU;Memory;Network;History;Usage;"
+#~ msgstr ""
+#~ "Monitor;System;Process;CPU;Memory;Network;History;Usage;نمایشگر;سامانه;پردازش;"
+#~ "حافظه;شبکه;تاریخچه;استفاده;"
+
+#~ msgid "View and manage system resources"
+#~ msgstr "نمایش و مدیریت منابع سامانه"
+
+#~ msgid ""
+#~ "System Monitor is a process viewer and system monitor with an attractive, easy-"
+#~ "to-use interface."
+#~ msgstr ""
+#~ "پایشگر سامانه، یک نمایشگر فرایندها و یک پایشگر سامانه، با یک واسط کاربری جذاب و "
+#~ "ساده است."
+
+#~ msgid ""
+#~ "System Monitor can help you find out what applications are using the processor "
+#~ "or the memory of your computer, can manage the running applications, force stop "
+#~ "processes not responding, and change the state or priority of existing "
+#~ "processes."
+#~ msgstr ""
+#~ "پایشگر سامانه این امکان را می‌دهد که بفهمید چه برنامه‌هایی در حال استفاده از "
+#~ "پردازشگر یا حافظهٔ رایانه‌تانند، بتوانید برنامه‌های درحال اجرا را مدیریت کرده، "
+#~ "فرایندهای ناپاسخگو را مجبور به توقف کنید و الویت یا وضعیت فرایندهای موجود را "
+#~ "تغییر دهید."
+
+#~ msgid ""
+#~ "The resource graphs feature shows you a quick overview of what is going on with "
+#~ "your computer displaying recent network, memory and processor usage."
+#~ msgstr ""
+#~ "امکان نمایش نمودار منابع‌، نمایی کلی از آن‌چه روی رایانه‌تان رخ می‌دهد را با نمایش "
+#~ "میزان استفاده از شبکه، حافظه و پردازشگر، به شما می‌دهد."
+
+#~ msgid "Process list view"
+#~ msgstr "نمای فهرست پردازش"
+
+#~ msgid "Resources overview"
+#~ msgstr "نمای‌کلی منابع"
+
+#~ msgid "File Systems view"
+#~ msgstr "نمای سامانه پرونده‌ها"
+
+#~ msgid "Privileges are required to control other users’ processes"
+#~ msgstr "برای واپایش فرایند‌های سایر کاربران نیاز به دسترسی است"
+
+#~ msgid "Renice process"
+#~ msgstr "نایس دوباره فرایند"
+
+#~ msgid "Privileges are required to change the priority of processes"
+#~ msgstr "برای تغییر اولویت فرایندها نیاز به دسترسی است"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Show help"
+#~ msgstr "نمایش راهنما"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Show Processes"
+#~ msgstr "نمایش فرایندها"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Show Resources"
+#~ msgstr "نمایش منبع‌ها"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Show File Systems"
+#~ msgstr "نمایش سامانه‌های پرونده"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Processes"
+#~ msgstr "فرایند‌ها"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Show dependencies"
+#~ msgstr "نمایش وابستگی‌ها"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Show process properties"
+#~ msgstr "نمایش ترجیحات فرایند"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Memory maps"
+#~ msgstr "نگاشت‌های حافظه"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Send stop signal"
+#~ msgstr "فرستادن پیام توقّف"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Send continue signal"
+#~ msgstr "فرستادن پیام ادامه"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Send End signal"
+#~ msgstr "فرستادن پیام پایان"
+
+#~ msgctxt "shortcut window"
+#~ msgid "Send Kill signal"
+#~ msgstr "فرستادن پیام کشتن"
+
+#~ msgid "_End Process"
+#~ msgid_plural "_End Processes"
+#~ msgstr[0] "_پایان فرایند"
+#~ msgstr[1] "_پایان فرایندها"
+
+#~ msgid "Show process properties"
+#~ msgstr "نمایش ترجیحات فرایند"
+
+#~ msgid "CPU"
+#~ msgstr "پردازنده"
+
+#~ msgid "Swap"
+#~ msgstr "مبادله"
+
+#~ msgid "Memory and Swap"
+#~ msgstr "حافظه و مبادله"
+
+#~ msgid "Receiving"
+#~ msgstr "دریافتی"
+
+#~ msgid "Total Received"
+#~ msgstr "کل دریافت"
+
+#~ msgid "Total Sent"
+#~ msgstr "کل ارسال"
+
+#~ msgid "Resources"
+#~ msgstr "منابع"
+
+#~ msgid "Filter files by name"
+#~ msgstr "پالایش پرونده‌ها با نام"
+
+#~ msgid "Case insensitive"
+#~ msgstr "غیرحساس به بزرگی و کوچکی"
+
+#~ msgctxt "Menu item to Open Search for Open Files dialog"
+#~ msgid "Search for Open Files"
+#~ msgstr "جست‌وجو برای پرونده‌های باز"
+
+#~ msgid "About System Monitor"
+#~ msgstr "دربارهٔ پایشگر سامانه"
+
+#~ msgid "_Refresh"
+#~ msgstr "_تازه‌سازی"
+
+#~ msgid "A_ll Processes"
+#~ msgstr "_تمام فرایند‌ها"
+
+#~ msgid "M_y Processes"
+#~ msgstr "فرایند‌های _من"
+
+#~ msgid "Show _Dependencies"
+#~ msgstr "نمایش _وابستگی‌ها"
+
+#~ msgid "_Properties"
+#~ msgstr "_ترجیحات"
+
+#~ msgid "_Memory Maps"
+#~ msgstr "نگاشت‌های _حافظه"
+
+#~ msgid "_Change Priority"
+#~ msgstr "_تغییر اولویت"
+
+#~ msgid "Very High"
+#~ msgstr "خیلی زیاد"
+
+#~ msgid "Very Low"
+#~ msgstr "خیلی کم"
+
+#~ msgid "Set _Affinity"
+#~ msgstr "تنظیم _خویشاوندی"
+
+#~ msgid "_Stop"
+#~ msgstr "_توقّف"
+
+#~ msgid "_Continue"
+#~ msgstr "_ادامه‌"
+
+#~ msgid "_End"
+#~ msgstr "_پایان"
+
+#~ msgid "_Kill"
+#~ msgstr "_کشتن"
+
+#~ msgid "Behavior"
+#~ msgstr "رفتار"
+
+#~ msgid "_Update Interval in Seconds"
+#~ msgstr "دورهٔ به‌روز رسانی به ثانیه"
+
+#~ msgid "Enable _Smooth Refresh"
+#~ msgstr "به کار انداختن تازه‌سازی _نرم"
+
+#~ msgid "Alert Before Ending or _Killing Processes"
+#~ msgstr "اخطار پیش از پایان یا _کشتن فرایند‌ها"
+
+#~ msgid "_Divide CPU Usage by CPU Count"
+#~ msgstr "_تقسیم استفاده بر تعداد پردازنده"
+
+#~ msgid "Show Memory in IEC"
+#~ msgstr "نمایش حافظه در IEC"
+
+#~ msgid "Process information shown in list:"
+#~ msgstr "اطّلاعات فرایند نمایشی در فهرست:"
+
+#~ msgid "_Update Interval in Seconds:"
+#~ msgstr "_دورهٔ به‌روز رسانی به ثانیه:"
+
+#~ msgid "_Chart Data Points:"
+#~ msgstr "نقطه‌های دادهٔ _نمودار:"
+
+#~ msgid "_Draw CPU Chart as Stacked Area Chart"
+#~ msgstr "_رسم نمودار پردازنده به شکل پشته‌ای"
+
+#~ msgid "Draw Charts as S_mooth Graphs"
+#~ msgstr "رسم نمودار پردازنده به شکل _نرم"
+
+#~ msgid "Show Memory and Swap in IEC"
+#~ msgstr "نمایش حافظه و مبادله در IEC"
+
+#~ msgid "Show Memory in Logarithmic Scale"
+#~ msgstr "نمایش حافظه در مقیاس لگاریتمی"
+
+#~ msgid "_Show Network Speed in Bits"
+#~ msgstr "_نمایش سرعت شبکه برحسب بیت"
+
+#~ msgid "Set Network Totals _Unit Separately"
+#~ msgstr "تنظیم _واحد مجموع شبکه به صورت جداگانه"
+
+#~ msgid "Show Network _Totals in Bits"
+#~ msgstr "نمایش مجموع شبکه بر حسب بیت"
+
+#~ msgid "Show _All File Systems"
+#~ msgstr "نمایش _تمام سامانه‌‌های پرونده"
+
+#~ msgid "File system information shown in list:"
+#~ msgstr "اطّلاعات نمایشی سامانه پرونده در فهرست:"
+
+#~ msgid "Change _Priority"
+#~ msgstr "تغییر _اولویت"
+
+#~ msgid "_Nice value:"
+#~ msgstr "مقدار _نایس:"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> The priority of a process is given by its nice value. A "
+#~ "lower nice value corresponds to a higher priority.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>نکته:</b> اولویت یک فرایند با مقدار نایس آن تعیین می‌شود. هرچه "
+#~ "میزان نایس پایین‌تر باشد، الویت بیشتری دارد.</i></small>"
+
+#~ msgid "A simple process and system monitor."
+#~ msgstr "یک پایشگر‌ سادهٔ فرایند و شبکه."
+
+#~ msgid "Show the Resources tab"
+#~ msgstr "نمایش زبانهٔ منابع"
+
+#~ msgid "Show the File Systems tab"
+#~ msgstr "نمایش زبانهٔ سامانه پرونده‌ها"
+
+#~ msgid "Total"
+#~ msgstr "مجموع"
+
+#~ msgid "Free"
+#~ msgstr "آزاد"
+
+#~ msgid "Pick a Color for “%s”"
+#~ msgstr "رنگی برای «%s» برگزینید"
+
+#~ msgid "CPU%d"
+#~ msgstr "پردازندهٔ %Id"
+
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "آرش موسوی <mousavi.arash@gmail.com>\n"
+#~ "دانیال بهزادی <dani.behzi@ubuntu.com>\n"
+#~ "مهیار مقیمی <mahyar.moqimi@gmail.com>\n"
+#~ "روزبه پورنادر <roozbeh@sharif.edu>"
+
+#~ msgid "?"
+#~ msgstr "؟"
+
+#~ msgid "Today %l∶%M %p"
+#~ msgstr "امروز %Ol:%OM %p"
+
+#~ msgid "Percentage full for pie color pickers"
+#~ msgstr "درصد پُر برای گزینشگر رنگ‌ها"
+
+#~ msgid "Title"
+#~ msgstr "عنوان"
+
+#~ msgid "The title of the color selection dialog"
+#~ msgstr "عنوان محاورهٔ گزینش رنگ"
+
+#~ msgid "Pick a Color"
+#~ msgstr "رنگی برگزینید"
+
+#~ msgid "Current Color"
+#~ msgstr "رنگ کنونی"
+
+#~ msgid "The selected color"
+#~ msgstr "رنگ گزیده"
+
+#~ msgid "Type of color picker"
+#~ msgstr "گونهٔ گزینشگر رنگ"
+
+#~ msgid "Received invalid color data\n"
+#~ msgstr "دریافت داده‌ٔ رنگ نامعتبر\n"
+
+#~ msgid "Click to set graph colors"
+#~ msgstr "کلیک برای تنظیم رنگ‌های نمودار"
+
+#~ msgid "%u hr"
+#~ msgid_plural "%u hrs"
+#~ msgstr[0] "%Iu س"
+#~ msgstr[1] "%Iu س"
+
+#~ msgid "%u sec"
+#~ msgid_plural "%u secs"
+#~ msgstr[0] "%Iu ثانیه"
+#~ msgstr[1] "%Iu ثانیه"
+
+#~ msgid "%s (%.1f%%) of %s"
+#~ msgstr "%s (٪%I.1f) %s"
+
+#~ msgid "%d matching open file"
+#~ msgid_plural "%d matching open files"
+#~ msgstr[0] "%Id پروندهٔ باز مطابق"
+#~ msgstr[1] "%Id پروندهٔ باز مطابق"
+
+#~ msgid "VM Start"
+#~ msgstr "آغاز حافظهٔ مجازی"
+
+#~ msgid "VM End"
+#~ msgstr "پایان حافظهٔ مجازی"
+
+#~ msgid "VM Size"
+#~ msgstr "اندازهٔ حافظهٔ مجازی"
+
+#~ msgid "Flags"
+#~ msgstr "پرچم‌ها"
+
+#~ msgid "VM Offset"
+#~ msgstr "جابه‌جایی حافظهٔ مجازی"
+
+#~ msgid "Private dirty"
+#~ msgstr "حافظهٔ خصوصی کثیف"
+
+#~ msgid "Shared clean"
+#~ msgstr "حافظهٔ اشتراکی پاک"
+
+#~ msgid "Shared dirty"
+#~ msgstr "حافظهٔ اشتراکی کثیف"
+
+#~ msgid "Inode"
+#~ msgstr "آی‌نود"
+
+#~ msgid "Memory Maps"
+#~ msgstr "نگاشت‌های حافظه"
+
+#~ msgid "_Memory maps for process “%s” (PID %u):"
+#~ msgstr "_نگاشت حافظه برای فرایند «%s» (شناسه %Iu):"
+
+#~ msgid "pipe"
+#~ msgstr "لوله‌"
+
+#~ msgid "IPv4 network connection"
+#~ msgstr "اتصال‌های شبکهٔ IPv4"
+
+#~ msgid "local socket"
+#~ msgstr "سوکت محلی"
+
+#~ msgid "unknown type"
+#~ msgstr "گونهٔ ناشناخته"
+
+#~ msgid "FD"
+#~ msgstr "FD"
+
+#~ msgid "_Files opened by process “%s” (PID %u):"
+#~ msgstr "_پرونده‌های گشوده با فرایند «%s» (شناسه %Iu):"
+
+#~ msgid "Main window size and position in the form (width, height, xpos, ypos)"
+#~ msgstr "اندازه و مکان پنجرهٔ اصلی در شکل (width, height, xpos, ypos)"
+
+#~ msgid "Main Window should open maximized"
+#~ msgstr "پنجرهٔ اصلی باید در حالت بیشینه باز شود"
+
+#~ msgid "Show process dependencies in tree form"
+#~ msgstr "نمایش وابستگی‌های فرایند به شکل درختی"
+
+#~ msgid "Solaris mode for CPU percentage"
+#~ msgstr "حالت سولاریس برای درصد پردازنده"
+
+#~ msgid ""
+#~ "If TRUE, system-monitor operates in “Solaris mode” where a task’s CPU usage is "
+#~ "divided by the total number of CPUs. Otherwise, it operates in “Irix mode”."
+#~ msgstr ""
+#~ "اگر درست باشد، پایشگر سامانه در «حالت سولاریس» اجرا می‌شود که در آن مصرف "
+#~ "پردازندهٔ یک تکلیف، بر تعداد کل پردازنده‌ها تقسیم می‌شود. در غیر این‌صورت در «حالت "
+#~ "ایریکس» عمل می‌کند."
+
+#~ msgid "Enable/Disable smooth refresh"
+#~ msgstr "به/از کار انداختن تازه‌سازی نرم"
+
+#~ msgid "Show warning dialog when killing processes"
+#~ msgstr "نمایش محاورهٔ هشدار هنگام کشتن فرایند‌ها"
+
+#~ msgid "Time in milliseconds between updates of the process view"
+#~ msgstr "زمان بین به‌روزرسانی‌های نمای فرایند‌ها بر حسب میلی‌ثانیه"
+
+#~ msgid "Time in milliseconds between updates of the graphs"
+#~ msgstr "زمان بین به‌روزرسانی‌های نمودارها بر حسب میلی‌ثانیه"
+
+#~ msgid "Whether information about all file systems should be displayed"
+#~ msgstr "این که باید اطّلاعات تمام سامانه پرونده‌ها نشان داده شود یا نه"
+
+#~ msgid ""
+#~ "Whether to display information about all file systems (including types like "
+#~ "“autofs” and “procfs”). Useful for getting a list of all currently mounted file "
+#~ "systems."
+#~ msgstr ""
+#~ "این که اطّلاعات تمام سامانه پرونده‌ها (از جمله گونه‌هایی چون autofs و procfs) نشان "
+#~ "داده شود یا نه . مفید برای گرفتن فهرستی از تمام سامانه پرونده‌های سوار‌شدهٔ جاری."
+
+#~ msgid "Time in milliseconds between updates of the devices list"
+#~ msgstr "زمان بین به‌روزرسانی‌های فهرست افزاره‌ها بر حسب میلی‌ثانیه"
+
+#~ msgid "Determines which processes to show."
+#~ msgstr "تعیین می‌کند کدام فرایندها نشان داده شوند."
+
+#~ msgid "Saves the currently viewed tab"
+#~ msgstr "زبانهٔ جاری را ذخیره می‌کند"
+
+#~ msgid "Each entry is in the format (CPU#, Hexadecimal color value)"
+#~ msgstr "هر ورودی در قالب (شمارهٔ پردازنده، مقدار هگزادسیمال رنگ) است"
+
+#~ msgid "Default graph memory color"
+#~ msgstr "رنگ پیش‌گزیدهٔ نمودار حافظه"
+
+#~ msgid "Default graph swap color"
+#~ msgstr "رنگ پیش‌گزیدهٔ نمودار مبادله"
+
+#~ msgid "Default graph incoming network traffic color"
+#~ msgstr "رنگ پیش‌گزیدهٔ نمودار ترافیک شبکهٔ ورودی"
+
+#~ msgid "Default graph outgoing network traffic color"
+#~ msgstr "رنگ پیش‌گزیدهٔ نمودار ترافیک شبکهٔ خروجی"
+
+#~ msgid "Show network traffic in bits"
+#~ msgstr "نمایش ترافیک شبکه بر حسب بیت"
+
+#~ msgid "Show network totals in bits"
+#~ msgstr "نمایش مجموع شبکه بر حسب بیت"
+
+#~ msgid ""
+#~ "If TRUE, system-monitor shows the CPU chart as a stacked area chart instead of "
+#~ "a line chart."
+#~ msgstr ""
+#~ "اگر درست باشد، پایشگر سامانه نمودار پردازنده را به‌جای نمودار خطی، به شکل نمودار "
+#~ "پشته‌ای نمایش می‌دهد."
+
+#~ msgid "Show CPU chart as stacked area chart"
+#~ msgstr "نمایش نمودار پردازنده به شکل پشته‌ای"
+
+#~ msgid "Show CPU, Memory, and Network charts as smooth graphs using Bezier curves"
+#~ msgstr ""
+#~ "نمایش نمودارهای پردازنده، حافظه و شبکه به شکل نمودار نرم با استفاده از منحنی‌های "
+#~ "بزیه"
+
+#~ msgid ""
+#~ "If TRUE, system-monitor shows the CPU, Memory, and Network charts as smoothed "
+#~ "graphs, otherwise as line charts."
+#~ msgstr ""
+#~ "اگر درست باشد، پایشگر سامانه، نمودارهای پردازنده، حافظه و شبکه را به‌جای نمودار "
+#~ "خطی، به شکل نمودار نرم نمایش می‌دهد."
+
+#~ msgid "Show memory and swap in IEC"
+#~ msgstr "نمایش حافظه و مبادله در IEC"
+
+#~ msgid "Process view sort column"
+#~ msgstr "ستون چینش نمای پردازنده"
+
+#~ msgid "Process view columns order"
+#~ msgstr "ترتیب ستون‌های نمای پردازنده"
+
+#~ msgid "Process view sort order"
+#~ msgstr "ترتیب چینش نمای پردازنده"
+
+#~ msgid "Width of process “Name” column"
+#~ msgstr "پهنای ستون «نام» فرایند"
+
+#~ msgid "Show process “Name” column on startup"
+#~ msgstr "نمایش ستون «نام» فرایند هنگام شروع"
+
+#~ msgid "Width of process “User” column"
+#~ msgstr "پهنای ستون «کاربر» فرایند"
+
+#~ msgid "Show process “User” column on startup"
+#~ msgstr "نمایش ستون «کاربر» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Status” column"
+#~ msgstr "پهنای ستون «وضعیت» فرایند"
+
+#~ msgid "Show process “Status” column on startup"
+#~ msgstr "نمایش ستون «وضعیت» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Virtual Memory” column"
+#~ msgstr "پهنای ستون «حافظهٔ مجازی» فرایند"
+
+#~ msgid "Show process “Virtual Memory” column on startup"
+#~ msgstr "نمایش ستون «حافظهٔ مجازی» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Resident Memory” column"
+#~ msgstr "پهنای ستون «حافظهٔ مقیم» فرایند"
+
+#~ msgid "Show process “Resident Memory” column on startup"
+#~ msgstr "نمایش ستون «حافظهٔ مقیم» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Writable Memory” column"
+#~ msgstr "پهنای ستون «حافظهٔ قابل نوشتن» فرایند"
+
+#~ msgid "Show process “Writable Memory” column on startup"
+#~ msgstr "نمایش ستون «حافظهٔ قابل نوشتن» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Shared Memory” column"
+#~ msgstr "پهنای ستون «حافظهٔ اشتراکی» فرایند"
+
+#~ msgid "Show process “Shared Memory” column on startup"
+#~ msgstr "نمایش ستون «حافظهٔ اشتراکی» فرایند هنگام شروع"
+
+#~ msgid "Width of process “X Server Memory” column"
+#~ msgstr "پهنای ستون «حافظهٔ کارساز ایکس» فرایند"
+
+#~ msgid "Show process “X Server Memory” column on startup"
+#~ msgstr "در زمان راه اندازی، ستونِ «حافظهٔ کارساز ایکس» فرایند هنگام شروع"
+
+#~ msgid "Width of process “CPU %” column"
+#~ msgstr "پهنای ستون «٪ پردازنده» فرایند"
+
+#~ msgid "Show process “CPU %” column on startup"
+#~ msgstr "در زمان راه‌اندازی ستون «٪ پردازنده» فرایند نشان داده شود"
+
+#~ msgid "Width of process “CPU Time” column"
+#~ msgstr "پهنای ستون «زمان پردازنده» فرایند"
+
+#~ msgid "Show process “CPU Time” column on startup"
+#~ msgstr "در زمان راه اندازی، ستونِ «زمانِ پردازندهِ» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Started” column"
+#~ msgstr "پهنای ستون «شروع» فرایند"
+
+#~ msgid "Show process “Started” column on startup"
+#~ msgstr "نمایش ستون «شروع» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Nice” column"
+#~ msgstr "پهنای ستون «نایس» فرایند"
+
+#~ msgid "Show process “Nice” column on startup"
+#~ msgstr "نمایش ستون «نایس» فرایند هنگام شروع"
+
+#~ msgid "Width of process “ID” column"
+#~ msgstr "پهنای ستون «شناسه‌»‌ فرایند"
+
+#~ msgid "Show process “ID” column on startup"
+#~ msgstr "نمایش ستون «شناسه» فرایند در شروع"
+
+#~ msgid "Width of process “SELinux Security Context” column"
+#~ msgstr "پهنای ستون «مفاد امنیتی سه‌لینوکس» فرایند"
+
+#~ msgid "Show process “SELinux Security Context” column on startup"
+#~ msgstr "در زمان راه اندازی، ستونِ «مفاد امنیتی سه‌لینوکس» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Command Line” column"
+#~ msgstr "پهنای ستون «خط فرمان» فرایند"
+
+#~ msgid "Show process “Command Line” column on startup"
+#~ msgstr "نمایش ستون «خط فرمان» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Memory” column"
+#~ msgstr "پهنای ستون «حافظه» فرایند"
+
+#~ msgid "Show process “Memory” column on startup"
+#~ msgstr "نمایش ستون «حافظه» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Waiting Channel” column"
+#~ msgstr "پهنای ستون «کانال انتظار» فرایند"
+
+#~ msgid "Show process “Waiting Channel” column on startup"
+#~ msgstr "نمایش ستون «کانال انتظار» فرایند در شروع"
+
+#~ msgid "Width of process “Control Group” column"
+#~ msgstr "پهنای ستون «گروه واپایش» فرایند"
+
+#~ msgid "Show process “Control Group” column on startup"
+#~ msgstr "نمایش ستون «گروه واپایش» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Unit” column"
+#~ msgstr "پهنای ستون «واحد» فرایند"
+
+#~ msgid "Show process “Unit” column on startup"
+#~ msgstr "نمایش ستون «واحد» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Session” column"
+#~ msgstr "پهنای ستون «نشست» فرایند"
+
+#~ msgid "Show process “Session” column on startup"
+#~ msgstr "نمایش ستون «نشست» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Seat” column"
+#~ msgstr "پهنای ستون «صندلی» فرایند"
+
+#~ msgid "Show process “Seat” column on startup"
+#~ msgstr "نمایش ستون «صندلی» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Owner” column"
+#~ msgstr "پهنای ستون «مالک» فرایند"
+
+#~ msgid "Show process “Owner” column on startup"
+#~ msgstr "نمایش ستون «مالک» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Total disk read” column"
+#~ msgstr "پهنای ستون «مجموع خواندن دیسک» فرایند"
+
+#~ msgid "Show process “Total disk read” column on startup"
+#~ msgstr "نمایش ستون «مجموع خواندن دیسک» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Total disk write” column"
+#~ msgstr "پهنای ستون «مجموع نوشتن دیسک» فرایند"
+
+#~ msgid "Show process “Total disk write” column on startup"
+#~ msgstr "نمایش ستون «مجموع نوشتن دیسک» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Disk read” column"
+#~ msgstr "پهنای ستون «خواندن دیسک» فرایند"
+
+#~ msgid "Show process “Disk read” column on startup"
+#~ msgstr "نمایش ستون «خواندن دیسک» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Disk write” column"
+#~ msgstr "پهنای ستون «نوشتن دیسک» فرایند"
+
+#~ msgid "Show process “Disk write” column on startup"
+#~ msgstr "نمایش ستون «نوشتن دیسک» فرایند هنگام شروع"
+
+#~ msgid "Width of process “Priority” column"
+#~ msgstr "پهنای ستون «الویت» فرایند"
+
+#~ msgid "Show process “Priority” column on startup"
+#~ msgstr "نمایش ستون «الویت» فرایند هنگام شروع"
+
+#~ msgid "Disk view sort column"
+#~ msgstr "ستون چینش نمای دیسک"
+
+#~ msgid "Disk view sort order"
+#~ msgstr "ترتیب چینش نمای دیسک"
+
+#~ msgid "Disk view columns order"
+#~ msgstr "ترتیب ستون‌های نمای دیسک"
+
+#~ msgid "Width of disk view “Device” column"
+#~ msgstr "پهنای ستون «افزاره» در نمای دیسک"
+
+#~ msgid "Show disk view “Device” column on startup"
+#~ msgstr "نمایش ستون «افزاره» نمای دیسک هنگام شروع"
+
+#~ msgid "Width of disk view “Directory” column"
+#~ msgstr "پهنای ستون «شاخه» در نمای دیسک"
+
+#~ msgid "Show disk view “Directory” column on startup"
+#~ msgstr "نمایش ستون «شاخه» نمای دیسک هنگام شروع"
+
+#~ msgid "Width of disk view “Type” column"
+#~ msgstr "پهنای ستون «گونه» در نمای دیسک"
+
+#~ msgid "Show disk view “Type” column on startup"
+#~ msgstr "نمایش ستون «گونه» نمای دیسک هنگام شروع"
+
+#~ msgid "Width of disk view “Total” column"
+#~ msgstr "پهنای ستون «مجموع» در نمای دیسک"
+
+#~ msgid "Show disk view “Total” column on startup"
+#~ msgstr "نمایش ستون «مجموع» نمای دیسک هنگام شروع"
+
+#~ msgid "Width of disk view “Free” column"
+#~ msgstr "پهنای ستون «آزاد» در نمای دیسک"
+
+#~ msgid "Show disk view “Free” column on startup"
+#~ msgstr "نمایش ستون «آزاد» نمای دیسک هنگام شروع"
+
+#~ msgid "Width of disk view “Available” column"
+#~ msgstr "پهنای ستون «موجود» در نمای دیسک"
+
+#~ msgid "Show disk view “Available” column on startup"
+#~ msgstr "نمایش ستون «موجود» نمای دیسک هنگام شروع"
+
+#~ msgid "Width of disk view “Used” column"
+#~ msgstr "پهنای ستون «استفاده شده» در نمای دیسک"
+
+#~ msgid "Show disk view “Used” column on startup"
+#~ msgstr "نمایش ستون «استفاده شده» نمای دیسک هنگام شروع"
+
+#~ msgid "Memory map sort column"
+#~ msgstr "ستون چینش نگاشت حافظه"
+
+#~ msgid "Memory map sort order"
+#~ msgstr "ترتیب چینش نگاشت حافظه"
+
+#~ msgid "Open files sort column"
+#~ msgstr "ستون چینش پرونده‌های باز"
+
+#~ msgid "Open files sort order"
+#~ msgstr "ترتیب چینش پرونده‌های باز"
+
+#~ msgid ""
+#~ "Cannot change the priority of process with PID %d to %d.\n"
+#~ "%s"
+#~ msgstr ""
+#~ "تغییر اولویت فرایند با شناسه %Id به %Id امکان‌پذیر نیست.\n"
+#~ "%s"
+
+#~ msgid ""
+#~ "Cannot kill process with PID %d with signal %d.\n"
+#~ "%s"
+#~ msgstr ""
+#~ "کشتن فرایند با شناسه %Id با سیگنال %Id امکان‌پذیر نیست.\n"
+#~ "%s"
+
+#~ msgid "Are you sure you want to kill the selected process “%s” (PID: %u)?"
+#~ msgstr "مطمئنید می‌خواهید فرایند «%s» (شناسه: %Iu) کشته شود؟"
+
+#~ msgid "Are you sure you want to end the selected process “%s” (PID: %u)?"
+#~ msgstr "مطمئنید می‌خواهید فرایند «%s» (شناسه: %Iu) پایان یابد؟"
+
+#~ msgid "Are you sure you want to stop the selected process “%s” (PID: %u)?"
+#~ msgstr "مطمئنید می‌خواهید فرایند «%s» (شناسه: %Iu) متوقّف شود؟"
+
+#~ msgid "Are you sure you want to kill the selected process?"
+#~ msgid_plural "Are you sure you want to kill the %d selected processes?"
+#~ msgstr[0] "مطمئنید می‌خواهید فرایند گزیده را بکشید؟"
+#~ msgstr[1] "مطمئنید می‌خواهید %Id فرایند گزیده را بکشید؟"
+
+#~ msgid "Are you sure you want to stop the selected process?"
+#~ msgid_plural "Are you sure you want to stop the %d selected processes?"
+#~ msgstr[0] "مطمئنید می‌خواهید فرایند گزیده را متوقّف کنید؟"
+#~ msgstr[1] "مطمئنید می‌خواهید %Id فرایند گزیده را متوقّف کنید؟"
+
+#~ msgid ""
+#~ "Killing a process may destroy data, break the session or introduce a security "
+#~ "risk. Only unresponsive processes should be killed."
+#~ msgstr ""
+#~ "کشتن یک فرایند می‌تواند باعث از بین رفتن داده، خرابی نشست، یا ایجاد خطری امنیتی "
+#~ "شود. تنها فرایند‌های ناپاسخگو باید کشته شوند."
+
+#~ msgid "_Kill Process"
+#~ msgid_plural "_Kill Processes"
+#~ msgstr[0] "_کشتن فرایند"
+#~ msgstr[1] "_کشتن فرایندها"
+
+#~ msgid ""
+#~ "Ending a process may destroy data, break the session or introduce a security "
+#~ "risk. Only unresponsive processes should be ended."
+#~ msgstr ""
+#~ "پایام یک فرایند می‌تواند باعث از بین رفتن داده، خرابی نشست، یا ایجاد خطری امنیتی "
+#~ "شود. تنها فرایند‌های ناپاسخگو باید پایان یابند."
+
+#~ msgid ""
+#~ "Stopping a process may destroy data, break the session or introduce a security "
+#~ "risk. Only unresponsive processes should be stopped."
+#~ msgstr ""
+#~ "نوقّف یک فرایند می‌تواند باعث از بین رفتن داده، خرابی نشست، یا ایجاد خطری امنیتی "
+#~ "شود. تنها فرایند‌های ناپاسخگو باید متوقّف شوند."
+
+#~ msgid "Change Priority of Process “%s” (PID: %u)"
+#~ msgstr "تغییر الویت فرایند «%s» (شناسه: %Iu)"
+
+#~ msgid "Change Priority of the selected process"
+#~ msgid_plural "Change Priority of %d selected processes"
+#~ msgstr[0] "تغییر اولویت فرایند گزیده"
+#~ msgstr[1] "تغییر اولویت %Id فرایند گزیده"
+
+#~ msgid "Note:"
+#~ msgstr "نکته:"
+
+#~ msgid ""
+#~ "The priority of a process is given by its nice value. A lower nice value "
+#~ "corresponds to a higher priority."
+#~ msgstr ""
+#~ "اولویت یک فرایند با مقدار نایس آن تعیین می‌شود. هرچه میزان نایس پایین‌تر باشد، "
+#~ "الویت بیشتری دارد."
+
+#~ msgid "N/A"
+#~ msgstr "نامعلوم"
+
+#~ msgid "Virtual Memory"
+#~ msgstr "حافظهٔ مجازی"
+
+#~ msgid "Resident Memory"
+#~ msgstr "حافظهٔ مقیم"
+
+#~ msgid "Writable Memory"
+#~ msgstr "حافظهٔ قابل نوشتن"
+
+#~ msgid "X Server Memory"
+#~ msgstr "حافظهٔ کارساز ایکس"
+
+#~ msgid "Nice"
+#~ msgstr "نایس"
+
+#~ msgid "Priority"
+#~ msgstr "اولویت"
+
+#~ msgid "ID"
+#~ msgstr "شناسه"
+
+#~ msgid "Waiting Channel"
+#~ msgstr "کانال انتظار"
+
+#~ msgid "Control Group"
+#~ msgstr "گروه واپایش"
+
+#~ msgid "% CPU"
+#~ msgstr "٪ پردازنده"
+
+#~ msgid "Unit"
+#~ msgstr "واحد"
+
+#~ msgid "Owner"
+#~ msgstr "مالک"
+
+#~ msgid "Disk read total"
+#~ msgstr "مجموع خواندن دیسک"
+
+#~ msgid "Disk write total"
+#~ msgstr "مجموع نوشتن دیسک"
+
+#~ msgid "Disk read"
+#~ msgstr "خواندن دیسک"
+
+#~ msgid "Set Affinity"
+#~ msgstr "تنظیم خویشاوندی"
+
+#~ msgid "CPU %d"
+#~ msgstr "پردازندهٔ %Id"
+
+#~ msgid "Running"
+#~ msgstr "در حال اجرا"
+
+#~ msgid "Zombie"
+#~ msgstr "زامبی"
+
+#~ msgid "Sleeping"
+#~ msgstr "خوابیده"
+
+#~ msgid "%uw%ud"
+#~ msgstr "%Iu هفته %Iu روز"
+
+#~ msgid "%ud%02uh"
+#~ msgstr "%Iu روز %I02u ساعت"
+
+#~ msgid "%u:%02u:%02u"
+#~ msgstr "%Iu:%I02u.%I02u"
+
+#~ msgid "%u:%02u.%02u"
+#~ msgstr "%Iu:%I02u.%I02u"
+
+#~ msgid "Very High Priority"
+#~ msgstr "اولویت خیلی زیاد"
+
+#~ msgid "Very Low Priority"
+#~ msgstr "اولویت خیلی کم"
+
+#~ msgid "System Monitor Preferences"
+#~ msgstr "ترجیحات پایشگر سامانه"
+
+#~ msgid "End _Process"
+#~ msgstr "_پایان فرایند"
+
+#~ msgid "%.1f KiB"
+#~ msgstr "%I.1f کیلوبایت"
+
+#~ msgid "%.1f MiB"
+#~ msgstr "%I.1f مگابایت"
+
+#~ msgid "%.1f GiB"
+#~ msgstr "%I.1f گیگابایت"
+
+#~ msgid "%.1f TiB"
+#~ msgstr "%I.1f کیلوبایت"
+
+#~ msgid "%.3g kbit"
+#~ msgstr "%I.1g کیلوبیت"
+
+#~ msgid "%.3g Mbit"
+#~ msgstr "%I.1g مگابیت"
+
+#~ msgid "%.3g Gbit"
+#~ msgstr "%I.1g گیگابیت"
+
+#~ msgid "%.3g Tbit"
+#~ msgstr "%I.1g تترابیت"
+
+#~ msgid "%u bit"
+#~ msgid_plural "%u bits"
+#~ msgstr[0] "%Iu بیت"
+#~ msgstr[1] "%Iu بیت"
+
+#~ msgctxt "Menu item to Open 'Search for Open Files' dialog"
+#~ msgid "Search for Open Files"
+#~ msgstr "جستجو برای پرونده‌های باز"
+
+#~ msgid "'%s' is not a valid Perl regular expression."
+#~ msgstr "«%s» یک عبارت با قائده‌ی معتبر پِرل نیست."
+
+#~ msgid "_Name contains:"
+#~ msgstr "_نام حاوی:"
+
+#~ msgid "_Find"
+#~ msgstr "_پیدا کردن"
+
+#~ msgid "Properties of process \"%s\" (PID %u):"
+#~ msgstr "ترجیحات فراروند «%s» (شناسه %Iu):"
+
+#~ msgid "Privileges are required to kill process"
+#~ msgstr "دسترسی‌ها جهت کشتن فراروند لازم هستند"
+
+#~| msgid "_View"
+#~ msgid "View"
+#~ msgstr "نما"
+
+#~ msgid "Sent"
+#~ msgstr "ارسال شد"
+
+#~ msgid "_View"
+#~ msgstr "_نما"
+
+#~ msgid "Stop process"
+#~ msgstr "توقف فراروند"
+
+#~ msgid "Continue process if stopped"
+#~ msgstr "فراروند را اگر متوقف شد ادامه بده"
+
+#~ msgid "Force process to finish normally"
+#~ msgstr "اجبار فراروند جهت پایان بردن به حالت معمولی"
+
+#~ msgid "Force process to finish immediately"
+#~ msgstr "فراروند مجبور شود که فوری به پایان برود"
+
+#~ msgid "Refresh the process list"
+#~ msgstr "نوسازی فهرست فراروند‌ها"
+
+#~ msgid "Open the memory maps associated with a process"
+#~ msgstr "نگاشت‌های حافظه‌ی همبسته با یک فراروند باز شوند"
+
+#~ msgid "View the files opened by a process"
+#~ msgstr "دیدن پرونده‌های باز شده توسط یک فراروند"
+
+#~ msgid "Show parent/child relationship between processes"
+#~ msgstr "نشان دادن روابط مادر فرزندی فراروندها"
+
+#~ msgid "Show active processes"
+#~ msgstr "فراروندهای فعال نشان داده شوند"
+
+#~ msgid "Show only user-owned processes"
+#~ msgstr "تنها نمایش فرآروند‌های مربوط به کاربر"
+
+#~ msgid "Set process priority to very high"
+#~ msgstr "تنظیم الویت فراروند به خیلی بالا"
+
+#~ msgid "Set process priority to high"
+#~ msgstr "تنظیم الویت فراروند به بالا"
+
+#~ msgid "Set process priority to normal"
+#~ msgstr "تنظیم الویت فراروند به عادی"
+
+#~ msgid "Set process priority to low"
+#~ msgstr "تنظیم الویت فراروند به پایین"
+
+#~ msgid "Set process priority to very low"
+#~ msgstr "تنظیم الویت فراروند به خیلی پایین"
+
+#~ msgid "Set process priority manually"
+#~ msgstr "تنظیم دستیِ الویت فراروند"
+
+#~ msgid "Main Window width"
+#~ msgstr "عرض پنجره اصلی"
+
+#~ msgid "Main Window height"
+#~ msgstr "طول پنجره اصلی"
+
+#~ msgid "Main Window X position"
+#~ msgstr "مکان X پنجره اصلی"
+
+#~ msgid "Main Window Y position"
+#~ msgstr "مکان Y پنجره اصلی"
+
+#~ msgid ""
+#~ "Determines which processes to show by default. 0 is All, 1 is user, and 2 is "
+#~ "active"
+#~ msgstr ""
+#~ "مشخص می‌کند که چه فراروند‌هایی به طور پیش‌فرض نشان داده شوند. ۰ برای همه، ۱ برای "
+#~ "کاربر، و ۲ برای فعال"
+
+#~ msgid ""
+#~ "0 for the System Info, 1 for the processes list, 2 for the resources and 3 for "
+#~ "the disks list"
+#~ msgstr ""
+#~ "۰ برای اطلاعات سیستم، ۱ برای فهرست فراروند‌ها، ۲ برای منابع و ۳ برای فهرست دیسک‌ها"
+
+#~ msgid "Load averages for the last 1, 5, 15 minutes: %0.2f, %0.2f, %0.2f"
+#~ msgstr "میانگین بار کردن در ۱، ۵، ۱۵ دقیقه‌ی گذشته: %I0.2f، %I0.2f، %I0.2f"
+
+#~ msgid "Show the System tab"
+#~ msgstr "نمایش زبانه‌ی سیستم"
+
+#~ msgid "Search for _Open Files"
+#~ msgstr "جستجوی برای پرونده‌های _باز"
+
+#~ msgid "Quit the program"
+#~ msgstr "خارج کردن برنامه"
+
+#~ msgid "Memory:"
+#~ msgstr "حافظه:"
+
+#~ msgid "<i>N/A</i>"
+#~ msgstr "<i>نامعلوم</i>"
+
+#~ msgid "_Change Priority..."
+#~ msgstr "_تغییر اولویت..."
+
+#~ msgid "Default graph cpu color"
+#~ msgstr "رنگ واحد پردازش مرکزی نمودار پیش‌فرض"
+
+#~ msgid "Show process 'arguments' column on startup"
+#~ msgstr "در زمان راه اندازی ستون «نشانوند‌ها»ی فراروند نشان داده شود."
+
+#~ msgid "Show process 'estimated memory usage' column on startup"
+#~ msgstr "در زمان راه‌اندازی ستون «حافظه‌ی استفاده‌ شده‌ی تخمینی» فراروند نشان داده شود"
+
+#~ msgid "Width of process 'arguments' column"
+#~ msgstr "عرض ستون «نشان‌وند‌ها»ی فراروند"
+
+#~ msgid "Width of process 'estimated memory usage' column"
+#~ msgstr "عرض ستون «حافظه‌ی استفاده‌شده‌ی تخمینی» فرایند"
+
+#~ msgid "Solaris mode"
+#~ msgstr "حالت سولاریس"
+
+#~ msgid "Processor %d:"
+#~ msgstr "پردازنده %Id:"
+
+#, fuzzy
+#~ msgid "Kevin Vandersloot"
+#~ msgstr "© 2001 Kevin Vandersloot"
+
+#~ msgid "(C) 2001 Kevin Vandersloot"
+#~ msgstr "© 2001 Kevin Vandersloot"
+
+#, fuzzy
+#~ msgid "_Hidden processes:"
+#~ msgstr "مخفی کردن فراروند"
+
+#, fuzzy
+#~ msgid "Total:"
+#~ msgstr "مجموع :"
+
+#~ msgid "More _Info >>"
+#~ msgstr "اطلاعات بیشتر >>"
+
+#, fuzzy
+#~ msgid "Used memory:"
+#~ msgstr "حافظه‌ی اشتراکی"
+
+#, fuzzy
+#~ msgid "_Show this dialog next time"
+#~ msgstr "نمایش محاوره در دفعه‌ی بعدی."
+
+#, fuzzy
+#~ msgid "Update _interval:"
+#~ msgstr "بازه‌ی به‌هنگام‌سازی ( ثانیه ) :"
+
+#~ msgid "Arguments"
+#~ msgstr "آرگومان‌ها"
+
+#~ msgid "%d K"
+#~ msgstr "%d کیلو"
+
+#~ msgid "%.0f MB"
+#~ msgstr "%.0f مگا"
+
+#~ msgid "Erik Johnsson (zaphod@linux.nu) - icon support"
+#~ msgstr "اریک جانسون (ٍzaphod@linux.nu) - پشتییانی شمایل‌ها"
+
+#~ msgid "Total : "
+#~ msgstr "مجموع :‌"
+
+#~ msgid "Change Priority ..."
+#~ msgstr "تغییر اولویت ..."

--- a/po/fi.po
+++ b/po/fi.po
@@ -24,9 +24,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-08-28 14:52+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-08-30 16:42+0300\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos+l10n@iki.fi>\n"
 "Language-Team: suomi <lokalisointi-lista@googlegroups.com>\n"
@@ -39,101 +38,7 @@ msgstr ""
 "X-POT-Import-Date: 2012-03-07 10:37:43+0000\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Järjestelmäväylä"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Täydet oikeudet"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Istuntoväylä"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Laitteet"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Täysi pääsy kohteeseen /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Verkko"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Verkon käyttö"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Koti"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Vain luku"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Tiedostojärjestelmä"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Asetukset"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Voi muuttaa asetuksia"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s omaa seuraavat sisäänrakennetut oikeudet. Niitä ei voi muuttaa. Jos olet "
-"huolissasi näistä oikeuksia, harkitse sovelluksen poistamista."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u tiedosto- ja linkkityyppi, jonka tämä sovellus avaa"
-msgstr[1] "%u tiedosto- ja linkkityyppiä, jotka tämä sovellus avaa"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"Sovellusta <b>%s</b> käytetään seuraavanlaisten tiedostojen ja linkkien "
-"avaamiseen."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s levytilaa käytetty."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -149,7 +54,6 @@ msgid "Install some…"
 msgstr "Asenna joitain…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Avaa"
 
@@ -173,24 +77,13 @@ msgstr "Haku"
 msgid "Receive system searches and send results."
 msgstr "Vastaanota hakuja järjestelmältä ja lähetä tuloksia."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Ei käytössä"
 
@@ -356,80 +249,20 @@ msgstr "Tyhjennä välimuisti…"
 msgid "Control various application permissions and settings"
 msgstr "Hallitse sovellusten eri oikeuksia ja asetuksia"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "application;flatpak;permission;setting;sovellus;käyttöoikeudet;asetus;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Valitse kuva"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Peru"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Avaa"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "useita kokoja"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Ei työpöydän taustaa"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Nykyinen taustakuva"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Tyyli"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Oletus"
 
@@ -453,7 +286,6 @@ msgstr "Ulkoasu"
 msgid "Change your background image or the UI colors"
 msgstr "Vaihda taustakuva tai käyttöliittymän värejä"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -506,9 +338,7 @@ msgstr "Laitetason lentokonetila on päällä"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Poista lentokonetila käytöstä käyttääksesi Bluetoothia."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -516,7 +346,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Kytke Bluetooth päälle tai pois ja yhdistä laitteita"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;jakaminen;jaot;"
@@ -550,91 +379,35 @@ msgstr "Mikään sovellus ei ole pyytänyt kameran käyttöoikeutta"
 msgid "Protect your pictures"
 msgstr "Suojaa kuvasi"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "camera;photos;video;webcam;lock;private;privacy;kamera;kuvat;lukitus;"
 "yksityisyys;tietosuoja;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Aseta kalibrointilaite neliön päälle ja napsauta ”Käynnistä”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "Vaihda kalibrointilaite kalibrointiasentoon ja napsauta ”Jatka”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Vaihda kalibrointilaite kalibrointiasentoon ja napsauta ”Jatka”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Sulje kannettavan kansi"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Tapahtui sisäinen virhe josta ei voitu toipua."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Kalibrointiin vaadittavia työkaluja ei ole asennettu."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Profiilin luonti ei onnistunut."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Kohdevalkopiste ei ole saavutettavissa."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Valmis!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrointi epäonnistui!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Voit irrottaa kalibrointilaitteen."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Älä liikuta kalibrointilaitetta kesken kalibroinnin"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Näytön kalibrointi"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Peru"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -651,140 +424,6 @@ msgstr "_Jatka"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Valmis"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Kannettavan näyttö"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Sisäänrakennettu web-kamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Näyttö - %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Kuvanlukija - %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Kamera - %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Tulostin - %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Web-kamera - %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Käytä värinhallintaa laitteelle %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Näytä laitteen %s väriprofiilit"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Ei kalibroitu"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Oletus: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Väriavaruus: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Testiprofiili: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Valitse ICC-profiilitiedosto"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Tuo"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Tuetut ICC-profiilit"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Kaikki tiedostot"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Näyttö"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Tallenna profiili"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Tallenna"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Luo väriprofiili valitulle laitteelle"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Mittalaitetta ei tunnistettu. Tarkista että se on oikein liitetty ja että "
-"siinä on virta päällä."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Mittalaite ei tue tulostimien profilointia."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Laitetyyppi ei ole tällä hetkellä tuettu."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -900,9 +539,9 @@ msgstr "Vaatii median, johon on mahdollista kirjoittaa"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Näistä ohjeista profiilin käyttöön <a href=\"linux\">GNU/Linuxilla</a>, <a "
 "href=\"osx\">Apple OS X:llä</a> ja <a href=\"windows\">Windowsilla</a> "
@@ -917,8 +556,8 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Ongelmia havaittu. Profiili ei välttämättä toimi kunnolla. <a href="
-"\"\">Näytä tiedot.</a>"
+"Ongelmia havaittu. Profiili ei välttämättä toimi kunnolla. <a "
+"href=\"\">Näytä tiedot.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -926,7 +565,6 @@ msgstr "_Tuo tiedosto\t…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -938,9 +576,7 @@ msgstr ""
 "Laitteet vaativat ajan tasalla olevan väriprofiilin, jotta niiden värejä on "
 "mahdollista hallita."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Lue lisää"
 
@@ -1072,82 +708,6 @@ msgstr "D65 (Valokuvaus ja grafiikka)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standardiavaruus"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testiprofiili"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automaattinen"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Matala laatu"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Keskimääräinen laatu"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Korkea laatu"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Oletus-RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Oletus-CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Oletusharmaasävy"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Valmistajan toimittaja tehdaskalibrointidata"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Koko ruudun näyttökorjaus ei ole mahdollista tällä profiililla"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Tämä profiili ei välttämättä ole enää tarkka"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Värit"
@@ -1157,14 +717,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Kalibroi laitteidesi, kuten näytön, kameran ja tulostimen värejä"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Väri;ICC;color;profiili;kalibrointi;Calibrate;Tulostin;Printer;Näyttö;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Muu…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1179,13 +734,8 @@ msgid "No languages found"
 msgstr "Kieli ei löytynyt"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Lisää…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Avaa lukitus muuttaaksesi asetuksia"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1214,151 +764,6 @@ msgstr "Vähennä tunti"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Vähennä minuutti"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Tänään"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Eilen"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d tunti"
-msgstr[1] "%d tuntia"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuutti"
-msgstr[1] "%d minuuttia"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekunti"
-msgstr[1] "%d sekuntia"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekuntia"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Yhteyspiste"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 tuntia"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e. %Bta %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e. %Bta %Y, %H.%M"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%H.%M"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1454,17 +859,11 @@ msgid "Requires location services enabled and internet access"
 msgstr ""
 "Vaatii paikannuspalvelun olevan käytössä ja aktiivisen internetyhteyden"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Käytössä"
 
@@ -1472,15 +871,42 @@ msgstr "Käytössä"
 msgid "Time Z_one"
 msgstr "Aikav_yöhyke"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Avaa lukitus"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Ajan _muoto"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Päivämäärät"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekuntia"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Kalenteri"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Numerot"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Vaihda aikaa, päivää tai aikavyöhykettä"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Kello;Aikavyöhyke;Sijainti;"
@@ -1526,20 +952,9 @@ msgstr "Oletussovellukset"
 msgid "Configure Default Applications"
 msgstr "Määritä oletussovellukset"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "default;application;preferred;media;oletussovellus;ensisijainen;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Vikailmoitusten lähettäminen auttaa parantamaan %sa. Ilmoitukset eivät "
-"sisällä henkilökohtaisia tietoja. Ilmoitukset lähetetään anonyymisti. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1557,44 +972,9 @@ msgstr "Diagnostiikka"
 msgid "Report your problems"
 msgstr "Ilmoita ongelmista"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostics;crash;diagnostiikka;vianselvitys;kaatuminen;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Päällä"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Pois"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Toteutetaanko muutokset?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Muutoksia ei voitu toteuttaa"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Tämä saattaa johtua laitteiston rajoituksista."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1644,31 +1024,6 @@ msgstr "Ensisijainen näyttö"
 msgid "Night Light"
 msgstr "Yövalo"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Vaaka"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Pysty oikea"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Pysty vasen"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Vaaka (käännetty)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1692,6 +1047,17 @@ msgstr "Sovita TV:hen"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Skaalaus"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Luonnollinen vieritys"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1787,7 +1153,6 @@ msgstr "Näytöt"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Valitse kuinka näyttöjä ja projektoreja käsitellään"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1796,77 +1161,6 @@ msgstr ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;Paneeli;Projektori;Näyttö;Resoluutio;Tarkkuus;"
 "Virkistystaajuus;yövalo;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Secure Boot on aktiivinen"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Secure Boot estää haitallisia ohjelmia latautumasta laitteen käynnistyessä. "
-"Se on nyt käytössä ja toimii oikein."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Secure Bootin kanssa on ongelmia"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Secure Boot estää haitallisia ohjelmia latautumasta laitteen käynnistyessä. "
-"Se on nyt kytketty päälle, mutta ei toimi virheellisen avaimen vuoksi."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Secure Boot -ongelmat on yleensä mahdollista korjata tietokoneen UEFI-"
-"laiteohjelmiston asetuksista (BIOS). Laitevalmistaja saattaa tarjota "
-"ohjeita, kuinka edetä asian kanssa."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "Pyydä tarvittaessa apua laitevalmistajalta tai IT-tuelta."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Secure Boot on kytketty pois päältä"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Secure Boot estää haitallisia ohjelmia latautumasta laitteen käynnistyessä. "
-"Se on nyt kytketty pois käytöstä."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Secure Boot on yleensä mahdollista ottaa käyttöön tietokoneen UEFI-"
-"laiteohjelmiston asetuksista (BIOS). Lisätietoja saat tarvittaessa "
-"laitevalmistajalta tai IT-tuelta."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1879,133 +1173,9 @@ msgstr ""
 "\n"
 "Pyydä tarvittaessa lisätietoja laitevalmistajalta tai IT-tuesta."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Läpäisty"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Epäonnistui"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Laite myötäilee HSI-tasoa %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:485
-msgid "Security Level 0"
-msgstr "Suojaustaso 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Tässä laitteessa ei ole suojausta laitetason tietoturvaongelmia vastaan. "
-"Tämä saattaa johtua laitteen tai laiteohjelmiston asetusongelmasta. Ole "
-"tarvittaessa yhteydessä IT-tukeen."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:492
-msgid "Security Level 1"
-msgstr "Suojaustaso 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Tässä laitteessa on vähimmäissuojaus laitetason tietoturvaongelmia vastaan. "
-"Tämä on matalin laitteen suojaustaso ja se tarjoaa suojauksen vain "
-"yksinkertaisia tietoturvauhkia vastaan."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:499
-msgid "Security Level 2"
-msgstr "Suojaustaso 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Tässä laitteessa on perustason suojaus laitetason tietoturvaongelmia "
-"vastaan. Se tarjoaa suojauksen joitain yleisimpiä tietoturvauhkia vastaan."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:506
-msgid "Security Level 3"
-msgstr "Suojaustaso 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Tässä laitteessa on laajennettu suojaus laitetason tietoturvaongelmia "
-"vastaan. Tämä on korkein laitteen suojaustaso ja se tarjoaa suojauksen "
-"edistyneitä tietoturvauhkia vastaan."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:521
 msgid "Security Level"
 msgstr "Suojaustaso"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:522
-msgid "Security levels are not available for this device."
-msgstr "Suojaustasot eivät ole saatavilla tälle laitteelle."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Ole yhteydessä laitevalmistajaan saadaksesi apua tietoturvapäivitysten "
-"kanssa."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Tämä ongelma on mahdollisesti selvitettävissä laitteen UEFI-laiteohjelmiston "
-"asetuksissa tai IT-tukihenkilön toimesta."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Tämä ongelma on mahdollisesti selvitettävissä laitteen UEFI-laiteohjelmiston "
-"asetuksissa."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
-"Tämä ongelma on mahdollisesti selvitettävissä IT-tukihenkilön toimesta."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2019,338 +1189,9 @@ msgstr "Taso 2"
 msgid "Level 3"
 msgstr "Taso 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Suojattu haitallisia ohjelmia vastaan laitteen käynnistyessä."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Secure Bootin kanssa on ongelmia"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Jonkinlaista suojausta laitteen käynnistyessä."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Secure Boot on pois päältä"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Ei suojausta laitteen käynnistyessä."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Tämä ongelma johtuu mahdollisesti muutoksista UEFI-laiteohjelmiston "
-"asetuksissa, käyttöjärjestelmän asetusmuutoksista tai haitallisesta "
-"ohjelmistosta tässä järjestelmässä."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Tämä ongelma johtuu mahdollisesti muutoksista UEFI-laiteohjelmiston "
-"asetuksissa tai haitallisesta ohjelmistosta tässä järjestelmässä."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Tämä ongelma johtuu mahdollisesti käyttöjärjestelmän asetusmuutoksista tai "
-"haitallisesta ohjelmistosta tässä järjestelmässä."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Exposed to serious security threats."
-msgstr "Alttiina vakaville tietoturvauhille."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Limited protection against simple security threats."
-msgstr "Rajoitetusti suojattu yksinkertaisilta tietoturvauhilta."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Protected against common security threats."
-msgstr "Suojattu yleisiltä tietoturvauhilta."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Protected against a wide range of security threats."
-msgstr "Suojattu laajalta joukolta tietoturvauhkia."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:514
-msgid "Comprehensive Protection"
-msgstr "Kattava suojaus"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Ei tapahtumia"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Laiteohjelmiston kirjoitussuojaus"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Laiteohjelmiston kirjoitussuojauksen lukko"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Laiteohjelmiston BIOS:in alue"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Laiteohjelmiston BIOS:in deskriptori"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Esikäynnistyksen DMA-suojaus"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuardin vahvistettu käynnistys"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM-suojattu"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard -virhekäytäntö"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard Fuse"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET käytössä"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET aktiivisena"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Salattu RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU-suojaus"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux-ytimen Lockdown-suojaus"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linux-ytimen todentaminen"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linuxin swap"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Keskeytä keskusmuistiin"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Keskeytys idleen"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI-alusta-avain"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI Secure Boot"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TPM-alustan kokoonpano"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM-jälleenrakennus"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel Management Engine -valmistajatila"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Intel Management Engine -ylitys"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Intel Management Engine -versio"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Laiteohjelmistopäivitykset"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Laiteohjelmiston todistus"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Laiteohjelmiston päivitysohjelman vahvistus"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Alustan virheenjäljitys"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Suorittimen turvallisuustarkastukset"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD:n takaisinpaluusuojaus"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD:n laiteohjelmiston Replay-suojaus"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "AMD:n laiteohjelmiston kirjoitussuojaus"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Fused-alusta"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Kelvollinen"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Ei kelvollinen"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Ei käytössä"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Lukittu"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Ei lukittu"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Salattu"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Ei salattu"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Turmeltunut"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Ei turmeltu"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Löytyi"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Ei löytynyt"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Tuettu"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Ei tuettu"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2360,7 +1201,6 @@ msgstr "Laitteen suojaus"
 msgid "Host firmware security status"
 msgstr "Host-koneen laiteohjelmiston suojaustila"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2369,49 +1209,6 @@ msgstr ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
 "network;identity;privacy;näyttö;lukitus;diagnostikka;kaatuminen;yksityinen;"
 "viimeisimmät;väliaikset;nimi;verkko;identiteetti;yksityisyys;tietosuoja;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Tuntematon"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Tuntematon"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Ei saatavilla"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Järjestelmän logo"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2505,11 +1302,6 @@ msgstr "Tietoja"
 msgid "View information about your system"
 msgstr "Katsele järjestelmän tietoja"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2590,6 +1382,12 @@ msgstr "Käynnistimet"
 msgid "Launch help browser"
 msgstr "Käynnistä ohjeselain"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Asetukset"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Käynnistä laskin"
@@ -2611,7 +1409,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Etsi"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Järjestelmä"
 
@@ -2660,15 +1458,6 @@ msgstr "Pienennä tekstin kokoa"
 msgid "High contrast on or off"
 msgstr "Korkea kontrasti päälle/pois"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Syötelähteitä ei löytynyt"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Muu"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Lisää syötelähde"
@@ -2701,106 +1490,9 @@ msgstr "Asetukset"
 msgid "View Keyboard Layout"
 msgstr "Näytä näppäimistöasettelu"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Poista"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Omat pikanäppäimet"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Vaihtoehtoinen merkkinäppäin"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Vaihtoehtoista merkkinäppäintä voi käyttää lisämerkkien kirjoittamiseen. "
-"Nämä merkit on usein merkitty näppäimiin kolmantena näytettävänä merkkinä."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Vasen Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Oikea Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Vasen Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Oikea Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Valikkonäppäin"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Oikea Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Compose-näppäin"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Compose-näppäin mahdollistaa useiden erilaisten merkkien kirjoittamisen. "
-"Paina ensin compose-näppäintä ja sitten muita merkkejä.  Esimerkiksi compose-"
-"näppäin, <b>C</b> ja <b>o</b> muodostavat merkin <b>©</b>, <b>a</b> ja <b>'</"
-"b> muodostavat merkin <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Syötetapoja voi vaihtaa käyttämällä pikanäppäintä %s.\n"
-"Näitä pikanäppäimiä voi muuttaa pikanäppäinten asetuksissa."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2830,45 +1522,21 @@ msgstr "Erikoismerkkien kirjoitus"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Tavat eri symbolien ja kirjainmuunnelmien syöttämiseen näppäimistöllä."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Vaihtoehtoinen merkkinäppäin"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose-näppäin"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Pikanäppäimet"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Katsele ja mukauta pikanäppäimiä"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d muokattu"
-msgstr[1] "%d muokattu"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Palautetaanko kaikkien pikanäppäinten oletukset?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Pikanäppäinten oletusten palauttaminen vaikuttaa asettamiisi pikanäppäimiin. "
-"Tätä toimintoa ei voi perua."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Peru"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Palauta kaikki oletusasetukset"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2908,35 +1576,6 @@ msgstr "Lisää pikanäppäin"
 msgid "No keyboard shortcut found"
 msgstr "Näppäimistön pikanäppäintä ei löytynyt"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s on jo asetettu toimintoon %s. Jos korvaat sen, toiminto %s poistetaan "
-"käytöstä"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Anna uusi pikanäppäin"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Aseta oma pikanäppäin"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Aseta pikanäppäin"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Anna uusi pikanäppäin vaihtaaksesi toiminnon %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Lisää oma pikanäppäin"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Poista"
@@ -2948,7 +1587,6 @@ msgstr "_Korvaa"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Aseta"
 
@@ -2985,6 +1623,11 @@ msgstr "Ei mikään"
 msgid "Reset the shortcut to its default value"
 msgstr "Palauta pikanäppäin oletusarvoon"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Käytä kameraa"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Näppäimistö"
@@ -2997,7 +1640,6 @@ msgstr ""
 "Muuta näppäimistön pikanäppäimiä ja aseta kirjoitusasetuksesi, "
 "näppäimistöasettelut ja syötelähteet"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3039,7 +1681,6 @@ msgstr "Mikään sovellus ei ole pyytänyt sijainnin käyttöoikeutta"
 msgid "Protect your location information"
 msgstr "Suojaa sijaintitietoasi"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "location;gps;private;privacy;sijainti;yksityisyys;tietosuoja;"
@@ -3074,7 +1715,6 @@ msgstr "Mikään sovellus ei ole pyytänyt mikrofonin käyttöoikeutta"
 msgid "Protect your conversations"
 msgstr "Suojaa keskustelusi"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
@@ -3107,81 +1747,140 @@ msgstr "Vasen"
 msgid "Right"
 msgstr "Oikea"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Hakukohteet"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Hiiri"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Hiiren nopeus"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Luonnollinen vieritys"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Vieritys alas"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Vieritys liikuttaa sisältöä, ei näkymää."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Vieritys liikuttaa sisältöä, ei näkymää."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktiivinen"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Kosketuslevy"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Kosketuslevyn nopeus"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Napsauta napauttamalla"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Napsauta napauttamalla"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Kahden sormen vieritys"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_Poista kosketuslevy käytöstä kirjoitettaessa"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Kosketuslevy (suhteellinen)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Reunavieritys"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Vieritys alas"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Kaksipuoleinen"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Kokeile napsauttamista, kaksoisnapsauttamista ja vierittämistä"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Viisi napsautusta, GEGL-aika!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Kaksoisnapsautus, ensisijainen painike"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Yksi napsautus, ensisijainen painike"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Kaksoisnapsautus, keskimmäinen painike"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Yksi napsautus, keskimmäinen painike"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Kaksoisnapsautus, toissijainen painike"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Yksi napsautus, toissijainen painike"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3193,7 +1892,6 @@ msgid ""
 msgstr ""
 "Muuta hiiren tai kosketuslevyn herkkyyttä ja valitse kumpaa kättä käytät"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3276,7 +1974,6 @@ msgstr "Moniajo"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Hallinnoi tuottavuuden ja moniajon asetuksia"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3285,20 +1982,11 @@ msgstr ""
 "moniajo;tuottavuus;mukautus;mukauttaminen;samanaikainen;aktivointikulma;"
 "työtilat;virtuaalipöydät;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Hups, jokin taisi mennä pieleen. Ota yhteys sovellustoimittajaan."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManagerin tulee olla käynnissä."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Muut laitteet"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3310,59 +1998,16 @@ msgstr "Lisää yhteys"
 msgid "Not set up"
 msgstr "Ei määritetty"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Turvaton verkko (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Turvallinen verkko (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Turvallinen verkko (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Turvallinen verkko (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Turvallinen verkko"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Yhdistetty"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Valinnat…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Yhteyspisteen ottaminen käyttöön katkaisee yhteyden verkkoon %s, eikä yhteys "
-"internetiin onnistu wifin kautta."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Tulee olla vähintään 8 merkkiä"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3412,20 +2057,6 @@ msgstr "Luo automaattisesti salasana"
 msgid "_Turn On"
 msgstr "_Ota käyttöön"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wifi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Suljetaanko yhteyspiste ja katkaistaanko kaikkien käyttäjien yhteydet?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Sulje yhteyspiste"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Lentokonetila"
@@ -3470,89 +2101,13 @@ msgstr "Näkyvissä olevat verkot"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManagerin tulee olla käynnissä"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Hups, jokin taisi mennä pieleen. Ota yhteys sovellustoimittajaan."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x-suojaus"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Tietoturva"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Varaa"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Pysyvä"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Satunnainen"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Vakaa"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Tähän kirjoitettua MAC-osoitetta käytetään laiteosoitteena sille "
-"verkkolaitteelle, jolle tämä yhteys aktivoidaan. Ominaisuus tunnetaan "
-"termeillä MAC-kloonaus tai -spooffaus. Esimerkki: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profiili %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Yritys"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ei mitään"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Ei koskaan"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3561,183 +2116,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i päivä sitten"
 msgstr[1] "%i päivää sitten"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Ei mitään"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Heikko"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "OK"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Hyvä"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Erinomainen"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4-osoite"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6-osoite"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP-osoite"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Unohda yhteys"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Poista yhteysprofiili"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Poista VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Tiedot"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automaattinen"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identiteetti"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Poista osoite"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Poista reitti"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ei mitään"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bittinen avain (Hex tai ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bittinen salalause"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynaaminen WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3-Personal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3748,8 +2126,20 @@ msgstr "Signaalin vahvuus"
 msgid "Link speed"
 msgstr "Yhteysnopeus"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Tietoturva"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4-osoite"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-osoite"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Laiteosoite"
 
@@ -3758,12 +2148,17 @@ msgid "Supported Frequencies"
 msgstr "Tuetut taajuudet"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Oletusreitti"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3828,7 +2223,7 @@ msgstr "Vain linkkiyhteys"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manuaalinen"
 
@@ -3872,9 +2267,8 @@ msgstr "Yhdyskäytävä"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automaattinen"
 
@@ -3927,90 +2321,9 @@ msgstr "Automaattinen, vain DHCP"
 msgid "Prefix"
 msgstr "Etuliite"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Yhteyseditorin avaaminen epäonnistui"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Uusi profiili"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Virheellinen asetus %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Virheellinen asetus %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Tuo tiedostosta…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Lisää VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Tietoturva"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "VPN-yhteyden tuonti epäonnistui"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Tiedoston ”%s” luku epäonnistui tai se ei sisällä tunnistettavaa VPN-"
-"yhteyden tietoa\n"
-"\n"
-"Virhe: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Valitse tuotava tiedosto"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Tiedosto nimeltä ”%s” on jo olemassa."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Korvaa"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-"Haluatko korvata tiedoston %s VPN-asetuksilla, joita olet tallentamassa?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "VPN-yhteyden vienti epäonnistui"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN-yhteyttä ”%s” ei voitu viedä tiedostoon %s.\n"
-"\n"
-"Virhe: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Vie VPN-yhteys"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4024,100 +2337,40 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Verkko"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Hallitse internetyhteyden asetuksia"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;lähiverkko;"
 "välityspalvelin;laajakaista;modeemi;erillisverkko;nimipalvelu;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wifi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Määritä miten wifi-verkkoihin otetaan yhteys"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;verkko;langaton;"
 "laajakaista;nimipalvelu;tukiasema;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "ei koskaan"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "tänään"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "eilen"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Viimeksi käytetty"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Kiinteä"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Lisää uusi yhteys"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Valittujen verkkojen tiedot, kuten salasanat ja omat asetukset, häviävät."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Unohda"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Tunnetut wifi-verkot"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Unohda"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Järjestelmäkäytännöt estävät käytön yhteyspisteenä"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Langaton verkkolaite ei tue yhteyspisteeksi asettamista"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "WPAD-automaattietsintää käytetään, kun hallinta-URL ei ole määritelty."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Tämä ei ole suositeltavaa julkisissa verkoissa."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4136,6 +2389,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Tarjoaja"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-osoite"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4220,291 +2477,6 @@ msgstr "_Käynnistä wifi-yhteyspiste…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Tunnetut wifi-verkot"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Tuntematon tila"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Hallitsematon"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Ei saatavilla"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Yhdistetään"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Tunnistautuminen vaaditaan"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Katkaistaan yhteyttä"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Yhteys epäonnistui"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Tila tuntematon (puuttuu)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Kokoonpanon käyttö epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP-asetukset epäonnistuivat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP-asetukset vanhenivat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Salaisuuksia ei annettu, vaikka niitä pyydettiin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x-anojan yhteys katkaistu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x-anojan asetukset epäonnistuivat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x-anoja epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x-anojalla kesti liian kauan tunnistautua"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP-palvelun käynnistys epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP-palvelun yhteys katkaistu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP-asiakkaan käynnistys epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP-asiakkaan virhe"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP-asiakas epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Jaetun yhteyden palvelun käynnistys epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Jaetun yhteyden palvelu epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP-palvelun käynnistys epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP-palvelun virhe"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP-palvelu epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linja on varattu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Ei valintaääntä"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Kantoaaltoa ei voitu muodostaa"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Soittopyyntö aikatkaistiin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Soittoyritys epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Modeemin alustus epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Halutun APN:n valinta epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Verkkoja ei etsitä"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Verkkoon rekisteröinti estettiin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Rekisteröinti verkkoon aikakatkaistiin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Määritettyyn verkkoon rekisteröinti epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN-tarkistus epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Laitteen laiteohjelmisto saattaa puuttua"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Yhteys katosi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Oletettiin olemassa oleva yhteys"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modeemia ei löytynyt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth-yhteys epäonnistui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM-korttia ei ole liitetty"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM-kortin PIN vaaditaan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM-kortin PUK vaaditaan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM väärin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Yhteysriippuvuus epäonnistui"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Laiteohjelmisto puuttuu"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Johto on irti"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "määrittelemätön virhe 802.1X-tietoturvassa (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "ei tiedostoa valittuna"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "määrittämätön virhe eap-method-tiedostoa vahvistaessa"
-
-#: panels/network/wireless-security/eap-method.c:394
-#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER-, PEM-, PKCS#12- tai PGP-yksityisavaimet"
-
-#: panels/network/wireless-security/eap-method.c:397
-#| msgid "_User certificate"
-msgid "DER or PEM certificates"
-msgstr "DER- tai PEM-varmenteet"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "puuttuva EAP-FAST PAC -tiedosto"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC-tiedostot (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4553,14 +2525,6 @@ msgstr "_Sisempi tunnistautuminen"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Salli automaattinen PAC-pro_visiointi"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "puuttuva EAP-LEAP-käyttäjätunnus"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "puuttuva EAP-LEAP-salasana"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4586,15 +2550,6 @@ msgstr "_Salasana"
 msgid "Sho_w password"
 msgstr "N_äytä salasana"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "virheellinen EAP-PEAP CA -varmenne: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "virheellinen EAP-PEAP CA -varmenne: varmennetta ei määritetty"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4616,7 +2571,6 @@ msgid "C_A certificate"
 msgstr "_Varmentajavarmenne (CA-varmenne)"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4631,63 +2585,6 @@ msgstr "_CA-varmennetta ei vaadita"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP-_versio"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "puuttuva EAP-käyttäjätunnus"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "puuttuva EAP-salasana"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "puuttuva EAP-TLS-identiteetti"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "virheellinen EAP-TLS CA -varmenne: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "virheellinen EAP-TLS:n CA-varmenne: varmennetta ei määritetty"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "virheellinen EAP-TLS:n yksityinen avain: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "virheellinen EAP-TLS-käyttäjävarmenne: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Salaamattomat yksityiset avaimet ovat epäluotettavia"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Valittua yksityistä avainta ei ole suojattu salasanalla. Tämä mahdollistaa "
-"turvallisuustietojen vaarantumisen. Valitse salasanalla suojattu yksityinen "
-"avain.\n"
-"\n"
-"(Voit salasanasuojata yksityisen avaimesi openssl:llä)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Valitse henkilökohtainen varmenteesi"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Valitse yksityinen avaimesi"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4704,15 +2601,6 @@ msgstr "_Yksityinen avain"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Yksityisen avaimen _salasana"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "virheellinen EAP-TTLS CA -varmenne: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "virheellinen EAP-TTLS CA -varmenne: varmennetta ei määritetty"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4735,14 +2623,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "T_oimialue"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Tuntematon virhe 802.1X-tietoturvaa vahvistaessa"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4770,62 +2659,10 @@ msgstr "Suojattu EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Tunnistautuminen"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Valitse tiedosto"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "puuttuva leap-käyttäjätunnus"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "puuttuva leap-salasana"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Langattoman verkon salasana puuttuu."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tyyppi"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "puuttuva wep-avain"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"virheellinen wep-key: avaimen jonka pituus on %zu tulee sisältää vain "
-"heksanumeroita"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"virheellinen wep-avain: avain pituutta %zu tulee sisältää vain ascii-merkkejä"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"virheellinen wep-key: väärä avaimen pituus %zu. Avaimen tulee olla "
-"pituudeltaan joko 5/13 (ascii) tai 10/26 (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "virheellinen wep-avain: tunnuslause ei voi olla tyhjä"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"virheellinen wep-avain: tunnuslause tulee olla vähemmän kuin 64 merkkiä"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4850,19 +2687,6 @@ msgstr "N_äytä avain"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP-inde_ksi"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"virheellinen wpa-psk: virheellinen avaimen pituus %zu. Tulee olla [8,63] "
-"tavua tai 64 heksanumeroa"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "virheellinen wpa-psk: ei voi tulkita 64 tavun avainta heksana"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4916,28 +2740,10 @@ msgstr "_Lukitusnäytön ilmoitukset"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Hallitse näytettäviä ilmoituksia ja niiden sisältämää tietoa"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Notifications;Banner;Message;Tray;Popup;ilmoitus;ilmoitukset;banneri;viesti;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Muu"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s poistettu"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Virhe tiliä poistaessa"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4961,17 +2767,6 @@ msgstr "Ei internetyhteyttä — muodosta yhteys määrittääksesi verkkotilisi
 msgid "Add an account"
 msgstr "Lisää tili"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s-tili"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Poista tili"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Verkkotilit"
@@ -4980,10 +2775,6 @@ msgstr "Verkkotilit"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Liitä verkkotilisi ja päätä, mihin tarkoituksiin niitä käytetään"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4992,10 +2783,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;keskustelu;kalenteri;sähköposti;"
 "yhteystiedot;kontaktit;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Tuntematon aika"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5011,13 +2798,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i tunti"
 msgstr[1] "%i tuntia"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5029,190 +2809,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuutti"
 msgstr[1] "minuuttia"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s kunnes ladattu täyteen"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Varoitus: %s jäljellä"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s jäljellä"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Ladattu täyteen"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Ei lataudu"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Tyhjä"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Latautuu"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Purkautuu"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Langaton hiiri"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Langaton näppäimistö"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Keskeytymätön virransyöttö"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Henkilökohtainen digitaalinen avustaja (PDA)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Matkapuhelin"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Mediasoitin"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Piirtopöytä"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Tietokone"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Pelaamiseen tarkoitettu syötelaite"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Akku"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Pääakku"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Lisäakku"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Akut"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Kun _käyttämättä"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Valmiustila"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Virta pois päältä"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Lepotila"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Ei mitään"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Käytettäessä akkua"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Käytettäessä verkkovirtaa"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Ei koskaan"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automaattinen valmiustila"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Suorituskykytila on poistettu väliaikaisesti käytöstä korkean "
-"käyntilämpötilan vuoksi."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Syli havaittu: suorituskykytila väliaikaisesti ei saatavilla. Siirrä laite "
-"tasaiselle alustalle palauttaaksesi suorituskykytilan."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Suorituskykytila väliaikaisesti pois käytöstä."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Akku vähissä: virransäästö otettu käyttöön. Aiempi tila palautetaan, kun "
-"akkua on ladattu riittävästi."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Virransäästötilan aktivoinut “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Suorituskykytilan aktivoinut “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5273,6 +2869,15 @@ msgstr "100 minuuttia"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 tuntia"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akku"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Laitteet"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5351,33 +2956,6 @@ msgstr "Käytettäessä _akkua"
 msgid "Delay"
 msgstr "Viive"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Suorituskyky"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Korkea suorituskyky ja virrankäyttö."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Tasapainotettu"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Normaali suorituskyky ja virrankäyttö."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Virransäästö"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Alennettu suorituskyky ja virrankäyttö."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Virranhallinta"
@@ -5386,7 +2964,6 @@ msgstr "Virranhallinta"
 msgid "View your battery status and change power saving settings"
 msgstr "Tarkkaile akkusi tilaa ja muuta virransäästöasetuksia"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5396,27 +2973,6 @@ msgstr ""
 "Energy;virta;uni;valmiustila;lepotila;akku;kirkkaus;himmennys;tyhjä;näyttö;"
 "jouten;virransäästö;virranhallinta;"
 
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Tulostin “%s” on poistettu"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Uuden tulostimen lisäys epäonnistui."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Käyttöliittymätiedoston lataus epäonnistui: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Avaa lukitus lisätäksesi tulostimia ja muuttaaksesi asetuksia"
-
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "Tulostimet"
@@ -5425,7 +2981,6 @@ msgstr "Tulostimet"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Lisää tulostimia, seuraa tulostustöitä ja määritä tulostusasetukset"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -5435,8 +2990,6 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Lisää tulostin"
 
@@ -5477,29 +3030,6 @@ msgstr ""
 msgid "Username"
 msgstr "Käyttäjätunnus"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Tulostimen %s tiedot"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Soveltuvaa ajuria ei löytynyt"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Valitse PPD-tiedosto"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript Printer Description -tiedostot (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
@@ -5509,9 +3039,7 @@ msgstr ""
 msgid "Location"
 msgstr "Sijainti"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Ajuri"
 
@@ -5539,140 +3067,20 @@ msgstr "Valitse tulostinajuri"
 msgid "Loading drivers database…"
 msgstr "Ladataan ajuritietokantaa…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Peru"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Valitse"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect-tulostin"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD-tulostin"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Yksipuoleinen"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "PItkä reuna"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Lyhyt reuna"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Pysty"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Vaaka"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Käänteinen vaaka"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Käänteinen pysty"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Jatka"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Keskeytä"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Odottaa"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Keskeytetty"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Tunnistautuminen vaaditaan"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Käsitellään"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Pysäytetty"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Peruttu"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Keskeytetynyt"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Valmis"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Siirrä tämä työ jonon kärkeen"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u työ vaatii tunnistautumisen"
 msgstr[1] "%u työtä vaatii tunnistautumisen"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Aktiiviset työt"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Syötä kirjautumistietosi tulostaaksesi tulostimesta %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5700,323 +3108,17 @@ msgstr "_Tunnistaudu"
 msgid "No Active Printer Jobs"
 msgstr "Ei aktiivisia tulostustöitä"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Avaa tulostuspalvelimen lukitus"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Avaa kohteen %s lukitus."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Syötä käyttäjätunnus ja salasana nähdäksesi palvelimella %s olevat "
-"tulostimet."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Etsitään tulostimia"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Sarjaportti"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Rinnakkaisportti"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Sijainti: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Osoite: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Palvelin vaatii tunnistautumisen"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Kaksipuoleinen"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Paperin tyyppi"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Paperin lähde"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Ulostulo"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Tarkkuus"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScriptin esisuodatus"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Sivuja per puoli"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Kaksipuoleinen"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Suunta"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Yleiset"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Sivun asetukset"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Asennettavat valinnat"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Työ"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Kuvalaatu"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Väri"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Viimeistely"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Lisäasetukset"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testisivu"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Testisivu"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Valitse automaattisesti"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Tulostimen oletus"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Upota vain GhostScript-fontit"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Muunna PS 1 -tasolle"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Muunna PS 2 -tasolle"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Ei esisuodatusta"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Valmistaja"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Ei aktiivisia töitä"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u työ"
 msgstr[1] "%u työtä"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Puhdista tulostuspäät"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Muste on vähissä"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Muste on loppu"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Kehite on vähissä"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Kehite on loppu"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Väriaine vähissä"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Väriaine loppu"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Avaa kansi"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Avaa ovi"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Paperi vähissä"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Paperi on loppu"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Poissa verkosta"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Pysäytetty"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Jätesäiliö melkein täynnä"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Jätesäiliö täynnä"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Valojohdeyksikkö on vaihdettava pian"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Valojohdeyksikkö on rikki"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Valmiina"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Ei hyväksy töitä"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Käsitellään"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6040,6 +3142,10 @@ msgstr "Puhdista tulostuspäät"
 msgid "Remove Printer"
 msgstr "Poista tulostin"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ei aktiivisia töitä"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6060,16 +3166,21 @@ msgid "Restart"
 msgstr "Käynnistä uudelleen"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Lisää tulostin…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Lisää tulostin…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Ei tulostimia"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6077,7 +3188,6 @@ msgstr ""
 "Valitettavasti tulostuspalvelu\n"
 "ei vaikuta olevan käytettävissä."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Muotoilut"
@@ -6105,16 +3215,6 @@ msgstr "Haut voivat kohdistua maihin tai kieliin."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Esikatselu"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperiaalinen"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrinen"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6152,20 +3252,24 @@ msgstr ""
 "Kieliasetus määrittää käyttöliittymän tekstin ja verkkosivustojen kielen. "
 "Muotoilut määrittävät numeroiden, päiväysten ja valuuttojen muodon."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Tilisi"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Kieli"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Muotoilut"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Kirjautumisnäkymä"
 
@@ -6177,99 +3281,9 @@ msgstr "Alue ja kielet"
 msgid "Select your display language and formats"
 msgstr "Valitse näytettävä kieli ja muotoilut"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Kieli;Asettelu;Näppäimistö;Syöte;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Kysy mitä tehdään"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Älä tee mitään"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Avaa kansio"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Muu media"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Valitse sovellus ääni-CD-levyille"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Valitse sovellus video-DVD-levyille"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Valitse sovellus ajettavaksi kun musiikkisoitin kytketään"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Valitse sovellus ajettavaksi kun kamera kytketään"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Valitse sovellus ohjelmisto-CD-levyille"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "ääni-DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "tyhjä Blu-ray-levy"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "tyhjä CD-levy"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "tyhjä DVD-levy"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "tyhjä HD DVD -levy"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray-videolevy"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "e-kirjalukija"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD -videolevy"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Kuva-CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video-CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows-ohjelmisto"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6319,7 +3333,6 @@ msgstr "Erilliset tallennusvälineet"
 msgid "Configure Removable Media settings"
 msgstr "Määritä erillisten tallennusvälineiden asetukset"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6329,114 +3342,6 @@ msgstr ""
 "removable;media;autorun;laite;järjestelmä;tiedot;muisti;suoritin;prosessori;"
 "versio;oletukset;sovellus;suositellut;automaattikäynnistys;ääni;irrotettava;"
 "ulkoinen;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Näyttö sammuu"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekuntia"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuutti"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minuuttia"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minuuttia"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minuuttia"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minuuttia"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 tunti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuutti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minuuttia"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minuuttia"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minuuttia"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minuuttia"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minuuttia"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minuuttia"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minuuttia"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minuuttia"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Ei koskaan"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6474,11 +3379,16 @@ msgstr "Näytön pimennyksen kesto, kunnes näyttö lukitaan automaattisesti."
 msgid "Show _Notifications on Lock Screen"
 msgstr "_Näytä ilmoitukset lukitusnäytöllä"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Lukitusnäytön ilmoitukset"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Estä uudet US_B-laitteet"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6486,30 +3396,25 @@ msgstr ""
 "Estä uusien USB-laitteiden vuorovaikutus järjestelmään, kun näyttö on "
 "lukittu."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Näytön tietosuoja"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Rajoita katselukulmaa"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Näyttö"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Näytön asetukset"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "screen;lock;private;privacy;näyttö;lukitus;yksityisyys;tietosuoja;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Valitse sijainti"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6540,10 +3445,6 @@ msgstr "Muut"
 msgid "Add Location"
 msgstr "Lisää sijainti"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Sovelluksia ei löytynyt"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Sovellusten haku"
@@ -6569,95 +3470,15 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "Mitkä ohjelmat näyttävät hakutuloksia Toiminnot-näkymässä"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Search;Find;Index;Hide;Privacy;Results;Haku;Etsi;Indeksi;Piilota;Yksityisyys;"
 "Tulokset;Hakutulokset;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Ei verkkoja valittu jakamista varten"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Verkot"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Päällä"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Pois"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Käytössä"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktiivinen"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Valitse kansio"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Lisää"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Ota käyttöön mediajako"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Tiedostonjaon avulla voit jakaa julkisen kansiosi sisällön verkon muiden "
-"käyttäjien kanssa käyttäen osoitetta: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Kun etäkirjautuminen on käytössä, etäkäyttäjät voivat yhdistää käyttäen "
-"Secure Shell -komentoa:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Ota käyttöön henkilökohtainen tiedostonjako"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Laitteen nimi kopioitu"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Laiteosoite kopioitu"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Käyttäjätunnus kopioitu"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Salasana kopioitu"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6789,7 +3610,6 @@ msgstr "Kansiot"
 msgid "Control what you want to share with others"
 msgstr "Valitse mitä haluat jakaa muiden kanssa"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6805,10 +3625,6 @@ msgstr "Käytä tai poista käytöstä etäkirjautuminen"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Etäkirjautumisen hallinta vaatii tunnistautuminen"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Oma"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6841,11 +3657,6 @@ msgstr "Taka"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Etu"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Testataan %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6899,11 +3710,6 @@ msgstr "Äänenvoimakkuus"
 msgid "Alert Sound"
 msgstr "Hälytysääni"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100 %"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Mykistä"
@@ -6916,7 +3722,6 @@ msgstr "Ääni"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Muuta äänenvoimakkuutta, sisään- ja ulostuloja sekä äänitapahtumia"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6924,76 +3729,6 @@ msgstr ""
 "Kortti;mikrofoni;äänenvoimakkuus;häivytys;tasapaino;Bluetooth;kuulokkeet;"
 "headset;Audio;Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
 "Output;Input;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Yhteys katkaistu"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Yhdistetään"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Yhdistetty"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Valtuutusvirhe"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Valtuutetaan"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Alentunut toiminnallisuus"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Yhdistetty ja valtuutettu"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Tuntematon"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Valtuutettu:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Yhdistetty:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Käyttöönotettu:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Laitteen valtuuttaminen epäonnistui: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Laitteen unohtaminen epäonnistui: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7027,56 +3762,6 @@ msgstr "Valtuuta ja yhdistä"
 msgid "Forget Device"
 msgstr "Unohda laite"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Virhe"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Valtuutettu"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Thunderbolt-alijärjestelmää (boltd) ei ole asennettu tai sen asetukset eivät "
-"ole kunnossa."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Salli suora pääsy laitteisiin kuten telakoihin ja erillisiin näytönohjaimiin."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Vain USB- ja DisplayPort-laitteet voivat liittyä."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderboltia ei havaittu.\n"
-"Järjestelmästä puuttuu Thunderbolt-tuki, tai se on poistettu käytöstä BIOS:"
-"in kautta, tai BIOS:in kautta sille asetettu turvataso ei ole tuettu."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt-tuki on poistettu käytöstä BIOS:in kautta."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Thunderbolt-turvatasoa ei voitu määrittää."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Virhe vaihtaessa direct-tilaan: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Ei Thunderbolt-tukea"
@@ -7088,6 +3773,11 @@ msgstr "Thunderbolt-alijärjestelmään ei voitu yhdistää."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Suora pääsy"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Salli suora pääsy laitteisiin kuten telakoihin ja erillisiin näytönohjaimiin."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7105,7 +3795,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Hallitse Thunderbolt-laitteita"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;yksityisyys;"
@@ -7308,40 +3997,6 @@ msgid "Turn accessibility features on and off using the keyboard"
 msgstr ""
 "Ota käyttöön/poista käytöstä esteettömyystoiminnot näppäimistöä käyttäen"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Oletus"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Keskikoko"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Suuri"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Suurempi"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Suurin"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pikseli"
-msgstr[1] "%d pikseliä"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Näytä esteettömyysvalikko aina"
@@ -7456,31 +4111,6 @@ msgstr "Väläytä _koko näyttöä"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Väläytä _koko ikkunaa"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Lyhyt"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ näyttöä"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ näyttöä"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ näyttöä"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Pitkä"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7637,7 +4267,6 @@ msgstr "Väritehosteet"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Helpota näkemistä, kuulemista, kirjoittamista ja hiiren käyttöä"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7653,114 +4282,6 @@ msgstr ""
 "kirjasin;koko;Pohjaan jäävät näppäimet;Hitaat näppäimet;Kimmonäppäimet;"
 "Hiiren painikkeet;kaksois;viive;vilkkuminen;kuuleminen;kirjoittaminen;"
 "animaatiot;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 tunti"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 päivä"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 päivää"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 päivää"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 päivää"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 päivää"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 päivää"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 päivää"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 päivää"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 päivää"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Tyhjennetäänkö roskakorin koko sisältö?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Kaikki roskakorissa olevat kohteet poistetaan pysyvästi."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Tyhjennä roskakori"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Poistetaanko kaikki väliaikaiset tiedostot?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Kaikki väliaikaiset tiedostot poistetaan pysyvästi."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Tu_hoa väliaikaistiedostot"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 päivä"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 päivää"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 päivää"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Ikuisesti"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7829,7 +4350,6 @@ msgstr "Tiedostohistoria ja roskakori"
 msgid "Don't leave traces"
 msgstr "Älä jätä jälkiä"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
@@ -7837,58 +4357,6 @@ msgstr ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 "käyttö;viimeisimmät;uusimmat;historia;tiedostot;väliaikaiset;yksityisyys;"
 "roskakori;säilytys;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Tulisi vastata kirjautumistilisi myöntäjän verkko-osoitetta."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Tilin lisäys epäonnistui"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Salasanat eivät täsmää."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Tilin rekisteröinti epäonnistui"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr ""
-"Tähän toimialueeseen vaadittavaa tunnistautumistapaa ei ole käytettävissä"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Toimialueeseen liittyminen epäonnistui"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Käyttäjätunnus ei kelvannut.\n"
-"Yritä uudelleen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Salasana ei kelvannut.\n"
-"Yritä uudelleen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Toimialueeseen kirjautuminen epäonnistui"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Toimialuetta ei löytynyt. Kirjoititko sen oikein?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7940,10 +4408,6 @@ msgstr ""
 "Yrityskirjautuminen mahdollistaa ennestään keskitetysti hallitun "
 "käyttäjätilin käytön tällä laitteella. Voit käyttää tätä tiliä myös "
 "yrityksen resurssien käyttöön internetissä."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Selaa lisää kuvia"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8014,222 +4478,6 @@ msgstr "_Poista sormenjäljet"
 msgid "Fingerprint Enroll"
 msgstr "Sormenjäljen lisääminen"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "laite tulee vaatia käyttöön tämän toiminnon suorittamiseksi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "toinen prosessi on jo varannut laitteen itselleen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "käyttöoikeutesi eivät riitä tämän toiminnon suorittamiseen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "sormenjälkiä ei ole rekisteröity"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Yhteydenpito laitteeseen epäonnistui rekisteröinnin aikana"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Yhteydenpito sormenjälkilukijaan epäonnistui"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Yhteydenpito sormenjälkitaustapalveluun epäonnistui"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Sormenjälkien listaaminen epäonnistui: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Tallennettujen sormenjälkien poistaminen epäonnistui: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Vasen peukalo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Vasen keskisormi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Vasen etusormi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Vasen nimetön"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Vasen pikkurilli"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Oikea peukalo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Oikea keskisormi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Oikea etusormi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Oikea nimetön"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Oikea pikkurilli"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Tuntematon sormi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Valmis"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Yhteys sormenjälkilaitteeseen katkaistu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Sormenjälkilaitteen tallennustila on täynnä"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Uuden sormenjäljen lisääminen epäonnistui"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Sormenjäljen lisäämisen aloittaminen epäonnistui: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Uuden sormenjäljen lisääminen epäonnistui"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Sormenjäljen lisäämisen pysäyttäminen epäonnistui: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Nosta sormea ja aseta se takaisin lukijaan toistuvasti lisätäksesi "
-"sormenjälkesi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Lisää uudelleen tämä sormi…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Lue uusi sormenjälki"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Sormenjälkilaitteen %s vapauttaminen epäonnistui: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Ongelma laitetta luettaessa"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Sormenjälkilaitteen %s varaaminen epäonnistui: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Sormenjälkilaitteiden saaminen epäonnistui: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Tällä viikolla"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Viime viikolla"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Istunto päättyi"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Istunto alkoi"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Tilin käyttöhistoria"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Edellinen"
@@ -8237,18 +4485,6 @@ msgstr "Edellinen"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Seuraava"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Valitse jokin toinen salasana."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Syötä nykyinen salasana uudelleen."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Salasanaa ei voitu vaihtaa"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8270,6 +4506,10 @@ msgstr "Uusi salasana"
 msgid "Confirm Password"
 msgstr "Vahvista salasana"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Salasanat eivät täsmää."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Salli käyttäjän vaihtaa salasana seuraavalla kirjautumiskerralla"
@@ -8277,134 +4517,6 @@ msgstr "Salli käyttäjän vaihtaa salasana seuraavalla kirjautumiskerralla"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Aseta salasana nyt"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Tämän tyyppiseen toimialueeseen ei voi liittyä automaattisesti"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Määriteltyä toimialuetta tai realmia ei löytynyt"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Kirjautuminen tunnuksella %s toimialueeseen %s ei onnistu"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Virheellinen salasana, yritä uudelleen"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Toimialueeseen %s yhdistäminen epäonnistui: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Käyttäjän poisto epäonnistui"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Etähallitun käyttäjän kumoaminen epäonnistui"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Et voi poistaa omaa tunnustasi."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s on yhä sisäänkirjautuneena"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Jos käyttäjä poistetaan hänen ollessaan sisäänkirjautuneena, järjestelmässä "
-"voi ilmetä ongelmia."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Haluatko säilyttää käyttäjän %s tiedostot?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Voit halutessasi säilyttää kotikansion, sähköpostit ja väliaikaistiedostot "
-"käyttäjätilin poiston yhteydessä."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "P_oista tiedostot"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Säilytä tiedostot"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Haluatko varmasti kumota käyttöoikeudet etähallitulta tililtä %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Poista"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Käyttäjätili pois käytöstä"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Asetetaan seuraavalla kirjautumiskerralla"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ei mitään"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Sisäänkirjautuneena"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Yhteys tilipalveluun (accounts service) epäonnistui"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Varmista, että AccountService on asennettu ja käytössä."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Tämän paneelin lukitus tulee avata, jotta tätä asetusta voi muuttaa"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Poista valittu käyttäjätili"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Poista valittu käyttäjä\n"
-"napsauttamalla ensin *-kuvaketta"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Avaa lukitus lisätäksesi käyttäjiä ja muuttaaksesi asetuksia"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8432,7 +4544,6 @@ msgid "Full name"
 msgstr "Koko nimi"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Muokkaa"
 
@@ -8494,7 +4605,6 @@ msgstr "Avaa lukitus lisätäksesi käyttäjätilin."
 msgid "Add or remove users and change your password"
 msgstr "Lisää tai poista käyttäjiä, vaihda salasanasi"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8540,179 +4650,6 @@ msgstr "Hallitse käyttäjätilejä"
 msgid "Authentication is required to change user data"
 msgstr "Käyttäjätietojen muuttaminen vaatii tunnistautuminen"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Uusi salasana ei saa olla vanhan salasanan kaltainen."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Vaihda kirjaimia ja numeroita."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Yritä muuttaa salasanaa vielä hieman."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Älä laita käyttäjätunnustasi salasanaasi."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Älä laita nimeäsi salasanaasi."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Vältä salasanassasi olevia sanoja."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Vältä yleisiä, sanakirjoista löytyviä sanoja."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Älä käytä samoja sanoja eri järjestyksessä."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Käytä enemmän numeroita."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Käytä enemmän isoja kirjaimia."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Käytä enemmän pieniä kirjaimia."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Käytä erikois- ja välimerkkejä."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Sekoita kirjaimia, numeroita ja välimerkkejä."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Vältä toistamasta samaa merkkiä."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Vältä saman merkkityylin käyttöä: sekoita kirjaimia, numeroita ja "
-"välimerkkejä."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Vältä sarjan kaltaisia jonoja, kuten 1234 tai abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Salasanan tulee olla nykyistä pidempi. Lisää kirjaimia, numeroita ja "
-"erikoismerkkejä."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Käytä isoja ja pieniä kirjaimia sekä joitain numeroita."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Mitä enemmän kirjaimia, numeroita ja erikoismerkkejä, sitä vahvempi salasana."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Tunnistautuminen epäonnistui"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Uusi salasana on liian lyhyt"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Uusi salasana on liian yksinkertainen"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Vanha ja uusi salasana ovat liian samankaltaiset"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Uusi salasana on ollut jo käytössä äskettäin."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Uuden salasanan tulee sisältää numeroita tai erikoismerkkejä"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Vanha ja uusi salasana ovat samat"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Salasanasi on vaihtunut ensimmäisen todennuksen jälkeen!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Uusi salasana ei sisällä riittävästi eri merkkejä"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Tuntematon virhe"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Käyttäjätunnuksen tulisi yleensä koostua vain pienistä kirjaimista välillä a-"
-"z, numeroista sekä seuraavista merkeistä: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Valitettavasti kyseinen käyttäjätunnus ei ole saatavilla. Valitse toinen "
-"käyttäjätunnus."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Käyttäjätunnus on liian pitkä."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8746,52 +4683,10 @@ msgstr "Kosketa näytöllä näkyviä kohdemerkkejä piirtopöydän kalibroimise
 msgid "Mis-click detected, restarting…"
 msgstr "Tunnistettiin ohi mennyt kosketus, aloitetaan alusta…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Painike %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Sovelluksen määrittämä"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Lähetä näppäinpainallus"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Vaihda näyttöä"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Näytä ohjeet näytöllä"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Piirtopöytä kiinnitettynä kannettavan paneeliin"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Piirtopöytä kiinnitettynä erilliseen näyttöön"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Ulkoinen piirtopöytälaite"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Ulkoinen piirtopöytälaite"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Kaikki näytöt"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8889,24 +4784,6 @@ msgstr "Hiiren oikean painikkeen napsautus"
 msgid "Forward"
 msgstr "Eteenpäin"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
-"Airbrush-piirtokynä paineella, kallistuksella ja integroidulla "
-"liukusäätimellä"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Airbrush-piirtokynä paineella, kallistuksella ja kierrolla"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standardi piirtokynä paineella ja kallistuksella"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standardi piirtokynä paineella"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom-piirtopöydät"
@@ -8915,54 +4792,96 @@ msgstr "Wacom-piirtopöydät"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Aseta piirtopöydän painikkeet ja kynän herkkyys"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Piirtopöytä;Wacom;Stylus;Eraser;Hiiri;Tablet;Mouse;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Uusi pikanäppäin…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Kakkospainikkeen simuloitu _napsautus"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows-ohjelmisto"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Muste on vähissä"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Toissijainen"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows-ohjelmisto"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Hallinnoi tuottavuuden ja moniajon asetuksia"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Yhteyspisteet"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Lisää"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Tallenna"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Toiminto peruttu"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Virhe:</b> Asetusten muuttaminen on estetty"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Virhe:</b> Mobiilitarvikkeen virhe"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Ei rekisteröity"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Rekisteröity"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Etsitään"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Estetty"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8992,212 +4911,13 @@ msgstr "Oma numero"
 msgid "Device Details"
 msgstr "Laitteen tiedot"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Valmistaja"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Laiteohjelmiston versio"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Vain 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Vain 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Vain 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Vain 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (ensisijainen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (ensisijainen), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (ensisijainen), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (ensisijainen), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (ensisijainen), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (ensisijainen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (ensisijainen), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (ensisijainen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (ensisijainen), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (ensisijainen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (ensisijainen), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (ensisijainen), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (ensisijainen), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (ensisijainen), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (ensisijainen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (ensisijainen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (ensisijainen)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (ensisijainen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Tuntematon"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Avaa SIM-kortin lukitus"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Avaa lukitus"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Anna SIM-kortin %d PIN-koodi"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Anna PIN-koodi avataksesi SIM-kortin lukituksen"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Anna SIM-kortin %d PUK-koodi"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Anna PUK-koodi avataksesi SIM-kortin lukituksen"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9212,26 +4932,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "%u yritys jäljellä"
 msgstr[1] "%u yritystä jäljellä"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Annettiin väärä salasana."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK-koodin tulisi olla 8 numeroa"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Anna uusi PIN-koodi"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN-koodin tulee olla 4-8 numeroa pitkä"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Avataan lukitus…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9289,94 +4989,6 @@ msgstr "Lukitse SIM-kortti PIN-koodilla"
 msgid "M_odem Details"
 msgstr "Mo_deemin tiedot"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Puhelinvirhe"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Ei yhteyttä puhelimeen"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Toiminto ei ole sallittu"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Toiminto ei ole tuettu"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM-korttia ei ole syötetty"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "SIM-kortin PIN-koodi vaaditaan"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "SIM-kortin PUK-koodi vaaditaan"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM-virhe"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM käytössä"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Väärä salasana"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIM-kortin PIN2-koodi vaaditaan"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIM-kortin PUK2-koodi vaaditaan"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Ei löytynyt"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Ei verkkopalvelua"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Verkon aikakatkaisu"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS-palvelut eivät ole sallittuja"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming ei ole sallittu tällä alueella"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Määrittämätön GPRS-virhe"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Ei virhettä"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Toiminto peruttu"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Pääsy estetty"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Tuntematon virhe"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Verkkotila"
@@ -9392,11 +5004,6 @@ msgstr "Valitse verkko"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Päivitä palveluntarjoajat"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9454,7 +5061,6 @@ msgstr "Mobiiliverkko"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Määritä puhelinverkko- ja mobiilidatayhteydet"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;wwan;telephony;sim;mobile;mobiili;"
@@ -9473,41 +5079,13 @@ msgstr ""
 msgid "The GNOME Project"
 msgstr "Gnome-projekti"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Näytä versionumero"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Ota käyttöön lisätietoja tulostava tila"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Etsi merkkijonoa"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Näytä mahdolliset paneelinimet ja lopeta"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Näytettävä paneeli"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEELI] [ARGUMENTTI…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Asetusten luokat"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Yksityisyys"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Käytettävissä olevat paneelit:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9565,7 +5143,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Peru haku"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Ominaisuudet;Asetukset;Preferences;Settings;"
@@ -9605,8 +5182,6 @@ msgstr ""
 "Järjestetty, muuttumaton lista (tuple) sisältäen alkuarvon leveyden ja "
 "korkeuden sekä sovellusikkunan suurennetun tilan osalta."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9614,8 +5189,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u ulostulo"
 msgstr[1] "%u ulostuloa"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9623,9 +5196,3129 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u sisääntulo"
 msgstr[1] "%u sisääntuloa"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Järjestelmän äänet"
+#~ msgid "System Bus"
+#~ msgstr "Järjestelmäväylä"
+
+#~ msgid "Full access"
+#~ msgstr "Täydet oikeudet"
+
+#~ msgid "Session Bus"
+#~ msgstr "Istuntoväylä"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Täysi pääsy kohteeseen /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Verkon käyttö"
+
+#~ msgid "Home"
+#~ msgstr "Koti"
+
+#~ msgid "Read-only"
+#~ msgstr "Vain luku"
+
+#~ msgid "File System"
+#~ msgstr "Tiedostojärjestelmä"
+
+#~ msgid "Can change settings"
+#~ msgstr "Voi muuttaa asetuksia"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s omaa seuraavat sisäänrakennetut oikeudet. Niitä ei voi muuttaa. Jos "
+#~ "olet huolissasi näistä oikeuksia, harkitse sovelluksen poistamista."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u tiedosto- ja linkkityyppi, jonka tämä sovellus avaa"
+#~ msgstr[1] "%u tiedosto- ja linkkityyppiä, jotka tämä sovellus avaa"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "Sovellusta <b>%s</b> käytetään seuraavanlaisten tiedostojen ja linkkien "
+#~ "avaamiseen."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s levytilaa käytetty."
+
+#~ msgid "Select a picture"
+#~ msgstr "Valitse kuva"
+
+#~ msgid "_Open"
+#~ msgstr "_Avaa"
+
+#~ msgid "multiple sizes"
+#~ msgstr "useita kokoja"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Ei työpöydän taustaa"
+
+#~ msgid "Current background"
+#~ msgstr "Nykyinen taustakuva"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Aseta kalibrointilaite neliön päälle ja napsauta ”Käynnistä”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "Vaihda kalibrointilaite kalibrointiasentoon ja napsauta ”Jatka”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "Vaihda kalibrointilaite kalibrointiasentoon ja napsauta ”Jatka”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Sulje kannettavan kansi"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Tapahtui sisäinen virhe josta ei voitu toipua."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Kalibrointiin vaadittavia työkaluja ei ole asennettu."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profiilin luonti ei onnistunut."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Kohdevalkopiste ei ole saavutettavissa."
+
+#~ msgid "Complete!"
+#~ msgstr "Valmis!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrointi epäonnistui!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Voit irrottaa kalibrointilaitteen."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Älä liikuta kalibrointilaitetta kesken kalibroinnin"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Kannettavan näyttö"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Sisäänrakennettu web-kamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Näyttö - %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Kuvanlukija - %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Kamera - %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Tulostin - %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Web-kamera - %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Käytä värinhallintaa laitteelle %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Näytä laitteen %s väriprofiilit"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Ei kalibroitu"
+
+#~ msgid "Default: "
+#~ msgstr "Oletus: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Väriavaruus: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testiprofiili: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Valitse ICC-profiilitiedosto"
+
+#~ msgid "_Import"
+#~ msgstr "_Tuo"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Tuetut ICC-profiilit"
+
+#~ msgid "All files"
+#~ msgstr "Kaikki tiedostot"
+
+#~ msgid "Save Profile"
+#~ msgstr "Tallenna profiili"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Luo väriprofiili valitulle laitteelle"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Mittalaitetta ei tunnistettu. Tarkista että se on oikein liitetty ja että "
+#~ "siinä on virta päällä."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Mittalaite ei tue tulostimien profilointia."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Laitetyyppi ei ole tällä hetkellä tuettu."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standardiavaruus"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testiprofiili"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automaattinen"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Matala laatu"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Keskimääräinen laatu"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Korkea laatu"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Oletus-RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Oletus-CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Oletusharmaasävy"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Valmistajan toimittaja tehdaskalibrointidata"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Koko ruudun näyttökorjaus ei ole mahdollista tällä profiililla"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Tämä profiili ei välttämättä ole enää tarkka"
+
+#~ msgid "Other…"
+#~ msgstr "Muu…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Avaa lukitus muuttaaksesi asetuksia"
+
+#~ msgid "Today"
+#~ msgstr "Tänään"
+
+#~ msgid "Yesterday"
+#~ msgstr "Eilen"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d tunti"
+#~ msgstr[1] "%d tuntia"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuutti"
+#~ msgstr[1] "%d minuuttia"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekunti"
+#~ msgstr[1] "%d sekuntia"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Yhteyspiste"
+
+#~ msgid "24-hour"
+#~ msgstr "24 tuntia"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e. %Bta %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e. %Bta %Y, %H.%M"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%H.%M"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Vikailmoitusten lähettäminen auttaa parantamaan %sa. Ilmoitukset eivät "
+#~ "sisällä henkilökohtaisia tietoja. Ilmoitukset lähetetään anonyymisti. %s"
+
+#~ msgid "On"
+#~ msgstr "Päällä"
+
+#~ msgid "Off"
+#~ msgstr "Pois"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Toteutetaanko muutokset?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Muutoksia ei voitu toteuttaa"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Tämä saattaa johtua laitteiston rajoituksista."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Vaaka"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Pysty oikea"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Pysty vasen"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Vaaka (käännetty)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Secure Boot on aktiivinen"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Secure Boot estää haitallisia ohjelmia latautumasta laitteen "
+#~ "käynnistyessä. Se on nyt käytössä ja toimii oikein."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Secure Bootin kanssa on ongelmia"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Secure Boot estää haitallisia ohjelmia latautumasta laitteen "
+#~ "käynnistyessä. Se on nyt kytketty päälle, mutta ei toimi virheellisen "
+#~ "avaimen vuoksi."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Secure Boot -ongelmat on yleensä mahdollista korjata tietokoneen UEFI-"
+#~ "laiteohjelmiston asetuksista (BIOS). Laitevalmistaja saattaa tarjota "
+#~ "ohjeita, kuinka edetä asian kanssa."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr "Pyydä tarvittaessa apua laitevalmistajalta tai IT-tuelta."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Secure Boot on kytketty pois päältä"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Secure Boot estää haitallisia ohjelmia latautumasta laitteen "
+#~ "käynnistyessä. Se on nyt kytketty pois käytöstä."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Secure Boot on yleensä mahdollista ottaa käyttöön tietokoneen UEFI-"
+#~ "laiteohjelmiston asetuksista (BIOS). Lisätietoja saat tarvittaessa "
+#~ "laitevalmistajalta tai IT-tuelta."
+
+#~ msgid "Passed"
+#~ msgstr "Läpäisty"
+
+#~ msgid "Failed"
+#~ msgstr "Epäonnistui"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Laite myötäilee HSI-tasoa %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Suojaustaso 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Tässä laitteessa ei ole suojausta laitetason tietoturvaongelmia vastaan. "
+#~ "Tämä saattaa johtua laitteen tai laiteohjelmiston asetusongelmasta. Ole "
+#~ "tarvittaessa yhteydessä IT-tukeen."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Suojaustaso 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Tässä laitteessa on vähimmäissuojaus laitetason tietoturvaongelmia "
+#~ "vastaan. Tämä on matalin laitteen suojaustaso ja se tarjoaa suojauksen "
+#~ "vain yksinkertaisia tietoturvauhkia vastaan."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Suojaustaso 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Tässä laitteessa on perustason suojaus laitetason tietoturvaongelmia "
+#~ "vastaan. Se tarjoaa suojauksen joitain yleisimpiä tietoturvauhkia vastaan."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Suojaustaso 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Tässä laitteessa on laajennettu suojaus laitetason tietoturvaongelmia "
+#~ "vastaan. Tämä on korkein laitteen suojaustaso ja se tarjoaa suojauksen "
+#~ "edistyneitä tietoturvauhkia vastaan."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Suojaustasot eivät ole saatavilla tälle laitteelle."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Ole yhteydessä laitevalmistajaan saadaksesi apua tietoturvapäivitysten "
+#~ "kanssa."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Tämä ongelma on mahdollisesti selvitettävissä laitteen UEFI-"
+#~ "laiteohjelmiston asetuksissa tai IT-tukihenkilön toimesta."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Tämä ongelma on mahdollisesti selvitettävissä laitteen UEFI-"
+#~ "laiteohjelmiston asetuksissa."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Tämä ongelma on mahdollisesti selvitettävissä IT-tukihenkilön toimesta."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Suojattu haitallisia ohjelmia vastaan laitteen käynnistyessä."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Secure Bootin kanssa on ongelmia"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Jonkinlaista suojausta laitteen käynnistyessä."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Secure Boot on pois päältä"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Ei suojausta laitteen käynnistyessä."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Tämä ongelma johtuu mahdollisesti muutoksista UEFI-laiteohjelmiston "
+#~ "asetuksissa, käyttöjärjestelmän asetusmuutoksista tai haitallisesta "
+#~ "ohjelmistosta tässä järjestelmässä."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Tämä ongelma johtuu mahdollisesti muutoksista UEFI-laiteohjelmiston "
+#~ "asetuksissa tai haitallisesta ohjelmistosta tässä järjestelmässä."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Tämä ongelma johtuu mahdollisesti käyttöjärjestelmän asetusmuutoksista "
+#~ "tai haitallisesta ohjelmistosta tässä järjestelmässä."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Alttiina vakaville tietoturvauhille."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Rajoitetusti suojattu yksinkertaisilta tietoturvauhilta."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Suojattu yleisiltä tietoturvauhilta."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Suojattu laajalta joukolta tietoturvauhkia."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Kattava suojaus"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Laiteohjelmiston kirjoitussuojaus"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Laiteohjelmiston kirjoitussuojauksen lukko"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Laiteohjelmiston BIOS:in alue"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Laiteohjelmiston BIOS:in deskriptori"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Esikäynnistyksen DMA-suojaus"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuardin vahvistettu käynnistys"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM-suojattu"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard -virhekäytäntö"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard Fuse"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET käytössä"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET aktiivisena"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Salattu RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU-suojaus"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux-ytimen Lockdown-suojaus"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux-ytimen todentaminen"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linuxin swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Keskeytä keskusmuistiin"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Keskeytys idleen"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI-alusta-avain"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI Secure Boot"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM-alustan kokoonpano"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM-jälleenrakennus"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine -valmistajatila"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine -ylitys"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine -versio"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Laiteohjelmistopäivitykset"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Laiteohjelmiston todistus"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Laiteohjelmiston päivitysohjelman vahvistus"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Alustan virheenjäljitys"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Suorittimen turvallisuustarkastukset"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD:n takaisinpaluusuojaus"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD:n laiteohjelmiston Replay-suojaus"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD:n laiteohjelmiston kirjoitussuojaus"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Fused-alusta"
+
+#~ msgid "Valid"
+#~ msgstr "Kelvollinen"
+
+#~ msgid "Not Valid"
+#~ msgstr "Ei kelvollinen"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Ei käytössä"
+
+#~ msgid "Locked"
+#~ msgstr "Lukittu"
+
+#~ msgid "Not Locked"
+#~ msgstr "Ei lukittu"
+
+#~ msgid "Encrypted"
+#~ msgstr "Salattu"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Ei salattu"
+
+#~ msgid "Tainted"
+#~ msgstr "Turmeltunut"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Ei turmeltu"
+
+#~ msgid "Found"
+#~ msgstr "Löytyi"
+
+#~ msgid "Not Found"
+#~ msgstr "Ei löytynyt"
+
+#~ msgid "Supported"
+#~ msgstr "Tuettu"
+
+#~ msgid "Not Supported"
+#~ msgstr "Ei tuettu"
+
+#~ msgid "Unknown"
+#~ msgstr "Tuntematon"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Tuntematon"
+
+#~ msgid "Not Available"
+#~ msgstr "Ei saatavilla"
+
+#~ msgid "System Logo"
+#~ msgstr "Järjestelmän logo"
+
+#~ msgid "No input sources found"
+#~ msgstr "Syötelähteitä ei löytynyt"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Muu"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Omat pikanäppäimet"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Vaihtoehtoista merkkinäppäintä voi käyttää lisämerkkien kirjoittamiseen. "
+#~ "Nämä merkit on usein merkitty näppäimiin kolmantena näytettävänä merkkinä."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Vasen Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Oikea Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Vasen Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Oikea Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Valikkonäppäin"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Oikea Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Compose-näppäin mahdollistaa useiden erilaisten merkkien kirjoittamisen. "
+#~ "Paina ensin compose-näppäintä ja sitten muita merkkejä.  Esimerkiksi "
+#~ "compose-näppäin, <b>C</b> ja <b>o</b> muodostavat merkin <b>©</b>, <b>a</"
+#~ "b> ja <b>'</b> muodostavat merkin <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Syötetapoja voi vaihtaa käyttämällä pikanäppäintä %s.\n"
+#~ "Näitä pikanäppäimiä voi muuttaa pikanäppäinten asetuksissa."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d muokattu"
+#~ msgstr[1] "%d muokattu"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Palautetaanko kaikkien pikanäppäinten oletukset?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Pikanäppäinten oletusten palauttaminen vaikuttaa asettamiisi "
+#~ "pikanäppäimiin. Tätä toimintoa ei voi perua."
+
+#~ msgid "Reset All"
+#~ msgstr "Palauta kaikki oletusasetukset"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s on jo asetettu toimintoon %s. Jos korvaat sen, toiminto %s poistetaan "
+#~ "käytöstä"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Anna uusi pikanäppäin"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Aseta oma pikanäppäin"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Aseta pikanäppäin"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Anna uusi pikanäppäin vaihtaaksesi toiminnon %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Lisää oma pikanäppäin"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Kahden sormen vieritys"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Viisi napsautusta, GEGL-aika!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Kaksoisnapsautus, ensisijainen painike"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Yksi napsautus, ensisijainen painike"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Kaksoisnapsautus, keskimmäinen painike"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Yksi napsautus, keskimmäinen painike"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Kaksoisnapsautus, toissijainen painike"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Yksi napsautus, toissijainen painike"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManagerin tulee olla käynnissä."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Turvaton verkko (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Turvallinen verkko (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Turvallinen verkko (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Turvallinen verkko (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Turvallinen verkko"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Yhteyspisteen ottaminen käyttöön katkaisee yhteyden verkkoon %s, eikä "
+#~ "yhteys internetiin onnistu wifin kautta."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Tulee olla vähintään 8 merkkiä"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr ""
+#~ "Suljetaanko yhteyspiste ja katkaistaanko kaikkien käyttäjien yhteydet?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Sulje yhteyspiste"
+
+#~ msgid "Preserve"
+#~ msgstr "Varaa"
+
+#~ msgid "Permanent"
+#~ msgstr "Pysyvä"
+
+#~ msgid "Random"
+#~ msgstr "Satunnainen"
+
+#~ msgid "Stable"
+#~ msgstr "Vakaa"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Tähän kirjoitettua MAC-osoitetta käytetään laiteosoitteena sille "
+#~ "verkkolaitteelle, jolle tämä yhteys aktivoidaan. Ominaisuus tunnetaan "
+#~ "termeillä MAC-kloonaus tai -spooffaus. Esimerkki: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profiili %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Yritys"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ei mitään"
+
+#~ msgid "Never"
+#~ msgstr "Ei koskaan"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Ei mitään"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Heikko"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "OK"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Hyvä"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Erinomainen"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Unohda yhteys"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Poista yhteysprofiili"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Poista VPN"
+
+#~ msgid "Details"
+#~ msgstr "Tiedot"
+
+#~ msgid "automatic"
+#~ msgstr "automaattinen"
+
+#~ msgid "Identity"
+#~ msgstr "Identiteetti"
+
+#~ msgid "Delete Address"
+#~ msgstr "Poista osoite"
+
+#~ msgid "Delete Route"
+#~ msgstr "Poista reitti"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ei mitään"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bittinen avain (Hex tai ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bittinen salalause"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynaaminen WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3-Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Yhteyseditorin avaaminen epäonnistui"
+
+#~ msgid "New Profile"
+#~ msgstr "Uusi profiili"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Virheellinen asetus %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Virheellinen asetus %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Tuo tiedostosta…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Lisää VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN-yhteyden tuonti epäonnistui"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Tiedoston ”%s” luku epäonnistui tai se ei sisällä tunnistettavaa VPN-"
+#~ "yhteyden tietoa\n"
+#~ "\n"
+#~ "Virhe: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Valitse tuotava tiedosto"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Tiedosto nimeltä ”%s” on jo olemassa."
+
+#~ msgid "_Replace"
+#~ msgstr "_Korvaa"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "Haluatko korvata tiedoston %s VPN-asetuksilla, joita olet tallentamassa?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN-yhteyden vienti epäonnistui"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN-yhteyttä ”%s” ei voitu viedä tiedostoon %s.\n"
+#~ "\n"
+#~ "Virhe: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Vie VPN-yhteys"
+
+#~ msgid "never"
+#~ msgstr "ei koskaan"
+
+#~ msgid "today"
+#~ msgstr "tänään"
+
+#~ msgid "yesterday"
+#~ msgstr "eilen"
+
+#~ msgid "Last used"
+#~ msgstr "Viimeksi käytetty"
+
+#~ msgid "Add new connection"
+#~ msgstr "Lisää uusi yhteys"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Valittujen verkkojen tiedot, kuten salasanat ja omat asetukset, häviävät."
+
+#~ msgid "_Forget"
+#~ msgstr "_Unohda"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Tunnetut wifi-verkot"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Unohda"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Järjestelmäkäytännöt estävät käytön yhteyspisteenä"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Langaton verkkolaite ei tue yhteyspisteeksi asettamista"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "WPAD-automaattietsintää käytetään, kun hallinta-URL ei ole määritelty."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Tämä ei ole suositeltavaa julkisissa verkoissa."
+
+#~ msgid "Status unknown"
+#~ msgstr "Tuntematon tila"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Hallitsematon"
+
+#~ msgid "Unavailable"
+#~ msgstr "Ei saatavilla"
+
+#~ msgid "Connecting"
+#~ msgstr "Yhdistetään"
+
+#~ msgid "Authentication required"
+#~ msgstr "Tunnistautuminen vaaditaan"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Katkaistaan yhteyttä"
+
+#~ msgid "Connection failed"
+#~ msgstr "Yhteys epäonnistui"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Tila tuntematon (puuttuu)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Kokoonpanon käyttö epäonnistui"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP-asetukset epäonnistuivat"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP-asetukset vanhenivat"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Salaisuuksia ei annettu, vaikka niitä pyydettiin"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x-anojan yhteys katkaistu"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x-anojan asetukset epäonnistuivat"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x-anoja epäonnistui"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x-anojalla kesti liian kauan tunnistautua"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP-palvelun käynnistys epäonnistui"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP-palvelun yhteys katkaistu"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP epäonnistui"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP-asiakkaan käynnistys epäonnistui"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP-asiakkaan virhe"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-asiakas epäonnistui"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Jaetun yhteyden palvelun käynnistys epäonnistui"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Jaetun yhteyden palvelu epäonnistui"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP-palvelun käynnistys epäonnistui"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP-palvelun virhe"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP-palvelu epäonnistui"
+
+#~ msgid "Line busy"
+#~ msgstr "Linja on varattu"
+
+#~ msgid "No dial tone"
+#~ msgstr "Ei valintaääntä"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Kantoaaltoa ei voitu muodostaa"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Soittopyyntö aikatkaistiin"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Soittoyritys epäonnistui"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Modeemin alustus epäonnistui"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Halutun APN:n valinta epäonnistui"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Verkkoja ei etsitä"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Verkkoon rekisteröinti estettiin"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Rekisteröinti verkkoon aikakatkaistiin"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Määritettyyn verkkoon rekisteröinti epäonnistui"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN-tarkistus epäonnistui"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Laitteen laiteohjelmisto saattaa puuttua"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Yhteys katosi"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Oletettiin olemassa oleva yhteys"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modeemia ei löytynyt"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth-yhteys epäonnistui"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM-korttia ei ole liitetty"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM-kortin PIN vaaditaan"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM-kortin PUK vaaditaan"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM väärin"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Yhteysriippuvuus epäonnistui"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Laiteohjelmisto puuttuu"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Johto on irti"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "määrittelemätön virhe 802.1X-tietoturvassa (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "ei tiedostoa valittuna"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "määrittämätön virhe eap-method-tiedostoa vahvistaessa"
+
+#~| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER-, PEM-, PKCS#12- tai PGP-yksityisavaimet"
+
+#~| msgid "_User certificate"
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER- tai PEM-varmenteet"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "puuttuva EAP-FAST PAC -tiedosto"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC-tiedostot (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "puuttuva EAP-LEAP-käyttäjätunnus"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "puuttuva EAP-LEAP-salasana"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "virheellinen EAP-PEAP CA -varmenne: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "virheellinen EAP-PEAP CA -varmenne: varmennetta ei määritetty"
+
+#~ msgid "missing EAP username"
+#~ msgstr "puuttuva EAP-käyttäjätunnus"
+
+#~ msgid "missing EAP password"
+#~ msgstr "puuttuva EAP-salasana"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "puuttuva EAP-TLS-identiteetti"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "virheellinen EAP-TLS CA -varmenne: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "virheellinen EAP-TLS:n CA-varmenne: varmennetta ei määritetty"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "virheellinen EAP-TLS:n yksityinen avain: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "virheellinen EAP-TLS-käyttäjävarmenne: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Salaamattomat yksityiset avaimet ovat epäluotettavia"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Valittua yksityistä avainta ei ole suojattu salasanalla. Tämä "
+#~ "mahdollistaa turvallisuustietojen vaarantumisen. Valitse salasanalla "
+#~ "suojattu yksityinen avain.\n"
+#~ "\n"
+#~ "(Voit salasanasuojata yksityisen avaimesi openssl:llä)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Valitse henkilökohtainen varmenteesi"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Valitse yksityinen avaimesi"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "virheellinen EAP-TTLS CA -varmenne: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "virheellinen EAP-TTLS CA -varmenne: varmennetta ei määritetty"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Tuntematon virhe 802.1X-tietoturvaa vahvistaessa"
+
+#~ msgid "Select a file"
+#~ msgstr "Valitse tiedosto"
+
+#~ msgid "missing leap-username"
+#~ msgstr "puuttuva leap-käyttäjätunnus"
+
+#~ msgid "missing leap-password"
+#~ msgstr "puuttuva leap-salasana"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Langattoman verkon salasana puuttuu."
+
+#~ msgid "missing wep-key"
+#~ msgstr "puuttuva wep-avain"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "virheellinen wep-key: avaimen jonka pituus on %zu tulee sisältää vain "
+#~ "heksanumeroita"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "virheellinen wep-avain: avain pituutta %zu tulee sisältää vain ascii-"
+#~ "merkkejä"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "virheellinen wep-key: väärä avaimen pituus %zu. Avaimen tulee olla "
+#~ "pituudeltaan joko 5/13 (ascii) tai 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "virheellinen wep-avain: tunnuslause ei voi olla tyhjä"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "virheellinen wep-avain: tunnuslause tulee olla vähemmän kuin 64 merkkiä"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "virheellinen wpa-psk: virheellinen avaimen pituus %zu. Tulee olla [8,63] "
+#~ "tavua tai 64 heksanumeroa"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "virheellinen wpa-psk: ei voi tulkita 64 tavun avainta heksana"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Muu"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s poistettu"
+
+#~ msgid "Error removing account"
+#~ msgstr "Virhe tiliä poistaessa"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s-tili"
+
+#~ msgid "Remove Account"
+#~ msgstr "Poista tili"
+
+#~ msgid "Unknown time"
+#~ msgstr "Tuntematon aika"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s kunnes ladattu täyteen"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Varoitus: %s jäljellä"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s jäljellä"
+
+#~ msgid "Fully charged"
+#~ msgstr "Ladattu täyteen"
+
+#~ msgid "Not charging"
+#~ msgstr "Ei lataudu"
+
+#~ msgid "Empty"
+#~ msgstr "Tyhjä"
+
+#~ msgid "Charging"
+#~ msgstr "Latautuu"
+
+#~ msgid "Discharging"
+#~ msgstr "Purkautuu"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Langaton hiiri"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Langaton näppäimistö"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Keskeytymätön virransyöttö"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Henkilökohtainen digitaalinen avustaja (PDA)"
+
+#~ msgid "Cellphone"
+#~ msgstr "Matkapuhelin"
+
+#~ msgid "Media player"
+#~ msgstr "Mediasoitin"
+
+#~ msgid "Tablet"
+#~ msgstr "Piirtopöytä"
+
+#~ msgid "Computer"
+#~ msgstr "Tietokone"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Pelaamiseen tarkoitettu syötelaite"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Pääakku"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Lisäakku"
+
+#~ msgid "Batteries"
+#~ msgstr "Akut"
+
+#~ msgid "When _idle"
+#~ msgstr "Kun _käyttämättä"
+
+#~ msgid "Suspend"
+#~ msgstr "Valmiustila"
+
+#~ msgid "Power Off"
+#~ msgstr "Virta pois päältä"
+
+#~ msgid "Hibernate"
+#~ msgstr "Lepotila"
+
+#~ msgid "Nothing"
+#~ msgstr "Ei mitään"
+
+#~ msgid "When on battery power"
+#~ msgstr "Käytettäessä akkua"
+
+#~ msgid "When plugged in"
+#~ msgstr "Käytettäessä verkkovirtaa"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Ei koskaan"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automaattinen valmiustila"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Suorituskykytila on poistettu väliaikaisesti käytöstä korkean "
+#~ "käyntilämpötilan vuoksi."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Syli havaittu: suorituskykytila väliaikaisesti ei saatavilla. Siirrä "
+#~ "laite tasaiselle alustalle palauttaaksesi suorituskykytilan."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Suorituskykytila väliaikaisesti pois käytöstä."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Akku vähissä: virransäästö otettu käyttöön. Aiempi tila palautetaan, kun "
+#~ "akkua on ladattu riittävästi."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Virransäästötilan aktivoinut “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Suorituskykytilan aktivoinut “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Suorituskyky"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Korkea suorituskyky ja virrankäyttö."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Tasapainotettu"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Normaali suorituskyky ja virrankäyttö."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Virransäästö"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Alennettu suorituskyky ja virrankäyttö."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Tulostin “%s” on poistettu"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Uuden tulostimen lisäys epäonnistui."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Käyttöliittymätiedoston lataus epäonnistui: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Avaa lukitus lisätäksesi tulostimia ja muuttaaksesi asetuksia"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Tulostimen %s tiedot"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Soveltuvaa ajuria ei löytynyt"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Valitse PPD-tiedosto"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript Printer Description -tiedostot (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+#~ "gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect-tulostin"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD-tulostin"
+
+#~ msgid "One Sided"
+#~ msgstr "Yksipuoleinen"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "PItkä reuna"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Lyhyt reuna"
+
+#~ msgid "Portrait"
+#~ msgstr "Pysty"
+
+#~ msgid "Landscape"
+#~ msgstr "Vaaka"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Käänteinen vaaka"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Käänteinen pysty"
+
+#~ msgid "Resume"
+#~ msgstr "Jatka"
+
+#~ msgid "Pause"
+#~ msgstr "Keskeytä"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Odottaa"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Keskeytetty"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Tunnistautuminen vaaditaan"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Käsitellään"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Pysäytetty"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Peruttu"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Keskeytetynyt"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Valmis"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Siirrä tämä työ jonon kärkeen"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Aktiiviset työt"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Syötä kirjautumistietosi tulostaaksesi tulostimesta %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Avaa tulostuspalvelimen lukitus"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Avaa kohteen %s lukitus."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Syötä käyttäjätunnus ja salasana nähdäksesi palvelimella %s olevat "
+#~ "tulostimet."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Etsitään tulostimia"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Sarjaportti"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Rinnakkaisportti"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Sijainti: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Osoite: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Palvelin vaatii tunnistautumisen"
+
+#~ msgid "Two Sided"
+#~ msgstr "Kaksipuoleinen"
+
+#~ msgid "Paper Type"
+#~ msgstr "Paperin tyyppi"
+
+#~ msgid "Paper Source"
+#~ msgstr "Paperin lähde"
+
+#~ msgid "Output Tray"
+#~ msgstr "Ulostulo"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Tarkkuus"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScriptin esisuodatus"
+
+#~ msgid "Pages per side"
+#~ msgstr "Sivuja per puoli"
+
+#~ msgid "Orientation"
+#~ msgstr "Suunta"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Yleiset"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Sivun asetukset"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Asennettavat valinnat"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Työ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Kuvalaatu"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Väri"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Viimeistely"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Lisäasetukset"
+
+#~ msgid "Test page"
+#~ msgstr "Testisivu"
+
+#~ msgid "Auto Select"
+#~ msgstr "Valitse automaattisesti"
+
+#~ msgid "Printer Default"
+#~ msgstr "Tulostimen oletus"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Upota vain GhostScript-fontit"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Muunna PS 1 -tasolle"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Muunna PS 2 -tasolle"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Ei esisuodatusta"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Puhdista tulostuspäät"
+
+#~ msgid "Out of toner"
+#~ msgstr "Muste on loppu"
+
+#~ msgid "Low on developer"
+#~ msgstr "Kehite on vähissä"
+
+#~ msgid "Out of developer"
+#~ msgstr "Kehite on loppu"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Väriaine vähissä"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Väriaine loppu"
+
+#~ msgid "Open cover"
+#~ msgstr "Avaa kansi"
+
+#~ msgid "Open door"
+#~ msgstr "Avaa ovi"
+
+#~ msgid "Low on paper"
+#~ msgstr "Paperi vähissä"
+
+#~ msgid "Out of paper"
+#~ msgstr "Paperi on loppu"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Poissa verkosta"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Pysäytetty"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Jätesäiliö melkein täynnä"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Jätesäiliö täynnä"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Valojohdeyksikkö on vaihdettava pian"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Valojohdeyksikkö on rikki"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Valmiina"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Ei hyväksy töitä"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Käsitellään"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperiaalinen"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrinen"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Kysy mitä tehdään"
+
+#~ msgid "Do nothing"
+#~ msgstr "Älä tee mitään"
+
+#~ msgid "Open folder"
+#~ msgstr "Avaa kansio"
+
+#~ msgid "Other Media"
+#~ msgstr "Muu media"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Valitse sovellus ääni-CD-levyille"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Valitse sovellus video-DVD-levyille"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Valitse sovellus ajettavaksi kun musiikkisoitin kytketään"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Valitse sovellus ajettavaksi kun kamera kytketään"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Valitse sovellus ohjelmisto-CD-levyille"
+
+#~ msgid "audio DVD"
+#~ msgstr "ääni-DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "tyhjä Blu-ray-levy"
+
+#~ msgid "blank CD disc"
+#~ msgstr "tyhjä CD-levy"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "tyhjä DVD-levy"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "tyhjä HD DVD -levy"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray-videolevy"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-kirjalukija"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD -videolevy"
+
+#~ msgid "Picture CD"
+#~ msgstr "Kuva-CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video-CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Näyttö sammuu"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekuntia"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuutti"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuuttia"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuuttia"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuuttia"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minuuttia"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 tunti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuutti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuuttia"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuuttia"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minuuttia"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuuttia"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minuuttia"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minuuttia"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minuuttia"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minuuttia"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Ei koskaan"
+
+#~ msgid "Select Location"
+#~ msgstr "Valitse sijainti"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Sovelluksia ei löytynyt"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Ei verkkoja valittu jakamista varten"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Päällä"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Pois"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Käytössä"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktiivinen"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Valitse kansio"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Ota käyttöön mediajako"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Tiedostonjaon avulla voit jakaa julkisen kansiosi sisällön verkon muiden "
+#~ "käyttäjien kanssa käyttäen osoitetta: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kun etäkirjautuminen on käytössä, etäkäyttäjät voivat yhdistää käyttäen "
+#~ "Secure Shell -komentoa:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Ota käyttöön henkilökohtainen tiedostonjako"
+
+#~ msgid "Device name copied"
+#~ msgstr "Laitteen nimi kopioitu"
+
+#~ msgid "Device address copied"
+#~ msgstr "Laiteosoite kopioitu"
+
+#~ msgid "Username copied"
+#~ msgstr "Käyttäjätunnus kopioitu"
+
+#~ msgid "Password copied"
+#~ msgstr "Salasana kopioitu"
+
+#~ msgid "Custom"
+#~ msgstr "Oma"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Testataan %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100 %"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Yhteys katkaistu"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Yhdistetään"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Yhdistetty"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Valtuutusvirhe"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Valtuutetaan"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Alentunut toiminnallisuus"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Yhdistetty ja valtuutettu"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Tuntematon"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Valtuutettu:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Yhdistetty:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Käyttöönotettu:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Laitteen valtuuttaminen epäonnistui: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Laitteen unohtaminen epäonnistui: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Virhe"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Valtuutettu"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt-alijärjestelmää (boltd) ei ole asennettu tai sen asetukset "
+#~ "eivät ole kunnossa."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Vain USB- ja DisplayPort-laitteet voivat liittyä."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderboltia ei havaittu.\n"
+#~ "Järjestelmästä puuttuu Thunderbolt-tuki, tai se on poistettu käytöstä "
+#~ "BIOS:in kautta, tai BIOS:in kautta sille asetettu turvataso ei ole tuettu."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt-tuki on poistettu käytöstä BIOS:in kautta."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Thunderbolt-turvatasoa ei voitu määrittää."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Virhe vaihtaessa direct-tilaan: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Oletus"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Keskikoko"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Suuri"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Suurempi"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Suurin"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pikseli"
+#~ msgstr[1] "%d pikseliä"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Lyhyt"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ näyttöä"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ näyttöä"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ näyttöä"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Pitkä"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 tunti"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 päivä"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 päivää"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 päivää"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 päivää"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 päivää"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 päivää"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 päivää"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 päivää"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 päivää"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Tyhjennetäänkö roskakorin koko sisältö?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Kaikki roskakorissa olevat kohteet poistetaan pysyvästi."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Tyhjennä roskakori"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Poistetaanko kaikki väliaikaiset tiedostot?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Kaikki väliaikaiset tiedostot poistetaan pysyvästi."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Tu_hoa väliaikaistiedostot"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 päivä"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 päivää"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 päivää"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Ikuisesti"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Tulisi vastata kirjautumistilisi myöntäjän verkko-osoitetta."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Tilin lisäys epäonnistui"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Tilin rekisteröinti epäonnistui"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr ""
+#~ "Tähän toimialueeseen vaadittavaa tunnistautumistapaa ei ole käytettävissä"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Toimialueeseen liittyminen epäonnistui"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Käyttäjätunnus ei kelvannut.\n"
+#~ "Yritä uudelleen."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Salasana ei kelvannut.\n"
+#~ "Yritä uudelleen."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Toimialueeseen kirjautuminen epäonnistui"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Toimialuetta ei löytynyt. Kirjoititko sen oikein?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Selaa lisää kuvia"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "laite tulee vaatia käyttöön tämän toiminnon suorittamiseksi"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "toinen prosessi on jo varannut laitteen itselleen"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "käyttöoikeutesi eivät riitä tämän toiminnon suorittamiseen"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "sormenjälkiä ei ole rekisteröity"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Yhteydenpito laitteeseen epäonnistui rekisteröinnin aikana"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Yhteydenpito sormenjälkilukijaan epäonnistui"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Yhteydenpito sormenjälkitaustapalveluun epäonnistui"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Sormenjälkien listaaminen epäonnistui: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Tallennettujen sormenjälkien poistaminen epäonnistui: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Vasen peukalo"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Vasen keskisormi"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Vasen etusormi"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Vasen nimetön"
+
+#~ msgid "Left little finger"
+#~ msgstr "Vasen pikkurilli"
+
+#~ msgid "Right thumb"
+#~ msgstr "Oikea peukalo"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Oikea keskisormi"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Oikea etusormi"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Oikea nimetön"
+
+#~ msgid "Right little finger"
+#~ msgstr "Oikea pikkurilli"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Tuntematon sormi"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Valmis"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Yhteys sormenjälkilaitteeseen katkaistu"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Sormenjälkilaitteen tallennustila on täynnä"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Uuden sormenjäljen lisääminen epäonnistui"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Sormenjäljen lisäämisen aloittaminen epäonnistui: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Uuden sormenjäljen lisääminen epäonnistui"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Sormenjäljen lisäämisen pysäyttäminen epäonnistui: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Nosta sormea ja aseta se takaisin lukijaan toistuvasti lisätäksesi "
+#~ "sormenjälkesi"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Lisää uudelleen tämä sormi…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Lue uusi sormenjälki"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Sormenjälkilaitteen %s vapauttaminen epäonnistui: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Ongelma laitetta luettaessa"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Sormenjälkilaitteen %s varaaminen epäonnistui: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Sormenjälkilaitteiden saaminen epäonnistui: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Tällä viikolla"
+
+#~ msgid "Last Week"
+#~ msgstr "Viime viikolla"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Istunto päättyi"
+
+#~ msgid "Session Started"
+#~ msgstr "Istunto alkoi"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Tilin käyttöhistoria"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Valitse jokin toinen salasana."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Syötä nykyinen salasana uudelleen."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Salasanaa ei voitu vaihtaa"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Tämän tyyppiseen toimialueeseen ei voi liittyä automaattisesti"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Määriteltyä toimialuetta tai realmia ei löytynyt"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Kirjautuminen tunnuksella %s toimialueeseen %s ei onnistu"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Virheellinen salasana, yritä uudelleen"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Toimialueeseen %s yhdistäminen epäonnistui: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Käyttäjän poisto epäonnistui"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Etähallitun käyttäjän kumoaminen epäonnistui"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Et voi poistaa omaa tunnustasi."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s on yhä sisäänkirjautuneena"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Jos käyttäjä poistetaan hänen ollessaan sisäänkirjautuneena, "
+#~ "järjestelmässä voi ilmetä ongelmia."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Haluatko säilyttää käyttäjän %s tiedostot?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Voit halutessasi säilyttää kotikansion, sähköpostit ja "
+#~ "väliaikaistiedostot käyttäjätilin poiston yhteydessä."
+
+#~ msgid "_Delete Files"
+#~ msgstr "P_oista tiedostot"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Säilytä tiedostot"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Haluatko varmasti kumota käyttöoikeudet etähallitulta tililtä %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Poista"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Käyttäjätili pois käytöstä"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Asetetaan seuraavalla kirjautumiskerralla"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ei mitään"
+
+#~ msgid "Logged in"
+#~ msgstr "Sisäänkirjautuneena"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Yhteys tilipalveluun (accounts service) epäonnistui"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Varmista, että AccountService on asennettu ja käytössä."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Tämän paneelin lukitus tulee avata, jotta tätä asetusta voi muuttaa"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Poista valittu käyttäjätili"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Poista valittu käyttäjä\n"
+#~ "napsauttamalla ensin *-kuvaketta"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Avaa lukitus lisätäksesi käyttäjiä ja muuttaaksesi asetuksia"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Uusi salasana ei saa olla vanhan salasanan kaltainen."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Vaihda kirjaimia ja numeroita."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Yritä muuttaa salasanaa vielä hieman."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Älä laita käyttäjätunnustasi salasanaasi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Älä laita nimeäsi salasanaasi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Vältä salasanassasi olevia sanoja."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Vältä yleisiä, sanakirjoista löytyviä sanoja."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Älä käytä samoja sanoja eri järjestyksessä."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Käytä enemmän numeroita."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Käytä enemmän isoja kirjaimia."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Käytä enemmän pieniä kirjaimia."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Käytä erikois- ja välimerkkejä."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Sekoita kirjaimia, numeroita ja välimerkkejä."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Vältä toistamasta samaa merkkiä."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Vältä saman merkkityylin käyttöä: sekoita kirjaimia, numeroita ja "
+#~ "välimerkkejä."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Vältä sarjan kaltaisia jonoja, kuten 1234 tai abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Salasanan tulee olla nykyistä pidempi. Lisää kirjaimia, numeroita ja "
+#~ "erikoismerkkejä."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Käytä isoja ja pieniä kirjaimia sekä joitain numeroita."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Mitä enemmän kirjaimia, numeroita ja erikoismerkkejä, sitä vahvempi "
+#~ "salasana."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Tunnistautuminen epäonnistui"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Uusi salasana on liian lyhyt"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Uusi salasana on liian yksinkertainen"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Vanha ja uusi salasana ovat liian samankaltaiset"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Uusi salasana on ollut jo käytössä äskettäin."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Uuden salasanan tulee sisältää numeroita tai erikoismerkkejä"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Vanha ja uusi salasana ovat samat"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Salasanasi on vaihtunut ensimmäisen todennuksen jälkeen!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Uusi salasana ei sisällä riittävästi eri merkkejä"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Tuntematon virhe"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Käyttäjätunnuksen tulisi yleensä koostua vain pienistä kirjaimista "
+#~ "välillä a-z, numeroista sekä seuraavista merkeistä: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Valitettavasti kyseinen käyttäjätunnus ei ole saatavilla. Valitse toinen "
+#~ "käyttäjätunnus."
+
+#~ msgid "The username is too long."
+#~ msgstr "Käyttäjätunnus on liian pitkä."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Painike %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Sovelluksen määrittämä"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Lähetä näppäinpainallus"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Vaihda näyttöä"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Näytä ohjeet näytöllä"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Piirtopöytä kiinnitettynä kannettavan paneeliin"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Piirtopöytä kiinnitettynä erilliseen näyttöön"
+
+#~ msgid "External tablet device"
+#~ msgstr "Ulkoinen piirtopöytälaite"
+
+#~ msgid "All Displays"
+#~ msgstr "Kaikki näytöt"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Airbrush-piirtokynä paineella, kallistuksella ja integroidulla "
+#~ "liukusäätimellä"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Airbrush-piirtokynä paineella, kallistuksella ja kierrolla"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standardi piirtokynä paineella ja kallistuksella"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standardi piirtokynä paineella"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Uusi pikanäppäin…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Toiminto peruttu"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Virhe:</b> Asetusten muuttaminen on estetty"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Virhe:</b> Mobiilitarvikkeen virhe"
+
+#~ msgid "Not Registered"
+#~ msgstr "Ei rekisteröity"
+
+#~ msgid "Registered"
+#~ msgstr "Rekisteröity"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Etsitään"
+
+#~ msgid "Denied"
+#~ msgstr "Estetty"
+
+#~ msgid "2G Only"
+#~ msgstr "Vain 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Vain 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Vain 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Vain 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (ensisijainen)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (ensisijainen), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (ensisijainen), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (ensisijainen), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (ensisijainen)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (ensisijainen), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (ensisijainen), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (ensisijainen)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (ensisijainen), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (ensisijainen), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (ensisijainen)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (ensisijainen), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (ensisijainen), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (ensisijainen)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (ensisijainen), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (ensisijainen), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (ensisijainen)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (ensisijainen), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (ensisijainen)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (ensisijainen), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (ensisijainen)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (ensisijainen), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (ensisijainen)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (ensisijainen), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (ensisijainen)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (ensisijainen), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (ensisijainen)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (ensisijainen), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Tuntematon"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Avaa SIM-kortin lukitus"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Anna SIM-kortin %d PIN-koodi"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Anna PIN-koodi avataksesi SIM-kortin lukituksen"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Anna SIM-kortin %d PUK-koodi"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Anna PUK-koodi avataksesi SIM-kortin lukituksen"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Annettiin väärä salasana."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK-koodin tulisi olla 8 numeroa"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Anna uusi PIN-koodi"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN-koodin tulee olla 4-8 numeroa pitkä"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Avataan lukitus…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Puhelinvirhe"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Ei yhteyttä puhelimeen"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Toiminto ei ole sallittu"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Toiminto ei ole tuettu"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM-korttia ei ole syötetty"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM-kortin PIN-koodi vaaditaan"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM-kortin PUK-koodi vaaditaan"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM-virhe"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM käytössä"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Väärä salasana"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM-kortin PIN2-koodi vaaditaan"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM-kortin PUK2-koodi vaaditaan"
+
+#~ msgid "Not found"
+#~ msgstr "Ei löytynyt"
+
+#~ msgid "No network service"
+#~ msgstr "Ei verkkopalvelua"
+
+#~ msgid "Network timeout"
+#~ msgstr "Verkon aikakatkaisu"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS-palvelut eivät ole sallittuja"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming ei ole sallittu tällä alueella"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Määrittämätön GPRS-virhe"
+
+#~ msgid "No Error"
+#~ msgstr "Ei virhettä"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Toiminto peruttu"
+
+#~ msgid "Access denied"
+#~ msgstr "Pääsy estetty"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Tuntematon virhe"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Näytä versionumero"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Ota käyttöön lisätietoja tulostava tila"
+
+#~ msgid "Search for the string"
+#~ msgstr "Etsi merkkijonoa"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Näytä mahdolliset paneelinimet ja lopeta"
+
+#~ msgid "Panel to display"
+#~ msgstr "Näytettävä paneeli"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEELI] [ARGUMENTTI…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Käytettävissä olevat paneelit:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Järjestelmän äänet"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Virhe: ei voitu määrittää HSI-tasoa."
@@ -9635,9 +8328,6 @@ msgstr "Järjestelmän äänet"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER- tai PEM-varmenteet (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Lisää tulostin…"
 
 #~ msgid "Light"
 #~ msgstr "Vaalea"
@@ -9736,11 +8426,11 @@ msgstr "Järjestelmän äänet"
 #~ msgstr "Ei voi muuttaa"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "Sovellusten yksittäiset oikeudet on mahdollista katselmoida <a href="
-#~ "\"privacy\">yksityisyysasetuksissa</a>."
+#~ "Sovellusten yksittäiset oikeudet on mahdollista katselmoida <a "
+#~ "href=\"privacy\">yksityisyysasetuksissa</a>."
 
 #~ msgid "Integration"
 #~ msgstr "Integraatio"
@@ -10022,9 +8712,6 @@ msgstr "Järjestelmän äänet"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Piirtopöytä (yksi yhteen)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Kosketuslevy (suhteellinen)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Piirtopöydän asetukset"
 
@@ -10193,9 +8880,6 @@ msgstr "Järjestelmän äänet"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Suora pääsy bluetooth-laitteisiin"
-
-#~ msgid "Use your camera"
-#~ msgstr "Käytä kameraa"
 
 #~ msgid "Print documents"
 #~ msgstr "Tulosta asiakirjoja"
@@ -10507,8 +9191,8 @@ msgstr "Järjestelmän äänet"
 #~ msgid ""
 #~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
 #~ msgstr ""
-#~ "Yhteyspisteen käyttöönotto katkaisee yhteyden langattomaan verkkoon <b>"
-#~ "%s</b>."
+#~ "Yhteyspisteen käyttöönotto katkaisee yhteyden langattomaan verkkoon "
+#~ "<b>%s</b>."
 
 #~ msgid ""
 #~ "It is not possible to access the Internet through your wireless while the "
@@ -11132,9 +9816,6 @@ msgstr "Järjestelmän äänet"
 #~ msgid "Mirrored"
 #~ msgstr "Peilattu"
 
-#~ msgid "Secondary"
-#~ msgstr "Toissijainen"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Järjestä yhdistetyt näytöt"
 
@@ -11307,9 +9988,6 @@ msgstr "Järjestelmän äänet"
 #~ msgid "Mail"
 #~ msgstr "Sähköposti"
 
-#~ msgid "Calendar"
-#~ msgstr "Kalenteri"
-
 #~ msgid "Contacts"
 #~ msgstr "Yhteystiedot"
 
@@ -11468,9 +10146,6 @@ msgstr "Järjestelmän äänet"
 #~ msgid "Scroll Up"
 #~ msgstr "Vieritys ylös"
 
-#~ msgid "Scroll Down"
-#~ msgstr "Vieritys alas"
-
 #~ msgid "Scroll Right"
 #~ msgstr "Vieritys oikealle"
 
@@ -11525,8 +10200,8 @@ msgstr "Järjestelmän äänet"
 #~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
 #~ "disabled."
 #~ msgstr ""
-#~ "Jos siirrät pikanäppäimen toimintoon \"%s\", poistetaan pikanäppäin \"%s"
-#~ "\" käytöstä."
+#~ "Jos siirrät pikanäppäimen toimintoon \"%s\", poistetaan pikanäppäin "
+#~ "\"%s\" käytöstä."
 
 #~ msgid "_Reassign"
 #~ msgstr "_Siirrä"
@@ -11752,9 +10427,6 @@ msgstr "Järjestelmän äänet"
 
 #~ msgid "China"
 #~ msgstr "Kiina"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "_Poista kosketuslevy käytöstä kirjoitettaessa"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr ""

--- a/po/fi.po~
+++ b/po/fi.po~
@@ -1,0 +1,11781 @@
+# gnome-control-center Finnish translation
+# Copyright (C) 2004-2009 Free Software Foundation, Inc.
+# Mikko Rauhala <mjr@iki.fi>, x-2000
+#
+# sticky key = pohjaan jäävä näppäin
+# bounce key = kimmonäppäin
+# mouse key = hiirinäppäin
+# toggle key = piippaava näppäin
+#
+# Gnome 2012-13 Finnish translation sprint participants:
+# Niklas Laxström
+# Timo Jyrinki
+#
+#
+#
+# Pauli Virtanen <pauli.virtanen@hut.fi>, 2000-2004.
+# Ilkka Tuohela <hile@iki.fi>, 2005-2009.
+# Tommi Vainikainen <thv@iki.fi>, 2009-2010.
+# Timo Jyrinki <timo.jyrinki@iki.fi>, 2008-2011.
+# Ville-Pekka Vainio <vpvainio@iki.fi>, 2013.
+# Lasse Liehu <lasse.liehu@gmail.com>, 2013, 2014.
+# Jiri Grönroos <jiri.gronroos+l10n@iki.fi>, 2012, 2013, 2014, 2015, 2016, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-08-28 14:52+0000\n"
+"PO-Revision-Date: 2022-08-30 16:42+0300\n"
+"Last-Translator: Jiri Grönroos <jiri.gronroos+l10n@iki.fi>\n"
+"Language-Team: suomi <lokalisointi-lista@googlegroups.com>\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.1.1\n"
+"X-POT-Import-Date: 2012-03-07 10:37:43+0000\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Järjestelmäväylä"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Täydet oikeudet"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Istuntoväylä"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Laitteet"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Täysi pääsy kohteeseen /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Verkko"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Verkon käyttö"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Koti"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Vain luku"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Tiedostojärjestelmä"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Asetukset"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Voi muuttaa asetuksia"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s omaa seuraavat sisäänrakennetut oikeudet. Niitä ei voi muuttaa. Jos olet "
+"huolissasi näistä oikeuksia, harkitse sovelluksen poistamista."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u tiedosto- ja linkkityyppi, jonka tämä sovellus avaa"
+msgstr[1] "%u tiedosto- ja linkkityyppiä, jotka tämä sovellus avaa"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"Sovellusta <b>%s</b> käytetään seuraavanlaisten tiedostojen ja linkkien "
+"avaamiseen."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s levytilaa käytetty."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Sovellukset"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Ei sovelluksia"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Asenna joitain…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Avaa"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Näytä tiedot"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Haku"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Vastaanota hakuja järjestelmältä ja lähetä tuloksia."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Ei käytössä"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Ilmoitukset"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Näytä järjestelmäilmoituksia."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Suorita taustalla"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Salli toiminta kun sovellus on suljettu."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Kuvakaappaukset"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Ota kuvia näytöstä milloin tahansa."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Vaihda taustakuva"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Vaihda työpöydän taustakuva."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Äänet"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Toista ääniä."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Estä pikanäppäimet"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Estä standardit pikanäppäimet."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Ota kuvia kameralla."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofoni"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Äänitä mikrofonilla."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Sijaintipalvelut"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Pääsy laitteen sijaintitietoon."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Sisäänrakennetut oikeudet"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Sovelluksen vaatima järjestelmän käyttöoikeus"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Tiedosto- ja linkkisidokset"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Tallennustila"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Tuloksia ei löytynyt"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Yritä eri hakuehdoilla"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Tiedosto- ja linkkisidokset"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Tiedostotyypit"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Linkkityypit"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Tyhjennä asetukset"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Kuinka paljon levytilaa tämä sovellus varaa sovellustiedoin ja välimuistin "
+"kera."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Sovellus"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Tiedot"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Välimuisti"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Yhteensä</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Tyhjennä välimuisti…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Hallitse sovellusten eri oikeuksia ja asetuksia"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "application;flatpak;permission;setting;sovellus;käyttöoikeudet;asetus;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Valitse kuva"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Peru"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Avaa"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "useita kokoja"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Ei työpöydän taustaa"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Nykyinen taustakuva"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Tyyli"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Oletus"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Tumma"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Taustakuva"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Lisää kuva…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Ulkoasu"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Vaihda taustakuva tai käyttöliittymän värejä"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;Taustakuva;"
+"Näyttö;Työpöytä;tyyli;vaalea;tumma;ulkoasu;ulkonäkö;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Käytä"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Bluetoothia ei löytynyt"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Liitä sovitin käyttääksesi Bluetoothia."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth on pois päältä"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Kytke päälle yhdistääksesi laitteita ja vastaanottaaksesi tiedostoja."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Lentokonetila on päällä"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth on pois käytöstä, kun lentokonetila on päällä."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Poista lentokonetila käytöstä"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Laitetason lentokonetila on päällä"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Poista lentokonetila käytöstä käyttääksesi Bluetoothia."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Kytke Bluetooth päälle tai pois ja yhdistä laitteita"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;jakaminen;jaot;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera on sammutettu"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Mikään sovellus ei voi ottaa valokuvia tai videota."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Kameran käyttö mahdollistaa sovellusten ottaa valo- ja videokuvaa. Kameran "
+"poistaminen käytöstä saattaa aiheuttaa ongelmia joidenkin sovellusten "
+"toimintaan.\n"
+"\n"
+"Salli alla olevien sovellusten käyttää kameraa."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Mikään sovellus ei ole pyytänyt kameran käyttöoikeutta"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Suojaa kuvasi"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;kamera;kuvat;lukitus;"
+"yksityisyys;tietosuoja;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Aseta kalibrointilaite neliön päälle ja napsauta ”Käynnistä”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "Vaihda kalibrointilaite kalibrointiasentoon ja napsauta ”Jatka”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Vaihda kalibrointilaite kalibrointiasentoon ja napsauta ”Jatka”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Sulje kannettavan kansi"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Tapahtui sisäinen virhe josta ei voitu toipua."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Kalibrointiin vaadittavia työkaluja ei ole asennettu."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Profiilin luonti ei onnistunut."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Kohdevalkopiste ei ole saavutettavissa."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Valmis!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrointi epäonnistui!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Voit irrottaa kalibrointilaitteen."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Älä liikuta kalibrointilaitetta kesken kalibroinnin"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Näytön kalibrointi"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Käynnistä"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Jatka"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Valmis"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Kannettavan näyttö"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Sisäänrakennettu web-kamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Näyttö - %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Kuvanlukija - %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Kamera - %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Tulostin - %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Web-kamera - %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Käytä värinhallintaa laitteelle %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Näytä laitteen %s väriprofiilit"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Ei kalibroitu"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Oletus: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Väriavaruus: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Testiprofiili: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Valitse ICC-profiilitiedosto"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Tuo"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Tuetut ICC-profiilit"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Kaikki tiedostot"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Näyttö"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Tallenna profiili"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Tallenna"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Luo väriprofiili valitulle laitteelle"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Mittalaitetta ei tunnistettu. Tarkista että se on oikein liitetty ja että "
+"siinä on virta päällä."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Mittalaite ei tue tulostimien profilointia."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Laitetyyppi ei ole tällä hetkellä tuettu."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Näytön kalibrointi"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibrointilaatu"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrointi tuottaa profiilin, jota voi käyttää näytön värien hallintaan. "
+"Profiilista tulee sitä parempi mitä kauemmin aikaa kalibrointiin käytetään."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Et voi käyttää tietokonettasi, kun kalibrointi on meneillään."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Laatu"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Arvioitu aika"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibrointilaite"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Valitse anturilaite jota haluat käyttää kalibrointiin."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Näytön tyyppi"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Valitse yhdistetyn näytön tyyppi."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profiilin valkopiste"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Valitse näytön valkopiste. Useimmat näytöt tulisi kalibroida D65-"
+"valonlähteeseen."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Näytön kirkkaus"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Aseta näyttö siihen kirkkauteen, jolla yleensä käytät sitä. Värienhallinta "
+"tulee olemaan tarkinta tällä kirkkaustasolla."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Voit myös käyttää samaa kirkkaustasoa kuin muut tätä laitetta varten tehdyt "
+"profiilit."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profiilin nimi"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Voit käyttää väriprofiilia eri tietokoneilla, tai vaikkapa luoda profiileja "
+"eri valaistuksia varten."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profiilin nimi:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Yhteenveto"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profiili luotiin onnistuneesti!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopioi profiili"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Vaatii median, johon on mahdollista kirjoittaa"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Näistä ohjeista profiilin käyttöön <a href=\"linux\">GNU/Linuxilla</a>, <a "
+"href=\"osx\">Apple OS X:llä</a> ja <a href=\"windows\">Windowsilla</a> "
+"saattaa olla hyötyä."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Lisää profiili"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Ongelmia havaittu. Profiili ei välttämättä toimi kunnolla. <a href="
+"\"\">Näytä tiedot.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Tuo tiedosto\t…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Lisää"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Laitteet vaativat ajan tasalla olevan väriprofiilin, jotta niiden värejä on "
+"mahdollista hallita."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Lue lisää"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Lue lisää värienhallinnasta"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Aseta _kaikille käyttäjille"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Aseta tämä profiili kaikille tietokoneen käyttäjille"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "K_äytä"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Lisää profiili"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibroi…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibroi laite"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Poista profiili"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "Näytä yk_sityiskohdat"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Värihallinnan piiriin sopivia laitteita ei havaittu"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektori"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL-taustalamppu)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED -taustalamppu)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (valkoinen LED-taustalamppu)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Laajan gamutin LCD (CCFL-taustalamppu)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Laajan gamutin LCD (RGB LED -taustalamppu)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Korkea"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minuuttia"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Keskitaso"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minuuttia"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Matala"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minuuttia"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Näytön natiivi"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Tulostus ja julkaisu)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Valokuvaus ja grafiikka)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standardiavaruus"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testiprofiili"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automaattinen"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Matala laatu"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Keskimääräinen laatu"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Korkea laatu"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Oletus-RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Oletus-CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Oletusharmaasävy"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Valmistajan toimittaja tehdaskalibrointidata"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Koko ruudun näyttökorjaus ei ole mahdollista tällä profiililla"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Tämä profiili ei välttämättä ole enää tarkka"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Värit"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Kalibroi laitteidesi, kuten näytön, kameran ja tulostimen värejä"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Väri;ICC;color;profiili;kalibrointi;Calibrate;Tulostin;Printer;Näyttö;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Muu…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Valitse kieli"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Valitse"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Kieli ei löytynyt"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Lisää…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Avaa lukitus muuttaaksesi asetuksia"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Joidenkin asetusten lukitus tulee avata, ennen kuin niitä voi muuttaa."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Avaa lukitus…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Lisää tunti"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Lisää minuutti"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Aika"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Vähennä tunti"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Vähennä minuutti"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Tänään"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Eilen"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d tunti"
+msgstr[1] "%d tuntia"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuutti"
+msgstr[1] "%d minuuttia"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekunti"
+msgstr[1] "%d sekuntia"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekuntia"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Yhteyspiste"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 tuntia"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e. %Bta %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e. %Bta %Y, %H.%M"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%H.%M"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Päivä ja aika"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Vuosi"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Kuukausi"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Tammikuu"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Helmikuu"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Maaliskuu"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Huhtikuu"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Toukokuu"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Kesäkuu"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Heinäkuu"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Elokuu"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Syyskuu"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Lokakuu"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Marraskuu"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Joulukuu"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Päivä"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Aikavyöhyke"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Etsi kaupunkia"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automaattinen _päivä ja aika"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Vaatii internetyhteyden"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Päivä _ja aika"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automaattinen _aikavyöhyke"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+"Vaatii paikannuspalvelun olevan käytössä ja aktiivisen internetyhteyden"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Käytössä"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Aikav_yöhyke"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Ajan _muoto"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Vaihda aikaa, päivää tai aikavyöhykettä"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Kello;Aikavyöhyke;Sijainti;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Muuta järjestelmän aika-asetuksia"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Muuttaaksesi ajan tai päivän asetuksia sinun tulee tunnistautua."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Verkko"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Sähköposti"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalenteri"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usiikki"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Kuvat"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Oletussovellukset"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Määritä oletussovellukset"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;oletussovellus;ensisijainen;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Vikailmoitusten lähettäminen auttaa parantamaan %sa. Ilmoitukset eivät "
+"sisällä henkilökohtaisia tietoja. Ilmoitukset lähetetään anonyymisti. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Vikailmoitukset"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automaattiset vikailmoitukset"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostiikka"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Ilmoita ongelmista"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;diagnostiikka;vianselvitys;kaatuminen;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Päällä"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Pois"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Toteutetaanko muutokset?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Muutoksia ei voitu toteuttaa"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Tämä saattaa johtua laitteiston rajoituksista."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Toteuta"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Takaisin"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Näyttöasetukset pois käytöstä"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Useita näyttöjä"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Liitä"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Peili"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Sisältää yläpalkin ja Toiminnot"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Ensisijainen näyttö"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Yövalo"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Vaaka"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Pysty oikea"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Pysty vasen"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Vaaka (käännetty)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Suunta"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Tarkkuus"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Päivitystaajuus"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Sovita TV:hen"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skaalaus"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Yövalo ei ole saatavilla"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Tämä saattaa olla tulos käytettävästä grafiikka-ajurista, tai työpöytää "
+"käytetään etänä"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Poistettu väliaikaisesti käytöstä huomiseen asti"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Käynnistä suodatin uudelleen"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Yövalo tekee näytön väreistä tavallista lämpimämpiä. Sen on tarkoitus estää "
+"silmien rasittumista ja unettomuutta."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Aikataulu"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Auringonlaskusta auringonnousuun"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Mukautettu aikataulu"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Aika"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Alkaa"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Tunti"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuutti"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Päättyy"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Värilämpötila"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Näytöt"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Valitse kuinka näyttöjä ja projektoreja käsitellään"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;Paneeli;Projektori;Näyttö;Resoluutio;Tarkkuus;"
+"Virkistystaajuus;yövalo;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Secure Boot on aktiivinen"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Secure Boot estää haitallisia ohjelmia latautumasta laitteen käynnistyessä. "
+"Se on nyt käytössä ja toimii oikein."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Secure Bootin kanssa on ongelmia"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Secure Boot estää haitallisia ohjelmia latautumasta laitteen käynnistyessä. "
+"Se on nyt kytketty päälle, mutta ei toimi virheellisen avaimen vuoksi."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Secure Boot -ongelmat on yleensä mahdollista korjata tietokoneen UEFI-"
+"laiteohjelmiston asetuksista (BIOS). Laitevalmistaja saattaa tarjota "
+"ohjeita, kuinka edetä asian kanssa."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "Pyydä tarvittaessa apua laitevalmistajalta tai IT-tuelta."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Secure Boot on kytketty pois päältä"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Secure Boot estää haitallisia ohjelmia latautumasta laitteen käynnistyessä. "
+"Se on nyt kytketty pois käytöstä."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Secure Boot on yleensä mahdollista ottaa käyttöön tietokoneen UEFI-"
+"laiteohjelmiston asetuksista (BIOS). Lisätietoja saat tarvittaessa "
+"laitevalmistajalta tai IT-tuelta."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Secure Boot estää haitallisia ohjelmia latautumasta laitteen käynnistyessä.\n"
+"\n"
+"Pyydä tarvittaessa lisätietoja laitevalmistajalta tai IT-tuesta."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Läpäisty"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Epäonnistui"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Laite myötäilee HSI-tasoa %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Suojaustaso 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Tässä laitteessa ei ole suojausta laitetason tietoturvaongelmia vastaan. "
+"Tämä saattaa johtua laitteen tai laiteohjelmiston asetusongelmasta. Ole "
+"tarvittaessa yhteydessä IT-tukeen."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Suojaustaso 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Tässä laitteessa on vähimmäissuojaus laitetason tietoturvaongelmia vastaan. "
+"Tämä on matalin laitteen suojaustaso ja se tarjoaa suojauksen vain "
+"yksinkertaisia tietoturvauhkia vastaan."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Suojaustaso 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Tässä laitteessa on perustason suojaus laitetason tietoturvaongelmia "
+"vastaan. Se tarjoaa suojauksen joitain yleisimpiä tietoturvauhkia vastaan."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Suojaustaso 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Tässä laitteessa on laajennettu suojaus laitetason tietoturvaongelmia "
+"vastaan. Tämä on korkein laitteen suojaustaso ja se tarjoaa suojauksen "
+"edistyneitä tietoturvauhkia vastaan."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Suojaustaso"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Suojaustasot eivät ole saatavilla tälle laitteelle."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Ole yhteydessä laitevalmistajaan saadaksesi apua tietoturvapäivitysten "
+"kanssa."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Tämä ongelma on mahdollisesti selvitettävissä laitteen UEFI-laiteohjelmiston "
+"asetuksissa tai IT-tukihenkilön toimesta."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Tämä ongelma on mahdollisesti selvitettävissä laitteen UEFI-laiteohjelmiston "
+"asetuksissa."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+"Tämä ongelma on mahdollisesti selvitettävissä IT-tukihenkilön toimesta."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Taso 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Taso 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Taso 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Suojattu haitallisia ohjelmia vastaan laitteen käynnistyessä."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Secure Bootin kanssa on ongelmia"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Jonkinlaista suojausta laitteen käynnistyessä."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Secure Boot on pois päältä"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Ei suojausta laitteen käynnistyessä."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Tämä ongelma johtuu mahdollisesti muutoksista UEFI-laiteohjelmiston "
+"asetuksissa, käyttöjärjestelmän asetusmuutoksista tai haitallisesta "
+"ohjelmistosta tässä järjestelmässä."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Tämä ongelma johtuu mahdollisesti muutoksista UEFI-laiteohjelmiston "
+"asetuksissa tai haitallisesta ohjelmistosta tässä järjestelmässä."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Tämä ongelma johtuu mahdollisesti käyttöjärjestelmän asetusmuutoksista tai "
+"haitallisesta ohjelmistosta tässä järjestelmässä."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Alttiina vakaville tietoturvauhille."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Rajoitetusti suojattu yksinkertaisilta tietoturvauhilta."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Suojattu yleisiltä tietoturvauhilta."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Suojattu laajalta joukolta tietoturvauhkia."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Kattava suojaus"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Ei tapahtumia"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Laiteohjelmiston kirjoitussuojaus"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Laiteohjelmiston kirjoitussuojauksen lukko"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Laiteohjelmiston BIOS:in alue"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Laiteohjelmiston BIOS:in deskriptori"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Esikäynnistyksen DMA-suojaus"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuardin vahvistettu käynnistys"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM-suojattu"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard -virhekäytäntö"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard Fuse"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET käytössä"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET aktiivisena"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Salattu RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU-suojaus"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux-ytimen Lockdown-suojaus"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux-ytimen todentaminen"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linuxin swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Keskeytä keskusmuistiin"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Keskeytys idleen"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI-alusta-avain"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI Secure Boot"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM-alustan kokoonpano"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM-jälleenrakennus"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine -valmistajatila"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine -ylitys"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine -versio"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Laiteohjelmistopäivitykset"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Laiteohjelmiston todistus"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Laiteohjelmiston päivitysohjelman vahvistus"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Alustan virheenjäljitys"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Suorittimen turvallisuustarkastukset"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD:n takaisinpaluusuojaus"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD:n laiteohjelmiston Replay-suojaus"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD:n laiteohjelmiston kirjoitussuojaus"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Fused-alusta"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Kelvollinen"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Ei kelvollinen"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Ei käytössä"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Lukittu"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Ei lukittu"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Salattu"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Ei salattu"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Turmeltunut"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Ei turmeltu"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Löytyi"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Ei löytynyt"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Tuettu"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Ei tuettu"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Laitteen suojaus"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Host-koneen laiteohjelmiston suojaustila"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;näyttö;lukitus;diagnostikka;kaatuminen;yksityinen;"
+"viimeisimmät;väliaikset;nimi;verkko;identiteetti;yksityisyys;tietosuoja;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Ei saatavilla"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Järjestelmän logo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Laitteen nimi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Laitemalli"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Muisti"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Suoritin"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafiikka"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Levyn kapasiteetti"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Lasketaan…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Käyttöjärjestelmän nimi"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Käyttöjärjestelmän koontitunniste"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Käyttöjärjestelmän tyyppi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Gnomen versio"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Ladataan…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Ikkunointijärjestelmä"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisointi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Ohjelmistopäivitykset"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Nimeä laite uudelleen"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Laitteen nimeä käytetään laitteen tunnistamiseen, kun sitä tarkastellaan "
+"verkossa tai paritetaan Bluetooth-laitteita."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Laitteen nimi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Nimeä uudelleen"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Tietoja"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Katsele järjestelmän tietoja"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"laite;järjestelmä;tiedot;konenimi;isäntänimi;muisti;suoritin;prosessori;"
+"versio;oletus;oletukset;sovellus;suositellut;ensisijaiset;"
+"automaattikäynnistys;ääni;irrotettava;ulkoinen;erillinen;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Ääni ja media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Äänen mykistys päällä/pois"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Vähennä äänenvoimakkuutta"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Lisää äänenvoimakkuutta"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Mikrofonin mykistys päällä/pois"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Käynnistä mediasoitin"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Soita (tai tauko)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Keskeytä toisto"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Pysäytä toisto"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Edellinen kappale"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Seuraava kappale"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Irrota"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Kirjoittaminen"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Vaihda seuraavaan lähteeseen"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Vaihda edelliseen lähteeseen"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Käynnistimet"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Käynnistä ohjeselain"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Käynnistä laskin"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Käynnistä sähköpostisovellus"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Käynnistä internetselain"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Kotikansio"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Etsi"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Järjestelmä"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Kirjaudu ulos"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Lukitse näyttö"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Esteettömyys"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Suurennus päällä/pois"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Lähennä"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Loitonna"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Näytönlukija päällä/pois"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Virtuaalinäppäimistö päällä/pois"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Suurenna tekstin kokoa"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Pienennä tekstin kokoa"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Korkea kontrasti päälle/pois"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Syötelähteitä ei löytynyt"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Muu"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Lisää syötelähde"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Syötemenetelmiä ei voi käyttää kirjautumisruudussa"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Syötelähdettä ei valittu"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Valinnat"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Siirrä ylös"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Siirrä alas"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Asetukset"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Näytä näppäimistöasettelu"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Poista"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Omat pikanäppäimet"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Vaihtoehtoinen merkkinäppäin"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Vaihtoehtoista merkkinäppäintä voi käyttää lisämerkkien kirjoittamiseen. "
+"Nämä merkit on usein merkitty näppäimiin kolmantena näytettävänä merkkinä."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Vasen Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Oikea Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Vasen Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Oikea Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Valikkonäppäin"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Oikea Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose-näppäin"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Compose-näppäin mahdollistaa useiden erilaisten merkkien kirjoittamisen. "
+"Paina ensin compose-näppäintä ja sitten muita merkkejä.  Esimerkiksi compose-"
+"näppäin, <b>C</b> ja <b>o</b> muodostavat merkin <b>©</b>, <b>a</b> ja <b>'</"
+"b> muodostavat merkin <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Syötetapoja voi vaihtaa käyttämällä pikanäppäintä %s.\n"
+"Näitä pikanäppäimiä voi muuttaa pikanäppäinten asetuksissa."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Syötelähteet"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Sisältää näppäimistöasettelut ja syötetavat."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Syötelähteen vaihtaminen"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Käytä _samaa lähdettä kaikille ikkunoille"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Vaihda syötelähteitä _yksittäin eri ikkunoille"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Erikoismerkkien kirjoitus"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Tavat eri symbolien ja kirjainmuunnelmien syöttämiseen näppäimistöllä."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Pikanäppäimet"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Katsele ja mukauta pikanäppäimiä"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d muokattu"
+msgstr[1] "%d muokattu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Palautetaanko kaikkien pikanäppäinten oletukset?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Pikanäppäinten oletusten palauttaminen vaikuttaa asettamiisi pikanäppäimiin. "
+"Tätä toimintoa ei voi perua."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Peru"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Palauta kaikki oletusasetukset"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Palauta kaikki oletusasetukset…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Palauta kaikki pikanäppäimet oletusarvoihin"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Osio"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Pikanäppäimet"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Lisää pikanäppäin"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Lisää mukautettu pikanäppäin"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Aseta mukautettuja pikanäppäimiä sovellusten käynnistämiseksi, "
+"komentorivisarjojen suorittamiseksi ja niin edelleen."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Lisää pikanäppäin"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Näppäimistön pikanäppäintä ei löytynyt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s on jo asetettu toimintoon %s. Jos korvaat sen, toiminto %s poistetaan "
+"käytöstä"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Anna uusi pikanäppäin"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Aseta oma pikanäppäin"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Aseta pikanäppäin"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Anna uusi pikanäppäin vaihtaaksesi toiminnon %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Lisää oma pikanäppäin"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Poista"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Korvaa"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Aseta"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Paina Esc peruaksesi tai askelpalautinta poistaaksesi pikanäppäimen käytöstä."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nimi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Komento"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Pikanäppäin"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Aseta pikanäppäin…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ei mikään"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Palauta pikanäppäin oletusarvoon"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Näppäimistö"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Muuta näppäimistön pikanäppäimiä ja aseta kirjoitusasetuksesi, "
+"näppäimistöasettelut ja syötelähteet"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+"pikanäppäin;työtila;ikkuna;syöte;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Sijaintipalvelut ovat pois päältä"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Mikään sovellus ei voi saada sijaintitietoa."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Sijaintipalvelut mahdollistavat sovellusten paikantaa sijaintisi. Tarkkuus "
+"paranee wifiä ja mobiiliyhteyttä käyttäen.\n"
+"\n"
+"Käyttää Mozillan paikannuspalvelua: <a href='https://location.services."
+"mozilla.com/privacy'>Tietosuojakäytäntö</a>\n"
+"\n"
+"Salli alla listattujen sovellusten paikantaa sijaintisi."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Mikään sovellus ei ole pyytänyt sijainnin käyttöoikeutta"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Suojaa sijaintitietoasi"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;sijainti;yksityisyys;tietosuoja;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofoni on pois päältä"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Sovellukset eivät voi tallentaa ääntä."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Mikrofonin käyttö mahdollistaa sovellusten tallentaa ja kuunnella ääntä. "
+"Mikrofonin poistaminen käytöstä saattaa aiheuttaa ongelmia joidenkin "
+"sovellusten toiminnassa.\n"
+"\n"
+"Salli alla listattujen sovellusten käyttää mikrofonia."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Mikään sovellus ei ole pyytänyt mikrofonin käyttöoikeutta"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Suojaa keskustelusi"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"microphone;recording;application;privacy;mikrofoni;nauhoitus;tallennus;"
+"sovellus;yksityisyys;tietosuoja;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Testaa asetukset"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Yleiset"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Ensisijainen painike"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+"Aseta fyysisten painikkeiden järjestys hiirien ja kosketuslevyjen kohdalla."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Vasen"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Oikea"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Hiiri"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Hiiren nopeus"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Luonnollinen vieritys"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Vieritys liikuttaa sisältöä, ei näkymää."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Kosketuslevy"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Kosketuslevyn nopeus"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Napsauta napauttamalla"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Napsauta napauttamalla"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Kahden sormen vieritys"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Reunavieritys"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Kokeile napsauttamista, kaksoisnapsauttamista ja vierittämistä"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Viisi napsautusta, GEGL-aika!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Kaksoisnapsautus, ensisijainen painike"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Yksi napsautus, ensisijainen painike"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Kaksoisnapsautus, keskimmäinen painike"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Yksi napsautus, keskimmäinen painike"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Kaksoisnapsautus, toissijainen painike"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Yksi napsautus, toissijainen painike"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Hiiri ja kosketuslevy"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Muuta hiiren tai kosketuslevyn herkkyyttä ja valitse kumpaa kättä käytät"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Kosketuslevy;Trackpad;Osoitin;Kohdistin;Napsauta;Klikkaa;Painike;Nappi;"
+"Kaksois;Pallohiiri;Trackball;vieritä;Tap;Double;Button;Tuplaklikkaa;Kaksois;"
+"Scroll;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Aktivointikulma"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Kosketa vasenta yläkulmaa avataksesi Toiminnot-yleisnäkymän."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Aktiiviset _näytön reunat"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Vedä ikkunat näytön yläreunaa, vasenta reunaa ja oikeaa reunaa vasten "
+"muuttaaksesi ikkunoiden kokoa."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Työtilat"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dynaamiset työtilat"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Poista automaattisesti tyhjät työtilat."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Muuttumaton määrä työtiloja"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Määritä muuttumattomien työtilojen määrä."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Työtilojen määrä"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Useampi näyttö"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Työtilat vain _ensisijaisella näytöllä"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Työtilat _kaikilla näytöillä"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Sovellusten välillä vaihtaminen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Sisällytä sovellukset k_aikista työtiloista"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Sisällytä sovellukset _vain nykyisestä työtilasta"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Moniajo"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Hallinnoi tuottavuuden ja moniajon asetuksia"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"moniajo;tuottavuus;mukautus;mukauttaminen;samanaikainen;aktivointikulma;"
+"työtilat;virtuaalipöydät;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Hups, jokin taisi mennä pieleen. Ota yhteys sovellustoimittajaan."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManagerin tulee olla käynnissä."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Muut laitteet"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Lisää yhteys"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Ei määritetty"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Turvaton verkko (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Turvallinen verkko (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Turvallinen verkko (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Turvallinen verkko (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Turvallinen verkko"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Yhdistetty"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Valinnat…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Yhteyspisteen ottaminen käyttöön katkaisee yhteyden verkkoon %s, eikä yhteys "
+"internetiin onnistu wifin kautta."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Tulee olla vähintään 8 merkkiä"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Tulee olla enintään %d merkki"
+msgstr[1] "Tulee olla enintään %d merkkiä"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Otetaanko wifi-yhteyspiste käyttöön?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wifi-yhteyspiste mahdollistaa internetyhteytesi jakamisen luomalla wifi-"
+"verkon, johon muut voivat yhdistää. Tämän edellytys on, että yhteys "
+"internetiin on muodostettu jollain muulla tavalla kuin wifi-yhteydellä."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Verkon nimi"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Salasana"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Luo satunnainen salasana"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Luo automaattisesti salasana"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Ota käyttöön"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wifi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Suljetaanko yhteyspiste ja katkaistaanko kaikkien käyttäjien yhteydet?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Sulje yhteyspiste"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Lentokonetila"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Poistaa käytöstä wifin, Bluetoothin ja mobiililaajakaistan"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Wifi-sovitinta ei löytynyt"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Varmista, että wifi-sovitin on kiinnitetty ja käynnistetty"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Lentokonetila päällä"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Sammuta käyttääksesi wifiä"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wifi-yhteyspiste aktiivisena"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobiililaitteet voivat lukea QR-koodin yhdistääkseen."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Käynnistä wifi-yhteyspiste…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Näkyvissä olevat verkot"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManagerin tulee olla käynnissä"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x-suojaus"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Tietoturva"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Varaa"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Pysyvä"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Satunnainen"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Vakaa"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Tähän kirjoitettua MAC-osoitetta käytetään laiteosoitteena sille "
+"verkkolaitteelle, jolle tämä yhteys aktivoidaan. Ominaisuus tunnetaan "
+"termeillä MAC-kloonaus tai -spooffaus. Esimerkki: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profiili %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Yritys"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ei mitään"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Ei koskaan"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i päivä sitten"
+msgstr[1] "%i päivää sitten"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Ei mitään"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Heikko"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "OK"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Hyvä"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Erinomainen"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4-osoite"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-osoite"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-osoite"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Unohda yhteys"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Poista yhteysprofiili"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Poista VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Tiedot"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automaattinen"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identiteetti"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Poista osoite"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Poista reitti"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ei mitään"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bittinen avain (Hex tai ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bittinen salalause"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynaaminen WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3-Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signaalin vahvuus"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Yhteysnopeus"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Laiteosoite"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Tuetut taajuudet"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Oletusreitti"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Viimeksi käytetty"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "_Yhdistä automaattisesti"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Aseta _kaikkien käyttäjien käytettäväksi"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Käytön mukaan laskutettava yhteys: sisältää datarajoituksia tai mahdollisia "
+"lisäkustannuksia"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Ohjelmistopäivityksiä ja muita suurikokoisia latauksia ei aloiteta "
+"automaattisesti."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nimi"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC-osoite"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Kloonattu osoite"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "tavua"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4-tapa"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automaattinen (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Vain linkkiyhteys"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manuaalinen"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Poista käytöstä"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Jaettu muille tietokoneille"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Osoitteet"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Osoite"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Aliverkon peite"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Yhdyskäytävä"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automaattinen"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automaattinen DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS-palvelimen osoite/osoitteet"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Erota IP-osoitteet pilkuin"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Reitit"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automaattiset reitit"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metriikka"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Käytä tätä yhteyttä _vain tässä verkossa oleviin resursseihin"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6-tapa"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automaattinen, vain DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Etuliite"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Yhteyseditorin avaaminen epäonnistui"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Uusi profiili"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Virheellinen asetus %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Virheellinen asetus %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Tuo tiedostosta…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Lisää VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_Tietoturva"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "VPN-yhteyden tuonti epäonnistui"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Tiedoston ”%s” luku epäonnistui tai se ei sisällä tunnistettavaa VPN-"
+"yhteyden tietoa\n"
+"\n"
+"Virhe: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Valitse tuotava tiedosto"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Tiedosto nimeltä ”%s” on jo olemassa."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Korvaa"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+"Haluatko korvata tiedoston %s VPN-asetuksilla, joita olet tallentamassa?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "VPN-yhteyden vienti epäonnistui"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN-yhteyttä ”%s” ei voitu viedä tiedostoon %s.\n"
+"\n"
+"Virhe: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Vie VPN-yhteys"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Virhe: VPN-yhteyseditoria ei voitu ladata)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Hallitse internetyhteyden asetuksia"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;lähiverkko;"
+"välityspalvelin;laajakaista;modeemi;erillisverkko;nimipalvelu;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Määritä miten wifi-verkkoihin otetaan yhteys"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;verkko;langaton;"
+"laajakaista;nimipalvelu;tukiasema;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "ei koskaan"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "tänään"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "eilen"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Viimeksi käytetty"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Kiinteä"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Lisää uusi yhteys"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Valittujen verkkojen tiedot, kuten salasanat ja omat asetukset, häviävät."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Unohda"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Tunnetut wifi-verkot"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Unohda"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Järjestelmäkäytännöt estävät käytön yhteyspisteenä"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Langaton verkkolaite ei tue yhteyspisteeksi asettamista"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "WPAD-automaattietsintää käytetään, kun hallinta-URL ei ole määritelty."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Tämä ei ole suositeltavaa julkisissa verkoissa."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Käännä laite pois päältä"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktiivinen"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Tarjoaja"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Verkon välityspalvelin"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP-välityspalvelin"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS-välityspalvelin"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP-välityspalvelin"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks-palvelin"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ohita koneet"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP-välityspalvelimen portti"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS-välityspalvelimen portti"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP-välityspalvelimen portti"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks-välityspalvelimen portti"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Määritys-URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Katkaise VPN-yhteys"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Verkon nimi"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Salauksen tyyppi"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Salasana"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Kytke wifi pois päältä"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Lisää valitoja…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "Y_hdistä piilotettuun verkkoon…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Käynnistä wifi-yhteyspiste…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Tunnetut wifi-verkot"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Tuntematon tila"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Hallitsematon"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Ei saatavilla"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Yhdistetään"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Tunnistautuminen vaaditaan"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Katkaistaan yhteyttä"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Yhteys epäonnistui"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Tila tuntematon (puuttuu)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Kokoonpanon käyttö epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP-asetukset epäonnistuivat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP-asetukset vanhenivat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Salaisuuksia ei annettu, vaikka niitä pyydettiin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x-anojan yhteys katkaistu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x-anojan asetukset epäonnistuivat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x-anoja epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x-anojalla kesti liian kauan tunnistautua"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP-palvelun käynnistys epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP-palvelun yhteys katkaistu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP-asiakkaan käynnistys epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP-asiakkaan virhe"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP-asiakas epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Jaetun yhteyden palvelun käynnistys epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Jaetun yhteyden palvelu epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP-palvelun käynnistys epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP-palvelun virhe"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP-palvelu epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linja on varattu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Ei valintaääntä"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Kantoaaltoa ei voitu muodostaa"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Soittopyyntö aikatkaistiin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Soittoyritys epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Modeemin alustus epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Halutun APN:n valinta epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Verkkoja ei etsitä"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Verkkoon rekisteröinti estettiin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Rekisteröinti verkkoon aikakatkaistiin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Määritettyyn verkkoon rekisteröinti epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN-tarkistus epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Laitteen laiteohjelmisto saattaa puuttua"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Yhteys katosi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Oletettiin olemassa oleva yhteys"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modeemia ei löytynyt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth-yhteys epäonnistui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM-korttia ei ole liitetty"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM-kortin PIN vaaditaan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM-kortin PUK vaaditaan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM väärin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Yhteysriippuvuus epäonnistui"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Laiteohjelmisto puuttuu"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Johto on irti"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "määrittelemätön virhe 802.1X-tietoturvassa (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "ei tiedostoa valittuna"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "määrittämätön virhe eap-method-tiedostoa vahvistaessa"
+
+#: panels/network/wireless-security/eap-method.c:394
+#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER-, PEM-, PKCS#12- tai PGP-yksityisavaimet"
+
+#: panels/network/wireless-security/eap-method.c:397
+#| msgid "_User certificate"
+msgid "DER or PEM certificates"
+msgstr "DER- tai PEM-varmenteet"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "puuttuva EAP-FAST PAC -tiedosto"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC-tiedostot (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonyymi"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Todennettu"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Molemmat"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anony_ymi identiteetti"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PA_C-tiedosto"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Valitse PAC-tiedosto"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Sisempi tunnistautuminen"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Salli automaattinen PAC-pro_visiointi"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "puuttuva EAP-LEAP-käyttäjätunnus"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "puuttuva EAP-LEAP-salasana"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Käyttäjätunnus"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Salasana"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "N_äytä salasana"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "virheellinen EAP-PEAP CA -varmenne: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "virheellinen EAP-PEAP CA -varmenne: varmennetta ei määritetty"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versio 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versio 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "_Varmentajavarmenne (CA-varmenne)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Valitse varmentajavarmenne"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "_CA-varmennetta ei vaadita"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP-_versio"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "puuttuva EAP-käyttäjätunnus"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "puuttuva EAP-salasana"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "puuttuva EAP-TLS-identiteetti"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "virheellinen EAP-TLS CA -varmenne: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "virheellinen EAP-TLS:n CA-varmenne: varmennetta ei määritetty"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "virheellinen EAP-TLS:n yksityinen avain: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "virheellinen EAP-TLS-käyttäjävarmenne: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Salaamattomat yksityiset avaimet ovat epäluotettavia"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Valittua yksityistä avainta ei ole suojattu salasanalla. Tämä mahdollistaa "
+"turvallisuustietojen vaarantumisen. Valitse salasanalla suojattu yksityinen "
+"avain.\n"
+"\n"
+"(Voit salasanasuojata yksityisen avaimesi openssl:llä)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Valitse henkilökohtainen varmenteesi"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Valitse yksityinen avaimesi"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentiteetti"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Käyttäjävarmenne"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Yksityinen avain"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Yksityisen avaimen _salasana"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "virheellinen EAP-TTLS CA -varmenne: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "virheellinen EAP-TTLS CA -varmenne: varmennetta ei määritetty"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (ei EAP:tä)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "T_oimialue"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Tuntematon virhe 802.1X-tietoturvaa vahvistaessa"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunneloitu TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Suojattu EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Tunnistautuminen"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Valitse tiedosto"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "puuttuva leap-käyttäjätunnus"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "puuttuva leap-salasana"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Langattoman verkon salasana puuttuu."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tyyppi"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "puuttuva wep-avain"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"virheellinen wep-key: avaimen jonka pituus on %zu tulee sisältää vain "
+"heksanumeroita"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"virheellinen wep-avain: avain pituutta %zu tulee sisältää vain ascii-merkkejä"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"virheellinen wep-key: väärä avaimen pituus %zu. Avaimen tulee olla "
+"pituudeltaan joko 5/13 (ascii) tai 10/26 (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "virheellinen wep-avain: tunnuslause ei voi olla tyhjä"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"virheellinen wep-avain: tunnuslause tulee olla vähemmän kuin 64 merkkiä"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Oletus)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Avoin järjestelmä"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Jaettu avain"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Avain"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "N_äytä avain"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP-inde_ksi"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"virheellinen wpa-psk: virheellinen avaimen pituus %zu. Tulee olla [8,63] "
+"tavua tai 64 heksanumeroa"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "virheellinen wpa-psk: ei voi tulkita 64 tavun avainta heksana"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Ilmoitukset"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Ääni-ilmoitukset"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Ponnahdusilmoitukset"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Ilmoitukset näkyvät ilmoitusluettelossa ponnahdusten ollessa pois käytöstä."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Näy_tä viestin sisältö ponnahduksen yhteydessä"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Lukitusnäytön i_lmoitukset"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Näytä viestin sisältö _lukitusnäytöllä"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Älä häiritse"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Lukitusnäytön ilmoitukset"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Hallitse näytettäviä ilmoituksia ja niiden sisältämää tietoa"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;Banner;Message;Tray;Popup;ilmoitus;ilmoitukset;banneri;viesti;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Muu"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s poistettu"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Virhe tiliä poistaessa"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Kumoa"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Sulje ilmoitus"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Muodosta yhteys pilvessä oleviin tietoihisi"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Ei internetyhteyttä — muodosta yhteys määrittääksesi verkkotilisi"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Lisää tili"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s-tili"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Poista tili"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Verkkotilit"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Liitä verkkotilisi ja päätä, mihin tarkoituksiin niitä käytetään"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;keskustelu;kalenteri;sähköposti;"
+"yhteystiedot;kontaktit;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Tuntematon aika"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuutti"
+msgstr[1] "%i minuuttia"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i tunti"
+msgstr[1] "%i tuntia"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "tunti"
+msgstr[1] "tuntia"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuutti"
+msgstr[1] "minuuttia"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s kunnes ladattu täyteen"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Varoitus: %s jäljellä"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s jäljellä"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Ladattu täyteen"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Ei lataudu"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Tyhjä"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Latautuu"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Purkautuu"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Langaton hiiri"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Langaton näppäimistö"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Keskeytymätön virransyöttö"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Henkilökohtainen digitaalinen avustaja (PDA)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Matkapuhelin"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Mediasoitin"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Piirtopöytä"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Tietokone"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Pelaamiseen tarkoitettu syötelaite"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akku"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Pääakku"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Lisäakku"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Akut"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Kun _käyttämättä"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Valmiustila"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Virta pois päältä"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Lepotila"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ei mitään"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Käytettäessä akkua"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Käytettäessä verkkovirtaa"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Ei koskaan"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automaattinen valmiustila"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Suorituskykytila on poistettu väliaikaisesti käytöstä korkean "
+"käyntilämpötilan vuoksi."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Syli havaittu: suorituskykytila väliaikaisesti ei saatavilla. Siirrä laite "
+"tasaiselle alustalle palauttaaksesi suorituskykytilan."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Suorituskykytila väliaikaisesti pois käytöstä."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Akku vähissä: virransäästö otettu käyttöön. Aiempi tila palautetaan, kun "
+"akkua on ladattu riittävästi."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Virransäästötilan aktivoinut “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Suorituskykytilan aktivoinut “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minuuttia"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minuuttia"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minuuttia"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minuuttia"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minuuttia"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 tunti"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minuuttia"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minuuttia"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minuuttia"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 tuntia"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Tehotila"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Vaikuttaa järjestelmän suorituskykyyn ja virrankäyttöön."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Virransäästön valinnat"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automaattinen näytön kirkkaus"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Näytön kirkkaus mukautuu ympäristön valon määrään."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Näytön himmennys"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Vähentää näytön kirkkautta, kun tietokone on käyttämättä."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Tyhjä näyttö"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Sammuttaa näytön kun tietokone on käyttämättä tietyn ajan."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automaattinen virransäästö"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Ottaa virransäästötilan käyttöön kun akku on vähissä."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automaattinen valmiustila"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Keskeyttää tietokoneen kun tietokone on käyttämättä tietyn ajan."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "_Virtapainikkeen toiminto"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Näytä akun _prosentti"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automaattinen valmiustila"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Käytettäessä _verkkovirtaa"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Käytettäessä _akkua"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Viive"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Suorituskyky"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Korkea suorituskyky ja virrankäyttö."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Tasapainotettu"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Normaali suorituskyky ja virrankäyttö."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Virransäästö"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Alennettu suorituskyky ja virrankäyttö."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Virranhallinta"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Tarkkaile akkusi tilaa ja muuta virransäästöasetuksia"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;virta;uni;valmiustila;lepotila;akku;kirkkaus;himmennys;tyhjä;näyttö;"
+"jouten;virransäästö;virranhallinta;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Tulostin “%s” on poistettu"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Uuden tulostimen lisäys epäonnistui."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Käyttöliittymätiedoston lataus epäonnistui: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Avaa lukitus lisätäksesi tulostimia ja muuttaaksesi asetuksia"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Tulostimet"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Lisää tulostimia, seuraa tulostustöitä ja määritä tulostusasetukset"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"Tulostin;jono;tulosta;paperi;muste;värikasetti;Printer;Queue;Print;Paper;Ink;"
+"Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Lisää tulostin"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Avaa lukitus"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Tulostimia ei löytynyt"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Kirjoita verkko-osoite tai etsi tulostinta"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Tunnistautuminen vaaditaan"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Syötä käyttäjätunnus ja salasana nähdäksesi tulostuspalvelimella olevat "
+"tulostimet."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Käyttäjätunnus"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Tulostimen %s tiedot"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Soveltuvaa ajuria ei löytynyt"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Valitse PPD-tiedosto"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript Printer Description -tiedostot (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+"Tulostimen nimessä ei voi olla välilyöntiä, sarkainta tai merkkejä # ja /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Sijainti"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Ajuri"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Etsitään ensisijaisia ajureita…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Etsi ajureita"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Valitse tietokannasta…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Asenna PPD-tiedosto…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Valitse tulostinajuri"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Ladataan ajuritietokantaa…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Valitse"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect-tulostin"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD-tulostin"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Yksipuoleinen"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "PItkä reuna"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Lyhyt reuna"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Pysty"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Vaaka"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Käänteinen vaaka"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Käänteinen pysty"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Jatka"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Keskeytä"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Odottaa"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Keskeytetty"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Tunnistautuminen vaaditaan"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Käsitellään"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Pysäytetty"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Peruttu"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Keskeytetynyt"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Valmis"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Siirrä tämä työ jonon kärkeen"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u työ vaatii tunnistautumisen"
+msgstr[1] "%u työtä vaatii tunnistautumisen"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Aktiiviset työt"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Syötä kirjautumistietosi tulostaaksesi tulostimesta %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Toimialue"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Tunnistaudu"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Tyhjennä kaikki"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Tunnistaudu"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Ei aktiivisia tulostustöitä"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Avaa tulostuspalvelimen lukitus"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Avaa kohteen %s lukitus."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Syötä käyttäjätunnus ja salasana nähdäksesi palvelimella %s olevat "
+"tulostimet."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Etsitään tulostimia"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Sarjaportti"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Rinnakkaisportti"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Sijainti: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Osoite: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Palvelin vaatii tunnistautumisen"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Kaksipuoleinen"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Paperin tyyppi"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Paperin lähde"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Ulostulo"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Tarkkuus"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScriptin esisuodatus"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Sivuja per puoli"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Kaksipuoleinen"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Suunta"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Yleiset"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Sivun asetukset"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Asennettavat valinnat"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Työ"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Kuvalaatu"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Väri"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Viimeistely"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Lisäasetukset"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Testisivu"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Testisivu"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Valitse automaattisesti"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Tulostimen oletus"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Upota vain GhostScript-fontit"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Muunna PS 1 -tasolle"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Muunna PS 2 -tasolle"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Ei esisuodatusta"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Valmistaja"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ei aktiivisia töitä"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u työ"
+msgstr[1] "%u työtä"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Puhdista tulostuspäät"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Muste on vähissä"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Muste on loppu"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Kehite on vähissä"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Kehite on loppu"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Väriaine vähissä"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Väriaine loppu"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Avaa kansi"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Avaa ovi"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Paperi vähissä"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Paperi on loppu"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Poissa verkosta"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Pysäytetty"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Jätesäiliö melkein täynnä"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Jätesäiliö täynnä"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Valojohdeyksikkö on vaihdettava pian"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Valojohdeyksikkö on rikki"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Valmiina"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Ei hyväksy töitä"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Käsitellään"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Tulostusvalinnat"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Tulostimen tiedot"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Käytä tulostinta oletuksena"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Puhdista tulostuspäät"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Poista tulostin"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Malli"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Musteen taso"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Käynnistä uudelleen kun ongelma on selvitetty."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Käynnistä uudelleen"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Lisää tulostin…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Ei tulostimia"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Valitettavasti tulostuspalvelu\n"
+"ei vaikuta olevan käytettävissä."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Muotoilut"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Etsi maa-asetustoja…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Yleiset muotoilut"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Kaikki muotoilut"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Ei hakutuloksia"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Haut voivat kohdistua maihin tai kieliin."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Esikatselu"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperiaalinen"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrinen"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Päivämäärät"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Päivä ja aika"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Numerot"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mitat"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Paperi"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Kieli ja muotoilu vaihdetaan seuraavan sisäänkirjautumisen jälkeen"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Kirjaudu ulos…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Kieliasetus määrittää käyttöliittymän tekstin ja verkkosivustojen kielen. "
+"Muotoilut määrittävät numeroiden, päiväysten ja valuuttojen muodon."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Tilisi"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Kieli"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Muotoilut"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Kirjautumisnäkymä"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Alue ja kielet"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Valitse näytettävä kieli ja muotoilut"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Kieli;Asettelu;Näppäimistö;Syöte;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Kysy mitä tehdään"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Älä tee mitään"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Avaa kansio"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Muu media"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Valitse sovellus ääni-CD-levyille"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Valitse sovellus video-DVD-levyille"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Valitse sovellus ajettavaksi kun musiikkisoitin kytketään"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Valitse sovellus ajettavaksi kun kamera kytketään"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Valitse sovellus ohjelmisto-CD-levyille"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "ääni-DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "tyhjä Blu-ray-levy"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "tyhjä CD-levy"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "tyhjä DVD-levy"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "tyhjä HD DVD -levy"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray-videolevy"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "e-kirjalukija"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD -videolevy"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Kuva-CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video-CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows-ohjelmisto"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Valitse kuinka mediaa käsitellään"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Ääni-CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD-video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Musiikkisoitin"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Ohjelmisto"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Muu media…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Älä koskaan kysy tai käynnistä ohjelmia liitettäessä media"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Valitse kuinka muita medioita käsitellään"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Toiminto:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tyyppi:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Erilliset tallennusvälineet"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Määritä erillisten tallennusvälineiden asetukset"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;laite;järjestelmä;tiedot;muisti;suoritin;prosessori;"
+"versio;oletukset;sovellus;suositellut;automaattikäynnistys;ääni;irrotettava;"
+"ulkoinen;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Näyttö sammuu"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekuntia"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuutti"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minuuttia"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minuuttia"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minuuttia"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minuuttia"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 tunti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuutti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minuuttia"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minuuttia"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minuuttia"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minuuttia"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minuuttia"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minuuttia"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minuuttia"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minuuttia"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Ei koskaan"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Näytön lukitus"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Näytön automaattinen lukitus estää muita käyttämästä laitetta "
+"käyttäjätililläsi, kun olet pois."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Tyhjän näytön viive"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Toimettomuuden kesto, kunnes näyttö pimennetään."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Automaattinen näytön lukitus"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Automaattisen näytön lukituksen viive"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Näytön pimennyksen kesto, kunnes näyttö lukitaan automaattisesti."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Näytä ilmoitukset lukitusnäytöllä"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Estä uudet US_B-laitteet"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Estä uusien USB-laitteiden vuorovaikutus järjestelmään, kun näyttö on "
+"lukittu."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Näytön tietosuoja"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Rajoita katselukulmaa"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Näytön asetukset"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;näyttö;lukitus;yksityisyys;tietosuoja;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Valitse sijainti"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Hakukohteet"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Kansiot, joista järjestelmäsovellukset kuten tiedostonhallinta sekä kuva- ja "
+"videosovellukset suorittavat haun."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Sijainnit"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Kirjanmerkit"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Muut"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Lisää sijainti"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Sovelluksia ei löytynyt"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Sovellusten haku"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Sisällytä sovellusten tarjoamat hakutulokset."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Kansiot, joista järjestelmäsovellukset suorittavat haun."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Hakutulokset"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Tulokset näytetään tässä järjestyksessä."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "Mitkä ohjelmat näyttävät hakutuloksia Toiminnot-näkymässä"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Find;Index;Hide;Privacy;Results;Haku;Etsi;Indeksi;Piilota;Yksityisyys;"
+"Tulokset;Hakutulokset;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Ei verkkoja valittu jakamista varten"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Verkot"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Päällä"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Pois"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Käytössä"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktiivinen"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Valitse kansio"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Lisää"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Ota käyttöön mediajako"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Tiedostonjaon avulla voit jakaa julkisen kansiosi sisällön verkon muiden "
+"käyttäjien kanssa käyttäen osoitetta: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Kun etäkirjautuminen on käytössä, etäkäyttäjät voivat yhdistää käyttäen "
+"Secure Shell -komentoa:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Ota käyttöön henkilökohtainen tiedostonjako"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Laitteen nimi kopioitu"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Laiteosoite kopioitu"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Käyttäjätunnus kopioitu"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Salasana kopioitu"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Jakaminen"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Ti_etokoneen nimi"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Tiedostonjako"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Et_ätyöpöytä"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Mediajako"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Etäkirjautuminen"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Tiedostojako"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Vaa_di salasana"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Etäkirjautuminen"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Etätyöpöytä"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Etätyöpöytä mahdollistaa tietokoneen työpöydän katselun ja ohjaamisen "
+"toiselta tietokoneelta."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Ota käyttöön tai poista käytöstä etätyöpöytäyhteydet tähän tietokoneeseen."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Etäkäyttö"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Sallii etäyhteyksien hallita näyttöä."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Miten yhdistää"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Yhdistä tähän tietokoneeseen käyttäen laitenimeä tai etätyöpöydän osoitetta."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopioi"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Etätyöpöytäosoite"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Tunnistautuminen"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Käyttäjätunnus ja salasana vaaditaan tähän tietokoneeseen yhdistämiseksi."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Käyttäjätunnus"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Vahvista salaus"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Salauksen sormenjälki"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Salauksen sormenjälki on näkyvissä yhdistäville asiakkaille ja sen pitäisi "
+"olla identtinen."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Mediajako"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Jaa musiikkia, kuvia ja videoita verkon kautta."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Kansiot"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Valitse mitä haluat jakaa muiden kanssa"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;jako;jakaminen;etä;työpöytä;ääni;video;kuvat;palvelin;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Käytä tai poista käytöstä etäkirjautuminen"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Etäkirjautumisen hallinta vaatii tunnistautuminen"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Oma"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Napsautus"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Jousi"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Heilahdus"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Hyräily"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Tasapaino"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Häivytys"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Taka"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Etu"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Testataan %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Napsauta kaiutinta testataksesi"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Järjestelmän äänenvoimakkuus"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Pää-äänenvoimakkuus"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Äänitasot"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Ulostulo"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Ulostulolaite"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testaa"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Määritys"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Sisääntulo"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Sisääntulolaite"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Äänenvoimakkuus"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Hälytysääni"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100 %"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Mykistä"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Ääni"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Muuta äänenvoimakkuutta, sisään- ja ulostuloja sekä äänitapahtumia"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kortti;mikrofoni;äänenvoimakkuus;häivytys;tasapaino;Bluetooth;kuulokkeet;"
+"headset;Audio;Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+"Output;Input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Yhteys katkaistu"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Yhdistetään"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Yhdistetty"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Valtuutusvirhe"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Valtuutetaan"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Alentunut toiminnallisuus"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Yhdistetty ja valtuutettu"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Valtuutettu:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Yhdistetty:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Käyttöönotettu:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Laitteen valtuuttaminen epäonnistui: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Laitteen unohtaminen epäonnistui: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Riippuvainen %u muusta laitteesta"
+msgstr[1] "Riippuvainen %u muusta laitteesta"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Sulje ilmoitus"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nimi:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Tila:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Valtuuta ja yhdistä"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Unohda laite"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Virhe"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Valtuutettu"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Thunderbolt-alijärjestelmää (boltd) ei ole asennettu tai sen asetukset eivät "
+"ole kunnossa."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Salli suora pääsy laitteisiin kuten telakoihin ja erillisiin näytönohjaimiin."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Vain USB- ja DisplayPort-laitteet voivat liittyä."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderboltia ei havaittu.\n"
+"Järjestelmästä puuttuu Thunderbolt-tuki, tai se on poistettu käytöstä BIOS:"
+"in kautta, tai BIOS:in kautta sille asetettu turvataso ei ole tuettu."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt-tuki on poistettu käytöstä BIOS:in kautta."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Thunderbolt-turvatasoa ei voitu määrittää."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Virhe vaihtaessa direct-tilaan: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Ei Thunderbolt-tukea"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Thunderbolt-alijärjestelmään ei voitu yhdistää."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Suora pääsy"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Odottavat laitteet"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Ei liitettyjä laitteita"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Hallitse Thunderbolt-laitteita"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;yksityisyys;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Kohdistimen vilkunta"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Kohdistin vilkkuu tekstikentissä."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Nopeus"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Kohdistimen vilkkumisnopeus"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Kohdistimen koko"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Kohdistimen koon muuttamisella ja suurennuksella on mahdollista tehdä "
+"kohdistimen erottaminen helpommaksi."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Napsautusapu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Kakkospainikkeen simuloitu _napsautus"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Käytä hiiren kakkosnäppäintä pitämällä ykkösnäppäintä pohjassa"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "V_iiveen kesto:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Lyhyt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Kakkosnäppäimen viive"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Pitkä"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Napsautus _kohdistamalla"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Toteuta painallus, kun hiiren kohdistin kohdistetaan"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Viiv_e:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Lyhyt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Pitkä"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Liikkeen _kynnysarvo:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Pieni"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Suuri"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Toistonäppäimet"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Painallus toistuu, kun näppäintä pidetään painettuna."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Näppäinten toiston viive"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Näppäinten toiston nopeus"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Kirjoitusapu"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Pohjaan jäävät näppäimet"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Kohtelee määritenäppäinten sarjaa näppäinyhdistelmänä"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Poista käytöstä, jos kahta näppäintä painetaan samanaikaisesti"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Soita äänimerkki, kun _määritenäppäintä painetaan"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Hitaat näppäimet"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Aseta viive hyväksyttyjen näppäinpainallusten välille"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Lyhyt"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Hitaiden näppäinten kirjoitusviive"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Pitkä"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Soita äänimerkki, kun näppäintä _painetaan"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Soita äänimerkki, kun näppäinpainallus _hyväksytään"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Soita äänimerkki, kun näppäinpainallusta _ei hyväksytty"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Kimmonäppäimet"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Älä huomioi nopeita kahden näppäimen painalluksia"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Lyhyt"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Kimmonäppäinten kirjoitusviive"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Pitkä"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Ota käyttöön näppäimistöä käyttäen"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Ota käyttöön/poista käytöstä esteettömyystoiminnot näppäimistöä käyttäen"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Oletus"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Keskikoko"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Suuri"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Suurempi"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Suurin"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pikseli"
+msgstr[1] "%d pikseliä"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Näytä esteettömyysvalikko aina"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Näkeminen"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Suuri kontrasti"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Suuri _teksti"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Käytä _animaatioita"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Näytönlukija"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Näytönlukija lukee ääneen näytöllä olevan tekstin vaihtaessasi kohdistusta."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Äänekkäät näppäimet"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Piippaa kun Num Lock tai Caps Lock otetaan käyttöön."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Ko_hdistimen koko"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "S_uurennus"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Kuuleminen"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Visuaaliset hälytykset"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "N_äppäimistö näytöllä"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Toist_onäppäimet"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Kohdistimen _vilkunta"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Kirjoitusapu (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Kohdistaminen ja napsauttaminen"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Hiirinäppäimet"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Paikanna kohdistin"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "N_apsautusapu"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Kaksoisnapsautuksen _viive"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Kaksoisnapsautuksen viive"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Visuaaliset hälytykset"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Testaa välähdystä"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Käytä visuaalista ilmoitusta, kun hälytyksen äänitehoste toistetaan."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Väläytä _koko näyttöä"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Väläytä _koko ikkunaa"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Lyhyt"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ näyttöä"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ näyttöä"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ näyttöä"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Pitkä"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Koko näyttö"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Yläosa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Alaosa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Vasen puoli"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Oikea puoli"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Suurennuksen valinnat"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Suurennus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Suurennuslasin sijainti:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "Seuraa _hiiren osoitinta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Näytön osa:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Suu_rennuslasi ulottuu näytön ulkopuolelle"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Pi_dä suurennuslasin osoitin keskitettynä"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Suur_ennuslasin osoitin työntää sisältöä"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Suurennuslasin osoit_in siirtyy sisällön kanssa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Suurennuslasi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Tähtäi_n:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Hii_ren osoittimen päällä"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Paksuus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Ohut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Paksu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "Pit_uus:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Vä_ri:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Tähtäimet"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Väritehosteet:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "Valkoista _mustalla:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "K_irkkaus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrasti:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "V_äri"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ei mitään"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Täysi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Matala"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Korkea"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Matala"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Korkea"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Väritehosteet"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Helpota näkemistä, kuulemista, kirjoittamista ja hiiren käyttöä"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;Näppäimistö;Hiiri;a11y;Esteettömyys;saavutettavuus;"
+"Kontrasti;Zoom;Mittakaava;Lähennys;Loitonnus;Näytönlukija;teksti;fontti;"
+"kirjasin;koko;Pohjaan jäävät näppäimet;Hitaat näppäimet;Kimmonäppäimet;"
+"Hiiren painikkeet;kaksois;viive;vilkkuminen;kuuleminen;kirjoittaminen;"
+"animaatiot;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 tunti"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 päivä"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 päivää"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 päivää"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 päivää"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 päivää"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 päivää"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 päivää"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 päivää"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 päivää"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Tyhjennetäänkö roskakorin koko sisältö?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Kaikki roskakorissa olevat kohteet poistetaan pysyvästi."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Tyhjennä roskakori"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Poistetaanko kaikki väliaikaiset tiedostot?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Kaikki väliaikaiset tiedostot poistetaan pysyvästi."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Tu_hoa väliaikaistiedostot"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 päivä"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 päivää"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 päivää"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Ikuisesti"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Tiedostohistoria"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Tiedostohistoria pitää kirjaa käyttämistäsi tiedostoista. Tämä tieto jaetaan "
+"sovellusten kesken, ja sen on tarkoitus helpottaa löytämään tiedostoja, "
+"joita haluat mahdollisesti käyttää."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Tiedosto_historia"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "_Tiedostohistorian kesto"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Tyhjennä historia…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Roskakori ja väliaikaiset tiedostot"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Roskakorin sisältö ja väliaikaiset tiedostot saattavat toisinaan sisältää "
+"henkilökohtaista tai arkaluonteista tietoa. Niiden automaattinen poistaminen "
+"voi auttaa yksityisyyden suojaamisessa."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Poista _roskakorin sisältö automaattisesti"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Poista _väliaikaistiedostot automaattisesti"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Poista _ajanjakso automaattisesti"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Tyhjennä roskakori…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Poista väliaikaistiedostot…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Tiedostohistoria ja roskakori"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Älä jätä jälkiä"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"käyttö;viimeisimmät;uusimmat;historia;tiedostot;väliaikaiset;yksityisyys;"
+"roskakori;säilytys;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Tulisi vastata kirjautumistilisi myöntäjän verkko-osoitetta."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Tilin lisäys epäonnistui"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Salasanat eivät täsmää."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Tilin rekisteröinti epäonnistui"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+"Tähän toimialueeseen vaadittavaa tunnistautumistapaa ei ole käytettävissä"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Toimialueeseen liittyminen epäonnistui"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Käyttäjätunnus ei kelvannut.\n"
+"Yritä uudelleen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Salasana ei kelvannut.\n"
+"Yritä uudelleen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Toimialueeseen kirjautuminen epäonnistui"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Toimialuetta ei löytynyt. Kirjoititko sen oikein?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Lisää käyttäjä"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Ylläpitäjä"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Ylläpitäjät voivat lisätä ja poistaa käyttäjiä sekä muuttaa kaikkien "
+"käyttäjien asetuksia. Perheasetuksia ei voi kohdistaa ylläpitäjätileihin."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Käyttäjä asettaa salasanan ensimmäisellä kirjautumiskerralla"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Aseta salasana nyt"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Vahvista"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Yrityskirjautuminen"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Käyttäjätilit, joita hallitsee yritys tai organisaatio."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Olet poissa verkosta"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Yrityskirjautuminen mahdollistaa ennestään keskitetysti hallitun "
+"käyttäjätilin käytön tällä laitteella. Voit käyttää tätä tiliä myös "
+"yrityksen resurssien käyttöön internetissä."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Selaa lisää kuvia"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Valitse tiedosto…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Sormenjälkien hallinta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Sormenjälki"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Ei"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Kyllä"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Haluatko poistaa rekisteröidyt sormenjälkesi, jolloin sormenjäljillä "
+"kirjautuminen poistetaan käytöstä?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Ei sormenjälkilaitetta"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Ei sormenjälkilaitetta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Varmista että laite kytketty kunnolla."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Sormenjälkilaite"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Valitse sormenjälkilaite, jonka haluat määrittää"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Sormenjäljellä kirjautuminen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Sormenjäljellä kirjautuminen mahdollistaa tietokoneen lukituksen avaamisen "
+"ja kirjautumisen sormenjäljellä"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Poista sormenjäljet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Sormenjäljen lisääminen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "laite tulee vaatia käyttöön tämän toiminnon suorittamiseksi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "toinen prosessi on jo varannut laitteen itselleen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "käyttöoikeutesi eivät riitä tämän toiminnon suorittamiseen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "sormenjälkiä ei ole rekisteröity"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Yhteydenpito laitteeseen epäonnistui rekisteröinnin aikana"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Yhteydenpito sormenjälkilukijaan epäonnistui"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Yhteydenpito sormenjälkitaustapalveluun epäonnistui"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Sormenjälkien listaaminen epäonnistui: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Tallennettujen sormenjälkien poistaminen epäonnistui: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Vasen peukalo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Vasen keskisormi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Vasen etusormi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Vasen nimetön"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Vasen pikkurilli"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Oikea peukalo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Oikea keskisormi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Oikea etusormi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Oikea nimetön"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Oikea pikkurilli"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Tuntematon sormi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Valmis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Yhteys sormenjälkilaitteeseen katkaistu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Sormenjälkilaitteen tallennustila on täynnä"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Uuden sormenjäljen lisääminen epäonnistui"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Sormenjäljen lisäämisen aloittaminen epäonnistui: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Uuden sormenjäljen lisääminen epäonnistui"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Sormenjäljen lisäämisen pysäyttäminen epäonnistui: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Nosta sormea ja aseta se takaisin lukijaan toistuvasti lisätäksesi "
+"sormenjälkesi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Lisää uudelleen tämä sormi…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Lue uusi sormenjälki"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Sormenjälkilaitteen %s vapauttaminen epäonnistui: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Ongelma laitetta luettaessa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Sormenjälkilaitteen %s varaaminen epäonnistui: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Sormenjälkilaitteiden saaminen epäonnistui: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Tällä viikolla"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Viime viikolla"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Istunto päättyi"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Istunto alkoi"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Tilin käyttöhistoria"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Edellinen"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Seuraava"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Valitse jokin toinen salasana."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Syötä nykyinen salasana uudelleen."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Salasanaa ei voitu vaihtaa"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Vaihda salasana"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Vaihda"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Nykyinen salasana"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Uusi salasana"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Vahvista salasana"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Salli käyttäjän vaihtaa salasana seuraavalla kirjautumiskerralla"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Aseta salasana nyt"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Tämän tyyppiseen toimialueeseen ei voi liittyä automaattisesti"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Määriteltyä toimialuetta tai realmia ei löytynyt"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Kirjautuminen tunnuksella %s toimialueeseen %s ei onnistu"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Virheellinen salasana, yritä uudelleen"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Toimialueeseen %s yhdistäminen epäonnistui: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Käyttäjän poisto epäonnistui"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Etähallitun käyttäjän kumoaminen epäonnistui"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Et voi poistaa omaa tunnustasi."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s on yhä sisäänkirjautuneena"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Jos käyttäjä poistetaan hänen ollessaan sisäänkirjautuneena, järjestelmässä "
+"voi ilmetä ongelmia."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Haluatko säilyttää käyttäjän %s tiedostot?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Voit halutessasi säilyttää kotikansion, sähköpostit ja väliaikaistiedostot "
+"käyttäjätilin poiston yhteydessä."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "P_oista tiedostot"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Säilytä tiedostot"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Haluatko varmasti kumota käyttöoikeudet etähallitulta tililtä %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Poista"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Käyttäjätili pois käytöstä"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Asetetaan seuraavalla kirjautumiskerralla"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ei mitään"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Sisäänkirjautuneena"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Yhteys tilipalveluun (accounts service) epäonnistui"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Varmista, että AccountService on asennettu ja käytössä."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Tämän paneelin lukitus tulee avata, jotta tätä asetusta voi muuttaa"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Poista valittu käyttäjätili"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Poista valittu käyttäjä\n"
+"napsauttamalla ensin *-kuvaketta"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Avaa lukitus lisätäksesi käyttäjiä ja muuttaaksesi asetuksia"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Käyttäjät"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Istunto täytyy käynnistää uudelleen, jotta muutokset tulevat voimaan"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Käynnistä uudelleen nyt"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Sulje"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Muokkaa avatar-kuvaa"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Koko nimi"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Muokkaa"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Sormenjäljellä kirjautuminen"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomaattinen kirjautuminen"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Tilin käyttöhistoria"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Ylläpitäjä"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Ylläpitäjät voivat lisätä ja poistaa käyttäjiä sekä muuttaa kaikkien "
+"käyttäjien asetuksia."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Perheasetukset"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Avaa Näyttöaika ja rajoitukset -sovellus."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Poista käyttäjätili…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Muut käyttäjät"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Lisää käyttäjä…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Käyttäjiä ei löytynyt"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Avaa lukitus lisätäksesi käyttäjätilin."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Lisää tai poista käyttäjiä, vaihda salasanasi"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+"näyttöaika;ruutuaika;rajoitukset;rajat;lapsi;kirjautuminen;sormenjälki;"
+"salasana;esto;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Liitä toimialueeseen"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Toimialueen ylläpitäjän kirjautuminen"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Yrityskirjautumisen käyttö vaatii, että tietokone on rekisteröity\n"
+"toimialueeseen. Pyydä verkkosi ylläpitäjää kirjoittamaan\n"
+"toimialueen salasanan tähän."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Ylläpitäjän _nimi"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Ylläpitäjän salasana"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Hallitse käyttäjätilejä"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Käyttäjätietojen muuttaminen vaatii tunnistautuminen"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Uusi salasana ei saa olla vanhan salasanan kaltainen."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Vaihda kirjaimia ja numeroita."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Yritä muuttaa salasanaa vielä hieman."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Älä laita käyttäjätunnustasi salasanaasi."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Älä laita nimeäsi salasanaasi."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Vältä salasanassasi olevia sanoja."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Vältä yleisiä, sanakirjoista löytyviä sanoja."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Älä käytä samoja sanoja eri järjestyksessä."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Käytä enemmän numeroita."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Käytä enemmän isoja kirjaimia."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Käytä enemmän pieniä kirjaimia."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Käytä erikois- ja välimerkkejä."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Sekoita kirjaimia, numeroita ja välimerkkejä."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Vältä toistamasta samaa merkkiä."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Vältä saman merkkityylin käyttöä: sekoita kirjaimia, numeroita ja "
+"välimerkkejä."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Vältä sarjan kaltaisia jonoja, kuten 1234 tai abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Salasanan tulee olla nykyistä pidempi. Lisää kirjaimia, numeroita ja "
+"erikoismerkkejä."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Käytä isoja ja pieniä kirjaimia sekä joitain numeroita."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Mitä enemmän kirjaimia, numeroita ja erikoismerkkejä, sitä vahvempi salasana."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Tunnistautuminen epäonnistui"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Uusi salasana on liian lyhyt"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Uusi salasana on liian yksinkertainen"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Vanha ja uusi salasana ovat liian samankaltaiset"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Uusi salasana on ollut jo käytössä äskettäin."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Uuden salasanan tulee sisältää numeroita tai erikoismerkkejä"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Vanha ja uusi salasana ovat samat"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Salasanasi on vaihtunut ensimmäisen todennuksen jälkeen!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Uusi salasana ei sisällä riittävästi eri merkkejä"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Tuntematon virhe"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Käyttäjätunnuksen tulisi yleensä koostua vain pienistä kirjaimista välillä a-"
+"z, numeroista sekä seuraavista merkeistä: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Valitettavasti kyseinen käyttäjätunnus ei ole saatavilla. Valitse toinen "
+"käyttäjätunnus."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Käyttäjätunnus on liian pitkä."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Määritä painikkeet"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Määritä painikkeille toimintoja"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Muokkaa pikanäppäintä valitsemalla ensin ”Lähetä näppäinpainallus” ja "
+"painamalla sitten pikanäppäinpainiketta. Paina sitten haluamasi uudet "
+"näppäimet pohjaan. Pikanäppäimen voi poistaa käytöstä painamalla "
+"askelpalautinta."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Sulje"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "Kosketa näytöllä näkyviä kohdemerkkejä piirtopöydän kalibroimiseksi."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Tunnistettiin ohi mennyt kosketus, aloitetaan alusta…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Painike %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Sovelluksen määrittämä"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Lähetä näppäinpainallus"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Vaihda näyttöä"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Näytä ohjeet näytöllä"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Piirtopöytä kiinnitettynä kannettavan paneeliin"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Piirtopöytä kiinnitettynä erilliseen näyttöön"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Ulkoinen piirtopöytälaite"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Ulkoinen piirtopöytälaite"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Kaikki näytöt"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Piirtopöytätila"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Käytä absoluuttista paikannusta kynälle"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Vasenkätinen suunta"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+"Piirtopöytä ja Express Keys™ -pikapainikkeet on suunnattu vasenkätisen "
+"käyttöön"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Kohdista näyttöön"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Säilytä kuvasuhde"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "Käytä vain osaa piirtopöydän alasta säilyttääksesi näytön kuvasuhteen"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibroi"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Piirtopöytää ei havaittu"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Liitä tai käynnistä Wacom-piirtopöytä."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Kynän kärjen paineentuntu"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Pehmeä"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Stylus-kärjen paine"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Kova"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Painike 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Painike 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Painike 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Pyyhekumin paineentuntu"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pyyhekumin paine"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Hiiren keskimmäisen painikkeen napsautus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Hiiren oikean painikkeen napsautus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Eteenpäin"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+"Airbrush-piirtokynä paineella, kallistuksella ja integroidulla "
+"liukusäätimellä"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Airbrush-piirtokynä paineella, kallistuksella ja kierrolla"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standardi piirtokynä paineella ja kallistuksella"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standardi piirtokynä paineella"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom-piirtopöydät"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Aseta piirtopöydän painikkeet ja kynän herkkyys"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Piirtopöytä;Wacom;Stylus;Eraser;Hiiri;Tablet;Mouse;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Uusi pikanäppäin…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Yhteyspisteet"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Toiminto peruttu"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Virhe:</b> Asetusten muuttaminen on estetty"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Virhe:</b> Mobiilitarvikkeen virhe"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Ei rekisteröity"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Rekisteröity"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Etsitään"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Estetty"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modeemin tiedot"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modeemin tila"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Verkko-operaattori"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Verkon tyyppi"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Verkon tila"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Oma numero"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Laitteen tiedot"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Laiteohjelmiston versio"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Vain 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Vain 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Vain 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Vain 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (ensisijainen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (ensisijainen), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (ensisijainen), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (ensisijainen), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (ensisijainen), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (ensisijainen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (ensisijainen), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (ensisijainen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (ensisijainen), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (ensisijainen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (ensisijainen), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (ensisijainen), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (ensisijainen), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (ensisijainen), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (ensisijainen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (ensisijainen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (ensisijainen)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (ensisijainen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Avaa SIM-kortin lukitus"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Avaa lukitus"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Anna SIM-kortin %d PIN-koodi"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Anna PIN-koodi avataksesi SIM-kortin lukituksen"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Anna SIM-kortin %d PUK-koodi"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Anna PUK-koodi avataksesi SIM-kortin lukituksen"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Annettu väärä salasana. %1$u yritys jäljellä"
+msgstr[1] "Annettu väärä salasana. %1$u yritystä jäljellä"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "%u yritys jäljellä"
+msgstr[1] "%u yritystä jäljellä"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Annettiin väärä salasana."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK-koodin tulisi olla 8 numeroa"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Anna uusi PIN-koodi"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN-koodin tulee olla 4-8 numeroa pitkä"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Avataan lukitus…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Ei SIM-korttia"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Syötä SIM-kortti käyttääksesi tätä modeemia"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM-kortti lukittu"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobiilidata"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Käytä dataa mobiiliverkon kautta"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Datan roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Käytä mobiilidataa roaming-tilassa"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Verkkotila"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Verkko"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Lisäasetukset"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Yhteyspisteiden nimet"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM-lukitus"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Lukitse SIM-kortti PIN-koodilla"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Mo_deemin tiedot"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Puhelinvirhe"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Ei yhteyttä puhelimeen"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Toiminto ei ole sallittu"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Toiminto ei ole tuettu"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM-korttia ei ole syötetty"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIM-kortin PIN-koodi vaaditaan"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIM-kortin PUK-koodi vaaditaan"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM-virhe"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM käytössä"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Väärä salasana"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM-kortin PIN2-koodi vaaditaan"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM-kortin PUK2-koodi vaaditaan"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Ei löytynyt"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Ei verkkopalvelua"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Verkon aikakatkaisu"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS-palvelut eivät ole sallittuja"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming ei ole sallittu tällä alueella"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Määrittämätön GPRS-virhe"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Ei virhettä"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Toiminto peruttu"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Pääsy estetty"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Tuntematon virhe"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Verkkotila"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automaattinen"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Valitse verkko"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Päivitä palveluntarjoajat"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Käytä mobiiliverkkoa"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "WWAN-sovitinta ei löytynyt"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Varmista, että sinulla on langaton WAN-/mobiililaite"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Langaton WAN on pois käytöstä, kun lentokonetila on päällä"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Poista _lentokonetila käytöstä"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Datayhteys"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Internetyhteyteen käytettävä SIM-kortti"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM-lukitus"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Seuraava"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Lukitse SIM-kortti PIN-koodilla"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Vaihda PIN-koodi"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Anna nykyinen PIN-koodi muuttaaksesi SIM-kortin lukitusasetuksia"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobiiliverkko"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Määritä puhelinverkko- ja mobiilidatayhteydet"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;wwan;telephony;sim;mobile;mobiili;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Työkalu Gnome-työpöydän asetusten muokkaukseen"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+"Asetukset on ensisijainen käyttöliittymä järjestelmäsi asetusten "
+"määrittämiseen."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Gnome-projekti"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Näytä versionumero"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Ota käyttöön lisätietoja tulostava tila"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Etsi merkkijonoa"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Näytä mahdolliset paneelinimet ja lopeta"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Näytettävä paneeli"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEELI] [ARGUMENTTI…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Asetusten luokat"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Yksityisyys"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Käytettävissä olevat paneelit:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Kaikki asetukset"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Ensisijainen valikko"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Varoitus: kehitysversio"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Tätä järjestelmäasetusten versiota tulee käyttää vain kehitystarkoituksiin. "
+"Saatat kohdata virheellistä järjestelmän toimintaa, tietojen menetystä tai "
+"muita odottamattomia ongelmia. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Ohje"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Yleiset"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Lopeta"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Haku"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneelit"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Siirry takaisin edelliseen paneeliin"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Peru haku"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Ominaisuudet;Asetukset;Preferences;Settings;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Viimeksi avattavan asetuspaneelin tunniste"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Viimeksi avattavan asetuspaneelin tunniste. Tuntemattomat arvot ohitetaan ja "
+"luettelossa ensimmäisenä oleva paneeli valitaan."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Näytä varoitus kun käytössä on järjestelmäasetusten kehitysversio"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Tulisiko järjestelmäasetusten näyttää varoitus, kun käytössä on "
+"kehitysversio."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Ikkunan alkutila"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Järjestetty, muuttumaton lista (tuple) sisältäen alkuarvon leveyden ja "
+"korkeuden sekä sovellusikkunan suurennetun tilan osalta."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u ulostulo"
+msgstr[1] "%u ulostuloa"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u sisääntulo"
+msgstr[1] "%u sisääntuloa"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Järjestelmän äänet"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Virhe: ei voitu määrittää HSI-tasoa."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Virhe: ei voitu määrittää virheellistä HSI-tasoa."
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER- tai PEM-varmenteet (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Lisää tulostin…"
+
+#~ msgid "Light"
+#~ msgstr "Vaalea"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;näyttö;lukitus;diagnostikka;kaatuminen;yksityinen;"
+#~ "viimeisimmät;väliaikset;nimi;verkko;identiteetti;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Näyttöjen järjestys"
+
+#~ msgid "Set"
+#~ msgstr "Aseta"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Lukitse näyttö"
+
+#~ msgid "Bark"
+#~ msgstr "Haukunta"
+
+#~ msgid "Drip"
+#~ msgstr "Vesipisara"
+
+#~ msgid "Glass"
+#~ msgstr "Lasi"
+
+#~ msgid "Sonar"
+#~ msgstr "Kaikuluotain"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Gnomen asetusten äänipaneeli"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Gnomen asetusten hiiri- ja kosketuslevypaneeli"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Gnomen asetusten taustakuvapaneeli"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Gnomen asetusten näppäimistöpaneeli"
+
+#~ msgid "Web Links"
+#~ msgstr "Verkkolinkit"
+
+#~ msgid "Git Links"
+#~ msgstr "Git-linkit"
+
+#~ msgid "%s Links"
+#~ msgstr "%s-linkit"
+
+#~ msgid "Unset"
+#~ msgstr "Poista asetus"
+
+#~ msgid "Links"
+#~ msgstr "Linkit"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hypertekstitiedostot"
+
+#~ msgid "Text Files"
+#~ msgstr "Tekstitiedostot"
+
+#~ msgid "Image Files"
+#~ msgstr "Kuvatiedostot"
+
+#~ msgid "Font Files"
+#~ msgstr "Fonttitiedostot"
+
+#~ msgid "Archive Files"
+#~ msgstr "Arkistotiedostot"
+
+#~ msgid "Package Files"
+#~ msgstr "Pakettitiedostot"
+
+#~ msgid "Audio Files"
+#~ msgstr "Äänitiedostot"
+
+#~ msgid "Video Files"
+#~ msgstr "Videotiedostot"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Käyttö- ja pääsyoikeudet"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Tiedot ja palvelut, joihin tämä sovellus on pyytänyt oikeudet, ja "
+#~ "sovelluksen vaatimat pakolliset oikeudet."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Ei voi muuttaa"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Sovellusten yksittäiset oikeudet on mahdollista katselmoida <a href="
+#~ "\"privacy\">yksityisyysasetuksissa</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integraatio"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Aseta työpöydän tausta"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Oletuskäsittelimet"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Sovelluksen avaamat tiedosto- ja linkkityypit."
+
+#~ msgid "Usage"
+#~ msgstr "Käyttö"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Kuinka paljon resursseja tämä sovellus käyttää."
+
+#~ msgid "Open in Software"
+#~ msgstr "Avaa ohjelmistokeskuksessa"
+
+#~ msgid "Activities"
+#~ msgstr "Toiminnot"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Salli alla listattujen sovellusten käyttää kameraa."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Tiedoston lähetys epäonnistui: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profiili on lähetetty:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Kirjoita ylös tämä osoite."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Käynnistä tietokone uudelleen ja käynnistä normaali käyttöjärjestelmäsi."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Kirjoita osoite selaimen osoitekenttään, lataa ja asenna profiili."
+
+#~ msgid "Upload profile"
+#~ msgstr "Lähetä profiili"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Vaatii internetyhteyden"
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopioi"
+
+#~ msgid "Select _All"
+#~ msgstr "_Valitse kaikki"
+
+#~ msgid "Single Display"
+#~ msgstr "Yksi näyttö"
+
+#~ msgid "Join Displays"
+#~ msgstr "Liitä näytöt"
+
+#~ msgid "Display Mode"
+#~ msgstr "Näyttötila"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Vedä näytöt vastaamaan näyttöjesi järjestystä. Valitse näyttö "
+#~ "muuttaaksesi sen asetuksia."
+
+#~ msgid "Active Display"
+#~ msgstr "Aktiivinen näyttö"
+
+#~ msgid "More Warm"
+#~ msgstr "Enemmän lämpöä"
+
+#~ msgid "Less Warm"
+#~ msgstr "Vähemmän lämpöä"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Tallenna kuvakaappaus kohteeseen $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Tallenna kuvakaappaus ikkunasta kohteeseen $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Tallenna kuvakaappaus alueesta $PICTURES-kansioon"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopioi kuvakaappaus leikepöydälle"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopioi kuvakaappaus ikkunasta leikepöydälle"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopioi kuvakaappaus alueesta leikepöydälle"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Nauhoita ruutukaappausvideo"
+
+#~ msgid "Move up"
+#~ msgstr "Siirrä ylös"
+
+#~ msgid "Move down"
+#~ msgstr "Siirrä alas"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Sijaintipalvelut mahdollistavat sovellusten paikantaa sijaintisi. "
+#~ "Tarkkuus paranee wifiä ja mobiiliyhteyttä käyttäen."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Käyttää Mozillan paikannuspalvelua: <a href='https://location.services."
+#~ "mozilla.com/privacy'>yksityisyyskäytäntö</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Salli alla listattujen sovellusten määrittää sijaintisi."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Salli alla listattujen sovellusten käyttää mikrofonia."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Kaksoisnapsautuksen aikaraja"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s - VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Valmiustila ja virran katkaisu"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Syli havaittu: suorituskykytila ei käytettävissä"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Korkea laitteiston lämpötila: suorituskykytila ei käytettävissä"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Suorituskykytila ei käytettävissä"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Tunnistaudu"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Valitse muotoilu numeroille, päiväyksille ja valuutoille. Muutokset "
+#~ "tulevat voimaan seuraavan kirjautumisen myötä."
+
+#~ msgid "My Account"
+#~ msgstr "Oma tili"
+
+#~ msgid "Language"
+#~ msgstr "Kieli"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Ikkunoissa ja verkkosivustoilla näkyvän tekstin kieli."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Käynnistä istunto uudelleen, jotta muutokset tulevat voimaan"
+
+#~ msgid "Restart…"
+#~ msgstr "Käynnistä uudelleen…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Kaikki käyttäjät käyttävät kirjautumisasetuksia kirjautuessaan "
+#~ "järjestelmään"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Määrittää mitä hakutuloksia näytetään Toiminnot-yleisnäkymässä. "
+#~ "Hakutulosten järjestystä voi muuttaa siirtämällä rivejä listassa."
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Näytön jakaminen sallii etäkäyttäjien seurata ja hallita näyttöäsi "
+#~ "yhdistämällä kohteeseen %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Näytön jakaminen"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Jotkut palvelut ovat poissa käytöstä, koska verkkoyhteyttä ei ole."
+
+#~ msgid "_Password:"
+#~ msgstr "_Salasana:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Näytä salasana"
+
+#~ msgid "Access Options"
+#~ msgstr "Käyttövalinnat"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Uusien yhteyksien tulee ky_syä lupa"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Vaadi salasana"
+
+#~ msgid "Sound Keys"
+#~ msgstr "_Äänekkäät näppäimet"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Näytönlukija"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Näytönlukija"
+
+#~ msgid "Standard"
+#~ msgstr "Normaali"
+
+#~ msgid "Account _Type"
+#~ msgstr "Tilin _tyyppi"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Salli käyttäjän vaihtaa salasana seuraavalla ki_rjautumiskerralla"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_Aseta salasana nyt"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Muodosta verkkoyhteys lisätäksesi yrityskirjautumistilejä."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Ota kuva…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Tee muutoksia\n"
+#~ "napsauttamalla ensin *-kuvaketta"
+
+#~ msgid "Create a user account"
+#~ msgstr "Luo käyttäjätili"
+
+#~ msgid "User Icon"
+#~ msgstr "Käyttäjän kuvake"
+
+#~ msgid "Account Settings"
+#~ msgstr "Tilin asetukset"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Tunnistautuminen ja kirjautuminen"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "Tätä käytetään kotikansiosi nimeämiseen, eikä sitä voi vaihtaa."
+
+#~ msgid "Output:"
+#~ msgstr "Ulostulo:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Säilytä kuvasuhde (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Kohdista näyttöön"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d / %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Kohdistus näyttöön"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Piirtopöytä (yksi yhteen)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Kosketuslevy (suhteellinen)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Piirtopöydän asetukset"
+
+#~ msgid "_Help"
+#~ msgstr "_Ohje"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth-asetukset"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Seurantatila"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Määritä painikkeet…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Muuta hiiren asetuksia"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Säädä näytön tarkkuutta"
+
+#~ msgid "No stylus found"
+#~ msgstr "Osoitinkynää ei löytynyt"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Siirrä osoitinkynä piirtopöydän läheisyyteen tehdäksesi määritykset"
+
+#~ msgid "Top Button"
+#~ msgstr "Yläpainike"
+
+#~ msgid "Lower Button"
+#~ msgstr "Alempi painike"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Alimmaisin painike"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Avataan lukitus..."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;kirjautuminen;nimi;"
+#~ "sormenjälki;avatar;kasvokuva;salasana;"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Pikanäppäimet"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Tämän voi muuttaa pikanäppäimien mukauttamisessa"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Pidä alhaalla ja näppäile kirjoittaaksesi eri merkkejä"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Näytön kirkkaus"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Näppäimistön _kirkkaus"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Himmennä näyttö koneen ollessa käyttämättä"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Tyhjä näyttö"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wifi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wifi voidaan sammuttaa virran säästämiseksi."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Mobiililaajakaista (3G, 4G, LTE jne.) voidaan sammuttaa virran "
+#~ "säästämiseksi."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth voidaan sammuttaa virran säästämiseksi."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Tasapainoinen teho"
+
+#~ msgid "Add…"
+#~ msgstr "Lisää…"
+
+#~ msgid "Left Alt"
+#~ msgstr "Vasen Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Oikea Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Vasen Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Oikea Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Oikea Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Vaihtoehtoinen merkistönäppäin"
+
+#, fuzzy
+#~| msgid "Switch to next source"
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Vaihda seuraavaan lähteeseen"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Valikkonäppäin"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Latautuu"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Varoitus"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Matala"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Hyvä"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Täyteen ladattu"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Tyhjä"
+
+#~ msgid "Previous source"
+#~ msgstr "Edellinen lähde"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Välilyönti"
+
+#~ msgid "Next source"
+#~ msgstr "Seuraava lähde"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Välilyönti"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Vasen+Oikea Alt"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Lisää käyttäjiä ja vaihda salasanoja"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Toista ja tallenna ääntä"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr ""
+#~ "Havaitse verkkolaitteet käyttäen mDNS:ää/DNS-SD:tä (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Suora pääsy bluetooth-laitteisiin"
+
+#~ msgid "Use your camera"
+#~ msgstr "Käytä kameraa"
+
+#~ msgid "Print documents"
+#~ msgstr "Tulosta asiakirjoja"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Käytä mitä tahansa yhdistettyä peliohjainta"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Salli yhdistäminen Docker-palveluun"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Muokkaa verkon palomuuria"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Aseta ja käytä etuoikeutettuja FUSE-tiedostojärjestelmiä"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Päivitä laiteohjelmisto (firmware) tällä laitteella"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Pääsy laitteiden tietoihin"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Tarjoa entropiaa laitepohjaiselle satunnaislukugeneraattorille"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Käytä laitteiston luomia satunnaislukuja"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Pääsy kotikansiosi tiedostoihin"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Pääsy libvirt-palveluun"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Muuta järjestelmän kieltä ja alueasetuksia"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Muuta sijainnin asetuksia ja palveluntarjoajia"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Lue järjestelmän ja sovellusten lokeja"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "Pääsy media-hub-palveluun"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Käytä ja muokkaa modeemeja"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Lue järjestelmän liitostietoja ja levykiintiöitä"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Hallitse musiikki- ja videosoittimia"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Muuta matalan tason verkkoasetuksia"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Pääsy NetworkManager-palveluun sekä verkkoasetuksien luku- ja "
+#~ "muutosoikeudet"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Lukuoikeus verkkoasetuksiin"
+
+#~ msgid "Change network settings"
+#~ msgstr "Muuta verkkoasetuksia"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Pääsy ofono-palveluun sekä mobiilipuhelinpalvelujen verkkoasetusten luku- "
+#~ "ja muutosoikeudet"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Hallitse Open vSwitch -laitteita"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Lue CD:ltä/DVD:ltä"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Lue, lisää, muuta tai poista tallennettuja salasanoja"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Pääsy pppd- ja ppp-laitteisiin sekä muokkausoikeus Point-to-Point-"
+#~ "yhteyskäytännön yhteyksiin"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Keskeytä tai lopeta mikä tahansa järjestelmän prosessi"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Suora pääsy USB-laitteisiin"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr ""
+#~ "Luku- ja kirjoitusoikeus erillisten tallennuslaitteiden tiedostoihin"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Estä näytön lepotila ja lukitus"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Pääsy sarjaportin laitteisiin"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Sammuta tai käynnistä laite uudelleen"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Asenna, poista ja muokkaa ohjelmistoja"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Pääsy Storage Framework -palveluun"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Lue prosessi- ja järjestelmätietoja"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Valvo ja hallitse mitä tahansa käynnissä olevaa ohjelmaa"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Vaihda päivää ja aikaa"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Vaihda aikapalvelimen asetuksia"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Vaihda aikavyöhykettä"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Pääsy UDisks2-palveluun sekä muokkaa levyjä ja irrotettavia medioita"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Lue ja muuta jaettuja kalenteritapahtumia Ubuntu Unity 8:ssa"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Lue ja muuta jaettuja yhteystietoja Ubuntu Unity 8:ssa"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Pääsy virrankäytön tietoihin"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Luku- ja kirjoitusoikeus altistetuille U2F-laitteille"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Esteettömyys"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Katkaise yhdistääksesi langattomaan verkkoon"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Salasana"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Luo käyttäjätili\n"
+#~ "napsauttamalla ensin *-kuvaketta"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Ota sormenjäljellä kirjautuminen käyttöön"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Muu sormi:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Sormenjälkesi tallennettiin onnistuneesti. Sinun pitäisi nyt pystyä "
+#~ "kirjautumaan sisään sormenjäljen avulla."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Sinulla ei ole oikeutta käyttää laitetta. Ota yhteyttä ylläpitäjäjääsi."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Tapahtui sisäinen virhe."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Poistetaanko rekisteröidyt sormenjäljet?"
+
+#~ msgid "Done!"
+#~ msgstr "Valmis!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Laitetta ”%s” ei voitu käsitellä"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Sormenjäljen tunnistusta ei voitu aloittaa laitteella “%s”"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Sormenjälkilukijoita ei voitu käyttää"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Kysy apua järjestelmäsi ylläpitäjältä."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Jotta voit ottaa sormenjäljellä kirjautumisen käyttöön, täytyy yksi "
+#~ "sormenjäljistä tallentaa käyttäen laitetta ”%s”."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Valitaan sormea"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Aseta taustakuva ja lukitusnäyttö"
+
+#~ msgid "Set Background"
+#~ msgstr "Aseta taustakuva"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Aseta lukitusnäyttö"
+
+#~ msgid "Remove Background"
+#~ msgstr "Poista taustakuva"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Raportit lähetetään anonyymisti, ja niistä poistetaan henkilökohtaiset "
+#~ "tiedot."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Teknisiin ongelmiin liittyvien raporttien lähettäminen auttaa meitä "
+#~ "parantamaan tätä käyttöjärjestelmää."
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Ponnahdusilmoitukset"
+
+#~ msgid "Last Login"
+#~ msgstr "Viimeisin kirjautuminen"
+
+#~ msgid "Version %s"
+#~ msgstr "Versio %s"
+
+#~ msgid "OS name"
+#~ msgstr "Käyttöjärjestelmän nimi"
+
+#~ msgid "OS type"
+#~ msgstr "Käyttöjärjestelmän tyyppi"
+
+#~ msgid "Disk"
+#~ msgstr "Levy"
+
+#~ msgid "Check for updates"
+#~ msgstr "Tarkista päivitykset"
+
+#~ msgid "Network proxy"
+#~ msgstr "Verkon välityspalvelin"
+
+#~ msgid "page 1"
+#~ msgstr "sivu 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "_Sisempi tunnistautuminen"
+
+#~ msgid "page 2"
+#~ msgstr "sivu 2"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Rajoita _datan taustakäyttöä"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr ""
+#~ "Sopiva yhteyksille, mihin sovelletaan datan määrään pohjautuvaa "
+#~ "hinnoittelua tai siirtorajoituksia."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Parikaapeli (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Yhteyspisteen käyttöönotto katkaisee yhteyden langattomaan verkkoon <b>"
+#~ "%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Yhteyspisteen ollessa käytössä langattoman internetyhteyden käyttö ei ole "
+#~ "mahdollista."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Wifi-yhteyspisteitä käytetään yleensä Internet-yhteyden jakamiseen "
+#~ "langattomasti."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Automaattinen _yhdistäminen"
+
+#~ msgid "details"
+#~ msgstr "tiedot"
+
+#~ msgid "Show P_assword"
+#~ msgstr "_Näytä salasana"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Aseta kaikkien käyttäjien käytettäväksi"
+
+#~ msgid "identity"
+#~ msgstr "identiteetti"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Osoitteet"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Vain automaattiset (DHCP-) osoitteet"
+
+#~ msgid "Link-local only"
+#~ msgstr "Vain linkkiyhteys"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Älä huomioi automaattisesti saatuja reittejä"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Kloonattu MAC-osoite"
+
+#~ msgid "_Reset"
+#~ msgstr "_Tyhjennä"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Tyhjennä tämän yhteyden asetukset ja palauta oletusasetukset, mutta "
+#~ "muista yhteys ensisijaisena."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Poista kaikki tähän verkkoon liittyvä tieto äläkä yritä yhdistää "
+#~ "automaattisesti."
+
+#~ msgid "Hardware"
+#~ msgstr "Laitteisto"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Tyhjennä asetukset"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Yhdistetyt laitteet"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastruktuuri"
+
+#~ msgid "In use"
+#~ msgstr "Käytössä"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Päällä"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Pois"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Pois"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Päällä"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Pois"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Päällä"
+
+#~ msgid "Usage & History"
+#~ msgstr "Käyttö ja historia"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Tietosuoja"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Historian muistaminen helpottaa asioiden löytämistä uudelleen. Näitä "
+#~ "tietoja ei koskaan jaeta verkossa."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Äskettäin käytetyt"
+
+#~ msgid "Retain _History"
+#~ msgstr "_Säilytä historia"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Näyttölukko suojaa yksityisyyttäsi kun olet poissa."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Lukitse näyttö kun se on ollut _tyhjänä"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Lukitusnäytön ilmoitukset"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Tyhjennä roskakori ja tuhoa väliaikaistiedostot automaattisesti, jotta "
+#~ "koneelle ei jää turhaa yksityistä tietoa."
+
+#~ msgid "Purge _After"
+#~ msgstr "Tyhjennä/tuhoa _viiveellä"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Lähettämällä käyttämiesi ohjelmistojen käyttötilastot saat parempia "
+#~ "suosituksia. Samalla autat parantamaan ohjelmistoja.\n"
+#~ "\n"
+#~ "Keräämäämme tietoa ei voi yhdistää yksittäisiin käyttäjiin, eikä "
+#~ "tietojasi tulla koskaan jakamaan kolmansien osapuolien kanssa."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "Lä_hetä ohjelmistojen käyttötilastot"
+
+#~ msgid "_Camera"
+#~ msgstr "_Kamera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Mikrofoni"
+
+#~ msgid "_Location Services"
+#~ msgstr "Sijai_ntipalvelut"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Suojaa henkilökohtaisia tietojasi ja hallitse, mitä tietoja muut voivat "
+#~ "nähdä"
+
+#~ msgid "No regions found"
+#~ msgstr "Alueita ei löytynyt"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Väläytä _ikkunan reunusta"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Käyttäjätunnus ei voi alkaa merkillä ”-”."
+
+#~ msgid "_Background"
+#~ msgstr "_Taustakuva"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Muuttuu päivän aikana"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Laatoitettu"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Lähennys"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Keskitetty"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Skaalattu"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Täyttö"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Peitetty"
+
+#~ msgid "Colors"
+#~ msgstr "Värit"
+
+#~ msgid "Pictures"
+#~ msgstr "Kuvat"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Kuvia ei löytynyt"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Voit lisätä kuvia %s-kansioon, jolloin ne näkyvät täällä"
+
+#~ msgid "_Off"
+#~ msgstr "_Pois"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Yhteys/SSID"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automaattinen valmiustila"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Kun virtapainiketta painetaan"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "Drag displays to match your setup."
+#~ msgstr "Järjestä näytöt vastaamaan kokoonpanoasi vetämällä niitä."
+
+#~ msgid "_Night Light"
+#~ msgstr "_Yövalo"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Näytön tietoja ei saatu"
+
+#~ msgid "hardware"
+#~ msgstr "laitteisto"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Vaihda edelliseen lähteeseen"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Vaihda seuraavaan lähteeseen"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Vaihtoehtoinen vaihto seuraavaan lähteeseen"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Englanti (Yhdistynyt kuningaskunta)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Yhdistynyt kuningaskunta"
+
+#~ msgid "_Options"
+#~ msgstr "_Valinnat"
+
+#~ msgid "Add input source"
+#~ msgstr "Lisää syötelähde"
+
+#~ msgid "Remove input source"
+#~ msgstr "Poista syötelähde"
+
+#~ msgid "Move input source up"
+#~ msgstr "Siirrä syötelähde ylös"
+
+#~ msgid "Move input source down"
+#~ msgstr "Siirrä syötelähde alas"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Näytä syötelähteenä olevan näppäimistön asettelu"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Vasen"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Oikea"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimi"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maksimi"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profiili:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Testaa kaiuttimia"
+
+#~ msgid "Peak detect"
+#~ msgstr "Havaitse piikit"
+
+#~ msgid "Device"
+#~ msgstr "Laite"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Kaiutintesti: %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Valitse laite äänen toistamiseksi:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Valitun laitteen asetukset:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Äänitysvoimakkuus:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Valitse laite äänen tallentamiseksi:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Äänitehosteet"
+
+#~ msgid "Built-in"
+#~ msgstr "Sisäänrakennettu"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Ääniasetukset"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Kokeillaan tapahtuman ääntä"
+
+#~ msgid "From theme"
+#~ msgstr "Teemasta"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Valitse hälytysääni:"
+
+#~ msgid "Stop"
+#~ msgstr "Pysäytä"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Normaali"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Ylläpitäjä"
+
+#~ msgid "page 3"
+#~ msgstr "sivu 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Gnomen asetuskeskus"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Asetuskeskus on Gnomen ensisijainen käyttöliittymä työpöydän monien eri "
+#~ "asetusten muokkaamiseen."
+
+#~ msgid "Quit"
+#~ msgstr "Lopeta"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "V_ahvista uusi salasana"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Salasanat eivät täsmää."
+
+#~ msgid "Show the overview"
+#~ msgstr "Näytä yleiskuva"
+
+#, fuzzy
+#~| msgid "_Left index finger"
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "_Vasen etusormi"
+
+#, fuzzy
+#~| msgid "_Left index finger"
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "_Vasen etusormi"
+
+#, fuzzy
+#~| msgid "Left middle finger"
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "Vasen keskisormi"
+
+#, fuzzy
+#~| msgid "Left middle finger"
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "Vasen keskisormi"
+
+#, fuzzy
+#~| msgid "Left ring finger"
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "Vasen nimetön"
+
+#, fuzzy
+#~| msgid "Left ring finger"
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "Vasen nimetön"
+
+#, fuzzy
+#~| msgid "Left little finger"
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "Vasen pikkurilli"
+
+#, fuzzy
+#~| msgid "Left little finger"
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "Vasen pikkurilli"
+
+#, fuzzy
+#~| msgid "_Right index finger"
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "_Oikea etusormi"
+
+#, fuzzy
+#~| msgid "_Right index finger"
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "_Oikea etusormi"
+
+#, fuzzy
+#~| msgid "Right middle finger"
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "Oikea keskisormi"
+
+#, fuzzy
+#~| msgid "Right middle finger"
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "Oikea keskisormi"
+
+#, fuzzy
+#~| msgid "Right ring finger"
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "Oikea nimetön"
+
+#, fuzzy
+#~| msgid "Right ring finger"
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "Oikea nimetön"
+
+#, fuzzy
+#~| msgid "Right little finger"
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "Oikea pikkurilli"
+
+#, fuzzy
+#~| msgid "Right little finger"
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "Oikea pikkurilli"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "Aseta sormesi lukijalle uudelleen"
+
+#~ msgid "Disable image"
+#~ msgstr "Poista kuva käytöstä"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Selaa lisää kuvia…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Käytössä (%s)"
+
+#~ msgid "Back­ground"
+#~ msgstr "Taustakuva"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Väri"
+
+#~ msgid "Overview"
+#~ msgstr "Yhteenveto"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Oletussovellukset"
+
+#~ msgid "Ab­out"
+#~ msgstr "Järjestelmätiedot"
+
+#~ msgid "De­tails"
+#~ msgstr "Tiedot"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Erilliset tallennusvälineet"
+
+#~ msgid "Net­work"
+#~ msgstr "Verkko"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Ilmoitukset"
+
+#~ msgid "Po­wer"
+#~ msgstr "Virranhallinta"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Yksityisyys"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Jakaminen"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Esteettömyys"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wacom-piirtopöytä"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Laitteisto"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Järjestelmä"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Kansi suljettu"
+
+#~ msgid "Mirrored"
+#~ msgstr "Peilattu"
+
+#~ msgid "Secondary"
+#~ msgstr "Toissijainen"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Järjestä yhdistetyt näytöt"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Käännä vastapäivään 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Käännä 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Käännä myötäpäivään 90°"
+
+#~ msgid "Size"
+#~ msgstr "Koko"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Näytä yläpalkki ja yleisnäkymä tällä näytöllä"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Liitä tämä näyttö toiseen luodaksesi lisää työtilaa"
+
+#~ msgid "Presentation"
+#~ msgstr "Esitys"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Näyttää vain diaesitykset ja muun median"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Näytä nykyinen näkymä molemmilla näytöillä"
+
+#~ msgid "Turn Off"
+#~ msgstr "Sammuta"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Älä käytä tätä näyttöä"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Järjestä yhdistetyt näytöt"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (Tunniste: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "Järjestelmä"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Pikanäppäin;Toisto;Vilkkuminen;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Paina Esc peruaksesi."
+
+#~ msgid "Server"
+#~ msgstr "Palvelin"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Poista DNS-palvelin"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Aseta kaikkien _käyttäjien käytettäväksi"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Palomuurin _vyöhyke"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Oletus"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Vyöhyke määrittää yhteyden luottamustason"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Tyhjennä tämän verkon asetukset, myös salasanat, mutta muista tämä verkko "
+#~ "ensisijaisena"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Poista kaikki tähän verkkoon liittyvä tieto äläkä yritä yhdistää "
+#~ "automaattisesti"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Jos käytössäsi on myös muu kuin langaton internetyhteys, voit käyttää "
+#~ "sitä kyseisen yhteyden jakamiseen muiden käyttäjien kanssa."
+
+#~ msgid "Proxy"
+#~ msgstr "Välityspalvelin"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Lisää profiili…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Ei mitään"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Käsin"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automaattinen"
+
+#~ msgid "Group Name"
+#~ msgstr "Ryhmän nimi"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Käytä yhteyspisteenä…"
+
+#~ msgid "_History"
+#~ msgstr "_Historia"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Lisää kirjaimia, numeroita ja symboleja."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Vahvuus: heikko"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Vahvuus: matala"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Vahvuus: keskitaso"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Vahvuus: hyvä"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Vahvuus: korkea"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Käyttäjätilisi</small>"
+
+#~ msgid "0"
+#~ msgstr "0"
+
+#~ msgid "Add Account"
+#~ msgstr "Lisää tili"
+
+#~ msgid "Mail"
+#~ msgstr "Sähköposti"
+
+#~ msgid "Calendar"
+#~ msgstr "Kalenteri"
+
+#~ msgid "Contacts"
+#~ msgstr "Yhteystiedot"
+
+#~ msgid "Chat"
+#~ msgstr "Keskustelu"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Määritetään asetuksia"
+
+#~ msgid "Toner Level"
+#~ msgstr "Värikasetin taso"
+
+#~ msgid "Supply Level"
+#~ msgstr "Täyttöaste"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Asennetaan"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktiivinen"
+#~ msgstr[1] "%u aktiivista"
+
+#~| msgid "Add Printer"
+#~ msgctxt "button"
+#~ msgid "Add Printer"
+#~ msgstr "Lisää tulostin"
+
+#~ msgid "Supply"
+#~ msgstr "Väri"
+
+#~ msgid "Jobs"
+#~ msgstr "Työt"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "N_äytä työt"
+
+#~ msgid "label"
+#~ msgstr "nimike"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Tulosta _testisivu"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Muut tilit"
+
+#~| msgid "Set Shortcut"
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Aseta pikanäppäin"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Ilmoitus_bannerit"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "_Ilmoitusbannerit"
+
+#~ msgid "Error creating account"
+#~ msgstr "Virhe tiliä luotaessa"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Haluatko varmasti poistaa tilin?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Tämä ei poista käyttäjää palvelimelta."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Verkkotilejä ei ole määritelty"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Lisäämällä tilin voit käyttää sitä asiakirjoja, sähköpostia, "
+#~ "yhteystietoja, kalenteria, pikaviestintää ja muuta varten."
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Lisää uusi tulostin"
+
+#~ msgid "No printers detected."
+#~ msgstr "Tulostimia ei havaittu."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Ylös"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Alas"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Ei mitään"
+
+#~ msgid "Left Ring"
+#~ msgstr "Vasen rengas"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Vasemman renkaan tila #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Oikean renkaan tila #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Vasen kosketusliuska"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Vasemman kosketusliuskan tila #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Oikea kosketusliuska"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Oikean kosketusliuskan tila #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Vasemman kosketusrenkaan tilavaihdin"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Oikean kosketusrenkaan tilavaihdin"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Vasemman kosketusliuskan tilavaihdin"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Oikean kosketusliuskan tilavaihdin"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Tilavaihdin #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Vasen painike #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Oikea painike #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Yläpainike #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Alapainike #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Ei toimintoa"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Hiiren vasemman painikkeen napsautus"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Vieritys ylös"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Vieritys alas"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Vieritys oikealle"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr ""
+#~ "Pikanäppäin toiminnolle <b>%s</b>. Anna uusi pikanäppäin vaihtaaksesi."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Muokkaa pikanäppäintä napsauttamalla riviä ja paina sitten haluamasi "
+#~ "uudet näppäimet pohjaan. Pikanäppäimen voi poistaa käytöstä painamalla "
+#~ "askelpalautinta."
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Virhe kirjauduttaessa käyttäjätilille"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Kirjautumistiedot ovat vanhentuneet."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Kirjaudu sisään ottaaksesi tämän tilin käyttöön."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Kirjaudu sisään"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Poista pikanäppäin"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Tuntematon toiminto>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Pikanäppäintä ”%s” ei voi käyttää, koska tällöin kyseistä näppäintä ei "
+#~ "enää voi käyttää kirjoittamiseen.\n"
+#~ "Kokeile yhdistämällä näppäin esimerkiksi Control-, Alt- tai "
+#~ "vaihtonäppäimeen."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Pikanäppäin ”%s” on jo kytketty toimintoon\n"
+#~ "”%s”"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Jos siirrät pikanäppäimen toimintoon \"%s\", poistetaan pikanäppäin \"%s"
+#~ "\" käytöstä."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Siirrä"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" on sidottu toimintoon \"%s\", tämä pikanäppäin poistetaan käytöstä "
+#~ "jos jatkat eteenpäin."
+
+#~ msgid "_Assign"
+#~ msgstr "_Aseta"
+
+#~ msgid "Bond"
+#~ msgstr "Liitos"
+
+#~ msgid "Bridge"
+#~ msgstr "Silta"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN-liittänäisten lataus epäonnistui"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Lisää verkkoyhteys"
+
+#~ msgid "(none)"
+#~ msgstr "(ei mitään)"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand-laite ei tue yhdistettyä tilaa"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Varmentajavarmennetta ei valittu"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Varmentajan (CA) käyttämättä jättäminen voi johtaa yhteyksien ottamiseen "
+#~ "turvattomiin, epäluotettaviin langattomiin verkkoihin. Haluatko valita "
+#~ "varmentajan varmenteen?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ohita"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Valitse CA-varmenne"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "K_ysy tätä salasanaa joka kerta"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "_Älä varoita uudelleen"
+
+#~ msgid "Yes"
+#~ msgstr "Kyllä"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Muu"
+
+#~ msgid "_Verify"
+#~ msgstr "_Vahvista"
+
+#~ msgid "Login History"
+#~ msgstr "Kirjautumishistoria"
+
+#~ msgid "Add User Account"
+#~ msgstr "Lisää käyttäjätili"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Käyttäjä tunnuksella '%s' on jo olemassa."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Käytetään maantieteellisen sijaintisi määrittämiseen"
+
+#~ msgid "Done"
+#~ msgstr "Valmis"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Aika_vyöhyke"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Jatka tulostusta"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Keskeytä tulostus"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Pidossa"
+
+#~ msgid "Job Title"
+#~ msgstr "Työn nimi"
+
+#~ msgid "Job State"
+#~ msgstr "Työn tila"
+
+#~ msgid "Password:"
+#~ msgstr "Salasana:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "Toistonäppäi_met"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "K_ohdistimen vilkunta"
+
+#~ msgid "Zoom"
+#~ msgstr "Lähennys"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Väri"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Viive:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Lyhyt"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Hidas"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Pitkä"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Nopea"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Nopeus:"
+
+#~ msgid "For mice and touchpads."
+#~ msgstr "Hiirelle ja kosketuslevylle."
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Testaa asetukset"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Hidas"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Nopea"
+
+#~ msgid "_Double-click"
+#~ msgstr "_Kaksoisnapsautus"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Vasen"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Oikea"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "O_soittimen nopeus"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Hidas"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Nopea"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Hidas"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Nopea"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Lisää uusi tulostin"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Langattomat laitteet tarvitsevat lisävirtaa"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Kun akkuvirtaa on e_rittäin vähän"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Bluetoothin avulla voit jakaa tiedostoja toisten Bluetooth-laitteiden "
+#~ "kanssa"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Vastaanota vain luotetuilta laitteilta"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Tallenna vastaanotetut tiedostot Lataukset-kansioon"
+
+#~ msgid "Show help options"
+#~ msgstr "Näytä ohjevalitsimet"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Suorita ”%s --help” nähdäksesi täyden luettelon komentorivivalitsimista.\n"
+
+#~ msgid "United States"
+#~ msgstr "Yhdysvallat"
+
+#~ msgid "Spain"
+#~ msgstr "Espanja"
+
+#~ msgid "China"
+#~ msgstr "Kiina"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "_Poista kosketuslevy käytöstä kirjoitettaessa"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr ""
+#~ "Järjestelmän verkkopalvelut eivät ole yhteensopivia tämän version kanssa."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Näytä ilmoitusbannerit"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Näytä lukitusnäytössä"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Näytä ilmoitusbannerit"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Sammuttaa langattomat laitteet"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Kirjoita tulostimen osoite tai tekstiä suodattaaksesi tuloksia"
+
+#~ msgid "Sorry"
+#~ msgstr "Virhe"

--- a/po/fr.po
+++ b/po/fr.po
@@ -36,9 +36,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center HEAD\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-04-19 17:02+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-04-19 19:16+0200\n"
 "Last-Translator: Guillaume Bernard <associations@guillaume-bernard.fr>\n"
 "Language-Team: GNOME French Team <gnomefr@traduc.org>\n"
@@ -49,101 +48,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Gtranslator 40.0\n"
 
-#: panels/applications/cc-applications-panel.c:803
-msgid "System Bus"
-msgstr "Bus système"
-
-#: panels/applications/cc-applications-panel.c:803
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:823
-msgid "Full access"
-msgstr "Accès complet"
-
-#: panels/applications/cc-applications-panel.c:805
-msgid "Session Bus"
-msgstr "Bus de session"
-
-#: panels/applications/cc-applications-panel.c:809
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Périphériques"
-
-#: panels/applications/cc-applications-panel.c:809
-msgid "Full access to /dev"
-msgstr "Accès complet à /dev"
-
-#: panels/applications/cc-applications-panel.c:813
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Réseau"
-
-#: panels/applications/cc-applications-panel.c:813
-msgid "Has network access"
-msgstr "A accès au réseau"
-
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:820
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Dossier personnel"
-
-#: panels/applications/cc-applications-panel.c:820
-#: panels/applications/cc-applications-panel.c:825
-msgid "Read-only"
-msgstr "Lecture seule"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-msgid "File System"
-msgstr "Système de fichiers"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Paramètres"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Can change settings"
-msgstr "Peut modifier les réglages"
-
-#: panels/applications/cc-applications-panel.c:831
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"Les permissions suivantes sont intégrées à %s. Elles ne peuvent être "
-"modifiées. Si ces permissions vous inquiètent, vous devez envisager de "
-"supprimer cette application."
-
-#: panels/applications/cc-applications-panel.c:1164
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u type de fichier et de lien ouvert par l’application"
-msgstr[1] "%u types de fichiers et de liens ouverts par l’application"
-
-#: panels/applications/cc-applications-panel.c:1171
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> est utilisé pour ouvrir les types de fichiers et liens suivants."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1223
-#, c-format
-msgid "%s of disk space used"
-msgstr "%s d’espace disque utilisé"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1387
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -159,7 +64,6 @@ msgid "Install some…"
 msgstr "Installer…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Ouvrir"
 
@@ -170,6 +74,10 @@ msgstr "Afficher les détails"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Recherche"
@@ -179,24 +87,13 @@ msgstr "Recherche"
 msgid "Receive system searches and send results."
 msgstr "Recevoir les recherches système et envoyer les résultats."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Désactivé"
 
@@ -210,7 +107,8 @@ msgid "Show system notifications."
 msgstr "Afficher les notifications système."
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+#, fuzzy
+msgid "Run in Background"
 msgstr "Exécuter en arrière-plan"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -218,131 +116,143 @@ msgid "Allow activity when the app is closed."
 msgstr "Autoriser l’exécution même lorsque l’application est fermée."
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Captures d’écran"
+
+#: panels/applications/cc-applications-panel.ui:141
+#, fuzzy
+msgid "Take pictures of the screen at any time."
+msgstr "Prendre des photos avec la caméra."
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "Modifier le papier peint"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "Modifier le papier peint du bureau."
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Sons"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "Reproduire les sons."
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "Ignorer les raccourcis"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "Bloquer les raccourcis clavier standard."
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "Caméra"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "Prendre des photos avec la caméra."
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "Micro"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "Enregistrer l’audio avec le microphone."
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Services de localisation"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "Accéder aux données d’emplacement du périphérique."
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "Permissions intégrées"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "L’accès au système qui est requis par l’application"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "Associations de fichiers et de liens"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Stockage"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Essayez une autre recherche"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "Associations de fichiers et de liens"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "Types de fichiers"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "Types de liens"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Espace disque consommé par cette application pour ses données et son cache."
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Application"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Données"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Cache"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Total</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Effacer le cache…"
 
@@ -350,91 +260,32 @@ msgstr "Effacer le cache…"
 msgid "Control various application permissions and settings"
 msgstr "Contrôle diverses permissions et réglages d’application"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "application;flatpak;permission;réglage;"
-
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "Sélectionner une image"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "A_nnuler"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:524
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Ouvrir"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "plusieurs tailles"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Aucun arrière-plan de bureau"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Arrière-plan actuel"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Style"
 
-#: panels/background/cc-background-panel.ui:45
-msgid "Light"
-msgstr "Clair"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Par défaut"
 
-#: panels/background/cc-background-panel.ui:72
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "Sombre"
 
-#: panels/background/cc-background-panel.ui:91
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Arrière-plan"
 
-#: panels/background/cc-background-panel.ui:97
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "Ajouter une image…"
 
@@ -448,52 +299,61 @@ msgstr ""
 "Remplacer votre image d’arrière-plan ou les couleurs de l’interface "
 "utilisateur"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+#, fuzzy
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Arrière-plan;Papier peint;Écran;Bureau;Style;Clair;Sombre;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "A_ctiver"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Pas de réseau Bluetooth trouvé"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Branchez la clé pour utiliser le Bluetooth."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth désactivé"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 "Activez pour connecter des périphériques et recevoir des transferts de "
 "fichiers."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "Le Mode avion est activé"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Le Bluetooth est désactivé lorsque le mode avion est activé."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Désactivez le mode avion"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "L’interrupteur matériel du mode avion est activé"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Désactivez le mode avion pour activer le Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -501,20 +361,19 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Active/désactive le Bluetooth et connecte vos périphériques"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "partage;partager;bluetooth;obex;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "La caméra est désactivée"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Aucune application ne peut prendre de photo ou de vidéo."
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
@@ -527,7 +386,7 @@ msgstr ""
 "\n"
 "Autoriser les applications ci-dessous à utiliser votre caméra."
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Aucune application n’a demandé l’accès à votre caméra"
 
@@ -535,100 +394,33 @@ msgstr "Aucune application n’a demandé l’accès à votre caméra"
 msgid "Protect your pictures"
 msgstr "Protéger vos images"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"écran;verrouiller;verrouillage;diagnostique;plantage;privé;confidentiel;"
-"récent;temporaire;tmp;index;nom;réseaux;identité;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Posez votre sonde d’étalonnage sur le carré et appuyez sur « Démarrer »"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Déplacez votre sonde d’étalonnage vers l’emplacement à étalonner et appuyez "
-"sur « Continuer »"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Déplacez votre sonde d’étalonnage à l’aplomb de l’emplacement à étalonner et "
-"appuyez sur « Continuer »"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Rabattez l’écran"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Une erreur interne irrécupérable est survenue."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Les outils nécessaires à l’étalonnage ne sont pas installés."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Le profil n’a pas pu être généré."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Le point blanc spécifié n’est pas disponible."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Terminé !"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Échec de l’étalonnage !"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Vous pouvez retirer la sonde d’étalonnage."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ne pas toucher à la sonde d’étalonnage pendant le processus"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Étalonnage de l’écran"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "A_nnuler"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -642,143 +434,9 @@ msgstr "_Reprendre"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Terminé"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Écran de portable"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Webcam intégrée"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Écran %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Scanner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Appareil photo %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Imprimante %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webcam %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Activer la gestion des couleurs de %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Afficher les profils de couleurs de %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Non étalonné"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Par défaut : "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Espace de couleurs : "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Profil test : "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Sélectionnez un fichier de profil ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importer"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Profils ICC pris en charge"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Tous les fichiers"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Écran"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Enregistrer le profil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Enregistrer"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Créer un profil de couleur pour le périphérique sélectionné"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"L’instrument de mesure n’est pas détecté. Vérifiez qu’il est allumé et "
-"connecté correctement."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-"L’instrument de mesure ne prend pas en charge les profils d’imprimante."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Le type de périphérique n’est pas actuellement pris en charge."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -895,13 +553,13 @@ msgstr "Nécessite un média inscriptible"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Ici, vous pouvez consulter d’utiles conseils sur l’utilisation d’un profil "
-"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> et <a href="
-"\"windows\">Microsoft Windows</a>."
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> et <a "
+"href=\"windows\">Microsoft Windows</a>."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -920,8 +578,8 @@ msgid "_Import File…"
 msgstr "_Importer un fichier…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "_Ajouter"
@@ -932,9 +590,7 @@ msgstr ""
 "Chaque périphérique a besoin d’un profil de couleur à jour pour la prise en "
 "charge des couleurs."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Pour en savoir plus"
 
@@ -1066,82 +722,6 @@ msgstr "D65 (photos et graphismes)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Espace de couleurs standard"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Profil test"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatique"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Basse qualité"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Qualité moyenne"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Haute qualité"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RVB par défaut"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMJN par défaut"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Gris par défaut"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Données d’étalonnage d’usine du fabricant"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Correction de l’écran en mode plein écran impossible avec ce profil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Ce profil n’est peut-être plus assez précis"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Couleur"
@@ -1153,14 +733,9 @@ msgstr ""
 "Étalonne la couleur de vos périphériques, comme les écrans, les appareils "
 "photos ou les imprimantes"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Couleur;ICC;Profil;Étalonner;Étalonnage;Imprimante;Écran;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Autre…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1175,21 +750,16 @@ msgid "No languages found"
 msgstr "Aucune langue trouvée"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Davantage…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Déverrouiller pour modifier les paramètres"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr ""
 "Certains paramètres doivent être déverrouillés avant de pouvoir être "
 "modifiés."
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "Déverrouiller…"
 
@@ -1212,151 +782,6 @@ msgstr "Décrémenter les heures"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Décrémenter les minutes"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Aujourd’hui"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Hier"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d heure"
-msgstr[1] "%d heures"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minute"
-msgstr[1] "%d minutes"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d seconde"
-msgstr[1] "%d secondes"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 seconde"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Point d’accès"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 heures"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1439,32 +864,68 @@ msgstr "_Date et heure automatiques"
 msgid "Requires internet access"
 msgstr "Nécessite une connexion internet"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "Date et _heure"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "_Fuseau horaire automatique"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr ""
 "Nécessite l’activation des services de localisation et une connexion internet"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Activé"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Fuseau h_oraire"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Déverrouiller"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format de l’heure"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dates"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 seconde"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calendrier"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Nombres"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Modifier la date et l’heure, y compris le fuseau horaire"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Horloge;Fuseau;Heure;Date;Emplacement;"
@@ -1510,21 +971,9 @@ msgstr "Applications par défaut"
 msgid "Configure Default Applications"
 msgstr "Configurer les applications par défaut"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "défaut;par défaut;application;préférée;média;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Envoyer des rapports ou signaler des problèmes techniques nous aide à "
-"améliorer %s. Les rapports sont envoyés anonymement et sont épurés de toute "
-"donnée personnelle. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1542,155 +991,116 @@ msgstr "Diagnostics"
 msgid "Report your problems"
 msgstr "Signaler des problèmes"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"écran;verrouiller;verrouillage;diagnostic;diagnostique;plantage;privé;"
-"confidentiel;récent;temporaire;tmp;index;nom;réseaux;identité;"
-"confidentialité;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Activé"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Désactivé"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "Appliquer les changements ?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "Les changements ne peuvent être appliqués"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "Cela peut venir de limitations matérielles."
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "Diagnostics"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Appliquer"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Précédent"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr "Paramètres d’affichage désactivés"
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "Disposition des écrans"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "Affichages multiples"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "Joindre"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Cloner"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Contient la barre supérieure et les activités"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Écran principal"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Mode nuit"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Paysage"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Portrait sur la droite"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Portrait sur la gauche"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Paysage (retourné)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Orientation"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Définition"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Fréquence de rafraîchissement"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Ajuster pour une TV"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Échelle"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Défilement naturel"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Mode nuit"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Désactivé temporairement jusqu’à demain"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "Redémarrer le filtre"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1698,59 +1108,59 @@ msgstr ""
 "Le mode nuit adoucit les couleurs bleues de l’écran. Il peut réduire la "
 "fatigue des yeux et les risques d’insomnies."
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Horaires"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Coucher au lever du soleil"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Horaire manuel"
 
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Horodatage"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "De"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "heure"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "minute"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "matin"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "après midi"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "à"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Température de couleur"
 
@@ -1762,7 +1172,6 @@ msgstr "Éc­rans"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Choisir le mode d’utilisation des écrans et projecteurs connectés"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1772,54 +1181,58 @@ msgstr ""
 "Moniteur;Nuit;Éclairage;Lumière;Bleue;Rouge;redshift;décalage;spectral;"
 "couleur;lever;coucher;soleil;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Inconnu"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s ; (identifiant de construction : %s)"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Type de sécurité"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64 bits"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Niveau d’encre"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32 bits"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Niveau d’encre"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Niveau d’encre"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Inconnu"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Sécurité"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo du système"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"écran;verrouiller;verrouillage;diagnostic;diagnostique;plantage;privé;"
+"confidentiel;récent;temporaire;tmp;index;nom;réseaux;identité;"
+"confidentialité;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Nom de l’appareil"
 
@@ -1852,31 +1265,43 @@ msgstr "Calcul en cours…"
 msgid "OS Name"
 msgstr "Nom du système d’exploitation"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s ; (identifiant de construction : %s)"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Type de système d’exploitation"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Version de GNOME"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Déverrouillage…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Système de fenêtrage"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Virtualisation"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Mises à jour logicielles"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Renommer l’appareil"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1884,7 +1309,12 @@ msgstr ""
 "Le nom de l’appareil est utilisé pour l’identifier lorsqu’il est visible sur "
 "le réseau, ou en attente d’appairage avec des périphériques Bluetooth."
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Nom de l’appareil"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "_Renommer"
 
@@ -1896,11 +1326,6 @@ msgstr "À propos"
 msgid "View information about your system"
 msgstr "Afficher les informations sur le système"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1979,6 +1404,12 @@ msgstr "Lanceurs"
 msgid "Launch help browser"
 msgstr "Démarrer le navigateur d’aide"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Paramètres"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Démarrer la calculatrice"
@@ -2000,7 +1431,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Rechercher"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Système"
 
@@ -2049,20 +1480,11 @@ msgstr "Réduire la taille du texte"
 msgid "High contrast on or off"
 msgstr "Activer ou désactiver le contraste élevé"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Aucune source de saisie trouvée"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Autre"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Ajouter une source de saisie"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr ""
 "Les méthodes de saisie ne peuvent pas être utilisées sur l’écran de connexion"
@@ -2071,123 +1493,30 @@ msgstr ""
 msgid "No input source selected"
 msgstr "Aucune source de saisie sélectionnée"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "Options…"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "Remonter"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "Descendre"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Préférences"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Afficher l’agencement du clavier"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Supprimer"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Raccourcis personnalisés"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "Touche de caractères alternatifs"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"La touche des caractères alternatifs peut être utilisée pour saisir des "
-"caractères supplémentaires. Ceux-ci sont parfois affichés en tant que "
-"troisième option sur votre clavier."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt gauche"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt droit"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Super gauche"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Super droit"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Touche menu"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl droit"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Touche de composition"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"La touche de composition permet de saisir une grande variété de caractères. "
-"Pour l’utiliser, maintenez-la enfoncée et appuyez sur <b>C</b> et <b>o</b> "
-"pour saisir <b>©</b>, ou <b>a</b> et <b>’</b> pour saisir <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Verr. Maj."
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Arrêt défil."
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Impr. écran"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Vous pouvez basculer d’une source de saise à une autre à l’aide du "
-"raccourcis clavier %s. Pour modifier ces raccourcis clavier, allez dans les "
-"préférences clavier"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2209,56 +1538,31 @@ msgstr "Utiliser la _même source pour toutes les fenêtres"
 msgid "Switch input sources _individually for each window"
 msgstr "Basculer les sources de saisie _individuellement pour chaque fenêtre"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Saisie de caractères spéciaux"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Méthodes pour la saisie de symboles et de variantes de lettres à l’aide du "
 "clavier."
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Touche de caractères alternatifs"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Touche de composition"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Voir et personnaliser les raccourcis"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modifié"
-msgstr[1] "%d modifiés"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
-msgid "Reset All Shortcuts?"
-msgstr "Réinitialiser tous les raccourcis ?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Réinitialiser tous les raccourcis peut aussi affecter vos raccourcis "
-"personnalisés. Cette action est irréversible."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Annuler"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
-msgid "Reset All"
-msgstr "Tout réinitialiser"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2268,97 +1572,93 @@ msgstr "Tout réinitialiser…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Réinitialiser tous les raccourcis à leurs combinaisons par défaut"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "_Action :"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Raccourci"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Ajouter un raccourci"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Ajouter des raccourcis personnalisés"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "Définissez des raccourcis personnalisés pour lancer des applications, "
 "exécuter des scripts, etc."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Ajouter un raccourci"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Aucun raccourci clavier trouvé"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s est déjà utilisé pour %s. Si vous le remplacez, %s sera désactivé"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "Supprimer"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Saisir le nouveau raccourci"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Définir un raccourci personnalisé"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Définir un raccourci"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Saisissez un nouveau raccourci pour changer %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Ajouter un raccourci personnalisé"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Ajouter"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
 msgstr "Remplacer"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "Définir"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "_Définir"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Appuyer sur Échap pour annuler ou sur Retour arrière pour désactiver le "
 "raccourci clavier."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Nom"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Commande"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Raccourci"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Définir un raccourci…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Aucun"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Réinitialiser le raccourci à sa valeur par défaut"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Utiliser la caméra"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2372,7 +1672,6 @@ msgstr ""
 "Modifier les raccourcis clavier et définir vos préférences de saisie, "
 "dispositions de clavier et sources de saisie"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2380,17 +1679,17 @@ msgstr ""
 "Raccourci;Espace de travail;Fenêtre;Redimensionner;Zoom;Contraste;Saisie;"
 "Source;Verrouiller;Volume;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "Les services de localisation sont désactivés"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr ""
 "Aucune application ne peut obtenir les informations liées à votre "
 "emplacement."
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2409,7 +1708,7 @@ msgstr ""
 "\n"
 "Autoriser les applications ci-dessous à accéder à votre emplacement."
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Aucune application n’a demandé l’accès à votre emplacement"
 
@@ -2417,179 +1716,19 @@ msgstr "Aucune application n’a demandé l’accès à votre emplacement"
 msgid "Protect your location information"
 msgstr "Protéger les informations liées à votre emplacement"
 
-#. FIXME
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Extinction de l’écran"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 secondes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minute"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 heure"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minute"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Jamais"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"Verrouiller automatiquement l’écran empêche quiconque d’accéder à votre "
-"ordinateur lorsque vous vous absentez."
 
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "Délai de l’écran noir"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Période d’inactivité après laquelle l’écran s’éteint."
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "_Verrouillage automatique de l’écran"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "_Délai du verrouillage automatique de l’écran"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-"Période après laquelle l’écran devient noir lorsque l’écran est "
-"automatiquement verrouillé."
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "Afficher les _notifications sur l’écran verrouillé"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "Interdire les nouveaux périphériques _USB"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Empêche les nouveaux périphériques USB d’interagir avec le système tant que "
-"l’écran est verrouillé"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Verrouillage de l’écran"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Verrouiller votre écran"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "Microphone désactivé"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Aucune application ne peut enregistrer du son."
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2603,7 +1742,7 @@ msgstr ""
 "\n"
 "Autoriser les applications ci-dessous à utiliser votre microphone."
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Aucune application n’a demandé l’accès au micro"
 
@@ -2611,7 +1750,10 @@ msgstr "Aucune application n’a demandé l’accès au micro"
 msgid "Protect your conversations"
 msgstr "Protégez vos conversations"
 
-#. FIXME
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Tester vos p_aramètres"
@@ -2630,83 +1772,147 @@ msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr ""
 "Définit l’ordre des boutons physiques sur les souris et pavés tactiles."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Gauche"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Droite"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Emplacements de la recherche"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Souris"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Vitesse de la souris"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "Défilement naturel"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Le défilement déplace le contenu, pas la vue."
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Le défilement déplace le contenu, pas la vue."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Actif"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Pavé tactile"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Vitesse du pavé tactile"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Taper pour cliquer"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "Défilement à deux doigts"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Taper pour cliquer"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Pavé tactile (relatif)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Défilement aux bords"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Arrêt défil."
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Recto-verso"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Essayez de cliquer, double-cliquer, faire défiler"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinq clics, l’époque GEGL !"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Double-clic, bouton principal"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Simple clic, bouton principal"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Double-clic, bouton du milieu"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Simple clic, bouton du milieu"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Double-clic, bouton secondaire"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Simple clic, bouton secondaire"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2718,7 +1924,6 @@ msgid ""
 msgstr ""
 "Modifier la sensibilité du pavé tactile et choisir entre droitier ou gaucher"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Pavé;Tactile;Pointeur;Clic;Frappe;Double;Bouton;Boule;Défilement;"
@@ -2799,86 +2004,39 @@ msgstr "Multi-tâches"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Gérer les préférences de productivité et du multi-tâches"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+#, fuzzy
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr "Multi-tâches;productivité;personnalisation;bureau;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Oups, quelque chose s’est mal passé. Veuillez contacter le fournisseur de "
-"votre logiciel."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager doit être en fonctionnement."
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Autres périphériques"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Ajouter une nouvelle connexion"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Non configuré"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID : %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "Réseau non sécurisé (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "Réseau sécurisé (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "Réseau sécurisé (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "Réseau sécurisé (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "Réseau sécurisé"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Connecté"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Options…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"L’activation du point d’accès entraînera une déconnexion de %s, et il ne "
-"sera pas possible d’accéder à Internet par Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Doit comporter au minimum 8 caractères"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -2907,355 +2065,90 @@ msgid "Network Name"
 msgstr "Nom du réseau"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Mot de passe"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Générer un mot de passe aléatoire"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Générer un mot de passe automatiquement"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "A_llumer"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Interrompre le point d’accès et déconnecter tous les utilisateurs ?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "_Interrompre le point d’accès"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Mode avion"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr ""
 "Désactive le Wi-Fi, le Bluetooth et les connexions mobiles à large bande"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Aucun adaptateur Wi-Fi trouvé"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Assurez-vous d’avoir un adaptateur Wi-Fi branché et opérationnel"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Mode avion activé"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Désactiver pour utiliser le Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Point d’accès Wi-Fi activé"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Les appareils mobiles peuvent scanner le code QR pour se connecter."
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "_Éteindre le point d’accès Wi-Fi…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Réseaux visibles"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager doit être en fonctionnement"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Oups, quelque chose s’est mal passé. Veuillez contacter le fournisseur de "
+"votre logiciel."
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Sécurité 802.1x"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Sécurité"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Conserver"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Aléatoire"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stable"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"L’adresse MAC saisie ici sera utilisée comme adresse matérielle du "
-"périphérique réseau activé pour cette connexion. Cette fonctionnalité est "
-"appelée « MAC cloning » ou « spoofing ». Exemple : 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Entreprise"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Aucune"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Jamais"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "Il y a %i jour"
 msgstr[1] "Il y a %i jours"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2,4 GHz ou 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2,4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Aucun"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Faible"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Correct"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Bon"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excellent"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Adresse IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "Adresse IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Adresse IP"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "Oublier la connexion"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "Supprimer le profil de la connexion"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "Supprimer le VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "Détails"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatique"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identité"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Supprimer l’adresse"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "Supprimer la route"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Aucune"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Clé WEP 40/128 bits (Hex ou ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Phrase de passe WEP 128 bits"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dynamique (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA et WPA2 privées"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA et WPA2 d’entreprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 privée"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3266,8 +2159,20 @@ msgstr "Force du signal"
 msgid "Link speed"
 msgstr "Vitesse de la connexion"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sécurité"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Adresse IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adresse IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Adresse matérielle"
 
@@ -3276,12 +2181,17 @@ msgid "Supported Frequencies"
 msgstr "Fréquences prises en charge"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Route par défaut"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3295,11 +2205,11 @@ msgstr "Connexion _automatique"
 msgid "Make available to _other users"
 msgstr "Rendre accessible aux autres _utilisateurs"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr "Connexion avec _quota : limite les données ou peut engendrer des frais"
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3344,7 +2254,7 @@ msgstr "Réseau local seulement"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manuel"
 
@@ -3364,33 +2274,32 @@ msgid "Addresses"
 msgstr "Adresses"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Adresse"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Masque de réseau"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Passerelle"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automatique"
 
@@ -3399,29 +2308,34 @@ msgstr "Automatique"
 msgid "Automatic DNS"
 msgstr "DNS automatique"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Séparer les adresses IP avec des virgules"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Routes"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Routes automatiques"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Métrique"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "N’utiliser cette connexion que pour les ressources sur ce réseau"
 
@@ -3434,84 +2348,13 @@ msgid "Automatic, DHCP only"
 msgstr "Automatique, DHCP seulement"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Préfixe"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Impossible d’ouvrir l’éditeur de connexions"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Nouveau profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Importer depuis un fichier…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "Ajouter un VPN"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Séc_urité"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Impossible d’importer la connexion VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Le fichier « %s » est illisible ou ne contient pas d’informations de "
-"connexion VPN reconnues\n"
-"\n"
-"Erreur : %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Sélectionner le fichier à importer"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Un fichier nommé « %s » existe déjà."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Remplacer"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-"Voulez-vous remplacer %s avec la connexion VPN en cours d’enregistrement ?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Impossible d’exporter la connexion VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"La connexion VPN « %s » n’a pas pu être exportée vers %s.\n"
-"\n"
-"Erreur : %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Exportation de la connexion VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3525,104 +2368,46 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Réseau"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Contrôler votre façon de vous connecter à Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Réseau;IP;LAN;Mandataire;WAN;Large bande;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Contrôler votre façon de vous connecter aux réseaux sans fil"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Réseau;Sans fil;Wi-Fi;Wifi;IP;LAN;Large bande;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "jamais"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "aujourd’hui"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "hier"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Dernière utilisation"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Filaire"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Ajouter une nouvelle connexion"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Les informations des réseaux sélectionnés, y compris les mots de passe et "
-"toute configuration personnalisée seront perdus."
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "_Oublier"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Réseaux Wi-Fi connus"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Oublier"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Les règles du système interdisent son utilisation comme point d’accès"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr ""
-"Le périphérique sans fil ne prend pas en charge le mode « point d’accès »"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"« Web Proxy Autodiscovery » est utilisé lorsqu’aucune URL de configuration "
-"n’est fournie."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Cela n’est pas recommandé pour des réseaux publics non fiables."
-
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Éteindre le périphérique"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Actif"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3633,47 +2418,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Fournisseur"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adresse IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Serveur mandataire"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "Serveur mandataire _HTTP"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "Serveur mandataire H_TTPS"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "Serveur mandataire _FTP"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Hôte _Socks"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "_Ignorer les hôtes"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Port du serveur mandataire HTTP"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Port du serveur mandataire HTTPS"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Port du serveur mandataire FTP"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Port du serveur mandataire Socks"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "URL de _configuration"
 
@@ -3700,300 +2489,22 @@ msgstr "Mot de passe"
 msgid "Turn Wi-Fi off"
 msgstr "Éteindre le Wi-Fi"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Options…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Connexion à un réseau masqué…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Allumer le point d’accès Wi-Fi…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "Réseaux Wi-Fi _connus"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "État inconnu"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Non géré"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Indisponible"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Connexion en cours"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Authentification requise"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Déconnexion en cours"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Échec de la connexion"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "État inconnu (absent)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Échec de la configuration"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Échec de la configuration IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Configuration IP expirée"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Des éléments secrets, non fournis, étaient nécessaires"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Le client 802.1x s’est déconnecté"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "La configuration du client 802.1x a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Le client 802.1x a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Le client 802.1x a mis trop de temps pour s’authentifier"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Le service PPP n’a pas réussi à démarrer"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Service PPP déconnecté"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Le client DHCP n’a pas réussi à démarrer"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Erreur du client DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Le client DHCP a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Le service de connexion partagée n’a pas réussi à démarrer"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Le service de connexion partagée a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Le service autoIP n’a pas réussi à démarrer"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Erreur du service autoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Le service autoIP a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Ligne occupée"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Pas de tonalité"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Aucune porteuse n’a pu être établie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Délai de numérotation dépassé"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "La tentative de numérotation a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "L’initialisation du modem a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Échec de la sélection de l’APN spécifié"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Aucune recherche de réseau en cours"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Enregistrement au réseau refusé"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Délai dépassé pour l’enregistrement au réseau"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Échec de l’enregistrement au réseau demandé"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "La vérification du code PIN a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Il se peut que le micrologiciel du périphérique manque"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "La connexion a disparu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Une connexion existante a été supposée"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem non trouvé"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "La connexion Bluetooth a échoué"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "La carte SIM n’est pas insérée"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Le code PIN de la SIM est nécessaire"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Le code PUK de la SIM est requis"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Mauvaise SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "La dépendance de la connexion a échoué"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Micrologiciel absent"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Câble débranché"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "erreur de sécurité inconnue dans 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "aucun fichier sélectionné"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "erreur inconnue à la validation du fichier eap-method"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "Clés privées DER, PEM, ou PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Certificats DER ou PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "fichier EAP-FAST PAC manquant"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Fichiers PAC (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4043,14 +2554,6 @@ msgstr "Authentification _interne"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Autoriser l’_obtention automatique de PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "nom d’utilisateur d’EAP-LEAP manquant"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "mot de passe d’EAP-LEAP manquant"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4063,7 +2566,7 @@ msgstr "Nom d’_utilisateur"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "Mot de _passe"
 
@@ -4075,15 +2578,6 @@ msgstr "Mot de _passe"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Affi_cher le mot de passe"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "certificat CA d’EAP-PEAP non valide : %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "certificat CA d’EAP-PEAP non valide : aucun certificat spécifié"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4106,7 +2600,6 @@ msgid "C_A certificate"
 msgstr "Certificat C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4121,63 +2614,6 @@ msgstr "Aucun certificat CA _requis"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Version PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "nom d’utilisateur EAP manquant"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "mot de passe EAP manquant"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "identité EAP-TLS manquante"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "certificat CA EAP-TLS non valide : %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TLS non valide : aucun certificat spécifié"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "clé privée EAP-TLS non valide : %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificat utilisateur EAP-TLS non valide : %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Les clés privées non chiffrées ne sont pas fiables"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"La clé privée sélectionnée ne semble pas être protégée par un mot de passe. "
-"Cela met en danger vos identifiants. Veuillez sélectionner une clé privée "
-"protégée par mot de passe.\n"
-"\n"
-"(Vous pouvez protéger votre clé par mot de passe avec openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Choisissez votre certificat personnel"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Choisissez votre clé privée"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4194,15 +2630,6 @@ msgstr "_Clé privée"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Mot de passe de la _clé privée"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "certificat CA EAP-TTLS non valide : %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TTLS non valide : aucun certificat spécifié"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4225,14 +2652,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domaine"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Erreur inconnue à la validation de la sécurité de 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4260,62 +2688,10 @@ msgstr "EAP sécurisé (PEAP)"
 msgid "Au_thentication"
 msgstr "Au_thentification"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Sélectionner un fichier"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "nom d’utilisateur leap manquant"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "mot de passe leap manquant"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Le mot de passe Wi-Fi est manquant."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Type"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "clé wep manquante"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"clé wep non valide : une clé de %zu ne doit contenir que des caractères "
-"hexadécimaux"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"clé wep non valide : une clé de %zu ne doit contenir que des caractères ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"clé wep non valide : longueur de clé %zu incorrecte. Elle doit être de 5 à "
-"13 caractères en ascii ou de 10 à 26 en hexa"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "clé wep non valide : phrase de passe non renseignée"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"clé wep non valide : la phrase de passe doit contenir moins de 64 caractères"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4340,21 +2716,6 @@ msgstr "_Afficher la clé"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Inde_x WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk non valide : longueur de clé %zu incorrecte. Doit être de [8,63] "
-"octets ou 64 caractères hexadécimaux"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk non valide : impossible de considérer une clé de 64 octets comme "
-"hexadécimale"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4409,58 +2770,34 @@ msgstr "Notifications sur l’écran de _verrouillage"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Contrôler quelles notifications s’affichent et leur contenu"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifications;Messages surgissants;Bannières;Message;Tiroir;Popup;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "%s supprimé"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Autre"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Erreur lors de la suppression du compte"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Annuler"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Afficher les notifications système."
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "Connexion à vos données du nuage"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "Aucune connexion internet — connectez-vous pour configurer de nouveaux "
 "comptes en ligne"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Ajouter un compte"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:426
-#, c-format
-msgid "%s Account"
-msgstr "Compte %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:429
-msgid "Remove Account"
-msgstr "Supprimer le compte"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4470,10 +2807,6 @@ msgstr "Comptes en ligne"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Connectez-vous à vos comptes en ligne et décidez de leur utilité"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4481,10 +2814,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;En ligne;Discussion;Agenda;Courriel;Email;"
 "Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Durée inconnue"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4500,13 +2829,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i heure"
 msgstr[1] "%i heures"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4518,190 +2840,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minute"
 msgstr[1] "minutes"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s avant chargement complet"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Attention : il reste %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s restant"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Batterie pleine"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Pas en charge"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Déchargée"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "En charge"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "En décharge"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Souris sans fil"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Clavier sans fil"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Onduleur"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Assistant personnel"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Téléphone portable"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Lecteur multimédia"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablette"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Ordinateur"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Périphérique d’entrée pour jeux"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batterie"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principale"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Secondaire"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batteries"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "Quand _inactif"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "Mettre en veille"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "Éteindre"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "Hiberner"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "Rien"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "Quand sur batterie"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "Quand le câble est branché"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Jamais"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "Mise en veille automatique"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Le mode performance est temporairement désactivé en raison de la température."
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Il semble que l’ordinateur soit posé sur vos genoux, le mode performance est "
-"temporairement indisponible. Posez l’appareil sur une surface stable pour le "
-"rétablir."
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr "Mode performance temporairement indisponible"
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Batterie faible : mode économie d’énergie activé. Le mode précédent sera "
-"rétabli quand le niveau de batterie sera suffisant."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Mode économie d’énergie activé par « %s »."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Mode performance activé par « %s »."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4763,6 +2901,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 heures"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batterie"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Périphériques"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Mode d’énergie"
@@ -4783,90 +2930,63 @@ msgstr "Luminosité de l’écran automatique"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "La luminosité de l’écran s’adapte à la luminosité ambiante."
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Écran assombri"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "Réduit la luminosité de l’écran quand l’ordinateur est inactif."
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "Écran _noir"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "Éteint l’écran après une période d’inactivité."
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Économie d’énergie automatique"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr ""
 "Activer le mode économie d’énergie quand le niveau de batterie est faible."
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "Mise en veille _automatique"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "Met l’ordinateur en pause après une période d’inactivité."
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Action du bouton d’e_xtinction"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Afficher le _pourcentage de batterie"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Mise en veille automatique"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_Câble branché"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Sur _batterie"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Délai"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Performance"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Performances élevées et forte consommation d’énergie."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Équilibré"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Performances et consommation d’énergie normales."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Économie d’énergie"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Performances et consommation d’énergie réduites."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4878,7 +2998,6 @@ msgstr ""
 "S’informer sur l’état de la batterie et modifier les paramètres d’économie "
 "d’énergie"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4886,27 +3005,6 @@ msgid ""
 msgstr ""
 "Énergie;Alimentation;Veille;Suspension;Hibernation;Batterie;Luminosité;"
 "Assombrir;Noir;Écran;DPMS;Inactif;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "L’imprimante « %s » a été supprimée"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "L’ajout de la nouvelle imprimante a échoué."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Impossible de charger l’interface utilisateur : %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Déverrouiller pour ajouter des imprimantes et modifier les paramètres"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4918,7 +3016,6 @@ msgstr ""
 "Ajouter des imprimantes, afficher les tâches et décider quand vous voulez "
 "imprimer"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Imprimante;File;Queue;Impression;Papier;Encre;Toner;"
@@ -4926,94 +3023,71 @@ msgstr "Imprimante;File;Queue;Impression;Papier;Encre;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Ajouter une imprimante"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Déverrouiller"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Aucune imprimante trouvée"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Saisissez l’adresse d’un réseau ou recherchez une imprimante"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Authentification requise"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Saisissez votre nom d’utilisateur et votre mot de passe pour afficher les "
 "imprimantes sur le serveur."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Nom d’utilisateur"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "Informations sur %s"
-
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Aucun pilote adéquat trouvé"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "Sélectionnez un fichier PPD"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"Fichiers de description PostScript de l’imprimante (*.ppd, *.PPD, *.ppd.gz, "
-"*.PPD.gz, *.PPD.GZ)"
 
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Emplacement"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Pilote"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Recherche des pilotes préférés…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Rechercher des pilotes"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Sélectionner à partir de la base de données…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Installer le fichier PPD…"
 
@@ -5025,133 +3099,20 @@ msgstr "Sélectionner un pilote d’imprimante"
 msgid "Loading drivers database…"
 msgstr "Chargement de la base de données des pilotes…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Annuler"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Sélectionner"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Imprimante JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Imprimante LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Recto"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Bord long (standard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Bord court (retourné)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Portrait"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Paysage"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Paysage inversé"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Portrait inversé"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "En attente"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "En pause"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Authentification requise"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "Traitement en cours"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Arrêtée"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Interrompue"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Annulée"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Terminée"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "Déplacer cette tâche en haut de la file d’attente"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u tâche nécessite une authentification"
 msgstr[1] "%u tâches nécessitent une authentification"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - tâches d’impression actives"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr ""
-"Saisissez vos informations d’authentification pour imprimer à partir de %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5160,342 +3121,36 @@ msgid "Domain"
 msgstr "Domaine"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "A_uthentification"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Tout effacer"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Authentification"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Aucune tâche d’impression active"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Déverrouiller le serveur d’imprimantes"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Déverrouiller %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Saisissez votre nom d’utilisateur et votre mot de passe pour afficher les "
-"imprimantes sur %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Recherche d’imprimantes"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Port série"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Port parallèle"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Emplacement : %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adresse : %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Le serveur nécessite une authentification"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Recto verso"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Type de papier"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Source du papier"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Bac de sortie"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Résolution"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Pré-filtrage GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Pages par côté"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Recto-verso"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientation"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Général"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Mise en page"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Options installables"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Tâche"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Qualité de l’image"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Couleur"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Finition"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avancé"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Page de test"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Page de test"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Sélection automatique"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Option par défaut de l’imprimante"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Incorporer seulement les polices GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Convertir en PS de niveau 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Convertir en PS de niveau 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Aucun pré-filtrage"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Fabricant"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Aucune tâche d’impression active"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u tâche"
 msgstr[1] "%u tâches"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Nettoyage des têtes d’impression"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Toner pratiquement épuisé"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Plus de toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Révélateur pratiquement épuisé"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Plus de révélateur"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Cartouche de couleur pratiquement vide"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Cartouche de couleur vide"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Couvercle ouvert"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Porte ouverte"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Pratiquement plus de papier"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Plus de papier"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Hors ligne"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Arrêtée"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Récipient à déchets pratiquement plein"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Récipient à déchets plein"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Le photo-conducteur optique est pratiquement en fin de vie"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Le photo-conducteur optique n’est plus en état"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Prête"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "N’accepte plus de tâche supplémentaire"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Traitement en cours"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5519,41 +3174,45 @@ msgstr "Nettoyer les têtes d’impression"
 msgid "Remove Printer"
 msgstr "Supprimer l’imprimante"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Aucune tâche d’impression active"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Modèle"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Niveau d’encre"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Veuillez redémarrer après résolution du problème."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Redémarrer"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Ajouter une imprimante…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Ajouter une imprimante…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Aucune imprimante"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Ajouter une imprimante…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5561,50 +3220,33 @@ msgstr ""
 "Désolé ! Le service d’impression du système\n"
 "    ne semble pas être disponible."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formats"
-
-#: panels/region/cc-format-chooser.ui:37
-#: panels/wacom/cc-wacom-stylus-page.ui:136
-#: panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "Précédent"
 
 #: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr "Rechercher des locales…"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Formats courants"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Tous les formats"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Aucun résultat pour la recherche"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Les recherches peuvent porter sur des pays ou des langues."
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Aperçu"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Impérial"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Métrique"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5636,27 +3278,32 @@ msgid "Logout…"
 msgstr "Déconnexion…"
 
 #: panels/region/cc-region-panel.ui:45
+#, fuzzy
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
 "Le paramètre de langue est utilisé pour les interfaces textuelles et les "
 "pages web. Le format est utilisé pour les nombres, dates et monnaies."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Votre compte"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Langue"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formats"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Écran de connexion"
 
@@ -5668,100 +3315,9 @@ msgstr "Pays et langue"
 msgid "Select your display language and formats"
 msgstr "Sélectionnez la langue et les formats d’affichage"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Langue;Disposition;Agencement;Clavier;Saisie;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Demander que faire"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Ne rien faire"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Ouvrir le dossier"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Autres médias"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Sélectionnez une application pour vos CD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Sélectionnez une application pour vos DVD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Sélectionnez une application à lancer lorsqu’un baladeur est connecté"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-"Sélectionnez une application à lancer lorsqu’un appareil photo est connecté"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Sélectionnez une application pour les CD contenant des logiciels"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "disque Blu-ray vierge"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "disque CD vierge"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "disque DVD vierge"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "disque HD DVD vierge"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "disque vidéo Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "lecteur e-book"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "disque vidéo HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Vidéo CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "CD vidéo"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Logiciels Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5811,7 +3367,6 @@ msgstr "Médias amovibles"
 msgid "Configure Removable Media settings"
 msgstr "Configurer les paramètres des médias amovibles"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5820,13 +3375,82 @@ msgstr ""
 "périphérique;système;par défaut;application;préférée;cd;dvd;usb;audio;vidéo;"
 "disque;amovible;média;exécution automatique;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Sélectionner un emplacement"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Verrouillage de l’écran"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Valider"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Verrouiller automatiquement l’écran empêche quiconque d’accéder à votre "
+"ordinateur lorsque vous vous absentez."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Délai de l’écran noir"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Période d’inactivité après laquelle l’écran s’éteint."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Verrouillage automatique de l’écran"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Délai du verrouillage automatique de l’écran"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Période après laquelle l’écran devient noir lorsque l’écran est "
+"automatiquement verrouillé."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Afficher les _notifications sur l’écran verrouillé"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Notifications sur l’écran de _verrouillage"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Interdire les nouveaux périphériques _USB"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Empêche les nouveaux périphériques USB d’interagir avec le système tant que "
+"l’écran est verrouillé"
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Confidentialité"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Écran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Partage d’écran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5845,21 +3469,17 @@ msgstr ""
 msgid "Places"
 msgstr "Emplacements"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Signets"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "Autres"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Ajouter un emplacement"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Aucune application trouvée"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5888,65 +3508,13 @@ msgstr ""
 "Contrôler quelles applications affichent les résultats d’une recherche dans "
 "la vue d’ensemble des activités"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Rechercher;Recherche;Index;Masquer;Confidentialité;Privé;Résultats;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "Aucun réseau de partage n’est sélectionné"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Réseaux"
-
-#: panels/sharing/cc-sharing-panel.c:367
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Activé"
-
-#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Désactivé"
-
-#: panels/sharing/cc-sharing-panel.c:399
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Activé"
-
-#: panels/sharing/cc-sharing-panel.c:402
-msgctxt "service is active"
-msgid "Active"
-msgstr "Actif"
-
-#: panels/sharing/cc-sharing-panel.c:520
-msgid "Choose a Folder"
-msgstr "Choisir un dossier"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:748
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Le partage de fichiers vous permet de partager votre dossier Public avec les "
-"autres sur le réseau actuel en utilisant : %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:754
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Lorsque la connexion à distance est activée, tout utilisateur distant peut "
-"se connecter à l’aide de cette commande shell sécurisée :\n"
-"%s"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -5986,12 +3554,12 @@ msgstr "Demander le mot de _passe"
 msgid "Remote Login"
 msgstr "Connexion distante"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "Bureau distant"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
@@ -5999,73 +3567,81 @@ msgstr ""
 "Le bureau distant permet d’afficher et de contrôler votre bureau depuis un "
 "autre ordinateur."
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr ""
 "Activer ou désactiver les connexions de bureau distantes à cet ordinateur."
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "Contrôle à distance"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
 msgstr "Autorise les connexions distantes à contrôler l’écran."
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
 msgstr "Connexion"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
 "Se connecter à cet ordinateur en utilisant le nom de l’appareil ou l’adresse "
 "du bureau distant."
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copier"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "Adresse du bureau distant"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "Authentification"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr ""
 "Le nom d’utilisateur et le mot de passe sont nécessaires pour se connecter à "
 "cet ordinateur."
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "Nom d’utilisateur"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "Vérifier le chiffrement"
 
-#: panels/sharing/cc-sharing-panel.ui:430
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr "Empreinte cryptographique"
 
-#: panels/sharing/cc-sharing-panel.ui:431
+#: panels/sharing/cc-sharing-panel.ui:435
+#, fuzzy
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
 "L’empreinte cryptographique peut être vue par les clients qui se connectent "
 "et doit être identique"
 
-#: panels/sharing/cc-sharing-panel.ui:463
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Partage de médias"
 
-#: panels/sharing/cc-sharing-panel.ui:485
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Partager de la musique, des photos et des vidéos sur le réseau."
 
-#: panels/sharing/cc-sharing-panel.ui:498
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Dossiers"
 
@@ -6073,7 +3649,6 @@ msgstr "Dossiers"
 msgid "Control what you want to share with others"
 msgstr "Contrôler ce que vous souhaitez partager avec les autres"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6091,38 +3666,38 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Authentification requise pour activer ou désactiver une connexion distante"
 
-#: panels/sound/cc-alert-chooser.c:150
-msgid "Custom"
-msgstr "Personnalisée"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Aboiement"
+msgid "Click"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "Goutte d’eau"
+#, fuzzy
+msgid "String"
+msgstr "Partage"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "Verre"
+msgid "Swing"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "Sonar"
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balance"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Fondu"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Arrière"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Avant"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Test de %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6132,58 +3707,54 @@ msgstr "Cliquez sur un haut-parleur à tester"
 msgid "System Volume"
 msgstr "Volume système"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Volume système"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Niveaux de volume"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Sortie"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Périphérique de sortie"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Test"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Configuration"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "Balance"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "Fondu"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Caisson de basse"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Entrée"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Périphérique d’entrée"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Volume"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Son d’alerte"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100 %"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6194,82 +3765,11 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Modifier les volumes sonores, les saisies, les sorties et les alertes sonores"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Carte;Microphone;Volume;Fondu;Balance;Bluetooth;Casque;Audio;Entrée;Sortie;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Déconnecté"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Connexion en cours"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Connecté"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Erreur d’autorisation"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autorisation en cours"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Fonctionnalité réduite"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Connecté et autorisé"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Inconnu"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autorisé depuis :"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Connecté depuis :"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Inscrit depuis :"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Échec de l’autorisation du périphérique : "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Échec de l’oubli du périphérique : "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6278,94 +3778,55 @@ msgid_plural "Depends on %u other devices"
 msgstr[0] "Dépend de %u autre périphérique"
 msgstr[1] "Dépend de %u autres périphériques"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Afficher les notifications système."
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Nom :"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "État :"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID :"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Autorisation et connexion"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Oublier le périphérique"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Erreur"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Aucune prise en charge de Thunderbolt"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorisé"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Impossible de se connecter au sous-système thunderbolt."
 
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Le sous-système Thunderbolt (boltd) n’est pas installé ou est mal configuré."
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Accès direct"
 
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 "Autoriser l’accès direct aux périphériques tels que les stations d’accueil "
 "et processeurs graphiques externes."
 
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Seuls les périphériques USB et Display Port peuvent être connectés."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt n’a pas pu être détecté.\n"
-"Soit le système ne prend pas en charge Thunderbolt, soit il a été désactivé "
-"dans le BIOS, soit il est paramétré sur un niveau de sécurité non pris en "
-"charge dans le BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "La prise en charge de Thunderbolt a été désactivée dans le BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Le niveau de sécurité Thunderbolt n’a pas pu être déterminé."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Erreur de bascule en mode direct : %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
-msgid "No Thunderbolt Support"
-msgstr "Aucune prise en charge de Thunderbolt"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:104
-msgid "Could not connect to the thunderbolt subsystem."
-msgstr "Impossible de se connecter au sous-système thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.ui:153
-msgid "Direct Access"
-msgstr "Accès direct"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Périphériques en attente"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Aucun périphérique connecté"
 
@@ -6377,7 +3838,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Gérer les périphériques Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;vie privée;confidentialité;"
@@ -6386,16 +3846,16 @@ msgstr "Thunderbolt;vie privée;confidentialité;"
 msgid "Cursor Blinking"
 msgstr "Clignotement du curseur"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Le curseur clignote dans les champs texte."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Vitesse"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Vitesse de clignotement du curseur"
 
@@ -6482,15 +3942,15 @@ msgstr "Grand"
 msgid "Repeat Keys"
 msgstr "Touches de répétition"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Répétition lorsqu’une touche est maintenue enfoncée."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Délai de répétition des touches"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Vitesse de répétition des touches"
 
@@ -6573,48 +4033,14 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Long"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "_Activer au clavier"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr ""
 "Activer et désactiver les fonctionnalités d’accessibilité à partir du clavier"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Par défaut"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Moyen"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Grand"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Plus grand"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Le plus grand"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixels"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6731,31 +4157,6 @@ msgstr "Faire clignoter tout l’é_cran"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Faire clignoter toute la _fenêtre"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Courte"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ d’écran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ écran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ d’écran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Longue"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6912,7 +4313,6 @@ msgstr "Effets de couleur"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Faciliter la vision, l’écoute, la saisie, la sélection et le clic"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -6924,114 +4324,6 @@ msgstr ""
 "grand;haut;élevé;texte;police;taille;AccessX;Rémanentes;Touches;Lentes;"
 "Rebonds;Souris;Double;clic;Délai;Vitesse;Assistance;Répétition;Clignotement;"
 "visuel;écoute;audio;frappe;animations;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 heure"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 jour"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 jours"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 jours"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 jours"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 jours"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 jours"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 jours"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 jours"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 jours"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Vider complètement la corbeille ?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Tout le contenu de la corbeille sera définitivement supprimé."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Vider la corbeille"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Supprimer tous les fichiers temporaires ?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Tous les fichiers temporaires seront définitivement supprimés."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Purger les fichiers temporaires"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 jour"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 jours"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 jours"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Toujours"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7100,57 +4392,10 @@ msgstr "Historique des fichiers et corbeille"
 msgid "Don't leave traces"
 msgstr "Ne laisser aucune trace"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Doit correspondre à l’adresse web de votre fournisseur d’accès."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "L’ajout du compte a échoué"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr "Les mots de passe ne concordent pas."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "L’enregistrement du compte a échoué"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Impossible de s’authentifier auprès de ce domaine"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Impossible de joindre ce domaine"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Cet identifiant de connexion ne fonctionne pas.\n"
-"Veuillez réessayer."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Ce mot de passe de connexion ne fonctionne pas.\n"
-"Veuillez réessayer."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "La connexion à ce domaine a échoué"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Impossible de trouver ce domaine. Vérifiez son orthographe."
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7187,16 +4432,17 @@ msgid "Enterprise Login"
 msgstr "Compte d’entreprise"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+#, fuzzy
+msgid "User accounts which are managed by a company or organization."
 msgstr ""
 "Les comptes des utilisateurs sont gérés par une entreprise ou une "
 "organisation."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "Vous êtes hors ligne"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7205,10 +4451,6 @@ msgstr ""
 "Un compte d’entreprise autorise l’usage d’un compte utilisateur centralisé à "
 "partir de ce périphérique. Il permet aussi d’accéder aux différents sites de "
 "la compagnie présents sur Internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Rechercher d’autres images"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7222,15 +4464,15 @@ msgstr "Gestionnaire d’empreintes digitales"
 msgid "Fingerprint"
 msgstr "Empreinte digitale"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_Non"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Oui"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7238,32 +4480,32 @@ msgstr ""
 "Souhaitez-vous supprimer les empreintes digitales enregistrées et désactiver "
 "ainsi ce type de connexion ?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Pas de lecteur d’empreintes"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "Pas de lecteur d’empreintes"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "Assurez-vous que le périphérique est branché correctement"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Lecteur d’empreintes"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "Sélectionner le lecteur d’empreintes que vous souhaitez configurer"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "Connexion par reconnaissance d’empreintes"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7271,441 +4513,107 @@ msgstr ""
 "La connexion par reconnaissance d’empreintes vous permet de déverrouiller et "
 "vous connecter à votre ordinateur avec un doigt"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "_Supprimer les empreintes"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Apprentissage d’une empreinte"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "l’appareil doit être sollicité pour effectuer cette action"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Piste précédente"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "l’appareil est déjà sollicité par un autre processus"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "vous ne disposez pas des permissions pour effectuer cette action"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "aucune empreinte enregistrée"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Échec de communication avec l’appareil lors de l’apprentissage"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Échec de communication avec le lecteur d’empreintes"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Échec de communication avec le démon d’empreintes"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Échec de chargement de la liste des empreintes : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Échec de suppression des empreintes enregistrées : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Pouce gauche"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Majeur gauche"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Index _gauche"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Annulaire gauche"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Auriculaire gauche"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Pouce droit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Majeur droit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Index _droit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Annulaire droit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Auriculaire droit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Doigt inconnu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Terminé"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Lecteur d’empreintes déconnecté"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "L’espace de stockage du lecteur d’empreintes est saturé"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "L’apprentissage de la nouvelle empreinte a échoué"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "L’apprentissage n’a pas pu démarrer : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "L’apprentissage de la nouvelle empreinte a échoué"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "L’arrêt de l’apprentissage de l’empreinte a échoué : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Positionnez et glissez votre doigt sur le lecteur d’empreintes plusieurs "
-"fois pour l’apprentissage de votre empreinte"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Recommencer l’apprentissage pour ce doigt"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Enregistrer une nouvelle empreinte"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Impossible de libérer le lecteur d’empreintes %s : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problème lors de la lecture de l’appareil"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr ""
-"Échec lors de la tentative de récupération du lecteur d’empreintes %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Échec lors de la récupération du lecteur d’empreintes : %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Cette semaine"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "La semaine dernière"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Fin de session"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Début de session"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "Activité du compte de %s"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Veuillez choisir un autre mot de passe."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Veuillez saisir à nouveau votre mot de passe actuel."
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Le mot de passe ne peut pas être modifié"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "_Suivant"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Modifier le mot de passe"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "_Modifier"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "Mot de passe actuel"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "Nouveau mot de passe"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "Confirmer le mot de passe"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Les mots de passe ne concordent pas."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
 "Autoriser l’utilisateur à changer son mot de passe à la prochaine connexion"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Définir un mot de passe maintenant"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Impossible de rejoindre ce type de domaine automatiquement"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Aucun domaine trouvé"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Impossible de se connecter en tant que %s au domaine %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Mot de passe non valide, essayez à nouveau"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Connexion au domaine %s impossible : %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "La suppression de l’utilisateur a échoué"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "La révocation de l’utilisateur géré à distance a échoué"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "Vous ne pouvez pas supprimer votre propre compte."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s est encore connecté"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Supprimer un utilisateur alors qu’il est connecté peut laisser le système "
-"dans un état instable."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Voulez-vous conserver les fichiers de %s ?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Il est possible de conserver le répertoire personnel, les courriers "
-"électroniques en attente (le « spool ») et les fichiers temporaires d’un "
-"compte utilisateur lors de sa suppression."
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "_Supprimer les fichiers"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "_Conserver les fichiers"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Voulez-vous vraiment révoquer le compte distant de %s ?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "_Supprimer"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Compte désactivé"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "À définir lors de la prochaine connexion"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Aucun"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Connecté"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "Activé"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "La connexion au service des comptes a échoué"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Veuillez vérifier que AccountService est installé et activé."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "Ce panneau doit être déverrouillé pour modifier ce paramètre"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "Supprimer le compte utilisateur sélectionné"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Pour supprimer le compte utilisateur sélectionné,\n"
-"cliquez d’abord sur l’icône *"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Déverrouiller pour ajouter des utilisateurs et modifier les paramètres"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 "Vous devez redémarrer la session pour que les changements soient pris en "
 "compte"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Redémarrer maintenant"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Fermer"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Nom complet"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Connexion par _reconnaissance d’empreintes"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "Connexion a_utomatique"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "Activité du compte"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Administrateur"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7713,32 +4621,32 @@ msgstr ""
 "Les administrateurs peuvent ajouter ou supprimer d’autres utilisateurs et "
 "peuvent modifier les paramètres de tous les utilisateurs."
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "Contrôle _parental"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Ouvre l’application des contrôles parentaux."
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Supprimer l’utilisateur…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "Autres utilisateurs"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "Ajouter un utilisateur…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Aucun utilisateur trouvé"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Déverrouillez pour créer un compte utilisateur."
 
@@ -7746,7 +4654,6 @@ msgstr "Déverrouillez pour créer un compte utilisateur."
 msgid "Add or remove users and change your password"
 msgstr "Ajouter ou supprimer des utilisateurs et modifier votre mot de passe"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7791,187 +4698,8 @@ msgstr "Gérer les comptes utilisateur"
 msgid "Authentication is required to change user data"
 msgstr "Authentification requise pour modifier les données utilisateur"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Le nouveau mot de passe doit être différent de l’ancien."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Essayez de changer quelques lettres et chiffres."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Essayez de modifier un peu plus le mot de passe."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr ""
-"Un mot de passe ne contenant pas votre nom d’utilisateur serait plus fort."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Essayez de ne pas incorporer votre patronyme dans le mot de passe."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Essayez d’éviter certains mots contenus dans le mot de passe."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Essayez d’éviter des mots usuels."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Essayez d’éviter de réarranger les mots existants."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Essayez d’utiliser plus de chiffres."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Essayez d’utiliser davantage de lettres majuscules."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Essayez d’utiliser davantage de lettres minuscules."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-"Essayez d’utiliser plus de caractères spéciaux, comme les ponctuations."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-"Essayez d’utiliser un mélange de lettres, de chiffres et de ponctuations."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Essayez d’éviter la répétition du même caractère."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Essayez d’éviter la répétition du même caractère : vous devez mélanger des "
-"lettres, des chiffres et des ponctuations."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Essayez d’éviter des séquences telles que 1234 ou abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Le mot de passe doit être plus long. Essayez d’ajouter des lettres, des "
-"chiffres et des ponctuations."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Mélangez des majuscules, des minuscules et aussi un ou deux nombres."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"L’ajout de lettres, de chiffres et de ponctuations renforcera le mot de "
-"passe."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Échec d’authentification"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "Le nouveau mot de passe est trop court"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "Le nouveau mot de passe est trop simple"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "L’ancien et le nouveau mot de passe sont trop ressemblants"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Le nouveau mot de passe a déjà été utilisé récemment."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-"Le nouveau mot de passe doit contenir des caractères spéciaux ou numériques"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "L’ancien et le nouveau mot de passe sont identiques"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-"Votre mot de passe a été modifié depuis que vous vous êtes authentifié !"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr ""
-"Le nouveau mot de passe ne comporte pas suffisamment de caractères différents"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Erreur inconnue"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Un nom d’utilisateur ne contient en principe que des lettres minuscules ou "
-"majuscules de a à z et l’un de ces caractères : - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Désolé, ce nom d’utilisateur n’est pas disponible. Veuillez en choisir un "
-"autre."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Le nom d’utilisateur est trop long."
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Associer les boutons"
 
@@ -8004,47 +4732,11 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Mauvais clic détecté, redémarrage…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Bouton %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Défini par l’application"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Envoyer les appuis sur les touches"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Inverser l’écran"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Afficher l’aide à l’écran"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "La tablette est montée sur le panneau de l’ordinateur portable"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "La tablette est montée sur un écran externe"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
 msgstr "Tablette externe"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Tous les éc­rans"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8054,32 +4746,32 @@ msgstr "Mode tablette"
 msgid "Use absolute positioning for the pen"
 msgstr "Utiliser le positionnement absolu pour le stylet"
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "Orientation pour gaucher"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 "La tablette et les Express Keys™ sont positionnées pour une utilisation de "
 "la main gauche"
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Associer à l’écran"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "Conserver le rapport d’affichage"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 "Utiliser seulement une partie de la surface de la tablette pour conserver le "
 "rapport d’affichage de l’écran"
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "Étalonner"
 
@@ -8095,9 +4787,19 @@ msgstr "Veuillez connecter ou allumer votre tablette Wacom."
 msgid "Tip Pressure Feel"
 msgstr "Pression ressentie sur la pointe"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Douce"
+
 #: panels/wacom/cc-wacom-stylus-page.ui:35
 msgid "Stylus tip pressure"
 msgstr "Pression sur la pointe du stylet"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Ferme"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:54
 msgctxt "display setting"
@@ -8118,21 +4820,9 @@ msgstr "Bouton 3"
 msgid "Eraser Pressure Feel"
 msgstr "Pression ressentie sur la gomme"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:82
-msgid "Soft"
-msgstr "Douce"
-
 #: panels/wacom/cc-wacom-stylus-page.ui:96
 msgid "Eraser pressure"
 msgstr "Pression sur la gomme"
-
-#: panels/wacom/cc-wacom-stylus-page.ui:102
-msgid "Firm"
-msgstr "Ferme"
-
-#: panels/wacom/cc-wacom-stylus-page.ui:133
-msgid "Default"
-msgstr "Par défaut"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:134
 msgid "Middle Mouse Button Click"
@@ -8146,22 +4836,6 @@ msgstr "Clic du bouton droit de la souris"
 msgid "Forward"
 msgstr "En avant"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Stylet aérographe avec pression, inclinaison et curseur intégré"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Stylet aérographe avec pression, inclinaison et rotation"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Stylet standard avec pression et inclinaison"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Stylet standard avec pression"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tablette Wacom"
@@ -8172,54 +4846,96 @@ msgstr ""
 "Associer les boutons et ajuster la sensibilité du stylet des tablettes "
 "graphiques"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablette;Wacom;Stylet;Gomme;Souris;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Nouveau raccourci…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulation du clic secondaire"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Logiciels Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Toner pratiquement épuisé"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Délai du clic secondaire"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Logiciels Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Gérer les préférences de productivité et du multi-tâches"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Points d’accès"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Ajouter"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Enregistrer"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Opération annulée"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Erreur :</b> accès refusé au changement des paramètres"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Erreur :</b> erreur de l’équipement mobile"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Non enregistré"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Enregistré"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Itinérance"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Recherche"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Refusé"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8249,104 +4965,13 @@ msgstr "Numéro de la ligne"
 msgid "Device Details"
 msgstr "Informations sur l’appareil"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricant"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Version du micrologiciel"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G uniquement"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G uniquement"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G uniquement"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (préférée)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (préférée), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (préférée), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (préférée)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (préférée), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (préférée)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (préférée), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (préférée)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (préférée), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Inconnu"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Déverrouiller la carte SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Déverrouiller"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Veuillez fournir un code PIN pour la SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Saisissez le PIN pour déverrouiller la carte SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Veuillez fournir le code PUK pour la SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Saisissez le PUK pour déverrouiller la carte SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8361,26 +4986,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Il vous reste %u essai"
 msgstr[1] "Il vous reste %u essais"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Mauvais mot de passe saisi."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Le code PUK devrait être un nombre à 8 chiffres"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Saisir le nouveau PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Le code PIN devrait être un nombre de 4 à 8 chiffres"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Déverrouillage…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -8438,148 +5043,48 @@ msgstr "Verrouiller la SIM avec un PIN"
 msgid "M_odem Details"
 msgstr "Informations sur le m_odem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Échec du téléphone"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Aucune connexion au téléphone"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Opération non autorisée"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Opération non prise en charge"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "La SIM n’est pas insérée"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Le code PIN de la SIM est nécessaire"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Le code PUK de la SIM est nécessaire"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Échec de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM occupée"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Mot de passe incorrect"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Le code PIN2 de la SIM est nécessaire"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Le code PUK2 de la SIM est nécessaire"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Introuvable"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Aucun service réseau"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Délai d’attente du réseau dépassé"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Le service GPRS n’est pas autorisé"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "L’itinérance n’est pas autorisée dans cette zone"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Erreur GPRS non précisée"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "Action interrompue"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Accès refusé"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Erreur inconnue"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Mode du réseau"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "_Définir"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "Fermer"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Automatique"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Sélectionner un réseau"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Actualiser les fournisseurs d’accès"
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "Activer le réseau mobile"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "Aucun adaptateur WWAN trouvé"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "Assurez-vous d’avoir un périphérique réseau cellulaire sans fil"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr ""
 "Le réseau cellulaire sans fil est désactivé lorsque le mode avion est activé"
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "_Désactiver le mode avion"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "Connexion de données"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "Carte SIM utilisée pour l’accès à Internet"
 
@@ -8591,15 +5096,15 @@ msgstr "Verrouillage de la SIM"
 msgid "_Next"
 msgstr "_Suivant"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "_Verrouiller la SIM avec le PIN"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "Modifier le PIN"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr ""
 "Saisir le PIN actuel pour modifier les paramètres de verrouillage de la SIM"
@@ -8612,8 +5117,6 @@ msgstr "Réseau mobile"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configurer la téléphonie et les connexions de données mobiles"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellulaire;wwan;téléphonie;sim;mobile;"
@@ -8630,37 +5133,13 @@ msgstr "Paramètres est l’interface principale de configuration du système."
 msgid "The GNOME Project"
 msgstr "Le projet GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Afficher le numéro de version"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Activer le mode verbeux"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Rechercher la chaîne"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Liste les noms possibles de volets et quitte"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Volet à afficher"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Confidentialité"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Volets disponibles :"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8718,7 +5197,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Interrompre la recherche"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Préférences;Paramètres;Réglages;"
@@ -8760,8 +5238,6 @@ msgstr ""
 "Un tuple contenant l’état initial de la largeur, la hauteur ainsi que l’état "
 "maximisé de la fenêtre de l’application."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -8769,8 +5245,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u sortie"
 msgstr[1] "%u sorties"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -8778,9 +5252,2715 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u entrée"
 msgstr[1] "%u entrées"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sons système"
+#~ msgid "System Bus"
+#~ msgstr "Bus système"
+
+#~ msgid "Full access"
+#~ msgstr "Accès complet"
+
+#~ msgid "Session Bus"
+#~ msgstr "Bus de session"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Accès complet à /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "A accès au réseau"
+
+#~ msgid "Home"
+#~ msgstr "Dossier personnel"
+
+#~ msgid "Read-only"
+#~ msgstr "Lecture seule"
+
+#~ msgid "File System"
+#~ msgstr "Système de fichiers"
+
+#~ msgid "Can change settings"
+#~ msgstr "Peut modifier les réglages"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "Les permissions suivantes sont intégrées à %s. Elles ne peuvent être "
+#~ "modifiées. Si ces permissions vous inquiètent, vous devez envisager de "
+#~ "supprimer cette application."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u type de fichier et de lien ouvert par l’application"
+#~ msgstr[1] "%u types de fichiers et de liens ouverts par l’application"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> est utilisé pour ouvrir les types de fichiers et liens suivants."
+
+#, c-format
+#~ msgid "%s of disk space used"
+#~ msgstr "%s d’espace disque utilisé"
+
+#~ msgid "Select a picture"
+#~ msgstr "Sélectionner une image"
+
+#~ msgid "_Open"
+#~ msgstr "_Ouvrir"
+
+#~ msgid "multiple sizes"
+#~ msgstr "plusieurs tailles"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Aucun arrière-plan de bureau"
+
+#~ msgid "Current background"
+#~ msgstr "Arrière-plan actuel"
+
+#~ msgid "Light"
+#~ msgstr "Clair"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "écran;verrouiller;verrouillage;diagnostique;plantage;privé;confidentiel;"
+#~ "récent;temporaire;tmp;index;nom;réseaux;identité;"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Posez votre sonde d’étalonnage sur le carré et appuyez sur « Démarrer »"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Déplacez votre sonde d’étalonnage vers l’emplacement à étalonner et "
+#~ "appuyez sur « Continuer »"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Déplacez votre sonde d’étalonnage à l’aplomb de l’emplacement à étalonner "
+#~ "et appuyez sur « Continuer »"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Rabattez l’écran"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Une erreur interne irrécupérable est survenue."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Les outils nécessaires à l’étalonnage ne sont pas installés."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Le profil n’a pas pu être généré."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Le point blanc spécifié n’est pas disponible."
+
+#~ msgid "Complete!"
+#~ msgstr "Terminé !"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Échec de l’étalonnage !"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Vous pouvez retirer la sonde d’étalonnage."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ne pas toucher à la sonde d’étalonnage pendant le processus"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Écran de portable"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Webcam intégrée"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Écran %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Scanner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Appareil photo %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Imprimante %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webcam %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Activer la gestion des couleurs de %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Afficher les profils de couleurs de %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Non étalonné"
+
+#~ msgid "Default: "
+#~ msgstr "Par défaut : "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Espace de couleurs : "
+
+#~ msgid "Test profile: "
+#~ msgstr "Profil test : "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Sélectionnez un fichier de profil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importer"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Profils ICC pris en charge"
+
+#~ msgid "All files"
+#~ msgstr "Tous les fichiers"
+
+#~ msgid "Save Profile"
+#~ msgstr "Enregistrer le profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Créer un profil de couleur pour le périphérique sélectionné"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "L’instrument de mesure n’est pas détecté. Vérifiez qu’il est allumé et "
+#~ "connecté correctement."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr ""
+#~ "L’instrument de mesure ne prend pas en charge les profils d’imprimante."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Le type de périphérique n’est pas actuellement pris en charge."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espace de couleurs standard"
+
+#~ msgid "Test Profile"
+#~ msgstr "Profil test"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatique"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Basse qualité"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Qualité moyenne"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Haute qualité"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RVB par défaut"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMJN par défaut"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Gris par défaut"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Données d’étalonnage d’usine du fabricant"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Correction de l’écran en mode plein écran impossible avec ce profil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Ce profil n’est peut-être plus assez précis"
+
+#~ msgid "Other…"
+#~ msgstr "Autre…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Déverrouiller pour modifier les paramètres"
+
+#~ msgid "Today"
+#~ msgstr "Aujourd’hui"
+
+#~ msgid "Yesterday"
+#~ msgstr "Hier"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d heure"
+#~ msgstr[1] "%d heures"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minute"
+#~ msgstr[1] "%d minutes"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d seconde"
+#~ msgstr[1] "%d secondes"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Point d’accès"
+
+#~ msgid "24-hour"
+#~ msgstr "24 heures"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Envoyer des rapports ou signaler des problèmes techniques nous aide à "
+#~ "améliorer %s. Les rapports sont envoyés anonymement et sont épurés de "
+#~ "toute donnée personnelle. %s"
+
+#~ msgid "On"
+#~ msgstr "Activé"
+
+#~ msgid "Off"
+#~ msgstr "Désactivé"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Appliquer les changements ?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Les changements ne peuvent être appliqués"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Cela peut venir de limitations matérielles."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Disposition des écrans"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Paysage"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portrait sur la droite"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portrait sur la gauche"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Paysage (retourné)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Unknown"
+#~ msgstr "Inconnu"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 bits"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 bits"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Inconnu"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo du système"
+
+#~ msgid "No input sources found"
+#~ msgstr "Aucune source de saisie trouvée"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Autre"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Raccourcis personnalisés"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "La touche des caractères alternatifs peut être utilisée pour saisir des "
+#~ "caractères supplémentaires. Ceux-ci sont parfois affichés en tant que "
+#~ "troisième option sur votre clavier."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt gauche"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt droit"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super gauche"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super droit"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Touche menu"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl droit"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "La touche de composition permet de saisir une grande variété de "
+#~ "caractères. Pour l’utiliser, maintenez-la enfoncée et appuyez sur <b>C</"
+#~ "b> et <b>o</b> pour saisir <b>©</b>, ou <b>a</b> et <b>’</b> pour saisir "
+#~ "<b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Verr. Maj."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Impr. écran"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Vous pouvez basculer d’une source de saise à une autre à l’aide du "
+#~ "raccourcis clavier %s. Pour modifier ces raccourcis clavier, allez dans "
+#~ "les préférences clavier"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modifié"
+#~ msgstr[1] "%d modifiés"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Réinitialiser tous les raccourcis ?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Réinitialiser tous les raccourcis peut aussi affecter vos raccourcis "
+#~ "personnalisés. Cette action est irréversible."
+
+#~ msgid "Reset All"
+#~ msgstr "Tout réinitialiser"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s est déjà utilisé pour %s. Si vous le remplacez, %s sera désactivé"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Saisir le nouveau raccourci"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Définir un raccourci personnalisé"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Définir un raccourci"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Saisissez un nouveau raccourci pour changer %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Ajouter un raccourci personnalisé"
+
+#~ msgid "Set"
+#~ msgstr "Définir"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Extinction de l’écran"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 secondes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 heure"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Jamais"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Verrouiller votre écran"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Défilement à deux doigts"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinq clics, l’époque GEGL !"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Double-clic, bouton principal"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Simple clic, bouton principal"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Double-clic, bouton du milieu"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Simple clic, bouton du milieu"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Double-clic, bouton secondaire"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Simple clic, bouton secondaire"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager doit être en fonctionnement."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID : %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Réseau non sécurisé (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Réseau sécurisé (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Réseau sécurisé (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Réseau sécurisé (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Réseau sécurisé"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "L’activation du point d’accès entraînera une déconnexion de %s, et il ne "
+#~ "sera pas possible d’accéder à Internet par Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Doit comporter au minimum 8 caractères"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Interrompre le point d’accès et déconnecter tous les utilisateurs ?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Interrompre le point d’accès"
+
+#~ msgid "Preserve"
+#~ msgstr "Conserver"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "Aléatoire"
+
+#~ msgid "Stable"
+#~ msgstr "Stable"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "L’adresse MAC saisie ici sera utilisée comme adresse matérielle du "
+#~ "périphérique réseau activé pour cette connexion. Cette fonctionnalité est "
+#~ "appelée « MAC cloning » ou « spoofing ». Exemple : 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Entreprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Aucune"
+
+#~ msgid "Never"
+#~ msgstr "Jamais"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2,4 GHz ou 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2,4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Aucun"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Faible"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Correct"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bon"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excellent"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Oublier la connexion"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Supprimer le profil de la connexion"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Supprimer le VPN"
+
+#~ msgid "Details"
+#~ msgstr "Détails"
+
+#~ msgid "automatic"
+#~ msgstr "automatique"
+
+#~ msgid "Identity"
+#~ msgstr "Identité"
+
+#~ msgid "Delete Address"
+#~ msgstr "Supprimer l’adresse"
+
+#~ msgid "Delete Route"
+#~ msgstr "Supprimer la route"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Aucune"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Clé WEP 40/128 bits (Hex ou ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Phrase de passe WEP 128 bits"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dynamique (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA et WPA2 privées"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA et WPA2 d’entreprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 privée"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Impossible d’ouvrir l’éditeur de connexions"
+
+#~ msgid "New Profile"
+#~ msgstr "Nouveau profil"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importer depuis un fichier…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Ajouter un VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Impossible d’importer la connexion VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Le fichier « %s » est illisible ou ne contient pas d’informations de "
+#~ "connexion VPN reconnues\n"
+#~ "\n"
+#~ "Erreur : %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Sélectionner le fichier à importer"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Un fichier nommé « %s » existe déjà."
+
+#~ msgid "_Replace"
+#~ msgstr "_Remplacer"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "Voulez-vous remplacer %s avec la connexion VPN en cours d’enregistrement ?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Impossible d’exporter la connexion VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "La connexion VPN « %s » n’a pas pu être exportée vers %s.\n"
+#~ "\n"
+#~ "Erreur : %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportation de la connexion VPN"
+
+#~ msgid "never"
+#~ msgstr "jamais"
+
+#~ msgid "today"
+#~ msgstr "aujourd’hui"
+
+#~ msgid "yesterday"
+#~ msgstr "hier"
+
+#~ msgid "Last used"
+#~ msgstr "Dernière utilisation"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Les informations des réseaux sélectionnés, y compris les mots de passe et "
+#~ "toute configuration personnalisée seront perdus."
+
+#~ msgid "_Forget"
+#~ msgstr "_Oublier"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Réseaux Wi-Fi connus"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Oublier"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr ""
+#~ "Les règles du système interdisent son utilisation comme point d’accès"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr ""
+#~ "Le périphérique sans fil ne prend pas en charge le mode « point d’accès »"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "« Web Proxy Autodiscovery » est utilisé lorsqu’aucune URL de "
+#~ "configuration n’est fournie."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Cela n’est pas recommandé pour des réseaux publics non fiables."
+
+#~ msgid "Status unknown"
+#~ msgstr "État inconnu"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Non géré"
+
+#~ msgid "Unavailable"
+#~ msgstr "Indisponible"
+
+#~ msgid "Connecting"
+#~ msgstr "Connexion en cours"
+
+#~ msgid "Authentication required"
+#~ msgstr "Authentification requise"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Déconnexion en cours"
+
+#~ msgid "Connection failed"
+#~ msgstr "Échec de la connexion"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "État inconnu (absent)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Échec de la configuration"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Échec de la configuration IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Configuration IP expirée"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Des éléments secrets, non fournis, étaient nécessaires"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Le client 802.1x s’est déconnecté"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "La configuration du client 802.1x a échoué"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Le client 802.1x a échoué"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Le client 802.1x a mis trop de temps pour s’authentifier"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Le service PPP n’a pas réussi à démarrer"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Service PPP déconnecté"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP a échoué"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Le client DHCP n’a pas réussi à démarrer"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Erreur du client DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Le client DHCP a échoué"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Le service de connexion partagée n’a pas réussi à démarrer"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Le service de connexion partagée a échoué"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Le service autoIP n’a pas réussi à démarrer"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Erreur du service autoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Le service autoIP a échoué"
+
+#~ msgid "Line busy"
+#~ msgstr "Ligne occupée"
+
+#~ msgid "No dial tone"
+#~ msgstr "Pas de tonalité"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Aucune porteuse n’a pu être établie"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Délai de numérotation dépassé"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "La tentative de numérotation a échoué"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "L’initialisation du modem a échoué"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Échec de la sélection de l’APN spécifié"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Aucune recherche de réseau en cours"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Enregistrement au réseau refusé"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Délai dépassé pour l’enregistrement au réseau"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Échec de l’enregistrement au réseau demandé"
+
+#~ msgid "PIN check failed"
+#~ msgstr "La vérification du code PIN a échoué"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Il se peut que le micrologiciel du périphérique manque"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "La connexion a disparu"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Une connexion existante a été supposée"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem non trouvé"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "La connexion Bluetooth a échoué"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "La carte SIM n’est pas insérée"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Le code PIN de la SIM est nécessaire"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Le code PUK de la SIM est requis"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Mauvaise SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "La dépendance de la connexion a échoué"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Micrologiciel absent"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Câble débranché"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "erreur de sécurité inconnue dans 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "aucun fichier sélectionné"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "erreur inconnue à la validation du fichier eap-method"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "Clés privées DER, PEM, ou PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificats DER ou PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "fichier EAP-FAST PAC manquant"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Fichiers PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "nom d’utilisateur d’EAP-LEAP manquant"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "mot de passe d’EAP-LEAP manquant"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "certificat CA d’EAP-PEAP non valide : %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "certificat CA d’EAP-PEAP non valide : aucun certificat spécifié"
+
+#~ msgid "missing EAP username"
+#~ msgstr "nom d’utilisateur EAP manquant"
+
+#~ msgid "missing EAP password"
+#~ msgstr "mot de passe EAP manquant"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "identité EAP-TLS manquante"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TLS non valide : %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TLS non valide : aucun certificat spécifié"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "clé privée EAP-TLS non valide : %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificat utilisateur EAP-TLS non valide : %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Les clés privées non chiffrées ne sont pas fiables"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "La clé privée sélectionnée ne semble pas être protégée par un mot de "
+#~ "passe. Cela met en danger vos identifiants. Veuillez sélectionner une clé "
+#~ "privée protégée par mot de passe.\n"
+#~ "\n"
+#~ "(Vous pouvez protéger votre clé par mot de passe avec openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Choisissez votre certificat personnel"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Choisissez votre clé privée"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TTLS non valide : %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TTLS non valide : aucun certificat spécifié"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Erreur inconnue à la validation de la sécurité de 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Sélectionner un fichier"
+
+#~ msgid "missing leap-username"
+#~ msgstr "nom d’utilisateur leap manquant"
+
+#~ msgid "missing leap-password"
+#~ msgstr "mot de passe leap manquant"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Le mot de passe Wi-Fi est manquant."
+
+#~ msgid "missing wep-key"
+#~ msgstr "clé wep manquante"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "clé wep non valide : une clé de %zu ne doit contenir que des caractères "
+#~ "hexadécimaux"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "clé wep non valide : une clé de %zu ne doit contenir que des caractères "
+#~ "ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "clé wep non valide : longueur de clé %zu incorrecte. Elle doit être de 5 "
+#~ "à 13 caractères en ascii ou de 10 à 26 en hexa"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "clé wep non valide : phrase de passe non renseignée"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "clé wep non valide : la phrase de passe doit contenir moins de 64 "
+#~ "caractères"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk non valide : longueur de clé %zu incorrecte. Doit être de [8,63] "
+#~ "octets ou 64 caractères hexadécimaux"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk non valide : impossible de considérer une clé de 64 octets comme "
+#~ "hexadécimale"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s supprimé"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Autre"
+
+#~ msgid "Error removing account"
+#~ msgstr "Erreur lors de la suppression du compte"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Compte %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Supprimer le compte"
+
+#~ msgid "Unknown time"
+#~ msgstr "Durée inconnue"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s avant chargement complet"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Attention : il reste %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s restant"
+
+#~ msgid "Fully charged"
+#~ msgstr "Batterie pleine"
+
+#~ msgid "Not charging"
+#~ msgstr "Pas en charge"
+
+#~ msgid "Empty"
+#~ msgstr "Déchargée"
+
+#~ msgid "Charging"
+#~ msgstr "En charge"
+
+#~ msgid "Discharging"
+#~ msgstr "En décharge"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Souris sans fil"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Clavier sans fil"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Onduleur"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Assistant personnel"
+
+#~ msgid "Cellphone"
+#~ msgstr "Téléphone portable"
+
+#~ msgid "Media player"
+#~ msgstr "Lecteur multimédia"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablette"
+
+#~ msgid "Computer"
+#~ msgstr "Ordinateur"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Périphérique d’entrée pour jeux"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principale"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Secondaire"
+
+#~ msgid "Batteries"
+#~ msgstr "Batteries"
+
+#~ msgid "When _idle"
+#~ msgstr "Quand _inactif"
+
+#~ msgid "Suspend"
+#~ msgstr "Mettre en veille"
+
+#~ msgid "Power Off"
+#~ msgstr "Éteindre"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hiberner"
+
+#~ msgid "Nothing"
+#~ msgstr "Rien"
+
+#~ msgid "When on battery power"
+#~ msgstr "Quand sur batterie"
+
+#~ msgid "When plugged in"
+#~ msgstr "Quand le câble est branché"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Jamais"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Mise en veille automatique"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Le mode performance est temporairement désactivé en raison de la "
+#~ "température."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Il semble que l’ordinateur soit posé sur vos genoux, le mode performance "
+#~ "est temporairement indisponible. Posez l’appareil sur une surface stable "
+#~ "pour le rétablir."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Mode performance temporairement indisponible"
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Batterie faible : mode économie d’énergie activé. Le mode précédent sera "
+#~ "rétabli quand le niveau de batterie sera suffisant."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Mode économie d’énergie activé par « %s »."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Mode performance activé par « %s »."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Performance"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Performances élevées et forte consommation d’énergie."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Équilibré"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Performances et consommation d’énergie normales."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Économie d’énergie"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Performances et consommation d’énergie réduites."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "L’imprimante « %s » a été supprimée"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "L’ajout de la nouvelle imprimante a échoué."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Impossible de charger l’interface utilisateur : %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr ""
+#~ "Déverrouiller pour ajouter des imprimantes et modifier les paramètres"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Informations sur %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Aucun pilote adéquat trouvé"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Sélectionnez un fichier PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Fichiers de description PostScript de l’imprimante (*.ppd, *.PPD, *.ppd."
+#~ "gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Imprimante JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Imprimante LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Recto"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Bord long (standard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Bord court (retourné)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portrait"
+
+#~ msgid "Landscape"
+#~ msgstr "Paysage"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Paysage inversé"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Portrait inversé"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "En attente"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "En pause"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Authentification requise"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Traitement en cours"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Arrêtée"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Interrompue"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Annulée"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Terminée"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Déplacer cette tâche en haut de la file d’attente"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - tâches d’impression actives"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr ""
+#~ "Saisissez vos informations d’authentification pour imprimer à partir de "
+#~ "%s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Déverrouiller le serveur d’imprimantes"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Déverrouiller %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Saisissez votre nom d’utilisateur et votre mot de passe pour afficher les "
+#~ "imprimantes sur %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Recherche d’imprimantes"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Port série"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Port parallèle"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Emplacement : %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresse : %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Le serveur nécessite une authentification"
+
+#~ msgid "Two Sided"
+#~ msgstr "Recto verso"
+
+#~ msgid "Paper Type"
+#~ msgstr "Type de papier"
+
+#~ msgid "Paper Source"
+#~ msgstr "Source du papier"
+
+#~ msgid "Output Tray"
+#~ msgstr "Bac de sortie"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Résolution"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Pré-filtrage GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Pages par côté"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientation"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Général"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Mise en page"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Options installables"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Tâche"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Qualité de l’image"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Couleur"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Finition"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avancé"
+
+#~ msgid "Test page"
+#~ msgstr "Page de test"
+
+#~ msgid "Auto Select"
+#~ msgstr "Sélection automatique"
+
+#~ msgid "Printer Default"
+#~ msgstr "Option par défaut de l’imprimante"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Incorporer seulement les polices GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Convertir en PS de niveau 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Convertir en PS de niveau 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Aucun pré-filtrage"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Nettoyage des têtes d’impression"
+
+#~ msgid "Out of toner"
+#~ msgstr "Plus de toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Révélateur pratiquement épuisé"
+
+#~ msgid "Out of developer"
+#~ msgstr "Plus de révélateur"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Cartouche de couleur pratiquement vide"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Cartouche de couleur vide"
+
+#~ msgid "Open cover"
+#~ msgstr "Couvercle ouvert"
+
+#~ msgid "Open door"
+#~ msgstr "Porte ouverte"
+
+#~ msgid "Low on paper"
+#~ msgstr "Pratiquement plus de papier"
+
+#~ msgid "Out of paper"
+#~ msgstr "Plus de papier"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Hors ligne"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Arrêtée"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Récipient à déchets pratiquement plein"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Récipient à déchets plein"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Le photo-conducteur optique est pratiquement en fin de vie"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Le photo-conducteur optique n’est plus en état"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Prête"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "N’accepte plus de tâche supplémentaire"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Traitement en cours"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Impérial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Métrique"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Demander que faire"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ne rien faire"
+
+#~ msgid "Open folder"
+#~ msgstr "Ouvrir le dossier"
+
+#~ msgid "Other Media"
+#~ msgstr "Autres médias"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Sélectionnez une application pour vos CD audio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Sélectionnez une application pour vos DVD audio"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Sélectionnez une application à lancer lorsqu’un baladeur est connecté"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Sélectionnez une application à lancer lorsqu’un appareil photo est "
+#~ "connecté"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Sélectionnez une application pour les CD contenant des logiciels"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD audio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "disque Blu-ray vierge"
+
+#~ msgid "blank CD disc"
+#~ msgstr "disque CD vierge"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "disque DVD vierge"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "disque HD DVD vierge"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "disque vidéo Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "lecteur e-book"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "disque vidéo HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Vidéo CD"
+
+#~ msgid "Video CD"
+#~ msgstr "CD vidéo"
+
+#~ msgid "Select Location"
+#~ msgstr "Sélectionner un emplacement"
+
+#~ msgid "_OK"
+#~ msgstr "_Valider"
+
+#~ msgid "No applications found"
+#~ msgstr "Aucune application trouvée"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Aucun réseau de partage n’est sélectionné"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Activé"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Désactivé"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Activé"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Choisir un dossier"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Le partage de fichiers vous permet de partager votre dossier Public avec "
+#~ "les autres sur le réseau actuel en utilisant : %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Lorsque la connexion à distance est activée, tout utilisateur distant "
+#~ "peut se connecter à l’aide de cette commande shell sécurisée :\n"
+#~ "%s"
+
+#~ msgid "Custom"
+#~ msgstr "Personnalisée"
+
+#~ msgid "Bark"
+#~ msgstr "Aboiement"
+
+#~ msgid "Drip"
+#~ msgstr "Goutte d’eau"
+
+#~ msgid "Glass"
+#~ msgstr "Verre"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Test de %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100 %"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Déconnecté"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Connexion en cours"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Connecté"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Erreur d’autorisation"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autorisation en cours"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Fonctionnalité réduite"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Connecté et autorisé"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Inconnu"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorisé depuis :"
+
+#~ msgid "Connected at:"
+#~ msgstr "Connecté depuis :"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Inscrit depuis :"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Échec de l’autorisation du périphérique : "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Échec de l’oubli du périphérique : "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Erreur"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorisé"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Le sous-système Thunderbolt (boltd) n’est pas installé ou est mal "
+#~ "configuré."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Seuls les périphériques USB et Display Port peuvent être connectés."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt n’a pas pu être détecté.\n"
+#~ "Soit le système ne prend pas en charge Thunderbolt, soit il a été "
+#~ "désactivé dans le BIOS, soit il est paramétré sur un niveau de sécurité "
+#~ "non pris en charge dans le BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "La prise en charge de Thunderbolt a été désactivée dans le BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Le niveau de sécurité Thunderbolt n’a pas pu être déterminé."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Erreur de bascule en mode direct : %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Par défaut"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Moyen"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Grand"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Plus grand"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Le plus grand"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixels"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Courte"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ d’écran"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ écran"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ d’écran"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Longue"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 heure"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 jour"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 jours"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 jours"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 jours"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 jours"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 jours"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 jours"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 jours"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 jours"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Vider complètement la corbeille ?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Tout le contenu de la corbeille sera définitivement supprimé."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Vider la corbeille"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Supprimer tous les fichiers temporaires ?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Tous les fichiers temporaires seront définitivement supprimés."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Purger les fichiers temporaires"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 jour"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 jours"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 jours"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Toujours"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Doit correspondre à l’adresse web de votre fournisseur d’accès."
+
+#~ msgid "Failed to add account"
+#~ msgstr "L’ajout du compte a échoué"
+
+#~ msgid "Failed to register account"
+#~ msgstr "L’enregistrement du compte a échoué"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Impossible de s’authentifier auprès de ce domaine"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Impossible de joindre ce domaine"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Cet identifiant de connexion ne fonctionne pas.\n"
+#~ "Veuillez réessayer."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ce mot de passe de connexion ne fonctionne pas.\n"
+#~ "Veuillez réessayer."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "La connexion à ce domaine a échoué"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Impossible de trouver ce domaine. Vérifiez son orthographe."
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Rechercher d’autres images"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "l’appareil doit être sollicité pour effectuer cette action"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "l’appareil est déjà sollicité par un autre processus"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "vous ne disposez pas des permissions pour effectuer cette action"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "aucune empreinte enregistrée"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Échec de communication avec l’appareil lors de l’apprentissage"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Échec de communication avec le lecteur d’empreintes"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Échec de communication avec le démon d’empreintes"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Échec de chargement de la liste des empreintes : %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Échec de suppression des empreintes enregistrées : %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Pouce gauche"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Majeur gauche"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Index _gauche"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Annulaire gauche"
+
+#~ msgid "Left little finger"
+#~ msgstr "Auriculaire gauche"
+
+#~ msgid "Right thumb"
+#~ msgstr "Pouce droit"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Majeur droit"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Index _droit"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Annulaire droit"
+
+#~ msgid "Right little finger"
+#~ msgstr "Auriculaire droit"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Doigt inconnu"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Terminé"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Lecteur d’empreintes déconnecté"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "L’espace de stockage du lecteur d’empreintes est saturé"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "L’apprentissage de la nouvelle empreinte a échoué"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "L’apprentissage n’a pas pu démarrer : %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "L’apprentissage de la nouvelle empreinte a échoué"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "L’arrêt de l’apprentissage de l’empreinte a échoué : %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Positionnez et glissez votre doigt sur le lecteur d’empreintes plusieurs "
+#~ "fois pour l’apprentissage de votre empreinte"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Recommencer l’apprentissage pour ce doigt"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Enregistrer une nouvelle empreinte"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Impossible de libérer le lecteur d’empreintes %s : %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problème lors de la lecture de l’appareil"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr ""
+#~ "Échec lors de la tentative de récupération du lecteur d’empreintes %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Échec lors de la récupération du lecteur d’empreintes : %s"
+
+#~ msgid "This Week"
+#~ msgstr "Cette semaine"
+
+#~ msgid "Last Week"
+#~ msgstr "La semaine dernière"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Fin de session"
+
+#~ msgid "Session Started"
+#~ msgstr "Début de session"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "Activité du compte de %s"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Veuillez choisir un autre mot de passe."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Veuillez saisir à nouveau votre mot de passe actuel."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Le mot de passe ne peut pas être modifié"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Impossible de rejoindre ce type de domaine automatiquement"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Aucun domaine trouvé"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Impossible de se connecter en tant que %s au domaine %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Mot de passe non valide, essayez à nouveau"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Connexion au domaine %s impossible : %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "La suppression de l’utilisateur a échoué"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "La révocation de l’utilisateur géré à distance a échoué"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Vous ne pouvez pas supprimer votre propre compte."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s est encore connecté"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Supprimer un utilisateur alors qu’il est connecté peut laisser le système "
+#~ "dans un état instable."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Voulez-vous conserver les fichiers de %s ?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Il est possible de conserver le répertoire personnel, les courriers "
+#~ "électroniques en attente (le « spool ») et les fichiers temporaires d’un "
+#~ "compte utilisateur lors de sa suppression."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Supprimer les fichiers"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Conserver les fichiers"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Voulez-vous vraiment révoquer le compte distant de %s ?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Supprimer"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Compte désactivé"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "À définir lors de la prochaine connexion"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Aucun"
+
+#~ msgid "Logged in"
+#~ msgstr "Connecté"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "La connexion au service des comptes a échoué"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Veuillez vérifier que AccountService est installé et activé."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Ce panneau doit être déverrouillé pour modifier ce paramètre"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Supprimer le compte utilisateur sélectionné"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pour supprimer le compte utilisateur sélectionné,\n"
+#~ "cliquez d’abord sur l’icône *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr ""
+#~ "Déverrouiller pour ajouter des utilisateurs et modifier les paramètres"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Le nouveau mot de passe doit être différent de l’ancien."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Essayez de changer quelques lettres et chiffres."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Essayez de modifier un peu plus le mot de passe."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr ""
+#~ "Un mot de passe ne contenant pas votre nom d’utilisateur serait plus fort."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Essayez de ne pas incorporer votre patronyme dans le mot de passe."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Essayez d’éviter certains mots contenus dans le mot de passe."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Essayez d’éviter des mots usuels."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Essayez d’éviter de réarranger les mots existants."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Essayez d’utiliser plus de chiffres."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Essayez d’utiliser davantage de lettres majuscules."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Essayez d’utiliser davantage de lettres minuscules."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Essayez d’utiliser plus de caractères spéciaux, comme les ponctuations."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Essayez d’utiliser un mélange de lettres, de chiffres et de ponctuations."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Essayez d’éviter la répétition du même caractère."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Essayez d’éviter la répétition du même caractère : vous devez mélanger "
+#~ "des lettres, des chiffres et des ponctuations."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Essayez d’éviter des séquences telles que 1234 ou abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Le mot de passe doit être plus long. Essayez d’ajouter des lettres, des "
+#~ "chiffres et des ponctuations."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Mélangez des majuscules, des minuscules et aussi un ou deux nombres."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "L’ajout de lettres, de chiffres et de ponctuations renforcera le mot de "
+#~ "passe."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Échec d’authentification"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Le nouveau mot de passe est trop court"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Le nouveau mot de passe est trop simple"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "L’ancien et le nouveau mot de passe sont trop ressemblants"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Le nouveau mot de passe a déjà été utilisé récemment."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr ""
+#~ "Le nouveau mot de passe doit contenir des caractères spéciaux ou "
+#~ "numériques"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "L’ancien et le nouveau mot de passe sont identiques"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Votre mot de passe a été modifié depuis que vous vous êtes authentifié !"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr ""
+#~ "Le nouveau mot de passe ne comporte pas suffisamment de caractères "
+#~ "différents"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Erreur inconnue"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Un nom d’utilisateur ne contient en principe que des lettres minuscules "
+#~ "ou majuscules de a à z et l’un de ces caractères : - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Désolé, ce nom d’utilisateur n’est pas disponible. Veuillez en choisir un "
+#~ "autre."
+
+#~ msgid "The username is too long."
+#~ msgstr "Le nom d’utilisateur est trop long."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Bouton %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Défini par l’application"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Envoyer les appuis sur les touches"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Inverser l’écran"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Afficher l’aide à l’écran"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "La tablette est montée sur le panneau de l’ordinateur portable"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "La tablette est montée sur un écran externe"
+
+#~ msgid "All Displays"
+#~ msgstr "Tous les éc­rans"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Stylet aérographe avec pression, inclinaison et curseur intégré"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Stylet aérographe avec pression, inclinaison et rotation"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Stylet standard avec pression et inclinaison"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Stylet standard avec pression"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nouveau raccourci…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Opération annulée"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Erreur :</b> accès refusé au changement des paramètres"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Erreur :</b> erreur de l’équipement mobile"
+
+#~ msgid "Not Registered"
+#~ msgstr "Non enregistré"
+
+#~ msgid "Registered"
+#~ msgstr "Enregistré"
+
+#~ msgid "Roaming"
+#~ msgstr "Itinérance"
+
+#~ msgid "Searching"
+#~ msgstr "Recherche"
+
+#~ msgid "Denied"
+#~ msgstr "Refusé"
+
+#~ msgid "2G Only"
+#~ msgstr "2G uniquement"
+
+#~ msgid "3G Only"
+#~ msgstr "3G uniquement"
+
+#~ msgid "4G Only"
+#~ msgstr "4G uniquement"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (préférée)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (préférée), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (préférée), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (préférée)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (préférée), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (préférée)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (préférée), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (préférée)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (préférée), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Inconnu"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Déverrouiller la carte SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Veuillez fournir un code PIN pour la SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Saisissez le PIN pour déverrouiller la carte SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Veuillez fournir le code PUK pour la SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Saisissez le PUK pour déverrouiller la carte SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Mauvais mot de passe saisi."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Le code PUK devrait être un nombre à 8 chiffres"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Saisir le nouveau PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Le code PIN devrait être un nombre de 4 à 8 chiffres"
+
+#~ msgid "Phone failure"
+#~ msgstr "Échec du téléphone"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Aucune connexion au téléphone"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Opération non autorisée"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Opération non prise en charge"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "La SIM n’est pas insérée"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Le code PIN de la SIM est nécessaire"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Le code PUK de la SIM est nécessaire"
+
+#~ msgid "SIM failure"
+#~ msgstr "Échec de la SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM occupée"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Mot de passe incorrect"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Le code PIN2 de la SIM est nécessaire"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Le code PUK2 de la SIM est nécessaire"
+
+#~ msgid "Not found"
+#~ msgstr "Introuvable"
+
+#~ msgid "No network service"
+#~ msgstr "Aucun service réseau"
+
+#~ msgid "Network timeout"
+#~ msgstr "Délai d’attente du réseau dépassé"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Le service GPRS n’est pas autorisé"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "L’itinérance n’est pas autorisée dans cette zone"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Erreur GPRS non précisée"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Action interrompue"
+
+#~ msgid "Access denied"
+#~ msgstr "Accès refusé"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Erreur inconnue"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Afficher le numéro de version"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Activer le mode verbeux"
+
+#~ msgid "Search for the string"
+#~ msgstr "Rechercher la chaîne"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Liste les noms possibles de volets et quitte"
+
+#~ msgid "Panel to display"
+#~ msgstr "Volet à afficher"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Volets disponibles :"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sons système"
 
 #~ msgid "GNOME Settings Sound Panel"
 #~ msgstr "Panneau de son des paramètres GNOME"
@@ -8847,8 +8027,8 @@ msgstr "Sons système"
 #~ msgstr "Non modifiable"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Les permissions spécifiques aux applications peuvent être examinées dans "
 #~ "les réglages de <a href=\"privacy\">Confidentialité</a>."
@@ -8937,9 +8117,6 @@ msgstr "Sons système"
 
 #~ msgid "Less Warm"
 #~ msgstr "Moins chaude"
-
-#~ msgid "Screenshots"
-#~ msgstr "Captures d’écran"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "Enregistrer une capture d’écran dans $PICTURES"
@@ -9057,17 +8234,11 @@ msgstr "Sons système"
 #~ "Le partage d’écran permet aux utilisateurs distants de voir ou contrôler "
 #~ "votre écran en se connectant à %s"
 
-#~ msgid "Copy"
-#~ msgstr "Copier"
-
 #~ msgid "_Screen Sharing"
 #~ msgstr "Partage d’é_cran"
 
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr "Certains services sont désactivés faute d’accès au réseau."
-
-#~ msgid "Screen Sharing"
-#~ msgstr "Partage d’écran"
 
 #~ msgid "_Password:"
 #~ msgstr "Mot de _passe :"
@@ -9092,9 +8263,6 @@ msgstr "Sons système"
 
 #~ msgid "_Screen Reader"
 #~ msgstr "_Lecteur d’écran"
-
-#~ msgid "_Full Name"
-#~ msgstr "_Nom complet"
 
 #~ msgid "Standard"
 #~ msgstr "Normal"
@@ -9155,9 +8323,6 @@ msgstr "Sons système"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablette (absolu)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Pavé tactile (relatif)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Préférences de la tablette"
@@ -9328,9 +8493,6 @@ msgstr "Sons système"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Accéder directement au matériel Bluetooth"
-
-#~ msgid "Use your camera"
-#~ msgstr "Utiliser la caméra"
 
 #~ msgid "Print documents"
 #~ msgstr "Imprimer des documents"

--- a/po/fr.po~
+++ b/po/fr.po~
@@ -1,0 +1,9782 @@
+# French translation of gnome-control-center.
+# Copyright (C) 1998-2020 Free Software Foundation, Inc.
+# This file is under the same license as the gnome-control-center package.
+#
+# Vincent Renardias <vincent@ldsol.com>, 1998-1999.
+# Fabrice Bellet <fabrice.bellet@imag.fr>, 1999.
+# Thibaut Cousin <thibaut.cousin@clermont.in2p3.fr>, 1999.
+# Joaquim Fellmann <joaquim@hrnet.fr>, 2000.
+# Christophe Merlet <redfox@redfoxcenter.org>, 2000-2006.
+# Christophe Fergeau <teuf@users.sourceforge.net>, 2002.
+# Mathieu Gauthier-Pilote <mathieu.g.p@videotron.ca>, 2002.
+# Sebastien Oustric <sebastien.oustric@laposte.net>, 2002.
+# Simon Manlay <simon@solintech.fr>, 2005.
+# Vincent Untz <vuntz@gnome.org>, 2005.
+# Robert-André Mauchin <zebob.m@pengzone.org>, 2006-2008.
+# Jonathan Ernst <jonathan@ernstfamily.ch>, 2006-2007.
+# Benoît Dejean <benoit@placenet.org>, 2006.
+# Samuel Mutel <samuel.mutel@free.fr>, 2006.
+# Damien Durand <splinux@fedoraproject.org>, 2006.
+# Marc Lorber <linux-lorber@club-internet.fr>, 2006.
+# Stéphane Raimbault <stephane.raimbault@gmail.com>, 2007-2008.
+# Christophe Benz <christophe.benz@gmail.com>, 2007.
+# Bruno Brouard <annoa.b@gmail.com>, 2008-2012.
+# Laurent Coudeur <laurentc@iol.ie>, 2009, 2010.
+# Gérard Baylard <Geodebay@gmail.com>, 2011.
+# Grawok <grawok@gmx.com>, 2012.
+# Alain Lojewski <allomervan@gmail.com>, 2011-2018.
+# Julien Hardelin <jhardlin@orange.fr>, 2013.
+# Erwan Georget <dremor@dremor.info>, 2015.
+# Claude Paroz <claude@2xlibre.net>, 2007-2020.
+# Thibault Martin <mail@thibaultmart.in>, 2020-2021.
+# Charles Monzat <charles.monzat@free.fr>, 2016-2021.
+# Alexandre Franke <afranke@gnome.org>, 2013-2021.
+# Guillaume Bernard <associations@guillaume-bernard.fr>, 2015-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center HEAD\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-04-19 17:02+0000\n"
+"PO-Revision-Date: 2022-04-19 19:16+0200\n"
+"Last-Translator: Guillaume Bernard <associations@guillaume-bernard.fr>\n"
+"Language-Team: GNOME French Team <gnomefr@traduc.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Gtranslator 40.0\n"
+
+#: panels/applications/cc-applications-panel.c:803
+msgid "System Bus"
+msgstr "Bus système"
+
+#: panels/applications/cc-applications-panel.c:803
+#: panels/applications/cc-applications-panel.c:805
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:823
+msgid "Full access"
+msgstr "Accès complet"
+
+#: panels/applications/cc-applications-panel.c:805
+msgid "Session Bus"
+msgstr "Bus de session"
+
+#: panels/applications/cc-applications-panel.c:809
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
+#: panels/thunderbolt/cc-bolt-panel.ui:310
+msgid "Devices"
+msgstr "Périphériques"
+
+#: panels/applications/cc-applications-panel.c:809
+msgid "Full access to /dev"
+msgstr "Accès complet à /dev"
+
+#: panels/applications/cc-applications-panel.c:813
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Réseau"
+
+#: panels/applications/cc-applications-panel.c:813
+msgid "Has network access"
+msgstr "A accès au réseau"
+
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:820
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Dossier personnel"
+
+#: panels/applications/cc-applications-panel.c:820
+#: panels/applications/cc-applications-panel.c:825
+msgid "Read-only"
+msgstr "Lecture seule"
+
+#: panels/applications/cc-applications-panel.c:823
+#: panels/applications/cc-applications-panel.c:825
+msgid "File System"
+msgstr "Système de fichiers"
+
+#: panels/applications/cc-applications-panel.c:829
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:878 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Paramètres"
+
+#: panels/applications/cc-applications-panel.c:829
+msgid "Can change settings"
+msgstr "Peut modifier les réglages"
+
+#: panels/applications/cc-applications-panel.c:831
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"Les permissions suivantes sont intégrées à %s. Elles ne peuvent être "
+"modifiées. Si ces permissions vous inquiètent, vous devez envisager de "
+"supprimer cette application."
+
+#: panels/applications/cc-applications-panel.c:1164
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u type de fichier et de lien ouvert par l’application"
+msgstr[1] "%u types de fichiers et de liens ouverts par l’application"
+
+#: panels/applications/cc-applications-panel.c:1171
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> est utilisé pour ouvrir les types de fichiers et liens suivants."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1223
+#, c-format
+msgid "%s of disk space used"
+msgstr "%s d’espace disque utilisé"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1387
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Applications"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Aucune application"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Installer…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Ouvrir"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Afficher les détails"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Recherche"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Recevoir les recherches système et envoyer les résultats."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/applications/cc-applications-panel.ui:177
+#: panels/applications/cc-applications-panel.ui:191
+#: panels/applications/cc-applications-panel.ui:205
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
+#: panels/user-accounts/cc-user-panel.c:789
+#: panels/user-accounts/cc-user-panel.c:879
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notifications"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Afficher les notifications système."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in background"
+msgstr "Exécuter en arrière-plan"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Autoriser l’exécution même lorsque l’application est fermée."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Change Wallpaper"
+msgstr "Modifier le papier peint"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Change the desktop wallpaper."
+msgstr "Modifier le papier peint du bureau."
+
+#: panels/applications/cc-applications-panel.ui:147
+#: panels/applications/cc-applications-panel.ui:154
+msgid "Sounds"
+msgstr "Sons"
+
+#: panels/applications/cc-applications-panel.ui:148
+#: panels/applications/cc-applications-panel.ui:155
+msgid "Reproduce sounds."
+msgstr "Reproduire les sons."
+
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Inhibit Shortcuts"
+msgstr "Ignorer les raccourcis"
+
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Block standard keyboard shortcuts."
+msgstr "Bloquer les raccourcis clavier standard."
+
+#: panels/applications/cc-applications-panel.ui:168
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Caméra"
+
+#: panels/applications/cc-applications-panel.ui:169
+#: panels/applications/cc-applications-panel.ui:176
+msgid "Take pictures with the camera."
+msgstr "Prendre des photos avec la caméra."
+
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Micro"
+
+#: panels/applications/cc-applications-panel.ui:183
+#: panels/applications/cc-applications-panel.ui:190
+msgid "Record audio with the microphone."
+msgstr "Enregistrer l’audio avec le microphone."
+
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Services de localisation"
+
+#: panels/applications/cc-applications-panel.ui:197
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Access device location data."
+msgstr "Accéder aux données d’emplacement du périphérique."
+
+#: panels/applications/cc-applications-panel.ui:215
+#: panels/applications/cc-applications-panel.ui:319
+msgid "Built-in Permissions"
+msgstr "Permissions intégrées"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System access that is required by the app"
+msgstr "L’accès au système qui est requis par l’application"
+
+#: panels/applications/cc-applications-panel.ui:224
+msgid "File &amp; Link Associations"
+msgstr "Associations de fichiers et de liens"
+
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:399
+msgid "Storage"
+msgstr "Stockage"
+
+#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+msgid "No results found"
+msgstr "Aucun résultat trouvé"
+
+#: panels/applications/cc-applications-panel.ui:304
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
+#: shell/cc-panel-list.ui:114
+msgid "Try a different search"
+msgstr "Essayez une autre recherche"
+
+#: panels/applications/cc-applications-panel.ui:344
+msgid "File & Link Associations"
+msgstr "Associations de fichiers et de liens"
+
+#: panels/applications/cc-applications-panel.ui:367
+msgid "File Types"
+msgstr "Types de fichiers"
+
+#: panels/applications/cc-applications-panel.ui:373
+msgid "Link Types"
+msgstr "Types de liens"
+
+#: panels/applications/cc-applications-panel.ui:383
+msgid "Reset"
+msgstr "Réinitialiser"
+
+#: panels/applications/cc-applications-panel.ui:410
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Espace disque consommé par cette application pour ses données et son cache."
+
+#: panels/applications/cc-applications-panel.ui:413
+msgid "Application"
+msgstr "Application"
+
+#: panels/applications/cc-applications-panel.ui:419
+msgid "Data"
+msgstr "Données"
+
+#: panels/applications/cc-applications-panel.ui:425
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:431
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:441
+msgid "Clear Cache…"
+msgstr "Effacer le cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Contrôle diverses permissions et réglages d’application"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "application;flatpak;permission;réglage;"
+
+#: panels/background/cc-background-chooser.c:307
+msgid "Select a picture"
+msgstr "Sélectionner une image"
+
+#: panels/background/cc-background-chooser.c:310
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:198
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/network/cc-wifi-hotspot-dialog.ui:123
+#: panels/network/cc-wifi-panel.c:881
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:860
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:263
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:18
+#: panels/user-accounts/cc-user-panel.c:579
+#: panels/user-accounts/cc-user-panel.c:597
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:139
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
+msgid "_Cancel"
+msgstr "A_nnuler"
+
+#: panels/background/cc-background-chooser.c:311
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:264
+#: panels/sharing/cc-sharing-panel.c:524
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Ouvrir"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "plusieurs tailles"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Aucun arrière-plan de bureau"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Arrière-plan actuel"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Style"
+
+#: panels/background/cc-background-panel.ui:45
+msgid "Light"
+msgstr "Clair"
+
+#: panels/background/cc-background-panel.ui:72
+msgid "Dark"
+msgstr "Sombre"
+
+#: panels/background/cc-background-panel.ui:91
+msgid "Background"
+msgstr "Arrière-plan"
+
+#: panels/background/cc-background-panel.ui:97
+msgid "Add Picture…"
+msgstr "Ajouter une image…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Apparence"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+"Remplacer votre image d’arrière-plan ou les couleurs de l’interface "
+"utilisateur"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgstr "Arrière-plan;Papier peint;Écran;Bureau;Style;Clair;Sombre;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:21
+msgid "No Bluetooth Found"
+msgstr "Pas de réseau Bluetooth trouvé"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:22
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Branchez la clé pour utiliser le Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:28
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth désactivé"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:29
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Activez pour connecter des périphériques et recevoir des transferts de "
+"fichiers."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:35
+msgid "Airplane Mode is On"
+msgstr "Le Mode avion est activé"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:36
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Le Bluetooth est désactivé lorsque le mode avion est activé."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Turn Off Airplane Mode"
+msgstr "Désactivez le mode avion"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:53
+msgid "Hardware Airplane Mode is On"
+msgstr "L’interrupteur matériel du mode avion est activé"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:54
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Désactivez le mode avion pour activer le Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Active/désactive le Bluetooth et connecte vos périphériques"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "partage;partager;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:21
+msgid "Camera is Turned Off"
+msgstr "La caméra est désactivée"
+
+#: panels/camera/cc-camera-panel.ui:22
+msgid "No applications can capture photos or video."
+msgstr "Aucune application ne peut prendre de photo ou de vidéo."
+
+#: panels/camera/cc-camera-panel.ui:36
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"L’utilisation de la caméra permet aux applications de prendre des photos et "
+"des vidéos. En la désactivant, il se peut que certaines applications ne "
+"fonctionnent pas correctement.\n"
+"\n"
+"Autoriser les applications ci-dessous à utiliser votre caméra."
+
+#: panels/camera/cc-camera-panel.ui:52
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Aucune application n’a demandé l’accès à votre caméra"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Protéger vos images"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"écran;verrouiller;verrouillage;diagnostique;plantage;privé;confidentiel;"
+"récent;temporaire;tmp;index;nom;réseaux;identité;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Posez votre sonde d’étalonnage sur le carré et appuyez sur « Démarrer »"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Déplacez votre sonde d’étalonnage vers l’emplacement à étalonner et appuyez "
+"sur « Continuer »"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Déplacez votre sonde d’étalonnage à l’aplomb de l’emplacement à étalonner et "
+"appuyez sur « Continuer »"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Rabattez l’écran"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Une erreur interne irrécupérable est survenue."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Les outils nécessaires à l’étalonnage ne sont pas installés."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Le profil n’a pas pu être généré."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Le point blanc spécifié n’est pas disponible."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Terminé !"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Échec de l’étalonnage !"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Vous pouvez retirer la sonde d’étalonnage."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ne pas toucher à la sonde d’étalonnage pendant le processus"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Étalonnage de l’écran"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Démarrer"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Reprendre"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+msgid "_Done"
+msgstr "_Terminé"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Écran de portable"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Webcam intégrée"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Écran %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Scanner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Appareil photo %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Imprimante %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webcam %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Activer la gestion des couleurs de %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Afficher les profils de couleurs de %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Non étalonné"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Par défaut : "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Espace de couleurs : "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Profil test : "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Sélectionnez un fichier de profil ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importer"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Profils ICC pris en charge"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Tous les fichiers"
+
+#: panels/color/cc-color-panel.c:586
+msgid "Screen"
+msgstr "Écran"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Enregistrer le profil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Enregistrer"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Créer un profil de couleur pour le périphérique sélectionné"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"L’instrument de mesure n’est pas détecté. Vérifiez qu’il est allumé et "
+"connecté correctement."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+"L’instrument de mesure ne prend pas en charge les profils d’imprimante."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Le type de périphérique n’est pas actuellement pris en charge."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Étalonnage de l’écran"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Qualité de l’étalonnage"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"L’étalonnage va générer un profil que vous pourrez utiliser pour gérer la "
+"couleur de votre écran. Plus l’étalonnage est long, meilleure est la qualité "
+"du profil de couleur."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Vous ne pourrez pas utiliser votre ordinateur pendant l’étalonnage."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Qualité"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Durée estimée"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Sonde d’étalonnage"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Sélectionnez la sonde que vous souhaitez utiliser pour l’étalonnage."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Type d’écran"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Sélectionnez le type d’écran qui est connecté."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Point blanc du profil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Sélectionnez un point blanc cible pour l’écran. La plupart des écrans "
+"doivent être étalonnés à l’illuminant D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Luminosité de l’écran"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Réglez la luminosité de l’écran à une valeur qui vous est habituelle. La "
+"gestion de couleur n’en sera que plus fiable."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Vous pouvez aussi utiliser la luminosité déjà définie dans d’autres profils "
+"pour ce périphérique."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nom du profil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Vous pouvez utiliser le même profil de couleur sur différents ordinateurs et "
+"aussi créer des profils adaptés à différentes conditions d’éclairage."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nom du profil :"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Résumé"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil créé avec succès !"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copier le profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Nécessite un média inscriptible"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Ici, vous pouvez consulter d’utiles conseils sur l’utilisation d’un profil "
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> et <a href="
+"\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Ajouter un profil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Il y a un problème. Il se peut que le profil ne fonctionne pas correctement. "
+"<a href=\"\">Afficher les détails</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importer un fichier…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/network/connection-editor/net-connection-editor.c:497
+#: panels/printers/new-printer-dialog.ui:84
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Ajouter"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Chaque périphérique a besoin d’un profil de couleur à jour pour la prise en "
+"charge des couleurs."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Pour en savoir plus"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Pour en savoir plus sur la gestion des couleurs"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Définir pour _tous les utilisateurs"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Définir ce profil pour tous les utilisateurs de cet ordinateur"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "A_ctiver"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Ajouter un profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "É_talonner…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Étalonner le périphérique"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Supprimer un profil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "A_fficher les détails"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Impossible de détecter un périphérique pour gérer sa couleur"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projecteur"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (rétro-éclairage CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (rétro-éclairage à LED RVB)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (rétro-éclairage à LED blanches)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD à gamut large (rétro-éclairage CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD à large gamut (rétro-éclairage à LED RVB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Élevée"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutes"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Moyenne"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Basse"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Native à écran"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (impression et publication)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (photos et graphismes)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Espace de couleurs standard"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Profil test"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatique"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Basse qualité"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Qualité moyenne"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Haute qualité"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RVB par défaut"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMJN par défaut"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Gris par défaut"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Données d’étalonnage d’usine du fabricant"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Correction de l’écran en mode plein écran impossible avec ce profil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Ce profil n’est peut-être plus assez précis"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Couleur"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Étalonne la couleur de vos périphériques, comme les écrans, les appareils "
+"photos ou les imprimantes"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Couleur;ICC;Profil;Étalonner;Étalonnage;Imprimante;Écran;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Autre…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Choisir la langue"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Sélectionner"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Aucune langue trouvée"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Davantage…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Déverrouiller pour modifier les paramètres"
+
+#: panels/common/cc-permission-infobar.ui:40
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+"Certains paramètres doivent être déverrouillés avant de pouvoir être "
+"modifiés."
+
+#: panels/common/cc-permission-infobar.ui:57
+msgid "Unlock…"
+msgstr "Déverrouiller…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Incrémenter les heures"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Incrémenter les minutes"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Heure"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Décrémenter les heures"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Décrémenter les minutes"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:162
+msgid "Today"
+msgstr "Aujourd’hui"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:164
+msgid "Yesterday"
+msgstr "Hier"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d heure"
+msgstr[1] "%d heures"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minute"
+msgstr[1] "%d minutes"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d seconde"
+msgstr[1] "%d secondes"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 seconde"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Point d’accès"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 heures"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Date et heure"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Année"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mois"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "janvier"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "février"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "mars"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "avril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "mai"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "juin"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "juillet"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "août"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "septembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "octobre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "novembre"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "décembre"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Jour"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Fuseau horaire"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Rechercher une ville"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Date et heure automatiques"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Nécessite une connexion internet"
+
+#: panels/datetime/cc-datetime-panel.ui:177
+msgid "Date &amp; _Time"
+msgstr "Date et _heure"
+
+#: panels/datetime/cc-datetime-panel.ui:201
+msgid "Automatic Time _Zone"
+msgstr "_Fuseau horaire automatique"
+
+#: panels/datetime/cc-datetime-panel.ui:202
+msgid "Requires location services enabled and internet access"
+msgstr ""
+"Nécessite l’activation des services de localisation et une connexion internet"
+
+#: panels/datetime/cc-datetime-panel.ui:214
+msgid "Time Z_one"
+msgstr "Fuseau h_oraire"
+
+#: panels/datetime/cc-datetime-panel.ui:239
+msgid "Time _Format"
+msgstr "_Format de l’heure"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Modifier la date et l’heure, y compris le fuseau horaire"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Horloge;Fuseau;Heure;Date;Emplacement;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Modifier la date et l’heure du système"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Vous devez vous authentifier pour modifier la date ou l’heure."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "Sites _web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Courriels"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendrier"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usique"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Vidéos"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Photos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Applications par défaut"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configurer les applications par défaut"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "défaut;par défaut;application;préférée;média;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Envoyer des rapports ou signaler des problèmes techniques nous aide à "
+"améliorer %s. Les rapports sont envoyés anonymement et sont épurés de toute "
+"donnée personnelle. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Signalement de problèmes"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Signalement _automatique de problèmes"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostics"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Signaler des problèmes"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"écran;verrouiller;verrouillage;diagnostic;diagnostique;plantage;privé;"
+"confidentiel;récent;temporaire;tmp;index;nom;réseaux;identité;"
+"confidentialité;"
+
+#: panels/display/cc-display-panel.c:512
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Activé"
+
+#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Désactivé"
+
+#: panels/display/cc-display-panel.c:945
+msgid "Apply Changes?"
+msgstr "Appliquer les changements ?"
+
+#: panels/display/cc-display-panel.c:950
+msgid "Changes Cannot be Applied"
+msgstr "Les changements ne peuvent être appliqués"
+
+#: panels/display/cc-display-panel.c:952
+msgid "This could be due to hardware limitations."
+msgstr "Cela peut venir de limitations matérielles."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Appliquer"
+
+#: panels/display/cc-display-panel.ui:97
+msgid "Display Settings Disabled"
+msgstr "Paramètres d’affichage désactivés"
+
+#: panels/display/cc-display-panel.ui:113
+msgid "Display Arrangement"
+msgstr "Disposition des écrans"
+
+#: panels/display/cc-display-panel.ui:124
+msgid "Multiple Displays"
+msgstr "Affichages multiples"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:133
+msgid "Join"
+msgstr "Joindre"
+
+#: panels/display/cc-display-panel.ui:140
+msgid "Mirror"
+msgstr "Cloner"
+
+#: panels/display/cc-display-panel.ui:153
+msgid "Contains top bar and Activities"
+msgstr "Contient la barre supérieure et les activités"
+
+#: panels/display/cc-display-panel.ui:154
+msgid "Primary Display"
+msgstr "Écran principal"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:175
+#: panels/display/cc-display-panel.ui:223
+#: panels/display/cc-night-light-page.ui:77
+msgid "Night Light"
+msgstr "Mode nuit"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Paysage"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portrait sur la droite"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portrait sur la gauche"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Paysage (retourné)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:40
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientation"
+
+#: panels/display/cc-display-settings.ui:47
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Définition"
+
+#: panels/display/cc-display-settings.ui:54
+msgid "Refresh Rate"
+msgstr "Fréquence de rafraîchissement"
+
+#: panels/display/cc-display-settings.ui:61
+msgid "Adjust for TV"
+msgstr "Ajuster pour une TV"
+
+#: panels/display/cc-display-settings.ui:75
+#: panels/display/cc-display-settings.ui:90
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Échelle"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:21
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Désactivé temporairement jusqu’à demain"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:35
+msgid "Restart Filter"
+msgstr "Redémarrer le filtre"
+
+#: panels/display/cc-night-light-page.ui:57
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Le mode nuit adoucit les couleurs bleues de l’écran. Il peut réduire la "
+"fatigue des yeux et les risques d’insomnies."
+
+#: panels/display/cc-night-light-page.ui:91
+msgid "Schedule"
+msgstr "Horaires"
+
+#: panels/display/cc-night-light-page.ui:99
+msgid "Sunset to Sunrise"
+msgstr "Coucher au lever du soleil"
+
+#: panels/display/cc-night-light-page.ui:100
+msgid "Manual Schedule"
+msgstr "Horaire manuel"
+
+#: panels/display/cc-night-light-page.ui:110
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Horodatage"
+
+#: panels/display/cc-night-light-page.ui:123
+msgid "From"
+msgstr "De"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/display/cc-night-light-page.ui:235
+msgid "Hour"
+msgstr "heure"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/display/cc-night-light-page.ui:241
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:171
+#: panels/display/cc-night-light-page.ui:258
+msgid "Minute"
+msgstr "minute"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:181
+#: panels/display/cc-night-light-page.ui:268
+msgid "AM"
+msgstr "matin"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:193
+#: panels/display/cc-night-light-page.ui:280
+msgid "PM"
+msgstr "après midi"
+
+#: panels/display/cc-night-light-page.ui:210
+msgid "To"
+msgstr "à"
+
+#: panels/display/cc-night-light-page.ui:316
+msgid "Color Temperature"
+msgstr "Température de couleur"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Éc­rans"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Choisir le mode d’utilisation des écrans et projecteurs connectés"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panneau;Projecteur;xrandr;Écran;Définition;Résolution;Rafraîchissement;"
+"Moniteur;Nuit;Éclairage;Lumière;Bleue;Rouge;redshift;décalage;spectral;"
+"couleur;lever;coucher;soleil;"
+
+#: panels/info-overview/cc-info-overview-panel.c:411
+#: panels/info-overview/cc-info-overview-panel.c:435
+#: panels/info-overview/cc-info-overview-panel.c:481
+#: panels/info-overview/cc-info-overview-panel.c:511
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Inconnu"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:443
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s ; (identifiant de construction : %s)"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:458
+#, c-format
+msgid "64-bit"
+msgstr "64 bits"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:461
+#, c-format
+msgid "32-bit"
+msgstr "32 bits"
+
+#: panels/info-overview/cc-info-overview-panel.c:720
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:724
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:726
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo du système"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "Device Name"
+msgstr "Nom de l’appareil"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Modèle du matériel"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Mémoire"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processeur"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Carte graphique"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacité du disque"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calcul en cours…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nom du système d’exploitation"
+
+#: panels/info-overview/cc-info-overview-panel.ui:106
+msgid "OS Type"
+msgstr "Type de système d’exploitation"
+
+#: panels/info-overview/cc-info-overview-panel.ui:114
+msgid "GNOME Version"
+msgstr "Version de GNOME"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "Windowing System"
+msgstr "Système de fenêtrage"
+
+#: panels/info-overview/cc-info-overview-panel.ui:131
+msgid "Virtualization"
+msgstr "Virtualisation"
+
+#: panels/info-overview/cc-info-overview-panel.ui:139
+msgid "Software Updates"
+msgstr "Mises à jour logicielles"
+
+#: panels/info-overview/cc-info-overview-panel.ui:158
+msgid "Rename Device"
+msgstr "Renommer l’appareil"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Le nom de l’appareil est utilisé pour l’identifier lorsqu’il est visible sur "
+"le réseau, ou en attente d’appairage avec des périphériques Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid "_Rename"
+msgstr "_Renommer"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "À propos"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Afficher les informations sur le système"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"appareil;périphérique;système;information;nom d’hôte;mémoire;processeur;"
+"version;défaut;application;préféré;cd;dvd;usb;audio;vidéo;disque;amovible;"
+"média;exécution automatique;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Son et média"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Couper/activer le son"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Diminuer le son"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Monter le son"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Couper/activer le micro"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Démarrer le lecteur multimédia"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Lire (ou lire/suspendre)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Mettre en pause"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Arrêter la lecture"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Piste précédente"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Piste suivante"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Éjecter"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Saisie"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Passer à la source de saisie suivante"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Passer à la source de saisie précédente"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lanceurs"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Démarrer le navigateur d’aide"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Démarrer la calculatrice"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Démarrer le client de messagerie"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Démarrer le navigateur web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Dossier personnel"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Rechercher"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Système"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Se déconnecter"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Verrouiller l’écran"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accessibilité"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Activer ou désactiver le zoom"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zoom avant"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Zoom arrière"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Activer ou désactiver le lecteur d’écran"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Activer ou désactiver le clavier visuel"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Augmenter la taille du texte"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Réduire la taille du texte"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Activer ou désactiver le contraste élevé"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Aucune source de saisie trouvée"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Autre"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Ajouter une source de saisie"
+
+#: panels/keyboard/cc-input-chooser.ui:81
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+"Les méthodes de saisie ne peuvent pas être utilisées sur l’écran de connexion"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Aucune source de saisie sélectionnée"
+
+#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+msgid "Move Up"
+msgstr "Remonter"
+
+#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+msgid "Move Down"
+msgstr "Descendre"
+
+#: panels/keyboard/cc-input-row.ui:38
+msgid "Preferences"
+msgstr "Préférences"
+
+#: panels/keyboard/cc-input-row.ui:45
+msgid "View Keyboard Layout"
+msgstr "Afficher l’agencement du clavier"
+
+#: panels/keyboard/cc-input-row.ui:51
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+msgid "Remove"
+msgstr "Supprimer"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Raccourcis personnalisés"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:62
+msgid "Alternate Characters Key"
+msgstr "Touche de caractères alternatifs"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"La touche des caractères alternatifs peut être utilisée pour saisir des "
+"caractères supplémentaires. Ceux-ci sont parfois affichés en tant que "
+"troisième option sur votre clavier."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt gauche"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt droit"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super gauche"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super droit"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Touche menu"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl droit"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:79
+msgid "Compose Key"
+msgstr "Touche de composition"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"La touche de composition permet de saisir une grande variété de caractères. "
+"Pour l’utiliser, maintenez-la enfoncée et appuyez sur <b>C</b> et <b>o</b> "
+"pour saisir <b>©</b>, ou <b>a</b> et <b>’</b> pour saisir <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Verr. Maj."
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Arrêt défil."
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Impr. écran"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Vous pouvez basculer d’une source de saise à une autre à l’aide du "
+"raccourcis clavier %s. Pour modifier ces raccourcis clavier, allez dans les "
+"préférences clavier"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Sources de saisie"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Comprend des agencements de clavier ou des méthodes d’entrée."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Basculement de la source de saisie"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Utiliser la _même source pour toutes les fenêtres"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Basculer les sources de saisie _individuellement pour chaque fenêtre"
+
+#: panels/keyboard/cc-keyboard-panel.ui:58
+msgid "Special Character Entry"
+msgstr "Saisie de caractères spéciaux"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Méthodes pour la saisie de symboles et de variantes de lettres à l’aide du "
+"clavier."
+
+#: panels/keyboard/cc-keyboard-panel.ui:97
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Raccourcis clavier"
+
+#: panels/keyboard/cc-keyboard-panel.ui:100
+msgid "View and Customize Shortcuts"
+msgstr "Voir et personnaliser les raccourcis"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modifié"
+msgstr[1] "%d modifiés"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
+msgid "Reset All Shortcuts?"
+msgstr "Réinitialiser tous les raccourcis ?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Réinitialiser tous les raccourcis peut aussi affecter vos raccourcis "
+"personnalisés. Cette action est irréversible."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Annuler"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
+msgid "Reset All"
+msgstr "Tout réinitialiser"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Tout réinitialiser…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Réinitialiser tous les raccourcis à leurs combinaisons par défaut"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+msgid "Add Custom Shortcuts"
+msgstr "Ajouter des raccourcis personnalisés"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Définissez des raccourcis personnalisés pour lancer des applications, "
+"exécuter des scripts, etc."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+msgid "Add Shortcut"
+msgstr "Ajouter un raccourci"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+msgid "No keyboard shortcut found"
+msgstr "Aucun raccourci clavier trouvé"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s est déjà utilisé pour %s. Si vous le remplacez, %s sera désactivé"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Saisir le nouveau raccourci"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Définir un raccourci personnalisé"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Définir un raccourci"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Saisissez un nouveau raccourci pour changer %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
+msgid "Add Custom Shortcut"
+msgstr "Ajouter un raccourci personnalisé"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Ajouter"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
+msgid "Replace"
+msgstr "Remplacer"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
+msgid "Set"
+msgstr "Définir"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Appuyer sur Échap pour annuler ou sur Retour arrière pour désactiver le "
+"raccourci clavier."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nom"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+msgid "Command"
+msgstr "Commande"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+msgid "Shortcut"
+msgstr "Raccourci"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+msgid "Set Shortcut…"
+msgstr "Définir un raccourci…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "Aucun"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Réinitialiser le raccourci à sa valeur par défaut"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Clavier"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Modifier les raccourcis clavier et définir vos préférences de saisie, "
+"dispositions de clavier et sources de saisie"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Raccourci;Espace de travail;Fenêtre;Redimensionner;Zoom;Contraste;Saisie;"
+"Source;Verrouiller;Volume;"
+
+#: panels/location/cc-location-panel.ui:20
+msgid "Location Services Turned Off"
+msgstr "Les services de localisation sont désactivés"
+
+#: panels/location/cc-location-panel.ui:21
+msgid "No applications can obtain location information."
+msgstr ""
+"Aucune application ne peut obtenir les informations liées à votre "
+"emplacement."
+
+#: panels/location/cc-location-panel.ui:35
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Les services de localisation autorisent les applications à connaître votre "
+"emplacement. Utiliser le Wi-Fi et les réseaux sans-fil améliore la "
+"précision.\n"
+"\n"
+"Utilise le service de localisation de Mozilla : <a href='https://location."
+"services.mozilla.com/privacy'>Politique de confidentialité</a>\n"
+"\n"
+"Autoriser les applications ci-dessous à accéder à votre emplacement."
+
+#: panels/location/cc-location-panel.ui:53
+msgid "No Applications Have Asked for Location Access"
+msgstr "Aucune application n’a demandé l’accès à votre emplacement"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Protéger les informations liées à votre emplacement"
+
+#. FIXME
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:62
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Extinction de l’écran"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:65
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 secondes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:68
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minute"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:71
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:74
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:77
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:80
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:83
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 heure"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:126
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minute"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:129
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:132
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:135
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:138
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:141
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:144
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:147
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:150
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:153
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Jamais"
+
+#: panels/lock/cc-lock-panel.ui:8
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Verrouiller automatiquement l’écran empêche quiconque d’accéder à votre "
+"ordinateur lorsque vous vous absentez."
+
+#: panels/lock/cc-lock-panel.ui:13
+msgid "Blank Screen Delay"
+msgstr "Délai de l’écran noir"
+
+#: panels/lock/cc-lock-panel.ui:14
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Période d’inactivité après laquelle l’écran s’éteint."
+
+#: panels/lock/cc-lock-panel.ui:32
+msgid "Automatic Screen _Lock"
+msgstr "_Verrouillage automatique de l’écran"
+
+#: panels/lock/cc-lock-panel.ui:46
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Délai du verrouillage automatique de l’écran"
+
+#: panels/lock/cc-lock-panel.ui:47
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Période après laquelle l’écran devient noir lorsque l’écran est "
+"automatiquement verrouillé."
+
+#: panels/lock/cc-lock-panel.ui:65
+msgid "Show _Notifications on Lock Screen"
+msgstr "Afficher les _notifications sur l’écran verrouillé"
+
+#: panels/lock/cc-lock-panel.ui:80
+msgid "Forbid new _USB devices"
+msgstr "Interdire les nouveaux périphériques _USB"
+
+#: panels/lock/cc-lock-panel.ui:81
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Empêche les nouveaux périphériques USB d’interagir avec le système tant que "
+"l’écran est verrouillé"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "Verrouillage de l’écran"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr "Verrouiller votre écran"
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:20
+msgid "Microphone Turned Off"
+msgstr "Microphone désactivé"
+
+#: panels/microphone/cc-microphone-panel.ui:21
+msgid "No applications can record sound."
+msgstr "Aucune application ne peut enregistrer du son."
+
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"L’utilisation du microphone permet aux applications d’enregistrer et "
+"d’écouter de l’audio. En le désactivant, il se peut que certaines "
+"applications ne fonctionnent pas correctement.\n"
+"\n"
+"Autoriser les applications ci-dessous à utiliser votre microphone."
+
+#: panels/microphone/cc-microphone-panel.ui:51
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Aucune application n’a demandé l’accès au micro"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Protégez vos conversations"
+
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Tester vos p_aramètres"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Général"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Bouton principal"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+"Définit l’ordre des boutons physiques sur les souris et pavés tactiles."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Gauche"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Droite"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Souris"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Vitesse de la souris"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
+msgid "Natural Scrolling"
+msgstr "Défilement naturel"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
+msgid "Scrolling moves the content, not the view."
+msgstr "Le défilement déplace le contenu, pas la vue."
+
+#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+msgid "Touchpad"
+msgstr "Pavé tactile"
+
+#: panels/mouse/cc-mouse-panel.ui:119
+msgid "Touchpad Speed"
+msgstr "Vitesse du pavé tactile"
+
+#: panels/mouse/cc-mouse-panel.ui:136
+msgid "Tap to Click"
+msgstr "Taper pour cliquer"
+
+#: panels/mouse/cc-mouse-panel.ui:147
+msgid "Two-finger Scrolling"
+msgstr "Défilement à deux doigts"
+
+#: panels/mouse/cc-mouse-panel.ui:159
+msgid "Edge Scrolling"
+msgstr "Défilement aux bords"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Essayez de cliquer, double-cliquer, faire défiler"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinq clics, l’époque GEGL !"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Double-clic, bouton principal"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Simple clic, bouton principal"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Double-clic, bouton du milieu"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Simple clic, bouton du milieu"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Double-clic, bouton secondaire"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Simple clic, bouton secondaire"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Sou­ris et pavé tac­tile"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Modifier la sensibilité du pavé tactile et choisir entre droitier ou gaucher"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Pavé;Tactile;Pointeur;Clic;Frappe;Double;Bouton;Boule;Défilement;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Coin actif"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+"Toucher le coin supérieur gauche pour ouvrir la vue d’ensemble des activités"
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Bords de l’écran _actifs"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Pousser les fenêtres contre les bords haut, gauche et droite pour les "
+"redimensionner."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Espace de travail"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "Espaces de travail _dynamiques"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Supprimer automatiquement les espaces de travail vides"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "Nombre d’espaces de travail _fixe"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Indiquez un nombre d’espaces de travail permanents"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Nombre d’espaces de travail"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multi-écran"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Espaces de travail sur l’écran _principal uniquement"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Espaces de travail sur _tous les écrans"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Bascule entre les applications"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Inclure les applications de tous les _espaces de travail"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Inclure les applications de l’espace de travail a_ctuel uniquement"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multi-tâches"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Gérer les préférences de productivité et du multi-tâches"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgstr "Multi-tâches;productivité;personnalisation;bureau;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Oups, quelque chose s’est mal passé. Veuillez contacter le fournisseur de "
+"votre logiciel."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager doit être en fonctionnement."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Autres périphériques"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
+#: panels/network/connection-editor/net-connection-editor.c:580
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:70
+msgid "Not set up"
+msgstr "Non configuré"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:207
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID : %s)"
+
+#: panels/network/cc-wifi-connection-row.c:263
+msgid "Insecure network (WEP)"
+msgstr "Réseau non sécurisé (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:267
+msgid "Secure network (WPA)"
+msgstr "Réseau sécurisé (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:271
+msgid "Secure network (WPA2)"
+msgstr "Réseau sécurisé (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Secure network (WPA3)"
+msgstr "Réseau sécurisé (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network"
+msgstr "Réseau sécurisé"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Connecté"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
+#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Options…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"L’activation du point d’accès entraînera une déconnexion de %s, et il ne "
+"sera pas possible d’accéder à Internet par Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Doit comporter au minimum 8 caractères"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Doit comporter au maximum %d caractère"
+msgstr[1] "Doit comporter au maximum %d caractères"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Allumer le point d’accès Wi-Fi ?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Le point d’accès Wi-Fi permet à d’autres personnes de partager votre "
+"connexion internet, en créant un réseau Wi-Fi auquel elles peuvent se "
+"connecter. Pour ce faire, vous devez disposer d’une connexion internet par "
+"une autre source que le Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nom du réseau"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:74
+#: panels/printers/new-printer-dialog.ui:331
+#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:362
+#: panels/wwan/cc-wwan-apn-dialog.ui:172
+msgid "Password"
+msgstr "Mot de passe"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:86
+msgid "Generate Random Password"
+msgstr "Générer un mot de passe aléatoire"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:87
+msgid "Autogenerate Password"
+msgstr "Générer un mot de passe automatiquement"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:129
+msgid "_Turn On"
+msgstr "A_llumer"
+
+#: panels/network/cc-wifi-panel.c:544
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:879
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Interrompre le point d’accès et déconnecter tous les utilisateurs ?"
+
+#: panels/network/cc-wifi-panel.c:882
+msgid "_Stop Hotspot"
+msgstr "_Interrompre le point d’accès"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Airplane Mode"
+msgstr "Mode avion"
+
+#: panels/network/cc-wifi-panel.ui:73
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+"Désactive le Wi-Fi, le Bluetooth et les connexions mobiles à large bande"
+
+#: panels/network/cc-wifi-panel.ui:110
+msgid "No Wi-Fi Adapter Found"
+msgstr "Aucun adaptateur Wi-Fi trouvé"
+
+#: panels/network/cc-wifi-panel.ui:120
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Assurez-vous d’avoir un adaptateur Wi-Fi branché et opérationnel"
+
+#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+msgid "Airplane Mode On"
+msgstr "Mode avion activé"
+
+#: panels/network/cc-wifi-panel.ui:162
+msgid "Turn off to use Wi-Fi"
+msgstr "Désactiver pour utiliser le Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:199
+msgid "Wi-Fi Hotspot Active"
+msgstr "Point d’accès Wi-Fi activé"
+
+#: panels/network/cc-wifi-panel.ui:209
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Les appareils mobiles peuvent scanner le code QR pour se connecter."
+
+#: panels/network/cc-wifi-panel.ui:217
+msgid "Turn Off Hotspot…"
+msgstr "_Éteindre le point d’accès Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:237
+msgid "Visible Networks"
+msgstr "Réseaux visibles"
+
+#: panels/network/cc-wifi-panel.ui:294
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager doit être en fonctionnement"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Sécurité 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sécurité"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Conserver"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Aléatoire"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stable"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"L’adresse MAC saisie ici sera utilisée comme adresse matérielle du "
+"périphérique réseau activé pour cette connexion. Cette fonctionnalité est "
+"appelée « MAC cloning » ou « spoofing ». Exemple : 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:101
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:107
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:112
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:119
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "Enterprise"
+msgstr "Entreprise"
+
+#: panels/network/connection-editor/ce-page-details.c:130
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Aucune"
+
+#: panels/network/connection-editor/ce-page-details.c:151
+msgid "Never"
+msgstr "Jamais"
+
+#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "Il y a %i jour"
+msgstr[1] "Il y a %i jours"
+
+#: panels/network/connection-editor/ce-page-details.c:293
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:295
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "2.4 GHz / 5 GHz"
+msgstr "2,4 GHz ou 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:312
+msgid "2.4 GHz"
+msgstr "2,4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Aucun"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Faible"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Correct"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bon"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excellent"
+
+#: panels/network/connection-editor/ce-page-details.c:409
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Adresse IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:410
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
+msgid "IPv6 Address"
+msgstr "Adresse IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:412
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adresse IP"
+
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:420
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
+#: panels/network/network-mobile.ui:217
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:473
+msgid "Forget Connection"
+msgstr "Oublier la connexion"
+
+#: panels/network/connection-editor/ce-page-details.c:475
+msgid "Remove Connection Profile"
+msgstr "Supprimer le profil de la connexion"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Remove VPN"
+msgstr "Supprimer le VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:495
+msgid "Details"
+msgstr "Détails"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatique"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identité"
+
+#: panels/network/connection-editor/ce-page-ip4.c:245
+#: panels/network/connection-editor/ce-page-ip6.c:226
+msgid "Delete Address"
+msgstr "Supprimer l’adresse"
+
+#: panels/network/connection-editor/ce-page-ip4.c:392
+#: panels/network/connection-editor/ce-page-ip6.c:361
+msgid "Delete Route"
+msgstr "Supprimer la route"
+
+#: panels/network/connection-editor/ce-page-ip4.c:742
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:712
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Aucune"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Clé WEP 40/128 bits (Hex ou ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Phrase de passe WEP 128 bits"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dynamique (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA et WPA2 privées"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA et WPA2 d’entreprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 privée"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Force du signal"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Vitesse de la connexion"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Adresse matérielle"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Fréquences prises en charge"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:189
+msgid "Default Route"
+msgstr "Route par défaut"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Dernière utilisation"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Connexion _automatique"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Rendre accessible aux autres _utilisateurs"
+
+#: panels/network/connection-editor/details-page.ui:412
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "Connexion avec _quota : limite les données ou peut engendrer des frais"
+
+#: panels/network/connection-editor/details-page.ui:421
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Les mises à jour logicielles et autres téléchargements importants ne seront "
+"pas démarrés automatiquement."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nom"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Adresse _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Adresse _clonée"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "octets"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Méthode IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatique (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Réseau local seulement"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+msgid "Manual"
+msgstr "Manuel"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Désactiver"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Partagée avec d’autres ordinateurs"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresses"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:255
+#: panels/printers/pp-details-dialog.ui:90
+msgid "Address"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:258
+msgid "Netmask"
+msgstr "Masque de réseau"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:279
+msgid "Gateway"
+msgstr "Passerelle"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:232
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automatique"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automatique"
+
+#: panels/network/connection-editor/ip4-page.ui:196
+#: panels/network/connection-editor/ip6-page.ui:205
+msgid "Separate IP addresses with commas"
+msgstr "Séparer les adresses IP avec des virgules"
+
+#: panels/network/connection-editor/ip4-page.ui:213
+#: panels/network/connection-editor/ip6-page.ui:222
+msgid "Routes"
+msgstr "Routes"
+
+#: panels/network/connection-editor/ip4-page.ui:231
+#: panels/network/connection-editor/ip6-page.ui:240
+msgid "Automatic Routes"
+msgstr "Routes automatiques"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:281
+#: panels/network/connection-editor/ip6-page.ui:290
+msgid "Metric"
+msgstr "Métrique"
+
+#: panels/network/connection-editor/ip4-page.ui:304
+#: panels/network/connection-editor/ip6-page.ui:313
+msgid "Use this connection _only for resources on its network"
+msgstr "N’utiliser cette connexion que pour les ressources sur ce réseau"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Méthode IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatique, DHCP seulement"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:267
+msgid "Prefix"
+msgstr "Préfixe"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Impossible d’ouvrir l’éditeur de connexions"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Nouveau profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:715
+msgid "Import from file…"
+msgstr "Importer depuis un fichier…"
+
+#: panels/network/connection-editor/net-connection-editor.c:741
+msgid "Add VPN"
+msgstr "Ajouter un VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Séc_urité"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Impossible d’importer la connexion VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Le fichier « %s » est illisible ou ne contient pas d’informations de "
+"connexion VPN reconnues\n"
+"\n"
+"Erreur : %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Sélectionner le fichier à importer"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Un fichier nommé « %s » existe déjà."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Remplacer"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+"Voulez-vous remplacer %s avec la connexion VPN en cours d’enregistrement ?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Impossible d’exporter la connexion VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"La connexion VPN « %s » n’a pas pu être exportée vers %s.\n"
+"\n"
+"Erreur : %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exportation de la connexion VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Erreur : impossible de charger l’éditeur de connexions VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Contrôler votre façon de vous connecter à Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Réseau;IP;LAN;Mandataire;WAN;Large bande;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Contrôler votre façon de vous connecter aux réseaux sans fil"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Réseau;Sans fil;Wi-Fi;Wifi;IP;LAN;Large bande;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "jamais"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "aujourd’hui"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "hier"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Dernière utilisation"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Filaire"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Ajouter une nouvelle connexion"
+
+#: panels/network/net-device-wifi.c:857
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Les informations des réseaux sélectionnés, y compris les mots de passe et "
+"toute configuration personnalisée seront perdus."
+
+#: panels/network/net-device-wifi.c:861
+msgid "_Forget"
+msgstr "_Oublier"
+
+#: panels/network/net-device-wifi.c:1041
+msgid "Known Wi-Fi Networks"
+msgstr "Réseaux Wi-Fi connus"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1073
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Oublier"
+
+#: panels/network/net-device-wifi.c:1216
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Les règles du système interdisent son utilisation comme point d’accès"
+
+#: panels/network/net-device-wifi.c:1219
+msgid "Wireless device does not support Hotspot mode"
+msgstr ""
+"Le périphérique sans fil ne prend pas en charge le mode « point d’accès »"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"« Web Proxy Autodiscovery » est utilisé lorsqu’aucune URL de configuration "
+"n’est fournie."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Cela n’est pas recommandé pour des réseaux publics non fiables."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Éteindre le périphérique"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Fournisseur"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+msgid "Network Proxy"
+msgstr "Serveur mandataire"
+
+#: panels/network/network-proxy.ui:139
+msgid "_HTTP Proxy"
+msgstr "Serveur mandataire _HTTP"
+
+#: panels/network/network-proxy.ui:156
+msgid "H_TTPS Proxy"
+msgstr "Serveur mandataire H_TTPS"
+
+#: panels/network/network-proxy.ui:173
+msgid "_FTP Proxy"
+msgstr "Serveur mandataire _FTP"
+
+#: panels/network/network-proxy.ui:190
+msgid "_Socks Host"
+msgstr "Hôte _Socks"
+
+#: panels/network/network-proxy.ui:207
+msgid "_Ignore Hosts"
+msgstr "_Ignorer les hôtes"
+
+#: panels/network/network-proxy.ui:244
+msgid "HTTP proxy port"
+msgstr "Port du serveur mandataire HTTP"
+
+#: panels/network/network-proxy.ui:307
+msgid "HTTPS proxy port"
+msgstr "Port du serveur mandataire HTTPS"
+
+#: panels/network/network-proxy.ui:322
+msgid "FTP proxy port"
+msgstr "Port du serveur mandataire FTP"
+
+#: panels/network/network-proxy.ui:337
+msgid "Socks proxy port"
+msgstr "Port du serveur mandataire Socks"
+
+#: panels/network/network-proxy.ui:357
+msgid "_Configuration URL"
+msgstr "URL de _configuration"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Fermer la connexion VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nom du réseau"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Type de sécurité"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Mot de passe"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Éteindre le Wi-Fi"
+
+#: panels/network/network-wifi.ui:121
+msgid "_Connect to Hidden Network…"
+msgstr "_Connexion à un réseau masqué…"
+
+#: panels/network/network-wifi.ui:128
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Allumer le point d’accès Wi-Fi…"
+
+#: panels/network/network-wifi.ui:135
+msgid "_Known Wi-Fi Networks"
+msgstr "Réseaux Wi-Fi _connus"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "État inconnu"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Non géré"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Indisponible"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Connexion en cours"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Authentification requise"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Déconnexion en cours"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Échec de la connexion"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "État inconnu (absent)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Échec de la configuration"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Échec de la configuration IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Configuration IP expirée"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Des éléments secrets, non fournis, étaient nécessaires"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Le client 802.1x s’est déconnecté"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "La configuration du client 802.1x a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Le client 802.1x a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Le client 802.1x a mis trop de temps pour s’authentifier"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Le service PPP n’a pas réussi à démarrer"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Service PPP déconnecté"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Le client DHCP n’a pas réussi à démarrer"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Erreur du client DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Le client DHCP a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Le service de connexion partagée n’a pas réussi à démarrer"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Le service de connexion partagée a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Le service autoIP n’a pas réussi à démarrer"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Erreur du service autoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Le service autoIP a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Ligne occupée"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Pas de tonalité"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Aucune porteuse n’a pu être établie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Délai de numérotation dépassé"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "La tentative de numérotation a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "L’initialisation du modem a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Échec de la sélection de l’APN spécifié"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Aucune recherche de réseau en cours"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Enregistrement au réseau refusé"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Délai dépassé pour l’enregistrement au réseau"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Échec de l’enregistrement au réseau demandé"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "La vérification du code PIN a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Il se peut que le micrologiciel du périphérique manque"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "La connexion a disparu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Une connexion existante a été supposée"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem non trouvé"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "La connexion Bluetooth a échoué"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "La carte SIM n’est pas insérée"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Le code PIN de la SIM est nécessaire"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Le code PUK de la SIM est requis"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Mauvaise SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "La dépendance de la connexion a échoué"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Micrologiciel absent"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Câble débranché"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "erreur de sécurité inconnue dans 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "aucun fichier sélectionné"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "erreur inconnue à la validation du fichier eap-method"
+
+#: panels/network/wireless-security/eap-method.c:389
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "Clés privées DER, PEM, ou PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:392
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "Certificats DER ou PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "fichier EAP-FAST PAC manquant"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Fichiers PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonyme"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Authentifié"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Les deux"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identité _masquée"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Fichier PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Choisir un fichier PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Authentification _interne"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Autoriser l’_obtention automatique de PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "nom d’utilisateur d’EAP-LEAP manquant"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "mot de passe d’EAP-LEAP manquant"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nom d’_utilisateur"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:175
+msgid "_Password"
+msgstr "Mot de _passe"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Affi_cher le mot de passe"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "certificat CA d’EAP-PEAP non valide : %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "certificat CA d’EAP-PEAP non valide : aucun certificat spécifié"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificat C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Choisir un certificat d’une autorité de certification"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Aucun certificat CA _requis"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Version PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "nom d’utilisateur EAP manquant"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "mot de passe EAP manquant"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "identité EAP-TLS manquante"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "certificat CA EAP-TLS non valide : %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TLS non valide : aucun certificat spécifié"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "clé privée EAP-TLS non valide : %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificat utilisateur EAP-TLS non valide : %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Les clés privées non chiffrées ne sont pas fiables"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"La clé privée sélectionnée ne semble pas être protégée par un mot de passe. "
+"Cela met en danger vos identifiants. Veuillez sélectionner une clé privée "
+"protégée par mot de passe.\n"
+"\n"
+"(Vous pouvez protéger votre clé par mot de passe avec openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Choisissez votre certificat personnel"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Choisissez votre clé privée"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentité"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificat _utilisateur"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Clé privée"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Mot de passe de la _clé privée"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "certificat CA EAP-TTLS non valide : %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TTLS non valide : aucun certificat spécifié"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domaine"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Erreur inconnue à la validation de la sécurité de 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS avec tunnel (TTLS)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP sécurisé (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_thentification"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Sélectionner un fichier"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "nom d’utilisateur leap manquant"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "mot de passe leap manquant"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Le mot de passe Wi-Fi est manquant."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Type"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "clé wep manquante"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"clé wep non valide : une clé de %zu ne doit contenir que des caractères "
+"hexadécimaux"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"clé wep non valide : une clé de %zu ne doit contenir que des caractères ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"clé wep non valide : longueur de clé %zu incorrecte. Elle doit être de 5 à "
+"13 caractères en ascii ou de 10 à 26 en hexa"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "clé wep non valide : phrase de passe non renseignée"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"clé wep non valide : la phrase de passe doit contenir moins de 64 caractères"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (par défaut)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Système ouvert"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Clé partagée"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Clé"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Afficher la clé"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Inde_x WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk non valide : longueur de clé %zu incorrecte. Doit être de [8,63] "
+"octets ou 64 caractères hexadécimaux"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk non valide : impossible de considérer une clé de 64 octets comme "
+"hexadécimale"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notifications"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alertes sonores"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Bannières de notifications"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Les notifications continuent à s’afficher dans la liste du tiroir lorsque "
+"l’affichage des bannières est désactivé."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Afficher le _contenu du message dans le tiroir des notifications"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notifications sur l’écran de _verrouillage"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Afficher le c_ontenu du message sur l’écran verrouillé"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Ne _pas déranger"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Notifications sur l’écran de _verrouillage"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Contrôler quelles notifications s’affichent et leur contenu"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Messages surgissants;Bannières;Message;Tiroir;Popup;"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:277
+#, c-format
+msgid "%s removed"
+msgstr "%s supprimé"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:406
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Autre"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "Erreur lors de la suppression du compte"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:51
+msgid "Undo"
+msgstr "Annuler"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:55
+msgid "Connect to your data in the cloud"
+msgstr "Connexion à vos données du nuage"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:66
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Aucune connexion internet — connectez-vous pour configurer de nouveaux "
+"comptes en ligne"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:93
+msgid "Add an account"
+msgstr "Ajouter un compte"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:426
+#, c-format
+msgid "%s Account"
+msgstr "Compte %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:429
+msgid "Remove Account"
+msgstr "Supprimer le compte"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Comptes en ligne"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Connectez-vous à vos comptes en ligne et décidez de leur utilité"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;En ligne;Discussion;Agenda;Courriel;Email;"
+"Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Durée inconnue"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minute"
+msgstr[1] "%i minutes"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i heure"
+msgstr[1] "%i heures"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "heure"
+msgstr[1] "heures"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minute"
+msgstr[1] "minutes"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s avant chargement complet"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Attention : il reste %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s restant"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Batterie pleine"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Pas en charge"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Déchargée"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "En charge"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "En décharge"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Souris sans fil"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Clavier sans fil"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Onduleur"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Assistant personnel"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Téléphone portable"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Lecteur multimédia"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablette"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Ordinateur"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Périphérique d’entrée pour jeux"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batterie"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principale"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Secondaire"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batteries"
+
+#: panels/power/cc-power-panel.c:511
+msgid "When _idle"
+msgstr "Quand _inactif"
+
+#: panels/power/cc-power-panel.c:671
+msgid "Suspend"
+msgstr "Mettre en veille"
+
+#: panels/power/cc-power-panel.c:672
+msgid "Power Off"
+msgstr "Éteindre"
+
+#: panels/power/cc-power-panel.c:673
+msgid "Hibernate"
+msgstr "Hiberner"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Nothing"
+msgstr "Rien"
+
+#: panels/power/cc-power-panel.c:730
+msgid "When on battery power"
+msgstr "Quand sur batterie"
+
+#: panels/power/cc-power-panel.c:732
+msgid "When plugged in"
+msgstr "Quand le câble est branché"
+
+#: panels/power/cc-power-panel.c:853
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Jamais"
+
+#: panels/power/cc-power-panel.c:937
+msgid "Automatic suspend"
+msgstr "Mise en veille automatique"
+
+#: panels/power/cc-power-panel.c:1030
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Le mode performance est temporairement désactivé en raison de la température."
+
+#: panels/power/cc-power-panel.c:1032
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Il semble que l’ordinateur soit posé sur vos genoux, le mode performance est "
+"temporairement indisponible. Posez l’appareil sur une surface stable pour le "
+"rétablir."
+
+#: panels/power/cc-power-panel.c:1034
+msgid "Performance mode temporarily disabled."
+msgstr "Mode performance temporairement indisponible"
+
+#: panels/power/cc-power-panel.c:1076
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Batterie faible : mode économie d’énergie activé. Le mode précédent sera "
+"rétabli quand le niveau de batterie sera suffisant."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1084
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Mode économie d’énergie activé par « %s »."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1088
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Mode performance activé par « %s »."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 heure"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 heures"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Mode d’énergie"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Affecte les performances du système et la consommation d’énergie."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Options d’économie d’énergie"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Luminosité de l’écran automatique"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "La luminosité de l’écran s’adapte à la luminosité ambiante."
+
+#: panels/power/cc-power-panel.ui:138
+msgid "Dim Screen"
+msgstr "Écran assombri"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Réduit la luminosité de l’écran quand l’ordinateur est inactif."
+
+#: panels/power/cc-power-panel.ui:150
+msgid "Screen _Blank"
+msgstr "Écran _noir"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Éteint l’écran après une période d’inactivité."
+
+#: panels/power/cc-power-panel.ui:159
+msgid "Automatic Power Saver"
+msgstr "Économie d’énergie automatique"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+"Activer le mode économie d’énergie quand le niveau de batterie est faible."
+
+#: panels/power/cc-power-panel.ui:173
+msgid "_Automatic Suspend"
+msgstr "Mise en veille _automatique"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Met l’ordinateur en pause après une période d’inactivité."
+
+#: panels/power/cc-power-panel.ui:199
+msgid "Po_wer Button Behavior"
+msgstr "Action du bouton d’e_xtinction"
+
+#: panels/power/cc-power-panel.ui:207
+msgid "Show Battery _Percentage"
+msgstr "Afficher le _pourcentage de batterie"
+
+#: panels/power/cc-power-panel.ui:243
+msgid "Automatic Suspend"
+msgstr "Mise en veille automatique"
+
+#: panels/power/cc-power-panel.ui:266
+msgid "_Plugged In"
+msgstr "_Câble branché"
+
+#: panels/power/cc-power-panel.ui:278
+msgid "On _Battery Power"
+msgstr "Sur _batterie"
+
+#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
+#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+msgid "Delay"
+msgstr "Délai"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Performance"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Performances élevées et forte consommation d’énergie."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Équilibré"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Performances et consommation d’énergie normales."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Économie d’énergie"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Performances et consommation d’énergie réduites."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Énergie"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"S’informer sur l’état de la batterie et modifier les paramètres d’économie "
+"d’énergie"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Énergie;Alimentation;Veille;Suspension;Hibernation;Batterie;Luminosité;"
+"Assombrir;Noir;Écran;DPMS;Inactif;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:676
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "L’imprimante « %s » a été supprimée"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:928
+msgid "Failed to add new printer."
+msgstr "L’ajout de la nouvelle imprimante a échoué."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1229
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Impossible de charger l’interface utilisateur : %s"
+
+#: panels/printers/cc-printers-panel.c:1297
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Déverrouiller pour ajouter des imprimantes et modifier les paramètres"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Imprimantes"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Ajouter des imprimantes, afficher les tâches et décider quand vous voulez "
+"imprimer"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Imprimante;File;Queue;Impression;Papier;Encre;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Ajouter une imprimante"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:100
+#: panels/printers/new-printer-dialog.ui:115
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Déverrouiller"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:194
+msgid "No Printers Found"
+msgstr "Aucune imprimante trouvée"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:244
+msgid "Enter a network address or search for a printer"
+msgstr "Saisissez l’adresse d’un réseau ou recherchez une imprimante"
+
+#: panels/printers/new-printer-dialog.ui:286
+msgid "Authentication Required"
+msgstr "Authentification requise"
+
+#: panels/printers/new-printer-dialog.ui:302
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Saisissez votre nom d’utilisateur et votre mot de passe pour afficher les "
+"imprimantes sur le serveur."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:311
+#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:148
+msgid "Username"
+msgstr "Nom d’utilisateur"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:365
+#, c-format
+msgid "%s Details"
+msgstr "Informations sur %s"
+
+#: panels/printers/pp-details-dialog.c:101
+msgid "No suitable driver found"
+msgstr "Aucun pilote adéquat trouvé"
+
+#: panels/printers/pp-details-dialog.c:260
+msgid "Select PPD File"
+msgstr "Sélectionnez un fichier PPD"
+
+#: panels/printers/pp-details-dialog.c:269
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Fichiers de description PostScript de l’imprimante (*.ppd, *.PPD, *.ppd.gz, "
+"*.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+msgid "Location"
+msgstr "Emplacement"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:115
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Pilote"
+
+#: panels/printers/pp-details-dialog.ui:154
+msgid "Searching for preferred drivers…"
+msgstr "Recherche des pilotes préférés…"
+
+#: panels/printers/pp-details-dialog.ui:173
+msgid "Search for Drivers"
+msgstr "Rechercher des pilotes"
+
+#: panels/printers/pp-details-dialog.ui:181
+msgid "Select from Database…"
+msgstr "Sélectionner à partir de la base de données…"
+
+#: panels/printers/pp-details-dialog.ui:189
+msgid "Install PPD File…"
+msgstr "Installer le fichier PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Sélectionner un pilote d’imprimante"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Chargement de la base de données des pilotes…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Sélectionner"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Imprimante JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Imprimante LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Recto"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Bord long (standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Bord court (retourné)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portrait"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Paysage"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Paysage inversé"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Portrait inversé"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:134
+msgctxt "print job"
+msgid "Pending"
+msgstr "En attente"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:140
+msgctxt "print job"
+msgid "Paused"
+msgstr "En pause"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:145
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Authentification requise"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "Traitement en cours"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Arrêtée"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Interrompue"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Annulée"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "Terminée"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:176
+msgid "Move this job to the top of the queue"
+msgstr "Déplacer cette tâche en haut de la file d’attente"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u tâche nécessite une authentification"
+msgstr[1] "%u tâches nécessitent une authentification"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - tâches d’impression actives"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+"Saisissez vos informations d’authentification pour imprimer à partir de %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domaine"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:100
+msgid "A_uthenticate"
+msgstr "A_uthentification"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:128
+msgid "Clear All"
+msgstr "Tout effacer"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:173
+msgid "_Authenticate"
+msgstr "_Authentification"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:214
+msgid "No Active Printer Jobs"
+msgstr "Aucune tâche d’impression active"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Déverrouiller le serveur d’imprimantes"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Déverrouiller %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Saisissez votre nom d’utilisateur et votre mot de passe pour afficher les "
+"imprimantes sur %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Recherche d’imprimantes"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Port série"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Port parallèle"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Emplacement : %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adresse : %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Le serveur nécessite une authentification"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Recto verso"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Type de papier"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Source du papier"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Bac de sortie"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Résolution"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Pré-filtrage GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Pages par côté"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Recto-verso"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientation"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Général"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Mise en page"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Options installables"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Tâche"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Qualité de l’image"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Couleur"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Finition"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avancé"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Page de test"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Page de test"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Sélection automatique"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Option par défaut de l’imprimante"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Incorporer seulement les polices GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Convertir en PS de niveau 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Convertir en PS de niveau 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Aucun pré-filtrage"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricant"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Aucune tâche d’impression active"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u tâche"
+msgstr[1] "%u tâches"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Nettoyage des têtes d’impression"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Toner pratiquement épuisé"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Plus de toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Révélateur pratiquement épuisé"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Plus de révélateur"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Cartouche de couleur pratiquement vide"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Cartouche de couleur vide"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Couvercle ouvert"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Porte ouverte"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Pratiquement plus de papier"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Plus de papier"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Hors ligne"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Arrêtée"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Récipient à déchets pratiquement plein"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Récipient à déchets plein"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Le photo-conducteur optique est pratiquement en fin de vie"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Le photo-conducteur optique n’est plus en état"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Prête"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "N’accepte plus de tâche supplémentaire"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Traitement en cours"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Options d’impression"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Informations sur l’imprimante"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Utiliser comme imprimante par défaut"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Nettoyer les têtes d’impression"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Supprimer l’imprimante"
+
+#: panels/printers/printer-entry.ui:187
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modèle"
+
+#: panels/printers/printer-entry.ui:242
+msgid "Ink Level"
+msgstr "Niveau d’encre"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:304
+msgid "Please restart when the problem is resolved."
+msgstr "Veuillez redémarrer après résolution du problème."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:310
+msgid "Restart"
+msgstr "Redémarrer"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10
+msgid "Add Printer…"
+msgstr "Ajouter une imprimante…"
+
+#: panels/printers/printers.ui:168
+msgid "No printers"
+msgstr "Aucune imprimante"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:179
+msgid "Add a Printer…"
+msgstr "Ajouter une imprimante…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:204
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Désolé ! Le service d’impression du système\n"
+"    ne semble pas être disponible."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formats"
+
+#: panels/region/cc-format-chooser.ui:37
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Précédent"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Rechercher des locales…"
+
+#: panels/region/cc-format-chooser.ui:113
+msgid "Common Formats"
+msgstr "Formats courants"
+
+#: panels/region/cc-format-chooser.ui:140
+msgid "All Formats"
+msgstr "Tous les formats"
+
+#: panels/region/cc-format-chooser.ui:188
+msgid "No Search Results"
+msgstr "Aucun résultat pour la recherche"
+
+#: panels/region/cc-format-chooser.ui:200
+msgid "Searches can be for countries or languages."
+msgstr "Les recherches peuvent porter sur des pays ou des langues."
+
+#: panels/region/cc-format-chooser.ui:236
+msgid "Preview"
+msgstr "Aperçu"
+
+#: panels/region/cc-format-preview.c:135
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Impérial"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Métrique"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Dates"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dates et heures"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Nombres"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mesure"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papier"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+"La langue et le format seront modifiés lors de votre prochaine connexion"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Déconnexion…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats is "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Le paramètre de langue est utilisé pour les interfaces textuelles et les "
+"pages web. Le format est utilisé pour les nombres, dates et monnaies."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Votre compte"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:299
+msgid "_Language"
+msgstr "_Langue"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formats"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Écran de connexion"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Pays et langue"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Sélectionnez la langue et les formats d’affichage"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Langue;Disposition;Agencement;Clavier;Saisie;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Demander que faire"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Ne rien faire"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Ouvrir le dossier"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Autres médias"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Sélectionnez une application pour vos CD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Sélectionnez une application pour vos DVD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Sélectionnez une application à lancer lorsqu’un baladeur est connecté"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+"Sélectionnez une application à lancer lorsqu’un appareil photo est connecté"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Sélectionnez une application pour les CD contenant des logiciels"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "disque Blu-ray vierge"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "disque CD vierge"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "disque DVD vierge"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "disque HD DVD vierge"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "disque vidéo Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "lecteur e-book"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "disque vidéo HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Vidéo CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "CD vidéo"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Logiciels Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Choisissez comment les médias doivent être gérés"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_CD audio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD vidéo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Baladeur"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Logiciels"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Autres médias…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Ne jamais demander ou lancer de programme à l’insertion de médias"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Choisissez comment les autres médias doivent être gérés"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Action :"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Type :"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Médias amovibles"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configurer les paramètres des médias amovibles"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"périphérique;système;par défaut;application;préférée;cd;dvd;usb;audio;vidéo;"
+"disque;amovible;média;exécution automatique;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Sélectionner un emplacement"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Valider"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Emplacements de la recherche"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Dossiers recherchés par les applications systèmes, tels que Fichiers, Photos "
+"et Vidéos."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Emplacements"
+
+#: panels/search/cc-search-locations-dialog.ui:33
+msgid "Bookmarks"
+msgstr "Signets"
+
+#: panels/search/cc-search-locations-dialog.ui:48
+msgid "Others"
+msgstr "Autres"
+
+#: panels/search/cc-search-locations-dialog.ui:55
+msgid "Add Location"
+msgstr "Ajouter un emplacement"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Aucune application trouvée"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Recherche d’applications"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Inclure les résultats de recherche fournis par les applications."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Dossiers recherchés par les applications système."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Résultats pour la recherche"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Les résultats sont affichés selon l’ordre de la liste."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Contrôler quelles applications affichent les résultats d’une recherche dans "
+"la vue d’ensemble des activités"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Rechercher;Recherche;Index;Masquer;Confidentialité;Privé;Résultats;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:265
+msgid "No networks selected for sharing"
+msgstr "Aucun réseau de partage n’est sélectionné"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Réseaux"
+
+#: panels/sharing/cc-sharing-panel.c:367
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Activé"
+
+#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Désactivé"
+
+#: panels/sharing/cc-sharing-panel.c:399
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Activé"
+
+#: panels/sharing/cc-sharing-panel.c:402
+msgctxt "service is active"
+msgid "Active"
+msgstr "Actif"
+
+#: panels/sharing/cc-sharing-panel.c:520
+msgid "Choose a Folder"
+msgstr "Choisir un dossier"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:748
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Le partage de fichiers vous permet de partager votre dossier Public avec les "
+"autres sur le réseau actuel en utilisant : %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:754
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Lorsque la connexion à distance est activée, tout utilisateur distant peut "
+"se connecter à l’aide de cette commande shell sécurisée :\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Partage"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Nom de l’_ordinateur"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Partage de _fichiers"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_Bureau distant"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Partage de _médias"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Connexion _distante"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Partage de fichiers"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Demander le mot de _passe"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Connexion distante"
+
+#: panels/sharing/cc-sharing-panel.ui:250
+#: panels/sharing/cc-sharing-panel.ui:267
+msgid "Remote Desktop"
+msgstr "Bureau distant"
+
+#: panels/sharing/cc-sharing-panel.ui:263
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Le bureau distant permet d’afficher et de contrôler votre bureau depuis un "
+"autre ordinateur."
+
+#: panels/sharing/cc-sharing-panel.ui:268
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Activer ou désactiver les connexions de bureau distantes à cet ordinateur."
+
+#: panels/sharing/cc-sharing-panel.ui:280
+msgid "Remote Control"
+msgstr "Contrôle à distance"
+
+#: panels/sharing/cc-sharing-panel.ui:281
+msgid "Allows remote connections to control the screen."
+msgstr "Autorise les connexions distantes à contrôler l’écran."
+
+#: panels/sharing/cc-sharing-panel.ui:294
+msgid "How to Connect"
+msgstr "Connexion"
+
+#: panels/sharing/cc-sharing-panel.ui:295
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Se connecter à cet ordinateur en utilisant le nom de l’appareil ou l’adresse "
+"du bureau distant."
+
+#: panels/sharing/cc-sharing-panel.ui:323
+msgid "Remote Desktop Address"
+msgstr "Adresse du bureau distant"
+
+#: panels/sharing/cc-sharing-panel.ui:350
+msgid "Authentication"
+msgstr "Authentification"
+
+#: panels/sharing/cc-sharing-panel.ui:351
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Le nom d’utilisateur et le mot de passe sont nécessaires pour se connecter à "
+"cet ordinateur."
+
+#: panels/sharing/cc-sharing-panel.ui:355
+msgid "User Name"
+msgstr "Nom d’utilisateur"
+
+#: panels/sharing/cc-sharing-panel.ui:401
+msgid "Verify Encryption"
+msgstr "Vérifier le chiffrement"
+
+#: panels/sharing/cc-sharing-panel.ui:430
+msgid "Encryption Fingerprint"
+msgstr "Empreinte cryptographique"
+
+#: panels/sharing/cc-sharing-panel.ui:431
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical"
+msgstr ""
+"L’empreinte cryptographique peut être vue par les clients qui se connectent "
+"et doit être identique"
+
+#: panels/sharing/cc-sharing-panel.ui:463
+msgid "Media Sharing"
+msgstr "Partage de médias"
+
+#: panels/sharing/cc-sharing-panel.ui:485
+msgid "Share music, photos and videos over the network."
+msgstr "Partager de la musique, des photos et des vidéos sur le réseau."
+
+#: panels/sharing/cc-sharing-panel.ui:498
+msgid "Folders"
+msgstr "Dossiers"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Contrôler ce que vous souhaitez partager avec les autres"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"partage;partager;ssh;hôte;nom;distant;bureau;média;audio;vidéo;images;photos;"
+"film,serveur;moteur de rendu;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Activer ou désactiver une connexion distante"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Authentification requise pour activer ou désactiver une connexion distante"
+
+#: panels/sound/cc-alert-chooser.c:150
+msgid "Custom"
+msgstr "Personnalisée"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr "Aboiement"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "Drip"
+msgstr "Goutte d’eau"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Glass"
+msgstr "Verre"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Sonar"
+msgstr "Sonar"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "Arrière"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "Avant"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Test de %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Cliquez sur un haut-parleur à tester"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volume système"
+
+#: panels/sound/cc-sound-panel.ui:25
+msgid "Volume Levels"
+msgstr "Niveaux de volume"
+
+#: panels/sound/cc-sound-panel.ui:35
+msgid "Output"
+msgstr "Sortie"
+
+#: panels/sound/cc-sound-panel.ui:56
+msgid "Output Device"
+msgstr "Périphérique de sortie"
+
+#: panels/sound/cc-sound-panel.ui:75
+msgid "Test"
+msgstr "Test"
+
+#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+msgid "Configuration"
+msgstr "Configuration"
+
+#: panels/sound/cc-sound-panel.ui:135
+msgid "Balance"
+msgstr "Balance"
+
+#: panels/sound/cc-sound-panel.ui:161
+msgid "Fade"
+msgstr "Fondu"
+
+#: panels/sound/cc-sound-panel.ui:187
+msgid "Subwoofer"
+msgstr "Caisson de basse"
+
+#: panels/sound/cc-sound-panel.ui:205
+msgid "Input"
+msgstr "Entrée"
+
+#: panels/sound/cc-sound-panel.ui:226
+msgid "Input Device"
+msgstr "Périphérique d’entrée"
+
+#: panels/sound/cc-sound-panel.ui:294
+msgid "Volume"
+msgstr "Volume"
+
+#: panels/sound/cc-sound-panel.ui:312
+msgid "Alert Sound"
+msgstr "Son d’alerte"
+
+#: panels/sound/cc-volume-slider.c:117
+msgctxt "volume"
+msgid "100%"
+msgstr "100 %"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Son"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Modifier les volumes sonores, les saisies, les sorties et les alertes sonores"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Carte;Microphone;Volume;Fondu;Balance;Bluetooth;Casque;Audio;Entrée;Sortie;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Déconnecté"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Connexion en cours"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Connecté"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Erreur d’autorisation"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autorisation en cours"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Fonctionnalité réduite"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Connecté et autorisé"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Inconnu"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autorisé depuis :"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Connecté depuis :"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Inscrit depuis :"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Échec de l’autorisation du périphérique : "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Échec de l’oubli du périphérique : "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Dépend de %u autre périphérique"
+msgstr[1] "Dépend de %u autres périphériques"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+msgid "Name:"
+msgstr "Nom :"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+msgid "Status:"
+msgstr "État :"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "UUID:"
+msgstr "UUID :"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+msgid "Authorize and Connect"
+msgstr "Autorisation et connexion"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+msgid "Forget Device"
+msgstr "Oublier le périphérique"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Erreur"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorisé"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Le sous-système Thunderbolt (boltd) n’est pas installé ou est mal configuré."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:157
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Autoriser l’accès direct aux périphériques tels que les stations d’accueil "
+"et processeurs graphiques externes."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Seuls les périphériques USB et Display Port peuvent être connectés."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt n’a pas pu être détecté.\n"
+"Soit le système ne prend pas en charge Thunderbolt, soit il a été désactivé "
+"dans le BIOS, soit il est paramétré sur un niveau de sécurité non pris en "
+"charge dans le BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "La prise en charge de Thunderbolt a été désactivée dans le BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Le niveau de sécurité Thunderbolt n’a pas pu être déterminé."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Erreur de bascule en mode direct : %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "No Thunderbolt Support"
+msgstr "Aucune prise en charge de Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:104
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Impossible de se connecter au sous-système thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:153
+msgid "Direct Access"
+msgstr "Accès direct"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:225
+msgid "Pending Devices"
+msgstr "Périphériques en attente"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:319
+msgid "No devices attached"
+msgstr "Aucun périphérique connecté"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Gérer les périphériques Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;vie privée;confidentialité;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Clignotement du curseur"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+msgid "Cursor blinks in text fields."
+msgstr "Le curseur clignote dans les champs texte."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
+#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+msgid "Speed"
+msgstr "Vitesse"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+msgid "Cursor blinking speed"
+msgstr "Vitesse de clignotement du curseur"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Taille du curseur"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"La taille du curseur peut-être associée au zoom pour faciliter sa visibilité."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Assistant de clic"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulation du clic secondaire"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+"Déclencher un clic secondaire en maintenant enfoncé le bouton principal"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Délai d’a_cceptation :"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Court"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Délai du clic secondaire"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Clic par s_urvol"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Déclencher un clic en survolant avec le pointeur"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Dé_lai :"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Court"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Seuil de _déplacement :"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Petit"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grand"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Touches de répétition"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+msgid "Key presses repeat when key is held down."
+msgstr "Répétition lorsqu’une touche est maintenue enfoncée."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+msgid "Repeat keys delay"
+msgstr "Délai de répétition des touches"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+msgid "Repeat keys speed"
+msgstr "Vitesse de répétition des touches"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Assistant de saisie"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Touches _rémanentes"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Traiter la frappe d’une suite de touches modificatrices comme une "
+"combinaison de celles-ci"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Désactiver si deux touches sont enfoncées simultanément"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Émettre un bip lorsqu’une touche _modificatrice est enfoncée"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Touches _lentes"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introduire un délai entre l’appui sur une touche et son acceptation"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Court"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Délai de saisie des touches lentes"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Émettre un bip lorsqu’une touche est _enfoncée"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Émettre un bip quand une touche est _acceptée"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Émettre un bip quand une touche est _rejetée"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Rebonds de touches"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorer les appuis de touches rapides et identiques"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Court"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Délai de saisie des rebonds de touches"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:326
+msgid "_Enable by Keyboard"
+msgstr "_Activer au clavier"
+
+#: panels/universal-access/cc-typing-dialog.ui:336
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Activer et désactiver les fonctionnalités d’accessibilité à partir du clavier"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Par défaut"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Moyen"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Grand"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Plus grand"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Le plus grand"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixels"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Toujours afficher le menu Accès universel"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Vision"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Contraste é_levé"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Grand texte"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Activer les a_nimations"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Lecteur d’écran"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Le lecteur d’écran lit le texte affiché au fur et à mesure que vous déplacez "
+"le focus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Touches _son"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Émet un bip lors d’un appui sur les touches Verr. Num. ou Verr. Maj."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Taille du c_urseur"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audition"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Alertes _visuelles"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Cla_vier visuel"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Touches de répétition"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Clignotement du curseur"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Assistant de _saisie (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Pointage et clic de souris"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Touches de la s_ouris"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Localiser le pointeur"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Assistant de _clic"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Délai du double-clic"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Délai du double-clic"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alertes visuelles"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Test rapide"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Utiliser une indication visuelle quand une alerte sonore intervient."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Faire clignoter tout l’é_cran"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Faire clignoter toute la _fenêtre"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Courte"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ d’écran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ écran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ d’écran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Longue"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Plein écran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Moitié supérieure"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Moitié inférieure"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Moitié gauche"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Moitié droite"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Options du zoom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "A_grandissement :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Position de la loupe :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Suit le curseur de la souris"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Partie d’écran :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "La loupe s’étend en _dehors de l’écran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Garde le curseur de la loupe _centré"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Le curseur de la loupe écar_te le contenu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Le curseur de la loupe suit le _contenu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Loupe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Pointeurs en _croix :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Recouvre le curseur de la souris"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "É_paisseur :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Fine"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Épaisse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Largeur :"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Cou_leur :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Pointeurs en croix"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Effets de couleur :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Blanc sur noir :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Luminosité :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contraste :"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Cou_leur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Aucune"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Pleine"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Faible"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Élevée"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Faible"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Élevé"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Effets de couleur"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Faciliter la vision, l’écoute, la saisie, la sélection et le clic"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Clavier;Souris;lien;Accessibilité;Contraste;Curseur;Son;Zoom;Lecteur d’écran;"
+"grand;haut;élevé;texte;police;taille;AccessX;Rémanentes;Touches;Lentes;"
+"Rebonds;Souris;Double;clic;Délai;Vitesse;Assistance;Répétition;Clignotement;"
+"visuel;écoute;audio;frappe;animations;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 heure"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 jour"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 jours"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 jours"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 jours"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 jours"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 jours"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 jours"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 jours"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 jours"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Vider complètement la corbeille ?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Tout le contenu de la corbeille sera définitivement supprimé."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Vider la corbeille"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Supprimer tous les fichiers temporaires ?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Tous les fichiers temporaires seront définitivement supprimés."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Purger les fichiers temporaires"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 jour"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 jours"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 jours"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Toujours"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Historique des fichiers"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"L’historique des fichiers garde la trace des fichiers que vous avez "
+"consultés. Cette information est partagée entre les applications et "
+"simplifie la recherche de fichiers que vous pourriez vouloir utiliser."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "H_istorique des fichiers"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Durée de l’historique des fichiers"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Effac_er l’historique…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Corbeille et fichiers temporaires"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"La corbeille et les fichiers temporaires peuvent parfois contenir des "
+"informations personnelles ou sensibles. Les supprimer automatiquement peut "
+"aider à protéger votre vie privée."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Supprimer automatiquement le contenu de la _corbeille"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Supprimer automatiquement les _fichiers temporaires"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Périodicité de suppression automatique"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Vider la corbeille…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Supprimer les fichiers temporaires…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Historique des fichiers et corbeille"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Ne laisser aucune trace"
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Doit correspondre à l’adresse web de votre fournisseur d’accès."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "L’ajout du compte a échoué"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.c:260
+msgid "The passwords do not match."
+msgstr "Les mots de passe ne concordent pas."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "L’enregistrement du compte a échoué"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Impossible de s’authentifier auprès de ce domaine"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Impossible de joindre ce domaine"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Cet identifiant de connexion ne fonctionne pas.\n"
+"Veuillez réessayer."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ce mot de passe de connexion ne fonctionne pas.\n"
+"Veuillez réessayer."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "La connexion à ce domaine a échoué"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Impossible de trouver ce domaine. Vérifiez son orthographe."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Ajouter un utilisateur"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrateur"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Les administrateurs peuvent ajouter ou supprimer d’autres utilisateurs et "
+"peuvent modifier les paramètres de tous les utilisateurs. Les contrôles "
+"parentaux ne peuvent s’appliquer aux administrateurs."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "L’utilisateur définit son mot de passe lors de la première connexion"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Définir un mot de passe maintenant"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirmer"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Compte d’entreprise"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organisation."
+msgstr ""
+"Les comptes des utilisateurs sont gérés par une entreprise ou une "
+"organisation."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:385
+msgid "You are Offline"
+msgstr "Vous êtes hors ligne"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:386
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Un compte d’entreprise autorise l’usage d’un compte utilisateur centralisé à "
+"partir de ce périphérique. Il permet aussi d’accéder aux différents sites de "
+"la compagnie présents sur Internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Rechercher d’autres images"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Sélectionner un fichier…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Gestionnaire d’empreintes digitales"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Empreinte digitale"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+msgid "_No"
+msgstr "_Non"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+msgid "_Yes"
+msgstr "_Oui"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Souhaitez-vous supprimer les empreintes digitales enregistrées et désactiver "
+"ainsi ce type de connexion ?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+msgid "No fingerprint device"
+msgstr "Pas de lecteur d’empreintes"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+msgid "No Fingerprint device"
+msgstr "Pas de lecteur d’empreintes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+msgid "Ensure the device is properly connected."
+msgstr "Assurez-vous que le périphérique est branché correctement"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+msgid "Fingerprint Device"
+msgstr "Lecteur d’empreintes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Sélectionner le lecteur d’empreintes que vous souhaitez configurer"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+msgid "Fingerprint Login"
+msgstr "Connexion par reconnaissance d’empreintes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"La connexion par reconnaissance d’empreintes vous permet de déverrouiller et "
+"vous connecter à votre ordinateur avec un doigt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+msgid "_Delete Fingerprints"
+msgstr "_Supprimer les empreintes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+msgid "Fingerprint Enroll"
+msgstr "Apprentissage d’une empreinte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "l’appareil doit être sollicité pour effectuer cette action"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "l’appareil est déjà sollicité par un autre processus"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "vous ne disposez pas des permissions pour effectuer cette action"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "aucune empreinte enregistrée"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Échec de communication avec l’appareil lors de l’apprentissage"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Échec de communication avec le lecteur d’empreintes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Échec de communication avec le démon d’empreintes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Échec de chargement de la liste des empreintes : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Échec de suppression des empreintes enregistrées : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Pouce gauche"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Majeur gauche"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "Index _gauche"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Annulaire gauche"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Auriculaire gauche"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Pouce droit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Majeur droit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Index _droit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Annulaire droit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Auriculaire droit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Doigt inconnu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Terminé"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Lecteur d’empreintes déconnecté"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "L’espace de stockage du lecteur d’empreintes est saturé"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "L’apprentissage de la nouvelle empreinte a échoué"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "L’apprentissage n’a pas pu démarrer : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "L’apprentissage de la nouvelle empreinte a échoué"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "L’arrêt de l’apprentissage de l’empreinte a échoué : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Positionnez et glissez votre doigt sur le lecteur d’empreintes plusieurs "
+"fois pour l’apprentissage de votre empreinte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Recommencer l’apprentissage pour ce doigt"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Enregistrer une nouvelle empreinte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Impossible de libérer le lecteur d’empreintes %s : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problème lors de la lecture de l’appareil"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr ""
+"Échec lors de la tentative de récupération du lecteur d’empreintes %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Échec lors de la récupération du lecteur d’empreintes : %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Cette semaine"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "La semaine dernière"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:712
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:716
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Fin de session"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Début de session"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "Activité du compte de %s"
+
+#: panels/user-accounts/cc-password-dialog.c:133
+msgid "Please choose another password."
+msgstr "Veuillez choisir un autre mot de passe."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Please type your current password again."
+msgstr "Veuillez saisir à nouveau votre mot de passe actuel."
+
+#: panels/user-accounts/cc-password-dialog.c:148
+msgid "Password could not be changed"
+msgstr "Le mot de passe ne peut pas être modifié"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Modifier le mot de passe"
+
+#: panels/user-accounts/cc-password-dialog.ui:32
+msgid "Ch_ange"
+msgstr "_Modifier"
+
+#: panels/user-accounts/cc-password-dialog.ui:51
+msgid "Current Password"
+msgstr "Mot de passe actuel"
+
+#: panels/user-accounts/cc-password-dialog.ui:76
+msgid "New Password"
+msgstr "Nouveau mot de passe"
+
+#: panels/user-accounts/cc-password-dialog.ui:121
+msgid "Confirm Password"
+msgstr "Confirmer le mot de passe"
+
+#: panels/user-accounts/cc-password-dialog.ui:175
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Autoriser l’utilisateur à changer son mot de passe à la prochaine connexion"
+
+#: panels/user-accounts/cc-password-dialog.ui:186
+msgid "Set a password now"
+msgstr "Définir un mot de passe maintenant"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Impossible de rejoindre ce type de domaine automatiquement"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Aucun domaine trouvé"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Impossible de se connecter en tant que %s au domaine %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Mot de passe non valide, essayez à nouveau"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Connexion au domaine %s impossible : %s"
+
+#: panels/user-accounts/cc-user-panel.c:341
+msgid "Failed to delete user"
+msgstr "La suppression de l’utilisateur a échoué"
+
+#: panels/user-accounts/cc-user-panel.c:398
+#: panels/user-accounts/cc-user-panel.c:453
+#: panels/user-accounts/cc-user-panel.c:499
+msgid "Failed to revoke remotely managed user"
+msgstr "La révocation de l’utilisateur géré à distance a échoué"
+
+#: panels/user-accounts/cc-user-panel.c:548
+msgid "You cannot delete your own account."
+msgstr "Vous ne pouvez pas supprimer votre propre compte."
+
+#: panels/user-accounts/cc-user-panel.c:557
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s est encore connecté"
+
+#: panels/user-accounts/cc-user-panel.c:561
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Supprimer un utilisateur alors qu’il est connecté peut laisser le système "
+"dans un état instable."
+
+#: panels/user-accounts/cc-user-panel.c:570
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Voulez-vous conserver les fichiers de %s ?"
+
+#: panels/user-accounts/cc-user-panel.c:574
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Il est possible de conserver le répertoire personnel, les courriers "
+"électroniques en attente (le « spool ») et les fichiers temporaires d’un "
+"compte utilisateur lors de sa suppression."
+
+#: panels/user-accounts/cc-user-panel.c:577
+msgid "_Delete Files"
+msgstr "_Supprimer les fichiers"
+
+#: panels/user-accounts/cc-user-panel.c:578
+msgid "_Keep Files"
+msgstr "_Conserver les fichiers"
+
+#: panels/user-accounts/cc-user-panel.c:592
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Voulez-vous vraiment révoquer le compte distant de %s ?"
+
+#: panels/user-accounts/cc-user-panel.c:596
+msgid "_Delete"
+msgstr "_Supprimer"
+
+#: panels/user-accounts/cc-user-panel.c:646
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Compte désactivé"
+
+#: panels/user-accounts/cc-user-panel.c:654
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "À définir lors de la prochaine connexion"
+
+#: panels/user-accounts/cc-user-panel.c:657
+msgctxt "Password mode"
+msgid "None"
+msgstr "Aucun"
+
+#: panels/user-accounts/cc-user-panel.c:700
+msgid "Logged in"
+msgstr "Connecté"
+
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:787
+#: panels/user-accounts/cc-user-panel.c:876
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Activé"
+
+#: panels/user-accounts/cc-user-panel.c:1173
+msgid "Failed to contact the accounts service"
+msgstr "La connexion au service des comptes a échoué"
+
+#: panels/user-accounts/cc-user-panel.c:1175
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Veuillez vérifier que AccountService est installé et activé."
+
+#: panels/user-accounts/cc-user-panel.c:1197
+msgid "This panel must be unlocked to change this setting"
+msgstr "Ce panneau doit être déverrouillé pour modifier ce paramètre"
+
+#: panels/user-accounts/cc-user-panel.c:1264
+msgid "Delete the selected user account"
+msgstr "Supprimer le compte utilisateur sélectionné"
+
+#: panels/user-accounts/cc-user-panel.c:1268
+#: panels/user-accounts/cc-user-panel.c:1377
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Pour supprimer le compte utilisateur sélectionné,\n"
+"cliquez d’abord sur l’icône *"
+
+#: panels/user-accounts/cc-user-panel.c:1423
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Déverrouiller pour ajouter des utilisateurs et modifier les paramètres"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Utilisateurs"
+
+#: panels/user-accounts/cc-user-panel.ui:60
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+"Vous devez redémarrer la session pour que les changements soient pris en "
+"compte"
+
+#: panels/user-accounts/cc-user-panel.ui:67
+msgid "Restart Now"
+msgstr "Redémarrer maintenant"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:195
+msgid "_Fingerprint Login"
+msgstr "Connexion par _reconnaissance d’empreintes"
+
+#: panels/user-accounts/cc-user-panel.ui:218
+msgid "A_utomatic Login"
+msgstr "Connexion a_utomatique"
+
+#: panels/user-accounts/cc-user-panel.ui:231
+msgid "Account Activity"
+msgstr "Activité du compte"
+
+#: panels/user-accounts/cc-user-panel.ui:259
+msgid "_Administrator"
+msgstr "_Administrateur"
+
+#: panels/user-accounts/cc-user-panel.ui:260
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Les administrateurs peuvent ajouter ou supprimer d’autres utilisateurs et "
+"peuvent modifier les paramètres de tous les utilisateurs."
+
+#: panels/user-accounts/cc-user-panel.ui:276
+msgid "_Parental Controls"
+msgstr "Contrôle _parental"
+
+#: panels/user-accounts/cc-user-panel.ui:277
+msgid "Open the Parental Controls application."
+msgstr "Ouvre l’application des contrôles parentaux."
+
+#: panels/user-accounts/cc-user-panel.ui:328
+msgid "Remove User…"
+msgstr "Supprimer l’utilisateur…"
+
+#: panels/user-accounts/cc-user-panel.ui:340
+msgid "Other Users"
+msgstr "Autres utilisateurs"
+
+#: panels/user-accounts/cc-user-panel.ui:353
+msgid "Add User…"
+msgstr "Ajouter un utilisateur…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:381
+msgid "No Users Found"
+msgstr "Aucun utilisateur trouvé"
+
+#: panels/user-accounts/cc-user-panel.ui:390
+msgid "Unlock to add a user account."
+msgstr "Déverrouillez pour créer un compte utilisateur."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Ajouter ou supprimer des utilisateurs et modifier votre mot de passe"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"connexion;nom;empreinte digitale;avatar;logo;visage;mot de passe;contrôle "
+"parental;durée d’utilisation de l’écran;restrictions des applications;"
+"restriction du web;utilisation;limitation de l’utilisation;enfant;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Inscrire"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Identifiant de l’administrateur du domaine"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Pour utiliser des identifiants d’entreprise, cet ordinateur doit\n"
+"être inscrit au domaine. Veuillez demander à votre administrateur\n"
+"réseau de saisir son mot de passe du domaine ici."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nom de l’administrateur"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Mot de passe de l’administrateur"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Gérer les comptes utilisateur"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Authentification requise pour modifier les données utilisateur"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Le nouveau mot de passe doit être différent de l’ancien."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Essayez de changer quelques lettres et chiffres."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Essayez de modifier un peu plus le mot de passe."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr ""
+"Un mot de passe ne contenant pas votre nom d’utilisateur serait plus fort."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Essayez de ne pas incorporer votre patronyme dans le mot de passe."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Essayez d’éviter certains mots contenus dans le mot de passe."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Essayez d’éviter des mots usuels."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Essayez d’éviter de réarranger les mots existants."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Essayez d’utiliser plus de chiffres."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Essayez d’utiliser davantage de lettres majuscules."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Essayez d’utiliser davantage de lettres minuscules."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+"Essayez d’utiliser plus de caractères spéciaux, comme les ponctuations."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+"Essayez d’utiliser un mélange de lettres, de chiffres et de ponctuations."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Essayez d’éviter la répétition du même caractère."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Essayez d’éviter la répétition du même caractère : vous devez mélanger des "
+"lettres, des chiffres et des ponctuations."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Essayez d’éviter des séquences telles que 1234 ou abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Le mot de passe doit être plus long. Essayez d’ajouter des lettres, des "
+"chiffres et des ponctuations."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Mélangez des majuscules, des minuscules et aussi un ou deux nombres."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"L’ajout de lettres, de chiffres et de ponctuations renforcera le mot de "
+"passe."
+
+#: panels/user-accounts/run-passwd.c:413
+msgid "Authentication failed"
+msgstr "Échec d’authentification"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The new password is too short"
+msgstr "Le nouveau mot de passe est trop court"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password is too simple"
+msgstr "Le nouveau mot de passe est trop simple"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "L’ancien et le nouveau mot de passe sont trop ressemblants"
+
+#: panels/user-accounts/run-passwd.c:507
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Le nouveau mot de passe a déjà été utilisé récemment."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+"Le nouveau mot de passe doit contenir des caractères spéciaux ou numériques"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "L’ancien et le nouveau mot de passe sont identiques"
+
+#: panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+"Votre mot de passe a été modifié depuis que vous vous êtes authentifié !"
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr ""
+"Le nouveau mot de passe ne comporte pas suffisamment de caractères différents"
+
+#: panels/user-accounts/run-passwd.c:526
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Erreur inconnue"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Un nom d’utilisateur ne contient en principe que des lettres minuscules ou "
+"majuscules de a à z et l’un de ces caractères : - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Désolé, ce nom d’utilisateur n’est pas disponible. Veuillez en choisir un "
+"autre."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Le nom d’utilisateur est trop long."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+msgid "Map Buttons"
+msgstr "Associer les boutons"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Associer les boutons aux fonctions"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Pour modifier un raccourci, choisissez l’action « Send Keystroke », appuyez "
+"sur le bouton du raccourci clavier et tenez enfoncées les nouvelles touches. "
+"Sinon, appuyez sur la touche Retour arrière pour annuler."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Fermer"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Veuillez taper sur les cibles lorsqu’elles apparaissent à l’écran pour "
+"étalonner la tablette."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Mauvais clic détecté, redémarrage…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Bouton %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Défini par l’application"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Envoyer les appuis sur les touches"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Inverser l’écran"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Afficher l’aide à l’écran"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "La tablette est montée sur le panneau de l’ordinateur portable"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "La tablette est montée sur un écran externe"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Tablette externe"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Tous les éc­rans"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Mode tablette"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Utiliser le positionnement absolu pour le stylet"
+
+#: panels/wacom/cc-wacom-page.ui:27
+msgid "Left Hand Orientation"
+msgstr "Orientation pour gaucher"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+"La tablette et les Express Keys™ sont positionnées pour une utilisation de "
+"la main gauche"
+
+#: panels/wacom/cc-wacom-page.ui:56
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Associer à l’écran"
+
+#: panels/wacom/cc-wacom-page.ui:62
+msgid "Keep Aspect Ratio"
+msgstr "Conserver le rapport d’affichage"
+
+#: panels/wacom/cc-wacom-page.ui:63
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Utiliser seulement une partie de la surface de la tablette pour conserver le "
+"rapport d’affichage de l’écran"
+
+#: panels/wacom/cc-wacom-page.ui:73
+msgid "Calibrate"
+msgstr "Étalonner"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Aucune tablette détectée"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Veuillez connecter ou allumer votre tablette Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Pression ressentie sur la pointe"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pression sur la pointe du stylet"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Bouton 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Bouton 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Bouton 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Pression ressentie sur la gomme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Douce"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pression sur la gomme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Ferme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Par défaut"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Clic du bouton central de la souris"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Clic du bouton droit de la souris"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "En avant"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Stylet aérographe avec pression, inclinaison et curseur intégré"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Stylet aérographe avec pression, inclinaison et rotation"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Stylet standard avec pression et inclinaison"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Stylet standard avec pression"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tablette Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Associer les boutons et ajuster la sensibilité du stylet des tablettes "
+"graphiques"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablette;Wacom;Stylet;Gomme;Souris;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Nouveau raccourci…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Points d’accès"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:122
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Opération annulée"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Erreur :</b> accès refusé au changement des paramètres"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Erreur :</b> erreur de l’équipement mobile"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Non enregistré"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Enregistré"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Itinérance"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Recherche"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Refusé"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Détails du modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "État du modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Opérateur"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Type du réseau"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "État du réseau"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Numéro de la ligne"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Informations sur l’appareil"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Version du micrologiciel"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G uniquement"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G uniquement"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G uniquement"
+
+#: panels/wwan/cc-wwan-device.c:1003
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (préférée)"
+
+#: panels/wwan/cc-wwan-device.c:1005
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (préférée), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (préférée), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (préférée)"
+
+#: panels/wwan/cc-wwan-device.c:1017
+msgid "3G (Preferred), 4G"
+msgstr "3G (préférée), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1019
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1025
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (préférée)"
+
+#: panels/wwan/cc-wwan-device.c:1027
+msgid "2G (Preferred), 4G"
+msgstr "2G (préférée), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1029
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (préférée)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "2G (Preferred), 3G"
+msgstr "2G (préférée), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1043
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Déverrouiller la carte SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Déverrouiller"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Veuillez fournir un code PIN pour la SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Saisissez le PIN pour déverrouiller la carte SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Veuillez fournir le code PUK pour la SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Saisissez le PUK pour déverrouiller la carte SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Mot de passe saisi incorrect. Il vous reste %1$u essai"
+msgstr[1] "Mot de passe saisi incorrect. Il vous reste %1$u essais"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Il vous reste %u essai"
+msgstr[1] "Il vous reste %u essais"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Mauvais mot de passe saisi."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Le code PUK devrait être un nombre à 8 chiffres"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Saisir le nouveau PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Le code PIN devrait être un nombre de 4 à 8 chiffres"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Déverrouillage…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Pas de SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Insérer une carte SIM pour utiliser ce modem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM verrouillée"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "Données _mobiles"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Accéder aux données via le réseau mobile"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "Itinérance des _données"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Utiliser les données mobiles en itinérance"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Mode du _réseau"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "Ré_seau"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avancé"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Noms du point d’_accès"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Verrouillage de la _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Verrouiller la SIM avec un PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Informations sur le m_odem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Échec du téléphone"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Aucune connexion au téléphone"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Opération non autorisée"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Opération non prise en charge"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "La SIM n’est pas insérée"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Le code PIN de la SIM est nécessaire"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Le code PUK de la SIM est nécessaire"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Échec de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM occupée"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Mot de passe incorrect"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Le code PIN2 de la SIM est nécessaire"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Le code PUK2 de la SIM est nécessaire"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Introuvable"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Aucun service réseau"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Délai d’attente du réseau dépassé"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Le service GPRS n’est pas autorisé"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "L’itinérance n’est pas autorisée dans cette zone"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Erreur GPRS non précisée"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "Action Cancelled"
+msgstr "Action interrompue"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Access denied"
+msgstr "Accès refusé"
+
+#: panels/wwan/cc-wwan-errors-private.h:103
+msgid "Unknown Error"
+msgstr "Erreur inconnue"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Mode du réseau"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:146
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Définir"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
+msgid "Close"
+msgstr "Fermer"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:69
+msgid "_Automatic"
+msgstr "_Automatique"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:84
+msgid "Choose Network"
+msgstr "Sélectionner un réseau"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:99
+msgid "Refresh Network Providers"
+msgstr "Actualiser les fournisseurs d’accès"
+
+#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Activer le réseau mobile"
+
+#: panels/wwan/cc-wwan-panel.ui:94
+msgid "No WWAN Adapter Found"
+msgstr "Aucun adaptateur WWAN trouvé"
+
+#: panels/wwan/cc-wwan-panel.ui:104
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Assurez-vous d’avoir un périphérique réseau cellulaire sans fil"
+
+#: panels/wwan/cc-wwan-panel.ui:145
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+"Le réseau cellulaire sans fil est désactivé lorsque le mode avion est activé"
+
+#: panels/wwan/cc-wwan-panel.ui:153
+msgid "_Turn off Airplane Mode"
+msgstr "_Désactiver le mode avion"
+
+#: panels/wwan/cc-wwan-panel.ui:184
+msgid "Data Connection"
+msgstr "Connexion de données"
+
+#: panels/wwan/cc-wwan-panel.ui:185
+msgid "SIM card used for internet"
+msgstr "Carte SIM utilisée pour l’accès à Internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Verrouillage de la SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Suivant"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+msgid "_Lock SIM with PIN"
+msgstr "_Verrouiller la SIM avec le PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+msgid "Change PIN"
+msgstr "Modifier le PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+"Saisir le PIN actuel pour modifier les paramètres de verrouillage de la SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Réseau mobile"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configurer la téléphonie et les connexions de données mobiles"
+
+#. FIXME
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellulaire;wwan;téléphonie;sim;mobile;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilitaire pour configurer l’environnement GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Paramètres est l’interface principale de configuration du système."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Le projet GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Afficher le numéro de version"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Activer le mode verbeux"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Rechercher la chaîne"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Liste les noms possibles de volets et quitte"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Volet à afficher"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Confidentialité"
+
+#: shell/cc-panel-loader.c:301
+msgid "Available panels:"
+msgstr "Volets disponibles :"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Tous les paramètres"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menu principal"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Avertissement : version de développement"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Cette version de Paramètres ne devrait être utilisée qu’à des fins de "
+"développement. Vous pourriez rencontrer des comportements incorrects du "
+"système, des pertes de données et d’autres problèmes inattendus. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Aide"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Général"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Quitter"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Rechercher"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panneaux"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Retourner au panneau précédent"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Interrompre la recherche"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Préférences;Paramètres;Réglages;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "L’identifiant du dernier panneau de paramètres à ouvrir"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"L’identifiant du dernier panneau de paramètres à ouvrir. Les valeurs non "
+"reconnues seront ignorées et le premier panneau de la liste sera sélectionné."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Afficher un avertissement lors de l’utilisation d’une version de "
+"développement de Paramètres"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Indique si Paramètres doit afficher un avertissement lors de l’utilisation "
+"d’une version de développement."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "État initial de la fenêtre"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Un tuple contenant l’état initial de la largeur, la hauteur ainsi que l’état "
+"maximisé de la fenêtre de l’application."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u sortie"
+msgstr[1] "%u sorties"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrée"
+msgstr[1] "%u entrées"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sons système"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Panneau de son des paramètres GNOME"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Panneau de souris et pavé tactile des paramètres GNOME"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Panneau d’arrière-plan des paramètres GNOME"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Panneau de clavier des paramètres GNOME"
+
+#~ msgid "Web Links"
+#~ msgstr "Liens Web"
+
+#~ msgid "Git Links"
+#~ msgstr "Liens Git"
+
+#~ msgid "%s Links"
+#~ msgstr "Liens %s"
+
+#~ msgid "Unset"
+#~ msgstr "Enlever"
+
+#~ msgid "Links"
+#~ msgstr "Liens"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Fichiers hypertexte"
+
+#~ msgid "Text Files"
+#~ msgstr "Fichiers texte"
+
+#~ msgid "Image Files"
+#~ msgstr "Fichiers image"
+
+#~ msgid "Font Files"
+#~ msgstr "Fichiers de polices"
+
+#~ msgid "Archive Files"
+#~ msgstr "Fichiers d’archives"
+
+#~ msgid "Package Files"
+#~ msgstr "Fichiers de paquets"
+
+#~ msgid "Audio Files"
+#~ msgstr "Fichiers audio"
+
+#~ msgid "Video Files"
+#~ msgstr "Fichiers vidéo"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permissions et accès"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Données et services auxquels cette application souhaite accéder et "
+#~ "permissions que cela implique."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Non modifiable"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Les permissions spécifiques aux applications peuvent être examinées dans "
+#~ "les réglages de <a href=\"privacy\">Confidentialité</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Intégration"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Définir l’arrière-plan de bureau"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Gestionnaires par défaut"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Types de fichiers et liens que cette application ouvre."
+
+#~ msgid "Usage"
+#~ msgstr "Utilisation"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Quantité de ressources utilisées par cette application."
+
+#~ msgid "Open in Software"
+#~ msgstr "Ouvrir dans Logiciels"
+
+#~ msgid "Activities"
+#~ msgstr "Activités"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Autoriser les applications ci-dessous à utiliser votre caméra."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Échec de chargement du fichier : %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Le profil a été chargé dans :"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Saisissez cette URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Redémarrez cet ordinateur et lancez votre système d’exploitation habituel."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Saisissez cette URL dans votre navigateur pour télécharger et installer "
+#~ "le profil."
+
+#~ msgid "Upload profile"
+#~ msgstr "Téléverser le profil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Nécessite une connexion Internet"
+
+#~ msgid "_Copy"
+#~ msgstr "_Copier"
+
+#~ msgid "Select _All"
+#~ msgstr "Sélectionner _tout"
+
+#~ msgid "Single Display"
+#~ msgstr "Écran unique"
+
+#~ msgid "Join Displays"
+#~ msgstr "Joindre les écrans"
+
+#~ msgid "Display Mode"
+#~ msgstr "Mode d’affichage"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Faites glisser les écrans pour correspondre à votre configuration réelle. "
+#~ "Sélectionnez un écran pour modifier ses réglages."
+
+#~ msgid "Active Display"
+#~ msgstr "Écran actif"
+
+#~ msgid "Display Configuration"
+#~ msgstr "Configuration des écrans"
+
+#~ msgid "More Warm"
+#~ msgstr "Plus chaude"
+
+#~ msgid "Less Warm"
+#~ msgstr "Moins chaude"
+
+#~ msgid "Screenshots"
+#~ msgstr "Captures d’écran"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Enregistrer une capture d’écran dans $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Enregistrer la capture d’écran d’une fenêtre dans $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Enregistrer la capture d’une partie de l’écran dans $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copier une capture d’écran dans le presse-papiers"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copier la capture d’écran d’une fenêtre dans le presse-papiers"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copier la capture d’une partie de l’écran dans le presse-papiers"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Enregistrer une courte capture vidéo"
+
+#~ msgid "Move up"
+#~ msgstr "Remonter"
+
+#~ msgid "Move down"
+#~ msgstr "Descendre"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Les services de localisation permettent aux applications de connaître "
+#~ "votre emplacement. Utiliser le Wi-Fi et le réseau mobile permet "
+#~ "d’augmenter la précision."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Utilise le service de localisation de Mozilla : <a href='https://location."
+#~ "services.mozilla.com/privacy'>Politique de confidentialité</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr ""
+#~ "Autoriser les applications ci-dessous à déterminer votre emplacement."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Autoriser les applications ci-dessous à utiliser votre micro."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Délai du double-clic"
+
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Bouton de mise en veille et extinction"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Portable détecté : mode performance indisponible"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Température matérielle élevée : mode performance indisponible"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Mode performance indisponible"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Authentification"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Choisir le format des nombres, dates et monnaies. Le changement prendra "
+#~ "effet à la prochaine connexion."
+
+#~ msgid "My Account"
+#~ msgstr "Mon compte"
+
+#~ msgid "Language"
+#~ msgstr "Langue"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "La langue utilisée pour le texte des fenêtres et des pages Web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr ""
+#~ "Redémarrer la session pour que les changements soient pris en compte"
+
+#~ msgid "Restart…"
+#~ msgstr "Redémarrer…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Les paramètres de connexion sont utilisés par tous les utilisateurs pour "
+#~ "accéder au système"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Contrôler quels résultats de recherche sont affichés dans l’aperçu des "
+#~ "activités. L’ordre des résultats de recherche peut aussi être modifié en "
+#~ "déplaçant les lignes dans la liste."
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Le partage d’écran permet aux utilisateurs distants de voir ou contrôler "
+#~ "votre écran en se connectant à %s"
+
+#~ msgid "Copy"
+#~ msgstr "Copier"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Partage d’é_cran"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Certains services sont désactivés faute d’accès au réseau."
+
+#~ msgid "Screen Sharing"
+#~ msgstr "Partage d’écran"
+
+#~ msgid "_Password:"
+#~ msgstr "Mot de _passe :"
+
+#~ msgid "_Show Password"
+#~ msgstr "A_fficher le mot de passe"
+
+#~ msgid "Access Options"
+#~ msgstr "Options d’accès"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Les _nouveaux connectés doivent demander l’autorisation d’accès"
+
+#~ msgid "_Require a password"
+#~ msgstr "Demande_r un mot de passe"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Touches son"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Lecteur d’écran"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Lecteur d’écran"
+
+#~ msgid "_Full Name"
+#~ msgstr "_Nom complet"
+
+#~ msgid "Standard"
+#~ msgstr "Normal"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Type de compte"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Autoriser l’utilisateur à définir un mot de passe à la prochaine "
+#~ "conne_xion"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Définir un mot de passe _maintenant"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "Vous devez être en ligne pour ajouter des utilisateurs de l’entreprise."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Prendre une photo…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pour effectuer les modifications,\n"
+#~ "cliquez d’abord sur l’icône *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Créer un compte utilisateur"
+
+#~ msgid "User Icon"
+#~ msgstr "Icône utilisateur"
+
+#~ msgid "Account Settings"
+#~ msgstr "Paramètres du compte"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Authentification et connexion"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Ceci est utilisé pour nommer votre dossier personnel et ne peut être "
+#~ "modifié."
+
+#~ msgid "Output:"
+#~ msgstr "Sortie :"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Associer à un seul écran"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d sur %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Afficher la correspondance"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablette (absolu)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Pavé tactile (relatif)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Préférences de la tablette"
+
+#~ msgid "_Help"
+#~ msgstr "Aid_e"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Paramètres du Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Mode de recherche"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Associer les boutons…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Ajuster les paramètres de la souris"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Ajuster la définition de l’écran"
+
+#~ msgid "No stylus found"
+#~ msgstr "Aucun stylet trouvé"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Veuillez placer votre stylet sur les cibles du bord de la tablette pour "
+#~ "la configurer"
+
+#~ msgid "Top Button"
+#~ msgstr "Bouton supérieur"
+
+#~ msgid "Lower Button"
+#~ msgstr "Bouton inférieur"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Bouton le plus bas"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Déverrouiller…"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Raccourci clavier"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr ""
+#~ "Une modification est possible dans la section « Personnaliser les "
+#~ "raccourcis »"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr ""
+#~ "Maintenez la touche enfoncée et tapez pour saisir des caractères "
+#~ "différents"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Luminosité de l’é_cran"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Luminosité du _clavier"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Assombrir l’écran si inactif"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "Écran _noir"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Le Wi-Fi peut être éteint pour économiser de l’énergie."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Les périphériques mobiles à large bande (LTE, 4G, 3G, etc.) peuvent être "
+#~ "éteints pour économiser de l’énergie."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Le Bluetooth peut être éteint pour économiser de l’énergie."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Énergie équilibrée"
+
+#~ msgid "Add…"
+#~ msgstr "Ajouter…"
+
+#~ msgid "Left Alt"
+#~ msgstr "Alt gauche"
+
+#~ msgid "Right Alt"
+#~ msgstr "Alt droit"
+
+#~ msgid "Left Super"
+#~ msgstr "Super gauche"
+
+#~ msgid "Right Super"
+#~ msgstr "Super droit"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl droit"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Touche de caractères alternatifs"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr ""
+#~ "Avec les touches de modification seules, basculer vers la source suivante"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Touche menu"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "En charge"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Attention"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Faible"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Bonne"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Pleine charge"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Déchargée"
+
+#~ msgid "Previous source"
+#~ msgstr "Source précédente"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Logo+Maj+Barre d’espace"
+
+#~ msgid "Next source"
+#~ msgstr "Source suivante"
+
+#~ msgid "Super+Space"
+#~ msgstr "Logo+Barre d’espace"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt de droite+Alt de gauche"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Ajouter des comptes utilisateurs et modifier des mots de passe"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Émettre et enregistrer des sons"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr ""
+#~ "Détecter des périphériques réseau à l’aide de mDNS ou DNS-SD (Bonjour ou "
+#~ "zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Accéder directement au matériel Bluetooth"
+
+#~ msgid "Use your camera"
+#~ msgstr "Utiliser la caméra"
+
+#~ msgid "Print documents"
+#~ msgstr "Imprimer des documents"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Utiliser toute manette de jeu connectée"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Autoriser la connexion au service Docker"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Configurer le pare-feu du réseau"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Configurer et utiliser des systèmes de fichiers FUSE privilégiés"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Mettre à jour le micrologiciel de ce périphérique"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Accéder aux informations liées au matériel"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr ""
+#~ "Fournir de l’entropie pour le générateur matériel de nombres aléatoires"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Utiliser des nombres aléatoires générés par le matériel"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Accéder aux fichiers de votre dossier personnel"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Accéder au service libvirt"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Modifier la langue du système et les paramètres régionaux"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Modifier les paramètres et les fournisseurs de localisation"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Lire les journaux du système et des applications"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "Accéder au service media-hub"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Utiliser et configurer les modems"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Lire les informations de montages système et les quotas des disques"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Contrôler les lecteurs de musique et de vidéos"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Modifier les paramètres bas niveau du réseau"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Accéder au service NetworkManager pour lire et modifier les paramètres du "
+#~ "réseau"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Lire les paramètres du réseau"
+
+#~ msgid "Change network settings"
+#~ msgstr "Modifier les paramètres du réseau"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Accéder au service ofono pour lire et modifier les paramètres du réseau "
+#~ "pour la téléphonie mobile"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Contrôler le matériel Open vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Lire depuis le CD ou le DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Lire, ajouter, modifier ou supprimer des mots de passe enregistrés"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Accéder aux périphériques pppd et ppp pour configurer les connexions du "
+#~ "protocole point à point"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Mettre en pause ou terminer n’importe quel processus du système"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Accéder directement au matériel USB"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Lire ou écrire des fichiers sur les supports de stockage amovibles"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Empêcher la veille ou le verrouillage de l’écran"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Accéder au matériel du port série"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Redémarrer ou éteindre le périphérique"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Installer, supprimer et configurer des logiciels"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Accéder au service d’infrastructure de stockage"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Lire les informations des processus et du système"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Surveiller et contrôler les programmes en cours"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Modifier les paramètres du serveur de temps"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Modifier le fuseau horaire"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Accéder au service UDisks2 pour configurer les disques et les médias "
+#~ "amovibles"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr ""
+#~ "Lire et modifier les évènements d’agendas partagés dans Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Lire et modifier les contacts partagés dans Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Accéder aux données d’utilisation de l’énergie"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Lire et écrire dans les périphériques U2F exposés"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Accès universel"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Éteindre pour se connecter à un réseau Wi-Fi"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Mot de passe"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pour créer un compte utilisateur,\n"
+#~ "cliquez d’abord sur l’icône *"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Activer l’identification de connexion par empreinte digitale"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Autre doigt :"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "L’enregistrement de votre empreinte digitale a réussi. Vous devriez "
+#~ "maintenant pouvoir vous identifier à l’aide du lecteur d’empreintes "
+#~ "digitales."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Vous n’avez pas accès au périphérique. Contactez votre administrateur "
+#~ "système."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Une erreur interne est survenue."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Supprimer les empreintes enregistrées ?"
+
+#~ msgid "Done!"
+#~ msgstr "Terminé !"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Impossible d’accéder au périphérique « %s »"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr ""
+#~ "Impossible de démarrer la capture d’empreintes avec le périphérique « %s »"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Aucun lecteur d’empreintes digitales n’est accessible"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Contactez votre administrateur système pour assistance."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Pour activer l’authentification par empreintes digitales, vous devez "
+#~ "enregistrer une de vos empreintes à l’aide du périphérique « %s »."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Sélection du doigt"
+
+#~ msgid "Network proxy"
+#~ msgstr "Serveur mandataire"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Paire torsadée (PT)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Interface de raccordement (AUI)"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Interface de connexion MII"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Afficher le mot de p_asse"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Mettre à disposition des autres utilisateurs"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adresses"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Adresses automatiques (DHCP) seulement"
+
+#~ msgid "Link-local only"
+#~ msgstr "Connexion locale uniquement"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignorer les routes obtenues automatiquement"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Adresse MAC _clonée"
+
+#~ msgid "_Reset"
+#~ msgstr "_Réinitialiser"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Réinitialiser les paramètres de cette connexion à leurs valeurs par "
+#~ "défaut, mais se souvenir qu’elle est une connexion préférée."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Supprimer toutes les informations relatives à ce réseau et ne pas essayer "
+#~ "de s’y connecter automatiquement."
+
+#~ msgid "Hardware"
+#~ msgstr "Matériel"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Réinitialiser"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Périphériques connectés"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastructure"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Bannières de notifications"
+
+#~ msgid "In use"
+#~ msgstr "En cours d’utilisation"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Activé"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Désactivé"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Désactivé"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Activé"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Désactivé"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Activé"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Politique de confidentialité"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "L’enregistrement de votre historique permet de retrouver les choses plus "
+#~ "facilement. Ces éléments ne sont jamais partagés sur le réseau."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Récemment utilisés"
+
+#~ msgid "Retain _History"
+#~ msgstr "Conserver l’_historique"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Le verrouillage de l’écran protège votre vie privée lorsque vous vous "
+#~ "éloignez."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Verrouiller l’écran lorsqu’il a été in_actif pendant"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Notifications sur l’écran de verrouillage"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Vider automatiquement la corbeille et les fichiers temporaires pour ne "
+#~ "pas conserver des informations sensibles sur votre ordinateur."
+
+#~ msgid "Purge _After"
+#~ msgstr "Purger _après"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "L’envoi d’information sur l’usage des logiciels nous aide à vous fournir "
+#~ "des recommandations plus précises et à améliorer nos logiciels.\n"
+#~ "\n"
+#~ "Toutes les informations que nous récoltons sont anonymisés, et nous ne "
+#~ "partagerons jamais vos données avec un tiers."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "Envoyer les _statistiques d’utilisation du logiciel"
+
+#~ msgid "_Camera"
+#~ msgstr "_Caméra"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Micro"
+
+#~ msgid "_Location Services"
+#~ msgstr "Services de _localisation"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Protéger vos informations personnelles et contrôler ce que d’autres "
+#~ "peuvent voir"
+
+#~ msgid "No regions found"
+#~ msgstr "Aucune région trouvée"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Faire clignoter la _barre de titre"
+
+#~ msgid "Last Login"
+#~ msgstr "Dernière connexion"
+
+#~ msgid "_Background"
+#~ msgstr "Arrière-_plan"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Évolue au cours de la journée"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Mosaïque"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centré"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Redimensionné"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Rempli"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Étendu"
+
+#~ msgid "Colors"
+#~ msgstr "Couleurs"
+
+#~ msgid "Pictures"
+#~ msgstr "Images"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Aucune image trouvée"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Vous pouvez ajouter des images dans votre dossier %s où elles "
+#~ "s’afficheront"
+
+#~ msgid "_Off"
+#~ msgstr "_Désactivé"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "Mise en veille _automatique"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Lorsque le bouton d’extinction est enfoncé"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Le nom d’utilisateur ne peut pas débuter par « - »."

--- a/po/fur.po
+++ b/po/fur.po
@@ -7,10 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-06-03 08:18+0000\n"
-"PO-Revision-Date: 2022-06-03 10:19+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-09-28 07:19+0200\n"
 "Last-Translator: Fabio Tomat <f.t.public@gmail.com>\n"
 "Language-Team: Friulian <f.t.public@gmail.com>\n"
 "Language: fur\n"
@@ -19,102 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Editor: HaiPO 1.0 Release\n"
-"X-Generator: Poedit 3.0.1\n"
-
-#: panels/applications/cc-applications-panel.c:790
-msgid "System Bus"
-msgstr "Bus di sisteme"
-
-#: panels/applications/cc-applications-panel.c:790
-#: panels/applications/cc-applications-panel.c:792
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:810
-msgid "Full access"
-msgstr "Acès complet"
-
-#: panels/applications/cc-applications-panel.c:792
-msgid "Session Bus"
-msgstr "Bus di session"
-
-#: panels/applications/cc-applications-panel.c:796
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Dispositîfs"
-
-#: panels/applications/cc-applications-panel.c:796
-msgid "Full access to /dev"
-msgstr "Acès complet a /dev"
-
-#: panels/applications/cc-applications-panel.c:800
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Rêt"
-
-#: panels/applications/cc-applications-panel.c:800
-msgid "Has network access"
-msgstr "Al à acès ae rêt"
-
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:807
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Cjase"
-
-#: panels/applications/cc-applications-panel.c:807
-#: panels/applications/cc-applications-panel.c:812
-msgid "Read-only"
-msgstr "Dome leture"
-
-#: panels/applications/cc-applications-panel.c:810
-#: panels/applications/cc-applications-panel.c:812
-msgid "File System"
-msgstr "File System"
-
-#: panels/applications/cc-applications-panel.c:816
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Impostazions"
-
-#: panels/applications/cc-applications-panel.c:816
-msgid "Can change settings"
-msgstr "Al pues cambiâ lis impostazions"
-
-#: panels/applications/cc-applications-panel.c:818
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s al à i permès integrâts chi daurman e no si puedin modificâ. Se chest ti "
-"preocupe, considere la opzion di gjavâ cheste aplicazion."
-
-#: panels/applications/cc-applications-panel.c:1154
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u gjenar di file e colegament che al ven viert de aplicazion"
-msgstr[1] "%u gjenars di file e colegaments che a vegnin vierts de aplicazion"
-
-#: panels/applications/cc-applications-panel.c:1161
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> al ven doprât par vierzi chescj gjenars di files e colegaments."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1213
-#, c-format
-msgid "%s of disk space used"
-msgstr "%s di spazi disc doprâts"
+"X-Generator: Poedit 3.1.1\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1377
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -130,7 +36,6 @@ msgid "Install some…"
 msgstr "Instale alc…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Vierç"
 
@@ -143,6 +48,7 @@ msgstr "Mostre detais"
 #: panels/keyboard/01-launchers.xml.in:16
 #: panels/keyboard/cc-input-chooser.ui:75
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
 #: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
@@ -153,24 +59,13 @@ msgstr "Cîr"
 msgid "Receive system searches and send results."
 msgstr "Ricevi ricercjis di sisteme e inviâ risultâts."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1900
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Disativât"
 
@@ -184,7 +79,7 @@ msgid "Show system notifications."
 msgstr "Mostrâ notifichis di sisteme."
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+msgid "Run in Background"
 msgstr "Eseguìs in sotfont"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -192,135 +87,143 @@ msgid "Allow activity when the app is closed."
 msgstr "Permeti la ativitât cuant che la aplicazion e je sierade."
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Schermadis"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Fâ videadis dal schermi in cualsisei moment."
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "Cambiâ fonts"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "Cambiâ il fondâl dal scritori."
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Suns"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "Riprodusi suns."
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
-msgstr "Inibî lis scurtis "
+msgstr "Inibî lis scurtis"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "Blocâ lis scurtis di tastiere standard."
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "Fotocjamare"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "Fâ fotos cu la fotocjamare."
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "Microfon"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "Regjistrâ audio cul microfon."
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Servizis su la posizion"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "Acedi ai dâts di posizion dal dispositîf."
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "Permès integrâts"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "Acès di sisteme necessari par cheste aplicazion"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "Associazions di files e colegaments"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Archiviazion"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Nissun risultât cjatât"
 
-#: panels/applications/cc-applications-panel.ui:304
+#: panels/applications/cc-applications-panel.ui:311
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
-#: shell/cc-panel-list.ui:114
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Prove une ricercje diferente"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "Associazions di files e colegaments"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "Gjenars di file"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "Gjenars di colegament"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Reset"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Trop spazi disc che cheste aplicazion e sta ocupant cun dâts de aplicazion e "
 "cache."
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Aplicazion"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Dâts"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Cache"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Totâl</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Nete cache…"
 
@@ -328,81 +231,22 @@ msgstr "Nete cache…"
 msgid "Control various application permissions and settings"
 msgstr "Controle i permès e lis impostazions des varis aplicazions"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplicazion;flatpak;permès;impostazion;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Selezione un imagjin"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:209
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:237
-msgid "_Cancel"
-msgstr "_Anule"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Vierç"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "dimensions multiplis"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Nissun fonts pe scrivanie"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Fonts atuâl"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stîl"
 
 #: panels/background/cc-background-panel.ui:49
-msgid "Light"
-msgstr "Clâr"
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Predefinît"
 
 #: panels/background/cc-background-panel.ui:79
 msgid "Dark"
@@ -424,7 +268,6 @@ msgstr "Aspiet"
 msgid "Change your background image or the UI colors"
 msgstr "Cambie la imagjin di fonts o i colôrs de interface utent"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -436,6 +279,8 @@ msgstr ""
 #: panels/diagnostics/cc-diagnostics-panel.ui:18
 #: panels/display/cc-night-light-page.ui:122
 #: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
 msgid "Enable"
 msgstr "Abilite"
 
@@ -475,9 +320,7 @@ msgstr "La modalitât avion hardware e je impiade"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Distude il cric de modalitât Avion par abilitâ il Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -485,7 +328,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Impie e distude il Bluetooth e conet i tiei dispositîfs"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "condividi;condivision;bluetooth;obex;"
@@ -518,96 +360,35 @@ msgstr "Nissune aplicazion e à domandât di doprâ la fotocjamare"
 msgid "Protect your pictures"
 msgstr "Protêç lis tôs imagjins"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "fotocjamare;fotos;video;webcam;videocjamare;bloche;privât;riservatece;"
 "privacy;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Place il tô dispositîf di calibrazion parsore dal cuadrât e sclice «Start»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Sposte il tô dispositîf di calibrazion su la posizion di calibradure e "
-"frache «Continue»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Sposte il tô dispositîf di calibrazion inte posizion di superficie e sclice "
-"«Continue»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Siere il tapon (visôr) dal portatil"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Al è vignût fûr un erôr interni impussibil di recuperâ."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "I struments necessaris pe calibradure no son instalâts."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Impussibil gjenerâ il profîl."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Impussibil vê il pont blanc prefissât."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Completât!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Calibrazion falide!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Al è pussibil gjavâ il dispositîf di calibrazion."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "No sta disturbâ il dispositîf di calibrazion intant che al lavore"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibrazion visôr"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Anule"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -621,142 +402,9 @@ msgstr "_Ripie"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Fat"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Visôr dal portatil"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Webcam integrade"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Scanner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Fotocjamare %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Stampant %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webcam %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Abilite gjestion dal colôr par %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Mostre i profîi di colôr par %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "No calibrât"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Predefinît: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Spazi colôr: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Profîl di prove: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Selezionâ file profîl ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Impuarte"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Profîi ICC supuartâts"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Ducj i files"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Schermi"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Salve Profîl"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Salve"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Cree un profîl di colôr pal dispositîf selezionât"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Nol è stât rilevât nissun strument di misure. Controle che al seti impiât e "
-"tacât te juste maniere."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Il strument di misure nol supuarte il profiling de stampant."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Il gjenar di dispositîf nol è al moment supuartât."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -874,13 +522,13 @@ msgstr "Al covente un supuart scrivibil"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "A podaressin jessi utii chestis istruzions su cemût doprâ il profîl su <a "
-"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a href="
-"\"windows\">Microsoft Windows</a>."
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a "
+"href=\"windows\">Microsoft Windows</a>."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -900,8 +548,7 @@ msgstr "_Impuarte file…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "_Zonte"
@@ -912,9 +559,7 @@ msgstr ""
 "Ogni dispositîf al scugne vê un profîl di colôr inzornât par podê gjestî il "
 "colôr."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Plui informazions"
 
@@ -1046,82 +691,6 @@ msgstr "D65 (Fotografie e grafiche)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Spazi  standard"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Prove profîl"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatic"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Cualitât basse"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Cualitât medie"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Cualitât alte"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB predefinît"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK predefinît"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Gray predefinît"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Dâts di calibrazion di fabriche furnîts dal vendidôr"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Cun chest profîl nol è pussibil la corezion dal visôr a plen schermi"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Chest profîl al podarès no jessi plui precîs"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Colôr"
@@ -1132,14 +701,9 @@ msgid ""
 msgstr ""
 "Calibre il colôr dai tiei dispositîfs, come visôrs, fotocjamaris o stampants"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Colôr;ICC;Profîll;Calibrazion;Stampant;Visôr;Schermi;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Altri…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1154,13 +718,8 @@ msgid "No languages found"
 msgstr "Nissune lenghe cjatade"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Plui…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Sblocâ par cambiâ lis impostazions"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1189,151 +748,6 @@ msgstr "Decremente ore"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Decremente minût"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Vuê"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Îr"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d ore"
-msgstr[1] "%d oris"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minût"
-msgstr[1] "%d minûts"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d secont"
-msgstr[1] "%d seconts"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s, %s e %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s e %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s e %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 seconts"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 oris"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %I:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %H:%M"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%I:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%H:%M"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1428,15 +842,11 @@ msgstr "_Fûs orari automatic"
 msgid "Requires location services enabled and internet access"
 msgstr "Si scugne vê abilitât i servizis di posizion e un acès a internet"
 
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
-#: panels/location/cc-location-panel.ui:9 panels/lock/cc-lock-panel.ui:39
-#: panels/lock/cc-lock-panel.ui:75 panels/lock/cc-lock-panel.ui:95
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Abilitât"
 
@@ -1444,15 +854,42 @@ msgstr "Abilitât"
 msgid "Time Z_one"
 msgstr "Fûs _orari"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Sbloche"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "F_ormât ore"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datis"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 seconts"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Calendari"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Numars"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Cambie date e ore, cussì ancje il fûs orari"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Orloi;Ore;Timp;Date;Fûs;Posizion;Orari;"
@@ -1499,21 +936,9 @@ msgstr "Aplicazions predefinidis"
 msgid "Configure Default Applications"
 msgstr "Configure lis aplicazions predefinidis"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "predefinît;aplicazion;preferît;multimedia;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Inviâ lis segnalazions di problemis tecnics nus jude di miorâ %s. Lis "
-"segnalazions a vegnin inviadis in maniere anonime e privis di dâts personâi. "
-"%s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1531,53 +956,21 @@ msgstr "Diagnostiche"
 msgid "Report your problems"
 msgstr "Segnale i problemis"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostiche;colàs;crash;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Impiât"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Distudât"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "Aplicâ lis modifichis?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "Lis modifichis no puedin jessi aplicadis"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "Chest al podarès jessi par vie di limitazions hardware."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Apliche"
 
-#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:222
-#: panels/display/cc-display-panel.ui:261 panels/network/cc-wifi-panel.ui:16
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
 #: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
 #: panels/wacom/cc-wacom-stylus-page.ui:136
 #: panels/wwan/cc-wwan-apn-dialog.ui:21
 msgid "Back"
@@ -1587,62 +980,33 @@ msgstr "Indaûr"
 msgid "Display Settings Disabled"
 msgstr "Impostazions dal visôr disabilitadis"
 
-#: panels/display/cc-display-panel.ui:116
-msgid "Display Arrangement"
-msgstr "Disposizion dai visôrs"
-
-#: panels/display/cc-display-panel.ui:127
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "Visôrs multiplis"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:136
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "Unìs"
 
-#: panels/display/cc-display-panel.ui:143
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Duplicât"
 
-#: panels/display/cc-display-panel.ui:156
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Al conten la sbare superiôr e lis Ativitâts"
 
-#: panels/display/cc-display-panel.ui:157
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Visôr primari"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:178
-#: panels/display/cc-display-panel.ui:229
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
 #: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Lûs noturne"
-
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Orizontâl"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Verticâl diestre"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Verticâl çampe"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Orizontâl (invertît)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
 
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
@@ -1667,6 +1031,17 @@ msgstr "Juste par TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Scjale"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Scoriment naturâl"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1762,7 +1137,6 @@ msgstr "Visôrs"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Sielç cemût doprâ i visôrs e i proietôrs tacâts"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1771,57 +1145,54 @@ msgstr ""
 "Panel;Proietôr;xrandr;Schermi;Risoluzion;Refresh;Visôr;Gnot;Lûs;Blu;inrossâ;"
 "colôr;tramont;cricâ;"
 
-#: panels/info-overview/cc-info-overview-panel.c:296
-#: panels/info-overview/cc-info-overview-panel.c:320
-#: panels/info-overview/cc-info-overview-panel.c:366
-#: panels/info-overview/cc-info-overview-panel.c:396
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "No cognossût"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"L'inviament sigûr al impedìs a software malevul dal sei cjariât cuant che al "
+"partìs il dispositîf.\n"
+"\n"
+"Par vê plui informazions, contate il produtôr hardware o il supuart "
+"informatic."
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:328
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; ID di costruzion: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr "Nivel di sigurece"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:343
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nivel 1"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:346
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nivel 2"
 
-#: panels/info-overview/cc-info-overview-panel.c:605
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nivel 3"
 
-#: panels/info-overview/cc-info-overview-panel.c:609
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Nissun event"
 
-#: panels/info-overview/cc-info-overview-panel.c:611
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "No cognossût"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Sigurece dal dispositîf"
 
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:689
-msgid "Not Available"
-msgstr "No disponibile"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Stât de sigurece dal firmware dal host"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo di sisteme"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"schermi;visôr;bloc;diagnostiche;colàs;crash;privât;resint;temporani;tmp;"
+"indiç;tabele;non;rêt;identitât;privacy;riservatece;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -1857,36 +1228,41 @@ msgstr "Calcul…"
 msgid "OS Name"
 msgstr "Non dal SO"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID di costruzion dal SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Gjenar di SO"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Version di GNOME"
 
 #. translators: this is a placeholder while the GNOME version is being fetched
-#: panels/info-overview/cc-info-overview-panel.ui:116
+#: panels/info-overview/cc-info-overview-panel.ui:125
 msgid "Loading…"
 msgstr "Daûr a cjariâ…"
 
-#: panels/info-overview/cc-info-overview-panel.ui:124
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Sisteme di gjestion barcons"
 
-#: panels/info-overview/cc-info-overview-panel.ui:132
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Virtualizazion"
 
-#: panels/info-overview/cc-info-overview-panel.ui:141
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Inzornaments software"
 
-#: panels/info-overview/cc-info-overview-panel.ui:165
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Cambie non al dispositîf"
 
-#: panels/info-overview/cc-info-overview-panel.ui:181
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1894,11 +1270,11 @@ msgstr ""
 "Il non dal dispositîf al ven doprât par identificâ chest dispositîf cuant "
 "che al ven viodût te rêt o cuant che si associe i dispositîfs Bluetooth."
 
-#: panels/info-overview/cc-info-overview-panel.ui:187
+#: panels/info-overview/cc-info-overview-panel.ui:196
 msgid "Device name"
 msgstr "Non dispositîf"
 
-#: panels/info-overview/cc-info-overview-panel.ui:201
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "_Cambie non"
 
@@ -1910,11 +1286,6 @@ msgstr "Informazions"
 msgid "View information about your system"
 msgstr "Mostre informazions su chest sisteme"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1993,6 +1364,12 @@ msgstr "Inviadôrs"
 msgid "Launch help browser"
 msgstr "Fâs partî il visualizadôr di manuâi"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Impostazions"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Fâs partî il calcoladôr"
@@ -2014,7 +1391,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Cîr"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sisteme"
 
@@ -2063,15 +1440,6 @@ msgstr "Diminuìs la dimension dal test"
 msgid "High contrast on or off"
 msgstr "Ative o disative il contrast elevât"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nissune sorzint input cjatade"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Altri"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Zonte une sorzint input"
@@ -2104,107 +1472,9 @@ msgstr "Preferencis"
 msgid "View Keyboard Layout"
 msgstr "Mostre disposizion de tastiere"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Gjave"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Scurtis personalizadis"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "Tast caratars alternatîfs"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Tu puedis doprâ il tast dai caratars alternatîfs par inserî caratars "
-"adizionâi. Chescj cualchi volte a son stampâts te tastiere come tierce "
-"opzion."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt a çampe"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt a diestre"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Super di çampe"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Super di diestre"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tast menù"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl di diestre"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Tast Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Il tast compose al permet di inserî une grande varietât di caratars. Par "
-"doprâlu, frache compose e podopo une secuence di caratars.  Par esempli, il "
-"tast compose cun daûr <b>C</b> e <b>o</b> al inserirà <b>©</b>, <b>a</b> cun "
-"daûr <b>'</b> al inserirà <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Bloc Maiusc"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "BlocScor"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Stampe"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Al è pussibil cambiâ sorzints di input doprant la scurte di tastiere %s.\n"
-"Al è pussibil cambiâ la scurte tes impostazions des scurtis di tastiere."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2226,54 +1496,29 @@ msgstr "Dopre la _stesse sorzint par ducj i barcons"
 msgid "Switch input sources _individually for each window"
 msgstr "Passe a sorzints diviersis in maniere _individuâl par ogni barcon"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Inseriment caratars speciâi"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Metodis par inserî variantis di simbui e letaris doprant la tastiere."
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tast caratars alternatîfs"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tast Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Scurte di tastiere"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Viôt e personalize lis scurtis"
-
-# Si riferìs aes scurtis, numar di scurtis modificadis
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modificade"
-msgstr[1] "%d modificadis"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Ristabilìs dutis lis scurtis?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Ristabilint lis scurtis tu podaressis influençâ lis tôs scurtis "
-"personalizadis. Nol sarà pussibil anulâ cheste operazion."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Anule"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Ristabilìs dut"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2313,34 +1558,6 @@ msgstr "Zonte scurte"
 msgid "No keyboard shortcut found"
 msgstr "Nissune scurte di tastiere cjatade"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s al è za doprât par %s. Se tu lu rimplacis, %s al vignarà disabilitât"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Inserìs la gnove scurte"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Stabilìs la scurte personalizade"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Met la scurte"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Inserìs la gnove scurte par cambiâ %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Zonte scurte personalizade"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Gjave"
@@ -2352,7 +1569,6 @@ msgstr "_Sostituìs"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Stabilìs"
 
@@ -2363,7 +1579,7 @@ msgstr "Frache Esc par anulâ o Backspace par disabilitâ la scurte di tastiere.
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Non"
@@ -2388,6 +1604,11 @@ msgstr "Nissun"
 msgid "Reset the shortcut to its default value"
 msgstr "Torne met la scurte al so valôr predefinît"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Doprâ la vuestre fotocjamare"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Tastiere"
@@ -2400,7 +1621,6 @@ msgstr ""
 "Cambie lis scurtis di tastiere e stabilìs lis preferencis di digjitazion, "
 "disposizions di tastiere e sorzints input"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2442,177 +1662,9 @@ msgstr "Nissune aplicazion e à domandât di doprâ la tô posizion"
 msgid "Protect your location information"
 msgstr "Protêç lis informazion su la tô posizion"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "posizion;gps;privât;riservatece;privacy;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Sospension dal schermi"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 seconts"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minût"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minûts"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minûts"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minûts"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minûts"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 ore"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minût"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minûts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minûts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minûts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minûts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minûts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minûts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minûts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minûts"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Mai"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
-msgstr ""
-"Il blocâ in automatic il schermi al impedìs a altris di doprâ il computer "
-"intant che si è vie."
-
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "Ritart schermi neri"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Periodi di inativitât daspò di chel il schermi al devente neri."
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "B_loc schermi automatic"
-
-#: panels/lock/cc-lock-panel.ui:49
-msgid "Automatic _Screen Lock Delay"
-msgstr "Ritart bloc _schermi automatic"
-
-#: panels/lock/cc-lock-panel.ui:50
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-"Periodi di timp, dopo che il schermi al è deventât neri, cuant che si è "
-"blocât in automatic."
-
-#: panels/lock/cc-lock-panel.ui:68
-msgid "Show _Notifications on Lock Screen"
-msgstr "Mostrâ lis _notifichis sul schermi blocât"
-
-#: panels/lock/cc-lock-panel.ui:86
-msgid "Forbid new _USB devices"
-msgstr "Impedìs gnûfs dispositîfs _USB"
-
-#: panels/lock/cc-lock-panel.ui:87
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Impedìs ai gnûfs dispositîfs USB di interagjî cul sisteme cuant che il "
-"schermi al è blocât."
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Bloc schermi"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Bloche il to schermi"
-
-#. Translators: Search terms to find the Lock panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-msgid "screen;lock;private;privacy;"
-msgstr "schermi;bloche;privât;riservatece;privacy;"
 
 #: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
@@ -2644,7 +1696,6 @@ msgstr "Nissune aplicazion e à domandât di doprâ il microfon"
 msgid "Protect your conversations"
 msgstr "Protêç lis tôs conversazions"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "microfon;regjistrazion;aplicazion;riservatece;privacy;"
@@ -2666,89 +1717,149 @@ msgstr "Boton primari"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "Stabilìs l'ordin dai botons fisics sui mouse e touchpad."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Çampe"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Drete"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Posizions di ricercje"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mouse"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Velocitât Mouse"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Scoriment naturâl"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Scor in jù"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Il scori al sposte il contignût, no la viodude."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Il scori al sposte il contignût, no la viodude."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Atîf"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Velocitât Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Maniere"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Tap par fâ clic"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Batuce par fâ clic"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Scoriment a doi dêts"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Disabilite imagjin"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relative)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Scor tal ôr"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scor in jù"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Denant e daûr"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Prove a fâ clic, dopli-clic o scori"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinc clic, e je ore di GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dopli-clic, boton primari"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Clic singul, boton primari"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dopli-clic, boton centrâl"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Clic singul, boton centrâl"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dopli-clic, boton secondari"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Clic singul, boton secondari"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2761,7 +1872,6 @@ msgstr ""
 "Cambie la sensibilitât di mouse e touchpad e selezione se par man diestre o "
 "çampe"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -2843,7 +1953,6 @@ msgstr "Multilavôr"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Gjestìs lis preferencis pe produtivitât e il multilavôr"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -2851,21 +1960,11 @@ msgstr ""
 "Multitasking;Multilavôr;Produtivitât;Personalize;Scritori;Scrivanie;Desktop;"
 "Angul cjalt;Spazis di lavôr;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Orpo, al somee che alc al sedi lât ledrôs. Contate il furnidôr di software."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager al à di jessi in esecuzion."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Altris dispositîfs"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:56
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
@@ -2873,63 +1972,20 @@ msgstr "VPN"
 msgid "Add connection"
 msgstr "Zonteconession"
 
-#: panels/network/cc-network-panel.ui:73
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "No configurade"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "Rêt no sigure (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "Rêt sigure (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "Rêt sigure (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "Rêt sigure (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "Rêt sigure"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Tacât"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opzions…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Impiant l'hotspot tu ti disconetarâs di %s e nol sarà pussibil acedi  su "
-"internet vie Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "E scugne vê un minim di 8 caratars"
 
 # Si riferìs ae password
 #: panels/network/cc-wifi-hotspot-dialog.c:271
@@ -2959,12 +2015,12 @@ msgstr "Non rêt"
 
 #. Translators: This is a password needed for printing.
 #: panels/network/cc-wifi-hotspot-dialog.ui:75
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:391
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Password"
 
@@ -2979,20 +2035,6 @@ msgstr "Gjenere in automatic la password"
 #: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Impie"
-
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Fermâ l'hotspot e disconeti ducj i utents?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "_Ferme Hotspot"
 
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
@@ -3038,275 +2080,22 @@ msgstr "Rêts visibilis"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager al à di jessi in esecuzion"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Orpo, al somee che alc al sedi lât ledrôs. Contate il furnidôr di software."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Sigurece 802.1x"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Sigurece"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Conserve"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Casuâl"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabile"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"La direzion MAC inseride chi e vignarà doprade come direzion hardware pal "
-"dispositîf di rêt dulà che cheste conession e je ativade. Cheste "
-"funzionalitât e je cognossude come clonazion MAC o spoofing. Esempli: "
-"00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profîl %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nissune"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Mai"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i zornade indaûr"
 msgstr[1] "%i dîs indaûr"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nissune"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Debul"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Bon"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Ecelent"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Direzion IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Direzion IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Direzions IP"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "Dismentee conession"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "Gjave profîl conession"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "Gjave VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "Detais"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatic"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitât"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Elimine direzion"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Elimine instradament"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Nissune"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Clâf WEP 40/128-bit(Hex o ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Passphrase WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinamic (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 personâl"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3317,8 +2106,20 @@ msgstr "Fuarce segnâl"
 msgid "Link speed"
 msgstr "Velocitât colegament"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sigurece"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Direzion IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Direzion IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Direzion Hardware"
 
@@ -3327,12 +2128,17 @@ msgid "Supported Frequencies"
 msgstr "Frecuencis supuartadis"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Instradament predefinît"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3346,12 +2152,12 @@ msgstr "Conet in _automatic"
 msgid "Make available to _other users"
 msgstr "Rindi disponibil a chei _altris utents"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 "Conession a _consum: e à un limit di dâts o si pues lâ cuintri a spesis"
 
-#: panels/network/connection-editor/details-page.ui:422
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3396,7 +2202,7 @@ msgstr "Nome Link-Local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manuâl"
 
@@ -3440,9 +2246,8 @@ msgstr "Gateway"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automatic"
 
@@ -3495,79 +2300,9 @@ msgstr "Automatic, nome DHCP"
 msgid "Prefix"
 msgstr "Prefìs"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Impussibil vierzi l'editor di conession"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Gnûf profîl"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Impuarte di file…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "Zonte VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Sigur_ece"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Impussibil impuartâ la conession VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Impussibil lei il file «%s» opûr nol ten informazions di conession VPN "
-"ricognossudis\n"
-"\n"
-"Erôr: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Selezione un file di impuartâ"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Un file clamât «%s» al esist za."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Rimplace"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Vûstu rimplaçâ %s cun la conession VPN che tu stâs salvant?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Impussibil espuartâ la conession VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Impussibil espuartâ la conession VPN «%s» su %s.\n"
-"\n"
-"Erôr: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Espuarte la conession VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3581,102 +2316,39 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rêt"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controle cemût conetiti a Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Rêt;Network;IP;LAN;Proxy;WAN;Broadband;Bande largje;Modem;Bluetooth;vpn;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controle cemût conetiti aes rêts Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Rêt;Network;Wireless;Cence fîl;Wi-Fi;Wifi;IP;LAN;Broadband;Bande largje;DNS;"
 "Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "mai"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "vuê"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "îr"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Ultime volte doprât"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Fîl"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Zonte gnove conession"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"A vignaran pierdûts i detais par lis rêts selezionadis, includût lis "
-"password e ogni configurazion personalizade."
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "_Dismentee"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Rêts Wi-Fi cognossudis"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Dismentee"
-
-#: panels/network/net-device-wifi.c:1229
-msgid "System policy prohibits use as a Hotspot"
-msgstr "La politiche di sisteme e proibìs l'ûs come Hotspot"
-
-#: panels/network/net-device-wifi.c:1232
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Il dispositîf wireless nol supuarte la modalitât Hotspot"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"La individuazion automatiche dal proxy web e ven doprade cuant che nol ven "
-"dât l'URL di configurazion."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Nol è conseât par rêts publichis no fidadis."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -3695,6 +2367,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Provider"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Direzions IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -3779,289 +2455,6 @@ msgstr "_Impie hotspot Wi-Fi…"
 msgid "_Known Wi-Fi Networks"
 msgstr "Rêts Wi-Fi _cognossudis"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Stât no cognossût"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "No gjestît"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "No disponibil"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Daûr a coneti"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Autenticazion necessarie"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Daûr a distacâsi"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Conession falide"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Stât no cognossût (al mancje)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Configurazion falide"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Configurazion IP falide"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Configurazion IP scjadude"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "A jerin domandâts segrets, ma no son stâts dâts"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Supplicant 802.1x distacât"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "configurazion supplicant 802.1x falide"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Supplicant 802.1x falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Le autenticazion dal supplicant 802.1x e à doprât masse timp"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Inviament dal servizi PPP falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Servizi PPP disconetût"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Inviament dal client DHCP falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Erôr client DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Client DHCP falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Inviament dal servizi di conession condividude falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Servizi conession condividude falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Inviament dal servizi AutoIP falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Erôr servizi AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Servizi AutoIP falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linie ocupade"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Nissun segnâl di clamade"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Impussibil stabilî cualchi puartant"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "La richieste di selezion e je scjadude"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Tentatîf di selezion falît"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Iniziazion modem falide"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Selezion dal APN specificât falide"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Nissune ricercje di rêts ative"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Regjistrazion rêt neade"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Regjistrazion rêt scjadude"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Regjistrazion falide su pe rêt domandade"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Verifiche PIN falide"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Al podarès mancjâ il firmware dal dispositîf"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Conession sparide"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "A je stade considerade la conession esistente"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem no cjatât"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Conession Bluetooth falide"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Schede SIM no inseride"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Si domande codiç PIN de SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Si domande codiç PUK de SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Schede SIM falade/sbaliade"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Dipendence de conession falide"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Firmware mancjant"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Fil stacât"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "erôr no definît inte sigurece 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "nissun file selezionât"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "erôr no specificât tal validâ il file dal metodi eap"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "Clâfs privadis DER, PEM, o PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Certificâts DER o PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "al mancje il file PAC di EAP-FAST"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Files PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4110,14 +2503,6 @@ msgstr "Autenticazion _interne"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Permet pro_visioning PAC automatic"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "al mancje il non utent EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "e mancje la password EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4130,7 +2515,7 @@ msgstr "Non _utent"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Password"
 
@@ -4142,15 +2527,6 @@ msgstr "_Password"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Mostre pass_word"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "CA dal certificât EAP-PEAP no valit: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "CA dal certificât EAP-PEAP no valit: nissun certificât specificât"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4173,7 +2549,6 @@ msgid "C_A certificate"
 msgstr "Certificât C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4188,63 +2563,6 @@ msgstr "No covente la CA dal ce_rtificât"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Version PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "al mancje il non utent EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "e mancje la password EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "e mancje la identitât EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "CA dal certificât EAP-TLS no valit: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "CA dal certificât EAP-TLS no valit: nissun certificât specificât"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "clâf privade EAP-TLS no valide: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificât utent EAP-TLS no valit: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Lis clâfs privadis no cifradis no son siguris"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"La clâf privade selezionade no somee jessi protete di une password. Chest al "
-"pues comprometi lis propris credenziâls di sigurece. Selezione une clâf "
-"privade protete di password.\n"
-"\n"
-"(Al è pussibil protezi lis propris clâfs privadis cun openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Sielzi il certificât personâl"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Sielzi la clâf privade personâl"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4261,15 +2579,6 @@ msgstr "_Clâf privade"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Password clâf _privade"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "CA dal certificât EAP-TTLS no valit: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "CA dal certificât EAP-TTLS no valit: nissun certificât specificât"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4292,14 +2601,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domini"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Erôr no cognossût tal validâ la sigurece 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4327,63 +2637,10 @@ msgstr "PEAP (Protected EAP)"
 msgid "Au_thentication"
 msgstr "Au_tenticazion"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Selezione un file"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "al mancje il non utent leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "e mancje la password leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "E mancje la password dal Wi-Fi."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Gjenar"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "e mancje la clâf wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"clâf wep no valide: une clâf di lungjece %zu e scugne contignî nome cifris "
-"esadecimâi"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"clâf wep no valide: une clâf di lungjece %zu e scugne contignî nome caratars "
-"ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"clâf wep no valide: lungjece %zu de clâf sbaliade. Une clâf e scugne jessi o "
-"di lungjece 5/13 (ascii) o 10/26 (esadecimâl)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "clâf wep no valide: la passphrase no pues jessi vueide"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"clâf wep no valide: la passphrase no pues jessi plui curte di 64 caratars"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4408,20 +2665,6 @@ msgstr "M_ostre la clâf"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Indi_ç WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk no valit: lungjece %zu de clâf no valide. E scugne jessi [8,63] "
-"bytes o 64 cifris esadecimâi"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk no valit: impussibil interpretâ la clâf di 64 bytes come esadecimâl"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4476,31 +2719,13 @@ msgstr "Notifichis sul schermi b_locât"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controle cualis notifichis mostrâ e ce che a mostrin"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifichis;Banner;Messaç;Tray;Popup;"
 
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Altri"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:279
-#, c-format
-msgid "%s removed"
-msgstr "%s gjavât"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:690
-msgid "Error removing account"
-msgstr "Erôr tal gjava l'account"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Disfe"
 
@@ -4521,17 +2746,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Zonte un account"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Account di %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Gjave account"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Ac­count­ ­on­line"
@@ -4540,10 +2754,6 @@ msgstr "Ac­count­ ­on­line"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Conetiti ai tiei account online e decît cemût doprâju"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4552,10 +2762,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Conversazions;Calendari;Mail;E-"
 "mail;Email;Pueste;Contat;Contats;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
 "ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Timp no cognossût"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4571,13 +2777,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i ore"
 msgstr[1] "%i oris"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s e %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4589,190 +2788,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minût"
 msgstr[1] "minûts"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s ae cjarie plene"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Atenzion: ancjemò %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "ancjemò %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Cjarie"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Nol sta cjariant"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Scjarie"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "In cjarie"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "In scjarie"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Mouse cence fîl"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Tastiere cence fîl"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "UPS"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "PDA"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Celulâr"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Letôr multimediâl"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Computer"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Dispositîf di input par zuiâ"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batarie"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principâl"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Adizionâl"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batariis"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Cuant _inatîf"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Sospindi"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Distudâ"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Ibernâ"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nissune azion"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Cuant che si dopre la batarie"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Cuant che al è alimentât"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Mai"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Sospension automatiche"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Modalitât prestazions disabilitade in mût temporani par vie de temperadure "
-"di operazion elevade."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Portatil rilevât: modalitât prestazions no disponibile in mût temporani. "
-"Sposte il dispositîf suntune superficie stabile par ripristinâ."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Modalitât prestazions disabilitade in mût temporani."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Cjarie batarie basse: sparagn energjetic abilitât. La modalitât precedente e "
-"vignarà ripristinade cuant che la batarie e sarà cjamade a suficience."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Modalitât sparagn energjetic ativade di “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Modalitât prestazions ativade di “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4833,6 +2848,15 @@ msgstr "100 minûts"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 oris"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batarie"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositîfs"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -4910,36 +2934,9 @@ msgid "On _Battery Power"
 msgstr "Alimentât a _batarie"
 
 #: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Ritart"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Prestazions"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Prestazions elevadis e consum energjetic."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Belançade"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Prestazions e consum energjetic normâi."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Sparagn energjetic"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Prestazions e consum energjetic ridots."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4950,7 +2947,6 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Mostre il stât de batarie e cambie lis impostazions di sparagn energjetic"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4958,27 +2954,6 @@ msgid ""
 msgstr ""
 "Alimentazion;Sleep;Sospension;Ibernazion;Batarie;Luminositât;Visôr;Dim;DPMS;"
 "Scûr;Vueit;Monitor;Inatîf;Energjie;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "La stampant “%s” e je stade eliminade"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "Zonte de gnove stampant falide."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Impussibil cjariâ la interface: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Sbloche par zontâ stampadoris e cambiâ impostazions"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4988,7 +2963,6 @@ msgstr "Stampants"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Zonte stampants, mostre i lavôrs di stampe e decît cemût stampâ"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Stampant;Code;Stampe;Cjarte;Ingjustri;Toner;"
@@ -4996,81 +2970,54 @@ msgstr "Stampant;Code;Stampe;Cjarte;Ingjustri;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Zonte stampant"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Sbloche"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Nissune stampant cjatade"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Scrîf une direzion di rêt o cîr une stampant"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Autenticazion necessarie"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Scrîf non utent e password par viodi lis stampants su Servidôr Stampant."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Non utent"
-
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Detais di %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Nissun driver adat cjatât"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Selezione file PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Files PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
 
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "I nons des stampadoris no puedin vê SPAZIS, TABULAZIONS, # o /"
 
-#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Colocazion"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Driver"
 
@@ -5098,132 +3045,20 @@ msgstr "Selezione driver stampant"
 msgid "Loading drivers database…"
 msgstr "Cjariament base di dâts dai driver…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Anule"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Selezione"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Stampant JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Stampant LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Une bande"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Ôr lunc (standard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Ôr curt (ribaltât)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Verticâl"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Orizontâl"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Orizontâl invertît"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Verticâl invertît"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "In atese"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "In pause"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Autenticazion necessarie"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "In elaborazion"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Fermât"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Anulât"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Interot"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Finît"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "Môf chest lavôr insom ae code"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u lavôr al domande autenticazion"
 msgstr[1] "%u lavôrs a domandin autenticazion"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Lavôrs Atîfs"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Inserìs lis credenziâls par stampâ di %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5232,340 +3067,36 @@ msgid "Domain"
 msgstr "Domini"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "A_utentiche"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Nete dut"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:174
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Autentiche"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:216
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Nissun lavôr di stampe atîf"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Sbloche servidôr di stampe"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Sbloche %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Scrîf non utent e password par viodi lis stampants su %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Daûr a cirî stampants"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Puarte seriâl"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Puarte paralele"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Colocazion: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Direzion: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Il server al domande autenticazion"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Denant e daûr"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Gjenar di cjarte"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Sorzint cjarte"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Casset di jessude"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Risoluzion"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Pre-filtradure GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Pagjinis par sfuei"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Denant e daûr"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientament"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Gjenerâl"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Impostazions pagjine"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opzions instalabii"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Lavôr"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Cualitât Imagjin"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Colôr"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Finidure"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avanzadis"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Pagjine di prove"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Pagjine di prove"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Automatic"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Impostazions predefinidis stampant"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Inclût nome i caratars GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Convertî a PS nivel 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Convertî a PS nivel 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Nissune pre-filtradure"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Produtôr"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Nissun lavôr atîf"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u Lavôr"
 msgstr[1] "%u Lavôrs"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Nete testinis stampant"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Toner in esauriment"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Toner esaurît"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Developer in esauriment"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Developer esaurît"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Furnidure toner in esauriment"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Furnidure toner esauride"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Tapon viert"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Sportel viert"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Cjarte in esauriment"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Cjarte esauride"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Fûr rêt"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Ferme"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Bidon scovacis cuasi plen"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Bidon scovacis plen"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Il fotocondutôr otic al sta par terminâ il sô timp di operativitât"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Il fotocondutôr otic nol funzione plui"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Pronte"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "No acete lavôrs"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "In elaborazion"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5589,41 +3120,45 @@ msgstr "Nete testinis stampant"
 msgid "Remove Printer"
 msgstr "Gjave stampant"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nissun lavôr atîf"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Nivel ingjustri"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Torne invie cuant che il probleme al ven risolt."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Torne invie"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Zonte stampadore…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Zonte une stampant…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Nissune stampant"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Zonte une stampant…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5631,7 +3166,6 @@ msgstr ""
 "Il servizi di sisteme pe stampe\n"
 "    nol somee jessi disponibil."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formâts"
@@ -5659,16 +3193,6 @@ msgstr "Lis ricercjis si puedin fâ par paîs o lenghis."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Anteprime"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperiâi"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrics"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5706,20 +3230,24 @@ msgstr ""
 "La impostazion de lenghe e ven doprade pai tescj de interface e pes pagjinis "
 "web. I formâts a vegnin doprâts pai numars, pes datis e pes monedis."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Il to account"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Lenghe"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formâts"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Videade di acès"
 
@@ -5731,99 +3259,9 @@ msgstr "Regjon e lenghe"
 msgid "Select your display language and formats"
 msgstr "Selezione la lenghe doprade e i formâts"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Lenghe;Disposizion;Layout;Tastiere;Input;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Domande ce fâ"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "No sta fâ nie"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Vierç cartele"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Vierç supuart"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Sielç une aplicazion par i CD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Sielç une aplicazion par i DVD video"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Sielç une aplicazion di eseguî cuant che al ven tacât un letôr musicâl"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Sielç une aplicazion di eseguî cuant che e ven tacade une fotocjamare"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Sielç une aplicazion par i CD di software"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "disc Blu-ray vueit"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "disc CD vueit"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "disc DVD vueit"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "disc HD DVD vueit"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Disc video Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "letôr e-book"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Disc video HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Software Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5873,7 +3311,6 @@ msgstr "Dispositîfs estraibii"
 msgid "Configure Removable Media settings"
 msgstr "Configure lis impostazions dai dispositîfs estraibils"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5882,13 +3319,80 @@ msgstr ""
 "dispositîf;sisteme;predefinît;preferît;preferide;cd;dvd;usb;audio;video;disc;"
 "estraibil;multimedia;esecuzion;autorun;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Selezione posizion"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Bloc schermi"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Il blocâ in automatic il schermi al impedìs a altris di doprâ il computer "
+"intant che si è vie."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Ritart schermi neri"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Periodi di inativitât daspò di chel il schermi al devente neri."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "B_loc schermi automatic"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Ritart bloc _schermi automatic"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Periodi di timp, dopo che il schermi al è deventât neri, cuant che si è "
+"blocât in automatic."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Mostrâ lis _notifichis sul schermi blocât"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Notifichis sul schermi b_locât"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Impedìs gnûfs dispositîfs _USB"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Impedìs ai gnûfs dispositîfs USB di interagjî cul sisteme cuant che il "
+"schermi al è blocât."
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr "Riservatece schermi"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr "Limite l'angul di viodude"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Schermi"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Impostazions schermi"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "schermi;bloche;privât;riservatece;privacy;"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5919,10 +3423,6 @@ msgstr "Altris"
 msgid "Add Location"
 msgstr "Zonte une colocazion"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nissune aplicazion cjatade"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Ricercje di aplicazion"
@@ -5950,93 +3450,13 @@ msgstr ""
 "Controle cualis aplicazions a mostrin risultâts di ricercje te panoramiche "
 "ativitâts"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Cîr;Cjate;Indiç;Plate;Privacy;Risultâts;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Nissune rêt selezionade pe condivision"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Rêts"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "On"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Off"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Abilitât"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Atîf"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Sielzi une cartele"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Zonte"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Abilite condivision multimediâl"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"La condivision di file e permet di condividi cun altris la proprie cartele "
-"Public su pe rêt atuâl doprant: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Cuant che l'acès esterni al è abilitât, i utents lontans a puedin tacâsi "
-"doprant il comant Secure Shell:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Abilite condivision dai files multimediâi personâi"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Non dispositîf copiât"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Direzion dal dispositîf copiade"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Non utent copiât"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Password copiade"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6115,8 +3535,8 @@ msgstr ""
 
 #: panels/sharing/cc-sharing-panel.ui:318
 #: panels/sharing/cc-sharing-panel.ui:345
-#: panels/sharing/cc-sharing-panel.ui:379
-#: panels/sharing/cc-sharing-panel.ui:405
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
 msgid "Copy"
 msgstr "Copie"
 
@@ -6137,15 +3557,15 @@ msgstr ""
 msgid "User Name"
 msgstr "Non utent"
 
-#: panels/sharing/cc-sharing-panel.ui:420
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "Cifradure di verifiche"
 
-#: panels/sharing/cc-sharing-panel.ui:449
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr "Impront di cifradure"
 
-#: panels/sharing/cc-sharing-panel.ui:450
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
 "identical."
@@ -6153,15 +3573,15 @@ msgstr ""
 "Al è pussibil viodi l'impront di cifradure tai clients che si conetin e al à "
 "di sei compagn."
 
-#: panels/sharing/cc-sharing-panel.ui:482
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Condivision multimediâl"
 
-#: panels/sharing/cc-sharing-panel.ui:504
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Condivît musiche, fotos e video su la rêt."
 
-#: panels/sharing/cc-sharing-panel.ui:517
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Cartelis"
 
@@ -6169,7 +3589,6 @@ msgstr "Cartelis"
 msgid "Control what you want to share with others"
 msgstr "Controle ce che si vûl condividi cun altris"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6186,34 +3605,37 @@ msgstr "Abilitâ o no l'acès esterni"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Al è necessari autenticâsi par abilitâ o no abilitâ l'acès di lontan"
 
-#: panels/sound/cc-alert-chooser.c:152
-msgid "Custom"
-msgstr "Personalizât"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Drip"
-msgstr "Gote"
+msgid "Click"
+msgstr "Clic"
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Glass"
-msgstr "Veri"
+msgid "String"
+msgstr "Stringhe"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Sonar"
-msgstr "Sonar"
+msgid "Swing"
+msgstr "Ossilazion"
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Businâ"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Belançament"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Sfantâ"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Daûr"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Denant"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Prove di %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6223,58 +3645,53 @@ msgstr "Fâs clic suntune casse par provâ"
 msgid "System Volume"
 msgstr "Volum di sisteme"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Volum principâl"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Nivei di volum"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Jessude"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Dispositîf di jessude"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Prove"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Configurazion"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "Belançament"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "Sfantâ"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Ingrès"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Dispositîf di ingrès"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Volum"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Sun di avîs"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Cidin"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6284,83 +3701,12 @@ msgstr "Audio"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Comede i nivei dal audio, i ingrès, lis jessudis e i suns di alerte"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Schede;Microfon;Volum;Sfantâ;Belançament;Bluetooth;Auricolâr;Scufis;Sun;"
 "Jessude;Jentrade;Ingrès;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Daûr a disconeti"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Daûr a coneti"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Conetût"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Erôr di autorizazion"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Daûr a autorizâ"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Funzionalitât ridote"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Conetût e autorizât"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "No cognossût"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autorizât aes:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Conetût aes:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Regjistrât aes:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "No i è rivâts a autorizâ il dispositîf: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "No si è rivâts a dismenteâ il dispositîf: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6369,93 +3715,53 @@ msgid_plural "Depends on %u other devices"
 msgstr[0] "Al dipent di %u altri dispositîf"
 msgstr[1] "Al dipent di %u altris dispositîfs"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Siere notifiche"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Non:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Stât:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Autorize e conet"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Dismentee dispositîf"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Erôr"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Nissun supuart par Thunderbolt"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorizât"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Impussibil colegâsi al sotsisteme di thunderbolt."
 
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Il sot-sisteme Thunderbolt (boltd) nol è instalât o nol è stât configurât in "
-"maniere adate."
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Acès diret"
 
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 "Permet l'acès diret a dispositîfs come supuarts (docks) e GPU esternis."
 
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Dome i dispositîfs USB e Display Port a puedin tacâsi."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Nol è stât pussibil rilevât Thunderbolt.\n"
-"O al mancje tal sisteme il supuart par Thunderbolt, o al è stât disabilitât "
-"tal BIOS o al è stât configurât tal BIOS a un nivel di sigurece no supuartât."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Il supuart a Thunderbolt al è stât disabilitât tal BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Impussibil determinâ il nivel di sigurece di Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Erôr tal passâ ae modalitât direte: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
-msgid "No Thunderbolt Support"
-msgstr "Nissun supuart par Thunderbolt"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:104
-msgid "Could not connect to the thunderbolt subsystem."
-msgstr "Impussibil colegâsi al sotsisteme di thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.ui:153
-msgid "Direct Access"
-msgstr "Acès diret"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Dispositîf in pîts in spiete"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Nissun dispositîf tacât"
 
@@ -6467,7 +3773,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Gjestìs i dispositîfs Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;riservatece;"
@@ -6476,16 +3781,16 @@ msgstr "Thunderbolt;privacy;riservatece;"
 msgid "Cursor Blinking"
 msgstr "Lampâ dal cursôr"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Il cursôr al lampe intai cjamps di test."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Velocitât"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Velocitât dal lampâ dal cursôr"
 
@@ -6572,15 +3877,15 @@ msgstr "Grant"
 msgid "Repeat Keys"
 msgstr "Ripet tascj"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Il fracâ dal tast al ripet il caratar fintremai che al reste fracât."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Ritart di ripetizion tascj"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Velocitât di ripetizion tascj"
 
@@ -6661,47 +3966,13 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Lunc"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "Abilite di _tastiere"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Tache e stache lis funzions di acessibilitât doprant la tastiere"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Predefinide"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Medie"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Grant"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Plui grant"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Il plui grant"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixel"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6817,31 +4088,6 @@ msgstr "Iluminâ dut il _visôr"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Iluminâ dut il _barcon"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Curt"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ di schermi"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ schermi"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ di schermi"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Lungje"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6998,7 +4244,6 @@ msgstr "Efiets colôr"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Al fâs diventâ plui facil viodi, sintî, digjitâ e fâ clic"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7011,115 +4256,6 @@ msgstr ""
 "font;dimension;AccessX;Tascj;Singui;Tacadiçs;Sticky;Lents;Slow;Sbalçâts;"
 "Bounce;Mouse;Dopli;clic;Ritart;Assisti;Ripeti;Lampâ;visuâl;sintî;audio;"
 "scriture;animazions;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 ore"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 zornade"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dîs"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dîs"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dîs"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dîs"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dîs"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dîs"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dîs"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dîs"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Disvuedâ la scovacere?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr ""
-"Ducj i elements te scovacere a vignaran eliminâts in maniere definitive."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Dis_vuede scovacere"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Eliminâ ducj i files temporanis?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Ducj i files temporanis a vignaran eliminâts in maniere definitive."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Nete files temporanis"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 zornade"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dîs"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dîs"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Par simpri"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7188,64 +4324,12 @@ msgstr "Cronologjie file e Scovacere"
 msgid "Don't leave traces"
 msgstr "No sta lassâ olmis"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "utilizazion;resint;cronologjie;files;temporani;tmp;privât;privacy;"
 "riservatece;scovacere;nete;conserve;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Al varès di corispuindi ae direzion web dal to furnidôr di acès."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Zonte dal account falide"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr "Lis password no corispuindin."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Regjistrazion account falide"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Nissun mût supuartât par autenticâsi cun chest domini"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Falît a unîsi al domini"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Non di acès no valit.\n"
-"Prove une altre volte."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Password no valide.\n"
-"Prove une altre volte."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Acès al domini falît"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Impussibil cjatâ il domini. Isal stât scrit mâl?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7285,11 +4369,11 @@ msgstr "Acès aziendâl"
 msgid "User accounts which are managed by a company or organization."
 msgstr "Accounts utent che a son gjestîts di une compagnie o une organizazion."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "Tu sês fûr rêt"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7298,10 +4382,6 @@ msgstr ""
 "L'acès enterprise al permet di doprâ su chest dispositîf un account utent za "
 "esistent ministrât in maniere centrâl. Tu puedis ancje doprâ chest account "
 "par jentrâ tes risorsis de compagnie su internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Esplore altris imagjins"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7315,15 +4395,15 @@ msgstr "Gjestôr improntis"
 msgid "Fingerprint"
 msgstr "Impronte"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_No"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Sì"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7331,460 +4411,133 @@ msgstr ""
 "Eliminâ lis improntis digjitâls regjistradis cussì di disabilitâ l'acès vie "
 "impronte?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Nissun dispositîf pes improntis"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "Nissun dispositîf pes improntis"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "Sigurâsi che il dispositîf al sedi tacât ben."
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Dispositîf pes improntis"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "Sielç il dispositîf pes improntis di configurâ"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "Acès cun impronte"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
 msgstr ""
 "L'acès cun impronte ti permet di sblocâ e jentrâ sul to computer cul to dêt"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "_Elimine improntis"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Regjistrazion impronte"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "si à di reclamâ il dispositîf par eseguî cheste azion"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Precedent"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "il dispositîf al è za reclamât di un altri procès"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "no tu âs i permès par eseguî la azion"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "no je stade regjistrade nissune impronte"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "No si è rivâts a comunicâ cul dispositîf dilunc la regjistrazion"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "No si è rivâts a comunicâ cul letôr di improntis digjitâls"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "No si è rivâts a comunicâ cul demoni pes improntis digjitâls"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "No si è rivâts a listâ lis improntis: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "No si è rivâts a eliminâ lis improntis salvadis: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Poleâr çamp"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Medi çamp"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Dêt indiç _çamp"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Anulâr çamp"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Dêt piçul çamp"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Poleâr diestri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Medi diestri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Dêt indiç _diestri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Anulâr diestri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Dêt piçul diestri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Impronte no cognossude"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Completade"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Dispositîf pes improntis disconetût"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Il spazi di archiviazion dal dispositîf pes improntis al è plen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "No si è rivâts a regjistrâ la gnove impronte"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "No si è rivâts a scomençâ la regjistrazion: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "No si è rivâts a regjistrâ la gnove impronte"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "No si è rivâts a fermâ la regjistrazion: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Alce e met tantis voltis il to dêt sul letôr par regjistrâ la tô impronte"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Torne regjistre chest dêt…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Regjistre gnove impronte"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "No si è rivâts a molâ il dispositîf pes improntis %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Probleme tal lei dal dispositîf"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "No si è rivâts a riclamâ il dispositîf pes improntis %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "No si è rivâts a otignî i dispositîfs pes improntis: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Cheste setemane"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Setemane passade"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%H:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Fin session"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Inizi session"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Ativitât dal account"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Sielç une altre password."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Scrîf di gnûf la tô password atuâl."
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Impussibil cambiâ la password"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Sucessîf"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Cambie password"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "C_ambie"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "Password atuâl"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "Gnove password"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "Conferme password"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lis password no corispuindin."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Permet al utent di cambiâ la sô password al prossim acès"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Stabilìs une password cumò"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Impussibil unîsi in automatic a chest gjenar di domini"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Nissun domini o ream cjatâts"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Impussibil acedi come %s al domini %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Password no valide, prove di gnûf"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Impussibil tacâsi al domini %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "Eliminazion utent falide"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "No si è rivâts a revocâ l'utent gjestît di lontan"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "Nol è permetût eliminâ il propri account."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s nol à ancjemò terminât la session"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Eliminâ un utent intant che la sô session e je ancjemò in cors, al pues "
-"lassâ il sisteme in stât incoerent."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Tignî i files di %s?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Al è pussibil tegnî la cartele home, la code di pueste e i varis files "
-"temporanis cuant che si elimine un account utent."
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "_Elimine i files"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "_Ten i files"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Revocâ pardabon l'account di %s gjestît di lontan?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "_Elimine"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Account disabilitât"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Di stabilî al prossim acès"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Nissun"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Acès eseguît"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "Comunicazion cun servizi account falide"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Sigurâsi che AccountService al sedi instalât e abilitât."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "Al è necessari sblocâ chest panel par cambiâ cheste impostazion"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "Elimine l'account utent selezionât"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Par eliminâ l'account utent selezionât,\n"
-"fâs prime clic su la icone *"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Sbloche par Zontâ utents e Cambiâ impostazions"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Utents"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "Al è necessari tornâ a inviâ la session par aplicâ lis modifichis"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Torne invie cumò"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Siere"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Modifiche avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Non complet"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Modifiche"
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Acès cun impronte"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "Acès automatic"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "Ativitât dal account"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Aministradôr"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7792,32 +4545,32 @@ msgstr ""
 "I aministradôrs a puedin zontâ e gjavâ altris utents e a puedin cambiâ lis "
 "impostazions par ducj i utent."
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "Controi _parentâi"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Vierç la aplicazion pai controi parentâi."
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Gjave utent…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "Altris utents"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "Zonte utent…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Nissun utent cjatât"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Sbloche par zontâ un account utent."
 
@@ -7825,7 +4578,6 @@ msgstr "Sbloche par zontâ un account utent."
 msgid "Add or remove users and change your password"
 msgstr "Zonte o gjave utents e cambie la tô password"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7870,179 +4622,8 @@ msgstr "Ministre i account online"
 msgid "Authentication is required to change user data"
 msgstr "Si scugne autenticâsi par cambiâ i dâts utent"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "La gnove password e scugne jessi divierse de precedent."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Prove cambie cualchi letare e numar."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Prove cambie la password un tic di plui."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Une password cence il tô non utent e sarès plui robuste."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Cîr di evitâ di doprâ il tô non te password."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Cîr di evitâ cualchi peraule includude te password."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Cîr di evitâ peraulis comunis."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Cîr di evitâ di tornâ a ordenâ  peraulis esistentis."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Cîr di doprâ plui numars."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Cîr di doprâ plui letaris maiusculis."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Cîr di doprâ plui letaris minusculis."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Cîr di doprâ plui caratars speciâi, come i ponts."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Cîr di doprâ une misture di letaris, numars e ponts."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Cîr di evitâ di ripeti il stes caratar."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Cîr di evitâ di ripeti il stes gjenar di caratar: tu scugnis miscliçâ "
-"letaris, numars e ponts."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Cîr di evitâ secuencis come 1234 o abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"La password e scugne jessi plui lungje. Cîr di zontâ plui letaris, numars e "
-"ponts."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Misture letaris maiusculis e minusculis e cîr di doprâ un numar o doi."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Zontant plui letaris, numars e ponts si fasarà diventâ la password plui "
-"robuste."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Autenticazion falide"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "La gnove password e je masse curte"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "La gnove password e je masse semplice"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "La password vecje e chê gnove a son masse similis"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "La gnove password e je za stade doprade di resint."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "La gnove password e scugne vê caratars numerics o speciâi"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "La password vecje e chê gnove a son compagnis"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "La tô password e je stade cambiade di cuant che tu ti sês autenticât!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "La gnove password no à vonde caratars diferents"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Erôr no cognossût"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Il non utent di solit al à di jessi formât di letaris minusculis (de a ae "
-"z), numars e dai caratars chi daurman: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Mi displâs, chel non utent nol è disponibil. Prove cuntun altri."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Il non utent al è masse lunc."
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Associe botons"
 
@@ -8075,47 +4656,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Rilevât clic sbaliât, si torne a inviâ…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Boton %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplicazion definide"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Invie pression tascj"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Cambie visôr"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Mostre jutori a schermi"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Taulete montade sul panel dal portatil"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Taulete montade su visôr esterni"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Dispositîf taulete esterni"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Ducj i visôrs"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Dispositîf esterni panel/taulete"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8125,31 +4669,31 @@ msgstr "Modalitât taulete"
 msgid "Use absolute positioning for the pen"
 msgstr "Dopre la posizion assolude pe pene"
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "Orientament par çampins"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 "Taulete e Express Keys™ a vegnin voltadis pe utilizazion cu la man çampe"
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Mape su visôr"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "Manten lis proporzions"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 "Dopre dome une porzion de superficie de taulete par mantignî lis proporzions "
 "dal visôr"
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "Calibre"
 
@@ -8202,10 +4746,6 @@ msgstr "Sensibilitât de gome"
 msgid "Eraser pressure"
 msgstr "Pression de gome"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:133
-msgid "Default"
-msgstr "Predefinît"
-
 #: panels/wacom/cc-wacom-stylus-page.ui:134
 msgid "Middle Mouse Button Click"
 msgstr "Clic boton di mieç dal mouse"
@@ -8218,22 +4758,6 @@ msgstr "Clic boton diestri dal mouse"
 msgid "Forward"
 msgstr "Indenant"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Stîl di aerograf cun pression, inclinazion e cursôr integrât"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Stîl di aerograf cun pression, inclinazion e rotazion"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Stîl standard cun pression e inclinazion"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Stîl standard cun pression"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Taulete Wacom"
@@ -8244,54 +4768,96 @@ msgstr ""
 "Stabilìs la mapadure dai botons e juste la sensibilitât de pene pes taulutis "
 "grafichis"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;Taulete;Pene;Gome;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Gnove scurte…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Clic secondari _simulât"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Software Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Toner in esauriment"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Secondari"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Software Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Gjestìs lis preferencis pe produtivitât e il multilavôr"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Ponts di acès"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Zonte"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salve"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operazion anulade"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Erôr:</b> acès dineât par cambiâ impostazions"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Erôr:</b> erôr aparât mobil"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "No regjistrât"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Regjistrât"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Daûr a cirî"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Dineât"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8321,104 +4887,13 @@ msgstr "Propri numar"
 msgid "Device Details"
 msgstr "Detais dal dispositîf"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Produtôr"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Version dal firmware"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Dome 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Dome 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Dome 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Preferît)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Preferît), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Preferît), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Preferît)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (Preferît), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Preferît)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (Preferît), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Preferît)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (Preferît), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "No cognossude"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Sbloche schede SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Sbloche"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Inserìs il codiç PIN pe SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Inserìs il PIN par sblocâ la tô schede SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Inserìs il codiç PUK pe SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Inserìs il PUK par sblocâ la tô schede SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8433,26 +4908,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Tu âs ancjemò %u tentatîf"
 msgstr[1] "Tu âs ancjemò %u tentatîfs"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Inseride password sbaliade."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Il codiç PUK al à di sei un numar di 8 cifris"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Inserìs il gnûf PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Il codiç PIN al à di sei un numar di 4-8 cifris"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Daûr a sblocâ…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -8510,95 +4965,6 @@ msgstr "Bloche la SIM cul PIN"
 msgid "M_odem Details"
 msgstr "Detais dal m_odem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Erôr dal telefon"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Nissune conession al telefon"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operazion no permetude"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operazion no supuartade"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM no inseride"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "PIN de SIM necessari"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "PUK de SIM necessari"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Erôr de SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM impegnade"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Password sbaliade"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "PIN2 de SIM necessari"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "PUK2 de SIM necessari"
-
-#  o no cjatade?
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "No cjatât"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Nissun servizi di rêt"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Timp di scjadince de rêt"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Servizis GPRS no permetûts"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming no consintût in cheste aree di posizione"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Erôr GPRS no specificât"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Nissun erôr"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Azion anulade"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Acès dineât"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Erôr no cognossût"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Modalitât de rêt"
@@ -8614,11 +4980,6 @@ msgstr "Sielç la rêt"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Inzorne i operadôrs di rêt"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -8666,7 +5027,7 @@ msgstr "_Bloche la SIM cul PIN"
 msgid "Change PIN"
 msgstr "Cambie il PIN"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:200
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr "Inserìs il PIN atuâl par cambiâ lis impostazion di bloc de SIM"
 
@@ -8678,7 +5039,6 @@ msgstr "Rêt mobile"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configure la telefonie e lis conessions dâts mobili"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "celulâr;wwan;telefonie;sim;mobil;"
@@ -8695,37 +5055,13 @@ msgstr "Impostazions e je la interface principâl par configurâ il sisteme."
 msgid "The GNOME Project"
 msgstr "Il progjet GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Mostre numar version"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categoriis des impostazions"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Abilite modalitât lungje/fetose"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Cîr la stringhe"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Liste i nons dai panei disponibii e jes"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel di mostrâ"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGOMENT…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacy"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Panei disponibii:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8783,7 +5119,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Anule ricercje"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferencis;Impostazions;"
@@ -8825,27 +5160,3177 @@ msgstr ""
 "Une tuple che e conten i valôrs iniziâi di largjece, altece e stât slargjât "
 "dal barcon de aplicazion."
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u jessude"
 msgstr[1] "%u jessudis"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u ingrès"
 msgstr[1] "%u jentradis"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "Suns di sisteme"
+#~ msgid "System Bus"
+#~ msgstr "Bus di sisteme"
+
+#~ msgid "Full access"
+#~ msgstr "Acès complet"
+
+#~ msgid "Session Bus"
+#~ msgstr "Bus di session"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Acès complet a /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Al à acès ae rêt"
+
+#~ msgid "Home"
+#~ msgstr "Cjase"
+
+#~ msgid "Read-only"
+#~ msgstr "Dome leture"
+
+#~ msgid "File System"
+#~ msgstr "File System"
+
+#~ msgid "Can change settings"
+#~ msgstr "Al pues cambiâ lis impostazions"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s al à i permès integrâts chi daurman e no si puedin modificâ. Se chest "
+#~ "ti preocupe, considere la opzion di gjavâ cheste aplicazion."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u gjenar di file e colegament che al ven viert de aplicazion"
+#~ msgstr[1] ""
+#~ "%u gjenars di file e colegaments che a vegnin vierts de aplicazion"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> al ven doprât par vierzi chescj gjenars di files e colegaments."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s di spazi disc doprâts."
+
+#~ msgid "Select a picture"
+#~ msgstr "Selezione un imagjin"
+
+#~ msgid "_Open"
+#~ msgstr "_Vierç"
+
+#~ msgid "multiple sizes"
+#~ msgstr "dimensions multiplis"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Nissun fonts pe scrivanie"
+
+#~ msgid "Current background"
+#~ msgstr "Fonts atuâl"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Place il tô dispositîf di calibrazion parsore dal cuadrât e sclice «Start»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Sposte il tô dispositîf di calibrazion su la posizion di calibradure e "
+#~ "frache «Continue»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Sposte il tô dispositîf di calibrazion inte posizion di superficie e "
+#~ "sclice «Continue»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Siere il tapon (visôr) dal portatil"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Al è vignût fûr un erôr interni impussibil di recuperâ."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "I struments necessaris pe calibradure no son instalâts."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Impussibil gjenerâ il profîl."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Impussibil vê il pont blanc prefissât."
+
+#~ msgid "Complete!"
+#~ msgstr "Completât!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Calibrazion falide!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Al è pussibil gjavâ il dispositîf di calibrazion."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "No sta disturbâ il dispositîf di calibrazion intant che al lavore"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Visôr dal portatil"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Webcam integrade"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Scanner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Fotocjamare %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Stampant %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webcam %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Abilite gjestion dal colôr par %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Mostre i profîi di colôr par %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "No calibrât"
+
+#~ msgid "Default: "
+#~ msgstr "Predefinît: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Spazi colôr: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Profîl di prove: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Selezionâ file profîl ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Impuarte"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Profîi ICC supuartâts"
+
+#~ msgid "All files"
+#~ msgstr "Ducj i files"
+
+#~ msgid "Save Profile"
+#~ msgstr "Salve Profîl"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Cree un profîl di colôr pal dispositîf selezionât"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Nol è stât rilevât nissun strument di misure. Controle che al seti impiât "
+#~ "e tacât te juste maniere."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Il strument di misure nol supuarte il profiling de stampant."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Il gjenar di dispositîf nol è al moment supuartât."
+
+#~ msgid "Standard Space"
+#~ msgstr "Spazi  standard"
+
+#~ msgid "Test Profile"
+#~ msgstr "Prove profîl"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatic"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Cualitât basse"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Cualitât medie"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Cualitât alte"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB predefinît"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK predefinît"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Gray predefinît"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Dâts di calibrazion di fabriche furnîts dal vendidôr"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "Cun chest profîl nol è pussibil la corezion dal visôr a plen schermi"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Chest profîl al podarès no jessi plui precîs"
+
+#~ msgid "Other…"
+#~ msgstr "Altri…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Sblocâ par cambiâ lis impostazions"
+
+#~ msgid "Today"
+#~ msgstr "Vuê"
+
+#~ msgid "Yesterday"
+#~ msgstr "Îr"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d ore"
+#~ msgstr[1] "%d oris"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minût"
+#~ msgstr[1] "%d minûts"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d secont"
+#~ msgstr[1] "%d seconts"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s, %s e %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s e %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s e %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24 oris"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %I:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %H:%M"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%I:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%H:%M"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Inviâ lis segnalazions di problemis tecnics nus jude di miorâ %s. Lis "
+#~ "segnalazions a vegnin inviadis in maniere anonime e privis di dâts "
+#~ "personâi. %s"
+
+#~ msgid "On"
+#~ msgstr "Impiât"
+
+#~ msgid "Off"
+#~ msgstr "Distudât"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Aplicâ lis modifichis?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Lis modifichis no puedin jessi aplicadis"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Chest al podarès jessi par vie di limitazions hardware."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Orizontâl"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Verticâl diestre"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Verticâl çampe"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Orizontâl (invertît)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "L'inviament sigûr al è atîf"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "L'inviament sigûr al impedìs a software malevul di sei cjariât cuant che "
+#~ "al partìs il dispositîf. In chest moment al è impiât e al sta funzionant "
+#~ "ben."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "L'inviament sigûr al à problemis"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "L'inviament sigûr al impedìs a software malevul di sei cjariât cuant che "
+#~ "al partìs il dispositîf. In chest moment al è impiât, ma nol funzione "
+#~ "parcè che al à une clâf che no je valide."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Di solit al è pussibil risolvi i problemis dal inviament sigûr lant tes "
+#~ "impostazions dal firmware UEFI dal to computer (BIOS), il produtôr dal to "
+#~ "hardware al varès di indicâ lis informazions su cemût fâlu."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Par jutori, contate il produtôr dal to hardware o il supuart informatic."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "L'inviament sigûr al è distudât"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "L'inviament sigûr al impedìs a software malevul di sei cjariât cuant che "
+#~ "al partìs il dispositîf. In chest moment al è distudât."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Di solit al è pussibil impiâ l'inviament sigûr da lis impostazions dal "
+#~ "firmware UEFI dal to computer (BIOS). Par jutori, contate il produtôr dal "
+#~ "to hardware o il supuart informatic."
+
+#~ msgid "Passed"
+#~ msgstr "Passât"
+
+#~ msgid "Failed"
+#~ msgstr "Falît"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Il dispositîf al è conformi al nivel HSI %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Nivel di sigurece 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Chest dispositîf nol à protezions cuintri i problemis di sigurece "
+#~ "hardware. Chest al podarès sei par vie di problemis di configurazion "
+#~ "hardware o firmware. Si consee di contatâ il propri supuart informatic."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Nivel di sigurece 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Chest dispositîf al à une protezion minime cuintri i problemis di "
+#~ "sigurece hardware. Chest al è il plui bas nivel di sigurece dal "
+#~ "dispositîf e al da protezion dome cuintri semplicis menacis di sigurece."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Nivel di sigurece 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Chest dispositîf al à une protezion base cuintri i problemis di sigurece "
+#~ "hardware. Chest al da une protezion cuintri cualchi menace comune di "
+#~ "sigurece."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Nivel di sigurece 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Chest dispositîf al à une protezion complete cuintri problemis di "
+#~ "sigurece hardware. Chest al è il nivel plui alt di sigurece dal "
+#~ "dispositîf e al da protezion cuintri lis menacis di sigurece plui "
+#~ "avanzadis."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "I nivei di sigurece no son disponibii par chest dispositîf."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Contate il to produtôr hardware par jutori cui inzornaments di sigurece."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Al podarès sei pussibil risolvi chest probleme intes impostazions dal "
+#~ "firmware UEFI dal dispositîf, opûr midiant un supuart tecnic di un espert."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Al podarès sei pussibil risolvi chest probleme intes impostazions dal "
+#~ "firmware UEFI dal dispositîf."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Un supuart tecnic di un espert al podarès risolvi chest probleme."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Protet cuintri software malevul cuant che al partìs il dispositîf."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "L'inviament sigûr al à problemis"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Cualchi protezion cuant che al partìs il dispositîf."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "L'inviament sigûr al è distudât"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Nissune protezion cuant che al partìs il dispositîf."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Une modifiche tes impostazions dal firmware UEFI, une modifiche te "
+#~ "configurazion dal sisteme operatîf opûr un software malevul su chest "
+#~ "sisteme a podaressin causâ chest probleme."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Une modifiche tes impostazions dal firmware UEFI o un software malevul su "
+#~ "chest sisteme a podaressin causâ chest probleme."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Une modifiche te configurazion dal sisteme operatîf opûr un software "
+#~ "malevul su chest sisteme a podaressin causâ chest probleme."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Esponût a seriis menacis di sigurece."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr ""
+#~ "Protezion limitade cuintri lis menacis semplicis di sigurece semplicis."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Protet cuintri lis menacis di sigurece cumunis."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Protet cuintri une grande schirie di menacis di sigurece."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Protezion complete"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Protezion de scriture dal firmware"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Bloc de protezion de scriture dal firmware"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Regjon BIOS dal firmware"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Descritôr BIOS dal firmware"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Protezion di DMA di pre-inviament"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard inviament verificât"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM Protet"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard politiche al erôr"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard Fuse"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET abilitât"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET atîf"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "RAM cifrade"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Protezion IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux Kernel Lockdown"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Verifiche kernel Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Sospension su RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Sospension a inativitât"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Clâf de plateforme UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Inviament sigûr di UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Configurazion plateforme TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Ricostruzion TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine modalitât produzion"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine Override"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Version di Intel Management Engine"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Inzornaments firmware"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Atestazion dal firmware"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Verifiche inzornadôr dal firmware"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Debug de plateforme"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Controi di sigurece dal processôr"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Protezion di rollback di AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Protezion di Replay dal firmware AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Protezion de scriture dal firmware AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Plateforme fondude (fuse)"
+
+#~ msgid "Valid"
+#~ msgstr "Valit"
+
+#~ msgid "Not Valid"
+#~ msgstr "No valit"
+
+#~ msgid "Not Enabled"
+#~ msgstr "No abilitât"
+
+#~ msgid "Locked"
+#~ msgstr "Blocât"
+
+#~ msgid "Not Locked"
+#~ msgstr "No blocât"
+
+#~ msgid "Encrypted"
+#~ msgstr "Cifrât"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "No cifrât"
+
+#~ msgid "Tainted"
+#~ msgstr "Contaminât"
+
+#~ msgid "Not Tainted"
+#~ msgstr "No contaminât"
+
+#~ msgid "Found"
+#~ msgstr "Cjatade"
+
+#  o no cjatade?
+#~ msgid "Not Found"
+#~ msgstr "No cjatade"
+
+#~ msgid "Supported"
+#~ msgstr "Supuartade"
+
+#~ msgid "Not Supported"
+#~ msgstr "No supuartade"
+
+#~ msgid "Unknown"
+#~ msgstr "No cognossût"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "No cognossût"
+
+#~ msgid "Not Available"
+#~ msgstr "No disponibile"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo di sisteme"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nissune sorzint input cjatade"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Altri"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Scurtis personalizadis"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Tu puedis doprâ il tast dai caratars alternatîfs par inserî caratars "
+#~ "adizionâi. Chescj cualchi volte a son stampâts te tastiere come tierce "
+#~ "opzion."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt a çampe"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt a diestre"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super di çampe"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super di diestre"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tast menù"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl di diestre"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Il tast compose al permet di inserî une grande varietât di caratars. Par "
+#~ "doprâlu, frache compose e podopo une secuence di caratars.  Par esempli, "
+#~ "il tast compose cun daûr <b>C</b> e <b>o</b> al inserirà <b>©</b>, <b>a</"
+#~ "b> cun daûr <b>'</b> al inserirà <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Bloc Maiusc"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "BlocScor"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Stampe"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Al è pussibil cambiâ sorzints di input doprant la scurte di tastiere %s.\n"
+#~ "Al è pussibil cambiâ la scurte tes impostazions des scurtis di tastiere."
+
+# Si riferìs aes scurtis, numar di scurtis modificadis
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificade"
+#~ msgstr[1] "%d modificadis"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Ristabilìs dutis lis scurtis?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Ristabilint lis scurtis tu podaressis influençâ lis tôs scurtis "
+#~ "personalizadis. Nol sarà pussibil anulâ cheste operazion."
+
+#~ msgid "Reset All"
+#~ msgstr "Ristabilìs dut"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s al è za doprât par %s. Se tu lu rimplacis, %s al vignarà disabilitât"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Inserìs la gnove scurte"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Stabilìs la scurte personalizade"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Met la scurte"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Inserìs la gnove scurte par cambiâ %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Zonte scurte personalizade"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Scoriment a doi dêts"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinc clic, e je ore di GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dopli-clic, boton primari"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Clic singul, boton primari"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dopli-clic, boton centrâl"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Clic singul, boton centrâl"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dopli-clic, boton secondari"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Clic singul, boton secondari"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager al à di jessi in esecuzion."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Rêt no sigure (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Rêt sigure (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Rêt sigure (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Rêt sigure (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Rêt sigure"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Impiant l'hotspot tu ti disconetarâs di %s e nol sarà pussibil acedi  su "
+#~ "internet vie Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "E scugne vê un minim di 8 caratars"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Fermâ l'hotspot e disconeti ducj i utents?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Ferme Hotspot"
+
+#~ msgid "Preserve"
+#~ msgstr "Conserve"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "Casuâl"
+
+#~ msgid "Stable"
+#~ msgstr "Stabile"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "La direzion MAC inseride chi e vignarà doprade come direzion hardware pal "
+#~ "dispositîf di rêt dulà che cheste conession e je ativade. Cheste "
+#~ "funzionalitât e je cognossude come clonazion MAC o spoofing. Esempli: "
+#~ "00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profîl %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nissune"
+
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nissune"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Debul"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bon"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Ecelent"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Dismentee conession"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Gjave profîl conession"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Gjave VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detais"
+
+#~ msgid "automatic"
+#~ msgstr "automatic"
+
+#~ msgid "Identity"
+#~ msgstr "Identitât"
+
+#~ msgid "Delete Address"
+#~ msgstr "Elimine direzion"
+
+#~ msgid "Delete Route"
+#~ msgstr "Elimine instradament"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Nissune"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Clâf WEP 40/128-bit(Hex o ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Passphrase WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinamic (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 personâl"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Impussibil vierzi l'editor di conession"
+
+#~ msgid "New Profile"
+#~ msgstr "Gnûf profîl"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Impostazion %s no valide: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Impostazion %s no valide"
+
+#~ msgid "Import from file…"
+#~ msgstr "Impuarte di file…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Zonte VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Impussibil impuartâ la conession VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Impussibil lei il file «%s» opûr nol ten informazions di conession VPN "
+#~ "ricognossudis\n"
+#~ "\n"
+#~ "Erôr: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Selezione un file di impuartâ"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Un file clamât «%s» al esist za."
+
+#~ msgid "_Replace"
+#~ msgstr "_Rimplace"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Vûstu rimplaçâ %s cun la conession VPN che tu stâs salvant?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Impussibil espuartâ la conession VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Impussibil espuartâ la conession VPN «%s» su %s.\n"
+#~ "\n"
+#~ "Erôr: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Espuarte la conession VPN"
+
+#~ msgid "never"
+#~ msgstr "mai"
+
+#~ msgid "today"
+#~ msgstr "vuê"
+
+#~ msgid "yesterday"
+#~ msgstr "îr"
+
+#~ msgid "Last used"
+#~ msgstr "Ultime volte doprât"
+
+#~ msgid "Add new connection"
+#~ msgstr "Zonte gnove conession"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "A vignaran pierdûts i detais par lis rêts selezionadis, includût lis "
+#~ "password e ogni configurazion personalizade."
+
+#~ msgid "_Forget"
+#~ msgstr "_Dismentee"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Rêts Wi-Fi cognossudis"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Dismentee"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "La politiche di sisteme e proibìs l'ûs come Hotspot"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Il dispositîf wireless nol supuarte la modalitât Hotspot"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "La individuazion automatiche dal proxy web e ven doprade cuant che nol "
+#~ "ven dât l'URL di configurazion."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Nol è conseât par rêts publichis no fidadis."
+
+#~ msgid "Status unknown"
+#~ msgstr "Stât no cognossût"
+
+#~ msgid "Unmanaged"
+#~ msgstr "No gjestît"
+
+#~ msgid "Unavailable"
+#~ msgstr "No disponibil"
+
+#~ msgid "Connecting"
+#~ msgstr "Daûr a coneti"
+
+#~ msgid "Authentication required"
+#~ msgstr "Autenticazion necessarie"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Daûr a distacâsi"
+
+#~ msgid "Connection failed"
+#~ msgstr "Conession falide"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Stât no cognossût (al mancje)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Configurazion falide"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Configurazion IP falide"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Configurazion IP scjadude"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "A jerin domandâts segrets, ma no son stâts dâts"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Supplicant 802.1x distacât"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "configurazion supplicant 802.1x falide"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Supplicant 802.1x falît"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Le autenticazion dal supplicant 802.1x e à doprât masse timp"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Inviament dal servizi PPP falît"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Servizi PPP disconetût"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP falît"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Inviament dal client DHCP falît"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Erôr client DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Client DHCP falît"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Inviament dal servizi di conession condividude falît"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Servizi conession condividude falît"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Inviament dal servizi AutoIP falît"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Erôr servizi AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Servizi AutoIP falît"
+
+#~ msgid "Line busy"
+#~ msgstr "Linie ocupade"
+
+#~ msgid "No dial tone"
+#~ msgstr "Nissun segnâl di clamade"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Impussibil stabilî cualchi puartant"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "La richieste di selezion e je scjadude"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Tentatîf di selezion falît"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Iniziazion modem falide"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Selezion dal APN specificât falide"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Nissune ricercje di rêts ative"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Regjistrazion rêt neade"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Regjistrazion rêt scjadude"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Regjistrazion falide su pe rêt domandade"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Verifiche PIN falide"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Al podarès mancjâ il firmware dal dispositîf"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Conession sparide"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "A je stade considerade la conession esistente"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem no cjatât"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Conession Bluetooth falide"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Schede SIM no inseride"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Si domande codiç PIN de SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Si domande codiç PUK de SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Schede SIM falade/sbaliade"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Dipendence de conession falide"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Firmware mancjant"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Fil stacât"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "erôr no definît inte sigurece 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "nissun file selezionât"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "erôr no specificât tal validâ il file dal metodi eap"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Clâfs privadis DER, PEM, PKCS#12 o PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certificâts DER o PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "al mancje il file PAC di EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Files PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "al mancje il non utent EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "e mancje la password EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "CA dal certificât EAP-PEAP no valit: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "CA dal certificât EAP-PEAP no valit: nissun certificât specificât"
+
+#~ msgid "missing EAP username"
+#~ msgstr "al mancje il non utent EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "e mancje la password EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "e mancje la identitât EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "CA dal certificât EAP-TLS no valit: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "CA dal certificât EAP-TLS no valit: nissun certificât specificât"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "clâf privade EAP-TLS no valide: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificât utent EAP-TLS no valit: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Lis clâfs privadis no cifradis no son siguris"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "La clâf privade selezionade no somee jessi protete di une password. Chest "
+#~ "al pues comprometi lis propris credenziâls di sigurece. Selezione une "
+#~ "clâf privade protete di password.\n"
+#~ "\n"
+#~ "(Al è pussibil protezi lis propris clâfs privadis cun openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Sielzi il certificât personâl"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Sielzi la clâf privade personâl"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "CA dal certificât EAP-TTLS no valit: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "CA dal certificât EAP-TTLS no valit: nissun certificât specificât"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Erôr no cognossût tal validâ la sigurece 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Selezione un file"
+
+#~ msgid "missing leap-username"
+#~ msgstr "al mancje il non utent leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "e mancje la password leap"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "E mancje la password dal Wi-Fi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "e mancje la clâf wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "clâf wep no valide: une clâf di lungjece %zu e scugne contignî nome "
+#~ "cifris esadecimâi"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "clâf wep no valide: une clâf di lungjece %zu e scugne contignî nome "
+#~ "caratars ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "clâf wep no valide: lungjece %zu de clâf sbaliade. Une clâf e scugne "
+#~ "jessi o di lungjece 5/13 (ascii) o 10/26 (esadecimâl)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "clâf wep no valide: la passphrase no pues jessi vueide"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "clâf wep no valide: la passphrase no pues jessi plui curte di 64 caratars"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk no valit: lungjece %zu de clâf no valide. E scugne jessi [8,63] "
+#~ "bytes o 64 cifris esadecimâi"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk no valit: impussibil interpretâ la clâf di 64 bytes come "
+#~ "esadecimâl"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Altri"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s gjavât"
+
+#~ msgid "Error removing account"
+#~ msgstr "Erôr tal gjava l'account"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Account di %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Gjave account"
+
+#~ msgid "Unknown time"
+#~ msgstr "Timp no cognossût"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s e %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s ae cjarie plene"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Atenzion: ancjemò %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "ancjemò %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Cjarie"
+
+#~ msgid "Not charging"
+#~ msgstr "Nol sta cjariant"
+
+#~ msgid "Empty"
+#~ msgstr "Scjarie"
+
+#~ msgid "Charging"
+#~ msgstr "In cjarie"
+
+#~ msgid "Discharging"
+#~ msgstr "In scjarie"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Mouse cence fîl"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Tastiere cence fîl"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "UPS"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "PDA"
+
+#~ msgid "Cellphone"
+#~ msgstr "Celulâr"
+
+#~ msgid "Media player"
+#~ msgstr "Letôr multimediâl"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Computer"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Dispositîf di input par zuiâ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principâl"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Adizionâl"
+
+#~ msgid "Batteries"
+#~ msgstr "Batariis"
+
+#~ msgid "When _idle"
+#~ msgstr "Cuant _inatîf"
+
+#~ msgid "Suspend"
+#~ msgstr "Sospindi"
+
+#~ msgid "Power Off"
+#~ msgstr "Distudâ"
+
+#~ msgid "Hibernate"
+#~ msgstr "Ibernâ"
+
+#~ msgid "Nothing"
+#~ msgstr "Nissune azion"
+
+#~ msgid "When on battery power"
+#~ msgstr "Cuant che si dopre la batarie"
+
+#~ msgid "When plugged in"
+#~ msgstr "Cuant che al è alimentât"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Sospension automatiche"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Modalitât prestazions disabilitade in mût temporani par vie de "
+#~ "temperadure di operazion elevade."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Portatil rilevât: modalitât prestazions no disponibile in mût temporani. "
+#~ "Sposte il dispositîf suntune superficie stabile par ripristinâ."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Modalitât prestazions disabilitade in mût temporani."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Cjarie batarie basse: sparagn energjetic abilitât. La modalitât "
+#~ "precedente e vignarà ripristinade cuant che la batarie e sarà cjamade a "
+#~ "suficience."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Modalitât sparagn energjetic ativade di “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Modalitât prestazions ativade di “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Prestazions"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Prestazions elevadis e consum energjetic."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Belançade"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Prestazions e consum energjetic normâi."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Sparagn energjetic"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Prestazions e consum energjetic ridots."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "La stampant “%s” e je stade eliminade"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Zonte de gnove stampant falide."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Impussibil cjariâ la interface: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Sbloche par zontâ stampadoris e cambiâ impostazions"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detais di %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nissun driver adat cjatât"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Selezione file PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Files PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Stampant JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Stampant LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Une bande"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Ôr lunc (standard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Ôr curt (ribaltât)"
+
+#~ msgid "Portrait"
+#~ msgstr "Verticâl"
+
+#~ msgid "Landscape"
+#~ msgstr "Orizontâl"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Orizontâl invertît"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Verticâl invertît"
+
+#~ msgid "Resume"
+#~ msgstr "Ripie"
+
+#~ msgid "Pause"
+#~ msgstr "Pause"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "In atese"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "In pause"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autenticazion necessarie"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "In elaborazion"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Fermât"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Anulât"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Interot"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Finît"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Môf chest lavôr insom ae code"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Lavôrs Atîfs"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Inserìs lis credenziâls par stampâ di %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Sbloche servidôr di stampe"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Sbloche %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Scrîf non utent e password par viodi lis stampants su %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Daûr a cirî stampants"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Puarte seriâl"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Puarte paralele"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Colocazion: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Direzion: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Il server al domande autenticazion"
+
+#~ msgid "Two Sided"
+#~ msgstr "Denant e daûr"
+
+#~ msgid "Paper Type"
+#~ msgstr "Gjenar di cjarte"
+
+#~ msgid "Paper Source"
+#~ msgstr "Sorzint cjarte"
+
+#~ msgid "Output Tray"
+#~ msgstr "Casset di jessude"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Risoluzion"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Pre-filtradure GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Pagjinis par sfuei"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientament"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Gjenerâl"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Impostazions pagjine"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opzions instalabii"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Lavôr"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Cualitât Imagjin"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Colôr"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Finidure"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avanzadis"
+
+#~ msgid "Test page"
+#~ msgstr "Pagjine di prove"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatic"
+
+#~ msgid "Printer Default"
+#~ msgstr "Impostazions predefinidis stampant"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Inclût nome i caratars GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Convertî a PS nivel 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Convertî a PS nivel 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Nissune pre-filtradure"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Nete testinis stampant"
+
+#~ msgid "Out of toner"
+#~ msgstr "Toner esaurît"
+
+#~ msgid "Low on developer"
+#~ msgstr "Developer in esauriment"
+
+#~ msgid "Out of developer"
+#~ msgstr "Developer esaurît"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Furnidure toner in esauriment"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Furnidure toner esauride"
+
+#~ msgid "Open cover"
+#~ msgstr "Tapon viert"
+
+#~ msgid "Open door"
+#~ msgstr "Sportel viert"
+
+#~ msgid "Low on paper"
+#~ msgstr "Cjarte in esauriment"
+
+#~ msgid "Out of paper"
+#~ msgstr "Cjarte esauride"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Fûr rêt"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Ferme"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Bidon scovacis cuasi plen"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Bidon scovacis plen"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Il fotocondutôr otic al sta par terminâ il sô timp di operativitât"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Il fotocondutôr otic nol funzione plui"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Pronte"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "No acete lavôrs"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "In elaborazion"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperiâi"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrics"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Domande ce fâ"
+
+#~ msgid "Do nothing"
+#~ msgstr "No sta fâ nie"
+
+#~ msgid "Open folder"
+#~ msgstr "Vierç cartele"
+
+#~ msgid "Other Media"
+#~ msgstr "Vierç supuart"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Sielç une aplicazion par i CD audio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Sielç une aplicazion par i DVD video"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Sielç une aplicazion di eseguî cuant che al ven tacât un letôr musicâl"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Sielç une aplicazion di eseguî cuant che e ven tacade une fotocjamare"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Sielç une aplicazion par i CD di software"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD audio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "disc Blu-ray vueit"
+
+#~ msgid "blank CD disc"
+#~ msgstr "disc CD vueit"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "disc DVD vueit"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "disc HD DVD vueit"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disc video Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "letôr e-book"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disc video HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Sospension dal schermi"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 seconts"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minût"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minûts"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minûts"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minûts"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minûts"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 ore"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minût"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minûts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minûts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minûts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minûts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minûts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minûts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minûts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minûts"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#~ msgid "Select Location"
+#~ msgstr "Selezione posizion"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Nissune aplicazion cjatade"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nissune rêt selezionade pe condivision"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "On"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Abilitât"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Atîf"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Sielzi une cartele"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Abilite condivision multimediâl"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "La condivision di file e permet di condividi cun altris la proprie "
+#~ "cartele Public su pe rêt atuâl doprant: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Cuant che l'acès esterni al è abilitât, i utents lontans a puedin tacâsi "
+#~ "doprant il comant Secure Shell:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Abilite condivision dai files multimediâi personâi"
+
+#~ msgid "Device name copied"
+#~ msgstr "Non dispositîf copiât"
+
+#~ msgid "Device address copied"
+#~ msgstr "Direzion dal dispositîf copiade"
+
+#~ msgid "Username copied"
+#~ msgstr "Non utent copiât"
+
+#~ msgid "Password copied"
+#~ msgstr "Password copiade"
+
+#~ msgid "Custom"
+#~ msgstr "Personalizât"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Prove di %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Daûr a disconeti"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Daûr a coneti"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Conetût"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Erôr di autorizazion"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Daûr a autorizâ"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Funzionalitât ridote"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Conetût e autorizât"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "No cognossût"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorizât aes:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Conetût aes:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Regjistrât aes:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "No i è rivâts a autorizâ il dispositîf: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "No si è rivâts a dismenteâ il dispositîf: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Erôr"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorizât"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Il sot-sisteme Thunderbolt (boltd) nol è instalât o nol è stât configurât "
+#~ "in maniere adate."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Dome i dispositîfs USB e Display Port a puedin tacâsi."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Nol è stât pussibil rilevât Thunderbolt.\n"
+#~ "O al mancje tal sisteme il supuart par Thunderbolt, o al è stât "
+#~ "disabilitât tal BIOS o al è stât configurât tal BIOS a un nivel di "
+#~ "sigurece no supuartât."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Il supuart a Thunderbolt al è stât disabilitât tal BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Impussibil determinâ il nivel di sigurece di Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Erôr tal passâ ae modalitât direte: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Predefinide"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Medie"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Grant"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Plui grant"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Il plui grant"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixel"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Curt"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ di schermi"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ schermi"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ di schermi"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Lungje"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 ore"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 zornade"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dîs"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dîs"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dîs"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dîs"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dîs"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dîs"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dîs"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dîs"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Disvuedâ la scovacere?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr ""
+#~ "Ducj i elements te scovacere a vignaran eliminâts in maniere definitive."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Dis_vuede scovacere"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Eliminâ ducj i files temporanis?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Ducj i files temporanis a vignaran eliminâts in maniere definitive."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Nete files temporanis"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 zornade"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dîs"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dîs"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Par simpri"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Al varès di corispuindi ae direzion web dal to furnidôr di acès."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Zonte dal account falide"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Regjistrazion account falide"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nissun mût supuartât par autenticâsi cun chest domini"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Falît a unîsi al domini"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Non di acès no valit.\n"
+#~ "Prove une altre volte."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Password no valide.\n"
+#~ "Prove une altre volte."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Acès al domini falît"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Impussibil cjatâ il domini. Isal stât scrit mâl?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Esplore altris imagjins"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "si à di reclamâ il dispositîf par eseguî cheste azion"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "il dispositîf al è za reclamât di un altri procès"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "no tu âs i permès par eseguî la azion"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "no je stade regjistrade nissune impronte"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "No si è rivâts a comunicâ cul dispositîf dilunc la regjistrazion"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "No si è rivâts a comunicâ cul letôr di improntis digjitâls"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "No si è rivâts a comunicâ cul demoni pes improntis digjitâls"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "No si è rivâts a listâ lis improntis: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "No si è rivâts a eliminâ lis improntis salvadis: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Poleâr çamp"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Medi çamp"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Dêt indiç _çamp"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Anulâr çamp"
+
+#~ msgid "Left little finger"
+#~ msgstr "Dêt piçul çamp"
+
+#~ msgid "Right thumb"
+#~ msgstr "Poleâr diestri"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Medi diestri"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Dêt indiç _diestri"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Anulâr diestri"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dêt piçul diestri"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Impronte no cognossude"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Completade"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Dispositîf pes improntis disconetût"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Il spazi di archiviazion dal dispositîf pes improntis al è plen"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "No si è rivâts a regjistrâ la gnove impronte"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "No si è rivâts a scomençâ la regjistrazion: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "No si è rivâts a regjistrâ la gnove impronte"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "No si è rivâts a fermâ la regjistrazion: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Alce e met tantis voltis il to dêt sul letôr par regjistrâ la tô impronte"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Torne regjistre chest dêt…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Regjistre gnove impronte"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "No si è rivâts a molâ il dispositîf pes improntis %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Probleme tal lei dal dispositîf"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "No si è rivâts a riclamâ il dispositîf pes improntis %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "No si è rivâts a otignî i dispositîfs pes improntis: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Cheste setemane"
+
+#~ msgid "Last Week"
+#~ msgstr "Setemane passade"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%H:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Fin session"
+
+#~ msgid "Session Started"
+#~ msgstr "Inizi session"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Ativitât dal account"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Sielç une altre password."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Scrîf di gnûf la tô password atuâl."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Impussibil cambiâ la password"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Impussibil unîsi in automatic a chest gjenar di domini"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nissun domini o ream cjatâts"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Impussibil acedi come %s al domini %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Password no valide, prove di gnûf"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Impussibil tacâsi al domini %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Eliminazion utent falide"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "No si è rivâts a revocâ l'utent gjestît di lontan"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nol è permetût eliminâ il propri account."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s nol à ancjemò terminât la session"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Eliminâ un utent intant che la sô session e je ancjemò in cors, al pues "
+#~ "lassâ il sisteme in stât incoerent."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Tignî i files di %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Al è pussibil tegnî la cartele home, la code di pueste e i varis files "
+#~ "temporanis cuant che si elimine un account utent."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Elimine i files"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Ten i files"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Revocâ pardabon l'account di %s gjestît di lontan?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Elimine"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Account disabilitât"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Di stabilî al prossim acès"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Nissun"
+
+#~ msgid "Logged in"
+#~ msgstr "Acès eseguît"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Comunicazion cun servizi account falide"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Sigurâsi che AccountService al sedi instalât e abilitât."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Al è necessari sblocâ chest panel par cambiâ cheste impostazion"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Elimine l'account utent selezionât"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Par eliminâ l'account utent selezionât,\n"
+#~ "fâs prime clic su la icone *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Sbloche par Zontâ utents e Cambiâ impostazions"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "La gnove password e scugne jessi divierse de precedent."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Prove cambie cualchi letare e numar."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Prove cambie la password un tic di plui."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Une password cence il tô non utent e sarès plui robuste."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Cîr di evitâ di doprâ il tô non te password."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Cîr di evitâ cualchi peraule includude te password."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Cîr di evitâ peraulis comunis."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Cîr di evitâ di tornâ a ordenâ  peraulis esistentis."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Cîr di doprâ plui numars."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Cîr di doprâ plui letaris maiusculis."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Cîr di doprâ plui letaris minusculis."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Cîr di doprâ plui caratars speciâi, come i ponts."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Cîr di doprâ une misture di letaris, numars e ponts."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Cîr di evitâ di ripeti il stes caratar."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Cîr di evitâ di ripeti il stes gjenar di caratar: tu scugnis miscliçâ "
+#~ "letaris, numars e ponts."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Cîr di evitâ secuencis come 1234 o abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "La password e scugne jessi plui lungje. Cîr di zontâ plui letaris, numars "
+#~ "e ponts."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Misture letaris maiusculis e minusculis e cîr di doprâ un numar o doi."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Zontant plui letaris, numars e ponts si fasarà diventâ la password plui "
+#~ "robuste."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autenticazion falide"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "La gnove password e je masse curte"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "La gnove password e je masse semplice"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "La password vecje e chê gnove a son masse similis"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "La gnove password e je za stade doprade di resint."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "La gnove password e scugne vê caratars numerics o speciâi"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "La password vecje e chê gnove a son compagnis"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "La tô password e je stade cambiade di cuant che tu ti sês autenticât!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "La gnove password no à vonde caratars diferents"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Erôr no cognossût"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Il non utent di solit al à di jessi formât di letaris minusculis (de a ae "
+#~ "z), numars e dai caratars chi daurman: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Mi displâs, chel non utent nol è disponibil. Prove cuntun altri."
+
+#~ msgid "The username is too long."
+#~ msgstr "Il non utent al è masse lunc."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Boton %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Aplicazion definide"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Invie pression tascj"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Cambie visôr"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Mostre jutori a schermi"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Taulete montade sul panel dal portatil"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Taulete montade su visôr esterni"
+
+#~ msgid "External tablet device"
+#~ msgstr "Dispositîf taulete esterni"
+
+#~ msgid "All Displays"
+#~ msgstr "Ducj i visôrs"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Stîl di aerograf cun pression, inclinazion e cursôr integrât"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Stîl di aerograf cun pression, inclinazion e rotazion"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Stîl standard cun pression e inclinazion"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Stîl standard cun pression"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Gnove scurte…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operazion anulade"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Erôr:</b> acès dineât par cambiâ impostazions"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Erôr:</b> erôr aparât mobil"
+
+#~ msgid "Not Registered"
+#~ msgstr "No regjistrât"
+
+#~ msgid "Registered"
+#~ msgstr "Regjistrât"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Daûr a cirî"
+
+#~ msgid "Denied"
+#~ msgstr "Dineât"
+
+#~ msgid "2G Only"
+#~ msgstr "Dome 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Dome 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Dome 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Dome 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (Preferît)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (Preferît), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (Preferît), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (Preferît), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Preferît)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Preferît), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Preferît), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (Preferît)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (Preferît), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (Preferît), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (Preferît)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (Preferît), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (Preferît), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (Preferît)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (Preferît), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (Preferît), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Preferît)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Preferît), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Preferît)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Preferît), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Preferît)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Preferît), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (Preferît)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (Preferît), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Preferît)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (Preferît), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (Preferît)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (Preferît), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "No cognossude"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Sbloche schede SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Inserìs il codiç PIN pe SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Inserìs il PIN par sblocâ la tô schede SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Inserìs il codiç PUK pe SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Inserìs il PUK par sblocâ la tô schede SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Inseride password sbaliade."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Il codiç PUK al à di sei un numar di 8 cifris"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Inserìs il gnûf PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Il codiç PIN al à di sei un numar di 4-8 cifris"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Daûr a sblocâ…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Erôr dal telefon"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Nissune conession al telefon"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operazion no permetude"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operazion no supuartade"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM no inseride"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "PIN de SIM necessari"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "PUK de SIM necessari"
+
+#~ msgid "SIM failure"
+#~ msgstr "Erôr de SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM impegnade"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Password sbaliade"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "PIN2 de SIM necessari"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "PUK2 de SIM necessari"
+
+#  o no cjatade?
+#~ msgid "Not found"
+#~ msgstr "No cjatât"
+
+#~ msgid "No network service"
+#~ msgstr "Nissun servizi di rêt"
+
+#~ msgid "Network timeout"
+#~ msgstr "Timp di scjadince de rêt"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Servizis GPRS no permetûts"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming no consintût in cheste aree di posizione"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Erôr GPRS no specificât"
+
+#~ msgid "No Error"
+#~ msgstr "Nissun erôr"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Azion anulade"
+
+#~ msgid "Access denied"
+#~ msgstr "Acès dineât"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Erôr no cognossût"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Mostre numar version"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Abilite modalitât lungje/fetose"
+
+#~ msgid "Search for the string"
+#~ msgstr "Cîr la stringhe"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Liste i nons dai panei disponibii e jes"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel di mostrâ"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGOMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Panei disponibii:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Suns di sisteme"
+
+#~ msgid "Light"
+#~ msgstr "Clâr"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Disposizion dai visôrs"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Bloche il to schermi"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificâts DER o PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Drip"
+#~ msgstr "Gote"
+
+#~ msgid "Glass"
+#~ msgstr "Veri"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
 
 #~ msgid ""
 #~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -8854,21 +8339,11 @@ msgstr "Suns di sisteme"
 #~ "schermi;visôr;bloc;diagnostiche;crash;privât;resint;temporani;tmp;indiç;"
 #~ "non;rêt;identitât;"
 
-#~ msgid ""
-#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-#~ "network;identity;privacy;"
-#~ msgstr ""
-#~ "schermi;visôr;bloc;diagnostiche;colàs;crash;privât;resint;temporani;tmp;"
-#~ "indiç;tabele;non;rêt;identitât;privacy;riservatece;"
-
 #~ msgid "Set"
 #~ msgstr "Met"
 
 #~ msgid "Bark"
 #~ msgstr "Vuacade"
-
-#~ msgid "Close"
-#~ msgstr "Siere"
 
 #~ msgid "GNOME Settings Sound Panel"
 #~ msgstr "Panel pai suns di Impostazions di GNOME"
@@ -8935,8 +8410,8 @@ msgstr "Suns di sisteme"
 #~ msgstr "No pues jessi cambiade"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Si puedin tornâ a viodi i permès individuâi pes aplicazions intes "
 #~ "impostazions de <a href=\"privacy\">Privacy</a>."
@@ -8984,17 +8459,11 @@ msgstr "Suns di sisteme"
 #~ msgid "Active Display"
 #~ msgstr "Visôr atîf"
 
-#~ msgid "Display Configuration"
-#~ msgstr "Configurazion visôr"
-
 #~ msgid "More Warm"
 #~ msgstr "Plui cjalt"
 
 #~ msgid "Less Warm"
 #~ msgstr "Mancul cjalt"
-
-#~ msgid "Screenshots"
-#~ msgstr "Schermadis"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "Salve une schermade in $PICTURES"
@@ -9108,9 +8577,6 @@ msgstr "Suns di sisteme"
 #~ msgid "_Screen Sharing"
 #~ msgstr "Condivision _schermi"
 
-#~ msgid "Screen Sharing"
-#~ msgstr "Condivision schermi"
-
 #~ msgid "_Password:"
 #~ msgstr "_Password:"
 
@@ -9134,9 +8600,6 @@ msgstr "Suns di sisteme"
 
 #~ msgid "_Screen Reader"
 #~ msgstr "Letôr _schermi"
-
-#~ msgid "_Full Name"
-#~ msgstr "Non _complet"
 
 #~ msgid "Standard"
 #~ msgstr "Normâl"
@@ -9200,9 +8663,6 @@ msgstr "Suns di sisteme"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Taulete (assolude)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Touchpad (relative)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Preferencis de taulete"
@@ -9414,9 +8874,6 @@ msgstr "Suns di sisteme"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Acedi a hardware bluetooth in maniere direte"
-
-#~ msgid "Use your camera"
-#~ msgstr "Doprâ la vuestre fotocjamare"
 
 #~ msgid "Print documents"
 #~ msgstr "Stampâ documents"
@@ -10234,9 +9691,6 @@ msgstr "Suns di sisteme"
 #~ msgid "Uni­ver­sal Access"
 #~ msgstr "A­cès­ ­u­ni­ver­sâl"
 
-#~ msgid "Disable image"
-#~ msgstr "Disabilite imagjin"
-
 #~ msgid "Browse for more pictures…"
 #~ msgstr "Esplore altris imagjins…"
 
@@ -10262,9 +9716,6 @@ msgstr "Suns di sisteme"
 
 #~ msgid "Mirrored"
 #~ msgstr "Duplicâts"
-
-#~ msgid "Secondary"
-#~ msgstr "Secondari"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Disponi visôrs cumbinâts"
@@ -10334,9 +9785,6 @@ msgstr "Suns di sisteme"
 #~ msgctxt "proxy method"
 #~ msgid "Automatic"
 #~ msgstr "Automatic"
-
-#~ msgid "_Method"
-#~ msgstr "_Maniere"
 
 #~ msgid "Group Name"
 #~ msgstr "Non grup"
@@ -10434,9 +9882,6 @@ msgstr "Suns di sisteme"
 #~ msgid "<small>Your account</small>"
 #~ msgstr "<small>Il to account</small>"
 
-#~ msgid "Edit"
-#~ msgstr "Modifiche"
-
 #~ msgctxt "button"
 #~ msgid "Set Shortcut"
 #~ msgstr "Met la scurte"
@@ -10446,9 +9891,6 @@ msgstr "Suns di sisteme"
 
 #~ msgid "Mail"
 #~ msgstr "E-mail"
-
-#~ msgid "Calendar"
-#~ msgstr "Calendari"
 
 #~ msgid "Contacts"
 #~ msgstr "Contats"
@@ -10490,9 +9932,6 @@ msgstr "Suns di sisteme"
 
 #~ msgid "label"
 #~ msgstr "etichete"
-
-#~ msgid "Setting new driver…"
-#~ msgstr "Impostazion gnûf driver..."
 
 #~ msgid "Print _Test Page"
 #~ msgstr "Stampe _pagjine di prove"
@@ -10595,9 +10034,6 @@ msgstr "Suns di sisteme"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Scor in sù"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Scor in jù"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Scor a drete"

--- a/po/fur.po~
+++ b/po/fur.po~
@@ -1,0 +1,11636 @@
+# Friulian translation for gnome-control-center.
+# Copyright (C) 2015 gnome-control-center's COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center package.
+# Fabio Tomat <f.t.public@gmail.com>, 2015, 2017.
+# Tomat <f.t.public@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-23 17:15+0000\n"
+"PO-Revision-Date: 2022-09-28 07:19+0200\n"
+"Last-Translator: Fabio Tomat <f.t.public@gmail.com>\n"
+"Language-Team: Friulian <f.t.public@gmail.com>\n"
+"Language: fur\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Editor: HaiPO 1.0 Release\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Bus di sisteme"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Acès complet"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Bus di session"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositîfs"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Acès complet a /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rêt"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Al à acès ae rêt"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Cjase"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Dome leture"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "File System"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Impostazions"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Al pues cambiâ lis impostazions"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s al à i permès integrâts chi daurman e no si puedin modificâ. Se chest ti "
+"preocupe, considere la opzion di gjavâ cheste aplicazion."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u gjenar di file e colegament che al ven viert de aplicazion"
+msgstr[1] "%u gjenars di file e colegaments che a vegnin vierts de aplicazion"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> al ven doprât par vierzi chescj gjenars di files e colegaments."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s di spazi disc doprâts."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicazions"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Nissune aplicazion"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Instale alc…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Vierç"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Mostre detais"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Cîr"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Ricevi ricercjis di sisteme e inviâ risultâts."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Disativât"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notifichis"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Mostrâ notifichis di sisteme."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Eseguìs in sotfont"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Permeti la ativitât cuant che la aplicazion e je sierade."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Schermadis"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Fâ videadis dal schermi in cualsisei moment."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Cambiâ fonts"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Cambiâ il fondâl dal scritori."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Suns"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Riprodusi suns."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Inibî lis scurtis"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Blocâ lis scurtis di tastiere standard."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Fotocjamare"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Fâ fotos cu la fotocjamare."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microfon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Regjistrâ audio cul microfon."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Servizis su la posizion"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Acedi ai dâts di posizion dal dispositîf."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Permès integrâts"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Acès di sisteme necessari par cheste aplicazion"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Associazions di files e colegaments"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Archiviazion"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Nissun risultât cjatât"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Prove une ricercje diferente"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Associazions di files e colegaments"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Gjenars di file"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Gjenars di colegament"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Reset"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Trop spazi disc che cheste aplicazion e sta ocupant cun dâts de aplicazion e "
+"cache."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplicazion"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Dâts"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Totâl</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Nete cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Controle i permès e lis impostazions des varis aplicazions"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplicazion;flatpak;permès;impostazion;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Selezione un imagjin"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Anule"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Vierç"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "dimensions multiplis"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Nissun fonts pe scrivanie"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Fonts atuâl"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stîl"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Predefinît"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Scûr"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Fondâl"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Zonte imagjin…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aspiet"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Cambie la imagjin di fonts o i colôrs de interface utent"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Fonts;Fondâl;Rivestiment;Schermi;Scritori;Scrivanie;Desktop;Stîl;Clâr;Scûr;"
+"Aspiet;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Abilite"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Nissun Bluetooth cjatât"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Tache une clâf par doprâ il Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth distudât"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Impie par coneti dispositîfs e ricevi trasferiments file."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "La modalitât Avion e je impiade"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Il Bluetooth nol è abilitât cuant che la modalitât avion e je impiade."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Distude Modalitât Avion"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "La modalitât avion hardware e je impiade"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Distude il cric de modalitât Avion par abilitâ il Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Impie e distude il Bluetooth e conet i tiei dispositîfs"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "condividi;condivision;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "La fotocjamare e je distudade"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Nissune aplicazion e pues caturâ fotos o video."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"La utilizazion de fotocjamare e permet aes aplicazions di fâ fotos e videos. "
+"Cualchi aplicazion e podarès no funzionâ ben disabilitant la fotocjamare.\n"
+"\n"
+"Permet aes aplicazions chi sot di doprâ la tô fotocjamare."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Nissune aplicazion e à domandât di doprâ la fotocjamare"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Protêç lis tôs imagjins"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"fotocjamare;fotos;video;webcam;videocjamare;bloche;privât;riservatece;"
+"privacy;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Place il tô dispositîf di calibrazion parsore dal cuadrât e sclice «Start»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Sposte il tô dispositîf di calibrazion su la posizion di calibradure e "
+"frache «Continue»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Sposte il tô dispositîf di calibrazion inte posizion di superficie e sclice "
+"«Continue»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Siere il tapon (visôr) dal portatil"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Al è vignût fûr un erôr interni impussibil di recuperâ."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "I struments necessaris pe calibradure no son instalâts."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Impussibil gjenerâ il profîl."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Impussibil vê il pont blanc prefissât."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Completât!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Calibrazion falide!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Al è pussibil gjavâ il dispositîf di calibrazion."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "No sta disturbâ il dispositîf di calibrazion intant che al lavore"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Calibrazion visôr"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Tache"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Ripie"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Fat"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Visôr dal portatil"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Webcam integrade"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Scanner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Fotocjamare %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Stampant %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webcam %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Abilite gjestion dal colôr par %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Mostre i profîi di colôr par %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "No calibrât"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Predefinît: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Spazi colôr: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Profîl di prove: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Selezionâ file profîl ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Impuarte"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Profîi ICC supuartâts"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Ducj i files"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Schermi"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Salve Profîl"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salve"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Cree un profîl di colôr pal dispositîf selezionât"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Nol è stât rilevât nissun strument di misure. Controle che al seti impiât e "
+"tacât te juste maniere."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Il strument di misure nol supuarte il profiling de stampant."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Il gjenar di dispositîf nol è al moment supuartât."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Calibrazion schermi"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Cualitât calibradure"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"La calibradure e produsarà un profîl che tu puedis doprâ par gjestî i colôrs "
+"dal visôr. Plui tu stâs a calibrâ miôr a sarà la cualitât dal profîl colôr."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Nol sarà pussibil doprâ il computer fintremai che la calibrazion e je in "
+"vore."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Cualitât"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Timp stimât"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Dispositîf par calibrâ"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Selezione il dispositîf sensôr che tu âs voie di doprâ par calibrâ."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Gjenar di visôr"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Selezione il gjenar di visôr tacât."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Pont blanc dal profîl"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Selezione un pont blanc prefissât pal visôr. La plui part dai visôrs a "
+"varessin di jessi calibrâts tal illuminant D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Luminositât visôr"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Stabilìs la luminositât dal visôr come chê che tu dopris normalmentri. La "
+"gjestion dal colôr e sarà plui precise a chel nivel di luminositât."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"In alternative al è pussibil doprâ il nivel di luminositât doprât cuntun di "
+"chei altris profîi par chest dispositîf."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Non dal profîl"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Al è pussibil doprâ un profîl colôr su diviers computer, o ancje creâ profîi "
+"par diviersis condizions di iluminazion."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Non dal profîl:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Somari"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Creazion dal profîl riesside!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copie profîl"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Al covente un supuart scrivibil"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"A podaressin jessi utii chestis istruzions su cemût doprâ il profîl su <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Zonte Profîl"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Rilevât un probleme. Il profîl al podarès no lavorà ben. <a href=\"\">Mostre "
+"detais.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Impuarte file…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Zonte"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Ogni dispositîf al scugne vê un profîl di colôr inzornât par podê gjestî il "
+"colôr."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Plui informazions"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Plui informazions su la gjestion dai colôrs"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Stabilìs par ducj i utents"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Stabilìs chest profîl par ducj i utents su chest computer"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Abilite"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Zonte profîl"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibre…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibre il dispositîf"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Gjave profîl"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Mostre detais"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Impussibil rilevâ un dispositîf che al supuarti la gjestion dal colôr"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Proietôr"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasme"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (iluminazion CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (iluminazion a LED RGB)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (iluminazion a LED blanc)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD Wide gamut (iluminazion CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD Wide gamut (iluminazion a LED RGB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alte"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minûts"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Medie"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minûts"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Basse"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minûts"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Natîf al visôr"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (stampe e publicazion)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografie e grafiche)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Spazi  standard"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Prove profîl"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatic"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Cualitât basse"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Cualitât medie"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Cualitât alte"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB predefinît"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK predefinît"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Gray predefinît"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Dâts di calibrazion di fabriche furnîts dal vendidôr"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Cun chest profîl nol è pussibil la corezion dal visôr a plen schermi"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Chest profîl al podarès no jessi plui precîs"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Colôr"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibre il colôr dai tiei dispositîfs, come visôrs, fotocjamaris o stampants"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Colôr;ICC;Profîll;Calibrazion;Stampant;Visôr;Schermi;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Altri…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Selezione lenghe"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Selezione"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nissune lenghe cjatade"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Plui…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Sblocâ par cambiâ lis impostazions"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Si à di sblocâ cualchi impostazion prime di podêlis cambiâ."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Sbloche…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Incremente ore"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Incremente minût"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Date"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Decremente ore"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Decremente minût"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Vuê"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Îr"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d ore"
+msgstr[1] "%d oris"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minût"
+msgstr[1] "%d minûts"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d secont"
+msgstr[1] "%d seconts"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s, %s e %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s e %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s e %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 seconts"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 oris"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %I:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %H:%M"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%I:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%H:%M"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Da­te­ ­e­ ­o­re"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Àn"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mês"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Zenâr"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Fevrâr"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Març"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Avrîl"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mai"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Jugn"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Lui"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Avost"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Setembar"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Otubar"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembar"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Dicembar"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dì"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Fûs orari"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Cîr une citât"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Date e ore automatiche"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Si scugne vê un acès a internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Da_te e ore"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "_Fûs orari automatic"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Si scugne vê abilitât i servizis di posizion e un acès a internet"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Abilitât"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Fûs _orari"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "F_ormât ore"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Cambie date e ore, cussì ancje il fûs orari"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Orloi;Ore;Timp;Date;Fûs;Posizion;Orari;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Cambie lis impostazions di sisteme pe ore e pe date"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Par cambiâ lis impostazions de ore e de date al è necessari autenticâsi."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "E_mail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendari"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usiche"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotografiis"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicazions predefinidis"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configure lis aplicazions predefinidis"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "predefinît;aplicazion;preferît;multimedia;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Inviâ lis segnalazions di problemis tecnics nus jude di miorâ %s. Lis "
+"segnalazions a vegnin inviadis in maniere anonime e privis di dâts personâi. "
+"%s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Segnalazion problemis"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Segnalazion _automatiche problemis"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostiche"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Segnale i problemis"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostiche;colàs;crash;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Impiât"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Distudât"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Aplicâ lis modifichis?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Lis modifichis no puedin jessi aplicadis"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Chest al podarès jessi par vie di limitazions hardware."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Apliche"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Indaûr"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Impostazions dal visôr disabilitadis"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Visôrs multiplis"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Unìs"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Duplicât"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Al conten la sbare superiôr e lis Ativitâts"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Visôr primari"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Lûs noturne"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Orizontâl"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Verticâl diestre"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Verticâl çampe"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Orizontâl (invertît)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientament"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Risoluzion"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Frecuence di inzornament"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Juste par TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Scjale"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Lûs noturne no disponibile"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Chest al podarès sei colpe di un driver grafic doprât o dal fat che il "
+"scritori al ven doprât di lontan"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Disabilitât in maniere temporanie fintremai doman"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Torne invie il filtri"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"La lûs noturne a rint i colôrs dal schermi plui cjalts. Chest al pues judâ a "
+"rilassâ i voi e prevignî la svearole."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Planificazion"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Dal tramont al cricâ dal dì"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Planificazion manuâl"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Oraris"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Di"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Ore"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minût"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "A"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperadure colôr"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Visôrs"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Sielç cemût doprâ i visôrs e i proietôrs tacâts"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Proietôr;xrandr;Schermi;Risoluzion;Refresh;Visôr;Gnot;Lûs;Blu;inrossâ;"
+"colôr;tramont;cricâ;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "L'inviament sigûr al è atîf"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"L'inviament sigûr al impedìs a software malevul di sei cjariât cuant che al "
+"partìs il dispositîf. In chest moment al è impiât e al sta funzionant ben."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "L'inviament sigûr al à problemis"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"L'inviament sigûr al impedìs a software malevul di sei cjariât cuant che al "
+"partìs il dispositîf. In chest moment al è impiât, ma nol funzione parcè che "
+"al à une clâf che no je valide."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Di solit al è pussibil risolvi i problemis dal inviament sigûr lant tes "
+"impostazions dal firmware UEFI dal to computer (BIOS), il produtôr dal to "
+"hardware al varès di indicâ lis informazions su cemût fâlu."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Par jutori, contate il produtôr dal to hardware o il supuart informatic."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "L'inviament sigûr al è distudât"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"L'inviament sigûr al impedìs a software malevul di sei cjariât cuant che al "
+"partìs il dispositîf. In chest moment al è distudât."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Di solit al è pussibil impiâ l'inviament sigûr da lis impostazions dal "
+"firmware UEFI dal to computer (BIOS). Par jutori, contate il produtôr dal to "
+"hardware o il supuart informatic."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"L'inviament sigûr al impedìs a software malevul dal sei cjariât cuant che al "
+"partìs il dispositîf.\n"
+"\n"
+"Par vê plui informazions, contate il produtôr hardware o il supuart "
+"informatic."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Passât"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Falît"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Il dispositîf al è conformi al nivel HSI %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Nivel di sigurece 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Chest dispositîf nol à protezions cuintri i problemis di sigurece hardware. "
+"Chest al podarès sei par vie di problemis di configurazion hardware o "
+"firmware. Si consee di contatâ il propri supuart informatic."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Nivel di sigurece 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Chest dispositîf al à une protezion minime cuintri i problemis di sigurece "
+"hardware. Chest al è il plui bas nivel di sigurece dal dispositîf e al da "
+"protezion dome cuintri semplicis menacis di sigurece."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Nivel di sigurece 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Chest dispositîf al à une protezion base cuintri i problemis di sigurece "
+"hardware. Chest al da une protezion cuintri cualchi menace comune di "
+"sigurece."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Nivel di sigurece 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Chest dispositîf al à une protezion complete cuintri problemis di sigurece "
+"hardware. Chest al è il nivel plui alt di sigurece dal dispositîf e al da "
+"protezion cuintri lis menacis di sigurece plui avanzadis."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Nivel di sigurece"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "I nivei di sigurece no son disponibii par chest dispositîf."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Contate il to produtôr hardware par jutori cui inzornaments di sigurece."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Al podarès sei pussibil risolvi chest probleme intes impostazions dal "
+"firmware UEFI dal dispositîf, opûr midiant un supuart tecnic di un espert."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Al podarès sei pussibil risolvi chest probleme intes impostazions dal "
+"firmware UEFI dal dispositîf."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Un supuart tecnic di un espert al podarès risolvi chest probleme."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nivel 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nivel 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nivel 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Protet cuintri software malevul cuant che al partìs il dispositîf."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "L'inviament sigûr al à problemis"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Cualchi protezion cuant che al partìs il dispositîf."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "L'inviament sigûr al è distudât"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Nissune protezion cuant che al partìs il dispositîf."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Une modifiche tes impostazions dal firmware UEFI, une modifiche te "
+"configurazion dal sisteme operatîf opûr un software malevul su chest sisteme "
+"a podaressin causâ chest probleme."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Une modifiche tes impostazions dal firmware UEFI o un software malevul su "
+"chest sisteme a podaressin causâ chest probleme."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Une modifiche te configurazion dal sisteme operatîf opûr un software malevul "
+"su chest sisteme a podaressin causâ chest probleme."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Esponût a seriis menacis di sigurece."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr ""
+"Protezion limitade cuintri lis menacis semplicis di sigurece semplicis."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Protet cuintri lis menacis di sigurece cumunis."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Protet cuintri une grande schirie di menacis di sigurece."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Protezion complete"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Nissun event"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Protezion de scriture dal firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Bloc de protezion de scriture dal firmware"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Regjon BIOS dal firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Descritôr BIOS dal firmware"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Protezion di DMA di pre-inviament"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard inviament verificât"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM Protet"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard politiche al erôr"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard Fuse"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET abilitât"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET atîf"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "RAM cifrade"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Protezion IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux Kernel Lockdown"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Verifiche kernel Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Sospension su RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Sospension a inativitât"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Clâf de plateforme UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Inviament sigûr di UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Configurazion plateforme TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Ricostruzion TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine modalitât produzion"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine Override"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Version di Intel Management Engine"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Inzornaments firmware"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Atestazion dal firmware"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Verifiche inzornadôr dal firmware"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Debug de plateforme"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Controi di sigurece dal processôr"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Protezion di rollback di AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Protezion di Replay dal firmware AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Protezion de scriture dal firmware AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Plateforme fondude (fuse)"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Valit"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "No valit"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "No abilitât"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Blocât"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "No blocât"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Cifrât"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "No cifrât"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Contaminât"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "No contaminât"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Cjatade"
+
+#  o no cjatade?
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "No cjatade"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Supuartade"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "No supuartade"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Sigurece dal dispositîf"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Stât de sigurece dal firmware dal host"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"schermi;visôr;bloc;diagnostiche;colàs;crash;privât;resint;temporani;tmp;"
+"indiç;tabele;non;rêt;identitât;privacy;riservatece;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "No cognossût"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "No cognossût"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "No disponibile"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo di sisteme"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Non dispositîf"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Model Hardware"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memorie"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processôr"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafiche"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacitât dal disc"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calcul…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Non dal SO"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID di costruzion dal SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Gjenar di SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Version di GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Daûr a cjariâ…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Sisteme di gjestion barcons"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualizazion"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Inzornaments software"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Cambie non al dispositîf"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Il non dal dispositîf al ven doprât par identificâ chest dispositîf cuant "
+"che al ven viodût te rêt o cuant che si associe i dispositîfs Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Non dispositîf"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Cambie non"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Informazions"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Mostre informazions su chest sisteme"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositîf;sisteme;informazions;non;host;memorie;processôr;version;"
+"predefinît;aplicazion;preferide;cd;dvd;usb;audio;video;disc;estraibil;"
+"removibil;multimedie;esecuzion;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Audio e Media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Cidine/Impie il volum"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Sbasse il volum"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Alce il volum"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Cidine/Impie il microfon"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Invie il letôr multimediâl"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Riprodûs (o riprodûs/pause)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pause"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Ferme la riproduzion"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Piste/linie precedent"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Piste/linie sucessive"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Pare fûr"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Digjitazion"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Passe ae sorzint di input sucessive"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Passe ae sorzint di input precedent"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Inviadôrs"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Fâs partî il visualizadôr di manuâi"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Fâs partî il calcoladôr"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Fâs partî il client email"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Fâs partî il browser web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Cartele home"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Cîr"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sisteme"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Termine session"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Bloche il schermi"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Acessibilitât"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Ative o disative l'ingrandiment"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Aumente ingrandiment"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Diminuìs ingrandiment"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Ative o disative letôr di schermi"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Ative o disative la tastiere a schermi"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Aumente la dimension dal test"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Diminuìs la dimension dal test"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Ative o disative il contrast elevât"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nissune sorzint input cjatade"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Altri"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Zonte une sorzint input"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Nol è pussibil doprâ i metodis di input te schermade di acès"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nissune sorzint input selezionade"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opzions"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Sposte in sù"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Sposte in jù"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferencis"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Mostre disposizion de tastiere"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Gjave"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Scurtis personalizadis"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tast caratars alternatîfs"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Tu puedis doprâ il tast dai caratars alternatîfs par inserî caratars "
+"adizionâi. Chescj cualchi volte a son stampâts te tastiere come tierce "
+"opzion."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt a çampe"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt a diestre"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super di çampe"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super di diestre"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tast menù"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl di diestre"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tast Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Il tast compose al permet di inserî une grande varietât di caratars. Par "
+"doprâlu, frache compose e podopo une secuence di caratars.  Par esempli, il "
+"tast compose cun daûr <b>C</b> e <b>o</b> al inserirà <b>©</b>, <b>a</b> cun "
+"daûr <b>'</b> al inserirà <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Bloc Maiusc"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "BlocScor"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Stampe"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Al è pussibil cambiâ sorzints di input doprant la scurte di tastiere %s.\n"
+"Al è pussibil cambiâ la scurte tes impostazions des scurtis di tastiere."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Sorzints Input"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Al inclût lis disposizions di tastiere e i metodis di input."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Passaç tra sorzints di input"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Dopre la _stesse sorzint par ducj i barcons"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Passe a sorzints diviersis in maniere _individuâl par ogni barcon"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Inseriment caratars speciâi"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Metodis par inserî variantis di simbui e letaris doprant la tastiere."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Scurte di tastiere"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Viôt e personalize lis scurtis"
+
+# Si riferìs aes scurtis, numar di scurtis modificadis
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificade"
+msgstr[1] "%d modificadis"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Ristabilìs dutis lis scurtis?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Ristabilint lis scurtis tu podaressis influençâ lis tôs scurtis "
+"personalizadis. Nol sarà pussibil anulâ cheste operazion."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Anule"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Ristabilìs dut"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Ristabilìs dut…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Torne met la scurte ae sô cumbinazion di tascj predefinide"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sezion"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Scurtis"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Zonte une scurte"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Zonte scurtis personalizadis"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Configure lis scurtis personalizadis par inviâ lis aplicazions, eseguî i "
+"scripts e altri."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Zonte scurte"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nissune scurte di tastiere cjatade"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s al è za doprât par %s. Se tu lu rimplacis, %s al vignarà disabilitât"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Inserìs la gnove scurte"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Stabilìs la scurte personalizade"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Met la scurte"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Inserìs la gnove scurte par cambiâ %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Zonte scurte personalizade"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Gjave"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Sostituìs"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Stabilìs"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Frache Esc par anulâ o Backspace par disabilitâ la scurte di tastiere."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Non"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Comant"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Scurte"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Met la scurte…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Nissun"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Torne met la scurte al so valôr predefinît"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastiere"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Cambie lis scurtis di tastiere e stabilìs lis preferencis di digjitazion, "
+"disposizions di tastiere e sorzints input"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Scurte;Spazi di lavôr;Barcon;Ridimensione;Cambiâ dimension;Ingrandiment;"
+"Contrast;Inpunt;Jentrade;Sorzint;Bloche;Volum;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Servizis su la posizion distudâts"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Nissune aplicazion e pues otignî informazion su la posizion."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"I servizis su la posizion a permetin aes aplicazions di cognossi la tô "
+"posizion. Doprâ Wi-Fi e rêts mobilis al aumente la precision.\n"
+"\n"
+"Al dopre il servizi pe posizion di Mozilla: <a href='https://location."
+"services.mozilla.com/privacy'>Politiche di riservatece</a>\n"
+"\n"
+"Permet aes aplicazions chi sot di determinâ la to posizion."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Nissune aplicazion e à domandât di doprâ la tô posizion"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Protêç lis informazion su la tô posizion"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "posizion;gps;privât;riservatece;privacy;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Microfon distudât"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Nissune aplicazion e pues regjistrâ suns."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"La utilizazion dal microfon e permet aes aplicazions di regjistrâ e scoltâ i "
+"suns. Cualchi aplicazion e podarès no funzionâ ben disabilitant il "
+"microfon.\n"
+"\n"
+"Permet aes aplicazions chi sot di doprâ il to microfon."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Nissune aplicazion e à domandât di doprâ il microfon"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Protêç lis tôs conversazions"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "microfon;regjistrazion;aplicazion;riservatece;privacy;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Prove lis _impostazions"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Gjenerâl"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Boton primari"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Stabilìs l'ordin dai botons fisics sui mouse e touchpad."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Çampe"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Drete"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mouse"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Velocitât Mouse"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Scoriment naturâl"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Il scori al sposte il contignût, no la viodude."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Velocitât Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Tap par fâ clic"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Batuce par fâ clic"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Scoriment a doi dêts"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Scor tal ôr"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Prove a fâ clic, dopli-clic o scori"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinc clic, e je ore di GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dopli-clic, boton primari"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Clic singul, boton primari"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dopli-clic, boton centrâl"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Clic singul, boton centrâl"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dopli-clic, boton secondari"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Clic singul, boton secondari"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mou­se­ e­ ­Touch­pad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Cambie la sensibilitât di mouse e touchpad e selezione se par man diestre o "
+"çampe"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Cursôr;Cursôr;Clic;Tap;Dopli;Boton;Trackball;Cursôr;Scroll;"
+"Scoriment;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Angul _cjalt"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Tocje l'angul in alt a çampe par vierzi la panoramiche des ativitâts."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Ôrs dal schermi _atîfs"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Par ridimensionâ i barcons, strissiniju cuintri i ôrs superiôr, di çampe e "
+"di diestre dal schermi."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Spazis di lavôr"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "Spazis di lavôr _dinamics"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Al gjave in automatic i spazis di lavôr vueits."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "Numar _fis di spazis di lavôr"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Specifiche un numar di spazis di lavôr permanents."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Numar di spazis di lavôr"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multi-Visôr"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Spazis di lavôr dome sul schermi _primari"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Spazis di lavôr su ducj i scherm_is"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Cambi di aplicazion"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Inclût lis aplicazions di ducj i spazis di _lavôr"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Inclût lis aplicazions dome dal spazi di lavôr _corint"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multilavôr"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Gjestìs lis preferencis pe produtivitât e il multilavôr"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multilavôr;Produtivitât;Personalize;Scritori;Scrivanie;Desktop;"
+"Angul cjalt;Spazis di lavôr;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Orpo, al somee che alc al sedi lât ledrôs. Contate il furnidôr di software."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager al à di jessi in esecuzion."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Altris dispositîfs"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Zonteconession"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "No configurade"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Rêt no sigure (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Rêt sigure (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Rêt sigure (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Rêt sigure (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Rêt sigure"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Tacât"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opzions…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Impiant l'hotspot tu ti disconetarâs di %s e nol sarà pussibil acedi  su "
+"internet vie Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "E scugne vê un minim di 8 caratars"
+
+# Si riferìs ae password
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "E scugne vê un massim di %d caratars"
+msgstr[1] "E scugne vê un massim di %d caratars"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Impiâ hotspot Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"L'hotspot Wi-Fi al permet a chei altris di doprâ la tô conession internet, "
+"creant une rêt Wi-Fi dulà che a puedin conetisi. Par fâlu tu scugnis vê une "
+"conession a internet cuntune sorzint divierse dal Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Non rêt"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Gjenere password casuâl"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Gjenere in automatic la password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Impie"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Fermâ l'hotspot e disconeti ducj i utents?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Ferme Hotspot"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Modalitât avion"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Al disabilite Wi-Fi, Bluetooth e la bande largje mobile"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nissun adatadôr Wi-Fi cjatât"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Sigurâsi di vê un adatadôr Wi-Fi tacât e impiât"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Modalitât avion impiade"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Distude par doprâ il Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Hotspot Wi-Fi atîf"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "I dispositîfs mobii a puedin scansionâ il codiç QR par conetisi."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Distude hotspot…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Rêts visibilis"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager al à di jessi in esecuzion"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Sigurece 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sigurece"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Conserve"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Casuâl"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabile"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"La direzion MAC inseride chi e vignarà doprade come direzion hardware pal "
+"dispositîf di rêt dulà che cheste conession e je ativade. Cheste "
+"funzionalitât e je cognossude come clonazion MAC o spoofing. Esempli: "
+"00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profîl %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nissune"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Mai"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i zornade indaûr"
+msgstr[1] "%i dîs indaûr"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nissune"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Debul"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bon"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Ecelent"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Direzion IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Direzion IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Direzions IP"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Dismentee conession"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Gjave profîl conession"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Gjave VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Detais"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatic"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitât"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Elimine direzion"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Elimine instradament"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Nissune"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Clâf WEP 40/128-bit(Hex o ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Passphrase WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinamic (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 personâl"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Fuarce segnâl"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Velocitât colegament"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Direzion Hardware"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Frecuencis supuartadis"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Instradament predefinît"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Ultime volte doprât"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Conet in _automatic"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Rindi disponibil a chei _altris utents"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"Conession a _consum: e à un limit di dâts o si pues lâ cuintri a spesis"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"I inzornaments dal software e altris grancj discjariaments no vignaran "
+"inviâts in automatic."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Non"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Direzion _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Direzion _Clonade"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Metodi IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatic (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Nome Link-Local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manuâl"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Disative"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Condividût cun altris computers"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Direzions"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Direzion"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Netmask"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatic"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS Automatic"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Direzion(s) servidôr DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Separe lis direzions IP cun virgulis"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Instradaments"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Instradaments automatics"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metriche"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Dopre cheste conession n_ome par lis risorsis inte sô rêt"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Metodi IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatic, nome DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefìs"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Impussibil vierzi l'editor di conession"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Gnûf profîl"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Impostazion %s no valide: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Impostazion %s no valide"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Impuarte di file…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Zonte VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Sigur_ece"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Impussibil impuartâ la conession VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Impussibil lei il file «%s» opûr nol ten informazions di conession VPN "
+"ricognossudis\n"
+"\n"
+"Erôr: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Selezione un file di impuartâ"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Un file clamât «%s» al esist za."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Rimplace"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Vûstu rimplaçâ %s cun la conession VPN che tu stâs salvant?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Impussibil espuartâ la conession VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Impussibil espuartâ la conession VPN «%s» su %s.\n"
+"\n"
+"Erôr: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Espuarte la conession VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Erôr: impussibil cjamâ l'editor di conessions VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Controle cemût conetiti a Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Rêt;Network;IP;LAN;Proxy;WAN;Broadband;Bande largje;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controle cemût conetiti aes rêts Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Rêt;Network;Wireless;Cence fîl;Wi-Fi;Wifi;IP;LAN;Broadband;Bande largje;DNS;"
+"Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "mai"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "vuê"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "îr"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Ultime volte doprât"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Fîl"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Zonte gnove conession"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"A vignaran pierdûts i detais par lis rêts selezionadis, includût lis "
+"password e ogni configurazion personalizade."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Dismentee"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Rêts Wi-Fi cognossudis"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Dismentee"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "La politiche di sisteme e proibìs l'ûs come Hotspot"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Il dispositîf wireless nol supuarte la modalitât Hotspot"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"La individuazion automatiche dal proxy web e ven doprade cuant che nol ven "
+"dât l'URL di configurazion."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Nol è conseât par rêts publichis no fidadis."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Distude il dispositîf"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Atîf"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Provider"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy di rêt"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Host _Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "Host di _ignorâ"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Puarte proxy HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Puarte proxy HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Puarte proxy FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Puarte proxy Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL di _configurazion"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Distude la conession VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Non rêt"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Gjenar di sigurece"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Password"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Distude Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Plui opzions…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Conet a rêt platade…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Impie hotspot Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Rêts Wi-Fi _cognossudis"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Stât no cognossût"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "No gjestît"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "No disponibil"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Daûr a coneti"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Autenticazion necessarie"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Daûr a distacâsi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Conession falide"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Stât no cognossût (al mancje)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Configurazion falide"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Configurazion IP falide"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Configurazion IP scjadude"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "A jerin domandâts segrets, ma no son stâts dâts"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Supplicant 802.1x distacât"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "configurazion supplicant 802.1x falide"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Supplicant 802.1x falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Le autenticazion dal supplicant 802.1x e à doprât masse timp"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Inviament dal servizi PPP falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Servizi PPP disconetût"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Inviament dal client DHCP falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Erôr client DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Client DHCP falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Inviament dal servizi di conession condividude falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Servizi conession condividude falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Inviament dal servizi AutoIP falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Erôr servizi AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Servizi AutoIP falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linie ocupade"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Nissun segnâl di clamade"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Impussibil stabilî cualchi puartant"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "La richieste di selezion e je scjadude"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Tentatîf di selezion falît"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Iniziazion modem falide"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Selezion dal APN specificât falide"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Nissune ricercje di rêts ative"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Regjistrazion rêt neade"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Regjistrazion rêt scjadude"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Regjistrazion falide su pe rêt domandade"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Verifiche PIN falide"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Al podarès mancjâ il firmware dal dispositîf"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Conession sparide"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "A je stade considerade la conession esistente"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem no cjatât"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Conession Bluetooth falide"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Schede SIM no inseride"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Si domande codiç PIN de SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Si domande codiç PUK de SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Schede SIM falade/sbaliade"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Dipendence de conession falide"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Firmware mancjant"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Fil stacât"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "erôr no definît inte sigurece 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "nissun file selezionât"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "erôr no specificât tal validâ il file dal metodi eap"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Clâfs privadis DER, PEM, PKCS#12 o PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certificâts DER o PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "al mancje il file PAC di EAP-FAST"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Files PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonim"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autenticât"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ducj i doi"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identitât anoni_me"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_File PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Sielç un file PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autenticazion _interne"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Permet pro_visioning PAC automatic"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "al mancje il non utent EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "e mancje la password EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Non _utent"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Password"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Mostre pass_word"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "CA dal certificât EAP-PEAP no valit: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "CA dal certificât EAP-PEAP no valit: nissun certificât specificât"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificât C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Sielç un certificât di une Autoritât di Certificazion"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "No covente la CA dal ce_rtificât"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Version PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "al mancje il non utent EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "e mancje la password EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "e mancje la identitât EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "CA dal certificât EAP-TLS no valit: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "CA dal certificât EAP-TLS no valit: nissun certificât specificât"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "clâf privade EAP-TLS no valide: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificât utent EAP-TLS no valit: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Lis clâfs privadis no cifradis no son siguris"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"La clâf privade selezionade no somee jessi protete di une password. Chest al "
+"pues comprometi lis propris credenziâls di sigurece. Selezione une clâf "
+"privade protete di password.\n"
+"\n"
+"(Al è pussibil protezi lis propris clâfs privadis cun openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Sielzi il certificât personâl"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Sielzi la clâf privade personâl"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitât"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificât _utent"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Clâf privade"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Password clâf _privade"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "CA dal certificât EAP-TTLS no valit: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "CA dal certificât EAP-TTLS no valit: nissun certificât specificât"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domini"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Erôr no cognossût tal validâ la sigurece 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS cun tunnel"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "PEAP (Protected EAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tenticazion"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Selezione un file"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "al mancje il non utent leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "e mancje la password leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "E mancje la password dal Wi-Fi."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Gjenar"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "e mancje la clâf wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"clâf wep no valide: une clâf di lungjece %zu e scugne contignî nome cifris "
+"esadecimâi"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"clâf wep no valide: une clâf di lungjece %zu e scugne contignî nome caratars "
+"ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"clâf wep no valide: lungjece %zu de clâf sbaliade. Une clâf e scugne jessi o "
+"di lungjece 5/13 (ascii) o 10/26 (esadecimâl)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "clâf wep no valide: la passphrase no pues jessi vueide"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"clâf wep no valide: la passphrase no pues jessi plui curte di 64 caratars"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Predefinît)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sisteme Viert"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Clâf condividude"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Clâf"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "M_ostre la clâf"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Indi_ç WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk no valit: lungjece %zu de clâf no valide. E scugne jessi [8,63] "
+"bytes o 64 cifris esadecimâi"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk no valit: impussibil interpretâ la clâf di 64 bytes come esadecimâl"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notifichis"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Avîs sonôrs"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Notifichis a com_parse"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Lis notifichis a continuaran a vignî fûr inte liste des notifichis cuant che "
+"lis notifichis a comparse a son disabilitadis."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Mostre _contignût messaç intes notifichis a comparse"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notifichis sul schermi b_locât"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Mostrâ i c_ontignûts dal messaç sul schermi blocât"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_No sta disturbâ"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Notifichis sul schermi b_locât"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controle cualis notifichis mostrâ e ce che a mostrin"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifichis;Banner;Messaç;Tray;Popup;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Altri"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s gjavât"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Erôr tal gjava l'account"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Disfe"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Siere la notifiche"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Tachiti ai tiei dâts tal cloud"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Nissune conession a internet — conetiti par configurâ gnûfs account onlinie"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Zonte un account"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Account di %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Gjave account"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Ac­count­ ­on­line"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Conetiti ai tiei account online e decît cemût doprâju"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Conversazions;Calendari;Mail;E-"
+"mail;Email;Pueste;Contat;Contats;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
+"ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Timp no cognossût"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minût"
+msgstr[1] "%i minûts"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ore"
+msgstr[1] "%i oris"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s e %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ore"
+msgstr[1] "oris"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minût"
+msgstr[1] "minûts"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s ae cjarie plene"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Atenzion: ancjemò %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "ancjemò %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Cjarie"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Nol sta cjariant"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Scjarie"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "In cjarie"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "In scjarie"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Mouse cence fîl"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Tastiere cence fîl"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "UPS"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "PDA"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Celulâr"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Letôr multimediâl"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Computer"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Dispositîf di input par zuiâ"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batarie"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principâl"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Adizionâl"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batariis"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Cuant _inatîf"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Sospindi"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Distudâ"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Ibernâ"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nissune azion"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Cuant che si dopre la batarie"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Cuant che al è alimentât"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Mai"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Sospension automatiche"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Modalitât prestazions disabilitade in mût temporani par vie de temperadure "
+"di operazion elevade."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Portatil rilevât: modalitât prestazions no disponibile in mût temporani. "
+"Sposte il dispositîf suntune superficie stabile par ripristinâ."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Modalitât prestazions disabilitade in mût temporani."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Cjarie batarie basse: sparagn energjetic abilitât. La modalitât precedente e "
+"vignarà ripristinade cuant che la batarie e sarà cjamade a suficience."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Modalitât sparagn energjetic ativade di “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Modalitât prestazions ativade di “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minûts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minûts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minûts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minûts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minûts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 ore"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minûts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minûts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minûts"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 oris"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Modalitât potence"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Al influìs su lis prestazions dal sisteme e sul consum energjetic."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opzions di sparagn energjetic"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Luminositât dal schermi automatiche"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "La luminositât dal schermi si juste in base ae lûs tor ator."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Scurî il schermi"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+"Al diminuìs la luminositât dal schermi cuant che il computer al è inatîf."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Schermi _neri"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Al distude il schermi daspò un periodi di inativitât."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Sparagn energjetic automatic"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+"Al abilite la modalitât di sparagn energjetic cuant che la cjarie de batarie "
+"e je basse."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "Sospension _automatiche"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Al met in pause il computer dopo un periodi di inativitât."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Compuartament boton par _impiâ"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Mostre _percentuâl batarie"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Sospension automatiche"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Alimentât de _prese"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Alimentât a _batarie"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Ritart"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Prestazions"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Prestazions elevadis e consum energjetic."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Belançade"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Prestazions e consum energjetic normâi."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Sparagn energjetic"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Prestazions e consum energjetic ridots."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Alimentazion"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Mostre il stât de batarie e cambie lis impostazions di sparagn energjetic"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Alimentazion;Sleep;Sospension;Ibernazion;Batarie;Luminositât;Visôr;Dim;DPMS;"
+"Scûr;Vueit;Monitor;Inatîf;Energjie;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "La stampant “%s” e je stade eliminade"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Zonte de gnove stampant falide."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Impussibil cjariâ la interface: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Sbloche par zontâ stampadoris e cambiâ impostazions"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Stampants"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Zonte stampants, mostre i lavôrs di stampe e decît cemût stampâ"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Stampant;Code;Stampe;Cjarte;Ingjustri;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Zonte stampant"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Sbloche"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Nissune stampant cjatade"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Scrîf une direzion di rêt o cîr une stampant"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autenticazion necessarie"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Scrîf non utent e password par viodi lis stampants su Servidôr Stampant."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Non utent"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Detais di %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Nissun driver adat cjatât"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Selezione file PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Files PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "I nons des stampadoris no puedin vê SPAZIS, TABULAZIONS, # o /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Colocazion"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Ricercje driver preferîts…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Cîr Drivers"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Selezione de Base di dâts…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instale file PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Selezione driver stampant"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Cjariament base di dâts dai driver…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Selezione"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Stampant JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Stampant LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Une bande"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Ôr lunc (standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Ôr curt (ribaltât)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Verticâl"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Orizontâl"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Orizontâl invertît"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Verticâl invertît"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Ripie"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pause"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "In atese"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "In pause"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autenticazion necessarie"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "In elaborazion"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Fermât"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Anulât"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Interot"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Finît"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Môf chest lavôr insom ae code"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u lavôr al domande autenticazion"
+msgstr[1] "%u lavôrs a domandin autenticazion"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Lavôrs Atîfs"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Inserìs lis credenziâls par stampâ di %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domini"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utentiche"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Nete dut"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autentiche"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Nissun lavôr di stampe atîf"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Sbloche servidôr di stampe"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Sbloche %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Scrîf non utent e password par viodi lis stampants su %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Daûr a cirî stampants"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Puarte seriâl"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Puarte paralele"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Colocazion: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Direzion: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Il server al domande autenticazion"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Denant e daûr"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Gjenar di cjarte"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Sorzint cjarte"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Casset di jessude"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Risoluzion"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Pre-filtradure GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Pagjinis par sfuei"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Denant e daûr"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientament"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Gjenerâl"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Impostazions pagjine"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opzions instalabii"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Lavôr"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Cualitât Imagjin"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Colôr"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Finidure"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avanzadis"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Pagjine di prove"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Pagjine di prove"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Automatic"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Impostazions predefinidis stampant"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Inclût nome i caratars GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Convertî a PS nivel 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Convertî a PS nivel 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Nissune pre-filtradure"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Produtôr"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nissun lavôr atîf"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u Lavôr"
+msgstr[1] "%u Lavôrs"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Nete testinis stampant"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Toner in esauriment"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Toner esaurît"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Developer in esauriment"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Developer esaurît"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Furnidure toner in esauriment"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Furnidure toner esauride"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Tapon viert"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Sportel viert"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Cjarte in esauriment"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Cjarte esauride"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Fûr rêt"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Ferme"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Bidon scovacis cuasi plen"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Bidon scovacis plen"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Il fotocondutôr otic al sta par terminâ il sô timp di operativitât"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Il fotocondutôr otic nol funzione plui"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Pronte"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "No acete lavôrs"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "In elaborazion"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Opzions di stampe"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Detais stampant"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Dopre la stampant come impostazion predefinide"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Nete testinis stampant"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Gjave stampant"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nivel ingjustri"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Torne invie cuant che il probleme al ven risolt."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Torne invie"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Zonte stampadore…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Nissune stampant"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Il servizi di sisteme pe stampe\n"
+"    nol somee jessi disponibil."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formâts"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Cîr configurazions regjonâls…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Formâts comuns"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Ducj i formâts"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Nissun risultât cjatât"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Lis ricercjis si puedin fâ par paîs o lenghis."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Anteprime"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperiâi"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrics"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datis"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Da­tis­ ­e­ ­o­ris"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Numars"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Unitât di misure"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Cjarte"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "La lenghe e il formât a vignaran cambiâts al prossim acès"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Jes…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"La impostazion de lenghe e ven doprade pai tescj de interface e pes pagjinis "
+"web. I formâts a vegnin doprâts pai numars, pes datis e pes monedis."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Il to account"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Lenghe"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formâts"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Videade di acès"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Regjon e lenghe"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Selezione la lenghe doprade e i formâts"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Lenghe;Disposizion;Layout;Tastiere;Input;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Domande ce fâ"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "No sta fâ nie"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Vierç cartele"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Vierç supuart"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Sielç une aplicazion par i CD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Sielç une aplicazion par i DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Sielç une aplicazion di eseguî cuant che al ven tacât un letôr musicâl"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Sielç une aplicazion di eseguî cuant che e ven tacade une fotocjamare"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Sielç une aplicazion par i CD di software"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "disc Blu-ray vueit"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "disc CD vueit"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "disc DVD vueit"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "disc HD DVD vueit"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Disc video Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "letôr e-book"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Disc video HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Software Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Selezione la modalitât di gjestion dai supuarts"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _audio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Letôr _musicâl"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Altris supuarts…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_No sta domandâ o inviâ programs cuant che si inserissin supuarts"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Selezione cemût gjestî altris supuarts"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Azion:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Gjenar:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Dispositîfs estraibii"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configure lis impostazions dai dispositîfs estraibils"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"dispositîf;sisteme;predefinît;preferît;preferide;cd;dvd;usb;audio;video;disc;"
+"estraibil;multimedia;esecuzion;autorun;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Sospension dal schermi"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 seconts"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minût"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minûts"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minûts"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minûts"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minûts"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 ore"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minût"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minûts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minûts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minûts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minûts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minûts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minûts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minûts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minûts"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Mai"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Bloc schermi"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Il blocâ in automatic il schermi al impedìs a altris di doprâ il computer "
+"intant che si è vie."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Ritart schermi neri"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Periodi di inativitât daspò di chel il schermi al devente neri."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "B_loc schermi automatic"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Ritart bloc _schermi automatic"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Periodi di timp, dopo che il schermi al è deventât neri, cuant che si è "
+"blocât in automatic."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Mostrâ lis _notifichis sul schermi blocât"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Impedìs gnûfs dispositîfs _USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Impedìs ai gnûfs dispositîfs USB di interagjî cul sisteme cuant che il "
+"schermi al è blocât."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Riservatece schermi"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Limite l'angul di viodude"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Impostazions schermi"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "schermi;bloche;privât;riservatece;privacy;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Selezione posizion"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Posizions di ricercje"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Lis cartelis dulà che lis aplicazions di sisteme,, come Files, Fotos e "
+"Videos, a cirin."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Risorsis"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Segnelibris"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Altris"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Zonte une colocazion"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nissune aplicazion cjatade"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Ricercje di aplicazion"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Inclût i risultâts de ricercje indicâts de aplicazion."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Lis cartelis dulà che lis aplicazions di sisteme a van a cirî."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Risultâts de ricercje"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "I risultâts a vegnin visualizâts secont l'ordin de liste."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controle cualis aplicazions a mostrin risultâts di ricercje te panoramiche "
+"ativitâts"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Cîr;Cjate;Indiç;Plate;Privacy;Risultâts;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Nissune rêt selezionade pe condivision"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Rêts"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "On"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Off"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Abilitât"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Atîf"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Sielzi une cartele"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Zonte"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Abilite condivision multimediâl"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"La condivision di file e permet di condividi cun altris la proprie cartele "
+"Public su pe rêt atuâl doprant: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Cuant che l'acès esterni al è abilitât, i utents lontans a puedin tacâsi "
+"doprant il comant Secure Shell:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Abilite condivision dai files multimediâi personâi"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Non dispositîf copiât"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Direzion dal dispositîf copiade"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Non utent copiât"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Password copiade"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Condivision"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Non _computer"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Condivision _file"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_Scritori lontan"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Condivision _multimediâl"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Acès _esterni"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Condivision file"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Covente password"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Acès esterni"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Scritori lontan"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Il scritori lontan ti permet di visualizâ e controlâ il to scritori doprant "
+"un altri computer."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Abilite o disabilite lis conessions dai scritoris esternis a chest computer."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Control di lontan"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Permet lis conessions di lontan par controlâ il schermi."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Cemût conetisi"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Conetiti a chest computer doprant il non dal dispositîf o la direzion dal "
+"scritori lontan."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copie"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Direzion dal scritori esterni"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autenticazion"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Il non utent e la password a son necessaris par conetisi al chest computer."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Non utent"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Cifradure di verifiche"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Impront di cifradure"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Al è pussibil viodi l'impront di cifradure tai clients che si conetin e al à "
+"di sei compagn."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Condivision multimediâl"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Condivît musiche, fotos e video su la rêt."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Cartelis"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controle ce che si vûl condividi cun altris"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"condivision;share;ssh;host;non;esterni;lontan;desktop;scritori;medie;"
+"multimedie;audio;video;imagjins;fotos;film;servidôr;server;renderer;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Abilitâ o no l'acès esterni"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Al è necessari autenticâsi par abilitâ o no abilitâ l'acès di lontan"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Personalizât"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Clic"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Stringhe"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Ossilazion"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Businâ"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Belançament"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Sfantâ"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Daûr"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Denant"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Prove di %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Fâs clic suntune casse par provâ"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volum di sisteme"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Volum principâl"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Nivei di volum"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Jessude"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Dispositîf di jessude"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Prove"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configurazion"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Ingrès"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Dispositîf di ingrès"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volum"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Sun di avîs"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Cidin"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Audio"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Comede i nivei dal audio, i ingrès, lis jessudis e i suns di alerte"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Schede;Microfon;Volum;Sfantâ;Belançament;Bluetooth;Auricolâr;Scufis;Sun;"
+"Jessude;Jentrade;Ingrès;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Daûr a disconeti"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Daûr a coneti"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Conetût"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Erôr di autorizazion"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Daûr a autorizâ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Funzionalitât ridote"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Conetût e autorizât"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "No cognossût"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autorizât aes:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Conetût aes:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Regjistrât aes:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "No i è rivâts a autorizâ il dispositîf: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "No si è rivâts a dismenteâ il dispositîf: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Al dipent di %u altri dispositîf"
+msgstr[1] "Al dipent di %u altris dispositîfs"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Siere notifiche"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Non:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Stât:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autorize e conet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Dismentee dispositîf"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Erôr"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorizât"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Il sot-sisteme Thunderbolt (boltd) nol è instalât o nol è stât configurât in "
+"maniere adate."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Permet l'acès diret a dispositîfs come supuarts (docks) e GPU esternis."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Dome i dispositîfs USB e Display Port a puedin tacâsi."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Nol è stât pussibil rilevât Thunderbolt.\n"
+"O al mancje tal sisteme il supuart par Thunderbolt, o al è stât disabilitât "
+"tal BIOS o al è stât configurât tal BIOS a un nivel di sigurece no supuartât."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Il supuart a Thunderbolt al è stât disabilitât tal BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Impussibil determinâ il nivel di sigurece di Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Erôr tal passâ ae modalitât direte: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Nissun supuart par Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Impussibil colegâsi al sotsisteme di thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Acès diret"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Dispositîf in pîts in spiete"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Nissun dispositîf tacât"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Gjestìs i dispositîfs Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;riservatece;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Lampâ dal cursôr"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Il cursôr al lampe intai cjamps di test."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocitât"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Velocitât dal lampâ dal cursôr"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Dimension cursôr"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Al è pussibil cumbinâ la dimension dal cursôr cul ingrandiment par fâ viodi "
+"miôr il cursôr."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Assistent clic"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Clic secondari _simulât"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Eseguìs un clic secondari tignint scliçât il pulsant primari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Ritart di a_cetazion:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Ritart clic secondari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lunc"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Clic automatic tal fermâsi"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Eseguìs in automatic un clic cuant che si ferme il cursôr"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "R_itart:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lunc"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Principi di m_oviment:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Piçul"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grant"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Ripet tascj"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Il fracâ dal tast al ripet il caratar fintremai che al reste fracât."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Ritart di ripetizion tascj"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocitât di ripetizion tascj"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Assistent di digjitazion"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Tascj _singui"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Trate une secuence di tascj di modifiche come une cumbinazion di tascj"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_No sta abilitâ se doi tascj a vegnin fracâts tal stes moment"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Avîs sonôr cuant che al ven scliçât un tast di _modifiche"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Tascj _lents"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Al met un ritart tra la pression di un tast e la sô acetazion"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Ritart digjitazion tascj lents"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lunc"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Avîs sonôr cuant che un tast al ven _scliçât"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Avîs sonôr cuant che un tast al ven _acetât"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Avîs sonôr cuant che un tast al ven _refudât"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Tascj s_balçâts"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignore rapidis pressions dopleadis di tascj"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Ritart digjitazion tascj sbalçâts"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lunc"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Abilite di _tastiere"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Tache e stache lis funzions di acessibilitât doprant la tastiere"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Predefinide"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Medie"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Grant"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Plui grant"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Il plui grant"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixel"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Mostre simpri il menù di acessibilitât"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Viste"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Contrast _elevât"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Test _larc"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Abilite lis A_nimazions"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Letôr schermi"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Il letôr di schermi al lei il test mostrât al spostament dal focus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Sun tascj"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Fâs un sun cuant che BlocNum o BlocMaiusc a vegnin ativâts o disativâts."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Dimension c_ursôr"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Ingrandiment"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Uldide"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Avîs _visibii"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Tastiere a visôr"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Rip_et tascj"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Lampâ dal cursôr"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Assistent di digjitazion (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Pontament e clic"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Mouse di tastiere"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Localize il pontadôr"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Assistent _clic"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Ritart _Dopli-clic"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Ritart Dopli-clic"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Avîs visibii"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Prove lampe"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Dopre une indicazion visive in presince di un avîs audio."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Iluminâ dut il _visôr"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Iluminâ dut il _barcon"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ di schermi"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ schermi"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ di schermi"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Lungje"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Plen visôr"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Metât superiôr"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Metât inferiôr"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Metât çampe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Metât diestre"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Opzions di ingrandiment"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "In_grandiment:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posizion dal ingranditôr:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Cor daûr dal cursôr dal mouse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Part di _schermi:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "L'ingranditôr si _slargje fûr dal visôr"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Tegnî il cursôr dal ingranditôr tal mieç"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Il cursôr dal ingranditôr al _sburte il contignût"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Il cursôr dal ingranditôr si sposte cui _contignûts"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Ingranditôr"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "S_mire:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Al sta parsore dal cursôr dal mouse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Spessôr:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Fin"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Spes"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Lungjece:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Co_lôr:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Smiris"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efiets colôr:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "Blanc su _neri:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "L_uminositât:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Co_lôr"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Nissun"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Plen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Basse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alte"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Ridot"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Elevât"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efiets colôr"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Al fâs diventâ plui facil viodi, sintî, digjitâ e fâ clic"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Tastiere;Mouse;a11y;Acessibilitât;Acès Universâl;Contrast;Cursôr;Sun;"
+"Ingrandiment;Zoom;Screen;Reader;Letôr;schermi;grant;alt;larc; test;caratar;"
+"font;dimension;AccessX;Tascj;Singui;Tacadiçs;Sticky;Lents;Slow;Sbalçâts;"
+"Bounce;Mouse;Dopli;clic;Ritart;Assisti;Ripeti;Lampâ;visuâl;sintî;audio;"
+"scriture;animazions;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 ore"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 zornade"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dîs"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dîs"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dîs"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dîs"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dîs"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dîs"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dîs"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dîs"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Disvuedâ la scovacere?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr ""
+"Ducj i elements te scovacere a vignaran eliminâts in maniere definitive."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Dis_vuede scovacere"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Eliminâ ducj i files temporanis?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Ducj i files temporanis a vignaran eliminâts in maniere definitive."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Nete files temporanis"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 zornade"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dîs"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dîs"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Par simpri"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Cronologjie dai file"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"La cronologjie dai files e ten un regjistri dai files che tu âs doprât. "
+"Cheste informazion e ven condividude tra lis aplicazions e e rint plui facil "
+"cjatâ i file che tu podaressis vê bisugne di doprâ."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Cronologj_ie file"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Durade _cronologjie file"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Nete cronologjie…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Scovacere e files temporanis"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Scovacere e files temporanis cualchi volte a puedin includi informazions "
+"sensibilis o personâls. Eliminâju in automatic al pues judâ a protezi la "
+"riservatece."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Elimine in automatic i contignûts de _scovacere"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Elimine in automatic i _files temporanis"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Periodi par eliminâ in automatic"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Dis_vuede scovacere…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Elimine file temporanis…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Cronologjie file e Scovacere"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "No sta lassâ olmis"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"utilizazion;resint;cronologjie;files;temporani;tmp;privât;privacy;"
+"riservatece;scovacere;nete;conserve;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Al varès di corispuindi ae direzion web dal to furnidôr di acès."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Zonte dal account falide"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lis password no corispuindin."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Regjistrazion account falide"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Nissun mût supuartât par autenticâsi cun chest domini"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Falît a unîsi al domini"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Non di acès no valit.\n"
+"Prove une altre volte."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Password no valide.\n"
+"Prove une altre volte."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Acès al domini falît"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Impussibil cjatâ il domini. Isal stât scrit mâl?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Zonte utent"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Aministradôr"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"I aministradôrs a puedin zontâ e gjavâ altris utents e a puedin cambiâ lis "
+"impostazions par ducj i utents. Nol è pussibil aplicâ i controi parentâi ai "
+"aministradôrs."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "L'utent al stabilìs la password al prin acès"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Stabilìs la password cumò"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Conferme"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Acès aziendâl"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Accounts utent che a son gjestîts di une compagnie o une organizazion."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Tu sês fûr rêt"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"L'acès enterprise al permet di doprâ su chest dispositîf un account utent za "
+"esistent ministrât in maniere centrâl. Tu puedis ancje doprâ chest account "
+"par jentrâ tes risorsis de compagnie su internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Esplore altris imagjins"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Selezione un file…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Gjestôr improntis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_No"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Sì"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Eliminâ lis improntis digjitâls regjistradis cussì di disabilitâ l'acès vie "
+"impronte?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Nissun dispositîf pes improntis"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Nissun dispositîf pes improntis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Sigurâsi che il dispositîf al sedi tacât ben."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Dispositîf pes improntis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Sielç il dispositîf pes improntis di configurâ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Acès cun impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"L'acès cun impronte ti permet di sblocâ e jentrâ sul to computer cul to dêt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Elimine improntis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Regjistrazion impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "si à di reclamâ il dispositîf par eseguî cheste azion"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "il dispositîf al è za reclamât di un altri procès"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "no tu âs i permès par eseguî la azion"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "no je stade regjistrade nissune impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "No si è rivâts a comunicâ cul dispositîf dilunc la regjistrazion"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "No si è rivâts a comunicâ cul letôr di improntis digjitâls"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "No si è rivâts a comunicâ cul demoni pes improntis digjitâls"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "No si è rivâts a listâ lis improntis: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "No si è rivâts a eliminâ lis improntis salvadis: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Poleâr çamp"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Medi çamp"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "Dêt indiç _çamp"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Anulâr çamp"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Dêt piçul çamp"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Poleâr diestri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Medi diestri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "Dêt indiç _diestri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Anulâr diestri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Dêt piçul diestri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Impronte no cognossude"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Completade"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Dispositîf pes improntis disconetût"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Il spazi di archiviazion dal dispositîf pes improntis al è plen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "No si è rivâts a regjistrâ la gnove impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "No si è rivâts a scomençâ la regjistrazion: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "No si è rivâts a regjistrâ la gnove impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "No si è rivâts a fermâ la regjistrazion: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Alce e met tantis voltis il to dêt sul letôr par regjistrâ la tô impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "_Torne regjistre chest dêt…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Regjistre gnove impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "No si è rivâts a molâ il dispositîf pes improntis %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Probleme tal lei dal dispositîf"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "No si è rivâts a riclamâ il dispositîf pes improntis %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "No si è rivâts a otignî i dispositîfs pes improntis: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Cheste setemane"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Setemane passade"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%H:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Fin session"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Inizi session"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Ativitât dal account"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Precedent"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Sucessîf"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Sielç une altre password."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Scrîf di gnûf la tô password atuâl."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Impussibil cambiâ la password"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Cambie password"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "C_ambie"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Password atuâl"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Gnove password"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Conferme password"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Permet al utent di cambiâ la sô password al prossim acès"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Stabilìs une password cumò"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Impussibil unîsi in automatic a chest gjenar di domini"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Nissun domini o ream cjatâts"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Impussibil acedi come %s al domini %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Password no valide, prove di gnûf"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Impussibil tacâsi al domini %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Eliminazion utent falide"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "No si è rivâts a revocâ l'utent gjestît di lontan"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Nol è permetût eliminâ il propri account."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s nol à ancjemò terminât la session"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Eliminâ un utent intant che la sô session e je ancjemò in cors, al pues "
+"lassâ il sisteme in stât incoerent."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Tignî i files di %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Al è pussibil tegnî la cartele home, la code di pueste e i varis files "
+"temporanis cuant che si elimine un account utent."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Elimine i files"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Ten i files"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Revocâ pardabon l'account di %s gjestît di lontan?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Elimine"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Account disabilitât"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Di stabilî al prossim acès"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Nissun"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Acès eseguît"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Comunicazion cun servizi account falide"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Sigurâsi che AccountService al sedi instalât e abilitât."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Al è necessari sblocâ chest panel par cambiâ cheste impostazion"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Elimine l'account utent selezionât"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Par eliminâ l'account utent selezionât,\n"
+"fâs prime clic su la icone *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Sbloche par Zontâ utents e Cambiâ impostazions"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Utents"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Al è necessari tornâ a inviâ la session par aplicâ lis modifichis"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Torne invie cumò"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Siere"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Modifiche avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Non complet"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Modifiche"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Acès cun impronte"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Acès automatic"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Ativitât dal account"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Aministradôr"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"I aministradôrs a puedin zontâ e gjavâ altris utents e a puedin cambiâ lis "
+"impostazions par ducj i utent."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "Controi _parentâi"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Vierç la aplicazion pai controi parentâi."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Gjave utent…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Altris utents"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Zonte utent…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Nissun utent cjatât"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Sbloche par zontâ un account utent."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Zonte o gjave utents e cambie la tô password"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Acès;Non;Impront;Digjitâl,Avatar;Logo;Muse;Password;Controi parentâi;"
+"Timp schermi;Restrizions aplicazions;Restrizions web;Utilizazion;Limit di "
+"utilizazion;Frut;Fi;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Regjistre"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Acès aministradôr domini"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Par podê doprâ i acès aziendâi, il computer al à di jessi\n"
+" regjistrât tal domini. Domandâ al aministradôr di rêt\n"
+"di scrivi la password pal domini in chest cjamp."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Non aministradôr"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Password aministradôr"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Ministre i account online"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Si scugne autenticâsi par cambiâ i dâts utent"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "La gnove password e scugne jessi divierse de precedent."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Prove cambie cualchi letare e numar."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Prove cambie la password un tic di plui."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Une password cence il tô non utent e sarès plui robuste."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Cîr di evitâ di doprâ il tô non te password."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Cîr di evitâ cualchi peraule includude te password."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Cîr di evitâ peraulis comunis."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Cîr di evitâ di tornâ a ordenâ  peraulis esistentis."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Cîr di doprâ plui numars."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Cîr di doprâ plui letaris maiusculis."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Cîr di doprâ plui letaris minusculis."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Cîr di doprâ plui caratars speciâi, come i ponts."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Cîr di doprâ une misture di letaris, numars e ponts."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Cîr di evitâ di ripeti il stes caratar."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Cîr di evitâ di ripeti il stes gjenar di caratar: tu scugnis miscliçâ "
+"letaris, numars e ponts."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Cîr di evitâ secuencis come 1234 o abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"La password e scugne jessi plui lungje. Cîr di zontâ plui letaris, numars e "
+"ponts."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Misture letaris maiusculis e minusculis e cîr di doprâ un numar o doi."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Zontant plui letaris, numars e ponts si fasarà diventâ la password plui "
+"robuste."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Autenticazion falide"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "La gnove password e je masse curte"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "La gnove password e je masse semplice"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "La password vecje e chê gnove a son masse similis"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "La gnove password e je za stade doprade di resint."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "La gnove password e scugne vê caratars numerics o speciâi"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "La password vecje e chê gnove a son compagnis"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "La tô password e je stade cambiade di cuant che tu ti sês autenticât!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "La gnove password no à vonde caratars diferents"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Erôr no cognossût"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Il non utent di solit al à di jessi formât di letaris minusculis (de a ae "
+"z), numars e dai caratars chi daurman: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Mi displâs, chel non utent nol è disponibil. Prove cuntun altri."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Il non utent al è masse lunc."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Associe botons"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Associe i botons a lis funzions"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Par modificâ une scurte, sielzi la azion \"Invie pression tascj\", scliçâ il "
+"boton de scurte de tastiere e tignî scliçâts i gnûfs tascj, o se no scliçâ "
+"Backspace par scancelâle."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Siere"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Fâs \"tap\" sui segnepuest cuant che a vegnin fûr sul visôr par calibrâ la "
+"taulete grafiche."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Rilevât clic sbaliât, si torne a inviâ…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Boton %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplicazion definide"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Invie pression tascj"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Cambie visôr"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Mostre jutori a schermi"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Taulete montade sul panel dal portatil"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Taulete montade su visôr esterni"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Dispositîf taulete esterni"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Dispositîf esterni panel/taulete"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Ducj i visôrs"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Modalitât taulete"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Dopre la posizion assolude pe pene"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientament par çampins"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+"Taulete e Express Keys™ a vegnin voltadis pe utilizazion cu la man çampe"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mape su visôr"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Manten lis proporzions"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Dopre dome une porzion de superficie de taulete par mantignî lis proporzions "
+"dal visôr"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Calibre"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nissune taulete rilevade"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Tache o impie la taulete Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensibilitât de ponte"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Lizere"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pression de ponte de pene"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Pesante"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Boton 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Boton 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Boton 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilitât de gome"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pression de gome"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Clic boton di mieç dal mouse"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Clic boton diestri dal mouse"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Indenant"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Stîl di aerograf cun pression, inclinazion e cursôr integrât"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Stîl di aerograf cun pression, inclinazion e rotazion"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Stîl standard cun pression e inclinazion"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Stîl standard cun pression"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Taulete Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Stabilìs la mapadure dai botons e juste la sensibilitât de pene pes taulutis "
+"grafichis"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;Taulete;Pene;Gome;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Gnove scurte…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Ponts di acès"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operazion anulade"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Erôr:</b> acès dineât par cambiâ impostazions"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Erôr:</b> erôr aparât mobil"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "No regjistrât"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Regjistrât"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Daûr a cirî"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Dineât"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Detais dal modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Stât dal modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operadôr"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Gjenar di rêt"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Stât de rêt"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Propri numar"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Detais dal dispositîf"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Version dal firmware"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Dome 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Dome 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Dome 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Dome 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (Preferît), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (Preferît), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (Preferît), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Preferît), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Preferît), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (Preferît), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (Preferît), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (Preferît), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (Preferît), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (Preferît), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (Preferît), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (Preferît), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (Preferît), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (Preferît), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (Preferît), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (Preferît), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (Preferît)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (Preferît), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "No cognossude"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Sbloche schede SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Sbloche"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Inserìs il codiç PIN pe SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Inserìs il PIN par sblocâ la tô schede SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Inserìs il codiç PUK pe SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Inserìs il PUK par sblocâ la tô schede SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Inseride password sbaliade. Tu âs ancjemò %1$u tentatîf"
+msgstr[1] "Inseride password sbaliade. Tu âs ancjemò %1$u tentatîfs"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Tu âs ancjemò %u tentatîf"
+msgstr[1] "Tu âs ancjemò %u tentatîfs"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Inseride password sbaliade."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Il codiç PUK al à di sei un numar di 8 cifris"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Inserìs il gnûf PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Il codiç PIN al à di sei un numar di 4-8 cifris"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Daûr a sblocâ…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Nissune SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Inserìs une schede SIM par doprâ chest modem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM blocade"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "Dâts _mobii"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Rive ai dâts doprant la rêt mobile"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Roaming di dâts"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Dopre i dâts mobii cuant che tu sês in roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Modalitât de rêt"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "R_êt"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avanzadis"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Nons dai ponts di _acès"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Bloc de _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Bloche la SIM cul PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Detais dal m_odem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Erôr dal telefon"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Nissune conession al telefon"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operazion no permetude"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operazion no supuartade"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM no inseride"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "PIN de SIM necessari"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "PUK de SIM necessari"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Erôr de SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM impegnade"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Password sbaliade"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "PIN2 de SIM necessari"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "PUK2 de SIM necessari"
+
+#  o no cjatade?
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "No cjatât"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Nissun servizi di rêt"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Timp di scjadince de rêt"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Servizis GPRS no permetûts"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming no consintût in cheste aree di posizione"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Erôr GPRS no specificât"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Nissun erôr"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Azion anulade"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Acès dineât"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Erôr no cognossût"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Modalitât de rêt"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatic"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Sielç la rêt"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Inzorne i operadôrs di rêt"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Abilite la rêt mobile"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nissun adatadôr WWAN cjatât"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Controle di vê un dispositîf pe rêt Wan cence fîi/celulâr"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+"La rêt Wan cence fîi no je abilitade cuant che la modalitât avion e je "
+"impiade"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Dis_tude modalitât avion"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Conession dâts"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Schede SIM doprade par internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Bloc de SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Sucessive"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Bloche la SIM cul PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Cambie il PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Inserìs il PIN atuâl par cambiâ lis impostazion di bloc de SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Rêt mobile"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configure la telefonie e lis conessions dâts mobili"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "celulâr;wwan;telefonie;sim;mobil;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilitât par configurâ l'ambient grafic GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Impostazions e je la interface principâl par configurâ il sisteme."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Il progjet GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Mostre numar version"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Abilite modalitât lungje/fetose"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Cîr la stringhe"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Liste i nons dai panei disponibii e jes"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel di mostrâ"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGOMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categoriis des impostazions"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privacy"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Panei disponibii:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Dutis lis impostazions"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menù primari"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Avertiment: Version di svilup"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Cheste version di Impostazions e à di jessi doprade dome par finalitâts di "
+"svilup. A puedin capitâ compuartaments dal sisteme sbaliâts, pierditis di "
+"dâts e altris problemis inspietâts. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Jutori"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Gjenerâl"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Jes"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Cîr"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panei"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Torne al panel precedent"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Anule ricercje"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferencis;Impostazions;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "L'identificadôr pal ultin panel di Impostazions di vierzi"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"L'identificadôr pal ultin panel di Impostazions di vierzi. I valôrs no "
+"ricognossûts a vignaran ignorâts e al vignarà selezionât il prin panel inte "
+"liste."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Mostre avertiment cuant che si eseguìs une version di svilup di Impostazions"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Indiche se Impostazions al à di mostrâ un avertiment cuant che si eseguìs "
+"une version di svilup."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Stât iniziâl dal barcon"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Une tuple che e conten i valôrs iniziâi di largjece, altece e stât slargjât "
+"dal barcon de aplicazion."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u jessude"
+msgstr[1] "%u jessudis"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ingrès"
+msgstr[1] "%u jentradis"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Suns di sisteme"
+
+#~ msgid "Light"
+#~ msgstr "Clâr"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Disposizion dai visôrs"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Bloche il to schermi"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificâts DER o PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Zonte une stampant…"
+
+#~ msgid "Drip"
+#~ msgstr "Gote"
+
+#~ msgid "Glass"
+#~ msgstr "Veri"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "schermi;visôr;bloc;diagnostiche;crash;privât;resint;temporani;tmp;indiç;"
+#~ "non;rêt;identitât;"
+
+#~ msgid "Set"
+#~ msgstr "Met"
+
+#~ msgid "Bark"
+#~ msgstr "Vuacade"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Panel pai suns di Impostazions di GNOME"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Panel pal mouse e touchpad di Impostazions di GNOME"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Panel pal fondâl di Impostazions di GNOME"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Panel pe tastiere di Impostazions di GNOME"
+
+#~ msgid "Web Links"
+#~ msgstr "Colegaments Web"
+
+#~ msgid "Git Links"
+#~ msgstr "Colegaments Git"
+
+#~ msgid "%s Links"
+#~ msgstr "Colegaments %s"
+
+#~ msgid "Unset"
+#~ msgstr "No assegnâ"
+
+#~ msgid "Links"
+#~ msgstr "Colegaments"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Files di ipertest"
+
+#~ msgid "Text Files"
+#~ msgstr "Files di test"
+
+#~ msgid "Image Files"
+#~ msgstr "Files di imagjin"
+
+#~ msgid "Font Files"
+#~ msgstr "Files di caratar"
+
+#~ msgid "Archive Files"
+#~ msgstr "Files di archivi"
+
+#~ msgid "Package Files"
+#~ msgstr "Files di pachet"
+
+#~ msgid "Audio Files"
+#~ msgstr "Files di sun"
+
+#~ msgid "Video Files"
+#~ msgstr "Files di video"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permès e acès"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Dâts e servizis che cheste aplicazion e à domandât di vê acès e permès "
+#~ "che e à dibisugne."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "No pues jessi cambiade"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Si puedin tornâ a viodi i permès individuâi pes aplicazions intes "
+#~ "impostazions de <a href=\"privacy\">Privacy</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integrazion"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Stabilìs fonts pe scrivanie"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Gjestôrs predefinîts"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Gjenars di files e colegaments che cheste aplicazion e vierç."
+
+#~ msgid "Usage"
+#~ msgstr "Ûs"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Tropis risorsis che cheste aplicazion e sta doprant."
+
+#~ msgid "Open in Software"
+#~ msgstr "Vierç in Software"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Permet aes aplicazion chi sot di doprâ la tô fotocjamare."
+
+#~ msgid "Display Mode"
+#~ msgstr "Modalitât visôr"
+
+#~ msgid "Join Displays"
+#~ msgstr "Unìs visôrs"
+
+#~ msgid "Single Display"
+#~ msgstr "Visôr ugnul"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Strissine i visôrs par fâ corispuindi la tô configurazion fisiche dai "
+#~ "visôrs. Selezione un visôr par cambiâ lis sôs impostazions."
+
+#~ msgid "Active Display"
+#~ msgstr "Visôr atîf"
+
+#~ msgid "More Warm"
+#~ msgstr "Plui cjalt"
+
+#~ msgid "Less Warm"
+#~ msgstr "Mancul cjalt"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Salve une schermade in $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Salve une schermade di un barcon in $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Salve une schermade di une aree in $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copie une schermade intes notis"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copie une schermade di un barcon intes notis"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copie une schermade di une aree intes notis"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Regjistre un piçul screencast"
+
+#~ msgid "Move up"
+#~ msgstr "Sposte in sù"
+
+#~ msgid "Move down"
+#~ msgstr "Sposte in jù"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "I servizis su la localizazion a permetin a lis aplicazions di cognossi la "
+#~ "tô posizion. Doprant il Wi-Fi e la bande largje mobile e aumente la "
+#~ "precision."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Al dopre il servizi di localizazion di Mozilla: <a href='https://location."
+#~ "services.mozilla.com/privacy'>Politiche di Privacy</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Permet aes aplicazions chi sot di determinâ la tô posizion."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Permet aes aplicazions chi sot di doprâ il tô microfon."
+
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+# Lap?
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Portatil rilevât: modalitât prestazions no disponibile"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Temperadure hardware elevade: modalitât prestazions no disponibile"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Modalitât prestazions no disponibile"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autentiche"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Sielç il formât pai numars, pes datis e pe monede. Lis modifichis a "
+#~ "deventaran ativis al prossim acès."
+
+#~ msgid "My Account"
+#~ msgstr "Account personâl"
+
+#~ msgid "Language"
+#~ msgstr "Lenghe"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "La lenghe doprade pal test tai barcons e tes pagjinis web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Torne invie la session par aplicâ lis modifichis"
+
+#~ msgid "Restart…"
+#~ msgstr "Torne invie…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Lis impostazions di acès a vegnin dopradis di ducj i utents cuant che a "
+#~ "fasin il login"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Controle cuai risultâts di ricercje a son mostrâts te Panoramiche "
+#~ "Ativitâts. Al è pussibil cambiâ l'ordin dai risultâts di ricercje "
+#~ "spostant lis riis inte liste."
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "La condivision dal visôr e permet ai utents esternis di viodi o controlâ "
+#~ "il to schermi conetintsi a %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Condivision _schermi"
+
+#~ msgid "_Password:"
+#~ msgstr "_Password:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Mostre password"
+
+#~ msgid "Access Options"
+#~ msgstr "Opzions di acès"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Lis _gnovis conessions a scugnin domandâ l'acès"
+
+#~ msgid "_Require a password"
+#~ msgstr "_E covente une password"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Sun tascj"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Letôr schermi"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Letôr _schermi"
+
+#~ msgid "Standard"
+#~ msgstr "Normâl"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Gjenar di account"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Permet al utent di stabilî une password al prossim _acès"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Stabilìs une password _cumò"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Tu scugnis jessi in rêt par zontâ utents enterprise."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Scate une foto…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Par aplicâ cambiaments,\n"
+#~ "fâs prime clic su la icone *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Cree un account utent"
+
+#~ msgid "User Icon"
+#~ msgstr "Icone utent"
+
+#~ msgid "Account Settings"
+#~ msgstr "Impostazions account"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autenticazion e acès"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Chest al vignarà doprât par dâ un non ae tô cartele cjase (home) e nol "
+#~ "podarà jessi cambiât."
+
+#~ msgid "Output:"
+#~ msgstr "Jessude:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Tegnî il rapuart (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mape su singul visôr"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d di %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Mapadure display"
+
+#~ msgid "Stylus"
+#~ msgstr "Pene"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Taulete (assolude)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Touchpad (relative)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferencis de taulete"
+
+#~ msgid "_Help"
+#~ msgstr "_Jutori"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Impostazions Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Modalitât segnadure"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Associe botons…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Juste lis impostazions dal mouse"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Juste la risoluzion dal visôr"
+
+#~ msgid "No stylus found"
+#~ msgstr "Nissune pene cjatade"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Sposte la tô pene dongje de taulete par configurâle"
+
+#~ msgid "Top Button"
+#~ msgstr "Boton superiôr"
+
+#~ msgid "Lower Button"
+#~ msgstr "Boton inferiôr"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Boton plui in bas"
+
+#~ msgid "Activities"
+#~ msgstr "Ativitâts"
+
+#~ msgid "_Copy"
+#~ msgstr "_Copie"
+
+#~ msgid "Select _All"
+#~ msgstr "Selezione _dut"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Timp util pal dopli-clic"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Sospension e boton par distudâ"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Cualchi servizi nol è abilitât parcè che nol è acès di rêt."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Falît tal cjariâ il file: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Il profîl al è stât cjariât su:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Cjape note di cheste URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Torne invie il computer e eseguìs il boot dal abituâl sisteme operatîf."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Scrîf l'URL tal browser par scjariâ e instalâ il profîl."
+
+#~ msgid "Upload profile"
+#~ msgstr "Cjarie profîl"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Si scugne vê une conession internet"
+
+#~ msgid "Balanced Power"
+#~ msgstr "Belançament energjetic"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Login;Acès;Non;Impronte;Avatar;Logo;Muse;Password;"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Luminositât dal _schermi"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Luminositât de _tastiere"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Scurìs il schermi cuant che si è inatîfs"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "Schermi _neri"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Si pues distudâ il Wi-Fi par sparagnâ curint."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Si pues distudâ la bande largje mobile (3G, 4G, LTE, ecc.) par sparagnâ "
+#~ "curint."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Si pues distudâ il Bluetooth par sparagnâ curint."
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Scurte di tastiere"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Chest si lu pues cambiâ in Scurtis personalizadis"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Ten fracât e digjite par inserî caratars diferents"
+
+#~ msgid "Add…"
+#~ msgstr "Zonte…"
+
+#~ msgid "Previous source"
+#~ msgstr "Sorzint precedente"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Maiusc+Spazi"
+
+#~ msgid "Next source"
+#~ msgstr "Prossime sorzint"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Spazi"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt diestri + çampe"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Tascj caratar alternatîfs"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Dome i \"modificadôrs\" a passin ae sorzint sucessive"
+
+#~ msgid "Left Alt"
+#~ msgstr "Alt a çampe"
+
+#~ msgid "Right Alt"
+#~ msgstr "Alt a diestre"
+
+#~ msgid "Left Super"
+#~ msgstr "Super di çampe"
+
+#~ msgid "Right Super"
+#~ msgstr "Super di diestre"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl di diestre"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Tast menù"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "In cjarie"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Atenzion"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Basse"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Buine"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Cjarie"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Scjarie"
+
+#~ msgid "Universal Access"
+#~ msgstr "Acès universâl"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Distude par tacâsi suntune rêt Wi-Fi"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Password"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Zontâ i account utent e cambiâ lis password"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Riprodusi e regjistrâ suns"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Rilevâ dispositîfs di rêt doprant mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Acedi a hardware bluetooth in maniere direte"
+
+#~ msgid "Use your camera"
+#~ msgstr "Doprâ la vuestre fotocjamare"
+
+#~ msgid "Print documents"
+#~ msgstr "Stampâ documents"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Doprâ cualsisei joystick tacât"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Permeti la conession al servizi Docker"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Configurâ il firewall di rêt"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Configurâ e doprâ i filesystem FUSE privilegjâts"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Inzornâ il firmware su chest dispositîf"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Acedi a informazions dal hardware"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Furnî entropie al gjeneradôr di numars casuâi in hardware"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Doprâ i numars casuâi gjenerâts in hardware"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Acedi ai file inte vuestre cartele home"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Acedi al servizi libvirt"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Cambiâ la lenghe dal sisteme e lis impostazions de regjon"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Cambiâ lis impostazions di localizazion e i furnidôrs dal servizi"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Lei i regjistris dal sisteme e des aplicazions"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "acedi al servizi di media-hub"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Doprâ e configurâ i modem"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Lei lis informazions di montaç dal sisteme e lis cuotis dai discs"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Controlâ i riprodutôrs musicâi e video"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Cambiâ lis impostazions di rêt di bas nivel"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Acedi al servizi NetworkManager par lei e cambiâ lis impostazions di rêt"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Lei l'acès aes impostazions di rêt"
+
+#~ msgid "Change network settings"
+#~ msgstr "Cambiâ lis impostazions di rêt"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Acedi al servizi ofono par lei e cambiâ lis impostazions di rêt pe "
+#~ "telefonie mobile"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Controlâ l'hardware Open vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Lei di CD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Lei, zontâ, cambiâ o gjavâ lis password salvadis"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Acedi ai dispositîfs pppd e ppp par configurâ lis conessions cul protocol "
+#~ "Pont-a-Pont (PPP)"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Meti in pause o terminâ cualsisei procès sul sisteme"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Acedi al hardware USB in maniere direte"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Lei/scrivi i file su dispositîfs di archiviazion estraibii"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Impedî al schermi di polsâ/blocâsi"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Acedi al hardware de puarte seriâl"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Tornâ a inviâ o distudâ il dispositîf"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Instalâ, gjavâ e configurâ software"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Acedi al servizi de suaze di archiviazion"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Lei i procès e lis informazions di sisteme"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Tignî monitorât e controlâ cualsisei program in esecuzion"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Cambiâ la date e la ore"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Cambiâ lis impostazions dal servidôr pe ore"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Cambiâ il fûs orari"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Acedi al servizi UDisks2 par configurâ i discs e i supuarts estraibii"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Lei/cambiâ i events condividûts dal calendari in Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Lei/cambiâ i contats condividûts in Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Acedi ai dâts su la energjie doprade"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Lei/scrivi l'acès ai dispositîfs U2F esposcj"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Par creâ un account utent,\n"
+#~ "fas prime clic su la icone *"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Abilite acès cun impronte"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Altri dêt:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "La tô impronte digjitâl e je stade salvade. Cumò tu puedis jentrâ doprant "
+#~ "il letôr di improntis."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "L'acès al dispositîf nol è permetût. Contatâ l'aministradôr di sisteme."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Al è vignût fûr un erôr interni."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Eliminâ lis improntis digjitâi regjistradis?"
+
+#~ msgid "Done!"
+#~ msgstr "Fat!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Impussibil acedi al dispositîf “%s”"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Impussibil tacâ la cature de impronte sul dispositîf “%s”"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "No rivi a acedi a nissun letôr di improntis digjitâi"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Contatâ l'aministradôr di sisteme par vê jutori."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Par abilitâ l'acès vie impronte digjitâl al covente salvâ une proprie "
+#~ "impronte digjitâl doprant il dispositîf «%s»."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Sielç dêt"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Stabilìs Fonts e Bloc schermi"
+
+#~ msgid "Set Background"
+#~ msgstr "Stabilìs fonts"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Stabilìs Bloc schermi"
+
+#~ msgid "Remove Background"
+#~ msgstr "Gjave fonts"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Lis segnalazions a vegnin inviadis in maniere anonime e netadis di "
+#~ "cualsisei dât personâl."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Inviant segnalazions di problemis tecnics nus jude a miorâ chest sisteme "
+#~ "operatîf."
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Notifichis a com_parse"
+
+#~ msgid "Last Login"
+#~ msgstr "Ultin acès"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Limite l'ûs di dâts in _sotfont"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Indicât par conessions cun adebit o limits di dâts."
+
+#~ msgid "No regions found"
+#~ msgstr "Nissune regjon cjatade"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Ilumine il titul dal _barcon"
+
+#~ msgid "Version %s"
+#~ msgstr "Version %s"
+
+#~ msgid "OS name"
+#~ msgstr "Non SO"
+
+#~ msgid "OS type"
+#~ msgstr "Gjenar di SO"
+
+#~ msgid "Disk"
+#~ msgstr "Disc"
+
+#~ msgid "Check for updates"
+#~ msgstr "Controle inzornaments"
+
+#~ msgid "Network proxy"
+#~ msgstr "Proxy di rêt"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "_Autenticazion interne"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "_Conet in automatic"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Mostre p_assword"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Rint disponibil a chei altris utents"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Direzions"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Dome direzions automatichis (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Dome link-local"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignore instradaments vûts in automatic"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Direzions MAC _clonadis"
+
+#~ msgid "_Reset"
+#~ msgstr "_Reset"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Puarte lis impostazions par cheste conession ai valôr predefinîts, ma "
+#~ "tegnile come conession predefinide."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Gjave ducj i detais relatîfs a cheste rêt e no cîr di conetisi in "
+#~ "automatic."
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Reset"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Dispositîfs tacâts"
+
+#~ msgid "In use"
+#~ msgstr "In ûs"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "On"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Distudât"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Impiât"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Distudât"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Impiât"
+
+#~ msgid "Usage & History"
+#~ msgstr "Ûs e Cronologjie"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Informative su la privacy"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Tegnî une cronologjie al fâs diventâ plui facil cjatâ ce che al covente. "
+#~ "Chescj elements no saran mai condividûts in rêt."
+
+#~ msgid "_Recently Used"
+#~ msgstr "Doprâts di recent"
+
+#~ msgid "Retain _History"
+#~ msgstr "_Ten la cronologjie"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Il bloc schermi al protêç la proprie privacy intant che si è assents."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "_Bloche schermi se neri par"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Notifichis sul schermi blocât"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Nete in automatic la scovacere e i file temporanis par tegnî il computer "
+#~ "libar di informazions sensibilis no necessaris."
+
+#~ msgid "Purge _After"
+#~ msgstr "Nete _dopo"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Inviâ informazions sul software doprât nus jude a furnî conseis plui "
+#~ "precîs e a miorâ il stes software.\n"
+#~ "\n"
+#~ "Dutis lis informazions a vegnin cjapadis in maniere anonime: chei dâts no "
+#~ "vegnaran mai condividûts cun tiercis parts."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "Inviâ _statistichis sul ûs dal software"
+
+#~ msgid "_Camera"
+#~ msgstr "Foto_cjamare"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Microfon"
+
+#~ msgid "_Location Services"
+#~ msgstr "Servizis di _localizazion"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Protêç lis propris informazions personâi e controle ce che i altris a "
+#~ "puedin viodi"
+
+#~ msgid "page 1"
+#~ msgstr "pagjine 1"
+
+#~ msgid "page 2"
+#~ msgstr "pagjine 2"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Impiant il hotspot wireless tu ti gjavarâs de conession cun <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Al è impussibil conetisi a internet vie wireless fintremai che il "
+#~ "hotspost al è atîf."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "I hotspot Wi-Fi a son doprâts di solit par condividi une conession "
+#~ "internet adizionâl sore dal Wi-Fi."
+
+#~ msgid "details"
+#~ msgstr "detais"
+
+#~ msgid "identity"
+#~ msgstr "identitât"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastructure"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Il non utent nol pues tacâ cuntun “-”."
+
+#~ msgid "Delete Background"
+#~ msgstr "Elimine fonts"
+
+#~ msgid "_Off"
+#~ msgstr "_Distude"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "Sospension _Automatiche"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Cuant che si frache il boton Distude"
+
+#~ msgid "_Background"
+#~ msgstr "_Sfont"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Al cambie dilunc il dì"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Mosaic"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Ingrandìs"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centre"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Scjale"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Jemple"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Slargje"
+
+#~ msgid "Colors"
+#~ msgstr "Colôrs"
+
+#~ msgid "Pictures"
+#~ msgstr "Imagjins"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Nissune imagjin cjatade"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Al è pussibil zontâ imagjins ae tô cartele %s e a vegnaran mostradis a chi"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Conession/SSID"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "Drag displays to match your setup."
+#~ msgstr "Strissine i visôrs par fâju corispuindi ae to configurazion."
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Çampe"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Diestre"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minim"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Massim"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "Sub_woofer:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profîl:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Prove cassis"
+
+#~ msgid "Peak detect"
+#~ msgstr "Rilevament pic"
+
+#~ msgid "Device"
+#~ msgstr "Dispositîf"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Prove cassis par %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Sielzi un dispositîf par la jessude audio:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Impostazions pal dispositîf selezionât:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Volum di _ingrès:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Sielzi un dispositîf par l'ingrès audio:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Efiets sonôrs"
+
+#~ msgid "Built-in"
+#~ msgstr "Integrât"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferencis sun"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Prove event sonôr"
+
+#~ msgid "From theme"
+#~ msgstr "Dal teme"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Sielzi un sun di avîs:"
+
+#~ msgid "Stop"
+#~ msgstr "Ferme"
+
+#~ msgid "Add input source"
+#~ msgstr "Zonte sorzint input"
+
+#~ msgid "Remove input source"
+#~ msgstr "Gjave sorzint input"
+
+#~ msgid "Move input source up"
+#~ msgstr "Sposte sorzint input in sù"
+
+#~ msgid "Move input source down"
+#~ msgstr "Sposte sorzint input in jù"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Mostre disposizion tastiere de sorzint di input"
+
+#~ msgid "_Night Light"
+#~ msgstr "Lûs _noturne"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Impussibil vê informazions sul schermi"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Centri di control GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Il centri di control GNOME e je la interface principâl par configurâ "
+#~ "diviers aspiets dal to scritori."
+
+#~ msgid "hardware"
+#~ msgstr "hardware"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Passe ae sorzint precedent"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Passe ae sorzint sucessive"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Passe ae sorzint sucessive (alternative)"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Inglês (Ream Unît)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Ream Unît"
+
+#~ msgid "_Options"
+#~ msgstr "_Opzions"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Normâl"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Aministradôr"
+
+#~ msgid "page 3"
+#~ msgstr "pagjine 3"
+
+#~ msgid "Quit"
+#~ msgstr "Jes"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Verifiche gnove password"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Lis password no corispuindin."
+
+#~ msgid "Show the overview"
+#~ msgstr "Mostre la panoramiche"
+
+#~ msgid "Back­ground"
+#~ msgstr "Sfont"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blue­tooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Co­lôr"
+
+#~ msgid "Overview"
+#~ msgstr "Panoramiche"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "A­pli­ca­zions­ ­pre­de­fi­ni­dis"
+
+#~ msgid "Ab­out"
+#~ msgstr "In­for­ma­zions"
+
+#~ msgid "De­tails"
+#~ msgstr "De­tais"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Dis­po­si­tîfs­ ­es­tra­i­bil"
+
+#~ msgid "Net­work"
+#~ msgstr "Rêt"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "No­ti­fi­chis"
+
+#~ msgid "Po­wer"
+#~ msgstr "A­li­men­ta­zion"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Pri­va­cy"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Con­di­vi­sion"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "A­cès­ ­u­ni­ver­sâl"
+
+#~ msgid "Disable image"
+#~ msgstr "Disabilite imagjin"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Esplore altris imagjins…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Doprade di %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Tau­lu­te­ ­Wa­com"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sisteme"
+
+#~ msgid "Apply"
+#~ msgstr "Apliche"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Tapon sierât"
+
+#~ msgid "Mirrored"
+#~ msgstr "Duplicâts"
+
+#~ msgid "Secondary"
+#~ msgstr "Secondari"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Disponi visôrs cumbinâts"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Ribalte in sens antiorari di 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Ribalte di 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Ribalte in sens orari di 90°"
+
+#~ msgid "Size"
+#~ msgstr "Dimension"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Mostre su chest visôr la sbare superiôr e la panoramiche ativitâts"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Unìs chest visôr cuntun altri par creâ un spazi di lavôr in plui"
+
+#~ msgid "Presentation"
+#~ msgstr "Presentazion"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Mostre dome presentazions e elements multimediâi"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Mostre su ducj i doi i visôrs ce che tu âs visibil"
+
+#~ msgid "Turn Off"
+#~ msgstr "Distude"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "No sta doprâ chest visôr"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Dispon visôrs cumbinâts"
+
+#~ msgid "Server"
+#~ msgstr "Server"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Elimine server DNS"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Zonte profîl..."
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Nissun"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manuâl"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatic"
+
+#~ msgid "_Method"
+#~ msgstr "_Maniere"
+
+#~ msgid "Group Name"
+#~ msgstr "Non grup"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "Modalitât a_vion"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Dopre come Hotspot..."
+
+#~ msgid "_History"
+#~ msgstr "_Cronologjie"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Rindi disponibil a chei altris _utents"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Scancele lis impostazions par cheste rêt, comprindudis lis password, ma "
+#~ "tegnile come une rêt preferide"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Gjave ducj i detais di cheste rêt e no sta cirî di coneti in automatic"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Frache Esc par anulâ."
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Se tu âs une altre conession a internet oltri a chê wireless, tu puedis "
+#~ "impuestâ un hotspot wireless par condividi la conession cun altris."
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (ID di costruzion: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "Sisteme base"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Cîr di zontâ plui letaris, numars e simbui."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Robustece: Debule"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Robustece: Basse"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Robustece: Medie"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Robustece: Buine"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Robustece: Alte"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Scurte;Ripet;Lampâ;"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Zone firewall"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Predefinide"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "La zone e definìs il nivel di fiducie de conession"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Il to account</small>"
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Met la scurte"
+
+#~ msgid "Add Account"
+#~ msgstr "Zonte account"
+
+#~ msgid "Mail"
+#~ msgstr "E-mail"
+
+#~ msgid "Calendar"
+#~ msgstr "Calendari"
+
+#~ msgid "Contacts"
+#~ msgstr "Contats"
+
+#~ msgid "Chat"
+#~ msgstr "Chat"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "In configurazion"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nivel toner"
+
+#~ msgid "Supply Level"
+#~ msgstr "Nivel consumabii"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Instalazion"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u atîf"
+#~ msgstr[1] "%u atîfs"
+
+#~ msgctxt "button"
+#~ msgid "Add Printer"
+#~ msgstr "Zonte stampant"
+
+#~ msgid "Supply"
+#~ msgstr "Nivei"
+
+#~ msgid "Jobs"
+#~ msgstr "Lavôrs"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Mostre _lavôrs"
+
+#~ msgid "label"
+#~ msgstr "etichete"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Stampe _pagjine di prove"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Altris account"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Banner di notifiche"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "_Banner di notifiche"
+
+#~ msgid "Error creating account"
+#~ msgstr "Erôr tal creâ l'account"
+
+# Metût plurâl par risolvi masculin/feminin
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Sigûrs di volê gjavâ chest account?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "In cheste maniere nol vegnarà gjavât l'account tal server."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Nissun account online configurât"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Zontâ un account al permet a lis tôs aplicazions di podê acedi ai "
+#~ "relatîfs documents, e-mail, contats, calendaris, chat e altri."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Sù"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Jù"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Nissun"
+
+#~ msgid "Left Ring"
+#~ msgstr "Ring çamp"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Modalitât Ring çamp #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Modalitât Ring diestri #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Touchstrip çamp"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Modalitât Touchstrip çamp #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Touchstrip diestri"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Modalitât Touchstrip diestri #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Interutôr modalitât Touchring çamp"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Interutôr modalitât Touchring diestri"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Interutôr modalitât Touchstrip çamp"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Interutôr modalitât Touchstrip diestri"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Interutôr modalitât #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Boton çamp #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Boton diestri #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Boton superiôr #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Boton inferiôr #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Nissune azion"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Clic boton çamp dal mouse"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Scor in sù"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Scor in jù"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Scor a drete"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Zonte une gnove stampant"
+
+#~ msgid "No printers detected."
+#~ msgstr "Nissune stampant rilevade."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr ""
+#~ "Scurte di tastiere par <b>%s</b>. Inserìs une gnove scurte par cambiâle."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Par modificâ une scurte fâs clic su la rie e sclice i gnûfs tascj o "
+#~ "sclice «Backspace» par scancelâle."
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Erôr tal jentrâ tal account"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Lis credenziâi a son scjadudis."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Eseguìs acès par abilitâ chest account."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Jentre"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Gjave scurte"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<azion no cognossude>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Nol è pussibil doprâ \"%s\" come scurte parcè che al deventarès "
+#~ "impussibil scrivi doprant chest tast.\n"
+#~ "Prove dopre in cumbinazion un tast come Ctrl, Alt o Maiusc."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "La scurte \"%s\" e je za doprade par\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Se tu tornis a assegnâ le scurte a \"%s\", la scurte \"%s\" a vegnarà "
+#~ "disativade."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Torne assegne"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "La scurte \"%s\" e je associade ae scurte \"%s\". Impuestâle in maniere "
+#~ "automatiche a \"%s\"?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" e je atualmentri associade cun \"%s\", continuant chê scurte e "
+#~ "vegnarà disativade."
+
+#~ msgid "_Assign"
+#~ msgstr "_Assegne"
+
+#~ msgid "Add User Account"
+#~ msgstr "Zonte account utent"
+
+#~ msgid "Bond"
+#~ msgstr "Bond"
+
+#~ msgid "Team"
+#~ msgstr "Team"
+
+#~ msgid "Bridge"
+#~ msgstr "Bridge"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Impussibil cjamâ i plugin VPN"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Zonte conession di rêt"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Bond slave"
+
+#~ msgid "(none)"
+#~ msgstr "(nissun)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Bridge slave"
+
+#~ msgid "Team slaves"
+#~ msgstr "Team slave"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "Il dispositîf InfiniBand nol supuarte la modalitât colegade"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr ""
+#~ "Nol è stât sielt nissun certificât di une Autoritât di Certificazion"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Il no doprâ un certificât mitût fûr di une Autoritât di Certificazion "
+#~ "(CA) al pues portâ a conessions Wi-Fi no siguris. Sielzi un certificât di "
+#~ "une Autoritât di Certificazion?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignore"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Sielç certificât CA"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "_Domande cheste password ogni volte"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "No stâ visâmi plui"
+
+#~ msgid "Yes"
+#~ msgstr "Sì"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Altri"
+
+#~ msgid "_Verify"
+#~ msgstr "_Verifiche"
+
+#~ msgid "Login History"
+#~ msgstr "Cronologjie acès"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Un utent cul non utent '%s' al esist za."
+
+#~ msgid "Done"
+#~ msgstr "Eseguide"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Fû_s orari"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Ritart:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Curt"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Lent"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Lunc"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Veloç"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Velocitât:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Test impostazions"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Lent"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Veloç"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Çamp"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Distri"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Velocitât cursôr"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lent"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Veloç"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lent"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Veloç"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "I dispositîfs cence fîl a domandin plui energjie"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Torne finìs le stampe"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Pause le stampe"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Stratignût"
+
+#~ msgid "Job Title"
+#~ msgstr "Titul lavôr"
+
+#~ msgid "Job State"
+#~ msgstr "Stât lavôr"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Zonte gnove stampant"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Doprâts par determinâ la posizion gjeografiche"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "La condivision Bluetooth a permet di condividi file cun altris "
+#~ "dispositîfs Bluetooth abilitâts"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Ricêf dome di dispositîfs fidâts"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Salve i file ricevûts te cartele Scjariâts"
+
+#~ msgid "Password:"
+#~ msgstr "Password:"
+
+#~ msgid "Zoom"
+#~ msgstr "Ingrandiment"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Colôr"

--- a/po/ga.po
+++ b/po/ga.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.master\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-23 15:26-0600\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2015-09-23 15:39-0600\n"
 "Last-Translator: Seán de Búrca <leftmostcat@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -19,2069 +19,2108 @@ msgstr ""
 "Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : "
 "4;\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Feidhmchláir"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Feidhmchlár gan aimsiú"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Oscail"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Amharc ar mhionsonraí"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Cuardach"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Díchumasaithe"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Fógairt"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Taispeáin _Fógairtí"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Cúlra"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Gabhálacha Scáileáin"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Cúlbhrait"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Fuaim"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Aicearraí"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Aicearraí Méarchláir"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "Ceamara %s"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "Suíomh"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Ceamara Gréasáin Ionsuite"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Réigiún gan aimsiú"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Cineál Taispeána"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Luas an cheangail"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Athshocraigh"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Feidhmchláir"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Réamhshocrú"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Cúlra"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "Ag athrú le linn an lae"
-
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "Lock Screen"
-msgstr "Scáileán Glasála"
-
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Tíligh"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Súmáil"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "Láraigh"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Scálaigh"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Líon"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "Réisigh"
-
-#: ../panels/background/cc-background-chooser-dialog.c:437
-msgid "Wallpapers"
-msgstr "Cúlbhrait"
-
-#: ../panels/background/cc-background-chooser-dialog.c:446
-msgid "Colors"
-msgstr "Dathanna"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:483
-msgid "Select Background"
-msgstr "Roghnaigh Cúlra"
-
-#: ../panels/background/cc-background-chooser-dialog.c:511
-msgid "Pictures"
-msgstr "Pictiúir"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:543
-msgid "No Pictures Found"
-msgstr "Níor Aimsíodh Aon Phictiúr"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:561
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "Baile"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:573
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr ""
-"Is féidir leat íomhánna a chur le d'fhillteán “%s” agus taispeánfar iad anseo"
-
-#: ../panels/background/cc-background-chooser-dialog.c:580
-#: ../panels/color/cc-color-panel.c:225 ../panels/color/cc-color-panel.c:963
-#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1561
-#: ../panels/display/cc-display-panel.c:2023
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1269
-#: ../panels/network/net-device-wifi.c:1462
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/cc-printers-panel.c:1940
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:568
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:374
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-#: ../panels/user-accounts/um-photo-dialog.c:94
-#: ../panels/user-accounts/um-photo-dialog.c:217
-#: ../panels/user-accounts/um-user-panel.c:708
-#: ../panels/user-accounts/um-user-panel.c:726
-msgid "_Cancel"
-msgstr "_Cealaigh"
-
-#: ../panels/background/cc-background-chooser-dialog.c:581
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:96
-msgid "Select"
-msgstr "Roghnaigh"
-
-#: ../panels/background/cc-background-item.c:203
-msgid "multiple sizes"
-msgstr ""
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:207
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:333
-msgid "No Desktop Background"
-msgstr "Gan Cúlra na Deisce"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "Cúlra reatha"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
-msgstr ""
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Cúlbhrat;Scáileán;Deasc;"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:259
+#: panels/background/cc-background-panel.ui:104
 #, fuzzy
-msgid "Turn Off Airplane Mode"
-msgstr "Múchann sé seo gléasanna gan sreang"
+msgid "Add Picture…"
+msgstr "Cuir _Próifíl Leis…"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:325
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Cumasaigh"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 #, fuzzy
 msgid "No Bluetooth Found"
 msgstr "Níor aimsíodh aon chuibheoir Bluetooth"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:325
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:326
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 #, fuzzy
 msgid "Bluetooth Turned Off"
 msgstr "Comhroinnt Bluetooth"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:326
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:327
-msgid "Airplane Mode is on"
-msgstr ""
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "Múchann sé seo gléasanna gan sreang"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:327
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 #, fuzzy
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Díchumasaíodh Bluetooth ag lasc chrua-earraí"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:328
-msgid "Hardware Airplane Mode is on"
-msgstr ""
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "Múchann sé seo gléasanna gan sreang"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:328
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Múchann sé seo gléasanna gan sreang"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1676
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 "Cumasaigh agus díchumasaigh Bluetooth agus ceangail do chuid ghléasanna"
 
-#. Translators: those are keywords for the bluetooth control-center panel
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:4
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "Socraigh do ghléas calabraithe thar an gcearnóg agus brúigh 'Tosaigh'"
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "Comhroinnt Bluetooth"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Níl fuaim á seinm nó á taifeadadh ag aon fheidhmchlár."
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
-msgstr ""
-"Bog do ghléas calabraithe go dtí an t-ionad calabraithe agus brúigh 'Ar "
-"Aghaidh'"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr ""
-"Bog do ghléas calabraithe go dtí an t-ionad dromchla agus brúigh 'Ar Aghaidh'"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "Dún an clúdach"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "Tá uirlisí de dhíth le haghaidh calabraithe nach bhfuil suiteáilte."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "Níorbh fhéidir an phróifíl a ghiniúint."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
 
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "Críochnaithe!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "Theip ar chalabrú!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "Is féidir leat an gléas calabraithe a bhaint."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ná cuir isteach ar an ngléas calabraithe nuair atá sé ar siúl"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Scáileán Ríomhaire Glúine"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Ceamara Gréasáin Ionsuite"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monatóir %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Scanóir %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Ceamara %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Printéir %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Ceamara Gréasáin %s"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Cumasaigh bainisteoireacht dathanna do %s"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Taispeáin próifílí datha do %s"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:323
-msgid "Not calibrated"
-msgstr "Gan chalabrú"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:141
-msgid "Default: "
-msgstr "Réamhshocrú: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:149
-msgid "Colorspace: "
-msgstr "Dathspás:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:156
-msgid "Test profile: "
-msgstr "Próifíl tástála:"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:223
-msgid "Select ICC Profile File"
-msgstr "Roghnaigh Comhad Próifíle ICC"
-
-#: ../panels/color/cc-color-panel.c:226
-msgid "_Import"
-msgstr "_Iompórtáil"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:237
-msgid "Supported ICC profiles"
-msgstr "Próifílí ICC le tacaíocht"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:244
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "Gach comhad"
-
-#: ../panels/color/cc-color-panel.c:583
-msgid "Screen"
-msgstr "Scáileán"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:908
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Theip ar uasluchtú comhaid: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:922
-msgid "The profile has been uploaded to:"
-msgstr "Uasluchtaíodh an phróifíl go:"
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Write down this URL."
-msgstr "Breac síos an URL seo."
-
-#: ../panels/color/cc-color-panel.c:925
-msgid "Restart this computer and boot your normal operating system."
-msgstr "Atosaigh an ríomhaire seo agus bútáil do ghnáthchóras oibriúcháin."
-
-#: ../panels/color/cc-color-panel.c:926
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-"Clóscríobh an URL isteach i do bhrabhsálaí chun an phróifíl a íosluchtú agus "
-"a shuiteáil."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:960
-msgid "Save Profile"
-msgstr "Sábháil Próifíl"
-
-#: ../panels/color/cc-color-panel.c:964
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "_Sábháil"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1324
-msgid "Create a color profile for the selected device"
-msgstr "Cruthaigh próifíl dathanna don ghléas roghnaithe"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
 msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1373
-msgid "The measuring instrument does not support printer profiling."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1384
-msgid "The device type is not currently supported."
-msgstr ""
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "Spás Caighdeánach"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "Próifíl Tástála"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Uathoibríoch"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Cáilíocht Íseal"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Cáilíocht Mheánach"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Ardcháilíocht"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB Réamhshocraithe"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK Réamhshocraithe"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Liath Réamhshocraithe"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr ""
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "Is féidir nach bhfuil an phróifíl seo cruinn a thuilleadh"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calabrú Taispeána"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1476
-msgid "Cancel"
-msgstr "Cealaigh"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cealaigh"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "Tosaigh"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "Lean"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "Críochnaithe"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Críochnaithe"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Calabrú Scáileáin"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Cáilíocht Chalabraithe"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "Ní féidir leat do ríomhaire a úsáid agus an calabrú á dhéanamh."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Cáilíocht"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Neas-am"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "Cáilíocht Chalabraithe"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr ""
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Gléas Calabraithe"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
 msgstr ""
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Cineál Taispeána"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr ""
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Taispeáin Gile"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "Taispeáin Gile"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Ainm Próifíle"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Ainm Próifíle:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "Ainm Próifíle"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr ""
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "Cóipeáil próifíl"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr ""
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "Uasluchtaigh próifíl"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr ""
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:729
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr ""
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "Iompórtáil Comhad…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
 
-#: ../panels/color/color.ui.h:30
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1477
-msgid "_Add"
-msgstr "Cuir _Leis"
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Cóipeáil próifíl"
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Cuir próifíl leis"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "Iompórtáil Comhad…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "Cuir _Leis"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Teastaíonn próifíl datha atá cothrom le dáta chun a chuid dathanna a "
 "bhainistiú."
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Faigh tuilleadh eolais"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr ""
 
-#: ../panels/color/color.ui.h:35
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "Socraigh do gach úsáideoir"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr ""
 
-#: ../panels/color/color.ui.h:37
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "Cumasaigh"
 
-#: ../panels/color/color.ui.h:38
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "Cuir próifíl leis"
 
-#: ../panels/color/color.ui.h:39
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "Calabraigh…"
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Calabraigh an gléas"
 
-#: ../panels/color/color.ui.h:41
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "Bain próifíl"
 
-#: ../panels/color/color.ui.h:42
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "Amharc ar mhionsonraí"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr ""
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Teilgeoir"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plasma"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (cúlsolas CCFL)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (cúlsolas LED RGB)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (cúlsolas LED bán)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "LCD raoin leathain (cúlsolas CCFL)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "LCD raoin leathain (cúlsolas LED RGB)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Ard"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 nóimeád"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Meánach"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:2
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 nóimeád"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Íseal"
 
-#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:1
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 nóimeád"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:663
 #, fuzzy
 msgid "Native to display"
 msgstr "Painéal le taispeáint"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Priontáil agus foilsiú)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Grianghrafadóireacht agus grafaic)"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Dath"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 "Calabraigh dath do ghléasanna, mar shampla taispeáintí, ceamaraí nó printéirí"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Dath;ICC;Próifíl;Calabraigh;Printéir;Taispeáint;"
 
-#: ../panels/common/cc-common-language.c:323
-msgid "Other…"
-msgstr "Eile…"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Teanga"
 
-#: ../panels/common/cc-language-chooser.c:124
-#: ../panels/region/cc-format-chooser.c:271
-#: ../panels/region/cc-input-chooser.c:168
-msgid "More…"
-msgstr "Tuilleadh…"
+#: panels/common/cc-language-chooser.ui:13
+#, fuzzy
+msgid "_Select"
+msgstr "Roghnaigh"
 
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Teanga gan aimsiú"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "Teanga"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Tuilleadh…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "_Críochnaithe"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#: ../panels/datetime/big.ui.h:1 ../panels/datetime/little.ui.h:1
-#: ../panels/datetime/middle.ui.h:1 ../panels/datetime/ydm.ui.h:1
-msgid "Day"
-msgstr "Lá"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#: ../panels/datetime/big.ui.h:2 ../panels/datetime/little.ui.h:2
-#: ../panels/datetime/middle.ui.h:2 ../panels/datetime/ydm.ui.h:2
-msgid "Month"
-msgstr "Mí"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: ../panels/datetime/big.ui.h:3 ../panels/datetime/little.ui.h:3
-#: ../panels/datetime/middle.ui.h:3 ../panels/datetime/ydm.ui.h:3
-msgid "Year"
-msgstr "Bliain"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%B %e %Y, %l:%M %p"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Am"
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%B %e %Y, %R"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "AUL%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "Eanáir"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "Feabhra"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "Márta"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "Aibreán"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "Bealtaine"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "Meitheamh"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "Iúil"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "Lúnasa"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "Meán Fómhair"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "Deireadh Fómhair"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "Samhain"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "Nollaig"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Dáta & Am"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "Uair"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Bliain"
 
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mí"
 
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "Nóimeád"
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Eanáir"
 
-#: ../panels/datetime/datetime.ui.h:18
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Feabhra"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Márta"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Aibreán"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Bealtaine"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Meitheamh"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Iúil"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Lúnasa"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Meán Fómhair"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Deireadh Fómhair"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Samhain"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Nollaig"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Lá"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Crios Ama"
 
-#: ../panels/datetime/datetime.ui.h:19
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Cuardaigh cathair"
 
-#: ../panels/datetime/datetime.ui.h:20
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "_Dáta & Am Uathoibríoch"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Rochtain idirlín de dhíth"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Dáta & _Am"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "C_rios Ama Uathoibríoch"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Date & _Time"
-msgstr "Dáta & _Am"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "Rochtain idirlín de dhíth"
 
-#: ../panels/datetime/datetime.ui.h:24
-msgid "Time _Zone"
-msgstr "Crios A_ma"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Cumasaithe"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "Crios Ama"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Formáid Ama"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "24-hour"
-msgstr "24 uair"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dátaí"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "Tánaisteach"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Féi_lire"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Uimhreacha"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Athraigh an dáta agus an t-am, crios ama ina measc"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clog;Crios Ama;Suíomh;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "Athraigh socruithe ama agus dáta an chórais"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Is gá fíordeimhniú chun socruithe ama nó dáta a athrú."
 
-#: ../panels/display/cc-display-panel.c:573
-msgid "Lid Closed"
-msgstr "Clúdach Dúnta"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Gréasán"
 
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:576
-msgid "Mirrored"
-msgstr "Scáthánaithe"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Post"
 
-#: ../panels/display/cc-display-panel.c:578
-#: ../panels/display/cc-display-panel.c:2195
-msgid "Primary"
-msgstr "Príomhúil"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "Féi_lire"
 
-#: ../panels/display/cc-display-panel.c:580
-#: ../panels/notifications/cc-notifications-panel.c:257
-#: ../panels/power/cc-power-panel.c:1847 ../panels/power/cc-power-panel.c:1858
-#: ../panels/privacy/cc-privacy-panel.c:155
-#: ../panels/privacy/cc-privacy-panel.c:222
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "Díchumasaithe"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Ceol"
 
-#: ../panels/display/cc-display-panel.c:583
-msgid "Secondary"
-msgstr "Tánaisteach"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Fís"
 
-#. Title of displays dialog when multiple monitors are present.
-#: ../panels/display/cc-display-panel.c:1558
-msgid "Arrange Combined Displays"
-msgstr "Leag Amach Taispeáintí Comhcheangailte"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "G_rianghraif"
 
-#: ../panels/display/cc-display-panel.c:1562
-#: ../panels/display/cc-display-panel.c:2024
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr "Cuir i bh_Feidhm"
-
-#: ../panels/display/cc-display-panel.c:1586
-msgid "Drag displays to rearrange them"
-msgstr "Tarraing taispeáintí chun iad a leagan amach"
-
-#: ../panels/display/cc-display-panel.c:2073
-msgid "Rotate counterclockwise by 90°"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2091
-msgid "Rotate by 180°"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2109
-msgid "Rotate clockwise by 90°"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2130
-msgid "Size"
-msgstr "Méid"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2143
-msgid "Aspect Ratio"
-msgstr "Cóimheas Treoíochta"
-
-#: ../panels/display/cc-display-panel.c:2165
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "Taifeach"
-
-#: ../panels/display/cc-display-panel.c:2196
-msgid "Show the top bar and Activities Overview on this display"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2202
-msgid "Secondary Display"
-msgstr "Taispeáint Tánaisteach"
-
-#: ../panels/display/cc-display-panel.c:2203
-msgid "Join this display with another to create an extra workspace"
-msgstr ""
-"Comhcheangail an taispeáint seo le ceann eile chun spás breise oibre a "
-"chruthú"
-
-#: ../panels/display/cc-display-panel.c:2210
-msgid "Presentation"
-msgstr "Láithreoireacht"
-
-#: ../panels/display/cc-display-panel.c:2211
-msgid "Show slideshows and media only"
-msgstr "Taispeáin teaspántais sleamhnán agus meáin amháin"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2216
-msgid "Mirror"
-msgstr "Scáthánaigh"
-
-#: ../panels/display/cc-display-panel.c:2217
-msgid "Show your existing view on both displays"
-msgstr "Taispeáin d'amharc atá ann ar an dá taispeáint"
-
-#: ../panels/display/cc-display-panel.c:2223
-msgid "Turn Off"
-msgstr "Múch"
-
-#: ../panels/display/cc-display-panel.c:2224
-#, fuzzy
-msgid "Don't use this display"
-msgstr "Ná bain úsáid as an taispeáint"
-
-#: ../panels/display/cc-display-panel.c:2525
-msgid "Could not get screen information"
-msgstr "Níorbh fhéidir eolas scáileáin a fháil"
-
-#: ../panels/display/cc-display-panel.c:2556
-msgid "_Arrange Combined Displays"
-msgstr "_Leag Amach Taispeáintí Comhcheangailte"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "Taispeáintí"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr ""
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-#, fuzzy
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "Painéal;Teilgeoir;xrandr;Scáileán;Taifeach;Athnuaigh;"
-
-#: ../panels/info/cc-info-panel.c:385
-msgid "Wayland"
-msgstr "Wayland"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:388 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "Anaithnid"
-
-#: ../panels/info/cc-info-panel.c:473
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-giotán"
-
-#: ../panels/info/cc-info-panel.c:475
-#, c-format
-msgid "%d-bit"
-msgstr "%d-giotán"
-
-#: ../panels/info/cc-info-panel.c:1155
-msgid "Ask what to do"
-msgstr "Fiafraigh díom"
-
-#: ../panels/info/cc-info-panel.c:1159
-msgid "Do nothing"
-msgstr "Ná déan faic"
-
-#: ../panels/info/cc-info-panel.c:1163
-msgid "Open folder"
-msgstr "Oscail fillteán"
-
-#: ../panels/info/cc-info-panel.c:1254
-msgid "Other Media"
-msgstr "Meáin Eile"
-
-#: ../panels/info/cc-info-panel.c:1285
-#, fuzzy
-msgid "Select an application for audio CDs"
-msgstr "Roghnaigh d'fheidhmchláir réamhshocraithe"
-
-#: ../panels/info/cc-info-panel.c:1286
-#, fuzzy
-msgid "Select an application for video DVDs"
-msgstr "Roghnaigh d'fheidhmchláir réamhshocraithe"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1289
-#, fuzzy
-msgid "Select an application for software CDs"
-msgstr "Roghnaigh d'fheidhmchláir réamhshocraithe"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1301
-msgid "audio DVD"
-msgstr "DVD fuaime"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank Blu-ray disc"
-msgstr "diosca Blu-ray bán"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank CD disc"
-msgstr "diosca CD bán"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank DVD disc"
-msgstr "diosca DVD bán"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "blank HD DVD disc"
-msgstr "diosca HD DVD bán"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "Blu-ray video disc"
-msgstr "diosca físe Blu-ray"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "e-book reader"
-msgstr "léitheoir r-leabhair"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "HD DVD video disc"
-msgstr "diosca físe HD DVD"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Video CD"
-msgstr "Video CD"
-
-#: ../panels/info/cc-info-panel.c:1312
-msgid "Windows software"
-msgstr "Bogearraí Windows"
-
-#: ../panels/info/cc-info-panel.c:1435
-#: ../panels/keyboard/keyboard-shortcuts.c:1947
-msgid "Section"
-msgstr "Rannán"
-
-#: ../panels/info/cc-info-panel.c:1444 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "Foramharc"
-
-#: ../panels/info/cc-info-panel.c:1450 ../panels/info/info.ui.h:21
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
 msgid "Default Applications"
 msgstr "Feidhmchláir Réamhshocraithe"
 
-#: ../panels/info/cc-info-panel.c:1455 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "Meáin Inbhainte"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Feidhmchláir Réamhshocraithe"
 
-#: ../panels/info/cc-info-panel.c:1480
-#, c-format
-msgid "Version %s"
-msgstr "Leagan %s"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:46
-msgid "Details"
-msgstr "Sonraí"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "Cuir i bh_Feidhm"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Taispeáintí"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Scáthánaigh"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Taispeáint Tánaisteach"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "Méar an fháinne dheas"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Gníomh an Bharra Teidil"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Taifeach"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Scálaigh"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Níl aon phrintéir ar fáil"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Atosaigh Anois"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Amanna"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Uair"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Nóimeád"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Taispeáintí"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Painéal;Teilgeoir;xrandr;Scáileán;Taifeach;Athnuaigh;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Eochracha Greamaitheacha"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Leibhéal Dúigh"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Leibhéal Dúigh"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Leibhéal Dúigh"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Slándáil"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Ainm gléis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Seoladh Crua-Earraí"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Cuimhne"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Próiseálaí"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafaic"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Á áireamh…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Ainm"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Cineál VPN"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Leagan 0"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Roghanna á luchtú…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Bogearraí Windows"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Fíorúlú"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Bogearraí"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Bain Gléas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Ainm gléis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_Ainm úsáideora"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr "Amharc ar eolas faoi do chóras"
 
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "gléas;córas;faisnéis;cuimhne;próiseálaí;leagan;réamhshocrú;feidhmchlár;rogha;"
 "cd;dvd;usb;fuaim;fís;diosca;inbhainte;meáin;uathrith;"
 
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr ""
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "_Gníomh:"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "C_ineál:"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "Ainm gléis"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "Cuimhne"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "Próiseálaí"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "Bunchóras"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "Diosca"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "Á áireamh…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "Grafaic"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "Fíorúlú"
-
-#: ../panels/info/info.ui.h:13
-#, fuzzy
-msgid "Check for updates"
-msgstr "Nuashonruithe á Seiceáil"
-
-#: ../panels/info/info.ui.h:15
-msgid "_Web"
-msgstr "_Gréasán"
-
-#: ../panels/info/info.ui.h:16
-msgid "_Mail"
-msgstr "_Post"
-
-#: ../panels/info/info.ui.h:17
-msgid "_Calendar"
-msgstr "Féi_lire"
-
-#: ../panels/info/info.ui.h:18
-msgid "M_usic"
-msgstr "_Ceol"
-
-#: ../panels/info/info.ui.h:19
-msgid "_Video"
-msgstr "_Fís"
-
-#: ../panels/info/info.ui.h:20
-msgid "_Photos"
-msgstr "G_rianghraif"
-
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr ""
-
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "fu_aim CD"
-
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "fís _DVD"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "Seinnteoir _ceoil"
-
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "_Bogearraí"
-
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "Meáin _Eile…"
-
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr ""
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "Fuaim agus Meáin"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Airde gan fuaim"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Airde síos"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Airde suas"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Luchtaigh seinnteoir meán"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Seinn (nó seinn/sos)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Cuir athsheinm ar shos"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Stad athsheinm"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "An t-amhrán roimhe seo"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "An chéad t-amhrán eile"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Díchuir"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Clóscríobh"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "Athraigh go dtí an chéad fhoinse ionchuir eile"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "Athraigh go dtí an fhoinse ionchuir roimhe seo"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "Tosaitheoirí"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Luchtaigh brabhsálaí cabhrach"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1605
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "Socruithe"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Luchtaigh áireamhán"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "Luchtaigh cliant ríomhphoist"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "Luchtaigh brabhsálaí gréasáin"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "Fillteán baile"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "Cuardaigh"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "Gabhálacha Scáileáin"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "Sábháil gabháil scáileáin i $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Sábháil gabháil scáileán fuinneoige i $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Sábháil gabháil scáileán limistéir i $PICTURES"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "Cóipeáil gabháil scáileáin go dtí an ghearrthaisce"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Cóipeáil gabháil scáileán fuinneoige go dtí an ghearrthaisce"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Cóipeáil gabháil scáileán limistéir go dtí an ghearrthaisce"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "Taifead físghabháil ghearr scáileáin"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Córas"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "Logáil amach"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "Cuir an scáileán faoi ghlas"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "Rochtain Uilíoch"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "Cumasaigh nó díchumasaigh súmáil"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "Súmáil isteach"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "Súmáil amach"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "Cumasaigh nó díchumasaigh léitheoir scáileáin"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "Cumasaigh nó díchumasaigh méarchlár scáileáin"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "Méadaigh clómhéid"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "Laghaidh clómhéid"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "Cumasaigh nó díchumasaigh ardchodarsnacht"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1219
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-msgid "Disabled"
-msgstr "Díchumasaithe"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Cuir Foinse Ionchuir Leis"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "Ní féidir modhanna ionchuir a úsáid ar an scáileán logála isteach"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Níl aon fhoinse ionchuir roghnaithe"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Roghanna"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Bog Suas"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Bog Síos"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Sainroghanna"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Aicearraí Méarchláir"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Bain"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Foinsí Ionchuir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Roghanna na Foinse Ionchuir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
 #, fuzzy
 msgid "Compose Key"
 msgstr "Cnaipe na Luiche"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Aicearraí Méarchláir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Aicearraí Saincheaptha"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Méarchlár"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
 msgstr ""
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Aicearra;Athbhrú;Caoch;"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Rannán"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "Aicearra Saincheaptha"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "_Ainm:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "_Ordú:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "Athbhrú Eochracha"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "Déantar brú eochracha _arís nuair a choinníonn an eochair síos"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "_Moill:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "_Luas:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "Gearr"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "Mall"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "Luas athbhrú eochracha"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "Fada"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "Tapa"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "Caochadh an Chúrsóra"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "_Caochann an cúrsóir i réimsí téacs"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "L_uas:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "Luas caochadh an chúrsóra"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
-msgid "Input Sources"
-msgstr "Foinsí Ionchuir"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "Cuir Aicearra Leis"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "Bain Aicearra"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
-msgstr ""
-"Chun aicearra a chur in eagar, cliceáil ar an ró agus coinnigh síos na "
-"heochracha nua, nó brúigh Backspace chun glanta."
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "Aicearraí"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:632
-#: ../panels/keyboard/keyboard-shortcuts.c:640
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Cuir Aicearra Leis"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "Aicearraí Saincheaptha"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:857
-msgid "<Unknown Action>"
-msgstr "<Gníomh Anaithnid>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1358
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1388
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Cuir Aicearra Leis"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1393
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1399
-msgid "_Reassign"
-msgstr "_Athshann"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1440
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
-msgstr ""
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1450
-#, c-format
-msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
-msgstr ""
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1457
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 #, fuzzy
-msgid "_Assign"
-msgstr "_Athshann"
+msgid "No keyboard shortcut found"
+msgstr "Aicearraí Méarchláir"
 
-#: ../panels/mouse/cc-mouse-panel.c:94
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Bain"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "_Ionadaigh"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Ainm"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "_Ordú:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+#, fuzzy
+msgid "Shortcut"
+msgstr "Aicearraí"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Aicearra nua..."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Neamhní"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Méarchlár"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "Suíomh"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Níl fuaim á seinm nó á taifeadadh ag aon fheidhmchlár."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Múchadh an Scáileáin"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Feidhmchlár gan aimsiú"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Tástáil Do _Shocruithe"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-msgid "Test Your Settings"
-msgstr "Tástáil Do Shocruithe"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Ginearálta"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "_Príomhchnaipe"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Clé"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Deas"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Suíomhanna Cuardaigh"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Luch"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Eocracha L_uiche"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Scrollú"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Gníomhach"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Ceap Tadhaill"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Ceap Tadhaill"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Modh"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Díchumasaigh íomhá"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Scrollú"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scrollú"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "Luch & Ceap Tadhaill"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 "Ceap Rianaithe;Pointeoir;Cliceáil;Cnag;Déchliceáil;Cnaipe;Rianliathróid;"
 "Scrollaigh;"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "Ginearálta"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "Mall"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "Teorainn am déchliceála"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "Tapa"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "_Déchliceáil"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "_Príomhchnaipe"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "_Clé"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "_Deas"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "Luch"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "_Luas an phointeora"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "Mall"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "Tapa"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "Ceap Tadhaill"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "Mall"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "Tapa"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Tap to _click"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
 #, fuzzy
-msgid "Two _finger scroll"
-msgstr "Scrollú dhá-_mhéar"
+msgid "Workspaces"
+msgstr "Dathspás:"
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
-msgid "_Natural scrolling"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-test.c:140
+#: panels/multitasking/cc-multitasking-panel.ui:77
 #, fuzzy
-msgid "Double click, primary button"
-msgstr "Teorainn Am Déchliceála"
+msgid "Automatically removes empty workspaces."
+msgstr "Folmhaigh _Bruscar go huathoibríoch"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
 #, fuzzy
-msgid "Double click, middle button"
-msgstr "Teorainn Am Déchliceála"
+msgid "Multi-Monitor"
+msgstr "Monatóir %s"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:146
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
 #, fuzzy
-msgid "Double click, secondary button"
-msgstr "Teorainn Am Déchliceála"
+msgid "Application Switching"
+msgstr "Feidhmchláir"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
 msgstr ""
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:358
-msgid "Air_plane Mode"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
 msgstr ""
 
-#: ../panels/network/cc-network-panel.c:967
-msgid "Network proxy"
-msgstr "Seachfhreastalaí líonra"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Gléasanna"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Cuir ceangal nua leis"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Ceangailte"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Roghanna…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%s VPN"
-msgstr "VPN %s"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
 
-#: ../panels/network/cc-network-panel.c:1300
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Méarchlár Scáileáin GNOME"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Ainm Líonra"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Focal Faire"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Focal Faire an Ghrúpa"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "_Focal Faire Reatha"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Múchann sé seo gléasanna gan sreang"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Níor Aimsíodh Aon Phictiúr"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Múchann sé seo gléasanna gan sreang"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Méarchlár Scáileáin GNOME"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "Úsáid Mar _Bhall Te…"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Líonra"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
 msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr ""
 
-#: ../panels/network/cc-network-panel.c:1306
-msgid "NetworkManager needs to be running."
-msgstr ""
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Slándáil 802.1x"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "leathanach 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr ""
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#, fuzzy
-msgid "Inner _authentication"
-msgstr "Fíordheimhnithe!"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:6
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "leathanach 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:469
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "Slándáil"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "uathoibríoch"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:219
-#: ../panels/network/net-device-wifi.c:383
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:223
-#: ../panels/network/net-device-wifi.c:388
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:227
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:232
-msgid "Enterprise"
-msgstr "Fiontar"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:237
-#: ../panels/network/net-device-wifi.c:373
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Neamhní"
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:17
-msgid "Never"
-msgstr "Riamh"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:815
-msgid "Today"
-msgstr "Inniu"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:818
-msgid "Yesterday"
-msgstr "Inné"
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:477
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
@@ -2091,1622 +2130,693 @@ msgstr[2] "%i lá ó shin"
 msgstr[3] "%i lá ó shin"
 msgstr[4] "%i lá ó shin"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:534
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:563
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Neamhní"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:565
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Lag"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:567
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Cuíosach"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:569
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Maith"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:571
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Ar fheabhas"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:262
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "Aitheantas"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "Seoladh"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "Masc Líonra"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:2
-msgid "Gateway"
-msgstr "Geata"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "Scrios Seoladh"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "Cuir Leis"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "Freastalaí"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "Scrios Freastalaí DNS"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "Méadrach"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "Scrios Ród"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP)"
-msgstr "Uathoibríoch (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:26
-#: ../panels/privacy/cc-privacy-panel.c:182
-msgid "Manual"
-msgstr "De láimh"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:967
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:182
-msgid "Automatic"
-msgstr "Uathoibríoch"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "Uathoibríoch, DHCP amháin"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:937
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:51
-msgid "Reset"
-msgstr "Athshocraigh"
-
-#: ../panels/network/connection-editor/ce-page-security.c:253
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Neamhní"
-
-#: ../panels/network/connection-editor/ce-page-security.c:276
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:286
-msgid "WEP 128-bit Passphrase"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:299
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:312
-msgid "Dynamic WEP (802.1x)"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:326
-msgid "WPA & WPA2 Personal"
-msgstr ""
-
-#: ../panels/network/connection-editor/ce-page-security.c:340
-#, fuzzy
-msgid "WPA & WPA2 Enterprise"
-msgstr "Fiontar"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr ""
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Luas an cheangail"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:157
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Slándáil"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "Seoladh IPv4"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:158
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "Seoladh IPv6"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:165
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Seoladh Crua-Earraí"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:169
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Próifílí ICC le tacaíocht"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Ród Réamhshocraithe"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "Casphéire (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Comhéadan Aonad Ceangail (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Ainm"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "Seoladh _MAC"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 #, fuzzy
 msgid "_Cloned Address"
 msgstr "Seoladh"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "beart"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "_Modh"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Uathoibríoch (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
-msgid "Connect _automatically"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "De láimh"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Díchumasaithe"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
 msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-msgid "Firewall _Zone"
-msgstr ""
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:113
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "Réamhshocrú"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr ""
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
 msgstr "_Seoltaí"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Seoladh"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Masc Líonra"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Geata"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Uathoibríoch"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "DNS Uathoibríoch"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:32
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Róid"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Róid Uathoibríocha"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:34
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "Méadrach"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr ""
 
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
+#: panels/network/connection-editor/ip6-page.ui:21
 #, fuzzy
-msgid "Unable to open connection editor"
-msgstr "Fíordheimhnithe!"
+msgid "IPv_6 Method"
+msgstr "_Modh"
 
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "Próifíl Nua"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Uathoibríoch, DHCP amháin"
 
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "Nasc"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
 msgstr ""
 
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "Droichead"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-#, fuzzy
-msgid "Could not load VPN plugins"
-msgstr "Níorbh fhéidir an príomhchomhéadan a luchtú"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "Iompórtáil ó chomhad…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "Cuir Ceangal Líonra Leis"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "_Athshocraigh"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1463
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "_Déan Dearmad"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_lándáil"
 
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1941
-#: ../panels/sharing/cc-sharing-panel.c:375
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "_Open"
-msgstr "_Oscail"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "Tá comhad darb ainm \"%s\" ann cheana."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "_Ionadaigh"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-#, fuzzy
-msgid "Export VPN connection"
-msgstr "Easpórtáil ceangal VPN..."
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr ""
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "Mo Líonra Baile"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
-msgid "Make available to _other users"
-msgstr ""
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "Líonra"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+#: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr ""
 
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#: panels/network/gnome-network-panel.desktop.in.in:19
 #, fuzzy
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Líonra;Gan Sreang;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Leathanbhanda;Móideim;"
 "Bluetooth;vpn;vlan;droichead;nasc;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
 msgstr ""
 
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
+"Líonra;Gan Sreang;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Leathanbhanda;Móideim;"
+"Bluetooth;vpn;vlan;droichead;nasc;"
 
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr ""
-
-#: ../panels/network/net-device-ethernet.c:110
-#: ../panels/network/net-device-wifi.c:463
-msgid "never"
-msgstr "riamh"
-
-#: ../panels/network/net-device-ethernet.c:120
-#: ../panels/network/net-device-wifi.c:473
-msgid "today"
-msgstr "inniu"
-
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:475
-msgid "yesterday"
-msgstr "inné"
-
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "Seoladh IP"
-
-#: ../panels/network/net-device-ethernet.c:176
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "Úsáid is déanaí"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:286
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Sreangaithe"
 
-#: ../panels/network/net-device-ethernet.c:354
-#: ../panels/network/net-device-wifi.c:1621
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Options…"
-msgstr "Roghanna…"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Múch gléas"
 
-#: ../panels/network/net-device-ethernet.c:473
-#, c-format
-msgid "Profile %d"
-msgstr "Próifíl %d"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Gníomhach"
 
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "Cuir ceangal nua leis"
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1176
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1180
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1184
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1267
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1270
-msgid "_Stop Hotspot"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1327
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1330
-msgid "Wireless device does not support Hotspot mode"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1459
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1774
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "Stair"
-
-#: ../panels/network/net-device-wifi.c:1778
-#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
-#: ../panels/wacom/cc-wacom-page.c:525
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "_Close"
-msgstr "_Dún"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1786
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Déan Dearmad"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr ""
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "Seachfhreastalaí"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "Cuir _Próifíl Leis…"
-
-#: ../panels/network/network-mobile.ui.h:1
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
-#: ../panels/network/network-mobile.ui.h:2
+#: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Soláthraí"
 
-#: ../panels/network/network-proxy.ui.h:1
-msgctxt "proxy method"
-msgid "None"
-msgstr "Neamhní"
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Seoladh IP"
 
-#: ../panels/network/network-proxy.ui.h:2
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "De láimh"
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Seachfhreastalaí líonra"
 
-#: ../panels/network/network-proxy.ui.h:3
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "Uathoibríoch"
-
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
-msgstr "_Modh"
-
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "U_RL Cumraíochta:"
-
-#: ../panels/network/network-proxy.ui.h:6
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "Seachfhreastalaí _HTTP"
 
-#: ../panels/network/network-proxy.ui.h:7
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "Seachfhreastalaí H_TTPS"
 
-#: ../panels/network/network-proxy.ui.h:8
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "Seachfhreastalaí _FTP"
 
-#: ../panels/network/network-proxy.ui.h:9
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Óstach _Socks"
 
-#: ../panels/network/network-proxy.ui.h:10
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr ""
 
-#: ../panels/network/network-proxy.ui.h:11
+#: panels/network/network-proxy.ui:246
 #, fuzzy
 msgid "HTTP proxy port"
 msgstr "Seachfhreastalaí _HTTP"
 
-#: ../panels/network/network-proxy.ui.h:12
+#: panels/network/network-proxy.ui:309
 #, fuzzy
 msgid "HTTPS proxy port"
 msgstr "Seachfhreastalaí _HTTP"
 
-#: ../panels/network/network-proxy.ui.h:13
+#: panels/network/network-proxy.ui:324
 #, fuzzy
 msgid "FTP proxy port"
 msgstr "Seachfhreastalaí _FTP:"
 
-#: ../panels/network/network-proxy.ui.h:14
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr ""
 
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "Múch gléas"
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "U_RL Cumraíochta:"
 
-#: ../panels/network/network.ui.h:1
-msgid "Add Device"
-msgstr "Cuir Gléas Leis"
-
-#: ../panels/network/network.ui.h:2
-msgid "Remove Device"
-msgstr "Bain Gléas"
-
-#: ../panels/network/network-vpn.ui.h:1
-msgid "VPN Type"
-msgstr "Cineál VPN"
-
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Group Name"
-msgstr "Ainm Grúpa"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Password"
-msgstr "Focal Faire an Ghrúpa"
-
-#: ../panels/network/network-vpn.ui.h:5
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "Ainm Úsáideora"
-
-#: ../panels/network/network-vpn.ui.h:6
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "_Ceangal Uathoibríoch"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "sonraí"
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "_Focal Faire"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "Neamhní"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "_Taispeáin Focal Faire"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "aitheantas"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "athshocraigh"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "Crua-Earraí"
-
-#: ../panels/network/network-wifi.ui.h:52
+#: panels/network/network-wifi.ui:34
 #, fuzzy
-msgid "Wi-Fi Hotspot"
-msgstr "Méarchlár Scáileáin GNOME"
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Turn On"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:54
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Turn Wi-Fi off"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_Use as Hotspot…"
-msgstr "Úsáid Mar _Bhall Te…"
-
-#: ../panels/network/network-wifi.ui.h:57
-msgid "_Connect to Hidden Network…"
-msgstr "_Nasc le Líonra Folaithe…"
-
-#: ../panels/network/network-wifi.ui.h:58
-msgid "_History"
-msgstr "_Stair"
-
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:60
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Ainm Líonra"
 
-#: ../panels/network/network-wifi.ui.h:61
+#: panels/network/network-wifi.ui:40
 #, fuzzy
-msgid "Connected Devices"
-msgstr "Gach Comhad"
-
-#: ../panels/network/network-wifi.ui.h:62
-#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Eochracha Greamaitheacha"
 
-#: ../panels/network/network-wifi.ui.h:63
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:10
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Focal Faire"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
 msgstr ""
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr ""
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "Stádas anaithnid"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "Níl ar fáil"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "Ag ceangal"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "Fíordheimhniú de dhíth"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "Ceangailte"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "Ag dícheangal"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr ""
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "Gan cheangal"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
 #, fuzzy
-msgid "Configuration failed"
-msgstr "U_RL Uathchumraíochta:"
+msgid "More options…"
+msgstr "Roghanna á luchtú…"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Nasc le Líonra Folaithe…"
+
+#: panels/network/network-wifi.ui:131
 #, fuzzy
-msgid "IP configuration failed"
-msgstr "Fíordheimhnithe!"
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Méarchlár Scáileáin GNOME"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-#, fuzzy
-msgid "IP configuration expired"
-msgstr "U_RL Uathchumraíochta:"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-#, fuzzy
-msgid "AutoIP service failed"
-msgstr "Fíordheimhnithe!"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-#, fuzzy
-msgid "Modem initialization failed"
-msgstr "Fíordheimhnithe!"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-#, fuzzy
-msgid "Network registration denied"
-msgstr "Socruithe an líonra"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-#, fuzzy
-msgid "Bluetooth connection failed"
-msgstr "Fíordheimhnithe!"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-#, fuzzy
-msgid "SIM wrong"
-msgstr "Láidir"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Fíordheimhnithe"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Comhad PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
 #, fuzzy
 msgid "Choose a PAC file"
 msgstr "Roghnaigh comhad PAC..."
 
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "Comhaid PAC (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "_Comhad PAC"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 #, fuzzy
 msgid "_Inner authentication"
 msgstr "Fíordheimhnithe!"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
-msgid "Anonymous"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
-msgid "Authenticated"
-msgstr "Fíordheimhnithe"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
-msgid "Both"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_Ainm úsáideora"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Focal Faire"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Taispeáin focal faire"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "Leagan 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "Leagan 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Fíordheimhniú de dhíth"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Leagan PEAP"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-msgid "Choose your personal certificate"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-msgid "Choose your private key"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 #, fuzzy
 msgid "_Private key password"
 msgstr "Socraigh focal faire anois"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr ""
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Fearann"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "Níl"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "Tá"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr ""
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Fío_rdheimniú"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "C_ineál"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
 msgstr "1 (Réamhshocrú)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+#: panels/network/wireless-security/ws-wep-key.ui:31
 #, fuzzy
 msgid "Open System"
 msgstr "Córas"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+#: panels/network/wireless-security/ws-wep-key.ui:34
 msgid "Shared Key"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "_Eochair"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr ""
 
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
-msgid "_Type"
-msgstr "C_ineál"
-
-#: ../panels/notifications/cc-notifications-panel.c:257
-#: ../panels/power/cc-power-panel.c:1853 ../panels/power/cc-power-panel.c:1860
-#: ../panels/privacy/cc-privacy-panel.c:155
-#: ../panels/privacy/cc-privacy-panel.c:222
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "Cumasaithe"
-
 #. This is the per application switch for message tray usage.
-#: ../panels/notifications/edit-dialog.ui.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "Fógairtí"
 
 #. This is the setting to configure sounds associated with notifications.
-#: ../panels/notifications/edit-dialog.ui.h:4
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "Foláirimh Fuaime"
 
-#: ../panels/notifications/edit-dialog.ui.h:5
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 #, fuzzy
 msgctxt "notifications"
-msgid "Notification Banners"
+msgid "Notification _Popups"
 msgstr "Fógairtí"
 
-#. Banners here refers to message tray notifications in the middle of the screen.
-#: ../panels/notifications/edit-dialog.ui.h:7
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 #, fuzzy
 msgctxt "notifications"
-msgid "Show Message Content in Banners"
+msgid "Show Message _Content in Popups"
 msgstr "Taispeáin Sonraí sna Meirgí"
 
-#: ../panels/notifications/edit-dialog.ui.h:8
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 #, fuzzy
 msgctxt "notifications"
-msgid "Lock Screen Notifications"
+msgid "_Lock Screen Notifications"
 msgstr "Fógairtí"
 
-#: ../panels/notifications/edit-dialog.ui.h:9
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 #, fuzzy
 msgctxt "notifications"
-msgid "Show Message Content on Lock Screen"
+msgid "Show Message C_ontent on Lock Screen"
 msgstr "Taispeán Sonraí ar an Scáileán Glasála"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
 msgstr "Fógairt"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr ""
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Fógairtí;Meirge;Teachtaireacht;Greille;Preab;"
 
-#: ../panels/notifications/notifications.ui.h:1
-#, fuzzy
-msgid "Notification Banners"
-msgstr "Fógairt"
-
-#: ../panels/notifications/notifications.ui.h:2
-#, fuzzy
-msgid "Lock Screen Notifications"
-msgstr "Fógairt"
-
-#. List of applications.
-#: ../panels/notifications/notifications.ui.h:4
-#: ../panels/sound/gvc-mixer-dialog.c:1781
-msgid "Applications"
-msgstr "Feidhmchláir"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Eile"
-
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:290
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
-msgstr "Cuir Cuntas Leis"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:329
-msgid "Mail"
-msgstr "Post"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:335
-msgid "Contacts"
-msgstr "Teagmhálacha"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:341
-msgid "Chat"
-msgstr "Comhrá"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:347
-msgid "Resources"
-msgstr "Acmhainní"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:422
-msgid "Error logging into the account"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:492
-msgid "Credentials have expired."
-msgstr "Chuaigh dintiúir as feidhm."
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Fíordheimhnithe!"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:496
-msgid "Sign in to enable this account."
-msgstr "Sínigh isteach chun an cuntas seo a chumasú."
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:501
-msgid "_Sign In"
-msgstr "_Sínigh Isteach"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:748
-msgid "Error creating account"
-msgstr "Earráid agus cuntas á chruthú"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Cuir cuntas ar líne leis"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:808
-msgid "Error removing account"
-msgstr "Earráid agus cuntas á bhaint"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:844
-msgid "Are you sure you want to remove the account?"
-msgstr "An bhfuil tú cinnte gur mhaith leat an cuntas a bhaint?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:846
-msgid "This will not remove the account on the server."
-msgstr "Ní bhainfidh sé seo an cuntas ón bhfreastalaí."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:847
-msgid "_Remove"
-msgstr "_Bain"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Cuntais ar Líne"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -3714,31 +2824,7 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Gréasán;Ar Líne;Comhrá;Féilire;Post;Teagmháil;"
 "ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "Níl cuntas ar líne cumasaithe"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "Bain Cuntas"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "Cuir cuntas ar líne leis"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"Nuair a chuireann tú cuntas leis, is féidir le feidhmchláir é a rochtain le "
-"haghaidh cáipéisí, poist, teagmhálacha, féilire, comhrá, agus ar uile."
-
-#: ../panels/power/cc-power-panel.c:200
-msgid "Unknown time"
-msgstr "Am anaithnid"
-
-#: ../panels/power/cc-power-panel.c:206
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
@@ -3748,7 +2834,7 @@ msgstr[2] "%i nóimeád"
 msgstr[3] "%i nóimeád"
 msgstr[4] "%i nóimeád"
 
-#: ../panels/power/cc-power-panel.c:218
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
@@ -3758,14 +2844,7 @@ msgstr[2] "%i uaire"
 msgstr[3] "%i n-uaire"
 msgstr[4] "%i uair"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:226
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:227
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "uair"
@@ -3774,7 +2853,7 @@ msgstr[2] "uaire"
 msgstr[3] "n-uaire"
 msgstr[4] "uair"
 
-#: ../panels/power/cc-power-panel.c:228
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "nóimeád"
@@ -3783,1616 +2862,2511 @@ msgstr[2] "nóimeád"
 msgstr[3] "nóimeád"
 msgstr[4] "nóimeád"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:247
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s go dtí luchtaithe go hiomlán"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:254
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Rabhadh: %s fágtha"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:259
-#, c-format
-msgid "%s remaining"
-msgstr "%s fágtha"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:264 ../panels/power/cc-power-panel.c:292
-msgid "Fully charged"
-msgstr "Luchtaithe go hiomlán"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:268 ../panels/power/cc-power-panel.c:296
-msgid "Empty"
-msgstr "Folamh"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:283
-msgid "Charging"
-msgstr "Á luchtú"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:288
-msgid "Discharging"
-msgstr "Á dhíluchtú"
-
-#: ../panels/power/cc-power-panel.c:411
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Príomhchadhnra"
-
-#: ../panels/power/cc-power-panel.c:413
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Breise"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:484
-msgid "Wireless mouse"
-msgstr "Luch gan sreang"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:487
-msgid "Wireless keyboard"
-msgstr "Méarchlár gan sreang"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:490
-msgid "Uninterruptible power supply"
-msgstr "Soláthar dobhriste cumhachta"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:493
-msgid "Personal digital assistant"
-msgstr "Ríomhaire boise"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:496
-msgid "Cellphone"
-msgstr "Fón póca"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:499
-msgid "Media player"
-msgstr "Seinnteoir meán"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:502
-msgid "Tablet"
-msgstr "Táibléad"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:505
-msgid "Computer"
-msgstr "Ríomhaire"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:508 ../panels/power/cc-power-panel.c:748
-#: ../panels/power/cc-power-panel.c:2109
-msgid "Battery"
-msgstr "Cadhnra"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Á luchtú"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:569
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Rabhadh"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:574
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Íseal"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:579
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Maith"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:584
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Luchtaithe go hiomlán"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:588
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Folamh"
-
-#: ../panels/power/cc-power-panel.c:746
-msgid "Batteries"
-msgstr "Cadhnraí"
-
-#: ../panels/power/cc-power-panel.c:1171
-msgid "When _idle"
-msgstr "Nuair _díomhaoin"
-
-#: ../panels/power/cc-power-panel.c:1560
-msgid "Power Saving"
-msgstr "Coigilt Chumhachta"
-
-#: ../panels/power/cc-power-panel.c:1595
-msgid "_Screen brightness"
-msgstr "Gile an _scáileáin"
-
-#: ../panels/power/cc-power-panel.c:1614
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
 #, fuzzy
-msgid "Automatic brightness"
-msgstr "Róid Uathoibríocha"
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 nóimeád"
 
-#: ../panels/power/cc-power-panel.c:1634
-msgid "_Keyboard brightness"
-msgstr "Gile an _mhéarchláir"
-
-#: ../panels/power/cc-power-panel.c:1644
-msgid "_Dim screen when inactive"
-msgstr "Maolaigh an scáileán agus _neamhghníomhach"
-
-#: ../panels/power/cc-power-panel.c:1669
-msgid "_Blank screen"
-msgstr "_Bánaigh an scáileán"
-
-#: ../panels/power/cc-power-panel.c:1706
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: ../panels/power/cc-power-panel.c:1711
-msgid "Turn off Wi-Fi to save power."
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1736
-msgid "_Mobile broadband"
-msgstr "Leathanbhanda _móibíleach"
-
-#: ../panels/power/cc-power-panel.c:1741
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
 #, fuzzy
-msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
-msgstr "Múchann sé seo gléasanna leathanbhanda móibíligh (3G, 4G, WiMax, srl.)"
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 nóimeád"
 
-#: ../panels/power/cc-power-panel.c:1793
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 nóimeád"
 
-#: ../panels/power/cc-power-panel.c:1849
-msgid "When on battery power"
-msgstr "Agus ar chumhacht chadhnra"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 nóimeád"
 
-#: ../panels/power/cc-power-panel.c:1851
-msgid "When plugged in"
-msgstr "Nuair atá ionsuite"
-
-#: ../panels/power/cc-power-panel.c:1968
-msgid "Suspend & Power Off"
-msgstr "Cur ar Fionraí & Múchadh"
-
-#: ../panels/power/cc-power-panel.c:2008
-msgid "_Automatic suspend"
-msgstr "_Cur ar fionraí uathoibríoch"
-
-#: ../panels/power/cc-power-panel.c:2009
-msgid "Automatic suspend"
-msgstr "Cur ar fionraí uathoibríoch"
-
-#: ../panels/power/cc-power-panel.c:2163
-msgid "Devices"
-msgstr "Gléasanna"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "Cumhacht"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr ""
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-
-#: ../panels/power/power.ui.h:3
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 nóimeád"
 
-#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 uair"
 
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 nóimeád"
 
-#: ../panels/power/power.ui.h:6
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 nóimeád"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 nóimeád"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 uair"
 
-#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 nóimeád"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Cadhnra"
 
-#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 nóimeád"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Gléasanna"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 nóimeád"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Cumhacht"
 
-#: ../panels/power/power.ui.h:12
-msgid "4 minutes"
-msgstr "4 nóiméad"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 nóimeád"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Coigilt Chumhachta"
 
-#: ../panels/power/power.ui.h:14
-msgid "8 minutes"
-msgstr "8 nóiméad"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Róid Uathoibríocha"
 
-#: ../panels/power/power.ui.h:15
-msgid "10 minutes"
-msgstr "10 nóimeád"
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
 
-#: ../panels/power/power.ui.h:16
-msgid "12 minutes"
-msgstr "12 nóimeád"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Scáileán"
 
-#: ../panels/power/power.ui.h:18
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "_Léitheoir Scáileáin"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Róid Uathoibríocha"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Cur ar Fionraí Uathoibríoch"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Cur ar Fionraí Uathoibríoch"
 
-#: ../panels/power/power.ui.h:19
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_Ionsuite"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Ar _Chumhacht Chadhnra"
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Moill"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "Fíordheimhnigh"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Cumhacht"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Printéirí"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr "Cuir Printéir Leis"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Níor Aimsíodh Aon Phictiúr"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Fíordheimhniú de Dhíth"
 
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:588
-msgid "Low on toner"
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Out of toner"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Ainm Úsáideora"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
 
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:593
-msgid "Low on developer"
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Suíomh"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Tiománaí"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
 msgstr ""
 
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:596
-msgid "Out of developer"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Low on a marker supply"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Out of a marker supply"
-msgstr ""
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Open cover"
-msgstr ""
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open door"
-msgstr ""
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Low on paper"
-msgstr ""
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Out of paper"
-msgstr ""
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:610
-msgctxt "printer state"
-msgid "Offline"
-msgstr "As líne"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:612
-#: ../panels/printers/cc-printers-panel.c:803
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Stadta"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:614
-msgid "Waste receptacle almost full"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle full"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is no longer functioning"
-msgstr ""
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:730
+#: panels/printers/pp-details-dialog.ui:197
 #, fuzzy
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "U_RL Uathchumraíochta:"
+msgid "Search for Drivers"
+msgstr "Cuardaigh cathair"
 
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:789
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Réidh"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:794
-msgctxt "printer state"
-msgid "Does not accept jobs"
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
 msgstr ""
 
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:799
+#: panels/printers/pp-details-dialog.ui:213
 #, fuzzy
-msgctxt "printer state"
-msgid "Processing"
-msgstr "_Gairm:"
+msgid "Install PPD File…"
+msgstr "Iompórtáil Comhad…"
 
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:919
-msgid "Toner Level"
-msgstr "Leibhéal Tonóra"
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "Méar an fháinne chlé"
 
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Ink Level"
-msgstr "Leibhéal Dúigh"
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Supply Level"
-msgstr "Leibhéal Soláthair"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Cealaigh"
 
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:943
-msgctxt "printer state"
-msgid "Installing"
-msgstr "Á shuiteáil"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Roghnaigh"
 
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1119
-msgid "No printers available"
-msgstr "Níl aon phrintéir ar fáil"
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "Fíordheimhnithe!"
+msgstr[1] "Fíordheimhnithe!"
+msgstr[2] "Fíordheimhnithe!"
+msgstr[3] "Fíordheimhnithe!"
+msgstr[4] "Fíordheimhnithe!"
 
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1429
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "_Fearann"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "Fíordheimhnigh"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Fíordheimhnigh"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "Bain Printéir"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Leathanach tástála"
+
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
-msgid "%u active"
-msgid_plural "%u active"
+msgid "%u Job"
+msgid_plural "%u Jobs"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
 
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1770
-msgid "Failed to add new printer."
-msgstr "Theip ar chur printéir nua leis."
-
-#: ../panels/printers/cc-printers-panel.c:1937
-msgid "Select PPD File"
-msgstr "Roghnaigh Comhad PPD"
-
-#: ../panels/printers/cc-printers-panel.c:1946
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2253
-msgid "No suitable driver found"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2324
-msgid "Searching for preferred drivers…"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2345
-msgid "Select from database…"
-msgstr ""
-
-#: ../panels/printers/cc-printers-panel.c:2354
-msgid "Provide PPD File…"
-msgstr ""
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2505
-#: ../panels/printers/cc-printers-panel.c:2528
-msgid "Test page"
-msgstr "Leathanach tástála"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2942
-#, fuzzy, c-format
-msgid "Could not load ui: %s"
-msgstr "Níorbh fhéidir an príomhchomhéadan a luchtú"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
-msgid "Printers"
-msgstr "Printéirí"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
-msgid "Add printers, view printer jobs and decide how you want to print"
-msgstr ""
-
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
-msgid "Printer;Queue;Print;Paper;Ink;Toner;"
-msgstr ""
-
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr ""
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "Dún"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr ""
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr ""
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr ""
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "Cuir Printéir Nua Leis"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
+#: panels/printers/printer-entry.ui:18
 #, fuzzy
-msgid "A_uthenticate"
-msgstr "Fíordheimhnigh"
+msgid "Printing Options"
+msgstr "Roghanna Logála Isteach"
 
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "Níor braitheadh aon phrintéir."
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-msgid "Enter a network address or search for a printer"
-msgstr ""
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "Roghanna á luchtú…"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
+#: panels/printers/printer-entry.ui:29
 #, fuzzy
-msgid "Select Printer Driver"
-msgstr "Méar an fháinne chlé"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr ""
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:526
-#, fuzzy
-msgid "JetDirect Printer"
-msgstr "Bain Printéir"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:782
-#, fuzzy
-msgid "LPD Printer"
-msgstr "Printéir %s"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr ""
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr ""
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr ""
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-#, fuzzy
-msgctxt "print job"
-msgid "Processing"
-msgstr "_Gairm:"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr ""
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr ""
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr ""
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr ""
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "Teideal Jab"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "Staid Jab"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "Am"
-
-#: ../panels/printers/pp-jobs-dialog.c:451
-#, c-format
-msgid "%s Active Jobs"
-msgstr ""
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1659
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1664
-msgid "Serial Port"
-msgstr ""
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "Parallel Port"
-msgstr ""
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1713
-#, c-format
-msgid "Location: %s"
-msgstr "Suíomh: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1718
-#, c-format
-msgid "Address: %s"
-msgstr "Seoladh: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1747
-#, fuzzy
-msgid "Server requires authentication"
-msgstr "Fíordheimhnithe!"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr ""
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr ""
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr ""
-
-#: ../panels/printers/pp-options-dialog.c:84
-#, fuzzy
-msgid "Output Tray"
-msgstr "Aschur"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr ""
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:533
-msgid "Pages per side"
-msgstr ""
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:545
-msgid "Two-sided"
-msgstr ""
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:557
-#, fuzzy
-msgid "Orientation"
-msgstr "Gníomh an Bharra Teidil"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:654
-#, fuzzy
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Ginearálta"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Socrú Leathanaigh"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:660
-#, fuzzy
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Gníomh an Bharra Teidil"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Jab"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Cáilíocht Íomhá"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Dath"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr ""
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:675
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Casta"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "Uathroghnaigh"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-#, fuzzy
-msgid "Printer Default"
+msgid "Printer Details"
 msgstr "Réamhshocrú"
 
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
 #, fuzzy
-msgid "No pre-filtering"
-msgstr "Gan phróifíl"
+msgid "Use Printer by Default"
+msgstr "Réamhshocrú"
 
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "Déantóir"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "Tiománaí"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:1
-msgid "Add Printer"
-msgstr "Cuir Printéir Leis"
-
-#: ../panels/printers/printers.ui.h:2
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Bain Printéir"
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "Soláthar"
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Gníomh"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
-msgid "Location"
-msgstr "Suíomh"
-
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default printer"
-msgstr "Printéir _réamhshocraithe"
-
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "Jabanna"
-
-#. Translators: Opens a dialog containing printer
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "Taispeáin _Jabanna"
-
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Samhail"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "lipéad"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Leibhéal Dúigh"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "leathanach 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "Priontáil Leathanach _Tástála"
-
-#. Translators: This button opens printer
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "_Roghanna"
-
-#. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "Cuir Printéir Nua Leis"
-
-#. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
-msgid ""
-"Sorry! The system printing service\n"
-"doesn't seem to be available."
-msgstr ""
-
-#: ../panels/privacy/cc-privacy-panel.c:352 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "Glas Scáileáin"
-
-#: ../panels/privacy/cc-privacy-panel.c:462 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "Úsáid & Stair"
-
-#: ../panels/privacy/cc-privacy-panel.c:587
-msgid "Empty all items from Trash?"
-msgstr "Folmhaigh gach mír ón mBruscar?"
-
-#: ../panels/privacy/cc-privacy-panel.c:588
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Scriosfar gach mír sa Bhruscar go buan."
-
-#: ../panels/privacy/cc-privacy-panel.c:589 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "_Folmhaigh an Bruscar"
-
-#: ../panels/privacy/cc-privacy-panel.c:612
-msgid "Delete all the temporary files?"
-msgstr "Scrios gach comhad sealadach?"
-
-#: ../panels/privacy/cc-privacy-panel.c:613
-msgid "All the temporary files will be permanently deleted."
-msgstr "Scriosfar gach comhad sealadach go buan."
-
-#: ../panels/privacy/cc-privacy-panel.c:614 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "_Purgaigh Comhaid Shealadacha"
-
-#: ../panels/privacy/cc-privacy-panel.c:636 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "Purgaigh Bruscar & Comhaid Shealadacha"
-
-#: ../panels/privacy/cc-privacy-panel.c:676 ../panels/privacy/privacy.ui.h:36
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
 #, fuzzy
-msgid "Software Usage"
-msgstr "Bogearraí"
-
-#: ../panels/privacy/cc-privacy-panel.c:717 ../panels/privacy/privacy.ui.h:44
-msgid "Problem Reporting"
-msgstr ""
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: ../panels/privacy/cc-privacy-panel.c:731
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-
-#: ../panels/privacy/cc-privacy-panel.c:743 ../panels/privacy/privacy.ui.h:41
-#, fuzzy
-msgid "Privacy Policy"
-msgstr "Príobháid­eachas"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "Príobháid­eachas"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "Múchadh an Scáileáin"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 soicind"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 lá"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 lá"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 lá"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 lá"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 lá"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 lá"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 lá"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 lá"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 lá"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "Go deo"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "Ú_sáidte le Déanaí"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "Coinnigh _Stair"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "_Glan an Stair Is Déanaí"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "Cosnaíonn Glas Scáileáin do phríobháideachas nuair atá tú amuigh."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "Glasáil Scáileáin Uathoibríoch"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "Cuir scáileán faoi _ghlas tar éis"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "Taispeáin _Fógairtí"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "Folmhaigh _Bruscar go huathoibríoch"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "Purgaigh _Comhaid Sealadacha go huathoibríoch"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "Purgaigh i _nDiaidh"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:42
-#, fuzzy
-msgid "_Location Services"
-msgstr "Suíomh"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:45
-msgid "_Automatic Problem Reporting"
-msgstr ""
-
-#: ../panels/region/cc-format-chooser.c:120
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Impiriúil"
-
-#: ../panels/region/cc-format-chooser.c:122
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Méadrach"
-
-#: ../panels/region/cc-format-chooser.c:287
-msgid "No regions found"
-msgstr "Réigiún gan aimsiú"
-
-#: ../panels/region/cc-input-chooser.c:181
-msgid "No input sources found"
-msgstr "Foinse ionchuir gan aimsiú"
-
-#: ../panels/region/cc-input-chooser.c:1015
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Eile"
-
-#: ../panels/region/cc-region-panel.c:247
-#: ../panels/user-accounts/um-user-panel.c:1072
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr ""
-
-#: ../panels/region/cc-region-panel.c:251
-#: ../panels/user-accounts/um-user-panel.c:1076
-msgid "Restart Now"
+msgid "Restart"
 msgstr "Atosaigh Anois"
 
-#: ../panels/region/cc-region-panel.c:877
-msgid "No input source selected"
-msgstr "Níl aon fhoinse ionchuir roghnaithe"
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Cuir Printéir Leis"
 
-#: ../panels/region/cc-region-panel.c:1797
-msgid "Login Screen"
-msgstr "Scáileán Logála Isteach"
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
 
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Printéirí"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formáidí"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Suíomhanna Cuardaigh"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Formáidí"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Formáidí"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Réamhamharc"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Dátaí"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "Amanna"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Dáta & Am"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Uimhreacha"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Tomhas"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Páipéir"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Mo Chuntas"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Teanga"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "Formáidí"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "Scáileán Logála Isteach"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Réigiún & Teanga"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
 msgstr ""
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Teanga;Leagan Amach;Méarchlár;Ionchur;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "Cuir Foinse Ionchuir Leis"
-
-#: ../panels/region/input-chooser.ui.h:4
-msgid "Input methods can't be used on the login screen"
-msgstr "Ní féidir modhanna ionchuir a úsáid ar an scáileán logála isteach"
-
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "Roghanna na Foinse Ionchuir"
-
-#: ../panels/region/input-options.ui.h:3
-msgid "Use the _same source for all windows"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Allow _different sources for each window"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "fu_aim CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "fís _DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Seinnteoir _ceoil"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Bogearraí"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "Meáin _Eile…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Keyboard Shortcuts"
-msgstr "Aicearraí Méarchláir"
-
-#: ../panels/region/input-options.ui.h:6
-msgid "Switch to previous source"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
 msgstr ""
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Gníomh:"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Switch to next source"
-msgstr ""
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "C_ineál:"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "Super+Space"
-msgstr "Super+Space"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Meáin Inbhainte"
 
-#: ../panels/region/input-options.ui.h:10
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr ""
-
-#: ../panels/region/input-options.ui.h:11
-msgid "Alternative switch to next source"
-msgstr ""
-
-#: ../panels/region/input-options.ui.h:12
-msgid "Left+Right Alt"
-msgstr "Left+Right Alt"
-
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "Béarla (An Ríocht Aontaithe)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "An Ríocht Aontaithe"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "Roghanna"
-
-#: ../panels/region/region.ui.h:7
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
 #, fuzzy
-msgid "Add input source"
-msgstr "Cuir Foinse Ionchuir Leis"
+msgid "Configure Removable Media settings"
+msgstr "Meáin Inbhainte"
 
-#: ../panels/region/region.ui.h:8
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 #, fuzzy
-msgid "Remove input source"
-msgstr "Foinse ionchuir gan aimsiú"
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"gléas;córas;faisnéis;cuimhne;próiseálaí;leagan;réamhshocrú;feidhmchlár;rogha;"
+"cd;dvd;usb;fuaim;fís;diosca;inbhainte;meáin;uathrith;"
 
-#: ../panels/region/region.ui.h:9
-#, fuzzy
-msgid "Move input source up"
-msgstr "Foinse ionchuir gan aimsiú"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Glas Scáileáin"
 
-#: ../panels/region/region.ui.h:10
-#, fuzzy
-msgid "Move input source down"
-msgstr "Foinse ionchuir gan aimsiú"
-
-#: ../panels/region/region.ui.h:11
-#, fuzzy
-msgid "Configure input source"
-msgstr "Athraigh go dtí an chéad fhoinse ionchuir eile"
-
-#: ../panels/region/region.ui.h:12
-#, fuzzy
-msgid "Show input source keyboard layout"
-msgstr "Níl aon fhoinse ionchuir roghnaithe"
-
-#: ../panels/region/region.ui.h:13
-msgid "Login settings are used by all users when logging into the system"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
 msgstr ""
 
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "_Bánaigh an scáileán"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Glasáil Scáileáin Uathoibríoch"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "Glasáil Scáileáin Uathoibríoch"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Taispeáin _Fógairtí"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Scáileán Glasála"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Príobháid­eachas"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Scáileán"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Comhroinnt an Scáileáin"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Suíomhanna Cuardaigh"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
 msgid "Places"
 msgstr "Áiteanna"
 
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
 msgid "Bookmarks"
 msgstr "Leabharmharcanna"
 
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Eile"
 
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "Roghnaigh Suíomh"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Suíomh"
 
-#: ../panels/search/cc-search-locations-dialog.c:682
-msgid "_OK"
-msgstr "Tá g_o Maith"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Feidhmchláir"
 
-#: ../panels/search/cc-search-panel.c:177
-msgid "No applications found"
-msgstr "Feidhmchlár gan aimsiú"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "Cuardach"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Suíomhanna Cuardaigh"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr "Suíomhanna Cuardaigh"
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Líonra"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "Bog Suas"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "Bog Síos"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "Sainroghanna"
-
-#: ../panels/sharing/cc-sharing-panel.c:265
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Cumasaithe"
-
-#: ../panels/sharing/cc-sharing-panel.c:267
-#: ../panels/sharing/cc-sharing-panel.c:294
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Díchumasaithe"
-
-#: ../panels/sharing/cc-sharing-panel.c:297
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Cumasaithe"
-
-#: ../panels/sharing/cc-sharing-panel.c:300
-msgctxt "service is active"
-msgid "Active"
-msgstr "Gníomhach"
-
-#: ../panels/sharing/cc-sharing-panel.c:371
-msgid "Choose a Folder"
-msgstr "Roghnaigh Fillteán"
-
-#: ../panels/sharing/cc-sharing-panel.c:800
-msgid "Copy"
-msgstr "Cóipeáil"
-
-#: ../panels/sharing/cc-sharing-panel.c:1126
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Comhroinnt"
 
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
+msgstr "Ainm an Ríomhaire"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Comhroinnt na gComhad Pearsanta"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "Comhroinnt Meán"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "Cianlogáil Isteach"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Comhroinnt"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Focal Faire:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Cianlogáil Isteach"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Cianlogáil Isteach"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Rialtán UI"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Gan cheangal"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Cóipeáil"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Scrios Seoladh"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Fío_rdheimniú"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Ainm Úsáideora"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Cumasaigh Logáil Isteach Méarloirg"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Comhroinnt Meán"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Fillteáin"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
 msgstr ""
 
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
 "movies;server;renderer;"
 msgstr ""
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
 msgstr ""
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 #, fuzzy
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Fíordheimhnithe!"
 
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:303
-msgid "No networks selected for sharing"
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
 msgstr ""
 
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
+#: panels/sound/cc-alert-chooser.ui:20
 #, fuzzy
-msgid "Networks"
-msgstr "Líonra"
+msgid "String"
+msgstr "Comhroinnt"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Computer Name"
-msgstr "Ainm an Ríomhaire"
-
-#: ../panels/sharing/sharing.ui.h:2
-msgid "Personal File Sharing"
-msgstr "Comhroinnt na gComhad Pearsanta"
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Screen Sharing"
-msgstr "Comhroinnt an Scáileáin"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Media Sharing"
-msgstr "Comhroinnt Meán"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Remote Login"
-msgstr "Cianlogáil Isteach"
-
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Some services are disabled because of no network access."
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:8
-#, no-c-format
-msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
 msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 #, fuzzy
-msgid "Require Password"
-msgstr "_Focal Faire:"
+msgid "Balance"
+msgstr "_Cothromaíocht:"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:15
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:16
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 #, fuzzy
-msgid "Allow Remote Control"
-msgstr "Rialtán UI"
+msgid "Fade"
+msgstr "Céi_mniú:"
 
-#: ../panels/sharing/sharing.ui.h:17
+#: panels/sound/cc-fade-slider.ui:16
 #, fuzzy
-msgid "Password:"
-msgstr "Focal Faire"
-
-#: ../panels/sharing/sharing.ui.h:18
-msgid "Show Password"
-msgstr "Taispeáin Focal Faire"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, fuzzy
-msgid "Access Options"
-msgstr "Roghanna"
-
-#: ../panels/sharing/sharing.ui.h:20
-msgid "New connections must ask for access"
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:21
-#, fuzzy
-msgid "Require a password"
-msgstr "_Focal Faire:"
-
-#: ../panels/sharing/sharing.ui.h:22
-msgid ""
-"Media sharing allows you to share music, photos and videos over the network."
-msgstr ""
-
-#: ../panels/sharing/sharing.ui.h:23
-msgid "Folders"
-msgstr "Fillteáin"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "Fuaim"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr ""
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr ""
-
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "Sceamh"
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "Sileadh"
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "Gloine"
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "Sonóir"
-
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "Clé"
-
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "Deas"
-
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
 msgid "Rear"
 msgstr "Cúl"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Aghaidh"
 
-#: ../panels/sound/gvc-balance-bar.c:113
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
 #, fuzzy
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Íoslaghdaigh"
+msgid "System Volume"
+msgstr "Fuaimeanna Córais"
 
-#: ../panels/sound/gvc-balance-bar.c:114
+#: panels/sound/cc-sound-panel.ui:12
 #, fuzzy
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Uasmhéadaigh"
+msgid "Master volume"
+msgstr "_Airde foláireamh:"
 
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "_Cothromaíocht:"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Airde gan fuaim"
 
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "Céi_mniú:"
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Aschur"
 
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Airde _aschuir:"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Tástáil"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "U_RL Cumraíochta:"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
 msgstr "Fo-dhordaire"
 
-#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Ionchur"
 
-#: ../panels/sound/gvc-channel-bar.c:615
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Gan aimpliú"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Leibhéal ionchuir:"
 
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
-#: ../panels/sound/gvc-mixer-dialog.c:515
-msgid "_Profile:"
-msgstr "_Próifíl:"
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Airde suas"
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "_Airde foláireamh:"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Fuaim"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Fógairt"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Ainm:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "_Ceangal Uathoibríoch"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Bain Gléas"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Rochtain Uilíoch"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Cuir Gléas Leis"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Caochadh an Chúrsóra"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "_Caochann an cúrsóir i réimsí téacs"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Luas:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Luas caochadh an chúrsóra"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Luas caochadh an chúrsóra"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Cliceáil Tánaisteach Ionsamhailte"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+#, fuzzy
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "_Truicear cliceáil tánaisteach agus an príomhcnaipe á choinneáil síos"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Gearr"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "Cliceáil Tánaisteach Ionsamhailte"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Fada"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "Cliceáil Fanachta"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+#, fuzzy
+msgid "Trigger a click when the pointer hovers"
+msgstr "_Cuir tús le cliceáil agus gluaiseacht an phointeora á stad"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "M_oill:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Gearr"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Fada"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "Tairseach _ghluaisne:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Beag"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Mór"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Athbhrú Eochracha"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Déantar brú eochracha _arís nuair a choinníonn an eochair síos"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Luas athbhrú eochracha"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Luas athbhrú eochracha"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Clóscríobh"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Eochracha _Greamaitheacha"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+"Dích_umasaigh eochracha greamaitheacha má bhrúitear dhá eochair le chéile"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Luas athbhrú eochracha"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Eochracha Malla"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Gearr"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Fada"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Luas athbhrú eochracha"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Eochracha _Preabtha"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Déan _neamhaird ar brúnna eochrach dúblacha tapa"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Gearr"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Fada"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+#, fuzzy
+msgid "_Enable by Keyboard"
+msgstr "Méarchlár"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Is féidir gnéithe _inrochtaineachta a scoránú le haicearraí méarchláir"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Taispeáin Roghchlár Rochtana Uilíoch i _gCónaí"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Feiceáil"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Ardchodarsnacht"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Téacs Mór"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Léitheoir Scáileáin"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Eochracha _Fuaime"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Luas caochadh an chúrsóra"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Súmáil"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Cloisteáil"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Folái_rimh Amhairc"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Méarchlár Scáileáin"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Athbhrú Eochracha"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Caochadh an Chúrsóra"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Cúnamh _Clóscríofa (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Pointeáil & Cliceáil"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Eocracha L_uiche"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Bain Printéir"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Cúnamh Cl_icéala"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "_Déchliceáil"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "_Déchliceáil"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Foláirimh Amhairc"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+#, fuzzy
+msgid "_Test flash"
+msgstr "LEATHANACH"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Splanc _scáileán ar fad"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Splanc _scáileán ar fad"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Scáileán"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "Ar Chlé"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "Ar Dheis"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Roghanna Súmála"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "Fógairt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Léitheoir Scáileáin Linux"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
+msgstr "Dath:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Maisíochtaí Datha:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
+msgstr "Bán ar dhubh:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Gile:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Codarsnacht:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Neamhní"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Lán"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Íseal"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Ard"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Íseal"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Ard"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Maisíochtaí Datha"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Méarchlár;Luch;a11y;Inrochtaineacht;Codarsnacht;Súmáil;Léitheoir Scáileáin;"
+"téacs;cló;méid;AccessX;Eocracha Greamaitheacha;Eochracha Malla;Eocracha "
+"Preabtha;Eochracha Luiche;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Stair"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "Stair"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "_Glan an Stair Is Déanaí"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "Purgaigh Bruscar & Comhaid Shealadacha"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "Folmhaigh _Bruscar go huathoibríoch"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Purgaigh _Comhaid Sealadacha go huathoibríoch"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "Folmhaigh _Bruscar go huathoibríoch"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "_Folmhaigh an Bruscar"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Purgaigh Comhaid Shealadacha"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Cuir Úsáideoir Leis"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "Riarthóir"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Socraigh focal faire anois"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "U_RL Uathchumraíochta:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Logáil Isteach _Fiontair"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "As líne"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Roghnaigh Comhad PPD"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Logáil Isteach _Méarloirg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Logáil Isteach _Méarloirg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Níl"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Níor braitheadh aon phrintéir."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Logáil Isteach _Méarloirg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Logáil Isteach _Méarloirg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Logáil Isteach _Méarloirg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Logáil Isteach _Méarloirg"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "An t-amhrán roimhe seo"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Taispeáin Focal Faire"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Athraigh"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "_Focal Faire Reatha"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Focal Faire _Nua"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Taispeáin Focal Faire"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Tá an focal faire ró-ghairid."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Socraigh focal faire anois"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Úsáideoirí"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Atosaigh Anois"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Dún"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Ainm _Iomlán"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Logáil Isteach _Méarloirg"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Logáil Isteach _Uathoibríoch"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "Cineál Cun_tais"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Riarthóir"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Bain Cuntas Úsáideora"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Méar _eile:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "Cuir Úsáideoir Leis"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Níor Aimsíodh Aon Phictiúr"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "Cruthaigh cuntas úsáideora"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+#, fuzzy
+msgid "Add or remove users and change your password"
+msgstr "Cuir leis nó bain úsáideoirí"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+#, fuzzy
+msgid "Domain Administrator Login"
+msgstr "Riarthóir"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Ai_nm Riarthóra"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Focal Faire Riarthóra"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Bainistigh cuntais úsáideora"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+#, fuzzy
+msgid "Authentication is required to change user data"
+msgstr "Fíordheimhnithe!"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Chun eochair aicearra a chur in eagar, cliceáil ar an ró comhfhreagrach agus "
+"clóscríobh teaglaim eochracha nua, nó brúigh backspace chun glanta."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Dún"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Táibléad"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Gníomh an Bharra Teidil"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Monatóir %s"
+
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Cóimheas Treoíochta"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Calabraigh…"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Níor braitheadh aon táibléad"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Ionsuigh nó cuir do tháibléad Wacom ar siúl"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Cnaipe"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Cnaipe"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Cnaipe"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Táibléad Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Táibléad;Wacom;Stíleas;Scriosán;Luch;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Cliceáil Tánaisteach Ionsamhailte"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Bogearraí Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Tánaisteach"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Bogearraí Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Roghanna"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Cuir Leis"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Sábháil"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Sonraí"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Ainm Líonra"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Líonra"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Uimhreacha"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Amharc ar mhionsonraí"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Déantóir"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "Leathanbhanda _móibíleach"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Ainm Líonra"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Líonra"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Casta"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Roghanna"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Glas Scáileáin"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Sonraí"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Ainm Líonra"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Uathoibríoch"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Mo Líonra Baile"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Mo Líonra Baile"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Díchumasaíodh Bluetooth ag lasc chrua-earraí"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Múchann sé seo gléasanna gan sreang"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Ag ceangal"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Glas Scáileáin"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "_Athraigh"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Mo Líonra Baile"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "Príobháid­eachas"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Gach Socrú"
+
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Príomhúil"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Cabhair"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Ginearálta"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Scoir"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Cuardach"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Cealaigh"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Sainroghanna;Socruithe;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
@@ -5402,9 +5376,7 @@ msgstr[2] "%u Aschur"
 msgstr[3] "%u nAschur"
 msgstr[4] "%u Aschur"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
@@ -5414,1804 +5386,1747 @@ msgstr[2] "%u Ionchur"
 msgstr[3] "%u nIonchur"
 msgstr[4] "%u Ionchur"
 
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
-msgstr "Fuaimeanna Córais"
+#~ msgid "Changes throughout the day"
+#~ msgstr "Ag athrú le linn an lae"
 
-#: ../panels/sound/gvc-mixer-dialog.c:251
-msgid "_Test Speakers"
-msgstr "_Tástáil Callairí"
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Tíligh"
 
-#: ../panels/sound/gvc-mixer-dialog.c:420
-msgid "Peak detect"
-msgstr ""
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Súmáil"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1493
-#: ../panels/sound/gvc-sound-theme-chooser.c:564
-msgid "Name"
-msgstr "Ainm"
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Láraigh"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1512
-msgid "Device"
-msgstr "Gléas"
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Líon"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1575
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Réisigh"
+
+#~ msgid "Colors"
+#~ msgstr "Dathanna"
+
+#~ msgid "Select Background"
+#~ msgstr "Roghnaigh Cúlra"
+
+#~ msgid "Pictures"
+#~ msgstr "Pictiúir"
+
+#~ msgid "Home"
+#~ msgstr "Baile"
+
 #, c-format
-msgid "Speaker Testing for %s"
-msgstr ""
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Is féidir leat íomhánna a chur le d'fhillteán “%s” agus taispeánfar iad "
+#~ "anseo"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1631
-msgid "_Output volume:"
-msgstr "Airde _aschuir:"
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1645
-msgid "Output"
-msgstr "Aschur"
+#~ msgid "No Desktop Background"
+#~ msgstr "Gan Cúlra na Deisce"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1650
-msgid "C_hoose a device for sound output:"
-msgstr "_Roghnaigh gléas le haghaidh aschur fuaime:"
+#~ msgid "Current background"
+#~ msgstr "Cúlra reatha"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1672
-msgid "Settings for the selected device:"
-msgstr "Socruithe don ghléas roghnaithe:"
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Cúlbhrat;Scáileán;Deasc;"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1683
-msgid "Input"
-msgstr "Ionchur"
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr ""
+#~ "Socraigh do ghléas calabraithe thar an gcearnóg agus brúigh 'Tosaigh'"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1690
-msgid "_Input volume:"
-msgstr "Airde _ionchuir:"
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr ""
+#~ "Bog do ghléas calabraithe go dtí an t-ionad calabraithe agus brúigh 'Ar "
+#~ "Aghaidh'"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "Input level:"
-msgstr "Leibhéal ionchuir:"
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr ""
+#~ "Bog do ghléas calabraithe go dtí an t-ionad dromchla agus brúigh 'Ar "
+#~ "Aghaidh'"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1737
-msgid "C_hoose a device for sound input:"
-msgstr "_Roghnaigh gléas le haghaidh ionchur fuaime:"
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Dún an clúdach"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1761
-msgid "Sound Effects"
-msgstr "Maisíochtaí Fuaime"
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Tá uirlisí de dhíth le haghaidh calabraithe nach bhfuil suiteáilte."
 
-#: ../panels/sound/gvc-mixer-dialog.c:1768
-msgid "_Alert volume:"
-msgstr "_Airde foláireamh:"
+#~ msgid "The profile could not be generated."
+#~ msgstr "Níorbh fhéidir an phróifíl a ghiniúint."
 
-#: ../panels/sound/gvc-mixer-dialog.c:1785
-msgid "No application is currently playing or recording audio."
-msgstr "Níl fuaim á seinm nó á taifeadadh ag aon fheidhmchlár."
+#~ msgid "Complete!"
+#~ msgstr "Críochnaithe!"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "Ionsuite"
+#~ msgid "Calibration failed!"
+#~ msgstr "Theip ar chalabrú!"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "Sainroghanna Fuaime"
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Is féidir leat an gléas calabraithe a bhaint."
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr ""
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ná cuir isteach ar an ngléas calabraithe nuair atá sé ar siúl"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:554
-msgid "Default"
-msgstr "Réamhshocrú"
+#~ msgid "Laptop Screen"
+#~ msgstr "Scáileán Ríomhaire Glúine"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:555
-msgid "From theme"
-msgstr "Ó théama"
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Scanóir %s"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:740
-msgid "C_hoose an alert sound:"
-msgstr "_Roghnaigh fuaim fholáirimh:"
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Printéir %s"
 
-#: ../panels/sound/gvc-speaker-test.c:231
-msgid "Stop"
-msgstr "Stad"
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Ceamara Gréasáin %s"
 
-#: ../panels/sound/gvc-speaker-test.c:231
-#: ../panels/sound/gvc-speaker-test.c:343
-msgid "Test"
-msgstr "Tástáil"
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Cumasaigh bainisteoireacht dathanna do %s"
 
-#: ../panels/sound/gvc-speaker-test.c:239
-msgid "Subwoofer"
-msgstr "Fo-dhordaire"
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Taispeáin próifílí datha do %s"
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "Saincheaptha"
+#~ msgid "Not calibrated"
+#~ msgstr "Gan chalabrú"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr ""
+#~ msgid "Default: "
+#~ msgstr "Réamhshocrú: "
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#~ msgid "Test profile: "
+#~ msgstr "Próifíl tástála:"
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Roghnaigh Comhad Próifíle ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Iompórtáil"
+
+#~ msgid "All files"
+#~ msgstr "Gach comhad"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Theip ar uasluchtú comhaid: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Uasluchtaíodh an phróifíl go:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Breac síos an URL seo."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Atosaigh an ríomhaire seo agus bútáil do ghnáthchóras oibriúcháin."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Clóscríobh an URL isteach i do bhrabhsálaí chun an phróifíl a íosluchtú "
+#~ "agus a shuiteáil."
+
+#~ msgid "Save Profile"
+#~ msgstr "Sábháil Próifíl"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Cruthaigh próifíl dathanna don ghléas roghnaithe"
+
+#~ msgid "Standard Space"
+#~ msgstr "Spás Caighdeánach"
+
+#~ msgid "Test Profile"
+#~ msgstr "Próifíl Tástála"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Uathoibríoch"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Cáilíocht Íseal"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Cáilíocht Mheánach"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Ardcháilíocht"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB Réamhshocraithe"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK Réamhshocraithe"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Liath Réamhshocraithe"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Is féidir nach bhfuil an phróifíl seo cruinn a thuilleadh"
+
+#~ msgid "Done"
+#~ msgstr "Críochnaithe"
+
+#~ msgid "Upload profile"
+#~ msgstr "Uasluchtaigh próifíl"
+
+#~ msgid "Other…"
+#~ msgstr "Eile…"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%B %e %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%B %e %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "AUL%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Crios A_ma"
+
+#~ msgid "24-hour"
+#~ msgstr "24 uair"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Clúdach Dúnta"
+
+#~ msgid "Mirrored"
+#~ msgstr "Scáthánaithe"
+
+#~ msgid "Off"
+#~ msgstr "Díchumasaithe"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Leag Amach Taispeáintí Comhcheangailte"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Tarraing taispeáintí chun iad a leagan amach"
+
+#~ msgid "Size"
+#~ msgstr "Méid"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Comhcheangail an taispeáint seo le ceann eile chun spás breise oibre a "
+#~ "chruthú"
+
+#~ msgid "Presentation"
+#~ msgstr "Láithreoireacht"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Taispeáin teaspántais sleamhnán agus meáin amháin"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Taispeáin d'amharc atá ann ar an dá taispeáint"
+
+#~ msgid "Turn Off"
+#~ msgstr "Múch"
+
 #, fuzzy
-msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
-msgstr ""
-"Méarchlár;Luch;a11y;Inrochtaineacht;Codarsnacht;Súmáil;Léitheoir Scáileáin;"
-"téacs;cló;méid;AccessX;Eocracha Greamaitheacha;Eochracha Malla;Eocracha "
-"Preabtha;Eochracha Luiche;"
+#~ msgid "Don't use this display"
+#~ msgstr "Ná bain úsáid as an taispeáint"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "Taispeáin Roghchlár Rochtana Uilíoch i _gCónaí"
+#~ msgid "Could not get screen information"
+#~ msgstr "Níorbh fhéidir eolas scáileáin a fháil"
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "Feiceáil"
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Leag Amach Taispeáintí Comhcheangailte"
 
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "_Ardchodarsnacht"
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "_Téacs Mór"
+#~ msgid "Unknown"
+#~ msgstr "Anaithnid"
 
-#: ../panels/universal-access/uap.ui.h:5
-msgid "_Zoom"
-msgstr "_Súmáil"
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-giotán"
 
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr "_Léitheoir Scáileáin"
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-giotán"
 
-#: ../panels/universal-access/uap.ui.h:8
-msgid "_Sound Keys"
-msgstr "Eochracha _Fuaime"
+#~ msgid "Ask what to do"
+#~ msgstr "Fiafraigh díom"
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "Cloisteáil"
+#~ msgid "Do nothing"
+#~ msgstr "Ná déan faic"
 
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
-msgstr "Folái_rimh Amhairc"
+#~ msgid "Open folder"
+#~ msgstr "Oscail fillteán"
 
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Screen _Keyboard"
-msgstr "_Méarchlár Scáileáin"
+#~ msgid "Other Media"
+#~ msgstr "Meáin Eile"
 
-#: ../panels/universal-access/uap.ui.h:13
-msgid "_Typing Assist (AccessX)"
-msgstr "Cúnamh _Clóscríofa (AccessX)"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Pointing & Clicking"
-msgstr "Pointeáil & Cliceáil"
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "_Mouse Keys"
-msgstr "Eocracha L_uiche"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "Cúnamh Cl_icéala"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "Léitheoir Scáileáin"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Screen Reader"
-msgstr "Léitheoir _Scáileáin"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Sound Keys"
-msgstr "Eochracha Fuaime"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "Foláirimh Amhairc"
-
-#: ../panels/universal-access/uap.ui.h:23
 #, fuzzy
-msgid "_Test flash"
-msgstr "LEATHANACH"
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Roghnaigh d'fheidhmchláir réamhshocraithe"
 
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Use a visual indication when an alert sound occurs."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:25
 #, fuzzy
-msgid "Flash the _window title"
-msgstr "Splanc barra teidil na _fuinneoige"
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Roghnaigh d'fheidhmchláir réamhshocraithe"
 
-#: ../panels/universal-access/uap.ui.h:26
 #, fuzzy
-msgid "Flash the entire _screen"
-msgstr "Splanc _scáileán ar fad"
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Roghnaigh d'fheidhmchláir réamhshocraithe"
 
-#: ../panels/universal-access/uap.ui.h:27
+#~ msgid "audio DVD"
+#~ msgstr "DVD fuaime"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "diosca Blu-ray bán"
+
+#~ msgid "blank CD disc"
+#~ msgstr "diosca CD bán"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "diosca DVD bán"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "diosca HD DVD bán"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "diosca físe Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "léitheoir r-leabhair"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "diosca físe HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "Overview"
+#~ msgstr "Foramharc"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "Leagan %s"
+
+#~ msgid "Base system"
+#~ msgstr "Bunchóras"
+
+#~ msgid "Disk"
+#~ msgstr "Diosca"
+
 #, fuzzy
-msgid "Typing Assist"
-msgstr "Clóscríobh"
+#~ msgid "Check for updates"
+#~ msgstr "Nuashonruithe á Seiceáil"
 
-#: ../panels/universal-access/uap.ui.h:28
-msgid "_Sticky Keys"
-msgstr "Eochracha _Greamaitheacha"
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Sábháil gabháil scáileáin i $PICTURES"
 
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr ""
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Sábháil gabháil scáileán fuinneoige i $PICTURES"
 
-#: ../panels/universal-access/uap.ui.h:30
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Sábháil gabháil scáileán limistéir i $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Cóipeáil gabháil scáileáin go dtí an ghearrthaisce"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Cóipeáil gabháil scáileán fuinneoige go dtí an ghearrthaisce"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Cóipeáil gabháil scáileán limistéir go dtí an ghearrthaisce"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Taifead físghabháil ghearr scáileáin"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Aicearra;Athbhrú;Caoch;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Aicearra Saincheaptha"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Moill:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Gearr"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Mall"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Fada"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Tapa"
+
+#~ msgid "S_peed:"
+#~ msgstr "L_uas:"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Bain Aicearra"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Chun aicearra a chur in eagar, cliceáil ar an ró agus coinnigh síos na "
+#~ "heochracha nua, nó brúigh Backspace chun glanta."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Gníomh Anaithnid>"
+
+#~ msgid "_Reassign"
+#~ msgstr "_Athshann"
+
 #, fuzzy
-msgid "_Disable if two keys are pressed together"
-msgstr ""
-"Dích_umasaigh eochracha greamaitheacha má bhrúitear dhá eochair le chéile"
+#~ msgid "_Assign"
+#~ msgstr "_Athshann"
 
-#: ../panels/universal-access/uap.ui.h:31
+#~ msgid "Test Your Settings"
+#~ msgstr "Tástáil Do Shocruithe"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Mall"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Teorainn am déchliceála"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Tapa"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Clé"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Deas"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Luas an phointeora"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Mall"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Tapa"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Mall"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Tapa"
+
 #, fuzzy
-msgid "Beep when a _modifier key is pressed"
-msgstr "Luas athbhrú eochracha"
+#~ msgid "Two _finger scroll"
+#~ msgstr "Scrollú dhá-_mhéar"
 
-#: ../panels/universal-access/uap.ui.h:32
-msgid "S_low Keys"
-msgstr "_Eochracha Malla"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:35
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Gearr"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:37
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Fada"
-
-#: ../panels/universal-access/uap.ui.h:38
 #, fuzzy
-msgid "Beep when a key is pr_essed"
-msgstr "Luas athbhrú eochracha"
+#~ msgid "Double click, primary button"
+#~ msgstr "Teorainn Am Déchliceála"
 
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Beep when a key is _accepted"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "_Bounce Keys"
-msgstr "Eochracha _Preabtha"
-
-#: ../panels/universal-access/uap.ui.h:42
 #, fuzzy
-msgid "Ignores fast duplicate keypresses"
-msgstr "Déan _neamhaird ar brúnna eochrach dúblacha tapa"
+#~ msgid "Double click, middle button"
+#~ msgstr "Teorainn Am Déchliceála"
 
-#: ../panels/universal-access/uap.ui.h:43
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Gearr"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:45
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Fada"
-
-#: ../panels/universal-access/uap.ui.h:46
 #, fuzzy
-msgid "_Enable by Keyboard"
-msgstr "Méarchlár"
+#~ msgid "Double click, secondary button"
+#~ msgstr "Teorainn Am Déchliceála"
 
-#: ../panels/universal-access/uap.ui.h:47
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "page 1"
+#~ msgstr "leathanach 1"
+
+#~ msgid "page 2"
+#~ msgstr "leathanach 2"
+
+#~ msgid "automatic"
+#~ msgstr "uathoibríoch"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Fiontar"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Neamhní"
+
+#~ msgid "Never"
+#~ msgstr "Riamh"
+
+#~ msgid "Today"
+#~ msgstr "Inniu"
+
+#~ msgid "Yesterday"
+#~ msgstr "Inné"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Neamhní"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Lag"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Cuíosach"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Maith"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Ar fheabhas"
+
+#~ msgid "Identity"
+#~ msgstr "Aitheantas"
+
+#~ msgid "Server"
+#~ msgstr "Freastalaí"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Scrios Freastalaí DNS"
+
+#~ msgid "Delete Route"
+#~ msgstr "Scrios Ród"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Neamhní"
+
 #, fuzzy
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "Is féidir gnéithe _inrochtaineachta a scoránú le haicearraí méarchláir"
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Fiontar"
 
-#: ../panels/universal-access/uap.ui.h:48
-msgid "Click Assist"
-msgstr ""
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Casphéire (TP)"
 
-#: ../panels/universal-access/uap.ui.h:49
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Comhéadan Aonad Ceangail (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Réamhshocrú"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
 #, fuzzy
-msgid "_Simulated Secondary Click"
-msgstr "Cliceáil Tánaisteach Ionsamhailte"
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Fíordheimhnithe!"
 
-#: ../panels/universal-access/uap.ui.h:50
+#~ msgid "New Profile"
+#~ msgstr "Próifíl Nua"
+
+#~ msgid "Bond"
+#~ msgstr "Nasc"
+
+#~ msgid "Bridge"
+#~ msgstr "Droichead"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
 #, fuzzy
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "_Truicear cliceáil tánaisteach agus an príomhcnaipe á choinneáil síos"
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Níorbh fhéidir an príomhchomhéadan a luchtú"
 
-#: ../panels/universal-access/uap.ui.h:51
-msgctxt "secondary click"
-msgid "Short"
-msgstr "Gearr"
+#~ msgid "Import from file…"
+#~ msgstr "Iompórtáil ó chomhad…"
 
-#: ../panels/universal-access/uap.ui.h:52
+#~ msgid "Add Network Connection"
+#~ msgstr "Cuir Ceangal Líonra Leis"
+
+#~ msgid "_Reset"
+#~ msgstr "_Athshocraigh"
+
+#~ msgid "_Forget"
+#~ msgstr "_Déan Dearmad"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "Tá comhad darb ainm \"%s\" ann cheana."
+
 #, fuzzy
-msgid "Secondary click delay"
-msgstr "Cliceáil Tánaisteach Ionsamhailte"
+#~ msgid "Export VPN connection"
+#~ msgstr "Easpórtáil ceangal VPN..."
 
-#: ../panels/universal-access/uap.ui.h:53
-msgctxt "secondary click delay"
-msgid "Long"
-msgstr "Fada"
+#~ msgid "never"
+#~ msgstr "riamh"
 
-#: ../panels/universal-access/uap.ui.h:54
+#~ msgid "today"
+#~ msgstr "inniu"
+
+#~ msgid "yesterday"
+#~ msgstr "inné"
+
+#~ msgid "Last used"
+#~ msgstr "Úsáid is déanaí"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Próifíl %d"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Déan Dearmad"
+
+#~ msgid "Proxy"
+#~ msgstr "Seachfhreastalaí"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Neamhní"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "De láimh"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Uathoibríoch"
+
+#~ msgid "Group Name"
+#~ msgstr "Ainm Grúpa"
+
+#~ msgid "details"
+#~ msgstr "sonraí"
+
+#~ msgid "Show P_assword"
+#~ msgstr "_Taispeáin Focal Faire"
+
+#~ msgid "identity"
+#~ msgstr "aitheantas"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "reset"
+#~ msgstr "athshocraigh"
+
+#~ msgid "Hardware"
+#~ msgstr "Crua-Earraí"
+
+#~ msgid "_History"
+#~ msgstr "_Stair"
+
 #, fuzzy
-msgid "_Hover Click"
-msgstr "Cliceáil Fanachta"
+#~ msgid "Connected Devices"
+#~ msgstr "Gach Comhad"
 
-#: ../panels/universal-access/uap.ui.h:55
+#~ msgid "Status unknown"
+#~ msgstr "Stádas anaithnid"
+
+#~ msgid "Unavailable"
+#~ msgstr "Níl ar fáil"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Ag dícheangal"
+
 #, fuzzy
-msgid "Trigger a click when the pointer hovers"
-msgstr "_Cuir tús le cliceáil agus gluaiseacht an phointeora á stad"
+#~ msgid "Configuration failed"
+#~ msgstr "U_RL Uathchumraíochta:"
 
-#: ../panels/universal-access/uap.ui.h:56
-msgid "D_elay:"
-msgstr "M_oill:"
-
-#: ../panels/universal-access/uap.ui.h:57
-msgctxt "dwell click delay"
-msgid "Short"
-msgstr "Gearr"
-
-#: ../panels/universal-access/uap.ui.h:58
-msgctxt "dwell click delay"
-msgid "Long"
-msgstr "Fada"
-
-#: ../panels/universal-access/uap.ui.h:59
 #, fuzzy
-msgid "Motion _threshold:"
-msgstr "Tairseach _ghluaisne:"
+#~ msgid "IP configuration failed"
+#~ msgstr "Fíordheimhnithe!"
 
-#: ../panels/universal-access/uap.ui.h:60
-msgctxt "dwell click threshold"
-msgid "Small"
-msgstr "Beag"
-
-#: ../panels/universal-access/uap.ui.h:61
-msgctxt "dwell click threshold"
-msgid "Large"
-msgstr "Mór"
-
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
-msgid "Short"
-msgstr "Gearr"
-
-#: ../panels/universal-access/zoom-options.c:334
 #, fuzzy
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "Scáileán"
+#~ msgid "IP configuration expired"
+#~ msgstr "U_RL Uathchumraíochta:"
 
-#: ../panels/universal-access/zoom-options.c:335
 #, fuzzy
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "Scáileán"
+#~ msgid "AutoIP service failed"
+#~ msgstr "Fíordheimhnithe!"
 
-#: ../panels/universal-access/zoom-options.c:336
 #, fuzzy
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "Scáileán"
+#~ msgid "Modem initialization failed"
+#~ msgstr "Fíordheimhnithe!"
 
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
-msgid "Long"
-msgstr "Fada"
-
-#: ../panels/universal-access/zoom-options.ui.h:1
 #, fuzzy
-msgid "Full Screen"
-msgstr "Scáileán"
+#~ msgid "Network registration denied"
+#~ msgstr "Socruithe an líonra"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
-msgid "Top Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:3
-msgid "Bottom Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:4
 #, fuzzy
-msgid "Left Half"
-msgstr "Ar Chlé"
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Fíordheimhnithe!"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
 #, fuzzy
-msgid "Right Half"
-msgstr "Ar Dheis"
+#~ msgid "SIM wrong"
+#~ msgstr "Láidir"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
-msgid "Zoom Options"
-msgstr "Roghanna Súmála"
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Comhaid PAC (*.pac)"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "Súmáil"
+#~ msgid " "
+#~ msgstr " "
 
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
-msgstr ""
+#~ msgid "Yes"
+#~ msgstr "Tá"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr ""
+#~ msgid "2"
+#~ msgstr "2"
 
-#: ../panels/universal-access/zoom-options.ui.h:10
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "On"
+#~ msgstr "Cumasaithe"
+
 #, fuzzy
-msgid "Screen part:"
-msgstr "Léitheoir Scáileáin Linux"
+#~ msgctxt "notifications"
+#~ msgid "Notification Banners"
+#~ msgstr "Fógairtí"
 
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:15
-msgid "Magnifier Position:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:16
-msgid "Magnifier"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:18
-msgctxt "universal access, thickness"
-msgid "Thin"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:19
-msgctxt "universal access, thickness"
-msgid "Thick"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
-msgstr ""
-
-#. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
-msgstr "Dath:"
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:25
-msgid "Crosshairs"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
-msgstr "Bán ar dhubh:"
-
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
-msgstr "Gile:"
-
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
-msgstr "Codarsnacht:"
-
-#. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
-msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "Dath"
-
-#: ../panels/universal-access/zoom-options.ui.h:31
-msgctxt "universal access, color"
-msgid "None"
-msgstr "Neamhní"
-
-#: ../panels/universal-access/zoom-options.ui.h:32
-msgctxt "universal access, color"
-msgid "Full"
-msgstr "Lán"
-
-#: ../panels/universal-access/zoom-options.ui.h:33
-msgctxt "universal access, brightness"
-msgid "Low"
-msgstr "Íseal"
-
-#: ../panels/universal-access/zoom-options.ui.h:34
-msgctxt "universal access, brightness"
-msgid "High"
-msgstr "Ard"
-
-#: ../panels/universal-access/zoom-options.ui.h:35
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "Íseal"
-
-#: ../panels/universal-access/zoom-options.ui.h:36
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "Ard"
-
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "Maisíochtaí Datha:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
-msgid "Color Effects"
-msgstr "Maisíochtaí Datha"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Gnáthchuntas"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "Riarthóir"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Full Name"
-msgstr "Ainm _Iomlán"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "Cineál Cun_tais"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to set a password when they next login"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "Socraigh focal faire anois"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "_Fearann"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid ""
-"Go online to add\n"
-"enterprise login accounts."
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "Logáil Isteach _Fiontair"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1466
-msgid "Add User"
-msgstr "Cuir Úsáideoir Leis"
-
-#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
-msgid "_Enroll"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
 #, fuzzy
-msgid "Domain Administrator Login"
-msgstr "Riarthóir"
+#~ msgid "Notification Banners"
+#~ msgstr "Fógairt"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
-msgid ""
-"In order to use enterprise logins, this computer needs to be\n"
-"enrolled in the domain. Please have your network administrator\n"
-"type their domain password here."
-msgstr ""
+#~ msgid "Add Account"
+#~ msgstr "Cuir Cuntas Leis"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
-msgid "Administrator _Name"
-msgstr "Ai_nm Riarthóra"
+#~ msgid "Mail"
+#~ msgstr "Post"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
-msgid "Administrator Password"
-msgstr "Focal Faire Riarthóra"
+#~ msgid "Contacts"
+#~ msgstr "Teagmhálacha"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "Ordóg chlé"
+#~ msgid "Chat"
+#~ msgstr "Comhrá"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "Méar mheáin chlé"
+#~ msgid "Resources"
+#~ msgstr "Acmhainní"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "Méar an fháinne chlé"
+#~ msgid "Credentials have expired."
+#~ msgstr "Chuaigh dintiúir as feidhm."
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "Lúidín clé"
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Sínigh isteach chun an cuntas seo a chumasú."
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "Ordóg dheas"
+#~ msgid "_Sign In"
+#~ msgstr "_Sínigh Isteach"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "Méar mheáin dheas"
+#~ msgid "Error creating account"
+#~ msgstr "Earráid agus cuntas á chruthú"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "Méar an fháinne dheas"
+#~ msgid "Error removing account"
+#~ msgstr "Earráid agus cuntas á bhaint"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "Lúidín deas"
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "An bhfuil tú cinnte gur mhaith leat an cuntas a bhaint?"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:686
-msgid "Enable Fingerprint Login"
-msgstr "Cumasaigh Logáil Isteach Méarloirg"
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Ní bhainfidh sé seo an cuntas ón bhfreastalaí."
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "Corrmhéar _dheas"
+#~ msgid "No online accounts configured"
+#~ msgstr "Níl cuntas ar líne cumasaithe"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "Corrmhéar _chlé"
+#~ msgid "Remove Account"
+#~ msgstr "Bain Cuntas"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "Méar _eile:"
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Nuair a chuireann tú cuntas leis, is féidir le feidhmchláir é a rochtain "
+#~ "le haghaidh cáipéisí, poist, teagmhálacha, féilire, comhrá, agus ar uile."
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"D'éirigh le sábháil do mhéarloirg. Ba chóir duit bheith in ann logáil "
-"isteach le do bhraiteoir méarloirg."
+#~ msgid "Unknown time"
+#~ msgstr "Am anaithnid"
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "Úsáideoirí"
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s go dtí luchtaithe go hiomlán"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Rabhadh: %s fágtha"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s fágtha"
+
+#~ msgid "Fully charged"
+#~ msgstr "Luchtaithe go hiomlán"
+
+#~ msgid "Empty"
+#~ msgstr "Folamh"
+
+#~ msgid "Charging"
+#~ msgstr "Á luchtú"
+
+#~ msgid "Discharging"
+#~ msgstr "Á dhíluchtú"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Príomhchadhnra"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Breise"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Luch gan sreang"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Méarchlár gan sreang"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Soláthar dobhriste cumhachta"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Ríomhaire boise"
+
+#~ msgid "Cellphone"
+#~ msgstr "Fón póca"
+
+#~ msgid "Media player"
+#~ msgstr "Seinnteoir meán"
+
+#~ msgid "Computer"
+#~ msgstr "Ríomhaire"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Á luchtú"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Rabhadh"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Íseal"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Maith"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Luchtaithe go hiomlán"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Folamh"
+
+#~ msgid "Batteries"
+#~ msgstr "Cadhnraí"
+
+#~ msgid "When _idle"
+#~ msgstr "Nuair _díomhaoin"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "Gile an _scáileáin"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "Gile an _mhéarchláir"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "Maolaigh an scáileán agus _neamhghníomhach"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
 #, fuzzy
-msgid "Add or remove users and change your password"
-msgstr "Cuir leis nó bain úsáideoirí"
+#~ msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+#~ msgstr ""
+#~ "Múchann sé seo gléasanna leathanbhanda móibíligh (3G, 4G, WiMax, srl.)"
 
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr ""
-"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Logáil Isteach;Ainm;"
-"Méarlorg;Abhatár;Aghaidh;Focal Faire;"
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
 
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "Stair Logála Isteach"
+#~ msgid "When on battery power"
+#~ msgstr "Agus ar chumhacht chadhnra"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#~ msgid "When plugged in"
+#~ msgstr "Nuair atá ionsuite"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "Cur ar Fionraí & Múchadh"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Cur ar fionraí uathoibríoch"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Cur ar fionraí uathoibríoch"
+
+#~ msgid "1 minute"
+#~ msgstr "1 nóimeád"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 nóimeád"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 nóiméad"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 nóiméad"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 nóimeád"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 nóimeád"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Stadta"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Réidh"
+
 #, fuzzy
-msgid "Change Password"
-msgstr "Taispeáin Focal Faire"
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "_Gairm:"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "_Athraigh"
+#~ msgid "Toner Level"
+#~ msgstr "Leibhéal Tonóra"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "_Deimhnigh Focal Faire Nua"
+#~ msgid "Supply Level"
+#~ msgstr "Leibhéal Soláthair"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "Focal Faire _Nua"
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Á shuiteáil"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "_Focal Faire Reatha"
+#~ msgid "Failed to add new printer."
+#~ msgstr "Theip ar chur printéir nua leis."
 
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "Cuir Cuntas Úsáideora Leis"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "Bain Cuntas Úsáideora"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "Roghanna Logála Isteach"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "Logáil Isteach _Uathoibríoch"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "Logáil Isteach _Méarloirg"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "Deilbhín Úsáideora"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "_Teanga"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "Logáil Isteach Is Déanaí"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
-msgid "Manage user accounts"
-msgstr "Bainistigh cuntais úsáideora"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
-#, fuzzy
-msgid "Authentication is required to change user data"
-msgstr "Fíordheimhnithe!"
-
-#: ../panels/user-accounts/pw-utils.c:81
-#, fuzzy
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr ""
-"Ní mór carachtair uimhriúla nó speisialta a bheith san fhocal faire nua."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-#, fuzzy
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Focal faire á athrú do"
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "Neart: Lag"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "Neart: Íseal"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "Neart: Meánach"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "Neart: Maith"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "Neart: Ard"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "Theip ar fhíordheimniú"
-
-#: ../panels/user-accounts/run-passwd.c:502
 #, fuzzy, c-format
-msgid "The new password is too short"
-msgstr "Tá an focal faire ró-ghairid."
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Níorbh fhéidir an príomhchomhéadan a luchtú"
 
-#: ../panels/user-accounts/run-passwd.c:508
+#~ msgid "Add a New Printer"
+#~ msgstr "Cuir Printéir Nua Leis"
+
+#, fuzzy
+#~ msgid "JetDirect Printer"
+#~ msgstr "Bain Printéir"
+
+#, fuzzy
+#~ msgid "LPD Printer"
+#~ msgstr "Printéir %s"
+
+#, fuzzy
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "_Gairm:"
+
+#~ msgid "Job Title"
+#~ msgstr "Teideal Jab"
+
+#~ msgid "Job State"
+#~ msgstr "Staid Jab"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Suíomh: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Seoladh: %s"
+
+#, fuzzy
+#~ msgid "Output Tray"
+#~ msgstr "Aschur"
+
+#, fuzzy
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Ginearálta"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Socrú Leathanaigh"
+
+#, fuzzy
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Gníomh an Bharra Teidil"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Jab"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Cáilíocht Íomhá"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Dath"
+
+#~ msgid "Auto Select"
+#~ msgstr "Uathroghnaigh"
+
+#, fuzzy
+#~ msgid "No pre-filtering"
+#~ msgstr "Gan phróifíl"
+
+#~ msgid "Supply"
+#~ msgstr "Soláthar"
+
+#~ msgid "_Default printer"
+#~ msgstr "Printéir _réamhshocraithe"
+
+#~ msgid "Jobs"
+#~ msgstr "Jabanna"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Taispeáin _Jabanna"
+
+#~ msgid "label"
+#~ msgstr "lipéad"
+
+#~ msgid "page 3"
+#~ msgstr "leathanach 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Priontáil Leathanach _Tástála"
+
+#~ msgid "_Options"
+#~ msgstr "_Roghanna"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Cuir Printéir Nua Leis"
+
+#~ msgid "Usage & History"
+#~ msgstr "Úsáid & Stair"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Folmhaigh gach mír ón mBruscar?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Scriosfar gach mír sa Bhruscar go buan."
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Scrios gach comhad sealadach?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Scriosfar gach comhad sealadach go buan."
+
+#, fuzzy
+#~ msgid "Privacy Policy"
+#~ msgstr "Príobháid­eachas"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 soicind"
+
+#~ msgid "1 day"
+#~ msgstr "1 lá"
+
+#~ msgid "2 days"
+#~ msgstr "2 lá"
+
+#~ msgid "3 days"
+#~ msgstr "3 lá"
+
+#~ msgid "4 days"
+#~ msgstr "4 lá"
+
+#~ msgid "5 days"
+#~ msgstr "5 lá"
+
+#~ msgid "6 days"
+#~ msgstr "6 lá"
+
+#~ msgid "7 days"
+#~ msgstr "7 lá"
+
+#~ msgid "14 days"
+#~ msgstr "14 lá"
+
+#~ msgid "30 days"
+#~ msgstr "30 lá"
+
+#~ msgid "Forever"
+#~ msgstr "Go deo"
+
+#~ msgid "_Recently Used"
+#~ msgstr "Ú_sáidte le Déanaí"
+
+#~ msgid "Retain _History"
+#~ msgstr "Coinnigh _Stair"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Cosnaíonn Glas Scáileáin do phríobháideachas nuair atá tú amuigh."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Cuir scáileán faoi _ghlas tar éis"
+
+#~ msgid "Purge _After"
+#~ msgstr "Purgaigh i _nDiaidh"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Impiriúil"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Méadrach"
+
+#~ msgid "No input sources found"
+#~ msgstr "Foinse ionchuir gan aimsiú"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Eile"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Left+Right Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Béarla (An Ríocht Aontaithe)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "An Ríocht Aontaithe"
+
+#, fuzzy
+#~ msgid "Add input source"
+#~ msgstr "Cuir Foinse Ionchuir Leis"
+
+#, fuzzy
+#~ msgid "Remove input source"
+#~ msgstr "Foinse ionchuir gan aimsiú"
+
+#, fuzzy
+#~ msgid "Move input source up"
+#~ msgstr "Foinse ionchuir gan aimsiú"
+
+#, fuzzy
+#~ msgid "Move input source down"
+#~ msgstr "Foinse ionchuir gan aimsiú"
+
+#, fuzzy
+#~ msgid "Configure input source"
+#~ msgstr "Athraigh go dtí an chéad fhoinse ionchuir eile"
+
+#, fuzzy
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Níl aon fhoinse ionchuir roghnaithe"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Eile"
+
+#~ msgid "Select Location"
+#~ msgstr "Roghnaigh Suíomh"
+
+#~ msgid "_OK"
+#~ msgstr "Tá g_o Maith"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Cumasaithe"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Díchumasaithe"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Cumasaithe"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Roghnaigh Fillteán"
+
+#, fuzzy
+#~ msgid "Password:"
+#~ msgstr "Focal Faire"
+
+#~ msgid "Show Password"
+#~ msgstr "Taispeáin Focal Faire"
+
+#, fuzzy
+#~ msgid "Require a password"
+#~ msgstr "_Focal Faire:"
+
+#~ msgid "Bark"
+#~ msgstr "Sceamh"
+
+#~ msgid "Drip"
+#~ msgstr "Sileadh"
+
+#~ msgid "Glass"
+#~ msgstr "Gloine"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonóir"
+
+#, fuzzy
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Íoslaghdaigh"
+
+#, fuzzy
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Uasmhéadaigh"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "Fo-dhordaire"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Gan aimpliú"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Próifíl:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Tástáil Callairí"
+
+#~ msgid "Device"
+#~ msgstr "Gléas"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Roghnaigh gléas le haghaidh aschur fuaime:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Socruithe don ghléas roghnaithe:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Airde _ionchuir:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Roghnaigh gléas le haghaidh ionchur fuaime:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Maisíochtaí Fuaime"
+
+#~ msgid "Built-in"
+#~ msgstr "Ionsuite"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Sainroghanna Fuaime"
+
+#~ msgid "From theme"
+#~ msgstr "Ó théama"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Roghnaigh fuaim fholáirimh:"
+
+#~ msgid "Stop"
+#~ msgstr "Stad"
+
+#~ msgid "Custom"
+#~ msgstr "Saincheaptha"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Léitheoir Scáileáin"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Léitheoir _Scáileáin"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Eochracha Fuaime"
+
+#, fuzzy
+#~ msgid "Flash the _window title"
+#~ msgstr "Splanc barra teidil na _fuinneoige"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Gearr"
+
+#, fuzzy
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "Scáileán"
+
+#, fuzzy
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "Scáileán"
+
+#, fuzzy
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "Scáileán"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Fada"
+
+#~ msgid "Zoom"
+#~ msgstr "Súmáil"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Dath"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Gnáthchuntas"
+
+#~ msgid "Left thumb"
+#~ msgstr "Ordóg chlé"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Méar mheáin chlé"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Méar an fháinne chlé"
+
+#~ msgid "Left little finger"
+#~ msgstr "Lúidín clé"
+
+#~ msgid "Right thumb"
+#~ msgstr "Ordóg dheas"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Méar mheáin dheas"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Méar an fháinne dheas"
+
+#~ msgid "Right little finger"
+#~ msgstr "Lúidín deas"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Corrmhéar _dheas"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Corrmhéar _chlé"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "D'éirigh le sábháil do mhéarloirg. Ba chóir duit bheith in ann logáil "
+#~ "isteach le do bhraiteoir méarloirg."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Logáil Isteach;Ainm;"
+#~ "Méarlorg;Abhatár;Aghaidh;Focal Faire;"
+
+#~ msgid "Login History"
+#~ msgstr "Stair Logála Isteach"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Deimhnigh Focal Faire Nua"
+
+#~ msgid "Add User Account"
+#~ msgstr "Cuir Cuntas Úsáideora Leis"
+
+#~ msgid "User Icon"
+#~ msgstr "Deilbhín Úsáideora"
+
+#~ msgid "Last Login"
+#~ msgstr "Logáil Isteach Is Déanaí"
+
+#, fuzzy
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr ""
+#~ "Ní mór carachtair uimhriúla nó speisialta a bheith san fhocal faire nua."
+
+#, fuzzy
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Focal faire á athrú do"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Neart: Lag"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Neart: Íseal"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Neart: Meánach"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Neart: Maith"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Neart: Ard"
+
+#~ msgid "Authentication failed"
+#~ msgstr "Theip ar fhíordheimniú"
+
 #, fuzzy, c-format
-msgid "The new password is too simple"
-msgstr "Tá an focal faire ró-shimplí."
+#~ msgid "The new password is too short"
+#~ msgstr "Tá an focal faire ró-ghairid."
 
-#: ../panels/user-accounts/run-passwd.c:514
 #, fuzzy, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Tá an focal faire nua agus an seanfhocal faire ró-chósúil."
+#~ msgid "The new password is too simple"
+#~ msgstr "Tá an focal faire ró-shimplí."
 
-#: ../panels/user-accounts/run-passwd.c:517
 #, fuzzy, c-format
-msgid "The new password has already been used recently."
-msgstr "Níl an dá fhocal faire cothrom."
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Tá an focal faire nua agus an seanfhocal faire ró-chósúil."
 
-#: ../panels/user-accounts/run-passwd.c:520
 #, fuzzy, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-"Ní mór carachtair uimhriúla nó speisialta a bheith san fhocal faire nua."
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Níl an dá fhocal faire cothrom."
 
-#: ../panels/user-accounts/run-passwd.c:524
 #, fuzzy, c-format
-msgid "The old and new passwords are the same"
-msgstr "Is ionann an focal faire nua agus an seanfhocal faire."
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr ""
+#~ "Ní mór carachtair uimhriúla nó speisialta a bheith san fhocal faire nua."
 
-#: ../panels/user-accounts/run-passwd.c:528
 #, fuzzy, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-"Athraíodh d'fhocal faire ó d'fhíordheimhnigh tú ar dtús! Athfhíordheimhnigh, "
-"le do thoil."
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Is ionann an focal faire nua agus an seanfhocal faire."
 
-#: ../panels/user-accounts/run-passwd.c:532
 #, fuzzy, c-format
-msgid "The new password does not contain enough different characters"
-msgstr ""
-"Ní mór carachtair uimhriúla nó speisialta a bheith san fhocal faire nua."
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Athraíodh d'fhocal faire ó d'fhíordheimhnigh tú ar dtús! "
+#~ "Athfhíordheimhnigh, le do thoil."
 
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "Earráid anaithnid"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-#, fuzzy
-msgid "Failed to add account"
-msgstr "Roghnaigh cuntas"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-#, fuzzy
-msgid "Passwords do not match."
-msgstr "Tá an focal faire ró-ghairid."
-
-#: ../panels/user-accounts/um-account-dialog.c:733
-#: ../panels/user-accounts/um-account-dialog.c:779
-#: ../panels/user-accounts/um-account-dialog.c:800
-msgid "Failed to register account"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:923
-msgid "No supported way to authenticate with this domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:982
-msgid "Failed to join domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:1043
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:1058
-msgid "Failed to log into domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:1116
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:138
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:140
-msgid "The device is already in use."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-#, fuzzy
-msgid "An internal error occurred."
-msgstr "Tharla earráid chórais"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Enabled"
-msgstr "Cumasaithe"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:443
-msgid "Done!"
-msgstr "Críochnaithe!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:504
-#: ../panels/user-accounts/um-fingerprint-dialog.c:546
-#, c-format
-msgid "Could not access '%s' device"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:587
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:637
-msgid "Could not access any fingerprint readers"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:638
-msgid "Please contact your system administrator for help."
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:720
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:727
-msgid "Selecting finger"
-msgstr "Méar á roghnú"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:728
-msgid "Enrolling fingerprints"
-msgstr ""
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "An tSeachtain Seo"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "An tSeachtain Seo Caite"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:844
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:848
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr ""
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-#, fuzzy
-msgid "Please type your current password again."
-msgstr ""
-"Clóscriobh d'fhocal faire isteach sa réimse <b>Focal faire nua</b>, le do "
-"thoil."
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-#, fuzzy
-msgid "Password could not be changed"
-msgstr "Athraítear d'fhocal faire."
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-#, fuzzy
-msgid "The passwords do not match."
-msgstr "Tá an focal faire ró-ghairid."
-
-#: ../panels/user-accounts/um-photo-dialog.c:214
-msgid "Browse for more pictures"
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:448
-msgid "Disable image"
-msgstr "Díchumasaigh íomhá"
-
-#: ../panels/user-accounts/um-photo-dialog.c:466
-msgid "Take a photo…"
-msgstr "Tóg grianghraf…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:484
-msgid "Browse for more pictures…"
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:708
-#, c-format
-msgid "Used by %s"
-msgstr ""
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr ""
-
-#: ../panels/user-accounts/um-realm-manager.c:815
-#: ../panels/user-accounts/um-realm-manager.c:829
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-realm-manager.c:821
-msgid "Invalid password, please try again"
-msgstr ""
-
-#: ../panels/user-accounts/um-realm-manager.c:834
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:240
-msgid "Other Accounts"
-msgstr "Cuntais Eile"
-
-#: ../panels/user-accounts/um-user-panel.c:450
-msgid "Failed to delete user"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:510
-#: ../panels/user-accounts/um-user-panel.c:569
-#: ../panels/user-accounts/um-user-panel.c:621
-msgid "Failed to revoke remotely managed user"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:677
-msgid "You cannot delete your own account."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:686
-#, c-format
-msgid "%s is still logged in"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:690
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:699
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:703
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:706
-msgid "_Delete Files"
-msgstr "_Scrios Comhaid"
-
-#: ../panels/user-accounts/um-user-panel.c:707
-msgid "_Keep Files"
-msgstr "_Coinnigh Comhaid"
-
-#: ../panels/user-accounts/um-user-panel.c:721
 #, fuzzy, c-format
-msgid "Are you sure you want to revoke remotely managed %s's account?"
-msgstr "An bhfuil tú cinnte gur mhaith leat an cuntas a bhaint?"
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr ""
+#~ "Ní mór carachtair uimhriúla nó speisialta a bheith san fhocal faire nua."
 
-#: ../panels/user-accounts/um-user-panel.c:725
-msgid "_Delete"
-msgstr "_Scrios"
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Earráid anaithnid"
 
-#: ../panels/user-accounts/um-user-panel.c:777
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Cuntas díchumasaithe"
-
-#: ../panels/user-accounts/um-user-panel.c:785
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:788
-msgctxt "Password mode"
-msgid "None"
-msgstr "Neamhní"
-
-#: ../panels/user-accounts/um-user-panel.c:837
-msgid "Logged in"
-msgstr "Logáilte isteach"
-
-#: ../panels/user-accounts/um-user-panel.c:1275
-msgid "Failed to contact the accounts service"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1277
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1318
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Chun athruithe a dhéanamh,\n"
-"cliceáil an deilbhín * ar dtús"
-
-#: ../panels/user-accounts/um-user-panel.c:1356
-msgid "Create a user account"
-msgstr "Cruthaigh cuntas úsáideora"
-
-#: ../panels/user-accounts/um-user-panel.c:1367
-#: ../panels/user-accounts/um-user-panel.c:1679
 #, fuzzy
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Chun úsáideoir a chruthú,\n"
-"cliceáil an deilbhín * ar dtús"
+#~ msgid "Failed to add account"
+#~ msgstr "Roghnaigh cuntas"
 
-#: ../panels/user-accounts/um-user-panel.c:1377
 #, fuzzy
-msgid "Delete the selected user account"
-msgstr "Scrios an úsáideoir roghnaithe"
+#~ msgid "Passwords do not match."
+#~ msgstr "Tá an focal faire ró-ghairid."
 
-#: ../panels/user-accounts/um-user-panel.c:1389
-#: ../panels/user-accounts/um-user-panel.c:1684
 #, fuzzy
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Chun an úsáideoir roghnaithe a scriosadh,\n"
-"cliceáil an deilbhín * ar dtús"
+#~ msgid "An internal error occurred."
+#~ msgstr "Tharla earráid chórais"
 
-#: ../panels/user-accounts/um-user-panel.c:1593
-msgid "My Account"
-msgstr "Mo Chuntas"
+#~ msgid "Done!"
+#~ msgstr "Críochnaithe!"
 
-#: ../panels/user-accounts/um-utils.c:563
+#~ msgid "Selecting finger"
+#~ msgstr "Méar á roghnú"
+
+#~ msgid "This Week"
+#~ msgstr "An tSeachtain Seo"
+
+#~ msgid "Last Week"
+#~ msgstr "An tSeachtain Seo Caite"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, fuzzy
+#~ msgid "Please type your current password again."
+#~ msgstr ""
+#~ "Clóscriobh d'fhocal faire isteach sa réimse <b>Focal faire nua</b>, le do "
+#~ "thoil."
+
+#, fuzzy
+#~ msgid "Password could not be changed"
+#~ msgstr "Athraítear d'fhocal faire."
+
+#~ msgid "Take a photo…"
+#~ msgstr "Tóg grianghraf…"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Cuntais Eile"
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Scrios Comhaid"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Coinnigh Comhaid"
+
 #, fuzzy, c-format
-msgid "A user with the username '%s' already exists."
-msgstr "Tá comhad darb ainm \"%s\" ann cheana."
+#~ msgid "Are you sure you want to revoke remotely managed %s's account?"
+#~ msgstr "An bhfuil tú cinnte gur mhaith leat an cuntas a bhaint?"
 
-#: ../panels/user-accounts/um-utils.c:567
+#~ msgid "_Delete"
+#~ msgstr "_Scrios"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Cuntas díchumasaithe"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Neamhní"
+
+#~ msgid "Logged in"
+#~ msgstr "Logáilte isteach"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Chun athruithe a dhéanamh,\n"
+#~ "cliceáil an deilbhín * ar dtús"
+
+#, fuzzy
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Chun úsáideoir a chruthú,\n"
+#~ "cliceáil an deilbhín * ar dtús"
+
+#, fuzzy
+#~ msgid "Delete the selected user account"
+#~ msgstr "Scrios an úsáideoir roghnaithe"
+
+#, fuzzy
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Chun an úsáideoir roghnaithe a scriosadh,\n"
+#~ "cliceáil an deilbhín * ar dtús"
+
 #, fuzzy, c-format
-msgid "The username is too long."
-msgstr "Tá an t-ainm úsáideora ró-fhada"
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Tá comhad darb ainm \"%s\" ann cheana."
 
-#: ../panels/user-accounts/um-utils.c:570
-msgid "The username cannot start with a '-'."
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:573
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:577
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:823
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
-msgid "Map Buttons"
-msgstr ""
-
-#: ../panels/wacom/button-mapping.ui.h:3
-msgid "Map buttons to functions"
-msgstr ""
-
-#: ../panels/wacom/button-mapping.ui.h:4
-#, fuzzy
-msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
-"shortcut button and hold down the new keys or press Backspace to clear."
-msgstr ""
-"Chun eochair aicearra a chur in eagar, cliceáil ar an ró comhfhreagrach agus "
-"clóscríobh teaglaim eochracha nua, nó brúigh backspace chun glanta."
-
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
-msgid ""
-"Please tap the target markers as they appear on screen to calibrate the "
-"tablet."
-msgstr ""
-
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "Suas"
-
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "Síos"
-
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "Neamhní"
-
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-button-row.h:56
-#, fuzzy
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Monatóir"
-
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "Aschur:"
-
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr ""
-
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d as %d"
-
-#: ../panels/wacom/cc-wacom-page.c:522
-#, fuzzy
-msgid "Display Mapping"
-msgstr "Taispeáint"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:377
-msgid "Button"
-msgstr "Cnaipe"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Wacom Tablet"
-msgstr "Táibléad Wacom"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr ""
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "Táibléad;Wacom;Stíleas;Scriosán;Luch;"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "Sainroghanna Táibléid"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-#, fuzzy
-msgid "_Help"
-msgstr "Cabhair"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "No tablet detected"
-msgstr "Níor braitheadh aon táibléad"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Ionsuigh nó cuir do tháibléad Wacom ar siúl"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Bluetooth Settings"
-msgstr "Socruithe Bluetooth"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map to Monitor…"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-#, fuzzy
-msgid "Map Buttons…"
-msgstr "Roghanna..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust display resolution"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-#, fuzzy
-msgid "Adjust mouse settings"
-msgstr "Socruithe Luiche"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Tracking Mode"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:16
-msgid "Left-Handed Orientation"
-msgstr ""
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1028
-#, fuzzy
-msgid "Left Ring"
-msgstr "Méar an fháinne chlé"
-
-#: ../panels/wacom/gsd-wacom-device.c:1039
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr ""
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1059
-#, fuzzy
-msgid "Right Ring"
-msgstr "Méar an fháinne dheas"
-
-#: ../panels/wacom/gsd-wacom-device.c:1070
 #, fuzzy, c-format
-msgid "Right Ring Mode #%d"
-msgstr "Méar an fháinne dheas"
+#~ msgid "The username is too long."
+#~ msgstr "Tá an t-ainm úsáideora ró-fhada"
 
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1112
-msgid "Left Touchstrip"
-msgstr ""
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
 
-#: ../panels/wacom/gsd-wacom-device.c:1123
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr ""
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
 
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1143
-msgid "Right Touchstrip"
-msgstr ""
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Suas"
 
-#: ../panels/wacom/gsd-wacom-device.c:1154
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr ""
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Síos"
 
-#: ../panels/wacom/gsd-wacom-device.c:1180
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr ""
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Neamhní"
 
-#: ../panels/wacom/gsd-wacom-device.c:1182
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1185
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1187
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1192
-#, c-format
-msgid "Mode Switch #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1300
-#, c-format
-msgid "Left Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1303
-#, c-format
-msgid "Right Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1306
-#, c-format
-msgid "Top Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1309
-#, c-format
-msgid "Bottom Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
 #, fuzzy
-msgid "New shortcut…"
-msgstr "Aicearra nua..."
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Monatóir"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
+#~ msgid "Output:"
+#~ msgstr "Aschur:"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d as %d"
+
 #, fuzzy
-msgid "No Action"
-msgstr "Gníomh"
+#~ msgid "Display Mapping"
+#~ msgstr "Taispeáint"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr ""
+#~ msgid "Tablet Preferences"
+#~ msgstr "Sainroghanna Táibléid"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
 #, fuzzy
-msgid "Scroll Up"
-msgstr "Scrollú"
+#~ msgid "_Help"
+#~ msgstr "Cabhair"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Socruithe Bluetooth"
+
 #, fuzzy
-msgid "Scroll Down"
-msgstr "Scrollú"
+#~ msgid "Map Buttons…"
+#~ msgstr "Roghanna..."
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
 #, fuzzy
-msgid "Scroll Left"
-msgstr "Scrollú"
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Socruithe Luiche"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
 #, fuzzy
-msgid "Scroll Right"
-msgstr "Scrollú"
+#~ msgid "Left Ring"
+#~ msgstr "Méar an fháinne chlé"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr ""
+#, fuzzy, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Méar an fháinne dheas"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
-msgid "Tip Pressure Feel"
-msgstr ""
-
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
-msgid "GNOME Control Center"
-msgstr ""
-
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
-msgid "Utilities to configure the GNOME desktop"
-msgstr ""
-
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
-msgid ""
-"The control center is GNOME's main interface for configuration of various "
-"aspects of your desktop."
-msgstr ""
-
-#: ../shell/cc-application.c:45
 #, fuzzy
-msgid "Display version number"
-msgstr "Taispeáin Gile"
+#~ msgid "Scroll Up"
+#~ msgstr "Scrollú"
 
-#: ../shell/cc-application.c:46
-msgid "Enable verbose mode"
-msgstr "Cumasaigh mód foclach"
+#, fuzzy
+#~ msgid "Display version number"
+#~ msgstr "Taispeáin Gile"
 
-#: ../shell/cc-application.c:47
-msgid "Show the overview"
-msgstr "Taispeáin an foramharc"
+#~ msgid "Enable verbose mode"
+#~ msgstr "Cumasaigh mód foclach"
 
-#: ../shell/cc-application.c:48
-msgid "Search for the string"
-msgstr ""
+#~ msgid "Show the overview"
+#~ msgstr "Taispeáin an foramharc"
 
-#: ../shell/cc-application.c:49
-msgid "List possible panel names and exit"
-msgstr ""
+#~ msgid "Panel to display"
+#~ msgstr "Painéal le taispeáint"
 
-#: ../shell/cc-application.c:50
-msgid "Panel to display"
-msgstr "Painéal le taispeáint"
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PAINÉAL] [ARGÓINT…]"
 
-#: ../shell/cc-application.c:50
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PAINÉAL] [ARGÓINT…]"
+#~ msgid "Available panels:"
+#~ msgstr "Painéil atá ar fáil:"
 
-#: ../shell/cc-application.c:113
-msgid "Available panels:"
-msgstr "Painéil atá ar fáil:"
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Pearsanta"
 
-#: ../shell/cc-application.c:251
-msgid "Help"
-msgstr "Cabhair"
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Crua-Earraí"
 
-#: ../shell/cc-application.c:252
-msgid "Quit"
-msgstr "Scoir"
-
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1494
-msgid "All Settings"
-msgstr "Gach Socrú"
-
-#. Add categories
-#: ../shell/cc-window.c:880
-msgctxt "category"
-msgid "Personal"
-msgstr "Pearsanta"
-
-#: ../shell/cc-window.c:881
-msgctxt "category"
-msgid "Hardware"
-msgstr "Crua-Earraí"
-
-#: ../shell/cc-window.c:882
-msgctxt "category"
-msgid "System"
-msgstr "Córas"
-
-#: ../shell/gnome-control-center.desktop.in.in.h:2
-msgid "Preferences;Settings;"
-msgstr "Sainroghanna;Socruithe;"
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Córas"

--- a/po/ga.po~
+++ b/po/ga.po~
@@ -1,0 +1,7217 @@
+# Irish translations for gnome-control-center package.
+# Copyright (C) 2002-2013 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+# Alastair McKinstry <mckinstry@debian.org>, 2003.
+# Seán de Búrca <leftmostcat@gmail.com>, 2007-2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.master\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-09-23 15:26-0600\n"
+"PO-Revision-Date: 2015-09-23 15:39-0600\n"
+"Last-Translator: Seán de Búrca <leftmostcat@gmail.com>\n"
+"Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
+"Language: ga\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : "
+"4;\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "Cúlra"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "Ag athrú le linn an lae"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "Lock Screen"
+msgstr "Scáileán Glasála"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Tíligh"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Súmáil"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "Láraigh"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Scálaigh"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Líon"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "Réisigh"
+
+#: ../panels/background/cc-background-chooser-dialog.c:437
+msgid "Wallpapers"
+msgstr "Cúlbhrait"
+
+#: ../panels/background/cc-background-chooser-dialog.c:446
+msgid "Colors"
+msgstr "Dathanna"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:483
+msgid "Select Background"
+msgstr "Roghnaigh Cúlra"
+
+#: ../panels/background/cc-background-chooser-dialog.c:511
+msgid "Pictures"
+msgstr "Pictiúir"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:543
+msgid "No Pictures Found"
+msgstr "Níor Aimsíodh Aon Phictiúr"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:561
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "Baile"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:573
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr ""
+"Is féidir leat íomhánna a chur le d'fhillteán “%s” agus taispeánfar iad anseo"
+
+#: ../panels/background/cc-background-chooser-dialog.c:580
+#: ../panels/color/cc-color-panel.c:225 ../panels/color/cc-color-panel.c:963
+#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1561
+#: ../panels/display/cc-display-panel.c:2023
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1269
+#: ../panels/network/net-device-wifi.c:1462
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/cc-printers-panel.c:1940
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:568
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:374
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+#: ../panels/user-accounts/um-photo-dialog.c:94
+#: ../panels/user-accounts/um-photo-dialog.c:217
+#: ../panels/user-accounts/um-user-panel.c:708
+#: ../panels/user-accounts/um-user-panel.c:726
+msgid "_Cancel"
+msgstr "_Cealaigh"
+
+#: ../panels/background/cc-background-chooser-dialog.c:581
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:96
+msgid "Select"
+msgstr "Roghnaigh"
+
+#: ../panels/background/cc-background-item.c:203
+msgid "multiple sizes"
+msgstr ""
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:207
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:333
+msgid "No Desktop Background"
+msgstr "Gan Cúlra na Deisce"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "Cúlra reatha"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr ""
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Cúlbhrat;Scáileán;Deasc;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:259
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "Múchann sé seo gléasanna gan sreang"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:325
+#, fuzzy
+msgid "No Bluetooth Found"
+msgstr "Níor aimsíodh aon chuibheoir Bluetooth"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:325
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:326
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Comhroinnt Bluetooth"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:326
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:327
+msgid "Airplane Mode is on"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:327
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Díchumasaíodh Bluetooth ag lasc chrua-earraí"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:328
+msgid "Hardware Airplane Mode is on"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:328
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+"Cumasaigh agus díchumasaigh Bluetooth agus ceangail do chuid ghléasanna"
+
+#. Translators: those are keywords for the bluetooth control-center panel
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:4
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "Socraigh do ghléas calabraithe thar an gcearnóg agus brúigh 'Tosaigh'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+"Bog do ghléas calabraithe go dtí an t-ionad calabraithe agus brúigh 'Ar "
+"Aghaidh'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr ""
+"Bog do ghléas calabraithe go dtí an t-ionad dromchla agus brúigh 'Ar Aghaidh'"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "Dún an clúdach"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr ""
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "Tá uirlisí de dhíth le haghaidh calabraithe nach bhfuil suiteáilte."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "Níorbh fhéidir an phróifíl a ghiniúint."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr ""
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "Críochnaithe!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "Theip ar chalabrú!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "Is féidir leat an gléas calabraithe a bhaint."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ná cuir isteach ar an ngléas calabraithe nuair atá sé ar siúl"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Scáileán Ríomhaire Glúine"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Ceamara Gréasáin Ionsuite"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monatóir %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Scanóir %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Ceamara %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Printéir %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Ceamara Gréasáin %s"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Cumasaigh bainisteoireacht dathanna do %s"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Taispeáin próifílí datha do %s"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:323
+msgid "Not calibrated"
+msgstr "Gan chalabrú"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:141
+msgid "Default: "
+msgstr "Réamhshocrú: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:149
+msgid "Colorspace: "
+msgstr "Dathspás:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:156
+msgid "Test profile: "
+msgstr "Próifíl tástála:"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:223
+msgid "Select ICC Profile File"
+msgstr "Roghnaigh Comhad Próifíle ICC"
+
+#: ../panels/color/cc-color-panel.c:226
+msgid "_Import"
+msgstr "_Iompórtáil"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:237
+msgid "Supported ICC profiles"
+msgstr "Próifílí ICC le tacaíocht"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:244
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "Gach comhad"
+
+#: ../panels/color/cc-color-panel.c:583
+msgid "Screen"
+msgstr "Scáileán"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:908
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Theip ar uasluchtú comhaid: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:922
+msgid "The profile has been uploaded to:"
+msgstr "Uasluchtaíodh an phróifíl go:"
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Write down this URL."
+msgstr "Breac síos an URL seo."
+
+#: ../panels/color/cc-color-panel.c:925
+msgid "Restart this computer and boot your normal operating system."
+msgstr "Atosaigh an ríomhaire seo agus bútáil do ghnáthchóras oibriúcháin."
+
+#: ../panels/color/cc-color-panel.c:926
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+"Clóscríobh an URL isteach i do bhrabhsálaí chun an phróifíl a íosluchtú agus "
+"a shuiteáil."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:960
+msgid "Save Profile"
+msgstr "Sábháil Próifíl"
+
+#: ../panels/color/cc-color-panel.c:964
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "_Sábháil"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1324
+msgid "Create a color profile for the selected device"
+msgstr "Cruthaigh próifíl dathanna don ghléas roghnaithe"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1373
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1384
+msgid "The device type is not currently supported."
+msgstr ""
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "Spás Caighdeánach"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "Próifíl Tástála"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Uathoibríoch"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Cáilíocht Íseal"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Cáilíocht Mheánach"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Ardcháilíocht"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB Réamhshocraithe"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK Réamhshocraithe"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Liath Réamhshocraithe"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr ""
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "Is féidir nach bhfuil an phróifíl seo cruinn a thuilleadh"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "Calabrú Taispeána"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1476
+msgid "Cancel"
+msgstr "Cealaigh"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "Tosaigh"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "Lean"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "Críochnaithe"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "Calabrú Scáileáin"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Ní féidir leat do ríomhaire a úsáid agus an calabrú á dhéanamh."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "Cáilíocht"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "Neas-am"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "Cáilíocht Chalabraithe"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "Gléas Calabraithe"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "Cineál Taispeána"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "Taispeáin Gile"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "Ainm Próifíle:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "Ainm Próifíle"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr ""
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "Cóipeáil próifíl"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr ""
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "Uasluchtaigh próifíl"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr ""
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:729
+msgid "Summary"
+msgstr ""
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "Iompórtáil Comhad…"
+
+#: ../panels/color/color.ui.h:30
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1477
+msgid "_Add"
+msgstr "Cuir _Leis"
+
+#: ../panels/color/color.ui.h:31
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: ../panels/color/color.ui.h:32
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Teastaíonn próifíl datha atá cothrom le dáta chun a chuid dathanna a "
+"bhainistiú."
+
+#: ../panels/color/color.ui.h:33
+msgid "Learn more"
+msgstr "Faigh tuilleadh eolais"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more about color management"
+msgstr ""
+
+#: ../panels/color/color.ui.h:35
+msgid "Set for all users"
+msgstr "Socraigh do gach úsáideoir"
+
+#: ../panels/color/color.ui.h:36
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: ../panels/color/color.ui.h:37
+msgid "Enable"
+msgstr "Cumasaigh"
+
+#: ../panels/color/color.ui.h:38
+msgid "Add profile"
+msgstr "Cuir próifíl leis"
+
+#: ../panels/color/color.ui.h:39
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Calibrate…"
+msgstr "Calabraigh…"
+
+#: ../panels/color/color.ui.h:40
+msgid "Calibrate the device"
+msgstr "Calabraigh an gléas"
+
+#: ../panels/color/color.ui.h:41
+msgid "Remove profile"
+msgstr "Bain próifíl"
+
+#: ../panels/color/color.ui.h:42
+msgid "View details"
+msgstr "Amharc ar mhionsonraí"
+
+#: ../panels/color/color.ui.h:43
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: ../panels/color/color.ui.h:44
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:45
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:46
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:47
+msgid "Projector"
+msgstr "Teilgeoir"
+
+#: ../panels/color/color.ui.h:48
+msgid "Plasma"
+msgstr "Plasma"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (cúlsolas CCFL)"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (cúlsolas LED RGB)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (white LED backlight)"
+msgstr "LCD (cúlsolas LED bán)"
+
+#: ../panels/color/color.ui.h:52
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD raoin leathain (cúlsolas CCFL)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD raoin leathain (cúlsolas LED RGB)"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Ard"
+
+#: ../panels/color/color.ui.h:55
+msgid "40 minutes"
+msgstr "40 nóimeád"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Meánach"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:2
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 nóimeád"
+
+#: ../panels/color/color.ui.h:58
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Íseal"
+
+#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:1
+msgid "15 minutes"
+msgstr "15 nóimeád"
+
+#: ../panels/color/color.ui.h:60
+#, fuzzy
+msgid "Native to display"
+msgstr "Painéal le taispeáint"
+
+#: ../panels/color/color.ui.h:61
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Priontáil agus foilsiú)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:63
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Grianghrafadóireacht agus grafaic)"
+
+#: ../panels/color/color.ui.h:64
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "Dath"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calabraigh dath do ghléasanna, mar shampla taispeáintí, ceamaraí nó printéirí"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Dath;ICC;Próifíl;Calabraigh;Printéir;Taispeáint;"
+
+#: ../panels/common/cc-common-language.c:323
+msgid "Other…"
+msgstr "Eile…"
+
+#: ../panels/common/cc-language-chooser.c:124
+#: ../panels/region/cc-format-chooser.c:271
+#: ../panels/region/cc-input-chooser.c:168
+msgid "More…"
+msgstr "Tuilleadh…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "Teanga gan aimsiú"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "Teanga"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "_Críochnaithe"
+
+#: ../panels/datetime/big.ui.h:1 ../panels/datetime/little.ui.h:1
+#: ../panels/datetime/middle.ui.h:1 ../panels/datetime/ydm.ui.h:1
+msgid "Day"
+msgstr "Lá"
+
+#: ../panels/datetime/big.ui.h:2 ../panels/datetime/little.ui.h:2
+#: ../panels/datetime/middle.ui.h:2 ../panels/datetime/ydm.ui.h:2
+msgid "Month"
+msgstr "Mí"
+
+#: ../panels/datetime/big.ui.h:3 ../panels/datetime/little.ui.h:3
+#: ../panels/datetime/middle.ui.h:3 ../panels/datetime/ydm.ui.h:3
+msgid "Year"
+msgstr "Bliain"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%B %e %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%B %e %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "AUL%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "Eanáir"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "Feabhra"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "Márta"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "Aibreán"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "Bealtaine"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "Meitheamh"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "Iúil"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "Lúnasa"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "Meán Fómhair"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "Deireadh Fómhair"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "Samhain"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "Nollaig"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "Dáta & Am"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "Uair"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "Nóimeád"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Time Zone"
+msgstr "Crios Ama"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Search for a city"
+msgstr "Cuardaigh cathair"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Automatic _Date & Time"
+msgstr "_Dáta & Am Uathoibríoch"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Requires internet access"
+msgstr "Rochtain idirlín de dhíth"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Automatic Time _Zone"
+msgstr "C_rios Ama Uathoibríoch"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Date & _Time"
+msgstr "Dáta & _Am"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Time _Zone"
+msgstr "Crios A_ma"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Time _Format"
+msgstr "_Formáid Ama"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "24-hour"
+msgstr "24 uair"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "Athraigh an dáta agus an t-am, crios ama ina measc"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "Clog;Crios Ama;Suíomh;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "Athraigh socruithe ama agus dáta an chórais"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Is gá fíordeimhniú chun socruithe ama nó dáta a athrú."
+
+#: ../panels/display/cc-display-panel.c:573
+msgid "Lid Closed"
+msgstr "Clúdach Dúnta"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:576
+msgid "Mirrored"
+msgstr "Scáthánaithe"
+
+#: ../panels/display/cc-display-panel.c:578
+#: ../panels/display/cc-display-panel.c:2195
+msgid "Primary"
+msgstr "Príomhúil"
+
+#: ../panels/display/cc-display-panel.c:580
+#: ../panels/notifications/cc-notifications-panel.c:257
+#: ../panels/power/cc-power-panel.c:1847 ../panels/power/cc-power-panel.c:1858
+#: ../panels/privacy/cc-privacy-panel.c:155
+#: ../panels/privacy/cc-privacy-panel.c:222
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "Díchumasaithe"
+
+#: ../panels/display/cc-display-panel.c:583
+msgid "Secondary"
+msgstr "Tánaisteach"
+
+#. Title of displays dialog when multiple monitors are present.
+#: ../panels/display/cc-display-panel.c:1558
+msgid "Arrange Combined Displays"
+msgstr "Leag Amach Taispeáintí Comhcheangailte"
+
+#: ../panels/display/cc-display-panel.c:1562
+#: ../panels/display/cc-display-panel.c:2024
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "Cuir i bh_Feidhm"
+
+#: ../panels/display/cc-display-panel.c:1586
+msgid "Drag displays to rearrange them"
+msgstr "Tarraing taispeáintí chun iad a leagan amach"
+
+#: ../panels/display/cc-display-panel.c:2073
+msgid "Rotate counterclockwise by 90°"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2091
+msgid "Rotate by 180°"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2109
+msgid "Rotate clockwise by 90°"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2130
+msgid "Size"
+msgstr "Méid"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2143
+msgid "Aspect Ratio"
+msgstr "Cóimheas Treoíochta"
+
+#: ../panels/display/cc-display-panel.c:2165
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "Taifeach"
+
+#: ../panels/display/cc-display-panel.c:2196
+msgid "Show the top bar and Activities Overview on this display"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2202
+msgid "Secondary Display"
+msgstr "Taispeáint Tánaisteach"
+
+#: ../panels/display/cc-display-panel.c:2203
+msgid "Join this display with another to create an extra workspace"
+msgstr ""
+"Comhcheangail an taispeáint seo le ceann eile chun spás breise oibre a "
+"chruthú"
+
+#: ../panels/display/cc-display-panel.c:2210
+msgid "Presentation"
+msgstr "Láithreoireacht"
+
+#: ../panels/display/cc-display-panel.c:2211
+msgid "Show slideshows and media only"
+msgstr "Taispeáin teaspántais sleamhnán agus meáin amháin"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2216
+msgid "Mirror"
+msgstr "Scáthánaigh"
+
+#: ../panels/display/cc-display-panel.c:2217
+msgid "Show your existing view on both displays"
+msgstr "Taispeáin d'amharc atá ann ar an dá taispeáint"
+
+#: ../panels/display/cc-display-panel.c:2223
+msgid "Turn Off"
+msgstr "Múch"
+
+#: ../panels/display/cc-display-panel.c:2224
+#, fuzzy
+msgid "Don't use this display"
+msgstr "Ná bain úsáid as an taispeáint"
+
+#: ../panels/display/cc-display-panel.c:2525
+msgid "Could not get screen information"
+msgstr "Níorbh fhéidir eolas scáileáin a fháil"
+
+#: ../panels/display/cc-display-panel.c:2556
+msgid "_Arrange Combined Displays"
+msgstr "_Leag Amach Taispeáintí Comhcheangailte"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "Taispeáintí"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+#, fuzzy
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "Painéal;Teilgeoir;xrandr;Scáileán;Taifeach;Athnuaigh;"
+
+#: ../panels/info/cc-info-panel.c:385
+msgid "Wayland"
+msgstr "Wayland"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:388 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "Anaithnid"
+
+#: ../panels/info/cc-info-panel.c:473
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-giotán"
+
+#: ../panels/info/cc-info-panel.c:475
+#, c-format
+msgid "%d-bit"
+msgstr "%d-giotán"
+
+#: ../panels/info/cc-info-panel.c:1155
+msgid "Ask what to do"
+msgstr "Fiafraigh díom"
+
+#: ../panels/info/cc-info-panel.c:1159
+msgid "Do nothing"
+msgstr "Ná déan faic"
+
+#: ../panels/info/cc-info-panel.c:1163
+msgid "Open folder"
+msgstr "Oscail fillteán"
+
+#: ../panels/info/cc-info-panel.c:1254
+msgid "Other Media"
+msgstr "Meáin Eile"
+
+#: ../panels/info/cc-info-panel.c:1285
+#, fuzzy
+msgid "Select an application for audio CDs"
+msgstr "Roghnaigh d'fheidhmchláir réamhshocraithe"
+
+#: ../panels/info/cc-info-panel.c:1286
+#, fuzzy
+msgid "Select an application for video DVDs"
+msgstr "Roghnaigh d'fheidhmchláir réamhshocraithe"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1289
+#, fuzzy
+msgid "Select an application for software CDs"
+msgstr "Roghnaigh d'fheidhmchláir réamhshocraithe"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1301
+msgid "audio DVD"
+msgstr "DVD fuaime"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank Blu-ray disc"
+msgstr "diosca Blu-ray bán"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank CD disc"
+msgstr "diosca CD bán"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank DVD disc"
+msgstr "diosca DVD bán"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "blank HD DVD disc"
+msgstr "diosca HD DVD bán"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "Blu-ray video disc"
+msgstr "diosca físe Blu-ray"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "e-book reader"
+msgstr "léitheoir r-leabhair"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "HD DVD video disc"
+msgstr "diosca físe HD DVD"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Video CD"
+msgstr "Video CD"
+
+#: ../panels/info/cc-info-panel.c:1312
+msgid "Windows software"
+msgstr "Bogearraí Windows"
+
+#: ../panels/info/cc-info-panel.c:1435
+#: ../panels/keyboard/keyboard-shortcuts.c:1947
+msgid "Section"
+msgstr "Rannán"
+
+#: ../panels/info/cc-info-panel.c:1444 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "Foramharc"
+
+#: ../panels/info/cc-info-panel.c:1450 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "Feidhmchláir Réamhshocraithe"
+
+#: ../panels/info/cc-info-panel.c:1455 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "Meáin Inbhainte"
+
+#: ../panels/info/cc-info-panel.c:1480
+#, c-format
+msgid "Version %s"
+msgstr "Leagan %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:46
+msgid "Details"
+msgstr "Sonraí"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "Amharc ar eolas faoi do chóras"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"gléas;córas;faisnéis;cuimhne;próiseálaí;leagan;réamhshocrú;feidhmchlár;rogha;"
+"cd;dvd;usb;fuaim;fís;diosca;inbhainte;meáin;uathrith;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "_Gníomh:"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "C_ineál:"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "Ainm gléis"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "Cuimhne"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "Próiseálaí"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "Bunchóras"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "Diosca"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "Á áireamh…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "Grafaic"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "Fíorúlú"
+
+#: ../panels/info/info.ui.h:13
+#, fuzzy
+msgid "Check for updates"
+msgstr "Nuashonruithe á Seiceáil"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "_Gréasán"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "_Post"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "Féi_lire"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "_Ceol"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "_Fís"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "G_rianghraif"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr ""
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "fu_aim CD"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "fís _DVD"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "Seinnteoir _ceoil"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "_Bogearraí"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "Meáin _Eile…"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "Fuaim agus Meáin"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "Airde gan fuaim"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "Airde síos"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "Airde suas"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "Luchtaigh seinnteoir meán"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "Seinn (nó seinn/sos)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "Cuir athsheinm ar shos"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "Stad athsheinm"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "An t-amhrán roimhe seo"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "An chéad t-amhrán eile"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "Díchuir"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "Clóscríobh"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "Athraigh go dtí an chéad fhoinse ionchuir eile"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "Athraigh go dtí an fhoinse ionchuir roimhe seo"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "Tosaitheoirí"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "Luchtaigh brabhsálaí cabhrach"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1605
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "Socruithe"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "Luchtaigh áireamhán"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "Luchtaigh cliant ríomhphoist"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "Luchtaigh brabhsálaí gréasáin"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "Fillteán baile"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Cuardaigh"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "Gabhálacha Scáileáin"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "Sábháil gabháil scáileáin i $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Sábháil gabháil scáileán fuinneoige i $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Sábháil gabháil scáileán limistéir i $PICTURES"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "Cóipeáil gabháil scáileáin go dtí an ghearrthaisce"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Cóipeáil gabháil scáileán fuinneoige go dtí an ghearrthaisce"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Cóipeáil gabháil scáileán limistéir go dtí an ghearrthaisce"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "Taifead físghabháil ghearr scáileáin"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "Córas"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Logáil amach"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "Cuir an scáileán faoi ghlas"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "Rochtain Uilíoch"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "Cumasaigh nó díchumasaigh súmáil"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "Súmáil isteach"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "Súmáil amach"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "Cumasaigh nó díchumasaigh léitheoir scáileáin"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "Cumasaigh nó díchumasaigh méarchlár scáileáin"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "Méadaigh clómhéid"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "Laghaidh clómhéid"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "Cumasaigh nó díchumasaigh ardchodarsnacht"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1219
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+msgid "Disabled"
+msgstr "Díchumasaithe"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr ""
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+#, fuzzy
+msgid "Compose Key"
+msgstr "Cnaipe na Luiche"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Méarchlár"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Aicearra;Athbhrú;Caoch;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "Aicearra Saincheaptha"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "_Ainm:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "_Ordú:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "Athbhrú Eochracha"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "Déantar brú eochracha _arís nuair a choinníonn an eochair síos"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "_Moill:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "_Luas:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "Gearr"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "Mall"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "Luas athbhrú eochracha"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "Fada"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "Tapa"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "Caochadh an Chúrsóra"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "_Caochann an cúrsóir i réimsí téacs"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "L_uas:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "Luas caochadh an chúrsóra"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "Foinsí Ionchuir"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "Cuir Aicearra Leis"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "Bain Aicearra"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"Chun aicearra a chur in eagar, cliceáil ar an ró agus coinnigh síos na "
+"heochracha nua, nó brúigh Backspace chun glanta."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "Aicearraí"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:632
+#: ../panels/keyboard/keyboard-shortcuts.c:640
+msgid "Custom Shortcuts"
+msgstr "Aicearraí Saincheaptha"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:857
+msgid "<Unknown Action>"
+msgstr "<Gníomh Anaithnid>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1358
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1388
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1393
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1399
+msgid "_Reassign"
+msgstr "_Athshann"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1440
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1450
+#, c-format
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1457
+#, fuzzy
+msgid "_Assign"
+msgstr "_Athshann"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "Tástáil Do _Shocruithe"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+msgid "Test Your Settings"
+msgstr "Tástáil Do Shocruithe"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "Luch & Ceap Tadhaill"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Ceap Rianaithe;Pointeoir;Cliceáil;Cnag;Déchliceáil;Cnaipe;Rianliathróid;"
+"Scrollaigh;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "Ginearálta"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "Mall"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "Teorainn am déchliceála"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "Tapa"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "_Déchliceáil"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "_Príomhchnaipe"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "_Clé"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "_Deas"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "Luch"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "_Luas an phointeora"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "Mall"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "Tapa"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "Ceap Tadhaill"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "Mall"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "Tapa"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Tap to _click"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+#, fuzzy
+msgid "Two _finger scroll"
+msgstr "Scrollú dhá-_mhéar"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+msgid "_Natural scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+#, fuzzy
+msgid "Double click, primary button"
+msgstr "Teorainn Am Déchliceála"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+#, fuzzy
+msgid "Double click, middle button"
+msgstr "Teorainn Am Déchliceála"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+#, fuzzy
+msgid "Double click, secondary button"
+msgstr "Teorainn Am Déchliceála"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr ""
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:358
+msgid "Air_plane Mode"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:967
+msgid "Network proxy"
+msgstr "Seachfhreastalaí líonra"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "VPN %s"
+
+#: ../panels/network/cc-network-panel.c:1300
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:1306
+msgid "NetworkManager needs to be running."
+msgstr ""
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "_Slándáil 802.1x"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "leathanach 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr ""
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#, fuzzy
+msgid "Inner _authentication"
+msgstr "Fíordheimhnithe!"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:6
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "leathanach 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:469
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "Slándáil"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "uathoibríoch"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:219
+#: ../panels/network/net-device-wifi.c:383
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:223
+#: ../panels/network/net-device-wifi.c:388
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:227
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:232
+msgid "Enterprise"
+msgstr "Fiontar"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:237
+#: ../panels/network/net-device-wifi.c:373
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Neamhní"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:17
+msgid "Never"
+msgstr "Riamh"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:815
+msgid "Today"
+msgstr "Inniu"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:818
+msgid "Yesterday"
+msgstr "Inné"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:477
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i lá ó shin"
+msgstr[1] "%i lá ó shin"
+msgstr[2] "%i lá ó shin"
+msgstr[3] "%i lá ó shin"
+msgstr[4] "%i lá ó shin"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:534
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:563
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Neamhní"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:565
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Lag"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:567
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Cuíosach"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:569
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Maith"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:571
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Ar fheabhas"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:262
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "Aitheantas"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "Seoladh"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "Masc Líonra"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:2
+msgid "Gateway"
+msgstr "Geata"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "Scrios Seoladh"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "Cuir Leis"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "Freastalaí"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "Scrios Freastalaí DNS"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "Méadrach"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "Scrios Ród"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "Uathoibríoch (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:26
+#: ../panels/privacy/cc-privacy-panel.c:182
+msgid "Manual"
+msgstr "De láimh"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:967
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:182
+msgid "Automatic"
+msgstr "Uathoibríoch"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "Uathoibríoch, DHCP amháin"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:937
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:51
+msgid "Reset"
+msgstr "Athshocraigh"
+
+#: ../panels/network/connection-editor/ce-page-security.c:253
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Neamhní"
+
+#: ../panels/network/connection-editor/ce-page-security.c:276
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:286
+msgid "WEP 128-bit Passphrase"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:299
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:312
+msgid "Dynamic WEP (802.1x)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:326
+msgid "WPA & WPA2 Personal"
+msgstr ""
+
+#: ../panels/network/connection-editor/ce-page-security.c:340
+#, fuzzy
+msgid "WPA & WPA2 Enterprise"
+msgstr "Fiontar"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr ""
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "Luas an cheangail"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:157
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "Seoladh IPv4"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:158
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "Seoladh IPv6"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:165
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "Seoladh Crua-Earraí"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:169
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "Ród Réamhshocraithe"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "Casphéire (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Comhéadan Aonad Ceangail (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "_Ainm"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "Seoladh _MAC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "Seoladh"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "beart"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr ""
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+msgid "Firewall _Zone"
+msgstr ""
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:113
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "Réamhshocrú"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "_Seoltaí"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "DNS Uathoibríoch"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "Róid"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "Róid Uathoibríocha"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+#, fuzzy
+msgid "Unable to open connection editor"
+msgstr "Fíordheimhnithe!"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "Próifíl Nua"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "Nasc"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "Droichead"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+#, fuzzy
+msgid "Could not load VPN plugins"
+msgstr "Níorbh fhéidir an príomhchomhéadan a luchtú"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "Iompórtáil ó chomhad…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "Cuir Ceangal Líonra Leis"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "_Athshocraigh"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1463
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "_Déan Dearmad"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "S_lándáil"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1941
+#: ../panels/sharing/cc-sharing-panel.c:375
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "_Open"
+msgstr "_Oscail"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "Tá comhad darb ainm \"%s\" ann cheana."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "_Ionadaigh"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+#, fuzzy
+msgid "Export VPN connection"
+msgstr "Easpórtáil ceangal VPN..."
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "Mo Líonra Baile"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "Líonra"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#, fuzzy
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"Líonra;Gan Sreang;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Leathanbhanda;Móideim;"
+"Bluetooth;vpn;vlan;droichead;nasc;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr ""
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr ""
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr ""
+
+#: ../panels/network/net-device-ethernet.c:110
+#: ../panels/network/net-device-wifi.c:463
+msgid "never"
+msgstr "riamh"
+
+#: ../panels/network/net-device-ethernet.c:120
+#: ../panels/network/net-device-wifi.c:473
+msgid "today"
+msgstr "inniu"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:475
+msgid "yesterday"
+msgstr "inné"
+
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "Seoladh IP"
+
+#: ../panels/network/net-device-ethernet.c:176
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "Úsáid is déanaí"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:286
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "Sreangaithe"
+
+#: ../panels/network/net-device-ethernet.c:354
+#: ../panels/network/net-device-wifi.c:1621
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Options…"
+msgstr "Roghanna…"
+
+#: ../panels/network/net-device-ethernet.c:473
+#, c-format
+msgid "Profile %d"
+msgstr "Próifíl %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "Cuir ceangal nua leis"
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1176
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1180
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1184
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1267
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1270
+msgid "_Stop Hotspot"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1327
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1330
+msgid "Wireless device does not support Hotspot mode"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1459
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1774
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "Stair"
+
+#: ../panels/network/net-device-wifi.c:1778
+#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
+#: ../panels/wacom/cc-wacom-page.c:525
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "_Close"
+msgstr "_Dún"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1786
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Déan Dearmad"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "Seachfhreastalaí"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "Cuir _Próifíl Leis…"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "Soláthraí"
+
+#: ../panels/network/network-proxy.ui.h:1
+msgctxt "proxy method"
+msgid "None"
+msgstr "Neamhní"
+
+#: ../panels/network/network-proxy.ui.h:2
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "De láimh"
+
+#: ../panels/network/network-proxy.ui.h:3
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "Uathoibríoch"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "_Modh"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "U_RL Cumraíochta:"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "Seachfhreastalaí _HTTP"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "Seachfhreastalaí H_TTPS"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "Seachfhreastalaí _FTP"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "Óstach _Socks"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: ../panels/network/network-proxy.ui.h:11
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "Seachfhreastalaí _HTTP"
+
+#: ../panels/network/network-proxy.ui.h:12
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "Seachfhreastalaí _HTTP"
+
+#: ../panels/network/network-proxy.ui.h:13
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "Seachfhreastalaí _FTP:"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr ""
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "Múch gléas"
+
+#: ../panels/network/network.ui.h:1
+msgid "Add Device"
+msgstr "Cuir Gléas Leis"
+
+#: ../panels/network/network.ui.h:2
+msgid "Remove Device"
+msgstr "Bain Gléas"
+
+#: ../panels/network/network-vpn.ui.h:1
+msgid "VPN Type"
+msgstr "Cineál VPN"
+
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Group Name"
+msgstr "Ainm Grúpa"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Password"
+msgstr "Focal Faire an Ghrúpa"
+
+#: ../panels/network/network-vpn.ui.h:5
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "Ainm Úsáideora"
+
+#: ../panels/network/network-vpn.ui.h:6
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "_Ceangal Uathoibríoch"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "sonraí"
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "_Focal Faire"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "Neamhní"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "_Taispeáin Focal Faire"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "aitheantas"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "athshocraigh"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "Crua-Earraí"
+
+#: ../panels/network/network-wifi.ui.h:52
+#, fuzzy
+msgid "Wi-Fi Hotspot"
+msgstr "Méarchlár Scáileáin GNOME"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Turn On"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_Use as Hotspot…"
+msgstr "Úsáid Mar _Bhall Te…"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "_Connect to Hidden Network…"
+msgstr "_Nasc le Líonra Folaithe…"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "_History"
+msgstr "_Stair"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Network Name"
+msgstr "Ainm Líonra"
+
+#: ../panels/network/network-wifi.ui.h:61
+#, fuzzy
+msgid "Connected Devices"
+msgstr "Gach Comhad"
+
+#: ../panels/network/network-wifi.ui.h:62
+#, fuzzy
+msgid "Security type"
+msgstr "Eochracha Greamaitheacha"
+
+#: ../panels/network/network-wifi.ui.h:63
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:10
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "Focal Faire"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "Stádas anaithnid"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "Níl ar fáil"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "Ag ceangal"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "Fíordheimhniú de dhíth"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "Ceangailte"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "Ag dícheangal"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr ""
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "Gan cheangal"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+#, fuzzy
+msgid "Configuration failed"
+msgstr "U_RL Uathchumraíochta:"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+#, fuzzy
+msgid "IP configuration failed"
+msgstr "Fíordheimhnithe!"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+#, fuzzy
+msgid "IP configuration expired"
+msgstr "U_RL Uathchumraíochta:"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+#, fuzzy
+msgid "AutoIP service failed"
+msgstr "Fíordheimhnithe!"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+#, fuzzy
+msgid "Modem initialization failed"
+msgstr "Fíordheimhnithe!"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+#, fuzzy
+msgid "Network registration denied"
+msgstr "Socruithe an líonra"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+#, fuzzy
+msgid "Bluetooth connection failed"
+msgstr "Fíordheimhnithe!"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+#, fuzzy
+msgid "SIM wrong"
+msgstr "Láidir"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+#, fuzzy
+msgid "Choose a PAC file"
+msgstr "Roghnaigh comhad PAC..."
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "Comhaid PAC (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "_Comhad PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "Fíordheimhnithe!"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "Fíordheimhnithe"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "_Ainm úsáideora"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "_Taispeáin focal faire"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "Leagan 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "Leagan 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "_Leagan PEAP"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+msgid "Choose your personal certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+msgid "Choose your private key"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#, fuzzy
+msgid "_Private key password"
+msgstr "Socraigh focal faire anois"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr ""
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "Níl"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "Tá"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr ""
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "Fío_rdheimniú"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (Réamhshocrú)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+#, fuzzy
+msgid "Open System"
+msgstr "Córas"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "_Eochair"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "C_ineál"
+
+#: ../panels/notifications/cc-notifications-panel.c:257
+#: ../panels/power/cc-power-panel.c:1853 ../panels/power/cc-power-panel.c:1860
+#: ../panels/privacy/cc-privacy-panel.c:155
+#: ../panels/privacy/cc-privacy-panel.c:222
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "Cumasaithe"
+
+#. This is the per application switch for message tray usage.
+#: ../panels/notifications/edit-dialog.ui.h:2
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "Fógairtí"
+
+#. This is the setting to configure sounds associated with notifications.
+#: ../panels/notifications/edit-dialog.ui.h:4
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "Foláirimh Fuaime"
+
+#: ../panels/notifications/edit-dialog.ui.h:5
+#, fuzzy
+msgctxt "notifications"
+msgid "Notification Banners"
+msgstr "Fógairtí"
+
+#. Banners here refers to message tray notifications in the middle of the screen.
+#: ../panels/notifications/edit-dialog.ui.h:7
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message Content in Banners"
+msgstr "Taispeáin Sonraí sna Meirgí"
+
+#: ../panels/notifications/edit-dialog.ui.h:8
+#, fuzzy
+msgctxt "notifications"
+msgid "Lock Screen Notifications"
+msgstr "Fógairtí"
+
+#: ../panels/notifications/edit-dialog.ui.h:9
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message Content on Lock Screen"
+msgstr "Taispeán Sonraí ar an Scáileán Glasála"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "Fógairt"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Fógairtí;Meirge;Teachtaireacht;Greille;Preab;"
+
+#: ../panels/notifications/notifications.ui.h:1
+#, fuzzy
+msgid "Notification Banners"
+msgstr "Fógairt"
+
+#: ../panels/notifications/notifications.ui.h:2
+#, fuzzy
+msgid "Lock Screen Notifications"
+msgstr "Fógairt"
+
+#. List of applications.
+#: ../panels/notifications/notifications.ui.h:4
+#: ../panels/sound/gvc-mixer-dialog.c:1781
+msgid "Applications"
+msgstr "Feidhmchláir"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Eile"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:290
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "Cuir Cuntas Leis"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:329
+msgid "Mail"
+msgstr "Post"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:335
+msgid "Contacts"
+msgstr "Teagmhálacha"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:341
+msgid "Chat"
+msgstr "Comhrá"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:347
+msgid "Resources"
+msgstr "Acmhainní"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:422
+msgid "Error logging into the account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:492
+msgid "Credentials have expired."
+msgstr "Chuaigh dintiúir as feidhm."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:496
+msgid "Sign in to enable this account."
+msgstr "Sínigh isteach chun an cuntas seo a chumasú."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:501
+msgid "_Sign In"
+msgstr "_Sínigh Isteach"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:748
+msgid "Error creating account"
+msgstr "Earráid agus cuntas á chruthú"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:808
+msgid "Error removing account"
+msgstr "Earráid agus cuntas á bhaint"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:844
+msgid "Are you sure you want to remove the account?"
+msgstr "An bhfuil tú cinnte gur mhaith leat an cuntas a bhaint?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:846
+msgid "This will not remove the account on the server."
+msgstr "Ní bhainfidh sé seo an cuntas ón bhfreastalaí."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:847
+msgid "_Remove"
+msgstr "_Bain"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "Cuntais ar Líne"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Gréasán;Ar Líne;Comhrá;Féilire;Post;Teagmháil;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "Níl cuntas ar líne cumasaithe"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "Bain Cuntas"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "Cuir cuntas ar líne leis"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"Nuair a chuireann tú cuntas leis, is féidir le feidhmchláir é a rochtain le "
+"haghaidh cáipéisí, poist, teagmhálacha, féilire, comhrá, agus ar uile."
+
+#: ../panels/power/cc-power-panel.c:200
+msgid "Unknown time"
+msgstr "Am anaithnid"
+
+#: ../panels/power/cc-power-panel.c:206
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i nóimeád"
+msgstr[1] "%i nóimeád"
+msgstr[2] "%i nóimeád"
+msgstr[3] "%i nóimeád"
+msgstr[4] "%i nóimeád"
+
+#: ../panels/power/cc-power-panel.c:218
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i uair"
+msgstr[1] "%i uair"
+msgstr[2] "%i uaire"
+msgstr[3] "%i n-uaire"
+msgstr[4] "%i uair"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:226
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:227
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "uair"
+msgstr[1] "uair"
+msgstr[2] "uaire"
+msgstr[3] "n-uaire"
+msgstr[4] "uair"
+
+#: ../panels/power/cc-power-panel.c:228
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "nóimeád"
+msgstr[1] "nóimeád"
+msgstr[2] "nóimeád"
+msgstr[3] "nóimeád"
+msgstr[4] "nóimeád"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:247
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s go dtí luchtaithe go hiomlán"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:254
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Rabhadh: %s fágtha"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:259
+#, c-format
+msgid "%s remaining"
+msgstr "%s fágtha"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:264 ../panels/power/cc-power-panel.c:292
+msgid "Fully charged"
+msgstr "Luchtaithe go hiomlán"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:268 ../panels/power/cc-power-panel.c:296
+msgid "Empty"
+msgstr "Folamh"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:283
+msgid "Charging"
+msgstr "Á luchtú"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:288
+msgid "Discharging"
+msgstr "Á dhíluchtú"
+
+#: ../panels/power/cc-power-panel.c:411
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Príomhchadhnra"
+
+#: ../panels/power/cc-power-panel.c:413
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Breise"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:484
+msgid "Wireless mouse"
+msgstr "Luch gan sreang"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:487
+msgid "Wireless keyboard"
+msgstr "Méarchlár gan sreang"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:490
+msgid "Uninterruptible power supply"
+msgstr "Soláthar dobhriste cumhachta"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:493
+msgid "Personal digital assistant"
+msgstr "Ríomhaire boise"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:496
+msgid "Cellphone"
+msgstr "Fón póca"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:499
+msgid "Media player"
+msgstr "Seinnteoir meán"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:502
+msgid "Tablet"
+msgstr "Táibléad"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:505
+msgid "Computer"
+msgstr "Ríomhaire"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:508 ../panels/power/cc-power-panel.c:748
+#: ../panels/power/cc-power-panel.c:2109
+msgid "Battery"
+msgstr "Cadhnra"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Á luchtú"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:569
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Rabhadh"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:574
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Íseal"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:579
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Maith"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:584
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Luchtaithe go hiomlán"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:588
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Folamh"
+
+#: ../panels/power/cc-power-panel.c:746
+msgid "Batteries"
+msgstr "Cadhnraí"
+
+#: ../panels/power/cc-power-panel.c:1171
+msgid "When _idle"
+msgstr "Nuair _díomhaoin"
+
+#: ../panels/power/cc-power-panel.c:1560
+msgid "Power Saving"
+msgstr "Coigilt Chumhachta"
+
+#: ../panels/power/cc-power-panel.c:1595
+msgid "_Screen brightness"
+msgstr "Gile an _scáileáin"
+
+#: ../panels/power/cc-power-panel.c:1614
+#, fuzzy
+msgid "Automatic brightness"
+msgstr "Róid Uathoibríocha"
+
+#: ../panels/power/cc-power-panel.c:1634
+msgid "_Keyboard brightness"
+msgstr "Gile an _mhéarchláir"
+
+#: ../panels/power/cc-power-panel.c:1644
+msgid "_Dim screen when inactive"
+msgstr "Maolaigh an scáileán agus _neamhghníomhach"
+
+#: ../panels/power/cc-power-panel.c:1669
+msgid "_Blank screen"
+msgstr "_Bánaigh an scáileán"
+
+#: ../panels/power/cc-power-panel.c:1706
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: ../panels/power/cc-power-panel.c:1711
+msgid "Turn off Wi-Fi to save power."
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1736
+msgid "_Mobile broadband"
+msgstr "Leathanbhanda _móibíleach"
+
+#: ../panels/power/cc-power-panel.c:1741
+#, fuzzy
+msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+msgstr "Múchann sé seo gléasanna leathanbhanda móibíligh (3G, 4G, WiMax, srl.)"
+
+#: ../panels/power/cc-power-panel.c:1793
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: ../panels/power/cc-power-panel.c:1849
+msgid "When on battery power"
+msgstr "Agus ar chumhacht chadhnra"
+
+#: ../panels/power/cc-power-panel.c:1851
+msgid "When plugged in"
+msgstr "Nuair atá ionsuite"
+
+#: ../panels/power/cc-power-panel.c:1968
+msgid "Suspend & Power Off"
+msgstr "Cur ar Fionraí & Múchadh"
+
+#: ../panels/power/cc-power-panel.c:2008
+msgid "_Automatic suspend"
+msgstr "_Cur ar fionraí uathoibríoch"
+
+#: ../panels/power/cc-power-panel.c:2009
+msgid "Automatic suspend"
+msgstr "Cur ar fionraí uathoibríoch"
+
+#: ../panels/power/cc-power-panel.c:2163
+msgid "Devices"
+msgstr "Gléasanna"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "Cumhacht"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+
+#: ../panels/power/power.ui.h:3
+msgid "45 minutes"
+msgstr "45 nóimeád"
+
+#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 uair"
+
+#: ../panels/power/power.ui.h:5
+msgid "80 minutes"
+msgstr "80 nóimeád"
+
+#: ../panels/power/power.ui.h:6
+msgid "90 minutes"
+msgstr "90 nóimeád"
+
+#: ../panels/power/power.ui.h:7
+msgid "100 minutes"
+msgstr "100 nóimeád"
+
+#: ../panels/power/power.ui.h:8
+msgid "2 hours"
+msgstr "2 uair"
+
+#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 nóimeád"
+
+#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 nóimeád"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 nóimeád"
+
+#: ../panels/power/power.ui.h:12
+msgid "4 minutes"
+msgstr "4 nóiméad"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 nóimeád"
+
+#: ../panels/power/power.ui.h:14
+msgid "8 minutes"
+msgstr "8 nóiméad"
+
+#: ../panels/power/power.ui.h:15
+msgid "10 minutes"
+msgstr "10 nóimeád"
+
+#: ../panels/power/power.ui.h:16
+msgid "12 minutes"
+msgstr "12 nóimeád"
+
+#: ../panels/power/power.ui.h:18
+msgid "Automatic Suspend"
+msgstr "Cur ar Fionraí Uathoibríoch"
+
+#: ../panels/power/power.ui.h:19
+msgid "_Plugged In"
+msgstr "_Ionsuite"
+
+#: ../panels/power/power.ui.h:20
+msgid "On _Battery Power"
+msgstr "Ar _Chumhacht Chadhnra"
+
+#: ../panels/power/power.ui.h:21
+msgid "Delay"
+msgstr "Moill"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "Fíordheimhnigh"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "Fíordheimhniú de Dhíth"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:588
+msgid "Low on toner"
+msgstr ""
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Out of toner"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:593
+msgid "Low on developer"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:596
+msgid "Out of developer"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Low on a marker supply"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Out of a marker supply"
+msgstr ""
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Open cover"
+msgstr ""
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open door"
+msgstr ""
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Low on paper"
+msgstr ""
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Out of paper"
+msgstr ""
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:610
+msgctxt "printer state"
+msgid "Offline"
+msgstr "As líne"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:612
+#: ../panels/printers/cc-printers-panel.c:803
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Stadta"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:614
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle full"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:730
+#, fuzzy
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "U_RL Uathchumraíochta:"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:789
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Réidh"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:794
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr ""
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:799
+#, fuzzy
+msgctxt "printer state"
+msgid "Processing"
+msgstr "_Gairm:"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:919
+msgid "Toner Level"
+msgstr "Leibhéal Tonóra"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Ink Level"
+msgstr "Leibhéal Dúigh"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Supply Level"
+msgstr "Leibhéal Soláthair"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:943
+msgctxt "printer state"
+msgid "Installing"
+msgstr "Á shuiteáil"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1119
+msgid "No printers available"
+msgstr "Níl aon phrintéir ar fáil"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1429
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1770
+msgid "Failed to add new printer."
+msgstr "Theip ar chur printéir nua leis."
+
+#: ../panels/printers/cc-printers-panel.c:1937
+msgid "Select PPD File"
+msgstr "Roghnaigh Comhad PPD"
+
+#: ../panels/printers/cc-printers-panel.c:1946
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2253
+msgid "No suitable driver found"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2324
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2345
+msgid "Select from database…"
+msgstr ""
+
+#: ../panels/printers/cc-printers-panel.c:2354
+msgid "Provide PPD File…"
+msgstr ""
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2505
+#: ../panels/printers/cc-printers-panel.c:2528
+msgid "Test page"
+msgstr "Leathanach tástála"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2942
+#, fuzzy, c-format
+msgid "Could not load ui: %s"
+msgstr "Níorbh fhéidir an príomhchomhéadan a luchtú"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "Printéirí"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr ""
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "Dún"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr ""
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr ""
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr ""
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "Cuir Printéir Nua Leis"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "Fíordheimhnigh"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "Níor braitheadh aon phrintéir."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "Roghanna á luchtú…"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "Méar an fháinne chlé"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr ""
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:526
+#, fuzzy
+msgid "JetDirect Printer"
+msgstr "Bain Printéir"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:782
+#, fuzzy
+msgid "LPD Printer"
+msgstr "Printéir %s"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr ""
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr ""
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr ""
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+#, fuzzy
+msgctxt "print job"
+msgid "Processing"
+msgstr "_Gairm:"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr ""
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr ""
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr ""
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr ""
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "Teideal Jab"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "Staid Jab"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "Am"
+
+#: ../panels/printers/pp-jobs-dialog.c:451
+#, c-format
+msgid "%s Active Jobs"
+msgstr ""
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1659
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1664
+msgid "Serial Port"
+msgstr ""
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "Parallel Port"
+msgstr ""
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1713
+#, c-format
+msgid "Location: %s"
+msgstr "Suíomh: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1718
+#, c-format
+msgid "Address: %s"
+msgstr "Seoladh: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1747
+#, fuzzy
+msgid "Server requires authentication"
+msgstr "Fíordheimhnithe!"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr ""
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr ""
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr ""
+
+#: ../panels/printers/pp-options-dialog.c:84
+#, fuzzy
+msgid "Output Tray"
+msgstr "Aschur"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr ""
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:533
+msgid "Pages per side"
+msgstr ""
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:545
+msgid "Two-sided"
+msgstr ""
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:557
+#, fuzzy
+msgid "Orientation"
+msgstr "Gníomh an Bharra Teidil"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:654
+#, fuzzy
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Ginearálta"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Socrú Leathanaigh"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:660
+#, fuzzy
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Gníomh an Bharra Teidil"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Jab"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Cáilíocht Íomhá"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Dath"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr ""
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:675
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Casta"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "Uathroghnaigh"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+#, fuzzy
+msgid "Printer Default"
+msgstr "Réamhshocrú"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+#, fuzzy
+msgid "No pre-filtering"
+msgstr "Gan phróifíl"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "Déantóir"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Tiománaí"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "Cuir Printéir Leis"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "Bain Printéir"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "Soláthar"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "Suíomh"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default printer"
+msgstr "Printéir _réamhshocraithe"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "Jabanna"
+
+#. Translators: Opens a dialog containing printer
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "Taispeáin _Jabanna"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "Samhail"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "lipéad"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "leathanach 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "Priontáil Leathanach _Tástála"
+
+#. Translators: This button opens printer
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "_Roghanna"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "Cuir Printéir Nua Leis"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:352 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "Glas Scáileáin"
+
+#: ../panels/privacy/cc-privacy-panel.c:462 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "Úsáid & Stair"
+
+#: ../panels/privacy/cc-privacy-panel.c:587
+msgid "Empty all items from Trash?"
+msgstr "Folmhaigh gach mír ón mBruscar?"
+
+#: ../panels/privacy/cc-privacy-panel.c:588
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Scriosfar gach mír sa Bhruscar go buan."
+
+#: ../panels/privacy/cc-privacy-panel.c:589 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "_Folmhaigh an Bruscar"
+
+#: ../panels/privacy/cc-privacy-panel.c:612
+msgid "Delete all the temporary files?"
+msgstr "Scrios gach comhad sealadach?"
+
+#: ../panels/privacy/cc-privacy-panel.c:613
+msgid "All the temporary files will be permanently deleted."
+msgstr "Scriosfar gach comhad sealadach go buan."
+
+#: ../panels/privacy/cc-privacy-panel.c:614 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "_Purgaigh Comhaid Shealadacha"
+
+#: ../panels/privacy/cc-privacy-panel.c:636 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "Purgaigh Bruscar & Comhaid Shealadacha"
+
+#: ../panels/privacy/cc-privacy-panel.c:676 ../panels/privacy/privacy.ui.h:36
+#, fuzzy
+msgid "Software Usage"
+msgstr "Bogearraí"
+
+#: ../panels/privacy/cc-privacy-panel.c:717 ../panels/privacy/privacy.ui.h:44
+msgid "Problem Reporting"
+msgstr ""
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: ../panels/privacy/cc-privacy-panel.c:731
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:743 ../panels/privacy/privacy.ui.h:41
+#, fuzzy
+msgid "Privacy Policy"
+msgstr "Príobháid­eachas"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "Príobháid­eachas"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "Múchadh an Scáileáin"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 soicind"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 lá"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 lá"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 lá"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 lá"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 lá"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 lá"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 lá"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 lá"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 lá"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "Go deo"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "Ú_sáidte le Déanaí"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "Coinnigh _Stair"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "_Glan an Stair Is Déanaí"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "Cosnaíonn Glas Scáileáin do phríobháideachas nuair atá tú amuigh."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "Glasáil Scáileáin Uathoibríoch"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "Cuir scáileán faoi _ghlas tar éis"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "Taispeáin _Fógairtí"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "Folmhaigh _Bruscar go huathoibríoch"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "Purgaigh _Comhaid Sealadacha go huathoibríoch"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "Purgaigh i _nDiaidh"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:42
+#, fuzzy
+msgid "_Location Services"
+msgstr "Suíomh"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:45
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: ../panels/region/cc-format-chooser.c:120
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Impiriúil"
+
+#: ../panels/region/cc-format-chooser.c:122
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Méadrach"
+
+#: ../panels/region/cc-format-chooser.c:287
+msgid "No regions found"
+msgstr "Réigiún gan aimsiú"
+
+#: ../panels/region/cc-input-chooser.c:181
+msgid "No input sources found"
+msgstr "Foinse ionchuir gan aimsiú"
+
+#: ../panels/region/cc-input-chooser.c:1015
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Eile"
+
+#: ../panels/region/cc-region-panel.c:247
+#: ../panels/user-accounts/um-user-panel.c:1072
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: ../panels/region/cc-region-panel.c:251
+#: ../panels/user-accounts/um-user-panel.c:1076
+msgid "Restart Now"
+msgstr "Atosaigh Anois"
+
+#: ../panels/region/cc-region-panel.c:877
+msgid "No input source selected"
+msgstr "Níl aon fhoinse ionchuir roghnaithe"
+
+#: ../panels/region/cc-region-panel.c:1797
+msgid "Login Screen"
+msgstr "Scáileán Logála Isteach"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "Formáidí"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "Réamhamharc"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "Dátaí"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "Amanna"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "Uimhreacha"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "Tomhas"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "Páipéir"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "Réigiún & Teanga"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Teanga;Leagan Amach;Méarchlár;Ionchur;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "Cuir Foinse Ionchuir Leis"
+
+#: ../panels/region/input-chooser.ui.h:4
+msgid "Input methods can't be used on the login screen"
+msgstr "Ní féidir modhanna ionchuir a úsáid ar an scáileán logála isteach"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "Roghanna na Foinse Ionchuir"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Allow _different sources for each window"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Keyboard Shortcuts"
+msgstr "Aicearraí Méarchláir"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Switch to previous source"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Switch to next source"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:9
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Alternative switch to next source"
+msgstr ""
+
+#: ../panels/region/input-options.ui.h:12
+msgid "Left+Right Alt"
+msgstr "Left+Right Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "Béarla (An Ríocht Aontaithe)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "An Ríocht Aontaithe"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "Roghanna"
+
+#: ../panels/region/region.ui.h:7
+#, fuzzy
+msgid "Add input source"
+msgstr "Cuir Foinse Ionchuir Leis"
+
+#: ../panels/region/region.ui.h:8
+#, fuzzy
+msgid "Remove input source"
+msgstr "Foinse ionchuir gan aimsiú"
+
+#: ../panels/region/region.ui.h:9
+#, fuzzy
+msgid "Move input source up"
+msgstr "Foinse ionchuir gan aimsiú"
+
+#: ../panels/region/region.ui.h:10
+#, fuzzy
+msgid "Move input source down"
+msgstr "Foinse ionchuir gan aimsiú"
+
+#: ../panels/region/region.ui.h:11
+#, fuzzy
+msgid "Configure input source"
+msgstr "Athraigh go dtí an chéad fhoinse ionchuir eile"
+
+#: ../panels/region/region.ui.h:12
+#, fuzzy
+msgid "Show input source keyboard layout"
+msgstr "Níl aon fhoinse ionchuir roghnaithe"
+
+#: ../panels/region/region.ui.h:13
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr "Áiteanna"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "Leabharmharcanna"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr "Eile"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "Roghnaigh Suíomh"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+msgid "_OK"
+msgstr "Tá g_o Maith"
+
+#: ../panels/search/cc-search-panel.c:177
+msgid "No applications found"
+msgstr "Feidhmchlár gan aimsiú"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "Cuardach"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "Suíomhanna Cuardaigh"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "Bog Suas"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "Bog Síos"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "Sainroghanna"
+
+#: ../panels/sharing/cc-sharing-panel.c:265
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Cumasaithe"
+
+#: ../panels/sharing/cc-sharing-panel.c:267
+#: ../panels/sharing/cc-sharing-panel.c:294
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Díchumasaithe"
+
+#: ../panels/sharing/cc-sharing-panel.c:297
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Cumasaithe"
+
+#: ../panels/sharing/cc-sharing-panel.c:300
+msgctxt "service is active"
+msgid "Active"
+msgstr "Gníomhach"
+
+#: ../panels/sharing/cc-sharing-panel.c:371
+msgid "Choose a Folder"
+msgstr "Roghnaigh Fillteán"
+
+#: ../panels/sharing/cc-sharing-panel.c:800
+msgid "Copy"
+msgstr "Cóipeáil"
+
+#: ../panels/sharing/cc-sharing-panel.c:1126
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "Comhroinnt"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr ""
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+#, fuzzy
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Fíordheimhnithe!"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:303
+msgid "No networks selected for sharing"
+msgstr ""
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+#, fuzzy
+msgid "Networks"
+msgstr "Líonra"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Computer Name"
+msgstr "Ainm an Ríomhaire"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid "Personal File Sharing"
+msgstr "Comhroinnt na gComhad Pearsanta"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Screen Sharing"
+msgstr "Comhroinnt an Scáileáin"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Media Sharing"
+msgstr "Comhroinnt Meán"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Remote Login"
+msgstr "Cianlogáil Isteach"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Some services are disabled because of no network access."
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:8
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:9
+#, fuzzy
+msgid "Require Password"
+msgstr "_Focal Faire:"
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:15
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:16
+#, fuzzy
+msgid "Allow Remote Control"
+msgstr "Rialtán UI"
+
+#: ../panels/sharing/sharing.ui.h:17
+#, fuzzy
+msgid "Password:"
+msgstr "Focal Faire"
+
+#: ../panels/sharing/sharing.ui.h:18
+msgid "Show Password"
+msgstr "Taispeáin Focal Faire"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, fuzzy
+msgid "Access Options"
+msgstr "Roghanna"
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "New connections must ask for access"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:21
+#, fuzzy
+msgid "Require a password"
+msgstr "_Focal Faire:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid ""
+"Media sharing allows you to share music, photos and videos over the network."
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:23
+msgid "Folders"
+msgstr "Fillteáin"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "Fuaim"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "Sceamh"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "Sileadh"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "Gloine"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "Sonóir"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "Clé"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "Deas"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "Cúl"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "Aghaidh"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+#, fuzzy
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Íoslaghdaigh"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+#, fuzzy
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Uasmhéadaigh"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "_Cothromaíocht:"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "Céi_mniú:"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "Fo-dhordaire"
+
+#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:615
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Gan aimpliú"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
+#: ../panels/sound/gvc-mixer-dialog.c:515
+msgid "_Profile:"
+msgstr "_Próifíl:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u Aschur"
+msgstr[1] "%u Aschur"
+msgstr[2] "%u Aschur"
+msgstr[3] "%u nAschur"
+msgstr[4] "%u Aschur"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u Ionchur"
+msgstr[1] "%u Ionchur"
+msgstr[2] "%u Ionchur"
+msgstr[3] "%u nIonchur"
+msgstr[4] "%u Ionchur"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "Fuaimeanna Córais"
+
+#: ../panels/sound/gvc-mixer-dialog.c:251
+msgid "_Test Speakers"
+msgstr "_Tástáil Callairí"
+
+#: ../panels/sound/gvc-mixer-dialog.c:420
+msgid "Peak detect"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1493
+#: ../panels/sound/gvc-sound-theme-chooser.c:564
+msgid "Name"
+msgstr "Ainm"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1512
+msgid "Device"
+msgstr "Gléas"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1575
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1631
+msgid "_Output volume:"
+msgstr "Airde _aschuir:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1645
+msgid "Output"
+msgstr "Aschur"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1650
+msgid "C_hoose a device for sound output:"
+msgstr "_Roghnaigh gléas le haghaidh aschur fuaime:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1672
+msgid "Settings for the selected device:"
+msgstr "Socruithe don ghléas roghnaithe:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1683
+msgid "Input"
+msgstr "Ionchur"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1690
+msgid "_Input volume:"
+msgstr "Airde _ionchuir:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "Input level:"
+msgstr "Leibhéal ionchuir:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1737
+msgid "C_hoose a device for sound input:"
+msgstr "_Roghnaigh gléas le haghaidh ionchur fuaime:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1761
+msgid "Sound Effects"
+msgstr "Maisíochtaí Fuaime"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1768
+msgid "_Alert volume:"
+msgstr "_Airde foláireamh:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1785
+msgid "No application is currently playing or recording audio."
+msgstr "Níl fuaim á seinm nó á taifeadadh ag aon fheidhmchlár."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "Ionsuite"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "Sainroghanna Fuaime"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:554
+msgid "Default"
+msgstr "Réamhshocrú"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:555
+msgid "From theme"
+msgstr "Ó théama"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:740
+msgid "C_hoose an alert sound:"
+msgstr "_Roghnaigh fuaim fholáirimh:"
+
+#: ../panels/sound/gvc-speaker-test.c:231
+msgid "Stop"
+msgstr "Stad"
+
+#: ../panels/sound/gvc-speaker-test.c:231
+#: ../panels/sound/gvc-speaker-test.c:343
+msgid "Test"
+msgstr "Tástáil"
+
+#: ../panels/sound/gvc-speaker-test.c:239
+msgid "Subwoofer"
+msgstr "Fo-dhordaire"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "Saincheaptha"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"Méarchlár;Luch;a11y;Inrochtaineacht;Codarsnacht;Súmáil;Léitheoir Scáileáin;"
+"téacs;cló;méid;AccessX;Eocracha Greamaitheacha;Eochracha Malla;Eocracha "
+"Preabtha;Eochracha Luiche;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "Taispeáin Roghchlár Rochtana Uilíoch i _gCónaí"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "Feiceáil"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "_Ardchodarsnacht"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "_Téacs Mór"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "_Zoom"
+msgstr "_Súmáil"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr "_Léitheoir Scáileáin"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "_Sound Keys"
+msgstr "Eochracha _Fuaime"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "Cloisteáil"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr "Folái_rimh Amhairc"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Screen _Keyboard"
+msgstr "_Méarchlár Scáileáin"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "_Typing Assist (AccessX)"
+msgstr "Cúnamh _Clóscríofa (AccessX)"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Pointing & Clicking"
+msgstr "Pointeáil & Cliceáil"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "_Mouse Keys"
+msgstr "Eocracha L_uiche"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "Cúnamh Cl_icéala"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "Léitheoir Scáileáin"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Screen Reader"
+msgstr "Léitheoir _Scáileáin"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Sound Keys"
+msgstr "Eochracha Fuaime"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "Foláirimh Amhairc"
+
+#: ../panels/universal-access/uap.ui.h:23
+#, fuzzy
+msgid "_Test flash"
+msgstr "LEATHANACH"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:25
+#, fuzzy
+msgid "Flash the _window title"
+msgstr "Splanc barra teidil na _fuinneoige"
+
+#: ../panels/universal-access/uap.ui.h:26
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Splanc _scáileán ar fad"
+
+#: ../panels/universal-access/uap.ui.h:27
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Clóscríobh"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "_Sticky Keys"
+msgstr "Eochracha _Greamaitheacha"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:30
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+"Dích_umasaigh eochracha greamaitheacha má bhrúitear dhá eochair le chéile"
+
+#: ../panels/universal-access/uap.ui.h:31
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Luas athbhrú eochracha"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "S_low Keys"
+msgstr "_Eochracha Malla"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:35
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Gearr"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:37
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Fada"
+
+#: ../panels/universal-access/uap.ui.h:38
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Luas athbhrú eochracha"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "_Bounce Keys"
+msgstr "Eochracha _Preabtha"
+
+#: ../panels/universal-access/uap.ui.h:42
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Déan _neamhaird ar brúnna eochrach dúblacha tapa"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Gearr"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:45
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Fada"
+
+#: ../panels/universal-access/uap.ui.h:46
+#, fuzzy
+msgid "_Enable by Keyboard"
+msgstr "Méarchlár"
+
+#: ../panels/universal-access/uap.ui.h:47
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Is féidir gnéithe _inrochtaineachta a scoránú le haicearraí méarchláir"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:49
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Cliceáil Tánaisteach Ionsamhailte"
+
+#: ../panels/universal-access/uap.ui.h:50
+#, fuzzy
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "_Truicear cliceáil tánaisteach agus an príomhcnaipe á choinneáil síos"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Gearr"
+
+#: ../panels/universal-access/uap.ui.h:52
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "Cliceáil Tánaisteach Ionsamhailte"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Fada"
+
+#: ../panels/universal-access/uap.ui.h:54
+#, fuzzy
+msgid "_Hover Click"
+msgstr "Cliceáil Fanachta"
+
+#: ../panels/universal-access/uap.ui.h:55
+#, fuzzy
+msgid "Trigger a click when the pointer hovers"
+msgstr "_Cuir tús le cliceáil agus gluaiseacht an phointeora á stad"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "M_oill:"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Gearr"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Fada"
+
+#: ../panels/universal-access/uap.ui.h:59
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "Tairseach _ghluaisne:"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Beag"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Mór"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "Gearr"
+
+#: ../panels/universal-access/zoom-options.c:334
+#, fuzzy
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "Scáileán"
+
+#: ../panels/universal-access/zoom-options.c:335
+#, fuzzy
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "Scáileán"
+
+#: ../panels/universal-access/zoom-options.c:336
+#, fuzzy
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "Scáileán"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "Fada"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+#, fuzzy
+msgid "Full Screen"
+msgstr "Scáileán"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+#, fuzzy
+msgid "Left Half"
+msgstr "Ar Chlé"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+#, fuzzy
+msgid "Right Half"
+msgstr "Ar Dheis"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "Roghanna Súmála"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "Súmáil"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+#, fuzzy
+msgid "Screen part:"
+msgstr "Léitheoir Scáileáin Linux"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "Dath:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "Bán ar dhubh:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "Gile:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "Codarsnacht:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "Dath"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Neamhní"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Lán"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Íseal"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Ard"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Íseal"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Ard"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "Maisíochtaí Datha:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "Maisíochtaí Datha"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Gnáthchuntas"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Riarthóir"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Full Name"
+msgstr "Ainm _Iomlán"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "Cineál Cun_tais"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to set a password when they next login"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "Socraigh focal faire anois"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "_Fearann"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "Logáil Isteach _Fiontair"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1466
+msgid "Add User"
+msgstr "Cuir Úsáideoir Leis"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#, fuzzy
+msgid "Domain Administrator Login"
+msgstr "Riarthóir"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "Ai_nm Riarthóra"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "Focal Faire Riarthóra"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "Ordóg chlé"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "Méar mheáin chlé"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "Méar an fháinne chlé"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "Lúidín clé"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "Ordóg dheas"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "Méar mheáin dheas"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "Méar an fháinne dheas"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "Lúidín deas"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:686
+msgid "Enable Fingerprint Login"
+msgstr "Cumasaigh Logáil Isteach Méarloirg"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "Corrmhéar _dheas"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "Corrmhéar _chlé"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "Méar _eile:"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"D'éirigh le sábháil do mhéarloirg. Ba chóir duit bheith in ann logáil "
+"isteach le do bhraiteoir méarloirg."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "Úsáideoirí"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+#, fuzzy
+msgid "Add or remove users and change your password"
+msgstr "Cuir leis nó bain úsáideoirí"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Logáil Isteach;Ainm;"
+"Méarlorg;Abhatár;Aghaidh;Focal Faire;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "Stair Logála Isteach"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#, fuzzy
+msgid "Change Password"
+msgstr "Taispeáin Focal Faire"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "_Athraigh"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "_Deimhnigh Focal Faire Nua"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "Focal Faire _Nua"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "_Focal Faire Reatha"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "Cuir Cuntas Úsáideora Leis"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "Bain Cuntas Úsáideora"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "Roghanna Logála Isteach"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "Logáil Isteach _Uathoibríoch"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "Logáil Isteach _Méarloirg"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "Deilbhín Úsáideora"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "_Teanga"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "Logáil Isteach Is Déanaí"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "Bainistigh cuntais úsáideora"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#, fuzzy
+msgid "Authentication is required to change user data"
+msgstr "Fíordheimhnithe!"
+
+#: ../panels/user-accounts/pw-utils.c:81
+#, fuzzy
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr ""
+"Ní mór carachtair uimhriúla nó speisialta a bheith san fhocal faire nua."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+#, fuzzy
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Focal faire á athrú do"
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "Neart: Lag"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "Neart: Íseal"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "Neart: Meánach"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "Neart: Maith"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "Neart: Ard"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "Theip ar fhíordheimniú"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, fuzzy, c-format
+msgid "The new password is too short"
+msgstr "Tá an focal faire ró-ghairid."
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, fuzzy, c-format
+msgid "The new password is too simple"
+msgstr "Tá an focal faire ró-shimplí."
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, fuzzy, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Tá an focal faire nua agus an seanfhocal faire ró-chósúil."
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, fuzzy, c-format
+msgid "The new password has already been used recently."
+msgstr "Níl an dá fhocal faire cothrom."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, fuzzy, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+"Ní mór carachtair uimhriúla nó speisialta a bheith san fhocal faire nua."
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, fuzzy, c-format
+msgid "The old and new passwords are the same"
+msgstr "Is ionann an focal faire nua agus an seanfhocal faire."
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, fuzzy, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+"Athraíodh d'fhocal faire ó d'fhíordheimhnigh tú ar dtús! Athfhíordheimhnigh, "
+"le do thoil."
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, fuzzy, c-format
+msgid "The new password does not contain enough different characters"
+msgstr ""
+"Ní mór carachtair uimhriúla nó speisialta a bheith san fhocal faire nua."
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "Earráid anaithnid"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+#, fuzzy
+msgid "Failed to add account"
+msgstr "Roghnaigh cuntas"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+#, fuzzy
+msgid "Passwords do not match."
+msgstr "Tá an focal faire ró-ghairid."
+
+#: ../panels/user-accounts/um-account-dialog.c:733
+#: ../panels/user-accounts/um-account-dialog.c:779
+#: ../panels/user-accounts/um-account-dialog.c:800
+msgid "Failed to register account"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:923
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:982
+msgid "Failed to join domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:1043
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:1058
+msgid "Failed to log into domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:1116
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:138
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:140
+msgid "The device is already in use."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+#, fuzzy
+msgid "An internal error occurred."
+msgstr "Tharla earráid chórais"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Enabled"
+msgstr "Cumasaithe"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:443
+msgid "Done!"
+msgstr "Críochnaithe!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:504
+#: ../panels/user-accounts/um-fingerprint-dialog.c:546
+#, c-format
+msgid "Could not access '%s' device"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:587
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:637
+msgid "Could not access any fingerprint readers"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:638
+msgid "Please contact your system administrator for help."
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:720
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:727
+msgid "Selecting finger"
+msgstr "Méar á roghnú"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:728
+msgid "Enrolling fingerprints"
+msgstr ""
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "An tSeachtain Seo"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "An tSeachtain Seo Caite"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:844
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:848
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr ""
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+#, fuzzy
+msgid "Please type your current password again."
+msgstr ""
+"Clóscriobh d'fhocal faire isteach sa réimse <b>Focal faire nua</b>, le do "
+"thoil."
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+#, fuzzy
+msgid "Password could not be changed"
+msgstr "Athraítear d'fhocal faire."
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Tá an focal faire ró-ghairid."
+
+#: ../panels/user-accounts/um-photo-dialog.c:214
+msgid "Browse for more pictures"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:448
+msgid "Disable image"
+msgstr "Díchumasaigh íomhá"
+
+#: ../panels/user-accounts/um-photo-dialog.c:466
+msgid "Take a photo…"
+msgstr "Tóg grianghraf…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:484
+msgid "Browse for more pictures…"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:708
+#, c-format
+msgid "Used by %s"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:815
+#: ../panels/user-accounts/um-realm-manager.c:829
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:821
+msgid "Invalid password, please try again"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:834
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:240
+msgid "Other Accounts"
+msgstr "Cuntais Eile"
+
+#: ../panels/user-accounts/um-user-panel.c:450
+msgid "Failed to delete user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:510
+#: ../panels/user-accounts/um-user-panel.c:569
+#: ../panels/user-accounts/um-user-panel.c:621
+msgid "Failed to revoke remotely managed user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:677
+msgid "You cannot delete your own account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:686
+#, c-format
+msgid "%s is still logged in"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:690
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:699
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:703
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:706
+msgid "_Delete Files"
+msgstr "_Scrios Comhaid"
+
+#: ../panels/user-accounts/um-user-panel.c:707
+msgid "_Keep Files"
+msgstr "_Coinnigh Comhaid"
+
+#: ../panels/user-accounts/um-user-panel.c:721
+#, fuzzy, c-format
+msgid "Are you sure you want to revoke remotely managed %s's account?"
+msgstr "An bhfuil tú cinnte gur mhaith leat an cuntas a bhaint?"
+
+#: ../panels/user-accounts/um-user-panel.c:725
+msgid "_Delete"
+msgstr "_Scrios"
+
+#: ../panels/user-accounts/um-user-panel.c:777
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Cuntas díchumasaithe"
+
+#: ../panels/user-accounts/um-user-panel.c:785
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:788
+msgctxt "Password mode"
+msgid "None"
+msgstr "Neamhní"
+
+#: ../panels/user-accounts/um-user-panel.c:837
+msgid "Logged in"
+msgstr "Logáilte isteach"
+
+#: ../panels/user-accounts/um-user-panel.c:1275
+msgid "Failed to contact the accounts service"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1277
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1318
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Chun athruithe a dhéanamh,\n"
+"cliceáil an deilbhín * ar dtús"
+
+#: ../panels/user-accounts/um-user-panel.c:1356
+msgid "Create a user account"
+msgstr "Cruthaigh cuntas úsáideora"
+
+#: ../panels/user-accounts/um-user-panel.c:1367
+#: ../panels/user-accounts/um-user-panel.c:1679
+#, fuzzy
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Chun úsáideoir a chruthú,\n"
+"cliceáil an deilbhín * ar dtús"
+
+#: ../panels/user-accounts/um-user-panel.c:1377
+#, fuzzy
+msgid "Delete the selected user account"
+msgstr "Scrios an úsáideoir roghnaithe"
+
+#: ../panels/user-accounts/um-user-panel.c:1389
+#: ../panels/user-accounts/um-user-panel.c:1684
+#, fuzzy
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Chun an úsáideoir roghnaithe a scriosadh,\n"
+"cliceáil an deilbhín * ar dtús"
+
+#: ../panels/user-accounts/um-user-panel.c:1593
+msgid "My Account"
+msgstr "Mo Chuntas"
+
+#: ../panels/user-accounts/um-utils.c:563
+#, fuzzy, c-format
+msgid "A user with the username '%s' already exists."
+msgstr "Tá comhad darb ainm \"%s\" ann cheana."
+
+#: ../panels/user-accounts/um-utils.c:567
+#, fuzzy, c-format
+msgid "The username is too long."
+msgstr "Tá an t-ainm úsáideora ró-fhada"
+
+#: ../panels/user-accounts/um-utils.c:570
+msgid "The username cannot start with a '-'."
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:573
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:577
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:823
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr ""
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr ""
+
+#: ../panels/wacom/button-mapping.ui.h:4
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Chun eochair aicearra a chur in eagar, cliceáil ar an ró comhfhreagrach agus "
+"clóscríobh teaglaim eochracha nua, nó brúigh backspace chun glanta."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "Suas"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "Síos"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "Neamhní"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+#, fuzzy
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Monatóir"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "Aschur:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr ""
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d as %d"
+
+#: ../panels/wacom/cc-wacom-page.c:522
+#, fuzzy
+msgid "Display Mapping"
+msgstr "Taispeáint"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:377
+msgid "Button"
+msgstr "Cnaipe"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Wacom Tablet"
+msgstr "Táibléad Wacom"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Táibléad;Wacom;Stíleas;Scriosán;Luch;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "Sainroghanna Táibléid"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+#, fuzzy
+msgid "_Help"
+msgstr "Cabhair"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "No tablet detected"
+msgstr "Níor braitheadh aon táibléad"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Ionsuigh nó cuir do tháibléad Wacom ar siúl"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Bluetooth Settings"
+msgstr "Socruithe Bluetooth"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map to Monitor…"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+#, fuzzy
+msgid "Map Buttons…"
+msgstr "Roghanna..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust display resolution"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+#, fuzzy
+msgid "Adjust mouse settings"
+msgstr "Socruithe Luiche"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Tracking Mode"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:16
+msgid "Left-Handed Orientation"
+msgstr ""
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1028
+#, fuzzy
+msgid "Left Ring"
+msgstr "Méar an fháinne chlé"
+
+#: ../panels/wacom/gsd-wacom-device.c:1039
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr ""
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1059
+#, fuzzy
+msgid "Right Ring"
+msgstr "Méar an fháinne dheas"
+
+#: ../panels/wacom/gsd-wacom-device.c:1070
+#, fuzzy, c-format
+msgid "Right Ring Mode #%d"
+msgstr "Méar an fháinne dheas"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1112
+msgid "Left Touchstrip"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1123
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr ""
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1143
+msgid "Right Touchstrip"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1154
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1180
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1182
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1185
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1187
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1192
+#, c-format
+msgid "Mode Switch #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1300
+#, c-format
+msgid "Left Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1303
+#, c-format
+msgid "Right Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1306
+#, c-format
+msgid "Top Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1309
+#, c-format
+msgid "Bottom Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+#, fuzzy
+msgid "New shortcut…"
+msgstr "Aicearra nua..."
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+#, fuzzy
+msgid "No Action"
+msgstr "Gníomh"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+#, fuzzy
+msgid "Scroll Up"
+msgstr "Scrollú"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+#, fuzzy
+msgid "Scroll Down"
+msgstr "Scrollú"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+#, fuzzy
+msgid "Scroll Left"
+msgstr "Scrollú"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+#, fuzzy
+msgid "Scroll Right"
+msgstr "Scrollú"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
+msgid "GNOME Control Center"
+msgstr ""
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
+msgid "Utilities to configure the GNOME desktop"
+msgstr ""
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
+msgid ""
+"The control center is GNOME's main interface for configuration of various "
+"aspects of your desktop."
+msgstr ""
+
+#: ../shell/cc-application.c:45
+#, fuzzy
+msgid "Display version number"
+msgstr "Taispeáin Gile"
+
+#: ../shell/cc-application.c:46
+msgid "Enable verbose mode"
+msgstr "Cumasaigh mód foclach"
+
+#: ../shell/cc-application.c:47
+msgid "Show the overview"
+msgstr "Taispeáin an foramharc"
+
+#: ../shell/cc-application.c:48
+msgid "Search for the string"
+msgstr ""
+
+#: ../shell/cc-application.c:49
+msgid "List possible panel names and exit"
+msgstr ""
+
+#: ../shell/cc-application.c:50
+msgid "Panel to display"
+msgstr "Painéal le taispeáint"
+
+#: ../shell/cc-application.c:50
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PAINÉAL] [ARGÓINT…]"
+
+#: ../shell/cc-application.c:113
+msgid "Available panels:"
+msgstr "Painéil atá ar fáil:"
+
+#: ../shell/cc-application.c:251
+msgid "Help"
+msgstr "Cabhair"
+
+#: ../shell/cc-application.c:252
+msgid "Quit"
+msgstr "Scoir"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1494
+msgid "All Settings"
+msgstr "Gach Socrú"
+
+#. Add categories
+#: ../shell/cc-window.c:880
+msgctxt "category"
+msgid "Personal"
+msgstr "Pearsanta"
+
+#: ../shell/cc-window.c:881
+msgctxt "category"
+msgid "Hardware"
+msgstr "Crua-Earraí"
+
+#: ../shell/cc-window.c:882
+msgctxt "category"
+msgid "System"
+msgstr "Córas"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "Sainroghanna;Socruithe;"

--- a/po/gd.po
+++ b/po/gd.po
@@ -7,9 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-04-07 11:50+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2018-02-26 12:42+0100\n"
 "Last-Translator: GunChleoc <fios@foramnagaidhlig.net>\n"
 "Language-Team: Fòram na Gàidhlig\n"
@@ -23,112 +22,7 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-04-20 12:56+0000\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:803
-#, fuzzy
-#| msgid "System Sounds"
-msgid "System Bus"
-msgstr "Fuaimean an t-siostaim"
-
-#: panels/applications/cc-applications-panel.c:803
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:823
-#, fuzzy
-#| msgid "_Full Name"
-msgid "Full access"
-msgstr "Ainm _slàn"
-
-#: panels/applications/cc-applications-panel.c:805
-#, fuzzy
-#| msgid "Session Ended"
-msgid "Session Bus"
-msgstr "Thàinig an seisean gu crìoch"
-
-#: panels/applications/cc-applications-panel.c:809
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Innleadan"
-
-#: panels/applications/cc-applications-panel.c:809
-msgid "Full access to /dev"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:813
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Lìonra"
-
-#: panels/applications/cc-applications-panel.c:813
-#, fuzzy
-#| msgid "Network Name"
-msgid "Has network access"
-msgstr "Ainm an lìonraidh"
-
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:820
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Dhachaigh"
-
-#: panels/applications/cc-applications-panel.c:820
-#: panels/applications/cc-applications-panel.c:825
-#, fuzzy
-#| msgctxt "printer state"
-#| msgid "Ready"
-msgid "Read-only"
-msgstr "Deiseil"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-#, fuzzy
-#| msgid "Open System"
-msgid "File System"
-msgstr "Siostam fosgailte"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Roghainnean"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Can change settings"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:831
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1164
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: panels/applications/cc-applications-panel.c:1171
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1223
-#, c-format
-msgid "%s of disk space used"
-msgstr ""
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1387
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -137,32 +31,31 @@ msgstr "Aplacaidean"
 
 #: panels/applications/cc-applications-panel.ui:31
 #, fuzzy
-#| msgid "No applications found"
 msgid "No applications"
 msgstr "Cha deach aplacaid sam bith a lorg"
 
 #: panels/applications/cc-applications-panel.ui:34
 #, fuzzy
-#| msgid "Install PPD File…"
 msgid "Install some…"
 msgstr "Stàlaich faidhle PPD…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 #, fuzzy
-#| msgid "_Open"
 msgid "Open"
 msgstr "F_osgail"
 
 #: panels/applications/cc-applications-panel.ui:94
 #, fuzzy
-#| msgid "_View details"
 msgid "View Details"
 msgstr "_Seall am mion-fhiosrachadh"
 
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Lorg"
@@ -172,24 +65,13 @@ msgstr "Lorg"
 msgid "Receive system searches and send results."
 msgstr ""
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "À comas"
 
@@ -200,14 +82,12 @@ msgstr "Brathan"
 
 #: panels/applications/cc-applications-panel.ui:127
 #, fuzzy
-#| msgid "Show _Notifications"
 msgid "Show system notifications."
 msgstr "Seall _na brathan"
 
 #: panels/applications/cc-applications-panel.ui:133
 #, fuzzy
-#| msgid "Current background"
-msgid "Run in background"
+msgid "Run in Background"
 msgstr "An cùlaibh làithreach"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -215,150 +95,151 @@ msgid "Allow activity when the app is closed."
 msgstr ""
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Glacaidhean-sgrìn"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
 #, fuzzy
-#| msgid "Wallpapers"
 msgid "Change Wallpaper"
 msgstr "Pàipearan-balla"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 #, fuzzy
-#| msgid "preferences-desktop-wallpaper"
 msgid "Change the desktop wallpaper."
 msgstr "preferences-desktop-wallpaper"
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 #, fuzzy
-#| msgid "Sound"
 msgid "Sounds"
 msgstr "Fuaim"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 #, fuzzy
-#| msgid "Set Shortcut"
 msgid "Inhibit Shortcuts"
 msgstr "Suidhich ath-ghoirid"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 #, fuzzy
-#| msgid "No keyboard shortcut found"
 msgid "Block standard keyboard shortcuts."
 msgstr "Cha deach ath-ghoirid a’ mheur-chlàir a lorg"
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "%s Camera"
 msgid "Camera"
 msgstr "Camara %s"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Seirbheisean ionaid"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 #, fuzzy
-#| msgid "Built-in Webcam"
 msgid "Built-in Permissions"
 msgstr "Camara-lìn ’na bhroinn"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Cha deach toradh a lorg"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Feuch lorg eile"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 #, fuzzy
-#| msgid "Display Type"
 msgid "File Types"
 msgstr "Seòrsa an uidheim-thaisbeanaidh"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 #, fuzzy
-#| msgid "Link speed"
 msgid "Link Types"
 msgstr "Astar a’ cheangail"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Ath-shuidhich"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 #, fuzzy
-#| msgid "Applications"
 msgid "Application"
 msgstr "Aplacaidean"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr ""
 
@@ -366,99 +247,34 @@ msgstr ""
 msgid "Control various application permissions and settings"
 msgstr ""
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 
-#: panels/background/cc-background-chooser.c:307
-#, fuzzy
-#| msgid "Select a File…"
-msgid "Select a picture"
-msgstr "Tagh faidhle…"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "_Sguir dheth"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:524
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "F_osgail"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "iomadh meud"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Chan eil cùlaibh aig an deasga"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "An cùlaibh làithreach"
-
 #: panels/background/cc-background-panel.ui:9
 #, fuzzy
-#| msgid "Stylus"
 msgid "Style"
 msgstr "Staidhleas"
 
-#: panels/background/cc-background-panel.ui:45
-#, fuzzy
-#| msgid "Right"
-msgid "Light"
-msgstr "Deas"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Bun-roghainn"
 
-#: panels/background/cc-background-panel.ui:72
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr ""
 
-#: panels/background/cc-background-panel.ui:91
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Cùlaibh"
 
-#: panels/background/cc-background-panel.ui:97
+#: panels/background/cc-background-panel.ui:104
 #, fuzzy
-#| msgid "Add a Printer…"
 msgid "Add Picture…"
 msgstr "Cuir clò-bhualadair ris…"
 
@@ -468,61 +284,65 @@ msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:4
 #, fuzzy
-#| msgid "Change your background image to a wallpaper or photo"
 msgid "Change your background image or the UI colors"
 msgstr "Cleachd pàipear-balla no dealbh mar chùlaibh"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 #, fuzzy
-#| msgid "Wallpaper;Screen;Desktop;"
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Wallpaper;Screen;Desktop;pàipear-balla;sgrìn;deasg;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "_Cuir an comas"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Cha deach Bluetooth a lorg"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Ceangail dongle gus Bluetooth a chleachdadh."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Tha Bluetooth dheth"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 "Cuir air e gus uidheaman a cheangal is tar-chuir fhaidhlichean fhaighinn."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 #, fuzzy
-#| msgid "Airplane Mode is on"
 msgid "Airplane Mode is On"
 msgstr "Tha am modh itealain air"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Tha Bluetooth à comas fhad ’s a tha am modh itealain air."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Cuir am modh itealain dheth"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 #, fuzzy
-#| msgid "Hardware Airplane Mode is on"
 msgid "Hardware Airplane Mode is On"
 msgstr "Tha modh itealain a’ bhathair-chruaidh air"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Cuir suidse a’ mhodh itealain dheth gus Bluetooth a chur an comas."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -530,25 +350,22 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Cuir Bluetooth air is dheth is ceangail na h-uidheaman agad ris"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;co-roinn;co-roinneadh;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 #, fuzzy
-#| msgid "Bluetooth Turned Off"
 msgid "Camera is Turned Off"
 msgstr "Tha Bluetooth dheth"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 #, fuzzy
-#| msgid "No application is currently playing or recording audio."
 msgid "No applications can capture photos or video."
 msgstr ""
 "Chan eil aplacaid sam bith a’ cluich no a’ clàradh fuaime an-dràsta fhèin."
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
@@ -556,113 +373,42 @@ msgid ""
 "Allow the applications below to use your camera."
 msgstr ""
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr ""
 
 #: panels/camera/gnome-camera-panel.desktop.in.in:4
 #, fuzzy
-#| msgid "Browse for more pictures"
 msgid "Protect your pictures"
 msgstr "Brabhsaich airson barrachd dhealbhan"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;sgrìn;glas;diagnosachd;tuisleadh;prìobhaideach;sealach;"
-"inneacs;lìonra;ainm;dearbh-aithne;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Cuir an t-uidheam cailbhreachaidh agad os cionn na ceàrnaige is brùth air "
-"“Tòisich”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Gluais an t-uidheam cailbhreachaidh agad dhan ionad chailbhreachaidh is "
-"brùth air “Air adhart”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Gluais an t-uidheam cailbhreachaidh agad dhan ionad uachdair is brùth air "
-"“Air adhart”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Dùin mullach an laptop"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Thachair mearachd inntearnail nach b’ urrainn dhuinn càradh."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr ""
-"Cha deach na h-innealan a stàladh air a bheil feum airson cailbhreachadh."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Cha b’ urrainn dhuinn a’ phròifil a ghintinn."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Cha d’fhuair sinn greim air geal-phuing na targaide."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Deiseil!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Dh’fhàillig an cailbhreachadh!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "’S urrainn dhut an t-uidheam cailbhreachaidh a thoirt air falbh a-nis."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Na bean ris an uidheam chailbhreachaidh fhad ’s a tha e trang"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Cailbhreachadh an uidheim-thaisbeanaidh"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Sguir dheth"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -676,143 +422,9 @@ msgstr "_Lean air"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Deiseil"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Sgrìn laptop"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Camara-lìn ’na bhroinn"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monatair %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Sganair %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Camara %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Clò-bhualadair %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Camara-lìn %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Cuir an comas stiùireadh dhathan airson %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Seall na pròifilean dhathan airson %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Cha deach a chailbhreachadh"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Tùsail: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Spàs nan dathan: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Pròifil deuchainne: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Tagh faidhle pròifil ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Ion-phortaich"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Pròifilean ICC ris a bheil taic"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "A h-uile faidhle"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Sgrìn"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Sàbhail a’ phròifil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Sàbhail"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Cruthaich pròifil dhathan airson an uidheim a thagh thu"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Cha do mhothaich sinn ri inneal tomhais. Dèan cinnteach gu bheil e air agus "
-"ceangailte ris mar bu chòir."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-"Chan eil an t-inneal tomhais a’ cur taic ri pròifileadh chlò-bhualadairean."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Chan eil taic ris an t-seòrsa seo a dh’uidheam aig an àm seo."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -934,9 +546,9 @@ msgstr "Feumaidh seo meadhan as urrainnear sgrìobhadh air"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Dh’fhaoidte gum bi an stiùireadh seo a thaobh mar a chleachdar na pròifilean "
 "seo air <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> agus "
@@ -959,8 +571,8 @@ msgid "_Import File…"
 msgstr "_Ion-phortaich faidhle…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "_Cuir ris"
@@ -971,9 +583,7 @@ msgstr ""
 "Feumaidh pròifil dhathan cho ùr ’s a ghabhas a bhith aig gach uidheam mus "
 "gabh an dath a stiùireadh."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Barrachd fiosrachaidh"
 
@@ -1109,82 +719,6 @@ msgstr "D65 (fotografachd is grafaigeachd)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Spàs stannardach"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Pròifil deuchainne"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Fèin-obrachail"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Càileachd ìseal"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Càileachd mheadhanach"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Càileachd àrd"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB tùsail"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK tùsail"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Liath tùsail"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Dàta cailbhreachaidh tùsail a sholair an reiceadair"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Cha ghabh ceartachadh taisbeanadh làn-sgrìn a dhèanamh sa phròifil seo"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Dh’fhaoidte nach eil a’ phròifil seo ceart tuilleadh"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Dath"
@@ -1196,20 +730,14 @@ msgstr ""
 "Cailbhrich dathan nan uidheaman agad, can uidheaman-taisbeanaidh, camarathan "
 "no clò-bhualadairean"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Color;ICC;Profile;Calibrate;Printer;Display;dath;ICC;pròifil;cailbhrich;"
 "cailbhreachadh;clò-bhualadair;taisbeanadh;uidheam-taisbenaidh;sgrìn;"
 
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Eile…"
-
 #: panels/common/cc-language-chooser.ui:5
 #, fuzzy
-#| msgid "Language"
 msgid "Select Language"
 msgstr "Cànan"
 
@@ -1222,23 +750,15 @@ msgid "No languages found"
 msgstr "Cha deach cànan a lorg"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Barrachd…"
 
-#: panels/common/cc-permission-infobar.c:109
-#, fuzzy
-#| msgid "Bluetooth Settings"
-msgid "Unlock to Change Settings"
-msgstr "Roghainnean Bluetooth"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr ""
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 #, fuzzy
-#| msgid "_Unlock"
 msgid "Unlock…"
 msgstr "_Thoir a’ ghlas dheth"
 
@@ -1261,167 +781,6 @@ msgstr ""
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr ""
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "An-diugh"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "An-dè"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#: panels/common/cc-util.c:165
-#, fuzzy, c-format
-#| msgid "%i hour"
-#| msgid_plural "%i hours"
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%i uair a thìde"
-msgstr[1] "%i uair a thìde"
-msgstr[2] "%i uairean a thìde"
-msgstr[3] "%i uair a thìde"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, fuzzy, c-format
-#| msgid "%i minute"
-#| msgid_plural "%i minutes"
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%i mhionaid"
-msgstr[1] "%i mhionaid"
-msgstr[2] "%i mionaidean"
-msgstr[3] "%i mionaid"
-
-#: panels/common/cc-util.c:167
-#, fuzzy, c-format
-#| msgid "30 seconds"
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "30 diog"
-msgstr[1] "30 diog"
-msgstr[2] "30 diog"
-msgstr[3] "30 diog"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, fuzzy, c-format
-#| msgid "%i %s %i %s"
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%i %s %i %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, fuzzy, c-format
-#| msgid "%i %s %i %s"
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%i %s %i %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr ""
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, fuzzy, c-format
-#| msgid "%i %s %i %s"
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%i %s %i %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr ""
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-#, fuzzy
-#| msgid "30 seconds"
-msgid "0 seconds"
-msgstr "30 diog"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 uairean"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "m/f"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %P"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %P"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1498,7 +857,6 @@ msgstr "Lorg baile"
 
 #: panels/datetime/cc-datetime-panel.ui:164
 #, fuzzy
-#| msgid "Automatic _Date & Time"
 msgid "Automatic _Date &amp; Time"
 msgstr "Ceann-là ⁊ an t-àm gu _fèin-obrachail"
 
@@ -1506,35 +864,68 @@ msgstr "Ceann-là ⁊ an t-àm gu _fèin-obrachail"
 msgid "Requires internet access"
 msgstr "Tha feum air an eadar-lìon"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 #, fuzzy
-#| msgid "Date & _Time"
 msgid "Date &amp; _Time"
 msgstr "Ceann-là ⁊ an t-àm"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "An _roinn-tìde gu fèin-obrachail"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 #, fuzzy
-#| msgid "Requires internet access"
 msgid "Requires location services enabled and internet access"
 msgstr "Tha feum air an eadar-lìon"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "An comas"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "R_oinn-tìde"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "_Thoir a’ ghlas dheth"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Fòrmat an ama"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Cinn-là"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "30 diog"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Mìosachan"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Àireamhan"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Atharraich an ceann-là ’s an t-àm, a’ gabhail a-steach na roinne-tìde"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;gleoc;cleoc;roinn-tìde;ionad;àite;"
@@ -1582,26 +973,11 @@ msgstr "Aplacaidean tùsail"
 msgid "Configure Default Applications"
 msgstr "Rèitich na h-placaidean tùsail"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "default;application;preferred;media;tùsail;bun-roghainn;bunaiteach;aplacaid;"
 "nas fheass;as fhearr;meadhan;meadhanan;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, fuzzy, c-format
-#| msgid ""
-#| "Sending reports of technical problems helps us improve %s. Reports are "
-#| "sent anonymously and are scrubbed of personal data."
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Ma chuireas tu aithrisean air duilgheadasan teicnigeach a-null, cuidichidh "
-"seo ach an leasaich sinn %s. Thèid na h-aithrisean a chur gun urra agus gach "
-"dàta pearsanta a thoirt air falbh uapa."
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1619,56 +995,8 @@ msgstr ""
 msgid "Report your problems"
 msgstr ""
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-#, fuzzy
-#| msgid ""
-#| "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-#| "network;identity;"
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;sgrìn;glas;diagnosachd;tuisleadh;prìobhaideach;sealach;"
-"inneacs;lìonra;ainm;dearbh-aithne;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Air"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Dheth"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "A bheil thu airson na h-atharraichean a chur an sàs?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr ""
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
+msgid "diagnostics;crash;"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:43
@@ -1676,112 +1004,111 @@ msgstr ""
 msgid "_Apply"
 msgstr "Cuir _an sàs"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Air ais"
+
+#: panels/display/cc-display-panel.ui:100
 #, fuzzy
-#| msgid "Bluetooth is disabled"
 msgid "Display Settings Disabled"
 msgstr "Tha Bluetooth à comas"
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "Rian nan uidheaman-taisbeanaidh"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 #, fuzzy
-#| msgid "Single Display"
 msgid "Multiple Displays"
 msgstr "Mar aon uidheam-taisbeanaidh"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Sgàthanaich"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Am prìomh uidheam-taisbeanaidh"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Solas oidhche"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Dreach-tìre"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Portraid dheas"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Portraid chlì"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Dreach-tìre (air a chuairteachadh)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 #, fuzzy
-#| msgid "Orientation"
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Comhair"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 #, fuzzy
-#| msgid "Resolution"
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Dùmhlachd-bhreacaidh"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Tricead an ath-nuadhachaidh"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Gleus airson TBh"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 #, fuzzy
-#| msgid "Scale"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Sgèile"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Sgroladh nàdarra"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Solas oidhche"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "À comas greis gu ruige a-màireach"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "Ath-thòisich a’ chriathrag"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1789,61 +1116,60 @@ msgstr ""
 "Nì an solas oidhche dath na sgrìn nas blàithe. Cuidichidh seo an aghaidh "
 "sgìths nan sùilean agus bacadh-cadail."
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Sgeideal"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "O laighe gu èirigh na grèine"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 #, fuzzy
-#| msgid "Schedule"
 msgid "Manual Schedule"
 msgstr "Sgeideal"
 
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Amannan"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "O"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Uair"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Mionaid"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "m"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "f"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Gu"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr ""
 
@@ -1857,7 +1183,6 @@ msgstr ""
 "Tagh mar a thèid monatairean is proiseactaran a tha ceangailte ris a "
 "chleachdadh"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1867,66 +1192,65 @@ msgstr ""
 "tilgear;sgrìn;dùmhlachd-bhreacaidh;ath-nuadhaich;ath-nuadhachadh;monatar;"
 "solar;oidhche;gorm;dearg;dath;laighe na grèine;èirigh na grèine;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Chan eil fhios"
-
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; ID na togail: %s"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64-biod"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32-biod"
-
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:726
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
 #, fuzzy
-#| msgid "Unknown"
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Chan eil fhios"
+msgid "Security Level"
+msgstr "Seòrsa na tèarainteachd"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
 #, fuzzy
-#| msgid "System"
-msgid "System Logo"
-msgstr "Siostam"
+msgid "Level 1"
+msgstr "Ìre na h-ince"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Ìre na h-ince"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Ìre na h-ince"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Tèarainteachd"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;sgrìn;glas;diagnosachd;tuisleadh;prìobhaideach;sealach;"
+"inneacs;lìonra;ainm;dearbh-aithne;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 #, fuzzy
-#| msgid "Device name"
 msgid "Device Name"
 msgstr "Ainm an uidheim"
 
 #: panels/info-overview/cc-info-overview-panel.ui:50
 #, fuzzy
-#| msgid "Hardware Address"
 msgid "Hardware Model"
 msgstr "Seòladh bathair-chruaidh"
 
@@ -1953,53 +1277,63 @@ msgstr "’Ga àireamhachadh…"
 #. translators: this field contains the distro name and version
 #: panels/info-overview/cc-info-overview-panel.ui:98
 #, fuzzy
-#| msgid "Name"
 msgid "OS Name"
 msgstr "Ainm"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
 #, fuzzy
-#| msgid "VPN Type"
+msgid "OS Build ID"
+msgstr "%s; ID na togail: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
 msgid "OS Type"
 msgstr "Seòrsa an VPN"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 #, fuzzy
-#| msgid "Version 0"
 msgid "GNOME Version"
 msgstr "Tionndadh 0"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
 #, fuzzy
-#| msgid "Windows software"
+msgid "Loading…"
+msgstr "A' luchdadh nan roghainnean…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
 msgid "Windowing System"
 msgstr "Bathar-bog Windows"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Biortaileachadh"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 #, fuzzy
-#| msgid "Software Usage"
 msgid "Software Updates"
 msgstr "Cleachdadh bathair-bhog"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 #, fuzzy
-#| msgid "Remove Device"
 msgid "Rename Device"
 msgstr "Thoirt an t-uidheam air falbh"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
 #, fuzzy
-#| msgid "_Username"
+msgid "Device name"
+msgstr "Ainm an uidheim"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
 msgid "_Rename"
 msgstr "_Ainm-cleachdaiche"
 
@@ -2011,16 +1345,8 @@ msgstr "Mu dhèidhinn"
 msgid "View information about your system"
 msgstr "Seall fiosrachadh mun t-siostam agad"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 #, fuzzy
-#| msgid ""
-#| "device;system;information;memory;processor;version;default;application;"
-#| "preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
 "application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
@@ -2036,7 +1362,6 @@ msgstr "Fuaim agus meadhanan"
 
 #: panels/keyboard/00-multimedia.xml.in:4
 #, fuzzy
-#| msgid "Volume mute"
 msgid "Volume mute/unmute"
 msgstr "Mùch an fhuaim"
 
@@ -2101,6 +1426,12 @@ msgstr "Lòinsearan"
 msgid "Launch help browser"
 msgstr "Cuir gu dol brabhsair na cobharach"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Roghainnean"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Cuir gu dol an t-àireamhair"
@@ -2122,7 +1453,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Lorg"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Siostam"
 
@@ -2171,20 +1502,11 @@ msgstr "Dèan an teacsa nas lugha"
 msgid "High contrast on or off"
 msgstr "Iomsgaradh àrd air no dheth"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Cha deach tùs ion-chuir a lorg"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Eile"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Cuir tùs ion-chuir ris"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Cha ghabh dòighean ion-chuir a chleachdadh air an sgrìn chlàraidh"
 
@@ -2192,137 +1514,30 @@ msgstr "Cha ghabh dòighean ion-chuir a chleachdadh air an sgrìn chlàraidh"
 msgid "No input source selected"
 msgstr "Cha deach tùs ion-chuir a thaghadh"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Roghainnean"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "Gluais suas"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "Gluais sìos"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Roghainnean"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "View Keyboard Layout"
 msgstr "Ath-ghoiridean a’ mheur-chlàir"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Thoir air falbh"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Ath-ghoiridean gnàthaichte"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-#, fuzzy
-#| msgid "Alternative Characters Key"
-msgid "Alternate Characters Key"
-msgstr "Roghainn eile de dh’iuchair caractair"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-#, fuzzy
-#| msgid "Left+Right Alt"
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt clì + deas"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-#, fuzzy
-#| msgid "Left+Right Alt"
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt clì + deas"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-#, fuzzy
-#| msgid "Left thumb"
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "An òrdag chlì"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-#, fuzzy
-#| msgid "Right thumb"
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "An òrdag dheas"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-#, fuzzy
-#| msgid "Security key"
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "An iuchair tèarainteachd"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-#, fuzzy
-#| msgid "Right Half"
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "An leth dheas"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Iuchair Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-#, fuzzy
-#| msgid "Scroll Left"
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Sgrolaich dhan taobh chlì"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-#, fuzzy
-#| msgid "Login _Screen"
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "_Sgrìn a’ chlàraidh a-steach"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, fuzzy, c-format
-#| msgid "You can change these shortcuts in the keyboard settings"
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"’S urrainn dhut na h-ath-ghoiridean seo atharrachadh ann an roghainnean a’ "
-"mheur-chlàir"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2334,7 +1549,6 @@ msgstr ""
 
 #: panels/keyboard/cc-keyboard-panel.ui:28
 #, fuzzy
-#| msgid "Input Source Options"
 msgid "Input Source Switching"
 msgstr "Roghainnean nan tùsan ion-chuir"
 
@@ -2344,63 +1558,34 @@ msgstr "Cleachd an aon tù_s airson gach uinneag"
 
 #: panels/keyboard/cc-keyboard-panel.ui:43
 #, fuzzy
-#| msgid "Allow _different sources for each window"
 msgid "Switch input sources _individually for each window"
 msgstr "Ceadaich _diofar tùsan airson gach uinneag"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "Roghainn eile de dh’iuchair caractair"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Iuchair Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Ath-ghoiridean a’ mheur-chlàir"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 #, fuzzy
-#| msgid "Custom Shortcuts"
 msgid "View and Customize Shortcuts"
 msgstr "Ath-ghoiridean gnàthaichte"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
-msgid "Reset All Shortcuts?"
-msgstr "A bheil thu airson na h-ath-ghoiridean uile ath-shuidheachadh?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Ma nì thu ath-shuidheachadh air na h-ath-ghoiridean agad, dh’fhaoidte gum bi "
-"buaidh air sin air na h-ath-ghoiridean gnàthaichte agad. Cha ghabh sin a neo-"
-"dhèanamh."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Sguir dheth"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
-msgid "Reset All"
-msgstr "Ath-shuidhich na h-uile"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2410,99 +1595,80 @@ msgstr "Ath-shuidhich na h-uile…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Ath-shuidhich na h-ath-ghoiridean uile air an luachan tùsail"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Earrann"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 #, fuzzy
-#| msgid "Add Custom Shortcut"
+msgid "Shortcuts"
+msgstr "Ath-ghoirid"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Cuir ath-ghoirid ris"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
 msgid "Add Custom Shortcuts"
 msgstr "Cuir ath-ghoirid ghnàthaichte ris"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Cuir ath-ghoirid ris"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Cha deach ath-ghoirid a’ mheur-chlàir a lorg"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, fuzzy, c-format
-#| msgid ""
-#| "%s is already being used for <b>%s</b>. If you replace it, %s will be "
-#| "disabled"
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"Tha %s ’ga chleachdadh airson <b>%s</b> mar-thà. Ma chuireas tu rud ’na "
-"àite, thèid %s a chur à comas"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Thoir air falbh"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Cuir a-steach an ath-ghoirid ùr"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Suidhich ath-ghoirid ghnàthaichte"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Suidhich ath-ghoirid"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, fuzzy, c-format
-#| msgid "Enter new shortcut to change <b>%s</b>."
-msgid "Enter new shortcut to change %s."
-msgstr "Cuir a-steach an ath-ghoirid a dh’atharrachadh <b>%s</b>."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Cuir ath-ghoirid ghnàthaichte ris"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Cuir ris"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
 msgstr "Cuir ’na àite"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "Suidhich"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 #, fuzzy
-#| msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Brùth air Esc airson sgud dheth no air Backspace gus ath-ghoirid a’ mheur-"
 "chlàir ath-shuidheachadh."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Ainm"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Àithne"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Ath-ghoirid"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Suidhich ath-ghoirid…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Chan eil gin"
 
@@ -2510,13 +1676,17 @@ msgstr "Chan eil gin"
 msgid "Reset the shortcut to its default value"
 msgstr "Ath-shuidhich an ath-ghoirid air a luach tùsail"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Cleachd an clò-bhualadair seo a gnàth"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Meur-chlàr"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
 #, fuzzy
-#| msgid "View and change keyboard shortcuts and set your typing preferences"
 msgid ""
 "Change keyboard shortcuts and set your typing preferences, keyboard layouts "
 "and input sources"
@@ -2524,7 +1694,6 @@ msgstr ""
 "Seall is atharraich ath-ghoiridean a’ mheur-chlàir agad is suidhich na "
 "roghainnean sgrìobhaidh agad"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2533,20 +1702,18 @@ msgstr ""
 "ghoirid;rum-obrach;uinneag;meud;meudaich;ath-mheudaich;ath-mheudachadh;sùm;"
 "iomsgaradh;ion-chur;cur a-steach;cuir a-steach;tùs;glas;glais;iom-dhraibh;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 #, fuzzy
-#| msgid "Location Services"
 msgid "Location Services Turned Off"
 msgstr "Seirbheisean ionaid"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 #, fuzzy
-#| msgid "No application is currently playing or recording audio."
 msgid "No applications can obtain location information."
 msgstr ""
 "Chan eil aplacaid sam bith a’ cluich no a’ clàradh fuaime an-dràsta fhèin."
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2557,7 +1724,7 @@ msgid ""
 "Allow the applications below to determine your location."
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr ""
 
@@ -2565,221 +1732,21 @@ msgstr ""
 msgid "Protect your location information"
 msgstr ""
 
-#. FIXME
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-#, fuzzy
-#| msgid "Screen Turns Off"
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Thèid na sgrìnichean dheth"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-#, fuzzy
-#| msgid "30 seconds"
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 diog"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-#, fuzzy
-#| msgid "1 minute"
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 mhionaid"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-#, fuzzy
-#| msgid "2 minutes"
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 mhionaid"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-#, fuzzy
-#| msgid "3 minutes"
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 mionaidean"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-#, fuzzy
-#| msgid "5 minutes"
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 mionaidean"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-#, fuzzy
-#| msgid "30 minutes"
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "Leth-uair a thìde"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-#, fuzzy
-#| msgid "1 hour"
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 uair a thìde"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-#, fuzzy
-#| msgid "1 minute"
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 mhionaid"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-#, fuzzy
-#| msgid "2 minutes"
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 mhionaid"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-#, fuzzy
-#| msgid "3 minutes"
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 mionaidean"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-#, fuzzy
-#| msgid "4 minutes"
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 mionaidean"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-#, fuzzy
-#| msgid "5 minutes"
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 mionaidean"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-#, fuzzy
-#| msgid "8 minutes"
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 mionaidean"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-#, fuzzy
-#| msgid "10 minutes"
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 mionaidean"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-#, fuzzy
-#| msgid "12 minutes"
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 mhionaid"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-#, fuzzy
-#| msgid "15 minutes"
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "Cairteal na h-uarach"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-#, fuzzy
-#| msgid "Never"
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Chan ann idir"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
 
-#: panels/lock/cc-lock-panel.ui:13
+#: panels/microphone/cc-microphone-panel.ui:23
 #, fuzzy
-#| msgid "_Blank screen"
-msgid "Blank Screen Delay"
-msgstr "Sgrìn _bhàn"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "G_las fhèin-obrachail na sgrìn"
-
-#: panels/lock/cc-lock-panel.ui:46
-#, fuzzy
-#| msgid "Automatic Screen _Lock"
-msgid "Automatic _Screen Lock Delay"
-msgstr "G_las fhèin-obrachail na sgrìn"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:65
-#, fuzzy
-#| msgid "Show _Notifications"
-msgid "Show _Notifications on Lock Screen"
-msgstr "Seall _na brathan"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Glas na sgrìn"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-#, fuzzy
-#| msgid "Lock screen"
-msgid "Lock your screen"
-msgstr "Glais an sgrìn"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:20
-#, fuzzy
-#| msgid "Screen Turns Off"
 msgid "Microphone Turned Off"
 msgstr "Thèid na sgrìnichean dheth"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 #, fuzzy
-#| msgid "No applications found"
 msgid "No applications can record sound."
 msgstr "Cha deach aplacaid sam bith a lorg"
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2788,7 +1755,7 @@ msgid ""
 "Allow the applications below to use your microphone."
 msgstr ""
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr ""
 
@@ -2796,7 +1763,10 @@ msgstr ""
 msgid "Protect your conversations"
 msgstr ""
 
-#. FIXME
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Cuir na roghainnean agad fo dheuchainn"
@@ -2816,83 +1786,149 @@ msgstr ""
 "Suidhichidh seo òrdugh nam putanan fiosaigeach air luchagan is padaichean-"
 "suathaidh."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Clì"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Deas"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Ionadan luirg"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Luchag"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Luaths na luchaige"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "Sgroladh nàdarra"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Sgrolaich sìos"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Gluaisidh an sgroladh an t-susbaint ’s cha ghluais an sealladh."
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Gluaisidh an sgroladh an t-susbaint ’s cha ghluais an sealladh."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Gnìomhach"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Pada-suathaidh"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Luaths a’ phada-shuathaidh"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Thoir gnogag airson briogadh"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "Sgroladh dà-chorragach"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Thoir gnogag airson briogadh"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Cuir an dealbh à comas"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Pada-suathaidh (dàimheach)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Sgroladh oir"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Sgrolaich sìos"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dà-thaobhach"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Feuch briogadh, briogadh dùbailte agus sgroladh"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Còig briogaidhean, àm GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Briogadh dùbailte, prìomh-phutan"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Briogadh singilte, prìomh-phutan"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Briogadh dùbailte, putan meadhain"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Briogadh singilte, putan meadhain"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Briogadh dùbailte, an dàrna putan"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Briogadh singilte, an dàrna putan"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2905,7 +1941,6 @@ msgstr ""
 "Atharraich mothalachd na luchaige no a’ phada-suathaidh agad is tagh tè "
 "deas- no chlì-làmhach"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -2931,7 +1966,6 @@ msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:70
 #, fuzzy
-#| msgid "Colorspace: "
 msgid "Workspaces"
 msgstr "Spàs nan dathan: "
 
@@ -2941,7 +1975,6 @@ msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:77
 #, fuzzy
-#| msgid "Automatically empty _Trash"
 msgid "Automatically removes empty workspaces."
 msgstr "Fa_lamhaich an sgudal gu fèin-obrachail"
 
@@ -2959,7 +1992,6 @@ msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:124
 #, fuzzy
-#| msgid "%s Monitor"
 msgid "Multi-Monitor"
 msgstr "Monatair %s"
 
@@ -2973,8 +2005,6 @@ msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:184
 #, fuzzy
-#| msgctxt "Wacom action-type"
-#| msgid "Application defined"
 msgid "Application Switching"
 msgstr "A-rèir na h-aplacaid"
 
@@ -2994,87 +2024,39 @@ msgstr ""
 msgid "Manage preferences for productivity and multitasking"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Ìoc, chaidh rudeigin cearr. Cuir fios gu reiceadair a’ bhathair-bhog agad."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Feumaidh NetworkManager a bhith a’ ruith."
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 #, fuzzy
-#| msgid "Devices"
 msgid "Other Devices"
 msgstr "Innleadan"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Cuir ceangal ùr ris"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Cha deach seo a shuidheachadh"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, fuzzy, c-format
-#| msgctxt "timezone desc"
-#| msgid "%s (%s)"
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (%s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Ceangailte"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Roghainnean…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr ""
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3101,187 +2083,89 @@ msgid "Network Name"
 msgstr "Ainm an lìonraidh"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Facal-faire"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 #, fuzzy
-#| msgid "Group Password"
 msgid "Generate Random Password"
 msgstr "Facal-faire a' bhuidhinn"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 #, fuzzy
-#| msgid "Current _Password"
 msgid "Autogenerate Password"
 msgstr "Am _facal-faire làithreach"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Cuir air"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "WiFi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-"A bheil thu airson stad a chur air an hotspot is cleachdaiche sam bith eile "
-"a dhì-cheangal?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "_Cuir stad air an hotspot"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Modh itealain"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Cuiridh seo WiFi, Bluetooth agus bann-leathann mobile à comas"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Cha deach adaptar WiFi a lorg"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr ""
 "Dèan cinnteach gu bheil adaptar WiFi agad ceangailte agus air a chur air"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 #, fuzzy
-#| msgid "Airplane Mode"
 msgid "Airplane Mode On"
 msgstr "Modh itealain"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 #, fuzzy
-#| msgid "Turn off Wi-Fi to save power."
 msgid "Turn off to use Wi-Fi"
 msgstr "Cuir WiFi dheth gus cumhachd a chaomhnadh."
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 #, fuzzy
-#| msgid "Wi-Fi Hotspot"
 msgid "Wi-Fi Hotspot Active"
 msgstr "WiFi Hotspot"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 #, fuzzy
-#| msgid "_Turn On Wi-Fi Hotspot…"
 msgid "Turn Off Hotspot…"
 msgstr "Cuir air WiFi Ho_tspot…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Lìonraidhean a chithear"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "Feumaidh NetworkManager a bhith a’ ruith"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ìoc, chaidh rudeigin cearr. Cuir fios gu reiceadair a’ bhathair-bhog agad."
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Tèarainteachd 802.1x"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Tèarainteachd"
-
-#: panels/network/connection-editor/ce-page.c:234
-#, fuzzy
-#| msgid "reset"
-msgid "Preserve"
-msgstr "ath-shuidhich"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:237
-#, fuzzy
-#| msgid "Tablet"
-msgid "Stable"
-msgstr "Tablaid"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Pròifil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr ""
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Chan eil gin"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Chan ann idir"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
@@ -3290,186 +2174,6 @@ msgstr[0] "%i latha air ais"
 msgstr[1] "%i latha air ais"
 msgstr[2] "%i làithean air ais"
 msgstr[3] "%i latha air ais"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr ""
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Chan eil gin"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Lag"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ceart ma-thà"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Math"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Fìor-mhath"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Seòladh IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "Seòladh IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Seòladh IP"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "Dìochuimhnich an ceangal"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "Thoir air falbh pròifil a’ cheangail"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "Thoir air falbh a’ VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "Mion-fhiosrachadh"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "fèin-obrachail"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Dearbh-aithne"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Sguab às an seòladh"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "Sguab às an t-slighe"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Chan eil gin"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Iuchair WEP 40/128-bit (Hex no ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Abairt-fhaire WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamic WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA ⁊ WPA2 pearsanta"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA ⁊ WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-#, fuzzy
-#| msgctxt "category"
-#| msgid "Personal"
-msgid "WPA3 Personal"
-msgstr "Pearsanta"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3480,24 +2184,40 @@ msgstr "Neart an t-siognail"
 msgid "Link speed"
 msgstr "Astar a’ cheangail"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Tèarainteachd"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Seòladh IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Seòladh IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Seòladh bathair-chruaidh"
 
 #: panels/network/connection-editor/details-page.ui:142
 #, fuzzy
-#| msgid "Supported ICC profiles"
 msgid "Supported Frequencies"
 msgstr "Pròifilean ICC ris a bheil taic"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "An t-slighe bhunaiteach"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3511,11 +2231,11 @@ msgstr "Ce_angail gu fèin-obrachail"
 msgid "Make available to _other users"
 msgstr "Cuir ri lài_mh chleachdaichean eile"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3558,7 +2278,7 @@ msgstr "Link-Local a-mhàin"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "A làimh"
 
@@ -3570,7 +2290,6 @@ msgstr "Cuir à comas"
 #: panels/network/connection-editor/ip4-page.ui:75
 #: panels/network/connection-editor/ip6-page.ui:85
 #, fuzzy
-#| msgid "Shared with other computers"
 msgid "Shared to other computers"
 msgstr "Co-roinnte le coimpiutairean eile"
 
@@ -3580,33 +2299,32 @@ msgid "Addresses"
 msgstr "Seòlaidhean"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Seòladh"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Netmask"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Bealach"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Fèin-obrachail"
 
@@ -3615,29 +2333,34 @@ msgstr "Fèin-obrachail"
 msgid "Automatic DNS"
 msgstr "DNS fèin-obrachail"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Sgaraich seòlaichean IP le cromagan"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Slighean"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Slighean fèin-obrachail"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Meatraigeachd"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Na cleachd an ceangal se_o ach airson goireasan air a lìonra fhèin"
 
@@ -3650,84 +2373,13 @@ msgid "Automatic, DHCP only"
 msgstr "Fèin-obrachail, DHCP a-mhàin"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Ro-leasachan"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Chan urrainn dhuinn deasaiche nan ceanglaichean fhosgladh"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Pròifil ùr"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Ion-phortaich o fhaidhle…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "Cuir ris VPN"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Tèaraint_eachd"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Chan urrainn dhuinn an ceangal VPN ion-phortadh"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Cha b’ urrainn dhuinn am faidhle “%s” a leughadh no chan eil dàta sam bith "
-"’na bhroinn leis an dèanar ceangal VPN\n"
-"\n"
-"Mearachd: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Tagh faidhle a thèid ion-phortadh"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Tha faidhle air a bheil “%s” ann mu thràth."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "Cui_r ’na àite"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-"A bheil thu airson an ceangal VPN a tha thu a’ sàbhaladh a chur an àite “%s”?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Chan urrainn dhuinn an ceangal VPN às-phortadh"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Cha b’ urrainn dhuinn an ceangal VPN “%s” às-phortadh gu %s.\n"
-"\n"
-"Mearachd: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Às-phortaich ceangal VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3742,115 +2394,52 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Lìonra"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Stiùirich an dòigh a cheanglas tu ris an eadar-lìon"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 #, fuzzy
-#| msgid ""
-#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
-#| "vpn;DNS;"
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
 "DNS;lìonra,uèirleas,progsaidh;bann-leathann;drochaid;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "WiFi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Stiùirich an dòigh a cheanglas tu ri lìonraidhean WiFi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 #, fuzzy
-#| msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;lìonra;uèirleas,bann-"
 "leathann;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "Chan ann idir"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "an-diugh"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "an-dè"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Air a chleachdadh an turas mu dheireadh"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Uèirichte"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Cuir ceangal ùr ris"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Thèid fiosrachadh nan lìonraidhean a thagh thu, a’ gabhail a-steach an "
-"fhacail-fhaire ’s rèiteachadh gnàthaichte sam bith, air chall."
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "_Dìochuimhnich"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Lìonraidhean WiFi as aithne dhuinn"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Dìochuimhnich"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-"Chan eil e ceadaichte a chleachdadh mar hotspot ri linn poileasaidh an t-"
-"siostaim"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Chan eil an t-uidheam uèirleas a’ cur taic ris a’ mhodh hotspot"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Nuair nach eil URL rèiteachaidh ’ga thoirt seachad, thèid fhèin-lorg "
-"progsaidh lìonraidh a chleachdadh."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Cha mholamaid seo air lìonraidhean poblach anns nach eil earbsa."
-
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Cuir an t-uidheam dheth"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Gnìomhach"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3861,47 +2450,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Sòlaraiche"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Seòladh IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Progsaidh lìonraidh"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "Progsaidh _HTTP"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "Progsaidh H_TTPS"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "Progsaidh _FTP"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Òstair _Socks"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "Le_ig seachad òstairean"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Port progsaidh HTTP"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Port progsaidh HTTPS"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Port progsaidh FTP"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Port progsaidh Socks"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "An URL _rèiteachaidh"
 
@@ -3911,21 +2504,18 @@ msgstr "Cuir an ceangal VPN dheth"
 
 #: panels/network/network-wifi.ui:34
 #, fuzzy
-#| msgid "Network Name"
 msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Ainm an lìonraidh"
 
 #: panels/network/network-wifi.ui:40
 #, fuzzy
-#| msgid "Security type"
 msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Seòrsa na tèarainteachd"
 
 #: panels/network/network-wifi.ui:46
 #, fuzzy
-#| msgid "Password"
 msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Facal-faire"
@@ -3934,301 +2524,22 @@ msgstr "Facal-faire"
 msgid "Turn Wi-Fi off"
 msgstr "Cuir am WiFi dheth"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "A' luchdadh nan roghainnean…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Ceangail ri lìonra falaichte…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Cuir air WiFi Ho_tspot…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Lìonraidhean WiFi as aithne dhuinn"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Chan eil fhios dè an staid"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Gun stiùireadh"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Chan eil seo ri fhaighinn"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "A’ ceangal"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Tha feum air dearbhadh"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "A’ briseadh a’ cheangail"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Dh’fhàillig an ceangal"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Chan eil fhios dè an staid (a dhìth)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Dh’fhàillig an rèiteachadh"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Dh’fhàillig rèiteachadh an IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Dh’fhalbh an ùine air rèiteachadh an IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Bha feum air rùintean ach cha dug thu seachad gin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Chaidh an ceangal ris an athchuingiche 802.1x a bhriseadh"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Dh’fhàillig rèiteachadh an athchuingiche 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Dh’fhàillig an t-athchuingiche 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Thug dearbhadh an t-athchuingiche 802.1x ro fhada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Dh’fhàillig tòiseachadh na seirbheise PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Chaidh an ceangal ris an t-seirbheis PPP a bhriseadh"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Dh’fhàillig PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Dh’fhàillig thòiseachadh a’ chliant DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Mearachd a’ chliant DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Dh’fhàillig an cliant DCHP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Dh’fhàillig tòiseachadh seirbheis a’ cheangail cho-roinnte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Dh’fhàillig seirbheis a’ cheangail cho-roinnte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Dh’fhàillig tòiseachadh na seirbheise AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Mearachd na seirbheise AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Dh’fhàillig an t-seirbheis AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Tha an loidhne trang"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Chan eil fuaim daithealaidh ann"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Cha b’ urrainn giùlanair a stèidheachadh"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Dh’fhalbh an ùine air an iarrtas daithealaidh"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Dh’fhàillig an oidhirp daithealaidh"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Dh’fhàillig tòiseachadh a’ mhòdaim"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Dh’fhàillig taghadh an APN a shònraich thu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Chan eilear a’ sireadh lìonraidhean"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Chaidh clàradh an lìonraidh a dhiùltadh"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Dh’fhalbh an ùine air clàradh an lìonraidh"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Cha b’ urrainn dhuinn clàradh aig an lìonra a dh’iarr thu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Dh’fhàillig sgrùdadh a’ PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Dh’fhaoidte gu bheil am bathar-an-sàs airson an uidheim a dhìth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Dh’fhalbh an ceangal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Chaidh ceangal a bha ann a ghabhail os làimh"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Cha deach am mòdam a lorg"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Dh’fhàillig an ceangal Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Cha deach cairt SIM a chur a-steach"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Tha feum air PIN an SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Tha feum air PUK an SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Tha an SIM cearr"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Dh’fhàillig eisimeileachd a’ cheangail"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Tha bathar-an-sàs a dhìth"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Chan eil an càball a-staigh"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "mearachd gun sònrachadh san tèarainteachd 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "cha deach faidhle a thaghadh"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "mearachd gun sònrachadh le dearbhadh an fhaidhle eap-method"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr ""
-"Iuchraichean prìobhaideach DER, PEM no PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER no teisteanasan PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "tha faidhle EAP-FAST PAC a dhìth"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Faidhlichean PAC (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4278,14 +2589,6 @@ msgstr "De_arbhadh a-staigh"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Ceadaich PAC _Provisioning fèin-obrachail"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "tha ainm-cleachdaiche EAP-LEAP a dhìth"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "tha facal-faire EAP-LEAP a dhìth"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4298,7 +2601,7 @@ msgstr "_Ainm-cleachdaiche"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Facal-faire"
 
@@ -4310,16 +2613,6 @@ msgstr "_Facal-faire"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Seall a_m facal-faire"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "teisteanas EAP-PEAP CA mì-dhligheach: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-"teisteanas EAP-PEAP CA mì-dhligheach: cha deach teisteanas a shònrachadh"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4342,7 +2635,6 @@ msgid "C_A certificate"
 msgstr "Teiste_anas le ùghdarras theisteanasan"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4357,64 +2649,6 @@ msgstr "Chan eil teisteanas CA _riatanach"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "Tionndadh _PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "tha ainm-cleachdaiche EAP a dhìth"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "tha facal-faire EAP a dhìth"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "tha dearbh-aithne EAP-TLS a dhìth"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "teisteanas EAP-TLS CA mì-dhligheach: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-"teisteanas EAP-TLS CA mì-dhligheach: cha deach teisteanas a shònrachadh"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "iuchair phrìobhaideach EAP-TLS mhì-dhligheach: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "teisteanas cleachdaiche EAP-TLS mì-dhligheach: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Chan eil iuchraichean prìobhaideach gun chrioptachadh tèarainte"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Tha coltas nach eil an iuchair phrìobhaideach a thagh thu air a "
-"chrioptachadh. Bheireadh sin cothrom do dhaoine an t-ainm is facal-faire "
-"agad a ghoid. Tagh iuchair phrìobhaideach a tha fo dhìon facail-fhaire.\n"
-"\n"
-"(’S urrainn dhut an iuchair phrìobhaideach agad a dhìon le openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Tagh an teisteanas prìobhaideach agad"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Tagh an iuchair phrìobhaideach agad"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4431,16 +2665,6 @@ msgstr "I_uchair phrìobhaideach"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Facal-faire na _h-iuchrach phrìobhaideach"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "teisteanas EAP-TTLS CA mì-dhligheach: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-"teisteanas EAP-TTLS CA mì-dhligheach: cha deach teisteanas a shònrachadh"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4463,14 +2687,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Àrainn"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Mearachd nach aithne dhuinn le dearbhadh tèarainteachd 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4498,69 +2723,10 @@ msgstr "Protected EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "D_earbhadh"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-#, fuzzy
-#| msgid "Select a File…"
-msgid "Select a file"
-msgstr "Tagh faidhle…"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "tha ainm-cleachdaiche leap a dhìth"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "tha facal-faire leap a dhìth"
-
-#: panels/network/wireless-security/ws-sae.c:77
-#, fuzzy
-#| msgid "invalid EAP-TLS password: missing"
-msgid "Wi-Fi password is missing."
-msgstr "facal-faire EAP-TLS mì-dhligheach: chan eil gin ann"
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Seòrsa"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "tha iuchair wep a dhìth"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"tha an iuchair wep mì-dhligheach: chan fhaod ach figearan sia-dheicheach a "
-"bhith am broinn iuchair a tha %zu a dh’fhaid"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"tha an iuchair wep mì-dhligheach: chan fhaod ach caractaran ASCII a bhith am "
-"broinn iuchair a tha %zu a dh’fhaid"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"tha an iuchair wep mì-dhligheach: tha faide na iuchrach %zu cearr. Feumaidh "
-"iuchair a bith 5/13 (ascii) no 10/26 (sia-dheicheach) a dh’fhaid"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr ""
-"tha an iuchair wep mì-dhligheach: chan fhaod an abairt-fhaire a bhith falamh"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"tha an iuchair wep mì-dhligheach: chan fhaod an abairt-fhaire a bhith nas "
-"giorra na 64 caractar"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4585,21 +2751,6 @@ msgstr "_Seall an iuchair"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Inneacs _WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk mì-dhligheach: tha faide na h-iuchrach %zu mì-dhligheach. Feumaidh i "
-"bhith [8,63] baidht no 64 figear sia-dheicheach"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk mì-dhligheach: cha ghabh an iuchair tuigsinn mar àireamh shia-"
-"dheicheach a tha 43 baidht a dh’fhaid"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4654,61 +2805,36 @@ msgstr "Brathan na sgrìn-g_lasaidh"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Stiùirich na brathan a chithear agus na sheallas iad"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Notifications;Banner;Message;Tray;Popup;brathan;bratach;teachdaireachd;"
 "treidhe;priob-uinneag;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, fuzzy, c-format
-#| msgid "<b>%s</b> removed"
-msgid "%s removed"
-msgstr "Chaidh <b>%s</b> a toirt air falbh"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Eile"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Mearachd a’ toirt air falbh a’ chunntais"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Neo-dhèan"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Seall _na brathan"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "Dèan ceangal ris an dàta agad san neul"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "Chan eil ceangal dhan eadar-lìon ann — dèan ceangal gus cunntas air loidhne "
 "ùr a chruthachadh"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Cuir cunntas ris"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:426
-#, c-format
-msgid "%s Account"
-msgstr "Cunntas %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:429
-msgid "Remove Account"
-msgstr "Thoir air falbh an cunntas"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4720,10 +2846,6 @@ msgstr ""
 "Ceangail ris na cunntasan air loidhne ’s cuir romhad mar a thèid an "
 "cleachdadh"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4731,10 +2853,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;cabadaich;post;mìosachadn;pòcaid;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Chan eil fhios dè cho fad"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4754,13 +2872,6 @@ msgstr[1] "%i uair a thìde"
 msgstr[2] "%i uairean a thìde"
 msgstr[3] "%i uair a thìde"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4777,192 +2888,9 @@ msgstr[1] "mhionaid"
 msgstr[2] "mionaidean"
 msgstr[3] "mionaid"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s gus am bi e air a làn-teairrdseadh"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Rabhadh: %s air fhàgail"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s air fhàgail"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Air a làn-teairrdseadh"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-#, fuzzy
-#| msgid "Charging"
-msgid "Not charging"
-msgstr "A’ teairrdseadh"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Falamh"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "A’ teairrdseadh"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "’Ga dhì-theairrdseadh"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Luchag uèirleas"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Meur-chlàr uèirleas"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Solar cumhachd do-bhrisidh"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Cuidiche digiteach pearsanta"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Fòn-làimhe"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Cluicheadair mheadhanan"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablaid"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Coimpiutair"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Uidheam ion-chuir geama"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Bataraidh"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Prìomh-bhataraidh"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Bataraidh a bharrachd"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Bataraidhean"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "Nua_ir a bhios e ’na thàmh"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "Cuir ’na dhàil"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "Cumhachd dheth"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "Dèan cadal-geamhraidh"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "Na dèan dad"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "Nuair a bhithear air cumhachd bataraidh"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "Nuair a bhios e air a phlugadh a-steach"
-
-#: panels/power/cc-power-panel.c:853
-#, fuzzy
-#| msgid "Never"
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Chan ann idir"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "Cur ’na dhàil fèin-obrachail"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr ""
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
 #, fuzzy
-#| msgid "15 minutes"
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "Cairteal na h-uarach"
@@ -4970,7 +2898,6 @@ msgstr "Cairteal na h-uarach"
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:16
 #, fuzzy
-#| msgid "20 minutes"
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "20 mionaid"
@@ -4978,7 +2905,6 @@ msgstr "20 mionaid"
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:20
 #, fuzzy
-#| msgid "25 minutes"
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "25 mionaid"
@@ -4986,7 +2912,6 @@ msgstr "25 mionaid"
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:24
 #, fuzzy
-#| msgid "30 minutes"
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "Leth-uair a thìde"
@@ -4994,7 +2919,6 @@ msgstr "Leth-uair a thìde"
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:28
 #, fuzzy
-#| msgid "45 minutes"
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "Trì cairtealan na h-uarach"
@@ -5002,7 +2926,6 @@ msgstr "Trì cairtealan na h-uarach"
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:32
 #, fuzzy
-#| msgid "1 hour"
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 uair a thìde"
@@ -5010,7 +2933,6 @@ msgstr "1 uair a thìde"
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:36
 #, fuzzy
-#| msgid "80 minutes"
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 mionaid"
@@ -5018,7 +2940,6 @@ msgstr "80 mionaid"
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:40
 #, fuzzy
-#| msgid "90 minutes"
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 mionaid"
@@ -5026,7 +2947,6 @@ msgstr "90 mionaid"
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:44
 #, fuzzy
-#| msgid "100 minutes"
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 mionaid"
@@ -5034,14 +2954,21 @@ msgstr "100 mionaid"
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:48
 #, fuzzy
-#| msgid "2 hours"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 uair a thìde"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bataraidh"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Innleadan"
+
 #: panels/power/cc-power-panel.ui:93
 #, fuzzy
-#| msgid "Power"
 msgid "Power Mode"
 msgstr "Cumhachd"
 
@@ -5051,13 +2978,11 @@ msgstr ""
 
 #: panels/power/cc-power-panel.ui:123
 #, fuzzy
-#| msgid "Power Saving"
 msgid "Power Saving Options"
 msgstr "Caomhnadh cumhachd"
 
 #: panels/power/cc-power-panel.ui:126
 #, fuzzy
-#| msgid "Automatic brightness"
 msgid "Automatic Screen Brightness"
 msgstr "Soilleireachd fhèin-obrachail"
 
@@ -5065,103 +2990,67 @@ msgstr "Soilleireachd fhèin-obrachail"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 #, fuzzy
-#| msgid "Screen"
 msgid "Dim Screen"
 msgstr "Sgrìn"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 #, fuzzy
-#| msgid "Screen _Reader"
 msgid "Screen _Blank"
 msgstr "Leughadai_r-sgrìn"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 #, fuzzy
-#| msgid "_Automatic Problem Reporting"
 msgid "Automatic Power Saver"
 msgstr "_Aithrisean fèin-obrachail air duilgheadasan"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 #, fuzzy
-#| msgid "Automatic Suspend"
 msgid "_Automatic Suspend"
 msgstr "Cuir ’na dhàil gu fèin-obrachail"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 #, fuzzy
-#| msgid "Lower Button"
 msgid "Po_wer Button Behavior"
 msgstr "Am putan aig a’ bhonn"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Cuir ’na dhàil gu fèin-obrachail"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_Plugte a-staigh"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Air cumhachd a’ _bhataraidh"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Dàil"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:136
-#, fuzzy
-#| msgid "_Balance:"
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Cothro_m:"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:140
-#, fuzzy
-#| msgid "Power Saving"
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Caomhnadh cumhachd"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr ""
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -5172,12 +3061,8 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Seall ìre a’ bhataraidh agad is atharraich roghainnean caomhnadh na cumhachd"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 #, fuzzy
-#| msgid ""
-#| "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;"
-#| "Idle;"
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
@@ -5185,27 +3070,6 @@ msgstr ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "cumhachd;cadal;dàil;cadal-geamhraidh;bataraidh;soilleireachd;doilleireachd;"
 "bàn;monatair;tàmh;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Chaidh an clò-bhualadair “%s” a sguabadh às"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Cha b’ urrainn dhuinn an eadar-aghaidh %s a luchdadh"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr ""
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5217,7 +3081,6 @@ msgstr ""
 "Cuir clò-bhualadairean, seall obraichean a’ chlò-bhualadair is cuir romhad "
 "mar a thèid clò-bhualadh"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Clò-bhualadair;Ciudha;Clò-bhualadh;Pàipear;Inc;Tònair;"
@@ -5225,94 +3088,71 @@ msgstr "Clò-bhualadair;Ciudha;Clò-bhualadh;Pàipear;Inc;Tònair;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Cuir clò-bhualadair ris"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Thoir a’ ghlas dheth"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Cha deach clò-bhualadair a lorg"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Cuir a-steach seòladh lìonraidh gus clò-bhualadair a lorg"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Tha feum air dearbhadh"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Cuir a-steach ainm-cleachdaiche ’s facal-faire gus na clò-bhualadairean "
 "fhaicinn a tha ri làimh air an fhrithealaiche."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Ainm-cleachdaiche"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "Fiosrachadh air %s"
-
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Cha deach draibhear freagarrach a lorg"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "Tagh faidhle PPD"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"Faidhlichean PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD."
-"gz, *.PPD.GZ)"
 
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Ionad"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Draibhear"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "A’ lorg nan draibhearan as fhearr…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Lorg draibhearan"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Tagh o stòr-dàta…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Stàlaich faidhle PPD…"
 
@@ -5324,113 +3164,14 @@ msgstr "Tagh draibhear a’ chlò-bhualadair"
 msgid "Loading drivers database…"
 msgstr "A’ luchdadh stòr-dàta nan draibhearan…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Sguir dheth"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Tagh"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Clò-bhualadair JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Clò-bualadair LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Aon-taobhach"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Oir fhada (stannardach)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Oir ghoirid (Flip)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Portraid"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Dreach-tìre"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Dreach-tìre contrarra"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Portraid chontrarra"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "Ri dhèanamh"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "’Na stad"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Tha feum air dearbhadh"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "’Ga phròiseasadh"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Sguireadh dheth"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Sguireadh dheth"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Sguireadh dheth"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Air a choileanadh"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr ""
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5440,19 +3181,6 @@ msgstr[1] "Tha %u obair feumach air dearbhadh"
 msgstr[2] "Tha %u obraichean feumach air dearbhadh"
 msgstr[3] "Tha %u obair feumach air dearbhadh"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s – Obraichean gnìomhach"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Cuir a-steach teisteas airson clò-bhualadh o %s."
-
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
 #: panels/user-accounts/cc-add-user-dialog.ui:300
@@ -5460,229 +3188,30 @@ msgid "Domain"
 msgstr "Àrainn"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "D_earbhaich"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Falamhaich na h-uile"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "De_arbhaich"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Chan eil obair clò-bhualaidh gnìomhach"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Thoir a’ ghlas far an fhrithealaiche clò-bhualaidh"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Thoir a’ ghlas far %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Cuir a-steach ainm-cleachdaiche ’s facal-faire gus na clò-bhualadairean "
-"fhaicinn a tha ri làimh air %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "A’ lorg clò-bhualadairean"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Port sreathach"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Port co-shìnte"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Ionad: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Seòladh: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Feumaidh am frithealaiche dearbhadh"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dà-thaobhach"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Seòrsa a’ phàipeir"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Tùs a’ phàipeir"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Treidhe às-chuir"
-
-#: panels/printers/pp-options-dialog.c:91
-#, fuzzy
-#| msgid "Resolution"
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Dùmhlachd-bhreacaidh"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Ro-chriathradh GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Duilleagan air gach taobh"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dà-thaobhach"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Comhair"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Coitcheann"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Suidheachadh na duilleige"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Roghainnean a gabhas stàladh"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Obair"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Càileachd an deilbh"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Dath"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Lìomhadh"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Adhartach"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Duilleag deuchainne"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Duilleag deuchainne"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Taghadh fèin-obrachail"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Bun-roghainnean a’ chlò-bhualadair"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Na leabaich ach cruthan-clò GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Iompaich ’na PS leibheil 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Iompaich ’na PS leibheil 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Gun ro-chriathradh"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Saothraiche"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Chan eil obair ghnìomhach ann"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5691,115 +3220,6 @@ msgstr[0] "%u obair"
 msgstr[1] "%u obair"
 msgstr[2] "%u obraichean"
 msgstr[3] "%u obair"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Glan na cinn clò-bhualaidh"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Tònair gann"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Chan eil tònair air fhàgail"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Stuth-leasachaidh gann"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Chan eil stuth-leasachaidh air fhàgail"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Dath gann ann am biona a’ chlò-bhualadair"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Chan eil dath air fhàgail ann am biona a’ chlò-bhualadair"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Tha am mullach fosgailte"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Tha an doras fosgailte"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Pàipear gann"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Chan eil pàipear air fhàgail"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Far loidhne"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Sguireadh dheth"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Tha soitheach an sgudail cha mhòr làn"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Tha soitheach an sgudail làn"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Tha am foto-ghiùlanair lèirsinneach a’ dol bàs"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Chan eil am foto-ghiùlanair lèirsinneach ag obair tuilleadh"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Deiseil"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Cha ghabh e ri obraichean"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "’Ga phròiseasadh"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5823,47 +3243,47 @@ msgstr "Glan na cinn clò-bhualaidh"
 msgid "Remove Printer"
 msgstr "Thoir air falbh an clò-bhualadair"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Chan eil obair ghnìomhach ann"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Modail"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Ìre na h-ince"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Dèan ath-thòiseachadh nuair a bhios an duilgheadas air a chàradh."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Ath-thòisich"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 #, fuzzy
-#| msgid "Add a Printer…"
 msgid "Add Printer…"
 msgstr "Cuir clò-bhualadair ris…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Cuir clò-bhualadair ris…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Chan eil clò-bhualadair ann"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Cuir clò-bhualadair ris…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 #, fuzzy
-#| msgid ""
-#| "Sorry! The system printing service\n"
-#| "doesn’t seem to be available."
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5871,56 +3291,37 @@ msgstr ""
 "Tha sinn duilich ach chan eil seirbheis clò-bhualadh\n"
 "an t-siostaim ri làimh a-rèir coltais."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Fòrmatan"
 
-#: panels/region/cc-format-chooser.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "Air ais"
-
 #: panels/region/cc-format-chooser.ui:76
 #, fuzzy
-#| msgid "Search Locations"
 msgid "Search locales…"
 msgstr "Ionadan luirg"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 #, fuzzy
-#| msgid "Formats"
 msgid "Common Formats"
 msgstr "Fòrmatan"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 #, fuzzy
-#| msgid "Formats"
 msgid "All Formats"
 msgstr "Fòrmatan"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 #, fuzzy
-#| msgid "No results found"
 msgid "No Search Results"
 msgstr "Cha deach toradh a lorg"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Ro-shealladh"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Impireil"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Meatraigeach"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5952,28 +3353,31 @@ msgstr ""
 
 #: panels/region/cc-region-panel.ui:45
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
 #, fuzzy
-#| msgid "Your account"
+msgid "Manage Installed Languages"
+msgstr "Stàlaich cànan"
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
 msgid "Your Account"
 msgstr "An cunntas agad"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Cànan"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Fòrmatan"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 #, fuzzy
-#| msgid "Login _Screen"
 msgid "Login Screen"
 msgstr "_Sgrìn a’ chlàraidh a-steach"
 
@@ -5983,105 +3387,13 @@ msgstr "Roinn-dùthcha ⁊ cànan"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
 #, fuzzy
-#| msgid ""
-#| "Select your display language, formats, keyboard layouts and input sources"
 msgid "Select your display language and formats"
 msgstr "Tagh an cànan-taisbeanaidh, fòrmatan, meur-chlàran is tùsan ion-chuir"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 "cànan;co-dhealbhachd;meur-chlàr;ion-chur;Language;Layout;Keyboard;Input;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Faighnich dhìom"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Na dèan dad"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Fosgail am pasgan"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Meadhanan eile"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Tagh aplacaid airson CDan fuaime"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Tagh aplacaid airson DVDan video"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Tagh aplacaid a thèid a ruith nuair a cheanglar cluicheadair ciùil ris"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Tagh aplacaid a thèid a ruith nuair a cheanglar camara ris"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Tagh aplacaid airson CDan bathair-bhog"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD fuaime"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "diosg Blu-ray bàn"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "diosg CD bàn"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "diosg DVD bàn"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "diosg DVD HD bàn"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "diosg video Blu-ray bàn"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "leughadair leabhair-d"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "diosg video DVD HD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "CD dhealbhan"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Bathar-bog Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6132,7 +3444,6 @@ msgstr "Meadhan so-ghiùlain"
 msgid "Configure Removable Media settings"
 msgstr "Rèitich roghainnean nam meadhanan so-ghiùlain"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6142,13 +3453,78 @@ msgstr ""
 "so-ghiùlain;meadhanan;fèin-ruith;device;system;default;application;preferred;"
 "cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Tagh ionad"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Glas na sgrìn"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Ceart ma-tha"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "Sgrìn _bhàn"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "G_las fhèin-obrachail na sgrìn"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "G_las fhèin-obrachail na sgrìn"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Seall _na brathan"
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr "Glais an sgrìn nuair a thèid a chur 'na dhàil"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Prìobhaideachd"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Sgrìn"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Co-roinneadh sgrìnichean"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6165,29 +3541,22 @@ msgstr ""
 msgid "Places"
 msgstr "Àitichean"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Comharran-lìn"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 #, fuzzy
-#| msgid "Other"
 msgid "Others"
 msgstr "Eile"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 #, fuzzy
-#| msgid "Location"
 msgid "Add Location"
 msgstr "Ionad"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Cha deach aplacaid sam bith a lorg"
-
 #: panels/search/cc-search-panel.ui:10
 #, fuzzy
-#| msgid "Applications"
 msgid "Application Search"
 msgstr "Aplacaidean"
 
@@ -6201,7 +3570,6 @@ msgstr ""
 
 #: panels/search/cc-search-panel.ui:37
 #, fuzzy
-#| msgid "Search Locations"
 msgid "Search Results"
 msgstr "Ionadan luirg"
 
@@ -6216,75 +3584,15 @@ msgstr ""
 "Stiùirich na h-aplacaidean a sheallas toraidhean luirg air foir-shealladh na "
 "gnìomhachd"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Search;Find;Index;Hide;Privacy;Results;lorg;inneacs;clàr-amais;falaich;"
 "prìobhaideachd;toraidhean;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "Cha deach lìonra a thaghadh a chum co-roinnidh"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Lìonraidhean"
-
-#: panels/sharing/cc-sharing-panel.c:367
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Air"
-
-#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Dheth"
-
-#: panels/sharing/cc-sharing-panel.c:399
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "An comas"
-
-#: panels/sharing/cc-sharing-panel.c:402
-msgctxt "service is active"
-msgid "Active"
-msgstr "Gnìomhach"
-
-#: panels/sharing/cc-sharing-panel.c:520
-msgid "Choose a Folder"
-msgstr "Tagh pasgan"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:748
-#, fuzzy, c-format
-#| msgid ""
-#| "File Sharing allows you to share your Public folder with others on your "
-#| "current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Bheir co-roinneadh fhaidhlichean comas dhut am pasgan poblach agad a cho-"
-"roinneadh le daoine eile air an lìonra làithreach agad slighe: <a href="
-"\"dav://%s\">dav://%s</a>"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:754
-#, fuzzy, c-format
-#| msgid ""
-#| "When remote login is enabled, remote users can connect using the Secure "
-#| "Shell command:\n"
-#| "<a href=\"ssh %s\">ssh %s</a>"
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Ma tha an clàradh a-steach cèin an coma, ’s urrainn dha chleachdaichean "
-"ceangal a dhèanamh on taobh a-muigh slighe na h-àithne Secure Shell:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6324,95 +3632,93 @@ msgstr "Ia_rr facal-faire"
 msgid "Remote Login"
 msgstr "Clàradh a-steach cèin"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 #, fuzzy
-#| msgid "Remote Login"
 msgid "Remote Desktop"
 msgstr "Clàradh a-steach cèin"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 #, fuzzy
-#| msgid "Enable or disable remote login"
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr "Cuir an comas no à comas clàradh a-steach cèin"
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 #, fuzzy
-#| msgid "_Allow Remote Control"
 msgid "Remote Control"
 msgstr "Ce_adaich smachd cèin"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 #, fuzzy
-#| msgid "_Allow connections to control the screen"
 msgid "Allows remote connections to control the screen."
 msgstr "Leig le ce_anglaichean an sgrìn a stiùireadh"
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 #, fuzzy
-#| msgid "Not connected"
 msgid "How to Connect"
 msgstr "Chan eil ceangal ann"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Dèan lethbhreac"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 #, fuzzy
-#| msgid "Delete Address"
 msgid "Remote Desktop Address"
 msgstr "Sguab às an seòladh"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 #, fuzzy
-#| msgid "Au_thentication"
 msgid "Authentication"
 msgstr "D_earbhadh"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 #, fuzzy
-#| msgid "Username"
 msgid "User Name"
 msgstr "Ainm-cleachdaiche"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:430
+#: panels/sharing/cc-sharing-panel.ui:434
 #, fuzzy
-#| msgid "Enrolling fingerprints"
 msgid "Encryption Fingerprint"
 msgstr "A’ clàradh nam meur-lorgan"
 
-#: panels/sharing/cc-sharing-panel.ui:431
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:463
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Co-roinneadh mheadhanan"
 
-#: panels/sharing/cc-sharing-panel.ui:485
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Co-roinn ceòl, dealbhan is videothan air an lìonra."
 
-#: panels/sharing/cc-sharing-panel.ui:498
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Pasgain"
 
@@ -6420,7 +3726,6 @@ msgstr "Pasgain"
 msgid "Control what you want to share with others"
 msgstr "Stiùirich na cho-roinneas tu le daoine eile"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6439,45 +3744,42 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Tha feum air dearbhadh mus gabh clàradh cèin a chur an comas no à comas"
 
-#: panels/sound/cc-alert-chooser.c:150
-msgid "Custom"
-msgstr "Gnàthaichte"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Comhartaich"
+msgid "Click"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "Friog-frag"
+#, fuzzy
+msgid "String"
+msgstr "Co-roinneadh"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "Glainne"
+msgid "Swing"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "Sònar"
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 #, fuzzy
-#| msgctxt "balance"
-#| msgid "Rear"
+msgid "Balance"
+msgstr "Cothro_m:"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Crìonadh:"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Deireadh"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 #, fuzzy
-#| msgctxt "balance"
-#| msgid "Front"
 msgid "Front"
 msgstr "Beulaibh"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, fuzzy, c-format
-#| msgid "Settings"
-msgid "Testing %s"
-msgstr "Roghainnean"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6485,78 +3787,63 @@ msgstr ""
 
 #: panels/sound/cc-sound-panel.ui:8
 #, fuzzy
-#| msgid "System Sounds"
 msgid "System Volume"
 msgstr "Fuaimean an t-siostaim"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
 #, fuzzy
-#| msgid "Volume mute"
+msgid "Master volume"
+msgstr "Fuaimean an t-siostaim"
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
 msgid "Volume Levels"
 msgstr "Mùch an fhuaim"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Às-chur"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 #, fuzzy
-#| msgid "_Output volume:"
 msgid "Output Device"
 msgstr "Àirde fuaim a_n às-chuir:"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Cuir fo dheuchainn"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 #, fuzzy
-#| msgid "_Configuration URL"
 msgid "Configuration"
 msgstr "An URL _rèiteachaidh"
 
-#: panels/sound/cc-sound-panel.ui:135
-#, fuzzy
-#| msgid "_Balance:"
-msgid "Balance"
-msgstr "Cothro_m:"
-
-#: panels/sound/cc-sound-panel.ui:161
-#, fuzzy
-#| msgid "_Fade:"
-msgid "Fade"
-msgstr "_Crìonadh:"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Ion-chur"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 #, fuzzy
-#| msgid "Input level:"
 msgid "Input Device"
 msgstr "Ìre an ion-chuir:"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 #, fuzzy
-#| msgid "Volume up"
 msgid "Volume"
 msgstr "Cuir an fhuaim an àirde"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 #, fuzzy
-#| msgid "_Alert volume:"
 msgid "Alert Sound"
 msgstr "Àirde _fuaim nan rabhadh:"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6567,104 +3854,12 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Atharraich ìre na fuaime, fuaimean ion-chuir, às-chuir is chaismeachdan"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 #, fuzzy
-#| msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Cairt;Micreofon;Àirde na fuaime;Crìonadh;Cothrom;Bluetooth;Headset;Fuaim;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-#, fuzzy
-#| msgid "Disconnecting"
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "A’ briseadh a’ cheangail"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-#, fuzzy
-#| msgid "Connecting"
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "A’ ceangal"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-#, fuzzy
-#| msgid "Connected"
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Ceangailte"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-#, fuzzy
-#| msgid "Authentication required"
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Tha feum air dearbhadh"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-#, fuzzy
-#| msgid "Connected Devices"
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Uidheaman a tha ceangailte ris"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-#, fuzzy
-#| msgid "Unknown"
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Chan eil fhios"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr ""
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-#, fuzzy
-#| msgid "Connected"
-msgid "Connected at:"
-msgstr "Ceangailte"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-#, fuzzy
-#| msgid "_Enroll"
-msgid "Enrolled at:"
-msgstr "_Clàraich"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-#, fuzzy
-#| msgid "Failed to upload file: %s"
-msgid "Failed to authorize device: "
-msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-#, fuzzy
-#| msgid "Failed to upload file: %s"
-msgid "Failed to forget device: "
-msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6675,105 +3870,59 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
 #, fuzzy
-#| msgid "_Name:"
+msgid "Close notification"
+msgstr "Seall _na brathan"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
 msgid "Name:"
 msgstr "_Ainm:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 #, fuzzy
-#| msgid "Automatic _Connect"
 msgid "Authorize and Connect"
 msgstr "_Ceangail gu fèin-obrachail"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 #, fuzzy
-#| msgid "Remove Device"
 msgid "Forget Device"
 msgstr "Thoirt an t-uidheam air falbh"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-#, fuzzy
-#| msgid "Mirror"
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Sgàthanaich"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-#, fuzzy
-#| msgid "Authenticated"
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Air a dhearbhadh"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-#, fuzzy
-#| msgid "The profile could not be generated."
-msgid "Thunderbolt security level could not be determined."
-msgstr "Cha b’ urrainn dhuinn a’ phròifil a ghintinn."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
+#: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:104
+#: panels/thunderbolt/cc-bolt-panel.ui:103
 #, fuzzy
-#| msgid "Couldn’t connect to the %s domain: %s"
 msgid "Could not connect to the thunderbolt subsystem."
 msgstr "Cha b’ urrainn ceangal ris an àrainn %s: %s"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:153
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 #, fuzzy
-#| msgid "Universal Access"
 msgid "Direct Access"
 msgstr "Inntrigeadh uile-choitcheann"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 #, fuzzy
-#| msgid "Add Device"
 msgid "Pending Devices"
 msgstr "Cuir uidheam ris"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr ""
 
@@ -6785,7 +3934,6 @@ msgstr ""
 msgid "Manage Thunderbolt devices"
 msgstr ""
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr ""
@@ -6794,16 +3942,16 @@ msgstr ""
 msgid "Cursor Blinking"
 msgstr "Priobadh a’ chùrsair"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Bidh an cùrsair a’ priobadh ann an raointean teacsa."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Luaths"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Luaths priobadh a’ chùrsair"
 
@@ -6890,15 +4038,15 @@ msgstr "Mòr"
 msgid "Repeat Keys"
 msgstr "Putain ath-dhèanaimh"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Thèid brùthadh na h-iuchrach ath-dhèanamh ma chumar shìos an iuchair."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Dàil nam putan ath-dhèanaimh"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Astar nam putan ath-dhèanaimh"
 
@@ -6981,54 +4129,17 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Fada"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "Cuir an comas l_eis a’ mheur-chlàr"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr ""
 "Cuiridh seo gleusan na so-ruigsinneach air no dheth leis a’ mheur-chlàr"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Bun-roghainn"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Meadhanach"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Mòr"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Nas motha"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "As motha"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d phiogsail"
-msgstr[1] "%d phiogsail"
-msgstr[2] "%d piogsailean"
-msgstr[3] "%d piogsail"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 #, fuzzy
-#| msgid "_Always Show Universal Access Menu"
 msgid "_Always Show Accessibility Menu"
 msgstr "Se_all clàr-taice an inntrigidh uile-choitchinn an-còmhnaidh"
 
@@ -7101,7 +4212,6 @@ msgstr "_Cuidiche sgrìobhaidh (AccessX)"
 
 #: panels/universal-access/cc-ua-panel.ui:240
 #, fuzzy
-#| msgid "Pointing & Clicking"
 msgid "Pointing &amp; Clicking"
 msgstr "Tomhadh ⁊ briogadh"
 
@@ -7111,7 +4221,6 @@ msgstr "I_uchraichean an luch-chlàir"
 
 #: panels/universal-access/cc-ua-panel.ui:255
 #, fuzzy
-#| msgid "Remove Printer"
 msgid "_Locate Pointer"
 msgstr "Thoir air falbh an clò-bhualadair"
 
@@ -7145,34 +4254,8 @@ msgstr "Boillsg an _sgrìn gu lèir"
 
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 #, fuzzy
-#| msgid "Flash the entire _screen"
 msgid "Flash the entire _window"
 msgstr "Boillsg an _sgrìn gu lèir"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Goirid"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ dhen sgrìn"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ dhen sgrìn"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ dhen sgrìn"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Fada"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7331,13 +4414,8 @@ msgstr ""
 "Dèan nas fhasa e rudan fhaicinn, a chluinntinn, a sgrìobhadh, a thomhadh ’s "
 "a bhriogadh"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 #, fuzzy
-#| msgid ""
-#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;"
-#| "size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;"
-#| "Repeat;Blink;"
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
@@ -7350,145 +4428,8 @@ msgstr ""
 "Contrast;Zoom;Screen;Reader;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;"
 "Mouse;Double;click;Delay;Assist;Repeat;Blink;"
 
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-#, fuzzy
-#| msgid "1 hour"
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 uair a thìde"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-#, fuzzy
-#| msgid "1 day"
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 latha"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-#, fuzzy
-#| msgid "2 days"
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 latha"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-#, fuzzy
-#| msgid "3 days"
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 làithean"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-#, fuzzy
-#| msgid "4 days"
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 làithean"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-#, fuzzy
-#| msgid "5 days"
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 làithean"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-#, fuzzy
-#| msgid "6 days"
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 làithean"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-#, fuzzy
-#| msgid "7 days"
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 làithean"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-#, fuzzy
-#| msgid "14 days"
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "Cola-deug"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-#, fuzzy
-#| msgid "30 days"
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 latha"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "A bheil thu airson an sgudal fhalamhachadh gu tur?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Thèid gach rud san sgudal a sguabadh às gu buan."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Falamhaich an sgudal"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "A bheil thu airson na faidhlichean sealach a sguabadh às?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Thèid gach faidhle sealach a sguabadh às gu buan."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Purgaidich na faidhlichean sealach"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-#, fuzzy
-#| msgid "1 day"
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 latha"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-#, fuzzy
-#| msgid "7 days"
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 làithean"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-#, fuzzy
-#| msgid "30 days"
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 latha"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-#, fuzzy
-#| msgid "Forever"
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Gu buan"
-
 #: panels/usage/cc-usage-panel.ui:9
 #, fuzzy
-#| msgid "History"
 msgid "File History"
 msgstr "An eachdraidh"
 
@@ -7501,7 +4442,6 @@ msgstr ""
 
 #: panels/usage/cc-usage-panel.ui:13
 #, fuzzy
-#| msgid "History"
 msgid "File H_istory"
 msgstr "An eachdraidh"
 
@@ -7511,13 +4451,11 @@ msgstr ""
 
 #: panels/usage/cc-usage-panel.ui:48
 #, fuzzy
-#| msgid "Cl_ear Recent History"
 msgid "_Clear History…"
 msgstr "Falamhaich an _eachdraidh faisg ort"
 
 #: panels/usage/cc-usage-panel.ui:63
 #, fuzzy
-#| msgid "Purge Trash & Temporary Files"
 msgid "Trash &amp; Temporary Files"
 msgstr "Purgaidich an sgudal ⁊ na faidhlichean sealach"
 
@@ -7529,19 +4467,16 @@ msgstr ""
 
 #: panels/usage/cc-usage-panel.ui:67
 #, fuzzy
-#| msgid "Automatically empty _Trash"
 msgid "Automatically Delete _Trash Content"
 msgstr "Fa_lamhaich an sgudal gu fèin-obrachail"
 
 #: panels/usage/cc-usage-panel.ui:79
 #, fuzzy
-#| msgid "Automatically purge Temporary _Files"
 msgid "Automatically Delete Temporary _Files"
 msgstr "P_urgaidich faidhlichean sealach gu fèin-obrachail"
 
 #: panels/usage/cc-usage-panel.ui:91
 #, fuzzy
-#| msgid "Automatically empty _Trash"
 msgid "Automatically Delete _Period"
 msgstr "Fa_lamhaich an sgudal gu fèin-obrachail"
 
@@ -7551,7 +4486,6 @@ msgstr "_Falamhaich an sgudal…"
 
 #: panels/usage/cc-usage-panel.ui:126
 #, fuzzy
-#| msgid "_Purge Temporary Files…"
 msgid "_Delete Temporary Files…"
 msgstr "_Purgaidich na faidhlichean sealach…"
 
@@ -7563,63 +4497,10 @@ msgstr ""
 msgid "Don't leave traces"
 msgstr ""
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr ""
-"Bu chòir dha a bhith co-ionnann ri seòladh-lìn solaraiche a’ chlàraidh a-"
-"steach agad."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Cha b’ urrainn dhuinn an cunntas a chur ris"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:258
-msgid "The passwords do not match."
-msgstr "Chan eil an dà fhacal-faire co-ionnann."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Cha b’ urrainn dhuinn an cunntas a chlàradh"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr ""
-"Chan eil dòigh sam bith ann ris a bheil taic agus leis an urrainnear "
-"dearbhadh a dhèanamh air an àrainn seo"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Cha b’ urrainn dhuinn ceangal ris an àrainn"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Cha do dh’obraich an t-ainm sin.\n"
-"Feuch ris a-rithist."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Cha do dh’obraich am facal-faire sin.\n"
-"Feuch ris a-rithist."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Cha b’ urrainn dhuinn clàradh a-steach aig an àrainn"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr ""
-"Chan fhaigh sinn greim air an àrainn. Saoil a bheil e air a dheagh-"
-"litreachadh?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7638,7 +4519,6 @@ msgstr ""
 
 #: panels/user-accounts/cc-add-user-dialog.ui:149
 #, fuzzy
-#| msgid "Allow user to change their password on next login"
 msgid "User sets password on first login"
 msgstr ""
 "Leig leis a’ chleachdaiche am facal-faire atharrachadh nuair a chlàraicheas "
@@ -7646,31 +4526,28 @@ msgstr ""
 
 #: panels/user-accounts/cc-add-user-dialog.ui:161
 #, fuzzy
-#| msgid "Set a password now"
 msgid "Set password now"
 msgstr "Suidhich facal-faire an-dràsta"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:224
 #, fuzzy
-#| msgid "_Confirm"
 msgid "Confirm"
 msgstr "_Dearbhaich"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:278
 #, fuzzy
-#| msgid "_Enterprise Login"
 msgid "Enterprise Login"
 msgstr "Clàradh a-steach _Enterprise"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+msgid "User accounts which are managed by a company or organization."
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "Tha thu far loidhne"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7681,37 +4558,30 @@ msgstr ""
 "seo a chleachdadh cuideachd gus goireasan na companaidh inntrigeadh air an "
 "eadar-lìn."
 
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Brabhsaich airson barrachd dhealbhan"
-
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "Tagh faidhle…"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:8
 #, fuzzy
-#| msgid "_Fingerprint Login"
 msgid "Fingerprint Manager"
 msgstr "Clàradh a-steach le _meur-lorg"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:20
 #, fuzzy
-#| msgid "_Fingerprint Login"
 msgid "Fingerprint"
 msgstr "Clàradh a-steach le _meur-lorg"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 #, fuzzy
-#| msgid "No"
 msgid "_No"
 msgstr "Chan eil"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7719,555 +4589,181 @@ msgstr ""
 "A bheil thu airson na meur-lorgan clàraichte a sguabadh às airson ’s nach "
 "urrainnear clàradh a-steach leotha tuilleadh?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 #, fuzzy
-#| msgid "Gaming input device"
 msgid "No fingerprint device"
 msgstr "Uidheam ion-chuir geama"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 #, fuzzy
-#| msgid "_Fingerprint Login"
 msgid "No Fingerprint device"
 msgstr "Clàradh a-steach le _meur-lorg"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 #, fuzzy
-#| msgid "_Fingerprint Login"
 msgid "Fingerprint Device"
 msgstr "Clàradh a-steach le _meur-lorg"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 #, fuzzy
-#| msgid "_Fingerprint Login"
 msgid "Fingerprint Login"
 msgstr "Clàradh a-steach le _meur-lorg"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "_Sguab às na meur-lorgan"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 #, fuzzy
-#| msgid "_Fingerprint Login"
 msgid "Fingerprint Enroll"
 msgstr "Clàradh a-steach le _meur-lorg"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "An traca roimhe"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
 msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-#, fuzzy
-#| msgid "The device is already in use."
-msgid "the device is already claimed by another process"
-msgstr "Tha an t-uidheam seo ’ga chleachdadh mu thràth."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-#, fuzzy
-#| msgid "Failed to register with the requested network"
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Cha b’ urrainn dhuinn clàradh aig an lìonra a dh’iarr thu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-#, fuzzy
-#| msgid "Could not access any fingerprint readers"
-msgid "Failed to communicate with the fingerprint reader"
-msgstr ""
-"Cha b’ urrainn dhuinn cothrom fhaighinn air leughadair mheur-lorgan sam bith"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, fuzzy, c-format
-#| msgid "Failed to upload file: %s"
-msgid "Failed to list fingerprints: %s"
-msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, fuzzy, c-format
-#| msgid "Failed to delete user"
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Cha b’ urrainn dhuinn an cleachdaiche a sguabadh às"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "An òrdag chlì"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "An gunna fada clì"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "An sgealbag _chlì"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Mac an aba clì"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "An lùdag bheag chlì"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "An òrdag dheas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "An gunna fada deas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "An sgealbag _dheas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Mac an aba deas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "An lùdag bheag dheas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-#, fuzzy
-#| msgid "Unknown time"
-msgid "Unknown Finger"
-msgstr "Chan eil fhios dè cho fad"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-#, fuzzy
-#| msgid "Complete!"
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Deiseil!"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-#, fuzzy
-#| msgid "PPP service disconnected"
-msgid "Fingerprint device disconnected"
-msgstr "Chaidh an ceangal ris an t-seirbheis PPP a bhriseadh"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-#, fuzzy
-#| msgid "Failed to add new printer."
-msgid "Failed to enroll new fingerprint"
-msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, fuzzy, c-format
-#| msgid "Failed to upload file: %s"
-msgid "Failed to start enrollment: %s"
-msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-#, fuzzy
-#| msgid "Failed to add new printer."
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, fuzzy, c-format
-#| msgid "Failed to upload file: %s"
-msgid "Failed to stop enrollment: %s"
-msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr ""
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-#, fuzzy
-#| msgid "Enrolling fingerprints"
-msgid "Scan new fingerprint"
-msgstr "A’ clàradh nam meur-lorgan"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-#, fuzzy
-#| msgid "Problem Reporting"
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Ag aithris air duilgheadasan"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, fuzzy, c-format
-#| msgid "Failed to upload file: %s"
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, fuzzy, c-format
-#| msgid "Failed to add new printer."
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "An t-seachdain-sa"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "An t-seachdain seo chaidh"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k.%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Thàinig an seisean gu crìoch"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Thòisich an seisean"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s – Gnìomhachd a’ chunntais"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Tagh facal-faire eile."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Nach cuir thu am facal-faire làithreach agad a-rithist?"
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Cha b’ urrainn dhuinn am facal-faire atharrachadh"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Atharraich am facal-faire"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "_Atharraich"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 #, fuzzy
-#| msgid "Current _Password"
 msgid "Current Password"
 msgstr "Am _facal-faire làithreach"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 #, fuzzy
-#| msgid "_New Password"
 msgid "New Password"
 msgstr "Facal-faire ù_r"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 #, fuzzy
-#| msgid "Change Password"
 msgid "Confirm Password"
 msgstr "Atharraich am facal-faire"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Chan eil an dà fhacal-faire co-ionnann."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
 "Leig leis a’ chleachdaiche am facal-faire atharrachadh nuair a chlàraicheas "
 "iad a-steach an ath-thuras"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Suidhich facal-faire an-dràsta"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr ""
-"Chan urrainnear pàirt a ghabhail sa leithid seo de dh’àrainn gu fèin-"
-"obrachail"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Cha deach àrainn no rìoghachd mar sin a lorg"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Chan urrainn dhut clàradh a-steach mar %s air an àrainn %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Tha am facal-faire cearr, nach fheuch thu ris a-rithist?"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Cha b’ urrainn ceangal ris an àrainn %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "Cha b’ urrainn dhuinn an cleachdaiche a sguabadh às"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "Cha deach leinn an cleachdaiche fo stiùireadh cèin a chùl-ghairm"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "Chan urrainn dhut an cunntas agad fhèin a sguabadh às."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "Tha %s clàraichte a-staigh fhathast"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Ma sguabas tu às cleachdaiche fhad ’s a tha iad clàraichte a-staigh "
-"fhathast, dh’fhaoidte gum fàg sin an siostam neo-sheasmhach."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "A bheil thu airson na faidhlichean aig %s a chumail?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Gabhaidh am pasgan dachaidh, spàl a’ phuist agus na faidhlichean sealach a "
-"ghlèidheadh nuair a sguabar às cunntas cleachdaiche."
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "_Sguab às na faidhlichean"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "_Cum na faidhlichean"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"A bheil thu cinnteach gu bheil thu airson an cunntas aig %s fo stiùireadh "
-"cèin a chùl-ghairm?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "_Sguab às"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Chaidh an cunntas a chur à comas"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Ri shuidheachadh an ath-thuras a nithear clàradh a-steach"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Chan eil gin"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Air clàradh a-steach"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "An comas"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "Cha b’ urrainn dhuinn fios a chur gu seirbheis nan cunntasan"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Dèan cinnteach gun deach AccountService a stàladh agus an comas."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "Sguab às cunntas a’ chleachdaiche a thagh thu"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Gus cunntas a’ chleachdaiche a thagh thu a sguabadh às,\n"
-"briog air an ìomhaigheag * an toiseach"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr ""
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Cleachdaichean"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 "Feumaidh tu an seisean ath-thòiseachadh gus bi buaidh aig na dh’atharraich "
 "thu"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Ath-thòisich an-dràsta"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Dùin"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Ainm _slàn"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Deasaich"
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Clàradh a-steach le _meur-lorg"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "Clàradh a-steach fèin-_obrachail"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 #, fuzzy
-#| msgid "%s — Account Activity"
 msgid "Account Activity"
 msgstr "%s – Gnìomhachd a’ chunntais"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 #, fuzzy
-#| msgid "Administrator"
 msgid "_Administrator"
 msgstr "Rianaire"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Thoir air falbh an cleachdaiche…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 #, fuzzy
-#| msgid "_Other finger:"
 msgid "Other Users"
 msgstr "Corrag _eile:"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 #, fuzzy
-#| msgid "_Add User…"
 msgid "Add User…"
 msgstr "Cuir cle_achdaiche ris…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Cha deach cleachdaiche a lorg"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Thoir a’ ghlas dheth gus cunntas cleachdaiche a chur ris."
 
@@ -8277,7 +4773,6 @@ msgstr ""
 "Cuir cleachdaichean ris no thoir air falbh feadhainn is atharraich am facal-"
 "faire agad"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8321,188 +4816,8 @@ msgstr ""
 "Feumaidh tu dearbhadh a dhèanamh mus urrainn dhut dàta a’ chleachdaiche "
 "atharrachadh"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Chan fhaod an seann fhacal-faire ’s am fear ùr a bhith co-ionnann."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Feuch is atharraich cuid dhe na litrichean is àireamhan."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Feuch is atharraich am facal-faire beagan a bharrachd"
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Bhiodh facal-faire as aonais an ainm-chleachdaiche agad nas làidire."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Feuch is na cleachd d’ ainm san fhacal-fhaire."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Feuch is seachain cuid dhe na faclan a tha san fhacal-fhaire."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Feuch is seachain faclan cumanta."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Feuch is seachain fìor-fhaclan ath-òrdachadh."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Feuch is cleachd barrachd àireamhan."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Feuch is cleachd barrachd litrichean mòra."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Feuch is cleachd barrachd litrichean beaga."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Feuch is cleachd barrachd charactaran sònraichte mar phuingeachadh."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Feuch is cleachd measgachadh de litrichean, àireamhan is puingeachadh."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Feuch is seachain an aon charactar a-rithist ’s a-rithist."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Feuch is seachain an aon seòrsa de charactar a-rithist ’s a-rithist: "
-"feumaidh tu measgachadh de litrichean, àireamhan is puingeachadh."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Feuch is seachain sreathan mar 1234 no abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Feumaidh faclan-faire a bhith nas fhaide. Feuch is cuir ris barrachd "
-"litrichean, àireamhan is puingeachadh."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Cleachd litrichean mòra ’s beaga agus feuch an cleachd thu àireamh no dhà."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Bidh e nas treasa ma chuireas tu barrachd litrichean, àireamhan is "
-"puingeachadh ris."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Dh’fhàillig an dearbhadh"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "Tha am facal-faire ùr ro ghoirid"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "Tha am facal-faire ùr ro shimplidh"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Tha an seann fhacal-faire agus am fear ùr ro choltach ri chèile"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Chaidh am facal-faire ùr a chleachdadh o chionn ghoirid mu thràth."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-"Feumaidh àireamhan no caractaran sònraichte a bhith san fhacal-fhaire ùr"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Tha an seann fhacal-faire ’s am fear ùra co-ionnann"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-"Chaidh am facal-faire agad atharrachadh on a rinn thu dearbhadh an toiseach!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Chan eil caractaran eadar-dhealaichte gu leòr san fhacal-fhaire ùr"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Mearachd neo-aithnichte"
-
-#: panels/user-accounts/user-utils.c:144
-#, fuzzy
-#| msgid ""
-#| "The username should only consist of upper and lower case letters from a-"
-#| "z, digits and the following characters: . - _"
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Cha bu chòir a bhith am broinn ainm-cleachdaiche ach litrichean mòra ’s "
-"beaga o a-z, àireamhan agus gin dhe na caractaran seo: . - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Tha sinn duilich ach chan eil an t-ainm-cleachdaiche seo ri fhaighinn. Feuch "
-"fear eile."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Tha an t-ainm-cleachdaiche ro fhada."
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Mapaich putanan"
 
@@ -8535,55 +4850,14 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Mhothaich sinn do bhriogadh claon, ag ath-thòiseachadh…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Putan %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "A-rèir na h-aplacaid"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Cuir buille-iuchrach"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Gearr leum gu monatair eile"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Seall a’ chobhair air an sgrìn"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:435
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
 #, fuzzy
-#| msgid "No tablet detected"
-msgid "External tablet device"
+msgid "External pad device"
 msgstr "Cha deach tablaid a lorg"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-#, fuzzy
-#| msgid "Displays"
-msgid "All Displays"
-msgstr "Uidheaman-taisbeanaidh"
 
 #: panels/wacom/cc-wacom-page.ui:16
 #, fuzzy
-#| msgid "Tablet"
 msgid "Tablet Mode"
 msgstr "Tablaid"
 
@@ -8591,36 +4865,32 @@ msgstr "Tablaid"
 msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 #, fuzzy
-#| msgid "Left-Handed Orientation"
 msgid "Left Hand Orientation"
 msgstr "An comhair na làimhe chlì"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 #, fuzzy
-#| msgid "Map to Monitor…"
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Mapaich ri monatair…"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 #, fuzzy
-#| msgid "Aspect Ratio"
 msgid "Keep Aspect Ratio"
 msgstr "Co-mheas an deilbh"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 #, fuzzy
-#| msgid "Calibrate…"
 msgid "Calibrate"
 msgstr "Cailbhrich…"
 
@@ -8630,7 +4900,6 @@ msgstr "Cha deach tablaid a lorg"
 
 #: panels/wacom/cc-wacom-panel.ui:57
 #, fuzzy
-#| msgid "Please plug in or turn on your Wacom tablet"
 msgid "Please plug in or turn on your Wacom tablet."
 msgstr "Plug a-steach an tablaid Wacom agad no cuir air e"
 
@@ -8638,23 +4907,34 @@ msgstr "Plug a-steach an tablaid Wacom agad no cuir air e"
 msgid "Tip Pressure Feel"
 msgstr "Faireachdainn brùthadh a’ chinn"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Bog"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Stalcanta"
+
 #: panels/wacom/cc-wacom-stylus-page.ui:54
 #, fuzzy
-#| msgid "Button"
 msgctxt "display setting"
 msgid "Button 1"
 msgstr "Putan"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:62
 #, fuzzy
-#| msgid "Button"
 msgctxt "display setting"
 msgid "Button 2"
 msgstr "Putan"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:70
 #, fuzzy
-#| msgid "Button"
 msgctxt "display setting"
 msgid "Button 3"
 msgstr "Putan"
@@ -8663,21 +4943,22 @@ msgstr "Putan"
 msgid "Eraser Pressure Feel"
 msgstr "Faireachdainn brùthadh an t-suathain"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Faireachdainn brùthadh an t-suathain"
 
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr ""
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Briogadh de phutan meadhan na luchaige"
 
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr ""
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Briogadh de phutan deas na luchaige"
 
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr ""
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Air adhart"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
@@ -8689,66 +4970,100 @@ msgstr ""
 "Suidhich mapadh nam putanan is cuir air gleus mothalachd an staidhleis "
 "airson tablaidean grafaigeachd"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablaid;Wacom;Staidhleas;Suathan:Luchag;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Ath-ghoirid ùr…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Dàrnacha briogadh ma_s-fhìor"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Bathar-bog Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Tònair gann"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Panail dhàrnach"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Bathar-bog Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 #, fuzzy
-#| msgid "Access Options"
 msgid "Access Points"
 msgstr "Roghainnean inntrigidh"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Cuir ris"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Sàbhail"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 #, fuzzy
-#| msgid "VPN"
 msgid "APN"
 msgstr "VPN"
 
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-#, fuzzy
-#| msgid "Yesterday"
-msgid "Registered"
-msgstr "An-dè"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-#, fuzzy
-#| msgid "Search"
-msgid "Searching"
-msgstr "Lorg"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr ""
-
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 #, fuzzy
-#| msgid "Details"
 msgid "Modem Details"
 msgstr "Mion-fhiosrachadh"
 
@@ -8762,132 +5077,32 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-details-dialog.ui:49
 #, fuzzy
-#| msgid "Network Name"
 msgid "Network Type"
 msgstr "Ainm an lìonraidh"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:97
 #, fuzzy
-#| msgid "Networks"
 msgid "Network Status"
 msgstr "Lìonraidhean"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:122
 #, fuzzy
-#| msgid "Numbers"
 msgid "Own Number"
 msgstr "Àireamhan"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:151
 #, fuzzy
-#| msgid "Printer Details"
 msgid "Device Details"
 msgstr "Fiosrachadh a’ chlò-bhualadair"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Saothraiche"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 #, fuzzy
-#| msgid "Firmware missing"
 msgid "Firmware Version"
 msgstr "Tha bathar-an-sàs a dhìth"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1043
-#, fuzzy
-#| msgid "Unknown"
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Chan eil fhios"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-#, fuzzy
-#| msgid "_Unlock"
-msgid "Unlock"
-msgstr "_Thoir a’ ghlas dheth"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8907,28 +5122,6 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:316
-#, fuzzy
-#| msgid "_Unlock"
-msgid "Unlocking…"
-msgstr "_Thoir a’ ghlas dheth"
-
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
 msgstr ""
@@ -8943,7 +5136,6 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:77
 #, fuzzy
-#| msgid "_Mobile broadband"
 msgid "_Mobile Data"
 msgstr "Bann-leathann _mobile"
 
@@ -8961,32 +5153,26 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:115
 #, fuzzy
-#| msgid "Network Name"
 msgid "_Network Mode"
 msgstr "Ainm an lìonraidh"
 
 #: panels/wwan/cc-wwan-device-page.ui:122
 #, fuzzy
-#| msgid "Network"
 msgid "N_etwork"
 msgstr "Lìonra"
 
 #: panels/wwan/cc-wwan-device-page.ui:132
 #, fuzzy
-#| msgctxt "Printer Option Group"
-#| msgid "Advanced"
 msgid "Advanced"
 msgstr "Adhartach"
 
 #: panels/wwan/cc-wwan-device-page.ui:146
 #, fuzzy
-#| msgid "Access Options"
 msgid "_Access Point Names"
 msgstr "Roghainnean inntrigidh"
 
 #: panels/wwan/cc-wwan-device-page.ui:155
 #, fuzzy
-#| msgid "Screen Lock"
 msgid "_SIM Lock"
 msgstr "Glas na sgrìn"
 
@@ -8996,207 +5182,66 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:165
 #, fuzzy
-#| msgid "%s Details"
 msgid "M_odem Details"
 msgstr "Fiosrachadh air %s"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-#, fuzzy
-#| msgid "PIN check failed"
-msgid "Phone failure"
-msgstr "Dh’fhàillig sgrùdadh a’ PIN"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-#, fuzzy
-#| msgid "Not connected"
-msgid "No connection to phone"
-msgstr "Chan eil ceangal ann"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-#, fuzzy
-#| msgid "SIM Card not inserted"
-msgid "SIM not inserted"
-msgstr "Cha deach cairt SIM a chur a-steach"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PIN required"
-msgstr "Tha feum air PIN an SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PUK required"
-msgstr "Tha feum air PIN an SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-#, fuzzy
-#| msgid "Current _Password"
-msgid "Incorrect password"
-msgstr "Am _facal-faire làithreach"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PIN2 required"
-msgstr "Tha feum air PIN an SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PUK2 required"
-msgstr "Tha feum air PIN an SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-#, fuzzy
-#| msgid "No stylus found"
-msgid "Not found"
-msgstr "Cha deach peann a lorg"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-#, fuzzy
-#| msgid "Networks"
-msgid "No network service"
-msgstr "Lìonraidhean"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-#, fuzzy
-#| msgid "Network Name"
-msgid "Network timeout"
-msgstr "Ainm an lìonraidh"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-#, fuzzy
-#| msgid "AutoIP service failed"
-msgid "GPRS services not allowed"
-msgstr "Dh’fhàillig an t-seirbheis AutoIP"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-#, fuzzy
-#| msgctxt "print job"
-#| msgid "Canceled"
-msgid "Action Cancelled"
-msgstr "Sguireadh dheth"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-#, fuzzy
-#| msgid "Unknown error"
-msgid "Unknown Error"
-msgstr "Mearachd neo-aithnichte"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 #, fuzzy
-#| msgid "Network Name"
 msgid "Network Mode"
 msgstr "Ainm an lìonraidh"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr ""
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "Dùin"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 #, fuzzy
-#| msgid "Automatic"
 msgid "_Automatic"
 msgstr "Fèin-obrachail"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 #, fuzzy
-#| msgid "My Home Network"
 msgid "Choose Network"
 msgstr "An lìonra-dhachaidh agam"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
 msgstr ""
 
 #: panels/wwan/cc-wwan-panel.ui:10
 #, fuzzy
-#| msgid "My Home Network"
 msgid "Enable Mobile Network"
 msgstr "An lìonra-dhachaidh agam"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 #, fuzzy
-#| msgid "No Wi-Fi Adapter Found"
 msgid "No WWAN Adapter Found"
 msgstr "Cha deach adaptar WiFi a lorg"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 #, fuzzy
-#| msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr ""
 "Dèan cinnteach gu bheil adaptar WiFi agad ceangailte agus air a chur air"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 #, fuzzy
-#| msgid "Bluetooth is disabled when airplane mode is on."
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "Tha Bluetooth à comas fhad ’s a tha am modh itealain air."
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 #, fuzzy
-#| msgid "Turn Off Airplane Mode"
 msgid "_Turn off Airplane Mode"
 msgstr "Cuir am modh itealain dheth"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 #, fuzzy
-#| msgid "Forget Connection"
 msgid "Data Connection"
 msgstr "Dìochuimhnich an ceangal"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 #, fuzzy
-#| msgid "SIM Card not inserted"
 msgid "SIM card used for internet"
 msgstr "Cha deach cairt SIM a chur a-steach"
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
 #, fuzzy
-#| msgid "Screen Lock"
 msgid "SIM Lock"
 msgstr "Glas na sgrìn"
 
@@ -9204,41 +5249,35 @@ msgstr "Glas na sgrìn"
 msgid "_Next"
 msgstr ""
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr ""
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 #, fuzzy
-#| msgid "Ch_ange"
 msgid "Change PIN"
 msgstr "_Atharraich"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr ""
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "My Home Network"
 msgid "Mobile Network"
 msgstr "An lìonra-dhachaidh agam"
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:4
 #, fuzzy
-#| msgid "Configure Removable Media settings"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Rèitich roghainnean nam meadhanan so-ghiùlain"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
 
 #: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 #, fuzzy
-#| msgid "Utilities to configure the GNOME desktop"
 msgid "Utility to configure the GNOME desktop"
 msgstr "Goireasan gus an deasg GNOME a rèiteachadh"
 
@@ -9250,37 +5289,14 @@ msgstr ""
 msgid "The GNOME Project"
 msgstr ""
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Seall àireamh an tionndaidh"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "A' suidheachadh an draibheir ùir…"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Cuir an comas am modh brathrach"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Lorg an t-sreang"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Seall ainmean a ghabhas a chleachdadh is dèan fàgail"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "A’ phanail a thèid a shealltainn"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Prìobhaideachd"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Panailean a tha ri fhaighinn:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9288,7 +5304,6 @@ msgstr "Na h-uile roghainn"
 
 #: shell/cc-window.ui:54
 #, fuzzy
-#| msgid "Primary"
 msgid "Primary Menu"
 msgstr "Prìomh-phanail"
 
@@ -9329,8 +5344,6 @@ msgstr "Panailean"
 
 #: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 #, fuzzy
-#| msgctxt "shortcut window"
-#| msgid "Go back to the overview"
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
 msgstr "Till dhan fhoir-shealladh"
@@ -9340,7 +5353,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Sguir dhen lorg"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Roghainnean;"
@@ -9377,8 +5389,6 @@ msgid ""
 "application window."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9388,8 +5398,6 @@ msgstr[1] "%u às-chur"
 msgstr[2] "%u às-chuir"
 msgstr[3] "%u às-chur"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9399,9 +5407,2586 @@ msgstr[1] "%u ion-chur"
 msgstr[2] "%u ion-chuir"
 msgstr[3] "%u ion-chur"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Fuaimean an t-siostaim"
+#, fuzzy
+#~| msgid "System Sounds"
+#~ msgid "System Bus"
+#~ msgstr "Fuaimean an t-siostaim"
+
+#, fuzzy
+#~| msgid "Session Ended"
+#~ msgid "Session Bus"
+#~ msgstr "Thàinig an seisean gu crìoch"
+
+#, fuzzy
+#~| msgid "Network Name"
+#~ msgid "Has network access"
+#~ msgstr "Ainm an lìonraidh"
+
+#~ msgid "Home"
+#~ msgstr "Dhachaigh"
+
+#, fuzzy
+#~| msgctxt "printer state"
+#~| msgid "Ready"
+#~ msgid "Read-only"
+#~ msgstr "Deiseil"
+
+#, fuzzy
+#~| msgid "Open System"
+#~ msgid "File System"
+#~ msgstr "Siostam fosgailte"
+
+#, fuzzy
+#~| msgid "Select a File…"
+#~ msgid "Select a picture"
+#~ msgstr "Tagh faidhle…"
+
+#~ msgid "_Open"
+#~ msgstr "F_osgail"
+
+#~ msgid "multiple sizes"
+#~ msgstr "iomadh meud"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Chan eil cùlaibh aig an deasga"
+
+#~ msgid "Current background"
+#~ msgstr "An cùlaibh làithreach"
+
+#, fuzzy
+#~| msgid "Right"
+#~ msgid "Light"
+#~ msgstr "Deas"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;sgrìn;glas;diagnosachd;tuisleadh;prìobhaideach;sealach;"
+#~ "inneacs;lìonra;ainm;dearbh-aithne;"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Cuir an t-uidheam cailbhreachaidh agad os cionn na ceàrnaige is brùth air "
+#~ "“Tòisich”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Gluais an t-uidheam cailbhreachaidh agad dhan ionad chailbhreachaidh is "
+#~ "brùth air “Air adhart”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Gluais an t-uidheam cailbhreachaidh agad dhan ionad uachdair is brùth air "
+#~ "“Air adhart”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Dùin mullach an laptop"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Thachair mearachd inntearnail nach b’ urrainn dhuinn càradh."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr ""
+#~ "Cha deach na h-innealan a stàladh air a bheil feum airson cailbhreachadh."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Cha b’ urrainn dhuinn a’ phròifil a ghintinn."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Cha d’fhuair sinn greim air geal-phuing na targaide."
+
+#~ msgid "Complete!"
+#~ msgstr "Deiseil!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Dh’fhàillig an cailbhreachadh!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr ""
+#~ "’S urrainn dhut an t-uidheam cailbhreachaidh a thoirt air falbh a-nis."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Na bean ris an uidheam chailbhreachaidh fhad ’s a tha e trang"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Sgrìn laptop"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Camara-lìn ’na bhroinn"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monatair %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Sganair %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Camara %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Clò-bhualadair %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Camara-lìn %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Cuir an comas stiùireadh dhathan airson %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Seall na pròifilean dhathan airson %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Cha deach a chailbhreachadh"
+
+#~ msgid "Default: "
+#~ msgstr "Tùsail: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Spàs nan dathan: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Pròifil deuchainne: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Tagh faidhle pròifil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Ion-phortaich"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Pròifilean ICC ris a bheil taic"
+
+#~ msgid "All files"
+#~ msgstr "A h-uile faidhle"
+
+#~ msgid "Save Profile"
+#~ msgstr "Sàbhail a’ phròifil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Cruthaich pròifil dhathan airson an uidheim a thagh thu"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Cha do mhothaich sinn ri inneal tomhais. Dèan cinnteach gu bheil e air "
+#~ "agus ceangailte ris mar bu chòir."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr ""
+#~ "Chan eil an t-inneal tomhais a’ cur taic ri pròifileadh chlò-"
+#~ "bhualadairean."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Chan eil taic ris an t-seòrsa seo a dh’uidheam aig an àm seo."
+
+#~ msgid "Standard Space"
+#~ msgstr "Spàs stannardach"
+
+#~ msgid "Test Profile"
+#~ msgstr "Pròifil deuchainne"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Fèin-obrachail"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Càileachd ìseal"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Càileachd mheadhanach"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Càileachd àrd"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB tùsail"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK tùsail"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Liath tùsail"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Dàta cailbhreachaidh tùsail a sholair an reiceadair"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "Cha ghabh ceartachadh taisbeanadh làn-sgrìn a dhèanamh sa phròifil seo"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Dh’fhaoidte nach eil a’ phròifil seo ceart tuilleadh"
+
+#~ msgid "Other…"
+#~ msgstr "Eile…"
+
+#, fuzzy
+#~| msgid "Bluetooth Settings"
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Roghainnean Bluetooth"
+
+#~ msgid "Today"
+#~ msgstr "An-diugh"
+
+#~ msgid "Yesterday"
+#~ msgstr "An-dè"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, fuzzy, c-format
+#~| msgid "%i hour"
+#~| msgid_plural "%i hours"
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%i uair a thìde"
+#~ msgstr[1] "%i uair a thìde"
+#~ msgstr[2] "%i uairean a thìde"
+#~ msgstr[3] "%i uair a thìde"
+
+#, fuzzy, c-format
+#~| msgid "%i minute"
+#~| msgid_plural "%i minutes"
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%i mhionaid"
+#~ msgstr[1] "%i mhionaid"
+#~ msgstr[2] "%i mionaidean"
+#~ msgstr[3] "%i mionaid"
+
+#, fuzzy, c-format
+#~| msgid "30 seconds"
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "30 diog"
+#~ msgstr[1] "30 diog"
+#~ msgstr[2] "30 diog"
+#~ msgstr[3] "30 diog"
+
+#, fuzzy, c-format
+#~| msgid "%i %s %i %s"
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%i %s %i %s"
+
+#, fuzzy, c-format
+#~| msgid "%i %s %i %s"
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%i %s %i %s"
+
+#, fuzzy, c-format
+#~| msgid "%i %s %i %s"
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%i %s %i %s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24 uairean"
+
+#~ msgid "AM / PM"
+#~ msgstr "m/f"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %P"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %P"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "Sending reports of technical problems helps us improve %s. Reports are "
+#~| "sent anonymously and are scrubbed of personal data."
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Ma chuireas tu aithrisean air duilgheadasan teicnigeach a-null, "
+#~ "cuidichidh seo ach an leasaich sinn %s. Thèid na h-aithrisean a chur gun "
+#~ "urra agus gach dàta pearsanta a thoirt air falbh uapa."
+
+#~ msgid "On"
+#~ msgstr "Air"
+
+#~ msgid "Off"
+#~ msgstr "Dheth"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "A bheil thu airson na h-atharraichean a chur an sàs?"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Rian nan uidheaman-taisbeanaidh"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Dreach-tìre"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portraid dheas"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portraid chlì"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Dreach-tìre (air a chuairteachadh)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Unknown"
+#~ msgstr "Chan eil fhios"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-biod"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-biod"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#, fuzzy
+#~| msgid "Unknown"
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Chan eil fhios"
+
+#, fuzzy
+#~| msgid "System"
+#~ msgid "System Logo"
+#~ msgstr "Siostam"
+
+#~ msgid "No input sources found"
+#~ msgstr "Cha deach tùs ion-chuir a lorg"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Eile"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Ath-ghoiridean gnàthaichte"
+
+#, fuzzy
+#~| msgid "Left+Right Alt"
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt clì + deas"
+
+#, fuzzy
+#~| msgid "Left+Right Alt"
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt clì + deas"
+
+#, fuzzy
+#~| msgid "Left thumb"
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "An òrdag chlì"
+
+#, fuzzy
+#~| msgid "Right thumb"
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "An òrdag dheas"
+
+#, fuzzy
+#~| msgid "Security key"
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "An iuchair tèarainteachd"
+
+#, fuzzy
+#~| msgid "Right Half"
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "An leth dheas"
+
+#, fuzzy
+#~| msgid "Scroll Left"
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Sgrolaich dhan taobh chlì"
+
+#, fuzzy
+#~| msgid "Login _Screen"
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "_Sgrìn a’ chlàraidh a-steach"
+
+#, fuzzy, c-format
+#~| msgid "You can change these shortcuts in the keyboard settings"
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "’S urrainn dhut na h-ath-ghoiridean seo atharrachadh ann an roghainnean "
+#~ "a’ mheur-chlàir"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "A bheil thu airson na h-ath-ghoiridean uile ath-shuidheachadh?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Ma nì thu ath-shuidheachadh air na h-ath-ghoiridean agad, dh’fhaoidte gum "
+#~ "bi buaidh air sin air na h-ath-ghoiridean gnàthaichte agad. Cha ghabh sin "
+#~ "a neo-dhèanamh."
+
+#~ msgid "Reset All"
+#~ msgstr "Ath-shuidhich na h-uile"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "%s is already being used for <b>%s</b>. If you replace it, %s will be "
+#~| "disabled"
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "Tha %s ’ga chleachdadh airson <b>%s</b> mar-thà. Ma chuireas tu rud ’na "
+#~ "àite, thèid %s a chur à comas"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Cuir a-steach an ath-ghoirid ùr"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Suidhich ath-ghoirid ghnàthaichte"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Suidhich ath-ghoirid"
+
+#, fuzzy, c-format
+#~| msgid "Enter new shortcut to change <b>%s</b>."
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Cuir a-steach an ath-ghoirid a dh’atharrachadh <b>%s</b>."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Cuir ath-ghoirid ghnàthaichte ris"
+
+#~ msgid "Set"
+#~ msgstr "Suidhich"
+
+#, fuzzy
+#~| msgid "Screen Turns Off"
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Thèid na sgrìnichean dheth"
+
+#, fuzzy
+#~| msgid "30 seconds"
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 diog"
+
+#, fuzzy
+#~| msgid "1 minute"
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 mhionaid"
+
+#, fuzzy
+#~| msgid "2 minutes"
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 mhionaid"
+
+#, fuzzy
+#~| msgid "3 minutes"
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 mionaidean"
+
+#, fuzzy
+#~| msgid "5 minutes"
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 mionaidean"
+
+#, fuzzy
+#~| msgid "30 minutes"
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "Leth-uair a thìde"
+
+#, fuzzy
+#~| msgid "1 hour"
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 uair a thìde"
+
+#, fuzzy
+#~| msgid "1 minute"
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 mhionaid"
+
+#, fuzzy
+#~| msgid "2 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 mhionaid"
+
+#, fuzzy
+#~| msgid "3 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 mionaidean"
+
+#, fuzzy
+#~| msgid "4 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 mionaidean"
+
+#, fuzzy
+#~| msgid "5 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 mionaidean"
+
+#, fuzzy
+#~| msgid "8 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 mionaidean"
+
+#, fuzzy
+#~| msgid "10 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 mionaidean"
+
+#, fuzzy
+#~| msgid "12 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 mhionaid"
+
+#, fuzzy
+#~| msgid "15 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "Cairteal na h-uarach"
+
+#, fuzzy
+#~| msgid "Never"
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Chan ann idir"
+
+#, fuzzy
+#~| msgid "Lock screen"
+#~ msgid "Lock your screen"
+#~ msgstr "Glais an sgrìn"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Sgroladh dà-chorragach"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Còig briogaidhean, àm GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Briogadh dùbailte, prìomh-phutan"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Briogadh singilte, prìomh-phutan"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Briogadh dùbailte, putan meadhain"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Briogadh singilte, putan meadhain"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Briogadh dùbailte, an dàrna putan"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Briogadh singilte, an dàrna putan"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Feumaidh NetworkManager a bhith a’ ruith."
+
+#, fuzzy, c-format
+#~| msgctxt "timezone desc"
+#~| msgid "%s (%s)"
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr ""
+#~ "A bheil thu airson stad a chur air an hotspot is cleachdaiche sam bith "
+#~ "eile a dhì-cheangal?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Cuir stad air an hotspot"
+
+#, fuzzy
+#~| msgid "reset"
+#~ msgid "Preserve"
+#~ msgstr "ath-shuidhich"
+
+#, fuzzy
+#~| msgid "Tablet"
+#~ msgid "Stable"
+#~ msgstr "Tablaid"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Pròifil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Chan eil gin"
+
+#~ msgid "Never"
+#~ msgstr "Chan ann idir"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Chan eil gin"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Lag"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ceart ma-thà"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Math"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Fìor-mhath"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Dìochuimhnich an ceangal"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Thoir air falbh pròifil a’ cheangail"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Thoir air falbh a’ VPN"
+
+#~ msgid "Details"
+#~ msgstr "Mion-fhiosrachadh"
+
+#~ msgid "automatic"
+#~ msgstr "fèin-obrachail"
+
+#~ msgid "Identity"
+#~ msgstr "Dearbh-aithne"
+
+#~ msgid "Delete Address"
+#~ msgstr "Sguab às an seòladh"
+
+#~ msgid "Delete Route"
+#~ msgstr "Sguab às an t-slighe"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Chan eil gin"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Iuchair WEP 40/128-bit (Hex no ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Abairt-fhaire WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamic WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA ⁊ WPA2 pearsanta"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA ⁊ WPA2 Enterprise"
+
+#, fuzzy
+#~| msgctxt "category"
+#~| msgid "Personal"
+#~ msgid "WPA3 Personal"
+#~ msgstr "Pearsanta"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Chan urrainn dhuinn deasaiche nan ceanglaichean fhosgladh"
+
+#~ msgid "New Profile"
+#~ msgstr "Pròifil ùr"
+
+#~ msgid "Import from file…"
+#~ msgstr "Ion-phortaich o fhaidhle…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Cuir ris VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Chan urrainn dhuinn an ceangal VPN ion-phortadh"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Cha b’ urrainn dhuinn am faidhle “%s” a leughadh no chan eil dàta sam "
+#~ "bith ’na bhroinn leis an dèanar ceangal VPN\n"
+#~ "\n"
+#~ "Mearachd: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Tagh faidhle a thèid ion-phortadh"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Tha faidhle air a bheil “%s” ann mu thràth."
+
+#~ msgid "_Replace"
+#~ msgstr "Cui_r ’na àite"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "A bheil thu airson an ceangal VPN a tha thu a’ sàbhaladh a chur an àite "
+#~ "“%s”?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Chan urrainn dhuinn an ceangal VPN às-phortadh"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Cha b’ urrainn dhuinn an ceangal VPN “%s” às-phortadh gu %s.\n"
+#~ "\n"
+#~ "Mearachd: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Às-phortaich ceangal VPN"
+
+#~ msgid "never"
+#~ msgstr "Chan ann idir"
+
+#~ msgid "today"
+#~ msgstr "an-diugh"
+
+#~ msgid "yesterday"
+#~ msgstr "an-dè"
+
+#~ msgid "Last used"
+#~ msgstr "Air a chleachdadh an turas mu dheireadh"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Thèid fiosrachadh nan lìonraidhean a thagh thu, a’ gabhail a-steach an "
+#~ "fhacail-fhaire ’s rèiteachadh gnàthaichte sam bith, air chall."
+
+#~ msgid "_Forget"
+#~ msgstr "_Dìochuimhnich"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Lìonraidhean WiFi as aithne dhuinn"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Dìochuimhnich"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr ""
+#~ "Chan eil e ceadaichte a chleachdadh mar hotspot ri linn poileasaidh an t-"
+#~ "siostaim"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Chan eil an t-uidheam uèirleas a’ cur taic ris a’ mhodh hotspot"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Nuair nach eil URL rèiteachaidh ’ga thoirt seachad, thèid fhèin-lorg "
+#~ "progsaidh lìonraidh a chleachdadh."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Cha mholamaid seo air lìonraidhean poblach anns nach eil earbsa."
+
+#~ msgid "Status unknown"
+#~ msgstr "Chan eil fhios dè an staid"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Gun stiùireadh"
+
+#~ msgid "Unavailable"
+#~ msgstr "Chan eil seo ri fhaighinn"
+
+#~ msgid "Connecting"
+#~ msgstr "A’ ceangal"
+
+#~ msgid "Authentication required"
+#~ msgstr "Tha feum air dearbhadh"
+
+#~ msgid "Disconnecting"
+#~ msgstr "A’ briseadh a’ cheangail"
+
+#~ msgid "Connection failed"
+#~ msgstr "Dh’fhàillig an ceangal"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Chan eil fhios dè an staid (a dhìth)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Dh’fhàillig an rèiteachadh"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Dh’fhàillig rèiteachadh an IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Dh’fhalbh an ùine air rèiteachadh an IP"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Bha feum air rùintean ach cha dug thu seachad gin"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Chaidh an ceangal ris an athchuingiche 802.1x a bhriseadh"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Dh’fhàillig rèiteachadh an athchuingiche 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Dh’fhàillig an t-athchuingiche 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Thug dearbhadh an t-athchuingiche 802.1x ro fhada"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Dh’fhàillig tòiseachadh na seirbheise PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Chaidh an ceangal ris an t-seirbheis PPP a bhriseadh"
+
+#~ msgid "PPP failed"
+#~ msgstr "Dh’fhàillig PPP"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Dh’fhàillig thòiseachadh a’ chliant DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Mearachd a’ chliant DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Dh’fhàillig an cliant DCHP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Dh’fhàillig tòiseachadh seirbheis a’ cheangail cho-roinnte"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Dh’fhàillig seirbheis a’ cheangail cho-roinnte"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Dh’fhàillig tòiseachadh na seirbheise AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Mearachd na seirbheise AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Dh’fhàillig an t-seirbheis AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "Tha an loidhne trang"
+
+#~ msgid "No dial tone"
+#~ msgstr "Chan eil fuaim daithealaidh ann"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Cha b’ urrainn giùlanair a stèidheachadh"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Dh’fhalbh an ùine air an iarrtas daithealaidh"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Dh’fhàillig an oidhirp daithealaidh"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Dh’fhàillig tòiseachadh a’ mhòdaim"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Dh’fhàillig taghadh an APN a shònraich thu"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Chan eilear a’ sireadh lìonraidhean"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Chaidh clàradh an lìonraidh a dhiùltadh"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Dh’fhalbh an ùine air clàradh an lìonraidh"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Cha b’ urrainn dhuinn clàradh aig an lìonra a dh’iarr thu"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Dh’fhàillig sgrùdadh a’ PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Dh’fhaoidte gu bheil am bathar-an-sàs airson an uidheim a dhìth"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Dh’fhalbh an ceangal"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Chaidh ceangal a bha ann a ghabhail os làimh"
+
+#~ msgid "Modem not found"
+#~ msgstr "Cha deach am mòdam a lorg"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Dh’fhàillig an ceangal Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Cha deach cairt SIM a chur a-steach"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Tha feum air PIN an SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Tha feum air PUK an SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Tha an SIM cearr"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Dh’fhàillig eisimeileachd a’ cheangail"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Tha bathar-an-sàs a dhìth"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Chan eil an càball a-staigh"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "mearachd gun sònrachadh san tèarainteachd 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "cha deach faidhle a thaghadh"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "mearachd gun sònrachadh le dearbhadh an fhaidhle eap-method"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr ""
+#~ "Iuchraichean prìobhaideach DER, PEM no PKCS#12 (*.der, *.pem, *.p12, *."
+#~ "key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER no teisteanasan PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "tha faidhle EAP-FAST PAC a dhìth"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Faidhlichean PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "tha ainm-cleachdaiche EAP-LEAP a dhìth"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "tha facal-faire EAP-LEAP a dhìth"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "teisteanas EAP-PEAP CA mì-dhligheach: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "teisteanas EAP-PEAP CA mì-dhligheach: cha deach teisteanas a shònrachadh"
+
+#~ msgid "missing EAP username"
+#~ msgstr "tha ainm-cleachdaiche EAP a dhìth"
+
+#~ msgid "missing EAP password"
+#~ msgstr "tha facal-faire EAP a dhìth"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "tha dearbh-aithne EAP-TLS a dhìth"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "teisteanas EAP-TLS CA mì-dhligheach: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "teisteanas EAP-TLS CA mì-dhligheach: cha deach teisteanas a shònrachadh"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "iuchair phrìobhaideach EAP-TLS mhì-dhligheach: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "teisteanas cleachdaiche EAP-TLS mì-dhligheach: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Chan eil iuchraichean prìobhaideach gun chrioptachadh tèarainte"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Tha coltas nach eil an iuchair phrìobhaideach a thagh thu air a "
+#~ "chrioptachadh. Bheireadh sin cothrom do dhaoine an t-ainm is facal-faire "
+#~ "agad a ghoid. Tagh iuchair phrìobhaideach a tha fo dhìon facail-fhaire.\n"
+#~ "\n"
+#~ "(’S urrainn dhut an iuchair phrìobhaideach agad a dhìon le openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Tagh an teisteanas prìobhaideach agad"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Tagh an iuchair phrìobhaideach agad"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "teisteanas EAP-TTLS CA mì-dhligheach: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "teisteanas EAP-TTLS CA mì-dhligheach: cha deach teisteanas a shònrachadh"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Mearachd nach aithne dhuinn le dearbhadh tèarainteachd 802.1X"
+
+#, fuzzy
+#~| msgid "Select a File…"
+#~ msgid "Select a file"
+#~ msgstr "Tagh faidhle…"
+
+#~ msgid "missing leap-username"
+#~ msgstr "tha ainm-cleachdaiche leap a dhìth"
+
+#~ msgid "missing leap-password"
+#~ msgstr "tha facal-faire leap a dhìth"
+
+#, fuzzy
+#~| msgid "invalid EAP-TLS password: missing"
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "facal-faire EAP-TLS mì-dhligheach: chan eil gin ann"
+
+#~ msgid "missing wep-key"
+#~ msgstr "tha iuchair wep a dhìth"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "tha an iuchair wep mì-dhligheach: chan fhaod ach figearan sia-dheicheach "
+#~ "a bhith am broinn iuchair a tha %zu a dh’fhaid"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "tha an iuchair wep mì-dhligheach: chan fhaod ach caractaran ASCII a bhith "
+#~ "am broinn iuchair a tha %zu a dh’fhaid"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "tha an iuchair wep mì-dhligheach: tha faide na iuchrach %zu cearr. "
+#~ "Feumaidh iuchair a bith 5/13 (ascii) no 10/26 (sia-dheicheach) a dh’fhaid"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr ""
+#~ "tha an iuchair wep mì-dhligheach: chan fhaod an abairt-fhaire a bhith "
+#~ "falamh"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "tha an iuchair wep mì-dhligheach: chan fhaod an abairt-fhaire a bhith nas "
+#~ "giorra na 64 caractar"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk mì-dhligheach: tha faide na h-iuchrach %zu mì-dhligheach. "
+#~ "Feumaidh i bhith [8,63] baidht no 64 figear sia-dheicheach"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk mì-dhligheach: cha ghabh an iuchair tuigsinn mar àireamh shia-"
+#~ "dheicheach a tha 43 baidht a dh’fhaid"
+
+#, fuzzy, c-format
+#~| msgid "<b>%s</b> removed"
+#~ msgid "%s removed"
+#~ msgstr "Chaidh <b>%s</b> a toirt air falbh"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Eile"
+
+#~ msgid "Error removing account"
+#~ msgstr "Mearachd a’ toirt air falbh a’ chunntais"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Cunntas %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Thoir air falbh an cunntas"
+
+#~ msgid "Unknown time"
+#~ msgstr "Chan eil fhios dè cho fad"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s gus am bi e air a làn-teairrdseadh"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Rabhadh: %s air fhàgail"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s air fhàgail"
+
+#~ msgid "Fully charged"
+#~ msgstr "Air a làn-teairrdseadh"
+
+#, fuzzy
+#~| msgid "Charging"
+#~ msgid "Not charging"
+#~ msgstr "A’ teairrdseadh"
+
+#~ msgid "Empty"
+#~ msgstr "Falamh"
+
+#~ msgid "Charging"
+#~ msgstr "A’ teairrdseadh"
+
+#~ msgid "Discharging"
+#~ msgstr "’Ga dhì-theairrdseadh"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Luchag uèirleas"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Meur-chlàr uèirleas"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Solar cumhachd do-bhrisidh"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Cuidiche digiteach pearsanta"
+
+#~ msgid "Cellphone"
+#~ msgstr "Fòn-làimhe"
+
+#~ msgid "Media player"
+#~ msgstr "Cluicheadair mheadhanan"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablaid"
+
+#~ msgid "Computer"
+#~ msgstr "Coimpiutair"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Uidheam ion-chuir geama"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Prìomh-bhataraidh"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Bataraidh a bharrachd"
+
+#~ msgid "Batteries"
+#~ msgstr "Bataraidhean"
+
+#~ msgid "When _idle"
+#~ msgstr "Nua_ir a bhios e ’na thàmh"
+
+#~ msgid "Suspend"
+#~ msgstr "Cuir ’na dhàil"
+
+#~ msgid "Power Off"
+#~ msgstr "Cumhachd dheth"
+
+#~ msgid "Hibernate"
+#~ msgstr "Dèan cadal-geamhraidh"
+
+#~ msgid "Nothing"
+#~ msgstr "Na dèan dad"
+
+#~ msgid "When on battery power"
+#~ msgstr "Nuair a bhithear air cumhachd bataraidh"
+
+#~ msgid "When plugged in"
+#~ msgstr "Nuair a bhios e air a phlugadh a-steach"
+
+#, fuzzy
+#~| msgid "Never"
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Chan ann idir"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Cur ’na dhàil fèin-obrachail"
+
+#, fuzzy
+#~| msgid "_Balance:"
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Cothro_m:"
+
+#, fuzzy
+#~| msgid "Power Saving"
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Caomhnadh cumhachd"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Chaidh an clò-bhualadair “%s” a sguabadh às"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Cha b’ urrainn dhuinn an eadar-aghaidh %s a luchdadh"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Fiosrachadh air %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Cha deach draibhear freagarrach a lorg"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Tagh faidhle PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Faidhlichean PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *."
+#~ "PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Clò-bhualadair JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Clò-bualadair LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Aon-taobhach"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Oir fhada (stannardach)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Oir ghoirid (Flip)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portraid"
+
+#~ msgid "Landscape"
+#~ msgstr "Dreach-tìre"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Dreach-tìre contrarra"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Portraid chontrarra"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Ri dhèanamh"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "’Na stad"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Tha feum air dearbhadh"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "’Ga phròiseasadh"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Sguireadh dheth"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Sguireadh dheth"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Sguireadh dheth"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Air a choileanadh"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s – Obraichean gnìomhach"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Cuir a-steach teisteas airson clò-bhualadh o %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Thoir a’ ghlas far an fhrithealaiche clò-bhualaidh"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Thoir a’ ghlas far %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Cuir a-steach ainm-cleachdaiche ’s facal-faire gus na clò-bhualadairean "
+#~ "fhaicinn a tha ri làimh air %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "A’ lorg clò-bhualadairean"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Port sreathach"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Port co-shìnte"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Ionad: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Seòladh: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Feumaidh am frithealaiche dearbhadh"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dà-thaobhach"
+
+#~ msgid "Paper Type"
+#~ msgstr "Seòrsa a’ phàipeir"
+
+#~ msgid "Paper Source"
+#~ msgstr "Tùs a’ phàipeir"
+
+#~ msgid "Output Tray"
+#~ msgstr "Treidhe às-chuir"
+
+#, fuzzy
+#~| msgid "Resolution"
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Dùmhlachd-bhreacaidh"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Ro-chriathradh GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Duilleagan air gach taobh"
+
+#~ msgid "Orientation"
+#~ msgstr "Comhair"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Coitcheann"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Suidheachadh na duilleige"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Roghainnean a gabhas stàladh"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Obair"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Càileachd an deilbh"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Dath"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Lìomhadh"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Adhartach"
+
+#~ msgid "Test page"
+#~ msgstr "Duilleag deuchainne"
+
+#~ msgid "Auto Select"
+#~ msgstr "Taghadh fèin-obrachail"
+
+#~ msgid "Printer Default"
+#~ msgstr "Bun-roghainnean a’ chlò-bhualadair"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Na leabaich ach cruthan-clò GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Iompaich ’na PS leibheil 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Iompaich ’na PS leibheil 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Gun ro-chriathradh"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Glan na cinn clò-bhualaidh"
+
+#~ msgid "Out of toner"
+#~ msgstr "Chan eil tònair air fhàgail"
+
+#~ msgid "Low on developer"
+#~ msgstr "Stuth-leasachaidh gann"
+
+#~ msgid "Out of developer"
+#~ msgstr "Chan eil stuth-leasachaidh air fhàgail"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Dath gann ann am biona a’ chlò-bhualadair"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Chan eil dath air fhàgail ann am biona a’ chlò-bhualadair"
+
+#~ msgid "Open cover"
+#~ msgstr "Tha am mullach fosgailte"
+
+#~ msgid "Open door"
+#~ msgstr "Tha an doras fosgailte"
+
+#~ msgid "Low on paper"
+#~ msgstr "Pàipear gann"
+
+#~ msgid "Out of paper"
+#~ msgstr "Chan eil pàipear air fhàgail"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Far loidhne"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Sguireadh dheth"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Tha soitheach an sgudail cha mhòr làn"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Tha soitheach an sgudail làn"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Tha am foto-ghiùlanair lèirsinneach a’ dol bàs"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Chan eil am foto-ghiùlanair lèirsinneach ag obair tuilleadh"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Deiseil"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Cha ghabh e ri obraichean"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "’Ga phròiseasadh"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Impireil"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Meatraigeach"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Faighnich dhìom"
+
+#~ msgid "Do nothing"
+#~ msgstr "Na dèan dad"
+
+#~ msgid "Open folder"
+#~ msgstr "Fosgail am pasgan"
+
+#~ msgid "Other Media"
+#~ msgstr "Meadhanan eile"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Tagh aplacaid airson CDan fuaime"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Tagh aplacaid airson DVDan video"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Tagh aplacaid a thèid a ruith nuair a cheanglar cluicheadair ciùil ris"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Tagh aplacaid a thèid a ruith nuair a cheanglar camara ris"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Tagh aplacaid airson CDan bathair-bhog"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD fuaime"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "diosg Blu-ray bàn"
+
+#~ msgid "blank CD disc"
+#~ msgstr "diosg CD bàn"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "diosg DVD bàn"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "diosg DVD HD bàn"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "diosg video Blu-ray bàn"
+
+#~ msgid "e-book reader"
+#~ msgstr "leughadair leabhair-d"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "diosg video DVD HD"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD dhealbhan"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "Select Location"
+#~ msgstr "Tagh ionad"
+
+#~ msgid "_OK"
+#~ msgstr "_Ceart ma-tha"
+
+#~ msgid "No applications found"
+#~ msgstr "Cha deach aplacaid sam bith a lorg"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Cha deach lìonra a thaghadh a chum co-roinnidh"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Air"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Dheth"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "An comas"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Tagh pasgan"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "File Sharing allows you to share your Public folder with others on your "
+#~| "current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Bheir co-roinneadh fhaidhlichean comas dhut am pasgan poblach agad a cho-"
+#~ "roinneadh le daoine eile air an lìonra làithreach agad slighe: <a "
+#~ "href=\"dav://%s\">dav://%s</a>"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "When remote login is enabled, remote users can connect using the Secure "
+#~| "Shell command:\n"
+#~| "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ma tha an clàradh a-steach cèin an coma, ’s urrainn dha chleachdaichean "
+#~ "ceangal a dhèanamh on taobh a-muigh slighe na h-àithne Secure Shell:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#~ msgid "Custom"
+#~ msgstr "Gnàthaichte"
+
+#~ msgid "Bark"
+#~ msgstr "Comhartaich"
+
+#~ msgid "Drip"
+#~ msgstr "Friog-frag"
+
+#~ msgid "Glass"
+#~ msgstr "Glainne"
+
+#~ msgid "Sonar"
+#~ msgstr "Sònar"
+
+#, fuzzy, c-format
+#~| msgid "Settings"
+#~ msgid "Testing %s"
+#~ msgstr "Roghainnean"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#, fuzzy
+#~| msgid "Disconnecting"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "A’ briseadh a’ cheangail"
+
+#, fuzzy
+#~| msgid "Connecting"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "A’ ceangal"
+
+#, fuzzy
+#~| msgid "Connected"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Ceangailte"
+
+#, fuzzy
+#~| msgid "Authentication required"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Tha feum air dearbhadh"
+
+#, fuzzy
+#~| msgid "Connected Devices"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Uidheaman a tha ceangailte ris"
+
+#, fuzzy
+#~| msgid "Unknown"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Chan eil fhios"
+
+#, fuzzy
+#~| msgid "Connected"
+#~ msgid "Connected at:"
+#~ msgstr "Ceangailte"
+
+#, fuzzy
+#~| msgid "_Enroll"
+#~ msgid "Enrolled at:"
+#~ msgstr "_Clàraich"
+
+#, fuzzy
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#, fuzzy
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to forget device: "
+#~ msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#, fuzzy
+#~| msgid "Mirror"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Sgàthanaich"
+
+#, fuzzy
+#~| msgid "Authenticated"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Air a dhearbhadh"
+
+#, fuzzy
+#~| msgid "The profile could not be generated."
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Cha b’ urrainn dhuinn a’ phròifil a ghintinn."
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Bun-roghainn"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Meadhanach"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Mòr"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Nas motha"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "As motha"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d phiogsail"
+#~ msgstr[1] "%d phiogsail"
+#~ msgstr[2] "%d piogsailean"
+#~ msgstr[3] "%d piogsail"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Goirid"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ dhen sgrìn"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ dhen sgrìn"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ dhen sgrìn"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Fada"
+
+#, fuzzy
+#~| msgid "1 hour"
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 uair a thìde"
+
+#, fuzzy
+#~| msgid "1 day"
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 latha"
+
+#, fuzzy
+#~| msgid "2 days"
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 latha"
+
+#, fuzzy
+#~| msgid "3 days"
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 làithean"
+
+#, fuzzy
+#~| msgid "4 days"
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 làithean"
+
+#, fuzzy
+#~| msgid "5 days"
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 làithean"
+
+#, fuzzy
+#~| msgid "6 days"
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 làithean"
+
+#, fuzzy
+#~| msgid "7 days"
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 làithean"
+
+#, fuzzy
+#~| msgid "14 days"
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "Cola-deug"
+
+#, fuzzy
+#~| msgid "30 days"
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 latha"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "A bheil thu airson an sgudal fhalamhachadh gu tur?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Thèid gach rud san sgudal a sguabadh às gu buan."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Falamhaich an sgudal"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "A bheil thu airson na faidhlichean sealach a sguabadh às?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Thèid gach faidhle sealach a sguabadh às gu buan."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Purgaidich na faidhlichean sealach"
+
+#, fuzzy
+#~| msgid "1 day"
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 latha"
+
+#, fuzzy
+#~| msgid "7 days"
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 làithean"
+
+#, fuzzy
+#~| msgid "30 days"
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 latha"
+
+#, fuzzy
+#~| msgid "Forever"
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Gu buan"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr ""
+#~ "Bu chòir dha a bhith co-ionnann ri seòladh-lìn solaraiche a’ chlàraidh a-"
+#~ "steach agad."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Cha b’ urrainn dhuinn an cunntas a chur ris"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Cha b’ urrainn dhuinn an cunntas a chlàradh"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr ""
+#~ "Chan eil dòigh sam bith ann ris a bheil taic agus leis an urrainnear "
+#~ "dearbhadh a dhèanamh air an àrainn seo"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Cha b’ urrainn dhuinn ceangal ris an àrainn"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Cha do dh’obraich an t-ainm sin.\n"
+#~ "Feuch ris a-rithist."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Cha do dh’obraich am facal-faire sin.\n"
+#~ "Feuch ris a-rithist."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Cha b’ urrainn dhuinn clàradh a-steach aig an àrainn"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr ""
+#~ "Chan fhaigh sinn greim air an àrainn. Saoil a bheil e air a dheagh-"
+#~ "litreachadh?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Brabhsaich airson barrachd dhealbhan"
+
+#, fuzzy
+#~| msgid "The device is already in use."
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "Tha an t-uidheam seo ’ga chleachdadh mu thràth."
+
+#, fuzzy
+#~| msgid "Failed to register with the requested network"
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Cha b’ urrainn dhuinn clàradh aig an lìonra a dh’iarr thu"
+
+#, fuzzy
+#~| msgid "Could not access any fingerprint readers"
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr ""
+#~ "Cha b’ urrainn dhuinn cothrom fhaighinn air leughadair mheur-lorgan sam "
+#~ "bith"
+
+#, fuzzy, c-format
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#, fuzzy, c-format
+#~| msgid "Failed to delete user"
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Cha b’ urrainn dhuinn an cleachdaiche a sguabadh às"
+
+#~ msgid "Left thumb"
+#~ msgstr "An òrdag chlì"
+
+#~ msgid "Left middle finger"
+#~ msgstr "An gunna fada clì"
+
+#~ msgid "_Left index finger"
+#~ msgstr "An sgealbag _chlì"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Mac an aba clì"
+
+#~ msgid "Left little finger"
+#~ msgstr "An lùdag bheag chlì"
+
+#~ msgid "Right thumb"
+#~ msgstr "An òrdag dheas"
+
+#~ msgid "Right middle finger"
+#~ msgstr "An gunna fada deas"
+
+#~ msgid "_Right index finger"
+#~ msgstr "An sgealbag _dheas"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Mac an aba deas"
+
+#~ msgid "Right little finger"
+#~ msgstr "An lùdag bheag dheas"
+
+#, fuzzy
+#~| msgid "Unknown time"
+#~ msgid "Unknown Finger"
+#~ msgstr "Chan eil fhios dè cho fad"
+
+#, fuzzy
+#~| msgid "Complete!"
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Deiseil!"
+
+#, fuzzy
+#~| msgid "PPP service disconnected"
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Chaidh an ceangal ris an t-seirbheis PPP a bhriseadh"
+
+#, fuzzy
+#~| msgid "Failed to add new printer."
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
+
+#, fuzzy, c-format
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#, fuzzy
+#~| msgid "Failed to add new printer."
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
+
+#, fuzzy, c-format
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#, fuzzy
+#~| msgid "Enrolling fingerprints"
+#~ msgid "Scan new fingerprint"
+#~ msgstr "A’ clàradh nam meur-lorgan"
+
+#, fuzzy
+#~| msgid "Problem Reporting"
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Ag aithris air duilgheadasan"
+
+#, fuzzy, c-format
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#, fuzzy, c-format
+#~| msgid "Failed to add new printer."
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
+
+#~ msgid "This Week"
+#~ msgstr "An t-seachdain-sa"
+
+#~ msgid "Last Week"
+#~ msgstr "An t-seachdain seo chaidh"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k.%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Thàinig an seisean gu crìoch"
+
+#~ msgid "Session Started"
+#~ msgstr "Thòisich an seisean"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s – Gnìomhachd a’ chunntais"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Tagh facal-faire eile."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Nach cuir thu am facal-faire làithreach agad a-rithist?"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Cha b’ urrainn dhuinn am facal-faire atharrachadh"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr ""
+#~ "Chan urrainnear pàirt a ghabhail sa leithid seo de dh’àrainn gu fèin-"
+#~ "obrachail"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Cha deach àrainn no rìoghachd mar sin a lorg"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Chan urrainn dhut clàradh a-steach mar %s air an àrainn %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Tha am facal-faire cearr, nach fheuch thu ris a-rithist?"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Cha b’ urrainn ceangal ris an àrainn %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Cha b’ urrainn dhuinn an cleachdaiche a sguabadh às"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Cha deach leinn an cleachdaiche fo stiùireadh cèin a chùl-ghairm"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Chan urrainn dhut an cunntas agad fhèin a sguabadh às."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "Tha %s clàraichte a-staigh fhathast"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Ma sguabas tu às cleachdaiche fhad ’s a tha iad clàraichte a-staigh "
+#~ "fhathast, dh’fhaoidte gum fàg sin an siostam neo-sheasmhach."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "A bheil thu airson na faidhlichean aig %s a chumail?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Gabhaidh am pasgan dachaidh, spàl a’ phuist agus na faidhlichean sealach "
+#~ "a ghlèidheadh nuair a sguabar às cunntas cleachdaiche."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Sguab às na faidhlichean"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Cum na faidhlichean"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "A bheil thu cinnteach gu bheil thu airson an cunntas aig %s fo stiùireadh "
+#~ "cèin a chùl-ghairm?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Sguab às"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Chaidh an cunntas a chur à comas"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Ri shuidheachadh an ath-thuras a nithear clàradh a-steach"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Chan eil gin"
+
+#~ msgid "Logged in"
+#~ msgstr "Air clàradh a-steach"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Cha b’ urrainn dhuinn fios a chur gu seirbheis nan cunntasan"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Dèan cinnteach gun deach AccountService a stàladh agus an comas."
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Sguab às cunntas a’ chleachdaiche a thagh thu"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Gus cunntas a’ chleachdaiche a thagh thu a sguabadh às,\n"
+#~ "briog air an ìomhaigheag * an toiseach"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Chan fhaod an seann fhacal-faire ’s am fear ùr a bhith co-ionnann."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Feuch is atharraich cuid dhe na litrichean is àireamhan."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Feuch is atharraich am facal-faire beagan a bharrachd"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr ""
+#~ "Bhiodh facal-faire as aonais an ainm-chleachdaiche agad nas làidire."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Feuch is na cleachd d’ ainm san fhacal-fhaire."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Feuch is seachain cuid dhe na faclan a tha san fhacal-fhaire."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Feuch is seachain faclan cumanta."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Feuch is seachain fìor-fhaclan ath-òrdachadh."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Feuch is cleachd barrachd àireamhan."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Feuch is cleachd barrachd litrichean mòra."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Feuch is cleachd barrachd litrichean beaga."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Feuch is cleachd barrachd charactaran sònraichte mar phuingeachadh."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Feuch is cleachd measgachadh de litrichean, àireamhan is puingeachadh."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Feuch is seachain an aon charactar a-rithist ’s a-rithist."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Feuch is seachain an aon seòrsa de charactar a-rithist ’s a-rithist: "
+#~ "feumaidh tu measgachadh de litrichean, àireamhan is puingeachadh."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Feuch is seachain sreathan mar 1234 no abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Feumaidh faclan-faire a bhith nas fhaide. Feuch is cuir ris barrachd "
+#~ "litrichean, àireamhan is puingeachadh."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Cleachd litrichean mòra ’s beaga agus feuch an cleachd thu àireamh no dhà."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Bidh e nas treasa ma chuireas tu barrachd litrichean, àireamhan is "
+#~ "puingeachadh ris."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Dh’fhàillig an dearbhadh"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Tha am facal-faire ùr ro ghoirid"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Tha am facal-faire ùr ro shimplidh"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Tha an seann fhacal-faire agus am fear ùr ro choltach ri chèile"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Chaidh am facal-faire ùr a chleachdadh o chionn ghoirid mu thràth."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr ""
+#~ "Feumaidh àireamhan no caractaran sònraichte a bhith san fhacal-fhaire ùr"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Tha an seann fhacal-faire ’s am fear ùra co-ionnann"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Chaidh am facal-faire agad atharrachadh on a rinn thu dearbhadh an "
+#~ "toiseach!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Chan eil caractaran eadar-dhealaichte gu leòr san fhacal-fhaire ùr"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Mearachd neo-aithnichte"
+
+#, fuzzy
+#~| msgid ""
+#~| "The username should only consist of upper and lower case letters from a-"
+#~| "z, digits and the following characters: . - _"
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Cha bu chòir a bhith am broinn ainm-cleachdaiche ach litrichean mòra ’s "
+#~ "beaga o a-z, àireamhan agus gin dhe na caractaran seo: . - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Tha sinn duilich ach chan eil an t-ainm-cleachdaiche seo ri fhaighinn. "
+#~ "Feuch fear eile."
+
+#~ msgid "The username is too long."
+#~ msgstr "Tha an t-ainm-cleachdaiche ro fhada."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Putan %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "A-rèir na h-aplacaid"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Cuir buille-iuchrach"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Gearr leum gu monatair eile"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Seall a’ chobhair air an sgrìn"
+
+#, fuzzy
+#~| msgid "Displays"
+#~ msgid "All Displays"
+#~ msgstr "Uidheaman-taisbeanaidh"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Ath-ghoirid ùr…"
+
+#, fuzzy
+#~| msgid "Yesterday"
+#~ msgid "Registered"
+#~ msgstr "An-dè"
+
+#, fuzzy
+#~| msgid "Search"
+#~ msgid "Searching"
+#~ msgstr "Lorg"
+
+#, fuzzy
+#~| msgid "Unknown"
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Chan eil fhios"
+
+#, fuzzy
+#~| msgid "_Unlock"
+#~ msgid "Unlocking…"
+#~ msgstr "_Thoir a’ ghlas dheth"
+
+#, fuzzy
+#~| msgid "PIN check failed"
+#~ msgid "Phone failure"
+#~ msgstr "Dh’fhàillig sgrùdadh a’ PIN"
+
+#, fuzzy
+#~| msgid "Not connected"
+#~ msgid "No connection to phone"
+#~ msgstr "Chan eil ceangal ann"
+
+#, fuzzy
+#~| msgid "SIM Card not inserted"
+#~ msgid "SIM not inserted"
+#~ msgstr "Cha deach cairt SIM a chur a-steach"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PIN required"
+#~ msgstr "Tha feum air PIN an SIM"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PUK required"
+#~ msgstr "Tha feum air PIN an SIM"
+
+#, fuzzy
+#~| msgid "Current _Password"
+#~ msgid "Incorrect password"
+#~ msgstr "Am _facal-faire làithreach"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Tha feum air PIN an SIM"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Tha feum air PIN an SIM"
+
+#, fuzzy
+#~| msgid "No stylus found"
+#~ msgid "Not found"
+#~ msgstr "Cha deach peann a lorg"
+
+#, fuzzy
+#~| msgid "Networks"
+#~ msgid "No network service"
+#~ msgstr "Lìonraidhean"
+
+#, fuzzy
+#~| msgid "Network Name"
+#~ msgid "Network timeout"
+#~ msgstr "Ainm an lìonraidh"
+
+#, fuzzy
+#~| msgid "AutoIP service failed"
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Dh’fhàillig an t-seirbheis AutoIP"
+
+#, fuzzy
+#~| msgctxt "print job"
+#~| msgid "Canceled"
+#~ msgid "Action Cancelled"
+#~ msgstr "Sguireadh dheth"
+
+#, fuzzy
+#~| msgid "Unknown error"
+#~ msgid "Unknown Error"
+#~ msgstr "Mearachd neo-aithnichte"
+
+#~ msgid "Display version number"
+#~ msgstr "Seall àireamh an tionndaidh"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Cuir an comas am modh brathrach"
+
+#~ msgid "Search for the string"
+#~ msgstr "Lorg an t-sreang"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Seall ainmean a ghabhas a chleachdadh is dèan fàgail"
+
+#~ msgid "Panel to display"
+#~ msgstr "A’ phanail a thèid a shealltainn"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Panailean a tha ri fhaighinn:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Fuaimean an t-siostaim"
 
 #~ msgid "_Background"
 #~ msgstr "Cùlai_bh"
@@ -9535,9 +8120,6 @@ msgstr "Fuaimean an t-siostaim"
 
 #~ msgid "Check for updates"
 #~ msgstr "Thoir sùil airson ùrachaidhean"
-
-#~ msgid "Screenshots"
-#~ msgstr "Glacaidhean-sgrìn"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "Cuir lethbhreac de ghlacadh-sgrìn dha $PICTURES"
@@ -9966,11 +8548,8 @@ msgstr "Fuaimean an t-siostaim"
 #~ "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
 #~ msgstr ""
 #~ "Bheir co-roinneadh na sgrìn cead do chleachdaichean an sgrìn agad a "
-#~ "shealltainn no a stiùireadh on taobh a-muigh slighe <a href=\"vnc://%s"
-#~ "\">vnc://%s</a>"
-
-#~ msgid "Copy"
-#~ msgstr "Dèan lethbhreac"
+#~ "shealltainn no a stiùireadh on taobh a-muigh slighe <a href=\"vnc://"
+#~ "%s\">vnc://%s</a>"
 
 #~ msgid "preferences-system-sharing"
 #~ msgstr "preferences-system-sharing"
@@ -9982,9 +8561,6 @@ msgstr "Fuaimean an t-siostaim"
 #~ msgstr ""
 #~ "Chaidh cuid dhe na seirbheisean a chur à comas a chionn ’s nach eil "
 #~ "cothrom air an lìonra."
-
-#~ msgid "Screen Sharing"
-#~ msgstr "Co-roinneadh sgrìnichean"
 
 #~ msgid "_Password:"
 #~ msgstr "_Facal-faire:"
@@ -10062,9 +8638,6 @@ msgstr "Fuaimean an t-siostaim"
 
 #~ msgid "Testing event sound"
 #~ msgstr "A’ cur na fuaime fo dheuchainn"
-
-#~ msgid "Default"
-#~ msgstr "Bun-roghainn"
 
 #~ msgid "From theme"
 #~ msgstr "On ùrlar"
@@ -10231,9 +8804,6 @@ msgstr "Fuaimean an t-siostaim"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablaid (absaloideach)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Pada-suathaidh (dàimheach)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Roghainnean na tablaid"
 
@@ -10252,24 +8822,9 @@ msgstr "Fuaimean an t-siostaim"
 #~ msgid "Tracking Mode"
 #~ msgstr "Am modh tracaidh"
 
-#~ msgid "Middle Mouse Button Click"
-#~ msgstr "Briogadh de phutan meadhan na luchaige"
-
-#~ msgid "Right Mouse Button Click"
-#~ msgstr "Briogadh de phutan deas na luchaige"
-
-#~ msgid "Forward"
-#~ msgstr "Air adhart"
-
 #~ msgid ""
 #~ "Please move your stylus to the proximity of the tablet to configure it"
 #~ msgstr "Gluais am peann agad faisg air an tablaid gus a rèiteachadh"
-
-#~ msgid "Soft"
-#~ msgstr "Bog"
-
-#~ msgid "Firm"
-#~ msgstr "Stalcanta"
 
 #~ msgid "Top Button"
 #~ msgstr "Am putan aig a’ bharr"
@@ -10309,9 +8864,6 @@ msgstr "Fuaimean an t-siostaim"
 #~ msgid "Co­lor"
 #~ msgstr "Dath"
 
-#~ msgid "Section"
-#~ msgstr "Earrann"
-
 #~ msgid "Overview"
 #~ msgstr "Foir-shealladh"
 
@@ -10347,9 +8899,6 @@ msgstr "Fuaimean an t-siostaim"
 #~ msgid "Uni­ver­sal Access"
 #~ msgstr "Inntrigeadh uile-choitcheann"
 
-#~ msgid "Disable image"
-#~ msgstr "Cuir an dealbh à comas"
-
 #~ msgid "Browse for more pictures…"
 #~ msgstr "Brabhsaich airson barrachd dhealbhan…"
 
@@ -10372,9 +8921,6 @@ msgstr "Fuaimean an t-siostaim"
 
 #~ msgid "Mirrored"
 #~ msgstr "Sgàthanaichte"
-
-#~ msgid "Secondary"
-#~ msgstr "Panail dhàrnach"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Cuir air gleus na co-thaisbeanaidhean"
@@ -10522,9 +9068,6 @@ msgstr "Fuaimean an t-siostaim"
 #~ msgid "4"
 #~ msgstr "4"
 
-#~ msgid "Loading options…"
-#~ msgstr "A' luchdadh nan roghainnean…"
-
 #~ msgctxt "Password hint"
 #~ msgid "Try to add more letters, numbers and symbols."
 #~ msgstr "Feuch is cleachd barrachd litrichean, àireamhan is chomharran."
@@ -10549,9 +9092,6 @@ msgstr "Fuaimean an t-siostaim"
 #~ msgid "Strength: High"
 #~ msgstr "Neart: àrd"
 
-#~ msgid "Edit"
-#~ msgstr "Deasaich"
-
 #~ msgctxt "notifications"
 #~ msgid "Notification _Banners"
 #~ msgstr "_Brataich bhrathan"
@@ -10564,9 +9104,6 @@ msgstr "Fuaimean an t-siostaim"
 
 #~ msgid "Mail"
 #~ msgstr "Post"
-
-#~ msgid "Calendar"
-#~ msgstr "Mìosachan"
 
 #~ msgid "Contacts"
 #~ msgstr "Luchd-aithne"
@@ -10587,9 +9124,6 @@ msgstr "Fuaimean an t-siostaim"
 
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "Cha doir seo air falbh an cunntas air an fhrithealaiche."
-
-#~ msgid "_Remove"
-#~ msgstr "_Thoir air falbh"
 
 #~ msgid "No online accounts configured"
 #~ msgstr "Cha deach cunntas air loidhne sam bith a rèiteachadh"
@@ -10646,9 +9180,6 @@ msgstr "Fuaimean an t-siostaim"
 
 #~ msgid "label"
 #~ msgstr "leubail"
-
-#~ msgid "Setting new driver…"
-#~ msgstr "A' suidheachadh an draibheir ùir…"
 
 #~ msgid "Print _Test Page"
 #~ msgstr "Clò-bhuail _duilleag deuchainne"
@@ -10728,9 +9259,6 @@ msgstr "Fuaimean an t-siostaim"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Sgrolaich suas"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Sgrolaich sìos"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Sgrolaich dhan taobh deas"
@@ -10896,9 +9424,6 @@ msgstr "Fuaimean an t-siostaim"
 #~ msgid "Done"
 #~ msgstr "Deiseil"
 
-#~ msgid "Install Language"
-#~ msgstr "Stàlaich cànan"
-
 #~ msgid "Time _Zone"
 #~ msgstr "An _roinn-tìde"
 
@@ -10990,14 +9515,8 @@ msgstr "Fuaimean an t-siostaim"
 #~ msgid "Add New Printer"
 #~ msgstr "Cuir clò-bhualadair ùr ris"
 
-#~ msgid "Lock Screen on Suspend"
-#~ msgstr "Glais an sgrìn nuair a thèid a chur 'na dhàil"
-
 #~ msgid "Used to determine your geographical location"
 #~ msgstr "Thèid an cleachdadh gus faighinn a-mach far a bheil thu"
-
-#~ msgid "Options"
-#~ msgstr "Roghainnean"
 
 #~ msgid "Password:"
 #~ msgstr "Facal-faire:"

--- a/po/gd.po~
+++ b/po/gd.po~
@@ -1,0 +1,11059 @@
+# Gaelic; Scottish translation for gnome-control-center
+# Copyright (c) 2011 Rosetta Contributors and Canonical Ltd 2011
+# This file is distributed under the same license as the gnome-control-center package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2011.
+# Michael Bauer <fios@akerbeltz.org>, 2014.
+# GunChleoc <fios@foramnagaidhlig.net>, 2016, 2017, 2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-04-07 11:50+0000\n"
+"PO-Revision-Date: 2018-02-26 12:42+0100\n"
+"Last-Translator: GunChleoc <fios@foramnagaidhlig.net>\n"
+"Language-Team: Fòram na Gàidhlig\n"
+"Language: gd\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : "
+"(n > 2 && n < 20) ? 2 : 3;\n"
+"X-Generator: Virtaal 0.7.1\n"
+"X-Launchpad-Export-Date: 2016-04-20 12:56+0000\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:803
+#, fuzzy
+#| msgid "System Sounds"
+msgid "System Bus"
+msgstr "Fuaimean an t-siostaim"
+
+#: panels/applications/cc-applications-panel.c:803
+#: panels/applications/cc-applications-panel.c:805
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:823
+#, fuzzy
+#| msgid "_Full Name"
+msgid "Full access"
+msgstr "Ainm _slàn"
+
+#: panels/applications/cc-applications-panel.c:805
+#, fuzzy
+#| msgid "Session Ended"
+msgid "Session Bus"
+msgstr "Thàinig an seisean gu crìoch"
+
+#: panels/applications/cc-applications-panel.c:809
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
+#: panels/thunderbolt/cc-bolt-panel.ui:310
+msgid "Devices"
+msgstr "Innleadan"
+
+#: panels/applications/cc-applications-panel.c:809
+msgid "Full access to /dev"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:813
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Lìonra"
+
+#: panels/applications/cc-applications-panel.c:813
+#, fuzzy
+#| msgid "Network Name"
+msgid "Has network access"
+msgstr "Ainm an lìonraidh"
+
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:820
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Dhachaigh"
+
+#: panels/applications/cc-applications-panel.c:820
+#: panels/applications/cc-applications-panel.c:825
+#, fuzzy
+#| msgctxt "printer state"
+#| msgid "Ready"
+msgid "Read-only"
+msgstr "Deiseil"
+
+#: panels/applications/cc-applications-panel.c:823
+#: panels/applications/cc-applications-panel.c:825
+#, fuzzy
+#| msgid "Open System"
+msgid "File System"
+msgstr "Siostam fosgailte"
+
+#: panels/applications/cc-applications-panel.c:829
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:878 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Roghainnean"
+
+#: panels/applications/cc-applications-panel.c:829
+msgid "Can change settings"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:831
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1164
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: panels/applications/cc-applications-panel.c:1171
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1223
+#, c-format
+msgid "%s of disk space used"
+msgstr ""
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1387
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplacaidean"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+#| msgid "No applications found"
+msgid "No applications"
+msgstr "Cha deach aplacaid sam bith a lorg"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+#| msgid "Install PPD File…"
+msgid "Install some…"
+msgstr "Stàlaich faidhle PPD…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+#, fuzzy
+#| msgid "_Open"
+msgid "Open"
+msgstr "F_osgail"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+#| msgid "_View details"
+msgid "View Details"
+msgstr "_Seall am mion-fhiosrachadh"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Lorg"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/applications/cc-applications-panel.ui:177
+#: panels/applications/cc-applications-panel.ui:191
+#: panels/applications/cc-applications-panel.ui:205
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
+#: panels/user-accounts/cc-user-panel.c:789
+#: panels/user-accounts/cc-user-panel.c:879
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "À comas"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Brathan"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+#| msgid "Show _Notifications"
+msgid "Show system notifications."
+msgstr "Seall _na brathan"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+#| msgid "Current background"
+msgid "Run in background"
+msgstr "An cùlaibh làithreach"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+#| msgid "Wallpapers"
+msgid "Change Wallpaper"
+msgstr "Pàipearan-balla"
+
+#: panels/applications/cc-applications-panel.ui:141
+#, fuzzy
+#| msgid "preferences-desktop-wallpaper"
+msgid "Change the desktop wallpaper."
+msgstr "preferences-desktop-wallpaper"
+
+#: panels/applications/cc-applications-panel.ui:147
+#: panels/applications/cc-applications-panel.ui:154
+#, fuzzy
+#| msgid "Sound"
+msgid "Sounds"
+msgstr "Fuaim"
+
+#: panels/applications/cc-applications-panel.ui:148
+#: panels/applications/cc-applications-panel.ui:155
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+#| msgid "Set Shortcut"
+msgid "Inhibit Shortcuts"
+msgstr "Suidhich ath-ghoirid"
+
+#: panels/applications/cc-applications-panel.ui:162
+#, fuzzy
+#| msgid "No keyboard shortcut found"
+msgid "Block standard keyboard shortcuts."
+msgstr "Cha deach ath-ghoirid a’ mheur-chlàir a lorg"
+
+#: panels/applications/cc-applications-panel.ui:168
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "%s Camera"
+msgid "Camera"
+msgstr "Camara %s"
+
+#: panels/applications/cc-applications-panel.ui:169
+#: panels/applications/cc-applications-panel.ui:176
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:183
+#: panels/applications/cc-applications-panel.ui:190
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Seirbheisean ionaid"
+
+#: panels/applications/cc-applications-panel.ui:197
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:215
+#: panels/applications/cc-applications-panel.ui:319
+#, fuzzy
+#| msgid "Built-in Webcam"
+msgid "Built-in Permissions"
+msgstr "Camara-lìn ’na bhroinn"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:224
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:399
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+msgid "No results found"
+msgstr "Cha deach toradh a lorg"
+
+#: panels/applications/cc-applications-panel.ui:304
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
+#: shell/cc-panel-list.ui:114
+msgid "Try a different search"
+msgstr "Feuch lorg eile"
+
+#: panels/applications/cc-applications-panel.ui:344
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:367
+#, fuzzy
+#| msgid "Display Type"
+msgid "File Types"
+msgstr "Seòrsa an uidheim-thaisbeanaidh"
+
+#: panels/applications/cc-applications-panel.ui:373
+#, fuzzy
+#| msgid "Link speed"
+msgid "Link Types"
+msgstr "Astar a’ cheangail"
+
+#: panels/applications/cc-applications-panel.ui:383
+msgid "Reset"
+msgstr "Ath-shuidhich"
+
+#: panels/applications/cc-applications-panel.ui:410
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:413
+#, fuzzy
+#| msgid "Applications"
+msgid "Application"
+msgstr "Aplacaidean"
+
+#: panels/applications/cc-applications-panel.ui:419
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:425
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:431
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:441
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-chooser.c:307
+#, fuzzy
+#| msgid "Select a File…"
+msgid "Select a picture"
+msgstr "Tagh faidhle…"
+
+#: panels/background/cc-background-chooser.c:310
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:198
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/network/cc-wifi-hotspot-dialog.ui:123
+#: panels/network/cc-wifi-panel.c:881
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:860
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:263
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:18
+#: panels/user-accounts/cc-user-panel.c:579
+#: panels/user-accounts/cc-user-panel.c:597
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:139
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
+msgid "_Cancel"
+msgstr "_Sguir dheth"
+
+#: panels/background/cc-background-chooser.c:311
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:264
+#: panels/sharing/cc-sharing-panel.c:524
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "F_osgail"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "iomadh meud"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Chan eil cùlaibh aig an deasga"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "An cùlaibh làithreach"
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+#| msgid "Stylus"
+msgid "Style"
+msgstr "Staidhleas"
+
+#: panels/background/cc-background-panel.ui:45
+#, fuzzy
+#| msgid "Right"
+msgid "Light"
+msgstr "Deas"
+
+#: panels/background/cc-background-panel.ui:72
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:91
+msgid "Background"
+msgstr "Cùlaibh"
+
+#: panels/background/cc-background-panel.ui:97
+#, fuzzy
+#| msgid "Add a Printer…"
+msgid "Add Picture…"
+msgstr "Cuir clò-bhualadair ris…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Change your background image to a wallpaper or photo"
+msgid "Change your background image or the UI colors"
+msgstr "Cleachd pàipear-balla no dealbh mar chùlaibh"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+#, fuzzy
+#| msgid "Wallpaper;Screen;Desktop;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgstr "Wallpaper;Screen;Desktop;pàipear-balla;sgrìn;deasg;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:21
+msgid "No Bluetooth Found"
+msgstr "Cha deach Bluetooth a lorg"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:22
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Ceangail dongle gus Bluetooth a chleachdadh."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:28
+msgid "Bluetooth Turned Off"
+msgstr "Tha Bluetooth dheth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:29
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Cuir air e gus uidheaman a cheangal is tar-chuir fhaidhlichean fhaighinn."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#, fuzzy
+#| msgid "Airplane Mode is on"
+msgid "Airplane Mode is On"
+msgstr "Tha am modh itealain air"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:36
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Tha Bluetooth à comas fhad ’s a tha am modh itealain air."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Turn Off Airplane Mode"
+msgstr "Cuir am modh itealain dheth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#, fuzzy
+#| msgid "Hardware Airplane Mode is on"
+msgid "Hardware Airplane Mode is On"
+msgstr "Tha modh itealain a’ bhathair-chruaidh air"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:54
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Cuir suidse a’ mhodh itealain dheth gus Bluetooth a chur an comas."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Cuir Bluetooth air is dheth is ceangail na h-uidheaman agad ris"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;co-roinn;co-roinneadh;"
+
+#: panels/camera/cc-camera-panel.ui:21
+#, fuzzy
+#| msgid "Bluetooth Turned Off"
+msgid "Camera is Turned Off"
+msgstr "Tha Bluetooth dheth"
+
+#: panels/camera/cc-camera-panel.ui:22
+#, fuzzy
+#| msgid "No application is currently playing or recording audio."
+msgid "No applications can capture photos or video."
+msgstr ""
+"Chan eil aplacaid sam bith a’ cluich no a’ clàradh fuaime an-dràsta fhèin."
+
+#: panels/camera/cc-camera-panel.ui:36
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:52
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Browse for more pictures"
+msgid "Protect your pictures"
+msgstr "Brabhsaich airson barrachd dhealbhan"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;sgrìn;glas;diagnosachd;tuisleadh;prìobhaideach;sealach;"
+"inneacs;lìonra;ainm;dearbh-aithne;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Cuir an t-uidheam cailbhreachaidh agad os cionn na ceàrnaige is brùth air "
+"“Tòisich”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Gluais an t-uidheam cailbhreachaidh agad dhan ionad chailbhreachaidh is "
+"brùth air “Air adhart”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Gluais an t-uidheam cailbhreachaidh agad dhan ionad uachdair is brùth air "
+"“Air adhart”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Dùin mullach an laptop"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Thachair mearachd inntearnail nach b’ urrainn dhuinn càradh."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr ""
+"Cha deach na h-innealan a stàladh air a bheil feum airson cailbhreachadh."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Cha b’ urrainn dhuinn a’ phròifil a ghintinn."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Cha d’fhuair sinn greim air geal-phuing na targaide."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Deiseil!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Dh’fhàillig an cailbhreachadh!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "’S urrainn dhut an t-uidheam cailbhreachaidh a thoirt air falbh a-nis."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Na bean ris an uidheam chailbhreachaidh fhad ’s a tha e trang"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Cailbhreachadh an uidheim-thaisbeanaidh"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Tòisich"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Lean air"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+msgid "_Done"
+msgstr "_Deiseil"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Sgrìn laptop"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Camara-lìn ’na bhroinn"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monatair %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Sganair %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Camara %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Clò-bhualadair %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Camara-lìn %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Cuir an comas stiùireadh dhathan airson %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Seall na pròifilean dhathan airson %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Cha deach a chailbhreachadh"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Tùsail: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Spàs nan dathan: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Pròifil deuchainne: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Tagh faidhle pròifil ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Ion-phortaich"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Pròifilean ICC ris a bheil taic"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "A h-uile faidhle"
+
+#: panels/color/cc-color-panel.c:586
+msgid "Screen"
+msgstr "Sgrìn"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Sàbhail a’ phròifil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Sàbhail"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Cruthaich pròifil dhathan airson an uidheim a thagh thu"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Cha do mhothaich sinn ri inneal tomhais. Dèan cinnteach gu bheil e air agus "
+"ceangailte ris mar bu chòir."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+"Chan eil an t-inneal tomhais a’ cur taic ri pròifileadh chlò-bhualadairean."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Chan eil taic ris an t-seòrsa seo a dh’uidheam aig an àm seo."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Cailbhreachadh na sgrìn"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Càileachd a’ chailbhreachaidh"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Cruthaichidh an cailbhreachadh pròifil leis an urrainn dhut na dathan air an "
+"sgrìn agad a stiùireadh. Mar as fhaide a bheir thu seachad air a "
+"chailbhreachadh, ’s ann as fhearr a bhios pròifil nan dathan agad."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Chan urrainn dhut an coimpiutair agad a chleachdadh fhad ’s a bhios an "
+"cailbhreachadh a’ dol air adhart."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Càileachd"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Tuairmeas air dè cho fad ’s a bheir e"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "An t-uidheam cailbhreachaidh"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+"Tagh an t-uidheam mothachaidh a bu toigh leat cleachdadh airson "
+"cailbhreachadh."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Seòrsa an uidheim-thaisbeanaidh"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Tagh seòrsa an uidheim-thaisbeanaidh a tha ceangailte ris."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Geal-phuing na pròifile"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Tagh geal-phuing targaide air an uidheam-taisbeanadh. Mar is trice, "
+"cleachdar illuminant D65 airson cailbhreachadh."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Soilleireachd an uidheim-thaisbeanaidh"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Suidhich an t-uidheam-taisbeanaidh air an t-soilleireachd a chleachdas tu "
+"mar is trice. Bidh stiùireadh nan dathan nas pongaile air an ìre seo de "
+"shoilleireachd."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Air neo ’s urrainn dhut ìre soilleireachd o phròifil eile aig an uidheam seo "
+"a chleachdadh."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Ainm na pròifile"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"’S urrainn dhut pròifil dhathan a chleachdadh air diofar choimpiutairean no "
+"fiù pròifilean a chleachdadh airson diofar ìrean de sholas."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Ainm na pròifile:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Gearr-chunntas"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Chaidh a’ phròifil a chruthachadh!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Dèan lethbhreac dhen phròifil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Feumaidh seo meadhan as urrainnear sgrìobhadh air"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Dh’fhaoidte gum bi an stiùireadh seo a thaobh mar a chleachdar na pròifilean "
+"seo air <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> agus "
+"<a href=\"windows\">Microsoft Windows</a> feumail dhut."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Cuir ris pròifil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Mhothaich sinn do dhuilgheadasan. Dh’fhaoidte nach obraich a’ phròifil mar "
+"bu chòir. <a href=\"\">Seall am mion-fhiosrachadh.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Ion-phortaich faidhle…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/network/connection-editor/net-connection-editor.c:497
+#: panels/printers/new-printer-dialog.ui:84
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Cuir ris"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Feumaidh pròifil dhathan cho ùr ’s a ghabhas a bhith aig gach uidheam mus "
+"gabh an dath a stiùireadh."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Barrachd fiosrachaidh"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Barrachd fiosrachaidh mu stiùireadh dhathan"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Suidhich airson a h-uile cleachdaiche"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+"Suidhich a’ phròifil seo airson na h-uile cleachdaiche air a’ choimpiutair "
+"seo"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Cuir an comas"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Cuir ris _pròifil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Cailbhrich…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Cailbhrich an t-uidheam"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Thoi_r air falbh a’ phròifil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Seall am mion-fhiosrachadh"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+"Cha do mhothaich sinn dha dh’uidheam sam bith a ghabhas na dathan a "
+"stiùireadh dha"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Proiseactar"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (solas-cùil CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (solas-cùil LED RGB)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (solas-cùil LED geal)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD gamut leathann (solas-cùil CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD gamut leathann (solas-cùil LED RGB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Àrd"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 mionaid"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Meadhanach"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "Leth-uair a thìde"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Ìseal"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "Cairteal na h-uarach"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Roghainn thùsail an uidheim-thaisbeanaidh"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (clò-bhualadh is foillseachadh)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografachd is grafaigeachd)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Spàs stannardach"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Pròifil deuchainne"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Fèin-obrachail"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Càileachd ìseal"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Càileachd mheadhanach"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Càileachd àrd"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB tùsail"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK tùsail"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Liath tùsail"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Dàta cailbhreachaidh tùsail a sholair an reiceadair"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Cha ghabh ceartachadh taisbeanadh làn-sgrìn a dhèanamh sa phròifil seo"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Dh’fhaoidte nach eil a’ phròifil seo ceart tuilleadh"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Dath"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Cailbhrich dathan nan uidheaman agad, can uidheaman-taisbeanaidh, camarathan "
+"no clò-bhualadairean"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Color;ICC;Profile;Calibrate;Printer;Display;dath;ICC;pròifil;cailbhrich;"
+"cailbhreachadh;clò-bhualadair;taisbeanadh;uidheam-taisbenaidh;sgrìn;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Eile…"
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+#| msgid "Language"
+msgid "Select Language"
+msgstr "Cànan"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Tagh"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Cha deach cànan a lorg"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Barrachd…"
+
+#: panels/common/cc-permission-infobar.c:109
+#, fuzzy
+#| msgid "Bluetooth Settings"
+msgid "Unlock to Change Settings"
+msgstr "Roghainnean Bluetooth"
+
+#: panels/common/cc-permission-infobar.ui:40
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:57
+#, fuzzy
+#| msgid "_Unlock"
+msgid "Unlock…"
+msgstr "_Thoir a’ ghlas dheth"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Àm"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:162
+msgid "Today"
+msgstr "An-diugh"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:164
+msgid "Yesterday"
+msgstr "An-dè"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#: panels/common/cc-util.c:165
+#, fuzzy, c-format
+#| msgid "%i hour"
+#| msgid_plural "%i hours"
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%i uair a thìde"
+msgstr[1] "%i uair a thìde"
+msgstr[2] "%i uairean a thìde"
+msgstr[3] "%i uair a thìde"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
+#, fuzzy, c-format
+#| msgid "%i minute"
+#| msgid_plural "%i minutes"
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%i mhionaid"
+msgstr[1] "%i mhionaid"
+msgstr[2] "%i mionaidean"
+msgstr[3] "%i mionaid"
+
+#: panels/common/cc-util.c:167
+#, fuzzy, c-format
+#| msgid "30 seconds"
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "30 diog"
+msgstr[1] "30 diog"
+msgstr[2] "30 diog"
+msgstr[3] "30 diog"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, fuzzy, c-format
+#| msgid "%i %s %i %s"
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%i %s %i %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, fuzzy, c-format
+#| msgid "%i %s %i %s"
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%i %s %i %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr ""
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, fuzzy, c-format
+#| msgid "%i %s %i %s"
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%i %s %i %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr ""
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+#, fuzzy
+#| msgid "30 seconds"
+msgid "0 seconds"
+msgstr "30 diog"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 uairean"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "m/f"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %P"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %P"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Ceann-là ⁊ an t-àm"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Bliadhna"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mìos"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Am Faoilleach"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "An Gearran"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Am Màrt"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "An Giblean"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "An Cèitean"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "An t-Ògmhios"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "An t-Iuchar"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "An Lùnastal"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "An t-Sultain"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "An Dàmhair"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "An t-Samhain"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "An Dùbhlachd"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Latha"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Roinn-tìde"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Lorg baile"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+#| msgid "Automatic _Date & Time"
+msgid "Automatic _Date &amp; Time"
+msgstr "Ceann-là ⁊ an t-àm gu _fèin-obrachail"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Tha feum air an eadar-lìon"
+
+#: panels/datetime/cc-datetime-panel.ui:177
+#, fuzzy
+#| msgid "Date & _Time"
+msgid "Date &amp; _Time"
+msgstr "Ceann-là ⁊ an t-àm"
+
+#: panels/datetime/cc-datetime-panel.ui:201
+msgid "Automatic Time _Zone"
+msgstr "An _roinn-tìde gu fèin-obrachail"
+
+#: panels/datetime/cc-datetime-panel.ui:202
+#, fuzzy
+#| msgid "Requires internet access"
+msgid "Requires location services enabled and internet access"
+msgstr "Tha feum air an eadar-lìon"
+
+#: panels/datetime/cc-datetime-panel.ui:214
+msgid "Time Z_one"
+msgstr "R_oinn-tìde"
+
+#: panels/datetime/cc-datetime-panel.ui:239
+msgid "Time _Format"
+msgstr "_Fòrmat an ama"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Atharraich an ceann-là ’s an t-àm, a’ gabhail a-steach na roinne-tìde"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;gleoc;cleoc;roinn-tìde;ionad;àite;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Atharraich roghainnean àm ’s ceann-là an t-siostaim"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Feumaidh tu dearbhadh a dhèanamh gus roghainnean an ama no a’ chinn-là "
+"atharrachadh."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Lìon"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Post"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Mìosachan"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "C_eòl"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Dealbhan"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplacaidean tùsail"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Rèitich na h-placaidean tùsail"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"default;application;preferred;media;tùsail;bun-roghainn;bunaiteach;aplacaid;"
+"nas fheass;as fhearr;meadhan;meadhanan;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, fuzzy, c-format
+#| msgid ""
+#| "Sending reports of technical problems helps us improve %s. Reports are "
+#| "sent anonymously and are scrubbed of personal data."
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Ma chuireas tu aithrisean air duilgheadasan teicnigeach a-null, cuidichidh "
+"seo ach an leasaich sinn %s. Thèid na h-aithrisean a chur gun urra agus gach "
+"dàta pearsanta a thoirt air falbh uapa."
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Ag aithris air duilgheadasan"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Aithrisean fèin-obrachail air duilgheadasan"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+#, fuzzy
+#| msgid ""
+#| "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#| "network;identity;"
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;sgrìn;glas;diagnosachd;tuisleadh;prìobhaideach;sealach;"
+"inneacs;lìonra;ainm;dearbh-aithne;"
+
+#: panels/display/cc-display-panel.c:512
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Air"
+
+#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Dheth"
+
+#: panels/display/cc-display-panel.c:945
+msgid "Apply Changes?"
+msgstr "A bheil thu airson na h-atharraichean a chur an sàs?"
+
+#: panels/display/cc-display-panel.c:950
+msgid "Changes Cannot be Applied"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:952
+msgid "This could be due to hardware limitations."
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "Cuir _an sàs"
+
+#: panels/display/cc-display-panel.ui:97
+#, fuzzy
+#| msgid "Bluetooth is disabled"
+msgid "Display Settings Disabled"
+msgstr "Tha Bluetooth à comas"
+
+#: panels/display/cc-display-panel.ui:113
+msgid "Display Arrangement"
+msgstr "Rian nan uidheaman-taisbeanaidh"
+
+#: panels/display/cc-display-panel.ui:124
+#, fuzzy
+#| msgid "Single Display"
+msgid "Multiple Displays"
+msgstr "Mar aon uidheam-taisbeanaidh"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:133
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:140
+msgid "Mirror"
+msgstr "Sgàthanaich"
+
+#: panels/display/cc-display-panel.ui:153
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:154
+msgid "Primary Display"
+msgstr "Am prìomh uidheam-taisbeanaidh"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:175
+#: panels/display/cc-display-panel.ui:223
+#: panels/display/cc-night-light-page.ui:77
+msgid "Night Light"
+msgstr "Solas oidhche"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Dreach-tìre"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portraid dheas"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portraid chlì"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Dreach-tìre (air a chuairteachadh)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:40
+#, fuzzy
+#| msgid "Orientation"
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Comhair"
+
+#: panels/display/cc-display-settings.ui:47
+#, fuzzy
+#| msgid "Resolution"
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Dùmhlachd-bhreacaidh"
+
+#: panels/display/cc-display-settings.ui:54
+msgid "Refresh Rate"
+msgstr "Tricead an ath-nuadhachaidh"
+
+#: panels/display/cc-display-settings.ui:61
+msgid "Adjust for TV"
+msgstr "Gleus airson TBh"
+
+#: panels/display/cc-display-settings.ui:75
+#: panels/display/cc-display-settings.ui:90
+#, fuzzy
+#| msgid "Scale"
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Sgèile"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:21
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "À comas greis gu ruige a-màireach"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:35
+msgid "Restart Filter"
+msgstr "Ath-thòisich a’ chriathrag"
+
+#: panels/display/cc-night-light-page.ui:57
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Nì an solas oidhche dath na sgrìn nas blàithe. Cuidichidh seo an aghaidh "
+"sgìths nan sùilean agus bacadh-cadail."
+
+#: panels/display/cc-night-light-page.ui:91
+msgid "Schedule"
+msgstr "Sgeideal"
+
+#: panels/display/cc-night-light-page.ui:99
+msgid "Sunset to Sunrise"
+msgstr "O laighe gu èirigh na grèine"
+
+#: panels/display/cc-night-light-page.ui:100
+#, fuzzy
+#| msgid "Schedule"
+msgid "Manual Schedule"
+msgstr "Sgeideal"
+
+#: panels/display/cc-night-light-page.ui:110
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Amannan"
+
+#: panels/display/cc-night-light-page.ui:123
+msgid "From"
+msgstr "O"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/display/cc-night-light-page.ui:235
+msgid "Hour"
+msgstr "Uair"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/display/cc-night-light-page.ui:241
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:171
+#: panels/display/cc-night-light-page.ui:258
+msgid "Minute"
+msgstr "Mionaid"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:181
+#: panels/display/cc-night-light-page.ui:268
+msgid "AM"
+msgstr "m"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:193
+#: panels/display/cc-night-light-page.ui:280
+msgid "PM"
+msgstr "f"
+
+#: panels/display/cc-night-light-page.ui:210
+msgid "To"
+msgstr "Gu"
+
+#: panels/display/cc-night-light-page.ui:316
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Uidheaman-taisbeanaidh"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+"Tagh mar a thèid monatairean is proiseactaran a tha ceangailte ris a "
+"chleachdadh"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;panail;proiseactar;"
+"tilgear;sgrìn;dùmhlachd-bhreacaidh;ath-nuadhaich;ath-nuadhachadh;monatar;"
+"solar;oidhche;gorm;dearg;dath;laighe na grèine;èirigh na grèine;"
+
+#: panels/info-overview/cc-info-overview-panel.c:411
+#: panels/info-overview/cc-info-overview-panel.c:435
+#: panels/info-overview/cc-info-overview-panel.c:481
+#: panels/info-overview/cc-info-overview-panel.c:511
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Chan eil fhios"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:443
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; ID na togail: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:458
+#, c-format
+msgid "64-bit"
+msgstr "64-biod"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:461
+#, c-format
+msgid "32-bit"
+msgstr "32-biod"
+
+#: panels/info-overview/cc-info-overview-panel.c:720
+msgid "X11"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.c:724
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:726
+#, fuzzy
+#| msgid "Unknown"
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Chan eil fhios"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+#, fuzzy
+#| msgid "System"
+msgid "System Logo"
+msgstr "Siostam"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+#| msgid "Device name"
+msgid "Device Name"
+msgstr "Ainm an uidheim"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+#| msgid "Hardware Address"
+msgid "Hardware Model"
+msgstr "Seòladh bathair-chruaidh"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Cuimhne"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Pròiseasar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafaigeachd"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "’Ga àireamhachadh…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+#| msgid "Name"
+msgid "OS Name"
+msgstr "Ainm"
+
+#: panels/info-overview/cc-info-overview-panel.ui:106
+#, fuzzy
+#| msgid "VPN Type"
+msgid "OS Type"
+msgstr "Seòrsa an VPN"
+
+#: panels/info-overview/cc-info-overview-panel.ui:114
+#, fuzzy
+#| msgid "Version 0"
+msgid "GNOME Version"
+msgstr "Tionndadh 0"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+#| msgid "Windows software"
+msgid "Windowing System"
+msgstr "Bathar-bog Windows"
+
+#: panels/info-overview/cc-info-overview-panel.ui:131
+msgid "Virtualization"
+msgstr "Biortaileachadh"
+
+#: panels/info-overview/cc-info-overview-panel.ui:139
+#, fuzzy
+#| msgid "Software Usage"
+msgid "Software Updates"
+msgstr "Cleachdadh bathair-bhog"
+
+#: panels/info-overview/cc-info-overview-panel.ui:158
+#, fuzzy
+#| msgid "Remove Device"
+msgid "Rename Device"
+msgstr "Thoirt an t-uidheam air falbh"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+#, fuzzy
+#| msgid "_Username"
+msgid "_Rename"
+msgstr "_Ainm-cleachdaiche"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Mu dhèidhinn"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Seall fiosrachadh mun t-siostam agad"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+#| msgid ""
+#| "device;system;information;memory;processor;version;default;application;"
+#| "preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"uidheam;siostam;fiosrachadh;cuimhne;pròiseasar;tionndadh;bunaiteach;aplacaid;"
+"as fhearr;cd;dvd;usb;fuaim;video;diosg;so-ghiùlain;meadhanan;fèin-ruith;"
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Fuaim agus meadhanan"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+#| msgid "Volume mute"
+msgid "Volume mute/unmute"
+msgstr "Mùch an fhuaim"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Lùghdaich an fhuaim"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Cuir an fhuaim an àirde"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Cuir gu dol cluicheadair nam meadhanan"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Cluich (no cluich/cuir ’na stad)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Cuir a chluich ’na stad"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Sguir dhen chluich"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "An traca roimhe"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "An ath-thraca"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Gluais a-mach"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Sgrìobhadh"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Gearr leum gun ath-thùs ion-chuir"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Gearr leum gun tùs ion-chuir roimhe"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lòinsearan"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Cuir gu dol brabhsair na cobharach"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Cuir gu dol an t-àireamhair"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Cuir gu dol cliant a’ phuist-d"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Cuir gu dol am brabhsair-lìn"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Am pasgan-dachaigh"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Lorg"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Siostam"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Clàraich a-mach"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Glais an sgrìn"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Cuir an sùmadh air no dheth"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Sùm a-steach"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Sùm a-mach"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Cuir leughadair na sgrìn air no dheth"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Cuir am meur-chlàr air an sgrìn air no dheth"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Dèan an teacsa nas motha"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Dèan an teacsa nas lugha"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Iomsgaradh àrd air no dheth"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Cha deach tùs ion-chuir a lorg"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Eile"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Cuir tùs ion-chuir ris"
+
+#: panels/keyboard/cc-input-chooser.ui:81
+msgid "Input methods can’t be used on the login screen"
+msgstr "Cha ghabh dòighean ion-chuir a chleachdadh air an sgrìn chlàraidh"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Cha deach tùs ion-chuir a thaghadh"
+
+#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+msgid "Move Up"
+msgstr "Gluais suas"
+
+#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+msgid "Move Down"
+msgstr "Gluais sìos"
+
+#: panels/keyboard/cc-input-row.ui:38
+msgid "Preferences"
+msgstr "Roghainnean"
+
+#: panels/keyboard/cc-input-row.ui:45
+#, fuzzy
+#| msgid "Keyboard Shortcuts"
+msgid "View Keyboard Layout"
+msgstr "Ath-ghoiridean a’ mheur-chlàir"
+
+#: panels/keyboard/cc-input-row.ui:51
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+msgid "Remove"
+msgstr "Thoir air falbh"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Ath-ghoiridean gnàthaichte"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:62
+#, fuzzy
+#| msgid "Alternative Characters Key"
+msgid "Alternate Characters Key"
+msgstr "Roghainn eile de dh’iuchair caractair"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+#, fuzzy
+#| msgid "Left+Right Alt"
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt clì + deas"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+#, fuzzy
+#| msgid "Left+Right Alt"
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt clì + deas"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+#, fuzzy
+#| msgid "Left thumb"
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "An òrdag chlì"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+#, fuzzy
+#| msgid "Right thumb"
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "An òrdag dheas"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+#, fuzzy
+#| msgid "Security key"
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "An iuchair tèarainteachd"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+#, fuzzy
+#| msgid "Right Half"
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "An leth dheas"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:79
+msgid "Compose Key"
+msgstr "Iuchair Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+#, fuzzy
+#| msgid "Scroll Left"
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Sgrolaich dhan taobh chlì"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+#, fuzzy
+#| msgid "Login _Screen"
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "_Sgrìn a’ chlàraidh a-steach"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, fuzzy, c-format
+#| msgid "You can change these shortcuts in the keyboard settings"
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"’S urrainn dhut na h-ath-ghoiridean seo atharrachadh ann an roghainnean a’ "
+"mheur-chlàir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Tùsan ion-chuir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+#| msgid "Input Source Options"
+msgid "Input Source Switching"
+msgstr "Roghainnean nan tùsan ion-chuir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Cleachd an aon tù_s airson gach uinneag"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+#| msgid "Allow _different sources for each window"
+msgid "Switch input sources _individually for each window"
+msgstr "Ceadaich _diofar tùsan airson gach uinneag"
+
+#: panels/keyboard/cc-keyboard-panel.ui:58
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:97
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Ath-ghoiridean a’ mheur-chlàir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:100
+#, fuzzy
+#| msgid "Custom Shortcuts"
+msgid "View and Customize Shortcuts"
+msgstr "Ath-ghoiridean gnàthaichte"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
+msgid "Reset All Shortcuts?"
+msgstr "A bheil thu airson na h-ath-ghoiridean uile ath-shuidheachadh?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Ma nì thu ath-shuidheachadh air na h-ath-ghoiridean agad, dh’fhaoidte gum bi "
+"buaidh air sin air na h-ath-ghoiridean gnàthaichte agad. Cha ghabh sin a neo-"
+"dhèanamh."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Sguir dheth"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
+msgid "Reset All"
+msgstr "Ath-shuidhich na h-uile"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Ath-shuidhich na h-uile…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Ath-shuidhich na h-ath-ghoiridean uile air an luachan tùsail"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#, fuzzy
+#| msgid "Add Custom Shortcut"
+msgid "Add Custom Shortcuts"
+msgstr "Cuir ath-ghoirid ghnàthaichte ris"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+msgid "Add Shortcut"
+msgstr "Cuir ath-ghoirid ris"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+msgid "No keyboard shortcut found"
+msgstr "Cha deach ath-ghoirid a’ mheur-chlàir a lorg"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, fuzzy, c-format
+#| msgid ""
+#| "%s is already being used for <b>%s</b>. If you replace it, %s will be "
+#| "disabled"
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"Tha %s ’ga chleachdadh airson <b>%s</b> mar-thà. Ma chuireas tu rud ’na "
+"àite, thèid %s a chur à comas"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Cuir a-steach an ath-ghoirid ùr"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Suidhich ath-ghoirid ghnàthaichte"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Suidhich ath-ghoirid"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, fuzzy, c-format
+#| msgid "Enter new shortcut to change <b>%s</b>."
+msgid "Enter new shortcut to change %s."
+msgstr "Cuir a-steach an ath-ghoirid a dh’atharrachadh <b>%s</b>."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
+msgid "Add Custom Shortcut"
+msgstr "Cuir ath-ghoirid ghnàthaichte ris"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Cuir ris"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
+msgid "Replace"
+msgstr "Cuir ’na àite"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
+msgid "Set"
+msgstr "Suidhich"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#, fuzzy
+#| msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Brùth air Esc airson sgud dheth no air Backspace gus ath-ghoirid a’ mheur-"
+"chlàir ath-shuidheachadh."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Ainm"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+msgid "Command"
+msgstr "Àithne"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+msgid "Shortcut"
+msgstr "Ath-ghoirid"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+msgid "Set Shortcut…"
+msgstr "Suidhich ath-ghoirid…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "Chan eil gin"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Ath-shuidhich an ath-ghoirid air a luach tùsail"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Meur-chlàr"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "View and change keyboard shortcuts and set your typing preferences"
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Seall is atharraich ath-ghoiridean a’ mheur-chlàir agad is suidhich na "
+"roghainnean sgrìobhaidh agad"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;ath-"
+"ghoirid;rum-obrach;uinneag;meud;meudaich;ath-mheudaich;ath-mheudachadh;sùm;"
+"iomsgaradh;ion-chur;cur a-steach;cuir a-steach;tùs;glas;glais;iom-dhraibh;"
+
+#: panels/location/cc-location-panel.ui:20
+#, fuzzy
+#| msgid "Location Services"
+msgid "Location Services Turned Off"
+msgstr "Seirbheisean ionaid"
+
+#: panels/location/cc-location-panel.ui:21
+#, fuzzy
+#| msgid "No application is currently playing or recording audio."
+msgid "No applications can obtain location information."
+msgstr ""
+"Chan eil aplacaid sam bith a’ cluich no a’ clàradh fuaime an-dràsta fhèin."
+
+#: panels/location/cc-location-panel.ui:35
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:53
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#. FIXME
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:62
+#, fuzzy
+#| msgid "Screen Turns Off"
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Thèid na sgrìnichean dheth"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:65
+#, fuzzy
+#| msgid "30 seconds"
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 diog"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:68
+#, fuzzy
+#| msgid "1 minute"
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 mhionaid"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:71
+#, fuzzy
+#| msgid "2 minutes"
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 mhionaid"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:74
+#, fuzzy
+#| msgid "3 minutes"
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 mionaidean"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:77
+#, fuzzy
+#| msgid "5 minutes"
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 mionaidean"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:80
+#, fuzzy
+#| msgid "30 minutes"
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "Leth-uair a thìde"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:83
+#, fuzzy
+#| msgid "1 hour"
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 uair a thìde"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:126
+#, fuzzy
+#| msgid "1 minute"
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 mhionaid"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:129
+#, fuzzy
+#| msgid "2 minutes"
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 mhionaid"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:132
+#, fuzzy
+#| msgid "3 minutes"
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 mionaidean"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:135
+#, fuzzy
+#| msgid "4 minutes"
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 mionaidean"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:138
+#, fuzzy
+#| msgid "5 minutes"
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 mionaidean"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:141
+#, fuzzy
+#| msgid "8 minutes"
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 mionaidean"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:144
+#, fuzzy
+#| msgid "10 minutes"
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 mionaidean"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:147
+#, fuzzy
+#| msgid "12 minutes"
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 mhionaid"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:150
+#, fuzzy
+#| msgid "15 minutes"
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "Cairteal na h-uarach"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:153
+#, fuzzy
+#| msgid "Never"
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Chan ann idir"
+
+#: panels/lock/cc-lock-panel.ui:8
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:13
+#, fuzzy
+#| msgid "_Blank screen"
+msgid "Blank Screen Delay"
+msgstr "Sgrìn _bhàn"
+
+#: panels/lock/cc-lock-panel.ui:14
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:32
+msgid "Automatic Screen _Lock"
+msgstr "G_las fhèin-obrachail na sgrìn"
+
+#: panels/lock/cc-lock-panel.ui:46
+#, fuzzy
+#| msgid "Automatic Screen _Lock"
+msgid "Automatic _Screen Lock Delay"
+msgstr "G_las fhèin-obrachail na sgrìn"
+
+#: panels/lock/cc-lock-panel.ui:47
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:65
+#, fuzzy
+#| msgid "Show _Notifications"
+msgid "Show _Notifications on Lock Screen"
+msgstr "Seall _na brathan"
+
+#: panels/lock/cc-lock-panel.ui:80
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:81
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "Glas na sgrìn"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Lock screen"
+msgid "Lock your screen"
+msgstr "Glais an sgrìn"
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:20
+#, fuzzy
+#| msgid "Screen Turns Off"
+msgid "Microphone Turned Off"
+msgstr "Thèid na sgrìnichean dheth"
+
+#: panels/microphone/cc-microphone-panel.ui:21
+#, fuzzy
+#| msgid "No applications found"
+msgid "No applications can record sound."
+msgstr "Cha deach aplacaid sam bith a lorg"
+
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:51
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Cuir na roghainnean agad fo dheuchainn"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Coitcheann"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Prìomh-phutan"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+"Suidhichidh seo òrdugh nam putanan fiosaigeach air luchagan is padaichean-"
+"suathaidh."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Clì"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Deas"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Luchag"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Luaths na luchaige"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
+msgid "Natural Scrolling"
+msgstr "Sgroladh nàdarra"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
+msgid "Scrolling moves the content, not the view."
+msgstr "Gluaisidh an sgroladh an t-susbaint ’s cha ghluais an sealladh."
+
+#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+msgid "Touchpad"
+msgstr "Pada-suathaidh"
+
+#: panels/mouse/cc-mouse-panel.ui:119
+msgid "Touchpad Speed"
+msgstr "Luaths a’ phada-shuathaidh"
+
+#: panels/mouse/cc-mouse-panel.ui:136
+msgid "Tap to Click"
+msgstr "Thoir gnogag airson briogadh"
+
+#: panels/mouse/cc-mouse-panel.ui:147
+msgid "Two-finger Scrolling"
+msgstr "Sgroladh dà-chorragach"
+
+#: panels/mouse/cc-mouse-panel.ui:159
+msgid "Edge Scrolling"
+msgstr "Sgroladh oir"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Feuch briogadh, briogadh dùbailte agus sgroladh"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Còig briogaidhean, àm GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Briogadh dùbailte, prìomh-phutan"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Briogadh singilte, prìomh-phutan"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Briogadh dùbailte, putan meadhain"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Briogadh singilte, putan meadhain"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Briogadh dùbailte, an dàrna putan"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Briogadh singilte, an dàrna putan"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "An luchag ⁊ am pada-suathaidh"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Atharraich mothalachd na luchaige no a’ phada-suathaidh agad is tagh tè "
+"deas- no chlì-làmhach"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Pada-suathaidh;Tomhaire;Briog;Gnogag;Dùbailte;Ball-lorgaire;Sgrolaich;"
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+#| msgid "Colorspace: "
+msgid "Workspaces"
+msgstr "Spàs nan dathan: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+#| msgid "Automatically empty _Trash"
+msgid "Automatically removes empty workspaces."
+msgstr "Fa_lamhaich an sgudal gu fèin-obrachail"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+#| msgid "%s Monitor"
+msgid "Multi-Monitor"
+msgstr "Monatair %s"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+#| msgctxt "Wacom action-type"
+#| msgid "Application defined"
+msgid "Application Switching"
+msgstr "A-rèir na h-aplacaid"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgstr ""
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ìoc, chaidh rudeigin cearr. Cuir fios gu reiceadair a’ bhathair-bhog agad."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Feumaidh NetworkManager a bhith a’ ruith."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+#| msgid "Devices"
+msgid "Other Devices"
+msgstr "Innleadan"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
+#: panels/network/connection-editor/net-connection-editor.c:580
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:70
+msgid "Not set up"
+msgstr "Cha deach seo a shuidheachadh"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:207
+#, fuzzy, c-format
+#| msgctxt "timezone desc"
+#| msgid "%s (%s)"
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (%s)"
+
+#: panels/network/cc-wifi-connection-row.c:263
+msgid "Insecure network (WEP)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:267
+msgid "Secure network (WPA)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:271
+msgid "Secure network (WPA2)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Secure network (WPA3)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Ceangailte"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
+#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Roghainnean…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "A bheil thu airson an WiFi Hotspot a chur air?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Ainm an lìonraidh"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:74
+#: panels/printers/new-printer-dialog.ui:331
+#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:362
+#: panels/wwan/cc-wwan-apn-dialog.ui:172
+msgid "Password"
+msgstr "Facal-faire"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#, fuzzy
+#| msgid "Group Password"
+msgid "Generate Random Password"
+msgstr "Facal-faire a' bhuidhinn"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#, fuzzy
+#| msgid "Current _Password"
+msgid "Autogenerate Password"
+msgstr "Am _facal-faire làithreach"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:129
+msgid "_Turn On"
+msgstr "_Cuir air"
+
+#: panels/network/cc-wifi-panel.c:544
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "WiFi"
+
+#: panels/network/cc-wifi-panel.c:879
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+"A bheil thu airson stad a chur air an hotspot is cleachdaiche sam bith eile "
+"a dhì-cheangal?"
+
+#: panels/network/cc-wifi-panel.c:882
+msgid "_Stop Hotspot"
+msgstr "_Cuir stad air an hotspot"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Airplane Mode"
+msgstr "Modh itealain"
+
+#: panels/network/cc-wifi-panel.ui:73
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Cuiridh seo WiFi, Bluetooth agus bann-leathann mobile à comas"
+
+#: panels/network/cc-wifi-panel.ui:110
+msgid "No Wi-Fi Adapter Found"
+msgstr "Cha deach adaptar WiFi a lorg"
+
+#: panels/network/cc-wifi-panel.ui:120
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+"Dèan cinnteach gu bheil adaptar WiFi agad ceangailte agus air a chur air"
+
+#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#, fuzzy
+#| msgid "Airplane Mode"
+msgid "Airplane Mode On"
+msgstr "Modh itealain"
+
+#: panels/network/cc-wifi-panel.ui:162
+#, fuzzy
+#| msgid "Turn off Wi-Fi to save power."
+msgid "Turn off to use Wi-Fi"
+msgstr "Cuir WiFi dheth gus cumhachd a chaomhnadh."
+
+#: panels/network/cc-wifi-panel.ui:199
+#, fuzzy
+#| msgid "Wi-Fi Hotspot"
+msgid "Wi-Fi Hotspot Active"
+msgstr "WiFi Hotspot"
+
+#: panels/network/cc-wifi-panel.ui:209
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:217
+#, fuzzy
+#| msgid "_Turn On Wi-Fi Hotspot…"
+msgid "Turn Off Hotspot…"
+msgstr "Cuir air WiFi Ho_tspot…"
+
+#: panels/network/cc-wifi-panel.ui:237
+msgid "Visible Networks"
+msgstr "Lìonraidhean a chithear"
+
+#: panels/network/cc-wifi-panel.ui:294
+msgid "NetworkManager needs to be running"
+msgstr "Feumaidh NetworkManager a bhith a’ ruith"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Tèarainteachd 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Tèarainteachd"
+
+#: panels/network/connection-editor/ce-page.c:234
+#, fuzzy
+#| msgid "reset"
+msgid "Preserve"
+msgstr "ath-shuidhich"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:237
+#, fuzzy
+#| msgid "Tablet"
+msgid "Stable"
+msgstr "Tablaid"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Pròifil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:101
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:107
+msgid "WPA3"
+msgstr ""
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:112
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:119
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:130
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Chan eil gin"
+
+#: panels/network/connection-editor/ce-page-details.c:151
+msgid "Never"
+msgstr "Chan ann idir"
+
+#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i latha air ais"
+msgstr[1] "%i latha air ais"
+msgstr[2] "%i làithean air ais"
+msgstr[3] "%i latha air ais"
+
+#: panels/network/connection-editor/ce-page-details.c:293
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr ""
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:295
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "2.4 GHz / 5 GHz"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:312
+msgid "2.4 GHz"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "5 GHz"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Chan eil gin"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Lag"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ceart ma-thà"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Math"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Fìor-mhath"
+
+#: panels/network/connection-editor/ce-page-details.c:409
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Seòladh IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:410
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
+msgid "IPv6 Address"
+msgstr "Seòladh IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:412
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Seòladh IP"
+
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:420
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
+#: panels/network/network-mobile.ui:217
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:473
+msgid "Forget Connection"
+msgstr "Dìochuimhnich an ceangal"
+
+#: panels/network/connection-editor/ce-page-details.c:475
+msgid "Remove Connection Profile"
+msgstr "Thoir air falbh pròifil a’ cheangail"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Remove VPN"
+msgstr "Thoir air falbh a’ VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:495
+msgid "Details"
+msgstr "Mion-fhiosrachadh"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "fèin-obrachail"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Dearbh-aithne"
+
+#: panels/network/connection-editor/ce-page-ip4.c:245
+#: panels/network/connection-editor/ce-page-ip6.c:226
+msgid "Delete Address"
+msgstr "Sguab às an seòladh"
+
+#: panels/network/connection-editor/ce-page-ip4.c:392
+#: panels/network/connection-editor/ce-page-ip6.c:361
+msgid "Delete Route"
+msgstr "Sguab às an t-slighe"
+
+#: panels/network/connection-editor/ce-page-ip4.c:742
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:712
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Chan eil gin"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Iuchair WEP 40/128-bit (Hex no ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Abairt-fhaire WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamic WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA ⁊ WPA2 pearsanta"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA ⁊ WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+#, fuzzy
+#| msgctxt "category"
+#| msgid "Personal"
+msgid "WPA3 Personal"
+msgstr "Pearsanta"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Neart an t-siognail"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Astar a’ cheangail"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Seòladh bathair-chruaidh"
+
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+#| msgid "Supported ICC profiles"
+msgid "Supported Frequencies"
+msgstr "Pròifilean ICC ris a bheil taic"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:189
+msgid "Default Route"
+msgstr "An t-slighe bhunaiteach"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Air a chleachdadh an turas mu dheireadh"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Ce_angail gu fèin-obrachail"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Cuir ri lài_mh chleachdaichean eile"
+
+#: panels/network/connection-editor/details-page.ui:412
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:421
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "Ai_nm"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Seòladh _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Seòladh _clònaichte"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Modh IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Fèin-obrachail (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Link-Local a-mhàin"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+msgid "Manual"
+msgstr "A làimh"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Cuir à comas"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+#| msgid "Shared with other computers"
+msgid "Shared to other computers"
+msgstr "Co-roinnte le coimpiutairean eile"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Seòlaidhean"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:255
+#: panels/printers/pp-details-dialog.ui:90
+msgid "Address"
+msgstr "Seòladh"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:258
+msgid "Netmask"
+msgstr "Netmask"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:279
+msgid "Gateway"
+msgstr "Bealach"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:232
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Fèin-obrachail"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS fèin-obrachail"
+
+#: panels/network/connection-editor/ip4-page.ui:196
+#: panels/network/connection-editor/ip6-page.ui:205
+msgid "Separate IP addresses with commas"
+msgstr "Sgaraich seòlaichean IP le cromagan"
+
+#: panels/network/connection-editor/ip4-page.ui:213
+#: panels/network/connection-editor/ip6-page.ui:222
+msgid "Routes"
+msgstr "Slighean"
+
+#: panels/network/connection-editor/ip4-page.ui:231
+#: panels/network/connection-editor/ip6-page.ui:240
+msgid "Automatic Routes"
+msgstr "Slighean fèin-obrachail"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:281
+#: panels/network/connection-editor/ip6-page.ui:290
+msgid "Metric"
+msgstr "Meatraigeachd"
+
+#: panels/network/connection-editor/ip4-page.ui:304
+#: panels/network/connection-editor/ip6-page.ui:313
+msgid "Use this connection _only for resources on its network"
+msgstr "Na cleachd an ceangal se_o ach airson goireasan air a lìonra fhèin"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Modh IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Fèin-obrachail, DHCP a-mhàin"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:267
+msgid "Prefix"
+msgstr "Ro-leasachan"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Chan urrainn dhuinn deasaiche nan ceanglaichean fhosgladh"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Pròifil ùr"
+
+#: panels/network/connection-editor/net-connection-editor.c:715
+msgid "Import from file…"
+msgstr "Ion-phortaich o fhaidhle…"
+
+#: panels/network/connection-editor/net-connection-editor.c:741
+msgid "Add VPN"
+msgstr "Cuir ris VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Tèaraint_eachd"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Chan urrainn dhuinn an ceangal VPN ion-phortadh"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Cha b’ urrainn dhuinn am faidhle “%s” a leughadh no chan eil dàta sam bith "
+"’na bhroinn leis an dèanar ceangal VPN\n"
+"\n"
+"Mearachd: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Tagh faidhle a thèid ion-phortadh"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Tha faidhle air a bheil “%s” ann mu thràth."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "Cui_r ’na àite"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+"A bheil thu airson an ceangal VPN a tha thu a’ sàbhaladh a chur an àite “%s”?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Chan urrainn dhuinn an ceangal VPN às-phortadh"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Cha b’ urrainn dhuinn an ceangal VPN “%s” às-phortadh gu %s.\n"
+"\n"
+"Mearachd: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Às-phortaich ceangal VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+"(Mearachd: Chan urrainn dhuinn deasaiche nan ceanglaichean VPN a luchdadh)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Stiùirich an dòigh a cheanglas tu ris an eadar-lìon"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
+#| "vpn;DNS;"
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;lìonra,uèirleas,progsaidh;bann-leathann;drochaid;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Stiùirich an dòigh a cheanglas tu ri lìonraidhean WiFi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+#| msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;lìonra;uèirleas,bann-"
+"leathann;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "Chan ann idir"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "an-diugh"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "an-dè"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Air a chleachdadh an turas mu dheireadh"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Uèirichte"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Cuir ceangal ùr ris"
+
+#: panels/network/net-device-wifi.c:857
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Thèid fiosrachadh nan lìonraidhean a thagh thu, a’ gabhail a-steach an "
+"fhacail-fhaire ’s rèiteachadh gnàthaichte sam bith, air chall."
+
+#: panels/network/net-device-wifi.c:861
+msgid "_Forget"
+msgstr "_Dìochuimhnich"
+
+#: panels/network/net-device-wifi.c:1041
+msgid "Known Wi-Fi Networks"
+msgstr "Lìonraidhean WiFi as aithne dhuinn"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1073
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Dìochuimhnich"
+
+#: panels/network/net-device-wifi.c:1216
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+"Chan eil e ceadaichte a chleachdadh mar hotspot ri linn poileasaidh an t-"
+"siostaim"
+
+#: panels/network/net-device-wifi.c:1219
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Chan eil an t-uidheam uèirleas a’ cur taic ris a’ mhodh hotspot"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Nuair nach eil URL rèiteachaidh ’ga thoirt seachad, thèid fhèin-lorg "
+"progsaidh lìonraidh a chleachdadh."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Cha mholamaid seo air lìonraidhean poblach anns nach eil earbsa."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Cuir an t-uidheam dheth"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Sòlaraiche"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+msgid "Network Proxy"
+msgstr "Progsaidh lìonraidh"
+
+#: panels/network/network-proxy.ui:139
+msgid "_HTTP Proxy"
+msgstr "Progsaidh _HTTP"
+
+#: panels/network/network-proxy.ui:156
+msgid "H_TTPS Proxy"
+msgstr "Progsaidh H_TTPS"
+
+#: panels/network/network-proxy.ui:173
+msgid "_FTP Proxy"
+msgstr "Progsaidh _FTP"
+
+#: panels/network/network-proxy.ui:190
+msgid "_Socks Host"
+msgstr "Òstair _Socks"
+
+#: panels/network/network-proxy.ui:207
+msgid "_Ignore Hosts"
+msgstr "Le_ig seachad òstairean"
+
+#: panels/network/network-proxy.ui:244
+msgid "HTTP proxy port"
+msgstr "Port progsaidh HTTP"
+
+#: panels/network/network-proxy.ui:307
+msgid "HTTPS proxy port"
+msgstr "Port progsaidh HTTPS"
+
+#: panels/network/network-proxy.ui:322
+msgid "FTP proxy port"
+msgstr "Port progsaidh FTP"
+
+#: panels/network/network-proxy.ui:337
+msgid "Socks proxy port"
+msgstr "Port progsaidh Socks"
+
+#: panels/network/network-proxy.ui:357
+msgid "_Configuration URL"
+msgstr "An URL _rèiteachaidh"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Cuir an ceangal VPN dheth"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+#| msgid "Network Name"
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Ainm an lìonraidh"
+
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+#| msgid "Security type"
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Seòrsa na tèarainteachd"
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+#| msgid "Password"
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Facal-faire"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Cuir am WiFi dheth"
+
+#: panels/network/network-wifi.ui:121
+msgid "_Connect to Hidden Network…"
+msgstr "_Ceangail ri lìonra falaichte…"
+
+#: panels/network/network-wifi.ui:128
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Cuir air WiFi Ho_tspot…"
+
+#: panels/network/network-wifi.ui:135
+msgid "_Known Wi-Fi Networks"
+msgstr "_Lìonraidhean WiFi as aithne dhuinn"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Chan eil fhios dè an staid"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Gun stiùireadh"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Chan eil seo ri fhaighinn"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "A’ ceangal"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Tha feum air dearbhadh"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "A’ briseadh a’ cheangail"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Dh’fhàillig an ceangal"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Chan eil fhios dè an staid (a dhìth)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Dh’fhàillig an rèiteachadh"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Dh’fhàillig rèiteachadh an IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Dh’fhalbh an ùine air rèiteachadh an IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Bha feum air rùintean ach cha dug thu seachad gin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Chaidh an ceangal ris an athchuingiche 802.1x a bhriseadh"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Dh’fhàillig rèiteachadh an athchuingiche 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Dh’fhàillig an t-athchuingiche 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Thug dearbhadh an t-athchuingiche 802.1x ro fhada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Dh’fhàillig tòiseachadh na seirbheise PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Chaidh an ceangal ris an t-seirbheis PPP a bhriseadh"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Dh’fhàillig PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Dh’fhàillig thòiseachadh a’ chliant DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Mearachd a’ chliant DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Dh’fhàillig an cliant DCHP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Dh’fhàillig tòiseachadh seirbheis a’ cheangail cho-roinnte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Dh’fhàillig seirbheis a’ cheangail cho-roinnte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Dh’fhàillig tòiseachadh na seirbheise AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Mearachd na seirbheise AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Dh’fhàillig an t-seirbheis AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Tha an loidhne trang"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Chan eil fuaim daithealaidh ann"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Cha b’ urrainn giùlanair a stèidheachadh"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Dh’fhalbh an ùine air an iarrtas daithealaidh"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Dh’fhàillig an oidhirp daithealaidh"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Dh’fhàillig tòiseachadh a’ mhòdaim"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Dh’fhàillig taghadh an APN a shònraich thu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Chan eilear a’ sireadh lìonraidhean"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Chaidh clàradh an lìonraidh a dhiùltadh"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Dh’fhalbh an ùine air clàradh an lìonraidh"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Cha b’ urrainn dhuinn clàradh aig an lìonra a dh’iarr thu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Dh’fhàillig sgrùdadh a’ PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Dh’fhaoidte gu bheil am bathar-an-sàs airson an uidheim a dhìth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Dh’fhalbh an ceangal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Chaidh ceangal a bha ann a ghabhail os làimh"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Cha deach am mòdam a lorg"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Dh’fhàillig an ceangal Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Cha deach cairt SIM a chur a-steach"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Tha feum air PIN an SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Tha feum air PUK an SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Tha an SIM cearr"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Dh’fhàillig eisimeileachd a’ cheangail"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Tha bathar-an-sàs a dhìth"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Chan eil an càball a-staigh"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "mearachd gun sònrachadh san tèarainteachd 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "cha deach faidhle a thaghadh"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "mearachd gun sònrachadh le dearbhadh an fhaidhle eap-method"
+
+#: panels/network/wireless-security/eap-method.c:389
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr ""
+"Iuchraichean prìobhaideach DER, PEM no PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:392
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER no teisteanasan PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "tha faidhle EAP-FAST PAC a dhìth"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Faidhlichean PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Gun urra"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Air a dhearbhadh"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "An dà chuid"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Gun _urra"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Faidhle PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Tagh faidhle PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "De_arbhadh a-staigh"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Ceadaich PAC _Provisioning fèin-obrachail"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "tha ainm-cleachdaiche EAP-LEAP a dhìth"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "tha facal-faire EAP-LEAP a dhìth"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Ainm-cleachdaiche"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:175
+msgid "_Password"
+msgstr "_Facal-faire"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Seall a_m facal-faire"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "teisteanas EAP-PEAP CA mì-dhligheach: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+"teisteanas EAP-PEAP CA mì-dhligheach: cha deach teisteanas a shònrachadh"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Tionndadh 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Tionndadh 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Teiste_anas le ùghdarras theisteanasan"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Tagh seirbheis ùghdarras theisteanasan"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Chan eil teisteanas CA _riatanach"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "Tionndadh _PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "tha ainm-cleachdaiche EAP a dhìth"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "tha facal-faire EAP a dhìth"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "tha dearbh-aithne EAP-TLS a dhìth"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "teisteanas EAP-TLS CA mì-dhligheach: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+"teisteanas EAP-TLS CA mì-dhligheach: cha deach teisteanas a shònrachadh"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "iuchair phrìobhaideach EAP-TLS mhì-dhligheach: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "teisteanas cleachdaiche EAP-TLS mì-dhligheach: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Chan eil iuchraichean prìobhaideach gun chrioptachadh tèarainte"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Tha coltas nach eil an iuchair phrìobhaideach a thagh thu air a "
+"chrioptachadh. Bheireadh sin cothrom do dhaoine an t-ainm is facal-faire "
+"agad a ghoid. Tagh iuchair phrìobhaideach a tha fo dhìon facail-fhaire.\n"
+"\n"
+"(’S urrainn dhut an iuchair phrìobhaideach agad a dhìon le openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Tagh an teisteanas prìobhaideach agad"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Tagh an iuchair phrìobhaideach agad"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Dearbh-aithne"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Teisteanas cleachdaiche"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "I_uchair phrìobhaideach"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Facal-faire na _h-iuchrach phrìobhaideach"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "teisteanas EAP-TTLS CA mì-dhligheach: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+"teisteanas EAP-TTLS CA mì-dhligheach: cha deach teisteanas a shònrachadh"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (gun EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Àrainn"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Mearachd nach aithne dhuinn le dearbhadh tèarainteachd 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunneled TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Protected EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "D_earbhadh"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+#, fuzzy
+#| msgid "Select a File…"
+msgid "Select a file"
+msgstr "Tagh faidhle…"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "tha ainm-cleachdaiche leap a dhìth"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "tha facal-faire leap a dhìth"
+
+#: panels/network/wireless-security/ws-sae.c:77
+#, fuzzy
+#| msgid "invalid EAP-TLS password: missing"
+msgid "Wi-Fi password is missing."
+msgstr "facal-faire EAP-TLS mì-dhligheach: chan eil gin ann"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Seòrsa"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "tha iuchair wep a dhìth"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"tha an iuchair wep mì-dhligheach: chan fhaod ach figearan sia-dheicheach a "
+"bhith am broinn iuchair a tha %zu a dh’fhaid"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"tha an iuchair wep mì-dhligheach: chan fhaod ach caractaran ASCII a bhith am "
+"broinn iuchair a tha %zu a dh’fhaid"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"tha an iuchair wep mì-dhligheach: tha faide na iuchrach %zu cearr. Feumaidh "
+"iuchair a bith 5/13 (ascii) no 10/26 (sia-dheicheach) a dh’fhaid"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr ""
+"tha an iuchair wep mì-dhligheach: chan fhaod an abairt-fhaire a bhith falamh"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"tha an iuchair wep mì-dhligheach: chan fhaod an abairt-fhaire a bhith nas "
+"giorra na 64 caractar"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Bun-roghainn)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Siostam fosgailte"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Iuchair cho-roinnte"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Iuchair"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Seall an iuchair"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Inneacs _WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk mì-dhligheach: tha faide na h-iuchrach %zu mì-dhligheach. Feumaidh i "
+"bhith [8,63] baidht no 64 figear sia-dheicheach"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk mì-dhligheach: cha ghabh an iuchair tuigsinn mar àireamh shia-"
+"dheicheach a tha 43 baidht a dh’fhaid"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Bratha_n"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "C_aismeachdan fuaime"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Priob-bhrathan"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Nochdaidh brathan fhathast air liosta nam brathan nuair a bhios am priobadh "
+"air a chur à comas."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Seall susbaint nan tea_chdaireachdan ann am priob-bhrathan"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Brathan na sgrìn-g_lasaidh"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Seall s_usbaint nan teachdaireachdan air an sgrìn-ghlasaidh"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Brathan na sgrìn-g_lasaidh"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Stiùirich na brathan a chithear agus na sheallas iad"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;Banner;Message;Tray;Popup;brathan;bratach;teachdaireachd;"
+"treidhe;priob-uinneag;"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:277
+#, fuzzy, c-format
+#| msgid "<b>%s</b> removed"
+msgid "%s removed"
+msgstr "Chaidh <b>%s</b> a toirt air falbh"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:406
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Eile"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "Mearachd a’ toirt air falbh a’ chunntais"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:51
+msgid "Undo"
+msgstr "Neo-dhèan"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:55
+msgid "Connect to your data in the cloud"
+msgstr "Dèan ceangal ris an dàta agad san neul"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:66
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Chan eil ceangal dhan eadar-lìon ann — dèan ceangal gus cunntas air loidhne "
+"ùr a chruthachadh"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:93
+msgid "Add an account"
+msgstr "Cuir cunntas ris"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:426
+#, c-format
+msgid "%s Account"
+msgstr "Cunntas %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:429
+msgid "Remove Account"
+msgstr "Thoir air falbh an cunntas"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Cunntasan air loidhne"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Ceangail ris na cunntasan air loidhne ’s cuir romhad mar a thèid an "
+"cleachdadh"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;cabadaich;post;mìosachadn;pòcaid;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Chan eil fhios dè cho fad"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i mhionaid"
+msgstr[1] "%i mhionaid"
+msgstr[2] "%i mionaidean"
+msgstr[3] "%i mionaid"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i uair a thìde"
+msgstr[1] "%i uair a thìde"
+msgstr[2] "%i uairean a thìde"
+msgstr[3] "%i uair a thìde"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "uair a thìde"
+msgstr[1] "uair a thìde"
+msgstr[2] "uairean a thìde"
+msgstr[3] "uair a thìde"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "mhionaid"
+msgstr[1] "mhionaid"
+msgstr[2] "mionaidean"
+msgstr[3] "mionaid"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s gus am bi e air a làn-teairrdseadh"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Rabhadh: %s air fhàgail"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s air fhàgail"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Air a làn-teairrdseadh"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+#, fuzzy
+#| msgid "Charging"
+msgid "Not charging"
+msgstr "A’ teairrdseadh"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Falamh"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "A’ teairrdseadh"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "’Ga dhì-theairrdseadh"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Luchag uèirleas"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Meur-chlàr uèirleas"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Solar cumhachd do-bhrisidh"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Cuidiche digiteach pearsanta"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Fòn-làimhe"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Cluicheadair mheadhanan"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablaid"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Coimpiutair"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Uidheam ion-chuir geama"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bataraidh"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Prìomh-bhataraidh"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Bataraidh a bharrachd"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Bataraidhean"
+
+#: panels/power/cc-power-panel.c:511
+msgid "When _idle"
+msgstr "Nua_ir a bhios e ’na thàmh"
+
+#: panels/power/cc-power-panel.c:671
+msgid "Suspend"
+msgstr "Cuir ’na dhàil"
+
+#: panels/power/cc-power-panel.c:672
+msgid "Power Off"
+msgstr "Cumhachd dheth"
+
+#: panels/power/cc-power-panel.c:673
+msgid "Hibernate"
+msgstr "Dèan cadal-geamhraidh"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Nothing"
+msgstr "Na dèan dad"
+
+#: panels/power/cc-power-panel.c:730
+msgid "When on battery power"
+msgstr "Nuair a bhithear air cumhachd bataraidh"
+
+#: panels/power/cc-power-panel.c:732
+msgid "When plugged in"
+msgstr "Nuair a bhios e air a phlugadh a-steach"
+
+#: panels/power/cc-power-panel.c:853
+#, fuzzy
+#| msgid "Never"
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Chan ann idir"
+
+#: panels/power/cc-power-panel.c:937
+msgid "Automatic suspend"
+msgstr "Cur ’na dhàil fèin-obrachail"
+
+#: panels/power/cc-power-panel.c:1030
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1032
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1034
+msgid "Performance mode temporarily disabled."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1076
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1084
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1088
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+#| msgid "15 minutes"
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "Cairteal na h-uarach"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+#| msgid "20 minutes"
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 mionaid"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+#| msgid "25 minutes"
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 mionaid"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+#| msgid "30 minutes"
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "Leth-uair a thìde"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+#| msgid "45 minutes"
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "Trì cairtealan na h-uarach"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+#| msgid "1 hour"
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 uair a thìde"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+#| msgid "80 minutes"
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 mionaid"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+#| msgid "90 minutes"
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 mionaid"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+#| msgid "100 minutes"
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 mionaid"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+#| msgid "2 hours"
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 uair a thìde"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+#| msgid "Power"
+msgid "Power Mode"
+msgstr "Cumhachd"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+#| msgid "Power Saving"
+msgid "Power Saving Options"
+msgstr "Caomhnadh cumhachd"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+#| msgid "Automatic brightness"
+msgid "Automatic Screen Brightness"
+msgstr "Soilleireachd fhèin-obrachail"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:138
+#, fuzzy
+#| msgid "Screen"
+msgid "Dim Screen"
+msgstr "Sgrìn"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:150
+#, fuzzy
+#| msgid "Screen _Reader"
+msgid "Screen _Blank"
+msgstr "Leughadai_r-sgrìn"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:159
+#, fuzzy
+#| msgid "_Automatic Problem Reporting"
+msgid "Automatic Power Saver"
+msgstr "_Aithrisean fèin-obrachail air duilgheadasan"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:173
+#, fuzzy
+#| msgid "Automatic Suspend"
+msgid "_Automatic Suspend"
+msgstr "Cuir ’na dhàil gu fèin-obrachail"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:199
+#, fuzzy
+#| msgid "Lower Button"
+msgid "Po_wer Button Behavior"
+msgstr "Am putan aig a’ bhonn"
+
+#: panels/power/cc-power-panel.ui:207
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:243
+msgid "Automatic Suspend"
+msgstr "Cuir ’na dhàil gu fèin-obrachail"
+
+#: panels/power/cc-power-panel.ui:266
+msgid "_Plugged In"
+msgstr "_Plugte a-staigh"
+
+#: panels/power/cc-power-panel.ui:278
+msgid "On _Battery Power"
+msgstr "Air cumhachd a’ _bhataraidh"
+
+#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
+#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+msgid "Delay"
+msgstr "Dàil"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:136
+#, fuzzy
+#| msgid "_Balance:"
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Cothro_m:"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:140
+#, fuzzy
+#| msgid "Power Saving"
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Caomhnadh cumhachd"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Cumhachd"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Seall ìre a’ bhataraidh agad is atharraich roghainnean caomhnadh na cumhachd"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;"
+#| "Idle;"
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"cumhachd;cadal;dàil;cadal-geamhraidh;bataraidh;soilleireachd;doilleireachd;"
+"bàn;monatair;tàmh;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:676
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Chaidh an clò-bhualadair “%s” a sguabadh às"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:928
+msgid "Failed to add new printer."
+msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1229
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Cha b’ urrainn dhuinn an eadar-aghaidh %s a luchdadh"
+
+#: panels/printers/cc-printers-panel.c:1297
+msgid "Unlock to Add Printers and Change Settings"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Clò-bhualadairean"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Cuir clò-bhualadairean, seall obraichean a’ chlò-bhualadair is cuir romhad "
+"mar a thèid clò-bhualadh"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Clò-bhualadair;Ciudha;Clò-bhualadh;Pàipear;Inc;Tònair;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Cuir clò-bhualadair ris"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:100
+#: panels/printers/new-printer-dialog.ui:115
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Thoir a’ ghlas dheth"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:194
+msgid "No Printers Found"
+msgstr "Cha deach clò-bhualadair a lorg"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:244
+msgid "Enter a network address or search for a printer"
+msgstr "Cuir a-steach seòladh lìonraidh gus clò-bhualadair a lorg"
+
+#: panels/printers/new-printer-dialog.ui:286
+msgid "Authentication Required"
+msgstr "Tha feum air dearbhadh"
+
+#: panels/printers/new-printer-dialog.ui:302
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Cuir a-steach ainm-cleachdaiche ’s facal-faire gus na clò-bhualadairean "
+"fhaicinn a tha ri làimh air an fhrithealaiche."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:311
+#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:148
+msgid "Username"
+msgstr "Ainm-cleachdaiche"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:365
+#, c-format
+msgid "%s Details"
+msgstr "Fiosrachadh air %s"
+
+#: panels/printers/pp-details-dialog.c:101
+msgid "No suitable driver found"
+msgstr "Cha deach draibhear freagarrach a lorg"
+
+#: panels/printers/pp-details-dialog.c:260
+msgid "Select PPD File"
+msgstr "Tagh faidhle PPD"
+
+#: panels/printers/pp-details-dialog.c:269
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Faidhlichean PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+"gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+msgid "Location"
+msgstr "Ionad"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:115
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Draibhear"
+
+#: panels/printers/pp-details-dialog.ui:154
+msgid "Searching for preferred drivers…"
+msgstr "A’ lorg nan draibhearan as fhearr…"
+
+#: panels/printers/pp-details-dialog.ui:173
+msgid "Search for Drivers"
+msgstr "Lorg draibhearan"
+
+#: panels/printers/pp-details-dialog.ui:181
+msgid "Select from Database…"
+msgstr "Tagh o stòr-dàta…"
+
+#: panels/printers/pp-details-dialog.ui:189
+msgid "Install PPD File…"
+msgstr "Stàlaich faidhle PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Tagh draibhear a’ chlò-bhualadair"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "A’ luchdadh stòr-dàta nan draibhearan…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Tagh"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Clò-bhualadair JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Clò-bualadair LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Aon-taobhach"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Oir fhada (stannardach)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Oir ghoirid (Flip)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portraid"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Dreach-tìre"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Dreach-tìre contrarra"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Portraid chontrarra"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:134
+msgctxt "print job"
+msgid "Pending"
+msgstr "Ri dhèanamh"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:140
+msgctxt "print job"
+msgid "Paused"
+msgstr "’Na stad"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:145
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Tha feum air dearbhadh"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "’Ga phròiseasadh"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Sguireadh dheth"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Sguireadh dheth"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Sguireadh dheth"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "Air a choileanadh"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:176
+msgid "Move this job to the top of the queue"
+msgstr ""
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "Tha %u obair feumach air dearbhadh"
+msgstr[1] "Tha %u obair feumach air dearbhadh"
+msgstr[2] "Tha %u obraichean feumach air dearbhadh"
+msgstr[3] "Tha %u obair feumach air dearbhadh"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s – Obraichean gnìomhach"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Cuir a-steach teisteas airson clò-bhualadh o %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Àrainn"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:100
+msgid "A_uthenticate"
+msgstr "D_earbhaich"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:128
+msgid "Clear All"
+msgstr "Falamhaich na h-uile"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:173
+msgid "_Authenticate"
+msgstr "De_arbhaich"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:214
+msgid "No Active Printer Jobs"
+msgstr "Chan eil obair clò-bhualaidh gnìomhach"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Thoir a’ ghlas far an fhrithealaiche clò-bhualaidh"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Thoir a’ ghlas far %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Cuir a-steach ainm-cleachdaiche ’s facal-faire gus na clò-bhualadairean "
+"fhaicinn a tha ri làimh air %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "A’ lorg clò-bhualadairean"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Port sreathach"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Port co-shìnte"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Ionad: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Seòladh: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Feumaidh am frithealaiche dearbhadh"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dà-thaobhach"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Seòrsa a’ phàipeir"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Tùs a’ phàipeir"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Treidhe às-chuir"
+
+#: panels/printers/pp-options-dialog.c:91
+#, fuzzy
+#| msgid "Resolution"
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Dùmhlachd-bhreacaidh"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Ro-chriathradh GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Duilleagan air gach taobh"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dà-thaobhach"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Comhair"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Coitcheann"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Suidheachadh na duilleige"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Roghainnean a gabhas stàladh"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Obair"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Càileachd an deilbh"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Dath"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Lìomhadh"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Adhartach"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Duilleag deuchainne"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Duilleag deuchainne"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Taghadh fèin-obrachail"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Bun-roghainnean a’ chlò-bhualadair"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Na leabaich ach cruthan-clò GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Iompaich ’na PS leibheil 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Iompaich ’na PS leibheil 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Gun ro-chriathradh"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Saothraiche"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Chan eil obair ghnìomhach ann"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u obair"
+msgstr[1] "%u obair"
+msgstr[2] "%u obraichean"
+msgstr[3] "%u obair"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Glan na cinn clò-bhualaidh"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Tònair gann"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Chan eil tònair air fhàgail"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Stuth-leasachaidh gann"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Chan eil stuth-leasachaidh air fhàgail"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Dath gann ann am biona a’ chlò-bhualadair"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Chan eil dath air fhàgail ann am biona a’ chlò-bhualadair"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Tha am mullach fosgailte"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Tha an doras fosgailte"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Pàipear gann"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Chan eil pàipear air fhàgail"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Far loidhne"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Sguireadh dheth"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Tha soitheach an sgudail cha mhòr làn"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Tha soitheach an sgudail làn"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Tha am foto-ghiùlanair lèirsinneach a’ dol bàs"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Chan eil am foto-ghiùlanair lèirsinneach ag obair tuilleadh"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Deiseil"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Cha ghabh e ri obraichean"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "’Ga phròiseasadh"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Roghainnean a’ chlò-bhualaidh"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Fiosrachadh a’ chlò-bhualadair"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Cleachd an clò-bhualadair seo a gnàth"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Glan na cinn clò-bhualaidh"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Thoir air falbh an clò-bhualadair"
+
+#: panels/printers/printer-entry.ui:187
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modail"
+
+#: panels/printers/printer-entry.ui:242
+msgid "Ink Level"
+msgstr "Ìre na h-ince"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:304
+msgid "Please restart when the problem is resolved."
+msgstr "Dèan ath-thòiseachadh nuair a bhios an duilgheadas air a chàradh."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:310
+msgid "Restart"
+msgstr "Ath-thòisich"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10
+#, fuzzy
+#| msgid "Add a Printer…"
+msgid "Add Printer…"
+msgstr "Cuir clò-bhualadair ris…"
+
+#: panels/printers/printers.ui:168
+msgid "No printers"
+msgstr "Chan eil clò-bhualadair ann"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:179
+msgid "Add a Printer…"
+msgstr "Cuir clò-bhualadair ris…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:204
+#, fuzzy
+#| msgid ""
+#| "Sorry! The system printing service\n"
+#| "doesn’t seem to be available."
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Tha sinn duilich ach chan eil seirbheis clò-bhualadh\n"
+"an t-siostaim ri làimh a-rèir coltais."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Fòrmatan"
+
+#: panels/region/cc-format-chooser.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Air ais"
+
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+#| msgid "Search Locations"
+msgid "Search locales…"
+msgstr "Ionadan luirg"
+
+#: panels/region/cc-format-chooser.ui:113
+#, fuzzy
+#| msgid "Formats"
+msgid "Common Formats"
+msgstr "Fòrmatan"
+
+#: panels/region/cc-format-chooser.ui:140
+#, fuzzy
+#| msgid "Formats"
+msgid "All Formats"
+msgstr "Fòrmatan"
+
+#: panels/region/cc-format-chooser.ui:188
+#, fuzzy
+#| msgid "No results found"
+msgid "No Search Results"
+msgstr "Cha deach toradh a lorg"
+
+#: panels/region/cc-format-chooser.ui:200
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:236
+msgid "Preview"
+msgstr "Ro-shealladh"
+
+#: panels/region/cc-format-preview.c:135
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Impireil"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Meatraigeach"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Cinn-là"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Cinn-là ⁊ amannan"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Àireamhan"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Tomhasan"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Pàipear"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats is "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:51
+#, fuzzy
+#| msgid "Your account"
+msgid "Your Account"
+msgstr "An cunntas agad"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:299
+msgid "_Language"
+msgstr "_Cànan"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Fòrmatan"
+
+#: panels/region/cc-region-panel.ui:90
+#, fuzzy
+#| msgid "Login _Screen"
+msgid "Login Screen"
+msgstr "_Sgrìn a’ chlàraidh a-steach"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Roinn-dùthcha ⁊ cànan"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+#| msgid ""
+#| "Select your display language, formats, keyboard layouts and input sources"
+msgid "Select your display language and formats"
+msgstr "Tagh an cànan-taisbeanaidh, fòrmatan, meur-chlàran is tùsan ion-chuir"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+"cànan;co-dhealbhachd;meur-chlàr;ion-chur;Language;Layout;Keyboard;Input;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Faighnich dhìom"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Na dèan dad"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Fosgail am pasgan"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Meadhanan eile"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Tagh aplacaid airson CDan fuaime"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Tagh aplacaid airson DVDan video"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Tagh aplacaid a thèid a ruith nuair a cheanglar cluicheadair ciùil ris"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Tagh aplacaid a thèid a ruith nuair a cheanglar camara ris"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Tagh aplacaid airson CDan bathair-bhog"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD fuaime"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "diosg Blu-ray bàn"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "diosg CD bàn"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "diosg DVD bàn"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "diosg DVD HD bàn"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "diosg video Blu-ray bàn"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "leughadair leabhair-d"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "diosg video DVD HD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "CD dhealbhan"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Bathar-bog Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Tagh mar a thèid am meadhan a làimhseachadh"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _fuaime"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Cluicheadair ciùil"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Bathar-bog"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Meadhanan eile…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Na dèan brodadh ’s na tòisich prògraman ma thèid meadhan a chur a-steach"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Tagh mar a thèid meadhanan eile a làimhseachadh"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Gnìomh:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Seòrsa:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Meadhan so-ghiùlain"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Rèitich roghainnean nam meadhanan so-ghiùlain"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"uidheam;siostam;bunaiteach;aplacaid;as fhearr;cd;dvd;usb;fuaim;video;diosg;"
+"so-ghiùlain;meadhanan;fèin-ruith;device;system;default;application;preferred;"
+"cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Tagh ionad"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Ceart ma-tha"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Ionadan luirg"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Àitichean"
+
+#: panels/search/cc-search-locations-dialog.ui:33
+msgid "Bookmarks"
+msgstr "Comharran-lìn"
+
+#: panels/search/cc-search-locations-dialog.ui:48
+#, fuzzy
+#| msgid "Other"
+msgid "Others"
+msgstr "Eile"
+
+#: panels/search/cc-search-locations-dialog.ui:55
+#, fuzzy
+#| msgid "Location"
+msgid "Add Location"
+msgstr "Ionad"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Cha deach aplacaid sam bith a lorg"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+#| msgid "Applications"
+msgid "Application Search"
+msgstr "Aplacaidean"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+#| msgid "Search Locations"
+msgid "Search Results"
+msgstr "Ionadan luirg"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Stiùirich na h-aplacaidean a sheallas toraidhean luirg air foir-shealladh na "
+"gnìomhachd"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Find;Index;Hide;Privacy;Results;lorg;inneacs;clàr-amais;falaich;"
+"prìobhaideachd;toraidhean;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:265
+msgid "No networks selected for sharing"
+msgstr "Cha deach lìonra a thaghadh a chum co-roinnidh"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Lìonraidhean"
+
+#: panels/sharing/cc-sharing-panel.c:367
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Air"
+
+#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Dheth"
+
+#: panels/sharing/cc-sharing-panel.c:399
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "An comas"
+
+#: panels/sharing/cc-sharing-panel.c:402
+msgctxt "service is active"
+msgid "Active"
+msgstr "Gnìomhach"
+
+#: panels/sharing/cc-sharing-panel.c:520
+msgid "Choose a Folder"
+msgstr "Tagh pasgan"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:748
+#, fuzzy, c-format
+#| msgid ""
+#| "File Sharing allows you to share your Public folder with others on your "
+#| "current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Bheir co-roinneadh fhaidhlichean comas dhut am pasgan poblach agad a cho-"
+"roinneadh le daoine eile air an lìonra làithreach agad slighe: <a href="
+"\"dav://%s\">dav://%s</a>"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:754
+#, fuzzy, c-format
+#| msgid ""
+#| "When remote login is enabled, remote users can connect using the Secure "
+#| "Shell command:\n"
+#| "<a href=\"ssh %s\">ssh %s</a>"
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Ma tha an clàradh a-steach cèin an coma, ’s urrainn dha chleachdaichean "
+"ceangal a dhèanamh on taobh a-muigh slighe na h-àithne Secure Shell:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Co-roinneadh"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Ainm a’ _choimpiutair"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Co-roinneadh _fhaidhlichean"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Co-roinneadh _mheadhanan"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Clà_radh a-steach cèin"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Co-roinneadh fhaidhlichean"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Ia_rr facal-faire"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Clàradh a-steach cèin"
+
+#: panels/sharing/cc-sharing-panel.ui:250
+#: panels/sharing/cc-sharing-panel.ui:267
+#, fuzzy
+#| msgid "Remote Login"
+msgid "Remote Desktop"
+msgstr "Clàradh a-steach cèin"
+
+#: panels/sharing/cc-sharing-panel.ui:263
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:268
+#, fuzzy
+#| msgid "Enable or disable remote login"
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Cuir an comas no à comas clàradh a-steach cèin"
+
+#: panels/sharing/cc-sharing-panel.ui:280
+#, fuzzy
+#| msgid "_Allow Remote Control"
+msgid "Remote Control"
+msgstr "Ce_adaich smachd cèin"
+
+#: panels/sharing/cc-sharing-panel.ui:281
+#, fuzzy
+#| msgid "_Allow connections to control the screen"
+msgid "Allows remote connections to control the screen."
+msgstr "Leig le ce_anglaichean an sgrìn a stiùireadh"
+
+#: panels/sharing/cc-sharing-panel.ui:294
+#, fuzzy
+#| msgid "Not connected"
+msgid "How to Connect"
+msgstr "Chan eil ceangal ann"
+
+#: panels/sharing/cc-sharing-panel.ui:295
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:323
+#, fuzzy
+#| msgid "Delete Address"
+msgid "Remote Desktop Address"
+msgstr "Sguab às an seòladh"
+
+#: panels/sharing/cc-sharing-panel.ui:350
+#, fuzzy
+#| msgid "Au_thentication"
+msgid "Authentication"
+msgstr "D_earbhadh"
+
+#: panels/sharing/cc-sharing-panel.ui:351
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:355
+#, fuzzy
+#| msgid "Username"
+msgid "User Name"
+msgstr "Ainm-cleachdaiche"
+
+#: panels/sharing/cc-sharing-panel.ui:401
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:430
+#, fuzzy
+#| msgid "Enrolling fingerprints"
+msgid "Encryption Fingerprint"
+msgstr "A’ clàradh nam meur-lorgan"
+
+#: panels/sharing/cc-sharing-panel.ui:431
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:463
+msgid "Media Sharing"
+msgstr "Co-roinneadh mheadhanan"
+
+#: panels/sharing/cc-sharing-panel.ui:485
+msgid "Share music, photos and videos over the network."
+msgstr "Co-roinn ceòl, dealbhan is videothan air an lìonra."
+
+#: panels/sharing/cc-sharing-panel.ui:498
+msgid "Folders"
+msgstr "Pasgain"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Stiùirich na cho-roinneas tu le daoine eile"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;co-roinn;co-roinneadh;òstair;cèin;meadhan;fuaim;"
+"dealbhan;deilbh;filmichean;frithealaiche;reandaraiche;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Cuir an comas no à comas clàradh a-steach cèin"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Tha feum air dearbhadh mus gabh clàradh cèin a chur an comas no à comas"
+
+#: panels/sound/cc-alert-chooser.c:150
+msgid "Custom"
+msgstr "Gnàthaichte"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr "Comhartaich"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "Drip"
+msgstr "Friog-frag"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Glass"
+msgstr "Glainne"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Sonar"
+msgstr "Sònar"
+
+#: panels/sound/cc-fade-slider.ui:13
+#, fuzzy
+#| msgctxt "balance"
+#| msgid "Rear"
+msgid "Rear"
+msgstr "Deireadh"
+
+#: panels/sound/cc-fade-slider.ui:15
+#, fuzzy
+#| msgctxt "balance"
+#| msgid "Front"
+msgid "Front"
+msgstr "Beulaibh"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, fuzzy, c-format
+#| msgid "Settings"
+msgid "Testing %s"
+msgstr "Roghainnean"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+#| msgid "System Sounds"
+msgid "System Volume"
+msgstr "Fuaimean an t-siostaim"
+
+#: panels/sound/cc-sound-panel.ui:25
+#, fuzzy
+#| msgid "Volume mute"
+msgid "Volume Levels"
+msgstr "Mùch an fhuaim"
+
+#: panels/sound/cc-sound-panel.ui:35
+msgid "Output"
+msgstr "Às-chur"
+
+#: panels/sound/cc-sound-panel.ui:56
+#, fuzzy
+#| msgid "_Output volume:"
+msgid "Output Device"
+msgstr "Àirde fuaim a_n às-chuir:"
+
+#: panels/sound/cc-sound-panel.ui:75
+msgid "Test"
+msgstr "Cuir fo dheuchainn"
+
+#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#, fuzzy
+#| msgid "_Configuration URL"
+msgid "Configuration"
+msgstr "An URL _rèiteachaidh"
+
+#: panels/sound/cc-sound-panel.ui:135
+#, fuzzy
+#| msgid "_Balance:"
+msgid "Balance"
+msgstr "Cothro_m:"
+
+#: panels/sound/cc-sound-panel.ui:161
+#, fuzzy
+#| msgid "_Fade:"
+msgid "Fade"
+msgstr "_Crìonadh:"
+
+#: panels/sound/cc-sound-panel.ui:187
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:205
+msgid "Input"
+msgstr "Ion-chur"
+
+#: panels/sound/cc-sound-panel.ui:226
+#, fuzzy
+#| msgid "Input level:"
+msgid "Input Device"
+msgstr "Ìre an ion-chuir:"
+
+#: panels/sound/cc-sound-panel.ui:294
+#, fuzzy
+#| msgid "Volume up"
+msgid "Volume"
+msgstr "Cuir an fhuaim an àirde"
+
+#: panels/sound/cc-sound-panel.ui:312
+#, fuzzy
+#| msgid "_Alert volume:"
+msgid "Alert Sound"
+msgstr "Àirde _fuaim nan rabhadh:"
+
+#: panels/sound/cc-volume-slider.c:117
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Fuaim"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Atharraich ìre na fuaime, fuaimean ion-chuir, às-chuir is chaismeachdan"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+#| msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Cairt;Micreofon;Àirde na fuaime;Crìonadh;Cothrom;Bluetooth;Headset;Fuaim;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+#, fuzzy
+#| msgid "Disconnecting"
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "A’ briseadh a’ cheangail"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+#, fuzzy
+#| msgid "Connecting"
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "A’ ceangal"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+#, fuzzy
+#| msgid "Connected"
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Ceangailte"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+#, fuzzy
+#| msgid "Authentication required"
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Tha feum air dearbhadh"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+#, fuzzy
+#| msgid "Connected Devices"
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Uidheaman a tha ceangailte ris"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+#, fuzzy
+#| msgid "Unknown"
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Chan eil fhios"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr ""
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+#, fuzzy
+#| msgid "Connected"
+msgid "Connected at:"
+msgstr "Ceangailte"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+#, fuzzy
+#| msgid "_Enroll"
+msgid "Enrolled at:"
+msgstr "_Clàraich"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+#, fuzzy
+#| msgid "Failed to upload file: %s"
+msgid "Failed to authorize device: "
+msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+#, fuzzy
+#| msgid "Failed to upload file: %s"
+msgid "Failed to forget device: "
+msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#, fuzzy
+#| msgid "_Name:"
+msgid "Name:"
+msgstr "_Ainm:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#, fuzzy
+#| msgid "Automatic _Connect"
+msgid "Authorize and Connect"
+msgstr "_Ceangail gu fèin-obrachail"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#, fuzzy
+#| msgid "Remove Device"
+msgid "Forget Device"
+msgstr "Thoirt an t-uidheam air falbh"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+#, fuzzy
+#| msgid "Mirror"
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Sgàthanaich"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+#, fuzzy
+#| msgid "Authenticated"
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Air a dhearbhadh"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:157
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+#, fuzzy
+#| msgid "The profile could not be generated."
+msgid "Thunderbolt security level could not be determined."
+msgstr "Cha b’ urrainn dhuinn a’ phròifil a ghintinn."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:104
+#, fuzzy
+#| msgid "Couldn’t connect to the %s domain: %s"
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Cha b’ urrainn ceangal ris an àrainn %s: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:153
+#, fuzzy
+#| msgid "Universal Access"
+msgid "Direct Access"
+msgstr "Inntrigeadh uile-choitcheann"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:225
+#, fuzzy
+#| msgid "Add Device"
+msgid "Pending Devices"
+msgstr "Cuir uidheam ris"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:319
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Priobadh a’ chùrsair"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+msgid "Cursor blinks in text fields."
+msgstr "Bidh an cùrsair a’ priobadh ann an raointean teacsa."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
+#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+msgid "Speed"
+msgstr "Luaths"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+msgid "Cursor blinking speed"
+msgstr "Luaths priobadh a’ chùrsair"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Meud a’ chùrsair"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"’S urrainn dhut meud a’ chùrsair agus an sùm a chleachdadh còmhla ach am bi "
+"e nas fhasa an cùrsair fhaicinn."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Taic le briogadh"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Dàrnacha briogadh ma_s-fhìor"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Dùisg dàrnacha briogadh le bhith a’ cumail sìos am prìomh-phutan"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Dàil g_abhail ris:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Goirid"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "An dàil air an dàrnacha briogadh"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Fada"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Briogadh _fantainn"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Dùisg briogadh nuair a dh’fhanas an tomhaire os cionn rud"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Dàil:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Goirid"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Fada"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Starsnaich gluasaid:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Beag"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Mòr"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Putain ath-dhèanaimh"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+msgid "Key presses repeat when key is held down."
+msgstr "Thèid brùthadh na h-iuchrach ath-dhèanamh ma chumar shìos an iuchair."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+msgid "Repeat keys delay"
+msgstr "Dàil nam putan ath-dhèanaimh"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+msgid "Repeat keys speed"
+msgstr "Astar nam putan ath-dhèanaimh"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "An cuidiche sgrìobhaidh"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Iuchraichean _steigeach"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Làimhsichidh seo sreath de dh’iuchraichean atharrachaidh mar cho-iuchraichean"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Cuir à comas ma thèid dà iuchair a bhrùthadh còmhla"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "_Bìd nuair a bhios iuchair atharrachaidh ’ga bhrùthadh"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Putanan s_laodach"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Cuiridh seo dàil eadar brùthadh iuchrach is cuin a ghabhas an siostam ris"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Goirid"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Dàil clò-sgrìobhadh nam putan slaodach"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Fada"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Dèan bìd nuair a thèid iuchair a _bhrùthadh"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Dèan bìd _nuair a ghabhar ri iuchair"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Dèan bìd nuair a thèid iuchair a _dhiùltadh"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Putanan bocaidh"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Leigidh seo seachad iuchraichean a thèid ath-bhrùthadh gu luath"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Goirid"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Dàil clò-sgrìobhadh air na putanan bocaidh"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Fada"
+
+#: panels/universal-access/cc-typing-dialog.ui:326
+msgid "_Enable by Keyboard"
+msgstr "Cuir an comas l_eis a’ mheur-chlàr"
+
+#: panels/universal-access/cc-typing-dialog.ui:336
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Cuiridh seo gleusan na so-ruigsinneach air no dheth leis a’ mheur-chlàr"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Bun-roghainn"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Meadhanach"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Mòr"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Nas motha"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "As motha"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d phiogsail"
+msgstr[1] "%d phiogsail"
+msgstr[2] "%d piogsailean"
+msgstr[3] "%d piogsail"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+#| msgid "_Always Show Universal Access Menu"
+msgid "_Always Show Accessibility Menu"
+msgstr "Se_all clàr-taice an inntrigidh uile-choitchinn an-còmhnaidh"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "A’ faicinn"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Iomsgarad_h àrd"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Teacsa mòr"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Leughadai_r-sgrìn"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Cuiridh leughadair na sgrìn fòcas air an teacsa ’s tu a’ gluasad troimhe."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Iuchraichean fuaime"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Dèan bìd nuair a thèid NumLock no CapsLock a chur air no dheth."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Me_ud a’ chùrsair"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "Sù_m"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Claisneachd"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Rabhaidhean lèirsinneach"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Meur-_chlàr air sgrìn"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Putain ath-dhèanaimh"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Prio_badh a’ chùrsair"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Cuidiche sgrìobhaidh (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+#| msgid "Pointing & Clicking"
+msgid "Pointing &amp; Clicking"
+msgstr "Tomhadh ⁊ briogadh"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "I_uchraichean an luch-chlàir"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+#| msgid "Remove Printer"
+msgid "_Locate Pointer"
+msgstr "Thoir air falbh an clò-bhualadair"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Taic le _briogadh"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Dàil air a’ bhriogadh dùbailte"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Dàil air a’ bhriogadh dùbailte"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Rabhaidhean lèirsinneach"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Boillsgeadh deuchainne"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Nochd sanas lèirsinneach nuair a thèid fuaim rabhaidh a chluich."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Boillsg an _sgrìn gu lèir"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+#| msgid "Flash the entire _screen"
+msgid "Flash the entire _window"
+msgstr "Boillsg an _sgrìn gu lèir"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Goirid"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ dhen sgrìn"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ dhen sgrìn"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ dhen sgrìn"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Fada"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Làn-sgrìn"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "An leth gu h-àrd"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "An leth gu h-ìosal"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "An leth chlì"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "An leth dheas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Roghainnean an t-sùm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Meudachadh:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Ionad a’ mheudaicheir:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Lean ri cùrsair na luchaige"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "A’ phàirt dhen _sgrìn:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Thèid am m_eudaichear a-mach air an sgrìn"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Cum cùrsair a’ mheudaicheir sa mheadhan"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "_Gluaisidh cùrsair a’ mheudaicheir susbaint mun cuairt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Gluaisidh cùrsair a’ mheudaicheir mun _cuairt leis an t-susbaint"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Am meudaichear"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Crois-ribeachan:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "A’ dol a-steach air cùrsair na _luchaige"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Tiughad:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tana"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Tiugh"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Faid:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Dath:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Crois-ribeachan"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Èifeachdan dhathan:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Geal air dubh:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Soilleireachd:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Iomsgaradh:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Dath"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Chan eil gin"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Làn"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Ìseal"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Àrd"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Ìseal"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Àrd"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Èifeachdan dhathan"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"Dèan nas fhasa e rudan fhaicinn, a chluinntinn, a sgrìobhadh, a thomhadh ’s "
+"a bhriogadh"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;"
+#| "size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;"
+#| "Repeat;Blink;"
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"meur-chlàr;a11y;so-ruigsinneachd;iomsgaradh;sùm;leughadair-sgrìn;teacsa;"
+"cruth-clò;AccessX;steigeach;slaodach;diùltaidh;luchag;dùbailte;briog;"
+"briogadh;dàil;taic;priobadh;boillsgeadh;Keyboard;Mouse;a11y;Accessibility;"
+"Contrast;Zoom;Screen;Reader;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;"
+"Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+#, fuzzy
+#| msgid "1 hour"
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 uair a thìde"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+#, fuzzy
+#| msgid "1 day"
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 latha"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+#, fuzzy
+#| msgid "2 days"
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 latha"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+#, fuzzy
+#| msgid "3 days"
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 làithean"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+#, fuzzy
+#| msgid "4 days"
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 làithean"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+#, fuzzy
+#| msgid "5 days"
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 làithean"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+#, fuzzy
+#| msgid "6 days"
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 làithean"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+#, fuzzy
+#| msgid "7 days"
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 làithean"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+#, fuzzy
+#| msgid "14 days"
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "Cola-deug"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+#, fuzzy
+#| msgid "30 days"
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 latha"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "A bheil thu airson an sgudal fhalamhachadh gu tur?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Thèid gach rud san sgudal a sguabadh às gu buan."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Falamhaich an sgudal"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "A bheil thu airson na faidhlichean sealach a sguabadh às?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Thèid gach faidhle sealach a sguabadh às gu buan."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Purgaidich na faidhlichean sealach"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+#, fuzzy
+#| msgid "1 day"
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 latha"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+#, fuzzy
+#| msgid "7 days"
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 làithean"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+#, fuzzy
+#| msgid "30 days"
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 latha"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+#, fuzzy
+#| msgid "Forever"
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Gu buan"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+#| msgid "History"
+msgid "File History"
+msgstr "An eachdraidh"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+#| msgid "History"
+msgid "File H_istory"
+msgstr "An eachdraidh"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+#| msgid "Cl_ear Recent History"
+msgid "_Clear History…"
+msgstr "Falamhaich an _eachdraidh faisg ort"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+#| msgid "Purge Trash & Temporary Files"
+msgid "Trash &amp; Temporary Files"
+msgstr "Purgaidich an sgudal ⁊ na faidhlichean sealach"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+#| msgid "Automatically empty _Trash"
+msgid "Automatically Delete _Trash Content"
+msgstr "Fa_lamhaich an sgudal gu fèin-obrachail"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+#| msgid "Automatically purge Temporary _Files"
+msgid "Automatically Delete Temporary _Files"
+msgstr "P_urgaidich faidhlichean sealach gu fèin-obrachail"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+#| msgid "Automatically empty _Trash"
+msgid "Automatically Delete _Period"
+msgstr "Fa_lamhaich an sgudal gu fèin-obrachail"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Falamhaich an sgudal…"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+#| msgid "_Purge Temporary Files…"
+msgid "_Delete Temporary Files…"
+msgstr "_Purgaidich na faidhlichean sealach…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr ""
+"Bu chòir dha a bhith co-ionnann ri seòladh-lìn solaraiche a’ chlàraidh a-"
+"steach agad."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Cha b’ urrainn dhuinn an cunntas a chur ris"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.c:258
+msgid "The passwords do not match."
+msgstr "Chan eil an dà fhacal-faire co-ionnann."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Cha b’ urrainn dhuinn an cunntas a chlàradh"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+"Chan eil dòigh sam bith ann ris a bheil taic agus leis an urrainnear "
+"dearbhadh a dhèanamh air an àrainn seo"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Cha b’ urrainn dhuinn ceangal ris an àrainn"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Cha do dh’obraich an t-ainm sin.\n"
+"Feuch ris a-rithist."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Cha do dh’obraich am facal-faire sin.\n"
+"Feuch ris a-rithist."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Cha b’ urrainn dhuinn clàradh a-steach aig an àrainn"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr ""
+"Chan fhaigh sinn greim air an àrainn. Saoil a bheil e air a dheagh-"
+"litreachadh?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Cuir ris Cleachdaiche"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Rianaire"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+#| msgid "Allow user to change their password on next login"
+msgid "User sets password on first login"
+msgstr ""
+"Leig leis a’ chleachdaiche am facal-faire atharrachadh nuair a chlàraicheas "
+"iad a-steach an ath-thuras"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+#| msgid "Set a password now"
+msgid "Set password now"
+msgstr "Suidhich facal-faire an-dràsta"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+#| msgid "_Confirm"
+msgid "Confirm"
+msgstr "_Dearbhaich"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+#| msgid "_Enterprise Login"
+msgid "Enterprise Login"
+msgstr "Clàradh a-steach _Enterprise"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organisation."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:385
+msgid "You are Offline"
+msgstr "Tha thu far loidhne"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:386
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Le clàradh a-steach enterprise, gabhaidh cunntas-cleachdaiche fo stiùireadh "
+"meadhanaichte a chleachdadh air an uidheam seo. ’S urrainn dhut an cunntas "
+"seo a chleachdadh cuideachd gus goireasan na companaidh inntrigeadh air an "
+"eadar-lìn."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Brabhsaich airson barrachd dhealbhan"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Tagh faidhle…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+#| msgid "_Fingerprint Login"
+msgid "Fingerprint Manager"
+msgstr "Clàradh a-steach le _meur-lorg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+#| msgid "_Fingerprint Login"
+msgid "Fingerprint"
+msgstr "Clàradh a-steach le _meur-lorg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#, fuzzy
+#| msgid "No"
+msgid "_No"
+msgstr "Chan eil"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"A bheil thu airson na meur-lorgan clàraichte a sguabadh às airson ’s nach "
+"urrainnear clàradh a-steach leotha tuilleadh?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#, fuzzy
+#| msgid "Gaming input device"
+msgid "No fingerprint device"
+msgstr "Uidheam ion-chuir geama"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#, fuzzy
+#| msgid "_Fingerprint Login"
+msgid "No Fingerprint device"
+msgstr "Clàradh a-steach le _meur-lorg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#, fuzzy
+#| msgid "_Fingerprint Login"
+msgid "Fingerprint Device"
+msgstr "Clàradh a-steach le _meur-lorg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#, fuzzy
+#| msgid "_Fingerprint Login"
+msgid "Fingerprint Login"
+msgstr "Clàradh a-steach le _meur-lorg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+msgid "_Delete Fingerprints"
+msgstr "_Sguab às na meur-lorgan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#, fuzzy
+#| msgid "_Fingerprint Login"
+msgid "Fingerprint Enroll"
+msgstr "Clàradh a-steach le _meur-lorg"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+#, fuzzy
+#| msgid "The device is already in use."
+msgid "the device is already claimed by another process"
+msgstr "Tha an t-uidheam seo ’ga chleachdadh mu thràth."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+#, fuzzy
+#| msgid "Failed to register with the requested network"
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Cha b’ urrainn dhuinn clàradh aig an lìonra a dh’iarr thu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+#, fuzzy
+#| msgid "Could not access any fingerprint readers"
+msgid "Failed to communicate with the fingerprint reader"
+msgstr ""
+"Cha b’ urrainn dhuinn cothrom fhaighinn air leughadair mheur-lorgan sam bith"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, fuzzy, c-format
+#| msgid "Failed to upload file: %s"
+msgid "Failed to list fingerprints: %s"
+msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, fuzzy, c-format
+#| msgid "Failed to delete user"
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Cha b’ urrainn dhuinn an cleachdaiche a sguabadh às"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "An òrdag chlì"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "An gunna fada clì"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "An sgealbag _chlì"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Mac an aba clì"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "An lùdag bheag chlì"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "An òrdag dheas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "An gunna fada deas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "An sgealbag _dheas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Mac an aba deas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "An lùdag bheag dheas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+#, fuzzy
+#| msgid "Unknown time"
+msgid "Unknown Finger"
+msgstr "Chan eil fhios dè cho fad"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+#, fuzzy
+#| msgid "Complete!"
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Deiseil!"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+#, fuzzy
+#| msgid "PPP service disconnected"
+msgid "Fingerprint device disconnected"
+msgstr "Chaidh an ceangal ris an t-seirbheis PPP a bhriseadh"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+#, fuzzy
+#| msgid "Failed to add new printer."
+msgid "Failed to enroll new fingerprint"
+msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, fuzzy, c-format
+#| msgid "Failed to upload file: %s"
+msgid "Failed to start enrollment: %s"
+msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+#, fuzzy
+#| msgid "Failed to add new printer."
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, fuzzy, c-format
+#| msgid "Failed to upload file: %s"
+msgid "Failed to stop enrollment: %s"
+msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr ""
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+#, fuzzy
+#| msgid "Enrolling fingerprints"
+msgid "Scan new fingerprint"
+msgstr "A’ clàradh nam meur-lorgan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+#, fuzzy
+#| msgid "Problem Reporting"
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Ag aithris air duilgheadasan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, fuzzy, c-format
+#| msgid "Failed to upload file: %s"
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Cha b’ urrainn dhuinn am faidhle a leanas a luchdadh suas: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, fuzzy, c-format
+#| msgid "Failed to add new printer."
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Cha b’ urrainn dhuinn an clò-bhualadair ùr a chur ris."
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "An t-seachdain-sa"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "An t-seachdain seo chaidh"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:712
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k.%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:716
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Thàinig an seisean gu crìoch"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Thòisich an seisean"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s – Gnìomhachd a’ chunntais"
+
+#: panels/user-accounts/cc-password-dialog.c:133
+msgid "Please choose another password."
+msgstr "Tagh facal-faire eile."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Please type your current password again."
+msgstr "Nach cuir thu am facal-faire làithreach agad a-rithist?"
+
+#: panels/user-accounts/cc-password-dialog.c:148
+msgid "Password could not be changed"
+msgstr "Cha b’ urrainn dhuinn am facal-faire atharrachadh"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Atharraich am facal-faire"
+
+#: panels/user-accounts/cc-password-dialog.ui:32
+msgid "Ch_ange"
+msgstr "_Atharraich"
+
+#: panels/user-accounts/cc-password-dialog.ui:51
+#, fuzzy
+#| msgid "Current _Password"
+msgid "Current Password"
+msgstr "Am _facal-faire làithreach"
+
+#: panels/user-accounts/cc-password-dialog.ui:76
+#, fuzzy
+#| msgid "_New Password"
+msgid "New Password"
+msgstr "Facal-faire ù_r"
+
+#: panels/user-accounts/cc-password-dialog.ui:121
+#, fuzzy
+#| msgid "Change Password"
+msgid "Confirm Password"
+msgstr "Atharraich am facal-faire"
+
+#: panels/user-accounts/cc-password-dialog.ui:175
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Leig leis a’ chleachdaiche am facal-faire atharrachadh nuair a chlàraicheas "
+"iad a-steach an ath-thuras"
+
+#: panels/user-accounts/cc-password-dialog.ui:186
+msgid "Set a password now"
+msgstr "Suidhich facal-faire an-dràsta"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr ""
+"Chan urrainnear pàirt a ghabhail sa leithid seo de dh’àrainn gu fèin-"
+"obrachail"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Cha deach àrainn no rìoghachd mar sin a lorg"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Chan urrainn dhut clàradh a-steach mar %s air an àrainn %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Tha am facal-faire cearr, nach fheuch thu ris a-rithist?"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Cha b’ urrainn ceangal ris an àrainn %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:341
+msgid "Failed to delete user"
+msgstr "Cha b’ urrainn dhuinn an cleachdaiche a sguabadh às"
+
+#: panels/user-accounts/cc-user-panel.c:398
+#: panels/user-accounts/cc-user-panel.c:453
+#: panels/user-accounts/cc-user-panel.c:499
+msgid "Failed to revoke remotely managed user"
+msgstr "Cha deach leinn an cleachdaiche fo stiùireadh cèin a chùl-ghairm"
+
+#: panels/user-accounts/cc-user-panel.c:548
+msgid "You cannot delete your own account."
+msgstr "Chan urrainn dhut an cunntas agad fhèin a sguabadh às."
+
+#: panels/user-accounts/cc-user-panel.c:557
+#, c-format
+msgid "%s is still logged in"
+msgstr "Tha %s clàraichte a-staigh fhathast"
+
+#: panels/user-accounts/cc-user-panel.c:561
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Ma sguabas tu às cleachdaiche fhad ’s a tha iad clàraichte a-staigh "
+"fhathast, dh’fhaoidte gum fàg sin an siostam neo-sheasmhach."
+
+#: panels/user-accounts/cc-user-panel.c:570
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "A bheil thu airson na faidhlichean aig %s a chumail?"
+
+#: panels/user-accounts/cc-user-panel.c:574
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Gabhaidh am pasgan dachaidh, spàl a’ phuist agus na faidhlichean sealach a "
+"ghlèidheadh nuair a sguabar às cunntas cleachdaiche."
+
+#: panels/user-accounts/cc-user-panel.c:577
+msgid "_Delete Files"
+msgstr "_Sguab às na faidhlichean"
+
+#: panels/user-accounts/cc-user-panel.c:578
+msgid "_Keep Files"
+msgstr "_Cum na faidhlichean"
+
+#: panels/user-accounts/cc-user-panel.c:592
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"A bheil thu cinnteach gu bheil thu airson an cunntas aig %s fo stiùireadh "
+"cèin a chùl-ghairm?"
+
+#: panels/user-accounts/cc-user-panel.c:596
+msgid "_Delete"
+msgstr "_Sguab às"
+
+#: panels/user-accounts/cc-user-panel.c:646
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Chaidh an cunntas a chur à comas"
+
+#: panels/user-accounts/cc-user-panel.c:654
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Ri shuidheachadh an ath-thuras a nithear clàradh a-steach"
+
+#: panels/user-accounts/cc-user-panel.c:657
+msgctxt "Password mode"
+msgid "None"
+msgstr "Chan eil gin"
+
+#: panels/user-accounts/cc-user-panel.c:700
+msgid "Logged in"
+msgstr "Air clàradh a-steach"
+
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:787
+#: panels/user-accounts/cc-user-panel.c:876
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "An comas"
+
+#: panels/user-accounts/cc-user-panel.c:1173
+msgid "Failed to contact the accounts service"
+msgstr "Cha b’ urrainn dhuinn fios a chur gu seirbheis nan cunntasan"
+
+#: panels/user-accounts/cc-user-panel.c:1175
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Dèan cinnteach gun deach AccountService a stàladh agus an comas."
+
+#: panels/user-accounts/cc-user-panel.c:1197
+msgid "This panel must be unlocked to change this setting"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1264
+msgid "Delete the selected user account"
+msgstr "Sguab às cunntas a’ chleachdaiche a thagh thu"
+
+#: panels/user-accounts/cc-user-panel.c:1268
+#: panels/user-accounts/cc-user-panel.c:1377
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Gus cunntas a’ chleachdaiche a thagh thu a sguabadh às,\n"
+"briog air an ìomhaigheag * an toiseach"
+
+#: panels/user-accounts/cc-user-panel.c:1423
+msgid "Unlock to Add Users and Change Settings"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Cleachdaichean"
+
+#: panels/user-accounts/cc-user-panel.ui:60
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+"Feumaidh tu an seisean ath-thòiseachadh gus bi buaidh aig na dh’atharraich "
+"thu"
+
+#: panels/user-accounts/cc-user-panel.ui:67
+msgid "Restart Now"
+msgstr "Ath-thòisich an-dràsta"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:195
+msgid "_Fingerprint Login"
+msgstr "Clàradh a-steach le _meur-lorg"
+
+#: panels/user-accounts/cc-user-panel.ui:218
+msgid "A_utomatic Login"
+msgstr "Clàradh a-steach fèin-_obrachail"
+
+#: panels/user-accounts/cc-user-panel.ui:231
+#, fuzzy
+#| msgid "%s — Account Activity"
+msgid "Account Activity"
+msgstr "%s – Gnìomhachd a’ chunntais"
+
+#: panels/user-accounts/cc-user-panel.ui:259
+#, fuzzy
+#| msgid "Administrator"
+msgid "_Administrator"
+msgstr "Rianaire"
+
+#: panels/user-accounts/cc-user-panel.ui:260
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:276
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:277
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:328
+msgid "Remove User…"
+msgstr "Thoir air falbh an cleachdaiche…"
+
+#: panels/user-accounts/cc-user-panel.ui:340
+#, fuzzy
+#| msgid "_Other finger:"
+msgid "Other Users"
+msgstr "Corrag _eile:"
+
+#: panels/user-accounts/cc-user-panel.ui:353
+#, fuzzy
+#| msgid "_Add User…"
+msgid "Add User…"
+msgstr "Cuir cle_achdaiche ris…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:381
+msgid "No Users Found"
+msgstr "Cha deach cleachdaiche a lorg"
+
+#: panels/user-accounts/cc-user-panel.ui:390
+msgid "Unlock to add a user account."
+msgstr "Thoir a’ ghlas dheth gus cunntas cleachdaiche a chur ris."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+"Cuir cleachdaichean ris no thoir air falbh feadhainn is atharraich am facal-"
+"faire agad"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Clàraich"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Clàradh a-steach rianaire na h-àrainne"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Feumaidh an coimpiutair agad a bhith clàraichte aig an àrainn\n"
+"mus urrainn dhut clàradh a-steach Enterprise a dhèanamh. Iarr air\n"
+"rianaire an lìonraidh facal-faire na h-àrainne a chur a-steach an-seo."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Ainm an rianaire"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Facal-faire an rianaire"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Stiùirich cunntasan nan cleachdaichean"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+"Feumaidh tu dearbhadh a dhèanamh mus urrainn dhut dàta a’ chleachdaiche "
+"atharrachadh"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Chan fhaod an seann fhacal-faire ’s am fear ùr a bhith co-ionnann."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Feuch is atharraich cuid dhe na litrichean is àireamhan."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Feuch is atharraich am facal-faire beagan a bharrachd"
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Bhiodh facal-faire as aonais an ainm-chleachdaiche agad nas làidire."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Feuch is na cleachd d’ ainm san fhacal-fhaire."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Feuch is seachain cuid dhe na faclan a tha san fhacal-fhaire."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Feuch is seachain faclan cumanta."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Feuch is seachain fìor-fhaclan ath-òrdachadh."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Feuch is cleachd barrachd àireamhan."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Feuch is cleachd barrachd litrichean mòra."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Feuch is cleachd barrachd litrichean beaga."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Feuch is cleachd barrachd charactaran sònraichte mar phuingeachadh."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Feuch is cleachd measgachadh de litrichean, àireamhan is puingeachadh."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Feuch is seachain an aon charactar a-rithist ’s a-rithist."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Feuch is seachain an aon seòrsa de charactar a-rithist ’s a-rithist: "
+"feumaidh tu measgachadh de litrichean, àireamhan is puingeachadh."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Feuch is seachain sreathan mar 1234 no abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Feumaidh faclan-faire a bhith nas fhaide. Feuch is cuir ris barrachd "
+"litrichean, àireamhan is puingeachadh."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Cleachd litrichean mòra ’s beaga agus feuch an cleachd thu àireamh no dhà."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Bidh e nas treasa ma chuireas tu barrachd litrichean, àireamhan is "
+"puingeachadh ris."
+
+#: panels/user-accounts/run-passwd.c:413
+msgid "Authentication failed"
+msgstr "Dh’fhàillig an dearbhadh"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The new password is too short"
+msgstr "Tha am facal-faire ùr ro ghoirid"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password is too simple"
+msgstr "Tha am facal-faire ùr ro shimplidh"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Tha an seann fhacal-faire agus am fear ùr ro choltach ri chèile"
+
+#: panels/user-accounts/run-passwd.c:507
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Chaidh am facal-faire ùr a chleachdadh o chionn ghoirid mu thràth."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+"Feumaidh àireamhan no caractaran sònraichte a bhith san fhacal-fhaire ùr"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Tha an seann fhacal-faire ’s am fear ùra co-ionnann"
+
+#: panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+"Chaidh am facal-faire agad atharrachadh on a rinn thu dearbhadh an toiseach!"
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Chan eil caractaran eadar-dhealaichte gu leòr san fhacal-fhaire ùr"
+
+#: panels/user-accounts/run-passwd.c:526
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Mearachd neo-aithnichte"
+
+#: panels/user-accounts/user-utils.c:144
+#, fuzzy
+#| msgid ""
+#| "The username should only consist of upper and lower case letters from a-"
+#| "z, digits and the following characters: . - _"
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Cha bu chòir a bhith am broinn ainm-cleachdaiche ach litrichean mòra ’s "
+"beaga o a-z, àireamhan agus gin dhe na caractaran seo: . - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Tha sinn duilich ach chan eil an t-ainm-cleachdaiche seo ri fhaighinn. Feuch "
+"fear eile."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Tha an t-ainm-cleachdaiche ro fhada."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+msgid "Map Buttons"
+msgstr "Mapaich putanan"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Mapaich putanan ri gnìomhan"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Gus ath-ghoirid a dheasachadh, tagh an gnìomh “Cuir buille-iuchrach”, brùth "
+"putan ath-ghoirid meur-chlàir is cum sìos na h-iuchraichean ùra no brùth "
+"Backspace gus fhalamhachadh."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Dùin"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Thoir gnogag air na comharran targaide mar a nochdas iad air an sgrìn gus an "
+"tablaid a chailbhreachadh."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Mhothaich sinn do bhriogadh claon, ag ath-thòiseachadh…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Putan %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "A-rèir na h-aplacaid"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Cuir buille-iuchrach"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Gearr leum gu monatair eile"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Seall a’ chobhair air an sgrìn"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:435
+#, fuzzy
+#| msgid "No tablet detected"
+msgid "External tablet device"
+msgstr "Cha deach tablaid a lorg"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+#, fuzzy
+#| msgid "Displays"
+msgid "All Displays"
+msgstr "Uidheaman-taisbeanaidh"
+
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+#| msgid "Tablet"
+msgid "Tablet Mode"
+msgstr "Tablaid"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:27
+#, fuzzy
+#| msgid "Left-Handed Orientation"
+msgid "Left Hand Orientation"
+msgstr "An comhair na làimhe chlì"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:56
+#, fuzzy
+#| msgid "Map to Monitor…"
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapaich ri monatair…"
+
+#: panels/wacom/cc-wacom-page.ui:62
+#, fuzzy
+#| msgid "Aspect Ratio"
+msgid "Keep Aspect Ratio"
+msgstr "Co-mheas an deilbh"
+
+#: panels/wacom/cc-wacom-page.ui:63
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:73
+#, fuzzy
+#| msgid "Calibrate…"
+msgid "Calibrate"
+msgstr "Cailbhrich…"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Cha deach tablaid a lorg"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+#| msgid "Please plug in or turn on your Wacom tablet"
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Plug a-steach an tablaid Wacom agad no cuir air e"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Faireachdainn brùthadh a’ chinn"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+#| msgid "Button"
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Putan"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+#| msgid "Button"
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Putan"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+#| msgid "Button"
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Putan"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Faireachdainn brùthadh an t-suathain"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tablaid Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Suidhich mapadh nam putanan is cuir air gleus mothalachd an staidhleis "
+"airson tablaidean grafaigeachd"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablaid;Wacom;Staidhleas;Suathan:Luchag;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Ath-ghoirid ùr…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+#| msgid "Access Options"
+msgid "Access Points"
+msgstr "Roghainnean inntrigidh"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#, fuzzy
+#| msgid "VPN"
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+#, fuzzy
+#| msgid "Yesterday"
+msgid "Registered"
+msgstr "An-dè"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+#, fuzzy
+#| msgid "Search"
+msgid "Searching"
+msgstr "Lorg"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+#| msgid "Details"
+msgid "Modem Details"
+msgstr "Mion-fhiosrachadh"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+#| msgid "Network Name"
+msgid "Network Type"
+msgstr "Ainm an lìonraidh"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+#| msgid "Networks"
+msgid "Network Status"
+msgstr "Lìonraidhean"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+#| msgid "Numbers"
+msgid "Own Number"
+msgstr "Àireamhan"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+#| msgid "Printer Details"
+msgid "Device Details"
+msgstr "Fiosrachadh a’ chlò-bhualadair"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+#| msgid "Firmware missing"
+msgid "Firmware Version"
+msgstr "Tha bathar-an-sàs a dhìth"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1003
+msgid "2G, 3G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1005
+msgid "2G, 3G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G (Preferred), 3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "3G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1017
+msgid "3G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1019
+msgid "3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1025
+msgid "2G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1027
+msgid "2G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1029
+msgid "2G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "2G, 3G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "2G (Preferred), 3G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "2G, 3G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1043
+#, fuzzy
+#| msgid "Unknown"
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Chan eil fhios"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+#, fuzzy
+#| msgid "_Unlock"
+msgid "Unlock"
+msgstr "_Thoir a’ ghlas dheth"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:316
+#, fuzzy
+#| msgid "_Unlock"
+msgid "Unlocking…"
+msgstr "_Thoir a’ ghlas dheth"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+#| msgid "_Mobile broadband"
+msgid "_Mobile Data"
+msgstr "Bann-leathann _mobile"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+#| msgid "Network Name"
+msgid "_Network Mode"
+msgstr "Ainm an lìonraidh"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+#| msgid "Network"
+msgid "N_etwork"
+msgstr "Lìonra"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+#| msgctxt "Printer Option Group"
+#| msgid "Advanced"
+msgid "Advanced"
+msgstr "Adhartach"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+#| msgid "Access Options"
+msgid "_Access Point Names"
+msgstr "Roghainnean inntrigidh"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+#| msgid "Screen Lock"
+msgid "_SIM Lock"
+msgstr "Glas na sgrìn"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+#| msgid "%s Details"
+msgid "M_odem Details"
+msgstr "Fiosrachadh air %s"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+#, fuzzy
+#| msgid "PIN check failed"
+msgid "Phone failure"
+msgstr "Dh’fhàillig sgrùdadh a’ PIN"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+#, fuzzy
+#| msgid "Not connected"
+msgid "No connection to phone"
+msgstr "Chan eil ceangal ann"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+#, fuzzy
+#| msgid "SIM Card not inserted"
+msgid "SIM not inserted"
+msgstr "Cha deach cairt SIM a chur a-steach"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PIN required"
+msgstr "Tha feum air PIN an SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PUK required"
+msgstr "Tha feum air PIN an SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+#, fuzzy
+#| msgid "Current _Password"
+msgid "Incorrect password"
+msgstr "Am _facal-faire làithreach"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PIN2 required"
+msgstr "Tha feum air PIN an SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PUK2 required"
+msgstr "Tha feum air PIN an SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+#, fuzzy
+#| msgid "No stylus found"
+msgid "Not found"
+msgstr "Cha deach peann a lorg"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+#, fuzzy
+#| msgid "Networks"
+msgid "No network service"
+msgstr "Lìonraidhean"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+#, fuzzy
+#| msgid "Network Name"
+msgid "Network timeout"
+msgstr "Ainm an lìonraidh"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+#, fuzzy
+#| msgid "AutoIP service failed"
+msgid "GPRS services not allowed"
+msgstr "Dh’fhàillig an t-seirbheis AutoIP"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+#, fuzzy
+#| msgctxt "print job"
+#| msgid "Canceled"
+msgid "Action Cancelled"
+msgstr "Sguireadh dheth"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Access denied"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:103
+#, fuzzy
+#| msgid "Unknown error"
+msgid "Unknown Error"
+msgstr "Mearachd neo-aithnichte"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+#| msgid "Network Name"
+msgid "Network Mode"
+msgstr "Ainm an lìonraidh"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:146
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
+msgid "Close"
+msgstr "Dùin"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:69
+#, fuzzy
+#| msgid "Automatic"
+msgid "_Automatic"
+msgstr "Fèin-obrachail"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:84
+#, fuzzy
+#| msgid "My Home Network"
+msgid "Choose Network"
+msgstr "An lìonra-dhachaidh agam"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:99
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
+#, c-format
+msgid "SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+#| msgid "My Home Network"
+msgid "Enable Mobile Network"
+msgstr "An lìonra-dhachaidh agam"
+
+#: panels/wwan/cc-wwan-panel.ui:94
+#, fuzzy
+#| msgid "No Wi-Fi Adapter Found"
+msgid "No WWAN Adapter Found"
+msgstr "Cha deach adaptar WiFi a lorg"
+
+#: panels/wwan/cc-wwan-panel.ui:104
+#, fuzzy
+#| msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+"Dèan cinnteach gu bheil adaptar WiFi agad ceangailte agus air a chur air"
+
+#: panels/wwan/cc-wwan-panel.ui:145
+#, fuzzy
+#| msgid "Bluetooth is disabled when airplane mode is on."
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Tha Bluetooth à comas fhad ’s a tha am modh itealain air."
+
+#: panels/wwan/cc-wwan-panel.ui:153
+#, fuzzy
+#| msgid "Turn Off Airplane Mode"
+msgid "_Turn off Airplane Mode"
+msgstr "Cuir am modh itealain dheth"
+
+#: panels/wwan/cc-wwan-panel.ui:184
+#, fuzzy
+#| msgid "Forget Connection"
+msgid "Data Connection"
+msgstr "Dìochuimhnich an ceangal"
+
+#: panels/wwan/cc-wwan-panel.ui:185
+#, fuzzy
+#| msgid "SIM Card not inserted"
+msgid "SIM card used for internet"
+msgstr "Cha deach cairt SIM a chur a-steach"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+#| msgid "Screen Lock"
+msgid "SIM Lock"
+msgstr "Glas na sgrìn"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#, fuzzy
+#| msgid "Ch_ange"
+msgid "Change PIN"
+msgstr "_Atharraich"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "My Home Network"
+msgid "Mobile Network"
+msgstr "An lìonra-dhachaidh agam"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Configure Removable Media settings"
+msgid "Configure Telephony and mobile data connections"
+msgstr "Rèitich roghainnean nam meadhanan so-ghiùlain"
+
+#. FIXME
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+#, fuzzy
+#| msgid "Utilities to configure the GNOME desktop"
+msgid "Utility to configure the GNOME desktop"
+msgstr "Goireasan gus an deasg GNOME a rèiteachadh"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Seall àireamh an tionndaidh"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Cuir an comas am modh brathrach"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Lorg an t-sreang"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Seall ainmean a ghabhas a chleachdadh is dèan fàgail"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "A’ phanail a thèid a shealltainn"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Prìobhaideachd"
+
+#: shell/cc-panel-loader.c:301
+msgid "Available panels:"
+msgstr "Panailean a tha ri fhaighinn:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Na h-uile roghainn"
+
+#: shell/cc-window.ui:54
+#, fuzzy
+#| msgid "Primary"
+msgid "Primary Menu"
+msgstr "Prìomh-phanail"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Cobhair"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Coitcheann"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Fàg an-seo"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Lorg"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panailean"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+#| msgctxt "shortcut window"
+#| msgid "Go back to the overview"
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Till dhan fhoir-shealladh"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Sguir dhen lorg"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Roghainnean;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Aithnichear a’ phanail roghainnean mu dheireadh a thèid fhosgladh"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Aithnichear a’ phanail roghainnean mu dheireadh a thèid fhosgladh. Thèid "
+"luachan nach aithne dhuinn a leigeil seachad agus a’ chiad phanail air an "
+"liosta a thaghadh ’na àite."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u às-chur"
+msgstr[1] "%u às-chur"
+msgstr[2] "%u às-chuir"
+msgstr[3] "%u às-chur"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ion-chur"
+msgstr[1] "%u ion-chur"
+msgstr[2] "%u ion-chuir"
+msgstr[3] "%u ion-chur"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Fuaimean an t-siostaim"
+
+#~ msgid "_Background"
+#~ msgstr "Cùlai_bh"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Atharraichean tron latha"
+
+#~ msgid "_Lock Screen"
+#~ msgstr "G_lais an sgrìn"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Leacag"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Sùm"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Meadhanaich"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Sgèile"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Lìon"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Ruigheachd"
+
+#~ msgid "Colors"
+#~ msgstr "Dathan"
+
+#~ msgid "Select Background"
+#~ msgstr "Tagh an cùlaibh"
+
+#~ msgid "Pictures"
+#~ msgstr "Dealbhan"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Cha deach dealbh a lorg"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "’S urrainn dhut dealbhan a chur ris a’ phasgan %s agad agus nochdaidh iad "
+#~ "an-seo"
+
+#~| msgid "Bluetooth"
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Chaidh a’ phròifil a luchdadh suas gu:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Sgrìobh sìos an URL seo."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Ath-thòisich an coimpiutair seo is tòisich an siostam-obrachaidh "
+#~ "àbhaisteach agad."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Cuir an URL seo a-steach dhan bhrabhsair agad gus a’ phròifil a luchdadh "
+#~ "a-nuas is a stàladh."
+
+#~ msgid "Upload profile"
+#~ msgstr "Luchdaich suas pròifil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Feumaidh seo ceangal ris an eadar-lìon"
+
+#~| msgid "Preferences"
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "∶"
+#~ msgstr ":"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid ""
+#~ "Drag displays to match your setup. The top bar is placed on the primary "
+#~ "display."
+#~ msgstr ""
+#~ "Slaod na h-uidheaman-taisbeanaidh gus am bidh iad a-rèir an t-"
+#~ "suidheachaidh agad. Thèid am bàr-barra a chur air a’ phrìomh uidheam-"
+#~ "taisbeanaidh"
+
+#~ msgid "Display Mode"
+#~ msgstr "Modh an taisbeanaidh"
+
+#~ msgid "Join Displays"
+#~ msgstr "Cuir na h-uidheaman-taisbeanaidh còmhla"
+
+#~ msgid "_Night Light"
+#~ msgstr "Solas _oidhche"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Cha b’ urrainn dhuinn fiosrachadh na sgrìn fhaighinn"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "Version %s"
+#~ msgstr "Tionndadh %s"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "OS name"
+#~ msgstr "Ainm an t-siostam-obrachaidh"
+
+#~ msgid "OS type"
+#~ msgstr "Seòrsa an t-siostam-obrachaidh"
+
+#~ msgid "Disk"
+#~ msgstr "Diosga"
+
+#~ msgid "Check for updates"
+#~ msgstr "Thoir sùil airson ùrachaidhean"
+
+#~ msgid "Screenshots"
+#~ msgstr "Glacaidhean-sgrìn"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Cuir lethbhreac de ghlacadh-sgrìn dha $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Cuir lethbhreac de ghlacadh-sgrìn uinneige dha $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Cuir lethbhreac de ghlacadh-sgrìn raoin dha $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Cuir lethbhreac de ghlacadh-sgrìn air an stòr-bhòrd"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Cuir lethbhreac de ghlacadh-sgrìn uinneige air an stòr-bhòrd"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Cuir lethbhreac de raon air an stòr-bhòrd"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Clàraich craoladh-sgrìn goirid"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Gluaisidh na h-iuchraichean atharrachaidh dhan ath-thùs thu"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Crìoch-ùine a’ bhriogaidh dhùbailte"
+
+#~ msgid "Network proxy"
+#~ msgstr "Progsaidh lìonraidh"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "page 1"
+#~ msgstr "duilleag 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "De_arbhadh a-staigh"
+
+#~ msgid "page 2"
+#~ msgstr "duilleag 2"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "Cuingich cleachdadh dàta sa chùlaibh"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr ""
+#~ "Tha seo iomchaidh airson ceanglaichean le cosgais no cuingeachadh dàta "
+#~ "orra."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Ma chuireas tu air an hotspot uèirleas, thèid an ceangal ri <b>%s</b> a "
+#~ "bhriseadh."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Chan fhaigh thu cothrom air an eadar-lìon slighe a’ cheangal uèirleas "
+#~ "agad fhad ’s a bhios an hotspot gnìomhach."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Tha WiFi hotspots ’gan cleachdadh mar as trice gus ceangal a bharrachd "
+#~ "dhan eadar-lìn a cho-roinneadh slighe WiFi."
+
+#~ msgid "details"
+#~ msgstr "mion-fhiosrachadh"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Seall _am facal-faire"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Cuir ri làimh chleachdaichean eile"
+
+#~ msgid "identity"
+#~ msgstr "dearbh-aithne"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "Seòl_aidhean"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Seòlaidhean fèin-obrachail (DHCP) a-mhàin"
+
+#~ msgid "Link-local only"
+#~ msgstr "Link-Local a-mhàin"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "Le_ig seachad slighean a fhuaras gu fèin-obrachail"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Seòladh MAC _clònaichte"
+
+#~ msgid "hardware"
+#~ msgstr "bathar-cruaidh"
+
+#~ msgid "_Reset"
+#~ msgstr "_Ath-shuidhich"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Aisig bun-roghainnean a’ cheangail seo ach cuimhnich e mar cheangal as "
+#~ "fhearr leat."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Thoir air falbh fiosrachadh sam bith mun lìonra seo ’s na dèan ceangal "
+#~ "ris gu fèin-obrachail a-rithist"
+
+#~ msgid "Hardware"
+#~ msgstr "Bathar Cruaidh"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Ath-shuidhich"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Cuir dheth e gus ceangal a dhèanamh ri lìonra WiFi"
+
+#~| msgid "Password"
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Facal-faire"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Bun-structar"
+
+#~| msgid "Preferences;Settings;"
+#~ msgid "preferences-system-notifications"
+#~ msgstr "preferences-system-notifications"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Priob-bhrathan"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "A’ teairrdseadh"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Aire"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Ìseal"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Math"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Air a làn-teairrdseadh"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Falamh"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "_Soilleireachd na sgrìn"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "Soilleireachd a’ _mheur-chlàir"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "_Doilleirich an sgrìn mur eil gnìomhachd sam bith"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_WiFi"
+
+#~ msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+#~ msgstr ""
+#~ "Cuir am bann-leathann mobile (3G, 4G, LTE, is msaa.) dheth gus cumhachd a "
+#~ "chaomhnadh."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~| msgid "Turn off Wi-Fi to save power."
+#~ msgid "Turn off Bluetooth to save power."
+#~ msgstr "Cuir Bluetooth dheth gus cumhachd a chaomhnadh."
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Putan cur ’na dhàil ⁊ na cumhachd"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "Cuir ’n_a dhàil gu fèin-obrachail"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Nuair a bhios putan na cumhachd ’ga bhrùthadh"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Dearbhaich"
+
+#~| msgid "No printers"
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "Add…"
+#~ msgstr "Cuir ris…"
+
+#~ msgid "In use"
+#~ msgstr "’Ga chleachdadh"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Air"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Dheth"
+
+#~ msgid "Usage & History"
+#~ msgstr "Cleachdadh ⁊ an eachraidh"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Am poileasaidh prìobhaideachd"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Dìon am fiosrachadh pearsanta agad is stiùirich na chì càch"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Ma chumas tu an eachdraidh an cuimhne, bidh e nas fhasa greim fhaighinn "
+#~ "air rudan. Cha dèid na rudan seo a nochdadh ris an lìonra idir."
+
+#~ msgid "_Recently Used"
+#~ msgstr "Ai_r an cleachdadh o chionn goirid"
+
+#~ msgid "Retain _History"
+#~ msgstr "Glèidh an eachdraid_h"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Dìonaidh glas na sgrìn do phrìobhaideachd nuair a bhios tu air falbh."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Glais _an sgrìn an dèidh dha a bhith bàn fad"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Purgaidich an sgudal is na faidhlichean sealach gu fèin-obrachail gus an "
+#~ "coimpiutair agad a chumail saor o fhiosrachadh prìobhaideach air nach eil "
+#~ "feum."
+
+#~ msgid "Purge _After"
+#~ msgstr "Purgaidich an _dèidh"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Ma chuireas tu fiosrachadh thugainn mun bhathar-bhog a chleachdas tu, ’s "
+#~ "urrainn dhuinn molaidhean nas pongaile a thoirt dhut. Agus bidh cothrom "
+#~ "againn am bathar-bog againn a leasachadh.\n"
+#~ "\n"
+#~ "Bidh fiosrachadh sam bith a chruinnicheas sinn gun urra agus cha doir "
+#~ "sinn an dàta agad do threas-phàrtaidhean idir."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "Cuir _stats air cleachdadh a’ bhathair-bhog"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Leigidh seirbheisean ionaid leis na h-aplacaidean faighinn a-mach far a "
+#~ "bheil thu. Bidh seo nas pongaile le WiFi is bann-leathann mobile."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Cleachdaidh e Mozilla Location Service: <a href='https://location."
+#~ "services.mozilla.com/privacy'>Poileasaidh prìobhaideachd</a>"
+
+#~ msgid "_Location Services"
+#~ msgstr "Seirbheisean _ionaid"
+
+#~ msgid "No regions found"
+#~ msgstr "Cha deach roinn-dùthcha a lorg"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Gearr leum gun tùs roimhe"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Gearr leum gun ath-thùs"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Dòigh eile airson leumadh gun ath-thùs"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Beurla (An Rìoghachd Aonaichte)"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr ""
+#~ "Feumaidh tu an seisean ath-thòiseachadh mus bi buaidh aig na "
+#~ "dh’atharraich thu"
+
+#~ msgid "Restart…"
+#~ msgstr "Ath-thòisich…"
+
+#~ msgid "United Kingdom"
+#~ msgstr "An Rìoghachd Aonaichte"
+
+#~ msgid "_Options"
+#~ msgstr "_Roghainnean"
+
+#~ msgid "Add input source"
+#~ msgstr "Cuir tùs ion-chuir ris"
+
+#~ msgid "Remove input source"
+#~ msgstr "Thoir an tùs ion-chuir air falbh"
+
+#~ msgid "Move input source up"
+#~ msgstr "Gluais an tùs ion-chuir suas"
+
+#~ msgid "Move input source down"
+#~ msgstr "Gluais an tùs ion-chuir sìos"
+
+#~ msgid "Configure input source"
+#~ msgstr "Rèitich an tùs ion-chuir"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Seall co-dhealbhachd a’ mheur-chlàir air an tùs ion-chuir"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Thèid roghainnean a’ chlàraidh a-steach a chleachdadh leis a h-uile "
+#~ "cleachdaiche nuair a chlàraicheas iad a-steach air an t-siostam"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "Bheir co-roinneadh na sgrìn cead do chleachdaichean an sgrìn agad a "
+#~ "shealltainn no a stiùireadh on taobh a-muigh slighe <a href=\"vnc://%s"
+#~ "\">vnc://%s</a>"
+
+#~ msgid "Copy"
+#~ msgstr "Dèan lethbhreac"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Co-roinneadh _sgrìnichean"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "Chaidh cuid dhe na seirbheisean a chur à comas a chionn ’s nach eil "
+#~ "cothrom air an lìonra."
+
+#~ msgid "Screen Sharing"
+#~ msgstr "Co-roinneadh sgrìnichean"
+
+#~ msgid "_Password:"
+#~ msgstr "_Facal-faire:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Seall am facal-faire"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Feumaidh ceanglaichean ùra cead-i_nntrigidh iarraidh"
+
+#~ msgid "_Require a password"
+#~ msgstr "Ia_rr facal-faire"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Clì"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Deas"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "As lugha"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "As motha"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "Sub_woofer:"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Gun amplachadh"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Pròifil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "Cuir na glaodhairean _fo dheuchainn"
+
+#~ msgid "Peak detect"
+#~ msgstr "Lorg am mullach"
+
+#~ msgid "Device"
+#~ msgstr "Uidheam"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Cuir na glaodhairean airson %s fo dheuchainn"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "T_agh uidheam airson às-chur na fuaime:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Roghainnean an uidheim a thagh thu:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Àirde fuaim an i_on-chuir:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "T_agh uidheam airson ion-chur fuaime:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Èifeachdan fuaime"
+
+#~ msgid "Built-in"
+#~ msgstr "’Na bhroinn o thùs"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Roghainnean na fuaime"
+
+#~ msgid "Testing event sound"
+#~ msgstr "A’ cur na fuaime fo dheuchainn"
+
+#~ msgid "Default"
+#~ msgstr "Bun-roghainn"
+
+#~ msgid "From theme"
+#~ msgstr "On ùrlar"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "T_agh fuaim rabhaidh:"
+
+#~ msgid "Stop"
+#~ msgstr "Stad"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Leughadair-sgrìn"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Leughadair-_sgrìn"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Iuchraichean fuaime"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Boillsg tiotal na _h-uinneige"
+
+#~ msgid "Standard"
+#~ msgstr "Stannardach"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Seòrsa a’ chunntais"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Leig leis a’ chleachdaiche facal-faire a thaghadh nuair a ch_làraicheas "
+#~ "iad a-steach an ath-thuras"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Suidhich facal-faire a_n-dràsta"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "Feumaidh tu bhith air loidhne gus cleachdaichean enterprise a chur ris."
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Cuir an comas clàradh a-steach le meur-lorg"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Chaidh lorg do mheòir a shàbhaladh. Bu chòir gun urrainn dhut clàradh a-"
+#~ "steach le leughadair nam meur-lorg a-nis."
+
+#~| msgid "Take a photo…"
+#~ msgid "Take a Picture…"
+#~ msgstr "Tog dealbh…"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Clàraich a-steach;Ainm;Meur-lorg;Avatar;Suaicheantas;Aodann;Facal-faire;"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "Dearbh a_m facal-faire ùr"
+
+#~ msgid "User Icon"
+#~ msgstr "Ìomhaigheag a’ chleachdaiche"
+
+#~ msgid "Last Login"
+#~ msgstr "An clàradh a-steach mu dheireadh"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Chan eil an dà fhacal-faire co-ionnann."
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Stannardach"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Rianaire"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Chan eil cead-inntrigidh agad dhan uidheam seo. Cuir fios gu rianaire an "
+#~ "t-siostaim agad."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Thachair mearachd inntearnail."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "A bheil thu airson na meur-lorgan clàraichte a sguabadh às?"
+
+#~ msgid "Done!"
+#~ msgstr "Deiseil!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Cha b’ urrainn dhuinn cothrom fhaighinn air an uidheam “%s”"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr ""
+#~ "Cha b’ urrainn dhuinn glacadh a’ mheòir a thòiseachadh air an uidheam “%s”"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Cuir fios gu rianaire an t-siostaim agad airson cuideachadh."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Feumaidh tu lorg do mheòir a chlàradh leis an uidheam “%s” mus urrainn "
+#~ "dhut clàradh a-steach le meur-lorg."
+
+#~ msgid "Selecting finger"
+#~ msgstr "A’ taghadh meur"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Gus atharraichean a dhèanamh,\n"
+#~ "briog an ìomhaigheag * an toiseach"
+
+#~ msgid "Create a user account"
+#~ msgstr "Cruthaich cunntas cleachdaiche"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Gus cunntas cleachdaiche a chruthachadh,\n"
+#~ "briog air an ìomhaigheag * an toiseach"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Chan fhaod an t-ainm-cleachdaiche tòiseachadh le “-”."
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Thèid seo a chleachdadh gus ainm a chur air a’ phasgan dachaigh agad is "
+#~ "cha ghabh atharrachadh."
+
+#~ msgid "Output:"
+#~ msgstr "Às-chur:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Glèidh co-mheas an deilbh (bogsa-litrichean):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapaich ri monatair singilte"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Seall am mapadh"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablaid (absaloideach)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Pada-suathaidh (dàimheach)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Roghainnean na tablaid"
+
+#~ msgid "_Help"
+#~ msgstr "Cob_hair"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Mapaich putanan…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Cuir air dòigh dùmhlachd-bhreacaidh an taisbeanaidh"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Cuir gleus roghainnean na luchaige."
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Am modh tracaidh"
+
+#~ msgid "Middle Mouse Button Click"
+#~ msgstr "Briogadh de phutan meadhan na luchaige"
+
+#~ msgid "Right Mouse Button Click"
+#~ msgstr "Briogadh de phutan deas na luchaige"
+
+#~ msgid "Forward"
+#~ msgstr "Air adhart"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Gluais am peann agad faisg air an tablaid gus a rèiteachadh"
+
+#~ msgid "Soft"
+#~ msgstr "Bog"
+
+#~ msgid "Firm"
+#~ msgstr "Stalcanta"
+
+#~ msgid "Top Button"
+#~ msgstr "Am putan aig a’ bharr"
+
+#~| msgid "Lower Button"
+#~ msgid "Lowest Button"
+#~ msgstr "Am putan aig a’ bhonn"
+
+#~ msgid "page 3"
+#~ msgstr "duilleag 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Ionad-stiùiridh GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "’S e a’ phrìomh eadar-aghaidh aig GNOME a tha san ionad-stiùiridh gus "
+#~ "iomadh gleus dhen deasg agad a rèiteachadh."
+
+#~ msgid "Show the overview"
+#~ msgstr "Seall am foir-shealladh"
+
+#~ msgid "Quit"
+#~ msgstr "Fàg an-seo"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "Back­ground"
+#~ msgstr "Cùlaibh"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Dath"
+
+#~ msgid "Section"
+#~ msgstr "Earrann"
+
+#~ msgid "Overview"
+#~ msgstr "Foir-shealladh"
+
+#~| msgid "Default Applications"
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Aplacaidean tùsail"
+
+#~ msgid "Ab­out"
+#~ msgstr "Mu dhèidhinn"
+
+#~ msgid "De­tails"
+#~ msgstr "Mion-fhiosrachadh"
+
+#~| msgid "Removable Media"
+#~ msgid "Remo­vable Media"
+#~ msgstr "Meadhan so-ghiùlain"
+
+#~ msgid "Net­work"
+#~ msgstr "Lìonra"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Brathan"
+
+#~ msgid "Po­wer"
+#~ msgstr "A’ chumhachd"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Prìobhaideachd"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Co-roinneadh"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Inntrigeadh uile-choitcheann"
+
+#~ msgid "Disable image"
+#~ msgstr "Cuir an dealbh à comas"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Brabhsaich airson barrachd dhealbhan…"
+
+#~ msgid "Used by %s"
+#~ msgstr "’Ga chleachdadh le %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Tablaid Wacom"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Bathar-cruaidh"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Siostam"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Mullach dùinte"
+
+#~ msgid "Mirrored"
+#~ msgstr "Sgàthanaichte"
+
+#~ msgid "Secondary"
+#~ msgstr "Panail dhàrnach"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Cuir air gleus na co-thaisbeanaidhean"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr ""
+#~ "Slaod na h-uidheaman-taisbeanaidh mun cuairt gus an t-òrdugh atharrachadh"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Cuairtich gu tuathail le 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Cuairtich le 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Cuairtich gu deiseil le 90°"
+
+#~ msgid "Size"
+#~ msgstr "Meud"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr ""
+#~ "Seall am bàr mullaich is foir-shealladh na gnìomhachd air an uidheam-"
+#~ "taisbeanaidh seo"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Cuir an t-uidheam-taisbeanaidh seo còmhla ri fear eile airson rum-obrach "
+#~ "a bharrachd a chruthachadh"
+
+#~ msgid "Presentation"
+#~ msgstr "Taisbeanadh"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Na seall ach taisbeanaidhean-shleamhnagan is meadhanan"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Seall an sealladh làithreach agad air an dà uidheam-taisbeanaidh"
+
+#~ msgid "Turn Off"
+#~ msgstr "Cuir dheth"
+
+#~| msgid "Don't use this display"
+#~ msgid "Don’t use this display"
+#~ msgstr "Na cleachd an t-uidheam-taisbeanaidh seo"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "Cuir _air gleus na co-thaisbeanaidhean"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-biod (ID na togail: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-biod"
+
+#~ msgid "Base system"
+#~ msgstr "Bun-shiostam"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Ath-ghoirid;Ath-dhèan;Priobadh;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Brùth air Esc airson sgur dheth."
+
+#~ msgid "Server"
+#~ msgstr "Frithealaiche"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Sguab às am frithealaiche DNS"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "C_uir ri làimh chleachdaichean eile"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Sòn na cachaileith-teine"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Bun-roghainn"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Tha an sòn seo a' sònrachadh ìre earbsa a' cheangail"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Ath-shuidhich roghainnean an lìonraidh seo, a' gabhail a-steach nam "
+#~ "faclan-faire, ach cuimhnich e mar lìonra as fhearr leat"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Thoir air falbh fiosrachadh sam bith mun lìonra seo 's na dèan ceangal "
+#~ "ris gu fèin-obrachail a-rithist"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Ma tha ceangal agad ris an eadar-lìon a bharrachd air a' cheangal "
+#~ "uèirleas, 's urrainn dhut hotspot uèirleas a shuidheachadh gus an ceangal "
+#~ "agad a cho-roinneadh le daoine eile."
+
+#~ msgid "Proxy"
+#~ msgstr "Progsaidh"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "Cui_r pròifil ris…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Chan eil gin"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "A làimh"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Gu fèin-obrachail"
+
+#~ msgid "Group Name"
+#~ msgstr "Ainm a' bhuidhinn"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Cleachd mar hotspot…"
+
+#~ msgid "_History"
+#~ msgstr "An eachdraid_h"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "Loading options…"
+#~ msgstr "A' luchdadh nan roghainnean…"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Feuch is cleachd barrachd litrichean, àireamhan is chomharran."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Neart: lag"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Neart: ìseal"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Neart: meadhanach"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Neart: math"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Neart: àrd"
+
+#~ msgid "Edit"
+#~ msgstr "Deasaich"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Brataich bhrathan"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "_Brataich bhrathan"
+
+#~ msgid "Add Account"
+#~ msgstr "Cuir cunntas ris"
+
+#~ msgid "Mail"
+#~ msgstr "Post"
+
+#~ msgid "Calendar"
+#~ msgstr "Mìosachan"
+
+#~ msgid "Contacts"
+#~ msgstr "Luchd-aithne"
+
+#~ msgid "Chat"
+#~ msgstr "Cabadaich"
+
+#~ msgid "Resources"
+#~ msgstr "Goireasan"
+
+#~ msgid "Error creating account"
+#~ msgstr "Mearachd a' cruthachadh a' chunntais"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr ""
+#~ "A bheil thu cinnteach gu bheil thu airson an cunntas seo a thoirt air "
+#~ "falbh?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Cha doir seo air falbh an cunntas air an fhrithealaiche."
+
+#~ msgid "_Remove"
+#~ msgstr "_Thoir air falbh"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Cha deach cunntas air loidhne sam bith a rèiteachadh"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Ma chuireas tu cunntas ris, bheir seo cead-inntrigidh dha na h-"
+#~ "aplacaidean agad air na sgrìobhainnean ann, am post, an luchd-aithne, am "
+#~ "mìosachan, cabadaich is mòran a bharrachd."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "'Ga rèiteachadh"
+
+#~ msgid "Toner Level"
+#~ msgstr "Ìre an tònair"
+
+#~ msgid "Supply Level"
+#~ msgstr "Ìre a' ghoireis"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "'Ga stàladh"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u gnìomhach"
+#~ msgstr[1] "%u gnìomhach"
+#~ msgstr[2] "%u gnìomhach"
+#~ msgstr[3] "%u gnìomhach"
+
+#~ msgid "Provide PPD File…"
+#~ msgstr "Solair faidhle PPD…"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Cuir clò-bhualadair ùr ris"
+
+#~ msgid "No printers detected."
+#~ msgstr "Cha deach clò-bhualadair sam bith a lorg."
+
+#~ msgid "Supply"
+#~ msgstr "Goireasan"
+
+#~ msgid "_Default printer"
+#~ msgstr "An clò-bhualadair _bunaiteach"
+
+#~ msgid "Jobs"
+#~ msgstr "Obraichean"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Sea_ll na h-obraichean"
+
+#~ msgid "label"
+#~ msgstr "leubail"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "A' suidheachadh an draibheir ùir…"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Clò-bhuail _duilleag deuchainne"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Cunntasan eile"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Suas"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Sìos"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Chan eil gin"
+
+#~ msgid "Left Ring"
+#~ msgstr "Fàinne chlì"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Am modh fàinneach clì #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Am modh fàinneach deas #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Touchstrip clì"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Am modh touchstrip clì #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Touchstrip deas"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Am modh touchstrip deas #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Am modh touchring clì"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Am modh touchring deas"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Suidse a' mhodh touchstrip chlì"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Suidse a' mhodh touchstrip deas"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Suidse nam modh #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Am putan clì #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Am putan deas #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Am putan aig a' bharr #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Am putan aig a' bhonn #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Gun ghnìomh"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Briogadh de phutan clì na luchaige"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Sgrolaich suas"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Sgrolaich sìos"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Sgrolaich dhan taobh deas"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Thoir an ath-ghoirid air falbh"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Gu ath-ghoirid a dheasachadh, briog air an ràgh agus cum sìos na h-"
+#~ "iuchraichean ùra no brùth Backspace gus an toirt air falbh."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Gnìomh nach aithne dhuinn>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Chan urrainn dhut an ath-ghoirid \"%s\" a chleachdadh a chionn 's nach b' "
+#~ "urrainn dhut sgrìobhadh leis an iuchair seo.\n"
+#~ "Feuch iuchair mar Ctrl, Alt no Shift aig an aon àm."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Tha an ath-ghoirid \"%s\" 'ga chleachdadh airson na leanas mu thràth: \n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Ma thaghas tu \"%s\" mar an ath-ghoirid ùr, thèid an seann ath-ghoirid "
+#~ "\"%s\" a chur à comas."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Ath-shònraich"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Tha ath-ghoirid \"%2$s\" an cois na h-ath-ghoirid \"%1$s\". A bheil thu "
+#~ "airson a suidheachadh air \"%3$s\" gu fèin-obrachail?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "Tha ath-ghoirid \"%2$s\" an cois na h-ath-ghoirid \"%1$s\" an-dràsta, "
+#~ "thèid an ath-ghoirid ud a chur à comas ma leanas tu air adhart leis."
+
+#~ msgid "_Assign"
+#~ msgstr "Sònr_aich"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Cuir ceangal lìonraidh ris"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Mearachd a' clàradh a-steach dhan chunntas"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Dh'fhalbh an ùine air an ainm is air an facal-fhaire."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Clàraich a-steach gus an cunntas seo a chur an comas."
+
+#~ msgid "_Sign In"
+#~ msgstr "Clàraich a-_steach"
+
+#~ msgid "Personal File Sharing"
+#~ msgstr "Co-roinneadh fhaidhlichean pearsanta"
+
+#~ msgid "Login History"
+#~ msgstr "Eachdraidh nan daoine a chlàraich a-steach"
+
+#~ msgid "Add User Account"
+#~ msgstr "Cuir cunntas cleachdaiche ris"
+
+#~| msgid "GNOME Control Center"
+#~ msgid "Welcome to the Control Center"
+#~ msgstr "Fàilte gun ionad smachd"
+
+#~ msgid "Select a panel in the sidelist to see the available options"
+#~ msgstr ""
+#~ "Tagh panail air an liosta-thaoibh gus na roghainnean a shealltainn a tha "
+#~ "ri am faighinn"
+
+#~ msgid "Bond"
+#~ msgstr "Bann"
+
+#~ msgid "Team"
+#~ msgstr "Sgioba"
+
+#~ msgid "Bridge"
+#~ msgstr "Drochaid"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Cha b' urrainn dhuinn na plugain VPN a luchdadh"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Tràillean banna"
+
+#~ msgid "(none)"
+#~ msgstr "(chan eil gin)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Tràillean drochaide"
+
+#~ msgid "Team slaves"
+#~ msgstr "Tràillean sgioba"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr ""
+#~ "Chan eil an t-uidheam InfiniBand a' cur taic ris a' mhodh cheangailte"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Cha deach ùghdarras theisteanasan a thaghadh"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Mur an cleachd thu teisteanas le ùghdarras theisteanasan, tha cunnart gun "
+#~ "dèan thu ceangal ri lìonraidhean WiFi droch-rùnach. A bheil thu airson "
+#~ "ùghdarras theisteanasan a thaghadh?"
+
+#~ msgid "Ignore"
+#~ msgstr "Leig seachad"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Tagh ùghdarras theisteanasan"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Iarr am facal-faire seo gach _turas"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Na thoir _rabhadh dhomh a-rithist"
+
+#~ msgid "Yes"
+#~ msgstr "Tha"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Eile"
+
+#~ msgid "_Verify"
+#~ msgstr "Dear_bh"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr ""
+#~ "Tha cleachdaiche air a bheil an t-ainm-cleachdaiche \"%s\" ann mar-tha."
+
+#~ msgid "Done"
+#~ msgstr "Deiseil"
+
+#~ msgid "Install Language"
+#~ msgstr "Stàlaich cànan"
+
+#~ msgid "Time _Zone"
+#~ msgstr "An _roinn-tìde"
+
+#~ msgid "Launch terminal"
+#~ msgstr "Cuir gu dol an tèirmineal"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Dàil:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Goirid"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Slaodach"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Fada"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Luath"
+
+#~ msgid "S_peed:"
+#~ msgstr "A_star:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Cuir na roghainnean agad fo dheuchainn"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Slaodach"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Luath"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "C_lì"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Deas"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "Astar an _tomhaire"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Slaodach"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Luath"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Slaodach"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Luath"
+
+#~ msgid "Apply system wide"
+#~ msgstr "Cuir an gnìomh air feadh an t-siostaim"
+
+#~ msgid "No printers available"
+#~ msgstr "Chan eil clò-bhualadair ri làimh"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Lean air a' chlò-bhualadh"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Cuir an clò-bhualadh 'na stad"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "'Ga chumail"
+
+#~ msgid "Job Title"
+#~ msgstr "Tiotal na h-obrach"
+
+#~ msgid "Job State"
+#~ msgstr "Staid na h-obrach"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Cuir clò-bhualadair ùr ris"
+
+#~ msgid "Lock Screen on Suspend"
+#~ msgstr "Glais an sgrìn nuair a thèid a chur 'na dhàil"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Thèid an cleachdadh gus faighinn a-mach far a bheil thu"
+
+#~ msgid "Options"
+#~ msgstr "Roghainnean"
+
+#~ msgid "Password:"
+#~ msgstr "Facal-faire:"
+
+#~ msgid "Zoom"
+#~ msgstr "Sùm"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Dath"
+
+#~ msgid "Bluetooth is disabled by hardware switch"
+#~ msgstr "Chaidh Bluetooth a chur à comas le suidse bathair-chruaidh"
+
+#~ msgid "No Bluetooth adapters found"
+#~ msgstr "Cha deach freagarraichearan Bluetooth a lorg"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Ruith '%s --help' airson liosta shlàn roghainnean na loidhne-àithne "
+#~ "fhaicinn a tha ri làimh.\n"
+
+#~ msgid "Show help options"
+#~ msgstr "Seall roghainnean na cobharach"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Nuair a bhios am bataraidh _cha mhòr falamh"
+
+#~ msgid ""
+#~ "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;"
+#~ "video;pictures;photos;movies;server;renderer;"
+#~ msgstr ""
+#~ "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;"
+#~ "video;pictures;photos;movies;server;renderer;co-roinn;co-roinneadh;òstair;"
+#~ "cèin;meadhan;fuaim;dealbhan;deilbh;filmichean;frithealaiche;reandaraiche;"
+
+#~ msgid "Bluetooth Sharing"
+#~ msgstr "Co-roinneadh Bluetooth"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Bheir co-roinneadh Bluetooth comas dhut faidhlichean a cho-roinneadh le "
+#~ "uidheaman eile a tha comasach air Bluetooth"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Na gabh ri stuth ach o uidheaman earbsach"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr ""
+#~ "Sàbhail faidhlichean a gheibhear ann am pasgan nan rudan a chaidh a "
+#~ "luchdadh a-nuas"
+
+#~ msgid "- Settings"
+#~ msgstr "- Roghainnean"

--- a/po/gl.po
+++ b/po/gl.po
@@ -18,9 +18,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center-master-po-gl-72290.merged\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-03 12:25+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-05 00:17+0200\n"
 "Last-Translator: Fran Dieguez <frandieguez@gnome.org>\n"
 "Language-Team: Galician <proxecto@trasno.gal>\n"
@@ -38,99 +37,7 @@ msgstr ""
 "X-DL-Domain: po\n"
 "X-DL-State: Translating\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Bus do sistema"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Acceso completo"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Bus de sesión"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Dispositivos"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Acceso completo a /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Rede"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Ten acceso á rede"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Cartafol persoal"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Só lectura"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Sistema de ficheiros"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Preferencias"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Pode cambiar preferencias"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s ten os seguintes permisos, que non se poden cambiar. Se está preocupado "
-"por estes permisos, considere eliminar esta aplicación."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u ficheiro e tipo de ligazón que está aberta pola aplicación"
-msgstr[1] "%u ficheiros e tipos de ligazón que está aberta pola aplicación"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> úsase para abrir os tipos de ficheiros e ligazóns seguintes."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s do espazo de disco usado."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -146,7 +53,6 @@ msgid "Install some…"
 msgstr "Instalar algún…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Abrir"
 
@@ -170,24 +76,13 @@ msgstr "Busca"
 msgid "Receive system searches and send results."
 msgstr "Recibir as buscas do sistema e enviar resultados."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Desactivado"
 
@@ -352,80 +247,20 @@ msgstr "Limpar caché…"
 msgid "Control various application permissions and settings"
 msgstr "Controla os distintos permisos e preferencias da aplicación"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "application;flatpak;permission;setting;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Seleccione unha imaxe"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Cancelar"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Abrir"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "tamaños múltiples"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Sen fondo de escritorio"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Fondo actual"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Estilo"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Predeterminado"
 
@@ -449,7 +284,6 @@ msgstr "Aparencia"
 msgid "Change your background image or the UI colors"
 msgstr "Cambie a súa imaxe de fondo ou as cores da interface"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Fondo de pantalla;Pantalla;Escritorio;Estilo;Claro;Escuro;Aparencia;"
@@ -501,9 +335,7 @@ msgstr "Modo avión por hardware activado"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Apague o modo avión para activar o Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -511,7 +343,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Active ou desactive o Bluetooth e conecte os seus dispositivos"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "compartir;compartición;bluetooth;obex;"
@@ -544,92 +375,33 @@ msgstr "Ningunha aplicación solicitou acceder á cámara"
 msgid "Protect your pictures"
 msgstr "Protexer as súas fotografías"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "cámara;fotos;vídeo;cámara web;bloquear;privado;privacidade;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Poña o dispositivo de calibración no cadrado e prema «Comezar»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Mova o dispositivo de calibración á posición de calibrado e prema «Continuar»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Mova o dispositivo de calibración á posición da superficie e prema "
-"«Continuar»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Pechar a tapa do portátil"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Produciuse un erro interno que non pode recuperarse."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "As ferramentas requiridas para o calibrado non están instaladas."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Non foi posíbel xerar o perfil."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Non foi posíbel obter o punto branco obxectivo."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Completado!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Calibrado fallado!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Pode quitar o dispositivo de calibrado."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Non moleste o dispositivo de calibrado mentres está traballando"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibración de pantalla"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancelar"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -646,140 +418,6 @@ msgstr "_Continuar"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Feito"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Pantalla do portátil"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Cámara web integrada"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Escáner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Cámara %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Impresora %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Cámara web %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Activar a xestión de cor para %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Mostrar os perfiles de cor para %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Non calibrado"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Predeterminado: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Espazo de cor: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Perfil de proba: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Seleccionar ficheiro de perfil ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importar"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Perfiles ICC admitidos"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Todos os ficheiros"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Pantalla"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Gardar perfil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Gardar"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Crear un perfil de cor para o dispositivo seleccionado"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Non se detectou o instrumento de medida. Comprobe que está acendido e "
-"correctamente conectado."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "O instrumento de medida non admite perfilado de impresoras."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "O tipo de dispositivo non é compatíbel actualmente."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -922,7 +560,6 @@ msgstr "_Importar ficheiro…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -934,9 +571,7 @@ msgstr ""
 "Cada dispositivo necesita un perfil de cor actualizado para poder xestionar "
 "a cor."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Aprender máis"
 
@@ -1068,83 +703,6 @@ msgstr "D65 (Fotografía e gráficos)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Espazo estándar"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Perfil de proba"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automático"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Calidade baixa"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Calidade media"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Calidade alta"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB predeterminado"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK predeterminado"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Gris predeterminado"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Datos de calibrado de fábrica fornecidos polo fabricante"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-"A corrección de pantalla a pantalla completa non é posíbel con este perfil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Este perfil podería non ser preciso"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Cor"
@@ -1155,14 +713,9 @@ msgid ""
 msgstr ""
 "Calibre o cor dos seus dispositivos, como as pantallas, cámaras ou impresoras"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Cor;ICC;Perfil;Calibrado;Impresora;Pantalla;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Outro…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1177,13 +730,8 @@ msgid "No languages found"
 msgstr "Non se atoparon idiomas"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Máis…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Desbloquear para cambiar as preferencias"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1212,151 +760,6 @@ msgstr "Decrementar hora"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Decrementar minuto"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Hoxe"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Onte"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e de %b de %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d hora"
-msgstr[1] "%d horas"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuto"
-msgstr[1] "%d minutos"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d segundos"
-msgstr[1] "%d segundos"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 segundos"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 horas"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1451,17 +854,11 @@ msgstr "Fuso _horario automático"
 msgid "Requires location services enabled and internet access"
 msgstr "Require ter activos os servizos de localización e acceso a internet"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Activado"
 
@@ -1469,15 +866,43 @@ msgstr "Activado"
 msgid "Time Z_one"
 msgstr "Fuso h_orario"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desbloquear"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Formato de hora"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datas"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 segundos"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calendario"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Números"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Cambie a data e hora, incluíndo o fuso horario"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Reloxo;Fuso horario;Localización;"
@@ -1523,20 +948,9 @@ msgstr "Aplicacións predeterminadas"
 msgid "Configure Default Applications"
 msgstr "Configurar as aplicacións predeterminadas"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "predeterminado;aplicación;preferido;media;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Ao enviar informes de problemas técnicos axudaranos a mellorar %s. Os "
-"informes envíanse de forma anónima e límpanse de datos persoais. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1554,44 +968,9 @@ msgstr "Diagnóstico"
 msgid "Report your problems"
 msgstr "Informar os seus erros"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnóstico;crash;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Activado"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Desactivado"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Desexa aplicar os cambios?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Os cambios non se poden aplicar"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Isto pode ser por limitacións do hardware."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1641,31 +1020,6 @@ msgstr "Pantalla principal"
 msgid "Night Light"
 msgstr "Luz nocturna"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Horizontal"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Vertical dereita"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Vertical esquerda"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Horizontal (volteado)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1689,6 +1043,17 @@ msgstr "Axustar para TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Escalar"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Desprazamento natural"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1784,7 +1149,6 @@ msgstr "Pantallas"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Escolla como usar os monitores conectados e proxectores"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1792,80 +1156,6 @@ msgid ""
 msgstr ""
 "Panel;Proxector;xrandr;Pantalla;Resolución;Refresco;Monitor;Noite;Luz;Azul;"
 "redshift;cor;solpor;amencer;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Secure Boot está activo"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Secure Boot prevén que software malicioso se cargue cando arranca o seu "
-"dispositivo. Actualmente está activo e funcionando correctamente."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Secure Boot ten problemas"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Secure Boot prevén que software malicioso se cargue cando arranca o seu "
-"dispositivo. Actualmente está activo, pero non funciona debido a que ten "
-"unha chave non válida."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Os problemas de Secure Boot poden normalmente resolverse desde as "
-"preferencias do firmware UEFI do seu computador (BIOS), o fabricante do seu "
-"hardware podería ofrecer información sobre como facer isto."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Para obter axuda, contacte co fabricante do seu hardware ou o seu fornecedor "
-"de asistencia tecnolóxica."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Secure Boot está desactivado"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Secure boot evita que software malicioso sexa cargado cando o dispositivo "
-"empeza. Actualmente está desactivado."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Secure boot pode ser activado polas preferencias do firmware UEFI do seu "
-"computador (BIOS). Para obter axuda, contacte co fabricante do seu hardware "
-"ou o seu fornecedor de soporte técnico."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1880,132 +1170,9 @@ msgstr ""
 "Para máis información, contacte co fabricante do soporte ou o soporte "
 "técnico."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Pasado"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Falla"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "O dispositivo cumple co nivel HSI %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Nivel de seguranza 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Este dispositivo non ten protección fronte a problemas de seguranza de "
-"hardware. Isto pode deberse a un problema na configuración do firmware. "
-"Recoméndamoslle contactar co seu fornecedor de soporte técnico"
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Nivel de seguranza 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Este dispositivo ten protección mínima fronte a problemas de seguranza de "
-"hardware. Este é o nivel de seguranza de dispositivo máis baixo e só fornece "
-"protección fronte a ameazas de seguranza simples."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Nivel de seguranza 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Este dispositivo ten protección básica fronte a problemas de seguranza de "
-"hardware. Isto fornece protección fronte a amezas de seguranza comúns."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Nivel de seguranza 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Este dispositivo ten protección estendida fronte a problemas de seguranza de "
-"hardware. Este é o nivel de seguranza de dispositivo máis alto e fornece "
-"protección fronte a ameazas de seguranza avanzados."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Nivel de seguranza"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Os niveis de seguranza non están dispoñíbeis para este dispositivo."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Contacte co seu fabricante de hardware para obter axuda coas actualizacións "
-"de seguranza."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Podería ser posíbel resolver este problema nas preferencias do firmware UEFI "
-"do dispositivo, ou por un técnico de asistencia técnica."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Podería ser posíbel resolver este problema nas preferencias do firmware UEFI "
-"do dispositivo."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Podería ser posíbel que un técnico de soporte resolva este problema."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2019,338 +1186,9 @@ msgstr "Nivel 2"
 msgid "Level 3"
 msgstr "Nivel 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Protección fronte a software malicioso cando o dispositivo arrinca."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Secure Boot ten problemas"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Algunha protección cando se inicia o dispositivo."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Secure Boot está desactivado"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Sen protección cando se inicia o dispositivo."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Este problema puido ser causado por un cambio na configuración do firmware "
-"UEFI, un cambio na configuración do sistema operativo ou por un software "
-"malicioso neste sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Este problema puido ser causado por un cambio na configuración do firmware "
-"UEFI ou por un software malicioso neste sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Este problema puido ser causado por un cambio na configuración do sistema "
-"operativo ou por un software malicioso neste sistema."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Altamente exposto ás ameazas de seguranza."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Protección limitada contra ameazas simples de seguranza."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Protexido contra ameazas de seguranza comúns."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Protexido contra unha ampla gama de ameazas de seguranza."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Protección integral"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Non hai eventos"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Protección contra escritura de firmware"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Bloqueo de protección contra escritura de firmware"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Rexión da BIOS do firmware"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Descriptor de BIOS de firmware"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Protección DMA previa al arranque"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Arrinque verificado de Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "ACM protexida de Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Normativa de erro de Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Fusíbel de Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET activado"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET activo"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "RAM cifrada"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Protección IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Bloqueo do núcleo de Linux"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Verificación do núcleo de Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux Swap"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Suspender á RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Suspender a inactivo"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Chave de plataforma UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Secure Boot UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Configuración da plataforma TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Reconstrucción TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Modo de fabricación do motor de xestión de Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Anulación do motor de xestión de Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Versión do motor de xestión de Intel"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Actualizacións de firmware"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Certificación de firmware"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Verificación do actualizador do firmware"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Depuración da plataforma"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Comprobacións de seguranza do procesador"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Protección de rollback de AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Protección de reprodución do firmware de AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Protección de escrita do firmware de AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Plataforma Fused"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Válido"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Non válido"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Activado"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Bloqueado"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Non bloqueado"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Cifrado"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Non cifrado"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Corrompido"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Non corrompido"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Atopado"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Non atopado"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Compatíbel"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Non é compatíbel"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2360,7 +1198,6 @@ msgstr "Seguranza do dispositivo"
 msgid "Host firmware security status"
 msgstr "Estado da seguranza do firmware do host"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2368,49 +1205,6 @@ msgid ""
 msgstr ""
 "pantalla;bloqueo;diagnóstico;peches;privado;recente;temporal;tmp;índice;nome;"
 "rede;identidade;privacidade;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Descoñecido"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Descoñecido"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Non dispoñíbel"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logotipo do sistema"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2504,11 +1298,6 @@ msgstr "Sobre"
 msgid "View information about your system"
 msgstr "Ver información sobre o seu sistema"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2587,6 +1376,12 @@ msgstr "Iniciadores"
 msgid "Launch help browser"
 msgstr "Iniciar o visor de axuda"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Preferencias"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Iniciar a calculadora"
@@ -2608,7 +1403,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Buscar"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
@@ -2657,15 +1452,6 @@ msgstr "Reducir o tamaño do texto"
 msgid "High contrast on or off"
 msgstr "Contraste alto activado ou desactivado"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Non se atopou ningunha orixe de entrada"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Outra"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Engadir unha orixe de entrada"
@@ -2698,107 +1484,9 @@ msgstr "Preferencias"
 msgid "View Keyboard Layout"
 msgstr "Ver a disposición do teclado"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Eliminar"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Personalizar os atallos"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Tecla de caracteres alternativos"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"A tecla de trocar caracteres poden usarse para escribir caracteres "
-"adicionais. A veces imprímense como unha terceira opción no seu teclado."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt esquerda"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt dereito"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Super esquerda"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Super dereita"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tecla de menú"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl dereito"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Tecla de composición"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"A tecla de composición permítelle escribir unha ampla variedade de "
-"caracteres. Para usala, prema a tecla e logo escriba a secuencia dos "
-"caracteres. Por exemplo, tecla de composición seguida por <b>C</b> e <b>o</"
-"b> escribirá <b>©</b>, <b>a</b> seguida por <b>'</b> escribirá <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Bloqueo de Maiúsculas"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Bloqueo de desprazamento"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Imprimir pantalla"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"As orixes de pantalla poden cambiarse usando o atallo de teclado %s.\n"
-"Estes atallos de teclado poden cambiarse nas preferencias de atallos de "
-"teclado."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2829,45 +1517,21 @@ msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Métodos para introducir símbolos e variantes de letra usando o teclado."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de caracteres alternativos"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composición"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Atallos de teclado"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Ver e personalizar atallos de teclado"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modificado"
-msgstr[1] "%d modificados"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Desexa restabelecer todos os atallos?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Ao restabelecer os atallos pode afectar aos atallos personalizados. Isto non "
-"se pode desfacer."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Restabelecer todo"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2907,33 +1571,6 @@ msgstr "Engadir atallo"
 msgid "No keyboard shortcut found"
 msgstr "Non se atopou ningún atallo de teclado"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s xa está sendo usado para %s. Se o substitúe, %s desactivarase"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Escriba o novo atallo"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Estabelecer atallo personalizado"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Estabelecer atallo"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Escriba o novo atallo para cambiar %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Engadir atallo personalizado"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Eliminar"
@@ -2945,7 +1582,6 @@ msgstr "_Substituír"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Estabelecer"
 
@@ -2982,6 +1618,11 @@ msgstr "Ningunha"
 msgid "Reset the shortcut to its default value"
 msgstr "Restabelecer o atallo ao valor predeterminado"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Usar a túa cámara"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Teclado"
@@ -2994,7 +1635,6 @@ msgstr ""
 "Cambie os atallos do teclado e estabeleza as preferencias de escritura, "
 "disposicións de teclado ou fontes de entrada"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3037,7 +1677,6 @@ msgstr "Ningunha aplicación solicitou á localización"
 msgid "Protect your location information"
 msgstr "Protexer a súa información de localización"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "localización;gps;privado;privacidade;"
@@ -3072,7 +1711,6 @@ msgstr "Ningunha aplicación solicitou acceso ao micrófono"
 msgid "Protect your conversations"
 msgstr "Protexa as túas conversas"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "micrófono;gravación;aplicación;privacidade;"
@@ -3102,81 +1740,139 @@ msgstr "Esquerda"
 msgid "Right"
 msgstr "Dereita"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Localizacións da busca"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Rato"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Velocidade do rato"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Desprazamento natural"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Notificacións"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "O desprazamento move o contido, non a vista."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "O desprazamento move o contido, non a vista."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Activo"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Área táctil"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Velocidade da área táctil"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Tocar para facer clic"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Tocar para facer clic"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Desprazamento con dous dedos"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Área táctil (relativo)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Desprazamento no bordo"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Bloqueo de desprazamento"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dúas caras"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Tente facer clic, dobre clic, desprazarse coa roda do rato"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinco clics, tempo de GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dobre clic, botón primario"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Un clic, botón primario"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dobre clic, botón do medio"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Un clic, botón do medio"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dobre clic, botón secundario"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Un clic, botón secundario"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3189,7 +1885,6 @@ msgstr ""
 "Cambie a sensibilidade do seu rato ou área táctil e seleccione se é destro "
 "ou zurdo"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Área táctil;Punteiro;Premer;Dobre;Pulsación;Botón;Desprazamento;"
@@ -3270,7 +1965,6 @@ msgstr "Multitarefa"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Xestionar as preferencias para a productividade e multitarefa"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3278,20 +1972,11 @@ msgstr ""
 "Multitarefa;Productividade;Personalizar;Escritorio;Esquina quente;Espazos de "
 "traballo;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Recoiro, algo foi mal. Contacte co seu fabricante de software."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Requírese que NetworkManager estea en execución."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Outros dispositivos"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3303,59 +1988,16 @@ msgstr "Engadir conexión"
 msgid "Not set up"
 msgstr "Non configurada"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Rede non segura (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Rede segura (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Rede segura (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Rede segura (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Rede segura"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Conectado"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opcións…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Activar o punto de acceso desconectarao de %s, non será posíbel acceder a "
-"internet mediante o Wifi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Debe ter cando menos 8 caracteres"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3405,20 +2047,6 @@ msgstr "Autoxerar un contrasinal"
 msgid "_Turn On"
 msgstr "_Activar"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wifi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Desexa deter o «hotspot» e desconectar aos usuarios?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Deter «hotspot»"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Modo avión"
@@ -3463,89 +2091,13 @@ msgstr "Redes visíbeis"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager debe estar en execución"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Recoiro, algo foi mal. Contacte co seu fabricante de software."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Seguranza 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Seguranza"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Preservar"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanente"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Aleatorio"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Estábel"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"O enderezo MAC escribo aquí usarase como o enderezo hardware para o "
-"dispositivo de rede para esta conexión. Esta característica é coñecida como "
-"clonado ou spoofing de MAC. Exemplo: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Perfil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Apertura mellorada"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Empresarial"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ningunha"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Nunca"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3554,183 +2106,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "Hai %i día"
 msgstr[1] "Hai %i días"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)Rede segura (WPA)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Ningunha"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Débil"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Aceptábel"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Boa"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excelente"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Enderezo IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Enderezo IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Enderezo IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Esquecer conexión"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Eliminar o perfil de conexión"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Eliminar VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Detalles"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automático"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identidade"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Eliminar enderezo"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Quitar ruta"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ningunha"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Chave WEP de 40/128 bits (Hexadecimal ou ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Frase de paso WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinámica (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Persoal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Empresarial"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Persoal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3741,8 +2116,20 @@ msgstr "Intensidade do sinal"
 msgid "Link speed"
 msgstr "Velocidade da ligazón"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguranza"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Enderezo IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Enderezo IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Enderezo hardware"
 
@@ -3751,12 +2138,17 @@ msgid "Supported Frequencies"
 msgstr "Frecuencias admitidas"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Ruta predeterminada"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3819,7 +2211,7 @@ msgstr "Só ligazón local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
@@ -3863,9 +2255,8 @@ msgstr "Pasarela"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automático"
 
@@ -3918,89 +2309,9 @@ msgstr "Automático, só DHCP"
 msgid "Prefix"
 msgstr "Prefixo"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Non foi posíbel abrir o editor de conexións"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Novo perfil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Preferencia %s non válida: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Preferencia %s non válida"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importar desde ficheiro…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Engadir VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_eguranza"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Non foi posíbel importar a conexión VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Non foi posíbel ler o ficheiro '%s' ou non contén información de conexión "
-"VPN recoñecíbel\n"
-"\n"
-"Erro: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Seleccione o ficheiro para importar"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Xa existe un ficheiro chamado «%s\"."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "S_ubstituír"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Quere substituír %s coa conexión VPN que está gardando?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Non é posíbel exportar a conexión VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Non foi posíbel exportar a conexión VPN «%s» a %s.\n"
-"\n"
-"Erro: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Exportar conexión VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4014,99 +2325,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rede"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controle como se conecta a Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Rede;IP;LAN;Proxy;WAN;Banda larga;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wifi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controle como se conecta a redes Wifi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Rede;Sen fíos;Wi-Fi;Wifi;IP;LAN;Banda larga;DNS;Punto de acceso;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nunca"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "hoxe"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "onte"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Última vez usada"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Con fíos"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Engadir nova conexión"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Perderase a información das redes seleccionadas, incluíndo os contrasinais e "
-"calquera configuración personalizada."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Esquecer"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Redes Wifi coñecidas"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Esquecer"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "A normativa do sistema prohibe o uso un «Hotspot»"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "O dispositivo Wireless non é compatíbel co modo «Hotspot»"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"O autodescubrimento do proxy web úsase cando non se fornece unha URL de "
-"configuración."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Non se recomenda para redes públicas nas que non se confía."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4125,6 +2373,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Fornecedor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Enderezo IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4209,289 +2461,6 @@ msgstr "_Activar o punto de acceso sen fíos…"
 msgid "_Known Wi-Fi Networks"
 msgstr "Redes Wifi _coñecidas"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Estado descoñecido"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Sen xestionar"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Non dispoñíbel"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Conectando"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Requírese autenticación"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Desconectado"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "A conexión fallou"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Estado descoñecido (ausente)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Fallou a configuración"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Fallou a configuración IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "A configuración IP expirou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Precísanse segredos, pero non se forneceron"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Suplicante de 802.1x desconectado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Fallou a configuración do suplicante de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Fallou o suplicante de 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "O suplicante de 802.1x tardou moito tempo en autenticarse"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Produciuse un erro ao iniciar o servizo de PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Servizo PPP desconectado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP fallou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Produciuse un erro ao iniciar o cliente DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Erro no cliente DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "O cliente DHCP fallou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Produciuse un erro ao iniciar o servizo de conexión compartida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "O servizo de conexión compartida fallou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Produciuse un erro ao iniciar o servizo AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Erro no servizo AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "O servizo AutoIP fallou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Liña ocupada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Non hai ton de chamada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Non foi posíbel estabelecer o «carrier»"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Expirou o tempo de solicitude de chamada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Intento de chamada fallado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Fallou a inicialización do módem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Produciuse un erro ao seleccionar o APN especificado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Non se están buscando redes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Rexistro da rede rexeitado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "O rexistro na rede superou o tempo de espera"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Produciuse un erro ao rexistrarse na rede solicitada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Produciuse un fallo na comprobación do PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "É posíbel que falte o firmware do dispositivo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "A conexión desapareceu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Asumiuse unha conexión existente"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Módem non atopado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Fallou a conexión Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Tarxeta SIM non inserida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Requírese o PIN da SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Requírese o PUK da SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM errónea"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Fallou a dependencia da conexión"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Falta o «firmware»"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Cable desconectado"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "erro non definido na seguranza 802.1x (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "non se seleccionou un ficheiro"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "erro non especificado ao validar o ficheiro eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, DEM, PKCS#12 ou chaves privadas PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Certificados DER ou PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "falta o ficheiro EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Ficheiros PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4540,14 +2509,6 @@ msgstr "Autenticación i_nterna"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Permite o pro_visionado automático PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "falta o nome de usuario EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "falta o contrasinal EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4573,15 +2534,6 @@ msgstr "_Contrasinal"
 msgid "Sho_w password"
 msgstr "Mostrar _contrasinal"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "certificado EAP-PEAP da CA non válido: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "certificado EAP-PEAP da CA non válido: certificado non especificado"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4603,7 +2555,6 @@ msgid "C_A certificate"
 msgstr "Certificado C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4618,63 +2569,6 @@ msgstr "Requírese o certificado da CA"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versión de PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "falta o nome de usuario EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "falta o contrasinal EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "falta a identidade EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "certificado EAP-TLS da CA non válido: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "certificado EAP-TLS da CA non válido: certificado non especificado"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "chave privada EAP-TLS non válida: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificado de usuario EAP-TLS non válido: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "As chaves privadas sen cifrar son inseguras"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"A chave privada seleccionada non parece estar protexida por un contrasinal. "
-"Isto podería permitir que as súas credenciais de seguranza se comprometesen. "
-"Seleccione unha chave privada protexida por contrasinal.\n"
-"\n"
-"(Pode protexer a súa chave privada con un contrasinal con openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Seleccione o seu certificado persoal"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Seleccione a súa chave privada"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4691,15 +2585,6 @@ msgstr "_Chave privada"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Xerar unha chave _privada"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "certificado EAP-TTLS da CA non válido: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "certificado EAP-TTLS da CA non válido: certificado non especificado"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4722,14 +2607,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Dominio"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Produciuse un erro descoñecido ao validar a seguranza 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4757,63 +2643,10 @@ msgstr "EAP protexido (PEAP)"
 msgid "Au_thentication"
 msgstr "_Autenticación"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Seleccionar un ficheiro"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "falta o usuario leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "falta o contrasinal leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Falta o contrasinal do Wifi."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipo"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "falta a chave wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"falta a chave wep: a chave con unha lonxitude %zu debe conter só díxitos "
-"hexadecimais"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"falta a chave wep: a chave con unha lonxitude %zu debe conter só díxitos "
-"ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"chave wep non válida: lonxitude %zu da chave non válida. A chave debe ter "
-"unha lonxitude 5/13 (ascii) ou 10/26 (hexadecimal)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "chave wep non válida: a frase de paso non debe estar baleira"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"chave wep non válida: a frase de paso debe ser máis curta que 64 caracteres"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4838,21 +2671,6 @@ msgstr "Mo_strar chave"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Índic_e WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk non válido: a lonxitude de chave %zu non é valida. Debe ser [8,63] "
-"bytes ou 64 díxitos hexadecimais"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk non válido: non se pode interpretar a chave con 64 bytes como "
-"hexadecimais"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4907,27 +2725,9 @@ msgstr "Notificacións na pantalla de b_loqueo"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controle que notificacións se mostran e que contido mostran"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notificacións;Anuncio;Mensaxe;Bandexa;Emerxente;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Outra"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s eliminada"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Produciuse un erro ao quitar a conta"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4953,17 +2753,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Engadir unha conta"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Conta de %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Retirar conta"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Contas en liña"
@@ -4972,10 +2761,6 @@ msgstr "Contas en liña"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Conéctese ás súas contas en liña a decida para que usalas"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4983,10 +2768,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;En liña;Conversa;Calendario;Correo-e;"
 "Contacto;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Hora descoñecida"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5002,13 +2783,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i hora"
 msgstr[1] "%i horas"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5020,190 +2794,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minutos"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s ate estar cargado completamente"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Precaución: %s restante"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s restante"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Cargada completamente"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Non cargando"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Baleira"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Cargando"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Descargándose"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Rato sen fíos"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Teclado sen fíos"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Fonte de alimentación non interrompíbel"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Asistente persoal dixital"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Teléfono móbil"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Reprodutor de música"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tableta"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Computador"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Dispositivo de entrada de xogos"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batería"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principal"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Adicional"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Baterías"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Ao estar _inactivo"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Suspender"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Apagar"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hibernar"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Non facer nada"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Ao usar enerxía da batería"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Ao estar enchufado"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nunca"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Suspensión automática"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Modo de rendemento desactivado temporalmente debido á temperatura de "
-"operación alta."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Colo detectado: o modo de rendemento está desactivado temporalmente. Mova o "
-"dispositivo a unha superficie estábel para restaurar."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Modo de rendemento temporalmente non dispoñíbel."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Batería baixa: aforro de enerxía activado. O anterior modo restabelecerase "
-"cando a batería estea suficientemente cargada."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Modo de aforro de enerxía activado por «%s»."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Modo de rendemento activado por «%s»"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5264,6 +2854,15 @@ msgstr "100 minutos"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 hora"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batería"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositivos"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5342,33 +2941,6 @@ msgstr "Ao usar a enerxía da _batería"
 msgid "Delay"
 msgstr "Atraso"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Rendemento"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Rendemento e uso de enerxía altos."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Balanceado"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Rendemento e uso de enerxía estándar."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Aforro de enerxí­a"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Rendemento e uso de enerxía reducidos."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Enerxía"
@@ -5378,7 +2950,6 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Vexa o estado da súa batería e cambie as preferencias de aforro de enerxía"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5386,27 +2957,6 @@ msgid ""
 msgstr ""
 "Enerxía;Durmir;Suspender;Hibernar;Batería;Brillo;Escurecer;En branco;Monitor;"
 "DPMS;Inactivo;Enerxía;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Eliminouse a impresora «%s»"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Produciuse un erro ao engadir unha nova impresora."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Non foi posíbel cargar a IU: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Desbloquear para engadir impresoras e cambiar as preferencias"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5418,7 +2968,6 @@ msgstr ""
 "Engadir impresoras, vexa os traballos de impresión e decida que quere "
 "imprimir"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Impresora;Cola;Imprimir;Papel;Tinta;Tóner;"
@@ -5426,8 +2975,6 @@ msgstr "Impresora;Cola;Imprimir;Papel;Tinta;Tóner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Engadir impresora"
 
@@ -5468,29 +3015,6 @@ msgstr ""
 msgid "Username"
 msgstr "Nome de usuario"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Detalles de %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Non se atopou ningún controlador axeitado"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Seleccionar ficheiro PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Ficheiros de descrición de impresora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
-"PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Os nomes de impresoras non poden conter ESPACIOS, TABULACIÓNS, # ou /"
@@ -5499,9 +3023,7 @@ msgstr "Os nomes de impresoras non poden conter ESPACIOS, TABULACIÓNS, # ou /"
 msgid "Location"
 msgstr "Localización"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Controladores"
 
@@ -5529,140 +3051,20 @@ msgstr "Seleccionar controlador da impresora"
 msgid "Loading drivers database…"
 msgstr "Cargando a base de datos dos controladores…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Cancelar"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Seleccionar"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Impresora JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Impresora LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Unha cara"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Marxe longo (estándar)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Marxe curto (xirar)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Vertical"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Horizontal"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Horizontal invertido"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Vertical invertido"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Continuar"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pausar"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Pendente"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Detido"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Requírese autenticación"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Procesando"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Detido"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Cancelado"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Interrompido"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Rematado"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Mover este traballo á parte superior da cola"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u traballo require autenticación"
 msgstr[1] "%u traballos requiren autenticación"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - Traballos activos"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Escriba as credenciais para imprimir desde %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5690,322 +3092,17 @@ msgstr "_Autenticar"
 msgid "No Active Printer Jobs"
 msgstr "Non hai traballos activos na impresora"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Desbloquear o servidor de impresión"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Desbloquear %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Escriba o seu nome de usuario e contrasinal para ver as impresoras en %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Buscar impresoras"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Porto serie"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Porto paralelo"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Localización: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Enderezo: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "O servidor require autenticación"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dúas caras"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Tipo de papel"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Fonte do papel"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Bandexa de saída"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolución"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Prefiltrado GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Páxinas por cara"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dúas caras"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientación"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Xeral"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Configuración da páxina"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opcións instalábeis"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Traballo"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Calidade da imaxe"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Cor"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Rematado"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avanzado"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Páxina de proba"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Páxina de proba"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Seleccionar automaticamente"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Impresora predeterminada"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Só empotrar tipografías GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Converter a PS nivel 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Converter a PS nivel 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Sen prefiltrado"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Fabricante"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Non hai traballos activos"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u traballo"
 msgstr[1] "%u traballos"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Limpar os cabezais de impresión"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Tóner baixo"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Sen tóner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Nivel de revelador baixo"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Sen revelador"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Cartucho con pouca tinta"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Cartucho esgotado"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Abrir cuberta"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Abrir porta"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Nivel de papel baixo"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Sen papel"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Desconectada"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Detida"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "O recipiente de refugallos está case cheo"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "O recipiente dos refugallos está cheo"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "O condutor óptico está preto do final da súa vida"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "O condutor óptico xa non funciona"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Lista"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Non aceptar traballos"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Procesando"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6029,6 +3126,10 @@ msgstr "Limpar os cabezais de impresión"
 msgid "Remove Printer"
 msgstr "Retirar impresora"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Non hai traballos activos"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6049,16 +3150,21 @@ msgid "Restart"
 msgstr "Reiniciar"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Engadir impresora…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Engadir unha impresora…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Non hai impresoras"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6066,7 +3172,6 @@ msgstr ""
 "O servizo do sistema de impresión\n"
 "semella que non está dispoñíbel."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formatos"
@@ -6094,16 +3199,6 @@ msgstr "As buscas poden ser por países ou por idiomas."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Previsualizar"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Métrico"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6141,20 +3236,24 @@ msgstr ""
 "A configuración de idioma úsase no texto da interface e nas páxinas web. Os "
 "formatos úsanse para os números, datas e moedas."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "A súa conta"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Idioma"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formatos"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Pantalla de inicio de sesión"
 
@@ -6166,100 +3265,9 @@ msgstr "Rexión e idioma"
 msgid "Select your display language and formats"
 msgstr "Seleccione o idioma en pantalla e formatos"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma:Distribución;Teclado;Entrada;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Preguntar que facer"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Non facer nada"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Abrir cartafol"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Outros soportes"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Seleccione unha aplicación para os CD de son"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Seleccione unha aplicación para os DVD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Seleccione a aplicación a executar cando se conecta un reprodutor de música"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Seleccione a aplicación a executar cando se conecta unha cámara"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Seleccione a aplicación para os CD de software"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD de son"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "disco Blu-ray virxe"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "disco CD virxe"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "disco DVD virxe"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "disco HD DVD virxe"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Disco Blu-ray de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "lector de libros electrónicos"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Disco HD DVD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "CD de imaxes"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Vídeo CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Vídeo CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Software de Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6309,7 +3317,6 @@ msgstr "Soportes extraíbeis"
 msgid "Configure Removable Media settings"
 msgstr "Configurar as preferencias de soportes extraíbeis"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6317,114 +3324,6 @@ msgid ""
 msgstr ""
 "dispositivo;sistema;predeterminado;aplicación;fallback;alternativo;preferido;"
 "cd;dvd;usb;son;video;disco;extraíbel;medio;autoexecutar;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "A pantalla apágase"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 segundos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nunca"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6464,11 +3363,16 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "Mostrar _notificacións na pantalla de bloqueo"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Notificacións na pantalla de b_loqueo"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Prohibir usar dispositivos _USB novos"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6476,30 +3380,25 @@ msgstr ""
 "Prohibir aos dispositivos USB novos interactuar co sistema cando a pantalla "
 "está bloqueada."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Privacidade de pantalla"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Restrinxir o ángulo de visualización"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantalla"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Preferencias da pantalla"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "pantalla;bloqueo;privado;privacidade"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Seleccionar localización"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Aceptar"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6530,10 +3429,6 @@ msgstr "Outros"
 msgid "Add Location"
 msgstr "Engadir localización"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Non se atoparon aplicacións"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Busca de aplicacións"
@@ -6560,93 +3455,13 @@ msgid ""
 msgstr ""
 "Controle que aplicacións mostran resultados de busca na Vista de actividades"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Buscar;Atopar;Índice;Oculto;Privacidade;Resultados;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Non hai ningunha rede seleccionada para compartir"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Redes"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Activado"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Desactivado"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Activado"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Activo"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Seleccione un cartafol"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Engadir"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Activar a compartición multimedia"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Compartir ficheiros permítelle compartir o seu cartafol Público con outros "
-"na súa rede actual usando: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Cando está activado o acceso remoto, os usuarios remotos poden conectarse "
-"usando a orde de Shell segura: \n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Activar a compartición multimedia personal"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Nome do dispositivo copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Enderezo do dispositivo copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Nome de usuario copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Contrasinal copiado"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6788,7 +3603,6 @@ msgstr "Controle que quere compartir con outros"
 #
 # Rutas:
 # panels/sharing/gnome-sharing-panel.desktop.in.in:16
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6805,10 +3619,6 @@ msgstr "Activar ou desactivar o inicio de sesión remoto"
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Requírese autenticación para activar ou desactivar o inicio de sesión remoto"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Personalizado"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6841,11 +3651,6 @@ msgstr "Atrás"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Adiante"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Probando %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6899,11 +3704,6 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Son de alerta"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Silenciar"
@@ -6916,81 +3716,10 @@ msgstr "Son"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Cambie os niveles de volume, entradas, saídas e sons de alerta"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr "Tarxeta;Micrófono;Volume;Esvaecer;Balance;Bluetooth;Auriculares;Son;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Desconectado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Conectando"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Conectado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Erro de autenticación"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autorizando"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Reducindo funcionalidade"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Conectado e autorizado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Descoñecido"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autorizado o:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Conectado a:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Rexistrado o:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Produciuse un erro ao autorizar o dispositivo: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Produciuse un fallo ao esquecer o dispositivo: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7024,55 +3753,6 @@ msgstr "Autorizar e conectar"
 msgid "Forget Device"
 msgstr "Esquecer dispositivo"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Erro"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorizado"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"O subsistema Thunderbolt (boltd) non está instalado ou non está configurado "
-"correctamente."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Permitir o acceso directo a dispositivos como docas ou GPU externas."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Só se poden anexar dispositivos USB e Display Port."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Non foi posíbel detectar o Thunderbolt.\n"
-"Ou ben o sistema carece de compatibilidade con Thunderbolt, foi desactivado "
-"na BIOS ou está configurado na BIOS nun nivel de seguranza incompatíbel."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "A compatibilidade con Thunderbolt foi desactivada no BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Non é posíbel determinar o nivel de seguranza de Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Produciuse un erro ao cambiar ao modo directo: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Non hai compatibilidade con Thunderbolt"
@@ -7084,6 +3764,10 @@ msgstr "Non foi posíbel conectarse ao subsistema de Thunderbolt"
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Acceso directo"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Permitir o acceso directo a dispositivos como docas ou GPU externas."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7101,7 +3785,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Xestionar dispositivos Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacidade;"
@@ -7304,40 +3987,6 @@ msgstr "_Activar co teclado"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Activar as características de accesibilidade desde o teclado"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Predeterminado"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Medio"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Grande"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Máis grande"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "O máis grande"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d píxel"
-msgstr[1] "%d píxeles"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Mostrar _sempre o menú de Acceso Universal"
@@ -7451,31 +4100,6 @@ msgstr "Escintilar toda a _pantalla"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Escintilar toda a _xanela"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Curta"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ da pantalla"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ da pantalla"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ da pantalla"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Longa"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7632,7 +4256,6 @@ msgstr "Efectos de cor"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Faga máis doado ver, escoitar, escribir, apuntar e clicar"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7644,114 +4267,6 @@ msgstr ""
 "pantalla;texto;tipo de letra;tamaño;AccessX;Persistente;Lenta;Rexeite;Rato;"
 "Dobre;clic;atraso;velocidade;asistencia;Repetición;Pestanexo;visión;audición;"
 "son;escrita;escoita;son;audio;animacións;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 día"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 días"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 días"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Desexa baleirar todos os elementos do lixo?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Pérdese permanentemente todos os elementos do lixo."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Baleirar o lixo"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Desexa eliminar todos os ficheiros temporais?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Todos os ficheiros temporais eliminaranse de forma permanente."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Eliminar os ficheiros temporais"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 día"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 días"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 días"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Para sempre"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7820,64 +4335,12 @@ msgstr "Historial de ficheiros e lixo"
 msgid "Don't leave traces"
 msgstr "Non deixar rastro"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "uso;recente;historial;ficheiros;temporais;tmp;privado;privacidade;lixo;"
 "purgar;reter;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Debería coincidir co enderezo web do seu fornecedor de conta."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Produciuse un erro ao engadir a conta"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Os contrasinais non coinciden."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Produciuse un erro ao rexistrar a conta"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Non hai unha maneira admitida de autenticar con este dominio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Produciuse un erro ao unirse ao dominio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Ese nome de inicio de sesión non funcionou.\n"
-"Ténteo de novo."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Ese contrasinal de inicio de sesión non funcionou.\n"
-"Ténteo de novo."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Produciuse un erro ao iniciar sesión no dominio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Non foi posíbel atopar o dominio. Pode ser que o escribira mal?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7931,10 +4394,6 @@ msgstr ""
 "O inicio de sesión corporativo permítelle xestionar unha conta de usuario "
 "xestionada de forma centralizada para usala neste dispositivo. Tamén pode "
 "usar esta conta para acceder a recursos corporativos en internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Explorar para buscar máis imaxes"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8005,222 +4464,6 @@ msgstr "_Eliminar pegadas dixitais"
 msgid "Fingerprint Enroll"
 msgstr "Rexistrar pegada dixital"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "para levar a cabo esta acción precisa reclamar o dispositivo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "O dispositivo xa está reclamado por outro proceso"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "non ten permiso para levar a cabo a acción"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "non se rexistraron impresións"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Produciuse un fallo na comunicación co dispositivo durante o rexistro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Produciuse un fallo ao comunicarse co lector de pegadas dixitais"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Produciuse un fallo ao comunicarse co «daemon» de pegada dixital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Produciuse un erro ao listar as pegadas dixitais: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Produciuse un erro ao eliminar as pegadas dixitais gardadas: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Dedo gordo esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Dedo corazón esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Dedo índice _esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Dedo anular esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Dedo maimiño esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Dedo gordo dereito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Dedo corazón dereito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Dedo índice dereito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Dedo anular dereito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Dedo maimiño dereito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Dedo descoñecido"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Completado"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Dispositivo de pegada dixital desconectado"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "O almacenamento do dispositivo de pegada dixital está cheo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Produciuse un erro ao rexistrar unha nova pegada dixital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Produciuse un erro ao iniciar o rexistro: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Produciuse un erro ao rexistrar unha nova pegada dixital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Produciuse un erro ao deter o rexistro: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Levante e poña o seu dedo varias veces sobre o lector para rexistrar a súa "
-"pegada dixital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Volver a rexistrar este dedo…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Analizar nova pegada dixital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Produciuse un fallo ao liberar o dispositivo de pegada dixital %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problema ao ler o dispositivo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Produciuse un fallo ao reclamar o dispositivo de pegada dixital %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Produciuse un fallo ao obter os dispositivos de pegada dixital: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Esta semana"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Última semana"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e de %b de %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sesión rematada"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sesión iniciada"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Actividade da conta"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Anterior"
@@ -8228,18 +4471,6 @@ msgstr "Anterior"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Seguinte"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Seleccione outro contrasinal."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Escriba o seu contrasinal actual de novo."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Non foi posíbel cambiar o contrasinal"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8261,6 +4492,10 @@ msgstr "Contrasinal novo"
 msgid "Confirm Password"
 msgstr "Confirmar contrasinal"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Os contrasinais non coinciden."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
@@ -8269,134 +4504,6 @@ msgstr ""
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Estabelecer un contrasinal agora"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Non é posíbel unirse automaticamente a este tipo de dominio"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Non existe o dominio ou non se atopou o reino"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Non é posíbel iniciar sesión como %s no dominio %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Contrasinal incorrecto, ténteo de novo"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Non foi posíbel conectarse ao dominio %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Produciuse un erro ao eliminar o usuario"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Produciuse un fallo ao revocar o usuario xestionado remotamente"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Non pode eliminar a súa propia conta."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s aínda ten a sesión iniciada"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Se elimina un usuario mentres ten a sesión iniciada pode poñer deixar o "
-"sistema nun estado inconsistente."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Desexa manter os ficheiros de %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"É posíbel manter o cartafol persoal, a caixa de correo e os ficheiros "
-"temporais ao eliminar unha conta de usuario."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Eliminar os ficheiros"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Manter os ficheiros"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Ten certeza que quere revocar a conta de %s xestionada remotamente?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Eliminar"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Conta desactivada"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Para configurar no seguinte inicio de sesión"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ningún"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Conectado"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Produciuse un erro ao contactar co servizo de contas"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Asegúrese de que o servizo de contas está instalado e activado."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Este panel debe desbloquearse para cambiar esta configuración"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Eliminar a conta de usuario seleccionada"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Para eliminar a conta de usuario seleccionada,\n"
-"primeiro prema na icona *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Desbloquear para engadir usuarios e cambiar as preferencias"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8424,7 +4531,6 @@ msgid "Full name"
 msgstr "Nome completo"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Editar"
 
@@ -8486,7 +4592,6 @@ msgstr "Desbloquear para engadir unha conta de usuario."
 msgid "Add or remove users and change your password"
 msgstr "Engadir ou quitar usuarios e cambiar os seus contrasinais"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8531,178 +4636,6 @@ msgstr "Xestionar contas de usuario"
 msgid "Authentication is required to change user data"
 msgstr "Requírese autenticación para cambiar os datos do usuario"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "O novo contrasinal debe ser distinto do antigo."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Tente cambiar algunhas letras e números."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Tente cambiar o contrasinal un pouco máis."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Un contrasinal sen o seu nome de usuario pode ser máis forte."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Tente evitar o uso do seu nome no contrasinal."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Tente evitar algunhas das palabras que inclúe o seu contrasinal."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Tente evitar palabras comúns."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Tente evitar a reordenación de palabras."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Tente usar máis números."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Tente usar máis letras en maiúsculas."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Tente usar máis letras en minúsculas."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Tente usar máis caracteres especiais, como signos de puntuacións."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Tente usar unha mestura de letras, números e signos de puntuación."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Tente evitar a repetición do mesmo carácter."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Tente evitar a repetición do mesmo tipo de carácter: debe formar unha "
-"mestura de letras, números e signos de puntuación."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Tente evitar secuencias como 1234 ou abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"O contrasinal debe ser máis largo. Tente usar unha mestura de letras, "
-"números e signos de puntuación."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Mesture letras en maiúsculas e minúsculas  e use un número ou dous."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Se engade máis letras, números e signos de puntuación fará o contrasinal "
-"máis forte."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Fallou a autenticación"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "O novo contrasinal é demasiado curto"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "O novo contrasinal é demasiado simple"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "O contrasinal novo e antigo son demasiado similares"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "O novo contrasinal xa foi usado recentemente."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "O novo contrasinal debe conter caracteres numéricos ou especiais"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "O contrasinal novo e o antigo son o mesmo"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "O seu contrasinal cambiou desde que iniciou a sesión inicialmente!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "O novo contrasinal non contén suficientes caracteres diferentes"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Erro descoñecido"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"O nome de usuario debe estar formado por letras en maiúsculas desde o «a» ao "
-"«z», díxitos, e o caracteres: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Desculpe, o nome de usuario non está dispoñíbel. Probe outro."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "O nome de usuario é demasiado longo."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8737,52 +4670,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Pulsación errónea detectada, reiniciando…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Botón %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplicación definida"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Enviar pulsación de tecla"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Cambiar monitor"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Mostrar axuda en pantalla"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tableta montada no panel do portátil"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tableta montada na pantalla externa"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Dispositivo de tableta externa"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Dispositivo de tableta externa"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Todas as pantallas"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8880,22 +4771,6 @@ msgstr "Pulsación do botón do medio do rato"
 msgid "Forward"
 msgstr "Adiante"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Lapis aerógrafo con presióbn, inclinación e desprazador integrado"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Lapis aerógrafo con presión, inclinación e rotación"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Lapis estándar con presión e inclinación"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Lapis estándar con presión"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tableta Wacom"
@@ -8906,54 +4781,96 @@ msgstr ""
 "Estabeleza a asignación de botóns e axuste a sensibilidade do seu bolígrafo "
 "dixital nas tabletas gráficas"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tableta;Wacom;Stylus;Borrador;Rato;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Novo atallo…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Clic secundario _simulado"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Software de Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Tóner baixo"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Retardo da pulsación secundaria"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Software de Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Xestionar as preferencias para a productividade e multitarefa"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Puntos de acceso"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Engadir"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Gardar"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operación cancelada"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Error:</b> Acceso denegado ao cambiar as preferencias"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Erro:</b> Erro no equipamento móbil"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Non rexistrado"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Rexistrado"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Buscando"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Denegado"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8983,212 +4900,13 @@ msgstr "Número propio"
 msgid "Device Details"
 msgstr "Detalles do dispositivo"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricante"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Versión do firmware"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Só 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Só 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Só 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Só 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (Prefirido)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (Prefirido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (Prefirido), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (Prefirido), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Preferido), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Preferido), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (Preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (Preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (Preferido), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (Prefirido)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (Prefirido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (Prefirido), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (Prefirido)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (Prefirido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (Prefirido), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (Preferido), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (Preferido), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (Preferido), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (Prefirido)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (Prefirido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (Preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (Preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (Preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (Preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Descoñecido"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Desbloquear a tarxeta SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Desbloquear"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Forneza un código PIN para a SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Escriba o PIN para desbloquear a súa tarxeta SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Forneza o código PUK para a tarxeta SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Escriba o código PUK para desbloquear a súa tarxeta SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9203,26 +4921,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Ten %1$u intento máis"
 msgstr[1] "Ten %1$u intentos máis"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Escribiu un contrasinal incorrecto."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "O código PUK debe ser un número de cando menos 8 díxitos"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Escriba o novo PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "O código PIN debe ser un número de 4 a 8 díxitos"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Desbloqueando…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9280,94 +4978,6 @@ msgstr "Bloquear SIM con un PIN"
 msgid "M_odem Details"
 msgstr "Detalles do mód_em"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Produciuse un fallo no teléfono"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Non hai conexión co teléfono"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operación non permitida"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operación non admitida"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM non inserida"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Requírese o PIN da SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Requírese o PUK da SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Fallo na SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM ocupada"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Contrasinal incorrecto"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Requírese o PIN2 da SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Requírese o PUK2 da SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Non atopado"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Non hai servizo de rede"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Tempo de espera de rede superado"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Non se permiten os servizos GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "O Roaming non está permitido nesta área de localización"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Produciuse un erro de GPRS non especificado"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Non hai erro"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Acción cancelada"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Acceso denegado"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Erro descoñecido"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Modo de rede"
@@ -9383,11 +4993,6 @@ msgstr "Seleccionar rede"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Actualizar os fornecedores de rede"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9446,7 +5051,6 @@ msgstr "Rede móbil"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configurar as conexións de telefonía e datos móbiles"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "celular;wwan;telefonía;sim;móbil;"
@@ -9463,41 +5067,13 @@ msgstr "Preferencias é a interface principal para configurar o seu sistema."
 msgid "The GNOME Project"
 msgstr "O proxecto GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Mostrar o número de versión"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Activar o modo detallado"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Buscar unha cadea"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Listar posíbeis nomes de paneis e saír"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel a mostrar"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENTO…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Categorías do sistema"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacidade"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Paneis dispoñíbeis:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9555,7 +5131,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Cancelar a busca"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferencias;Configuración;"
@@ -9597,8 +5172,6 @@ msgstr ""
 "Unha tupla que contén a anchura, altura e estado maximizado iniciais da "
 "xanela da aplicación."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9606,8 +5179,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u saída"
 msgstr[1] "%u saídas"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9615,9 +5186,3133 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u entrada"
 msgstr[1] "%u entradas"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sons do sistema"
+#~ msgid "System Bus"
+#~ msgstr "Bus do sistema"
+
+#~ msgid "Full access"
+#~ msgstr "Acceso completo"
+
+#~ msgid "Session Bus"
+#~ msgstr "Bus de sesión"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Acceso completo a /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Ten acceso á rede"
+
+#~ msgid "Home"
+#~ msgstr "Cartafol persoal"
+
+#~ msgid "Read-only"
+#~ msgstr "Só lectura"
+
+#~ msgid "File System"
+#~ msgstr "Sistema de ficheiros"
+
+#~ msgid "Can change settings"
+#~ msgstr "Pode cambiar preferencias"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s ten os seguintes permisos, que non se poden cambiar. Se está "
+#~ "preocupado por estes permisos, considere eliminar esta aplicación."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u ficheiro e tipo de ligazón que está aberta pola aplicación"
+#~ msgstr[1] "%u ficheiros e tipos de ligazón que está aberta pola aplicación"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> úsase para abrir os tipos de ficheiros e ligazóns seguintes."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s do espazo de disco usado."
+
+#~ msgid "Select a picture"
+#~ msgstr "Seleccione unha imaxe"
+
+#~ msgid "_Open"
+#~ msgstr "_Abrir"
+
+#~ msgid "multiple sizes"
+#~ msgstr "tamaños múltiples"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Sen fondo de escritorio"
+
+#~ msgid "Current background"
+#~ msgstr "Fondo actual"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Poña o dispositivo de calibración no cadrado e prema «Comezar»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Mova o dispositivo de calibración á posición de calibrado e prema "
+#~ "«Continuar»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Mova o dispositivo de calibración á posición da superficie e prema "
+#~ "«Continuar»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Pechar a tapa do portátil"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Produciuse un erro interno que non pode recuperarse."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "As ferramentas requiridas para o calibrado non están instaladas."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Non foi posíbel xerar o perfil."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Non foi posíbel obter o punto branco obxectivo."
+
+#~ msgid "Complete!"
+#~ msgstr "Completado!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Calibrado fallado!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Pode quitar o dispositivo de calibrado."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Non moleste o dispositivo de calibrado mentres está traballando"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Pantalla do portátil"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Cámara web integrada"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Escáner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Cámara %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Impresora %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Cámara web %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Activar a xestión de cor para %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Mostrar os perfiles de cor para %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Non calibrado"
+
+#~ msgid "Default: "
+#~ msgstr "Predeterminado: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Espazo de cor: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Perfil de proba: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Seleccionar ficheiro de perfil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importar"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Perfiles ICC admitidos"
+
+#~ msgid "All files"
+#~ msgstr "Todos os ficheiros"
+
+#~ msgid "Save Profile"
+#~ msgstr "Gardar perfil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Crear un perfil de cor para o dispositivo seleccionado"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Non se detectou o instrumento de medida. Comprobe que está acendido e "
+#~ "correctamente conectado."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "O instrumento de medida non admite perfilado de impresoras."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "O tipo de dispositivo non é compatíbel actualmente."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espazo estándar"
+
+#~ msgid "Test Profile"
+#~ msgstr "Perfil de proba"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automático"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Calidade baixa"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Calidade media"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Calidade alta"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB predeterminado"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK predeterminado"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Gris predeterminado"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Datos de calibrado de fábrica fornecidos polo fabricante"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "A corrección de pantalla a pantalla completa non é posíbel con este perfil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Este perfil podería non ser preciso"
+
+#~ msgid "Other…"
+#~ msgstr "Outro…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Desbloquear para cambiar as preferencias"
+
+#~ msgid "Today"
+#~ msgstr "Hoxe"
+
+#~ msgid "Yesterday"
+#~ msgstr "Onte"
+
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b de %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d hora"
+#~ msgstr[1] "%d horas"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuto"
+#~ msgstr[1] "%d minutos"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d segundos"
+#~ msgstr[1] "%d segundos"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24 horas"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Ao enviar informes de problemas técnicos axudaranos a mellorar %s. Os "
+#~ "informes envíanse de forma anónima e límpanse de datos persoais. %s"
+
+#~ msgid "On"
+#~ msgstr "Activado"
+
+#~ msgid "Off"
+#~ msgstr "Desactivado"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Desexa aplicar os cambios?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Os cambios non se poden aplicar"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Isto pode ser por limitacións do hardware."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Horizontal"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Vertical dereita"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Vertical esquerda"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Horizontal (volteado)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Secure Boot está activo"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Secure Boot prevén que software malicioso se cargue cando arranca o seu "
+#~ "dispositivo. Actualmente está activo e funcionando correctamente."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Secure Boot ten problemas"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Secure Boot prevén que software malicioso se cargue cando arranca o seu "
+#~ "dispositivo. Actualmente está activo, pero non funciona debido a que ten "
+#~ "unha chave non válida."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Os problemas de Secure Boot poden normalmente resolverse desde as "
+#~ "preferencias do firmware UEFI do seu computador (BIOS), o fabricante do "
+#~ "seu hardware podería ofrecer información sobre como facer isto."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Para obter axuda, contacte co fabricante do seu hardware ou o seu "
+#~ "fornecedor de asistencia tecnolóxica."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Secure Boot está desactivado"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Secure boot evita que software malicioso sexa cargado cando o dispositivo "
+#~ "empeza. Actualmente está desactivado."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Secure boot pode ser activado polas preferencias do firmware UEFI do seu "
+#~ "computador (BIOS). Para obter axuda, contacte co fabricante do seu "
+#~ "hardware ou o seu fornecedor de soporte técnico."
+
+#~ msgid "Passed"
+#~ msgstr "Pasado"
+
+#~ msgid "Failed"
+#~ msgstr "Falla"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "O dispositivo cumple co nivel HSI %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Nivel de seguranza 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Este dispositivo non ten protección fronte a problemas de seguranza de "
+#~ "hardware. Isto pode deberse a un problema na configuración do firmware. "
+#~ "Recoméndamoslle contactar co seu fornecedor de soporte técnico"
+
+#~ msgid "Security Level 1"
+#~ msgstr "Nivel de seguranza 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Este dispositivo ten protección mínima fronte a problemas de seguranza de "
+#~ "hardware. Este é o nivel de seguranza de dispositivo máis baixo e só "
+#~ "fornece protección fronte a ameazas de seguranza simples."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Nivel de seguranza 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Este dispositivo ten protección básica fronte a problemas de seguranza de "
+#~ "hardware. Isto fornece protección fronte a amezas de seguranza comúns."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Nivel de seguranza 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Este dispositivo ten protección estendida fronte a problemas de seguranza "
+#~ "de hardware. Este é o nivel de seguranza de dispositivo máis alto e "
+#~ "fornece protección fronte a ameazas de seguranza avanzados."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Os niveis de seguranza non están dispoñíbeis para este dispositivo."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Contacte co seu fabricante de hardware para obter axuda coas "
+#~ "actualizacións de seguranza."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Podería ser posíbel resolver este problema nas preferencias do firmware "
+#~ "UEFI do dispositivo, ou por un técnico de asistencia técnica."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Podería ser posíbel resolver este problema nas preferencias do firmware "
+#~ "UEFI do dispositivo."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Podería ser posíbel que un técnico de soporte resolva este problema."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Protección fronte a software malicioso cando o dispositivo arrinca."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Secure Boot ten problemas"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Algunha protección cando se inicia o dispositivo."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Secure Boot está desactivado"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Sen protección cando se inicia o dispositivo."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Este problema puido ser causado por un cambio na configuración do "
+#~ "firmware UEFI, un cambio na configuración do sistema operativo ou por un "
+#~ "software malicioso neste sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Este problema puido ser causado por un cambio na configuración do "
+#~ "firmware UEFI ou por un software malicioso neste sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Este problema puido ser causado por un cambio na configuración do sistema "
+#~ "operativo ou por un software malicioso neste sistema."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Altamente exposto ás ameazas de seguranza."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Protección limitada contra ameazas simples de seguranza."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Protexido contra ameazas de seguranza comúns."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Protexido contra unha ampla gama de ameazas de seguranza."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Protección integral"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Protección contra escritura de firmware"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Bloqueo de protección contra escritura de firmware"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Rexión da BIOS do firmware"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Descriptor de BIOS de firmware"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Protección DMA previa al arranque"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Arrinque verificado de Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "ACM protexida de Intel BootGuard"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Normativa de erro de Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Fusíbel de Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET activado"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET activo"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "RAM cifrada"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Protección IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Bloqueo do núcleo de Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Verificación do núcleo de Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Suspender á RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Suspender a inactivo"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Chave de plataforma UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Secure Boot UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Configuración da plataforma TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Reconstrucción TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Modo de fabricación do motor de xestión de Intel"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Anulación do motor de xestión de Intel"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Versión do motor de xestión de Intel"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Actualizacións de firmware"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Certificación de firmware"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Verificación do actualizador do firmware"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Depuración da plataforma"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Comprobacións de seguranza do procesador"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Protección de rollback de AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Protección de reprodución do firmware de AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Protección de escrita do firmware de AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Plataforma Fused"
+
+#~ msgid "Valid"
+#~ msgstr "Válido"
+
+#~ msgid "Not Valid"
+#~ msgstr "Non válido"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Activado"
+
+#~ msgid "Locked"
+#~ msgstr "Bloqueado"
+
+#~ msgid "Not Locked"
+#~ msgstr "Non bloqueado"
+
+#~ msgid "Encrypted"
+#~ msgstr "Cifrado"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Non cifrado"
+
+#~ msgid "Tainted"
+#~ msgstr "Corrompido"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Non corrompido"
+
+#~ msgid "Found"
+#~ msgstr "Atopado"
+
+#~ msgid "Not Found"
+#~ msgstr "Non atopado"
+
+#~ msgid "Supported"
+#~ msgstr "Compatíbel"
+
+#~ msgid "Not Supported"
+#~ msgstr "Non é compatíbel"
+
+#~ msgid "Unknown"
+#~ msgstr "Descoñecido"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Descoñecido"
+
+#~ msgid "Not Available"
+#~ msgstr "Non dispoñíbel"
+
+#~ msgid "System Logo"
+#~ msgstr "Logotipo do sistema"
+
+#~ msgid "No input sources found"
+#~ msgstr "Non se atopou ningunha orixe de entrada"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Outra"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Personalizar os atallos"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "A tecla de trocar caracteres poden usarse para escribir caracteres "
+#~ "adicionais. A veces imprímense como unha terceira opción no seu teclado."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt esquerda"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt dereito"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super esquerda"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super dereita"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tecla de menú"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl dereito"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "A tecla de composición permítelle escribir unha ampla variedade de "
+#~ "caracteres. Para usala, prema a tecla e logo escriba a secuencia dos "
+#~ "caracteres. Por exemplo, tecla de composición seguida por <b>C</b> e "
+#~ "<b>o</b> escribirá <b>©</b>, <b>a</b> seguida por <b>'</b> escribirá "
+#~ "<b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Bloqueo de Maiúsculas"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Imprimir pantalla"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "As orixes de pantalla poden cambiarse usando o atallo de teclado %s.\n"
+#~ "Estes atallos de teclado poden cambiarse nas preferencias de atallos de "
+#~ "teclado."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificado"
+#~ msgstr[1] "%d modificados"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Desexa restabelecer todos os atallos?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Ao restabelecer os atallos pode afectar aos atallos personalizados. Isto "
+#~ "non se pode desfacer."
+
+#~ msgid "Reset All"
+#~ msgstr "Restabelecer todo"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s xa está sendo usado para %s. Se o substitúe, %s desactivarase"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Escriba o novo atallo"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Estabelecer atallo personalizado"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Estabelecer atallo"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Escriba o novo atallo para cambiar %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Engadir atallo personalizado"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Desprazamento con dous dedos"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinco clics, tempo de GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dobre clic, botón primario"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Un clic, botón primario"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dobre clic, botón do medio"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Un clic, botón do medio"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dobre clic, botón secundario"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Un clic, botón secundario"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Requírese que NetworkManager estea en execución."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Rede non segura (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Rede segura (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Rede segura (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Rede segura (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Rede segura"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Activar o punto de acceso desconectarao de %s, non será posíbel acceder a "
+#~ "internet mediante o Wifi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Debe ter cando menos 8 caracteres"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Desexa deter o «hotspot» e desconectar aos usuarios?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Deter «hotspot»"
+
+#~ msgid "Preserve"
+#~ msgstr "Preservar"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanente"
+
+#~ msgid "Random"
+#~ msgstr "Aleatorio"
+
+#~ msgid "Stable"
+#~ msgstr "Estábel"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "O enderezo MAC escribo aquí usarase como o enderezo hardware para o "
+#~ "dispositivo de rede para esta conexión. Esta característica é coñecida "
+#~ "como clonado ou spoofing de MAC. Exemplo: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Perfil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Apertura mellorada"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Empresarial"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ningunha"
+
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)Rede segura (WPA)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Ningunha"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Débil"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Aceptábel"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Boa"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excelente"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Esquecer conexión"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Eliminar o perfil de conexión"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Eliminar VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detalles"
+
+#~ msgid "automatic"
+#~ msgstr "automático"
+
+#~ msgid "Identity"
+#~ msgstr "Identidade"
+
+#~ msgid "Delete Address"
+#~ msgstr "Eliminar enderezo"
+
+#~ msgid "Delete Route"
+#~ msgstr "Quitar ruta"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ningunha"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Chave WEP de 40/128 bits (Hexadecimal ou ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Frase de paso WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinámica (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Persoal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Empresarial"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Persoal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Non foi posíbel abrir o editor de conexións"
+
+#~ msgid "New Profile"
+#~ msgstr "Novo perfil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Preferencia %s non válida: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Preferencia %s non válida"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importar desde ficheiro…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Engadir VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Non foi posíbel importar a conexión VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Non foi posíbel ler o ficheiro '%s' ou non contén información de conexión "
+#~ "VPN recoñecíbel\n"
+#~ "\n"
+#~ "Erro: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Seleccione o ficheiro para importar"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Xa existe un ficheiro chamado «%s\"."
+
+#~ msgid "_Replace"
+#~ msgstr "S_ubstituír"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Quere substituír %s coa conexión VPN que está gardando?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Non é posíbel exportar a conexión VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Non foi posíbel exportar a conexión VPN «%s» a %s.\n"
+#~ "\n"
+#~ "Erro: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportar conexión VPN"
+
+#~ msgid "never"
+#~ msgstr "nunca"
+
+#~ msgid "today"
+#~ msgstr "hoxe"
+
+#~ msgid "yesterday"
+#~ msgstr "onte"
+
+#~ msgid "Last used"
+#~ msgstr "Última vez usada"
+
+#~ msgid "Add new connection"
+#~ msgstr "Engadir nova conexión"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Perderase a información das redes seleccionadas, incluíndo os "
+#~ "contrasinais e calquera configuración personalizada."
+
+#~ msgid "_Forget"
+#~ msgstr "_Esquecer"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Redes Wifi coñecidas"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Esquecer"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "A normativa do sistema prohibe o uso un «Hotspot»"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "O dispositivo Wireless non é compatíbel co modo «Hotspot»"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "O autodescubrimento do proxy web úsase cando non se fornece unha URL de "
+#~ "configuración."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Non se recomenda para redes públicas nas que non se confía."
+
+#~ msgid "Status unknown"
+#~ msgstr "Estado descoñecido"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Sen xestionar"
+
+#~ msgid "Unavailable"
+#~ msgstr "Non dispoñíbel"
+
+#~ msgid "Connecting"
+#~ msgstr "Conectando"
+
+#~ msgid "Authentication required"
+#~ msgstr "Requírese autenticación"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Desconectado"
+
+#~ msgid "Connection failed"
+#~ msgstr "A conexión fallou"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Estado descoñecido (ausente)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Fallou a configuración"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Fallou a configuración IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "A configuración IP expirou"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Precísanse segredos, pero non se forneceron"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Suplicante de 802.1x desconectado"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Fallou a configuración do suplicante de 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Fallou o suplicante de 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "O suplicante de 802.1x tardou moito tempo en autenticarse"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Produciuse un erro ao iniciar o servizo de PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Servizo PPP desconectado"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP fallou"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Produciuse un erro ao iniciar o cliente DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Erro no cliente DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "O cliente DHCP fallou"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Produciuse un erro ao iniciar o servizo de conexión compartida"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "O servizo de conexión compartida fallou"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Produciuse un erro ao iniciar o servizo AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Erro no servizo AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "O servizo AutoIP fallou"
+
+#~ msgid "Line busy"
+#~ msgstr "Liña ocupada"
+
+#~ msgid "No dial tone"
+#~ msgstr "Non hai ton de chamada"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Non foi posíbel estabelecer o «carrier»"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Expirou o tempo de solicitude de chamada"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Intento de chamada fallado"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Fallou a inicialización do módem"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Produciuse un erro ao seleccionar o APN especificado"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Non se están buscando redes"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Rexistro da rede rexeitado"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "O rexistro na rede superou o tempo de espera"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Produciuse un erro ao rexistrarse na rede solicitada"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Produciuse un fallo na comprobación do PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "É posíbel que falte o firmware do dispositivo"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "A conexión desapareceu"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Asumiuse unha conexión existente"
+
+#~ msgid "Modem not found"
+#~ msgstr "Módem non atopado"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Fallou a conexión Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Tarxeta SIM non inserida"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Requírese o PIN da SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Requírese o PUK da SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM errónea"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Fallou a dependencia da conexión"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Falta o «firmware»"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cable desconectado"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "erro non definido na seguranza 802.1x (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "non se seleccionou un ficheiro"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "erro non especificado ao validar o ficheiro eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, DEM, PKCS#12 ou chaves privadas PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certificados DER ou PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "falta o ficheiro EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Ficheiros PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "falta o nome de usuario EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "falta o contrasinal EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "certificado EAP-PEAP da CA non válido: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "certificado EAP-PEAP da CA non válido: certificado non especificado"
+
+#~ msgid "missing EAP username"
+#~ msgstr "falta o nome de usuario EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "falta o contrasinal EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "falta a identidade EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "certificado EAP-TLS da CA non válido: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "certificado EAP-TLS da CA non válido: certificado non especificado"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "chave privada EAP-TLS non válida: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificado de usuario EAP-TLS non válido: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "As chaves privadas sen cifrar son inseguras"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "A chave privada seleccionada non parece estar protexida por un "
+#~ "contrasinal. Isto podería permitir que as súas credenciais de seguranza "
+#~ "se comprometesen. Seleccione unha chave privada protexida por "
+#~ "contrasinal.\n"
+#~ "\n"
+#~ "(Pode protexer a súa chave privada con un contrasinal con openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Seleccione o seu certificado persoal"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Seleccione a súa chave privada"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "certificado EAP-TTLS da CA non válido: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "certificado EAP-TTLS da CA non válido: certificado non especificado"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Produciuse un erro descoñecido ao validar a seguranza 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Seleccionar un ficheiro"
+
+#~ msgid "missing leap-username"
+#~ msgstr "falta o usuario leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "falta o contrasinal leap"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Falta o contrasinal do Wifi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "falta a chave wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "falta a chave wep: a chave con unha lonxitude %zu debe conter só díxitos "
+#~ "hexadecimais"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "falta a chave wep: a chave con unha lonxitude %zu debe conter só díxitos "
+#~ "ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "chave wep non válida: lonxitude %zu da chave non válida. A chave debe ter "
+#~ "unha lonxitude 5/13 (ascii) ou 10/26 (hexadecimal)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "chave wep non válida: a frase de paso non debe estar baleira"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "chave wep non válida: a frase de paso debe ser máis curta que 64 "
+#~ "caracteres"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk non válido: a lonxitude de chave %zu non é valida. Debe ser "
+#~ "[8,63] bytes ou 64 díxitos hexadecimais"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk non válido: non se pode interpretar a chave con 64 bytes como "
+#~ "hexadecimais"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Outra"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s eliminada"
+
+#~ msgid "Error removing account"
+#~ msgstr "Produciuse un erro ao quitar a conta"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Conta de %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Retirar conta"
+
+#~ msgid "Unknown time"
+#~ msgstr "Hora descoñecida"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s ate estar cargado completamente"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Precaución: %s restante"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s restante"
+
+#~ msgid "Fully charged"
+#~ msgstr "Cargada completamente"
+
+#~ msgid "Not charging"
+#~ msgstr "Non cargando"
+
+#~ msgid "Empty"
+#~ msgstr "Baleira"
+
+#~ msgid "Charging"
+#~ msgstr "Cargando"
+
+#~ msgid "Discharging"
+#~ msgstr "Descargándose"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Rato sen fíos"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Teclado sen fíos"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Fonte de alimentación non interrompíbel"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Asistente persoal dixital"
+
+#~ msgid "Cellphone"
+#~ msgstr "Teléfono móbil"
+
+#~ msgid "Media player"
+#~ msgstr "Reprodutor de música"
+
+#~ msgid "Tablet"
+#~ msgstr "Tableta"
+
+#~ msgid "Computer"
+#~ msgstr "Computador"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Dispositivo de entrada de xogos"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principal"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Adicional"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterías"
+
+#~ msgid "When _idle"
+#~ msgstr "Ao estar _inactivo"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspender"
+
+#~ msgid "Power Off"
+#~ msgstr "Apagar"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernar"
+
+#~ msgid "Nothing"
+#~ msgstr "Non facer nada"
+
+#~ msgid "When on battery power"
+#~ msgstr "Ao usar enerxía da batería"
+
+#~ msgid "When plugged in"
+#~ msgstr "Ao estar enchufado"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Suspensión automática"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Modo de rendemento desactivado temporalmente debido á temperatura de "
+#~ "operación alta."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Colo detectado: o modo de rendemento está desactivado temporalmente. Mova "
+#~ "o dispositivo a unha superficie estábel para restaurar."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Modo de rendemento temporalmente non dispoñíbel."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Batería baixa: aforro de enerxía activado. O anterior modo "
+#~ "restabelecerase cando a batería estea suficientemente cargada."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Modo de aforro de enerxía activado por «%s»."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Modo de rendemento activado por «%s»"
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Rendemento"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Rendemento e uso de enerxía altos."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Balanceado"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Rendemento e uso de enerxía estándar."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Aforro de enerxí­a"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Rendemento e uso de enerxía reducidos."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Eliminouse a impresora «%s»"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Produciuse un erro ao engadir unha nova impresora."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Non foi posíbel cargar a IU: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Desbloquear para engadir impresoras e cambiar as preferencias"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detalles de %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Non se atopou ningún controlador axeitado"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Seleccionar ficheiro PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Ficheiros de descrición de impresora PostScript (*.ppd, *.PPD, *.ppd.gz, "
+#~ "*.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Impresora JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Impresora LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Unha cara"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Marxe longo (estándar)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Marxe curto (xirar)"
+
+#~ msgid "Portrait"
+#~ msgstr "Vertical"
+
+#~ msgid "Landscape"
+#~ msgstr "Horizontal"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Horizontal invertido"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Vertical invertido"
+
+#~ msgid "Resume"
+#~ msgstr "Continuar"
+
+#~ msgid "Pause"
+#~ msgstr "Pausar"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Pendente"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Detido"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Requírese autenticación"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Procesando"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Detido"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Cancelado"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Interrompido"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Rematado"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Mover este traballo á parte superior da cola"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - Traballos activos"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Escriba as credenciais para imprimir desde %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Desbloquear o servidor de impresión"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Desbloquear %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Escriba o seu nome de usuario e contrasinal para ver as impresoras en %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Buscar impresoras"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Porto serie"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Porto paralelo"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Localización: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Enderezo: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "O servidor require autenticación"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dúas caras"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tipo de papel"
+
+#~ msgid "Paper Source"
+#~ msgstr "Fonte do papel"
+
+#~ msgid "Output Tray"
+#~ msgstr "Bandexa de saída"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolución"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Prefiltrado GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Páxinas por cara"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientación"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Xeral"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Configuración da páxina"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opcións instalábeis"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Traballo"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Calidade da imaxe"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Cor"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Rematado"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avanzado"
+
+#~ msgid "Test page"
+#~ msgstr "Páxina de proba"
+
+#~ msgid "Auto Select"
+#~ msgstr "Seleccionar automaticamente"
+
+#~ msgid "Printer Default"
+#~ msgstr "Impresora predeterminada"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Só empotrar tipografías GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Converter a PS nivel 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Converter a PS nivel 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Sen prefiltrado"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Limpar os cabezais de impresión"
+
+#~ msgid "Out of toner"
+#~ msgstr "Sen tóner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Nivel de revelador baixo"
+
+#~ msgid "Out of developer"
+#~ msgstr "Sen revelador"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Cartucho con pouca tinta"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Cartucho esgotado"
+
+#~ msgid "Open cover"
+#~ msgstr "Abrir cuberta"
+
+#~ msgid "Open door"
+#~ msgstr "Abrir porta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Nivel de papel baixo"
+
+#~ msgid "Out of paper"
+#~ msgstr "Sen papel"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Desconectada"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Detida"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "O recipiente de refugallos está case cheo"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "O recipiente dos refugallos está cheo"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "O condutor óptico está preto do final da súa vida"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "O condutor óptico xa non funciona"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Lista"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Non aceptar traballos"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Procesando"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Métrico"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Preguntar que facer"
+
+#~ msgid "Do nothing"
+#~ msgstr "Non facer nada"
+
+#~ msgid "Open folder"
+#~ msgstr "Abrir cartafol"
+
+#~ msgid "Other Media"
+#~ msgstr "Outros soportes"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Seleccione unha aplicación para os CD de son"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Seleccione unha aplicación para os DVD de vídeo"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Seleccione a aplicación a executar cando se conecta un reprodutor de "
+#~ "música"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Seleccione a aplicación a executar cando se conecta unha cámara"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Seleccione a aplicación para os CD de software"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD de son"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "disco Blu-ray virxe"
+
+#~ msgid "blank CD disc"
+#~ msgstr "disco CD virxe"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "disco DVD virxe"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "disco HD DVD virxe"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disco Blu-ray de vídeo"
+
+#~ msgid "e-book reader"
+#~ msgstr "lector de libros electrónicos"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disco HD DVD de vídeo"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD de imaxes"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Vídeo CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Vídeo CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "A pantalla apágase"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 segundos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#~ msgid "Select Location"
+#~ msgstr "Seleccionar localización"
+
+#~ msgid "_OK"
+#~ msgstr "_Aceptar"
+
+#~ msgid "No applications found"
+#~ msgstr "Non se atoparon aplicacións"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Non hai ningunha rede seleccionada para compartir"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Activado"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Desactivado"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Activado"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Activo"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Seleccione un cartafol"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Activar a compartición multimedia"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Compartir ficheiros permítelle compartir o seu cartafol Público con "
+#~ "outros na súa rede actual usando: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Cando está activado o acceso remoto, os usuarios remotos poden conectarse "
+#~ "usando a orde de Shell segura: \n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Activar a compartición multimedia personal"
+
+#~ msgid "Device name copied"
+#~ msgstr "Nome do dispositivo copiado"
+
+#~ msgid "Device address copied"
+#~ msgstr "Enderezo do dispositivo copiado"
+
+#~ msgid "Username copied"
+#~ msgstr "Nome de usuario copiado"
+
+#~ msgid "Password copied"
+#~ msgstr "Contrasinal copiado"
+
+#~ msgid "Custom"
+#~ msgstr "Personalizado"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Probando %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Desconectado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Conectando"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Conectado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Erro de autenticación"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autorizando"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Reducindo funcionalidade"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Conectado e autorizado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Descoñecido"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorizado o:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Conectado a:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Rexistrado o:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Produciuse un erro ao autorizar o dispositivo: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Produciuse un fallo ao esquecer o dispositivo: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Erro"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorizado"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "O subsistema Thunderbolt (boltd) non está instalado ou non está "
+#~ "configurado correctamente."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Só se poden anexar dispositivos USB e Display Port."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Non foi posíbel detectar o Thunderbolt.\n"
+#~ "Ou ben o sistema carece de compatibilidade con Thunderbolt, foi "
+#~ "desactivado na BIOS ou está configurado na BIOS nun nivel de seguranza "
+#~ "incompatíbel."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "A compatibilidade con Thunderbolt foi desactivada no BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Non é posíbel determinar o nivel de seguranza de Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Produciuse un erro ao cambiar ao modo directo: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Predeterminado"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Medio"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Grande"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Máis grande"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "O máis grande"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d píxel"
+#~ msgstr[1] "%d píxeles"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Curta"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ da pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ da pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ da pantalla"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Longa"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 día"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 días"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 días"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Desexa baleirar todos os elementos do lixo?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Pérdese permanentemente todos os elementos do lixo."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Baleirar o lixo"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Desexa eliminar todos os ficheiros temporais?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Todos os ficheiros temporais eliminaranse de forma permanente."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Eliminar os ficheiros temporais"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 día"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 días"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 días"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Para sempre"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Debería coincidir co enderezo web do seu fornecedor de conta."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Produciuse un erro ao engadir a conta"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Produciuse un erro ao rexistrar a conta"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Non hai unha maneira admitida de autenticar con este dominio"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Produciuse un erro ao unirse ao dominio"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ese nome de inicio de sesión non funcionou.\n"
+#~ "Ténteo de novo."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ese contrasinal de inicio de sesión non funcionou.\n"
+#~ "Ténteo de novo."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Produciuse un erro ao iniciar sesión no dominio"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Non foi posíbel atopar o dominio. Pode ser que o escribira mal?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Explorar para buscar máis imaxes"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "para levar a cabo esta acción precisa reclamar o dispositivo"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "O dispositivo xa está reclamado por outro proceso"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "non ten permiso para levar a cabo a acción"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "non se rexistraron impresións"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr ""
+#~ "Produciuse un fallo na comunicación co dispositivo durante o rexistro"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Produciuse un fallo ao comunicarse co lector de pegadas dixitais"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Produciuse un fallo ao comunicarse co «daemon» de pegada dixital"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Produciuse un erro ao listar as pegadas dixitais: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Produciuse un erro ao eliminar as pegadas dixitais gardadas: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Dedo gordo esquerdo"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Dedo corazón esquerdo"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Dedo índice _esquerdo"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Dedo anular esquerdo"
+
+#~ msgid "Left little finger"
+#~ msgstr "Dedo maimiño esquerdo"
+
+#~ msgid "Right thumb"
+#~ msgstr "Dedo gordo dereito"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Dedo corazón dereito"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Dedo índice dereito"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Dedo anular dereito"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dedo maimiño dereito"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Dedo descoñecido"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Completado"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Dispositivo de pegada dixital desconectado"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "O almacenamento do dispositivo de pegada dixital está cheo"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Produciuse un erro ao rexistrar unha nova pegada dixital"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Produciuse un erro ao iniciar o rexistro: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Produciuse un erro ao rexistrar unha nova pegada dixital"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Produciuse un erro ao deter o rexistro: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Levante e poña o seu dedo varias veces sobre o lector para rexistrar a "
+#~ "súa pegada dixital"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Volver a rexistrar este dedo…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Analizar nova pegada dixital"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr ""
+#~ "Produciuse un fallo ao liberar o dispositivo de pegada dixital %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problema ao ler o dispositivo"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr ""
+#~ "Produciuse un fallo ao reclamar o dispositivo de pegada dixital %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Produciuse un fallo ao obter os dispositivos de pegada dixital: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Esta semana"
+
+#~ msgid "Last Week"
+#~ msgstr "Última semana"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b de %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sesión rematada"
+
+#~ msgid "Session Started"
+#~ msgstr "Sesión iniciada"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Actividade da conta"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Seleccione outro contrasinal."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Escriba o seu contrasinal actual de novo."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Non foi posíbel cambiar o contrasinal"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Non é posíbel unirse automaticamente a este tipo de dominio"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Non existe o dominio ou non se atopou o reino"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Non é posíbel iniciar sesión como %s no dominio %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Contrasinal incorrecto, ténteo de novo"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Non foi posíbel conectarse ao dominio %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Produciuse un erro ao eliminar o usuario"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Produciuse un fallo ao revocar o usuario xestionado remotamente"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Non pode eliminar a súa propia conta."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s aínda ten a sesión iniciada"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Se elimina un usuario mentres ten a sesión iniciada pode poñer deixar o "
+#~ "sistema nun estado inconsistente."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Desexa manter os ficheiros de %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "É posíbel manter o cartafol persoal, a caixa de correo e os ficheiros "
+#~ "temporais ao eliminar unha conta de usuario."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Eliminar os ficheiros"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Manter os ficheiros"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Ten certeza que quere revocar a conta de %s xestionada remotamente?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Eliminar"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Conta desactivada"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Para configurar no seguinte inicio de sesión"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ningún"
+
+#~ msgid "Logged in"
+#~ msgstr "Conectado"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Produciuse un erro ao contactar co servizo de contas"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Asegúrese de que o servizo de contas está instalado e activado."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Este panel debe desbloquearse para cambiar esta configuración"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Eliminar a conta de usuario seleccionada"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para eliminar a conta de usuario seleccionada,\n"
+#~ "primeiro prema na icona *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Desbloquear para engadir usuarios e cambiar as preferencias"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "O novo contrasinal debe ser distinto do antigo."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Tente cambiar algunhas letras e números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Tente cambiar o contrasinal un pouco máis."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Un contrasinal sen o seu nome de usuario pode ser máis forte."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Tente evitar o uso do seu nome no contrasinal."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Tente evitar algunhas das palabras que inclúe o seu contrasinal."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Tente evitar palabras comúns."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Tente evitar a reordenación de palabras."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Tente usar máis números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Tente usar máis letras en maiúsculas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Tente usar máis letras en minúsculas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Tente usar máis caracteres especiais, como signos de puntuacións."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Tente usar unha mestura de letras, números e signos de puntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Tente evitar a repetición do mesmo carácter."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Tente evitar a repetición do mesmo tipo de carácter: debe formar unha "
+#~ "mestura de letras, números e signos de puntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Tente evitar secuencias como 1234 ou abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "O contrasinal debe ser máis largo. Tente usar unha mestura de letras, "
+#~ "números e signos de puntuación."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Mesture letras en maiúsculas e minúsculas  e use un número ou dous."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Se engade máis letras, números e signos de puntuación fará o contrasinal "
+#~ "máis forte."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Fallou a autenticación"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "O novo contrasinal é demasiado curto"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "O novo contrasinal é demasiado simple"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "O contrasinal novo e antigo son demasiado similares"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "O novo contrasinal xa foi usado recentemente."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "O novo contrasinal debe conter caracteres numéricos ou especiais"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "O contrasinal novo e o antigo son o mesmo"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "O seu contrasinal cambiou desde que iniciou a sesión inicialmente!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "O novo contrasinal non contén suficientes caracteres diferentes"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Erro descoñecido"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "O nome de usuario debe estar formado por letras en maiúsculas desde o «a» "
+#~ "ao «z», díxitos, e o caracteres: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Desculpe, o nome de usuario non está dispoñíbel. Probe outro."
+
+#~ msgid "The username is too long."
+#~ msgstr "O nome de usuario é demasiado longo."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Botón %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Aplicación definida"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Enviar pulsación de tecla"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Cambiar monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Mostrar axuda en pantalla"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tableta montada no panel do portátil"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tableta montada na pantalla externa"
+
+#~ msgid "External tablet device"
+#~ msgstr "Dispositivo de tableta externa"
+
+#~ msgid "All Displays"
+#~ msgstr "Todas as pantallas"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Lapis aerógrafo con presióbn, inclinación e desprazador integrado"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Lapis aerógrafo con presión, inclinación e rotación"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Lapis estándar con presión e inclinación"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Lapis estándar con presión"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Novo atallo…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operación cancelada"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Error:</b> Acceso denegado ao cambiar as preferencias"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Erro:</b> Erro no equipamento móbil"
+
+#~ msgid "Not Registered"
+#~ msgstr "Non rexistrado"
+
+#~ msgid "Registered"
+#~ msgstr "Rexistrado"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Buscando"
+
+#~ msgid "Denied"
+#~ msgstr "Denegado"
+
+#~ msgid "2G Only"
+#~ msgstr "Só 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Só 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Só 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Só 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (Prefirido)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (Prefirido), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (Prefirido), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (Prefirido), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Preferido)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Preferido), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Preferido), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (Preferido)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (Preferido), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (Preferido), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (Prefirido)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (Prefirido), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (Prefirido), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (Prefirido)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (Prefirido), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (Prefirido), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Preferido)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Preferido), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Preferido)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Preferido), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Preferido)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Preferido), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (Prefirido)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (Prefirido), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Preferido)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (Preferido), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (Preferido)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (Preferido), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Descoñecido"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Desbloquear a tarxeta SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Forneza un código PIN para a SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Escriba o PIN para desbloquear a súa tarxeta SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Forneza o código PUK para a tarxeta SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Escriba o código PUK para desbloquear a súa tarxeta SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Escribiu un contrasinal incorrecto."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "O código PUK debe ser un número de cando menos 8 díxitos"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Escriba o novo PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "O código PIN debe ser un número de 4 a 8 díxitos"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Desbloqueando…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Produciuse un fallo no teléfono"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Non hai conexión co teléfono"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operación non permitida"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operación non admitida"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM non inserida"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Requírese o PIN da SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Requírese o PUK da SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Fallo na SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM ocupada"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Contrasinal incorrecto"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Requírese o PIN2 da SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Requírese o PUK2 da SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Non atopado"
+
+#~ msgid "No network service"
+#~ msgstr "Non hai servizo de rede"
+
+#~ msgid "Network timeout"
+#~ msgstr "Tempo de espera de rede superado"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Non se permiten os servizos GPRS"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "O Roaming non está permitido nesta área de localización"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Produciuse un erro de GPRS non especificado"
+
+#~ msgid "No Error"
+#~ msgstr "Non hai erro"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Acción cancelada"
+
+#~ msgid "Access denied"
+#~ msgstr "Acceso denegado"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Erro descoñecido"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Mostrar o número de versión"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Activar o modo detallado"
+
+#~ msgid "Search for the string"
+#~ msgstr "Buscar unha cadea"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Listar posíbeis nomes de paneis e saír"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel a mostrar"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENTO…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Paneis dispoñíbeis:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sons do sistema"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Erro: non foi posíbel determinar o nivel HSI."
@@ -9627,14 +8322,6 @@ msgstr "Sons do sistema"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "Certificados DER ou PEM (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Engadir unha impresora…"
-
-#, fuzzy
-#~| msgid "Notifications"
-#~ msgid "No Protection"
-#~ msgstr "Notificacións"
 
 #~ msgid "Minimal Protection"
 #~ msgstr "Protección mínima"
@@ -9846,9 +8533,6 @@ msgstr "Sons do sistema"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tableta (absoluto)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Área táctil (relativo)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Preferencias da tableta"
@@ -10222,9 +8906,6 @@ msgstr "Sons do sistema"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Acceder ao hardware de bluetooth directamente"
-
-#~ msgid "Use your camera"
-#~ msgstr "Usar a túa cámara"
 
 #~ msgid "Print documents"
 #~ msgstr "Imprimir documentos"

--- a/po/gl.po~
+++ b/po/gl.po~
@@ -1,0 +1,10481 @@
+# Galician translation of GNOME Control Center
+# (C) 2002 Free Software Foundation, Inc.
+# Proxecto Trasno - Adaptación do software libre á lingua galega:  Se desexas
+# colaborar connosco, podes atopar máis información en http://www.trasno.net
+#
+# Rubén López Gómez <ryo@mundivia.es>, 1999, 2000.
+# Manuel A. Fernández Montecelo <manuel@sindominio.net>, 2002.
+# Xabi García <xabigf@gmx.net>, 2002.
+# Ignacio Casal Quinteiro <nacho.resa@gmail.com>, 2005, 2006.
+# Ignacio Casal Quinteiro <icq@svn.gnome.org>, 2007, 2008.
+# Mancomún - Centro de Referencia e Servizos de Software Libre <g11n@mancomun.org>, 2009.
+# Antón Méixome <meixome@mancomun.org>, 2009.
+# Antón Méixome <meixome@certima.net>, 2010.
+# Leandro Regueiro <leandro.regueiro@gmail.com>, 2011, 2012.
+# Fran Diéguez <frandieguez@gnome.org>, 2009-2022.
+# Fran Dieguez <frandieguez@gnome.org>, 2012-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center-master-po-gl-72290.merged\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-03 12:25+0000\n"
+"PO-Revision-Date: 2022-09-05 00:17+0200\n"
+"Last-Translator: Fran Dieguez <frandieguez@gnome.org>\n"
+"Language-Team: Galician <proxecto@trasno.gal>\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Gtranslator 40.0\n"
+"X-Launchpad-Export-Date: 2014-05-09 14:44+0000\n"
+"X-Project-Style: gnome\n"
+"X-DL-Team: gl\n"
+"X-DL-Module: gnome-control-center\n"
+"X-DL-Branch: main\n"
+"X-DL-Domain: po\n"
+"X-DL-State: Translating\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Bus do sistema"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Acceso completo"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Bus de sesión"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositivos"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Acceso completo a /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rede"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Ten acceso á rede"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Cartafol persoal"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Só lectura"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Sistema de ficheiros"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Preferencias"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Pode cambiar preferencias"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s ten os seguintes permisos, que non se poden cambiar. Se está preocupado "
+"por estes permisos, considere eliminar esta aplicación."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u ficheiro e tipo de ligazón que está aberta pola aplicación"
+msgstr[1] "%u ficheiros e tipos de ligazón que está aberta pola aplicación"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> úsase para abrir os tipos de ficheiros e ligazóns seguintes."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s do espazo de disco usado."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicacións"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Sen aplicacións"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Instalar algún…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Abrir"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Ver detalles"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Busca"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Recibir as buscas do sistema e enviar resultados."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Desactivado"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificacións"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Mostrar as notificacións do sistema."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Executar en segundo plano"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Permitir actividade cando a aplicación está pechada."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Capturas de pantalla"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Sacar fotos da pantalla en calquera momento."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Cambiar fondo"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Cambiar o fondo de escritorio."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sons"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reproducir sons."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Inhibir sons"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Bloquear os atallos de teclado estándar."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Cámara"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Sacar fotos coa cámara."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Micrófono"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Gravar son co micrófono."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Servizos de localización"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Acceder aos datos de localización do dispositivo."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Permisos incorporados"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "A aplicación require acceso ao sistema"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Asociacións de ficheiro e ligazóns"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Almacenamento"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Non se atoparon resultados"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Probe unha busca diferente"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Asociacións de ficheiro e ligazóns"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Tipos de ficheiro"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Tipos de ligazóns"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Restabelecer"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Canto espazo está usando esta aplicación con datos de aplicación e cachés."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplicacións"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Datos"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Caché"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Limpar caché…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Controla os distintos permisos e preferencias da aplicación"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "application;flatpak;permission;setting;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Seleccione unha imaxe"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancelar"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Abrir"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "tamaños múltiples"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Sen fondo de escritorio"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Fondo actual"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Estilo"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Predeterminado"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Escuro"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Fondo"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Engadir imaxe…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aparencia"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Cambie a súa imaxe de fondo ou as cores da interface"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Fondo de pantalla;Pantalla;Escritorio;Estilo;Claro;Escuro;Aparencia;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Activar"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Non se atopou o Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Conecte un dongle para usar Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth apagado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Acender para conectarse a dispositivos e recibir transferencias de ficheiros."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Modo avión activado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "O Bluetooth está desactivado cando o modo avión está activado."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Apagar o modo avión"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Modo avión por hardware activado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Apague o modo avión para activar o Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Active ou desactive o Bluetooth e conecte os seus dispositivos"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "compartir;compartición;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "A cámara está apagada"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Neste momento non hai ningún aplicación reproducindo ou gravando son."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Usar a cámara permítelle ás aplicacións capturar fotos e vídeo. Desactivar a "
+"cámara pode causar que varias aplicacións non funcionen correctamente.\n"
+"\n"
+"As aplicacións de embaixo poden usar a súa cámara."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Ningunha aplicación solicitou acceder á cámara"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Protexer as súas fotografías"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "cámara;fotos;vídeo;cámara web;bloquear;privado;privacidade;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Poña o dispositivo de calibración no cadrado e prema «Comezar»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Mova o dispositivo de calibración á posición de calibrado e prema «Continuar»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Mova o dispositivo de calibración á posición da superficie e prema "
+"«Continuar»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Pechar a tapa do portátil"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Produciuse un erro interno que non pode recuperarse."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "As ferramentas requiridas para o calibrado non están instaladas."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Non foi posíbel xerar o perfil."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Non foi posíbel obter o punto branco obxectivo."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Completado!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Calibrado fallado!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Pode quitar o dispositivo de calibrado."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Non moleste o dispositivo de calibrado mentres está traballando"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Calibración de pantalla"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Comezar"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Continuar"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Feito"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Pantalla do portátil"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Cámara web integrada"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Escáner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Cámara %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Impresora %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Cámara web %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Activar a xestión de cor para %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Mostrar os perfiles de cor para %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Non calibrado"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Predeterminado: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Espazo de cor: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Perfil de proba: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Seleccionar ficheiro de perfil ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importar"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Perfiles ICC admitidos"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Todos os ficheiros"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Pantalla"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Gardar perfil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Gardar"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Crear un perfil de cor para o dispositivo seleccionado"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Non se detectou o instrumento de medida. Comprobe que está acendido e "
+"correctamente conectado."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "O instrumento de medida non admite perfilado de impresoras."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "O tipo de dispositivo non é compatíbel actualmente."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Calibración de pantalla"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Calidade do calibrado"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"O calibrado creará un perfil que poderá usar para xestionar a cor da súa "
+"pantalla. Canto máis tempo gaste no calibrado mellor será a calidade do "
+"perfil de cor."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Non poderá usar o seu computador mentres se leva a cabo o calibrado."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Calidade"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Tempo aproximado"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Dispositivo de calibrado"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Seleccione o dispositivo sensor que quere usar para o calibrado."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tipo de pantalla"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Seleccione o tipo de pantalla que está conectada."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Perfil do punto branco"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Seleccione un punto branco obxectivo da pantalla. A maioría das pantallas "
+"deberían calibrarse a unha iluminación D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Brillo da pantalla"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Configure a pantalla ao brillo que use acotío. A xestión de cor será máis "
+"precisa neste nivel de brillo."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativamente, pode usar o nivel de brillo usado con un dos outros "
+"perfiles para este dispositivo."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nome do perfil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Pode usar un perfil de cor en computadores distintos, ou incluso crear "
+"perfiles para diferentes condicións de iluminación."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nome do perfil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Resumo"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Perfil creado correctamente!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copiar perfil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Require un soporte escribíbel"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Pode atopar útiles estas instrucións sobre como usar un perfil en sistemas "
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Engadir perfil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Detectáronse problemas. O perfil podería non funcionar correctamente. <a "
+"href=\"\">Mostrar detalles</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importar ficheiro…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Engadir"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Cada dispositivo necesita un perfil de cor actualizado para poder xestionar "
+"a cor."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Aprender máis"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Aprenda máis sobre a xestión de cor"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "E_stabelecer para todos os usuarios"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Estabelecer este perfil para todos os usuarios deste equipo"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Activar"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Engadir perfil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibrar…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibrar o dispositivo"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Retirar perfil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Ver detalles"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Non foi posíbel detectar un dispositivo no que poida xestionarse a cor"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Proxector"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (retroiluminación CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (retroiluminación LED RGB)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (retroiluminación LED branca)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Gamut amplo LCD (retroiluminación CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Gamut amplo LCD (retroiluminación LED RGB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alta"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutos"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Media"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Baixa"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Nativa da pantalla"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Impresión e publicación)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografía e gráficos)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Espazo estándar"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Perfil de proba"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automático"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Calidade baixa"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Calidade media"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Calidade alta"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB predeterminado"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK predeterminado"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Gris predeterminado"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Datos de calibrado de fábrica fornecidos polo fabricante"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+"A corrección de pantalla a pantalla completa non é posíbel con este perfil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Este perfil podería non ser preciso"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Cor"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibre o cor dos seus dispositivos, como as pantallas, cámaras ou impresoras"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Cor;ICC;Perfil;Calibrado;Impresora;Pantalla;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Outro…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Seleccionar idioma"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Seleccionar"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Non se atoparon idiomas"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Máis…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Desbloquear para cambiar as preferencias"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Algunhas preferencias deben desbloquearse antes de poder cambialas."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Desbloquear…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Incrementar hora"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Incrementar minuto"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Hora"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Decrementar hora"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Decrementar minuto"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Hoxe"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Onte"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e de %b de %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hora"
+msgstr[1] "%d horas"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuto"
+msgstr[1] "%d minutos"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d segundos"
+msgstr[1] "%d segundos"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 segundos"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 horas"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data e hora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Ano"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mes"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Xaneiro"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Febreiro"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Marzo"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Abril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maio"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Xuño"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Xullo"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Agosto"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Setembro"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Outubro"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembro"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Decembro"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Día"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Fuso horario"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Buscar unha cidade"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Data e hora automática"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Require conexión a Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Data e _hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Fuso _horario automático"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Require ter activos os servizos de localización e acceso a internet"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Activado"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Fuso h_orario"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Formato de hora"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Cambie a data e hora, incluíndo o fuso horario"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Reloxo;Fuso horario;Localización;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Cambiar as preferencias da data e hora do sistema"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Para cambiar as preferencias de data e hora debe autenticarse."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "Co_rreo"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendario"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_úsica"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "Víde_o"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicacións predeterminadas"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configurar as aplicacións predeterminadas"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "predeterminado;aplicación;preferido;media;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Ao enviar informes de problemas técnicos axudaranos a mellorar %s. Os "
+"informes envíanse de forma anónima e límpanse de datos persoais. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Informe de erros"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Informar de problemas _automaticamente"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnóstico"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Informar os seus erros"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnóstico;crash;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Activado"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Desactivado"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Desexa aplicar os cambios?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Os cambios non se poden aplicar"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Isto pode ser por limitacións do hardware."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Aplicar"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Atrás"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Preferencias da pantalla desactivadas"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Varias pantallas"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Unir"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Espello"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Contén a barra superior e Actividades"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Pantalla principal"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Luz nocturna"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Horizontal"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Vertical dereita"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Vertical esquerda"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Horizontal (volteado)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientación"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolución"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Taxa de refresco"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Axustar para TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Escalar"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Luz nocturna non dispoñíbel"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Isto pode ser debido ao controlador gráfico que se está usando, ou que se "
+"use o escritorio remoto"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Desactivado temporalmente ate o seguinte día"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Reiniciar filtro"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"A luz de noite fai que a cor da pantalla máis quente. Isto evita o cansazo "
+"de ollos e insomnio."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Programar"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Solpor a amencer"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Programación manual"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Horas"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Desde"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hora"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuto"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Ate"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura da cor"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Pantallas"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Escolla como usar os monitores conectados e proxectores"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Proxector;xrandr;Pantalla;Resolución;Refresco;Monitor;Noite;Luz;Azul;"
+"redshift;cor;solpor;amencer;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Secure Boot está activo"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Secure Boot prevén que software malicioso se cargue cando arranca o seu "
+"dispositivo. Actualmente está activo e funcionando correctamente."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Secure Boot ten problemas"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Secure Boot prevén que software malicioso se cargue cando arranca o seu "
+"dispositivo. Actualmente está activo, pero non funciona debido a que ten "
+"unha chave non válida."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Os problemas de Secure Boot poden normalmente resolverse desde as "
+"preferencias do firmware UEFI do seu computador (BIOS), o fabricante do seu "
+"hardware podería ofrecer información sobre como facer isto."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Para obter axuda, contacte co fabricante do seu hardware ou o seu fornecedor "
+"de asistencia tecnolóxica."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Secure Boot está desactivado"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Secure boot evita que software malicioso sexa cargado cando o dispositivo "
+"empeza. Actualmente está desactivado."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Secure boot pode ser activado polas preferencias do firmware UEFI do seu "
+"computador (BIOS). Para obter axuda, contacte co fabricante do seu hardware "
+"ou o seu fornecedor de soporte técnico."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Secure boot evita que software malicioso poida cargarse cando o dispositivo "
+"arrinca.\n"
+"\n"
+"Para máis información, contacte co fabricante do soporte ou o soporte "
+"técnico."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Pasado"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Falla"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "O dispositivo cumple co nivel HSI %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Nivel de seguranza 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Este dispositivo non ten protección fronte a problemas de seguranza de "
+"hardware. Isto pode deberse a un problema na configuración do firmware. "
+"Recoméndamoslle contactar co seu fornecedor de soporte técnico"
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Nivel de seguranza 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Este dispositivo ten protección mínima fronte a problemas de seguranza de "
+"hardware. Este é o nivel de seguranza de dispositivo máis baixo e só fornece "
+"protección fronte a ameazas de seguranza simples."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Nivel de seguranza 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Este dispositivo ten protección básica fronte a problemas de seguranza de "
+"hardware. Isto fornece protección fronte a amezas de seguranza comúns."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Nivel de seguranza 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Este dispositivo ten protección estendida fronte a problemas de seguranza de "
+"hardware. Este é o nivel de seguranza de dispositivo máis alto e fornece "
+"protección fronte a ameazas de seguranza avanzados."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Nivel de seguranza"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Os niveis de seguranza non están dispoñíbeis para este dispositivo."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Contacte co seu fabricante de hardware para obter axuda coas actualizacións "
+"de seguranza."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Podería ser posíbel resolver este problema nas preferencias do firmware UEFI "
+"do dispositivo, ou por un técnico de asistencia técnica."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Podería ser posíbel resolver este problema nas preferencias do firmware UEFI "
+"do dispositivo."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Podería ser posíbel que un técnico de soporte resolva este problema."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nivel 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nivel 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nivel 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Protección fronte a software malicioso cando o dispositivo arrinca."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Secure Boot ten problemas"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Algunha protección cando se inicia o dispositivo."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Secure Boot está desactivado"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Sen protección cando se inicia o dispositivo."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Este problema puido ser causado por un cambio na configuración do firmware "
+"UEFI, un cambio na configuración do sistema operativo ou por un software "
+"malicioso neste sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Este problema puido ser causado por un cambio na configuración do firmware "
+"UEFI ou por un software malicioso neste sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Este problema puido ser causado por un cambio na configuración do sistema "
+"operativo ou por un software malicioso neste sistema."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Altamente exposto ás ameazas de seguranza."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Protección limitada contra ameazas simples de seguranza."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Protexido contra ameazas de seguranza comúns."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Protexido contra unha ampla gama de ameazas de seguranza."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Protección integral"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Non hai eventos"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Protección contra escritura de firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Bloqueo de protección contra escritura de firmware"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Rexión da BIOS do firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Descriptor de BIOS de firmware"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Protección DMA previa al arranque"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Arrinque verificado de Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "ACM protexida de Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Normativa de erro de Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Fusíbel de Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET activado"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET activo"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "RAM cifrada"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Protección IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Bloqueo do núcleo de Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Verificación do núcleo de Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Suspender á RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Suspender a inactivo"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Chave de plataforma UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Secure Boot UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Configuración da plataforma TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Reconstrucción TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Modo de fabricación do motor de xestión de Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Anulación do motor de xestión de Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Versión do motor de xestión de Intel"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Actualizacións de firmware"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Certificación de firmware"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Verificación do actualizador do firmware"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Depuración da plataforma"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Comprobacións de seguranza do procesador"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Protección de rollback de AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Protección de reprodución do firmware de AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Protección de escrita do firmware de AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Plataforma Fused"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Válido"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Non válido"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Activado"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Bloqueado"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Non bloqueado"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Cifrado"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Non cifrado"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Corrompido"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Non corrompido"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Atopado"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Non atopado"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Compatíbel"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Non é compatíbel"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Seguranza do dispositivo"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Estado da seguranza do firmware do host"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"pantalla;bloqueo;diagnóstico;peches;privado;recente;temporal;tmp;índice;nome;"
+"rede;identidade;privacidade;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Descoñecido"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Descoñecido"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Non dispoñíbel"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logotipo do sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nome do dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Modelo de Hardware"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memoria"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesador"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Gráficos"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacidade do disco"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calculando…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nome do sistema operativo"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID de construción do SO: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tipo do sistema operativo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Versión de GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Desbloqueando…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Sistema de xanelas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualización"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Actualizacións do sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Renomear dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"O nome do dispositivo úsase para identificar este dispositivo cando se ve na "
+"rede, ou cando se emparellan os dispositivos Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nome do dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Renomear"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Sobre"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Ver información sobre o seu sistema"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;información;memoria;procesador;versión;predeterminado;"
+"aplicación;fallback;alternativo;preferido;cd;dvd;usb;son;video;disco;"
+"extraíbel;medio;autoexecutar;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Son e medios"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Silenciar/Desilenciar"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Baixar o volume"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Subir o volume"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Micrófono silenciar/desilenciar"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Iniciar o reprodutor multimedia"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Reproducir (ou reproducir/pausar)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pausar a reprodución"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Deter a reprodución"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Pista anterior"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Seguinte pista"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Expulsar"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Escritura"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Cambiar á seguinte orixe de entrada"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Cambiar á orixe de entrada anterior"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Iniciadores"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Iniciar o visor de axuda"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Iniciar a calculadora"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Iniciar o cliente de correo"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Iniciar o navegador web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Cartafol persoal"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Buscar"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Saír da sesión"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Bloquear a pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accesibilidade"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Activar ou desactivar o zoom"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Ampliar"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Afastar"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Activar ou desactivar o lector de pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Activar ou desactivar o teclado en pantalla"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Aumentar o tamaño do texto"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Reducir o tamaño do texto"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Contraste alto activado ou desactivado"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Non se atopou ningunha orixe de entrada"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Outra"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Engadir unha orixe de entrada"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Os métodos de entrada non poden usarse na pantalla de inicio de sesión"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Non se atopou ningunha orixe de entrada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opcións"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Subir"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Baixar"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Ver a disposición do teclado"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Eliminar"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Personalizar os atallos"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de caracteres alternativos"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"A tecla de trocar caracteres poden usarse para escribir caracteres "
+"adicionais. A veces imprímense como unha terceira opción no seu teclado."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt esquerda"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt dereito"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super esquerda"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super dereita"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tecla de menú"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl dereito"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composición"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"A tecla de composición permítelle escribir unha ampla variedade de "
+"caracteres. Para usala, prema a tecla e logo escriba a secuencia dos "
+"caracteres. Por exemplo, tecla de composición seguida por <b>C</b> e <b>o</"
+"b> escribirá <b>©</b>, <b>a</b> seguida por <b>'</b> escribirá <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Bloqueo de Maiúsculas"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Bloqueo de desprazamento"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Imprimir pantalla"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"As orixes de pantalla poden cambiarse usando o atallo de teclado %s.\n"
+"Estes atallos de teclado poden cambiarse nas preferencias de atallos de "
+"teclado."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Orixes de entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Inclúe disposicións de teclados ou métodos de entrada."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Cambiar Orixe de entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Usar a me_sma orixe para todas as xanelas"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Trocar entre orixes de entrada _individualmente para cada xanela"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Entrada de caracteres especiais"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Métodos para introducir símbolos e variantes de letra usando o teclado."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Atallos de teclado"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Ver e personalizar atallos de teclado"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificado"
+msgstr[1] "%d modificados"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Desexa restabelecer todos os atallos?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Ao restabelecer os atallos pode afectar aos atallos personalizados. Isto non "
+"se pode desfacer."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Restabelecer todo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Restabelecer todo…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Restabelecer todos os atallos ao valor predeterminado"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sección"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Atallos"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Engadir un atallo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Engadir atallos personalizados"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Configure un atallo personalizado para iniciar aplicacións, executar scripts "
+"e máis"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Engadir atallo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Non se atopou ningún atallo de teclado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s xa está sendo usado para %s. Se o substitúe, %s desactivarase"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Escriba o novo atallo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Estabelecer atallo personalizado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Estabelecer atallo"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Escriba o novo atallo para cambiar %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Engadir atallo personalizado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Eliminar"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Substituír"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Estabelecer"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Prema Esc para cancelar ou Borrar para restabelecer o atallo de teclado."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nome"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Orde"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Atallo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Estabelecer atallo…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ningunha"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Restabelecer o atallo ao valor predeterminado"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Teclado"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Cambie os atallos do teclado e estabeleza as preferencias de escritura, "
+"disposicións de teclado ou fontes de entrada"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Atallo;Espazo de traballo;Xanela;Redimensionar;Zoom;Contraste;Entrada;Orixe;"
+"Bloqueo;Volume;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Os servizos de localización están desactivados"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+"Neste momento non hai ningunha aplicación reproducindo ou gravando son."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Os servizos de localización permítenlle ás aplicacións saber a súa "
+"localización. Se usa o Wifi ou banda larga móvil mellorarase a precisión.\n"
+"\n"
+"Usa os Servizos de Localización de Mozilla: <a href='https://location."
+"services.mozilla.com/privacy'>Política de privacidade</a>\n"
+"\n"
+"Permitirlle ás aplicacións de embaixo determinar a súa localización"
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Ningunha aplicación solicitou á localización"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Protexer a súa información de localización"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "localización;gps;privado;privacidade;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "O micrófono está apagado"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Non hai aplicacións que poidan gravar son."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Usar o micrófono permítelle ás aplicación gravar e escoitar audio. "
+"Desactivar o micrófono pode causar que varias aplicación non funcionen "
+"correctamente.\n"
+"\n"
+"Permitirlle ás aplicacións de embaixo usar o seu micrófono."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Ningunha aplicación solicitou acceso ao micrófono"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Protexa as túas conversas"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "micrófono;gravación;aplicación;privacidade;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Comprobe a _configuración"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Xeral"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Botón primario"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Configura a orde dos botóns físicos do rato e das áreas táctiles."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Esquerda"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Dereita"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Rato"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Velocidade do rato"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Desprazamento natural"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "O desprazamento move o contido, non a vista."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Área táctil"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Velocidade da área táctil"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Tocar para facer clic"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Tocar para facer clic"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Desprazamento con dous dedos"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Desprazamento no bordo"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Tente facer clic, dobre clic, desprazarse coa roda do rato"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinco clics, tempo de GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dobre clic, botón primario"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Un clic, botón primario"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dobre clic, botón do medio"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Un clic, botón do medio"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dobre clic, botón secundario"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Un clic, botón secundario"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Rato e área táctil"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Cambie a sensibilidade do seu rato ou área táctil e seleccione se é destro "
+"ou zurdo"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Área táctil;Punteiro;Premer;Dobre;Pulsación;Botón;Desprazamento;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Esquina _activa"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+"Toque a esquina superior esquerda para abrir a Vista xeral de actividades."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Bordos da pantalla _activos"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Arrastre xanelas aos bordos superior, esquerdo e dereito da pantalla para "
+"redimensionalas."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Espazos de traballo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "Espazos de traballo _dinámicos"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Os espazos de traballo baleiros elimínanse automaticamente."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "Número de espazos de traballo _fixos"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Especifique un número de espazos de traballo permanentes."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Número de espazos de traballo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multimonitor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Espazos de traballo só na pantalla _principal"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Espazos de traballo en _todas as pantallas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Trocar entre aplicacións"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Incluír aplicacións de todos os _espazos de traballo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Incluír aplicacións só do espazos de traballo _actual"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitarefa"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Xestionar as preferencias para a productividade e multitarefa"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitarefa;Productividade;Personalizar;Escritorio;Esquina quente;Espazos de "
+"traballo;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Recoiro, algo foi mal. Contacte co seu fabricante de software."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Requírese que NetworkManager estea en execución."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Outros dispositivos"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Engadir conexión"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Non configurada"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Rede non segura (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Rede segura (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Rede segura (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Rede segura (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Rede segura"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Conectado"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opcións…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Activar o punto de acceso desconectarao de %s, non será posíbel acceder a "
+"internet mediante o Wifi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Debe ter cando menos 8 caracteres"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Debe ter como máximo %d caractér"
+msgstr[1] "Debe ter como máximo %d caracteres"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Activar o punto de acceso sen fíos?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"O punto de acceso Wifi permite a outras persoas compartir a súa conexión de "
+"internet creando unha rede Wifi ao que se pode conectar. Para facer isto, "
+"debe ter unha conexión a internet mediante outra orixe que non sexa o Wifi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nobre de rede"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Contrasinal"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Xerar un contrasinal aleatorio"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Autoxerar un contrasinal"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Activar"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wifi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Desexa deter o «hotspot» e desconectar aos usuarios?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Deter «hotspot»"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Modo avión"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Desactiva o Wifi, o Bluetooth e a banda larga móbil"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Non se atopou ningún adaptador Wifi"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Asegúrese que o adaptador Wifi está conectado e acendido"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Modo avión activado"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Desactíveo para usar o Wifi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Punto de acceso sen fíos activo"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Os dispositivos móbiles poden analizar o código QA ao que conectarse."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Desactivar o punto de acceso sen fíos…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Redes visíbeis"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager debe estar en execución"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Seguranza 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguranza"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Preservar"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanente"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Aleatorio"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Estábel"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"O enderezo MAC escribo aquí usarase como o enderezo hardware para o "
+"dispositivo de rede para esta conexión. Esta característica é coñecida como "
+"clonado ou spoofing de MAC. Exemplo: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Perfil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Apertura mellorada"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Empresarial"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ningunha"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "Hai %i día"
+msgstr[1] "Hai %i días"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)Rede segura (WPA)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Ningunha"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Débil"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Aceptábel"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Boa"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excelente"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Enderezo IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Enderezo IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Enderezo IP"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Esquecer conexión"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Eliminar o perfil de conexión"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Eliminar VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Detalles"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automático"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identidade"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Eliminar enderezo"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Quitar ruta"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ningunha"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Chave WEP de 40/128 bits (Hexadecimal ou ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Frase de paso WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinámica (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Persoal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Empresarial"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Persoal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Intensidade do sinal"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Velocidade da ligazón"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Enderezo hardware"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Frecuencias admitidas"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Ruta predeterminada"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Último uso"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Conectar automaticamente"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Facer dispoñíbel a _outros usuarios"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "Conexión _medida: pode ter límites de datos ou incorrer en cobros."
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"As actualizacións de software as descargas grandes non se iniciarán "
+"automaticamente."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nome"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Enderezo _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Enderezo _clonado"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Método IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automático (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Só ligazón local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Desactivar"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Compartir con outros computadores"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Enderezos"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Enderezo"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Máscara de rede"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Pasarela"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automático"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automático"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Enderezo(s) de servidor DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Separe os enderezos IP con comas"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rutas"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Rutas automáticas"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Métrico"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Usar esta conexión _só para os recursos desta rede"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Método IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automático, só DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefixo"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Non foi posíbel abrir o editor de conexións"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Novo perfil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Preferencia %s non válida: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Preferencia %s non válida"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importar desde ficheiro…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Engadir VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_eguranza"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Non foi posíbel importar a conexión VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Non foi posíbel ler o ficheiro '%s' ou non contén información de conexión "
+"VPN recoñecíbel\n"
+"\n"
+"Erro: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Seleccione o ficheiro para importar"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Xa existe un ficheiro chamado «%s\"."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "S_ubstituír"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Quere substituír %s coa conexión VPN que está gardando?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Non é posíbel exportar a conexión VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Non foi posíbel exportar a conexión VPN «%s» a %s.\n"
+"\n"
+"Erro: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exportar conexión VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Erro: non foi posíbel cargar o editor de conexión VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Controle como se conecta a Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Rede;IP;LAN;Proxy;WAN;Banda larga;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controle como se conecta a redes Wifi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Rede;Sen fíos;Wi-Fi;Wifi;IP;LAN;Banda larga;DNS;Punto de acceso;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nunca"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "hoxe"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "onte"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Última vez usada"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Con fíos"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Engadir nova conexión"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Perderase a información das redes seleccionadas, incluíndo os contrasinais e "
+"calquera configuración personalizada."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Esquecer"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Redes Wifi coñecidas"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Esquecer"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "A normativa do sistema prohibe o uso un «Hotspot»"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "O dispositivo Wireless non é compatíbel co modo «Hotspot»"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"O autodescubrimento do proxy web úsase cando non se fornece unha URL de "
+"configuración."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Non se recomenda para redes públicas nas que non se confía."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Desactivar dispositivo"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Activo"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Fornecedor"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy da rede"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy para _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy para H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy para _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Servidor socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Equipos ignorados"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Porto do proxy para HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Porto do proxy para HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Porto do proxy para FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Porto do proxy para Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuración"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Desactivar a conexión VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nome da rede"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tipo de seguranza"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Contrasinal"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Desactivar Wifi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Máis opcións…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Conectar a unha rede oculta…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Activar o punto de acceso sen fíos…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Redes Wifi _coñecidas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Estado descoñecido"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Sen xestionar"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Non dispoñíbel"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Conectando"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Requírese autenticación"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Desconectado"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "A conexión fallou"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Estado descoñecido (ausente)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Fallou a configuración"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Fallou a configuración IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "A configuración IP expirou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Precísanse segredos, pero non se forneceron"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Suplicante de 802.1x desconectado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Fallou a configuración do suplicante de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Fallou o suplicante de 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "O suplicante de 802.1x tardou moito tempo en autenticarse"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Produciuse un erro ao iniciar o servizo de PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Servizo PPP desconectado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP fallou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Produciuse un erro ao iniciar o cliente DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Erro no cliente DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "O cliente DHCP fallou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Produciuse un erro ao iniciar o servizo de conexión compartida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "O servizo de conexión compartida fallou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Produciuse un erro ao iniciar o servizo AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Erro no servizo AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "O servizo AutoIP fallou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Liña ocupada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Non hai ton de chamada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Non foi posíbel estabelecer o «carrier»"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Expirou o tempo de solicitude de chamada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Intento de chamada fallado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Fallou a inicialización do módem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Produciuse un erro ao seleccionar o APN especificado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Non se están buscando redes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Rexistro da rede rexeitado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "O rexistro na rede superou o tempo de espera"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Produciuse un erro ao rexistrarse na rede solicitada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Produciuse un fallo na comprobación do PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "É posíbel que falte o firmware do dispositivo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "A conexión desapareceu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Asumiuse unha conexión existente"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Módem non atopado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Fallou a conexión Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Tarxeta SIM non inserida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Requírese o PIN da SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Requírese o PUK da SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM errónea"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Fallou a dependencia da conexión"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Falta o «firmware»"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Cable desconectado"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "erro non definido na seguranza 802.1x (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "non se seleccionou un ficheiro"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "erro non especificado ao validar o ficheiro eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, DEM, PKCS#12 ou chaves privadas PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certificados DER ou PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "falta o ficheiro EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Ficheiros PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anónimo"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autenticado"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ambos"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identidade anóni_ma"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "Ficheiro _PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Seleccione un ficheiro PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autenticación i_nterna"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Permite o pro_visionado automático PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "falta o nome de usuario EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "falta o contrasinal EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nome de u_suario"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Contrasinal"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Mostrar _contrasinal"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "certificado EAP-PEAP da CA non válido: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "certificado EAP-PEAP da CA non válido: certificado non especificado"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versión 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versión 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificado C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Seleccionar un certificado de Autoridade de Certificación"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Requírese o certificado da CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Versión de PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "falta o nome de usuario EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "falta o contrasinal EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "falta a identidade EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "certificado EAP-TLS da CA non válido: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "certificado EAP-TLS da CA non válido: certificado non especificado"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "chave privada EAP-TLS non válida: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificado de usuario EAP-TLS non válido: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "As chaves privadas sen cifrar son inseguras"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"A chave privada seleccionada non parece estar protexida por un contrasinal. "
+"Isto podería permitir que as súas credenciais de seguranza se comprometesen. "
+"Seleccione unha chave privada protexida por contrasinal.\n"
+"\n"
+"(Pode protexer a súa chave privada con un contrasinal con openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Seleccione o seu certificado persoal"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Seleccione a súa chave privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentidade"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificado de _usuario"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Chave privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Xerar unha chave _privada"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "certificado EAP-TTLS da CA non válido: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "certificado EAP-TTLS da CA non válido: certificado non especificado"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (non EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Dominio"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Produciuse un erro descoñecido ao validar a seguranza 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS por medio de túnel"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP protexido (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Autenticación"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Seleccionar un ficheiro"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "falta o usuario leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "falta o contrasinal leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Falta o contrasinal do Wifi."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipo"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "falta a chave wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"falta a chave wep: a chave con unha lonxitude %zu debe conter só díxitos "
+"hexadecimais"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"falta a chave wep: a chave con unha lonxitude %zu debe conter só díxitos "
+"ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"chave wep non válida: lonxitude %zu da chave non válida. A chave debe ter "
+"unha lonxitude 5/13 (ascii) ou 10/26 (hexadecimal)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "chave wep non válida: a frase de paso non debe estar baleira"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"chave wep non válida: a frase de paso debe ser máis curta que 64 caracteres"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Predeterminada)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistema aberto"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Chave compartida"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Chave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Mo_strar chave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Índic_e WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk non válido: a lonxitude de chave %zu non é valida. Debe ser [8,63] "
+"bytes ou 64 díxitos hexadecimais"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk non válido: non se pode interpretar a chave con 64 bytes como "
+"hexadecimais"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificacións"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alertas de son"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Xanelas emerxentes de _notificacións"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"As notificacións continuarán aparecendo na lista de notificacións cando as "
+"xanelas emerxentes están desactivadas."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Mostrar o _contido das xanelas emerxentes"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notificacións na pantalla de b_loqueo"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Mostrar c_ontido das mensaxes na pantalla de bloqueo"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Non molestar"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Notificacións na pantalla de b_loqueo"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controle que notificacións se mostran e que contido mostran"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notificacións;Anuncio;Mensaxe;Bandexa;Emerxente;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Outra"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s eliminada"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Produciuse un erro ao quitar a conta"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Desfacer"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Pechar a notificación"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Conectarse aos seus datos na nube"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Non hai conexión a internet — conéctese para configurar as súas contas en "
+"liña"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Engadir unha conta"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Conta de %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Retirar conta"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Contas en liña"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Conéctese ás súas contas en liña a decida para que usalas"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;En liña;Conversa;Calendario;Correo-e;"
+"Contacto;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Hora descoñecida"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuto"
+msgstr[1] "%i minutos"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hora"
+msgstr[1] "%i horas"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hora"
+msgstr[1] "horas"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuto"
+msgstr[1] "minutos"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s ate estar cargado completamente"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Precaución: %s restante"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s restante"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Cargada completamente"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Non cargando"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Baleira"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Cargando"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Descargándose"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Rato sen fíos"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Teclado sen fíos"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Fonte de alimentación non interrompíbel"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Asistente persoal dixital"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Teléfono móbil"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Reprodutor de música"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tableta"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Computador"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Dispositivo de entrada de xogos"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batería"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principal"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Adicional"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Baterías"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Ao estar _inactivo"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Suspender"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Apagar"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernar"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Non facer nada"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Ao usar enerxía da batería"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Ao estar enchufado"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Suspensión automática"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Modo de rendemento desactivado temporalmente debido á temperatura de "
+"operación alta."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Colo detectado: o modo de rendemento está desactivado temporalmente. Mova o "
+"dispositivo a unha superficie estábel para restaurar."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Modo de rendemento temporalmente non dispoñíbel."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Batería baixa: aforro de enerxía activado. O anterior modo restabelecerase "
+"cando a batería estea suficientemente cargada."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Modo de aforro de enerxía activado por «%s»."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Modo de rendemento activado por «%s»"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 hora"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Modo de enerxía"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Afecta ao rendemento do sistema e uso da enerxía."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opcións de aforro de enerxí­a"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Brillo de pantalla automático"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Axusta o brillo de pantalla á luz ambiental."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Escurecer a pantalla"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Reduce o brillo de pantalla cando o computador estea activo."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Pantalla en _branco"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Apaga a pantalla despois dun período de inactividade."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Aforro de enerxí­a automático"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Activa o modo de aforro de enerxía cando a batería está baixa."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "Suspensión _automática"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Detén o computador despois dun período de inactividade."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Comportamento do botón de _acendido"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Mostrar o _porcentaxe de batería"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Suspensión automática"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Enchufado"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Ao usar a enerxía da _batería"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Atraso"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Rendemento"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Rendemento e uso de enerxía altos."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Balanceado"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Rendemento e uso de enerxía estándar."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Aforro de enerxí­a"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Rendemento e uso de enerxía reducidos."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Enerxía"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Vexa o estado da súa batería e cambie as preferencias de aforro de enerxía"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Enerxía;Durmir;Suspender;Hibernar;Batería;Brillo;Escurecer;En branco;Monitor;"
+"DPMS;Inactivo;Enerxía;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Eliminouse a impresora «%s»"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Produciuse un erro ao engadir unha nova impresora."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Non foi posíbel cargar a IU: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Desbloquear para engadir impresoras e cambiar as preferencias"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Impresoras"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Engadir impresoras, vexa os traballos de impresión e decida que quere "
+"imprimir"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Impresora;Cola;Imprimir;Papel;Tinta;Tóner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Engadir impresora"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Desbloquear"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Non se atopou ningunha impresora"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Escriba un enderezo de rede ou busque unha impresora"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Requírese autenticación"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Escriba o seu nome de usuario e contrasinal para ver as impresoras "
+"dispoñíbeis no Servidor de Impresión."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nome de usuario"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Detalles de %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Non se atopou ningún controlador axeitado"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Seleccionar ficheiro PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Ficheiros de descrición de impresora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
+"PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Os nomes de impresoras non poden conter ESPACIOS, TABULACIÓNS, # ou /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Localización"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Controladores"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Buscando controladores preferidos…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Buscar controladores"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Seleccionar desde a base de datos…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instalar ficheiro PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Seleccionar controlador da impresora"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Cargando a base de datos dos controladores…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Seleccionar"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Impresora JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Impresora LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Unha cara"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Marxe longo (estándar)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Marxe curto (xirar)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Vertical"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Horizontal"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Horizontal invertido"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Vertical invertido"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Continuar"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pausar"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Pendente"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Detido"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Requírese autenticación"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Procesando"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Detido"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Cancelado"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Interrompido"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Rematado"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Mover este traballo á parte superior da cola"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u traballo require autenticación"
+msgstr[1] "%u traballos requiren autenticación"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - Traballos activos"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Escriba as credenciais para imprimir desde %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Dominio"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utenticar"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Limpar todos"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autenticar"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Non hai traballos activos na impresora"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Desbloquear o servidor de impresión"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Desbloquear %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Escriba o seu nome de usuario e contrasinal para ver as impresoras en %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Buscar impresoras"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Porto serie"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Porto paralelo"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Localización: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Enderezo: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "O servidor require autenticación"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dúas caras"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tipo de papel"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Fonte do papel"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Bandexa de saída"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolución"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Prefiltrado GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Páxinas por cara"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dúas caras"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientación"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Xeral"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Configuración da páxina"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opcións instalábeis"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Traballo"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Calidade da imaxe"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Cor"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Rematado"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avanzado"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Páxina de proba"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Páxina de proba"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Seleccionar automaticamente"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Impresora predeterminada"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Só empotrar tipografías GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Converter a PS nivel 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Converter a PS nivel 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Sen prefiltrado"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricante"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Non hai traballos activos"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u traballo"
+msgstr[1] "%u traballos"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Limpar os cabezais de impresión"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Tóner baixo"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Sen tóner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Nivel de revelador baixo"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Sen revelador"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Cartucho con pouca tinta"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Cartucho esgotado"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Abrir cuberta"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Abrir porta"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Nivel de papel baixo"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Sen papel"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Desconectada"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Detida"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "O recipiente de refugallos está case cheo"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "O recipiente dos refugallos está cheo"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "O condutor óptico está preto do final da súa vida"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "O condutor óptico xa non funciona"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Lista"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Non aceptar traballos"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Procesando"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Preferencias de impresión"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Detalles da impresora"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Usar como impresora por omisión"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Limpar os cabezais de impresión"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Retirar impresora"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modelo"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nivel de tinta"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Por favor reinicie cando o se resolva o problema."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Reiniciar"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Engadir impresora…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Non hai impresoras"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"O servizo do sistema de impresión\n"
+"semella que non está dispoñíbel."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Buscar configuracións rexionais…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Formatos comúns"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Todos os formatos"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Non se atoparon resultados"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "As buscas poden ser por países ou por idiomas."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Previsualizar"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Métrico"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datas"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Datas e horas"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Números"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Medida"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papel"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "O idioma e formato cambiaranse no seguinte inicio de sesión"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Saír da sesión…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"A configuración de idioma úsase no texto da interface e nas páxinas web. Os "
+"formatos úsanse para os números, datas e moedas."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "A súa conta"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Idioma"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formatos"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Pantalla de inicio de sesión"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Rexión e idioma"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Seleccione o idioma en pantalla e formatos"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Idioma:Distribución;Teclado;Entrada;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Preguntar que facer"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Non facer nada"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Abrir cartafol"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Outros soportes"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Seleccione unha aplicación para os CD de son"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Seleccione unha aplicación para os DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Seleccione a aplicación a executar cando se conecta un reprodutor de música"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Seleccione a aplicación a executar cando se conecta unha cámara"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Seleccione a aplicación para os CD de software"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD de son"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "disco Blu-ray virxe"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "disco CD virxe"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "disco DVD virxe"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "disco HD DVD virxe"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Disco Blu-ray de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "lector de libros electrónicos"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Disco HD DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "CD de imaxes"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Vídeo CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Vídeo CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Software de Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Seleccione como se deben xestionar os soportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD de _son"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Reprodutor de _música"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Outros soportes…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Non preguntar nin iniciar programas ao inserir un soporte"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Seleccione como se deben xestionar outros soportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Acción:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipo:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Soportes extraíbeis"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configurar as preferencias de soportes extraíbeis"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;predeterminado;aplicación;fallback;alternativo;preferido;"
+"cd;dvd;usb;son;video;disco;extraíbel;medio;autoexecutar;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "A pantalla apágase"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 segundos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Bloqueo de pantalla"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Se bloquea automaticamente a pantalla evitará que outros poida acceder ao "
+"seu computador mentres non está presente."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Atraso da pantalla en branco"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "O período de inactividade despois do cal a pantalla se porá en negro."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Bloqueo de pantalla automático"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Atraso do _bloqueo de pantalla automático"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Período despois de que pantalla se poña en negro, esta se bloquee "
+"automaticamente."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Mostrar _notificacións na pantalla de bloqueo"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Prohibir usar dispositivos _USB novos"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Prohibir aos dispositivos USB novos interactuar co sistema cando a pantalla "
+"está bloqueada."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Privacidade de pantalla"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Restrinxir o ángulo de visualización"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Preferencias da pantalla"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "pantalla;bloqueo;privado;privacidade"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Seleccionar localización"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Aceptar"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Localizacións da busca"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Cartafoles que son buscados polas aplicacións do sistema, como Ficheiros, "
+"Fotos, e Vídeos."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Lugares"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Outros"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Engadir localización"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Non se atoparon aplicacións"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Busca de aplicacións"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Incluír resultados de busca fornecidos por aplicacións."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Cartafoles que son buscados polas aplicacións do sistema."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Resultados da busca"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Os resultados móstranse segundo á orde da lista."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controle que aplicacións mostran resultados de busca na Vista de actividades"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Buscar;Atopar;Índice;Oculto;Privacidade;Resultados;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Non hai ningunha rede seleccionada para compartir"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Redes"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Activado"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Desactivado"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Activado"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Activo"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Seleccione un cartafol"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Engadir"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Activar a compartición multimedia"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Compartir ficheiros permítelle compartir o seu cartafol Público con outros "
+"na súa rede actual usando: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Cando está activado o acceso remoto, os usuarios remotos poden conectarse "
+"usando a orde de Shell segura: \n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Activar a compartición multimedia personal"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Nome do dispositivo copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Enderezo do dispositivo copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Nome de usuario copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Contrasinal copiado"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Compartir"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Nome do _computador"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Compartir _ficheiros"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Escritorio _remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Compartir _multimedia"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Inicio de sesión _remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Compartir ficheiros"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Requirir _contrasinal"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Inicio de sesión remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Escritorio remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"O escritorio remoto permítelle ver e controlar o seu escritorio desde outro "
+"computador."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Activar ou desactivar as conexións de escritorio remoto a este computador."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Control remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Permite as conexións para controlar a pantalla"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Como conectarse"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Conéctese a este computador usando o nome de dispositivo ou enderezo de "
+"escritorio remoto."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copiar"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Enderezo de escritorio remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autenticación"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Requírese o nome de usuario e contrasinal para conectarse a este computador."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nome de usuario"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Comprobar cifrado"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Pegada dixital do cifrado"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"A pegada dixital do cifrado pode verse nos clientes conectándose e debería "
+"ser idéntica."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Compartir multimedia"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Compartir música, fotos e vídeos pola rede."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Cartafoles"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controle que quere compartir con outros"
+
+# Notas:
+# Engadir nota
+#
+# Comentarios extraídos:
+# Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#
+#
+# Rutas:
+# panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"compartir;compartición;ssh:equipo;nome;remoto;escritorio;son;vídeo;imaxes;"
+"fotos;filmes;servidor;renderizador;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Activar ou desactivar o inicio de sesión remoto"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Requírese autenticación para activar ou desactivar o inicio de sesión remoto"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Personalizado"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Click"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Cadea"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Oscilación"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Zumbido"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balance"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Esvaecer"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Atrás"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Adiante"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Probando %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Prema no altofalante para probalo"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volume do sistema"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Volume principal"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Niveis do volume"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Saída"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Dispositivo de saída"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Probar"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuración"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Entrada"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Dispositivo de entrada"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volume"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Son de alerta"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Silenciar"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Son"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Cambie os niveles de volume, entradas, saídas e sons de alerta"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "Tarxeta;Micrófono;Volume;Esvaecer;Balance;Bluetooth;Auriculares;Son;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Desconectado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Conectando"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Conectado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Erro de autenticación"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autorizando"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Reducindo funcionalidade"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Conectado e autorizado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Descoñecido"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autorizado o:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Conectado a:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Rexistrado o:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Produciuse un erro ao autorizar o dispositivo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Produciuse un fallo ao esquecer o dispositivo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Depende de %u dispositivo"
+msgstr[1] "Depende de outros %u dispositivo"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Pechar notificación"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nome:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Estado:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autorizar e conectar"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Esquecer dispositivo"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Erro"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorizado"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"O subsistema Thunderbolt (boltd) non está instalado ou non está configurado "
+"correctamente."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Permitir o acceso directo a dispositivos como docas ou GPU externas."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Só se poden anexar dispositivos USB e Display Port."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Non foi posíbel detectar o Thunderbolt.\n"
+"Ou ben o sistema carece de compatibilidade con Thunderbolt, foi desactivado "
+"na BIOS ou está configurado na BIOS nun nivel de seguranza incompatíbel."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "A compatibilidade con Thunderbolt foi desactivada no BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Non é posíbel determinar o nivel de seguranza de Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Produciuse un erro ao cambiar ao modo directo: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Non hai compatibilidade con Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Non foi posíbel conectarse ao subsistema de Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Acceso directo"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Dispositivos pendentes"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Non hai dispositivos anexados"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Xestionar dispositivos Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacidade;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Pestanexo do cursor"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "O cursor pestanexa nos campos de texto."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocidade"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Velocidade de pestanexo do cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Tamaño do cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"O tamaño do cursor pode combinarse co zoom para facer máis doado ver o "
+"cursor."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Asistente de clic"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Clic secundario _simulado"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Iniciar un clic secundario ao manter o botón primario"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Atraso na aceptación:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Retardo da pulsación secundaria"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Premer ao _pasar por enriba"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Iniciar un clic cando se pasa por enriba o punteiro"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Retardo:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Limiar de _movemento:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Pequeno"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetición de teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "As pulsacións de teclas repítense cando a tecla se mantén premida."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Atraso da repetición de teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocidade de repetición de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Asistente de escritura"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Teclas per_sistentes"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Trata unha secuencia de teclas modificadores como unha combinación de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desactivar se se premen dúas teclas á vez"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pitar cando se prema unha tecla _modificadora"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Teclas _lentas"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Engade un atraso entre cando se preme unha tecla e cando se acepta"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Retardo das teclas lentas ao escribir"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Pitar ao pr_emer unha tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Pitar ao _aceptar unha tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Pitar ao _rexeitar unha tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Teclas de re_bote"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorar as pulsacións duplicadas rápidas"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Retardo de pulsación do rexeite de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Activar co teclado"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Activar as características de accesibilidade desde o teclado"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Predeterminado"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Medio"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Máis grande"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "O máis grande"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d píxel"
+msgstr[1] "%d píxeles"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Mostrar _sempre o menú de Acceso Universal"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Visión"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Contraste _alto"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Texto _grande"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Activar a_nimacións"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Lector de _pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "O lector de pantalla le o texto mostrado segundo move o foco."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Teclas de son"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pitar cando o Bloq Num ou Maiús Bloq se activen ou desactiven."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Tamaño do c_ursor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Ampliación"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audición"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Alertas _visuais"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Tecla_do en pantalla"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "R_epetición de teclas"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Pestanexo do cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Asistente de _escritura (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Apuntar e premer"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Teclas do _rato"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Localizar o punteiro"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Asistente de _clic"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Atraso da _dupla pulsación"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Atraso da dupla pulsación"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alertas visuais"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Probar flashes"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Usar un indicador visual cando se produza un son de alerta."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Escintilar toda a _pantalla"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Escintilar toda a _xanela"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Curta"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ da pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ da pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ da pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Longa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Pantalla completa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Metade superior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Metade inferior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Metade esquerda"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Metade dereita"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Preferencias de ampliación"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Magnificación:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posición do magnificador:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Seguir o cursor do rato"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Parte da _pantalla:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "O magnificador _esténdese máis aló da pantalla"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Manter centrado o cursor do magnificador"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "O cursor do magnificador em_purra os contidos cara os lados"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "O cursor do magnificador móvese co _contido"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Miras:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Sobrepón o cursor do rato"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Grosor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Fino"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Groso"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Lonxitude:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Co_r:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Miras"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efectos de cor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Branco sobre negro:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Brillo:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contraste:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Co_r"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ningunha"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Completo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Baixo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alto"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Baixa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efectos de cor"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Faga máis doado ver, escoitar, escribir, apuntar e clicar"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Teclado;Rato;a11y;Accesibilidade;Contraste;Cursor;Son;Ampliación;Lector de "
+"pantalla;texto;tipo de letra;tamaño;AccessX;Persistente;Lenta;Rexeite;Rato;"
+"Dobre;clic;atraso;velocidade;asistencia;Repetición;Pestanexo;visión;audición;"
+"son;escrita;escoita;son;audio;animacións;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 día"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 días"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 días"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Desexa baleirar todos os elementos do lixo?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Pérdese permanentemente todos os elementos do lixo."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Baleirar o lixo"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Desexa eliminar todos os ficheiros temporais?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Todos os ficheiros temporais eliminaranse de forma permanente."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Eliminar os ficheiros temporais"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 día"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 días"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 días"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Para sempre"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Historial de ficheiros"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"O historial de ficheiros mantén un rexistro dos ficheiros que usou. Esta "
+"información está compartida entre as aplicacións, e fai máis doado atopar "
+"ficheiros que pode querer usar."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Historial de f_icheiros"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Duración do _historial de ficheiros"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Limpar o historial…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Lixo e ficheiros temporais"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"O lixo e ficheiros temporais poden incluír en ocasións información persoal "
+"ou sensíbel. Se os elimina automaticamente pode axudarlle a protexer a súa "
+"privacidade."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Limpar o contido do _lixo automaticamente"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Limpar os _ficheiros temporais automaticamente"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Período de limpeza do _lixo automática"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Baleirar o lixo…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Eliminar os ficheiros temporais…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Historial de ficheiros e lixo"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Non deixar rastro"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"uso;recente;historial;ficheiros;temporais;tmp;privado;privacidade;lixo;"
+"purgar;reter;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Debería coincidir co enderezo web do seu fornecedor de conta."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Produciuse un erro ao engadir a conta"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Os contrasinais non coinciden."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Produciuse un erro ao rexistrar a conta"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Non hai unha maneira admitida de autenticar con este dominio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Produciuse un erro ao unirse ao dominio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ese nome de inicio de sesión non funcionou.\n"
+"Ténteo de novo."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ese contrasinal de inicio de sesión non funcionou.\n"
+"Ténteo de novo."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Produciuse un erro ao iniciar sesión no dominio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Non foi posíbel atopar o dominio. Pode ser que o escribira mal?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Engadir usuario"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrador"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Os administradores poden engadir ou eliminar usuarios e poden cambiar as "
+"preferencias para todos os usuarios. Os controles parentais non se aplican "
+"aos administradores."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "O usuario estabelece o seu contrasinal no primeiro inicio de sesión"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Estabelecer contrasinal agora"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Inicio de sesión corporativo"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+"Contas de usuario que están xestionadas por unha empresa ou organización."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Vostede está desconectado"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"O inicio de sesión corporativo permítelle xestionar unha conta de usuario "
+"xestionada de forma centralizada para usala neste dispositivo. Tamén pode "
+"usar esta conta para acceder a recursos corporativos en internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Explorar para buscar máis imaxes"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Seleccionar un ficheiro…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Xestión das pegadas dixitais"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Non"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Sí"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Desexa eliminar as súas pegadas dixitais rexistradas para desactivar o "
+"inicio de sesión con pegadas dixitais?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Non hai ningún dispositivo de pegada dixital"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Non hai ningún dispositivo de pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Asegúrese que o dispositivo está conectado correctamente"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Dispositivo de pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Seleccione o dispositivo de pegada dixital que quere configurar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Inicio de sesión con pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"O inicio de sesión con pegada dixital permítelle desbloquear e iniciar "
+"sesión no seu computador co seu dedo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Eliminar pegadas dixitais"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Rexistrar pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "para levar a cabo esta acción precisa reclamar o dispositivo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "O dispositivo xa está reclamado por outro proceso"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "non ten permiso para levar a cabo a acción"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "non se rexistraron impresións"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Produciuse un fallo na comunicación co dispositivo durante o rexistro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Produciuse un fallo ao comunicarse co lector de pegadas dixitais"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Produciuse un fallo ao comunicarse co «daemon» de pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Produciuse un erro ao listar as pegadas dixitais: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Produciuse un erro ao eliminar as pegadas dixitais gardadas: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Dedo gordo esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Dedo corazón esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "Dedo índice _esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Dedo anular esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Dedo maimiño esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Dedo gordo dereito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Dedo corazón dereito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Dedo índice dereito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Dedo anular dereito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Dedo maimiño dereito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Dedo descoñecido"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Completado"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Dispositivo de pegada dixital desconectado"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "O almacenamento do dispositivo de pegada dixital está cheo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Produciuse un erro ao rexistrar unha nova pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Produciuse un erro ao iniciar o rexistro: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Produciuse un erro ao rexistrar unha nova pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Produciuse un erro ao deter o rexistro: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Levante e poña o seu dedo varias veces sobre o lector para rexistrar a súa "
+"pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Volver a rexistrar este dedo…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Analizar nova pegada dixital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Produciuse un fallo ao liberar o dispositivo de pegada dixital %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problema ao ler o dispositivo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Produciuse un fallo ao reclamar o dispositivo de pegada dixital %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Produciuse un fallo ao obter os dispositivos de pegada dixital: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Esta semana"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Última semana"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e de %b de %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sesión rematada"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sesión iniciada"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Actividade da conta"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Anterior"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Seguinte"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Seleccione outro contrasinal."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Escriba o seu contrasinal actual de novo."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Non foi posíbel cambiar o contrasinal"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Cambiar contrasinal"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "C_ambiar"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Contrasinal actual"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Contrasinal novo"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Confirmar contrasinal"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Permitirlle ao usuario cambiar o seu contrasinal no seguinte inicio de sesión"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Estabelecer un contrasinal agora"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Non é posíbel unirse automaticamente a este tipo de dominio"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Non existe o dominio ou non se atopou o reino"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Non é posíbel iniciar sesión como %s no dominio %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Contrasinal incorrecto, ténteo de novo"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Non foi posíbel conectarse ao dominio %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Produciuse un erro ao eliminar o usuario"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Produciuse un fallo ao revocar o usuario xestionado remotamente"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Non pode eliminar a súa propia conta."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s aínda ten a sesión iniciada"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Se elimina un usuario mentres ten a sesión iniciada pode poñer deixar o "
+"sistema nun estado inconsistente."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Desexa manter os ficheiros de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"É posíbel manter o cartafol persoal, a caixa de correo e os ficheiros "
+"temporais ao eliminar unha conta de usuario."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Eliminar os ficheiros"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Manter os ficheiros"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Ten certeza que quere revocar a conta de %s xestionada remotamente?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Eliminar"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Conta desactivada"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Para configurar no seguinte inicio de sesión"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ningún"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Conectado"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Produciuse un erro ao contactar co servizo de contas"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Asegúrese de que o servizo de contas está instalado e activado."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Este panel debe desbloquearse para cambiar esta configuración"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Eliminar a conta de usuario seleccionada"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Para eliminar a conta de usuario seleccionada,\n"
+"primeiro prema na icona *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Desbloquear para engadir usuarios e cambiar as preferencias"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Usuarios"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "A súa sesión debe reiniciarse para que se apliquen os cambios"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Reiniciar agora"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Pechar"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Editar avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Nome completo"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Editar"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Inicio de sesión con _pegadas dixitais"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Inicio de sesión automático"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Actividade da conta"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrador"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Os administradores poden engadir ou eliminar usuarios e poden cambiar as "
+"preferencias para todos os usuarios."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "Controis _parentais"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Abrir a aplicación de Control Parental."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Eliminar usuario…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Outros usuarios"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Engadir usuario…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Non se atoparon usuarios"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Desbloquear para engadir unha conta de usuario."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Engadir ou quitar usuarios e cambiar os seus contrasinais"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Inicio de sesión;Nome;Pegada dixital;Avatar;Logotipo;Cara;Contrasinal;"
+"Controis parentais;Tempo en pantalla;Restricións de aplicacións;Restricións "
+"web;Uso;Límite de uso;Rapaz;Neno;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Unirse"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Inicio de sesión do administrador do dominio"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Para usar inicios de sesión corporativos, este equipo precisa \n"
+"formar parte dun dominio. Pida ao administrador do seu sistema \n"
+"que escriba aquí o contrasinal do dominio."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nome do administrador"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Contrasinal do administrador"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Xestionar contas de usuario"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Requírese autenticación para cambiar os datos do usuario"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "O novo contrasinal debe ser distinto do antigo."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Tente cambiar algunhas letras e números."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Tente cambiar o contrasinal un pouco máis."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Un contrasinal sen o seu nome de usuario pode ser máis forte."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Tente evitar o uso do seu nome no contrasinal."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Tente evitar algunhas das palabras que inclúe o seu contrasinal."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Tente evitar palabras comúns."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Tente evitar a reordenación de palabras."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Tente usar máis números."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Tente usar máis letras en maiúsculas."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Tente usar máis letras en minúsculas."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Tente usar máis caracteres especiais, como signos de puntuacións."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Tente usar unha mestura de letras, números e signos de puntuación."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Tente evitar a repetición do mesmo carácter."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Tente evitar a repetición do mesmo tipo de carácter: debe formar unha "
+"mestura de letras, números e signos de puntuación."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Tente evitar secuencias como 1234 ou abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"O contrasinal debe ser máis largo. Tente usar unha mestura de letras, "
+"números e signos de puntuación."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Mesture letras en maiúsculas e minúsculas  e use un número ou dous."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Se engade máis letras, números e signos de puntuación fará o contrasinal "
+"máis forte."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Fallou a autenticación"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "O novo contrasinal é demasiado curto"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "O novo contrasinal é demasiado simple"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "O contrasinal novo e antigo son demasiado similares"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "O novo contrasinal xa foi usado recentemente."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "O novo contrasinal debe conter caracteres numéricos ou especiais"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "O contrasinal novo e o antigo son o mesmo"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "O seu contrasinal cambiou desde que iniciou a sesión inicialmente!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "O novo contrasinal non contén suficientes caracteres diferentes"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Erro descoñecido"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"O nome de usuario debe estar formado por letras en maiúsculas desde o «a» ao "
+"«z», díxitos, e o caracteres: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Desculpe, o nome de usuario non está dispoñíbel. Probe outro."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "O nome de usuario é demasiado longo."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Mapear botóns"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Mapear botóns a funcións"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Para editar unha tecla de atallo, seleccione a acción «Enviar pulsación de "
+"tecla», prema o botón do atallo de teclado e prema as novas teclas ou prema "
+"«Retroceso» para limpar todo."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Pechar"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Prema nos marcadores obxectivo a medida que aparezan na pantalla para "
+"calibrar a tableta."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Pulsación errónea detectada, reiniciando…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Botón %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplicación definida"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Enviar pulsación de tecla"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Cambiar monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Mostrar axuda en pantalla"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tableta montada no panel do portátil"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tableta montada na pantalla externa"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Dispositivo de tableta externa"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Dispositivo de tableta externa"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Todas as pantallas"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Modo tableta"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Usar posicionamento absoluto para o lapis"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientación para zurdos"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "A tabletas e «Express Keys» están rotadas para o uso coa man esquerda"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapa que monitorizar"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Manter relación de aspecto"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Usar só unha porción da superficie da tableta para manter a taxa de aspecto "
+"do monitor"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Calibrar"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Non se detectou ningunha tableta"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Conecte ou acenda a súa tableta Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensación de presión da punta"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Suave"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Presión da punta do lapis"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Botón 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botón 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botón 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensación de presión do borrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Presión do borrador"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Pulsación do botón dereito do rato"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Pulsación do botón do medio do rato"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Adiante"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Lapis aerógrafo con presióbn, inclinación e desprazador integrado"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Lapis aerógrafo con presión, inclinación e rotación"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Lapis estándar con presión e inclinación"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Lapis estándar con presión"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tableta Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Estabeleza a asignación de botóns e axuste a sensibilidade do seu bolígrafo "
+"dixital nas tabletas gráficas"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tableta;Wacom;Stylus;Borrador;Rato;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Novo atallo…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Puntos de acceso"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operación cancelada"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Error:</b> Acceso denegado ao cambiar as preferencias"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Erro:</b> Erro no equipamento móbil"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Non rexistrado"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Rexistrado"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Buscando"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Denegado"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Detalles do módem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Estado do módem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operador"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tipo de rede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Estado da rede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Número propio"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Detalles do dispositivo"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Versión do firmware"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Só 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Só 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Só 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Só 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (Prefirido)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (Prefirido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (Prefirido), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (Prefirido), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Preferido), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Preferido), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (Preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (Preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (Preferido), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (Prefirido)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (Prefirido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (Prefirido), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (Prefirido)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (Prefirido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (Prefirido), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (Preferido), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (Preferido), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (Preferido), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (Prefirido)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (Prefirido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (Preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (Preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (Preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (Preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Descoñecido"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Desbloquear a tarxeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Desbloquear"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Forneza un código PIN para a SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Escriba o PIN para desbloquear a súa tarxeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Forneza o código PUK para a tarxeta SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Escriba o código PUK para desbloquear a súa tarxeta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Escribiu un contrasinal incorrecto. Ten %1$u intento máis"
+msgstr[1] "Escribiu un contrasinal incorrecto. Ten %1$u intentos máis"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Ten %1$u intento máis"
+msgstr[1] "Ten %1$u intentos máis"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Escribiu un contrasinal incorrecto."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "O código PUK debe ser un número de cando menos 8 díxitos"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Escriba o novo PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "O código PIN debe ser un número de 4 a 8 díxitos"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Desbloqueando…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Sen SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Insira unha tarxeta SIM para usar este módem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM bloqueada"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "Datos _móbiles"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Datos de acceso usando a rede móbil"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "Roaming de _datos"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Usar os datos móbiles ao estar en «roaming»"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Modo da _rede"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "R_ede"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Nomes de puntos de _acceso"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Bloqueo de _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Bloquear SIM con un PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Detalles do mód_em"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Produciuse un fallo no teléfono"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Non hai conexión co teléfono"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operación non permitida"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operación non admitida"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM non inserida"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Requírese o PIN da SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Requírese o PUK da SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Fallo na SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM ocupada"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Contrasinal incorrecto"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Requírese o PIN2 da SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Requírese o PUK2 da SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Non atopado"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Non hai servizo de rede"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Tempo de espera de rede superado"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Non se permiten os servizos GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "O Roaming non está permitido nesta área de localización"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Produciuse un erro de GPRS non especificado"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Non hai erro"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Acción cancelada"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Acceso denegado"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Erro descoñecido"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Modo de rede"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automático"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Seleccionar rede"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Actualizar os fornecedores de rede"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Activar a rede móbil"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Non se atopou ningún adaptador WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+"Asegúrese que o adaptador Wan/Celular sen fíos está conectado e acendido"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "O Wan sen fíos está desactivado cando o modo avión está activado."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Apagar o modo avión"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Conexión de datos"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Tarxeta SIM usada para internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Bloqueo de SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Seguinte"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Bloquear SIM con PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Cambiar PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Escriba o PIN actual para cambiar as preferencias de bloqueo de SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Rede móbil"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configurar as conexións de telefonía e datos móbiles"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "celular;wwan;telefonía;sim;móbil;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilidades para configurar o escritorio GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Preferencias é a interface principal para configurar o seu sistema."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "O proxecto GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Mostrar o número de versión"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Activar o modo detallado"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Buscar unha cadea"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Listar posíbeis nomes de paneis e saír"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel a mostrar"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENTO…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categorías do sistema"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privacidade"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Paneis dispoñíbeis:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Todas as preferencias"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menú principal"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Aviso: versión para desenvolvemento"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Esta versión da configuración só se debe usar para fins de desenvolvemento. "
+"Pode experimentar un comportamento incorrecto do sistema, perda de datos e "
+"outros problemas inesperados. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Axuda"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Xeral"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Saír"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Buscar"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneis"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Ir ao panel anterior"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Cancelar a busca"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferencias;Configuración;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "O identificador do último panel de Preferencias para abrir"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"O identificador do último panel de Preferencias para abrir. Os valores non "
+"recoñecíbeis serán ignorados e seleccionarase o primeiro panel da lista."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Mostrar un aviso cando se execute unha construción para desenvolvemento da "
+"configuración"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Indica se a configuración mostrará un aviso cando se execute unha "
+"construción para desenvolvemento."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Estado inicial da xanela"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Unha tupla que contén a anchura, altura e estado maximizado iniciais da "
+"xanela da aplicación."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u saída"
+msgstr[1] "%u saídas"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrada"
+msgstr[1] "%u entradas"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sons do sistema"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Erro: non foi posíbel determinar o nivel HSI."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Erro: non foi posíbel determinar o nivel HSI incorrecto."
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificados DER ou PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Engadir unha impresora…"
+
+#, fuzzy
+#~| msgid "Notifications"
+#~ msgid "No Protection"
+#~ msgstr "Notificacións"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "Protección mínima"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Protección básica"
+
+#, fuzzy
+#~| msgid "Add connection"
+#~ msgid "Extended Protection"
+#~ msgstr "Engadir conexión"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "Proteccións de seguranza mínimas"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Proteccións de seguranza básicas"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Proteccións de seguranza extendidas"
+
+#~ msgid "Drip"
+#~ msgstr "Goteo"
+
+#~ msgid "Glass"
+#~ msgstr "Cristal"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "Light"
+#~ msgstr "Claro"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Disposición de pantallas"
+
+#~ msgid "Set"
+#~ msgstr "Estabelecer"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Bloquear a súa pantalla"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "pantalla;bloqueo;diagnóstico;peches;privado;recente;temporal;tmp;índice;"
+#~ "nome;rede;identidade;"
+
+#~ msgid "Bark"
+#~ msgstr "Ladrido"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Panel das preferencias de son de GNOME"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Panel das preferencias da área táctil ou rato de GNOME"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Panel das preferencias do fondo de GNOME"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Panel das preferencias do teclado de GNOME"
+
+#~ msgid "More Warm"
+#~ msgstr "Máis quente"
+
+#~ msgid "Less Warm"
+#~ msgstr "Menos quente"
+
+#~ msgid "Move up"
+#~ msgstr "Subir"
+
+#~ msgid "Move down"
+#~ msgstr "Baixar"
+
+#~ msgid "%s VPN"
+#~ msgstr "VPN «%s»"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autenticar"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Compartir pantalla permítelle aos usuarios remotos ver ou controlar a súa "
+#~ "pantalla conectándose a: %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Compartir _pantalla"
+
+#~ msgid "_Password:"
+#~ msgstr "_Contrasinal:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Mo_strar contrasinal"
+
+#~ msgid "Access Options"
+#~ msgstr "Opcións de acceso"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "As _novas conexións deben solicitar acceso"
+
+#~ msgid "_Require a password"
+#~ msgstr "Requirir un _contrasinal"
+
+#~ msgid "Show the screenshot UI"
+#~ msgstr "Mostrar UI de captura"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Sacar unha captura de pantalla"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "Sacar unha captura dunha xanela"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "Mostrar a UI de gravación de pantalla"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Permitirlle ás aplicacións de embaixo usar o seu micrófono."
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Seleccione o formato para os números, datas e moedas. Os cambios "
+#~ "aplicaranse no seguinte inicio de sesión."
+
+#~ msgid "My Account"
+#~ msgstr "A miña conta"
+
+#~ msgid "Language"
+#~ msgstr "Idioma"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "O idioma usado para o texto en xanelas e páxinas web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Reinicie a sesión para que se apliquen os cambios"
+
+#~ msgid "Restart…"
+#~ msgstr "Reiniciar…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "As preferencias de inicio de sesión úsanas todos os usuarios ao iniciar a "
+#~ "sesión no sistema"
+
+#~ msgid "Standard"
+#~ msgstr "Estándar"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Tipo de conta"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Permitirlle ao usuario estabelecer o contrasinal no seguinte _inicio de "
+#~ "sesión"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Estabelecer un contrasinal _agora"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Debe estar en liña para engadir usuarios corporativos."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Sacar unha foto…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para realizar os cambios,\n"
+#~ "primeiro prema na icona *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Crear unha conta de usuario"
+
+#~ msgid "User Icon"
+#~ msgstr "Icona de usuario"
+
+#~ msgid "Account Settings"
+#~ msgstr "Preferencias da conta"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autenticación e inicio de sesión"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "Usarase como nome para o seu cartafol persoal e non pode cambiarse."
+
+#~ msgid "Output:"
+#~ msgstr "Saída:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Asignar a unha única pantalla"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Mostrar mapeo"
+
+#~ msgid "Stylus"
+#~ msgstr "Lapis"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tableta (absoluto)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Área táctil (relativo)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferencias da tableta"
+
+#~ msgid "_Help"
+#~ msgstr "_Axuda"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Preferencias de Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Modo de seguimento"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Asignar botóns…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Axustar as preferencias do rato"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Axustar a resolución do monitor"
+
+#~ msgid "Decouple Display"
+#~ msgstr "Desacoplar pantallas"
+
+#~ msgid "No stylus found"
+#~ msgstr "Non se atopou ningún lapis dixital"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Mova o seu lapis dixital preto da táboa para configuralo"
+
+#~ msgid "Top Button"
+#~ msgstr "Botón superior"
+
+#~ msgid "Lower Button"
+#~ msgstr "Botón inferior"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Botón inferior"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Gardar unha captura de pantalla en $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Gardar unha captura de pantalla dunha área en $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copiar unha captura de pantalla ao portapapeis"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copiar unha captura de pantalla dunha xanela ao portapapeis"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copiar unha captura de pantalla dunha área ao portapapeis"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Facer unha gravación da pantalla"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Controla que resultados de busca se mostran na Vista xeral de "
+#~ "Actividades. A orde dos resultados da busca tamén se poden cambiar "
+#~ "movendo as filas na lista."
+
+#~ msgid "Web Links"
+#~ msgstr "Ligazóns web"
+
+#~ msgid "Git Links"
+#~ msgstr "Ligazóns de Git"
+
+#~ msgid "%s Links"
+#~ msgstr "Ligazóns de %s"
+
+#~ msgid "Unset"
+#~ msgstr "Desestabelecer"
+
+#~ msgid "Links"
+#~ msgstr "Ligazóns"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Ficheiros de hipertexto"
+
+#~ msgid "Text Files"
+#~ msgstr "Ficheiros de texto"
+
+#~ msgid "Image Files"
+#~ msgstr "Ficheiros de imaxe"
+
+#~ msgid "Font Files"
+#~ msgstr "Ficheiros de tipos de letra"
+
+#~ msgid "Archive Files"
+#~ msgstr "Ficheiros de arquivo"
+
+#~ msgid "Package Files"
+#~ msgstr "Ficheiros de paquetes"
+
+#~ msgid "Audio Files"
+#~ msgstr "Ficheiros de audio"
+
+#~ msgid "Video Files"
+#~ msgstr "Ficheiros de vídeo"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permisos e acceso"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Os datos e os servizos aos que esta aplicación solicitou acceso e os "
+#~ "permisos que require."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Non se pode cambiar"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Os permisos individuais para as aplicacións poden ser revisados nas "
+#~ "Preferencias de <a href=\"privacy\">Privacidade</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integración"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Estabelecer o fondo de escritorio"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Xestor por omisión"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Os tipos de ficheiros e ligazóns que esta aplicación abre."
+
+#~ msgid "Usage"
+#~ msgstr "Uso"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Cantos recursos está usando esta aplicación."
+
+#~ msgid "Open in Software"
+#~ msgstr "Abrir en Software"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Permitir que os aplicativos de abaixo usar a súa cámara."
+
+#~ msgid "Display Mode"
+#~ msgstr "Modo de pantalla"
+
+#~ msgid "Join Displays"
+#~ msgstr "Unir pantallas"
+
+#~ msgid "Single Display"
+#~ msgstr "Pantalla única"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Arrastre as pantallas para que coincidan coa súa configuración física de "
+#~ "pantallas. Seleccione unha pantalla para cambiar as súas configuracións."
+
+#~ msgid "Active Display"
+#~ msgstr "Pantalla activa"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Os servizos de localización permítenlle ás aplicacións determinar a "
+#~ "posición xeográfica. A precisión aumentará ao activar o Wifi ou conexión "
+#~ "de banda larga."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Usa o Servizo de Localización de Mozilla: <a href='https://location."
+#~ "services.mozilla.com/privacy'>Política de privacidade</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Permitir ás aplicacións de embaixo determinar a súa localización."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Portátil detectado: modo de rendemento non dispoñíbel"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Temperatura do hardware alta: modo de rendemento non dispoñíbel"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Modo de rendemento non dispoñíbel"
+
+#~ msgid "Activities"
+#~ msgstr "Actividades"
+
+#~ msgid "_Copy"
+#~ msgstr "_Copiar"
+
+#~ msgid "Select _All"
+#~ msgstr "Seleccionar _todo"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Tempo de espera da pulsación dobre"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Botón de suspender e apagar"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "Algúns servizos están desactivados devido a que non ten acceso á rede."
+
+#~ msgid "Sound Keys"
+#~ msgstr "Teclas de son"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Lector de pantalla"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Lector de _pantalla"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Produciuse un erro ao subir o ficheiro: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "O perfil foi subido a:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Anote este URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Reinicie este computador e arrinque o sistema operativo normal."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Escriba o URL no seu navegador para descargar e instalar este perfil."
+
+#~ msgid "Upload profile"
+#~ msgstr "Subir perfil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Require unha conexión a Internet"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Desbloqueando…"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Inicio de sesión;Nome;Pegada dixital;Avatar;Logotipo;Cara;Contrasinal;"
+
+#~ msgid "Balanced Power"
+#~ msgstr "Balanceo de enerxía"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Atallo de teclado"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Isto pode cambiarse en Personalizar Atallos"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Manteña e escriba para escribir caracteres diferentes"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Brillo da pantall_a"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Brillo do _teclado"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Escurecer a pantalla se está inactivo"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "Pantalla en _branco"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wifi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Pode desactivar o Wifi para aforrar enerxía."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Pode desactivar a banda larga móbil (3G, 4G, WiMax, etc.) para aforrar "
+#~ "enerxía."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Pode desactivar o Bluetooth para aforrar enerxía."
+
+#~ msgid "Add…"
+#~ msgstr "Engadir…"
+
+#~ msgid "Left Alt"
+#~ msgstr "Alt esquerda"
+
+#~ msgid "Right Alt"
+#~ msgstr "Alt dereito"
+
+#~ msgid "Left Super"
+#~ msgstr "Super esquerda"
+
+#~ msgid "Right Super"
+#~ msgstr "Super dereita"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl dereito"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Tecla de caracteres alternativos"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Só modificadores cambian á seguinte orixe"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Tecla menú"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Cargando"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Precaución"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Baixa"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Boa"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Cargada completamente"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Baleir"
+
+#~ msgid "Previous source"
+#~ msgstr "Anterior orixe"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Maiús+Espacio"
+
+#~ msgid "Next source"
+#~ msgstr "Seguinte orixe"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Espacio"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt esquerdo+dereito"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Engadir contas de usuario e cambiar contrasinais"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Reproducir e gravar son"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Detectar dispositivos de rede usando mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Acceder ao hardware de bluetooth directamente"
+
+#~ msgid "Use your camera"
+#~ msgstr "Usar a túa cámara"
+
+#~ msgid "Print documents"
+#~ msgstr "Imprimir documentos"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Usar calquera joystick conectado"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Permitir conectarse ao servizo Docker"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Configurar o cortalumes da rede"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Configurar e usar un sistema de ficheiros FUSE privilexiado"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Actualizar o firmware neste dispositivo"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Acceder á información do hardware"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Fornecer entropía ao xerador de números aleatorios hardware"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Usar un xerador de números aleatorios por hardware"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Acceder aos ficheiros no seu cartafol persoal"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Acceder ao servizo libvirt"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Cambiar o idioma do sistema e as preferencias de rexión"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Cambiar as preferencias e fornecedores de localización"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Ler os rexistros de aplicación e sistema"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "acceder ao servizo do hub multimedia"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Usar e configurar modems"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Ler a información dos montaxes do sistema e as cuotas de disco"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Controlar os reprodutores de música e vídeo"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Cambiar as preferencias de baixo nivel da rede"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Acceder ao servizo NetworkManager para ler e cambiar as preferencias de "
+#~ "rede"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Acceso de lectura ás preferencias da rede"
+
+#~ msgid "Change network settings"
+#~ msgstr "Cambiar as preferencias da rede"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Acceder ao servizo de ofono para ler e cambiar as preferencias de rede "
+#~ "para a rede de telefonía"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Controlar o hardware de Open vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Ler desde o CD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Ler, engadir, cambiar ou eliminar os contrasinais gardados"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Acceder aos dispositivos pppd e ppp para configurar as conexións do "
+#~ "Protocolo Punto-a-Punto"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Pausar e deter calquera proceso no sistema"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Acceder ao hardware USB directamente"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Ler/escribir ficheiros nos dispositivos de almacenamento removíbeis"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Previr o bloqueo e apagado da pantalla"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Acceso a hardware por porto serie"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Reiniciar e apagar o dispositivo"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Instalar, eliminar e configurar software"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Acceder ao servizo do marco de traballo de almacenamento"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Ler o proceso e información do sistema"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Monitorizar e controlar calquera programa en execución"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Cambiar as preferencias do servidor de hora"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Cambiar o fuso horario"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Acceder ao servizo de UDisks2 para configurar discos e medios removíbeis"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Ler/cambiar os eventos de calendario compartido en Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Ler/cambiar os contactos compartidos en Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Acceder aos datos de uso da enerxía"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Ler/escribir o acceso aos dispositivos U2F expostos"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Estabelecer fondo e pantalla de bloqueo"
+
+#~ msgid "Set Background"
+#~ msgstr "Estabelecer fondo"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Estabelecer pantalla de bloqueo"
+
+#~ msgid "Remove Background"
+#~ msgstr "Quitar fondo"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Acceso universal"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Apagar para conectarse a unha rede sen fíos"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Contrasinal"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para crear unha conta de usuario,\n"
+#~ "primeiro prema na icona *"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Activar o Inicio con pegadas dixitais"
+
+#~ msgid "_Other finger:"
+#~ msgstr "Outro _dedo:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "A súa pegada dixital foi gardada correctamente. Agora poderá iniciar a "
+#~ "sesión usando o seu lector de pegadas dixitais."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Non ten permiso para acceder ao dispositivo. Contacte co administrador do "
+#~ "seu sistema."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Produciuse un erro interno."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Desexa eliminar as pegadas dixitais rexistradas?"
+
+#~ msgid "Done!"
+#~ msgstr "Feito!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Non foi posíbel acceder ao dispositivo «%s»"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Non foi posíbel iniciar a captura do dedo no dispositivo «%s»"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Non foi posíbel acceder a ningún lector de pegadas dixitais"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Contacte co administrador do seu sistema para obter axuda."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Para activar o inicio de sesión con pegadas dixitais debe gardar unha das "
+#~ "súas pegadas dixitais usando o dispositivo «%s»."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Seleccionando dedo"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "Os informes envíanse de forma anónima e límpanse de datos persoais."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Ao enviar informes de problemas técnicos axudaranos a mellorar este "
+#~ "sistema operativo."
+
+#, fuzzy
+#~| msgid "Restrict background data usage"
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Restrinxir o uso de datos en segundo plano"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Axeitado para as conexións que teñen custo ou límites de datos."
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Xanelas _emerxentes das notificacións"
+
+#~ msgid "No regions found"
+#~ msgstr "Non se atoparon rexións"
+
+#~ msgid "Last Login"
+#~ msgstr "Último inicio de sesión"

--- a/po/gnome-control-center.pot
+++ b/po/gnome-control-center.pot
@@ -1,0 +1,4964 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+msgid "Seconds"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr ""
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr ""
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr ""
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+msgid "Pointer Location"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr ""
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr ""
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr ""
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr ""
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr ""
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr ""
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr ""
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr ""
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr ""
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr ""
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr ""
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr ""
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+msgid "Windows Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr ""
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr ""
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""

--- a/po/gu.po
+++ b/po/gu.po
@@ -5,9 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.master.gu\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug."
-"cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-08-27 06:31+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-09-22 11:54+0530\n"
 "Last-Translator: \n"
 "Language-Team: American English <kde-i18n-doc@kde.org>\n"
@@ -53,6327 +52,4802 @@ msgstr ""
 "\n"
 "\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "કાર્યક્રમો"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "કાર્યક્રમો મળ્યા નથી"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "સુધારા સ્થાપિત કરો"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "ખોલો (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "વિગતો દર્શાવો"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "શોધો"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "નિષ્ક્રિય"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "સૂચનાઓ"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "સૂચનાઓ બતાવો (_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "પાશ્વ ભાગ"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "સ્ક્રીનશોટ"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "વોલપેપરો"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "ધ્વનિ"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "ટૂંકાણો"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "કિબોર્ડ ટૂંકાણો"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s કેમેરા"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "માઇક્રોફોન વોલ્યુમ"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "સ્થાન સેવા (_L)"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "બિલ્ટ-ઇન વેબકેમ"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "વિસ્તાર મળ્યા નથી"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "પ્રકારને દર્શાવો"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "કડી ઝડપ"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "પુનઃસુયોજીત કરો"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "કાર્યક્રમો"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "સ્ટાયલસ"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "મૂળભૂત"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "પાશ્વ ભાગ"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "દિવસ દરમ્યામ બદલે છે"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "રૂપરેખા ઉમેરો (_A)..."
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-#| msgid "Lock screen"
-msgid "Lock Screen"
-msgstr "સ્ક્રીનને તાળુ મારો"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "ફ્રાન્સ"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "તકતી"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "નાનુ મોટુ કરો"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "કેન્દ્ર"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "માપ"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "ભરો"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "સ્પાન"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:442
-msgid "Select Background"
-msgstr "પાશ્વભાગ પસંદ કરો"
-
-#: ../panels/background/cc-background-chooser-dialog.c:463
-msgid "Wallpapers"
-msgstr "વોલપેપરો"
-
-#: ../panels/background/cc-background-chooser-dialog.c:472
-msgid "Pictures"
-msgstr "ચિત્રો"
-
-#: ../panels/background/cc-background-chooser-dialog.c:481
-msgid "Colors"
-msgstr "રંગો"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:540
-#| msgid "Pictures Folder"
-msgid "No Pictures Found"
-msgstr "ચિત્ર મળ્યા નથી"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:558
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "ઘર"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:570
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "તમે તમારાં %s ફોલ્ડરમાં ઇમેજોને ઉમેરી શકો છો અને તેઓ અહિંયા બતાવશે"
-
-#: ../panels/background/cc-background-chooser-dialog.c:592
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1537
-#: ../panels/display/cc-display-panel.c:1976
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1240
-#: ../panels/network/net-device-wifi.c:1448
-#: ../panels/printers/cc-printers-panel.c:1947
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-#: ../panels/user-accounts/um-photo-dialog.c:95
-#: ../panels/user-accounts/um-photo-dialog.c:222
-#: ../panels/user-accounts/um-user-panel.c:513
-msgid "_Cancel"
-msgstr "રદ કરો (_C)"
-
-#: ../panels/background/cc-background-chooser-dialog.c:593
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:97
-msgid "Select"
-msgstr "પસંદ કરો"
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "ઘણાબધા માપો"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "ડેસ્કટોપ પાશ્વ ભાગ નથી"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "હાલનાં પાશ્ર્વભાગો"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "વોલપેપર અથવા ફોટોમાં તમારાં ઇમેજનાં પાશ્ર્વભાગને બદલો"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "વોલપેપર;સ્ક્રીન;ડેસ્કટોપ;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "બ્લુટુથ નિષ્ક્રિય થયેલ છે"
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "સક્રિય"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "બ્લુટુથ ઍડપ્ટર મળ્યુ નથી"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "બ્લુટુથ ભાગીદારી"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "ઍરપ્લેન સ્થિતિ (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "હાર્ડવેર સ્વીચ દ્દારા બ્લુટુથ નિષ્ક્રિય થયેલ છે"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1688
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "ઍરપ્લેન સ્થિતિ (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "ઍરપ્લેન સ્થિતિ (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "બ્લુટુથ"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "બ્લુટુથને ચાલુ અને બંધ કરો અને તમારાં ઉપકરણો સાથે જોડાવો"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "ચોરસ પર તમારું માપદંડ ઉપકરણને સ્થિત કરો અને 'શરૂ કરો' બટન દબાવો"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
-msgid "Move your calibration device to the calibrate position and press 'Continue'"
-msgstr "સ્થાનને માપન કરવા માટે તમારું માપદંડ ઉપકરણને ખસાડો અને 'ચાલુ રાખો' બટન દબાવો"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid "Move your calibration device to the surface position and press 'Continue'"
-msgstr "સપાટ સ્થાન માટે તમારાં માપદંડ ઉપકરણને ખસેજો અને 'ચાલુ રાખો' બટનને દબાવો"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "લૅપટોપ lid ને બંધ કરો"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-#| msgid "An internal error occurred."
-msgid "An internal error occurred that could not be recovered."
-msgstr "આંતરિક ભૂલ ઉદ્દભવી કે જે પ્રાપ્ત કરી શક્યા નહિં."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "કેલિબ્રેશન માટે જરૂરી સાધનો સ્થાપિત થયેલ નથી."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "રૂપરેખાને બનાવી શક્યા નહિં."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "લક્ષ્ય સફેદબિંદુને પ્રાપ્ત કરી શકાય તેમ નથી."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-#| msgctxt "print job"
-#| msgid "Completed"
-msgid "Complete!"
-msgstr "સમાપ્ત!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-#| msgid "Configuration failed"
-msgid "Calibration failed!"
-msgstr "માપદંડ નિષ્ફળ!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "તમે કેલિબ્રેશન ઉપકરણને દૂર કરી શકો છો."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "કેલિબ્રેશન ઉપકરણને ખલેલ પહોંચાડો નહિં જ્યાપે પ્રગતિમાં હોય"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-#| msgid "Lock screen"
-msgid "Laptop Screen"
-msgstr "લૅપટોપ સ્ક્રીન"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-#| msgid "Built-in"
-msgid "Built-in Webcam"
-msgstr "બિલ્ટ-ઇન વેબકેમ"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-#| msgid "Monitor"
-msgid "%s Monitor"
-msgstr "%s મોનિટર"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-#| msgctxt "Device kind"
-#| msgid "Scanner"
-msgid "%s Scanner"
-msgstr "%s સ્કેનર"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-#| msgctxt "Device kind"
-#| msgid "Camera"
-msgid "%s Camera"
-msgstr "%s કેમેરા"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-#| msgctxt "Device kind"
-#| msgid "Printer"
-msgid "%s Printer"
-msgstr "%s પ્રિન્ટર"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-#| msgctxt "Device kind"
-#| msgid "Webcam"
-msgid "%s Webcam"
-msgstr "%s વેબકેમ"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-#| msgid "Learn more about color management"
-msgid "Enable color management for %s"
-msgstr "%s માટે રંગ સંચાલનને સક્રિય કરો"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s માટે રંગ રૂપરેખાને બતાવો"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-#| msgid "Uncalibrated"
-msgid "Not calibrated"
-msgstr "માપદંડ થયેલ નથી"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "મૂળભૂત: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "રંગસ્થાન: "
-
-# libgnomeprintui/gpaui/add-printer-dialog.c:83
-# libgnomeprintui/gpaui/config-dialog.c:83
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "રૂપરેખા ચકાસો: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "ICC રૂપરેખા ફાઇલ પસંદ કરો"
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "આયાત કરો (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "આધારભૂત ICC રૂપરેખાઓ"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "બધી ફાઇલો"
-
-#: ../panels/color/cc-color-panel.c:582
-#| msgctxt "Distance"
-#| msgid "¼ Screen"
-msgid "Screen"
-msgstr "સ્ક્રીન"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-#| msgid "Failed to apply configuration: %s"
-msgid "Failed to upload file: %s"
-msgstr "ફાઇલને અપલોડ કરવામાં નિષ્ફળતા: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "રૂપરેખા તેમાં સુધારી દેવામાં આવી છે:"
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "આ URL ને લખો."
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
-msgstr "આ કમ્પ્યૂટરને ફરી શરૂ કરો અને તમારી સામાન્ય ઓપરેટીંગ સિસ્ટમને બુટ કરો."
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "ડાઉનલોડ કરવા માટે તમારાં બ્રાઉઝરમાં URL ને ટાઇપ કરો અને રૂપરેખાને સ્થાપિત કરો."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-#| msgid "Remove profile"
-msgid "Save Profile"
-msgstr "પ્રોફાઇલને સંગ્રહ કરો"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "સંગ્રહો (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "પસંદ થયેલ ઉપકરણ માટે રંગ રૂપરેખા બનાવો:"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
-"માપન સાધન મળતુ નથી. મહેરબાની કરીને ચકાસો કે તે ચાલુ છે કે નહિં અને યોગ્ય રીતે જોડાયેલ છે."
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "માપન સાધન પ્રિન્ટર રૂપરેખાને આધાર આપતુ નથી."
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "ઉપકરણ પ્રકાર હાલમાં આધારભૂત નથી."
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "કાર્યક્રમ હાલમાં ઓડિયોને વગાડી અથવા રેકોર્ડ કરી રહ્યુ છે."
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-#| msgctxt "Experience"
-#| msgid "Standard"
-msgid "Standard Space"
-msgstr "મૂળભૂત જગ્યા"
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-# libgnomeprintui/gpaui/add-printer-dialog.c:83
-# libgnomeprintui/gpaui/config-dialog.c:83
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-#| msgid "Test profile: "
-msgid "Test Profile"
-msgstr "રૂપરેખા ચકાસો"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-#| msgctxt "proxy method"
-#| msgid "Automatic"
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "સ્વયં"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "વધારે ચિત્રો માટે બ્રાઉઝ કરો"
 
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-#| msgctxt "Printer Option Group"
-#| msgid "Image Quality"
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "નીચી ગુણવત્તા"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-#| msgctxt "Printer Option Group"
-#| msgid "Image Quality"
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "મધ્યમ ગુણવત્તા"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-#| msgctxt "Printer Option Group"
-#| msgid "Image Quality"
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "ઉચ્ચ ગુણવત્તા"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "મૂળભૂત RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "મૂળભૂત CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "મૂળભૂત ગ્રે"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "વિક્રેતા ફેક્ટરી માપદંડ માહિતીને પૂરુ પાડે છે"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "સંપૂર્ણ-સ્ક્રીન દર્શાવ સુધારો આ રૂપરેખા સાથે શક્ય નથી"
-
-#: ../panels/color/cc-color-profile.c:225
-#| msgid "This device has an old profile that may no longer be accurate."
-msgid "This profile may no longer be accurate"
-msgstr "આ રૂપરેખા લાંબા સમય સુધી ચોક્કસ રહી શકતી નથી"
-
-#: ../panels/color/color-calibrate.ui.h:1
-#| msgid "Calibration"
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "કેલિબ્રેશન દર્શાવો"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr "રદ કરો"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "રદ કરો (_C)"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "શરૂ કરો"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "ફરી શરૂ કરો"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-#| msgid "Done!"
-msgid "Done"
-msgstr "પૂર્ણ"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "પૂર્ણ (_D)"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "સ્ક્રીન માપાંકન"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "કેલિબ્રેશન ગુણવત્તા"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"માપદંડ રૂપરેખાને પેદા કરશે કે જે રંગ સંચાલિત તમારી સ્ક્રીનને વાપરી શકો છો. માપદંડ પર લાંબો સમય "
-"વિતાવી શકો છો, રંગ રૂપરેખાની ગુણવત્તાને સારી બનાવવા."
+"માપદંડ રૂપરેખાને પેદા કરશે કે જે રંગ સંચાલિત તમારી સ્ક્રીનને વાપરી શકો છો. માપદંડ પર લાંબો "
+"સમય વિતાવી શકો છો, રંગ રૂપરેખાની ગુણવત્તાને સારી બનાવવા."
 
-#: ../panels/color/color.ui.h:3
-msgid "You will not be able to use your computer while calibration takes place."
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
 msgstr "તમે તમારું કમ્પ્યૂટર વાપરી શકશો નહિં જ્યારે માપદંડ થતુ હોય."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
-#| msgctxt "Printer Option Group"
-#| msgid "Image Quality"
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "ગુણવત્તા"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "આશરે સમય"
 
-#: ../panels/color/color.ui.h:8
-#| msgid "Calibration"
-msgid "Calibration Quality"
-msgstr "કેલિબ્રેશન ગુણવત્તા"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "સેન્સર ઉપકરણને પસંદ કરો તમે કેલિબ્રેશન માટે વાપરવા માંગો તો."
-
-#: ../panels/color/color.ui.h:10
-#| msgid "Calibration"
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "કેલિબ્રેશન ઉપકરણ"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "દર્શાવનાં પ્રકારને પસંદ કરો કે જે જોડાયેલ છે."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "સેન્સર ઉપકરણને પસંદ કરો તમે કેલિબ્રેશન માટે વાપરવા માંગો તો."
 
-#: ../panels/color/color.ui.h:12
-#| msgctxt "Device kind"
-#| msgid "Display"
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "પ્રકારને દર્શાવો"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "દર્શાવનાં પ્રકારને પસંદ કરો કે જે જોડાયેલ છે."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "રૂપરેખા સફેદબિંદુ"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
-"દર્શા લક્ષ્ય સફેદ બિંદુને પસંદ કરો. મોટેભાગે દર્શાવો D65 illuminant માં માપદંડ થયેલ હોવુ જોઇએ."
+"દર્શા લક્ષ્ય સફેદ બિંદુને પસંદ કરો. મોટેભાગે દર્શાવો D65 illuminant માં માપદંડ થયેલ હોવુ "
+"જોઇએ."
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "રૂપરેખા સફેદબિંદુ"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "પ્રકાશતા દર્શાવો"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"મહેરબાની કરીને તેજ પ્રદર્શન માટે દર્શાવ સુયોજિત કરો કે જે ખાસ કરીને તમારી માટે છે. રંગ સંચાલન "
-"આ પ્રકાશતા સ્તરે વધારે ચોક્કસ હશે."
+"મહેરબાની કરીને તેજ પ્રદર્શન માટે દર્શાવ સુયોજિત કરો કે જે ખાસ કરીને તમારી માટે છે. રંગ "
+"સંચાલન આ પ્રકાશતા સ્તરે વધારે ચોક્કસ હશે."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
-"વૈકલ્પિક રીતે, તમે આ ઉપકરણ માટે બીજી રૂપરેખાનાં એક સાથે વાપરેલ પ્રકાશતા સ્તરને વાપરી શકો છો."
+"વૈકલ્પિક રીતે, તમે આ ઉપકરણ માટે બીજી રૂપરેખાનાં એક સાથે વાપરેલ પ્રકાશતા સ્તરને વાપરી શકો "
+"છો."
 
-#: ../panels/color/color.ui.h:17
-#| msgid "Brightness"
-msgid "Display Brightness"
-msgstr "પ્રકાશતા દર્શાવો"
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "રૂપરેખાનું નામ"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
-"તમે વિવિધ કમ્પ્યૂટર પર રંગ રૂપરેખાને વાપરી શકો છો, અથવા વિવિધ પ્રકાશતા શરતો માટે રૂપરેખાઓને "
-"બનાવી પણ શકો છો."
+"તમે વિવિધ કમ્પ્યૂટર પર રંગ રૂપરેખાને વાપરી શકો છો, અથવા વિવિધ પ્રકાશતા શરતો માટે "
+"રૂપરેખાઓને બનાવી પણ શકો છો."
 
 # libgnomeprintui/gpaui/add-printer-dialog.c:83
 # libgnomeprintui/gpaui/config-dialog.c:83
-#: ../panels/color/color.ui.h:19
-#| msgid "_Profile:"
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "રૂપરેખાનું નામ:"
 
-# libgnomeprintui/gpaui/add-printer-dialog.c:83
-# libgnomeprintui/gpaui/config-dialog.c:83
-#: ../panels/color/color.ui.h:20
-#| msgid "_Profile:"
-msgid "Profile Name"
-msgstr "રૂપરેખાનું નામ"
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "સારાંશ"
 
-#: ../panels/color/color.ui.h:21
+#: panels/color/cc-color-panel.ui:259
 msgid "Profile successfully created!"
 msgstr "રૂપરેખા સફળતાપૂર્વક બનાવેલ છે!"
 
 # libgnomeprintui/gpaui/add-printer-dialog.c:83
 # libgnomeprintui/gpaui/config-dialog.c:83
-#: ../panels/color/color.ui.h:22
-#| msgid "No profile"
+#: panels/color/cc-color-panel.ui:290
 msgid "Copy profile"
 msgstr "રૂપરેખાની નકલ કરો"
 
-#: ../panels/color/color.ui.h:23
+#: panels/color/cc-color-panel.ui:296
 msgid "Requires writable media"
 msgstr "લખી શકાય તેવી મીડિયાની જરૂરિયાત છે"
 
-# libgnomeprintui/gpaui/add-printer-dialog.c:83
-# libgnomeprintui/gpaui/config-dialog.c:83
-#: ../panels/color/color.ui.h:24
-#| msgid "No profile"
-msgid "Upload profile"
-msgstr "રૂપરેખા અપલોડ કરો"
-
-#: ../panels/color/color.ui.h:25
-#| msgid "Add new connection"
-msgid "Requires Internet connection"
-msgstr "ઇન્ટરનેટ જોડાણની જરૂરિયાત છે"
-
-#: ../panels/color/color.ui.h:26
+#: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"તમે આ સૂચનાઓને શોધી શકો છો કે જે <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> અને <a href=\"windows"
-"\">Microsoft Windows</a> અને ઉપયોગી સિસ્ટમો પર કેવી રીતે વાપરે છે."
+"તમે આ સૂચનાઓને શોધી શકો છો કે જે <a href=\"linux\">GNU/Linux</a>, <a "
+"href=\"osx\">Apple OS X</a> અને <a href=\"windows\">Microsoft Windows</a> અને "
+"ઉપયોગી સિસ્ટમો પર કેવી રીતે વાપરે છે."
 
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:740
-msgid "Summary"
-msgstr "સારાંશ"
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "રૂપરેખા ઉમેરો"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "ફાઈલ આયાત કરો…"
-
-#: ../panels/color/color.ui.h:29
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
-msgstr "સમસ્યાઓ શોધાઇ. રૂપરેખા યોગ્ય રીકે કામ કરી શકશે નહિં. <a href=\"\">વિગતો બતાવો.</a>"
+msgstr ""
+"સમસ્યાઓ શોધાઇ. રૂપરેખા યોગ્ય રીકે કામ કરી શકશે નહિં. <a href=\"\">વિગતો બતાવો.</a>"
 
-#: ../panels/color/color.ui.h:30
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "ફાઈલ આયાત કરો…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "ઉમેરો (_A)"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "દરેક ઉપકરણને સંચાલિત રંગની રંગ રૂપરેખાને અદ્યતન રાખવાની જરૂર છે."
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "વધારે શીખો"
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "રંગ સંચાલન વિશે વધારે શીખો"
 
 # #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/color/color.ui.h:33
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "બધા વપરાશકર્તાઓ માટે સુયોજિત કરો"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "આ કમ્પ્યૂટર પર બધા વપરાશકર્તાઓ માટે આ રૂપરેખાને સુયોજિત કરો"
 
 # #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
-#: ../panels/color/color.ui.h:35
-#| msgid "Enabled"
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "સક્રિય"
 
-#: ../panels/color/color.ui.h:36
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "રૂપરેખા ઉમેરો"
 
-#: ../panels/color/color.ui.h:37
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "માપદંડ કરો…"
 
-#: ../panels/color/color.ui.h:38
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "ઉપકરણનું માપદંડ કરો"
 
-#: ../panels/color/color.ui.h:39
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "રૂપરેખાને દૂર કરો"
 
-#: ../panels/color/color.ui.h:40
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "વિગતો દર્શાવો"
 
-#: ../panels/color/color.ui.h:41
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "કોઇપણ ઉપકરણોને શોધવાનું અસમર્થ કે જે રંગને સંચાલિત કરી શકાય છે"
 
-#: ../panels/color/color.ui.h:42
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:45
-#| msgid "Co_untry:"
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "પ્રોજેક્ટર"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "પ્લાઝ્મા"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL બેકલાઇટ)"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED બેકલાઇટ)"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (white LED બેકલાઇટ)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Wide gamut LCD (CCFL બેકલાઇટ)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Wide gamut LCD (RGB LED બેકલાઇટ)"
 
-#: ../panels/color/color.ui.h:52
-#| msgid "High"
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "વધારે"
 
-#: ../panels/color/color.ui.h:53
-#| msgid "10 minutes"
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 મિનિટો"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "મધ્યમ"
 
-#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 મિનિટો"
 
-#: ../panels/color/color.ui.h:56
-#| msgid "Low"
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "ઓછુ"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
-#| msgid "5 minutes"
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 મિનિટ"
 
-#: ../panels/color/color.ui.h:58
-#| msgid "Panel to display"
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "પ્રદર્શિત કરલા માટે મૂળ"
 
-#: ../panels/color/color.ui.h:59
-#| msgid "Pointing and Clicking"
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (છાપન અને પ્રકાશિત)"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (ફોટોગ્રાફી અને ગ્રાફિક્સ)"
 
-#: ../panels/color/color.ui.h:62
-#| msgid "75%"
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "રંગ"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Calibrate the color of your devices, such as displays, cameras or printers"
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "તમારાં ઉપકરણોનાં રંગને કેલિબ્રેટ કરો, જેમ કે દર્શાવ, કૅમેરા અથવા પ્રિન્ટરો"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "રંગ;ICC;રૂપરેખા;માપદંડ;પ્રિન્ટર;દર્શાવ;"
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:684
-msgid "United States"
-msgstr "યુનાઇટેડ સ્ટેટ્સ"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "ભાષા પસંદ કરો"
 
-#: ../panels/common/cc-common-language.c:685
-msgid "Germany"
-msgstr "જર્મની"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "પસંદ કરો (_S)"
 
-#: ../panels/common/cc-common-language.c:686
-msgid "France"
-msgstr "ફ્રાન્સ"
-
-#: ../panels/common/cc-common-language.c:687
-msgid "Spain"
-msgstr "સ્પેન"
-
-#: ../panels/common/cc-common-language.c:688
-msgid "China"
-msgstr "ચાઇના"
-
-#: ../panels/common/cc-common-language.c:758
-#| msgid "Other profile…"
-msgid "Other…"
-msgstr "બીજું..."
-
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr "વધારે…"
-
-#: ../panels/common/cc-language-chooser.c:140
-#| msgid "No Bluetooth adapters found"
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "ભાષાઓ મળી નથી"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "ભાષા"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "વધારે…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-#| msgid "Done!"
-msgid "_Done"
-msgstr "પૂર્ણ (_D)"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-#| msgid "%a %l:%M %p"
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "તાળુ ખોલો"
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "માપ વધારો:"
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "સમય"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-#| msgid "%a %l:%M %p"
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "માપને ઘટાડો:"
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "જાન્યુઅરી "
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "ફેબ્રુઆરી"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "માર્ચ"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "એપ્રિલ"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "મે"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "જૂન"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "જુલાઈ"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "ઑગસ્ટ"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "સેપ્ટેમ્બર"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "ઑક્ટોબર"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "નવેમ્બર"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "ડિસેમ્બર"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "તારીખ અને સમય"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "કલાક"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-#| msgid "minute"
-#| msgid_plural "minutes"
-msgid "Minute"
-msgstr "મિનિટ"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "દિવસ"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "મહિનો"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "વર્ષ"
 
-#: ../panels/datetime/datetime.ui.h:21
-#| msgid "Time"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "મહિનો"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "જાન્યુઅરી "
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ફેબ્રુઆરી"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "માર્ચ"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "એપ્રિલ"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "મે"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "જૂન"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "જુલાઈ"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "ઑગસ્ટ"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "સેપ્ટેમ્બર"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ઑક્ટોબર"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "નવેમ્બર"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ડિસેમ્બર"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "દિવસ"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "ટાઈમ ઝોન"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "શહેર માટે શોધો"
 
-#: ../panels/datetime/datetime.ui.h:23
-#| msgid "Date & Time"
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "આપોઆપ તારીખ અને સમય (_D)"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "ઇન્ટરનેટ પ્રવેશની જરૂરિયાત છે"
 
-#: ../panels/datetime/datetime.ui.h:25
-#| msgid "A_utomatic Login"
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "તારીખ અને સમય (_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "આપોઆપ ટાઇમઝોન (_Z)"
 
-#: ../panels/datetime/datetime.ui.h:26
-#| msgid "Date & Time"
-msgid "Date & _Time"
-msgstr "તારીખ અને સમય (_T)"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "ઇન્ટરનેટ પ્રવેશની જરૂરિયાત છે"
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
-msgstr "ટાઈમ ઝોન (_Z)"
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "સક્રિય"
 
-#: ../panels/datetime/datetime.ui.h:28
-#| msgid "Formats"
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "ટાઈમ ઝોન"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "તાળુ ખોલો"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "સમય બંધારણ (_F)"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24-કલાક"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "તારીખો"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "ગૌણ"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "કૅલેન્ડર (_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "નંબરો"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "તારીખ અને સમયને બદલો, ટાઇમ ઝોનને સમાવી રહ્યા છે"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "ઘડિયાળ;ટાઇમઝોન;સ્થાન;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "સિસ્ટમ સમય અને તારીખ સુયોજનોને બદલો"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "સમય અથવા તારીખ સુયોજનોને બદલવા માટે, તમારે સત્તાધિકરણ કરવુ જરૂરી છે."
 
-#: ../panels/display/cc-display-panel.c:487
-#| msgid "Close"
-msgid "Lid Closed"
-msgstr "ઢાંકણ બંધ થયેલ છે"
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-#| msgid "Mirrored Displays"
-msgid "Mirrored"
-msgstr "પ્રતિબિંબિત"
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2145
-#| msgid "Primary _button"
-msgid "Primary"
-msgstr "પ્રાથમિક"
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "બંધ"
-
-#: ../panels/display/cc-display-panel.c:497
-#| msgid "Secondary color"
-msgid "Secondary"
-msgstr "ગૌણ"
-
-#: ../panels/display/cc-display-panel.c:1533
-#| msgid "Mirrored Displays"
-msgid "Arrange Combined Displays"
-msgstr "સંયુક્ત દર્શાવોને ગોઠવો"
-
-#: ../panels/display/cc-display-panel.c:1539
-#: ../panels/display/cc-display-panel.c:1979
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#| msgid "Supply"
-msgid "_Apply"
-msgstr "લાગુ કરો (_A)"
-
-#: ../panels/display/cc-display-panel.c:1560
-msgid "Drag displays to rearrange them"
-msgstr "તેઓને ફરી ગોઠવવા માટે દર્શાવોને ખેંચો"
-
-#: ../panels/display/cc-display-panel.c:2081
-msgid "Size"
-msgstr "માપ"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2094
-msgid "Aspect Ratio"
-msgstr "આશરે દર"
-
-#: ../panels/display/cc-display-panel.c:2115
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "રીઝોલ્યુશન"
-
-#: ../panels/display/cc-display-panel.c:2146
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "આ દર્શાવ પર ટોચવી પટ્ટી અને પ્રવૃત્તિ ઝાંખીને બતાવો"
-
-#: ../panels/display/cc-display-panel.c:2152
-#| msgid "Secondary click delay"
-msgid "Secondary Display"
-msgstr "ગૌણ દર્શાવ"
-
-#: ../panels/display/cc-display-panel.c:2153
-msgid "Join this display with another to create an extra workspace"
-msgstr "વધારાની કાર્ય કરવાની જગ્યાને બનાવવા બીજા સાથે આ દર્શાવને જોડો"
-
-#: ../panels/display/cc-display-panel.c:2160
-#| msgid "Orientation"
-msgid "Presentation"
-msgstr "રજૂઆત"
-
-#: ../panels/display/cc-display-panel.c:2161
-msgid "Show slideshows and media only"
-msgstr "તકતીપૂર્વદર્શન અને મીડિયાને ફક્ત બતાવો"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2166
-msgid "Mirror"
-msgstr "મિરર"
-
-#: ../panels/display/cc-display-panel.c:2167
-msgid "Show your existing view on both displays"
-msgstr "બંને દર્શાવ પર તમારું હાલનુ દૃશ્ય બતાવો"
-
-#: ../panels/display/cc-display-panel.c:2173
-#| msgid "_Turn On"
-msgid "Turn Off"
-msgstr "બંધ કરો"
-
-#: ../panels/display/cc-display-panel.c:2174
-#| msgid "Panel to display"
-msgid "Don't use this display"
-msgstr "આ દર્શાવને વાપરો નહિં"
-
-#: ../panels/display/cc-display-panel.c:2383
-msgid "Could not get screen information"
-msgstr "સ્ક્રીન જાણકારી ને મેળવી શકાયુ નહિં"
-
-#: ../panels/display/cc-display-panel.c:2414
-#| msgid "Mirrored Displays"
-msgid "_Arrange Combined Displays"
-msgstr "સંયુક્ત દર્શાવને ગોઠવો (_A)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "દેખાવો"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-#| msgid "Change resolution and position of monitors and projectors"
-msgid "Choose how to use connected monitors and projectors"
-msgstr "કેવી રીતે મોનિટર અને પ્રોજેક્ટરને વાપરવુ તેને પસંદ કરો"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "પેનલ;પ્રોજેક્ટર;xrandr;સ્ક્રીન;રિઝોલ્યુશન;તાજુ કરો;મોનિટર;"
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr "Wayland"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "અજ્ઞાત"
-
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-#| msgid "%d-bit"
-msgid "%s %d-bit"
-msgstr "%s %d-બીટ"
-
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr "%d-બીટ"
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr "શું કરવુ છે તે પૂછો"
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr "કઇ કરવાનુ નથી"
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr "ફોલ્ડરને ખોલો"
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr "બીજી મીડિયા"
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr "ઓડિયો CDs માટે કાર્યક્રમને પસંદ કરો"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr "વિડિઓ DVDs માટે કાર્યક્રમને પસંદ કરો"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr "ચલાવવા માટે કાર્યક્રમને પસંદ કરો જ્યારે સંગીત પ્લેયર જોડાયેલ હોય"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr "ચલાવવા માટે કાર્યક્રમને પસંદ કરો જ્યારે કેમેરા જોડાયેલ હોય"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr "સોફ્ટવેર CDs માટે કાર્યક્રમને પસંદ કરો"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr "ઓડિયો DVD"
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr "ખાલી બ્લુ-રે ડિસ્ક"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr "ખાલી CD ડિસ્ક"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr "ખાલી DVD ડિસ્ક"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr "ખાલી HD DVD ડિસ્ક"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr "બ્લુ-રે વિડિયો ડિસ્ક"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr "ઇ-બુટ વાંચનાર"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr "HD DVD વિડિયો ડિસ્ક"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr "ચિત્ર CD"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr "મુખ્ય વિડીયો CD"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr "વિડિયો CD"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr "Windows સોફ્ટવેર"
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
-# gnome-session/logout.c:266
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1917
-msgid "Section"
-msgstr "વિભાગ"
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "ઝાંખી"
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr "મૂળભૂત કાર્યક્રમો"
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "દૂર કરી શકાય તેવી મીડિયા"
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr "આવૃત્તિ %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:44
-msgid "Details"
-msgstr "વિગતો"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr "તમારી સિસ્ટમ વિશે જાણકારી જુઓ"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-#| msgid ""
-#| "device;system;information;memory;processor;version;default;application;"
-#| "fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"ઉપકરણ;સિસ્ટમ;જાણકારી;મેમરી;પ્રોસેસર;આવૃત્તિ;મૂળભૂત;કાર્યક્રમ;પસંદ થયેલ;cd;dvd;usb;"
-"ઓડિયો;વિડિયો;ડિસ્ક;નિરાકરણ;મીડિયા;સ્વયં ચલાવો;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "પસંદ કરો કેવી રીતે બીજી મીડિયાને સંભાળવુ જોઇએ"
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "ક્રિયા (_A):"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "પ્રકાર (_T):"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "ઉપકરણ નામ"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "મેમરી"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "પ્રોસેસર"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "મૂળભૂત સિસ્ટમ"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "ડિસ્ક"
-
-#: ../panels/info/info.ui.h:10
-#| msgid "Calculating..."
-msgid "Calculating…"
-msgstr "ગણતરી…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "ગ્રાફિક્સ"
-
-#: ../panels/info/info.ui.h:12
-#| msgid "Calibration"
-msgid "Virtualization"
-msgstr "વર્ચ્યુલાઇઝેશન"
-
-#: ../panels/info/info.ui.h:13
-#| msgid "Checking for Updates"
-msgid "Check for updates"
-msgstr "સુધારાઓ માટે ચકાસો"
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "વેબ (_W)"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "મેઇલ (_M)"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "કૅલેન્ડર (_C)"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "સંગીત (_u)"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "વિડિઓ (_V)"
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "ફોટા (_P)"
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "પસંદ કરો કેવી રીતે મીડિયાને સંભાળવુ જોઇએ"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "મૂળભૂત કાર્યક્રમો"
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "CD ઓડિયો (_a)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "મૂળભૂત કાર્યક્રમો"
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "DVD વિડિયો (_D)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "સંગીત પ્લેયર (_M)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "સોફ્ટવેર (_S)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:27
-#| msgid "Other Media"
-msgid "_Other Media…"
-msgstr "બીજી મીડિયા (_O)…"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr "મીડિયા નિવેશ પર કદી પૂછો નહિં અથવા કાર્યક્રમ શરૂ કરો (_N)"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "લાગુ કરો (_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "પાછા"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "બ્લુટુથ નિષ્ક્રિય થયેલ છે"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "દર્શાવોને શોધો (_D)"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "મિરર"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "ગૌણ દર્શાવ"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "જમણી રીંગ"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "દિશા"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "રીઝોલ્યુશન"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "માપ"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "પ્રિન્ટરો ઉપલબ્ધ નથી"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "હવે પુન:શરૂ કરો"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "સમય"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "કલાક"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "મિનિટ"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "દેખાવો"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "કેવી રીતે મોનિટર અને પ્રોજેક્ટરને વાપરવુ તેને પસંદ કરો"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "પેનલ;પ્રોજેક્ટર;xrandr;સ્ક્રીન;રિઝોલ્યુશન;તાજુ કરો;મોનિટર;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "સુરક્ષા કી"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "ઇંક સ્તર"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "ઇંક સ્તર"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "ઇંક સ્તર"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "સુરક્ષા"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"સ્ક્રીન;તાળુ;નિદાન;ભંગાણ;ખાનગી;તાજેતરનું;કામચલાઉ;tmp;અનુક્રમણિકા;નામ;નેટવર્ક;ઓળખાણ;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ઉપકરણ નામ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "હાર્ડવેર સરનામું"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "મેમરી"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "પ્રોસેસર"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "ગ્રાફિક્સ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "ગણતરી…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "નામ"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "પ્રકાર"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "આવૃત્તિ 0"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "વિકલ્પો લાવી રહ્યા છે…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows સોફ્ટવેર"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "વર્ચ્યુલાઇઝેશન"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "સોફ્ટવેર વપરાશ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "ઉપકરણ દૂર કરો"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ઉપકરણ નામ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "વપરાશકર્તા નામ (_U)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "તમારી સિસ્ટમ વિશે જાણકારી જુઓ"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ઉપકરણ;સિસ્ટમ;જાણકારી;મેમરી;પ્રોસેસર;આવૃત્તિ;મૂળભૂત;કાર્યક્રમ;પસંદ થયેલ;cd;dvd;usb;ઓડિયો;"
+"વિડિયો;ડિસ્ક;નિરાકરણ;મીડિયા;સ્વયં ચલાવો;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "સાઉન્ડ અને મીડિયા"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "અવાજ મૂંગો"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "અવાજ ઓછો કરો"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "અવાજ વધારો"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "માઇક્રોફોન વોલ્યુમ"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "મીડિયા પ્લેયરને શરૂ કરો"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "વગાડો (વગાડો/અટકાવો)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "પ્લેબેક અટકાવો"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "પ્લેબેક બંધ કરો"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "પહેલાંનુ ટ્રેક"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "આગળનો ટ્રેક"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "બહાર નીકાળો"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "ટાઇપ કરી રહ્યા છે"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
-#| msgid "Switch to next source"
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "આગળનાં ઇનપુટ સ્ત્રોતમાં જાવ"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
-#| msgid "Switch to previous source"
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "પહેલાનાં ઇનપુટ સ્ત્રોતમાં જાવ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "લૉંચર"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "મદદ બ્રાઉઝર શરૂ કરો"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
-#: ../shell/gnome-control-center.desktop.in.in.h:1
-#| msgid "_Settings..."
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "સુયોજનો"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "કૅલ્ક્યુલેટર શરૂ કરો"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "ઇમેલ ક્લાયન્ટ શરૂ કરો"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "વેબ બ્રાઉઝર શરૂ કરો"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "ઘર ફોલ્ડર"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
-#| msgid "Search"
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "શોધો"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "સ્ક્રીનશોટ"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-#| msgid "Save a screenshot to Pictures"
-msgid "Save a screenshot to $PICTURES"
-msgstr "$PICTURES માં સ્ક્રીનશોટને સંગ્રહો"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-#| msgid "Save a screenshot of a window to Pictures"
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "$PICTURES માં વિન્ડોનાં સ્ક્રીનશોટને સંગ્રહો"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-#| msgid "Save a screenshot of an area to Pictures"
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "$PICTURES માં એક વિસ્તારનાં સ્ક્રીનશોટને સંગ્રહો"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "ક્લિપબોર્ડમાં સ્ક્રીનશોટની નકલ કરો"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "ક્લિપબોર્ડમાં વિન્ડોના સ્ક્રિનશોટની નકલ કરો"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "ક્લિપબોર્ડમાં વિસ્તારનાં સ્ક્રીનશોટની નકલ કરો"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "ટૂંકી સ્ક્રીનકાસ્ટનો અહેવાલ લો"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "સિસ્ટમ"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "બહાર નીકળો"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "સ્ક્રીનને તાળુ મારો"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "સાર્વત્રિક વપરાશ"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "દૃશ્યતા"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "નાનું મોટુ કરવાનુ ચાલુ અથવા બંધ કરો"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "મોટુ કરો"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "નાનું કરો"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "સ્ક્રીન વાંચકને ચાલુ અથવા બંધ રાખો"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "ઓન-સ્ક્રીન કિબોર્ડને ચાલુ અથવા બંધ રાખો"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "લખાણ માપ વધારો"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "લખાણ માપ ઘટાડો"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "ઉચ્ચ વિરોધાભાસ ચાલુ અથવા બંધ"
 
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
-# gtk/gtkinputdialog.c:238
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1217
-#: ../panels/network/network-wifi.ui.h:29
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-#: ../panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Disabled"
-msgstr "નિષ્ક્રિય"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "ઇનપુટ સ્ત્રોત ઉમેરો "
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "વૈકલ્પિક અક્ષર કી"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "પ્રવેશ સ્ક્રીન પર ઇનપુટ પદ્દતિઓને વાપરી શકાતુ નથી"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "કંપોઝ કી"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "ઇનપુટ સ્ત્રોત પસંદ થયેલ નથી"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-#| msgid "Switch to next source"
-msgid "Modifiers-only switch to next source"
-msgstr "સંશોધક ફક્ત આગળનાં સ્ત્રોત પર જવા માટે"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "વિકલ્પો"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "કીબોર્ડ"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "ઉપર ખસેડો"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr "કિબોર્ડ ટૂંકાણોને બદલો અને જુઓ અને તમારી ટાઇપીંગ પસંદગીઓને સુયોજિત કરો"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "નીચે ખસેડો"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "ટૂંકાણ;ચાલુ રાખો;ઝબૂકવુ;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "પસંદગીઓ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "વૈવિધ્યપૂર્ણ ટુંકાણો"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "કીબોર્ડ લેઆઉટને બતાવો"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
-msgstr "ઉમેરો (_A)"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "દૂર કરો (_R)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "નામ (_N):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "આદેશ (_o):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "પુનરાવર્તિત કીઓ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "જ્યારે કી દબાવી રાખી હોય ત્યારે પુનરાવર્તિત કી દબાણ. (_r)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "વિલંબ (_D):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "ઝડપ (_S):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-#| msgid "Short"
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "ટૂંકુ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-#| msgid "Slow"
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "ધીમુ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "પુનરાવર્તન કીઓની ઝડપ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-#| msgid "Long"
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "લાંબુ"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-#| msgid "Fast"
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "ઝડપી"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "કર્સર ઝબૂકે છે"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "કર્સર લખાણ ક્ષેત્રોમાં ઝબૂકે છે (_b)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "ઝડપ (_p):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "કર્સર ઝબૂકવાની ઝડપ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "ઇનપુટ સ્ત્રોત"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "ટુંકાણ ઉમેરો"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "ટુંકાણ દૂર કરો"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"ટુકાણ કીમાં ફેરફાર કરવા માટે, તેને લાગતી હરોળ પર ક્લિક કરો અને નવી કી જોડાણોને ટાઇપ "
-"કરો, અથવા સાફ કરવા માટે Backspace કી દબાવો."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "ઇનપુટ સ્ત્રોત વિકલ્પો"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "બધી વિન્ડો માટે સરખા સ્ત્રોતને વાપરો (_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "દરેક વિન્ડો માટે વિવિધ સ્ત્રોતોને પરવાનગી આપો (_d)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "વૈકલ્પિક અક્ષર કી"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "કંપોઝ કી"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "કિબોર્ડ ટૂંકાણો"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "વૈવિધ્યપૂર્ણ ટુંકાણો"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "વિભાગ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "ટૂંકાણો"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:634
-#: ../panels/keyboard/keyboard-shortcuts.c:642
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "ટુંકાણ ઉમેરો"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "વૈવિધ્યપૂર્ણ ટુંકાણો"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:859
-msgid "<Unknown Action>"
-msgstr "&lt;Unknown Action&gt;"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1356
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"ટૂંકાણ \"%s\" વાપરી શકાશે નહિં કારણ કે તે આ કીને લખવા માટે વાપરવા માટે અશક્ય બનશે.\n"
-"Control, Alt અથવા Shift જેવી કીને એક જ સમયે વાપરવાનો પ્રયાસ કરી જુઓ."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1386
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "ટુંકાણ ઉમેરો"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "કિબોર્ડ ટૂંકાણો"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "દૂર કરો (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "બદલો (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"આ ટુંકાણ \"%s\" પહેલેથી \"%s\" માટે વપરાયેલ\n"
-"છે"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1391
-#, c-format
-msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "જો \"%s\" ને ટુંકાણોમાં ફરીથી નિશ્ચત કરો તો, \"%s\" ટુંકાણો નિષ્ક્રિય થયેલ હશે."
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1397
-msgid "_Reassign"
-msgstr "પુન:નિશ્ચત કરો (_R)"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1429
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"\"%s\" ટૂંકાણ એ \"%s\" ટૂંકાણ સાથે સંકળાયેલ છે. શું તમે \"%s\" માં તેને આપમેળે સુયોજિત કરવા "
-"માંગો છો?"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1435
-#, c-format
-#| msgid ""
-#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
-#| "disabled."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "નામ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "આદેશ (_o):"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "ટુંકાણ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "નવાં ટૂંકાણ..."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "કંઈ જ નહિં"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "મૂળભૂતોમાં પુનઃસુયોજિત કરો (_f)"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "કીબોર્ડ"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
 msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
-msgstr "\"%s\"  એ હાલમાં \"%s\" સાથે સંકળાયેલ છે, આ ટૂંકાણ એ નિષ્ક્રિય થશે જો તમે આગળ ખસો તો."
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "કિબોર્ડ ટૂંકાણોને બદલો અને જુઓ અને તમારી ટાઇપીંગ પસંદગીઓને સુયોજિત કરો"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1441
-#| msgid "_Reassign"
-msgid "_Assign"
-msgstr "સોંપો (_A)"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
 
-#: ../panels/mouse/cc-mouse-panel.c:94
-#| msgid "_Test Your Settings"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "સ્થાન સેવા (_L)"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "કાર્યક્રમ હાલમાં ઓડિયોને વગાડી અથવા રેકોર્ડ કરી રહ્યુ છે."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "માઇક્રોફોન વોલ્યુમ"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "કાર્યક્રમો મળ્યા નથી"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "તમારાં સુયોજનો ચકાસો (_S)"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-#| msgid "_Test Your Settings"
-msgid "Test Your Settings"
-msgstr "તમારાં સુયોજનો ચકાસો"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse & Touchpad"
-msgstr "માઇસ અને ટચપેડ"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr "તમારી માઉસ અને ટચપેડ સંવેદનશીલતાને બદલો અને જમણી અથવા ડાબી બાજુ પસંદ કરો"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-#| msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-msgstr "ટ્રેકપેડ;નિર્દેશક;ક્લિક;ટેપ;બમણું;બટન;ટ્રેકબોલ;સ્ક્રોલ;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
 msgid "General"
 msgstr "સામાન્ય"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-#| msgid "Slow"
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "ધીમુ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "બે ક્લિકની સમયસમાપ્તિ"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-#| msgid "Fast"
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "ઝડપી"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "બે ક્લિક (_D)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
 msgstr "પ્રાથમિક બટન (_b)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-#| msgid "_Left"
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "ડાબું (_L)"
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-#| msgid "_Right"
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "જમણું (_R)"
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "ડાબું"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "જમણું"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "સ્થાનો શોધો"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "માઉસ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "પોઇન્ટર ઝડપ (_P)"
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "માઉસ કી (_M)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-#| msgid "Slow"
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "ધીમુ"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "નીચે સ્ક્રોલ કરો"
 
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-#| msgid "Fast"
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "ઝડપી"
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "બૃહદદર્શક કર્સર સમાવિષ્ટ સાથે ખસે છે"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "પ્રવેગ (_c):"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "સક્રિય"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "ટચપેડ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-#| msgid "Slow"
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "ધીમુ"
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "ટચપેડ"
 
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-#| msgid "Fast"
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "ઝડપી"
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "પદ્દતિ (_M)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
-msgstr "જ્યારે ટાઇપ કરી રહ્યા હોય ત્યારે નિષ્ક્રિય કરો (_t)"
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
 msgstr "ક્લિક કરવા માટે ટૅપ (_c)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
-msgstr "બે- આંગળી થી ખસેડવુ (_fi)"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-#| msgid "_Edge scrolling"
-msgid "_Natural scrolling"
-msgstr "કુદરતી સ્ક્રોલીંગ (_N)"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "ક્લિક કરવા માટે ટૅપ (_c)"
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "જ્યારે ટાઇપ કરી રહ્યા હોય ત્યારે નિષ્ક્રિય કરો (_t)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "ટચપેડ (સંબંધિત)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "સ્ક્રોલ કરી રહ્યા છે"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "ડાબે સ્ક્રોલ કરો"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "દ્દિતરફી"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "ક્લિક કરવાનો પ્રયત્ન કરો, બે વાર ક્લિક કરો, ખસેડી રહ્યા છે"
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "પાંચ ક્લિક, GEGL સમય!"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "માઇસ અને ટચપેડ"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "બે ક્લિક, પ્રાથમિક બટન"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "તમારી માઉસ અને ટચપેડ સંવેદનશીલતાને બદલો અને જમણી અથવા ડાબી બાજુ પસંદ કરો"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "એક જ ક્લિક, પ્રાથમિક બટન"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ટ્રેકપેડ;નિર્દેશક;ક્લિક;ટેપ;બમણું;બટન;ટ્રેકબોલ;સ્ક્રોલ;"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "બે ક્લિક, મધ્ય બટન"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "એકજ ક્લિક, મધ્ય બટન"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "બે વાર ક્લિક, ગૌણ બટન"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "એકજ ક્લિક, ગૌણ બટન"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:366
-msgid "Air_plane Mode"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "રંગસ્થાન: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "આપમેળે કચરાપેટી ખાલી (_T)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "%s મોનિટર"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "પ્રાથમિક દર્શાવને બદલવા ખેંચો."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "કાર્યક્રમો"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ઉપકરણો"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "નવાં જોડાણને ઉમેરો"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "જોડાયેલ"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "વિકલ્પો…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi હૉટસ્પોટ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "નેટવર્ક નામ"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "પાસવર્ડ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "જૂથ પાસવર્ડ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "ઉત્પન્ન થયેલ પાસવર્ડને પસંદ કરો"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "ચાલુ કરો (_T)"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
 msgstr "ઍરપ્લેન સ્થિતિ (_p)"
 
-#: ../panels/network/cc-network-panel.c:965
-msgid "Network proxy"
-msgstr "નેટવર્ક પ્રોક્સી"
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "ચિત્ર મળ્યા નથી"
 
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1289
-msgid "The system network services are not compatible with this version."
-msgstr "સિસ્ટમ નેટવર્ક સેવાઓ આવૃત્તિ સાથે સુસંગત નથી."
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
-#| msgid "Security"
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "ઍરપ્લેન સ્થિતિ (_p)"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi હૉટસ્પોટ"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "હૉટસ્પોટ તરીકે વાપરો (_U)..."
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "નેટવર્ક"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x સુરક્ષા (_S)"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "પાનું 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "અનામિક ઓળખાણ (_m)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-#| msgid "Authentication failed"
-msgid "Inner _authentication"
-msgstr "આંતરિક સત્તાધિકરણ (_a)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "પાનું 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:4
-msgid "Security"
-msgstr "સુરક્ષા"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-#| msgctxt "proxy method"
-#| msgid "Automatic"
-msgid "automatic"
-msgstr "સ્વયં"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:217
-#: ../panels/network/net-device-wifi.c:378
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:221
-#: ../panels/network/net-device-wifi.c:383
-#: ../panels/network/network-wifi.ui.h:17
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:225
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:230
-msgid "Enterprise"
-msgstr "એન્ટરપ્રાઇઝ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:235
-#: ../panels/network/net-device-wifi.c:368
-msgctxt "Wifi security"
-msgid "None"
-msgstr "કંઈ નહિં"
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-#| msgid "never"
-msgid "Never"
-msgstr "કદી નહિં"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:819
-#| msgid "today"
-msgid "Today"
-msgstr "આજે"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:822
-#| msgid "yesterday"
-msgid "Yesterday"
-msgstr "ગઈકાલે"
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:472
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i દિવસ અગાઉ"
 msgstr[1] "%i દિવસો અગાઉ"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:529
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:558
-msgctxt "Signal strength"
-msgid "None"
-msgstr "કંઈ નહિં"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:560
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "નબળુ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "બરાબર"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "સરસ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "હોશિયાર"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:45
-msgid "Identity"
-msgstr "ઓળખ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "સરનામું"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "નેટમાસ્ક"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "ગેટવે"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-#| msgid "IP Address"
-msgid "Delete Address"
-msgstr "સરનામું કાઢી નાંખો"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-#| msgid "_Add"
-msgid "Add"
-msgstr "ઉમેરો"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "સર્વર"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-#| msgid "Delete device"
-msgid "Delete DNS Server"
-msgstr "DNS સર્વર કાઢી નાંખો"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-#| msgid "Metric"
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "મેટ્રીક"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-#| msgid "Default Route"
-msgid "Delete Route"
-msgstr "માર્ગ કાઢી નાંખો"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:25
-#| msgctxt "proxy method"
-#| msgid "Automatic"
-msgid "Automatic (DHCP)"
-msgstr "સ્વયં (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:24
-#| msgctxt "proxy method"
-#| msgid "Manual"
-msgid "Manual"
-msgstr "પુસ્તિકા"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "ફક્ત સ્થાનિક કડી"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:46
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "પૂર્વગ"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-#| msgctxt "proxy method"
-#| msgid "Automatic"
-msgid "Automatic"
-msgstr "સ્વયં"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-#| msgid "A_utomatic Login"
-msgid "Automatic, DHCP only"
-msgstr "આપોઆપ, ફક્ત DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:47
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:49
-msgid "Reset"
-msgstr "પુનઃસુયોજીત કરો"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-#| msgid "None"
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "કંઈ જ નહિં"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit Key (Hex અથવા ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit પાસફ્રેજ"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "ડાયનેમિક WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA અને WPA2 વ્યક્તિગત"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-#| msgid "Enterprise"
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA અને WPA2 એન્ટરપ્રાઇઝ"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:2
-#| msgid "Strength"
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "સંકેત મજબૂતાઇ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:3
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "કડી ઝડપ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "સુરક્ષા"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 સરનામું"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 સરનામું"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:7
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "હાર્ડવેર સરનામું"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:8
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "આધારભૂત ICC રૂપરેખાઓ"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "મૂળભૂત માર્ગ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
-#| msgid "Last used"
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "છેલ્લે વાપરેલ"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "Twisted Pair (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Attachment Unit Interface (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "Media Independent Interface (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-#| msgid "%d Mb/s"
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-#| msgid "%d Mb/s"
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-#| msgid "_Name:"
-msgid "_Name"
-msgstr "નામ (_N)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:36
-#| msgid "Address"
-msgid "_MAC Address"
-msgstr "MAC સરનામું (_M)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "MTU (_T)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-#| msgid "IP Address"
-msgid "_Cloned Address"
-msgstr "ક્લોન થયેલ સરનામું (_C)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-#| msgid "%u byte"
-#| msgid_plural "%u bytes"
-msgid "bytes"
-msgstr "બાઇટ"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "બીજા વપરાશકર્તાઓ માટે ઉપલબ્ધ બનાવો (_u)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "આપમેળે જોડાવો (_a)"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "ફાયરવોલ ઝોન (_Z)"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-#| msgid "Default"
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "મૂળભૂત"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "વિસ્તાર જોડાણનાં વિશ્ર્વાસ સ્તરને દર્શાવે છે"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:22
-msgid "IPv_4"
-msgstr "IPv4 (_4)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:23
-#| msgid "Address"
-msgid "_Addresses"
-msgstr "સરનામાં (_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-#| msgctxt "proxy method"
-#| msgid "Automatic"
-msgid "Automatic DNS"
-msgstr "આપોઆપ DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Routes"
-msgstr "માર્ગ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-#| msgctxt "proxy method"
-#| msgid "Automatic"
-msgid "Automatic Routes"
-msgstr "આપમેળે માર્ગ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Use this connection _only for resources on its network"
-msgstr "તેનાં નેટવર્ક પર સ્ત્રોતો માટે ફક્ત આ જોડાણને વાપરો (_o)"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:34
-msgid "IPv_6"
-msgstr "IPv6 (_6)"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-#| msgid "Bluetooth connection failed"
-msgid "Unable to open connection editor"
-msgstr "જોડાણ સંપાદકને ખોલવાનું અસમર્થ"
-
-# libgnomeprintui/gpaui/add-printer-dialog.c:83
-# libgnomeprintui/gpaui/config-dialog.c:83
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-#| msgid "No profile"
-msgid "New Profile"
-msgstr "નવી રૂપરેખા"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "બોન્ડ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "જૂથ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "બ્રિજ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-#| msgid "Could not load ui: %s"
-msgid "Could not load VPN plugins"
-msgstr "VPN પ્લગઇનને લાવી શક્યા નહિં"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-#| msgid "Other profile…"
-msgid "Import from file…"
-msgstr "ફાઇલમાંથી આયાત કરો..."
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-#| msgid "Add new connection"
-msgid "Add Network Connection"
-msgstr "નેટવર્ક જોડાણને ઉમેરો"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Reset"
-msgstr "ફરી સુયોજીત કરો (_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1449
-#: ../panels/network/network-wifi.ui.h:40
-#| msgid "Forget"
-msgid "_Forget"
-msgstr "ભૂલી જાઓ (_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"આ નેટવર્ક માટે સુયોજનો સુયોજિત કરો, પાસવર્ડને સમાવી રહ્યા છે, પરંતુ યાદ રાખો કે તે પસંદ થયેલ "
-"નેટવર્ક ચે"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr "આ નેટવર્કને લગતી બધી વિગતોને દૂર કરો અને આપમેળે જોડાવા માટે પ્રયત્ન કરો નહિં"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-#| msgid "Security"
-msgid "S_ecurity"
-msgstr "સુરક્ષા (_e)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "VPN જોડાણની આયાત કરી શકાતુ નથી"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"ફાઇલ '%s' એ વાંચી શકાયુ નહિં અથવા ઓળખેલ VPN જોડાણ જાણકારીને સમાવતુ નથી\n"
-"\n"
-"ભૂલ: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "આયાત કરવા માટે ફાઇલ પસંદ કરો"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1948
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:223
-msgid "_Open"
-msgstr "ખોલો (_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-#| msgid "A user with name '%s' already exists."
-msgid "A file named \"%s\" already exists."
-msgstr "નામ \"%s\" ફાઇલ પહેલેથી અસ્તિત્વ ધરાવે છે."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "બદલો (_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "શું તમે સંગ્રહ કરી રહ્યા છો તે VPN જોડાણ સાથે %s ને બદલવા માંગો છો?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "VPN જોડાણનું નિકાસ કરી શકાતુ નથી"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN જોડાણ '%s' ને %s માં નિકાસ કરી શક્યા નહિં.\n"
-"\n"
-"ભૂલ: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-#| msgid "Add new connection"
-msgid "Export VPN connection"
-msgstr "VPN જોડાણની નિકાસ કરો"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(ભૂલ: VPN જોડાણ સંપાદકને લાવવાનું અસમર્થ)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:12
-msgid "_SSID"
-msgstr "SSID (_S)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:13
-msgid "_BSSID"
-msgstr "BSSID (_B)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:16
-#| msgid "_Forget Network"
-msgid "My Home Network"
-msgstr "મારું ઘર નેટવર્ક"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "બીજા વપરાશકર્તાઓને ઉપલબ્ધ બનાવો (_o)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "નેટવર્ક"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-#| msgid "Not connected to the internet."
-msgid "Control how you connect to the Internet"
-msgstr "તમે કેવી રીતે ઇન્ટરનેટ સાથે જોડાવે તેને નિયંત્રિત કરો"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
-"નેટવર્ક;વાયરલેસ;Wi-Fi;Wifi;IP;LAN;પ્રોક્સી;WAN;બ્રોડબેન્ડ;મોડેમ;બ્લુટુથ;vpn;"
-"vlan;બ્રિજ;બોન્ડ;DNS;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "બોન્ડ સ્લેવ"
-
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(કંઇ નહિં)"
-
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "બ્રિજ સ્લેવ"
-
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:458
-msgid "never"
-msgstr "કદી નહિં"
-
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:468
-msgid "today"
-msgstr "આજે"
-
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:470
-msgid "yesterday"
-msgstr "ગઇ કાલે"
-
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP સરનામું"
-
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:10
-msgid "Last used"
-msgstr "છેલ્લે વાપરેલ"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "વાયર લગાવેલ"
-
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1604
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-#| msgid "Options"
-msgid "Options…"
-msgstr "વિકલ્પો…"
-
-# libgnomeprintui/gpaui/add-printer-dialog.c:83
-# libgnomeprintui/gpaui/config-dialog.c:83
-#: ../panels/network/net-device-ethernet.c:474
-#, c-format
-#| msgid "_Profile:"
-msgid "Profile %d"
-msgstr "રૂપરેખા %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "નવાં જોડાણને ઉમેરો"
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr "જૂથ સ્લેવ"
-
-#: ../panels/network/net-device-wifi.c:1153
-#| msgid ""
-#| "If you have a connection to the Internet other than wireless, you can use "
-#| "it to share your internet connection with others."
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
-"જો તમારી પાસે વાયરલેસ કરતા બીજુ ઇન્ટરનેટનું જોડાણ હોય તો, તમે બીજા સાથે જોડાણની ભાગીદારી કરવા "
-"માટે વાયરલેસ હૉટસ્પોટને સુયોજિત કરી શકો છો."
 
-#: ../panels/network/net-device-wifi.c:1157
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "વાયરલેસ હૉટસ્પોટ પર અદલાબદલી કરવાથી <b>%s</b> માંથી તમારુ જોડાણ તૂટી જશે."
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "નામ (_N)"
 
-#: ../panels/network/net-device-wifi.c:1161
-#| msgid ""
-#| "It is not possible to access the internet through your wireless while the "
-#| "hotspot is active."
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr "તમારા વાયરલેસ મારફતે ઇન્ટરનેટને વાપરવાનું તેની માટે શક્ય નથી જ્યારે હૉટસ્પોટ સક્રિય હોય."
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC સરનામું (_M)"
 
-#: ../panels/network/net-device-wifi.c:1238
-msgid "Stop hotspot and disconnect any users?"
-msgstr "હૉટસ્પોટને અટકાવો અને કોઇપણ વપરાશકર્તાનું જોડાણ તોડો? "
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "MTU (_T)"
 
-#: ../panels/network/net-device-wifi.c:1241
-msgid "_Stop Hotspot"
-msgstr "હૉટસ્પોટ બંધ કરો (_S)"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "ક્લોન થયેલ સરનામું (_C)"
 
-#: ../panels/network/net-device-wifi.c:1313
-msgid "System policy prohibits use as a Hotspot"
-msgstr "સિસ્ટમ પોલિસી હૉટસ્પોટ તરીકે વાપરવાનું અટકાવે છે"
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "બાઇટ"
 
-#: ../panels/network/net-device-wifi.c:1316
-#| msgid "InfiniBand device does not support connected mode"
-msgid "Wireless device does not support Hotspot mode"
-msgstr "વાયરલેસ ઉપકરણ હૉટસ્પોટને આધાર આપતુ નથી"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "પદ્દતિ (_M)"
 
-#: ../panels/network/net-device-wifi.c:1445
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"પસંદ થયેલ નેટવર્કો માટે નેટવર્ક વિગતો, પાસવર્ડને સમાવીને અને કોઇપણ વૈવિધ્ય રૂપરેખાંકન ગુમ થઇ "
-"જશે."
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "સ્વયં (DHCP)"
 
-#: ../panels/network/net-device-wifi.c:1753
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "ઇતિહાસ"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "ફક્ત સ્થાનિક કડી"
 
-#: ../panels/network/net-device-wifi.c:1757
-#: ../panels/wacom/cc-wacom-page.c:533
-#| msgid "Close"
-msgid "_Close"
-msgstr "બંધ કરો (_C)"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1765
-#| msgid "Forget"
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "ભૂલી જાઓ (_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "Web Proxy Autodiscovery વાપરેલ છે જ્યારે રૂપરેખાંકન URL પૂરી પાડેલ નથી."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "આ અવિશ્ર્વાસુ સાર્વજનિક નેટવર્કો માટે અગ્રહણીય નથી."
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "પ્રોક્સી"
-
-#: ../panels/network/network-ethernet.ui.h:2
-#| msgid "Add profile"
-msgid "_Add Profile…"
-msgstr "રૂપરેખા ઉમેરો (_A)..."
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "પોષણકર્તા"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "કઇ નહિં"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
-msgstr "મેન્યુઅલ"
+msgstr "પુસ્તિકા"
 
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "નિષ્ક્રિય"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "બીજા કમ્પ્યૂટર સાથે વહેંચેલ છે"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "સરનામાં (_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "સરનામું"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "નેટમાસ્ક"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "ગેટવે"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "સ્વયં"
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "આપોઆપ DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "માર્ગ"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "આપમેળે માર્ગ"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "મેટ્રીક"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "તેનાં નેટવર્ક પર સ્ત્રોતો માટે ફક્ત આ જોડાણને વાપરો (_o)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
 msgstr "પદ્દતિ (_M)"
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "રૂપરેખાંકન URL (_C)"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "આપોઆપ, ફક્ત DHCP"
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "HTTP પ્રોક્સી (_H)"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "પૂર્વગ"
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "HTTPS પ્રોક્સી (_T)"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "સુરક્ષા (_e)"
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "FTP પ્રોક્સી (_F)"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ભૂલ: VPN જોડાણ સંપાદકને લાવવાનું અસમર્થ)"
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "Socks યજમાન (_S)"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "SSID (_S)"
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "યજમાનો અવગણો (_I)"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "BSSID (_B)"
 
-#: ../panels/network/network-proxy.ui.h:11
-#| msgid "_HTTP Proxy"
-msgid "HTTP proxy port"
-msgstr "HTTP પ્રોક્સી પોર્ટ"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "નેટવર્ક"
 
-#: ../panels/network/network-proxy.ui.h:12
-#| msgid "H_TTPS Proxy"
-msgid "HTTPS proxy port"
-msgstr "FTP પ્રોક્સી પોર્ટ"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "તમે કેવી રીતે ઇન્ટરનેટ સાથે જોડાવે તેને નિયંત્રિત કરો"
 
-#: ../panels/network/network-proxy.ui.h:13
-#| msgid "_FTP Proxy"
-msgid "FTP proxy port"
-msgstr "FTP પ્રોક્સી પોર્ટ"
-
-#: ../panels/network/network-proxy.ui.h:14
-#| msgid "Socks Port"
-msgid "Socks proxy port"
-msgstr "Socks પ્રોક્સી પોર્ટ"
-
-#: ../panels/network/network-simple.ui.h:7
-#| msgid "Device"
-msgid "Turn device off"
-msgstr "ઉપકરણ બંધ કરો"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "ઉપકરણ ઉમેરો"
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "ઉપકરણ દૂર કરો"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN પ્રકાર"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "જૂથ નામ"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "જૂથ પાસવર્ડ"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "વપરાશકર્તા નામ"
-
-#: ../panels/network/network-vpn.ui.h:7
-#| msgid "Turn on or off:"
-msgid "Turn VPN connection off"
-msgstr "VPN જોડાણને બંધ કરો"
-
-#: ../panels/network/network-wifi.ui.h:1
-#| msgid "A_utomatic Login"
-msgid "Automatic _Connect"
-msgstr "સ્વયમ જોડાવો (_C)"
-
-#: ../panels/network/network-wifi.ui.h:11
-#| msgid "Details"
-msgid "details"
-msgstr "વિગતો"
-
-#: ../panels/network/network-wifi.ui.h:15
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "પાસવર્ડ (_P)"
-
-#: ../panels/network/network-wifi.ui.h:18
-msgid "None"
-msgstr "કંઈ જ નહિં"
-
-#: ../panels/network/network-wifi.ui.h:19
-#| msgid "_Show password"
-msgid "Show P_assword"
-msgstr "પાસવર્ડ બતાવો (_a)"
-
-#: ../panels/network/network-wifi.ui.h:20
-#| msgid "Failed to delete user"
-msgid "Make available to other users"
-msgstr "બીજા વપરાશકર્તાઓ માટે ઉપલબ્ધ બનાવો"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "identity"
-msgstr "ઓળખાણ"
-
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Automatic (DHCP) addresses only"
-msgstr "ફક્ત સ્વયં (DHCP) સરનામાંઓ"
-
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Link-local only"
-msgstr "ફક્ત સ્થાનિક કડી"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Shared with other computers"
-msgstr "બીજા કમ્પ્યૂટર સાથે વહેંચેલ છે"
-
-#: ../panels/network/network-wifi.ui.h:31
-#| msgid "Cannot remove automatically added profile"
-msgid "_Ignore automatically obtained routes"
-msgstr "પ્રાપ્ત થયેલ માર્ગને આપમેળે અવગણો (_I)"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "_Cloned MAC Address"
-msgstr "ક્લોન થયેલ MAC સરનામું (_C)"
-
-#: ../panels/network/network-wifi.ui.h:38
-#| msgid "Hardware"
-msgid "hardware"
-msgstr "હાર્ડવેર"
-
-#: ../panels/network/network-wifi.ui.h:41
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
-"તેનાં મૂળભૂતમાં આ જોડાણ માટે સુયોજનોને પુન:સુયોજિત કરો, પરંતુ પસંદ થયેલ જોડાણ તરીકે યાદ રાખો."
+"નેટવર્ક;વાયરલેસ;Wi-Fi;Wifi;IP;LAN;પ્રોક્સી;WAN;બ્રોડબેન્ડ;મોડેમ;બ્લુટુથ;vpn;vlan;બ્રિજ;"
+"બોન્ડ;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:42
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr "આ નેટવર્કને લગતી બધી વિગતોને દૂર કરો અને આપમેળે જોડાવા માટે પ્રયત્ન કરો નહિં."
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid "reset"
-msgstr "પુનઃસુયોજીત કરો"
-
-#: ../panels/network/network-wifi.ui.h:48
-msgid "Hardware"
-msgstr "હાર્ડવેર"
-
-#: ../panels/network/network-wifi.ui.h:50
-#| msgid "Wireless Hotspot"
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi હૉટસ્પોટ"
-
-#: ../panels/network/network-wifi.ui.h:51
-msgid "_Turn On"
-msgstr "ચાલુ કરો (_T)"
-
-#: ../panels/network/network-wifi.ui.h:52
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:53
-#| msgid "Turn on or off:"
-msgid "Turn Wi-Fi off"
-msgstr "Wi-Fi બંધ કરો"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "તમે કેવી રીતે ઇન્ટરનેટ સાથે જોડાવે તેને નિયંત્રિત કરો"
 
-#: ../panels/network/network-wifi.ui.h:54
-#| msgid "_Use as Hotspot..."
-msgid "_Use as Hotspot…"
-msgstr "હૉટસ્પોટ તરીકે વાપરો (_U)..."
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"નેટવર્ક;વાયરલેસ;Wi-Fi;Wifi;IP;LAN;પ્રોક્સી;WAN;બ્રોડબેન્ડ;મોડેમ;બ્લુટુથ;vpn;vlan;બ્રિજ;"
+"બોન્ડ;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:55
-#| msgid "Connect to a Hidden Network"
-msgid "_Connect to Hidden Network…"
-msgstr "છુપાયેલ નેટવર્ક સાથે જોડાવો (_C)..."
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "વાયર લગાવેલ"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_History"
-msgstr "ઇતિહાસ (_H)"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "ઉપકરણ બંધ કરો"
 
-#: ../panels/network/network-wifi.ui.h:57
-#| msgid "Switch off to connect to a wireless network"
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Wi-Fi નેટવર્કમાં જોડાવાનુ બંધ કરો"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "સક્રિય"
 
-#: ../panels/network/network-wifi.ui.h:58
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "પોષણકર્તા"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP સરનામું"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "નેટવર્ક પ્રોક્સી"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "HTTP પ્રોક્સી (_H)"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTPS પ્રોક્સી (_T)"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "FTP પ્રોક્સી (_F)"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Socks યજમાન (_S)"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "યજમાનો અવગણો (_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP પ્રોક્સી પોર્ટ"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "FTP પ્રોક્સી પોર્ટ"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP પ્રોક્સી પોર્ટ"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks પ્રોક્સી પોર્ટ"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "રૂપરેખાંકન URL (_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN જોડાણને બંધ કરો"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "નેટવર્ક નામ"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Connected Devices"
-msgstr "જોડાયેલ ઉપકરણો"
-
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "સુરક્ષા પ્રકાર"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Security key"
-msgstr "સુરક્ષા કી"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "પાસવર્ડ"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi બંધ કરો"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "ઇન્ફ્રાસ્ટ્રક્ચર"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "વિકલ્પો લાવી રહ્યા છે…"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "અજ્ઞાત સ્થિતિ"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "છુપાયેલ નેટવર્ક સાથે જોડાવો (_C)..."
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "અસંચાલિત"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi હૉટસ્પોટ"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "બિનઉપલબ્ધ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "જોડાઇ રહ્યા છે"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "સત્તાધિકરણ જરૂરી"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "જોડાયેલ"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "જોડાણ તૂટી રહ્યુ છે"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "જોડાણ નિષ્ફળ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "અજ્ઞાત સ્થિતિ (ગેરહાજર)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "જોડાયેલ નથી"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "રૂપરેખાંકન નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "IP રૂપરેખાંકન નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "IP રૂપરેખાંકન નિવૃત્ત"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "ખાનગીની જરૂરિયાત હતી, પરંતુ પૂરુ પાડેલ નથી"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1X સપ્લિકન્ટનું જોડાણ તૂટી ગયુ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1X સપ્લિકન્ટ રૂપરેખાંકન નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1X સપ્લિકન્ટ નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1X સપ્લિકન્ટ સત્તાધિકરણ કરવા માટે લાંબો સમય લીધો"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "શરૂ કરવા માટે PPP સેવા નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "તૂટી ગયેલ PPP સેવા જોડાણ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "શરૂ કરવા માટે DHCP ક્લાયન્ટ નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP ક્લાયન્ટ ભૂલ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP ક્લાયન્ટ નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "શરૂ કરતી વખતે વહેંચાયેલ જોડાણ સેવા નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "વહેંચાયેલ જોડાણ સેવા નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "શરૂ કરવા માટે AutoIP સેવા નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "AutoIP સેવા ભૂલ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "AutoIP સેવા નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "લાઇન વ્યસ્ત છે"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "ડાયલ ટોન નથી"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "કૅરિઅર સ્થાપિત કરી શક્યા નહિં"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "ડાયલ કરવાની માંગણીનો સમય સમાપ્ત"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "ડાયલ કરવાનો પ્રયાસ નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "મોડેમની શરૂઆત નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "ખાસ APN ને પસંદ કરવાનું નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "નેટવર્કો માટે શોધી રહ્યા નથી"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "નામંજૂર થયેલ નેટવર્ક રજીસ્ટ્રેશન"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "નેટવર્ક રજીસ્ટ્રેશન કરવાનો સમય સમાપ્ત થઇ ગયો"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "સૂચિત નેટવર્ક સાથે રજીસ્ટર કરવાનું નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "PIN ચકાસણી નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "ઉપકરણ માટે જરૂરી ફર્મવેર ગુમ થઇ શકે છે"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "જોડાણ અદૃશ્ય"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "હાલનાં જોડાણને ધારેલ હતુ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "મોડેમ મળ્યુ નથી"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "બ્લુટુથ જોડાણ નિષ્ફળ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "SIM કાર્ડ દાખલ થયેલ નથી"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "SIM પીનની જરૂરિયાત છે"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "SIM Puk જરૂરી"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "SIM ખોટુ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "InfiniBand ઉપકરણ જોડાયેલ સ્થિતિને આધાર આપતુ નથી"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "જોડાણ નિર્ભરતા નિષ્ફળ"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "ફર્મવેર ગેરહાજર"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "કૅબલ પ્લગ થયેલ નથી"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "Certificate Authority (પ્રમાણપત્ર સત્તા) પ્રમાણપત્ર પસંદ થયેલ નથી"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"Certificate Authority (CA) પ્રમાણપત્ર વાપર્યા વગર અસુરક્ષિત, ઠગ Wi-Fi નેટવર્કો "
-"જોડાણોમાં પરિણમી શકે છે. શું તમે Certificate Authority પ્રમાણપત્રને પસંદ કરવા માંગો છો?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "અવગણો"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "CA પ્રમાણપત્રને પસંદ કરો"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, અથવા PKCS#12 ખાનગી કી (*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER અથવા PEM પ્રમાણપત્રો (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-msgid "Choose a PAC file"
-msgstr "PAC ફાઇલને પસંદ કરો"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC ફાઇલો (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-#| msgid "All files"
-msgid "PAC _file"
-msgstr "PAC ફાઇલ (_f)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-#| msgid "Authentication failed"
-msgid "_Inner authentication"
-msgstr "આંતરિક સત્તાધિકરણ (_I)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "PAC બચાવ (_v)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "અનામિક"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
-#| msgid "Authentication failed"
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "સત્તાધિકરણ થયેલ"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "બંને"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "અનામિક ઓળખાણ (_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC ફાઇલ (_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PAC ફાઇલને પસંદ કરો"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "આંતરિક સત્તાધિકરણ (_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC બચાવ (_v)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "વપરાશકર્તા નામ (_U)"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
-#| msgid "_Show password"
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "પાસવર્ડ (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "પાસવર્ડ બતાવો (_w)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate"
-msgstr "Certificate Authority પ્રમાણપત્ર ને પસંદ કરો"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
-#| msgid "Version %s"
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "આવૃત્તિ 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
-#| msgid "Version %s"
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "આવૃત્તિ 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "CA પ્રમાણપત્ર (_A)"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Certificate Authority પ્રમાણપત્ર ને પસંદ કરો"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "સત્તાધિકરણ જરૂરી"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP આવૃત્તિ (_v)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "દરેક વખતે આ પાસવર્ડ માટે પૂછો (_k)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "એનક્રિપ્ટ ન થયેલ ખાનગી કી અસુરક્ષિત છે"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"પસંદ થયેલ ખાનગી કીને પાસવર્ડ દ્દારા સુરક્ષિત કરવા માટે દેખાતુ નથી.  આ સમાધાન કરવા માટે "
-"તમારી સુરક્ષા શ્રેયોને પરવાનગી આપી શકે છે.  મહેરબાની કરીને પાસવર્ડ-સુરક્ષિત થયેલ ખાનગી કી "
-"ને પસંદ કરો.\n"
-"\n"
-"(તમે openssl સાથે તમારી ખાનગી કીને પાસવર્ડ-સુરક્ષિત કરી શકો છો)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-msgid "Choose your personal certificate"
-msgstr "તમારાં વ્યક્તિગત પ્રમાણપત્રને પસંદ કરો"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-msgid "Choose your private key"
-msgstr "તમારી ખાનગી કીને પસંદ કરો"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "ઓળખાણ (_d)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "વપરાશકર્તા પ્રમાણપત્ર (_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "ખાનગી કી (_k)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
-#| msgid "_Generate a password"
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "ખાનગી કી પાસવર્ડ (_P)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
-#| msgid "WPA"
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "મને ફરીથી ચેતવણી આપો નહિં (_w)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "ડોમેઇન (_D)"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "ના"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "હાં"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "ટનલ TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "સુરક્ષિત EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
-#| msgid "Authentication failed"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "સત્તાધિકરણ (_t)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-#| msgid "Default"
-msgid "1 (Default)"
-msgstr "1 (મૂળભૂત)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-#| msgid "System"
-msgid "Open System"
-msgstr "ખુલ્લી સિસ્ટમ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "વહેંચાયેલ કી"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "કી (_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "કી બતાવો (_w)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP અનુક્રમણિકા (_x)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
-#| msgid "_Type:"
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "પ્રકાર (_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
-#| msgid "Magnification:"
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (મૂળભૂત)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "ખુલ્લી સિસ્ટમ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "વહેંચાયેલ કી"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "કી (_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "કી બતાવો (_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP અનુક્રમણિકા (_x)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "સૂચનાઓ"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
-#| msgid "Sound Effects"
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "સાઉન્ડ ચેતવણી"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "પોપઅપ બેનરને બતાવો"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "બેનરમાં વિગતો બતાવો"
-
-#: ../panels/notifications/cc-edit-dialog.c:43
-#| msgid "Lock screen"
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "સ્ક્રીન તાળુમાં જુઓ"
-
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "સ્ક્રીન તાળુમાં વિગતો બતાવો"
-
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "ચાલુ"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-#| msgid "Magnification:"
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "સૂચનાઓ"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "સૂચનાઓ"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "સ્ક્રીન તાળુમાં વિગતો બતાવો"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "સૂચનાઓ"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "કઇ સૂચનાઓ દર્શાવેલ છે અને શું તેઓ બતાવે છે તેની પર નિયંત્રણ કરો"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "સૂચના;બેનર;સંદેશો;ટ્રે;પોપઅપ;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "પોપ અપ બેનરને બતાવો"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-#| msgid "Lock screen"
-msgid "Show in Lock Screen"
-msgstr "સ્ક્રીન તાળુમાં બતાવો"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "આંતરિક સત્તાધિકરણ (_a)"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-#| msgid "Other..."
-msgctxt "Online Account"
-msgid "Other"
-msgstr "બીજુ"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "ખાતુ ઉમેરો"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-#| msgid "_Mail"
-msgid "Mail"
-msgstr "મેઈલ"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-#| msgid "Contrast:"
-msgid "Contacts"
-msgstr "સંપર્કો"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "વાતચીત"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "સ્ત્રોતો"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "ખાતામાં પ્રવેશતી વખતે ભૂલ"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "શ્રેયની મર્યાદા પૂરી થઇ ગઇ."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-#| msgid "Enable this account"
-msgid "Sign in to enable this account."
-msgstr "આ ખાતાને સક્રિય કરવા માટે પ્રવેશો."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr "પ્રવેશો (_S)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "ખાતાને બનાવતી વખતે ભૂલ"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "ખાતાને દૂર કરી રહ્યા હોય ત્યારે ભૂલ"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "શું તમે ખરેખર ખાતાને દૂર કરવા માંગો છો?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "આ સર્વર પર ખાતાને દૂર કરશે નહિં."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "દૂર કરો (_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "ઓનલાઇન ખાતાઓ"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "તમારાં ઓનલાઇન ખાતામાં જોડાવો અને નક્કી કરો તે તેઓ માટે શું વાપરવુ છે"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-#| msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-"Google;Facebook;Twitter;Yahoo;વેબ;ઓનલાઇન;વાતચીત;કૅલેન્ડર;મેઇલ;સંપર્ક;ownCloud;કર્બોસ;IMAP;SMTP;"
-"પોકેટ;ReadItLater;"
+"Google;Facebook;Twitter;Yahoo;વેબ;ઓનલાઇન;વાતચીત;કૅલેન્ડર;મેઇલ;સંપર્ક;ownCloud;કર્બોસ;"
+"IMAP;SMTP;પોકેટ;ReadItLater;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "રૂપરેખાંકિત થયેલ ઓનલાઇન ખાતા નથી"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "ખાતુ દૂર કરો"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "ઓનલાઇન ખાતા ઉમેરો"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"ખાતાને ઉમેરવાનું દસ્તાવેજો, મેઇલ, સંપર્કો, કૅલેન્ડર, વાચચીત અને વધારે માટે તમારાં કાર્યક્રમોને "
-"વાપરવાની પરવાનગી આપે છે."
-
-#: ../panels/power/cc-power-panel.c:183
-msgid "Unknown time"
-msgstr "અજ્ઞાત સમય"
-
-#: ../panels/power/cc-power-panel.c:189
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i મિનિટ"
 msgstr[1] "%i મિનિટ"
 
-#: ../panels/power/cc-power-panel.c:201
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i કલાક"
 msgstr[1] "%i કલાકો"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:209
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "કલાક"
 msgstr[1] "કલાકો"
 
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "મિનિટ"
 msgstr[1] "મિનિટ"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:230
-#, c-format
-#| msgid "Charging - %s until fully charged"
-msgid "%s until fully charged"
-msgstr "ચાર્જ થાય ત્યાં સુધી %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 મિનિટ"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:237
-#, c-format
-#| msgid "Caution low UPS, %s remaining"
-msgid "Caution: %s remaining"
-msgstr "ચેતવણી: %s બાકી રહ્યુ છે"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 મિનિટો"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:242
-#, c-format
-msgid "%s remaining"
-msgstr "%s બાકી રહેલ છે"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 મિનિટો"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
-#| msgid "Full Screen"
-msgid "Fully charged"
-msgstr "સંપૂર્ણપણે ચાર્જ થયેલ છે"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 મિનિટો"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
-msgid "Empty"
-msgstr "ખાલી"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Charging"
-msgstr "ચાર્જિંગ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:271
-#| msgid "Charging"
-msgid "Discharging"
-msgstr "ડિસ્ચાર્જ થઇ રહ્યુ છે"
-
-#: ../panels/power/cc-power-panel.c:396
-msgctxt "Battery name"
-msgid "Main"
-msgstr "મુખ્ય"
-
-#: ../panels/power/cc-power-panel.c:398
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "વધારાનું"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:470
-msgid "Wireless mouse"
-msgstr "વાયરલેસ માઉસ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:473
-msgid "Wireless keyboard"
-msgstr "વાયરલેસ કિબોર્ડ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:476
-msgid "Uninterruptible power supply"
-msgstr "અવરોધી ન શકાય તેવો વીજ પુરવઠો"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Personal digital assistant"
-msgstr "વ્યક્તિગત ડિઝિટલ મદદકર્તા"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Cellphone"
-msgstr "સેલફોન"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Media player"
-msgstr "મીડિયા પ્લેયર"
-
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Tablet"
-msgstr "ટૅબલેટ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Computer"
-msgstr "કમ્પ્યૂટર"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
-#: ../panels/power/cc-power-panel.c:2019
-msgid "Battery"
-msgstr "બેટરી"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "ચાર્જિંગ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "સાવધાન"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Low"
-msgstr "નીચે"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Good"
-msgstr "સરસ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:562
-#| msgid "Full Screen"
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "સંપૂર્ણપણે ચાર્જ થયેલ છે"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "ખાલી"
-
-#: ../panels/power/cc-power-panel.c:715
-#| msgid "Battery"
-msgid "Batteries"
-msgstr "બેટરી"
-
-#: ../panels/power/cc-power-panel.c:1117
-msgid "When _idle"
-msgstr "જ્યારે નિષ્ક્રિય હોય (_i)"
-
-#: ../panels/power/cc-power-panel.c:1445
-msgid "Power Saving"
-msgstr "પાવર સંગ્રહ"
-
-#: ../panels/power/cc-power-panel.c:1473
-#| msgid "Brightness"
-msgid "_Screen brightness"
-msgstr "સ્ક્રીન પ્રકાશતા (_S)"
-
-#: ../panels/power/cc-power-panel.c:1479
-#| msgid "Keyboard Settings"
-msgid "_Keyboard brightness"
-msgstr "કિબોર્ડ પ્રકાશતા (_K)"
-
-#: ../panels/power/cc-power-panel.c:1489
-#| msgid "_Turn screen off when inactive for:"
-msgid "_Dim screen when inactive"
-msgstr "ઝાંખી સ્ક્રીન જ્યારે નિષ્ક્રિય હોય (_D)"
-
-#: ../panels/power/cc-power-panel.c:1514
-#| msgid "Lock screen"
-msgid "_Blank screen"
-msgstr "કોરી સ્ક્રીન (_B)"
-
-#: ../panels/power/cc-power-panel.c:1551
-msgid "_Wi-Fi"
-msgstr "Wi-Fi (_W)"
-
-#: ../panels/power/cc-power-panel.c:1556
-msgid "Turns off wireless devices"
-msgstr "વાયરલેસ ઉપકરણોને બંધ કરે છે"
-
-#: ../panels/power/cc-power-panel.c:1581
-#| msgid "Mobile broadband"
-msgid "_Mobile broadband"
-msgstr "મોબાઇલ બ્રોડબેન્ડ (_M)"
-
-#: ../panels/power/cc-power-panel.c:1586
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "મોબાઇલ બ્રોડબેન્ડ (3G, 4G, WiMax, વગેરે.) ઉપકરણોને બંધ કરે છે"
-
-#: ../panels/power/cc-power-panel.c:1635
-#| msgid "Bluetooth"
-msgid "_Bluetooth"
-msgstr "બ્લુટુથ (_B)"
-
-#: ../panels/power/cc-power-panel.c:1686
-#| msgid "On battery power"
-msgid "When on battery power"
-msgstr "જ્યારે બેટરી પાવર પર છે"
-
-#: ../panels/power/cc-power-panel.c:1688
-msgid "When plugged in"
-msgstr "જ્યારે પ્લગ થયેલ હોય"
-
-#: ../panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Off"
-msgstr "સ્થગિત અને પાવર બંધ"
-
-#: ../panels/power/cc-power-panel.c:1851
-#| msgctxt "proxy method"
-#| msgid "Automatic"
-msgid "_Automatic suspend"
-msgstr "આપમેળે સ્થગિત (_A)"
-
-#: ../panels/power/cc-power-panel.c:1875
-#| msgid "When power is _critically low"
-msgid "When battery power is _critical"
-msgstr "જ્યારે બેટરી પાવર જટીલ હોય (_C)"
-
-#: ../panels/power/cc-power-panel.c:1930
-#| msgid "Power off"
-msgid "Power Off"
-msgstr "પાવર બંધ"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Devices"
-msgstr "ઉપકરણો"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "પાવર"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr "તમારી બેટરી સ્થિતિને જુઓ અને પાવર સંગ્રહ સુયોજનોને બદલો"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-#| msgid "Power;Sleep;Suspend;Hibernate;Battery;"
-msgid "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr "પાવર;સ્લીપ;સ્થગિત;હાઇબરનેટ;બેટરી;પ્રકાશતા;ઝાંખુ;ખાલી;મોનિટર;DPMS;નિષ્ક્રિય;"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "હાઇબરનેટ"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "પાવર બંધ"
-
-#: ../panels/power/power.ui.h:5
-#| msgid "5 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 મિનિટ"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 કલાક"
 
-#: ../panels/power/power.ui.h:7
-#| msgid "10 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 મિનિટ"
 
-#: ../panels/power/power.ui.h:8
-#| msgid "10 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 મિનિટ"
 
-#: ../panels/power/power.ui.h:9
-#| msgid "10 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 મિનિટ"
 
-#: ../panels/power/power.ui.h:10
-#| msgid "1 hour"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 કલાક"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 મિનિટ"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "બેટરી"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 મિનિટો"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ઉપકરણો"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 મિનિટો"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "પાવર બંધ"
 
-#: ../panels/power/power.ui.h:14
-#| msgid "5 minutes"
-msgid "4 minutes"
-msgstr "4 મિનિટ"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 મિનિટો"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "પાવર સંગ્રહ"
 
-#: ../panels/power/power.ui.h:16
-#| msgid "5 minutes"
-msgid "8 minutes"
-msgstr "8 મિનિટ"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "સ્ક્રીન પ્રકાશતા (_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 મિનિટો"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "સ્ક્રીન તેજસ્વિતા અને તાળા સુયોજનો"
 
-#: ../panels/power/power.ui.h:18
-#| msgid "2 minutes"
-msgid "12 minutes"
-msgstr "12 મિનિટ"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "સ્ક્રીન"
 
-#: ../panels/power/power.ui.h:20
-#| msgctxt "proxy method"
-#| msgid "Automatic"
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "સ્ક્રીન વાંચક (_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "આપમેળે માર્ગ"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "આપમેળે સ્થગિત"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "નીચેનું બટન"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "આપમેળે સ્થગિત"
 
-#: ../panels/power/power.ui.h:21
-#| msgid "When plugged in"
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "માં પ્લગ થયેલ (_P)"
 
-#: ../panels/power/power.ui.h:22
-#| msgid "On battery power"
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "બેટરી પાવર પર (_B):"
 
-#: ../panels/power/power.ui.h:23
-#| msgid "_Delay:"
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "વિલંબ"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-#| msgid "Authentication failed"
-msgid "Authenticate"
-msgstr "સત્તાધિકરણ"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "પાવર"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-#| msgid "_Password"
-msgid "Password"
-msgstr "પાસવર્ડ"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "તમારી બેટરી સ્થિતિને જુઓ અને પાવર સંગ્રહ સુયોજનોને બદલો"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-#| msgid "Authentication required"
-msgid "Authentication Required"
-msgstr "સત્તાધિકરણ જરૂરી"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr "ટૉનર ઓછુ છે"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr "ટોનરની બહાર"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr "ડેવલપર ઓછું છે"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr "ડેવલપરની બહાર"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr "માર્કર પૂરવઠો ઓછો છે"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr "માર્કર પૂરવઠાની બહાર"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr "કવર ખોલો"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr "દરવાજો ખોલો"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr "પેપર ઓછા"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr "પેપરની બહાર"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ઓફલાઇન"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "બંધ થયેલ"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr "લગભગ સંપૂર્ણ પાત્ર કચરો"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr "સંપૂર્ણ પાત્ર કચરો"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr "ઓપ્ટીકલ ફોટો કન્ડક્ટર જીવનનાં અંત નજીક છે"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ઓપ્ટીકલ ફોટો કન્ડક્ટર લાંબા સમય સુધી કાર્ય કરતુ નથી"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "રૂપરેખાંકિત કરી રહ્યા છે"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr "તૈયાર"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "કાર્યોને સ્વીકારો નહિં"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr "પ્રોસેસીંગ"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Toner Level"
-msgstr "ટૉનર સ્તર"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Ink Level"
-msgstr "ઇંક સ્તર"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:928
-msgid "Supply Level"
-msgstr "પૂરવઠો સ્તર"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:946
-msgctxt "printer state"
-msgid "Installing"
-msgstr "સ્થાપિત કરી રહ્યા છે"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1123
-msgid "No printers available"
-msgstr "પ્રિન્ટરો ઉપલબ્ધ નથી"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1433
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u સક્રિય"
-msgstr[1] "%u સક્રિય"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1777
-msgid "Failed to add new printer."
-msgstr "નવાં પ્રિન્ટરને ઉમેરવાનું નિષ્ફળ."
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid "Select PPD File"
-msgstr "PPD ફાઇલ પસંદ કરો"
-
-#: ../panels/printers/cc-printers-panel.c:1953
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr "PostScript પ્રિન્ટર વર્ણન ફાઈલો (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "પાવર;સ્લીપ;સ્થગિત;હાઇબરનેટ;બેટરી;પ્રકાશતા;ઝાંખુ;ખાલી;મોનિટર;DPMS;નિષ્ક્રિય;"
 
-#: ../panels/printers/cc-printers-panel.c:2258
-msgid "No suitable driver found"
-msgstr "સુસંગત ડ્રાઇવર મળ્યુ નથી"
-
-#: ../panels/printers/cc-printers-panel.c:2327
-#| msgid "Searching for preferred drivers..."
-msgid "Searching for preferred drivers…"
-msgstr "પસંદ થયેલ ડ્રાઇવરોને શોધી રહ્યા છે..."
-
-#: ../panels/printers/cc-printers-panel.c:2342
-#| msgid "Select from database..."
-msgid "Select from database…"
-msgstr "ડેટાબેઝમાંથી પસંદ કરો..."
-
-#: ../panels/printers/cc-printers-panel.c:2351
-#| msgid "Provide PPD File..."
-msgid "Provide PPD File…"
-msgstr "PPD ફાઈલ પૂરી પાડો..."
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2502
-#: ../panels/printers/cc-printers-panel.c:2525
-msgid "Test page"
-msgstr "ચકાસણી પાનું"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2933
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui ને લોડ કરી શક્યા નહિં: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "પ્રિન્ટરો"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "પ્રિન્ટર ઉમેરો, પ્રિન્ટર ક્રિયાને જુઓ અને નક્કી કરો કે કેવી રીતે તમે છાપવા માંગો છો"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "પ્રિન્ટર;કતાર;છાપો;પેપર;સહી;ટૉનર;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "સક્રિય ક્રિયા"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "બંધ કરો"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "છાપવાનું પુન:લાવો"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "છાપવાનું અટકાવો"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "છાપન ક્રિયા રદ કરો"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "નવાં પ્રિન્ટરને ઉમેરો"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-#| msgid "Authentication failed"
-msgid "A_uthenticate"
-msgstr "સત્તાધિકરણ (_u)"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "પ્રિન્ટર શોધાયેલ નથી."
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-#| msgid "Search for network printers or filter result"
-msgid "Enter address of a printer or a text to filter results"
-msgstr "પરિણામોને ફિલ્ટર કરવા માટે પ્રિન્ટર અથવા લખાણનાં સરનામાંને દાખલ કરો"
-
-#: ../panels/printers/options-dialog.ui.h:1
-#| msgid "Loading options..."
-msgid "Loading options…"
-msgstr "વિકલ્પો લાવી રહ્યા છે…"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "પ્રિન્ટર ડ્રાઇવરને પસંદ કરો"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "ડ્રાઇવર ડેટાબેઝને લાવી રહ્યા છે..."
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-#| msgid "Remove Printer"
-msgid "JetDirect Printer"
-msgstr "JetDirect પ્રિન્ટર"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-#| msgctxt "Device kind"
-#| msgid "Printer"
-msgid "LPD Printer"
-msgstr "LPD પ્રિન્ટર"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "એકતરફી"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "લાંબી બાજુ (મૂળભૂત)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "ટૂંકી બાજુ (ફ્લિપ)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "પૉર્ટેટ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "લૅન્ડસ્કેપ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "વિપરીત લૅન્ડસ્કેપ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "વિપરીત પૉર્ટ્રેટ"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "સ્થગિત"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "અટકેલ"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "પ્રોસેસીંગ"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "બંધ થયેલ"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "રદ થયેલ"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "કાઢી નાંખેલ"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "સમાપ્ત"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "જોબ શીર્ષક"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "જૉબ સ્થિતિ"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "સમય"
-
-#: ../panels/printers/pp-jobs-dialog.c:495
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s સક્રિય ક્રિયા"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Serial Port"
-msgstr "સીરીયલ પોર્ટ"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1683
-msgid "Parallel Port"
-msgstr "સમાંતર પોર્ટ"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-#| msgid "Location"
-msgid "Location: %s"
-msgstr "સ્થાન: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1744
-#, c-format
-#| msgid "A_ddress:"
-msgid "Address: %s"
-msgstr "સરનામું: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1768
-msgid "Server requires authentication"
-msgstr "સર્વરને સત્તાધિકરણની જરૂરિયાત છે"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "દ્દિતરફી"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "પેપર પ્રકાર"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "પેપર સ્ત્રોત"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "આઉટપુટ ટ્રે"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript ફરી ફિલ્ટર કરી રહ્યા છે"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:531
-msgid "Pages per side"
-msgstr "બાજુ પ્રતિ પાનાંઓ"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:543
-msgid "Two-sided"
-msgstr "દ્દિતરફી"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:555
-msgid "Orientation"
-msgstr "દિશા"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:652
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "સામાન્ય"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "પાનું સુયોજન"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "સ્થાપન કરી શકાય તેવા વિકલ્પો"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "ક્રિયા"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "ઇમેજ ગુણવત્તા"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "રંગ"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "સમાપ્ત કરી રહ્યા છે"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "ઉન્નત"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "સ્વયં પસંદ કરો"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "મૂળભૂત પ્રિન્ટર "
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "ફક્ત ઍમ્બેડ GhostScript ફોન્ટ"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "PS સ્તર 1 માં રૂપાંતરિત કરો"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "PS સ્તર 2 માં રૂપાંતરિત કરો"
-
-# libgnomeprintui/gpaui/add-printer-dialog.c:83
-# libgnomeprintui/gpaui/config-dialog.c:83
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "પહેલેથી ફિલ્ટર કરવુ નહિં"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-#| msgid "Manufacturer:"
-msgid "Manufacturer"
-msgstr "ઉત્પાદક"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "ડ્રાઇવર"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr "%s પર ઉપલબ્ધ પ્રિન્ટરોને જોવા માટે તમારાં વપરાશકર્તાનામ અને પાસવર્ડને દાખલ કરો."
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "પ્રિન્ટરને ઉમેરો"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "પ્રિન્ટર દૂર કરો"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "તાળુ ખોલો"
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "પૂરુ પાડો"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "ચિત્ર મળ્યા નથી"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "સત્તાધિકરણ જરૂરી"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr "%s પર ઉપલબ્ધ પ્રિન્ટરોને જોવા માટે તમારાં વપરાશકર્તાનામ અને પાસવર્ડને દાખલ કરો."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "વપરાશકર્તા નામ"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "સ્થાન"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-#| msgid "Default Route"
-msgid "_Default printer"
-msgstr "મૂળભૂત પ્રિન્ટર (_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "ડ્રાઇવર"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "જોબ"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "પસંદ થયેલ ડ્રાઇવરોને શોધી રહ્યા છે..."
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "કાર્યોને બતાવો (_J)"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "શહેર માટે શોધો"
+
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "ડેટાબેઝમાંથી પસંદ કરો..."
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "PPD ફાઈલ પૂરી પાડો..."
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "પ્રિન્ટર ડ્રાઇવરને પસંદ કરો"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "ડ્રાઇવર ડેટાબેઝને લાવી રહ્યા છે..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "રદ કરો"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "પસંદ કરો"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "સર્વરને સત્તાધિકરણની જરૂરિયાત છે"
+msgstr[1] "સર્વરને સત્તાધિકરણની જરૂરિયાત છે"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "ડોમેઇન (_D)"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "સત્તાધિકરણ (_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "સત્તાધિકરણ"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s સક્રિય ક્રિયા"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "ચકાસણી પાનું"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "પ્રવેશ વિકલ્પો"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "મૂળભૂત પ્રિન્ટર "
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "મૂળભૂત પ્રિન્ટર "
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "છાપન ક્રિયા રદ કરો"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "પ્રિન્ટર દૂર કરો"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "સક્રિય ક્રિયા"
 
 # libgnomeprintui/gpaui/add-printer-dialog.c:83
 # libgnomeprintui/gpaui/config-dialog.c:83
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "મોડેલ"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "લેબલ"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "ઇંક સ્તર"
 
-#: ../panels/printers/printers.ui.h:17
-#| msgid "Setting new driver..."
-msgid "Setting new driver…"
-msgstr "નવાં ડ્રાઇવરને સુયોજિત કરી રહ્યા છે…"
-
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "પાનું 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "ચકાસણી પાનાંને છાપો (_T)"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "વિકલ્પો (_O)"
-
-#. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "નવાં પ્રિન્ટરને ઉમેરો"
-
-#. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
-msgid ""
-"Sorry! The system printing service\n"
-"doesn't seem to be available."
-msgstr "દિલગીર છુ! સિસ્ટમ પ્રિન્ટીંગ સેવા ઉપલબ્ધ નથી એવુ લાગે છે."
-
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-#| msgid "Screenshots"
-msgid "Screen Lock"
-msgstr "સ્ક્રીન તાળુ"
-
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "વપરાશ અને ઇતિહાસ"
-
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
-msgstr "શું કચરાપેટીમાંથી બધી વસ્તુઓને ખાલી કરો?"
-
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
-msgstr "કચરાપેટીમાં બધી વસ્તુઓને કાયમ માટે કાઢી નાંખેલ છે."
-
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "કચરાપેટી ખાલી કરો (_E)"
-
-#: ../panels/privacy/cc-privacy-panel.c:512
-msgid "Delete all the temporary files?"
-msgstr "શું બધી કામચલાઉ ફાઇલોને કાઢવાની છે?"
-
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
-msgstr "બધી કામચલાઉ ફાઇલો કાયમ માટે કાઢી નંખાશે."
-
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-#| msgid "_Keep Files"
-msgid "_Purge Temporary Files"
-msgstr "કામચલાઉ ફાઇલોને સાફ કરો (_P)"
-
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "કચરાપેટી અને કામચલાઉ ફાઇલોને સાફ કરો"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-#| msgid "Software"
-msgid "Software Usage"
-msgstr "સોફ્ટવેર વપરાશ"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "ખાનગી"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr "તમારી વ્યક્તિગત જાણકારીને સુરક્ષિત કરો અને બીજા શું જોઇ શકે તેની પર નિયંત્રણ કરો"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
 msgstr ""
-"સ્ક્રીન;તાળુ;નિદાન;ભંગાણ;ખાનગી;તાજેતરનું;કામચલાઉ;tmp;અનુક્રમણિકા;નામ;"
-"નેટવર્ક;ઓળખાણ;"
 
-#: ../panels/privacy/privacy.ui.h:1
-#| msgid "Screen turns off"
-msgid "Screen Turns Off"
-msgstr "સ્ક્રીન બંધ થાય છે"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 સેકંડ"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 દિવસ"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 દિવસો"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 દિવસો"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 દિવસો"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 દિવસો"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 દિવસો"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 દિવસો"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 દિવસો"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 દિવસો"
-
-#: ../panels/privacy/privacy.ui.h:18
-#| msgid "never"
-msgid "Forever"
-msgstr "હંમેશા"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"તમારાં ઇતિહાસને યાદ રાખવુ ફરી શોધવા માટે સરળ બની જાય છે. આ વસ્તુઓ નેટવર્ક પર કદી વહેંચાતી નથી."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "તાજેતરમાં વાપરેલ છે (_R)"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "ઇતિહાસને પુન:પ્રાપ્ત કરો (_H)"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "તાજેતરનો ઇતિહાસ સાફ કરો (_e)"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "તાળુ સ્ક્રીન તમારી ખાનગી જાણકારીને સુરક્ષિત રાખે છે જ્યારે તમે દૂર હોય."
-
-#: ../panels/privacy/privacy.ui.h:26
-#| msgid "A_utomatic Login"
-msgid "Automatic Screen _Lock"
-msgstr "આપમેળે સ્ક્રીનનું તાળુ (_L)"
-
-#: ../panels/privacy/privacy.ui.h:27
-#| msgid "_Lock screen after:"
-msgid "Lock screen _after blank for"
-msgstr "ખાલી પછી સ્ક્રીનને તાળુ મારો (_a)"
-
-#: ../panels/privacy/privacy.ui.h:28
-#| msgid "Show _notifications when locked"
-msgid "Show _Notifications"
-msgstr "સૂચનાઓ બતાવો (_N)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"બિનજરૂરી સંવેદનશીલ જાણકારીથી તમારાં કમ્પ્યૂટરને મુક્ત રાખવા મદદ કરવા માટે પહેલાં આપમેળે "
-"કચરાપેટી અને કામચલાઉ ફાઇલોને સાફ કરો."
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "આપમેળે કચરાપેટી ખાલી (_T)"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "આપમેળે કામચલાઉ ફાઇલોને સાફ કરો (_F)"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "પછી સાફ કરો (_A)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"ક્યાં સોફ્ટવેર તમે વાપરો છે જે તમને વધારે ચોક્કસ અગ્રહતા સાથે તમને પૂરુ પાડવા મદદ કરે છે તે "
-"વિશે જાણકારી અમને મોકલી રહ્યા છે. તે અમારાં સોફ્ટવેરને સુધારવા માટે પણ અમને મદદ કરે છે.\n"
-"\n"
-"બધી જાણકારી જે અમે અનામિક રીતે સંગ્રહી છે, અને અમે ત્રીજી પાર્ટી સાથે તમારી માહિતીને વહેંચવાની "
-"કદી જરૂર પડશે નહિં."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "સોફ્ટવેર વપરાશનાં આંકડા મોકલો (_S)"
-
-#: ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "ખાનગી પોલિસી"
-
-#: ../panels/privacy/privacy.ui.h:42
-#| msgid "Location"
-msgid "_Location Services"
-msgstr "સ્થાન સેવા (_L)"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "તમારાં ભૌગોલિક સ્થાનને નક્કી કરવા વાપરેલ છે"
-
-#: ../panels/region/cc-format-chooser.c:119
-#| msgid "Imperial"
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ઇમ્પેરીઅલ"
-
-#: ../panels/region/cc-format-chooser.c:121
-#| msgid "Metric"
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "મેટ્રીક"
-
-#: ../panels/region/cc-format-chooser.c:284
-msgid "No regions found"
-msgstr "વિસ્તાર મળ્યા નથી"
-
-#: ../panels/region/cc-input-chooser.c:179
-#| msgid "Move Input Source Down"
-msgid "No input sources found"
-msgstr "ઇનપુટ સ્ત્રોત મળ્યા નથી"
-
-#: ../panels/region/cc-input-chooser.c:1076
-#| msgid "Other..."
-msgctxt "Input Source"
-msgid "Other"
-msgstr "બીજુ"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:896
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "તમારાં બદલાવોની અસર લાવવા માટે તમારા સત્રને પુન:શરૂ કરવુ જરૂરી છે"
-
-#: ../panels/region/cc-region-panel.c:240
-#: ../panels/user-accounts/um-user-panel.c:897
-msgid "Restart Now"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
 msgstr "હવે પુન:શરૂ કરો"
 
-#: ../panels/region/cc-region-panel.c:858
-#| msgid "No printers detected."
-msgid "No input source selected"
-msgstr "ઇનપુટ સ્ત્રોત પસંદ થયેલ નથી"
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "પ્રિન્ટરને ઉમેરો"
 
-#: ../panels/region/cc-region-panel.c:1088
-msgid "Sorry"
-msgstr "દિલગીર છુ"
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "પ્રિન્ટર સુયોજનોને બદલો"
 
-#: ../panels/region/cc-region-panel.c:1090
-msgid "Input methods can't be used on the login screen"
-msgstr "પ્રવેશ સ્ક્રીન પર ઇનપુટ પદ્દતિઓને વાપરી શકાતુ નથી"
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "પ્રિન્ટરો"
 
-#: ../panels/region/cc-region-panel.c:1727
-#| msgid "Lock screen"
-msgid "Login Screen"
-msgstr "પ્રવેશ સ્ક્રીન"
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+#, fuzzy
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr "દિલગીર છુ! સિસ્ટમ પ્રિન્ટીંગ સેવા ઉપલબ્ધ નથી એવુ લાગે છે."
 
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "બંધારણો"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "સ્થાનો શોધો"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "બંધારણો"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "બંધારણો"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "પૂર્વદર્શન"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "તારીખો"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "સમય"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "તારીખ અને સમય"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "નંબરો"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "માપ"
 
-#: ../panels/region/format-chooser.ui.h:9
-#| msgid "Paper Type"
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "કાગળ"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "ભાષાઓને સ્થાપિત કરો..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "મારુ ખાતુ"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "ભાષા (_L)"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "બંધારણો"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "પ્રવેશ સ્ક્રીન"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "પ્રદેશ અને ભાષા"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid "Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr "તમારી દર્શાવ ભાષા, બંધારણો, કિબોર્ડ લેઆઉટ અને ઇનપુટ સ્ત્રોતોને પસંદ કરો"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-#| msgid "Language;Layout;Keyboard;"
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ભાષા;લેઆઉટ;કિબોર્ડ;ઇનપુટ;"
 
-#: ../panels/region/input-chooser.ui.h:1
-#| msgid "Add Input Source"
-msgid "Add an Input Source"
-msgstr "ઇનપુટ સ્ત્રોત ઉમેરો "
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "પસંદ કરો કેવી રીતે મીડિયાને સંભાળવુ જોઇએ"
 
-#: ../panels/region/input-options.ui.h:1
-#| msgid "Input Source Settings"
-msgid "Input Source Options"
-msgstr "ઇનપુટ સ્ત્રોત વિકલ્પો"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD ઓડિયો (_a)"
 
-#: ../panels/region/input-options.ui.h:2
-#| msgid "Use same layout in all windows"
-msgid "Use the _same source for all windows"
-msgstr "બધી વિન્ડો માટે સરખા સ્ત્રોતને વાપરો (_s)"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "DVD વિડિયો (_D)"
 
-#: ../panels/region/input-options.ui.h:3
-#| msgid "Allow different layouts for each window"
-msgid "Allow _different sources for each window"
-msgstr "દરેક વિન્ડો માટે વિવિધ સ્ત્રોતોને પરવાનગી આપો (_d)"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "સંગીત પ્લેયર (_M)"
 
-#: ../panels/region/input-options.ui.h:4
-#| msgid "Keyboard Settings"
-msgid "Keyboard Shortcuts"
-msgstr "કિબોર્ડ ટૂંકાણો"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "સોફ્ટવેર (_S)"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Switch to previous source"
-msgstr "પહેલાનાં સ્ત્રોતમાં બદલો"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "બીજી મીડિયા (_O)…"
 
-#: ../panels/region/input-options.ui.h:6
-#| msgid "Ctrl+Alt+Shift+Space"
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "મીડિયા નિવેશ પર કદી પૂછો નહિં અથવા કાર્યક્રમ શરૂ કરો (_N)"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Switch to next source"
-msgstr "આગળનાં સ્ત્રોત પર જાવ"
-
-#: ../panels/region/input-options.ui.h:8
-msgid "Super+Space"
-msgstr "Super+Space"
-
-#: ../panels/region/input-options.ui.h:9
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "કિબોર્ડ સુયોજનોમાં આ ટૂંકાણોને તમે બદલી શકો છો"
-
-#: ../panels/region/input-options.ui.h:10
-#| msgid "Switch to next source"
-msgid "Alternative switch to next source"
-msgstr "આગળનાં સ્ત્રોત પર જાવ"
-
-#: ../panels/region/input-options.ui.h:11
-msgid "Left+Right Alt"
-msgstr "ડાબી+જમણી Alt"
-
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "અંગ્રેજી (United Kingdom)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "United Kingdom"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "વિકલ્પો"
-
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
-msgstr "બધા વપરાશકર્તાઓ દ્દારા પ્રવેશ સુયોજનો વાપરેલ છે જ્યારે સિસ્ટમમાં પ્રવેશી રહ્યા છે"
-
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
-msgid "Places"
-msgstr "સ્થાનો"
-
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
-msgid "Bookmarks"
-msgstr "બુકમાર્કો"
-
-#: ../panels/search/cc-search-locations-dialog.c:480
-#| msgid "Other..."
-msgctxt "Search Location"
-msgid "Other"
-msgstr "બીજુ"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "પસંદ કરો કેવી રીતે બીજી મીડિયાને સંભાળવુ જોઇએ"
 
 # #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/search/cc-search-locations-dialog.c:678
-#| msgid "Select a region"
-msgid "Select Location"
-msgstr "સ્થાન પસંદ કરો"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "ક્રિયા (_A):"
 
-#: ../panels/search/cc-search-locations-dialog.c:682
-#| msgid "GOK"
-msgid "_OK"
-msgstr "બરાબર (_O)"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "પ્રકાર (_T):"
 
-#: ../panels/search/cc-search-panel.c:176
-#| msgid "Applications"
-msgid "No applications found"
-msgstr "કાર્યક્રમો મળ્યા નથી"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "દૂર કરી શકાય તેવી મીડિયા"
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "શોધો"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "બ્લુટુથ સુયોજનોને રૂપરેખાંકિત કરો"
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
-msgid "Control which applications show search results in the Activities Overview"
-msgstr "પ્રવૃત્તિ ઝાંખીમાં ક્યાં કાર્યક્રમો શોધ પરિણામોને બતાવે છે તેની પર નિયંત્રણ કરો"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"ઉપકરણ;સિસ્ટમ;જાણકારી;મેમરી;પ્રોસેસર;આવૃત્તિ;મૂળભૂત;કાર્યક્રમ;પસંદ થયેલ;cd;dvd;usb;ઓડિયો;"
+"વિડિયો;ડિસ્ક;નિરાકરણ;મીડિયા;સ્વયં ચલાવો;"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
-msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "શોધો;શોધો;અનુક્રમણિકા;છુપાડો;ખાનગી;પરિણામો;"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "સ્ક્રીન તાળુ"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-#| msgid "Location"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "કોરી સ્ક્રીન (_B)"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "આપમેળે સ્ક્રીનનું તાળુ (_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "આપમેળે સ્ક્રીનનું તાળુ (_L)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "સ્ક્રીન તાળુમાં વિગતો બતાવો"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "સ્ક્રીનને તાળુ મારો"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "ખાનગી"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "સ્ક્રીન"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "સાઉન્ડ સુયોજનો"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "સ્થાનો શોધો"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "ઉપર ખસેડો"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "નીચે ખસેડો"
-
-#: ../panels/search/search.ui.h:3
-#| msgid "Mouse Preferences"
-msgid "Preferences"
-msgstr "પસંદગીઓ"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "ચાલુ"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "બંધ"
-
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
-#: ../panels/sharing/cc-sharing-panel.c:304
-#| msgid "Enabled"
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "સક્રિય"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-#| msgid "Active Jobs"
-msgctxt "service is active"
-msgid "Active"
-msgstr "સક્રિય"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-#| msgid "Choose a Layout"
-msgid "Choose a Folder"
-msgstr "ફોલ્ડર પસંદ કરો"
-
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "નકલ કરો"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-#| msgid "Hearing"
-msgid "Sharing"
-msgstr "ભાગીદારી"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr "તમે શું બીજાઓ સાથે ભાગીદારી કરવા માંગો છો તેની પર નિયંત્રિત કરો"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
 msgstr ""
-"વહેંચો;ભાગીદારી;ssh;યજમાન;નામ;દૂરસ્થ;ડેસ્કટોપ;બ્લુટુથ;ઑબેક્સ;મીડિયા;ઓડિયો;વિડિયો;"
-"ચિત્રો;ફોટા;ચિત્રપટ;સર્વર;રેન્ડરર;"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-#| msgid "Enable h_orizontal scrolling"
-msgid "Enable or disable remote login"
-msgstr "દૂરસ્થ પ્રવેશને સક્રિય અથવા નિષ્ક્રિય કરો"
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
+msgid "Places"
+msgstr "સ્થાનો"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-#| msgid "Authentication is required to change user data"
-msgid "Authentication is required to enable or disable remote login"
-msgstr "દૂરસ્થ પ્રવેશને સક્રિય અથવા નિષ્ક્રિય કરવા માટે સત્તાધિકરણ જરૂરી છે"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
+msgid "Bookmarks"
+msgstr "બુકમાર્કો"
 
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:299
-msgid "No networks selected for sharing"
-msgstr "ભાગીદારી માટે પસંદ થયેલ નેટવર્ક નથી"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "બીજુ"
 
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
-#| msgid "Network"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "સ્થાન"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "કાર્યક્રમો"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "સરનામાં પ્રમાણે શોધો (_S)"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "પ્રવૃત્તિ ઝાંખીમાં ક્યાં કાર્યક્રમો શોધ પરિણામોને બતાવે છે તેની પર નિયંત્રણ કરો"
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "શોધો;શોધો;અનુક્રમણિકા;છુપાડો;ખાનગી;પરિણામો;"
+
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "નેટવર્ક"
 
-#: ../panels/sharing/sharing.ui.h:1
-#| msgid "Bluetooth Settings"
-msgid "Bluetooth Sharing"
-msgstr "બ્લુટુથ ભાગીદારી"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "ભાગીદારી"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-"બ્લુટુથ ભાગીદારી બીજા બ્લુટુથ સક્રિય થયેલ ઉપકરણો સાથે ફાઇલોને વહેંચવા તમને પરવાનગી આપે છે"
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "ફક્ત વિશ્ર્વાસપાત્ર ઉપકરણોમાંથી મેળવો"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "ડાઉનલોડ ફોલ્ડરમાં મળેલ ફાઇલોને સંગ્રહો"
-
-#: ../panels/sharing/sharing.ui.h:5
-#| msgid "Computer"
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "કમ્પ્યૂટર નામ"
 
-#: ../panels/sharing/sharing.ui.h:6
-#| msgid "Personal digital assistant"
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "ખાનગી ફાઈલ વહેંચણી"
 
-#: ../panels/sharing/sharing.ui.h:7
-#| msgid "Screen part:"
-msgid "Screen Sharing"
-msgstr "સ્ક્રીન ભાગીદારી"
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:8
-#| msgid "Media player"
-msgid "Media Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
 msgstr "મીડિયા ભાગીદારી"
 
-#: ../panels/sharing/sharing.ui.h:9
-#| msgid "Remove Region"
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "દૂરસ્થ પ્રવેશ"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "ભાગીદારી"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "પાસવર્ડ જરૂરી"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "દૂરસ્થ પ્રવેશ"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "અમુક સેવાઓ નિષ્ક્રિય થયેલ છે કારણ કે નેટવર્ક પ્રવેશ નથી."
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "દૂરસ્થ પ્રવેશ"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
-"વ્યક્તિગત ફાઇલ ભાગીદારી તમારાં હાલના નેટવર્કને વાપરીને બીજાઓ સાથે તમારા સાર્વજનિક ફોલ્ડરને "
-"વહેંચવા તમને પરવાનગી આપે છે: <a href=\"dav://%s\">dav://%s</a>"
 
-#: ../panels/sharing/sharing.ui.h:13
-#| msgid "Group Password"
-msgid "Require Password"
-msgstr "પાસવર્ડ જરૂરી"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "દૂરસ્થ પ્રવેશને સક્રિય અથવા નિષ્ક્રિય કરો"
 
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"સુરક્ષિત શેલ આદેશની મદદથી જોડાવા માટે દૂરસ્થ વપરાશકર્તાઓને પરવાનગી આપો:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"જોવા માટે દૂરસ્થ વપરાશકર્તાઓને પરવાનગી આપો અથવા તેની સાથે જોડાઇને તમારી સ્ક્રીન પર નિયંત્રણ "
-"કરો: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:20
-#| msgid "Volume Control"
-msgid "Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "દૂરસ્થ નિયંત્રણને પરવાનગી આપો"
 
-#: ../panels/sharing/sharing.ui.h:21
-#| msgid "_Password"
-msgid "Password:"
-msgstr "પાસવર્ડ:"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:22
-#| msgid "_Show password"
-msgid "Show Password"
-msgstr "પાસવર્ડને બતાવો"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "જોડાયેલ નથી"
 
-#: ../panels/sharing/sharing.ui.h:23
-#| msgid "%s Options"
-msgid "Access Options"
-msgstr "વિકલ્પો વાપરો"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "નવાં જોડાણે પ્રવેશ માટે પૂછવુ જ જોઇએ"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "નકલ કરો"
 
-#: ../panels/sharing/sharing.ui.h:25
-#| msgid "Generate a password"
-msgid "Require a password"
-msgstr "પાસવર્ડની જરૂર છે"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "સરનામું કાઢી નાંખો"
 
-#: ../panels/sharing/sharing.ui.h:26
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "સત્તાધિકરણ (_t)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "વપરાશકર્તા નામ"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "આંગળી છાપનની નોંધણી"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "મીડિયા ભાગીદારી"
+
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "નેટવર્ક પર સંગીત, ફોટા અને વિડિયોની ભાગીદારી કરો."
 
-#: ../panels/sharing/sharing.ui.h:27
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "ફોલ્ડર"
 
-# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
-# 48x48/emblems/emblem-sound.icon.in.h:1
-# 48x48/emblems/emblem-sound.icon.in.h:1
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "ધ્વનિ"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "તમે શું બીજાઓ સાથે ભાગીદારી કરવા માંગો છો તેની પર નિયંત્રિત કરો"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-#| msgid "Change sound volume and sound events"
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "સાઉન્ડ સ્તર, ઇનપુટ, આઉટપુટ, અને સાઉન્ડ ચેતવણીને બદલો"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"વહેંચો;ભાગીદારી;ssh;યજમાન;નામ;દૂરસ્થ;ડેસ્કટોપ;બ્લુટુથ;ઑબેક્સ;મીડિયા;ઓડિયો;વિડિયો;ચિત્રો;"
+"ફોટા;ચિત્રપટ;સર્વર;રેન્ડરર;"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "કાર્ડ;માઇક્રોફોન;વોલ્યુમ;ઝાંખુ;સંતુલન;બ્લુટુથ;હૅન્ડસેટ;ઓડિયો;"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "દૂરસ્થ પ્રવેશને સક્રિય અથવા નિષ્ક્રિય કરો"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "બાર્ક"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "દૂરસ્થ પ્રવેશને સક્રિય અથવા નિષ્ક્રિય કરવા માટે સત્તાધિકરણ જરૂરી છે"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "ઝરમર"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "ફ્લિકર"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "ગ્લાસ"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "ભાગીદારી"
 
-# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-# 48x48/emblems/emblem-sound.icon.in.h:1
-# 48x48/emblems/emblem-sound.icon.in.h:1
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "સોનાર"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "ડાબું"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "જમણું"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "સમતુલન (_B):"
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "ઝાંખુ પડવુ (_F):"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "પાછળનું"
 
 # #-#-#-#-#  libgnomecanvas.gnome-2-2.hi.po (libgnomecanvas)  #-#-#-#-# libgnomecanvas/gnome-canvas-text.c:238
 # #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-font-picker.c:184 libgnomeui/gnome-font-picker.c:979
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "આગળનું"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "ન્યૂનતમ"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "મહત્તમ"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "સમતુલન (_B):"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "ઝાંખુ પડવુ (_F):"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "સબવુફર (_S):"
-
-#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:616
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "અવાજ વધારો નહિં"
-
-# libgnomeprintui/gpaui/add-printer-dialog.c:83
-# libgnomeprintui/gpaui/config-dialog.c:83
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "રૂપરેખા (_P):"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u આઉટપુટ"
-msgstr[1] "%u આઉટપુટો"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u ઇનપુટ"
-msgstr[1] "%u ઇનપુટો"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "સિસ્ટમ સાઉન્ડ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "સ્પીકર ચકાસો (_T)"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "ચેતવણી વોલ્યુમ (_A):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "પીક મળ્યુ"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "અવાજ મૂંગો"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1509
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "નામ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1528
-msgid "Device"
-msgstr "ઉપકરણ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1591
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s માટે સ્પીકર ચકાસણી"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1649
-msgid "_Output volume:"
-msgstr "આઉટપુટ વોલ્યુમ (_O): "
-
-#: ../panels/sound/gvc-mixer-dialog.c:1663
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "આઉટપુટ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1668
-msgid "C_hoose a device for sound output:"
-msgstr "સાઉન્ડ આઉટપુટ માટે ઉપકરણને પસંદ કરો (_h):"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "આઉટપુટ વોલ્યુમ (_O): "
 
-#: ../panels/sound/gvc-mixer-dialog.c:1693
-msgid "Settings for the selected device:"
-msgstr "પસંદ થયેલ ઉપકરણ માટે સુયોજનો:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "Input"
-msgstr "ઇનપુટ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "_Input volume:"
-msgstr "ઇનપુટ વોલ્યુમ (_I): "
-
-#: ../panels/sound/gvc-mixer-dialog.c:1734
-msgid "Input level:"
-msgstr "ઈનપુટ સ્તર:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1762
-msgid "C_hoose a device for sound input:"
-msgstr "સાઉન્ડ ઇનપુટ માટે ઉપકરણને પસંદ કરો (_h):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "Sound Effects"
-msgstr "સાઉન્ડ અસરો"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-msgid "_Alert volume:"
-msgstr "ચેતવણી વોલ્યુમ (_A):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1809
-msgid "Applications"
-msgstr "કાર્યક્રમો"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1813
-msgid "No application is currently playing or recording audio."
-msgstr "કાર્યક્રમ હાલમાં ઓડિયોને વગાડી અથવા રેકોર્ડ કરી રહ્યુ છે."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "બિલ્ટ-ઇન"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "સાઉન્ડ પસંદગીઓ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "ઘટના સાઉન્ડની ચકાસણી કરી રહ્યા છીએ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "મૂળભૂત"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "થીમ માંથી"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:769
-msgid "C_hoose an alert sound:"
-msgstr "ચેતવણી સાઉન્ડને પસંદ કરો (_h):"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "બંધ કરો"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "ચકાસો"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "રૂપરેખાંકન URL (_C)"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "સબવુફર"
 
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
-# libgnomeprint/gpa/gpa-media.c:241
-# #-#-#-#-#  libgnomeprint.gnome-2-2.hi.po (libgnomeprint VERSION)  #-#-#-#-#
-# libgnomeprint/gpa/gpa-media.c:241
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "વૈવિધ્યપૂર્ણ"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "ઇનપુટ"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "તેને જોવા, સાંભળવા, ટાઇપ, નિર્દેશિત અને ક્લિક કરવાનું સરળ બનાવો"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "ઈનપુટ સ્તર:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "અવાજ વધારો"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "ચેતવણી વોલ્યુમ (_A):"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "મૂંગુ"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ધ્વનિ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "સાઉન્ડ સ્તર, ઇનપુટ, આઉટપુટ, અને સાઉન્ડ ચેતવણીને બદલો"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "કાર્ડ;માઇક્રોફોન;વોલ્યુમ;ઝાંખુ;સંતુલન;બ્લુટુથ;હૅન્ડસેટ;ઓડિયો;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "સૂચનાઓ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "નામ (_N):"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"કિબોર્ડ;માઉસ;a11y;સુલભતા;ભેદ;નાનું મોટુ કરો;સ્ક્રીન વાંચક;લખાણ;ફોન્ટ;માપ;"
-"AccessX;સ્ટીકી;કી;ધીમી;બાઉન્સ;માઉસ;"
 
-#: ../panels/universal-access/uap.ui.h:1
-#| msgid "Universal Access"
-msgid "_Always Show Universal Access Menu"
-msgstr "સાર્વત્રિક વપરાશ મેનુને હંમેશા બતાવો (_A)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "જોઇ રહ્યા છે"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "સ્વયમ જોડાવો (_C)"
 
-#: ../panels/universal-access/uap.ui.h:3
-#| msgid "High Contrast"
-msgid "_High Contrast"
-msgstr "ઉચ્ચ વિરોધાભાસ (_H)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "ઉપકરણ દૂર કરો"
 
-#: ../panels/universal-access/uap.ui.h:4
-#| msgid "Large Text"
-msgid "_Large Text"
-msgstr "લાંબુ લખાણ (_L)"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:5
-#| msgid "Zoom"
-msgid "_Zoom"
-msgstr "નાનું મોટું (_Z)"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s ડોમેઇનમાં જોડાઇ શકાયુ નહિં: %s"
 
-#: ../panels/universal-access/uap.ui.h:7
-#| msgid "Screen Reader"
-msgid "Screen _Reader"
-msgstr "સ્ક્રીન વાંચક (_R)"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "સાર્વત્રિક વપરાશ"
 
-#: ../panels/universal-access/uap.ui.h:8
-#| msgid "Bounce Keys"
-msgid "_Sound Keys"
-msgstr "સાઉન્ડ કી (_S)"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "સાંભળવુ"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "ઉપકરણ ઉમેરો"
 
-#: ../panels/universal-access/uap.ui.h:10
-#| msgid "Visual Alerts"
-msgid "_Visual Alerts"
-msgstr "દેખીતી ચેતવણીઓ (_V)"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:12
-#| msgid "Screen keyboard"
-msgid "Screen _Keyboard"
-msgstr "સ્ક્રીન કિબોર્ડ (_K)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:13
-#| msgid "Typing Assistant"
-msgid "_Typing Assist (AccessX)"
-msgstr "ટાઇપીંગ સહાયક (AccessX) (_T)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:14
-#| msgid "Pointing and Clicking"
-msgid "Pointing & Clicking"
-msgstr "નિર્દેશિત અને ક્લિક કરી રહ્યા છે"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:15
-#| msgid "Mouse Keys"
-msgid "_Mouse Keys"
-msgstr "માઉસ કી (_M)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "કર્સર ઝબૂકે છે"
 
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "મદદ માટે ક્લિક કરો (_C)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "કર્સર લખાણ ક્ષેત્રોમાં ઝબૂકે છે (_b)"
 
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "સ્ક્રીન વાંચક"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "ઝડપ"
 
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "સ્ક્રીન વાંચક દર્શાવેલ લખાણને વાંચે છે જે તમે ફોકસને ખસેડો છો."
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "કર્સર ઝબૂકવાની ઝડપ"
 
-#: ../panels/universal-access/uap.ui.h:19
-#| msgid "Screen Reader"
-msgid "_Screen Reader"
-msgstr "સ્ક્રીન વાંચક (_S)"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "કર્સર ઝબૂકવાની ઝડપ"
 
-#: ../panels/universal-access/uap.ui.h:20
-#| msgid "Bounce Keys"
-msgid "Sound Keys"
-msgstr "સાઉન્ડ કી"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "જ્યારે Num Lock અથવા Caps Lock ચાલુ રાખેલ હોય તો બીપ વગાડો."
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "દેખીતી ચેતવણીઓ"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "ફ્લેશ ચકાસો (_T)"
-
-#: ../panels/universal-access/uap.ui.h:24
-#| msgid "Use a visual indication when an alert sound occurs"
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "દ્રશ્ય સંકેત વાપરો જ્યારે ચેતવણી અવાજ કરે."
-
-#: ../panels/universal-access/uap.ui.h:25
-#| msgid "Flash the window title"
-msgid "Flash the _window title"
-msgstr "વિન્ડો શીર્ષકપટ્ટી ઝબકાવો (_w)"
-
-#: ../panels/universal-access/uap.ui.h:26
-#| msgid "Flash the entire screen"
-msgid "Flash the entire _screen"
-msgstr "આખી સ્ક્રીન ઝબકાવો (_s)"
-
-#: ../panels/universal-access/uap.ui.h:27
-#| msgid "Typing Assistant"
-msgid "Typing Assist"
-msgstr "ટાઇપીંગ સહાયક"
-
-#: ../panels/universal-access/uap.ui.h:28
-#| msgid "Sticky Keys"
-msgid "_Sticky Keys"
-msgstr "સ્ટીકી કીઓ (_S)"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "કિ સંયોજનો તરીકે બદલનાર કીઓની કતાર સાથે વર્તે છે"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "જો બે કી એકસાથે દબાવાય તો નિષ્ક્રિય કરો (_D)"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifer key is pressed"
-msgstr "જ્યારે બદલનાર દબાયેલ હોય ત્યારે બીપ વગાડો (_m)"
-
-#: ../panels/universal-access/uap.ui.h:32
-#| msgid "Slow Keys"
-msgid "S_low Keys"
-msgstr "ધીમી કીઓ (_l)"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "જ્યારે કી દબાયેલ હોય અને જ્યારે તેને સ્વીકારેલ હોય તો તેની વચ્ચે વિલંબ મૂકો"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "સ્વીકૃતિ વિલંબ (_c):"
-
-#: ../panels/universal-access/uap.ui.h:35
-#| msgid "Short"
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "ટૂંકુ"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "સ્લો કી વિલંબને સૂચવે છે"
-
-#: ../panels/universal-access/uap.ui.h:37
-#| msgid "Long"
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "લાંબુ"
-
-#: ../panels/universal-access/uap.ui.h:38
-#| msgid "Beep when a _modifer key is pressed"
-msgid "Beep when a key is pr_essed"
-msgstr "જ્યારે કી દબાયેલ હોય ત્યારે બીપ વગાડો (_e)"
-
-#: ../panels/universal-access/uap.ui.h:39
-#| msgid "Beep when a key is _rejected"
-msgid "Beep when a key is _accepted"
-msgstr "જ્યારે કી સ્વીકારેલ હોય ત્યારે બીપ વગાડો (_a)"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "જ્યારે કી નકારી દેવામાં આવે તો બીપ વગાડો (_r)"
-
-#: ../panels/universal-access/uap.ui.h:41
-#| msgid "Bounce Keys"
-msgid "_Bounce Keys"
-msgstr "બાઉન્સ કી (_B)"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "આમાં ઝડપી નકલી કી દબાણ અવગણો"
-
-#: ../panels/universal-access/uap.ui.h:43
-#| msgid "Short"
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "ટૂંકુ"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "બાઉન્સ કી વિલંબને સૂચવે છે"
-
-#: ../panels/universal-access/uap.ui.h:45
-#| msgid "Long"
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "લાંબુ"
-
-#: ../panels/universal-access/uap.ui.h:46
-#| msgid "Enable by Keyboard"
-msgid "_Enable by Keyboard"
-msgstr "કિબોર્ડ દ્દારા સક્રિય કરો (_E)"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "કીબોર્ડમાંથી સુલભતા લક્ષણોને ચાલુ અને બંધ કરો"
-
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "મદદ માટે ક્લિક કરો"
 
-#: ../panels/universal-access/uap.ui.h:49
-#| msgid "Simulated Secondary Click"
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "પ્રદર્શનીય દ્દિતીય ક્લિક (_S)"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "પ્રાથમિક બટન દબાવવા દ્દારા દ્દિતીય ક્લિક સક્રિય કરો"
 
-#: ../panels/universal-access/uap.ui.h:51
-#| msgid "Short"
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "સ્વીકૃતિ વિલંબ (_c):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "ટુંકુ"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "ગૌણ કી વિલંબ"
 
-#: ../panels/universal-access/uap.ui.h:53
-#| msgid "Long"
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "લાંબુ"
 
-#: ../panels/universal-access/uap.ui.h:54
-#| msgid "Hover Click"
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "Hover ક્લિક (_H)"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "જ્યારે પોઇંટરની હિલચાલ બંધ કરવા દરમિયાન ક્લિકની શરૂઆત કરો"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "વિલંબ (_e):"
 
-#: ../panels/universal-access/uap.ui.h:57
-#| msgid "Short"
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "ટુંકુ"
 
-#: ../panels/universal-access/uap.ui.h:58
-#| msgid "Long"
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "લાંબુ"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "હિલચાલ થ્રેશોલ્ડ (_t):"
 
-#: ../panels/universal-access/uap.ui.h:60
-#| msgid "Small"
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "નાનું"
 
-#: ../panels/universal-access/uap.ui.h:61
-#| msgid "Large"
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "વિશાળ"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "પુનરાવર્તિત કીઓ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "જ્યારે કી દબાવી રાખી હોય ત્યારે પુનરાવર્તિત કી દબાણ. (_r)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "પુનરાવર્તન કીઓની ઝડપ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "પુનરાવર્તન કીઓની ઝડપ"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "ટાઇપીંગ સહાયક"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "સ્ટીકી કીઓ (_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "કિ સંયોજનો તરીકે બદલનાર કીઓની કતાર સાથે વર્તે છે"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "જો બે કી એકસાથે દબાવાય તો નિષ્ક્રિય કરો (_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "જ્યારે બદલનાર દબાયેલ હોય ત્યારે બીપ વગાડો (_m)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "ધીમી કીઓ (_l)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "જ્યારે કી દબાયેલ હોય અને જ્યારે તેને સ્વીકારેલ હોય તો તેની વચ્ચે વિલંબ મૂકો"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
-msgstr "ટુંકુ"
+msgstr "ટૂંકુ"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ સ્ક્રીન"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "સ્લો કી વિલંબને સૂચવે છે"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ સ્ક્રીન"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ સ્ક્રીન"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "લાંબુ"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "જ્યારે કી દબાયેલ હોય ત્યારે બીપ વગાડો (_e)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "જ્યારે કી સ્વીકારેલ હોય ત્યારે બીપ વગાડો (_a)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "જ્યારે કી નકારી દેવામાં આવે તો બીપ વગાડો (_r)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "બાઉન્સ કી (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "આમાં ઝડપી નકલી કી દબાણ અવગણો"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "ટૂંકુ"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "બાઉન્સ કી વિલંબને સૂચવે છે"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "લાંબુ"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "કિબોર્ડ દ્દારા સક્રિય કરો (_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "કીબોર્ડમાંથી સુલભતા લક્ષણોને ચાલુ અને બંધ કરો"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "સાર્વત્રિક વપરાશ મેનુને હંમેશા બતાવો (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "જોઇ રહ્યા છે"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "ઉચ્ચ વિરોધાભાસ (_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "લાંબુ લખાણ (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "સ્ક્રીન વાંચક (_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "સ્ક્રીન વાંચક દર્શાવેલ લખાણને વાંચે છે જે તમે ફોકસને ખસેડો છો."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "સાઉન્ડ કી (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "જ્યારે Num Lock અથવા Caps Lock ચાલુ રાખેલ હોય તો બીપ વગાડો."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "કર્સર ઝબૂકવાની ઝડપ"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "નાનું મોટું (_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "સાંભળવુ"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "દેખીતી ચેતવણીઓ (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "સ્ક્રીન કિબોર્ડ (_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "પુનરાવર્તિત કીઓ"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "કર્સર ઝબૂકે છે"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "ટાઇપીંગ સહાયક (AccessX) (_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "નિર્દેશિત અને ક્લિક કરી રહ્યા છે"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "માઉસ કી (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "પ્રિન્ટર દૂર કરો"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "મદદ માટે ક્લિક કરો (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "બે ક્લિક (_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "બે ક્લિકની સમયસમાપ્તિ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "દેખીતી ચેતવણીઓ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "ફ્લેશ ચકાસો (_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "દ્રશ્ય સંકેત વાપરો જ્યારે ચેતવણી અવાજ કરે."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "આખી સ્ક્રીન ઝબકાવો (_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "આખી સ્ક્રીન ઝબકાવો (_s)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "સંપૂર્ણ સ્ક્રીન"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "ઊંચે અદધો ભાગ"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "નીચે અદધો ભાગ"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "ડાબો અદધો ભાગ"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "જમણો અડધો ભાગ"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "નાનુ મોટુ કરવાનાં વિકલ્પો"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "નાનુ મોટુ કરો"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "વિસ્તૃતીકરણ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "માઉસ કર્સર અનૂસરો"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "સ્ક્રીન ભાગ:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "બૃહદદર્શક સ્ક્રીન બહાર વિસ્તરેલ"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "બૃહદદર્શક કર્સર ને કેન્દ્રમાં રાખો"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "બૃહદદર્શક કર્સર સમાવિષ્ટને આજુબાજુથી દબાવે છે"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "બૃહદદર્શક કર્સર સમાવિષ્ટ સાથે ખસે છે"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "બૃહદદર્શક સ્થિતિ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "માઉસ કર્સર અનૂસરો"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "સ્ક્રીન ભાગ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "બૃહદદર્શક સ્ક્રીન બહાર વિસ્તરેલ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "બૃહદદર્શક કર્સર ને કેન્દ્રમાં રાખો"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "બૃહદદર્શક કર્સર સમાવિષ્ટને આજુબાજુથી દબાવે છે"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "બૃહદદર્શક કર્સર સમાવિષ્ટ સાથે ખસે છે"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "બૃહદદર્શક"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "ક્રોસહેર:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "માઉસ કર્સર ઓવરલેપ થાય ચે"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "જાડાઈ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
-#| msgid "Thin"
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "પાતળુ"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
-#| msgid "Thick"
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "ઘટ્ટ"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "લંબાઇ:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "રંગ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "ક્રોસહેર:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "માઉસ કર્સર ઓવરલેપ થાય ચે"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "ક્રોસહેર"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "રંગ અસરો:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "કાળા પર સફેદ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "તેજસ્વીતા:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "વિરોધાભાસ:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
-#| msgid "Color"
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "રંગ"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
-#| msgid "None"
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "કંઈ જ નહિં"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
-#| msgctxt "Zoom Grayscale"
-#| msgid "Full"
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "પૂર્ણ"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
-#| msgid "Low"
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "ઓછુ"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
-#| msgid "High"
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "ઉચ્ચ"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "ઓછુ"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "વધારે"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "રંગ અસરો:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "રંગ અસરો"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "પ્રમાણભૂત"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "તેને જોવા, સાંભળવા, ટાઇપ, નિર્દેશિત અને ક્લિક કરવાનું સરળ બનાવો"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"કિબોર્ડ;માઉસ;a11y;સુલભતા;ભેદ;નાનું મોટુ કરો;સ્ક્રીન વાંચક;લખાણ;ફોન્ટ;માપ;AccessX;સ્ટીકી;"
+"કી;ધીમી;બાઉન્સ;માઉસ;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ઇતિહાસ"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "ઇતિહાસ"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "તાજેતરનો ઇતિહાસ સાફ કરો (_e)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "કચરાપેટી અને કામચલાઉ ફાઇલોને સાફ કરો"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "આપમેળે કચરાપેટી ખાલી (_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "આપમેળે કામચલાઉ ફાઇલોને સાફ કરો (_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "આપમેળે કચરાપેટી ખાલી (_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "કચરાપેટી ખાલી કરો (_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "કામચલાઉ ફાઇલોને સાફ કરો (_P)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "વપરાશકર્તાને ઉમેરો"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
 msgid "Administrator"
 msgstr "વહીવટકર્તા"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-#| msgid "_Full name"
-msgid "_Full Name"
-msgstr "સંપૂર્ણ નામ (_F)"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "ખાતા પ્રકાર (_T)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-#| msgid "Choose password at next login"
-msgid "Allow user to set a password when they next login"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
 msgstr "પાસવર્ડને સુયોજિત કરવા વપરાશકર્તાને પરવાનગી આપો જ્યારે તેઓ આગળ પ્રવેશે"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
 msgstr "હવે પાસવર્ડને સુયોજિત કરો"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "ખાતરી કરો (_V)"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "રૂપરેખાંકિત કરી રહ્યા છે"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "એન્ટરપ્રાઇઝ પ્રવેશ (_E)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "ઓફલાઇન"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
 "એન્ટરપ્રાઇઝ પ્રવેશ આ ઉપકરણ પર વાપરવા માટે હાલની કેન્દ્રિય સંચાલિત થયેલ વપરાશકર્તા ખાતાને "
 "પરવાનગી આપે છે."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "ડોમેઇન (_D)"
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PPD ફાઇલ પસંદ કરો"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "આંગળીછાપન પ્રવેશ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "આંગળીછાપન પ્રવેશ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "ના"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
 msgstr ""
-"એન્ટરપ્રાઇઝ પ્રવેશ ખાતાને ઉમેરવા માટે\n"
-"ઓનલાઇન થાવ."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "એન્ટરપ્રાઇઝ પ્રવેશ (_E)"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"શું તમે તમારી રજીસ્ટર થયેલ આંગળીની છાપો ને કાઢી નાંખવા માંગો છો તેથી આંગળીની છાપ પ્રવેશ ને "
+"નિષ્ક્રિય થયેલ હોય?"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
-msgid "Add User"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "પ્રિન્ટર શોધાયેલ નથી."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "આંગળીછાપન પ્રવેશ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "આંગળીછાપન પ્રવેશ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "રૂપરેખાંકિત કરવા માટે ઉપકરણને પસંદ કરો (_h):"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "આંગળીછાપન પ્રવેશ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "આંગળીની છાપો ને કાઢી નાંખો (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "આંગળીછાપન પ્રવેશ (_F)"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "પહેલાંનુ ટ્રેક"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "પાસવર્ડ બદલો"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "બદલો (_a)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "વર્તમાન પાસવર્ડ (_p)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "નવો પાસવર્ડ (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "પાસવર્ડની ખાતરી કરો (_o)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "પાસવર્ડો બંધબેસતા નથી."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "પાસવર્ડને સુયોજિત કરવા વપરાશકર્તાને પરવાનગી આપો જ્યારે તેઓ આગળ પ્રવેશે"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "હવે પાસવર્ડને સુયોજિત કરો"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "વપરાશકર્તાઓ"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "તમારાં બદલાવોની અસર લાવવા માટે તમારા સત્રને પુન:શરૂ કરવુ જરૂરી છે"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "હવે પુન:શરૂ કરો"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "બંધ કરો"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "સંપૂર્ણ નામ (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "આંગળીછાપન પ્રવેશ (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "સ્વયં પ્રવેશ (_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "ખાતા પ્રકાર (_t)"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "વહીવટકર્તા"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "વોલપેપર દૂર કરો"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "બીજી આંગળી (_O): "
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
 msgstr "વપરાશકર્તાને ઉમેરો"
 
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "ચિત્ર મળ્યા નથી"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "વપરાશકર્તા ખાતાને બનાવો"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "વપરાશકર્તાઓને ઉમેરો અથવા દૂર કરો અને તમારા પાસવર્ડને બદલો"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "નોંધણી કરો (_E)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "ડોમેઇન સંચાલક પ્રવેશ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6382,1179 +4856,3537 @@ msgstr ""
 "એન્ટરપ્રાઇઝ પ્રવેશને વાપરવા માટે ક્રમમાં, આ કમ્યૂટરને ડોમેઇનમાં ઉમેદવારી કરવાની જરૂર છે. "
 "મહેરબાની કરીને તમારુ નેટવર્ક સંચાલકને લઇને તેનાં ડોમેઇન પાસવર્ડને અહિં ટાઇપ કરો."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "સંચાલક નામ (_N)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "સંચાલક પાસવર્ડ"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "થમ્ભને છોડો"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "ડાબી મધ્ય આંગળી"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "ડાબી વીંટી આંગળી"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "ડાબી નાની આંગળી"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "જમણું થમ્ભ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "જમણી મધ્ય આંગળી"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "જમણી વીંટી આંગળી"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "જમણી નાની આંગળી"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:697
-msgid "Enable Fingerprint Login"
-msgstr "આંગળીછાપ પ્રવેશ ને સક્રિય કરો"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "જમણી અનુક્રમાંક આંગળી (_R)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "ડાબી અનુક્રમાંક આંગળી (_L)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "બીજી આંગળી (_O): "
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"તમારી આંગળી છાપ એ સફળતાપૂર્વક સંગ્રહ થયેલ છે. તમારે હવે તમારા આંગળી છાપ વાંચનાર ની "
-"મદદથી પ્રવેશવા માટે સક્ષમ થવુ જ જોઇએ."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-#| msgid "Username"
-msgid "Users"
-msgstr "વપરાશકર્તાઓ"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-#| msgid "Add or remove users"
-msgid "Add or remove users and change your password"
-msgstr "વપરાશકર્તાઓને ઉમેરો અથવા દૂર કરો અને તમારા પાસવર્ડને બદલો"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "પ્રવેશ;નામ;આંગળીછાપન;અવતાર;લૉગો;ચહેરો;પાસવર્ડ;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-#| msgid "Login Options"
-msgid "Login History"
-msgstr "પ્રવેશ ઇતિહાસ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-#| msgid "Changing password for"
-msgid "Change Password"
-msgstr "પાસવર્ડ બદલો"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "બદલો (_a)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-#| msgid "_New password"
-msgid "_Verify New Password"
-msgstr "નવાં પાસવર્ડની ખાતરી કરો (_V)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-#| msgid "_New password"
-msgid "_New Password"
-msgstr "નવો પાસવર્ડ (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-#| msgid "Current _password"
-msgid "Current _Password"
-msgstr "વર્તમાન પાસવર્ડ (_p)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "વપરાશકર્તા ખાતુ ઉમેરો"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "વપરાશકર્તા ખાતુ દૂર કરો"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "પ્રવેશ વિકલ્પો"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "સ્વયં પ્રવેશ (_u)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "આંગળીછાપન પ્રવેશ (_F)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "વપરાશકર્તા ચિહ્ન"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "ભાષા (_L)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-#| msgid "A_utomatic Login"
-msgid "Last Login"
-msgstr "છેલ્લો પ્રવેશ"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "વપરાશકર્તા ખાતાઓ સંચાલિત કરો"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "વપરાશકર્તા માહિતીને બદલવા માટે સત્તાધિકરણ જરૂરી છે"
 
-#: ../panels/user-accounts/pw-utils.c:81
-#| msgid "The new password does not contain enough different characters"
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "નવો પાસવર્ડ જૂનાંથી અલગ હોવો જરૂરી છે."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "અમુક અક્ષરો અને આંકડાને બદલવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-#| msgid "Changing password for"
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "પાસવર્ડને થોડો વધારે બદલવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "તમારાં વપરાશકર્તા નામ વગર પાસવર્ડ મજબૂત હશે."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "પાસવર્ડમાં તમારા નામને અવગણવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "પાસવર્ડમાં સમાવેલ શબ્દોનાં અમુકને અવગણવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "સામાન્ય શબ્દોને અવગણવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "હાલનાં શબ્દોને પુન:ક્રમાંક અવગણવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "વધારે નંબરોને વાપરવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "વધારે મોટા અક્ષરો વાપરવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "વધારે નાનાં અક્ષરો વાપરવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "ખાસ અક્ષરો, જેમ કે વિરામચિહ્ન વધારે વાપરવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "અક્ષરો, નંબરો અને વિરામચિહ્નોનું મિશ્રણને વાપરવા માટે પ્રયતન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "વારંવાર આવતા એજ અક્ષરને અવગણવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"વારંવાર વપરાતા એજ પ્રકારનાં અક્ષરને અવગણવાનો પ્રયત્ન કરો: તમે અક્ષરો, નંબરો અને "
-"વિરામચિહ્નનોનાં મિશ્રણની જરૂર છે."
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "શ્રેણી જેમ કે 1234 અથવા abcd ને અવગણવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "વધારે અક્ષરો, આંકડા અને સંકેતોને ઉમેરવાનો પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr "મોટા અક્ષર અને નાનાં અક્ષરને મિશ્રિત કરો અને આંકડા અથવા બેને વાપરો."
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr "સરસ પાસવર્ડ! વધારે અક્ષરો, આંકડા અને વિરામચિહ્ન એ તેને મજબૂત બનાવશે."
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-#| msgid "Strength"
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "મજબૂતાઇ: નબળી"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-#| msgid "Strength"
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "મજબૂતાઇ: ઓછી"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-#| msgid "Strength"
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "મજબૂતાઇ: મધ્યમ"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-#| msgid "Strength"
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "મજબૂતાઇ: સરસ"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-#| msgid "Strength"
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "મજબૂતાઇ: વધારે"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "સત્તાધિકરણ નિષ્ફળ"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "નવો પાસવર્ડ ઘણો ટૂંકો છે"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "નવો પાસવર્ડ ઘણો સરળ છે"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "જૂના અને નવા પાસવર્ડો એકદમ સરખા છે"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "નવો પાસવર્ડ પહેલેથી જ તાજેતરમાં વાપરી દેવાયો છે."
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "નવો પાસવર્ડ આંકડા અને વિશિષ્ટ અક્ષરો સમાવતો હોવો જ જોઈએ."
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "જૂના અને નવા પાસવર્ડો સરખા છે"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "તમારો પાસવર્ડ બદલાઈ ગયેલ છે કારણ કે તમે શરૂઆતમાં સત્તાધિકારીત થઈ ગયેલ છે!"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "નવો પાસવર્ડ પૂરતા વિવિધ અક્ષરોને સમાવતુ નથી"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "અજ્ઞાત ભૂલ"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "તમારાં ખાતા પ્રદાતાનાં વેબ સરનામાં સાથે બંધબેસતુ હોવુ જોઇએ."
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "ખાતાને ઉમેરવામાં નિષ્ફળ"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-#| msgid "Passwords do not match"
-msgid "Passwords do not match."
-msgstr "પાસવર્ડ બંધબેસતો નથી."
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr "ખાતાને રજીસ્ટર કરવામાં નિષ્ફળ"
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr "આ ડોમેઇન સાથે આ રીતે સત્તાધિકરણ કરવાનું આધારભૂત નથી"
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr "ડોમેઇન સાથે જોડાવામાં નિષ્ફળ"
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"તે પ્રવેશ નામ કામ કરતુ ન હતુ.\n"
-"મહેરબાની કરીને ફરી પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-#| msgid "Invalid password, please try again"
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"તે પ્રવેશ પાસવર્ડ કામ કરતુ ન હતુ.\n"
-"મહેરબાની કરીને ફરી પ્રયત્ન કરો."
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr "ડોમેઇનમાં પ્રવેશ કરવામાં નિષ્ફળતા"
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "ડોમેઇનને શોધવાનું અસમર્થ. કદાચ તમે તેની જોડણી ખોટી કરી છે?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:137
-msgid "You are not allowed to access the device. Contact your system administrator."
-msgstr "તમને ઉપકરણ ને દાખલ કરવા માટે પરવાનગી આપેલ નથી. તમારા સિસ્ટમ વહીવટકર્તાને સંપર્ક કરો."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
-msgid "The device is already in use."
-msgstr "ઉપકરણ એ પહેલેથી વપરાશમાં છે."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "An internal error occurred."
-msgstr "આંતરિક ભૂલ ઉદ્દભવી હતી."
-
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
-# gtk/gtkinputdialog.c:238
-#: ../panels/user-accounts/um-fingerprint-dialog.c:217
-#: ../panels/user-accounts/um-fingerprint-dialog.c:218
-msgid "Enabled"
-msgstr "સક્રિય"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:266
-msgid "Delete registered fingerprints?"
-msgstr "રજીસ્ટર થયેલ આંગળીની છાપો ને કાઢી નાંખો?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:270
-msgid "_Delete Fingerprints"
-msgstr "આંગળીની છાપો ને કાઢી નાંખો (_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:276
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"શું તમે તમારી રજીસ્ટર થયેલ આંગળીની છાપો ને કાઢી નાંખવા માંગો છો તેથી આંગળીની છાપ પ્રવેશ ને "
-"નિષ્ક્રિય થયેલ હોય?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:452
-msgid "Done!"
-msgstr "પૂરુ થઇ ગયુ!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:513
-#: ../panels/user-accounts/um-fingerprint-dialog.c:555
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' ઉપકરણ ને દાખલ કરી શકાયો નહિં"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:596
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "'%s' ઉપકરણ પર આંગળીને પકડવાનું શરૂ કરી શકાયુ નહિં"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:647
-msgid "Could not access any fingerprint readers"
-msgstr "કોઇપણ આંગળીછાપ વાંચનાર ને દાખલ કરી શકાયુ નહિં"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:648
-msgid "Please contact your system administrator for help."
-msgstr "મહેરબાની કરીને મદદ માટે તમારા સિસ્ટમ વહીવટકર્તા ને સંપર્ક કરો."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:731
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"આંગળી છાપ દાખલ કરવાનું સક્રિય કરવા માટે, તમારે તમારા આંગળી છાપોનાં એક ને સંગ્રહ કરવાની "
-"જરૂર પડશે, '%s' ઉપકરણની મદદથી."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:738
-msgid "Selecting finger"
-msgstr "આંગળી પસંદ કરી રહ્યા છે"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:739
-msgid "Enrolling fingerprints"
-msgstr "આંગળી છાપનની નોંધણી"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "આ અઠવાડિયે"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-#| msgid "Last used"
-msgid "Last Week"
-msgstr "છેલ્લા અઠવાડિયે"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:631
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:635
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "સત્રનો અંત આવ્યો"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "સત્ર શરૂ થઇ ગયું"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "મહેરબાની કરીને બીજા પાસવર્ડને પસંદ કરો."
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "મહેરબાની કરીને ફરીથી તમારા હાલના પાસવર્ડને લખો."
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "પાસવર્ડને બદલી શક્યા નહિં"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-#| msgid "The passwords do not match"
-msgid "The passwords do not match."
-msgstr "પાસવર્ડો બંધબેસતા નથી."
-
-#: ../panels/user-accounts/um-photo-dialog.c:219
-msgid "Browse for more pictures"
-msgstr "વધારે ચિત્રો માટે બ્રાઉઝ કરો"
-
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
-# gtk/gtkinputdialog.c:238
-#: ../panels/user-accounts/um-photo-dialog.c:453
-msgid "Disable image"
-msgstr "ઇમેજને નિષ્ક્રિય કરો"
-
-#: ../panels/user-accounts/um-photo-dialog.c:471
-#| msgid "Take a photo..."
-msgid "Take a photo…"
-msgstr "ફોટો લો..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:489
-#| msgid "Browse for more pictures"
-msgid "Browse for more pictures…"
-msgstr "વધારે ચિત્રો માટે બ્રાઉઝ કરો..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:713
-#, c-format
-msgid "Used by %s"
-msgstr "%s દ્દારા વપરાયેલ છે"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-#| msgid "Cannot remove automatically added profile"
-msgid "Cannot automatically join this type of domain"
-msgstr "આપમેળે ઉમેરાયેલ રૂપરેખાને દૂર કરી શકાતુ નથી"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "આવુ કોઈ ડોમેઈન અથવા ક્ષેત્ર મળ્યુ નથી"
-
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s ડોમેઇન પર %s તરીકે પ્રવેશી શકાતુ નથી"
-
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
-msgstr "અયોગ્ય પાસવર્ડ, મહેરબાની કરીને ફરી પ્રયત્ન કરો"
-
-#: ../panels/user-accounts/um-realm-manager.c:832
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "%s ડોમેઇનમાં જોડાઇ શકાયુ નહિં: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:198
-msgid "Other Accounts"
-msgstr "બીજા ખાતાઓ"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "Failed to delete user"
-msgstr "વપરાશકર્તાને કાઢી નાખતી વખતે નિષ્ફળતા"
-
-#: ../panels/user-accounts/um-user-panel.c:482
-msgid "You cannot delete your own account."
-msgstr "તમે તમારા પોતાના ખાતાને કાઢી શકતા નથી."
-
-#: ../panels/user-accounts/um-user-panel.c:491
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s હજુ પ્રવેશેલ છે"
-
-#: ../panels/user-accounts/um-user-panel.c:495
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"વપરાશકર્તાને કાઢી રહ્યા છે જ્યારે તેઓ પ્રવેશેલ છે કે જે અસ્થાયી સ્થિતિમાં સિસ્ટમને છોડી શકે છે."
-
-#: ../panels/user-accounts/um-user-panel.c:504
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "શું તમે %s ની ફાઇલોને રાખવા માંગો છો?"
-
-#: ../panels/user-accounts/um-user-panel.c:508
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"તેની આજુબાજુ ઘર ડિરેક્ટરી, મેઇલ સ્પુલ અને કામચલાઉ ફાઇલોને રાખવાનું શક્ય છે જ્યારે વપરાશકર્તા "
-"ખાતાને કાઢી રહ્યા હોય."
-
-#: ../panels/user-accounts/um-user-panel.c:511
-msgid "_Delete Files"
-msgstr "ફાઇલોને કાઢી નાંખો (_D)"
-
-#: ../panels/user-accounts/um-user-panel.c:512
-msgid "_Keep Files"
-msgstr "ફાઇલોને રાખો (_K)"
-
-#: ../panels/user-accounts/um-user-panel.c:564
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "નિષ્ક્રિય થયેલ ખાતુ"
-
-#: ../panels/user-accounts/um-user-panel.c:572
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "આગળનાં પ્રવેશે સુયોજિત કરવા માટે"
-
-#: ../panels/user-accounts/um-user-panel.c:575
-msgctxt "Password mode"
-msgid "None"
-msgstr "કઈ નહિં"
-
-#: ../panels/user-accounts/um-user-panel.c:624
-msgid "Logged in"
-msgstr "પ્રવેશેલ છે"
-
-#: ../panels/user-accounts/um-user-panel.c:1072
-msgid "Failed to contact the accounts service"
-msgstr "ખાતા સેવાને સંપર્ક કરવામાં નિષ્ફળ"
-
-#: ../panels/user-accounts/um-user-panel.c:1074
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "મહેરબાની કરીને ખાતરી કરો કે AccountService એ સ્થાપિત અને સક્રિય થયેલ છે."
-
-#: ../panels/user-accounts/um-user-panel.c:1115
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"ફેરફારો કરવા માટે,\n"
-"પહેલાં * ચિહ્ન પર ક્લિક કરો"
-
-#: ../panels/user-accounts/um-user-panel.c:1153
-msgid "Create a user account"
-msgstr "વપરાશકર્તા ખાતાને બનાવો"
-
-#: ../panels/user-accounts/um-user-panel.c:1164
-#: ../panels/user-accounts/um-user-panel.c:1453
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"વપરાશકર્તા ખાતાને બનાવવા માટે,\n"
-"પહેલાં * ચિહ્ન પર ક્લિક કરો"
-
-#: ../panels/user-accounts/um-user-panel.c:1174
-msgid "Delete the selected user account"
-msgstr "પસંદ થયેલ વપરાશકર્તા ખાતાને કાઢી નાંખો"
-
-#: ../panels/user-accounts/um-user-panel.c:1186
-#: ../panels/user-accounts/um-user-panel.c:1458
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"પસંદ થયેલ વપરાશકર્તા ખાતાને કાઢી નાંખવા માટે,\n"
-"પહેલાં * ચિહ્ન પર ક્લિક કરો"
-
-#: ../panels/user-accounts/um-user-panel.c:1368
-msgid "My Account"
-msgstr "મારુ ખાતુ"
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-#| msgid "A user with the username '%s' already exists"
-msgid "A user with the username '%s' already exists."
-msgstr "વપરાશકર્તાનામ '%s' સાથે વપરાશકર્તા પહેલેથી જ અસ્તિત્વ ધરાવે છે."
-
-#: ../panels/user-accounts/um-utils.c:571
-#, c-format
-#| msgid "The username is too long"
-msgid "The username is too long."
-msgstr "વપરાશકર્તાનામ ઘણુ લાંબુ છે."
-
-#: ../panels/user-accounts/um-utils.c:574
-#| msgid "The username cannot start with a '-'"
-msgid "The username cannot start with a '-'."
-msgstr "વપરાશકર્તાનામ '-' સાથે શરૂ કરી શકાતુ નથી."
-
-#: ../panels/user-accounts/um-utils.c:577
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"વપરાશકર્તા ફક્ત a-z, આંકડા અને કોઇપણ અક્ષરો '.', '-' અને '_' માંથી નાનાં અને મોટા અક્ષરોને "
-"સમાવવા જોઇએ."
-
-#: ../panels/user-accounts/um-utils.c:581
-msgid "This will be used to name your home folder and can't be changed."
-msgstr "આ તમારા ઘર ફોલ્ડરનાં નામ માટે વપરાશે અને બદલી શકાતુ નથી."
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:831
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "માપન બટનો"
 
-#: ../panels/wacom/button-mapping.ui.h:2
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "વિધેયોનાં માપન બટનો"
 
-#: ../panels/wacom/button-mapping.ui.h:3
-#| msgid ""
-#| "To edit a shortcut, click the row and hold down the new keys or press "
-#| "Backspace to clear."
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"ટુકાણ કીમાં ફેરફાર કરવા માટે, \"કિસ્ટ્રોકને મોકલો\" ક્રિયાને પસંદ કરો, કિબોર્ડ ટૂંકાણ બટનને "
-"દબાવો અને નવી કીને પકડી રાખો અથવા સાફ કરવા માટે Backspace ને દબાવો."
+"ટુકાણ કીમાં ફેરફાર કરવા માટે, \"કિસ્ટ્રોકને મોકલો\" ક્રિયાને પસંદ કરો, કિબોર્ડ ટૂંકાણ "
+"બટનને દબાવો અને નવી કીને પકડી રાખો અથવા સાફ કરવા માટે Backspace ને દબાવો."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "બંધ કરો (_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr "લક્ષ્ય માર્કરને મહેરબાની કરીને ટૅપ કરો તેઓ ટૅબલેટને ગોઠવવા માટે સ્ક્રીન પર દેખાશે."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "ખોટી ક્લિક શોધાઇ, પુન:શરૂ કરી રહ્યા છે..."
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-#| msgid "Up"
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "ઉપર"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "વર્ચ્યુઅલ ઉપકરણને બનાવો"
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-#| msgid "Down"
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "નીચે"
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "ટૅબલેટ"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "કંઈ નહિં"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "કીસ્ટ્રોકને મોકલો"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "ડાબી બાજુની દિશા"
 
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "મોનિટર બદલો"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "ઑન-સ્ક્રીન મદદ બતાવો"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "મોનિટરનું માપન…"
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "આઉટપુટ:"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "આશરે દર"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "સાપેક્ષ ગુણોત્તર રાખો (લેટરબોક્સ):"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "એકજ મોનિટરનું માપ લો"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "માપદંડ કરો…"
 
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d નું %d"
-
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "માપન દર્શાવો"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
-msgstr "બટન"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr "Wacom ટૅબલેટ"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr "બટન મેપીંગને સુયોજિત કરો અને ગ્રાફિક્સ ટૅબલેટ માટે સ્ટાયલસ સંવેદનશીલતાને ગોઠવો"
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "ટૅબલેટ;Wacom;સ્ટાયલસ;ઇરૅજર;માઉસ;"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "ટૅબલેટ (સંપૂર્ણ)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "ટચપેડ (સંબંધિત)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "ટૅબલેટ પસંદગીઓ"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "ટૅબલેટ શોધાયુ નથી"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "મહેરબાની કરીને પ્લગ કરો અથવા તમારાં Wacom ટૅબલેટને ચાલુ રાખો"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr "Bluetooth સુયોજનો"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-#| msgid "Map to Monitor..."
-msgid "Map to Monitor…"
-msgstr "મોનિટરનું માપન…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-#| msgid "Map Buttons"
-msgid "Map Buttons…"
-msgstr "માપન બટનો…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr "દર્શાવ રિઝોલ્યુશનને ગોઠવો"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-#| msgid "Mouse Settings"
-msgid "Adjust mouse settings"
-msgstr "માઉસ સુયોજનોને ગોઠવો"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Tracking Mode"
-msgstr "ટ્રેકિંગ સ્થિતિ"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Left-Handed Orientation"
-msgstr "ડાબી બાજુની દિશા"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-#| msgid "Left Ring Mode #%d"
-msgid "Left Ring"
-msgstr "ડાબી રીંગ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "ડાબી રીંગ સ્થિતિ #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-#| msgid "Right Ring Mode #%d"
-msgid "Right Ring"
-msgstr "જમણી રીંગ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1104
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "જમણી રીંગ સ્થિતિ #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-#| msgid "Left Touchstrip Mode #%d"
-msgid "Left Touchstrip"
-msgstr "ડાબુ ટચસ્ટ્રીપ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1157
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "ડાબી ટચસ્ટ્રીપ સ્થિતિ #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-#| msgid "Right Touchstrip Mode #%d"
-msgid "Right Touchstrip"
-msgstr "જમણી ટચસ્ટ્રીપ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "જમણી ટચસ્ટ્રીપ સ્થિતિ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1214
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "ડાબુ ટચરીંગ મોડ સ્વીચ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1216
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "જમણી ટચરીંગ મોડ સ્વીચ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1219
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "ડાબી ટચસ્ટ્રીપ મોડ સ્વીચ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1221
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "જમણી ટચસ્ટ્રીપ મોડ સ્વીચ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1226
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "મોડ સ્વીચ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1334
-#, c-format
-msgid "Left Button #%d"
-msgstr "ડાબુ બટન #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1337
-#, c-format
-msgid "Right Button #%d"
-msgstr "જમણુ બટન #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1340
-#, c-format
-msgid "Top Button #%d"
-msgstr "ટોચનુ બટન #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1343
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "નીચેનું બટન #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-#| msgid "New shortcut..."
-msgid "New shortcut…"
-msgstr "નવાં ટૂંકાણ..."
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "ક્રિયા નથી"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "ડાબુ માઉસ બટન ક્લિક"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "મધ્ય માઉસ બટન ક્લિક"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "જમણુ માઉસ બટન ક્લિક"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "ઉપર સ્ક્રોલ કરો"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "નીચે સ્ક્રોલ કરો"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "ડાબે સ્ક્રોલ કરો"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "જમણે સ્ક્રોલ કરો"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "પાછા"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "આગળ ધપાવો"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "સ્ટાયલસ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "ઇરૅજર પ્રેસર ફીલ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "નરમ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "ફર્મ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "ટોચનુ બટન"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "નીચેનું બટન"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "ટીપ પ્રેસર ફીલ"
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "વર્બોસ સ્થિતિ સક્રિય કરો"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "નરમ"
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "ઝાંખી બતાવો"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "શબ્દમાળા માટે શોધો"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "શક્ય પેનલ નામોની યાદી કરો અને બહાર નીકળો"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "મદદ વિકલ્પો બતાવો"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "દર્શાવવા માટે પેનલ"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: ../shell/cc-application.c:145
-#| msgid "All Settings"
-msgid "- Settings"
-msgstr "- સુયોજનો"
-
-#: ../shell/cc-application.c:163
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-"%s\n"
-"ઉપલબ્ધ આદેશ વાક્ય વિકલ્પોની સંપૂર્ણ યાદીને જોવા માટે  '%s --help' ચલાવો.\n"
 
-#: ../shell/cc-application.c:193
-#| msgid "Available Profiles"
-msgid "Available panels:"
-msgstr "ઉપલબ્ધ પેનલો:"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "ફર્મ"
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "મદદ"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "બટન"
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "બહાર નીકળો"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "બટન"
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "બટન"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "ઇરૅજર પ્રેસર ફીલ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "ઇરૅજર પ્રેસર ફીલ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "મધ્ય માઉસ બટન ક્લિક"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "જમણુ માઉસ બટન ક્લિક"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "આગળ ધપાવો"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom ટૅબલેટ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "બટન મેપીંગને સુયોજિત કરો અને ગ્રાફિક્સ ટૅબલેટ માટે સ્ટાયલસ સંવેદનશીલતાને ગોઠવો"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "ટૅબલેટ;Wacom;સ્ટાયલસ;ઇરૅજર;માઉસ;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "દેખાવ"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "પ્રદર્શનીય દ્દિતીય ક્લિક (_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows સોફ્ટવેર"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "ટૉનર ઓછુ છે"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "ગૌણ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows સોફ્ટવેર"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "વિકલ્પો વાપરો"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "ઉમેરો"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "સંગ્રહો (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "વિગતો"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "નેટવર્ક સમય (_N)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "નેટવર્ક સુયોજનો"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "નંબરો"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "ઉપકરણ પ્રકારો"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "ઉત્પાદક"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "ફર્મવેર ગેરહાજર"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "તાળુ મારેલ"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "મોબાઇલ બ્રોડબેન્ડ (_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "નેટવર્ક સમય (_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "નેટવર્ક"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "ઉન્નત"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "વિકલ્પો વાપરો"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "તાળુ મારો"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "વિગતો"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "નેટવર્ક નામ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "સ્વયં"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "મારું ઘર નેટવર્ક"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "મારું ઘર નેટવર્ક"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "બ્લુટુથ ઍડપ્ટર મળ્યુ નથી"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "ઍરપ્લેન સ્થિતિ (_p)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "જોડાણ"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM કાર્ડ દાખલ થયેલ નથી"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "તાળુ મારો"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "બદલો (_a)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "મારું ઘર નેટવર્ક"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "નવાં ડ્રાઇવરને સુયોજિત કરી રહ્યા છે…"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "ખાનગી"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "બધા સુયોજનો"
 
-#. Add categories
-#: ../shell/cc-window.c:876
-msgctxt "category"
-msgid "Personal"
-msgstr "વ્યક્તિગત"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "પ્રાથમિક"
 
-#: ../shell/cc-window.c:877
-#| msgid "Hardware"
-msgctxt "category"
-msgid "Hardware"
-msgstr "હાર્ડવેર"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:878
-#| msgid "System"
-msgctxt "category"
-msgid "System"
-msgstr "સિસ્ટમ"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "મદદ"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "સામાન્ય"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "બહાર નીકળો"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "શોધો"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "પહેલાનાં સ્ત્રોતમાં બદલો"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "રદ થયેલ"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "પસંદગીઓ;સુયોજનો;"
 
-#~ msgid "Flickr"
-#~ msgstr "ફ્લિકર"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u આઉટપુટ"
+msgstr[1] "%u આઉટપુટો"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ઇનપુટ"
+msgstr[1] "%u ઇનપુટો"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "દિવસ દરમ્યામ બદલે છે"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "તકતી"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "નાનુ મોટુ કરો"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "કેન્દ્ર"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "ભરો"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "સ્પાન"
+
+#~ msgid "Select Background"
+#~ msgstr "પાશ્વભાગ પસંદ કરો"
+
+#~ msgid "Pictures"
+#~ msgstr "ચિત્રો"
+
+#~ msgid "Colors"
+#~ msgstr "રંગો"
+
+#~ msgid "Home"
+#~ msgstr "ઘર"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "તમે તમારાં %s ફોલ્ડરમાં ઇમેજોને ઉમેરી શકો છો અને તેઓ અહિંયા બતાવશે"
+
+#~ msgid "multiple sizes"
+#~ msgstr "ઘણાબધા માપો"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "ડેસ્કટોપ પાશ્વ ભાગ નથી"
+
+#~ msgid "Current background"
+#~ msgstr "હાલનાં પાશ્ર્વભાગો"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "વોલપેપર;સ્ક્રીન;ડેસ્કટોપ;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "ચોરસ પર તમારું માપદંડ ઉપકરણને સ્થિત કરો અને 'શરૂ કરો' બટન દબાવો"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "સ્થાનને માપન કરવા માટે તમારું માપદંડ ઉપકરણને ખસાડો અને 'ચાલુ રાખો' બટન દબાવો"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "સપાટ સ્થાન માટે તમારાં માપદંડ ઉપકરણને ખસેજો અને 'ચાલુ રાખો' બટનને દબાવો"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "લૅપટોપ lid ને બંધ કરો"
+
+#~| msgid "An internal error occurred."
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "આંતરિક ભૂલ ઉદ્દભવી કે જે પ્રાપ્ત કરી શક્યા નહિં."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "કેલિબ્રેશન માટે જરૂરી સાધનો સ્થાપિત થયેલ નથી."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "રૂપરેખાને બનાવી શક્યા નહિં."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "લક્ષ્ય સફેદબિંદુને પ્રાપ્ત કરી શકાય તેમ નથી."
+
+#~| msgctxt "print job"
+#~| msgid "Completed"
+#~ msgid "Complete!"
+#~ msgstr "સમાપ્ત!"
+
+#~| msgid "Configuration failed"
+#~ msgid "Calibration failed!"
+#~ msgstr "માપદંડ નિષ્ફળ!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "તમે કેલિબ્રેશન ઉપકરણને દૂર કરી શકો છો."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "કેલિબ્રેશન ઉપકરણને ખલેલ પહોંચાડો નહિં જ્યાપે પ્રગતિમાં હોય"
+
+#~| msgid "Lock screen"
+#~ msgid "Laptop Screen"
+#~ msgstr "લૅપટોપ સ્ક્રીન"
+
+#, c-format
+#~| msgctxt "Device kind"
+#~| msgid "Scanner"
+#~ msgid "%s Scanner"
+#~ msgstr "%s સ્કેનર"
+
+#, c-format
+#~| msgctxt "Device kind"
+#~| msgid "Printer"
+#~ msgid "%s Printer"
+#~ msgstr "%s પ્રિન્ટર"
+
+#, c-format
+#~| msgctxt "Device kind"
+#~| msgid "Webcam"
+#~ msgid "%s Webcam"
+#~ msgstr "%s વેબકેમ"
+
+#, c-format
+#~| msgid "Learn more about color management"
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s માટે રંગ સંચાલનને સક્રિય કરો"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s માટે રંગ રૂપરેખાને બતાવો"
+
+#~| msgid "Uncalibrated"
+#~ msgid "Not calibrated"
+#~ msgstr "માપદંડ થયેલ નથી"
+
+#~ msgid "Default: "
+#~ msgstr "મૂળભૂત: "
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~ msgid "Test profile: "
+#~ msgstr "રૂપરેખા ચકાસો: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC રૂપરેખા ફાઇલ પસંદ કરો"
+
+#~ msgid "_Import"
+#~ msgstr "આયાત કરો (_I)"
+
+#~ msgid "All files"
+#~ msgstr "બધી ફાઇલો"
+
+#, c-format
+#~| msgid "Failed to apply configuration: %s"
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "ફાઇલને અપલોડ કરવામાં નિષ્ફળતા: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "રૂપરેખા તેમાં સુધારી દેવામાં આવી છે:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "આ URL ને લખો."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "આ કમ્પ્યૂટરને ફરી શરૂ કરો અને તમારી સામાન્ય ઓપરેટીંગ સિસ્ટમને બુટ કરો."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "ડાઉનલોડ કરવા માટે તમારાં બ્રાઉઝરમાં URL ને ટાઇપ કરો અને રૂપરેખાને સ્થાપિત કરો."
+
+#~| msgid "Remove profile"
+#~ msgid "Save Profile"
+#~ msgstr "પ્રોફાઇલને સંગ્રહ કરો"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "પસંદ થયેલ ઉપકરણ માટે રંગ રૂપરેખા બનાવો:"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "માપન સાધન મળતુ નથી. મહેરબાની કરીને ચકાસો કે તે ચાલુ છે કે નહિં અને યોગ્ય રીતે જોડાયેલ "
+#~ "છે."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "માપન સાધન પ્રિન્ટર રૂપરેખાને આધાર આપતુ નથી."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "ઉપકરણ પ્રકાર હાલમાં આધારભૂત નથી."
+
+#~| msgctxt "Experience"
+#~| msgid "Standard"
+#~ msgid "Standard Space"
+#~ msgstr "મૂળભૂત જગ્યા"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~| msgid "Test profile: "
+#~ msgid "Test Profile"
+#~ msgstr "રૂપરેખા ચકાસો"
+
+#~| msgctxt "proxy method"
+#~| msgid "Automatic"
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "સ્વયં"
+
+#~| msgctxt "Printer Option Group"
+#~| msgid "Image Quality"
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "નીચી ગુણવત્તા"
+
+#~| msgctxt "Printer Option Group"
+#~| msgid "Image Quality"
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "મધ્યમ ગુણવત્તા"
+
+#~| msgctxt "Printer Option Group"
+#~| msgid "Image Quality"
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "ઉચ્ચ ગુણવત્તા"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "મૂળભૂત RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "મૂળભૂત CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "મૂળભૂત ગ્રે"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "વિક્રેતા ફેક્ટરી માપદંડ માહિતીને પૂરુ પાડે છે"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "સંપૂર્ણ-સ્ક્રીન દર્શાવ સુધારો આ રૂપરેખા સાથે શક્ય નથી"
+
+#~| msgid "This device has an old profile that may no longer be accurate."
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "આ રૂપરેખા લાંબા સમય સુધી ચોક્કસ રહી શકતી નથી"
+
+#~| msgid "Done!"
+#~ msgid "Done"
+#~ msgstr "પૂર્ણ"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~| msgid "No profile"
+#~ msgid "Upload profile"
+#~ msgstr "રૂપરેખા અપલોડ કરો"
+
+#~| msgid "Add new connection"
+#~ msgid "Requires Internet connection"
+#~ msgstr "ઇન્ટરનેટ જોડાણની જરૂરિયાત છે"
+
+#~ msgid "United States"
+#~ msgstr "યુનાઇટેડ સ્ટેટ્સ"
+
+#~ msgid "Germany"
+#~ msgstr "જર્મની"
+
+#~ msgid "Spain"
+#~ msgstr "સ્પેન"
+
+#~ msgid "China"
+#~ msgstr "ચાઇના"
+
+#~| msgid "Other profile…"
+#~ msgid "Other…"
+#~ msgstr "બીજું..."
+
+#~ msgid "Language"
+#~ msgstr "ભાષા"
+
+#~| msgid "%a %l:%M %p"
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~| msgid "%a %l:%M %p"
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "ટાઈમ ઝોન (_Z)"
+
+#~ msgid "24-hour"
+#~ msgstr "24-કલાક"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~| msgid "Close"
+#~ msgid "Lid Closed"
+#~ msgstr "ઢાંકણ બંધ થયેલ છે"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Mirrored"
+#~ msgstr "પ્રતિબિંબિત"
+
+#~ msgid "Off"
+#~ msgstr "બંધ"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "સંયુક્ત દર્શાવોને ગોઠવો"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "તેઓને ફરી ગોઠવવા માટે દર્શાવોને ખેંચો"
+
+#~ msgid "Size"
+#~ msgstr "માપ"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "આ દર્શાવ પર ટોચવી પટ્ટી અને પ્રવૃત્તિ ઝાંખીને બતાવો"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "વધારાની કાર્ય કરવાની જગ્યાને બનાવવા બીજા સાથે આ દર્શાવને જોડો"
+
+#~| msgid "Orientation"
+#~ msgid "Presentation"
+#~ msgstr "રજૂઆત"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "તકતીપૂર્વદર્શન અને મીડિયાને ફક્ત બતાવો"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "બંને દર્શાવ પર તમારું હાલનુ દૃશ્ય બતાવો"
+
+#~| msgid "_Turn On"
+#~ msgid "Turn Off"
+#~ msgstr "બંધ કરો"
+
+#~| msgid "Panel to display"
+#~ msgid "Don't use this display"
+#~ msgstr "આ દર્શાવને વાપરો નહિં"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "સ્ક્રીન જાણકારી ને મેળવી શકાયુ નહિં"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "સંયુક્ત દર્શાવને ગોઠવો (_A)"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "Unknown"
+#~ msgstr "અજ્ઞાત"
+
+#, c-format
+#~| msgid "%d-bit"
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-બીટ"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-બીટ"
+
+#~ msgid "Ask what to do"
+#~ msgstr "શું કરવુ છે તે પૂછો"
+
+#~ msgid "Do nothing"
+#~ msgstr "કઇ કરવાનુ નથી"
+
+#~ msgid "Open folder"
+#~ msgstr "ફોલ્ડરને ખોલો"
+
+#~ msgid "Other Media"
+#~ msgstr "બીજી મીડિયા"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ઓડિયો CDs માટે કાર્યક્રમને પસંદ કરો"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "વિડિઓ DVDs માટે કાર્યક્રમને પસંદ કરો"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "ચલાવવા માટે કાર્યક્રમને પસંદ કરો જ્યારે સંગીત પ્લેયર જોડાયેલ હોય"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "ચલાવવા માટે કાર્યક્રમને પસંદ કરો જ્યારે કેમેરા જોડાયેલ હોય"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "સોફ્ટવેર CDs માટે કાર્યક્રમને પસંદ કરો"
+
+#~ msgid "audio DVD"
+#~ msgstr "ઓડિયો DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "ખાલી બ્લુ-રે ડિસ્ક"
+
+#~ msgid "blank CD disc"
+#~ msgstr "ખાલી CD ડિસ્ક"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "ખાલી DVD ડિસ્ક"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "ખાલી HD DVD ડિસ્ક"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "બ્લુ-રે વિડિયો ડિસ્ક"
+
+#~ msgid "e-book reader"
+#~ msgstr "ઇ-બુટ વાંચનાર"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD વિડિયો ડિસ્ક"
+
+#~ msgid "Picture CD"
+#~ msgstr "ચિત્ર CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "મુખ્ય વિડીયો CD"
+
+#~ msgid "Video CD"
+#~ msgstr "વિડિયો CD"
+
+#~ msgid "Overview"
+#~ msgstr "ઝાંખી"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "આવૃત્તિ %s"
+
+#~ msgid "Base system"
+#~ msgstr "મૂળભૂત સિસ્ટમ"
+
+#~ msgid "Disk"
+#~ msgstr "ડિસ્ક"
+
+#~| msgid "Checking for Updates"
+#~ msgid "Check for updates"
+#~ msgstr "સુધારાઓ માટે ચકાસો"
+
+#~| msgid "Save a screenshot to Pictures"
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "$PICTURES માં સ્ક્રીનશોટને સંગ્રહો"
+
+#~| msgid "Save a screenshot of a window to Pictures"
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "$PICTURES માં વિન્ડોનાં સ્ક્રીનશોટને સંગ્રહો"
+
+#~| msgid "Save a screenshot of an area to Pictures"
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "$PICTURES માં એક વિસ્તારનાં સ્ક્રીનશોટને સંગ્રહો"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "ક્લિપબોર્ડમાં સ્ક્રીનશોટની નકલ કરો"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "ક્લિપબોર્ડમાં વિન્ડોના સ્ક્રિનશોટની નકલ કરો"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "ક્લિપબોર્ડમાં વિસ્તારનાં સ્ક્રીનશોટની નકલ કરો"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "ટૂંકી સ્ક્રીનકાસ્ટનો અહેવાલ લો"
+
+#~| msgid "Switch to next source"
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "સંશોધક ફક્ત આગળનાં સ્ત્રોત પર જવા માટે"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "ટૂંકાણ;ચાલુ રાખો;ઝબૂકવુ;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "વૈવિધ્યપૂર્ણ ટુંકાણો"
+
+#~ msgid "_Delay:"
+#~ msgstr "વિલંબ (_D):"
+
+#~ msgid "_Speed:"
+#~ msgstr "ઝડપ (_S):"
+
+#~| msgid "Short"
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "ટૂંકુ"
+
+#~| msgid "Slow"
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "ધીમુ"
+
+#~| msgid "Long"
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "લાંબુ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~| msgid "Fast"
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "ઝડપી"
+
+#~ msgid "S_peed:"
+#~ msgstr "ઝડપ (_p):"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "ટુંકાણ દૂર કરો"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "ટુકાણ કીમાં ફેરફાર કરવા માટે, તેને લાગતી હરોળ પર ક્લિક કરો અને નવી કી જોડાણોને "
+#~ "ટાઇપ કરો, અથવા સાફ કરવા માટે Backspace કી દબાવો."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "&lt;Unknown Action&gt;"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "ટૂંકાણ \"%s\" વાપરી શકાશે નહિં કારણ કે તે આ કીને લખવા માટે વાપરવા માટે અશક્ય બનશે.\n"
+#~ "Control, Alt અથવા Shift જેવી કીને એક જ સમયે વાપરવાનો પ્રયાસ કરી જુઓ."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "આ ટુંકાણ \"%s\" પહેલેથી \"%s\" માટે વપરાયેલ\n"
+#~ "છે"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "જો \"%s\" ને ટુંકાણોમાં ફરીથી નિશ્ચત કરો તો, \"%s\" ટુંકાણો નિષ્ક્રિય થયેલ હશે."
+
+#~ msgid "_Reassign"
+#~ msgstr "પુન:નિશ્ચત કરો (_R)"
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" ટૂંકાણ એ \"%s\" ટૂંકાણ સાથે સંકળાયેલ છે. શું તમે \"%s\" માં તેને આપમેળે સુયોજિત "
+#~ "કરવા માંગો છો?"
+
+#, c-format
+#~| msgid ""
+#~| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~| "disabled."
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\"  એ હાલમાં \"%s\" સાથે સંકળાયેલ છે, આ ટૂંકાણ એ નિષ્ક્રિય થશે જો તમે આગળ ખસો તો."
+
+#~| msgid "_Reassign"
+#~ msgid "_Assign"
+#~ msgstr "સોંપો (_A)"
+
+#~| msgid "_Test Your Settings"
+#~ msgid "Test Your Settings"
+#~ msgstr "તમારાં સુયોજનો ચકાસો"
+
+#~| msgid "Slow"
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "ધીમુ"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "બે ક્લિકની સમયસમાપ્તિ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~| msgid "Fast"
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "ઝડપી"
+
+#~| msgid "_Left"
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "ડાબું (_L)"
+
+#~| msgid "_Right"
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "જમણું (_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "પોઇન્ટર ઝડપ (_P)"
+
+#~| msgid "Slow"
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ધીમુ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~| msgid "Fast"
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "ઝડપી"
+
+#~| msgid "Slow"
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ધીમુ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~| msgid "Fast"
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "ઝડપી"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "બે- આંગળી થી ખસેડવુ (_fi)"
+
+#~| msgid "_Edge scrolling"
+#~ msgid "_Natural scrolling"
+#~ msgstr "કુદરતી સ્ક્રોલીંગ (_N)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "પાંચ ક્લિક, GEGL સમય!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "બે ક્લિક, પ્રાથમિક બટન"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "એક જ ક્લિક, પ્રાથમિક બટન"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "બે ક્લિક, મધ્ય બટન"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "એકજ ક્લિક, મધ્ય બટન"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "બે વાર ક્લિક, ગૌણ બટન"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "એકજ ક્લિક, ગૌણ બટન"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "સિસ્ટમ નેટવર્ક સેવાઓ આવૃત્તિ સાથે સુસંગત નથી."
+
+#~ msgid "page 1"
+#~ msgstr "પાનું 1"
+
+#~ msgid "page 2"
+#~ msgstr "પાનું 2"
+
+#~| msgctxt "proxy method"
+#~| msgid "Automatic"
+#~ msgid "automatic"
+#~ msgstr "સ્વયં"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "એન્ટરપ્રાઇઝ"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "કંઈ નહિં"
+
+#~| msgid "never"
+#~ msgid "Never"
+#~ msgstr "કદી નહિં"
+
+#~| msgid "today"
+#~ msgid "Today"
+#~ msgstr "આજે"
+
+#~| msgid "yesterday"
+#~ msgid "Yesterday"
+#~ msgstr "ગઈકાલે"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "કંઈ નહિં"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "નબળુ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "બરાબર"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "સરસ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "હોશિયાર"
+
+#~ msgid "Identity"
+#~ msgstr "ઓળખ"
+
+#~ msgid "Server"
+#~ msgstr "સર્વર"
+
+#~| msgid "Delete device"
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS સર્વર કાઢી નાંખો"
+
+#~| msgid "Default Route"
+#~ msgid "Delete Route"
+#~ msgstr "માર્ગ કાઢી નાંખો"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~| msgid "None"
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "કંઈ જ નહિં"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit Key (Hex અથવા ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit પાસફ્રેજ"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "ડાયનેમિક WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA અને WPA2 વ્યક્તિગત"
+
+#~| msgid "Enterprise"
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA અને WPA2 એન્ટરપ્રાઇઝ"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~| msgid "%d Mb/s"
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~| msgid "%d Mb/s"
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "બીજા વપરાશકર્તાઓ માટે ઉપલબ્ધ બનાવો (_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "ફાયરવોલ ઝોન (_Z)"
+
+#~| msgid "Default"
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "મૂળભૂત"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "વિસ્તાર જોડાણનાં વિશ્ર્વાસ સ્તરને દર્શાવે છે"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv4 (_4)"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv6 (_6)"
+
+#~| msgid "Bluetooth connection failed"
+#~ msgid "Unable to open connection editor"
+#~ msgstr "જોડાણ સંપાદકને ખોલવાનું અસમર્થ"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~| msgid "No profile"
+#~ msgid "New Profile"
+#~ msgstr "નવી રૂપરેખા"
+
+#~ msgid "Bond"
+#~ msgstr "બોન્ડ"
+
+#~ msgid "Team"
+#~ msgstr "જૂથ"
+
+#~ msgid "Bridge"
+#~ msgstr "બ્રિજ"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~| msgid "Could not load ui: %s"
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN પ્લગઇનને લાવી શક્યા નહિં"
+
+#~| msgid "Other profile…"
+#~ msgid "Import from file…"
+#~ msgstr "ફાઇલમાંથી આયાત કરો..."
+
+#~| msgid "Add new connection"
+#~ msgid "Add Network Connection"
+#~ msgstr "નેટવર્ક જોડાણને ઉમેરો"
+
+#~ msgid "_Reset"
+#~ msgstr "ફરી સુયોજીત કરો (_R)"
+
+#~| msgid "Forget"
+#~ msgid "_Forget"
+#~ msgstr "ભૂલી જાઓ (_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "આ નેટવર્ક માટે સુયોજનો સુયોજિત કરો, પાસવર્ડને સમાવી રહ્યા છે, પરંતુ યાદ રાખો કે તે પસંદ "
+#~ "થયેલ નેટવર્ક ચે"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr "આ નેટવર્કને લગતી બધી વિગતોને દૂર કરો અને આપમેળે જોડાવા માટે પ્રયત્ન કરો નહિં"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN જોડાણની આયાત કરી શકાતુ નથી"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "ફાઇલ '%s' એ વાંચી શકાયુ નહિં અથવા ઓળખેલ VPN જોડાણ જાણકારીને સમાવતુ નથી\n"
+#~ "\n"
+#~ "ભૂલ: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "આયાત કરવા માટે ફાઇલ પસંદ કરો"
+
+#, c-format
+#~| msgid "A user with name '%s' already exists."
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "નામ \"%s\" ફાઇલ પહેલેથી અસ્તિત્વ ધરાવે છે."
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "શું તમે સંગ્રહ કરી રહ્યા છો તે VPN જોડાણ સાથે %s ને બદલવા માંગો છો?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN જોડાણનું નિકાસ કરી શકાતુ નથી"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN જોડાણ '%s' ને %s માં નિકાસ કરી શક્યા નહિં.\n"
+#~ "\n"
+#~ "ભૂલ: %s."
+
+#~| msgid "Add new connection"
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN જોડાણની નિકાસ કરો"
+
+#~ msgid "Bond slaves"
+#~ msgstr "બોન્ડ સ્લેવ"
+
+#~ msgid "(none)"
+#~ msgstr "(કંઇ નહિં)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "બ્રિજ સ્લેવ"
+
+#~ msgid "never"
+#~ msgstr "કદી નહિં"
+
+#~ msgid "today"
+#~ msgstr "આજે"
+
+#~ msgid "yesterday"
+#~ msgstr "ગઇ કાલે"
+
+#~ msgid "Last used"
+#~ msgstr "છેલ્લે વાપરેલ"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#, c-format
+#~| msgid "_Profile:"
+#~ msgid "Profile %d"
+#~ msgstr "રૂપરેખા %d"
+
+#~ msgid "Team slaves"
+#~ msgstr "જૂથ સ્લેવ"
+
+#~| msgid ""
+#~| "If you have a connection to the Internet other than wireless, you can "
+#~| "use it to share your internet connection with others."
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "જો તમારી પાસે વાયરલેસ કરતા બીજુ ઇન્ટરનેટનું જોડાણ હોય તો, તમે બીજા સાથે જોડાણની "
+#~ "ભાગીદારી કરવા માટે વાયરલેસ હૉટસ્પોટને સુયોજિત કરી શકો છો."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "વાયરલેસ હૉટસ્પોટ પર અદલાબદલી કરવાથી <b>%s</b> માંથી તમારુ જોડાણ તૂટી જશે."
+
+#~| msgid ""
+#~| "It is not possible to access the internet through your wireless while "
+#~| "the hotspot is active."
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "તમારા વાયરલેસ મારફતે ઇન્ટરનેટને વાપરવાનું તેની માટે શક્ય નથી જ્યારે હૉટસ્પોટ સક્રિય હોય."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "હૉટસ્પોટને અટકાવો અને કોઇપણ વપરાશકર્તાનું જોડાણ તોડો? "
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "હૉટસ્પોટ બંધ કરો (_S)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "સિસ્ટમ પોલિસી હૉટસ્પોટ તરીકે વાપરવાનું અટકાવે છે"
+
+#~| msgid "InfiniBand device does not support connected mode"
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "વાયરલેસ ઉપકરણ હૉટસ્પોટને આધાર આપતુ નથી"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "પસંદ થયેલ નેટવર્કો માટે નેટવર્ક વિગતો, પાસવર્ડને સમાવીને અને કોઇપણ વૈવિધ્ય રૂપરેખાંકન ગુમ "
+#~ "થઇ જશે."
+
+#~| msgid "Forget"
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "ભૂલી જાઓ (_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "Web Proxy Autodiscovery વાપરેલ છે જ્યારે રૂપરેખાંકન URL પૂરી પાડેલ નથી."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "આ અવિશ્ર્વાસુ સાર્વજનિક નેટવર્કો માટે અગ્રહણીય નથી."
+
+#~ msgid "Proxy"
+#~ msgstr "પ્રોક્સી"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "કઇ નહિં"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "મેન્યુઅલ"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "સ્વયં"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN પ્રકાર"
+
+#~ msgid "Group Name"
+#~ msgstr "જૂથ નામ"
+
+#~| msgid "Details"
+#~ msgid "details"
+#~ msgstr "વિગતો"
+
+#~| msgid "_Show password"
+#~ msgid "Show P_assword"
+#~ msgstr "પાસવર્ડ બતાવો (_a)"
+
+#~| msgid "Failed to delete user"
+#~ msgid "Make available to other users"
+#~ msgstr "બીજા વપરાશકર્તાઓ માટે ઉપલબ્ધ બનાવો"
+
+#~ msgid "identity"
+#~ msgstr "ઓળખાણ"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "ફક્ત સ્વયં (DHCP) સરનામાંઓ"
+
+#~ msgid "Link-local only"
+#~ msgstr "ફક્ત સ્થાનિક કડી"
+
+#~| msgid "Cannot remove automatically added profile"
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "પ્રાપ્ત થયેલ માર્ગને આપમેળે અવગણો (_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "ક્લોન થયેલ MAC સરનામું (_C)"
+
+#~| msgid "Hardware"
+#~ msgid "hardware"
+#~ msgstr "હાર્ડવેર"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "તેનાં મૂળભૂતમાં આ જોડાણ માટે સુયોજનોને પુન:સુયોજિત કરો, પરંતુ પસંદ થયેલ જોડાણ તરીકે યાદ "
+#~ "રાખો."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr "આ નેટવર્કને લગતી બધી વિગતોને દૂર કરો અને આપમેળે જોડાવા માટે પ્રયત્ન કરો નહિં."
+
+#~ msgid "reset"
+#~ msgstr "પુનઃસુયોજીત કરો"
+
+#~ msgid "Hardware"
+#~ msgstr "હાર્ડવેર"
+
+#~ msgid "_History"
+#~ msgstr "ઇતિહાસ (_H)"
+
+#~| msgid "Switch off to connect to a wireless network"
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Wi-Fi નેટવર્કમાં જોડાવાનુ બંધ કરો"
+
+#~ msgid "Connected Devices"
+#~ msgstr "જોડાયેલ ઉપકરણો"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "ઇન્ફ્રાસ્ટ્રક્ચર"
+
+#~ msgid "Status unknown"
+#~ msgstr "અજ્ઞાત સ્થિતિ"
+
+#~ msgid "Unmanaged"
+#~ msgstr "અસંચાલિત"
+
+#~ msgid "Unavailable"
+#~ msgstr "બિનઉપલબ્ધ"
+
+#~ msgid "Connecting"
+#~ msgstr "જોડાઇ રહ્યા છે"
+
+#~ msgid "Disconnecting"
+#~ msgstr "જોડાણ તૂટી રહ્યુ છે"
+
+#~ msgid "Connection failed"
+#~ msgstr "જોડાણ નિષ્ફળ"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "અજ્ઞાત સ્થિતિ (ગેરહાજર)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "રૂપરેખાંકન નિષ્ફળ"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP રૂપરેખાંકન નિષ્ફળ"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP રૂપરેખાંકન નિવૃત્ત"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "ખાનગીની જરૂરિયાત હતી, પરંતુ પૂરુ પાડેલ નથી"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1X સપ્લિકન્ટનું જોડાણ તૂટી ગયુ"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1X સપ્લિકન્ટ રૂપરેખાંકન નિષ્ફળ"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1X સપ્લિકન્ટ નિષ્ફળ"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1X સપ્લિકન્ટ સત્તાધિકરણ કરવા માટે લાંબો સમય લીધો"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "શરૂ કરવા માટે PPP સેવા નિષ્ફળ"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "તૂટી ગયેલ PPP સેવા જોડાણ"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP નિષ્ફળ"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "શરૂ કરવા માટે DHCP ક્લાયન્ટ નિષ્ફળ"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP ક્લાયન્ટ ભૂલ"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP ક્લાયન્ટ નિષ્ફળ"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "શરૂ કરતી વખતે વહેંચાયેલ જોડાણ સેવા નિષ્ફળ"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "વહેંચાયેલ જોડાણ સેવા નિષ્ફળ"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "શરૂ કરવા માટે AutoIP સેવા નિષ્ફળ"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP સેવા ભૂલ"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP સેવા નિષ્ફળ"
+
+#~ msgid "Line busy"
+#~ msgstr "લાઇન વ્યસ્ત છે"
+
+#~ msgid "No dial tone"
+#~ msgstr "ડાયલ ટોન નથી"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "કૅરિઅર સ્થાપિત કરી શક્યા નહિં"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "ડાયલ કરવાની માંગણીનો સમય સમાપ્ત"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "ડાયલ કરવાનો પ્રયાસ નિષ્ફળ"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "મોડેમની શરૂઆત નિષ્ફળ"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "ખાસ APN ને પસંદ કરવાનું નિષ્ફળ"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "નેટવર્કો માટે શોધી રહ્યા નથી"
+
+#~ msgid "Network registration denied"
+#~ msgstr "નામંજૂર થયેલ નેટવર્ક રજીસ્ટ્રેશન"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "નેટવર્ક રજીસ્ટ્રેશન કરવાનો સમય સમાપ્ત થઇ ગયો"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "સૂચિત નેટવર્ક સાથે રજીસ્ટર કરવાનું નિષ્ફળ"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN ચકાસણી નિષ્ફળ"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "ઉપકરણ માટે જરૂરી ફર્મવેર ગુમ થઇ શકે છે"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "જોડાણ અદૃશ્ય"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "હાલનાં જોડાણને ધારેલ હતુ"
+
+#~ msgid "Modem not found"
+#~ msgstr "મોડેમ મળ્યુ નથી"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "બ્લુટુથ જોડાણ નિષ્ફળ"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM પીનની જરૂરિયાત છે"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk જરૂરી"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM ખોટુ"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand ઉપકરણ જોડાયેલ સ્થિતિને આધાર આપતુ નથી"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "જોડાણ નિર્ભરતા નિષ્ફળ"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "કૅબલ પ્લગ થયેલ નથી"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Certificate Authority (પ્રમાણપત્ર સત્તા) પ્રમાણપત્ર પસંદ થયેલ નથી"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Certificate Authority (CA) પ્રમાણપત્ર વાપર્યા વગર અસુરક્ષિત, ઠગ Wi-Fi નેટવર્કો "
+#~ "જોડાણોમાં પરિણમી શકે છે. શું તમે Certificate Authority પ્રમાણપત્રને પસંદ કરવા માંગો "
+#~ "છો?"
+
+#~ msgid "Ignore"
+#~ msgstr "અવગણો"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA પ્રમાણપત્રને પસંદ કરો"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, અથવા PKCS#12 ખાનગી કી (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER અથવા PEM પ્રમાણપત્રો (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ફાઇલો (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "દરેક વખતે આ પાસવર્ડ માટે પૂછો (_k)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "એનક્રિપ્ટ ન થયેલ ખાનગી કી અસુરક્ષિત છે"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "પસંદ થયેલ ખાનગી કીને પાસવર્ડ દ્દારા સુરક્ષિત કરવા માટે દેખાતુ નથી.  આ સમાધાન કરવા "
+#~ "માટે તમારી સુરક્ષા શ્રેયોને પરવાનગી આપી શકે છે.  મહેરબાની કરીને પાસવર્ડ-સુરક્ષિત થયેલ "
+#~ "ખાનગી કી ને પસંદ કરો.\n"
+#~ "\n"
+#~ "(તમે openssl સાથે તમારી ખાનગી કીને પાસવર્ડ-સુરક્ષિત કરી શકો છો)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "તમારાં વ્યક્તિગત પ્રમાણપત્રને પસંદ કરો"
+
+#~ msgid "Choose your private key"
+#~ msgstr "તમારી ખાનગી કીને પસંદ કરો"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "મને ફરીથી ચેતવણી આપો નહિં (_w)"
+
+#~ msgid "Yes"
+#~ msgstr "હાં"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "પોપઅપ બેનરને બતાવો"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "બેનરમાં વિગતો બતાવો"
+
+#~| msgid "Lock screen"
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "સ્ક્રીન તાળુમાં જુઓ"
+
+#~ msgid "On"
+#~ msgstr "ચાલુ"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "પોપ અપ બેનરને બતાવો"
+
+#~| msgid "Lock screen"
+#~ msgid "Show in Lock Screen"
+#~ msgstr "સ્ક્રીન તાળુમાં બતાવો"
+
+#~ msgid "Add Account"
+#~ msgstr "ખાતુ ઉમેરો"
+
+#~| msgid "_Mail"
+#~ msgid "Mail"
+#~ msgstr "મેઈલ"
+
+#~| msgid "Contrast:"
+#~ msgid "Contacts"
+#~ msgstr "સંપર્કો"
+
+#~ msgid "Chat"
+#~ msgstr "વાતચીત"
+
+#~ msgid "Resources"
+#~ msgstr "સ્ત્રોતો"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "ખાતામાં પ્રવેશતી વખતે ભૂલ"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "શ્રેયની મર્યાદા પૂરી થઇ ગઇ."
+
+#~| msgid "Enable this account"
+#~ msgid "Sign in to enable this account."
+#~ msgstr "આ ખાતાને સક્રિય કરવા માટે પ્રવેશો."
+
+#~ msgid "_Sign In"
+#~ msgstr "પ્રવેશો (_S)"
+
+#~ msgid "Error creating account"
+#~ msgstr "ખાતાને બનાવતી વખતે ભૂલ"
+
+#~ msgid "Error removing account"
+#~ msgstr "ખાતાને દૂર કરી રહ્યા હોય ત્યારે ભૂલ"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "શું તમે ખરેખર ખાતાને દૂર કરવા માંગો છો?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "આ સર્વર પર ખાતાને દૂર કરશે નહિં."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "રૂપરેખાંકિત થયેલ ઓનલાઇન ખાતા નથી"
+
+#~ msgid "Remove Account"
+#~ msgstr "ખાતુ દૂર કરો"
+
+#~ msgid "Add an online account"
+#~ msgstr "ઓનલાઇન ખાતા ઉમેરો"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "ખાતાને ઉમેરવાનું દસ્તાવેજો, મેઇલ, સંપર્કો, કૅલેન્ડર, વાચચીત અને વધારે માટે તમારાં "
+#~ "કાર્યક્રમોને વાપરવાની પરવાનગી આપે છે."
+
+#~ msgid "Unknown time"
+#~ msgstr "અજ્ઞાત સમય"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~| msgid "Charging - %s until fully charged"
+#~ msgid "%s until fully charged"
+#~ msgstr "ચાર્જ થાય ત્યાં સુધી %s"
+
+#, c-format
+#~| msgid "Caution low UPS, %s remaining"
+#~ msgid "Caution: %s remaining"
+#~ msgstr "ચેતવણી: %s બાકી રહ્યુ છે"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s બાકી રહેલ છે"
+
+#~| msgid "Full Screen"
+#~ msgid "Fully charged"
+#~ msgstr "સંપૂર્ણપણે ચાર્જ થયેલ છે"
+
+#~ msgid "Empty"
+#~ msgstr "ખાલી"
+
+#~ msgid "Charging"
+#~ msgstr "ચાર્જિંગ"
+
+#~| msgid "Charging"
+#~ msgid "Discharging"
+#~ msgstr "ડિસ્ચાર્જ થઇ રહ્યુ છે"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "મુખ્ય"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "વધારાનું"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "વાયરલેસ માઉસ"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "વાયરલેસ કિબોર્ડ"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "અવરોધી ન શકાય તેવો વીજ પુરવઠો"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "વ્યક્તિગત ડિઝિટલ મદદકર્તા"
+
+#~ msgid "Cellphone"
+#~ msgstr "સેલફોન"
+
+#~ msgid "Media player"
+#~ msgstr "મીડિયા પ્લેયર"
+
+#~ msgid "Computer"
+#~ msgstr "કમ્પ્યૂટર"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "ચાર્જિંગ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "સાવધાન"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "નીચે"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "સરસ"
+
+#~| msgid "Full Screen"
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "સંપૂર્ણપણે ચાર્જ થયેલ છે"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "ખાલી"
+
+#~| msgid "Battery"
+#~ msgid "Batteries"
+#~ msgstr "બેટરી"
+
+#~ msgid "When _idle"
+#~ msgstr "જ્યારે નિષ્ક્રિય હોય (_i)"
+
+#~| msgid "Keyboard Settings"
+#~ msgid "_Keyboard brightness"
+#~ msgstr "કિબોર્ડ પ્રકાશતા (_K)"
+
+#~| msgid "_Turn screen off when inactive for:"
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "ઝાંખી સ્ક્રીન જ્યારે નિષ્ક્રિય હોય (_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "Wi-Fi (_W)"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "વાયરલેસ ઉપકરણોને બંધ કરે છે"
+
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "મોબાઇલ બ્રોડબેન્ડ (3G, 4G, WiMax, વગેરે.) ઉપકરણોને બંધ કરે છે"
+
+#~| msgid "Bluetooth"
+#~ msgid "_Bluetooth"
+#~ msgstr "બ્લુટુથ (_B)"
+
+#~| msgid "On battery power"
+#~ msgid "When on battery power"
+#~ msgstr "જ્યારે બેટરી પાવર પર છે"
+
+#~ msgid "When plugged in"
+#~ msgstr "જ્યારે પ્લગ થયેલ હોય"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "સ્થગિત અને પાવર બંધ"
+
+#~| msgctxt "proxy method"
+#~| msgid "Automatic"
+#~ msgid "_Automatic suspend"
+#~ msgstr "આપમેળે સ્થગિત (_A)"
+
+#~| msgid "When power is _critically low"
+#~ msgid "When battery power is _critical"
+#~ msgstr "જ્યારે બેટરી પાવર જટીલ હોય (_C)"
+
+#~| msgid "Power off"
+#~ msgid "Power Off"
+#~ msgstr "પાવર બંધ"
+
+#~ msgid "Hibernate"
+#~ msgstr "હાઇબરનેટ"
+
+#~ msgid "1 minute"
+#~ msgstr "1 મિનિટ"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 મિનિટો"
+
+#~| msgid "5 minutes"
+#~ msgid "4 minutes"
+#~ msgstr "4 મિનિટ"
+
+#~| msgid "5 minutes"
+#~ msgid "8 minutes"
+#~ msgstr "8 મિનિટ"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 મિનિટો"
+
+#~| msgid "2 minutes"
+#~ msgid "12 minutes"
+#~ msgstr "12 મિનિટ"
+
+#~ msgid "Out of toner"
+#~ msgstr "ટોનરની બહાર"
+
+#~ msgid "Low on developer"
+#~ msgstr "ડેવલપર ઓછું છે"
+
+#~ msgid "Out of developer"
+#~ msgstr "ડેવલપરની બહાર"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "માર્કર પૂરવઠો ઓછો છે"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "માર્કર પૂરવઠાની બહાર"
+
+#~ msgid "Open cover"
+#~ msgstr "કવર ખોલો"
+
+#~ msgid "Open door"
+#~ msgstr "દરવાજો ખોલો"
+
+#~ msgid "Low on paper"
+#~ msgstr "પેપર ઓછા"
+
+#~ msgid "Out of paper"
+#~ msgstr "પેપરની બહાર"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "બંધ થયેલ"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "લગભગ સંપૂર્ણ પાત્ર કચરો"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "સંપૂર્ણ પાત્ર કચરો"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ઓપ્ટીકલ ફોટો કન્ડક્ટર જીવનનાં અંત નજીક છે"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ઓપ્ટીકલ ફોટો કન્ડક્ટર લાંબા સમય સુધી કાર્ય કરતુ નથી"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "તૈયાર"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "કાર્યોને સ્વીકારો નહિં"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "પ્રોસેસીંગ"
+
+#~ msgid "Toner Level"
+#~ msgstr "ટૉનર સ્તર"
+
+#~ msgid "Supply Level"
+#~ msgstr "પૂરવઠો સ્તર"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "સ્થાપિત કરી રહ્યા છે"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u સક્રિય"
+#~ msgstr[1] "%u સક્રિય"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "નવાં પ્રિન્ટરને ઉમેરવાનું નિષ્ફળ."
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript પ્રિન્ટર વર્ણન ફાઈલો (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "સુસંગત ડ્રાઇવર મળ્યુ નથી"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui ને લોડ કરી શક્યા નહિં: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "છાપવાનું પુન:લાવો"
+
+#~ msgid "Pause Printing"
+#~ msgstr "છાપવાનું અટકાવો"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "નવાં પ્રિન્ટરને ઉમેરો"
+
+#~| msgid "Search for network printers or filter result"
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "પરિણામોને ફિલ્ટર કરવા માટે પ્રિન્ટર અથવા લખાણનાં સરનામાંને દાખલ કરો"
+
+#~| msgid "Remove Printer"
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect પ્રિન્ટર"
+
+#~| msgctxt "Device kind"
+#~| msgid "Printer"
+#~ msgid "LPD Printer"
+#~ msgstr "LPD પ્રિન્ટર"
+
+#~ msgid "One Sided"
+#~ msgstr "એકતરફી"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "લાંબી બાજુ (મૂળભૂત)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "ટૂંકી બાજુ (ફ્લિપ)"
+
+#~ msgid "Portrait"
+#~ msgstr "પૉર્ટેટ"
+
+#~ msgid "Landscape"
+#~ msgstr "લૅન્ડસ્કેપ"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "વિપરીત લૅન્ડસ્કેપ"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "વિપરીત પૉર્ટ્રેટ"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "સ્થગિત"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "અટકેલ"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "પ્રોસેસીંગ"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "બંધ થયેલ"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "કાઢી નાંખેલ"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "સમાપ્ત"
+
+#~ msgid "Job Title"
+#~ msgstr "જોબ શીર્ષક"
+
+#~ msgid "Job State"
+#~ msgstr "જૉબ સ્થિતિ"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "સીરીયલ પોર્ટ"
+
+#~ msgid "Parallel Port"
+#~ msgstr "સમાંતર પોર્ટ"
+
+#, c-format
+#~| msgid "Location"
+#~ msgid "Location: %s"
+#~ msgstr "સ્થાન: %s"
+
+#, c-format
+#~| msgid "A_ddress:"
+#~ msgid "Address: %s"
+#~ msgstr "સરનામું: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "દ્દિતરફી"
+
+#~ msgid "Paper Type"
+#~ msgstr "પેપર પ્રકાર"
+
+#~ msgid "Paper Source"
+#~ msgstr "પેપર સ્ત્રોત"
+
+#~ msgid "Output Tray"
+#~ msgstr "આઉટપુટ ટ્રે"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript ફરી ફિલ્ટર કરી રહ્યા છે"
+
+#~ msgid "Pages per side"
+#~ msgstr "બાજુ પ્રતિ પાનાંઓ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "સામાન્ય"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "પાનું સુયોજન"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "સ્થાપન કરી શકાય તેવા વિકલ્પો"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "ક્રિયા"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "ઇમેજ ગુણવત્તા"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "રંગ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "સમાપ્ત કરી રહ્યા છે"
+
+#~ msgid "Auto Select"
+#~ msgstr "સ્વયં પસંદ કરો"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "ફક્ત ઍમ્બેડ GhostScript ફોન્ટ"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS સ્તર 1 માં રૂપાંતરિત કરો"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS સ્તર 2 માં રૂપાંતરિત કરો"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~ msgid "No pre-filtering"
+#~ msgstr "પહેલેથી ફિલ્ટર કરવુ નહિં"
+
+#~ msgid "Supply"
+#~ msgstr "પૂરુ પાડો"
+
+#~| msgid "Default Route"
+#~ msgid "_Default printer"
+#~ msgstr "મૂળભૂત પ્રિન્ટર (_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "જોબ"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "કાર્યોને બતાવો (_J)"
+
+#~ msgid "label"
+#~ msgstr "લેબલ"
+
+#~ msgid "page 3"
+#~ msgstr "પાનું 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "ચકાસણી પાનાંને છાપો (_T)"
+
+#~ msgid "_Options"
+#~ msgstr "વિકલ્પો (_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "નવાં પ્રિન્ટરને ઉમેરો"
+
+#~ msgid "Usage & History"
+#~ msgstr "વપરાશ અને ઇતિહાસ"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "શું કચરાપેટીમાંથી બધી વસ્તુઓને ખાલી કરો?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "કચરાપેટીમાં બધી વસ્તુઓને કાયમ માટે કાઢી નાંખેલ છે."
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "શું બધી કામચલાઉ ફાઇલોને કાઢવાની છે?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "બધી કામચલાઉ ફાઇલો કાયમ માટે કાઢી નંખાશે."
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "તમારી વ્યક્તિગત જાણકારીને સુરક્ષિત કરો અને બીજા શું જોઇ શકે તેની પર નિયંત્રણ કરો"
+
+#~| msgid "Screen turns off"
+#~ msgid "Screen Turns Off"
+#~ msgstr "સ્ક્રીન બંધ થાય છે"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 સેકંડ"
+
+#~ msgid "1 day"
+#~ msgstr "1 દિવસ"
+
+#~ msgid "2 days"
+#~ msgstr "2 દિવસો"
+
+#~ msgid "3 days"
+#~ msgstr "3 દિવસો"
+
+#~ msgid "4 days"
+#~ msgstr "4 દિવસો"
+
+#~ msgid "5 days"
+#~ msgstr "5 દિવસો"
+
+#~ msgid "6 days"
+#~ msgstr "6 દિવસો"
+
+#~ msgid "7 days"
+#~ msgstr "7 દિવસો"
+
+#~ msgid "14 days"
+#~ msgstr "14 દિવસો"
+
+#~ msgid "30 days"
+#~ msgstr "30 દિવસો"
+
+#~| msgid "never"
+#~ msgid "Forever"
+#~ msgstr "હંમેશા"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "તમારાં ઇતિહાસને યાદ રાખવુ ફરી શોધવા માટે સરળ બની જાય છે. આ વસ્તુઓ નેટવર્ક પર કદી "
+#~ "વહેંચાતી નથી."
+
+#~ msgid "_Recently Used"
+#~ msgstr "તાજેતરમાં વાપરેલ છે (_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "ઇતિહાસને પુન:પ્રાપ્ત કરો (_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "તાળુ સ્ક્રીન તમારી ખાનગી જાણકારીને સુરક્ષિત રાખે છે જ્યારે તમે દૂર હોય."
+
+#~| msgid "_Lock screen after:"
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "ખાલી પછી સ્ક્રીનને તાળુ મારો (_a)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "બિનજરૂરી સંવેદનશીલ જાણકારીથી તમારાં કમ્પ્યૂટરને મુક્ત રાખવા મદદ કરવા માટે પહેલાં આપમેળે "
+#~ "કચરાપેટી અને કામચલાઉ ફાઇલોને સાફ કરો."
+
+#~ msgid "Purge _After"
+#~ msgstr "પછી સાફ કરો (_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "ક્યાં સોફ્ટવેર તમે વાપરો છે જે તમને વધારે ચોક્કસ અગ્રહતા સાથે તમને પૂરુ પાડવા મદદ કરે છે તે "
+#~ "વિશે જાણકારી અમને મોકલી રહ્યા છે. તે અમારાં સોફ્ટવેરને સુધારવા માટે પણ અમને મદદ કરે "
+#~ "છે.\n"
+#~ "\n"
+#~ "બધી જાણકારી જે અમે અનામિક રીતે સંગ્રહી છે, અને અમે ત્રીજી પાર્ટી સાથે તમારી માહિતીને "
+#~ "વહેંચવાની કદી જરૂર પડશે નહિં."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "સોફ્ટવેર વપરાશનાં આંકડા મોકલો (_S)"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "ખાનગી પોલિસી"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "તમારાં ભૌગોલિક સ્થાનને નક્કી કરવા વાપરેલ છે"
+
+#~| msgid "Imperial"
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ઇમ્પેરીઅલ"
+
+#~| msgid "Metric"
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "મેટ્રીક"
+
+#~| msgid "Move Input Source Down"
+#~ msgid "No input sources found"
+#~ msgstr "ઇનપુટ સ્ત્રોત મળ્યા નથી"
+
+#~| msgid "Other..."
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "બીજુ"
+
+#~ msgid "Sorry"
+#~ msgstr "દિલગીર છુ"
+
+#~| msgid "Ctrl+Alt+Shift+Space"
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "આગળનાં સ્ત્રોત પર જાવ"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "કિબોર્ડ સુયોજનોમાં આ ટૂંકાણોને તમે બદલી શકો છો"
+
+#~| msgid "Switch to next source"
+#~ msgid "Alternative switch to next source"
+#~ msgstr "આગળનાં સ્ત્રોત પર જાવ"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "ડાબી+જમણી Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "અંગ્રેજી (United Kingdom)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "United Kingdom"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "બધા વપરાશકર્તાઓ દ્દારા પ્રવેશ સુયોજનો વાપરેલ છે જ્યારે સિસ્ટમમાં પ્રવેશી રહ્યા છે"
+
+#~| msgid "Other..."
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "બીજુ"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#~| msgid "Select a region"
+#~ msgid "Select Location"
+#~ msgstr "સ્થાન પસંદ કરો"
+
+#~| msgid "GOK"
+#~ msgid "_OK"
+#~ msgstr "બરાબર (_O)"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "ચાલુ"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "બંધ"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#~| msgid "Enabled"
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "સક્રિય"
+
+#~| msgid "Choose a Layout"
+#~ msgid "Choose a Folder"
+#~ msgstr "ફોલ્ડર પસંદ કરો"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "ભાગીદારી માટે પસંદ થયેલ નેટવર્ક નથી"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "બ્લુટુથ ભાગીદારી બીજા બ્લુટુથ સક્રિય થયેલ ઉપકરણો સાથે ફાઇલોને વહેંચવા તમને પરવાનગી આપે છે"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "ફક્ત વિશ્ર્વાસપાત્ર ઉપકરણોમાંથી મેળવો"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "ડાઉનલોડ ફોલ્ડરમાં મળેલ ફાઇલોને સંગ્રહો"
+
+#~| msgid "Screen part:"
+#~ msgid "Screen Sharing"
+#~ msgstr "સ્ક્રીન ભાગીદારી"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "અમુક સેવાઓ નિષ્ક્રિય થયેલ છે કારણ કે નેટવર્ક પ્રવેશ નથી."
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "વ્યક્તિગત ફાઇલ ભાગીદારી તમારાં હાલના નેટવર્કને વાપરીને બીજાઓ સાથે તમારા સાર્વજનિક "
+#~ "ફોલ્ડરને વહેંચવા તમને પરવાનગી આપે છે: <a href=\"dav://%s\">dav://%s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "સુરક્ષિત શેલ આદેશની મદદથી જોડાવા માટે દૂરસ્થ વપરાશકર્તાઓને પરવાનગી આપો:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "જોવા માટે દૂરસ્થ વપરાશકર્તાઓને પરવાનગી આપો અથવા તેની સાથે જોડાઇને તમારી સ્ક્રીન પર "
+#~ "નિયંત્રણ કરો: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~| msgid "_Password"
+#~ msgid "Password:"
+#~ msgstr "પાસવર્ડ:"
+
+#~| msgid "_Show password"
+#~ msgid "Show Password"
+#~ msgstr "પાસવર્ડને બતાવો"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "નવાં જોડાણે પ્રવેશ માટે પૂછવુ જ જોઇએ"
+
+#~| msgid "Generate a password"
+#~ msgid "Require a password"
+#~ msgstr "પાસવર્ડની જરૂર છે"
+
+#~ msgid "Bark"
+#~ msgstr "બાર્ક"
+
+#~ msgid "Drip"
+#~ msgstr "ઝરમર"
+
+#~ msgid "Glass"
+#~ msgstr "ગ્લાસ"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#~ msgid "Sonar"
+#~ msgstr "સોનાર"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "ન્યૂનતમ"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "મહત્તમ"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "સબવુફર (_S):"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "અવાજ વધારો નહિં"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~ msgid "_Profile:"
+#~ msgstr "રૂપરેખા (_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "સ્પીકર ચકાસો (_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "પીક મળ્યુ"
+
+#~ msgid "Device"
+#~ msgstr "ઉપકરણ"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s માટે સ્પીકર ચકાસણી"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "સાઉન્ડ આઉટપુટ માટે ઉપકરણને પસંદ કરો (_h):"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "પસંદ થયેલ ઉપકરણ માટે સુયોજનો:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "ઇનપુટ વોલ્યુમ (_I): "
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "સાઉન્ડ ઇનપુટ માટે ઉપકરણને પસંદ કરો (_h):"
+
+#~ msgid "Sound Effects"
+#~ msgstr "સાઉન્ડ અસરો"
+
+#~ msgid "Built-in"
+#~ msgstr "બિલ્ટ-ઇન"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "સાઉન્ડ પસંદગીઓ"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ઘટના સાઉન્ડની ચકાસણી કરી રહ્યા છીએ"
+
+#~ msgid "From theme"
+#~ msgstr "થીમ માંથી"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "ચેતવણી સાઉન્ડને પસંદ કરો (_h):"
+
+#~ msgid "Stop"
+#~ msgstr "બંધ કરો"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# libgnomeprint/gpa/gpa-media.c:241
+# #-#-#-#-#  libgnomeprint.gnome-2-2.hi.po (libgnomeprint VERSION)  #-#-#-#-#
+# libgnomeprint/gpa/gpa-media.c:241
+#~ msgid "Custom"
+#~ msgstr "વૈવિધ્યપૂર્ણ"
+
+#~ msgid "Screen Reader"
+#~ msgstr "સ્ક્રીન વાંચક"
+
+#~| msgid "Screen Reader"
+#~ msgid "_Screen Reader"
+#~ msgstr "સ્ક્રીન વાંચક (_S)"
+
+#~| msgid "Bounce Keys"
+#~ msgid "Sound Keys"
+#~ msgstr "સાઉન્ડ કી"
+
+#~| msgid "Flash the window title"
+#~ msgid "Flash the _window title"
+#~ msgstr "વિન્ડો શીર્ષકપટ્ટી ઝબકાવો (_w)"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "ટુંકુ"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ સ્ક્રીન"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ સ્ક્રીન"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ સ્ક્રીન"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "લાંબુ"
+
+#~ msgid "Zoom"
+#~ msgstr "નાનુ મોટુ કરો"
+
+#~| msgid "Color"
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "રંગ"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "પ્રમાણભૂત"
+
+#~ msgid "Account _Type"
+#~ msgstr "ખાતા પ્રકાર (_T)"
+
+#~ msgid "_Verify"
+#~ msgstr "ખાતરી કરો (_V)"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "એન્ટરપ્રાઇઝ પ્રવેશ ખાતાને ઉમેરવા માટે\n"
+#~ "ઓનલાઇન થાવ."
+
+#~ msgid "Left thumb"
+#~ msgstr "થમ્ભને છોડો"
+
+#~ msgid "Left middle finger"
+#~ msgstr "ડાબી મધ્ય આંગળી"
+
+#~ msgid "Left ring finger"
+#~ msgstr "ડાબી વીંટી આંગળી"
+
+#~ msgid "Left little finger"
+#~ msgstr "ડાબી નાની આંગળી"
+
+#~ msgid "Right thumb"
+#~ msgstr "જમણું થમ્ભ"
+
+#~ msgid "Right middle finger"
+#~ msgstr "જમણી મધ્ય આંગળી"
+
+#~ msgid "Right ring finger"
+#~ msgstr "જમણી વીંટી આંગળી"
+
+#~ msgid "Right little finger"
+#~ msgstr "જમણી નાની આંગળી"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "આંગળીછાપ પ્રવેશ ને સક્રિય કરો"
+
+#~ msgid "_Right index finger"
+#~ msgstr "જમણી અનુક્રમાંક આંગળી (_R)"
+
+#~ msgid "_Left index finger"
+#~ msgstr "ડાબી અનુક્રમાંક આંગળી (_L)"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "તમારી આંગળી છાપ એ સફળતાપૂર્વક સંગ્રહ થયેલ છે. તમારે હવે તમારા આંગળી છાપ વાંચનાર ની "
+#~ "મદદથી પ્રવેશવા માટે સક્ષમ થવુ જ જોઇએ."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "પ્રવેશ;નામ;આંગળીછાપન;અવતાર;લૉગો;ચહેરો;પાસવર્ડ;"
+
+#~| msgid "Login Options"
+#~ msgid "Login History"
+#~ msgstr "પ્રવેશ ઇતિહાસ"
+
+#~| msgid "_New password"
+#~ msgid "_Verify New Password"
+#~ msgstr "નવાં પાસવર્ડની ખાતરી કરો (_V)"
+
+#~ msgid "Add User Account"
+#~ msgstr "વપરાશકર્તા ખાતુ ઉમેરો"
+
+#~ msgid "Remove User Account"
+#~ msgstr "વપરાશકર્તા ખાતુ દૂર કરો"
+
+#~ msgid "User Icon"
+#~ msgstr "વપરાશકર્તા ચિહ્ન"
+
+#~| msgid "A_utomatic Login"
+#~ msgid "Last Login"
+#~ msgstr "છેલ્લો પ્રવેશ"
+
+#~| msgid "The new password does not contain enough different characters"
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "નવો પાસવર્ડ જૂનાંથી અલગ હોવો જરૂરી છે."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "અમુક અક્ષરો અને આંકડાને બદલવાનો પ્રયત્ન કરો."
+
+#~| msgid "Changing password for"
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "પાસવર્ડને થોડો વધારે બદલવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "તમારાં વપરાશકર્તા નામ વગર પાસવર્ડ મજબૂત હશે."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "પાસવર્ડમાં તમારા નામને અવગણવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "પાસવર્ડમાં સમાવેલ શબ્દોનાં અમુકને અવગણવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "સામાન્ય શબ્દોને અવગણવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "હાલનાં શબ્દોને પુન:ક્રમાંક અવગણવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "વધારે નંબરોને વાપરવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "વધારે મોટા અક્ષરો વાપરવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "વધારે નાનાં અક્ષરો વાપરવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "ખાસ અક્ષરો, જેમ કે વિરામચિહ્ન વધારે વાપરવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "અક્ષરો, નંબરો અને વિરામચિહ્નોનું મિશ્રણને વાપરવા માટે પ્રયતન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "વારંવાર આવતા એજ અક્ષરને અવગણવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "વારંવાર વપરાતા એજ પ્રકારનાં અક્ષરને અવગણવાનો પ્રયત્ન કરો: તમે અક્ષરો, નંબરો અને "
+#~ "વિરામચિહ્નનોનાં મિશ્રણની જરૂર છે."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "શ્રેણી જેમ કે 1234 અથવા abcd ને અવગણવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "વધારે અક્ષરો, આંકડા અને સંકેતોને ઉમેરવાનો પ્રયત્ન કરો."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr "મોટા અક્ષર અને નાનાં અક્ષરને મિશ્રિત કરો અને આંકડા અથવા બેને વાપરો."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr "સરસ પાસવર્ડ! વધારે અક્ષરો, આંકડા અને વિરામચિહ્ન એ તેને મજબૂત બનાવશે."
+
+#~| msgid "Strength"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "મજબૂતાઇ: નબળી"
+
+#~| msgid "Strength"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "મજબૂતાઇ: ઓછી"
+
+#~| msgid "Strength"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "મજબૂતાઇ: મધ્યમ"
+
+#~| msgid "Strength"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "મજબૂતાઇ: સરસ"
+
+#~| msgid "Strength"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "મજબૂતાઇ: વધારે"
+
+#~ msgid "Authentication failed"
+#~ msgstr "સત્તાધિકરણ નિષ્ફળ"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "નવો પાસવર્ડ ઘણો ટૂંકો છે"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "નવો પાસવર્ડ ઘણો સરળ છે"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "જૂના અને નવા પાસવર્ડો એકદમ સરખા છે"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "નવો પાસવર્ડ પહેલેથી જ તાજેતરમાં વાપરી દેવાયો છે."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "નવો પાસવર્ડ આંકડા અને વિશિષ્ટ અક્ષરો સમાવતો હોવો જ જોઈએ."
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "જૂના અને નવા પાસવર્ડો સરખા છે"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "તમારો પાસવર્ડ બદલાઈ ગયેલ છે કારણ કે તમે શરૂઆતમાં સત્તાધિકારીત થઈ ગયેલ છે!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "નવો પાસવર્ડ પૂરતા વિવિધ અક્ષરોને સમાવતુ નથી"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "અજ્ઞાત ભૂલ"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "તમારાં ખાતા પ્રદાતાનાં વેબ સરનામાં સાથે બંધબેસતુ હોવુ જોઇએ."
+
+#~ msgid "Failed to add account"
+#~ msgstr "ખાતાને ઉમેરવામાં નિષ્ફળ"
+
+#~| msgid "Passwords do not match"
+#~ msgid "Passwords do not match."
+#~ msgstr "પાસવર્ડ બંધબેસતો નથી."
+
+#~ msgid "Failed to register account"
+#~ msgstr "ખાતાને રજીસ્ટર કરવામાં નિષ્ફળ"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "આ ડોમેઇન સાથે આ રીતે સત્તાધિકરણ કરવાનું આધારભૂત નથી"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "ડોમેઇન સાથે જોડાવામાં નિષ્ફળ"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "તે પ્રવેશ નામ કામ કરતુ ન હતુ.\n"
+#~ "મહેરબાની કરીને ફરી પ્રયત્ન કરો."
+
+#~| msgid "Invalid password, please try again"
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "તે પ્રવેશ પાસવર્ડ કામ કરતુ ન હતુ.\n"
+#~ "મહેરબાની કરીને ફરી પ્રયત્ન કરો."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "ડોમેઇનમાં પ્રવેશ કરવામાં નિષ્ફળતા"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "ડોમેઇનને શોધવાનું અસમર્થ. કદાચ તમે તેની જોડણી ખોટી કરી છે?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "તમને ઉપકરણ ને દાખલ કરવા માટે પરવાનગી આપેલ નથી. તમારા સિસ્ટમ વહીવટકર્તાને સંપર્ક "
+#~ "કરો."
+
+#~ msgid "The device is already in use."
+#~ msgstr "ઉપકરણ એ પહેલેથી વપરાશમાં છે."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "આંતરિક ભૂલ ઉદ્દભવી હતી."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "રજીસ્ટર થયેલ આંગળીની છાપો ને કાઢી નાંખો?"
+
+#~ msgid "Done!"
+#~ msgstr "પૂરુ થઇ ગયુ!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' ઉપકરણ ને દાખલ કરી શકાયો નહિં"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' ઉપકરણ પર આંગળીને પકડવાનું શરૂ કરી શકાયુ નહિં"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "કોઇપણ આંગળીછાપ વાંચનાર ને દાખલ કરી શકાયુ નહિં"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "મહેરબાની કરીને મદદ માટે તમારા સિસ્ટમ વહીવટકર્તા ને સંપર્ક કરો."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "આંગળી છાપ દાખલ કરવાનું સક્રિય કરવા માટે, તમારે તમારા આંગળી છાપોનાં એક ને સંગ્રહ "
+#~ "કરવાની જરૂર પડશે, '%s' ઉપકરણની મદદથી."
+
+#~ msgid "Selecting finger"
+#~ msgstr "આંગળી પસંદ કરી રહ્યા છે"
+
+#~ msgid "This Week"
+#~ msgstr "આ અઠવાડિયે"
+
+#~| msgid "Last used"
+#~ msgid "Last Week"
+#~ msgstr "છેલ્લા અઠવાડિયે"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "સત્રનો અંત આવ્યો"
+
+#~ msgid "Session Started"
+#~ msgstr "સત્ર શરૂ થઇ ગયું"
+
+#~ msgid "Please choose another password."
+#~ msgstr "મહેરબાની કરીને બીજા પાસવર્ડને પસંદ કરો."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "મહેરબાની કરીને ફરીથી તમારા હાલના પાસવર્ડને લખો."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "પાસવર્ડને બદલી શક્યા નહિં"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#~ msgid "Disable image"
+#~ msgstr "ઇમેજને નિષ્ક્રિય કરો"
+
+#~| msgid "Take a photo..."
+#~ msgid "Take a photo…"
+#~ msgstr "ફોટો લો..."
+
+#~| msgid "Browse for more pictures"
+#~ msgid "Browse for more pictures…"
+#~ msgstr "વધારે ચિત્રો માટે બ્રાઉઝ કરો..."
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s દ્દારા વપરાયેલ છે"
+
+#~| msgid "Cannot remove automatically added profile"
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "આપમેળે ઉમેરાયેલ રૂપરેખાને દૂર કરી શકાતુ નથી"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "આવુ કોઈ ડોમેઈન અથવા ક્ષેત્ર મળ્યુ નથી"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s ડોમેઇન પર %s તરીકે પ્રવેશી શકાતુ નથી"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "અયોગ્ય પાસવર્ડ, મહેરબાની કરીને ફરી પ્રયત્ન કરો"
+
+#~ msgid "Other Accounts"
+#~ msgstr "બીજા ખાતાઓ"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "વપરાશકર્તાને કાઢી નાખતી વખતે નિષ્ફળતા"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "તમે તમારા પોતાના ખાતાને કાઢી શકતા નથી."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s હજુ પ્રવેશેલ છે"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "વપરાશકર્તાને કાઢી રહ્યા છે જ્યારે તેઓ પ્રવેશેલ છે કે જે અસ્થાયી સ્થિતિમાં સિસ્ટમને છોડી શકે "
+#~ "છે."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "શું તમે %s ની ફાઇલોને રાખવા માંગો છો?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "તેની આજુબાજુ ઘર ડિરેક્ટરી, મેઇલ સ્પુલ અને કામચલાઉ ફાઇલોને રાખવાનું શક્ય છે જ્યારે "
+#~ "વપરાશકર્તા ખાતાને કાઢી રહ્યા હોય."
+
+#~ msgid "_Delete Files"
+#~ msgstr "ફાઇલોને કાઢી નાંખો (_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "ફાઇલોને રાખો (_K)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "નિષ્ક્રિય થયેલ ખાતુ"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "આગળનાં પ્રવેશે સુયોજિત કરવા માટે"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "કઈ નહિં"
+
+#~ msgid "Logged in"
+#~ msgstr "પ્રવેશેલ છે"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "ખાતા સેવાને સંપર્ક કરવામાં નિષ્ફળ"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "મહેરબાની કરીને ખાતરી કરો કે AccountService એ સ્થાપિત અને સક્રિય થયેલ છે."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ફેરફારો કરવા માટે,\n"
+#~ "પહેલાં * ચિહ્ન પર ક્લિક કરો"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "વપરાશકર્તા ખાતાને બનાવવા માટે,\n"
+#~ "પહેલાં * ચિહ્ન પર ક્લિક કરો"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "પસંદ થયેલ વપરાશકર્તા ખાતાને કાઢી નાંખો"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "પસંદ થયેલ વપરાશકર્તા ખાતાને કાઢી નાંખવા માટે,\n"
+#~ "પહેલાં * ચિહ્ન પર ક્લિક કરો"
+
+#, c-format
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "વપરાશકર્તાનામ '%s' સાથે વપરાશકર્તા પહેલેથી જ અસ્તિત્વ ધરાવે છે."
+
+#, c-format
+#~| msgid "The username is too long"
+#~ msgid "The username is too long."
+#~ msgstr "વપરાશકર્તાનામ ઘણુ લાંબુ છે."
+
+#~| msgid "The username cannot start with a '-'"
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "વપરાશકર્તાનામ '-' સાથે શરૂ કરી શકાતુ નથી."
+
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "વપરાશકર્તા ફક્ત a-z, આંકડા અને કોઇપણ અક્ષરો '.', '-' અને '_' માંથી નાનાં અને મોટા "
+#~ "અક્ષરોને સમાવવા જોઇએ."
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr "આ તમારા ઘર ફોલ્ડરનાં નામ માટે વપરાશે અને બદલી શકાતુ નથી."
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~| msgid "Up"
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "ઉપર"
+
+#~| msgid "Down"
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "નીચે"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "કંઈ નહિં"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "કીસ્ટ્રોકને મોકલો"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "મોનિટર બદલો"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "ઑન-સ્ક્રીન મદદ બતાવો"
+
+#~ msgid "Output:"
+#~ msgstr "આઉટપુટ:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "સાપેક્ષ ગુણોત્તર રાખો (લેટરબોક્સ):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "એકજ મોનિટરનું માપ લો"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d નું %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "માપન દર્શાવો"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "ટૅબલેટ (સંપૂર્ણ)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "ટૅબલેટ પસંદગીઓ"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth સુયોજનો"
+
+#~| msgid "Map Buttons"
+#~ msgid "Map Buttons…"
+#~ msgstr "માપન બટનો…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "દર્શાવ રિઝોલ્યુશનને ગોઠવો"
+
+#~| msgid "Mouse Settings"
+#~ msgid "Adjust mouse settings"
+#~ msgstr "માઉસ સુયોજનોને ગોઠવો"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ટ્રેકિંગ સ્થિતિ"
+
+#~| msgid "Left Ring Mode #%d"
+#~ msgid "Left Ring"
+#~ msgstr "ડાબી રીંગ"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "ડાબી રીંગ સ્થિતિ #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "જમણી રીંગ સ્થિતિ #%d"
+
+#~| msgid "Left Touchstrip Mode #%d"
+#~ msgid "Left Touchstrip"
+#~ msgstr "ડાબુ ટચસ્ટ્રીપ"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "ડાબી ટચસ્ટ્રીપ સ્થિતિ #%d"
+
+#~| msgid "Right Touchstrip Mode #%d"
+#~ msgid "Right Touchstrip"
+#~ msgstr "જમણી ટચસ્ટ્રીપ"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "જમણી ટચસ્ટ્રીપ સ્થિતિ #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "ડાબુ ટચરીંગ મોડ સ્વીચ"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "જમણી ટચરીંગ મોડ સ્વીચ"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "ડાબી ટચસ્ટ્રીપ મોડ સ્વીચ"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "જમણી ટચસ્ટ્રીપ મોડ સ્વીચ"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "મોડ સ્વીચ #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "ડાબુ બટન #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "જમણુ બટન #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "ટોચનુ બટન #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "નીચેનું બટન #%d"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#~ msgid "No Action"
+#~ msgstr "ક્રિયા નથી"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "ડાબુ માઉસ બટન ક્લિક"
+
+#~ msgid "Scroll Up"
+#~ msgstr "ઉપર સ્ક્રોલ કરો"
+
+#~ msgid "Scroll Right"
+#~ msgstr "જમણે સ્ક્રોલ કરો"
+
+#~ msgid "Top Button"
+#~ msgstr "ટોચનુ બટન"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "વર્બોસ સ્થિતિ સક્રિય કરો"
+
+#~ msgid "Show the overview"
+#~ msgstr "ઝાંખી બતાવો"
+
+#~ msgid "Search for the string"
+#~ msgstr "શબ્દમાળા માટે શોધો"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "શક્ય પેનલ નામોની યાદી કરો અને બહાર નીકળો"
+
+#~ msgid "Show help options"
+#~ msgstr "મદદ વિકલ્પો બતાવો"
+
+#~ msgid "Panel to display"
+#~ msgstr "દર્શાવવા માટે પેનલ"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~| msgid "All Settings"
+#~ msgid "- Settings"
+#~ msgstr "- સુયોજનો"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "ઉપલબ્ધ આદેશ વાક્ય વિકલ્પોની સંપૂર્ણ યાદીને જોવા માટે  '%s --help' ચલાવો.\n"
+
+#~| msgid "Available Profiles"
+#~ msgid "Available panels:"
+#~ msgstr "ઉપલબ્ધ પેનલો:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "વ્યક્તિગત"
+
+#~| msgid "Hardware"
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "હાર્ડવેર"
+
+#~| msgid "System"
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "સિસ્ટમ"
 
 #~ msgid "Change the background"
 #~ msgstr "પાશ્વભાગને બદલો"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "બ્લુટુથ સુયોજનોને રૂપરેખાંકિત કરો"
-
 #~ msgid "Set Up New Device"
 #~ msgstr "નવાં ઉપકરણને સુયોજિત કરો"
-
-#~ msgid "Connection"
-#~ msgstr "જોડાણ"
 
 #~ msgid "Paired"
 #~ msgstr "જોડી"
 
-#~ msgid "Type"
-#~ msgstr "પ્રકાર"
-
 #~ msgid "Mouse and Touchpad Settings"
 #~ msgstr "માઉસ અને ટચપેડ સુયોજનો"
-
-#~ msgid "Sound Settings"
-#~ msgstr "સાઉન્ડ સુયોજનો"
 
 #~ msgid "Send Files..."
 #~ msgstr "ફાઇલો મોકલો..."
@@ -7566,9 +8398,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "Bluetooth"
 #~ msgstr "બ્લુટુથ"
 
-#~ msgid "Visibility"
-#~ msgstr "દૃશ્યતા"
-
 #~ msgid "Visibility of “%s”"
 #~ msgstr "“%s” ની દૃશ્યતા"
 
@@ -7579,9 +8408,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ "If you remove the device, you will have to set it up again before next "
 #~ "use."
 #~ msgstr "જો તમે ઉપકરણને દૂક કરો તો, તમારે આગળનાં વપરાશ પહેલાં ફરી સુયોજિત કરવુ જ પડશે."
-
-#~ msgid "Create virtual device"
-#~ msgstr "વર્ચ્યુઅલ ઉપકરણને બનાવો"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "દર્શાવો માટે ઉપલબ્ધ રૂપરેખાઓ"
@@ -7685,23 +8511,11 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "Unspecified"
 #~ msgstr "સ્પષ્ટ થયેલ નથી"
 
-#~ msgid "Select a language"
-#~ msgstr "ભાષા પસંદ કરો"
-
-#~ msgid "_Select"
-#~ msgstr "પસંદ કરો (_S)"
-
 #~ msgid "_Region:"
 #~ msgstr "વિસ્તાર (_R):"
 
 #~ msgid "_City:"
 #~ msgstr "શહેર (_C):"
-
-#~ msgid "_Network Time"
-#~ msgstr "નેટવર્ક સમય (_N)"
-
-#~ msgid ":"
-#~ msgstr ":"
 
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "એક કલાક આગળ સમયને સુયોજિત કરો."
@@ -7743,9 +8557,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "%d x %d"
 #~ msgstr "%d x %d"
 
-#~ msgid "Drag to change primary display."
-#~ msgstr "પ્રાથમિક દર્શાવને બદલવા ખેંચો."
-
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
 #~ "placement."
@@ -7773,9 +8584,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "નોંધ: રિઝોલ્યુશન વિકલ્પો પર મર્યાદા આવી શકે છે"
 
-#~ msgid "_Detect Displays"
-#~ msgstr "દર્શાવોને શોધો (_D)"
-
 #~ msgid "VESA: %s"
 #~ msgstr "VESA: %s"
 
@@ -7788,9 +8596,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgctxt "Experience"
 #~ msgid "Fallback"
 #~ msgstr "ફોલબૅક"
-
-#~ msgid "Install Updates"
-#~ msgstr "સુધારા સ્થાપિત કરો"
 
 #~ msgid "System Up-To-Date"
 #~ msgstr "સિસ્ટમ અદ્યતન"
@@ -7818,9 +8623,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 
 #~ msgid "Set your mouse and touchpad preferences"
 #~ msgstr "તમારુ માઉસ અને ટચપેડ પસંદગીઓને સુયોજિત કરો"
-
-#~ msgid "Network settings"
-#~ msgstr "નેટવર્ક સુયોજનો"
 
 #~ msgid "Network;Wireless;IP;LAN;Proxy;"
 #~ msgstr "નેટવર્ક;વાયરલેસ;IP;LAN;પ્રોક્સી;"
@@ -7930,9 +8732,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "Paused"
 #~ msgstr "અટકેલ"
 
-#~ msgid "Change printer settings"
-#~ msgstr "પ્રિન્ટર સુયોજનોને બદલો"
-
 #~ msgid "Manufacturers"
 #~ msgstr "ઉત્પાદક"
 
@@ -7973,9 +8772,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "Remove Language"
 #~ msgstr "ભાષા દૂર કરો"
 
-#~ msgid "Install languages..."
-#~ msgstr "ભાષાઓને સ્થાપિત કરો..."
-
 #~ msgid "Select a region (change will be applied the next time you log in)"
 #~ msgstr "વિસ્તારને પસંદ કરો (બદલાવ પછી તમે ફરી પ્રવેશશો ત્યારે લાગુ થશે)"
 
@@ -7996,9 +8792,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 
 #~ msgid "Move Input Source Up"
 #~ msgstr "ઇનપુટ સ્ત્રોતને ઉપર ખસેડો "
-
-#~ msgid "Show Keyboard Layout"
-#~ msgstr "કીબોર્ડ લેઆઉટને બતાવો"
 
 #~ msgid "Ctrl+Alt+Space"
 #~ msgstr "Ctrl+Alt+Space"
@@ -8025,9 +8818,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "Brightness & Lock"
 #~ msgstr "પ્રકાશતા અને તાળુ"
 
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "સ્ક્રીન તેજસ્વિતા અને તાળા સુયોજનો"
-
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "પ્રકાશતા;તાળુ;ઝાંખી;ખાલી;મોનિટર;"
 
@@ -8039,9 +8829,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 
 #~ msgid "Locations..."
 #~ msgstr "સ્થાનો..."
-
-#~ msgid "Lock"
-#~ msgstr "તાળુ મારો"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "ડિબગીંગ સ્થિતિ સક્રિય કરો"
@@ -8057,9 +8844,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 
 #~ msgid "Sound Output Volume"
 #~ msgstr "સાઉન્ડ આઉટપુટ વોલ્યુમ"
-
-#~ msgid "Microphone Volume"
-#~ msgstr "માઇક્રોફોન વોલ્યુમ"
 
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "સાઉન્ડ પસંદગીઓને શરૂ કરવામાં નિષ્ફળતા: %s"
@@ -8178,9 +8962,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "None"
 #~ msgstr "કંઈ નહિં"
 
-#~ msgid "Add account"
-#~ msgstr "ખાતુ ઉમેરો"
-
 #~ msgid "_Local Account"
 #~ msgstr "સ્થાનિક ખાતુ (_L)"
 
@@ -8205,9 +8986,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~| msgid "C_ity:"
 #~ msgid "_Hint"
 #~ msgstr "ઇશારો (_H)"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "પાસવર્ડની ખાતરી કરો (_o)"
 
 #~| msgid "Filter"
 #~ msgid "Fair"
@@ -8350,9 +9128,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "Take a screenshot"
 #~ msgstr "સ્ક્રીનશોટ લો"
 
-#~ msgid "Shortcut"
-#~ msgstr "ટુંકાણ"
-
 #~ msgid "_Right-handed"
 #~ msgstr "જમણા-હાથવાળી (_R)"
 
@@ -8361,10 +9136,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 
 #~ msgid "Sh_ow position of pointer when the Control key is pressed"
 #~ msgstr "જ્યારે Control કી દબાયેલ હોય ત્યારે પોઇંટરની જગ્યાને બતાવો"
-
-#~| msgid "_Acceleration:"
-#~ msgid "A_cceleration:"
-#~ msgstr "પ્રવેગ (_c):"
 
 #~ msgid "_Sensitivity:"
 #~ msgstr "ચેતના (_S):"
@@ -8380,9 +9151,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "Drag Threshold"
 #~ msgstr "થ્રેશોલ્ડ (_e):"
 
-#~ msgid "Double-Click Timeout"
-#~ msgstr "બે ક્લિકની સમયસમાપ્તિ"
-
 #~ msgid "_Timeout:"
 #~ msgstr "સમય સમાપ્ત (_T):"
 
@@ -8395,9 +9163,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "ટચપેડ સાથે માઉસ ક્લિકોને સક્રિય કરો (_m)"
-
-#~ msgid "Scrolling"
-#~ msgstr "સ્ક્રોલ કરી રહ્યા છે"
 
 # #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
 # gtk/gtkinputdialog.c:238
@@ -8446,9 +9211,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "Brightness Settings"
 #~ msgstr "પ્રકાશતા"
 
-#~ msgid "_Search by Address"
-#~ msgstr "સરનામાં પ્રમાણે શોધો (_S)"
-
 #~ msgctxt "printer type"
 #~ msgid "Local"
 #~ msgstr "સ્થાનિક"
@@ -8456,9 +9218,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgctxt "printer type"
 #~ msgid "Network"
 #~ msgstr "નેટવર્ક"
-
-#~ msgid "Device types"
-#~ msgstr "ઉપકરણ પ્રકારો"
 
 #~ msgid "Automatic configuration"
 #~ msgstr "આપમેળે રૂપરેખાંકન"
@@ -8474,11 +9233,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 
 #~ msgid "_Back"
 #~ msgstr "પાછળ (_B)"
-
-#, fuzzy
-#~| msgid "Remove wallpaper"
-#~ msgid "Remove User"
-#~ msgstr "વોલપેપર દૂર કરો"
 
 #~ msgid "Allowed users"
 #~ msgstr "પરવાનગી આપેવ વપરાશકર્તાઓ"
@@ -8506,9 +9260,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "View and edit keyboard layout options"
 #~ msgstr "કિબોર્ડ લેઆઉટ વિકલ્પોમાં ફેરફાર કરો અને દર્શાવો"
 
-#~ msgid "Reset to De_faults"
-#~ msgstr "મૂળભૂતોમાં પુનઃસુયોજિત કરો (_f)"
-
 #~ msgid ""
 #~ "Replace the current keyboard layout settings with the\n"
 #~ "default settings"
@@ -8516,12 +9267,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 
 #~ msgid "Layouts"
 #~ msgstr "દેખાવો"
-
-#~ msgid "Layout"
-#~ msgstr "દેખાવ"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "રૂપરેખાંકિત કરવા માટે ઉપકરણને પસંદ કરો (_h):"
 
 #~ msgid "Dasher"
 #~ msgstr "ડેશર"
@@ -8538,12 +9283,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 
 #~ msgid "_Text size:"
 #~ msgstr "લખાણ માપ (_T):"
-
-#~ msgid "Increase size:"
-#~ msgstr "માપ વધારો:"
-
-#~ msgid "Decrease size:"
-#~ msgstr "માપને ઘટાડો:"
 
 #~ msgctxt "universal access, seeing"
 #~ msgid "Display"
@@ -8574,12 +9313,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 # libgnomeui/gnome-app-helper.c:166
 #~ msgid "Cr_eate"
 #~ msgstr "બનાવો (_e)"
-
-#~ msgid "Choose a generated password"
-#~ msgstr "ઉત્પન્ન થયેલ પાસવર્ડને પસંદ કરો"
-
-#~ msgid "Account _type"
-#~ msgstr "ખાતા પ્રકાર (_t)"
 
 #~ msgid "More choices..."
 #~ msgstr "વધારે પસંદગીઓ..."
@@ -8634,12 +9367,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgid "cd;dvd;usb;audio;video;disc;"
 #~ msgstr "cd;dvd;usb;ઓડિયો;વિડિયો;ડિસ્ક;"
 
-#~ msgid "Speed"
-#~ msgstr "ઝડપ"
-
-#~ msgid "Unlock"
-#~ msgstr "તાળુ ખોલો"
-
 #~ msgid "Ask me"
 #~ msgstr "મને પૂછો"
 
@@ -8658,9 +9385,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~| msgid "Turn off after:"
 #~ msgid "_Turn off after:"
 #~ msgstr "પછી બંધ કરો:"
-
-#~ msgid "Mute"
-#~ msgstr "મૂંગુ"
 
 #~ msgid "Key"
 #~ msgstr "કી"
@@ -8776,9 +9500,6 @@ msgstr "પસંદગીઓ;સુયોજનો;"
 #~ msgstr ""
 #~ "ક્યાં વધારે ડેસ્કટોપ થીમો મળે છે તે માટે URL. જો ખાલી શબ્દમાળા માટે સુયોજિત હોય તો "
 #~ "કડી દેખાશે."
-
-#~ msgid "Locked"
-#~ msgstr "તાળુ મારેલ"
 
 #~ msgid ""
 #~ "Dialog is unlocked.\n"

--- a/po/gu.po~
+++ b/po/gu.po~
@@ -1,0 +1,8867 @@
+# translation of gnome-control-center.master.gu.po to Gujarati
+# Ankit Patel <ankit644@yahoo.com>, 2005, 2006.
+# Ankit Patel <ankit@redhat.com>, 2006, 2007, 2009.
+# Sweta Kothari <swkothar@redhat.com>, 2008, 2009, 2010, 2011, 2012, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.master.gu\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug."
+"cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-08-27 06:31+0000\n"
+"PO-Revision-Date: 2014-09-22 11:54+0530\n"
+"Last-Translator: \n"
+"Language-Team: American English <kde-i18n-doc@kde.org>\n"
+"Language: gu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "પાશ્વ ભાગ"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "દિવસ દરમ્યામ બદલે છે"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+#| msgid "Lock screen"
+msgid "Lock Screen"
+msgstr "સ્ક્રીનને તાળુ મારો"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "તકતી"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "નાનુ મોટુ કરો"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "કેન્દ્ર"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "માપ"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "ભરો"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "સ્પાન"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:442
+msgid "Select Background"
+msgstr "પાશ્વભાગ પસંદ કરો"
+
+#: ../panels/background/cc-background-chooser-dialog.c:463
+msgid "Wallpapers"
+msgstr "વોલપેપરો"
+
+#: ../panels/background/cc-background-chooser-dialog.c:472
+msgid "Pictures"
+msgstr "ચિત્રો"
+
+#: ../panels/background/cc-background-chooser-dialog.c:481
+msgid "Colors"
+msgstr "રંગો"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:540
+#| msgid "Pictures Folder"
+msgid "No Pictures Found"
+msgstr "ચિત્ર મળ્યા નથી"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:558
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "ઘર"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:570
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "તમે તમારાં %s ફોલ્ડરમાં ઇમેજોને ઉમેરી શકો છો અને તેઓ અહિંયા બતાવશે"
+
+#: ../panels/background/cc-background-chooser-dialog.c:592
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1537
+#: ../panels/display/cc-display-panel.c:1976
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1240
+#: ../panels/network/net-device-wifi.c:1448
+#: ../panels/printers/cc-printers-panel.c:1947
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+#: ../panels/user-accounts/um-photo-dialog.c:95
+#: ../panels/user-accounts/um-photo-dialog.c:222
+#: ../panels/user-accounts/um-user-panel.c:513
+msgid "_Cancel"
+msgstr "રદ કરો (_C)"
+
+#: ../panels/background/cc-background-chooser-dialog.c:593
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:97
+msgid "Select"
+msgstr "પસંદ કરો"
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "ઘણાબધા માપો"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "ડેસ્કટોપ પાશ્વ ભાગ નથી"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "હાલનાં પાશ્ર્વભાગો"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "વોલપેપર અથવા ફોટોમાં તમારાં ઇમેજનાં પાશ્ર્વભાગને બદલો"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "વોલપેપર;સ્ક્રીન;ડેસ્કટોપ;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "બ્લુટુથ નિષ્ક્રિય થયેલ છે"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "બ્લુટુથ ઍડપ્ટર મળ્યુ નથી"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "હાર્ડવેર સ્વીચ દ્દારા બ્લુટુથ નિષ્ક્રિય થયેલ છે"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+msgid "Bluetooth"
+msgstr "બ્લુટુથ"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "બ્લુટુથને ચાલુ અને બંધ કરો અને તમારાં ઉપકરણો સાથે જોડાવો"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "ચોરસ પર તમારું માપદંડ ઉપકરણને સ્થિત કરો અને 'શરૂ કરો' બટન દબાવો"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid "Move your calibration device to the calibrate position and press 'Continue'"
+msgstr "સ્થાનને માપન કરવા માટે તમારું માપદંડ ઉપકરણને ખસાડો અને 'ચાલુ રાખો' બટન દબાવો"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid "Move your calibration device to the surface position and press 'Continue'"
+msgstr "સપાટ સ્થાન માટે તમારાં માપદંડ ઉપકરણને ખસેજો અને 'ચાલુ રાખો' બટનને દબાવો"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "લૅપટોપ lid ને બંધ કરો"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+#| msgid "An internal error occurred."
+msgid "An internal error occurred that could not be recovered."
+msgstr "આંતરિક ભૂલ ઉદ્દભવી કે જે પ્રાપ્ત કરી શક્યા નહિં."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "કેલિબ્રેશન માટે જરૂરી સાધનો સ્થાપિત થયેલ નથી."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "રૂપરેખાને બનાવી શક્યા નહિં."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "લક્ષ્ય સફેદબિંદુને પ્રાપ્ત કરી શકાય તેમ નથી."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+#| msgctxt "print job"
+#| msgid "Completed"
+msgid "Complete!"
+msgstr "સમાપ્ત!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+#| msgid "Configuration failed"
+msgid "Calibration failed!"
+msgstr "માપદંડ નિષ્ફળ!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "તમે કેલિબ્રેશન ઉપકરણને દૂર કરી શકો છો."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "કેલિબ્રેશન ઉપકરણને ખલેલ પહોંચાડો નહિં જ્યાપે પ્રગતિમાં હોય"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+#| msgid "Lock screen"
+msgid "Laptop Screen"
+msgstr "લૅપટોપ સ્ક્રીન"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+#| msgid "Built-in"
+msgid "Built-in Webcam"
+msgstr "બિલ્ટ-ઇન વેબકેમ"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+#| msgid "Monitor"
+msgid "%s Monitor"
+msgstr "%s મોનિટર"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+#| msgctxt "Device kind"
+#| msgid "Scanner"
+msgid "%s Scanner"
+msgstr "%s સ્કેનર"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+#| msgctxt "Device kind"
+#| msgid "Camera"
+msgid "%s Camera"
+msgstr "%s કેમેરા"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+#| msgctxt "Device kind"
+#| msgid "Printer"
+msgid "%s Printer"
+msgstr "%s પ્રિન્ટર"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+#| msgctxt "Device kind"
+#| msgid "Webcam"
+msgid "%s Webcam"
+msgstr "%s વેબકેમ"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+#| msgid "Learn more about color management"
+msgid "Enable color management for %s"
+msgstr "%s માટે રંગ સંચાલનને સક્રિય કરો"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s માટે રંગ રૂપરેખાને બતાવો"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+#| msgid "Uncalibrated"
+msgid "Not calibrated"
+msgstr "માપદંડ થયેલ નથી"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "મૂળભૂત: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "રંગસ્થાન: "
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "રૂપરેખા ચકાસો: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "ICC રૂપરેખા ફાઇલ પસંદ કરો"
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "આયાત કરો (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "આધારભૂત ICC રૂપરેખાઓ"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "બધી ફાઇલો"
+
+#: ../panels/color/cc-color-panel.c:582
+#| msgctxt "Distance"
+#| msgid "¼ Screen"
+msgid "Screen"
+msgstr "સ્ક્રીન"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+#| msgid "Failed to apply configuration: %s"
+msgid "Failed to upload file: %s"
+msgstr "ફાઇલને અપલોડ કરવામાં નિષ્ફળતા: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "રૂપરેખા તેમાં સુધારી દેવામાં આવી છે:"
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "આ URL ને લખો."
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr "આ કમ્પ્યૂટરને ફરી શરૂ કરો અને તમારી સામાન્ય ઓપરેટીંગ સિસ્ટમને બુટ કરો."
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "ડાઉનલોડ કરવા માટે તમારાં બ્રાઉઝરમાં URL ને ટાઇપ કરો અને રૂપરેખાને સ્થાપિત કરો."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+#| msgid "Remove profile"
+msgid "Save Profile"
+msgstr "પ્રોફાઇલને સંગ્રહ કરો"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "સંગ્રહો (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "પસંદ થયેલ ઉપકરણ માટે રંગ રૂપરેખા બનાવો:"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"માપન સાધન મળતુ નથી. મહેરબાની કરીને ચકાસો કે તે ચાલુ છે કે નહિં અને યોગ્ય રીતે જોડાયેલ છે."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "માપન સાધન પ્રિન્ટર રૂપરેખાને આધાર આપતુ નથી."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "ઉપકરણ પ્રકાર હાલમાં આધારભૂત નથી."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+#| msgctxt "Experience"
+#| msgid "Standard"
+msgid "Standard Space"
+msgstr "મૂળભૂત જગ્યા"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+#| msgid "Test profile: "
+msgid "Test Profile"
+msgstr "રૂપરેખા ચકાસો"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+#| msgctxt "proxy method"
+#| msgid "Automatic"
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "સ્વયં"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+#| msgctxt "Printer Option Group"
+#| msgid "Image Quality"
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "નીચી ગુણવત્તા"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+#| msgctxt "Printer Option Group"
+#| msgid "Image Quality"
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "મધ્યમ ગુણવત્તા"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+#| msgctxt "Printer Option Group"
+#| msgid "Image Quality"
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "ઉચ્ચ ગુણવત્તા"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "મૂળભૂત RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "મૂળભૂત CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "મૂળભૂત ગ્રે"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "વિક્રેતા ફેક્ટરી માપદંડ માહિતીને પૂરુ પાડે છે"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "સંપૂર્ણ-સ્ક્રીન દર્શાવ સુધારો આ રૂપરેખા સાથે શક્ય નથી"
+
+#: ../panels/color/cc-color-profile.c:225
+#| msgid "This device has an old profile that may no longer be accurate."
+msgid "This profile may no longer be accurate"
+msgstr "આ રૂપરેખા લાંબા સમય સુધી ચોક્કસ રહી શકતી નથી"
+
+#: ../panels/color/color-calibrate.ui.h:1
+#| msgid "Calibration"
+msgid "Display Calibration"
+msgstr "કેલિબ્રેશન દર્શાવો"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr "રદ કરો"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "શરૂ કરો"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "ફરી શરૂ કરો"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+#| msgid "Done!"
+msgid "Done"
+msgstr "પૂર્ણ"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "સ્ક્રીન માપાંકન"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"માપદંડ રૂપરેખાને પેદા કરશે કે જે રંગ સંચાલિત તમારી સ્ક્રીનને વાપરી શકો છો. માપદંડ પર લાંબો સમય "
+"વિતાવી શકો છો, રંગ રૂપરેખાની ગુણવત્તાને સારી બનાવવા."
+
+#: ../panels/color/color.ui.h:3
+msgid "You will not be able to use your computer while calibration takes place."
+msgstr "તમે તમારું કમ્પ્યૂટર વાપરી શકશો નહિં જ્યારે માપદંડ થતુ હોય."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+#| msgctxt "Printer Option Group"
+#| msgid "Image Quality"
+msgid "Quality"
+msgstr "ગુણવત્તા"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "આશરે સમય"
+
+#: ../panels/color/color.ui.h:8
+#| msgid "Calibration"
+msgid "Calibration Quality"
+msgstr "કેલિબ્રેશન ગુણવત્તા"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "સેન્સર ઉપકરણને પસંદ કરો તમે કેલિબ્રેશન માટે વાપરવા માંગો તો."
+
+#: ../panels/color/color.ui.h:10
+#| msgid "Calibration"
+msgid "Calibration Device"
+msgstr "કેલિબ્રેશન ઉપકરણ"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "દર્શાવનાં પ્રકારને પસંદ કરો કે જે જોડાયેલ છે."
+
+#: ../panels/color/color.ui.h:12
+#| msgctxt "Device kind"
+#| msgid "Display"
+msgid "Display Type"
+msgstr "પ્રકારને દર્શાવો"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"દર્શા લક્ષ્ય સફેદ બિંદુને પસંદ કરો. મોટેભાગે દર્શાવો D65 illuminant માં માપદંડ થયેલ હોવુ જોઇએ."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "રૂપરેખા સફેદબિંદુ"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"મહેરબાની કરીને તેજ પ્રદર્શન માટે દર્શાવ સુયોજિત કરો કે જે ખાસ કરીને તમારી માટે છે. રંગ સંચાલન "
+"આ પ્રકાશતા સ્તરે વધારે ચોક્કસ હશે."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"વૈકલ્પિક રીતે, તમે આ ઉપકરણ માટે બીજી રૂપરેખાનાં એક સાથે વાપરેલ પ્રકાશતા સ્તરને વાપરી શકો છો."
+
+#: ../panels/color/color.ui.h:17
+#| msgid "Brightness"
+msgid "Display Brightness"
+msgstr "પ્રકાશતા દર્શાવો"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"તમે વિવિધ કમ્પ્યૂટર પર રંગ રૂપરેખાને વાપરી શકો છો, અથવા વિવિધ પ્રકાશતા શરતો માટે રૂપરેખાઓને "
+"બનાવી પણ શકો છો."
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: ../panels/color/color.ui.h:19
+#| msgid "_Profile:"
+msgid "Profile Name:"
+msgstr "રૂપરેખાનું નામ:"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: ../panels/color/color.ui.h:20
+#| msgid "_Profile:"
+msgid "Profile Name"
+msgstr "રૂપરેખાનું નામ"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "રૂપરેખા સફળતાપૂર્વક બનાવેલ છે!"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: ../panels/color/color.ui.h:22
+#| msgid "No profile"
+msgid "Copy profile"
+msgstr "રૂપરેખાની નકલ કરો"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "લખી શકાય તેવી મીડિયાની જરૂરિયાત છે"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: ../panels/color/color.ui.h:24
+#| msgid "No profile"
+msgid "Upload profile"
+msgstr "રૂપરેખા અપલોડ કરો"
+
+#: ../panels/color/color.ui.h:25
+#| msgid "Add new connection"
+msgid "Requires Internet connection"
+msgstr "ઇન્ટરનેટ જોડાણની જરૂરિયાત છે"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"તમે આ સૂચનાઓને શોધી શકો છો કે જે <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> અને <a href=\"windows"
+"\">Microsoft Windows</a> અને ઉપયોગી સિસ્ટમો પર કેવી રીતે વાપરે છે."
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+msgid "Summary"
+msgstr "સારાંશ"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "ફાઈલ આયાત કરો…"
+
+#: ../panels/color/color.ui.h:29
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr "સમસ્યાઓ શોધાઇ. રૂપરેખા યોગ્ય રીકે કામ કરી શકશે નહિં. <a href=\"\">વિગતો બતાવો.</a>"
+
+#: ../panels/color/color.ui.h:30
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "દરેક ઉપકરણને સંચાલિત રંગની રંગ રૂપરેખાને અદ્યતન રાખવાની જરૂર છે."
+
+#: ../panels/color/color.ui.h:31
+msgid "Learn more"
+msgstr "વધારે શીખો"
+
+#: ../panels/color/color.ui.h:32
+msgid "Learn more about color management"
+msgstr "રંગ સંચાલન વિશે વધારે શીખો"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/color/color.ui.h:33
+msgid "Set for all users"
+msgstr "બધા વપરાશકર્તાઓ માટે સુયોજિત કરો"
+
+#: ../panels/color/color.ui.h:34
+msgid "Set this profile for all users on this computer"
+msgstr "આ કમ્પ્યૂટર પર બધા વપરાશકર્તાઓ માટે આ રૂપરેખાને સુયોજિત કરો"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#: ../panels/color/color.ui.h:35
+#| msgid "Enabled"
+msgid "Enable"
+msgstr "સક્રિય"
+
+#: ../panels/color/color.ui.h:36
+msgid "Add profile"
+msgstr "રૂપરેખા ઉમેરો"
+
+#: ../panels/color/color.ui.h:37
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate…"
+msgstr "માપદંડ કરો…"
+
+#: ../panels/color/color.ui.h:38
+msgid "Calibrate the device"
+msgstr "ઉપકરણનું માપદંડ કરો"
+
+#: ../panels/color/color.ui.h:39
+msgid "Remove profile"
+msgstr "રૂપરેખાને દૂર કરો"
+
+#: ../panels/color/color.ui.h:40
+msgid "View details"
+msgstr "વિગતો દર્શાવો"
+
+#: ../panels/color/color.ui.h:41
+msgid "Unable to detect any devices that can be color managed"
+msgstr "કોઇપણ ઉપકરણોને શોધવાનું અસમર્થ કે જે રંગને સંચાલિત કરી શકાય છે"
+
+#: ../panels/color/color.ui.h:42
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:43
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:44
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:45
+#| msgid "Co_untry:"
+msgid "Projector"
+msgstr "પ્રોજેક્ટર"
+
+#: ../panels/color/color.ui.h:46
+msgid "Plasma"
+msgstr "પ્લાઝ્મા"
+
+#: ../panels/color/color.ui.h:47
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL બેકલાઇટ)"
+
+#: ../panels/color/color.ui.h:48
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED બેકલાઇટ)"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (white LED backlight)"
+msgstr "LCD (white LED બેકલાઇટ)"
+
+#: ../panels/color/color.ui.h:50
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Wide gamut LCD (CCFL બેકલાઇટ)"
+
+#: ../panels/color/color.ui.h:51
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Wide gamut LCD (RGB LED બેકલાઇટ)"
+
+#: ../panels/color/color.ui.h:52
+#| msgid "High"
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "વધારે"
+
+#: ../panels/color/color.ui.h:53
+#| msgid "10 minutes"
+msgid "40 minutes"
+msgstr "40 મિનિટો"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "મધ્યમ"
+
+#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 મિનિટો"
+
+#: ../panels/color/color.ui.h:56
+#| msgid "Low"
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "ઓછુ"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
+#| msgid "5 minutes"
+msgid "15 minutes"
+msgstr "15 મિનિટ"
+
+#: ../panels/color/color.ui.h:58
+#| msgid "Panel to display"
+msgid "Native to display"
+msgstr "પ્રદર્શિત કરલા માટે મૂળ"
+
+#: ../panels/color/color.ui.h:59
+#| msgid "Pointing and Clicking"
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (છાપન અને પ્રકાશિત)"
+
+#: ../panels/color/color.ui.h:60
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:61
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (ફોટોગ્રાફી અને ગ્રાફિક્સ)"
+
+#: ../panels/color/color.ui.h:62
+#| msgid "75%"
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "રંગ"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "તમારાં ઉપકરણોનાં રંગને કેલિબ્રેટ કરો, જેમ કે દર્શાવ, કૅમેરા અથવા પ્રિન્ટરો"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "રંગ;ICC;રૂપરેખા;માપદંડ;પ્રિન્ટર;દર્શાવ;"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:684
+msgid "United States"
+msgstr "યુનાઇટેડ સ્ટેટ્સ"
+
+#: ../panels/common/cc-common-language.c:685
+msgid "Germany"
+msgstr "જર્મની"
+
+#: ../panels/common/cc-common-language.c:686
+msgid "France"
+msgstr "ફ્રાન્સ"
+
+#: ../panels/common/cc-common-language.c:687
+msgid "Spain"
+msgstr "સ્પેન"
+
+#: ../panels/common/cc-common-language.c:688
+msgid "China"
+msgstr "ચાઇના"
+
+#: ../panels/common/cc-common-language.c:758
+#| msgid "Other profile…"
+msgid "Other…"
+msgstr "બીજું..."
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr "વધારે…"
+
+#: ../panels/common/cc-language-chooser.c:140
+#| msgid "No Bluetooth adapters found"
+msgid "No languages found"
+msgstr "ભાષાઓ મળી નથી"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "ભાષા"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+#| msgid "Done!"
+msgid "_Done"
+msgstr "પૂર્ણ (_D)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+#| msgid "%a %l:%M %p"
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+#| msgid "%a %l:%M %p"
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "જાન્યુઅરી "
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "ફેબ્રુઆરી"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "માર્ચ"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "એપ્રિલ"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "મે"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "જૂન"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "જુલાઈ"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "ઑગસ્ટ"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "સેપ્ટેમ્બર"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "ઑક્ટોબર"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "નવેમ્બર"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "ડિસેમ્બર"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "તારીખ અને સમય"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "કલાક"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+#| msgid "minute"
+#| msgid_plural "minutes"
+msgid "Minute"
+msgstr "મિનિટ"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "દિવસ"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "મહિનો"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "વર્ષ"
+
+#: ../panels/datetime/datetime.ui.h:21
+#| msgid "Time"
+msgid "Time Zone"
+msgstr "ટાઈમ ઝોન"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Search for a city"
+msgstr "શહેર માટે શોધો"
+
+#: ../panels/datetime/datetime.ui.h:23
+#| msgid "Date & Time"
+msgid "Automatic _Date & Time"
+msgstr "આપોઆપ તારીખ અને સમય (_D)"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr "ઇન્ટરનેટ પ્રવેશની જરૂરિયાત છે"
+
+#: ../panels/datetime/datetime.ui.h:25
+#| msgid "A_utomatic Login"
+msgid "Automatic Time _Zone"
+msgstr "આપોઆપ ટાઇમઝોન (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:26
+#| msgid "Date & Time"
+msgid "Date & _Time"
+msgstr "તારીખ અને સમય (_T)"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr "ટાઈમ ઝોન (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:28
+#| msgid "Formats"
+msgid "Time _Format"
+msgstr "સમય બંધારણ (_F)"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24-કલાક"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "તારીખ અને સમયને બદલો, ટાઇમ ઝોનને સમાવી રહ્યા છે"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "ઘડિયાળ;ટાઇમઝોન;સ્થાન;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "સિસ્ટમ સમય અને તારીખ સુયોજનોને બદલો"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "સમય અથવા તારીખ સુયોજનોને બદલવા માટે, તમારે સત્તાધિકરણ કરવુ જરૂરી છે."
+
+#: ../panels/display/cc-display-panel.c:487
+#| msgid "Close"
+msgid "Lid Closed"
+msgstr "ઢાંકણ બંધ થયેલ છે"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+#| msgid "Mirrored Displays"
+msgid "Mirrored"
+msgstr "પ્રતિબિંબિત"
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2145
+#| msgid "Primary _button"
+msgid "Primary"
+msgstr "પ્રાથમિક"
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "બંધ"
+
+#: ../panels/display/cc-display-panel.c:497
+#| msgid "Secondary color"
+msgid "Secondary"
+msgstr "ગૌણ"
+
+#: ../panels/display/cc-display-panel.c:1533
+#| msgid "Mirrored Displays"
+msgid "Arrange Combined Displays"
+msgstr "સંયુક્ત દર્શાવોને ગોઠવો"
+
+#: ../panels/display/cc-display-panel.c:1539
+#: ../panels/display/cc-display-panel.c:1979
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#| msgid "Supply"
+msgid "_Apply"
+msgstr "લાગુ કરો (_A)"
+
+#: ../panels/display/cc-display-panel.c:1560
+msgid "Drag displays to rearrange them"
+msgstr "તેઓને ફરી ગોઠવવા માટે દર્શાવોને ખેંચો"
+
+#: ../panels/display/cc-display-panel.c:2081
+msgid "Size"
+msgstr "માપ"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2094
+msgid "Aspect Ratio"
+msgstr "આશરે દર"
+
+#: ../panels/display/cc-display-panel.c:2115
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "રીઝોલ્યુશન"
+
+#: ../panels/display/cc-display-panel.c:2146
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "આ દર્શાવ પર ટોચવી પટ્ટી અને પ્રવૃત્તિ ઝાંખીને બતાવો"
+
+#: ../panels/display/cc-display-panel.c:2152
+#| msgid "Secondary click delay"
+msgid "Secondary Display"
+msgstr "ગૌણ દર્શાવ"
+
+#: ../panels/display/cc-display-panel.c:2153
+msgid "Join this display with another to create an extra workspace"
+msgstr "વધારાની કાર્ય કરવાની જગ્યાને બનાવવા બીજા સાથે આ દર્શાવને જોડો"
+
+#: ../panels/display/cc-display-panel.c:2160
+#| msgid "Orientation"
+msgid "Presentation"
+msgstr "રજૂઆત"
+
+#: ../panels/display/cc-display-panel.c:2161
+msgid "Show slideshows and media only"
+msgstr "તકતીપૂર્વદર્શન અને મીડિયાને ફક્ત બતાવો"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2166
+msgid "Mirror"
+msgstr "મિરર"
+
+#: ../panels/display/cc-display-panel.c:2167
+msgid "Show your existing view on both displays"
+msgstr "બંને દર્શાવ પર તમારું હાલનુ દૃશ્ય બતાવો"
+
+#: ../panels/display/cc-display-panel.c:2173
+#| msgid "_Turn On"
+msgid "Turn Off"
+msgstr "બંધ કરો"
+
+#: ../panels/display/cc-display-panel.c:2174
+#| msgid "Panel to display"
+msgid "Don't use this display"
+msgstr "આ દર્શાવને વાપરો નહિં"
+
+#: ../panels/display/cc-display-panel.c:2383
+msgid "Could not get screen information"
+msgstr "સ્ક્રીન જાણકારી ને મેળવી શકાયુ નહિં"
+
+#: ../panels/display/cc-display-panel.c:2414
+#| msgid "Mirrored Displays"
+msgid "_Arrange Combined Displays"
+msgstr "સંયુક્ત દર્શાવને ગોઠવો (_A)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "દેખાવો"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+#| msgid "Change resolution and position of monitors and projectors"
+msgid "Choose how to use connected monitors and projectors"
+msgstr "કેવી રીતે મોનિટર અને પ્રોજેક્ટરને વાપરવુ તેને પસંદ કરો"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "પેનલ;પ્રોજેક્ટર;xrandr;સ્ક્રીન;રિઝોલ્યુશન;તાજુ કરો;મોનિટર;"
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr "Wayland"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "અજ્ઞાત"
+
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+#| msgid "%d-bit"
+msgid "%s %d-bit"
+msgstr "%s %d-બીટ"
+
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr "%d-બીટ"
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr "શું કરવુ છે તે પૂછો"
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr "કઇ કરવાનુ નથી"
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr "ફોલ્ડરને ખોલો"
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr "બીજી મીડિયા"
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr "ઓડિયો CDs માટે કાર્યક્રમને પસંદ કરો"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr "વિડિઓ DVDs માટે કાર્યક્રમને પસંદ કરો"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr "ચલાવવા માટે કાર્યક્રમને પસંદ કરો જ્યારે સંગીત પ્લેયર જોડાયેલ હોય"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr "ચલાવવા માટે કાર્યક્રમને પસંદ કરો જ્યારે કેમેરા જોડાયેલ હોય"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr "સોફ્ટવેર CDs માટે કાર્યક્રમને પસંદ કરો"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr "ઓડિયો DVD"
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr "ખાલી બ્લુ-રે ડિસ્ક"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr "ખાલી CD ડિસ્ક"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr "ખાલી DVD ડિસ્ક"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr "ખાલી HD DVD ડિસ્ક"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr "બ્લુ-રે વિડિયો ડિસ્ક"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr "ઇ-બુટ વાંચનાર"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr "HD DVD વિડિયો ડિસ્ક"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr "ચિત્ર CD"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr "મુખ્ય વિડીયો CD"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr "વિડિયો CD"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr "Windows સોફ્ટવેર"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1917
+msgid "Section"
+msgstr "વિભાગ"
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "ઝાંખી"
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "મૂળભૂત કાર્યક્રમો"
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "દૂર કરી શકાય તેવી મીડિયા"
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr "આવૃત્તિ %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:44
+msgid "Details"
+msgstr "વિગતો"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "તમારી સિસ્ટમ વિશે જાણકારી જુઓ"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+#| msgid ""
+#| "device;system;information;memory;processor;version;default;application;"
+#| "fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ઉપકરણ;સિસ્ટમ;જાણકારી;મેમરી;પ્રોસેસર;આવૃત્તિ;મૂળભૂત;કાર્યક્રમ;પસંદ થયેલ;cd;dvd;usb;"
+"ઓડિયો;વિડિયો;ડિસ્ક;નિરાકરણ;મીડિયા;સ્વયં ચલાવો;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "પસંદ કરો કેવી રીતે બીજી મીડિયાને સંભાળવુ જોઇએ"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "ક્રિયા (_A):"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "પ્રકાર (_T):"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "ઉપકરણ નામ"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "મેમરી"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "પ્રોસેસર"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "મૂળભૂત સિસ્ટમ"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "ડિસ્ક"
+
+#: ../panels/info/info.ui.h:10
+#| msgid "Calculating..."
+msgid "Calculating…"
+msgstr "ગણતરી…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "ગ્રાફિક્સ"
+
+#: ../panels/info/info.ui.h:12
+#| msgid "Calibration"
+msgid "Virtualization"
+msgstr "વર્ચ્યુલાઇઝેશન"
+
+#: ../panels/info/info.ui.h:13
+#| msgid "Checking for Updates"
+msgid "Check for updates"
+msgstr "સુધારાઓ માટે ચકાસો"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "વેબ (_W)"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "મેઇલ (_M)"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "કૅલેન્ડર (_C)"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "સંગીત (_u)"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "વિડિઓ (_V)"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "ફોટા (_P)"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "પસંદ કરો કેવી રીતે મીડિયાને સંભાળવુ જોઇએ"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "CD ઓડિયો (_a)"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "DVD વિડિયો (_D)"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "સંગીત પ્લેયર (_M)"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "સોફ્ટવેર (_S)"
+
+#: ../panels/info/info.ui.h:27
+#| msgid "Other Media"
+msgid "_Other Media…"
+msgstr "બીજી મીડિયા (_O)…"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr "મીડિયા નિવેશ પર કદી પૂછો નહિં અથવા કાર્યક્રમ શરૂ કરો (_N)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "સાઉન્ડ અને મીડિયા"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "અવાજ મૂંગો"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "અવાજ ઓછો કરો"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "અવાજ વધારો"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "મીડિયા પ્લેયરને શરૂ કરો"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "વગાડો (વગાડો/અટકાવો)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "પ્લેબેક અટકાવો"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "પ્લેબેક બંધ કરો"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "પહેલાંનુ ટ્રેક"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "આગળનો ટ્રેક"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "બહાર નીકાળો"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "ટાઇપ કરી રહ્યા છે"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#| msgid "Switch to next source"
+msgid "Switch to next input source"
+msgstr "આગળનાં ઇનપુટ સ્ત્રોતમાં જાવ"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#| msgid "Switch to previous source"
+msgid "Switch to previous input source"
+msgstr "પહેલાનાં ઇનપુટ સ્ત્રોતમાં જાવ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "લૉંચર"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "મદદ બ્રાઉઝર શરૂ કરો"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+#| msgid "_Settings..."
+msgid "Settings"
+msgstr "સુયોજનો"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "કૅલ્ક્યુલેટર શરૂ કરો"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "ઇમેલ ક્લાયન્ટ શરૂ કરો"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "વેબ બ્રાઉઝર શરૂ કરો"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "ઘર ફોલ્ડર"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+#| msgid "Search"
+msgctxt "keybinding"
+msgid "Search"
+msgstr "શોધો"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "સ્ક્રીનશોટ"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+#| msgid "Save a screenshot to Pictures"
+msgid "Save a screenshot to $PICTURES"
+msgstr "$PICTURES માં સ્ક્રીનશોટને સંગ્રહો"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+#| msgid "Save a screenshot of a window to Pictures"
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "$PICTURES માં વિન્ડોનાં સ્ક્રીનશોટને સંગ્રહો"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+#| msgid "Save a screenshot of an area to Pictures"
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "$PICTURES માં એક વિસ્તારનાં સ્ક્રીનશોટને સંગ્રહો"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "ક્લિપબોર્ડમાં સ્ક્રીનશોટની નકલ કરો"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "ક્લિપબોર્ડમાં વિન્ડોના સ્ક્રિનશોટની નકલ કરો"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "ક્લિપબોર્ડમાં વિસ્તારનાં સ્ક્રીનશોટની નકલ કરો"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "ટૂંકી સ્ક્રીનકાસ્ટનો અહેવાલ લો"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "સિસ્ટમ"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "બહાર નીકળો"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "સ્ક્રીનને તાળુ મારો"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "સાર્વત્રિક વપરાશ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "નાનું મોટુ કરવાનુ ચાલુ અથવા બંધ કરો"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "મોટુ કરો"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "નાનું કરો"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "સ્ક્રીન વાંચકને ચાલુ અથવા બંધ રાખો"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "ઓન-સ્ક્રીન કિબોર્ડને ચાલુ અથવા બંધ રાખો"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "લખાણ માપ વધારો"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "લખાણ માપ ઘટાડો"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "ઉચ્ચ વિરોધાભાસ ચાલુ અથવા બંધ"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1217
+#: ../panels/network/network-wifi.ui.h:29
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+#: ../panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Disabled"
+msgstr "નિષ્ક્રિય"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "વૈકલ્પિક અક્ષર કી"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "કંપોઝ કી"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+#| msgid "Switch to next source"
+msgid "Modifiers-only switch to next source"
+msgstr "સંશોધક ફક્ત આગળનાં સ્ત્રોત પર જવા માટે"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "કીબોર્ડ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "કિબોર્ડ ટૂંકાણોને બદલો અને જુઓ અને તમારી ટાઇપીંગ પસંદગીઓને સુયોજિત કરો"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "ટૂંકાણ;ચાલુ રાખો;ઝબૂકવુ;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "વૈવિધ્યપૂર્ણ ટુંકાણો"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr "ઉમેરો (_A)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "નામ (_N):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "આદેશ (_o):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "પુનરાવર્તિત કીઓ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "જ્યારે કી દબાવી રાખી હોય ત્યારે પુનરાવર્તિત કી દબાણ. (_r)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "વિલંબ (_D):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "ઝડપ (_S):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+#| msgid "Short"
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "ટૂંકુ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+#| msgid "Slow"
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "ધીમુ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "પુનરાવર્તન કીઓની ઝડપ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+#| msgid "Long"
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "લાંબુ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+#| msgid "Fast"
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "ઝડપી"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "કર્સર ઝબૂકે છે"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "કર્સર લખાણ ક્ષેત્રોમાં ઝબૂકે છે (_b)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "ઝડપ (_p):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "કર્સર ઝબૂકવાની ઝડપ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "ઇનપુટ સ્ત્રોત"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "ટુંકાણ ઉમેરો"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "ટુંકાણ દૂર કરો"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"ટુકાણ કીમાં ફેરફાર કરવા માટે, તેને લાગતી હરોળ પર ક્લિક કરો અને નવી કી જોડાણોને ટાઇપ "
+"કરો, અથવા સાફ કરવા માટે Backspace કી દબાવો."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "ટૂંકાણો"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:634
+#: ../panels/keyboard/keyboard-shortcuts.c:642
+msgid "Custom Shortcuts"
+msgstr "વૈવિધ્યપૂર્ણ ટુંકાણો"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:859
+msgid "<Unknown Action>"
+msgstr "&lt;Unknown Action&gt;"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1356
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"ટૂંકાણ \"%s\" વાપરી શકાશે નહિં કારણ કે તે આ કીને લખવા માટે વાપરવા માટે અશક્ય બનશે.\n"
+"Control, Alt અથવા Shift જેવી કીને એક જ સમયે વાપરવાનો પ્રયાસ કરી જુઓ."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1386
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"આ ટુંકાણ \"%s\" પહેલેથી \"%s\" માટે વપરાયેલ\n"
+"છે"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1391
+#, c-format
+msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "જો \"%s\" ને ટુંકાણોમાં ફરીથી નિશ્ચત કરો તો, \"%s\" ટુંકાણો નિષ્ક્રિય થયેલ હશે."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1397
+msgid "_Reassign"
+msgstr "પુન:નિશ્ચત કરો (_R)"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1429
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"\"%s\" ટૂંકાણ એ \"%s\" ટૂંકાણ સાથે સંકળાયેલ છે. શું તમે \"%s\" માં તેને આપમેળે સુયોજિત કરવા "
+"માંગો છો?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1435
+#, c-format
+#| msgid ""
+#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#| "disabled."
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr "\"%s\"  એ હાલમાં \"%s\" સાથે સંકળાયેલ છે, આ ટૂંકાણ એ નિષ્ક્રિય થશે જો તમે આગળ ખસો તો."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1441
+#| msgid "_Reassign"
+msgid "_Assign"
+msgstr "સોંપો (_A)"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+#| msgid "_Test Your Settings"
+msgid "Test Your _Settings"
+msgstr "તમારાં સુયોજનો ચકાસો (_S)"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+#| msgid "_Test Your Settings"
+msgid "Test Your Settings"
+msgstr "તમારાં સુયોજનો ચકાસો"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "માઇસ અને ટચપેડ"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "તમારી માઉસ અને ટચપેડ સંવેદનશીલતાને બદલો અને જમણી અથવા ડાબી બાજુ પસંદ કરો"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#| msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ટ્રેકપેડ;નિર્દેશક;ક્લિક;ટેપ;બમણું;બટન;ટ્રેકબોલ;સ્ક્રોલ;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "સામાન્ય"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+#| msgid "Slow"
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "ધીમુ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "બે ક્લિકની સમયસમાપ્તિ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+#| msgid "Fast"
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "ઝડપી"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "બે ક્લિક (_D)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "પ્રાથમિક બટન (_b)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+#| msgid "_Left"
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "ડાબું (_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+#| msgid "_Right"
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "જમણું (_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "માઉસ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "પોઇન્ટર ઝડપ (_P)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+#| msgid "Slow"
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "ધીમુ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+#| msgid "Fast"
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "ઝડપી"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "ટચપેડ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+#| msgid "Slow"
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "ધીમુ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+#| msgid "Fast"
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "ઝડપી"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr "જ્યારે ટાઇપ કરી રહ્યા હોય ત્યારે નિષ્ક્રિય કરો (_t)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr "ક્લિક કરવા માટે ટૅપ (_c)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr "બે- આંગળી થી ખસેડવુ (_fi)"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+#| msgid "_Edge scrolling"
+msgid "_Natural scrolling"
+msgstr "કુદરતી સ્ક્રોલીંગ (_N)"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ક્લિક કરવાનો પ્રયત્ન કરો, બે વાર ક્લિક કરો, ખસેડી રહ્યા છે"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "પાંચ ક્લિક, GEGL સમય!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "બે ક્લિક, પ્રાથમિક બટન"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "એક જ ક્લિક, પ્રાથમિક બટન"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "બે ક્લિક, મધ્ય બટન"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "એકજ ક્લિક, મધ્ય બટન"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "બે વાર ક્લિક, ગૌણ બટન"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "એકજ ક્લિક, ગૌણ બટન"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:366
+msgid "Air_plane Mode"
+msgstr "ઍરપ્લેન સ્થિતિ (_p)"
+
+#: ../panels/network/cc-network-panel.c:965
+msgid "Network proxy"
+msgstr "નેટવર્ક પ્રોક્સી"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1289
+msgid "The system network services are not compatible with this version."
+msgstr "સિસ્ટમ નેટવર્ક સેવાઓ આવૃત્તિ સાથે સુસંગત નથી."
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#| msgid "Security"
+msgid "802.1x _Security"
+msgstr "802.1x સુરક્ષા (_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "પાનું 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "અનામિક ઓળખાણ (_m)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+#| msgid "Authentication failed"
+msgid "Inner _authentication"
+msgstr "આંતરિક સત્તાધિકરણ (_a)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "પાનું 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Security"
+msgstr "સુરક્ષા"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+#| msgctxt "proxy method"
+#| msgid "Automatic"
+msgid "automatic"
+msgstr "સ્વયં"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:217
+#: ../panels/network/net-device-wifi.c:378
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:221
+#: ../panels/network/net-device-wifi.c:383
+#: ../panels/network/network-wifi.ui.h:17
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:225
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:230
+msgid "Enterprise"
+msgstr "એન્ટરપ્રાઇઝ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:235
+#: ../panels/network/net-device-wifi.c:368
+msgctxt "Wifi security"
+msgid "None"
+msgstr "કંઈ નહિં"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+#| msgid "never"
+msgid "Never"
+msgstr "કદી નહિં"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:819
+#| msgid "today"
+msgid "Today"
+msgstr "આજે"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:822
+#| msgid "yesterday"
+msgid "Yesterday"
+msgstr "ગઈકાલે"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:472
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i દિવસ અગાઉ"
+msgstr[1] "%i દિવસો અગાઉ"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:529
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:558
+msgctxt "Signal strength"
+msgid "None"
+msgstr "કંઈ નહિં"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:560
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "નબળુ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "બરાબર"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "સરસ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "હોશિયાર"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:45
+msgid "Identity"
+msgstr "ઓળખ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "સરનામું"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "નેટમાસ્ક"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "ગેટવે"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+#| msgid "IP Address"
+msgid "Delete Address"
+msgstr "સરનામું કાઢી નાંખો"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+#| msgid "_Add"
+msgid "Add"
+msgstr "ઉમેરો"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "સર્વર"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+#| msgid "Delete device"
+msgid "Delete DNS Server"
+msgstr "DNS સર્વર કાઢી નાંખો"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+#| msgid "Metric"
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "મેટ્રીક"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+#| msgid "Default Route"
+msgid "Delete Route"
+msgstr "માર્ગ કાઢી નાંખો"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:25
+#| msgctxt "proxy method"
+#| msgid "Automatic"
+msgid "Automatic (DHCP)"
+msgstr "સ્વયં (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:24
+#| msgctxt "proxy method"
+#| msgid "Manual"
+msgid "Manual"
+msgstr "પુસ્તિકા"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "ફક્ત સ્થાનિક કડી"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:46
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "પૂર્વગ"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+#| msgctxt "proxy method"
+#| msgid "Automatic"
+msgid "Automatic"
+msgstr "સ્વયં"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+#| msgid "A_utomatic Login"
+msgid "Automatic, DHCP only"
+msgstr "આપોઆપ, ફક્ત DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:47
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:49
+msgid "Reset"
+msgstr "પુનઃસુયોજીત કરો"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+#| msgid "None"
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "કંઈ જ નહિં"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit Key (Hex અથવા ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit પાસફ્રેજ"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "ડાયનેમિક WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA અને WPA2 વ્યક્તિગત"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+#| msgid "Enterprise"
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA અને WPA2 એન્ટરપ્રાઇઝ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:2
+#| msgid "Strength"
+msgid "Signal Strength"
+msgstr "સંકેત મજબૂતાઇ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Link speed"
+msgstr "કડી ઝડપ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 સરનામું"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 સરનામું"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:7
+msgid "Hardware Address"
+msgstr "હાર્ડવેર સરનામું"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:8
+msgid "Default Route"
+msgstr "મૂળભૂત માર્ગ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:9
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+#| msgid "Last used"
+msgid "Last Used"
+msgstr "છેલ્લે વાપરેલ"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "Twisted Pair (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Attachment Unit Interface (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "Media Independent Interface (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+#| msgid "%d Mb/s"
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+#| msgid "%d Mb/s"
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+#| msgid "_Name:"
+msgid "_Name"
+msgstr "નામ (_N)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:36
+#| msgid "Address"
+msgid "_MAC Address"
+msgstr "MAC સરનામું (_M)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "MTU (_T)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+#| msgid "IP Address"
+msgid "_Cloned Address"
+msgstr "ક્લોન થયેલ સરનામું (_C)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+#| msgid "%u byte"
+#| msgid_plural "%u bytes"
+msgid "bytes"
+msgstr "બાઇટ"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "બીજા વપરાશકર્તાઓ માટે ઉપલબ્ધ બનાવો (_u)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "આપમેળે જોડાવો (_a)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "ફાયરવોલ ઝોન (_Z)"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+#| msgid "Default"
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "મૂળભૂત"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "વિસ્તાર જોડાણનાં વિશ્ર્વાસ સ્તરને દર્શાવે છે"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:22
+msgid "IPv_4"
+msgstr "IPv4 (_4)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:23
+#| msgid "Address"
+msgid "_Addresses"
+msgstr "સરનામાં (_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+#| msgctxt "proxy method"
+#| msgid "Automatic"
+msgid "Automatic DNS"
+msgstr "આપોઆપ DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Routes"
+msgstr "માર્ગ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+#| msgctxt "proxy method"
+#| msgid "Automatic"
+msgid "Automatic Routes"
+msgstr "આપમેળે માર્ગ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Use this connection _only for resources on its network"
+msgstr "તેનાં નેટવર્ક પર સ્ત્રોતો માટે ફક્ત આ જોડાણને વાપરો (_o)"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:34
+msgid "IPv_6"
+msgstr "IPv6 (_6)"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+#| msgid "Bluetooth connection failed"
+msgid "Unable to open connection editor"
+msgstr "જોડાણ સંપાદકને ખોલવાનું અસમર્થ"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+#| msgid "No profile"
+msgid "New Profile"
+msgstr "નવી રૂપરેખા"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "બોન્ડ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "જૂથ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "બ્રિજ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+#| msgid "Could not load ui: %s"
+msgid "Could not load VPN plugins"
+msgstr "VPN પ્લગઇનને લાવી શક્યા નહિં"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+#| msgid "Other profile…"
+msgid "Import from file…"
+msgstr "ફાઇલમાંથી આયાત કરો..."
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+#| msgid "Add new connection"
+msgid "Add Network Connection"
+msgstr "નેટવર્ક જોડાણને ઉમેરો"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Reset"
+msgstr "ફરી સુયોજીત કરો (_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1449
+#: ../panels/network/network-wifi.ui.h:40
+#| msgid "Forget"
+msgid "_Forget"
+msgstr "ભૂલી જાઓ (_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"આ નેટવર્ક માટે સુયોજનો સુયોજિત કરો, પાસવર્ડને સમાવી રહ્યા છે, પરંતુ યાદ રાખો કે તે પસંદ થયેલ "
+"નેટવર્ક ચે"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr "આ નેટવર્કને લગતી બધી વિગતોને દૂર કરો અને આપમેળે જોડાવા માટે પ્રયત્ન કરો નહિં"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+#| msgid "Security"
+msgid "S_ecurity"
+msgstr "સુરક્ષા (_e)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "VPN જોડાણની આયાત કરી શકાતુ નથી"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"ફાઇલ '%s' એ વાંચી શકાયુ નહિં અથવા ઓળખેલ VPN જોડાણ જાણકારીને સમાવતુ નથી\n"
+"\n"
+"ભૂલ: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "આયાત કરવા માટે ફાઇલ પસંદ કરો"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1948
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:223
+msgid "_Open"
+msgstr "ખોલો (_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+#| msgid "A user with name '%s' already exists."
+msgid "A file named \"%s\" already exists."
+msgstr "નામ \"%s\" ફાઇલ પહેલેથી અસ્તિત્વ ધરાવે છે."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "બદલો (_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "શું તમે સંગ્રહ કરી રહ્યા છો તે VPN જોડાણ સાથે %s ને બદલવા માંગો છો?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "VPN જોડાણનું નિકાસ કરી શકાતુ નથી"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN જોડાણ '%s' ને %s માં નિકાસ કરી શક્યા નહિં.\n"
+"\n"
+"ભૂલ: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+#| msgid "Add new connection"
+msgid "Export VPN connection"
+msgstr "VPN જોડાણની નિકાસ કરો"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ભૂલ: VPN જોડાણ સંપાદકને લાવવાનું અસમર્થ)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:12
+msgid "_SSID"
+msgstr "SSID (_S)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:13
+msgid "_BSSID"
+msgstr "BSSID (_B)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:16
+#| msgid "_Forget Network"
+msgid "My Home Network"
+msgstr "મારું ઘર નેટવર્ક"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "બીજા વપરાશકર્તાઓને ઉપલબ્ધ બનાવો (_o)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "નેટવર્ક"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+#| msgid "Not connected to the internet."
+msgid "Control how you connect to the Internet"
+msgstr "તમે કેવી રીતે ઇન્ટરનેટ સાથે જોડાવે તેને નિયંત્રિત કરો"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"નેટવર્ક;વાયરલેસ;Wi-Fi;Wifi;IP;LAN;પ્રોક્સી;WAN;બ્રોડબેન્ડ;મોડેમ;બ્લુટુથ;vpn;"
+"vlan;બ્રિજ;બોન્ડ;DNS;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "બોન્ડ સ્લેવ"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(કંઇ નહિં)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "બ્રિજ સ્લેવ"
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:458
+msgid "never"
+msgstr "કદી નહિં"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:468
+msgid "today"
+msgstr "આજે"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:470
+msgid "yesterday"
+msgstr "ગઇ કાલે"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP સરનામું"
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Last used"
+msgstr "છેલ્લે વાપરેલ"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "વાયર લગાવેલ"
+
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1604
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+#| msgid "Options"
+msgid "Options…"
+msgstr "વિકલ્પો…"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: ../panels/network/net-device-ethernet.c:474
+#, c-format
+#| msgid "_Profile:"
+msgid "Profile %d"
+msgstr "રૂપરેખા %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "નવાં જોડાણને ઉમેરો"
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr "જૂથ સ્લેવ"
+
+#: ../panels/network/net-device-wifi.c:1153
+#| msgid ""
+#| "If you have a connection to the Internet other than wireless, you can use "
+#| "it to share your internet connection with others."
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"જો તમારી પાસે વાયરલેસ કરતા બીજુ ઇન્ટરનેટનું જોડાણ હોય તો, તમે બીજા સાથે જોડાણની ભાગીદારી કરવા "
+"માટે વાયરલેસ હૉટસ્પોટને સુયોજિત કરી શકો છો."
+
+#: ../panels/network/net-device-wifi.c:1157
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "વાયરલેસ હૉટસ્પોટ પર અદલાબદલી કરવાથી <b>%s</b> માંથી તમારુ જોડાણ તૂટી જશે."
+
+#: ../panels/network/net-device-wifi.c:1161
+#| msgid ""
+#| "It is not possible to access the internet through your wireless while the "
+#| "hotspot is active."
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr "તમારા વાયરલેસ મારફતે ઇન્ટરનેટને વાપરવાનું તેની માટે શક્ય નથી જ્યારે હૉટસ્પોટ સક્રિય હોય."
+
+#: ../panels/network/net-device-wifi.c:1238
+msgid "Stop hotspot and disconnect any users?"
+msgstr "હૉટસ્પોટને અટકાવો અને કોઇપણ વપરાશકર્તાનું જોડાણ તોડો? "
+
+#: ../panels/network/net-device-wifi.c:1241
+msgid "_Stop Hotspot"
+msgstr "હૉટસ્પોટ બંધ કરો (_S)"
+
+#: ../panels/network/net-device-wifi.c:1313
+msgid "System policy prohibits use as a Hotspot"
+msgstr "સિસ્ટમ પોલિસી હૉટસ્પોટ તરીકે વાપરવાનું અટકાવે છે"
+
+#: ../panels/network/net-device-wifi.c:1316
+#| msgid "InfiniBand device does not support connected mode"
+msgid "Wireless device does not support Hotspot mode"
+msgstr "વાયરલેસ ઉપકરણ હૉટસ્પોટને આધાર આપતુ નથી"
+
+#: ../panels/network/net-device-wifi.c:1445
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"પસંદ થયેલ નેટવર્કો માટે નેટવર્ક વિગતો, પાસવર્ડને સમાવીને અને કોઇપણ વૈવિધ્ય રૂપરેખાંકન ગુમ થઇ "
+"જશે."
+
+#: ../panels/network/net-device-wifi.c:1753
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "ઇતિહાસ"
+
+#: ../panels/network/net-device-wifi.c:1757
+#: ../panels/wacom/cc-wacom-page.c:533
+#| msgid "Close"
+msgid "_Close"
+msgstr "બંધ કરો (_C)"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1765
+#| msgid "Forget"
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "ભૂલી જાઓ (_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "Web Proxy Autodiscovery વાપરેલ છે જ્યારે રૂપરેખાંકન URL પૂરી પાડેલ નથી."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "આ અવિશ્ર્વાસુ સાર્વજનિક નેટવર્કો માટે અગ્રહણીય નથી."
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "પ્રોક્સી"
+
+#: ../panels/network/network-ethernet.ui.h:2
+#| msgid "Add profile"
+msgid "_Add Profile…"
+msgstr "રૂપરેખા ઉમેરો (_A)..."
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "પોષણકર્તા"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "કઇ નહિં"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "મેન્યુઅલ"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "સ્વયં"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "પદ્દતિ (_M)"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "રૂપરેખાંકન URL (_C)"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "HTTP પ્રોક્સી (_H)"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "HTTPS પ્રોક્સી (_T)"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "FTP પ્રોક્સી (_F)"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "Socks યજમાન (_S)"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "યજમાનો અવગણો (_I)"
+
+#: ../panels/network/network-proxy.ui.h:11
+#| msgid "_HTTP Proxy"
+msgid "HTTP proxy port"
+msgstr "HTTP પ્રોક્સી પોર્ટ"
+
+#: ../panels/network/network-proxy.ui.h:12
+#| msgid "H_TTPS Proxy"
+msgid "HTTPS proxy port"
+msgstr "FTP પ્રોક્સી પોર્ટ"
+
+#: ../panels/network/network-proxy.ui.h:13
+#| msgid "_FTP Proxy"
+msgid "FTP proxy port"
+msgstr "FTP પ્રોક્સી પોર્ટ"
+
+#: ../panels/network/network-proxy.ui.h:14
+#| msgid "Socks Port"
+msgid "Socks proxy port"
+msgstr "Socks પ્રોક્સી પોર્ટ"
+
+#: ../panels/network/network-simple.ui.h:7
+#| msgid "Device"
+msgid "Turn device off"
+msgstr "ઉપકરણ બંધ કરો"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "ઉપકરણ ઉમેરો"
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "ઉપકરણ દૂર કરો"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN પ્રકાર"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "જૂથ નામ"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "જૂથ પાસવર્ડ"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "વપરાશકર્તા નામ"
+
+#: ../panels/network/network-vpn.ui.h:7
+#| msgid "Turn on or off:"
+msgid "Turn VPN connection off"
+msgstr "VPN જોડાણને બંધ કરો"
+
+#: ../panels/network/network-wifi.ui.h:1
+#| msgid "A_utomatic Login"
+msgid "Automatic _Connect"
+msgstr "સ્વયમ જોડાવો (_C)"
+
+#: ../panels/network/network-wifi.ui.h:11
+#| msgid "Details"
+msgid "details"
+msgstr "વિગતો"
+
+#: ../panels/network/network-wifi.ui.h:15
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "પાસવર્ડ (_P)"
+
+#: ../panels/network/network-wifi.ui.h:18
+msgid "None"
+msgstr "કંઈ જ નહિં"
+
+#: ../panels/network/network-wifi.ui.h:19
+#| msgid "_Show password"
+msgid "Show P_assword"
+msgstr "પાસવર્ડ બતાવો (_a)"
+
+#: ../panels/network/network-wifi.ui.h:20
+#| msgid "Failed to delete user"
+msgid "Make available to other users"
+msgstr "બીજા વપરાશકર્તાઓ માટે ઉપલબ્ધ બનાવો"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "identity"
+msgstr "ઓળખાણ"
+
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Automatic (DHCP) addresses only"
+msgstr "ફક્ત સ્વયં (DHCP) સરનામાંઓ"
+
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Link-local only"
+msgstr "ફક્ત સ્થાનિક કડી"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Shared with other computers"
+msgstr "બીજા કમ્પ્યૂટર સાથે વહેંચેલ છે"
+
+#: ../panels/network/network-wifi.ui.h:31
+#| msgid "Cannot remove automatically added profile"
+msgid "_Ignore automatically obtained routes"
+msgstr "પ્રાપ્ત થયેલ માર્ગને આપમેળે અવગણો (_I)"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "_Cloned MAC Address"
+msgstr "ક્લોન થયેલ MAC સરનામું (_C)"
+
+#: ../panels/network/network-wifi.ui.h:38
+#| msgid "Hardware"
+msgid "hardware"
+msgstr "હાર્ડવેર"
+
+#: ../panels/network/network-wifi.ui.h:41
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"તેનાં મૂળભૂતમાં આ જોડાણ માટે સુયોજનોને પુન:સુયોજિત કરો, પરંતુ પસંદ થયેલ જોડાણ તરીકે યાદ રાખો."
+
+#: ../panels/network/network-wifi.ui.h:42
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr "આ નેટવર્કને લગતી બધી વિગતોને દૂર કરો અને આપમેળે જોડાવા માટે પ્રયત્ન કરો નહિં."
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid "reset"
+msgstr "પુનઃસુયોજીત કરો"
+
+#: ../panels/network/network-wifi.ui.h:48
+msgid "Hardware"
+msgstr "હાર્ડવેર"
+
+#: ../panels/network/network-wifi.ui.h:50
+#| msgid "Wireless Hotspot"
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi હૉટસ્પોટ"
+
+#: ../panels/network/network-wifi.ui.h:51
+msgid "_Turn On"
+msgstr "ચાલુ કરો (_T)"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:53
+#| msgid "Turn on or off:"
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi બંધ કરો"
+
+#: ../panels/network/network-wifi.ui.h:54
+#| msgid "_Use as Hotspot..."
+msgid "_Use as Hotspot…"
+msgstr "હૉટસ્પોટ તરીકે વાપરો (_U)..."
+
+#: ../panels/network/network-wifi.ui.h:55
+#| msgid "Connect to a Hidden Network"
+msgid "_Connect to Hidden Network…"
+msgstr "છુપાયેલ નેટવર્ક સાથે જોડાવો (_C)..."
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_History"
+msgstr "ઇતિહાસ (_H)"
+
+#: ../panels/network/network-wifi.ui.h:57
+#| msgid "Switch off to connect to a wireless network"
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Wi-Fi નેટવર્કમાં જોડાવાનુ બંધ કરો"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "Network Name"
+msgstr "નેટવર્ક નામ"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Connected Devices"
+msgstr "જોડાયેલ ઉપકરણો"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Security type"
+msgstr "સુરક્ષા પ્રકાર"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Security key"
+msgstr "સુરક્ષા કી"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "ઇન્ફ્રાસ્ટ્રક્ચર"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "અજ્ઞાત સ્થિતિ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "અસંચાલિત"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "બિનઉપલબ્ધ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "જોડાઇ રહ્યા છે"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "સત્તાધિકરણ જરૂરી"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "જોડાયેલ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "જોડાણ તૂટી રહ્યુ છે"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "જોડાણ નિષ્ફળ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "અજ્ઞાત સ્થિતિ (ગેરહાજર)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "જોડાયેલ નથી"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "રૂપરેખાંકન નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "IP રૂપરેખાંકન નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "IP રૂપરેખાંકન નિવૃત્ત"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "ખાનગીની જરૂરિયાત હતી, પરંતુ પૂરુ પાડેલ નથી"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1X સપ્લિકન્ટનું જોડાણ તૂટી ગયુ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1X સપ્લિકન્ટ રૂપરેખાંકન નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1X સપ્લિકન્ટ નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1X સપ્લિકન્ટ સત્તાધિકરણ કરવા માટે લાંબો સમય લીધો"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "શરૂ કરવા માટે PPP સેવા નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "તૂટી ગયેલ PPP સેવા જોડાણ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "શરૂ કરવા માટે DHCP ક્લાયન્ટ નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP ક્લાયન્ટ ભૂલ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP ક્લાયન્ટ નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "શરૂ કરતી વખતે વહેંચાયેલ જોડાણ સેવા નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "વહેંચાયેલ જોડાણ સેવા નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "શરૂ કરવા માટે AutoIP સેવા નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "AutoIP સેવા ભૂલ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "AutoIP સેવા નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "લાઇન વ્યસ્ત છે"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "ડાયલ ટોન નથી"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "કૅરિઅર સ્થાપિત કરી શક્યા નહિં"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "ડાયલ કરવાની માંગણીનો સમય સમાપ્ત"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "ડાયલ કરવાનો પ્રયાસ નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "મોડેમની શરૂઆત નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "ખાસ APN ને પસંદ કરવાનું નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "નેટવર્કો માટે શોધી રહ્યા નથી"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "નામંજૂર થયેલ નેટવર્ક રજીસ્ટ્રેશન"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "નેટવર્ક રજીસ્ટ્રેશન કરવાનો સમય સમાપ્ત થઇ ગયો"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "સૂચિત નેટવર્ક સાથે રજીસ્ટર કરવાનું નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "PIN ચકાસણી નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "ઉપકરણ માટે જરૂરી ફર્મવેર ગુમ થઇ શકે છે"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "જોડાણ અદૃશ્ય"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "હાલનાં જોડાણને ધારેલ હતુ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "મોડેમ મળ્યુ નથી"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "બ્લુટુથ જોડાણ નિષ્ફળ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "SIM કાર્ડ દાખલ થયેલ નથી"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "SIM પીનની જરૂરિયાત છે"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "SIM Puk જરૂરી"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "SIM ખોટુ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "InfiniBand ઉપકરણ જોડાયેલ સ્થિતિને આધાર આપતુ નથી"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "જોડાણ નિર્ભરતા નિષ્ફળ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "ફર્મવેર ગેરહાજર"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "કૅબલ પ્લગ થયેલ નથી"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "Certificate Authority (પ્રમાણપત્ર સત્તા) પ્રમાણપત્ર પસંદ થયેલ નથી"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"Certificate Authority (CA) પ્રમાણપત્ર વાપર્યા વગર અસુરક્ષિત, ઠગ Wi-Fi નેટવર્કો "
+"જોડાણોમાં પરિણમી શકે છે. શું તમે Certificate Authority પ્રમાણપત્રને પસંદ કરવા માંગો છો?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "અવગણો"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "CA પ્રમાણપત્રને પસંદ કરો"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, અથવા PKCS#12 ખાનગી કી (*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER અથવા PEM પ્રમાણપત્રો (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+msgid "Choose a PAC file"
+msgstr "PAC ફાઇલને પસંદ કરો"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC ફાઇલો (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+#| msgid "All files"
+msgid "PAC _file"
+msgstr "PAC ફાઇલ (_f)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+#| msgid "Authentication failed"
+msgid "_Inner authentication"
+msgstr "આંતરિક સત્તાધિકરણ (_I)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "PAC બચાવ (_v)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "અનામિક"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#| msgid "Authentication failed"
+msgid "Authenticated"
+msgstr "સત્તાધિકરણ થયેલ"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "બંને"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "વપરાશકર્તા નામ (_U)"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#| msgid "_Show password"
+msgid "Sho_w password"
+msgstr "પાસવર્ડ બતાવો (_w)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate"
+msgstr "Certificate Authority પ્રમાણપત્ર ને પસંદ કરો"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#| msgid "Version %s"
+msgid "Version 0"
+msgstr "આવૃત્તિ 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#| msgid "Version %s"
+msgid "Version 1"
+msgstr "આવૃત્તિ 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "CA પ્રમાણપત્ર (_A)"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP આવૃત્તિ (_v)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "દરેક વખતે આ પાસવર્ડ માટે પૂછો (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "એનક્રિપ્ટ ન થયેલ ખાનગી કી અસુરક્ષિત છે"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"પસંદ થયેલ ખાનગી કીને પાસવર્ડ દ્દારા સુરક્ષિત કરવા માટે દેખાતુ નથી.  આ સમાધાન કરવા માટે "
+"તમારી સુરક્ષા શ્રેયોને પરવાનગી આપી શકે છે.  મહેરબાની કરીને પાસવર્ડ-સુરક્ષિત થયેલ ખાનગી કી "
+"ને પસંદ કરો.\n"
+"\n"
+"(તમે openssl સાથે તમારી ખાનગી કીને પાસવર્ડ-સુરક્ષિત કરી શકો છો)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+msgid "Choose your personal certificate"
+msgstr "તમારાં વ્યક્તિગત પ્રમાણપત્રને પસંદ કરો"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+msgid "Choose your private key"
+msgstr "તમારી ખાનગી કીને પસંદ કરો"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "ઓળખાણ (_d)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "વપરાશકર્તા પ્રમાણપત્ર (_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "ખાનગી કી (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#| msgid "_Generate a password"
+msgid "_Private key password"
+msgstr "ખાનગી કી પાસવર્ડ (_P)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#| msgid "WPA"
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "મને ફરીથી ચેતવણી આપો નહિં (_w)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "ના"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "હાં"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "ટનલ TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "સુરક્ષિત EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#| msgid "Authentication failed"
+msgid "Au_thentication"
+msgstr "સત્તાધિકરણ (_t)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+#| msgid "Default"
+msgid "1 (Default)"
+msgstr "1 (મૂળભૂત)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+#| msgid "System"
+msgid "Open System"
+msgstr "ખુલ્લી સિસ્ટમ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "વહેંચાયેલ કી"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "કી (_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "કી બતાવો (_w)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP અનુક્રમણિકા (_x)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#| msgid "_Type:"
+msgid "_Type"
+msgstr "પ્રકાર (_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+#| msgid "Magnification:"
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "સૂચનાઓ"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+#| msgid "Sound Effects"
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "સાઉન્ડ ચેતવણી"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "પોપઅપ બેનરને બતાવો"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "બેનરમાં વિગતો બતાવો"
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+#| msgid "Lock screen"
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "સ્ક્રીન તાળુમાં જુઓ"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "સ્ક્રીન તાળુમાં વિગતો બતાવો"
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "ચાલુ"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+#| msgid "Magnification:"
+msgid "Notifications"
+msgstr "સૂચનાઓ"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr "કઇ સૂચનાઓ દર્શાવેલ છે અને શું તેઓ બતાવે છે તેની પર નિયંત્રણ કરો"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "સૂચના;બેનર;સંદેશો;ટ્રે;પોપઅપ;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "પોપ અપ બેનરને બતાવો"
+
+#: ../panels/notifications/notifications.ui.h:2
+#| msgid "Lock screen"
+msgid "Show in Lock Screen"
+msgstr "સ્ક્રીન તાળુમાં બતાવો"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+#| msgid "Other..."
+msgctxt "Online Account"
+msgid "Other"
+msgstr "બીજુ"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "ખાતુ ઉમેરો"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+#| msgid "_Mail"
+msgid "Mail"
+msgstr "મેઈલ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+#| msgid "Contrast:"
+msgid "Contacts"
+msgstr "સંપર્કો"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "વાતચીત"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "સ્ત્રોતો"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "ખાતામાં પ્રવેશતી વખતે ભૂલ"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "શ્રેયની મર્યાદા પૂરી થઇ ગઇ."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+#| msgid "Enable this account"
+msgid "Sign in to enable this account."
+msgstr "આ ખાતાને સક્રિય કરવા માટે પ્રવેશો."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr "પ્રવેશો (_S)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "ખાતાને બનાવતી વખતે ભૂલ"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "ખાતાને દૂર કરી રહ્યા હોય ત્યારે ભૂલ"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "શું તમે ખરેખર ખાતાને દૂર કરવા માંગો છો?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "આ સર્વર પર ખાતાને દૂર કરશે નહિં."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "દૂર કરો (_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "ઓનલાઇન ખાતાઓ"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "તમારાં ઓનલાઇન ખાતામાં જોડાવો અને નક્કી કરો તે તેઓ માટે શું વાપરવુ છે"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#| msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;વેબ;ઓનલાઇન;વાતચીત;કૅલેન્ડર;મેઇલ;સંપર્ક;ownCloud;કર્બોસ;IMAP;SMTP;"
+"પોકેટ;ReadItLater;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "રૂપરેખાંકિત થયેલ ઓનલાઇન ખાતા નથી"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "ખાતુ દૂર કરો"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "ઓનલાઇન ખાતા ઉમેરો"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"ખાતાને ઉમેરવાનું દસ્તાવેજો, મેઇલ, સંપર્કો, કૅલેન્ડર, વાચચીત અને વધારે માટે તમારાં કાર્યક્રમોને "
+"વાપરવાની પરવાનગી આપે છે."
+
+#: ../panels/power/cc-power-panel.c:183
+msgid "Unknown time"
+msgstr "અજ્ઞાત સમય"
+
+#: ../panels/power/cc-power-panel.c:189
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i મિનિટ"
+msgstr[1] "%i મિનિટ"
+
+#: ../panels/power/cc-power-panel.c:201
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i કલાક"
+msgstr[1] "%i કલાકો"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:209
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:210
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "કલાક"
+msgstr[1] "કલાકો"
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "મિનિટ"
+msgstr[1] "મિનિટ"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:230
+#, c-format
+#| msgid "Charging - %s until fully charged"
+msgid "%s until fully charged"
+msgstr "ચાર્જ થાય ત્યાં સુધી %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:237
+#, c-format
+#| msgid "Caution low UPS, %s remaining"
+msgid "Caution: %s remaining"
+msgstr "ચેતવણી: %s બાકી રહ્યુ છે"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:242
+#, c-format
+msgid "%s remaining"
+msgstr "%s બાકી રહેલ છે"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
+#| msgid "Full Screen"
+msgid "Fully charged"
+msgstr "સંપૂર્ણપણે ચાર્જ થયેલ છે"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
+msgid "Empty"
+msgstr "ખાલી"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Charging"
+msgstr "ચાર્જિંગ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:271
+#| msgid "Charging"
+msgid "Discharging"
+msgstr "ડિસ્ચાર્જ થઇ રહ્યુ છે"
+
+#: ../panels/power/cc-power-panel.c:396
+msgctxt "Battery name"
+msgid "Main"
+msgstr "મુખ્ય"
+
+#: ../panels/power/cc-power-panel.c:398
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "વધારાનું"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:470
+msgid "Wireless mouse"
+msgstr "વાયરલેસ માઉસ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:473
+msgid "Wireless keyboard"
+msgstr "વાયરલેસ કિબોર્ડ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:476
+msgid "Uninterruptible power supply"
+msgstr "અવરોધી ન શકાય તેવો વીજ પુરવઠો"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Personal digital assistant"
+msgstr "વ્યક્તિગત ડિઝિટલ મદદકર્તા"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Cellphone"
+msgstr "સેલફોન"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Media player"
+msgstr "મીડિયા પ્લેયર"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Tablet"
+msgstr "ટૅબલેટ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Computer"
+msgstr "કમ્પ્યૂટર"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
+#: ../panels/power/cc-power-panel.c:2019
+msgid "Battery"
+msgstr "બેટરી"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "ચાર્જિંગ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "સાવધાન"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Low"
+msgstr "નીચે"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Good"
+msgstr "સરસ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:562
+#| msgid "Full Screen"
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "સંપૂર્ણપણે ચાર્જ થયેલ છે"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "ખાલી"
+
+#: ../panels/power/cc-power-panel.c:715
+#| msgid "Battery"
+msgid "Batteries"
+msgstr "બેટરી"
+
+#: ../panels/power/cc-power-panel.c:1117
+msgid "When _idle"
+msgstr "જ્યારે નિષ્ક્રિય હોય (_i)"
+
+#: ../panels/power/cc-power-panel.c:1445
+msgid "Power Saving"
+msgstr "પાવર સંગ્રહ"
+
+#: ../panels/power/cc-power-panel.c:1473
+#| msgid "Brightness"
+msgid "_Screen brightness"
+msgstr "સ્ક્રીન પ્રકાશતા (_S)"
+
+#: ../panels/power/cc-power-panel.c:1479
+#| msgid "Keyboard Settings"
+msgid "_Keyboard brightness"
+msgstr "કિબોર્ડ પ્રકાશતા (_K)"
+
+#: ../panels/power/cc-power-panel.c:1489
+#| msgid "_Turn screen off when inactive for:"
+msgid "_Dim screen when inactive"
+msgstr "ઝાંખી સ્ક્રીન જ્યારે નિષ્ક્રિય હોય (_D)"
+
+#: ../panels/power/cc-power-panel.c:1514
+#| msgid "Lock screen"
+msgid "_Blank screen"
+msgstr "કોરી સ્ક્રીન (_B)"
+
+#: ../panels/power/cc-power-panel.c:1551
+msgid "_Wi-Fi"
+msgstr "Wi-Fi (_W)"
+
+#: ../panels/power/cc-power-panel.c:1556
+msgid "Turns off wireless devices"
+msgstr "વાયરલેસ ઉપકરણોને બંધ કરે છે"
+
+#: ../panels/power/cc-power-panel.c:1581
+#| msgid "Mobile broadband"
+msgid "_Mobile broadband"
+msgstr "મોબાઇલ બ્રોડબેન્ડ (_M)"
+
+#: ../panels/power/cc-power-panel.c:1586
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "મોબાઇલ બ્રોડબેન્ડ (3G, 4G, WiMax, વગેરે.) ઉપકરણોને બંધ કરે છે"
+
+#: ../panels/power/cc-power-panel.c:1635
+#| msgid "Bluetooth"
+msgid "_Bluetooth"
+msgstr "બ્લુટુથ (_B)"
+
+#: ../panels/power/cc-power-panel.c:1686
+#| msgid "On battery power"
+msgid "When on battery power"
+msgstr "જ્યારે બેટરી પાવર પર છે"
+
+#: ../panels/power/cc-power-panel.c:1688
+msgid "When plugged in"
+msgstr "જ્યારે પ્લગ થયેલ હોય"
+
+#: ../panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Off"
+msgstr "સ્થગિત અને પાવર બંધ"
+
+#: ../panels/power/cc-power-panel.c:1851
+#| msgctxt "proxy method"
+#| msgid "Automatic"
+msgid "_Automatic suspend"
+msgstr "આપમેળે સ્થગિત (_A)"
+
+#: ../panels/power/cc-power-panel.c:1875
+#| msgid "When power is _critically low"
+msgid "When battery power is _critical"
+msgstr "જ્યારે બેટરી પાવર જટીલ હોય (_C)"
+
+#: ../panels/power/cc-power-panel.c:1930
+#| msgid "Power off"
+msgid "Power Off"
+msgstr "પાવર બંધ"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Devices"
+msgstr "ઉપકરણો"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "પાવર"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr "તમારી બેટરી સ્થિતિને જુઓ અને પાવર સંગ્રહ સુયોજનોને બદલો"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+#| msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+msgid "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr "પાવર;સ્લીપ;સ્થગિત;હાઇબરનેટ;બેટરી;પ્રકાશતા;ઝાંખુ;ખાલી;મોનિટર;DPMS;નિષ્ક્રિય;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "હાઇબરનેટ"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "પાવર બંધ"
+
+#: ../panels/power/power.ui.h:5
+#| msgid "5 minutes"
+msgid "45 minutes"
+msgstr "45 મિનિટ"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 કલાક"
+
+#: ../panels/power/power.ui.h:7
+#| msgid "10 minutes"
+msgid "80 minutes"
+msgstr "80 મિનિટ"
+
+#: ../panels/power/power.ui.h:8
+#| msgid "10 minutes"
+msgid "90 minutes"
+msgstr "90 મિનિટ"
+
+#: ../panels/power/power.ui.h:9
+#| msgid "10 minutes"
+msgid "100 minutes"
+msgstr "100 મિનિટ"
+
+#: ../panels/power/power.ui.h:10
+#| msgid "1 hour"
+msgid "2 hours"
+msgstr "2 કલાક"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 મિનિટ"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 મિનિટો"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 મિનિટો"
+
+#: ../panels/power/power.ui.h:14
+#| msgid "5 minutes"
+msgid "4 minutes"
+msgstr "4 મિનિટ"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 મિનિટો"
+
+#: ../panels/power/power.ui.h:16
+#| msgid "5 minutes"
+msgid "8 minutes"
+msgstr "8 મિનિટ"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 મિનિટો"
+
+#: ../panels/power/power.ui.h:18
+#| msgid "2 minutes"
+msgid "12 minutes"
+msgstr "12 મિનિટ"
+
+#: ../panels/power/power.ui.h:20
+#| msgctxt "proxy method"
+#| msgid "Automatic"
+msgid "Automatic Suspend"
+msgstr "આપમેળે સ્થગિત"
+
+#: ../panels/power/power.ui.h:21
+#| msgid "When plugged in"
+msgid "_Plugged In"
+msgstr "માં પ્લગ થયેલ (_P)"
+
+#: ../panels/power/power.ui.h:22
+#| msgid "On battery power"
+msgid "On _Battery Power"
+msgstr "બેટરી પાવર પર (_B):"
+
+#: ../panels/power/power.ui.h:23
+#| msgid "_Delay:"
+msgid "Delay"
+msgstr "વિલંબ"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+#| msgid "Authentication failed"
+msgid "Authenticate"
+msgstr "સત્તાધિકરણ"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+#| msgid "_Password"
+msgid "Password"
+msgstr "પાસવર્ડ"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+#| msgid "Authentication required"
+msgid "Authentication Required"
+msgstr "સત્તાધિકરણ જરૂરી"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr "ટૉનર ઓછુ છે"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr "ટોનરની બહાર"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr "ડેવલપર ઓછું છે"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr "ડેવલપરની બહાર"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr "માર્કર પૂરવઠો ઓછો છે"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr "માર્કર પૂરવઠાની બહાર"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr "કવર ખોલો"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr "દરવાજો ખોલો"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr "પેપર ઓછા"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr "પેપરની બહાર"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ઓફલાઇન"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "બંધ થયેલ"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr "લગભગ સંપૂર્ણ પાત્ર કચરો"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr "સંપૂર્ણ પાત્ર કચરો"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr "ઓપ્ટીકલ ફોટો કન્ડક્ટર જીવનનાં અંત નજીક છે"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ઓપ્ટીકલ ફોટો કન્ડક્ટર લાંબા સમય સુધી કાર્ય કરતુ નથી"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "રૂપરેખાંકિત કરી રહ્યા છે"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr "તૈયાર"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "કાર્યોને સ્વીકારો નહિં"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr "પ્રોસેસીંગ"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Toner Level"
+msgstr "ટૉનર સ્તર"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Ink Level"
+msgstr "ઇંક સ્તર"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:928
+msgid "Supply Level"
+msgstr "પૂરવઠો સ્તર"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:946
+msgctxt "printer state"
+msgid "Installing"
+msgstr "સ્થાપિત કરી રહ્યા છે"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1123
+msgid "No printers available"
+msgstr "પ્રિન્ટરો ઉપલબ્ધ નથી"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1433
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u સક્રિય"
+msgstr[1] "%u સક્રિય"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1777
+msgid "Failed to add new printer."
+msgstr "નવાં પ્રિન્ટરને ઉમેરવાનું નિષ્ફળ."
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid "Select PPD File"
+msgstr "PPD ફાઇલ પસંદ કરો"
+
+#: ../panels/printers/cc-printers-panel.c:1953
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr "PostScript પ્રિન્ટર વર્ણન ફાઈલો (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2258
+msgid "No suitable driver found"
+msgstr "સુસંગત ડ્રાઇવર મળ્યુ નથી"
+
+#: ../panels/printers/cc-printers-panel.c:2327
+#| msgid "Searching for preferred drivers..."
+msgid "Searching for preferred drivers…"
+msgstr "પસંદ થયેલ ડ્રાઇવરોને શોધી રહ્યા છે..."
+
+#: ../panels/printers/cc-printers-panel.c:2342
+#| msgid "Select from database..."
+msgid "Select from database…"
+msgstr "ડેટાબેઝમાંથી પસંદ કરો..."
+
+#: ../panels/printers/cc-printers-panel.c:2351
+#| msgid "Provide PPD File..."
+msgid "Provide PPD File…"
+msgstr "PPD ફાઈલ પૂરી પાડો..."
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2502
+#: ../panels/printers/cc-printers-panel.c:2525
+msgid "Test page"
+msgstr "ચકાસણી પાનું"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2933
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui ને લોડ કરી શક્યા નહિં: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "પ્રિન્ટરો"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "પ્રિન્ટર ઉમેરો, પ્રિન્ટર ક્રિયાને જુઓ અને નક્કી કરો કે કેવી રીતે તમે છાપવા માંગો છો"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "પ્રિન્ટર;કતાર;છાપો;પેપર;સહી;ટૉનર;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "સક્રિય ક્રિયા"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "બંધ કરો"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "છાપવાનું પુન:લાવો"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "છાપવાનું અટકાવો"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "છાપન ક્રિયા રદ કરો"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "નવાં પ્રિન્ટરને ઉમેરો"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+#| msgid "Authentication failed"
+msgid "A_uthenticate"
+msgstr "સત્તાધિકરણ (_u)"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "પ્રિન્ટર શોધાયેલ નથી."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+#| msgid "Search for network printers or filter result"
+msgid "Enter address of a printer or a text to filter results"
+msgstr "પરિણામોને ફિલ્ટર કરવા માટે પ્રિન્ટર અથવા લખાણનાં સરનામાંને દાખલ કરો"
+
+#: ../panels/printers/options-dialog.ui.h:1
+#| msgid "Loading options..."
+msgid "Loading options…"
+msgstr "વિકલ્પો લાવી રહ્યા છે…"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "પ્રિન્ટર ડ્રાઇવરને પસંદ કરો"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "ડ્રાઇવર ડેટાબેઝને લાવી રહ્યા છે..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+#| msgid "Remove Printer"
+msgid "JetDirect Printer"
+msgstr "JetDirect પ્રિન્ટર"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+#| msgctxt "Device kind"
+#| msgid "Printer"
+msgid "LPD Printer"
+msgstr "LPD પ્રિન્ટર"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "એકતરફી"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "લાંબી બાજુ (મૂળભૂત)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "ટૂંકી બાજુ (ફ્લિપ)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "પૉર્ટેટ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "લૅન્ડસ્કેપ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "વિપરીત લૅન્ડસ્કેપ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "વિપરીત પૉર્ટ્રેટ"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "સ્થગિત"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "અટકેલ"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "પ્રોસેસીંગ"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "બંધ થયેલ"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "રદ થયેલ"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "કાઢી નાંખેલ"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "સમાપ્ત"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "જોબ શીર્ષક"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "જૉબ સ્થિતિ"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "સમય"
+
+#: ../panels/printers/pp-jobs-dialog.c:495
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s સક્રિય ક્રિયા"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Serial Port"
+msgstr "સીરીયલ પોર્ટ"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1683
+msgid "Parallel Port"
+msgstr "સમાંતર પોર્ટ"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+#| msgid "Location"
+msgid "Location: %s"
+msgstr "સ્થાન: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1744
+#, c-format
+#| msgid "A_ddress:"
+msgid "Address: %s"
+msgstr "સરનામું: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1768
+msgid "Server requires authentication"
+msgstr "સર્વરને સત્તાધિકરણની જરૂરિયાત છે"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "દ્દિતરફી"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "પેપર પ્રકાર"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "પેપર સ્ત્રોત"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "આઉટપુટ ટ્રે"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript ફરી ફિલ્ટર કરી રહ્યા છે"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:531
+msgid "Pages per side"
+msgstr "બાજુ પ્રતિ પાનાંઓ"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:543
+msgid "Two-sided"
+msgstr "દ્દિતરફી"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:555
+msgid "Orientation"
+msgstr "દિશા"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:652
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "સામાન્ય"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "પાનું સુયોજન"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "સ્થાપન કરી શકાય તેવા વિકલ્પો"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "ક્રિયા"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "ઇમેજ ગુણવત્તા"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "રંગ"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "સમાપ્ત કરી રહ્યા છે"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "ઉન્નત"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "સ્વયં પસંદ કરો"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "મૂળભૂત પ્રિન્ટર "
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "ફક્ત ઍમ્બેડ GhostScript ફોન્ટ"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "PS સ્તર 1 માં રૂપાંતરિત કરો"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "PS સ્તર 2 માં રૂપાંતરિત કરો"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "પહેલેથી ફિલ્ટર કરવુ નહિં"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+#| msgid "Manufacturer:"
+msgid "Manufacturer"
+msgstr "ઉત્પાદક"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "ડ્રાઇવર"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr "%s પર ઉપલબ્ધ પ્રિન્ટરોને જોવા માટે તમારાં વપરાશકર્તાનામ અને પાસવર્ડને દાખલ કરો."
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "પ્રિન્ટરને ઉમેરો"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "પ્રિન્ટર દૂર કરો"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "પૂરુ પાડો"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "સ્થાન"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+#| msgid "Default Route"
+msgid "_Default printer"
+msgstr "મૂળભૂત પ્રિન્ટર (_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "જોબ"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "કાર્યોને બતાવો (_J)"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "મોડેલ"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "લેબલ"
+
+#: ../panels/printers/printers.ui.h:17
+#| msgid "Setting new driver..."
+msgid "Setting new driver…"
+msgstr "નવાં ડ્રાઇવરને સુયોજિત કરી રહ્યા છે…"
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "પાનું 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "ચકાસણી પાનાંને છાપો (_T)"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "વિકલ્પો (_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "નવાં પ્રિન્ટરને ઉમેરો"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr "દિલગીર છુ! સિસ્ટમ પ્રિન્ટીંગ સેવા ઉપલબ્ધ નથી એવુ લાગે છે."
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+#| msgid "Screenshots"
+msgid "Screen Lock"
+msgstr "સ્ક્રીન તાળુ"
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "વપરાશ અને ઇતિહાસ"
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr "શું કચરાપેટીમાંથી બધી વસ્તુઓને ખાલી કરો?"
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr "કચરાપેટીમાં બધી વસ્તુઓને કાયમ માટે કાઢી નાંખેલ છે."
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "કચરાપેટી ખાલી કરો (_E)"
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+msgid "Delete all the temporary files?"
+msgstr "શું બધી કામચલાઉ ફાઇલોને કાઢવાની છે?"
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr "બધી કામચલાઉ ફાઇલો કાયમ માટે કાઢી નંખાશે."
+
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+#| msgid "_Keep Files"
+msgid "_Purge Temporary Files"
+msgstr "કામચલાઉ ફાઇલોને સાફ કરો (_P)"
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "કચરાપેટી અને કામચલાઉ ફાઇલોને સાફ કરો"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+#| msgid "Software"
+msgid "Software Usage"
+msgstr "સોફ્ટવેર વપરાશ"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "ખાનગી"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr "તમારી વ્યક્તિગત જાણકારીને સુરક્ષિત કરો અને બીજા શું જોઇ શકે તેની પર નિયંત્રણ કરો"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"સ્ક્રીન;તાળુ;નિદાન;ભંગાણ;ખાનગી;તાજેતરનું;કામચલાઉ;tmp;અનુક્રમણિકા;નામ;"
+"નેટવર્ક;ઓળખાણ;"
+
+#: ../panels/privacy/privacy.ui.h:1
+#| msgid "Screen turns off"
+msgid "Screen Turns Off"
+msgstr "સ્ક્રીન બંધ થાય છે"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 સેકંડ"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 દિવસ"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 દિવસો"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 દિવસો"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 દિવસો"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 દિવસો"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 દિવસો"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 દિવસો"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 દિવસો"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 દિવસો"
+
+#: ../panels/privacy/privacy.ui.h:18
+#| msgid "never"
+msgid "Forever"
+msgstr "હંમેશા"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"તમારાં ઇતિહાસને યાદ રાખવુ ફરી શોધવા માટે સરળ બની જાય છે. આ વસ્તુઓ નેટવર્ક પર કદી વહેંચાતી નથી."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "તાજેતરમાં વાપરેલ છે (_R)"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "ઇતિહાસને પુન:પ્રાપ્ત કરો (_H)"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "તાજેતરનો ઇતિહાસ સાફ કરો (_e)"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "તાળુ સ્ક્રીન તમારી ખાનગી જાણકારીને સુરક્ષિત રાખે છે જ્યારે તમે દૂર હોય."
+
+#: ../panels/privacy/privacy.ui.h:26
+#| msgid "A_utomatic Login"
+msgid "Automatic Screen _Lock"
+msgstr "આપમેળે સ્ક્રીનનું તાળુ (_L)"
+
+#: ../panels/privacy/privacy.ui.h:27
+#| msgid "_Lock screen after:"
+msgid "Lock screen _after blank for"
+msgstr "ખાલી પછી સ્ક્રીનને તાળુ મારો (_a)"
+
+#: ../panels/privacy/privacy.ui.h:28
+#| msgid "Show _notifications when locked"
+msgid "Show _Notifications"
+msgstr "સૂચનાઓ બતાવો (_N)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"બિનજરૂરી સંવેદનશીલ જાણકારીથી તમારાં કમ્પ્યૂટરને મુક્ત રાખવા મદદ કરવા માટે પહેલાં આપમેળે "
+"કચરાપેટી અને કામચલાઉ ફાઇલોને સાફ કરો."
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "આપમેળે કચરાપેટી ખાલી (_T)"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "આપમેળે કામચલાઉ ફાઇલોને સાફ કરો (_F)"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "પછી સાફ કરો (_A)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"ક્યાં સોફ્ટવેર તમે વાપરો છે જે તમને વધારે ચોક્કસ અગ્રહતા સાથે તમને પૂરુ પાડવા મદદ કરે છે તે "
+"વિશે જાણકારી અમને મોકલી રહ્યા છે. તે અમારાં સોફ્ટવેરને સુધારવા માટે પણ અમને મદદ કરે છે.\n"
+"\n"
+"બધી જાણકારી જે અમે અનામિક રીતે સંગ્રહી છે, અને અમે ત્રીજી પાર્ટી સાથે તમારી માહિતીને વહેંચવાની "
+"કદી જરૂર પડશે નહિં."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "સોફ્ટવેર વપરાશનાં આંકડા મોકલો (_S)"
+
+#: ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "ખાનગી પોલિસી"
+
+#: ../panels/privacy/privacy.ui.h:42
+#| msgid "Location"
+msgid "_Location Services"
+msgstr "સ્થાન સેવા (_L)"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "તમારાં ભૌગોલિક સ્થાનને નક્કી કરવા વાપરેલ છે"
+
+#: ../panels/region/cc-format-chooser.c:119
+#| msgid "Imperial"
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ઇમ્પેરીઅલ"
+
+#: ../panels/region/cc-format-chooser.c:121
+#| msgid "Metric"
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "મેટ્રીક"
+
+#: ../panels/region/cc-format-chooser.c:284
+msgid "No regions found"
+msgstr "વિસ્તાર મળ્યા નથી"
+
+#: ../panels/region/cc-input-chooser.c:179
+#| msgid "Move Input Source Down"
+msgid "No input sources found"
+msgstr "ઇનપુટ સ્ત્રોત મળ્યા નથી"
+
+#: ../panels/region/cc-input-chooser.c:1076
+#| msgid "Other..."
+msgctxt "Input Source"
+msgid "Other"
+msgstr "બીજુ"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:896
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "તમારાં બદલાવોની અસર લાવવા માટે તમારા સત્રને પુન:શરૂ કરવુ જરૂરી છે"
+
+#: ../panels/region/cc-region-panel.c:240
+#: ../panels/user-accounts/um-user-panel.c:897
+msgid "Restart Now"
+msgstr "હવે પુન:શરૂ કરો"
+
+#: ../panels/region/cc-region-panel.c:858
+#| msgid "No printers detected."
+msgid "No input source selected"
+msgstr "ઇનપુટ સ્ત્રોત પસંદ થયેલ નથી"
+
+#: ../panels/region/cc-region-panel.c:1088
+msgid "Sorry"
+msgstr "દિલગીર છુ"
+
+#: ../panels/region/cc-region-panel.c:1090
+msgid "Input methods can't be used on the login screen"
+msgstr "પ્રવેશ સ્ક્રીન પર ઇનપુટ પદ્દતિઓને વાપરી શકાતુ નથી"
+
+#: ../panels/region/cc-region-panel.c:1727
+#| msgid "Lock screen"
+msgid "Login Screen"
+msgstr "પ્રવેશ સ્ક્રીન"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "બંધારણો"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "પૂર્વદર્શન"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "તારીખો"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "સમય"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "નંબરો"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "માપ"
+
+#: ../panels/region/format-chooser.ui.h:9
+#| msgid "Paper Type"
+msgid "Paper"
+msgstr "કાગળ"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "પ્રદેશ અને ભાષા"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid "Select your display language, formats, keyboard layouts and input sources"
+msgstr "તમારી દર્શાવ ભાષા, બંધારણો, કિબોર્ડ લેઆઉટ અને ઇનપુટ સ્ત્રોતોને પસંદ કરો"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#| msgid "Language;Layout;Keyboard;"
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "ભાષા;લેઆઉટ;કિબોર્ડ;ઇનપુટ;"
+
+#: ../panels/region/input-chooser.ui.h:1
+#| msgid "Add Input Source"
+msgid "Add an Input Source"
+msgstr "ઇનપુટ સ્ત્રોત ઉમેરો "
+
+#: ../panels/region/input-options.ui.h:1
+#| msgid "Input Source Settings"
+msgid "Input Source Options"
+msgstr "ઇનપુટ સ્ત્રોત વિકલ્પો"
+
+#: ../panels/region/input-options.ui.h:2
+#| msgid "Use same layout in all windows"
+msgid "Use the _same source for all windows"
+msgstr "બધી વિન્ડો માટે સરખા સ્ત્રોતને વાપરો (_s)"
+
+#: ../panels/region/input-options.ui.h:3
+#| msgid "Allow different layouts for each window"
+msgid "Allow _different sources for each window"
+msgstr "દરેક વિન્ડો માટે વિવિધ સ્ત્રોતોને પરવાનગી આપો (_d)"
+
+#: ../panels/region/input-options.ui.h:4
+#| msgid "Keyboard Settings"
+msgid "Keyboard Shortcuts"
+msgstr "કિબોર્ડ ટૂંકાણો"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Switch to previous source"
+msgstr "પહેલાનાં સ્ત્રોતમાં બદલો"
+
+#: ../panels/region/input-options.ui.h:6
+#| msgid "Ctrl+Alt+Shift+Space"
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Switch to next source"
+msgstr "આગળનાં સ્ત્રોત પર જાવ"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "કિબોર્ડ સુયોજનોમાં આ ટૂંકાણોને તમે બદલી શકો છો"
+
+#: ../panels/region/input-options.ui.h:10
+#| msgid "Switch to next source"
+msgid "Alternative switch to next source"
+msgstr "આગળનાં સ્ત્રોત પર જાવ"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Left+Right Alt"
+msgstr "ડાબી+જમણી Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "અંગ્રેજી (United Kingdom)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "United Kingdom"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "વિકલ્પો"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr "બધા વપરાશકર્તાઓ દ્દારા પ્રવેશ સુયોજનો વાપરેલ છે જ્યારે સિસ્ટમમાં પ્રવેશી રહ્યા છે"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr "સ્થાનો"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "બુકમાર્કો"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+#| msgid "Other..."
+msgctxt "Search Location"
+msgid "Other"
+msgstr "બીજુ"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/search/cc-search-locations-dialog.c:678
+#| msgid "Select a region"
+msgid "Select Location"
+msgstr "સ્થાન પસંદ કરો"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+#| msgid "GOK"
+msgid "_OK"
+msgstr "બરાબર (_O)"
+
+#: ../panels/search/cc-search-panel.c:176
+#| msgid "Applications"
+msgid "No applications found"
+msgstr "કાર્યક્રમો મળ્યા નથી"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "શોધો"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid "Control which applications show search results in the Activities Overview"
+msgstr "પ્રવૃત્તિ ઝાંખીમાં ક્યાં કાર્યક્રમો શોધ પરિણામોને બતાવે છે તેની પર નિયંત્રણ કરો"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "શોધો;શોધો;અનુક્રમણિકા;છુપાડો;ખાનગી;પરિણામો;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+#| msgid "Location"
+msgid "Search Locations"
+msgstr "સ્થાનો શોધો"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "ઉપર ખસેડો"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "નીચે ખસેડો"
+
+#: ../panels/search/search.ui.h:3
+#| msgid "Mouse Preferences"
+msgid "Preferences"
+msgstr "પસંદગીઓ"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "ચાલુ"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "બંધ"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#: ../panels/sharing/cc-sharing-panel.c:304
+#| msgid "Enabled"
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "સક્રિય"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+#| msgid "Active Jobs"
+msgctxt "service is active"
+msgid "Active"
+msgstr "સક્રિય"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+#| msgid "Choose a Layout"
+msgid "Choose a Folder"
+msgstr "ફોલ્ડર પસંદ કરો"
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "નકલ કરો"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+#| msgid "Hearing"
+msgid "Sharing"
+msgstr "ભાગીદારી"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "તમે શું બીજાઓ સાથે ભાગીદારી કરવા માંગો છો તેની પર નિયંત્રિત કરો"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"વહેંચો;ભાગીદારી;ssh;યજમાન;નામ;દૂરસ્થ;ડેસ્કટોપ;બ્લુટુથ;ઑબેક્સ;મીડિયા;ઓડિયો;વિડિયો;"
+"ચિત્રો;ફોટા;ચિત્રપટ;સર્વર;રેન્ડરર;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+#| msgid "Enable h_orizontal scrolling"
+msgid "Enable or disable remote login"
+msgstr "દૂરસ્થ પ્રવેશને સક્રિય અથવા નિષ્ક્રિય કરો"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+#| msgid "Authentication is required to change user data"
+msgid "Authentication is required to enable or disable remote login"
+msgstr "દૂરસ્થ પ્રવેશને સક્રિય અથવા નિષ્ક્રિય કરવા માટે સત્તાધિકરણ જરૂરી છે"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:299
+msgid "No networks selected for sharing"
+msgstr "ભાગીદારી માટે પસંદ થયેલ નેટવર્ક નથી"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+#| msgid "Network"
+msgid "Networks"
+msgstr "નેટવર્ક"
+
+#: ../panels/sharing/sharing.ui.h:1
+#| msgid "Bluetooth Settings"
+msgid "Bluetooth Sharing"
+msgstr "બ્લુટુથ ભાગીદારી"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"બ્લુટુથ ભાગીદારી બીજા બ્લુટુથ સક્રિય થયેલ ઉપકરણો સાથે ફાઇલોને વહેંચવા તમને પરવાનગી આપે છે"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "ફક્ત વિશ્ર્વાસપાત્ર ઉપકરણોમાંથી મેળવો"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "ડાઉનલોડ ફોલ્ડરમાં મળેલ ફાઇલોને સંગ્રહો"
+
+#: ../panels/sharing/sharing.ui.h:5
+#| msgid "Computer"
+msgid "Computer Name"
+msgstr "કમ્પ્યૂટર નામ"
+
+#: ../panels/sharing/sharing.ui.h:6
+#| msgid "Personal digital assistant"
+msgid "Personal File Sharing"
+msgstr "ખાનગી ફાઈલ વહેંચણી"
+
+#: ../panels/sharing/sharing.ui.h:7
+#| msgid "Screen part:"
+msgid "Screen Sharing"
+msgstr "સ્ક્રીન ભાગીદારી"
+
+#: ../panels/sharing/sharing.ui.h:8
+#| msgid "Media player"
+msgid "Media Sharing"
+msgstr "મીડિયા ભાગીદારી"
+
+#: ../panels/sharing/sharing.ui.h:9
+#| msgid "Remove Region"
+msgid "Remote Login"
+msgstr "દૂરસ્થ પ્રવેશ"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "અમુક સેવાઓ નિષ્ક્રિય થયેલ છે કારણ કે નેટવર્ક પ્રવેશ નથી."
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"વ્યક્તિગત ફાઇલ ભાગીદારી તમારાં હાલના નેટવર્કને વાપરીને બીજાઓ સાથે તમારા સાર્વજનિક ફોલ્ડરને "
+"વહેંચવા તમને પરવાનગી આપે છે: <a href=\"dav://%s\">dav://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:13
+#| msgid "Group Password"
+msgid "Require Password"
+msgstr "પાસવર્ડ જરૂરી"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"સુરક્ષિત શેલ આદેશની મદદથી જોડાવા માટે દૂરસ્થ વપરાશકર્તાઓને પરવાનગી આપો:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"જોવા માટે દૂરસ્થ વપરાશકર્તાઓને પરવાનગી આપો અથવા તેની સાથે જોડાઇને તમારી સ્ક્રીન પર નિયંત્રણ "
+"કરો: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:20
+#| msgid "Volume Control"
+msgid "Allow Remote Control"
+msgstr "દૂરસ્થ નિયંત્રણને પરવાનગી આપો"
+
+#: ../panels/sharing/sharing.ui.h:21
+#| msgid "_Password"
+msgid "Password:"
+msgstr "પાસવર્ડ:"
+
+#: ../panels/sharing/sharing.ui.h:22
+#| msgid "_Show password"
+msgid "Show Password"
+msgstr "પાસવર્ડને બતાવો"
+
+#: ../panels/sharing/sharing.ui.h:23
+#| msgid "%s Options"
+msgid "Access Options"
+msgstr "વિકલ્પો વાપરો"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "નવાં જોડાણે પ્રવેશ માટે પૂછવુ જ જોઇએ"
+
+#: ../panels/sharing/sharing.ui.h:25
+#| msgid "Generate a password"
+msgid "Require a password"
+msgstr "પાસવર્ડની જરૂર છે"
+
+#: ../panels/sharing/sharing.ui.h:26
+msgid "Share music, photos and videos over the network."
+msgstr "નેટવર્ક પર સંગીત, ફોટા અને વિડિયોની ભાગીદારી કરો."
+
+#: ../panels/sharing/sharing.ui.h:27
+msgid "Folders"
+msgstr "ફોલ્ડર"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "ધ્વનિ"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+#| msgid "Change sound volume and sound events"
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "સાઉન્ડ સ્તર, ઇનપુટ, આઉટપુટ, અને સાઉન્ડ ચેતવણીને બદલો"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "કાર્ડ;માઇક્રોફોન;વોલ્યુમ;ઝાંખુ;સંતુલન;બ્લુટુથ;હૅન્ડસેટ;ઓડિયો;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "બાર્ક"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "ઝરમર"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "ગ્લાસ"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "સોનાર"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "ડાબું"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "જમણું"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "પાછળનું"
+
+# #-#-#-#-#  libgnomecanvas.gnome-2-2.hi.po (libgnomecanvas)  #-#-#-#-# libgnomecanvas/gnome-canvas-text.c:238
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-font-picker.c:184 libgnomeui/gnome-font-picker.c:979
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "આગળનું"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "ન્યૂનતમ"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "મહત્તમ"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "સમતુલન (_B):"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "ઝાંખુ પડવુ (_F):"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "સબવુફર (_S):"
+
+#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:616
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "અવાજ વધારો નહિં"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "રૂપરેખા (_P):"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u આઉટપુટ"
+msgstr[1] "%u આઉટપુટો"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ઇનપુટ"
+msgstr[1] "%u ઇનપુટો"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "સિસ્ટમ સાઉન્ડ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "સ્પીકર ચકાસો (_T)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "પીક મળ્યુ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1509
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "નામ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1528
+msgid "Device"
+msgstr "ઉપકરણ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1591
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s માટે સ્પીકર ચકાસણી"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1649
+msgid "_Output volume:"
+msgstr "આઉટપુટ વોલ્યુમ (_O): "
+
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "Output"
+msgstr "આઉટપુટ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1668
+msgid "C_hoose a device for sound output:"
+msgstr "સાઉન્ડ આઉટપુટ માટે ઉપકરણને પસંદ કરો (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1693
+msgid "Settings for the selected device:"
+msgstr "પસંદ થયેલ ઉપકરણ માટે સુયોજનો:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "Input"
+msgstr "ઇનપુટ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "_Input volume:"
+msgstr "ઇનપુટ વોલ્યુમ (_I): "
+
+#: ../panels/sound/gvc-mixer-dialog.c:1734
+msgid "Input level:"
+msgstr "ઈનપુટ સ્તર:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1762
+msgid "C_hoose a device for sound input:"
+msgstr "સાઉન્ડ ઇનપુટ માટે ઉપકરણને પસંદ કરો (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "Sound Effects"
+msgstr "સાઉન્ડ અસરો"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+msgid "_Alert volume:"
+msgstr "ચેતવણી વોલ્યુમ (_A):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1809
+msgid "Applications"
+msgstr "કાર્યક્રમો"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1813
+msgid "No application is currently playing or recording audio."
+msgstr "કાર્યક્રમ હાલમાં ઓડિયોને વગાડી અથવા રેકોર્ડ કરી રહ્યુ છે."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "બિલ્ટ-ઇન"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "સાઉન્ડ પસંદગીઓ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "ઘટના સાઉન્ડની ચકાસણી કરી રહ્યા છીએ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "મૂળભૂત"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "થીમ માંથી"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:769
+msgid "C_hoose an alert sound:"
+msgstr "ચેતવણી સાઉન્ડને પસંદ કરો (_h):"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "બંધ કરો"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "ચકાસો"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "સબવુફર"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# libgnomeprint/gpa/gpa-media.c:241
+# #-#-#-#-#  libgnomeprint.gnome-2-2.hi.po (libgnomeprint VERSION)  #-#-#-#-#
+# libgnomeprint/gpa/gpa-media.c:241
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "વૈવિધ્યપૂર્ણ"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "તેને જોવા, સાંભળવા, ટાઇપ, નિર્દેશિત અને ક્લિક કરવાનું સરળ બનાવો"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"કિબોર્ડ;માઉસ;a11y;સુલભતા;ભેદ;નાનું મોટુ કરો;સ્ક્રીન વાંચક;લખાણ;ફોન્ટ;માપ;"
+"AccessX;સ્ટીકી;કી;ધીમી;બાઉન્સ;માઉસ;"
+
+#: ../panels/universal-access/uap.ui.h:1
+#| msgid "Universal Access"
+msgid "_Always Show Universal Access Menu"
+msgstr "સાર્વત્રિક વપરાશ મેનુને હંમેશા બતાવો (_A)"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "જોઇ રહ્યા છે"
+
+#: ../panels/universal-access/uap.ui.h:3
+#| msgid "High Contrast"
+msgid "_High Contrast"
+msgstr "ઉચ્ચ વિરોધાભાસ (_H)"
+
+#: ../panels/universal-access/uap.ui.h:4
+#| msgid "Large Text"
+msgid "_Large Text"
+msgstr "લાંબુ લખાણ (_L)"
+
+#: ../panels/universal-access/uap.ui.h:5
+#| msgid "Zoom"
+msgid "_Zoom"
+msgstr "નાનું મોટું (_Z)"
+
+#: ../panels/universal-access/uap.ui.h:7
+#| msgid "Screen Reader"
+msgid "Screen _Reader"
+msgstr "સ્ક્રીન વાંચક (_R)"
+
+#: ../panels/universal-access/uap.ui.h:8
+#| msgid "Bounce Keys"
+msgid "_Sound Keys"
+msgstr "સાઉન્ડ કી (_S)"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "સાંભળવુ"
+
+#: ../panels/universal-access/uap.ui.h:10
+#| msgid "Visual Alerts"
+msgid "_Visual Alerts"
+msgstr "દેખીતી ચેતવણીઓ (_V)"
+
+#: ../panels/universal-access/uap.ui.h:12
+#| msgid "Screen keyboard"
+msgid "Screen _Keyboard"
+msgstr "સ્ક્રીન કિબોર્ડ (_K)"
+
+#: ../panels/universal-access/uap.ui.h:13
+#| msgid "Typing Assistant"
+msgid "_Typing Assist (AccessX)"
+msgstr "ટાઇપીંગ સહાયક (AccessX) (_T)"
+
+#: ../panels/universal-access/uap.ui.h:14
+#| msgid "Pointing and Clicking"
+msgid "Pointing & Clicking"
+msgstr "નિર્દેશિત અને ક્લિક કરી રહ્યા છે"
+
+#: ../panels/universal-access/uap.ui.h:15
+#| msgid "Mouse Keys"
+msgid "_Mouse Keys"
+msgstr "માઉસ કી (_M)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "મદદ માટે ક્લિક કરો (_C)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "સ્ક્રીન વાંચક"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "સ્ક્રીન વાંચક દર્શાવેલ લખાણને વાંચે છે જે તમે ફોકસને ખસેડો છો."
+
+#: ../panels/universal-access/uap.ui.h:19
+#| msgid "Screen Reader"
+msgid "_Screen Reader"
+msgstr "સ્ક્રીન વાંચક (_S)"
+
+#: ../panels/universal-access/uap.ui.h:20
+#| msgid "Bounce Keys"
+msgid "Sound Keys"
+msgstr "સાઉન્ડ કી"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "જ્યારે Num Lock અથવા Caps Lock ચાલુ રાખેલ હોય તો બીપ વગાડો."
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "દેખીતી ચેતવણીઓ"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "ફ્લેશ ચકાસો (_T)"
+
+#: ../panels/universal-access/uap.ui.h:24
+#| msgid "Use a visual indication when an alert sound occurs"
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "દ્રશ્ય સંકેત વાપરો જ્યારે ચેતવણી અવાજ કરે."
+
+#: ../panels/universal-access/uap.ui.h:25
+#| msgid "Flash the window title"
+msgid "Flash the _window title"
+msgstr "વિન્ડો શીર્ષકપટ્ટી ઝબકાવો (_w)"
+
+#: ../panels/universal-access/uap.ui.h:26
+#| msgid "Flash the entire screen"
+msgid "Flash the entire _screen"
+msgstr "આખી સ્ક્રીન ઝબકાવો (_s)"
+
+#: ../panels/universal-access/uap.ui.h:27
+#| msgid "Typing Assistant"
+msgid "Typing Assist"
+msgstr "ટાઇપીંગ સહાયક"
+
+#: ../panels/universal-access/uap.ui.h:28
+#| msgid "Sticky Keys"
+msgid "_Sticky Keys"
+msgstr "સ્ટીકી કીઓ (_S)"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "કિ સંયોજનો તરીકે બદલનાર કીઓની કતાર સાથે વર્તે છે"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "જો બે કી એકસાથે દબાવાય તો નિષ્ક્રિય કરો (_D)"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifer key is pressed"
+msgstr "જ્યારે બદલનાર દબાયેલ હોય ત્યારે બીપ વગાડો (_m)"
+
+#: ../panels/universal-access/uap.ui.h:32
+#| msgid "Slow Keys"
+msgid "S_low Keys"
+msgstr "ધીમી કીઓ (_l)"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "જ્યારે કી દબાયેલ હોય અને જ્યારે તેને સ્વીકારેલ હોય તો તેની વચ્ચે વિલંબ મૂકો"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "સ્વીકૃતિ વિલંબ (_c):"
+
+#: ../panels/universal-access/uap.ui.h:35
+#| msgid "Short"
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "ટૂંકુ"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "સ્લો કી વિલંબને સૂચવે છે"
+
+#: ../panels/universal-access/uap.ui.h:37
+#| msgid "Long"
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "લાંબુ"
+
+#: ../panels/universal-access/uap.ui.h:38
+#| msgid "Beep when a _modifer key is pressed"
+msgid "Beep when a key is pr_essed"
+msgstr "જ્યારે કી દબાયેલ હોય ત્યારે બીપ વગાડો (_e)"
+
+#: ../panels/universal-access/uap.ui.h:39
+#| msgid "Beep when a key is _rejected"
+msgid "Beep when a key is _accepted"
+msgstr "જ્યારે કી સ્વીકારેલ હોય ત્યારે બીપ વગાડો (_a)"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "જ્યારે કી નકારી દેવામાં આવે તો બીપ વગાડો (_r)"
+
+#: ../panels/universal-access/uap.ui.h:41
+#| msgid "Bounce Keys"
+msgid "_Bounce Keys"
+msgstr "બાઉન્સ કી (_B)"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "આમાં ઝડપી નકલી કી દબાણ અવગણો"
+
+#: ../panels/universal-access/uap.ui.h:43
+#| msgid "Short"
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "ટૂંકુ"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "બાઉન્સ કી વિલંબને સૂચવે છે"
+
+#: ../panels/universal-access/uap.ui.h:45
+#| msgid "Long"
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "લાંબુ"
+
+#: ../panels/universal-access/uap.ui.h:46
+#| msgid "Enable by Keyboard"
+msgid "_Enable by Keyboard"
+msgstr "કિબોર્ડ દ્દારા સક્રિય કરો (_E)"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "કીબોર્ડમાંથી સુલભતા લક્ષણોને ચાલુ અને બંધ કરો"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "મદદ માટે ક્લિક કરો"
+
+#: ../panels/universal-access/uap.ui.h:49
+#| msgid "Simulated Secondary Click"
+msgid "_Simulated Secondary Click"
+msgstr "પ્રદર્શનીય દ્દિતીય ક્લિક (_S)"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "પ્રાથમિક બટન દબાવવા દ્દારા દ્દિતીય ક્લિક સક્રિય કરો"
+
+#: ../panels/universal-access/uap.ui.h:51
+#| msgid "Short"
+msgctxt "secondary click"
+msgid "Short"
+msgstr "ટુંકુ"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "ગૌણ કી વિલંબ"
+
+#: ../panels/universal-access/uap.ui.h:53
+#| msgid "Long"
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "લાંબુ"
+
+#: ../panels/universal-access/uap.ui.h:54
+#| msgid "Hover Click"
+msgid "_Hover Click"
+msgstr "Hover ક્લિક (_H)"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "જ્યારે પોઇંટરની હિલચાલ બંધ કરવા દરમિયાન ક્લિકની શરૂઆત કરો"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "વિલંબ (_e):"
+
+#: ../panels/universal-access/uap.ui.h:57
+#| msgid "Short"
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "ટુંકુ"
+
+#: ../panels/universal-access/uap.ui.h:58
+#| msgid "Long"
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "લાંબુ"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "હિલચાલ થ્રેશોલ્ડ (_t):"
+
+#: ../panels/universal-access/uap.ui.h:60
+#| msgid "Small"
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "નાનું"
+
+#: ../panels/universal-access/uap.ui.h:61
+#| msgid "Large"
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "વિશાળ"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "ટુંકુ"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ સ્ક્રીન"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ સ્ક્રીન"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ સ્ક્રીન"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "લાંબુ"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "સંપૂર્ણ સ્ક્રીન"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "ઊંચે અદધો ભાગ"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "નીચે અદધો ભાગ"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "ડાબો અદધો ભાગ"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "જમણો અડધો ભાગ"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "નાનુ મોટુ કરવાનાં વિકલ્પો"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "નાનુ મોટુ કરો"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "વિસ્તૃતીકરણ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "માઉસ કર્સર અનૂસરો"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "સ્ક્રીન ભાગ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "બૃહદદર્શક સ્ક્રીન બહાર વિસ્તરેલ"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "બૃહદદર્શક કર્સર ને કેન્દ્રમાં રાખો"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "બૃહદદર્શક કર્સર સમાવિષ્ટને આજુબાજુથી દબાવે છે"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "બૃહદદર્શક કર્સર સમાવિષ્ટ સાથે ખસે છે"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "બૃહદદર્શક સ્થિતિ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "બૃહદદર્શક"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "જાડાઈ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+#| msgid "Thin"
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "પાતળુ"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+#| msgid "Thick"
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "ઘટ્ટ"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "લંબાઇ:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "રંગ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "ક્રોસહેર:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "માઉસ કર્સર ઓવરલેપ થાય ચે"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "ક્રોસહેર"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "કાળા પર સફેદ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "તેજસ્વીતા:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "વિરોધાભાસ:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+#| msgid "Color"
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "રંગ"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+#| msgid "None"
+msgctxt "universal access, color"
+msgid "None"
+msgstr "કંઈ જ નહિં"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+#| msgctxt "Zoom Grayscale"
+#| msgid "Full"
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "પૂર્ણ"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+#| msgid "Low"
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "ઓછુ"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+#| msgid "High"
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "ઉચ્ચ"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "ઓછુ"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "વધારે"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "રંગ અસરો:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "રંગ અસરો"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "પ્રમાણભૂત"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "વહીવટકર્તા"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+#| msgid "_Full name"
+msgid "_Full Name"
+msgstr "સંપૂર્ણ નામ (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "ખાતા પ્રકાર (_T)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+#| msgid "Choose password at next login"
+msgid "Allow user to set a password when they next login"
+msgstr "પાસવર્ડને સુયોજિત કરવા વપરાશકર્તાને પરવાનગી આપો જ્યારે તેઓ આગળ પ્રવેશે"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "હવે પાસવર્ડને સુયોજિત કરો"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "ખાતરી કરો (_V)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"એન્ટરપ્રાઇઝ પ્રવેશ આ ઉપકરણ પર વાપરવા માટે હાલની કેન્દ્રિય સંચાલિત થયેલ વપરાશકર્તા ખાતાને "
+"પરવાનગી આપે છે."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "ડોમેઇન (_D)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"એન્ટરપ્રાઇઝ પ્રવેશ ખાતાને ઉમેરવા માટે\n"
+"ઓનલાઇન થાવ."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "એન્ટરપ્રાઇઝ પ્રવેશ (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "વપરાશકર્તાને ઉમેરો"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "નોંધણી કરો (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "ડોમેઇન સંચાલક પ્રવેશ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"એન્ટરપ્રાઇઝ પ્રવેશને વાપરવા માટે ક્રમમાં, આ કમ્યૂટરને ડોમેઇનમાં ઉમેદવારી કરવાની જરૂર છે. "
+"મહેરબાની કરીને તમારુ નેટવર્ક સંચાલકને લઇને તેનાં ડોમેઇન પાસવર્ડને અહિં ટાઇપ કરો."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "સંચાલક નામ (_N)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "સંચાલક પાસવર્ડ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "થમ્ભને છોડો"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "ડાબી મધ્ય આંગળી"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "ડાબી વીંટી આંગળી"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "ડાબી નાની આંગળી"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "જમણું થમ્ભ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "જમણી મધ્ય આંગળી"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "જમણી વીંટી આંગળી"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "જમણી નાની આંગળી"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:697
+msgid "Enable Fingerprint Login"
+msgstr "આંગળીછાપ પ્રવેશ ને સક્રિય કરો"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "જમણી અનુક્રમાંક આંગળી (_R)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "ડાબી અનુક્રમાંક આંગળી (_L)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "બીજી આંગળી (_O): "
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"તમારી આંગળી છાપ એ સફળતાપૂર્વક સંગ્રહ થયેલ છે. તમારે હવે તમારા આંગળી છાપ વાંચનાર ની "
+"મદદથી પ્રવેશવા માટે સક્ષમ થવુ જ જોઇએ."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+#| msgid "Username"
+msgid "Users"
+msgstr "વપરાશકર્તાઓ"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+#| msgid "Add or remove users"
+msgid "Add or remove users and change your password"
+msgstr "વપરાશકર્તાઓને ઉમેરો અથવા દૂર કરો અને તમારા પાસવર્ડને બદલો"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "પ્રવેશ;નામ;આંગળીછાપન;અવતાર;લૉગો;ચહેરો;પાસવર્ડ;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+#| msgid "Login Options"
+msgid "Login History"
+msgstr "પ્રવેશ ઇતિહાસ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#| msgid "Changing password for"
+msgid "Change Password"
+msgstr "પાસવર્ડ બદલો"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "બદલો (_a)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+#| msgid "_New password"
+msgid "_Verify New Password"
+msgstr "નવાં પાસવર્ડની ખાતરી કરો (_V)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+#| msgid "_New password"
+msgid "_New Password"
+msgstr "નવો પાસવર્ડ (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+#| msgid "Current _password"
+msgid "Current _Password"
+msgstr "વર્તમાન પાસવર્ડ (_p)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "વપરાશકર્તા ખાતુ ઉમેરો"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "વપરાશકર્તા ખાતુ દૂર કરો"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "પ્રવેશ વિકલ્પો"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "સ્વયં પ્રવેશ (_u)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "આંગળીછાપન પ્રવેશ (_F)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "વપરાશકર્તા ચિહ્ન"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "ભાષા (_L)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+#| msgid "A_utomatic Login"
+msgid "Last Login"
+msgstr "છેલ્લો પ્રવેશ"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "વપરાશકર્તા ખાતાઓ સંચાલિત કરો"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "વપરાશકર્તા માહિતીને બદલવા માટે સત્તાધિકરણ જરૂરી છે"
+
+#: ../panels/user-accounts/pw-utils.c:81
+#| msgid "The new password does not contain enough different characters"
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "નવો પાસવર્ડ જૂનાંથી અલગ હોવો જરૂરી છે."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "અમુક અક્ષરો અને આંકડાને બદલવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+#| msgid "Changing password for"
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "પાસવર્ડને થોડો વધારે બદલવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "તમારાં વપરાશકર્તા નામ વગર પાસવર્ડ મજબૂત હશે."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "પાસવર્ડમાં તમારા નામને અવગણવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "પાસવર્ડમાં સમાવેલ શબ્દોનાં અમુકને અવગણવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "સામાન્ય શબ્દોને અવગણવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "હાલનાં શબ્દોને પુન:ક્રમાંક અવગણવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "વધારે નંબરોને વાપરવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "વધારે મોટા અક્ષરો વાપરવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "વધારે નાનાં અક્ષરો વાપરવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "ખાસ અક્ષરો, જેમ કે વિરામચિહ્ન વધારે વાપરવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "અક્ષરો, નંબરો અને વિરામચિહ્નોનું મિશ્રણને વાપરવા માટે પ્રયતન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "વારંવાર આવતા એજ અક્ષરને અવગણવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"વારંવાર વપરાતા એજ પ્રકારનાં અક્ષરને અવગણવાનો પ્રયત્ન કરો: તમે અક્ષરો, નંબરો અને "
+"વિરામચિહ્નનોનાં મિશ્રણની જરૂર છે."
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "શ્રેણી જેમ કે 1234 અથવા abcd ને અવગણવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "વધારે અક્ષરો, આંકડા અને સંકેતોને ઉમેરવાનો પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr "મોટા અક્ષર અને નાનાં અક્ષરને મિશ્રિત કરો અને આંકડા અથવા બેને વાપરો."
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr "સરસ પાસવર્ડ! વધારે અક્ષરો, આંકડા અને વિરામચિહ્ન એ તેને મજબૂત બનાવશે."
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+#| msgid "Strength"
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "મજબૂતાઇ: નબળી"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+#| msgid "Strength"
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "મજબૂતાઇ: ઓછી"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+#| msgid "Strength"
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "મજબૂતાઇ: મધ્યમ"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+#| msgid "Strength"
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "મજબૂતાઇ: સરસ"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+#| msgid "Strength"
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "મજબૂતાઇ: વધારે"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "સત્તાધિકરણ નિષ્ફળ"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "નવો પાસવર્ડ ઘણો ટૂંકો છે"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "નવો પાસવર્ડ ઘણો સરળ છે"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "જૂના અને નવા પાસવર્ડો એકદમ સરખા છે"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "નવો પાસવર્ડ પહેલેથી જ તાજેતરમાં વાપરી દેવાયો છે."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "નવો પાસવર્ડ આંકડા અને વિશિષ્ટ અક્ષરો સમાવતો હોવો જ જોઈએ."
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "જૂના અને નવા પાસવર્ડો સરખા છે"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "તમારો પાસવર્ડ બદલાઈ ગયેલ છે કારણ કે તમે શરૂઆતમાં સત્તાધિકારીત થઈ ગયેલ છે!"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "નવો પાસવર્ડ પૂરતા વિવિધ અક્ષરોને સમાવતુ નથી"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "અજ્ઞાત ભૂલ"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "તમારાં ખાતા પ્રદાતાનાં વેબ સરનામાં સાથે બંધબેસતુ હોવુ જોઇએ."
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "ખાતાને ઉમેરવામાં નિષ્ફળ"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+#| msgid "Passwords do not match"
+msgid "Passwords do not match."
+msgstr "પાસવર્ડ બંધબેસતો નથી."
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr "ખાતાને રજીસ્ટર કરવામાં નિષ્ફળ"
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr "આ ડોમેઇન સાથે આ રીતે સત્તાધિકરણ કરવાનું આધારભૂત નથી"
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr "ડોમેઇન સાથે જોડાવામાં નિષ્ફળ"
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"તે પ્રવેશ નામ કામ કરતુ ન હતુ.\n"
+"મહેરબાની કરીને ફરી પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+#| msgid "Invalid password, please try again"
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"તે પ્રવેશ પાસવર્ડ કામ કરતુ ન હતુ.\n"
+"મહેરબાની કરીને ફરી પ્રયત્ન કરો."
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr "ડોમેઇનમાં પ્રવેશ કરવામાં નિષ્ફળતા"
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "ડોમેઇનને શોધવાનું અસમર્થ. કદાચ તમે તેની જોડણી ખોટી કરી છે?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:137
+msgid "You are not allowed to access the device. Contact your system administrator."
+msgstr "તમને ઉપકરણ ને દાખલ કરવા માટે પરવાનગી આપેલ નથી. તમારા સિસ્ટમ વહીવટકર્તાને સંપર્ક કરો."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid "The device is already in use."
+msgstr "ઉપકરણ એ પહેલેથી વપરાશમાં છે."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "An internal error occurred."
+msgstr "આંતરિક ભૂલ ઉદ્દભવી હતી."
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: ../panels/user-accounts/um-fingerprint-dialog.c:217
+#: ../panels/user-accounts/um-fingerprint-dialog.c:218
+msgid "Enabled"
+msgstr "સક્રિય"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:266
+msgid "Delete registered fingerprints?"
+msgstr "રજીસ્ટર થયેલ આંગળીની છાપો ને કાઢી નાંખો?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:270
+msgid "_Delete Fingerprints"
+msgstr "આંગળીની છાપો ને કાઢી નાંખો (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:276
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"શું તમે તમારી રજીસ્ટર થયેલ આંગળીની છાપો ને કાઢી નાંખવા માંગો છો તેથી આંગળીની છાપ પ્રવેશ ને "
+"નિષ્ક્રિય થયેલ હોય?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:452
+msgid "Done!"
+msgstr "પૂરુ થઇ ગયુ!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:513
+#: ../panels/user-accounts/um-fingerprint-dialog.c:555
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' ઉપકરણ ને દાખલ કરી શકાયો નહિં"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:596
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "'%s' ઉપકરણ પર આંગળીને પકડવાનું શરૂ કરી શકાયુ નહિં"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:647
+msgid "Could not access any fingerprint readers"
+msgstr "કોઇપણ આંગળીછાપ વાંચનાર ને દાખલ કરી શકાયુ નહિં"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:648
+msgid "Please contact your system administrator for help."
+msgstr "મહેરબાની કરીને મદદ માટે તમારા સિસ્ટમ વહીવટકર્તા ને સંપર્ક કરો."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:731
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"આંગળી છાપ દાખલ કરવાનું સક્રિય કરવા માટે, તમારે તમારા આંગળી છાપોનાં એક ને સંગ્રહ કરવાની "
+"જરૂર પડશે, '%s' ઉપકરણની મદદથી."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:738
+msgid "Selecting finger"
+msgstr "આંગળી પસંદ કરી રહ્યા છે"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:739
+msgid "Enrolling fingerprints"
+msgstr "આંગળી છાપનની નોંધણી"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "આ અઠવાડિયે"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+#| msgid "Last used"
+msgid "Last Week"
+msgstr "છેલ્લા અઠવાડિયે"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:631
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "સત્રનો અંત આવ્યો"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "સત્ર શરૂ થઇ ગયું"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "મહેરબાની કરીને બીજા પાસવર્ડને પસંદ કરો."
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "મહેરબાની કરીને ફરીથી તમારા હાલના પાસવર્ડને લખો."
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "પાસવર્ડને બદલી શક્યા નહિં"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+#| msgid "The passwords do not match"
+msgid "The passwords do not match."
+msgstr "પાસવર્ડો બંધબેસતા નથી."
+
+#: ../panels/user-accounts/um-photo-dialog.c:219
+msgid "Browse for more pictures"
+msgstr "વધારે ચિત્રો માટે બ્રાઉઝ કરો"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: ../panels/user-accounts/um-photo-dialog.c:453
+msgid "Disable image"
+msgstr "ઇમેજને નિષ્ક્રિય કરો"
+
+#: ../panels/user-accounts/um-photo-dialog.c:471
+#| msgid "Take a photo..."
+msgid "Take a photo…"
+msgstr "ફોટો લો..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:489
+#| msgid "Browse for more pictures"
+msgid "Browse for more pictures…"
+msgstr "વધારે ચિત્રો માટે બ્રાઉઝ કરો..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:713
+#, c-format
+msgid "Used by %s"
+msgstr "%s દ્દારા વપરાયેલ છે"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+#| msgid "Cannot remove automatically added profile"
+msgid "Cannot automatically join this type of domain"
+msgstr "આપમેળે ઉમેરાયેલ રૂપરેખાને દૂર કરી શકાતુ નથી"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "આવુ કોઈ ડોમેઈન અથવા ક્ષેત્ર મળ્યુ નથી"
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s ડોમેઇન પર %s તરીકે પ્રવેશી શકાતુ નથી"
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr "અયોગ્ય પાસવર્ડ, મહેરબાની કરીને ફરી પ્રયત્ન કરો"
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "%s ડોમેઇનમાં જોડાઇ શકાયુ નહિં: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:198
+msgid "Other Accounts"
+msgstr "બીજા ખાતાઓ"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "Failed to delete user"
+msgstr "વપરાશકર્તાને કાઢી નાખતી વખતે નિષ્ફળતા"
+
+#: ../panels/user-accounts/um-user-panel.c:482
+msgid "You cannot delete your own account."
+msgstr "તમે તમારા પોતાના ખાતાને કાઢી શકતા નથી."
+
+#: ../panels/user-accounts/um-user-panel.c:491
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s હજુ પ્રવેશેલ છે"
+
+#: ../panels/user-accounts/um-user-panel.c:495
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"વપરાશકર્તાને કાઢી રહ્યા છે જ્યારે તેઓ પ્રવેશેલ છે કે જે અસ્થાયી સ્થિતિમાં સિસ્ટમને છોડી શકે છે."
+
+#: ../panels/user-accounts/um-user-panel.c:504
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "શું તમે %s ની ફાઇલોને રાખવા માંગો છો?"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"તેની આજુબાજુ ઘર ડિરેક્ટરી, મેઇલ સ્પુલ અને કામચલાઉ ફાઇલોને રાખવાનું શક્ય છે જ્યારે વપરાશકર્તા "
+"ખાતાને કાઢી રહ્યા હોય."
+
+#: ../panels/user-accounts/um-user-panel.c:511
+msgid "_Delete Files"
+msgstr "ફાઇલોને કાઢી નાંખો (_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:512
+msgid "_Keep Files"
+msgstr "ફાઇલોને રાખો (_K)"
+
+#: ../panels/user-accounts/um-user-panel.c:564
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "નિષ્ક્રિય થયેલ ખાતુ"
+
+#: ../panels/user-accounts/um-user-panel.c:572
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "આગળનાં પ્રવેશે સુયોજિત કરવા માટે"
+
+#: ../panels/user-accounts/um-user-panel.c:575
+msgctxt "Password mode"
+msgid "None"
+msgstr "કઈ નહિં"
+
+#: ../panels/user-accounts/um-user-panel.c:624
+msgid "Logged in"
+msgstr "પ્રવેશેલ છે"
+
+#: ../panels/user-accounts/um-user-panel.c:1072
+msgid "Failed to contact the accounts service"
+msgstr "ખાતા સેવાને સંપર્ક કરવામાં નિષ્ફળ"
+
+#: ../panels/user-accounts/um-user-panel.c:1074
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "મહેરબાની કરીને ખાતરી કરો કે AccountService એ સ્થાપિત અને સક્રિય થયેલ છે."
+
+#: ../panels/user-accounts/um-user-panel.c:1115
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"ફેરફારો કરવા માટે,\n"
+"પહેલાં * ચિહ્ન પર ક્લિક કરો"
+
+#: ../panels/user-accounts/um-user-panel.c:1153
+msgid "Create a user account"
+msgstr "વપરાશકર્તા ખાતાને બનાવો"
+
+#: ../panels/user-accounts/um-user-panel.c:1164
+#: ../panels/user-accounts/um-user-panel.c:1453
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"વપરાશકર્તા ખાતાને બનાવવા માટે,\n"
+"પહેલાં * ચિહ્ન પર ક્લિક કરો"
+
+#: ../panels/user-accounts/um-user-panel.c:1174
+msgid "Delete the selected user account"
+msgstr "પસંદ થયેલ વપરાશકર્તા ખાતાને કાઢી નાંખો"
+
+#: ../panels/user-accounts/um-user-panel.c:1186
+#: ../panels/user-accounts/um-user-panel.c:1458
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"પસંદ થયેલ વપરાશકર્તા ખાતાને કાઢી નાંખવા માટે,\n"
+"પહેલાં * ચિહ્ન પર ક્લિક કરો"
+
+#: ../panels/user-accounts/um-user-panel.c:1368
+msgid "My Account"
+msgstr "મારુ ખાતુ"
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+#| msgid "A user with the username '%s' already exists"
+msgid "A user with the username '%s' already exists."
+msgstr "વપરાશકર્તાનામ '%s' સાથે વપરાશકર્તા પહેલેથી જ અસ્તિત્વ ધરાવે છે."
+
+#: ../panels/user-accounts/um-utils.c:571
+#, c-format
+#| msgid "The username is too long"
+msgid "The username is too long."
+msgstr "વપરાશકર્તાનામ ઘણુ લાંબુ છે."
+
+#: ../panels/user-accounts/um-utils.c:574
+#| msgid "The username cannot start with a '-'"
+msgid "The username cannot start with a '-'."
+msgstr "વપરાશકર્તાનામ '-' સાથે શરૂ કરી શકાતુ નથી."
+
+#: ../panels/user-accounts/um-utils.c:577
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"વપરાશકર્તા ફક્ત a-z, આંકડા અને કોઇપણ અક્ષરો '.', '-' અને '_' માંથી નાનાં અને મોટા અક્ષરોને "
+"સમાવવા જોઇએ."
+
+#: ../panels/user-accounts/um-utils.c:581
+msgid "This will be used to name your home folder and can't be changed."
+msgstr "આ તમારા ઘર ફોલ્ડરનાં નામ માટે વપરાશે અને બદલી શકાતુ નથી."
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:831
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "માપન બટનો"
+
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr "વિધેયોનાં માપન બટનો"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+#| msgid ""
+#| "To edit a shortcut, click the row and hold down the new keys or press "
+#| "Backspace to clear."
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ટુકાણ કીમાં ફેરફાર કરવા માટે, \"કિસ્ટ્રોકને મોકલો\" ક્રિયાને પસંદ કરો, કિબોર્ડ ટૂંકાણ બટનને "
+"દબાવો અને નવી કીને પકડી રાખો અથવા સાફ કરવા માટે Backspace ને દબાવો."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "લક્ષ્ય માર્કરને મહેરબાની કરીને ટૅપ કરો તેઓ ટૅબલેટને ગોઠવવા માટે સ્ક્રીન પર દેખાશે."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "ખોટી ક્લિક શોધાઇ, પુન:શરૂ કરી રહ્યા છે..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+#| msgid "Up"
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "ઉપર"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+#| msgid "Down"
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "નીચે"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "કંઈ નહિં"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "કીસ્ટ્રોકને મોકલો"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "મોનિટર બદલો"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "ઑન-સ્ક્રીન મદદ બતાવો"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "આઉટપુટ:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "સાપેક્ષ ગુણોત્તર રાખો (લેટરબોક્સ):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "એકજ મોનિટરનું માપ લો"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d નું %d"
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "માપન દર્શાવો"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "બટન"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr "Wacom ટૅબલેટ"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "બટન મેપીંગને સુયોજિત કરો અને ગ્રાફિક્સ ટૅબલેટ માટે સ્ટાયલસ સંવેદનશીલતાને ગોઠવો"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "ટૅબલેટ;Wacom;સ્ટાયલસ;ઇરૅજર;માઉસ;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "ટૅબલેટ (સંપૂર્ણ)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "ટચપેડ (સંબંધિત)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "ટૅબલેટ પસંદગીઓ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr "ટૅબલેટ શોધાયુ નથી"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "મહેરબાની કરીને પ્લગ કરો અથવા તમારાં Wacom ટૅબલેટને ચાલુ રાખો"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr "Bluetooth સુયોજનો"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+#| msgid "Map to Monitor..."
+msgid "Map to Monitor…"
+msgstr "મોનિટરનું માપન…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+#| msgid "Map Buttons"
+msgid "Map Buttons…"
+msgstr "માપન બટનો…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr "દર્શાવ રિઝોલ્યુશનને ગોઠવો"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+#| msgid "Mouse Settings"
+msgid "Adjust mouse settings"
+msgstr "માઉસ સુયોજનોને ગોઠવો"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Tracking Mode"
+msgstr "ટ્રેકિંગ સ્થિતિ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Left-Handed Orientation"
+msgstr "ડાબી બાજુની દિશા"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+#| msgid "Left Ring Mode #%d"
+msgid "Left Ring"
+msgstr "ડાબી રીંગ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "ડાબી રીંગ સ્થિતિ #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+#| msgid "Right Ring Mode #%d"
+msgid "Right Ring"
+msgstr "જમણી રીંગ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "જમણી રીંગ સ્થિતિ #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+#| msgid "Left Touchstrip Mode #%d"
+msgid "Left Touchstrip"
+msgstr "ડાબુ ટચસ્ટ્રીપ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "ડાબી ટચસ્ટ્રીપ સ્થિતિ #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+#| msgid "Right Touchstrip Mode #%d"
+msgid "Right Touchstrip"
+msgstr "જમણી ટચસ્ટ્રીપ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "જમણી ટચસ્ટ્રીપ સ્થિતિ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "ડાબુ ટચરીંગ મોડ સ્વીચ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "જમણી ટચરીંગ મોડ સ્વીચ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "ડાબી ટચસ્ટ્રીપ મોડ સ્વીચ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "જમણી ટચસ્ટ્રીપ મોડ સ્વીચ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "મોડ સ્વીચ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr "ડાબુ બટન #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr "જમણુ બટન #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr "ટોચનુ બટન #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "નીચેનું બટન #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+#| msgid "New shortcut..."
+msgid "New shortcut…"
+msgstr "નવાં ટૂંકાણ..."
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "ક્રિયા નથી"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "ડાબુ માઉસ બટન ક્લિક"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "મધ્ય માઉસ બટન ક્લિક"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "જમણુ માઉસ બટન ક્લિક"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "ઉપર સ્ક્રોલ કરો"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "નીચે સ્ક્રોલ કરો"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "ડાબે સ્ક્રોલ કરો"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "જમણે સ્ક્રોલ કરો"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "પાછા"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "આગળ ધપાવો"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "સ્ટાયલસ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "ઇરૅજર પ્રેસર ફીલ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "નરમ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "ફર્મ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "ટોચનુ બટન"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "નીચેનું બટન"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "ટીપ પ્રેસર ફીલ"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "વર્બોસ સ્થિતિ સક્રિય કરો"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "ઝાંખી બતાવો"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "શબ્દમાળા માટે શોધો"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "શક્ય પેનલ નામોની યાદી કરો અને બહાર નીકળો"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "મદદ વિકલ્પો બતાવો"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "દર્શાવવા માટે પેનલ"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:145
+#| msgid "All Settings"
+msgid "- Settings"
+msgstr "- સુયોજનો"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"ઉપલબ્ધ આદેશ વાક્ય વિકલ્પોની સંપૂર્ણ યાદીને જોવા માટે  '%s --help' ચલાવો.\n"
+
+#: ../shell/cc-application.c:193
+#| msgid "Available Profiles"
+msgid "Available panels:"
+msgstr "ઉપલબ્ધ પેનલો:"
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "મદદ"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "બહાર નીકળો"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+msgid "All Settings"
+msgstr "બધા સુયોજનો"
+
+#. Add categories
+#: ../shell/cc-window.c:876
+msgctxt "category"
+msgid "Personal"
+msgstr "વ્યક્તિગત"
+
+#: ../shell/cc-window.c:877
+#| msgid "Hardware"
+msgctxt "category"
+msgid "Hardware"
+msgstr "હાર્ડવેર"
+
+#: ../shell/cc-window.c:878
+#| msgid "System"
+msgctxt "category"
+msgid "System"
+msgstr "સિસ્ટમ"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "પસંદગીઓ;સુયોજનો;"
+
+#~ msgid "Flickr"
+#~ msgstr "ફ્લિકર"
+
+#~ msgid "Change the background"
+#~ msgstr "પાશ્વભાગને બદલો"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "બ્લુટુથ સુયોજનોને રૂપરેખાંકિત કરો"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "નવાં ઉપકરણને સુયોજિત કરો"
+
+#~ msgid "Connection"
+#~ msgstr "જોડાણ"
+
+#~ msgid "Paired"
+#~ msgstr "જોડી"
+
+#~ msgid "Type"
+#~ msgstr "પ્રકાર"
+
+#~ msgid "Mouse and Touchpad Settings"
+#~ msgstr "માઉસ અને ટચપેડ સુયોજનો"
+
+#~ msgid "Sound Settings"
+#~ msgstr "સાઉન્ડ સુયોજનો"
+
+#~ msgid "Send Files..."
+#~ msgstr "ફાઇલો મોકલો..."
+
+#~ msgid "Browse Files..."
+#~ msgstr "ફાઇલો બ્રાઉઝ કરો..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "બ્લુટુથ"
+
+#~ msgid "Visibility"
+#~ msgstr "દૃશ્યતા"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” ની દૃશ્યતા"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "શું ઉપકરણોની યાદીમાંથી '%s' ને દૂર કરવાનુ છે?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr "જો તમે ઉપકરણને દૂક કરો તો, તમારે આગળનાં વપરાશ પહેલાં ફરી સુયોજિત કરવુ જ પડશે."
+
+#~ msgid "Create virtual device"
+#~ msgstr "વર્ચ્યુઅલ ઉપકરણને બનાવો"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "દર્શાવો માટે ઉપલબ્ધ રૂપરેખાઓ"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "સ્કેનર માટે ઉપલબ્ધ રૂપરેખાઓ"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "પ્રિન્ટર માટે ઉપલબ્ધ રૂપરેખાઓ"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "કૅમેરા માટે ઉપલબ્ધ રૂપરેખાઓ"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "વેબકેમ માટે ઉપલબ્ધ રૂપરેખાઓ"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i વર્ષ"
+#~ msgstr[1] "%i વર્ષો"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i મહિનો"
+#~ msgstr[1] "%i મહિના"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i અઠવાડિયુ"
+#~ msgstr[1] "%i અઠવાડિયા"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "1 અઠવાડિયા કરતા ઓછુ"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "આ ઉપકરણ રંગ સંચાલિત થયેલ નથી."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "આ ઉપકરણ ઉત્પાદન માપદંડ થયેલ માહિતીને વાપરી રહ્યુ છે."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "આ ઉપકરણ પાસે આખી-સ્ક્રીનની રંગ ચકાસણી માટે સુસંગત રૂપરેખા નથી."
+
+#~ msgid "Not specified"
+#~ msgstr "સ્પષ્ટ થયેલ નથી"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "ઉપકરણો શોધાયેલ રંગ સંચાલનને આધાર આપી રહ્યુ નથી"
+
+#~ msgid "Add device"
+#~ msgstr "ઉપકરણ ઉમેરો"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "વર્ચ્યુઅલ ઉપકરણને ઉમેરો"
+
+#~ msgid "Remove a device"
+#~ msgstr "ઉપકરણ દૂર કરો"
+
+#~ msgid "Device type:"
+#~ msgstr "ઉપકરણ પ્રકાર:"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~ msgid "Model:"
+#~ msgstr "મોડેલ:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "ઉપરનાં ક્ષેત્રોને સ્વયં સમાપ્ત કરવા માટે આ વિન્ડો પર ઇમેજ ફાઇલોને ખેંચી શકાય છે."
+
+#~ msgid "Color management settings"
+#~ msgstr "રંગ સંચાલન સુયોજનો"
+
+#~ msgid "English"
+#~ msgstr "અંગ્રેજી"
+
+#~ msgid "British English"
+#~ msgstr "બ્રિટીશ અંગ્રેજી"
+
+#~ msgid "German"
+#~ msgstr "જર્મન"
+
+#~ msgid "French"
+#~ msgstr "ફ્રેન્ચ"
+
+#~ msgid "Spanish"
+#~ msgstr "સ્પેનિશ"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "ચીની (સરળ)"
+
+#~ msgid "Russian"
+#~ msgstr "રશિયન"
+
+#~ msgid "Arabic"
+#~ msgstr "અરેબિક"
+
+#~ msgid "Unspecified"
+#~ msgstr "સ્પષ્ટ થયેલ નથી"
+
+#~ msgid "Select a language"
+#~ msgstr "ભાષા પસંદ કરો"
+
+#~ msgid "_Select"
+#~ msgstr "પસંદ કરો (_S)"
+
+#~ msgid "_Region:"
+#~ msgstr "વિસ્તાર (_R):"
+
+#~ msgid "_City:"
+#~ msgstr "શહેર (_C):"
+
+#~ msgid "_Network Time"
+#~ msgstr "નેટવર્ક સમય (_N)"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "એક કલાક આગળ સમયને સુયોજિત કરો."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "એક કલાક પાછળ સમયને સુયોજિત કરો."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "એક મિનિટ આગળ સમય સુયોજિત કરો."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "એક મિનિટ પાછળ સમય સુયોજિત કરો."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM અને PM ની વચ્ચે બદલો."
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "તારીખ અને સમય પસંદગીઓ પેનલ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "સામાન્ય"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "વિષમઘડી દિશા"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "સમઘડી દિશા"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 અંશ"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "પ્રાથમિક દર્શાવને બદલવા ખેંચો."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "તેનાં ગુણધર્મોને બદલવા માટે મોનિટરને પસંદ કરો; તેનાં સ્થાનને પુન:ગોઠવવા માટે તેને ખેંચો."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "મોનિટર રૂપરેખાંકનને સંગ્રહ કરી શકાયુ નહિં"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "દર્શાવોને શોધી શકાયુ નહિં"
+
+#~ msgid "_Resolution"
+#~ msgstr "રીઝોલ્યુશન (_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "ફેરવવાનું (_o):"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "મિરર દેખાવો (_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "નોંધ: રિઝોલ્યુશન વિકલ્પો પર મર્યાદા આવી શકે છે"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "દર્શાવોને શોધો (_D)"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "અજ્ઞાત મોડેલ"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "આગળનો પ્રવેશ મૂળભૂત અનુભવને વાપરવા માટે પ્રયત્ન કરશે."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "ફોલબૅક"
+
+#~ msgid "Install Updates"
+#~ msgstr "સુધારા સ્થાપિત કરો"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "સિસ્ટમ અદ્યતન"
+
+#~ msgid "System Information"
+#~ msgstr "સિસ્ટમ જાણકારી"
+
+#~ msgid "OS type"
+#~ msgstr "OS પ્રકાર"
+
+#~ msgid "_Other Media..."
+#~ msgstr "બીજી મીડિયા (_O)..."
+
+#~ msgid "Experience"
+#~ msgstr "અનુભવ"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "દબાણ થયેલ ફોલબેક સ્થિતિ (_F)"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "કિબોર્ડ સુયોજનોને બદલો"
+
+#~ msgid "Layout Settings"
+#~ msgstr "લેઆઉટ સુયોજનો"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "તમારુ માઉસ અને ટચપેડ પસંદગીઓને સુયોજિત કરો"
+
+#~ msgid "Network settings"
+#~ msgstr "નેટવર્ક સુયોજનો"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "નેટવર્ક;વાયરલેસ;IP;LAN;પ્રોક્સી;"
+
+#~ msgid "Out of range"
+#~ msgstr "સીમાની બહાર"
+
+#~ msgid "_Options..."
+#~ msgstr "વિકલ્પો (_O)..."
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "નવી સેવા માટે વાપરવા ઇન્ટરફેસને પસંદ કરો"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~ msgid "C_reate..."
+#~ msgstr "બનાવો (_r)..."
+
+#~ msgid "_Interface"
+#~ msgstr "ઇન્ટરફેસ (_I)"
+
+#~ msgid "_Configure..."
+#~ msgstr "રૂપરેખાંકિત કરો (_C)..."
+
+#~ msgid "Wireless"
+#~ msgstr "વાયરલેસ"
+
+#~| msgid "Disconnected"
+#~ msgid "_Disconnect"
+#~ msgstr "તૂટેલ જોડાણ (_D)"
+
+#~| msgid "Connected"
+#~ msgid "_Connect"
+#~ msgstr "જોડાવો (_C)"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~| msgid "Models"
+#~ msgid "Mesh"
+#~ msgstr "મેશ"
+
+#~ msgid "Disconnected"
+#~ msgstr "જોડાણ તૂટી ગયું"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "કૅરિઅર/કડી બદલાયેલ છે"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "શ્રેયનો સમય સમાપ્ત થઇ ગયો. મહેરબાની કરીને ફરી પ્રવેશો."
+
+#~ msgid "_Log In"
+#~ msgstr "પ્રવેશો (_L)"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "ઓનલાઇન ખાતાઓ સંચાલિત કરો"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "સાવધાન બેટરી ઓછી, %s બાકી રહેલ છે"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "બેટરી પાવરને વાપરી રહ્યા છે - %s બાકી રહેલ છે"
+
+#~ msgid "Using battery power"
+#~ msgstr "બેટરી પાવર વાપરી રહ્યા છે"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "ચાર્જિંગ - સંપૂર્ણ ચાર્જ"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "UPS પાવરને વાપરી રહ્યા છે - %s બાકી રહેલ છે"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "સાવધાન UPS ઓછુ"
+
+#~ msgid "Using UPS power"
+#~ msgstr "UPS પાવરને વાપરી રહ્યા છે"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "તમારી ગૌણ બેટરી સંપૂર્ણપણે ચાર્જ થયેલ છે"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "તમારી ગૌણ બેટરી ખાલી છે"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "ચાર્જિંગ - સંપૂર્ણ ચાર્જ"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "મદદ: <a href=\"screen\">સ્ક્રીન પ્રકાશતા</a> કેટલો પાવર વાપરો છે તેની પર અસર કરે "
+#~ "છે"
+
+#~ msgid "Power management settings"
+#~ msgstr "પાવર સંચાલન સુયોજનો"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#~| msgid "Sound"
+#~ msgid "Don't suspend"
+#~ msgstr "અટકાવો નહિં"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "જ્યારે નિષ્ક્રિય હોય ત્યારે સ્થગિત કરો"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "અટકેલ"
+
+#~ msgid "Change printer settings"
+#~ msgstr "પ્રિન્ટર સુયોજનોને બદલો"
+
+#~ msgid "Manufacturers"
+#~ msgstr "ઉત્પાદક"
+
+#~ msgid "Drivers"
+#~ msgstr "ડ્રાઈવરો"
+
+#~ msgid "_Default"
+#~ msgstr "મૂળભૂત (_D)"
+
+#~ msgid "_Show"
+#~ msgstr "બતાવો (_S)"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "તમારો પ્રદેશ અને ભાષા સુયોજનોને બદલો"
+
+#~ msgid "Choose an input source"
+#~ msgstr "ઇનપુટ સ્ત્રોતને પસંદ કરો"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "ઉમેરવા માટે ઇનપુટ સ્ત્રોતને પસંદ કરો"
+
+#~ msgid "Copy Settings"
+#~ msgstr "સુયોજનોની નકલ કરો"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "સુયોજનોની નકલ કરો..."
+
+#~ msgid "Region and Language"
+#~ msgstr "પ્રદેશ અને ભાષા"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr "દેખાતી ભાષાને પસંદ કરો (બદલાવ પછી તમે ફરી પ્રવેશશો ત્યારે લાગુ થશે)"
+
+#~ msgid "Add Language"
+#~ msgstr "ભાષા ઉમેરો"
+
+#~ msgid "Remove Language"
+#~ msgstr "ભાષા દૂર કરો"
+
+#~ msgid "Install languages..."
+#~ msgstr "ભાષાઓને સ્થાપિત કરો..."
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "વિસ્તારને પસંદ કરો (બદલાવ પછી તમે ફરી પ્રવેશશો ત્યારે લાગુ થશે)"
+
+#~ msgid "Add Region"
+#~ msgstr "વિસ્તાર ઉમેરો"
+
+#~ msgid "Currency"
+#~ msgstr "ચલણ"
+
+#~ msgid "Examples"
+#~ msgstr "ઉદાહરણો"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "કિબોર્ડ અથવા બીજા ઇનપુટ સ્ત્રોતને પસંદ કરો"
+
+#~ msgid "Remove Input Source"
+#~ msgstr "ઇનપુટ સ્ત્રોત દૂર કરો"
+
+#~ msgid "Move Input Source Up"
+#~ msgstr "ઇનપુટ સ્ત્રોતને ઉપર ખસેડો "
+
+#~ msgid "Show Keyboard Layout"
+#~ msgstr "કીબોર્ડ લેઆઉટને બતાવો"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "ટૂંકાણ સુયોજનો"
+
+#~ msgid "Display language:"
+#~ msgstr "ભાષાને દર્શાવો:"
+
+#~ msgid "Input source:"
+#~ msgstr "ઇનપુટ સ્ત્રોત: "
+
+#~ msgid "Format:"
+#~ msgstr "બંધારણ:"
+
+#~ msgid "Your settings"
+#~ msgstr "તમારાં સુયોજનો"
+
+#~ msgid "System settings"
+#~ msgstr "સિસ્ટમ સુયોજનો"
+
+#~| msgid "Brightness"
+#~ msgid "Brightness & Lock"
+#~ msgstr "પ્રકાશતા અને તાળુ"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "સ્ક્રીન તેજસ્વિતા અને તાળા સુયોજનો"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "પ્રકાશતા;તાળુ;ઝાંખી;ખાલી;મોનિટર;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "પાવર બચાવવા માટે સ્ક્રીન ઝાંખી રાખો (_D)"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "તાળુ મારો નહિં જ્યારે ઘરે હોવ"
+
+#~ msgid "Locations..."
+#~ msgstr "સ્થાનો..."
+
+#~ msgid "Lock"
+#~ msgstr "તાળુ મારો"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "ડિબગીંગ સ્થિતિ સક્રિય કરો"
+
+#~ msgid "Version of this application"
+#~ msgstr "આ કાર્યક્રમની આવૃત્તિ"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME વોલ્યુમ નિયંત્રણ એપલેટ"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "ડેસ્કટોપ વોલ્યુમ નિયંત્રણને બતાવો"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "સાઉન્ડ આઉટપુટ વોલ્યુમ"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "માઇક્રોફોન વોલ્યુમ"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "સાઉન્ડ પસંદગીઓને શરૂ કરવામાં નિષ્ફળતા: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "મૂંગુ (_M)"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "સાઉન્ડ પસંદગીઓ (_S)"
+
+#~ msgid "Muted"
+#~ msgstr "મૂંગુ"
+
+#~ msgid "No shortcut set"
+#~ msgstr "ટૂંકાણો સુયોજિત નથી"
+
+#~| msgid "Appearance Preferences"
+#~ msgid "Universal Access Preferences"
+#~ msgstr "સાર્વત્રિક વપરાશ પસંદગીઓ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "સામાન્ય"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "ઉચ્ચ/વિપરીત"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "ઓનસ્ક્રીન કીબોર્ડ"
+
+#~ msgid "OnBoard"
+#~ msgstr "ઑનબોર્ડ"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Small"
+#~ msgstr "નાનું"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "સામાન્ય"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Large"
+#~ msgstr "વિશાળ"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "વિશાળ"
+
+#~| msgid "Beep when Caps and Num Lock are used"
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Caps અને Num Lock વાપરેલ હોય ત્યારે બીપ વગાડો"
+
+#~ msgid "Options..."
+#~ msgstr "વિકલ્પો..."
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "નાનુ મોટુ કરો"
+
+#~ msgid "Zoom in:"
+#~ msgstr "નાનુ મોટુ કરો:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "નાનુ મોટુ કરો:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "અનુશીર્ષક બંધ થયેલ"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "વાણી અને અવાજ નું એક શાબ્દિક વર્ણન દર્શાવો"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "ઓન સ્ક્રીન કિબોર્ડ"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "જ્યારે કી દબાયેલ હોય ત્યારે બીપ વગાડો"
+
+#~ msgid "pressed"
+#~ msgstr "દબાયેલ"
+
+#~ msgid "accepted"
+#~ msgstr "સ્વીકારેલ"
+
+#~ msgid "rejected"
+#~ msgstr "રદ કરેલ"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "સ્વીકૃતિ વિલંબ (_e):"
+
+#~| msgid "_Pointer can be controlled using the keypad"
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "કીપેડની મદદથી નિર્દેશકને નિયંત્રિત કરો"
+
+#~ msgid "Video Mouse"
+#~ msgstr "વિડિઓ માઉસ"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "વિડિયો કૅમેરાની મદદથી નિર્દેશકને નિયંત્રિત કરો."
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "રંગ"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "કંઈ નહિં"
+
+#~ msgid "Add account"
+#~ msgstr "ખાતુ ઉમેરો"
+
+#~ msgid "_Local Account"
+#~ msgstr "સ્થાનિક ખાતુ (_L)"
+
+#~ msgid "_Login Name"
+#~ msgstr "પ્રવેશ નામ (_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "મદદ: એન્ટરપ્રાઇઝ ડોમેઇન અથવા ક્ષેત્ર નામ"
+
+#~ msgid "C_ontinue"
+#~ msgstr "ચાલુ રાખો (_o)"
+
+#~ msgid "User Accounts"
+#~ msgstr "વપરાશકર્તા ખાતાઓ"
+
+#~ msgid "Log in without a password"
+#~ msgstr "પાસવર્જ વગર પ્રવેશો"
+
+#~ msgid "Disable this account"
+#~ msgstr "આ ખાતાને નિષ્ક્રિય કરો"
+
+#~| msgid "C_ity:"
+#~ msgid "_Hint"
+#~ msgstr "ઇશારો (_H)"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "પાસવર્ડની ખાતરી કરો (_o)"
+
+#~| msgid "Filter"
+#~ msgid "Fair"
+#~ msgstr "વ્યાજબી"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#~ msgid "_Action"
+#~ msgstr "ક્રિયા (_A)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "મજબૂત પાસવર્ડને કેવી રીતે પસંદ કરવું"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "તેની માટે ફોટોને બદલી રહ્યા છે:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "ચિત્રને પસંદ કરો કે જે આ ખાતા માટે પ્રવેશ સ્ક્રીન પર દેખાશે."
+
+#~ msgid "Gallery"
+#~ msgstr "ગૅલરિ"
+
+#~ msgid "Take a photograph"
+#~ msgstr "ફોટોગ્રાફ લો"
+
+#~ msgid "Browse"
+#~ msgstr "બ્રાઉઝ"
+
+#~ msgid "Photograph"
+#~ msgstr "ફોટોગ્રાફ"
+
+#~ msgid "Account Information"
+#~ msgstr "ખાતા જાણકારી"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "ઘણો ટૂંકો"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "નબળુ"
+
+#~| msgid "Filter"
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "વ્યાજબી"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "સરસ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "મજબૂત"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "તમારે નવો પાસવર્ડ દાખલ કરવાની જરૂર છે"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "તમારે પાસવર્ડની ખાતરી કરવાની જરૂર છે"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "તમારે તમારા હાલના પાસવર્ડને દાખલ કરવાની જરૂર છે"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "હાલનો પાસવર્ડ યોગ્ય નથી"
+
+#~ msgid "Wrong password"
+#~ msgstr "ખોટો પાસવર્ડ"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "વધારે ચિત્રો માટે બ્રાઉઝ કરો..."
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "નામ '%s' સાથે વપરાશકર્તા અસ્તિત્વમાં છે."
+
+#~ msgid "This user does not exist."
+#~ msgstr "આ વપરાશકર્તા અસ્તિત્વ ધરાવતુ નથી."
+
+#~ msgid "Switch Modes"
+#~ msgstr "સ્વીચ મોડ"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#~ msgid "Action"
+#~ msgstr "ક્રિયા"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "તમારાં Wacom ટૅબલેટ પસંદગીઓને સુયોજિત કરો"
+
+#~| msgid "Options..."
+#~ msgid "Map Buttons..."
+#~ msgstr "માપન બટનો..."
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~| msgid "Create..."
+#~ msgid "Calibrate..."
+#~ msgstr "માપદંડ કરો..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- સિસ્ટમ સુયોજનો"
+
+#~ msgid "Control Center"
+#~ msgstr "નિયંત્રણ કેન્દ્ર"
+
+#~ msgid "System Settings"
+#~ msgstr "સિસ્ટમ સુયોજનો"
+
+#~ msgid "Security Key"
+#~ msgstr "સુરક્ષા કી"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "સબનેટ માસ્ક"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "વોલપેપર ઉમેરો"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "વોલપેપર દૂર કરો"
+
+#~ msgid "Swap colors"
+#~ msgstr "સ્વેર રંગ"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "આડો ઢાળ"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "ઊભો ઢાળ"
+
+#~ msgid "Solid Color"
+#~ msgstr "ઘટ્ટ રંગ"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#~ msgid "Acti_on:"
+#~ msgstr "ક્રિયા (_o)"
+
+#~| msgid "Take a photo..."
+#~ msgid "Take a screenshot"
+#~ msgstr "સ્ક્રીનશોટ લો"
+
+#~ msgid "Shortcut"
+#~ msgstr "ટુંકાણ"
+
+#~ msgid "_Right-handed"
+#~ msgstr "જમણા-હાથવાળી (_R)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "ડાબા હાથવાળુ (_L)"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "જ્યારે Control કી દબાયેલ હોય ત્યારે પોઇંટરની જગ્યાને બતાવો"
+
+#~| msgid "_Acceleration:"
+#~ msgid "A_cceleration:"
+#~ msgstr "પ્રવેગ (_c):"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "ચેતના (_S):"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "ખેંચો અને છોડો"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "થ્રેશોલ્ડ (_e):"
+
+#, fuzzy
+#~| msgid "Thr_eshold:"
+#~ msgid "Drag Threshold"
+#~ msgstr "થ્રેશોલ્ડ (_e):"
+
+#~ msgid "Double-Click Timeout"
+#~ msgstr "બે ક્લિકની સમયસમાપ્તિ"
+
+#~ msgid "_Timeout:"
+#~ msgstr "સમય સમાપ્ત (_T):"
+
+#, fuzzy
+#~| msgid ""
+#~| "To test your double-click settings, try to double-click on the light "
+#~| "bulb."
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "તમારી ડબલ-ક્લિક સુયોજનોને ચકાસો, લાઇટ બલ્બ પર ડબલ-ક્લિક નો પ્રયત્ન કરો."
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "ટચપેડ સાથે માઉસ ક્લિકોને સક્રિય કરો (_m)"
+
+#~ msgid "Scrolling"
+#~ msgstr "સ્ક્રોલ કરી રહ્યા છે"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#~ msgid "_Disabled"
+#~ msgstr "નિષ્ક્રિય થયેલ (_D)"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "બીજા..."
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "આ ફક્ત તમારા ઇન્ટરનેટનું જોડાણ છે."
+
+#~ msgid "_Network Name"
+#~ msgstr "નેટવર્ક નામ (_N)"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#~| msgid "Disabled"
+#~ msgid "Disable VPN"
+#~ msgstr "VPN નિષ્ક્રિય કરો"
+
+#~| msgid "_HTTP Proxy"
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP પોર્ટ"
+
+#~| msgid "H_TTPS Proxy"
+#~ msgid "HTTPS Port"
+#~ msgstr "HTTPS પોર્ટ"
+
+#~| msgid "_FTP Proxy"
+#~ msgid "FTP Port"
+#~ msgstr "FTP પોર્ટ"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "નવાં ખાતાને ઉમેરવા માટે, પહેલાં ખાતા પ્રકાર પસંદ કરો"
+
+#~ msgid "_Add..."
+#~ msgstr "ઉમેરો (_A)..."
+
+#~| msgid "_Type:"
+#~ msgid "Tip:"
+#~ msgstr "મદદ:"
+
+#, fuzzy
+#~| msgid "Brightness"
+#~ msgid "Brightness Settings"
+#~ msgstr "પ્રકાશતા"
+
+#~ msgid "_Search by Address"
+#~ msgstr "સરનામાં પ્રમાણે શોધો (_S)"
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "સ્થાનિક"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "નેટવર્ક"
+
+#~ msgid "Device types"
+#~ msgstr "ઉપકરણ પ્રકારો"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "આપમેળે રૂપરેખાંકન"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "mDNS જોડાણો માટે ફાયરવોલ ખોલી રહ્યા છે"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "સામ્બા જોડાણો માટે ફાયરવોલને ખોલી રહ્યા છે"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "IPP જોડાણો માટે ફાયરવોલને ખોલી રહ્યા છે"
+
+#~ msgid "_Back"
+#~ msgstr "પાછળ (_B)"
+
+#, fuzzy
+#~| msgid "Remove wallpaper"
+#~ msgid "Remove User"
+#~ msgstr "વોલપેપર દૂર કરો"
+
+#~ msgid "Allowed users"
+#~ msgstr "પરવાનગી આપેવ વપરાશકર્તાઓ"
+
+#~| msgid "Layout"
+#~ msgid "Add Layout"
+#~ msgstr "લેઆઉટને ઉમેરો"
+
+#~| msgid "Choose a Layout"
+#~ msgid "Remove Layout"
+#~ msgstr "લેઆઉટ દૂર કરો"
+
+#~| msgid "Preview"
+#~ msgid "Preview Layout"
+#~ msgstr "લેઆઉટનું પૂર્વદર્શન"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "નવી વિન્ડો મૂળભૂત લેઆઉટને વાપરે છે"
+
+#, fuzzy
+#~| msgid "Use previous window's layout in new windows"
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "નવી વિન્ડોમાં પહેલાંની વિન્ડોનાં લેઆઉટને વાપરો"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "કિબોર્ડ લેઆઉટ વિકલ્પોમાં ફેરફાર કરો અને દર્શાવો"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "મૂળભૂતોમાં પુનઃસુયોજિત કરો (_f)"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr "હાલનાં કીબોર્ડ લેઆઉટ સુયોજનોને મૂળભૂત સુયોજનો સાથે બદલો"
+
+#~ msgid "Layouts"
+#~ msgstr "દેખાવો"
+
+#~ msgid "Layout"
+#~ msgstr "દેખાવ"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "રૂપરેખાંકિત કરવા માટે ઉપકરણને પસંદ કરો (_h):"
+
+#~ msgid "Dasher"
+#~ msgstr "ડેશર"
+
+#, fuzzy
+#~| msgid "None"
+#~ msgid "Nomon"
+#~ msgstr "કંઈ જ નહિં"
+
+#, fuzzy
+#~| msgid "Change set"
+#~ msgid "Change contrast:"
+#~ msgstr "બદલનાર સમૂહ"
+
+#~ msgid "_Text size:"
+#~ msgstr "લખાણ માપ (_T):"
+
+#~ msgid "Increase size:"
+#~ msgstr "માપ વધારો:"
+
+#~ msgid "Decrease size:"
+#~ msgstr "માપને ઘટાડો:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "દેખાવ"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "નાનુ મોટુ કરો"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "સુયોજનોની ચકાસણી કરવા માટે અહિંયા ટાઇપ કરો"
+
+#~| msgid "Screen"
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 સ્ક્રીન"
+
+#~| msgid "Screen"
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 સ્ક્રીન"
+
+#~ msgid "Create new account"
+#~ msgstr "નવા ખાતાને બનાવો"
+
+#~ msgid "_Account Type"
+#~ msgstr "ખાતા પ્રકાર (_A)"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-app-helper.c:166
+#~ msgid "Cr_eate"
+#~ msgstr "બનાવો (_e)"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "ઉત્પન્ન થયેલ પાસવર્ડને પસંદ કરો"
+
+#~ msgid "Account _type"
+#~ msgstr "ખાતા પ્રકાર (_t)"
+
+#~ msgid "More choices..."
+#~ msgstr "વધારે પસંદગીઓ..."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Wacom ગ્રાફિક ટૅબલેટ"
+
+#~ msgid "Upside-down"
+#~ msgstr "અસ્તવ્યસ્ત"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr ""
+#~ "જ્યારે રૂપરેખાંકનને દર્શાવવાનું અમલમાં કરી રહ્યા હોય ત્યારે સત્ર બસ ને મેળવી શકાયુ નહિં"
+
+#~ msgid "System Info"
+#~ msgstr "સિસ્ટમ જાણકારી"
+
+#, fuzzy
+#~| msgid "Change set"
+#~ msgid "Toggle contrast"
+#~ msgstr "બદલનાર સમૂહ"
+
+#, fuzzy
+#~| msgid "Linux Screen Reader"
+#~ msgid "Toggle screen reader"
+#~ msgstr "Linux સ્ક્રીન વાંચક"
+
+#~ msgid "Accelerator key"
+#~ msgstr "પ્રવેગક કી"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "પ્રવેગ બદલનાર"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "પ્રવેગક કી કોડ"
+
+#~ msgid "Accel Mode"
+#~ msgstr "એક્સેલ સ્થિતિ"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "પ્રવેગનો પ્રકાર."
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "નવા ટુંકાણોનો સંગ્રહ કરવા દરમિયાન ભૂલ"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "ઘણાબધા વૈવિધ્યપૂર્ણ ટુંકાણો"
+
+#~ msgid "_Photos:"
+#~ msgstr "ફોટા (_P):"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "cd;dvd;usb;ઓડિયો;વિડિયો;ડિસ્ક;"
+
+#~ msgid "Speed"
+#~ msgstr "ઝડપ"
+
+#~ msgid "Unlock"
+#~ msgstr "તાળુ ખોલો"
+
+#~ msgid "Ask me"
+#~ msgstr "મને પૂછો"
+
+#~ msgid "Shutdown"
+#~ msgstr "બંધ કરો"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#, fuzzy
+#~| msgid "Sound"
+#~ msgid "Suspend"
+#~ msgstr "ધ્વનિ"
+
+#, fuzzy
+#~| msgid "Turn off after:"
+#~ msgid "_Turn off after:"
+#~ msgstr "પછી બંધ કરો:"
+
+#~ msgid "Mute"
+#~ msgstr "મૂંગુ"
+
+#~ msgid "Key"
+#~ msgstr "કી"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "જીકોન્ફ કી કે જેની સાથે આ ગુણધર્મ સંપાદક સંકળાયેલ છે"
+
+#~ msgid "Callback"
+#~ msgstr "કોલબેક"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "જ્યારે આ કીને સંબંધિત કિંમત બદલાય ત્યારે કોલબેક ચાલુ કરો"
+
+#~ msgid "Change set"
+#~ msgstr "બદલનાર સમૂહ"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "જીકોન્ફ બદલનાર સમૂહ પાસે માહિતી હોય છે જે અમલમાં મૂકતાં જીકોન્ફ ક્લાયન્ટને મોકલાય છે"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "વિજેટ કોલબેકમાં ફેરવો"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "જ્યારે માહિતી જીકોન્ફમાંથી વિજેટમાં ફેરવાય છે ત્યારે કોલબેક અપાય છે"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "વિજેટ કોલબેકમાંથી ફેરવો"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "જ્યારે માહિતી વિજેટમાંથી જીકોન્ફમાં ફેરવાય છે ત્યારે કોલબેક અપાય છે"
+
+#~ msgid "UI Control"
+#~ msgstr "UI નિયંત્રણ"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "ઓબ્જેક્ટ કે જે ગુણધર્મનું નિયંત્રણ કરે છે (સામાન્ય રીતે વિજેટ)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "ઓબ્જેક્ટની માહિતીનો ગુણધર્મ સંપાદક"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "વિશિષ્ટ ગુણધર્મ સંપાદકને કસ્ટમ માહિતી જોઈએ છે"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "ગુણધર્મ સંપાદક માહિતી મુક્ત કરે છે કોલબેક"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "ગુણધર્મ સંપાદક ઓબ્જેક્ટની માહિતી જ્યારે મુક્ત થાય ત્યારે કોલબેક અપાય છે"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "ફાઈલ '%s' શોધી શકાઈ નહિં. \n"
+#~ "મહેરબાની કરી ખાતરી કરો કે તે અસ્તિત્વમાં છે કે તે  ચકાસો, \n"
+#~ "અથવા અલગ જ પાશ્વ ભાગનું ચિત્ર પસંદ કરો."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "મને ખબર નથી કે ફાઈલ '%s' કેવી રીતે ખોલવી. \n"
+#~ "કદાચ આ એ પ્રકારનું ચિત્ર છે કે જે હજુ સુધી ટેકો આપી શકાય તેવુ નથી\n"
+#~ "\n"
+#~ "મહેરબાની કરીને એના બદલામાં બીજુ ચિત્ર પસંદ કરો."
+
+#~ msgid "Please select an image."
+#~ msgstr "મહેરબાની કરીને ચિત્ર પસંદ કરો."
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-app-helper.c:166
+#~ msgid "Create a user"
+#~ msgstr "વપરાશકર્તાને બનાવો"
+
+#~ msgid "Current network location"
+#~ msgstr "હાલનું નેટવર્ક સ્થાન"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "વધારે પાશ્ર્વભાગો URL"
+
+#~ msgid "More themes URL"
+#~ msgstr "વધારે થીમો URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "તમારા હાલનાં સ્થાન નામમાં આને સુયોજિત કરો. આ અનૂકુળ નેટવર્ક પ્રોક્સી રૂપરેખાંકનને નક્કી "
+#~ "કરવા માટે વપરાયેલ છે."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "ક્યાં વધારે ડેસ્કટોપ પાશ્ર્વભાગો મળે છે તે માટે URL, જો ખાલી શબ્દમાળા માં સુયોજિત હોય "
+#~ "તો કડી દેખાશે નહિં."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "ક્યાં વધારે ડેસ્કટોપ થીમો મળે છે તે માટે URL. જો ખાલી શબ્દમાળા માટે સુયોજિત હોય તો "
+#~ "કડી દેખાશે."
+
+#~ msgid "Locked"
+#~ msgstr "તાળુ મારેલ"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "સંવાદને તાળુ મારેલ નથી.\n"
+#~ "ભવિષ્યનાં બદલાવોને અટકાવવા માટે ક્લિક કરો"
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "સંવાદને તાળુ મારેલ છે.\n"
+#~ "બદલાવો કરવા માટે ક્લિક કરો"
+
+#, fuzzy
+#~| msgid "Please contact your system administrator for help."
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr "મહેરબાની કરીને મદદ માટે તમારા સિસ્ટમ વહીવટકર્તા ને સંપર્ક કરો."
+
+#~ msgid "24-Hour Time"
+#~ msgstr "24-કલાક સમય"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f KB"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f MB"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f GB"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TB"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PB"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EB"
+
+#~| msgid "_Photos:"
+#~ msgid "Photos"
+#~ msgstr "ફોટા"
+
+#~| msgid "Update Available"
+#~ msgid "Updates Available"
+#~ msgstr "સુધારો ઉપલબ્ધ"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "નવી વિન્ડોમાં મૂળભૂત લેઆઉટને વાપરો"
+
+#~ msgid "On AC power:"
+#~ msgstr "AC પાવર પર:"
+
+#~ msgid "When the power button is pressed:"
+#~ msgstr "જ્યારે પાવર બટન દબાયેલ હોય:"
+
+#~| msgid "_Keyboard Accessibility"
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "કીબોર્ડ;માઉસ;a11y;સુલભતા;"
+
+#~| msgid "<span size=\"x-large\">High</span>"
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">વધારે/ઊલટું</span>"
+
+#~| msgid "<span size=\"x-large\">High</span>"
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">વધારે</span>"
+
+#~| msgid "<span size=\"x-large\">Low</span>"
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">ઓછુ</span>"
+
+#~| msgid "<span size=\"x-large\">Normal</span>"
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">સામાન્ય</span>"

--- a/po/he.po
+++ b/po/he.po
@@ -10,116 +10,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.HEAD.he\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-05 18:05+0000\n"
-"PO-Revision-Date: 2022-09-11 06:45+0300\n"
-"Last-Translator: Yosef Or Boczko <yoseforb@gmail.com>\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-10-06 15:34+0300\n"
+"Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <>\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n==2 ? 1 : n>10 && n%10==0 ? "
-"2 : 3)\n"
-"X-Generator: Gtranslator 40.0\n"
-
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "אפיק נתונים"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "גישה מלאה"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "אפיק הפעלה"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "התקנים"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "גישה מלאה אל ‎/dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "רשת"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "יש גישה לרשת"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "בית"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "קריאה בלבד"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "מערכת הפעלה"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "הגדרות"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "ניתן לשנות הגדרות"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"ליישום %s יש את ההרשאות הבאות בצורה מובנית. לא ניתן לשנות זאת. אם הדבר מדאיג "
-"אותך, כדאי לשקול את הסרת היישום."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "סוג קבצים וקישורים אחד שנפתח על ידי היישום הזה"
-msgstr[1] "‫%u סוגי קבצים וקישורים שנפתחים על ידי היישום הזה"
-msgstr[2] "‫%u סוגי קבצים וקישורים שנפתחים על ידי היישום הזה"
-msgstr[3] "‫%u סוגי קבצים וקישורים שנפתחים על ידי היישום הזה"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "‫<b>%s</b> משמש לפתיחת סוגי הקבצים והקישורים הבאים."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-#| msgid "%s of disk space used"
-msgid "%s of disk space used."
-msgstr "‫%s משטח הכונן מנוצלים."
+"2 : 3);\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -128,14 +32,13 @@ msgstr "יישומים"
 
 #: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
-msgstr "לא נמצאו יישומים"
+msgstr "אין יישומים"
 
 #: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
-msgstr "מתקין…"
+msgstr "מתבצעת התקנה…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "פתיחה"
 
@@ -159,24 +62,13 @@ msgstr "חיפוש"
 msgid "Receive system searches and send results."
 msgstr "קבלת חיפושי מערכת ושליחת התוצאות."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "מושבת"
 
@@ -190,9 +82,8 @@ msgid "Show system notifications."
 msgstr "הצגת התראות מערכת."
 
 #: panels/applications/cc-applications-panel.ui:133
-#| msgid "Run in background"
 msgid "Run in Background"
-msgstr "פועל ברקע"
+msgstr "פעילות ברקע"
 
 #: panels/applications/cc-applications-panel.ui:134
 msgid "Allow activity when the app is closed."
@@ -203,7 +94,6 @@ msgid "Screenshots"
 msgstr "צילומי מסך"
 
 #: panels/applications/cc-applications-panel.ui:141
-#| msgid "Take pictures with the camera."
 msgid "Take pictures of the screen at any time."
 msgstr "צילום המסך בכל רגע."
 
@@ -223,7 +113,7 @@ msgstr "שמע"
 #: panels/applications/cc-applications-panel.ui:155
 #: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
-msgstr "שחזור צלילים."
+msgstr "הפקת צלילים."
 
 #: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
@@ -273,7 +163,7 @@ msgstr "הרשאות מובנות"
 
 #: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
-msgstr "גישה למערכת שדורש היישום"
+msgstr "גישה למערכת לדרישת היישום"
 
 #: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
@@ -343,80 +233,20 @@ msgstr "ניקוי מטמון…"
 msgid "Control various application permissions and settings"
 msgstr "שליטה בהגדרות והרשאות של מספר יישומים"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "יישומים;flatpak;הרשאות;השראה;יישום;אפליקציה;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "בחירת תמונה"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_ביטול"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_פתיחה"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "מספר גדלים"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "אין רקע לשולחן העבודה"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "הרקע הנוכחי"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "סגנון"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "בררת מחדל"
 
@@ -440,7 +270,6 @@ msgstr "מראה"
 msgid "Change your background image or the UI colors"
 msgstr "החלפת תמונת הרקע או צבעי ממשק המשתמש"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "רקע;תמונת רקע;צג;מסך;שולחן עבודה;סגנון;בהיר;כהה;סטייל;מראה;"
@@ -491,9 +320,7 @@ msgstr "מצב טיסה חומרתי מופעל"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "יש לכבות את מצב הטיסה על מנת לאפשר בלוטות'."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "בלוטות'"
 
@@ -501,7 +328,6 @@ msgstr "בלוטות'"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "הפעלה וכיבוי של הבלוטות' והתחברות להתקנים שלך"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "שיתוף;לשתף;Bluetooth;obex;בלוטות';"
@@ -534,91 +360,35 @@ msgstr "אף יישום לא ביקש גישה למצלמה"
 msgid "Protect your pictures"
 msgstr "הגנה על התמונות שלך"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "מצלמה;תמונות;תמונה;וידאו;סרט;סרטון;סרטים;מצלמת רשת;מצלמת אינטרנט;נעילה;מנעול;"
 "פרטיות;פרטי;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "יש להציב את התקן הכיול שלך על הריבוע וללחוץ על „התחלה“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "יש להעביר את התקן הכיול שלך לעמדת הכיול וללחוץ „המשך”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "יש להעביר את התקן הכיול שלך למשטח הכיול וללחוץ „המשך”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "סגירת המסך במחשב נייד"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "אירעה שגיאה פנימית שלא ניתן להתאושש ממנה."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "הכלים הנדרשים לכיול אינם מותקנים."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "לא ניתן לייצר את הפרופיל."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "יעד נקודת הלובן אינו בר השגה."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "הושלם!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "הכיול נכשל!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "ניתן להסיר את התקן הכיול."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "נא לא להפריע להתקן הכיול במהלך ההתקדמות"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "כיול התצוגה"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_ביטול"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -635,138 +405,6 @@ msgstr "ה_משך"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_סיום"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "מסך של מחשב נייד"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "מצלמה מובנית"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "צג %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "סורק %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "מצלמת %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "מדפסת %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "מצלמת רשת %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "הפעלת ניהול צבע עבור %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "הצגת פרופילי צבע עבור %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "ללא כיול"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "בררת מחדל: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "מרחב צבעים: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "פרופיל בדיקה: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "בחירת פרופיל ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "יי_בוא"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "פרופילי ICC נתמכים"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "כל הקבצים"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "מסך"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "שמירת הפרופיל"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_שמירה"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "יצירת פרופיל צבע עבור ההתקן הנבחר"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "התקן המדידה לא זוהה. נא לבדוק כי הוא פועל ומחובר כראוי."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "התקן המדידה אינו תומך ביצירת פרופילים למדפסות."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "סוג ההתקן אינו נתמך נכון לעכשיו."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -903,7 +541,6 @@ msgstr "_ייבוא קובץ…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -913,9 +550,7 @@ msgstr "הו_ספה"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "לכל התקן דרוש פרופיל צבע עדכני כדי שניתן יהיה לנהל אותו לפי צבע."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "מידע נוסף"
 
@@ -1047,82 +682,6 @@ msgstr "D65 (צילום וגרפיקה)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "מרחב רגיל"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "בדיקת הפרופיל"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "אוטומטית"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "איכות נמוכה"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "איכות בינונית"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "איכות גבוהה"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "בררת מחדל RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "בררת מחדל CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "בררת מחדל גווני אפור"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "נתוני כיול שסופקו על ידי היצרן"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "תיקון תצוגת מסך מלא אינו אפשרי עם פרופיל זה"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "יתכן שפרופיל זה אינו מדויק עוד"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "צבע"
@@ -1132,14 +691,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "כיול הצבע של ההתקנים שלך כגון צגים, מצלמות או מדפסות"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "צבע;ICC;פרופיל;כיול;מדפסת;צג;תצוגה;מסך;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "אחר…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1154,13 +708,8 @@ msgid "No languages found"
 msgstr "לא נמצאו שפות"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "עוד…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "יש לשחרר לשינוי הגדרות"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1189,157 +738,6 @@ msgstr "הפחתת שעה"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "הפחתת דקה"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "היום"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "אתמול"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e ב%b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e ב%b, 2013"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "שעה"
-msgstr[1] "שעתיים"
-msgstr[2] "‫%d שעות"
-msgstr[3] "‫%d שעות"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "דקה"
-msgstr[1] "שתי דקות"
-msgstr[2] "‏‫%d דקות"
-msgstr[3] "‏‫%d דקות"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "שנייה"
-msgstr[1] "שתי שניות"
-msgstr[2] "‫%d שניות"
-msgstr[3] "‏‫%d שניות"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "‏%s, ‏%s ו־%s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "‏%s ו־%s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "‏%s ו־%s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 שניות"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "נקודה חמה"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 שעות"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e ב%B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e ב%B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "‎%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1434,17 +832,11 @@ msgstr "אזור _זמן אוטומטי"
 msgid "Requires location services enabled and internet access"
 msgstr "נדרשת גישה לשירותי מיקום וחיבור לאינטרנט"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "פעיל"
 
@@ -1452,15 +844,42 @@ msgstr "פעיל"
 msgid "Time Z_one"
 msgstr "_אזור זמן"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "שחרור"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_תבנית זמן"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "תאריכים"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 שניות"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "לוח שנה"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "מספרים"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "החלפת השעה והתאריך לרבות אזור הזמן"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "שעון;אזור זמן;מיקום;"
@@ -1506,20 +925,9 @@ msgstr "יישומי בררת המחדל"
 msgid "Configure Default Applications"
 msgstr "הגדרת יישומי בררת המחדל"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "ברירת מחדל;בררת מחדל;דפאולט;יישום;יישומים;מאפיינים;הגדרות;הגדרה;מדיה;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"שליחת דיווחים על בעיות טכניות תעזור לנו לשפר את %s. הדיווחים נשלחים בעילום "
-"שם וללא מידע אישי. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1537,44 +945,9 @@ msgstr "אבחון"
 msgid "Report your problems"
 msgstr "דיווח על בעיות"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "אבחון;אבחנה;קריסה;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "פעיל"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "כבוי"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "להחיל שינויים?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "אי אפשר להחיל את השינויים"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "אולי זה קשור למגבלות חומרה."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1624,31 +997,6 @@ msgstr "צג ראשי"
 msgid "Night Light"
 msgstr "תאורת לילה"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "לרוחב"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "ימין לאורך"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "שמאל לאורך"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "לרוחב (הפוך)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "‏%.2lf הרץ"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1672,6 +1020,17 @@ msgstr "התאמה לטלויזיה"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "גודל"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "גלילה טבעית"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1766,7 +1125,6 @@ msgstr "צגים"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "בחירה כיצד להשתמש בצגים ובמקרנים מחוברים"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1774,92 +1132,6 @@ msgid ""
 msgstr ""
 "לוח;מקרן;xrandr;צג;מסך;רזולוציה;הבחנה;רענון;צג;לילה;אור;תאורה;כחול;היסט "
 "לאדום;צבע;שקיעה;זריחה;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "הפעלה מאובטחת פעילה"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-#| msgid ""
-#| "Secure boot prevents malicious software from being loaded when the device "
-#| "starts.\n"
-#| "\n"
-#| "For more information, contact the hardware manufacturer or IT support."
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן. היא פעילה כעת "
-"ופועלת בצורה תקינה."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-#| msgid "Secure Boot has Problems"
-msgid "Secure Boot Has Problems"
-msgstr "יש בעיות בהפעלה מאובטחת"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-#| msgid ""
-#| "Secure boot prevents malicious software from being loaded when the device "
-#| "starts.\n"
-#| "\n"
-#| "For more information, contact the hardware manufacturer or IT support."
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן. היא פעילה כעת, "
-"אך לא תעבוד עקב מפתח לא תקף."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"לעתים קרובות ניתן לפתור בעיות בהפעלה מאובטחת מהגדרות קָשְחת UEFI ‏(BIOS) של "
-"המחשב. יצרן החָמְרָה שלך עשוי לספק מידע כיצד לעשות זאת."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "לעזרה, יש ליצור קשר עם יצרן החָמְרָה או עם תמיכת ה־IT של הספק."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-#| msgid "Camera is Turned Off"
-msgid "Secure Boot is Turned Off"
-msgstr "הפעלה מאובטחת אינה פעילה"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-#| msgid ""
-#| "Secure boot prevents malicious software from being loaded when the device "
-#| "starts.\n"
-#| "\n"
-#| "For more information, contact the hardware manufacturer or IT support."
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן. היא אינה פעילת "
-"כעת."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"לעתים קרובות ניתן להפעיל את ההפעלה המאובטחת מהגדרות קָשְחת UEFI ‏(BIOS) של "
-"המחשב. למידע נוסף, יש ליצור קשר עם יצרן החָמְרָה או עם תמיכת ה־IT של הספק."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1872,125 +1144,9 @@ msgstr ""
 "\n"
 "למידע נוסף, יש ליצור קשר עם יצרן החומרה או עם תמיכת IT."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-#| msgid "Password"
-msgid "Passed"
-msgstr "עבר"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "נכשל"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "ההתקן תואם לרמת HSI (מזהה אבטחת מארח)‏ %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "רמת אבטחה 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"להתקן זה אין הגנה כנגד בעיות אבטחת חָמְרָה. יתכן וזה נובע מהגדרות חומרה או "
-"קָשְחה. מומלץ ליצור קשר עם ספק תמיכת ה־IT שלך."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "רמת אבטחה 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"להתקן זה הגנה מזערית כנגד בעיות אבטחת חָמְרָה. זוהי הרמה הנמוכה ביותר של הגנת "
-"התקן המספקת הגנה למול איומי אבטחה בסיסיים בלבד."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "רמת אבטחה 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"להתקן זה הגנה בסיסית כנגד בעיות אבטחת חָמְרָה. זה מספק הגנה מפני איומי אבטחה "
-"נפוצים."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "רמת אבטחה 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"להתקן זה אבטחה מורחבת כנגד בעיות אבטחת חָמְרָה. זוהי הרמה הגבוה ביותר של הגנת "
-"התקן המספקת הגנה מפני איומי אבטחה מתקדמים."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "רמת אבטחה"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "רמות אבטחה אינן זמינות עבור התקן זה"
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr "יש ליצור קשר עם יצרן החָמְרָה לעזרה בנושא עדכוני אבטחה."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"יתכן וניתן לפתור בעיה זו בהגדרות קָשְחת UEFI של ההתקן, או על ידי תמיכה טכנית. "
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr "יתכן וניתן לפתור בעיה זו בהגדרות קָשְחת UEFI של ההתקן. "
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "יתכן וניתן לפתור בעיה זו על ידי תמיכה טכנית. "
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2004,365 +1160,9 @@ msgstr "רמת 2"
 msgid "Level 3"
 msgstr "רמת 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "הגנה כנגד תכנות זדוניות בזמן הפעלת ההתקן."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "יש בעיות בהפעלה מאובטחת"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "קצת הגנה בזמן שההתקן מופעל."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-#| msgid "Secure Boot is Active"
-msgid "Secure Boot is Off"
-msgstr "הפעלה מאובטחת כבויה"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "אין הגנה בזמן שההתקן מופעל."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"יתכן ובעיה זו נגרמה בגלל שינוי בהגדרות קָשְחת UEFI, שינוי תצורת מערכת ההפעלה "
-"או בגלל תכנה זדונית במערכת זו."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"יתכן ובעיה זו נגרמה בגלל שינוי בהגדרות קָשְחת UEFI או בגלל תכנה זדונית במערכת "
-"זו."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"יתכן ובעיה זו נגרמה בגלל שינוי תצורת מערכת ההפעלה או בגלל תכנה זדונית במערכת "
-"זו."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-#| msgid "Highly exposed to security threats."
-msgid "Exposed to serious security threats."
-msgstr "חשוף לאיומי אבטחה רציניים."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "הגנה מוגבלת כנגד איומי אבטחה פשוטים."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "הגנה כנגד איומי אבטחה נפוצים."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "הגנה כנגד מנעד רחב של אימוי אבטחה."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "הגנה מקיפה"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "אין אירועים"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection"
-msgstr "הגנת כתיבה לקָשְחה"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection Lock"
-msgstr "הגנת כתיבה לקָשְחה נעולה"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Region"
-msgstr "תחום קָשְחת BIOS"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Descriptor"
-msgstr "תיאור קָשְחת BIOS"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-#| msgid "No Protection"
-msgid "Pre-boot DMA Protection"
-msgstr "הגנת DMA קדם־אתחול"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr ""
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "‏RAM מוצפן"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-#| msgid "No Protection"
-msgid "IOMMU Protection"
-msgstr "הגנת IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "נעילת ליבת לינוקס"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "אימות ליבת לינוקס"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "מחיצת החלפה לינוקס"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-#| msgid "Suspend"
-msgid "Suspend To RAM"
-msgstr "השהיה ל־RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-#, fuzzy
-#| msgid "Suspend"
-msgid "Suspend To Idle"
-msgstr "השהיה"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr ""
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-#| msgid "Secure boot"
-msgid "UEFI Secure Boot"
-msgstr "אתחול UEFI מאובטח"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-#, fuzzy
-#| msgid "Display Configuration"
-msgid "TPM Platform Configuration"
-msgstr "הגדרות צג"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-#, fuzzy
-#| msgid "Restrictions:"
-msgid "TPM Reconstruction"
-msgstr "הגבלות:"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-#| msgid "Firmware Version"
-msgid "Firmware Updates"
-msgstr "עדכוני קָשְחה"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-#| msgid "Firmware Version"
-msgid "Firmware Attestation"
-msgstr "תעודת קָשְחה"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-#| msgid "Firmware Version"
-msgid "Firmware Updater Verification"
-msgstr "עדכון אימות קָשְחה"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-#, fuzzy
-msgid "Platform Debugging"
-msgstr "ניפוי שגיאות בפלטפורמה"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "בדיקות אבטחת מעבד"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-#, fuzzy
-#| msgid "No Protection"
-msgid "AMD Rollback Protection"
-msgstr "ללא הגנה"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-#, fuzzy
-#| msgid "Minimal Protection"
-msgid "AMD Firmware Replay Protection"
-msgstr "הגנה מזערית"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-#, fuzzy
-#| msgid "Minimal Security Protections"
-msgid "AMD Firmware Write Protection"
-msgstr "הגנת אבטחה מזערית"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr ""
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "תקף"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "לא תקף"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "לא מאופשר"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "נעולה"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "לא נעול"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "מוצפן"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "לא מוצפן"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "מזוהם"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-#| msgid "Not calibrated"
-msgid "Not Tainted"
-msgstr "לא מזוהם"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "נמצא"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "לא נמצא"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "נתמך"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "לא נתמך"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2372,7 +1172,6 @@ msgstr "אבטחת התקן"
 msgid "Host firmware security status"
 msgstr "מצב אבטחת קָשְחת המארח"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2380,49 +1179,6 @@ msgid ""
 msgstr ""
 "מסך;צד;נעילה;ניתוח;דיאגנוסטיקה;קריסה;פרטיות;פרטי;אחרונים;אחרון;זמני;זמניים;"
 "מפתח;אינדקס;שם;רשת;זהות;פרטיות;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "לא ידוע"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64 סיביות"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32 סיביות"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "לא ידוע"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "לא זמין"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "לוגו המערכת"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2460,7 +1216,6 @@ msgstr "שם מערכת הפעלה"
 
 #. translators: this field contains the distro build ID
 #: panels/info-overview/cc-info-overview-panel.ui:107
-#| msgid "%s; Build ID: %s"
 msgid "OS Build ID"
 msgstr "מזהה בניית מערכת הפעלה"
 
@@ -2515,11 +1270,6 @@ msgstr "אודות"
 msgid "View information about your system"
 msgstr "צפייה בפרטים על המערכת שלך"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2599,6 +1349,12 @@ msgstr "משגרים"
 msgid "Launch help browser"
 msgstr "הפעלת דפדפן העזרה"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "הגדרות"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "הפעלת המחשבון"
@@ -2620,7 +1376,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "חיפוש"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "מערכת"
 
@@ -2669,15 +1425,6 @@ msgstr "הקטנת הטקסט"
 msgid "High contrast on or off"
 msgstr "ביטול/הפעלה של ניגודיות גבוהה"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "לא נמצא מקור קלט"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "אחר"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "הוספת מקור קלט"
@@ -2710,106 +1457,9 @@ msgstr "העדפות"
 msgid "View Keyboard Layout"
 msgstr "הצגת פריסת המקלדת"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "הסרה"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "צירופי מקשים מותאמים"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "מקש לתווים חלופיים"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"מקש לתווים חלופיים יכול לשמש להזנת תווים נוספים. לעתים זה מופיע כאפשרות "
-"שלישית במקלדת שלך."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "‏Alt שמאלי"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "‏Alt ימני"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "‏Super שמאלי"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "‏Super ימני"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "מקש תפריט"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "‏Ctrl ימני"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "מקש Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"מקש Compose מאפשר הקלדת מגוון רחב של תווים. כדי להשתמש בו, יש ללחוץ על "
-"Compose ואז על צירוף תווים.  למשל, מקש Compose שלאחריו נלחצים <b>C</b> ואז "
-"<b>o</b> יקליד <b>©</b>, ‏<b>a</b> ולאחריו <b>’</b> יקליד <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "‫Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "צילום מסך"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"ניתן לשנות את מקורות הקלט באמצעות קיצור המקלדת %s.\n"
-"‬\n"
-"‫בהגדרות קיצורי המקלדת אפשר לשנות את ההגדרה הזאת."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2839,47 +1489,21 @@ msgstr "מילוי תווים מיוחדים"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "שיטות למילוי סימנים והגווני אותיות באמצעות המקלדת."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "מקש לתווים חלופיים"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "מקש Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "צירופי מקשים"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "הצגה והתאמה של קיצורי מקשים"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "‫%d נערך"
-msgstr[1] "‫%d נערכו"
-msgstr[2] "‫%d נערכו"
-msgstr[3] "‫%d נערכו"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "איפוס כל צירופי המקשים?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"איפוס צירופי המקשים עשוי להשפיע על ההתאמה האישית של המקלדת שלך. לא נתן לבטל "
-"פעולה זאת."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "ביטול"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "איפוס הכול"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2917,33 +1541,6 @@ msgstr "הוספת קיצור דרך"
 msgid "No keyboard shortcut found"
 msgstr "לא נמצאו צירופי מקשים"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "‫%s כבר בשימוש על ידי %s. החלפה שלו, תשבית את %s"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "יש להקיש את צירוף המקשים החדש"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "הגדרת צירופי מקשים מותאמים אישית"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "הגדרת צירופי מקשים"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "יש להקיש צירופי מקשים חדשים לשינוי ‏%s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "הוספת צירוף מקשים חדש"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "הס_רה"
@@ -2955,7 +1552,6 @@ msgstr "_החלפה"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "ה_גדרה"
 
@@ -2991,6 +1587,11 @@ msgstr "ללא"
 msgid "Reset the shortcut to its default value"
 msgstr "איפוס צירופי המקשים לערך בררת המחדל"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_חזור לברירת מחדל"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "מקלדת"
@@ -3002,7 +1603,6 @@ msgid ""
 msgstr ""
 "החלפת קיצורי המקשים שלך והגדרת העדפות ההקלדה, פריסות המקלדת ומקורות הקלט"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3044,7 +1644,6 @@ msgstr "אף יישום לא ביקש גישה למיקום"
 msgid "Protect your location information"
 msgstr "הגנה על פרטי המיקום שלך"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "מיקום;gps;GPS;פרטיות;איכון;ג'י פי אס;"
@@ -3078,7 +1677,6 @@ msgstr "אף יישום לא דרש גישה למיקרופון"
 msgid "Protect your conversations"
 msgstr "הגנה על השיחות שלך"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "מיקרופון;הקלטה;יישום;פרטיות;"
@@ -3108,81 +1706,141 @@ msgstr "שמאל"
 msgid "Right"
 msgstr "ימין"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "מקומות לחיפוש"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "עכבר"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "מהירות העכבר"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "גלילה טבעית"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "גלילה למטה"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "גלילה מזיזה את התוכן, לא את התצוגה."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "גלילה מזיזה את התוכן, לא את התצוגה."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_קיצור:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "פעיל"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "משטח מגע"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "מהירות משטח מגע"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "הקשה היא לחיצה"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "הקשה היא לחיצה"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "גלילה בשתי אצבעות"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "נטרול _בעת הקלדה"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "משטח מגע"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "קצה גלילה"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "גלילה למטה"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "דו־צדדי"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "נא לנסות ללחוץ, ללחוץ לחיצה כפולה, לגלול"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "חמש לחיצות, זכית בעז!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "לחיצה כפולה, לחצן ראשי"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "לחיצה בודדת, לחצן ראשי"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "לחיצה כפולה, לחצן אמצעי"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "לחיצה בודדת, לחיצה אמצעית"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "לחיצה כפולה, לחצן משני"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "לחיצה בודדת, לחצן משני"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3193,7 +1851,6 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "שינוי העכבר שלך או רגישות משטח מגע ובחירת לחצן ראשי ימני או שמאלי"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "משטח מגע;סמן;לחיצה;טפיחה;כפולה;לחצן;כדור שליטה;"
@@ -3272,7 +1929,6 @@ msgstr "ריבוי משימות"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "ניהול העדפות ליעילות וריבוי משימות"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3281,20 +1937,11 @@ msgstr ""
 "שינוי;עריכה;שולחן עבודה;התאמה אישית;נקודה חמה;פינה חמה;שולחנות עבודה;מרחבי "
 "עבודה;שולחן עבודה;מרחב עבודה;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "אופס, משהו השתבש. נא ליצור קשר עם ספק התכנה שלך."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "‏NetworkManager צריך לפעול."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "התקנים אחרים"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3306,58 +1953,16 @@ msgstr "הוספת התחברות"
 msgid "Not set up"
 msgstr "לא מוגדר"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "‏%s ‏(SSID: ‏%s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "רשת לא מאובטחת (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "רשת מאובטחת (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "רשת מאובטחת (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "רשת מאובטחת (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "רשת מאובטחת"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "מחובר"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "אפשרויות…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"הפעלת נקודה חמה תגרום ניתוק מ־%s, וכן לא תתאפשר גישה לרשת דרך אינטרנט אלחוטי."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "חובה 8 תווים לכל הפחות"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3409,20 +2014,6 @@ msgstr "יצירת ססמה אקראית באופן אוטומטי"
 msgid "_Turn On"
 msgstr "ה_פעלה"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "רשת אלחוטית"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "לעצור את נקודת הגישה ולנתק את כל המשתמשים ?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_עצירת נקודת הגישה"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "מצב טיסה"
@@ -3467,89 +2058,13 @@ msgstr "רשתות גלויות"
 msgid "NetworkManager needs to be running"
 msgstr "‏NetworkManager צריך להיות פעיל"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "אופס, משהו השתבש. נא ליצור קשר עם ספק התכנה שלך."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_אבטחת 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "אבטחה"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "שמירה"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "קבוע"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "אקראי"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "יציב"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"כתובת ה־MAC שהוזנה כאן תשמש ככתובת החומרה של התקן הרשת המחובר ופועל. תכונה "
-"זו ידועה כשיבוט או זיוף כתובת MAC (באנגלית: cloning או spoofing). לדוגמה: "
-"00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "פרופיל %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "פתוחה מורחבת"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "ארגוני"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "ללא"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "לעולם לא"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3561,183 +2076,6 @@ msgstr[1] "שלשום"
 msgstr[2] "לפני %i ימים"
 msgstr[3] "לפני %i ימים"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "‏%d מ״ב/שנייה (%1.1f גה״צ‏)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "‏%d מ״ב/שנייה"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "‏5 גה״צ / 2.4 גה״צ"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 גה״צ"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 גה״צ"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "ללא"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "חלש"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "טוב"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "טוב"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "מצוין"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "כתובת IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "כתובת IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "כתובת IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "לשכוח התחברות"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "הסרת פרופיל התחברות"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "הסרת VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "פרטים"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "אוטומטית"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "זהות"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "מחיקת כתובת"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "מחיקת נתיב"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "ללא"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "מפתח WEP 40‏/128-סיביות (הקסדצימלי או ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "מילת צופן WEP‏ 128-סיביות"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "‏WEP דינמי (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "‏WPA ו־WPA2 אישי"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "‏WPA ו־WPA2 ארגוני"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "‏WPA3 אישי"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3747,8 +2085,20 @@ msgstr "עצמת הקליטה"
 msgid "Link speed"
 msgstr "מהירות הקישור"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "אבטחה"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "כתובת IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "כתובת IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "כתובת חומרה"
 
@@ -3757,12 +2107,17 @@ msgid "Supported Frequencies"
 msgstr "תדרים נתמכים"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "נתיב בררת המחדל"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3823,7 +2178,7 @@ msgstr "קישור מקומי בלבד"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "ידני"
 
@@ -3867,9 +2222,8 @@ msgstr "שער גישה"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "אוטומטי"
 
@@ -3922,90 +2276,9 @@ msgstr "אוטומטי, DHCP בלבד"
 msgid "Prefix"
 msgstr "קידומת"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "לא ניתן לפתוח את עורך החיבורים"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "פרופיל חדש"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "הגדרה %s לא תקפה: ‏%s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "הגדרה %s לא תקפה"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "יבוא מקובץ…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "הוספת VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_אבטחה"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "לא ניתן לייבא חיבור VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"הקובץ „%s” לא ניתן לקריאה או שאינו מכיל מידע התחברות VPN מוכר\n"
-"\n"
-"שגיאה: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "נא לבחור קובץ לייבוא"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "כבר קיים קובץ בשם „%s“."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "ה_חלפה"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "להחליף את %s בחיבור ה־VPN שנשמר כעת?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "לא ניתן לייצא את חיבור ה־VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"החיבור „%s” לא ניתן לייצוא אל %s.\n"
-"‬\n"
-"‏‫\n"
-"‬\n"
-"‫שגיאה: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "יצוא חיבור VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4019,99 +2292,40 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "רשת"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "שליטה באופן החיבור לאינטרנט"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "רשת;אלחוטי;אלחוטית;וייפיי;IP;רשת מקומית;מתווך;פרוקסי;אינטרנט;רשת רחבה;רוחב "
 "פס;מודם;בלוטות׳;DNS;vpn;Bluetooth;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "רשת אלחוטית"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "שליטה באופן החיבור לרשת האלחוטית"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "רשת;אלחוטי;אלחוטית;וייפיי;IP;רשת מקומית;מתווך;פרוקסי;אינטרנט;רשת רחבה;רוחב "
 "פס;מודם;בלוטות׳;DNS;נקודה חמה;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "מעולם לא"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "היום"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "אתמול"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "שימוש אחרון"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "קווי"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "הוספת התחברות חדשה"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr "פרטי הרשתות הנבחרות, לרבות ססמאות וכל תצורה אחרת שהותאמה אישית יאבדו."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "הת_עלמות"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "רשתות אלחוטיות לא מוכרות"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "הת_עלמות"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "מדיניות המערכת אוסרת שימוש בנקודה חמה"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "התקן הרשת האלחוטית אינו תומך במצב נקודה חמה"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "נעשה שימוש בזיהוי אוטומטי של מתווך רשת כאשר לא מסופקת כתובת תצורה."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "מצב זה אינו מומלץ לרשתות ציבוריות שאינן מהימנות."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4130,6 +2344,10 @@ msgstr "IMEI (מס׳ ברזל)"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "ספק"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "כתובת IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4214,291 +2432,6 @@ msgstr "_הפעלת נקודת גישה…"
 msgid "_Known Wi-Fi Networks"
 msgstr "רשתות אלחוטיות לא _ידועות"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "המצב אינו ידוע"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "לא מנוהל"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "לא זמין"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "בהתחברות"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "נדרש אימות"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "מתבצע ניתוק"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "החיבור נכשל"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "המצב אינו ידוע (חסר)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "התצורה נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "תצורת ה־IP נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "תצורת ה־IP פגה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "נדרשו סודות אך לא סופקו"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "משלים ה־802.1x מנותק"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "תצורת משלים ה־802.1x נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "משלים ה־802.1x נכשל"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "למשלים ה־802.1x לקח זמן רב מדי ליצור אימות"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "הפעלת שירות ה־PPP נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "שירות ה־PPP מנותק"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "ה־PPP נכשל"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "הפעלת לקוח ה־DHCP נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "שגיאת לקוח DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "לקוח ה־DHCP נכשל"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "הפעלת שירות שיתוף החיבורים נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "שירות החיבור השיתופי נכשל"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "הפעלת שירות ה־AutoIP נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "שגיאה בשירות AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "שירות ה־AutoIP נכשל"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "הקו תפוס"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "אין צליל חיוג"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "לא ניתן ליצור קשר עם אף ספק"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "הזמן שהוקצב לבקשת החיוג פג"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "ניסיון החיוג נכשל"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "הפעלת המודם נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "הבחירה ב־APN הזה נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "לא מחפש אחר רשתות"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "הרישום ברשת נדחה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "הזמן שהוקצב לרישום לרשת פג"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "הרישום לרשת המבוקשת נכשל"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "בדיקת ה־PIN נכשלה"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "ייתכן שחסרה קושחה עבור ההתקן"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "החיבור נעלם"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "החיבור הנוכחי התבצע לפי הנחות"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "המודם לא נמצא"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "חיבור הבלוטות' נכשל"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "לא הוכנס כרטיס SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "נדרש ה־Pin של ה־SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "נדרש ה־Puk של ה־SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "ה־SIM שגוי"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "תלות החיבור נכשלה"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "הקושחה חסרה"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "הכבל מנותק"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "שגיאה לא מוגדרת באבטחת 802.1x ‏(wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "לא נבחר קובץ"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "שגיאה לא ידועה באימות קובץ eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "מפתחות פרטיים מסוג DER, PEM, PKCS#12 או PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-#| msgid "_User certificate"
-msgid "DER or PEM certificates"
-msgstr "אישורי DER או PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "חסרים הקבצים EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "קובצי PAC‏ (‎*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4547,14 +2480,6 @@ msgstr "אימות _פנימי"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "אפשור הקצאת PAC _אוטומטית"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "חסר שם משתמש EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "חסרה ססמת EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4580,15 +2505,6 @@ msgstr "_ססמה"
 msgid "Sho_w password"
 msgstr "ה_צגת ססמה"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "אישור EAP-PEAP CA לא תקף: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "אישור EAP-PEAP CA לא תקף: לא סופקו אישורים"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4610,7 +2526,6 @@ msgid "C_A certificate"
 msgstr "אישור C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4625,62 +2540,6 @@ msgstr "לא נ_דרש אישור CA"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_גרסת PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "חסר שם משתמש EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "חסרה ססמת EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "חסר מזהה EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "אישור EAP-TLS CA לא תקף: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "אישור EAP-TLS CA לא תקף: לא סופק אישור"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "מפתח פרטי EAP-TLS לא תקף: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "משתמש אישור EAP-TLS לא תקף: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "מפתחות פרטיים בלתי מוצפנים אינם בטוחים"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"נראה שהמפתח הפרטי הנבחר לא מוגן על ידי ססמה. זה עלול לסכן את אישורי האבטחה "
-"שלך. נא לבחור מפתח פרטי המוגן בססמה.\n"
-"\n"
-"(ניתן להגן על המפתח הפרטי שלך עם openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "נא לבחור את האישור האישי שלך"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "בחירת המפתח הפרטי שלך"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4697,15 +2556,6 @@ msgstr "מפתח _פרטי"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "ססמה למפתח ה_פרטי"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "אישור רשות אישורים מסוג EAP-TTLS לא תקף: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "אישור רשות אישורים מסוג EAP-TTLS לא תקף: לא צוין אישור"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4728,14 +2578,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "מ_תחם"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "שגיאת אימות אבטחת 802.1x לא ידועה"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4763,58 +2614,10 @@ msgstr "EAP מאובטח (PEAP)"
 msgid "Au_thentication"
 msgstr "_אימות"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "בחירת קובץ"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "חסר שם משתמש leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "חסרה ססמת leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "חסרה ססמת רשת אלחוטית."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_סוג"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "חסר מפתח wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "מפתח wep לא תקף: מפתח באורך %zu חייב להכיל ספרות הקסדצימליות בלבד"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "מפתח wep לא תקף: מפתח באורך %zu חייב להכיל אך ורך תווי ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"מפתח wep לא תקף: אורך מפתח %zu שגוי. מפתח חייב להיות או באורך 5/13 (‏ascii) "
-"או 10/26 (הקסדצימלי)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "מפתח wep לא תקף: ססמה לא יכולה להיות ריקה"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "מפתח wep לא תקף: ססמה חייבת להיות קצרה מ־64 תווים"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4839,19 +2642,6 @@ msgstr "ה_צגת מפתח"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "מ_פתח ה־WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"‏wpa-psk לא תקף: %zu אורך מפתח לא תקף. חייב להיות [8,63] בתים או 64 ספרות "
-"הקסדצימליות"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "‏wpa-psk לא תקף: לא נתן לפענח מפתח עם 64 בתים כהקסדצילמי"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4904,27 +2694,9 @@ msgstr "התראות במסך _נעילה"
 msgid "Control which notifications are displayed and what they show"
 msgstr "שליטה בהתראות שתוצגנה ומה הן תצגנה"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "התראות;התרעות;באנר;הודעה;אזור דיווחים;הודעה קופצת;חלונית קופצת;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "אחר"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "הסרת %s"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "אירעה שגיאה בעת הסרת החשבון"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4948,17 +2720,6 @@ msgstr "אין חיבור לאינטרנט - יש להתחבר על מנת לה�
 msgid "Add an account"
 msgstr "הוספת חשבון"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "חשבון %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "הסרת חשבון"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "חשבונות מקוונים"
@@ -4967,10 +2728,6 @@ msgstr "חשבונות מקוונים"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "אפשר להתחבר לחשבון המקוונים שלך ולהחליט כיצד להשתמש בהם"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4978,10 +2735,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;מקוון;שיחה;יומן;דוא״ל;לוח שנה;צ׳אט;צ'אט;"
 "דואר אלקטרוני;דוא\"ל;ownCloud;אונליין;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "זמן בלתי ידוע"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5001,13 +2754,6 @@ msgstr[1] "שעתיים"
 msgstr[2] "‫%i שעות"
 msgstr[3] "‏‫%i שעות"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5023,188 +2769,6 @@ msgstr[0] "דקה"
 msgstr[1] "דקות"
 msgstr[2] "דקות"
 msgstr[3] "דקות"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s עד לטעינה מלאה"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "אזהרה: נותרו %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "נותרו %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "בטעינה מלאה"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "לא בטעינה"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "ריקה"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "בטעינה"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "בפריקה"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "עכבר אלחוטי"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "מקלדת אלחוטית"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "אל־פסק"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "עוזר דיגיטלי אישי"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "טלפון סלולרי"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "נגן מדיה"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "משטח"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "מחשב"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "התקני קלט למשחקים"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "סוללה"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "ראשי"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "נוסף"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "סוללות"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "ב_חוסר פעילות"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "השהיה"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "כיבוי"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "מצב תרדמת"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "לא לעשות דבר"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "בעת הפעלה מהסוללה"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "עם חיבור לחשמל"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "לעולם לא"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "השהיה אוטומטית"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "מצב הביצועים הושבת זמנית עקב טמפרטורה גבוהה בזמן הפעילות."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"זוהו ירכיים: מצב הביצועים אינו זמין באופן זמני. יש להעביר את המכשיר למשטח "
-"יציב כדי לשחזר את המצב הקודם."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "מצב הביצועים מושבת זמנית."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"סוללה חלשה: חיסכון בחשמל הופעל. המצב הקודם ישוחזר כאשר הסוללה תיטען באופן "
-"מספק."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "מצב החיסכון בחשמל הופעל על ידי „%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "מצב הביצועים מופעל על ידי „%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5265,6 +2829,15 @@ msgstr "100 דקות"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "שעתיים"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "סוללה"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "התקנים"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5343,33 +2916,6 @@ msgstr "על _סוללה"
 msgid "Delay"
 msgstr "השהיה"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "ביצועים"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "ביצועים גבוהים וצריכת חשמל מוגברת."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "מאוזן"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "ביצועים רגילים וצריכת חשמל רגילה."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "חיסכון בחשמל"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "ביצועים מופחתים וצריכת חשמל חסכונית."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "צריכת חשמל"
@@ -5378,7 +2924,6 @@ msgstr "צריכת חשמל"
 msgid "View your battery status and change power saving settings"
 msgstr "הצגת מצב הסוללה שלך ושינוי הגדרות חיסכון בחשמל"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5386,27 +2931,6 @@ msgid ""
 msgstr ""
 "צריכת חשמל;שינה;השהיה;תרדמת;סוללה;בהירות;עמעום;החשכה;ריק;צג;בהמתנה;המתנה;"
 "אנרגיה;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "המדפסת „%s” נמחקה"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "הוספת המדפסת החדשה נכשלה."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "לא ניתן לטעון את מנשק המשתמש: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "שחרור להוספת מדפסות ולשינוי הגדרות"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5416,7 +2940,6 @@ msgstr "מדפסות"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "הוספת מדפסות, הצגת עבודות מדפסת ולהחליט כיצד ברצונך להדפיס"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "מדפסת;תור;הדפסה;דף;דיו;טונר;"
@@ -5424,8 +2947,6 @@ msgstr "מדפסת;תור;הדפסה;דף;דיו;טונר;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "הוספת מדפסת"
 
@@ -5464,28 +2985,6 @@ msgstr "יש להזין שם משתמש וססמה להצגת מדפסות זמ�
 msgid "Username"
 msgstr "שם משתמש"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "פרטי %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "לא נמצא מנהל התקן מתאים"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "בחירת קובץ PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"קובצי הגדרות מדפסת של PostScript ‏(‎*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "שמות מדפסות לא יכולות להכיל רווח, טאב, # או לוכסן /"
@@ -5494,9 +2993,7 @@ msgstr "שמות מדפסות לא יכולות להכיל רווח, טאב, # �
 msgid "Location"
 msgstr "מיקום"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "מנהל התקן"
 
@@ -5524,121 +3021,14 @@ msgstr "בחירת מנהל התקן למדפסת"
 msgid "Loading drivers database…"
 msgstr "מסד נתוני מנהלי ההתקנים נטען…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "ביטול"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "בחירה"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "מדפסת JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "מדפסת LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "חד־צדדי"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "שול ארוך (רגיל)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "שול קצר (היפוך אנכי)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "לאורך"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "לרוחב"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "לרוחב הפוך"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "לאורך הפוך"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "המשך"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "השהיה"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "ממתינה"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "מושהית"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "נדרש אימות"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "מעבדת"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "נעצרה"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "בוטלה"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "נפסקה"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "הושלמה"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "העברת המשימה הזאת לראש התור"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5647,19 +3037,6 @@ msgstr[0] "משימה אחת דורשת אימות"
 msgstr[1] "שתי משימות דורשות אימות"
 msgstr[2] "‫%u משימות דורשות אימות"
 msgstr[3] "‏‫%u משימות דורשות אימות"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - הדפסות פעילות"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "יש להזין אישור על מנת להדפיס מ־%s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5687,206 +3064,11 @@ msgstr "_אימות"
 msgid "No Active Printer Jobs"
 msgstr "אין משימת הדפסה פעילה"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "שחרור שרת הדפסה"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "שחרור %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "יש להזין שם משתמש וססמה להצגת מדפסות על %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "חיפוש מדפסות"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "יציאה טורית"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "יציאה מקבילית"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "מיקום: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "כתובת: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "אימות _פנימי"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "דו־צדדי"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "סוג הנייר"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "מקור הנייר"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "מגש הפלט"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "הבחנה"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "סינון קדם של GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "עמודים לצד"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "דו־צדדי"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "כיוון"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "כללי"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "הגדרת עמוד"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "אפשרויות הניתנות להתקנה"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "משימה"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "איכות התמונה"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "צבע"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "גימור"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "מתקדם"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "דף בדיקה"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "דף בדיקה"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "בחירה אוטומטית"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "בררת המחדל של המדפסת"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "הטמעת גופני GhostScript בלבד"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "המרה ל־PostScript רמה 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "המרה ל־PostScript רמה 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "אין סינון קדם"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "יצרן"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "אין משימות פעילות"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5895,115 +3077,6 @@ msgstr[0] "משימה אחת"
 msgstr[1] "שתי משימות"
 msgstr[2] "‫%u משימות"
 msgstr[3] "‫%u משימות"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "ניקוי ראשי ההדפסה"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "הטונר כמעט נגמר"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "נגמר הטונר"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "נותר מעט נייר צילום"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "נגמר נייר הצילום"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "נותרה מעט אספקת צבע"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "נגמרה אספקת הצבע"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "הכיסוי פתוח"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "הדלת פתוחה"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "נותר מעט נייר"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "נגמר הנייר"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "מנותקת"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "נעצרה"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "כלי קיבול הפסולת כמעט מלא"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "כלי קיבול הפסולת מלא"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "הפוטו מוליך האופטי עומד לסיים את חייו"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "הפוטו מוליך האופטי אינו מתפקד עוד"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "מוכנה"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "אין עבודות"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "מעבדת"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6027,6 +3100,10 @@ msgstr "ניקוי ראשי ההדפסה"
 msgid "Remove Printer"
 msgstr "הסרת מדפסת"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "אין משימות פעילות"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6047,16 +3124,21 @@ msgid "Restart"
 msgstr "הפעלה מחדש"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "הוספת מדפסת…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "הוספת מדפסת…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "אין מדפסות בנמצא"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6065,7 +3147,6 @@ msgstr ""
 "‬\n"
 "‫    ‫‫‬‫‬אינם זמינים, עמך הסליחה."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "תבניות"
@@ -6093,16 +3174,6 @@ msgstr "ניתן לחפש מדינות או שפות."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "תצוגה מקדימה"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "אימפריאלית"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "מטרית"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6140,20 +3211,25 @@ msgstr ""
 "הגדרת השפה תשמש לטקסט בממשק המשתמש ובאתרי האינטרנט. התבנית תשמש עבור מספרים, "
 "תאריכים ומטבעות."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "התקנת שפות..."
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "החשבון שלך"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_שפה"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_תבניות"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "מסך כניסה"
 
@@ -6165,99 +3241,9 @@ msgstr "אזור ושפה"
 msgid "Select your display language and formats"
 msgstr "בחירת שפת התצוגה והתצורות המקומיות"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "שפה;פריסה;מקלדת;פלט;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "הצגת שאלה בנוגע להמשך"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "לא לעשות דבר"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "פתיחת תיקייה"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "מדיה אחרת"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "נא לבחור יישום לתקליטורי שמע"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "נא לבחור יישום לתקליטורי וידאו DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "נא לבחור יישום להפעלה בעת חיבור נגן מוזיקה"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "נא לבחור יישום להפעלה בעת חיבור המצלמה"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "נא לבחור יישום לתקליטורי תכנה"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "תקליטור DVD שמע"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "תקליטור Blu-ray ריק"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "תקליטור CD ריק"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "תקליטור DVD ריק"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "תקליטור HD DVD ריק"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "תקליטור וידאו Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "מציג ספרים אלקטרוניים"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "תקליטור וידאו HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "תקליטור תמונות"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "סופר תקליטור וידאו (SVCD)"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "תקליטור וידאו (VCD)"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "תכנה של Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6307,7 +3293,6 @@ msgstr "מדיה נתיקה"
 msgid "Configure Removable Media settings"
 msgstr "הגדרות מדיה נתיקה"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6315,114 +3300,6 @@ msgid ""
 msgstr ""
 "התקן;מערכת;מידע;זיכרון;זכרון;מעבד;גרסה;בררת מחדל;יישום;העדפה;מועדף;גיבוי;"
 "דיסק;תקליטור;DVD;USB;שמע;אודיו;חוזי;וידאו;נשלף;נתיק;מדיה;הפעלה אוטומטית;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "המסך יכבה"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "חצי דקה"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "דקה"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "שתי דקות"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 דקות"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 דקות"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "חצי שעה"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "שעה"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "דקה"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 דקות"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 דקות"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 דקות"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 דקות"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 דקות"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 דקות"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 דקות"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "רבע שעה"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "לעולם לא"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6459,40 +3336,40 @@ msgstr "פרק הזמן שלאחר החשכת המסך כאשר המסך ננע�
 msgid "Show _Notifications on Lock Screen"
 msgstr "הצגת הת_ראות במסך נעילה"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "מסך _נעילה"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "מניעת התקני _USB חדשים"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr "מניעת פעילות של התקני USB חדשים בזמן שהמסך נעול."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "פרטיות מסך"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "הגבלת זווית הצפייה"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "מסך"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "הגדרות מסך"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "מסך;נעילה;פרטי;פרטיות;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "בחירת מיקום"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_אישור"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6521,10 +3398,6 @@ msgstr "אחרים"
 msgid "Add Location"
 msgstr "הוספת מיקום"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "לא נמצאו יישומים"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "חיפוש יישום"
@@ -6550,93 +3423,13 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "שליטה באילו יישומים יציגו תוצאות חיפוש בסקירת פעילויות"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "חיפוש;מציאה;חפש;מצא;למצוא;לחפש;אינדקס;מפתח;הסתרה;החבאה;פרטיות;תוצאות;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "לא נבחרו רשתות לשיתוף"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "רשתות"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "פעיל"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "כבוי"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "מופעל"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "פעיל"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "נא לבחור בתיקייה"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "הוספה"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "הפעלת שיתוף מדיה"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"שיתוף קבצים מאפשר לך לשתף את התיקייה ציבורי שלך עם משתמשים נוספים ברשת "
-"הנוכחית שלך באמצעות: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"כאשר התחברות מרוחקת מאופשרת, משתמשים מרוחקים יכולים להתחבר באמצעות פקודה "
-"במעטפת מאובטחת: \n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "הפעלת שיתוף מדיה פרטי"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "שם ההתקן הועתק"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "כתובת ההתקן הועתקה"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "שם המשתמש הועתק"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "ססמה הועתקה"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6761,7 +3554,6 @@ msgstr "תיקיות"
 msgid "Control what you want to share with others"
 msgstr "שליטה במה שמעניין אותך לשתף עם אחרים"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6778,23 +3570,17 @@ msgstr "הפעלה או השבתה של התחברות מרוחקת"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "נדרש אימות כדי להפעיל או להשבית התחברות מרחוק"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "התאמה אישית"
-
 #: panels/sound/cc-alert-chooser.ui:12
-#| msgid "Flickr"
 msgid "Click"
 msgstr "נקישה"
 
 #: panels/sound/cc-alert-chooser.ui:20
-#| msgid "Sharing"
 msgid "String"
 msgstr "מיתר"
 
 #: panels/sound/cc-alert-chooser.ui:28
 msgid "Swing"
-msgstr ""
+msgstr "הנפה"
 
 #: panels/sound/cc-alert-chooser.ui:36
 msgid "Hum"
@@ -6815,11 +3601,6 @@ msgstr "אחורי"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "קדמי"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "‏%s בבדיקה"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6873,11 +3654,6 @@ msgstr "עצמה"
 msgid "Alert Sound"
 msgstr "צליל התראה"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "השתקה"
@@ -6890,83 +3666,12 @@ msgstr "צליל"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "שינוי עצמת השמע, קלט, פלט וצלילי התראה"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "כרטיס;מיקרופון;עצמת שמע;ווליום;איזון;בלוטות׳;Bluetooth;אזניות;אוזניות;שמע;"
 "קלט;פלט;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "מנותק"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "בהתחברות"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "מחובר"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "שגיאת אימות"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "אימות"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "תפקוד ירוד"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "התקנים מחוברים ומאומתים"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "לא ידוע"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "אומת ב־:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "מחובר החל מ־:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "נרשם ב־:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "אימות ההתקן נכשל: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "שכיחת ההתקן נכשלה: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7002,53 +3707,6 @@ msgstr "אימות והתחברות"
 msgid "Forget Device"
 msgstr "שכיחת ההתקן"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "שגיאה"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "אומת"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr "מערכת הבת של Thunderbolt ‏(boltd) אינה מותקנת או לא מוגדרת כראוי."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "לאפשר גישה ישירה להתקנים דוגמת תחנות עגינה ומעבדים גרפיים חיצוניים."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "רק התקני USB ו־DisplayPort ניתנים לצירוף."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"‏Thunderbolt לא ניתנת לזיהוי.\n"
-"או שהמערכת חסרת תמיכה ב־Thunderbolt, או שהיא הושבתה ב־BIOS או שהיא הוגדרה "
-"כשכבת אבטחה לא נתמכת ב־BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "תמיכה ב־Thunderbolt הושבתה ב־BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "שכבת האבטחה של Thunderbolt לא ניתנת לקביעה."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "שגיאה בשינוי המצב הישיר: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "אין תמיכה ב־Thunderbolt"
@@ -7060,6 +3718,10 @@ msgstr "לא ניתן להתחבר אל מערכת הבת של Thunderbolt."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "גישה ישירה"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "לאפשר גישה ישירה להתקנים דוגמת תחנות עגינה ומעבדים גרפיים חיצוניים."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7077,7 +3739,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "ניהול התקני Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;פרטיות;"
@@ -7277,42 +3938,6 @@ msgstr "הפעלה באמצעות המ_קלדת"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "הפעלת וכיבוי של תכונות נגישות באמצעות המקלדת"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "בררת מחדל"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "בינוני"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "גדול"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "גדול יותר"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "ענק"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "פיקסל אחד"
-msgstr[1] "שני פיקסלים"
-msgstr[2] "‫%d פיקסלים"
-msgstr[3] "‏‫%d פיקסלים"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_תמיד להציג תפריט נגישות"
@@ -7426,31 +4051,6 @@ msgstr "הבהוב המסך _כולו"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "הבהוב המסך _כולו"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "קצר"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ מסך"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ מסך"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ מסך"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "ארוך"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7607,7 +4207,6 @@ msgstr "אפקטים של צבע"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "להקל ראייה, שמיעה, הקלדה, הצבעה ולחיצה"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7618,114 +4217,6 @@ msgstr ""
 "מקלדת;עכבר;a11y;נגישות;ניגודיות;ניגוד;תקריב;זום;מקריא מסך;טקסט;גופן;גודל;"
 "AccessX;מקשים דביקים;מקשים אטיים;מקשים חוזרים;מקשי עכבר;לחיצה;כפול;כפולה;"
 "המתנה;מהירות;סיוע;חזרה;הבהוב;שמיעה;שמע;הקלדה;-;הנפשה;הנפשות;אנימציה;אנימציות;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "שעה"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "יום"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "יומיים"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 ימים"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 ימים"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 ימים"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 ימים"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "שבוע"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "שבועיים"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "חודש"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "לרוקן את כל הפריטים באשפה?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "כל הפריטים באשפה ימחקו לצמיתות."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_פינוי האשפה"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "למחוק את כל הקבצים הזמניים?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "כל הקבצים הזמניים ימחקו לצמיתות."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "מחיקת קבצים _זמניים"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "יום"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "שבוע"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "חודש"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "לעד"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7792,62 +4283,10 @@ msgstr "היסטוריית קבצים ואשפה"
 msgid "Don't leave traces"
 msgstr "לא להשאיר עקבות"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr "שימוש;ניצול;לאחרונה;היסטוריה;קבצים;זמני;פרטי;פרטיות;אשפה;ניקוי;שמירה;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "צריך להתאים את כתובת האינטרנט של ספק החשבון שלך."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "הוספת החשבון נכשלה"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "הססמאות אינן תואמות."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "הרשמת החשבון נכשלה"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "אין שיטה נתמכת לאימות עם מתחם זה (domain)"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "ההצטרפות למתחם נכשלה"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"שם התחברות זה לא עובד.\n"
-"נא לנסות שוב."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"ססמה זו לא עובדת.\n"
-"נא לנסות שוב."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "ההתחברות למתחם נכשלה"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "לא ניתן למצוא את התחום. אולי שגית באיות?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7898,10 +4337,6 @@ msgid ""
 msgstr ""
 "התחברות ארגונית מאפשרת ניהול חשבון משתמש מרוכז לשימוש בהתקן זה. נתן גם "
 "להשתמש בחשבון זה לגישה למשאבי חברות באינטרנט."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "עיון אחר תמונות נוספות"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7970,220 +4405,6 @@ msgstr "_מחיקת טביעות אצבע"
 msgid "Fingerprint Enroll"
 msgstr "רישום טביעת אצבע"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "יש לדרוש את ההתקן כדי לבצע את הפעולה הזאת"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "ההתקן כבר נדרש על ידי תהליך אחר"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "אין לך הרשאות לביצוע הפעולה"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "אין הדפסות רשומות"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "ההתקשורת עם ההתקן בעת הרישום נכשלה"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "ההתקשרות עם קורא טביעות האצבע נכשלה"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "ההתקשרות עם שרת קורא טביעות האצבע נכשלה"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "הצגת טביעות האצבעות נכשלה: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "מחיקת טביעות אצבע שמורות נכשלה: ‏%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "אגודל שמאלית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "אמה שמאלית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "אצבע _שמאלית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "קמיצה שמאלית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "זרת שמאלית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "אגודל ימנית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "אמה ימנית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "אצבע _ימנית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "קמיצה ימנית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "זרת ימנית"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "אצבע לא ידועה"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "הושלם"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "התקן טביעת האצבע התנתק"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "אחסון התקן טביעת האצבע מלא"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "רישום טביעת אצבע חדשה נכשל"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "התחלת הרישום נכשלה: ‏%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "רישום טביעת אצבע חדשה נכשל"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "עצירת הרישום נכשלה: ‏%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr "יש לחזור על הרמת והנחת האצבע על הקורא כדי לרשום את טביעת האצבע שלך"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_רישום מחדש של אצבע זו…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "סריקת טביעת אצבע חדשה"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "שחרור התקן טביעת אצבע %s נכשל: ‏%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "בעיה בקריאת התקן"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "טעינת התקן טביעת אצבע %s נכשלה: ‏%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "קבלת התקני טביעת אצבע נכשלה: ‏%s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "השבוע"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "השבוע האחרון"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e ב%b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e ב%b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "‏%s – %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "הפעלה הסתיימה"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "הפעלה התחילה"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "‏‏%s – פעילות בחשבון"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "הקודם"
@@ -8191,18 +4412,6 @@ msgstr "הקודם"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "הבא"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "נא לבחור בססמה אחרת."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "נא להזין את הססמה הנוכחית שלך שוב."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "לא ניתן להחליף את הססמה"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8224,6 +4433,10 @@ msgstr "ססמה חדשה"
 msgid "Confirm Password"
 msgstr "אימות ססמה"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "הססמאות אינן תואמות."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "לאפשר למשתמש לשנות את הססמה בהתחברות הבאה"
@@ -8231,132 +4444,6 @@ msgstr "לאפשר למשתמש לשנות את הססמה בהתחברות הב
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "הגדרת ססמה כעת"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "לא ניתן להצטרף אוטומטית לסוג כזה של תחום"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "לא נמצאו תחום או מתחם כאלה"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "לא ניתן להיכנס בשם %s לתחום %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "הססמה שגויה, נא לנסות שוב"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "לא ניתן להתחבר אל התחום %s:‏ %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "מחיקת משתמש נכשלה"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "ביטול המשתמש המנוהל מרחוק נכשל"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "מחיקת החשבון שלך על ידיך אינה אפשרית."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s עדיין במערכת"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "מחיקת משתמש כשהוא מחובר עלולה להשאיר את המערכת במצב בלתי יציב."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "לשמור על הקבצים של %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"ניתן לשמור על תיקיית הבית, מאגר הדואר והקבצים הזמניים בהישג ידך לאחר מחיקת "
-"משתמש."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_מחיקת הקבצים"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_שמירת הקבצים"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "לשלול את החשבון של %s שמנוהל מרחוק?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "מ_חיקה"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "חשבון מושבת"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "להגדרה בהתחברות הבאה"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "אין"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "נכנסת"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "לא ניתן ליצור קשר עם שירות החשבונות"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "נא לוודא ששירות החשבונות (AccountService) מותקן ומופעל."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "יש הכרח לשחרר לוח זה על מנת לשנות הגדרה זו"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "מחיקת חשבון המשתמש הנבחר"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"כדי למחוק את המשתמש הנבחר\n"
-"ראשית יש ללחוץ על הסמל *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "שחרור להוספת משתמשים ולשינוי הגדרות"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8385,7 +4472,6 @@ msgid "Full name"
 msgstr "שם מלא"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "עריכה"
 
@@ -8445,7 +4531,6 @@ msgstr "שחרור על מנת להוסיף משתמש."
 msgid "Add or remove users and change your password"
 msgstr "הוספה או הסרה של משתמשים והחלפת הססמה שלך"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8491,175 +4576,6 @@ msgstr "ניהול חשבונות משתמשים"
 msgid "Authentication is required to change user data"
 msgstr "נדרש אימות כדי לשנות את נתוני המשתמש"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "הססמה החדשה מוכרחה להיות שונה מהקודמת."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "כדאי לשנות כמה תווים או מספרים."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "כדאי לנסות לערוך שינויים נרחבים יותר בססמה."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "ססמה ללא שם המשתמש שלך תהיה חזקה יותר."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "כדאי לנסות להימנע משימוש בשם שלך בססמה."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "כדאי לנסות להימנע מכמה מהמילים הכלולות בססמה."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "כדאי לנסות להימנע ממילים נפוצות."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "כדאי לנסות להימנע מסידור מחדש של מילים קיימות."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "כדאי לנסות להשתמש ביותר מספרים."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "כדאי לנסות להשתמש ביותר אותיות רישיות."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "כדאי לנסות השתמש ביותר אותיות קטנות."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "כדאי לנסות להשתמש ביותר תווים מיוחדים, כמו סימני פיסוק."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "כדאי לנסות להשתמש בתערובת של אותיות, מספרים וסימני פיסוק."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "כדאי לנסות להימנע מחזרה על אותו התו."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"כדאי לנסות להימנע מחזרה על אותו סוג של תו: צריך לערבב אותיות, מספרים וסימני "
-"פיסוק."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "כדאי להימנע מרצפים כמו 1234, abcd או אבגד."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"הססמה צריכה להיות ארוכה יותר. יש לנסות להוסיף תווים, מספרים וסימני פיסוק."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "יש לערבב אותיות רישיות וקטנות ולהשתמש במספר או שניים."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "הוספת תווים נוספים, מספרים וסימני פיסוק תחזק את הססמה עוד יותר."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "האימות נכשל"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "הססמה החדשה קצרה מדי"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "הססמה החדשה פשוטה מדי"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "הססמאות הישנה והחדשה דומות מדי"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "הססמה החדשה כבר הייתה בשימוש לאחרונה."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "על הססמה החדשה להכיל תווים מספריים או מיוחדים"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "הססמאות הישנה והחדשה זהות"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "ססמתך הוחלפה מאז שביצעת אימות לראשונה!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "הססמה החדשה לא מכילה מספיק תווים השונים זה מזה"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "שגיאה בלתי ידועה"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"שם המשתמש יכול להכיל רק אותיות קטנות מהאלפבית האנגלי, ספרות ואחד  מהתווים: . "
-"- _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "למרבה הצער, שם משתמש זה אינו זמין. יש לנסות שם אחר."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "שם המשתמש ארוך מדי."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8691,53 +4607,10 @@ msgstr "נא ללחוץ על סמני היעד כאשר הם מופיעים על
 msgid "Mis-click detected, restarting…"
 msgstr "זוהתה לחיצה שגויה, הפעולה תתחיל מההתחלה…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "כפתור %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "יישום מוגדר"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "שליחת צירוף מקשים"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "החלפת צג"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "הצגת עזרה על גבי המסך"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "מחשב לוח מעוגן על לוח מחשב נייד"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "מחשב לוח מעוגן על צג חיצוני"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "מחשב לוח חיצוני"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
-#| msgid "External tablet device"
 msgid "External pad device"
 msgstr "התקן משטח חיצוני"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "כל הצגים"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8833,22 +4706,6 @@ msgstr "לחיצה על לחצן העכבר הימני"
 msgid "Forward"
 msgstr "קדימה"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "עט איירבראש עם לחץ, הטייה ומחוון גלילה מובנה"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "עט איירבראש עם לחץ, הטייה וסיבוב"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "עט רגיל עם לחץ והטייה"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "עט רגיל עם לחץ"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "לוח מגע"
@@ -8857,54 +4714,97 @@ msgstr "לוח מגע"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "הגדרת מיפויי כפתור והתאמת רגישות עט עבור לוח ציור"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "לוח;Wacom;עט מגע;מחק;מוחק;עכבר;משטח מגע;לוח מגע; מגע;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "קיצור דרך חדש…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "פריסה"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "חלון הורה"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "לחיצה _שנייה מדומה"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "_חלונות..."
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "הטונר כמעט נגמר"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "משני"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "_חלונות..."
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "ניהול העדפות ליעילות וריבוי משימות"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "נקודות גישה"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "הוספה"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_שמירה"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "הגדרות גלישה"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "הפעולה בוטלה"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "‫<b>שגיאה:</b> הגישה לשינוי ההגדרות נדחתה"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "‫<b>שגיאה:</b> שגיאה בציוד התקשורת הסלולרית"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "לא רשום"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "רשום"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "ניוד"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "בחיפוש"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "נדחה"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8934,212 +4834,13 @@ msgstr "המספר העצמי"
 msgid "Device Details"
 msgstr "פרטי ההתקן"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "יצרן"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "גרסת קושחה"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "‫2G בלבד"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "‫3G בלבד"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "‫4G בלבד"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "‫5G בלבד"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "‫2G,‏ 3G,‏ 4G, ‏5G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "‫2G,‏ 3G,‏ 4G (עדיפה), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "‫2G,‏ 3G (עדיפה), 4G, ‏5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "‫2G (עדיפה), 3G,‏ 4G, ‏5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "‫2G,‏ 3G,‏ 4G, ‏5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "‫2G,‏ 3G,‏ 4G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "‫2G,‏ 3G (עדיפה), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "‫2G (עדיפה), 3G,‏ 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "‫2G,‏ 3G,‏ 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "‫3G,‏ ‏4G, ‏‎5G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "‫3G,‏ 4G (עדיפה), ‎5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "‫3G (עדיפה), ‏4G, ‏‎5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "‫3G,‏ 4G, ‏5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "‫2G,‏ 4G,‏ 5G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "‫2G,‏ 4G (עדיפה), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "‫2G (עדיפה), 4G,‏ 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "‫2G,‏ 4G,‏ 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "‫2G,‏ 3G,‏ 5G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "‫2G,‏ 3G (עדיפה), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "‫2G (עדיפה), 3G,‏ 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "‫2G,‏ 3G,‏ 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "‫3G,‏ 4G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "‫3G (עדיפה), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "‫3G,‏ 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "‫2G,‏ 4G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "‫2G (עדיפה), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "‫2G,‏ 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "‫2G,‏ 3G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "‫2G (עדיפה), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "‫2G,‏ 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "‫2G,‏ 5G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "‫2G (עדיפה), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "‫2G,‏ 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "‫3G,‏ 5G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "‫3G (עדיפה), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "‫3G,‏ 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "‫4G,‏ 5G (עדיפה)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "‫4G (עדיפה), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "‏‎4G, ‏‎5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "לא ידוע"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "שחרור כרטיס SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "שחרור"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "נא לספק קוד PIN עבור SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "נא להקליד PIN לשחרור כרטיס ה־SIM שלך"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "נא לספק קוד PUK ל־SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "נא להקליד PUK לשחרור כרטיס ה־SIM שלך"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9158,26 +4859,6 @@ msgstr[0] "נותר לך ניסיון אחד"
 msgstr[1] "נותרו לך שני ניסיונות"
 msgstr[2] "נותרו לך %u ניסיונות"
 msgstr[3] "נותרו לך %u ניסיונות"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "הססמה שהוקלדה שגויה."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "קוד ה־PUK אמור להיות באורך 8 ספרות"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "נא להקליד PIN חדש"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "קוד ה־PIN אמור להיות מספר באורך 4-8 ספרות"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "מתבצע שחרור…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9235,94 +4916,6 @@ msgstr "נעילת SIM ב־PIN"
 msgid "M_odem Details"
 msgstr "_פרטי מודם"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "שגיאת טלפון"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "אין חיבור לטלפון"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "הפעולה אסורה"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "הפעולה אינה נתמכת"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "לא הוכנס SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "נדרש PIN ל־SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "נדרש PUK ל־SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "כשל ב־SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "ה־SIM עסוק"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "ססמה שגויה"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "נדרש PIN2 ל־SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "נדרש PUK2 ל־SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "לא נמצא"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "אין שירות רשת"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "תום זמן המתנה לרשת"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "שירותי GPRS אסורים"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "ניוד אסור באזור זה"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "שגיאת GPRS לא ידועה"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "אין שגיאה"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "הפעולה בוטלה"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "הגישה נדחתה"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "שגיאה לא ידועה"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "מצב רשת"
@@ -9338,11 +4931,6 @@ msgstr "בחירת רשת"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "רענון ספקי רשת"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9400,7 +4988,6 @@ msgstr "רשת סלולרית"
 msgid "Configure Telephony and mobile data connections"
 msgstr "הגדרת טלפוניה וחיבורי נתונים סלולריים"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -9419,41 +5006,13 @@ msgstr "הגדרות הוא הממשק העיקרי להגדיר את המערכ
 msgid "The GNOME Project"
 msgstr "מיזם GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "הצגת מספר הגרסה"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "הפעלת מצב מפורט"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "חיפוש אחר מחרוזת"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "הצגת שמות הלוחות האפשריים ואז לצאת"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "לוח להצגה"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "קטגוריות הגדרות"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "פרטיות"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "לוחות זמינים:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9510,7 +5069,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "ביטול החיפוש"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "העדפות;הגדרות;"
@@ -9547,8 +5105,6 @@ msgid ""
 "application window."
 msgstr "סדרה של ערכים שמכילה את הרוחב, הגובה ומצב ההגדלה של חלון היישום."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9558,8 +5114,6 @@ msgstr[1] "שני ערוצי פלט"
 msgstr[2] "‫%u ערוצי פלט"
 msgstr[3] "‏‫%u ערוצי פלט"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9569,9 +5123,3098 @@ msgstr[1] "שני ערוצי קלט"
 msgstr[2] "‏‫%u ערוצי קלט"
 msgstr[3] "‏‫%u ערוצי קלט"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "צלילי מערכת"
+#~ msgid "System Bus"
+#~ msgstr "אפיק מערכת"
+
+#~ msgid "Full access"
+#~ msgstr "גישה מלאה"
+
+#~ msgid "Session Bus"
+#~ msgstr "אפיק הפעלה"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "גישה מלאה אל ‎/dev"
+
+#~ msgid "Has network access"
+#~ msgstr "יש גישה לרשת"
+
+#~ msgid "Home"
+#~ msgstr "בית"
+
+#~ msgid "Read-only"
+#~ msgstr "קריאה בלבד"
+
+#~ msgid "File System"
+#~ msgstr "מערכת הפעלה"
+
+#~ msgid "Can change settings"
+#~ msgstr "ניתן לשנות הגדרות"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "ליישום %s יש את ההרשאות הבאות בצורה מובנית. לא ניתן לשנות זאת. אם הדבר "
+#~ "מדאיג אותך, כדאי לשקול את הסרת היישום."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "סוג קבצים וקישורים אחד שנפתח על ידי היישום הזה"
+#~ msgstr[1] "‫%u סוגי קבצים וקישורים שנפתחים על ידי היישום הזה"
+#~ msgstr[2] "‫%u סוגי קבצים וקישורים שנפתחים על ידי היישום הזה"
+#~ msgstr[3] "‫%u סוגי קבצים וקישורים שנפתחים על ידי היישום הזה"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "‫<b>%s</b> משמש לפתיחת סוגי הקבצים והקישורים הבאים."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "‫%s משטח הכונן מנוצלים."
+
+#~ msgid "Select a picture"
+#~ msgstr "בחירת תמונה"
+
+#~ msgid "_Open"
+#~ msgstr "_פתיחה"
+
+#~ msgid "multiple sizes"
+#~ msgstr "מגוון גדלים"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d ×‏ %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "אין רקע לשולחן העבודה"
+
+#~ msgid "Current background"
+#~ msgstr "הרקע הנוכחי"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "יש להציב את התקן הכיול שלך על הריבוע וללחוץ על „התחלה“"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "יש להעביר את התקן הכיול שלך לעמדת הכיול וללחוץ „המשך”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "יש להעביר את התקן הכיול שלך למשטח הכיול וללחוץ „המשך”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "סגירת המסך במחשב נייד"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "אירעה שגיאה פנימית שלא ניתן להתאושש ממנה."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "הכלים הנדרשים לכיול אינם מותקנים."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "לא ניתן לייצר את הפרופיל."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "יעד נקודת הלובן אינו בר השגה."
+
+#~ msgid "Complete!"
+#~ msgstr "הושלם!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "הכיול נכשל!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "ניתן להסיר את התקן הכיול."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "נא לא להפריע להתקן הכיול במהלך ההתקדמות"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "מסך של מחשב נייד"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "מצלמה מובנית"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "צג %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "סורק %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "מצלמת %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "מדפסת %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "מצלמת רשת %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "הפעלת ניהול צבע עבור %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "הצגת פרופילי צבע עבור %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "ללא כיול"
+
+#~ msgid "Default: "
+#~ msgstr "בררת מחדל: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "מרחב צבעים: "
+
+#~ msgid "Test profile: "
+#~ msgstr "פרופיל בדיקה: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "בחירת פרופיל ICC"
+
+#~ msgid "_Import"
+#~ msgstr "יי_בוא"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "פרופילי ICC נתמכים"
+
+#~ msgid "All files"
+#~ msgstr "כל הקבצים"
+
+#~ msgid "Save Profile"
+#~ msgstr "שמירת הפרופיל"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "יצירת פרופיל צבע עבור ההתקן הנבחר"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr "התקן המדידה לא זוהה. נא לבדוק כי הוא פועל ומחובר כראוי."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "התקן המדידה אינו תומך ביצירת פרופילים למדפסות."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "סוג ההתקן אינו נתמך נכון לעכשיו."
+
+#~ msgid "Standard Space"
+#~ msgstr "מרחב רגיל"
+
+#~ msgid "Test Profile"
+#~ msgstr "בדיקת הפרופיל"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "אוטומטית"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "איכות נמוכה"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "איכות בינונית"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "איכות גבוהה"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "בררת מחדל RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "בררת מחדל CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "בררת מחדל גווני אפור"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "נתוני כיול שסופקו על ידי היצרן"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "תיקון תצוגת מסך מלא אינו אפשרי עם פרופיל זה"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "יתכן שפרופיל זה אינו מדויק עוד"
+
+#~ msgid "Other…"
+#~ msgstr "אחר…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "יש לשחרר לשינוי הגדרות"
+
+#~ msgid "Today"
+#~ msgstr "היום"
+
+#~ msgid "Yesterday"
+#~ msgstr "אתמול"
+
+#~ msgid "%b %e"
+#~ msgstr "%e ב%b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e ב%b, 2013"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "שעה"
+#~ msgstr[1] "שעתיים"
+#~ msgstr[2] "‫%d שעות"
+#~ msgstr[3] "‫%d שעות"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "דקה"
+#~ msgstr[1] "שתי דקות"
+#~ msgstr[2] "‏‫%d דקות"
+#~ msgstr[3] "‏‫%d דקות"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "שנייה"
+#~ msgstr[1] "שתי שניות"
+#~ msgstr[2] "‫%d שניות"
+#~ msgstr[3] "‏‫%d שניות"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "‏%s, ‏%s ו־%s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "‏%s ו־%s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "‏%s ו־%s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "נקודה חמה"
+
+#~ msgid "24-hour"
+#~ msgstr "24 שעות"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e ב%B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e ב%B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "‎%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "שליחת דיווחים על בעיות טכניות תעזור לנו לשפר את %s. הדיווחים נשלחים "
+#~ "בעילום שם וללא מידע אישי. %s"
+
+#~ msgid "On"
+#~ msgstr "פעיל"
+
+#~ msgid "Off"
+#~ msgstr "כבוי"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "להחיל שינויים?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "אי אפשר להחיל את השינויים"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "אולי זה קשור למגבלות חומרה."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "לרוחב"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "ימין לאורך"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "שמאל לאורך"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "לרוחב (הפוך)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "‏%.2lf הרץ"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "הפעלה מאובטחת פעילה"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן. היא פעילה "
+#~ "כעת ופועלת בצורה תקינה."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "יש בעיות בהפעלה מאובטחת"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן. היא פעילה "
+#~ "כעת, אך לא תעבוד עקב מפתח לא תקף."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "לעתים קרובות ניתן לפתור בעיות בהפעלה מאובטחת מהגדרות קָשְחת UEFI ‏(BIOS) של "
+#~ "המחשב. יצרן החָמְרָה שלך עשוי לספק מידע כיצד לעשות זאת."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr "לעזרה, יש ליצור קשר עם יצרן החָמְרָה או עם תמיכת ה־IT של הספק."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "הפעלה מאובטחת אינה פעילה"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן. היא אינה "
+#~ "פעילת כעת."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "לעתים קרובות ניתן להפעיל את ההפעלה המאובטחת מהגדרות קָשְחת UEFI ‏(BIOS) של "
+#~ "המחשב. למידע נוסף, יש ליצור קשר עם יצרן החָמְרָה או עם תמיכת ה־IT של הספק."
+
+#~ msgid "Passed"
+#~ msgstr "עבר"
+
+#~ msgid "Failed"
+#~ msgstr "נכשל"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "ההתקן תואם לרמת HSI (מזהה אבטחת מארח)‏ %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "רמת אבטחה 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "להתקן זה אין הגנה כנגד בעיות אבטחת חָמְרָה. יתכן וזה נובע מהגדרות חומרה או "
+#~ "קָשְחה. מומלץ ליצור קשר עם ספק תמיכת ה־IT שלך."
+
+#~ msgid "Security Level 1"
+#~ msgstr "רמת אבטחה 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "להתקן זה הגנה מזערית כנגד בעיות אבטחת חָמְרָה. זוהי הרמה הנמוכה ביותר של "
+#~ "הגנת התקן המספקת הגנה למול איומי אבטחה בסיסיים בלבד."
+
+#~ msgid "Security Level 2"
+#~ msgstr "רמת אבטחה 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "להתקן זה הגנה בסיסית כנגד בעיות אבטחת חָמְרָה. זה מספק הגנה מפני איומי אבטחה "
+#~ "נפוצים."
+
+#~ msgid "Security Level 3"
+#~ msgstr "רמת אבטחה 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "להתקן זה אבטחה מורחבת כנגד בעיות אבטחת חָמְרָה. זוהי הרמה הגבוה ביותר של "
+#~ "הגנת התקן המספקת הגנה מפני איומי אבטחה מתקדמים."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "רמות אבטחה אינן זמינות עבור התקן זה."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr "יש ליצור קשר עם יצרן החָמְרָה לעזרה בנושא עדכוני אבטחה."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "יתכן שניתן לפתור בעיה זו בהגדרות קָשְחת UEFI של ההתקן, או על ידי תמיכה "
+#~ "טכנית."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr "יתכן שניתן לפתור בעיה זו בהגדרות קָשְחת UEFI של ההתקן."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "ייתכן שניתן לפתור בעיה זו על ידי תמיכה טכנית."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "הגנה כנגד תכנות זדוניות בזמן הפעלת ההתקן."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "יש בעיות בהפעלה מאובטחת"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "קצת הגנה בזמן שההתקן מופעל."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "הפעלה מאובטחת כבויה"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "אין הגנה בזמן שההתקן מופעל."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "יתכן ובעיה זו נגרמה בגלל שינוי בהגדרות קָשְחת UEFI, שינוי תצורת מערכת "
+#~ "ההפעלה או בגלל תכנה זדונית במערכת זו."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "יתכן ובעיה זו נגרמה בגלל שינוי בהגדרות קָשְחת UEFI או בגלל תכנה זדונית "
+#~ "במערכת זו."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "יתכן ובעיה זו נגרמה בגלל שינוי תצורת מערכת ההפעלה או בגלל תכנה זדונית "
+#~ "במערכת זו."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "חשוף לאיומי אבטחה רציניים."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "הגנה מוגבלת כנגד איומי אבטחה פשוטים."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "הגנה כנגד איומי אבטחה נפוצים."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "הגנה כנגד מנעד רחב של אימוי אבטחה."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "הגנה מקיפה"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "הגנת כתיבה לקָשְחה"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "נעילת הגנת כתיבת קושחה"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "תחום קָשְחת BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "תיאור קָשְחת BIOS"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "הגנת DMA קדם־אתחול"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "טעינה מאומתת של Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "ACM מוגן של Intel BootGuard"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "מדיניות שגיאה של Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "מיזוג של Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET מאופשר"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET פעיל"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "‏RAM מוצפן"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "הגנת IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "נעילת ליבת לינוקס"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "אימות ליבת לינוקס"
+
+#~ msgid "Linux Swap"
+#~ msgstr "מחיצת החלפה לינוקס"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "השהיה ל־RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "השהיה להמתנה"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "מפתח פלטפורמת UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "אתחול UEFI מאובטח"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "הגדרות פלטפורמת TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "בנייה מחדש של TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "מצב ייצור של מנוע הניהול של אינטל"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "מעקף של מנגנון הניהול של אינטל"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "גרסת מנגנון הניהול של אינטל"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "עדכוני קָשְחה"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "תעודת קָשְחה"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "עדכון אימות קָשְחה"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "ניפוי שגיאות בפלטפורמה"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "בדיקות אבטחת מעבד"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "הגנת שחזור של AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "הגנת הפעלה מחדש של קושחת AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "הגנת כתיב לקושחת AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "פלטפורמה ממוזגת"
+
+#~ msgid "Valid"
+#~ msgstr "תקף"
+
+#~ msgid "Not Valid"
+#~ msgstr "לא תקף"
+
+#~ msgid "Not Enabled"
+#~ msgstr "לא מאופשר"
+
+#~ msgid "Locked"
+#~ msgstr "נעולה"
+
+#~ msgid "Not Locked"
+#~ msgstr "לא נעול"
+
+#~ msgid "Encrypted"
+#~ msgstr "מוצפן"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "לא מוצפן"
+
+#~ msgid "Tainted"
+#~ msgstr "מזוהם"
+
+#~ msgid "Not Tainted"
+#~ msgstr "לא מזוהם"
+
+#~ msgid "Found"
+#~ msgstr "נמצא"
+
+#~ msgid "Not Found"
+#~ msgstr "לא נמצא"
+
+#~ msgid "Supported"
+#~ msgstr "נתמך"
+
+#~ msgid "Not Supported"
+#~ msgstr "לא נתמך"
+
+#~ msgid "Unknown"
+#~ msgstr "לא ידוע"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 סיביות"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 סיביות"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "לא ידוע"
+
+#~ msgid "Not Available"
+#~ msgstr "לא זמין"
+
+#~ msgid "System Logo"
+#~ msgstr "לוגו המערכת"
+
+#~ msgid "No input sources found"
+#~ msgstr "לא נמצא מקור קלט"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "אחר"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "צירופי מקשים מותאמים"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "מקש לתווים חלופיים יכול לשמש להזנת תווים נוספים. לעתים זה מופיע כאפשרות "
+#~ "שלישית במקלדת שלך."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "‏Alt שמאלי"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "‏Alt ימני"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "‏Super שמאלי"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "‏Super ימני"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "מקש תפריט"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "‏Ctrl ימני"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "מקש Compose מאפשר הקלדת מגוון רחב של תווים. כדי להשתמש בו, יש ללחוץ על "
+#~ "Compose ואז על צירוף תווים.  למשל, מקש Compose שלאחריו נלחצים <b>C</b> "
+#~ "ואז <b>o</b> יקליד <b>©</b>, ‏<b>a</b> ולאחריו <b>’</b> יקליד <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "‫Scroll Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "צילום מסך"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "ניתן לשנות את מקורות הקלט באמצעות קיצור המקלדת %s.\n"
+#~ "‬\n"
+#~ "‫בהגדרות קיצורי המקלדת אפשר לשנות את ההגדרה הזאת."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "‫%d נערך"
+#~ msgstr[1] "‫%d נערכו"
+#~ msgstr[2] "‫%d נערכו"
+#~ msgstr[3] "‫%d נערכו"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "איפוס כל צירופי המקשים?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "איפוס צירופי המקשים עשוי להשפיע על ההתאמה האישית של המקלדת שלך. לא נתן "
+#~ "לבטל פעולה זאת."
+
+#~ msgid "Reset All"
+#~ msgstr "איפוס הכול"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "‫%s כבר בשימוש על ידי %s. החלפה שלו, תשבית את %s"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "יש להקיש את צירוף המקשים החדש"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "הגדרת צירופי מקשים מותאמים אישית"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "הגדרת צירופי מקשים"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "יש להקיש צירופי מקשים חדשים לשינוי ‏%s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "הוספת צירוף מקשים חדש"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "גלילה בשתי אצבעות"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "חמש לחיצות, זכית בעז!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "לחיצה כפולה, לחצן ראשי"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "לחיצה בודדת, לחצן ראשי"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "לחיצה כפולה, לחצן אמצעי"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "לחיצה בודדת, לחיצה אמצעית"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "לחיצה כפולה, לחצן משני"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "לחיצה בודדת, לחצן משני"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "‏NetworkManager צריך לפעול."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "‏%s ‏(SSID: ‏%s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "רשת לא מאובטחת (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "רשת מאובטחת (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "רשת מאובטחת (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "רשת מאובטחת (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "רשת מאובטחת"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "הפעלת נקודה חמה תגרום ניתוק מ־%s, וכן לא תתאפשר גישה לרשת דרך אינטרנט "
+#~ "אלחוטי."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "חובה 8 תווים לכל הפחות"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "לעצור את נקודת הגישה ולנתק את כל המשתמשים ?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_עצירת נקודת הגישה"
+
+#~ msgid "Preserve"
+#~ msgstr "שמירה"
+
+#~ msgid "Permanent"
+#~ msgstr "קבוע"
+
+#~ msgid "Random"
+#~ msgstr "אקראי"
+
+#~ msgid "Stable"
+#~ msgstr "יציב"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "כתובת ה־MAC שהוזנה כאן תשמש ככתובת החומרה של התקן הרשת המחובר ופועל. "
+#~ "תכונה זו ידועה כשיבוט או זיוף כתובת MAC (באנגלית: cloning או spoofing). "
+#~ "לדוגמה: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "פרופיל %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "פתוחה מורחבת"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "ארגוני"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "ללא"
+
+#~ msgid "Never"
+#~ msgstr "לעולם לא"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "‏%d מ״ב/שנייה (%1.1f גה״צ‏)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "‏%d מ״ב/שנייה"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "‏5 גה״צ / 2.4 גה״צ"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 גה״צ"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 גה״צ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "ללא"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "חלש"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "טוב"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "טוב"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "מצוין"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "לשכוח התחברות"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "הסרת פרופיל התחברות"
+
+#~ msgid "Remove VPN"
+#~ msgstr "הסרת VPN"
+
+#~ msgid "Details"
+#~ msgstr "פרטים"
+
+#~ msgid "automatic"
+#~ msgstr "אוטומטית"
+
+#~ msgid "Identity"
+#~ msgstr "זהות"
+
+#~ msgid "Delete Address"
+#~ msgstr "מחיקת כתובת"
+
+#~ msgid "Delete Route"
+#~ msgstr "מחיקת נתיב"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "ללא"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "מפתח WEP 40‏/128-סיביות (הקסדצימלי או ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "מילת צופן WEP‏ 128-סיביות"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "‏WEP דינמי (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "‏WPA ו־WPA2 אישי"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "‏WPA ו־WPA2 ארגוני"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "‏WPA3 אישי"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "לא ניתן לפתוח את עורך החיבורים"
+
+#~ msgid "New Profile"
+#~ msgstr "פרופיל חדש"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "הגדרה %s לא תקפה: ‏%s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "הגדרה %s לא תקפה"
+
+#~ msgid "Import from file…"
+#~ msgstr "יבוא מקובץ…"
+
+#~ msgid "Add VPN"
+#~ msgstr "הוספת VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "לא ניתן לייבא חיבור VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "הקובץ „%s” לא ניתן לקריאה או שאינו מכיל מידע התחברות VPN מוכר\n"
+#~ "\n"
+#~ "שגיאה: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "נא לבחור קובץ לייבוא"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "כבר קיים קובץ בשם „%s“."
+
+#~ msgid "_Replace"
+#~ msgstr "ה_חלפה"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "להחליף את %s בחיבור ה־VPN שנשמר כעת?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "לא ניתן לייצא את חיבור ה־VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "החיבור „%s” לא ניתן לייצוא אל %s.\n"
+#~ "‬\n"
+#~ "‏‫\n"
+#~ "‬\n"
+#~ "‫שגיאה: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "יצוא חיבור VPN"
+
+#~ msgid "never"
+#~ msgstr "מעולם לא"
+
+#~ msgid "today"
+#~ msgstr "היום"
+
+#~ msgid "yesterday"
+#~ msgstr "אתמול"
+
+#~ msgid "Last used"
+#~ msgstr "שימוש אחרון"
+
+#~ msgid "Add new connection"
+#~ msgstr "הוספת התחברות חדשה"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "פרטי הרשתות הנבחרות, לרבות ססמאות וכל תצורה אחרת שהותאמה אישית יאבדו."
+
+#~ msgid "_Forget"
+#~ msgstr "הת_עלמות"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "רשתות אלחוטיות לא מוכרות"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "הת_עלמות"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "מדיניות המערכת אוסרת שימוש בנקודה חמה"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "התקן הרשת האלחוטית אינו תומך במצב נקודה חמה"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "נעשה שימוש בזיהוי אוטומטי של מתווך רשת כאשר לא מסופקת כתובת תצורה."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "מצב זה אינו מומלץ לרשתות ציבוריות שאינן מהימנות."
+
+#~ msgid "Status unknown"
+#~ msgstr "המצב אינו ידוע"
+
+#~ msgid "Unmanaged"
+#~ msgstr "לא מנוהל"
+
+#~ msgid "Unavailable"
+#~ msgstr "לא זמין"
+
+#~ msgid "Connecting"
+#~ msgstr "בהתחברות"
+
+#~ msgid "Authentication required"
+#~ msgstr "נדרש אימות"
+
+#~ msgid "Disconnecting"
+#~ msgstr "מתבצע ניתוק"
+
+#~ msgid "Connection failed"
+#~ msgstr "החיבור נכשל"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "המצב אינו ידוע (חסר)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "התצורה נכשלה"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "תצורת ה־IP נכשלה"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "תצורת ה־IP פגה"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "נדרשו סודות אך לא סופקו"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "משלים ה־802.1x מנותק"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "תצורת משלים ה־802.1x נכשלה"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "משלים ה־802.1x נכשל"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "למשלים ה־802.1x לקח זמן רב מדי ליצור אימות"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "הפעלת שירות ה־PPP נכשלה"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "שירות ה־PPP מנותק"
+
+#~ msgid "PPP failed"
+#~ msgstr "ה־PPP נכשל"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "הפעלת לקוח ה־DHCP נכשלה"
+
+#~ msgid "DHCP client error"
+#~ msgstr "שגיאת לקוח DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "לקוח ה־DHCP נכשל"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "הפעלת שירות שיתוף החיבורים נכשלה"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "שירות החיבור השיתופי נכשל"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "הפעלת שירות ה־AutoIP נכשלה"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "שגיאה בשירות AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "שירות ה־AutoIP נכשל"
+
+#~ msgid "Line busy"
+#~ msgstr "הקו תפוס"
+
+#~ msgid "No dial tone"
+#~ msgstr "אין צליל חיוג"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "לא ניתן ליצור קשר עם אף ספק"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "הזמן שהוקצב לבקשת החיוג פג"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "ניסיון החיוג נכשל"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "הפעלת המודם נכשלה"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "הבחירה ב־APN הזה נכשלה"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "לא מחפש אחר רשתות"
+
+#~ msgid "Network registration denied"
+#~ msgstr "הרישום ברשת נדחה"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "הזמן שהוקצב לרישום לרשת פג"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "הרישום לרשת המבוקשת נכשל"
+
+#~ msgid "PIN check failed"
+#~ msgstr "בדיקת ה־PIN נכשלה"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "ייתכן שחסרה קושחה עבור ההתקן"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "החיבור נעלם"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "החיבור הנוכחי התבצע לפי הנחות"
+
+#~ msgid "Modem not found"
+#~ msgstr "המודם לא נמצא"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "חיבור הבלוטות' נכשל"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "לא הוכנס כרטיס SIM"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "נדרש ה־Pin של ה־SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "נדרש ה־Puk של ה־SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "ה־SIM שגוי"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "תלות החיבור נכשלה"
+
+#~ msgid "Firmware missing"
+#~ msgstr "הקושחה חסרה"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "הכבל מנותק"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "שגיאה לא מוגדרת באבטחת 802.1x ‏(wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "לא נבחר קובץ"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "שגיאה לא ידועה באימות קובץ eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "מפתחות פרטיים מסוג DER, PEM, PKCS#12 או PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "אישורי DER או PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "חסרים הקבצים EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "קובצי PAC‏ (‎*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "חסר שם משתמש EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "חסרה ססמת EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "אישור EAP-PEAP CA לא תקף: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "אישור EAP-PEAP CA לא תקף: לא סופקו אישורים"
+
+#~ msgid "missing EAP username"
+#~ msgstr "חסר שם משתמש EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "חסרה ססמת EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "חסר מזהה EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "אישור EAP-TLS CA לא תקף: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "אישור EAP-TLS CA לא תקף: לא סופק אישור"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "מפתח פרטי EAP-TLS לא תקף: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "משתמש אישור EAP-TLS לא תקף: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "מפתחות פרטיים בלתי מוצפנים אינם בטוחים"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "נראה שהמפתח הפרטי הנבחר לא מוגן על ידי ססמה. זה עלול לסכן את אישורי "
+#~ "האבטחה שלך. נא לבחור מפתח פרטי המוגן בססמה.\n"
+#~ "\n"
+#~ "(ניתן להגן על המפתח הפרטי שלך עם openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "נא לבחור את האישור האישי שלך"
+
+#~ msgid "Choose your private key"
+#~ msgstr "בחירת המפתח הפרטי שלך"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "אישור רשות אישורים מסוג EAP-TTLS לא תקף: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "אישור רשות אישורים מסוג EAP-TTLS לא תקף: לא צוין אישור"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "שגיאת אימות אבטחת 802.1x לא ידועה"
+
+#~ msgid "Select a file"
+#~ msgstr "בחירת קובץ"
+
+#~ msgid "missing leap-username"
+#~ msgstr "חסר שם משתמש leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "חסרה ססמת leap"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "חסרה ססמת רשת אלחוטית."
+
+#~ msgid "missing wep-key"
+#~ msgstr "חסר מפתח wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr "מפתח wep לא תקף: מפתח באורך %zu חייב להכיל ספרות הקסדצימליות בלבד"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr "מפתח wep לא תקף: מפתח באורך %zu חייב להכיל אך ורך תווי ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "מפתח wep לא תקף: אורך מפתח %zu שגוי. מפתח חייב להיות או באורך 5/13 "
+#~ "(‏ascii) או 10/26 (הקסדצימלי)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "מפתח wep לא תקף: ססמה לא יכולה להיות ריקה"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "מפתח wep לא תקף: ססמה חייבת להיות קצרה מ־64 תווים"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "‏wpa-psk לא תקף: %zu אורך מפתח לא תקף. חייב להיות [8,63] בתים או 64 ספרות "
+#~ "הקסדצימליות"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "‏wpa-psk לא תקף: לא נתן לפענח מפתח עם 64 בתים כהקסדצילמי"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "אחר"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "הסרת %s"
+
+#~ msgid "Error removing account"
+#~ msgstr "אירעה שגיאה בעת הסרת החשבון"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "חשבון %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "הסרת חשבון"
+
+#~ msgid "Unknown time"
+#~ msgstr "זמן בלתי ידוע"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s עד לטעינה מלאה"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "אזהרה: נותרו %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "נותרו %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "בטעינה מלאה"
+
+#~ msgid "Not charging"
+#~ msgstr "לא בטעינה"
+
+#~ msgid "Empty"
+#~ msgstr "ריקה"
+
+#~ msgid "Charging"
+#~ msgstr "בטעינה"
+
+#~ msgid "Discharging"
+#~ msgstr "בפריקה"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "עכבר אלחוטי"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "מקלדת אלחוטית"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "אל־פסק"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "עוזר דיגיטלי אישי"
+
+#~ msgid "Cellphone"
+#~ msgstr "טלפון סלולרי"
+
+#~ msgid "Media player"
+#~ msgstr "נגן מדיה"
+
+#~ msgid "Tablet"
+#~ msgstr "משטח"
+
+#~ msgid "Computer"
+#~ msgstr "מחשב"
+
+#~ msgid "Gaming input device"
+#~ msgstr "התקני קלט למשחקים"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "ראשי"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "נוסף"
+
+#~ msgid "Batteries"
+#~ msgstr "סוללות"
+
+#~ msgid "When _idle"
+#~ msgstr "ב_חוסר פעילות"
+
+#~ msgid "Suspend"
+#~ msgstr "השהיה"
+
+#~ msgid "Power Off"
+#~ msgstr "כיבוי"
+
+#~ msgid "Hibernate"
+#~ msgstr "מצב תרדמת"
+
+#~ msgid "Nothing"
+#~ msgstr "לא לעשות דבר"
+
+#~ msgid "When on battery power"
+#~ msgstr "בעת הפעלה מהסוללה"
+
+#~ msgid "When plugged in"
+#~ msgstr "עם חיבור לחשמל"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "לעולם לא"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "השהיה אוטומטית"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "מצב הביצועים הושבת זמנית עקב טמפרטורה גבוהה בזמן הפעילות."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "זוהו ירכיים: מצב הביצועים אינו זמין באופן זמני. יש להעביר את המכשיר למשטח "
+#~ "יציב כדי לשחזר את המצב הקודם."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "מצב הביצועים מושבת זמנית."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "סוללה חלשה: חיסכון בחשמל הופעל. המצב הקודם ישוחזר כאשר הסוללה תיטען באופן "
+#~ "מספק."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "מצב החיסכון בחשמל הופעל על ידי „%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "מצב הביצועים מופעל על ידי „%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "ביצועים"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "ביצועים גבוהים וצריכת חשמל מוגברת."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "מאוזן"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "ביצועים רגילים וצריכת חשמל רגילה."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "חיסכון בחשמל"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "ביצועים מופחתים וצריכת חשמל חסכונית."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "המדפסת „%s” נמחקה"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "הוספת המדפסת החדשה נכשלה."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "לא ניתן לטעון את מנשק המשתמש: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "שחרור להוספת מדפסות ולשינוי הגדרות"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "פרטי %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "לא נמצא מנהל התקן מתאים"
+
+#~ msgid "Select PPD File"
+#~ msgstr "בחירת קובץ PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "קובצי הגדרות מדפסת של PostScript ‏(‎*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+#~ "GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "מדפסת JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "מדפסת LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "חד־צדדי"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "שול ארוך (רגיל)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "שול קצר (היפוך אנכי)"
+
+#~ msgid "Portrait"
+#~ msgstr "לאורך"
+
+#~ msgid "Landscape"
+#~ msgstr "לרוחב"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "לרוחב הפוך"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "לאורך הפוך"
+
+#~ msgid "Resume"
+#~ msgstr "המשך"
+
+#~ msgid "Pause"
+#~ msgstr "השהיה"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "ממתינה"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "מושהית"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "נדרש אימות"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "מעבדת"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "נעצרה"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "בוטלה"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "נפסקה"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "הושלמה"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "העברת המשימה הזאת לראש התור"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - הדפסות פעילות"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "יש להזין אישור על מנת להדפיס מ־%s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "שחרור שרת הדפסה"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "שחרור %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "יש להזין שם משתמש וססמה להצגת מדפסות על %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "חיפוש מדפסות"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "יציאה טורית"
+
+#~ msgid "Parallel Port"
+#~ msgstr "יציאה מקבילית"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "מיקום: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "כתובת: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "אימות _פנימי"
+
+#~ msgid "Two Sided"
+#~ msgstr "דו־צדדי"
+
+#~ msgid "Paper Type"
+#~ msgstr "סוג הנייר"
+
+#~ msgid "Paper Source"
+#~ msgstr "מקור הנייר"
+
+#~ msgid "Output Tray"
+#~ msgstr "מגש הפלט"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "הבחנה"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "סינון קדם של GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "עמודים לצד"
+
+#~ msgid "Orientation"
+#~ msgstr "כיוון"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "כללי"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "הגדרת עמוד"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "אפשרויות הניתנות להתקנה"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "משימה"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "איכות התמונה"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "צבע"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "גימור"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "מתקדם"
+
+#~ msgid "Test page"
+#~ msgstr "דף בדיקה"
+
+#~ msgid "Auto Select"
+#~ msgstr "בחירה אוטומטית"
+
+#~ msgid "Printer Default"
+#~ msgstr "בררת המחדל של המדפסת"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "הטמעת גופני GhostScript בלבד"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "המרה ל־PostScript רמה 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "המרה ל־PostScript רמה 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "אין סינון קדם"
+
+#~ msgid "Clean print heads"
+#~ msgstr "ניקוי ראשי ההדפסה"
+
+#~ msgid "Out of toner"
+#~ msgstr "נגמר הטונר"
+
+#~ msgid "Low on developer"
+#~ msgstr "נותר מעט נייר צילום"
+
+#~ msgid "Out of developer"
+#~ msgstr "נגמר נייר הצילום"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "נותרה מעט אספקת צבע"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "נגמרה אספקת הצבע"
+
+#~ msgid "Open cover"
+#~ msgstr "הכיסוי פתוח"
+
+#~ msgid "Open door"
+#~ msgstr "הדלת פתוחה"
+
+#~ msgid "Low on paper"
+#~ msgstr "נותר מעט נייר"
+
+#~ msgid "Out of paper"
+#~ msgstr "נגמר הנייר"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "מנותקת"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "נעצרה"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "כלי קיבול הפסולת כמעט מלא"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "כלי קיבול הפסולת מלא"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "הפוטו מוליך האופטי עומד לסיים את חייו"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "הפוטו מוליך האופטי אינו מתפקד עוד"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "מוכנה"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "אין עבודות"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "מעבדת"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "אימפריאלית"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "מטרית"
+
+#~ msgid "Ask what to do"
+#~ msgstr "הצגת שאלה בנוגע להמשך"
+
+#~ msgid "Do nothing"
+#~ msgstr "לא לעשות דבר"
+
+#~ msgid "Open folder"
+#~ msgstr "פתיחת תיקייה"
+
+#~ msgid "Other Media"
+#~ msgstr "מדיה אחרת"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "נא לבחור יישום לתקליטורי שמע"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "נא לבחור יישום לתקליטורי וידאו DVD"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "נא לבחור יישום להפעלה בעת חיבור נגן מוזיקה"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "נא לבחור יישום להפעלה בעת חיבור המצלמה"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "נא לבחור יישום לתקליטורי תכנה"
+
+#~ msgid "audio DVD"
+#~ msgstr "תקליטור DVD שמע"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "תקליטור Blu-ray ריק"
+
+#~ msgid "blank CD disc"
+#~ msgstr "תקליטור CD ריק"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "תקליטור DVD ריק"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "תקליטור HD DVD ריק"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "תקליטור וידאו Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "מציג ספרים אלקטרוניים"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "תקליטור וידאו HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "תקליטור תמונות"
+
+#~ msgid "Super Video CD"
+#~ msgstr "סופר תקליטור וידאו (SVCD)"
+
+#~ msgid "Video CD"
+#~ msgstr "תקליטור וידאו (VCD)"
+
+#~ msgid "Windows software"
+#~ msgstr "תכנה של Windows"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "המסך יכבה"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "חצי דקה"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "דקה"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "שתי דקות"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 דקות"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 דקות"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "חצי שעה"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "שעה"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "דקה"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 דקות"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 דקות"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 דקות"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 דקות"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 דקות"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 דקות"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 דקות"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "רבע שעה"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "לעולם לא"
+
+#~ msgid "Select Location"
+#~ msgstr "בחירת מיקום"
+
+#~ msgid "_OK"
+#~ msgstr "_אישור"
+
+#~ msgid "No applications found"
+#~ msgstr "לא נמצאו יישומים"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "לא נבחרו רשתות לשיתוף"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "פעיל"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "כבוי"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "מופעל"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "פעיל"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "נא לבחור בתיקייה"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "הפעלת שיתוף מדיה"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "שיתוף קבצים מאפשר לך לשתף את התיקייה ציבורי שלך עם משתמשים נוספים ברשת "
+#~ "הנוכחית שלך באמצעות: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "כאשר התחברות מרוחקת מאופשרת, משתמשים מרוחקים יכולים להתחבר באמצעות פקודה "
+#~ "במעטפת מאובטחת: \n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "הפעלת שיתוף מדיה פרטי"
+
+#~ msgid "Device name copied"
+#~ msgstr "שם ההתקן הועתק"
+
+#~ msgid "Device address copied"
+#~ msgstr "כתובת ההתקן הועתקה"
+
+#~ msgid "Username copied"
+#~ msgstr "שם המשתמש הועתק"
+
+#~ msgid "Password copied"
+#~ msgstr "ססמה הועתקה"
+
+#~ msgid "Custom"
+#~ msgstr "התאמה אישית"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "‏%s בבדיקה"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "מנותק"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "בהתחברות"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "מחובר"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "שגיאת אימות"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "אימות"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "תפקוד ירוד"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "התקנים מחוברים ומאומתים"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "לא ידוע"
+
+#~ msgid "Authorized at:"
+#~ msgstr "אומת ב־:"
+
+#~ msgid "Connected at:"
+#~ msgstr "מחובר החל מ־:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "נרשם ב־:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "אימות ההתקן נכשל: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "שכיחת ההתקן נכשלה: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "שגיאה"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "אומת"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr "מערכת הבת של Thunderbolt ‏(boltd) אינה מותקנת או לא מוגדרת כראוי."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "רק התקני USB ו־DisplayPort ניתנים לצירוף."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "‏Thunderbolt לא ניתנת לזיהוי.\n"
+#~ "או שהמערכת חסרת תמיכה ב־Thunderbolt, או שהיא הושבתה ב־BIOS או שהיא הוגדרה "
+#~ "כשכבת אבטחה לא נתמכת ב־BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "תמיכה ב־Thunderbolt הושבתה ב־BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "שכבת האבטחה של Thunderbolt לא ניתנת לקביעה."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "שגיאה בשינוי המצב הישיר: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "בררת מחדל"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "בינוני"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "גדול"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "גדול יותר"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "ענק"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "פיקסל אחד"
+#~ msgstr[1] "שני פיקסלים"
+#~ msgstr[2] "‫%d פיקסלים"
+#~ msgstr[3] "‏‫%d פיקסלים"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "קצר"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ מסך"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ מסך"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ מסך"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "ארוך"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "שעה"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "יום"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "יומיים"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 ימים"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 ימים"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 ימים"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 ימים"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "שבוע"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "שבועיים"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "חודש"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "לרוקן את כל הפריטים באשפה?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "כל הפריטים באשפה ימחקו לצמיתות."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_פינוי האשפה"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "למחוק את כל הקבצים הזמניים?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "כל הקבצים הזמניים ימחקו לצמיתות."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "מחיקת קבצים _זמניים"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "יום"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "שבוע"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "חודש"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "לעד"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "צריך להתאים את כתובת האינטרנט של ספק החשבון שלך."
+
+#~ msgid "Failed to add account"
+#~ msgstr "הוספת החשבון נכשלה"
+
+#~ msgid "Failed to register account"
+#~ msgstr "הרשמת החשבון נכשלה"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "אין שיטה נתמכת לאימות עם מתחם זה (domain)"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "ההצטרפות למתחם נכשלה"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "שם התחברות זה לא עובד.\n"
+#~ "נא לנסות שוב."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ססמה זו לא עובדת.\n"
+#~ "נא לנסות שוב."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "ההתחברות למתחם נכשלה"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "לא ניתן למצוא את התחום. אולי שגית באיות?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "עיון אחר תמונות נוספות"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "יש לדרוש את ההתקן כדי לבצע את הפעולה הזאת"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "ההתקן כבר נדרש על ידי תהליך אחר"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "אין לך הרשאות לביצוע הפעולה"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "אין הדפסות רשומות"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "ההתקשורת עם ההתקן בעת הרישום נכשלה"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "ההתקשרות עם קורא טביעות האצבע נכשלה"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "ההתקשרות עם שרת קורא טביעות האצבע נכשלה"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "הצגת טביעות האצבעות נכשלה: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "מחיקת טביעות אצבע שמורות נכשלה: ‏%s"
+
+#~ msgid "Left thumb"
+#~ msgstr "אגודל שמאלית"
+
+#~ msgid "Left middle finger"
+#~ msgstr "אמה שמאלית"
+
+#~ msgid "_Left index finger"
+#~ msgstr "אצבע _שמאלית"
+
+#~ msgid "Left ring finger"
+#~ msgstr "קמיצה שמאלית"
+
+#~ msgid "Left little finger"
+#~ msgstr "זרת שמאלית"
+
+#~ msgid "Right thumb"
+#~ msgstr "אגודל ימנית"
+
+#~ msgid "Right middle finger"
+#~ msgstr "אמה ימנית"
+
+#~ msgid "_Right index finger"
+#~ msgstr "אצבע _ימנית"
+
+#~ msgid "Right ring finger"
+#~ msgstr "קמיצה ימנית"
+
+#~ msgid "Right little finger"
+#~ msgstr "זרת ימנית"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "אצבע לא ידועה"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "הושלם"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "התקן טביעת האצבע התנתק"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "אחסון התקן טביעת האצבע מלא"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "רישום טביעת אצבע חדשה נכשל"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "התחלת הרישום נכשלה: ‏%s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "רישום טביעת אצבע חדשה נכשל"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "עצירת הרישום נכשלה: ‏%s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr "יש לחזור על הרמת והנחת האצבע על הקורא כדי לרשום את טביעת האצבע שלך"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_רישום מחדש של אצבע זו…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "סריקת טביעת אצבע חדשה"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "שחרור התקן טביעת אצבע %s נכשל: ‏%s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "בעיה בקריאת התקן"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "טעינת התקן טביעת אצבע %s נכשלה: ‏%s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "קבלת התקני טביעת אצבע נכשלה: ‏%s"
+
+#~ msgid "This Week"
+#~ msgstr "השבוע"
+
+#~ msgid "Last Week"
+#~ msgstr "השבוע האחרון"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e ב%b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e ב%b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "‏%s – %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "הפעלה הסתיימה"
+
+#~ msgid "Session Started"
+#~ msgstr "הפעלה התחילה"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "‏‏%s – פעילות בחשבון"
+
+#~ msgid "Please choose another password."
+#~ msgstr "נא לבחור בססמה אחרת."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "נא להזין את הססמה הנוכחית שלך שוב."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "לא ניתן להחליף את הססמה"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "לא ניתן להצטרף אוטומטית לסוג כזה של תחום"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "לא נמצאו תחום או מתחם כאלה"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "לא ניתן להיכנס בשם %s לתחום %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "הססמה שגויה, נא לנסות שוב"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "לא ניתן להתחבר אל התחום %s:‏ %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "מחיקת משתמש נכשלה"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "ביטול המשתמש המנוהל מרחוק נכשל"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "מחיקת החשבון שלך על ידיך אינה אפשרית."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s עדיין במערכת"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "מחיקת משתמש כשהוא מחובר עלולה להשאיר את המערכת במצב בלתי יציב."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "לשמור על הקבצים של %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ניתן לשמור על תיקיית הבית, מאגר הדואר והקבצים הזמניים בהישג ידך לאחר "
+#~ "מחיקת משתמש."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_מחיקת הקבצים"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_שמירת הקבצים"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "לשלול את החשבון של %s שמנוהל מרחוק?"
+
+#~ msgid "_Delete"
+#~ msgstr "מ_חיקה"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "חשבון מושבת"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "להגדרה בהתחברות הבאה"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "אין"
+
+#~ msgid "Logged in"
+#~ msgstr "נכנסת"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "לא ניתן ליצור קשר עם שירות החשבונות"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "נא לוודא ששירות החשבונות (AccountService) מותקן ומופעל."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "יש הכרח לשחרר לוח זה על מנת לשנות הגדרה זו"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "מחיקת חשבון המשתמש הנבחר"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "כדי למחוק את המשתמש הנבחר\n"
+#~ "ראשית יש ללחוץ על הסמל *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "שחרור להוספת משתמשים ולשינוי הגדרות"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "הססמה החדשה מוכרחה להיות שונה מהקודמת."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "כדאי לשנות כמה תווים או מספרים."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "כדאי לנסות לערוך שינויים נרחבים יותר בססמה."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "ססמה ללא שם המשתמש שלך תהיה חזקה יותר."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "כדאי לנסות להימנע משימוש בשם שלך בססמה."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "כדאי לנסות להימנע מכמה מהמילים הכלולות בססמה."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "כדאי לנסות להימנע ממילים נפוצות."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "כדאי לנסות להימנע מסידור מחדש של מילים קיימות."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "כדאי לנסות להשתמש ביותר מספרים."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "כדאי לנסות להשתמש ביותר אותיות רישיות."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "כדאי לנסות השתמש ביותר אותיות קטנות."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "כדאי לנסות להשתמש ביותר תווים מיוחדים, כמו סימני פיסוק."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "כדאי לנסות להשתמש בתערובת של אותיות, מספרים וסימני פיסוק."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "כדאי לנסות להימנע מחזרה על אותו התו."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "כדאי לנסות להימנע מחזרה על אותו סוג של תו: צריך לערבב אותיות, מספרים "
+#~ "וסימני פיסוק."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "כדאי להימנע מרצפים כמו 1234, abcd או אבגד."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "הססמה צריכה להיות ארוכה יותר. יש לנסות להוסיף תווים, מספרים וסימני פיסוק."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "יש לערבב אותיות רישיות וקטנות ולהשתמש במספר או שניים."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "הוספת תווים נוספים, מספרים וסימני פיסוק תחזק את הססמה עוד יותר."
+
+#~ msgid "Authentication failed"
+#~ msgstr "האימות נכשל"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "הססמה החדשה קצרה מדי"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "הססמה החדשה פשוטה מדי"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "הססמאות הישנה והחדשה דומות מדי"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "הססמה החדשה כבר הייתה בשימוש לאחרונה."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "על הססמה החדשה להכיל תווים מספריים או מיוחדים"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "הססמאות הישנה והחדשה זהות"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "ססמתך הוחלפה מאז שביצעת אימות לראשונה!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "הססמה החדשה לא מכילה מספיק תווים השונים זה מזה"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "שגיאה בלתי ידועה"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "שם המשתמש יכול להכיל רק אותיות קטנות מהאלפבית האנגלי, ספרות ואחד  "
+#~ "מהתווים: . - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "למרבה הצער, שם משתמש זה אינו זמין. יש לנסות שם אחר."
+
+#~ msgid "The username is too long."
+#~ msgstr "שם המשתמש ארוך מדי."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "כפתור %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "יישום מוגדר"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "שליחת צירוף מקשים"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "החלפת צג"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "הצגת עזרה על גבי המסך"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "מחשב לוח מעוגן על לוח מחשב נייד"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "מחשב לוח מעוגן על צג חיצוני"
+
+#~ msgid "External tablet device"
+#~ msgstr "מחשב לוח חיצוני"
+
+#~ msgid "All Displays"
+#~ msgstr "כל הצגים"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "עט איירבראש עם לחץ, הטייה ומחוון גלילה מובנה"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "עט איירבראש עם לחץ, הטייה וסיבוב"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "עט רגיל עם לחץ והטייה"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "עט רגיל עם לחץ"
+
+#~ msgid "New shortcut…"
+#~ msgstr "קיצור דרך חדש…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "הפעולה בוטלה"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "‫<b>שגיאה:</b> הגישה לשינוי ההגדרות נדחתה"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "‫<b>שגיאה:</b> שגיאה בציוד התקשורת הסלולרית"
+
+#~ msgid "Not Registered"
+#~ msgstr "לא רשום"
+
+#~ msgid "Registered"
+#~ msgstr "רשום"
+
+#~ msgid "Roaming"
+#~ msgstr "ניוד"
+
+#~ msgid "Searching"
+#~ msgstr "בחיפוש"
+
+#~ msgid "Denied"
+#~ msgstr "נדחה"
+
+#~ msgid "2G Only"
+#~ msgstr "‫2G בלבד"
+
+#~ msgid "3G Only"
+#~ msgstr "‫3G בלבד"
+
+#~ msgid "4G Only"
+#~ msgstr "‫4G בלבד"
+
+#~ msgid "5G Only"
+#~ msgstr "‫5G בלבד"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "‫2G,‏ 3G,‏ 4G, ‏5G (עדיפה)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "‫2G,‏ 3G,‏ 4G (עדיפה), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "‫2G,‏ 3G (עדיפה), 4G, ‏5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "‫2G (עדיפה), 3G,‏ 4G, ‏5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "‫2G,‏ 3G,‏ 4G, ‏5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "‫2G,‏ 3G,‏ 4G (עדיפה)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "‫2G,‏ 3G (עדיפה), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "‫2G (עדיפה), 3G,‏ 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "‫2G,‏ 3G,‏ 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "‫3G,‏ ‏4G, ‏‎5G (עדיפה)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "‫3G,‏ 4G (עדיפה), ‎5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "‫3G (עדיפה), ‏4G, ‏‎5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "‫3G,‏ 4G, ‏5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "‫2G,‏ 4G,‏ 5G (עדיפה)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "‫2G,‏ 4G (עדיפה), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "‫2G (עדיפה), 4G,‏ 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "‫2G,‏ 4G,‏ 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "‫2G,‏ 3G,‏ 5G (עדיפה)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "‫2G,‏ 3G (עדיפה), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "‫2G (עדיפה), 3G,‏ 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "‫2G,‏ 3G,‏ 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "‫3G,‏ 4G (עדיפה)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "‫3G (עדיפה), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "‫3G,‏ 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "‫2G,‏ 4G (עדיפה)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "‫2G (עדיפה), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "‫2G,‏ 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "‫2G,‏ 3G (עדיפה)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "‫2G (עדיפה), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "‫2G,‏ 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "‫2G,‏ 5G (עדיפה)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "‫2G (עדיפה), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "‫2G,‏ 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "‫3G,‏ 5G (עדיפה)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "‫3G (עדיפה), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "‫3G,‏ 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "‫4G,‏ 5G (עדיפה)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "‫4G (עדיפה), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "‏‎4G, ‏‎5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "לא ידוע"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "שחרור כרטיס SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "נא לספק קוד PIN עבור SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "נא להקליד PIN לשחרור כרטיס ה־SIM שלך"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "נא לספק קוד PUK ל־SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "נא להקליד PUK לשחרור כרטיס ה־SIM שלך"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "הססמה שהוקלדה שגויה."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "קוד ה־PUK אמור להיות באורך 8 ספרות"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "נא להקליד PIN חדש"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "קוד ה־PIN אמור להיות מספר באורך 4-8 ספרות"
+
+#~ msgid "Unlocking…"
+#~ msgstr "מתבצע שחרור…"
+
+#~ msgid "Phone failure"
+#~ msgstr "שגיאת טלפון"
+
+#~ msgid "No connection to phone"
+#~ msgstr "אין חיבור לטלפון"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "הפעולה אסורה"
+
+#~ msgid "Operation not supported"
+#~ msgstr "הפעולה אינה נתמכת"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "לא הוכנס SIM"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "נדרש PIN ל־SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "נדרש PUK ל־SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "כשל ב־SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "ה־SIM עסוק"
+
+#~ msgid "Incorrect password"
+#~ msgstr "ססמה שגויה"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "נדרש PIN2 ל־SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "נדרש PUK2 ל־SIM"
+
+#~ msgid "Not found"
+#~ msgstr "לא נמצא"
+
+#~ msgid "No network service"
+#~ msgstr "אין שירות רשת"
+
+#~ msgid "Network timeout"
+#~ msgstr "תום זמן המתנה לרשת"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "שירותי GPRS אסורים"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "ניוד אסור באזור זה"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "שגיאת GPRS לא ידועה"
+
+#~ msgid "No Error"
+#~ msgstr "אין שגיאה"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "הפעולה בוטלה"
+
+#~ msgid "Access denied"
+#~ msgstr "הגישה נדחתה"
+
+#~ msgid "Unknown Error"
+#~ msgstr "שגיאה לא ידועה"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "הצגת מספר הגרסה"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "הפעלת מצב מפורט"
+
+#~ msgid "Search for the string"
+#~ msgstr "חיפוש אחר מחרוזת"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "הצגת שמות הלוחות האפשריים ואז לצאת"
+
+#~ msgid "Panel to display"
+#~ msgstr "לוח להצגה"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "לוחות זמינים:"
+
+#~ msgid "System Sounds"
+#~ msgstr "צלילי מערכת"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "שגיאה: לא ניתן לקבוע את רמת HSI."
@@ -9581,9 +8224,6 @@ msgstr "צלילי מערכת"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "אישורי DER או PEM‏ (‎*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "הוספת מדפסת…"
 
 #~ msgid "Drip"
 #~ msgstr "טפטוף"
@@ -9847,9 +8487,6 @@ msgstr "צלילי מערכת"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "לוח (מוחלט)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "משטח מגע"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "העדפות מחשב לוח"
@@ -10408,9 +9045,6 @@ msgstr "צלילי מערכת"
 #~ msgid "Changes throughout the day"
 #~ msgstr "משתנה במהלך היום"
 
-#~ msgid "_Lock Screen"
-#~ msgstr "מסך _נעילה"
-
 #~ msgctxt "background, style"
 #~ msgid "Tile"
 #~ msgstr "ריצוף"
@@ -10457,9 +9091,6 @@ msgstr "צלילי מערכת"
 
 #~ msgid "Mirrored"
 #~ msgstr "שכפול צגים"
-
-#~ msgid "Secondary"
-#~ msgstr "משני"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "סידור תצוגה משולבת"
@@ -10753,9 +9384,6 @@ msgstr "צלילי מערכת"
 
 #~ msgid "Mail"
 #~ msgstr "דוא״ל"
-
-#~ msgid "Calendar"
-#~ msgstr "לוח שנה"
 
 #~ msgid "Contacts"
 #~ msgstr "אנשי קשר"
@@ -11147,9 +9775,6 @@ msgstr "צלילי מערכת"
 #~ msgid "Scroll Up"
 #~ msgstr "גלילה למעלה"
 
-#~ msgid "Scroll Down"
-#~ msgstr "גלילה למטה"
-
 #~ msgid "Scroll Right"
 #~ msgstr "גלילה לימין"
 
@@ -11469,9 +10094,6 @@ msgstr "צלילי מערכת"
 
 #~ msgid "Turns off wireless devices"
 #~ msgstr "כיבוי התקנים אלחוטיים"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "נטרול _בעת הקלדה"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "שירותי הרשת של המערכת אינם תואמים לגרסה זו."
@@ -12382,9 +11004,6 @@ msgstr "צלילי מערכת"
 #~ "Select a display language (change will be applied next time you log in)"
 #~ msgstr "יש לבחור שפת תצוגה (השינוי יחול עם הכניסה הבאה לסביבת המשתמש)"
 
-#~ msgid "Install languages..."
-#~ msgstr "התקנת שפות..."
-
 #~ msgid "Locations..."
 #~ msgstr "מיקומים..."
 
@@ -12649,9 +11268,6 @@ msgstr "צלילי מערכת"
 
 #~ msgid "Layouts"
 #~ msgstr "פריסות"
-
-#~ msgid "Layout"
-#~ msgstr "פריסה"
 
 #~ msgid "Change contrast:"
 #~ msgstr "שינוי הבהירות:"
@@ -12960,9 +11576,6 @@ msgstr "צלילי מערכת"
 
 #~ msgid "---"
 #~ msgstr "---"
-
-#~ msgid "_Acceleration:"
-#~ msgstr "_קיצור:"
 
 #~ msgid "Beep when a modifer key is pressed"
 #~ msgstr "צפצוף בעת לחיצה על מקשי החלפה"
@@ -14449,9 +13062,6 @@ msgstr "צלילי מערכת"
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "_חזור לברירת מחדל"
-
 #~ msgid "_Size:"
 #~ msgstr "_גודל:"
 
@@ -14466,9 +13076,6 @@ msgstr "צלילי מערכת"
 
 #~ msgid "_Window title font:"
 #~ msgstr "גופן כותרת ה_חלון:"
-
-#~ msgid "_Windows:"
-#~ msgstr "_חלונות..."
 
 #~ msgid "dots per inch"
 #~ msgstr "נקודות לאינץ':"
@@ -14579,9 +13186,6 @@ msgstr "צלילי מערכת"
 
 #~ msgid "Copying '%s'"
 #~ msgstr "מעתיק '%s'"
-
-#~ msgid "Parent Window"
-#~ msgstr "חלון הורה"
 
 #~ msgid "Parent window of the dialog"
 #~ msgstr "חלון הורה של הדו־שיח"

--- a/po/he.po~
+++ b/po/he.po~
@@ -1,0 +1,14604 @@
+# translation of gnome-control-center.HEAD.he.po to Hebrew
+# translation of gnome-control-center.gnome-2-0.he.po to Hebrew
+# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) 2005 THE PACKAGE'S COPYRIGHT HOLDER.
+# Gil 'Dolfin' Osher <dolfin@rpg.org.il>, 2002,2003.
+# Yuval Tanny, 2005.
+# Yaron Shahrabani <sh.yaron@gmail.com>, 2010, 2011.
+# Yosef Or Boczko <yoseforb@gmail.com>, 2013-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.HEAD.he\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issues\n"
+"POT-Creation-Date: 2022-09-23 17:15+0000\n"
+"PO-Revision-Date: 2022-10-06 15:34+0300\n"
+"Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
+"Language-Team: Hebrew <>\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n==2 ? 1 : n>10 && n%10==0 ? 2 : 3);\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "אפיק מערכת"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "גישה מלאה"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "אפיק הפעלה"
+
+#: panels/applications/cc-applications-panel.c:828 panels/power/cc-power-panel.ui:75
+#: panels/thunderbolt/cc-bolt-panel.ui:265 panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "התקנים"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "גישה מלאה אל ‎/dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "רשת"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "יש גישה לרשת"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "בית"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "קריאה בלבד"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "מערכת הפעלה"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "הגדרות"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "ניתן לשנות הגדרות"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you are "
+"concerned about these permissions, consider removing this application."
+msgstr ""
+"ליישום %s יש את ההרשאות הבאות בצורה מובנית. לא ניתן לשנות זאת. אם הדבר מדאיג אותך, "
+"כדאי לשקול את הסרת היישום."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "סוג קבצים וקישורים אחד שנפתח על ידי היישום הזה"
+msgstr[1] "‫%u סוגי קבצים וקישורים שנפתחים על ידי היישום הזה"
+msgstr[2] "‫%u סוגי קבצים וקישורים שנפתחים על ידי היישום הזה"
+msgstr[3] "‫%u סוגי קבצים וקישורים שנפתחים על ידי היישום הזה"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "‫<b>%s</b> משמש לפתיחת סוגי הקבצים והקישורים הבאים."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "‫%s משטח הכונן מנוצלים."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "יישומים"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "אין יישומים"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "מתבצעת התקנה…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "פתיחה"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "הצגת פרטים"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16 panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252 panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "חיפוש"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "קבלת חיפושי מערכת ושליחת התוצאות."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804 panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478 subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "מושבת"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "התראות"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "הצגת התראות מערכת."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "פעילות ברקע"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "לאפשר פעילות כשהיישום סגור."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "צילומי מסך"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "צילום המסך בכל רגע."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "החלפת רקע"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "החלפת רקע שולחן העבודה."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "שמע"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "הפקת צלילים."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "מניעת צירופי מקשים"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "חסימת צירופי מקשי המערכת הרגילים."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "מצלמה"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "צילום עם המצלמה."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "מיקרופון"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "הקלטת שמע עם המיקרופון."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "שירותי איכון"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "גישה לנתוני המיקום של המכשיר."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "הרשאות מובנות"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "גישה למערכת לדרישת היישום"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "שיוכי קבצים וקישורים"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "אחסון"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "לא נמצאו תוצאות"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210 shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "יש לנסות חיפוש שונה"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "שיוכי קבצים וקישורים"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "סוגי קבצים"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "סוגי קישורים"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "איפוס"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid "How much disk space this application is occupying with app data and caches."
+msgstr "כמות האחסון על הדיסק בשימוש על ידי היישום לטובת אחסון מידע ונתוני מטמון."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "יישום"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "מידע"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "מטמון"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "‫<b>סך הכול</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "ניקוי מטמון…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "שליטה בהגדרות והרשאות של מספר יישומים"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "יישומים;flatpak;הרשאות;השראה;יישום;אפליקציה;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "בחירת תמונה"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125 panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866 panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269 panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594 panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17 panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_ביטול"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270 panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_פתיחה"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "מגוון גדלים"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d ×‏ %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "אין רקע לשולחן העבודה"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "הרקע הנוכחי"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "סגנון"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "בררת מחדל"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "כהה"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "רקע"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "הוספת תמונה…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "מראה"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "החלפת תמונת הרקע או צבעי ממשק המשתמש"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "רקע;תמונת רקע;צג;מסך;שולחן עבודה;סגנון;בהיר;כהה;סטייל;מראה;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "לאפשר"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "לא נמצא מתאם בלוטות'"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "יש לחבר מתאם על מנת להשתמש בבלוטות’."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "התקן הבלוטות' כבוי"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "יש להפעיל על מנת להתחבר להתקנים ולקבל העברות קבצים."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "מצב טיסה מופעל"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "‏בלוטות' מושבת כאשר מצב טיסה מופעל."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "לכבות מצב טיסה"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "מצב טיסה חומרתי מופעל"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "יש לכבות את מצב הטיסה על מנת לאפשר בלוטות'."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "בלוטות'"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "הפעלה וכיבוי של הבלוטות' והתחברות להתקנים שלך"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "שיתוף;לשתף;Bluetooth;obex;בלוטות';"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "המצלמה כבויה"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "אף יישום לא יכול לצלם תמונה או סרטון."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling the "
+"camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"שימוש במצלמה מאפשר ליישומים לצלם תמונות וסרטים. השבתת המצלמה עשויה לגרום לכמה "
+"יישומים לא לעבוד כראוי..\n"
+"\n"
+"מתן אפשרות ליישומים הבאים להשתמש במצלמה שלך."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "אף יישום לא ביקש גישה למצלמה"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "הגנה על התמונות שלך"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"מצלמה;תמונות;תמונה;וידאו;סרט;סרטון;סרטים;מצלמת רשת;מצלמת אינטרנט;נעילה;מנעול;"
+"פרטיות;פרטי;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "יש להציב את התקן הכיול שלך על הריבוע וללחוץ על „התחלה“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid "Move your calibration device to the calibrate position and press “Continue”"
+msgstr "יש להעביר את התקן הכיול שלך לעמדת הכיול וללחוץ „המשך”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid "Move your calibration device to the surface position and press “Continue”"
+msgstr "יש להעביר את התקן הכיול שלך למשטח הכיול וללחוץ „המשך”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "סגירת המסך במחשב נייד"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "אירעה שגיאה פנימית שלא ניתן להתאושש ממנה."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "הכלים הנדרשים לכיול אינם מותקנים."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "לא ניתן לייצר את הפרופיל."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "יעד נקודת הלובן אינו בר השגה."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "הושלם!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "הכיול נכשל!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "ניתן להסיר את התקן הכיול."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "נא לא להפריע להתקן הכיול במהלך ההתקדמות"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "כיול התצוגה"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "ה_תחלה"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "ה_משך"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_סיום"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "מסך של מחשב נייד"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "מצלמה מובנית"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "צג %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "סורק %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "מצלמת %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "מדפסת %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "מצלמת רשת %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "הפעלת ניהול צבע עבור %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "הצגת פרופילי צבע עבור %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "ללא כיול"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "בררת מחדל: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "מרחב צבעים: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "פרופיל בדיקה: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "בחירת פרופיל ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "יי_בוא"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "פרופילי ICC נתמכים"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "כל הקבצים"
+
+#: panels/color/cc-color-panel.c:586 panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "מסך"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "שמירת הפרופיל"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_שמירה"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "יצירת פרופיל צבע עבור ההתקן הנבחר"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "התקן המדידה לא זוהה. נא לבדוק כי הוא פועל ומחובר כראוי."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "התקן המדידה אינו תומך ביצירת פרופילים למדפסות."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "סוג ההתקן אינו נתמך נכון לעכשיו."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "כיול מסך"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "איכות הכיול"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your screen. "
+"The longer you spend on calibration, the better the quality of the color profile."
+msgstr ""
+"הכיול ייצר פרופיל שניתן להשתמש בו לנהל את צבעי המסך שלך. ככל שהכיול יארך זמן רב "
+"יותר איכות פרופיל הצבע תהיה טובה יותר."
+
+#: panels/color/cc-color-panel.ui:28
+msgid "You will not be able to use your computer while calibration takes place."
+msgstr "לא יהיה ניתן להשתמש במחשב שלך בזמן הכיול."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "איכות"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "הזמן המוערך"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "התקן הכיול"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "נא לבחור את התקן החישה לטובת כיול."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "סוג התצוגה"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "נא לבחור את סוג הצג המחובר."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "נקודת הלובן של הפרופיל"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a D65 "
+"illuminant."
+msgstr "יש לבחור נקודת יעד לבנה. רוב הצגים צריכים להיות מכוילים לתאורת D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "בהירות התצוגה"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color management "
+"will be most accurate at this brightness level."
+msgstr ""
+"נא להגדיר את התצוגה לבהירות אופיינית לך. ניהול צבע יהיה מדויק ביותר ברמת בהירות זו."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr "לחלופין, ניתן להשתמש ברמת בהירות שבשימוש אחד הפרופילים האחרים למכשיר זה."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "שם הפרופיל"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles for "
+"different lighting conditions."
+msgstr ""
+"ניתן להשתמש בפרופיל צבע על מחשבים שונים, או אפילו ליצור פרופילים לתנאי תאורה שונים."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "שם הפרופיל:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "תקציר"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "הפרופיל נוצר בהצלחה!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "העתקת פרופיל"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "דרושה מדיה לכתיבה"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux\">GNU/"
+"Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows\">Microsoft "
+"Windows</a> systems useful."
+msgstr ""
+"יכול להיות שההנחיות הבאות על אופן השימוש בפרופיל תחת <a href=\"linux\">GNU/לינוקס</"
+"a>, <a href=\"osx\">Apple OS X</a> ו־<a href=\"windows\">Microsoft Windows</a> "
+"יביאו לך תועלת."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "הוספת פרופיל"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show details.</"
+"a>"
+msgstr "התגלו בעיות. אולי הפרופיל לא יעבוד כראוי. <a href=\"\">הצגת פרטים.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_ייבוא קובץ…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "הו_ספה"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "לכל התקן דרוש פרופיל צבע עדכני כדי שניתן יהיה לנהל אותו לפי צבע."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434 panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "מידע נוסף"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "מידע נוסף בנוגע לניהול צבעים"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "ה_גדרה לכל המשתמשים"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "הגדרת פרופיל זה לכל המשתמשים במחשב זה"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "ה_פעלה"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "הו_ספת פרופיל"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_כיול…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "כיול ההתקן"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "ה_סרת פרופיל"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_צפייה בפרטים"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "לא ניתן לזהות התקנים כלשהם שניתן לנהל בהם את הצבע"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "מקרן"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "פלזמה"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "‏LCD ‏(CCFL תאורה אחורית)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "‏LCD ‏(RGB LED תאורה אחורית)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "‏LCD (תאורת LED אחורית)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "טווח צבעים רחב LCD ‏(CCLF תאורה אחורית)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "טווח צבעים רחב LCD ‏(RGB LED תאורה אחורית)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "גבוהה"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 דקות"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "בינונית"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "חצי שעה"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "נמוכה"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "רבע שעה"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "טבעי לתצוגה"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (הדפסה והוצאה לאור)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (צילום וגרפיקה)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "מרחב רגיל"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "בדיקת הפרופיל"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "אוטומטית"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "איכות נמוכה"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "איכות בינונית"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "איכות גבוהה"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "בררת מחדל RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "בררת מחדל CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "בררת מחדל גווני אפור"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "נתוני כיול שסופקו על ידי היצרן"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "תיקון תצוגת מסך מלא אינו אפשרי עם פרופיל זה"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "יתכן שפרופיל זה אינו מדויק עוד"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "צבע"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid "Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "כיול הצבע של ההתקנים שלך כגון צגים, מצלמות או מדפסות"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "צבע;ICC;פרופיל;כיול;מדפסת;צג;תצוגה;מסך;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "אחר…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "בחירת שפה"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "ב_חירה"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "לא נמצאו שפות"
+
+#: panels/common/cc-language-chooser.ui:69 panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "עוד…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "יש לשחרר לשינוי הגדרות"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "יש לשחרר חלק מההגדרות בכדי לבצע בהן שינויים."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "שחרור…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "הוספת שעה"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "הוספת דקה"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "זמן"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "הפחתת שעה"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "הפחתת דקה"
+
+#: panels/common/cc-util.c:127 panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "היום"
+
+#: panels/common/cc-util.c:131 panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "אתמול"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e ב%b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e ב%b, 2013"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "שעה"
+msgstr[1] "שעתיים"
+msgstr[2] "‫%d שעות"
+msgstr[3] "‫%d שעות"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "דקה"
+msgstr[1] "שתי דקות"
+msgstr[2] "‏‫%d דקות"
+msgstr[3] "‏‫%d דקות"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "שנייה"
+msgstr[1] "שתי שניות"
+msgstr[2] "‫%d שניות"
+msgstr[3] "‏‫%d שניות"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "‏%s, ‏%s ו־%s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "‏%s ו־%s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "‏%s ו־%s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 שניות"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "נקודה חמה"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 שעות"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e ב%B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e ב%B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "‎%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "תאריך ושעה"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "שנה"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "חודש"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "ינואר"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "פברואר"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "מרץ"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "אפריל"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "מאי"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "יוני"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "יולי"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "אוגוסט"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "ספטמבר"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "אוקטובר"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "נובמבר"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "דצמבר"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "יום"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "זמן"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "חיפוש עיר"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "תאריך ושעה _אוטומטיים"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "נדרש חיבור לאינטרנט"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "תאריך ו_שעה"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "אזור _זמן אוטומטי"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "נדרשת גישה לשירותי מיקום וחיבור לאינטרנט"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212 panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802 panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "פעיל"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "_אזור זמן"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_תבנית זמן"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "החלפת השעה והתאריך לרבות אזור הזמן"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "שעון;אזור זמן;מיקום;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "שינוי הגדרות השעה והתאריך של המערכת"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "כדי לשנות את הגדרות השעה או התאריך עליך להזדהות."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_אינטרנט"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_דוא״ל"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_לוח שנה"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "מו_זיקה"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_וידאו"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "תמו_נות"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "יישומי בררת המחדל"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "הגדרת יישומי בררת המחדל"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "ברירת מחדל;בררת מחדל;דפאולט;יישום;יישומים;מאפיינים;הגדרות;הגדרה;מדיה;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"שליחת דיווחים על בעיות טכניות תעזור לנו לשפר את %s. הדיווחים נשלחים בעילום שם וללא "
+"מידע אישי. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "דיווח על בעיות"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "דיווח בעיות _אוטומטית"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "אבחון"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "דיווח על בעיות"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "אבחון;אבחנה;קריסה;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "פעיל"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "כבוי"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "להחיל שינויים?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "אי אפשר להחיל את השינויים"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "אולי זה קשור למגבלות חומרה."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "ה_חלה"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64 panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31 panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "חזרה"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "הגדרות הצג מושבתות"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "צגים מרובים"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "הצטרפות"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "מראה"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "מכיל את השורה העליונה וכפתור פעילויות"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "צג ראשי"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177 panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "תאורת לילה"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "לרוחב"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "ימין לאורך"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "שמאל לאורך"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "לרוחב (הפוך)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "‏%.2lf הרץ"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "כיוון"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "הבחנה"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "תדירות רענון"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "התאמה לטלויזיה"
+
+#: panels/display/cc-display-settings.ui:78 panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "גודל"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "תאורת לילה לא זמינה"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop being "
+"used remotely"
+msgstr "יתכן וזה כתוצאה מההתקן הגרפי שבשימוש, או מכך ששולחן העבודה בשימוש מרחוק"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "להשבית באופן זמני עד מחר"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "הפעלה מחדש של המסננים"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye strain and "
+"sleeplessness."
+msgstr ""
+"תאורת לילה משנה את צבע המסך לצבע חם יותר. אפשרות זו מפחיתה את העומס על העיניים "
+"הגורם לעייפות."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "לוח זמנים"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "מהשקיעה עד לזריחה"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "לוח זמנים מותאם"
+
+#: panels/display/cc-night-light-page.ui:154 panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "זמנים"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "מ־"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "שעה"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "דקה"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "עד"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "טמפרטורת הצבע"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "צגים"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "בחירה כיצד להשתמש בצגים ובמקרנים מחוברים"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;"
+"color;sunset;sunrise;"
+msgstr ""
+"לוח;מקרן;xrandr;צג;מסך;רזולוציה;הבחנה;רענון;צג;לילה;אור;תאורה;כחול;היסט לאדום;צבע;"
+"שקיעה;זריחה;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "הפעלה מאובטחת פעילה"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts. "
+"It is currently turned on and is functioning correctly."
+msgstr ""
+"הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן. היא פעילה כעת ופועלת "
+"בצורה תקינה."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "יש בעיות בהפעלה מאובטחת"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts. "
+"It is currently turned on, but will not work due to having an invalid key."
+msgstr ""
+"הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן. היא פעילה כעת, אך לא "
+"תעבוד עקב מפתח לא תקף."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI firmware "
+"settings (BIOS) and your hardware manufacturer may provide information on how to "
+"do this."
+msgstr ""
+"לעתים קרובות ניתן לפתור בעיות בהפעלה מאובטחת מהגדרות קָשְחת UEFI ‏(BIOS) של המחשב. "
+"יצרן החָמְרָה שלך עשוי לספק מידע כיצד לעשות זאת."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "לעזרה, יש ליצור קשר עם יצרן החָמְרָה או עם תמיכת ה־IT של הספק."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "הפעלה מאובטחת אינה פעילה"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts. "
+"It is currently turned off."
+msgstr ""
+"הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן. היא אינה פעילת כעת."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware settings "
+"(BIOS). For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"לעתים קרובות ניתן להפעיל את ההפעלה המאובטחת מהגדרות קָשְחת UEFI ‏(BIOS) של המחשב. "
+"למידע נוסף, יש ליצור קשר עם יצרן החָמְרָה או עם תמיכת ה־IT של הספק."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"הפעלה מאובטחת מגנה מפני טעינה של תכנה זדונית עם הפעלת ההתקן.\n"
+"\n"
+"למידע נוסף, יש ליצור קשר עם יצרן החומרה או עם תמיכת IT."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "עבר"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "נכשל"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "ההתקן תואם לרמת HSI (מזהה אבטחת מארח)‏ %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "רמת אבטחה 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could be "
+"because of a hardware or firmware configuration issue. It is recommended to "
+"contact your IT support provider."
+msgstr ""
+"להתקן זה אין הגנה כנגד בעיות אבטחת חָמְרָה. יתכן וזה נובע מהגדרות חומרה או קָשְחה. "
+"מומלץ ליצור קשר עם ספק תמיכת ה־IT שלך."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "רמת אבטחה 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is the "
+"lowest device security level and only provides protection against simple security "
+"threats."
+msgstr ""
+"להתקן זה הגנה מזערית כנגד בעיות אבטחת חָמְרָה. זוהי הרמה הנמוכה ביותר של הגנת התקן "
+"המספקת הגנה למול איומי אבטחה בסיסיים בלבד."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "רמת אבטחה 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This provides "
+"protection against some common security threats."
+msgstr ""
+"להתקן זה הגנה בסיסית כנגד בעיות אבטחת חָמְרָה. זה מספק הגנה מפני איומי אבטחה נפוצים."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "רמת אבטחה 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This is the "
+"highest device security level and provides protection against advanced security "
+"threats."
+msgstr ""
+"להתקן זה אבטחה מורחבת כנגד בעיות אבטחת חָמְרָה. זוהי הרמה הגבוה ביותר של הגנת התקן "
+"המספקת הגנה מפני איומי אבטחה מתקדמים."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "רמת אבטחה"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "רמות אבטחה אינן זמינות עבור התקן זה."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr "יש ליצור קשר עם יצרן החָמְרָה לעזרה בנושא עדכוני אבטחה."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware settings, "
+"or by a support technician."
+msgstr "יתכן שניתן לפתור בעיה זו בהגדרות קָשְחת UEFI של ההתקן, או על ידי תמיכה טכנית."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware settings."
+msgstr "יתכן שניתן לפתור בעיה זו בהגדרות קָשְחת UEFI של ההתקן."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "ייתכן שניתן לפתור בעיה זו על ידי תמיכה טכנית."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "רמת 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "רמת 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "רמת 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "הגנה כנגד תכנות זדוניות בזמן הפעלת ההתקן."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "יש בעיות בהפעלה מאובטחת"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "קצת הגנה בזמן שההתקן מופעל."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "הפעלה מאובטחת כבויה"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "אין הגנה בזמן שההתקן מופעל."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on this "
+"system."
+msgstr ""
+"יתכן ובעיה זו נגרמה בגלל שינוי בהגדרות קָשְחת UEFI, שינוי תצורת מערכת ההפעלה או בגלל "
+"תכנה זדונית במערכת זו."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, or "
+"because of malicious software on this system."
+msgstr ""
+"יתכן ובעיה זו נגרמה בגלל שינוי בהגדרות קָשְחת UEFI או בגלל תכנה זדונית במערכת זו."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration change, or "
+"because of malicious software on this system."
+msgstr ""
+"יתכן ובעיה זו נגרמה בגלל שינוי תצורת מערכת ההפעלה או בגלל תכנה זדונית במערכת זו."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "חשוף לאיומי אבטחה רציניים."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "הגנה מוגבלת כנגד איומי אבטחה פשוטים."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "הגנה כנגד איומי אבטחה נפוצים."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "הגנה כנגד מנעד רחב של אימוי אבטחה."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "הגנה מקיפה"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "אין אירועים"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "הגנת כתיבה לקָשְחה"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "נעילת הגנת כתיבת קושחה"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "תחום קָשְחת BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "תיאור קָשְחת BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "הגנת DMA קדם־אתחול"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "טעינה מאומתת של Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "ACM מוגן של Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "מדיניות שגיאה של Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "מיזוג של Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET מאופשר"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET פעיל"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "‏RAM מוצפן"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "הגנת IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "נעילת ליבת לינוקס"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "אימות ליבת לינוקס"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "מחיצת החלפה לינוקס"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "השהיה ל־RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "השהיה להמתנה"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "מפתח פלטפורמת UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "אתחול UEFI מאובטח"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "הגדרות פלטפורמת TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "בנייה מחדש של TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "מצב ייצור של מנוע הניהול של אינטל"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "מעקף של מנגנון הניהול של אינטל"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "גרסת מנגנון הניהול של אינטל"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "עדכוני קָשְחה"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "תעודת קָשְחה"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "עדכון אימות קָשְחה"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "ניפוי שגיאות בפלטפורמה"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "בדיקות אבטחת מעבד"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "הגנת שחזור של AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "הגנת הפעלה מחדש של קושחת AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "הגנת כתיב לקושחת AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "פלטפורמה ממוזגת"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "תקף"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "לא תקף"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "לא מאופשר"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "נעולה"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "לא נעול"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "מוצפן"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "לא מוצפן"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "מזוהם"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "לא מזוהם"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "נמצא"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "לא נמצא"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "נתמך"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "לא נתמך"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "אבטחת התקן"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "מצב אבטחת קָשְחת המארח"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
+"identity;privacy;"
+msgstr ""
+"מסך;צד;נעילה;ניתוח;דיאגנוסטיקה;קריסה;פרטיות;פרטי;אחרונים;אחרון;זמני;זמניים;מפתח;"
+"אינדקס;שם;רשת;זהות;פרטיות;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "לא ידוע"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64 סיביות"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32 סיביות"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "לא ידוע"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "לא זמין"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "לוגו המערכת"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "שם ההתקן"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "דגם חומרה"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "זיכרון"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "מעבד"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "גרפיקה"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "קיבלות דיסק"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "מתבצע חישוב…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "שם מערכת הפעלה"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "מזהה בניית מערכת הפעלה"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "סוג מערכת הפעלה"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "גרסת GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "בטעינה…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "מערכת חלונות"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "הדמייה"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "עדכוני תכנה"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "שינוי שם התקן"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr "שם ההתקן משמש לזיהוי ההתקן על גבי הרשת, או בעת צימוד לבלוטות'."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "שם התקן"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_שינוי שם"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "אודות"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "צפייה בפרטים על המערכת שלך"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"התקן;מערכת;מידע;שם מארח;שם;מארח;זיכרון;זכרון;זיכרון;מעבד;גרסה;בררת מחדל;ברירת מחדל;"
+"דפאולט;יישום;העדפות;העדפה;CD;DVD;USB;התקן חיצוני;פלאש;שמע;צליל;וידאו;סרט;סרטון;"
+"מדיה;מדיה נתיקה;נשלף;נתיק;מדיה נשלפת;הפעלה אוטומטית;תקליטור;דיסק;אודיו;חוזי;גיבוי;"
+"העדפה;גרסה;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "שמע ומדיה"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "השתקה או הפעלת שמע"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "הנמכת עצמת השמע"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "הגברת עצמת השמע"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "השתקה או הפעלת מיקרופון"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "הפעלת נגן המולטימדיה"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "נגינה (או נגינה/השהיה)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "השהיית הנגינה"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "עצירת הנגינה"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "הרצועה הקודמת"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "הרצועה הבאה"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "שליפה"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "הקלדה"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "מעבר למקור הקלט הבא"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "מעבר למקור הקלט הקודם"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "משגרים"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "הפעלת דפדפן העזרה"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "הפעלת המחשבון"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "הפעלת לקוח דוא״ל"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "הפעלת דפדפן האינטרנט"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "תיקיית הבית"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "חיפוש"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "מערכת"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "יציאה"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "נעילת המסך"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "נגישות"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "הפעלה/השבתה של תכונת התקריב"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "התקרבות"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "התרחקות"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "הפעלה/השבתה של מקריא המסך"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "הצגת/הסתרת מקלדת על־גבי המסך"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "הגדלת הטקסט"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "הקטנת הטקסט"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "ביטול/הפעלה של ניגודיות גבוהה"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "לא נמצא מקור קלט"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "אחר"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "הוספת מקור קלט"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "לא ניתן להשתמש בשיטות קלט במסך הכניסה"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "לא נבחר מקור קלט"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "אפשרויות"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "הזזה למעלה"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "הזזה למטה"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "העדפות"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "הצגת פריסת המקלדת"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "הסרה"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "צירופי מקשים מותאמים"
+
+#: panels/keyboard/cc-keyboard-panel.c:64 panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "מקש לתווים חלופיים"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. These are "
+"sometimes printed as a third-option on your keyboard."
+msgstr ""
+"מקש לתווים חלופיים יכול לשמש להזנת תווים נוספים. לעתים זה מופיע כאפשרות שלישית "
+"במקלדת שלך."
+
+#: panels/keyboard/cc-keyboard-panel.c:67 panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "‏Alt שמאלי"
+
+#: panels/keyboard/cc-keyboard-panel.c:68 panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "‏Alt ימני"
+
+#: panels/keyboard/cc-keyboard-panel.c:69 panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "‏Super שמאלי"
+
+#: panels/keyboard/cc-keyboard-panel.c:70 panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "‏Super ימני"
+
+#: panels/keyboard/cc-keyboard-panel.c:71 panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "מקש תפריט"
+
+#: panels/keyboard/cc-keyboard-panel.c:72 panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "‏Ctrl ימני"
+
+#: panels/keyboard/cc-keyboard-panel.c:80 panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "מקש Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use it, "
+"press compose then a sequence of characters.  For example, compose key followed by "
+"<b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by <b>'</b> will "
+"enter <b>á</b>."
+msgstr ""
+"מקש Compose מאפשר הקלדת מגוון רחב של תווים. כדי להשתמש בו, יש ללחוץ על Compose ואז "
+"על צירוף תווים.  למשל, מקש Compose שלאחריו נלחצים <b>C</b> ואז <b>o</b> יקליד "
+"<b>©</b>, ‏<b>a</b> ולאחריו <b>’</b> יקליד <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "‫Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "צילום מסך"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"ניתן לשנות את מקורות הקלט באמצעות קיצור המקלדת %s.\n"
+"‬\n"
+"‫בהגדרות קיצורי המקלדת אפשר לשנות את ההגדרה הזאת."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "מקורות הקלט"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "כולל פריסות מקלדת ושיטות קלט."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "החלפת מקורות קלט"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "שימוש באותו המקור ל_כל החלונות"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "החלפת מקורות קלט עבור כל חלון _בנפרד"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "מילוי תווים מיוחדים"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "שיטות למילוי סימנים והגווני אותיות באמצעות המקלדת."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "צירופי מקשים"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "הצגה והתאמה של קיצורי מקשים"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "‫%d נערך"
+msgstr[1] "‫%d נערכו"
+msgstr[2] "‫%d נערכו"
+msgstr[3] "‫%d נערכו"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "איפוס כל צירופי המקשים?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be undone."
+msgstr ""
+"איפוס צירופי המקשים עשוי להשפיע על ההתאמה האישית של המקלדת שלך. לא נתן לבטל פעולה "
+"זאת."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83 panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "ביטול"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "איפוס הכול"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "איפוס של הכול…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "איפוס כל צירופי המקשים לערכי ברירת המחדל"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "אגף"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "צירופי מקשים"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "הוספת צירוף מקשים"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "הוספת צירוף מקשים מותאם"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "הגדרת צירופי מקשים מותאמים להפעלת יישומים, הרצת תסריטים ועוד."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "הוספת קיצור דרך"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "לא נמצאו צירופי מקשים"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "‫%s כבר בשימוש על ידי %s. החלפה שלו, תשבית את %s"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "יש להקיש את צירוף המקשים החדש"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "הגדרת צירופי מקשים מותאמים אישית"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "הגדרת צירופי מקשים"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "יש להקיש צירופי מקשים חדשים לשינוי ‏%s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "הוספת צירוף מקשים חדש"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "הס_רה"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_החלפה"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39 panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "ה_גדרה"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "יש ללחוץ Esc לביטול או Backspace להשבתת צירופי המקשים."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137 panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "שם"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "פקודה"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "קיצור"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "הגדרת צירופי מקשים…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "ללא"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "איפוס צירופי המקשים לערך בררת המחדל"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "מקלדת"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts and "
+"input sources"
+msgstr "החלפת קיצורי המקשים שלך והגדרת העדפות ההקלדה, פריסות המקלדת ומקורות הקלט"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"צירופי מקשים;קיצורי מקשים;מרחב עבודה;חלון;חלונות;שינוי גודל;הגדלה;ניגודיות;קלט;"
+"מקור;נעילה;עצמה;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "שירותי האיכון מושבתים"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "אף יישום לא יכול לקבל מידע על המיקום שלך."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and mobile "
+"broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/"
+"privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"שירותי איכון מאפשרים ליישומים לקבל את המיקום שלך. שימוש ברשת אלחוטית וברשת סלולרית "
+"מגביר את דיוק האיכון.\n"
+"\n"
+"שימוש בשירות האיכון של מוזילה: <a href='https://location.services.mozilla.com/"
+"privacy'>מדיניות פרטיות</a>.\n"
+"\n"
+"מתן אפשרות ליישומים הבאים לאכן את המיקום שלך."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "אף יישום לא ביקש גישה למיקום"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "הגנה על פרטי המיקום שלך"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "מיקום;gps;GPS;פרטיות;איכון;ג'י פי אס;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "המיקרופון כובה"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "אף יישום לא יכול להקליט שמע."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. Disabling "
+"the microphone may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"שימוש במיקרופון מאפשר ליישומים להקליט ולהשמיע שמע. השבתת המיקרופון עשויה לגרום "
+"לחלק מהיישומים להיות לא שמישים.\n"
+"\n"
+"מתן אפשרות ליישומים הבאים להשתמש במיקרופון שלך."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "אף יישום לא דרש גישה למיקרופון"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "הגנה על השיחות שלך"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "מיקרופון;הקלטה;יישום;פרטיות;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "ב_דיקת ההגדרות שלך"
+
+#: panels/mouse/cc-mouse-panel.ui:23 panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "כללי"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "לחצן ראשי"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "הגדרת סדר הכפתורים הפיזיים על עכברים ומשטחי מגע."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "שמאל"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "ימין"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "עכבר"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "מהירות העכבר"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "גלילה טבעית"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "גלילה מזיזה את התוכן, לא את התצוגה."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "משטח מגע"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "מהירות משטח מגע"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "הקשה היא לחיצה"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "הקשה היא לחיצה"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "גלילה בשתי אצבעות"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "קצה גלילה"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "נא לנסות ללחוץ, ללחוץ לחיצה כפולה, לגלול"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "חמש לחיצות, זכית בעז!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "לחיצה כפולה, לחצן ראשי"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "לחיצה בודדת, לחצן ראשי"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "לחיצה כפולה, לחצן אמצעי"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "לחיצה בודדת, לחיצה אמצעית"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "לחיצה כפולה, לחצן משני"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "לחיצה בודדת, לחצן משני"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "עכבר ומשטח מגע"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid "Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "שינוי העכבר שלך או רגישות משטח מגע ובחירת לחצן ראשי ימני או שמאלי"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "משטח מגע;סמן;לחיצה;טפיחה;כפולה;לחצן;כדור שליטה;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_פינה חמה"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "נגיעה בפינה הימנית העליונה תפתח את סקירת הפעילויות."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_קצוות מסך פעילים"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid "Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"גרירה של החלונות כלפי השוליים העליונים, שמאליים וימנים של המסך תשנה את גודלם."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "מרחבי עבודה"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "מרחבי עבודה _גמישים"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "מסיר מרחבי עבודה ריקים אוטומטית."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "מספר _קבוע של מרחבי עבודה"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "נא לציין מספר של מרחבי עבודה קבועים."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "מ_ספר מרחבי עבודה"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "ריבוי צגים"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "מרחבי עבודה בצג ה_ראשי בלבד"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "מרחבי עבודה ב_כל הצגים"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "החלפת יישומים"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "לכלול יישומים מ_כל מרחבי העבודה"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "לכלול יישומים ממרחב העבודה ה_נוכחי בלבד"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "ריבוי משימות"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "ניהול העדפות ליעילות וריבוי משימות"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"ריבוי משימות;ביצוע מפוצל;יעילות;פרודוקטיביות;מולטיטאסקינג;מולטיטסקינג;התאמה;שינוי;"
+"עריכה;שולחן עבודה;התאמה אישית;נקודה חמה;פינה חמה;שולחנות עבודה;מרחבי עבודה;שולחן "
+"עבודה;מרחב עבודה;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "אופס, משהו השתבש. נא ליצור קשר עם ספק התכנה שלך."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "‏NetworkManager צריך לפעול."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "התקנים אחרים"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "הוספת התחברות"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "לא מוגדר"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "‏%s ‏(SSID: ‏%s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "רשת לא מאובטחת (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "רשת מאובטחת (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "רשת מאובטחת (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "רשת מאובטחת (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "רשת מאובטחת"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "מחובר"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325 panels/network/network-bluetooth.ui:22
+#: panels/network/network-ethernet.ui:56 panels/network/network-mobile.ui:329
+#: panels/network/network-proxy.ui:62 panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "אפשרויות…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible to "
+"access the internet through Wi-Fi."
+msgstr ""
+"הפעלת נקודה חמה תגרום ניתוק מ־%s, וכן לא תתאפשר גישה לרשת דרך אינטרנט אלחוטי."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "חובה 8 תווים לכל הפחות"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "חייב להיות לפחות תו אחד"
+msgstr[1] "חייבים להיות לפחות שני תווים"
+msgstr[2] "חייבים להיות לפחות %d תווים"
+msgstr[3] "חייבים להיות לפחות %d תווים"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "הפעלת נקודת חמה אלחוטית?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a Wi-Fi "
+"network that they can connect to. To do this, you must have an internet connection "
+"through a source other than Wi-Fi."
+msgstr ""
+"נקודה חמה אלחוטית תאפשר לאחרים לשתף בחיבור האינטרנט שלך, על ידי יצירת רשת אלחוטית "
+"שהם יכולים להתחבר אליה. על מנת לעשות זאת, ברשותך חייב להיות חיבור לאינטרנט דרך "
+"מקור שאינו רשת אלחוטית."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "שם הרשת"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338 panels/printers/pp-jobs-dialog.ui:54
+#: panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "ססמה"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "יצירת ססמה אקראית"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "יצירת ססמה אקראית באופן אוטומטי"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "ה_פעלה"
+
+#: panels/network/cc-wifi-panel.c:549 panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "רשת אלחוטית"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "לעצור את נקודת הגישה ולנתק את כל המשתמשים ?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_עצירת נקודת הגישה"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "מצב טיסה"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "השבתת רשת אלחוטית, בלוטות' ורשת סלולרית"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "לא נמצא מתאם לרשת אלחוטית"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "יש לוודא כי ברשותך מתאם לרשת אלחוטית מחובר ופועל"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "מצב טיסה פועל"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "יש לכבות על מנת להשתמש ברשת האלחוטית"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "נקודת גישה אלחוטית פעילה"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "התקנים ניידים יכולים לסרוק את קוד ה־QR כדי להתחבר."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "_כיבוי נקודת גישה…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "רשתות גלויות"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "‏NetworkManager צריך להיות פעיל"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_אבטחת 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "אבטחה"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "שמירה"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "קבוע"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "אקראי"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "יציב"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the network "
+"device this connection is activated on. This feature is known as MAC cloning or "
+"spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"כתובת ה־MAC שהוזנה כאן תשמש ככתובת החומרה של התקן הרשת המחובר ופועל. תכונה זו "
+"ידועה כשיבוט או זיוף כתובת MAC (באנגלית: cloning או spoofing). לדוגמה: "
+"00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "פרופיל %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "פתוחה מורחבת"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "ארגוני"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "ללא"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "לעולם לא"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "אתמול"
+msgstr[1] "שלשום"
+msgstr[2] "לפני %i ימים"
+msgstr[3] "לפני %i ימים"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "‏%d מ״ב/שנייה (%1.1f גה״צ‏)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "‏%d מ״ב/שנייה"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "‏5 גה״צ / 2.4 גה״צ"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 גה״צ"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 גה״צ"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "ללא"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "חלש"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "טוב"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "טוב"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "מצוין"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144 panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "כתובת IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146 panels/network/net-device-mobile.c:442
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "כתובת IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149 panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445 panels/network/net-device-mobile.c:446
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "כתובת IP"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166 panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167 panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169 panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453 panels/network/net-device-mobile.c:454
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "לשכוח התחברות"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "הסרת פרופיל התחברות"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "הסרת VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "פרטים"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "אוטומטית"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "זהות"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "מחיקת כתובת"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "מחיקת נתיב"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "ללא"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "מפתח WEP 40‏/128-סיביות (הקסדצימלי או ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "מילת צופן WEP‏ 128-סיביות"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "‏WEP דינמי (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "‏WPA ו־WPA2 אישי"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "‏WPA ו־WPA2 ארגוני"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "‏WPA3 אישי"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "עצמת הקליטה"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "מהירות הקישור"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "כתובת חומרה"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "תדרים נתמכים"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158 panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162 panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "נתיב בררת המחדל"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "שימוש אחרון"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "התחברות _אוטומטית"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "לאפשר גישה גם למשתמשים _אחרים"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "חיבור _מדוד: יש מגבלת נתונים או שיגרור חיובים נוספים"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid "Software updates and other large downloads will not be started automatically."
+msgstr "עדכוני תכנה והורדות גדולות אחרות לא יתחילו באופן אוטומטי."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_שם"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_כתובת MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "כתובות מ_שוכפלות"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "בתים"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "שיטת IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "אוטומטי (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "קישור מקומי בלבד"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65 panels/network/net-proxy.c:71
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "ידני"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "השבתה"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "שיתוף למחשבים אחרים"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "כתובות"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "כתובת"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "מסכת רשת"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "שער גישה"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237 panels/network/net-proxy.c:73
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "אוטומטי"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS אוטומטי"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "כתובות שרת DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "יש להפריד כתובות IP עם פסיקים"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "ניתובים"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "נתיבים אוטומטיים"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "מטריקה"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "יש להשתמש בחיבור זה _רק עבור משאבים ברשת שלו"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "שיטת IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "אוטומטי, DHCP בלבד"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "קידומת"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "לא ניתן לפתוח את עורך החיבורים"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "פרופיל חדש"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "הגדרה %s לא תקפה: ‏%s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "הגדרה %s לא תקפה"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "יבוא מקובץ…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "הוספת VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_אבטחה"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "לא ניתן לייבא חיבור VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN connection "
+"information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"הקובץ „%s” לא ניתן לקריאה או שאינו מכיל מידע התחברות VPN מוכר\n"
+"\n"
+"שגיאה: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "נא לבחור קובץ לייבוא"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "כבר קיים קובץ בשם „%s“."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "ה_חלפה"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "להחליף את %s בחיבור ה־VPN שנשמר כעת?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "לא ניתן לייצא את חיבור ה־VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"החיבור „%s” לא ניתן לייצוא אל %s.\n"
+"‬\n"
+"‏‫\n"
+"‬\n"
+"‫שגיאה: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "יצוא חיבור VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(שגיאה: לא ניתן לטעון את עורך חיבורי ה־VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "שליטה באופן החיבור לאינטרנט"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"רשת;אלחוטי;אלחוטית;וייפיי;IP;רשת מקומית;מתווך;פרוקסי;אינטרנט;רשת רחבה;רוחב פס;מודם;"
+"בלוטות׳;DNS;vpn;Bluetooth;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "שליטה באופן החיבור לרשת האלחוטית"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"רשת;אלחוטי;אלחוטית;וייפיי;IP;רשת מקומית;מתווך;פרוקסי;אינטרנט;רשת רחבה;רוחב פס;מודם;"
+"בלוטות׳;DNS;נקודה חמה;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "מעולם לא"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "היום"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "אתמול"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "שימוש אחרון"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264 panels/network/network-bluetooth.ui:5
+#: panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "קווי"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "הוספת התחברות חדשה"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any custom "
+"configuration will be lost."
+msgstr "פרטי הרשתות הנבחרות, לרבות ססמאות וכל תצורה אחרת שהותאמה אישית יאבדו."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "הת_עלמות"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "רשתות אלחוטיות לא מוכרות"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "הת_עלמות"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "מדיניות המערכת אוסרת שימוש בנקודה חמה"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "התקן הרשת האלחוטית אינו תומך במצב נקודה חמה"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "נעשה שימוש בזיהוי אוטומטי של מתווך רשת כאשר לא מסופקת כתובת תצורה."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "מצב זה אינו מומלץ לרשתות ציבוריות שאינן מהימנות."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "כיבוי ההתקן"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "פעיל"
+
+#: panels/network/network-mobile.ui:27 panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI (מס׳ ברזל)"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "ספק"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "מתווך הרשת"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_מתווך HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "מת_ווך HTTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "מתוו_ך FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "מ_ארח Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "הת_עלמות ממארחים"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "הפתחה של מתווך ה־HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "הפתחה של מתווך ה־HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "הפתחה של מתווך ה־FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "הפתחה של מתווך ה־Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "כתובת הת_צורה"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "כיבוי חיבור ה־VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "שם הרשת"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "סוג האבטחה"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "ססמה"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "כיבוי הרשת האלחוטית"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "אפשרויות נוספות…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "התחברות לרשת _נסתרת…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_הפעלת נקודת גישה…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "רשתות אלחוטיות לא _ידועות"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "המצב אינו ידוע"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "לא מנוהל"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "לא זמין"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "בהתחברות"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "נדרש אימות"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "מתבצע ניתוק"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "החיבור נכשל"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "המצב אינו ידוע (חסר)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "התצורה נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "תצורת ה־IP נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "תצורת ה־IP פגה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "נדרשו סודות אך לא סופקו"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "משלים ה־802.1x מנותק"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "תצורת משלים ה־802.1x נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "משלים ה־802.1x נכשל"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "למשלים ה־802.1x לקח זמן רב מדי ליצור אימות"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "הפעלת שירות ה־PPP נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "שירות ה־PPP מנותק"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "ה־PPP נכשל"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "הפעלת לקוח ה־DHCP נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "שגיאת לקוח DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "לקוח ה־DHCP נכשל"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "הפעלת שירות שיתוף החיבורים נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "שירות החיבור השיתופי נכשל"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "הפעלת שירות ה־AutoIP נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "שגיאה בשירות AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "שירות ה־AutoIP נכשל"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "הקו תפוס"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "אין צליל חיוג"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "לא ניתן ליצור קשר עם אף ספק"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "הזמן שהוקצב לבקשת החיוג פג"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "ניסיון החיוג נכשל"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "הפעלת המודם נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "הבחירה ב־APN הזה נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "לא מחפש אחר רשתות"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "הרישום ברשת נדחה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "הזמן שהוקצב לרישום לרשת פג"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "הרישום לרשת המבוקשת נכשל"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "בדיקת ה־PIN נכשלה"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "ייתכן שחסרה קושחה עבור ההתקן"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "החיבור נעלם"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "החיבור הנוכחי התבצע לפי הנחות"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "המודם לא נמצא"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "חיבור הבלוטות' נכשל"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "לא הוכנס כרטיס SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "נדרש ה־Pin של ה־SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "נדרש ה־Puk של ה־SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "ה־SIM שגוי"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "תלות החיבור נכשלה"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "הקושחה חסרה"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "הכבל מנותק"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "שגיאה לא מוגדרת באבטחת 802.1x ‏(wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "לא נבחר קובץ"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "שגיאה לא ידועה באימות קובץ eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "מפתחות פרטיים מסוג DER, PEM, PKCS#12 או PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "אישורי DER או PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "חסרים הקבצים EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "קובצי PAC‏ (‎*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "אלמוני"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "עם אימות"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "שניהם"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "זהות _אלמונית"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_קובץ PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "בחירת קובץ PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "אימות _פנימי"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "אפשור הקצאת PAC _אוטומטית"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "חסר שם משתמש EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "חסרה ססמת EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_שם משתמש"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152 panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_ססמה"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "ה_צגת ססמה"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "אישור EAP-PEAP CA לא תקף: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "אישור EAP-PEAP CA לא תקף: לא סופקו אישורים"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "גרסה 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "גרסה 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "אישור C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "בחירת אישור של רשות אישורים"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "לא נ_דרש אישור CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_גרסת PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "חסר שם משתמש EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "חסרה ססמת EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "חסר מזהה EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "אישור EAP-TLS CA לא תקף: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "אישור EAP-TLS CA לא תקף: לא סופק אישור"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "מפתח פרטי EAP-TLS לא תקף: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "משתמש אישור EAP-TLS לא תקף: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "מפתחות פרטיים בלתי מוצפנים אינם בטוחים"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This could "
+"allow your security credentials to be compromised. Please select a password-"
+"protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"נראה שהמפתח הפרטי הנבחר לא מוגן על ידי ססמה. זה עלול לסכן את אישורי האבטחה שלך. נא "
+"לבחור מפתח פרטי המוגן בססמה.\n"
+"\n"
+"(ניתן להגן על המפתח הפרטי שלך עם openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "נא לבחור את האישור האישי שלך"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "בחירת המפתח הפרטי שלך"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_זהות"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_אישור המשתמש"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "מפתח _פרטי"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "ססמה למפתח ה_פרטי"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "אישור רשות אישורים מסוג EAP-TTLS לא תקף: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "אישור רשות אישורים מסוג EAP-TTLS לא תקף: לא צוין אישור"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "‏MSCHAPv2 ‏(לא EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "מ_תחם"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "שגיאת אימות אבטחת 802.1x לא ידועה"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS מתועל"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP מאובטח (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_אימות"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "בחירת קובץ"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "חסר שם משתמש leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "חסרה ססמת leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "חסרה ססמת רשת אלחוטית."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_סוג"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "חסר מפתח wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "מפתח wep לא תקף: מפתח באורך %zu חייב להכיל ספרות הקסדצימליות בלבד"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "מפתח wep לא תקף: מפתח באורך %zu חייב להכיל אך ורך תווי ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 (ascii) "
+"or 10/26 (hex)"
+msgstr ""
+"מפתח wep לא תקף: אורך מפתח %zu שגוי. מפתח חייב להיות או באורך 5/13 (‏ascii) או "
+"10/26 (הקסדצימלי)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "מפתח wep לא תקף: ססמה לא יכולה להיות ריקה"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "מפתח wep לא תקף: ססמה חייבת להיות קצרה מ־64 תווים"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (בררת מחדל)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "מערכת פתוחה"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "מפתח משותף"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "מ_פתח"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "ה_צגת מפתח"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "מ_פתח ה־WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex digits"
+msgstr ""
+"‏wpa-psk לא תקף: %zu אורך מפתח לא תקף. חייב להיות [8,63] בתים או 64 ספרות "
+"הקסדצימליות"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "‏wpa-psk לא תקף: לא נתן לפענח מפתח עם 64 בתים כהקסדצילמי"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "ה_תראות"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "ה_תראות צליל"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "התראות _קופצות"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups are "
+"disabled."
+msgstr "התראות עדיין תופענה ברשימה ההתראות כאשר חלוניות קופצות מושבתות."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "הצגת תוכן הודעה בחלונות קופ_צים"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "התראות במסך _נעילה"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "הצגת _תוכן הודעה במסך נעילה"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_נא לא להפריע"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "התראות במסך _נעילה"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "שליטה בהתראות שתוצגנה ומה הן תצגנה"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "התראות;התרעות;באנר;הודעה;אזור דיווחים;הודעה קופצת;חלונית קופצת;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "אחר"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "הסרת %s"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "אירעה שגיאה בעת הסרת החשבון"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "ביטול"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "סגירת ההתראות"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "התחברות למידע שלך שבענן"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "אין חיבור לאינטרנט - יש להתחבר על מנת להגדיר חשבון מקוון חדש"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "הוספת חשבון"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "חשבון %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "הסרת חשבון"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "חשבונות מקוונים"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "אפשר להתחבר לחשבון המקוונים שלך ולהחליט כיצד להשתמש בהם"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;מקוון;שיחה;יומן;דוא״ל;לוח שנה;צ׳אט;צ'אט;דואר "
+"אלקטרוני;דוא\"ל;ownCloud;אונליין;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "זמן בלתי ידוע"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "דקה"
+msgstr[1] "שתי דקות"
+msgstr[2] "‏‫%i דקות"
+msgstr[3] "‏‫%i דקות"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "שעה"
+msgstr[1] "שעתיים"
+msgstr[2] "‫%i שעות"
+msgstr[3] "‏‫%i שעות"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "שעה"
+msgstr[1] "שעתיים"
+msgstr[2] "שעות"
+msgstr[3] "שעות"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "דקה"
+msgstr[1] "דקות"
+msgstr[2] "דקות"
+msgstr[3] "דקות"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s עד לטעינה מלאה"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "אזהרה: נותרו %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "נותרו %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "בטעינה מלאה"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "לא בטעינה"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "ריקה"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "בטעינה"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "בפריקה"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "עכבר אלחוטי"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "מקלדת אלחוטית"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "אל־פסק"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "עוזר דיגיטלי אישי"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "טלפון סלולרי"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "נגן מדיה"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "משטח"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "מחשב"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "התקני קלט למשחקים"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "סוללה"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "ראשי"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "נוסף"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "סוללות"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "ב_חוסר פעילות"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "השהיה"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "כיבוי"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "מצב תרדמת"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "לא לעשות דבר"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "בעת הפעלה מהסוללה"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "עם חיבור לחשמל"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "לעולם לא"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "השהיה אוטומטית"
+
+#: panels/power/cc-power-panel.c:1036
+msgid "Performance mode temporarily disabled due to high operating temperature."
+msgstr "מצב הביצועים הושבת זמנית עקב טמפרטורה גבוהה בזמן הפעילות."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"זוהו ירכיים: מצב הביצועים אינו זמין באופן זמני. יש להעביר את המכשיר למשטח יציב כדי "
+"לשחזר את המצב הקודם."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "מצב הביצועים מושבת זמנית."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when battery is "
+"sufficiently charged."
+msgstr ""
+"סוללה חלשה: חיסכון בחשמל הופעל. המצב הקודם ישוחזר כאשר הסוללה תיטען באופן מספק."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "מצב החיסכון בחשמל הופעל על ידי „%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "מצב הביצועים מופעל על ידי „%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "רבע שעה"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 דקות"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 דקות"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "חצי שעה"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 דקות"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "שעה"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 דקות"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "שעה וחצי"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 דקות"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "שעתיים"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "מצב כיבוי"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "השפעה על ביצועי המערכת וצריכה החשמל."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "אפשרויות חיסכון בחשמל"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "בהירות מסך אוטומטית"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "בהירות המסך מתכווננת לפי האור שמסביב."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "עמעום מסך"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "מפחית את בהירות המסך כאשר המחשב אינו פעיל."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "ה_חשכת מסך"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "מכבה את המסך לאחר זמן מה של חוסר פעילות."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "חיסכון אוטומטי בחשמל"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "מאפשר מצב חיסכון בחשמל כאשר הסוללה חלשה."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "השהיה _אוטומטית"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "משהה את המחשב זמן מה של חוסר פעילות."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "פעולת כפתור _כיבוי"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "הצגת אחוז ה_סוללה"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "השהיה אוטומטית"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "ב_חיבור לחשמל"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "על _סוללה"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "השהיה"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "ביצועים"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "ביצועים גבוהים וצריכת חשמל מוגברת."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "מאוזן"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "ביצועים רגילים וצריכת חשמל רגילה."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "חיסכון בחשמל"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "ביצועים מופחתים וצריכת חשמל חסכונית."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "צריכת חשמל"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "הצגת מצב הסוללה שלך ושינוי הגדרות חיסכון בחשמל"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"צריכת חשמל;שינה;השהיה;תרדמת;סוללה;בהירות;עמעום;החשכה;ריק;צג;בהמתנה;המתנה;אנרגיה;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "המדפסת „%s” נמחקה"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "הוספת המדפסת החדשה נכשלה."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "לא ניתן לטעון את מנשק המשתמש: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "שחרור להוספת מדפסות ולשינוי הגדרות"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "מדפסות"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "הוספת מדפסות, הצגת עבודות מדפסת ולהחליט כיצד ברצונך להדפיס"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "מדפסת;תור;הדפסה;דף;דיו;טונר;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28 panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "הוספת מדפסת"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118 panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_שחרור"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "לא נמצא מדפסות"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "יש להזין כתובת רשת או חיפוש מדפסת"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "נדרש אימות"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr "יש להזין שם משתמש וססמה להצגת מדפסות זמינות על שרת ההדפסה."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317 panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "שם משתמש"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76 panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "פרטי %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "לא נמצא מנהל התקן מתאים"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "בחירת קובץ PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+msgstr ""
+"קובצי הגדרות מדפסת של PostScript ‏(‎*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "שמות מדפסות לא יכולות להכיל רווח, טאב, # או לוכסן /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "מיקום"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "מנהל התקן"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "מתבצע חיפוש אחר מנהלי ההתקנים המועדפים…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "חיפוש התקנים"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "בחירה ממסד הנתונים…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "התקנת קובץ PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "בחירת מנהל התקן למדפסת"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "מסד נתוני מנהלי ההתקנים נטען…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "בחירה"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "מדפסת JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "מדפסת LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "חד־צדדי"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "שול ארוך (רגיל)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "שול קצר (היפוך אנכי)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "לאורך"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "לרוחב"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "לרוחב הפוך"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "לאורך הפוך"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "המשך"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "השהיה"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "ממתינה"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "מושהית"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "נדרש אימות"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "מעבדת"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "נעצרה"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "בוטלה"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "נפסקה"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "הושלמה"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "העברת המשימה הזאת לראש התור"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "משימה אחת דורשת אימות"
+msgstr[1] "שתי משימות דורשות אימות"
+msgstr[2] "‫%u משימות דורשות אימות"
+msgstr[3] "‏‫%u משימות דורשות אימות"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - הדפסות פעילות"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "יש להזין אישור על מנת להדפיס מ־%s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "מתחם"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "אי_מות"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "ניקוי הכול"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_אימות"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "אין משימת הדפסה פעילה"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "שחרור שרת הדפסה"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "שחרור %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "יש להזין שם משתמש וססמה להצגת מדפסות על %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "חיפוש מדפסות"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "יציאה טורית"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "יציאה מקבילית"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "מיקום: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "כתובת: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "אימות _פנימי"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "דו־צדדי"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "סוג הנייר"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "מקור הנייר"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "מגש הפלט"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "הבחנה"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "סינון קדם של GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "עמודים לצד"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "דו־צדדי"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "כיוון"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "כללי"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "הגדרת עמוד"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "אפשרויות הניתנות להתקנה"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "משימה"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "איכות התמונה"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "צבע"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "גימור"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "מתקדם"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844 panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "דף בדיקה"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "דף בדיקה"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "בחירה אוטומטית"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "בררת המחדל של המדפסת"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "הטמעת גופני GhostScript בלבד"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "המרה ל־PostScript רמה 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "המרה ל־PostScript רמה 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "אין סינון קדם"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "יצרן"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "אין משימות פעילות"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "משימה אחת"
+msgstr[1] "שתי משימות"
+msgstr[2] "‫%u משימות"
+msgstr[3] "‫%u משימות"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "ניקוי ראשי ההדפסה"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "הטונר כמעט נגמר"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "נגמר הטונר"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "נותר מעט נייר צילום"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "נגמר נייר הצילום"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "נותרה מעט אספקת צבע"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "נגמרה אספקת הצבע"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "הכיסוי פתוח"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "הדלת פתוחה"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "נותר מעט נייר"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "נגמר הנייר"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "מנותקת"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743 panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "נעצרה"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "כלי קיבול הפסולת כמעט מלא"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "כלי קיבול הפסולת מלא"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "הפוטו מוליך האופטי עומד לסיים את חייו"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "הפוטו מוליך האופטי אינו מתפקד עוד"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "מוכנה"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "אין עבודות"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "מעבדת"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "אפשרויות הדפסה"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "פרטי מדפסת"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "הגדרת המדפסת כבררת מחדל"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "ניקוי ראשי ההדפסה"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "הסרת מדפסת"
+
+#: panels/printers/printer-entry.ui:183 panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "דגם"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "רמת הדיו"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "יש להפעיל מחדש כאשר הבעיה נפתרת."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "הפעלה מחדש"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "הוספת מדפסת…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "אין מדפסות בנמצא"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"כפי הנראה, שירותי ההדפסה של המערכת\n"
+"‬\n"
+"‫    ‫‫‬‫‬אינם זמינים, עמך הסליחה."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "תבניות"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "חיפוש שפות…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "תבניות נפוצות"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "כל התבניות"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "לא נמצאו תוצאות"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "ניתן לחפש מדינות או שפות."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "תצוגה מקדימה"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "אימפריאלית"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "מטרית"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "תאריכים"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "תאריך ושעה"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "מספרים"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "מדידה"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "נייר"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "השפה והתבנית ישתנו לאחר ההתחברות הבאה"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "יציאה…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are used "
+"for numbers, dates, and currencies."
+msgstr ""
+"הגדרת השפה תשמש לטקסט בממשק המשתמש ובאתרי האינטרנט. התבנית תשמש עבור מספרים, "
+"תאריכים ומטבעות."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "החשבון שלך"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_שפה"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_תבניות"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "מסך כניסה"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "אזור ושפה"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "בחירת שפת התצוגה והתצורות המקומיות"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "שפה;פריסה;מקלדת;פלט;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "הצגת שאלה בנוגע להמשך"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "לא לעשות דבר"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "פתיחת תיקייה"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "מדיה אחרת"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "נא לבחור יישום לתקליטורי שמע"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "נא לבחור יישום לתקליטורי וידאו DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "נא לבחור יישום להפעלה בעת חיבור נגן מוזיקה"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "נא לבחור יישום להפעלה בעת חיבור המצלמה"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "נא לבחור יישום לתקליטורי תכנה"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "תקליטור DVD שמע"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "תקליטור Blu-ray ריק"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "תקליטור CD ריק"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "תקליטור DVD ריק"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "תקליטור HD DVD ריק"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "תקליטור וידאו Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "מציג ספרים אלקטרוניים"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "תקליטור וידאו HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "תקליטור תמונות"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "סופר תקליטור וידאו (SVCD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "תקליטור וידאו (VCD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "תכנה של Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "נא לבחור כיצד מדיה תטופל"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "תקליטור _שמע"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_וידאו DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "נ_גן מוזיקה"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_תכנה"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "מ_דיה אחרת…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "ל_עולם לא לשאול או להפעיל תכנית עם הכנסת מדיה"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "יש לבחור כיצד מדיה אחרת תטופל"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_פעולה:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_סוג:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "מדיה נתיקה"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "הגדרות מדיה נתיקה"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;"
+"media;autorun;"
+msgstr ""
+"התקן;מערכת;מידע;זיכרון;זכרון;מעבד;גרסה;בררת מחדל;יישום;העדפה;מועדף;גיבוי;דיסק;"
+"תקליטור;DVD;USB;שמע;אודיו;חוזי;וידאו;נשלף;נתיק;מדיה;הפעלה אוטומטית;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "המסך יכבה"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "חצי דקה"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "דקה"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "שתי דקות"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 דקות"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 דקות"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "חצי שעה"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "שעה"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "דקה"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 דקות"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 דקות"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 דקות"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 דקות"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 דקות"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 דקות"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 דקות"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "רבע שעה"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "לעולם לא"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "נעילת מסך"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer while "
+"you're away."
+msgstr "נעילה אוטומטית של המסך מונעת מאנשים אחרים לגשת למחשב שלך בזמן שאינך בנמצא."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "זמן החשכת מסך"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "פרק הזמן של חוסר פעילות שלאחריו המסך יוחשך."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_נעילת מסך אוטומטית"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "זמן _נעילת מסך אוטומטית"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "פרק הזמן שלאחר החשכת המסך כאשר המסך ננעל באופן אוטומטי."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "הצגת הת_ראות במסך נעילה"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "מניעת התקני _USB חדשים"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is locked."
+msgstr "מניעת פעילות של התקני USB חדשים בזמן שהמסך נעול."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "פרטיות מסך"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "הגבלת זווית הצפייה"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "הגדרות מסך"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "מסך;נעילה;פרטי;פרטיות;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "בחירת מיקום"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_אישור"
+
+#: panels/search/cc-search-locations-dialog.ui:8 panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "מקומות לחיפוש"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr "תיקיות אשר מבוצע בהן חיפוש על ידי יישומים כמו קבצים, תמונות וסרטונים."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "מיקומים"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "סימניות"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "אחרים"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "הוספת מיקום"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "לא נמצאו יישומים"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "חיפוש יישום"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "לכלול תוצאות חיפוש מספקי יישומים."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "תיקיות אשר מבוצע בהן חיפוש על ידי יישומי מערכת."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "תוצאות חיפוש"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "תוצאות מוצגות לפי סדר הרשימה."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid "Control which applications show search results in the Activities Overview"
+msgstr "שליטה באילו יישומים יציגו תוצאות חיפוש בסקירת פעילויות"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "חיפוש;מציאה;חפש;מצא;למצוא;לחפש;אינדקס;מפתח;הסתרה;החבאה;פרטיות;תוצאות;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "לא נבחרו רשתות לשיתוף"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "רשתות"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "פעיל"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "כבוי"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "מופעל"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "פעיל"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "נא לבחור בתיקייה"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "הוספה"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "הפעלת שיתוף מדיה"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your current "
+"network using: %s"
+msgstr ""
+"שיתוף קבצים מאפשר לך לשתף את התיקייה ציבורי שלך עם משתמשים נוספים ברשת הנוכחית שלך "
+"באמצעות: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure Shell "
+"command:\n"
+"%s"
+msgstr ""
+"כאשר התחברות מרוחקת מאופשרת, משתמשים מרוחקים יכולים להתחבר באמצעות פקודה במעטפת "
+"מאובטחת: \n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "הפעלת שיתוף מדיה פרטי"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "שם ההתקן הועתק"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "כתובת ההתקן הועתקה"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "שם המשתמש הועתק"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "ססמה הועתקה"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "שיתוף"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "שם ה_מחשב"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "שיתוף _קבצים"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_שולחן עבודה מרוחק"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "שיתוף _מדיה"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "כניסה מ_רוחקת"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "שיתוף קבצים"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "ד_רישת ססמה"
+
+#: panels/sharing/cc-sharing-panel.ui:195 panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "התחברות מרוחקת"
+
+#: panels/sharing/cc-sharing-panel.ui:251 panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "שולחן עבודה מרוחק"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another computer."
+msgstr "שולחן עבודה מרוחק מאפשר צפייה ושליטה בשולחן העבודה שלך ממחשב אחר."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "הפעלה או השבתה של התחברות מרוחקת לשולחן העבודה של מחשב זה."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "שליטה מרחוק"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "לאפשר להתחברויות מרוחקות לשלוט במסך זה."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "כיצד להתחבר"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid "Connect to this computer using the device name or remote desktop address."
+msgstr "התחברות למחשב זה באמצעות שם ההתקן או כתובת שולחן העבודה המרוחק."
+
+#: panels/sharing/cc-sharing-panel.ui:318 panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372 panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "העתקה"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "כתובת שולחן עבודה מרוחק"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "אימות"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "שם משתמש וססמה נדרשים על מנת להתחבר למחשב זה."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "שם משתמש"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "אימות הצפנה"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "הצפנת טביעת אצבע"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr "הצפנת טביעת האצבע ניתנת לצפייה בצד הלקוח המתחבר וצריכה להיות זהה."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "שיתוף מדיה"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "שיתוף מוזיקה, תמונות וסרטים ברשת."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "תיקיות"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "שליטה במה שמעניין אותך לשתף עם אחרים"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"שיתוף;מארח;שרת;שם;מרוחק;רחוק;מרחוק;שולחן עבודה;מדיה;שמע;אודיו;קול;צליל;וידאו;סרטון;"
+"סרט;תמונות;צילומים;תצלומים;עיבוד;מעבד;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "הפעלה או השבתה של התחברות מרוחקת"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "נדרש אימות כדי להפעיל או להשבית התחברות מרחוק"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "התאמה אישית"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "נקישה"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "מיתר"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "הנפה"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "המהום"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "איזון"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "עמעום"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "אחורי"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "קדמי"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "‏%s בבדיקה"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "יש ללחוץ על רמקול לבדיקה"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "עצמת צלילי מערכת"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "עצמת צלילי מערכת עיקרית"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "דרגות עצמת שמע"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "פלט"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "התקן פלט"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "בדיקה"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "הגדרה"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "סאבוופר"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "קלט"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "התקני קלט"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "עצמה"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "צליל התראה"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "השתקה"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "צליל"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "שינוי עצמת השמע, קלט, פלט וצלילי התראה"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"כרטיס;מיקרופון;עצמת שמע;ווליום;איזון;בלוטות׳;Bluetooth;אזניות;אוזניות;שמע;קלט;פלט;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "מנותק"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "בהתחברות"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "מחובר"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "שגיאת אימות"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "אימות"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "תפקוד ירוד"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "התקנים מחוברים ומאומתים"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "לא ידוע"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "אומת ב־:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "מחובר החל מ־:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "נרשם ב־:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "אימות ההתקן נכשל: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "שכיחת ההתקן נכשלה: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "תלוי בהתקן אחר"
+msgstr[1] "תלוי בשני התקנים אחרים"
+msgstr[2] "תלוי ב־%u התקנים אחרים"
+msgstr[3] "‫תלוי ב־%u התקנים אחרים"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "סגירת ההתראות"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "שם:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "מצב:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "‏UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "אימות והתחברות"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "שכיחת ההתקן"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "שגיאה"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "אומת"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr "מערכת הבת של Thunderbolt ‏(boltd) אינה מותקנת או לא מוגדרת כראוי."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425 panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "לאפשר גישה ישירה להתקנים דוגמת תחנות עגינה ומעבדים גרפיים חיצוניים."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "רק התקני USB ו־DisplayPort ניתנים לצירוף."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the BIOS or "
+"is set to an unsupported security level in the BIOS."
+msgstr ""
+"‏Thunderbolt לא ניתנת לזיהוי.\n"
+"או שהמערכת חסרת תמיכה ב־Thunderbolt, או שהיא הושבתה ב־BIOS או שהיא הוגדרה כשכבת "
+"אבטחה לא נתמכת ב־BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "תמיכה ב־Thunderbolt הושבתה ב־BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "שכבת האבטחה של Thunderbolt לא ניתנת לקביעה."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "שגיאה בשינוי המצב הישיר: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "אין תמיכה ב־Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "לא ניתן להתחבר אל מערכת הבת של Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "גישה ישירה"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "ההתקנים מתקבלים"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "אף התקן לא צורף"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "ניהול התקני Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;פרטיות;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "הבהוב סמן"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "סמן מהבהב בשדות טקסט."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "מהירות"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "מהירות הבהוב הסמן"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "גודל סמן"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid "Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "סמן העכבר ניתן להגדלה על מנת להקל עליך לראות אותו."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "מסייע לחיצה"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "לחיצה _שנייה מדומה"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "הפעלת לחיצה משנית על ידי החזקת הלחצן הראשי"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "ה_שהיית קבלה:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "קצרה"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "השהיית לחיצה משנית"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "ארוכה"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "לחיצה במעבר מ_על"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "הפעלת לחיצה כאשר העכבר עובר מעל"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "ה_שהיה:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "קצרה"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "ארוכה"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_סף תנועה:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "קטן"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "גדול"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "מקשים חוזרים"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "לחיצות מקש חוזרות בעת לחיצה רצופה."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "מהירות החזרת מקשים"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "מהירות החזרת מקשים"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "מסייע ההקלדה"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "מקשים _דביקים"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "התייחסות לרצף של מקשי החלפה כצירוף מקשים"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "ה_שבתה אם שני מקשים נלחצים ביחד"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "צפצוף בעת לחיצה על מקש ה_חלפה"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "מקשים _אטיים"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "הוספת השהיה בין לחיצת המקש לבין קבלת הלחיצה"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "קצרה"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "ההשהיה בין מקשים אטיים"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "ארוכה"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "צפצוף כאשר מקש _נלחץ"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "צפצוף כאשר מקש ה_תקבל"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "צפצוף בעת _דחיית לחיצת מקש"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "מקשים _חוזרים"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "התעלמות מלחיצות מקשים כפולות מהירות"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "קצרה"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "ההשהיה בין החזרת המקשים"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "ארוכה"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "הפעלה באמצעות המ_קלדת"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "הפעלת וכיבוי של תכונות נגישות באמצעות המקלדת"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "בררת מחדל"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "בינוני"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "גדול"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "גדול יותר"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "ענק"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "פיקסל אחד"
+msgstr[1] "שני פיקסלים"
+msgstr[2] "‫%d פיקסלים"
+msgstr[3] "‏‫%d פיקסלים"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_תמיד להציג תפריט נגישות"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "ראייה"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "ניגודיות _גבוהה"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "טקסט _גדול"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "הפעלת ה_נפשות"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "מ_קריא מסך"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "קורא המסך קורא את הטקסט המוצג כאשר המוקד זז."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_צלילי מקשים"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "צפצוף כאשר Num Lock או Caps Lock מופעלים או מושבתים."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "גודל _סמן"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "ת_קריב"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "שמיעה"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "התראות ח_זותיות"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "מקלדת _על המסך"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "מקשים _חוזרים"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "ה_בהוב סמן"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "מסייע הה_קלדה (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "הצבעה ולחיצה"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "מקשי _עכבר"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_איתור סמן"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "מסייע ל_חיצה"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "פרק זמן לחיצה _כפולה"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "פרק זמן ללחיצה כפולה"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "התראות חזותיות"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "בדיקת הה_בהוב"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "שימוש בחיווי חזותי כאשר מושמע צליל התראה."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "הבהוב המסך _כולו"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "הבהוב המסך _כולו"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "קצר"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ מסך"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ מסך"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ מסך"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "ארוך"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "מסך מלא"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "החצי העליון"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "החצי התחתון"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "החצי השמאלי"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "החצי הימני"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "אפשרויות תקריב"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "ה_גדלה:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "מיקום זכוכית המגדלת:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "מע_קב אחר סמן העכבר"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "החלק מה_מסך:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "האזור המו_גדל מוצג מחוץ למסך"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_שמירה על סמן ההגדלה ממורכז"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "סמן ההגדלה _דוחף את התכנים סביב"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "סמן ההגדלה זז עם ה_תכנים"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "זכוכית מגדלת"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "סמני _צלב:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_חופף את סמן העכבר"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_עובי:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "צר"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "עבה"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_אורך:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_צבע:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "סמני צלב"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "אפקטים של צבע:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_לבן על שחור:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_בהירות:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_ניגודיות:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_צבע"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "ללא"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "מלא"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "נמוכה"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "גבוהה"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "נמוכה"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "גבוהה"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "אפקטים של צבע"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "להקל ראייה, שמיעה, הקלדה, הצבעה ולחיצה"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;Zoom;"
+"Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+"animations;"
+msgstr ""
+"מקלדת;עכבר;a11y;נגישות;ניגודיות;ניגוד;תקריב;זום;מקריא מסך;טקסט;גופן;גודל;AccessX;"
+"מקשים דביקים;מקשים אטיים;מקשים חוזרים;מקשי עכבר;לחיצה;כפול;כפולה;המתנה;מהירות;סיוע;"
+"חזרה;הבהוב;שמיעה;שמע;הקלדה;-;הנפשה;הנפשות;אנימציה;אנימציות;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "שעה"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "יום"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "יומיים"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 ימים"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 ימים"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 ימים"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 ימים"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "שבוע"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "שבועיים"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "חודש"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "לרוקן את כל הפריטים באשפה?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "כל הפריטים באשפה ימחקו לצמיתות."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_פינוי האשפה"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "למחוק את כל הקבצים הזמניים?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "כל הקבצים הזמניים ימחקו לצמיתות."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "מחיקת קבצים _זמניים"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "יום"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "שבוע"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "חודש"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "לעד"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "היסטוריית קבצים"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you might want "
+"to use."
+msgstr ""
+"היסטוריית קבצים שומרת תיעוד של קבצים שהיו בשימוש על ידך. מידע זה משותף בין "
+"יישומים, ומקל על מציאת קבצים שעשויים לשמש אותך."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "_היסטוריית קבצים"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "משך _היסטוריית קבצים"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "מחיקת _היסטוריה…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "אשפה וקבצים זמניים"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive information. "
+"Automatically deleting them can help to protect privacy."
+msgstr ""
+"אשפה וקבצים זמניים עשויים לעתים להכיל מידע אישי או רגיש. מחיקה אוטומטית שלהם עשויה "
+"לעזור על הגנה על הפרטיות שלך."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "פינוי תוכן האשפה _אוטומטית"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "מ_חיקת הקבצים הזמניים אוטומטית"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "תקופת פינוי אשפה _אוטומטית"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_פינוי האשפה…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "מחיקת קבצים _זמניים…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "היסטוריית קבצים ואשפה"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "לא להשאיר עקבות"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr "שימוש;ניצול;לאחרונה;היסטוריה;קבצים;זמני;פרטי;פרטיות;אשפה;ניקוי;שמירה;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "צריך להתאים את כתובת האינטרנט של ספק החשבון שלך."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "הוספת החשבון נכשלה"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "הססמאות אינן תואמות."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "הרשמת החשבון נכשלה"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "אין שיטה נתמכת לאימות עם מתחם זה (domain)"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "ההצטרפות למתחם נכשלה"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"שם התחברות זה לא עובד.\n"
+"נא לנסות שוב."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"ססמה זו לא עובדת.\n"
+"נא לנסות שוב."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "ההתחברות למתחם נכשלה"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "לא ניתן למצוא את התחום. אולי שגית באיות?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "הוספת משתמש"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "מנהל"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for all "
+"users. Parental controls cannot be applied to administrators."
+msgstr ""
+"מנהל יכול להוסיף ולהסיר משתמשים, וכן לשנות הגדרות עבור כלל המשתמשים. בקרת הורים לא "
+"ניתנת להחלה על מנהל."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "הגדרת ססמה בכניסה הראשונה של המשתמש"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "הגדרת ססמה כעת"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "אישור"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "כניסה ארגונית"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "חשבונות משתמש המנוהלים על ידי חברה או ארגון."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "התנתקת"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be used on "
+"this device. You can also use this account to access company resources on the "
+"internet."
+msgstr ""
+"התחברות ארגונית מאפשרת ניהול חשבון משתמש מרוכז לשימוש בהתקן זה. נתן גם להשתמש "
+"בחשבון זה לגישה למשאבי חברות באינטרנט."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "עיון אחר תמונות נוספות"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "בחירת קובץ…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "ניהול טביעות אצבע"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "טביעת אצבע"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_לא"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_כן"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "למחוק את טביעות האצבעות שלך שנרשמו כך שכניסה עם טביעת אצבע תושבת?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "אין התקן טביעת אצבע"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "אין התקן טביעת אצבע"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "יש לוודא כי ההתקן מחובר כראוי."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "התקן טביעת אצבע"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "נא לבחור את התקן טביעות האצבע להגדרה"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "כניסה באמצעות טביעת אצבע"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your finger"
+msgstr ""
+"התחברות באמצעות טביעת אצבע מאפשרת לך לבטל נעילה ולהתחבר למחשב שלך באמצעות האצבע שלך"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_מחיקת טביעות אצבע"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "רישום טביעת אצבע"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "יש לדרוש את ההתקן כדי לבצע את הפעולה הזאת"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "ההתקן כבר נדרש על ידי תהליך אחר"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "אין לך הרשאות לביצוע הפעולה"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "אין הדפסות רשומות"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "ההתקשורת עם ההתקן בעת הרישום נכשלה"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "ההתקשרות עם קורא טביעות האצבע נכשלה"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "ההתקשרות עם שרת קורא טביעות האצבע נכשלה"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "הצגת טביעות האצבעות נכשלה: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "מחיקת טביעות אצבע שמורות נכשלה: ‏%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "אגודל שמאלית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "אמה שמאלית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "אצבע _שמאלית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "קמיצה שמאלית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "זרת שמאלית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "אגודל ימנית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "אמה ימנית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "אצבע _ימנית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "קמיצה ימנית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "זרת ימנית"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "אצבע לא ידועה"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "הושלם"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "התקן טביעת האצבע התנתק"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "אחסון התקן טביעת האצבע מלא"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "רישום טביעת אצבע חדשה נכשל"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "התחלת הרישום נכשלה: ‏%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "רישום טביעת אצבע חדשה נכשל"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "עצירת הרישום נכשלה: ‏%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your fingerprint"
+msgstr "יש לחזור על הרמת והנחת האצבע על הקורא כדי לרשום את טביעת האצבע שלך"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "_רישום מחדש של אצבע זו…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "סריקת טביעת אצבע חדשה"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "שחרור התקן טביעת אצבע %s נכשל: ‏%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "בעיה בקריאת התקן"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "טעינת התקן טביעת אצבע %s נכשלה: ‏%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "קבלת התקני טביעת אצבע נכשלה: ‏%s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "השבוע"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "השבוע האחרון"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e ב%b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e ב%b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "‏%s – %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "הפעלה הסתיימה"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "הפעלה התחילה"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "‏‏%s – פעילות בחשבון"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "הקודם"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "הבא"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "נא לבחור בססמה אחרת."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "נא להזין את הססמה הנוכחית שלך שוב."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "לא ניתן להחליף את הססמה"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "החלפת ססמה"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "ה_חלפה"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "ססמה נוכחית"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "ססמה חדשה"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "אימות ססמה"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "לאפשר למשתמש לשנות את הססמה בהתחברות הבאה"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "הגדרת ססמה כעת"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "לא ניתן להצטרף אוטומטית לסוג כזה של תחום"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "לא נמצאו תחום או מתחם כאלה"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "לא ניתן להיכנס בשם %s לתחום %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "הססמה שגויה, נא לנסות שוב"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "לא ניתן להתחבר אל התחום %s:‏ %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "מחיקת משתמש נכשלה"
+
+#: panels/user-accounts/cc-user-panel.c:413 panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "ביטול המשתמש המנוהל מרחוק נכשל"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "מחיקת החשבון שלך על ידיך אינה אפשרית."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s עדיין במערכת"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an inconsistent "
+"state."
+msgstr "מחיקת משתמש כשהוא מחובר עלולה להשאיר את המערכת במצב בלתי יציב."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "לשמור על הקבצים של %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files around "
+"when deleting a user account."
+msgstr ""
+"ניתן לשמור על תיקיית הבית, מאגר הדואר והקבצים הזמניים בהישג ידך לאחר מחיקת משתמש."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_מחיקת הקבצים"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_שמירת הקבצים"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "לשלול את החשבון של %s שמנוהל מרחוק?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "מ_חיקה"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "חשבון מושבת"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "להגדרה בהתחברות הבאה"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "אין"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "נכנסת"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "לא ניתן ליצור קשר עם שירות החשבונות"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "נא לוודא ששירות החשבונות (AccountService) מותקן ומופעל."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "יש הכרח לשחרר לוח זה על מנת לשנות הגדרה זו"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "מחיקת חשבון המשתמש הנבחר"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"כדי למחוק את המשתמש הנבחר\n"
+"ראשית יש ללחוץ על הסמל *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "שחרור להוספת משתמשים ולשינוי הגדרות"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "משתמשים"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "יש להפעיל מחדש את ההפעלה שלך כדי שהשינויים ייכנסו לתוקף (יש לצאת ולהיכנס)"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "הפעלה מחדש כעת"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "סגירה"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "עריכת תמונה"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "שם מלא"
+
+#: panels/user-accounts/cc-user-panel.ui:171 panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "עריכה"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "כניסה באמצעות _טביעת אצבע"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "כניסה _אוטומטית"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "פעילות בחשבון"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_מנהל"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for all "
+"users."
+msgstr "מנהל יכול להוסיף ולהסיר משתמשים, וכן לשנות הגדרות עבור כלל המשתמשים."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_בקרת הורים"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "פתיחת יישום בקרת הורים."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "הסרת משתמש…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "משתמשים אחרים"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "הוספת משתמש…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "לא נמצאו משתמשים"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "שחרור על מנת להוסיף משתמש."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "הוספה או הסרה של משתמשים והחלפת הססמה שלך"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen Time;App "
+"Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"כניסה;שם משתמש;שם;טביעת אצבע;טביעות אצבע;תמונת משתמש;תמונה ייצוגית;לוגו;פנים;ססמה;"
+"סיסמה;סיסמא;ססמא;בקרת הורים;זמן מסך;מגבלות יישומים;הגבלות;מגבלות אינטרנט;הגבלות "
+"אינטרנט;שימוש;מגבלת שימוש;הגבלת שימוש;ילד;ילדים;ילדות;ילדה;בן;בת;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "ה_רשמה"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "כניסת מנהל המתחם"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"כדי להשתמש בכניסה ארגונית, על מחשב זה להיות רשום\n"
+"במתחם. נא לבקש ממנהל הרשת להקליד את ססמת המתחם\n"
+"שלו להלן."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_שם המנהל"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "ססמת מנהל"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "ניהול חשבונות משתמשים"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "נדרש אימות כדי לשנות את נתוני המשתמש"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "הססמה החדשה מוכרחה להיות שונה מהקודמת."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "כדאי לשנות כמה תווים או מספרים."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "כדאי לנסות לערוך שינויים נרחבים יותר בססמה."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "ססמה ללא שם המשתמש שלך תהיה חזקה יותר."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "כדאי לנסות להימנע משימוש בשם שלך בססמה."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "כדאי לנסות להימנע מכמה מהמילים הכלולות בססמה."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "כדאי לנסות להימנע ממילים נפוצות."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "כדאי לנסות להימנע מסידור מחדש של מילים קיימות."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "כדאי לנסות להשתמש ביותר מספרים."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "כדאי לנסות להשתמש ביותר אותיות רישיות."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "כדאי לנסות השתמש ביותר אותיות קטנות."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "כדאי לנסות להשתמש ביותר תווים מיוחדים, כמו סימני פיסוק."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "כדאי לנסות להשתמש בתערובת של אותיות, מספרים וסימני פיסוק."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "כדאי לנסות להימנע מחזרה על אותו התו."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up letters, "
+"numbers and punctuation."
+msgstr ""
+"כדאי לנסות להימנע מחזרה על אותו סוג של תו: צריך לערבב אותיות, מספרים וסימני פיסוק."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "כדאי להימנע מרצפים כמו 1234, abcd או אבגד."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and punctuation."
+msgstr "הססמה צריכה להיות ארוכה יותר. יש לנסות להוסיף תווים, מספרים וסימני פיסוק."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "יש לערבב אותיות רישיות וקטנות ולהשתמש במספר או שניים."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid "Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "הוספת תווים נוספים, מספרים וסימני פיסוק תחזק את הססמה עוד יותר."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "האימות נכשל"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "הססמה החדשה קצרה מדי"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "הססמה החדשה פשוטה מדי"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "הססמאות הישנה והחדשה דומות מדי"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "הססמה החדשה כבר הייתה בשימוש לאחרונה."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "על הססמה החדשה להכיל תווים מספריים או מיוחדים"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "הססמאות הישנה והחדשה זהות"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "ססמתך הוחלפה מאז שביצעת אימות לראשונה!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "הססמה החדשה לא מכילה מספיק תווים השונים זה מזה"
+
+#: panels/user-accounts/run-passwd.c:514 panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "שגיאה בלתי ידועה"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, digits "
+"and the following characters: - _"
+msgstr ""
+"שם המשתמש יכול להכיל רק אותיות קטנות מהאלפבית האנגלי, ספרות ואחד  מהתווים: . - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "למרבה הצער, שם משתמש זה אינו זמין. יש לנסות שם אחר."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "שם המשתמש ארוך מדי."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "מיפוי לחצנים"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "מיפוי לחצנים לפונקציות"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"על מנת לערוך צירוף מקשים, יש לבחור בפעולה „שליחת צירוף מקשים”, ללחוץ על כפתור "
+"צירופי מקשים ולהקיש על המקשים החדשים או על Backspace למחיקה."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "ס_גירה"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the tablet."
+msgstr "נא ללחוץ על סמני היעד כאשר הם מופיעים על המסך כדי לכייל את משטח המגע."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "זוהתה לחיצה שגויה, הפעולה תתחיל מההתחלה…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "כפתור %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "יישום מוגדר"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "שליחת צירוף מקשים"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "החלפת צג"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "הצגת עזרה על גבי המסך"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "מחשב לוח מעוגן על לוח מחשב נייד"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "מחשב לוח מעוגן על צג חיצוני"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "מחשב לוח חיצוני"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "התקן משטח חיצוני"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "כל הצגים"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "מצב מחשב לוח"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "שימוש במיקום מוחלט עבור העט"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "התאמה הכיווניות לשמאליים"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "מחשב לוח וכפתורים מותאמים (Express Keys™) מסובבים לשימוש שמאליים"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "מיפוי לצג"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "שמירה על יחס התצוגה"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "שימוש חלק במשטח מחשב הלוח על מנת לשמור על יחס תצוגה"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "כיול"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "לא זוהה לוח מגע"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "נא לחבר או להפעיל את לוח המגע השולחני שלך."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "תחושת לחץ החוד"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21 panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "רכה"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "עט רגיל עם לחץ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41 panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "נוקשה"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "לחצן 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "לחצן 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "לחצן 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "תחושת לחץ המוחק"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "לחץ המוחק"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "לחיצה על לחצן העכבר האמצעי"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "לחיצה על לחצן העכבר הימני"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "קדימה"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "עט איירבראש עם לחץ, הטייה ומחוון גלילה מובנה"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "עט איירבראש עם לחץ, הטייה וסיבוב"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "עט רגיל עם לחץ והטייה"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "עט רגיל עם לחץ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "לוח מגע"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "הגדרת מיפויי כפתור והתאמת רגישות עט עבור לוח ציור"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "לוח;Wacom;עט מגע;מחק;מוחק;עכבר;משטח מגע;לוח מגע; מגע;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "קיצור דרך חדש…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "נקודות גישה"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "הגדרות גלישה"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "הפעולה בוטלה"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "‫<b>שגיאה:</b> הגישה לשינוי ההגדרות נדחתה"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "‫<b>שגיאה:</b> שגיאה בציוד התקשורת הסלולרית"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "לא רשום"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "רשום"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "ניוד"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "בחיפוש"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "נדחה"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "פרטי המודם"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "מצב המודם"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "מפעילה"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "סוג הרשת"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "מצב הרשת"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "המספר העצמי"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "פרטי ההתקן"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "גרסת קושחה"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "‫2G בלבד"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "‫3G בלבד"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "‫4G בלבד"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "‫5G בלבד"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "‫2G,‏ 3G,‏ 4G, ‏5G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "‫2G,‏ 3G,‏ 4G (עדיפה), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "‫2G,‏ 3G (עדיפה), 4G, ‏5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "‫2G (עדיפה), 3G,‏ 4G, ‏5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "‫2G,‏ 3G,‏ 4G, ‏5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "‫2G,‏ 3G,‏ 4G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "‫2G,‏ 3G (עדיפה), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "‫2G (עדיפה), 3G,‏ 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "‫2G,‏ 3G,‏ 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "‫3G,‏ ‏4G, ‏‎5G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "‫3G,‏ 4G (עדיפה), ‎5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "‫3G (עדיפה), ‏4G, ‏‎5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "‫3G,‏ 4G, ‏5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "‫2G,‏ 4G,‏ 5G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "‫2G,‏ 4G (עדיפה), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "‫2G (עדיפה), 4G,‏ 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "‫2G,‏ 4G,‏ 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "‫2G,‏ 3G,‏ 5G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "‫2G,‏ 3G (עדיפה), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "‫2G (עדיפה), 3G,‏ 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "‫2G,‏ 3G,‏ 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "‫3G,‏ 4G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "‫3G (עדיפה), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "‫3G,‏ 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "‫2G,‏ 4G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "‫2G (עדיפה), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "‫2G,‏ 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "‫2G,‏ 3G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "‫2G (עדיפה), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "‫2G,‏ 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "‫2G,‏ 5G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "‫2G (עדיפה), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "‫2G,‏ 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "‫3G,‏ 5G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "‫3G (עדיפה), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "‫3G,‏ 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "‫4G,‏ 5G (עדיפה)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "‫4G (עדיפה), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "‏‎4G, ‏‎5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "לא ידוע"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "שחרור כרטיס SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "שחרור"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "נא לספק קוד PIN עבור SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "נא להקליד PIN לשחרור כרטיס ה־SIM שלך"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "נא לספק קוד PUK ל־SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "נא להקליד PUK לשחרור כרטיס ה־SIM שלך"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "הוקלדה ססמה שגויה. נותר לך עוד ניסיון אחד"
+msgstr[1] "הוקלדה ססמה שגויה. נותרו לך עוד שני ניסיונות"
+msgstr[2] "הוקלדה ססמה שגויה. נותרו לך עוד %1$u ניסיונות"
+msgstr[3] "הוקלדה ססמה שגויה. נותרו לך עוד %1$u ניסיונות"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "נותר לך ניסיון אחד"
+msgstr[1] "נותרו לך שני ניסיונות"
+msgstr[2] "נותרו לך %u ניסיונות"
+msgstr[3] "נותרו לך %u ניסיונות"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "הססמה שהוקלדה שגויה."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "קוד ה־PUK אמור להיות באורך 8 ספרות"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "נא להקליד PIN חדש"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "קוד ה־PIN אמור להיות מספר באורך 4-8 ספרות"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "מתבצע שחרור…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "אין SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "נא להכניס כרטיס SIM כדי להשתמש במודם הזה"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "‫SIM נעול"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_נתונים סלולריים"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "גישה לנתונים דרך רשת סלולרית"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_ניוד נתונים"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "להשתמש ברשת סלולרית בעת ניוד"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "מ_צב רשת"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_רשת"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "מתקדם"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_שמות נקודות גישה"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_נעילת SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "נעילת SIM ב־PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "_פרטי מודם"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "שגיאת טלפון"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "אין חיבור לטלפון"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "הפעולה אסורה"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "הפעולה אינה נתמכת"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "לא הוכנס SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "נדרש PIN ל־SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "נדרש PUK ל־SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "כשל ב־SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "ה־SIM עסוק"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "ססמה שגויה"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "נדרש PIN2 ל־SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "נדרש PUK2 ל־SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "לא נמצא"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "אין שירות רשת"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "תום זמן המתנה לרשת"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "שירותי GPRS אסורים"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "ניוד אסור באזור זה"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "שגיאת GPRS לא ידועה"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "אין שגיאה"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "הפעולה בוטלה"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "הגישה נדחתה"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "שגיאה לא ידועה"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "מצב רשת"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_אוטומטי"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "בחירת רשת"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "רענון ספקי רשת"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "הפעלת רשת סלולרית"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "לא נמצא מתאם לרשת אלחוטית מרחבית"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "כדאי לוודא כי יש לך התקן רשת אלחוטית מרחבית/סלולרי"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "‏בלוטות' מושבת כאשר מצב טיסה פועל"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_כיבוי מצב טיסה"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "חיבור נתונים"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "כרטיס SIM משמש לאינטרנט"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "נעילת SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "ה_בא"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_נעילת SIM ב־PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "החלפת PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "נא להקליד את ה־PIN הנוכחי כדי לשנות את הגדרות נעילת ה־SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "רשת סלולרית"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "הגדרת טלפוניה וחיבורי נתונים סלולריים"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+"סלולרי;אלחוטי;סים;SIM;נייד;תקשורת;מובייל;פלאפון;סלקום;פרטנר;רמי לוי;גולן;טלקום;"
+"טלפוניה;חיוג;טלפון;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "כלים להגדרת שולחן העבודה GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "הגדרות הוא הממשק העיקרי להגדיר את המערכת שלך."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "מיזם GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "הצגת מספר הגרסה"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "הפעלת מצב מפורט"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "חיפוש אחר מחרוזת"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "הצגת שמות הלוחות האפשריים ואז לצאת"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "לוח להצגה"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "קטגוריות הגדרות"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "פרטיות"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "לוחות זמינים:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "כל ההגדרות"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "תפריט ראשי"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "אזהרה: גרסת פיתוח"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You may "
+"experience incorrect system behavior, data loss, and other unexpected issues. "
+msgstr ""
+"גרסה זו של הגדרות צריכה לשמש למטרות פיתוח בלבד. הגרסה עשויה לגרום להתנהגויות לא "
+"תקינות של המערכת, לאבדן מידע לתקלות אחרות בלתי צפויות. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "עזרה"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "כללי"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "יציאה"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "חיפוש"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "לוחות"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "חזרה ללוח הקודם"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "ביטול החיפוש"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "העדפות;הגדרות;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "The identifier for the last Settings panel to be opened"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values will "
+"be ignored and the first panel in the list selected."
+msgstr ""
+"The identifier for the last Settings panel to be opened. Unrecognised values will "
+"be ignored and the first panel in the list selected."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Show warning when running a development build of Settings"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid "Whether Settings should show a warning when running a development build."
+msgstr "Whether Settings should show a warning when running a development build."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "מצב החלון ההתחלתי"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr "סדרה של ערכים שמכילה את הרוחב, הגובה ומצב ההגדלה של חלון היישום."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "ערוץ פלט אחד"
+msgstr[1] "שני ערוצי פלט"
+msgstr[2] "‫%u ערוצי פלט"
+msgstr[3] "‏‫%u ערוצי פלט"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "ערוץ קלט אחד"
+msgstr[1] "שני ערוצי קלט"
+msgstr[2] "‏‫%u ערוצי קלט"
+msgstr[3] "‏‫%u ערוצי קלט"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "צלילי מערכת"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "שגיאה: לא ניתן לקבוע את רמת HSI."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "שגיאה: לא ניתן לקבוע רמת HSI לא נכונה."
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "אישורי DER או PEM‏ (‎*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "הוספת מדפסת…"
+
+#~ msgid "Drip"
+#~ msgstr "טפטוף"
+
+#~ msgid "Glass"
+#~ msgstr "זכוכית"
+
+#~ msgid "Sonar"
+#~ msgstr "סונאר"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "הפעלה בטוחה אינה פעילה"
+
+#~ msgid "Basic Protection"
+#~ msgstr "הגנה בסיסית"
+
+#~| msgid "Add connection"
+#~ msgid "Extended Protection"
+#~ msgstr "הגנה מורחבת"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "הגנת אבטחה בסיסית"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "הגנת אבטחה מורחבת"
+
+#, fuzzy
+#~| msgid "Select a region"
+#~ msgid "SPI BIOS region"
+#~ msgstr "נא לבחור באזור"
+
+#, fuzzy
+#~| msgid "Suspend"
+#~ msgid "Suspend-to-ram"
+#~ msgstr "השהיה"
+
+#, fuzzy
+#~| msgid "Manufacturer"
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "יצרן"
+
+#~| msgid "PEAP _version"
+#~ msgid "MEI version"
+#~ msgstr "גרסת MEI"
+
+#~| msgctxt "Password mode"
+#~| msgid "Account disabled"
+#~ msgid "Secure Boot disabled"
+#~ msgstr "הפעלה בטוחה מושבתת"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "הפעלה בטוחה מופעלת"
+
+#~ msgid "Lock your screen"
+#~ msgstr "נעילת המסך"
+
+#~ msgid "Light"
+#~ msgstr "בהיר"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "סידור צגים"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;"
+#~ "identity;"
+#~ msgstr ""
+#~ "מסך;צד;נעילה;ניתוח;דיאגנוסטיקה;קריסה;פרטיות;פרטי;אחרונים;אחרון;זמני;זמניים;מפתח;"
+#~ "אינדקס;שם;רשת;זהות;"
+
+#~ msgid "Set"
+#~ msgstr "הגדרה"
+
+#~ msgid "Bark"
+#~ msgstr "נביחה"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "לוח שמע בהגדרות GNOME"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "עכבר ולמשטח מגע בהגדרות GNOME"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "לוח הרקע בהגדרות GNOME"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "לוח המקלדת בהגדרות GNOME"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "אימות"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by connecting "
+#~ "to %s"
+#~ msgstr ""
+#~ "שיתוף מסך מאפשר למשתמשים מרוחקים לצפות או לשלוח במסך שלך על ידי התחברות אל ‎%s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "שיתוף _מסך"
+
+#~ msgid "_Password:"
+#~ msgstr "_ססמה:"
+
+#~ msgid "_Show Password"
+#~ msgstr "ה_צגת ססמה"
+
+#~ msgid "Access Options"
+#~ msgstr "אפשרויות גישה"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "התחברויות ח_דשות מחייבות בקשת גישה"
+
+#~ msgid "_Require a password"
+#~ msgstr "_דרושה ססמה"
+
+#~ msgid "More Warm"
+#~ msgstr "יותר חם"
+
+#~ msgid "Less Warm"
+#~ msgstr "פחות חם"
+
+#~ msgid "Move up"
+#~ msgstr "הזזה למעלה"
+
+#~ msgid "Move down"
+#~ msgstr "הזזה למטה"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Show the screenshot UI"
+#~ msgstr "הצגת מנשק משתמש לצילום מסך"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "צילום המסך"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "צילום החלון"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "הצגת מנשק המשתמש להקלטת מסך"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "לאפשר ליישומים הבאים להשתמש במיקרופון שלך."
+
+#~ msgid "Standard"
+#~ msgstr "רגיל"
+
+#~ msgid "Account _Type"
+#~ msgstr "_סוג החשבון"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "בחירת ססמה ב_כניסה הבאה"
+
+#~ msgid "Set a password _now"
+#~ msgstr "הגדרת ססמה _כעת"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "עליך להתחבר לרשת כדי להוסיף משתמשים ארגוניים."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "צילום תמונה…"
+
+#~ msgid "_Confirm New Password"
+#~ msgstr "_אימות הססמה החדשה"
+
+#~ msgid "Your account"
+#~ msgstr "החשבון שלך"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "כדי לערוך שינויים,\n"
+#~ "ראשית יש ללחוץ על הסמל *"
+
+#~ msgid "Create a user account"
+#~ msgstr "יצירת חשבון משתמש"
+
+#~ msgid "User Icon"
+#~ msgstr "סמל משתמש"
+
+#~ msgid "Account Settings"
+#~ msgstr "הגדרות משתמש"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "אימות והתחברות"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "שם זה ישמש לשם תיקיית הבית שלך ולא יהיה ניתן לשנותו."
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "שמירת צילום מסך לתיקייה $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "שמירת צילום מסך של אזור מסוים לתיקייה $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "העתקת צילום מסך ללוח הגזירים"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "העתקת צילום של חלון ללוח הגזירים"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "העתקת צילום מסך של אזור ללוח הגזירים"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "הסרטת המסך"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect on "
+#~ "next login."
+#~ msgstr "בחירת תבנית עבור מספרים, תאריכים ומטבעות. השינוי יופיע החל מהכניסה הבאה."
+
+#~ msgid "My Account"
+#~ msgstr "החשבון שלי"
+
+#~ msgid "Language"
+#~ msgstr "שפה"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "השפה שתשמש עבור הטקסט בחלונות ובדפי האינטרנט."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "יש לסגור את ההפעלה הנוכחית כדי להחיל את השינויים"
+
+#~ msgid "Restart…"
+#~ msgstr "הפעלה מחדש…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "הגדרות כניסה נמצאות בשימוש על ידי כל המשתמשים בעת כניסה למערכת"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The order of "
+#~ "search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "שליטה בתוצאות החיפוש אשר תופענה בסקירת פעילויות. הסדר של תוצאות החיפוש ניתן "
+#~ "לשינוי גם כן על ידי הזזת השורות ברשימה."
+
+#~ msgid "Output:"
+#~ msgstr "פלט:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "שמירה על יחס התצוגה (פסים שחורים):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "מיפוי לצג יחיד"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d מתוך %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "הצגת מיפוי"
+
+#~ msgid "Stylus"
+#~ msgstr "עט מגע"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "לוח (מוחלט)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "משטח מגע"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "העדפות מחשב לוח"
+
+#~ msgid "_Help"
+#~ msgstr "_עזרה"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "הגדרות בלוטות'"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "מצב עקיבה"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "מיפוי לחצנים…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "התאמת הגדרות העכבר"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "התאמת רזולוציית התצוגה"
+
+#~ msgid "Decouple Display"
+#~ msgstr "ניתוק תצוגה"
+
+#~ msgid "No stylus found"
+#~ msgstr "לא נמצא עט"
+
+#~ msgid "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "יש להזיז את העט שלך בסמוך ללוח כדי להגדיר אותו"
+
+#~ msgid "Top Button"
+#~ msgstr "לחצן עליון"
+
+#~ msgid "Lower Button"
+#~ msgstr "הלחצן הנמוך יותר"
+
+#~ msgid "Lowest Button"
+#~ msgstr "הלחצן הנמוך יותר"
+
+#~ msgid "Web Links"
+#~ msgstr "קישורים לאתרים"
+
+#~ msgid "Git Links"
+#~ msgstr "קישורים למאגרי Git"
+
+#~ msgid "%s Links"
+#~ msgstr "‏%s קישורים"
+
+#~ msgid "Unset"
+#~ msgstr "לא נקבע"
+
+#~ msgid "Links"
+#~ msgstr "קישורים"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "קובצי היפרטקסט"
+
+#~ msgid "Text Files"
+#~ msgstr "קובצי טקסט"
+
+#~ msgid "Image Files"
+#~ msgstr "קובצי תמונות"
+
+#~ msgid "Font Files"
+#~ msgstr "קובצי גופנים"
+
+#~ msgid "Archive Files"
+#~ msgstr "קובצי ארכיון"
+
+#~ msgid "Package Files"
+#~ msgstr "קובצי חבילות"
+
+#~ msgid "Audio Files"
+#~ msgstr "קובצי שמע"
+
+#~ msgid "Video Files"
+#~ msgstr "קובצי וידאו"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "הרשאות וגישה"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions that it "
+#~ "requires."
+#~ msgstr "מידע ושירותים הנדרשים עבור יישום זה."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "לא ניתן לשנות"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr "הרשאות מיוחדות ניתנות לשינוי בהגדרות <a href=\"privacy\">הפרטיות</a>."
+
+#~ msgid "Integration"
+#~ msgstr "שילוב"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "הגדרת רקע שולחן העבודה"
+
+#~ msgid "Default Handlers"
+#~ msgstr "מפעיל בררת מחדל"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "סוגי קבצים וקישורים אותם היישום פותח."
+
+#~ msgid "Usage"
+#~ msgstr "שימוש"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "המשאבים בשימוש היישום."
+
+#~ msgid "Open in Software"
+#~ msgstr "פתיחה בתכנות"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "לאפשר ליישומים הבאים להשתמש במצלמה שלך."
+
+#~ msgid "Display Mode"
+#~ msgstr "מצב תצוגה"
+
+#~ msgid "Join Displays"
+#~ msgstr "צירוף צגים"
+
+#~ msgid "Single Display"
+#~ msgstr "צג יחיד"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to change "
+#~ "its settings."
+#~ msgstr ""
+#~ "ניתן לגרור את הצגים על מנת להתאימם למיקום הפיזי שלהם. בחירה בצג תאפשר לשנות את "
+#~ "ההגדרות שלו."
+
+#~ msgid "Active Display"
+#~ msgstr "צג פעיל"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi and "
+#~ "mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "שירותי האיכון מאפשרים ליישומים לזהות את המיקום שלך. \n"
+#~ "הדיוק גדל עם הפעלת אינטרנט אלחוטי ופס רחב נייד."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/"
+#~ "privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "שימוש בשירות האיכון של מוזילה: <a href='https://location.services.mozilla.com/"
+#~ "privacy'>מדיניות פרטיות</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "לאפשר ליישומים שלהלן לאכן את המיקום שלך."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "התגלו ירכיים: מצב ביצועים לא זמין"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "טמפרטורת חומרה גבוהה: מצב הביצוע אינו זמין"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "מצב הביצוע אינו זמין"
+
+#~ msgid "Sound Keys"
+#~ msgstr "צלילי מקשים"
+
+#~ msgid "Screen Reader"
+#~ msgstr "מקריא מסך"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "מ_קריא מסך"
+
+#~ msgid "Activities"
+#~ msgstr "פעילויות"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "העלאת הקובץ נכשלה: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "הפרופיל הועלה אל:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "כדאי לכתוב לך את הכתובת הזאת."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "יש להפעיל מחדש את המחשב ולטעון את מערכת ההפעלה הרגילה שלך."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "יש למלא את כתובת האתר בדפדפן שלך להורדה ולהתקנת הפרופיל."
+
+#~ msgid "Upload profile"
+#~ msgstr "העלאת פרופיל"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "נדרש חיבור לאינטרנט"
+
+#~ msgid "_Copy"
+#~ msgstr "ה_עתקה"
+
+#~ msgid "Select _All"
+#~ msgstr "בחירה בה_כול"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "תום זמן ההמתנה ללחיצה כפולה"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "השהיה וכפתור כיבוי"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "יתכן שחלק מהשירותים יושבתו עקב העדר גישה לרשת."
+
+#~ msgid "Unlocking..."
+#~ msgstr "מתבצע שחרור…"
+
+#~ msgid "Select your display language, formats, keyboard layouts and input sources"
+#~ msgstr "ניתן לבחור את שפת התצוגה, התבניות, פריסות המקלדת ומקורות הקלט"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "כניסה;שם;טביעת אצבע;תמונה אישית;לוגו;פרצוף;פנים;ססמה;"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "צירופי מקשים"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "ניתן לשנות זאת בצירופי מקשים מותאמים"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "יש ללחוץ כאן על מנת לבחור תווים שונים"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "בהירות המ_סך"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "בהירות המ_קלדת"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "עמעום המסך בחוסר פעילות"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "ה_חשכת המסך"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "רשת _אלחוטית"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "ניתן לכבות את הרשת האל־חוטי על מנת לשמור סוללה."
+
+#~ msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr "ניתן לכבות פס רחב נייד (‏‏LTE, 4G, 3G וכו׳) על מנת לשמור סוללה."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_בלוטות'"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "ניתן לכבות את הבלוטות' על מנת לשמור סוללה."
+
+#~ msgid "Balanced Power"
+#~ msgstr "צריכת חשמל מאוזנת"
+
+#~ msgid "Add…"
+#~ msgstr "הוספה…"
+
+#~ msgid "Left Alt"
+#~ msgstr "‏Alt שמאלי"
+
+#~ msgid "Right Alt"
+#~ msgstr "‏Alt ימני"
+
+#~ msgid "Left Super"
+#~ msgstr "‏Super שמאלי"
+
+#~ msgid "Right Super"
+#~ msgstr "‏Super ימני"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "‏Ctrl ימני"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "מקש לתווים חלופיים"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "העברה באמצעות מקשי החלפה בלבד למקור הבא"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "מקש תפריט"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "בטעינה"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "אזהרה"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "נמוך"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "טוב"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "בטעינה מלאה"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "ריקה"
+
+#~ msgid "Previous source"
+#~ msgstr "המקור הקודם"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+רווח"
+
+#~ msgid "Next source"
+#~ msgstr "המקור הבא"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+רווח"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "שמאלי+Alt ימני"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "הוספת משתמשים ושינוי הססמה שלך"
+
+#~ msgid "Play and record sound"
+#~ msgstr "הפעלה והקלטת שמע"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "זיהוי התקני רשת באמצעות mDNS/DNS-SD ‏(Bonjour/zeroconf)."
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "גישה ישירה לחומרת בלוטות'"
+
+#~ msgid "Use your camera"
+#~ msgstr "שימוש במצלמה שלך"
+
+#~ msgid "Print documents"
+#~ msgstr "הדפסת מסמכים"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "שימוש בבקר מחובר"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "לאפשר להתחברויות לשלוט במסך"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "הגדרת חומת אש לרשת"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "הגדרה ושימוש במערכות קביצם מותאמות (FUSE)"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "עדכון חומת אש שבהתקן"
+
+#~ msgid "Access hardware information"
+#~ msgstr "גישה למידע על החומרה"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "לספק נקודת מוצא למייצר המספרים האקראיים של החומרה"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "שימוש במייצר המספרים האקראיים של החומרה"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "גיש לקבצים בתיקיית הבית שלך"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "גישה לשירותי libvirt"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "שינוי הגדרות השפה והאזור של המערכת"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "שינוי הגדרות המיקום והספקים"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "קריאת יומני המערכת והיישומים"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "גישה לשירותי MediaHub"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "שימוש והגדרת מודם"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "קורא מידע על קיבולת כונן במערכת."
+
+#~ msgid "Control music and video players"
+#~ msgstr "שליטה בנגני מוסיקה וסרטים"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "שינוי הגדרות רשת בסיסיות"
+
+#~ msgid "Access the NetworkManager service to read and change network settings"
+#~ msgstr "גישה לשירות NetworkManager על מנת לקרוא ולשנות הגדרות רשת"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "גישה לקריאה להגדרות הרשת"
+
+#~ msgid "Change network settings"
+#~ msgstr "שינוי הגדרות רשת"
+
+#~ msgid "Read network settings"
+#~ msgstr "קריאת הגדרות רשת"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr "גישה לשרת oFono לקריאה ושינוי הגדרות הרשת לטלפונייה ניידת."
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "שליטה בחומרת Open vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "קריאה מתקליטור CD\\DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "קריא, הוספה, שינוי או הסרה של ססות שמורות"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol connections"
+#~ msgstr "גישה להתקני PPPD ו-PPP עבור הגדרת חיבורי PPP."
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "השהייה או סיום כל תהליך מערכת"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "גישה ישירה לחומרת מדיה נתיקה (USB)"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "קריאה/כתיבת קבצים על אחסון מדיה נתיקה"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "מניעת מצב נעילה/שינה למסך"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "גישה לסדרת פתחות חומרה"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "הפעלה מחדש או כיבוי של ההתקן"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "התקנה, הסרה והגדרת תכנה"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "גישה למסגרת שרת האחסון"
+
+#~ msgid "Read process and system information"
+#~ msgstr "קריאת תהליכים ומידע מערכת"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "הצגה ושליטה בכל תכנית שרצה"
+
+#~ msgid "Change time server settings"
+#~ msgstr "שינוי הגדרת שרת הזמן"
+
+#~ msgid "Change the time zone"
+#~ msgstr "שינוי אזור הזמן"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr "גישה לשירות ה־UDisks2 להגדרה כוננים ומדיה נתיקה"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "קריאה/שינוי אירועי יומן משותפים ב־Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "קריאה/שינוי אנשי קשר משותפים ב־Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "גישה למידע על שימוש באנרגיה"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "גישה לקריאה/כתיבה להתקין U2F גלויים"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "גישה אוניברסלית"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "יש לכבות כדי להתחבר לרשת אלחוטית"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "ססמה"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "כדי ליצור משתמש,\n"
+#~ "ראשית יש ללחוץ על הסמל *"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "הפעלת התחברות באמצעות טביעת אצבע"
+
+#~ msgid "_Other finger:"
+#~ msgstr "אצבע א_חרת: "
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in using "
+#~ "your fingerprint reader."
+#~ msgstr ""
+#~ "טביעת האצבע שלך נשמרה בהצלחה. כעת ההתחברות באמצעות קורא טביעות האצבעות שלך "
+#~ "אמורה להיות אפשרית."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system administrator."
+#~ msgstr "אין מורשה לגשת להתקן. צור קשר עם מנהל המערכת שלך."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "אירעה שגיאה פנימית."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "האם למחוק את טביעות האצבע הרשומות?"
+
+#~ msgid "Done!"
+#~ msgstr "בוצע!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "אין אפשרות לגשת אל התקן „%s”"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "לא ניתן להפעיל את לכידת האצבע על ההתקן „%s”"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "לא ניתן לגשת לקוראי טביעות האצבעות"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "נא ליצור קשר עם מנהל המערכת שלך לקבלת עזרה."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, using "
+#~ "the “%s” device."
+#~ msgstr ""
+#~ "כדי לאפשר התחברות באמצעות טביעת אצבע, עליך לשמור את אחת מטביעות האצבעות שלך, "
+#~ "באמצעות ההתקן „%s”."
+
+#~ msgid "Selecting finger"
+#~ msgstr "נבחרת אצבע"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "משתנה במהלך היום"
+
+#~ msgid "_Lock Screen"
+#~ msgstr "מסך _נעילה"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "ריצוף"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "תקריב"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "מרכוז"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "מילוי"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "פרישה"
+
+#~ msgid "Colors"
+#~ msgstr "צבעים"
+
+#~ msgid "Select Background"
+#~ msgstr "בחירת רקע"
+
+#~ msgid "Pictures"
+#~ msgstr "תמונות"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "ניתן להוסיף תמונות לתיקייה %s שלך והן תופענה כאן"
+
+#~ msgid "Back­ground"
+#~ msgstr "רקע"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "צבע"
+
+#~ msgid "Lid Closed"
+#~ msgstr "סגירה"
+
+#~ msgid "Mirrored"
+#~ msgstr "שכפול צגים"
+
+#~ msgid "Secondary"
+#~ msgstr "משני"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "סידור תצוגה משולבת"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "יש לגרור את התצוגות כדי לסדר אותן מחדש"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d הרץ (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d הרץ"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "סיבוב נגד כיוון השעון ב־90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "סיבוב ב־180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "סיבוב עם כיוון השעון ב־90°"
+
+#~ msgid "Size"
+#~ msgstr "גודל"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "הצגת הלוח העליון וסקירת פעילויות בתצוגה זו"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "צירוף תצוגה זו עם אחרת ליצירת שולחן עבודה נוסף"
+
+#~ msgid "Presentation"
+#~ msgstr "כיוון"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "הצגת מצגות ומדיה בלבד"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "הצגת התצוגה הקיימת שלך בשתי התצוגות"
+
+#~ msgid "Turn Off"
+#~ msgstr "ה_פעלה"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "אין להשתמש בתצוגה זו"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "לא ניתן לקבל את פרטי הצג"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "סידור _תצוגה משולבת"
+
+#~ msgid "Dis­plays"
+#~ msgstr "תצוגות"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "‏%s ‏%d סיביות (מזהה בנייה: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "‏%s %d סיביות"
+
+#~ msgid "Overview"
+#~ msgstr "סקירה"
+
+#~ msgid "Version %s"
+#~ msgstr "גרסה %s"
+
+#~ msgid "De­tails"
+#~ msgstr "פרטים"
+
+#~ msgid "Base system"
+#~ msgstr "מערכת הבסיס"
+
+#~ msgid "Disk"
+#~ msgstr "כונן"
+
+#~ msgid "Check for updates"
+#~ msgstr "בדיקת עדכונים"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "צירופי מקשים;חזרה;הבהוב;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "יש להקיש Esc לביטול."
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "הגדרת צירופי מקשים"
+
+#~ msgid "page 1"
+#~ msgstr "עמוד 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "אימות _פנימי"
+
+#~ msgid "page 2"
+#~ msgstr "עמוד 2"
+
+#~ msgid "Server"
+#~ msgstr "שרת"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "מחיקת שרת DNS"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "זוג מלופף (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "מנשק יחידת חיבור (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "מנשק בלתי תלוי במדיה (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 מסל״ש"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 מסל״ש"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 גסל״ש"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 גסל״ש"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "שיתוף עם משתמשים _אחרים"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "אזור _חומת אש"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "בררת מחדל"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "האזור מגדיר את רמת המהימנות של החיבור"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "_Reset"
+#~ msgstr "_איפוס"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it as a "
+#~ "preferred network"
+#~ msgstr "איפוס הגדרות הרשת הזאת לרבות ססמאות אך לשמור אותה כרשת מועדפת"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to automatically "
+#~ "connect"
+#~ msgstr "הסרת כל הפרטים הקשורים לרשת זו ולא לנסות להתחבר אליה אוטומטית"
+
+#~ msgid "Net­work"
+#~ msgstr "רשת"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set up a "
+#~ "wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "אם יש לך חיבור לאינטרנט שאינו אלחוטי, ניתן להשתמש בכלי זה כדי לשתף את חיבור "
+#~ "האינטרנט שלך עם אחרים."
+
+#~ msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "מעבר למצב נקודה אלחוטית תנתק אותך מהרשת <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "לא ניתן לגשת לאינטרנט דרך החיבור האלחוטי בזמן שהנקודה האלחוטית פעילה."
+
+#~ msgid "Proxy"
+#~ msgstr "מתווך"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "ללא"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "ידני"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "אוטומטית"
+
+#~ msgid "Add Device"
+#~ msgstr "הוספת התקן"
+
+#~ msgid "VPN Type"
+#~ msgstr "סוג ה־VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "שם הקבוצה"
+
+#~ msgid "Group Password"
+#~ msgstr "ססמת הקבוצה"
+
+#~ msgid "details"
+#~ msgstr "פרטים"
+
+#~ msgid "Show P_assword"
+#~ msgstr "הצגת _ססמה"
+
+#~ msgid "Make available to other users"
+#~ msgstr "שיתוף עם משתמשים אחרים"
+
+#~ msgid "identity"
+#~ msgstr "זהות"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "כתובות אוטומטיות (DHCP) בלבד"
+
+#~ msgid "Link-local only"
+#~ msgstr "קישור מקומי בלבד"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "הת_עלמות אוטומטית מנתיבים שהתקבלו"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "כתובת MAC מ_שוכפלת"
+
+#~ msgid "hardware"
+#~ msgstr "חומרה"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as a "
+#~ "preferred connection."
+#~ msgstr "איפוס ההגדרות של חיבור זה לבררת המחדל אך לשמור כחיבור מועדף."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to automatically "
+#~ "connect to it."
+#~ msgstr "הסרת כל הפרטים הקשורים לרשת זו ולא לנסות להתחבר אליה."
+
+#~ msgid "Hardware"
+#~ msgstr "חומרה"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "איפוס"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "שימוש _כנקודת גישה…"
+
+#~ msgid "_History"
+#~ msgstr "היס_טוריה"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "ייעודית"
+
+#~ msgid "Infrastructure"
+#~ msgstr "תשתית"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "מודעות גרפיות ה_תרעתיות"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "התרעות"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "מודעות גרפיות ה_תרעתיות"
+
+#~ msgid "Add Account"
+#~ msgstr "הוספת חשבון"
+
+#~ msgid "Mail"
+#~ msgstr "דוא״ל"
+
+#~ msgid "Calendar"
+#~ msgstr "לוח שנה"
+
+#~ msgid "Contacts"
+#~ msgstr "אנשי קשר"
+
+#~ msgid "Chat"
+#~ msgstr "צ׳אט"
+
+#~ msgid "Error creating account"
+#~ msgstr "שגיאה בעת יצירת החשבון"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "האם אכן ברצונך להסיר את החשבון?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "פעולה זו לא תסיר את החשבון מהשרת."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "לא הוגדרו חשבונות מקוונים"
+
+#~ msgid "Add an online account"
+#~ msgstr "הוספת חשבון מקוון"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, mail, "
+#~ "contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "הוספת חשבון מאפשרת ליישום שלך לגשת באמצעותו למסמכים, דוא״ל, אנשי קשר, יומן, "
+#~ "תכנית הצ׳אט ועוד."
+
+#~ msgid "_Mobile broadband"
+#~ msgstr "רשת ס_לולרית"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "ה_שהיה אוטומטית"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "כאשר כפתור ה_כיבוי נלחץ"
+
+#~ msgid "Po­wer"
+#~ msgstr "חשמל"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "מתבצעת הגדרה"
+
+#~ msgid "Toner Level"
+#~ msgstr "רמת הטונר"
+
+#~ msgid "Supply Level"
+#~ msgstr "רמת האספקה"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "מתבצעת התקנה"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u פעילה"
+#~ msgstr[1] "%u פעילות"
+#~ msgstr[2] "2 פעילות"
+
+#~ msgid "No printers detected."
+#~ msgstr "לא זוהו מדפסות."
+
+#~ msgid "Supply"
+#~ msgstr "אספקה"
+
+#~ msgid "Jobs"
+#~ msgstr "משימות"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "הצגת מ_שימות"
+
+#~ msgid "label"
+#~ msgstr "תווית"
+
+#~ msgid "page 3"
+#~ msgstr "עמוד 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "הדפסת דף _ניסיון"
+
+#~ msgid "_Options"
+#~ msgstr "א_פשרויות"
+
+#~ msgid "In use"
+#~ msgstr "בשימוש"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "פועל"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "כבוי"
+
+#~ msgid "Usage & History"
+#~ msgstr "שימוש והיסטוריה"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "מדיניות פרטיות"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "פרטיות"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "הגנה על המידע האישי שלך ושליטה במה שאחרים יכולים לראות"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items are "
+#~ "never shared over the network."
+#~ msgstr ""
+#~ "שמירת ההיסטוריה מקלה עליך בחיפוש דברים מהעבר. פריטים אלה אינם משותפים ברשת."
+
+#~ msgid "_Recently Used"
+#~ msgstr "ב_שימוש לאחרונה"
+
+#~ msgid "Retain _History"
+#~ msgstr "שמי_רת ההיסטוריה"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "נעילת המסך מגנה על הפרטיות שלך כשאינך מול המחשב."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "יש לנעול את המסך לאחר ה_חשכה של"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your computer "
+#~ "free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "למחוק את האשפה ואת הקבצים הזמניים כדי לסייע לשמור על המחשב שלך נקי ממידע רגיש "
+#~ "בלתי חיוני."
+
+#~ msgid "Purge _After"
+#~ msgstr "לנקות ל_אחר"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you with "
+#~ "more accurate recommendations. It also helps us to improve our software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share your "
+#~ "data with third parties."
+#~ msgstr ""
+#~ "שליחת מידע על איזו תכנה משמשת אותך עוזרת לנו לספק לך המלצות מדויקות יותר. כמו "
+#~ "כן זה גם עוזר לנו לשפר את התכנה שלנו.\n"
+#~ "\n"
+#~ "כל המידע שאנו אוספים הנו בעילום שם, ואנו לעולם לא נשתף את המידע שלך עם צדדים "
+#~ "שלישיים."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_שליחת סטטיסטיקת שימוש בתכנה"
+
+#~ msgid "_Location Services"
+#~ msgstr "שירותי _איכון"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "מעבר למקור הקודם"
+
+#~ msgid "Switch to next source"
+#~ msgstr "מעבר למקור הבא"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "שינוי חלופי למקור הבא"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "אנגלית (אנגליה)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "אנגליה"
+
+#~ msgid "Add input source"
+#~ msgstr "הוספת מקור קלט"
+
+#~ msgid "Remove input source"
+#~ msgstr "הסרת מקור קלט"
+
+#~ msgid "Move input source up"
+#~ msgstr "העברת מקור הקלט מעלה"
+
+#~ msgid "Move input source down"
+#~ msgstr "העברת מקור הקלט מטה"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "הצגת מקור פריסת מקלדת"
+
+#~ msgid "Sha­ring"
+#~ msgstr "שיתוף"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "שמאל"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "ימין"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "מזערי"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "מרבי"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_סאבוופר:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_פרופיל:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "בדיקת ה_רמקולים"
+
+#~ msgid "Peak detect"
+#~ msgstr "זיהוי עצמה מרבית"
+
+#~ msgid "Device"
+#~ msgstr "התקן"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "בדיקת רמקולים עבור %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "ב_חירת התקן להשמעה:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "הגדרות עבור ההתקן הנבחר:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "עצמת ה_קלט:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "ב_חירת התקן להקלטת שמע:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "אפקטים קוליים"
+
+#~ msgid "_Alert volume:"
+#~ msgstr "עצמת צליל הה_תראה:"
+
+#~ msgid "Built-in"
+#~ msgstr "מובנה"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "העדפות שמע"
+
+#~ msgid "Testing event sound"
+#~ msgstr "אירוע הצליל בבדיקה"
+
+#~ msgid "From theme"
+#~ msgstr "מערכת הנושא"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "ב_חירת צליל התראה:"
+
+#~ msgid "Stop"
+#~ msgstr "עצירה"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "גישה אוניברסלית"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "ה_בהוב כותרת החלון"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "ססמה _חדשה"
+
+#~ msgid "Last Login"
+#~ msgstr "כניסה _אחרונה"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "כדאי להוסיף תווים, מספרים וסימנים."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "חוזק: חלשה"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "חוזק: חלשה"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "חוזק: בינונית"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "חוזק: טובה"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "חוזק: גבוהה"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "הססמאות אינן תואמות."
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "רגיל"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "מנהל"
+
+#~ msgid "Disable image"
+#~ msgstr "נטרול התמונה"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "עיון אחר תמונות נוספות…"
+
+#~ msgid "Used by %s"
+#~ msgstr "בשימוש על ידי %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "חשבונות אחרים"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "שם המשתמש לא יכול להתחיל ב־„-”."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "למעלה"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "למטה"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "ללא"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "לוח מגע"
+
+#~ msgid "Left Ring"
+#~ msgstr "טבעת שמאלית"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "מצב טבעת שמאלית מס׳ %d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "מצב טבעת ימנית מס׳ %d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "פס מגע שמאלי"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "מצב פס מגע שמאלי מס׳ %d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "פס מגע ימני"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "מצב פס מגע ימני מס׳ %d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "מתג מצב טבעת שמאלית"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "מתג מצב טבעת ימנית"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "מתג מצב פס מגע שמאלי"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "מתג מצב פס מגע ימני"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "מתג מצב מס׳ %d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "לחצן שמאלי מס׳ %d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "לחצן ימני מס׳ %d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "לחצן עליון מס׳ %d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "לחצן תחתון מס׳ %d"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "לחיצה על לחצן העכבר השמאלי"
+
+#~ msgid "Scroll Up"
+#~ msgstr "גלילה למעלה"
+
+#~ msgid "Scroll Down"
+#~ msgstr "גלילה למטה"
+
+#~ msgid "Scroll Right"
+#~ msgstr "גלילה לימין"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME מרכז הבקרה"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "מרכז הבקרה הוא ממשק מרכזי של GNOME להגדרה של היבטים שונים של שולחן העבודה שלך."
+
+#~ msgid "Show the overview"
+#~ msgstr "Show the overview"
+
+#~ msgid "Quit"
+#~ msgstr "יציאה"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "חומרה"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "מערכת"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "הוספת מדפסת חדשה"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s – %s"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr "צירופי מקשים עבור <b>%s</b>. יש להזין צירוף מקש חד לשינוי."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press Backspace "
+#~ "to clear."
+#~ msgstr ""
+#~ "כדי לערוך מקש קיצור דרך, יש ללחוץ על השורה המתאימה ולהחזיק את צירוף המקשים החדש "
+#~ "או ללחוץ על Backspace כדי למחוק."
+
+#~ msgid "Error logging into the account"
+#~ msgstr "אירעה שגיאה בעת הכניסה לחשבון"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "תוקף פרטי הגישה פג."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "יש להיכנס כדי להפעיל חשבון זה."
+
+#~ msgid "_Sign In"
+#~ msgstr "_כניסה"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "הסרת קיצור דרך"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<פעולה לא ידועה>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to type "
+#~ "using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "לא ניתן להשתמש בקיצור הדרך „%s“ מכיוון שלא ניתן יהיה להקליד באמצעות מקש זה.\n"
+#~ "נא לנסות מקש או צירוף מקשים שונה כגון לחיצה על Ctrl, Alt או Shift יחדיו."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "קיצור הדרך „%s“ כבר משמש ל:\n"
+#~ "„%s“"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#~ msgstr "אם קיצור הדרך יוקצה מחדש אל „%s“, קיצור הדרך „%s“ יבוטל."
+
+#~ msgid "_Reassign"
+#~ msgstr "הקצאה _מחדש"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "הקיצור „%s” משויך לקיצור „%s”. האם ברצונך להגדיר אותו באופן אוטומטי ל־„%s”?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be disabled if "
+#~ "you move forward."
+#~ msgstr "‏„%s” משויך כעת אל „%s”, קיצור זה יושבת אם אפשרות זו תיבחר."
+
+#~ msgid "_Assign"
+#~ msgstr "ה_קצאה"
+
+#~ msgid "Login History"
+#~ msgstr "היסטוריית כניסה"
+
+#~ msgid "Add User Account"
+#~ msgstr "הוספת חשבון משתמש"
+
+#~ msgid "Bond"
+#~ msgstr "מאגד"
+
+#~ msgid "Team"
+#~ msgstr "צוות"
+
+#~ msgid "Bridge"
+#~ msgstr "גשר"
+
+#~ msgid "VLAN"
+#~ msgstr "רשת וירטואלית"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "לא ניתן לטעון את תוספי ה־VPN"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "הוספת חיבור לרשת"
+
+#~ msgid "Bond slaves"
+#~ msgstr "שותפים במאגד"
+
+#~ msgid "(none)"
+#~ msgstr "(אף אחד)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "שותפים במאגד"
+
+#~ msgid "Team slaves"
+#~ msgstr "שותפים בצוות"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "התקן InfiniBand אינו תומך במצב מחובר"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "לא נבחר אישור של רשות אישורים"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in connections to "
+#~ "insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+#~ "Authority certificate?"
+#~ msgstr ""
+#~ "חוסר אישור של רשות אישורים (CA) יכול לגרום להתחברויות לא בטוחות, רשתות אלחוטיות "
+#~ "מזויפות. האם ברצונך לבחור אישור של רשות אישורים?"
+
+#~ msgid "Ignore"
+#~ msgstr "התעלמות"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "נא לבחור באישור רשות אישורים"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "יש ל_בקש ססמה זו בכל פעם מחדש"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "לא לה_זהיר אותי שוב"
+
+#~ msgid "Yes"
+#~ msgstr "כן"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "אחר"
+
+#~ msgid "_Verify"
+#~ msgstr "אי_מות"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "משתמש בשם '%s' כבר קיים."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "משמש לקביעת המיקום הגאוגרפי שלך"
+
+#~ msgid "Done"
+#~ msgstr "בוצע"
+
+#~ msgid "Time _Zone"
+#~ msgstr "אזור _זמן"
+
+#~ msgid "Resume Printing"
+#~ msgstr "המשך פעולת מדפסת"
+
+#~ msgid "Pause Printing"
+#~ msgstr "השהיית ההדפסה"
+
+#~ msgid "Cancel Print Job"
+#~ msgstr "ביטול משימות הדפסה"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "מוחזקת"
+
+#~ msgid "Job Title"
+#~ msgstr "כותרת העבודה"
+
+#~ msgid "Job State"
+#~ msgstr "מצב המשימה"
+
+#~ msgid "Password:"
+#~ msgstr "ססמה:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "מקשים _חוזרים"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "הבהוב _סמן"
+
+#~ msgid "Zoom"
+#~ msgstr "תקריב"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "צבע"
+
+#~ msgid "_Delay:"
+#~ msgstr "ה_שהיה:"
+
+#~ msgid "_Speed:"
+#~ msgstr "_מהירות:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "קצר"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "אטי"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "ארוך"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "מהיר"
+
+#~ msgid "S_peed:"
+#~ msgstr "_מהירות:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "בדיקת ההגדרות שלך"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "אטית"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "מהירה"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_שמאל"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_ימין"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "מהירות ה_סמן"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "אטי"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "מהיר"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "אטי"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "מהיר"
+
+#~ msgid "No printers available"
+#~ msgstr "אין מדפסות זמינות"
+
+#~ msgid "Add New Printer"
+#~ msgstr "הוספת מדפסת חדשה"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "רשת אלחוטית דורשת מקור כוח נוסף"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled devices"
+#~ msgstr "שיתוף Bluetooth מאפשר לך לשתף קבצים עם התקני Bluetooth מופעלים אחרים"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "קבלה מהתקנים מהימנים בלבד"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "שמירת הקבצים הנכנסים בתיקיית ההורדות"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "כאשר עצמת הסוללה _חלשה מאוד"
+
+#~ msgid "Show help options"
+#~ msgstr "Show help options"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "כיבוי התקנים אלחוטיים"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "נטרול _בעת הקלדה"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "שירותי הרשת של המערכת אינם תואמים לגרסה זו."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "הצגת באנרים קופצים"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "צפייה במסך הנעילה"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "הצגת באנרים קופצים"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "הצגה במסך הנעילה"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "חיפוש אחר מדפסות רשת או סינון התוצאות"
+
+#~ msgid "Sorry"
+#~ msgstr "עמך הסליחה"
+
+#~ msgid "%d ے %d"
+#~ msgstr "%d ے %d"
+
+#~ msgid "United States"
+#~ msgstr "ארצות הברית"
+
+#~ msgid "Germany"
+#~ msgstr "גרמניה"
+
+#~ msgid "France"
+#~ msgstr "צרפתית"
+
+#~ msgid "Spain"
+#~ msgstr "ספרד"
+
+#~ msgid "China"
+#~ msgstr "סין"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "שיתוף מדיה ברשת זו"
+
+#~ msgid "Shared Folders"
+#~ msgstr "תיקיות משותפות"
+
+#~ msgid "column"
+#~ msgstr "עמודה"
+
+#~ msgid "Remove Folder"
+#~ msgstr "הסרת תיקייה"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "שיתוף תיקיות ציבוריות ברשת זו"
+
+#~ msgid "Immediately"
+#~ msgstr "מיידית"
+
+#~ msgid "Remote View"
+#~ msgstr "תצוגה מרחוק"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "אישור כל החיבורים"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "הגדרת התקן חדש"
+
+#~ msgid "Paired"
+#~ msgstr "מצוות"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "הגדרות עכבר ומשטח מגע"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "הגדרות המקלדת"
+
+#~ msgid "Send Files…"
+#~ msgstr "שליחת קבצים…"
+
+#~ msgid "Visibility"
+#~ msgstr "גילוי"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "גילוי של „%s“"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "האם להסיר את '%s' מרשימת ההתקנים?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next use."
+#~ msgstr "אם ההתקן יוסר, יהיה עליך להגדיר אותו שוב לפני השימוש הבא."
+
+#~ msgid "Device type:"
+#~ msgstr "סוג ההתקן:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "יצרן:"
+
+#~ msgid "Model:"
+#~ msgstr "דגם:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above fields."
+#~ msgstr "ניתן לגרור קובצי תמונה לחלון זה כדי להשלים אוטומטית את השדות שלהלן."
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "הצגת התצוגה העיקרית שלך גם במסך זה"
+
+#~ msgid "Combine"
+#~ msgstr "שילוב"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "צרף עם התצוגה העיקרית ליצירת מקום נוסף"
+
+#~ msgid "Don't use the display"
+#~ msgstr "לא ניתן לזהות את הצגים"
+
+#~ msgid "Install Updates"
+#~ msgstr "התקנת עדכונים"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "המערכת עדכנית"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "העדפות עכבר"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "נא לבחור את המנשק לשימוש עבור השירות החדש"
+
+#~ msgid "C_reate…"
+#~ msgstr "יצי_רה…"
+
+#~ msgid "_Interface"
+#~ msgstr "מ_נשק"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "חיפוש אחר מדפסות רשת או סינון התוצאות"
+
+#~ msgid "_Default"
+#~ msgstr "_בררת מחדל"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "ללא"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "שיתוף תיקייה ציבורית"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "יש לשתף עם התקנים מהימנים בלבד"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "שינוי תמונה עבור:"
+
+#~ msgid "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "בחירת תמונה שתוצג במסך הפתיחה עבור חשבון זה."
+
+#~ msgid "Gallery"
+#~ msgstr "גלריה"
+
+#~ msgid "Take a photograph"
+#~ msgstr "צילום תמונה"
+
+#~ msgid "Browse"
+#~ msgstr "עיון"
+
+#~ msgid "Photograph"
+#~ msgstr "צילום"
+
+#~ msgid "_Region:"
+#~ msgstr "א_זור:"
+
+#~ msgid "_City:"
+#~ msgstr "_עיר"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "קידום הזמן בשעה אחת."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "החזרת הזמן אחורה בשעה אחת."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "קידום הזמן בדקה אחת."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "החזרת הזמן אחורה בדקה אחת."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "החלפה בין AM ל־PM"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "רגיל"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "עם כיוון השעון"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 מעלות"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its placement."
+#~ msgstr "יש לבחור את הצג כדי לשנות את מאפייניו; יש לגרור אותו כדי לשנות את מיקומו."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "‏%a‎ ‏‎%l:%M %p"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "לא ניתן לשמור את תצורת הצג"
+
+#~ msgid "_Resolution"
+#~ msgstr "א_בחנה"
+
+#~ msgid "R_otation"
+#~ msgstr "סי_בוב"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "היפוך _מראה בצגים"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "לתשומת לבך: עלול להגביל את אפשרויות הרזולוציה"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "ניצולת הסוללה המשוערת: %s"
+
+#~ msgid "Hidden"
+#~ msgstr "מוסתר"
+
+#~ msgid "Visible"
+#~ msgstr "גלוי"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "שם וגילוי"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "שליטה על ההצגה שלך על המסך וברשת."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "הצגת השם המ_לא בסרגל העליון"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "הצגת השם המלא במסך ה_נעילה"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "מ_צב חשאיות"
+
+#~ msgid "_Login Name"
+#~ msgstr "שם ה_כניסה"
+
+#, fuzzy
+#~ msgid "Login _Password"
+#~ msgstr "_ססמה"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "הססמאות אינן תואמות"
+
+#~ msgid "Domain not found."
+#~ msgstr "המתחם לא נמצא"
+
+#~ msgid "Export"
+#~ msgstr "יצוא"
+
+#~ msgid "Left Shift"
+#~ msgstr "Shift שמאלי"
+
+#~ msgid "Right Shift"
+#~ msgstr "Shift ימני"
+
+#, fuzzy
+#~ msgid "Left Alt+Shift"
+#~ msgstr "החצי השמאלי"
+
+#, fuzzy
+#~ msgid "Right Alt+Shift"
+#~ msgstr "החצי הימני"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Ctrl שמאלי+Shift"
+
+#, fuzzy
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "החצי הימני"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Left+Shift ימני"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Left+Ctrl ימני"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "אטי"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "מהיר"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "ה_תוכן נצמד לאצבעות"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "אגף\n"
+#~ "הכתובות\n"
+#~ "שייך\n"
+#~ "לכאן"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "אגף\n"
+#~ "ה־DNS\n"
+#~ "שייך\n"
+#~ "לכאן"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "אגף\n"
+#~ "הניתובים\n"
+#~ "שייך\n"
+#~ "לכאן"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "No shortcut set"
+#~ msgstr "לא הוגדר קיצור דרך"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "רגילה"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "גבוהה/הפוכה"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "מקלדת על המסך"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "רגיל"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "צפצוף בעת הפעלה וכיבוי של Caps Lock ו־Num Lock"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "הפעלה או כיבוי:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "תקריב"
+
+#~ msgid "Zoom in:"
+#~ msgstr "התקרבות:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "התרחקות:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "כתוביות סיוע"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "הצגת תיאור מילולי של דיבור וצלילים."
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "מקלדת על המסך"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "קצר"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "ארוך"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "צפצוף בעת ביצוע פעולה על מקש"
+
+#~ msgid "pressed"
+#~ msgstr "נלחץ"
+
+#~ msgid "accepted"
+#~ msgstr "התקבל"
+
+#~ msgid "rejected"
+#~ msgstr "נדחה"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "השהיית _קבלה:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "שליטה על סמן העכבר באמצעות לחצני העכבר."
+
+#~ msgid "Video Mouse"
+#~ msgstr "עכבר בווידאו"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "שליטה על סמן העכבר באמצעות מצלמת וידאו."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "קטן"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "גדול"
+
+#~ msgid "_Local Account"
+#~ msgstr "חשבון מ_קומי"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "עצה: מתחם (domain) ארגוני או שם התחום (realm)"
+
+#~ msgid "C_ontinue"
+#~ msgstr "המ_שך"
+
+#~ msgid "Next Week"
+#~ msgstr "השבוע הבא"
+
+#~ msgid "Next week"
+#~ msgstr "השבוע הבא"
+
+#~ msgid "Log in without a password"
+#~ msgstr "כניסה ללא ססמה"
+
+#~ msgid "Disable this account"
+#~ msgstr "נטרול חשבון זה"
+
+#~ msgid "Enable this account"
+#~ msgstr "הפעלת חשבון זה"
+
+#~ msgid "_Action"
+#~ msgstr "_פעולה"
+
+#~ msgid "_Show password"
+#~ msgstr "ה_צגת ססמה:"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "כיצד לבחור ססמה חזקה"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "קצרה מדי"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "לא מספיק טוב"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "חלש"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "סביר"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "טוב"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "חזק"
+
+#~ msgid "_Generate a password"
+#~ msgstr "י_צירת ססמה"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "עליך להזין ססמה חדשה"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "הססמה החדשה אינה חזקה מספיק"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "עליך לאמת את הססמה"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "עליך להזין את הססמה הנוכחית שלך"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "הססמה הנוכחית אינה נכונה"
+
+#~ msgid "Switch Modes"
+#~ msgstr "החלפת מצבים"
+
+#~ msgid "Action"
+#~ msgstr "פעולה"
+
+#~ msgid "_Options…"
+#~ msgstr "א_פשרויות…"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "פרטי הגישה פגו. נא להיכנס שוב."
+
+#~ msgid "_Log In"
+#~ msgstr "_כניסה"
+
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "ללא"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Color management settings"
+#~ msgstr "הגדרות ניהול צבע"
+
+#~ msgid "British English"
+#~ msgstr "אנגלית בריטית"
+
+#~ msgid "Spanish"
+#~ msgstr "ספרדית"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "סינית (מפושטת)"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "לוח ניהול התאריך והשעה"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "שינוי הגדרות המקלדת"
+
+#~ msgid "Layout Settings"
+#~ msgstr "הגדרות פריסה"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "הגדרת העדפות העכבר ומשטח המגע שלך"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "ספק/קישור הוחלף"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "ניהול החשבונות המקוונים"
+
+#~ msgid "Power management settings"
+#~ msgstr "הגדרות ניהול צריכת חשמל"
+
+#~ msgid "Manufacturers"
+#~ msgstr "יצרנים"
+
+#~ msgid "Drivers"
+#~ msgstr "מנהל התקן"
+
+#~ msgid "Don't retain history"
+#~ msgstr "לא לשמור היסטורייה"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "שינוי ההגדרות בהתאם לשפה ולאזור"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-wide "
+#~ "Region and Language settings."
+#~ msgstr ""
+#~ "מסך הכניסה, חשבונות המערכת וחשבונות המשתמש החדשים משתמשים בהגדרות השפה והאזור "
+#~ "הכלליות."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-wide "
+#~ "Region and Language settings. You may change the system settings to match yours."
+#~ msgstr ""
+#~ "מסך הכניסה, חשבונות המערכת וחשבונות המשתמש החדשים משתמשים בהגדרות השפה והאזור "
+#~ "הכלליות. ניתן לשנות את הגדרות המערכת כדי שיתאימו להעדפותיך."
+
+#~ msgid "Copy Settings"
+#~ msgstr "העתקת ההגדרות"
+
+#~ msgid "Copy Settings…"
+#~ msgstr "העתקת ההגדרות…"
+
+#~ msgid "Region and Language"
+#~ msgstr "אזור ושפה"
+
+#~ msgid "Add Language"
+#~ msgstr "הוספת שפה"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "יש לבחור מיקום (השינוי יחול עם הכניסה הבאה לסביבת המשתמש)"
+
+#~ msgid "Add Region"
+#~ msgstr "הוספת אזור"
+
+#~ msgid "Remove Region"
+#~ msgstr "הסרת אזור"
+
+#~ msgid "Currency"
+#~ msgstr "מטבע"
+
+#~ msgid "Examples"
+#~ msgstr "דוגמאות"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "בחירת מקלדות או מקורות קלט אחרים"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+רווח"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "הגדרות הקיצורים"
+
+#~ msgid "Input source:"
+#~ msgstr "מקור הקלט:"
+
+#~ msgid "Format:"
+#~ msgstr "תבנית:"
+
+#~ msgid "Your settings"
+#~ msgstr "ההגדרות שלך"
+
+#~ msgid "System settings"
+#~ msgstr "הגדרות המערכת"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "העדפות הגישה האוניברסלית"
+
+#~ msgid "_Hint"
+#~ msgstr "_רמז"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to all "
+#~ "users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "רמז זה עשוי להיות מוצג במסך הפתיחה. כל משתמשי המערכת יוכלו לראות אותו.  מוטב "
+#~ "ש<b>לא</b> לכתוב את הססמה שלך כאן."
+
+#~ msgid "Fair"
+#~ msgstr "סביר"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "הגדרת העדפות לוח המגע שלך"
+
+#~ msgid "Create virtual device"
+#~ msgstr "יצירת התקן וירטואלי"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "שנה אחת"
+#~ msgstr[1] "%i שנים"
+#~ msgstr[2] "שנתיים"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "חודש אחד"
+#~ msgstr[1] "%i חודשים"
+#~ msgstr[2] "חודשיים"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "שבוע אחד"
+#~ msgstr[1] "%i שבועות"
+#~ msgstr[2] "שבועיים"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "פחות משבוע"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "התקן זה אינו מנוהל לפי צבעים."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "התקן זה משתמש בנתונים שכוילו בעת הייצור."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color correction."
+#~ msgstr "להתקן זה אין פרופיל המתאים לתיקון צבע במסך מלא."
+
+#~ msgid "Not specified"
+#~ msgstr "לא צוין"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "לא נמצאו התקנים התומכים בניהול צבע"
+
+#~ msgid "Add device"
+#~ msgstr "הוספת התקן"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "הוספת התקן וירטואלי"
+
+#~ msgid "Remove a device"
+#~ msgstr "הסרת התקן"
+
+#~ msgid "Out of range"
+#~ msgstr "מחוץ לטווח"
+
+#~ msgid "_Disconnect"
+#~ msgstr "_ניתוק"
+
+#~ msgid "_Connect"
+#~ msgstr "_חיבור"
+
+#~ msgid "_Settings…"
+#~ msgstr "ה_גדרות…"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "אזהרה, הסוללה חלשה, נותרו %s"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "מופעל באמצעות סוללה - נותרו %s"
+
+#~ msgid "Using battery power"
+#~ msgstr "מופעל באמצעות סוללה"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "בטעינה - הטעינה הושלמה"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "שימוש בעצמת האל־פסק - נותרו %s"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "אזהרה, עצמת האל־פסק חלשה"
+
+#~ msgid "Using UPS power"
+#~ msgstr "שימוש באל־פסק"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "הסוללה המשנית שלך טעונה במלואה"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "הסוללה המשנית שלך ריקה"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "בטעינה - הטעינה הושלמה"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is used"
+#~ msgstr "עצה: <a href=\"screen\">בהירות המסך</a> משפיעה על צריכת החשמל"
+
+#~ msgid "Don't suspend"
+#~ msgstr "אין להשהות"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "יש להשהות בעת חוסר פעילות במשך"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "בהירות ונעילה"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "בהירות;נעילה;עמעום;החשכה;צג;מסך;"
+
+#~ msgid "Screen turns off"
+#~ msgstr "המסך יכבה לאחר:"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "_עמעום המסך כדי לחסוך בחשמל"
+
+#~ msgid "_Lock screen after:"
+#~ msgstr "_נעילת המסך לאחר:"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "אין לנעול כאשר בבית"
+
+#~ msgid "Locations…"
+#~ msgstr "מקומות…"
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "לא קיים משתמש בשם '%s'."
+
+#~ msgid "This user does not exist."
+#~ msgstr "משתמש זה אינו קיים."
+
+#~ msgid "Browse Files..."
+#~ msgstr "עיון בקבצים..."
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "פרופילים הזמינים לתצוגות"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "פרופילים הזמינים לסורקים"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "פרופילים הזמינים למדפסות"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "פרופילים הזמינים למצלמות"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "פרופילים הזמינים למצלמות רשת"
+
+#~ msgid "English"
+#~ msgstr "אנגלית"
+
+#~ msgid "French"
+#~ msgstr "צרפתית"
+
+#~ msgid "Russian"
+#~ msgstr "רוסית"
+
+#~ msgid "Arabic"
+#~ msgstr "ערבית"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "דגם לא ידוע"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "בכניסה הבאה יתבצע ניסיון להשתמש בחוויה הרגילה."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported graphics "
+#~ "hardware."
+#~ msgstr "בכניסה הבאה יעשה שימוש במצב השחזור המיועד לחומרת גרפיקה שאינה נתמכת."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "שחזור"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "רגיל"
+
+#~ msgid "OS type"
+#~ msgstr "סוג מערכת ההפעלה"
+
+#~ msgid "_Other Media..."
+#~ msgstr "מדיה _אחרת..."
+
+#~ msgid "Experience"
+#~ msgstr "חוויה"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "מצב _שחזור מאולץ"
+
+#~ msgid "_Options..."
+#~ msgstr "_אפשרויות..."
+
+#~ msgid "C_reate..."
+#~ msgstr "י_צירה..."
+
+#~ msgid "_Settings..."
+#~ msgstr "ה_גדרות..."
+
+#~ msgid "_Show"
+#~ msgstr "ה_צגה"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "העתקת ההגדרות..."
+
+#~ msgid "Select a display language (change will be applied next time you log in)"
+#~ msgstr "יש לבחור שפת תצוגה (השינוי יחול עם הכניסה הבאה לסביבת המשתמש)"
+
+#~ msgid "Install languages..."
+#~ msgstr "התקנת שפות..."
+
+#~ msgid "Locations..."
+#~ msgstr "מיקומים..."
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Enable debugging code"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME Volume Control Applet"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "הצגת בקרת עצמה בשולחן העבודה"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "עצמת פלט השמע"
+
+#~ msgid "_Mute"
+#~ msgstr "ה_שתקה"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "העדפות _שמע"
+
+#~ msgid "Muted"
+#~ msgstr "מושתק"
+
+#~ msgid "Options..."
+#~ msgstr "אפשרויות..."
+
+#~ msgid "User Accounts"
+#~ msgstr "חשבונות משתמשים"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "עיון אחר תמונות נוספות..."
+
+#~ msgid "Map Buttons..."
+#~ msgstr "מיפוי לחצנים..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "כיול..."
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "רשת;אלחוטי;IP;LAN;פרוקסי"
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "נקודה אלחוטית"
+
+#~ msgid "Wireless"
+#~ msgstr "אלחוטי"
+
+#~ msgid "Mesh"
+#~ msgstr "סריג"
+
+#~ msgid "Remove Language"
+#~ msgstr "הסרת שפה"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "צבע"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "ללא"
+
+#~ msgid "- System Settings"
+#~ msgstr "- הגדרות מערכת"
+
+#~ msgid "System Settings"
+#~ msgstr "הגדרות מערכת"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "מסכת רשת"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "כדי לבדוק את ההגדרות שלך, יש ללחוץ פעמיים על הפרצוף."
+
+#~ msgid "_Search by Address"
+#~ msgstr "חיפוש לפי _כתובת"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, ipp, "
+#~ "ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD אינו פעיל. איתור מדפסות הרשת דורש שהשירותים mdns, ipp, ipp-client "
+#~ "ו־samba-client יופעלו בחומת האש."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "מקומי"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "רשת"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "תצורה אוטומטית"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "מתבצעת פתיחת חומת האש לחיבורי mDNS"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "מתבצעת פתיחת חומת האש לחיבורי Samba"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "מתבצעת פתיחת חומת האש לחיבורי IPP"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "הוספת רקע"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "הסרת רקע"
+
+#~ msgid "Swap colors"
+#~ msgstr "החלפה בין הצבעים"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "מדרג אופקי"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "מדרג אנכי"
+
+#~ msgid "Solid Color"
+#~ msgstr "צבע אחיד"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "צבעים ומדרגים"
+
+#~ msgid "Acti_on:"
+#~ msgstr "פ_עולה:"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_ימניים"
+
+#~ msgid "_Left-handed"
+#~ msgstr "שמאליים"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "ה_צגת מיקום הסמן בעת לחיצה על Ctrl"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "_קיצור:"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_רגישות:"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "גרירה והשלכה"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "_סף:"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "סף הגרירה"
+
+#~ msgid "_Timeout:"
+#~ msgstr "_פרק זמן:"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "הפעלת _לחיצות עכבר עם משטח מגע"
+
+#~ msgid "_Disabled"
+#~ msgstr "מ_נוטרל"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "אחר..."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "האם ליצור את נקודת הגישה בכל זאת ?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "האם להתנתק מהרשת %s וליצור נקודת גישה חדשה ?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "זהו החיבור היחיד שלך לאינטרנט."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "יצירת _נקודת גישה"
+
+#~ msgid "_Network Name"
+#~ msgstr "שם ה_רשת"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "_עצירת נקודת הגישה..."
+
+#~ msgid "Disable VPN"
+#~ msgstr "נטרול ה־VPN"
+
+#~ msgid "_Back"
+#~ msgstr "_חזרה"
+
+#~ msgid "Allowed users"
+#~ msgstr "משתמשים מורשים"
+
+#~ msgid "Account _type"
+#~ msgstr "סוג ה_חשבון"
+
+#~ msgid "HTTP Port"
+#~ msgstr "פתחת HTTP"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "פתחת HTTPS"
+
+#~ msgid "FTP Port"
+#~ msgstr "פתחת FTP"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "כדי להוסיף חשבון חדש, ראשית עליך לבחור את סוג החשבון"
+
+#~ msgid "_Add..."
+#~ msgstr "הו_ספה..."
+
+#~ msgid "Select an account"
+#~ msgstr "נא לבחור חשבון"
+
+#~ msgid "Tip:"
+#~ msgstr "עצה:"
+
+#~ msgid "Brightness Settings"
+#~ msgstr "הגדרות בהירות"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "משפיע על כיצד נעשה שימוש בחשמל"
+
+#~ msgid "Create new account"
+#~ msgstr "יצירת חשבון חדש"
+
+#~ msgid "Cr_eate"
+#~ msgstr "י_צירה"
+
+#~ msgid "Add Layout"
+#~ msgstr "הוספת פריסה"
+
+#~ msgid "Remove Layout"
+#~ msgstr "הסרת פריסה"
+
+#~ msgid "Preview Layout"
+#~ msgstr "תצוגה מקדימה של הפריסה"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "חלונות חדשים ישתמשו בפריסת בררת המחדל"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "חלונות חדשים ישתמשו בפריסת החלון הקודם"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "החזרה ל_בררת המחדל"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "החלפת הגדרות פריסת המקלדת הנוכחית\n"
+#~ "בהגדרות בררת המחדל"
+
+#~ msgid "Layouts"
+#~ msgstr "פריסות"
+
+#~ msgid "Layout"
+#~ msgstr "פריסה"
+
+#~ msgid "Change contrast:"
+#~ msgstr "שינוי הבהירות:"
+
+#~ msgid "_Text size:"
+#~ msgstr "_גודל הטקסט:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "תקריב"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "ניתן לכתוב כאן כדי לבדוק את ההגדרות"
+
+#~ msgid "1/4 Screen"
+#~ msgstr "1/4 צג"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 צג"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 צג"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "בחירת ססמה שנוצרה אוטומטית"
+
+#~ msgid "More choices..."
+#~ msgstr "אפשרויות נוספות..."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "לוח גרפי Wacom"
+
+#~ msgid "Display Mapping..."
+#~ msgstr "הצגת המיפוי..."
+
+#~ msgid "Battery discharging"
+#~ msgstr "הסוללה מתרוקנת"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s עד לטעינה מלאה (%.0lf%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s עד לפריקה מלאה (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% נטענו"
+
+#~ msgid "Always"
+#~ msgstr "תמיד"
+
+#~ msgid "Color and Opacity"
+#~ msgstr "צבע ואטימות"
+
+#~ msgid "Image moves with the mouse pointer"
+#~ msgstr "התמונה זזה עם סמן העכבר"
+
+#~ msgid "Image scrolls at screen edges"
+#~ msgstr "התמונה נגללת בקצוות המסך"
+
+#~ msgid "Moveable lens - magnified view follows mouse movements"
+#~ msgstr "עדשה ניידת – תצוגה מוגדלת עוקבת אחר תנועות העכבר"
+
+#~ msgid "Position of magnified view on screen"
+#~ msgstr "מיקום התצוגה המוגדלת על גבי המסך"
+
+#~ msgid "Push"
+#~ msgstr "דחיפה"
+
+#~ msgid "Show"
+#~ msgstr "הצגה"
+
+#~ msgid "Show crosshairs intersection"
+#~ msgstr "הצגת הצטלבות סמני הצלב"
+
+#~ msgid "To keep the pointer centered"
+#~ msgstr "השארת הסמן ממורכז"
+
+#~ msgid "To keep the pointer visible"
+#~ msgstr "השרת הסמן גלוי"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "לא ניתן לאחזר את אפיק ההפעלה בעת החלת תצורת התצוגה"
+
+#~ msgid "_Photos:"
+#~ msgstr "תמו_נות:"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "החלפת מצב היפוך צבע"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "החלפת מצב זכוכית המגדלת"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "החלפת הפעלת מקריא מסך"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "יותר מדי קיצורי דרך מותאמים אישית"
+
+#~ msgid "Key"
+#~ msgstr "Key"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf key to which this property editor is attached"
+
+#~ msgid "Callback"
+#~ msgstr "Callback"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Issue this callback when the value associated with key gets changed"
+
+#~ msgid "Change set"
+#~ msgstr "Change set"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on apply"
+#~ msgstr ""
+#~ "GConf change set containing data to be forwarded to the gconf client on apply"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Conversion to widget callback"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the widget"
+#~ msgstr ""
+#~ "Callback to be issued when data are to be converted from GConf to the widget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Conversion from widget callback"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the widget"
+#~ msgstr ""
+#~ "Callback to be issued when data are to be converted to GConf from the widget"
+
+#~ msgid "UI Control"
+#~ msgstr "UI Control"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Object that controls the property (normally a widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Property editor object data"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Custom data required by the specific property editor"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Property editor data freeing callback"
+
+#~ msgid "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "Callback to be issued when property editor object data is to be freed"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different background "
+#~ "picture."
+#~ msgstr ""
+#~ "לא ניתן למצוא את הקובץ '%s'.\n"
+#~ "\n"
+#~ "נא לוודא כי הוא קיים, או לבחור בתמונת רקע אחרת."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "אין פרטים בנוגע לאופן פתיחת הקובץ '%s'.\n"
+#~ "ייתכן שזהו סוג של תמונה שטרם נתמכת.\n"
+#~ "\n"
+#~ "נא לבחור בתמונה אחרת במקום."
+
+#~ msgid "Please select an image."
+#~ msgstr "נא לבחור בתמונה."
+
+#~ msgid "Accelerator key"
+#~ msgstr "מקש קיצור"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "מאיצי החלפה"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "קוד מקש האצה"
+
+#~ msgid "Accel Mode"
+#~ msgstr "מצב האצה"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "סוג הקיצור."
+
+#~ msgid "Create a user"
+#~ msgstr "יצירת משתמש"
+
+#~ msgid "Ask me"
+#~ msgstr "הצגת שאלה"
+
+#~ msgid "Shutdown"
+#~ msgstr "כיבוי"
+
+#~ msgid "Only profiles that are compatible with the device will be listed above."
+#~ msgstr "רק פרופיל הנתמכים על ידי ההתקן יוצגו להלן."
+
+#~ msgid "24-_Hour Time"
+#~ msgstr "השעה בתצוגת _24 שעות"
+
+#~ msgid "Upside-down"
+#~ msgstr "היפוך"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "מדיה והפעלה אוטומטית"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "הגדרת העדפות המדיה וההפעלה האוטומטית"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "תקליטור;וידאו;אודיו;שמע;cd;dvd;usb;audio;video;disc;"
+
+#~ msgid "On AC _power:"
+#~ msgstr "מופעל באמצעות מ_קור חשמל:"
+
+#~ msgid "When the _sleep button is pressed:"
+#~ msgstr "כאשר לחצן ה_שינה נלחץ:"
+
+#~ msgid "_Turn off after:"
+#~ msgstr "_כיבוי לאחר:"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "מקלדת;עכבר;נגישות;"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f ק״ב"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f מ״ב"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f ג״ב"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f ט״ב"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f פ״ב"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f א״ב"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">גבוהה/הפוכה</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">גבוהה</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">נמוכה</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">רגילה</span>"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "שימוש בפריסת בררת המחדל בחלונות חדשים"
+
+#~ msgid "Use previous window's layout in new windows"
+#~ msgstr "יש להשתמש בפריסת החלון הקודם בחלונות חדשים"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "תיבת הדו־שיח משוחררת.\n"
+#~ "יש ללחוץ כדי למנוע שינויים נוספים"
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "תיבת הדו־שיח נעולה.\n"
+#~ "יש ללחוץ כדי לערוך שינויים"
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "מדיניות המערכת מונעת ביצוע שינויים.\n"
+#~ "נא ליצור קשר עם מנהל המערכת שלך."
+
+#~ msgid "Photos"
+#~ msgstr "תמונות"
+
+#~ msgid "Web"
+#~ msgstr "רשת"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "_קיצור:"
+
+#~ msgid "Beep when a modifer key is pressed"
+#~ msgstr "צפצוף בעת לחיצה על מקשי החלפה"
+
+#~ msgid "Current network location"
+#~ msgstr "Current network location"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "More backgrounds URL"
+
+#~ msgid "More themes URL"
+#~ msgstr "More themes URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string the "
+#~ "link will not appear."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the link "
+#~ "will not appear."
+#~ msgstr ""
+#~ "URL for where to get more desktop themes. If set to an empty string the link "
+#~ "will not appear."
+
+#~ msgid "An error has occured during a maintenance command."
+#~ msgstr "אירעה שגיאה במהלך פקודת התחזוקה."
+
+#~ msgid "16"
+#~ msgstr "16"
+
+#~ msgid "2010"
+#~ msgstr "2010"
+
+#~ msgid "Info"
+#~ msgstr "פרטים"
+
+#~ msgid "Set the system proxy settings"
+#~ msgstr "הגדרת תצורת מתווך המערכת"
+
+#~ msgid "Virtual private network"
+#~ msgstr "רשת וירטואלית פרטית"
+
+#~ msgid "The running NetworkManager version is not compatible (too new)."
+#~ msgstr "הגרסה הפעילה של NetworkManager אינה נתמכת (חדשה מדי)."
+
+#~ msgid "The running NetworkManager version is not compatible (too old)."
+#~ msgstr "הגרסה הפעילה של NetworkManager אינה נתמכת (ישנה מדי)."
+
+#~ msgid "DSL"
+#~ msgstr "DSL"
+
+#~ msgid "IP Address:"
+#~ msgstr "כתובת IP:"
+
+#~ msgid "Preparing connection"
+#~ msgstr "החיבור בהכנות"
+
+#~ msgid "Preparing"
+#~ msgstr "בהכנות"
+
+#~ msgctxt "Account type"
+#~ msgid "Supervised"
+#~ msgstr "בפיקוח"
+
+#~ msgid "Secure HTTP Proxy:"
+#~ msgstr "מתווך HTTP מאובטח:"
+
+#~ msgid "Chipset"
+#~ msgstr "ערכת שבבים"
+
+#~ msgid "LowContrast"
+#~ msgstr "ניגודיות_נמוכה"
+
+#~ msgid "Ctrl+Alt+0"
+#~ msgstr "Ctrl+Alt+0"
+
+#~ msgid "Ctrl+Alt+4"
+#~ msgstr "Ctrl+Alt+4"
+
+#~ msgid "Ctrl+Alt+8"
+#~ msgstr "Ctrl+Alt+8"
+
+#~ msgid "Ctrl+Alt+="
+#~ msgstr "Ctrl+Alt+="
+
+#~ msgid "Shift+Ctrl+Alt+-"
+#~ msgstr "Shift+Ctrl+Alt+-"
+
+#~ msgid "Shift+Ctrl+Alt+="
+#~ msgstr "Shift+Ctrl+Alt+="
+
+#~ msgid "Use an alternative form of text input"
+#~ msgstr "שימוש בצורה חלופית לקלט טקסט"
+
+#~ msgid "Language:"
+#~ msgstr "שפה:"
+
+#~ msgid "%i kb/s"
+#~ msgstr "%i קסל״ש"
+
+#~ msgid "More Info"
+#~ msgstr "פרטים נוספים"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "שגיאה בביטול מאיץ במסד נתוני ההגדרות: %s"
+
+#~ msgid "Idle"
+#~ msgstr "בהמתנה"
+
+#~ msgid "By _country"
+#~ msgstr "לפי _מדינה"
+
+#~ msgid "By _language"
+#~ msgstr "לפי _שפה"
+
+#~ msgid "_Country:"
+#~ msgstr "מ_דינה:"
+
+#~ msgid "_Variants:"
+#~ msgstr "ה_גוונים:"
+
+#~ msgid "Upside Down"
+#~ msgstr "היפוך"
+
+#~ msgid "\t"
+#~ msgstr "\t"
+
+#~ msgid "Description:"
+#~ msgstr "תיאור:"
+
+#~ msgid "Queue"
+#~ msgstr "תור"
+
+#~ msgid "Show / hide printer's jobs"
+#~ msgstr "הצגה / הסתרה של משימות המדפסת"
+
+#~ msgid "Battery power and inactive for:"
+#~ msgstr "על סוללה ובלתי פעיל למשך:"
+
+#~ msgid "Put the computer to sleep when on:"
+#~ msgstr "הרדמת המחשב כאשר הוא על:"
+
+#~ msgid "Hold"
+#~ msgstr "החזקה"
+
+#~ msgid "Release"
+#~ msgstr "שחרור"
+
+#~ msgid "toolbutton1"
+#~ msgstr "toolbutton1"
+
+#~ msgid "toolbutton2"
+#~ msgstr "toolbutton2"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "דגם המ_קלדת:"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "הזזת פריסת המקלדת הנבחרת במעלה הרשימה"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "הדפסת תרשים של פריסת המקלדת הנבחרת"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "הסרת פריסת המקלדת הנבחרת מהרשימה"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "נא לבחור פריסת מקלדת להוספה מהרשימה"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "בחירת סוג המקלדת"
+
+#~ msgid "_Models:"
+#~ msgstr "ד_גמים:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "י_צרנים:"
+
+#~ msgid "Vendors"
+#~ msgstr "יצרנים"
+
+#~ msgid "remove-toolbutton"
+#~ msgstr "remove-toolbutton"
+
+#~ msgid ""
+#~ "A guest account will allow anyone to temporarily log in to this computer "
+#~ "without a password.  For security, remote logins to this account are not "
+#~ "allowed.\n"
+#~ "\n"
+#~ "<b>When the guest user logs out, all files and data associated with the account "
+#~ "will be deleted.</b>"
+#~ msgstr ""
+#~ "חשבון אורח יאפשר זמנית לכל אחד להיכנס למחשב זה ללא ססמה. מטעמי אבטחה, התחברויות "
+#~ "מרחוק לחשבון זה אינן מורשות.\n"
+#~ "\n"
+#~ "<b>כאשר משתמש אורח יוצא מהמערכת, כל הקבצים והמידע המשויכים לחשבונו נמחקים</b>"
+
+#~ msgid "Accounts"
+#~ msgstr "חשבון"
+
+#~ msgid "Address Book Card:"
+#~ msgstr "כרטיס בספר הכתובות:"
+
+#~ msgid "Allow guests to log in to this computer"
+#~ msgstr "מתן האפשרות להיכנס למחשב זה כאורח"
+
+#~ msgid "E-mail address:"
+#~ msgstr "כתובת דוא״ל:"
+
+#~ msgid "Show Shutdown, Suspend and Restart actions"
+#~ msgstr "הצגת הפעולות כיבוי, השהיה והפעלה מחדש"
+
+#~ msgid "Show list of users"
+#~ msgstr "הצגת רשימת משתמשים"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "_ניתן לשלוט בסמן העכבר בעזרת המקלדת"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "ניתן ל_כתוב כדי לבדוק את ההגדרות:"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "יש לבחור את סוג הלחיצה מ_ראש"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "יש לבחור את סוג הלחיצה עם פעולת _עכבר"
+
+#~ msgid "D_rag click:"
+#~ msgstr "לחיצה ו_גרירה:"
+
+#~ msgid "Dwell Click"
+#~ msgstr "לחיצת השהיה"
+
+#~ msgid "Show click type _window"
+#~ msgstr "הצגת חלון _סוג הלחיצה"
+
+#~ msgid "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr "ניתן להשתמש ביישומון לחיצת ההשהיה על הלוח כדי לבחור את סוג הלחיצה."
+
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "ה_פעלת לחיצה כאשר נעצרת תזוזת העכבר"
+
+#~ msgid "_Single click:"
+#~ msgstr "_לחיצה בודדת:"
+
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr "ה_פעלת לחיצה משנית על ידי החזקת הכפתור הראשי"
+
+#~ msgid "PrintSelfTestPage"
+#~ msgstr "הדפסת_דף_בדיקה_עצמית"
+
+#~ msgid "Clean print heads command"
+#~ msgstr "פקודת ניקוי ראשי ההדפסה"
+
+#~ msgid "Foo;Bar;Baz;"
+#~ msgstr "שטויות;במיץ;"
+
+#~ msgid "Example preferences panel"
+#~ msgstr "לוח להדגמת ההעדפות"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "יישומים מועדפים"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "הפעלת טכנולוגיית הסיוע החזותי המועדפת"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "סיוע חזותי"
+
+#~ msgid "Error setting default browser: %s"
+#~ msgstr "שגיאה בהגדרת דפדפן בררת המחדל: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "לא ניתן להעלות את המנשק הראשי"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "כל המאורעות של %s יוחלפו בקישור ממשי"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "פ_קודה:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "דגל ה_פעלה:"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "מסרים מידיים"
+
+#~ msgid "Mail Reader"
+#~ msgstr "קורא דואר"
+
+#~ msgid "Mobility"
+#~ msgstr "ניידות"
+
+#~ msgid "Run at st_art"
+#~ msgstr "הרצה עם הה_פעלה"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "הרצה במ_סוף"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "מדמה מסוף"
+
+#~ msgid "Text Editor"
+#~ msgstr "עורך טקסט"
+
+#~ msgid "Visual"
+#~ msgstr "חזותי"
+
+#~ msgid "Web Browser"
+#~ msgstr "דפדפן אינטרנט"
+
+#~ msgid "_Run at start"
+#~ msgstr "הרצה _עם ההפעלה"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "נגן המוזיקה Banshee"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "מסוף בררת מחדל"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "זכוכית המגדלת של GNOME ללא קורא מסך"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus עם זכוכית מגדלת"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "זכוכית המגדלת של KDE ללא קורא מסך"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Linux Screen Reader"
+#~ msgstr "מקריא המסך של Linux"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "קורא המסך של Linux ללא זכוכית מגדלת"
+
+#~ msgid "Listen"
+#~ msgstr "האזנה"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "נגן המוסיקה Muine"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "‏Orca עם זכוכית מגדלת"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "נגן המוסיקה Rhytmbox"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "מסוף X רגיל"
+
+#~ msgid "Terminator"
+#~ msgstr "Terminator"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "נגן הסרטים Totem"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "12 hour format"
+#~ msgstr "מבנה 12 שעות"
+
+#~ msgid "24 hour format"
+#~ msgstr "מבנה 24 שעות"
+
+#~ msgid "Orange"
+#~ msgstr "כתום"
+
+#~ msgid "Chocolate"
+#~ msgstr "שוקולד"
+
+#~ msgid "Chameleon"
+#~ msgstr "זיקית"
+
+#~ msgid "Plum"
+#~ msgstr "שזיף"
+
+#~ msgid "Aluminium"
+#~ msgstr "אלומיניום"
+
+#~ msgid "Gray"
+#~ msgstr "אפור"
+
+#~ msgid "Slide Show"
+#~ msgstr "מצגת שקפים"
+
+#~ msgid "Image"
+#~ msgstr "תמונה"
+
+#~ msgid "%d %s by %d %s"
+#~ msgstr "%d %s ב־%d %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "תיקייה: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "תיקייה: %s"
+
+#~ msgid "Image missing"
+#~ msgstr "חסרה תמונה"
+
+#~ msgid "Location already exists"
+#~ msgstr "המיקום כבר קיים"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "הגדרת העדפות מתווך הרשת"
+
+#~ msgid "Web;Location;"
+#~ msgstr "אינטרנט;מיקום;"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>הגדרות מ_תווך ידניות</b>"
+
+#~ msgid "Autoconfiguration _URL:"
+#~ msgstr "_כתובת הגדרות אוטומטיות:"
+
+#~ msgid "Create New Location"
+#~ msgstr "יצירת מיקום חדש"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "פרטי מתווך HTTP"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "התעלמות מרשימת מארחים"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "העדפות מתווך רשת"
+
+#~ msgid "S_ocks host:"
+#~ msgstr "מא_רח ה־Socks:"
+
+#~ msgid "The location already exists."
+#~ msgstr "המיקום כבר קיים."
+
+#~ msgid "U_sername:"
+#~ msgstr "_שם משתמש:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "מתווך HTTP מ_אובטח"
+
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "_שימוש באותו המתווך עבור כל הפרוטוקולים"
+
+#~ msgid "_Detect Monitors"
+#~ msgstr "_זיהוי צגים"
+
+#~ msgid "Mirror Screens"
+#~ msgstr "היפוך התצוגה כמראה"
+
+#~ msgid "_Mirror Screens"
+#~ msgstr "היפוך _צגים"
+
+#~ msgid "Sound _theme:"
+#~ msgstr "_ערכת צלילים:"
+
+#~ msgid "Enable _window and button sounds"
+#~ msgstr "הפעלת צלילים עבור _חלונות ולחצנים"
+
+#~ msgid "I need assistance with:"
+#~ msgstr "אזדקק לעזרה עם:"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "דפדפן אינטרנט בררת מחדל"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "דפדפן האינטרנט Epiphany"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "קורא הדואר Evolution"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "דואר Iceape"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "דואר Mozilla"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "דואר SeaMonkey"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "_Include Top Menu Bar"
+#~ msgstr "ה_כללת סרגל התפריטים העליון"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "צג: %s"
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "לא ניתן לטעון את הסמל '%s' מהחבילה\n"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "הזזה שמאלה"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "הזזה ימינה"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "הזזה למעלה"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "הזזה למטה"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "כבוי"
+
+#~ msgid "Waiting for sound system to respond"
+#~ msgstr "בהמתנה לתגובה ממערכת השמע"
+
+#~ msgctxt "Sound event"
+#~ msgid "Windows and Buttons"
+#~ msgstr "חלונות ולחצנים"
+
+#~ msgctxt "Sound event"
+#~ msgid "Button clicked"
+#~ msgstr "לחיצה על לחצן"
+
+#~ msgctxt "Sound event"
+#~ msgid "Toggle button clicked"
+#~ msgstr "לחיצה על לחצן החלפה"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window maximized"
+#~ msgstr "הגדלת חלון"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window unmaximized"
+#~ msgstr "ביטול מזעור חלון"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window minimised"
+#~ msgstr "מזעור חלון"
+
+#~ msgctxt "Sound event"
+#~ msgid "Desktop"
+#~ msgstr "שולחן העבודה"
+
+#~ msgctxt "Sound event"
+#~ msgid "New e-mail"
+#~ msgstr "הודעת דוא״ל חדשה"
+
+#~ msgctxt "Sound event"
+#~ msgid "Long action completed (download, CD burning, etc.)"
+#~ msgstr "פעולה ארוכה הושלמה (הורדה, צריבת תקליטור וכו׳)"
+
+#~ msgctxt "Sound event"
+#~ msgid "Alerts"
+#~ msgstr "התראות"
+
+#~ msgctxt "Sound event"
+#~ msgid "Information or question"
+#~ msgstr "מידע או שאלה"
+
+#~ msgctxt "Sound event"
+#~ msgid "Warning"
+#~ msgstr "אזהרה"
+
+#~ msgid "Custom…"
+#~ msgstr "התאמה אישית…"
+
+#~ msgid "Sound Theme:"
+#~ msgstr "ערכת צלילים:"
+
+#~ msgid "Enable window and button sounds"
+#~ msgstr "הפעלת צלילים עבור חלונות ולחצנים"
+
+#~ msgid "Monitors"
+#~ msgstr "צגים"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "שיוך מקשי קיצור לפקודות"
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "צפצוף כאשר מקש _שינוי נלחץ"
+
+#~ msgid "Beep when a key is reje_cted"
+#~ msgstr "צפצוף כאשר מקש _נדחה"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "צפצוף כאשר מקש נ_דחה"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "הבהוב _כותרת החלון"
+
+#~ msgid "Flash entire _screen"
+#~ msgstr "הבהוב ה_מסך כולו"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "משוב קולי לנגישות מקלדת"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "הצגת משוב ח_זותי עבור צליל ההתראה"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "סימונים חזותיים עבור צלילים"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "_משוב קולי..."
+
+#~ msgid "Disa_ble sticky keys if two keys are pressed together"
+#~ msgstr "כי_בוי מקשים דביקים אם שני מקשים נלחצים יחד"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "העדפות מקלדת"
+
+#~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#~ msgstr "_ניתן להפעיל ולנטרל את תכונות הנגישות באמצעות קיצורי מקלדת"
+
+#~ msgid "_Ignore fast duplicate keypresses"
+#~ msgstr "ה_תעלמות מלחיצות מקש כפולות מהירות"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_קבלת לחיצות ארוכות בלבד"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "ה_דמיית לחיצות מספר מקשים במקביל"
+
+#~ msgid "Accessibility features can be turned on or off with keyboard shortcuts"
+#~ msgstr "ניתן לכבות או להפעיל את תכונות הנגישות בעזרת צירופי מקשים"
+
+#~ msgid "Image Viewer"
+#~ msgstr "מציג תמונות"
+
+#~ msgid "Multimedia"
+#~ msgstr "מולטימדיה"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "פתיחת קישור ב_לשונית חדשה"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "פתיחת קישור בחלון _חדש"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "פתיחת קישור לפי בררת המחדל של ה_דפדפן"
+
+#~ msgid "Include _panel"
+#~ msgstr "הכללת _לוח"
+
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors.xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors.xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "This program can only be used by the root user"
+
+#~ msgid "The source filename must be absolute"
+#~ msgstr "The source filename must be absolute"
+
+#~ msgid "Could not get information for %s: %s\n"
+#~ msgstr "Could not get information for %s: %s\n"
+
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s must be a regular file\n"
+
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "This program must only be run through pkexec(1)"
+
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "PKEXEC_UID must be set to an integer value"
+
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "%s must be owned by you\n"
+
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s must not have any directory components\n"
+
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s must be a directory\n"
+
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "Could not open %s/%s: %s\n"
+
+#~ msgid "Authentication is required to install multi-monitor settings for all users"
+#~ msgstr "נדרש אימות כדי להתקין הגדרות ריבוי צגים לכל המשתמשים"
+
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "התקנת הגדרות ריבוי צגים עבור כלל משתמשי המערכת"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "ני_תן לדחות הפסקות"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "יש לסמן כדי שניתן יהיה לדחות את ההפסקות"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "משך ההפסקה כאשר הקלדה אסורה"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "משך העבודה לפני שמכריחים הפסקה"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard use "
+#~ "injuries"
+#~ msgstr ""
+#~ "יש לנעול את המסך לאחר פרק זמן מסוים כדי לעזור למנוע נזקי שימוש מחזורי במקלדת"
+
+#~ msgid "Typing Break"
+#~ msgstr "הפסקת הקלדה"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_זמן ההפסקה אורך:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "יש ל_נעול את המסך כדי להכריח הפסקת הקלדה"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "זמן ה_עבודה נמשך:"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_דחיית ההפסקה"
+
+#~ msgid "_Take a Break"
+#~ msgstr "י_ציאה להפסקה"
+
+#~ msgid "Take a break now (next in %dm)"
+#~ msgstr "נא לצאת להפסקה כעת (ניתן להמשיך בעוד %d דקות)"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "דקה עד ההפסקה הבאה"
+#~ msgstr[1] "%d דקות עד ההפסקה הבאה"
+
+#~ msgid "Take a break now (next in less than one minute)"
+#~ msgstr "נא לצאת להפסקה כעת (ניתן להמשיך בעוד פחות מדקה)"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "פחות מדקה אחת עד ההפסקה הבאה"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following error: "
+#~ "%s"
+#~ msgstr "לא ניתן להציג את דו־שיח מאפייני הפסקת הקלדה עם השגיאה הבאה: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "נכתב על־ידי <‎Richard Hult <richard@imendio.com"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "העיצוב המרהיב נוסף על־ידי Anders Carlsson"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "מזכיר הפסקות ממוחשב."
+
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "יאיר הרשקוביץ <yairhr@gmail.com>\n"
+#~ "‏מארק קרפיבנר <mark125@gmail.com>\n"
+#~ "‏Omri Strumza https://launchpad.net/~blueomega\n"
+#~ "‏Yaniv Abir https://launchpad.net/~yanivabir\n"
+#~ "‏Yaron Shahrabani https://launchpad.net/~sh-yaron\n"
+#~ "‏ליאל פרידמן <lielft@ubuntu.com>\n"
+#~ "\n"
+#~ "פרויקט תרגום GNOME לעברית:\n"
+#~ "‏http://gnome-il.berlios.de"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Don't check whether the notification area exists"
+
+#~ msgid "Typing Monitor"
+#~ msgstr "צג הקלדה"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You don't "
+#~ "seem to have a notification area on your panel. You can add it by right-"
+#~ "clicking on your panel and choosing 'Add to panel', selecting 'Notification "
+#~ "area' and clicking 'Add'."
+#~ msgstr ""
+#~ "צג ההקלדה משתמש באזור ההודעות כדי להציג מידע. נראה שלא קיים אזור התרעות בלוח "
+#~ "שלך. ניתן להוסיף אותו על־ידי לחיצה ימנית על הלוח ובחירת 'הוספה ללוח', סימון "
+#~ "'אזור הדיווחים' ולחיצה על 'הוספה'."
+
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "תצורת הצג נשמרה"
+
+#~ msgid "This configuration will be used the next time someone logs in."
+#~ msgstr "תצורה זו תשמש את כל המשתמשים שייכנסו למערכת מעתה ואילך."
+
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "לא ניתן להגדיר את תצורת בררת המחדל עבור צגים"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "אותה התמונה ב_כול הצגים"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Close the control-center when a task is activated"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "Exit shell on add or remove action performed"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Exit shell on help action performed"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Exit shell on start action performed"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "Exit shell on upgrade or uninstall action performed"
+
+#~ msgid "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "Indicates whether to close the shell when a help action is performed."
+
+#~ msgid "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "Indicates whether to close the shell when a start action is performed."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is performed."
+#~ msgstr ""
+#~ "Indicates whether to close the shell when an add or remove action is performed."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action is "
+#~ "performed."
+#~ msgstr ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action is "
+#~ "performed."
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "Task names and associated .desktop files"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for that "
+#~ "task."
+#~ msgstr ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for that "
+#~ "task."
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
+#~ "applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
+#~ "applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is activated."
+#~ msgstr ""
+#~ "if true, the control-center will close when a \"Common Task\" is activated."
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "כלי התצורה של GNOME"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "If set to true, then OpenType fonts will be thumbnailed."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "If set to true, then PCF fonts will be thumbnailed."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "If set to true, then TrueType fonts will be thumbnailed."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "If set to true, then Type1 fonts will be thumbnailed."
+
+#~ msgid "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr "Set this key to the command used to create thumbnails for OpenType fonts."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "Set this key to the command used to create thumbnails for PCF fonts."
+
+#~ msgid "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr "Set this key to the command used to create thumbnails for TrueType fonts."
+
+#~ msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "Set this key to the command used to create thumbnails for Type1 fonts."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Thumbnail command for OpenType fonts"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Thumbnail command for PCF fonts"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Thumbnail command for TrueType fonts"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Thumbnail command for Type1 fonts"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Whether to thumbnail OpenType fonts"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Whether to thumbnail PCF fonts"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Whether to thumbnail TrueType fonts"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Whether to thumbnail Type1 fonts"
+
+#~ msgid "Copyright:"
+#~ msgstr "זכויות יוצרים"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "שימוש: %s fontfile\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "ה_תקן גופן"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Text to thumbnail (default: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Font size (default: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "Image/label border"
+#~ msgstr "גבול תמונה/תווית"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "רוחב הקו סביב התווית והתמונה בדו־שיח התראה"
+
+#~ msgid "The type of alert"
+#~ msgstr "סוג ההתרעה"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "הכפתורים שיוצגו בדו־שיח ההתראה"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "הנח את האגודל השמאלית על %s"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "העבר את האגודל השמאלית על %s"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "הנח את האצבע השמאלית על %s"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "העבר את האצבע השמאלית על %s"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "הנח את האצבע האמצעית השמאלית על %s"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "העבר את האצבע האמצעית השמאלית על %s"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "הנח את הקמיצה השמאלית על %s"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "העבר את הקמיצה השמאלית על %s"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "הנח את הזרת השמאלית על %s"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "העבר את הזרת השמאלית על %s"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "הנח את האגודל הימנית על %s"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "העבר את האגודל הימנית על %s"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "הנח את האצבע הימנית על %s"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "העבר את האצבע הימנית על %s"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "הנח את האצבע האמצעית הימנית על %s"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "העבר את האצבע האמצעית הימנית על %s"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "הנח את הקמיצה הימנית על %s"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "העבר את הקמיצה הימנית על %s"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "הנח את הזרת הימנית על %s"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "העבר את הזרת הימנית על %s"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "הנח את האצבע שלך על הקורא שוב"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "העבר את האצבע שלך שוב"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "ההעברה הייתה קצרה מדי, נסה שוב"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "האצבע שלך לא רוכזה, נסה להעביר את האצבע שלך שוב"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "הרחק את האצבע שלך ונסה להעביר את האצבע שלך שוב"
+
+#~ msgid "No Image"
+#~ msgstr "בלי תמונה"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "התרחשה שגיאה בעת הניסיון לגשת למידע ספר הכתובות. \n"
+#~ "שרת המידע של Evolution אינו יכול לגשת לפרוטוקול."
+
+#~ msgid "Unable to open address book"
+#~ msgstr "לא ניתן לפתוח פנקס כתובות"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "_עוזר:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "_חברה:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "שנה _סיסמה..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "_עיר:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "_מדינה:"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "כיבוי התחברות באמצעות טביעת _אצבע..."
+
+#~ msgid "Email"
+#~ msgstr "דואר אלקטרוני"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "הפעל התחברות באמצעות טביעת _אצבע..."
+
+#~ msgid "Hom_e:"
+#~ msgstr "_בית:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "מסרים מידיים"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "_תא דואר"
+
+#~ msgid "P._O. box:"
+#~ msgstr "ת_א דואר"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "מדינה/מחוז:"
+
+#~ msgid "Web _log:"
+#~ msgstr "_בלוג:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_עבודה:"
+
+#~ msgid "Work"
+#~ msgstr "עבודה"
+
+#~ msgid "Work _fax:"
+#~ msgstr "_פקס בעבודה:"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "קוד ZIP/‏מי_קוד:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_דף הבית:"
+
+#~ msgid "_Home:"
+#~ msgstr "_בית:"
+
+#~ msgid "_Manager:"
+#~ msgstr "מנ_הל:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "מ_דינה/מחוז:"
+
+#~ msgid "_Work:"
+#~ msgstr "עבודה:"
+
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "קו_ד ZIP/‏מיקוד:"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "העבר את האצבע על הקורא"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "הנח את האצבע על הקורא"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "Child exited unexpectedly"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "Could not shutdown backend_stdin IO channel: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "Could not shutdown backend_stdout IO channel: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "שגיאת מערכת: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "לא ניתן להריץ %s: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "לא ניתן להריץ תשתית"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "ארעה שגיאת מערכת"
+
+#~ msgid "Checking password..."
+#~ msgstr "בודק סיסמה..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "הקלק <b>החלף סיסמה</b> להחלפת הסיסמא שלך."
+
+#~ msgid "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "אנא הכנס את הסיסמה שנית לשדה <b>הכנס את הסיסמה שנית</b>."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "שני הסיסמאות אינן זהות."
+
+#~ msgid "Change your password"
+#~ msgstr "החלף סיסמה"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below and "
+#~ "click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "כדי לשנות את הסיסמה שלך, הכנס את הסיסמה הנוכחית בשדה מתחת ולחץ על <b>אמת</b>.\n"
+#~ "לאחר האימות, הכנס את הסיסמה החדשה שלך, הכנס אותה שוב לווידוא ולחץ על <b>שנה "
+#~ "סיסמה</b>."
+
+#~ msgid "Font may be too large"
+#~ msgstr "הגופן עלול להיות גדול מדי"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to effectively "
+#~ "use the computer.  It is recommended that you select a size smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to effectively "
+#~ "use the computer. It is recommended that you select a size smaller than %d."
+#~ msgstr[0] ""
+#~ "גודלו של הגופן הנבחר הוא נקודה אחת, ועלול להקשות על שימוש יעיל במחשב. מומלץ "
+#~ "לבחור גופן בגודל הקטן מ־%d נקודות."
+#~ msgstr[1] ""
+#~ "גודלו של הגופן הנבחר הוא %d נקודות, ועלול להקשות על שימוש יעיל במחשב. מומלץ "
+#~ "לבחור גופן בגודל הקטן מ־%d נקודות."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to effectively "
+#~ "use the computer.  It is recommended that you select a smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to effectively "
+#~ "use the computer. It is recommended that you select a smaller sized font."
+#~ msgstr[0] ""
+#~ "גודלו של הגופן הנבחר הוא נקודה אחת, ועלול להקשות על שימוש יעיל במחשב. מומלץ "
+#~ "לבחור גופן בגודל קטן יותר."
+#~ msgstr[1] ""
+#~ "גודלו של הגופן הנבחר הוא %d נקודות, ועלול להקשות על שימוש יעיל במחשב. מומלץ "
+#~ "לבחור גופן בגודל קטן יותר."
+
+#~ msgid "Use previous font"
+#~ msgstr "השתמש בגופן ה_קודם"
+
+#~ msgid "Use selected font"
+#~ msgstr "השתמש בגופן הנבחר"
+
+#~ msgid "Could not load user interface file: %s"
+#~ msgstr "לא ניתן להעלות את קובץ ממשק המשתמש: %s"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Specify the filename of a theme to install"
+
+#~ msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr "Specify the name of the page to show (theme|background|fonts|interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme engine "
+#~ "'%s' is not installed."
+#~ msgstr "ערכת הנושא לא תראה כמצופה בגלל שמנוע ערכת הנושא של GTK+ '%s' לא מותקן."
+
+#~ msgid "Apply Background"
+#~ msgstr "החל רקע"
+
+#~ msgid "Apply Font"
+#~ msgstr "החל גופן"
+
+#~ msgid "Revert Font"
+#~ msgstr "שחזר גופן"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "ערכת הנושא הנוכחית מציעה רקע וגופן. כמובן, שהצעת הגופן האחרונה שהופעלה ניתנת "
+#~ "לביטול."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "ערכת הנושא הנוכחית מציעה רקע. כמובן, שהצעת הגופן האחרונה שהופעלה ניתנת לביטול."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "ערכת הנושא הנוכחית מציע רקע וגופן."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion can "
+#~ "be reverted."
+#~ msgstr ""
+#~ "ערכת הנושא הנוכחית מציע גופן. כמובן, שהצעת הגופן האחרונה שהופעלה ניתנת לביטול."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "ערכת הנושא הנוכחית מציע רקע."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "הצעת הגופן האחרונה שהופעלה ניתנת לביטול."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "ערכת הנושא הנוכחית מציע גופן."
+
+#~ msgid "Best _shapes"
+#~ msgstr "ה_צורות הטובות ביותר"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "ה_ניגוד הטוב ביותר"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "_מותאם אישית..."
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "שינוי ערכת הנושא של הסמן יכנס לתוקף בכניסה הבאה"
+
+#~ msgid "Customize Theme"
+#~ msgstr "התאמה אישית של ערכת נושא"
+
+#~ msgid "D_etails..."
+#~ msgstr "_פרטים..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "גופן שול_חן העבודה:"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "פרטי ציור גופן"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "הורדת רקעים נוספים מהרשת"
+
+#~ msgid "Get more themes online"
+#~ msgstr "הורדת ערכות נושא נוספות מהרשת"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "גווני _אפור"
+
+#~ msgid "Icons"
+#~ msgstr "איקונים"
+
+#~ msgid "Icons only"
+#~ msgstr "איקונים בלבד"
+
+#~ msgid "N_one"
+#~ msgstr "_ללא"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "פתח תיבת דו־שיח כדי לבחור צבע"
+
+#~ msgid "R_esolution:"
+#~ msgstr "_רזולוצייה:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "_שמור ערכת נושא בשם..."
+
+#~ msgid "Save _As..."
+#~ msgstr "שמור _בשם..."
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "תת _פיקסל (צגי LCD)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "החלקת תת _פיקסל (לצגי LCD)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "סדר תת־פיקסל"
+
+#~ msgid "Text"
+#~ msgstr "טקסט"
+
+#~ msgid "Text below items"
+#~ msgstr "טקסט מתחת לפריטים"
+
+#~ msgid "Text beside items"
+#~ msgstr "טקסט ליד הפריטים"
+
+#~ msgid "Text only"
+#~ msgstr "טקסט בלבד"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "ערכת הנושא של הפקדים לא תומכת בערכות צבעים."
+
+#~ msgid "Theme"
+#~ msgstr "ערכת נושא"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Document font:"
+#~ msgstr "_גופן מסמכים:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "גופן _רוחב קבוע:"
+
+#~ msgid "_Monochrome"
+#~ msgstr "מונו_כרום"
+
+#~ msgid "_None"
+#~ msgstr "_ללא"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "_חזור לברירת מחדל"
+
+#~ msgid "_Size:"
+#~ msgstr "_גודל:"
+
+#~ msgid "_Slight"
+#~ msgstr "מו_עטת"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "רמזים _צצים:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "גופן כותרת ה_חלון:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_חלונות..."
+
+#~ msgid "dots per inch"
+#~ msgstr "נקודות לאינץ':"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "התאמה אישית של המראה של שולחן העבודה"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "התקן חבילות ערכות נושא לחלקים שונים בשולחן העבודה"
+
+#~ msgid "Theme Installer"
+#~ msgstr "מתקין ערכות נושא"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "חבילת ערכת נושא של GNOME"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "לא ניתן להתקין את ערכת הנושא"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "הכלי %s אינו מותקן."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "ארעה שגיאה בחילוץ ערכת הנושא."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "ארעה שגיאה בהתקנת הקובץ הנבחר"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "‏\"%s\" אינה ערכת נושא תקנית."
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine which you "
+#~ "need to compile."
+#~ msgstr ""
+#~ "מסתבר כי \"%s\" אינה ערכת נושא תקנית. ייתכן שזהו מנוע לערכת נושא שעלייך להדר."
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "התקנת ערכת הנושא \"%s\" נכשלה."
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "ערכת הנושא \"%s\" הותקנה."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "האם לטעון את הערכה החדשה, או לשמור על ערכת הנושא הנוכחית שלך?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "שמור על ערכת הנושא הנוכחית"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "החל ערכת נושא חדשה"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "ערכת הנושא של GNOME %s הותקנה בהצלחה"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "ערכות נושא חדשות הותקנו בהצלחה."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "לא צויין נתיב לקובץ ערכת נושא להתקנה"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "אין לך הרשאות להתקין ערכת נושא ב־:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "בחר ערכת נושא"
+
+#~ msgid "Theme Packages"
+#~ msgstr "חבילות ערכת נושא"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "ערכת הנושא חייבת להיות בנמצא"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "ערכת הנושא כבר קיימת. האם ברצונך להחליף אותה?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_החלף"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "האם למחוק את ערכת הנושא?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "לא ניתן להתקין את מנוע ערכת הנושא"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. KDE) "
+#~ "settings manager may already be active and conflicting with the GNOME settings "
+#~ "manager."
+#~ msgstr ""
+#~ "לא ניתן להפעיל את מנהל ההגדרות 'gnome-settings-daemon'.\n"
+#~ "בלי aמנהל ההגדרות של GNOME פועל, חלק מההעדפות לא יכולות לפעול. זה יכול להצביע "
+#~ "על בעיה עם DBus, או מנהל הגדרות שאינו GNOME (לדוגמה KDE) שיכול להיות פעיל "
+#~ "ולהתנגש עם מנהל הגדרות של GNOME."
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "ארעה שגיאה בהצגת העזרה: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "מעתיק קובץ %u מתוך %u"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "מעתיק '%s'"
+
+#~ msgid "Parent Window"
+#~ msgstr "חלון הורה"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "חלון הורה של הדו־שיח"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "הכתובת שממנה מעבירים"
+
+#~ msgid "To URI"
+#~ msgstr "לכתובת"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "הכתובת שאליה מעבירים"
+
+#~ msgid "Fraction completed"
+#~ msgstr "חלק שהסתיים"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "החלק מההעברה שהסתיים כבר"
+
+#~ msgid "Current URI index"
+#~ msgstr "אינדקס כתובת נוכחי"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "אינדקס כתובת נוכחי - מתחיל מ־1"
+
+#~ msgid "Total URIs"
+#~ msgstr "סך כל הכתובות"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "המספר הכולל של כתובות"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "הקובץ '%s' כבר קיים. להחליף אותו??"
+
+#~ msgid "_Skip"
+#~ msgstr "_דלג"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "_החלף הכל"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "סמן ברירת המחדל - נוכחי"
+
+#~ msgid "White Pointer"
+#~ msgstr "סמן לבן"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "סמן לבן - נוכחי"
+
+#~ msgid "Large Pointer"
+#~ msgstr "<b>סמן גדול</b>"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "סמן גדול - נוכחי"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "סמן גדול לבן - נוכחי"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' is "
+#~ "not installed."
+#~ msgstr "ערכת הנושא לא תראה כמצופה בגלל שערכת GTK+ '%s' לא מותקנת."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager theme "
+#~ "'%s' is not installed."
+#~ msgstr "ערכת הנושא לא תראה כמצופה כי ערכת מנהל החלונות '%s' לא מותקנת."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' is "
+#~ "not installed."
+#~ msgstr "ערכת הנושא לא תראה כמצופה כי ערכת האיקונים '%s' לא מותקנת."
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "מנהל החלונות \"%s\" לא רשם כלי הגדרות\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "הגדלה אנכית"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "הגדלה אופקית"
+
+#~ msgid "Monitor Preferences"
+#~ msgstr "העדפות צג"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "התחברות _נגישה"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "טכנולוגיות מסייעות"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "העדפות טכנולוגיות מסייעות"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your next "
+#~ "log in."
+#~ msgstr "שינויים להפעלת טכנולוגיות מסייעות יכנסו לתוקף רק בהתחברות הבאה."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "סגור וה_תנתק"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "עבור לתיבת הדו־שיח של היישומים המועדפים"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "עבור אל תיבת הדו־שיח להתחברות נגישה"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "עבור למסך נגישות המקלדת"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "עבור לתיבת הדו־שיח של נגישות העכבר"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_אפשר טכנולוגיות מסייעות"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "יישומים מוע_דפים"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "בחר אילו תכונות נגישות יופעלו בהתחברות"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr "Specify the name of the page to show (internet|multimedia|system|a11y)"
+
+#~ msgid "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "רק החל הגדרות וצא (תאימות בלבד; עכשיו מנוהל על־ידי תהליך שירות)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "התחל את העמוד עם הצגת הגדרות הפסקת הקלדה"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "התחל את העמוד עם הצגת הגדרות נגישות"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- העדפות מקלדת של GNOME"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "Specify the name of the page to show (general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- העדפות עכבר של GNOME"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr ">לא ניתן להפעיל את יישום ההעדפות של מנהל החלונות שלך"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "ה_יפר"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "_סופר (או \"סמל חלונות\")"
+
+#~ msgid "_Meta"
+#~ msgstr "_מטא"
+
+#~ msgid "Titlebar Action"
+#~ msgstr "פעולת כותרת"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "כדי להזיז חלון, לחץ והחזק מקש זה ואז גרור את החלון:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "העדפות חלון"
+
+#~ msgid "Window Selection"
+#~ msgstr "בחירת חלונות"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "ה_שהייה לפני העלאה:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "ה_עלה חלונות נבחרים לאחר השהייה זו"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_בחר חלונות כאשר הסמן זז מעליהם"
+
+#~ msgid "Set your window properties"
+#~ msgstr "קבע את מאפייני חלונות"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "Hide on start (useful to preload the shell)"
+
+#~ msgid "Groups"
+#~ msgstr "קבוצות"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "המסנן \"%s\" לא תואם לאף פריט."
+
+#~ msgid "Upgrade"
+#~ msgstr "שדרג"
+
+#~ msgid "Uninstall"
+#~ msgstr "הסר"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "הוסף למועדפים"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "הסר מתוכניות אתחול"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "הוסף לתוכניות אתחול"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "גיליון אלקטרוני חדש"
+
+#~ msgid "New Document"
+#~ msgstr "מסמך חדש"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "אם תמחק את הפריט, הוא יאבד נצח."
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "פתח עם \"%s\""
+
+#~ msgid "Open in File Manager"
+#~ msgstr "פתח במנהל הקבצים"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "היום ‎%l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "אתמול ‎%l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "חפש עכשיו"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>פתח %s</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "הסר מפריטי המערכת"
+
+#~ msgid "Menus and Toolbars"
+#~ msgstr "תפריטים וסרגלי כלים"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "הצג _איקונים בתפריטים"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "תוויות _כפתורי סרגל הכלים:"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "_מקשי הקיצור בתפריטים ניתנים לעריכה"
+
+#~ msgid "Display Preferences"
+#~ msgstr "העדפות תצוגה"
+
+#~ msgid "Drag the monitors to set their place"
+#~ msgstr "גרור את הצגים כדי להגדיר את מיקומם"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "שנה את הפרדת המסך"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_פריסות נבחרות:"
+
+#~ msgid "C_ontrol"
+#~ msgstr "C_ontrol"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "דג סקרן שט לו בים זך ולפתע מצא חבורה נחמדה. 0123456789"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "פרטי הגישה לא ידועים, ייתכן שמאגר המשתמשים שבור."

--- a/po/hi.po
+++ b/po/hi.po
@@ -10,9 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.master.hi\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-09-19 18:34+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-09-23 15:25+0630\n"
 "Last-Translator: rajesh <rajesh>\n"
 "Language-Team: Hindi <kde-i18n-doc@kde.org>\n"
@@ -37,5455 +36,3776 @@ msgstr ""
 "\n"
 "\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "अनुप्रयोग"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "कोई अनुप्रयोग नहीं मिला"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "अद्यतन संस्थापित करें"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "खोलें (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "विवरण देखें"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "ढूंढें"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "अक्षम"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "सूचनाएँ"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "अधिसूचना दिखाएँ (_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "पृष्ठभूमि"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "स्क्रीनशॉट"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#  Create the file chooser dialog stuff here
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "वालपेपर्स"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "ध्वनि"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "शॉर्टकट्स"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "कुंजीपट शॉर्टकट"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s कैमरा"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "माइक्रोफ़ोन वॉल्यूम"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "अवस्थिति सेवाएँ (_L)"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "अंतर्निर्मित वेब कैमरा"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "कोई क्षेत्रों नहीं मिला"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "प्रदर्शक प्रकार "
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "कड़ी गति"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "रीसेट"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "अनुप्रयोग"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "स्टाइलस"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "तयशुदा"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "पृष्ठभूमि"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "पूरे दिन परिवर्तन"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "जोड़ें प्रोफाइल... (_A)"
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-#| msgid "Lock screen"
-msgid "Lock Screen"
-msgstr "स्क्रीन पर ताला लगाएँ"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "फ्रांस"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "टाइल"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "छोटा-बड़ा करें"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "मध्य"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "मापक"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
-# test-gnome/testgnome.xml.h:5
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "भरें"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "स्पैन"
-
-#  Create the file chooser dialog stuff here
-#: ../panels/background/cc-background-chooser-dialog.c:438
-msgid "Wallpapers"
-msgstr "वालपेपर्स"
-
-#: ../panels/background/cc-background-chooser-dialog.c:447
-msgid "Colors"
-msgstr "रंग"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:485
-msgid "Select Background"
-msgstr "पृष्ठभूमि चुनें"
-
-#: ../panels/background/cc-background-chooser-dialog.c:514
-msgid "Pictures"
-msgstr "तस्वीर"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:546
-#| msgid "No input sources found"
-msgid "No Pictures Found"
-msgstr "कोई  तस्वीर नहीं मिला"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:564
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "घर"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:576
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "आप अपने %s फ़ोल्डर में छवि जोड़ सकते हैं और वे यहाँ दिखाए जाएँगे"
-
-#: ../panels/background/cc-background-chooser-dialog.c:583
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1537
-#: ../panels/display/cc-display-panel.c:1976
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1247
-#: ../panels/network/net-device-wifi.c:1440
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/cc-printers-panel.c:1947
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-#: ../panels/user-accounts/um-photo-dialog.c:95
-#: ../panels/user-accounts/um-photo-dialog.c:222
-#: ../panels/user-accounts/um-user-panel.c:513
-msgid "_Cancel"
-msgstr "रद्द करें (_C)"
-
-#: ../panels/background/cc-background-chooser-dialog.c:584
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:97
-msgid "Select"
-msgstr "चुनें"
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "बहुत आकार"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "कोई डेस्कटॉप पृष्ठभूमि"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "मौजूदा पृष्ठभूमि"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "एक वॉलपेपर या तस्वीर का उपयोग करके अपनी पृष्ठभूमि छवि बदलें"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "वॉलपेपर; स्क्रीन; डेस्कटॉप;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "ब्लूटूथ अक्षम है"
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "सक्रिय करें"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "कोई ब्लूटूथ एडाप्टर मौजूद नहीं मिला"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "ब्लूटूथ सेटिंग "
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "हवाई जहाज मोड (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "ब्लूटूथ हार्डवेयर स्विच से अक्षम है"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1688
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "हवाई जहाज मोड (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "हवाई जहाज मोड (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "ब्लूटूथ"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "ब्लूटूथ को चालू और बंद करें और अपने उपकरणों को जोड़ें"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "वर्ग के ऊपर अपने अंशांकन युक्ति को रखें और 'आरंभ' दवाएँ "
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "कोई अनुप्रयोग अभी ध्वनि बजा या रिकार्ड नहीं कर रहा है."
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"अपने अंशांकन युक्ति को अंशांकन स्थिति में खिसकाएं और 'जारी रखें' दवाएँ "
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr "अपने अंशांकन युक्ति को सतह स्थिति में खिसकाएं और 'जारी रखें' दवाएँ "
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "लैपटॉप ढक्कन बंद करो"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "एक आंतरिक त्रुटि आई है जो बरामद नहीं किया जा सकता है."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "अंशांकन के लिए आवश्यक उपकरण नहीं स्थापित कर रहे हैं."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "प्रोफाइल उत्पन्न नहीं किया जा सका."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "लक्ष्य श्वेतबिंदु प्राप्य नहीं किया गया."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "पूर्ण!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "विन्यास विफल!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "आप अंशांकन युक्ति निकाल सकते हैं."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "जारी रखने के दौरान अंशांकन युक्ति को परेशान नहीं करें"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "लैपटॉप स्क्रीन"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "अंतर्निर्मित वेब कैमरा"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s मॉनीटर"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s स्कैनर"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s कैमरा"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s मुद्रक"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s वेबकैम"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s के लिए रंग प्रबंधन सक्रिय करें"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s के लिए रंग प्रोफाइल दिखाएं"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-msgid "Not calibrated"
-msgstr "कैलिब्रेट नहीं किया गया"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "तयशुदा: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "कलरस्पेस: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "टेस्ट प्रोफ़ाइल: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "आईसीसी प्रोफाइल फ़ाइल का चयन करें"
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "आयात करें (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "समर्थित आईसीसी प्रोफाइल"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "सभी फ़ाइलें"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "स्क्रीन"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-#| msgid "Failed to apply configuration: %s"
-msgid "Failed to upload file: %s"
-msgstr "फ़ाइल अपलोड करने में विफल: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "इन प्रोफ़ाइल को इसमें अद्यतन किया जा रहा है:"
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "इस URL को लिखें."
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-"इस कंप्यूटर को फिर आरंभ करें और अपने सामान्य ऑपरेटिंग तंत्र को बूट करें."
 
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "अधिक छवियाँ के लिए ब्राउज़ करें"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"अपने ब्राउज़र में इस यूआरएल को टाइप करें ताकि प्रोफ़ाइल डाउनलोड और संस्थापित "
-"किया जा सके."
 
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "प्रोफ़ाइल सहेजें"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "सहेजें (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "चयनित युक्ति के लिए एक रंग प्रोफ़ाइल बनाएँ"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"मापन यंत्र का पता नहीं लगा है. कृपया जाचें कि यह चालू है और सही रूप से "
-"कनेक्टेड है."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "माप उपकरण प्रिंटर प्रोफाइलिंग का समर्थन नहीं करता है."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "युक्ति प्रकार मौजूदा में समर्थित नहीं है."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "मानक स्थान "
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "टेस्ट प्रोफ़ाइल"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "स्वचालित "
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "कम विशेषता"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "मध्यम विशेषता"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "उच्च गुणवत्ता"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "मूलभूत RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "तयशुदा CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "डिफ़ॉल्ट ग्रे"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "विक्रेता द्वारा दी गयी कारखाने अंशांकन डेटा"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "पूर्ण स्क्रीन सुधार प्रदर्शन इस प्रोफाइल के साथ संभव नहीं है "
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "यह युक्ति एक प्रोफाइल ज्यादा देर तक सही नहीं है."
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "केलिब्रेशन प्रदर्शित करें"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr "रद्द करें"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "रद्द करें (_C)"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "प्रारंभ"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "पुनरारंभ"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "संपन्न"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "संपन्न (_D)"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "स्क्रीन कैलिब्रेशन"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "अंशांकन गुणवत्ता"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"अंशांकन एक प्रोफाइल को पैदा करेगा जो कि आप रंग का उपयोग करके अपनी स्क्रीन का "
-"प्रबंधन कर "
-"सकते हैं.अब आप अंशांकन पर ज्यादा समय खर्च करते हैं, रंग प्रोफाइल की गुणवत्ता "
-"बेहतर होगी."
+"अंशांकन एक प्रोफाइल को पैदा करेगा जो कि आप रंग का उपयोग करके अपनी स्क्रीन का प्रबंधन कर "
+"सकते हैं.अब आप अंशांकन पर ज्यादा समय खर्च करते हैं, रंग प्रोफाइल की गुणवत्ता बेहतर होगी."
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "अंशांकन के दौरान आप अपने कंप्यूटर का उपयोग नहीं कर सकते हैं."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "गुणवत्ता"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "अनुमानित समय"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "अंशांकन गुणवत्ता"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "अंशांकन का उपयोग करने के लिए सेंसर डिवाइस का चयन करें"
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "कैलिब्रेशन युक्ति "
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "जुड़ा हुआ प्रदर्शन के प्रकार का चयन करें."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "अंशांकन का उपयोग करने के लिए सेंसर डिवाइस का चयन करें"
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "प्रदर्शक प्रकार "
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "जुड़ा हुआ प्रदर्शन के प्रकार का चयन करें."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "प्रोफ़ाइल श्वेतबिंदु"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
-"प्रदर्शन लक्ष्य श्वेत बिंदु का चयन करें. D65 रोशन के लिए अधिकांश प्रदर्शन को "
-"कैलिब्रेटेड किया "
+"प्रदर्शन लक्ष्य श्वेत बिंदु का चयन करें. D65 रोशन के लिए अधिकांश प्रदर्शन को कैलिब्रेटेड किया "
 "जाना चाहिए."
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "प्रोफ़ाइल श्वेतबिंदु"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "दृश्य चमक"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-" चमक को प्रदर्शन के आधार पर सेट करें जो आप के लिए विशिष्ट है.इस चमक के स्तर "
-"पर रंग प्रबंधन "
+" चमक को प्रदर्शन के आधार पर सेट करें जो आप के लिए विशिष्ट है.इस चमक के स्तर पर रंग प्रबंधन "
 "सबसे सटीक होगा."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
-"वैकल्पिक रूप से, आप इस डिवाइस के लिए अन्य प्रोफाइल के साथ इस्तेमाल किया चमक "
-"स्तर का "
+"वैकल्पिक रूप से, आप इस डिवाइस के लिए अन्य प्रोफाइल के साथ इस्तेमाल किया चमक स्तर का "
 "उपयोग कर सकते हैं."
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "दृश्य चमक"
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "प्रोफ़ाइल नाम"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
-"आप अलग कंप्यूटर पर एक रंग प्रोफ़ाइल का उपयोग कर, या भी अलग प्रकाश व्यवस्था की "
-"स्थिति के "
+"आप अलग कंप्यूटर पर एक रंग प्रोफ़ाइल का उपयोग कर, या भी अलग प्रकाश व्यवस्था की स्थिति के "
 "लिए प्रोफाइल बना सकते हैं."
 
 # #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
 # test-gnome/testgnome.xml.h:5
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "प्रोफाइल नाम:"
 
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
-# test-gnome/testgnome.xml.h:5
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "प्रोफ़ाइल नाम"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "प्रोफ़ाइल सफलतापूर्वक बनाई गई!"
-
-#: ../panels/color/color.ui.h:22
-#| msgid "Add profile"
-msgid "Copy profile"
-msgstr "प्रोफाइल की नक़ल लें"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "लेखनयोग्य मीडिया की जरूरत"
-
-#: ../panels/color/color.ui.h:24
-#| msgid "Add profile"
-msgid "Upload profile"
-msgstr "प्रोफाइल अपलोड करें"
-
-#: ../panels/color/color.ui.h:25
-#| msgid "Add new connection"
-msgid "Requires Internet connection"
-msgstr "इंटरनेट कनेक्शन जोड़ें"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"<a href=\"linux\">ग्नू / लिनक्स</a>, <a href=\"osx\">एप्पल ओएस एक्स </a>और <a "
-"href=\"windows\">माइक्रोसॉफ्ट विंडोज </a>उपयोगी सिस्टम पर प्रोफ़ाइल का उपयोग "
-"करने के "
-"लिए आप कैसे इन निर्देशों को खोज पाते है."
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "सारांश"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "फ़ाइल आयात करें…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "प्रोफ़ाइल सफलतापूर्वक बनाई गई!"
 
-#: ../panels/color/color.ui.h:30
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
-msgstr "जोड़ें (_A)"
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "प्रोफाइल की नक़ल लें"
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "लेखनयोग्य मीडिया की जरूरत"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">ग्नू / लिनक्स</a>, <a href=\"osx\">एप्पल ओएस एक्स </a>और <a "
+"href=\"windows\">माइक्रोसॉफ्ट विंडोज </a>उपयोगी सिस्टम पर प्रोफ़ाइल का उपयोग करने के "
+"लिए आप कैसे इन निर्देशों को खोज पाते है."
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "जोड़ें प्रोफाइल"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"समस्याओं का पता चला. प्रोफ़ाइल सही ढंग से काम नहीं कर रहा.<a href=\"\">विवरण "
-"दिखाएँ."
+"समस्याओं का पता चला. प्रोफ़ाइल सही ढंग से काम नहीं कर रहा.<a href=\"\">विवरण दिखाएँ."
 "</a>"
 
-#: ../panels/color/color.ui.h:32
-msgid "Each device needs an up to date color profile to be color managed."
-msgstr ""
-"प्रत्येक युक्ति को रंग प्रबंधित होने के लिए रंग प्रोफ़ाइल के अद्यतन की जरुरत "
-"है. "
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "फ़ाइल आयात करें…"
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "जोड़ें (_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "प्रत्येक युक्ति को रंग प्रबंधित होने के लिए रंग प्रोफ़ाइल के अद्यतन की जरुरत है. "
+
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "अधिक जानें"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "रंग प्रबंधन के बारे में अधिक जानें"
 
 # #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/color/color.ui.h:35
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "सभी उपयोगकर्ताओं के लिए सेट करें"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "इस कंप्यूटर पर सभी उपयोगकर्ताओं के लिए इस प्रोफ़ाइल को सेट करें"
 
 # #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
-#: ../panels/color/color.ui.h:37
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "सक्रिय करें"
 
-#: ../panels/color/color.ui.h:38
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "जोड़ें प्रोफाइल"
 
-#: ../panels/color/color.ui.h:39
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "कैलिब्रेट…"
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "युक्ति जांच"
 
-#: ../panels/color/color.ui.h:41
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "प्रोफ़ाइल हटायें"
 
-#: ../panels/color/color.ui.h:42
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "विवरण देखें"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "उपकरण जिसमे रंग प्रबंधन हो सकता हैं का पता लगाने में असमर्थ"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "एलसीडी"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "एलईडी"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "प्रोजेक्टर"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "प्लासमा"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL बैकलाइट)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED बैकलाइट)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (सफेद LED बैकलाइट)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "वाइड गैमट LCD (CCFL बैकलाइट)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "वाइड गैमट LCD (RGB LED बैकलाइट)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "उच्च"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 मिनट"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "मध्यम"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 मिनट"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "कम"
 
-#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 मिनट"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "दिखाने के लिए पटल "
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (मुद्रण और प्रकाशन)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (फोटोग्राफी और ग्राफिक्स)"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "रंग"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "अपने उपकरणों जैसे प्रदर्शन , कैमरा, या प्रिंटर के रंग का आशंकन करें"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "रंग;आईसीसी;प्रोफाइल;जांच;प्रिंटर;प्रदर्शन;"
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:684
-msgid "United States"
-msgstr "यूनाइटेड स्टेट्स"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "भाषा चुनें"
 
-#: ../panels/common/cc-common-language.c:685
-msgid "Germany"
-msgstr "जर्मनी"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "चुनें (_S)"
 
-#: ../panels/common/cc-common-language.c:686
-msgid "France"
-msgstr "फ्रांस"
-
-#: ../panels/common/cc-common-language.c:687
-msgid "Spain"
-msgstr "स्पैन"
-
-#: ../panels/common/cc-common-language.c:688
-msgid "China"
-msgstr "चीन"
-
-#: ../panels/common/cc-common-language.c:758
-msgid "Other…"
-msgstr "अन्य..."
-
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr "अधिक…"
-
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "कोई भाषाएँ नहीं मिला"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "भाषा"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "अधिक…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "संपन्न (_D)"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-#| msgid "%a %l:%M %p"
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "खोलें"
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "आकार बढ़ाएँ:"
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "समय"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-#| msgid "%a %l:%M %p"
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "आकार घटाएँ:"
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "जनवरी"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "फरवरी"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "मार्च"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "अप्रैल"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "मई"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "जून"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "जुलाई"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "अगस्त"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "सितम्बर"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "अक्टूबर"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "नवम्बर"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "दिसम्बर"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "तिथि व समय"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "घंटा"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-#| msgid "minute"
-#| msgid_plural "minutes"
-msgid "Minute"
-msgstr "मिनट"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "दिन"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "माह"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "वर्ष"
 
-#: ../panels/datetime/datetime.ui.h:21
-#| msgid "Time"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "माह"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "जनवरी"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "फरवरी"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "मार्च"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "अप्रैल"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "मई"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "जून"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "जुलाई"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "अगस्त"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "सितम्बर"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "अक्टूबर"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "नवम्बर"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "दिसम्बर"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "दिन"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "समय क्षेत्र"
 
-#: ../panels/datetime/datetime.ui.h:22
-#| msgid "Search for the string"
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "एक शहर के लिए खोजें"
 
-#: ../panels/datetime/datetime.ui.h:23
-#| msgid "Date & Time"
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "स्वचालित दिनांक व समय"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "इंटरनेट कनेक्शन चाहिए"
 
-#: ../panels/datetime/datetime.ui.h:25
-#| msgid "Automatic _Connect"
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "दिनांक व समय (_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "स्वचालित समय क्षेत्र (_Z)"
 
-#: ../panels/datetime/datetime.ui.h:26
-#| msgid "Date & Time"
-msgid "Date & _Time"
-msgstr "दिनांक व समय (_T)"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "इंटरनेट कनेक्शन चाहिए"
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
-msgstr "समय क्षेत्र (_Z)"
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "सक्षम"
 
-#: ../panels/datetime/datetime.ui.h:28
-#| msgid "Formats"
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "समय क्षेत्र"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "खोलें"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "समय प्रारूप (_F)"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24-घंटे"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "पूर्वाह्न/अपराह्न"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "तिथियाँ"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "द्वितीयक"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "पंचांग (_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "संख्याएँ"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "दिनांक और समय समय क्षेत्र सहित बदलें"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "घड़ी;समय क्षेत्र;स्थान;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "सिस्टम का समय और दिनांक सेटिंग्स बदलें"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
-msgstr ""
-"समय या दिनांक सेटिंग्स को बदलने के लिए, आपको प्रमाणित करने की जरूरत है."
+msgstr "समय या दिनांक सेटिंग्स को बदलने के लिए, आपको प्रमाणित करने की जरूरत है."
 
-#: ../panels/display/cc-display-panel.c:487
-#| msgid "Close"
-msgid "Lid Closed"
-msgstr "Lid बंद किया गया"
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-#| msgid "Mirrored Displays"
-msgid "Mirrored"
-msgstr "मिरर किया"
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2145
-#| msgid "Primary _button"
-msgid "Primary"
-msgstr "प्राथमिक"
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "बंद"
-
-#: ../panels/display/cc-display-panel.c:497
-#| msgid "Secondary color"
-msgid "Secondary"
-msgstr "द्वितीयक"
-
-#: ../panels/display/cc-display-panel.c:1533
-#| msgid "Mirrored Displays"
-msgid "Arrange Combined Displays"
-msgstr "संयुग्मित प्रदर्शक की व्यवस्था करें"
-
-#: ../panels/display/cc-display-panel.c:1539
-#: ../panels/display/cc-display-panel.c:1979
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr "लागू करें (_A)"
-
-#: ../panels/display/cc-display-panel.c:1560
-msgid "Drag displays to rearrange them"
-msgstr "उन्हें फिर व्यवस्थित करने के लिए प्रदर्शन खींचें"
-
-#: ../panels/display/cc-display-panel.c:2081
-msgid "Size"
-msgstr "आकार"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2094
-msgid "Aspect Ratio"
-msgstr "पहलू अनुपात"
-
-#: ../panels/display/cc-display-panel.c:2115
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "रेज़ोल्यूशन"
-
-#: ../panels/display/cc-display-panel.c:2146
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "शीर्ष बार दिखाएँ और इस प्रदर्शन के लिए गतिविधि सारांश"
-
-#: ../panels/display/cc-display-panel.c:2152
-#| msgid "Secondary click delay"
-msgid "Secondary Display"
-msgstr "द्वितीयक प्रदर्शन"
-
-#: ../panels/display/cc-display-panel.c:2153
-msgid "Join this display with another to create an extra workspace"
-msgstr ""
-"अतिरिक्त कार्यस्थान बनाने के लिए दूसरों के साथ इस प्रदर्शन में शामिल हों"
-
-#: ../panels/display/cc-display-panel.c:2160
-#| msgid "Orientation"
-msgid "Presentation"
-msgstr "प्रस्तुति"
-
-#: ../panels/display/cc-display-panel.c:2161
-msgid "Show slideshows and media only"
-msgstr "स्लाइडशो और मीडिया केवल दिखाएँ"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2166
-msgid "Mirror"
-msgstr "मिरर"
-
-#: ../panels/display/cc-display-panel.c:2167
-msgid "Show your existing view on both displays"
-msgstr "मौजूदा दृश्य दोनों प्रदर्शन पर दिखाएँ"
-
-#: ../panels/display/cc-display-panel.c:2173
-#| msgid "_Turn On"
-msgid "Turn Off"
-msgstr "बन्द करें"
-
-#: ../panels/display/cc-display-panel.c:2174
-#| msgid "Panel to display"
-msgid "Don't use this display"
-msgstr "इस प्रदर्शन का उपयोग मत करें"
-
-#: ../panels/display/cc-display-panel.c:2383
-msgid "Could not get screen information"
-msgstr "स्क्रीन सूचना नहीं पा सका"
-
-#: ../panels/display/cc-display-panel.c:2414
-#| msgid "Mirrored Displays"
-msgid "_Arrange Combined Displays"
-msgstr "संयुग्मित प्रदर्शक की व्यवस्था करें (_A)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "प्रदर्शक"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr "जुड़े हुए मॉनिटर और प्रोजेक्टर का उपयोग करने के लिए चुनें"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "पैनल;प्रोजेक्टर;xrandr;स्क्रीन;रिज़ॉल्यूशन;रिफ्रेश;मॉनिटर;"
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr "Wayland"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "अज्ञात"
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/session-properties-capplet.c:303
-# gnome-session/session-properties-capplet.c:376
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:84 libgnomeui/gnome-app-helper.h:516
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-bit"
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
-# gnome-session/session-properties-capplet.c:303
-# gnome-session/session-properties-capplet.c:376
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
-# libgnomeui/gnome-app-helper.c:84 libgnomeui/gnome-app-helper.h:516
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr "%d-bit"
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr "पूछें कि क्या करना है"
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr "कुछ मत करें"
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr "फ़ोल्डर खोलें"
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr "अन्य मीडिया"
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr "ऑडियो सीडी के लिए अनुप्रयोग चुनें"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr "वीडियो सीडी के लिए अनुप्रयोग चुनें"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr "अनुप्रयोग को चालू करने के लिए चयन करे जब एक म्यूजिक प्लयेर जुड़ा हो"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr "अनुप्रयोग को चालू करने के लिए चयन करे जब एक कैमरा जुड़ा हो"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr "सॉफ़्टवेयर सीडी के लिए अनुप्रयोग चुनें"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr "ऑडियो डीवीडी"
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr "खाली Blu-Ray डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr "खाली सीडी डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr "रिक्त डीवीडी डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr "खाली HD DVD डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr "Blu-ray वीडियो डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr "ई-बुक रीडर"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr "HD डीवीडी वीडियो डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr "पिक्चर सीडी"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr "सुपर वीडियो सीडी"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr "वीडियो सीडी"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr "विंडोज़ सॉफ़्टवेयर"
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
-# gnome-session/logout.c:266
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1932
-msgid "Section"
-msgstr "विभाग"
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "सारांश"
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr "तयशुदा अनुप्रयोग"
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "हटाने योग्य मीडिया"
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr "संस्करण %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:46
-msgid "Details"
-msgstr "विवरण"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr "अपने प्रणाली के बारे में सूचना देखें"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"युक्ति;सिस्टम;जानकारी;स्मृति;प्रोसेसर;संस्करण;डिफ़ॉल्ट;अनुप्रयोग;अनुशंसित;सीडी"
-";डीवीडी;यूएसबी;"
-"ऑडियो;वीडियो;डिस्क;हटाने योग्य;मीडिया;स्वतः चालू;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "चुनें कैसे अन्य मीडिया को नियंत्रित किया जाना चाहिए"
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "क्रिया (_A):"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "प्रकार: (_T)"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "युक्ति नाम"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "मेमोरी"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "प्रोसेसर"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "आधार प्रणाली"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "डिस्क"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "गणना में..."
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "आलेखी"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "वर्चुअलाइजेशन"
-
-#: ../panels/info/info.ui.h:13
-#| msgid "Checking for Updates"
-msgid "Check for updates"
-msgstr "अद्यतन के लिए जाँचें"
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "वेब (_W)"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "मेल (_M)"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "पंचांग (_C)"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "संगीत (_u)"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "वीडियो (_V)"
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "फोटो (_P)"
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "चुनें कैसे मीडिया को नियंत्रित किया जाना चाहिए"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "तयशुदा अनुप्रयोग"
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "सीडी ऑडियो (_a)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "तयशुदा अनुप्रयोग"
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "_DVD वीडियो"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "संगीत प्लेयर (_M)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "सॉफ्टवेयर (_S)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "अन्य मीडिया... (_O)"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr "मीडिया प्रवेश पर कभी प्रांप्ट मत करें या प्रोग्राम आरंभ मत करें (_N)"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "लागू करें (_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "पीछे"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "ब्लूटूथ अक्षम है"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "प्रदर्शक का पता लगायें (_D)"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "मिरर"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "द्वितीयक प्रदर्शन"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "दाहिनी तर्जनी"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "दिशा"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "रेज़ोल्यूशन"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "मापक"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "कोई प्रिंटर उपलब्ध नहीं"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "अब फिर आरंभ करें"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "बार"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "घंटा"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "मिनट"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "प्रदर्शक"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "जुड़े हुए मॉनिटर और प्रोजेक्टर का उपयोग करने के लिए चुनें"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "पैनल;प्रोजेक्टर;xrandr;स्क्रीन;रिज़ॉल्यूशन;रिफ्रेश;मॉनिटर;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "सुरक्षा कुंजी"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "स्याही स्तर"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "स्याही स्तर"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "स्याही स्तर"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "सुरक्षा"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"स्क्रीन;ताला;निदान;दुर्घटना;निजी;हाल ही में;अस्थायी;tmp;सूचकांक; नाम;नेटवर्क;पहचान;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "युक्ति नाम"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "हार्डवेयर पता"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "मेमोरी"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "प्रोसेसर"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "आलेखी"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "गणना में..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "नाम"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "प्रकार"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "संस्करण 0"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "लोडिंग विकल्प... "
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "विंडोज़ सॉफ़्टवेयर"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "वर्चुअलाइजेशन"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "सॉफ्टवेयर प्रयोग"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "युक्ति हटायें"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "युक्ति नाम"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "उपयोक्ता नाम (_U)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "अपने प्रणाली के बारे में सूचना देखें"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"युक्ति;सिस्टम;जानकारी;स्मृति;प्रोसेसर;संस्करण;डिफ़ॉल्ट;अनुप्रयोग;अनुशंसित;सीडी;डीवीडी;यूएसबी;"
+"ऑडियो;वीडियो;डिस्क;हटाने योग्य;मीडिया;स्वतः चालू;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "ध्वनि और मीडिया"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "आवाज मौन"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "आवाज कम करें"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "आवाज बढ़ाएँ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "माइक्रोफ़ोन वॉल्यूम"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "मीडिया प्लेयर लॉन्च करें"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "बजाएँ (या बजाएँ/ठहरें)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "प्लेबैक रोकें"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "प्लेबैक रोकें"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "पिछला ट्रैक"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "अगला ट्रैक"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "बाहर करें"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "टंकित कर रहा है"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "अगले इनपुट स्रोत के लिए स्विच करें"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "पिछले इनपुट स्रोत पर जाएँ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "लांचर"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "मदद ब्राउज़र लॉन्च करें"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "सेटिंग्स"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "कैलकुलेटर लॉन्च करें"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "ई-मेल क्लाइंट लॉन्च करें"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "वेब ब्राउज़र चलाएँ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "घर फ़ोल्डर"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "ढूंढें"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "स्क्रीनशॉट"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "$PICTURES में एक स्क्रीनशॉट सहेजें"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr " $PICTURES में विंडो का स्क्रीनशॉट सहेजें"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr " $PICTURES में किसी क्षेत्र का एक स्क्रीनशॉट सहेजें"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "क्लिपबोर्ड पर स्क्रीनशॉट की नकल करें"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "क्लिपबोर्ड पर विंडो का स्क्रीनशॉट की नकल बनाएं"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "क्लिपबोर्ड पर क्षेत्र की स्क्रीनशॉट की नकल बनाएं"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "छोटा स्क्रीनकास्ट रिकॉर्ड करें"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "सिस्टम"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "लॉग आउट"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "स्क्रीन पर ताला"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "सार्वभौमिक पहुँच"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "दृश्यता"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "जूम चालू या बंद करें"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "बडे रूप में दिखाएँ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "छोटे रूप में दिखाएँ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "स्क्रीन रीडर को चालू या बंद करें"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "ऑन स्क्रीन कुंजीपटल के चालू या बंद करें"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "पाठ का आकार बढ़ाएँ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "पाठ का आकार घटाएँ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "अधिक कंट्रास्ट चालू या बंद करें"
 
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
-# gtk/gtkinputdialog.c:238
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1218
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-msgid "Disabled"
-msgstr "अक्षम"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "इनपुट स्रोत जोड़ें "
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "वैकल्पिक वर्ण कुँजी"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "इनपुट विधि लॉगिन स्क्रीन पर नहीं किया जा सकता"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "लेखन कुंजी"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "कोई इनपुट स्रोत चयनित नहीं"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "संशोधक केवल अगले स्रोत में जाएँ"
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "विकल्प"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "कुंजीपटल"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "ऊपर जाएँ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr ""
-"देखें और कुंजीपटल शॉर्टकट को बदलें और अपनी टाइपिंग की वरीयताओं को सेट करें"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "नीचे जाएँ"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "शॉर्टकट;दोहराएँ;ब्लिंक;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "वरीयताएँ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "मनपसंद शार्टकट"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "कुंजीपटल लेआउट दिखाएँ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "नाम: (_N)"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "हटाएं (_R)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "कमांड: (_o):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "दुहराव कुंजी"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "जब कुंजी दबा कर रखा जाए तो कुंजी दोहराना (_r)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "देरीः (_D)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "गतिः (_S)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "छोटा"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "धीमा"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "दुहराने वाली कुंजी गति"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "लंबा"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "तेज"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "संकेतक टिमटिमाना"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "पाठ बक्सा में संकेतक टिमटिमाएँ (_b)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "गति: (_p)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "कर्सर ब्लिंक गति"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "इनपुट स्रोत"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "शॉर्टकट जोड़ें"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "शॉर्टकट हटायें"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"शॉर्टकट संपादित करने के लिए, पंक्ति पर क्लिक करें और नई कुंजी नीचे पकड़े या "
-"स्पष्ट करने के लिए "
-"बैकस्पेस प्रेस करें."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "इनपुट स्रोत विकल्प"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "सभी विंडोज़ के लिए एक ही स्रोत का उपयोग करें  (_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "व्यक्तिगत विंडोज़ के लिए विभिन्न स्रोत की अनुमति दें (_d)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "वैकल्पिक वर्ण कुँजी"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "लेखन कुंजी"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "कुंजीपट शॉर्टकट"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "पसंदीदा शार्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "विभाग"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "शॉर्टकट्स"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:635
-#: ../panels/keyboard/keyboard-shortcuts.c:643
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "शॉर्टकट जोड़ें"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "पसंदीदा शार्टकट"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:860
-msgid "<Unknown Action>"
-msgstr "<अज्ञात क्रिया>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1357
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"शॉर्टकट \"%s\" प्रयोग नहीं की जा सकती है क्योंकि इस कुंजी के प्रयोग से इसे "
-"टाइप करना "
-"असंभव होगा.\n"
-"कृपया Control, Alt या Shift कुंजी को एक साथ कोशिश करें."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1387
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "शॉर्टकट जोड़ें"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "कुंजीपट शॉर्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "हटाएं (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "बदलें (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"यह शार्टकट \"%s\" पहले से ही:\n"
-" \"%s\" हेतु प्रयुक्त है"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1392
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"यदि आप \"%s\" को फिर नियत करते हैं, \"%s\" शॉर्टकट को निष्क्रिय किया जाएगा."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1398
-msgid "_Reassign"
-msgstr "फिर नियत करें (_R)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "नाम"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1439
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
-msgstr ""
-"\"%s\" शॉर्टकट में एक संबद्ध \"%s\" शॉर्टकट है. क्या आप इसे \"%s\" पर स्वतः "
-"सेट करना चाहते हैं?"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "कमांड: (_o):"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1449
-#, c-format
-#| msgid ""
-#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
-#| "disabled."
-msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
-msgstr ""
-"\"%s\" अभी \"%s\" से जुड़ा है, शॉर्टकट को निष्क्रिय किया जाएगा यदि आप आगे "
-"बढ़ते हैं."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "शार्टकट"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1456
-#| msgid "_Reassign"
-msgid "_Assign"
-msgstr "फिर नियत करें (_A)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "नया शार्टकट..."
 
-#: ../panels/mouse/cc-mouse-panel.c:94
-msgid "Test Your _Settings"
-msgstr "अपनी सेटिंग्स जाँचें (_S)"
-
-#: ../panels/mouse/cc-mouse-panel.c:107
-#| msgid "Test Your _Settings"
-msgid "Test Your Settings"
-msgstr "अपनी सेटिंग्स जाँचें"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse & Touchpad"
-msgstr "माउस व टचपैड"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid ""
-"Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr ""
-"अपने माउस या संवेदनशीलता टचपैड बदलें और सही है या बाएँ हाथ का चयन करें "
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-#| msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-msgstr "ट्रैकपैड;सूचक;क्लिक करें;टैब;डबल;बटन;ट्रैकबॉल;स्क्रॉल;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "सामान्य"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-#| msgctxt "keyboard, speed"
-#| msgid "Slow"
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "धीमा"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "दोहरा क्लिक टाइमआउट"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-#| msgctxt "keyboard, speed"
-#| msgid "Fast"
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "तेज"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "दोहरा क्लिक करें (_D)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "प्राथमिक बटन (_b)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "बायाँ (_L)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "दाँया (_R)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "माउस"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "संकेतक गति (_P)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-#| msgctxt "keyboard, speed"
-#| msgid "Slow"
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "धीमा"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-#| msgctxt "keyboard, speed"
-#| msgid "Fast"
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "तेज"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "टचपैड"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-#| msgctxt "keyboard, speed"
-#| msgid "Slow"
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "धीमा"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-#| msgctxt "keyboard, speed"
-#| msgid "Fast"
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "तेज"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
-msgstr "टाइपिंग के दौरान निष्क्रिय करें (_t)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
-msgstr "क्लिक करने के लिए टैप करें (_c)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
-msgstr "दो अंगुली से स्क्रॉल (_f)"
-
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-#| msgid "_Edge scrolling"
-msgid "_Natural scrolling"
-msgstr "प्राकृतिक स्क्रॉलिंग (_N)"
-
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "क्लिक करने, दोहरा क्लिक करने और स्क्रॉल करने की कोशिश करें"
-
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "पाँच क्लिक, GEGL समय!"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "दोहरा क्लिक, प्राथमिक बटन"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "एकल क्लिक, प्राथमिक बटन"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "दोहरा क्लिक, मध्य बटन"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "एकल क्लिक, मध्य बटन"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "दोहरा क्लिक, द्वितीयक बटन"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "एकल क्लिक, द्वितीयक बटन"
-
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:366
-msgid "Air_plane Mode"
-msgstr "हवाई जहाज मोड (_p)"
-
-#: ../panels/network/cc-network-panel.c:974
-msgid "Network proxy"
-msgstr "नेटवर्क प्रॉक्सी"
-
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1153 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1298
-msgid "The system network services are not compatible with this version."
-msgstr "तंत्र संजाल सेवाओं इस संस्करण के साथ संगत नहीं हैं."
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
-msgid "802.1x _Security"
-msgstr "802.1x सुरक्षा (_S)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "पृष्ठ 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "बेनाम पहचान (_m)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "आंतरिक सत्यापन (_a)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "पृष्ठ 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "सुरक्षा"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "स्वचालित"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:218
-#: ../panels/network/net-device-wifi.c:382
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:222
-#: ../panels/network/net-device-wifi.c:387
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:226
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:231
-msgid "Enterprise"
-msgstr "उद्यम"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:236
-#: ../panels/network/net-device-wifi.c:372
-msgctxt "Wifi security"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "कुछ नहीं"
 
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "कभी नहीं"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
 
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:819
-msgid "Today"
-msgstr "आज"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "डिफ़ॉल्ट में रीसेट करें (_f)"
 
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:822
-msgid "Yesterday"
-msgstr "कल"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "कुंजीपटल"
 
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:476
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "देखें और कुंजीपटल शॉर्टकट को बदलें और अपनी टाइपिंग की वरीयताओं को सेट करें"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "अवस्थिति सेवाएँ (_L)"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "कोई अनुप्रयोग अभी ध्वनि बजा या रिकार्ड नहीं कर रहा है."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "माइक्रोफ़ोन वॉल्यूम"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "कोई अनुप्रयोग नहीं मिला"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "अपनी सेटिंग्स जाँचें (_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "सामान्य"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "प्राथमिक बटन (_b)"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "बायाँ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "दायाँ"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "खोजें स्थान"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "माउस"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "माउस कुंजियाँ (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "नीचे स्क्रॉल करें"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "विषयवस्तु के साथ आवर्धक कर्सर चलता है"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "त्वरक: (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "सक्रिय"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "टचपैड"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "टचपैड"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "विधि (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "क्लिक करने के लिए टैप करें (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "क्लिक करने के लिए टैप करें (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "टाइपिंग के दौरान निष्क्रिय करें (_t)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "टचपैड (सापेक्षिक)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "स्क्रॉल कर रहे"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "बाएँ स्क्रॉल करें"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "दो तरफा"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "क्लिक करने, दोहरा क्लिक करने और स्क्रॉल करने की कोशिश करें"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "माउस व टचपैड"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "अपने माउस या संवेदनशीलता टचपैड बदलें और सही है या बाएँ हाथ का चयन करें "
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ट्रैकपैड;सूचक;क्लिक करें;टैब;डबल;बटन;ट्रैकबॉल;स्क्रॉल;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "कलरस्पेस: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "स्वचालित रूप से रद्दी खाली करें (_T)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "मॉनीटर"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "प्राथमिक प्रदर्शन बदलने के लिए खींचें."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "अनुप्रयोग"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "औज़ार"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "नया कनेक्शन जोड़ें"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "कनेक्टेड"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "विकल्प…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi हॉटस्पॉट "
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "संजाल नाम"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "कूटशब्द"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "कूटशब्द उत्पन्न करें"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "कूटशब्द उत्पन्न करें"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "चालू करें (_T)"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "हवाई जहाज मोड (_p)"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "कोई  तस्वीर नहीं मिला"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "हवाई जहाज मोड (_p)"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi हॉटस्पॉट "
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "हॉटस्पॉट के रूप में प्रयोग... (_U) "
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "संजाल"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x सुरक्षा (_S)"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i दिन पहले"
 msgstr[1] "%i दिनों पहले"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:533
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "None"
-msgstr "कुछ नहीं"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "कमजोर"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ठीक"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:568
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "अच्छा"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:570
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "बहुत बढिया"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "उपयोक्ता"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "पता"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "नेटमास्क"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "गेटवे"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "पता मिटाएँ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "जोड़ें"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "सर्वर"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "DNS सर्वर मिटायें"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "मेट्रिक"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "मार्ग  मिटाएँ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP)"
-msgstr "स्वचालित (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Manual"
-msgstr "हस्तचालित"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "लिंक स्थानीय सिर्फ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "उपसर्ग"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "स्वचालित"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "स्वचालित, केवल DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:51
-msgid "Reset"
-msgstr "रीसेट"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "कुछ नहीं"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-बिट कुंजी (हेक्स या ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit पासफ्रेज"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "गतिशील WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 निजी"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 एंटरप्राइज"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "सिग्नल सामर्थ्य "
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "कड़ी गति"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "सुरक्षा"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 पता"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 पता"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "हार्डवेयर पता"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "समर्थित आईसीसी प्रोफाइल"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "तयशुदा मार्ग"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "डीएनएस"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "अंतिम प्रयुक्त"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "मुड़ जोड़ी (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "संलग्न एकक अंतराफलन (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "मीडिया स्वतंत्र अंतरफलक (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 गीबा/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "नाम (_N)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
-msgid "_MAC Address"
-msgstr "MAC पता (_M)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "M_TU"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "क्लोन पता (_C)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "बाइट्स"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "अन्य उपयोगकर्ताओं के लिए उपलब्ध है (_u)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "स्वतः कनेक्ट करें (_a) "
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "फायरवॉल क्षेत्र (_Z)"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-#| msgid "Default"
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "तयशुदा"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "यह क्षेत्र कनेक्शन का भरोसेमंद स्तर परिभाषित करता है"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
-msgstr "पता (_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "स्वचालित DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Routes"
-msgstr "रूट"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "स्वचालित रूट"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:34
-msgid "Use this connection _only for resources on its network"
-msgstr "इस कनेक्शन का उपयोग करें इसके संजाल पर संसाधन के लिए (_o)"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "कनेक्शन संपादक खोलने में असमर्थ"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
-# test-gnome/testgnome.xml.h:5
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "कोई प्रोफ़ाइल"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "बंधन"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "टोली"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "पुल"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "वीपीएन प्लगिन लोड नहीं कर सका"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "फ़ाइल से आयात करें… "
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "नया संजाल कनेक्शन जोड़ें"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "रीसेट करें (_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1441
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "भूलें (_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"पासवर्ड सहित इस नेटवर्क के लिए सेटिंग्स रीसेट करें, लेकिन इसे एक पसंदीदा "
-"नेटवर्क समझें"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"इस नेटवर्क से संबंधित सभी जानकारी निकालें और स्वचालित रूप से कनेक्ट करने की "
-"कोशिश नहीं करें."
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
-msgid "S_ecurity"
-msgstr "सुरक्षा (_e)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "VPN कनेक्शन आय़ात नहीं कर सका"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"फाइल '%s' पढ़ा नहीं जा सका अथवा कोई परिचित VPN कनेक्शन सूचना को समाहित नहीं "
-"कर "
-"सका\n"
-"\n"
-"त्रुटि: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "आयात के लिए फाइल चुनें"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1948
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:223
-msgid "_Open"
-msgstr "खोलें (_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "\"%s\" नामक फाइल पहले से मौजूद है."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "बदलें (_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "क्या आप %s को VPN कनेक्शन के साथ बदलना चाहते हैं जिसे आप सहेज रहे हैं?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "VPN कनेक्शन निर्यात नहीं कर सका"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN कनेक्शन '%s' को %s में निर्यात नहीं किया जा सका.\n"
-"\n"
-"त्रुटि: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-#| msgid "Export VPN connection..."
-msgid "Export VPN connection"
-msgstr "VPN संबंधन निर्यात करें"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(त्रुटि: कनेक्शन संपादक खोलने में असमर्थ)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "_SSID"
-msgstr "_SSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
-msgid "_BSSID"
-msgstr "_BSSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "मेरा घर संजाल"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "अन्य उपयोगकर्ताओं के लिए उपलब्ध है (_o)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "नेटवर्क"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Control how you connect to the Internet"
-msgstr "नियंत्रित करें कैसे आप इंटरनेट से कनेक्ट होते हैं"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
-"संजाल;वायरलेस;वाई - फाई;वाईफ़ाई;आईपी;लैन;प्रॉक्सी;वैन;ब्रॉडबैंड;मोडेम;ब्लूटूथ;"
-"वीपीएन;ब्रिज;बांड;डीएनएस;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "बॉण्ड गुलाम"
-
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(कोई नहीं)"
-
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "पुल गुलाम"
-
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:462
-msgid "never"
-msgstr "कभी नहीं"
-
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:472
-msgid "today"
-msgstr "आज"
-
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:474
-msgid "yesterday"
-msgstr "कल"
-
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "आईपी पता"
-
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "अंतिम प्रयुक्त"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "तारसहित"
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1596
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "विकल्प…"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
-# test-gnome/testgnome.xml.h:5
-#: ../panels/network/net-device-ethernet.c:474
-#, c-format
-msgid "Profile %d"
-msgstr "प्रोफ़ाइल %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "नया कनेक्शन जोड़ें"
-
-#: ../panels/network/net-device-team.c:77
-#| msgid "Bridge slaves"
-msgid "Team slaves"
-msgstr "टीम स्लेव"
-
-#: ../panels/network/net-device-wifi.c:1154
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
-"यदि आपके पास बेतार के अलावा इंटरनेट पर कोई कनेक्शन है, आप इसे दूसरे के साथ "
-"बेतार हॉटस्पॉट "
-"सेट करकेकनेक्शन साझा करने के लिए उपयोग कर सकते हैं."
 
-#: ../panels/network/net-device-wifi.c:1158
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "बेतार हॉटस्पॉट पर जाना आपको <b>%s</b> से कनेक्ट नहीं रहने देगा."
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "नाम (_N)"
 
-#: ../panels/network/net-device-wifi.c:1162
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"आपके बेतार कनेक्शन से इंटरनेट में पहुँच लेना संभव नहीं है जब हॉटस्पॉट सक्रिय "
-"हो. "
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC पता (_M)"
 
-#: ../panels/network/net-device-wifi.c:1245
-msgid "Stop hotspot and disconnect any users?"
-msgstr "हॉटस्पॉट रोकें और किसी भी उपयोगकर्ताओं को डिस्कनेक्ट करें?"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
 
-#: ../panels/network/net-device-wifi.c:1248
-msgid "_Stop Hotspot"
-msgstr "हॉटस्पॉट रोकें (_S)"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "क्लोन पता (_C)"
 
-#: ../panels/network/net-device-wifi.c:1305
-msgid "System policy prohibits use as a Hotspot"
-msgstr "तंत्र नीति हॉटस्पॉट के रूप में उपयोग को प्रतिबंधित करता हैं"
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "बाइट्स"
 
-#: ../panels/network/net-device-wifi.c:1308
-msgid "Wireless device does not support Hotspot mode"
-msgstr "वायरलेस युक्ति हॉटस्पॉट मोड समर्थन नहीं करता है"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "विधि (_M)"
 
-#: ../panels/network/net-device-wifi.c:1437
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"कूटशब्द सहित चुने गए नेटवर्कों के लिए संजाल विवरण और अन्य कोई मनपसंद विन्यास "
-"नष्ट हो "
-"जाएगा."
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "स्वचालित (DHCP)"
 
-#: ../panels/network/net-device-wifi.c:1745
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "इतिहास"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "लिंक स्थानीय सिर्फ"
 
-#: ../panels/network/net-device-wifi.c:1749
-#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
-#: ../panels/wacom/cc-wacom-page.c:533
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Close"
-msgstr "बंद करें (_C)"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1757
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "भूलें (_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"वेब प्रॉक्सी ऑटो डिस्कवरी का प्रयोग किया जाता है जब कॉन्फ़िगरेशन यूआरएल "
-"प्रदान नहीं किया "
-"जाता है."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "यह अविश्वसनीय सार्वजनिक संजाल के लिए अनुशंसित नहीं है."
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "प्रॉक्सी"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "जोड़ें प्रोफाइल... (_A)"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "प्रदाता"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "कुछ नहीं"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "हस्तचालित"
 
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "अक्षम"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "अन्य कंप्यूटरों के साथ साझा किया"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "पता (_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "पता"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "नेटमास्क"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "गेटवे"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "स्वचालित"
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "स्वचालित DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "रूट"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "स्वचालित रूट"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "मेट्रिक"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "इस कनेक्शन का उपयोग करें इसके संजाल पर संसाधन के लिए (_o)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
 msgstr "विधि (_M)"
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "विन्यास यूआरएल (_C)"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "स्वचालित, केवल DHCP"
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "एचटीटीपी प्रॉक्सी (_H)"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "उपसर्ग"
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "एचटीटीपी प्रॉक्सी: (_T)"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "सुरक्षा (_e)"
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "एफटीपी प्रॉक्सी (_F)"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(त्रुटि: कनेक्शन संपादक खोलने में असमर्थ)"
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "साक्स होस्ट (_S)"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "होस्ट अनदेखा करें (_I)"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
 
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "HTTP प्राक्सी पोर्ट"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "नेटवर्क"
 
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "एफ़टीपी प्रॉक्सी पोर्ट "
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "नियंत्रित करें कैसे आप इंटरनेट से कनेक्ट होते हैं"
 
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "एफ़टीपी प्रॉक्सी पोर्ट"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "SOCKS प्राक्सी पोर्ट "
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "युक्ति बन्द करें"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "युक्ति जोड़ें"
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "युक्ति हटायें"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN क़िस्म"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "समूह नाम"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "समूह कूटशब्द"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "उपयोक्तानाम"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr "VPN संबंधन बंद करें"
-
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "स्वचालित कनेक्ट करें (_C)"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "विवरण"
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "कूटशब्द (_P)"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "कुछ नहीं"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "कूटशब्द दिखाएं (_a)"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr "अन्य उपयोगकर्ताओं के लिए उपलब्ध है"
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "उपयोक्ता"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr "स्वचालित (DHCP) पता केवल"
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr "लिंक स्थानीय सिर्फ"
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr "अन्य कंप्यूटरों के साथ साझा किया"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr "स्वतः प्राप्त रूट अनदेखा करें (_n) "
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "IPv4"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "IPv6"
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr "क्लोन MAC पता (_C)"
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr "हार्डवेयर"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
-"उनकी चूक को इस कनेक्शन के लिए सेटिंग्स रीसेट करें, लेकिन एक पसंदीदा कनेक्शन "
-"के रूप में याद करें."
+"संजाल;वायरलेस;वाई - फाई;वाईफ़ाई;आईपी;लैन;प्रॉक्सी;वैन;ब्रॉडबैंड;मोडेम;ब्लूटूथ;वीपीएन;ब्रिज;"
+"बांड;डीएनएस;"
 
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"इस नेटवर्क से संबंधित सभी जानकारी निकालें और स्वचालित रूप से इसे कनेक्ट करने "
-"की कोशिश नहीं "
-"करें."
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "रीसेट"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "हार्डवेयर"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi हॉटस्पॉट "
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Turn On"
-msgstr "चालू करें (_T)"
-
-#: ../panels/network/network-wifi.ui.h:54
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "वाई फाई"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Turn Wi-Fi off"
-msgstr "वाई फाई चालू या बंद करें:"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "नियंत्रित करें कैसे आप इंटरनेट से कनेक्ट होते हैं"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_Use as Hotspot…"
-msgstr "हॉटस्पॉट के रूप में प्रयोग... (_U) "
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"संजाल;वायरलेस;वाई - फाई;वाईफ़ाई;आईपी;लैन;प्रॉक्सी;वैन;ब्रॉडबैंड;मोडेम;ब्लूटूथ;वीपीएन;ब्रिज;"
+"बांड;डीएनएस;"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "_Connect to Hidden Network…"
-msgstr "छिपे संजाल में कनेक्ट करें... (_C)"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "तारसहित"
 
-#: ../panels/network/network-wifi.ui.h:58
-msgid "_History"
-msgstr "इतिहास (_H)"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "युक्ति बन्द करें"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "वाई फाई संजाल में कनेक्ट होने के लिए बंद करें"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "सक्रिय"
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "प्रदाता"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "आईपी पता"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "नेटवर्क प्रॉक्सी"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "एचटीटीपी प्रॉक्सी (_H)"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "एचटीटीपी प्रॉक्सी: (_T)"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "एफटीपी प्रॉक्सी (_F)"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "साक्स होस्ट (_S)"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "होस्ट अनदेखा करें (_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP प्राक्सी पोर्ट"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "एफ़टीपी प्रॉक्सी पोर्ट "
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "एफ़टीपी प्रॉक्सी पोर्ट"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "SOCKS प्राक्सी पोर्ट "
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "विन्यास यूआरएल (_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN संबंधन बंद करें"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "संजाल नाम"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Connected Devices"
-msgstr "कनेक्टेड युक्तियाँ"
-
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "सुरक्षा प्रकार"
 
-#: ../panels/network/network-wifi.ui.h:63
-msgid "Security key"
-msgstr "सुरक्षा कुंजी"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "कूटशब्द"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "तदर्थ"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "वाई फाई चालू या बंद करें:"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "बुनियादी ढाँचा"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "लोडिंग विकल्प... "
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "स्थिति अज्ञात"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "छिपे संजाल में कनेक्ट करें... (_C)"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "बिना प्रबंधित"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi हॉटस्पॉट "
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "अनुपलब्ध"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "जोड़ रहा है"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "सत्यापन आवश्यक"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "कनेक्टेड"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "डिसकनेक्टिंग"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "कनेक्शन असफल"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "स्थिति अज्ञात (गुम)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "कनेक्टेड नहीं है"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "विन्यास विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "IP विन्यास विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "आईपी विन्यास का समय समाप्त"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "गोपनीयता जरूरी थी, लेकिन प्रदान नहीं किया गया था"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x सप्लीकेंट डिसकनेक्टेड"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x सप्लीकेंट विन्यास विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1x सप्लीकेंट विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x सप्लीकेंट प्रमाणित करने में काफी समय लिया"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "PPP आरंभ होने में विफल रहा"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "PPP सेवा डिस्कनेक्टेड"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "DHCP क्लाइंट आरंभ होने में विफल रहा"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP क्लाइंट त्रुटि"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP क्लाइंट विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "साझा कनेक्शन सेवा आरंभ होने में विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "साझा कनेक्शन सेवा विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "AutoIP सेवा आरंभ होने में विफल रहा"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "AutoIP सेवा त्रुटि"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "AutoIP सेवा विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "पंक्ति व्यस्त"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "डायल टोन नहीं"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "कोई कैरियर स्थापित नहीं किया जा सका"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "डायलिंग आग्रह का समय समाप्त"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "डायलिंग प्रयास विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "मोडेम आरंभीकरण असफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "विशेष APN चुनने में विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "संजाल के लिए खोज नहीं रहा है"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "संजाल पंजीयन मनाही"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "संजाल पंजीयन का समय समाप्त"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "निवेदित संजाल के साथ पंजीयन में विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "पिन चेक विफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "युक्ति के लिए फर्मवेयर अनुपस्थित हो सकता है"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "कनेक्शन गुम"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "मौज़ूदा कनेक्शन चालू हुआ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "मोडेम नहीं मिला"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "ब्लूटूथ कनेक्शन असफल"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "SIM कार्ड नहीं घुसाया गया"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "SIM पिन जरूरी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "SIM Puk जरूरी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "SIM गलत"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "InfiniBand युक्ति कनेक्टेड अवस्था का समर्थन नहीं करता है"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "कनेक्शन निर्भरता विफल"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "गुम फर्मवेयर"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "केबल अनप्लग"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "कोई प्रमाणपत्र प्राधिकार प्रमाणपत्र चुना गया"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"एक सर्टिफिकेट ऑथोरिटी (CA) प्रमाणपत्र का उपयोग नहीं असुरक्षित, दुष्ट Wi-Fi "
-"नेटवर्क के "
-"लिए कनेक्शन में परिणाम कर सकते हैं.आप एक सर्टिफिकेट ऑथोरिटी प्रमाणपत्र का चयन "
-"करना चाहेंगे?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "नज़रअंदाज़ करें"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "सीए प्रमाणपत्र चुनें"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, या PKCS#12 निजी कुंजी (*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER या PEM प्रमाणपत्र (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-#| msgid "Choose a PAC file..."
-msgid "Choose a PAC file"
-msgstr "PAC फ़ाइल चुनें"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC फ़ाइल (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC फाइल (_f)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "आंतरिक सत्यापन (_I) "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "PAC pro_visioning"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "अज्ञातनाम"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "सत्यापित"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "दोनों"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "बेनाम पहचान (_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC फाइल (_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PAC फ़ाइल चुनें"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "आंतरिक सत्यापन (_I) "
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC pro_visioning"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "उपयोक्ता नाम (_U)"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "कूटशब्द (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "कूटशब्द दिखाएँ (_w)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "एमडी5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-#| msgid "Choose a Certificate Authority certificate..."
-msgid "Choose a Certificate Authority certificate"
-msgstr "सर्टिफिकेट ऑथरिटी प्रमाणपत्र चुनें"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "संस्करण 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "संस्करण 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "सीए प्रमाणपत्र (_A)"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "सर्टिफिकेट ऑथरिटी प्रमाणपत्र चुनें"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "सत्यापन आवश्यक"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP संस्करण (_v)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "इस कूटशब्द के लिए हर समय पूछें (_k)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "विगोपित निजी कुंजी असुरक्षित हैं"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"चुना गया निजी कुंजी कूटशब्द के द्वारा संरक्षित नहीं दिखता है.  यह आपके "
-"सुरक्षा साख को खराब "
-"कर सकता है.  कृपया कोई कूटशब्द संरक्षित निजी कुंजी चुनें.\n"
-"\n"
-"(आप अपने निजी कुंजी से openssl के साथ अपना कूटशब्द संरक्षित कर सकते हैं)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-#| msgid "Choose your personal certificate..."
-msgid "Choose your personal certificate"
-msgstr "अपना व्यक्तिगत प्रमाणपत्र चुनें"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-#| msgid "Choose your private key..."
-msgid "Choose your private key"
-msgstr "अपनी निजी कुंजी चुनें"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "पहचान (_d)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "उपयोक्ता प्रमाणपत्र (_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "निजी कुंजी (_k)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "निजी कुंजी कूटशब्द (_P) "
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "पीएपी"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "सीएचएपी"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "मुझे फिर मत चेताएँ (_w)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "डोमेन (_D)"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "नहीं"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "हाँ"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "टीएलएस"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "तीव्र"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "टनेल किया टीएलएस"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "संरक्षित EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "सत्यापन (_t)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1(तयशुदा)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "खुला तंत्र"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "साझा कुंजी"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "कुंजी (_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "कुंजी दिखाएँ (_w)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP सूची (_x)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "प्रकार (_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1(तयशुदा)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "खुला तंत्र"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "साझा कुंजी"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "कुंजी (_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "कुंजी दिखाएँ (_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP सूची (_x)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "सूचनाएँ"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "ध्वनि चेतावनी"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "पॉपअप बैनर दिखाएं"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "बैनर में विवरण दिखाएँ"
-
-#: ../panels/notifications/cc-edit-dialog.c:43
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "लॉक स्क्रीन में देखें"
-
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "लॉक स्क्रीन में विवरण दिखाएँ "
-
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "चालू"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "सूचनाएँ"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "सूचनाएँ"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "लॉक स्क्रीन में विवरण दिखाएँ "
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "सूचनाएँ"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "नियंत्रण जो सूचनाएं प्रदर्शित कर रहे हैं कि वे क्या दिखाते हैं।"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "बैनर;संदेश;ट्रे;पॉपअप;सूचनाएं;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "पॉपअप बैनर दिखाएं"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "लॉक स्क्रीन में दिखाएँ "
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "आंतरिक सत्यापन (_a)"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-#| msgid "Other"
-msgctxt "Online Account"
-msgid "Other"
-msgstr "अन्य"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "खाता जोड़ें"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
-msgstr "डाक"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr "संपर्क"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "गपशप"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "संसाधन "
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "खाते में लॉगिंग त्रुटि"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "महत्व का समय समाप्त हो गया."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr "इस खाते को सक्षम करने के लिए साइन - इन करें."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr " साइन - इन करें (_S)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "खाता बनाने में त्रुटि"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "खाता हटाने में त्रुटि"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "क्या आप वाक़ई ख़ाता को मिटाना चाहते हैं?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "यह सर्वर पर खाता को हटा देगा."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "हटाएं (_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "ऑनलाइन खातों"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
-msgstr ""
-"आपके ऑनलाइन खातों से कनेक्ट करने और निर्णय क्या उनके लिए उपयोग करने के लिए"
+msgstr "आपके ऑनलाइन खातों से कनेक्ट करने और निर्णय क्या उनके लिए उपयोग करने के लिए"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
-#| "ownCloud;"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-"गूगल;फेसबुक;ट्विटर;याहू;वेब;ऑनलाइन;चैट;कैलेंडर;मेल;संपर्क;ओनक्लाउड;Kerberos;IM"
-"AP;SMTP;Pocket;ReadItLater;"
+"गूगल;फेसबुक;ट्विटर;याहू;वेब;ऑनलाइन;चैट;कैलेंडर;मेल;संपर्क;ओनक्लाउड;Kerberos;IMAP;SMTP;"
+"Pocket;ReadItLater;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "कोई ऑनलाइन खाता विन्यस्त नहीं"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "खाता मिटाएँ"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "एक ऑनलाइन खाता जोड़ें"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"किसी खाता को जोड़ना आपके अनुप्रयोग को दस्तावेज़, डाक, संपर्क, पंचांग, चैट और "
-"भी कुछेक में "
-"पहुँछ लेने देता है."
-
-#: ../panels/power/cc-power-panel.c:183
-msgid "Unknown time"
-msgstr "अज्ञात समय"
-
-#: ../panels/power/cc-power-panel.c:189
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i मिनट"
 msgstr[1] "%i मिनट"
 
-#: ../panels/power/cc-power-panel.c:201
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i घंटा"
 msgstr[1] "%i घंटा"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:209
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "घंटा"
 msgstr[1] "घंटे"
 
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "मिनट"
 msgstr[1] "मिनट"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:230
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s जब तक पूरी तरह चार्ज्ड"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 मिनट"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:237
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "चेतावनी: %s शेष"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 मिनट"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:242
-#, c-format
-msgid "%s remaining"
-msgstr "%s शेष"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 मिनट"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
-msgid "Fully charged"
-msgstr "पूरी तरह चार्ज्ड "
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 मिनट"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
-msgid "Empty"
-msgstr "रिक्त"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Charging"
-msgstr "चार्ज हो रहा है"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:271
-msgid "Discharging"
-msgstr "डिस्चार्ज कर रहा है"
-
-#: ../panels/power/cc-power-panel.c:396
-msgctxt "Battery name"
-msgid "Main"
-msgstr "मुख्य"
-
-#: ../panels/power/cc-power-panel.c:398
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "अतिरिक्त"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:470
-msgid "Wireless mouse"
-msgstr "बेतार माउस"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:473
-msgid "Wireless keyboard"
-msgstr "बेतार कीबोर्ड"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:476
-msgid "Uninterruptible power supply"
-msgstr "बिना व्यवधान के ऊर्जा आपूर्ति"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Personal digital assistant"
-msgstr "व्यक्तिगत डिजिटल सहायक"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Cellphone"
-msgstr "सेलफोन"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Media player"
-msgstr "मीडिया प्लेयर"
-
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Tablet"
-msgstr "टेबलेट"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Computer"
-msgstr "कम्प्यूटर"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
-#: ../panels/power/cc-power-panel.c:2019
-msgid "Battery"
-msgstr "बैटरी"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "चार्ज हो रहा है"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "चेतावनी"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Low"
-msgstr "कम"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Good"
-msgstr "अच्छा"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "पूरी तरह चार्ज्ड "
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "रिक्त"
-
-#: ../panels/power/cc-power-panel.c:715
-msgid "Batteries"
-msgstr "बैटरी"
-
-#: ../panels/power/cc-power-panel.c:1117
-msgid "When _idle"
-msgstr "निष्क्रिय जब (_I)"
-
-#: ../panels/power/cc-power-panel.c:1445
-msgid "Power Saving"
-msgstr "पावर सेविंग"
-
-#: ../panels/power/cc-power-panel.c:1473
-#| msgid "_Screen Brightness"
-msgid "_Screen brightness"
-msgstr "स्क्रीन चमक (_S)"
-
-#: ../panels/power/cc-power-panel.c:1479
-#| msgid "Keyboard Settings"
-msgid "_Keyboard brightness"
-msgstr "कुंजीपट चमकीलापन (_K)"
-
-#: ../panels/power/cc-power-panel.c:1489
-#| msgid "_Dim Screen when Inactive"
-msgid "_Dim screen when inactive"
-msgstr "स्क्रीन मंद करें जब निष्क्रिय हैं (_D)"
-
-#: ../panels/power/cc-power-panel.c:1514
-#| msgid "_Blank Screen"
-msgid "_Blank screen"
-msgstr "खाली स्क्रीन (_B)"
-
-#: ../panels/power/cc-power-panel.c:1551
-msgid "_Wi-Fi"
-msgstr "वाई फाई (_W)"
-
-#: ../panels/power/cc-power-panel.c:1556
-msgid "Turns off wireless devices"
-msgstr "बेतार युक्तियाँ बंद करें"
-
-#: ../panels/power/cc-power-panel.c:1581
-#| msgid "_Mobile Broadband"
-msgid "_Mobile broadband"
-msgstr "मोबाइल ब्रॉडबैंड (_M)"
-
-#: ../panels/power/cc-power-panel.c:1586
-#| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "मोबाइल ब्रॉडबैंड (3G, 4G, WiMax, आदि.) युक्तियाँ बंद करें"
-
-#: ../panels/power/cc-power-panel.c:1635
-msgid "_Bluetooth"
-msgstr "ब्लूटूथ (_B)"
-
-#: ../panels/power/cc-power-panel.c:1686
-msgid "When on battery power"
-msgstr "जब बैटरी शक्ति पर चल रहा हो"
-
-#: ../panels/power/cc-power-panel.c:1688
-msgid "When plugged in"
-msgstr "जब प्लगिन"
-
-#: ../panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Off"
-msgstr "निलंबित & पावर ऑफ करें"
-
-#: ../panels/power/cc-power-panel.c:1851
-#| msgid "_Automatic Suspend"
-msgid "_Automatic suspend"
-msgstr "स्वत: निलंबित (_A)"
-
-#: ../panels/power/cc-power-panel.c:1875
-#| msgid "When Battery Power is _Critical"
-msgid "When battery power is _critical"
-msgstr "जब पावर बहुत कम है (_C)"
-
-#: ../panels/power/cc-power-panel.c:1930
-msgid "Power Off"
-msgstr "बंद करें"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Devices"
-msgstr "औज़ार"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "पावर"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr "अपनी बैटरी की स्थिति और परिवर्तन बिजली की बचत सेटिंग्स देखें"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-"पावर;नींद;निलंबित करें; सीतनिद्रा में होना; "
-"बैटरी;चमक;मंद;खाली;मॉनिटर;DPMS;निष्क्रिय;"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "सुप्तावस्था"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "पावर ऑफ"
-
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 मिनट"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 घंटा"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 मिनट"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 मिनट"
 
-#: ../panels/power/power.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 मिनट"
 
-#: ../panels/power/power.ui.h:10
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 घंटा"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 मिनट"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "बैटरी"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 मिनट"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "औज़ार"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "मिनट"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "पावर ऑफ"
 
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "4 मिनट"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 मिनट"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "पावर सेविंग"
 
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "8 मिनट"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "स्क्रीन चमक (_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 मिनट"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "स्क्रीन चमकीलापन और लॉक सेटिंग्स"
 
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "12 मिनट"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "स्क्रीन"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "स्क्रीन वाचक (_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "स्वचालित रूट"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "स्वत: निलंबित"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "निचले बटन"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "स्वत: निलंबित"
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "जब प्लगिन (_P)"
 
-#: ../panels/power/power.ui.h:22
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "बैटरी पॉवर ऑन करें (_B)"
 
-#: ../panels/power/power.ui.h:23
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "देरी"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "सत्यापित करें"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "पावर"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "कूटशब्द"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "अपनी बैटरी की स्थिति और परिवर्तन बिजली की बचत सेटिंग्स देखें"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "सत्यापन आवश्यक"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr "टोनर पर कम"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr "टोनर के बाहर"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr "डेवलपर पर कम"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr "डेवलपर के बाहर"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr "चिह्न आपूर्ति पर कम"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr "चिह्न आपूर्ति के बाहर"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr "कवर खोलें"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr "खुला दरवाजा"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr "कागज पर कम"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr "कागज के बाहर"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ऑफ़लाइन"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "रुक गया"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr "लगभग पूरा गोदाम बेकार"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr "लगभग गोदाम बेकार"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr "ऑप्टिकल फोटो कंडक्टर जीवन का अंत निकट है"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ऑप्टिकल फोटो कंडक्टर कामकाज नहीं रहा है"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "विन्यस्त कर रहा है"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr "तैयार"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "काम नहीं स्वीकार कर सकते हैं"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr "प्रक्रिया हो रही है"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Toner Level"
-msgstr "टोनर स्तर"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Ink Level"
-msgstr "स्याही स्तर"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:928
-msgid "Supply Level"
-msgstr "आपूर्ति स्तर"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:946
-msgctxt "printer state"
-msgid "Installing"
-msgstr "संस्थापित किया जा रहा है"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1123
-msgid "No printers available"
-msgstr "कोई प्रिंटर उपलब्ध नहीं"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1433
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u सक्रिय"
-msgstr[1] "%u सक्रिय"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1777
-msgid "Failed to add new printer."
-msgstr "नया प्रिंटर जोड़ने में विफल."
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid "Select PPD File"
-msgstr "एक PPD फाइल चुनें"
-
-#: ../panels/printers/cc-printers-panel.c:1953
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
-"पोस्टस्क्रिप्ट प्रिंटर विवरण फ़ाइल (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD.GZ)"
+"पावर;नींद;निलंबित करें; सीतनिद्रा में होना; बैटरी;चमक;मंद;खाली;मॉनिटर;DPMS;निष्क्रिय;"
 
-#: ../panels/printers/cc-printers-panel.c:2258
-msgid "No suitable driver found"
-msgstr "कोई उपयुक्त ड्राइवर नहीं मिला"
-
-#: ../panels/printers/cc-printers-panel.c:2327
-msgid "Searching for preferred drivers…"
-msgstr "वरीय ड्राइवर के लिए खोज रहा है... "
-
-#: ../panels/printers/cc-printers-panel.c:2342
-msgid "Select from database…"
-msgstr "डेटाबेस से चुनें... "
-
-#: ../panels/printers/cc-printers-panel.c:2351
-msgid "Provide PPD File…"
-msgstr "PPD फाइल दें... "
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2502
-#: ../panels/printers/cc-printers-panel.c:2525
-msgid "Test page"
-msgstr "जाँच पृष्ठ"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2933
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "लोड नहीं कर सका ui: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "मुद्रक"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
-"प्रिंटर जोड़ें, प्रिंटर नौकरियों देखने के लिए और तय करें कि कैसे आप मुद्रित "
-"करना चाहते हैं."
+"प्रिंटर जोड़ें, प्रिंटर नौकरियों देखने के लिए और तय करें कि कैसे आप मुद्रित करना चाहते हैं."
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "प्रिंटर;पंक्ति;मुद्रण;पेपर;इंक;टोनर;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "सक्रिय कार्य"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "बंद करें"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "मुद्रण फिर से शुरू"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "ठहराव मुद्रण"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "मुद्रण कार्य रद्द करें"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "नया प्रिंटर जोड़ें"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-#| msgid "Authenticate"
-msgid "A_uthenticate"
-msgstr "सत्यापन करें (_u)"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "कोई मुद्रक नहीं खोज सका."
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-#| msgid "Search for network printers or filter result"
-msgid "Enter address of a printer or a text to filter results"
-msgstr "प्रिंटर का पता डालें या परिणाम फिल्टर करने के लिए पाठ डालें"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "लोडिंग विकल्प... "
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "प्रिंटर ड्राइवर चुनें"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "ड्राइवर डेटाबेस लोड कर रहा है..."
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-#| msgid "Remove Printer"
-msgid "JetDirect Printer"
-msgstr "जेटप्रिंटर प्रिंटर"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-#| msgid "%s Printer"
-msgid "LPD Printer"
-msgstr "LPD मुद्रक"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "एक तरफा"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "लंबा किनारा (मानक)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "छोटा किनारा (पलटें)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "व्यक्तिचित्र"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "भूदृश्य"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "उल्टा भूदृश्य"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "उल्टा व्यक्तिचित्र"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "स्थगित"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "रोकें"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "प्रक्रिया हो रही है"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "रुक गया"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "रद्द"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "छोड़ा गया"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "पूर्ण"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "पद नाम"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "जॉब स्थिति"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "समय"
-
-#: ../panels/printers/pp-jobs-dialog.c:495
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s सक्रिय कार्य"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "USB"
-msgstr "यूएसबी"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Serial Port"
-msgstr "क्रमिक पोर्ट"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1683
-msgid "Parallel Port"
-msgstr "समांतर पोर्ट"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-#| msgid "Location"
-msgid "Location: %s"
-msgstr "स्थानः %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1744
-#, c-format
-#| msgid "A_ddress:"
-msgid "Address: %s"
-msgstr "पता: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1768
-#| msgid "_Inner authentication"
-msgid "Server requires authentication"
-msgstr "सर्वर को प्रमाणीकरण की आवश्यकता है"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "दो तरफा"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "कागज का प्रकार"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "कागज स्रोत"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "आउटपुट तश्तरी"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript प्री फ़िल्टरिंग"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:531
-msgid "Pages per side"
-msgstr "पृष्ठ प्रति पक्ष"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:543
-msgid "Two-sided"
-msgstr "दो तरफा"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:555
-msgid "Orientation"
-msgstr "दिशा"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:652
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "सामान्य"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "पृष्ठ सेटअप"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "मुद्रक विकल्प"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "कार्य"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "छवि गुणवत्ता"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "रंग"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "समाप्त कर रहा है"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "उन्नत"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "स्वतः चुनें"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "मुद्रक तयशुदा"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "अंतस्थापित GhostScript फ़ॉन्ट केवल"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "PS स्तर 1 में बदलें"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "पीएस स्तर 2 पर परिवर्तित करें"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
-# test-gnome/testgnome.xml.h:5
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "कोई पूर्व फ़िल्टरिंग नहीं"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "उत्पादक"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "ड्राइवर"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-"%s पर उपलब्ध प्रिंटर को देखने के लिए अपने उपयोगकर्ता नाम और पासवर्ड दर्ज करें."
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "प्रिंटर जोड़ें"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "प्रिंटर हटायें"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "खोलें"
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "आपूर्ति"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "कोई  तस्वीर नहीं मिला"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "सत्यापन आवश्यक"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr "%s पर उपलब्ध प्रिंटर को देखने के लिए अपने उपयोगकर्ता नाम और पासवर्ड दर्ज करें."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "उपयोक्तानाम"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "स्थान"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-#| msgid "Default Route"
-msgid "_Default printer"
-msgstr "तयशुदा प्रिंटग (_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "ड्राइवर"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "कार्य"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "वरीय ड्राइवर के लिए खोज रहा है... "
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "जॉब दिखाएं (_J)"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "एक शहर के लिए खोजें"
+
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "डेटाबेस से चुनें... "
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "PPD फाइल दें... "
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "प्रिंटर ड्राइवर चुनें"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "ड्राइवर डेटाबेस लोड कर रहा है..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "रद्द करें"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "चुनें"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "सर्वर को प्रमाणीकरण की आवश्यकता है"
+msgstr[1] "सर्वर को प्रमाणीकरण की आवश्यकता है"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "डोमेन (_D)"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "सत्यापन करें (_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "सत्यापित करें"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s सक्रिय कार्य"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "जाँच पृष्ठ"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "लॉगिन विकल्प"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "मुद्रक तयशुदा"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "मुद्रक तयशुदा"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "मुद्रण कार्य रद्द करें"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "प्रिंटर हटायें"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "सक्रिय कार्य"
 
 # libgnomeprintui/gpaui/add-printer-dialog.c:83
 # libgnomeprintui/gpaui/config-dialog.c:83
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "मॉडल"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "लेबल"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "स्याही स्तर"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "नए ड्राइवर की स्थापना कर रहा है ..."
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "पृष्ठ 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "जाँच पृष्ठ छापें (_T)"
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "विकल्प (_O)"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "अब फिर आरंभ करें"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "नया प्रिंटर जोड़ें"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "प्रिंटर जोड़ें"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "प्रिंटर सेटिंग्स बदलें"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "मुद्रक"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "क्षमा करें!तंत्र मुद्रण सेवा\n"
 "उपलब्ध नहीं लगती है."
 
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "स्क्रीन ताला"
-
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "उपयोग & इतिहास"
-
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
-msgstr "रद्दी से सभी मदों खाली करें?"
-
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
-msgstr "रद्दी में सभी मदों हमेशा के लिए मिटा दी जाएंगी."
-
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "रद्दी खाली करें (_E)"
-
-#: ../panels/privacy/cc-privacy-panel.c:512
-#| msgid "Purge Trash & Temporary Files"
-msgid "Delete all the temporary files?"
-msgstr "ट्रैश व अस्थाई फ़ाइलें मिटाएँ?"
-
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
-msgstr "सभी अस्थाई फ़ाइल स्थाई रूप से मिटा दी जाएगी."
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
-# test-gnome/testgnome.xml.h:5
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "अस्थाई फ़ाइलें मिटाएँ (_P)"
-
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "ट्रैश & अस्थाई फ़ाइलें मिटाएँ"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-#| msgid "Software"
-msgid "Software Usage"
-msgstr "सॉफ्टवेयर प्रयोग"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "गोपनीयता"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-"आपकी व्यक्तिगत जानकारी और नियंत्रण जो दूसरों को देख सकते हैं की सुरक्षित रखें"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"स्क्रीन;ताला;निदान;दुर्घटना;निजी;हाल ही में;अस्थायी;tmp;सूचकांक; "
-"नाम;नेटवर्क;पहचान;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "स्क्रीन बंद करता है "
-
-#  set the timeout value  label with correct value of timeout
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 सेकण्ड"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 दिन"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 दिन"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 दिन"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 दिन"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 दिन"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 दिन"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 दिन"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 दिन"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 दिन"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "सदा के लिए "
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"अपने इतिहास को याद बातें करने के लिए फिर से खोजने के लिए आसान बनाता है.इन "
-"मदों नेटवर्क "
-"पर कभी नहीं साझा कर रहे हैं."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "हाल ही में प्रयुक्त (_R)"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "इतिहास रख सकेंगे (_H)"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "हालिया इतिहास साफ करें (_e)"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "स्क्रीन लॉक आपकी गोपनीयता की रक्षा जब आप दूर कर रहे हैं."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "स्वचालित स्क्रीन लॉक (_L)"
-
-#: ../panels/privacy/privacy.ui.h:27
-#| msgid "Lock Screen _After Blank For"
-msgid "Lock screen _after blank for"
-msgstr "खाली करने के बाद स्क्रीन लॉक (_a)"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "अधिसूचना दिखाएँ (_N)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"स्वचालित रूप से कचरा पेटी और अस्थायी फ़ाइलें को मिटायें  अपने कंप्यूटर को "
-"अनावश्यक संवेदनशील "
-"जानकारी के मुक्त रखने में मदद करने के लिए "
-
-#: ../panels/privacy/privacy.ui.h:31
-#| msgid "Automatically Empty _Trash"
-msgid "Automatically empty _Trash"
-msgstr "स्वचालित रूप से रद्दी खाली करें (_T)"
-
-#: ../panels/privacy/privacy.ui.h:32
-#| msgid "Automatically Purge Temporary _Files"
-msgid "Automatically purge Temporary _Files"
-msgstr "स्वचालित रूप से अस्थाई फ़ाइलें मिटाएँ (_F)"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "के बाद मिटाएँ (_A)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"आप किस सॉफ़्टवेयर का उपयोग करते हैं इसपर सूचना भेजा हमें अधिक सटीक अनुशंसा के "
-"लिए मदद करता है. यह हमेें हमारे सॉफ्टवेयर को सुधारने में मदद करता है.\n"
-"\n"
-"सभी जानकारियाँ जो हम जमा करते हैं वह बेनाम रहती हैं, और हम आपके आँकड़े को "
-"किसी तीसरे पक्ष से साझा कभी नहीं करते हैं."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "सॉफ़्टवेयर प्रयोग आँकड़ा भेजें (_S)"
-
-#: ../panels/privacy/privacy.ui.h:41
-#| msgid "Privacy"
-msgid "Privacy Policy"
-msgstr "गोपनीयता नीति"
-
-#: ../panels/privacy/privacy.ui.h:42
-#| msgid "Location"
-msgid "_Location Services"
-msgstr "अवस्थिति सेवाएँ (_L)"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "आपके भौगोलिक अवस्थिति निर्धारित करने के लिए प्रयोग"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "इम्पीरियल"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "मेट्रिक"
-
-#: ../panels/region/cc-format-chooser.c:284
-msgid "No regions found"
-msgstr "कोई क्षेत्रों नहीं मिला"
-
-#: ../panels/region/cc-input-chooser.c:179
-msgid "No input sources found"
-msgstr "कोई  इनपुट स्रोत नहीं मिला"
-
-#: ../panels/region/cc-input-chooser.c:1076
-#| msgid "Other"
-msgctxt "Input Source"
-msgid "Other"
-msgstr "अन्य"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:892
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "परिवर्तनों को प्रभावी करने के लिए अपने सत्र के लिए आरंभ किया जाना है"
-
-#: ../panels/region/cc-region-panel.c:243
-#: ../panels/user-accounts/um-user-panel.c:896
-msgid "Restart Now"
-msgstr "अब फिर आरंभ करें"
-
-#: ../panels/region/cc-region-panel.c:862
-msgid "No input source selected"
-msgstr "कोई इनपुट स्रोत चयनित नहीं"
-
-#: ../panels/region/cc-region-panel.c:1092
-msgid "Sorry"
-msgstr "खेद है"
-
-#: ../panels/region/cc-region-panel.c:1094
-msgid "Input methods can't be used on the login screen"
-msgstr "इनपुट विधि लॉगिन स्क्रीन पर नहीं किया जा सकता"
-
-#: ../panels/region/cc-region-panel.c:1731
-msgid "Login Screen"
-msgstr "लॉगिन स्क्रीन"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "प्रारूप"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "खोजें स्थान"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "प्रारूप"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "प्रारूप"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "पूर्वावलोकन"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "तिथियाँ"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "बार"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "तिथि व समय"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "संख्याएँ"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "माप"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "कागज"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "भाषा संस्थापित करें..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "मेरा खाता"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "भाषा (_L)"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "प्रारूप"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "लॉगिन स्क्रीन"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "क्षेत्र और भाषा"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
-msgstr ""
-"अपनी प्रदर्शन भाषा, स्वरूपों, कीबोर्ड लेआउट और इनपुट सूत्रों का चयन करें"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "अपनी प्रदर्शन भाषा, स्वरूपों, कीबोर्ड लेआउट और इनपुट सूत्रों का चयन करें"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "भाषा;लेआउट;कीबोर्ड; इनपुट;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "इनपुट स्रोत जोड़ें "
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "चुनें कैसे मीडिया को नियंत्रित किया जाना चाहिए"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "इनपुट स्रोत विकल्प"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "सीडी ऑडियो (_a)"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Use the _same source for all windows"
-msgstr "सभी विंडोज़ के लिए एक ही स्रोत का उपयोग करें  (_s)"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD वीडियो"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Allow _different sources for each window"
-msgstr "व्यक्तिगत विंडोज़ के लिए विभिन्न स्रोत की अनुमति दें (_d)"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "संगीत प्लेयर (_M)"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Keyboard Shortcuts"
-msgstr "कुंजीपट शॉर्टकट"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "सॉफ्टवेयर (_S)"
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Switch to previous source"
-msgstr "पिछले स्रोत पर जाएँ"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "अन्य मीडिया... (_O)"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "मीडिया प्रवेश पर कभी प्रांप्ट मत करें या प्रोग्राम आरंभ मत करें (_N)"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Switch to next source"
-msgstr "अगले स्रोत में जाएँ"
-
-#: ../panels/region/input-options.ui.h:9
-msgid "Super+Space"
-msgstr "Super+Space"
-
-#: ../panels/region/input-options.ui.h:10
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "आप कुंजीपटल सेटिंग्स में इन शॉर्टकट बदल सकते हैं"
-
-#: ../panels/region/input-options.ui.h:11
-msgid "Alternative switch to next source"
-msgstr "अगले स्रोत के लिए वैकल्पिक स्विच"
-
-#: ../panels/region/input-options.ui.h:12
-msgid "Left+Right Alt"
-msgstr "दायां + बायां आल्ट"
-
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "अंग्रेज़ी (यूनाइटेड किंगडम)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "यूनाइटेड किंगडम"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "चुनें कैसे अन्य मीडिया को नियंत्रित किया जाना चाहिए"
 
 # #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "विकल्प"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "क्रिया (_A):"
 
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "प्रकार: (_T)"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "हटाने योग्य मीडिया"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "ब्लूटूथ सेटिंग विन्यस्त करें"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"लॉगइन सेटिंग्स सभी उपयोगकर्ताओं द्वारा उपयोग किया जाता है जब सिस्टम में "
-"प्रवेश करते हैं"
+"युक्ति;सिस्टम;जानकारी;स्मृति;प्रोसेसर;संस्करण;डिफ़ॉल्ट;अनुप्रयोग;अनुशंसित;सीडी;डीवीडी;यूएसबी;"
+"ऑडियो;वीडियो;डिस्क;हटाने योग्य;मीडिया;स्वतः चालू;"
 
-#: ../panels/search/cc-search-locations-dialog.c:476
-#| msgid "Places"
-msgctxt "Search Location"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "स्क्रीन ताला"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "खाली स्क्रीन (_B)"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "स्वचालित स्क्रीन लॉक (_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "स्वचालित स्क्रीन लॉक (_L)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "लॉक स्क्रीन में विवरण दिखाएँ "
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "स्क्रीन पर ताला लगाएँ"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "गोपनीयता"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "स्क्रीन"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "ध्वनि विन्यास"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "खोजें स्थान"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
 msgid "Places"
 msgstr "स्थान"
 
-#: ../panels/search/cc-search-locations-dialog.c:478
-#| msgid "Bookmarks"
-msgctxt "Search Location"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
 msgid "Bookmarks"
 msgstr "पुस्तचिह्न"
 
-#: ../panels/search/cc-search-locations-dialog.c:480
-#| msgid "Other"
-msgctxt "Search Location"
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "अन्य"
 
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "स्थान चुनें"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "स्थान"
 
-#: ../panels/search/cc-search-locations-dialog.c:682
-#| msgid "GOK"
-msgid "_OK"
-msgstr "ठीक (_O)"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "अनुप्रयोग"
 
-#: ../panels/search/cc-search-panel.c:176
-msgid "No applications found"
-msgstr "कोई अनुप्रयोग नहीं मिला"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "ढूंढें"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "पते द्वारा खोजें (_S)"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "नियंत्रण के लिए जो आवेदन गतिविधियों के अवलोकन में खोज परिणाम बताते हैं"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "खोज;पता लगाएं;सूचकांक;छिपाएँ;गोपनीयता;परिणाम;"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr "खोजें स्थान"
-
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "ऊपर जाएँ"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "नीचे जाएँ"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "वरीयताएँ"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "चालू"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "बंद"
-
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
-#: ../panels/sharing/cc-sharing-panel.c:304
-#| msgid "Enabled"
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "सक्षम"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-#| msgid "Active Jobs"
-msgctxt "service is active"
-msgid "Active"
-msgstr "सक्रिय"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "कोई फ़ोल्डर चुनें "
-
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "नक़ल"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-msgid "Sharing"
-msgstr "साझेदारी"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr "नियंत्रण आप क्या दूसरों के साथ साझा करना चाहते हैं"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
-msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
-msgstr ""
-"शेयर; साझा करने; ssh; मेजबान; नाम; दूरस्थ; डेस्कटॉप; ब्लूटूथ;OBEX; मीडिया; "
-"ऑडिय; "
-"वीडियो;चित्र; फोटो; फिल्मों; सर्वर; रेंडरर;"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "दूरस्थ लॉगिन सक्षम या अक्षम करें."
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "उपयोक्ता दूरस्थ लॉगिन सक्षम या अक्षम करने के लिए सत्यापन आवश्यक है"
-
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:299
-msgid "No networks selected for sharing"
-msgstr "साझा करने के लिए कोई संजाल चयनित नहीं"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
-#| msgid "Network"
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "संजाल"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "ब्लूटूथ सेटिंग "
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "साझेदारी"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-"ब्लूटूथ शेयरिंग आप अन्य ब्लूटूथ सक्षम उपकरणों के साथ फ़ाइलें साझा करने की "
-"अनुमति देता है."
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "केवल विश्वसनीय उपकरण से प्राप्त करें"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "डाउनलोड फ़ोल्डर में प्राप्त फ़ाइलों को सहेजें"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "कम्प्यूटर नाम"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "निजी फ़ाइल साझा"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "स्क्रीन हिस्सा"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "रिमोट दृश्य"
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
 msgstr "मीडिया साझेदारी"
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "दूरस्थ लॉगिन"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "साझेदारी"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr " पासवर्ड की आवश्यकता होगी"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "दूरस्थ लॉगिन"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "कुछ सेवाओं को कोई नेटवर्क का उपयोग की वजह से अक्षम हैं."
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "रिमोट दृश्य"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
-"व्यक्तिगत फ़ाइल शेयरिंग आप दूसरों के साथ अपने वर्तमान नेटवर्क का उपयोग कर पर "
-"अपने "
-"सार्वजनिक फ़ोल्डर साझा करने के लिए अनुमति देता है: <a href=\"dav://%s\">"
-"dav://%s</a>"
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr " पासवर्ड की आवश्यकता होगी"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "दूरस्थ लॉगिन सक्षम या अक्षम करें."
 
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"दूरदराज के उपयोगकर्ताओं को सुरक्षित शैल कमांड का उपयोग कर कनेक्ट करने के लिए "
-"अनुमति दें.:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"दूरदराज के उपयोगकर्ताओं को देखने के लिए या को जोड़ने के द्वारा अपनी स्क्रीन "
-"पर नियंत्रण की "
-"अनुमति दें: <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:20
-#| msgid "Remote Control"
-msgid "Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "रिमोट दृश्य स्वीकारें"
 
-#: ../panels/sharing/sharing.ui.h:21
-#| msgid "Password"
-msgid "Password:"
-msgstr "कूटशब्द:"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "कूटशब्द दिखाएँ"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "कनेक्टेड नहीं है"
 
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/sharing/sharing.ui.h:23
-#| msgid "%s Options"
-msgid "Access Options"
-msgstr "पहुँच विकल्प"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "नया कनेक्शन पहुँच के लिए जरूर पूछें"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "नक़ल"
 
-#: ../panels/sharing/sharing.ui.h:25
-#| msgid "Require Password"
-msgid "Require a password"
-msgstr "कूटशब्द की आवश्यकता होगी"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "पता मिटाएँ"
 
-#: ../panels/sharing/sharing.ui.h:26
-#| msgid "Share Music, Photos and Videos with others on the current network."
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "सत्यापन (_t)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "उपयोक्तानाम"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "फिंगरप्रिंट दाखिला"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "मीडिया साझेदारी"
+
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "संगीत, तस्वीरें और वीडियो के संजाल पर साझा करें."
 
-#: ../panels/sharing/sharing.ui.h:27
-#| msgid "Add Folder"
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "फ़ोल्डर"
 
-# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
-# 48x48/emblems/emblem-sound.icon.in.h:1
-# 48x48/emblems/emblem-sound.icon.in.h:1
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "ध्वनि"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "नियंत्रण आप क्या दूसरों के साथ साझा करना चाहते हैं"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "ध्वनि के स्तर, निविष्टियाँ, outputs, और चेतावनी लगता बदलें"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"शेयर; साझा करने; ssh; मेजबान; नाम; दूरस्थ; डेस्कटॉप; ब्लूटूथ;OBEX; मीडिया; ऑडिय; "
+"वीडियो;चित्र; फोटो; फिल्मों; सर्वर; रेंडरर;"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "कार्ड;माइक्रोफोन; वॉल्यूम; फीका; बैलेंस; ब्लूटूथ; हेडसेट; ऑडियो;"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "दूरस्थ लॉगिन सक्षम या अक्षम करें."
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "बार्क"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "उपयोक्ता दूरस्थ लॉगिन सक्षम या अक्षम करने के लिए सत्यापन आवश्यक है"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "ड्रिप"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "फ्लिकर"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "ग्लास"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "साझेदारी"
 
-# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
-# 48x48/emblems/emblem-sound.icon.in.h:1
-# 48x48/emblems/emblem-sound.icon.in.h:1
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "सोनार"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "बायाँ"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "दायाँ"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "संतुलन: (_B)"
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "धुंधला: (_F)"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "पिछला"
 
@@ -5493,758 +3813,1039 @@ msgstr "पिछला"
 # libgnomecanvas/gnome-canvas-text.c:238
 # #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
 # libgnomeui/gnome-font-picker.c:184 libgnomeui/gnome-font-picker.c:979
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "अग्र भाग"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "न्यूनतम"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "अधिकतम"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "संतुलन: (_B)"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "धुंधला: (_F)"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "उप वूफ़र: (_S)"
-
-#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:616
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "बिना संवर्द्धित"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
-# test-gnome/testgnome.xml.h:5
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "प्रोफाइल: (_P)"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u आउटपुट"
-msgstr[1] "%u आउटपुट"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u इनपुट"
-msgstr[1] "%u इनपुट"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "सिस्टम ध्वनि"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "टेस्ट स्पीकर्स (_T)"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "आवाज़ निर्धारक: (_A)"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "पीक जाँच"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "आवाज मौन"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1509
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "नाम"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1528
-msgid "Device"
-msgstr "युक्ति"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1591
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "स्पीकर टेस्टिंग %s के लिए"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1649
-msgid "_Output volume:"
-msgstr "आउटपुट आवाज: (_O)"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1663
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "आउटपुट"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1668
-msgid "C_hoose a device for sound output:"
-msgstr "ध्वनि आउटपुट के लिए कोई युक्ति चुनें: (_h)"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "आउटपुट आवाज: (_O)"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1693
-msgid "Settings for the selected device:"
-msgstr "चयनित युक्ति के लिए सेटिंग:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "Input"
-msgstr "इनपुट"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "_Input volume:"
-msgstr "इनपुट आवाज: (_I)"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1734
-msgid "Input level:"
-msgstr "इनपुट स्तर:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1762
-msgid "C_hoose a device for sound input:"
-msgstr "ध्वनि इनपुट के लिए कोई युक्ति चुनें: (_h)"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "Sound Effects"
-msgstr "ध्वनि प्रभाव"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-msgid "_Alert volume:"
-msgstr "आवाज़ निर्धारक: (_A)"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1809
-msgid "Applications"
-msgstr "अनुप्रयोग"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1813
-msgid "No application is currently playing or recording audio."
-msgstr "कोई अनुप्रयोग अभी ध्वनि बजा या रिकार्ड नहीं कर रहा है."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "अंतर्निर्मित"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "ध्वनि वरीयता"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "घटना ध्वनि जाँच रहा है"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "तयशुदा"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "प्रसंग से"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:769
-msgid "C_hoose an alert sound:"
-msgstr "कोई चेतावनी ध्वनि चुनें: (_h)"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "रूकें"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "जांच"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "विन्यास यूआरएल (_C)"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
-# libgnomeprint/gpa/gpa-media.c:241
-# #-#-#-#-#  libgnomeprint.gnome-2-2.hi.po (libgnomeprint VERSION)  #-#-#-#-#
-# libgnomeprint/gpa/gpa-media.c:241
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "पसंदीदा"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "इनपुट"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "इसे देखना, सुनना, प्रकार, बिंदु और क्लिक करें आसान बनाओ"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "इनपुट स्तर:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;"
-#| "size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "आवाज बढ़ाएँ"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "आवाज़ निर्धारक: (_A)"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "मौन"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ध्वनि"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ध्वनि के स्तर, निविष्टियाँ, outputs, और चेतावनी लगता बदलें"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "कार्ड;माइक्रोफोन; वॉल्यूम; फीका; बैलेंस; ब्लूटूथ; हेडसेट; ऑडियो;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "सूचनाएँ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "नाम: (_N)"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"कुंजीपटल;माउस;a11y;एक्सेसिबिलिटी;कंट्रास्ट;ज़ूम;स्क्रीन;रीडर;पाठ;फ़ॉन्ट;आकार;ए"
-"क्सेसX;स्टिकी;कुंजी;धीमी;बाउंस;माउस;"
 
-#: ../panels/universal-access/uap.ui.h:1
-#| msgid "Universal Access"
-msgid "_Always Show Universal Access Menu"
-msgstr "सार्वभौमिक पहुँच मेन्यू हमेशा दिखाएँ (_A)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "देख कर रहा है"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "स्वचालित कनेक्ट करें (_C)"
 
-#: ../panels/universal-access/uap.ui.h:3
-#| msgid "High Contrast"
-msgid "_High Contrast"
-msgstr "अधिक विरोध (_H)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "युक्ति हटायें"
 
-#: ../panels/universal-access/uap.ui.h:4
-#| msgid "Large Text"
-msgid "_Large Text"
-msgstr "बड़ा पाठ (_L)"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:5
-#| msgid "Zoom"
-msgid "_Zoom"
-msgstr "छोटा-बड़ा करें (_Z)"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s डोमेन से कनेक्ट नहीं कर सका: %s"
 
-#: ../panels/universal-access/uap.ui.h:7
-#| msgid "Screen Reader"
-msgid "Screen _Reader"
-msgstr "स्क्रीन वाचक (_R)"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "सार्वभौमिक पहुँच"
 
-#: ../panels/universal-access/uap.ui.h:8
-#| msgid "Bounce Keys"
-msgid "_Sound Keys"
-msgstr "ध्वनि कुँजी (_S)"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "सुनवाई"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "युक्ति जोड़ें"
 
-#: ../panels/universal-access/uap.ui.h:10
-#| msgid "Visual Alerts"
-msgid "_Visual Alerts"
-msgstr "दृष्टि चेतावनी (_V)"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:12
-#| msgid "Screen keyboard"
-msgid "Screen _Keyboard"
-msgstr "स्क्रीन कुंजीपटल (_K)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:13
-#| msgid "Typing Assistant"
-msgid "_Typing Assist (AccessX)"
-msgstr "टाइपिंग सहायक (_T) (AccessX)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:14
-#| msgid "Pointing and Clicking"
-msgid "Pointing & Clicking"
-msgstr "इंगित और क्लिक"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:15
-#| msgid "Mouse Keys"
-msgid "_Mouse Keys"
-msgstr "माउस कुंजियाँ (_M)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "संकेतक टिमटिमाना"
 
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "क्लिक मददगार (_C)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "पाठ बक्सा में संकेतक टिमटिमाएँ (_b)"
 
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "स्क्रीन वाचक"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "गति"
 
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "स्क्रीन रीडर प्रदर्शित पाठ पढ़ता है जैसे ही आप फोकस पर बढते हैं."
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "कर्सर ब्लिंक गति"
 
-#: ../panels/universal-access/uap.ui.h:19
-#| msgid "Screen Reader"
-msgid "_Screen Reader"
-msgstr "स्क्रीन वाचक (_S)"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "कर्सर ब्लिंक गति"
 
-#: ../panels/universal-access/uap.ui.h:20
-#| msgid "Bounce Keys"
-msgid "Sound Keys"
-msgstr "ध्वनि कुंजियाँ"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "जब Num Lock या Caps Lock चालू है तो बीप करें."
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "दृष्टि चेतावनी"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "जाँच फ्लैश (_T)"
-
-#: ../panels/universal-access/uap.ui.h:24
-#| msgid "Use a visual indication when an alert sound occurs"
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "दृश्य संकेत का प्रयोग करें जब एक चेतावनी ध्वनि होती है."
-
-#: ../panels/universal-access/uap.ui.h:25
-#| msgid "Flash the window title"
-msgid "Flash the _window title"
-msgstr "विंडो शीर्षक को चमकाएँ (_w)"
-
-#: ../panels/universal-access/uap.ui.h:26
-#| msgid "Flash the entire screen"
-msgid "Flash the entire _screen"
-msgstr "पूरा स्क्रीन चमकाएँ (_s)"
-
-#: ../panels/universal-access/uap.ui.h:27
-#| msgid "Typing Assistant"
-msgid "Typing Assist"
-msgstr "टाइपिंग सहायक"
-
-#: ../panels/universal-access/uap.ui.h:28
-#| msgid "Sticky Keys"
-msgid "_Sticky Keys"
-msgstr "स्टिकी कुंजी (_S)"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "कुंजी संयोजन के रूप में आपरिवर्तक कुंजी का एक अनुक्रम को मानना"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "निष्क्रिय करें यदि दो कुंजी एक साथ दबाया जाए (_D)"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifer key is pressed"
-msgstr "जब परिवर्धक कुंजी दबाएँ तो बीप बजाएँ (_m)"
-
-#: ../panels/universal-access/uap.ui.h:32
-#| msgid "Slow Keys"
-msgid "S_low Keys"
-msgstr "धीमी कुंजी (_l)"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "जब कुंजी दबा जाता है और जब इसे स्वीकार किया जाता है के बीच देरी रखें"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "स्वीकृति में देरी: (_c)"
-
-#: ../panels/universal-access/uap.ui.h:35
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "छोटा"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "धीमी कुंजी टाइपिंग विलंब"
-
-#: ../panels/universal-access/uap.ui.h:37
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "लंबा"
-
-#: ../panels/universal-access/uap.ui.h:38
-#| msgid "Beep when a _modifer key is pressed"
-msgid "Beep when a key is pr_essed"
-msgstr "जब कुंजी दबाएँ तो बीप बजाएँ (_e)"
-
-#: ../panels/universal-access/uap.ui.h:39
-#| msgid "Beep when a key is _rejected"
-msgid "Beep when a key is _accepted"
-msgstr "जब कुंजी अस्वीकृत हो तो बीप बजाएँ  (_r)"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "जब कुंजी अस्वीकृत हो तो बीप बजाएँ  (_r)"
-
-#: ../panels/universal-access/uap.ui.h:41
-#| msgid "Bounce Keys"
-msgid "_Bounce Keys"
-msgstr "उछलती कुंजियाँ (_B)"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "तेज नक़ल कीप्रेस अनदेखा करें"
-
-#: ../panels/universal-access/uap.ui.h:43
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "छोटा"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "उछलती कुंजी टाइपिंग विलंब"
-
-#: ../panels/universal-access/uap.ui.h:45
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "लंबा"
-
-#: ../panels/universal-access/uap.ui.h:46
-#| msgid "Enable by Keyboard"
-msgid "_Enable by Keyboard"
-msgstr "कुंजीपट से सक्षम करें (_E)"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "कुंजीपटल के उपयोग पर पहुंच सुविधाओं को चालू करें"
-
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "क्लिक मदद"
 
-#: ../panels/universal-access/uap.ui.h:49
-#| msgid "Simulated Secondary Click"
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "सिमुलेटेड द्वितीयक क्लिक (_S)"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "प्राथमिक बटन पकड़ने के दौरान द्वितीयक कुंजी ट्रिगर करें"
 
-#: ../panels/universal-access/uap.ui.h:51
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "स्वीकृति में देरी: (_c)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "छोटा"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "माध्यमिक क्लिक विलंब"
 
-#: ../panels/universal-access/uap.ui.h:53
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "लंबा"
 
-#: ../panels/universal-access/uap.ui.h:54
-#| msgid "Hover Click"
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "होवर क्लिक (_H)"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "प्वाइंटर गति रोकने के दौरान क्लिक आरंभ करें"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "देरी: (_e)"
 
-#: ../panels/universal-access/uap.ui.h:57
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "छोटा"
 
-#: ../panels/universal-access/uap.ui.h:58
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "लंबा"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "गति देहलीज़: (_t)"
 
-#: ../panels/universal-access/uap.ui.h:60
-#| msgctxt "universal access, text size"
-#| msgid "Small"
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "छोटा"
 
-#: ../panels/universal-access/uap.ui.h:61
-#| msgctxt "universal access, text size"
-#| msgid "Large"
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "बड़ा"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "दुहराव कुंजी"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "जब कुंजी दबा कर रखा जाए तो कुंजी दोहराना (_r)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "दुहराने वाली कुंजी गति"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "दुहराने वाली कुंजी गति"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "टाइपिंग सहायक"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "स्टिकी कुंजी (_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "कुंजी संयोजन के रूप में आपरिवर्तक कुंजी का एक अनुक्रम को मानना"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "निष्क्रिय करें यदि दो कुंजी एक साथ दबाया जाए (_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "जब परिवर्धक कुंजी दबाएँ तो बीप बजाएँ (_m)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "धीमी कुंजी (_l)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "जब कुंजी दबा जाता है और जब इसे स्वीकार किया जाता है के बीच देरी रखें"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "छोटा"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ स्क्रीन"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "धीमी कुंजी टाइपिंग विलंब"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ स्क्रीन"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ स्क्रीन"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "लंबा"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "जब कुंजी दबाएँ तो बीप बजाएँ (_e)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "जब कुंजी अस्वीकृत हो तो बीप बजाएँ  (_r)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "जब कुंजी अस्वीकृत हो तो बीप बजाएँ  (_r)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "उछलती कुंजियाँ (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "तेज नक़ल कीप्रेस अनदेखा करें"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "छोटा"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "उछलती कुंजी टाइपिंग विलंब"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "लंबा"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "कुंजीपट से सक्षम करें (_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "कुंजीपटल के उपयोग पर पहुंच सुविधाओं को चालू करें"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "सार्वभौमिक पहुँच मेन्यू हमेशा दिखाएँ (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "देख कर रहा है"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "अधिक विरोध (_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "बड़ा पाठ (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "स्क्रीन वाचक (_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "स्क्रीन रीडर प्रदर्शित पाठ पढ़ता है जैसे ही आप फोकस पर बढते हैं."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "ध्वनि कुँजी (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "जब Num Lock या Caps Lock चालू है तो बीप करें."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "कर्सर ब्लिंक गति"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "छोटा-बड़ा करें (_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "सुनवाई"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "दृष्टि चेतावनी (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "स्क्रीन कुंजीपटल (_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "दुहराव कुंजी"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "संकेतक टिमटिमाना"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "टाइपिंग सहायक (_T) (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "इंगित और क्लिक"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "माउस कुंजियाँ (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "प्रिंटर हटायें"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "क्लिक मददगार (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "दोहरा क्लिक करें (_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "दोहरा क्लिक टाइमआउट"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "दृष्टि चेतावनी"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "जाँच फ्लैश (_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "दृश्य संकेत का प्रयोग करें जब एक चेतावनी ध्वनि होती है."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "पूरा स्क्रीन चमकाएँ (_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "पूरा स्क्रीन चमकाएँ (_s)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "पूर्ण स्क्रीन"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "ऊपरी आधा"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "नीचला आधा"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "बायाँ आधा"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "दायाँ आधा"
 
 # #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "ज़ूम विकल्प"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "ज़ूम"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "आवर्धन:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "माउस संकेतक का अनुसरण करें"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "स्क्रीन हिस्सा:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "आवर्धक स्क्रीन के बाहर विस्तार करता है"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "आवर्धक कर्सर केन्द्रित रखें"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "आवर्धक कर्सर के आसपास विषयवस्तु को पुश करें"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "विषयवस्तु के साथ आवर्धक कर्सर चलता है"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "आवर्धक स्थिति:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "माउस संकेतक का अनुसरण करें"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "स्क्रीन हिस्सा:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "आवर्धक स्क्रीन के बाहर विस्तार करता है"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "आवर्धक कर्सर केन्द्रित रखें"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "आवर्धक कर्सर के आसपास विषयवस्तु को पुश करें"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "विषयवस्तु के साथ आवर्धक कर्सर चलता है"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "आवर्धक:"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "क्रासहेयर्स:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "ओवरलैप माउस संकेतक"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "मोटाईः"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "पतला"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "मोटा "
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "लंबाईः "
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "रंगः"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "क्रासहेयर्स:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "ओवरलैप माउस संकेतक"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "क्रासहेयर्स:"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "रंग प्रभाव:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "काले पर सफेद:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "चमकीलापन:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "विरोधी:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "रंग "
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "कुछ नहीं "
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr " पूरा"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "निम्न "
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr " उच्च"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "कम"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "उच्च"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "रंग प्रभाव:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "रंग प्रभाव"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "मानक"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "इसे देखना, सुनना, प्रकार, बिंदु और क्लिक करें आसान बनाओ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "प्रशासक"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-#| msgid "_Full name"
-msgid "_Full Name"
-msgstr "पूरा नाम (_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "खाता प्रकार (_T)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-#| msgid "Choose password at next login"
-msgid "Allow user to set a password when they next login"
-msgstr "अगले लॉगिन में कूटशब्द सेट करने के लिए उपयोक्ता को छूट दें"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "अभी कूटशब्द निर्धारित करें"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "जाँचें (_V)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"एंटरप्राइज लॉगिन मौजूदा केंद्रीय रूप से प्रबंधित उपयोक्ता खाता की अनुमति देता "
-"है जिसे इस युक्ति पर प्रयोग किया जा सके."
+"कुंजीपटल;माउस;a11y;एक्सेसिबिलिटी;कंट्रास्ट;ज़ूम;स्क्रीन;रीडर;पाठ;फ़ॉन्ट;आकार;एक्सेसX;स्टिकी;"
+"कुंजी;धीमी;बाउंस;माउस;"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "डोमेन (_D)"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "इतिहास"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"ऑनलाइन हों\n"
-"ताकि एंटरप्राइज लॉगिन खाता बनाएँ."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "एंटरप्राइज लॉगिन (_F)"
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "इतिहास"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "हालिया इतिहास साफ करें (_e)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "ट्रैश & अस्थाई फ़ाइलें मिटाएँ"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "स्वचालित रूप से रद्दी खाली करें (_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "स्वचालित रूप से अस्थाई फ़ाइलें मिटाएँ (_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "स्वचालित रूप से रद्दी खाली करें (_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "रद्दी खाली करें (_E)"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "अस्थाई फ़ाइलें मिटाएँ (_P)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "उपयोक्ता जोड़ें"
 
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "प्रशासक"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "अगले लॉगिन में कूटशब्द सेट करने के लिए उपयोक्ता को छूट दें"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "अभी कूटशब्द निर्धारित करें"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "विन्यस्त कर रहा है"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "एंटरप्राइज लॉगिन (_F)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "ऑफ़लाइन"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"एंटरप्राइज लॉगिन मौजूदा केंद्रीय रूप से प्रबंधित उपयोक्ता खाता की अनुमति देता है जिसे इस "
+"युक्ति पर प्रयोग किया जा सके."
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "एक PPD फाइल चुनें"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "फिंगरप्रिंट लॉगिन (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "फिंगरप्रिंट लॉगिन (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "नहीं"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"क्या आफ अपना पंजीकृत फिंगरप्रिंट को मिटाना चाहते हैं ताकि फिंगरप्रिंट लॉगिन निष्क्रिय हो "
+"जाए?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "कोई मुद्रक नहीं खोज सका."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "फिंगरप्रिंट लॉगिन (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "फिंगरप्रिंट लॉगिन (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "विन्यस्त करने के लिए कोई युक्ति चुनें: (_h)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "फिंगरप्रिंट लॉगिन (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "फिंगरप्रिंट मिटाएँ (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "फिंगरप्रिंट लॉगिन (_F)"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "पिछला सप्ताह "
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "अगले सप्ताह"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "कूटशब्द बदलें"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "बदलें (_a)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "मौजूदा कूटशब्द (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "नया कूटशब्द (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "कूटशब्द की पुष्टि करें (_o)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "कूटशब्द मेल नहीं खाता है."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "अगले लॉगिन में कूटशब्द सेट करने के लिए उपयोक्ता को छूट दें"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "अभी कूटशब्द निर्धारित करें"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "उपयोक्तानाम "
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "परिवर्तनों को प्रभावी करने के लिए अपने सत्र के लिए आरंभ किया जाना है"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "अब फिर आरंभ करें"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "बंद करें"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "पूरा नाम (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "फिंगरप्रिंट लॉगिन (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "स्वचालित लॉगिन (_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "खाता प्रकार (_t)"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "प्रशासक"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#  set the timeout value  label with correct value of timeout
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "उपयोगकर्ता खाता हटायें"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "दूसरी अंगुली: (_O)"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "उपयोक्ता जोड़ें"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "कोई  तस्वीर नहीं मिला"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "उपयोगकर्ता खाता बनाएँ"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "उपयोगकर्ताओं को जोड़ें या हटाने और अपना पासवर्ड बदलें"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "नामांकन (_E)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "डोमेन प्रशासक लॉगिन"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6254,1178 +4855,3454 @@ msgstr ""
 "इस डोमेन में नामांकित होने की जरूरत है. कृपया अपने संजाल प्रशासक को\n"
 "अपने डोमेन कूटशब्द को यहाँ टाइप करने दें."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "प्रशासक नाम (_N)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "प्रशासक कूटशब्द"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "बायां थंब"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "बाईं मध्य अंगुली"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "बाईं अनामिका"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "बाईं तर्जनी"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "दाहिना अंगूठा"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "दाहिनी मध्य अंगुली"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "दाहिनी तर्जनी"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "दाहिनी तर्जनी"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:687
-msgid "Enable Fingerprint Login"
-msgstr "फिंगरप्रिंट लॉगिन सक्रिय करें"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "दायां तर्जनी (_R)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "बाईं तर्जनी (_L)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "दूसरी अंगुली: (_O)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"आपका फिंगरप्रिंट सफलतापूर्वक सहेजा गया था. आपको अब अपने फिंगरप्रिंट रीडर के "
-"प्रयोग से "
-"लॉगिन में समर्थ होना चाहिए."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "उपयोक्तानाम "
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr "उपयोगकर्ताओं को जोड़ें या हटाने और अपना पासवर्ड बदलें"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "लॉगिन इतिहास"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-#| msgid "Changing password for"
-msgid "Change Password"
-msgstr "कूटशब्द बदलें"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "बदलें (_a)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-#| msgid "_New password"
-msgid "_Verify New Password"
-msgstr "नया कूटशब्द जाँचें (_V)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-#| msgid "_New password"
-msgid "_New Password"
-msgstr "नया कूटशब्द (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-#| msgid "Current _password"
-msgid "Current _Password"
-msgstr "मौजूदा कूटशब्द (_P)"
-
-#  set the timeout value  label with correct value of timeout
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "उपयोगकर्ता खाता जोड़ें"
-
-#  set the timeout value  label with correct value of timeout
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "उपयोगकर्ता खाता हटायें"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "लॉगिन विकल्प"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "स्वचालित लॉगिन (_u)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "फिंगरप्रिंट लॉगिन (_F)"
-
-#  set the timeout value  label with correct value of timeout
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "उपयोक्ता प्रतीक"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "भाषा (_L)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "अंतिम लॉगिन"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "उपयोक्ता खातों का प्रबंधन करें"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "उपयोक्ता आँकड़ा बदलने के लिए सत्यापन आवश्यक है"
 
-#: ../panels/user-accounts/pw-utils.c:81
-#| msgid "The new password does not contain enough different characters"
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "नया कूटशब्द पुराने से काफी अलग होना चाहिए."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "कुछ अक्षर और संख्या बदलने की कोशिश करें."
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-#| msgid "Changing password for"
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "कूटशब्द कुछ बदलने की कोशिश करें."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "बिना आपके कूटशब्द के उपयोक्तानाम मजबूत होगा."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "कूटशब्द में अपना नाम मत डालें."
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "कूटशब्द में कोई शब्द डालने से बचें."
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "सामान्य शब्द से बचें."
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "किसी मौजूदा शब्द के बिखरी वर्तनी का उपयोग मत करें."
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "अधिक संख्या डालने की कोशिश करें."
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "अधिक बड़े अक्षर डालने की कोशिश करें."
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "अधिक छोटे अक्षर डालने की कोशिश करें."
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "अधिक विशेष वर्ण डालने की कोशिश करें, जैसे कि चिह्न विचार."
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "अक्षर, संख्या और चिह्नों के उपयोग की कोशिश करें."
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "वही वर्ण को दुहराने से बचें."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"समान प्रकार वर्ण को दुहराने से बचें: आपको अक्षर, संख्या और चिह्नों का मेल "
-"तैयार करना है."
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 या abcd जैसे शृंखला से बचें."
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "अधिक अक्षर, संख्या और संकेत जोड़ें."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr "बड़े और छोटे अक्षर और एकाधिक संख्या डालें."
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr "बढ़िया कूटशब्द! अधिक अक्षर, संख्या और चिह्न इसे मजबूत बनाएगा."
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "सामर्थ्य: कमजोर"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-#| msgid "Length:"
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "सामर्थ्य: कम"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "सामर्थ्य: मध्यम"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "सामर्थ्य: अच्छा"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "सामर्थ्य: उच्च"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "सत्यापन असफल"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "नया कूटशब्द काफी छोटा है"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "नया कूटशब्द काफी आसान है"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "नया पुराना व नया कूटशब्द काफी समान है"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "नया दो कूटशब्द समान नहीं है."
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "नया कूटशब्द को जरूर संख्या या विशेष संप्रतीक शामिल रखना चाहिये."
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "पुराना व नया कूटशब्द समान है"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "आपका कूटशब्द बदला गया है जबसे आपने आरंभ में सत्यापित किया."
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "नया कूटशब्द काफी अलग अलग अक्षरों को शामिल नहीं करता है"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "अज्ञात त्रुटि"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "आपके खाता प्रदाता के वेब पता से मेल खाना चाहिए."
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "खाता जोड़ने में विफल"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-#| msgid "Passwords do not match"
-msgid "Passwords do not match."
-msgstr "कूटशब्द मेल नहीं खाता है."
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr "खाता पंजीयन में विफल"
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr "इस डोमेन के साथ प्रमाणित करने के लिए कोई समर्थित तरीका नहीं"
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr "डोमेन में शामिल होने में विफल"
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"वह लॉगिन नाम काम नहीं करता है.\n"
-"कृपया फिर कोशिश करें."
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-#| msgid "Invalid password, please try again"
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"लॉगिन कूटशब्द काम नहीं करता है.\n"
-"कृपया फिर कोशिश करें."
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr "डोमेन में लॉगिन में विफल"
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "डोमेन ढूँढ़ने में असमर्थ. शायद आपने गलत वर्तनी दे दिया हो?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:138
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"आपको युक्ति के अभिगम की अनुमति नहीं है. अपने तंत्र प्रशासक से संपर्क करें."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:140
-msgid "The device is already in use."
-msgstr "यह युक्ति पहले से प्रयोग में है."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid "An internal error occurred."
-msgstr "आंतरिक त्रुटि आयी."
-
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
-# gtk/gtkinputdialog.c:238
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Enabled"
-msgstr "सक्षम"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr "पंजीकृत फिंगरप्रिंट मिटाएँ?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
-msgstr "फिंगरप्रिंट मिटाएँ (_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"क्या आफ अपना पंजीकृत फिंगरप्रिंट को मिटाना चाहते हैं ताकि फिंगरप्रिंट लॉगिन "
-"निष्क्रिय हो "
-"जाए?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:444
-msgid "Done!"
-msgstr "संपन्न!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:505
-#: ../panels/user-accounts/um-fingerprint-dialog.c:547
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' युक्ति की पहुँच नहीं ले सका"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:588
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "'%s' युक्ति पर फिंगर पकड़ नहीं आरंभ कर सका"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:638
-msgid "Could not access any fingerprint readers"
-msgstr "कोई फिंगरप्रिंट रीडर की पहुँच नहीं ले सका"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:639
-msgid "Please contact your system administrator for help."
-msgstr "मदद के लिए तंत्र प्रशासक से संपर्क करें."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:721
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"फिंगरप्रिंट लॉगिन के लिए समर्थ करने में, आप अपने एक फिंगरप्रिंट को सहेजने की "
-"जरूरत है, '%s' "
-"युक्ति के प्रयोग से."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:728
-msgid "Selecting finger"
-msgstr "उंगली का चयन"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:729
-msgid "Enrolling fingerprints"
-msgstr "फिंगरप्रिंट दाखिला"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "इस हफते"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "पिछले सप्ताह"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:631
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:635
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "सत्र समाप्त"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "सत्र आरंभ"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "कृपया अन्य कूटशब्द का चयन करें."
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "अपना मौजूदा कूटशब्द फिर टाइप करें."
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "आपका कूटशब्द बदला गया है"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-#| msgid "The passwords do not match"
-msgid "The passwords do not match."
-msgstr "कूटशब्द मेल नहीं खाता है."
-
-#: ../panels/user-accounts/um-photo-dialog.c:219
-msgid "Browse for more pictures"
-msgstr "अधिक छवियाँ के लिए ब्राउज़ करें"
-
-# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
-# gtk/gtkinputdialog.c:238
-#: ../panels/user-accounts/um-photo-dialog.c:453
-msgid "Disable image"
-msgstr "छिव अक्षम करें"
-
-#: ../panels/user-accounts/um-photo-dialog.c:471
-msgid "Take a photo…"
-msgstr "एक तस्वीर लें... "
-
-#: ../panels/user-accounts/um-photo-dialog.c:489
-msgid "Browse for more pictures…"
-msgstr "अधिक छवियाँ के लिए ब्राउज़ करें…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:713
-#, c-format
-msgid "Used by %s"
-msgstr "%s के द्वारा प्रयुक्त"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "डोमेन के इस प्रकार के स्वचालित रूप से शामिल नहीं हो सकते"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "कोई ऐसा डोमेन या रियल्म नहीं मिला"
-
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "बतौर %s %s डोमेन पर लॉगिन नहीं कर सकता है"
-
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
-msgstr "अवैध कूटशब्द, कृपया फिर कोशिश करें"
-
-#: ../panels/user-accounts/um-realm-manager.c:832
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "%s डोमेन से कनेक्ट नहीं कर सका: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:198
-msgid "Other Accounts"
-msgstr "अन्य खाता"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "Failed to delete user"
-msgstr "उपयोक्ता मिटाने में विफल"
-
-#: ../panels/user-accounts/um-user-panel.c:482
-msgid "You cannot delete your own account."
-msgstr "आप अपने खुद के खाते को नष्ट नहीं कर सकते हैं."
-
-#: ../panels/user-accounts/um-user-panel.c:491
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s अभी भी लॉग इन है"
-
-#: ../panels/user-accounts/um-user-panel.c:495
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"उपयोगकर्ता का विलोपन जब वे लॉग इन कर रहे हो से तंत्र को छोड़ सकते हैं असंगत "
-"स्थिति में."
-
-#: ../panels/user-accounts/um-user-panel.c:504
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "क्या आप %s के फाइल को रखना चाहते है?"
-
-#: ../panels/user-accounts/um-user-panel.c:508
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"उपयोगकर्ता खाते को हटाने के समय घर निर्देशिका, मेल स्पूल और अस्थायी फ़ाइलों "
-"को रखने की "
-"संभावना है."
-
-#: ../panels/user-accounts/um-user-panel.c:511
-msgid "_Delete Files"
-msgstr "फ़ाइल मिटाएँ (_D)"
-
-# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
-# test-gnome/testgnome.xml.h:5
-#: ../panels/user-accounts/um-user-panel.c:512
-msgid "_Keep Files"
-msgstr "फ़ाइल रखें (_F)"
-
-#: ../panels/user-accounts/um-user-panel.c:564
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "खाता अक्षम"
-
-#: ../panels/user-accounts/um-user-panel.c:572
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "अगले लॉगिन में इसे सेट करें"
-
-#: ../panels/user-accounts/um-user-panel.c:575
-msgctxt "Password mode"
-msgid "None"
-msgstr "कुछ नहीं"
-
-#: ../panels/user-accounts/um-user-panel.c:624
-msgid "Logged in"
-msgstr "लाग्ड इन"
-
-#: ../panels/user-accounts/um-user-panel.c:1071
-msgid "Failed to contact the accounts service"
-msgstr "खातों सेवा से संपर्क करने में विफल"
-
-#: ../panels/user-accounts/um-user-panel.c:1073
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "कृपया सुनिश्चित करें कि खाता सेवा स्थापित और सक्षम है."
-
-#: ../panels/user-accounts/um-user-panel.c:1114
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"बदलाब लाने के लिए,\n"
-"क्लिक करें * चिह्न पर पहले"
-
-#: ../panels/user-accounts/um-user-panel.c:1152
-msgid "Create a user account"
-msgstr "उपयोगकर्ता खाता बनाएँ"
-
-#: ../panels/user-accounts/um-user-panel.c:1163
-#: ../panels/user-accounts/um-user-panel.c:1475
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"उपयोगकर्ता खाता बनाने के लिए,\n"
-"क्लिक करें * चिह्न पर पहले"
-
-#: ../panels/user-accounts/um-user-panel.c:1173
-msgid "Delete the selected user account"
-msgstr "चयनित उपयोगकर्ता खाता को हटायें"
-
-#: ../panels/user-accounts/um-user-panel.c:1185
-#: ../panels/user-accounts/um-user-panel.c:1480
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"चयनित उपयोगकर्ता खाता को हटाने के लिए,\n"
-"क्लिक करें * चिह्न पर पहले"
-
-#: ../panels/user-accounts/um-user-panel.c:1389
-msgid "My Account"
-msgstr "मेरा खाता"
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-#| msgid "A user with the username '%s' already exists"
-msgid "A user with the username '%s' already exists."
-msgstr "उपयोक्तानाम '%s' के साथ उपयोगकर्ता पहले से मौजूद है."
-
-#: ../panels/user-accounts/um-utils.c:571
-#, c-format
-#| msgid "The username is too long"
-msgid "The username is too long."
-msgstr "उपयोक्तानाम काफी लंबा है."
-
-#: ../panels/user-accounts/um-utils.c:574
-#| msgid "The username cannot start with a '-'"
-msgid "The username cannot start with a '-'."
-msgstr "उपयोक्तानाम '-' के साथ आरंभ नहीं कर सका."
-
-#: ../panels/user-accounts/um-utils.c:577
-#| msgid ""
-#| "The username must only consist of:\n"
-#| " ➣ letters from the English alphabet\n"
-#| " ➣ digits\n"
-#| " ➣ any of the characters '.', '-' and '_'"
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"उपयोक्तानाम  केवल a-z अक्षर, अंकों और '.', '-' और '_' में से किसी वर्ण से "
-"मिलकर होना चाहिए."
-
-#: ../panels/user-accounts/um-utils.c:581
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-"यह करने के लिए अपने घर फ़ोल्डर नाम का इस्तेमाल किया जाएगा और बदला नहीं जा "
-"सकता."
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:831
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "नक्शे बटन"
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "कार्य करने के लिए नक्शे बटन"
 
-#: ../panels/wacom/button-mapping.ui.h:4
-#| msgid ""
-#| "To edit a shortcut, click the row and hold down the new keys or press "
-#| "Backspace to clear."
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"शॉर्टकट संपादित करने के लिए, \"Send Keystroke\"  क्रिया चुनें, कुंजीपट "
-"शॉर्टकल बटन दबाएँ और नई कुंजी नीचे पकड़े या स्पष्ट करने के लिए बैकस्पेस प्रेस "
-"करें."
+"शॉर्टकट संपादित करने के लिए, \"Send Keystroke\"  क्रिया चुनें, कुंजीपट शॉर्टकल बटन दबाएँ "
+"और नई कुंजी नीचे पकड़े या स्पष्ट करने के लिए बैकस्पेस प्रेस करें."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "बंद करें (_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
-"कृपया लक्ष्य मार्करों को टैप करें जो टैबलेट को कैलिब्रेट करते समय स्क्रीन पर "
-"दिखाई देते हैं."
+"कृपया लक्ष्य मार्करों को टैप करें जो टैबलेट को कैलिब्रेट करते समय स्क्रीन पर दिखाई देते हैं."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "गलत-क्लिक का पता चला, पुनरारंभ कर रहा है ..."
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "ऊपर"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "वर्चुअल मशीन बनाएँ"
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "नीचे"
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "टेबलेट"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "कुछ नहीं"
-
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "कीस्ट्रोक भेजें"
-
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "मॉनिटर बदलें"
-
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "स्क्रीन पर मदद दिखाएं"
-
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "आउटपुट:"
-
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "पहलू अनुपात बनाए रखें (लेटरबॉक्स):"
-
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "एकल मॉनिटर से मानचित्रित करें"
-
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d का %d"
-
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "मानचित्रण प्रदर्शित करें"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
-msgstr "बटन"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Wacom Tablet"
-msgstr "Wacom टेब्लेट"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
-"बटन मैपिंग सेट और ग्राफिक्स गोलियाँ के लिए स्टाइलस संवेदनशीलता को समायोजित"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "टैब्लेट;Wacom;लेखनी;इरेज़र;माउस;"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "बाएँ-हाथ ओरिएंटेशन"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "टैब्लेट (निरपेक्ष)"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "टचपैड (सापेक्षिक)"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "मॉनिटर से मानचित्रित करें..."
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "टैबलेट वरीयताएँ"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "पहलू अनुपात"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "कैलिब्रेट…"
+
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "कोई टैबलेट पता नहीं लगा है"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "कृपया अपने Wacom टैबलेट को चालू या प्लगिन करें"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Bluetooth Settings"
-msgstr "ब्लूटूथ सेटिंग"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map to Monitor…"
-msgstr "मॉनिटर से मानचित्रित करें..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map Buttons…"
-msgstr "नक्शे बटन…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust display resolution"
-msgstr "रिसॉल्यूशन प्रदर्शन समायोजित करें"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-#| msgid "Mouse Settings"
-msgid "Adjust mouse settings"
-msgstr "माउस सेटिंग समायोजित करें"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Tracking Mode"
-msgstr "ट्रैकिंग मोड"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Left-Handed Orientation"
-msgstr "बाएँ-हाथ ओरिएंटेशन"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-msgid "Left Ring"
-msgstr "बाईं अनामिका"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "बाईं अनामिका मोड #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-msgid "Right Ring"
-msgstr "दाहिनी तर्जनी"
-
-#: ../panels/wacom/gsd-wacom-device.c:1104
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "दाहिनी तर्जनी मोड #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-msgid "Left Touchstrip"
-msgstr "बाईं Touchstrip"
-
-#: ../panels/wacom/gsd-wacom-device.c:1157
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "बाईं Touchstrip मोड #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-msgid "Right Touchstrip"
-msgstr "दायाँ Touchstrip"
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "दायाँ Touchstrip मोड #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1214
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "बाईं Touchring मोड स्विच करें"
-
-#: ../panels/wacom/gsd-wacom-device.c:1216
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "दायाँ Touchring मोड स्विच करें"
-
-#: ../panels/wacom/gsd-wacom-device.c:1219
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "बाईं Touchstrip मोड स्विच करें"
-
-#: ../panels/wacom/gsd-wacom-device.c:1221
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "दायाँ Touchstrip मोड स्विच करें"
-
-#: ../panels/wacom/gsd-wacom-device.c:1226
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "मोड स्विच #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1334
-#, c-format
-msgid "Left Button #%d"
-msgstr "बायाँ बटन #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1337
-#, c-format
-msgid "Right Button #%d"
-msgstr "दायाँ बटन #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1340
-#, c-format
-msgid "Top Button #%d"
-msgstr "शीर्ष बटन #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1343
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "नीचे बटन #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-#| msgid "New shortcut..."
-msgid "New shortcut…"
-msgstr "नया शार्टकट..."
-
-# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "कोई क्रिया नहीं"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "बाईं माउस बटन पर क्लिक करें"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "मध्य माउस बटन पर क्लिक करें"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "दायाँ माउस बटन पर क्लिक करें"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "ऊपर स्क्रॉल करें"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "नीचे स्क्रॉल करें"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "बाएँ स्क्रॉल करें"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "दाएँ स्क्रॉल करें"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "पीछे"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "आगे"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "स्टाइलस"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "इरेज़र दबाव फील करें"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "सॉफ्ट"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "फर्म"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "शीर्ष बटन"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "निचले बटन"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "टिप दबाव फील करें"
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "भर्बोस विधि सक्रिय करें"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "सॉफ्ट"
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "सारांश दिखाएँ"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "स्ट्रिंग के लिए खोजें"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "संभव पैनल के नामों की सूची और बाहर निकलें"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "मदद विकल्प दिखाएँ"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "दिखाने के लिए पटल"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- सेटिंग्स"
-
-#: ../shell/cc-application.c:163
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-"%s\n"
-"'%s --help' को उपलब्ध कमांड लाइन विकल्प की पूरी सूची दिखाने के लिए चलाएँ.\n"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "उपलब्ध पैनल:"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "फर्म"
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "मदद"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "बटन"
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "बाहर"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "बटन"
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "बटन"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "इरेज़र दबाव फील करें"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "इरेज़र दबाव फील करें"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "मध्य माउस बटन पर क्लिक करें"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "दायाँ माउस बटन पर क्लिक करें"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "आगे"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom टेब्लेट"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "बटन मैपिंग सेट और ग्राफिक्स गोलियाँ के लिए स्टाइलस संवेदनशीलता को समायोजित"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "टैब्लेट;Wacom;लेखनी;इरेज़र;माउस;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "अभिन्यास"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "सिमुलेटेड द्वितीयक क्लिक (_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "विंडोज़ सॉफ़्टवेयर"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "टोनर पर कम"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "द्वितीयक"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "विंडोज़ सॉफ़्टवेयर"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "पहुँच विकल्प"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "जोड़ें"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "सहेजें (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "विवरण"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "संजाल समय (_N)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "नेटवर्क सेटिंग्स"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "संख्याएँ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "उपकरण प्रकार"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "उत्पादक"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "गुम फर्मवेयर"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "तालाबंद"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "मोबाइल ब्रॉडबैंड (_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "संजाल समय (_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "नेटवर्क"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "उन्नत"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "पहुँच विकल्प"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "बंद करें"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "विवरण"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "संजाल नाम"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "स्वचालित"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "मेरा घर संजाल"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "मेरा घर संजाल"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "कोई ब्लूटूथ एडाप्टर मौजूद नहीं मिला"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "हवाई जहाज मोड (_p)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "कनेक्शन"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM कार्ड नहीं घुसाया गया"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "बंद करें"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "बदलें (_a)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "मेरा घर संजाल"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "नए ड्राइवर की स्थापना कर रहा है ..."
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "गोपनीयता"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "सभी सेटिंग्स"
 
-#. Add categories
-#: ../shell/cc-window.c:876
-msgctxt "category"
-msgid "Personal"
-msgstr "निजी"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "प्राथमिक"
 
-#: ../shell/cc-window.c:877
-msgctxt "category"
-msgid "Hardware"
-msgstr "हार्डवेयर"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:878
-msgctxt "category"
-msgid "System"
-msgstr "सिस्टम"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "मदद"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "सामान्य"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "बाहर"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "ढूंढें"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "पिछले स्रोत पर जाएँ"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "रद्द"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "वरीयताएँ;सेटिंग्स;"
 
-#~ msgid "Flickr"
-#~ msgstr "फ्लिकर"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u आउटपुट"
+msgstr[1] "%u आउटपुट"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u इनपुट"
+msgstr[1] "%u इनपुट"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "पूरे दिन परिवर्तन"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "टाइल"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "छोटा-बड़ा करें"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "मध्य"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "भरें"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "स्पैन"
+
+#~ msgid "Colors"
+#~ msgstr "रंग"
+
+#~ msgid "Select Background"
+#~ msgstr "पृष्ठभूमि चुनें"
+
+#~ msgid "Pictures"
+#~ msgstr "तस्वीर"
+
+#~ msgid "Home"
+#~ msgstr "घर"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "आप अपने %s फ़ोल्डर में छवि जोड़ सकते हैं और वे यहाँ दिखाए जाएँगे"
+
+#~ msgid "multiple sizes"
+#~ msgstr "बहुत आकार"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "कोई डेस्कटॉप पृष्ठभूमि"
+
+#~ msgid "Current background"
+#~ msgstr "मौजूदा पृष्ठभूमि"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "वॉलपेपर; स्क्रीन; डेस्कटॉप;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "वर्ग के ऊपर अपने अंशांकन युक्ति को रखें और 'आरंभ' दवाएँ "
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "अपने अंशांकन युक्ति को अंशांकन स्थिति में खिसकाएं और 'जारी रखें' दवाएँ "
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "अपने अंशांकन युक्ति को सतह स्थिति में खिसकाएं और 'जारी रखें' दवाएँ "
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "लैपटॉप ढक्कन बंद करो"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "एक आंतरिक त्रुटि आई है जो बरामद नहीं किया जा सकता है."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "अंशांकन के लिए आवश्यक उपकरण नहीं स्थापित कर रहे हैं."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "प्रोफाइल उत्पन्न नहीं किया जा सका."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "लक्ष्य श्वेतबिंदु प्राप्य नहीं किया गया."
+
+#~ msgid "Complete!"
+#~ msgstr "पूर्ण!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "विन्यास विफल!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "आप अंशांकन युक्ति निकाल सकते हैं."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "जारी रखने के दौरान अंशांकन युक्ति को परेशान नहीं करें"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "लैपटॉप स्क्रीन"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s मॉनीटर"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s स्कैनर"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s मुद्रक"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s वेबकैम"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s के लिए रंग प्रबंधन सक्रिय करें"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s के लिए रंग प्रोफाइल दिखाएं"
+
+#~ msgid "Not calibrated"
+#~ msgstr "कैलिब्रेट नहीं किया गया"
+
+#~ msgid "Default: "
+#~ msgstr "तयशुदा: "
+
+#~ msgid "Test profile: "
+#~ msgstr "टेस्ट प्रोफ़ाइल: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "आईसीसी प्रोफाइल फ़ाइल का चयन करें"
+
+#~ msgid "_Import"
+#~ msgstr "आयात करें (_I)"
+
+#~ msgid "All files"
+#~ msgstr "सभी फ़ाइलें"
+
+#, c-format
+#~| msgid "Failed to apply configuration: %s"
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "फ़ाइल अपलोड करने में विफल: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "इन प्रोफ़ाइल को इसमें अद्यतन किया जा रहा है:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "इस URL को लिखें."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "इस कंप्यूटर को फिर आरंभ करें और अपने सामान्य ऑपरेटिंग तंत्र को बूट करें."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "अपने ब्राउज़र में इस यूआरएल को टाइप करें ताकि प्रोफ़ाइल डाउनलोड और संस्थापित किया जा "
+#~ "सके."
+
+#~ msgid "Save Profile"
+#~ msgstr "प्रोफ़ाइल सहेजें"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "चयनित युक्ति के लिए एक रंग प्रोफ़ाइल बनाएँ"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "मापन यंत्र का पता नहीं लगा है. कृपया जाचें कि यह चालू है और सही रूप से कनेक्टेड है."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "माप उपकरण प्रिंटर प्रोफाइलिंग का समर्थन नहीं करता है."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "युक्ति प्रकार मौजूदा में समर्थित नहीं है."
+
+#~ msgid "Standard Space"
+#~ msgstr "मानक स्थान "
+
+#~ msgid "Test Profile"
+#~ msgstr "टेस्ट प्रोफ़ाइल"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "स्वचालित "
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "कम विशेषता"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "मध्यम विशेषता"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "उच्च गुणवत्ता"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "मूलभूत RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "तयशुदा CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "डिफ़ॉल्ट ग्रे"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "विक्रेता द्वारा दी गयी कारखाने अंशांकन डेटा"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "पूर्ण स्क्रीन सुधार प्रदर्शन इस प्रोफाइल के साथ संभव नहीं है "
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "यह युक्ति एक प्रोफाइल ज्यादा देर तक सही नहीं है."
+
+#~ msgid "Done"
+#~ msgstr "संपन्न"
+
+#~| msgid "Add profile"
+#~ msgid "Upload profile"
+#~ msgstr "प्रोफाइल अपलोड करें"
+
+#~| msgid "Add new connection"
+#~ msgid "Requires Internet connection"
+#~ msgstr "इंटरनेट कनेक्शन जोड़ें"
+
+#~ msgid "United States"
+#~ msgstr "यूनाइटेड स्टेट्स"
+
+#~ msgid "Germany"
+#~ msgstr "जर्मनी"
+
+#~ msgid "Spain"
+#~ msgstr "स्पैन"
+
+#~ msgid "China"
+#~ msgstr "चीन"
+
+#~ msgid "Other…"
+#~ msgstr "अन्य..."
+
+#~ msgid "Language"
+#~ msgstr "भाषा"
+
+#~| msgid "%a %l:%M %p"
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~| msgid "%a %l:%M %p"
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "समय क्षेत्र (_Z)"
+
+#~ msgid "24-hour"
+#~ msgstr "24-घंटे"
+
+#~ msgid "AM / PM"
+#~ msgstr "पूर्वाह्न/अपराह्न"
+
+#~| msgid "Close"
+#~ msgid "Lid Closed"
+#~ msgstr "Lid बंद किया गया"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Mirrored"
+#~ msgstr "मिरर किया"
+
+#~ msgid "Off"
+#~ msgstr "बंद"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "संयुग्मित प्रदर्शक की व्यवस्था करें"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "उन्हें फिर व्यवस्थित करने के लिए प्रदर्शन खींचें"
+
+#~ msgid "Size"
+#~ msgstr "आकार"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "शीर्ष बार दिखाएँ और इस प्रदर्शन के लिए गतिविधि सारांश"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "अतिरिक्त कार्यस्थान बनाने के लिए दूसरों के साथ इस प्रदर्शन में शामिल हों"
+
+#~| msgid "Orientation"
+#~ msgid "Presentation"
+#~ msgstr "प्रस्तुति"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "स्लाइडशो और मीडिया केवल दिखाएँ"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "मौजूदा दृश्य दोनों प्रदर्शन पर दिखाएँ"
+
+#~| msgid "_Turn On"
+#~ msgid "Turn Off"
+#~ msgstr "बन्द करें"
+
+#~| msgid "Panel to display"
+#~ msgid "Don't use this display"
+#~ msgstr "इस प्रदर्शन का उपयोग मत करें"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "स्क्रीन सूचना नहीं पा सका"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "संयुग्मित प्रदर्शक की व्यवस्था करें (_A)"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "Unknown"
+#~ msgstr "अज्ञात"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/session-properties-capplet.c:303
+# gnome-session/session-properties-capplet.c:376
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:84 libgnomeui/gnome-app-helper.h:516
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/session-properties-capplet.c:303
+# gnome-session/session-properties-capplet.c:376
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-app-helper.c:84 libgnomeui/gnome-app-helper.h:516
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-bit"
+
+#~ msgid "Ask what to do"
+#~ msgstr "पूछें कि क्या करना है"
+
+#~ msgid "Do nothing"
+#~ msgstr "कुछ मत करें"
+
+#~ msgid "Open folder"
+#~ msgstr "फ़ोल्डर खोलें"
+
+#~ msgid "Other Media"
+#~ msgstr "अन्य मीडिया"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ऑडियो सीडी के लिए अनुप्रयोग चुनें"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "वीडियो सीडी के लिए अनुप्रयोग चुनें"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "अनुप्रयोग को चालू करने के लिए चयन करे जब एक म्यूजिक प्लयेर जुड़ा हो"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "अनुप्रयोग को चालू करने के लिए चयन करे जब एक कैमरा जुड़ा हो"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "सॉफ़्टवेयर सीडी के लिए अनुप्रयोग चुनें"
+
+#~ msgid "audio DVD"
+#~ msgstr "ऑडियो डीवीडी"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "खाली Blu-Ray डिस्क"
+
+#~ msgid "blank CD disc"
+#~ msgstr "खाली सीडी डिस्क"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "रिक्त डीवीडी डिस्क"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "खाली HD DVD डिस्क"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray वीडियो डिस्क"
+
+#~ msgid "e-book reader"
+#~ msgstr "ई-बुक रीडर"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD डीवीडी वीडियो डिस्क"
+
+#~ msgid "Picture CD"
+#~ msgstr "पिक्चर सीडी"
+
+#~ msgid "Super Video CD"
+#~ msgstr "सुपर वीडियो सीडी"
+
+#~ msgid "Video CD"
+#~ msgstr "वीडियो सीडी"
+
+#~ msgid "Overview"
+#~ msgstr "सारांश"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "संस्करण %s"
+
+#~ msgid "Base system"
+#~ msgstr "आधार प्रणाली"
+
+#~ msgid "Disk"
+#~ msgstr "डिस्क"
+
+#~| msgid "Checking for Updates"
+#~ msgid "Check for updates"
+#~ msgstr "अद्यतन के लिए जाँचें"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "$PICTURES में एक स्क्रीनशॉट सहेजें"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr " $PICTURES में विंडो का स्क्रीनशॉट सहेजें"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr " $PICTURES में किसी क्षेत्र का एक स्क्रीनशॉट सहेजें"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "क्लिपबोर्ड पर स्क्रीनशॉट की नकल करें"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "क्लिपबोर्ड पर विंडो का स्क्रीनशॉट की नकल बनाएं"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "क्लिपबोर्ड पर क्षेत्र की स्क्रीनशॉट की नकल बनाएं"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "छोटा स्क्रीनकास्ट रिकॉर्ड करें"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "संशोधक केवल अगले स्रोत में जाएँ"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "शॉर्टकट;दोहराएँ;ब्लिंक;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "मनपसंद शार्टकट"
+
+#~ msgid "_Delay:"
+#~ msgstr "देरीः (_D)"
+
+#~ msgid "_Speed:"
+#~ msgstr "गतिः (_S)"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "छोटा"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "धीमा"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "लंबा"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "तेज"
+
+#~ msgid "S_peed:"
+#~ msgstr "गति: (_p)"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "शॉर्टकट हटायें"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "शॉर्टकट संपादित करने के लिए, पंक्ति पर क्लिक करें और नई कुंजी नीचे पकड़े या स्पष्ट करने के "
+#~ "लिए बैकस्पेस प्रेस करें."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<अज्ञात क्रिया>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "शॉर्टकट \"%s\" प्रयोग नहीं की जा सकती है क्योंकि इस कुंजी के प्रयोग से इसे टाइप करना "
+#~ "असंभव होगा.\n"
+#~ "कृपया Control, Alt या Shift कुंजी को एक साथ कोशिश करें."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "यह शार्टकट \"%s\" पहले से ही:\n"
+#~ " \"%s\" हेतु प्रयुक्त है"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "यदि आप \"%s\" को फिर नियत करते हैं, \"%s\" शॉर्टकट को निष्क्रिय किया जाएगा."
+
+#~ msgid "_Reassign"
+#~ msgstr "फिर नियत करें (_R)"
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" शॉर्टकट में एक संबद्ध \"%s\" शॉर्टकट है. क्या आप इसे \"%s\" पर स्वतः सेट करना "
+#~ "चाहते हैं?"
+
+#, c-format
+#~| msgid ""
+#~| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~| "disabled."
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" अभी \"%s\" से जुड़ा है, शॉर्टकट को निष्क्रिय किया जाएगा यदि आप आगे बढ़ते हैं."
+
+#~| msgid "_Reassign"
+#~ msgid "_Assign"
+#~ msgstr "फिर नियत करें (_A)"
+
+#~| msgid "Test Your _Settings"
+#~ msgid "Test Your Settings"
+#~ msgstr "अपनी सेटिंग्स जाँचें"
+
+#~| msgctxt "keyboard, speed"
+#~| msgid "Slow"
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "धीमा"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "दोहरा क्लिक टाइमआउट"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~| msgctxt "keyboard, speed"
+#~| msgid "Fast"
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "तेज"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "बायाँ (_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "दाँया (_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "संकेतक गति (_P)"
+
+#~| msgctxt "keyboard, speed"
+#~| msgid "Slow"
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "धीमा"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~| msgctxt "keyboard, speed"
+#~| msgid "Fast"
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "तेज"
+
+#~| msgctxt "keyboard, speed"
+#~| msgid "Slow"
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "धीमा"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~| msgctxt "keyboard, speed"
+#~| msgid "Fast"
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "तेज"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "दो अंगुली से स्क्रॉल (_f)"
+
+#~| msgid "_Edge scrolling"
+#~ msgid "_Natural scrolling"
+#~ msgstr "प्राकृतिक स्क्रॉलिंग (_N)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "पाँच क्लिक, GEGL समय!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "दोहरा क्लिक, प्राथमिक बटन"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "एकल क्लिक, प्राथमिक बटन"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "दोहरा क्लिक, मध्य बटन"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "एकल क्लिक, मध्य बटन"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "दोहरा क्लिक, द्वितीयक बटन"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "एकल क्लिक, द्वितीयक बटन"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "तंत्र संजाल सेवाओं इस संस्करण के साथ संगत नहीं हैं."
+
+#~ msgid "page 1"
+#~ msgstr "पृष्ठ 1"
+
+#~ msgid "page 2"
+#~ msgstr "पृष्ठ 2"
+
+#~ msgid "automatic"
+#~ msgstr "स्वचालित"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "उद्यम"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "कुछ नहीं"
+
+#~ msgid "Never"
+#~ msgstr "कभी नहीं"
+
+#~ msgid "Today"
+#~ msgstr "आज"
+
+#~ msgid "Yesterday"
+#~ msgstr "कल"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "कुछ नहीं"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "कमजोर"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ठीक"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "अच्छा"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "बहुत बढिया"
+
+#~ msgid "Identity"
+#~ msgstr "उपयोक्ता"
+
+#~ msgid "Server"
+#~ msgstr "सर्वर"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS सर्वर मिटायें"
+
+#~ msgid "Delete Route"
+#~ msgstr "मार्ग  मिटाएँ"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "कुछ नहीं"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-बिट कुंजी (हेक्स या ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit पासफ्रेज"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "गतिशील WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 निजी"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 एंटरप्राइज"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "मुड़ जोड़ी (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "संलग्न एकक अंतराफलन (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "मीडिया स्वतंत्र अंतरफलक (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 गीबा/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "अन्य उपयोगकर्ताओं के लिए उपलब्ध है (_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "फायरवॉल क्षेत्र (_Z)"
+
+#~| msgid "Default"
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "तयशुदा"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "यह क्षेत्र कनेक्शन का भरोसेमंद स्तर परिभाषित करता है"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "कनेक्शन संपादक खोलने में असमर्थ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#~ msgid "New Profile"
+#~ msgstr "कोई प्रोफ़ाइल"
+
+#~ msgid "Bond"
+#~ msgstr "बंधन"
+
+#~ msgid "Team"
+#~ msgstr "टोली"
+
+#~ msgid "Bridge"
+#~ msgstr "पुल"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "वीपीएन प्लगिन लोड नहीं कर सका"
+
+#~ msgid "Import from file…"
+#~ msgstr "फ़ाइल से आयात करें… "
+
+#~ msgid "Add Network Connection"
+#~ msgstr "नया संजाल कनेक्शन जोड़ें"
+
+#~ msgid "_Reset"
+#~ msgstr "रीसेट करें (_R)"
+
+#~ msgid "_Forget"
+#~ msgstr "भूलें (_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "पासवर्ड सहित इस नेटवर्क के लिए सेटिंग्स रीसेट करें, लेकिन इसे एक पसंदीदा नेटवर्क समझें"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "इस नेटवर्क से संबंधित सभी जानकारी निकालें और स्वचालित रूप से कनेक्ट करने की कोशिश नहीं "
+#~ "करें."
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN कनेक्शन आय़ात नहीं कर सका"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "फाइल '%s' पढ़ा नहीं जा सका अथवा कोई परिचित VPN कनेक्शन सूचना को समाहित नहीं कर "
+#~ "सका\n"
+#~ "\n"
+#~ "त्रुटि: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "आयात के लिए फाइल चुनें"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "\"%s\" नामक फाइल पहले से मौजूद है."
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "क्या आप %s को VPN कनेक्शन के साथ बदलना चाहते हैं जिसे आप सहेज रहे हैं?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN कनेक्शन निर्यात नहीं कर सका"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN कनेक्शन '%s' को %s में निर्यात नहीं किया जा सका.\n"
+#~ "\n"
+#~ "त्रुटि: %s."
+
+#~| msgid "Export VPN connection..."
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN संबंधन निर्यात करें"
+
+#~ msgid "Bond slaves"
+#~ msgstr "बॉण्ड गुलाम"
+
+#~ msgid "(none)"
+#~ msgstr "(कोई नहीं)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "पुल गुलाम"
+
+#~ msgid "never"
+#~ msgstr "कभी नहीं"
+
+#~ msgid "today"
+#~ msgstr "आज"
+
+#~ msgid "yesterday"
+#~ msgstr "कल"
+
+#~ msgid "Last used"
+#~ msgstr "अंतिम प्रयुक्त"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "प्रोफ़ाइल %d"
+
+#~| msgid "Bridge slaves"
+#~ msgid "Team slaves"
+#~ msgstr "टीम स्लेव"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "यदि आपके पास बेतार के अलावा इंटरनेट पर कोई कनेक्शन है, आप इसे दूसरे के साथ बेतार "
+#~ "हॉटस्पॉट सेट करकेकनेक्शन साझा करने के लिए उपयोग कर सकते हैं."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "बेतार हॉटस्पॉट पर जाना आपको <b>%s</b> से कनेक्ट नहीं रहने देगा."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "आपके बेतार कनेक्शन से इंटरनेट में पहुँच लेना संभव नहीं है जब हॉटस्पॉट सक्रिय हो. "
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "हॉटस्पॉट रोकें और किसी भी उपयोगकर्ताओं को डिस्कनेक्ट करें?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "हॉटस्पॉट रोकें (_S)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "तंत्र नीति हॉटस्पॉट के रूप में उपयोग को प्रतिबंधित करता हैं"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "वायरलेस युक्ति हॉटस्पॉट मोड समर्थन नहीं करता है"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "कूटशब्द सहित चुने गए नेटवर्कों के लिए संजाल विवरण और अन्य कोई मनपसंद विन्यास नष्ट हो "
+#~ "जाएगा."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "भूलें (_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "वेब प्रॉक्सी ऑटो डिस्कवरी का प्रयोग किया जाता है जब कॉन्फ़िगरेशन यूआरएल प्रदान नहीं "
+#~ "किया जाता है."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "यह अविश्वसनीय सार्वजनिक संजाल के लिए अनुशंसित नहीं है."
+
+#~ msgid "Proxy"
+#~ msgstr "प्रॉक्सी"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "कुछ नहीं"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "हस्तचालित"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "स्वचालित"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN क़िस्म"
+
+#~ msgid "Group Name"
+#~ msgstr "समूह नाम"
+
+#~ msgid "Group Password"
+#~ msgstr "समूह कूटशब्द"
+
+#~ msgid "details"
+#~ msgstr "विवरण"
+
+#~ msgid "Show P_assword"
+#~ msgstr "कूटशब्द दिखाएं (_a)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "अन्य उपयोगकर्ताओं के लिए उपलब्ध है"
+
+#~ msgid "identity"
+#~ msgstr "उपयोक्ता"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "स्वचालित (DHCP) पता केवल"
+
+#~ msgid "Link-local only"
+#~ msgstr "लिंक स्थानीय सिर्फ"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "स्वतः प्राप्त रूट अनदेखा करें (_n) "
+
+#~ msgid "ipv4"
+#~ msgstr "IPv4"
+
+#~ msgid "ipv6"
+#~ msgstr "IPv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "क्लोन MAC पता (_C)"
+
+#~ msgid "hardware"
+#~ msgstr "हार्डवेयर"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "उनकी चूक को इस कनेक्शन के लिए सेटिंग्स रीसेट करें, लेकिन एक पसंदीदा कनेक्शन के रूप में याद "
+#~ "करें."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "इस नेटवर्क से संबंधित सभी जानकारी निकालें और स्वचालित रूप से इसे कनेक्ट करने की कोशिश "
+#~ "नहीं करें."
+
+#~ msgid "reset"
+#~ msgstr "रीसेट"
+
+#~ msgid "Hardware"
+#~ msgstr "हार्डवेयर"
+
+#~ msgid "_History"
+#~ msgstr "इतिहास (_H)"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "वाई फाई संजाल में कनेक्ट होने के लिए बंद करें"
+
+#~ msgid "Connected Devices"
+#~ msgstr "कनेक्टेड युक्तियाँ"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "तदर्थ"
+
+#~ msgid "Infrastructure"
+#~ msgstr "बुनियादी ढाँचा"
+
+#~ msgid "Status unknown"
+#~ msgstr "स्थिति अज्ञात"
+
+#~ msgid "Unmanaged"
+#~ msgstr "बिना प्रबंधित"
+
+#~ msgid "Unavailable"
+#~ msgstr "अनुपलब्ध"
+
+#~ msgid "Connecting"
+#~ msgstr "जोड़ रहा है"
+
+#~ msgid "Disconnecting"
+#~ msgstr "डिसकनेक्टिंग"
+
+#~ msgid "Connection failed"
+#~ msgstr "कनेक्शन असफल"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "स्थिति अज्ञात (गुम)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "विन्यास विफल"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP विन्यास विफल"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "आईपी विन्यास का समय समाप्त"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "गोपनीयता जरूरी थी, लेकिन प्रदान नहीं किया गया था"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x सप्लीकेंट डिसकनेक्टेड"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x सप्लीकेंट विन्यास विफल"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x सप्लीकेंट विफल"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x सप्लीकेंट प्रमाणित करने में काफी समय लिया"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP आरंभ होने में विफल रहा"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP सेवा डिस्कनेक्टेड"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP विफल"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP क्लाइंट आरंभ होने में विफल रहा"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP क्लाइंट त्रुटि"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP क्लाइंट विफल"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "साझा कनेक्शन सेवा आरंभ होने में विफल"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "साझा कनेक्शन सेवा विफल"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP सेवा आरंभ होने में विफल रहा"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP सेवा त्रुटि"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP सेवा विफल"
+
+#~ msgid "Line busy"
+#~ msgstr "पंक्ति व्यस्त"
+
+#~ msgid "No dial tone"
+#~ msgstr "डायल टोन नहीं"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "कोई कैरियर स्थापित नहीं किया जा सका"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "डायलिंग आग्रह का समय समाप्त"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "डायलिंग प्रयास विफल"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "मोडेम आरंभीकरण असफल"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "विशेष APN चुनने में विफल"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "संजाल के लिए खोज नहीं रहा है"
+
+#~ msgid "Network registration denied"
+#~ msgstr "संजाल पंजीयन मनाही"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "संजाल पंजीयन का समय समाप्त"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "निवेदित संजाल के साथ पंजीयन में विफल"
+
+#~ msgid "PIN check failed"
+#~ msgstr "पिन चेक विफल"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "युक्ति के लिए फर्मवेयर अनुपस्थित हो सकता है"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "कनेक्शन गुम"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "मौज़ूदा कनेक्शन चालू हुआ"
+
+#~ msgid "Modem not found"
+#~ msgstr "मोडेम नहीं मिला"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ब्लूटूथ कनेक्शन असफल"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM पिन जरूरी"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk जरूरी"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM गलत"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand युक्ति कनेक्टेड अवस्था का समर्थन नहीं करता है"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "कनेक्शन निर्भरता विफल"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "केबल अनप्लग"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "कोई प्रमाणपत्र प्राधिकार प्रमाणपत्र चुना गया"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "एक सर्टिफिकेट ऑथोरिटी (CA) प्रमाणपत्र का उपयोग नहीं असुरक्षित, दुष्ट Wi-Fi नेटवर्क के "
+#~ "लिए कनेक्शन में परिणाम कर सकते हैं.आप एक सर्टिफिकेट ऑथोरिटी प्रमाणपत्र का चयन करना "
+#~ "चाहेंगे?"
+
+#~ msgid "Ignore"
+#~ msgstr "नज़रअंदाज़ करें"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "सीए प्रमाणपत्र चुनें"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, या PKCS#12 निजी कुंजी (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER या PEM प्रमाणपत्र (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC फ़ाइल (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "इस कूटशब्द के लिए हर समय पूछें (_k)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "विगोपित निजी कुंजी असुरक्षित हैं"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "चुना गया निजी कुंजी कूटशब्द के द्वारा संरक्षित नहीं दिखता है.  यह आपके सुरक्षा साख को "
+#~ "खराब कर सकता है.  कृपया कोई कूटशब्द संरक्षित निजी कुंजी चुनें.\n"
+#~ "\n"
+#~ "(आप अपने निजी कुंजी से openssl के साथ अपना कूटशब्द संरक्षित कर सकते हैं)"
+
+#~| msgid "Choose your personal certificate..."
+#~ msgid "Choose your personal certificate"
+#~ msgstr "अपना व्यक्तिगत प्रमाणपत्र चुनें"
+
+#~| msgid "Choose your private key..."
+#~ msgid "Choose your private key"
+#~ msgstr "अपनी निजी कुंजी चुनें"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "मुझे फिर मत चेताएँ (_w)"
+
+#~ msgid "Yes"
+#~ msgstr "हाँ"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "पॉपअप बैनर दिखाएं"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "बैनर में विवरण दिखाएँ"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "लॉक स्क्रीन में देखें"
+
+#~ msgid "On"
+#~ msgstr "चालू"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "पॉपअप बैनर दिखाएं"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "लॉक स्क्रीन में दिखाएँ "
+
+#~ msgid "Add Account"
+#~ msgstr "खाता जोड़ें"
+
+#~ msgid "Mail"
+#~ msgstr "डाक"
+
+#~ msgid "Contacts"
+#~ msgstr "संपर्क"
+
+#~ msgid "Chat"
+#~ msgstr "गपशप"
+
+#~ msgid "Resources"
+#~ msgstr "संसाधन "
+
+#~ msgid "Error logging into the account"
+#~ msgstr "खाते में लॉगिंग त्रुटि"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "महत्व का समय समाप्त हो गया."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "इस खाते को सक्षम करने के लिए साइन - इन करें."
+
+#~ msgid "_Sign In"
+#~ msgstr " साइन - इन करें (_S)"
+
+#~ msgid "Error creating account"
+#~ msgstr "खाता बनाने में त्रुटि"
+
+#~ msgid "Error removing account"
+#~ msgstr "खाता हटाने में त्रुटि"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "क्या आप वाक़ई ख़ाता को मिटाना चाहते हैं?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "यह सर्वर पर खाता को हटा देगा."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "कोई ऑनलाइन खाता विन्यस्त नहीं"
+
+#~ msgid "Remove Account"
+#~ msgstr "खाता मिटाएँ"
+
+#~ msgid "Add an online account"
+#~ msgstr "एक ऑनलाइन खाता जोड़ें"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "किसी खाता को जोड़ना आपके अनुप्रयोग को दस्तावेज़, डाक, संपर्क, पंचांग, चैट और भी कुछेक में "
+#~ "पहुँछ लेने देता है."
+
+#~ msgid "Unknown time"
+#~ msgstr "अज्ञात समय"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s जब तक पूरी तरह चार्ज्ड"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "चेतावनी: %s शेष"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s शेष"
+
+#~ msgid "Fully charged"
+#~ msgstr "पूरी तरह चार्ज्ड "
+
+#~ msgid "Empty"
+#~ msgstr "रिक्त"
+
+#~ msgid "Charging"
+#~ msgstr "चार्ज हो रहा है"
+
+#~ msgid "Discharging"
+#~ msgstr "डिस्चार्ज कर रहा है"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "मुख्य"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "अतिरिक्त"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "बेतार माउस"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "बेतार कीबोर्ड"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "बिना व्यवधान के ऊर्जा आपूर्ति"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "व्यक्तिगत डिजिटल सहायक"
+
+#~ msgid "Cellphone"
+#~ msgstr "सेलफोन"
+
+#~ msgid "Media player"
+#~ msgstr "मीडिया प्लेयर"
+
+#~ msgid "Computer"
+#~ msgstr "कम्प्यूटर"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "चार्ज हो रहा है"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "चेतावनी"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "कम"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "अच्छा"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "पूरी तरह चार्ज्ड "
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "रिक्त"
+
+#~ msgid "Batteries"
+#~ msgstr "बैटरी"
+
+#~ msgid "When _idle"
+#~ msgstr "निष्क्रिय जब (_I)"
+
+#~| msgid "Keyboard Settings"
+#~ msgid "_Keyboard brightness"
+#~ msgstr "कुंजीपट चमकीलापन (_K)"
+
+#~| msgid "_Dim Screen when Inactive"
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "स्क्रीन मंद करें जब निष्क्रिय हैं (_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "वाई फाई (_W)"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "बेतार युक्तियाँ बंद करें"
+
+#~| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "मोबाइल ब्रॉडबैंड (3G, 4G, WiMax, आदि.) युक्तियाँ बंद करें"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "ब्लूटूथ (_B)"
+
+#~ msgid "When on battery power"
+#~ msgstr "जब बैटरी शक्ति पर चल रहा हो"
+
+#~ msgid "When plugged in"
+#~ msgstr "जब प्लगिन"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "निलंबित & पावर ऑफ करें"
+
+#~| msgid "_Automatic Suspend"
+#~ msgid "_Automatic suspend"
+#~ msgstr "स्वत: निलंबित (_A)"
+
+#~| msgid "When Battery Power is _Critical"
+#~ msgid "When battery power is _critical"
+#~ msgstr "जब पावर बहुत कम है (_C)"
+
+#~ msgid "Power Off"
+#~ msgstr "बंद करें"
+
+#~ msgid "Hibernate"
+#~ msgstr "सुप्तावस्था"
+
+#~ msgid "1 minute"
+#~ msgstr "1 मिनट"
+
+#~ msgid "3 minutes"
+#~ msgstr "मिनट"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 मिनट"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 मिनट"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 मिनट"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 मिनट"
+
+#~ msgid "Out of toner"
+#~ msgstr "टोनर के बाहर"
+
+#~ msgid "Low on developer"
+#~ msgstr "डेवलपर पर कम"
+
+#~ msgid "Out of developer"
+#~ msgstr "डेवलपर के बाहर"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "चिह्न आपूर्ति पर कम"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "चिह्न आपूर्ति के बाहर"
+
+#~ msgid "Open cover"
+#~ msgstr "कवर खोलें"
+
+#~ msgid "Open door"
+#~ msgstr "खुला दरवाजा"
+
+#~ msgid "Low on paper"
+#~ msgstr "कागज पर कम"
+
+#~ msgid "Out of paper"
+#~ msgstr "कागज के बाहर"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "रुक गया"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "लगभग पूरा गोदाम बेकार"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "लगभग गोदाम बेकार"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ऑप्टिकल फोटो कंडक्टर जीवन का अंत निकट है"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ऑप्टिकल फोटो कंडक्टर कामकाज नहीं रहा है"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "तैयार"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "काम नहीं स्वीकार कर सकते हैं"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "प्रक्रिया हो रही है"
+
+#~ msgid "Toner Level"
+#~ msgstr "टोनर स्तर"
+
+#~ msgid "Supply Level"
+#~ msgstr "आपूर्ति स्तर"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "संस्थापित किया जा रहा है"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u सक्रिय"
+#~ msgstr[1] "%u सक्रिय"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "नया प्रिंटर जोड़ने में विफल."
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "पोस्टस्क्रिप्ट प्रिंटर विवरण फ़ाइल (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "कोई उपयुक्त ड्राइवर नहीं मिला"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "लोड नहीं कर सका ui: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "मुद्रण फिर से शुरू"
+
+#~ msgid "Pause Printing"
+#~ msgstr "ठहराव मुद्रण"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "नया प्रिंटर जोड़ें"
+
+#~| msgid "Search for network printers or filter result"
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "प्रिंटर का पता डालें या परिणाम फिल्टर करने के लिए पाठ डालें"
+
+#~| msgid "Remove Printer"
+#~ msgid "JetDirect Printer"
+#~ msgstr "जेटप्रिंटर प्रिंटर"
+
+#~| msgid "%s Printer"
+#~ msgid "LPD Printer"
+#~ msgstr "LPD मुद्रक"
+
+#~ msgid "One Sided"
+#~ msgstr "एक तरफा"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "लंबा किनारा (मानक)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "छोटा किनारा (पलटें)"
+
+#~ msgid "Portrait"
+#~ msgstr "व्यक्तिचित्र"
+
+#~ msgid "Landscape"
+#~ msgstr "भूदृश्य"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "उल्टा भूदृश्य"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "उल्टा व्यक्तिचित्र"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "स्थगित"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "रोकें"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "प्रक्रिया हो रही है"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "रुक गया"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "छोड़ा गया"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "पूर्ण"
+
+#~ msgid "Job Title"
+#~ msgstr "पद नाम"
+
+#~ msgid "Job State"
+#~ msgstr "जॉब स्थिति"
+
+#~ msgid "USB"
+#~ msgstr "यूएसबी"
+
+#~ msgid "Serial Port"
+#~ msgstr "क्रमिक पोर्ट"
+
+#~ msgid "Parallel Port"
+#~ msgstr "समांतर पोर्ट"
+
+#, c-format
+#~| msgid "Location"
+#~ msgid "Location: %s"
+#~ msgstr "स्थानः %s"
+
+#, c-format
+#~| msgid "A_ddress:"
+#~ msgid "Address: %s"
+#~ msgstr "पता: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "दो तरफा"
+
+#~ msgid "Paper Type"
+#~ msgstr "कागज का प्रकार"
+
+#~ msgid "Paper Source"
+#~ msgstr "कागज स्रोत"
+
+#~ msgid "Output Tray"
+#~ msgstr "आउटपुट तश्तरी"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript प्री फ़िल्टरिंग"
+
+#~ msgid "Pages per side"
+#~ msgstr "पृष्ठ प्रति पक्ष"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "सामान्य"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "पृष्ठ सेटअप"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "मुद्रक विकल्प"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "कार्य"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "छवि गुणवत्ता"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "रंग"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "समाप्त कर रहा है"
+
+#~ msgid "Auto Select"
+#~ msgstr "स्वतः चुनें"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "अंतस्थापित GhostScript फ़ॉन्ट केवल"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS स्तर 1 में बदलें"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "पीएस स्तर 2 पर परिवर्तित करें"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#~ msgid "No pre-filtering"
+#~ msgstr "कोई पूर्व फ़िल्टरिंग नहीं"
+
+#~ msgid "Supply"
+#~ msgstr "आपूर्ति"
+
+#~| msgid "Default Route"
+#~ msgid "_Default printer"
+#~ msgstr "तयशुदा प्रिंटग (_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "कार्य"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "जॉब दिखाएं (_J)"
+
+#~ msgid "label"
+#~ msgstr "लेबल"
+
+#~ msgid "page 3"
+#~ msgstr "पृष्ठ 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "जाँच पृष्ठ छापें (_T)"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#~ msgid "_Options"
+#~ msgstr "विकल्प (_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "नया प्रिंटर जोड़ें"
+
+#~ msgid "Usage & History"
+#~ msgstr "उपयोग & इतिहास"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "रद्दी से सभी मदों खाली करें?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "रद्दी में सभी मदों हमेशा के लिए मिटा दी जाएंगी."
+
+#~| msgid "Purge Trash & Temporary Files"
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "ट्रैश व अस्थाई फ़ाइलें मिटाएँ?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "सभी अस्थाई फ़ाइल स्थाई रूप से मिटा दी जाएगी."
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "आपकी व्यक्तिगत जानकारी और नियंत्रण जो दूसरों को देख सकते हैं की सुरक्षित रखें"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "स्क्रीन बंद करता है "
+
+#  set the timeout value  label with correct value of timeout
+#~ msgid "30 seconds"
+#~ msgstr "30 सेकण्ड"
+
+#~ msgid "1 day"
+#~ msgstr "1 दिन"
+
+#~ msgid "2 days"
+#~ msgstr "2 दिन"
+
+#~ msgid "3 days"
+#~ msgstr "3 दिन"
+
+#~ msgid "4 days"
+#~ msgstr "4 दिन"
+
+#~ msgid "5 days"
+#~ msgstr "5 दिन"
+
+#~ msgid "6 days"
+#~ msgstr "6 दिन"
+
+#~ msgid "7 days"
+#~ msgstr "7 दिन"
+
+#~ msgid "14 days"
+#~ msgstr "14 दिन"
+
+#~ msgid "30 days"
+#~ msgstr "30 दिन"
+
+#~ msgid "Forever"
+#~ msgstr "सदा के लिए "
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "अपने इतिहास को याद बातें करने के लिए फिर से खोजने के लिए आसान बनाता है.इन मदों "
+#~ "नेटवर्क पर कभी नहीं साझा कर रहे हैं."
+
+#~ msgid "_Recently Used"
+#~ msgstr "हाल ही में प्रयुक्त (_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "इतिहास रख सकेंगे (_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "स्क्रीन लॉक आपकी गोपनीयता की रक्षा जब आप दूर कर रहे हैं."
+
+#~| msgid "Lock Screen _After Blank For"
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "खाली करने के बाद स्क्रीन लॉक (_a)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "स्वचालित रूप से कचरा पेटी और अस्थायी फ़ाइलें को मिटायें  अपने कंप्यूटर को अनावश्यक "
+#~ "संवेदनशील जानकारी के मुक्त रखने में मदद करने के लिए "
+
+#~ msgid "Purge _After"
+#~ msgstr "के बाद मिटाएँ (_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "आप किस सॉफ़्टवेयर का उपयोग करते हैं इसपर सूचना भेजा हमें अधिक सटीक अनुशंसा के लिए मदद "
+#~ "करता है. यह हमेें हमारे सॉफ्टवेयर को सुधारने में मदद करता है.\n"
+#~ "\n"
+#~ "सभी जानकारियाँ जो हम जमा करते हैं वह बेनाम रहती हैं, और हम आपके आँकड़े को किसी तीसरे "
+#~ "पक्ष से साझा कभी नहीं करते हैं."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "सॉफ़्टवेयर प्रयोग आँकड़ा भेजें (_S)"
+
+#~| msgid "Privacy"
+#~ msgid "Privacy Policy"
+#~ msgstr "गोपनीयता नीति"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "आपके भौगोलिक अवस्थिति निर्धारित करने के लिए प्रयोग"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "इम्पीरियल"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "मेट्रिक"
+
+#~ msgid "No input sources found"
+#~ msgstr "कोई  इनपुट स्रोत नहीं मिला"
+
+#~| msgid "Other"
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "अन्य"
+
+#~ msgid "Sorry"
+#~ msgstr "खेद है"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "अगले स्रोत में जाएँ"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "आप कुंजीपटल सेटिंग्स में इन शॉर्टकट बदल सकते हैं"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "अगले स्रोत के लिए वैकल्पिक स्विच"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "दायां + बायां आल्ट"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "अंग्रेज़ी (यूनाइटेड किंगडम)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "यूनाइटेड किंगडम"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "लॉगइन सेटिंग्स सभी उपयोगकर्ताओं द्वारा उपयोग किया जाता है जब सिस्टम में प्रवेश करते हैं"
+
+#~| msgid "Other"
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "अन्य"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#~ msgid "Select Location"
+#~ msgstr "स्थान चुनें"
+
+#~| msgid "GOK"
+#~ msgid "_OK"
+#~ msgstr "ठीक (_O)"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "चालू"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "बंद"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#~| msgid "Enabled"
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "सक्षम"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "कोई फ़ोल्डर चुनें "
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "साझा करने के लिए कोई संजाल चयनित नहीं"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "ब्लूटूथ शेयरिंग आप अन्य ब्लूटूथ सक्षम उपकरणों के साथ फ़ाइलें साझा करने की अनुमति देता है."
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "केवल विश्वसनीय उपकरण से प्राप्त करें"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "डाउनलोड फ़ोल्डर में प्राप्त फ़ाइलों को सहेजें"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "स्क्रीन हिस्सा"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "कुछ सेवाओं को कोई नेटवर्क का उपयोग की वजह से अक्षम हैं."
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "व्यक्तिगत फ़ाइल शेयरिंग आप दूसरों के साथ अपने वर्तमान नेटवर्क का उपयोग कर पर अपने "
+#~ "सार्वजनिक फ़ोल्डर साझा करने के लिए अनुमति देता है: <a href=\"dav://%s\">dav://%s</"
+#~ "a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "दूरदराज के उपयोगकर्ताओं को सुरक्षित शैल कमांड का उपयोग कर कनेक्ट करने के लिए अनुमति "
+#~ "दें.:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "दूरदराज के उपयोगकर्ताओं को देखने के लिए या को जोड़ने के द्वारा अपनी स्क्रीन पर नियंत्रण "
+#~ "की अनुमति दें: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~| msgid "Password"
+#~ msgid "Password:"
+#~ msgstr "कूटशब्द:"
+
+#~ msgid "Show Password"
+#~ msgstr "कूटशब्द दिखाएँ"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "नया कनेक्शन पहुँच के लिए जरूर पूछें"
+
+#~| msgid "Require Password"
+#~ msgid "Require a password"
+#~ msgstr "कूटशब्द की आवश्यकता होगी"
+
+#~ msgid "Bark"
+#~ msgstr "बार्क"
+
+#~ msgid "Drip"
+#~ msgstr "ड्रिप"
+
+#~ msgid "Glass"
+#~ msgstr "ग्लास"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#~ msgid "Sonar"
+#~ msgstr "सोनार"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "न्यूनतम"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "अधिकतम"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "उप वूफ़र: (_S)"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "बिना संवर्द्धित"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#~ msgid "_Profile:"
+#~ msgstr "प्रोफाइल: (_P)"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "टेस्ट स्पीकर्स (_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "पीक जाँच"
+
+#~ msgid "Device"
+#~ msgstr "युक्ति"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "स्पीकर टेस्टिंग %s के लिए"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "ध्वनि आउटपुट के लिए कोई युक्ति चुनें: (_h)"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "चयनित युक्ति के लिए सेटिंग:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "इनपुट आवाज: (_I)"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "ध्वनि इनपुट के लिए कोई युक्ति चुनें: (_h)"
+
+#~ msgid "Sound Effects"
+#~ msgstr "ध्वनि प्रभाव"
+
+#~ msgid "Built-in"
+#~ msgstr "अंतर्निर्मित"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ध्वनि वरीयता"
+
+#~ msgid "Testing event sound"
+#~ msgstr "घटना ध्वनि जाँच रहा है"
+
+#~ msgid "From theme"
+#~ msgstr "प्रसंग से"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "कोई चेतावनी ध्वनि चुनें: (_h)"
+
+#~ msgid "Stop"
+#~ msgstr "रूकें"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# libgnomeprint/gpa/gpa-media.c:241
+# #-#-#-#-#  libgnomeprint.gnome-2-2.hi.po (libgnomeprint VERSION)  #-#-#-#-#
+# libgnomeprint/gpa/gpa-media.c:241
+#~ msgid "Custom"
+#~ msgstr "पसंदीदा"
+
+#~ msgid "Screen Reader"
+#~ msgstr "स्क्रीन वाचक"
+
+#~| msgid "Screen Reader"
+#~ msgid "_Screen Reader"
+#~ msgstr "स्क्रीन वाचक (_S)"
+
+#~| msgid "Bounce Keys"
+#~ msgid "Sound Keys"
+#~ msgstr "ध्वनि कुंजियाँ"
+
+#~| msgid "Flash the window title"
+#~ msgid "Flash the _window title"
+#~ msgstr "विंडो शीर्षक को चमकाएँ (_w)"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "छोटा"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ स्क्रीन"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ स्क्रीन"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ स्क्रीन"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "लंबा"
+
+#~ msgid "Zoom"
+#~ msgstr "ज़ूम"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "रंग "
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "मानक"
+
+#~ msgid "Account _Type"
+#~ msgstr "खाता प्रकार (_T)"
+
+#~ msgid "_Verify"
+#~ msgstr "जाँचें (_V)"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "ऑनलाइन हों\n"
+#~ "ताकि एंटरप्राइज लॉगिन खाता बनाएँ."
+
+#~ msgid "Left thumb"
+#~ msgstr "बायां थंब"
+
+#~ msgid "Left middle finger"
+#~ msgstr "बाईं मध्य अंगुली"
+
+#~ msgid "Left ring finger"
+#~ msgstr "बाईं अनामिका"
+
+#~ msgid "Left little finger"
+#~ msgstr "बाईं तर्जनी"
+
+#~ msgid "Right thumb"
+#~ msgstr "दाहिना अंगूठा"
+
+#~ msgid "Right middle finger"
+#~ msgstr "दाहिनी मध्य अंगुली"
+
+#~ msgid "Right ring finger"
+#~ msgstr "दाहिनी तर्जनी"
+
+#~ msgid "Right little finger"
+#~ msgstr "दाहिनी तर्जनी"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "फिंगरप्रिंट लॉगिन सक्रिय करें"
+
+#~ msgid "_Right index finger"
+#~ msgstr "दायां तर्जनी (_R)"
+
+#~ msgid "_Left index finger"
+#~ msgstr "बाईं तर्जनी (_L)"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "आपका फिंगरप्रिंट सफलतापूर्वक सहेजा गया था. आपको अब अपने फिंगरप्रिंट रीडर के प्रयोग से "
+#~ "लॉगिन में समर्थ होना चाहिए."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+
+#~ msgid "Login History"
+#~ msgstr "लॉगिन इतिहास"
+
+#~| msgid "_New password"
+#~ msgid "_Verify New Password"
+#~ msgstr "नया कूटशब्द जाँचें (_V)"
+
+#  set the timeout value  label with correct value of timeout
+#~ msgid "Add User Account"
+#~ msgstr "उपयोगकर्ता खाता जोड़ें"
+
+#  set the timeout value  label with correct value of timeout
+#~ msgid "User Icon"
+#~ msgstr "उपयोक्ता प्रतीक"
+
+#~ msgid "Last Login"
+#~ msgstr "अंतिम लॉगिन"
+
+#~| msgid "The new password does not contain enough different characters"
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "नया कूटशब्द पुराने से काफी अलग होना चाहिए."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "कुछ अक्षर और संख्या बदलने की कोशिश करें."
+
+#~| msgid "Changing password for"
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "कूटशब्द कुछ बदलने की कोशिश करें."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "बिना आपके कूटशब्द के उपयोक्तानाम मजबूत होगा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "कूटशब्द में अपना नाम मत डालें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "कूटशब्द में कोई शब्द डालने से बचें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "सामान्य शब्द से बचें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "किसी मौजूदा शब्द के बिखरी वर्तनी का उपयोग मत करें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "अधिक संख्या डालने की कोशिश करें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "अधिक बड़े अक्षर डालने की कोशिश करें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "अधिक छोटे अक्षर डालने की कोशिश करें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "अधिक विशेष वर्ण डालने की कोशिश करें, जैसे कि चिह्न विचार."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "अक्षर, संख्या और चिह्नों के उपयोग की कोशिश करें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "वही वर्ण को दुहराने से बचें."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "समान प्रकार वर्ण को दुहराने से बचें: आपको अक्षर, संख्या और चिह्नों का मेल तैयार करना है."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 या abcd जैसे शृंखला से बचें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "अधिक अक्षर, संख्या और संकेत जोड़ें."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr "बड़े और छोटे अक्षर और एकाधिक संख्या डालें."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr "बढ़िया कूटशब्द! अधिक अक्षर, संख्या और चिह्न इसे मजबूत बनाएगा."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "सामर्थ्य: कमजोर"
+
+#~| msgid "Length:"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "सामर्थ्य: कम"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "सामर्थ्य: मध्यम"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "सामर्थ्य: अच्छा"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "सामर्थ्य: उच्च"
+
+#~ msgid "Authentication failed"
+#~ msgstr "सत्यापन असफल"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "नया कूटशब्द काफी छोटा है"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "नया कूटशब्द काफी आसान है"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "नया पुराना व नया कूटशब्द काफी समान है"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "नया दो कूटशब्द समान नहीं है."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "नया कूटशब्द को जरूर संख्या या विशेष संप्रतीक शामिल रखना चाहिये."
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "पुराना व नया कूटशब्द समान है"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "आपका कूटशब्द बदला गया है जबसे आपने आरंभ में सत्यापित किया."
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "नया कूटशब्द काफी अलग अलग अक्षरों को शामिल नहीं करता है"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "अज्ञात त्रुटि"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "आपके खाता प्रदाता के वेब पता से मेल खाना चाहिए."
+
+#~ msgid "Failed to add account"
+#~ msgstr "खाता जोड़ने में विफल"
+
+#~| msgid "Passwords do not match"
+#~ msgid "Passwords do not match."
+#~ msgstr "कूटशब्द मेल नहीं खाता है."
+
+#~ msgid "Failed to register account"
+#~ msgstr "खाता पंजीयन में विफल"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "इस डोमेन के साथ प्रमाणित करने के लिए कोई समर्थित तरीका नहीं"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "डोमेन में शामिल होने में विफल"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "वह लॉगिन नाम काम नहीं करता है.\n"
+#~ "कृपया फिर कोशिश करें."
+
+#~| msgid "Invalid password, please try again"
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "लॉगिन कूटशब्द काम नहीं करता है.\n"
+#~ "कृपया फिर कोशिश करें."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "डोमेन में लॉगिन में विफल"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "डोमेन ढूँढ़ने में असमर्थ. शायद आपने गलत वर्तनी दे दिया हो?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "आपको युक्ति के अभिगम की अनुमति नहीं है. अपने तंत्र प्रशासक से संपर्क करें."
+
+#~ msgid "The device is already in use."
+#~ msgstr "यह युक्ति पहले से प्रयोग में है."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "आंतरिक त्रुटि आयी."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "पंजीकृत फिंगरप्रिंट मिटाएँ?"
+
+#~ msgid "Done!"
+#~ msgstr "संपन्न!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' युक्ति की पहुँच नहीं ले सका"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' युक्ति पर फिंगर पकड़ नहीं आरंभ कर सका"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "कोई फिंगरप्रिंट रीडर की पहुँच नहीं ले सका"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "मदद के लिए तंत्र प्रशासक से संपर्क करें."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "फिंगरप्रिंट लॉगिन के लिए समर्थ करने में, आप अपने एक फिंगरप्रिंट को सहेजने की जरूरत है, "
+#~ "'%s' युक्ति के प्रयोग से."
+
+#~ msgid "Selecting finger"
+#~ msgstr "उंगली का चयन"
+
+#~ msgid "This Week"
+#~ msgstr "इस हफते"
+
+#~ msgid "Last Week"
+#~ msgstr "पिछले सप्ताह"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "सत्र समाप्त"
+
+#~ msgid "Session Started"
+#~ msgstr "सत्र आरंभ"
+
+#~ msgid "Please choose another password."
+#~ msgstr "कृपया अन्य कूटशब्द का चयन करें."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "अपना मौजूदा कूटशब्द फिर टाइप करें."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "आपका कूटशब्द बदला गया है"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#~ msgid "Disable image"
+#~ msgstr "छिव अक्षम करें"
+
+#~ msgid "Take a photo…"
+#~ msgstr "एक तस्वीर लें... "
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "अधिक छवियाँ के लिए ब्राउज़ करें…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s के द्वारा प्रयुक्त"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "डोमेन के इस प्रकार के स्वचालित रूप से शामिल नहीं हो सकते"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "कोई ऐसा डोमेन या रियल्म नहीं मिला"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "बतौर %s %s डोमेन पर लॉगिन नहीं कर सकता है"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "अवैध कूटशब्द, कृपया फिर कोशिश करें"
+
+#~ msgid "Other Accounts"
+#~ msgstr "अन्य खाता"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "उपयोक्ता मिटाने में विफल"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "आप अपने खुद के खाते को नष्ट नहीं कर सकते हैं."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s अभी भी लॉग इन है"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "उपयोगकर्ता का विलोपन जब वे लॉग इन कर रहे हो से तंत्र को छोड़ सकते हैं असंगत स्थिति में."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "क्या आप %s के फाइल को रखना चाहते है?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "उपयोगकर्ता खाते को हटाने के समय घर निर्देशिका, मेल स्पूल और अस्थायी फ़ाइलों को रखने की "
+#~ "संभावना है."
+
+#~ msgid "_Delete Files"
+#~ msgstr "फ़ाइल मिटाएँ (_D)"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#~ msgid "_Keep Files"
+#~ msgstr "फ़ाइल रखें (_F)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "खाता अक्षम"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "अगले लॉगिन में इसे सेट करें"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "कुछ नहीं"
+
+#~ msgid "Logged in"
+#~ msgstr "लाग्ड इन"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "खातों सेवा से संपर्क करने में विफल"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "कृपया सुनिश्चित करें कि खाता सेवा स्थापित और सक्षम है."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "बदलाब लाने के लिए,\n"
+#~ "क्लिक करें * चिह्न पर पहले"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "उपयोगकर्ता खाता बनाने के लिए,\n"
+#~ "क्लिक करें * चिह्न पर पहले"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "चयनित उपयोगकर्ता खाता को हटायें"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "चयनित उपयोगकर्ता खाता को हटाने के लिए,\n"
+#~ "क्लिक करें * चिह्न पर पहले"
+
+#, c-format
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "उपयोक्तानाम '%s' के साथ उपयोगकर्ता पहले से मौजूद है."
+
+#, c-format
+#~| msgid "The username is too long"
+#~ msgid "The username is too long."
+#~ msgstr "उपयोक्तानाम काफी लंबा है."
+
+#~| msgid "The username cannot start with a '-'"
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "उपयोक्तानाम '-' के साथ आरंभ नहीं कर सका."
+
+#~| msgid ""
+#~| "The username must only consist of:\n"
+#~| " ➣ letters from the English alphabet\n"
+#~| " ➣ digits\n"
+#~| " ➣ any of the characters '.', '-' and '_'"
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "उपयोक्तानाम  केवल a-z अक्षर, अंकों और '.', '-' और '_' में से किसी वर्ण से मिलकर "
+#~ "होना चाहिए."
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr ""
+#~ "यह करने के लिए अपने घर फ़ोल्डर नाम का इस्तेमाल किया जाएगा और बदला नहीं जा सकता."
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "ऊपर"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "नीचे"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "कुछ नहीं"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "कीस्ट्रोक भेजें"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "मॉनिटर बदलें"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "स्क्रीन पर मदद दिखाएं"
+
+#~ msgid "Output:"
+#~ msgstr "आउटपुट:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "पहलू अनुपात बनाए रखें (लेटरबॉक्स):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "एकल मॉनिटर से मानचित्रित करें"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d का %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "मानचित्रण प्रदर्शित करें"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "टैब्लेट (निरपेक्ष)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "टैबलेट वरीयताएँ"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ब्लूटूथ सेटिंग"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "नक्शे बटन…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "रिसॉल्यूशन प्रदर्शन समायोजित करें"
+
+#~| msgid "Mouse Settings"
+#~ msgid "Adjust mouse settings"
+#~ msgstr "माउस सेटिंग समायोजित करें"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ट्रैकिंग मोड"
+
+#~ msgid "Left Ring"
+#~ msgstr "बाईं अनामिका"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "बाईं अनामिका मोड #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "दाहिनी तर्जनी मोड #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "बाईं Touchstrip"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "बाईं Touchstrip मोड #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "दायाँ Touchstrip"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "दायाँ Touchstrip मोड #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "बाईं Touchring मोड स्विच करें"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "दायाँ Touchring मोड स्विच करें"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "बाईं Touchstrip मोड स्विच करें"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "दायाँ Touchstrip मोड स्विच करें"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "मोड स्विच #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "बायाँ बटन #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "दायाँ बटन #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "शीर्ष बटन #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "नीचे बटन #%d"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#~ msgid "No Action"
+#~ msgstr "कोई क्रिया नहीं"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "बाईं माउस बटन पर क्लिक करें"
+
+#~ msgid "Scroll Up"
+#~ msgstr "ऊपर स्क्रॉल करें"
+
+#~ msgid "Scroll Right"
+#~ msgstr "दाएँ स्क्रॉल करें"
+
+#~ msgid "Top Button"
+#~ msgstr "शीर्ष बटन"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "भर्बोस विधि सक्रिय करें"
+
+#~ msgid "Show the overview"
+#~ msgstr "सारांश दिखाएँ"
+
+#~ msgid "Search for the string"
+#~ msgstr "स्ट्रिंग के लिए खोजें"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "संभव पैनल के नामों की सूची और बाहर निकलें"
+
+#~ msgid "Show help options"
+#~ msgstr "मदद विकल्प दिखाएँ"
+
+#~ msgid "Panel to display"
+#~ msgstr "दिखाने के लिए पटल"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- सेटिंग्स"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "'%s --help' को उपलब्ध कमांड लाइन विकल्प की पूरी सूची दिखाने के लिए चलाएँ.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "उपलब्ध पैनल:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "निजी"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "हार्डवेयर"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "सिस्टम"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "नई युक्ति सेटअप करें"
 
-#~ msgid "Connection"
-#~ msgstr "कनेक्शन"
-
 #~ msgid "Paired"
 #~ msgstr "युग्म"
-
-#~ msgid "Type"
-#~ msgstr "प्रकार"
 
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "माउस & टचपैड सेटिंग"
 
-#~ msgid "Sound Settings"
-#~ msgstr "ध्वनि विन्यास"
-
 #~ msgid "Send Files…"
 #~ msgstr "फाइल भेजें... "
-
-#~ msgid "Visibility"
-#~ msgstr "दृश्यता"
 
 #~ msgid "Visibility of “%s”"
 #~ msgstr "दृश्यता “%s” का"
@@ -7510,12 +8387,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "_City:"
 #~ msgstr "शहर: (_C)"
 
-#~ msgid "_Network Time"
-#~ msgstr "संजाल समय (_N)"
-
-#~ msgid ":"
-#~ msgstr ":"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "समय एक घंटे आगे निर्धारित करें."
 
@@ -7550,12 +8421,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "180 Degrees"
 #~ msgstr "180 डिग्रीज़"
 
-#~ msgid "Monitor"
-#~ msgstr "मॉनीटर"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "प्राथमिक प्रदर्शन बदलने के लिए खींचें."
-
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
 #~ "placement."
@@ -7583,12 +8448,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "नोट: रिसॉल्यूशन विकल्पों को सीमित कर सकते हैं"
-
-#~ msgid "_Detect Displays"
-#~ msgstr "प्रदर्शक का पता लगायें (_D)"
-
-#~ msgid "Install Updates"
-#~ msgstr "अद्यतन संस्थापित करें"
 
 #~ msgid "System Up-To-Date"
 #~ msgstr "सिस्टम अद्यतन"
@@ -7672,9 +8531,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Share Public Folder On This Network"
 #~ msgstr "इस नेटवर्क पर सार्वजनिक फ़ोल्डर साझा करें "
-
-#~ msgid "Remote View"
-#~ msgstr "रिमोट दृश्य"
 
 #~ msgid "Approve All Connections"
 #~ msgstr "सभी कनेक्शनों को स्वीकृत करें"
@@ -7781,9 +8637,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "Large"
 #~ msgstr "विशाल"
 
-#~ msgid "Add account"
-#~ msgstr "खाता जोड़ें"
-
 #~ msgid "_Local Account"
 #~ msgstr "स्थानीय खाता (_L)"
 
@@ -7796,12 +8649,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "C_ontinue"
 #~ msgstr "जारी रखें (_o)"
 
-#~ msgid "Previous Week"
-#~ msgstr "पिछला सप्ताह "
-
-#~ msgid "Next Week"
-#~ msgstr "अगले सप्ताह"
-
 #~ msgid "Next week"
 #~ msgstr "अगला सप्ताह"
 
@@ -7813,12 +8660,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Enable this account"
 #~ msgstr "खाता सक्रिय करें"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "कूटशब्द की पुष्टि करें (_o)"
-
-#~ msgid "Generate a password"
-#~ msgstr "कूटशब्द उत्पन्न करें"
 
 # #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
 # gnome-session/logout.c:266
@@ -7963,18 +8804,12 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "Change the background"
 #~ msgstr "पृष्ठभूमि बदलें"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "ब्लूटूथ सेटिंग विन्यस्त करें"
-
 #~ msgid "Browse Files..."
 #~ msgstr "फाइल ब्रॉउज करें..."
 
 #~ msgctxt "Power"
 #~ msgid "Bluetooth"
 #~ msgstr "ब्लूटूथ"
-
-#~ msgid "Create virtual device"
-#~ msgstr "वर्चुअल मशीन बनाएँ"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "प्रदर्शन के लिए उपलब्ध प्रोफाइल"
@@ -8065,12 +8900,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "Unspecified"
 #~ msgstr "अविशिष्ट"
 
-#~ msgid "Select a language"
-#~ msgstr "भाषा चुनें"
-
-#~ msgid "_Select"
-#~ msgstr "चुनें (_S)"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "दिनांक और समय वरीयताओं पैनल"
 
@@ -8120,9 +8949,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Set your mouse and touchpad preferences"
 #~ msgstr "अपने माउस और टचपैड की वरीयताएँ नियत करें"
-
-#~ msgid "Network settings"
-#~ msgstr "नेटवर्क सेटिंग्स"
 
 #~ msgid "Network;Wireless;IP;LAN;Proxy;"
 #~ msgstr "नेटवर्क;वायरलेस;आईपी;लैन;प्रॉक्सी;"
@@ -8226,9 +9052,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "Paused"
 #~ msgstr "ठहरा"
 
-#~ msgid "Change printer settings"
-#~ msgstr "प्रिंटर सेटिंग्स बदलें"
-
 #~ msgid "Manufacturers"
 #~ msgstr "उत्पादक:"
 
@@ -8281,9 +9104,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "Remove Language"
 #~ msgstr "भाषा हटाएँ"
 
-#~ msgid "Install languages..."
-#~ msgstr "भाषा संस्थापित करें..."
-
 #~ msgid "Select a region (change will be applied the next time you log in)"
 #~ msgstr "क्षेत्र चुनें (अगली बार जब आप लॉगइन करेगे तब परिवर्तन लागु होगा)"
 
@@ -8307,10 +9127,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~| msgid "Input source:"
 #~ msgid "Move Input Source Up"
 #~ msgstr "इनपुट स्रोत ऊपर खिसकाएँ"
-
-#~| msgid "Keyboard Layout Options"
-#~ msgid "Show Keyboard Layout"
-#~ msgstr "कुंजीपटल लेआउट दिखाएँ"
 
 #~ msgid "Ctrl+Alt+Space"
 #~ msgstr "Ctrl+Alt+Space"
@@ -8336,9 +9152,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "Brightness & Lock"
 #~ msgstr "चमकीलापन और लॉक"
 
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "स्क्रीन चमकीलापन और लॉक सेटिंग्स"
-
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "चमकीलापन;लॉक;डिम;रिक्त;मॉनिटर;"
 
@@ -8350,9 +9163,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Locations..."
 #~ msgstr "स्थान..."
-
-#~ msgid "Lock"
-#~ msgstr "बंद करें"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "डिबगिंग कोड सक्रिय करें"
@@ -8368,9 +9178,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Sound Output Volume"
 #~ msgstr "ध्वनि आउटपुट आवाज़"
-
-#~ msgid "Microphone Volume"
-#~ msgstr "माइक्रोफ़ोन वॉल्यूम"
 
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "ध्वनि वरीयता आरंभ करने में विफल: %s"
@@ -8478,9 +9285,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "Take a screenshot"
 #~ msgstr "स्क्रीनशॉट लें"
 
-#~ msgid "Shortcut"
-#~ msgstr "शार्टकट"
-
 #~ msgid "_Right-handed"
 #~ msgstr "दाहिने हाथ से काम करने वाला (_R)"
 
@@ -8489,10 +9293,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Sh_ow position of pointer when the Control key is pressed"
 #~ msgstr "Control कुंजी दबाए जाने पर प्वाइंटर की स्थिति दिखाएँ (_o)"
-
-#~| msgid "_Acceleration:"
-#~ msgid "A_cceleration:"
-#~ msgstr "त्वरक: (_c)"
 
 #~ msgid "_Sensitivity:"
 #~ msgstr "संवेदनशीलता:  (_S)"
@@ -8507,9 +9307,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "Drag Threshold"
 #~ msgstr "ड्रैग थ्रेशोल्ड"
 
-#~ msgid "Double-Click Timeout"
-#~ msgstr "दोहरा क्लिक टाइमआउट"
-
 #~ msgid "_Timeout:"
 #~ msgstr "टाइमआउट: (_T)"
 
@@ -8518,9 +9315,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "टचपैड के साथ माउस क्लिक सक्रिय करें (_m)"
-
-#~ msgid "Scrolling"
-#~ msgstr "स्क्रॉल कर रहे"
 
 # #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
 # gtk/gtkinputdialog.c:238
@@ -8588,9 +9382,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "affect how much power is used"
 #~ msgstr "प्रभावित कितना शक्ति का इस्तेमाल किया है"
 
-#~ msgid "_Search by Address"
-#~ msgstr "पते द्वारा खोजें (_S)"
-
 #~ msgid ""
 #~ "FirewallD is not running. Network printer detection needs services mdns, "
 #~ "ipp, ipp-client and samba-client enabled on firewall."
@@ -8607,9 +9398,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgctxt "printer type"
 #~ msgid "Network"
 #~ msgstr "संजाल"
-
-#~ msgid "Device types"
-#~ msgstr "उपकरण प्रकार"
 
 #~ msgid "Automatic configuration"
 #~ msgstr "स्वचालित विन्यास"
@@ -8651,9 +9439,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "View and edit keyboard layout options"
 #~ msgstr "कुंजीपटल लेआउट विकल्प संपादित करें और देखें"
 
-#~ msgid "Reset to De_faults"
-#~ msgstr "डिफ़ॉल्ट में रीसेट करें (_f)"
-
 #~ msgid ""
 #~ "Replace the current keyboard layout settings with the\n"
 #~ "default settings"
@@ -8663,12 +9448,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Layouts"
 #~ msgstr "अभिन्यास"
-
-#~ msgid "Layout"
-#~ msgstr "अभिन्यास"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "विन्यस्त करने के लिए कोई युक्ति चुनें: (_h)"
 
 #~ msgid "Dasher"
 #~ msgstr "डैशर"
@@ -8685,12 +9464,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~| msgid "Text size:"
 #~ msgid "_Text size:"
 #~ msgstr "पाठ आकार: (_T)"
-
-#~ msgid "Increase size:"
-#~ msgstr "आकार बढ़ाएँ:"
-
-#~ msgid "Decrease size:"
-#~ msgstr "आकार घटाएँ:"
 
 #~ msgctxt "universal access, seeing"
 #~ msgid "Display"
@@ -8724,10 +9497,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Choose a generated password"
 #~ msgstr "उत्पन्न किया कूटशब्द बदलें"
-
-#~| msgid "Account type"
-#~ msgid "Account _type"
-#~ msgstr "खाता प्रकार (_t)"
 
 #~ msgid "More choices..."
 #~ msgstr "अधिक पसंद..."
@@ -8764,12 +9533,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgstr ""
 #~ "URL जहाँ से अधिक डेस्कटॉप प्रसंग पाना है. यदि रिक्त स्ट्रिंग पर सेट किया जाता है कड़ी "
 #~ "प्रकट नहीं होगा."
-
-#~ msgid "Unlock"
-#~ msgstr "खोलें"
-
-#~ msgid "Locked"
-#~ msgstr "तालाबंद"
 
 #, fuzzy
 #~ msgid ""
@@ -8923,9 +9686,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 #~ msgid "Use default layout in new windows"
 #~ msgstr "प्रत्येक विंडो हेतु पृथक समूह (_l)"
 
-#~ msgid "Speed"
-#~ msgstr "गति"
-
 #~ msgid "Battery discharging"
 #~ msgstr "बैटरी डिसचार्जिंग"
 
@@ -8946,9 +9706,6 @@ msgstr "वरीयताएँ;सेटिंग्स;"
 
 #~ msgid "Shutdown"
 #~ msgstr "बंद करें"
-
-#~ msgid "Mute"
-#~ msgstr "मौन"
 
 #~ msgid "Keyboard;Mouse;a11y;Accessibility;"
 #~ msgstr "Keyboard;Mouse;a11y;Accessibility;"

--- a/po/hi.po~
+++ b/po/hi.po~
@@ -1,0 +1,8970 @@
+# translation of gnome-control-center.master.hi.po to Hindi
+# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER.
+#
+# Ravishankar Shrivastava <raviratlami@yahoo.com>, 2003, 2004.
+# Rajesh Ranjan <rranjan@redhat.com>, 2005, 2006, 2008, 2009.
+# Rajesh Ranjan <rajesh672@gmail.com>, 2009.
+# chandankumar(ciypro) <chandankumar.093047@gmail.com>, 2012, 2013.
+# rajesh <rajeshkajha@yahoo.com>, 2012, 2013, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.master.hi\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-09-19 18:34+0000\n"
+"PO-Revision-Date: 2014-09-23 15:25+0630\n"
+"Last-Translator: rajesh <rajesh>\n"
+"Language-Team: Hindi <kde-i18n-doc@kde.org>\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "पृष्ठभूमि"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "पूरे दिन परिवर्तन"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+#| msgid "Lock screen"
+msgid "Lock Screen"
+msgstr "स्क्रीन पर ताला लगाएँ"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "टाइल"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "छोटा-बड़ा करें"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "मध्य"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "मापक"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "भरें"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "स्पैन"
+
+#  Create the file chooser dialog stuff here
+#: ../panels/background/cc-background-chooser-dialog.c:438
+msgid "Wallpapers"
+msgstr "वालपेपर्स"
+
+#: ../panels/background/cc-background-chooser-dialog.c:447
+msgid "Colors"
+msgstr "रंग"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:485
+msgid "Select Background"
+msgstr "पृष्ठभूमि चुनें"
+
+#: ../panels/background/cc-background-chooser-dialog.c:514
+msgid "Pictures"
+msgstr "तस्वीर"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:546
+#| msgid "No input sources found"
+msgid "No Pictures Found"
+msgstr "कोई  तस्वीर नहीं मिला"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:564
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "घर"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:576
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "आप अपने %s फ़ोल्डर में छवि जोड़ सकते हैं और वे यहाँ दिखाए जाएँगे"
+
+#: ../panels/background/cc-background-chooser-dialog.c:583
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1537
+#: ../panels/display/cc-display-panel.c:1976
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1247
+#: ../panels/network/net-device-wifi.c:1440
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/cc-printers-panel.c:1947
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+#: ../panels/user-accounts/um-photo-dialog.c:95
+#: ../panels/user-accounts/um-photo-dialog.c:222
+#: ../panels/user-accounts/um-user-panel.c:513
+msgid "_Cancel"
+msgstr "रद्द करें (_C)"
+
+#: ../panels/background/cc-background-chooser-dialog.c:584
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:97
+msgid "Select"
+msgstr "चुनें"
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "बहुत आकार"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "कोई डेस्कटॉप पृष्ठभूमि"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "मौजूदा पृष्ठभूमि"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "एक वॉलपेपर या तस्वीर का उपयोग करके अपनी पृष्ठभूमि छवि बदलें"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "वॉलपेपर; स्क्रीन; डेस्कटॉप;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "ब्लूटूथ अक्षम है"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "कोई ब्लूटूथ एडाप्टर मौजूद नहीं मिला"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "ब्लूटूथ हार्डवेयर स्विच से अक्षम है"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+msgid "Bluetooth"
+msgstr "ब्लूटूथ"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "ब्लूटूथ को चालू और बंद करें और अपने उपकरणों को जोड़ें"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "वर्ग के ऊपर अपने अंशांकन युक्ति को रखें और 'आरंभ' दवाएँ "
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+"अपने अंशांकन युक्ति को अंशांकन स्थिति में खिसकाएं और 'जारी रखें' दवाएँ "
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr "अपने अंशांकन युक्ति को सतह स्थिति में खिसकाएं और 'जारी रखें' दवाएँ "
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "लैपटॉप ढक्कन बंद करो"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "एक आंतरिक त्रुटि आई है जो बरामद नहीं किया जा सकता है."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "अंशांकन के लिए आवश्यक उपकरण नहीं स्थापित कर रहे हैं."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "प्रोफाइल उत्पन्न नहीं किया जा सका."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "लक्ष्य श्वेतबिंदु प्राप्य नहीं किया गया."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "पूर्ण!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "विन्यास विफल!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "आप अंशांकन युक्ति निकाल सकते हैं."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "जारी रखने के दौरान अंशांकन युक्ति को परेशान नहीं करें"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "लैपटॉप स्क्रीन"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "अंतर्निर्मित वेब कैमरा"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s मॉनीटर"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s स्कैनर"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s कैमरा"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s मुद्रक"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s वेबकैम"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s के लिए रंग प्रबंधन सक्रिय करें"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s के लिए रंग प्रोफाइल दिखाएं"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+msgid "Not calibrated"
+msgstr "कैलिब्रेट नहीं किया गया"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "तयशुदा: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "कलरस्पेस: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "टेस्ट प्रोफ़ाइल: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "आईसीसी प्रोफाइल फ़ाइल का चयन करें"
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "आयात करें (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "समर्थित आईसीसी प्रोफाइल"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "सभी फ़ाइलें"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "स्क्रीन"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+#| msgid "Failed to apply configuration: %s"
+msgid "Failed to upload file: %s"
+msgstr "फ़ाइल अपलोड करने में विफल: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "इन प्रोफ़ाइल को इसमें अद्यतन किया जा रहा है:"
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "इस URL को लिखें."
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+"इस कंप्यूटर को फिर आरंभ करें और अपने सामान्य ऑपरेटिंग तंत्र को बूट करें."
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+"अपने ब्राउज़र में इस यूआरएल को टाइप करें ताकि प्रोफ़ाइल डाउनलोड और संस्थापित "
+"किया जा सके."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "प्रोफ़ाइल सहेजें"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "सहेजें (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "चयनित युक्ति के लिए एक रंग प्रोफ़ाइल बनाएँ"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"मापन यंत्र का पता नहीं लगा है. कृपया जाचें कि यह चालू है और सही रूप से "
+"कनेक्टेड है."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "माप उपकरण प्रिंटर प्रोफाइलिंग का समर्थन नहीं करता है."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "युक्ति प्रकार मौजूदा में समर्थित नहीं है."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "मानक स्थान "
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "टेस्ट प्रोफ़ाइल"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "स्वचालित "
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "कम विशेषता"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "मध्यम विशेषता"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "उच्च गुणवत्ता"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "मूलभूत RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "तयशुदा CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "डिफ़ॉल्ट ग्रे"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "विक्रेता द्वारा दी गयी कारखाने अंशांकन डेटा"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "पूर्ण स्क्रीन सुधार प्रदर्शन इस प्रोफाइल के साथ संभव नहीं है "
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "यह युक्ति एक प्रोफाइल ज्यादा देर तक सही नहीं है."
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "केलिब्रेशन प्रदर्शित करें"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr "रद्द करें"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "प्रारंभ"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "पुनरारंभ"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "संपन्न"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "स्क्रीन कैलिब्रेशन"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"अंशांकन एक प्रोफाइल को पैदा करेगा जो कि आप रंग का उपयोग करके अपनी स्क्रीन का "
+"प्रबंधन कर "
+"सकते हैं.अब आप अंशांकन पर ज्यादा समय खर्च करते हैं, रंग प्रोफाइल की गुणवत्ता "
+"बेहतर होगी."
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "अंशांकन के दौरान आप अपने कंप्यूटर का उपयोग नहीं कर सकते हैं."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "गुणवत्ता"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "अनुमानित समय"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "अंशांकन गुणवत्ता"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "अंशांकन का उपयोग करने के लिए सेंसर डिवाइस का चयन करें"
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "कैलिब्रेशन युक्ति "
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "जुड़ा हुआ प्रदर्शन के प्रकार का चयन करें."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "प्रदर्शक प्रकार "
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"प्रदर्शन लक्ष्य श्वेत बिंदु का चयन करें. D65 रोशन के लिए अधिकांश प्रदर्शन को "
+"कैलिब्रेटेड किया "
+"जाना चाहिए."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "प्रोफ़ाइल श्वेतबिंदु"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+" चमक को प्रदर्शन के आधार पर सेट करें जो आप के लिए विशिष्ट है.इस चमक के स्तर "
+"पर रंग प्रबंधन "
+"सबसे सटीक होगा."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"वैकल्पिक रूप से, आप इस डिवाइस के लिए अन्य प्रोफाइल के साथ इस्तेमाल किया चमक "
+"स्तर का "
+"उपयोग कर सकते हैं."
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "दृश्य चमक"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"आप अलग कंप्यूटर पर एक रंग प्रोफ़ाइल का उपयोग कर, या भी अलग प्रकाश व्यवस्था की "
+"स्थिति के "
+"लिए प्रोफाइल बना सकते हैं."
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "प्रोफाइल नाम:"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "प्रोफ़ाइल नाम"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "प्रोफ़ाइल सफलतापूर्वक बनाई गई!"
+
+#: ../panels/color/color.ui.h:22
+#| msgid "Add profile"
+msgid "Copy profile"
+msgstr "प्रोफाइल की नक़ल लें"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "लेखनयोग्य मीडिया की जरूरत"
+
+#: ../panels/color/color.ui.h:24
+#| msgid "Add profile"
+msgid "Upload profile"
+msgstr "प्रोफाइल अपलोड करें"
+
+#: ../panels/color/color.ui.h:25
+#| msgid "Add new connection"
+msgid "Requires Internet connection"
+msgstr "इंटरनेट कनेक्शन जोड़ें"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">ग्नू / लिनक्स</a>, <a href=\"osx\">एप्पल ओएस एक्स </a>और <a "
+"href=\"windows\">माइक्रोसॉफ्ट विंडोज </a>उपयोगी सिस्टम पर प्रोफ़ाइल का उपयोग "
+"करने के "
+"लिए आप कैसे इन निर्देशों को खोज पाते है."
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+msgid "Summary"
+msgstr "सारांश"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "फ़ाइल आयात करें…"
+
+#: ../panels/color/color.ui.h:30
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr "जोड़ें (_A)"
+
+#: ../panels/color/color.ui.h:31
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"समस्याओं का पता चला. प्रोफ़ाइल सही ढंग से काम नहीं कर रहा.<a href=\"\">विवरण "
+"दिखाएँ."
+"</a>"
+
+#: ../panels/color/color.ui.h:32
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"प्रत्येक युक्ति को रंग प्रबंधित होने के लिए रंग प्रोफ़ाइल के अद्यतन की जरुरत "
+"है. "
+
+#: ../panels/color/color.ui.h:33
+msgid "Learn more"
+msgstr "अधिक जानें"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more about color management"
+msgstr "रंग प्रबंधन के बारे में अधिक जानें"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/color/color.ui.h:35
+msgid "Set for all users"
+msgstr "सभी उपयोगकर्ताओं के लिए सेट करें"
+
+#: ../panels/color/color.ui.h:36
+msgid "Set this profile for all users on this computer"
+msgstr "इस कंप्यूटर पर सभी उपयोगकर्ताओं के लिए इस प्रोफ़ाइल को सेट करें"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#: ../panels/color/color.ui.h:37
+msgid "Enable"
+msgstr "सक्रिय करें"
+
+#: ../panels/color/color.ui.h:38
+msgid "Add profile"
+msgstr "जोड़ें प्रोफाइल"
+
+#: ../panels/color/color.ui.h:39
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Calibrate…"
+msgstr "कैलिब्रेट…"
+
+#: ../panels/color/color.ui.h:40
+msgid "Calibrate the device"
+msgstr "युक्ति जांच"
+
+#: ../panels/color/color.ui.h:41
+msgid "Remove profile"
+msgstr "प्रोफ़ाइल हटायें"
+
+#: ../panels/color/color.ui.h:42
+msgid "View details"
+msgstr "विवरण देखें"
+
+#: ../panels/color/color.ui.h:43
+msgid "Unable to detect any devices that can be color managed"
+msgstr "उपकरण जिसमे रंग प्रबंधन हो सकता हैं का पता लगाने में असमर्थ"
+
+#: ../panels/color/color.ui.h:44
+msgid "LCD"
+msgstr "एलसीडी"
+
+#: ../panels/color/color.ui.h:45
+msgid "LED"
+msgstr "एलईडी"
+
+#: ../panels/color/color.ui.h:46
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:47
+msgid "Projector"
+msgstr "प्रोजेक्टर"
+
+#: ../panels/color/color.ui.h:48
+msgid "Plasma"
+msgstr "प्लासमा"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL बैकलाइट)"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED बैकलाइट)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (white LED backlight)"
+msgstr "LCD (सफेद LED बैकलाइट)"
+
+#: ../panels/color/color.ui.h:52
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "वाइड गैमट LCD (CCFL बैकलाइट)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "वाइड गैमट LCD (RGB LED बैकलाइट)"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "उच्च"
+
+#: ../panels/color/color.ui.h:55
+msgid "40 minutes"
+msgstr "40 मिनट"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 मिनट"
+
+#: ../panels/color/color.ui.h:58
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "कम"
+
+#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 मिनट"
+
+#: ../panels/color/color.ui.h:60
+msgid "Native to display"
+msgstr "दिखाने के लिए पटल "
+
+#: ../panels/color/color.ui.h:61
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (मुद्रण और प्रकाशन)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:63
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (फोटोग्राफी और ग्राफिक्स)"
+
+#: ../panels/color/color.ui.h:64
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "रंग"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "अपने उपकरणों जैसे प्रदर्शन , कैमरा, या प्रिंटर के रंग का आशंकन करें"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "रंग;आईसीसी;प्रोफाइल;जांच;प्रिंटर;प्रदर्शन;"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:684
+msgid "United States"
+msgstr "यूनाइटेड स्टेट्स"
+
+#: ../panels/common/cc-common-language.c:685
+msgid "Germany"
+msgstr "जर्मनी"
+
+#: ../panels/common/cc-common-language.c:686
+msgid "France"
+msgstr "फ्रांस"
+
+#: ../panels/common/cc-common-language.c:687
+msgid "Spain"
+msgstr "स्पैन"
+
+#: ../panels/common/cc-common-language.c:688
+msgid "China"
+msgstr "चीन"
+
+#: ../panels/common/cc-common-language.c:758
+msgid "Other…"
+msgstr "अन्य..."
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr "अधिक…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "कोई भाषाएँ नहीं मिला"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "भाषा"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "संपन्न (_D)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+#| msgid "%a %l:%M %p"
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+#| msgid "%a %l:%M %p"
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "जनवरी"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "फरवरी"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "मार्च"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "अप्रैल"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "मई"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "जून"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "जुलाई"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "अगस्त"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "सितम्बर"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "अक्टूबर"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "नवम्बर"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "दिसम्बर"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "तिथि व समय"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "घंटा"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+#| msgid "minute"
+#| msgid_plural "minutes"
+msgid "Minute"
+msgstr "मिनट"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "दिन"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "माह"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "वर्ष"
+
+#: ../panels/datetime/datetime.ui.h:21
+#| msgid "Time"
+msgid "Time Zone"
+msgstr "समय क्षेत्र"
+
+#: ../panels/datetime/datetime.ui.h:22
+#| msgid "Search for the string"
+msgid "Search for a city"
+msgstr "एक शहर के लिए खोजें"
+
+#: ../panels/datetime/datetime.ui.h:23
+#| msgid "Date & Time"
+msgid "Automatic _Date & Time"
+msgstr "स्वचालित दिनांक व समय"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr "इंटरनेट कनेक्शन चाहिए"
+
+#: ../panels/datetime/datetime.ui.h:25
+#| msgid "Automatic _Connect"
+msgid "Automatic Time _Zone"
+msgstr "स्वचालित समय क्षेत्र (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:26
+#| msgid "Date & Time"
+msgid "Date & _Time"
+msgstr "दिनांक व समय (_T)"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr "समय क्षेत्र (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:28
+#| msgid "Formats"
+msgid "Time _Format"
+msgstr "समय प्रारूप (_F)"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24-घंटे"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "पूर्वाह्न/अपराह्न"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "दिनांक और समय समय क्षेत्र सहित बदलें"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "घड़ी;समय क्षेत्र;स्थान;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "सिस्टम का समय और दिनांक सेटिंग्स बदलें"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"समय या दिनांक सेटिंग्स को बदलने के लिए, आपको प्रमाणित करने की जरूरत है."
+
+#: ../panels/display/cc-display-panel.c:487
+#| msgid "Close"
+msgid "Lid Closed"
+msgstr "Lid बंद किया गया"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+#| msgid "Mirrored Displays"
+msgid "Mirrored"
+msgstr "मिरर किया"
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2145
+#| msgid "Primary _button"
+msgid "Primary"
+msgstr "प्राथमिक"
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "बंद"
+
+#: ../panels/display/cc-display-panel.c:497
+#| msgid "Secondary color"
+msgid "Secondary"
+msgstr "द्वितीयक"
+
+#: ../panels/display/cc-display-panel.c:1533
+#| msgid "Mirrored Displays"
+msgid "Arrange Combined Displays"
+msgstr "संयुग्मित प्रदर्शक की व्यवस्था करें"
+
+#: ../panels/display/cc-display-panel.c:1539
+#: ../panels/display/cc-display-panel.c:1979
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "लागू करें (_A)"
+
+#: ../panels/display/cc-display-panel.c:1560
+msgid "Drag displays to rearrange them"
+msgstr "उन्हें फिर व्यवस्थित करने के लिए प्रदर्शन खींचें"
+
+#: ../panels/display/cc-display-panel.c:2081
+msgid "Size"
+msgstr "आकार"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2094
+msgid "Aspect Ratio"
+msgstr "पहलू अनुपात"
+
+#: ../panels/display/cc-display-panel.c:2115
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "रेज़ोल्यूशन"
+
+#: ../panels/display/cc-display-panel.c:2146
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "शीर्ष बार दिखाएँ और इस प्रदर्शन के लिए गतिविधि सारांश"
+
+#: ../panels/display/cc-display-panel.c:2152
+#| msgid "Secondary click delay"
+msgid "Secondary Display"
+msgstr "द्वितीयक प्रदर्शन"
+
+#: ../panels/display/cc-display-panel.c:2153
+msgid "Join this display with another to create an extra workspace"
+msgstr ""
+"अतिरिक्त कार्यस्थान बनाने के लिए दूसरों के साथ इस प्रदर्शन में शामिल हों"
+
+#: ../panels/display/cc-display-panel.c:2160
+#| msgid "Orientation"
+msgid "Presentation"
+msgstr "प्रस्तुति"
+
+#: ../panels/display/cc-display-panel.c:2161
+msgid "Show slideshows and media only"
+msgstr "स्लाइडशो और मीडिया केवल दिखाएँ"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2166
+msgid "Mirror"
+msgstr "मिरर"
+
+#: ../panels/display/cc-display-panel.c:2167
+msgid "Show your existing view on both displays"
+msgstr "मौजूदा दृश्य दोनों प्रदर्शन पर दिखाएँ"
+
+#: ../panels/display/cc-display-panel.c:2173
+#| msgid "_Turn On"
+msgid "Turn Off"
+msgstr "बन्द करें"
+
+#: ../panels/display/cc-display-panel.c:2174
+#| msgid "Panel to display"
+msgid "Don't use this display"
+msgstr "इस प्रदर्शन का उपयोग मत करें"
+
+#: ../panels/display/cc-display-panel.c:2383
+msgid "Could not get screen information"
+msgstr "स्क्रीन सूचना नहीं पा सका"
+
+#: ../panels/display/cc-display-panel.c:2414
+#| msgid "Mirrored Displays"
+msgid "_Arrange Combined Displays"
+msgstr "संयुग्मित प्रदर्शक की व्यवस्था करें (_A)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "प्रदर्शक"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr "जुड़े हुए मॉनिटर और प्रोजेक्टर का उपयोग करने के लिए चुनें"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "पैनल;प्रोजेक्टर;xrandr;स्क्रीन;रिज़ॉल्यूशन;रिफ्रेश;मॉनिटर;"
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr "Wayland"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "अज्ञात"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/session-properties-capplet.c:303
+# gnome-session/session-properties-capplet.c:376
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:84 libgnomeui/gnome-app-helper.h:516
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-bit"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/session-properties-capplet.c:303
+# gnome-session/session-properties-capplet.c:376
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-app-helper.c:84 libgnomeui/gnome-app-helper.h:516
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr "%d-bit"
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr "पूछें कि क्या करना है"
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr "कुछ मत करें"
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr "फ़ोल्डर खोलें"
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr "अन्य मीडिया"
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr "ऑडियो सीडी के लिए अनुप्रयोग चुनें"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr "वीडियो सीडी के लिए अनुप्रयोग चुनें"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr "अनुप्रयोग को चालू करने के लिए चयन करे जब एक म्यूजिक प्लयेर जुड़ा हो"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr "अनुप्रयोग को चालू करने के लिए चयन करे जब एक कैमरा जुड़ा हो"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr "सॉफ़्टवेयर सीडी के लिए अनुप्रयोग चुनें"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr "ऑडियो डीवीडी"
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr "खाली Blu-Ray डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr "खाली सीडी डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr "रिक्त डीवीडी डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr "खाली HD DVD डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr "Blu-ray वीडियो डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr "ई-बुक रीडर"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr "HD डीवीडी वीडियो डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr "पिक्चर सीडी"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr "सुपर वीडियो सीडी"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr "वीडियो सीडी"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr "विंडोज़ सॉफ़्टवेयर"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1932
+msgid "Section"
+msgstr "विभाग"
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "सारांश"
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "तयशुदा अनुप्रयोग"
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "हटाने योग्य मीडिया"
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr "संस्करण %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:46
+msgid "Details"
+msgstr "विवरण"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "अपने प्रणाली के बारे में सूचना देखें"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"युक्ति;सिस्टम;जानकारी;स्मृति;प्रोसेसर;संस्करण;डिफ़ॉल्ट;अनुप्रयोग;अनुशंसित;सीडी"
+";डीवीडी;यूएसबी;"
+"ऑडियो;वीडियो;डिस्क;हटाने योग्य;मीडिया;स्वतः चालू;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "चुनें कैसे अन्य मीडिया को नियंत्रित किया जाना चाहिए"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "क्रिया (_A):"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "प्रकार: (_T)"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "युक्ति नाम"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "मेमोरी"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "प्रोसेसर"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "आधार प्रणाली"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "डिस्क"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "गणना में..."
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "आलेखी"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "वर्चुअलाइजेशन"
+
+#: ../panels/info/info.ui.h:13
+#| msgid "Checking for Updates"
+msgid "Check for updates"
+msgstr "अद्यतन के लिए जाँचें"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "वेब (_W)"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "मेल (_M)"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "पंचांग (_C)"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "संगीत (_u)"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "वीडियो (_V)"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "फोटो (_P)"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "चुनें कैसे मीडिया को नियंत्रित किया जाना चाहिए"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "सीडी ऑडियो (_a)"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "_DVD वीडियो"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "संगीत प्लेयर (_M)"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "सॉफ्टवेयर (_S)"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "अन्य मीडिया... (_O)"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr "मीडिया प्रवेश पर कभी प्रांप्ट मत करें या प्रोग्राम आरंभ मत करें (_N)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "ध्वनि और मीडिया"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "आवाज मौन"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "आवाज कम करें"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "आवाज बढ़ाएँ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "मीडिया प्लेयर लॉन्च करें"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "बजाएँ (या बजाएँ/ठहरें)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "प्लेबैक रोकें"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "प्लेबैक रोकें"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "पिछला ट्रैक"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "अगला ट्रैक"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "बाहर करें"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "टंकित कर रहा है"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "अगले इनपुट स्रोत के लिए स्विच करें"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "पिछले इनपुट स्रोत पर जाएँ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "लांचर"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "मदद ब्राउज़र लॉन्च करें"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "सेटिंग्स"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "कैलकुलेटर लॉन्च करें"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "ई-मेल क्लाइंट लॉन्च करें"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "वेब ब्राउज़र चलाएँ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "घर फ़ोल्डर"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ढूंढें"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "स्क्रीनशॉट"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "$PICTURES में एक स्क्रीनशॉट सहेजें"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr " $PICTURES में विंडो का स्क्रीनशॉट सहेजें"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr " $PICTURES में किसी क्षेत्र का एक स्क्रीनशॉट सहेजें"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "क्लिपबोर्ड पर स्क्रीनशॉट की नकल करें"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "क्लिपबोर्ड पर विंडो का स्क्रीनशॉट की नकल बनाएं"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "क्लिपबोर्ड पर क्षेत्र की स्क्रीनशॉट की नकल बनाएं"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "छोटा स्क्रीनकास्ट रिकॉर्ड करें"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "सिस्टम"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "लॉग आउट"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "स्क्रीन पर ताला"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "सार्वभौमिक पहुँच"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "जूम चालू या बंद करें"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "बडे रूप में दिखाएँ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "छोटे रूप में दिखाएँ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "स्क्रीन रीडर को चालू या बंद करें"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "ऑन स्क्रीन कुंजीपटल के चालू या बंद करें"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "पाठ का आकार बढ़ाएँ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "पाठ का आकार घटाएँ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "अधिक कंट्रास्ट चालू या बंद करें"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1218
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+msgid "Disabled"
+msgstr "अक्षम"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "वैकल्पिक वर्ण कुँजी"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "लेखन कुंजी"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "संशोधक केवल अगले स्रोत में जाएँ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "कुंजीपटल"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"देखें और कुंजीपटल शॉर्टकट को बदलें और अपनी टाइपिंग की वरीयताओं को सेट करें"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "शॉर्टकट;दोहराएँ;ब्लिंक;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "मनपसंद शार्टकट"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "नाम: (_N)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "कमांड: (_o):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "दुहराव कुंजी"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "जब कुंजी दबा कर रखा जाए तो कुंजी दोहराना (_r)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "देरीः (_D)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "गतिः (_S)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "छोटा"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "धीमा"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "दुहराने वाली कुंजी गति"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "लंबा"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "तेज"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "संकेतक टिमटिमाना"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "पाठ बक्सा में संकेतक टिमटिमाएँ (_b)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "गति: (_p)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "कर्सर ब्लिंक गति"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "इनपुट स्रोत"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "शॉर्टकट जोड़ें"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "शॉर्टकट हटायें"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"शॉर्टकट संपादित करने के लिए, पंक्ति पर क्लिक करें और नई कुंजी नीचे पकड़े या "
+"स्पष्ट करने के लिए "
+"बैकस्पेस प्रेस करें."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "शॉर्टकट्स"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:635
+#: ../panels/keyboard/keyboard-shortcuts.c:643
+msgid "Custom Shortcuts"
+msgstr "पसंदीदा शार्टकट"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:860
+msgid "<Unknown Action>"
+msgstr "<अज्ञात क्रिया>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1357
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"शॉर्टकट \"%s\" प्रयोग नहीं की जा सकती है क्योंकि इस कुंजी के प्रयोग से इसे "
+"टाइप करना "
+"असंभव होगा.\n"
+"कृपया Control, Alt या Shift कुंजी को एक साथ कोशिश करें."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1387
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"यह शार्टकट \"%s\" पहले से ही:\n"
+" \"%s\" हेतु प्रयुक्त है"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1392
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"यदि आप \"%s\" को फिर नियत करते हैं, \"%s\" शॉर्टकट को निष्क्रिय किया जाएगा."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1398
+msgid "_Reassign"
+msgstr "फिर नियत करें (_R)"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1439
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"\"%s\" शॉर्टकट में एक संबद्ध \"%s\" शॉर्टकट है. क्या आप इसे \"%s\" पर स्वतः "
+"सेट करना चाहते हैं?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1449
+#, c-format
+#| msgid ""
+#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#| "disabled."
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"\"%s\" अभी \"%s\" से जुड़ा है, शॉर्टकट को निष्क्रिय किया जाएगा यदि आप आगे "
+"बढ़ते हैं."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1456
+#| msgid "_Reassign"
+msgid "_Assign"
+msgstr "फिर नियत करें (_A)"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "अपनी सेटिंग्स जाँचें (_S)"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+#| msgid "Test Your _Settings"
+msgid "Test Your Settings"
+msgstr "अपनी सेटिंग्स जाँचें"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "माउस व टचपैड"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"अपने माउस या संवेदनशीलता टचपैड बदलें और सही है या बाएँ हाथ का चयन करें "
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#| msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ट्रैकपैड;सूचक;क्लिक करें;टैब;डबल;बटन;ट्रैकबॉल;स्क्रॉल;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "सामान्य"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+#| msgctxt "keyboard, speed"
+#| msgid "Slow"
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "धीमा"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "दोहरा क्लिक टाइमआउट"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+#| msgctxt "keyboard, speed"
+#| msgid "Fast"
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "तेज"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "दोहरा क्लिक करें (_D)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "प्राथमिक बटन (_b)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "बायाँ (_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "दाँया (_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "माउस"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "संकेतक गति (_P)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+#| msgctxt "keyboard, speed"
+#| msgid "Slow"
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "धीमा"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+#| msgctxt "keyboard, speed"
+#| msgid "Fast"
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "तेज"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "टचपैड"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+#| msgctxt "keyboard, speed"
+#| msgid "Slow"
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "धीमा"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+#| msgctxt "keyboard, speed"
+#| msgid "Fast"
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "तेज"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr "टाइपिंग के दौरान निष्क्रिय करें (_t)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr "क्लिक करने के लिए टैप करें (_c)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr "दो अंगुली से स्क्रॉल (_f)"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+#| msgid "_Edge scrolling"
+msgid "_Natural scrolling"
+msgstr "प्राकृतिक स्क्रॉलिंग (_N)"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "क्लिक करने, दोहरा क्लिक करने और स्क्रॉल करने की कोशिश करें"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "पाँच क्लिक, GEGL समय!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "दोहरा क्लिक, प्राथमिक बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "एकल क्लिक, प्राथमिक बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "दोहरा क्लिक, मध्य बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "एकल क्लिक, मध्य बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "दोहरा क्लिक, द्वितीयक बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "एकल क्लिक, द्वितीयक बटन"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:366
+msgid "Air_plane Mode"
+msgstr "हवाई जहाज मोड (_p)"
+
+#: ../panels/network/cc-network-panel.c:974
+msgid "Network proxy"
+msgstr "नेटवर्क प्रॉक्सी"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1153 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1298
+msgid "The system network services are not compatible with this version."
+msgstr "तंत्र संजाल सेवाओं इस संस्करण के साथ संगत नहीं हैं."
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x सुरक्षा (_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "पृष्ठ 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "बेनाम पहचान (_m)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "आंतरिक सत्यापन (_a)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "पृष्ठ 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "सुरक्षा"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "स्वचालित"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:218
+#: ../panels/network/net-device-wifi.c:382
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:222
+#: ../panels/network/net-device-wifi.c:387
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:226
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:231
+msgid "Enterprise"
+msgstr "उद्यम"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:236
+#: ../panels/network/net-device-wifi.c:372
+msgctxt "Wifi security"
+msgid "None"
+msgstr "कुछ नहीं"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "कभी नहीं"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:819
+msgid "Today"
+msgstr "आज"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:822
+msgid "Yesterday"
+msgstr "कल"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:476
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i दिन पहले"
+msgstr[1] "%i दिनों पहले"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:533
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "None"
+msgstr "कुछ नहीं"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "कमजोर"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ठीक"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:568
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "अच्छा"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:570
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "बहुत बढिया"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "उपयोक्ता"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "पता"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "नेटमास्क"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "गेटवे"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "पता मिटाएँ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "जोड़ें"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "सर्वर"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "DNS सर्वर मिटायें"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "मेट्रिक"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "मार्ग  मिटाएँ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "स्वचालित (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Manual"
+msgstr "हस्तचालित"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "लिंक स्थानीय सिर्फ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "उपसर्ग"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "स्वचालित"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "स्वचालित, केवल DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:51
+msgid "Reset"
+msgstr "रीसेट"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "कुछ नहीं"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-बिट कुंजी (हेक्स या ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit पासफ्रेज"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "गतिशील WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 निजी"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 एंटरप्राइज"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr "सिग्नल सामर्थ्य "
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "कड़ी गति"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 पता"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 पता"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "हार्डवेयर पता"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "तयशुदा मार्ग"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "डीएनएस"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "अंतिम प्रयुक्त"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "मुड़ जोड़ी (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "संलग्न एकक अंतराफलन (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "मीडिया स्वतंत्र अंतरफलक (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 गीबा/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "नाम (_N)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "MAC पता (_M)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "क्लोन पता (_C)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "बाइट्स"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "अन्य उपयोगकर्ताओं के लिए उपलब्ध है (_u)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "स्वतः कनेक्ट करें (_a) "
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "फायरवॉल क्षेत्र (_Z)"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+#| msgid "Default"
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "तयशुदा"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "यह क्षेत्र कनेक्शन का भरोसेमंद स्तर परिभाषित करता है"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "पता (_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "स्वचालित DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "रूट"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "स्वचालित रूट"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr "इस कनेक्शन का उपयोग करें इसके संजाल पर संसाधन के लिए (_o)"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "कनेक्शन संपादक खोलने में असमर्थ"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "कोई प्रोफ़ाइल"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "बंधन"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "टोली"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "पुल"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "वीपीएन प्लगिन लोड नहीं कर सका"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "फ़ाइल से आयात करें… "
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "नया संजाल कनेक्शन जोड़ें"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "रीसेट करें (_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1441
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "भूलें (_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"पासवर्ड सहित इस नेटवर्क के लिए सेटिंग्स रीसेट करें, लेकिन इसे एक पसंदीदा "
+"नेटवर्क समझें"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"इस नेटवर्क से संबंधित सभी जानकारी निकालें और स्वचालित रूप से कनेक्ट करने की "
+"कोशिश नहीं करें."
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "सुरक्षा (_e)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "VPN कनेक्शन आय़ात नहीं कर सका"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"फाइल '%s' पढ़ा नहीं जा सका अथवा कोई परिचित VPN कनेक्शन सूचना को समाहित नहीं "
+"कर "
+"सका\n"
+"\n"
+"त्रुटि: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "आयात के लिए फाइल चुनें"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1948
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:223
+msgid "_Open"
+msgstr "खोलें (_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "\"%s\" नामक फाइल पहले से मौजूद है."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "बदलें (_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "क्या आप %s को VPN कनेक्शन के साथ बदलना चाहते हैं जिसे आप सहेज रहे हैं?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "VPN कनेक्शन निर्यात नहीं कर सका"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN कनेक्शन '%s' को %s में निर्यात नहीं किया जा सका.\n"
+"\n"
+"त्रुटि: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+#| msgid "Export VPN connection..."
+msgid "Export VPN connection"
+msgstr "VPN संबंधन निर्यात करें"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(त्रुटि: कनेक्शन संपादक खोलने में असमर्थ)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "मेरा घर संजाल"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "अन्य उपयोगकर्ताओं के लिए उपलब्ध है (_o)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "नेटवर्क"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "नियंत्रित करें कैसे आप इंटरनेट से कनेक्ट होते हैं"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"संजाल;वायरलेस;वाई - फाई;वाईफ़ाई;आईपी;लैन;प्रॉक्सी;वैन;ब्रॉडबैंड;मोडेम;ब्लूटूथ;"
+"वीपीएन;ब्रिज;बांड;डीएनएस;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "बॉण्ड गुलाम"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(कोई नहीं)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "पुल गुलाम"
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:462
+msgid "never"
+msgstr "कभी नहीं"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:472
+msgid "today"
+msgstr "आज"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:474
+msgid "yesterday"
+msgstr "कल"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "आईपी पता"
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "अंतिम प्रयुक्त"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "तारसहित"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1596
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "विकल्प…"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: ../panels/network/net-device-ethernet.c:474
+#, c-format
+msgid "Profile %d"
+msgstr "प्रोफ़ाइल %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "नया कनेक्शन जोड़ें"
+
+#: ../panels/network/net-device-team.c:77
+#| msgid "Bridge slaves"
+msgid "Team slaves"
+msgstr "टीम स्लेव"
+
+#: ../panels/network/net-device-wifi.c:1154
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"यदि आपके पास बेतार के अलावा इंटरनेट पर कोई कनेक्शन है, आप इसे दूसरे के साथ "
+"बेतार हॉटस्पॉट "
+"सेट करकेकनेक्शन साझा करने के लिए उपयोग कर सकते हैं."
+
+#: ../panels/network/net-device-wifi.c:1158
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "बेतार हॉटस्पॉट पर जाना आपको <b>%s</b> से कनेक्ट नहीं रहने देगा."
+
+#: ../panels/network/net-device-wifi.c:1162
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"आपके बेतार कनेक्शन से इंटरनेट में पहुँच लेना संभव नहीं है जब हॉटस्पॉट सक्रिय "
+"हो. "
+
+#: ../panels/network/net-device-wifi.c:1245
+msgid "Stop hotspot and disconnect any users?"
+msgstr "हॉटस्पॉट रोकें और किसी भी उपयोगकर्ताओं को डिस्कनेक्ट करें?"
+
+#: ../panels/network/net-device-wifi.c:1248
+msgid "_Stop Hotspot"
+msgstr "हॉटस्पॉट रोकें (_S)"
+
+#: ../panels/network/net-device-wifi.c:1305
+msgid "System policy prohibits use as a Hotspot"
+msgstr "तंत्र नीति हॉटस्पॉट के रूप में उपयोग को प्रतिबंधित करता हैं"
+
+#: ../panels/network/net-device-wifi.c:1308
+msgid "Wireless device does not support Hotspot mode"
+msgstr "वायरलेस युक्ति हॉटस्पॉट मोड समर्थन नहीं करता है"
+
+#: ../panels/network/net-device-wifi.c:1437
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"कूटशब्द सहित चुने गए नेटवर्कों के लिए संजाल विवरण और अन्य कोई मनपसंद विन्यास "
+"नष्ट हो "
+"जाएगा."
+
+#: ../panels/network/net-device-wifi.c:1745
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "इतिहास"
+
+#: ../panels/network/net-device-wifi.c:1749
+#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
+#: ../panels/wacom/cc-wacom-page.c:533
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Close"
+msgstr "बंद करें (_C)"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1757
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "भूलें (_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"वेब प्रॉक्सी ऑटो डिस्कवरी का प्रयोग किया जाता है जब कॉन्फ़िगरेशन यूआरएल "
+"प्रदान नहीं किया "
+"जाता है."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "यह अविश्वसनीय सार्वजनिक संजाल के लिए अनुशंसित नहीं है."
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "प्रॉक्सी"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "जोड़ें प्रोफाइल... (_A)"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "प्रदाता"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "कुछ नहीं"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "हस्तचालित"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "स्वचालित"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "विधि (_M)"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "विन्यास यूआरएल (_C)"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "एचटीटीपी प्रॉक्सी (_H)"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "एचटीटीपी प्रॉक्सी: (_T)"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "एफटीपी प्रॉक्सी (_F)"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "साक्स होस्ट (_S)"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "होस्ट अनदेखा करें (_I)"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "HTTP प्राक्सी पोर्ट"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "एफ़टीपी प्रॉक्सी पोर्ट "
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "एफ़टीपी प्रॉक्सी पोर्ट"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "SOCKS प्राक्सी पोर्ट "
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "युक्ति बन्द करें"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "युक्ति जोड़ें"
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "युक्ति हटायें"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN क़िस्म"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "समूह नाम"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "समूह कूटशब्द"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "उपयोक्तानाम"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "VPN संबंधन बंद करें"
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "स्वचालित कनेक्ट करें (_C)"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "विवरण"
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "कूटशब्द (_P)"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "कुछ नहीं"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "कूटशब्द दिखाएं (_a)"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr "अन्य उपयोगकर्ताओं के लिए उपलब्ध है"
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "उपयोक्ता"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr "स्वचालित (DHCP) पता केवल"
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr "लिंक स्थानीय सिर्फ"
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr "अन्य कंप्यूटरों के साथ साझा किया"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr "स्वतः प्राप्त रूट अनदेखा करें (_n) "
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "IPv4"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "IPv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr "क्लोन MAC पता (_C)"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr "हार्डवेयर"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"उनकी चूक को इस कनेक्शन के लिए सेटिंग्स रीसेट करें, लेकिन एक पसंदीदा कनेक्शन "
+"के रूप में याद करें."
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"इस नेटवर्क से संबंधित सभी जानकारी निकालें और स्वचालित रूप से इसे कनेक्ट करने "
+"की कोशिश नहीं "
+"करें."
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "रीसेट"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "हार्डवेयर"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi हॉटस्पॉट "
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Turn On"
+msgstr "चालू करें (_T)"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Wi-Fi"
+msgstr "वाई फाई"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Turn Wi-Fi off"
+msgstr "वाई फाई चालू या बंद करें:"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_Use as Hotspot…"
+msgstr "हॉटस्पॉट के रूप में प्रयोग... (_U) "
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "_Connect to Hidden Network…"
+msgstr "छिपे संजाल में कनेक्ट करें... (_C)"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "_History"
+msgstr "इतिहास (_H)"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "वाई फाई संजाल में कनेक्ट होने के लिए बंद करें"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Network Name"
+msgstr "संजाल नाम"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Connected Devices"
+msgstr "कनेक्टेड युक्तियाँ"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "Security type"
+msgstr "सुरक्षा प्रकार"
+
+#: ../panels/network/network-wifi.ui.h:63
+msgid "Security key"
+msgstr "सुरक्षा कुंजी"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "तदर्थ"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "बुनियादी ढाँचा"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "स्थिति अज्ञात"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "बिना प्रबंधित"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "अनुपलब्ध"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "जोड़ रहा है"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "सत्यापन आवश्यक"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "कनेक्टेड"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "डिसकनेक्टिंग"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "कनेक्शन असफल"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "स्थिति अज्ञात (गुम)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "कनेक्टेड नहीं है"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "विन्यास विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "IP विन्यास विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "आईपी विन्यास का समय समाप्त"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "गोपनीयता जरूरी थी, लेकिन प्रदान नहीं किया गया था"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x सप्लीकेंट डिसकनेक्टेड"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x सप्लीकेंट विन्यास विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1x सप्लीकेंट विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x सप्लीकेंट प्रमाणित करने में काफी समय लिया"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "PPP आरंभ होने में विफल रहा"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "PPP सेवा डिस्कनेक्टेड"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "DHCP क्लाइंट आरंभ होने में विफल रहा"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP क्लाइंट त्रुटि"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP क्लाइंट विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "साझा कनेक्शन सेवा आरंभ होने में विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "साझा कनेक्शन सेवा विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "AutoIP सेवा आरंभ होने में विफल रहा"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "AutoIP सेवा त्रुटि"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "AutoIP सेवा विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "पंक्ति व्यस्त"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "डायल टोन नहीं"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "कोई कैरियर स्थापित नहीं किया जा सका"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "डायलिंग आग्रह का समय समाप्त"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "डायलिंग प्रयास विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "मोडेम आरंभीकरण असफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "विशेष APN चुनने में विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "संजाल के लिए खोज नहीं रहा है"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "संजाल पंजीयन मनाही"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "संजाल पंजीयन का समय समाप्त"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "निवेदित संजाल के साथ पंजीयन में विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "पिन चेक विफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "युक्ति के लिए फर्मवेयर अनुपस्थित हो सकता है"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "कनेक्शन गुम"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "मौज़ूदा कनेक्शन चालू हुआ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "मोडेम नहीं मिला"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "ब्लूटूथ कनेक्शन असफल"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "SIM कार्ड नहीं घुसाया गया"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "SIM पिन जरूरी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "SIM Puk जरूरी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "SIM गलत"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "InfiniBand युक्ति कनेक्टेड अवस्था का समर्थन नहीं करता है"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "कनेक्शन निर्भरता विफल"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "गुम फर्मवेयर"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "केबल अनप्लग"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "कोई प्रमाणपत्र प्राधिकार प्रमाणपत्र चुना गया"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"एक सर्टिफिकेट ऑथोरिटी (CA) प्रमाणपत्र का उपयोग नहीं असुरक्षित, दुष्ट Wi-Fi "
+"नेटवर्क के "
+"लिए कनेक्शन में परिणाम कर सकते हैं.आप एक सर्टिफिकेट ऑथोरिटी प्रमाणपत्र का चयन "
+"करना चाहेंगे?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "नज़रअंदाज़ करें"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "सीए प्रमाणपत्र चुनें"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, या PKCS#12 निजी कुंजी (*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER या PEM प्रमाणपत्र (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+#| msgid "Choose a PAC file..."
+msgid "Choose a PAC file"
+msgstr "PAC फ़ाइल चुनें"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC फ़ाइल (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC फाइल (_f)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "आंतरिक सत्यापन (_I) "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "PAC pro_visioning"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "अज्ञातनाम"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "सत्यापित"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "दोनों"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "उपयोक्ता नाम (_U)"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "कूटशब्द दिखाएँ (_w)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "एमडी5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+#| msgid "Choose a Certificate Authority certificate..."
+msgid "Choose a Certificate Authority certificate"
+msgstr "सर्टिफिकेट ऑथरिटी प्रमाणपत्र चुनें"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "संस्करण 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "संस्करण 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "सीए प्रमाणपत्र (_A)"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP संस्करण (_v)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "इस कूटशब्द के लिए हर समय पूछें (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "विगोपित निजी कुंजी असुरक्षित हैं"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"चुना गया निजी कुंजी कूटशब्द के द्वारा संरक्षित नहीं दिखता है.  यह आपके "
+"सुरक्षा साख को खराब "
+"कर सकता है.  कृपया कोई कूटशब्द संरक्षित निजी कुंजी चुनें.\n"
+"\n"
+"(आप अपने निजी कुंजी से openssl के साथ अपना कूटशब्द संरक्षित कर सकते हैं)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+#| msgid "Choose your personal certificate..."
+msgid "Choose your personal certificate"
+msgstr "अपना व्यक्तिगत प्रमाणपत्र चुनें"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+#| msgid "Choose your private key..."
+msgid "Choose your private key"
+msgstr "अपनी निजी कुंजी चुनें"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "पहचान (_d)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "उपयोक्ता प्रमाणपत्र (_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "निजी कुंजी (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "निजी कुंजी कूटशब्द (_P) "
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "पीएपी"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "सीएचएपी"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "मुझे फिर मत चेताएँ (_w)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "नहीं"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "हाँ"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "टीएलएस"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "तीव्र"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "टनेल किया टीएलएस"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "संरक्षित EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "सत्यापन (_t)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1(तयशुदा)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "खुला तंत्र"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "साझा कुंजी"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "कुंजी (_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "कुंजी दिखाएँ (_w)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP सूची (_x)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "प्रकार (_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "सूचनाएँ"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "ध्वनि चेतावनी"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "पॉपअप बैनर दिखाएं"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "बैनर में विवरण दिखाएँ"
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "लॉक स्क्रीन में देखें"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "लॉक स्क्रीन में विवरण दिखाएँ "
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "चालू"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "सूचनाएँ"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr "नियंत्रण जो सूचनाएं प्रदर्शित कर रहे हैं कि वे क्या दिखाते हैं।"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "बैनर;संदेश;ट्रे;पॉपअप;सूचनाएं;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "पॉपअप बैनर दिखाएं"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "लॉक स्क्रीन में दिखाएँ "
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+#| msgid "Other"
+msgctxt "Online Account"
+msgid "Other"
+msgstr "अन्य"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "खाता जोड़ें"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr "डाक"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr "संपर्क"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "गपशप"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "संसाधन "
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "खाते में लॉगिंग त्रुटि"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "महत्व का समय समाप्त हो गया."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr "इस खाते को सक्षम करने के लिए साइन - इन करें."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr " साइन - इन करें (_S)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "खाता बनाने में त्रुटि"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "खाता हटाने में त्रुटि"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "क्या आप वाक़ई ख़ाता को मिटाना चाहते हैं?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "यह सर्वर पर खाता को हटा देगा."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "हटाएं (_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "ऑनलाइन खातों"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"आपके ऑनलाइन खातों से कनेक्ट करने और निर्णय क्या उनके लिए उपयोग करने के लिए"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+#| "ownCloud;"
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"गूगल;फेसबुक;ट्विटर;याहू;वेब;ऑनलाइन;चैट;कैलेंडर;मेल;संपर्क;ओनक्लाउड;Kerberos;IM"
+"AP;SMTP;Pocket;ReadItLater;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "कोई ऑनलाइन खाता विन्यस्त नहीं"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "खाता मिटाएँ"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "एक ऑनलाइन खाता जोड़ें"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"किसी खाता को जोड़ना आपके अनुप्रयोग को दस्तावेज़, डाक, संपर्क, पंचांग, चैट और "
+"भी कुछेक में "
+"पहुँछ लेने देता है."
+
+#: ../panels/power/cc-power-panel.c:183
+msgid "Unknown time"
+msgstr "अज्ञात समय"
+
+#: ../panels/power/cc-power-panel.c:189
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i मिनट"
+msgstr[1] "%i मिनट"
+
+#: ../panels/power/cc-power-panel.c:201
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i घंटा"
+msgstr[1] "%i घंटा"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:209
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:210
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "घंटा"
+msgstr[1] "घंटे"
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "मिनट"
+msgstr[1] "मिनट"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:230
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s जब तक पूरी तरह चार्ज्ड"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:237
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "चेतावनी: %s शेष"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:242
+#, c-format
+msgid "%s remaining"
+msgstr "%s शेष"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
+msgid "Fully charged"
+msgstr "पूरी तरह चार्ज्ड "
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
+msgid "Empty"
+msgstr "रिक्त"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Charging"
+msgstr "चार्ज हो रहा है"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:271
+msgid "Discharging"
+msgstr "डिस्चार्ज कर रहा है"
+
+#: ../panels/power/cc-power-panel.c:396
+msgctxt "Battery name"
+msgid "Main"
+msgstr "मुख्य"
+
+#: ../panels/power/cc-power-panel.c:398
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "अतिरिक्त"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:470
+msgid "Wireless mouse"
+msgstr "बेतार माउस"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:473
+msgid "Wireless keyboard"
+msgstr "बेतार कीबोर्ड"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:476
+msgid "Uninterruptible power supply"
+msgstr "बिना व्यवधान के ऊर्जा आपूर्ति"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Personal digital assistant"
+msgstr "व्यक्तिगत डिजिटल सहायक"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Cellphone"
+msgstr "सेलफोन"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Media player"
+msgstr "मीडिया प्लेयर"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Tablet"
+msgstr "टेबलेट"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Computer"
+msgstr "कम्प्यूटर"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
+#: ../panels/power/cc-power-panel.c:2019
+msgid "Battery"
+msgstr "बैटरी"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "चार्ज हो रहा है"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "चेतावनी"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Low"
+msgstr "कम"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Good"
+msgstr "अच्छा"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "पूरी तरह चार्ज्ड "
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "रिक्त"
+
+#: ../panels/power/cc-power-panel.c:715
+msgid "Batteries"
+msgstr "बैटरी"
+
+#: ../panels/power/cc-power-panel.c:1117
+msgid "When _idle"
+msgstr "निष्क्रिय जब (_I)"
+
+#: ../panels/power/cc-power-panel.c:1445
+msgid "Power Saving"
+msgstr "पावर सेविंग"
+
+#: ../panels/power/cc-power-panel.c:1473
+#| msgid "_Screen Brightness"
+msgid "_Screen brightness"
+msgstr "स्क्रीन चमक (_S)"
+
+#: ../panels/power/cc-power-panel.c:1479
+#| msgid "Keyboard Settings"
+msgid "_Keyboard brightness"
+msgstr "कुंजीपट चमकीलापन (_K)"
+
+#: ../panels/power/cc-power-panel.c:1489
+#| msgid "_Dim Screen when Inactive"
+msgid "_Dim screen when inactive"
+msgstr "स्क्रीन मंद करें जब निष्क्रिय हैं (_D)"
+
+#: ../panels/power/cc-power-panel.c:1514
+#| msgid "_Blank Screen"
+msgid "_Blank screen"
+msgstr "खाली स्क्रीन (_B)"
+
+#: ../panels/power/cc-power-panel.c:1551
+msgid "_Wi-Fi"
+msgstr "वाई फाई (_W)"
+
+#: ../panels/power/cc-power-panel.c:1556
+msgid "Turns off wireless devices"
+msgstr "बेतार युक्तियाँ बंद करें"
+
+#: ../panels/power/cc-power-panel.c:1581
+#| msgid "_Mobile Broadband"
+msgid "_Mobile broadband"
+msgstr "मोबाइल ब्रॉडबैंड (_M)"
+
+#: ../panels/power/cc-power-panel.c:1586
+#| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "मोबाइल ब्रॉडबैंड (3G, 4G, WiMax, आदि.) युक्तियाँ बंद करें"
+
+#: ../panels/power/cc-power-panel.c:1635
+msgid "_Bluetooth"
+msgstr "ब्लूटूथ (_B)"
+
+#: ../panels/power/cc-power-panel.c:1686
+msgid "When on battery power"
+msgstr "जब बैटरी शक्ति पर चल रहा हो"
+
+#: ../panels/power/cc-power-panel.c:1688
+msgid "When plugged in"
+msgstr "जब प्लगिन"
+
+#: ../panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Off"
+msgstr "निलंबित & पावर ऑफ करें"
+
+#: ../panels/power/cc-power-panel.c:1851
+#| msgid "_Automatic Suspend"
+msgid "_Automatic suspend"
+msgstr "स्वत: निलंबित (_A)"
+
+#: ../panels/power/cc-power-panel.c:1875
+#| msgid "When Battery Power is _Critical"
+msgid "When battery power is _critical"
+msgstr "जब पावर बहुत कम है (_C)"
+
+#: ../panels/power/cc-power-panel.c:1930
+msgid "Power Off"
+msgstr "बंद करें"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Devices"
+msgstr "औज़ार"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "पावर"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr "अपनी बैटरी की स्थिति और परिवर्तन बिजली की बचत सेटिंग्स देखें"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"पावर;नींद;निलंबित करें; सीतनिद्रा में होना; "
+"बैटरी;चमक;मंद;खाली;मॉनिटर;DPMS;निष्क्रिय;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "सुप्तावस्था"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "पावर ऑफ"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "45 मिनट"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 घंटा"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "80 मिनट"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "90 मिनट"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "100 मिनट"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "2 घंटा"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 मिनट"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 मिनट"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "मिनट"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "4 मिनट"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 मिनट"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "8 मिनट"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 मिनट"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "12 मिनट"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "स्वत: निलंबित"
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr "जब प्लगिन (_P)"
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr "बैटरी पॉवर ऑन करें (_B)"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "देरी"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "सत्यापित करें"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "कूटशब्द"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "सत्यापन आवश्यक"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr "टोनर पर कम"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr "टोनर के बाहर"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr "डेवलपर पर कम"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr "डेवलपर के बाहर"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr "चिह्न आपूर्ति पर कम"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr "चिह्न आपूर्ति के बाहर"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr "कवर खोलें"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr "खुला दरवाजा"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr "कागज पर कम"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr "कागज के बाहर"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ऑफ़लाइन"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "रुक गया"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr "लगभग पूरा गोदाम बेकार"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr "लगभग गोदाम बेकार"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr "ऑप्टिकल फोटो कंडक्टर जीवन का अंत निकट है"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ऑप्टिकल फोटो कंडक्टर कामकाज नहीं रहा है"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "विन्यस्त कर रहा है"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr "तैयार"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "काम नहीं स्वीकार कर सकते हैं"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr "प्रक्रिया हो रही है"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Toner Level"
+msgstr "टोनर स्तर"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Ink Level"
+msgstr "स्याही स्तर"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:928
+msgid "Supply Level"
+msgstr "आपूर्ति स्तर"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:946
+msgctxt "printer state"
+msgid "Installing"
+msgstr "संस्थापित किया जा रहा है"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1123
+msgid "No printers available"
+msgstr "कोई प्रिंटर उपलब्ध नहीं"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1433
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u सक्रिय"
+msgstr[1] "%u सक्रिय"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1777
+msgid "Failed to add new printer."
+msgstr "नया प्रिंटर जोड़ने में विफल."
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid "Select PPD File"
+msgstr "एक PPD फाइल चुनें"
+
+#: ../panels/printers/cc-printers-panel.c:1953
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"पोस्टस्क्रिप्ट प्रिंटर विवरण फ़ाइल (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2258
+msgid "No suitable driver found"
+msgstr "कोई उपयुक्त ड्राइवर नहीं मिला"
+
+#: ../panels/printers/cc-printers-panel.c:2327
+msgid "Searching for preferred drivers…"
+msgstr "वरीय ड्राइवर के लिए खोज रहा है... "
+
+#: ../panels/printers/cc-printers-panel.c:2342
+msgid "Select from database…"
+msgstr "डेटाबेस से चुनें... "
+
+#: ../panels/printers/cc-printers-panel.c:2351
+msgid "Provide PPD File…"
+msgstr "PPD फाइल दें... "
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2502
+#: ../panels/printers/cc-printers-panel.c:2525
+msgid "Test page"
+msgstr "जाँच पृष्ठ"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2933
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "लोड नहीं कर सका ui: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "मुद्रक"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"प्रिंटर जोड़ें, प्रिंटर नौकरियों देखने के लिए और तय करें कि कैसे आप मुद्रित "
+"करना चाहते हैं."
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "प्रिंटर;पंक्ति;मुद्रण;पेपर;इंक;टोनर;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "सक्रिय कार्य"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "बंद करें"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "मुद्रण फिर से शुरू"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "ठहराव मुद्रण"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "मुद्रण कार्य रद्द करें"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "नया प्रिंटर जोड़ें"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+#| msgid "Authenticate"
+msgid "A_uthenticate"
+msgstr "सत्यापन करें (_u)"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "कोई मुद्रक नहीं खोज सका."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+#| msgid "Search for network printers or filter result"
+msgid "Enter address of a printer or a text to filter results"
+msgstr "प्रिंटर का पता डालें या परिणाम फिल्टर करने के लिए पाठ डालें"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "लोडिंग विकल्प... "
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "प्रिंटर ड्राइवर चुनें"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "ड्राइवर डेटाबेस लोड कर रहा है..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+#| msgid "Remove Printer"
+msgid "JetDirect Printer"
+msgstr "जेटप्रिंटर प्रिंटर"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+#| msgid "%s Printer"
+msgid "LPD Printer"
+msgstr "LPD मुद्रक"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "एक तरफा"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "लंबा किनारा (मानक)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "छोटा किनारा (पलटें)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "व्यक्तिचित्र"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "भूदृश्य"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "उल्टा भूदृश्य"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "उल्टा व्यक्तिचित्र"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "स्थगित"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "रोकें"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "प्रक्रिया हो रही है"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "रुक गया"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "रद्द"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "छोड़ा गया"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "पूर्ण"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "पद नाम"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "जॉब स्थिति"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "समय"
+
+#: ../panels/printers/pp-jobs-dialog.c:495
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s सक्रिय कार्य"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "USB"
+msgstr "यूएसबी"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Serial Port"
+msgstr "क्रमिक पोर्ट"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1683
+msgid "Parallel Port"
+msgstr "समांतर पोर्ट"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+#| msgid "Location"
+msgid "Location: %s"
+msgstr "स्थानः %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1744
+#, c-format
+#| msgid "A_ddress:"
+msgid "Address: %s"
+msgstr "पता: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1768
+#| msgid "_Inner authentication"
+msgid "Server requires authentication"
+msgstr "सर्वर को प्रमाणीकरण की आवश्यकता है"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "दो तरफा"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "कागज का प्रकार"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "कागज स्रोत"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "आउटपुट तश्तरी"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript प्री फ़िल्टरिंग"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:531
+msgid "Pages per side"
+msgstr "पृष्ठ प्रति पक्ष"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:543
+msgid "Two-sided"
+msgstr "दो तरफा"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:555
+msgid "Orientation"
+msgstr "दिशा"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:652
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "सामान्य"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "पृष्ठ सेटअप"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "मुद्रक विकल्प"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "कार्य"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "छवि गुणवत्ता"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "रंग"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "समाप्त कर रहा है"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "उन्नत"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "स्वतः चुनें"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "मुद्रक तयशुदा"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "अंतस्थापित GhostScript फ़ॉन्ट केवल"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "PS स्तर 1 में बदलें"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "पीएस स्तर 2 पर परिवर्तित करें"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "कोई पूर्व फ़िल्टरिंग नहीं"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "उत्पादक"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "ड्राइवर"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"%s पर उपलब्ध प्रिंटर को देखने के लिए अपने उपयोगकर्ता नाम और पासवर्ड दर्ज करें."
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "प्रिंटर जोड़ें"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "प्रिंटर हटायें"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "आपूर्ति"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "स्थान"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+#| msgid "Default Route"
+msgid "_Default printer"
+msgstr "तयशुदा प्रिंटग (_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "कार्य"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "जॉब दिखाएं (_J)"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "मॉडल"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "लेबल"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "नए ड्राइवर की स्थापना कर रहा है ..."
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "पृष्ठ 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "जाँच पृष्ठ छापें (_T)"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "विकल्प (_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "नया प्रिंटर जोड़ें"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"क्षमा करें!तंत्र मुद्रण सेवा\n"
+"उपलब्ध नहीं लगती है."
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "स्क्रीन ताला"
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "उपयोग & इतिहास"
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr "रद्दी से सभी मदों खाली करें?"
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr "रद्दी में सभी मदों हमेशा के लिए मिटा दी जाएंगी."
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "रद्दी खाली करें (_E)"
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+#| msgid "Purge Trash & Temporary Files"
+msgid "Delete all the temporary files?"
+msgstr "ट्रैश व अस्थाई फ़ाइलें मिटाएँ?"
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr "सभी अस्थाई फ़ाइल स्थाई रूप से मिटा दी जाएगी."
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "अस्थाई फ़ाइलें मिटाएँ (_P)"
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "ट्रैश & अस्थाई फ़ाइलें मिटाएँ"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+#| msgid "Software"
+msgid "Software Usage"
+msgstr "सॉफ्टवेयर प्रयोग"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "गोपनीयता"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+"आपकी व्यक्तिगत जानकारी और नियंत्रण जो दूसरों को देख सकते हैं की सुरक्षित रखें"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"स्क्रीन;ताला;निदान;दुर्घटना;निजी;हाल ही में;अस्थायी;tmp;सूचकांक; "
+"नाम;नेटवर्क;पहचान;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "स्क्रीन बंद करता है "
+
+#  set the timeout value  label with correct value of timeout
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 सेकण्ड"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 दिन"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 दिन"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 दिन"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 दिन"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 दिन"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 दिन"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 दिन"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 दिन"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 दिन"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "सदा के लिए "
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"अपने इतिहास को याद बातें करने के लिए फिर से खोजने के लिए आसान बनाता है.इन "
+"मदों नेटवर्क "
+"पर कभी नहीं साझा कर रहे हैं."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "हाल ही में प्रयुक्त (_R)"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "इतिहास रख सकेंगे (_H)"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "हालिया इतिहास साफ करें (_e)"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "स्क्रीन लॉक आपकी गोपनीयता की रक्षा जब आप दूर कर रहे हैं."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "स्वचालित स्क्रीन लॉक (_L)"
+
+#: ../panels/privacy/privacy.ui.h:27
+#| msgid "Lock Screen _After Blank For"
+msgid "Lock screen _after blank for"
+msgstr "खाली करने के बाद स्क्रीन लॉक (_a)"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "अधिसूचना दिखाएँ (_N)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"स्वचालित रूप से कचरा पेटी और अस्थायी फ़ाइलें को मिटायें  अपने कंप्यूटर को "
+"अनावश्यक संवेदनशील "
+"जानकारी के मुक्त रखने में मदद करने के लिए "
+
+#: ../panels/privacy/privacy.ui.h:31
+#| msgid "Automatically Empty _Trash"
+msgid "Automatically empty _Trash"
+msgstr "स्वचालित रूप से रद्दी खाली करें (_T)"
+
+#: ../panels/privacy/privacy.ui.h:32
+#| msgid "Automatically Purge Temporary _Files"
+msgid "Automatically purge Temporary _Files"
+msgstr "स्वचालित रूप से अस्थाई फ़ाइलें मिटाएँ (_F)"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "के बाद मिटाएँ (_A)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"आप किस सॉफ़्टवेयर का उपयोग करते हैं इसपर सूचना भेजा हमें अधिक सटीक अनुशंसा के "
+"लिए मदद करता है. यह हमेें हमारे सॉफ्टवेयर को सुधारने में मदद करता है.\n"
+"\n"
+"सभी जानकारियाँ जो हम जमा करते हैं वह बेनाम रहती हैं, और हम आपके आँकड़े को "
+"किसी तीसरे पक्ष से साझा कभी नहीं करते हैं."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "सॉफ़्टवेयर प्रयोग आँकड़ा भेजें (_S)"
+
+#: ../panels/privacy/privacy.ui.h:41
+#| msgid "Privacy"
+msgid "Privacy Policy"
+msgstr "गोपनीयता नीति"
+
+#: ../panels/privacy/privacy.ui.h:42
+#| msgid "Location"
+msgid "_Location Services"
+msgstr "अवस्थिति सेवाएँ (_L)"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "आपके भौगोलिक अवस्थिति निर्धारित करने के लिए प्रयोग"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "इम्पीरियल"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "मेट्रिक"
+
+#: ../panels/region/cc-format-chooser.c:284
+msgid "No regions found"
+msgstr "कोई क्षेत्रों नहीं मिला"
+
+#: ../panels/region/cc-input-chooser.c:179
+msgid "No input sources found"
+msgstr "कोई  इनपुट स्रोत नहीं मिला"
+
+#: ../panels/region/cc-input-chooser.c:1076
+#| msgid "Other"
+msgctxt "Input Source"
+msgid "Other"
+msgstr "अन्य"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:892
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "परिवर्तनों को प्रभावी करने के लिए अपने सत्र के लिए आरंभ किया जाना है"
+
+#: ../panels/region/cc-region-panel.c:243
+#: ../panels/user-accounts/um-user-panel.c:896
+msgid "Restart Now"
+msgstr "अब फिर आरंभ करें"
+
+#: ../panels/region/cc-region-panel.c:862
+msgid "No input source selected"
+msgstr "कोई इनपुट स्रोत चयनित नहीं"
+
+#: ../panels/region/cc-region-panel.c:1092
+msgid "Sorry"
+msgstr "खेद है"
+
+#: ../panels/region/cc-region-panel.c:1094
+msgid "Input methods can't be used on the login screen"
+msgstr "इनपुट विधि लॉगिन स्क्रीन पर नहीं किया जा सकता"
+
+#: ../panels/region/cc-region-panel.c:1731
+msgid "Login Screen"
+msgstr "लॉगिन स्क्रीन"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "प्रारूप"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "पूर्वावलोकन"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "तिथियाँ"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "बार"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "संख्याएँ"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "माप"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "कागज"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "क्षेत्र और भाषा"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"अपनी प्रदर्शन भाषा, स्वरूपों, कीबोर्ड लेआउट और इनपुट सूत्रों का चयन करें"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "भाषा;लेआउट;कीबोर्ड; इनपुट;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "इनपुट स्रोत जोड़ें "
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "इनपुट स्रोत विकल्प"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Use the _same source for all windows"
+msgstr "सभी विंडोज़ के लिए एक ही स्रोत का उपयोग करें  (_s)"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Allow _different sources for each window"
+msgstr "व्यक्तिगत विंडोज़ के लिए विभिन्न स्रोत की अनुमति दें (_d)"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Keyboard Shortcuts"
+msgstr "कुंजीपट शॉर्टकट"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Switch to previous source"
+msgstr "पिछले स्रोत पर जाएँ"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Switch to next source"
+msgstr "अगले स्रोत में जाएँ"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "आप कुंजीपटल सेटिंग्स में इन शॉर्टकट बदल सकते हैं"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Alternative switch to next source"
+msgstr "अगले स्रोत के लिए वैकल्पिक स्विच"
+
+#: ../panels/region/input-options.ui.h:12
+msgid "Left+Right Alt"
+msgstr "दायां + बायां आल्ट"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "अंग्रेज़ी (यूनाइटेड किंगडम)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "यूनाइटेड किंगडम"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "विकल्प"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"लॉगइन सेटिंग्स सभी उपयोगकर्ताओं द्वारा उपयोग किया जाता है जब सिस्टम में "
+"प्रवेश करते हैं"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+#| msgid "Places"
+msgctxt "Search Location"
+msgid "Places"
+msgstr "स्थान"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+#| msgid "Bookmarks"
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "पुस्तचिह्न"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+#| msgid "Other"
+msgctxt "Search Location"
+msgid "Other"
+msgstr "अन्य"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "स्थान चुनें"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+#| msgid "GOK"
+msgid "_OK"
+msgstr "ठीक (_O)"
+
+#: ../panels/search/cc-search-panel.c:176
+msgid "No applications found"
+msgstr "कोई अनुप्रयोग नहीं मिला"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "ढूंढें"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "नियंत्रण के लिए जो आवेदन गतिविधियों के अवलोकन में खोज परिणाम बताते हैं"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "खोज;पता लगाएं;सूचकांक;छिपाएँ;गोपनीयता;परिणाम;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "खोजें स्थान"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "ऊपर जाएँ"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "नीचे जाएँ"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "वरीयताएँ"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "चालू"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "बंद"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#: ../panels/sharing/cc-sharing-panel.c:304
+#| msgid "Enabled"
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "सक्षम"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+#| msgid "Active Jobs"
+msgctxt "service is active"
+msgid "Active"
+msgstr "सक्रिय"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "कोई फ़ोल्डर चुनें "
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "नक़ल"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "साझेदारी"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "नियंत्रण आप क्या दूसरों के साथ साझा करना चाहते हैं"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"शेयर; साझा करने; ssh; मेजबान; नाम; दूरस्थ; डेस्कटॉप; ब्लूटूथ;OBEX; मीडिया; "
+"ऑडिय; "
+"वीडियो;चित्र; फोटो; फिल्मों; सर्वर; रेंडरर;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "दूरस्थ लॉगिन सक्षम या अक्षम करें."
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "उपयोक्ता दूरस्थ लॉगिन सक्षम या अक्षम करने के लिए सत्यापन आवश्यक है"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:299
+msgid "No networks selected for sharing"
+msgstr "साझा करने के लिए कोई संजाल चयनित नहीं"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+#| msgid "Network"
+msgid "Networks"
+msgstr "संजाल"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "ब्लूटूथ सेटिंग "
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"ब्लूटूथ शेयरिंग आप अन्य ब्लूटूथ सक्षम उपकरणों के साथ फ़ाइलें साझा करने की "
+"अनुमति देता है."
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "केवल विश्वसनीय उपकरण से प्राप्त करें"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "डाउनलोड फ़ोल्डर में प्राप्त फ़ाइलों को सहेजें"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "कम्प्यूटर नाम"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "निजी फ़ाइल साझा"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "स्क्रीन हिस्सा"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "मीडिया साझेदारी"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "दूरस्थ लॉगिन"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "कुछ सेवाओं को कोई नेटवर्क का उपयोग की वजह से अक्षम हैं."
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"व्यक्तिगत फ़ाइल शेयरिंग आप दूसरों के साथ अपने वर्तमान नेटवर्क का उपयोग कर पर "
+"अपने "
+"सार्वजनिक फ़ोल्डर साझा करने के लिए अनुमति देता है: <a href=\"dav://%s\">"
+"dav://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr " पासवर्ड की आवश्यकता होगी"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"दूरदराज के उपयोगकर्ताओं को सुरक्षित शैल कमांड का उपयोग कर कनेक्ट करने के लिए "
+"अनुमति दें.:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"दूरदराज के उपयोगकर्ताओं को देखने के लिए या को जोड़ने के द्वारा अपनी स्क्रीन "
+"पर नियंत्रण की "
+"अनुमति दें: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:20
+#| msgid "Remote Control"
+msgid "Allow Remote Control"
+msgstr "रिमोट दृश्य स्वीकारें"
+
+#: ../panels/sharing/sharing.ui.h:21
+#| msgid "Password"
+msgid "Password:"
+msgstr "कूटशब्द:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "कूटशब्द दिखाएँ"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/sharing/sharing.ui.h:23
+#| msgid "%s Options"
+msgid "Access Options"
+msgstr "पहुँच विकल्प"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "नया कनेक्शन पहुँच के लिए जरूर पूछें"
+
+#: ../panels/sharing/sharing.ui.h:25
+#| msgid "Require Password"
+msgid "Require a password"
+msgstr "कूटशब्द की आवश्यकता होगी"
+
+#: ../panels/sharing/sharing.ui.h:26
+#| msgid "Share Music, Photos and Videos with others on the current network."
+msgid "Share music, photos and videos over the network."
+msgstr "संगीत, तस्वीरें और वीडियो के संजाल पर साझा करें."
+
+#: ../panels/sharing/sharing.ui.h:27
+#| msgid "Add Folder"
+msgid "Folders"
+msgstr "फ़ोल्डर"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "ध्वनि"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ध्वनि के स्तर, निविष्टियाँ, outputs, और चेतावनी लगता बदलें"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "कार्ड;माइक्रोफोन; वॉल्यूम; फीका; बैलेंस; ब्लूटूथ; हेडसेट; ऑडियो;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "बार्क"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "ड्रिप"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "ग्लास"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "सोनार"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "बायाँ"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "दायाँ"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "पिछला"
+
+# #-#-#-#-#  libgnomecanvas.gnome-2-2.hi.po (libgnomecanvas)  #-#-#-#-#
+# libgnomecanvas/gnome-canvas-text.c:238
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-font-picker.c:184 libgnomeui/gnome-font-picker.c:979
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "अग्र भाग"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "न्यूनतम"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "अधिकतम"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "संतुलन: (_B)"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "धुंधला: (_F)"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "उप वूफ़र: (_S)"
+
+#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:616
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "बिना संवर्द्धित"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "प्रोफाइल: (_P)"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u आउटपुट"
+msgstr[1] "%u आउटपुट"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u इनपुट"
+msgstr[1] "%u इनपुट"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "सिस्टम ध्वनि"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "टेस्ट स्पीकर्स (_T)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "पीक जाँच"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1509
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "नाम"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1528
+msgid "Device"
+msgstr "युक्ति"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1591
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "स्पीकर टेस्टिंग %s के लिए"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1649
+msgid "_Output volume:"
+msgstr "आउटपुट आवाज: (_O)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "Output"
+msgstr "आउटपुट"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1668
+msgid "C_hoose a device for sound output:"
+msgstr "ध्वनि आउटपुट के लिए कोई युक्ति चुनें: (_h)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1693
+msgid "Settings for the selected device:"
+msgstr "चयनित युक्ति के लिए सेटिंग:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "Input"
+msgstr "इनपुट"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "_Input volume:"
+msgstr "इनपुट आवाज: (_I)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1734
+msgid "Input level:"
+msgstr "इनपुट स्तर:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1762
+msgid "C_hoose a device for sound input:"
+msgstr "ध्वनि इनपुट के लिए कोई युक्ति चुनें: (_h)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "Sound Effects"
+msgstr "ध्वनि प्रभाव"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+msgid "_Alert volume:"
+msgstr "आवाज़ निर्धारक: (_A)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1809
+msgid "Applications"
+msgstr "अनुप्रयोग"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1813
+msgid "No application is currently playing or recording audio."
+msgstr "कोई अनुप्रयोग अभी ध्वनि बजा या रिकार्ड नहीं कर रहा है."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "अंतर्निर्मित"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "ध्वनि वरीयता"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "घटना ध्वनि जाँच रहा है"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "तयशुदा"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "प्रसंग से"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:769
+msgid "C_hoose an alert sound:"
+msgstr "कोई चेतावनी ध्वनि चुनें: (_h)"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "रूकें"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "जांच"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# libgnomeprint/gpa/gpa-media.c:241
+# #-#-#-#-#  libgnomeprint.gnome-2-2.hi.po (libgnomeprint VERSION)  #-#-#-#-#
+# libgnomeprint/gpa/gpa-media.c:241
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "पसंदीदा"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "इसे देखना, सुनना, प्रकार, बिंदु और क्लिक करें आसान बनाओ"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;"
+#| "size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"कुंजीपटल;माउस;a11y;एक्सेसिबिलिटी;कंट्रास्ट;ज़ूम;स्क्रीन;रीडर;पाठ;फ़ॉन्ट;आकार;ए"
+"क्सेसX;स्टिकी;कुंजी;धीमी;बाउंस;माउस;"
+
+#: ../panels/universal-access/uap.ui.h:1
+#| msgid "Universal Access"
+msgid "_Always Show Universal Access Menu"
+msgstr "सार्वभौमिक पहुँच मेन्यू हमेशा दिखाएँ (_A)"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "देख कर रहा है"
+
+#: ../panels/universal-access/uap.ui.h:3
+#| msgid "High Contrast"
+msgid "_High Contrast"
+msgstr "अधिक विरोध (_H)"
+
+#: ../panels/universal-access/uap.ui.h:4
+#| msgid "Large Text"
+msgid "_Large Text"
+msgstr "बड़ा पाठ (_L)"
+
+#: ../panels/universal-access/uap.ui.h:5
+#| msgid "Zoom"
+msgid "_Zoom"
+msgstr "छोटा-बड़ा करें (_Z)"
+
+#: ../panels/universal-access/uap.ui.h:7
+#| msgid "Screen Reader"
+msgid "Screen _Reader"
+msgstr "स्क्रीन वाचक (_R)"
+
+#: ../panels/universal-access/uap.ui.h:8
+#| msgid "Bounce Keys"
+msgid "_Sound Keys"
+msgstr "ध्वनि कुँजी (_S)"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "सुनवाई"
+
+#: ../panels/universal-access/uap.ui.h:10
+#| msgid "Visual Alerts"
+msgid "_Visual Alerts"
+msgstr "दृष्टि चेतावनी (_V)"
+
+#: ../panels/universal-access/uap.ui.h:12
+#| msgid "Screen keyboard"
+msgid "Screen _Keyboard"
+msgstr "स्क्रीन कुंजीपटल (_K)"
+
+#: ../panels/universal-access/uap.ui.h:13
+#| msgid "Typing Assistant"
+msgid "_Typing Assist (AccessX)"
+msgstr "टाइपिंग सहायक (_T) (AccessX)"
+
+#: ../panels/universal-access/uap.ui.h:14
+#| msgid "Pointing and Clicking"
+msgid "Pointing & Clicking"
+msgstr "इंगित और क्लिक"
+
+#: ../panels/universal-access/uap.ui.h:15
+#| msgid "Mouse Keys"
+msgid "_Mouse Keys"
+msgstr "माउस कुंजियाँ (_M)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "क्लिक मददगार (_C)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "स्क्रीन वाचक"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "स्क्रीन रीडर प्रदर्शित पाठ पढ़ता है जैसे ही आप फोकस पर बढते हैं."
+
+#: ../panels/universal-access/uap.ui.h:19
+#| msgid "Screen Reader"
+msgid "_Screen Reader"
+msgstr "स्क्रीन वाचक (_S)"
+
+#: ../panels/universal-access/uap.ui.h:20
+#| msgid "Bounce Keys"
+msgid "Sound Keys"
+msgstr "ध्वनि कुंजियाँ"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "जब Num Lock या Caps Lock चालू है तो बीप करें."
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "दृष्टि चेतावनी"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "जाँच फ्लैश (_T)"
+
+#: ../panels/universal-access/uap.ui.h:24
+#| msgid "Use a visual indication when an alert sound occurs"
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "दृश्य संकेत का प्रयोग करें जब एक चेतावनी ध्वनि होती है."
+
+#: ../panels/universal-access/uap.ui.h:25
+#| msgid "Flash the window title"
+msgid "Flash the _window title"
+msgstr "विंडो शीर्षक को चमकाएँ (_w)"
+
+#: ../panels/universal-access/uap.ui.h:26
+#| msgid "Flash the entire screen"
+msgid "Flash the entire _screen"
+msgstr "पूरा स्क्रीन चमकाएँ (_s)"
+
+#: ../panels/universal-access/uap.ui.h:27
+#| msgid "Typing Assistant"
+msgid "Typing Assist"
+msgstr "टाइपिंग सहायक"
+
+#: ../panels/universal-access/uap.ui.h:28
+#| msgid "Sticky Keys"
+msgid "_Sticky Keys"
+msgstr "स्टिकी कुंजी (_S)"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "कुंजी संयोजन के रूप में आपरिवर्तक कुंजी का एक अनुक्रम को मानना"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "निष्क्रिय करें यदि दो कुंजी एक साथ दबाया जाए (_D)"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifer key is pressed"
+msgstr "जब परिवर्धक कुंजी दबाएँ तो बीप बजाएँ (_m)"
+
+#: ../panels/universal-access/uap.ui.h:32
+#| msgid "Slow Keys"
+msgid "S_low Keys"
+msgstr "धीमी कुंजी (_l)"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "जब कुंजी दबा जाता है और जब इसे स्वीकार किया जाता है के बीच देरी रखें"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "स्वीकृति में देरी: (_c)"
+
+#: ../panels/universal-access/uap.ui.h:35
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "छोटा"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "धीमी कुंजी टाइपिंग विलंब"
+
+#: ../panels/universal-access/uap.ui.h:37
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "लंबा"
+
+#: ../panels/universal-access/uap.ui.h:38
+#| msgid "Beep when a _modifer key is pressed"
+msgid "Beep when a key is pr_essed"
+msgstr "जब कुंजी दबाएँ तो बीप बजाएँ (_e)"
+
+#: ../panels/universal-access/uap.ui.h:39
+#| msgid "Beep when a key is _rejected"
+msgid "Beep when a key is _accepted"
+msgstr "जब कुंजी अस्वीकृत हो तो बीप बजाएँ  (_r)"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "जब कुंजी अस्वीकृत हो तो बीप बजाएँ  (_r)"
+
+#: ../panels/universal-access/uap.ui.h:41
+#| msgid "Bounce Keys"
+msgid "_Bounce Keys"
+msgstr "उछलती कुंजियाँ (_B)"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "तेज नक़ल कीप्रेस अनदेखा करें"
+
+#: ../panels/universal-access/uap.ui.h:43
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "छोटा"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "उछलती कुंजी टाइपिंग विलंब"
+
+#: ../panels/universal-access/uap.ui.h:45
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "लंबा"
+
+#: ../panels/universal-access/uap.ui.h:46
+#| msgid "Enable by Keyboard"
+msgid "_Enable by Keyboard"
+msgstr "कुंजीपट से सक्षम करें (_E)"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "कुंजीपटल के उपयोग पर पहुंच सुविधाओं को चालू करें"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "क्लिक मदद"
+
+#: ../panels/universal-access/uap.ui.h:49
+#| msgid "Simulated Secondary Click"
+msgid "_Simulated Secondary Click"
+msgstr "सिमुलेटेड द्वितीयक क्लिक (_S)"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "प्राथमिक बटन पकड़ने के दौरान द्वितीयक कुंजी ट्रिगर करें"
+
+#: ../panels/universal-access/uap.ui.h:51
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "secondary click"
+msgid "Short"
+msgstr "छोटा"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "माध्यमिक क्लिक विलंब"
+
+#: ../panels/universal-access/uap.ui.h:53
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "लंबा"
+
+#: ../panels/universal-access/uap.ui.h:54
+#| msgid "Hover Click"
+msgid "_Hover Click"
+msgstr "होवर क्लिक (_H)"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "प्वाइंटर गति रोकने के दौरान क्लिक आरंभ करें"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "देरी: (_e)"
+
+#: ../panels/universal-access/uap.ui.h:57
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "छोटा"
+
+#: ../panels/universal-access/uap.ui.h:58
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "लंबा"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "गति देहलीज़: (_t)"
+
+#: ../panels/universal-access/uap.ui.h:60
+#| msgctxt "universal access, text size"
+#| msgid "Small"
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "छोटा"
+
+#: ../panels/universal-access/uap.ui.h:61
+#| msgctxt "universal access, text size"
+#| msgid "Large"
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "बड़ा"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "छोटा"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ स्क्रीन"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ स्क्रीन"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ स्क्रीन"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "लंबा"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "पूर्ण स्क्रीन"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "ऊपरी आधा"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "नीचला आधा"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "बायाँ आधा"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "दायाँ आधा"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "ज़ूम विकल्प"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "ज़ूम"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "आवर्धन:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "माउस संकेतक का अनुसरण करें"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "स्क्रीन हिस्सा:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "आवर्धक स्क्रीन के बाहर विस्तार करता है"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "आवर्धक कर्सर केन्द्रित रखें"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "आवर्धक कर्सर के आसपास विषयवस्तु को पुश करें"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "विषयवस्तु के साथ आवर्धक कर्सर चलता है"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "आवर्धक स्थिति:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "आवर्धक:"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "मोटाईः"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "पतला"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "मोटा "
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "लंबाईः "
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "रंगः"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "क्रासहेयर्स:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "ओवरलैप माउस संकेतक"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "क्रासहेयर्स:"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "काले पर सफेद:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "चमकीलापन:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "विरोधी:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "रंग "
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "कुछ नहीं "
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr " पूरा"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "निम्न "
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr " उच्च"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "कम"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "उच्च"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "रंग प्रभाव:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "रंग प्रभाव"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "मानक"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "प्रशासक"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+#| msgid "_Full name"
+msgid "_Full Name"
+msgstr "पूरा नाम (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "खाता प्रकार (_T)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+#| msgid "Choose password at next login"
+msgid "Allow user to set a password when they next login"
+msgstr "अगले लॉगिन में कूटशब्द सेट करने के लिए उपयोक्ता को छूट दें"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "अभी कूटशब्द निर्धारित करें"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "जाँचें (_V)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"एंटरप्राइज लॉगिन मौजूदा केंद्रीय रूप से प्रबंधित उपयोक्ता खाता की अनुमति देता "
+"है जिसे इस युक्ति पर प्रयोग किया जा सके."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "डोमेन (_D)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"ऑनलाइन हों\n"
+"ताकि एंटरप्राइज लॉगिन खाता बनाएँ."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "एंटरप्राइज लॉगिन (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "उपयोक्ता जोड़ें"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "नामांकन (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "डोमेन प्रशासक लॉगिन"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"एंटरप्राइज लॉगिन के लिए, इस कंप्यूटर को\n"
+"इस डोमेन में नामांकित होने की जरूरत है. कृपया अपने संजाल प्रशासक को\n"
+"अपने डोमेन कूटशब्द को यहाँ टाइप करने दें."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "प्रशासक नाम (_N)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "प्रशासक कूटशब्द"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "बायां थंब"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "बाईं मध्य अंगुली"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "बाईं अनामिका"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "बाईं तर्जनी"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "दाहिना अंगूठा"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "दाहिनी मध्य अंगुली"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "दाहिनी तर्जनी"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "दाहिनी तर्जनी"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:687
+msgid "Enable Fingerprint Login"
+msgstr "फिंगरप्रिंट लॉगिन सक्रिय करें"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "दायां तर्जनी (_R)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "बाईं तर्जनी (_L)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "दूसरी अंगुली: (_O)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"आपका फिंगरप्रिंट सफलतापूर्वक सहेजा गया था. आपको अब अपने फिंगरप्रिंट रीडर के "
+"प्रयोग से "
+"लॉगिन में समर्थ होना चाहिए."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "उपयोक्तानाम "
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "उपयोगकर्ताओं को जोड़ें या हटाने और अपना पासवर्ड बदलें"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "लॉगिन इतिहास"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#| msgid "Changing password for"
+msgid "Change Password"
+msgstr "कूटशब्द बदलें"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "बदलें (_a)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+#| msgid "_New password"
+msgid "_Verify New Password"
+msgstr "नया कूटशब्द जाँचें (_V)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+#| msgid "_New password"
+msgid "_New Password"
+msgstr "नया कूटशब्द (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+#| msgid "Current _password"
+msgid "Current _Password"
+msgstr "मौजूदा कूटशब्द (_P)"
+
+#  set the timeout value  label with correct value of timeout
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "उपयोगकर्ता खाता जोड़ें"
+
+#  set the timeout value  label with correct value of timeout
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "उपयोगकर्ता खाता हटायें"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "लॉगिन विकल्प"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "स्वचालित लॉगिन (_u)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "फिंगरप्रिंट लॉगिन (_F)"
+
+#  set the timeout value  label with correct value of timeout
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "उपयोक्ता प्रतीक"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "भाषा (_L)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "अंतिम लॉगिन"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "उपयोक्ता खातों का प्रबंधन करें"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "उपयोक्ता आँकड़ा बदलने के लिए सत्यापन आवश्यक है"
+
+#: ../panels/user-accounts/pw-utils.c:81
+#| msgid "The new password does not contain enough different characters"
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "नया कूटशब्द पुराने से काफी अलग होना चाहिए."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "कुछ अक्षर और संख्या बदलने की कोशिश करें."
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+#| msgid "Changing password for"
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "कूटशब्द कुछ बदलने की कोशिश करें."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "बिना आपके कूटशब्द के उपयोक्तानाम मजबूत होगा."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "कूटशब्द में अपना नाम मत डालें."
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "कूटशब्द में कोई शब्द डालने से बचें."
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "सामान्य शब्द से बचें."
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "किसी मौजूदा शब्द के बिखरी वर्तनी का उपयोग मत करें."
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "अधिक संख्या डालने की कोशिश करें."
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "अधिक बड़े अक्षर डालने की कोशिश करें."
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "अधिक छोटे अक्षर डालने की कोशिश करें."
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "अधिक विशेष वर्ण डालने की कोशिश करें, जैसे कि चिह्न विचार."
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "अक्षर, संख्या और चिह्नों के उपयोग की कोशिश करें."
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "वही वर्ण को दुहराने से बचें."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"समान प्रकार वर्ण को दुहराने से बचें: आपको अक्षर, संख्या और चिह्नों का मेल "
+"तैयार करना है."
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 या abcd जैसे शृंखला से बचें."
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "अधिक अक्षर, संख्या और संकेत जोड़ें."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr "बड़े और छोटे अक्षर और एकाधिक संख्या डालें."
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr "बढ़िया कूटशब्द! अधिक अक्षर, संख्या और चिह्न इसे मजबूत बनाएगा."
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "सामर्थ्य: कमजोर"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+#| msgid "Length:"
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "सामर्थ्य: कम"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "सामर्थ्य: मध्यम"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "सामर्थ्य: अच्छा"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "सामर्थ्य: उच्च"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "सत्यापन असफल"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "नया कूटशब्द काफी छोटा है"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "नया कूटशब्द काफी आसान है"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "नया पुराना व नया कूटशब्द काफी समान है"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "नया दो कूटशब्द समान नहीं है."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "नया कूटशब्द को जरूर संख्या या विशेष संप्रतीक शामिल रखना चाहिये."
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "पुराना व नया कूटशब्द समान है"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "आपका कूटशब्द बदला गया है जबसे आपने आरंभ में सत्यापित किया."
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "नया कूटशब्द काफी अलग अलग अक्षरों को शामिल नहीं करता है"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "अज्ञात त्रुटि"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "आपके खाता प्रदाता के वेब पता से मेल खाना चाहिए."
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "खाता जोड़ने में विफल"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+#| msgid "Passwords do not match"
+msgid "Passwords do not match."
+msgstr "कूटशब्द मेल नहीं खाता है."
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr "खाता पंजीयन में विफल"
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr "इस डोमेन के साथ प्रमाणित करने के लिए कोई समर्थित तरीका नहीं"
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr "डोमेन में शामिल होने में विफल"
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"वह लॉगिन नाम काम नहीं करता है.\n"
+"कृपया फिर कोशिश करें."
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+#| msgid "Invalid password, please try again"
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"लॉगिन कूटशब्द काम नहीं करता है.\n"
+"कृपया फिर कोशिश करें."
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr "डोमेन में लॉगिन में विफल"
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "डोमेन ढूँढ़ने में असमर्थ. शायद आपने गलत वर्तनी दे दिया हो?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:138
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"आपको युक्ति के अभिगम की अनुमति नहीं है. अपने तंत्र प्रशासक से संपर्क करें."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:140
+msgid "The device is already in use."
+msgstr "यह युक्ति पहले से प्रयोग में है."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid "An internal error occurred."
+msgstr "आंतरिक त्रुटि आयी."
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Enabled"
+msgstr "सक्षम"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr "पंजीकृत फिंगरप्रिंट मिटाएँ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr "फिंगरप्रिंट मिटाएँ (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"क्या आफ अपना पंजीकृत फिंगरप्रिंट को मिटाना चाहते हैं ताकि फिंगरप्रिंट लॉगिन "
+"निष्क्रिय हो "
+"जाए?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:444
+msgid "Done!"
+msgstr "संपन्न!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:505
+#: ../panels/user-accounts/um-fingerprint-dialog.c:547
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' युक्ति की पहुँच नहीं ले सका"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:588
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "'%s' युक्ति पर फिंगर पकड़ नहीं आरंभ कर सका"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:638
+msgid "Could not access any fingerprint readers"
+msgstr "कोई फिंगरप्रिंट रीडर की पहुँच नहीं ले सका"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:639
+msgid "Please contact your system administrator for help."
+msgstr "मदद के लिए तंत्र प्रशासक से संपर्क करें."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:721
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"फिंगरप्रिंट लॉगिन के लिए समर्थ करने में, आप अपने एक फिंगरप्रिंट को सहेजने की "
+"जरूरत है, '%s' "
+"युक्ति के प्रयोग से."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:728
+msgid "Selecting finger"
+msgstr "उंगली का चयन"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:729
+msgid "Enrolling fingerprints"
+msgstr "फिंगरप्रिंट दाखिला"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "इस हफते"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "पिछले सप्ताह"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:631
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "सत्र समाप्त"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "सत्र आरंभ"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "कृपया अन्य कूटशब्द का चयन करें."
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "अपना मौजूदा कूटशब्द फिर टाइप करें."
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "आपका कूटशब्द बदला गया है"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+#| msgid "The passwords do not match"
+msgid "The passwords do not match."
+msgstr "कूटशब्द मेल नहीं खाता है."
+
+#: ../panels/user-accounts/um-photo-dialog.c:219
+msgid "Browse for more pictures"
+msgstr "अधिक छवियाँ के लिए ब्राउज़ करें"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#: ../panels/user-accounts/um-photo-dialog.c:453
+msgid "Disable image"
+msgstr "छिव अक्षम करें"
+
+#: ../panels/user-accounts/um-photo-dialog.c:471
+msgid "Take a photo…"
+msgstr "एक तस्वीर लें... "
+
+#: ../panels/user-accounts/um-photo-dialog.c:489
+msgid "Browse for more pictures…"
+msgstr "अधिक छवियाँ के लिए ब्राउज़ करें…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:713
+#, c-format
+msgid "Used by %s"
+msgstr "%s के द्वारा प्रयुक्त"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "डोमेन के इस प्रकार के स्वचालित रूप से शामिल नहीं हो सकते"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "कोई ऐसा डोमेन या रियल्म नहीं मिला"
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "बतौर %s %s डोमेन पर लॉगिन नहीं कर सकता है"
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr "अवैध कूटशब्द, कृपया फिर कोशिश करें"
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "%s डोमेन से कनेक्ट नहीं कर सका: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:198
+msgid "Other Accounts"
+msgstr "अन्य खाता"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "Failed to delete user"
+msgstr "उपयोक्ता मिटाने में विफल"
+
+#: ../panels/user-accounts/um-user-panel.c:482
+msgid "You cannot delete your own account."
+msgstr "आप अपने खुद के खाते को नष्ट नहीं कर सकते हैं."
+
+#: ../panels/user-accounts/um-user-panel.c:491
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s अभी भी लॉग इन है"
+
+#: ../panels/user-accounts/um-user-panel.c:495
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"उपयोगकर्ता का विलोपन जब वे लॉग इन कर रहे हो से तंत्र को छोड़ सकते हैं असंगत "
+"स्थिति में."
+
+#: ../panels/user-accounts/um-user-panel.c:504
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "क्या आप %s के फाइल को रखना चाहते है?"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"उपयोगकर्ता खाते को हटाने के समय घर निर्देशिका, मेल स्पूल और अस्थायी फ़ाइलों "
+"को रखने की "
+"संभावना है."
+
+#: ../panels/user-accounts/um-user-panel.c:511
+msgid "_Delete Files"
+msgstr "फ़ाइल मिटाएँ (_D)"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-app-helper.c:82 libgnomeui/gnome-app-helper.h:513
+# test-gnome/testgnome.xml.h:5
+#: ../panels/user-accounts/um-user-panel.c:512
+msgid "_Keep Files"
+msgstr "फ़ाइल रखें (_F)"
+
+#: ../panels/user-accounts/um-user-panel.c:564
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "खाता अक्षम"
+
+#: ../panels/user-accounts/um-user-panel.c:572
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "अगले लॉगिन में इसे सेट करें"
+
+#: ../panels/user-accounts/um-user-panel.c:575
+msgctxt "Password mode"
+msgid "None"
+msgstr "कुछ नहीं"
+
+#: ../panels/user-accounts/um-user-panel.c:624
+msgid "Logged in"
+msgstr "लाग्ड इन"
+
+#: ../panels/user-accounts/um-user-panel.c:1071
+msgid "Failed to contact the accounts service"
+msgstr "खातों सेवा से संपर्क करने में विफल"
+
+#: ../panels/user-accounts/um-user-panel.c:1073
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "कृपया सुनिश्चित करें कि खाता सेवा स्थापित और सक्षम है."
+
+#: ../panels/user-accounts/um-user-panel.c:1114
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"बदलाब लाने के लिए,\n"
+"क्लिक करें * चिह्न पर पहले"
+
+#: ../panels/user-accounts/um-user-panel.c:1152
+msgid "Create a user account"
+msgstr "उपयोगकर्ता खाता बनाएँ"
+
+#: ../panels/user-accounts/um-user-panel.c:1163
+#: ../panels/user-accounts/um-user-panel.c:1475
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"उपयोगकर्ता खाता बनाने के लिए,\n"
+"क्लिक करें * चिह्न पर पहले"
+
+#: ../panels/user-accounts/um-user-panel.c:1173
+msgid "Delete the selected user account"
+msgstr "चयनित उपयोगकर्ता खाता को हटायें"
+
+#: ../panels/user-accounts/um-user-panel.c:1185
+#: ../panels/user-accounts/um-user-panel.c:1480
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"चयनित उपयोगकर्ता खाता को हटाने के लिए,\n"
+"क्लिक करें * चिह्न पर पहले"
+
+#: ../panels/user-accounts/um-user-panel.c:1389
+msgid "My Account"
+msgstr "मेरा खाता"
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+#| msgid "A user with the username '%s' already exists"
+msgid "A user with the username '%s' already exists."
+msgstr "उपयोक्तानाम '%s' के साथ उपयोगकर्ता पहले से मौजूद है."
+
+#: ../panels/user-accounts/um-utils.c:571
+#, c-format
+#| msgid "The username is too long"
+msgid "The username is too long."
+msgstr "उपयोक्तानाम काफी लंबा है."
+
+#: ../panels/user-accounts/um-utils.c:574
+#| msgid "The username cannot start with a '-'"
+msgid "The username cannot start with a '-'."
+msgstr "उपयोक्तानाम '-' के साथ आरंभ नहीं कर सका."
+
+#: ../panels/user-accounts/um-utils.c:577
+#| msgid ""
+#| "The username must only consist of:\n"
+#| " ➣ letters from the English alphabet\n"
+#| " ➣ digits\n"
+#| " ➣ any of the characters '.', '-' and '_'"
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"उपयोक्तानाम  केवल a-z अक्षर, अंकों और '.', '-' और '_' में से किसी वर्ण से "
+"मिलकर होना चाहिए."
+
+#: ../panels/user-accounts/um-utils.c:581
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+"यह करने के लिए अपने घर फ़ोल्डर नाम का इस्तेमाल किया जाएगा और बदला नहीं जा "
+"सकता."
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:831
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "नक्शे बटन"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr "कार्य करने के लिए नक्शे बटन"
+
+#: ../panels/wacom/button-mapping.ui.h:4
+#| msgid ""
+#| "To edit a shortcut, click the row and hold down the new keys or press "
+#| "Backspace to clear."
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"शॉर्टकट संपादित करने के लिए, \"Send Keystroke\"  क्रिया चुनें, कुंजीपट "
+"शॉर्टकल बटन दबाएँ और नई कुंजी नीचे पकड़े या स्पष्ट करने के लिए बैकस्पेस प्रेस "
+"करें."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"कृपया लक्ष्य मार्करों को टैप करें जो टैबलेट को कैलिब्रेट करते समय स्क्रीन पर "
+"दिखाई देते हैं."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "गलत-क्लिक का पता चला, पुनरारंभ कर रहा है ..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "ऊपर"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "नीचे"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "कुछ नहीं"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "कीस्ट्रोक भेजें"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "मॉनिटर बदलें"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "स्क्रीन पर मदद दिखाएं"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "आउटपुट:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "पहलू अनुपात बनाए रखें (लेटरबॉक्स):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "एकल मॉनिटर से मानचित्रित करें"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d का %d"
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "मानचित्रण प्रदर्शित करें"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "बटन"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Wacom Tablet"
+msgstr "Wacom टेब्लेट"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"बटन मैपिंग सेट और ग्राफिक्स गोलियाँ के लिए स्टाइलस संवेदनशीलता को समायोजित"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "टैब्लेट;Wacom;लेखनी;इरेज़र;माउस;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "टैब्लेट (निरपेक्ष)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "टचपैड (सापेक्षिक)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "टैबलेट वरीयताएँ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "No tablet detected"
+msgstr "कोई टैबलेट पता नहीं लगा है"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "कृपया अपने Wacom टैबलेट को चालू या प्लगिन करें"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Bluetooth Settings"
+msgstr "ब्लूटूथ सेटिंग"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map to Monitor…"
+msgstr "मॉनिटर से मानचित्रित करें..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map Buttons…"
+msgstr "नक्शे बटन…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust display resolution"
+msgstr "रिसॉल्यूशन प्रदर्शन समायोजित करें"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+#| msgid "Mouse Settings"
+msgid "Adjust mouse settings"
+msgstr "माउस सेटिंग समायोजित करें"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Tracking Mode"
+msgstr "ट्रैकिंग मोड"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Left-Handed Orientation"
+msgstr "बाएँ-हाथ ओरिएंटेशन"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+msgid "Left Ring"
+msgstr "बाईं अनामिका"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "बाईं अनामिका मोड #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+msgid "Right Ring"
+msgstr "दाहिनी तर्जनी"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "दाहिनी तर्जनी मोड #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+msgid "Left Touchstrip"
+msgstr "बाईं Touchstrip"
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "बाईं Touchstrip मोड #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+msgid "Right Touchstrip"
+msgstr "दायाँ Touchstrip"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "दायाँ Touchstrip मोड #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "बाईं Touchring मोड स्विच करें"
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "दायाँ Touchring मोड स्विच करें"
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "बाईं Touchstrip मोड स्विच करें"
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "दायाँ Touchstrip मोड स्विच करें"
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "मोड स्विच #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr "बायाँ बटन #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr "दायाँ बटन #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr "शीर्ष बटन #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "नीचे बटन #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+#| msgid "New shortcut..."
+msgid "New shortcut…"
+msgstr "नया शार्टकट..."
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "कोई क्रिया नहीं"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "बाईं माउस बटन पर क्लिक करें"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "मध्य माउस बटन पर क्लिक करें"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "दायाँ माउस बटन पर क्लिक करें"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "ऊपर स्क्रॉल करें"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "नीचे स्क्रॉल करें"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "बाएँ स्क्रॉल करें"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "दाएँ स्क्रॉल करें"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "पीछे"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "आगे"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "स्टाइलस"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "इरेज़र दबाव फील करें"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "सॉफ्ट"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "फर्म"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "शीर्ष बटन"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "निचले बटन"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "टिप दबाव फील करें"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "भर्बोस विधि सक्रिय करें"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "सारांश दिखाएँ"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "स्ट्रिंग के लिए खोजें"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "संभव पैनल के नामों की सूची और बाहर निकलें"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "मदद विकल्प दिखाएँ"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "दिखाने के लिए पटल"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- सेटिंग्स"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"'%s --help' को उपलब्ध कमांड लाइन विकल्प की पूरी सूची दिखाने के लिए चलाएँ.\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "उपलब्ध पैनल:"
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "मदद"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "बाहर"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+msgid "All Settings"
+msgstr "सभी सेटिंग्स"
+
+#. Add categories
+#: ../shell/cc-window.c:876
+msgctxt "category"
+msgid "Personal"
+msgstr "निजी"
+
+#: ../shell/cc-window.c:877
+msgctxt "category"
+msgid "Hardware"
+msgstr "हार्डवेयर"
+
+#: ../shell/cc-window.c:878
+msgctxt "category"
+msgid "System"
+msgstr "सिस्टम"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "वरीयताएँ;सेटिंग्स;"
+
+#~ msgid "Flickr"
+#~ msgstr "फ्लिकर"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "नई युक्ति सेटअप करें"
+
+#~ msgid "Connection"
+#~ msgstr "कनेक्शन"
+
+#~ msgid "Paired"
+#~ msgstr "युग्म"
+
+#~ msgid "Type"
+#~ msgstr "प्रकार"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "माउस & टचपैड सेटिंग"
+
+#~ msgid "Sound Settings"
+#~ msgstr "ध्वनि विन्यास"
+
+#~ msgid "Send Files…"
+#~ msgstr "फाइल भेजें... "
+
+#~ msgid "Visibility"
+#~ msgstr "दृश्यता"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "दृश्यता “%s” का"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "'%s' को युक्तियों की सूची से हटाता है?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "यदि आप युक्ति को हटाते हैं, आपको इसे फिर से सेटअप करना होगा आगे के प्रयोग के पहले."
+
+#~ msgid "Export"
+#~ msgstr "निर्यात"
+
+#~ msgid "Device type:"
+#~ msgstr "उपकरण क़िस्म:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "उत्पादक:"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~ msgid "Model:"
+#~ msgstr "मॉडलः"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "छवि फ़ाइलें इस विंडो पर उपरोक्त क्षेत्रों को स्वत: पूरा करने के लिए ड्रैग कर सकते हैं."
+
+#~ msgid "Left Shift"
+#~ msgstr "बायां शिफ्ट "
+
+#~ msgid "Left Alt"
+#~ msgstr "बायां आल्ट "
+
+#~ msgid "Left Ctrl"
+#~ msgstr "बायाँ कंट्रोल"
+
+#~ msgid "Right Shift"
+#~ msgstr "दायां शिफ्ट "
+
+#~ msgid "Right Alt"
+#~ msgstr " दायां आल्ट"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "दायाँ कंट्रोल"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "बायां आल्ट+शिफ्ट "
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "बायां कंट्रोल+शिफ़्ट"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "दायां कंट्रोल+शिफ़्ट"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "आल्ट+शिफ्ट "
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "कंट्रोल+शिफ़्ट"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "आल्ट+कंट्रोल"
+
+#~ msgid "Caps"
+#~ msgstr "कैप्स"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "शिफ्ट + कैप्स"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "आल्ट+कैप्स"
+
+#~ msgid "_Region:"
+#~ msgstr "क्षेत्र: (_R)"
+
+#~ msgid "_City:"
+#~ msgstr "शहर: (_C)"
+
+#~ msgid "_Network Time"
+#~ msgstr "संजाल समय (_N)"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "समय एक घंटे आगे निर्धारित करें."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "वापस समय एक घंटे के सेट करें."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "समय एक मिनट आगे निर्धारित करें."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "समय एक मिनट पहले निर्धारित करें."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM और PM के बीच स्विच करें."
+
+#~ msgid "AM/PM"
+#~ msgstr "पूर्वाह्न/अपराह्न"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "सामान्य"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "घड़ी की विपरीत दिशा में"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "घड़ी की दिशा में"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 डिग्रीज़"
+
+#~ msgid "Monitor"
+#~ msgstr "मॉनीटर"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "प्राथमिक प्रदर्शन बदलने के लिए खींचें."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "इसके गुणों को बदलने के लिए मॉनिटर का चयन करें; इसे उसके स्थान पर पुनर्व्यवस्थित करने के "
+#~ "लिए खींचें."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "मॉनिटर विन्यास सहेज नहीं सका"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "प्रदर्शन पता नहीं कर सका"
+
+#~ msgid "_Resolution"
+#~ msgstr "रेज़ोल्यूशन (_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "घूर्णन (_o)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "मिरर प्रदर्शन (_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "नोट: रिसॉल्यूशन विकल्पों को सीमित कर सकते हैं"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "प्रदर्शक का पता लगायें (_D)"
+
+#~ msgid "Install Updates"
+#~ msgstr "अद्यतन संस्थापित करें"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "सिस्टम अद्यतन"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "माउस वरीयताएँ"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "धीमा"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "तेज"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "फिंगर में अंतर्वस्तु चिपक जाती है (_o)"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-# gnome-session/logout.c:266
+#~ msgid "_Options…"
+#~ msgstr "विकल्प... (_O)"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "नयी सुविधा का उपयोग करने के लिए अंतरफलक का चयन करे"
+
+#~ msgid "C_reate…"
+#~ msgstr "बनाएँ…  (_r)"
+
+#~ msgid "_Interface"
+#~ msgstr "अंतरफलक (_I)"
+
+#~ msgid "_Default"
+#~ msgstr "तयशुदा (_D)"
+
+#~ msgid "Hidden"
+#~ msgstr "छुपा"
+
+#~ msgid "Visible"
+#~ msgstr "दृष्टिगोचर"
+
+#~ msgid "Name & Visibility"
+#~ msgstr " नाम & दृश्यता"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "नियंत्रित करें कैसे आप स्क्रीन और नेटवर्क पर दिखाई देते हैं."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "शीर्ष बार में पूरा नाम प्रदर्शित करें (_f)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "लॉक स्क्रीन में पूरा नाम प्रदर्शित करें (_l)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "गुप्त मोड (_S)"
+
+#~ msgid "Immediately"
+#~ msgstr "तत्काल"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "कुछ नहीं"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "सार्वजनिक फ़ोल्डर साझा करें."
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "विश्वस्त युक्तियां के साथ केवल साझा करें"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "इस नेटवर्क पर मीडिया साझा करें "
+
+#~ msgid "Shared Folders"
+#~ msgstr "साझा फोल्डर"
+
+#~ msgid "column"
+#~ msgstr "स्तम्भ"
+
+#~ msgid "Remove Folder"
+#~ msgstr "फ़ोल्डर मिटाएँ"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "इस नेटवर्क पर सार्वजनिक फ़ोल्डर साझा करें "
+
+#~ msgid "Remote View"
+#~ msgstr "रिमोट दृश्य"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "सभी कनेक्शनों को स्वीकृत करें"
+
+#~ msgid "No shortcut set"
+#~ msgstr "कोई शार्टकट सेट नहीं है..."
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "सामान्य"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "उच्च/विलोम"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "आऩ स्क्रीन कुंजीपटल"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "सामान्य"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "बड़ा"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "कैप्स और न्यूम लॉक पर बीप"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "चालू या बंद करें:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "छोटा-बड़ा करें"
+
+#~ msgid "Zoom in:"
+#~ msgstr "बड़ा करें:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "छोटा करें:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "बंद अनुशीर्षक"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "भाषण और ध्वनियों की शाब्दिक वर्णन प्रदर्शित करें"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "ऑनस्क्रीन कुंजीपटल"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "छोटा"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "लंबा"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "जब कुंजी दबाएँ तो बीप बजाएँ"
+
+#~ msgid "pressed"
+#~ msgstr "दबाया गया"
+
+#~ msgid "accepted"
+#~ msgstr "स्वीकृत"
+
+#~ msgid "rejected"
+#~ msgstr "अस्वीकृत"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "स्वीकृति विलंब: (_e)"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "कुंजीपैड के प्रयोग से प्वाइंटर नियंत्रित किया जा सकता है"
+
+#~ msgid "Video Mouse"
+#~ msgstr "वीडियो माउस"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "वीडियो कैमरा का उपयोग से संकेतक नियंत्रण."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "छोटा"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "विशाल"
+
+#~ msgid "Add account"
+#~ msgstr "खाता जोड़ें"
+
+#~ msgid "_Local Account"
+#~ msgstr "स्थानीय खाता (_L)"
+
+#~ msgid "_Login Name"
+#~ msgstr "लॉगिन नाम (_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "संकेत: एंटरप्राइज डोमेन नाम या रियल्म नाम"
+
+#~ msgid "C_ontinue"
+#~ msgstr "जारी रखें (_o)"
+
+#~ msgid "Previous Week"
+#~ msgstr "पिछला सप्ताह "
+
+#~ msgid "Next Week"
+#~ msgstr "अगले सप्ताह"
+
+#~ msgid "Next week"
+#~ msgstr "अगला सप्ताह"
+
+#~ msgid "Log in without a password"
+#~ msgstr "कूटशब्द के बिना में लॉग इन करें"
+
+#~ msgid "Disable this account"
+#~ msgstr "इस खाते को अक्षम करें"
+
+#~ msgid "Enable this account"
+#~ msgstr "खाता सक्रिय करें"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "कूटशब्द की पुष्टि करें (_o)"
+
+#~ msgid "Generate a password"
+#~ msgstr "कूटशब्द उत्पन्न करें"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#~ msgid "_Action"
+#~ msgstr "क्रिया (_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "कूटशब्द दिखाएं (_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "How to choose a strong password"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "इसके लिए फोटो बदलें:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "तस्वीर चुनें जो इस खाते के लिए लॉगिन स्क्रीन पर दिखाया जाएगा."
+
+#~ msgid "Gallery"
+#~ msgstr "दीर्घा"
+
+#~ msgid "Take a photograph"
+#~ msgstr "एक चित्र लें"
+
+#~ msgid "Browse"
+#~ msgstr "ब्राउज़"
+
+#~ msgid "Photograph"
+#~ msgstr "फोटोग्राफ"
+
+#~ msgid "Account Information"
+#~ msgstr "खाता जानकारी"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "काफी छोटा"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "पर्याप्त अच्छा नहीं"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "कमजोर"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "साफ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "अच्छा"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "मजबूत"
+
+#~ msgid "_Generate a password"
+#~ msgstr "एक कूटशब्द बनाएँ (_G)"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "आपको नया पासवर्ड फिर टाइप करना होगा"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "नया पासवर्ड पर्याप्त मजबूत नहीं है"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "आप को कूटशब्द की पुष्टि करने की आवश्यकता है"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "आप अपने मौजूदा कूटशब्द दर्ज करने की आवश्यकता है"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "कूटशब्द गलत था"
+
+#~ msgid "Wrong password"
+#~ msgstr "गलत पासवर्ड"
+
+#~ msgid "Switch Modes"
+#~ msgstr "स्विच मोड"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#~ msgid "Action"
+#~ msgstr "कार्य"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "दायां आल्ट+शिफ्ट "
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "दायां + बायां शिफ्ट "
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "दायां + बायां कंट्रोल"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "कंट्रोल+कैप्स"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "अनुमानित बैटरी की क्षमता: %s"
+
+#~ msgid "blablabla"
+#~ msgstr "blablabla"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "पता\n"
+#~ "अनुभाग\n"
+#~ "यहाँ\n"
+#~ "जाता है"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "अनुभाग\n"
+#~ "यहाँ\n"
+#~ "जाता है"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "मार्ग\n"
+#~ "अनुभाग\n"
+#~ "यहाँ\n"
+#~ "जाता है"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "Change the background"
+#~ msgstr "पृष्ठभूमि बदलें"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "ब्लूटूथ सेटिंग विन्यस्त करें"
+
+#~ msgid "Browse Files..."
+#~ msgstr "फाइल ब्रॉउज करें..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "ब्लूटूथ"
+
+#~ msgid "Create virtual device"
+#~ msgstr "वर्चुअल मशीन बनाएँ"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "प्रदर्शन के लिए उपलब्ध प्रोफाइल"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "स्कैनर्स के लिए उपलब्ध प्रोफाइल"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "प्रिंटर्स के लिए उपलब्ध प्रोफाइल"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "कैमरे के लिए उपलब्ध प्रोफाइल"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "वेबकैम के लिए उपलब्ध प्रोफाइल"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i साल"
+#~ msgstr[1] "%i साल"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i माह"
+#~ msgstr[1] "%i माह"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i सप्ताह"
+#~ msgstr[1] "%i सप्ताह"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "कम से कम 1 सप्ताह"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "इस उपकरण में प्रबंधित रंग नहीं है."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "कैलिब्रेटेड डेटा का प्रयोग करके इस युक्ति का निर्माण हुआ है."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "इस युक्ति के लिए कोई उपयुक्त प्रोफाइल पूर्ण स्क्रीन रंग सुधार के लिए नहीं है."
+
+#~ msgid "Not specified"
+#~ msgstr "उल्लेखित नहीं"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "कोई रंग प्रबंधन समर्थन उपकरणों नहीं मिला"
+
+#~ msgid "Add device"
+#~ msgstr "युक्ति जोड़ें"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "वर्चुअल युक्ति जोड़ें"
+
+#~ msgid "Remove a device"
+#~ msgstr "युक्ति हटायें"
+
+#~ msgid "Color management settings"
+#~ msgstr "रंग प्रबंधन सेटिंग्स"
+
+#~ msgid "English"
+#~ msgstr "अंग्रेज़ी"
+
+#~ msgid "British English"
+#~ msgstr "ब्रिटिश अंग्रेजी"
+
+#~ msgid "German"
+#~ msgstr "जर्मन"
+
+#~ msgid "French"
+#~ msgstr "फ्रेंच"
+
+#~ msgid "Spanish"
+#~ msgstr "स्पानिश"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "चीनी (सरल))"
+
+#~ msgid "Russian"
+#~ msgstr "रूसी"
+
+#~ msgid "Arabic"
+#~ msgstr "अरबी"
+
+#~ msgid "Unspecified"
+#~ msgstr "अविशिष्ट"
+
+#~ msgid "Select a language"
+#~ msgstr "भाषा चुनें"
+
+#~ msgid "_Select"
+#~ msgstr "चुनें (_S)"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "दिनांक और समय वरीयताओं पैनल"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "अज्ञात मॉडल"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "अगले लॉगिन मानक अनुभव का उपयोग करने का प्रयास करेंगे."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "असमर्थित ग्राफिक्स हार्डवेयर का प्रयोजन रखने के लिए अगले लॉगिन फॉलबैक मोड का उपयोग "
+#~ "करेगा."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "फालबैक"
+
+#~ msgid "System Information"
+#~ msgstr "तंत्र जानकारी"
+
+#~ msgid "OS type"
+#~ msgstr "OS प्रकार"
+
+#~ msgid "_Other Media..."
+#~ msgstr "अन्य मीडिया ... (_O)"
+
+#~ msgid "Experience"
+#~ msgstr "अनुभव"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "फोर्स्ड फ़ॉलबैक मोड  (_F)"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "कुंजीपटल सेटिंग्स बदलें"
+
+#~ msgid "Layout Settings"
+#~ msgstr "लेआउट सेटिंग्स"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "अपने माउस और टचपैड की वरीयताएँ नियत करें"
+
+#~ msgid "Network settings"
+#~ msgstr "नेटवर्क सेटिंग्स"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "नेटवर्क;वायरलेस;आईपी;लैन;प्रॉक्सी;"
+
+#~ msgid "Out of range"
+#~ msgstr "सीमा से बाहर"
+
+#~ msgid "_Options..."
+#~ msgstr "विकल्प... (_O)"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~ msgid "C_reate..."
+#~ msgstr "बनाएँ (_r)..."
+
+#~ msgid "_Configure..."
+#~ msgstr "विन्यस्त करें... (_C)"
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "बेतार हॉटस्पॉट"
+
+#~ msgid "Wireless"
+#~ msgstr "बेतार"
+
+#~| msgid "Disconnected"
+#~ msgid "_Disconnect"
+#~ msgstr "डिस्कनेक्ट करें (_D)..."
+
+#~ msgid "_Connect"
+#~ msgstr "कनेक्ट करें (_C)"
+
+# libgnomeprintui/gpaui/add-printer-dialog.c:83
+# libgnomeprintui/gpaui/config-dialog.c:83
+#~ msgid "Mesh"
+#~ msgstr "मेश"
+
+#~ msgid "Disconnected"
+#~ msgstr "डिस्कनेक्टेड"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "कैरियर/कड़ी परिवर्तित"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "क्रेडेंशियल की समय सीमा समाप्त.कृपया फिर से प्रवेश करें."
+
+#~ msgid "_Log In"
+#~ msgstr "लॉग इन (_L) "
+
+#~ msgid "Manage online accounts"
+#~ msgstr "ऑनलाइन खातों का प्रबंधन"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "सावधान कम बैटरी, %s शेष"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "बैटरी शक्ति का उपयोग - %s शेष"
+
+#~ msgid "Using battery power"
+#~ msgstr "बैटरी शक्ति का उपयोग"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "चार्जिंग - पूरी तरह चार्ज्ड"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "यूपीएस शक्ति का उपयोग - %s शेष"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "सावधान कम यूपीएस"
+
+#~ msgid "Using UPS power"
+#~ msgstr "यूपीएस शक्ति का उपयोग"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "आपका माध्यमिक बैटरी पूरी तरह चार्ज है"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "आपका माध्यमिक बैटरी खाली है"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "चार्जिंग - पूरी तरह चार्ज्ड"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "संकेत: <a href=\"screen\">screen brightness</a> प्रभावित करता है कि कितनी "
+#~ "शक्ति प्रयोग होनी है"
+
+#~ msgid "Power management settings"
+#~ msgstr "बिजली प्रबंधन सेटिंग्स"
+
+# #-#-#-#-#  gnome-icon-theme.gnome-2-2.hi.po (gnome-icon theme 2.2)  #-#-#-#-# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#~ msgid "Don't suspend"
+#~ msgstr "निलंबित नहीं"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "निलंबित करें जब इसके लिए निष्क्रिय है"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "ठहरा"
+
+#~ msgid "Change printer settings"
+#~ msgstr "प्रिंटर सेटिंग्स बदलें"
+
+#~ msgid "Manufacturers"
+#~ msgstr "उत्पादक:"
+
+#~ msgid "Drivers"
+#~ msgstr "ड्राइवर"
+
+#~ msgid "_Show"
+#~ msgstr "दिखाएँ (_S)"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "अपने क्षेत्र और भाषा सेटिंग्स को बदलें"
+
+#~ msgid "Choose an input source"
+#~ msgstr "इनपुट स्रोत चुनें"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "जोड़ने के लिए इनपुट स्रोत का चुनें"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "लॉगिन स्क्रीन, तंत्र खातों और नई उपयोगकर्ता खातों सिस्टम-विस्तारित क्षेत्र और भाषा "
+#~ "सेटिंग्स का उपयोग करें."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "लॉगिन स्क्रीन, तंत्र खातों और नई उपयोगकर्ता खातों सिस्टम-विस्तारित क्षेत्र और भाषा "
+#~ "सेटिंग्स का उपयोग करें. आप अपने से मेल करने के लिए तंत्र सेटिंग को बदल सकते है"
+
+#~ msgid "Copy Settings"
+#~ msgstr "सेटिंग की नक़ल लें"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "सेटिंग की नक़ल लें..."
+
+#~ msgid "Region and Language"
+#~ msgstr "क्षेत्र और भाषा"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr "प्रदर्शन भाषा चुनें (अगली बार जब आप लॉगइन करेगे तब परिवर्तन लागु होगा)"
+
+#~ msgid "Add Language"
+#~ msgstr "भाषा जोड़ें"
+
+#~ msgid "Remove Language"
+#~ msgstr "भाषा हटाएँ"
+
+#~ msgid "Install languages..."
+#~ msgstr "भाषा संस्थापित करें..."
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "क्षेत्र चुनें (अगली बार जब आप लॉगइन करेगे तब परिवर्तन लागु होगा)"
+
+#~ msgid "Add Region"
+#~ msgstr "क्षेत्र जोड़ें"
+
+#~ msgid "Currency"
+#~ msgstr "मुद्रा"
+
+#~ msgid "Examples"
+#~ msgstr "उदाहरण"
+
+#~| msgid "Select an input source to add"
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "कुंजीपटल या अन्य इनपुट स्रोत को चुनें"
+
+#~| msgid "Input source:"
+#~ msgid "Remove Input Source"
+#~ msgstr "इनपुट स्रोत हटाएँ"
+
+#~| msgid "Input source:"
+#~ msgid "Move Input Source Up"
+#~ msgstr "इनपुट स्रोत ऊपर खिसकाएँ"
+
+#~| msgid "Keyboard Layout Options"
+#~ msgid "Show Keyboard Layout"
+#~ msgstr "कुंजीपटल लेआउट दिखाएँ"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "शॉर्टकट सेटिंग्स"
+
+#~ msgid "Display language:"
+#~ msgstr "भाषा प्रदर्शित करें:"
+
+#~ msgid "Input source:"
+#~ msgstr "इनपुट स्रोत:"
+
+#~ msgid "Format:"
+#~ msgstr "प्रारूप:"
+
+#~ msgid "Your settings"
+#~ msgstr "आपकी सेटिंग्स"
+
+#~ msgid "System settings"
+#~ msgstr "तंत्र सेटिंग"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "चमकीलापन और लॉक"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "स्क्रीन चमकीलापन और लॉक सेटिंग्स"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "चमकीलापन;लॉक;डिम;रिक्त;मॉनिटर;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "डिम स्क्रीन शक्ति सहेजने के लिए (_D)"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "लॉक न करे जब घर पर हो"
+
+#~ msgid "Locations..."
+#~ msgstr "स्थान..."
+
+#~ msgid "Lock"
+#~ msgstr "बंद करें"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "डिबगिंग कोड सक्रिय करें"
+
+#~ msgid "Version of this application"
+#~ msgstr "इस अनुप्रयोग का संस्करण"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — गनोम आवाज नियंत्रक एप्लेट"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "डेस्कटॉप आवाज नियंत्रण दिखाएँ"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "ध्वनि आउटपुट आवाज़"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "माइक्रोफ़ोन वॉल्यूम"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "ध्वनि वरीयता आरंभ करने में विफल: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "मूक (_M)"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "ध्वनि वरीयता (_S)"
+
+#~ msgid "Muted"
+#~ msgstr "मौन"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "सार्वभौमिक पहुंच वरीयता"
+
+#~ msgid "Options..."
+#~ msgstr "विकल्प..."
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "रंग"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "कुछ नहीं"
+
+#  set the timeout value  label with correct value of timeout
+#~ msgid "User Accounts"
+#~ msgstr "उपयोक्ता खाता"
+
+#~ msgid "_Hint"
+#~ msgstr "संकेत (_H)"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "यह संकेत लॉगिन स्क्रीन पर प्रदर्शित किया जा सकता है. यह दृश्यमान हो जाएगा इस  "
+#~ "प्रणाली के सभी उपयोगकर्ताओं  के लिए.  यहाँ पासवर्ड शामिल </b>नहीं</b> करें."
+
+#~ msgid "Fair"
+#~ msgstr "ठीक-ठाक"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "अधिक छवियाँ के लिए ब्राउज़ करें..."
+
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "'%s' नाम का कोई उपयोक्ता मौजूद नहीं."
+
+#~ msgid "This user does not exist."
+#~ msgstr "यह उपयोक्ता मौजूद नहीं है."
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "अपने Wacom टैबलेट वरीयताओं को सेट करें"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "नक्शे बटन..."
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-# libgnomeui/gnome-app-helper.c:166
+#~ msgid "Calibrate..."
+#~ msgstr "कैलिब्रेट..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- तंत्र सेटिंग्स"
+
+#~ msgid "Control Center"
+#~ msgstr "नियंत्रण केंद्र"
+
+#~ msgid "System Settings"
+#~ msgstr "तंत्र विन्यास"
+
+#  Create the file chooser dialog stuff here
+#~| msgid "Wallpapers"
+#~ msgid "Add wallpaper"
+#~ msgstr "वालपेपर जोड़ें"
+
+#  Create the file chooser dialog stuff here
+#~| msgid "Wallpapers"
+#~ msgid "Remove wallpaper"
+#~ msgstr "वालपेपर हटाएँ"
+
+#~ msgid "Swap colors"
+#~ msgstr "रंग आपस में बदलें"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "क्षैतिज ढाल"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "लंबवत झुकाव"
+
+#~ msgid "Solid Color"
+#~ msgstr "ठोस रंग"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "रंग & अनुपात"
+
+# #-#-#-#-#  gnome-session.gnome-2-2.hi.po (gnome-session VERSION)  #-#-#-#-#
+# gnome-session/logout.c:266
+#~ msgid "Acti_on:"
+#~ msgstr "क्रिया: (_o)"
+
+#~| msgid "Take a photo..."
+#~ msgid "Take a screenshot"
+#~ msgstr "स्क्रीनशॉट लें"
+
+#~ msgid "Shortcut"
+#~ msgstr "शार्टकट"
+
+#~ msgid "_Right-handed"
+#~ msgstr "दाहिने हाथ से काम करने वाला (_R)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "वाम-हस्त (_L)"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Control कुंजी दबाए जाने पर प्वाइंटर की स्थिति दिखाएँ (_o)"
+
+#~| msgid "_Acceleration:"
+#~ msgid "A_cceleration:"
+#~ msgstr "त्वरक: (_c)"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "संवेदनशीलता:  (_S)"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "खींचें और गिराएँ"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "देहलीज़:  (_e)"
+
+#~| msgid "Thr_eshold:"
+#~ msgid "Drag Threshold"
+#~ msgstr "ड्रैग थ्रेशोल्ड"
+
+#~ msgid "Double-Click Timeout"
+#~ msgstr "दोहरा क्लिक टाइमआउट"
+
+#~ msgid "_Timeout:"
+#~ msgstr "टाइमआउट: (_T)"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "अपनी दोहरा क्लिक सेटिंग को जाँचने के लिए, चेहरे पर दोहरा क्लिक आजमाएँ."
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "टचपैड के साथ माउस क्लिक सक्रिय करें (_m)"
+
+#~ msgid "Scrolling"
+#~ msgstr "स्क्रॉल कर रहे"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-#
+# gtk/gtkinputdialog.c:238
+#~ msgid "_Disabled"
+#~ msgstr "निष्क्रिय (_D)"
+
+#~| msgid "Other..."
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "अन्य..."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "कैसे भी हॉटस्पॉट बनाएँ?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "डिस्कनेक्ट करें %s से और नया हॉटस्पॉट बनायें?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "यह आपका एकमात्र कनेक्शन इन्टरनेट से है."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "हॉटस्पॉट बनाएँ (_H)"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "सबनेट मास्क"
+
+#~ msgid "_Network Name"
+#~ msgstr "संजाल नाम (_N)"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "हॉटस्पॉट रोकें... (_S)"
+
+# #-#-#-#-#  gnome-applets.gnome-2-2.hi.po (gnome-applets 2.x)  #-#-#-#-# gtk/gtkinputdialog.c:238
+#~| msgid "Disabled"
+#~ msgid "Disable VPN"
+#~ msgstr "अक्षम VPN"
+
+#~| msgid "_HTTP Proxy"
+#~ msgid "HTTP Port"
+#~ msgstr "एचटीटीपी पोर्ट"
+
+#~| msgid "H_TTPS Proxy"
+#~ msgid "HTTPS Port"
+#~ msgstr "एचटीटीपीस पोर्ट"
+
+#~| msgid "_FTP Proxy"
+#~ msgid "FTP Port"
+#~ msgstr "एफटीपी पोर्ट"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "नया खाता जोड़ने के लिए, पहले खाता प्रकार का चयन करें"
+
+#~| msgid "Add"
+#~ msgid "_Add..."
+#~ msgstr "जोड़ें... (_A)"
+
+#~| msgid "_Type:"
+#~ msgid "Tip:"
+#~ msgstr "नुस्ख़ा:"
+
+#~| msgid "Brightness"
+#~ msgid "Brightness Settings"
+#~ msgstr "चमकीलापन सेटिंग्स"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "प्रभावित कितना शक्ति का इस्तेमाल किया है"
+
+#~ msgid "_Search by Address"
+#~ msgstr "पते द्वारा खोजें (_S)"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD नहीं चल रहा है. संजाल प्रिंटर का पता लगाने में सुविधाएँ mdns, IPP, आईपीपी-"
+#~ "क्लाइंट और साम्बा-क्लाइंट की जरुरत है जो फायरवाल पर सक्षम है. "
+
+#~| msgid "Local"
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "स्थानीय"
+
+#~| msgid "Network"
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "संजाल"
+
+#~ msgid "Device types"
+#~ msgstr "उपकरण प्रकार"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "स्वचालित विन्यास"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "फ़ायरवॉल खोलें MDNS कनेक्शन के लिए "
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "फ़ायरवॉल खोले सांबा कनेक्शन के लिए"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "फ़ायरवॉल खोलने के लिए आईपीपी कनेक्शन"
+
+#~| msgid "Back"
+#~ msgid "_Back"
+#~ msgstr "पीछे (_B)"
+
+#~ msgid "Allowed users"
+#~ msgstr "अनुमति प्राप्त उपयोक्ता"
+
+#~| msgid "Layout"
+#~ msgid "Add Layout"
+#~ msgstr "खाका जोड़ें"
+
+#~| msgid "Choose a Layout"
+#~ msgid "Remove Layout"
+#~ msgstr "खाका हटायें"
+
+#~| msgid "Preview"
+#~ msgid "Preview Layout"
+#~ msgstr "पूर्वावलोकन खाका"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "नई विंडोज डिफ़ॉल्ट खाका का उपयोग करें"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "नए विंडोज़ पिछले विंडो खाका का उपयोग करें"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "कुंजीपटल लेआउट विकल्प संपादित करें और देखें"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "डिफ़ॉल्ट में रीसेट करें (_f)"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "मौजूदा कुंजीपटल खाका सेटिंग्स प्रतिस्थापित करें\n"
+#~ "डिफ़ॉल्ट सेटिंग्स के साथ"
+
+#~ msgid "Layouts"
+#~ msgstr "अभिन्यास"
+
+#~ msgid "Layout"
+#~ msgstr "अभिन्यास"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "विन्यस्त करने के लिए कोई युक्ति चुनें: (_h)"
+
+#~ msgid "Dasher"
+#~ msgstr "डैशर"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "Caribou"
+#~ msgstr "कैरिबू"
+
+#~ msgid "Change contrast:"
+#~ msgstr "कंट्रास्ट बदलें:"
+
+#~| msgid "Text size:"
+#~ msgid "_Text size:"
+#~ msgstr "पाठ आकार: (_T)"
+
+#~ msgid "Increase size:"
+#~ msgstr "आकार बढ़ाएँ:"
+
+#~ msgid "Decrease size:"
+#~ msgstr "आकार घटाएँ:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "प्रदर्शित करें"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "बड़ा-छोटा करें"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "विन्यास जांचने हेतु टाइप करें"
+
+#~| msgid "Screen"
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 स्क्रीन"
+
+#~| msgid "Screen"
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 स्क्रीन"
+
+#~ msgid "Create new account"
+#~ msgstr "नया खाता बनाएँ"
+
+#~ msgid "_Account Type"
+#~ msgstr "खाता प्रकार (_A)"
+
+# #-#-#-#-#  libgnomeui.gnome-2-2.hi.po (libgnomeui HEAD)  #-#-#-#-#
+# libgnomeui/gnome-app-helper.c:166
+#~ msgid "Cr_eate"
+#~ msgstr "बनाएँ (_e)"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "उत्पन्न किया कूटशब्द बदलें"
+
+#~| msgid "Account type"
+#~ msgid "Account _type"
+#~ msgstr "खाता प्रकार (_t)"
+
+#~ msgid "More choices..."
+#~ msgstr "अधिक पसंद..."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Wacom आलेखी टेब्लेट"
+
+#~ msgid "Current network location"
+#~ msgstr "मौजूदा संजाल स्थान"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "अधिक पृष्ठभूमि URL"
+
+#~ msgid "More themes URL"
+#~ msgstr "अधिक प्रसंग URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "अपने मौजूदा स्थान नाम में इसे सेट करें. यह उचित संजाल प्रॉक्सी विन्यास को निर्धारित करने "
+#~ "के लिए प्रयुक्त होता है."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "URL जहाँ से अधिक डेस्कटॉप पृष्ठभूमि पाना है. यदि रिक्त स्ट्रिंग पर सेट किया जाता है कड़ी "
+#~ "प्रकट नहीं होगा."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "URL जहाँ से अधिक डेस्कटॉप प्रसंग पाना है. यदि रिक्त स्ट्रिंग पर सेट किया जाता है कड़ी "
+#~ "प्रकट नहीं होगा."
+
+#~ msgid "Unlock"
+#~ msgstr "खोलें"
+
+#~ msgid "Locked"
+#~ msgstr "तालाबंद"
+
+#, fuzzy
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr "मदद के लिए तंत्र प्रशासक से संपर्क करें."
+
+#~ msgid "Key"
+#~ msgstr "कुंजी"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "जी-कान्फ़ कुंजी जिसमें गुण संपादक संलग्न है"
+
+#~ msgid "Callback"
+#~ msgstr "कालबैक "
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "जब इस कुंजी का सम्बद्ध मूल्य बदलता है तो कालबैक जारी करें"
+
+#~ msgid "Change set"
+#~ msgstr "चेंज सेट"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr "लागू करने पर जी-कान्फ़ चेंज सेट जिसमें डेटा मिला हुआ है, जी-कान्फ़ क्लाइन्ट को भेजें."
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "विज़ेट कालबैक में परिवर्तन"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "जब डेटा जी-कान्फ़ से विज़ेट में बदला जाना हो तो कालबैक जारी करें"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "विज़ेट कालबैक से परिवर्तन"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "जब डेटा विज़ेट से जी-कान्फ़ में बदला जाना हो तो कालबैक जारी करें"
+
+#~ msgid "UI Control"
+#~ msgstr "यूआई नियंत्रण"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "आब्जेक्ट जो गुण नियंत्रण करते हैं (सामान्यतः एक विज़ेट)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "गुण संपादक ऑब्जेक्ट डेटा"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "निर्दिष्ट गुण संपादक द्वारा चाहा गया अनुकूलित डेटा"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "गुण संपादक डेटा मुक्त करते हैं कालबैक"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "गुण संपादक ऑब्जेक्ट डेटा जब मुक्त करने हों तो कालबैक जारी किया जाए"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "फ़ाइल '%s' ढूंढ नहीं सका. \n"
+#~ "कृपया सुनिश्चित करें कि यह मौज़ूद है, \n"
+#~ "फिर कोशिश करें या अन्य पृष्ठ भूमि छवि चुनें."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "मुझे मालूम नहीं है कि फ़ाइल '%s' कैसे खोला जाता है. \n"
+#~ "संभवतः यह उस प्रकार का छवि है \n"
+#~ " जो अभी समर्थित नहीं है.\n"
+#~ " कृपया बदले में कोई अन्य छवि चुनें."
+
+#~ msgid "Please select an image."
+#~ msgstr "कृपया कोई छवि चुनें."
+
+#~ msgid "24-Hour Time"
+#~ msgstr "24-घंटा समय"
+
+#~ msgid "Upside-down"
+#~ msgstr "उलटा नीचे"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "प्रदर्शन विन्यास लागू करने के दौरान सत्र बस नहीं पा सका"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f कि.बा."
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f मे.बा."
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f गी.बा."
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TB"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PB"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EB"
+
+#~ msgid "System Info"
+#~ msgstr "तंत्र जानकारी"
+
+#~ msgid "Photos"
+#~ msgstr "फोटो"
+
+#~ msgid "Updates Available"
+#~ msgstr "अद्यतन उपलब्ध"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "कंट्रास्ट टॉगल करें"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "आवर्धक टॉगल करें"
+
+#~ msgid "Accelerator key"
+#~ msgstr "त्वरक कुंजी"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "त्वरक परिवर्धक"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "त्वरक कुंजीकोड"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "त्वरक प्रकार"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "नए शॉर्टकट सहेजने में त्रुटि"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "कई मनपसंद शॉर्टकट"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#, fuzzy
+#~ msgid "Use default layout in new windows"
+#~ msgstr "प्रत्येक विंडो हेतु पृथक समूह (_l)"
+
+#~ msgid "Speed"
+#~ msgstr "गति"
+
+#~ msgid "Battery discharging"
+#~ msgstr "बैटरी डिसचार्जिंग"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s तक चार्ज (%.0lf%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s तक रिक्त (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% चार्ज"
+
+#~ msgid "Ask me"
+#~ msgstr "मुझसे पूछें"
+
+#~ msgid "On AC power:"
+#~ msgstr "एसी पावर पर:"
+
+#~ msgid "Shutdown"
+#~ msgstr "बंद करें"
+
+#~ msgid "Mute"
+#~ msgstr "मौन"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "Keyboard;Mouse;a11y;Accessibility;"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">High/Inverse</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">उच्च</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">निम्न</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">सामान्य</span>"

--- a/po/hr.po
+++ b/po/hr.po
@@ -5,10 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center 2.0\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-08 23:11+0000\n"
-"PO-Revision-Date: 2022-09-11 00:47+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-10-01 18:42+0200\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <lokalizacija@linux.hr>\n"
 "Language: hr\n"
@@ -20,101 +19,7 @@ msgstr ""
 "X-Launchpad-Export-Date: 2016-10-09 11:56+0000\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Sabirnica sustava"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Potpuni pristup"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Sabirnica sesije"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Uređaji"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Potpuni pristup u /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Mreža"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Ima pristup mreži"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Osobna mapa"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Samo za čitanje"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Datotečni sustav"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Postavke"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Može promijeniti postavke"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s ima sljedeće ugrađene dozvole. One se ne mogu mijenjati. Ako ste u "
-"nedoumici zbog tih dozvola, razmislite o uklanjanju te aplikacije."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u datoteka i vrsta poveznice koja je otvorena aplikacijom"
-msgstr[1] "%u datoteka i vrsta poveznice koje su otvorene aplikacijom"
-msgstr[2] "%u datoteka i vrsta poveznice koje su otvorene aplikacijom"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> se koristi za otvaranje sljedećih vrsta datoteka i poveznica."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s diskovnog prostora se koristi."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -130,7 +35,6 @@ msgid "Install some…"
 msgstr "Instaliraj nešto…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Otvori"
 
@@ -154,24 +58,13 @@ msgstr "Pretraga"
 msgid "Receive system searches and send results."
 msgstr "Primajte pretrage sustava i šaljite rezultate."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Onemogućen"
 
@@ -337,80 +230,20 @@ msgstr "Obriši predmemoriju…"
 msgid "Control various application permissions and settings"
 msgstr "Upravlja različitim dozvolama i postavkama aplikacije"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplikacija;flatpak;dozvole;postavka;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Odaberi sliku"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Odustani"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Otvori"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "višestruke veličine"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Bez pozadine radne površine"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Trenutna pozadina"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Izgled"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Uobičajeni"
 
@@ -434,7 +267,6 @@ msgstr "Izgled"
 msgid "Change your background image or the UI colors"
 msgstr "Promijenite vašu pozadinsku sliku ili boju korisničkog sučelja"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Pozadina;Slika pozadine;Zaslon;Radna površina;Izgled;Svjetlo;Tamno;"
@@ -485,9 +317,7 @@ msgstr "Hardverski način rada u zrakoplovu je uključen"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Isključite način rada u zrakoplovu kako bi mogli kristiti Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -495,7 +325,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Uključite ili isključite Bluetooth i povežite svoje uređaje"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "dijeli;dijeljenje;bluetooth;obex;"
@@ -529,94 +358,33 @@ msgstr "Nema aplikacija koje su zatražile pristup kameri"
 msgid "Protect your pictures"
 msgstr "Zaštitite svoje slike"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "kamera;fotografije;video;web kamera;zaključaj;privatno;privatnost;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Smjestite vaš uređaj za kalibraciju preko četverokuta i pritisnite ”Pokreni”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Pomaknite vaš uređaj za kalibraciju na položaj kalibracije i pritisnite "
-"”Nastavi”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Pomaknite vaš uređaj za kalibraciju na položaj površine i pritisnite "
-"”Nastavi”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Spusti zaslon prijenosnika"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Dogodila se unutrašnja greška koja se ne može oporaviti."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Alati potrebni za kalibraciju nisu instalirani."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Profil se ne može stvoriti."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Odredišna bijela točka je dostižna."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Završeno!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibracija nije uspjela!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Možete ukloniti uređaj za kalibraciju."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Nemojte ometati uređaj tijekom kalibracije"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kalibracija zaslona"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Odustani"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -633,139 +401,6 @@ msgstr "_Nastavi"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Završeno"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Zaslon prijenosnika"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Ugrađena web kamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s zaslon"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s skener"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s kamera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s pisač"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s web kamera"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Omogući upravljanje bojom za %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Prikaži profile boje za %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Nije kalibriran"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Uobičajeno: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Raspon boja: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Testni profil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Odaberi ICC datoteku profila"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Uvezi"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Podržani ICC profili"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Sve datoteke"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Zaslon"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Spremi profil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Spremi"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Napravi profil boje za odabrani uređaj"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Mjerni uređaj nije pronađen. Provjerite je li uključen i ispravno spojen."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Mjerni uređaj ne podržava profiliranje pisača."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Vrsta uređaja trenutno nije podržana."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -907,7 +542,6 @@ msgstr "_Uvezi datoteku…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -919,9 +553,7 @@ msgstr ""
 "Svaki uređaj posebno mora imati nadopunjeni profil boja kako bi se "
 "upravljalo bojama na tim uređajima."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Saznajte više"
 
@@ -1054,82 +686,6 @@ msgstr "D65 (Fotografija i grafika)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standardan razmak"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testiraj profil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatski"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Niska kvaliteta"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Srednja kavaliteta"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Visoka kvaliteta"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Uobičajeni RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Uobičajeni CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Uobičajeno sivo"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Proizvođačem isporučeni podaci tvorničke kalibracije"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Cijelozaslonski prikaz nije moguć sa ovim profilom"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Ovaj profil možda nije više točan"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Boja"
@@ -1139,14 +695,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Kalibrirajte boju vašeg uređaja, poput zalona, kamera i pisača"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Boja;ICC;Profil;Kalibriraj;Pisač;Zaslon;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Ostalo…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1161,13 +712,8 @@ msgid "No languages found"
 msgstr "Nema pronađenih jezika"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Više…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Otključaj za promjenu postavki"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1196,154 +742,6 @@ msgstr "Smanji sat"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Smanji minutu"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Danas"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Jučer"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d sat"
-msgstr[1] "%d sata"
-msgstr[2] "%d sati"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuta"
-msgstr[1] "%d minute"
-msgstr[2] "%d minuta"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekunda"
-msgstr[1] "%d sekunde"
-msgstr[2] "%d sekundi"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekundi"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Pristupna točka"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-satni"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "12-satni"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1438,17 +836,11 @@ msgstr "Automatska vremenska _zona"
 msgid "Requires location services enabled and internet access"
 msgstr "Zahtijeva pristup internetu i omogućenu uslugu lociranja"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Omogućeno"
 
@@ -1456,15 +848,42 @@ msgstr "Omogućeno"
 msgid "Time Z_one"
 msgstr "Vremenska z_ona"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Otključaj"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Format _vremena"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datumi"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekundi"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Kalendar"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Brojevi"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Promijenite datum i vrijeme, uključujući vremensku zonu"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Sat;vremenska zona;lokacija;"
@@ -1510,20 +929,9 @@ msgstr "Zadane aplikacije"
 msgid "Configure Default Applications"
 msgstr "Prilagodite zadane aplikacije"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "zadano;aplikacija;poželjno;medij;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Slanje izvještaja tehničkih problema pomaže nam poboljšati %s. Izvještaji su "
-"poslani anonimno i ne sadrže osobne podatke. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1541,44 +949,9 @@ msgstr "Dijagnostika"
 msgid "Report your problems"
 msgstr "Prijavite svoje probleme"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "dijagnostika;rušenje;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Uključeno"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Isključeno"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Primijeni promjene?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Promjene se ne mogu primijeniti"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "To može biti uzrokovano ograničenjem hardvera."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1628,31 +1001,6 @@ msgstr "Glavni zaslon"
 msgid "Night Light"
 msgstr "Noćno osvjetljenje"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Položeno"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Uspravno desno"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Uspravno lijevo"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Obrnuto položeno"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1676,6 +1024,17 @@ msgstr "Prilagodi za TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Prilagodba veličine"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Prirodno pomicanje"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1771,7 +1130,6 @@ msgstr "Zasloni"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Odaberite kako koristiti monitore i projektore"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1779,80 +1137,6 @@ msgid ""
 msgstr ""
 "Panel;Projektor;xrandr;Zaslon;Razlučivost;Osvježi;Monitor;Noć;Osvjetljenje;"
 "Plavo;crveni pomak; boja;zalazak;izlazak;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Sigurno pokretanje (Secure Boot) je aktivno"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se učita "
-"kada se uređaj pokrene. Trenutno je uključeno i radi ispravno."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Sigurno pokretanje (Secure Boot) ima probleme"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se učita "
-"kada se uređaj pokrene. Trenutno je uključeno, ali neće raditi jer ima "
-"nevaljani ključ."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Problemi sigurnog pokretanja (Secure Boot) uobičajeno se mogu riješiti iz "
-"UEFI firmver postavki (BIOS) vašeg računala, a vaš proizvođač hardvera pruža "
-"informacije za ovo rješenje."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Za pomoć, kontaktirajte svojeg proizvođača hardvera ili pružatelja IT "
-"podrške."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Sigurno pokretanje (Secure Boot) je isključeno"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se ne "
-"učita kada se uređaj pokrene. Trenutno je isključeno."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Sigurno pokretanje (Secure Boot) uobičajeno može biti isključeno u UEFI "
-"firmver postavkama (BIOS) vašeg računala. Za pomoć, kontaktirajte svojeg "
-"proizvođača hardvera ili pružatelja IT podrške."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1867,129 +1151,9 @@ msgstr ""
 "Za više informacija, kontaktirajte svojeg proizvođača hardvera ili "
 "pružatelja IT podrške."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Prošlo"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Neuspjelo"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Uređaj je usklađen s HSI razinom %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Sigurnosna razina 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Ovaj uređaj nema zaštitu protiv hardverskih sigurnosnih problema. Uzrok tome "
-"može biti problem u podešavanju hardvera ili firmvera. Preporučljivo je da "
-"kontaktirate svojeg proizvođača hardvera ili pružatelja IT podrške."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Sigurnosna razina 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Ovaj uređaj ima najmanju zaštitu protiv hardverskih sigurnosnih problema. "
-"Ovo je najmanja razina sigurnosti uređaja i samo pruža zaštitu od "
-"jednostavnih sigurnosnih prijetnji."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Sigurnosna razina 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Ovaj uređaj ima osnovnu zaštitu protiv hardverskih sigurnosnih problema. Ova "
-"razina pruža zaštitu protiv učestalih sigurnosnih prijetnji."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Sigurnosna razina 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Ovaj uređaj ima proširenu zaštitu protiv hardverskih sigurnosnih problema. "
-"Ovo je najviša razina sigurnosti uređaja i pruža zaštitu protiv naprednih "
-"sigurnosnih prijetnji."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Sigurnosna razina"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Sigurnosne razine nisu dostupne za ovaj uređaj."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Kontaktirajte svojeg proizvođača hardvera za pomoć oko sigurnosnih nadopuna."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Moguće rješenje ovog problema je u postavkama UEFI firmvera uređaja, ili u "
-"podršci od strane tehničara."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr "Moguće rješenje ovog problema je u postavkama UEFI firmvera uređaja."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Moguće rješenje ovog problema je u podršci od strane tehničara."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2003,338 +1167,9 @@ msgstr "Razina 2"
 msgid "Level 3"
 msgstr "Razina 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Zaštita od zlonamjernog softvera pri pokretanju uređaja."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Sigurno pokretanje (Secure Boot) ima probleme"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Određena zaštita pri pokretanju uređaja."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Sigurno pokretanje (Secure Boot) je isključeno"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Bez zaštite pri pokretanju uređaja."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Ovaj problem mogao bi biti uzrokovan promjenom u postavkama UEFI firmvera, "
-"promjenom podešavanja operativnog sustava ili zbog zlonamjernog softvera na "
-"ovom sustavu."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Ovaj problem mogao bi biti uzrokovan promjenom u postavkama UEFI firmvera "
-"ili zbog zlonamjernog softvera na ovom sustavu."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Ovaj problem mogao bi biti uzrokovan promjenom u podešavanja operativnog "
-"sustava ili zbog zlonamjernog softvera na ovom sustavu."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Izloženi ste ozbiljnim sigurnosnim prijetnjama."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Ograničena zaštita protiv jednostavnih sigurnosnih prijetnji."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Zaštita protiv učestalih sigurnosnih prijetnji."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Zaštita protiv širokog raspona sigurnosnih prijetnji."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Sveobuhvatna zaštita"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Nema događaja"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Zaštita od zapisivanja firmvera"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Zaključavanje zaštite od zapisivanja firmvera"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Firmver BIOS područje"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Firmver BIOS opisnik"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "DMA zaštita predpokretanja"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard provjereno pokretanje"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM zaštićen"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard pravilo greške"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard osigurač"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET omogućen"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET aktivan"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Šifrirani RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU zaštita"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux kernel zaključavanje"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linux kernel provjera"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux swap"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Suspendiraj u ram"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Suspendiraj u mirovanje"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI ključ platforme"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI Sigurno pokretanje (Secure Boot)"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Podešavanje TPM platforme"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM rekonstrukcija"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Način proizvodnje Intel pogona upravljanja (MEI)"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Zaobilaženje Intel pogona upravljanja (MEI)"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Inačica Intel pogona upravljanja (MEI)"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Nadopune firmvera"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Frimver provjera"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Provjera firmver nadopunitelja"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Otklanjanje grešaka platforme"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Sigurnosne provjere procesora"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD Rollback zaštita"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Zaštita od ponavljanja AMD firmvera"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Zaštita od zapisivanja AMD firmvera"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Pregorjela platforma"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Valjano"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Nije valjano"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Nije omogućeno"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Zaključano"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Nije zaključano"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Šifriran"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Nije šifriran"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Pokvaren"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Nije pokvaren"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Pronađeno"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Nije pronađeno"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Podržano"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Nije podržano"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2344,7 +1179,6 @@ msgstr "Sigurnost uređaja"
 msgid "Host firmware security status"
 msgstr "Sigurnosno stanje firmvera računala"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2352,49 +1186,6 @@ msgid ""
 msgstr ""
 "zaslon;zaključaj;dijagnostika;rušenje;privatno;nedavno;privremeno;tmp;"
 "sadržaj;naziv;mreža;identitet;privatnost;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Nepoznato"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bitna"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bitna"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Nepoznat"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Nedostupno"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logotip sustava"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2488,11 +1279,6 @@ msgstr "O sustavu"
 msgid "View information about your system"
 msgstr "Prikaži informacije ovog sustava"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2571,6 +1357,12 @@ msgstr "Pokretači"
 msgid "Launch help browser"
 msgstr "Pokreni preglednik pomoći"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Postavke"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Pokreni kalkulator"
@@ -2592,7 +1384,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Pretraga"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sustav"
 
@@ -2641,18 +1433,9 @@ msgstr "Smanji veličinu teksta"
 msgid "High contrast on or off"
 msgstr "Uključi ili isključi visoki kontrast"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nema pronađenih načina unosa"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Ostalo"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
-msgstr "Dodaj izvor ulaza"
+msgstr "Dodaj jezik unosa"
 
 #: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
@@ -2682,106 +1465,9 @@ msgstr "Osobitosti"
 msgid "View Keyboard Layout"
 msgstr "Prikaži prečace tipkovnice"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Ukloni"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Prilagođeni prečaci"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Zamjenska tipka znakova"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Zamjenska tipka znakova može se koristiti za unos dodatnih znakova. To je "
-"ponekad ispisano na vašoj tipkovnici kao treća mogućnost."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Lijevi Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Desni Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Lijevi Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Desni Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tipka Izbornika"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Desni Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Tipka za sastavljanje"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Tipka sastavljanja dopušta širok raspon znakova za unos. Za korištenje, "
-"pritisnite sastavljanje zatim slijed znakova.  Na primjer, tipku "
-"sastavljanja za kojom slijedi <b>C</b> i <b>o</b> koji će unijeti <b>©</b>, "
-"<b>a</b> za kojima slijedi <b>'</b> koji će unijeti <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Načini unosa mogu se mijenjati koristeći %s prečac tipkovnice.\n"
-"Ovo se može promijeniti u postavkama prečaca tipkovnice."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2811,46 +1497,21 @@ msgstr "Unos posebnih znakova"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Način unosa varijanti simbola i slova koristeći tipkovnicu."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Zamjenska tipka znakova"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tipka za sastavljanje"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Prečaci tipkovnice"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Pogledaj i prilagodi prečace"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d promijenjen"
-msgstr[1] "%d promijenjena"
-msgstr[2] "%d promijenjeno"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Vrati sve prečace na izvorno stanje?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Vraćanje prečaca na izvorno stanje može utjecati na vaše prilagođene "
-"prečace. To se ne može poništit."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Odustani"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Vrati sve na izvorno"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2890,33 +1551,6 @@ msgstr "Dodavanje prečaca"
 msgid "No keyboard shortcut found"
 msgstr "Nema pronađenih prečaca tipkovnice"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s se već koristi za %s. Ako ga zamjenjujete, %s biti će onemogućen"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Upišite novi prečac"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Postavi prilagođen prečac"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Postavi prečac"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Upišite novi prečac za promjenu %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Dodaj prilagođeni prečac"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Ukloni"
@@ -2928,7 +1562,6 @@ msgstr "Za_mijeni"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Postavi"
 
@@ -2966,6 +1599,11 @@ msgstr "Nepoznata"
 msgid "Reset the shortcut to its default value"
 msgstr "Vrati izvorne vrijednosti prečaca"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Koristite svoju kameru"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Tipkovnica"
@@ -2978,7 +1616,6 @@ msgstr ""
 "Promijenite prečace tipkovnice i postavite osobitosti tipkanja, raspored "
 "tipkovnice i izvore unosa"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3020,7 +1657,6 @@ msgstr "Nema aplikacija koje su zatražile pristup vašoj lokaciji"
 msgid "Protect your location information"
 msgstr "Zaštite informacije vaše lokacije"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "lokacija;gps;privatno;privatnost;"
@@ -3055,7 +1691,6 @@ msgstr "Nema aplikacija koje su zatražile pristup vašem mikrofonu"
 msgid "Protect your conversations"
 msgstr "Zaštitite svoje razgovore"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofon;snimanje;aplikacija;privatnost;"
@@ -3085,81 +1720,141 @@ msgstr "Lijevo"
 msgid "Right"
 msgstr "Desno"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Pretraga lokacija"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Miš"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Brzina miša"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Prirodno pomicanje"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Klizi prema dolje"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Pomicanje pomiče sadržaj, a ne pogled."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Pomicanje pomiče sadržaj, a ne pogled."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktivno"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Brzina touchpada"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Način"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Dodirni za klik"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Dodirni za klik"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Pomicanje s dva prsta"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Onemogući sliku"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relativno)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Rubno pomicanje"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Klizi prema dolje"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Obostrano"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Pokušajte kliknuti, dvostruko kliknuti, pomicati"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Pet klika, vrijeme je za GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dvostruki klik, glavna tipka"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Jednostruki klik, glavna tipka"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dvostruki klik, srednja tipka"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Jednostruki klik, srednja tipka"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dvostruki klik, druga tipka"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Jednostruki klik, druga tipka"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3171,7 +1866,6 @@ msgid ""
 msgstr ""
 "Promijenite osjetljivost touchpada i miša i odaberite lijevu ili desnu ruku"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3252,7 +1946,6 @@ msgstr "Višezadaćnost"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Upravljajte osobitostima za produktivnost i višezadaćnost"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3260,21 +1953,11 @@ msgstr ""
 "Višezadaćnost;Višezadaća;Produktivnost;Prilagodi;Radna površina;Kut zaslona;"
 "Radni prostori;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Ups, nešto je pošlo po krivu. Kontaktirajte svojeg dobavljača softvera."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Mrežni upravitelj mora biti pokrenut."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Ostali uređaji"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3286,59 +1969,16 @@ msgstr "Dodaj povezivanje"
 msgid "Not set up"
 msgstr "Nije postavljeno"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Otvorena mreža (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Zaštićena mreža (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Zaštićena mreža (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Zaštićena mreža (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Zaštićena mreža"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Povezano"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Mogućnosti…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Uključivanje pristupne točke će prekinuti %s povezivanje i nećete biti u "
-"mogućnosti pristupiti internetu putem bežične mreže."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Mora sadržavati najmanje 8 znakova"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3389,20 +2029,6 @@ msgstr "Automatsko stvaranje lozinke"
 msgid "_Turn On"
 msgstr "_Uključi"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Bežična mreža"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Zaustaviti pristupnu točku i odspojiti sve korisnike?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Zaustavi pristupnu točku"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Način rada u zrakoplovu"
@@ -3447,89 +2073,14 @@ msgstr "Vidljive mreže"
 msgid "NetworkManager needs to be running"
 msgstr "Mrežni upravitelj mora biti pokrenut"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ups, nešto je pošlo po krivu. Kontaktirajte svojeg dobavljača softvera."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _sigurnost"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Sigurnost"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Očuvano"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Trajno"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Naizmjenično"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabilno"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"MAC adresa koja je ovdje upisana, koristit će se kao hardverska adresa za "
-"mrežni uređaj na kojemu je aktivirano ovo povezivanje. Ova mogućnost je "
-"poznata kao MAC kloniranje ili zavaravanje. Primjer: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Poboljšano otvoreno (OWE)"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Poslovanje"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nepoznata"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Nikada"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3540,183 +2091,6 @@ msgstr[0] "prije %i dan"
 msgstr[1] "prije %i dana"
 msgstr[2] "prije %i dana"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nepoznata"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Slaba"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "U redu"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Dobra"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Izvrsna"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 adresa"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 adresa"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP adresa"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Zaboravi povezivanje"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Ukloni profil povezivanja"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Ukloni VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Pojedinosti"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatski"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitet"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Obriši adrese"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Obriši rutu"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Nepoznata"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bitni ključ (Heks. ili ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bitna lozinka"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Promjenjivi WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA i WPA2 osobni"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA i WPA2 poslovni"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 osobni"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3726,8 +2100,20 @@ msgstr "Jačina signala"
 msgid "Link speed"
 msgstr "Brzina povezivanja"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sigurnost"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 adresa"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 adresa"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hardverska adresa"
 
@@ -3736,12 +2122,17 @@ msgid "Supported Frequencies"
 msgstr "Podržane frekvencije"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Uobičajena ruta"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3806,7 +2197,7 @@ msgstr "Samo Lokalno-povezivanje"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Ručno"
 
@@ -3850,9 +2241,8 @@ msgstr "Pristupnik"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automatski"
 
@@ -3905,89 +2295,9 @@ msgstr "Automatski, samo DHCP"
 msgid "Prefix"
 msgstr "Prefiks"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Nemoguće otvaranje uređivača povezivanja"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Novi profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Nevaljana postavka %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Nevaljana postavka %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Uvezi iz datoteke…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Dodaj VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_igurnost"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Nemoguć uvoz VPN povezivanja"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Datoteka ”%s” nije mogla biti pročitana ili ne sadrži poznate informacije "
-"VPN povezivanja\n"
-"\n"
-"Greška: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Odaberi datoteku za uvoz"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Datoteka naziva \"%s\" već postoji."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Zamijeni"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Želite li zamijeniti %s s VPN povezivanjem kojeg spremate?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Nemoguć izvoz VPN povezivanja"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN povezivanje ”%s” nije moglo biti izvezeno u %s.\n"
-"\n"
-"Greška: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Izvezi VPN povezivanje"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4001,103 +2311,40 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Mreža"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Upravljajte načinom povezivanja na Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Mreža;Bežično;IP;Žično;Proxy;WAN;Širokopojasni internet;Modem;Bluetooth;vpn;"
 "DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Bežična mreža"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Upravljajte načinom povezivanja na bežične mreže"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Mreža;Bežično;Bežična mreža;IP;Žično;Širokopojasni internet;DNS;Pristupna "
 "točka;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nikada"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "danas"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "jučer"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Zadnje korištena"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Žična mreža"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Dodaj novu mrežu"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Mrežne pojedinosti za odabrane mreže, uključujući lozinke i sve prilagođene "
-"postavke će biti izgubljene."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Zaboravi"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Poznate bežične mreže"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Zaboravi"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Pravila sustava ne dopuštaju korištenje kao pristupne točke"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Bežični uređaj ne podržava način pristupne točke"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Automatsko otkrivanje web proxyja se koristi kada URL podešavanja nije "
-"omogućen."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Ovo nije preporučljivo za javne mreže kojima se ne vjeruje."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4116,6 +2363,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Pružatelj usluge"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP adresa"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4200,289 +2451,6 @@ msgstr "_Uključi bežičnu pristupnu točku…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Poznate bežične mreže"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Nepoznato stanje"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Neupravljano"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Nedostupno"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Povezivanje"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Potrebna je ovjera"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Prekidanje povezivanja"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Neuspješno povezivanje"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Nepoznato stanje (nedostaje)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Neuspjelo podešavanja"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP podešavanje neuspjelo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP podešavanje isteklo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Tajne su zahtijevane, ali ne i pružane"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x opskrbitelj nije povezan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x opskrbitelj neuspjelo podešavanje"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x opskrbitelj neuspio"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x opskrbitelj predugo trajanje ovjere"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP usluga se nije uspjela pokrenuti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP usluga je prekinula povezivanje"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP je neuspio"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP klijent se nije uspio pokrenuti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Greška DHCP klijenta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP kijent je neuspio"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Usluga dijeljenja povezivanja se nije uspjela pokrenuti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Usluga dijeljenja povezivanja je neuspjela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP usluga se nije uspjela pokrenuti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Greška AutoIP usluge"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP usluga nije uspjela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linija zauzeta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Nema tona biranja"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Nije pronađen nijedan operater"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Biranje zahtijeva čekanje"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Pokušaj biranja neuspio"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Pokretanje modema nije uspjelo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Odabir određenog APN-a nije uspjelo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Mreže se ne traže"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Mrežna registracija odbijena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Isteklo vrijeme mrežne registracije"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Registracija sa zatraženom mrežnom nije uspjela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Provjera PIN-a nije uspjela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Firmver uređaja možda nedostaje"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Povezivanje je nestalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Postojeće povezivanje je predpostavljeno"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem nije pronađen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth povezivanje neuspjelo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM kartica nije umetnuta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM Pin je potreban"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM Puk je potreban"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Pogrešan SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Neuspjelo povezivanje zavisnosti"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Nedostaje firmver"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabel je odspojen"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "neodređena greška u 802.1x sigurnosti (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "nema odabrane datoteke"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "neodređena greška provjeravanja datoteke eap-načina"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12 ili PGP privatni ključevi"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER ili PEM vjerodajnice"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "nedostaje EAP-FAST PAC datoteka"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC datoteke (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4531,14 +2499,6 @@ msgstr "_Unutrašnja ovjera"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Dopusti automatsko PAC dod_jeljivanje"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "nedostaje EAP-LEAP korisničko ime"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "nedostaje EAP-LEAP lozinka"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4564,15 +2524,6 @@ msgstr "_Lozinka"
 msgid "Sho_w password"
 msgstr "Pri_kaži lozinku"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "nevaljana EAP-PEAP CA vjerodajnica: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "nevaljana EAP-PEAP CA vjerodajnica: vjerodajnica nije određena"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4594,7 +2545,6 @@ msgid "C_A certificate"
 msgstr "C_A vjerodajnica"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4609,63 +2559,6 @@ msgstr "CA vjerodajnica nije _potrebna"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _inačica"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "nedostaje EAP korisničko ime"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "nedostaje EAP lozinka"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "nedostaje EAP-TLS identitet"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "nevaljana EAP-TLS CA vjerodajnica: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "nevaljana EAP-TLS CA vjerodajnica: vjerodajnica nije određena"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "nevaljani EAP-TLS privatni ključ: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "nevaljana EAP-TLS CA korisnička-vjerodajnica: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Nešifriani privatni ključevi su nesigurni"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Čini se da odabrani privatni ključ nije zaštićen lozinkom. Ovo može "
-"dopustiti kompromitiranje vaših sigurnosnih podataka. Odaberite lozinkom "
-"zaštićeni privatni ključ.\n"
-"\n"
-"(Svoj privatni ključ možete zaštititi lozinkom pomoću openssla)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Odaberite svoju osobnu vjerodajnicu"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Odaberite svoj privatni ključ"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4682,15 +2575,6 @@ msgstr "Privatni _ključ"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Lozinka privatnog ključa"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "nevaljana EAP-TTLS CA vjerodajnica: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "nevaljana EAP-TTLS CA vjerodajnica: vjerodajnica nije određena"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4713,14 +2597,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domena"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Nepoznata greška provjere 802.1X sigurnosti"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4748,60 +2633,10 @@ msgstr "Zaštićeni EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "Ov_jera"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Odaberi datoteku"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "nedostaje leap korisničko ime"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "nedostaje leap lozinka"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Lozinka bežične mreže nedostaje."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Vrsta"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "nedostaje wep ključ"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"nevaljani wep ključ: ključ duljine %zu mora sadržavati samo heks. znamenke"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"nevaljani wep ključ: ključ duljine %zu mora sadržavati samo ascii znamenke"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"nevaljani wep ključ: pogrešna duljina ključa %zu. Ključ mora biti 5/13 "
-"(ascii) ili 10/26 (heks.)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "nevaljani wep ključ: lozinka ne smije biti prazna"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "nevaljani wep ključ: lozinka mora sadržavati manje od 64 znamenaka"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4826,20 +2661,6 @@ msgstr "Prika_ži ključ"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP sadr_žaj"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"nevaljani wpa-psk: nevaljana duljina ključa %zu. Mora biti [8,63] bajtova "
-"ili 64 heks. znamenke"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"nevaljani wpa-psk: ne može se interpretirati ključ sa 64 bajtova kao heks"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4894,27 +2715,9 @@ msgstr "_Obavijesti zaključanog zaslona"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Upravljajte prikazom poruka i što će se prikazivati"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Obavijesti;Transparent;Poruka;Statusna traka;Skočni prozor;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Ostalo"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s je uklonjen"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Greška pri uklanjanju računa"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4939,17 +2742,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Dodaj račun"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s račun"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Ukloni račun"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Mrežni računi"
@@ -4959,10 +2751,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Povežite se sa svojim mrežnim računima i odredite za što ih želite koristiti"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4970,10 +2758,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Mreža;Razgovor;Kalendar;Pošta;Kontakt;"
 "ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Nepoznato vrijeme"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4991,13 +2775,6 @@ msgstr[0] "%i sat"
 msgstr[1] "%i sata"
 msgstr[2] "%i sati"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5011,190 +2788,6 @@ msgid_plural "minutes"
 msgstr[0] "minuta"
 msgstr[1] "minute"
 msgstr[2] "minuta"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s do potpune napunjenosti"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Upozorenje: %s preostalo"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s preostalo"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Potpuno napunjeno"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Ne puni se"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Prazna"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Punjenje"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Pražnjenje"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Bežični miš"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Bežična tipkovnica"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Neprekinuta opskrba energijom (UPS)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Osobni digitalni pomagač (PDA)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobitel"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Medijski reproduktor"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Računalo"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Uređaj za igranje"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Baterija"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Glavna"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Dodatna"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Baterije"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Pri _mirovanju"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Suspendiraj"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Isključi"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hiberniraj"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Ništa"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Na bateriji"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Na napajanju"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nikada"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automatska suspenzija"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Performanse način rada je trenutno onemogućen uslijed visoke temperature "
-"rada."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Preklop otkriven: performanse način rada je privremeno nedostupan. "
-"Premjestite uređaj na stabilnu površinu za obnavljanje."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Performanse način rada je onemogućen."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Slaba baterija: štednja energije je omogućena. Prijašnji način rada će biti "
-"obnovljen kada se baterija dovoljno napuni."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Štednju energije je aktivirao “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Performanse način rada je aktivirao “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5255,6 +2848,15 @@ msgstr "100 minuta"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 sata"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterija"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Uređaji"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5333,33 +2935,6 @@ msgstr "Na _bateriji"
 msgid "Delay"
 msgstr "Odgoda"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Performanse"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Visoke performanse i potrošnja energije."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Uravnoteženo"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standardne performanse i potrošnja energije."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Štednja energije"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Smanjene performanse i potrošnja energije."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Energija"
@@ -5369,7 +2944,6 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Pogledajte svoje stanje baterije i promijenite postavke štednje energije"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5377,27 +2951,6 @@ msgid ""
 msgstr ""
 "Energija;Spavanje;Suspenzija;Hibernacija;Baterija;Svjetlina;Zatamnjenje;"
 "Tamno;Zaslon;DPMS;Mirovanje;Energija;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Pisač “%s” je obrisan"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Neuspjelo dodavanje novoga pisača."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Nemoguće učitati kor. sučelje: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Otključaj za dodavanje pisača i promjenu postavki"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5408,7 +2961,6 @@ msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Dodajte pisače, pogledajte zadatke ispisivanja i odredite kakav ispis želite"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Pisač;Red;Ispis;Papir;Tinta;Toner;"
@@ -5416,8 +2968,6 @@ msgstr "Pisač;Red;Ispis;Papir;Tinta;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Dodaj pisač"
 
@@ -5458,29 +3008,6 @@ msgstr ""
 msgid "Username"
 msgstr "Korisničko ime"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s pojedinosti"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Nije pronađen odgovarajući upravljački program"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Odaberi PPD datoteku"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Datoteka opisa PostSkripta pisača (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Nazivi pisača ne mogu sadržavati RAZMAK, TABULATOR, #, ili /"
@@ -5489,9 +3016,7 @@ msgstr "Nazivi pisača ne mogu sadržavati RAZMAK, TABULATOR, #, ili /"
 msgid "Location"
 msgstr "Lokacija"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Upravljački program"
 
@@ -5519,121 +3044,14 @@ msgstr "Odaberi upravljački program za pisač"
 msgid "Loading drivers database…"
 msgstr "Učitavanje baze podataka upravljačkih programa…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Odustani"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Odaberi"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect pisač"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD pisač"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Jednostrano"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Dugom stranom (standardno)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Kratkom stranom (okrenuto)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Uspravno"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Položeno"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Obrnuto položeno"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Obrnuto uspravno"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Nastavi"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pauziraj"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Na čekanju"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pauzirano"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Potrebna je ovjera"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Obrada"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Zaustavljen"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Otkazan"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Prekinut"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Završen"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Premjesti ovaj zadatak na vrh reda čekanja"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5641,19 +3059,6 @@ msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u zadatak zahtijeva ovjeru"
 msgstr[1] "%u zadatka zahtijevaju ovjeru"
 msgstr[2] "%u zadataka zahtijeva ovjeru"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — aktivnih zadataka"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Upišite korisničko ime i lozinku za ispis sa %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5681,207 +3086,11 @@ msgstr "_Ovjera"
 msgid "No Active Printer Jobs"
 msgstr "Nema aktivnih zadataka ispisa"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Otključaj poslužitelj pisača"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Otključaj %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Upišite korisničko ime i lozinku kako bi vidjeli pisače dostupne na %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Pretraživanje pisača"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Serijski priključak"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Paralelni priključak"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Lokacija: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adresa: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Poslužitelj zahtijeva ovjeru"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Obostrano"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Vrsta papira"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Izvor papira"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Izlazna ladica"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Razlučivost"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostSkripta predfiltriranja"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Stranica po listu"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Obostrano"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orijentacija"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Općenito"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Postavke ispisa"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Mogućnosti instaliranja"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Zadatak"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Kvaliteta slike"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Boja"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Završavanje"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Napredno"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testna stranica"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Testna stranica"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Automatski odabir"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Zadani pisač"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Ugradi samo Ghostskript slova"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Prevedi u PS razine 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Prevedi u PS razine 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Bez prevođenja"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Proizvođač"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Nema aktivnih zadataka ispisa"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5889,115 +3098,6 @@ msgid_plural "%u Jobs"
 msgstr[0] "%u zadatak"
 msgstr[1] "%u zadatka"
 msgstr[2] "%u zadataka"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Čišćenje glava pisača"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Ponestaje tinte u toneru"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Ponestalo tinte u toneru"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Razvijatelj nizak"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Ponestalo razvijatelja"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Ponestaje tinte"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Ponestalo tinte"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Otvoren je poklopac"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Otvorena su vratašca"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Ponestaje papira"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Ponestalo papira"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Nije povezan"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Zaustavljen"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Pisačeva kantica za otpad je skoro puna"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Pisačeva kantica za otpad je puna"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Optički fotografski vodič je pri kraju vijeka trajanja"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Optički fotografski vodič je istrošen"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Spreman"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Ne prihvaća zadatke"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Obrada"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6021,6 +3121,10 @@ msgstr "Čišćenje glava pisača"
 msgid "Remove Printer"
 msgstr "Ukloni pisač"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nema aktivnih zadataka ispisa"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6041,16 +3145,21 @@ msgid "Restart"
 msgstr "Ponovno pokreni"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Dodaj pisač…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Dodaj pisač…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Nema otkrivenih pisača"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6058,7 +3167,6 @@ msgstr ""
 "Nažalost! Usluga ispisa\n"
 "    sustava nije dostupna."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formati"
@@ -6086,16 +3194,6 @@ msgstr "Pretrage mogu biti jezici ili zemlje."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Pretpregled"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperijalne"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrički"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6133,20 +3231,24 @@ msgstr ""
 "Postavke jezika se koriste za tekst sučelja i web stranica. Formati se "
 "koriste za brojeve, datume i valute."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Vaš račun"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Jezik"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formati"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Zaslon prijave"
 
@@ -6158,100 +3260,9 @@ msgstr "Jezik i regija"
 msgid "Select your display language and formats"
 msgstr "Odaberite svoj jezik prikaza i formate"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Jezik;Raspored;Tipkovnica;ulaz;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Pitaj što učiniti"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Ne čini ništa"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Otvori mapu"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Ostali mediji"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Odaberite aplikaciju za glazbene CD-e"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Odaberite aplikaciju za video DVD-e"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Odaberite aplikaciju koja će se pokrenuti kada je glazbeni svirač spojen"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Odaberite aplikaciju koja će se pokrenuti kada je kamera spojena"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Odaberite aplikaciju za softverske CD-e"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "Glazbeni DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Prazni Blu-ray disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "Prazni CD disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "Prazni DVD disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "Prazni HD DVD disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "Čitač e-knjiga"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD video disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Slikovni CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows softver"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6301,7 +3312,6 @@ msgstr "Prijenosni mediji"
 msgid "Configure Removable Media settings"
 msgstr "Prilagodite prijenosne medije"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6309,114 +3319,6 @@ msgid ""
 msgstr ""
 "uređaj;sustav;zadano;aplikacija;poželjno;cd;dvd;usb;zvuk;video;disk;"
 "prijenosni;medij;automomatsko pokretanje;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Odmah"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekundi"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuta"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minute"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minute"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minuta"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minuta"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 sat"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minute"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minute"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minute"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minuta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minuta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minuta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minuta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minuta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nikada"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6456,41 +3358,41 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "Prikaži _obavijesti na zaključanome zaslonu"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Obavijesti zaključanog zaslona"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Zabrani nove _USB uređaje"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr ""
 "Sprječava interakciju novih USB uređaja sa sustavom kada je zaslon zaključan."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Privatnost zaslona"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Ograniči kut gledanja"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Zaslon"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Postavke zaslona"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "zaslon;zaključaj;privatno;privatnost;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Odaberi lokaciju"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_U redu"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6521,10 +3423,6 @@ msgstr "Ostalo"
 msgid "Add Location"
 msgstr "Dodaj lokaciju"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Aplikacije nisu pronađene"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Pretraga aplikacija"
@@ -6551,93 +3449,13 @@ msgid ""
 msgstr ""
 "Upravljajte prikazom rezultata pretrage aplikacija u pregledu aktivnosti"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Pretraga;Pretraži;Sadržaj;Sakrij;Privatnost;Rezultati;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Nema odabranih mreža za dijeljenje"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Mreže"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Uključeno"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Isključeno"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Omogućeno"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktivno"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Odaberi mapu"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Dodaj"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Omogući dijeljenje medija"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Dijeljenje datoteka omogućuje vam dijeljenje Javne mape s ostalim "
-"korisnicima vaše trenutne mreže koristeći: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Kada je udaljena prijava omogućena, udaljeni korisnici mogu se povezati "
-"koristeći naredbu sigurne ljuske (SSH):\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Omogući dijeljenje osobnih medija"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Naziv uređaja je kopiran"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Adresa uređaja je kopirana"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Korisničko ime je kopirano"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Lozinka je kopirana"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6769,7 +3587,6 @@ msgstr "Mape"
 msgid "Control what you want to share with others"
 msgstr "Postavite što želite dijeliti s ostalim korisnicima"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6785,10 +3602,6 @@ msgstr "Omogući ili onemogući udaljenu prijavu"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Potrebna je ovjera za omogućavanje ili onemogućavanje udaljene prijave"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Prilagođeno"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6821,11 +3634,6 @@ msgstr "Straga"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Sprijeda"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s - proba"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6879,11 +3687,6 @@ msgstr "Glasnoća zvuka"
 msgid "Alert Sound"
 msgstr "Zvuk upozorenja"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Utišaj"
@@ -6896,83 +3699,12 @@ msgstr "Zvuk"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Promijenite glasnoću zvuka, ulaze, izlaze i zvukove upozorenja"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Kartica;Mikrofon;Glasnoća zvuka;Isčezni;Uravnoteženje;Bluetooth;Slušalice s "
 "mikrofonom;Zvuk;Izlaz;Ulaz;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Odspojeno"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Povezivanje"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Povezano"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Greška ovjere"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Odobravanje"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Smanjena funkcionalnost"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Povezano i odobreno"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Nepoznato"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Odobreno na:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Povezano na:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Upisano:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Neuspjelo odobravanje uređaja: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Neuspjelo zaboravljanje uređaja: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7007,53 +3739,6 @@ msgstr "Odobri i poveži"
 msgid "Forget Device"
 msgstr "Zaboravi uređaj"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Greška"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Odobreno"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr "Thunderbolt podsustav (boltd) nije instaliran ili podešen ispravno."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Dopusti izravan pristup uređajima poput dokova i vanjskih GPU-ova."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Samo USB i Display Port uređaji se mogu spojiti."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt se ne može otkriti.\n"
-"Ili sustav nema podršku za Thunderbolt, jer je onemogućena u BIOSU ili je "
-"postavljena nepodržana razina sigurnosti u BIOSU."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt podrška je onemogućena u BIOSU."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Thunderbolt sigurnosna razina se ne može odrediti."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Greška prebacivanja izravnog načina :%s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Nema Thunderbolt podrške"
@@ -7065,6 +3750,10 @@ msgstr "Nemoguće povezivanje s Thunderbolt podsustavom."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Izravan pristup"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Dopusti izravan pristup uređajima poput dokova i vanjskih GPU-ova."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7082,7 +3771,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Upravljaj Thunderbolt uređajima"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privatnost;"
@@ -7288,41 +3976,6 @@ msgstr ""
 "Uključi mogućnosti isključivanja i uključivanja pristupačnosti koristeći "
 "tipkovnicu"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Uobičajena"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Srednja"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Velika"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Veća"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Najveća"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d piksel"
-msgstr[1] "%d piksela"
-msgstr[2] "%d piksela"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Uvijek prikaži izbornik pristupačnosti"
@@ -7436,31 +4089,6 @@ msgstr "Zabljesni _cijeli zaslon"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Zabljesni _cijeli prozor"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Kratko"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ zaslona"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ zaslona"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ zaslona"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Dugo"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7617,7 +4245,6 @@ msgstr "Efekti boje"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Make it easier to see, hear, type, point and click"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7629,114 +4256,6 @@ msgstr ""
 "Zvuk;Uvećanje;Zaslon;Čitač;velik;visok;tekst;slova;veličina;PristupX;"
 "Pričvrstiv;Tipke;Sporo;Odbijanje;Miš;Dvostruko;klik;Odgoda;Brzina;Pomoć;"
 "Ponovi;Blinkaj;vizualno;slušanje;glazba;zvuk;tipkanje;animacije;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 sat"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dan"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dana"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dana"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dana"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dana"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dana"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dana"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dana"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dana"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Želite li isprazniti sve stavke iz smeća?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Sve stavke u smeću biti će trajno obrisane."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Isprazni smeće"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Želite li obrisati sve privremene datoteke?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Sve privremene datoteke će biti trajno obrisane."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Obriši privremene datoteke"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dan"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dana"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dana"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Zauvijek"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7804,64 +4323,12 @@ msgstr "Povijest datoteka i smeće"
 msgid "Don't leave traces"
 msgstr "Ne ostavljaj tragove"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "upotreba;nedavno;povijest;datoteke;privremeno;prv;privatno;privatnost;smeće;"
 "isprazni;zadrži;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Treba se podudarati web adresa vašeg pružatelja računa."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Dodavanje računa nije upjelo"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Lozinka se ne podudara."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Registracija računa nije uspjela"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Nema podaržanog načina za ovjeru s ovom domenom"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Pridruživanje s domenom nije uspjelo"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"To ime prijave ne radi.\n"
-"Pokušajte ponovno."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Ta lozinka prijave ne radi.\n"
-"Pokušajte ponovno."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Prijava na domenu nije uspjela"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Nemoguće je pronaći domenu. Možda ste ju pogrešno upisali?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7895,7 +4362,7 @@ msgstr "Potvrdi"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:278
 msgid "Enterprise Login"
-msgstr "Poslovno prijava"
+msgstr "Poslovna prijava"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
 msgid "User accounts which are managed by a company or organization."
@@ -7914,10 +4381,6 @@ msgstr ""
 "Poslovna prijava dopušta centralizirano upravljanje postojećim korisničkim "
 "računom kako bi se mogao koristiti na ovom uređaju. Taj račun možete "
 "koristiti isto za pristup resursima tvrtke na internetu."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Potraži još slika"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7988,222 +4451,6 @@ msgstr "_Obriši otiske prsta"
 msgid "Fingerprint Enroll"
 msgstr "Unos otiska prsta"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "uređaj treba zatražiti da izvrši ovu radnju"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "ovaj uređaj je već zatražen od strane drugog procesa"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "nemate dozvolu za izvođenje ove radnje"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "nema unesenih otisaka"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Neuspjela komunikacija s uređajem tijekom unosa"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Neuspjela komunikacija s čitačem otiska tijekom unosa"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Neuspjela komunikacija s pozadinskim programom čitača otiska"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Neuspjeli prikaz otiska prstiju: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Neuspjelo brisanje spremljenih otiska prstiju: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Lijevi palac"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Lijevi srednjak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Lijevi kažiprst"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Lijevi prestenjak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Lijevi mali prst"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Desni palac"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Desni srednjak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Desni kažiprst"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Desni prestenjak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Desni mali prst"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Nepoznat prst"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Završen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Uređaj prijave otiskom prsta odspojen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Pohrana uređaja prijave otiskom prsta je puna"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Neuspjeli unos novoga otiska prsta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Neuspjelo pokretanje unosa: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Neuspjeli unos novoga otiska prsta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Neuspjelo zaustavljanje unosa: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Uzastopno podignite i stavite prst na čitač kako biste unijeli svoj otisak "
-"prsta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Ponovni unos otiska prsta…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Skeniraj novi otisak prsta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Neuspjelo otpuštanje uređaja otiska prstiju %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problem čitanja uređaja"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Neuspjelo potraživanje uređaja otiska prstiju %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Neuspjelo dobivanje uređaja otiska prstiju: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Ovaj tjedan"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Protekli tjedan"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sesija omogućena"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sesija pokrenuta"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Aktivnost računa"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Prijašnja"
@@ -8211,18 +4458,6 @@ msgstr "Prijašnja"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Sljedeća"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Odaberite drugu lozinku."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Ponovo upišite vašu trenutnu lozinku."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Lozinka ne može biti promijenjena"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8244,6 +4479,10 @@ msgstr "Nova lozinka"
 msgid "Confirm Password"
 msgstr "Potvrda nove lozinke"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lozinka se ne podudara."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Dopušta korisniku postavljanje lozinke pri sljedećoj prijavi"
@@ -8251,134 +4490,6 @@ msgstr "Dopušta korisniku postavljanje lozinke pri sljedećoj prijavi"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Postavi lozinku odmah"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Nemoguće se automatski pridružiti ovoj vrsti domene"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Takva domena ili područje nije pornađeno"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Nemoguća prijava kao %s na %s domenu"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Neispravna lozinka, pokušajte ponovno"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Nemoguće povezivanje s %s domenom: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Neuspjelo brisanje korisnika"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Nemoguće je opozvati udaljeno upravljanog korisnika"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Ne možete obrisati vlastiti račun."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s je još prijavljen"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Brisanje korisnika dok su prijavljeni može ostaviti sustav u neupotrebljivom "
-"stanju."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Želite li zadržati %s's datoteke?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Moguće je očuvati osobnu mapu, e-poštu i privremene datoteke kada se briše "
-"korisnički račun."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Obriši datoteke"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Zadrži datoteke"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Sigurno želite opozvati udaljeno upravljani %s's račun?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Obriši"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Račun onemogućen"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Biti će postavljen kod sljedeće prijave"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Nepoznata"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Prijavljeni"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Neuspjelo kontaktiranje usluge računa"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Pobrinite se da je AccountService instaliran i omogućen."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Ovaj panel mora biti otključan za promjenu ove postavke"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Obrišite odabrani korisnički račun"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Kako biste obrisali odabrani korisnički račun,\n"
-"najprije kliknite na ikonu *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Otključaj za dodavanje korisnika i promjenu postavki"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8406,7 +4517,6 @@ msgid "Full name"
 msgstr "Ime i prezime"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Uredi"
 
@@ -8468,7 +4578,6 @@ msgstr "Otključaj za dodavanje korisničkog računa."
 msgid "Add or remove users and change your password"
 msgstr "Dodajte ili uklonite korisnike i promijenite svoju lozinku"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8513,176 +4622,6 @@ msgstr "Upravljanje korisničkim računima"
 msgid "Authentication is required to change user data"
 msgstr "Potrebna je ovjera za promjenu podataka korisnika"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Nova lozinka mora se razlikovati od stare."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Pokušajte promijeniti neka slova i brojeve."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Pokušajte promijeniti lozinku malo više."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Lozinka bez vašeg korisničkog imena bila bi snažnija."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Pokušajte izbjeći korištenje svojeg imena u lozinici."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Pokušajte izbjeći neke riječi sadržane u lozinici."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Pokušajte izbjeći učestale riječi."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Pokušajte izbjeći preslagivanje postojećih riječi."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Pokušajte koristiti više brojeva."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Pokušajte koristiti više velikih slova."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Pokušajte koristiti više malih slova."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Pokušajte koristiti više posebnih znakova, poput interpukcija."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Pokušajte koristiti mješavinu slova, brojeva i interpukcija."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Pokušajte izbjeći iste znakove."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Pokušajte izbjeći ponavljanje istih znakova, trebate koristiti mješavinu "
-"slova, brojeva i interpukcija."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Pokušajte izbjeći slijedove poput 1234 ili abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Lozinka mora biti dulja. Pokušajte dodati više slova, brojeva i interpukcija."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Izmješajte velika i mala slova i dodajte slovo ili dva."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Dodavanje više slova, brojeva i interpunkcija učinit će lozinku snažnijom."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Ovjera nije uspjela"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Nova lozinka je prekratka"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Nova lozinka je prejednostavna"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Nova i stara lozinka su preslične"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Nova lozinka je nedavno već korištena."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Nova lozinka mora sadržavati brojčane ili posebne znakove"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Stara i nova lozinka su iste"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Vaša lozinka je promijenjena otkada ste se prvotno ovjerili!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Nova lozinka ne sadrži dovoljno različitih znakova"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Nepoznata greška"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Korisničko ime može sadržavati samo mala i velika slova od a-z, brojke i ove "
-"znakove: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Nažalost, to korisničko ime nije dostupno. Pokušajte s drugim."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Korisnčko ime je predugačko."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8717,52 +4656,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Loš klik otkriven, ponovno pokretanje…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Tipka %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Određeno aplikacijom"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Pošalji pritisak tipke"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Prebaci zaslon"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Prikaži zaslonsku pomoć"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tablet montiran na panel prijenosnog računala"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tablet montiran na vanjski zaslon"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Vanjski tablet uređaj"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Vanjski uređaj za crtanje"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Svi zasloni"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8858,22 +4755,6 @@ msgstr "Klik desnom tipkom miša"
 msgid "Forward"
 msgstr "Naprijed"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Olovka zračnog kista s pritiskom, nagibom i integriranim klizačem"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Olovka zračnog kista s pritiskom, nagibom i zakretanjem"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standardna olovka s pritiskom i nagibom"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standardna olovka s pritiskom"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom tablet"
@@ -8883,54 +4764,96 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Postavi tipke mapiranja i prilagodi osjetljivost pisaljke grafičkih tableta"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Pisaljka;Gumica;Miš;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Novi prečac…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simuliraj drugi klik"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows softver"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Ponestaje tinte u toneru"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Pomoćni"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows softver"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Upravljajte osobitostima za produktivnost i višezadaćnost"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Pristupne točke"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Dodaj"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Spremi"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "NPT"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Radnja je prekinuta"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Greška:</b> Pristup je uskraćen zbog promjene postavki"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Greška:</b> Greška mobilne opreme"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Nije registrirano"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registrirano"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Pretraživanje"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Uskraćeno"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8960,212 +4883,13 @@ msgstr "Vlastit broj"
 msgid "Device Details"
 msgstr "Pojedinosti uređaja"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Proizvođač"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Inačica firmvera"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G samo"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G samo"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G samo"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "5G samo"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G,5G  (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (preporučeno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (preporučeno), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (preporučeno), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (preporučeno), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (preporučeno), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (preporučeno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (preporučeno), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (preporučeno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (preporučeno), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (preporučeno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (preporučeno), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (preporučeno), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (preporučeno), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (preporučeno), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (preporučeno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (preporučeno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (preporučeno)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (preporučeno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Nepoznat"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Otključaj SIM karticu"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Otključaj"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Navedite PIN kôd za SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Upišite PIN kôd za otključavanje SIM kartice"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Navedite PUK kôd za SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Upišite PUK kôd za otključavanje SIM kartice"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9182,26 +4906,6 @@ msgid_plural "You have %u tries left"
 msgstr[0] "Imate %u preostao pokušaj"
 msgstr[1] "Imate %u preostala pokušaja"
 msgstr[2] "Imate %u preostalih pokušaja"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Nevaljana lozinka upisana."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK kôd bi trebao biti 8-znamenkasti broj"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Upišite novi PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN kôd bi trebao biti 4-8-znamenkasti broj"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Otključavanje…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9259,94 +4963,6 @@ msgstr "Zaključaj SIM sa PIN-om"
 msgid "M_odem Details"
 msgstr "P_ojedinosti modema"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Kvar telefona"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Nema povezivanja s telefonom"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Radnja nije dopuštena"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Radnja nije podržana"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM kartica nije umetnuta"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "SIM PIN je potreban"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "SIM PUK je potreban"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Neuspjeh SIM kartice"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM kartica je zauzeta"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Lozinka je netočna"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIM PIN2 je potreban"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIM PUK2 je potreban"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Nije pronađeno"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Nema mrežne usluge"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Istek mreže"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS usluga nije dopuštena"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming nije dopušten u ovom području"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Neodređena GPRS greška"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Bez greške"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Radnja prekinuta"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Pristup uskraćen"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Nepoznata greška"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Način rada mreže"
@@ -9362,11 +4978,6 @@ msgstr "Odaberi mrežu"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Osvježi mrežne operatere"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9424,7 +5035,6 @@ msgstr "Mobilna mreža"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Prilagodite telefoniranje i povezivanje mobilnim podacima"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "mobitel;wwan;telefoniranje;sim;mobilno;"
@@ -9441,41 +5051,13 @@ msgstr "Postavke su glavno sučelje za podešavanje vašeg sustava."
 msgid "The GNOME Project"
 msgstr "GNOME projekt"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Prikaži broj inačice"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Omogući opširni opisni način rada"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Pretraživanje niza"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Prikaži moguće nazive panela i izađi"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel za prikaz"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Kategorije postavki"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privatnost"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Dostupni paneli:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9533,7 +5115,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Prekini pretragu"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Osobitosti;Postavke;"
@@ -9572,8 +5153,6 @@ msgstr ""
 "Pravilo koje sadrži početnu širinu, visinu i uvećano stanje prozora "
 "aplikacije."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9582,8 +5161,6 @@ msgstr[0] "%u izlaz"
 msgstr[1] "%u izlaza"
 msgstr[2] "%u izlaza"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9592,18 +5169,3131 @@ msgstr[0] "%u ulaz"
 msgstr[1] "%u ulaza"
 msgstr[2] "%u ulaza"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Zvukovi sustava"
+#~ msgid "System Bus"
+#~ msgstr "Sabirnica sustava"
+
+#~ msgid "Full access"
+#~ msgstr "Potpuni pristup"
+
+#~ msgid "Session Bus"
+#~ msgstr "Sabirnica sesije"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Potpuni pristup u /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Ima pristup mreži"
+
+#~ msgid "Home"
+#~ msgstr "Osobna mapa"
+
+#~ msgid "Read-only"
+#~ msgstr "Samo za čitanje"
+
+#~ msgid "File System"
+#~ msgstr "Datotečni sustav"
+
+#~ msgid "Can change settings"
+#~ msgstr "Može promijeniti postavke"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s ima sljedeće ugrađene dozvole. One se ne mogu mijenjati. Ako ste u "
+#~ "nedoumici zbog tih dozvola, razmislite o uklanjanju te aplikacije."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u datoteka i vrsta poveznice koja je otvorena aplikacijom"
+#~ msgstr[1] "%u datoteka i vrsta poveznice koje su otvorene aplikacijom"
+#~ msgstr[2] "%u datoteka i vrsta poveznice koje su otvorene aplikacijom"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> se koristi za otvaranje sljedećih vrsta datoteka i poveznica."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s diskovnog prostora se koristi."
+
+#~ msgid "Select a picture"
+#~ msgstr "Odaberi sliku"
+
+#~ msgid "_Open"
+#~ msgstr "_Otvori"
+
+#~ msgid "multiple sizes"
+#~ msgstr "višestruke veličine"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Bez pozadine radne površine"
+
+#~ msgid "Current background"
+#~ msgstr "Trenutna pozadina"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Smjestite vaš uređaj za kalibraciju preko četverokuta i pritisnite "
+#~ "”Pokreni”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Pomaknite vaš uređaj za kalibraciju na položaj kalibracije i pritisnite "
+#~ "”Nastavi”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Pomaknite vaš uređaj za kalibraciju na položaj površine i pritisnite "
+#~ "”Nastavi”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Spusti zaslon prijenosnika"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Dogodila se unutrašnja greška koja se ne može oporaviti."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Alati potrebni za kalibraciju nisu instalirani."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profil se ne može stvoriti."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Odredišna bijela točka je dostižna."
+
+#~ msgid "Complete!"
+#~ msgstr "Završeno!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibracija nije uspjela!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Možete ukloniti uređaj za kalibraciju."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Nemojte ometati uređaj tijekom kalibracije"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Zaslon prijenosnika"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Ugrađena web kamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s zaslon"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s skener"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s kamera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s pisač"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s web kamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Omogući upravljanje bojom za %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Prikaži profile boje za %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nije kalibriran"
+
+#~ msgid "Default: "
+#~ msgstr "Uobičajeno: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Raspon boja: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testni profil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Odaberi ICC datoteku profila"
+
+#~ msgid "_Import"
+#~ msgstr "_Uvezi"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Podržani ICC profili"
+
+#~ msgid "All files"
+#~ msgstr "Sve datoteke"
+
+#~ msgid "Save Profile"
+#~ msgstr "Spremi profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Napravi profil boje za odabrani uređaj"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Mjerni uređaj nije pronađen. Provjerite je li uključen i ispravno spojen."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Mjerni uređaj ne podržava profiliranje pisača."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Vrsta uređaja trenutno nije podržana."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standardan razmak"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testiraj profil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatski"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Niska kvaliteta"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Srednja kavaliteta"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Visoka kvaliteta"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Uobičajeni RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Uobičajeni CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Uobičajeno sivo"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Proizvođačem isporučeni podaci tvorničke kalibracije"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Cijelozaslonski prikaz nije moguć sa ovim profilom"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Ovaj profil možda nije više točan"
+
+#~ msgid "Other…"
+#~ msgstr "Ostalo…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Otključaj za promjenu postavki"
+
+#~ msgid "Today"
+#~ msgstr "Danas"
+
+#~ msgid "Yesterday"
+#~ msgstr "Jučer"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d sat"
+#~ msgstr[1] "%d sata"
+#~ msgstr[2] "%d sati"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuta"
+#~ msgstr[1] "%d minute"
+#~ msgstr[2] "%d minuta"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekunda"
+#~ msgstr[1] "%d sekunde"
+#~ msgstr[2] "%d sekundi"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Pristupna točka"
+
+#~ msgid "24-hour"
+#~ msgstr "24-satni"
+
+#~ msgid "AM / PM"
+#~ msgstr "12-satni"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Slanje izvještaja tehničkih problema pomaže nam poboljšati %s. Izvještaji "
+#~ "su poslani anonimno i ne sadrže osobne podatke. %s"
+
+#~ msgid "On"
+#~ msgstr "Uključeno"
+
+#~ msgid "Off"
+#~ msgstr "Isključeno"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Primijeni promjene?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Promjene se ne mogu primijeniti"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "To može biti uzrokovano ograničenjem hardvera."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Položeno"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Uspravno desno"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Uspravno lijevo"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Obrnuto položeno"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Sigurno pokretanje (Secure Boot) je aktivno"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se "
+#~ "učita kada se uređaj pokrene. Trenutno je uključeno i radi ispravno."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Sigurno pokretanje (Secure Boot) ima probleme"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se "
+#~ "učita kada se uređaj pokrene. Trenutno je uključeno, ali neće raditi jer "
+#~ "ima nevaljani ključ."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Problemi sigurnog pokretanja (Secure Boot) uobičajeno se mogu riješiti iz "
+#~ "UEFI firmver postavki (BIOS) vašeg računala, a vaš proizvođač hardvera "
+#~ "pruža informacije za ovo rješenje."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Za pomoć, kontaktirajte svojeg proizvođača hardvera ili pružatelja IT "
+#~ "podrške."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Sigurno pokretanje (Secure Boot) je isključeno"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se ne "
+#~ "učita kada se uređaj pokrene. Trenutno je isključeno."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Sigurno pokretanje (Secure Boot) uobičajeno može biti isključeno u UEFI "
+#~ "firmver postavkama (BIOS) vašeg računala. Za pomoć, kontaktirajte svojeg "
+#~ "proizvođača hardvera ili pružatelja IT podrške."
+
+#~ msgid "Passed"
+#~ msgstr "Prošlo"
+
+#~ msgid "Failed"
+#~ msgstr "Neuspjelo"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Uređaj je usklađen s HSI razinom %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Sigurnosna razina 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Ovaj uređaj nema zaštitu protiv hardverskih sigurnosnih problema. Uzrok "
+#~ "tome može biti problem u podešavanju hardvera ili firmvera. Preporučljivo "
+#~ "je da kontaktirate svojeg proizvođača hardvera ili pružatelja IT podrške."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Sigurnosna razina 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Ovaj uređaj ima najmanju zaštitu protiv hardverskih sigurnosnih problema. "
+#~ "Ovo je najmanja razina sigurnosti uređaja i samo pruža zaštitu od "
+#~ "jednostavnih sigurnosnih prijetnji."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Sigurnosna razina 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Ovaj uređaj ima osnovnu zaštitu protiv hardverskih sigurnosnih problema. "
+#~ "Ova razina pruža zaštitu protiv učestalih sigurnosnih prijetnji."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Sigurnosna razina 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Ovaj uređaj ima proširenu zaštitu protiv hardverskih sigurnosnih "
+#~ "problema. Ovo je najviša razina sigurnosti uređaja i pruža zaštitu protiv "
+#~ "naprednih sigurnosnih prijetnji."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Sigurnosne razine nisu dostupne za ovaj uređaj."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Kontaktirajte svojeg proizvođača hardvera za pomoć oko sigurnosnih "
+#~ "nadopuna."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Moguće rješenje ovog problema je u postavkama UEFI firmvera uređaja, ili "
+#~ "u podršci od strane tehničara."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Moguće rješenje ovog problema je u postavkama UEFI firmvera uređaja."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Moguće rješenje ovog problema je u podršci od strane tehničara."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Zaštita od zlonamjernog softvera pri pokretanju uređaja."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Sigurno pokretanje (Secure Boot) ima probleme"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Određena zaštita pri pokretanju uređaja."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Sigurno pokretanje (Secure Boot) je isključeno"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Bez zaštite pri pokretanju uređaja."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Ovaj problem mogao bi biti uzrokovan promjenom u postavkama UEFI "
+#~ "firmvera, promjenom podešavanja operativnog sustava ili zbog zlonamjernog "
+#~ "softvera na ovom sustavu."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Ovaj problem mogao bi biti uzrokovan promjenom u postavkama UEFI firmvera "
+#~ "ili zbog zlonamjernog softvera na ovom sustavu."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Ovaj problem mogao bi biti uzrokovan promjenom u podešavanja operativnog "
+#~ "sustava ili zbog zlonamjernog softvera na ovom sustavu."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Izloženi ste ozbiljnim sigurnosnim prijetnjama."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Ograničena zaštita protiv jednostavnih sigurnosnih prijetnji."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Zaštita protiv učestalih sigurnosnih prijetnji."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Zaštita protiv širokog raspona sigurnosnih prijetnji."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Sveobuhvatna zaštita"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Zaštita od zapisivanja firmvera"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Zaključavanje zaštite od zapisivanja firmvera"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Firmver BIOS područje"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Firmver BIOS opisnik"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "DMA zaštita predpokretanja"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard provjereno pokretanje"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM zaštićen"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard pravilo greške"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard osigurač"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET omogućen"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET aktivan"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Šifrirani RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU zaštita"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux kernel zaključavanje"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux kernel provjera"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Suspendiraj u ram"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Suspendiraj u mirovanje"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI ključ platforme"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI Sigurno pokretanje (Secure Boot)"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Podešavanje TPM platforme"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM rekonstrukcija"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Način proizvodnje Intel pogona upravljanja (MEI)"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Zaobilaženje Intel pogona upravljanja (MEI)"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Inačica Intel pogona upravljanja (MEI)"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Nadopune firmvera"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Frimver provjera"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Provjera firmver nadopunitelja"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Otklanjanje grešaka platforme"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Sigurnosne provjere procesora"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD Rollback zaštita"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Zaštita od ponavljanja AMD firmvera"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Zaštita od zapisivanja AMD firmvera"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Pregorjela platforma"
+
+#~ msgid "Valid"
+#~ msgstr "Valjano"
+
+#~ msgid "Not Valid"
+#~ msgstr "Nije valjano"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Nije omogućeno"
+
+#~ msgid "Locked"
+#~ msgstr "Zaključano"
+
+#~ msgid "Not Locked"
+#~ msgstr "Nije zaključano"
+
+#~ msgid "Encrypted"
+#~ msgstr "Šifriran"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Nije šifriran"
+
+#~ msgid "Tainted"
+#~ msgstr "Pokvaren"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Nije pokvaren"
+
+#~ msgid "Found"
+#~ msgstr "Pronađeno"
+
+#~ msgid "Not Found"
+#~ msgstr "Nije pronađeno"
+
+#~ msgid "Supported"
+#~ msgstr "Podržano"
+
+#~ msgid "Not Supported"
+#~ msgstr "Nije podržano"
+
+#~ msgid "Unknown"
+#~ msgstr "Nepoznato"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bitna"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bitna"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Nepoznat"
+
+#~ msgid "Not Available"
+#~ msgstr "Nedostupno"
+
+#~ msgid "System Logo"
+#~ msgstr "Logotip sustava"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nema pronađenih načina unosa"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Ostalo"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Prilagođeni prečaci"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Zamjenska tipka znakova može se koristiti za unos dodatnih znakova. To je "
+#~ "ponekad ispisano na vašoj tipkovnici kao treća mogućnost."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Lijevi Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Desni Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Lijevi Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Desni Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tipka Izbornika"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Desni Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Tipka sastavljanja dopušta širok raspon znakova za unos. Za korištenje, "
+#~ "pritisnite sastavljanje zatim slijed znakova.  Na primjer, tipku "
+#~ "sastavljanja za kojom slijedi <b>C</b> i <b>o</b> koji će unijeti <b>©</"
+#~ "b>, <b>a</b> za kojima slijedi <b>'</b> koji će unijeti <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Načini unosa mogu se mijenjati koristeći %s prečac tipkovnice.\n"
+#~ "Ovo se može promijeniti u postavkama prečaca tipkovnice."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d promijenjen"
+#~ msgstr[1] "%d promijenjena"
+#~ msgstr[2] "%d promijenjeno"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Vrati sve prečace na izvorno stanje?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Vraćanje prečaca na izvorno stanje može utjecati na vaše prilagođene "
+#~ "prečace. To se ne može poništit."
+
+#~ msgid "Reset All"
+#~ msgstr "Vrati sve na izvorno"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s se već koristi za %s. Ako ga zamjenjujete, %s biti će onemogućen"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Upišite novi prečac"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Postavi prilagođen prečac"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Postavi prečac"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Upišite novi prečac za promjenu %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Dodaj prilagođeni prečac"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Pomicanje s dva prsta"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Pet klika, vrijeme je za GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dvostruki klik, glavna tipka"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Jednostruki klik, glavna tipka"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dvostruki klik, srednja tipka"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Jednostruki klik, srednja tipka"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dvostruki klik, druga tipka"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Jednostruki klik, druga tipka"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Mrežni upravitelj mora biti pokrenut."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Otvorena mreža (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Zaštićena mreža (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Zaštićena mreža (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Zaštićena mreža (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Zaštićena mreža"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Uključivanje pristupne točke će prekinuti %s povezivanje i nećete biti u "
+#~ "mogućnosti pristupiti internetu putem bežične mreže."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Mora sadržavati najmanje 8 znakova"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Zaustaviti pristupnu točku i odspojiti sve korisnike?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Zaustavi pristupnu točku"
+
+#~ msgid "Preserve"
+#~ msgstr "Očuvano"
+
+#~ msgid "Permanent"
+#~ msgstr "Trajno"
+
+#~ msgid "Random"
+#~ msgstr "Naizmjenično"
+
+#~ msgid "Stable"
+#~ msgstr "Stabilno"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "MAC adresa koja je ovdje upisana, koristit će se kao hardverska adresa za "
+#~ "mrežni uređaj na kojemu je aktivirano ovo povezivanje. Ova mogućnost je "
+#~ "poznata kao MAC kloniranje ili zavaravanje. Primjer: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Poboljšano otvoreno (OWE)"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Poslovanje"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nepoznata"
+
+#~ msgid "Never"
+#~ msgstr "Nikada"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nepoznata"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Slaba"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "U redu"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Dobra"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Izvrsna"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Zaboravi povezivanje"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Ukloni profil povezivanja"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Ukloni VPN"
+
+#~ msgid "Details"
+#~ msgstr "Pojedinosti"
+
+#~ msgid "automatic"
+#~ msgstr "automatski"
+
+#~ msgid "Identity"
+#~ msgstr "Identitet"
+
+#~ msgid "Delete Address"
+#~ msgstr "Obriši adrese"
+
+#~ msgid "Delete Route"
+#~ msgstr "Obriši rutu"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Nepoznata"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bitni ključ (Heks. ili ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bitna lozinka"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Promjenjivi WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA i WPA2 osobni"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA i WPA2 poslovni"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 osobni"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Nemoguće otvaranje uređivača povezivanja"
+
+#~ msgid "New Profile"
+#~ msgstr "Novi profil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Nevaljana postavka %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Nevaljana postavka %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Uvezi iz datoteke…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Dodaj VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Nemoguć uvoz VPN povezivanja"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Datoteka ”%s” nije mogla biti pročitana ili ne sadrži poznate informacije "
+#~ "VPN povezivanja\n"
+#~ "\n"
+#~ "Greška: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Odaberi datoteku za uvoz"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Datoteka naziva \"%s\" već postoji."
+
+#~ msgid "_Replace"
+#~ msgstr "_Zamijeni"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Želite li zamijeniti %s s VPN povezivanjem kojeg spremate?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Nemoguć izvoz VPN povezivanja"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN povezivanje ”%s” nije moglo biti izvezeno u %s.\n"
+#~ "\n"
+#~ "Greška: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Izvezi VPN povezivanje"
+
+#~ msgid "never"
+#~ msgstr "nikada"
+
+#~ msgid "today"
+#~ msgstr "danas"
+
+#~ msgid "yesterday"
+#~ msgstr "jučer"
+
+#~ msgid "Last used"
+#~ msgstr "Zadnje korištena"
+
+#~ msgid "Add new connection"
+#~ msgstr "Dodaj novu mrežu"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Mrežne pojedinosti za odabrane mreže, uključujući lozinke i sve "
+#~ "prilagođene postavke će biti izgubljene."
+
+#~ msgid "_Forget"
+#~ msgstr "_Zaboravi"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Poznate bežične mreže"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Zaboravi"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Pravila sustava ne dopuštaju korištenje kao pristupne točke"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Bežični uređaj ne podržava način pristupne točke"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Automatsko otkrivanje web proxyja se koristi kada URL podešavanja nije "
+#~ "omogućen."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Ovo nije preporučljivo za javne mreže kojima se ne vjeruje."
+
+#~ msgid "Status unknown"
+#~ msgstr "Nepoznato stanje"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Neupravljano"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nedostupno"
+
+#~ msgid "Connecting"
+#~ msgstr "Povezivanje"
+
+#~ msgid "Authentication required"
+#~ msgstr "Potrebna je ovjera"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Prekidanje povezivanja"
+
+#~ msgid "Connection failed"
+#~ msgstr "Neuspješno povezivanje"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Nepoznato stanje (nedostaje)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Neuspjelo podešavanja"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP podešavanje neuspjelo"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP podešavanje isteklo"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Tajne su zahtijevane, ali ne i pružane"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x opskrbitelj nije povezan"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x opskrbitelj neuspjelo podešavanje"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x opskrbitelj neuspio"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x opskrbitelj predugo trajanje ovjere"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP usluga se nije uspjela pokrenuti"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP usluga je prekinula povezivanje"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP je neuspio"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP klijent se nije uspio pokrenuti"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Greška DHCP klijenta"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP kijent je neuspio"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Usluga dijeljenja povezivanja se nije uspjela pokrenuti"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Usluga dijeljenja povezivanja je neuspjela"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP usluga se nije uspjela pokrenuti"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Greška AutoIP usluge"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP usluga nije uspjela"
+
+#~ msgid "Line busy"
+#~ msgstr "Linija zauzeta"
+
+#~ msgid "No dial tone"
+#~ msgstr "Nema tona biranja"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Nije pronađen nijedan operater"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Biranje zahtijeva čekanje"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Pokušaj biranja neuspio"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Pokretanje modema nije uspjelo"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Odabir određenog APN-a nije uspjelo"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Mreže se ne traže"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Mrežna registracija odbijena"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Isteklo vrijeme mrežne registracije"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Registracija sa zatraženom mrežnom nije uspjela"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Provjera PIN-a nije uspjela"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firmver uređaja možda nedostaje"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Povezivanje je nestalo"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Postojeće povezivanje je predpostavljeno"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem nije pronađen"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth povezivanje neuspjelo"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM kartica nije umetnuta"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM Pin je potreban"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk je potreban"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Pogrešan SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Neuspjelo povezivanje zavisnosti"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Nedostaje firmver"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel je odspojen"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "neodređena greška u 802.1x sigurnosti (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "nema odabrane datoteke"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "neodređena greška provjeravanja datoteke eap-načina"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 ili PGP privatni ključevi"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER ili PEM vjerodajnice"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "nedostaje EAP-FAST PAC datoteka"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC datoteke (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "nedostaje EAP-LEAP korisničko ime"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "nedostaje EAP-LEAP lozinka"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "nevaljana EAP-PEAP CA vjerodajnica: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "nevaljana EAP-PEAP CA vjerodajnica: vjerodajnica nije određena"
+
+#~ msgid "missing EAP username"
+#~ msgstr "nedostaje EAP korisničko ime"
+
+#~ msgid "missing EAP password"
+#~ msgstr "nedostaje EAP lozinka"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "nedostaje EAP-TLS identitet"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "nevaljana EAP-TLS CA vjerodajnica: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "nevaljana EAP-TLS CA vjerodajnica: vjerodajnica nije određena"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "nevaljani EAP-TLS privatni ključ: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "nevaljana EAP-TLS CA korisnička-vjerodajnica: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Nešifriani privatni ključevi su nesigurni"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Čini se da odabrani privatni ključ nije zaštićen lozinkom. Ovo može "
+#~ "dopustiti kompromitiranje vaših sigurnosnih podataka. Odaberite lozinkom "
+#~ "zaštićeni privatni ključ.\n"
+#~ "\n"
+#~ "(Svoj privatni ključ možete zaštititi lozinkom pomoću openssla)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Odaberite svoju osobnu vjerodajnicu"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Odaberite svoj privatni ključ"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "nevaljana EAP-TTLS CA vjerodajnica: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "nevaljana EAP-TTLS CA vjerodajnica: vjerodajnica nije određena"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Nepoznata greška provjere 802.1X sigurnosti"
+
+#~ msgid "Select a file"
+#~ msgstr "Odaberi datoteku"
+
+#~ msgid "missing leap-username"
+#~ msgstr "nedostaje leap korisničko ime"
+
+#~ msgid "missing leap-password"
+#~ msgstr "nedostaje leap lozinka"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Lozinka bežične mreže nedostaje."
+
+#~ msgid "missing wep-key"
+#~ msgstr "nedostaje wep ključ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "nevaljani wep ključ: ključ duljine %zu mora sadržavati samo heks. znamenke"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "nevaljani wep ključ: ključ duljine %zu mora sadržavati samo ascii znamenke"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "nevaljani wep ključ: pogrešna duljina ključa %zu. Ključ mora biti 5/13 "
+#~ "(ascii) ili 10/26 (heks.)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "nevaljani wep ključ: lozinka ne smije biti prazna"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "nevaljani wep ključ: lozinka mora sadržavati manje od 64 znamenaka"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "nevaljani wpa-psk: nevaljana duljina ključa %zu. Mora biti [8,63] bajtova "
+#~ "ili 64 heks. znamenke"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "nevaljani wpa-psk: ne može se interpretirati ključ sa 64 bajtova kao heks"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Ostalo"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s je uklonjen"
+
+#~ msgid "Error removing account"
+#~ msgstr "Greška pri uklanjanju računa"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s račun"
+
+#~ msgid "Remove Account"
+#~ msgstr "Ukloni račun"
+
+#~ msgid "Unknown time"
+#~ msgstr "Nepoznato vrijeme"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s do potpune napunjenosti"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Upozorenje: %s preostalo"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s preostalo"
+
+#~ msgid "Fully charged"
+#~ msgstr "Potpuno napunjeno"
+
+#~ msgid "Not charging"
+#~ msgstr "Ne puni se"
+
+#~ msgid "Empty"
+#~ msgstr "Prazna"
+
+#~ msgid "Charging"
+#~ msgstr "Punjenje"
+
+#~ msgid "Discharging"
+#~ msgstr "Pražnjenje"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Bežični miš"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Bežična tipkovnica"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Neprekinuta opskrba energijom (UPS)"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Osobni digitalni pomagač (PDA)"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobitel"
+
+#~ msgid "Media player"
+#~ msgstr "Medijski reproduktor"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Računalo"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Uređaj za igranje"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Glavna"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Dodatna"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterije"
+
+#~ msgid "When _idle"
+#~ msgstr "Pri _mirovanju"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspendiraj"
+
+#~ msgid "Power Off"
+#~ msgstr "Isključi"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hiberniraj"
+
+#~ msgid "Nothing"
+#~ msgstr "Ništa"
+
+#~ msgid "When on battery power"
+#~ msgstr "Na bateriji"
+
+#~ msgid "When plugged in"
+#~ msgstr "Na napajanju"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nikada"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatska suspenzija"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Performanse način rada je trenutno onemogućen uslijed visoke temperature "
+#~ "rada."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Preklop otkriven: performanse način rada je privremeno nedostupan. "
+#~ "Premjestite uređaj na stabilnu površinu za obnavljanje."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Performanse način rada je onemogućen."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Slaba baterija: štednja energije je omogućena. Prijašnji način rada će "
+#~ "biti obnovljen kada se baterija dovoljno napuni."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Štednju energije je aktivirao “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Performanse način rada je aktivirao “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Performanse"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Visoke performanse i potrošnja energije."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Uravnoteženo"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standardne performanse i potrošnja energije."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Štednja energije"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Smanjene performanse i potrošnja energije."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Pisač “%s” je obrisan"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Neuspjelo dodavanje novoga pisača."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Nemoguće učitati kor. sučelje: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Otključaj za dodavanje pisača i promjenu postavki"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s pojedinosti"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nije pronađen odgovarajući upravljački program"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Odaberi PPD datoteku"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Datoteka opisa PostSkripta pisača (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect pisač"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD pisač"
+
+#~ msgid "One Sided"
+#~ msgstr "Jednostrano"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Dugom stranom (standardno)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kratkom stranom (okrenuto)"
+
+#~ msgid "Portrait"
+#~ msgstr "Uspravno"
+
+#~ msgid "Landscape"
+#~ msgstr "Položeno"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Obrnuto položeno"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Obrnuto uspravno"
+
+#~ msgid "Resume"
+#~ msgstr "Nastavi"
+
+#~ msgid "Pause"
+#~ msgstr "Pauziraj"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Na čekanju"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pauzirano"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Potrebna je ovjera"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Obrada"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Zaustavljen"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Otkazan"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Prekinut"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Završen"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Premjesti ovaj zadatak na vrh reda čekanja"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — aktivnih zadataka"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Upišite korisničko ime i lozinku za ispis sa %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Otključaj poslužitelj pisača"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Otključaj %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Upišite korisničko ime i lozinku kako bi vidjeli pisače dostupne na %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Pretraživanje pisača"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serijski priključak"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralelni priključak"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Lokacija: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresa: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Poslužitelj zahtijeva ovjeru"
+
+#~ msgid "Two Sided"
+#~ msgstr "Obostrano"
+
+#~ msgid "Paper Type"
+#~ msgstr "Vrsta papira"
+
+#~ msgid "Paper Source"
+#~ msgstr "Izvor papira"
+
+#~ msgid "Output Tray"
+#~ msgstr "Izlazna ladica"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Razlučivost"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostSkripta predfiltriranja"
+
+#~ msgid "Pages per side"
+#~ msgstr "Stranica po listu"
+
+#~ msgid "Orientation"
+#~ msgstr "Orijentacija"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Općenito"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Postavke ispisa"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Mogućnosti instaliranja"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Zadatak"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Kvaliteta slike"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Boja"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Završavanje"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Napredno"
+
+#~ msgid "Test page"
+#~ msgstr "Testna stranica"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatski odabir"
+
+#~ msgid "Printer Default"
+#~ msgstr "Zadani pisač"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Ugradi samo Ghostskript slova"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Prevedi u PS razine 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Prevedi u PS razine 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Bez prevođenja"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Čišćenje glava pisača"
+
+#~ msgid "Out of toner"
+#~ msgstr "Ponestalo tinte u toneru"
+
+#~ msgid "Low on developer"
+#~ msgstr "Razvijatelj nizak"
+
+#~ msgid "Out of developer"
+#~ msgstr "Ponestalo razvijatelja"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Ponestaje tinte"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Ponestalo tinte"
+
+#~ msgid "Open cover"
+#~ msgstr "Otvoren je poklopac"
+
+#~ msgid "Open door"
+#~ msgstr "Otvorena su vratašca"
+
+#~ msgid "Low on paper"
+#~ msgstr "Ponestaje papira"
+
+#~ msgid "Out of paper"
+#~ msgstr "Ponestalo papira"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Nije povezan"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Zaustavljen"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Pisačeva kantica za otpad je skoro puna"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Pisačeva kantica za otpad je puna"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Optički fotografski vodič je pri kraju vijeka trajanja"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Optički fotografski vodič je istrošen"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Spreman"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Ne prihvaća zadatke"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Obrada"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperijalne"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrički"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Pitaj što učiniti"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ne čini ništa"
+
+#~ msgid "Open folder"
+#~ msgstr "Otvori mapu"
+
+#~ msgid "Other Media"
+#~ msgstr "Ostali mediji"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Odaberite aplikaciju za glazbene CD-e"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Odaberite aplikaciju za video DVD-e"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Odaberite aplikaciju koja će se pokrenuti kada je glazbeni svirač spojen"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Odaberite aplikaciju koja će se pokrenuti kada je kamera spojena"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Odaberite aplikaciju za softverske CD-e"
+
+#~ msgid "audio DVD"
+#~ msgstr "Glazbeni DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Prazni Blu-ray disk"
+
+#~ msgid "blank CD disc"
+#~ msgstr "Prazni CD disk"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "Prazni DVD disk"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Prazni HD DVD disk"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video disk"
+
+#~ msgid "e-book reader"
+#~ msgstr "Čitač e-knjiga"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video disk"
+
+#~ msgid "Picture CD"
+#~ msgstr "Slikovni CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Odmah"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekundi"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuta"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuta"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minuta"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 sat"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minuta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minuta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minuta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minuta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nikada"
+
+#~ msgid "Select Location"
+#~ msgstr "Odaberi lokaciju"
+
+#~ msgid "_OK"
+#~ msgstr "_U redu"
+
+#~ msgid "No applications found"
+#~ msgstr "Aplikacije nisu pronađene"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nema odabranih mreža za dijeljenje"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Uključeno"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Isključeno"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Omogućeno"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktivno"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Odaberi mapu"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Omogući dijeljenje medija"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Dijeljenje datoteka omogućuje vam dijeljenje Javne mape s ostalim "
+#~ "korisnicima vaše trenutne mreže koristeći: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kada je udaljena prijava omogućena, udaljeni korisnici mogu se povezati "
+#~ "koristeći naredbu sigurne ljuske (SSH):\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Omogući dijeljenje osobnih medija"
+
+#~ msgid "Device name copied"
+#~ msgstr "Naziv uređaja je kopiran"
+
+#~ msgid "Device address copied"
+#~ msgstr "Adresa uređaja je kopirana"
+
+#~ msgid "Username copied"
+#~ msgstr "Korisničko ime je kopirano"
+
+#~ msgid "Password copied"
+#~ msgstr "Lozinka je kopirana"
+
+#~ msgid "Custom"
+#~ msgstr "Prilagođeno"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s - proba"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Odspojeno"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Povezivanje"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Povezano"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Greška ovjere"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Odobravanje"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Smanjena funkcionalnost"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Povezano i odobreno"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Nepoznato"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Odobreno na:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Povezano na:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Upisano:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Neuspjelo odobravanje uređaja: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Neuspjelo zaboravljanje uređaja: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Greška"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Odobreno"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr "Thunderbolt podsustav (boltd) nije instaliran ili podešen ispravno."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Samo USB i Display Port uređaji se mogu spojiti."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt se ne može otkriti.\n"
+#~ "Ili sustav nema podršku za Thunderbolt, jer je onemogućena u BIOSU ili je "
+#~ "postavljena nepodržana razina sigurnosti u BIOSU."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt podrška je onemogućena u BIOSU."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Thunderbolt sigurnosna razina se ne može odrediti."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Greška prebacivanja izravnog načina :%s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Uobičajena"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Srednja"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Velika"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Veća"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Najveća"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d piksel"
+#~ msgstr[1] "%d piksela"
+#~ msgstr[2] "%d piksela"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kratko"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ zaslona"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ zaslona"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ zaslona"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Dugo"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 sat"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dan"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dana"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dana"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dana"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dana"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dana"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dana"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dana"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dana"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Želite li isprazniti sve stavke iz smeća?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Sve stavke u smeću biti će trajno obrisane."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Isprazni smeće"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Želite li obrisati sve privremene datoteke?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Sve privremene datoteke će biti trajno obrisane."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Obriši privremene datoteke"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dan"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dana"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dana"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Zauvijek"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Treba se podudarati web adresa vašeg pružatelja računa."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Dodavanje računa nije upjelo"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Registracija računa nije uspjela"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nema podaržanog načina za ovjeru s ovom domenom"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Pridruživanje s domenom nije uspjelo"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "To ime prijave ne radi.\n"
+#~ "Pokušajte ponovno."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ta lozinka prijave ne radi.\n"
+#~ "Pokušajte ponovno."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Prijava na domenu nije uspjela"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Nemoguće je pronaći domenu. Možda ste ju pogrešno upisali?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Potraži još slika"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "uređaj treba zatražiti da izvrši ovu radnju"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "ovaj uređaj je već zatražen od strane drugog procesa"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "nemate dozvolu za izvođenje ove radnje"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "nema unesenih otisaka"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Neuspjela komunikacija s uređajem tijekom unosa"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Neuspjela komunikacija s čitačem otiska tijekom unosa"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Neuspjela komunikacija s pozadinskim programom čitača otiska"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Neuspjeli prikaz otiska prstiju: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Neuspjelo brisanje spremljenih otiska prstiju: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Lijevi palac"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Lijevi srednjak"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Lijevi kažiprst"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Lijevi prestenjak"
+
+#~ msgid "Left little finger"
+#~ msgstr "Lijevi mali prst"
+
+#~ msgid "Right thumb"
+#~ msgstr "Desni palac"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Desni srednjak"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Desni kažiprst"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Desni prestenjak"
+
+#~ msgid "Right little finger"
+#~ msgstr "Desni mali prst"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Nepoznat prst"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Završen"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Uređaj prijave otiskom prsta odspojen"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Pohrana uređaja prijave otiskom prsta je puna"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Neuspjeli unos novoga otiska prsta"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Neuspjelo pokretanje unosa: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Neuspjeli unos novoga otiska prsta"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Neuspjelo zaustavljanje unosa: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Uzastopno podignite i stavite prst na čitač kako biste unijeli svoj "
+#~ "otisak prsta"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Ponovni unos otiska prsta…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Skeniraj novi otisak prsta"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Neuspjelo otpuštanje uređaja otiska prstiju %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problem čitanja uređaja"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Neuspjelo potraživanje uređaja otiska prstiju %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Neuspjelo dobivanje uređaja otiska prstiju: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Ovaj tjedan"
+
+#~ msgid "Last Week"
+#~ msgstr "Protekli tjedan"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sesija omogućena"
+
+#~ msgid "Session Started"
+#~ msgstr "Sesija pokrenuta"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Aktivnost računa"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Odaberite drugu lozinku."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Ponovo upišite vašu trenutnu lozinku."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Lozinka ne može biti promijenjena"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Nemoguće se automatski pridružiti ovoj vrsti domene"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Takva domena ili područje nije pornađeno"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Nemoguća prijava kao %s na %s domenu"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Neispravna lozinka, pokušajte ponovno"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Nemoguće povezivanje s %s domenom: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Neuspjelo brisanje korisnika"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Nemoguće je opozvati udaljeno upravljanog korisnika"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Ne možete obrisati vlastiti račun."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s je još prijavljen"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Brisanje korisnika dok su prijavljeni može ostaviti sustav u "
+#~ "neupotrebljivom stanju."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Želite li zadržati %s's datoteke?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Moguće je očuvati osobnu mapu, e-poštu i privremene datoteke kada se "
+#~ "briše korisnički račun."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Obriši datoteke"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Zadrži datoteke"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Sigurno želite opozvati udaljeno upravljani %s's račun?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Obriši"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Račun onemogućen"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Biti će postavljen kod sljedeće prijave"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Nepoznata"
+
+#~ msgid "Logged in"
+#~ msgstr "Prijavljeni"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Neuspjelo kontaktiranje usluge računa"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Pobrinite se da je AccountService instaliran i omogućen."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Ovaj panel mora biti otključan za promjenu ove postavke"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Obrišite odabrani korisnički račun"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Kako biste obrisali odabrani korisnički račun,\n"
+#~ "najprije kliknite na ikonu *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Otključaj za dodavanje korisnika i promjenu postavki"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Nova lozinka mora se razlikovati od stare."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Pokušajte promijeniti neka slova i brojeve."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Pokušajte promijeniti lozinku malo više."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Lozinka bez vašeg korisničkog imena bila bi snažnija."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Pokušajte izbjeći korištenje svojeg imena u lozinici."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Pokušajte izbjeći neke riječi sadržane u lozinici."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Pokušajte izbjeći učestale riječi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Pokušajte izbjeći preslagivanje postojećih riječi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Pokušajte koristiti više brojeva."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Pokušajte koristiti više velikih slova."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Pokušajte koristiti više malih slova."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Pokušajte koristiti više posebnih znakova, poput interpukcija."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Pokušajte koristiti mješavinu slova, brojeva i interpukcija."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Pokušajte izbjeći iste znakove."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Pokušajte izbjeći ponavljanje istih znakova, trebate koristiti mješavinu "
+#~ "slova, brojeva i interpukcija."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Pokušajte izbjeći slijedove poput 1234 ili abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Lozinka mora biti dulja. Pokušajte dodati više slova, brojeva i "
+#~ "interpukcija."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Izmješajte velika i mala slova i dodajte slovo ili dva."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Dodavanje više slova, brojeva i interpunkcija učinit će lozinku snažnijom."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Ovjera nije uspjela"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Nova lozinka je prekratka"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Nova lozinka je prejednostavna"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Nova i stara lozinka su preslične"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Nova lozinka je nedavno već korištena."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Nova lozinka mora sadržavati brojčane ili posebne znakove"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Stara i nova lozinka su iste"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Vaša lozinka je promijenjena otkada ste se prvotno ovjerili!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Nova lozinka ne sadrži dovoljno različitih znakova"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Nepoznata greška"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Korisničko ime može sadržavati samo mala i velika slova od a-z, brojke i "
+#~ "ove znakove: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Nažalost, to korisničko ime nije dostupno. Pokušajte s drugim."
+
+#~ msgid "The username is too long."
+#~ msgstr "Korisnčko ime je predugačko."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Tipka %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Određeno aplikacijom"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Pošalji pritisak tipke"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Prebaci zaslon"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Prikaži zaslonsku pomoć"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tablet montiran na panel prijenosnog računala"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tablet montiran na vanjski zaslon"
+
+#~ msgid "External tablet device"
+#~ msgstr "Vanjski tablet uređaj"
+
+#~ msgid "All Displays"
+#~ msgstr "Svi zasloni"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Olovka zračnog kista s pritiskom, nagibom i integriranim klizačem"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Olovka zračnog kista s pritiskom, nagibom i zakretanjem"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standardna olovka s pritiskom i nagibom"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standardna olovka s pritiskom"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Novi prečac…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Radnja je prekinuta"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Greška:</b> Pristup je uskraćen zbog promjene postavki"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Greška:</b> Greška mobilne opreme"
+
+#~ msgid "Not Registered"
+#~ msgstr "Nije registrirano"
+
+#~ msgid "Registered"
+#~ msgstr "Registrirano"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Pretraživanje"
+
+#~ msgid "Denied"
+#~ msgstr "Uskraćeno"
+
+#~ msgid "2G Only"
+#~ msgstr "2G samo"
+
+#~ msgid "3G Only"
+#~ msgstr "3G samo"
+
+#~ msgid "4G Only"
+#~ msgstr "4G samo"
+
+#~ msgid "5G Only"
+#~ msgstr "5G samo"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G,5G  (preporučeno)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (preporučeno), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (preporučeno), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (preporučeno), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (preporučeno)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (preporučeno), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (preporučeno), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (preporučeno)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (preporučeno), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (preporučeno), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (preporučeno)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (preporučeno), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (preporučeno), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (preporučeno)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (preporučeno), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (preporučeno), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (preporučeno)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (preporučeno), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (preporučeno)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (preporučeno), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (preporučeno)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (preporučeno), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (preporučeno)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (preporučeno), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (preporučeno)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (preporučeno), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (preporučeno)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (preporučeno), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Nepoznat"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Otključaj SIM karticu"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Navedite PIN kôd za SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Upišite PIN kôd za otključavanje SIM kartice"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Navedite PUK kôd za SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Upišite PUK kôd za otključavanje SIM kartice"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Nevaljana lozinka upisana."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK kôd bi trebao biti 8-znamenkasti broj"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Upišite novi PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN kôd bi trebao biti 4-8-znamenkasti broj"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Otključavanje…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Kvar telefona"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Nema povezivanja s telefonom"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Radnja nije dopuštena"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Radnja nije podržana"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM kartica nije umetnuta"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM PIN je potreban"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM PUK je potreban"
+
+#~ msgid "SIM failure"
+#~ msgstr "Neuspjeh SIM kartice"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM kartica je zauzeta"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Lozinka je netočna"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM PIN2 je potreban"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM PUK2 je potreban"
+
+#~ msgid "Not found"
+#~ msgstr "Nije pronađeno"
+
+#~ msgid "No network service"
+#~ msgstr "Nema mrežne usluge"
+
+#~ msgid "Network timeout"
+#~ msgstr "Istek mreže"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS usluga nije dopuštena"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming nije dopušten u ovom području"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Neodređena GPRS greška"
+
+#~ msgid "No Error"
+#~ msgstr "Bez greške"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Radnja prekinuta"
+
+#~ msgid "Access denied"
+#~ msgstr "Pristup uskraćen"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Nepoznata greška"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Prikaži broj inačice"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Omogući opširni opisni način rada"
+
+#~ msgid "Search for the string"
+#~ msgstr "Pretraživanje niza"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Prikaži moguće nazive panela i izađi"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel za prikaz"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Dostupni paneli:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Zvukovi sustava"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Greška: nemoguće otkrivanje HSI razine."
 
 #~ msgid "Error: unable to determine Incorrect HSI level."
 #~ msgstr "Greška: nemoguće otkrivanje neispravne HSI razine."
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Dodaj pisač…"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER ili PEM vjerodajnice (*.der, *.pem, *.crt, *.cer)"
@@ -9968,9 +8658,6 @@ msgstr "Zvukovi sustava"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablet (apsolutno)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Touchpad (relativno)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Osobitosti tableta"
 
@@ -10157,9 +8844,6 @@ msgstr "Zvukovi sustava"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Pristupite bluetooth hardveru izravno"
-
-#~ msgid "Use your camera"
-#~ msgstr "Koristite svoju kameru"
 
 #~ msgid "Print documents"
 #~ msgstr "Ispišite dokumente"
@@ -10966,9 +9650,6 @@ msgstr "Zvukovi sustava"
 #~ msgid "Uni­ver­sal Access"
 #~ msgstr "Univerzalni pristup"
 
-#~ msgid "Disable image"
-#~ msgstr "Onemogući sliku"
-
 #~ msgid "Browse for more pictures…"
 #~ msgstr "Pregledaj za više slika…"
 
@@ -11000,9 +9681,6 @@ msgstr "Zvukovi sustava"
 
 #~ msgid "Mirrored"
 #~ msgstr "Zrcaljeno"
-
-#~ msgid "Secondary"
-#~ msgstr "Pomoćni"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Raspored kombiniranih zaslona"
@@ -11078,9 +9756,6 @@ msgstr "Zvukovi sustava"
 #~ msgctxt "proxy method"
 #~ msgid "Automatic"
 #~ msgstr "Automatski"
-
-#~ msgid "_Method"
-#~ msgstr "_Način"
 
 #~ msgid "Group Name"
 #~ msgstr "Naziv grupe"
@@ -11187,9 +9862,6 @@ msgstr "Zvukovi sustava"
 
 #~ msgid "Mail"
 #~ msgstr "Pošta"
-
-#~ msgid "Calendar"
-#~ msgstr "Kalendar"
 
 #~ msgid "Contacts"
 #~ msgstr "Kontakti"
@@ -11322,9 +9994,6 @@ msgstr "Zvukovi sustava"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Klizi prema gore"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Klizi prema dolje"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Klizi desno"

--- a/po/hr.po~
+++ b/po/hr.po~
@@ -1,0 +1,11340 @@
+# Translation of gnome-control-center 2.0 for Croatiann
+# Copyright (C) Croatiann team
+# Translators: Automatski Prijevod <>,Danijel Studen <dstuden@vuka.hr>,Denis Lackovic <delacko@fly.srk.fer.hr>,Robert Sedak <robert.sedak@sk.t-com.hr>,Vedran Vyroubal <vedran.vyroubal@inet.hr>,Miroslav Sabljić <civija@ubuntu-hr.org>
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center 2.0\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-23 17:15+0000\n"
+"PO-Revision-Date: 2022-10-01 18:42+0200\n"
+"Last-Translator: gogo <trebelnik2@gmail.com>\n"
+"Language-Team: Croatian <lokalizacija@linux.hr>\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Launchpad-Export-Date: 2016-10-09 11:56+0000\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Sabirnica sustava"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Potpuni pristup"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Sabirnica sesije"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Uređaji"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Potpuni pristup u /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Mreža"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Ima pristup mreži"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Osobna mapa"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Samo za čitanje"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Datotečni sustav"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Postavke"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Može promijeniti postavke"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s ima sljedeće ugrađene dozvole. One se ne mogu mijenjati. Ako ste u "
+"nedoumici zbog tih dozvola, razmislite o uklanjanju te aplikacije."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u datoteka i vrsta poveznice koja je otvorena aplikacijom"
+msgstr[1] "%u datoteka i vrsta poveznice koje su otvorene aplikacijom"
+msgstr[2] "%u datoteka i vrsta poveznice koje su otvorene aplikacijom"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> se koristi za otvaranje sljedećih vrsta datoteka i poveznica."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s diskovnog prostora se koristi."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplikacije"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Nema aplikacija"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Instaliraj nešto…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Otvori"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Pogledaj pojedinosti"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Pretraga"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Primajte pretrage sustava i šaljite rezultate."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Onemogućen"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Obavijesti"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Prikaži obavijesti sustava."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Pokreni u pozadini"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Dopusti aktivnost kada se aplikacija zatvori."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Slike zaslona"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Uslikaj slike zaslona u bilo koje vrijeme."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Promijeni sliku pozadine"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Promijenite sliku pozadine radne površine."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Zvukovi"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reproduciranje zvukova."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Sprječavanje prečaca"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Blokiraj standardne prečace tipkovnice."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Uslikaj fotografije s kamerom."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Snimi zvuk s mikrofonom."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Usluge lociranja"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Pristup podacima o lokaciji uređaja."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Ugrađene dozvole"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Pristup sustavu koji zahtijeva aplikacija"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Pridruživanja datoteka i poveznica"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Pohrana"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Nema pronađenih rezultata"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Pokušaj drugačiju pretragu"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Pridruživanja datoteka i poveznica"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Vrste datoteka"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Vrste poveznica"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Vrati izvorno"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Koliko diskovnog prostora ova aplikacija zauzima s podacima aplikacije i "
+"predmemorijom."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplikacije"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Podaci"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Predmemorija"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Ukupno</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Obriši predmemoriju…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Upravlja različitim dozvolama i postavkama aplikacije"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplikacija;flatpak;dozvole;postavka;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Odaberi sliku"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Odustani"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Otvori"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "višestruke veličine"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Bez pozadine radne površine"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Trenutna pozadina"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Izgled"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Uobičajeni"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Tamni"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Pozadina"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Dodaj sliku…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Izgled"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Promijenite vašu pozadinsku sliku ili boju korisničkog sučelja"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Pozadina;Slika pozadine;Zaslon;Radna površina;Izgled;Svjetlo;Tamno;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Omogući"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Nema pronađenih Bluetooth uređaja"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Priključite uređaj kako bi mogli koristiti Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth je isključen"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Uključite za povezivanje uređaja i prijenos datoteka."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Način rada u zrakoplovu je uključen"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth je onemogućen kada je način rada u zrakoplovu uključen."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Isključi način rada u zrakoplovu"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Hardverski način rada u zrakoplovu je uključen"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Isključite način rada u zrakoplovu kako bi mogli kristiti Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Uključite ili isključite Bluetooth i povežite svoje uređaje"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "dijeli;dijeljenje;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera je isključena"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Nema aplikacija za snimanje fotografije ili video snimke."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Korištenje kamere aplikacijama dopušta slikanje fotografija i snimanje video "
+"snimaka. Onemogućavanje kamere može prouzrokovati neispravan rad u određenim "
+"aplikacijama.\n"
+"\n"
+"Dopusti aplikacijama ispod korištenje kamere."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Nema aplikacija koje su zatražile pristup kameri"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Zaštitite svoje slike"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "kamera;fotografije;video;web kamera;zaključaj;privatno;privatnost;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Smjestite vaš uređaj za kalibraciju preko četverokuta i pritisnite ”Pokreni”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Pomaknite vaš uređaj za kalibraciju na položaj kalibracije i pritisnite "
+"”Nastavi”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Pomaknite vaš uređaj za kalibraciju na položaj površine i pritisnite "
+"”Nastavi”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Spusti zaslon prijenosnika"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Dogodila se unutrašnja greška koja se ne može oporaviti."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Alati potrebni za kalibraciju nisu instalirani."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Profil se ne može stvoriti."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Odredišna bijela točka je dostižna."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Završeno!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibracija nije uspjela!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Možete ukloniti uređaj za kalibraciju."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Nemojte ometati uređaj tijekom kalibracije"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Kalibracija zaslona"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Pokreni"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Nastavi"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Završeno"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Zaslon prijenosnika"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Ugrađena web kamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s zaslon"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s skener"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s kamera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s pisač"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s web kamera"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Omogući upravljanje bojom za %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Prikaži profile boje za %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Nije kalibriran"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Uobičajeno: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Raspon boja: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Testni profil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Odaberi ICC datoteku profila"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Uvezi"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Podržani ICC profili"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Sve datoteke"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Zaslon"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Spremi profil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Spremi"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Napravi profil boje za odabrani uređaj"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Mjerni uređaj nije pronađen. Provjerite je li uključen i ispravno spojen."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Mjerni uređaj ne podržava profiliranje pisača."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Vrsta uređaja trenutno nije podržana."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Kalibracija zaslona"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kvaliteta kalibracije"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibracija će stvoriti profil koji možete koristiti za upravljanje bojom "
+"vašeg zaslona. Ako dulje kalibrirate, biti će bolja kvaliteta profila boje."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Nećete moći koristiti vaše računalo dok kalibracija traje."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kvaliteta"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Približno vrijeme"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Uređaj kalibracije"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Odaberite senzor uređaja koji želite koristiti za kalibraciju."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Vrsta zalona"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Odaberite vrstu zalona koji je priključen."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profil bijele točke"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Odaberi odredišnu bijelu točku zaslona. Veći zaslona bi trebalo kalibrirati "
+"na D65 svijetlo."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Svjetlina zaslona"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Postavite zaslon na svjetlinu koje je karakteristična vama. Upravljanje "
+"bojama biti će najpreciznije na toj razini svjetline."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativno, možete koristiti razinu svjetline s jednim od drugih profila "
+"za ovaj uređaj."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Naziv profila"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Možete koristiti profil boja na različitim računalima ili čak stvoriti "
+"profile za različite uvjete svjetline."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Naziv profila:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Sažetak"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil je uspješno stvoren!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopiraj profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Zahtijeva zapisivi medij"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Ove upute kako koristiti profil možete pogledati na <a href=\"linux\">GNU/"
+"Linuxu</a>, <a href=\"osx\">Apple OS X</a> i <a href=\"windows\">Microsoft "
+"Windows</a> upotrebljivim sustavima."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Dodaj profil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Otkriven je problem. Profil možda neće raditi ispravno. <a href=\"\">Prikaži "
+"pojedinosti.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Uvezi datoteku…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Dodaj"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Svaki uređaj posebno mora imati nadopunjeni profil boja kako bi se "
+"upravljalo bojama na tim uređajima."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Saznajte više"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Saznajte više o upravljanju bojama"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Postavi za sve korisnike"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Postavi ovaj profil za sve korisnike na ovom računalu"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Omogući"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Dodaj profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibriraj…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibriraj uređaj"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Ukloni profil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Pogledaj pojedinosti"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+"Nemoguće otkrivanje bilo kojeg uređaja kojima se može upravaljati bojom"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plazma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL pozadinsko osvjetljenje)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED pozadinsko osvjetljenje)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (bijelo LED pozadinsko osvjetljenje)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Širok spektar LCD (CCFL pozadinsko osvjetljenje)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Širok spektar LCD (RGB LED pozadinsko osvjetljenje)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Visoka"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minuta"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Srednja"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minuta"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Niska"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minuta"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Izvorno zaslonu"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Ispisivanje i objava)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografija i grafika)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standardan razmak"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testiraj profil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatski"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Niska kvaliteta"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Srednja kavaliteta"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Visoka kvaliteta"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Uobičajeni RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Uobičajeni CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Uobičajeno sivo"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Proizvođačem isporučeni podaci tvorničke kalibracije"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Cijelozaslonski prikaz nije moguć sa ovim profilom"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Ovaj profil možda nije više točan"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Boja"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Kalibrirajte boju vašeg uređaja, poput zalona, kamera i pisača"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Boja;ICC;Profil;Kalibriraj;Pisač;Zaslon;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Ostalo…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Odaberi jezik"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Odaberi"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nema pronađenih jezika"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Više…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Otključaj za promjenu postavki"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Pojedine postavke moraju biti otključane kako bi se mogle promijeniti."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Otključaj…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Povećaj sat"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Povećaj minutu"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Vrijeme"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Smanji sat"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Smanji minutu"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Danas"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Jučer"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d sat"
+msgstr[1] "%d sata"
+msgstr[2] "%d sati"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuta"
+msgstr[1] "%d minute"
+msgstr[2] "%d minuta"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekunda"
+msgstr[1] "%d sekunde"
+msgstr[2] "%d sekundi"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekundi"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Pristupna točka"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-satni"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "12-satni"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Datum i vrijeme"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Godina"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mjesec"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Siječanj"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Veljača"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Ožujak"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Travanj"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Svibanj"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Lipanj"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Srpanj"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Kolovoz"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Rujan"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Listopad"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Studeni"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Prosinac"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dan"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Vremenska zona"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Potraži grad"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatski _datum i vrijeme"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Zahtijeva pristup internetu"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Datum i _vrijeme"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automatska vremenska _zona"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Zahtijeva pristup internetu i omogućenu uslugu lociranja"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Vremenska z_ona"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Format _vremena"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Promijenite datum i vrijeme, uključujući vremensku zonu"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Sat;vremenska zona;lokacija;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Promijeni postavke vremena i datuma sustava"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Morate se ovjeriti kako bi promijenili postavke vremena ili datuma."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Pošta"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalendar"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "G_lazba"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotografije"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Zadane aplikacije"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Prilagodite zadane aplikacije"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "zadano;aplikacija;poželjno;medij;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Slanje izvještaja tehničkih problema pomaže nam poboljšati %s. Izvještaji su "
+"poslani anonimno i ne sadrže osobne podatke. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Prijava problema"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatsko prijavljivanje problema"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Dijagnostika"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Prijavite svoje probleme"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "dijagnostika;rušenje;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Uključeno"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Isključeno"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Primijeni promjene?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Promjene se ne mogu primijeniti"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "To može biti uzrokovano ograničenjem hardvera."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Primijeni"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Natrag"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Postavke zaslona su onemogućene"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Više zaslona"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Spoji"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Zrcali"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Sadrži gornju traku i pregled aktivnosti"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Glavni zaslon"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Noćno osvjetljenje"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Položeno"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Uspravno desno"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Uspravno lijevo"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Obrnuto položeno"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orijentacija"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Razlučivost"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Frekvencija"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Prilagodi za TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Prilagodba veličine"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Noćno osvjetljenje je nedostupno"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Uzrok ovome bi mogli biti upravljački programi koji se koriste, ili se "
+"koristi udaljena radna površina"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Privremeno onemogućeno do sutra"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Ponovno pokreni filter"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Noćno osvjetljenje čini boje zaslona toplijim. To može pomoći u sprječavanju "
+"nesanice i naprezanja očiju."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Raspored"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Zalazak prema izlasku sunca"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Ručni raspored"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Vrijeme"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Od"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Sat"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuta"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Do"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura boje"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Zasloni"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Odaberite kako koristiti monitore i projektore"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projektor;xrandr;Zaslon;Razlučivost;Osvježi;Monitor;Noć;Osvjetljenje;"
+"Plavo;crveni pomak; boja;zalazak;izlazak;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Sigurno pokretanje (Secure Boot) je aktivno"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se učita "
+"kada se uređaj pokrene. Trenutno je uključeno i radi ispravno."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Sigurno pokretanje (Secure Boot) ima probleme"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se učita "
+"kada se uređaj pokrene. Trenutno je uključeno, ali neće raditi jer ima "
+"nevaljani ključ."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Problemi sigurnog pokretanja (Secure Boot) uobičajeno se mogu riješiti iz "
+"UEFI firmver postavki (BIOS) vašeg računala, a vaš proizvođač hardvera pruža "
+"informacije za ovo rješenje."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Za pomoć, kontaktirajte svojeg proizvođača hardvera ili pružatelja IT "
+"podrške."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Sigurno pokretanje (Secure Boot) je isključeno"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se ne "
+"učita kada se uređaj pokrene. Trenutno je isključeno."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Sigurno pokretanje (Secure Boot) uobičajeno može biti isključeno u UEFI "
+"firmver postavkama (BIOS) vašeg računala. Za pomoć, kontaktirajte svojeg "
+"proizvođača hardvera ili pružatelja IT podrške."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Sigurno pokretanje (Secure Boot) sprječava zlonamjeran softver da se učita "
+"kada se uređaj pokrene.\n"
+"\n"
+"Za više informacija, kontaktirajte svojeg proizvođača hardvera ili "
+"pružatelja IT podrške."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Prošlo"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Neuspjelo"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Uređaj je usklađen s HSI razinom %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Sigurnosna razina 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Ovaj uređaj nema zaštitu protiv hardverskih sigurnosnih problema. Uzrok tome "
+"može biti problem u podešavanju hardvera ili firmvera. Preporučljivo je da "
+"kontaktirate svojeg proizvođača hardvera ili pružatelja IT podrške."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Sigurnosna razina 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Ovaj uređaj ima najmanju zaštitu protiv hardverskih sigurnosnih problema. "
+"Ovo je najmanja razina sigurnosti uređaja i samo pruža zaštitu od "
+"jednostavnih sigurnosnih prijetnji."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Sigurnosna razina 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Ovaj uređaj ima osnovnu zaštitu protiv hardverskih sigurnosnih problema. Ova "
+"razina pruža zaštitu protiv učestalih sigurnosnih prijetnji."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Sigurnosna razina 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Ovaj uređaj ima proširenu zaštitu protiv hardverskih sigurnosnih problema. "
+"Ovo je najviša razina sigurnosti uređaja i pruža zaštitu protiv naprednih "
+"sigurnosnih prijetnji."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Sigurnosna razina"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Sigurnosne razine nisu dostupne za ovaj uređaj."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Kontaktirajte svojeg proizvođača hardvera za pomoć oko sigurnosnih nadopuna."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Moguće rješenje ovog problema je u postavkama UEFI firmvera uređaja, ili u "
+"podršci od strane tehničara."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "Moguće rješenje ovog problema je u postavkama UEFI firmvera uređaja."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Moguće rješenje ovog problema je u podršci od strane tehničara."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Razina 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Razina 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Razina 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Zaštita od zlonamjernog softvera pri pokretanju uređaja."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Sigurno pokretanje (Secure Boot) ima probleme"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Određena zaštita pri pokretanju uređaja."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Sigurno pokretanje (Secure Boot) je isključeno"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Bez zaštite pri pokretanju uređaja."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Ovaj problem mogao bi biti uzrokovan promjenom u postavkama UEFI firmvera, "
+"promjenom podešavanja operativnog sustava ili zbog zlonamjernog softvera na "
+"ovom sustavu."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Ovaj problem mogao bi biti uzrokovan promjenom u postavkama UEFI firmvera "
+"ili zbog zlonamjernog softvera na ovom sustavu."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Ovaj problem mogao bi biti uzrokovan promjenom u podešavanja operativnog "
+"sustava ili zbog zlonamjernog softvera na ovom sustavu."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Izloženi ste ozbiljnim sigurnosnim prijetnjama."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Ograničena zaštita protiv jednostavnih sigurnosnih prijetnji."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Zaštita protiv učestalih sigurnosnih prijetnji."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Zaštita protiv širokog raspona sigurnosnih prijetnji."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Sveobuhvatna zaštita"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Nema događaja"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Zaštita od zapisivanja firmvera"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Zaključavanje zaštite od zapisivanja firmvera"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Firmver BIOS područje"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Firmver BIOS opisnik"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "DMA zaštita predpokretanja"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard provjereno pokretanje"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM zaštićen"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard pravilo greške"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard osigurač"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET omogućen"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET aktivan"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Šifrirani RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU zaštita"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux kernel zaključavanje"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux kernel provjera"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Suspendiraj u ram"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Suspendiraj u mirovanje"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI ključ platforme"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI Sigurno pokretanje (Secure Boot)"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Podešavanje TPM platforme"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM rekonstrukcija"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Način proizvodnje Intel pogona upravljanja (MEI)"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Zaobilaženje Intel pogona upravljanja (MEI)"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Inačica Intel pogona upravljanja (MEI)"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Nadopune firmvera"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Frimver provjera"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Provjera firmver nadopunitelja"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Otklanjanje grešaka platforme"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Sigurnosne provjere procesora"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD Rollback zaštita"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Zaštita od ponavljanja AMD firmvera"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Zaštita od zapisivanja AMD firmvera"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Pregorjela platforma"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Valjano"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Nije valjano"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Nije omogućeno"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Zaključano"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Nije zaključano"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Šifriran"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Nije šifriran"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Pokvaren"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Nije pokvaren"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Pronađeno"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Nije pronađeno"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Podržano"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Nije podržano"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Sigurnost uređaja"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Sigurnosno stanje firmvera računala"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"zaslon;zaključaj;dijagnostika;rušenje;privatno;nedavno;privremeno;tmp;"
+"sadržaj;naziv;mreža;identitet;privatnost;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bitna"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bitna"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Nepoznat"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Nedostupno"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logotip sustava"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Naziv uređaja"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Model hardvera"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memorija"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Kapacitet diska"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Izračunavanje…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Operativni sustav"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID izgradnje OS-a"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Arhitektura"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME inačica"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Učitavanje…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Prozorski sustav"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualizacija"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Nadopune softvera"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Preimenuj uređaj"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Naziv uređaja se koristi za identifikaciju ovog uređaja na mreži ili kada se "
+"uparuje s Bluetooth uređajima."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Naziv uređaja"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Preimenuj"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "O sustavu"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Prikaži informacije ovog sustava"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"uređaj;sustav;informacije;naziv računala;memorija;procesor;inačica;"
+"uobičajeno;aplikacija;poželjno;cd;dvd;usb;zvuk;video;disk;prijenosni;medij;"
+"automatsko pokretanje;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Zvuk i medij"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Isključi/Uključi zvuk"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Smanji glasnoću zvuka"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Pojačaj glasnoću zvuka"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Isključi/Uključi mikrofon"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Pokreni medijski reproduktor"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Reproduciraj (ili reprodukcija/pauza)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pauziraj reprodukciju"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Zaustavi reprodukciju"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Prijašnja pjesma"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Sljedeća pjesma"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Izbaci"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Tipkanje"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Prebaci na sljedeći način unosa"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Prebaci na prijašnji način unosa"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Pokretači"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Pokreni preglednik pomoći"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Pokreni kalkulator"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Pokreni klijent e-pošte"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Pokreni web preglednik"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Osobna mapa"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Pretraga"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sustav"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Odjavi se"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Zaključavanje zaslona"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Pristupačnost"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Uključi ili isključi približavanje"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Približi"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Udalji"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Uključi ili isključi čitač zaslona"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Uključi/Isključi zaslonsku tipkovnicu"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Povećaj veličinu teksta"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Smanji veličinu teksta"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Uključi ili isključi visoki kontrast"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nema pronađenih načina unosa"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Ostalo"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Dodaj jezik unosa"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Način unosa ne može se koristi na zaslonu prijave"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nema odabranih načina unosa"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Mogućnosti"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Pomakni gore"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Pomakni dolje"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Osobitosti"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Prikaži prečace tipkovnice"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Ukloni"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Prilagođeni prečaci"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Zamjenska tipka znakova"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Zamjenska tipka znakova može se koristiti za unos dodatnih znakova. To je "
+"ponekad ispisano na vašoj tipkovnici kao treća mogućnost."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Lijevi Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Desni Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Lijevi Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Desni Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tipka Izbornika"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Desni Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tipka za sastavljanje"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Tipka sastavljanja dopušta širok raspon znakova za unos. Za korištenje, "
+"pritisnite sastavljanje zatim slijed znakova.  Na primjer, tipku "
+"sastavljanja za kojom slijedi <b>C</b> i <b>o</b> koji će unijeti <b>©</b>, "
+"<b>a</b> za kojima slijedi <b>'</b> koji će unijeti <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Načini unosa mogu se mijenjati koristeći %s prečac tipkovnice.\n"
+"Ovo se može promijeniti u postavkama prečaca tipkovnice."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Način unosa"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Uključuje raspored tipkovnice i načine unosa."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Prebacivanje načina unosa"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Koristi _isti način unosa za sve prozore"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Prebaci _načine unosa pojedinačno za svaki prozor"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Unos posebnih znakova"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Način unosa varijanti simbola i slova koristeći tipkovnicu."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Prečaci tipkovnice"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Pogledaj i prilagodi prečace"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d promijenjen"
+msgstr[1] "%d promijenjena"
+msgstr[2] "%d promijenjeno"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Vrati sve prečace na izvorno stanje?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Vraćanje prečaca na izvorno stanje može utjecati na vaše prilagođene "
+"prečace. To se ne može poništit."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Odustani"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Vrati sve na izvorno"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Vrati sve na izvorno…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Vrati sve prečace na izvorne vrijednosti"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Odjeljak"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Prečaci"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Dodaj prečac"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Dodavanje prilagođenih prečaca"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Postavljanje prilagođenih prečaca za pokretanje aplikacija, pokretanje "
+"skripta i još mnogo toga."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Dodavanje prečaca"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nema pronađenih prečaca tipkovnice"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s se već koristi za %s. Ako ga zamjenjujete, %s biti će onemogućen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Upišite novi prečac"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Postavi prilagođen prečac"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Postavi prečac"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Upišite novi prečac za promjenu %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Dodaj prilagođeni prečac"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Ukloni"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Za_mijeni"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Postavi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Pritisni Esc za odustajanje ili Backspace za onemogućavanje prečaca "
+"tipkovnice."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Ime"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Naredba"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Prečac"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Postavi prečac…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Nepoznata"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Vrati izvorne vrijednosti prečaca"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tipkovnica"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Promijenite prečace tipkovnice i postavite osobitosti tipkanja, raspored "
+"tipkovnice i izvore unosa"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Prečac;Radni prostor;Prozor;Promjena veličine;Uvećanje;Kontrast;Ulaz;Izvor;"
+"Zaključavanje;Glasnoća zvuka;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Usluge lociranja su isključene"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Nijedna aplikacija trenutno ne pruža usluge lokacije."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Usluge lociranja omogućuju aplikacijama da saznaju vašu lokaciju. Korištenje "
+"bežične i mobilne širokopojasne mreže povećava preciznost.\n"
+"\n"
+"Koristi se usluga Mozilla lociranja: <a href='https://location.services."
+"mozilla.com/privacy'>Pravila privatnosti</a>\n"
+"\n"
+"Dopusti aplikacijama ispod otkrivanje lokacije."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Nema aplikacija koje su zatražile pristup vašoj lokaciji"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Zaštite informacije vaše lokacije"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "lokacija;gps;privatno;privatnost;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofon je isključen"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Nema aplikacija za snimanje zvuka."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Korištenje mikrofona aplikacijama dopušta snimanje i slušanje zvuka. "
+"Onemogućavanje mikrofona može prouzrokovati neispravan rad u određenim "
+"aplikacijama.\n"
+"\n"
+"Dopusti aplikacijama ispod korištenje mikrofona."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Nema aplikacija koje su zatražile pristup vašem mikrofonu"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Zaštitite svoje razgovore"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofon;snimanje;aplikacija;privatnost;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Testirajte svoje _postavke"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Općenito"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Glavna tipka"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Postavite poredak za fizičke tipke miša i touchpada."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Lijevo"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Desno"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Miš"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Brzina miša"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Prirodno pomicanje"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Pomicanje pomiče sadržaj, a ne pogled."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Brzina touchpada"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Dodirni za klik"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Dodirni za klik"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Pomicanje s dva prsta"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Rubno pomicanje"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Pokušajte kliknuti, dvostruko kliknuti, pomicati"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Pet klika, vrijeme je za GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dvostruki klik, glavna tipka"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Jednostruki klik, glavna tipka"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dvostruki klik, srednja tipka"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Jednostruki klik, srednja tipka"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dvostruki klik, druga tipka"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Jednostruki klik, druga tipka"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Miš i touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Promijenite osjetljivost touchpada i miša i odaberite lijevu ili desnu ruku"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Klizna površina;Pokazivač;Klik;Dodir;Dvostruk;Tipka;Klizna kugla;Pomakni;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Kut zaslona"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Dodirni gornji lijevi kut za otvaranje pregleda aktivnosti."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Aktivni rubovi zaslona"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Povlači prozore po gornjem, lijevom i desnom rubu zaslona kako bi im "
+"promijenili veličinu."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Radni prostori"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Promjenjivi radni prostori"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Automatski uklanja prazne radne prostore."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Nepromjenjiv broj radnih prostora"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Odredite broj stalnih radnih prostora."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Broj radnih prostora"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Više zaslona"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Radni prostori na _glavnom zaslonu"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Radni prostori na svima z_aslonima"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Prebacivanje aplikacija"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Obuhvati aplikacije sa svih _radnih prostora"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Obuhvati aplikacije samo s _trenutnog radnog prostora"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Višezadaćnost"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Upravljajte osobitostima za produktivnost i višezadaćnost"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Višezadaćnost;Višezadaća;Produktivnost;Prilagodi;Radna površina;Kut zaslona;"
+"Radni prostori;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ups, nešto je pošlo po krivu. Kontaktirajte svojeg dobavljača softvera."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Mrežni upravitelj mora biti pokrenut."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Ostali uređaji"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Dodaj povezivanje"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nije postavljeno"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Otvorena mreža (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Zaštićena mreža (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Zaštićena mreža (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Zaštićena mreža (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Zaštićena mreža"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Povezano"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Mogućnosti…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Uključivanje pristupne točke će prekinuti %s povezivanje i nećete biti u "
+"mogućnosti pristupiti internetu putem bežične mreže."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Mora sadržavati najmanje 8 znakova"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Mora sadržavati najviše %d znak"
+msgstr[1] "Mora sadržavati najviše %d znaka"
+msgstr[2] "Mora sadržavati najviše %d znakova"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Uključi bežičnu pristupnu točku?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Bežična pristupna točka dopušta drugim korisnicima dijeljenje vašeg pristupa "
+"internetu, stvaranjem bežične mreže na koju se mogu povezati. Kako bi to "
+"učinili, morate imati pristup internetu drugačijim od bežičnog pristupa."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Naziv mreže"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Lozinka"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Stvori naizmjeničnu lozinku"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Automatsko stvaranje lozinke"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Uključi"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Bežična mreža"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Zaustaviti pristupnu točku i odspojiti sve korisnike?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Zaustavi pristupnu točku"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Način rada u zrakoplovu"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Onemogućuje bežičnu mrežu, Bluetooth i mobilni širokopojasni internet"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nema pronađenih bežičnih uređaja"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Pobrinite se da imate bežični uređaj priključen i uključen"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Način rada u zrakoplovu uključen"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Isključite kako biste mogli koristiti bežičnu mrežu"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Bežična pristupna točka je aktivna"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobilni uređaji mogu skenirati QR kôd u svrhu povezivanja."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Isključi pristupnu točku…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Vidljive mreže"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Mrežni upravitelj mora biti pokrenut"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x _sigurnost"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sigurnost"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Očuvano"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Trajno"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Naizmjenično"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabilno"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"MAC adresa koja je ovdje upisana, koristit će se kao hardverska adresa za "
+"mrežni uređaj na kojemu je aktivirano ovo povezivanje. Ova mogućnost je "
+"poznata kao MAC kloniranje ili zavaravanje. Primjer: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Poboljšano otvoreno (OWE)"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Poslovanje"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nepoznata"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nikada"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "prije %i dan"
+msgstr[1] "prije %i dana"
+msgstr[2] "prije %i dana"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nepoznata"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Slaba"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "U redu"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Dobra"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Izvrsna"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 adresa"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 adresa"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP adresa"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Zaboravi povezivanje"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Ukloni profil povezivanja"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Ukloni VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Pojedinosti"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatski"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitet"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Obriši adrese"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Obriši rutu"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Nepoznata"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bitni ključ (Heks. ili ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bitna lozinka"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Promjenjivi WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA i WPA2 osobni"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA i WPA2 poslovni"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 osobni"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Jačina signala"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Brzina povezivanja"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hardverska adresa"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Podržane frekvencije"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Uobičajena ruta"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Zadnje korišteno"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Poveži se _automatski"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Učini dostupno _ostalim korisnicima"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Povezivanje ograničeno podacima: ima ograničenje podataka koji se mogu "
+"dodatno naplaćivati"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Nadopunjivanje softvera i ostala velika preuzimanja neće se pokrenuti "
+"automatski."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Naziv"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC adresa"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonirana adresa"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bajtova"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 način"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatski (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Samo Lokalno-povezivanje"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Ručno"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Onemogućen"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Podijeli s ostalim računalima"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adrese"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresa"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Mrežna maska"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Pristupnik"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatski"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatski DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Adrese DNS poslužitelja"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Odvoji IP adrese zarezima"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rute"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatske rute"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrički"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Koristi ovo povezivanje _samo za resurse na svojoj mreži"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 način"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatski, samo DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefiks"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Nemoguće otvaranje uređivača povezivanja"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Novi profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Nevaljana postavka %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Nevaljana postavka %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Uvezi iz datoteke…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Dodaj VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_igurnost"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Nemoguć uvoz VPN povezivanja"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Datoteka ”%s” nije mogla biti pročitana ili ne sadrži poznate informacije "
+"VPN povezivanja\n"
+"\n"
+"Greška: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Odaberi datoteku za uvoz"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Datoteka naziva \"%s\" već postoji."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Zamijeni"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Želite li zamijeniti %s s VPN povezivanjem kojeg spremate?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Nemoguć izvoz VPN povezivanja"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN povezivanje ”%s” nije moglo biti izvezeno u %s.\n"
+"\n"
+"Greška: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Izvezi VPN povezivanje"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Greška: nemoguće učitavanje uređivača VPN povezivanja)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Upravljajte načinom povezivanja na Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Mreža;Bežično;IP;Žično;Proxy;WAN;Širokopojasni internet;Modem;Bluetooth;vpn;"
+"DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Upravljajte načinom povezivanja na bežične mreže"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Mreža;Bežično;Bežična mreža;IP;Žično;Širokopojasni internet;DNS;Pristupna "
+"točka;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nikada"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "danas"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "jučer"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Zadnje korištena"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Žična mreža"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Dodaj novu mrežu"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Mrežne pojedinosti za odabrane mreže, uključujući lozinke i sve prilagođene "
+"postavke će biti izgubljene."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Zaboravi"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Poznate bežične mreže"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Zaboravi"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Pravila sustava ne dopuštaju korištenje kao pristupne točke"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Bežični uređaj ne podržava način pristupne točke"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Automatsko otkrivanje web proxyja se koristi kada URL podešavanja nije "
+"omogućen."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Ovo nije preporučljivo za javne mreže kojima se ne vjeruje."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Isključi uređaj"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktivno"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Pružatelj usluge"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Mrežni proxy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP proxy"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS proxy"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP Proxy"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks računalo"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Zanemari računala"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP proxy ulaz"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS proxy ulaz"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP proxy ulaz"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks proxy ulaz"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_URL podešavanja"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Isključi VPN povezivanje"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Naziv mreže"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Vrsta sigurnosti"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Lozinka"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Isključi bežičnu mrežu"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Više mogućnosti…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Poveži se na skrivenu mrežu…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Uključi bežičnu pristupnu točku…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Poznate bežične mreže"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Nepoznato stanje"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Neupravljano"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Nedostupno"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Povezivanje"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Potrebna je ovjera"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Prekidanje povezivanja"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Neuspješno povezivanje"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Nepoznato stanje (nedostaje)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Neuspjelo podešavanja"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP podešavanje neuspjelo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP podešavanje isteklo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Tajne su zahtijevane, ali ne i pružane"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x opskrbitelj nije povezan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x opskrbitelj neuspjelo podešavanje"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x opskrbitelj neuspio"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x opskrbitelj predugo trajanje ovjere"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP usluga se nije uspjela pokrenuti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP usluga je prekinula povezivanje"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP je neuspio"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP klijent se nije uspio pokrenuti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Greška DHCP klijenta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP kijent je neuspio"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Usluga dijeljenja povezivanja se nije uspjela pokrenuti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Usluga dijeljenja povezivanja je neuspjela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP usluga se nije uspjela pokrenuti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Greška AutoIP usluge"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP usluga nije uspjela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linija zauzeta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Nema tona biranja"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Nije pronađen nijedan operater"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Biranje zahtijeva čekanje"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Pokušaj biranja neuspio"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Pokretanje modema nije uspjelo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Odabir određenog APN-a nije uspjelo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Mreže se ne traže"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Mrežna registracija odbijena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Isteklo vrijeme mrežne registracije"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Registracija sa zatraženom mrežnom nije uspjela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Provjera PIN-a nije uspjela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Firmver uređaja možda nedostaje"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Povezivanje je nestalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Postojeće povezivanje je predpostavljeno"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem nije pronađen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth povezivanje neuspjelo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM kartica nije umetnuta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM Pin je potreban"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM Puk je potreban"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Pogrešan SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Neuspjelo povezivanje zavisnosti"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Nedostaje firmver"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabel je odspojen"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "neodređena greška u 802.1x sigurnosti (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "nema odabrane datoteke"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "neodređena greška provjeravanja datoteke eap-načina"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 ili PGP privatni ključevi"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER ili PEM vjerodajnice"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "nedostaje EAP-FAST PAC datoteka"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC datoteke (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonimno"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Ovjereno"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Oboje"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anoni_man identitet"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _datoteka"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Odaberite PAC datoteku"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Unutrašnja ovjera"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Dopusti automatsko PAC dod_jeljivanje"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "nedostaje EAP-LEAP korisničko ime"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "nedostaje EAP-LEAP lozinka"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Korisničko ime"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Lozinka"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Pri_kaži lozinku"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "nevaljana EAP-PEAP CA vjerodajnica: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "nevaljana EAP-PEAP CA vjerodajnica: vjerodajnica nije određena"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Inačica 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Inačica 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A vjerodajnica"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Odaberite vjerodajnicu izdavatelja vjerodajnice"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "CA vjerodajnica nije _potrebna"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP _inačica"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "nedostaje EAP korisničko ime"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "nedostaje EAP lozinka"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "nedostaje EAP-TLS identitet"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "nevaljana EAP-TLS CA vjerodajnica: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "nevaljana EAP-TLS CA vjerodajnica: vjerodajnica nije određena"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "nevaljani EAP-TLS privatni ključ: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "nevaljana EAP-TLS CA korisnička-vjerodajnica: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Nešifriani privatni ključevi su nesigurni"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Čini se da odabrani privatni ključ nije zaštićen lozinkom. Ovo može "
+"dopustiti kompromitiranje vaših sigurnosnih podataka. Odaberite lozinkom "
+"zaštićeni privatni ključ.\n"
+"\n"
+"(Svoj privatni ključ možete zaštititi lozinkom pomoću openssla)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Odaberite svoju osobnu vjerodajnicu"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Odaberite svoj privatni ključ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitet"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Korisnikova vjerodajnica"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Privatni _ključ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Lozinka privatnog ključa"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "nevaljana EAP-TTLS CA vjerodajnica: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "nevaljana EAP-TTLS CA vjerodajnica: vjerodajnica nije određena"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (bez EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domena"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Nepoznata greška provjere 802.1X sigurnosti"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "LOZINKA"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "BRZO"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunelirani TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Zaštićeni EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Ov_jera"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Odaberi datoteku"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "nedostaje leap korisničko ime"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "nedostaje leap lozinka"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Lozinka bežične mreže nedostaje."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Vrsta"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "nedostaje wep ključ"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"nevaljani wep ključ: ključ duljine %zu mora sadržavati samo heks. znamenke"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"nevaljani wep ključ: ključ duljine %zu mora sadržavati samo ascii znamenke"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"nevaljani wep ključ: pogrešna duljina ključa %zu. Ključ mora biti 5/13 "
+"(ascii) ili 10/26 (heks.)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "nevaljani wep ključ: lozinka ne smije biti prazna"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "nevaljani wep ključ: lozinka mora sadržavati manje od 64 znamenaka"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Zadano)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Otvoreni sustav"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Dijeljeni ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Prika_ži ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP sadr_žaj"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"nevaljani wpa-psk: nevaljana duljina ključa %zu. Mora biti [8,63] bajtova "
+"ili 64 heks. znamenke"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"nevaljani wpa-psk: ne može se interpretirati ključ sa 64 bajtova kao heks"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Obavijesti"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Zvučna _upozorenja"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Skočne obavijesti"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Obavijesti će se nastaviti pojavljivati u popisu obavijesti kada se skočne "
+"obavijesti onemoguće."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Prikaži sadržaj _poruke u skočnim obavijestima"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Obavijesti zaključanog zaslona"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Prikaži sadržaj _poruke na zaključanom zaslonu"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Ne ometaj"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Obavijesti zaključanog zaslona"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Upravljajte prikazom poruka i što će se prikazivati"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Obavijesti;Transparent;Poruka;Statusna traka;Skočni prozor;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Ostalo"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s je uklonjen"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Greška pri uklanjanju računa"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Vrati"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Zatvori obavijest"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Povežite se s vašim podacima u oblaku"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Nema pristupa internetu — povežite se za postavljanje novog mrežnog računa"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Dodaj račun"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s račun"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Ukloni račun"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Mrežni računi"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Povežite se sa svojim mrežnim računima i odredite za što ih želite koristiti"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Mreža;Razgovor;Kalendar;Pošta;Kontakt;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Nepoznato vrijeme"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuta"
+msgstr[1] "%i minute"
+msgstr[2] "%i minuta"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i sat"
+msgstr[1] "%i sata"
+msgstr[2] "%i sati"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "sat"
+msgstr[1] "sata"
+msgstr[2] "sati"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuta"
+msgstr[1] "minute"
+msgstr[2] "minuta"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s do potpune napunjenosti"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Upozorenje: %s preostalo"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s preostalo"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Potpuno napunjeno"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Ne puni se"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Prazna"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Punjenje"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Pražnjenje"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Bežični miš"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Bežična tipkovnica"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Neprekinuta opskrba energijom (UPS)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Osobni digitalni pomagač (PDA)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobitel"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Medijski reproduktor"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Računalo"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Uređaj za igranje"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterija"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Glavna"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Dodatna"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Baterije"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Pri _mirovanju"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Suspendiraj"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Isključi"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hiberniraj"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ništa"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Na bateriji"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Na napajanju"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nikada"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatska suspenzija"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Performanse način rada je trenutno onemogućen uslijed visoke temperature "
+"rada."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Preklop otkriven: performanse način rada je privremeno nedostupan. "
+"Premjestite uređaj na stabilnu površinu za obnavljanje."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Performanse način rada je onemogućen."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Slaba baterija: štednja energije je omogućena. Prijašnji način rada će biti "
+"obnovljen kada se baterija dovoljno napuni."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Štednju energije je aktivirao “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Performanse način rada je aktivirao “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 sat"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 sata"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Način rada energije"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Utječe na performanse sustava i potrošnju energije."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Mogućnosti štednje energije"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatska svjetlina zaslona"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Osvjetljenje zaslona se prilagođava prema okolnom osvjetljenju."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Zatamni zaslon"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Smanjuje svjetlinu zaslona kada je računalo neaktivno."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Isključi _zaslon"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Isključuje zaslon nakon razdoblja neaktivnosti."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatska štednja energije"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Omogućuje štednju energije kada je baterija slaba."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatska suspenzija"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pauzira računalo nakon razdoblja neaktivnosti."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Po_našanje tipke isključivanja"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Prikaži postotak _baterije"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatska suspenzija"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Na napajanju"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Na _bateriji"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Odgoda"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Performanse"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Visoke performanse i potrošnja energije."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Uravnoteženo"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standardne performanse i potrošnja energije."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Štednja energije"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Smanjene performanse i potrošnja energije."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energija"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Pogledajte svoje stanje baterije i promijenite postavke štednje energije"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Energija;Spavanje;Suspenzija;Hibernacija;Baterija;Svjetlina;Zatamnjenje;"
+"Tamno;Zaslon;DPMS;Mirovanje;Energija;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Pisač “%s” je obrisan"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Neuspjelo dodavanje novoga pisača."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Nemoguće učitati kor. sučelje: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Otključaj za dodavanje pisača i promjenu postavki"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Pisači"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Dodajte pisače, pogledajte zadatke ispisivanja i odredite kakav ispis želite"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Pisač;Red;Ispis;Papir;Tinta;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Dodaj pisač"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Otključaj"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Nema pronađenih pisača"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Upišite mrežnu adresu ili pretražite pisač"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Potrebna je ovjera"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Upišite svoje korisničko ime i lozinku kako bi vidjeli pisače dostupne na "
+"poslužitelju ispisa."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Korisničko ime"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s pojedinosti"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Nije pronađen odgovarajući upravljački program"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Odaberi PPD datoteku"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Datoteka opisa PostSkripta pisača (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Nazivi pisača ne mogu sadržavati RAZMAK, TABULATOR, #, ili /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Lokacija"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Upravljački program"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Pretraživanje odgovarajućih upravljačkih programa…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Pretraživanje upravljačkih programa"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Odaberi iz baze podataka…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instaliraj PPD datoteku…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Odaberi upravljački program za pisač"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Učitavanje baze podataka upravljačkih programa…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Odaberi"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect pisač"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD pisač"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Jednostrano"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Dugom stranom (standardno)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Kratkom stranom (okrenuto)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Uspravno"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Položeno"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Obrnuto položeno"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Obrnuto uspravno"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Nastavi"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pauziraj"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Na čekanju"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pauzirano"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Potrebna je ovjera"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Obrada"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Zaustavljen"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Otkazan"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Prekinut"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Završen"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Premjesti ovaj zadatak na vrh reda čekanja"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u zadatak zahtijeva ovjeru"
+msgstr[1] "%u zadatka zahtijevaju ovjeru"
+msgstr[2] "%u zadataka zahtijeva ovjeru"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — aktivnih zadataka"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Upišite korisničko ime i lozinku za ispis sa %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domena"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "O_vjeri"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Ukloni sve"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Ovjera"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Nema aktivnih zadataka ispisa"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Otključaj poslužitelj pisača"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Otključaj %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Upišite korisničko ime i lozinku kako bi vidjeli pisače dostupne na %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Pretraživanje pisača"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Serijski priključak"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Paralelni priključak"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Lokacija: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adresa: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Poslužitelj zahtijeva ovjeru"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Obostrano"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Vrsta papira"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Izvor papira"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Izlazna ladica"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Razlučivost"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostSkripta predfiltriranja"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Stranica po listu"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Obostrano"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orijentacija"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Općenito"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Postavke ispisa"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Mogućnosti instaliranja"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Zadatak"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Kvaliteta slike"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Boja"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Završavanje"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Napredno"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Testna stranica"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Testna stranica"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Automatski odabir"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Zadani pisač"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Ugradi samo Ghostskript slova"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Prevedi u PS razine 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Prevedi u PS razine 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Bez prevođenja"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Proizvođač"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nema aktivnih zadataka ispisa"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u zadatak"
+msgstr[1] "%u zadatka"
+msgstr[2] "%u zadataka"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Čišćenje glava pisača"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Ponestaje tinte u toneru"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Ponestalo tinte u toneru"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Razvijatelj nizak"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Ponestalo razvijatelja"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Ponestaje tinte"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Ponestalo tinte"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Otvoren je poklopac"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Otvorena su vratašca"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Ponestaje papira"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Ponestalo papira"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Nije povezan"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Zaustavljen"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Pisačeva kantica za otpad je skoro puna"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Pisačeva kantica za otpad je puna"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Optički fotografski vodič je pri kraju vijeka trajanja"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Optički fotografski vodič je istrošen"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Spreman"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Ne prihvaća zadatke"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Obrada"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Mogućnosti ispisivanja"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Pojedinosti pisača"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Koristi kao zadani pisač"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Čišćenje glava pisača"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Ukloni pisač"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Razina tinte"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Ponovno pokrenite kada je problem razriješen."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Ponovno pokreni"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Dodaj pisač…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Nema otkrivenih pisača"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Nažalost! Usluga ispisa\n"
+"    sustava nije dostupna."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formati"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Pretraži lokalizaciju…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Uobičajeni formati"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Svi formati"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Nema pronađenih rezultata"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Pretrage mogu biti jezici ili zemlje."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Pretpregled"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperijalne"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrički"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datumi"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Datum i vrijeme"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Brojevi"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mjere"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papir"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Jezik i format vremena će biti promijenjen nakon sljedeće prijave"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Odjava…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Postavke jezika se koriste za tekst sučelja i web stranica. Formati se "
+"koriste za brojeve, datume i valute."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Vaš račun"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Jezik"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formati"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Zaslon prijave"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Jezik i regija"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Odaberite svoj jezik prikaza i formate"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Jezik;Raspored;Tipkovnica;ulaz;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Pitaj što učiniti"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Ne čini ništa"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Otvori mapu"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Ostali mediji"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Odaberite aplikaciju za glazbene CD-e"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Odaberite aplikaciju za video DVD-e"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Odaberite aplikaciju koja će se pokrenuti kada je glazbeni svirač spojen"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Odaberite aplikaciju koja će se pokrenuti kada je kamera spojena"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Odaberite aplikaciju za softverske CD-e"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "Glazbeni DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Prazni Blu-ray disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "Prazni CD disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "Prazni DVD disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "Prazni HD DVD disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "Čitač e-knjiga"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD video disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Slikovni CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows softver"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Odaberite kako bi se trebalo rukovati pojedinim medijima"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "Glazbeni _CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Glazbeni svirač"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Softver"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Ostali mediji…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nikad ne pitaj niti pokreći programe pri umetanju medija"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Odaberite kako će se rukovati s ostalim medijima"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Radnja:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Vrsta:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Prijenosni mediji"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Prilagodite prijenosne medije"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"uređaj;sustav;zadano;aplikacija;poželjno;cd;dvd;usb;zvuk;video;disk;"
+"prijenosni;medij;automomatsko pokretanje;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Odmah"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekundi"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuta"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minute"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minute"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minuta"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minuta"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 sat"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minute"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minute"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minute"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minuta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minuta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minuta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minuta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minuta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nikada"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Zaključavanje zaslona"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatsko zaključavanje zaslona sprječava pristup drugim osobama vašem "
+"računalu dok ste odsutni."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Odgoda zatamnjivanja zaslona"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Razdoblje neaktivnosti nakon koje će se zaslon zatamniti."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatsko zaključavanje _zaslona"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Odgoda _automatskog zaključavanja zaslona"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Razdoblje neaktivnosti nakon što se zaslon zatamni kada se zaslon automatski "
+"zaključa."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Prikaži _obavijesti na zaključanome zaslonu"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Zabrani nove _USB uređaje"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Sprječava interakciju novih USB uređaja sa sustavom kada je zaslon zaključan."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Privatnost zaslona"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Ograniči kut gledanja"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Postavke zaslona"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "zaslon;zaključaj;privatno;privatnost;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Odaberi lokaciju"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_U redu"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Pretraga lokacija"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Mape koje se pretražuju aplikacijama sustava, poput Datoteka, Fotografija i "
+"Snimaka."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Lokacije"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Zabilješke"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Ostalo"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Dodaj lokaciju"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Aplikacije nisu pronađene"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Pretraga aplikacija"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Obuhvati rezultate pretrage koje pruža aplikacija."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Mape koje se pretražuju aplikacijama sustava."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Rezultati pretrage"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Rezultati se prikazuju prema redoslijedu popisa."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Upravljajte prikazom rezultata pretrage aplikacija u pregledu aktivnosti"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Pretraga;Pretraži;Sadržaj;Sakrij;Privatnost;Rezultati;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Nema odabranih mreža za dijeljenje"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Mreže"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Uključeno"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Isključeno"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktivno"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Odaberi mapu"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Dodaj"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Omogući dijeljenje medija"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Dijeljenje datoteka omogućuje vam dijeljenje Javne mape s ostalim "
+"korisnicima vaše trenutne mreže koristeći: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Kada je udaljena prijava omogućena, udaljeni korisnici mogu se povezati "
+"koristeći naredbu sigurne ljuske (SSH):\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Omogući dijeljenje osobnih medija"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Naziv uređaja je kopiran"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Adresa uređaja je kopirana"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Korisničko ime je kopirano"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Lozinka je kopirana"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Dijeljenje"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Naziv računala"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Dijeljenje datoteka"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Udaljena _radna površina"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Dijeljenje medija"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Udaljena prijava"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Dijeljenje datoteka"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Potrebna je lozinka"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Udaljena prijava"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Udaljena radna površina"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Udaljena radna površina omogućuje pregled i upravljanje vašom radnom "
+"površinom s drugog računala."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Omogući ili onemogući povezivanje udaljene radne površine s ovim računalom."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Udaljeno upravljanje"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Dopusti udaljenim povezivanjima da upravljaju zaslonom."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Kako se povezati"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Povežite se s ovim računalom koristeći naziv računala ili adresu udaljene "
+"radne površine."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Adresa udaljene radne površine"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Ovjera"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "Potrebno je korisničko ime i lozinka za povezivanje s ovim računalom."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Korisničko ime"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Potvrda šifriranja"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Otisak prsta za šifriranje"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Otisak prsta za šifriranje može se vidjeti u klijentima povezivanja i trebao "
+"bi biti istovjetan."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Dijeljenje medija"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Dijelite glazbu, fotografije i video snimke diljem mreže."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Mape"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Postavite što želite dijeliti s ostalim korisnicima"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"dijeli;dijeljenje;ssh;računalo;naziv;udaljeno;radna površina;medija;zvuk;"
+"snimka;slika;fotografije;filmovi;poslužitelj;prikazivanje;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Omogući ili onemogući udaljenu prijavu"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Potrebna je ovjera za omogućavanje ili onemogućavanje udaljene prijave"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Prilagođeno"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klik"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Izraz"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Ljuljanje"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Šum"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Uravnoteženje"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Izblijedi"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Straga"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Sprijeda"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s - proba"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Kliknite kako bi isprobali zvučnike"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Zvukovi sustava"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Glavna glasnoća zvuka"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Razina glasnoće zvuka"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Izlaz"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Izlazni uređaj"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Isprobaj"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Podešavanje"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Dubokotonac"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Ulaz"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Ulazni uređaj"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Glasnoća zvuka"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Zvuk upozorenja"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Utišaj"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Zvuk"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Promijenite glasnoću zvuka, ulaze, izlaze i zvukove upozorenja"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kartica;Mikrofon;Glasnoća zvuka;Isčezni;Uravnoteženje;Bluetooth;Slušalice s "
+"mikrofonom;Zvuk;Izlaz;Ulaz;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Odspojeno"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Povezivanje"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Povezano"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Greška ovjere"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Odobravanje"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Smanjena funkcionalnost"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Povezano i odobreno"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Odobreno na:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Povezano na:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Upisano:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Neuspjelo odobravanje uređaja: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Neuspjelo zaboravljanje uređaja: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Ovisi o %u drugom uređaju"
+msgstr[1] "Ovisi o %u druga uređaja"
+msgstr[2] "Ovisi o %u drugih uređaja"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Zatvori obavijest"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Naziv:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Stanje:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Odobri i poveži"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Zaboravi uređaj"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Greška"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Odobreno"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr "Thunderbolt podsustav (boltd) nije instaliran ili podešen ispravno."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Dopusti izravan pristup uređajima poput dokova i vanjskih GPU-ova."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Samo USB i Display Port uređaji se mogu spojiti."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt se ne može otkriti.\n"
+"Ili sustav nema podršku za Thunderbolt, jer je onemogućena u BIOSU ili je "
+"postavljena nepodržana razina sigurnosti u BIOSU."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt podrška je onemogućena u BIOSU."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Thunderbolt sigurnosna razina se ne može odrediti."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Greška prebacivanja izravnog načina :%s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Nema Thunderbolt podrške"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Nemoguće povezivanje s Thunderbolt podsustavom."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Izravan pristup"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Uređaji na čekanju"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Nema spojenih uređaja"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Upravljaj Thunderbolt uređajima"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privatnost;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Treptanje pokazivača"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Pokazivač treperi u tekstnim poljima."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Brzina"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Brzina treptanja pokazivača"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Veličina pokazivača"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Veličina pokazivača se može kombinirati sa uvećavanjem/udaljavanjem kako bi "
+"se lakše pokazivač vidio."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Pomoć klikanja"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simuliraj drugi klik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Pokreni drugi klik držeći prvu tipku"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "O_dgoda prihvaćanja:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kratko"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Odgoda drugog klika"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Klik lebdenja"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Obavi klik kada pokazivač prijeđe preko"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "O_dgoda:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kratko"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Prag _pomicanja:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Mala"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Velika"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Tipke ponavljanja"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Pritisak tipke se ponavlja kada je tipka pritisnuta."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Odgoda ponavljanja tipka"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Brzina ponavljanja znakova"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Pomoć tipkanja"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Pričvrstive tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Tretira niz promjenjivih tipki kao kombinaciju tipki"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Onemogući ako su dvije tipke istodobno pritisnute"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Oglasi zvučni signal kada se pritisne _tipka prečaca"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "S_pore tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Stavlja odgodu između vremena kada se tipka pritisne i kada se prihvati "
+"signal tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kratko"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Odgoda tipkanja za spore tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Oglasi zvčni signal kada je p_ritisnuta tipka"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Oglasi zvčni signal kada je tipka _prihvačena"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Oglasi zvučni signal kada je tipka _odbijena"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Odbijanje tipki"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Zanemaruje brze dvostruke pritiske tipki"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kratko"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Odgoda tipkanja za odbijene tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Dugo"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Omogući tipkovnicom"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Uključi mogućnosti isključivanja i uključivanja pristupačnosti koristeći "
+"tipkovnicu"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Uobičajena"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Srednja"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Velika"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Veća"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Najveća"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d piksel"
+msgstr[1] "%d piksela"
+msgstr[2] "%d piksela"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Uvijek prikaži izbornik pristupačnosti"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Gledanje"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Visok kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Velik tekst"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Omogući a_nimacije"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Čitač _zaslona"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Čitač zaslona čita prikazani tekst kako se pomičete fokus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Zvučne tipke"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Oglasi zvučni signal pri uključivanju ili isključivanju velikih slova."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "V_eličina pokazivača"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Uvećanje"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Slušanje"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Vizualna upozorenja"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Zaslonska _tipkovnica"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "T_ipke ponavljanja"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Treptanje _pokazivača"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Pomoć tipkanja (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Usmjeravanje i klikanje"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Tipke miša"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Lociraj pokazivač"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Pomoć klikanja"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Odgoda dvostrukog klika"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Odgoda dvostrukog klika"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Vizualna upozorenja"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Testiraj bljeskanje"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Koristi vizualno upozorenje kada zvuk upozorenja nastane."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Zabljesni _cijeli zaslon"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Zabljesni _cijeli prozor"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kratko"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ zaslona"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ zaslona"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ zaslona"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Dugo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Cijeli zaslon"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Gornja polovina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Donja polovina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Lijeva polovina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Desna polovina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Mogućnosti uvećanja"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Uvećavanje:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Položaj povećala:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Prati pokazivač miša"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Dio zaslona:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "_Povećalo se proteže van zaslona"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Drži pokazivač povećala u središtu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Pokazivač povećala _gura sadržaj okolo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Pokazivač povećala se pomiče sa _sadržajem"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Povećalo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Nišan:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Preklapa pokazivač miša"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Debljina:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tanko"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Debelo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Duljina:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Bo_ja:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Nišan"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efekti boje:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Bijelo na crno:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Svjetlina:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Bo_ja"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Nepoznata"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Potpuna"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Niska"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Visoka"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Niska"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Visoka"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efekti boje"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Make it easier to see, hear, type, point and click"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Tipkovnica;Miš;a11y;Pristupačnost;Univerzalni Pristup;Kontrast;Pokazivač;"
+"Zvuk;Uvećanje;Zaslon;Čitač;velik;visok;tekst;slova;veličina;PristupX;"
+"Pričvrstiv;Tipke;Sporo;Odbijanje;Miš;Dvostruko;klik;Odgoda;Brzina;Pomoć;"
+"Ponovi;Blinkaj;vizualno;slušanje;glazba;zvuk;tipkanje;animacije;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 sat"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dan"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dana"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dana"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dana"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dana"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dana"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dana"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dana"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dana"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Želite li isprazniti sve stavke iz smeća?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Sve stavke u smeću biti će trajno obrisane."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Isprazni smeće"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Želite li obrisati sve privremene datoteke?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Sve privremene datoteke će biti trajno obrisane."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Obriši privremene datoteke"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dan"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dana"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dana"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Zauvijek"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Povijest datoteka"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Povijest datoteka čuva podatke korištenja datoteka. Te informacije se dijele "
+"između aplikacija što olakšava pretragu datoteka koje želite koristiti."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Povijest d_atoteka"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Trajanje _povijesti datoteka"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Obriši povijest…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Smeće i privremene datoteke"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Smeće i privremene datoteke mogu ponekada uključivati osobne ili osjetljive "
+"informacije. Njihovo automatsko brisanje može pomoći u zaštiti vaše "
+"privatnosti."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Automatski obriši _sadržaj smeća"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automatski obriši privremene _datoteke"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Razdoblje automatskog _brisanja"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Isprazni smeće…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Obriši privremene datoteke…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Povijest datoteka i smeće"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Ne ostavljaj tragove"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"upotreba;nedavno;povijest;datoteke;privremeno;prv;privatno;privatnost;smeće;"
+"isprazni;zadrži;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Treba se podudarati web adresa vašeg pružatelja računa."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Dodavanje računa nije upjelo"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lozinka se ne podudara."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Registracija računa nije uspjela"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Nema podaržanog načina za ovjeru s ovom domenom"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Pridruživanje s domenom nije uspjelo"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"To ime prijave ne radi.\n"
+"Pokušajte ponovno."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ta lozinka prijave ne radi.\n"
+"Pokušajte ponovno."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Prijava na domenu nije uspjela"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Nemoguće je pronaći domenu. Možda ste ju pogrešno upisali?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Dodaj korisnika"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administrator može dodavati i uklanjati druge korisnike, i može mijenjati "
+"postavke za sve korisnike. Roditeljski nadzor ne može se primijeniti na "
+"administratore."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Korisnik postavlja lozinku pri prvoj prijavi"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Postavi lozinku odmah"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Potvrdi"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Poslovna prijava"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Korisnički računi kojima upravlja tvrtka ili organizacija."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Niste povezanni"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Poslovna prijava dopušta centralizirano upravljanje postojećim korisničkim "
+"računom kako bi se mogao koristiti na ovom uređaju. Taj račun možete "
+"koristiti isto za pristup resursima tvrtke na internetu."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Potraži još slika"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Odaberi datoteku…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Upravitelj otiska prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Otisak prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Ne"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Da"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Želite li obrisati svoje registrirane otiske prsta, te će prijava pomoću "
+"otiska prsta biti onemogućena?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Nema uređaja prijave otiskom prsta"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Nema uređaja prijave otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Osigurajte da je uređaj pravilno povezan."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Uređaj prijave otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Odaberite uređaj prijave otiskom prsta koji želite podesiti"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Prijava otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Prijava otiskom prsta omogućuje vam otključavanje i prijavu u vaše računalo "
+"pomoću vašeg prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Obriši otiske prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Unos otiska prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "uređaj treba zatražiti da izvrši ovu radnju"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "ovaj uređaj je već zatražen od strane drugog procesa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "nemate dozvolu za izvođenje ove radnje"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "nema unesenih otisaka"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Neuspjela komunikacija s uređajem tijekom unosa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Neuspjela komunikacija s čitačem otiska tijekom unosa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Neuspjela komunikacija s pozadinskim programom čitača otiska"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Neuspjeli prikaz otiska prstiju: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Neuspjelo brisanje spremljenih otiska prstiju: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Lijevi palac"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Lijevi srednjak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "_Lijevi kažiprst"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Lijevi prestenjak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Lijevi mali prst"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Desni palac"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Desni srednjak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "_Desni kažiprst"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Desni prestenjak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Desni mali prst"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Nepoznat prst"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Završen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Uređaj prijave otiskom prsta odspojen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Pohrana uređaja prijave otiskom prsta je puna"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Neuspjeli unos novoga otiska prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Neuspjelo pokretanje unosa: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Neuspjeli unos novoga otiska prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Neuspjelo zaustavljanje unosa: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Uzastopno podignite i stavite prst na čitač kako biste unijeli svoj otisak "
+"prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "_Ponovni unos otiska prsta…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Skeniraj novi otisak prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Neuspjelo otpuštanje uređaja otiska prstiju %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problem čitanja uređaja"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Neuspjelo potraživanje uređaja otiska prstiju %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Neuspjelo dobivanje uređaja otiska prstiju: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Ovaj tjedan"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Protekli tjedan"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sesija omogućena"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sesija pokrenuta"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Aktivnost računa"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Prijašnja"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Sljedeća"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Odaberite drugu lozinku."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Ponovo upišite vašu trenutnu lozinku."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Lozinka ne može biti promijenjena"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Promijeni lozinku"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Pr_omijeni"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Trenutna lozinka"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nova lozinka"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Potvrda nove lozinke"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Dopušta korisniku postavljanje lozinke pri sljedećoj prijavi"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Postavi lozinku odmah"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Nemoguće se automatski pridružiti ovoj vrsti domene"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Takva domena ili područje nije pornađeno"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Nemoguća prijava kao %s na %s domenu"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Neispravna lozinka, pokušajte ponovno"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Nemoguće povezivanje s %s domenom: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Neuspjelo brisanje korisnika"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Nemoguće je opozvati udaljeno upravljanog korisnika"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Ne možete obrisati vlastiti račun."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s je još prijavljen"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Brisanje korisnika dok su prijavljeni može ostaviti sustav u neupotrebljivom "
+"stanju."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Želite li zadržati %s's datoteke?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Moguće je očuvati osobnu mapu, e-poštu i privremene datoteke kada se briše "
+"korisnički račun."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Obriši datoteke"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Zadrži datoteke"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Sigurno želite opozvati udaljeno upravljani %s's račun?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Obriši"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Račun onemogućen"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Biti će postavljen kod sljedeće prijave"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Nepoznata"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Prijavljeni"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Neuspjelo kontaktiranje usluge računa"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Pobrinite se da je AccountService instaliran i omogućen."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Ovaj panel mora biti otključan za promjenu ove postavke"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Obrišite odabrani korisnički račun"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Kako biste obrisali odabrani korisnički račun,\n"
+"najprije kliknite na ikonu *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Otključaj za dodavanje korisnika i promjenu postavki"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Korisnici"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Vaša sesija se mora ponovno pokrenuti za primjenu promjena"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Ponovno pokreni odmah"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Zatvori"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Uredi avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Ime i prezime"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Uredi"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Prijava otiskom prsta"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatska prijava"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Aktivnost računa"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administrator može dodavati i uklanjati druge korisnike, i može mijenjati "
+"postavke za sve korisnike."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Roditeljski nadzor"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Otvori aplikaciju roditeljskog nadzora."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Ukloni korisnika…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Drugi korisnici"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Dodaj korisnika…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Nema pronađenih korisnika"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Otključaj za dodavanje korisničkog računa."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Dodajte ili uklonite korisnike i promijenite svoju lozinku"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Prijava;Ime;Otisak;Avatar;Logo;Lice;Lozinka;Roditeljski nadzor;Vrijeme "
+"zaslona;Ograničenja aplikacija;Ograničenja weba;Upotreba;Ograničenje "
+"upotrebe;Klinci;Djeca;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Upiši"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Prijava administratora domene"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Za korištenje poslovne prijave, ovo računalo treba biti\n"
+"upisano u domenu. Neka administrator vaše mreže\n"
+"ovdje upiše lozinku njihove domene."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Administratorovo _ime"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Administratorova lozinka"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Upravljanje korisničkim računima"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Potrebna je ovjera za promjenu podataka korisnika"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Nova lozinka mora se razlikovati od stare."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Pokušajte promijeniti neka slova i brojeve."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Pokušajte promijeniti lozinku malo više."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Lozinka bez vašeg korisničkog imena bila bi snažnija."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Pokušajte izbjeći korištenje svojeg imena u lozinici."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Pokušajte izbjeći neke riječi sadržane u lozinici."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Pokušajte izbjeći učestale riječi."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Pokušajte izbjeći preslagivanje postojećih riječi."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Pokušajte koristiti više brojeva."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Pokušajte koristiti više velikih slova."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Pokušajte koristiti više malih slova."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Pokušajte koristiti više posebnih znakova, poput interpukcija."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Pokušajte koristiti mješavinu slova, brojeva i interpukcija."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Pokušajte izbjeći iste znakove."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Pokušajte izbjeći ponavljanje istih znakova, trebate koristiti mješavinu "
+"slova, brojeva i interpukcija."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Pokušajte izbjeći slijedove poput 1234 ili abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Lozinka mora biti dulja. Pokušajte dodati više slova, brojeva i interpukcija."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Izmješajte velika i mala slova i dodajte slovo ili dva."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Dodavanje više slova, brojeva i interpunkcija učinit će lozinku snažnijom."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Ovjera nije uspjela"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Nova lozinka je prekratka"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Nova lozinka je prejednostavna"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Nova i stara lozinka su preslične"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Nova lozinka je nedavno već korištena."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Nova lozinka mora sadržavati brojčane ili posebne znakove"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Stara i nova lozinka su iste"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Vaša lozinka je promijenjena otkada ste se prvotno ovjerili!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Nova lozinka ne sadrži dovoljno različitih znakova"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Nepoznata greška"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Korisničko ime može sadržavati samo mala i velika slova od a-z, brojke i ove "
+"znakove: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Nažalost, to korisničko ime nije dostupno. Pokušajte s drugim."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Korisnčko ime je predugačko."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Mapiraj tipke"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Mapiraj tipke na funkcije"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Kako bi uredili prečac, odaberite \"Pošalji pritisak tipke\" radnju, "
+"pritisnite tipku prečaca i držite pritisnutim nove tipke ili pritisnite "
+"Backspace za uklanjanje tipke prečaca."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Zatvori"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Dodirnite ciljne markere kako se oni pojavljuju na zaslonu za kalibraciju "
+"tableta."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Loš klik otkriven, ponovno pokretanje…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Tipka %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Određeno aplikacijom"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Pošalji pritisak tipke"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Prebaci zaslon"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Prikaži zaslonsku pomoć"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tablet montiran na panel prijenosnog računala"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tablet montiran na vanjski zaslon"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Vanjski tablet uređaj"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Vanjski uređaj za crtanje"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Svi zasloni"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Način rada tableta"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Koristite apsolutno pozicioniranje za olovku"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Ljevoruka orijentacija"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tablet i Brze tipke™ su zakrenuti za ljevoruko korištenje"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapiraj na zaslon"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Zadrži omjer slike"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "Koristi samo dio površine tableta za zadržavanje omjera slike zaslona"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibriraj"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nema prepoznatog tableta"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Priključite ili upalite svoj Wacom tablet."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Osjet pritiska vrha"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Mekan"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Vrsta pritiska pisaljke"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Čvrst"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Tipka 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Tipka 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Tipka 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Osjet pritiska gumice brisanja"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pritisk gumice brisanja"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Klik srednjom tipkom miša"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Klik desnom tipkom miša"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Naprijed"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Olovka zračnog kista s pritiskom, nagibom i integriranim klizačem"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Olovka zračnog kista s pritiskom, nagibom i zakretanjem"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standardna olovka s pritiskom i nagibom"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standardna olovka s pritiskom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Postavi tipke mapiranja i prilagodi osjetljivost pisaljke grafičkih tableta"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Pisaljka;Gumica;Miš;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Novi prečac…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Pristupne točke"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "NPT"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Radnja je prekinuta"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Greška:</b> Pristup je uskraćen zbog promjene postavki"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Greška:</b> Greška mobilne opreme"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Nije registrirano"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registrirano"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Pretraživanje"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Uskraćeno"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Pojedinosti modema"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Stanje modema"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operater"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Vrsta mreže"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Stanje mreže"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Vlastit broj"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Pojedinosti uređaja"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Inačica firmvera"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G samo"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G samo"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G samo"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "5G samo"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G,5G  (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (preporučeno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (preporučeno), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (preporučeno), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (preporučeno), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (preporučeno), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (preporučeno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (preporučeno), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (preporučeno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (preporučeno), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (preporučeno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (preporučeno), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (preporučeno), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (preporučeno), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (preporučeno), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (preporučeno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (preporučeno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (preporučeno)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (preporučeno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Nepoznat"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Otključaj SIM karticu"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Otključaj"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Navedite PIN kôd za SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Upišite PIN kôd za otključavanje SIM kartice"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Navedite PUK kôd za SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Upišite PUK kôd za otključavanje SIM kartice"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Nevaljana lozinka upisana. Preostao vam je %1$u pokušaj"
+msgstr[1] "Nevaljana lozinka upisana. Preostala su vam %1$u pokušaja"
+msgstr[2] "Nevaljana lozinka upisana. Preostao vam je %1$u pokušaja"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Imate %u preostao pokušaj"
+msgstr[1] "Imate %u preostala pokušaja"
+msgstr[2] "Imate %u preostalih pokušaja"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Nevaljana lozinka upisana."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK kôd bi trebao biti 8-znamenkasti broj"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Upišite novi PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN kôd bi trebao biti 4-8-znamenkasti broj"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Otključavanje…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Nema SIM kartice"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Umetnite SIM karticu za korištenje ovog modema"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM kartica zaključana"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobilni podaci"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Pristupite podacima koristeći mobilnu mrežu"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Roaming podataka"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Koristi mobilne podatke pri roamingu"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Način rada mreže"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "M_reža"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Napredno"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Nazivi pristupnih točka"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_Zaključavanje SIM kartice"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Zaključaj SIM sa PIN-om"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "P_ojedinosti modema"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Kvar telefona"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Nema povezivanja s telefonom"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Radnja nije dopuštena"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Radnja nije podržana"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM kartica nije umetnuta"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIM PIN je potreban"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIM PUK je potreban"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Neuspjeh SIM kartice"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM kartica je zauzeta"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Lozinka je netočna"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM PIN2 je potreban"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM PUK2 je potreban"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Nije pronađeno"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Nema mrežne usluge"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Istek mreže"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS usluga nije dopuštena"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming nije dopušten u ovom području"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Neodređena GPRS greška"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Bez greške"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Radnja prekinuta"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Pristup uskraćen"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Nepoznata greška"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Način rada mreže"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatski"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Odaberi mrežu"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Osvježi mrežne operatere"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Omogući mobilnu mrežu"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nema pronađenih WWAN uređaja"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Pobrinite se da imate bežični wan/mobilni uređaj"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Bežični wan je onemogućen kada je način rada u zrakoplovu uključen"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Isključi način rada u zrakoplovu"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Podatkovno povezivanje"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM kartica namijenjena za internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM zaključavanje"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Sljedeće"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Zaključaj SIM sa PIN-om"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Promijeni PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Upišite trenutni PIN za promjenu postavki zaključavanja SIM kartice"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobilna mreža"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Prilagodite telefoniranje i povezivanje mobilnim podacima"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "mobitel;wwan;telefoniranje;sim;mobilno;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Pomagalo za podešavanje GNOME radne površine"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Postavke su glavno sučelje za podešavanje vašeg sustava."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME projekt"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Prikaži broj inačice"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Omogući opširni opisni način rada"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Pretraživanje niza"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Prikaži moguće nazive panela i izađi"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel za prikaz"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Kategorije postavki"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privatnost"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Dostupni paneli:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Sve postavke"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Glavni izbornik"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Upozorenje: Razvojna inačica"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Ova inačica Postavki trebala bi se koristiti samo u razvojne svrhe. Možete "
+"iskusiti neispravno ponašanje sustava, gubitak podataka i ostale neočekivane "
+"probleme. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Priručnik"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Općenito"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Zatvori"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Pretraga"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneli"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Idi natrag na prijašnji panel"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Prekini pretragu"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Osobitosti;Postavke;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Identifikator za posljednji panel postavki koji treba biti otvoren"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Identifikator za posljednji panel postavki koji treba biti otvoren. "
+"Neprepoznate vrijednosti će biti zanemarene i prvi panel na popisu odabran."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Prikaži upozorenje kada je pokrenuta razvojna inačica Postavki"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Trebaju li Postavke prikazati upozorenje kada je pokrenuta razvojna inačica."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Početno stanje prozora"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Pravilo koje sadrži početnu širinu, visinu i uvećano stanje prozora "
+"aplikacije."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u izlaz"
+msgstr[1] "%u izlaza"
+msgstr[2] "%u izlaza"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ulaz"
+msgstr[1] "%u ulaza"
+msgstr[2] "%u ulaza"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Zvukovi sustava"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Greška: nemoguće otkrivanje HSI razine."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Greška: nemoguće otkrivanje neispravne HSI razine."
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Dodaj pisač…"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER ili PEM vjerodajnice (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Light"
+#~ msgstr "Svjetli"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "zaslon;zaključaj;dijagnostika;rušenje;privatno;nedavno;privremeno;tmp;"
+#~ "sadržaj;naziv;mreža;identitet;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Razmještaj zaslona"
+
+#~ msgid "Set"
+#~ msgstr "Postavi"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Zaključajte svoj zaslon"
+
+#~ msgid "Bark"
+#~ msgstr "Lavež"
+
+#~ msgid "Drip"
+#~ msgstr "Kapanje"
+
+#~ msgid "Glass"
+#~ msgstr "Staklo"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "GNOME postavke panel zvuka"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "GNOME postavke panel miša i touchpada"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "GNOME postavke panel pozadine"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "GNOME postavke panel tipkovnice"
+
+#~ msgid "Web Links"
+#~ msgstr "Web poveznice"
+
+#~ msgid "Git Links"
+#~ msgstr "Git poveznice"
+
+#~ msgid "%s Links"
+#~ msgstr "%s poveznice"
+
+#~ msgid "Unset"
+#~ msgstr "Ukloni"
+
+#~ msgid "Links"
+#~ msgstr "Poveznice"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Datoteke hiperteksta"
+
+#~ msgid "Text Files"
+#~ msgstr "Datoteke teksta"
+
+#~ msgid "Image Files"
+#~ msgstr "Datoteke slika"
+
+#~ msgid "Font Files"
+#~ msgstr "Datoteke slova"
+
+#~ msgid "Archive Files"
+#~ msgstr "Datoteke arhiva"
+
+#~ msgid "Package Files"
+#~ msgstr "Datoteke paketa"
+
+#~ msgid "Audio Files"
+#~ msgstr "Zvučne datoteke"
+
+#~ msgid "Video Files"
+#~ msgstr "Video datoteke"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Dozvole i pristup"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Podaci i usluge koje je ova aplikacija zatražila za pristup i za potrebne "
+#~ "dozvole."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Ne može biti promijenjena"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Pojedinačne dozvole za aplikacije se mogu vidjeti u postavkama <a "
+#~ "href=\"privacy\">Privatnosti</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integracija"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Postavi pozadinu radne površine"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Zadani rukovatelji"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Vrste datoteka i poveznica koje ova aplikacija otvara."
+
+#~ msgid "Usage"
+#~ msgstr "Upotreba"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Koliko resursa ova aplikacija koristi."
+
+#~ msgid "Open in Software"
+#~ msgstr "Otvori u Softveru"
+
+#~ msgid "Activities"
+#~ msgstr "Aktivnosti"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Dopusti aplikacijama ispod korištenje svoje kamere."
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopiraj"
+
+#~ msgid "Select _All"
+#~ msgstr "Odaberi _sve"
+
+#~ msgid "Single Display"
+#~ msgstr "Jednostruki zaslon"
+
+#~ msgid "Join Displays"
+#~ msgstr "Spojeni zasloni"
+
+#~ msgid "Display Mode"
+#~ msgstr "Način rada zalona"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Povlačite zaslone kako bi se prilagodili vašim fizičkim postavkama "
+#~ "zaslona. Odaberite zaslon kako bi promijenili njegove postavke."
+
+#~ msgid "Active Display"
+#~ msgstr "Aktivan zaslon"
+
+#~ msgid "More Warm"
+#~ msgstr "Toplija"
+
+#~ msgid "Less Warm"
+#~ msgstr "Hladnija"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Spremi sliku zaslona u $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Spremi sliku zaslona prozora u $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Spremi sliku zaslona područja u $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopiraj sliku zaslona u međuspremnik"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopiraj sliku prozora u međuspremnik"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopiraj sliku područja u međuspremnik"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Snimi kratak video snimak"
+
+#~ msgid "Move up"
+#~ msgstr "Pomakni gore"
+
+#~ msgid "Move down"
+#~ msgstr "Pomakni dolje"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Usluge lokacije dopuštaju aplikacijama da saznaju vašu lokaciju. Upotreba "
+#~ "bežične mreže i mobilnog širokopojasnog interneta povećava točnost "
+#~ "lociranja."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Koristi se usluga Mozilla lociranja: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Pravila privatnosti</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Dopusti aplikacijama ispod otkrivanje vaše lokacije."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Dopusti aplikacijama ispod korištenje svojeg mikrofona."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Istek vremena dvostrukog klika"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Suspenzija i tipka isključivanja"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Preklop otkriven: performanse način rada nedostupan"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Visoka temperatura hardvera: performanse način rada nedostupan"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Performanse način rada nedostupan"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Ovjera"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Odaberite format za brojeve, datume i valute. Promjene će se primijeniti "
+#~ "prilikom sljedeće prijave."
+
+#~ msgid "My Account"
+#~ msgstr "Moj račun"
+
+#~ msgid "Language"
+#~ msgstr "Jezik"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Jezik koji se koristi za tekst u prozorima i web stranicama."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Vaša sesija se mora ponovno pokrenuti za primjenu promjena"
+
+#~ msgid "Restart…"
+#~ msgstr "Ponovno pokreni…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "Postavke prijave koriste svi korisnici prilikom prijave u sustav"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Upravljajte prikazom rezultata pretrage u pregledu aktivnosti. Redoslijed "
+#~ "rezultata pretrage se isto može mijenjati pomicanjem redaka u popisu."
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Dijeljenje zaslona dopušta udaljenim korisnicima da vide ili upravljaju "
+#~ "vašim zaslonom povezivanjem na: %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Dijeljenje zaslona"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Neke usluge su onemogućene zbog nedostupnog mrežnog pristupa."
+
+#~ msgid "_Password:"
+#~ msgstr "_Lozinka:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Prikaži lozinku"
+
+#~ msgid "Access Options"
+#~ msgstr "Mogućnosti pristupa"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Nova povezivanja moraju upitati za pristup"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Potrebna je lozinka"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Zvučne tipke"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Čitač zaslona"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Čitač zaslona"
+
+#~ msgid "Standard"
+#~ msgstr "Standardan"
+
+#~ msgid "Account _Type"
+#~ msgstr "Vrsta _računa"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Dopušta korisniku postavljanje lozinke pri sljedećoj _prijavi"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Postavi lozinku _odmah"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Morate biti povezani s internetom za dodavanje poslovnih korisnika."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Uslikaj…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Kako bi napravili promjene\n"
+#~ "prvo kliknite * ikonu"
+
+#~ msgid "Create a user account"
+#~ msgstr "Napravite korisnički račun"
+
+#~ msgid "User Icon"
+#~ msgstr "Ikona korisnika"
+
+#~ msgid "Account Settings"
+#~ msgstr "Postavke računa"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Ovjera i prijava"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "To će se koristiti kao naziv vaše osobne mape i ne može se promijeniti."
+
+#~ msgid "Output:"
+#~ msgstr "Izlaz:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Zadrži omjer slike (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapiraj na jedan zaslon"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d od %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Prikaži mapiranje"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (apsolutno)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Touchpad (relativno)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Osobitosti tableta"
+
+#~ msgid "_Help"
+#~ msgstr "_Pomoć"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth postavke"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Način praćenja"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Mapiraj tipke…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Prilagodi postavke miša"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Prilagodi razlučivost zaslona"
+
+#~ msgid "No stylus found"
+#~ msgstr "Nema pronađenih pisaljka"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Pomičite svoju pisaljku u blizini vašeg tableta kako bi ju podesili"
+
+#~ msgid "Top Button"
+#~ msgstr "Gornja tipka"
+
+#~ msgid "Lower Button"
+#~ msgstr "Donja tipka"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Najniža tipka"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Neuspjelo slanje datoteke: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profil je poslan na:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Zapišite ovaj URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Ponovno pokrenite ovo računalo i pokrenite vaš uobičajeni operativni "
+#~ "sustav."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Upišite URL u vaš preglednik za preuzimanje i instalaciju profila."
+
+#~ msgid "Upload profile"
+#~ msgstr "Pošalji profil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Zahtijeva pristup Internetu"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Otključavanje..."
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Prečaci tipkovnice"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Ovo se može promijeniti u Prilagođeni prečaci postavkama"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Drži pritisnuto i upiši drugačije znakove"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Svjetlina zaslona"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Svjetlina tipkovnice"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Zatamni zaslon kada je neaktivan"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Zatamni zaslon"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Bežična mreža"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Bežična mreža se može isključiti u svrhu štednje energije."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Mobilni širokopojasni internet (LTE, 4G, 3G, itd.) se može isključiti u "
+#~ "svrhu štednje energije."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth se može isključiti u svrhu štednje energije."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Uravnotežena energija"
+
+#~ msgid "Add…"
+#~ msgstr "Dodaj…"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Prijava;Ime;Otisak prsta;Avatar;Logo;Lice;Lozinka;"
+
+#~ msgid "Left Alt"
+#~ msgstr "Lijevi Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Desni Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Lijevi Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Desni Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Desni Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Zamjenska tipka znakova"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Samo promjena, prebacivanje na sljedeći izvor"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Tipka Izbornika"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Punjenje"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Upozorenje"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Niska"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Dobra"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Potpuno napunjeno"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Prazna"
+
+#~ msgid "Previous source"
+#~ msgstr "Prijašnji izvor"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "Sljedeći izvor"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Left+Right Alt"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Dodajte korisničke račune i promijenite lozinke"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Reproducirajte ili snimite zvuk"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Otkrij mrežne uređaje pomoću mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Pristupite bluetooth hardveru izravno"
+
+#~ msgid "Use your camera"
+#~ msgstr "Koristite svoju kameru"
+
+#~ msgid "Print documents"
+#~ msgstr "Ispišite dokumente"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Koristi bilo koju povezanu igraču palicu"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Dopusti povezivanje s Docker uslugom"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Prilagodi mrežni vatrozid"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Podesi i koristi privilegirani FUSE datotečni sustav"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Nadopuni frimver na ovom uređaju"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Pristupi informacijama hardvera"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Omogućite entropiju za hardverski generator slučajnih brojeva"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Koristi hardverski generirane slučajne brojeve"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Pristupite datotekama u svojoj osobnoj mapi"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Pristupi libvirt usluzi"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Promijeni jezik sustava i postavke regije"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Promijeni postavke lokacije i pružatelje usluge"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Čitajte zapise sustava i aplikacija"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "pristupi media-hub usluzi"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Koristi i podesi modem"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Čitajte informacije montiranja sustava i kvota diska"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Upravljajte glazbenom i video reprodukcijom"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Promijenite naprednije mrežne postavke"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Pristupite usluzi Mrežnog upravitelja kako bi čitali i mijenjali mrežne "
+#~ "postavke"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Pristup čitanja mrežnim postavkama"
+
+#~ msgid "Change network settings"
+#~ msgstr "Promijeni mrežne postavke"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Pristupi ofono usluzi kako bi mogli čitati i mijenjati mrežne postavke za "
+#~ "mobilnu telefoniju"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Upravljaj Open vSwitch hardverom"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Čitaj sa CD-a/DVD-a"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Čitaj, dodaj promijeni ili ukloni spremljene lozinke"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Pristupite pppd i ppp uređajima za podešavanje točka-u-točka protokola "
+#~ "povezivanja"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Pauziraj ili završi bilo koji proces u sustavu"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Pristupi USB hardveru izravno"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Čitaj/Zapisuj datoteke na uklonjive uređaje pohrane"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Spriječi spavanje/zaključavanje zaslona"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Pristupi hardveru serijskog priključka"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Isključi ili ponovno pokreni uređaj"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Instaliraj, ukloni i podesi softver"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Pristupi usluzi radnog okvira pohrane"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Čitaj procese i informacije sustava"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Nadgledaj i upravljaj bilo koji pokrenuti program"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Promijeni datum i vrijeme"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Promijeni postavke poslužitelja vremena"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Promijeni vremensku zonu"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr "Pristupi UDisks2 usluzi za podešavanje diskova i uklonjivih medija"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Čitaj/Promijeni zajedničke događaje kalendara u Ubuntu Unityu 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Čitaj/Promijeni zajedničke kontakte u Ubuntu Unityu 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Pristupi podacima korištenja energije"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Čitaj/Zapisuj pristup izloženim U2F uređajima"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Univerzalni pristup"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Isključi povezivanje s bežičnom mrežom"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Lozinka"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Kako biste napravili korisnički račun,\n"
+#~ "najprije kliknite na ikonu *"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Omogući prijavu otiskom prsta"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Drugi prst:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Vaš otisak prsta je uspješno spremljen. Sada biste trebali biti u "
+#~ "mogućnosti prijaviti se koristeći čitač otisaka prsta."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Nemate ovlasti pristupa ovom uređaju. Kontaktirajte svog administratora."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Dogodila se unutrašnja greška."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Obrisati registrirane otiske prsta?"
+
+#~ msgid "Done!"
+#~ msgstr "Završeno!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Nemoguće pristupiti uređaju ”%s”"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Nemoguće uzeti otiske prsta na uređaju ”%s”"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Nemoguće pristupiti nijednom čitaču otiska prsta"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Za pomoć upitajte svog administratora."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Za omogućavanje prijave otiskom prsta, morate spremiti jedan od vaših "
+#~ "otisaka prsta koristeći ”%s” uređaj."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Odabiranje prsta"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Postavi pozadinu i zaključaj zaslon"
+
+#~ msgid "Set Background"
+#~ msgstr "Postavi pozadinu"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Postavi zaključavanje zaslona"
+
+#~ msgid "Remove Background"
+#~ msgstr "Ukloni pozadinu"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "Izvještaji su poslani anonimno i ne sadrže osobne podatke."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Slanje izvještaja tehničkih problema pomaže nam poboljšati ovaj "
+#~ "operativni sustav."
+
+#~ msgid "Version %s"
+#~ msgstr "Inačica %s"
+
+#~ msgid "OS name"
+#~ msgstr "Naziv operativnog sustava"
+
+#~ msgid "OS type"
+#~ msgstr "Vrsta operativnog sustava"
+
+#~ msgid "Disk"
+#~ msgstr "Disk"
+
+#~ msgid "Check for updates"
+#~ msgstr "Provjeri nadopune"
+
+#~ msgid "Network proxy"
+#~ msgstr "Mrežni proxy"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Unutrašnja _ovjera"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Ograniči _upotrebu pozadinskih podataka"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Prikladno za povezivanja s naplatom ili ograničenjem podataka."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Upleteni par (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Dodatna jedinica sučelja (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Medijski nezavisno sučelje (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Automatsko _povezivanje"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Prikaži l_ozinku"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Učini dostupnim ostalim korisnicima"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adrese"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Samo automatske (DHCP) adrese"
+
+#~ msgid "Link-local only"
+#~ msgstr "Samo poveži lokalno"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Zanemari automatski dobivene rute"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Klonirana MAC adresa"
+
+#~ msgid "_Reset"
+#~ msgstr "_Vrati izvorno"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Vraćanje postavki za ovu mrežu na izvorne vrijednosti, ali kao "
+#~ "prioritetnu mrežu."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Uklanjanje svih pojedinosti povezanih s ovom mrežom i nemojte se pokušati "
+#~ "automatski povezati s njom."
+
+#~ msgid "Hardware"
+#~ msgstr "Hardver"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Vrati izvorno"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Povezani uređaji"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Skočne _obavijesti"
+
+#~ msgid "In use"
+#~ msgstr "Koristi se"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Uključeno"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Isključeno"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Isključena"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Uključena"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Isključen"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Uključen"
+
+#~ msgid "Usage & History"
+#~ msgstr "Upotreba i povijest"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Pravila privatnosti"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Pamćenje vaše povijesti čini stvari lakšima za ponovno pretraživanje. Te "
+#~ "stavke se nikada ne dijele putem mreže."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Nedavno korišteno"
+
+#~ msgid "Retain _History"
+#~ msgstr "Zadrži _povijest"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Zaključavanje zaslona štiti vašu privatnost kada ste odsutni."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Zaključaj zaslon _nakon zatamnjenja za"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "Obavijesti zaključanog _zaslona"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Automatski ukloni smeće i privremene datoteke kako bi uklonili s vašeg "
+#~ "računala nepotrebne osjetljive informacije."
+
+#~ msgid "Purge _After"
+#~ msgstr "Ukloni _nakon"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Slanjem informacije o tome koji softver koristite pomaže nam da vam "
+#~ "pružimo bolje preporuke. Isto tako nam pomaže da poboljšamo naš softver.\n"
+#~ "\n"
+#~ "Sve informacije koje prikupimo su anonimne, i nikada nećemo podijeliti "
+#~ "vaše podatke s trećom stranom."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Pošalji statistiku korištenja softvera"
+
+#~ msgid "_Camera"
+#~ msgstr "_Kamera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Mikrofon"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Usluge lokacije"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Zaštitite svoje osobne informacije i postavite što drugi korisnici mogu "
+#~ "vidjeti"
+
+#~ msgid "No regions found"
+#~ msgstr "Nema pronađenih regija"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Zabljeni _naslov prozora"
+
+#~ msgid "Last Login"
+#~ msgstr "Posljednja prijava"
+
+#~ msgid "page 1"
+#~ msgstr "stranica 1"
+
+#~ msgid "page 2"
+#~ msgstr "stranica 2"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Prebacivanje na bežičnu pristupnu točku odspojiti će vas s <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Pristup Internetu nije moguć putem vašeg bežičnog povezivanja dok je "
+#~ "pristupna točka aktivna."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Bežične pristupne točke uobičajeno se koriste za dijeljenje dodatnog "
+#~ "pristupa internetu putem bežične mreže."
+
+#~ msgid "details"
+#~ msgstr "pojedinosti"
+
+#~ msgid "identity"
+#~ msgstr "identitet"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastruktura"
+
+#~ msgid "Delete Background"
+#~ msgstr "Obriši pozadinu"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Korisničko ime ne može početi s ”-”."
+
+#~ msgid "_Background"
+#~ msgstr "_Pozadina"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Promjene u tijeku dana"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Popločano"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Približavanje/Udaljavanje"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Sredina"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Prilagodba veličine"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Ispuni"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Raspon"
+
+#~ msgid "Colors"
+#~ msgstr "Boje"
+
+#~ msgid "Pictures"
+#~ msgstr "Slike"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Nema pronađenih slika"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Možete dodati slike u vašu %s mapu i zatim će se prikazati ovdje gore"
+
+#~ msgid "_Off"
+#~ msgstr "_Isključeno"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Povezivanje/SSID"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automatska suspenzija"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Kada je tipka isključivanja pritisnuta"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Noćno svjetlo"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Nemoguće dobivanje informacije zaslona"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Prebaci na prijašnji način unosa"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Prebaci na slijedeći način unosa"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Zamjensko prebacivanje na sljedeći način unosa"
+
+#~ msgid "Add input source"
+#~ msgstr "Dodaj način unosa"
+
+#~ msgid "Remove input source"
+#~ msgstr "Ukloni način unosa"
+
+#~ msgid "Move input source up"
+#~ msgstr "Pomakni način unosa gore"
+
+#~ msgid "Move input source down"
+#~ msgstr "Pomakni način unosa dolje"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Prikaži način unosa rasporeda tipkovnice"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Lijevo"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Desno"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Najmanje"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Najviše"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Dubokotonac:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Testiranje zvučnika"
+
+#~ msgid "Peak detect"
+#~ msgstr "Otkrivanje vrhunca"
+
+#~ msgid "Device"
+#~ msgstr "Uređaj"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Testiranje zvučnika za %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "O_daberite uređaj za izlaz zvuka:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Postavke za odabrani uređaj:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Ulazna glasnoća zvuka:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "O_daberite uređaj za ulaz zvuka:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Zvučni efekti"
+
+#~ msgid "Built-in"
+#~ msgstr "Ugrađen"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Osobitosti zvuka"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Testiranje zvuka događaja"
+
+#~ msgid "From theme"
+#~ msgstr "Iz teme"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "O_daberite zvuk upozorenja:"
+
+#~ msgid "Stop"
+#~ msgstr "Zaustavi"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standardan"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrator"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME središte upravljanja"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Središte upravljanja je GNOME glavno sučelje za podešavanje vaše radne "
+#~ "površine."
+
+#~ msgid "Quit"
+#~ msgstr "Zatvori"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "hardware"
+#~ msgstr "hardver"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Engleski (Ujedinjeno Kraljevstvo)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Ujedinjeno Kraljevstvo"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Potvrdi novu lozinku"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Lozinke se ne podudaraju."
+
+#~ msgid "page 3"
+#~ msgstr "stranica 3"
+
+#~ msgid "Show the overview"
+#~ msgstr "Prikaži pregled"
+
+#~ msgid "Back­ground"
+#~ msgstr "Pozadina"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blue­tooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Boja"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Zadane aplikacije"
+
+#~ msgid "Ab­out"
+#~ msgstr "O progrmu"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Prijenosni mediji"
+
+#~ msgid "Net­work"
+#~ msgstr "Mreža"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Obavijesti"
+
+#~ msgid "Po­wer"
+#~ msgstr "Energija"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Privatnost"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Dijeljenje"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Univerzalni pristup"
+
+#~ msgid "Disable image"
+#~ msgstr "Onemogući sliku"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Pregledaj za više slika…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Koristio %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wa­com tab­let"
+
+#~ msgid "Overview"
+#~ msgstr "Pregled"
+
+#~ msgid "De­tails"
+#~ msgstr "Pojedinosti"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardver"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sustav"
+
+#~ msgid "Apply"
+#~ msgstr "Primijeni"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Zaslon prijenosnika spušten"
+
+#~ msgid "Mirrored"
+#~ msgstr "Zrcaljeno"
+
+#~ msgid "Secondary"
+#~ msgstr "Pomoćni"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Raspored kombiniranih zaslona"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Povucite zaslone za promjenu rasporeda"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Zakreni ulijevo 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Zakreni za 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Zakreni udesno za 90°"
+
+#~ msgid "Size"
+#~ msgstr "Veličina"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Prikaži gornju traku i pregled aktivnosti na ovom zaslonu"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Spoji ovaj zaslon s drugim, kako bi stvorili dodati radni prostor"
+
+#~ msgid "Presentation"
+#~ msgstr "Prezentacija"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Prikaži samo prezentacije i medije"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Prikažite vaš postojeći prikaz na oba zaslona"
+
+#~ msgid "Turn Off"
+#~ msgstr "Isključi"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Ne koristi ovaj zaslon"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Rasporedi kombinirane zaslone"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "Način _rada u zrakoplovu"
+
+#~ msgid "Server"
+#~ msgstr "Poslužitelj"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Obriši DNS poslužitelja"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Dodaj profil…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Nepoznata"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Ručno"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatski"
+
+#~ msgid "_Method"
+#~ msgstr "_Način"
+
+#~ msgid "Group Name"
+#~ msgstr "Naziv grupe"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Pritisni Esc za prekidanje."
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Učini dostupnim ostalim _korisnicima"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Vraćanje izvornih postavki za ovu mrežu, uključujući lozinke, ali kao "
+#~ "prioritetnu mrežu."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr "Ukloni sve pojedinosti ove mreže i nemoj se povezati automatski"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Ako niste povezani na Internet bežičnim putem, možete postaviti bežičnu "
+#~ "pristupnu točku za dijeljenje povezivanja s ostalim korisnicima."
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Koristi kao pristupnu točku..."
+
+#~ msgid "_History"
+#~ msgstr "_Povijest"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bitni (ID izgradnje: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bitna"
+
+#~ msgid "Base system"
+#~ msgstr "Osnovni sustav"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Prečac;Ponovi;Treptanje;"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Vatrozid _zona"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Uobičajena"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Zona određuje pouzdanu razinu povezivanja"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Pokušajte dodati više slova, brojeva i simbola."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Snaga: slaba"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Snaga: mala"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Snaga: srednja"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Snaga: dobra"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Snaga: velika"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Postavi prečac"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Transparenti _obavijesti"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Transparenti _obavijesti"
+
+#~ msgid "Add Account"
+#~ msgstr "Dodaj račun"
+
+#~ msgid "Mail"
+#~ msgstr "Pošta"
+
+#~ msgid "Calendar"
+#~ msgstr "Kalendar"
+
+#~ msgid "Contacts"
+#~ msgstr "Kontakti"
+
+#~ msgid "Chat"
+#~ msgstr "Razgovor"
+
+#~ msgid "Error creating account"
+#~ msgstr "Greška pri stvaranju računa"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Sigurno želite ukloniti ovaj račun?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Ovo neće ukloniti račun na poslužitelju."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Nema podešenih mrežnih računa"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Dodavanje računa dopušta vašim aplikacijama pristup dokumentima, pošti, "
+#~ "kontaktima, kalendaru, razgovorima i još mnogo toga."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Podešavanje"
+
+#~ msgid "Toner Level"
+#~ msgstr "Razina tonera"
+
+#~ msgid "Supply Level"
+#~ msgstr "Razina opskrbe"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Instalacija"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktivan"
+#~ msgstr[1] "%u aktivna"
+#~ msgstr[2] "%u aktivnih"
+
+#~ msgid "Supply"
+#~ msgstr "Opskrba"
+
+#~ msgid "Jobs"
+#~ msgstr "Zadaci"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Prikaži _zadatke"
+
+#~ msgid "label"
+#~ msgstr "oznaka"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "_Ispis probne stranice"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Ostali računi"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Gore"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Dolje"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Nepoznata"
+
+#~ msgid "Left Ring"
+#~ msgstr "Lijevi prsten"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Način lijevog prstena #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Način desnog prstena #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Lijeva dodirna traka"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Način lijeve dodirne trake #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Desna dodirna traka"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Način desne dodirne trake #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Način prebacivanja lijevog dodirnog prstena"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Način prebacivanja desnog dodirnog prstena"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Način prebacivanja lijeve dodirne trake"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Način prebacivanja desne dodirne trake"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Način prebacivanja #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Lijeva tipka #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Desna tipka #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Gornja tipka #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Donja tipka #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Bez radnje"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Klik lijevom tipkom miša"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Klizi prema gore"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Klizi prema dolje"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Klizi desno"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Dodaj novi pisač"
+
+#~ msgid "No printers detected."
+#~ msgstr "Nema otkrivenih pisača."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"

--- a/po/hu.po
+++ b/po/hu.po
@@ -17,9 +17,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issu"
-"es\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-03 02:32+0200\n"
 "Last-Translator: Balázs Úr <ur.balazs at fsf dot hu>\n"
 "Language-Team: Hungarian <gnome-hu-list at gnome dot org>\n"
@@ -30,103 +29,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 19.12.3\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Rendszerbusz"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Teljes hozzáférés"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Munkamenetbusz"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Eszközök"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Teljes hozzáférés a /dev-hez"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Hálózat"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Van hálózati kapcsolata"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Saját mappa"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Csak olvasható"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Fájlrendszer"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Beállítások"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Módosíthatja a beállításokat"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"A(z) %s ezket a jogosultságokat tartalmazza beépítve. Ezek nem "
-"módosíthatóak. Ha zavarják ezek a jogosultságok, akkor fontolja meg az "
-"alkalmazás eltávolítását."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "Az alkalmazás által megnyitott %u fájl- és hivatkozástípus"
-msgstr[1] "Az alkalmazás által megnyitott %u fájl- és hivatkozástípus"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> van használatban a fájlok és hivatkozások alábbi típusainak "
-"megnyitásához."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-#| msgid "%s of disk space used"
-msgid "%s of disk space used."
-msgstr "%s lemezterület van használatban."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -142,7 +45,6 @@ msgid "Install some…"
 msgstr "Néhány telepítése…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Megnyitás"
 
@@ -166,24 +68,13 @@ msgstr "Keresés"
 msgid "Receive system searches and send results."
 msgstr "Rendszerkeresések fogadása és a találatok küldése."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Tiltva"
 
@@ -197,7 +88,6 @@ msgid "Show system notifications."
 msgstr "Rendszerértesítések megjelenítése."
 
 #: panels/applications/cc-applications-panel.ui:133
-#| msgid "Run in background"
 msgid "Run in Background"
 msgstr "Futtatás a háttérben"
 
@@ -206,12 +96,10 @@ msgid "Allow activity when the app is closed."
 msgstr "Tevékenység engedélyezése, ha az alkalmazás be van zárva."
 
 #: panels/applications/cc-applications-panel.ui:140
-#| msgid "Screen"
 msgid "Screenshots"
 msgstr "Képernyőképek"
 
 #: panels/applications/cc-applications-panel.ui:141
-#| msgid "Take pictures with the camera."
 msgid "Take pictures of the screen at any time."
 msgstr "Képek készítése a képernyőről bármikor."
 
@@ -351,82 +239,20 @@ msgstr "Gyorsítótár ürítése…"
 msgid "Control various application permissions and settings"
 msgstr "Különböző alkalmazások jogosultságainak és beállításainak vezérlése"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "alkalmazás;flatpak;jogosultság;beállítás;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Fénykép kiválasztása"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "Mé_gse"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Megnyitás"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "több méret"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Nincs asztalháttér"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Jelenlegi háttér"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stílus"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
-#| msgctxt "cursor size"
-#| msgid "Default"
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Alapértelmezett"
 
@@ -450,9 +276,7 @@ msgstr "Megjelenés"
 msgid "Change your background image or the UI colors"
 msgstr "A háttérkép vagy a felhasználói felület színeinek megváltoztatása"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-#| msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Háttér;Háttérkép;Képernyő;Asztal;Stílus;Világos;Sötét;Megjelenés;"
 
@@ -463,7 +287,6 @@ msgstr "Háttér;Háttérkép;Képernyő;Asztal;Stílus;Világos;Sötét;Megjele
 #: panels/microphone/cc-microphone-panel.ui:9
 #: panels/universal-access/cc-cursor-blinking-dialog.ui:15
 #: panels/universal-access/cc-repeat-keys-dialog.ui:15
-#| msgid "_Enable"
 msgid "Enable"
 msgstr "Engedélyezés"
 
@@ -503,9 +326,7 @@ msgstr "A hardver repülési üzemmódja be van kapcsolva"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Kapcsolja ki a repülési üzemmód kapcsolót a Bluetooth bekapcsolásához."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -513,7 +334,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Kapcsolja be és ki a Bluetooth-t, majd csatlakoztassa eszközeit"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;megosztás;bluetooth;obex;"
@@ -548,93 +368,33 @@ msgstr "Egyetlen alkalmazás sem kérte a kamera elérését"
 msgid "Protect your pictures"
 msgstr "A képei védelme"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "kamera;fényképek;videó;webkamera;zárolás;személyes;adatvédelem;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Helyezze a kalibrálóeszközt a négyzetre, és nyomja meg a „Kezdés” gombot"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Vigye a kalibrálóeszközt a kalibrálási pozícióba, és nyomja meg a „Tovább” "
-"gombot"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Vigye a kalibrálóeszközt a felület pozícióba, és nyomja meg a „Tovább” gombot"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Zárja le a laptop fedelét"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Belső hiba történt, a folytatás nem lehetséges."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "A kalibráláshoz szükséges eszközök nincsenek telepítve."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "A profil nem állítható elő."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "A cél fehér pont nem szerezhető be."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Kész!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "A kalibrálás sikertelen!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Eltávolíthatja a kalibrálóeszközt."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ne zavarja a kalibrálóeszközt a folyamat során"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kijelző kalibrálása"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Mé_gse"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -651,140 +411,6 @@ msgstr "_Folytatás"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Kész"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Laptop képernyő"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Beépített webkamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s monitor"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s szkenner"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s fényképezőgép"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s nyomtató"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s webkamera"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Színkezelés bekapcsolása ehhez: %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Színprofilok megjelenítése ehhez: %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Nem kalibrált"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Alapértelmezett: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Színtér: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Tesztprofil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Válasszon ICC profilfájlt"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importálás"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Támogatott ICC profilok"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Minden fájl"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Képernyő"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Profil mentése"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "M_entés"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Színprofil létrehozása a kiválasztott eszközhöz"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"A mérőkészülék nem található. Ellenőrizze, hogy be van-e kapcsolva, és "
-"megfelelően van-e csatlakoztatva."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "A mérőkészülék nem támogatja a nyomtatóprofilozást."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Az eszköztípus jelenleg nem támogatott."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -900,9 +526,9 @@ msgstr "Írható adathordozót igényel"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "A profil használatával kapcsolatos ezen utasításokat <a href=\"linux\">GNU/"
 "Linux</a>, <a href=\"osx\">Apple OS X</a> és <a href=\"windows\">Microsoft "
@@ -917,8 +543,8 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Problémák találhatók. A profil esetleg nem fog megfelelően működni. <a href="
-"\"\">Részletek megjelenítése.</a>"
+"Problémák találhatók. A profil esetleg nem fog megfelelően működni. <a "
+"href=\"\">Részletek megjelenítése.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -926,7 +552,6 @@ msgstr "Fájl _importálása…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -936,9 +561,7 @@ msgstr "_Hozzáadás"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "Minden eszköz esetén a színkezeléshez friss színprofil szükséges."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "További információk"
 
@@ -1070,82 +693,6 @@ msgstr "D65 (fényképészet és grafika)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Szabványos színtér"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Tesztprofil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatikus"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Alacsony minőség"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Közepes minőség"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Magas minőség"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Alapértelmezett RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Alapértelmezett CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Alapértelmezett szürke"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Gyártó által biztosított gyári kalibrálási adatok"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Ezzel a profillal nem lehetséges a teljes képernyős kijelzőkorrekció"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Ez a profil már nem feltétlenül pontos"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Szín"
@@ -1155,14 +702,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Kijelzők, fényképezőgépek vagy nyomtatók színeinek kalibrálása"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Szín;ICC;Színek;Profilozás;Kalibrálás;Nyomtató;Kijelző;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Egyéb…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1177,13 +719,8 @@ msgid "No languages found"
 msgstr "Nem találhatók nyelvek"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Tovább…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Feloldás a beállítások módosításához"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1212,151 +749,6 @@ msgstr "Óra csökkentése"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Másodperc csökkentése"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Ma"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Tegnap"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b. %-e."
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%Y. %b. %-e."
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d óra"
-msgstr[1] "%d óra"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d perc"
-msgstr[1] "%d perc"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d másodperc"
-msgstr[1] "%d másodperc"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 másodperc"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 órás"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "12 órás"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%Y. %B %-e. %H:%M"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%Y. %B %-e. %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%H:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1453,17 +845,11 @@ msgstr ""
 "A helymeghatározó szolgáltatások engedélyezését és internetkapcsolatot "
 "igényel"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Engedélyezve"
 
@@ -1471,15 +857,43 @@ msgstr "Engedélyezve"
 msgid "Time Z_one"
 msgstr "Idő_zóna"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Feloldás"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Idő_formátum"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dátumok"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 másodperc"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Naptár"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Számok"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Dátum, idő és időzóna módosítása"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Óra;Időzóna;Hely;"
@@ -1525,21 +939,9 @@ msgstr "Alap alkalmazások"
 msgid "Configure Default Applications"
 msgstr "Alap alkalmazások beállítása"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "alap;alapértelmezett;alkalmazás;előnyben részesített;média;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"A műszaki problémák jelentéseinek elküldése segít nekünk a(z) %s "
-"továbbfejlesztésében. A jelentések névtelenül és személyes adatoktól "
-"mentesen lesznek elküldve. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1557,45 +959,9 @@ msgstr "Diagnosztika"
 msgid "Report your problems"
 msgstr "Problémák bejelentése"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#| msgid "Diagnostics"
 msgid "diagnostics;crash;"
 msgstr "diagnosztika;összeomlás;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Be"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Ki"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Módosítások alkalmazása?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "A módosítások nem alkalmazhatóak"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Ez hardveres korlátozások miatt is lehet."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1645,31 +1011,6 @@ msgstr "Elsődleges kijelző"
 msgid "Night Light"
 msgstr "Éjszakai fény"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Fekvő"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Álló (jobbra)"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Álló (balra)"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Fekvő (fordított)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1694,8 +1035,18 @@ msgctxt "display setting"
 msgid "Scale"
 msgstr "Méretezés"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Természetes görgetés"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
 #: panels/display/cc-night-light-page.ui:22
-#| msgid "Night Light"
 msgid "Night Light unavailable"
 msgstr "Az éjszakai fény nem érhető el"
 
@@ -1704,8 +1055,8 @@ msgid ""
 "This could be the result of the graphics driver being used, or the desktop "
 "being used remotely"
 msgstr ""
-"Ennek oka a használt grafikus illesztőprogram vagy a távolról használt asztal"
-" lehet"
+"Ennek oka a használt grafikus illesztőprogram vagy a távolról használt "
+"asztal lehet"
 
 #. Inhibit the redshift functionality until the next day starts
 #: panels/display/cc-night-light-page.ui:58
@@ -1789,7 +1140,6 @@ msgstr "Ki­jel­zők"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Csatlakoztatott monitorok és projektorok beállítása"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1798,82 +1148,6 @@ msgstr ""
 "Panel;Projektor;xrandr;Képernyő;Felbontás;Frissítés;Monitor;Éjszakai;fény;"
 "redshift;szín;napkelte;napnyugta;"
 
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "A biztonságos rendszerindítás aktív"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú szoftverek"
-" töltődjenek be az eszköz indításakor. Ez jelenleg be van kapcsolva, és"
-" megfelelően működik."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "A biztonságos rendszerindításnak problémái vannak"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú szoftverek"
-" töltődjenek be az eszköz indításakor. Ez jelenleg be van kapcsolva, de nem"
-" fog működni egy érvénytelen kulcs megléte miatt."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"A biztonságos rendszerindítással kapcsolatos problémák gyakran megoldhatók a"
-" számítógép UEFI belső vezérlőprogramjának beállításaiból (BIOS), és a"
-" hardver gyártója tájékoztatást adhat arról, hogyan lehet ezt megtenni."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Segítségért forduljon a hardver gyártójához vagy az informatikai"
-" támogatójához."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-#| msgid "Camera is Turned Off"
-msgid "Secure Boot is Turned Off"
-msgstr "A biztonságos rendszerindítás ki van kapcsolva"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú szoftverek"
-" töltődjenek be az eszköz indításakor. Ez jelenleg ki van kapcsolva."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"A biztonságos rendszerindítás gyakran a számítógép UEFI belső"
-" vezérlőprogramjának beállításaiban (BIOS) kapcsolható be. Segítségért"
-" forduljon a hardver gyártójához vagy az informatikai támogatójához."
-
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
 "Secure boot prevents malicious software from being loaded when the device "
@@ -1881,527 +1155,33 @@ msgid ""
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
-"A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú szoftverek"
-" töltődjenek be az eszköz indításakor.\n"
+"A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú szoftverek "
+"töltődjenek be az eszköz indításakor.\n"
 "\n"
-"További információkért forduljon a hardver gyártójához vagy az informatikai"
-" támogatóhoz."
+"További információkért forduljon a hardver gyártójához vagy az informatikai "
+"támogatóhoz."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-#| msgid "Password"
-msgid "Passed"
-msgstr "Sikeres"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-#| msgid "PPP failed"
-msgid "Failed"
-msgstr "Sikertelen"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Az eszköz megfelel a(z) %d. HSI-szintnek"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
-msgid "Security Level 0"
-msgstr "0. biztonsági szint"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Ez az eszköz nem rendelkezik védelemmel a hardveres biztonsági problémák"
-" ellen. Ennek oka hardverbeállítási probléma vagy belső vezérlőprogram"
-" beállítási probléma lehet. Ajánlott felvennie a kapcsolatot az informatikai"
-" támogatójával."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
-msgid "Security Level 1"
-msgstr "1. biztonsági szint"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Ez az eszköz minimális védelemmel rendelkezik a hardveres biztonsági"
-" problémák ellen. Ez a legalacsonyabb eszközbiztonsági szint, és csak az"
-" egyszerű biztonsági fenyegetésekkel szemben nyújt védelmet."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
-msgid "Security Level 2"
-msgstr "2. biztonsági szint"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Ez az eszköz alapvető védelemmel rendelkezik a hardveres biztonsági problémák"
-" ellen. Ez védelmet nyújt néhány gyakori biztonsági fenyegetés ellen."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
-msgid "Security Level 3"
-msgstr "3. biztonsági szint"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Ez az eszköz kibővített védelemmel rendelkezik a hardveres biztonsági"
-" problémák ellen. Ez a legmagasabb eszközbiztonsági szint, és védelmet nyújt"
-" a speciális biztonsági fenyegetések ellen."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
 msgid "Security Level"
 msgstr "Biztonsági szint"
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr "A biztonsági szintek nem érhetők el ehhez az eszközhöz."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Forduljon a hardver gyártójához a biztonsági frissítésekkel kapcsolatos"
-" segítségért."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Lehetséges, hogy ezt a problémát az eszköz UEFI belső vezérlőprogramjának"
-" beállításaiban vagy egy támogató technikus segítségével lehet megoldani."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Lehetséges, hogy ezt a problémát az eszköz UEFI belső vezérlőprogramjának"
-" beállításaiban lehet megoldani."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
-"Lehetséges, hogy egy támogató technikus segítségével lehet ezt a problémát"
-" megoldani."
-
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
-#| msgid "Ink Level"
 msgid "Level 1"
 msgstr "1. szint"
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:124
-#| msgid "Ink Level"
 msgid "Level 2"
 msgstr "2. szint"
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:160
-#| msgid "Ink Level"
 msgid "Level 3"
 msgstr "3. szint"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr "Védelem a rosszindulatú szoftverek ellen az eszköz indításakor."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "A biztonságos rendszerindításnak problémái vannak"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "Némi védelem az eszköz indításakor."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "A biztonságos rendszerindítás ki van kapcsolva"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "Nincs védelem az eszköz indításakor."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Ezt a problémát az UEFI belső vezérlőprogramjának beállításaiban történt"
-" változtatás, az operációs rendszer konfigurációjának megváltoztatása vagy a"
-" rendszerben lévő rosszindulatú szoftver okozhatta."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Ezt a problémát az UEFI belső vezérlőprogramjának beállításaiban történt"
-" változtatás vagy a rendszerben lévő rosszindulatú szoftver okozhatta."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Ezt a problémát az operációs rendszer konfigurációjának megváltoztatása vagy"
-" a rendszerben lévő rosszindulatú szoftver okozhatta."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "Komoly biztonsági fenyegetéseknek van kitéve."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "Korlátozott védelem az egyszerű biztonsági fenyegetések ellen."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "Védve van a gyakori biztonsági fenyegetések ellen."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "Védve van a biztonsági fenyegetések széles tartománya ellen."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "Átfogó védelem"
 
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Nincsenek események"
 
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection"
-msgstr "Belső vezérlőprogram írásvédelme"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection Lock"
-msgstr "Belső vezérlőprogram írásvédelmének zárolása"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Region"
-msgstr "Belső vezérlőprogram BIOS-ának régiója"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Descriptor"
-msgstr "Belső vezérlőprogram BIOS-ának leírója"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Rendszerindítás előtti közvetlen memória hozzáférés elleni védelem"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard által ellenőrzött rendszerindítás"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM védett"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard hibairányelv"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard biztosíték"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET engedélyezve"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET aktív"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Titkosított memória"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU védelem"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux Kernel zárlat"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linux Kernel ellenőrzés"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux cserehely"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-#| msgid "Suspend"
-msgid "Suspend To RAM"
-msgstr "Felfüggesztés a memóriába"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-#| msgid "Suspend"
-msgid "Suspend To Idle"
-msgstr "Felfüggesztés üresjáratba"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI platformkulcs"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI biztonságos rendszerindítás"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-#| msgid "Configuration"
-msgid "TPM Platform Configuration"
-msgstr "TPM platformbeállítás"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM újjáépítés"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM 2.0-s verzió"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel Management Engine gyártói mód"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Intel Management Engine felülbírálás"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Intel Management Engine verziója"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-#| msgid "Software Updates"
-msgid "Firmware Updates"
-msgstr "Belső vezérlőprogram frissítések"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-#| msgid "Firmware Version"
-msgid "Firmware Attestation"
-msgstr "Belső vezérlőprogram tanúsítás"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-#| msgid "Firmware Version"
-msgid "Firmware Updater Verification"
-msgstr "Belső vezérlőprogram frissítőjének ellenőrzése"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Platform hibakeresése"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Processzor biztonsági ellenőrzései"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD visszaállítási védelem"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-#| msgid "Firmware Version"
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD belső vezérlőprogram visszajátszási védelem"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-#| msgid "Firmware Version"
-msgid "AMD Firmware Write Protection"
-msgstr "AMD belső vezérlőprogram írásvédelme"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Biztosított platform"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Érvényes"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-#| msgid "Not calibrated"
-msgid "Not Valid"
-msgstr "Nem érvényes"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-#| msgid "Enabled"
-msgid "Not Enabled"
-msgstr "Nincs engedélyezve"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-#| msgid "SIM Locked"
-msgid "Locked"
-msgstr "Zárolva"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-#| msgid "SIM Locked"
-msgid "Not Locked"
-msgstr "Nincs zárolva"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Titkosított"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-#| msgid "Not calibrated"
-msgid "Not Encrypted"
-msgstr "Nem titkosított"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Fertőzött"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-#| msgid "Not calibrated"
-msgid "Not Tainted"
-msgstr "Nem fertőzött"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-#| msgid "Sound"
-msgid "Found"
-msgstr "Található"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-#| msgid "Not found"
-msgid "Not Found"
-msgstr "Nem található"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-#| msgctxt "print job"
-#| msgid "Aborted"
-msgid "Supported"
-msgstr "Támogatott"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-#| msgid "No Thunderbolt Support"
-msgid "Not Supported"
-msgstr "Nem támogatott"
-
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
-#| msgid "Security"
 msgid "Device Security"
 msgstr "Eszközbiztonság"
 
@@ -2409,7 +1189,6 @@ msgstr "Eszközbiztonság"
 msgid "Host firmware security status"
 msgstr "Gazda belső vezérlőprogramjának biztonsági állapota"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2417,50 +1196,6 @@ msgid ""
 msgstr ""
 "képernyő;zárolás;diagnosztika;összeomlás;magán;privát;legutóbbi;nemrégi;"
 "ideiglenes;temp;index;név;hálózat;azonosság;identitás;adatvédelem;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Ismeretlen"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64 bites"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32 bites"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Ismeretlen"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-#| msgid "Unavailable"
-msgid "Not Available"
-msgstr "Nem érhető el"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Rendszerlogó"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2498,7 +1233,6 @@ msgstr "Operációs rendszer neve"
 
 #. translators: this field contains the distro build ID
 #: panels/info-overview/cc-info-overview-panel.ui:107
-#| msgid "%s; Build ID: %s"
 msgid "OS Build ID"
 msgstr "Operációs rendszer összeállítás-azonosítója"
 
@@ -2512,7 +1246,6 @@ msgstr "GNOME verzió"
 
 #. translators: this is a placeholder while the GNOME version is being fetched
 #: panels/info-overview/cc-info-overview-panel.ui:125
-#| msgid "Unlocking…"
 msgid "Loading…"
 msgstr "Betöltés…"
 
@@ -2541,7 +1274,6 @@ msgstr ""
 "tekintik meg, vagy Bluetooth eszközökkel akarják párosítani."
 
 #: panels/info-overview/cc-info-overview-panel.ui:196
-#| msgid "Device Name"
 msgid "Device name"
 msgstr "Eszköz neve"
 
@@ -2557,11 +1289,6 @@ msgstr "Névjegy"
 msgid "View information about your system"
 msgstr "Információk megjelenítése a rendszeréről"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2640,6 +1367,12 @@ msgstr "Parancsikonok"
 msgid "Launch help browser"
 msgstr "Súgóböngésző indítása"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Beállítások"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Számológép indítása"
@@ -2661,7 +1394,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Keresés"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Rendszer"
 
@@ -2710,15 +1443,6 @@ msgstr "Szövegméret csökkentése"
 msgid "High contrast on or off"
 msgstr "Nagy kontraszt be- vagy kikapcsolása"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nem találhatók bemeneti források"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Egyéb"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Bemeneti forrás hozzáadása"
@@ -2732,7 +1456,6 @@ msgid "No input source selected"
 msgstr "Nincs kiválasztva bemeneti forrás"
 
 #: panels/keyboard/cc-input-row.ui:20
-#| msgid "Options…"
 msgid "Options"
 msgstr "Beállítások"
 
@@ -2752,107 +1475,9 @@ msgstr "Beállítások"
 msgid "View Keyboard Layout"
 msgstr "Billentyűzetkiosztás megtekintése"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Eltávolítás"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Egyéni gyorsbillentyűk"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Alternatív karakterek billentyű"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Az alternatív karakterek billentyű további karakterek bevitelére "
-"használható. Ezek néha harmadik lehetőségként vannak felfestve a "
-"billentyűzetre."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Bal Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Jobb Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Bal Szuper"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Jobb Szuper"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menügomb"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Jobb Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Kombináló billentyű"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"A kombináló billentyűvel számos karakter beírható. A használatához nyomja "
-"meg a kombináló billentyűt, majd írjon be egy karaktersorozatot. Például a "
-"kombináló billentyű után a <b>C</b> és az <b>o</b> a <b>©</b> karaktert írja "
-"be, az <b>a</b> után a <b>'</b> az <b>á</b> betűt írja be."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"A bemeneti források a(z) %s gyorsbillentyűvel válthatóak át.\n"
-"Ezt a gyorsbillentyűk beállításaiban lehet megváltoztatni."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2883,45 +1508,21 @@ msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Módok a szimbólumok és betűváltozatok beírására a billentyűzet segítségével."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternatív karakterek billentyű"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Kombináló billentyű"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Gyorsbillentyűk"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Gyorsbillentyűk megtekintése és testreszabása"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d módosítva"
-msgstr[1] "%d módosítva"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Minden gyorsbillentyű visszaállítása?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"A gyorsbillentyűk visszaállítása az egyéni gyorsbillentyűket is érintheti. "
-"Ez nem vonható vissza."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Mégse"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Összes visszaállítása"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2932,17 +1533,14 @@ msgid "Reset all shortcuts to their default keybindings"
 msgstr "Az összes gyorsbillentyű visszaállítása az alapértelmezett értékekre"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
-#| msgid "_Action:"
 msgid "Section"
 msgstr "Szakasz"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
-#| msgid "Shortcut"
 msgid "Shortcuts"
 msgstr "Gyorsbillentyűk"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
-#| msgid "Add Shortcut"
 msgid "Add a shortcut"
 msgstr "Gyorsbillentyű hozzáadása"
 
@@ -2964,49 +1562,17 @@ msgstr "Gyorsbillentyű hozzáadása"
 msgid "No keyboard shortcut found"
 msgstr "Nem található gyorsbillentyű"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"A(z) %s már használatban van ennél: %s. Ha lecseréli, akkor a(z) %s "
-"letiltásra kerül"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Adja meg az új gyorsbillentyűt"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Egyéni gyorsbillentyű beállítása"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Gyorsbillentyű beállítása"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Adja meg az új gyorsbillentyűt a(z) %s megváltoztatásához."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Egyéni gyorsbillentyű hozzáadása"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
-#| msgid "Remove"
 msgid "_Remove"
 msgstr "_Eltávolítás"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
-#| msgid "Replace"
 msgid "Re_place"
 msgstr "_Csere"
 
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Beállítás"
 
@@ -3044,6 +1610,11 @@ msgstr "Nincs"
 msgid "Reset the shortcut to its default value"
 msgstr "A gyorsbillentyű visszaállítása az alapértelmezett értékre"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Nyomtató használata alapértelmezetten"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Billentyűzet"
@@ -3056,7 +1627,6 @@ msgstr ""
 "Gyorsbillentyűk módosítása és gépelési beállítások megadása, "
 "billentyűzetkiosztások és bemeneti források"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3099,7 +1669,6 @@ msgstr "Egyetlen alkalmazás sem kérte a helyadatok elérését"
 msgid "Protect your location information"
 msgstr "A helyadatai védelme"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "hely;gps;személyes;adatvédelem;"
@@ -3134,7 +1703,6 @@ msgstr "Egyetlen alkalmazás sem kérte a mikrofon elérését"
 msgid "Protect your conversations"
 msgstr "A beszélgetései védelme"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofon;felvétel;alkalmazás;adatvédelem;"
@@ -3164,82 +1732,139 @@ msgstr "Bal"
 msgid "Right"
 msgstr "Jobb"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Keresési helyek"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Egér"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Egér sebessége"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Természetes görgetés"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Szakasz"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "A görgetés a tartalmat mozgatja, nem a nézetet."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "A görgetés a tartalmat mozgatja, nem a nézetet."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktív"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Érintőtábla"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Érintőtábla sebessége"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Koppintás a kattintáshoz"
 
-#: panels/mouse/cc-mouse-panel.ui:150
-#| msgid "Tap to Click"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Koppintás a kattintáshoz"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Kétujjas görgetés"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Érintőtábla sebessége"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Görgetés a szélen"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Kétoldalas"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Próbáljon kattintani, duplán kattintani, görgetni"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Öt kattintás, ez a GEGL ideje!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dupla kattintás, elsődleges gomb"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Egy kattintás, elsődleges gomb"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dupla kattintás, középső gomb"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Egy kattintás, középső gomb"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dupla kattintás, másodlagos gomb"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Egy kattintás, másodlagos gomb"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3251,7 +1876,6 @@ msgid ""
 msgstr ""
 "Egér vagy érintőtábla érzékenységének, bal vagy jobb kezességének módosítása"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3334,34 +1958,22 @@ msgstr "Többfeladatos munkavégzés"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "A hatékony többfeladatos munkavégzés beállításainak kezelése"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-#| msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
-"Többfeladatos;Termelékenység;Produktivitás;Testreszabás;Személyre"
-" szabás;Asztal;Forró sarok;Munkaterületek;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Hoppá, valami elromlott. Lépjen kapcsolatba a szoftver szállítójával."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "A Hálózatkezelőnek futnia kell."
+"Többfeladatos;Termelékenység;Produktivitás;Testreszabás;Személyre szabás;"
+"Asztal;Forró sarok;Munkaterületek;"
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Egyéb eszközök"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
 #: panels/network/cc-network-panel.ui:42
-#| msgid "Add new connection"
 msgid "Add connection"
 msgstr "Kapcsolat hozzáadása"
 
@@ -3369,59 +1981,16 @@ msgstr "Kapcsolat hozzáadása"
 msgid "Not set up"
 msgstr "Nincs beállítva"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Nem biztonságos hálózat (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Biztonságos hálózat (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Biztonságos hálózat (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Biztonságos hálózat (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Biztonságos hálózat"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Kapcsolódva"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Beállítások…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"A hotspot bekapcsolása le fogja választani a(z) %s Wi-Fi hálózatról, és nem "
-"lesz lehetséges elérni az internetet Wi-Fi használatával."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Legalább 8 karakter szükséges"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3472,20 +2041,6 @@ msgstr "Jelszó automatikus előállítása"
 msgid "_Turn On"
 msgstr "_Bekapcsolás"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Leállítja a hotspotot, és leválasztja a felhasználókat?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "H_otspot leállítása"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Repülési üzemmód"
@@ -3531,89 +2086,13 @@ msgstr "Látható hálózatok"
 msgid "NetworkManager needs to be running"
 msgstr "A Hálózatkezelőnek futnia kell"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Hoppá, valami elromlott. Lépjen kapcsolatba a szoftver szállítójával."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _biztonság"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Biztonság"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Megőrzés"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Állandó"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Véletlen"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabil"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Az itt megadott MAC-cím lesz használva hardvercímként annál a hálózati "
-"eszköznél, amelyen ez a kapcsolat aktiválva van. Ez a funkció MAC-cím "
-"klónozás vagy hamisítás néven ismert. Példa: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "%d. profil"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Javított megnyitás"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nincs"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Soha"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3622,183 +2101,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i napja"
 msgstr[1] "%i napja"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2,4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2,4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nincs"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Gyenge"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Jó"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Kitűnő"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4-cím"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6-cím"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP-cím"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Kapcsolat elfelejtése"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Kapcsolatprofil eltávolítása"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "VPN eltávolítása"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Részletek"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatikus"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Személyazonosság"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Cím törlése"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Útvonal törlése"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Nincs"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128 bites kulcs (Hex vagy ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128 bites jelmondat"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dinamikus WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA és WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA és WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3809,8 +2111,20 @@ msgstr "Jelerősség"
 msgid "Link speed"
 msgstr "Kapcsolat sebessége"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Biztonság"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4-cím"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-cím"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hardvercím"
 
@@ -3819,12 +2133,17 @@ msgid "Supported Frequencies"
 msgstr "Támogatott frekvenciák"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Alapértelmezett útvonal"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3888,7 +2207,7 @@ msgstr "Csak közvetlen kapcsolat"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Kézi"
 
@@ -3932,9 +2251,8 @@ msgstr "Átjáró"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automatikus"
 
@@ -3987,90 +2305,9 @@ msgstr "Automatikus, csak DHCP"
 msgid "Prefix"
 msgstr "Előtag"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "A kapcsolatszerkesztő megnyitása sikertelen"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Új profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Érvénytelen beállítás (%s): %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-#| msgid "All Settings"
-msgid "Invalid setting %s"
-msgstr "Érvénytelen beállítás: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importálás fájlból…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "VPN hozzáadása"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Bi_ztonság"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Nem lehet importálni a VPN kapcsolatot"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"A fájl („%s”) nem olvasható vagy nem tartalmaz ismert VPN "
-"kapcsolatinformációkat\n"
-"\n"
-"Hiba: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Válassza ki az importálandó fájlt"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Már létezik „%s” nevű fájl."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Csere"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Le kívánja cserélni a(z) %s fájlt a mentendő VPN kapcsolatra?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Nem lehet exportálni a VPN kapcsolatot"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"A VPN kapcsolat („%s”) nem exportálható ide: %s.\n"
-"\n"
-"Hiba: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "VPN kapcsolat exportálása"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4084,100 +2321,37 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "BSS_ID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Hálózat"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Internetkapcsolatok beállítása"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Hálózat;IP;LAN;Proxy;WAN;Széles sáv;Szélessáv;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Wi-Fi hálózati kapcsolat beállítása"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Hálózat;Vezeték nélküli;Wi-Fi;Wifi;IP;LAN;Széles sáv;Szélessáv;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "soha"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "ma"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "tegnap"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Utolsó használat"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Vezetékes"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Új kapcsolat hozzáadása"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"A kijelölt hálózatok adatai elvesznek, beleértve a jelszavakat és az egyedi "
-"beállításokat is."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Elfelejtés"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Ismert Wi-Fi hálózatok"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Felejtse el"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "A rendszer házirendje megtiltja a hotspotként való használatot"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "A vezeték nélküli eszköz nem támogatja a hotspot módot"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Az automatikus webproxy-felderítés akkor használatos, ha nincs megadva "
-"konfigurációs URL."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Ez nem javasolt nyilvános, nem biztonságos hálózatokon."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4185,8 +2359,6 @@ msgstr "Eszköz kikapcsolása"
 
 #: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
 #: panels/power/cc-power-profile-row.ui:21
-#| msgctxt "service is active"
-#| msgid "Active"
 msgid "Active"
 msgstr "Aktív"
 
@@ -4198,6 +2370,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Szolgáltató"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-cím"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4267,7 +2443,6 @@ msgid "Turn Wi-Fi off"
 msgstr "Wi-Fi kikapcsolása"
 
 #: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
-#| msgid "Options…"
 msgid "More options…"
 msgstr "További beállítások…"
 
@@ -4282,291 +2457,6 @@ msgstr "Wi-Fi hotspot be_kapcsolása…"
 #: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Ismert Wi-Fi hálózatok"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Ismeretlen állapot"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Felügyeletlen"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Nem érhető el"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Kapcsolódás"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Hitelesítés szükséges"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Bontás"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Kapcsolódás meghiúsult"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Ismeretlen állapot (hiányzik)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "A beállítás sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Az IP-beállítás sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Az IP-beállítás lejárt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Titkos információkra volt szükség, de nem lettek megadva"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "A 802.1x-kliens bontotta a kapcsolatot"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "A 802.1x-kliens beállítása meghiúsult"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "A 802.1x-kliens sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "A 802.1x-kliens hitelesítése túl sokáig tartott"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "A PPP szolgáltatás nem indult el"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP szolgáltatás leválasztva"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "A PPP sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "A DHCP kliens nem indult el"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP-klienshiba"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "A DHCP-kliens sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "A megosztott kapcsolat szolgáltatás nem indult el"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "A megosztott kapcsolat szolgáltatás sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Az AutoIP szolgáltatás nem indult el"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP szolgáltatáshiba"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Az AutoIP szolgáltatás sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "A vonal foglalt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Nincs tárcsahang"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Nem hozható létre hívás"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "A tárcsázási kérés túllépte az időkorlátot"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "A tárcsázási kísérlet meghiúsult"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "A modem előkészítése sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "A megadott APN kiválasztása meghiúsult"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Nem keres hálózatokat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Hálózatregisztráció megtagadva"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "A hálózatregisztráció túllépte az időkorlátot"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "A kért hálózaton való regisztráció sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "A PIN ellenőrzése sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Az eszközhöz firmware hiányozhat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "A kapcsolat eltűnt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "A meglévő kapcsolat felvéve"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Nem található modem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "A Bluetooth kapcsolódás sikertelen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "A SIM kártya nincs behelyezve"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "A SIM Pin szükséges"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "A SIM Puk szükséges"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "A SIM hibás"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Kapcsolódás függősége meghiúsult"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Hiányzó firmware"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kábel kihúzva"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "meghatározatlan hiba a 802.1X biztonságban (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "nincs fájl kiválasztva"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "meghatározatlan hiba az eap-method fájl ellenőrzése közben"
-
-#: panels/network/wireless-security/eap-method.c:394
-#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12 vagy PGP személyes kulcsok"
-
-#: panels/network/wireless-security/eap-method.c:397
-#| msgid "_User certificate"
-msgid "DER or PEM certificates"
-msgstr "DER vagy PEM tanúsítványok"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "hiányzó EAP-FAST PAC fájl"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC fájlok (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4616,14 +2506,6 @@ msgstr "Belső _hitelesítés"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Automatikus PA_C létesítés engedélyezése"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "hiányzó EAP-LEAP felhasználónév"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "hiányzó EAP-LEAP jelszó"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4649,15 +2531,6 @@ msgstr "Jels_zó"
 msgid "Sho_w password"
 msgstr "_Jelszó megjelenítése"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "érvénytelen EAP-PEAP CA tanúsítvány: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "érvénytelen EAP-PEAP CA tanúsítvány: nincs tanúsítvány megadva"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4679,7 +2552,6 @@ msgid "C_A certificate"
 msgstr "_CA tanúsítvány"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4694,63 +2566,6 @@ msgstr "CA tanúsítvány nem _szükséges"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_PEAP verzió"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "hiányzó EAP felhasználónév"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "hiányzó EAP jelszó"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "hiányzó EAP-TLS személyazonosság"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "érvénytelen EAP-TLS CA tanúsítvány: „%s”"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "érvénytelen EAP-TLS CA tanúsítvány: nincs tanúsítvány megadva"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "érvénytelen EAP-TLS személyes kulcs: „%s”"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "érvénytelen EAP-TLS felhasználói tanúsítvány: „%s”"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "A nem titkosított személyes kulcsok nem biztonságosak"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Úgy tűnik, hogy a kiválasztott személyes kulcsot nem védi jelszó. Ez "
-"lehetővé teszi a hitelesítési adatok kompromittálását. Válasszon jelszóval "
-"védett személyes kulcsot.\n"
-"\n"
-"Személyes kulcsát az OpenSSL segítségével teheti jelszóval védetté."
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Válassza ki a személyes tanúsítványát"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Válassza ki a személyes kulcsát"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4767,15 +2582,6 @@ msgstr "Személyes k_ulcs"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "S_zemélyes kulcs jelszava"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "érvénytelen EAP-TTLS CA tanúsítvány: „%s”"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "érvénytelen EAP-TTLS CA tanúsítvány: nincs tanúsítvány megadva"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4798,14 +2604,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Tartomány"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Ismeretlen hiba a 802.1X biztonság ellenőrzésekor"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4833,62 +2640,10 @@ msgstr "Védett EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Hitelesítés"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Fájl kiválasztása"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "hiányzó leap felhasználónév"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "hiányzó leap jelszó"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "A Wi-Fi jelszó hiányzik."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Típus"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "hiányzó wep-kulcs"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"érvénytelen wep-kulcs: egy %zu hosszú kulcsban csak hexadecimális számjegyek "
-"lehetnek"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"érvénytelen wep-kulcs: egy %zu hosszú kulcsban csak ascii karakterek lehetnek"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"érvénytelen wep-kulcs: hibás kulcshossz: %zu. A kulcs hossza 5/13 (ascii) "
-"vagy 10/26 lehet (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "érvénytelen wep-kulcs: a jelmondat nem lehet üres"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"érvénytelen wep-kulcs: a jelmondatnak 64 karakternél rövidebbnek kell lennie"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4913,20 +2668,6 @@ msgstr "Kul_cs megjelenítése"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP inde_x"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"érvénytelen wpa-psk: érvénytelen kulcshossz: %zu. [8,63] bájtnak, vagy 64 "
-"hexadecimális számjegynek kell lennie"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"érvénytelen wpa-psk: a 64 bájtos kulcs nem értelmezhető hexadecimálisként"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4981,27 +2722,9 @@ msgstr "_Zárolási képernyő értesítések"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Az értesítések megjelenítésének és tartalmuk beállítása"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Értesítések;Felugró sáv;Üzenet;Sáv;Tálca;Figyelmeztetés;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Egyéb"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s eltávolítva"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Hiba a fiók eltávolításakor"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -5010,7 +2733,6 @@ msgid "Undo"
 msgstr "Visszavonás"
 
 #: panels/online-accounts/cc-online-accounts-panel.ui:31
-#| msgid "Show system notifications."
 msgid "Close the notification"
 msgstr "Az értesítés bezárása"
 
@@ -5026,17 +2748,6 @@ msgstr "Nincs internetkapcsolat – csatlakozzon új online fiókok beállítás
 msgid "Add an account"
 msgstr "Fiók hozzáadása"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s fiók"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Fiók eltávolítása"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "On­line fi­ó­kok"
@@ -5045,10 +2756,6 @@ msgstr "On­line fi­ó­kok"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Kapcsolódás online fiókjaihoz, és felhasználási módjuk kiválasztása"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5056,10 +2763,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Csevegés;Chat;Naptár;E-mail;Levél;"
 "Levelezés;Névjegyek;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Ismeretlen idő"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5075,13 +2778,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i óra"
 msgstr[1] "%i óra"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s, %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5093,190 +2789,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "perc"
 msgstr[1] "perc"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s a teljes feltöltésig"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Figyelem: %s van hátra"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s van hátra"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Teljesen feltöltve"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Nem tölt"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Lemerült"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Töltés"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Kisülés"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Vezeték nélküli egér"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Vezeték nélküli billentyűzet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Szünetmentes tápegység (UPS)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Személyes digitális asszisztens"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobiltelefon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Médialejátszó"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Táblagép"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Számítógép"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Bemeneti eszköz játékokhoz"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Akkumulátor"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Elsődleges"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Extra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Akkumulátorok"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Ü_resjáratban"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Felfüggesztés"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Kikapcsolás"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hibernálás"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Ne tegyen semmit"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Akkumulátoron"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Ha csatlakoztatva van"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Soha"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automatikus felfüggesztés"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"A teljesítményközpontú mód átmenetileg letiltva a magas működési hőmérséklet "
-"miatt."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Ölben használat észlelve: a teljesítményközpontú mód átmenetileg nem érhető "
-"el. A helyreállításhoz helyezze stabil felületre az eszközt."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Teljesítményközpontú mód átmenetileg letiltva."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Alacsony töltés: energiatakarékos mód bekapcsolva. Az előző mód visszaáll, "
-"amint elég töltés lesz az akkumulátorban."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "A(z) „%s” aktiválta az energiatakarékos módot."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "A(z) „%s” aktiválta az teljesítményközpontú módot."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5337,6 +2849,15 @@ msgstr "100 perc"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 óra"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akkumulátor"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Eszközök"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5417,33 +2938,6 @@ msgstr "_Akkumulátoron"
 msgid "Delay"
 msgstr "Késleltetés"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Teljesítmény"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Magas teljesítmény és fogyasztás."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Kiegyensúlyozott"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Szokásos teljesítmény és fogyasztás."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Energiatakarékos"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Csökkentett teljesítmény és fogyasztás."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Energiagazdálkodás"
@@ -5454,7 +2948,6 @@ msgstr ""
 "Akkumulátorállapot megjelenítése és energiagazdálkodási beállítások "
 "módosítása"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5462,27 +2955,6 @@ msgid ""
 msgstr ""
 "Energia;Energiagazdálkodás;Alvás;Felfüggesztés;Hibernálás;Akkumulátor;Telep;"
 "Elsötétítés;Elhalványítás;Monitor;DPMS;Üresjárat;Energia;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "A(z) „%s” nyomtató törölve lett"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Az új nyomtató hozzáadása meghiúsult."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "A felület nem tölthető be: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Feloldás a nyomtatók hozzáadásához és a beállítások módosításához"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5494,7 +2966,6 @@ msgstr ""
 "Nyomtatók hozzáadása, nyomtatási feladatok megjelenítése és nyomtatás "
 "beállítása"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Nyomtató;Sor;Nyomtatás;Papír;Tinta;Festékkazetta;"
@@ -5502,8 +2973,6 @@ msgstr "Nyomtató;Sor;Nyomtatás;Papír;Tinta;Festékkazetta;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Nyomtató hozzáadása"
 
@@ -5544,28 +3013,6 @@ msgstr ""
 msgid "Username"
 msgstr "Felhasználónév"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s adatai"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Nem található megfelelő illesztőprogram"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Válasszon PPD fájlt"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript nyomtatóleíró fájlok (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
@@ -5575,9 +3022,7 @@ msgstr ""
 msgid "Location"
 msgstr "Hely"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Illesztőprogram"
 
@@ -5605,143 +3050,20 @@ msgstr "Válassza ki a nyomtató-illesztőprogramot"
 msgid "Loading drivers database…"
 msgstr "Illesztőprogram-adatbázis betöltése…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Mégse"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Kijelölés"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect nyomtató"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD nyomtató"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Egyoldalas"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Hosszú él (szabványos)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Rövid él (fordított)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Álló"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Fekvő"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Fordított fekvő"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Fordított álló"
-
-#: panels/printers/pp-job-row.c:55
-#| msgid "_Resume"
-msgid "Resume"
-msgstr "Folytatás"
-
-#: panels/printers/pp-job-row.c:55
-#| msgctxt "print job"
-#| msgid "Paused"
-msgid "Pause"
-msgstr "Szüneteltetés"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Függőben"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Szüneteltetve"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Hitelesítés szükséges"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Feldolgozás"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Leállítva"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Megszakítva"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Félbeszakítva"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Befejezve"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "A feladat áthelyezése a sor elejére"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u feladat hitelesítést igényel"
 msgstr[1] "%u feladat hitelesítést igényel"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s – Aktív feladatok"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Hitelesítési adatok megadása a következőről történő nyomtatáshoz: %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5769,322 +3091,17 @@ msgstr "_Hitelesítés"
 msgid "No Active Printer Jobs"
 msgstr "Nincsenek aktív nyomtatási feladatok"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Nyomtatókiszolgáló feloldása"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s feloldása."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Adja meg felhasználónevét és jelszavát a nyomtatók megjelenítéséhez ezen: %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Nyomtatók keresése"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Soros port"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Párhuzamos port"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Hely: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Cím: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "A kiszolgáló hitelesítést igényel"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Kétoldalas"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Papírtípus"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Papírforrás"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Kimeneti tálca"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Felbontás"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript előszűrés"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Oldalak laponként"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Kétoldalas"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Tájolás"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Általános"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Oldalbeállítás"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Telepíthető beállítások"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Feladat"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Képminőség"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Szín"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Befejezés"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Speciális"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Tesztoldal"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Tesztoldal"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Automatikus kiválasztás"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Nyomtató alapértelmezése"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Csak GhostScript betűkészletek beágyazása"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Átalakítás 1. PS szintre"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Átalakítás 2. PS szintre"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Nincs előszűrés"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Gyártó"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Nincsenek aktív feladatok"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u feladat"
 msgstr[1] "%u feladat"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Nyomtatófejek tisztítása"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "A festékkazetta kifogyóban"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "A festékkazetta kifogyott"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Az előhívó kifogyóban"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Az előhívó kifogyott"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "A tintapatron kifogyóban"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "A tintapatron kifogyott"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Fedél nyitva"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Ajtó nyitva"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Kevés a papír"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Kifogyott a papír"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Kikapcsolva"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Leállítva"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "A hulladékgyűjtő majdnem tele"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "A hulladékgyűjtő tele"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Az optikai fotovezető közel jár az élete végéhez"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Az optikai fotovezető már nem működik"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Kész"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Nem fogad feladatokat"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Feldolgozás"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6108,6 +3125,10 @@ msgstr "Nyomtatófejek tisztítása"
 msgid "Remove Printer"
 msgstr "Nyomtató eltávolítása"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nincsenek aktív feladatok"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6128,16 +3149,21 @@ msgid "Restart"
 msgstr "Újraindítás"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Nyomtató hozzáadása…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Nyomtató hozzáadása…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Nincsenek nyomtatók"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6145,7 +3171,6 @@ msgstr ""
 "Elnézést, a rendszer nyomtatószolgáltatása\n"
 "    nem tűnik elérhetőnek."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formátumok"
@@ -6173,16 +3198,6 @@ msgstr "Országokra és nyelvekre kereshet."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Előnézet"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Angolszász"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrikus"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6214,9 +3229,6 @@ msgid "Logout…"
 msgstr "Kijelentkezés…"
 
 #: panels/region/cc-region-panel.ui:45
-#| msgid ""
-#| "The language setting is used for interface text and web pages. Formats is "
-#| "used for numbers, dates, and currencies."
 msgid ""
 "The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
@@ -6225,20 +3237,24 @@ msgstr ""
 "használva. A formátumok a számokhoz, a dátumokhoz és a pénznemekhez vannak "
 "használva."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Az Ön fiókja"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Nyelv"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formátumok"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Bejelentkezési képernyő"
 
@@ -6250,99 +3266,9 @@ msgstr "Terület és nyelv"
 msgid "Select your display language and formats"
 msgstr "Válassza ki a felület nyelvét és az adatformátumokat"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Nyelv;kiosztás;billentyűzet;bevitel;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Kérdezze meg, mi a teendő"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Ne tegyen semmit"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Mappa megnyitása"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Egyéb média"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Válasszon alkalmazást CD-khez"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Válasszon alkalmazást videó DVD-khez"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Válassza ki a zenelejátszó csatlakoztatásakor futtatandó alkalmazást"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Válassza ki a fényképezőgép csatlakoztatásakor futtatandó alkalmazást"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Válasszon alkalmazást szoftver CD-khez"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "hang DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "üres Blu-Ray lemez"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "üres CD-lemez"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "üres DVD-lemez"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "üres HD DVD-lemez"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray videolemez"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "e-könyvolvasó"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD videolemez"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows-szoftver"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6393,7 +3319,6 @@ msgstr "Külső adathordozók"
 msgid "Configure Removable Media settings"
 msgstr "Külső adathordozók beállításai"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6402,116 +3327,6 @@ msgstr ""
 "eszköz;rendszer;információk;memória;processzor;verzió;alapértelmezett;"
 "alkalmazás;előnyben részesített;cd;dvd;usb;hang;videó;lemez;eltávolítható;"
 "cserélhető;média;automatikus futtatás;autorun;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Képernyő kikapcsol"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 másodperc"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 perc"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 perc"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 perc"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-#| msgctxt "blank_screen"
-#| msgid "5 minutes"
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 perc"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 perc"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 óra"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 perc"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 perc"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 perc"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 perc"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 perc"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 perc"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 perc"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 perc"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 perc"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Soha"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6551,11 +3366,16 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "É_rtesítések megjelenítése a zárolási képernyőn"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Zárolási képernyő értesítések"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Új _USB-s eszközök tiltása"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6563,32 +3383,25 @@ msgstr ""
 "Az új USB-s eszközök megakadályozása, hogy ne tudjanak kapcsolatba lépni a "
 "rendszerrel, ha a képernyő zárolt."
 
-#: panels/screen/cc-screen-panel.ui:108
-#| msgid "Privacy"
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Képernyő-adatvédelem"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Látószög korlátozása"
 
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Képernyő"
+
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
-#| msgid "Settings"
 msgid "Screen Settings"
 msgstr "Képernyő-beállítások"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "képernyő;zárolás;személyes;adatvédelem;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Válasszon régiót"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6619,10 +3432,6 @@ msgstr "Egyebek"
 msgid "Add Location"
 msgstr "Hely hozzáadása"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nem találhatók alkalmazások"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Alkalmazás keresése"
@@ -6649,97 +3458,13 @@ msgid ""
 msgstr ""
 "A Tevékenységek áttekintésben találatokat megjelenítő alkalmazások beállítása"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Keresés;Indexelés;Elrejtés;Adatvédelem;Találatok;Eredmények;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Nincs kiválasztott hálózat a megosztáshoz"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Hálózatok"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Be"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Ki"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Engedélyezve"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktív"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Válasszon mappát"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Hozzáadás"
-
-#: panels/sharing/cc-sharing-panel.c:736
-#| msgid "Media Sharing"
-msgid "Enable media sharing"
-msgstr "Médiamegosztás engedélyezése"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"A fájlmegosztás lehetővé teszi a Nyilvános mappájának megosztását másokkal a "
-"jelenlegi hálózaton a %s használatával."
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Ha a távoli bejelentkezés engedélyezett, akkor a távoli felhasználók a "
-"következő parancs használatával kapcsolódhatnak:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Személyes médiamegosztás engedélyezése"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-#| msgid "Device Name"
-msgid "Device name copied"
-msgstr "Eszköznév lemásolva"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Eszközcím lemásolva"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-#| msgid "Username"
-msgid "Username copied"
-msgstr "Felhasználónév lemásolva"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-#| msgid "Password"
-msgid "Password copied"
-msgstr "Jelszó lemásolva"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6850,9 +3575,6 @@ msgid "Encryption Fingerprint"
 msgstr "Titkosítás ujjlenyomata"
 
 #: panels/sharing/cc-sharing-panel.ui:435
-#| msgid ""
-#| "The encryption fingerprint can be seen in connecting clients and should "
-#| "be identical"
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
 "identical."
@@ -6876,7 +3598,6 @@ msgstr "Mappák"
 msgid "Control what you want to share with others"
 msgstr "Megosztások beállítása"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6894,16 +3615,11 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Hitelesítés szükséges a távoli bejelentkezés engedélyezéséhez vagy tiltásához"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Egyéni"
-
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
 msgstr "Kattintás"
 
 #: panels/sound/cc-alert-chooser.ui:20
-#| msgid "Sharing"
 msgid "String"
 msgstr "Karakterlánc"
 
@@ -6931,11 +3647,6 @@ msgstr "Hátsó"
 msgid "Front"
 msgstr "Első"
 
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s tesztelése"
-
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
 msgstr "A teszteléshez kattintson egy hangszóróra"
@@ -6945,7 +3656,6 @@ msgid "System Volume"
 msgstr "Rendszerhangerő"
 
 #: panels/sound/cc-sound-panel.ui:12
-#| msgid "System Volume"
 msgid "Master volume"
 msgstr "Fő hangerő"
 
@@ -6989,11 +3699,6 @@ msgstr "Hangerő"
 msgid "Alert Sound"
 msgstr "Riasztási hang"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Némítás"
@@ -7006,83 +3711,12 @@ msgstr "Hang"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Hangerő, bemenetek, kimenetek és riasztáshangok módosítása"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Kártya;Mikrofon;Hangerő;Elhalás;Egyensúly;Bluetooth;Fejhallgató;Audio;Hang;"
 "Kimenet;Bemenet;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Bontva"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Kapcsolódás"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Kapcsolódva"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Engedélyezési hiba"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Engedélyezés"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Csökkentett funkcionalitás"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Kapcsolódva és engedélyezve"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Ismeretlen"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Engedélyezve ekkor:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Kapcsolódva ekkor:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Bejegyezve ekkor:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Az eszköz engedélyezése meghiúsult: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Az eszköz elfelejtése meghiúsult: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7093,7 +3727,6 @@ msgstr[1] "%u egyéb eszköztől függ"
 
 #: panels/thunderbolt/cc-bolt-device-dialog.ui:43
 #: panels/thunderbolt/cc-bolt-panel.ui:41
-#| msgid "Show system notifications."
 msgid "Close notification"
 msgstr "Értesítés bezárása"
 
@@ -7117,56 +3750,6 @@ msgstr "Engedélyezés és kapcsolódás"
 msgid "Forget Device"
 msgstr "Eszköz elfelejtése"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Hiba"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Engedélyezve"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"A Thunderbolt alrendszer (boltd) nincs telepítve vagy rosszul van beállítva."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Közvetlen hozzáférés engedélyezése az olyan eszközökhöz, mint a dokkolók és "
-"külső GPU-k."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Csak USB és Display Port eszközök csatlakoztathatóak."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"A Thunderbolt nem észlelhető.\n"
-"Vagy hiányzik a rendszerből a Thunderbolt támogatás, vagy le lett tiltva a "
-"BIOS-ban, vagy nem támogatott biztonsági szintre van állítva a BIOS-ban."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "A Thunderbolt támogatás le lett tiltva a BIOS-ban."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "A Thunderbolt biztonsági szintje nem határozható meg."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Hiba a közvetlen módra váltáskor: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Nincs Thunderbolt támogatás"
@@ -7178,6 +3761,12 @@ msgstr "Nem sikerült kapcsolódni a thunderbolt alrendszerhez."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Közvetlen hozzáférés"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Közvetlen hozzáférés engedélyezése az olyan eszközökhöz, mint a dokkolók és "
+"külső GPU-k."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7195,7 +3784,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Thunderbolt eszközök kezelése"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;adatvédelem;"
@@ -7398,40 +3986,6 @@ msgid "Turn accessibility features on and off using the keyboard"
 msgstr ""
 "Akadálymentesítési szolgáltatások be- és kikapcsolása a billentyűzetről"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Alapértelmezett"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Közepes"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Nagy"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Nagyobb"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Legnagyobb"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d képpont"
-msgstr[1] "%d képpont"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Akadálymentesítés menü megjelenítése mindig"
@@ -7547,31 +4101,6 @@ msgstr "Teljes _képernyő megvillantása"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Teljes _ablak megvillantása"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Rövid"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ képernyő"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ képernyő"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ képernyő"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Hosszú"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7728,7 +4257,6 @@ msgstr "Színeffektusok"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "A látás, hallás, gépelés, mutatás és kattintás egyszerűbbé tétele"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7740,114 +4268,6 @@ msgstr ""
 "Képernyő;Olvasó;magas;szöveg;betű;méret;AccessX;Ragadós;Billentyűk;Lassú;"
 "Pattogó;Egér;Dupla;kattintás;Késleltetés;Sebesség;Kisegítő;Ismétlés;Villogás;"
 "vizuális;hallás;hang;írás;animációk;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 óra"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 nap"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 nap"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 nap"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 nap"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 nap"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 nap"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 nap"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 nap"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 nap"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Törölni kívánja az összes elemet a Kukából?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "A Kuka összes eleme véglegesen törölve lesz."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Kuka ürítése"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Törli az összes ideiglenes fájlt?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Minden ideiglenes fájl véglegesen törlésre kerül."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Ideiglenes fájlok törlése"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 nap"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 nap"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 nap"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Örökké"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7915,64 +4335,12 @@ msgstr "Fájlelőzmények és kuka"
 msgid "Don't leave traces"
 msgstr "Ne hagyjon nyomokat"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"használat;legutóbbi;előzmények;fájlok;átmeneti;tmp;személyes;adatvédelem;kuka;"
-"törlés;megtartás;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Egyeznie kell a bejelentkezés szolgáltatójának webcímével."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "A fiók hozzáadása sikertelen"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "A jelszavak nem egyeznek."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "A fiók regisztrálása sikertelen"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Nincs támogatott módszer a tartományban való hitelesítésre"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Nem sikerült a tartományhoz csatlakozni"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"A bejelentkezési név nem működik.\n"
-"Próbálja újra."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"A bejelentkezési jelszó nem működik.\n"
-"Próbálja újra."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Nem sikerült bejelentkezni a tartományba"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "A tartomány nem található. Lehet, hogy elgépelte?"
+"használat;legutóbbi;előzmények;fájlok;átmeneti;tmp;személyes;adatvédelem;"
+"kuka;törlés;megtartás;"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -8009,7 +4377,6 @@ msgid "Enterprise Login"
 msgstr "Vállalati bejelentkezés"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-#| msgid "User accounts which are managed by a company or organisation."
 msgid "User accounts which are managed by a company or organization."
 msgstr "Felhasználói fiókok, amelyeket egy vállalat vagy szervezet kezel."
 
@@ -8026,10 +4393,6 @@ msgstr ""
 "A vállalati bejelentkezés lehetővé teszi egy meglévő, központilag felügyelt "
 "felhasználói fiók használatát ezen az eszközön. A fiókot arra is "
 "használhatja, hogy céges erőforrásokhoz férjen hozzá az interneten."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "További képek tallózása"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8100,243 +4463,13 @@ msgstr "Ujjlenyomatok _törlése"
 msgid "Fingerprint Enroll"
 msgstr "Ujjlenyomat bevitele"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "az eszközt le kell foglalni a művelet elvégzéséhez"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "az eszközt már lefoglalta egy másik folyamat"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "nincs jogosultsága a művelet elvégzéséhez"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "nem lett lenyomat bevíve"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Nem sikerült kommunikálni az eszközzel a bevitel során"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Nem sikerült kommunikálni az ujjlenyomat-olvasóval"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Nem sikerült kommunikálni az ujjlenyomat-démonnal"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Az ujjlenyomatok felsorolása sikertelen: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "A mentett ujjlenyomatok törlése sikertelen: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Bal hüvelykujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Bal középső ujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Bal mutatóujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Bal gyűrűsujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Bal kisujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Jobb hüvelykujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Jobb középső ujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Jobb mutatóujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Jobb gyűrűsujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Jobb kisujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Ismeretlen ujj"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Kész"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Ujjlenyomatos eszköz leválasztva"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Ujjlenyomatos eszköz tárhelye megtelt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Az új ujjlenyomat bevitele sikertelen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "A bevitel elindítása sikertelen: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Az új ujjlenyomat bevitele sikertelen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "A bevitel leállítása sikertelen: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Ismételten emelje fel, majd helyezze az ujját az olvasóra az ujjlenyomat "
-"beviteléhez"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Ujj ú_jbóli bevitele…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Új ujjlenyomat leolvasása"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "A(z) %s ujjlenyomatos eszköz kiadása sikertelen: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Probléma az eszköz olvasásakor"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "A(z) %s ujjlenyomatos eszköz megszerzése sikertelen: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Az ujjlenyomatos eszközök lekérése sikertelen: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Ezen a héten"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Múlt héten"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b. %-e."
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%Y. %b. %-e."
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s – %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%H:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Munkamenet befejeződött"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Munkamenet elkezdődött"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s – Fiókaktivitás"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
-#| msgid "Previous track"
 msgid "Previous"
 msgstr "Előző"
 
 #: panels/user-accounts/cc-login-history-dialog.ui:40
-#| msgid "_Next"
 msgid "Next"
 msgstr "Következő"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Válasszon másik jelszót."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Írja be újra jelenlegi jelszavát."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "A jelszót nem sikerült megváltoztatni"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8358,6 +4491,10 @@ msgstr "Új jelszó"
 msgid "Confirm Password"
 msgstr "Jelszó megerősítése"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "A jelszavak nem egyeznek."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "A felhasználó módosíthatja a jelszót a következő bejelentkezéskor"
@@ -8365,134 +4502,6 @@ msgstr "A felhasználó módosíthatja a jelszót a következő bejelentkezésko
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Jelszó beállítása most"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Ilyen típusú tartományhoz nem lehet automatikusan csatlakozni"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Nem található ilyen tartomány vagy zóna"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Nem lehet bejelentkezni %s néven a(z) %s tartományba"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Érvénytelen jelszó, próbálja újra"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Nem lehet csatlakozni a(z) %s tartományhoz: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "A felhasználó törlése meghiúsult"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "A távmenedzselt felhasználó visszavonása meghiúsult"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Nem törölheti saját fiókját."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s még be van jelentkezve"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"A bejelentkezett felhasználók törlése a rendszert inkonzisztens állapotban "
-"hagyhatja."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Meg szeretné tartani %s fájljait?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Felhasználói fiók törlésekor lehetősége van a saját könyvtár, a levelezési "
-"várólista és az ideiglenes fájlok megtartására."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "Fájlok _törlése"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "Fájlok _megtartása"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Biztosan vissza szeretné vonni a távmenedzselt %s fiókját?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Törlés"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Fiók letiltva"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Következő belépéskor állítandó be"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Nincs"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Bejelentkezve"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "A fiókszolgáltatás nem érhető el"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Győződjön meg róla, hogy az AccountService telepítve van és fut."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Ezt a panelt fel kell oldani a beállítás megváltoztatásához"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Kijelölt felhasználói fiók törlése"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"A kijelölt felhasználói fiók törléséhez\n"
-"először kattintson a * ikonra"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Feloldás a felhasználók hozzáadásához és a beállítások módosításához"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8516,12 +4525,10 @@ msgid "Edit avatar"
 msgstr "Profilkép szerkesztése"
 
 #: panels/user-accounts/cc-user-panel.ui:152
-#| msgid "Full access"
 msgid "Full name"
 msgstr "Teljes név"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Szerkesztés"
 
@@ -8583,7 +4590,6 @@ msgstr "Feloldás felhasználói fiók hozzáadásához."
 msgid "Add or remove users and change your password"
 msgstr "Felhasználók hozzáadása vagy eltávolítása és jelszómódosítás"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8628,178 +4634,6 @@ msgstr "Felhasználói fiókok kezelése"
 msgid "Authentication is required to change user data"
 msgstr "Hitelesítés szükséges a felhasználói adatok módosításához"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Az új jelszó nem lehet azonos a régivel."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Próbáljon megváltoztatni néhány betűt és számot."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Próbálja jobban megváltoztatni a jelszót."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "A felhasználói neve nélkül a jelszava erősebb."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Próbálja meg kihagyni a felhasználónevét a jelszóból."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Próbálja meg kerülni a jelszóban lévő szavak egy részét."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Próbálja meg kerülni a gyakori szavakat."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Próbálja meg kerülni a meglévő szavak átrendezését."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Próbáljon meg több számot használni."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Próbáljon meg több nagybetűt használni."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Próbáljon meg több kisbetűt használni."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Próbáljon meg több speciális karaktert, például írásjeleket használni."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Próbálja meg betűk, számok és írásjelek keverékét használni."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Próbálja meg kerülni ugyanannak a karakternek az ismétlését."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Próbálja meg kerülni ugyanazon típusú karakterek ismétlését: keverjen "
-"betűket, számokat és írásjeleket."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Próbálja meg kerülni az 1234 vagy abcd-szerű egyszerű sorozatokat."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"A jelszónak hosszabbnak kell lennie. Próbáljon meg több betűt, számot és "
-"írásjelet hozzáadni."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Használjon vegyesen kis- és nagybetűket, és tegyen közéjük egy-két számot is."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Több betű, szám és írásjel hozzáadása erősebbé fogja tenni a jelszót."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "A hitelesítés meghiúsult"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Az új jelszó túl rövid"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Az új jelszó túl egyszerű"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "A régi és az új jelszó túlságosan hasonlít egymáshoz"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Az új jelszót nemrég használta."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-"Az új jelszónak számokat vagy speciális karaktereket is tartalmaznia kell"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "A régi és az új jelszó ugyanaz"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "A jelszava megváltozott az első hitelesítés óta."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Az új jelszó nem tartalmaz elég eltérő karaktert"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Ismeretlen hiba"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"A felhasználónév általában csak a-z közötti kisbetűkből, számjegyekből és a "
-"következő karakterekből állhat: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Ez a felhasználónév nem érhető el. Próbáljon egy másikat."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "A felhasználónév túl hosszú."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8832,53 +4666,10 @@ msgstr "Érintse meg a céljelölőket a képernyőn a táblagép kalibrálásá
 msgid "Mis-click detected, restarting…"
 msgstr "Félrekattintás észlelve, újraindítás…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "%d. gomb"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Alkalmazás által meghatározott"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Billentyűleütés küldése"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Monitorváltás"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Képernyőn lévő súgó megjelenítése"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Laptop paneljéhez csatolt rajztábla"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Külső kijelzőre csatolt rajztábla"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Külső rajztábla eszköz"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
-#| msgid "External tablet device"
 msgid "External pad device"
 msgstr "Külső rajztábla eszköz"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Összes kijelző"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8930,12 +4721,10 @@ msgstr "Hegy nyomásérzékenysége"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:21
 #: panels/wacom/cc-wacom-stylus-page.ui:82
-#| msgid "_Software"
 msgid "Soft"
 msgstr "Lágy"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:35
-#| msgid "Standard stylus with pressure"
 msgid "Stylus tip pressure"
 msgstr "Toll hegyének nyomása"
 
@@ -8964,7 +4753,6 @@ msgid "Eraser Pressure Feel"
 msgstr "Radír nyomásérzékenysége"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:96
-#| msgid "Eraser Pressure Feel"
 msgid "Eraser pressure"
 msgstr "Radír nyomása"
 
@@ -8980,22 +4768,6 @@ msgstr "Jobb egérgombkattintás"
 msgid "Forward"
 msgstr "Tovább"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Festékszóró toll nyomás, dőlés és integrált csúszka funkcióval"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Festékszóró toll nyomás, dőlés és forgatás funkcióval"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Szabványos toll nyomás és dőlés funkcióval"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Szabványos toll nyomás funkcióval"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom rajztábla"
@@ -9005,54 +4777,96 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Rajztáblák gombleképezéseinek beállítása és a toll érzékenységének módosítása"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Rajztábla;Wacom;Toll;Radír;Egér;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Új gyorsbillentyű…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Szim_ulált másodlagos kattintás"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows-szoftver"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "A festékkazetta kifogyóban"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Másodlagos kattintás késleltetése"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows-szoftver"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "A hatékony többfeladatos munkavégzés beállításainak kezelése"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Hozzáférési pontok"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Hozzáadás"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "M_entés"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Művelet megszakítva"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Hiba:</b> Hozzáférés megtagadva a beállítások módosításakor"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Hiba:</b> Mobilfelszerelést érintő hiba"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Nem regisztrált"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Regisztrált"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Barangolás"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Keresés"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Megtagadva"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9082,238 +4896,13 @@ msgstr "Saját szám"
 msgid "Device Details"
 msgstr "Eszköz adatai"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Gyártó"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Firmware verzió"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Csak 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Csak 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Csak 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-#| msgid "2G Only"
-msgid "5G Only"
-msgstr "Csak 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (előnyben részesített), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-#| msgid "2G, 3G (Preferred), 4G"
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (előnyben részesített), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-#| msgid "2G (Preferred), 3G, 4G"
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (előnyben részesített), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-#| msgid "2G, 3G, 4G"
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (előnyben részesített), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (előnyben részesített), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-#| msgid "3G, 4G (Preferred)"
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-#| msgid "3G, 4G (Preferred)"
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (előnyben részesített), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-#| msgid "3G (Preferred), 4G"
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (előnyben részesített), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-#| msgid "3G, 4G"
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-#| msgid "2G, 3G (Preferred), 4G"
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (előnyben részesített), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-#| msgid "2G (Preferred), 3G, 4G"
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (előnyben részesített), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-#| msgid "2G, 3G, 4G"
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-#| msgid "2G, 3G (Preferred), 4G"
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (előnyben részesített), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-#| msgid "2G (Preferred), 3G, 4G"
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (előnyben részesített), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-#| msgid "2G, 3G, 4G"
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (előnyben részesített), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (előnyben részesített), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (előnyben részesített), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-#| msgid "2G, 4G (Preferred)"
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-#| msgid "2G (Preferred), 4G"
-msgid "2G (Preferred), 5G"
-msgstr "2G (előnyben részesített), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-#| msgid "2G, 4G"
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-#| msgid "3G, 4G (Preferred)"
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-#| msgid "3G (Preferred), 4G"
-msgid "3G (Preferred), 5G"
-msgstr "3G (előnyben részesített), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-#| msgid "3G, 4G"
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-#| msgid "3G, 4G (Preferred)"
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (előnyben részesített)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-#| msgid "3G (Preferred), 4G"
-msgid "4G (Preferred), 5G"
-msgstr "4G (előnyben részesített), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Ismeretlen"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "SIM-kártya feloldása"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Feloldás"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Adja meg a PIN-kódot a(z) %d. SIM-kártyához"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Adja meg a PIN-kódot a SIM-kártyája feloldásához"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Adja meg a PUK-kódot a(z) %d. SIM-kártyához"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Adja meg a PUK-kódot a SIM-kártyája feloldásához"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9328,26 +4917,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "%u próbálkozása maradt"
 msgstr[1] "%u próbálkozása maradt"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Hibás jelszó lett megadva."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "A PUK-kódnak 8 számjegyűnek kell lennie"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Új PIN-kód megadása"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "A PIN-kódnak 4-8 számjegyűnek kell lennie"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Feloldás…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9405,96 +4974,6 @@ msgstr "SIM zárolása PIN-kóddal"
 msgid "M_odem Details"
 msgstr "M_odem részletei"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Telefonhiba"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Nincs kapcsolat a telefon felé"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "A művelet nem engedélyezett"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "A művelet nem támogatott"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "A SIM-kártya nincs behelyezve"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "A SIM-kártya PIN-kódja szükséges"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "A SIM-kártya PUK-kódja szükséges"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM-kártya hiba"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "A SIM-kártya foglalt"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Helytelen jelszó"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "A SIM-kártya PIN2-kódja szükséges"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "A SIM-kártya PUK2-kódja szükséges"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Nem található"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Nincs hálózati szolgáltatás"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Hálózat időtúllépése"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "A GPRS szolgáltatások nem engedélyezettek"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "A barangolás nem engedélyezett ezen a területen"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Meghatározatlan GPRS hiba"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-#| msgctxt "Thunderbolt Device Status"
-#| msgid "Error"
-msgid "No Error"
-msgstr "Nincs hiba"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Művelet megszakítva"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Hozzáférés megtagadva"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Ismeretlen hiba"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Hálózati mód"
@@ -9510,11 +4989,6 @@ msgstr "Válasszon hálózatot"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Hálózati szolgáltatók frissítése"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "%d. SIM"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9575,7 +5049,6 @@ msgstr "Mobilhálózat"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Telefónia és mobil adatkapcsolatok beállítása"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "mobil;wwan;telefónia;sim;telefon;"
@@ -9592,41 +5065,13 @@ msgstr "A Beállítások az elsődleges felület a rendszer beállításához."
 msgid "The GNOME Project"
 msgstr "A GNOME projekt"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Verziószám kiírása"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Részletes mód engedélyezése"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Karakterlánc keresése"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Lehetséges panelnevek felsorolása és kilépés"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Megjelenítendő panel"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENTUM…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Beállítások kategóriái"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Adatvédelem"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Elérhető panelek:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9684,7 +5129,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Keresés megszakítása"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Tulajdonságok;Beállítások;"
@@ -9726,8 +5170,6 @@ msgstr ""
 "Egy elemhármas, amely az alkalmazásablak kezdeti szélességét, magasságát és "
 "maximalizálási állapotát tartalmazza."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9735,8 +5177,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u kimenet"
 msgstr[1] "%u kimenet"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9744,6 +5184,3217 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u bemenet"
 msgstr[1] "%u bemenet"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Rendszerhangok"
+#~ msgid "System Bus"
+#~ msgstr "Rendszerbusz"
+
+#~ msgid "Full access"
+#~ msgstr "Teljes hozzáférés"
+
+#~ msgid "Session Bus"
+#~ msgstr "Munkamenetbusz"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Teljes hozzáférés a /dev-hez"
+
+#~ msgid "Has network access"
+#~ msgstr "Van hálózati kapcsolata"
+
+#~ msgid "Home"
+#~ msgstr "Saját mappa"
+
+#~ msgid "Read-only"
+#~ msgstr "Csak olvasható"
+
+#~ msgid "File System"
+#~ msgstr "Fájlrendszer"
+
+#~ msgid "Can change settings"
+#~ msgstr "Módosíthatja a beállításokat"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "A(z) %s ezket a jogosultságokat tartalmazza beépítve. Ezek nem "
+#~ "módosíthatóak. Ha zavarják ezek a jogosultságok, akkor fontolja meg az "
+#~ "alkalmazás eltávolítását."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "Az alkalmazás által megnyitott %u fájl- és hivatkozástípus"
+#~ msgstr[1] "Az alkalmazás által megnyitott %u fájl- és hivatkozástípus"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> van használatban a fájlok és hivatkozások alábbi típusainak "
+#~ "megnyitásához."
+
+#, c-format
+#~| msgid "%s of disk space used"
+#~ msgid "%s of disk space used."
+#~ msgstr "%s lemezterület van használatban."
+
+#~ msgid "Select a picture"
+#~ msgstr "Fénykép kiválasztása"
+
+#~ msgid "_Open"
+#~ msgstr "_Megnyitás"
+
+#~ msgid "multiple sizes"
+#~ msgstr "több méret"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Nincs asztalháttér"
+
+#~ msgid "Current background"
+#~ msgstr "Jelenlegi háttér"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Helyezze a kalibrálóeszközt a négyzetre, és nyomja meg a „Kezdés” gombot"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Vigye a kalibrálóeszközt a kalibrálási pozícióba, és nyomja meg a "
+#~ "„Tovább” gombot"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Vigye a kalibrálóeszközt a felület pozícióba, és nyomja meg a „Tovább” "
+#~ "gombot"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Zárja le a laptop fedelét"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Belső hiba történt, a folytatás nem lehetséges."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "A kalibráláshoz szükséges eszközök nincsenek telepítve."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "A profil nem állítható elő."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "A cél fehér pont nem szerezhető be."
+
+#~ msgid "Complete!"
+#~ msgstr "Kész!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "A kalibrálás sikertelen!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Eltávolíthatja a kalibrálóeszközt."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ne zavarja a kalibrálóeszközt a folyamat során"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Laptop képernyő"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Beépített webkamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s monitor"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s szkenner"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s fényképezőgép"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s nyomtató"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s webkamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Színkezelés bekapcsolása ehhez: %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Színprofilok megjelenítése ehhez: %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nem kalibrált"
+
+#~ msgid "Default: "
+#~ msgstr "Alapértelmezett: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Színtér: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Tesztprofil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Válasszon ICC profilfájlt"
+
+#~ msgid "_Import"
+#~ msgstr "_Importálás"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Támogatott ICC profilok"
+
+#~ msgid "All files"
+#~ msgstr "Minden fájl"
+
+#~ msgid "Save Profile"
+#~ msgstr "Profil mentése"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Színprofil létrehozása a kiválasztott eszközhöz"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "A mérőkészülék nem található. Ellenőrizze, hogy be van-e kapcsolva, és "
+#~ "megfelelően van-e csatlakoztatva."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "A mérőkészülék nem támogatja a nyomtatóprofilozást."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Az eszköztípus jelenleg nem támogatott."
+
+#~ msgid "Standard Space"
+#~ msgstr "Szabványos színtér"
+
+#~ msgid "Test Profile"
+#~ msgstr "Tesztprofil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatikus"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Alacsony minőség"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Közepes minőség"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Magas minőség"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Alapértelmezett RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Alapértelmezett CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Alapértelmezett szürke"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Gyártó által biztosított gyári kalibrálási adatok"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "Ezzel a profillal nem lehetséges a teljes képernyős kijelzőkorrekció"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Ez a profil már nem feltétlenül pontos"
+
+#~ msgid "Other…"
+#~ msgstr "Egyéb…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Feloldás a beállítások módosításához"
+
+#~ msgid "Today"
+#~ msgstr "Ma"
+
+#~ msgid "Yesterday"
+#~ msgstr "Tegnap"
+
+#~ msgid "%b %e"
+#~ msgstr "%b. %-e."
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y. %b. %-e."
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d óra"
+#~ msgstr[1] "%d óra"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d perc"
+#~ msgstr[1] "%d perc"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d másodperc"
+#~ msgstr[1] "%d másodperc"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24 órás"
+
+#~ msgid "AM / PM"
+#~ msgstr "12 órás"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%Y. %B %-e. %H:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%Y. %B %-e. %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%H:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "A műszaki problémák jelentéseinek elküldése segít nekünk a(z) %s "
+#~ "továbbfejlesztésében. A jelentések névtelenül és személyes adatoktól "
+#~ "mentesen lesznek elküldve. %s"
+
+#~ msgid "On"
+#~ msgstr "Be"
+
+#~ msgid "Off"
+#~ msgstr "Ki"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Módosítások alkalmazása?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "A módosítások nem alkalmazhatóak"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Ez hardveres korlátozások miatt is lehet."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Fekvő"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Álló (jobbra)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Álló (balra)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Fekvő (fordított)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "A biztonságos rendszerindítás aktív"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú "
+#~ "szoftverek töltődjenek be az eszköz indításakor. Ez jelenleg be van "
+#~ "kapcsolva, és megfelelően működik."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "A biztonságos rendszerindításnak problémái vannak"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú "
+#~ "szoftverek töltődjenek be az eszköz indításakor. Ez jelenleg be van "
+#~ "kapcsolva, de nem fog működni egy érvénytelen kulcs megléte miatt."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "A biztonságos rendszerindítással kapcsolatos problémák gyakran "
+#~ "megoldhatók a számítógép UEFI belső vezérlőprogramjának beállításaiból "
+#~ "(BIOS), és a hardver gyártója tájékoztatást adhat arról, hogyan lehet ezt "
+#~ "megtenni."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Segítségért forduljon a hardver gyártójához vagy az informatikai "
+#~ "támogatójához."
+
+#~| msgid "Camera is Turned Off"
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "A biztonságos rendszerindítás ki van kapcsolva"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú "
+#~ "szoftverek töltődjenek be az eszköz indításakor. Ez jelenleg ki van "
+#~ "kapcsolva."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "A biztonságos rendszerindítás gyakran a számítógép UEFI belső "
+#~ "vezérlőprogramjának beállításaiban (BIOS) kapcsolható be. Segítségért "
+#~ "forduljon a hardver gyártójához vagy az informatikai támogatójához."
+
+#~| msgid "Password"
+#~ msgid "Passed"
+#~ msgstr "Sikeres"
+
+#~| msgid "PPP failed"
+#~ msgid "Failed"
+#~ msgstr "Sikertelen"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Az eszköz megfelel a(z) %d. HSI-szintnek"
+
+#~| msgctxt "Wi-Fi Hotspot"
+#~| msgid "Security type"
+#~ msgid "Security Level 0"
+#~ msgstr "0. biztonsági szint"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Ez az eszköz nem rendelkezik védelemmel a hardveres biztonsági problémák "
+#~ "ellen. Ennek oka hardverbeállítási probléma vagy belső vezérlőprogram "
+#~ "beállítási probléma lehet. Ajánlott felvennie a kapcsolatot az "
+#~ "informatikai támogatójával."
+
+#~| msgctxt "Wi-Fi Hotspot"
+#~| msgid "Security type"
+#~ msgid "Security Level 1"
+#~ msgstr "1. biztonsági szint"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Ez az eszköz minimális védelemmel rendelkezik a hardveres biztonsági "
+#~ "problémák ellen. Ez a legalacsonyabb eszközbiztonsági szint, és csak az "
+#~ "egyszerű biztonsági fenyegetésekkel szemben nyújt védelmet."
+
+#~| msgctxt "Wi-Fi Hotspot"
+#~| msgid "Security type"
+#~ msgid "Security Level 2"
+#~ msgstr "2. biztonsági szint"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Ez az eszköz alapvető védelemmel rendelkezik a hardveres biztonsági "
+#~ "problémák ellen. Ez védelmet nyújt néhány gyakori biztonsági fenyegetés "
+#~ "ellen."
+
+#~| msgctxt "Wi-Fi Hotspot"
+#~| msgid "Security type"
+#~ msgid "Security Level 3"
+#~ msgstr "3. biztonsági szint"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Ez az eszköz kibővített védelemmel rendelkezik a hardveres biztonsági "
+#~ "problémák ellen. Ez a legmagasabb eszközbiztonsági szint, és védelmet "
+#~ "nyújt a speciális biztonsági fenyegetések ellen."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "A biztonsági szintek nem érhetők el ehhez az eszközhöz."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Forduljon a hardver gyártójához a biztonsági frissítésekkel kapcsolatos "
+#~ "segítségért."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Lehetséges, hogy ezt a problémát az eszköz UEFI belső vezérlőprogramjának "
+#~ "beállításaiban vagy egy támogató technikus segítségével lehet megoldani."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Lehetséges, hogy ezt a problémát az eszköz UEFI belső vezérlőprogramjának "
+#~ "beállításaiban lehet megoldani."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Lehetséges, hogy egy támogató technikus segítségével lehet ezt a "
+#~ "problémát megoldani."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Védelem a rosszindulatú szoftverek ellen az eszköz indításakor."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "A biztonságos rendszerindításnak problémái vannak"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Némi védelem az eszköz indításakor."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "A biztonságos rendszerindítás ki van kapcsolva"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Nincs védelem az eszköz indításakor."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Ezt a problémát az UEFI belső vezérlőprogramjának beállításaiban történt "
+#~ "változtatás, az operációs rendszer konfigurációjának megváltoztatása vagy "
+#~ "a rendszerben lévő rosszindulatú szoftver okozhatta."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Ezt a problémát az UEFI belső vezérlőprogramjának beállításaiban történt "
+#~ "változtatás vagy a rendszerben lévő rosszindulatú szoftver okozhatta."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Ezt a problémát az operációs rendszer konfigurációjának megváltoztatása "
+#~ "vagy a rendszerben lévő rosszindulatú szoftver okozhatta."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Komoly biztonsági fenyegetéseknek van kitéve."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Korlátozott védelem az egyszerű biztonsági fenyegetések ellen."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Védve van a gyakori biztonsági fenyegetések ellen."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Védve van a biztonsági fenyegetések széles tartománya ellen."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Átfogó védelem"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Belső vezérlőprogram írásvédelme"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Belső vezérlőprogram írásvédelmének zárolása"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Belső vezérlőprogram BIOS-ának régiója"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Belső vezérlőprogram BIOS-ának leírója"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Rendszerindítás előtti közvetlen memória hozzáférés elleni védelem"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard által ellenőrzött rendszerindítás"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM védett"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard hibairányelv"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard biztosíték"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET engedélyezve"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET aktív"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Titkosított memória"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU védelem"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux Kernel zárlat"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux Kernel ellenőrzés"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux cserehely"
+
+#~| msgid "Suspend"
+#~ msgid "Suspend To RAM"
+#~ msgstr "Felfüggesztés a memóriába"
+
+#~| msgid "Suspend"
+#~ msgid "Suspend To Idle"
+#~ msgstr "Felfüggesztés üresjáratba"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI platformkulcs"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI biztonságos rendszerindítás"
+
+#~| msgid "Configuration"
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM platformbeállítás"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM újjáépítés"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM 2.0-s verzió"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine gyártói mód"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine felülbírálás"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine verziója"
+
+#~| msgid "Software Updates"
+#~ msgid "Firmware Updates"
+#~ msgstr "Belső vezérlőprogram frissítések"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Attestation"
+#~ msgstr "Belső vezérlőprogram tanúsítás"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Belső vezérlőprogram frissítőjének ellenőrzése"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Platform hibakeresése"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Processzor biztonsági ellenőrzései"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD visszaállítási védelem"
+
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD belső vezérlőprogram visszajátszási védelem"
+
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD belső vezérlőprogram írásvédelme"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Biztosított platform"
+
+#~ msgid "Valid"
+#~ msgstr "Érvényes"
+
+#~| msgid "Not calibrated"
+#~ msgid "Not Valid"
+#~ msgstr "Nem érvényes"
+
+#~| msgid "Enabled"
+#~ msgid "Not Enabled"
+#~ msgstr "Nincs engedélyezve"
+
+#~| msgid "SIM Locked"
+#~ msgid "Locked"
+#~ msgstr "Zárolva"
+
+#~| msgid "SIM Locked"
+#~ msgid "Not Locked"
+#~ msgstr "Nincs zárolva"
+
+#~ msgid "Encrypted"
+#~ msgstr "Titkosított"
+
+#~| msgid "Not calibrated"
+#~ msgid "Not Encrypted"
+#~ msgstr "Nem titkosított"
+
+#~ msgid "Tainted"
+#~ msgstr "Fertőzött"
+
+#~| msgid "Not calibrated"
+#~ msgid "Not Tainted"
+#~ msgstr "Nem fertőzött"
+
+#~| msgid "Sound"
+#~ msgid "Found"
+#~ msgstr "Található"
+
+#~| msgid "Not found"
+#~ msgid "Not Found"
+#~ msgstr "Nem található"
+
+#~| msgctxt "print job"
+#~| msgid "Aborted"
+#~ msgid "Supported"
+#~ msgstr "Támogatott"
+
+#~| msgid "No Thunderbolt Support"
+#~ msgid "Not Supported"
+#~ msgstr "Nem támogatott"
+
+#~ msgid "Unknown"
+#~ msgstr "Ismeretlen"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 bites"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 bites"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Ismeretlen"
+
+#~| msgid "Unavailable"
+#~ msgid "Not Available"
+#~ msgstr "Nem érhető el"
+
+#~ msgid "System Logo"
+#~ msgstr "Rendszerlogó"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nem találhatók bemeneti források"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Egyéb"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Egyéni gyorsbillentyűk"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Az alternatív karakterek billentyű további karakterek bevitelére "
+#~ "használható. Ezek néha harmadik lehetőségként vannak felfestve a "
+#~ "billentyűzetre."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Bal Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Jobb Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Bal Szuper"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Jobb Szuper"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menügomb"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Jobb Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "A kombináló billentyűvel számos karakter beírható. A használatához nyomja "
+#~ "meg a kombináló billentyűt, majd írjon be egy karaktersorozatot. Például "
+#~ "a kombináló billentyű után a <b>C</b> és az <b>o</b> a <b>©</b> karaktert "
+#~ "írja be, az <b>a</b> után a <b>'</b> az <b>á</b> betűt írja be."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "A bemeneti források a(z) %s gyorsbillentyűvel válthatóak át.\n"
+#~ "Ezt a gyorsbillentyűk beállításaiban lehet megváltoztatni."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d módosítva"
+#~ msgstr[1] "%d módosítva"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Minden gyorsbillentyű visszaállítása?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "A gyorsbillentyűk visszaállítása az egyéni gyorsbillentyűket is "
+#~ "érintheti. Ez nem vonható vissza."
+
+#~ msgid "Reset All"
+#~ msgstr "Összes visszaállítása"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "A(z) %s már használatban van ennél: %s. Ha lecseréli, akkor a(z) %s "
+#~ "letiltásra kerül"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Adja meg az új gyorsbillentyűt"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Egyéni gyorsbillentyű beállítása"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Gyorsbillentyű beállítása"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Adja meg az új gyorsbillentyűt a(z) %s megváltoztatásához."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Egyéni gyorsbillentyű hozzáadása"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Kétujjas görgetés"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Öt kattintás, ez a GEGL ideje!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dupla kattintás, elsődleges gomb"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Egy kattintás, elsődleges gomb"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dupla kattintás, középső gomb"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Egy kattintás, középső gomb"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dupla kattintás, másodlagos gomb"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Egy kattintás, másodlagos gomb"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "A Hálózatkezelőnek futnia kell."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Nem biztonságos hálózat (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Biztonságos hálózat (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Biztonságos hálózat (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Biztonságos hálózat (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Biztonságos hálózat"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "A hotspot bekapcsolása le fogja választani a(z) %s Wi-Fi hálózatról, és "
+#~ "nem lesz lehetséges elérni az internetet Wi-Fi használatával."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Legalább 8 karakter szükséges"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Leállítja a hotspotot, és leválasztja a felhasználókat?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "H_otspot leállítása"
+
+#~ msgid "Preserve"
+#~ msgstr "Megőrzés"
+
+#~ msgid "Permanent"
+#~ msgstr "Állandó"
+
+#~ msgid "Random"
+#~ msgstr "Véletlen"
+
+#~ msgid "Stable"
+#~ msgstr "Stabil"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Az itt megadott MAC-cím lesz használva hardvercímként annál a hálózati "
+#~ "eszköznél, amelyen ez a kapcsolat aktiválva van. Ez a funkció MAC-cím "
+#~ "klónozás vagy hamisítás néven ismert. Példa: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "%d. profil"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Javított megnyitás"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nincs"
+
+#~ msgid "Never"
+#~ msgstr "Soha"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2,4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2,4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nincs"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Gyenge"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Jó"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Kitűnő"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Kapcsolat elfelejtése"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Kapcsolatprofil eltávolítása"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN eltávolítása"
+
+#~ msgid "Details"
+#~ msgstr "Részletek"
+
+#~ msgid "automatic"
+#~ msgstr "automatikus"
+
+#~ msgid "Identity"
+#~ msgstr "Személyazonosság"
+
+#~ msgid "Delete Address"
+#~ msgstr "Cím törlése"
+
+#~ msgid "Delete Route"
+#~ msgstr "Útvonal törlése"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Nincs"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128 bites kulcs (Hex vagy ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128 bites jelmondat"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dinamikus WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA és WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA és WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "A kapcsolatszerkesztő megnyitása sikertelen"
+
+#~ msgid "New Profile"
+#~ msgstr "Új profil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Érvénytelen beállítás (%s): %s"
+
+#, c-format
+#~| msgid "All Settings"
+#~ msgid "Invalid setting %s"
+#~ msgstr "Érvénytelen beállítás: %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importálás fájlból…"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN hozzáadása"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Nem lehet importálni a VPN kapcsolatot"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "A fájl („%s”) nem olvasható vagy nem tartalmaz ismert VPN "
+#~ "kapcsolatinformációkat\n"
+#~ "\n"
+#~ "Hiba: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Válassza ki az importálandó fájlt"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Már létezik „%s” nevű fájl."
+
+#~ msgid "_Replace"
+#~ msgstr "_Csere"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Le kívánja cserélni a(z) %s fájlt a mentendő VPN kapcsolatra?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Nem lehet exportálni a VPN kapcsolatot"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "A VPN kapcsolat („%s”) nem exportálható ide: %s.\n"
+#~ "\n"
+#~ "Hiba: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN kapcsolat exportálása"
+
+#~ msgid "never"
+#~ msgstr "soha"
+
+#~ msgid "today"
+#~ msgstr "ma"
+
+#~ msgid "yesterday"
+#~ msgstr "tegnap"
+
+#~ msgid "Last used"
+#~ msgstr "Utolsó használat"
+
+#~ msgid "Add new connection"
+#~ msgstr "Új kapcsolat hozzáadása"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "A kijelölt hálózatok adatai elvesznek, beleértve a jelszavakat és az "
+#~ "egyedi beállításokat is."
+
+#~ msgid "_Forget"
+#~ msgstr "_Elfelejtés"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Ismert Wi-Fi hálózatok"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Felejtse el"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "A rendszer házirendje megtiltja a hotspotként való használatot"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "A vezeték nélküli eszköz nem támogatja a hotspot módot"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Az automatikus webproxy-felderítés akkor használatos, ha nincs megadva "
+#~ "konfigurációs URL."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Ez nem javasolt nyilvános, nem biztonságos hálózatokon."
+
+#~ msgid "Status unknown"
+#~ msgstr "Ismeretlen állapot"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Felügyeletlen"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nem érhető el"
+
+#~ msgid "Connecting"
+#~ msgstr "Kapcsolódás"
+
+#~ msgid "Authentication required"
+#~ msgstr "Hitelesítés szükséges"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Bontás"
+
+#~ msgid "Connection failed"
+#~ msgstr "Kapcsolódás meghiúsult"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Ismeretlen állapot (hiányzik)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "A beállítás sikertelen"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Az IP-beállítás sikertelen"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Az IP-beállítás lejárt"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Titkos információkra volt szükség, de nem lettek megadva"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "A 802.1x-kliens bontotta a kapcsolatot"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "A 802.1x-kliens beállítása meghiúsult"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "A 802.1x-kliens sikertelen"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "A 802.1x-kliens hitelesítése túl sokáig tartott"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "A PPP szolgáltatás nem indult el"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP szolgáltatás leválasztva"
+
+#~ msgid "PPP failed"
+#~ msgstr "A PPP sikertelen"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "A DHCP kliens nem indult el"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP-klienshiba"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "A DHCP-kliens sikertelen"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "A megosztott kapcsolat szolgáltatás nem indult el"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "A megosztott kapcsolat szolgáltatás sikertelen"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Az AutoIP szolgáltatás nem indult el"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP szolgáltatáshiba"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Az AutoIP szolgáltatás sikertelen"
+
+#~ msgid "Line busy"
+#~ msgstr "A vonal foglalt"
+
+#~ msgid "No dial tone"
+#~ msgstr "Nincs tárcsahang"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Nem hozható létre hívás"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "A tárcsázási kérés túllépte az időkorlátot"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "A tárcsázási kísérlet meghiúsult"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "A modem előkészítése sikertelen"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "A megadott APN kiválasztása meghiúsult"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Nem keres hálózatokat"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Hálózatregisztráció megtagadva"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "A hálózatregisztráció túllépte az időkorlátot"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "A kért hálózaton való regisztráció sikertelen"
+
+#~ msgid "PIN check failed"
+#~ msgstr "A PIN ellenőrzése sikertelen"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Az eszközhöz firmware hiányozhat"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "A kapcsolat eltűnt"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "A meglévő kapcsolat felvéve"
+
+#~ msgid "Modem not found"
+#~ msgstr "Nem található modem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "A Bluetooth kapcsolódás sikertelen"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "A SIM kártya nincs behelyezve"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "A SIM Pin szükséges"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "A SIM Puk szükséges"
+
+#~ msgid "SIM wrong"
+#~ msgstr "A SIM hibás"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Kapcsolódás függősége meghiúsult"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Hiányzó firmware"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kábel kihúzva"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "meghatározatlan hiba a 802.1X biztonságban (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "nincs fájl kiválasztva"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "meghatározatlan hiba az eap-method fájl ellenőrzése közben"
+
+#~| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 vagy PGP személyes kulcsok"
+
+#~| msgid "_User certificate"
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER vagy PEM tanúsítványok"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "hiányzó EAP-FAST PAC fájl"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC fájlok (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "hiányzó EAP-LEAP felhasználónév"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "hiányzó EAP-LEAP jelszó"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "érvénytelen EAP-PEAP CA tanúsítvány: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "érvénytelen EAP-PEAP CA tanúsítvány: nincs tanúsítvány megadva"
+
+#~ msgid "missing EAP username"
+#~ msgstr "hiányzó EAP felhasználónév"
+
+#~ msgid "missing EAP password"
+#~ msgstr "hiányzó EAP jelszó"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "hiányzó EAP-TLS személyazonosság"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "érvénytelen EAP-TLS CA tanúsítvány: „%s”"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "érvénytelen EAP-TLS CA tanúsítvány: nincs tanúsítvány megadva"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "érvénytelen EAP-TLS személyes kulcs: „%s”"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "érvénytelen EAP-TLS felhasználói tanúsítvány: „%s”"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "A nem titkosított személyes kulcsok nem biztonságosak"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Úgy tűnik, hogy a kiválasztott személyes kulcsot nem védi jelszó. Ez "
+#~ "lehetővé teszi a hitelesítési adatok kompromittálását. Válasszon "
+#~ "jelszóval védett személyes kulcsot.\n"
+#~ "\n"
+#~ "Személyes kulcsát az OpenSSL segítségével teheti jelszóval védetté."
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Válassza ki a személyes tanúsítványát"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Válassza ki a személyes kulcsát"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "érvénytelen EAP-TTLS CA tanúsítvány: „%s”"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "érvénytelen EAP-TTLS CA tanúsítvány: nincs tanúsítvány megadva"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Ismeretlen hiba a 802.1X biztonság ellenőrzésekor"
+
+#~ msgid "Select a file"
+#~ msgstr "Fájl kiválasztása"
+
+#~ msgid "missing leap-username"
+#~ msgstr "hiányzó leap felhasználónév"
+
+#~ msgid "missing leap-password"
+#~ msgstr "hiányzó leap jelszó"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "A Wi-Fi jelszó hiányzik."
+
+#~ msgid "missing wep-key"
+#~ msgstr "hiányzó wep-kulcs"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "érvénytelen wep-kulcs: egy %zu hosszú kulcsban csak hexadecimális "
+#~ "számjegyek lehetnek"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "érvénytelen wep-kulcs: egy %zu hosszú kulcsban csak ascii karakterek "
+#~ "lehetnek"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "érvénytelen wep-kulcs: hibás kulcshossz: %zu. A kulcs hossza 5/13 (ascii) "
+#~ "vagy 10/26 lehet (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "érvénytelen wep-kulcs: a jelmondat nem lehet üres"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "érvénytelen wep-kulcs: a jelmondatnak 64 karakternél rövidebbnek kell "
+#~ "lennie"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "érvénytelen wpa-psk: érvénytelen kulcshossz: %zu. [8,63] bájtnak, vagy 64 "
+#~ "hexadecimális számjegynek kell lennie"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "érvénytelen wpa-psk: a 64 bájtos kulcs nem értelmezhető hexadecimálisként"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Egyéb"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s eltávolítva"
+
+#~ msgid "Error removing account"
+#~ msgstr "Hiba a fiók eltávolításakor"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s fiók"
+
+#~ msgid "Remove Account"
+#~ msgstr "Fiók eltávolítása"
+
+#~ msgid "Unknown time"
+#~ msgstr "Ismeretlen idő"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s, %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s a teljes feltöltésig"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Figyelem: %s van hátra"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s van hátra"
+
+#~ msgid "Fully charged"
+#~ msgstr "Teljesen feltöltve"
+
+#~ msgid "Not charging"
+#~ msgstr "Nem tölt"
+
+#~ msgid "Empty"
+#~ msgstr "Lemerült"
+
+#~ msgid "Charging"
+#~ msgstr "Töltés"
+
+#~ msgid "Discharging"
+#~ msgstr "Kisülés"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Vezeték nélküli egér"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Vezeték nélküli billentyűzet"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Szünetmentes tápegység (UPS)"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Személyes digitális asszisztens"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobiltelefon"
+
+#~ msgid "Media player"
+#~ msgstr "Médialejátszó"
+
+#~ msgid "Tablet"
+#~ msgstr "Táblagép"
+
+#~ msgid "Computer"
+#~ msgstr "Számítógép"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Bemeneti eszköz játékokhoz"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Elsődleges"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Extra"
+
+#~ msgid "Batteries"
+#~ msgstr "Akkumulátorok"
+
+#~ msgid "When _idle"
+#~ msgstr "Ü_resjáratban"
+
+#~ msgid "Suspend"
+#~ msgstr "Felfüggesztés"
+
+#~ msgid "Power Off"
+#~ msgstr "Kikapcsolás"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernálás"
+
+#~ msgid "Nothing"
+#~ msgstr "Ne tegyen semmit"
+
+#~ msgid "When on battery power"
+#~ msgstr "Akkumulátoron"
+
+#~ msgid "When plugged in"
+#~ msgstr "Ha csatlakoztatva van"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Soha"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatikus felfüggesztés"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "A teljesítményközpontú mód átmenetileg letiltva a magas működési "
+#~ "hőmérséklet miatt."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Ölben használat észlelve: a teljesítményközpontú mód átmenetileg nem "
+#~ "érhető el. A helyreállításhoz helyezze stabil felületre az eszközt."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Teljesítményközpontú mód átmenetileg letiltva."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Alacsony töltés: energiatakarékos mód bekapcsolva. Az előző mód "
+#~ "visszaáll, amint elég töltés lesz az akkumulátorban."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "A(z) „%s” aktiválta az energiatakarékos módot."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "A(z) „%s” aktiválta az teljesítményközpontú módot."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Teljesítmény"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Magas teljesítmény és fogyasztás."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Kiegyensúlyozott"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Szokásos teljesítmény és fogyasztás."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Energiatakarékos"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Csökkentett teljesítmény és fogyasztás."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "A(z) „%s” nyomtató törölve lett"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Az új nyomtató hozzáadása meghiúsult."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "A felület nem tölthető be: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Feloldás a nyomtatók hozzáadásához és a beállítások módosításához"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s adatai"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nem található megfelelő illesztőprogram"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Válasszon PPD fájlt"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript nyomtatóleíró fájlok (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+#~ "GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect nyomtató"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD nyomtató"
+
+#~ msgid "One Sided"
+#~ msgstr "Egyoldalas"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Hosszú él (szabványos)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Rövid él (fordított)"
+
+#~ msgid "Portrait"
+#~ msgstr "Álló"
+
+#~ msgid "Landscape"
+#~ msgstr "Fekvő"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Fordított fekvő"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Fordított álló"
+
+#~| msgid "_Resume"
+#~ msgid "Resume"
+#~ msgstr "Folytatás"
+
+#~| msgctxt "print job"
+#~| msgid "Paused"
+#~ msgid "Pause"
+#~ msgstr "Szüneteltetés"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Függőben"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Szüneteltetve"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Hitelesítés szükséges"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Feldolgozás"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Leállítva"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Megszakítva"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Félbeszakítva"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Befejezve"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "A feladat áthelyezése a sor elejére"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s – Aktív feladatok"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr ""
+#~ "Hitelesítési adatok megadása a következőről történő nyomtatáshoz: %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Nyomtatókiszolgáló feloldása"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s feloldása."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Adja meg felhasználónevét és jelszavát a nyomtatók megjelenítéséhez ezen: "
+#~ "%s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Nyomtatók keresése"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Soros port"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Párhuzamos port"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Hely: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Cím: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "A kiszolgáló hitelesítést igényel"
+
+#~ msgid "Two Sided"
+#~ msgstr "Kétoldalas"
+
+#~ msgid "Paper Type"
+#~ msgstr "Papírtípus"
+
+#~ msgid "Paper Source"
+#~ msgstr "Papírforrás"
+
+#~ msgid "Output Tray"
+#~ msgstr "Kimeneti tálca"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Felbontás"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript előszűrés"
+
+#~ msgid "Pages per side"
+#~ msgstr "Oldalak laponként"
+
+#~ msgid "Orientation"
+#~ msgstr "Tájolás"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Általános"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Oldalbeállítás"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Telepíthető beállítások"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Feladat"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Képminőség"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Szín"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Befejezés"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Speciális"
+
+#~ msgid "Test page"
+#~ msgstr "Tesztoldal"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatikus kiválasztás"
+
+#~ msgid "Printer Default"
+#~ msgstr "Nyomtató alapértelmezése"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Csak GhostScript betűkészletek beágyazása"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Átalakítás 1. PS szintre"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Átalakítás 2. PS szintre"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Nincs előszűrés"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Nyomtatófejek tisztítása"
+
+#~ msgid "Out of toner"
+#~ msgstr "A festékkazetta kifogyott"
+
+#~ msgid "Low on developer"
+#~ msgstr "Az előhívó kifogyóban"
+
+#~ msgid "Out of developer"
+#~ msgstr "Az előhívó kifogyott"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "A tintapatron kifogyóban"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "A tintapatron kifogyott"
+
+#~ msgid "Open cover"
+#~ msgstr "Fedél nyitva"
+
+#~ msgid "Open door"
+#~ msgstr "Ajtó nyitva"
+
+#~ msgid "Low on paper"
+#~ msgstr "Kevés a papír"
+
+#~ msgid "Out of paper"
+#~ msgstr "Kifogyott a papír"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Kikapcsolva"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Leállítva"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "A hulladékgyűjtő majdnem tele"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "A hulladékgyűjtő tele"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Az optikai fotovezető közel jár az élete végéhez"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Az optikai fotovezető már nem működik"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Kész"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Nem fogad feladatokat"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Feldolgozás"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Angolszász"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrikus"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Kérdezze meg, mi a teendő"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ne tegyen semmit"
+
+#~ msgid "Open folder"
+#~ msgstr "Mappa megnyitása"
+
+#~ msgid "Other Media"
+#~ msgstr "Egyéb média"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Válasszon alkalmazást CD-khez"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Válasszon alkalmazást videó DVD-khez"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Válassza ki a zenelejátszó csatlakoztatásakor futtatandó alkalmazást"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Válassza ki a fényképezőgép csatlakoztatásakor futtatandó alkalmazást"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Válasszon alkalmazást szoftver CD-khez"
+
+#~ msgid "audio DVD"
+#~ msgstr "hang DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "üres Blu-Ray lemez"
+
+#~ msgid "blank CD disc"
+#~ msgstr "üres CD-lemez"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "üres DVD-lemez"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "üres HD DVD-lemez"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray videolemez"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-könyvolvasó"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD videolemez"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Képernyő kikapcsol"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 másodperc"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 perc"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 perc"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 perc"
+
+#~| msgctxt "blank_screen"
+#~| msgid "5 minutes"
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 perc"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 perc"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 óra"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 perc"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 perc"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 perc"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 perc"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 perc"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 perc"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 perc"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 perc"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 perc"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Soha"
+
+#~ msgid "Select Location"
+#~ msgstr "Válasszon régiót"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Nem találhatók alkalmazások"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nincs kiválasztott hálózat a megosztáshoz"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Be"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Ki"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Engedélyezve"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktív"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Válasszon mappát"
+
+#~| msgid "Media Sharing"
+#~ msgid "Enable media sharing"
+#~ msgstr "Médiamegosztás engedélyezése"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "A fájlmegosztás lehetővé teszi a Nyilvános mappájának megosztását "
+#~ "másokkal a jelenlegi hálózaton a %s használatával."
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ha a távoli bejelentkezés engedélyezett, akkor a távoli felhasználók a "
+#~ "következő parancs használatával kapcsolódhatnak:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Személyes médiamegosztás engedélyezése"
+
+#~| msgid "Device Name"
+#~ msgid "Device name copied"
+#~ msgstr "Eszköznév lemásolva"
+
+#~ msgid "Device address copied"
+#~ msgstr "Eszközcím lemásolva"
+
+#~| msgid "Username"
+#~ msgid "Username copied"
+#~ msgstr "Felhasználónév lemásolva"
+
+#~| msgid "Password"
+#~ msgid "Password copied"
+#~ msgstr "Jelszó lemásolva"
+
+#~ msgid "Custom"
+#~ msgstr "Egyéni"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s tesztelése"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Bontva"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Kapcsolódás"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Kapcsolódva"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Engedélyezési hiba"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Engedélyezés"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Csökkentett funkcionalitás"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Kapcsolódva és engedélyezve"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Ismeretlen"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Engedélyezve ekkor:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Kapcsolódva ekkor:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Bejegyezve ekkor:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Az eszköz engedélyezése meghiúsult: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Az eszköz elfelejtése meghiúsult: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Hiba"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Engedélyezve"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "A Thunderbolt alrendszer (boltd) nincs telepítve vagy rosszul van "
+#~ "beállítva."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Csak USB és Display Port eszközök csatlakoztathatóak."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "A Thunderbolt nem észlelhető.\n"
+#~ "Vagy hiányzik a rendszerből a Thunderbolt támogatás, vagy le lett tiltva "
+#~ "a BIOS-ban, vagy nem támogatott biztonsági szintre van állítva a BIOS-ban."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "A Thunderbolt támogatás le lett tiltva a BIOS-ban."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "A Thunderbolt biztonsági szintje nem határozható meg."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Hiba a közvetlen módra váltáskor: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Alapértelmezett"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Közepes"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Nagy"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Nagyobb"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Legnagyobb"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d képpont"
+#~ msgstr[1] "%d képpont"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Rövid"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ képernyő"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ képernyő"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ képernyő"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Hosszú"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 óra"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 nap"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 nap"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 nap"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 nap"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 nap"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 nap"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 nap"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 nap"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 nap"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Törölni kívánja az összes elemet a Kukából?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "A Kuka összes eleme véglegesen törölve lesz."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Kuka ürítése"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Törli az összes ideiglenes fájlt?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Minden ideiglenes fájl véglegesen törlésre kerül."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Ideiglenes fájlok törlése"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 nap"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 nap"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 nap"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Örökké"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Egyeznie kell a bejelentkezés szolgáltatójának webcímével."
+
+#~ msgid "Failed to add account"
+#~ msgstr "A fiók hozzáadása sikertelen"
+
+#~ msgid "Failed to register account"
+#~ msgstr "A fiók regisztrálása sikertelen"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nincs támogatott módszer a tartományban való hitelesítésre"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Nem sikerült a tartományhoz csatlakozni"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "A bejelentkezési név nem működik.\n"
+#~ "Próbálja újra."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "A bejelentkezési jelszó nem működik.\n"
+#~ "Próbálja újra."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Nem sikerült bejelentkezni a tartományba"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "A tartomány nem található. Lehet, hogy elgépelte?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "További képek tallózása"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "az eszközt le kell foglalni a művelet elvégzéséhez"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "az eszközt már lefoglalta egy másik folyamat"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "nincs jogosultsága a művelet elvégzéséhez"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "nem lett lenyomat bevíve"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Nem sikerült kommunikálni az eszközzel a bevitel során"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Nem sikerült kommunikálni az ujjlenyomat-olvasóval"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Nem sikerült kommunikálni az ujjlenyomat-démonnal"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Az ujjlenyomatok felsorolása sikertelen: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "A mentett ujjlenyomatok törlése sikertelen: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Bal hüvelykujj"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Bal középső ujj"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Bal mutatóujj"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Bal gyűrűsujj"
+
+#~ msgid "Left little finger"
+#~ msgstr "Bal kisujj"
+
+#~ msgid "Right thumb"
+#~ msgstr "Jobb hüvelykujj"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Jobb középső ujj"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Jobb mutatóujj"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Jobb gyűrűsujj"
+
+#~ msgid "Right little finger"
+#~ msgstr "Jobb kisujj"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Ismeretlen ujj"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Kész"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Ujjlenyomatos eszköz leválasztva"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Ujjlenyomatos eszköz tárhelye megtelt"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Az új ujjlenyomat bevitele sikertelen"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "A bevitel elindítása sikertelen: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Az új ujjlenyomat bevitele sikertelen"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "A bevitel leállítása sikertelen: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Ismételten emelje fel, majd helyezze az ujját az olvasóra az ujjlenyomat "
+#~ "beviteléhez"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Ujj ú_jbóli bevitele…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Új ujjlenyomat leolvasása"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "A(z) %s ujjlenyomatos eszköz kiadása sikertelen: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Probléma az eszköz olvasásakor"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "A(z) %s ujjlenyomatos eszköz megszerzése sikertelen: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Az ujjlenyomatos eszközök lekérése sikertelen: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Ezen a héten"
+
+#~ msgid "Last Week"
+#~ msgstr "Múlt héten"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b. %-e."
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y. %b. %-e."
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s – %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%H:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Munkamenet befejeződött"
+
+#~ msgid "Session Started"
+#~ msgstr "Munkamenet elkezdődött"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s – Fiókaktivitás"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Válasszon másik jelszót."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Írja be újra jelenlegi jelszavát."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "A jelszót nem sikerült megváltoztatni"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Ilyen típusú tartományhoz nem lehet automatikusan csatlakozni"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nem található ilyen tartomány vagy zóna"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Nem lehet bejelentkezni %s néven a(z) %s tartományba"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Érvénytelen jelszó, próbálja újra"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Nem lehet csatlakozni a(z) %s tartományhoz: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "A felhasználó törlése meghiúsult"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "A távmenedzselt felhasználó visszavonása meghiúsult"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nem törölheti saját fiókját."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s még be van jelentkezve"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "A bejelentkezett felhasználók törlése a rendszert inkonzisztens "
+#~ "állapotban hagyhatja."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Meg szeretné tartani %s fájljait?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Felhasználói fiók törlésekor lehetősége van a saját könyvtár, a "
+#~ "levelezési várólista és az ideiglenes fájlok megtartására."
+
+#~ msgid "_Delete Files"
+#~ msgstr "Fájlok _törlése"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Fájlok _megtartása"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Biztosan vissza szeretné vonni a távmenedzselt %s fiókját?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Törlés"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Fiók letiltva"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Következő belépéskor állítandó be"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Nincs"
+
+#~ msgid "Logged in"
+#~ msgstr "Bejelentkezve"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "A fiókszolgáltatás nem érhető el"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Győződjön meg róla, hogy az AccountService telepítve van és fut."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Ezt a panelt fel kell oldani a beállítás megváltoztatásához"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Kijelölt felhasználói fiók törlése"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "A kijelölt felhasználói fiók törléséhez\n"
+#~ "először kattintson a * ikonra"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr ""
+#~ "Feloldás a felhasználók hozzáadásához és a beállítások módosításához"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Az új jelszó nem lehet azonos a régivel."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Próbáljon megváltoztatni néhány betűt és számot."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Próbálja jobban megváltoztatni a jelszót."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "A felhasználói neve nélkül a jelszava erősebb."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Próbálja meg kihagyni a felhasználónevét a jelszóból."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Próbálja meg kerülni a jelszóban lévő szavak egy részét."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Próbálja meg kerülni a gyakori szavakat."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Próbálja meg kerülni a meglévő szavak átrendezését."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Próbáljon meg több számot használni."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Próbáljon meg több nagybetűt használni."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Próbáljon meg több kisbetűt használni."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Próbáljon meg több speciális karaktert, például írásjeleket használni."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Próbálja meg betűk, számok és írásjelek keverékét használni."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Próbálja meg kerülni ugyanannak a karakternek az ismétlését."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Próbálja meg kerülni ugyanazon típusú karakterek ismétlését: keverjen "
+#~ "betűket, számokat és írásjeleket."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Próbálja meg kerülni az 1234 vagy abcd-szerű egyszerű sorozatokat."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "A jelszónak hosszabbnak kell lennie. Próbáljon meg több betűt, számot és "
+#~ "írásjelet hozzáadni."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Használjon vegyesen kis- és nagybetűket, és tegyen közéjük egy-két számot "
+#~ "is."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Több betű, szám és írásjel hozzáadása erősebbé fogja tenni a jelszót."
+
+#~ msgid "Authentication failed"
+#~ msgstr "A hitelesítés meghiúsult"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Az új jelszó túl rövid"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Az új jelszó túl egyszerű"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "A régi és az új jelszó túlságosan hasonlít egymáshoz"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Az új jelszót nemrég használta."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr ""
+#~ "Az új jelszónak számokat vagy speciális karaktereket is tartalmaznia kell"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "A régi és az új jelszó ugyanaz"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "A jelszava megváltozott az első hitelesítés óta."
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Az új jelszó nem tartalmaz elég eltérő karaktert"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Ismeretlen hiba"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "A felhasználónév általában csak a-z közötti kisbetűkből, számjegyekből és "
+#~ "a következő karakterekből állhat: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Ez a felhasználónév nem érhető el. Próbáljon egy másikat."
+
+#~ msgid "The username is too long."
+#~ msgstr "A felhasználónév túl hosszú."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "%d. gomb"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Alkalmazás által meghatározott"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Billentyűleütés küldése"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Monitorváltás"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Képernyőn lévő súgó megjelenítése"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Laptop paneljéhez csatolt rajztábla"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Külső kijelzőre csatolt rajztábla"
+
+#~ msgid "External tablet device"
+#~ msgstr "Külső rajztábla eszköz"
+
+#~ msgid "All Displays"
+#~ msgstr "Összes kijelző"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Festékszóró toll nyomás, dőlés és integrált csúszka funkcióval"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Festékszóró toll nyomás, dőlés és forgatás funkcióval"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Szabványos toll nyomás és dőlés funkcióval"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Szabványos toll nyomás funkcióval"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Új gyorsbillentyű…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Művelet megszakítva"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Hiba:</b> Hozzáférés megtagadva a beállítások módosításakor"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Hiba:</b> Mobilfelszerelést érintő hiba"
+
+#~ msgid "Not Registered"
+#~ msgstr "Nem regisztrált"
+
+#~ msgid "Registered"
+#~ msgstr "Regisztrált"
+
+#~ msgid "Roaming"
+#~ msgstr "Barangolás"
+
+#~ msgid "Searching"
+#~ msgstr "Keresés"
+
+#~ msgid "Denied"
+#~ msgstr "Megtagadva"
+
+#~ msgid "2G Only"
+#~ msgstr "Csak 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Csak 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Csak 4G"
+
+#~| msgid "2G Only"
+#~ msgid "5G Only"
+#~ msgstr "Csak 5G"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (előnyben részesített)"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (előnyben részesített), 5G"
+
+#~| msgid "2G, 3G (Preferred), 4G"
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (előnyben részesített), 4G, 5G"
+
+#~| msgid "2G (Preferred), 3G, 4G"
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (előnyben részesített), 3G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (előnyben részesített)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (előnyben részesített), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (előnyben részesített), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (előnyben részesített)"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (előnyben részesített), 5G"
+
+#~| msgid "3G (Preferred), 4G"
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (előnyben részesített), 4G, 5G"
+
+#~| msgid "3G, 4G"
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (előnyben részesített)"
+
+#~| msgid "2G, 3G (Preferred), 4G"
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (előnyben részesített), 5G"
+
+#~| msgid "2G (Preferred), 3G, 4G"
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (előnyben részesített), 4G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (előnyben részesített)"
+
+#~| msgid "2G, 3G (Preferred), 4G"
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (előnyben részesített), 5G"
+
+#~| msgid "2G (Preferred), 3G, 4G"
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (előnyben részesített), 3G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (előnyben részesített)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (előnyben részesített), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (előnyben részesített)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (előnyben részesített), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (előnyben részesített)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (előnyben részesített), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~| msgid "2G, 4G (Preferred)"
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (előnyben részesített)"
+
+#~| msgid "2G (Preferred), 4G"
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (előnyben részesített), 5G"
+
+#~| msgid "2G, 4G"
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (előnyben részesített)"
+
+#~| msgid "3G (Preferred), 4G"
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (előnyben részesített), 5G"
+
+#~| msgid "3G, 4G"
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (előnyben részesített)"
+
+#~| msgid "3G (Preferred), 4G"
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (előnyben részesített), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Ismeretlen"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "SIM-kártya feloldása"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Adja meg a PIN-kódot a(z) %d. SIM-kártyához"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Adja meg a PIN-kódot a SIM-kártyája feloldásához"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Adja meg a PUK-kódot a(z) %d. SIM-kártyához"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Adja meg a PUK-kódot a SIM-kártyája feloldásához"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Hibás jelszó lett megadva."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "A PUK-kódnak 8 számjegyűnek kell lennie"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Új PIN-kód megadása"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "A PIN-kódnak 4-8 számjegyűnek kell lennie"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Feloldás…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Telefonhiba"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Nincs kapcsolat a telefon felé"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "A művelet nem engedélyezett"
+
+#~ msgid "Operation not supported"
+#~ msgstr "A művelet nem támogatott"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "A SIM-kártya nincs behelyezve"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "A SIM-kártya PIN-kódja szükséges"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "A SIM-kártya PUK-kódja szükséges"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM-kártya hiba"
+
+#~ msgid "SIM busy"
+#~ msgstr "A SIM-kártya foglalt"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Helytelen jelszó"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "A SIM-kártya PIN2-kódja szükséges"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "A SIM-kártya PUK2-kódja szükséges"
+
+#~ msgid "Not found"
+#~ msgstr "Nem található"
+
+#~ msgid "No network service"
+#~ msgstr "Nincs hálózati szolgáltatás"
+
+#~ msgid "Network timeout"
+#~ msgstr "Hálózat időtúllépése"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "A GPRS szolgáltatások nem engedélyezettek"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "A barangolás nem engedélyezett ezen a területen"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Meghatározatlan GPRS hiba"
+
+#~| msgctxt "Thunderbolt Device Status"
+#~| msgid "Error"
+#~ msgid "No Error"
+#~ msgstr "Nincs hiba"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Művelet megszakítva"
+
+#~ msgid "Access denied"
+#~ msgstr "Hozzáférés megtagadva"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Ismeretlen hiba"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "%d. SIM"
+
+#~ msgid "Display version number"
+#~ msgstr "Verziószám kiírása"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Részletes mód engedélyezése"
+
+#~ msgid "Search for the string"
+#~ msgstr "Karakterlánc keresése"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Lehetséges panelnevek felsorolása és kilépés"
+
+#~ msgid "Panel to display"
+#~ msgstr "Megjelenítendő panel"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENTUM…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Elérhető panelek:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Rendszerhangok"

--- a/po/hu.po~
+++ b/po/hu.po~
@@ -1,0 +1,9749 @@
+# Hungarian translation for gnome-control-center.
+# Copyright (C) 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Szabolcs Ban <shooby at gnome dot hu>, 1998, 1999, 2000.
+# Emese Kovacs <emese at gnome dot hu>, 2001.
+# Peter Doma <zelin at pointernet dot hu>, 2002.
+# Andras Timar <timar at gnome dot hu>, 2001, 2002, 2003.
+# Gabor Sari <saga at gnome dot hu>, 2003.
+# Laszlo Dvornik <dvornik at gnome dot hu>, 2004.
+# Gabor Kelemen <kelemeng at gnome dot hu>, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2015, 2016, 2017, 2018.
+# Mate ORY <orymate at gmail d0t com>, 2006.
+# Richard Somloi <ricsipontaz at gmail dot com>, 2011, 2012.
+# Peter Trombitas <trombipeti at gmail dot com>, 2012.
+# Balázs Úr <ur.balazs at fsf dot hu>, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022.
+# Balázs Meskó <mesko.balazs at fsf dot hu>, 2019, 2020, 2021.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issu"
+"es\n"
+"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"PO-Revision-Date: 2022-09-03 02:32+0200\n"
+"Last-Translator: Balázs Úr <ur.balazs at fsf dot hu>\n"
+"Language-Team: Hungarian <gnome-hu-list at gnome dot org>\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 19.12.3\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Rendszerbusz"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Teljes hozzáférés"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Munkamenetbusz"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Eszközök"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Teljes hozzáférés a /dev-hez"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Hálózat"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Van hálózati kapcsolata"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Saját mappa"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Csak olvasható"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Fájlrendszer"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Beállítások"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Módosíthatja a beállításokat"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"A(z) %s ezket a jogosultságokat tartalmazza beépítve. Ezek nem "
+"módosíthatóak. Ha zavarják ezek a jogosultságok, akkor fontolja meg az "
+"alkalmazás eltávolítását."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "Az alkalmazás által megnyitott %u fájl- és hivatkozástípus"
+msgstr[1] "Az alkalmazás által megnyitott %u fájl- és hivatkozástípus"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> van használatban a fájlok és hivatkozások alábbi típusainak "
+"megnyitásához."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+#| msgid "%s of disk space used"
+msgid "%s of disk space used."
+msgstr "%s lemezterület van használatban."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Alkalmazások"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Nincsenek alkalmazások"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Néhány telepítése…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Megnyitás"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Részletek megjelenítése"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Keresés"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Rendszerkeresések fogadása és a találatok küldése."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Tiltva"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Értesítések"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Rendszerértesítések megjelenítése."
+
+#: panels/applications/cc-applications-panel.ui:133
+#| msgid "Run in background"
+msgid "Run in Background"
+msgstr "Futtatás a háttérben"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Tevékenység engedélyezése, ha az alkalmazás be van zárva."
+
+#: panels/applications/cc-applications-panel.ui:140
+#| msgid "Screen"
+msgid "Screenshots"
+msgstr "Képernyőképek"
+
+#: panels/applications/cc-applications-panel.ui:141
+#| msgid "Take pictures with the camera."
+msgid "Take pictures of the screen at any time."
+msgstr "Képek készítése a képernyőről bármikor."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Háttérkép megváltoztatása"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Az asztal háttérképének megváltoztatása."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Hangok"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Hangok reprodukálása."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Gyorsbillentyűk elnyomása"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "A szabványos gyorsbillentyűk tiltása."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Fényképek készítése a kamerával."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Hang rögzítése a mikrofonnal."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Helymeghatározó szolgáltatások"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Hozzáférés az eszköz helyadataihoz."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Beépített jogosultságok"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Az alkalmazás által megkövetelt rendszerhozzáférések"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Fájl- és hivatkozás-hozzárendelések"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Tároló"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Nincs találat"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Próbáljon valami mást keresni"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Fájl- és hivatkozás-hozzárendelések"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Fájltípusok"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Hivatkozástípusok"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Visszaállítás"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Mennyi tárhelyet foglal ez az alkalmazás az adataival és a gyorsítótáraival."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Alkalmazás"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Adatok"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Gyorsítótár"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Összesen</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Gyorsítótár ürítése…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Különböző alkalmazások jogosultságainak és beállításainak vezérlése"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "alkalmazás;flatpak;jogosultság;beállítás;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Fénykép kiválasztása"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Mé_gse"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Megnyitás"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "több méret"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Nincs asztalháttér"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Jelenlegi háttér"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stílus"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#| msgctxt "cursor size"
+#| msgid "Default"
+msgid "Default"
+msgstr "Alapértelmezett"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Sötét"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Háttér"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Fénykép hozzáadása…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Megjelenés"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "A háttérkép vagy a felhasználói felület színeinek megváltoztatása"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+#| msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Háttér;Háttérkép;Képernyő;Asztal;Stílus;Világos;Sötét;Megjelenés;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#| msgid "_Enable"
+msgid "Enable"
+msgstr "Engedélyezés"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Nem található Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Csatlakoztasson egy kulcsot a Bluetooth használatához."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth kikapcsolva"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Kapcsolja be eszközök csatlakoztatásához és fájlátvitelek fogadásához."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "A repülési üzemmód be van kapcsolva"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "A Bluetooth ki van kapcsolva repülési üzemmódban."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Repülési üzemmód kikapcsolása"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "A hardver repülési üzemmódja be van kapcsolva"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Kapcsolja ki a repülési üzemmód kapcsolót a Bluetooth bekapcsolásához."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Kapcsolja be és ki a Bluetooth-t, majd csatlakoztassa eszközeit"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;megosztás;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "A kamera ki van kapcsolva"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+"Nincsenek alkalmazások, amelyek fényképet vagy videót tudnának rögzíteni."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"A kamera használata lehetővé teszi, hogy az alkalmazások képet és videót "
+"rögzítsenek. A kamera letiltása azt okozhatja, hogy egyes alkalmazások nem "
+"működnek megfelelően.\n"
+"\n"
+"Engedélyezze az alábbi alkalmazások számára a kamera használatát."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Egyetlen alkalmazás sem kérte a kamera elérését"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "A képei védelme"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "kamera;fényképek;videó;webkamera;zárolás;személyes;adatvédelem;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Helyezze a kalibrálóeszközt a négyzetre, és nyomja meg a „Kezdés” gombot"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Vigye a kalibrálóeszközt a kalibrálási pozícióba, és nyomja meg a „Tovább” "
+"gombot"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Vigye a kalibrálóeszközt a felület pozícióba, és nyomja meg a „Tovább” gombot"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Zárja le a laptop fedelét"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Belső hiba történt, a folytatás nem lehetséges."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "A kalibráláshoz szükséges eszközök nincsenek telepítve."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "A profil nem állítható elő."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "A cél fehér pont nem szerezhető be."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Kész!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "A kalibrálás sikertelen!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Eltávolíthatja a kalibrálóeszközt."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ne zavarja a kalibrálóeszközt a folyamat során"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Kijelző kalibrálása"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Kezdés"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Folytatás"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Kész"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Laptop képernyő"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Beépített webkamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s monitor"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s szkenner"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s fényképezőgép"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s nyomtató"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s webkamera"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Színkezelés bekapcsolása ehhez: %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Színprofilok megjelenítése ehhez: %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Nem kalibrált"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Alapértelmezett: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Színtér: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Tesztprofil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Válasszon ICC profilfájlt"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importálás"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Támogatott ICC profilok"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Minden fájl"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Képernyő"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Profil mentése"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "M_entés"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Színprofil létrehozása a kiválasztott eszközhöz"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"A mérőkészülék nem található. Ellenőrizze, hogy be van-e kapcsolva, és "
+"megfelelően van-e csatlakoztatva."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "A mérőkészülék nem támogatja a nyomtatóprofilozást."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Az eszköztípus jelenleg nem támogatott."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Képernyő kalibrálása"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibrálási minőség"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"A kalibrálás a képernyő színkezelésére használható profilt fog előállítani. "
+"Minél tovább tart a kalibrálás, a színprofil minősége annál jobb lesz."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "A számítógépét nem fogja tudni használni a kalibrálás során."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Minőség"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Becsült idő"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibrálóeszköz"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Válassza ki a kalibráláshoz használni kívánt érzékelőeszközt."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Kijelző típusa"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Válassza ki a csatlakoztatott kijelző típusát."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profil fehér pontja"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Válasszon egy cél fehér pontot. A legtöbb kijelzőt D65 fényforráshoz kell "
+"kalibrálni."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Kijelző fényereje"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Állítsa be a kijelzőt az általában használt fényerőre. A színkezelés ezen a "
+"fényerőn lesz a legpontosabb."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Ennek alternatívájaként használhatja az eszköz valamely másik profiljához "
+"használt fényerőt."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profil neve"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"A színprofilt használhatja különböző számítógépeken, vagy akár különböző "
+"fényviszonyokhoz is létrehozhat profilokat."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profil neve:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Összegzés"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "A profil sikeresen létrehozva!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Profil másolása"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Írható adathordozót igényel"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"A profil használatával kapcsolatos ezen utasításokat <a href=\"linux\">GNU/"
+"Linux</a>, <a href=\"osx\">Apple OS X</a> és <a href=\"windows\">Microsoft "
+"Windows</a> rendszereken is használhatja."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Profil hozzáadása"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Problémák találhatók. A profil esetleg nem fog megfelelően működni. <a href="
+"\"\">Részletek megjelenítése.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "Fájl _importálása…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Hozzáadás"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "Minden eszköz esetén a színkezeléshez friss színprofil szükséges."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "További információk"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Tudjon meg többet a színkezelésről"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Beállítás minden felhasználónak"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Profil beállítása a számítógép összes felhasználójának"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Engedélyezés"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Profil hozzáadása"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrálás…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Eszköz kalibrálása"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Profil _eltávolítása"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Részletek megjelenítése"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Nem találhatók eszközök a színkezeléshez"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plazma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL háttérvilágítás)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED háttérvilágítás)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (fehér LED háttérvilágítás)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Széles skálájú LCD (CCFL háttérvilágítás)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Széles skálájú LCD (RGB LED háttérvilágítás)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Nagy"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 perc"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Közepes"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 perc"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Alacsony"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 perc"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Kijelző natív értéke"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (nyomtatás és közzététel)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fényképészet és grafika)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Szabványos színtér"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Tesztprofil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatikus"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Alacsony minőség"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Közepes minőség"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Magas minőség"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Alapértelmezett RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Alapértelmezett CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Alapértelmezett szürke"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Gyártó által biztosított gyári kalibrálási adatok"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Ezzel a profillal nem lehetséges a teljes képernyős kijelzőkorrekció"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Ez a profil már nem feltétlenül pontos"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Szín"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Kijelzők, fényképezőgépek vagy nyomtatók színeinek kalibrálása"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Szín;ICC;Színek;Profilozás;Kalibrálás;Nyomtató;Kijelző;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Egyéb…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Válasszon nyelvet"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Kijelölés"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nem találhatók nyelvek"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Tovább…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Feloldás a beállítások módosításához"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Egyes beállításokat fel kell oldani a megváltoztatásuk előtt."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Feloldás…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Óra növelése"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Perc növelése"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Idő"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Óra csökkentése"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Másodperc csökkentése"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Ma"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Tegnap"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b. %-e."
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%Y. %b. %-e."
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d óra"
+msgstr[1] "%d óra"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d perc"
+msgstr[1] "%d perc"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d másodperc"
+msgstr[1] "%d másodperc"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 másodperc"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 órás"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "12 órás"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%Y. %B %-e. %H:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%Y. %B %-e. %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%H:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Dátum és idő"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Év"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Hónap"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "január"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "február"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "március"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "április"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "május"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "június"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "július"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "augusztus"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "szeptember"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "október"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "november"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "december"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Nap"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Időzóna"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Város keresése"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatikus _dátum és idő"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Internet-hozzáférést igényel"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Dátum és _idő"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automatikus idő_zóna"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+"A helymeghatározó szolgáltatások engedélyezését és internetkapcsolatot "
+"igényel"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Engedélyezve"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Idő_zóna"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Idő_formátum"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Dátum, idő és időzóna módosítása"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Óra;Időzóna;Hely;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Rendszer dátum- és időbeállításainak módosítása"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Hitelesítés szükséges a dátum- és időbeállítások módosításához."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Levelezés"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Naptár"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Zene"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Videó"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fényképek"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Alap alkalmazások"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Alap alkalmazások beállítása"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "alap;alapértelmezett;alkalmazás;előnyben részesített;média;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"A műszaki problémák jelentéseinek elküldése segít nekünk a(z) %s "
+"továbbfejlesztésében. A jelentések névtelenül és személyes adatoktól "
+"mentesen lesznek elküldve. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Hiba jelentése"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatikus hibajelentés"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnosztika"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Problémák bejelentése"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#| msgid "Diagnostics"
+msgid "diagnostics;crash;"
+msgstr "diagnosztika;összeomlás;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Be"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Ki"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Módosítások alkalmazása?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "A módosítások nem alkalmazhatóak"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Ez hardveres korlátozások miatt is lehet."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Alkalmaz"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Vissza"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Megjelenítési beállítások letiltva"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Több kijelző"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Összekapcsolás"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Tükrözés"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "A felső sávot és a tevékenységet tartalmazza"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Elsődleges kijelző"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Éjszakai fény"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Fekvő"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Álló (jobbra)"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Álló (balra)"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Fekvő (fordított)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Tájolás"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Felbontás"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Frissítési gyakoriság"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Igazítás a TV-hez"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Méretezés"
+
+#: panels/display/cc-night-light-page.ui:22
+#| msgid "Night Light"
+msgid "Night Light unavailable"
+msgstr "Az éjszakai fény nem érhető el"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Ennek oka a használt grafikus illesztőprogram vagy a távolról használt asztal"
+" lehet"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Holnapig ideiglenesen letiltva"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Szűrő újraindítása"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Az éjszakai fény melegebbé teszi a kijelző színét. Ez segít megakadályozni a "
+"szemfáradtságot és az álmatlanságot."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Ütemezés"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Napnyugtától napkeltéig"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Kézi ütemezés"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Idők"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Ettől"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Óra"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Perc"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "de."
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "du."
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Eddig"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Színhőmérséklet"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ki­jel­zők"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Csatlakoztatott monitorok és projektorok beállítása"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projektor;xrandr;Képernyő;Felbontás;Frissítés;Monitor;Éjszakai;fény;"
+"redshift;szín;napkelte;napnyugta;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:109
+msgid "Secure Boot is Active"
+msgstr "A biztonságos rendszerindítás aktív"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú szoftverek"
+" töltődjenek be az eszköz indításakor. Ez jelenleg be van kapcsolva, és"
+" megfelelően működik."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "A biztonságos rendszerindításnak problémái vannak"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú szoftverek"
+" töltődjenek be az eszköz indításakor. Ez jelenleg be van kapcsolva, de nem"
+" fog működni egy érvénytelen kulcs megléte miatt."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"A biztonságos rendszerindítással kapcsolatos problémák gyakran megoldhatók a"
+" számítógép UEFI belső vezérlőprogramjának beállításaiból (BIOS), és a"
+" hardver gyártója tájékoztatást adhat arról, hogyan lehet ezt megtenni."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Segítségért forduljon a hardver gyártójához vagy az informatikai"
+" támogatójához."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+#| msgid "Camera is Turned Off"
+msgid "Secure Boot is Turned Off"
+msgstr "A biztonságos rendszerindítás ki van kapcsolva"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú szoftverek"
+" töltődjenek be az eszköz indításakor. Ez jelenleg ki van kapcsolva."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"A biztonságos rendszerindítás gyakran a számítógép UEFI belső"
+" vezérlőprogramjának beállításaiban (BIOS) kapcsolható be. Segítségért"
+" forduljon a hardver gyártójához vagy az informatikai támogatójához."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"A biztonságos rendszerindítás megakadályozza, hogy rosszindulatú szoftverek"
+" töltődjenek be az eszköz indításakor.\n"
+"\n"
+"További információkért forduljon a hardver gyártójához vagy az informatikai"
+" támogatóhoz."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#| msgid "Password"
+msgid "Passed"
+msgstr "Sikeres"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#| msgid "PPP failed"
+msgid "Failed"
+msgstr "Sikertelen"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Az eszköz megfelel a(z) %d. HSI-szintnek"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:482
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level 0"
+msgstr "0. biztonsági szint"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Ez az eszköz nem rendelkezik védelemmel a hardveres biztonsági problémák"
+" ellen. Ennek oka hardverbeállítási probléma vagy belső vezérlőprogram"
+" beállítási probléma lehet. Ajánlott felvennie a kapcsolatot az informatikai"
+" támogatójával."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:489
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level 1"
+msgstr "1. biztonsági szint"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Ez az eszköz minimális védelemmel rendelkezik a hardveres biztonsági"
+" problémák ellen. Ez a legalacsonyabb eszközbiztonsági szint, és csak az"
+" egyszerű biztonsági fenyegetésekkel szemben nyújt védelmet."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:496
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level 2"
+msgstr "2. biztonsági szint"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Ez az eszköz alapvető védelemmel rendelkezik a hardveres biztonsági problémák"
+" ellen. Ez védelmet nyújt néhány gyakori biztonsági fenyegetés ellen."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:503
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level 3"
+msgstr "3. biztonsági szint"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Ez az eszköz kibővített védelemmel rendelkezik a hardveres biztonsági"
+" problémák ellen. Ez a legmagasabb eszközbiztonsági szint, és védelmet nyújt"
+" a speciális biztonsági fenyegetések ellen."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:518
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level"
+msgstr "Biztonsági szint"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:519
+msgid "Security levels are not available for this device."
+msgstr "A biztonsági szintek nem érhetők el ehhez az eszközhöz."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Forduljon a hardver gyártójához a biztonsági frissítésekkel kapcsolatos"
+" segítségért."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Lehetséges, hogy ezt a problémát az eszköz UEFI belső vezérlőprogramjának"
+" beállításaiban vagy egy támogató technikus segítségével lehet megoldani."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Lehetséges, hogy ezt a problémát az eszköz UEFI belső vezérlőprogramjának"
+" beállításaiban lehet megoldani."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+"Lehetséges, hogy egy támogató technikus segítségével lehet ezt a problémát"
+" megoldani."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#| msgid "Ink Level"
+msgid "Level 1"
+msgstr "1. szint"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#| msgid "Ink Level"
+msgid "Level 2"
+msgstr "2. szint"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#| msgid "Ink Level"
+msgid "Level 3"
+msgstr "3. szint"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:110
+msgid "Protected against malicious software when the device starts."
+msgstr "Védelem a rosszindulatú szoftverek ellen az eszköz indításakor."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:116
+msgid "Secure Boot has Problems"
+msgstr "A biztonságos rendszerindításnak problémái vannak"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:117
+msgid "Some protection when the device is started."
+msgstr "Némi védelem az eszköz indításakor."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:122
+msgid "Secure Boot is Off"
+msgstr "A biztonságos rendszerindítás ki van kapcsolva"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:123
+msgid "No protection when the device is started."
+msgstr "Nincs védelem az eszköz indításakor."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:142
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Ezt a problémát az UEFI belső vezérlőprogramjának beállításaiban történt"
+" változtatás, az operációs rendszer konfigurációjának megváltoztatása vagy a"
+" rendszerben lévő rosszindulatú szoftver okozhatta."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:150
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Ezt a problémát az UEFI belső vezérlőprogramjának beállításaiban történt"
+" változtatás vagy a rendszerben lévő rosszindulatú szoftver okozhatta."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:157
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Ezt a problémát az operációs rendszer konfigurációjának megváltoztatása vagy"
+" a rendszerben lévő rosszindulatú szoftver okozhatta."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:483
+msgid "Exposed to serious security threats."
+msgstr "Komoly biztonsági fenyegetéseknek van kitéve."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:490
+msgid "Limited protection against simple security threats."
+msgstr "Korlátozott védelem az egyszerű biztonsági fenyegetések ellen."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:497
+msgid "Protected against common security threats."
+msgstr "Védve van a gyakori biztonsági fenyegetések ellen."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:504
+#: panels/firmware-security/cc-firmware-security-panel.c:512
+msgid "Protected against a wide range of security threats."
+msgstr "Védve van a biztonsági fenyegetések széles tartománya ellen."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:511
+msgid "Comprehensive Protection"
+msgstr "Átfogó védelem"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Nincsenek események"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection"
+msgstr "Belső vezérlőprogram írásvédelme"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection Lock"
+msgstr "Belső vezérlőprogram írásvédelmének zárolása"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Region"
+msgstr "Belső vezérlőprogram BIOS-ának régiója"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Descriptor"
+msgstr "Belső vezérlőprogram BIOS-ának leírója"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Rendszerindítás előtti közvetlen memória hozzáférés elleni védelem"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard által ellenőrzött rendszerindítás"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM védett"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard hibairányelv"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard biztosíték"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET engedélyezve"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET aktív"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Titkosított memória"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU védelem"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux Kernel zárlat"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux Kernel ellenőrzés"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux cserehely"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+#| msgid "Suspend"
+msgid "Suspend To RAM"
+msgstr "Felfüggesztés a memóriába"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+#| msgid "Suspend"
+msgid "Suspend To Idle"
+msgstr "Felfüggesztés üresjáratba"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI platformkulcs"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI biztonságos rendszerindítás"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+#| msgid "Configuration"
+msgid "TPM Platform Configuration"
+msgstr "TPM platformbeállítás"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM újjáépítés"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM 2.0-s verzió"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine gyártói mód"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine felülbírálás"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine verziója"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+#| msgid "Software Updates"
+msgid "Firmware Updates"
+msgstr "Belső vezérlőprogram frissítések"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+#| msgid "Firmware Version"
+msgid "Firmware Attestation"
+msgstr "Belső vezérlőprogram tanúsítás"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+#| msgid "Firmware Version"
+msgid "Firmware Updater Verification"
+msgstr "Belső vezérlőprogram frissítőjének ellenőrzése"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Platform hibakeresése"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Processzor biztonsági ellenőrzései"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD visszaállítási védelem"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+#| msgid "Firmware Version"
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD belső vezérlőprogram visszajátszási védelem"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+#| msgid "Firmware Version"
+msgid "AMD Firmware Write Protection"
+msgstr "AMD belső vezérlőprogram írásvédelme"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Biztosított platform"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Érvényes"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+#| msgid "Not calibrated"
+msgid "Not Valid"
+msgstr "Nem érvényes"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+#| msgid "Enabled"
+msgid "Not Enabled"
+msgstr "Nincs engedélyezve"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+#| msgid "SIM Locked"
+msgid "Locked"
+msgstr "Zárolva"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+#| msgid "SIM Locked"
+msgid "Not Locked"
+msgstr "Nincs zárolva"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Titkosított"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+#| msgid "Not calibrated"
+msgid "Not Encrypted"
+msgstr "Nem titkosított"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Fertőzött"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+#| msgid "Not calibrated"
+msgid "Not Tainted"
+msgstr "Nem fertőzött"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+#| msgid "Sound"
+msgid "Found"
+msgstr "Található"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+#| msgid "Not found"
+msgid "Not Found"
+msgstr "Nem található"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+#| msgctxt "print job"
+#| msgid "Aborted"
+msgid "Supported"
+msgstr "Támogatott"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+#| msgid "No Thunderbolt Support"
+msgid "Not Supported"
+msgstr "Nem támogatott"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#| msgid "Security"
+msgid "Device Security"
+msgstr "Eszközbiztonság"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Gazda belső vezérlőprogramjának biztonsági állapota"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"képernyő;zárolás;diagnosztika;összeomlás;magán;privát;legutóbbi;nemrégi;"
+"ideiglenes;temp;index;név;hálózat;azonosság;identitás;adatvédelem;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Ismeretlen"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64 bites"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32 bites"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Ismeretlen"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+#| msgid "Unavailable"
+msgid "Not Available"
+msgstr "Nem érhető el"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Rendszerlogó"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Eszköz neve"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Hardvermodell"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memória"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processzor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Lemezkapacitás"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Számítás…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Operációs rendszer neve"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#| msgid "%s; Build ID: %s"
+msgid "OS Build ID"
+msgstr "Operációs rendszer összeállítás-azonosítója"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Operációs rendszer típusa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME verzió"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#| msgid "Unlocking…"
+msgid "Loading…"
+msgstr "Betöltés…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Ablakkezelő-rendszer"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualizáció"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Szoftverfrissítések"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Eszköz átnevezése"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Az eszköznév az eszköz azonosításra szolgál, ha a hálózaton keresztül "
+"tekintik meg, vagy Bluetooth eszközökkel akarják párosítani."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#| msgid "Device Name"
+msgid "Device name"
+msgstr "Eszköz neve"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "Á_tnevezés"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Névjegy"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Információk megjelenítése a rendszeréről"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"eszköz;rendszer;információk;memória;processzor;verzió;alapértelmezett;"
+"alkalmazás;előnyben részesített;cd;dvd;usb;hang;video;lemez;eltávolítható;"
+"cserélhető;média;automatikus futtatás;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Hang és média"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Hangerő némítása vagy visszahangosítása"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Halkítás"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Hangosítás"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Mikrofon némítása vagy visszahangosítása"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Médialejátszó indítása"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Lejátszás (vagy lejátszás/szünet)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Lejátszás szüneteltetése"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Lejátszás leállítása"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Előző szám"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Következő szám"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Kiadás"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Gépelés"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Váltás a következő bemeneti forrásra"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Váltás az előző bemeneti forrásra"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Parancsikonok"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Súgóböngésző indítása"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Számológép indítása"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "E-mail kliens indítása"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Webböngésző indítása"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Saját mappa"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Keresés"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Rendszer"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Kijelentkezés"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Képernyő zárolása"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Akadálymentesítés"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Nagyító be- vagy kikapcsolása"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Nagyítás"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Kicsinyítés"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Képernyőolvasó be- vagy kikapcsolása"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Képernyő-billentyűzet be- vagy kikapcsolása"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Szövegméret növelése"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Szövegméret csökkentése"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Nagy kontraszt be- vagy kikapcsolása"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nem találhatók bemeneti források"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Egyéb"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Bemeneti forrás hozzáadása"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Nem használhatók bemeneti módszerek a bejelentkezési képernyőn"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nincs kiválasztva bemeneti forrás"
+
+#: panels/keyboard/cc-input-row.ui:20
+#| msgid "Options…"
+msgid "Options"
+msgstr "Beállítások"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Mozgatás felfelé"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Mozgatás lefelé"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Beállítások"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Billentyűzetkiosztás megtekintése"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Eltávolítás"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Egyéni gyorsbillentyűk"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternatív karakterek billentyű"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Az alternatív karakterek billentyű további karakterek bevitelére "
+"használható. Ezek néha harmadik lehetőségként vannak felfestve a "
+"billentyűzetre."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Bal Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Jobb Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Bal Szuper"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Jobb Szuper"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menügomb"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Jobb Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Kombináló billentyű"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"A kombináló billentyűvel számos karakter beírható. A használatához nyomja "
+"meg a kombináló billentyűt, majd írjon be egy karaktersorozatot. Például a "
+"kombináló billentyű után a <b>C</b> és az <b>o</b> a <b>©</b> karaktert írja "
+"be, az <b>a</b> után a <b>'</b> az <b>á</b> betűt írja be."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"A bemeneti források a(z) %s gyorsbillentyűvel válthatóak át.\n"
+"Ezt a gyorsbillentyűk beállításaiban lehet megváltoztatni."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Bemeneti források"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Tartalmazza a billentyűzetkiosztásokat és a beviteli módokat."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Bemeneti forrás váltása"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "_Azonos forrás használata az összes ablakhoz"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Források váltása _egyesével az összes ablaknál"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Különleges karakterek beírása"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Módok a szimbólumok és betűváltozatok beírására a billentyűzet segítségével."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Gyorsbillentyűk"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Gyorsbillentyűk megtekintése és testreszabása"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d módosítva"
+msgstr[1] "%d módosítva"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Minden gyorsbillentyű visszaállítása?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"A gyorsbillentyűk visszaállítása az egyéni gyorsbillentyűket is érintheti. "
+"Ez nem vonható vissza."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Mégse"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Összes visszaállítása"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Összes visszaállítása…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Az összes gyorsbillentyű visszaállítása az alapértelmezett értékekre"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#| msgid "_Action:"
+msgid "Section"
+msgstr "Szakasz"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#| msgid "Shortcut"
+msgid "Shortcuts"
+msgstr "Gyorsbillentyűk"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#| msgid "Add Shortcut"
+msgid "Add a shortcut"
+msgstr "Gyorsbillentyű hozzáadása"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Egyéni gyorsbillentyűk hozzáadása"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Állítson be egyéni gyorsbillentyűket alkalmazások elindításához, "
+"parancsfájlok futtatásához és egyebekhez."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Gyorsbillentyű hozzáadása"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nem található gyorsbillentyű"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"A(z) %s már használatban van ennél: %s. Ha lecseréli, akkor a(z) %s "
+"letiltásra kerül"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Adja meg az új gyorsbillentyűt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Egyéni gyorsbillentyű beállítása"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Gyorsbillentyű beállítása"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Adja meg az új gyorsbillentyűt a(z) %s megváltoztatásához."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Egyéni gyorsbillentyű hozzáadása"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#| msgid "Remove"
+msgid "_Remove"
+msgstr "_Eltávolítás"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#| msgid "Replace"
+msgid "Re_place"
+msgstr "_Csere"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Beállítás"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Nyomja meg az Esc billentyűt a megszakításhoz, vagy a Backspace billentyűt a "
+"gyorsbillentyű letiltásához."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Név"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Parancs"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Gyorsbillentyű"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Gyorsbillentyű beállítása…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Nincs"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "A gyorsbillentyű visszaállítása az alapértelmezett értékre"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Billentyűzet"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Gyorsbillentyűk módosítása és gépelési beállítások megadása, "
+"billentyűzetkiosztások és bemeneti források"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Gyorsbillentyű;Munkaterület;Ablak;Átméretezés;Nagyítás;Kontraszt;Bemenet;"
+"Forrás;Zárolás;Kötet;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "A helymeghatározó szolgáltatások ki vannak kapcsolva"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Egyetlen alkalmazás sem kérheti le a helyadatait."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"A helymeghatározó szolgáltatások lehetővé teszik az alkalmazások számára, "
+"hogy megtudják a helyzetét. A Wi-Fi és a mobil széles sáv növeli a "
+"pontosságot.\n"
+"\n"
+"A Mozilla helymeghatározó szolgáltatását használja: <a href='https://"
+"location.services.mozilla.com/privacy'>adatvédelmi irányelvek</a>\n"
+"\n"
+"Engedélyezze az alábbi alkalmazások számára a helyzete meghatározását."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Egyetlen alkalmazás sem kérte a helyadatok elérését"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "A helyadatai védelme"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "hely;gps;személyes;adatvédelem;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "A mikrofon ki van kapcsolva"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Egyetlen alkalmazás sem tud hangot rögzíteni."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"A mikrofon használata lehetővé teszi, hogy az alkalmazások hangot "
+"rögzítsenek és figyeljenek. A mikrofon letiltása azt okozhatja, hogy egyes "
+"alkalmazások nem működnek megfelelően.\n"
+"\n"
+"Engedélyezze az alábbi alkalmazások számára a mikrofon használatát."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Egyetlen alkalmazás sem kérte a mikrofon elérését"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "A beszélgetései védelme"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofon;felvétel;alkalmazás;adatvédelem;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Beállítás_ok tesztelése"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Általános"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Elsődleges gomb"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Beállítja a fizikai gombok sorrendjét egereken és érintőtáblákon."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Bal"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Jobb"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Egér"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Egér sebessége"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Természetes görgetés"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "A görgetés a tartalmat mozgatja, nem a nézetet."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Érintőtábla"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Érintőtábla sebessége"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Koppintás a kattintáshoz"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+#| msgid "Tap to Click"
+msgid "Tap to click"
+msgstr "Koppintás a kattintáshoz"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Kétujjas görgetés"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Görgetés a szélen"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Próbáljon kattintani, duplán kattintani, görgetni"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Öt kattintás, ez a GEGL ideje!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dupla kattintás, elsődleges gomb"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Egy kattintás, elsődleges gomb"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dupla kattintás, középső gomb"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Egy kattintás, középső gomb"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dupla kattintás, másodlagos gomb"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Egy kattintás, másodlagos gomb"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "E­gér és é­rin­tő­táb­la"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Egér vagy érintőtábla érzékenységének, bal vagy jobb kezességének módosítása"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Érintőtábla;Tapipad;Mutató;Kattintás;Koppintás;Dupla;Gomb;Hanyattegér;"
+"Görgetés;Gördítés;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Forró sarok"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+"Érintse meg a bal felső sarkot, hogy megnyissa a Tevékenységek áttekintést."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Aktív képernyőszegélyek"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Húzza az ablakokat a képernyő felső, bal és jobb szegélyéhez, hogy "
+"átméretezze őket."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Munkaterületek"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dinamikus munkaterületek"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Automatikusan eltávolítja az üres munkaterületeket."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Kötött számú munkaterület"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Adja meg az állandó munkaterületek számát."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "Munkaterületek _száma"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Több kijelző"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Munkaterületek csak az _elsődleges kijelzőn"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Munkaterületek az összes _kijelzőn"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Alkalmazásváltás"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Az összes munkaterületen szereplő alkalmazás belevétele"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Csak a _jelenlegi munkaterületen szereplő alkalmazások belevétele"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Többfeladatos munkavégzés"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "A hatékony többfeladatos munkavégzés beállításainak kezelése"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+#| msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Többfeladatos;Termelékenység;Produktivitás;Testreszabás;Személyre"
+" szabás;Asztal;Forró sarok;Munkaterületek;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Hoppá, valami elromlott. Lépjen kapcsolatba a szoftver szállítójával."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "A Hálózatkezelőnek futnia kell."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Egyéb eszközök"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#| msgid "Add new connection"
+msgid "Add connection"
+msgstr "Kapcsolat hozzáadása"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nincs beállítva"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Nem biztonságos hálózat (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Biztonságos hálózat (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Biztonságos hálózat (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Biztonságos hálózat (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Biztonságos hálózat"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Kapcsolódva"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Beállítások…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"A hotspot bekapcsolása le fogja választani a(z) %s Wi-Fi hálózatról, és nem "
+"lesz lehetséges elérni az internetet Wi-Fi használatával."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Legalább 8 karakter szükséges"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Legfeljebb %d karakter szükséges"
+msgstr[1] "Legfeljebb %d karakter szükséges"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Bekapcsolja a Wi-Fi hotspotot?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"A Wi-Fi hotspot lehetővé teszi másoknak az internetkapcsolat megosztását egy "
+"olyan Wi-Fi hálózat létrehozásával, amelyhez mások kapcsolódhatnak. Ehhez "
+"rendelkeznie kell egy másik, a Wi-Fi hálózaton kívüli forráson keresztül "
+"elérhető internetkapcsolattal."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Hálózat neve"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Jelszó"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Véletlen jelszó előállítása"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Jelszó automatikus előállítása"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Bekapcsolás"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Leállítja a hotspotot, és leválasztja a felhasználókat?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "H_otspot leállítása"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Repülési üzemmód"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Letiltja a Wi-Fi-t, Bluetooth-t és mobil szélessávot"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nem található Wi-Fi adapter"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+"Győződjön meg róla, hogy a Wi-Fi adapter be van dugva, és be van kapcsolva"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Repülési üzemmód be"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Kapcsolja ki a Wi-Fi használatához"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi hotspot aktív"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "A mobileszközök a kapcsolódáshoz leolvashatják a QR-kódot."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Hotspot kikapcsolása…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Látható hálózatok"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "A Hálózatkezelőnek futnia kell"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x _biztonság"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Biztonság"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Megőrzés"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Állandó"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Véletlen"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabil"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Az itt megadott MAC-cím lesz használva hardvercímként annál a hálózati "
+"eszköznél, amelyen ez a kapcsolat aktiválva van. Ez a funkció MAC-cím "
+"klónozás vagy hamisítás néven ismert. Példa: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "%d. profil"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Javított megnyitás"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nincs"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Soha"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i napja"
+msgstr[1] "%i napja"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2,4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2,4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nincs"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Gyenge"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Jó"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Kitűnő"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4-cím"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-cím"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-cím"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Kapcsolat elfelejtése"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Kapcsolatprofil eltávolítása"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "VPN eltávolítása"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Részletek"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatikus"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Személyazonosság"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Cím törlése"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Útvonal törlése"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Nincs"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128 bites kulcs (Hex vagy ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128 bites jelmondat"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dinamikus WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA és WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA és WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Jelerősség"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Kapcsolat sebessége"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hardvercím"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Támogatott frekvenciák"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Alapértelmezett útvonal"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Utolsó használat"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "A_utomatikus csatlakozás"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Elérhetővé tétel más _felhasználóknak"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Forgalomdíjas kapcsolat: adatkorlátokkal rendelkezik és költsége lehet"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"A szoftverfrissítések és egyéb nagy letöltések nem fognak automatikusan "
+"elindulni."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Név"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC cím"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klónozott cím"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bájt"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 módszer"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatikus (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Csak közvetlen kapcsolat"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Kézi"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Letiltás"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Megosztva más számítógépekkel"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Címek"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Cím"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Hálózati maszk"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Átjáró"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automatikus"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatikus DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS-kiszolgáló címei"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Vesszőkkel válassza el az IP-címeket"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Útvonalak"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatikus útvonalak"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrika"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "A kapcsolat _használata csak a hálózatán lévő erőforrásokhoz"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 módszer"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatikus, csak DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Előtag"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "A kapcsolatszerkesztő megnyitása sikertelen"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Új profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Érvénytelen beállítás (%s): %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+#| msgid "All Settings"
+msgid "Invalid setting %s"
+msgstr "Érvénytelen beállítás: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importálás fájlból…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "VPN hozzáadása"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Bi_ztonság"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Nem lehet importálni a VPN kapcsolatot"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"A fájl („%s”) nem olvasható vagy nem tartalmaz ismert VPN "
+"kapcsolatinformációkat\n"
+"\n"
+"Hiba: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Válassza ki az importálandó fájlt"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Már létezik „%s” nevű fájl."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Csere"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Le kívánja cserélni a(z) %s fájlt a mentendő VPN kapcsolatra?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Nem lehet exportálni a VPN kapcsolatot"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"A VPN kapcsolat („%s”) nem exportálható ide: %s.\n"
+"\n"
+"Hiba: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "VPN kapcsolat exportálása"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Hiba: a VPN kapcsolatszerkesztő nem tölthető be)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "BSS_ID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Internetkapcsolatok beállítása"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Hálózat;IP;LAN;Proxy;WAN;Széles sáv;Szélessáv;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Wi-Fi hálózati kapcsolat beállítása"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Hálózat;Vezeték nélküli;Wi-Fi;Wifi;IP;LAN;Széles sáv;Szélessáv;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "soha"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "ma"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "tegnap"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Utolsó használat"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Vezetékes"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Új kapcsolat hozzáadása"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"A kijelölt hálózatok adatai elvesznek, beleértve a jelszavakat és az egyedi "
+"beállításokat is."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Elfelejtés"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Ismert Wi-Fi hálózatok"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Felejtse el"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "A rendszer házirendje megtiltja a hotspotként való használatot"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "A vezeték nélküli eszköz nem támogatja a hotspot módot"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Az automatikus webproxy-felderítés akkor használatos, ha nincs megadva "
+"konfigurációs URL."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Ez nem javasolt nyilvános, nem biztonságos hálózatokon."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Eszköz kikapcsolása"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#| msgctxt "service is active"
+#| msgid "Active"
+msgid "Active"
+msgstr "Aktív"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Szolgáltató"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Hálózati proxy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP-proxy"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS-proxy"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP-proxy"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks kiszolgáló"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "Gépek _figyelmen kívül hagyása"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP proxy port"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS proxy port"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP proxy port"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "SOCKS proxy port"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Konfigurációs URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN kapcsolat kikapcsolása"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Hálózat neve"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Biztonsági típus"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Jelszó"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi kikapcsolása"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#| msgid "Options…"
+msgid "More options…"
+msgstr "További beállítások…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "Kapcsolódás _rejtett hálózathoz…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi hotspot be_kapcsolása…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Ismert Wi-Fi hálózatok"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Ismeretlen állapot"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Felügyeletlen"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Nem érhető el"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Kapcsolódás"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Hitelesítés szükséges"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Bontás"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Kapcsolódás meghiúsult"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Ismeretlen állapot (hiányzik)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "A beállítás sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Az IP-beállítás sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Az IP-beállítás lejárt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Titkos információkra volt szükség, de nem lettek megadva"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "A 802.1x-kliens bontotta a kapcsolatot"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "A 802.1x-kliens beállítása meghiúsult"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "A 802.1x-kliens sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "A 802.1x-kliens hitelesítése túl sokáig tartott"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "A PPP szolgáltatás nem indult el"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP szolgáltatás leválasztva"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "A PPP sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "A DHCP kliens nem indult el"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP-klienshiba"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "A DHCP-kliens sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "A megosztott kapcsolat szolgáltatás nem indult el"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "A megosztott kapcsolat szolgáltatás sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Az AutoIP szolgáltatás nem indult el"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP szolgáltatáshiba"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Az AutoIP szolgáltatás sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "A vonal foglalt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Nincs tárcsahang"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Nem hozható létre hívás"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "A tárcsázási kérés túllépte az időkorlátot"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "A tárcsázási kísérlet meghiúsult"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "A modem előkészítése sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "A megadott APN kiválasztása meghiúsult"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Nem keres hálózatokat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Hálózatregisztráció megtagadva"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "A hálózatregisztráció túllépte az időkorlátot"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "A kért hálózaton való regisztráció sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "A PIN ellenőrzése sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Az eszközhöz firmware hiányozhat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "A kapcsolat eltűnt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "A meglévő kapcsolat felvéve"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Nem található modem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "A Bluetooth kapcsolódás sikertelen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "A SIM kártya nincs behelyezve"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "A SIM Pin szükséges"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "A SIM Puk szükséges"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "A SIM hibás"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Kapcsolódás függősége meghiúsult"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Hiányzó firmware"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kábel kihúzva"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "meghatározatlan hiba a 802.1X biztonságban (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "nincs fájl kiválasztva"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "meghatározatlan hiba az eap-method fájl ellenőrzése közben"
+
+#: panels/network/wireless-security/eap-method.c:394
+#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 vagy PGP személyes kulcsok"
+
+#: panels/network/wireless-security/eap-method.c:397
+#| msgid "_User certificate"
+msgid "DER or PEM certificates"
+msgstr "DER vagy PEM tanúsítványok"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "hiányzó EAP-FAST PAC fájl"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC fájlok (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonymous"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Hitelesített"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Mindkettő"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_Névtelen személyazonosság"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _fájl"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Válasszon PAC fájlt"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Belső _hitelesítés"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Automatikus PA_C létesítés engedélyezése"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "hiányzó EAP-LEAP felhasználónév"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "hiányzó EAP-LEAP jelszó"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Felhasználónév"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "Jels_zó"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Jelszó megjelenítése"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "érvénytelen EAP-PEAP CA tanúsítvány: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "érvénytelen EAP-PEAP CA tanúsítvány: nincs tanúsítvány megadva"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "0. verzió"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "1. verzió"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "_CA tanúsítvány"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Válasszon hitelesítésszolgáltatói tanúsítványt"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "CA tanúsítvány nem _szükséges"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_PEAP verzió"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "hiányzó EAP felhasználónév"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "hiányzó EAP jelszó"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "hiányzó EAP-TLS személyazonosság"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "érvénytelen EAP-TLS CA tanúsítvány: „%s”"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "érvénytelen EAP-TLS CA tanúsítvány: nincs tanúsítvány megadva"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "érvénytelen EAP-TLS személyes kulcs: „%s”"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "érvénytelen EAP-TLS felhasználói tanúsítvány: „%s”"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "A nem titkosított személyes kulcsok nem biztonságosak"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Úgy tűnik, hogy a kiválasztott személyes kulcsot nem védi jelszó. Ez "
+"lehetővé teszi a hitelesítési adatok kompromittálását. Válasszon jelszóval "
+"védett személyes kulcsot.\n"
+"\n"
+"Személyes kulcsát az OpenSSL segítségével teheti jelszóval védetté."
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Válassza ki a személyes tanúsítványát"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Válassza ki a személyes kulcsát"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "S_zemélyazonosság"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Felhasználói tanúsítvány"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Személyes k_ulcs"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "S_zemélyes kulcs jelszava"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "érvénytelen EAP-TTLS CA tanúsítvány: „%s”"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "érvénytelen EAP-TTLS CA tanúsítvány: nincs tanúsítvány megadva"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (nincs EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Tartomány"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Ismeretlen hiba a 802.1X biztonság ellenőrzésekor"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Alagutazott TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Védett EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Hitelesítés"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Fájl kiválasztása"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "hiányzó leap felhasználónév"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "hiányzó leap jelszó"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "A Wi-Fi jelszó hiányzik."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Típus"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "hiányzó wep-kulcs"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"érvénytelen wep-kulcs: egy %zu hosszú kulcsban csak hexadecimális számjegyek "
+"lehetnek"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"érvénytelen wep-kulcs: egy %zu hosszú kulcsban csak ascii karakterek lehetnek"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"érvénytelen wep-kulcs: hibás kulcshossz: %zu. A kulcs hossza 5/13 (ascii) "
+"vagy 10/26 lehet (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "érvénytelen wep-kulcs: a jelmondat nem lehet üres"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"érvénytelen wep-kulcs: a jelmondatnak 64 karakternél rövidebbnek kell lennie"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Alapértelmezett)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Nyílt rendszer"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Megosztott kulcs"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Kulcs"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Kul_cs megjelenítése"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP inde_x"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"érvénytelen wpa-psk: érvénytelen kulcshossz: %zu. [8,63] bájtnak, vagy 64 "
+"hexadecimális számjegynek kell lennie"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"érvénytelen wpa-psk: a 64 bájtos kulcs nem értelmezhető hexadecimálisként"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "É_rtesítések"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Figyelmeztető _hangok"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Felugró értesítések"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Az értesítések továbbra is megjelennek az értesítések listájában, ha a "
+"felugrók le vannak tiltva."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Üzenettartalom _megjelenítése a felugrókban"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Zárolási képernyő értesítések"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Üzenet_tartalom megjelenítése a zárolási képernyőn"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Ne zavarjanak"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Zárolási képernyő értesítések"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Az értesítések megjelenítésének és tartalmuk beállítása"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Értesítések;Felugró sáv;Üzenet;Sáv;Tálca;Figyelmeztetés;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Egyéb"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s eltávolítva"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Hiba a fiók eltávolításakor"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Visszavonás"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#| msgid "Show system notifications."
+msgid "Close the notification"
+msgstr "Az értesítés bezárása"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Kapcsolódás a felhőben lévő adataihoz"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Nincs internetkapcsolat – csatlakozzon új online fiókok beállításához"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Fiók hozzáadása"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s fiók"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Fiók eltávolítása"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "On­line fi­ó­kok"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Kapcsolódás online fiókjaihoz, és felhasználási módjuk kiválasztása"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Csevegés;Chat;Naptár;E-mail;Levél;"
+"Levelezés;Névjegyek;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Ismeretlen idő"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i perc"
+msgstr[1] "%i perc"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i óra"
+msgstr[1] "%i óra"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s, %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "óra"
+msgstr[1] "óra"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "perc"
+msgstr[1] "perc"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s a teljes feltöltésig"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Figyelem: %s van hátra"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s van hátra"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Teljesen feltöltve"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Nem tölt"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Lemerült"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Töltés"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Kisülés"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Vezeték nélküli egér"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Vezeték nélküli billentyűzet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Szünetmentes tápegység (UPS)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Személyes digitális asszisztens"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobiltelefon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Médialejátszó"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Táblagép"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Számítógép"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Bemeneti eszköz játékokhoz"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akkumulátor"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Elsődleges"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Extra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Akkumulátorok"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Ü_resjáratban"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Felfüggesztés"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Kikapcsolás"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernálás"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ne tegyen semmit"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Akkumulátoron"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Ha csatlakoztatva van"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Soha"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatikus felfüggesztés"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"A teljesítményközpontú mód átmenetileg letiltva a magas működési hőmérséklet "
+"miatt."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Ölben használat észlelve: a teljesítményközpontú mód átmenetileg nem érhető "
+"el. A helyreállításhoz helyezze stabil felületre az eszközt."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Teljesítményközpontú mód átmenetileg letiltva."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Alacsony töltés: energiatakarékos mód bekapcsolva. Az előző mód visszaáll, "
+"amint elég töltés lesz az akkumulátorban."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "A(z) „%s” aktiválta az energiatakarékos módot."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "A(z) „%s” aktiválta az teljesítményközpontú módot."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 perc"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 perc"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 perc"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 perc"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 perc"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 óra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 perc"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 perc"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 perc"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 óra"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Energiagazdálkodási mód"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Befolyásolja a rendszer teljesítményét és energiagazdálkodását."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Energiatakarékossági beállítások"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatikus képernyőfényerő"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "A képernyő fényereje a környező fényhez lesz igazítva."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Képernyő elhalványítása"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Csökkenti a képernyő fényerejét, ha a számítógép tétlen."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Képernyő el_sötétítése"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Bizonyos hosszúságú tétlenség után kikapcsolja a képernyőt."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatikus energiatakarékosság"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+"Engedélyezi az energiatakarékos módot, ha az akkumulátor töltöttsége "
+"alacsony."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatikus felfüggesztés"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Bizonyos hosszúságú tétlenség után szünetelteti a számítógépet."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "_Kikapcsolás gomb művelete"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "_Akkumulátorszázalék megjelenítése"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatikus felfüggesztés"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Csa_tlakoztatva"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "_Akkumulátoron"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Késleltetés"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Teljesítmény"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Magas teljesítmény és fogyasztás."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Kiegyensúlyozott"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Szokásos teljesítmény és fogyasztás."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Energiatakarékos"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Csökkentett teljesítmény és fogyasztás."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energiagazdálkodás"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Akkumulátorállapot megjelenítése és energiagazdálkodási beállítások "
+"módosítása"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Energia;Energiagazdálkodás;Alvás;Felfüggesztés;Hibernálás;Akkumulátor;Telep;"
+"Elsötétítés;Elhalványítás;Monitor;DPMS;Üresjárat;Energia;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "A(z) „%s” nyomtató törölve lett"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Az új nyomtató hozzáadása meghiúsult."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "A felület nem tölthető be: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Feloldás a nyomtatók hozzáadásához és a beállítások módosításához"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Nyom­tatók"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Nyomtatók hozzáadása, nyomtatási feladatok megjelenítése és nyomtatás "
+"beállítása"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Nyomtató;Sor;Nyomtatás;Papír;Tinta;Festékkazetta;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Nyomtató hozzáadása"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Feloldás"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Nem található nyomtató"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Adja meg a hálózati címet vagy keressen egy nyomtatót"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Hitelesítés szükséges"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Adja meg felhasználónevét és jelszavát a nyomtatókiszolgálón lévő nyomtatók "
+"megjelenítéséhez."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Felhasználónév"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s adatai"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Nem található megfelelő illesztőprogram"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Válasszon PPD fájlt"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript nyomtatóleíró fájlok (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+"A nyomtatónevek nem tartalmazhatnak szóközt, tabulátort, # vagy / karaktert"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Hely"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Illesztőprogram"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Előnyben részesített illesztőprogramok keresése…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Illesztőprogramok keresése"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Kiválasztás adatbázisból…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "PPD-fájl telepítése…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Válassza ki a nyomtató-illesztőprogramot"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Illesztőprogram-adatbázis betöltése…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Kijelölés"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect nyomtató"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD nyomtató"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Egyoldalas"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Hosszú él (szabványos)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Rövid él (fordított)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Álló"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Fekvő"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Fordított fekvő"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Fordított álló"
+
+#: panels/printers/pp-job-row.c:55
+#| msgid "_Resume"
+msgid "Resume"
+msgstr "Folytatás"
+
+#: panels/printers/pp-job-row.c:55
+#| msgctxt "print job"
+#| msgid "Paused"
+msgid "Pause"
+msgstr "Szüneteltetés"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Függőben"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Szüneteltetve"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Hitelesítés szükséges"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Feldolgozás"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Leállítva"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Megszakítva"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Félbeszakítva"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Befejezve"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "A feladat áthelyezése a sor elejére"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u feladat hitelesítést igényel"
+msgstr[1] "%u feladat hitelesítést igényel"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s – Aktív feladatok"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Hitelesítési adatok megadása a következőről történő nyomtatáshoz: %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Tartomány"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "Hi_telesítés"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Összes törlése"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Hitelesítés"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Nincsenek aktív nyomtatási feladatok"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Nyomtatókiszolgáló feloldása"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s feloldása."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Adja meg felhasználónevét és jelszavát a nyomtatók megjelenítéséhez ezen: %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Nyomtatók keresése"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Soros port"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Párhuzamos port"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Hely: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Cím: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "A kiszolgáló hitelesítést igényel"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Kétoldalas"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Papírtípus"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Papírforrás"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Kimeneti tálca"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Felbontás"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript előszűrés"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Oldalak laponként"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Kétoldalas"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Tájolás"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Általános"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Oldalbeállítás"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Telepíthető beállítások"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Feladat"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Képminőség"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Szín"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Befejezés"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Speciális"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Tesztoldal"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Tesztoldal"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Automatikus kiválasztás"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Nyomtató alapértelmezése"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Csak GhostScript betűkészletek beágyazása"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Átalakítás 1. PS szintre"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Átalakítás 2. PS szintre"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Nincs előszűrés"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Gyártó"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nincsenek aktív feladatok"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u feladat"
+msgstr[1] "%u feladat"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Nyomtatófejek tisztítása"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "A festékkazetta kifogyóban"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "A festékkazetta kifogyott"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Az előhívó kifogyóban"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Az előhívó kifogyott"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "A tintapatron kifogyóban"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "A tintapatron kifogyott"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Fedél nyitva"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Ajtó nyitva"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Kevés a papír"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Kifogyott a papír"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Kikapcsolva"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Leállítva"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "A hulladékgyűjtő majdnem tele"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "A hulladékgyűjtő tele"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Az optikai fotovezető közel jár az élete végéhez"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Az optikai fotovezető már nem működik"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Kész"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Nem fogad feladatokat"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Feldolgozás"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Nyomtatóbeállítások"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Nyomtató adatai"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Nyomtató használata alapértelmezetten"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Nyomtatófejek tisztítása"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Nyomtató eltávolítása"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modell"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Tintaszint"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Indítsa újra, ha a probléma megoldódott."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Újraindítás"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Nyomtató hozzáadása…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Nincsenek nyomtatók"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Elnézést, a rendszer nyomtatószolgáltatása\n"
+"    nem tűnik elérhetőnek."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formátumok"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Területi beállítások keresése…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Gyakori formátumok"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Összes formátum"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Nincs találat"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Országokra és nyelvekre kereshet."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Előnézet"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Angolszász"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrikus"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Dátumok"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dátumok és idők"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Számok"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mértékegység"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papír"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+"A nyelv és a formátum a következő bejelentkezés után lesz megváltoztatva"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Kijelentkezés…"
+
+#: panels/region/cc-region-panel.ui:45
+#| msgid ""
+#| "The language setting is used for interface text and web pages. Formats is "
+#| "used for numbers, dates, and currencies."
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"A nyelvi beállítás a kezelőfelület szövegéhez és a weboldalakhoz van "
+"használva. A formátumok a számokhoz, a dátumokhoz és a pénznemekhez vannak "
+"használva."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Az Ön fiókja"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Nyelv"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formátumok"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Bejelentkezési képernyő"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Terület és nyelv"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Válassza ki a felület nyelvét és az adatformátumokat"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Nyelv;kiosztás;billentyűzet;bevitel;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Kérdezze meg, mi a teendő"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Ne tegyen semmit"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Mappa megnyitása"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Egyéb média"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Válasszon alkalmazást CD-khez"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Válasszon alkalmazást videó DVD-khez"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Válassza ki a zenelejátszó csatlakoztatásakor futtatandó alkalmazást"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Válassza ki a fényképezőgép csatlakoztatásakor futtatandó alkalmazást"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Válasszon alkalmazást szoftver CD-khez"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "hang DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "üres Blu-Ray lemez"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "üres CD-lemez"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "üres DVD-lemez"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "üres HD DVD-lemez"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray videolemez"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "e-könyvolvasó"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD videolemez"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows-szoftver"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Válassza ki az adathordozók kezelésének módját"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _hang"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD videó"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Zenelejátszó"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "Sz_oftver"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Egyéb adathordozók…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"Soha _ne kérdezzen vagy indítson programokat adathordozó behelyezésekor"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Válassza ki az egyéb adathordozók kezelésének módját"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Művelet:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Típus:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Külső adathordozók"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Külső adathordozók beállításai"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"eszköz;rendszer;információk;memória;processzor;verzió;alapértelmezett;"
+"alkalmazás;előnyben részesített;cd;dvd;usb;hang;videó;lemez;eltávolítható;"
+"cserélhető;média;automatikus futtatás;autorun;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Képernyő kikapcsol"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 másodperc"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 perc"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 perc"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 perc"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+#| msgctxt "blank_screen"
+#| msgid "5 minutes"
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 perc"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 perc"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 óra"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 perc"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 perc"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 perc"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 perc"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 perc"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 perc"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 perc"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 perc"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 perc"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Soha"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Képernyőzár"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"A képernyő automatikus zárolása megakadályozza, hogy mások elérjék a "
+"számítógépét, amíg Ön távol van."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Képernyő elsötétítésének késleltetése"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Tétlenség hossza, miután a képernyő el fog sötétülni."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "A_utomatikus képernyőzárolás"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Automatikus _képernyőzárolás késleltetése"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Időtartam, amely után a képernyő elsötétül, ha a képernyő automatikusan "
+"zárolásra kerül."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "É_rtesítések megjelenítése a zárolási képernyőn"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Új _USB-s eszközök tiltása"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Az új USB-s eszközök megakadályozása, hogy ne tudjanak kapcsolatba lépni a "
+"rendszerrel, ha a képernyő zárolt."
+
+#: panels/screen/cc-screen-panel.ui:108
+#| msgid "Privacy"
+msgid "Screen Privacy"
+msgstr "Képernyő-adatvédelem"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Látószög korlátozása"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#| msgid "Settings"
+msgid "Screen Settings"
+msgstr "Képernyő-beállítások"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "képernyő;zárolás;személyes;adatvédelem;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Válasszon régiót"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Keresési helyek"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Azok a mappák, amelyeket a rendszer alkalmazásai keresnek, például Fájlok, "
+"Képek és Videók."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Helyek"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Könyvjelzők"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Egyebek"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Hely hozzáadása"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nem találhatók alkalmazások"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Alkalmazás keresése"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Tartalmazza az alkalmazás által biztosított keresési eredményeket."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Azok a mappák, amelyeket a rendszer alkalmazásai keresnek."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Keresési eredmények"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "A találatok a lista sorrendje szerint vannak megjelenítve."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"A Tevékenységek áttekintésben találatokat megjelenítő alkalmazások beállítása"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Keresés;Indexelés;Elrejtés;Adatvédelem;Találatok;Eredmények;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Nincs kiválasztott hálózat a megosztáshoz"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Hálózatok"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Be"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Ki"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Engedélyezve"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktív"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Válasszon mappát"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Hozzáadás"
+
+#: panels/sharing/cc-sharing-panel.c:736
+#| msgid "Media Sharing"
+msgid "Enable media sharing"
+msgstr "Médiamegosztás engedélyezése"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"A fájlmegosztás lehetővé teszi a Nyilvános mappájának megosztását másokkal a "
+"jelenlegi hálózaton a %s használatával."
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Ha a távoli bejelentkezés engedélyezett, akkor a távoli felhasználók a "
+"következő parancs használatával kapcsolódhatnak:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Személyes médiamegosztás engedélyezése"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+#| msgid "Device Name"
+msgid "Device name copied"
+msgstr "Eszköznév lemásolva"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Eszközcím lemásolva"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+#| msgid "Username"
+msgid "Username copied"
+msgstr "Felhasználónév lemásolva"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+#| msgid "Password"
+msgid "Password copied"
+msgstr "Jelszó lemásolva"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Megosztás"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Számítógép neve"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Fájlmegosztás"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Távoli _asztal"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Médiamegosztás"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Távoli bejelentkezés"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Fájlmegosztás"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Jelszó _kérése"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Távoli bejelentkezés"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Távoli asztal"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"A távoli asztal lehetővé teszi az asztal megtekintését és vezérlését egy "
+"másik számítógépről."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Erre a számítógépre érkező távoli asztali kapcsolatok engedélyezése vagy "
+"letiltása."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Távoli vezérlés"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Engedélyezi a távoli kapcsolatokat a képernyő vezérléséhez."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Hogyan kapcsolódjon"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Kapcsolódás ehhez a számítógéphez az eszköz nevének vagy a távoli asztal "
+"címének használatával."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Másolás"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Távoli asztal címe"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Hitelesítés"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"A felhasználónév és jelszó kötelező a számítógéphez történő kapcsolódáshoz."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Felhasználónév"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Titkosítás ellenőrzése"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Titkosítás ujjlenyomata"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+#| msgid ""
+#| "The encryption fingerprint can be seen in connecting clients and should "
+#| "be identical"
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"A titkosítás ujjlenyomata a kapcsolódó kliensprogramokban látható, és "
+"azonosnak kell lennie."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Médiamegosztás"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Zenék, fényképek és videók megosztása a hálózaton."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Mappák"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Megosztások beállítása"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"megosztás;ssh;host;név;távoli;asztal;média;audio;hang;video;kép;fénykép;"
+"filmek;kiszolgáló;szerver;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Távoli bejelentkezés engedélyezése vagy tiltása"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Hitelesítés szükséges a távoli bejelentkezés engedélyezéséhez vagy tiltásához"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Egyéni"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Kattintás"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#| msgid "Sharing"
+msgid "String"
+msgstr "Karakterlánc"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Hinta"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Hümmögés"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Egyensúly"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Elhalás"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Hátsó"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Első"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s tesztelése"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "A teszteléshez kattintson egy hangszóróra"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Rendszerhangerő"
+
+#: panels/sound/cc-sound-panel.ui:12
+#| msgid "System Volume"
+msgid "Master volume"
+msgstr "Fő hangerő"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Hangerőszintek"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Kimenet"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Kimeneti eszköz"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Teszt"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Beállítások"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Mélysugárzó"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Bemenet"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Bemeneti eszköz"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Hangerő"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Riasztási hang"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Némítás"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Hang"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Hangerő, bemenetek, kimenetek és riasztáshangok módosítása"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kártya;Mikrofon;Hangerő;Elhalás;Egyensúly;Bluetooth;Fejhallgató;Audio;Hang;"
+"Kimenet;Bemenet;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Bontva"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Kapcsolódás"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Kapcsolódva"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Engedélyezési hiba"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Engedélyezés"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Csökkentett funkcionalitás"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Kapcsolódva és engedélyezve"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Ismeretlen"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Engedélyezve ekkor:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Kapcsolódva ekkor:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Bejegyezve ekkor:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Az eszköz engedélyezése meghiúsult: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Az eszköz elfelejtése meghiúsult: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "%u egyéb eszköztől függ"
+msgstr[1] "%u egyéb eszköztől függ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#| msgid "Show system notifications."
+msgid "Close notification"
+msgstr "Értesítés bezárása"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Név:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Állapot:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Engedélyezés és kapcsolódás"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Eszköz elfelejtése"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Hiba"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Engedélyezve"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"A Thunderbolt alrendszer (boltd) nincs telepítve vagy rosszul van beállítva."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Közvetlen hozzáférés engedélyezése az olyan eszközökhöz, mint a dokkolók és "
+"külső GPU-k."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Csak USB és Display Port eszközök csatlakoztathatóak."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"A Thunderbolt nem észlelhető.\n"
+"Vagy hiányzik a rendszerből a Thunderbolt támogatás, vagy le lett tiltva a "
+"BIOS-ban, vagy nem támogatott biztonsági szintre van állítva a BIOS-ban."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "A Thunderbolt támogatás le lett tiltva a BIOS-ban."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "A Thunderbolt biztonsági szintje nem határozható meg."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Hiba a közvetlen módra váltáskor: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Nincs Thunderbolt támogatás"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Nem sikerült kapcsolódni a thunderbolt alrendszerhez."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Közvetlen hozzáférés"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Függőben lévő eszközök"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Nincs eszköz csatlakoztatva"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Thunderbolt eszközök kezelése"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;adatvédelem;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Villogó kurzor"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "A kurzor villog a szövegmezőkben."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Sebesség"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Kurzor villogásának sebessége"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Kurzorméret"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"A kurzorméret egyesíthető a nagyítással a kurzor könnyebben láthatóvá "
+"tételéhez."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Kattintássegéd"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Szim_ulált másodlagos kattintás"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Másodlagos kattintás aktiválása az elsődleges gomb nyomva tartásával"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Elfogadás késleltetése:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Rövid"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Másodlagos kattintás késleltetése"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Hosszú"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Rámutatási kattintás"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Kattintás kezdeményezése a mutató mozgásának megállásakor"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Késlel_tetés:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Rövid"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Hosszú"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "M_ozgás küszöbszintje:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Alacsony"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Magas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Billentyűk ismétlése"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "A billentyűlenyomások ismétlése a gomb nyomva tartásakor."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Billentyűk ismétlésének késleltetése"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Billentyűk ismétlésének sebessége"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Gépelési segéd"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Ragadós billentyűk"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "A módosítóbillentyűk sorozatát billentyűkombinációként kezeli"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Letiltás két billentyű egyi_dejű lenyomásakor"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Hangjelzés _módosító billentyű lenyomásakor"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Lassú billentyűk"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Késleltetés a billentyűk lenyomása és elfogadása között"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Rövid"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Lassú billentyűk késleltetése"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Hosszú"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Hangjelzés billentyű le_nyomásakor"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Hangjelzés billentyű _elfogadásakor"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Hangjelzés billentyű el_utasításakor"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Billentyűs_zűrés"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ismételt leütések figyelmen kívül hagyása"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Rövid"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Billentyűszűrés késleltetése"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Hosszú"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Enge_délyezés billentyűzetről"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Akadálymentesítési szolgáltatások be- és kikapcsolása a billentyűzetről"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Alapértelmezett"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Közepes"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Nagy"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Nagyobb"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Legnagyobb"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d képpont"
+msgstr[1] "%d képpont"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Akadálymentesítés menü megjelenítése mindig"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Látás"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Nagy k_ontraszt"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Nagy s_zöveg"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "A_nimációk engedélyezése"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Képernyőolvasó"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"A képernyőolvasó felolvassa a megjelenített szöveget a fókusz mozgatása "
+"közben."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Billentyű_hangok"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Hangjelzés a Num Lock vagy Caps Lock ki- és bekapcsolásakor."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "K_urzorméret"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Nagyítás"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Hallás"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Vizuális figyelmeztetések"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Képe_rnyő-billentyűzet"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Billentyűk _ismétlése"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Villogó kurzor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Gépelési segéd (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Mutatás és kattintás"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Egérbillentyűk"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Mutató _megkeresése"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Kattintássegé_d"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Dupla kattintás késleltetése"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Dupla kattintás késleltetése"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Vizuális figyelmeztetések"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Villanás tesztelése"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Vizuális jelzés használata figyelmeztető hang esetén."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Teljes _képernyő megvillantása"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Teljes _ablak megvillantása"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Rövid"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ képernyő"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ képernyő"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ képernyő"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Hosszú"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Teljes képernyő"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Felső fél"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Alsó fél"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Bal fél"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Jobb fél"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Nagyító beállításai"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Nagyítás:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Nagyító pozíciója:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "Egérkurzor _követése"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Képernyő_részlet:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "A nagyító _kiterjed a képernyőn kívülre is"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "A nagyítókurzor középen _tartása"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "A nagyítókurzor _eltolja a tartalmakat"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "A nagyítókurzor a tartalmakkal együtt _mozog"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Nagyító"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Szál_keresztek:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Át_fedi az egérkurzort"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Vastagság:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Vékony"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Vastag"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Hossz:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Szín:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Szálkeresztek"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Színeffektusok:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "F_ehér a feketén:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Fényerő:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontraszt:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Szín"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Nincs"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Teljes"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Alacsony"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Magas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Alacsony"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Nagy"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Színeffektusok"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "A látás, hallás, gépelés, mutatás és kattintás egyszerűbbé tétele"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Billentyűzet;Egér;a11y;Akadálymentesítés;Kontraszt;Kurzor;Hang;Nagyítás;"
+"Képernyő;Olvasó;magas;szöveg;betű;méret;AccessX;Ragadós;Billentyűk;Lassú;"
+"Pattogó;Egér;Dupla;kattintás;Késleltetés;Sebesség;Kisegítő;Ismétlés;Villogás;"
+"vizuális;hallás;hang;írás;animációk;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 óra"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 nap"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 nap"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 nap"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 nap"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 nap"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 nap"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 nap"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 nap"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 nap"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Törölni kívánja az összes elemet a Kukából?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "A Kuka összes eleme véglegesen törölve lesz."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Kuka ürítése"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Törli az összes ideiglenes fájlt?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Minden ideiglenes fájl véglegesen törlésre kerül."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Ideiglenes fájlok törlése"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 nap"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 nap"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 nap"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Örökké"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Fájlelőzmények"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"A fájlelőzmények rögzítik a használt fájlokat. Ez az információ meg van "
+"osztva az alkalmazások között, így könnyebbé teszi azon fájlok megtalálását, "
+"amelyeket használni szeretne."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Fájl_előzmények"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Fájlelőzmények _hossza"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Előzmények _törlése…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Kuka és ideiglenes fájlok"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"A kuka és ideiglenes fájlok gyakran személyes vagy érzékeny információkat "
+"tartalmazhatnak. Az automatikus törlésük segíthet az adatvédelemben."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "K_uka tartalmának automatikus ürítése"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "_Ideiglenes fájlok automatikus törlése"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Automatikus törlés _időszaka"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Kuka ürítése…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Ideiglenes fájlok _törlése…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Fájlelőzmények és kuka"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Ne hagyjon nyomokat"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"használat;legutóbbi;előzmények;fájlok;átmeneti;tmp;személyes;adatvédelem;kuka;"
+"törlés;megtartás;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Egyeznie kell a bejelentkezés szolgáltatójának webcímével."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "A fiók hozzáadása sikertelen"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "A jelszavak nem egyeznek."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "A fiók regisztrálása sikertelen"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Nincs támogatott módszer a tartományban való hitelesítésre"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Nem sikerült a tartományhoz csatlakozni"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"A bejelentkezési név nem működik.\n"
+"Próbálja újra."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"A bejelentkezési jelszó nem működik.\n"
+"Próbálja újra."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Nem sikerült bejelentkezni a tartományba"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "A tartomány nem található. Lehet, hogy elgépelte?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Felhasználó hozzáadása"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Rendszergazda"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"A rendszergazdák hozzáadhatnak és eltávolíthatnak más felhasználókat, és "
+"módosíthatják az összes felhasználó beállításait. A szülői felügyelet nem "
+"alkalmazható rendszergazdákra."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "A felhasználó az első bejelentkezéskor állít be jelszót"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Jelszó beállítása most"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Megerősítés"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Vállalati bejelentkezés"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+#| msgid "User accounts which are managed by a company or organisation."
+msgid "User accounts which are managed by a company or organization."
+msgstr "Felhasználói fiókok, amelyeket egy vállalat vagy szervezet kezel."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Kapcsolat nélkül"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"A vállalati bejelentkezés lehetővé teszi egy meglévő, központilag felügyelt "
+"felhasználói fiók használatát ezen az eszközön. A fiókot arra is "
+"használhatja, hogy céges erőforrásokhoz férjen hozzá az interneten."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "További képek tallózása"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Fájl kiválasztása…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Ujjlenyomat-kezelő"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Ujjlenyomat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Nem"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Igen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Törölni kívánja a regisztrált ujjlenyomatokat, ezzel letiltva az "
+"ujjlenyomatos bejelentkezést?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Nincs ujjlenyomatos eszköz"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Nincs ujjlenyomatos eszköz"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Győződjön meg róla, hogy az eszköz helyesen van csatlakoztatva."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Ujjlenyomatos eszköz"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Válasszon ujjlenyomatos eszközt a beállításhoz"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Ujjlenyomatos bejelentkezés"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Az ujjlenyomatos bejelentkezéssel az ujjával oldhatja fel és jelentkezhet be "
+"a számítógépébe"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "Ujjlenyomatok _törlése"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Ujjlenyomat bevitele"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "az eszközt le kell foglalni a művelet elvégzéséhez"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "az eszközt már lefoglalta egy másik folyamat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "nincs jogosultsága a művelet elvégzéséhez"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "nem lett lenyomat bevíve"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Nem sikerült kommunikálni az eszközzel a bevitel során"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Nem sikerült kommunikálni az ujjlenyomat-olvasóval"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Nem sikerült kommunikálni az ujjlenyomat-démonnal"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Az ujjlenyomatok felsorolása sikertelen: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "A mentett ujjlenyomatok törlése sikertelen: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Bal hüvelykujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Bal középső ujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Bal mutatóujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Bal gyűrűsujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Bal kisujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Jobb hüvelykujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Jobb középső ujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Jobb mutatóujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Jobb gyűrűsujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Jobb kisujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Ismeretlen ujj"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Kész"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Ujjlenyomatos eszköz leválasztva"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Ujjlenyomatos eszköz tárhelye megtelt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Az új ujjlenyomat bevitele sikertelen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "A bevitel elindítása sikertelen: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Az új ujjlenyomat bevitele sikertelen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "A bevitel leállítása sikertelen: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Ismételten emelje fel, majd helyezze az ujját az olvasóra az ujjlenyomat "
+"beviteléhez"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Ujj ú_jbóli bevitele…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Új ujjlenyomat leolvasása"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "A(z) %s ujjlenyomatos eszköz kiadása sikertelen: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Probléma az eszköz olvasásakor"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "A(z) %s ujjlenyomatos eszköz megszerzése sikertelen: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Az ujjlenyomatos eszközök lekérése sikertelen: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Ezen a héten"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Múlt héten"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b. %-e."
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%Y. %b. %-e."
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s – %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%H:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Munkamenet befejeződött"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Munkamenet elkezdődött"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s – Fiókaktivitás"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#| msgid "Previous track"
+msgid "Previous"
+msgstr "Előző"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#| msgid "_Next"
+msgid "Next"
+msgstr "Következő"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Válasszon másik jelszót."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Írja be újra jelenlegi jelszavát."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "A jelszót nem sikerült megváltoztatni"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Jelszó megváltoztatása"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Mó_dosítás"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Jelenlegi jelszó"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Új jelszó"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Jelszó megerősítése"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "A felhasználó módosíthatja a jelszót a következő bejelentkezéskor"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Jelszó beállítása most"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Ilyen típusú tartományhoz nem lehet automatikusan csatlakozni"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Nem található ilyen tartomány vagy zóna"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Nem lehet bejelentkezni %s néven a(z) %s tartományba"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Érvénytelen jelszó, próbálja újra"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Nem lehet csatlakozni a(z) %s tartományhoz: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "A felhasználó törlése meghiúsult"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "A távmenedzselt felhasználó visszavonása meghiúsult"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Nem törölheti saját fiókját."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s még be van jelentkezve"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"A bejelentkezett felhasználók törlése a rendszert inkonzisztens állapotban "
+"hagyhatja."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Meg szeretné tartani %s fájljait?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Felhasználói fiók törlésekor lehetősége van a saját könyvtár, a levelezési "
+"várólista és az ideiglenes fájlok megtartására."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "Fájlok _törlése"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "Fájlok _megtartása"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Biztosan vissza szeretné vonni a távmenedzselt %s fiókját?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Törlés"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Fiók letiltva"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Következő belépéskor állítandó be"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Nincs"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Bejelentkezve"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "A fiókszolgáltatás nem érhető el"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Győződjön meg róla, hogy az AccountService telepítve van és fut."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Ezt a panelt fel kell oldani a beállítás megváltoztatásához"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Kijelölt felhasználói fiók törlése"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"A kijelölt felhasználói fiók törléséhez\n"
+"először kattintson a * ikonra"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Feloldás a felhasználók hozzáadásához és a beállítások módosításához"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Felhasználók"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "A változtatások életbe léptetéséhez lépjen ki, majd újra be"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Újraindítás most"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Bezárás"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Profilkép szerkesztése"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#| msgid "Full access"
+msgid "Full name"
+msgstr "Teljes név"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Szerkesztés"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Ujjlenyomatos bejelentkezés"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatikus bejelentkezés"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Fióktevékenység"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Rendszergazda"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"A rendszergazdák hozzáadhatnak és eltávolíthatnak más felhasználókat, és "
+"módosíthatják az összes felhasználó beállításait."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "Szülői _felügyeleti eszközök"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "A Szülői felügyeleti eszközök alkalmazás megnyitása."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Felhasználó eltávolítása…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Egyéb felhasználók"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Felhasználó hozzáadása…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Nem találhatók felhasználók"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Feloldás felhasználói fiók hozzáadásához."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Felhasználók hozzáadása vagy eltávolítása és jelszómódosítás"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Bejelentkezés;Név;Ujjlenyomat;Profilkép;Logó;Arc;Jelszó;Szülői felügyelet;"
+"Képernyőidő;Alkalmazáskorlátozások;Webes korlátozások;Használat;Limit;"
+"Gyermek;Gyerek;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "B_ejegyzés"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Tartományadminisztrátori bejelentkezés"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"A vállalati bejelentkezések használatához a számítógépet be kell\n"
+"jegyezni a tartományba. Kérje meg a hálózati rendszergazdát,\n"
+"hogy írja be itt a tartomány jelszavát."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Rendszergazda _neve"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Rendszergazdai jelszó"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Felhasználói fiókok kezelése"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Hitelesítés szükséges a felhasználói adatok módosításához"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Az új jelszó nem lehet azonos a régivel."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Próbáljon megváltoztatni néhány betűt és számot."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Próbálja jobban megváltoztatni a jelszót."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "A felhasználói neve nélkül a jelszava erősebb."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Próbálja meg kihagyni a felhasználónevét a jelszóból."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Próbálja meg kerülni a jelszóban lévő szavak egy részét."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Próbálja meg kerülni a gyakori szavakat."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Próbálja meg kerülni a meglévő szavak átrendezését."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Próbáljon meg több számot használni."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Próbáljon meg több nagybetűt használni."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Próbáljon meg több kisbetűt használni."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Próbáljon meg több speciális karaktert, például írásjeleket használni."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Próbálja meg betűk, számok és írásjelek keverékét használni."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Próbálja meg kerülni ugyanannak a karakternek az ismétlését."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Próbálja meg kerülni ugyanazon típusú karakterek ismétlését: keverjen "
+"betűket, számokat és írásjeleket."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Próbálja meg kerülni az 1234 vagy abcd-szerű egyszerű sorozatokat."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"A jelszónak hosszabbnak kell lennie. Próbáljon meg több betűt, számot és "
+"írásjelet hozzáadni."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Használjon vegyesen kis- és nagybetűket, és tegyen közéjük egy-két számot is."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Több betű, szám és írásjel hozzáadása erősebbé fogja tenni a jelszót."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "A hitelesítés meghiúsult"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Az új jelszó túl rövid"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Az új jelszó túl egyszerű"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "A régi és az új jelszó túlságosan hasonlít egymáshoz"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Az új jelszót nemrég használta."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+"Az új jelszónak számokat vagy speciális karaktereket is tartalmaznia kell"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "A régi és az új jelszó ugyanaz"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "A jelszava megváltozott az első hitelesítés óta."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Az új jelszó nem tartalmaz elég eltérő karaktert"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Ismeretlen hiba"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"A felhasználónév általában csak a-z közötti kisbetűkből, számjegyekből és a "
+"következő karakterekből állhat: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Ez a felhasználónév nem érhető el. Próbáljon egy másikat."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "A felhasználónév túl hosszú."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Gombok leképezése"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Gombok leképezése funkciókra"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Gyorsbillentyű szerkesztéséhez válassza a „Billentyűleütés küldése” "
+"műveletet, nyomja meg a gyorsbillentyű gombot, majd nyomja le az új "
+"billentyűket vagy a Backspace billentyűt a törléshez."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Bezárás"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "Érintse meg a céljelölőket a képernyőn a táblagép kalibrálásához."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Félrekattintás észlelve, újraindítás…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "%d. gomb"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Alkalmazás által meghatározott"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Billentyűleütés küldése"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Monitorváltás"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Képernyőn lévő súgó megjelenítése"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Laptop paneljéhez csatolt rajztábla"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Külső kijelzőre csatolt rajztábla"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Külső rajztábla eszköz"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#| msgid "External tablet device"
+msgid "External pad device"
+msgstr "Külső rajztábla eszköz"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Összes kijelző"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Táblagép mód"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Abszolút pozicionálás használata a tollnál"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Balkezes tájolás"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+"A rajztábla és a gyorsbillentyűk balkezes használathoz vannak elforgatva"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Leképezés monitorra"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Méretarány megtartása"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"A rajztábla felületének csak egy részét használja a monitor képarányának "
+"megtartásához"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibrálás"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nem található rajztábla"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Csatlakoztassa vagy kapcsolja be Wacom rajztábláját."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Hegy nyomásérzékenysége"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+#| msgid "_Software"
+msgid "Soft"
+msgstr "Lágy"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+#| msgid "Standard stylus with pressure"
+msgid "Stylus tip pressure"
+msgstr "Toll hegyének nyomása"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Kemény"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "1. gomb"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "2. gomb"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "3. gomb"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Radír nyomásérzékenysége"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#| msgid "Eraser Pressure Feel"
+msgid "Eraser pressure"
+msgstr "Radír nyomása"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Középső egérgombkattintás"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Jobb egérgombkattintás"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Tovább"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Festékszóró toll nyomás, dőlés és integrált csúszka funkcióval"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Festékszóró toll nyomás, dőlés és forgatás funkcióval"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Szabványos toll nyomás és dőlés funkcióval"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Szabványos toll nyomás funkcióval"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom rajztábla"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Rajztáblák gombleképezéseinek beállítása és a toll érzékenységének módosítása"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Rajztábla;Wacom;Toll;Radír;Egér;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Új gyorsbillentyű…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Hozzáférési pontok"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Művelet megszakítva"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Hiba:</b> Hozzáférés megtagadva a beállítások módosításakor"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Hiba:</b> Mobilfelszerelést érintő hiba"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Nem regisztrált"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Regisztrált"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Barangolás"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Keresés"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Megtagadva"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modem részletei"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modem állapota"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Szolgáltató"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Hálózattípus"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Hálózati állapot"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Saját szám"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Eszköz adatai"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Firmware verzió"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Csak 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Csak 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Csak 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+#| msgid "2G Only"
+msgid "5G Only"
+msgstr "Csak 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (előnyben részesített), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+#| msgid "2G, 3G (Preferred), 4G"
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (előnyben részesített), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+#| msgid "2G (Preferred), 3G, 4G"
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (előnyben részesített), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+#| msgid "2G, 3G, 4G"
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (előnyben részesített), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (előnyben részesített), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+#| msgid "3G, 4G (Preferred)"
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+#| msgid "3G, 4G (Preferred)"
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (előnyben részesített), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+#| msgid "3G (Preferred), 4G"
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (előnyben részesített), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+#| msgid "3G, 4G"
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+#| msgid "2G, 3G (Preferred), 4G"
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (előnyben részesített), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+#| msgid "2G (Preferred), 3G, 4G"
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (előnyben részesített), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+#| msgid "2G, 3G, 4G"
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+#| msgid "2G, 3G (Preferred), 4G"
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (előnyben részesített), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+#| msgid "2G (Preferred), 3G, 4G"
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (előnyben részesített), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+#| msgid "2G, 3G, 4G"
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (előnyben részesített), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (előnyben részesített), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (előnyben részesített), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+#| msgid "2G, 4G (Preferred)"
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+#| msgid "2G (Preferred), 4G"
+msgid "2G (Preferred), 5G"
+msgstr "2G (előnyben részesített), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+#| msgid "2G, 4G"
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+#| msgid "3G, 4G (Preferred)"
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+#| msgid "3G (Preferred), 4G"
+msgid "3G (Preferred), 5G"
+msgstr "3G (előnyben részesített), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+#| msgid "3G, 4G"
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+#| msgid "3G, 4G (Preferred)"
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (előnyben részesített)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+#| msgid "3G (Preferred), 4G"
+msgid "4G (Preferred), 5G"
+msgstr "4G (előnyben részesített), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Ismeretlen"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "SIM-kártya feloldása"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Feloldás"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Adja meg a PIN-kódot a(z) %d. SIM-kártyához"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Adja meg a PIN-kódot a SIM-kártyája feloldásához"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Adja meg a PUK-kódot a(z) %d. SIM-kártyához"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Adja meg a PUK-kódot a SIM-kártyája feloldásához"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Hibás jelszó lett megadva. Még %1$u próbálkozása maradt."
+msgstr[1] "Hibás jelszó lett megadva. Még %1$u próbálkozása maradt."
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "%u próbálkozása maradt"
+msgstr[1] "%u próbálkozása maradt"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Hibás jelszó lett megadva."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "A PUK-kódnak 8 számjegyűnek kell lennie"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Új PIN-kód megadása"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "A PIN-kódnak 4-8 számjegyűnek kell lennie"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Feloldás…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Nincs SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Helyezzen be egy SIM-kártyát a modem használatához"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM zárolva"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobil adatkapcsolat"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Adatkapcsolat mobilhálózat használatával"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Adatbarangolás"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Mobil adatkapcsolat használata barangolás közben"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Hálózati _mód"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Hálózat"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Speciális"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Hozzáférési pontok nevei"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM zárolása"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "SIM zárolása PIN-kóddal"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "M_odem részletei"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Telefonhiba"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Nincs kapcsolat a telefon felé"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "A művelet nem engedélyezett"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "A művelet nem támogatott"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "A SIM-kártya nincs behelyezve"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "A SIM-kártya PIN-kódja szükséges"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "A SIM-kártya PUK-kódja szükséges"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM-kártya hiba"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "A SIM-kártya foglalt"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Helytelen jelszó"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "A SIM-kártya PIN2-kódja szükséges"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "A SIM-kártya PUK2-kódja szükséges"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Nem található"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Nincs hálózati szolgáltatás"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Hálózat időtúllépése"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "A GPRS szolgáltatások nem engedélyezettek"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "A barangolás nem engedélyezett ezen a területen"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Meghatározatlan GPRS hiba"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+#| msgctxt "Thunderbolt Device Status"
+#| msgid "Error"
+msgid "No Error"
+msgstr "Nincs hiba"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Művelet megszakítva"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Hozzáférés megtagadva"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Ismeretlen hiba"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Hálózati mód"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatikus"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Válasszon hálózatot"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Hálózati szolgáltatók frissítése"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "%d. SIM"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Mobilhálózat engedélyezése"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nem található WWAN adapter"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+"Győződjön meg róla, hogy rendelkezik vezeték nélküli WAN/mobil eszközzel"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "A vezeték nélküli WAN ki van kapcsolva repülési üzemmódban"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Repülési üzemmód _kikapcsolása"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Adatkapcsolat"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Internethez használandó SIM-kártya"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM-kártya zár"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Következő"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "SIM-kártya _zárolása PIN-kóddal"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "PIN-kód módosítása"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+"Adja meg a jelenlegi PIN-kódot a SIM-kártya zárolási beállításainak "
+"módosításához"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobilhálózat"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Telefónia és mobil adatkapcsolatok beállítása"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "mobil;wwan;telefónia;sim;telefon;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Segédprogram a GNOME asztali környezet személyre szabásához"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "A Beállítások az elsődleges felület a rendszer beállításához."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "A GNOME projekt"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Verziószám kiírása"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Részletes mód engedélyezése"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Karakterlánc keresése"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Lehetséges panelnevek felsorolása és kilépés"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Megjelenítendő panel"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENTUM…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Beállítások kategóriái"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Adatvédelem"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Elérhető panelek:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Minden beállítás"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Elsődleges menü"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Figyelmeztetés: fejlesztői verzió"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"A Beállítások ezen verziója csak fejlesztési célokra használandó. Nem "
+"megfelelő rendszerműködést, adatvesztést és más váratlan problémákat "
+"tapasztalhat. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Súgó"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Általános"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Kilépés"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Keresés"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panelek"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Vissza az előző panelhez"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Keresés megszakítása"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Tulajdonságok;Beállítások;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Az azonosító a megnyitandó legutolsó Beállítások panelhez"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Az azonosító a megnyitandó legutolsó Beállítások panelhez. A "
+"felismerhetetlen értékek mellőzve lesznek, és a listában lévő első panel "
+"kerül kiválasztásra."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Figyelmeztetés megjelenítése, ha a Beállítások fejlesztői verzióját futtatja"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"A Beállítások jelenítsen-e meg figyelmeztetést, ha fejlesztői kiadást "
+"használ."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Az ablak kezdeti állapota"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Egy elemhármas, amely az alkalmazásablak kezdeti szélességét, magasságát és "
+"maximalizálási állapotát tartalmazza."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u kimenet"
+msgstr[1] "%u kimenet"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u bemenet"
+msgstr[1] "%u bemenet"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Rendszerhangok"

--- a/po/hy.po
+++ b/po/hy.po
@@ -7,2165 +7,6364 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.HEAD.hy\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-09-01 11:35+0500\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2010-09-02 11:06+0400\n"
 "Last-Translator: Nune <nune@instigatedesign.com>\n"
 "Language-Team:  <norayr@arnet.am>\n"
 "Language: hy\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-#: ../gnome-control-center.schemas.in.h:1
-msgid "Current network location"
-msgstr "Ընթացիկ ցանցի տեղակայություն"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
+msgstr "Նախընտրելի ծրագրեր"
 
-#: ../gnome-control-center.schemas.in.h:2
-msgid "More backgrounds URL"
-msgstr "Ավելի շատ ֆոների URL"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Նախընտրելի ծրագրեր"
 
-#: ../gnome-control-center.schemas.in.h:3
-msgid "More themes URL"
-msgstr "Ավելի շատ թեմաների URL"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Տեղադրված է"
 
-#: ../gnome-control-center.schemas.in.h:4
-msgid ""
-"Set this to your current location name. This is used to determine the "
-"appropriate network proxy configuration."
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
 msgstr ""
-"Կարգավորել սա ընթացիկ տեղակայության անվանման համար։ Սա օգտագործվում է "
-"համապատասխան ցանցի պրոքսի կոնֆիգուրացիան որոշելու համար։"
 
-#: ../gnome-control-center.schemas.in.h:5
-msgid ""
-"URL for where to get more desktop backgrounds. If set to an empty string the "
-"link will not appear."
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_Մանրամասներ"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
 msgstr ""
-"URL որտեղից ստանալ աշխատասեղանի ավելի շատ ֆոների համար։ Եթե կարգավորված է "
-"դատարկ ծրագրատողում տողը չի երևա։"
 
-#: ../gnome-control-center.schemas.in.h:6
-msgid ""
-"URL for where to get more desktop themes. If set to an empty string the link "
-"will not appear."
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
-"URL՝ ավելի շատ աշխատանքային սեղանի թեմաներ գտնելու համար։ Դատարկ տողի "
-"դեպքում հղումը չի հայտնվի։"
 
-#: ../libgnome-control-center/gconf-property-editor.c:134
-msgid "Key"
-msgstr "Ստեղն"
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Ապաակտիվացված է"
 
-#: ../libgnome-control-center/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr "GConf ստեղն, որին կցված է հատկությունների այս խմբագիրը "
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "Տեղակայություն՝"
 
-#: ../libgnome-control-center/gconf-property-editor.c:141
-msgid "Callback"
-msgstr "Մշակող"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Ցուցադրել Ձեռնարկի հատկությունները"
 
-#: ../libgnome-control-center/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Գործարկել այս մշակողը, երբ ստեղնի հետ կապված արժեքը փոխվում է"
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr ""
 
-#: ../libgnome-control-center/gconf-property-editor.c:147
-msgid "Change set"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
 msgstr "Փոխել կարգավորումը"
 
-#: ../libgnome-control-center/gconf-property-editor.c:148
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
 msgstr ""
-"gconf հաճախորդին իր դիմումի համաձայն ուղարկվղ GConf փոփոխություն պարունակող "
-"տվյալ"
 
-#: ../libgnome-control-center/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr "Փոփոխություն վիջեթ մշակողում"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Ձայն"
 
-#: ../libgnome-control-center/gconf-property-editor.c:154
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "Գործարկել մշակողը, երբ տվյալները GConf–ից վերածվում են վիջեթի"
-
-#: ../libgnome-control-center/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr "Փոխակերպում վիջեթից մշակողի"
-
-#: ../libgnome-control-center/gconf-property-editor.c:160
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr "Գործարկել մշակողը, երբ տվյալները GConf–ից վերածվում են վիջեթի"
-
-#: ../libgnome-control-center/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "UI ղեկավարում"
-
-#: ../libgnome-control-center/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr "Օբյեկտ, որ ղեկավարում է հատկույունը (սովորաբար վիջեթ)"
-
-#: ../libgnome-control-center/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr "Հատկությունների խմբագրի օբյեկտի տվյալ"
-
-#: ../libgnome-control-center/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr "հատուկ հատկությունների խմբագրի սովորական տվյալ"
-
-#: ../libgnome-control-center/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr "Հատկության խմբագրի տվյալները ազատում են մշակողը"
-
-#: ../libgnome-control-center/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
-"Գործարկել մշակողը, երբ պետք է ազատվեն հատկության խմբագրի օբյեկտի տվյալները"
 
-#: ../libgnome-control-center/gconf-property-editor.c:1406
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Սովորական ստեղների համադրություն"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Ստեղնաշարի ստեղների համադրություն"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
 msgstr ""
-"Չի հաջողվել գտնել '%s' ֆայլը։\n"
-"\n"
-"Խնդրում ենք հաստատել, որ այն գոյություն ունի և նորից փորձել կամ ընտրել ֆոնի "
-"այլ նկար։"
 
-#: ../libgnome-control-center/gconf-property-editor.c:1414
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
 msgstr ""
-"Ես չգիտեմ, թե ինչպես բացել '%s' ֆայլը։\n"
-"Հավանաբար այն նկարի մի տեսակ է, որը դեռ ապահովված չէ։\n"
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "_Տեղակայության անվանումը՝"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Գործողություն"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Ոճ՝"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Նախնական"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "Ավելի շատ ֆոների URL"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
 "\n"
-"Խնդրում ենք փոխարենն այլ նկար ընտրել։"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#: ../libgnome-control-center/gconf-property-editor.c:1536
-msgid "Please select an image."
-msgstr "Խնդրում ենք նկար ընտրել։"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#: ../libgnome-control-center/gconf-property-editor.c:1541
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "Ցուցադրել"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Ավելացնել…"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "_Ապաակտիվացված է"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Մանրամասներ"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Բարձր"
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "րոպեներ"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "րոպեներ"
+
+#: panels/color/cc-color-panel.ui:640
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Ցածր"
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "րոպեներ"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+#, fuzzy
+msgid "D50 (Printing and publishing)"
+msgstr "Հղվել և Սեղմել"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "_Լեզու՝"
+
+#: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
 msgstr "_Ընտրել"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
-msgid "Date And Time"
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Լեզվով"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "Աճեցնել չափը"
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_Ժամանակը լրացել է՝"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "Նվազեցնել չափը"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+#, fuzzy
+msgid "Date & Time"
 msgstr "Ամսաթիվ և Ժամանակ"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Date and Time preferences panel"
-msgstr "Ամսաթիվը և Ժամանակի նախընտրությունների վահանակ"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-panel.desktop.in.in.h:1
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:17
-msgid "Preferred Applications"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "Հ_ետաձգում՝"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Ամսաթիվ և Ժամանակ"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Ապաակտիվացված է"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+msgid "Seconds"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
 msgstr "Նախընտրելի ծրագրեր"
 
-#: ../panels/default-applications/gnome-default-applications-panel.desktop.in.in.h:2
-msgid "Select your default applications"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
 msgstr "Ընտրել նախնական ծրագրերը"
 
-#: ../panels/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Start the preferred visual assistive technology"
-msgstr "Սկսել նախընտրելի տեսողական աջակցող տեխնոլոգիան"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr "Տեսողական օգնություն"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
 
-#: ../panels/default-applications/gnome-da-capplet.c:99
-#: ../panels/default-applications/gnome-da-capplet.c:363
-#: ../panels/default-applications/gnome-da-capplet.c:384
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "Սխալ՝ %s կոնֆիգուրացիան պահպանելիս"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/default-applications/gnome-da-capplet.c:692
-msgid "Custom"
-msgstr "Սովորական"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/default-applications/gnome-da-capplet.c:723
-msgid "Could not load the main interface"
-msgstr "Չի հաջողվել բեռնել գլխավոր ինտերֆեյսը"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/default-applications/gnome-da-capplet.c:725
-msgid "Please make sure that the applet is properly installed"
-msgstr "Խնդրում ենք համոզվել, որ ապլետը ճիշտ է տեղադրված"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:1
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:1
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "Accessibility"
-msgstr "Հասանելիություն"
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:3
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "Բոլոր %s դեպքերը կտեղափոխվեն իրական տողերով"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
 
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:4
-#: ../panels/keybindings/gnome-keybinding-properties.ui.h:1
-msgid "C_ommand:"
-msgstr "Հ_րաման՝"
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:5
-msgid "Co_mmand:"
-msgstr "Հ_րաման՝"
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:6
-msgid "E_xecute flag:"
-msgstr "Գ_ործարկել դրոշակը՝"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:7
-msgid "Image Viewer"
-msgstr "Նկարի դիտակ"
+#: panels/display/cc-display-panel.ui:127
+#, fuzzy
+msgid "Mirror"
+msgstr "Հայելային էկրաններ"
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:8
-msgid "Instant Messenger"
-msgstr "Ակնթարթային հաղորդագրող"
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:9
-msgid "Internet"
-msgstr "Համացանց"
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Ցուցադրել"
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:10
-msgid "Mail Reader"
-msgstr "Էլ–փոստ ընթերցող"
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:11
-msgid "Mobility"
-msgstr "Շարժունություն"
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Մկնիկի ուղղությունը"
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:12
-msgid "Multimedia"
-msgstr "Մուլտիմեդիա"
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Որոշում՝"
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:13
-msgid "Multimedia Player"
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Թարմացման արագություն."
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "րոպեներ"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+#, fuzzy
+msgid "Displays"
+msgstr "Ցուցադրել"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Անվանում."
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Տեսակ՝"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME տերմինալ"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Օ_գտագործողի անունը՝"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+#, fuzzy
+msgid "Launch media player"
 msgstr "Մուլտիմեդիա նվագարկիչ"
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:14
-msgid "Open link in new _tab"
-msgstr "Բացել տողը նոր _ներդիրով"
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:15
-msgid "Open link in new _window"
-msgstr "Բացել տողը նոր _պատուհանով"
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:16
-msgid "Open link with web browser _default"
-msgstr "Բացել տողը նոր վեբ զննիչով _նախնական"
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:18
-msgid "Run at st_art"
-msgstr "Սկսել սկ_զբից"
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:19
-msgid "Run in t_erminal"
-msgstr "Սկսել տ_երմինալում"
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:20
+#: panels/keyboard/00-multimedia.xml.in:24
+#, fuzzy
+msgid "Eject"
+msgstr "մերժված է"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Տպվում է"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "_Բոլոր Պարամետրերը"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+#, fuzzy
+msgid "Launch web browser"
+msgstr "Epiphany վեբ զննիչ"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Համակարգ"
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:21
-msgid "Terminal Emulator"
-msgstr "Տերմինալի էմուլյատոր"
+#: panels/keyboard/01-system.xml.in:4
+#, fuzzy
+msgid "Log out"
+msgstr "Փոքրացնել․"
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:22
-msgid "Text Editor"
-msgstr "Տեքստային խմբագիր"
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:23
-msgid "Video Player"
-msgstr "Վիդեո նվագարկիչ"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Հասանելիություն"
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:24
-msgid "Visual"
-msgstr "Տեսողական"
+#: panels/keyboard/50-accessibility.xml.in:4
+#, fuzzy
+msgid "Turn zoom on or off"
+msgstr "Միացնել կամ անջատել․"
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:25
-msgid "Web Browser"
-msgstr "Վեբ զննիչ "
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "Մեծացնել."
 
-#: ../panels/default-applications/gnome-default-applications-properties.ui.h:26
-msgid "_Run at start"
-msgstr "_Սկսել սկզբից"
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Փոքրացնել․"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Բալսա"
+#: panels/keyboard/50-accessibility.xml.in:10
+#, fuzzy
+msgid "Turn screen reader on or off"
+msgstr "Միացնել կամ անջատել․"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr "Banshee երաժշտական նվագարկիչ"
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "Gnome-ի On screen ստեղնաշար"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr "Claws Mail"
+#: panels/keyboard/50-accessibility.xml.in:14
+#, fuzzy
+msgid "Increase text size"
+msgstr "Աճեցնել չափը"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:4
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Dasher"
-msgstr "Dasher"
+#: panels/keyboard/50-accessibility.xml.in:16
+#, fuzzy
+msgid "Decrease text size"
+msgstr "Նվազեցնել չափը"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr "Debian Զգայուն զննիչ"
+#: panels/keyboard/50-accessibility.xml.in:18
+#, fuzzy
+msgid "High contrast on or off"
+msgstr "Մեծ Հակադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr "Debian Տերմինալի էմուլյատոր"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr "ETerm"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr "Շրջապատել"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr "Epiphany վեբ զննիչ"
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "_Ընտրանքներ..."
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr "Evolution փոստային ընթերցող"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+#, fuzzy
+msgid "Move Up"
+msgstr "Շարժել _վերև"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr "Firebird"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+#, fuzzy
+msgid "Move Down"
+msgstr "Շարժել _ներքև"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Firefox"
-msgstr "Firefox"
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "Մկնիկի նախընտրություններ"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr "GNOME խոշորացույց առանց էկրանի ընթերցող սարքի"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Ստեղնաշարի դասավորության ընտրանքներ"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr "GNOME OnScreen ստեղնաշար"
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr "GNOME տերմինալ"
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Galeon"
-msgstr "Galeon"
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Gnopernicus"
-msgstr "Gnopernicus"
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Gnopernicus with Magnifier"
-msgstr "Gnopernicus խոշորացույցով"
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "_Միևնույն պրոքսին օգտագործել բոլոր պրոտոկոլների համար"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Iceape"
-msgstr "Iceape"
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Iceape Mail"
-msgstr "Iceape էլ–փոստ"
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Icedove"
-msgstr "Icedove"
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Iceweasel"
-msgstr "Iceweasel"
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr "KDE խոշորացույց առանց էկրանի ընթերցող սարքի"
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Մկնիկի ստեղներ"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr "KMail"
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Ստեղնաշարի ստեղների համադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr "Konqueror"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Սովորական ստեղների համադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Konsole"
-msgstr "Konsole"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr "Linux էկրանի ընթերցող սարք"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr "Linux–ի էկրանի ընթերցող սարք խոշորացույցով"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Գործողություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Listen"
-msgstr "Լսել"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Ստեղների համադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Midori"
-msgstr "Midori"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Ստեղների համադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Mozilla"
-msgstr "Mozilla"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Սովորական ստեղների համադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Mozilla Mail"
-msgstr "Mozilla էլ–փոստ"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Ստեղների համադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Ստեղնաշարի ստեղների համադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Muine Music Player"
-msgstr "Muine երաժշտական նվագարկիչ"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:36
-msgid "Mutt"
-msgstr "Mutt"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:37
-msgid "NXterm"
-msgstr "NXterm"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Netscape Communicator"
-msgstr "Netscape հաղորդակցվող"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Opera"
-msgstr "Opera"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Անվանում."
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca"
-msgstr "Orca"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Հ_րաման՝"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:41
-msgid "Orca with Magnifier"
-msgstr "Orca խոշորացույցով"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Ստեղների համադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:42
-msgid "RXVT"
-msgstr "RXVT"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Ստեղների համադրություն"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:43
-msgid "Rhythmbox Music Player"
-msgstr "Rhythmbox նվագարկիչ"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ոչ մի"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:44
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:45
-msgid "SeaMonkey Mail"
-msgstr "SeaMonkey էլ–փոստ"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Վերադարձնել լռելյայն վիճակին"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Standard XTerminal"
-msgstr "Ստանդարտ X–տերմինալ"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Ստեղնաշար"
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:47
-msgid "Sylpheed"
-msgstr "Sylpheed"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:48
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Terminator"
-msgstr "Terminator"
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Thunderbird"
-msgstr "Thunderbird"
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:51
-msgid "Totem Movie Player"
-msgstr "Totem նվագարկիչ"
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
 
-#: ../panels/default-applications/gnome-default-applications.xml.in.h:52
-msgid "aterm"
-msgstr "aterm"
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
 
-#: ../panels/display/display-capplet.ui.h:1
-msgid "Include _panel"
-msgstr "Ընդգրկել _վահանակը"
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
 
-#: ../panels/display/display-capplet.ui.h:2
-#: ../panels/display/xrandr-capplet.c:320
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Համակարգի Պարամետրեր"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Ընդհանուր"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Ձախ"
 
-#: ../panels/display/display-capplet.ui.h:3
-msgid "Make Default"
-msgstr "Դարձնել Լռելյայն"
-
-#: ../panels/display/display-capplet.ui.h:4
-#: ../panels/display/xrandr-capplet.c:523
-msgid "Monitor"
-msgstr "Մոնիտոր"
-
-#: ../panels/display/display-capplet.ui.h:5
-#: ../panels/display/xrandr-capplet.c:319
-#: ../panels/display/xrandr-capplet.c:358
-#: ../panels/universal-access/uap.ui.h:60
-msgid "Normal"
-msgstr "Նորմալ"
-
-#: ../panels/display/display-capplet.ui.h:6
-#: ../panels/universal-access/uap.ui.h:61
-msgid "Off"
-msgstr "Անջատել"
-
-#: ../panels/display/display-capplet.ui.h:7
-#: ../panels/universal-access/uap.ui.h:62
-msgid "On"
-msgstr "Միացնել"
-
-#: ../panels/display/display-capplet.ui.h:8
-msgid "Panel icon"
-msgstr "վահանակի պատկերանիշ"
-
-#: ../panels/display/display-capplet.ui.h:9
-msgid "R_otation:"
-msgstr "Շ_րջում՝"
-
-#: ../panels/display/display-capplet.ui.h:10
-msgid "Re_fresh rate:"
-msgstr "Թարմացման արագություն."
-
-#: ../panels/display/display-capplet.ui.h:11
-#: ../panels/display/xrandr-capplet.c:321
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Աջ"
 
-#: ../panels/display/display-capplet.ui.h:12
-msgid "Sa_me image in all monitors"
-msgstr "Նույն պատկերը բորոր մոնիտորներում"
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_Ջնջել տեղակայությունը"
 
-#: ../panels/display/display-capplet.ui.h:13
-msgid "Upside-down"
-msgstr "Վերից վար"
-
-#: ../panels/display/display-capplet.ui.h:14
-msgid "_Detect monitors"
-msgstr "_Հայտնաբերել մոնիտորները"
-
-#: ../panels/display/display-capplet.ui.h:15
-msgid "_Resolution:"
-msgstr "_Որոշում՝"
-
-#: ../panels/display/display-capplet.ui.h:16
-msgid "_Show monitors in panel"
-msgstr "_Մոնիտորները ցույց տալ վահանակի վրա"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Change resolution and position of monitors"
-msgstr "Փոխել մոնիտորների բաժանումը և դիրքը"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Monitors"
-msgstr "Մոնիտորներ"
-
-#: ../panels/display/gnome-display-properties-install-systemwide.c:44
-#, c-format
-msgid ""
-"Usage: %s SOURCE_FILE DEST_NAME\n"
-"\n"
-"This program installs a RANDR profile for multi-monitor setups into\n"
-"a systemwide location.  The resulting profile will get used when\n"
-"the RANDR plug-in gets run in gnome-settings-daemon.\n"
-"\n"
-"SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
-"xml\n"
-"\n"
-"DEST_NAME - relative name for the installed file.  This will get put in\n"
-"            the systemwide directory for RANDR configurations,\n"
-"            so the result will typically be %s/DEST_NAME\n"
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
 msgstr ""
-"Օգտագործում․ %s SOURCE_FILE DEST_NAME\n"
-"\n"
-"Այս ծրագիրը տեղադրում է RANDR պրոֆիլը բազմակի մոնիտորային ռեժիմի համար "
-"նշված\n"
-"համակարգային տարածքում։ Վերջնական պրոֆիլը կդառնա սովոր սովորական, երբ\n"
-"RANDR plug-in գործարկվում է gnome-settings-daemon -ում։\n"
-"\n"
-"SOURCE_FILE - ամբողջական ճանապարհն է, տիպիկ /home/username/.config/monitors."
-"xml\n"
-"\n"
-"DEST_NAME - տեղադրված ֆայլի հարաբերական անունը. Այն կդրվի նշված տեղում\n"
-"            RANDR կոնֆիգուրացիաների համար՝ իր համակարգի պանակում,\n"
-"            այնպես որ արդյունքը տիպիկ կլինի %s/DEST_NAME\n"
 
-#. Translators: only able to install RANDR profiles as root
-#: ../panels/display/gnome-display-properties-install-systemwide.c:151
-msgid "This program can only be used by the root user"
-msgstr "Այս ծրագիրը կարող է օգտագործվել միայն արմատային օգտագործողի կողմից"
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Մկնիկ"
 
-#: ../panels/display/gnome-display-properties-install-systemwide.c:168
-msgid "The source filename must be absolute"
-msgstr "Պետք է նշված լինի ֆայլի բացարձակ անունը"
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Մկնիկի ստեղներ"
 
-#. Translators: first %s is a filename; second %s is an error message
-#: ../panels/display/gnome-display-properties-install-systemwide.c:179
-msgid "Could not open %s: %s\n"
-msgstr "Չի հաջողվել բացել %s. %s\n"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Ոլորում"
 
-#. Translators: first %s is a filename; second %s is an error message
-#: ../panels/display/gnome-display-properties-install-systemwide.c:188
-msgid "Could not get information for %s: %s\n"
-msgstr "Չի հաջողվել ստանալ %s -ի վերաբերյալ տեղեկատվություն․ %s\n"
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
 
-#: ../panels/display/gnome-display-properties-install-systemwide.c:195
-#, c-format
-msgid "%s must be a regular file\n"
-msgstr "%s պետք է լինի ռեգուլյար ֆայլ\n"
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
 
-#: ../panels/display/gnome-display-properties-install-systemwide.c:204
-msgid "This program must only be run through pkexec(1)"
-msgstr "Այս ծրագիրը պետք է գործարկվի միայն pkexec(1) - ի միջոցով"
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
 
-#: ../panels/display/gnome-display-properties-install-systemwide.c:209
-msgid "PKEXEC_UID must be set to an integer value"
-msgstr "PKEXEC_UID պետք է սահմանվի ամբողջ արժեք"
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
 
-#. Translators: we are complaining that a file must be really owned by the user who called this program
-#: ../panels/display/gnome-display-properties-install-systemwide.c:215
-#, c-format
-msgid "%s must be owned by you\n"
-msgstr "%s -ը պետք է լինի ձեր սեփականությունը\n"
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
 
-#. Translators: here we are saying that a plain filename must look like "filename", not like "some_dir/filename"
-#: ../panels/display/gnome-display-properties-install-systemwide.c:223
-#, c-format
-msgid "%s must not have any directory components\n"
-msgstr "%s -ը պետք է չունենա որևէ պանակ-կոմպոնոնտներ\n"
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Արագացում՝"
 
-#: ../panels/display/gnome-display-properties-install-systemwide.c:231
-#, c-format
-msgid "%s must be a directory\n"
-msgstr "%s -ը պետք է լինի պանակ\n"
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
 
-#. Translators: the first %s/%s is a directory/filename; the last %s is an error message
-#: ../panels/display/gnome-display-properties-install-systemwide.c:242
-msgid "Could not open %s/%s: %s\n"
-msgstr "Չի հաջողվել բացել %s/%s. %s\n"
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
 
-#: ../panels/display/gnome-display-properties-install-systemwide.c:262
-#, c-format
-msgid "Could not rename %s to %s: %s\n"
-msgstr "Չի հաջողվել անվանափոխել %s -ը %s -ով․ %s\n"
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Սենսորային վահանակ"
 
-#: ../panels/display/org.gnome.randr.policy.in.h:1
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Սենսորային վահանակ"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "Կտտոց վրայով անցնելիս"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Ապաակտիվացնել _սենսորային վահանակը մեքենագրելու ժամանակ"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Արագացում՝"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "Ոլորում"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
+msgstr "Սենսորային վահանակ"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
-"Authentication is required to install multi-monitor settings for all users"
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Մոնիտոր"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Գործողություն"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "_Ընտրանքներ..."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Ցանցի պրոքսի"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Գաղտնաբառ՝"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Արագացման ռեժիմ"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Կուրսորի թարթման արագություն"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Նախնական"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Անվանում՝"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Ապաակտիվացված է"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "սեղմված է"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "րոպեներ"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Ցանցի պրոքսի"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+#, fuzzy
+msgid "Turn device off"
+msgstr "Միացնել կամ անջատել․"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Գործողություն"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr ""
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Ցանցի պրոքսի"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "H_TTP պրոքսի՝"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "H_TTP պրոքսի՝"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP պրոքսի՝"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "S_ocks հոսթ՝"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "Անտեսված հոսթեր"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "H_TTP պրոքսի՝"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "H_TTP պրոքսի՝"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP պրոքսի՝"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Վավերացում _URL՝"
+
+#: panels/network/network-vpn.ui:11
+#, fuzzy
+msgid "Turn VPN connection off"
+msgstr "Միացնել կամ անջատել․"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Ցանցի պրոքսի"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Գաղտնաբառ՝"
+
+#: panels/network/network-wifi.ui:90
+#, fuzzy
+msgid "Turn Wi-Fi off"
+msgstr "Միացնել կամ անջատել․"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Ցուցադրել Ձեռնարկի հատկությունները"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Օգտագործել վավերացումը</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "Օ_գտագործողի անունը՝"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Գաղտնաբառ՝"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Գաղտնաբառ՝"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Տարբերակ՝"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Տարբերակ՝"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "<b>_Օգտագործել վավերացումը</b>"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Տեսակ՝"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Նախնական"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Համակարգ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Շ_րջում՝"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Տեսողական ահազանգեր"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "_Ջնջել տեղակայությունը"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "րոպեներ"
+msgstr[1] "րոպեներ"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "րոպեներ"
+msgstr[1] "րոպեներ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "րոպեներ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "րոպեներ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "րոպեներ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "րոպեներ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "րոպեներ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "րոպեներ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "րոպեներ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "րոպեներ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Արագացման ռեժիմ"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Հայելային էկրաններ"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Էկրանի ընթերցող սարք"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Հետաձգում՝"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "Օ_գտագործողի անունը՝"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Տեղակայություն՝"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Տեղադրումը ձախողվել է"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Ընտրել"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "Տեղակայել ցուցիչը"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Տեստավորել թարթումը"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "_Մանրամասներ"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Վերադարձնել լռելյայն վիճակին"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
+msgstr "Տեղակայել ցուցիչը"
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Մոդելներ"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Խնդրում ենք համոզվել, որ ապլետը ճիշտ է տեղադրված"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "_Սկսել սկզբից"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "Նորմալ"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Նախնական տեսք՝"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Ամսաթիվ և Ժամանակ"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+#, fuzzy
+msgid "_Language"
+msgstr "_Լեզու՝"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Linux էկրանի ընթերցող սարք"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "Muine երաժշտական նվագարկիչ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Գործողություն"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Տեսակ՝"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+#, fuzzy
+msgid "Screen"
+msgstr "Էկրանի ընթերցող սարք"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Համակարգի Պարամետրեր"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Նոր տեղակայություն..."
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Տեղակայություն՝"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Ցանցի պրոքսի"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+#, fuzzy
+msgid "Sharing"
+msgstr "Լսում"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Լսում"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Աշխատասեղան"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Ջնջել տեղակայությունը"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Լսում"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Գաղտնաբառ՝"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Աշխատասեղան"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "UI ղեկավարում"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<b>_Օգտագործել վավերացումը</b>"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "Լսում"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+#, fuzzy
+msgid "Enable or disable remote login"
+msgstr "Ակտիվացնել հ_որիզոնական ոլորումը"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+#, fuzzy
+msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Բոլոր օգտագործողների բազմակի մոնիտորային պարամետրերը տեղադրելու համար "
 "վավերացում է անհրաժեշտ"
 
-#: ../panels/display/org.gnome.randr.policy.in.h:2
-msgid "Install multi-monitor settings for the whole system"
-msgstr "Տեղադրել բազմակի մոնիտորային պարամետրերը ամբողջ համակարգի համար"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Կրկնակի կտտոց"
 
-#: ../panels/display/xrandr-capplet.c:322
-msgid "Upside Down"
-msgstr "Վերից վար"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Լսում"
 
-#: ../panels/display/xrandr-capplet.c:364
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../panels/display/xrandr-capplet.c:512
-#: ../panels/display/xrandr-capplet.c:1658
-msgid "Mirror Screens"
-msgstr "Հայելային էկրաններ"
-
-#: ../panels/display/xrandr-capplet.c:514
-#, c-format
-msgid "Monitor: %s"
-msgstr "Մոնիտոր. %s"
-
-#: ../panels/display/xrandr-capplet.c:592
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#: ../panels/display/xrandr-capplet.c:1514
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
-"Ընտրել մոնիտոր՝ հատկությունները փոխելու համար. քաշել այն դիրքի փոփոխության "
-"համար։"
 
-#: ../panels/display/xrandr-capplet.c:2079
-msgid "Could not save the monitor configuration"
-msgstr "Չհաջողվեց պահել մոնիտորի կոնֆիգուրացումը"
-
-#: ../panels/display/xrandr-capplet.c:2102
-msgid "Could not get session bus while applying display configuration"
-msgstr "Չի հաջողվել ստանալ կապուղին էկրանի կոնֆիգուրացիան կիրառելու ժամանակ"
-
-#: ../panels/display/xrandr-capplet.c:2147
-msgid "Could not detect displays"
-msgstr "Էկրաններ հայտնաբերումը չի հաջողվել"
-
-#: ../panels/display/xrandr-capplet.c:2322
-msgid "The monitor configuration has been saved"
-msgstr "Մոնիտորի կոնֆիգուրացիան պահպանվել է"
-
-#: ../panels/display/xrandr-capplet.c:2324
-msgid "This configuration will be used the next time someone logs in."
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
 msgstr ""
-"Այս կոնֆիգուրացիան կօգտագործվի հաջորդ անգամ, երբ ինչ-որ մեկը մուտք գործի "
-"համակարգ"
 
-#: ../panels/display/xrandr-capplet.c:2358
-msgid "Could not set the default configuration for monitors"
-msgstr "Չհաջողվեց մոնիտորի համար սահմանել լռելյայն կոնֆիգուրացիա"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
 
-#: ../panels/display/xrandr-capplet.c:2416
-msgid "Could not get screen information"
-msgstr "Չի հաջողվել ստանալ էկրանի տվյալները"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
 
-#: ../panels/keybindings/00-multimedia-key.xml.in.h:1
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Համակարգ"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+#, fuzzy
+msgid "Test"
+msgstr "Տեստ."
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Պրոքսի կոնֆիգուրացիա"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Ձայն"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
 msgstr "Ձայն"
 
-#: ../panels/keybindings/01-desktop-key.xml.in.h:1
-msgid "Desktop"
-msgstr "Աշխատասեղան"
-
-#: ../panels/keybindings/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr "Նոր ստեղների համադրություն…"
-
-#: ../panels/keybindings/eggcellrendererkeys.c:163
-#: ../panels/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Արագացուցչի ստեղն"
-
-#: ../panels/keybindings/eggcellrendererkeys.c:173
-#: ../panels/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Արագացուցչի ձևափոխիչ"
-
-#: ../panels/keybindings/eggcellrendererkeys.c:182
-#: ../panels/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Արագացնող ստեղնի գաղտնագիր"
-
-#: ../panels/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Արագացման ռեժիմ"
-
-#: ../panels/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Արագացուցչի տեսակը։"
-
-#: ../panels/keybindings/eggcellrendererkeys.c:242
-#: ../panels/keybindings/gnome-keybinding-properties.c:100
-#: ../typing-break/drwright.c:498
-msgid "Disabled"
-msgstr "Ապաակտիվացված է"
-
-#: ../panels/keybindings/gnome-keybinding-properties.c:181
-msgid "<Unknown Action>"
-msgstr "<Անհայտ գործողություն>"
-
-#: ../panels/keybindings/gnome-keybinding-properties.c:931
-#: ../panels/keybindings/gnome-keybinding-properties.c:1562
-msgid "Custom Shortcuts"
-msgstr "Սովորական ստեղների համադրություն"
-
-#: ../panels/keybindings/gnome-keybinding-properties.c:1073
-msgid "Error saving the new shortcut"
-msgstr "Սխալ՝ ստեղների համադրությունը պահպանելիս"
-
-#: ../panels/keybindings/gnome-keybinding-properties.c:1152
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
-"\"%s\" ստեղների համադրությունը չի հաջողվել գործածել, որովհետև մեքենագրելու "
-"ժամանակ այս ստեղնի օգտագործումը անհնար կլինի։\n"
-"Խնդրում ենք փորձել այնպիսի ստեղներով ինչպիսիք են Control, Alt կամ Shift–ը "
-"միաժամանակ։"
 
-#: ../panels/keybindings/gnome-keybinding-properties.c:1182
-#, c-format
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
-"\"%s\" ստեղների համադրությունն արդեն օգտագործված է՝\n"
-"\"%s\""
 
-#: ../panels/keybindings/gnome-keybinding-properties.c:1188
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Փակված տակագրում"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Անվանում."
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"Եթե \"%s\" ստեղների համադրությունը վերանշանակեք, \"%s\" ստեղների "
-"համադրությունը կապաակտիվացվի։"
 
-#: ../panels/keybindings/gnome-keybinding-properties.c:1196
-msgid "_Reassign"
-msgstr "_Վերանշանակել"
-
-#: ../panels/keybindings/gnome-keybinding-properties.c:1316
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s"
-msgstr "Սխալ՝ կոնֆիգուրացիայի տվյալների բազայում արագացուցիչն անջատելիս՝ %s"
-
-#: ../panels/keybindings/gnome-keybinding-properties.c:1517
-msgid "Too many custom shortcuts"
-msgstr "Չափազանց շատ սովորական ստեղների համադրություն"
-
-#: ../panels/keybindings/gnome-keybinding-properties.c:1849
-msgid "Action"
-msgstr "Գործողություն"
-
-#: ../panels/keybindings/gnome-keybinding-properties.c:1871
-msgid "Shortcut"
-msgstr "Ստեղների համադրություն"
-
-#: ../panels/keybindings/gnome-keybinding-properties.ui.h:2
-msgid "Custom Shortcut"
-msgstr "Սովորական ստեղների համադրություն"
-
-#: ../panels/keybindings/gnome-keybinding-properties.ui.h:3
-#: ../panels/keybindings/gnome-keybindings-panel.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Ստեղնաշարի ստեղների համադրություն"
-
-#: ../panels/keybindings/gnome-keybinding-properties.ui.h:4
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new key "
-"combination, or press backspace to clear."
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
 msgstr ""
-"Ստեղների համադրությունը խմբագրելու համար կտտացրեք համապատասխան տողի վրա և "
-"մեքենագրեք ստեղների նոր համադրություն կամ սեղմեք backspace–ը ջնջելու համար։"
 
-#: ../panels/keybindings/gnome-keybinding-properties.ui.h:5
-msgid "_Name:"
-msgstr "_Անվանում՝"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../panels/keybindings/gnome-keybindings-panel.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Նշանակել ստեղների համադրություն հրամանների համար"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:1
-msgid "Beep when _accessibility features are turned on or off"
-msgstr "Ազդանշանել, երբ _հասանելիությունը միացված կամ անջատված է"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:2
-msgid "Beep when a _modifier key is pressed"
-msgstr "Ազդանշանել, երբ _մոդիֆիկատորի ստեղնը միացված է"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:3
-msgid "Beep when a _toggle key is pressed"
-msgstr "Ազդանշանել, երբ _փոխանջատչի ստեղնը սեղմված է"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Համընդհանուր Հասանելիություն"
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:4
-msgid "Beep when a key is pr_essed"
-msgstr "Ազդանշանել, երբ _ստեղնը սեղմված է"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:5
-msgid "Beep when a key is reje_cted"
-msgstr "Ազդանշանել, երբ ստեղնը մերժ_ված է"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:6
-msgid "Beep when key is _accepted"
-msgstr "Ազդանշանել, երբ ստեղնն _ընդունված է"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:7
-msgid "Beep when key is _rejected"
-msgstr "Ազդանշանել, երբ ստեղնը _մերժված է"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:8
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:4
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Bounce Keys"
-msgstr "Անցման ստեղներ"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:9
-msgid "Flash _window titlebar"
-msgstr "_Պատուհանի վերնագրի տողի թարթում"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:10
-msgid "Flash entire _screen"
-msgstr "Ամբողջ _էկրանի թարթում"
-
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:11
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:14
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgid "General"
-msgstr "Ընդհանուր"
-
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:12
-msgid "Keyboard Accessibility Audio Feedback"
-msgstr "Ստեղնաշարի հասանելիության ձայնային հետդարձ կապ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:13
-msgid "Show _visual feedback for the alert sound"
-msgstr "Ցույց տալ _տեսողական հետդարձ կապ զգուշացման ազդանշանի ձայնի համար"
-
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:14
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:39
-#: ../panels/universal-access/uap.ui.h:76
-msgid "Slow Keys"
-msgstr "Դանդաղ ստեղներ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:15
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:40
-#: ../panels/universal-access/uap.ui.h:80
-msgid "Sticky Keys"
-msgstr "Կպչուն ստեղներ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:16
-msgid "Visual cues for sounds"
-msgstr "Տեսողական հուշում ձայների համար"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:2
-msgid "All_ow postponing of breaks"
-msgstr "Թու_յլատրել ընդմիջումների հետաձգումը"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:3
-msgid "Audio _Feedback..."
-msgstr "Ձայնային _հետդարձ կապ..."
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:5
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Ստուգել, երբ թույլատրվում է ընդմիջումներն հետաձգել"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:6
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 msgid "Cursor Blinking"
 msgstr "Կուրսորի թարթում"
 
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:7
-msgid "Cursor _blinks in text fields"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
 msgstr "Կուրսորը _թարթում է տեքստի շրջանում"
 
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:8
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Cursor blinks speed"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Արագություն՝"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
 msgstr "Կուրսորի թարթման արագություն"
 
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:9
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-#: ../panels/universal-access/uap.ui.h:30
-msgid "D_elay:"
-msgstr "Հ_ետաձգում՝"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Կուրսորի թարթում"
 
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:10
-msgid "Disa_ble sticky keys if two keys are pressed together"
-msgstr ""
-"Ապաա_կտիվացնել կպչուն ստեղները, եթե երկու ստեղները սեղմվում են միաժամանակ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:11
-msgid "Duration of the break when typing is disallowed"
-msgstr "Ընդմիջման ժամանակը, երբ չի թույլատրվում մեքենագրելը"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:12
-msgid "Duration of work before forcing a break"
-msgstr "Աշխատանքի տևողությունը նախքան ստիպողական ընդմիջումը"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:13
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgid "Fast"
-msgstr "Արագ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:15
-msgid "Key presses _repeat when key is held down"
-msgstr "Սեղմած ստեղնի նորից սեղմում"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:16
-msgid "Keyboard Preferences"
-msgstr "Ստեղնաշարի նախընտրություններ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:17
-msgid "Keyboard _model:"
-msgstr "Ստեղնաշարի _մոդել՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:18
-msgid "Layouts"
-msgstr "Դասավորություններ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:19
-msgid "List of keyboard layouts selected for usage"
-msgstr "Օգտագործման համար ընտրված ստեղնաշարային դասավորությունների ցուցակը"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:20
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
+"Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
-"Որոշակի ժամանակ անց արգելափակել էկրանը՝ ստեղնաշարի անընդհատ օգտագործոման "
-"հետևանքով բարդություններից խուսափելու համար"
 
-#. long delay
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:21
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
-#: ../panels/universal-access/uap.ui.h:53
-msgid "Long"
-msgstr "Երկար"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:22
-#: ../panels/universal-access/uap.ui.h:56
-msgid "Mouse Keys"
-msgstr "Մկնիկի ստեղներ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:23
-msgid "Move _Down"
-msgstr "Շարժել _ներքև"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:24
-msgid "Move _Up"
-msgstr "Շարժել _վերև"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:25
-msgid "Move the selected keyboard layout down in the list"
-msgstr "Ընտրված ստեղնաշարային դասավորությունը տեղափոխել ցուցակում դեպի ներքև"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:26
-msgid "Move the selected keyboard layout up in the list"
-msgstr "Ընտրված ստեղնաշարային դասավորությունը տեղափոխել ցուցակում դեպի վերև"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:27
-msgid "New windows u_se active window's layout"
-msgstr "Նոր պատուհաններն օգտագործում են ակտիվ պատուհանի ծրագիրը"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:28
-msgid "Print a diagram of the selected keyboard layout"
-msgstr "Ընտրված ստեղնաշարային դասավորության համար տպել սխեմա"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:29
-msgid "Remove the selected keyboard layout from the list"
-msgstr "Հեռացնել ընտրված ստեղնաշարային դասավորությունը ցուցակից"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:30
-msgid "Repeat Keys"
-msgstr "Կրկնել ստեղները"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:31
-msgid "Repeat keys speed"
-msgstr "Կրկնել ստեղների արագությունը"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:32
-msgid ""
-"Replace the current keyboard layout settings with the\n"
-"default settings"
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
 msgstr ""
-"Փոխարինել ընթացիկ ստեղնաշարային դասավորության պարամետրերը\n"
-"լռելյայն պարամետրերով"
 
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:34
-msgid "Reset to De_faults"
-msgstr "Վերադարձնել լռելյայն վիճակին"
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Մոդելավորված երկրորդական կտտոց"
 
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:35
-msgid "S_peed:"
-msgstr "Ա_րագություն՝"
+#: panels/universal-access/cc-pointing-dialog.ui:49
+#, fuzzy
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Գործարկել երկրորդական կտտոց՝ պահելով հիմնական կոճակը"
 
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:36
-msgid "Select a keyboard layout to be added to the list"
-msgstr "Ընտրեք ցուցակին ավելացվող ստեղնաշարային դասավորությունը"
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+#, fuzzy
+msgid "A_cceptance delay:"
+msgstr "Ընդունման հապաղում"
 
-#. short delay
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:37
-#: ../panels/mouse/gnome-mouse-properties.ui.h:27
-#: ../panels/universal-access/uap.ui.h:73
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
 msgid "Short"
 msgstr "Կարճ"
 
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:38
-#: ../panels/mouse/gnome-mouse-properties.ui.h:30
-msgid "Slow"
-msgstr "Դանդաղ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:41
-msgid "Typing Break"
-msgstr "Աշխատանքային ընդմիջում"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:42
-msgid "View and edit keyboard layout options"
-msgstr "Դիտել և խմբագրել ստեղնաշարի դասավորության ընտրանքները"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:43
-#: ../panels/mouse/gnome-mouse-properties.ui.h:37
-msgid "_Acceleration:"
-msgstr "_Արագացում՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:44
-msgid "_Accessibility features can be toggled with keyboard shortcuts"
-msgstr "_Օժանդակ հատկությունները կարելի է փոփոխել ստեղների համադրություններով"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:45
-msgid "_Add..."
-msgstr "_Ավելացնել…"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:46
-msgid "_Break interval lasts:"
-msgstr "_Ընդմիջման տևողությունը."
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:47
-#: ../panels/mouse/gnome-mouse-properties.ui.h:38
-msgid "_Delay:"
-msgstr "_Հետաձգում՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:48
-msgid "_Ignore fast duplicate keypresses"
-msgstr "_Անտեսել ստեղների սեղմման արագ կրկնումները"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:49
-msgid "_Lock screen to enforce typing break"
-msgstr "_Արգելափակել էկրանը աշխատանքային ընդմիջման համար"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:50
-msgid "_Only accept long keypresses"
-msgstr "_Ընդունել միայն ստեղների երկար սեղմումները"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:51
-msgid "_Options..."
-msgstr "_Ընտրացանկ..."
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:52
-msgid "_Pointer can be controlled using the keypad"
-msgstr "_Ցուցիչը կարող է կառավարվել ստեղնխմբով"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:53
-msgid "_Separate layout for each window"
-msgstr "_Առանձին դասավորություն ամեն մի պատուհանի համար"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:54
-msgid "_Simulate simultaneous keypresses"
-msgstr "_Մոդելավորել ստեղների միաժամանակյա սեղմումները"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:55
-msgid "_Speed:"
-msgstr "_Արագություն՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:56
-msgid "_Type to test settings:"
-msgstr "_Մեքենագրել պարամետրերը ստուգելու համար՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:57
-msgid "_Work interval lasts:"
-msgstr "_Աշխատանքի ընդմիջումը տևում է՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:58
-msgid "minutes"
-msgstr "րոպեներ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:1
-msgid "By _country"
-msgstr "Երկրով"
-
-#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:2
-msgid "By _language"
-msgstr "Լեզվով"
-
-#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:3
-msgid "Choose a Layout"
-msgstr "Ընտրել դասավորություն"
-
-#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:4
-msgid "Preview:"
-msgstr "Նախնական տեսք՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:5
-msgid "_Country:"
-msgstr "_Երկիր՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:6
-msgid "_Language:"
-msgstr "_Լեզու՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:7
-msgid "_Variants:"
-msgstr "_Տարբերակներ՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-model-chooser.ui.h:1
-msgid "Choose a Keyboard Model"
-msgstr "Ընտրել ստեղնաշարի մոդելը"
-
-#: ../panels/keyboard/gnome-keyboard-properties-model-chooser.ui.h:2
-msgid "_Models:"
-msgstr "_Մոդելներ՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-model-chooser.ui.h:3
-msgid "_Vendors:"
-msgstr "_Վաճառող՝"
-
-#: ../panels/keyboard/gnome-keyboard-properties-options-dialog.ui.h:1
-msgid "Keyboard Layout Options"
-msgstr "Ստեղնաշարի դասավորության ընտրանքներ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-xkb.c:81
-msgid "Unknown"
-msgstr "Անհայտ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-xkblt.c:241
-msgid "Layout"
-msgstr "Դասավորություն"
-
-#: ../panels/keyboard/gnome-keyboard-properties-xkbmc.c:166
-msgid "Vendors"
-msgstr "Վաճառողներ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-xkbmc.c:232
-msgid "Models"
-msgstr "Մոդելներ"
-
-#: ../panels/keyboard/gnome-keyboard-properties-xkbot.c:233
-#: ../panels/network/gnome-network-properties.c:582
-msgid "Default"
-msgstr "Նախնական"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Ստեղնաշար"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Կարգավորել ստեղնաշարի նախընտրությունները"
-
-#: ../panels/mouse/capplet-stock-icons.c:66
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "Հնարավոր չէ բեռնել '%s' պատկերանիշը\n"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../panels/mouse/gnome-mouse-accessibility.c:90
-msgid "gesture|Move left"
-msgstr "շարժում|դեպի ձախ"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../panels/mouse/gnome-mouse-accessibility.c:95
-msgid "gesture|Move right"
-msgstr "շարժում|դեպի աջ"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../panels/mouse/gnome-mouse-accessibility.c:100
-msgid "gesture|Move up"
-msgstr "շարժում|դեպի վեր"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../panels/mouse/gnome-mouse-accessibility.c:105
-msgid "gesture|Move down"
-msgstr "շարժում|դեպի վար"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../panels/mouse/gnome-mouse-accessibility.c:110
-msgid "gesture|Disabled"
-msgstr "շարժում|ապաակտիվացված է"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "Choose type of click _beforehand"
-msgstr "Ընտրել կտտացնելու տեսակը _նախապես"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Choose type of click with mo_use gestures"
-msgstr "Ընտրել կտտացնելու տեսակը մկն_իկի շարժումներով"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "D_ouble click:"
-msgstr "Կ_րկնակի կտտոց՝"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "D_rag click:"
-msgstr "Ա_րգելակի կտտոց՝"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "Disable _touchpad while typing"
-msgstr "Ապաակտիվացնել _սենսորային վահանակը մեքենագրելու ժամանակ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Double-Click Timeout"
-msgstr "Հապաղում կրկնակի կտտոցի դեպքում"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "Drag and Drop"
-msgstr "Քաշել և գցել"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgid "Dwell Click"
-msgstr "Կրկնակի կտտոց"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgid "Enable _mouse clicks with touchpad"
-msgstr "Ակտիվացնել _մկնիկի կտտոցը սենսորային վահանակի հետ միաժամանակ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Enable h_orizontal scrolling"
-msgstr "Ակտիվացնել հ_որիզոնական ոլորումը"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-#: ../panels/universal-access/uap.ui.h:40
-msgid "High"
-msgstr "Բարձր"
-
-#. large threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-#: ../panels/universal-access/uap.ui.h:50
-msgid "Large"
-msgstr "Մեծ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Locate Pointer"
-msgstr "Տեղակայել ցուցիչը"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-#: ../panels/universal-access/uap.ui.h:54
-msgid "Low"
-msgstr "Ցածր"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:21
-msgid "Mouse Orientation"
-msgstr "Մկնիկի ուղղությունը"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:22
-msgid "Mouse Preferences"
-msgstr "Մկնիկի նախընտրություններ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:23
-msgid "Pointer Speed"
-msgstr "Ցուցչի արագություն"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:24
-msgid "Scrolling"
-msgstr "Ոլորում"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:25
-msgid "Seco_ndary click:"
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
 msgstr "Երկր_որդական կտտոց՝"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:26
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr "Ցու_յց տալ ցուցչի դիրքը, երբ ղեկավարման ստեղնը սեղմված է"
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Երկար"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:28
-msgid "Show click type _window"
-msgstr "Ցույց տալ պատուհանի կտտոցի _տեսակը"
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "Կտտոց վրայով անցնելիս"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:29
-#: ../panels/universal-access/uap.ui.h:75
-msgid "Simulated Secondary Click"
-msgstr "Մոդելավորված երկրորդական կտտոց"
+#: panels/universal-access/cc-pointing-dialog.ui:137
+#, fuzzy
+msgid "Trigger a click when the pointer hovers"
+msgstr "Գործարկել կտտոցը, երբ ցուցիչը անցնում է վրայով"
 
-#. small threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:31
-#: ../panels/universal-access/uap.ui.h:78
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Հ_ետաձգում՝"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Կարճ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Երկար"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Շարժման սահմանային արժեք՝"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Փոքր"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:32
-msgid "Thr_eshold:"
-msgstr "Սահմանային _արժեք՝"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:33
-msgid ""
-"To test your double-click settings, try to double-click on the light bulb."
-msgstr ""
-"Կրկնակի կտտոցի պարամետրերը ստուգելու համար փորձեք կրկնակի կտտացնել վառվող "
-"լույսի վրա։"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:34
-msgid "Touchpad"
-msgstr "Սենսորային վահանակ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:35
-msgid "Two-_finger scrolling"
-msgstr "Ոլորում երկու _մատով"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:36
-msgid "You can also use the Dwell Click panel applet to choose the click type."
-msgstr ""
-"Կարող եք նաև օգտագործել հապաղումով կտտոցը վահանակի ապլետի կտտոցի տեսակը "
-"ընտրելու համար։"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:39
-msgid "_Disabled"
-msgstr "_Ապաակտիվացված է"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:40
-msgid "_Edge scrolling"
-msgstr "_Եզրային ոլորում"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:41
-msgid "_Initiate click when stopping pointer movement"
-msgstr "_Գործարկել կտտոցը, երբ դադարեցվում է ցուցչի շարժումը"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:42
-msgid "_Left-handed"
-msgstr "_Ձախ ձեռքով"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:43
-#: ../panels/universal-access/uap.ui.h:98
-msgid "_Motion threshold:"
-msgstr "_Շարժման սահմանային արժեք՝"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:44
-msgid "_Right-handed"
-msgstr "_Աջ ձեռքով"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:45
-msgid "_Sensitivity:"
-msgstr "_Զգայունություն՝"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:46
-msgid "_Single click:"
-msgstr "_Մեկ կտտոց՝"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:47
-msgid "_Timeout:"
-msgstr "_Ժամանակը լրացել է՝"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:48
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr "_Իրականցնել երկրորդական կտտոցը՝ պահելով հիմնական կոճակը"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Մկնիկ"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Կարգավորել մկնիկի նախընտրությունները"
-
-#: ../panels/network/gnome-network-properties.c:700
-#: ../panels/network/gnome-network-properties.c:851
-msgid "New Location..."
-msgstr "Նոր տեղակայություն..."
-
-#: ../panels/network/gnome-network-properties.c:817
-msgid "Location already exists"
-msgstr "Տեղակայությունն արդեն գոյություն ունի"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Ցանցի պրոքսի"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "Կարգավորել ցանցի պրոքսիի նախընտրությունները"
-
-#: ../panels/network/gnome-network-properties.ui.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>Ու_ղիղ համացանցային կապ</b>"
-
-#: ../panels/network/gnome-network-properties.ui.h:2
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>_Ավտոմատ պրոքսի կոնֆիգուրացիա</b>"
-
-#: ../panels/network/gnome-network-properties.ui.h:3
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>_Ձեռքով պրոքսի կոնֆիգուրացիա</b>"
-
-#: ../panels/network/gnome-network-properties.ui.h:4
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Օգտագործել վավերացումը</b>"
-
-#: ../panels/network/gnome-network-properties.ui.h:5
-msgid "Autoconfiguration _URL:"
-msgstr "Վավերացում _URL՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:6
-msgid "C_reate"
-msgstr "Ս_տեղծել"
-
-#: ../panels/network/gnome-network-properties.ui.h:7
-msgid "Create New Location"
-msgstr "Ստեղծել նոր տեղակայություն"
-
-#: ../panels/network/gnome-network-properties.ui.h:8
-msgid "HTTP Proxy Details"
-msgstr "HTTP պրոքսի մանրամասներ"
-
-#: ../panels/network/gnome-network-properties.ui.h:9
-msgid "H_TTP proxy:"
-msgstr "H_TTP պրոքսի՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:10
-msgid "Ignore Host List"
-msgstr "Անտեսել հոսթի ցուցակը"
-
-#: ../panels/network/gnome-network-properties.ui.h:11
-msgid "Ignored Hosts"
-msgstr "Անտեսված հոսթեր"
-
-#: ../panels/network/gnome-network-properties.ui.h:12
-msgid "Location:"
-msgstr "Տեղակայություն՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:13
-msgid "Network Proxy Preferences"
-msgstr "Ցանցի պրոքսիի նախընտրություններ"
-
-#: ../panels/network/gnome-network-properties.ui.h:14
-msgid "Port:"
-msgstr "Պորտ՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:15
-msgid "Proxy Configuration"
-msgstr "Պրոքսի կոնֆիգուրացիա"
-
-#: ../panels/network/gnome-network-properties.ui.h:16
-msgid "S_ocks host:"
-msgstr "S_ocks հոսթ՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:17
-msgid "The location already exists."
-msgstr "Տեղանքն արդեն գոյություն ունի։"
-
-#: ../panels/network/gnome-network-properties.ui.h:18
-msgid "U_sername:"
-msgstr "Օ_գտագործողի անունը՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:19
-msgid "_Delete Location"
-msgstr "_Ջնջել տեղակայությունը"
-
-#: ../panels/network/gnome-network-properties.ui.h:20
-msgid "_Details"
-msgstr "_Մանրամասներ"
-
-#: ../panels/network/gnome-network-properties.ui.h:21
-msgid "_FTP proxy:"
-msgstr "_FTP պրոքսի՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:22
-msgid "_Location name:"
-msgstr "_Տեղակայության անվանումը՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:23
-msgid "_Password:"
-msgstr "_Գաղտնաբառ՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:24
-msgid "_Secure HTTP proxy:"
-msgstr "_Ապահովել HTTP պրոքսի՝"
-
-#: ../panels/network/gnome-network-properties.ui.h:25
-msgid "_Use the same proxy for all protocols"
-msgstr "_Միևնույն պրոքսին օգտագործել բոլոր պրոտոկոլների համար"
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "Համընդհանուր Հասանելիություն"
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Universal Access Preferences"
-msgstr "Համընդհանուր հասանելիության նախընտրություններ"
-
-#: ../panels/universal-access/uap.ui.h:2
-#, no-c-format
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/universal-access/uap.ui.h:4
-#, no-c-format
-msgid "125%"
-msgstr "125%"
-
-#: ../panels/universal-access/uap.ui.h:6
-#, no-c-format
-msgid "150%"
-msgstr "150%"
-
-#: ../panels/universal-access/uap.ui.h:7
-msgid "<span size=\"x-large\">High/Inverse</span>"
-msgstr "<span size=\"x-large\">Բարձր/Հետադարձ</span>"
-
-#: ../panels/universal-access/uap.ui.h:8
-msgid "<span size=\"x-large\">High</span>"
-msgstr "<span size=\"x-large\">Բարձր</span>"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "<span size=\"x-large\">Low</span>"
-msgstr "<span size=\"x-large\">Ցածր</span>"
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "<span size=\"x-large\">Normal</span>"
-msgstr "<span size=\"x-large\">Նորմալ</span>"
-
-#: ../panels/universal-access/uap.ui.h:11
-msgid "Acceptance delay:"
-msgstr "Ընդունման հապաղում"
-
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Accessibility features can be turned on or off with keyboard shortcuts"
-msgstr ""
-"Մատչելիության հատկությունները կարելի է միացնել կամ անջատել ստեղների "
-"համադրություններով"
-
-#: ../panels/universal-access/uap.ui.h:13
-msgid "Beep when Caps and Num Lock are used"
-msgstr "Ազդանշանել, երբ Caps և Num Lock-ը օգտագործված են"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Beep when a key is"
-msgstr "Ազդանշանել, երբ ստեղնը սեղմված է"
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "Beep when a key is rejected"
-msgstr "Ազդանշանել, երբ ստեղնը մերժված է"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "Beep when a modifer key is pressed"
-msgstr "Ազդանշանել, երբ մոդիֆիկատորի ստեղնը միացված է"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "Caribou"
-msgstr "Կարիբու"
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "Change constrast:"
-msgstr "Փոխել հակադրությունը"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Closed Captioning"
-msgstr "Փակված տակագրում"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Contrast:"
-msgstr "Հակադրություն"
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Control the pointer using the keypad."
-msgstr "Կառավարել ցուցիչը՝ օգտագործելով ստեղնախումբ։"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "Control the pointer using the video camera."
-msgstr "Կառավարել ցուցիչը՝ օգտագործելով տեսախցիկ։"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Ctrl+Alt+-"
-msgstr "Ctrl+Alt+-"
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Ctrl+Alt+0"
-msgstr "Ctrl+Alt+0"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Ctrl+Alt+4"
-msgstr "Ctrl+Alt+4"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Ctrl+Alt+8"
-msgstr "Ctrl+Alt+8"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "Ctrl+Alt+="
-msgstr "Ctrl+Alt+="
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Decrease size:"
-msgstr "Նվազեցնել չափը"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Disable if two keys are pressed together"
-msgstr "Ապաակտիվացնել, եթե երկու ստեղները սեղմվում են միաժամանակ"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Display"
-msgstr "Ցուցադրել"
-
-#: ../panels/universal-access/uap.ui.h:35
-msgid "Display a textual description of speech and sounds."
-msgstr "Ցուցադրել խոսքի և ձայնի տեքստային նկարագրությունը"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Flash the entire screen"
-msgstr "Ամբողջ էկրանի թարթում"
-
-#: ../panels/universal-access/uap.ui.h:37
-msgid "Flash the window title"
-msgstr "Պատուհանի վերնագրի թարթում"
-
-#: ../panels/universal-access/uap.ui.h:38
-msgid "GOK"
-msgstr "GOK"
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Hearing"
-msgstr "Լսում"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "High/Inverse"
-msgstr "Բարձր/Հակադարձ"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "HighContrast"
-msgstr "Մեծ Հակադրություն"
-
-#: ../panels/universal-access/uap.ui.h:43
-msgid "HighContrastInverse"
-msgstr "Մեծ Հակադրության Հակադարձ"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Hover Click"
-msgstr "Կտտոց վրայով անցնելիս"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "I need assistance with:"
-msgstr "Ես կարիք ունեմ այսպիսի օգնականի․"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "Ignores fast duplicate keypresses"
-msgstr "Անտեսել ստեղների սեղմման արագ կրկնումները"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Increase size:"
-msgstr "Աճեցնել չափը"
-
-#: ../panels/universal-access/uap.ui.h:48
-msgid "Keyboard Settings..."
-msgstr "Ստեղնաշարի պարամետրեր․․․"
-
-#: ../panels/universal-access/uap.ui.h:51
-msgid "Larger"
-msgstr "Ավելի Մեծ"
-
-#: ../panels/universal-access/uap.ui.h:55
-msgid "LowContrast"
-msgstr "Փոքր Հակադրություն"
-
-#: ../panels/universal-access/uap.ui.h:57
-msgid "Mouse Settings..."
-msgstr "Մկնիկի Պարամետրերը․․․"
-
-#: ../panels/universal-access/uap.ui.h:58
-msgid "Nomon"
-msgstr "Nomon"
-
-#: ../panels/universal-access/uap.ui.h:59
-msgid "None"
-msgstr "Ոչ մի"
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "On screen keyboard"
-msgstr "Gnome-ի On screen ստեղնաշար"
-
-#: ../panels/universal-access/uap.ui.h:64
-msgid "OnBoard"
-msgstr "Ներդրված"
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "Options..."
-msgstr "_Ընտրանքներ..."
-
-#: ../panels/universal-access/uap.ui.h:66
-msgid "Pointing and Clicking"
-msgstr "Հղվել և Սեղմել"
-
-#: ../panels/universal-access/uap.ui.h:67
-msgid "Puts a delay between when a key is pressed and when it is accepted."
-msgstr "Ստեղնի սեղմման և նրա ընդունման միջև դնում է հապաղում"
-
-#: ../panels/universal-access/uap.ui.h:68
-msgid "Screen Reader"
-msgstr "Էկրանի ընթերցող սարք"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Seeing"
-msgstr "Դիտում է"
-
-#: ../panels/universal-access/uap.ui.h:70
-msgid "Shift+Ctrl+Alt+-"
-msgstr "Shift+Ctrl+Alt+-"
-
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Shift+Ctrl+Alt+="
-msgstr "Shift+Ctrl+Alt+="
-
-#: ../panels/universal-access/uap.ui.h:74
-msgid "Show Universal Access status"
-msgstr "Ցուցադրում է Համընդհանուր Հասանելիության վիճակը"
-
-#: ../panels/universal-access/uap.ui.h:79
-msgid "Sound Settings..."
-msgstr "Ձայնի Պարամետրեր․․․"
-
-#: ../panels/universal-access/uap.ui.h:81
-msgid "Test flash"
-msgstr "Տեստավորել թարթումը"
-
-#: ../panels/universal-access/uap.ui.h:82
-msgid "Test:"
-msgstr "Տեստ."
-
-#: ../panels/universal-access/uap.ui.h:83
-msgid "Text size:"
-msgstr "Տեքստի չափ․"
-
-#: ../panels/universal-access/uap.ui.h:84
-msgid "Treats a sequence of modifier keys as a key combination."
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Մեծ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Կրկնել ստեղները"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Սեղմած ստեղնի նորից սեղմում"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Կրկնել ստեղների արագությունը"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Կրկնել ստեղների արագությունը"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Տպման Օ_գնական՝"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Կպչուն ստեղներ"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+#, fuzzy
+msgid "Treats a sequence of modifier keys as a key combination"
 msgstr ""
 "Բանալիների մոդիֆիկատորների հաջորդականությունը դիտարկում է որպես բանալիների "
 "հաջորդականություն։"
 
-#: ../panels/universal-access/uap.ui.h:85
-msgid "Trigger a click when the pointer hovers."
-msgstr "Գործարկել կտտոցը, երբ ցուցիչը անցնում է վրայով"
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Ապաակտիվացնել, եթե երկու ստեղները սեղմվում են միաժամանակ"
 
-#: ../panels/universal-access/uap.ui.h:86
-msgid "Trigger a secondary click by holding down the primary button."
-msgstr "Գործարկել երկրորդական կտտոց՝ պահելով հիմնական կոճակը"
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Ազդանշանել, երբ _մոդիֆիկատորի ստեղնը միացված է"
 
-#: ../panels/universal-access/uap.ui.h:87
-msgid "Turn on or off:"
-msgstr "Միացնել կամ անջատել․"
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Դանդաղ ստեղներ"
 
-#: ../panels/universal-access/uap.ui.h:88
-msgid "Type here to test settings"
-msgstr "Տպել այստեղ՝ պարամետրերը ստուգելու համար․"
+#: panels/universal-access/cc-typing-dialog.ui:106
+#, fuzzy
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Ստեղնի սեղմման և նրա ընդունման միջև դնում է հապաղում"
 
-#: ../panels/universal-access/uap.ui.h:89
-msgid "Typing"
-msgstr "Տպվում է"
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Կարճ"
 
-#: ../panels/universal-access/uap.ui.h:90
-msgid "Typing Assistant"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Երկար"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Ազդանշանել, երբ _ստեղնը սեղմված է"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Ազդանշանել, երբ ստեղնն _ընդունված է"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Ազդանշանել, երբ ստեղնը մերժված է"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Անցման ստեղներ"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Անտեսել ստեղների սեղմման արագ կրկնումները"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Կարճ"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Երկար"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Մատչելիության հատկությունները կարելի է միացնել կամ անջատել ստեղների "
+"համադրություններով"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Դիտում է"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "Մեծ Հակադրություն"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Մեծ"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Էկրանի ընթերցող սարք"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Անցման ստեղներ"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Ազդանշանել, երբ _հասանելիությունը միացված կամ անջատված է"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Մեծացնել"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Լսում"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Տեսողական ահազանգեր"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "GNOME OnScreen ստեղնաշար"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Կրկնել ստեղները"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Կուրսորի թարթում"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
 msgstr "Տպման Օ_գնական՝"
 
-#: ../panels/universal-access/uap.ui.h:91
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "Օգտագործել տեսողական ցուցումները, երբ զգուշացման ձայներ են լսվում։"
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Հղվել և Սեղմել"
 
-#: ../panels/universal-access/uap.ui.h:92
-msgid "Use an alternative form of text input"
-msgstr "Տեքստի մուտքագրման համար օգտագործել ալտերնատիվ ձև"
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Մկնիկի ստեղներ"
 
-#: ../panels/universal-access/uap.ui.h:93
-msgid "Video Mouse"
-msgstr "ՏեսաՄկնիկ"
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Տեղակայել ցուցիչը"
 
-#: ../panels/universal-access/uap.ui.h:94
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "Հապաղում կրկնակի կտտոցի դեպքում"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "Հապաղում կրկնակի կտտոցի դեպքում"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
 msgid "Visual Alerts"
 msgstr "Տեսողական ահազանգեր"
 
-#: ../panels/universal-access/uap.ui.h:95
-msgid "Zoom"
-msgstr "Մեծացնել"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+#, fuzzy
+msgid "_Test flash"
+msgstr "Տեստավորել թարթումը"
 
-#: ../panels/universal-access/uap.ui.h:96
-msgid "Zoom in:"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Օգտագործել տեսողական ցուցումները, երբ զգուշացման ձայներ են լսվում։"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Ամբողջ էկրանի թարթում"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Ամբողջ էկրանի թարթում"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "Ձախ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "Աջ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
 msgstr "Մեծացնել."
 
-#: ../panels/universal-access/uap.ui.h:97
-msgid "Zoom out:"
-msgstr "Փոքրացնել․"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:99
-msgid "accepted"
-msgstr "ընդունված է"
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:100
-msgid "pressed"
-msgstr "սեղմված է"
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:101
-msgid "rejected"
-msgstr "մերժված է"
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Էկրանի ընթերցող սարք"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Կառավարման կենտրոն"
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "GNOME-ի կոնֆիգուրացման գործիք"
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
 
-#: ../typing-break/drw-break-window.c:194
-msgid "_Postpone Break"
-msgstr "_Հետաձգել ընդմիջումը"
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
 
-#: ../typing-break/drw-break-window.c:250
-msgid "Take a break!"
-msgstr "Ընդմիջում անել։"
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
 
-#: ../typing-break/drwright.c:136
-msgid "_Take a Break"
-msgstr "_Ընդմիջում անել"
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "Orca խոշորացույցով"
 
-#: ../typing-break/drwright.c:507
-#, c-format
-msgid "Take a break now (next in %dm)"
-msgstr "Ընդմիջում կատարել հիմա (հաջորդը %dm ժամանակից)"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
 
-#: ../typing-break/drwright.c:509
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "%d րոպե նախքան ընդմիջումը"
-msgstr[1] "%d րոպե նախքան ընդմիջումը"
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
 
-#: ../typing-break/drwright.c:515
-#, c-format
-msgid "Take a break now (next in less than one minute)"
-msgstr "Ընդմիջում կատարել հիմա (հաջորդը մեկ րոպեից էլ քիչ ժամանակից)"
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
 
-#: ../typing-break/drwright.c:517
-#, c-format
-msgid "Less than one minute until the next break"
-msgstr "Հաջորդ ընդմիջմանը մեկ րոպեից քիչ է մնացել"
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
 
-#: ../typing-break/drwright.c:614
-#, c-format
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Հակադրություն"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ոչ մի"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Ցածր"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Բարձր"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+#, fuzzy
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Ցածր"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+#, fuzzy
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Բարձր"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"Չի հաջողվել բերել մեքենագրման նախընտրությունների երկխոսությունը հետևյալ "
-"սխալի պատճառով՝ %s"
 
-#: ../typing-break/drwright.c:631
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "Գրել է Ռիչարդ Հալթը <richard@imendio.com>"
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
 
-#: ../typing-break/drwright.c:632
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Գրավիչ արտաքին, որն ավելացրել է Անդերս Քարլսոնը"
-
-#: ../typing-break/drwright.c:641
-msgid "A computer break reminder."
-msgstr "Ընդիմիջման մասին հիշեցնող ծրագիր։"
-
-#: ../typing-break/drwright.c:643
-msgid "translator-credits"
-msgstr "թարգմանչի կրեդիտներ"
-
-#: ../typing-break/main.c:63
-msgid "Enable debugging code"
-msgstr "Ակտիվացնել վրիպազերծման կոդը"
-
-#: ../typing-break/main.c:65
-msgid "Don't check whether the notification area exists"
-msgstr "Չստուգել՝ ծանուցման տարածք կա, թե՞ ոչ"
-
-#: ../typing-break/main.c:91
-msgid "Typing Monitor"
-msgstr "Մեքենագրելու մոնիտոր"
-
-#: ../typing-break/main.c:108
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"Տեղեկությունը ցույց տալու համար մեքենագրման մոնիտորն օգտագործում է "
-"տեղեկացման տարածքը։ Դուք վահանակի վրա չունեք տեղեկացման տարածք։ Այն "
-"ավելացնելու համար աջ ստեղնով կտտացրեք վահանակի վրա և ընտրեք 'Add to panel', "
-"ապա՝ 'Notification area' և հետո՝ 'Add'։"
 
-#: ../font-viewer/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "Եթե դրված է որպես ճշմարիտ, ապա OpenType տառատեսակը կդառնա մանրապատկեր։"
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "Եթե դրված է որպես ճշմարիտ, ապա PCF տառատեսակը կդառնա մանրապատկեր։"
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "Եթե դրված է որպես ճշմարիտ, ապա TrueType տառատեսակը կդառնա մանրապատկեր։"
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "Եթե դրված է որպես ճշմարիտ, ապա Type1 տառատեսակը կդառնա մանրապատկեր։"
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:5
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
 msgstr ""
-"Կարգավորել այս ստեղնը OpenType տառատեսակի մանրապատկերի հրաման ստեղծելու "
-"համար։"
 
-#: ../font-viewer/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr "Կարգավորել ստեղնը PCF տառատեսակի մանրապատկերի հրաման ստեղծելու համար։"
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:7
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Դնել այս ստեղնը TrueType տառատեսակի մանրապատկերի ստեղծելու համար հրամանի վրա։"
 
-#: ../font-viewer/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
 msgstr ""
-"Դնել այս ստեղնը այն հրամանի վրա, որն օգտագործվում է առաջին խմբի "
-"տառատեսակների մանրապատկեր ստեղծելու համար։"
 
-#: ../font-viewer/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "Մանրապատկերի հրաման OpenType տառատեսակի համար"
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "Terminator"
 
-#: ../font-viewer/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "Մանրապատկերի հրաման PCF տառատեսակի համար"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "Մանրապատկերի հրաման TrueType տառատեսակի համար"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Մանրապատկերի հրաման Type1 տառատեսակի համար"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "Ստեղծե՞լ OpenType տառատեսակի մանրապատկեր։"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "Ստեղծե՞լ PCF տառատեսակի մանրապատկեր։"
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "Ստեղծե՞լ TrueType տառատեսակի մանրապատկեր։"
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "Ստեղծե՞լ Type1 տառատեսակի մանրապատկեր։"
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
 
-#: ../font-viewer/font-view.c:297
-msgid "Name:"
-msgstr "Անվանում."
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
 
-#: ../font-viewer/font-view.c:300
-msgid "Style:"
-msgstr "Ոճ՝"
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr ""
 
-#: ../font-viewer/font-view.c:313
-msgid "Type:"
-msgstr "Տեսակ՝"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
 
-#: ../font-viewer/font-view.c:317
-msgid "Size:"
-msgstr "Չափ՝"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
 
-#: ../font-viewer/font-view.c:361 ../font-viewer/font-view.c:374
-msgid "Version:"
-msgstr "Տարբերակ՝"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr ""
 
-#: ../font-viewer/font-view.c:365 ../font-viewer/font-view.c:376
-msgid "Copyright:"
-msgstr "Հեղինակային իրավունք՝"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
 
-#: ../font-viewer/font-view.c:369
-msgid "Description:"
-msgstr "Նկարագրություն՝"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
 
-#: ../font-viewer/font-view.c:453
-msgid "Installed"
-msgstr "Տեղադրված է"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
 
-#: ../font-viewer/font-view.c:456
-msgid "Install Failed"
-msgstr "Տեղադրումը ձախողվել է"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
 
-#: ../font-viewer/font-view.c:526
-#, c-format
-msgid "usage: %s fontfile\n"
-msgstr "օգտագործում. %s ֆոնտֆայլ\n"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
 
-#: ../font-viewer/font-view.c:597
-msgid "I_nstall Font"
-msgstr "Տեղադրել տառատեսակ"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
 
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
-msgid "Font Viewer"
-msgstr "Տառատեսակ ցուցադրող"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
 
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
-msgid "Preview fonts"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
 msgstr "Ցուցադրել տառատեսակները"
 
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "Text to thumbnail (default: Aa)"
-msgstr "Տեքստը մանրապատկերով (նախնական։ Aa)"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
 
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "TEXT"
-msgstr "ՏԵՔՍՏ"
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "_Գաղտնաբառ՝"
 
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "Font size (default: 64)"
-msgstr "Տառատեսակի չափ (լռելյայն՝ 64)"
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Փոխել կարգավորումը"
 
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "SIZE"
-msgstr "ՉԱՓ"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "_Գաղտնաբառ՝"
 
-#: ../font-viewer/font-thumbnailer.c:249
-msgid "FONT-FILE OUTPUT-FILE"
-msgstr "ՏԱՌԱՏԵՍԱԿԻ ՖԱՅԼ, ԱՐՏԱԾՄԱՆ ՖԱՅԼ"
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Գաղտնաբառ՝"
 
-#: ../font-viewer/font-thumbnailer.c:268
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "_Գաղտնաբառ՝"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+#, fuzzy
+msgid "Authentication is required to change user data"
+msgstr ""
+"Բոլոր օգտագործողների բազմակի մոնիտորային պարամետրերը տեղադրելու համար "
+"վավերացում է անհրաժեշտ"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Ստեղների համադրությունը խմբագրելու համար կտտացրեք համապատասխան տողի վրա և "
+"մեքենագրեք ստեղների նոր համադրություն կամ սեղմեք backspace–ը ջնջելու համար։"
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Մկնիկի ուղղությունը"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Մոնիտոր"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Դասավորություն"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Մոդելավորված երկրորդական կտտոց"
+
+#: panels/windows/cc-windows-panel.ui:89
+msgid "Windows Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Երկր_որդական կտտոց՝"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Հասանելիություն"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "_Ավելացնել…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Մանրամասներ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Ցանցի պրոքսի"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "_Մանրամասներ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid "Error parsing arguments: %s\n"
-msgstr "Սխալը վերլուծող փաստարկումներ. %s\n"
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../examples/gnome-example-panel.desktop.in.in.h:1
-msgid "Example Panel"
-msgstr "Վահանակի Օրինակ"
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../examples/gnome-example-panel.desktop.in.in.h:2
-msgid "Example preferences panel"
-msgstr "Նախընտրությունների վահանակի օրինակ"
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
 
-#: ../shell/shell.ui.h:1
-msgid "System Settings"
-msgstr "Համակարգի Պարամետրեր"
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
 
-#: ../shell/shell.ui.h:2
-msgid "_All Settings"
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "Շարժունություն"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Ցանցի պրոքսի"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Ցանցի պրոքսի"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Մանրամասներ"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Ցանցի պրոքսի"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Փոխել կարգավորումը"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
 msgstr "_Բոլոր Պարամետրերը"
 
-msgid "Show help options"
-msgstr "Ցուցադրել Ձեռնարկի հատկությունները"
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Ընդհանուր"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr ""
+
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "վահանակի պատկերանիշ"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgid "Current network location"
+#~ msgstr "Ընթացիկ ցանցի տեղակայություն"
+
+#~ msgid "More themes URL"
+#~ msgstr "Ավելի շատ թեմաների URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "Կարգավորել սա ընթացիկ տեղակայության անվանման համար։ Սա օգտագործվում է "
+#~ "համապատասխան ցանցի պրոքսի կոնֆիգուրացիան որոշելու համար։"
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "URL որտեղից ստանալ աշխատասեղանի ավելի շատ ֆոների համար։ Եթե կարգավորված է "
+#~ "դատարկ ծրագրատողում տողը չի երևա։"
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "URL՝ ավելի շատ աշխատանքային սեղանի թեմաներ գտնելու համար։ Դատարկ տողի "
+#~ "դեպքում հղումը չի հայտնվի։"
+
+#~ msgid "Key"
+#~ msgstr "Ստեղն"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf ստեղն, որին կցված է հատկությունների այս խմբագիրը "
+
+#~ msgid "Callback"
+#~ msgstr "Մշակող"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Գործարկել այս մշակողը, երբ ստեղնի հետ կապված արժեքը փոխվում է"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "gconf հաճախորդին իր դիմումի համաձայն ուղարկվղ GConf փոփոխություն "
+#~ "պարունակող տվյալ"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Փոփոխություն վիջեթ մշակողում"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "Գործարկել մշակողը, երբ տվյալները GConf–ից վերածվում են վիջեթի"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Փոխակերպում վիջեթից մշակողի"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "Գործարկել մշակողը, երբ տվյալները GConf–ից վերածվում են վիջեթի"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Օբյեկտ, որ ղեկավարում է հատկույունը (սովորաբար վիջեթ)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Հատկությունների խմբագրի օբյեկտի տվյալ"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "հատուկ հատկությունների խմբագրի սովորական տվյալ"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Հատկության խմբագրի տվյալները ազատում են մշակողը"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Գործարկել մշակողը, երբ պետք է ազատվեն հատկության խմբագրի օբյեկտի տվյալները"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Չի հաջողվել գտնել '%s' ֆայլը։\n"
+#~ "\n"
+#~ "Խնդրում ենք հաստատել, որ այն գոյություն ունի և նորից փորձել կամ ընտրել "
+#~ "ֆոնի այլ նկար։"
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Ես չգիտեմ, թե ինչպես բացել '%s' ֆայլը։\n"
+#~ "Հավանաբար այն նկարի մի տեսակ է, որը դեռ ապահովված չէ։\n"
+#~ "\n"
+#~ "Խնդրում ենք փոխարենն այլ նկար ընտրել։"
+
+#~ msgid "Please select an image."
+#~ msgstr "Խնդրում ենք նկար ընտրել։"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Ամսաթիվը և Ժամանակի նախընտրությունների վահանակ"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "Սկսել նախընտրելի տեսողական աջակցող տեխնոլոգիան"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "Տեսողական օգնություն"
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Սխալ՝ %s կոնֆիգուրացիան պահպանելիս"
+
+#~ msgid "Custom"
+#~ msgstr "Սովորական"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Չի հաջողվել բեռնել գլխավոր ինտերֆեյսը"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Բոլոր %s դեպքերը կտեղափոխվեն իրական տողերով"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Հ_րաման՝"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "Գ_ործարկել դրոշակը՝"
+
+#~ msgid "Image Viewer"
+#~ msgstr "Նկարի դիտակ"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "Ակնթարթային հաղորդագրող"
+
+#~ msgid "Internet"
+#~ msgstr "Համացանց"
+
+#~ msgid "Mail Reader"
+#~ msgstr "Էլ–փոստ ընթերցող"
+
+#~ msgid "Multimedia"
+#~ msgstr "Մուլտիմեդիա"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Բացել տողը նոր _ներդիրով"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Բացել տողը նոր _պատուհանով"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Բացել տողը նոր վեբ զննիչով _նախնական"
+
+#~ msgid "Run at st_art"
+#~ msgstr "Սկսել սկ_զբից"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Սկսել տ_երմինալում"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "Տերմինալի էմուլյատոր"
+
+#~ msgid "Text Editor"
+#~ msgstr "Տեքստային խմբագիր"
+
+#~ msgid "Video Player"
+#~ msgstr "Վիդեո նվագարկիչ"
+
+#~ msgid "Visual"
+#~ msgstr "Տեսողական"
+
+#~ msgid "Web Browser"
+#~ msgstr "Վեբ զննիչ "
+
+#~ msgid "Balsa"
+#~ msgstr "Բալսա"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee երաժշտական նվագարկիչ"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian Զգայուն զննիչ"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian Տերմինալի էմուլյատոր"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Շրջապատել"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution փոստային ընթերցող"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "GNOME խոշորացույց առանց էկրանի ընթերցող սարքի"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus խոշորացույցով"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape էլ–փոստ"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "KDE խոշորացույց առանց էկրանի ընթերցող սարքի"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Linux–ի էկրանի ընթերցող սարք խոշորացույցով"
+
+#~ msgid "Listen"
+#~ msgstr "Լսել"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla էլ–փոստ"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape հաղորդակցվող"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox նվագարկիչ"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey էլ–փոստ"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Ստանդարտ X–տերմինալ"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem նվագարկիչ"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Include _panel"
+#~ msgstr "Ընդգրկել _վահանակը"
+
+#~ msgid "Make Default"
+#~ msgstr "Դարձնել Լռելյայն"
+
+#~ msgid "Off"
+#~ msgstr "Անջատել"
+
+#~ msgid "On"
+#~ msgstr "Միացնել"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "Նույն պատկերը բորոր մոնիտորներում"
+
+#~ msgid "Upside-down"
+#~ msgstr "Վերից վար"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "_Հայտնաբերել մոնիտորները"
+
+#~ msgid "_Show monitors in panel"
+#~ msgstr "_Մոնիտորները ցույց տալ վահանակի վրա"
+
+#~ msgid "Change resolution and position of monitors"
+#~ msgstr "Փոխել մոնիտորների բաժանումը և դիրքը"
+
+#~ msgid "Monitors"
+#~ msgstr "Մոնիտորներ"
+
+#, c-format
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "Օգտագործում․ %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "Այս ծրագիրը տեղադրում է RANDR պրոֆիլը բազմակի մոնիտորային ռեժիմի համար "
+#~ "նշված\n"
+#~ "համակարգային տարածքում։ Վերջնական պրոֆիլը կդառնա սովոր սովորական, երբ\n"
+#~ "RANDR plug-in գործարկվում է gnome-settings-daemon -ում։\n"
+#~ "\n"
+#~ "SOURCE_FILE - ամբողջական ճանապարհն է, տիպիկ /home/username/.config/"
+#~ "monitors.xml\n"
+#~ "\n"
+#~ "DEST_NAME - տեղադրված ֆայլի հարաբերական անունը. Այն կդրվի նշված տեղում\n"
+#~ "            RANDR կոնֆիգուրացիաների համար՝ իր համակարգի պանակում,\n"
+#~ "            այնպես որ արդյունքը տիպիկ կլինի %s/DEST_NAME\n"
+
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "Այս ծրագիրը կարող է օգտագործվել միայն արմատային օգտագործողի կողմից"
+
+#~ msgid "The source filename must be absolute"
+#~ msgstr "Պետք է նշված լինի ֆայլի բացարձակ անունը"
+
+#~ msgid "Could not open %s: %s\n"
+#~ msgstr "Չի հաջողվել բացել %s. %s\n"
+
+#~ msgid "Could not get information for %s: %s\n"
+#~ msgstr "Չի հաջողվել ստանալ %s -ի վերաբերյալ տեղեկատվություն․ %s\n"
+
+#, c-format
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s պետք է լինի ռեգուլյար ֆայլ\n"
+
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "Այս ծրագիրը պետք է գործարկվի միայն pkexec(1) - ի միջոցով"
+
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "PKEXEC_UID պետք է սահմանվի ամբողջ արժեք"
+
+#, c-format
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "%s -ը պետք է լինի ձեր սեփականությունը\n"
+
+#, c-format
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s -ը պետք է չունենա որևէ պանակ-կոմպոնոնտներ\n"
+
+#, c-format
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s -ը պետք է լինի պանակ\n"
+
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "Չի հաջողվել բացել %s/%s. %s\n"
+
+#, c-format
+#~ msgid "Could not rename %s to %s: %s\n"
+#~ msgstr "Չի հաջողվել անվանափոխել %s -ը %s -ով․ %s\n"
+
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "Տեղադրել բազմակի մոնիտորային պարամետրերը ամբողջ համակարգի համար"
+
+#~ msgid "Upside Down"
+#~ msgstr "Վերից վար"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#, c-format
+#~ msgid "Monitor: %s"
+#~ msgstr "Մոնիտոր. %s"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Ընտրել մոնիտոր՝ հատկությունները փոխելու համար. քաշել այն դիրքի "
+#~ "փոփոխության համար։"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Չհաջողվեց պահել մոնիտորի կոնֆիգուրացումը"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "Չի հաջողվել ստանալ կապուղին էկրանի կոնֆիգուրացիան կիրառելու ժամանակ"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "Էկրաններ հայտնաբերումը չի հաջողվել"
+
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "Մոնիտորի կոնֆիգուրացիան պահպանվել է"
+
+#~ msgid "This configuration will be used the next time someone logs in."
+#~ msgstr ""
+#~ "Այս կոնֆիգուրացիան կօգտագործվի հաջորդ անգամ, երբ ինչ-որ մեկը մուտք գործի "
+#~ "համակարգ"
+
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "Չհաջողվեց մոնիտորի համար սահմանել լռելյայն կոնֆիգուրացիա"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Չի հաջողվել ստանալ էկրանի տվյալները"
+
+#~ msgid "New shortcut..."
+#~ msgstr "Նոր ստեղների համադրություն…"
+
+#~ msgid "Accelerator key"
+#~ msgstr "Արագացուցչի ստեղն"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Արագացուցչի ձևափոխիչ"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Արագացնող ստեղնի գաղտնագիր"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Արագացուցչի տեսակը։"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Անհայտ գործողություն>"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "Սխալ՝ ստեղների համադրությունը պահպանելիս"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "\"%s\" ստեղների համադրությունը չի հաջողվել գործածել, որովհետև "
+#~ "մեքենագրելու ժամանակ այս ստեղնի օգտագործումը անհնար կլինի։\n"
+#~ "Խնդրում ենք փորձել այնպիսի ստեղներով ինչպիսիք են Control, Alt կամ Shift–ը "
+#~ "միաժամանակ։"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "\"%s\" ստեղների համադրությունն արդեն օգտագործված է՝\n"
+#~ "\"%s\""
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Եթե \"%s\" ստեղների համադրությունը վերանշանակեք, \"%s\" ստեղների "
+#~ "համադրությունը կապաակտիվացվի։"
+
+#~ msgid "_Reassign"
+#~ msgstr "_Վերանշանակել"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "Սխալ՝ կոնֆիգուրացիայի տվյալների բազայում արագացուցիչն անջատելիս՝ %s"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Չափազանց շատ սովորական ստեղների համադրություն"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Սովորական ստեղների համադրություն"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Նշանակել ստեղների համադրություն հրամանների համար"
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "Ազդանշանել, երբ _փոխանջատչի ստեղնը սեղմված է"
+
+#~ msgid "Beep when a key is reje_cted"
+#~ msgstr "Ազդանշանել, երբ ստեղնը մերժ_ված է"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Ազդանշանել, երբ ստեղնը _մերժված է"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "_Պատուհանի վերնագրի տողի թարթում"
+
+#~ msgid "Flash entire _screen"
+#~ msgstr "Ամբողջ _էկրանի թարթում"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Ստեղնաշարի հասանելիության ձայնային հետդարձ կապ"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "Ցույց տալ _տեսողական հետդարձ կապ զգուշացման ազդանշանի ձայնի համար"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "Տեսողական հուշում ձայների համար"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Թու_յլատրել ընդմիջումների հետաձգումը"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Ձայնային _հետդարձ կապ..."
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Ստուգել, երբ թույլատրվում է ընդմիջումներն հետաձգել"
+
+#~ msgid "Disa_ble sticky keys if two keys are pressed together"
+#~ msgstr ""
+#~ "Ապաա_կտիվացնել կպչուն ստեղները, եթե երկու ստեղները սեղմվում են միաժամանակ"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Ընդմիջման ժամանակը, երբ չի թույլատրվում մեքենագրելը"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Աշխատանքի տևողությունը նախքան ստիպողական ընդմիջումը"
+
+#~ msgid "Fast"
+#~ msgstr "Արագ"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Ստեղնաշարի նախընտրություններ"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Ստեղնաշարի _մոդել՝"
+
+#~ msgid "Layouts"
+#~ msgstr "Դասավորություններ"
+
+#~ msgid "List of keyboard layouts selected for usage"
+#~ msgstr "Օգտագործման համար ընտրված ստեղնաշարային դասավորությունների ցուցակը"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Որոշակի ժամանակ անց արգելափակել էկրանը՝ ստեղնաշարի անընդհատ օգտագործոման "
+#~ "հետևանքով բարդություններից խուսափելու համար"
+
+#~ msgid "Move the selected keyboard layout down in the list"
+#~ msgstr ""
+#~ "Ընտրված ստեղնաշարային դասավորությունը տեղափոխել ցուցակում դեպի ներքև"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "Ընտրված ստեղնաշարային դասավորությունը տեղափոխել ցուցակում դեպի վերև"
+
+#~ msgid "New windows u_se active window's layout"
+#~ msgstr "Նոր պատուհաններն օգտագործում են ակտիվ պատուհանի ծրագիրը"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "Ընտրված ստեղնաշարային դասավորության համար տպել սխեմա"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "Հեռացնել ընտրված ստեղնաշարային դասավորությունը ցուցակից"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Փոխարինել ընթացիկ ստեղնաշարային դասավորության պարամետրերը\n"
+#~ "լռելյայն պարամետրերով"
+
+#~ msgid "S_peed:"
+#~ msgstr "Ա_րագություն՝"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "Ընտրեք ցուցակին ավելացվող ստեղնաշարային դասավորությունը"
+
+#~ msgid "Slow"
+#~ msgstr "Դանդաղ"
+
+#~ msgid "Typing Break"
+#~ msgstr "Աշխատանքային ընդմիջում"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "Դիտել և խմբագրել ստեղնաշարի դասավորության ընտրանքները"
+
+#~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#~ msgstr ""
+#~ "_Օժանդակ հատկությունները կարելի է փոփոխել ստեղների համադրություններով"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Ընդմիջման տևողությունը."
+
+#~ msgid "_Ignore fast duplicate keypresses"
+#~ msgstr "_Անտեսել ստեղների սեղմման արագ կրկնումները"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "_Արգելափակել էկրանը աշխատանքային ընդմիջման համար"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_Ընդունել միայն ստեղների երկար սեղմումները"
+
+#~ msgid "_Options..."
+#~ msgstr "_Ընտրացանկ..."
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "_Ցուցիչը կարող է կառավարվել ստեղնխմբով"
+
+#~ msgid "_Separate layout for each window"
+#~ msgstr "_Առանձին դասավորություն ամեն մի պատուհանի համար"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Մոդելավորել ստեղների միաժամանակյա սեղմումները"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Մեքենագրել պարամետրերը ստուգելու համար՝"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Աշխատանքի ընդմիջումը տևում է՝"
+
+#~ msgid "By _country"
+#~ msgstr "Երկրով"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Ընտրել դասավորություն"
+
+#~ msgid "_Country:"
+#~ msgstr "_Երկիր՝"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Տարբերակներ՝"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Ընտրել ստեղնաշարի մոդելը"
+
+#~ msgid "_Models:"
+#~ msgstr "_Մոդելներ՝"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_Վաճառող՝"
+
+#~ msgid "Unknown"
+#~ msgstr "Անհայտ"
+
+#~ msgid "Vendors"
+#~ msgstr "Վաճառողներ"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Կարգավորել ստեղնաշարի նախընտրությունները"
+
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Հնարավոր չէ բեռնել '%s' պատկերանիշը\n"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "շարժում|դեպի ձախ"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "շարժում|դեպի աջ"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "շարժում|դեպի վեր"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "շարժում|դեպի վար"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "շարժում|ապաակտիվացված է"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Ընտրել կտտացնելու տեսակը _նախապես"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "Ընտրել կտտացնելու տեսակը մկն_իկի շարժումներով"
+
+#~ msgid "D_ouble click:"
+#~ msgstr "Կ_րկնակի կտտոց՝"
+
+#~ msgid "D_rag click:"
+#~ msgstr "Ա_րգելակի կտտոց՝"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "Քաշել և գցել"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "Ակտիվացնել _մկնիկի կտտոցը սենսորային վահանակի հետ միաժամանակ"
+
+#~ msgid "Pointer Speed"
+#~ msgstr "Ցուցչի արագություն"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Ցու_յց տալ ցուցչի դիրքը, երբ ղեկավարման ստեղնը սեղմված է"
+
+#~ msgid "Show click type _window"
+#~ msgstr "Ցույց տալ պատուհանի կտտոցի _տեսակը"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "Սահմանային _արժեք՝"
+
+#~ msgid ""
+#~ "To test your double-click settings, try to double-click on the light bulb."
+#~ msgstr ""
+#~ "Կրկնակի կտտոցի պարամետրերը ստուգելու համար փորձեք կրկնակի կտտացնել վառվող "
+#~ "լույսի վրա։"
+
+#~ msgid "Two-_finger scrolling"
+#~ msgstr "Ոլորում երկու _մատով"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr ""
+#~ "Կարող եք նաև օգտագործել հապաղումով կտտոցը վահանակի ապլետի կտտոցի տեսակը "
+#~ "ընտրելու համար։"
+
+#~ msgid "_Edge scrolling"
+#~ msgstr "_Եզրային ոլորում"
+
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "_Գործարկել կտտոցը, երբ դադարեցվում է ցուցչի շարժումը"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Ձախ ձեռքով"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_Աջ ձեռքով"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Զգայունություն՝"
+
+#~ msgid "_Single click:"
+#~ msgstr "_Մեկ կտտոց՝"
+
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr "_Իրականցնել երկրորդական կտտոցը՝ պահելով հիմնական կոճակը"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Կարգավորել մկնիկի նախընտրությունները"
+
+#~ msgid "Location already exists"
+#~ msgstr "Տեղակայությունն արդեն գոյություն ունի"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Կարգավորել ցանցի պրոքսիի նախընտրությունները"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Ու_ղիղ համացանցային կապ</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>_Ավտոմատ պրոքսի կոնֆիգուրացիա</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_Ձեռքով պրոքսի կոնֆիգուրացիա</b>"
+
+#~ msgid "C_reate"
+#~ msgstr "Ս_տեղծել"
+
+#~ msgid "Create New Location"
+#~ msgstr "Ստեղծել նոր տեղակայություն"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP պրոքսի մանրամասներ"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "Անտեսել հոսթի ցուցակը"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Ցանցի պրոքսիի նախընտրություններ"
+
+#~ msgid "Port:"
+#~ msgstr "Պորտ՝"
+
+#~ msgid "The location already exists."
+#~ msgstr "Տեղանքն արդեն գոյություն ունի։"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Ապահովել HTTP պրոքսի՝"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Համընդհանուր հասանելիության նախընտրություններ"
+
+#, no-c-format
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#, no-c-format
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#, no-c-format
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">Բարձր/Հետադարձ</span>"
+
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">Բարձր</span>"
+
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">Ցածր</span>"
+
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">Նորմալ</span>"
+
+#~ msgid "Beep when Caps and Num Lock are used"
+#~ msgstr "Ազդանշանել, երբ Caps և Num Lock-ը օգտագործված են"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Ազդանշանել, երբ ստեղնը սեղմված է"
+
+#~ msgid "Beep when a modifer key is pressed"
+#~ msgstr "Ազդանշանել, երբ մոդիֆիկատորի ստեղնը միացված է"
+
+#~ msgid "Caribou"
+#~ msgstr "Կարիբու"
+
+#~ msgid "Change constrast:"
+#~ msgstr "Փոխել հակադրությունը"
+
+#~ msgid "Control the pointer using the keypad."
+#~ msgstr "Կառավարել ցուցիչը՝ օգտագործելով ստեղնախումբ։"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Կառավարել ցուցիչը՝ օգտագործելով տեսախցիկ։"
+
+#~ msgid "Ctrl+Alt+-"
+#~ msgstr "Ctrl+Alt+-"
+
+#~ msgid "Ctrl+Alt+0"
+#~ msgstr "Ctrl+Alt+0"
+
+#~ msgid "Ctrl+Alt+4"
+#~ msgstr "Ctrl+Alt+4"
+
+#~ msgid "Ctrl+Alt+8"
+#~ msgstr "Ctrl+Alt+8"
+
+#~ msgid "Ctrl+Alt+="
+#~ msgstr "Ctrl+Alt+="
+
+#~ msgid "Display a textual description of speech and sounds."
+#~ msgstr "Ցուցադրել խոսքի և ձայնի տեքստային նկարագրությունը"
+
+#~ msgid "Flash the window title"
+#~ msgstr "Պատուհանի վերնագրի թարթում"
+
+#~ msgid "GOK"
+#~ msgstr "GOK"
+
+#~ msgid "High/Inverse"
+#~ msgstr "Բարձր/Հակադարձ"
+
+#~ msgid "HighContrastInverse"
+#~ msgstr "Մեծ Հակադրության Հակադարձ"
+
+#~ msgid "I need assistance with:"
+#~ msgstr "Ես կարիք ունեմ այսպիսի օգնականի․"
+
+#~ msgid "Keyboard Settings..."
+#~ msgstr "Ստեղնաշարի պարամետրեր․․․"
+
+#~ msgid "Larger"
+#~ msgstr "Ավելի Մեծ"
+
+#~ msgid "LowContrast"
+#~ msgstr "Փոքր Հակադրություն"
+
+#~ msgid "Mouse Settings..."
+#~ msgstr "Մկնիկի Պարամետրերը․․․"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "OnBoard"
+#~ msgstr "Ներդրված"
+
+#~ msgid "Shift+Ctrl+Alt+-"
+#~ msgstr "Shift+Ctrl+Alt+-"
+
+#~ msgid "Shift+Ctrl+Alt+="
+#~ msgstr "Shift+Ctrl+Alt+="
+
+#~ msgid "Show Universal Access status"
+#~ msgstr "Ցուցադրում է Համընդհանուր Հասանելիության վիճակը"
+
+#~ msgid "Sound Settings..."
+#~ msgstr "Ձայնի Պարամետրեր․․․"
+
+#~ msgid "Text size:"
+#~ msgstr "Տեքստի չափ․"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "Տպել այստեղ՝ պարամետրերը ստուգելու համար․"
+
+#~ msgid "Use an alternative form of text input"
+#~ msgstr "Տեքստի մուտքագրման համար օգտագործել ալտերնատիվ ձև"
+
+#~ msgid "Video Mouse"
+#~ msgstr "ՏեսաՄկնիկ"
+
+#~ msgid "accepted"
+#~ msgstr "ընդունված է"
+
+#~ msgid "Control Center"
+#~ msgstr "Կառավարման կենտրոն"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME-ի կոնֆիգուրացման գործիք"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_Հետաձգել ընդմիջումը"
+
+#~ msgid "Take a break!"
+#~ msgstr "Ընդմիջում անել։"
+
+#~ msgid "_Take a Break"
+#~ msgstr "_Ընդմիջում անել"
+
+#, c-format
+#~ msgid "Take a break now (next in %dm)"
+#~ msgstr "Ընդմիջում կատարել հիմա (հաջորդը %dm ժամանակից)"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d րոպե նախքան ընդմիջումը"
+#~ msgstr[1] "%d րոպե նախքան ընդմիջումը"
+
+#, c-format
+#~ msgid "Take a break now (next in less than one minute)"
+#~ msgstr "Ընդմիջում կատարել հիմա (հաջորդը մեկ րոպեից էլ քիչ ժամանակից)"
+
+#, c-format
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Հաջորդ ընդմիջմանը մեկ րոպեից քիչ է մնացել"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Չի հաջողվել բերել մեքենագրման նախընտրությունների երկխոսությունը հետևյալ "
+#~ "սխալի պատճառով՝ %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Գրել է Ռիչարդ Հալթը <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Գրավիչ արտաքին, որն ավելացրել է Անդերս Քարլսոնը"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Ընդիմիջման մասին հիշեցնող ծրագիր։"
+
+#~ msgid "translator-credits"
+#~ msgstr "թարգմանչի կրեդիտներ"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Ակտիվացնել վրիպազերծման կոդը"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Չստուգել՝ ծանուցման տարածք կա, թե՞ ոչ"
+
+#~ msgid "Typing Monitor"
+#~ msgstr "Մեքենագրելու մոնիտոր"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Տեղեկությունը ցույց տալու համար մեքենագրման մոնիտորն օգտագործում է "
+#~ "տեղեկացման տարածքը։ Դուք վահանակի վրա չունեք տեղեկացման տարածք։ Այն "
+#~ "ավելացնելու համար աջ ստեղնով կտտացրեք վահանակի վրա և ընտրեք 'Add to "
+#~ "panel', ապա՝ 'Notification area' և հետո՝ 'Add'։"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Եթե դրված է որպես ճշմարիտ, ապա OpenType տառատեսակը կդառնա մանրապատկեր։"
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Եթե դրված է որպես ճշմարիտ, ապա PCF տառատեսակը կդառնա մանրապատկեր։"
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Եթե դրված է որպես ճշմարիտ, ապա TrueType տառատեսակը կդառնա մանրապատկեր։"
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Եթե դրված է որպես ճշմարիտ, ապա Type1 տառատեսակը կդառնա մանրապատկեր։"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Կարգավորել այս ստեղնը OpenType տառատեսակի մանրապատկերի հրաման ստեղծելու "
+#~ "համար։"
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Կարգավորել ստեղնը PCF տառատեսակի մանրապատկերի հրաման ստեղծելու համար։"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Դնել այս ստեղնը TrueType տառատեսակի մանրապատկերի ստեղծելու համար հրամանի "
+#~ "վրա։"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Դնել այս ստեղնը այն հրամանի վրա, որն օգտագործվում է առաջին խմբի "
+#~ "տառատեսակների մանրապատկեր ստեղծելու համար։"
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Մանրապատկերի հրաման OpenType տառատեսակի համար"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Մանրապատկերի հրաման PCF տառատեսակի համար"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Մանրապատկերի հրաման TrueType տառատեսակի համար"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Մանրապատկերի հրաման Type1 տառատեսակի համար"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Ստեղծե՞լ OpenType տառատեսակի մանրապատկեր։"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Ստեղծե՞լ PCF տառատեսակի մանրապատկեր։"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Ստեղծե՞լ TrueType տառատեսակի մանրապատկեր։"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Ստեղծե՞լ Type1 տառատեսակի մանրապատկեր։"
+
+#~ msgid "Size:"
+#~ msgstr "Չափ՝"
+
+#~ msgid "Copyright:"
+#~ msgstr "Հեղինակային իրավունք՝"
+
+#~ msgid "Description:"
+#~ msgstr "Նկարագրություն՝"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "օգտագործում. %s ֆոնտֆայլ\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "Տեղադրել տառատեսակ"
+
+#~ msgid "Font Viewer"
+#~ msgstr "Տառատեսակ ցուցադրող"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Տեքստը մանրապատկերով (նախնական։ Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "ՏԵՔՍՏ"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Տառատեսակի չափ (լռելյայն՝ 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "ՉԱՓ"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "ՏԱՌԱՏԵՍԱԿԻ ՖԱՅԼ, ԱՐՏԱԾՄԱՆ ՖԱՅԼ"
+
+#, c-format
+#~ msgid "Error parsing arguments: %s\n"
+#~ msgstr "Սխալը վերլուծող փաստարկումներ. %s\n"
+
+#~ msgid "Example Panel"
+#~ msgstr "Վահանակի Օրինակ"
+
+#~ msgid "Example preferences panel"
+#~ msgstr "Նախընտրությունների վահանակի օրինակ"

--- a/po/hy.po~
+++ b/po/hy.po~
@@ -1,0 +1,2171 @@
+# translation of gnome-control-center.HEAD.hy.po to armenian
+# Copyright (C) 2010
+# This file is distributed under the same license as the PACKAGE package.
+# Narine Martirosyan <training@instigate.am>
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.HEAD.hy\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2010-09-01 11:35+0500\n"
+"PO-Revision-Date: 2010-09-02 11:06+0400\n"
+"Last-Translator: Nune <nune@instigatedesign.com>\n"
+"Language-Team:  <norayr@arnet.am>\n"
+"Language: hy\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+#: ../gnome-control-center.schemas.in.h:1
+msgid "Current network location"
+msgstr "Ընթացիկ ցանցի տեղակայություն"
+
+#: ../gnome-control-center.schemas.in.h:2
+msgid "More backgrounds URL"
+msgstr "Ավելի շատ ֆոների URL"
+
+#: ../gnome-control-center.schemas.in.h:3
+msgid "More themes URL"
+msgstr "Ավելի շատ թեմաների URL"
+
+#: ../gnome-control-center.schemas.in.h:4
+msgid ""
+"Set this to your current location name. This is used to determine the "
+"appropriate network proxy configuration."
+msgstr ""
+"Կարգավորել սա ընթացիկ տեղակայության անվանման համար։ Սա օգտագործվում է "
+"համապատասխան ցանցի պրոքսի կոնֆիգուրացիան որոշելու համար։"
+
+#: ../gnome-control-center.schemas.in.h:5
+msgid ""
+"URL for where to get more desktop backgrounds. If set to an empty string the "
+"link will not appear."
+msgstr ""
+"URL որտեղից ստանալ աշխատասեղանի ավելի շատ ֆոների համար։ Եթե կարգավորված է "
+"դատարկ ծրագրատողում տողը չի երևա։"
+
+#: ../gnome-control-center.schemas.in.h:6
+msgid ""
+"URL for where to get more desktop themes. If set to an empty string the link "
+"will not appear."
+msgstr ""
+"URL՝ ավելի շատ աշխատանքային սեղանի թեմաներ գտնելու համար։ Դատարկ տողի "
+"դեպքում հղումը չի հայտնվի։"
+
+#: ../libgnome-control-center/gconf-property-editor.c:134
+msgid "Key"
+msgstr "Ստեղն"
+
+#: ../libgnome-control-center/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr "GConf ստեղն, որին կցված է հատկությունների այս խմբագիրը "
+
+#: ../libgnome-control-center/gconf-property-editor.c:141
+msgid "Callback"
+msgstr "Մշակող"
+
+#: ../libgnome-control-center/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Գործարկել այս մշակողը, երբ ստեղնի հետ կապված արժեքը փոխվում է"
+
+#: ../libgnome-control-center/gconf-property-editor.c:147
+msgid "Change set"
+msgstr "Փոխել կարգավորումը"
+
+#: ../libgnome-control-center/gconf-property-editor.c:148
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"gconf հաճախորդին իր դիմումի համաձայն ուղարկվղ GConf փոփոխություն պարունակող "
+"տվյալ"
+
+#: ../libgnome-control-center/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr "Փոփոխություն վիջեթ մշակողում"
+
+#: ../libgnome-control-center/gconf-property-editor.c:154
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "Գործարկել մշակողը, երբ տվյալները GConf–ից վերածվում են վիջեթի"
+
+#: ../libgnome-control-center/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr "Փոխակերպում վիջեթից մշակողի"
+
+#: ../libgnome-control-center/gconf-property-editor.c:160
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr "Գործարկել մշակողը, երբ տվյալները GConf–ից վերածվում են վիջեթի"
+
+#: ../libgnome-control-center/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "UI ղեկավարում"
+
+#: ../libgnome-control-center/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr "Օբյեկտ, որ ղեկավարում է հատկույունը (սովորաբար վիջեթ)"
+
+#: ../libgnome-control-center/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr "Հատկությունների խմբագրի օբյեկտի տվյալ"
+
+#: ../libgnome-control-center/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr "հատուկ հատկությունների խմբագրի սովորական տվյալ"
+
+#: ../libgnome-control-center/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr "Հատկության խմբագրի տվյալները ազատում են մշակողը"
+
+#: ../libgnome-control-center/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Գործարկել մշակողը, երբ պետք է ազատվեն հատկության խմբագրի օբյեկտի տվյալները"
+
+#: ../libgnome-control-center/gconf-property-editor.c:1406
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Չի հաջողվել գտնել '%s' ֆայլը։\n"
+"\n"
+"Խնդրում ենք հաստատել, որ այն գոյություն ունի և նորից փորձել կամ ընտրել ֆոնի "
+"այլ նկար։"
+
+#: ../libgnome-control-center/gconf-property-editor.c:1414
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Ես չգիտեմ, թե ինչպես բացել '%s' ֆայլը։\n"
+"Հավանաբար այն նկարի մի տեսակ է, որը դեռ ապահովված չէ։\n"
+"\n"
+"Խնդրում ենք փոխարենն այլ նկար ընտրել։"
+
+#: ../libgnome-control-center/gconf-property-editor.c:1536
+msgid "Please select an image."
+msgstr "Խնդրում ենք նկար ընտրել։"
+
+#: ../libgnome-control-center/gconf-property-editor.c:1541
+msgid "_Select"
+msgstr "_Ընտրել"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date And Time"
+msgstr "Ամսաթիվ և Ժամանակ"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Date and Time preferences panel"
+msgstr "Ամսաթիվը և Ժամանակի նախընտրությունների վահանակ"
+
+#: ../panels/default-applications/gnome-default-applications-panel.desktop.in.in.h:1
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:17
+msgid "Preferred Applications"
+msgstr "Նախընտրելի ծրագրեր"
+
+#: ../panels/default-applications/gnome-default-applications-panel.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Ընտրել նախնական ծրագրերը"
+
+#: ../panels/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Start the preferred visual assistive technology"
+msgstr "Սկսել նախընտրելի տեսողական աջակցող տեխնոլոգիան"
+
+#: ../panels/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr "Տեսողական օգնություն"
+
+#: ../panels/default-applications/gnome-da-capplet.c:99
+#: ../panels/default-applications/gnome-da-capplet.c:363
+#: ../panels/default-applications/gnome-da-capplet.c:384
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "Սխալ՝ %s կոնֆիգուրացիան պահպանելիս"
+
+#: ../panels/default-applications/gnome-da-capplet.c:692
+msgid "Custom"
+msgstr "Սովորական"
+
+#: ../panels/default-applications/gnome-da-capplet.c:723
+msgid "Could not load the main interface"
+msgstr "Չի հաջողվել բեռնել գլխավոր ինտերֆեյսը"
+
+#: ../panels/default-applications/gnome-da-capplet.c:725
+msgid "Please make sure that the applet is properly installed"
+msgstr "Խնդրում ենք համոզվել, որ ապլետը ճիշտ է տեղադրված"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:1
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:1
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "Accessibility"
+msgstr "Հասանելիություն"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:3
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "Բոլոր %s դեպքերը կտեղափոխվեն իրական տողերով"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:4
+#: ../panels/keybindings/gnome-keybinding-properties.ui.h:1
+msgid "C_ommand:"
+msgstr "Հ_րաման՝"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:5
+msgid "Co_mmand:"
+msgstr "Հ_րաման՝"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:6
+msgid "E_xecute flag:"
+msgstr "Գ_ործարկել դրոշակը՝"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:7
+msgid "Image Viewer"
+msgstr "Նկարի դիտակ"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:8
+msgid "Instant Messenger"
+msgstr "Ակնթարթային հաղորդագրող"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:9
+msgid "Internet"
+msgstr "Համացանց"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:10
+msgid "Mail Reader"
+msgstr "Էլ–փոստ ընթերցող"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:11
+msgid "Mobility"
+msgstr "Շարժունություն"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:12
+msgid "Multimedia"
+msgstr "Մուլտիմեդիա"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:13
+msgid "Multimedia Player"
+msgstr "Մուլտիմեդիա նվագարկիչ"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:14
+msgid "Open link in new _tab"
+msgstr "Բացել տողը նոր _ներդիրով"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:15
+msgid "Open link in new _window"
+msgstr "Բացել տողը նոր _պատուհանով"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:16
+msgid "Open link with web browser _default"
+msgstr "Բացել տողը նոր վեբ զննիչով _նախնական"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:18
+msgid "Run at st_art"
+msgstr "Սկսել սկ_զբից"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:19
+msgid "Run in t_erminal"
+msgstr "Սկսել տ_երմինալում"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:20
+msgid "System"
+msgstr "Համակարգ"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:21
+msgid "Terminal Emulator"
+msgstr "Տերմինալի էմուլյատոր"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:22
+msgid "Text Editor"
+msgstr "Տեքստային խմբագիր"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:23
+msgid "Video Player"
+msgstr "Վիդեո նվագարկիչ"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:24
+msgid "Visual"
+msgstr "Տեսողական"
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:25
+msgid "Web Browser"
+msgstr "Վեբ զննիչ "
+
+#: ../panels/default-applications/gnome-default-applications-properties.ui.h:26
+msgid "_Run at start"
+msgstr "_Սկսել սկզբից"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Բալսա"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr "Banshee երաժշտական նվագարկիչ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr "Claws Mail"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:4
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Dasher"
+msgstr "Dasher"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr "Debian Զգայուն զննիչ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr "Debian Տերմինալի էմուլյատոր"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr "Շրջապատել"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr "Epiphany վեբ զննիչ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr "Evolution փոստային ընթերցող"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr "GNOME խոշորացույց առանց էկրանի ընթերցող սարքի"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr "GNOME OnScreen ստեղնաշար"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr "GNOME տերմինալ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Gnopernicus"
+msgstr "Gnopernicus"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Gnopernicus with Magnifier"
+msgstr "Gnopernicus խոշորացույցով"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Iceape"
+msgstr "Iceape"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Iceape Mail"
+msgstr "Iceape էլ–փոստ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Icedove"
+msgstr "Icedove"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Iceweasel"
+msgstr "Iceweasel"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr "KDE խոշորացույց առանց էկրանի ընթերցող սարքի"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr "KMail"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Konsole"
+msgstr "Konsole"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr "Linux էկրանի ընթերցող սարք"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr "Linux–ի էկրանի ընթերցող սարք խոշորացույցով"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Listen"
+msgstr "Լսել"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Midori"
+msgstr "Midori"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Mozilla Mail"
+msgstr "Mozilla էլ–փոստ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Muine Music Player"
+msgstr "Muine երաժշտական նվագարկիչ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:36
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:37
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Netscape Communicator"
+msgstr "Netscape հաղորդակցվող"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Opera"
+msgstr "Opera"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca"
+msgstr "Orca"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:41
+msgid "Orca with Magnifier"
+msgstr "Orca խոշորացույցով"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:42
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:43
+msgid "Rhythmbox Music Player"
+msgstr "Rhythmbox նվագարկիչ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:44
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:45
+msgid "SeaMonkey Mail"
+msgstr "SeaMonkey էլ–փոստ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Standard XTerminal"
+msgstr "Ստանդարտ X–տերմինալ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:47
+msgid "Sylpheed"
+msgstr "Sylpheed"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:48
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Terminator"
+msgstr "Terminator"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:51
+msgid "Totem Movie Player"
+msgstr "Totem նվագարկիչ"
+
+#: ../panels/default-applications/gnome-default-applications.xml.in.h:52
+msgid "aterm"
+msgstr "aterm"
+
+#: ../panels/display/display-capplet.ui.h:1
+msgid "Include _panel"
+msgstr "Ընդգրկել _վահանակը"
+
+#: ../panels/display/display-capplet.ui.h:2
+#: ../panels/display/xrandr-capplet.c:320
+msgid "Left"
+msgstr "Ձախ"
+
+#: ../panels/display/display-capplet.ui.h:3
+msgid "Make Default"
+msgstr "Դարձնել Լռելյայն"
+
+#: ../panels/display/display-capplet.ui.h:4
+#: ../panels/display/xrandr-capplet.c:523
+msgid "Monitor"
+msgstr "Մոնիտոր"
+
+#: ../panels/display/display-capplet.ui.h:5
+#: ../panels/display/xrandr-capplet.c:319
+#: ../panels/display/xrandr-capplet.c:358
+#: ../panels/universal-access/uap.ui.h:60
+msgid "Normal"
+msgstr "Նորմալ"
+
+#: ../panels/display/display-capplet.ui.h:6
+#: ../panels/universal-access/uap.ui.h:61
+msgid "Off"
+msgstr "Անջատել"
+
+#: ../panels/display/display-capplet.ui.h:7
+#: ../panels/universal-access/uap.ui.h:62
+msgid "On"
+msgstr "Միացնել"
+
+#: ../panels/display/display-capplet.ui.h:8
+msgid "Panel icon"
+msgstr "վահանակի պատկերանիշ"
+
+#: ../panels/display/display-capplet.ui.h:9
+msgid "R_otation:"
+msgstr "Շ_րջում՝"
+
+#: ../panels/display/display-capplet.ui.h:10
+msgid "Re_fresh rate:"
+msgstr "Թարմացման արագություն."
+
+#: ../panels/display/display-capplet.ui.h:11
+#: ../panels/display/xrandr-capplet.c:321
+msgid "Right"
+msgstr "Աջ"
+
+#: ../panels/display/display-capplet.ui.h:12
+msgid "Sa_me image in all monitors"
+msgstr "Նույն պատկերը բորոր մոնիտորներում"
+
+#: ../panels/display/display-capplet.ui.h:13
+msgid "Upside-down"
+msgstr "Վերից վար"
+
+#: ../panels/display/display-capplet.ui.h:14
+msgid "_Detect monitors"
+msgstr "_Հայտնաբերել մոնիտորները"
+
+#: ../panels/display/display-capplet.ui.h:15
+msgid "_Resolution:"
+msgstr "_Որոշում՝"
+
+#: ../panels/display/display-capplet.ui.h:16
+msgid "_Show monitors in panel"
+msgstr "_Մոնիտորները ցույց տալ վահանակի վրա"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Change resolution and position of monitors"
+msgstr "Փոխել մոնիտորների բաժանումը և դիրքը"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Monitors"
+msgstr "Մոնիտորներ"
+
+#: ../panels/display/gnome-display-properties-install-systemwide.c:44
+#, c-format
+msgid ""
+"Usage: %s SOURCE_FILE DEST_NAME\n"
+"\n"
+"This program installs a RANDR profile for multi-monitor setups into\n"
+"a systemwide location.  The resulting profile will get used when\n"
+"the RANDR plug-in gets run in gnome-settings-daemon.\n"
+"\n"
+"SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+"xml\n"
+"\n"
+"DEST_NAME - relative name for the installed file.  This will get put in\n"
+"            the systemwide directory for RANDR configurations,\n"
+"            so the result will typically be %s/DEST_NAME\n"
+msgstr ""
+"Օգտագործում․ %s SOURCE_FILE DEST_NAME\n"
+"\n"
+"Այս ծրագիրը տեղադրում է RANDR պրոֆիլը բազմակի մոնիտորային ռեժիմի համար "
+"նշված\n"
+"համակարգային տարածքում։ Վերջնական պրոֆիլը կդառնա սովոր սովորական, երբ\n"
+"RANDR plug-in գործարկվում է gnome-settings-daemon -ում։\n"
+"\n"
+"SOURCE_FILE - ամբողջական ճանապարհն է, տիպիկ /home/username/.config/monitors."
+"xml\n"
+"\n"
+"DEST_NAME - տեղադրված ֆայլի հարաբերական անունը. Այն կդրվի նշված տեղում\n"
+"            RANDR կոնֆիգուրացիաների համար՝ իր համակարգի պանակում,\n"
+"            այնպես որ արդյունքը տիպիկ կլինի %s/DEST_NAME\n"
+
+#. Translators: only able to install RANDR profiles as root
+#: ../panels/display/gnome-display-properties-install-systemwide.c:151
+msgid "This program can only be used by the root user"
+msgstr "Այս ծրագիրը կարող է օգտագործվել միայն արմատային օգտագործողի կողմից"
+
+#: ../panels/display/gnome-display-properties-install-systemwide.c:168
+msgid "The source filename must be absolute"
+msgstr "Պետք է նշված լինի ֆայլի բացարձակ անունը"
+
+#. Translators: first %s is a filename; second %s is an error message
+#: ../panels/display/gnome-display-properties-install-systemwide.c:179
+msgid "Could not open %s: %s\n"
+msgstr "Չի հաջողվել բացել %s. %s\n"
+
+#. Translators: first %s is a filename; second %s is an error message
+#: ../panels/display/gnome-display-properties-install-systemwide.c:188
+msgid "Could not get information for %s: %s\n"
+msgstr "Չի հաջողվել ստանալ %s -ի վերաբերյալ տեղեկատվություն․ %s\n"
+
+#: ../panels/display/gnome-display-properties-install-systemwide.c:195
+#, c-format
+msgid "%s must be a regular file\n"
+msgstr "%s պետք է լինի ռեգուլյար ֆայլ\n"
+
+#: ../panels/display/gnome-display-properties-install-systemwide.c:204
+msgid "This program must only be run through pkexec(1)"
+msgstr "Այս ծրագիրը պետք է գործարկվի միայն pkexec(1) - ի միջոցով"
+
+#: ../panels/display/gnome-display-properties-install-systemwide.c:209
+msgid "PKEXEC_UID must be set to an integer value"
+msgstr "PKEXEC_UID պետք է սահմանվի ամբողջ արժեք"
+
+#. Translators: we are complaining that a file must be really owned by the user who called this program
+#: ../panels/display/gnome-display-properties-install-systemwide.c:215
+#, c-format
+msgid "%s must be owned by you\n"
+msgstr "%s -ը պետք է լինի ձեր սեփականությունը\n"
+
+#. Translators: here we are saying that a plain filename must look like "filename", not like "some_dir/filename"
+#: ../panels/display/gnome-display-properties-install-systemwide.c:223
+#, c-format
+msgid "%s must not have any directory components\n"
+msgstr "%s -ը պետք է չունենա որևէ պանակ-կոմպոնոնտներ\n"
+
+#: ../panels/display/gnome-display-properties-install-systemwide.c:231
+#, c-format
+msgid "%s must be a directory\n"
+msgstr "%s -ը պետք է լինի պանակ\n"
+
+#. Translators: the first %s/%s is a directory/filename; the last %s is an error message
+#: ../panels/display/gnome-display-properties-install-systemwide.c:242
+msgid "Could not open %s/%s: %s\n"
+msgstr "Չի հաջողվել բացել %s/%s. %s\n"
+
+#: ../panels/display/gnome-display-properties-install-systemwide.c:262
+#, c-format
+msgid "Could not rename %s to %s: %s\n"
+msgstr "Չի հաջողվել անվանափոխել %s -ը %s -ով․ %s\n"
+
+#: ../panels/display/org.gnome.randr.policy.in.h:1
+msgid ""
+"Authentication is required to install multi-monitor settings for all users"
+msgstr ""
+"Բոլոր օգտագործողների բազմակի մոնիտորային պարամետրերը տեղադրելու համար "
+"վավերացում է անհրաժեշտ"
+
+#: ../panels/display/org.gnome.randr.policy.in.h:2
+msgid "Install multi-monitor settings for the whole system"
+msgstr "Տեղադրել բազմակի մոնիտորային պարամետրերը ամբողջ համակարգի համար"
+
+#: ../panels/display/xrandr-capplet.c:322
+msgid "Upside Down"
+msgstr "Վերից վար"
+
+#: ../panels/display/xrandr-capplet.c:364
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../panels/display/xrandr-capplet.c:512
+#: ../panels/display/xrandr-capplet.c:1658
+msgid "Mirror Screens"
+msgstr "Հայելային էկրաններ"
+
+#: ../panels/display/xrandr-capplet.c:514
+#, c-format
+msgid "Monitor: %s"
+msgstr "Մոնիտոր. %s"
+
+#: ../panels/display/xrandr-capplet.c:592
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#: ../panels/display/xrandr-capplet.c:1514
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr ""
+"Ընտրել մոնիտոր՝ հատկությունները փոխելու համար. քաշել այն դիրքի փոփոխության "
+"համար։"
+
+#: ../panels/display/xrandr-capplet.c:2079
+msgid "Could not save the monitor configuration"
+msgstr "Չհաջողվեց պահել մոնիտորի կոնֆիգուրացումը"
+
+#: ../panels/display/xrandr-capplet.c:2102
+msgid "Could not get session bus while applying display configuration"
+msgstr "Չի հաջողվել ստանալ կապուղին էկրանի կոնֆիգուրացիան կիրառելու ժամանակ"
+
+#: ../panels/display/xrandr-capplet.c:2147
+msgid "Could not detect displays"
+msgstr "Էկրաններ հայտնաբերումը չի հաջողվել"
+
+#: ../panels/display/xrandr-capplet.c:2322
+msgid "The monitor configuration has been saved"
+msgstr "Մոնիտորի կոնֆիգուրացիան պահպանվել է"
+
+#: ../panels/display/xrandr-capplet.c:2324
+msgid "This configuration will be used the next time someone logs in."
+msgstr ""
+"Այս կոնֆիգուրացիան կօգտագործվի հաջորդ անգամ, երբ ինչ-որ մեկը մուտք գործի "
+"համակարգ"
+
+#: ../panels/display/xrandr-capplet.c:2358
+msgid "Could not set the default configuration for monitors"
+msgstr "Չհաջողվեց մոնիտորի համար սահմանել լռելյայն կոնֆիգուրացիա"
+
+#: ../panels/display/xrandr-capplet.c:2416
+msgid "Could not get screen information"
+msgstr "Չի հաջողվել ստանալ էկրանի տվյալները"
+
+#: ../panels/keybindings/00-multimedia-key.xml.in.h:1
+msgid "Sound"
+msgstr "Ձայն"
+
+#: ../panels/keybindings/01-desktop-key.xml.in.h:1
+msgid "Desktop"
+msgstr "Աշխատասեղան"
+
+#: ../panels/keybindings/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr "Նոր ստեղների համադրություն…"
+
+#: ../panels/keybindings/eggcellrendererkeys.c:163
+#: ../panels/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Արագացուցչի ստեղն"
+
+#: ../panels/keybindings/eggcellrendererkeys.c:173
+#: ../panels/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Արագացուցչի ձևափոխիչ"
+
+#: ../panels/keybindings/eggcellrendererkeys.c:182
+#: ../panels/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Արագացնող ստեղնի գաղտնագիր"
+
+#: ../panels/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Արագացման ռեժիմ"
+
+#: ../panels/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Արագացուցչի տեսակը։"
+
+#: ../panels/keybindings/eggcellrendererkeys.c:242
+#: ../panels/keybindings/gnome-keybinding-properties.c:100
+#: ../typing-break/drwright.c:498
+msgid "Disabled"
+msgstr "Ապաակտիվացված է"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:181
+msgid "<Unknown Action>"
+msgstr "<Անհայտ գործողություն>"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:931
+#: ../panels/keybindings/gnome-keybinding-properties.c:1562
+msgid "Custom Shortcuts"
+msgstr "Սովորական ստեղների համադրություն"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:1073
+msgid "Error saving the new shortcut"
+msgstr "Սխալ՝ ստեղների համադրությունը պահպանելիս"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:1152
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"\"%s\" ստեղների համադրությունը չի հաջողվել գործածել, որովհետև մեքենագրելու "
+"ժամանակ այս ստեղնի օգտագործումը անհնար կլինի։\n"
+"Խնդրում ենք փորձել այնպիսի ստեղներով ինչպիսիք են Control, Alt կամ Shift–ը "
+"միաժամանակ։"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:1182
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"\"%s\" ստեղների համադրությունն արդեն օգտագործված է՝\n"
+"\"%s\""
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:1188
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"Եթե \"%s\" ստեղների համադրությունը վերանշանակեք, \"%s\" ստեղների "
+"համադրությունը կապաակտիվացվի։"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:1196
+msgid "_Reassign"
+msgstr "_Վերանշանակել"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:1316
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr "Սխալ՝ կոնֆիգուրացիայի տվյալների բազայում արագացուցիչն անջատելիս՝ %s"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:1517
+msgid "Too many custom shortcuts"
+msgstr "Չափազանց շատ սովորական ստեղների համադրություն"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:1849
+msgid "Action"
+msgstr "Գործողություն"
+
+#: ../panels/keybindings/gnome-keybinding-properties.c:1871
+msgid "Shortcut"
+msgstr "Ստեղների համադրություն"
+
+#: ../panels/keybindings/gnome-keybinding-properties.ui.h:2
+msgid "Custom Shortcut"
+msgstr "Սովորական ստեղների համադրություն"
+
+#: ../panels/keybindings/gnome-keybinding-properties.ui.h:3
+#: ../panels/keybindings/gnome-keybindings-panel.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Ստեղնաշարի ստեղների համադրություն"
+
+#: ../panels/keybindings/gnome-keybinding-properties.ui.h:4
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new key "
+"combination, or press backspace to clear."
+msgstr ""
+"Ստեղների համադրությունը խմբագրելու համար կտտացրեք համապատասխան տողի վրա և "
+"մեքենագրեք ստեղների նոր համադրություն կամ սեղմեք backspace–ը ջնջելու համար։"
+
+#: ../panels/keybindings/gnome-keybinding-properties.ui.h:5
+msgid "_Name:"
+msgstr "_Անվանում՝"
+
+#: ../panels/keybindings/gnome-keybindings-panel.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Նշանակել ստեղների համադրություն հրամանների համար"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:1
+msgid "Beep when _accessibility features are turned on or off"
+msgstr "Ազդանշանել, երբ _հասանելիությունը միացված կամ անջատված է"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:2
+msgid "Beep when a _modifier key is pressed"
+msgstr "Ազդանշանել, երբ _մոդիֆիկատորի ստեղնը միացված է"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:3
+msgid "Beep when a _toggle key is pressed"
+msgstr "Ազդանշանել, երբ _փոխանջատչի ստեղնը սեղմված է"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:4
+msgid "Beep when a key is pr_essed"
+msgstr "Ազդանշանել, երբ _ստեղնը սեղմված է"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:5
+msgid "Beep when a key is reje_cted"
+msgstr "Ազդանշանել, երբ ստեղնը մերժ_ված է"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:6
+msgid "Beep when key is _accepted"
+msgstr "Ազդանշանել, երբ ստեղնն _ընդունված է"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:7
+msgid "Beep when key is _rejected"
+msgstr "Ազդանշանել, երբ ստեղնը _մերժված է"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:8
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:4
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Bounce Keys"
+msgstr "Անցման ստեղներ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:9
+msgid "Flash _window titlebar"
+msgstr "_Պատուհանի վերնագրի տողի թարթում"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:10
+msgid "Flash entire _screen"
+msgstr "Ամբողջ _էկրանի թարթում"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:11
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:14
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgid "General"
+msgstr "Ընդհանուր"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:12
+msgid "Keyboard Accessibility Audio Feedback"
+msgstr "Ստեղնաշարի հասանելիության ձայնային հետդարձ կապ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:13
+msgid "Show _visual feedback for the alert sound"
+msgstr "Ցույց տալ _տեսողական հետդարձ կապ զգուշացման ազդանշանի ձայնի համար"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:14
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:39
+#: ../panels/universal-access/uap.ui.h:76
+msgid "Slow Keys"
+msgstr "Դանդաղ ստեղներ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:15
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:40
+#: ../panels/universal-access/uap.ui.h:80
+msgid "Sticky Keys"
+msgstr "Կպչուն ստեղներ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:16
+msgid "Visual cues for sounds"
+msgstr "Տեսողական հուշում ձայների համար"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:2
+msgid "All_ow postponing of breaks"
+msgstr "Թու_յլատրել ընդմիջումների հետաձգումը"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:3
+msgid "Audio _Feedback..."
+msgstr "Ձայնային _հետդարձ կապ..."
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:5
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Ստուգել, երբ թույլատրվում է ընդմիջումներն հետաձգել"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:6
+msgid "Cursor Blinking"
+msgstr "Կուրսորի թարթում"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:7
+msgid "Cursor _blinks in text fields"
+msgstr "Կուրսորը _թարթում է տեքստի շրջանում"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:8
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Cursor blinks speed"
+msgstr "Կուրսորի թարթման արագություն"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:9
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+#: ../panels/universal-access/uap.ui.h:30
+msgid "D_elay:"
+msgstr "Հ_ետաձգում՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:10
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr ""
+"Ապաա_կտիվացնել կպչուն ստեղները, եթե երկու ստեղները սեղմվում են միաժամանակ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:11
+msgid "Duration of the break when typing is disallowed"
+msgstr "Ընդմիջման ժամանակը, երբ չի թույլատրվում մեքենագրելը"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:12
+msgid "Duration of work before forcing a break"
+msgstr "Աշխատանքի տևողությունը նախքան ստիպողական ընդմիջումը"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:13
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgid "Fast"
+msgstr "Արագ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:15
+msgid "Key presses _repeat when key is held down"
+msgstr "Սեղմած ստեղնի նորից սեղմում"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:16
+msgid "Keyboard Preferences"
+msgstr "Ստեղնաշարի նախընտրություններ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:17
+msgid "Keyboard _model:"
+msgstr "Ստեղնաշարի _մոդել՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:18
+msgid "Layouts"
+msgstr "Դասավորություններ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:19
+msgid "List of keyboard layouts selected for usage"
+msgstr "Օգտագործման համար ընտրված ստեղնաշարային դասավորությունների ցուցակը"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:20
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Որոշակի ժամանակ անց արգելափակել էկրանը՝ ստեղնաշարի անընդհատ օգտագործոման "
+"հետևանքով բարդություններից խուսափելու համար"
+
+#. long delay
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:21
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+#: ../panels/universal-access/uap.ui.h:53
+msgid "Long"
+msgstr "Երկար"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:22
+#: ../panels/universal-access/uap.ui.h:56
+msgid "Mouse Keys"
+msgstr "Մկնիկի ստեղներ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:23
+msgid "Move _Down"
+msgstr "Շարժել _ներքև"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:24
+msgid "Move _Up"
+msgstr "Շարժել _վերև"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:25
+msgid "Move the selected keyboard layout down in the list"
+msgstr "Ընտրված ստեղնաշարային դասավորությունը տեղափոխել ցուցակում դեպի ներքև"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:26
+msgid "Move the selected keyboard layout up in the list"
+msgstr "Ընտրված ստեղնաշարային դասավորությունը տեղափոխել ցուցակում դեպի վերև"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:27
+msgid "New windows u_se active window's layout"
+msgstr "Նոր պատուհաններն օգտագործում են ակտիվ պատուհանի ծրագիրը"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:28
+msgid "Print a diagram of the selected keyboard layout"
+msgstr "Ընտրված ստեղնաշարային դասավորության համար տպել սխեմա"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:29
+msgid "Remove the selected keyboard layout from the list"
+msgstr "Հեռացնել ընտրված ստեղնաշարային դասավորությունը ցուցակից"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:30
+msgid "Repeat Keys"
+msgstr "Կրկնել ստեղները"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:31
+msgid "Repeat keys speed"
+msgstr "Կրկնել ստեղների արագությունը"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:32
+msgid ""
+"Replace the current keyboard layout settings with the\n"
+"default settings"
+msgstr ""
+"Փոխարինել ընթացիկ ստեղնաշարային դասավորության պարամետրերը\n"
+"լռելյայն պարամետրերով"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:34
+msgid "Reset to De_faults"
+msgstr "Վերադարձնել լռելյայն վիճակին"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:35
+msgid "S_peed:"
+msgstr "Ա_րագություն՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:36
+msgid "Select a keyboard layout to be added to the list"
+msgstr "Ընտրեք ցուցակին ավելացվող ստեղնաշարային դասավորությունը"
+
+#. short delay
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:37
+#: ../panels/mouse/gnome-mouse-properties.ui.h:27
+#: ../panels/universal-access/uap.ui.h:73
+msgid "Short"
+msgstr "Կարճ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:38
+#: ../panels/mouse/gnome-mouse-properties.ui.h:30
+msgid "Slow"
+msgstr "Դանդաղ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:41
+msgid "Typing Break"
+msgstr "Աշխատանքային ընդմիջում"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:42
+msgid "View and edit keyboard layout options"
+msgstr "Դիտել և խմբագրել ստեղնաշարի դասավորության ընտրանքները"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:43
+#: ../panels/mouse/gnome-mouse-properties.ui.h:37
+msgid "_Acceleration:"
+msgstr "_Արագացում՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:44
+msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgstr "_Օժանդակ հատկությունները կարելի է փոփոխել ստեղների համադրություններով"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:45
+msgid "_Add..."
+msgstr "_Ավելացնել…"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:46
+msgid "_Break interval lasts:"
+msgstr "_Ընդմիջման տևողությունը."
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:47
+#: ../panels/mouse/gnome-mouse-properties.ui.h:38
+msgid "_Delay:"
+msgstr "_Հետաձգում՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:48
+msgid "_Ignore fast duplicate keypresses"
+msgstr "_Անտեսել ստեղների սեղմման արագ կրկնումները"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:49
+msgid "_Lock screen to enforce typing break"
+msgstr "_Արգելափակել էկրանը աշխատանքային ընդմիջման համար"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:50
+msgid "_Only accept long keypresses"
+msgstr "_Ընդունել միայն ստեղների երկար սեղմումները"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:51
+msgid "_Options..."
+msgstr "_Ընտրացանկ..."
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:52
+msgid "_Pointer can be controlled using the keypad"
+msgstr "_Ցուցիչը կարող է կառավարվել ստեղնխմբով"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:53
+msgid "_Separate layout for each window"
+msgstr "_Առանձին դասավորություն ամեն մի պատուհանի համար"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:54
+msgid "_Simulate simultaneous keypresses"
+msgstr "_Մոդելավորել ստեղների միաժամանակյա սեղմումները"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:55
+msgid "_Speed:"
+msgstr "_Արագություն՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:56
+msgid "_Type to test settings:"
+msgstr "_Մեքենագրել պարամետրերը ստուգելու համար՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:57
+msgid "_Work interval lasts:"
+msgstr "_Աշխատանքի ընդմիջումը տևում է՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-dialog.ui.h:58
+msgid "minutes"
+msgstr "րոպեներ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:1
+msgid "By _country"
+msgstr "Երկրով"
+
+#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:2
+msgid "By _language"
+msgstr "Լեզվով"
+
+#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:3
+msgid "Choose a Layout"
+msgstr "Ընտրել դասավորություն"
+
+#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:4
+msgid "Preview:"
+msgstr "Նախնական տեսք՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:5
+msgid "_Country:"
+msgstr "_Երկիր՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:6
+msgid "_Language:"
+msgstr "_Լեզու՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:7
+msgid "_Variants:"
+msgstr "_Տարբերակներ՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-model-chooser.ui.h:1
+msgid "Choose a Keyboard Model"
+msgstr "Ընտրել ստեղնաշարի մոդելը"
+
+#: ../panels/keyboard/gnome-keyboard-properties-model-chooser.ui.h:2
+msgid "_Models:"
+msgstr "_Մոդելներ՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-model-chooser.ui.h:3
+msgid "_Vendors:"
+msgstr "_Վաճառող՝"
+
+#: ../panels/keyboard/gnome-keyboard-properties-options-dialog.ui.h:1
+msgid "Keyboard Layout Options"
+msgstr "Ստեղնաշարի դասավորության ընտրանքներ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-xkb.c:81
+msgid "Unknown"
+msgstr "Անհայտ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-xkblt.c:241
+msgid "Layout"
+msgstr "Դասավորություն"
+
+#: ../panels/keyboard/gnome-keyboard-properties-xkbmc.c:166
+msgid "Vendors"
+msgstr "Վաճառողներ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-xkbmc.c:232
+msgid "Models"
+msgstr "Մոդելներ"
+
+#: ../panels/keyboard/gnome-keyboard-properties-xkbot.c:233
+#: ../panels/network/gnome-network-properties.c:582
+msgid "Default"
+msgstr "Նախնական"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Ստեղնաշար"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Կարգավորել ստեղնաշարի նախընտրությունները"
+
+#: ../panels/mouse/capplet-stock-icons.c:66
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "Հնարավոր չէ բեռնել '%s' պատկերանիշը\n"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../panels/mouse/gnome-mouse-accessibility.c:90
+msgid "gesture|Move left"
+msgstr "շարժում|դեպի ձախ"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../panels/mouse/gnome-mouse-accessibility.c:95
+msgid "gesture|Move right"
+msgstr "շարժում|դեպի աջ"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../panels/mouse/gnome-mouse-accessibility.c:100
+msgid "gesture|Move up"
+msgstr "շարժում|դեպի վեր"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../panels/mouse/gnome-mouse-accessibility.c:105
+msgid "gesture|Move down"
+msgstr "շարժում|դեպի վար"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../panels/mouse/gnome-mouse-accessibility.c:110
+msgid "gesture|Disabled"
+msgstr "շարժում|ապաակտիվացված է"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "Choose type of click _beforehand"
+msgstr "Ընտրել կտտացնելու տեսակը _նախապես"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Choose type of click with mo_use gestures"
+msgstr "Ընտրել կտտացնելու տեսակը մկն_իկի շարժումներով"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "D_ouble click:"
+msgstr "Կ_րկնակի կտտոց՝"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "D_rag click:"
+msgstr "Ա_րգելակի կտտոց՝"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "Disable _touchpad while typing"
+msgstr "Ապաակտիվացնել _սենսորային վահանակը մեքենագրելու ժամանակ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Double-Click Timeout"
+msgstr "Հապաղում կրկնակի կտտոցի դեպքում"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "Drag and Drop"
+msgstr "Քաշել և գցել"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgid "Dwell Click"
+msgstr "Կրկնակի կտտոց"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgid "Enable _mouse clicks with touchpad"
+msgstr "Ակտիվացնել _մկնիկի կտտոցը սենսորային վահանակի հետ միաժամանակ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Enable h_orizontal scrolling"
+msgstr "Ակտիվացնել հ_որիզոնական ոլորումը"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+#: ../panels/universal-access/uap.ui.h:40
+msgid "High"
+msgstr "Բարձր"
+
+#. large threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Large"
+msgstr "Մեծ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Locate Pointer"
+msgstr "Տեղակայել ցուցիչը"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+#: ../panels/universal-access/uap.ui.h:54
+msgid "Low"
+msgstr "Ցածր"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:21
+msgid "Mouse Orientation"
+msgstr "Մկնիկի ուղղությունը"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:22
+msgid "Mouse Preferences"
+msgstr "Մկնիկի նախընտրություններ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:23
+msgid "Pointer Speed"
+msgstr "Ցուցչի արագություն"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:24
+msgid "Scrolling"
+msgstr "Ոլորում"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:25
+msgid "Seco_ndary click:"
+msgstr "Երկր_որդական կտտոց՝"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:26
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr "Ցու_յց տալ ցուցչի դիրքը, երբ ղեկավարման ստեղնը սեղմված է"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:28
+msgid "Show click type _window"
+msgstr "Ցույց տալ պատուհանի կտտոցի _տեսակը"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:29
+#: ../panels/universal-access/uap.ui.h:75
+msgid "Simulated Secondary Click"
+msgstr "Մոդելավորված երկրորդական կտտոց"
+
+#. small threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:31
+#: ../panels/universal-access/uap.ui.h:78
+msgid "Small"
+msgstr "Փոքր"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:32
+msgid "Thr_eshold:"
+msgstr "Սահմանային _արժեք՝"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:33
+msgid ""
+"To test your double-click settings, try to double-click on the light bulb."
+msgstr ""
+"Կրկնակի կտտոցի պարամետրերը ստուգելու համար փորձեք կրկնակի կտտացնել վառվող "
+"լույսի վրա։"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:34
+msgid "Touchpad"
+msgstr "Սենսորային վահանակ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:35
+msgid "Two-_finger scrolling"
+msgstr "Ոլորում երկու _մատով"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:36
+msgid "You can also use the Dwell Click panel applet to choose the click type."
+msgstr ""
+"Կարող եք նաև օգտագործել հապաղումով կտտոցը վահանակի ապլետի կտտոցի տեսակը "
+"ընտրելու համար։"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:39
+msgid "_Disabled"
+msgstr "_Ապաակտիվացված է"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:40
+msgid "_Edge scrolling"
+msgstr "_Եզրային ոլորում"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:41
+msgid "_Initiate click when stopping pointer movement"
+msgstr "_Գործարկել կտտոցը, երբ դադարեցվում է ցուցչի շարժումը"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:42
+msgid "_Left-handed"
+msgstr "_Ձախ ձեռքով"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:43
+#: ../panels/universal-access/uap.ui.h:98
+msgid "_Motion threshold:"
+msgstr "_Շարժման սահմանային արժեք՝"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:44
+msgid "_Right-handed"
+msgstr "_Աջ ձեռքով"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:45
+msgid "_Sensitivity:"
+msgstr "_Զգայունություն՝"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:46
+msgid "_Single click:"
+msgstr "_Մեկ կտտոց՝"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:47
+msgid "_Timeout:"
+msgstr "_Ժամանակը լրացել է՝"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:48
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr "_Իրականցնել երկրորդական կտտոցը՝ պահելով հիմնական կոճակը"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Մկնիկ"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Կարգավորել մկնիկի նախընտրությունները"
+
+#: ../panels/network/gnome-network-properties.c:700
+#: ../panels/network/gnome-network-properties.c:851
+msgid "New Location..."
+msgstr "Նոր տեղակայություն..."
+
+#: ../panels/network/gnome-network-properties.c:817
+msgid "Location already exists"
+msgstr "Տեղակայությունն արդեն գոյություն ունի"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Ցանցի պրոքսի"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "Կարգավորել ցանցի պրոքսիի նախընտրությունները"
+
+#: ../panels/network/gnome-network-properties.ui.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>Ու_ղիղ համացանցային կապ</b>"
+
+#: ../panels/network/gnome-network-properties.ui.h:2
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>_Ավտոմատ պրոքսի կոնֆիգուրացիա</b>"
+
+#: ../panels/network/gnome-network-properties.ui.h:3
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>_Ձեռքով պրոքսի կոնֆիգուրացիա</b>"
+
+#: ../panels/network/gnome-network-properties.ui.h:4
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Օգտագործել վավերացումը</b>"
+
+#: ../panels/network/gnome-network-properties.ui.h:5
+msgid "Autoconfiguration _URL:"
+msgstr "Վավերացում _URL՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:6
+msgid "C_reate"
+msgstr "Ս_տեղծել"
+
+#: ../panels/network/gnome-network-properties.ui.h:7
+msgid "Create New Location"
+msgstr "Ստեղծել նոր տեղակայություն"
+
+#: ../panels/network/gnome-network-properties.ui.h:8
+msgid "HTTP Proxy Details"
+msgstr "HTTP պրոքսի մանրամասներ"
+
+#: ../panels/network/gnome-network-properties.ui.h:9
+msgid "H_TTP proxy:"
+msgstr "H_TTP պրոքսի՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:10
+msgid "Ignore Host List"
+msgstr "Անտեսել հոսթի ցուցակը"
+
+#: ../panels/network/gnome-network-properties.ui.h:11
+msgid "Ignored Hosts"
+msgstr "Անտեսված հոսթեր"
+
+#: ../panels/network/gnome-network-properties.ui.h:12
+msgid "Location:"
+msgstr "Տեղակայություն՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:13
+msgid "Network Proxy Preferences"
+msgstr "Ցանցի պրոքսիի նախընտրություններ"
+
+#: ../panels/network/gnome-network-properties.ui.h:14
+msgid "Port:"
+msgstr "Պորտ՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:15
+msgid "Proxy Configuration"
+msgstr "Պրոքսի կոնֆիգուրացիա"
+
+#: ../panels/network/gnome-network-properties.ui.h:16
+msgid "S_ocks host:"
+msgstr "S_ocks հոսթ՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:17
+msgid "The location already exists."
+msgstr "Տեղանքն արդեն գոյություն ունի։"
+
+#: ../panels/network/gnome-network-properties.ui.h:18
+msgid "U_sername:"
+msgstr "Օ_գտագործողի անունը՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:19
+msgid "_Delete Location"
+msgstr "_Ջնջել տեղակայությունը"
+
+#: ../panels/network/gnome-network-properties.ui.h:20
+msgid "_Details"
+msgstr "_Մանրամասներ"
+
+#: ../panels/network/gnome-network-properties.ui.h:21
+msgid "_FTP proxy:"
+msgstr "_FTP պրոքսի՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:22
+msgid "_Location name:"
+msgstr "_Տեղակայության անվանումը՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:23
+msgid "_Password:"
+msgstr "_Գաղտնաբառ՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:24
+msgid "_Secure HTTP proxy:"
+msgstr "_Ապահովել HTTP պրոքսի՝"
+
+#: ../panels/network/gnome-network-properties.ui.h:25
+msgid "_Use the same proxy for all protocols"
+msgstr "_Միևնույն պրոքսին օգտագործել բոլոր պրոտոկոլների համար"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "Համընդհանուր Հասանելիություն"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Universal Access Preferences"
+msgstr "Համընդհանուր հասանելիության նախընտրություններ"
+
+#: ../panels/universal-access/uap.ui.h:2
+#, no-c-format
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/universal-access/uap.ui.h:4
+#, no-c-format
+msgid "125%"
+msgstr "125%"
+
+#: ../panels/universal-access/uap.ui.h:6
+#, no-c-format
+msgid "150%"
+msgstr "150%"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "<span size=\"x-large\">High/Inverse</span>"
+msgstr "<span size=\"x-large\">Բարձր/Հետադարձ</span>"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "<span size=\"x-large\">High</span>"
+msgstr "<span size=\"x-large\">Բարձր</span>"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "<span size=\"x-large\">Low</span>"
+msgstr "<span size=\"x-large\">Ցածր</span>"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "<span size=\"x-large\">Normal</span>"
+msgstr "<span size=\"x-large\">Նորմալ</span>"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Acceptance delay:"
+msgstr "Ընդունման հապաղում"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Accessibility features can be turned on or off with keyboard shortcuts"
+msgstr ""
+"Մատչելիության հատկությունները կարելի է միացնել կամ անջատել ստեղների "
+"համադրություններով"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "Beep when Caps and Num Lock are used"
+msgstr "Ազդանշանել, երբ Caps և Num Lock-ը օգտագործված են"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Beep when a key is"
+msgstr "Ազդանշանել, երբ ստեղնը սեղմված է"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "Beep when a key is rejected"
+msgstr "Ազդանշանել, երբ ստեղնը մերժված է"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "Beep when a modifer key is pressed"
+msgstr "Ազդանշանել, երբ մոդիֆիկատորի ստեղնը միացված է"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "Caribou"
+msgstr "Կարիբու"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "Change constrast:"
+msgstr "Փոխել հակադրությունը"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Closed Captioning"
+msgstr "Փակված տակագրում"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Contrast:"
+msgstr "Հակադրություն"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Control the pointer using the keypad."
+msgstr "Կառավարել ցուցիչը՝ օգտագործելով ստեղնախումբ։"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "Control the pointer using the video camera."
+msgstr "Կառավարել ցուցիչը՝ օգտագործելով տեսախցիկ։"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Ctrl+Alt+-"
+msgstr "Ctrl+Alt+-"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Ctrl+Alt+0"
+msgstr "Ctrl+Alt+0"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Ctrl+Alt+4"
+msgstr "Ctrl+Alt+4"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Ctrl+Alt+8"
+msgstr "Ctrl+Alt+8"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Ctrl+Alt+="
+msgstr "Ctrl+Alt+="
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Decrease size:"
+msgstr "Նվազեցնել չափը"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Disable if two keys are pressed together"
+msgstr "Ապաակտիվացնել, եթե երկու ստեղները սեղմվում են միաժամանակ"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Display"
+msgstr "Ցուցադրել"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgid "Display a textual description of speech and sounds."
+msgstr "Ցուցադրել խոսքի և ձայնի տեքստային նկարագրությունը"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Flash the entire screen"
+msgstr "Ամբողջ էկրանի թարթում"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgid "Flash the window title"
+msgstr "Պատուհանի վերնագրի թարթում"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "GOK"
+msgstr "GOK"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Hearing"
+msgstr "Լսում"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "High/Inverse"
+msgstr "Բարձր/Հակադարձ"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "HighContrast"
+msgstr "Մեծ Հակադրություն"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgid "HighContrastInverse"
+msgstr "Մեծ Հակադրության Հակադարձ"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Hover Click"
+msgstr "Կտտոց վրայով անցնելիս"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "I need assistance with:"
+msgstr "Ես կարիք ունեմ այսպիսի օգնականի․"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "Ignores fast duplicate keypresses"
+msgstr "Անտեսել ստեղների սեղմման արագ կրկնումները"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Increase size:"
+msgstr "Աճեցնել չափը"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Keyboard Settings..."
+msgstr "Ստեղնաշարի պարամետրեր․․․"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgid "Larger"
+msgstr "Ավելի Մեծ"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "LowContrast"
+msgstr "Փոքր Հակադրություն"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgid "Mouse Settings..."
+msgstr "Մկնիկի Պարամետրերը․․․"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgid "Nomon"
+msgstr "Nomon"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "None"
+msgstr "Ոչ մի"
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "On screen keyboard"
+msgstr "Gnome-ի On screen ստեղնաշար"
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "OnBoard"
+msgstr "Ներդրված"
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Options..."
+msgstr "_Ընտրանքներ..."
+
+#: ../panels/universal-access/uap.ui.h:66
+msgid "Pointing and Clicking"
+msgstr "Հղվել և Սեղմել"
+
+#: ../panels/universal-access/uap.ui.h:67
+msgid "Puts a delay between when a key is pressed and when it is accepted."
+msgstr "Ստեղնի սեղմման և նրա ընդունման միջև դնում է հապաղում"
+
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Screen Reader"
+msgstr "Էկրանի ընթերցող սարք"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Seeing"
+msgstr "Դիտում է"
+
+#: ../panels/universal-access/uap.ui.h:70
+msgid "Shift+Ctrl+Alt+-"
+msgstr "Shift+Ctrl+Alt+-"
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Shift+Ctrl+Alt+="
+msgstr "Shift+Ctrl+Alt+="
+
+#: ../panels/universal-access/uap.ui.h:74
+msgid "Show Universal Access status"
+msgstr "Ցուցադրում է Համընդհանուր Հասանելիության վիճակը"
+
+#: ../panels/universal-access/uap.ui.h:79
+msgid "Sound Settings..."
+msgstr "Ձայնի Պարամետրեր․․․"
+
+#: ../panels/universal-access/uap.ui.h:81
+msgid "Test flash"
+msgstr "Տեստավորել թարթումը"
+
+#: ../panels/universal-access/uap.ui.h:82
+msgid "Test:"
+msgstr "Տեստ."
+
+#: ../panels/universal-access/uap.ui.h:83
+msgid "Text size:"
+msgstr "Տեքստի չափ․"
+
+#: ../panels/universal-access/uap.ui.h:84
+msgid "Treats a sequence of modifier keys as a key combination."
+msgstr ""
+"Բանալիների մոդիֆիկատորների հաջորդականությունը դիտարկում է որպես բանալիների "
+"հաջորդականություն։"
+
+#: ../panels/universal-access/uap.ui.h:85
+msgid "Trigger a click when the pointer hovers."
+msgstr "Գործարկել կտտոցը, երբ ցուցիչը անցնում է վրայով"
+
+#: ../panels/universal-access/uap.ui.h:86
+msgid "Trigger a secondary click by holding down the primary button."
+msgstr "Գործարկել երկրորդական կտտոց՝ պահելով հիմնական կոճակը"
+
+#: ../panels/universal-access/uap.ui.h:87
+msgid "Turn on or off:"
+msgstr "Միացնել կամ անջատել․"
+
+#: ../panels/universal-access/uap.ui.h:88
+msgid "Type here to test settings"
+msgstr "Տպել այստեղ՝ պարամետրերը ստուգելու համար․"
+
+#: ../panels/universal-access/uap.ui.h:89
+msgid "Typing"
+msgstr "Տպվում է"
+
+#: ../panels/universal-access/uap.ui.h:90
+msgid "Typing Assistant"
+msgstr "Տպման Օ_գնական՝"
+
+#: ../panels/universal-access/uap.ui.h:91
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Օգտագործել տեսողական ցուցումները, երբ զգուշացման ձայներ են լսվում։"
+
+#: ../panels/universal-access/uap.ui.h:92
+msgid "Use an alternative form of text input"
+msgstr "Տեքստի մուտքագրման համար օգտագործել ալտերնատիվ ձև"
+
+#: ../panels/universal-access/uap.ui.h:93
+msgid "Video Mouse"
+msgstr "ՏեսաՄկնիկ"
+
+#: ../panels/universal-access/uap.ui.h:94
+msgid "Visual Alerts"
+msgstr "Տեսողական ահազանգեր"
+
+#: ../panels/universal-access/uap.ui.h:95
+msgid "Zoom"
+msgstr "Մեծացնել"
+
+#: ../panels/universal-access/uap.ui.h:96
+msgid "Zoom in:"
+msgstr "Մեծացնել."
+
+#: ../panels/universal-access/uap.ui.h:97
+msgid "Zoom out:"
+msgstr "Փոքրացնել․"
+
+#: ../panels/universal-access/uap.ui.h:99
+msgid "accepted"
+msgstr "ընդունված է"
+
+#: ../panels/universal-access/uap.ui.h:100
+msgid "pressed"
+msgstr "սեղմված է"
+
+#: ../panels/universal-access/uap.ui.h:101
+msgid "rejected"
+msgstr "մերժված է"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Կառավարման կենտրոն"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "GNOME-ի կոնֆիգուրացման գործիք"
+
+#: ../typing-break/drw-break-window.c:194
+msgid "_Postpone Break"
+msgstr "_Հետաձգել ընդմիջումը"
+
+#: ../typing-break/drw-break-window.c:250
+msgid "Take a break!"
+msgstr "Ընդմիջում անել։"
+
+#: ../typing-break/drwright.c:136
+msgid "_Take a Break"
+msgstr "_Ընդմիջում անել"
+
+#: ../typing-break/drwright.c:507
+#, c-format
+msgid "Take a break now (next in %dm)"
+msgstr "Ընդմիջում կատարել հիմա (հաջորդը %dm ժամանակից)"
+
+#: ../typing-break/drwright.c:509
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "%d րոպե նախքան ընդմիջումը"
+msgstr[1] "%d րոպե նախքան ընդմիջումը"
+
+#: ../typing-break/drwright.c:515
+#, c-format
+msgid "Take a break now (next in less than one minute)"
+msgstr "Ընդմիջում կատարել հիմա (հաջորդը մեկ րոպեից էլ քիչ ժամանակից)"
+
+#: ../typing-break/drwright.c:517
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr "Հաջորդ ընդմիջմանը մեկ րոպեից քիչ է մնացել"
+
+#: ../typing-break/drwright.c:614
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Չի հաջողվել բերել մեքենագրման նախընտրությունների երկխոսությունը հետևյալ "
+"սխալի պատճառով՝ %s"
+
+#: ../typing-break/drwright.c:631
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "Գրել է Ռիչարդ Հալթը <richard@imendio.com>"
+
+#: ../typing-break/drwright.c:632
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Գրավիչ արտաքին, որն ավելացրել է Անդերս Քարլսոնը"
+
+#: ../typing-break/drwright.c:641
+msgid "A computer break reminder."
+msgstr "Ընդիմիջման մասին հիշեցնող ծրագիր։"
+
+#: ../typing-break/drwright.c:643
+msgid "translator-credits"
+msgstr "թարգմանչի կրեդիտներ"
+
+#: ../typing-break/main.c:63
+msgid "Enable debugging code"
+msgstr "Ակտիվացնել վրիպազերծման կոդը"
+
+#: ../typing-break/main.c:65
+msgid "Don't check whether the notification area exists"
+msgstr "Չստուգել՝ ծանուցման տարածք կա, թե՞ ոչ"
+
+#: ../typing-break/main.c:91
+msgid "Typing Monitor"
+msgstr "Մեքենագրելու մոնիտոր"
+
+#: ../typing-break/main.c:108
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Տեղեկությունը ցույց տալու համար մեքենագրման մոնիտորն օգտագործում է "
+"տեղեկացման տարածքը։ Դուք վահանակի վրա չունեք տեղեկացման տարածք։ Այն "
+"ավելացնելու համար աջ ստեղնով կտտացրեք վահանակի վրա և ընտրեք 'Add to panel', "
+"ապա՝ 'Notification area' և հետո՝ 'Add'։"
+
+#: ../font-viewer/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "Եթե դրված է որպես ճշմարիտ, ապա OpenType տառատեսակը կդառնա մանրապատկեր։"
+
+#: ../font-viewer/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "Եթե դրված է որպես ճշմարիտ, ապա PCF տառատեսակը կդառնա մանրապատկեր։"
+
+#: ../font-viewer/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "Եթե դրված է որպես ճշմարիտ, ապա TrueType տառատեսակը կդառնա մանրապատկեր։"
+
+#: ../font-viewer/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "Եթե դրված է որպես ճշմարիտ, ապա Type1 տառատեսակը կդառնա մանրապատկեր։"
+
+#: ../font-viewer/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"Կարգավորել այս ստեղնը OpenType տառատեսակի մանրապատկերի հրաման ստեղծելու "
+"համար։"
+
+#: ../font-viewer/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr "Կարգավորել ստեղնը PCF տառատեսակի մանրապատկերի հրաման ստեղծելու համար։"
+
+#: ../font-viewer/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"Դնել այս ստեղնը TrueType տառատեսակի մանրապատկերի ստեղծելու համար հրամանի վրա։"
+
+#: ../font-viewer/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"Դնել այս ստեղնը այն հրամանի վրա, որն օգտագործվում է առաջին խմբի "
+"տառատեսակների մանրապատկեր ստեղծելու համար։"
+
+#: ../font-viewer/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "Մանրապատկերի հրաման OpenType տառատեսակի համար"
+
+#: ../font-viewer/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "Մանրապատկերի հրաման PCF տառատեսակի համար"
+
+#: ../font-viewer/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "Մանրապատկերի հրաման TrueType տառատեսակի համար"
+
+#: ../font-viewer/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Մանրապատկերի հրաման Type1 տառատեսակի համար"
+
+#: ../font-viewer/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "Ստեղծե՞լ OpenType տառատեսակի մանրապատկեր։"
+
+#: ../font-viewer/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "Ստեղծե՞լ PCF տառատեսակի մանրապատկեր։"
+
+#: ../font-viewer/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "Ստեղծե՞լ TrueType տառատեսակի մանրապատկեր։"
+
+#: ../font-viewer/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "Ստեղծե՞լ Type1 տառատեսակի մանրապատկեր։"
+
+#: ../font-viewer/font-view.c:297
+msgid "Name:"
+msgstr "Անվանում."
+
+#: ../font-viewer/font-view.c:300
+msgid "Style:"
+msgstr "Ոճ՝"
+
+#: ../font-viewer/font-view.c:313
+msgid "Type:"
+msgstr "Տեսակ՝"
+
+#: ../font-viewer/font-view.c:317
+msgid "Size:"
+msgstr "Չափ՝"
+
+#: ../font-viewer/font-view.c:361 ../font-viewer/font-view.c:374
+msgid "Version:"
+msgstr "Տարբերակ՝"
+
+#: ../font-viewer/font-view.c:365 ../font-viewer/font-view.c:376
+msgid "Copyright:"
+msgstr "Հեղինակային իրավունք՝"
+
+#: ../font-viewer/font-view.c:369
+msgid "Description:"
+msgstr "Նկարագրություն՝"
+
+#: ../font-viewer/font-view.c:453
+msgid "Installed"
+msgstr "Տեղադրված է"
+
+#: ../font-viewer/font-view.c:456
+msgid "Install Failed"
+msgstr "Տեղադրումը ձախողվել է"
+
+#: ../font-viewer/font-view.c:526
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "օգտագործում. %s ֆոնտֆայլ\n"
+
+#: ../font-viewer/font-view.c:597
+msgid "I_nstall Font"
+msgstr "Տեղադրել տառատեսակ"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
+msgid "Font Viewer"
+msgstr "Տառատեսակ ցուցադրող"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
+msgid "Preview fonts"
+msgstr "Ցուցադրել տառատեսակները"
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "Text to thumbnail (default: Aa)"
+msgstr "Տեքստը մանրապատկերով (նախնական։ Aa)"
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "TEXT"
+msgstr "ՏԵՔՍՏ"
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "Font size (default: 64)"
+msgstr "Տառատեսակի չափ (լռելյայն՝ 64)"
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "SIZE"
+msgstr "ՉԱՓ"
+
+#: ../font-viewer/font-thumbnailer.c:249
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr "ՏԱՌԱՏԵՍԱԿԻ ՖԱՅԼ, ԱՐՏԱԾՄԱՆ ՖԱՅԼ"
+
+#: ../font-viewer/font-thumbnailer.c:268
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr "Սխալը վերլուծող փաստարկումներ. %s\n"
+
+#: ../examples/gnome-example-panel.desktop.in.in.h:1
+msgid "Example Panel"
+msgstr "Վահանակի Օրինակ"
+
+#: ../examples/gnome-example-panel.desktop.in.in.h:2
+msgid "Example preferences panel"
+msgstr "Նախընտրությունների վահանակի օրինակ"
+
+#: ../shell/shell.ui.h:1
+msgid "System Settings"
+msgstr "Համակարգի Պարամետրեր"
+
+#: ../shell/shell.ui.h:2
+msgid "_All Settings"
+msgstr "_Բոլոր Պարամետրերը"
+
+msgid "Show help options"
+msgstr "Ցուցադրել Ձեռնարկի հատկությունները"

--- a/po/id.po
+++ b/po/id.po
@@ -11,9 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-08-26 09:03+0700\n"
 "Last-Translator: Kukuh Syafaat <kukuhsyafaat@gnome.org>\n"
 "Language-Team: Indonesian <gnome-l10n-id@googlegroups.com>\n"
@@ -24,98 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Bus Sistem"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Akses penuh"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Bus Sesi"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Perangkat"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Akses penuh ke /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Jaringan"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Memiliki akses jaringan"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Rumah"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Hanya-baca"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Sistem Berkas"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Pengaturan"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Dapat mengubah pengaturan"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s memiliki izin berikut sebagai bawaan. Ini tidak dapat diubah. Jika Anda "
-"khawatir tentang izin ini, pertimbangkan untuk menghapus aplikasi ini."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u jenis berkas dan tautan yang dibuka oleh aplikasi"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> digunakan untuk membuka jenis berkas dan tautan berikut."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s ruang diska yang digunakan."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -131,7 +39,6 @@ msgid "Install some…"
 msgstr "Pasang beberapa…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Buka"
 
@@ -155,24 +62,13 @@ msgstr "Cari"
 msgid "Receive system searches and send results."
 msgstr "Menerima pencarian sistem dan mengirim hasil."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Dimatikan"
 
@@ -338,80 +234,20 @@ msgstr "Bersihkan Tembolok…"
 msgid "Control various application permissions and settings"
 msgstr "Kontrol berbagai izin dan pengaturan aplikasi"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplikasi;flatpak;izin;pengaturan;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Pilih gambar"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "Ba_tal"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Buka"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "ukuran berganda"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Tanpa Latar Belakang Desktop"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Latar belakang kini"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Gaya"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Bawaan"
 
@@ -435,7 +271,6 @@ msgstr "Penampilan"
 msgid "Change your background image or the UI colors"
 msgstr "Ubah gambar latar belakang Anda atau warna antarmuka"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Latar Belakang; Layar;Destop; Gaya; Terang;Gelap; Penampilan;"
@@ -486,9 +321,7 @@ msgstr "Mode Pesawat Terbang Perangkat Keras Aktif"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Matikan saklar mode Pesawat Terbang untuk memfungsikan Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -496,7 +329,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Nyalakan dan matikan Bluetooth dan sambungkan perangkat Anda"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "berbagi;bluetooth;obex;bersama;"
@@ -530,91 +362,33 @@ msgstr "Tidak Ada Aplikasi yang Meminta Akses Kamera"
 msgid "Protect your pictures"
 msgstr "Lindungi gambar Anda"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "kamera;foto;video;kamera web;kunci;pribadi;privasi;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Tempatkan perangkat kalibrasi di atas kotak dan tekan '\"Mulai'\""
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Pindahkan perangkat kalibrasi ke posisi kalibrasi dan tekan \"Lanjutkan\""
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Pindahkan perangkat kalibrasi ke posisi permukaan dan tekan \"Lanjutkan\""
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Tutup lid laptop"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Terjadi galat internal yang tak dapat dipulihkan."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Perkakas yang diperlukan untuk kalibrasi tak terpasang."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Profil tak dapat dijangkitkan."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Titik putik target tak dapat dicapai."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Komplit!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrasi gagal!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Anda dapat melepas perangkat kalibrasi."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Jangan mengganggu perangkat kalibrasi ketika tengah berlangsung"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kalibrasi Tampilan"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Ba_tal"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -631,140 +405,6 @@ msgstr "Lanjut_kan"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Selesai"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Layar Laptop"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Webcam Bawaan"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Pelarik %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Kamera %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Pencetak %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webcam %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Fungsikan manajemen warna bagi %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Tampilkan profil warna bagi %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Tak dikalibrasi"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Baku: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Ruang warna: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Profil uji: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Pilih Berkas Profil ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Impor"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Profil ICC yang didukung"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Semua berkas"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Layar"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Simpan profil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Simpan"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Buat profil warna bagi perangkat yang dipilih"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Instrumen pengukur tak terdeteksi. Silakan periksa apakah sudah dinyalakan "
-"dari disambung dengan benar."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Instrumen pengukur tak mendukung pembuatan profil pencetak."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Jenis perangkat belum didukung."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -882,13 +522,13 @@ msgstr "Memerlukan media yang dapat ditulisi"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"Mungkin instruksi tentang bagaimana memakai profil pada sistem <a href="
-"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a>, dan <a href="
-"\"windows\">Microsoft Windows</a> ini berguna."
+"Mungkin instruksi tentang bagaimana memakai profil pada sistem <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a>, dan <a "
+"href=\"windows\">Microsoft Windows</a> ini berguna."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -899,8 +539,8 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Masalah terdeteksi. Profil mungkin tak bekerja dengan benar. <a href="
-"\"\">Tampilkan rincian.</a>"
+"Masalah terdeteksi. Profil mungkin tak bekerja dengan benar. <a "
+"href=\"\">Tampilkan rincian.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -908,7 +548,6 @@ msgstr "_Impor Berkas…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -919,9 +558,7 @@ msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Setiap perangkat perlu profil warna terkini untuk menjadi terkelola warnanya."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Pelajari lebih jauh"
 
@@ -1053,82 +690,6 @@ msgstr "D65 (Fotografi and grafis)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Ruang Standar"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Profil Uji"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Otomatis"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Kualitas Rendah"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Kualitas Sedang"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Kualitas Tinggi"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB bawaan"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK bawaan"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Kelabu bawaan"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Data kalibrasi dari pabrik yang disediakan oleh vendor"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Koreksi tampilan layar penuh tak mungkin dengan profil ini"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Profil ini mungkin tidak akurat lagi"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Warna"
@@ -1139,14 +700,9 @@ msgid ""
 msgstr ""
 "Kalibrasikan warna perangkat Anda, seperti monitor, kamera, atau pencetak"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Warna;ICC;Profil;Kalibrasi;Pencetak;Tampilan;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Lainnya…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1161,13 +717,8 @@ msgid "No languages found"
 msgstr "Tak ada bahasa yang ditemukan"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Lebih banyak…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Buka Kunci untuk Mengubah Pengaturan"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1196,148 +747,6 @@ msgstr "Turunkan Jam"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Turunkan Menit"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Hari ini"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Kemarin"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d jam"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d menit"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d detik"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 detik"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-jam"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1432,17 +841,11 @@ msgstr "_Zona Waktu Otomatis"
 msgid "Requires location services enabled and internet access"
 msgstr "Membutuhkan layanan lokasi diaktifkan dan akses internet"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Diaktifkan"
 
@@ -1450,15 +853,43 @@ msgstr "Diaktifkan"
 msgid "Time Z_one"
 msgstr "Z_ona Waktu"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Buka Kunci"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Tanggal"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 detik"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalender"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Angka"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Ubah tanggal dan waktu, termasuk zona waktu"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Jam;Zona waktu;Lokasi;"
@@ -1504,20 +935,9 @@ msgstr "Aplikasi Baku"
 msgid "Configure Default Applications"
 msgstr "Mengkonfigurasi Aplikasi Bawaan"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "bawaan;aplikasi;disukai;media;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Mengirim laporan masalah teknis membantu kami memperbaiki %s. Laporan "
-"dikirim secara anonim dan dibersihkan dari data pribadi. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1535,44 +955,9 @@ msgstr "Diagnostik"
 msgid "Report your problems"
 msgstr "Laporkan masalah Anda"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostik;kres;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Nyala"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Mati"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Terapkan Perubahan?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Perubahan Tidak Dapat Diterapkan"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Ini mungkin karena keterbatasan perangkat keras."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1622,31 +1007,6 @@ msgstr "Tampilan Primer"
 msgid "Night Light"
 msgstr "Terang Malam"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Landsekap"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Potret Kanan"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Potret Kiri"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Landsekap (dijungkir)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1670,6 +1030,17 @@ msgstr "Setel untuk TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Skala"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Pengguliran Alami"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1765,7 +1136,6 @@ msgstr "Tampilan"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Pilih bagaimana menggunakan monitor dan proyektor yang tersambung"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1773,80 +1143,6 @@ msgid ""
 msgstr ""
 "Panel;Proyektor;xrandr;Layar;Resolusi;Segarkan;Monitor;Malam;Terang;Biru;"
 "redshift;warna;matahari terbit;matahari tenggelam;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "Secure Boot Aktif"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat mulai. "
-"Saat ini dihidupkan dan berfungsi dengan benar."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Secure Boot Memiliki Masalah"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat mulai. "
-"Saat ini dihidupkan, tetapi tidak akan berfungsi karena memiliki kunci yang "
-"tidak valid."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Masalah secure boot seringkali dapat diselesaikan dari pengaturan perangkat "
-"tegar UEFI (BIOS) komputer Anda dan produsen perangkat keras Anda dapat "
-"memberikan informasi tentang cara melakukannya."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Untuk bantuan, hubungi produsen perangkat keras atau penyedia dukungan TI "
-"Anda."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Secure Boot Dimatikan"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat mulai. "
-"Saat ini dihidupkan dan berfungsi dengan benar."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Secure boot sering kali dapat dihidupkan dari pengaturan perangkat tegar "
-"UEFI (BIOS) komputer Anda. Untuk bantuan, hubungi produsen perangkat keras "
-"atau penyedia dukungan TI Anda."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1860,133 +1156,9 @@ msgstr ""
 "Untuk informasi lebih lanjut, hubungi produsen perangkat keras atau dukungan "
 "TI."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Lulus"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Gagal"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Perangkat sesuai dengan tingkat HSI %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "Tingkat Keamanan 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Perangkat ini tidak memiliki perlindungan terhadap masalah keamanan "
-"perangkat keras. Ini bisa jadi karena masalah konfigurasi perangkat keras "
-"atau perangkat tegar. Disarankan untuk menghubungi penyedia dukungan TI Anda."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "Tingkat Keamanan 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Perangkat ini memiliki perlindungan minimal terhadap masalah keamanan "
-"perangkat keras. Ini adalah tingkat keamanan perangkat terendah dan hanya "
-"memberikan perlindungan terhadap ancaman keamanan sederhana."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "Tingkat Keamanan"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Perangkat ini memiliki perlindungan dasar terhadap masalah keamanan "
-"perangkat keras. Ini memberikan perlindungan terhadap beberapa ancaman "
-"keamanan umum."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "Tingkat Keamanan 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Perangkat ini telah memperluas perlindungan terhadap masalah keamanan "
-"perangkat keras. Ini adalah tingkat keamanan perangkat tertinggi dan "
-"memberikan perlindungan terhadap ancaman keamanan tingkat lanjut."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "Tingkat Keamanan"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr "Tingkat keamanan tidak tersedia untuk perangkat ini."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Hubungi produsen perangkat keras Anda untuk mendapatkan bantuan terkait "
-"pemutakhiran keamanan."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Dimungkinkan untuk mengatasi masalah ini di pengaturan perangkat tegar UEFI "
-"perangkat, atau oleh teknisi dukungan."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Dimungkinkan untuk mengatasi masalah ini di pengaturan perangkat tegar UEFI "
-"perangkat."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Mungkin saja teknisi dukungan dapat mengatasi masalah ini."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2000,338 +1172,9 @@ msgstr "Level 2"
 msgid "Level 3"
 msgstr "Level 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr "Dilindungi dari perangkat lunak berbahaya saat perangkat dimulai."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "Secure Boot memiliki Masalah"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "Beberapa perlindungan saat perangkat dimulai."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "Secure Boot Dimatikan"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "Tidak ada perlindungan saat perangkat dimulai."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Masalah ini bisa disebabkan oleh perubahan pengaturan perangkat tegar UEFI, "
-"perubahan konfigurasi sistem operasi, atau karena perangkat lunak berbahaya "
-"pada sistem ini."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Masalah ini bisa disebabkan oleh perubahan dalam pengaturan perangkat tegar "
-"UEFI, atau karena perangkat lunak berbahaya pada sistem ini."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Masalah ini bisa disebabkan oleh perubahan konfigurasi sistem operasi, atau "
-"karena perangkat lunak berbahaya pada sistem ini."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "Rentan terhadap ancaman keamanan."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "Perlindungan terbatas terhadap ancaman keamanan sederhana."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "Dilindungi dari ancaman keamanan umum."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "Dilindungi dari berbagai ancaman keamanan."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "Perlindungan Komprehensif"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Tak Ada Acara"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Perlindungan Tulis Perangkat Tegar"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Kunci Perlindungan Tulis Perangkat Tegar"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Wilayah Perangkat Tegar BIOS"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Deskriptor Perangkat Tegar BIOS"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Perlindungan DMA Pra-Boot"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Boot Terverifikasi Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM Dilindungi"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Kebijakan Kesalahan Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Fuse Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET Diaktifkan"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET Aktif"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "RAM terenkripsi"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Perlindungan IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Penguncian Kernel Linux"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Verifikasi Kernel Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Swap Linux"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Suspensi Ke RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Suspensi Ke Diam"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Kunci Platform UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Secure Boot UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Konfigurasi Platform TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Rekonstruksi TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Mode Pembuatan Mesin Manajemen Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Penggantian Mesin Manajemen Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Versi Mesin Manajemen Intel"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Pemutakhiran Perangkat Tegar"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Pengesahan Perangkat Tegar"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Verifikasi Pemutakhiran Perangkat Tegar"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Platform Pengawakutuan"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Pemeriksaan Keamanan Prosesor"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Perlindungan Rollback AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Perlindungan Replay Perangkat Tegar AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Perlindungan Tulis Perangkat Tegar AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Platform yang Menyatu"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Sah"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Tidak Valid"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Tidak Diaktifkan"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Terkunci"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Tidak Terkunci"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Dienkripsi"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Tidak Dienkripsi"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Tercemar"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Tidak Tercemar"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Ditemukan"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Tidak ditemukan"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Didukung"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Tidak Didukung"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2341,7 +1184,6 @@ msgstr "Keamanan Perangkat"
 msgid "Host firmware security status"
 msgstr "Status keamanan firmware host"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2349,49 +1191,6 @@ msgid ""
 msgstr ""
 "layar;kunci;diagnostik;crash;privat;terkini;temporer;tmp;indeks;nama;"
 "jaringan;identitas;privasi;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Unknown"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Tidak diketahui"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Tidak Tersedia"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo Sistem"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2485,11 +1284,6 @@ msgstr "Ihwal"
 msgid "View information about your system"
 msgstr "Tilik informasi tentang sistem Anda"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2567,6 +1361,12 @@ msgstr "Peluncur"
 msgid "Launch help browser"
 msgstr "Tampilkan layar bantuan"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Pengaturan"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Luncurkan kalkulator"
@@ -2588,7 +1388,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Cari"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistem"
 
@@ -2637,15 +1437,6 @@ msgstr "Perkecil ukuran teks"
 msgid "High contrast on or off"
 msgstr "Nyalakan atau matikan kontras tinggi"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Sumber masukan tak ditemukan"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Lainnya"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Tambah Sumber Masukan"
@@ -2678,106 +1469,9 @@ msgstr "Preferensi"
 msgid "View Keyboard Layout"
 msgstr "Tampilkan Tata Letak Papan Tik"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Hapus"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Tombol Pintas Gubahan"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Tombol Karakter Alternatif"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Tombol karakter alternatif dapat digunakan untuk memasukkan karakter "
-"tambahan. Tombol ini biasanya dicetak sebagai opsi ketiga pada keyboard Anda."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt Kiri"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt Kanan"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Super Kiri"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Super Kanan"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tombol menu"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl Kanan"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Tombol Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Tombol tulis memungkinkan berbagai macam karakter untuk dimasukkan. Untuk "
-"menggunakannya, tekan buat lalu masukkan karakter.  Misalnya, tombol tulis "
-"diikuti dengan <b>C</b> dan <b>o</b> akan menjadi <b>©</b>, <b>a</b> diikuti "
-"oleh <b> '</b> akan menjadi <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Sumber masukan dapat dialihkan menggunakan pintasan papan tik %s Anda.\n"
-"Ini dapat diubah di pengaturan pintasan papan tik."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2807,44 +1501,21 @@ msgstr "Entri Karakter Khusus"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Metode untuk memasukkan simbol dan varian huruf menggunakan papan tik."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tombol Karakter Alternatif"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tombol Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Tombol Pintas"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Tampilkan dan Ubah Pintasan"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d diubah"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Atur Ulang Semua Pintasan?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Atur ulang pintasan dapat mempengaruhi cara pintasan gubahan Anda. Hal ini "
-"tidak dapat dibatalkan."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Batal"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Atur Ulang Semua"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2884,34 +1555,6 @@ msgstr "Tambah Pintasan"
 msgid "No keyboard shortcut found"
 msgstr "Tak ditemukan tombol pintas"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s telah dipakai untuk %s. Jika Anda menggantinya, %s akan dinonaktifkan"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Masukkan pintasan baru"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Atur Pintasan Ubahan"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Atur Pintasan"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Masukkan pintasan baru untuk mengubah %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Tambah Pintas Gubahan"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Hapus"
@@ -2923,7 +1566,6 @@ msgstr "_Gantikan"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "A_tur"
 
@@ -2961,6 +1603,11 @@ msgstr "Tak Ada"
 msgid "Reset the shortcut to its default value"
 msgstr "Tata ulang pintasan ke nilai baku"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Secara Baku Memakai Pencetak"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Papan Ketik"
@@ -2973,7 +1620,6 @@ msgstr ""
 "Ubah pintasan papan tik dan atur preferensi pengetikan, tata letak papan "
 "tik, dan sumber masukan"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3015,7 +1661,6 @@ msgstr "Tak Ada Aplikasi yang Meminta Akses Lokasi"
 msgid "Protect your location information"
 msgstr "Lindungi informasi lokasi Anda"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "lokasi;gps;pribadi;privasi;"
@@ -3050,7 +1695,6 @@ msgstr "Tak Ada Aplikasi yang Meminta Akses Mikrofon"
 msgid "Protect your conversations"
 msgstr "Lindungi percakapan Anda"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofon;rekaman;aplikasi;privasi;"
@@ -3080,81 +1724,139 @@ msgstr "Kiri"
 msgid "Right"
 msgstr "Kanan"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Cari Lokasi"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Tetikus"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Laju Tetikus"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Pengguliran Alami"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Bagian"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Pengguliran memindah isi, bukan tilikan."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Pengguliran memindah isi, bukan tilikan."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktif"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Laju Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Ketuk untuk Mengklik"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Ketuk untuk mengklik"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Pengguliran Dua Jari"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relatif)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Pengguliran Tepi"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dua Sisi"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Cobalah mengklik, klik ganda, menggulung"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Lima klik, waktunya GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Klik ganda, tombol primer"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Klik tunggal, tombol primer"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Klik ganda, tombol tengah"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Klik tunggal, tombol tengah"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Klik ganda, tombol sekunder"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Klik tunggal, tombol sekunder"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3166,7 +1868,6 @@ msgid ""
 msgstr ""
 "Ubah sensitivitas tetikus atau touchpad Anda dan pilih kidal atau bukan"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Trackpad;Pointer;Klik;Sentuh;Ganda;Tombol;Trackball;Gulir;"
@@ -3246,7 +1947,6 @@ msgstr "Multitasking"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Mengelola preferensi untuk produktivitas dan multitasking"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3254,21 +1954,11 @@ msgstr ""
 "Multitasking;Multitask;Produktivitas;Sesuaikan;Destop;Sudut Panas;Ruang "
 "kerja;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Ups, ada sesuatu yang salah. Harap hubungi vendor perangkat lunak Anda."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager perlu berjalan."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Perangkat Lainnya"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3280,59 +1970,16 @@ msgstr "Tambah koneksi"
 msgid "Not set up"
 msgstr "Belum ditata"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Jaringan tidak aman (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Jaringan aman (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Jaringan aman (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Jaringan aman (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Jaringan aman"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Tersambung"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opsi…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Menyalakan hotspot akan memutuskan koneksi dari %s, dan tidak mungkin untuk "
-"mengakses internet melalui Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Harus memiliki minimal 8 karakter"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3381,20 +2028,6 @@ msgstr "Hasilkan Otomatis Kata Sandi"
 msgid "_Turn On"
 msgstr "Ak_tifkan"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Hentikan hotspot dan putuskan semua pengguna?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Stop Hotspot"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Mode Pesawat Terbang"
@@ -3439,89 +2072,14 @@ msgstr "Jaringan Terlihat"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager perlu berjalan"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ups, ada sesuatu yang salah. Harap hubungi vendor perangkat lunak Anda."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Keamanan 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Keamanan"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Pertahankan"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanen"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Acak"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabil"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Alamat MAC yang dimasukkan di sini akan digunakan sebagai alamat perangkat "
-"keras untuk perangkat jaringan tempat koneksi ini diaktifkan. Fitur ini "
-"dikenal sebagai MAC cloning atau spoofing. Contoh: 00: 11: 22: 33: 44: 55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nihil"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Tak pernah"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3529,183 +2087,6 @@ msgstr "Tak pernah"
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i hari yang lalu"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nihil"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Lemah"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Bagus"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Sempurna"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Alamat IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Alamat IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Alamat IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Lupakan Sambungan"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Hapus Profil Sambungan"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Hapus VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Rincian"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "otomatis"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitas"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Hapus Alamat"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Hapus Route"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Tak Ada"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Kunci WEP 40/128-bit (Heksa atau ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Frasa-sandi WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP Dinamik (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Pribadi"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3716,8 +2097,20 @@ msgstr "Kuat Sinyal"
 msgid "Link speed"
 msgstr "Kecepatan link"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Keamanan"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Alamat IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Alamat IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Alamat Perangkat Keras"
 
@@ -3726,12 +2119,17 @@ msgid "Supported Frequencies"
 msgstr "Frekuensi Didukung"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Rute Utama"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3794,7 +2192,7 @@ msgstr "Hanya Link-Lokal"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
@@ -3838,9 +2236,8 @@ msgstr "Gateway"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Otomatis"
 
@@ -3893,91 +2290,9 @@ msgstr "Otomatis, hanya DHCP"
 msgid "Prefix"
 msgstr "Awalan"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Tak bisa membuka penyunting koneksi"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Profil Baru"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Pengaturan tidak valid %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Pengaturan tidak valid %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Impor dari berkas…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Tambah VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "K_eamanan"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Tak dapat mengimpor sambungan VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Berkas \"%s\" tidak dapat dibaca atau tidak berisi informasi sambungan VPN "
-"yang dikenali\n"
-"\n"
-"Galat: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Pilih berkas untuk diimpor"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Berkas bernama \"%s\" sudah ada."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Gantikan"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-"Apakah Anda ingin menggantikan %s dengan sambungan VPN yang sedang Anda "
-"simpan?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Tak dapat mengekspor sambungan VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Sambungan VPN \"%s\" tidak dapat diekspor ke %s.\n"
-"\n"
-"Galat: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Ekspor sambungan VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3991,98 +2306,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Jaringan"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Kendalikan bagaimana Anda menyambung ke Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Jaringan;IP;LAN;Proksi;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Kendalikan bagaimana Anda menyambung ke jaringan Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Jaringan;Nirkabel;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "tak pernah"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "hari ini"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "kemarin"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Terakhir dipakai"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Kabel"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Tambah sambungan baru"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Rincian jaringan bagi jaringan yang dipilih, termasuk kata sandi dan "
-"sebarang konfigurasi gubahan akan hilang."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Lupakan"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Jaringan Wi-Fi yang Dikenal"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Lupakan"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Kebijakan sistem melarang pemakaian sebagai Hotspot"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Perangkat nirkabel tak mendukung mode Hotspot"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Mencari Sendiri Proksi Web dipakai ketika URL Konfigurai tak diberikan."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Ini tak dianjurkan bagi jaringan publik yang tak terpercaya."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4101,6 +2354,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Penyedia"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Alamat IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4185,289 +2442,6 @@ msgstr "Hidupkan Ho_tspot Wi-Fi…"
 msgid "_Known Wi-Fi Networks"
 msgstr "Jaringan Wi-Fi yang Di_kenal"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Status tak diketahui"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Tak dikelola"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Tak tersedia"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Menyambung"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Perlu autentikasi"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Memutus"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Koneksi gagal"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Status tak diketahui (hilang)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Konfigurasi gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Konfigurasi IP gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Konfigurasi IP kadaluarsa"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Rahasia diperlukan, tapi tak disediakan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1X supplicant diputus"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Konfigurasi 802.1X supplicant gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1X supplicant gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1X supplicant makan waktu terlalu lama untuk mengautentikasi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Layanan PPP gagal dimulai"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Layanan PPP diputus"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Klien DHCP gagal dimulai"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Galat klien DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Klien DHCP gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Layanan koneksi bersama gagal dimulai"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Layanan koneksi bersama gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Layanan AutoIP gagal dimulai"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Galat layanan AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Layanan AutoIP gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Jalur sibuk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Tak ada nada panggil"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Carrier tak dapat dijalin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Permintaan pemanggilan habis waktu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Usaha memanggil gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Inisialisasi modem gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Gagal memilih APN yang dinyatakan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Tak mencari jaringan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Pendaftaran jaringan ditolak"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Pendaftaran jaringan habis waktu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Gagal mendaftar ke jaringan yang diminta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Uji PIN gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Firmware yang diperlukan bagi perangkat mungkin hilang"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Koneksi aktif perangkat menghilang"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Koneksi perangkat kini diasumsikan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem tak ditemukan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Koneksi Bluetooth gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Kartu SIM tak dipasang"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Perlu PIN SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Perlu PUK SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM salah"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Kebergantungan koneksi gagal"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Firmware hilang"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabel tercabut"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "galat tak terdefinisi dalam keamanan 802.1x (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "tak ada berkas yang dipilih"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "galat tak dispesifikasikan saat memvalidasi berkas eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Kunci privat DER, PEM, PKCS#12, atau PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Sertifikat DER atau PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "kurang berkas PAC EAP-FAST"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Berkas PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4516,14 +2490,6 @@ msgstr "Autent_ikasi dalam"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Izinkan pro_visi PAC otomatis"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "kurang nama pengguna EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "kurang kata sandi EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4549,15 +2515,6 @@ msgstr "Kata _Sandi"
 msgid "Sho_w password"
 msgstr "Tampilkan kata _sandi"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "sertifikat CA EAP-PEAP tak valid: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "sertifikat CA EAP-PEAP tak valid: tak ada sertifikat yang dinyatakan"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4579,7 +2536,6 @@ msgid "C_A certificate"
 msgstr "Sertifikat C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4594,63 +2550,6 @@ msgstr "Tidak dipe_rlukan sertifikat CA"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versi PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "kurang nama pengguna EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "kurang kata sandi EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "kurang identitas EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "sertifikat CA EAP-TLS tak valid: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "sertificat CA EAP-TLS tak valid: tak ada sertifikat yang dinyatakan"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "kunci privat EAP-TLS tak valid: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "sertifikat pengguna CA EAP-TLS tak valid: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Kunci privat tak tersandi itu tidak aman"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Kunci pribadi yang dipilih sepertinya tidak dilindungi oleh kata sandi. Ini "
-"dapat menyebabkan kredensial keamanan Anda disalahgunakan. Silakan pilih "
-"kunci pribadi yang diamankan oleh sandi.\n"
-"\n"
-"(Anda dapat melindungi kunci pribadi Anda dengan openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Pilih sertifikat pribadi Anda"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Pilih kunci privat Anda"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4667,15 +2566,6 @@ msgstr "_Kunci privat"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Kata sandi kunci _privat"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "sertifikat CA EAP-TTLS tak valid: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "sertificat CA EAP-TTLS tak valid: tak ada sertifikat yang dinyatakan"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4698,14 +2588,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domain"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Galat tak diketahui saat memvalidasi keamanan 802.1x"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4733,60 +2624,10 @@ msgstr "Protected EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "O_tentikasi"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Pilih berkas"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "kurang leap-username"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "kurang leap-password"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Kata sandi Wi-Fi hilang."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipe"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "kurang wep-key"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"wep-key tak valid: kunci dengan panjang %zu mesti hanya memuat dijit heksa"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"wep-key tak valid: kunci dengan panjang %zu mesti hanya memuat karakter ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"wep-key tak valid: panjang kunci %zu salah. Suatu kunci mesti sepanjang 5/13 "
-"(ascii) atau 10/26 (heksa)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "wep-key tak valid: frasa sandi tidak boleh kosong"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "wep-key tak valid: frasa sandi mesti kurang dari 64 karakter"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4811,21 +2652,6 @@ msgstr "Tampilkan _kunci"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Inde_ks WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk tak valid: panjang kunci %zu tak valid. Mesti [8,63] byte atau 64 "
-"dijit heksa"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk tak valid: tak bisa interpretasikan kunci dengan 64 byte sebagai "
-"heksa"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4879,27 +2705,9 @@ msgstr "Notifikasi _Layar Kunci"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Kendalikan notifikasi mana yang ditampilkan dan apa yang ditunjukkan"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifikasi;Banner;Pesan;Baki;Popup;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Lainnya"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s dihapus"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Galat saat menghapus akun"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4924,17 +2732,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Tambah akun"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Akun %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Hapus Akun"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Akun Daring"
@@ -4943,10 +2740,6 @@ msgstr "Akun Daring"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Sambung ke akun daring Anda dan tentukan mereka akan dipakai apa"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4954,10 +2747,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Daring;Obrolan;Kalender;Surel;Kontak;"
 "ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Waktu tak diketahui"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4971,13 +2760,6 @@ msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i jam"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4987,189 +2769,6 @@ msgstr[0] "jam"
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "menit"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s sampai terisi penuh"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Hati-hati: %s tersisa"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s tersisa"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Terisi penuh"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Tidak Mengisi"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Kosong"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Mengisi"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Mengosongkan"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Tetikus nirkabel"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Papan tik nirkabel"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Pasokan tenaga tak putus"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Asisten dijital pribadi"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Telepon seluler"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Pemutar media"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Komputer"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Perangkat masukan permainan"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Baterai"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Utama"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Ekstra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batera"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Ket_ika menganggur"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Suspensi"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Matikan"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hibernasi"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Bukan apapun"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Ketika memakai baterai"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Ketika ditancapkan"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Tak pernah"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Suspensi otomatis"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Mode kinerja dinonaktifkan sementara karena suhu pengoperasian yang tinggi."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Putaran terdeteksi: mode kinerja untuk sementara tidak tersedia. Pindahkan "
-"perangkat ke permukaan yang stabil untuk memulihkan."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Mode kinerja dinonaktifkan untuk sementara."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Baterai rendah: penghemat daya diaktifkan. Mode sebelumnya akan dipulihkan "
-"ketika baterai terisi cukup."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Mode Penghemat Daya diaktifkan oleh \"%s\"."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Mode kinerja diaktifkan oleh \"%s\"."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5230,6 +2829,15 @@ msgstr "100 menit"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 jam"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterai"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Perangkat"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5308,33 +2916,6 @@ msgstr "Memakai Tenaga _Baterai"
 msgid "Delay"
 msgstr "Tunda"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Kinerja"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Kinerja tinggi dan penggunaan daya."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Seimbang"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Kinerja standar dan penggunaan daya."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Penghemat Daya"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Kurangi kinerja dan penggunaan daya."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Daya"
@@ -5343,7 +2924,6 @@ msgstr "Daya"
 msgid "View your battery status and change power saving settings"
 msgstr "Tilik status baterai Anda dan ubah pengaturan penghematan daya"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5351,27 +2931,6 @@ msgid ""
 msgstr ""
 "Daya;Tidur;Suspensi;Hibernasi;Baterai;Kecerahan;Redup;Kosong;Monitor;DPMS;"
 "Menganggur;Energi;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Pencetak “%s” telah dihapus"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Gagal menambah pencetak baru."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Tak dapat memuat ui: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Buka Kunci untuk Menambahkan Pencetak dan Mengubah Pengaturan"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5383,7 +2942,6 @@ msgstr ""
 "Tambah pencetak, tilik tugas pencetak, dan menentukan bagaimana Anda ingin "
 "mencetak"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Pencetak;Antrian;Cetak;Kertas;Tinta;Pewarna;"
@@ -5391,8 +2949,6 @@ msgstr "Pencetak;Antrian;Cetak;Kertas;Tinta;Pewarna;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Tambah Pencetak"
 
@@ -5433,29 +2989,6 @@ msgstr ""
 msgid "Username"
 msgstr "Nama Pengguna"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Rincian %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Tak ditemukan penggerak yang cocok"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Pilih Berkas PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Berkas Deskripsi Pencetak PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Nama pencetak tidak boleh berisi SPACE, TAB, #, atau /"
@@ -5464,9 +2997,7 @@ msgstr "Nama pencetak tidak boleh berisi SPACE, TAB, #, atau /"
 msgid "Location"
 msgstr "Lokasi"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Penggerak"
 
@@ -5494,139 +3025,19 @@ msgstr "Pilih Penggerak Pencetak"
 msgid "Loading drivers database…"
 msgstr "Memuat basis data penggerak…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Batal"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Pilih"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Pencetak JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Pencetak LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Satu Sisi"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Sisi Panjang (Standar)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Sisi Pendek (Putar)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Potret"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Landskap"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Lansekap terbalik"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Potret terbalik"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Lanjutkan"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Jeda"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Ditunda"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Diistirahatkan"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Perlu autentikasi"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Diproses"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Berhenti"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Batal"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Dibatalkan"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Selesai"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Pindahkan pekerjaan ini ke urutan teratas antrean"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u Tugas Memerlukan Autentikasi"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Tugas Aktif"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Masukkan kredensial untuk mencetak dari %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5654,321 +3065,16 @@ msgstr "_Autentikasikan"
 msgid "No Active Printer Jobs"
 msgstr "Tidak Ada Tugas Pencetak Yang Aktif"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Pilih Peladen Pencetak"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Buka Kunci %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Masukkan nama pengguna dan kata sandi Anda untuk melihat pencetak pada %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Mencari Pencetak"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Porta Serial"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Porta Paralel"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Lokasi: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Alamat: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Server memerlukan autentikasi"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dua Sisi"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Jenis Kertas"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Sumber Kertas"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Baki Keluaran"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolusi"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Pra penapisan GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Halaman per sisi"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dua Sisi"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientasi"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Umum"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Penyiapan Halaman"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opsi Dapat Dipasang"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Tugas"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Kualitas Gambar"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Warna"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Menyelesaikan"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Tingkat Lanjut"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Halaman Uji"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Halaman uji"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Pilih Otomatis"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Pencetak Baku"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Tempelkan fonta GhostScript saja"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Konversi ke PS tingkat 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Konversi ke PS tingkat 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Tanpa pra penapisan"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Pabrikan"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Tidak Ada Tugas Aktif"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u Tugas"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Bersihkan kepala cetak"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Pewarna sedikit"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Pewarna habis"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Developer sedikit"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Developer habis"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Asupan penanda sedikit"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Asupan penanda habis"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Buka penutup"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Buka pinta"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Kertas sedikit"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Kertas habis"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Luring"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Dihentikan"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Penampung sampah hampir penuh"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Penampung sampah penuh"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Penghantar foto optik hampir mati"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Penghantar foto optik tak berfungsi lagi"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Siap"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Tak menerima tugas"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Memroses"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5992,6 +3098,10 @@ msgstr "Bersihkan Kepala Cetak"
 msgid "Remove Printer"
 msgstr "Hapus Pencetak"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Tidak Ada Tugas Aktif"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6012,16 +3122,21 @@ msgid "Restart"
 msgstr "Nyalakan Ulang"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Tambah Pencetak…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Tambah Pencetak…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Tidak ada pencetak"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6029,7 +3144,6 @@ msgstr ""
 "Maaf! Layanan pencetakan sistem\n"
 "    sepertinya tak tersedia."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Format"
@@ -6057,16 +3171,6 @@ msgstr "Pencarikan dapat berupa negara atau bahasa."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Pratayang"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Kerajaan"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrik"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6104,20 +3208,24 @@ msgstr ""
 "Pengaturan bahasa digunakan untuk teks antarmuka dan halaman web. Format "
 "digunakan untuk angka, tanggal, dan mata uang."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Akun Anda"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Bahasa"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Format"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Layar Log Masuk"
 
@@ -6129,99 +3237,9 @@ msgstr "Wilayah & Bahasa"
 msgid "Select your display language and formats"
 msgstr "Pilih bahasa dan format tampilan Anda"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Bahasa;Tata Letak;Papan Tik;Masukan;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Tanya apa yang akan dilakukan"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Jangan lakukan apa pun"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Buka folder"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Media Lain"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Pilih aplikasi bagi CD musik"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Pilih aplikasi bagi DVD video"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Pilih aplikasi yang dijalankan ketika pemutar musik disambungkan"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Pilih aplikasi yang dijalankan ketika kamera disambungkan"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Pilih aplikasi bagi CD perangkat lunak"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "diska Blu-ray kosong"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "diska CD kosong"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "diska DVD kosong"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "diska HD DVD kosong"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Diska video Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "pembaca e-book"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Diska video HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "CD gambar"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "CD Super Video"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "CD video"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Perangkat lunak Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6271,7 +3289,6 @@ msgstr "Media Lepasan"
 msgid "Configure Removable Media settings"
 msgstr "Mengkonfigurasi pengaturan Media Lepasan"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6279,114 +3296,6 @@ msgid ""
 msgstr ""
 "perangkat;sistem;bawaan;aplikasi;disukai;cd;dvd;usb;audio;video;cakram;dapat "
 "dicopot;media;autorun;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Layar Dimatikan"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 detik"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 menit"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 menit"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 menit"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 menit"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 menit"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 jam"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 menit"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 menit"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 menit"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 menit"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 menit"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 menit"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 menit"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 menit"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 menit"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Tak pernah"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6424,41 +3333,41 @@ msgstr "Jeda setelah layar kosong kapan layar terkunci otomatis."
 msgid "Show _Notifications on Lock Screen"
 msgstr "Tampilkan _Notifikasi pada Layar Kunci"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Notifikasi _Layar Kunci"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Larang perangkat _USB baru"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr ""
 "Cegah perangkat USB baru berinteraksi dengan sistem saat layar terkunci."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Privasi Layar"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Batasi Sudut Pandang"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Layar"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Pengaturan Layar"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "layar;kunci;pribadi;privasi;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Pilih Lokasi"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6488,10 +3397,6 @@ msgstr "Lainnya"
 msgid "Add Location"
 msgstr "Tambah Lokasi"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Tak menemukan aplikasi"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Pencarian Aplikasi"
@@ -6519,93 +3424,13 @@ msgstr ""
 "Kendalikan aplikasi mana yang menampilkan hasil pencarian dalam Ringkasan "
 "Aktivitas"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Cari;Temukan;Indeks;Sembunyikan;Privasi;Hasil;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Tiada jaringan yang dipilih untuk berbagi"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Jaringan"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Nyala"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Mati"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Diaktifkan"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktif"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Pilih Folder"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Tambah"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Aktifkan berbagi media"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Berbagi Pakai Berkas memungkinkan Anda berbagi pakai folder Publik Anda "
-"dengan orang lain pada jaringan Anda kini memakai: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Bila log masuk jarak jauh difungsikan, pengguna jarak jauh dapat menyambung "
-"memakai perintah Secure Shell:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Aktifkan berbagi media pribadi"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Nama perangkat disalin"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Alamat perangkat disalin"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Nama pengguna disalin"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Kata sandi disalin"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6737,7 +3562,6 @@ msgstr "Folder"
 msgid "Control what you want to share with others"
 msgstr "Kendalikan apa yang ingin Anda bagikan dengan orang lain"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6754,10 +3578,6 @@ msgstr "Fungsikan atau matikan log masuk jarak jauh"
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Autentikasi diperlukan untuk memfungsikan atau mematikan log masuk jarak jauh"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Gubahan"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6790,11 +3610,6 @@ msgstr "Belakang"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Depan"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Menguji %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6848,11 +3663,6 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Suara Waspada"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Bisu"
@@ -6865,82 +3675,11 @@ msgstr "Suara"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Mengubah aras suara, masukan, keluaran, dan suara peringatan"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Kartu;Mikrofon;Volume;Fade;Balans;Bluetooth;Headset;Audio;Keluaran;Masukan;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Terputus"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Menyambung"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Tersambung"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Galat Autorisasi"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Mengotorisasi"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Fungsionalitas Dikurangi"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Tersambung & Terotorisasi"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Tidak Diketahui"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Diotorisasi di:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Tersambung pada:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Terdaftar di:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Gagal mengotorisasi perangkat: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Gagal melupakan perangkat: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6973,55 +3712,6 @@ msgstr "Autorisasikan dan Sambungkan"
 msgid "Forget Device"
 msgstr "Lupakan Perangkat"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Galat"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Terotorisasi"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Subsistem Thunderbolt (boltd) tidak dipasang atau tidak diatur dengan benar."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Izinkan akses langsung ke perangkat seperti dok dan GPU eksternal."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Hanya perangkat USB dan Display Port yang dapat dipasang."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt tidak dapat dideteksi.\n"
-"Entah sistem tidak memiliki dukungan Thunderbolt, hal itu telah "
-"dinonaktifkan di BIOS atau diatur ke tingkat keamanan yang tidak didukung di "
-"BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Dukungan Thunderbolt telah dinonaktifkan di BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Tingkat keamanan thunderbolt tidak dapat ditentukan."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Galat saat mengalihkan mode langsung: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Tidak Ada Dukungan Thunderbolt"
@@ -7033,6 +3723,10 @@ msgstr "Tak bisa menyambung ke subsistem thunderbolt."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Akses Langsung"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Izinkan akses langsung ke perangkat seperti dok dan GPU eksternal."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7050,7 +3744,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Kelola perangkat Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privasi;"
@@ -7252,39 +3945,6 @@ msgstr "Aktifkan m_elalui Papan Tik"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Nyalakan dan matikan fitur aksesibilitas memakai papan tik"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Bawaan"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Sedang"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Besar"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Lebih Besar"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Terbesar"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d piksel"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Selalu Tampilkan Menu _Aksesibilitas"
@@ -7399,31 +4059,6 @@ msgstr "Kedipkan _seluruh layar"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Kedipkan seluruh _jendela"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Pendek"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ Layar"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ Layar"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ Layar"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Panjang"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7582,7 +4217,6 @@ msgstr ""
 "Membuat lebih mudah untuk melihat, mendengar, mengetik, menunjuk, dan "
 "mengklik"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7594,114 +4228,6 @@ msgstr ""
 "Zum;Layar;Pembaca;besar;tinggi;besar;teks;fonta;ukuran;AccessX;Lengket;"
 "Tombol;Lambat;Pantul;Tetikus;Dobel;klik;Tunda;Kecepatan;Bantu;Ulangi; "
 "Berkedip;visual;mendengar;audio;mengetik;animasi;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 jam"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 hari"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 hari"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 hari"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 hari"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 hari"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 hari"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 hari"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 hari"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 hari"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Kosongkan semua butir dari Tempat Sampah?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Semua butir dalam Tempat Sampah akan dihapus secara permanen."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Kosongkan Tempat Sampah"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Hapus semua berkas temporer?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Semua berkas temporer akan dihapus secara permanen."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Bersihkan Berkas Tem_porer"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 hari"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 hari"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 hari"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Selamanya"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7769,64 +4295,12 @@ msgstr "Riwayat Berkas dan Tempat Sampah"
 msgid "Don't leave traces"
 msgstr "Jangan tinggalkan jejak"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "penggunaan;terkini;riwayat;berkas;sementara;tmp;pribadi;privasi;sampah;"
 "pembersihan;simpan;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Mesti cocok dengan alamat web dari penyedia log masuk Anda."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Gagal menambah akun"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Kata sandi tak cocok."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Gagal mendaftarkan akun"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Tak ada cara yang didukung untuk mengautentikasi dengan domain ini"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Gagal bergabung ke domain"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Nama log masuk itu tak bekerja.\n"
-"Harap coba lagi."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Kata sandi log masuk itu tak bekerja.\n"
-"Harap coba lagi."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Gagal log masuk domain"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Tak bisa temukan domain. Mungkin Anda salah eja?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7879,10 +4353,6 @@ msgstr ""
 "Log masuk enterprise memungkinkan akun pengguna yang telah ada yang dikelola "
 "secara terpusat dipakai pada perangkat ini. Anda juga dapat memakai akun ini "
 "untuk mengakses sumber daya perusahaan di internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Ramban lebih banyak gambar"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7953,222 +4423,6 @@ msgstr "Hapus Si_dik Jari"
 msgid "Fingerprint Enroll"
 msgstr "Pendaftaran Sidik Jari"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "perangkat perlu diklaim untuk melakukan tindakan ini"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "perangkat sudah diklaim oleh proses lain"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "Anda tidak memiliki izin untuk melakukan tindakan"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "tidak ada sidik jari yang terdaftar"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Gagal berkomunikasi dengan perangkat selama pendaftaran"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Gagal berkomunikasi dengan pembaca sidik jari"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Gagal berkomunikasi dengan daemon sidik jari"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Gagal mencantumkan sidik jari: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Gagal menghapus sidik jari yang disimpan: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Jempol kiri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Jari tengah kiri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Telunjuk k_iri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Jari manis kiri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Kelingking kiri"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Jempol kanan"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Jari tengah kanan"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Telunjuk k_anan"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Jari manis kanan"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Kelingking kanan"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Jari Tidak Dikenal"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Komplit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Perangkat sidik jari terputus"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Penyimpanan perangkat sidik jari penuh"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Gagal mendaftarkan sidik jari baru"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Gagal memulai pendaftaran: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Gagal mendaftarkan sidik jari baru"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Gagal menghentikan pendaftaran: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Angkat dan letakkan jari Anda berulang kali pada pembaca untuk mendaftarkan "
-"sidik jari Anda"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Dafta_rkan ulang jari ini…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Pindai sidik jari baru"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Gagal melepaskan perangkat sidik jari %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Masalah pada Perangkat Membaca"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Gagal mengklaim perangkat sidik jari %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Gagal mendapatkan perangkat sidik jari: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Minggu Ini"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Minggu Lalu"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sesi Berakhir"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sesi Dimulai"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Aktivitas Akun"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Sebelumnya"
@@ -8176,18 +4430,6 @@ msgstr "Sebelumnya"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Selanjutnya"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Silakan pilih kata sandi lain."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Silakan tik ulang kata sandi kini."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Kata sandi tak dapat diubah"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8209,6 +4451,10 @@ msgstr "Kata Sandi Baru"
 msgid "Confirm Password"
 msgstr "Konfirmasi Kata Sandi"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Kata sandi tak cocok."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Izinkan pengguna mengubah kata sandi saat log masuk berikutnya"
@@ -8216,134 +4462,6 @@ msgstr "Izinkan pengguna mengubah kata sandi saat log masuk berikutnya"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Isi kata sandi sekarang"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Tak bisa secara otomatis bergabung ke tipe domain ini"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Domain atau realm tersebut tak ditemukan"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Tak bisa log masuk sebagai %s pada domain %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Kata sandi salah, harap coba lagi"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Tak bisa menyambung ke domain %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Gagal menghapus pengguna"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Gagal mencabut pengguna yang dikelola jarak jauh"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Anda tak bisa menghapus akunmu sendiri."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s masih log masuk"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Menghapus pengguna saat mereka log masuk dapat menjerumuskan sistem ke dalam "
-"keadaan tak konsisten."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Apakah Anda ingin mempertahankan berkas milik %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Dimungkinkan untuk mempertahankan direktori rumah, spool surel, dan berkas "
-"temporer ketika menghapus suatu akun pengguna."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Hapus Berkas"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "Biarkan Berkas"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Anda yakin ingin mencabut akun %s yang dikelola jarak jauh?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Hapus"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Akun dimatikan"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Untuk ditata saat log masuk berikutnya"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Tak ada"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Log masuk"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Gagal menghubungi layanan akun"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Pastikan bahwa AccountService ini telah terpasang dan diaktifkan."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Panel ini harus dibuka untuk mengubah pengaturan ini"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Hapus akun pengguna yang dipilih"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Untuk menghapus akun pengguna yang dipilih,\n"
-"pertama kali klik ikon *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Buka Kunci untuk Menambahkan Pengguna dan Mengubah Pengaturan"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8371,7 +4489,6 @@ msgid "Full name"
 msgstr "Nama Lengkap"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Sunting"
 
@@ -8433,7 +4550,6 @@ msgstr "Buka kunci untuk menambahkan akun pengguna."
 msgid "Add or remove users and change your password"
 msgstr "Tambah atau hapus pengguna dan ubah kata sandi Anda"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8478,179 +4594,6 @@ msgstr "Kelola akun pengguna"
 msgid "Authentication is required to change user data"
 msgstr "Autentikasi diperlukan untuk mengubah data pengguna"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Kata sandi baru perlu berbeda dengan yang lama."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Cobalah mengubah beberapa huruf dan angka."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Cobalah mengubah kata sandi lebih banyak lagi."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Suatu kata sandi tanpa nama penggunamu akan lebih kuat."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Cobalah menghindari memakai nama Anda dalam kata sandi."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Cobalah menghindari beberapa kata yang termasuk dalam kata sandi."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Cobalah menghindari kata-kata umum."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Cobalah menghindari mengatur ulang urutan kata yang ada."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Cobalah memakai lebih banyak angka."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Cobalah memakai lebih banyak huruf besar."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Cobalah memakai lebih banyak huruf kecil."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Cobalah memakai lebih banyak karakter khusus, seperti tanda baca."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Cobalah memakai campuran huruf, angka, dan tanda baca."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Cobalah menghindari pengulangan karakter yang sama."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Cobalah menghindari mengulang karakter bertipe sama: Anda perlu mencampur "
-"huruf, angka, dan tanda baca."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Cobalah menghindari urutan seperti 1234 atau abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Kata sandi harus lebih panjang. Cobalah menambahkan lebih banyak huruf, "
-"angka dan tanda baca."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Campurlah huruf besar dan kecil dan cobalah memakai satu atau dua angka."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Menambahkan lebih banyak huruf, angka dan tanda baca akan membuat kata sandi "
-"lebih kuat."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Autentikasi gagal"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Kata sandi baru terlalu pendek"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Kata sandi baru terlalu sederhana"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Kata sandi lama dan baru terlalu mirip"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Kata sandi baru pernah dipakai baru-baru ini."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Kata sandi baru harus mengandung angka atau karakter istimewa"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Kata sandi lama dan baru sama"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Kata sandi Anda telah diubah sejak dari Anda terautentikasi!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Kata sandi baru tidak memuat cukup banyak karakter berbeda"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Galat tak dikenal"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Nama pengguna hanya boleh terdiri dari huruf a-z besar dan kecil, angka, dan "
-"karakter berikut: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Maaf, nama pengguna tersebut tidak tersedia. Harap coba yang lain."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Nama pengguna terlalu panjang."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8685,52 +4628,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Salah klik terdeteksi, memulai ulang…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Tombol %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplikasi yang didefinisikan"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Kirim Ketukan Tombol"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Tukar Monitor"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Tampilkan Bantuan Pada Layar"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tablet dipasang pada panel laptop"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tablet yang dipasang pada layar eksternal"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Perangkat tablet eksternal"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Perangkat pad eksternal"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Semua Tampilan"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8828,22 +4729,6 @@ msgstr "Klik Tombol Kanan Tetikus"
 msgid "Forward"
 msgstr "Maju"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Stylus Airbrush dengan tekanan, kemiringan, dan slider terintegrasi"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Stylus airbrush dengan tekanan, kemiringan, dan rotasi"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Stylus standar dengan tekanan dan kemiringan"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Stylus standar dengan tekanan"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tablet Wacom"
@@ -8852,54 +4737,96 @@ msgstr "Tablet Wacom"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Tata pemetaan tombol dan atur kepekaan stylus bagi tablet grafis"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Penghapus;Tetikus;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Pintasan baru…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Klik _Sekunder Tersimulasi"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Perangkat lunak Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Pewarna sedikit"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Tundaan klik sekunder"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Perangkat lunak Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Mengelola preferensi untuk produktivitas dan multitasking"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Titik Akses"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Tambah"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Simpan"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operasi Dibatalkan"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Galat:</b> Akses ditolak saat mengubah pengaturan"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Galat:</b> Galat Peralatan Seluler"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Tidak Terdaftar"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Terdaftar"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Mencari"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Ditolak"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8929,212 +4856,13 @@ msgstr "Nomor Ini"
 msgid "Device Details"
 msgstr "Rincian Peranti"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Pabrikan"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Versi Firmware"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Hanya 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Hanya 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Hanya 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Hanya 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (Disukai), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (Disukai), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (Disukai), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Disukai), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Disukai), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (Disukai), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (Disukai), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (Disukai), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (Disukai), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (Disukai), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (Disukai), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (Disukai), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (Disukai), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (Disukai), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (Disukai), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (Disukai), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (Disukai)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (Disukai), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Tak Dikenal"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Buka kunci kartu SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Buka Kunci"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Harap berikan kode PIN untuk SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Masukkan PIN untuk membuka kunci kartu SIM Anda"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Harap berikan kode PUK untuk SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Masukkan PUK untuk membuka kunci kartu SIM Anda"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9147,26 +4875,6 @@ msgstr[0] "Kata sandi yang dimasukkan salah. Anda punya sisa %1$u percobaan"
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Anda punya sisa %u percobaan"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Kata sandi yang dimasukkan salah."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Kode PUK mesti berupa suatu angka 8 digit"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Masukkan PIN Baru"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Kode PIN mesti berupa suatu angka 4-8 digit"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Buka Kunci…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9224,94 +4932,6 @@ msgstr "Kunci SIM dengan PIN"
 msgid "M_odem Details"
 msgstr "Rincian Modem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Kegagalan telepon"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Tidak ada koneksi ke telepon"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operasi tak diizinkan"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operasi tak didukung"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM tak dipasang"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Perlu PIN SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Perlu PUK SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Kegagalan SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM sibuk"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Kata sandi salah"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Perlu PIN2 SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Perlu PUK2 SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Tak ditemukan"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Tidak ada layanan jaringan"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Jaringan habis waktu"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Layanan GPS tak diizinkan"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming tak diizinkan di wilayah lokasi ini"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Galat GPS yang tak dinyatakan"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Tidak ada Galat"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Aksi Dibatalkan"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Akses ditolak"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Galat Tak Dikenal"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Mode Jaringan"
@@ -9327,11 +4947,6 @@ msgstr "Pilih Jaringan"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Segarkan Penyedia Jaringan"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9389,7 +5004,6 @@ msgstr "Jaringan Seluler"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Mengkonfigurasi koneksi data seluler dan telefoni"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "seluler;wwan;telefoni;sim;mobile;"
@@ -9406,41 +5020,13 @@ msgstr "Pengaturan adalah antarmuka utama untuk mengkonfigurasi sistem Anda."
 msgid "The GNOME Project"
 msgstr "Proyek GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Tampilkan nomor versi"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Aktifkan moda verbose"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Cari string"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Tampilkan daftar nama panel yang mungkin dan keluar"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel yang hendak ditampilkan"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMEN…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Kategori pengaturan"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privasi"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Panel yang tersedia:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9498,7 +5084,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Batalkan pencarian"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferensi;Pengaturan;"
@@ -9540,34 +5125,3139 @@ msgstr ""
 "Sebuah tuple yang berisi lebar awal, tinggi dan keadaan maksimal jendela "
 "aplikasi."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u Keluaran"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u Masukan"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Suara Sistem"
+#~ msgid "System Bus"
+#~ msgstr "Bus Sistem"
+
+#~ msgid "Full access"
+#~ msgstr "Akses penuh"
+
+#~ msgid "Session Bus"
+#~ msgstr "Bus Sesi"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Akses penuh ke /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Memiliki akses jaringan"
+
+#~ msgid "Home"
+#~ msgstr "Rumah"
+
+#~ msgid "Read-only"
+#~ msgstr "Hanya-baca"
+
+#~ msgid "File System"
+#~ msgstr "Sistem Berkas"
+
+#~ msgid "Can change settings"
+#~ msgstr "Dapat mengubah pengaturan"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s memiliki izin berikut sebagai bawaan. Ini tidak dapat diubah. Jika "
+#~ "Anda khawatir tentang izin ini, pertimbangkan untuk menghapus aplikasi "
+#~ "ini."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u jenis berkas dan tautan yang dibuka oleh aplikasi"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> digunakan untuk membuka jenis berkas dan tautan berikut."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s ruang diska yang digunakan."
+
+#~ msgid "Select a picture"
+#~ msgstr "Pilih gambar"
+
+#~ msgid "_Open"
+#~ msgstr "_Buka"
+
+#~ msgid "multiple sizes"
+#~ msgstr "ukuran berganda"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Tanpa Latar Belakang Desktop"
+
+#~ msgid "Current background"
+#~ msgstr "Latar belakang kini"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Tempatkan perangkat kalibrasi di atas kotak dan tekan '\"Mulai'\""
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Pindahkan perangkat kalibrasi ke posisi kalibrasi dan tekan \"Lanjutkan\""
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Pindahkan perangkat kalibrasi ke posisi permukaan dan tekan \"Lanjutkan\""
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Tutup lid laptop"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Terjadi galat internal yang tak dapat dipulihkan."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Perkakas yang diperlukan untuk kalibrasi tak terpasang."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profil tak dapat dijangkitkan."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Titik putik target tak dapat dicapai."
+
+#~ msgid "Complete!"
+#~ msgstr "Komplit!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrasi gagal!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Anda dapat melepas perangkat kalibrasi."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Jangan mengganggu perangkat kalibrasi ketika tengah berlangsung"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Layar Laptop"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Webcam Bawaan"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Pelarik %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Kamera %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Pencetak %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webcam %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Fungsikan manajemen warna bagi %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Tampilkan profil warna bagi %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Tak dikalibrasi"
+
+#~ msgid "Default: "
+#~ msgstr "Baku: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Ruang warna: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Profil uji: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Pilih Berkas Profil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Impor"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Profil ICC yang didukung"
+
+#~ msgid "All files"
+#~ msgstr "Semua berkas"
+
+#~ msgid "Save Profile"
+#~ msgstr "Simpan profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Buat profil warna bagi perangkat yang dipilih"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Instrumen pengukur tak terdeteksi. Silakan periksa apakah sudah "
+#~ "dinyalakan dari disambung dengan benar."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Instrumen pengukur tak mendukung pembuatan profil pencetak."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Jenis perangkat belum didukung."
+
+#~ msgid "Standard Space"
+#~ msgstr "Ruang Standar"
+
+#~ msgid "Test Profile"
+#~ msgstr "Profil Uji"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Otomatis"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Kualitas Rendah"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Kualitas Sedang"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Kualitas Tinggi"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB bawaan"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK bawaan"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Kelabu bawaan"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Data kalibrasi dari pabrik yang disediakan oleh vendor"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Koreksi tampilan layar penuh tak mungkin dengan profil ini"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Profil ini mungkin tidak akurat lagi"
+
+#~ msgid "Other…"
+#~ msgstr "Lainnya…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Buka Kunci untuk Mengubah Pengaturan"
+
+#~ msgid "Today"
+#~ msgstr "Hari ini"
+
+#~ msgid "Yesterday"
+#~ msgstr "Kemarin"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d jam"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d menit"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d detik"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24-jam"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Mengirim laporan masalah teknis membantu kami memperbaiki %s. Laporan "
+#~ "dikirim secara anonim dan dibersihkan dari data pribadi. %s"
+
+#~ msgid "On"
+#~ msgstr "Nyala"
+
+#~ msgid "Off"
+#~ msgstr "Mati"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Terapkan Perubahan?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Perubahan Tidak Dapat Diterapkan"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Ini mungkin karena keterbatasan perangkat keras."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Landsekap"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Potret Kanan"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Potret Kiri"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Landsekap (dijungkir)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Secure Boot Aktif"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat "
+#~ "mulai. Saat ini dihidupkan dan berfungsi dengan benar."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Secure Boot Memiliki Masalah"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat "
+#~ "mulai. Saat ini dihidupkan, tetapi tidak akan berfungsi karena memiliki "
+#~ "kunci yang tidak valid."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Masalah secure boot seringkali dapat diselesaikan dari pengaturan "
+#~ "perangkat tegar UEFI (BIOS) komputer Anda dan produsen perangkat keras "
+#~ "Anda dapat memberikan informasi tentang cara melakukannya."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Untuk bantuan, hubungi produsen perangkat keras atau penyedia dukungan TI "
+#~ "Anda."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Secure Boot Dimatikan"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat "
+#~ "mulai. Saat ini dihidupkan dan berfungsi dengan benar."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Secure boot sering kali dapat dihidupkan dari pengaturan perangkat tegar "
+#~ "UEFI (BIOS) komputer Anda. Untuk bantuan, hubungi produsen perangkat "
+#~ "keras atau penyedia dukungan TI Anda."
+
+#~ msgid "Passed"
+#~ msgstr "Lulus"
+
+#~ msgid "Failed"
+#~ msgstr "Gagal"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Perangkat sesuai dengan tingkat HSI %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Tingkat Keamanan 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Perangkat ini tidak memiliki perlindungan terhadap masalah keamanan "
+#~ "perangkat keras. Ini bisa jadi karena masalah konfigurasi perangkat keras "
+#~ "atau perangkat tegar. Disarankan untuk menghubungi penyedia dukungan TI "
+#~ "Anda."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Tingkat Keamanan 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Perangkat ini memiliki perlindungan minimal terhadap masalah keamanan "
+#~ "perangkat keras. Ini adalah tingkat keamanan perangkat terendah dan hanya "
+#~ "memberikan perlindungan terhadap ancaman keamanan sederhana."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Tingkat Keamanan"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Perangkat ini memiliki perlindungan dasar terhadap masalah keamanan "
+#~ "perangkat keras. Ini memberikan perlindungan terhadap beberapa ancaman "
+#~ "keamanan umum."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Tingkat Keamanan 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Perangkat ini telah memperluas perlindungan terhadap masalah keamanan "
+#~ "perangkat keras. Ini adalah tingkat keamanan perangkat tertinggi dan "
+#~ "memberikan perlindungan terhadap ancaman keamanan tingkat lanjut."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Tingkat keamanan tidak tersedia untuk perangkat ini."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Hubungi produsen perangkat keras Anda untuk mendapatkan bantuan terkait "
+#~ "pemutakhiran keamanan."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Dimungkinkan untuk mengatasi masalah ini di pengaturan perangkat tegar "
+#~ "UEFI perangkat, atau oleh teknisi dukungan."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Dimungkinkan untuk mengatasi masalah ini di pengaturan perangkat tegar "
+#~ "UEFI perangkat."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Mungkin saja teknisi dukungan dapat mengatasi masalah ini."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Dilindungi dari perangkat lunak berbahaya saat perangkat dimulai."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Secure Boot memiliki Masalah"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Beberapa perlindungan saat perangkat dimulai."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Secure Boot Dimatikan"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Tidak ada perlindungan saat perangkat dimulai."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Masalah ini bisa disebabkan oleh perubahan pengaturan perangkat tegar "
+#~ "UEFI, perubahan konfigurasi sistem operasi, atau karena perangkat lunak "
+#~ "berbahaya pada sistem ini."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Masalah ini bisa disebabkan oleh perubahan dalam pengaturan perangkat "
+#~ "tegar UEFI, atau karena perangkat lunak berbahaya pada sistem ini."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Masalah ini bisa disebabkan oleh perubahan konfigurasi sistem operasi, "
+#~ "atau karena perangkat lunak berbahaya pada sistem ini."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Rentan terhadap ancaman keamanan."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Perlindungan terbatas terhadap ancaman keamanan sederhana."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Dilindungi dari ancaman keamanan umum."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Dilindungi dari berbagai ancaman keamanan."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Perlindungan Komprehensif"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Perlindungan Tulis Perangkat Tegar"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Kunci Perlindungan Tulis Perangkat Tegar"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Wilayah Perangkat Tegar BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Deskriptor Perangkat Tegar BIOS"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Perlindungan DMA Pra-Boot"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Boot Terverifikasi Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM Dilindungi"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Kebijakan Kesalahan Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Fuse Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET Diaktifkan"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET Aktif"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "RAM terenkripsi"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Perlindungan IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Penguncian Kernel Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Verifikasi Kernel Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Swap Linux"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Suspensi Ke RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Suspensi Ke Diam"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Kunci Platform UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Secure Boot UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Konfigurasi Platform TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Rekonstruksi TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Mode Pembuatan Mesin Manajemen Intel"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Penggantian Mesin Manajemen Intel"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Versi Mesin Manajemen Intel"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Pemutakhiran Perangkat Tegar"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Pengesahan Perangkat Tegar"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Verifikasi Pemutakhiran Perangkat Tegar"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Platform Pengawakutuan"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Pemeriksaan Keamanan Prosesor"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Perlindungan Rollback AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Perlindungan Replay Perangkat Tegar AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Perlindungan Tulis Perangkat Tegar AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Platform yang Menyatu"
+
+#~ msgid "Valid"
+#~ msgstr "Sah"
+
+#~ msgid "Not Valid"
+#~ msgstr "Tidak Valid"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Tidak Diaktifkan"
+
+#~ msgid "Locked"
+#~ msgstr "Terkunci"
+
+#~ msgid "Not Locked"
+#~ msgstr "Tidak Terkunci"
+
+#~ msgid "Encrypted"
+#~ msgstr "Dienkripsi"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Tidak Dienkripsi"
+
+#~ msgid "Tainted"
+#~ msgstr "Tercemar"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Tidak Tercemar"
+
+#~ msgid "Found"
+#~ msgstr "Ditemukan"
+
+#~ msgid "Not Found"
+#~ msgstr "Tidak ditemukan"
+
+#~ msgid "Supported"
+#~ msgstr "Didukung"
+
+#~ msgid "Not Supported"
+#~ msgstr "Tidak Didukung"
+
+#~ msgid "Unknown"
+#~ msgstr "Unknown"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Tidak diketahui"
+
+#~ msgid "Not Available"
+#~ msgstr "Tidak Tersedia"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo Sistem"
+
+#~ msgid "No input sources found"
+#~ msgstr "Sumber masukan tak ditemukan"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Lainnya"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Tombol Pintas Gubahan"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Tombol karakter alternatif dapat digunakan untuk memasukkan karakter "
+#~ "tambahan. Tombol ini biasanya dicetak sebagai opsi ketiga pada keyboard "
+#~ "Anda."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt Kiri"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt Kanan"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super Kiri"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super Kanan"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tombol menu"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl Kanan"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Tombol tulis memungkinkan berbagai macam karakter untuk dimasukkan. Untuk "
+#~ "menggunakannya, tekan buat lalu masukkan karakter.  Misalnya, tombol "
+#~ "tulis diikuti dengan <b>C</b> dan <b>o</b> akan menjadi <b>©</b>, <b>a</"
+#~ "b> diikuti oleh <b> '</b> akan menjadi <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Sumber masukan dapat dialihkan menggunakan pintasan papan tik %s Anda.\n"
+#~ "Ini dapat diubah di pengaturan pintasan papan tik."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d diubah"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Atur Ulang Semua Pintasan?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Atur ulang pintasan dapat mempengaruhi cara pintasan gubahan Anda. Hal "
+#~ "ini tidak dapat dibatalkan."
+
+#~ msgid "Reset All"
+#~ msgstr "Atur Ulang Semua"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s telah dipakai untuk %s. Jika Anda menggantinya, %s akan dinonaktifkan"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Masukkan pintasan baru"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Atur Pintasan Ubahan"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Atur Pintasan"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Masukkan pintasan baru untuk mengubah %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Tambah Pintas Gubahan"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Pengguliran Dua Jari"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Lima klik, waktunya GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Klik ganda, tombol primer"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Klik tunggal, tombol primer"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Klik ganda, tombol tengah"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Klik tunggal, tombol tengah"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Klik ganda, tombol sekunder"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Klik tunggal, tombol sekunder"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager perlu berjalan."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Jaringan tidak aman (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Jaringan aman (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Jaringan aman (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Jaringan aman (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Jaringan aman"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Menyalakan hotspot akan memutuskan koneksi dari %s, dan tidak mungkin "
+#~ "untuk mengakses internet melalui Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Harus memiliki minimal 8 karakter"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Hentikan hotspot dan putuskan semua pengguna?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Stop Hotspot"
+
+#~ msgid "Preserve"
+#~ msgstr "Pertahankan"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanen"
+
+#~ msgid "Random"
+#~ msgstr "Acak"
+
+#~ msgid "Stable"
+#~ msgstr "Stabil"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Alamat MAC yang dimasukkan di sini akan digunakan sebagai alamat "
+#~ "perangkat keras untuk perangkat jaringan tempat koneksi ini diaktifkan. "
+#~ "Fitur ini dikenal sebagai MAC cloning atau spoofing. Contoh: 00: 11: 22: "
+#~ "33: 44: 55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nihil"
+
+#~ msgid "Never"
+#~ msgstr "Tak pernah"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nihil"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Lemah"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bagus"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Sempurna"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Lupakan Sambungan"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Hapus Profil Sambungan"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Hapus VPN"
+
+#~ msgid "Details"
+#~ msgstr "Rincian"
+
+#~ msgid "automatic"
+#~ msgstr "otomatis"
+
+#~ msgid "Identity"
+#~ msgstr "Identitas"
+
+#~ msgid "Delete Address"
+#~ msgstr "Hapus Alamat"
+
+#~ msgid "Delete Route"
+#~ msgstr "Hapus Route"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Tak Ada"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Kunci WEP 40/128-bit (Heksa atau ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Frasa-sandi WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP Dinamik (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Pribadi"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Tak bisa membuka penyunting koneksi"
+
+#~ msgid "New Profile"
+#~ msgstr "Profil Baru"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Pengaturan tidak valid %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Pengaturan tidak valid %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Impor dari berkas…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Tambah VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Tak dapat mengimpor sambungan VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Berkas \"%s\" tidak dapat dibaca atau tidak berisi informasi sambungan "
+#~ "VPN yang dikenali\n"
+#~ "\n"
+#~ "Galat: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Pilih berkas untuk diimpor"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Berkas bernama \"%s\" sudah ada."
+
+#~ msgid "_Replace"
+#~ msgstr "_Gantikan"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "Apakah Anda ingin menggantikan %s dengan sambungan VPN yang sedang Anda "
+#~ "simpan?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Tak dapat mengekspor sambungan VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Sambungan VPN \"%s\" tidak dapat diekspor ke %s.\n"
+#~ "\n"
+#~ "Galat: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Ekspor sambungan VPN"
+
+#~ msgid "never"
+#~ msgstr "tak pernah"
+
+#~ msgid "today"
+#~ msgstr "hari ini"
+
+#~ msgid "yesterday"
+#~ msgstr "kemarin"
+
+#~ msgid "Last used"
+#~ msgstr "Terakhir dipakai"
+
+#~ msgid "Add new connection"
+#~ msgstr "Tambah sambungan baru"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Rincian jaringan bagi jaringan yang dipilih, termasuk kata sandi dan "
+#~ "sebarang konfigurasi gubahan akan hilang."
+
+#~ msgid "_Forget"
+#~ msgstr "_Lupakan"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Jaringan Wi-Fi yang Dikenal"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Lupakan"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Kebijakan sistem melarang pemakaian sebagai Hotspot"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Perangkat nirkabel tak mendukung mode Hotspot"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Mencari Sendiri Proksi Web dipakai ketika URL Konfigurai tak diberikan."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Ini tak dianjurkan bagi jaringan publik yang tak terpercaya."
+
+#~ msgid "Status unknown"
+#~ msgstr "Status tak diketahui"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Tak dikelola"
+
+#~ msgid "Unavailable"
+#~ msgstr "Tak tersedia"
+
+#~ msgid "Connecting"
+#~ msgstr "Menyambung"
+
+#~ msgid "Authentication required"
+#~ msgstr "Perlu autentikasi"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Memutus"
+
+#~ msgid "Connection failed"
+#~ msgstr "Koneksi gagal"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Status tak diketahui (hilang)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Konfigurasi gagal"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Konfigurasi IP gagal"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Konfigurasi IP kadaluarsa"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Rahasia diperlukan, tapi tak disediakan"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1X supplicant diputus"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Konfigurasi 802.1X supplicant gagal"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1X supplicant gagal"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1X supplicant makan waktu terlalu lama untuk mengautentikasi"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Layanan PPP gagal dimulai"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Layanan PPP diputus"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP gagal"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Klien DHCP gagal dimulai"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Galat klien DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Klien DHCP gagal"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Layanan koneksi bersama gagal dimulai"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Layanan koneksi bersama gagal"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Layanan AutoIP gagal dimulai"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Galat layanan AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Layanan AutoIP gagal"
+
+#~ msgid "Line busy"
+#~ msgstr "Jalur sibuk"
+
+#~ msgid "No dial tone"
+#~ msgstr "Tak ada nada panggil"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Carrier tak dapat dijalin"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Permintaan pemanggilan habis waktu"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Usaha memanggil gagal"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Inisialisasi modem gagal"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Gagal memilih APN yang dinyatakan"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Tak mencari jaringan"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Pendaftaran jaringan ditolak"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Pendaftaran jaringan habis waktu"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Gagal mendaftar ke jaringan yang diminta"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Uji PIN gagal"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firmware yang diperlukan bagi perangkat mungkin hilang"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Koneksi aktif perangkat menghilang"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Koneksi perangkat kini diasumsikan"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem tak ditemukan"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Koneksi Bluetooth gagal"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Kartu SIM tak dipasang"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Perlu PIN SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Perlu PUK SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM salah"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Kebergantungan koneksi gagal"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Firmware hilang"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel tercabut"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "galat tak terdefinisi dalam keamanan 802.1x (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "tak ada berkas yang dipilih"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "galat tak dispesifikasikan saat memvalidasi berkas eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Kunci privat DER, PEM, PKCS#12, atau PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Sertifikat DER atau PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "kurang berkas PAC EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Berkas PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "kurang nama pengguna EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "kurang kata sandi EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "sertifikat CA EAP-PEAP tak valid: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "sertifikat CA EAP-PEAP tak valid: tak ada sertifikat yang dinyatakan"
+
+#~ msgid "missing EAP username"
+#~ msgstr "kurang nama pengguna EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "kurang kata sandi EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "kurang identitas EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "sertifikat CA EAP-TLS tak valid: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "sertificat CA EAP-TLS tak valid: tak ada sertifikat yang dinyatakan"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "kunci privat EAP-TLS tak valid: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "sertifikat pengguna CA EAP-TLS tak valid: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Kunci privat tak tersandi itu tidak aman"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Kunci pribadi yang dipilih sepertinya tidak dilindungi oleh kata sandi. "
+#~ "Ini dapat menyebabkan kredensial keamanan Anda disalahgunakan. Silakan "
+#~ "pilih kunci pribadi yang diamankan oleh sandi.\n"
+#~ "\n"
+#~ "(Anda dapat melindungi kunci pribadi Anda dengan openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Pilih sertifikat pribadi Anda"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Pilih kunci privat Anda"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "sertifikat CA EAP-TTLS tak valid: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "sertificat CA EAP-TTLS tak valid: tak ada sertifikat yang dinyatakan"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Galat tak diketahui saat memvalidasi keamanan 802.1x"
+
+#~ msgid "Select a file"
+#~ msgstr "Pilih berkas"
+
+#~ msgid "missing leap-username"
+#~ msgstr "kurang leap-username"
+
+#~ msgid "missing leap-password"
+#~ msgstr "kurang leap-password"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Kata sandi Wi-Fi hilang."
+
+#~ msgid "missing wep-key"
+#~ msgstr "kurang wep-key"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "wep-key tak valid: kunci dengan panjang %zu mesti hanya memuat dijit heksa"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "wep-key tak valid: kunci dengan panjang %zu mesti hanya memuat karakter "
+#~ "ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "wep-key tak valid: panjang kunci %zu salah. Suatu kunci mesti sepanjang "
+#~ "5/13 (ascii) atau 10/26 (heksa)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "wep-key tak valid: frasa sandi tidak boleh kosong"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "wep-key tak valid: frasa sandi mesti kurang dari 64 karakter"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk tak valid: panjang kunci %zu tak valid. Mesti [8,63] byte atau 64 "
+#~ "dijit heksa"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk tak valid: tak bisa interpretasikan kunci dengan 64 byte sebagai "
+#~ "heksa"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Lainnya"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s dihapus"
+
+#~ msgid "Error removing account"
+#~ msgstr "Galat saat menghapus akun"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Akun %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Hapus Akun"
+
+#~ msgid "Unknown time"
+#~ msgstr "Waktu tak diketahui"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s sampai terisi penuh"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Hati-hati: %s tersisa"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s tersisa"
+
+#~ msgid "Fully charged"
+#~ msgstr "Terisi penuh"
+
+#~ msgid "Not charging"
+#~ msgstr "Tidak Mengisi"
+
+#~ msgid "Empty"
+#~ msgstr "Kosong"
+
+#~ msgid "Charging"
+#~ msgstr "Mengisi"
+
+#~ msgid "Discharging"
+#~ msgstr "Mengosongkan"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Tetikus nirkabel"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Papan tik nirkabel"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Pasokan tenaga tak putus"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Asisten dijital pribadi"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telepon seluler"
+
+#~ msgid "Media player"
+#~ msgstr "Pemutar media"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Komputer"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Perangkat masukan permainan"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Utama"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Ekstra"
+
+#~ msgid "Batteries"
+#~ msgstr "Batera"
+
+#~ msgid "When _idle"
+#~ msgstr "Ket_ika menganggur"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspensi"
+
+#~ msgid "Power Off"
+#~ msgstr "Matikan"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernasi"
+
+#~ msgid "Nothing"
+#~ msgstr "Bukan apapun"
+
+#~ msgid "When on battery power"
+#~ msgstr "Ketika memakai baterai"
+
+#~ msgid "When plugged in"
+#~ msgstr "Ketika ditancapkan"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Tak pernah"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Suspensi otomatis"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Mode kinerja dinonaktifkan sementara karena suhu pengoperasian yang "
+#~ "tinggi."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Putaran terdeteksi: mode kinerja untuk sementara tidak tersedia. "
+#~ "Pindahkan perangkat ke permukaan yang stabil untuk memulihkan."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Mode kinerja dinonaktifkan untuk sementara."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Baterai rendah: penghemat daya diaktifkan. Mode sebelumnya akan "
+#~ "dipulihkan ketika baterai terisi cukup."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Mode Penghemat Daya diaktifkan oleh \"%s\"."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Mode kinerja diaktifkan oleh \"%s\"."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Kinerja"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Kinerja tinggi dan penggunaan daya."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Seimbang"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Kinerja standar dan penggunaan daya."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Penghemat Daya"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Kurangi kinerja dan penggunaan daya."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Pencetak “%s” telah dihapus"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Gagal menambah pencetak baru."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Tak dapat memuat ui: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Buka Kunci untuk Menambahkan Pencetak dan Mengubah Pengaturan"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Rincian %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Tak ditemukan penggerak yang cocok"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Pilih Berkas PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Berkas Deskripsi Pencetak PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Pencetak JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Pencetak LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Satu Sisi"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Sisi Panjang (Standar)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Sisi Pendek (Putar)"
+
+#~ msgid "Portrait"
+#~ msgstr "Potret"
+
+#~ msgid "Landscape"
+#~ msgstr "Landskap"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Lansekap terbalik"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Potret terbalik"
+
+#~ msgid "Resume"
+#~ msgstr "Lanjutkan"
+
+#~ msgid "Pause"
+#~ msgstr "Jeda"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Ditunda"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Diistirahatkan"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Perlu autentikasi"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Diproses"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Berhenti"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Batal"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Dibatalkan"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Selesai"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Pindahkan pekerjaan ini ke urutan teratas antrean"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Tugas Aktif"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Masukkan kredensial untuk mencetak dari %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Pilih Peladen Pencetak"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Buka Kunci %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Masukkan nama pengguna dan kata sandi Anda untuk melihat pencetak pada %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Mencari Pencetak"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Porta Serial"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Porta Paralel"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Lokasi: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Alamat: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Server memerlukan autentikasi"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dua Sisi"
+
+#~ msgid "Paper Type"
+#~ msgstr "Jenis Kertas"
+
+#~ msgid "Paper Source"
+#~ msgstr "Sumber Kertas"
+
+#~ msgid "Output Tray"
+#~ msgstr "Baki Keluaran"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolusi"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Pra penapisan GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Halaman per sisi"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientasi"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Umum"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Penyiapan Halaman"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opsi Dapat Dipasang"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Tugas"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Kualitas Gambar"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Warna"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Menyelesaikan"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Tingkat Lanjut"
+
+#~ msgid "Test page"
+#~ msgstr "Halaman uji"
+
+#~ msgid "Auto Select"
+#~ msgstr "Pilih Otomatis"
+
+#~ msgid "Printer Default"
+#~ msgstr "Pencetak Baku"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Tempelkan fonta GhostScript saja"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Konversi ke PS tingkat 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Konversi ke PS tingkat 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Tanpa pra penapisan"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Bersihkan kepala cetak"
+
+#~ msgid "Out of toner"
+#~ msgstr "Pewarna habis"
+
+#~ msgid "Low on developer"
+#~ msgstr "Developer sedikit"
+
+#~ msgid "Out of developer"
+#~ msgstr "Developer habis"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Asupan penanda sedikit"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Asupan penanda habis"
+
+#~ msgid "Open cover"
+#~ msgstr "Buka penutup"
+
+#~ msgid "Open door"
+#~ msgstr "Buka pinta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Kertas sedikit"
+
+#~ msgid "Out of paper"
+#~ msgstr "Kertas habis"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Luring"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Dihentikan"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Penampung sampah hampir penuh"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Penampung sampah penuh"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Penghantar foto optik hampir mati"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Penghantar foto optik tak berfungsi lagi"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Siap"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Tak menerima tugas"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Memroses"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Kerajaan"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrik"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Tanya apa yang akan dilakukan"
+
+#~ msgid "Do nothing"
+#~ msgstr "Jangan lakukan apa pun"
+
+#~ msgid "Open folder"
+#~ msgstr "Buka folder"
+
+#~ msgid "Other Media"
+#~ msgstr "Media Lain"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Pilih aplikasi bagi CD musik"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Pilih aplikasi bagi DVD video"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Pilih aplikasi yang dijalankan ketika pemutar musik disambungkan"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Pilih aplikasi yang dijalankan ketika kamera disambungkan"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Pilih aplikasi bagi CD perangkat lunak"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD audio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "diska Blu-ray kosong"
+
+#~ msgid "blank CD disc"
+#~ msgstr "diska CD kosong"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "diska DVD kosong"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "diska HD DVD kosong"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Diska video Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "pembaca e-book"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Diska video HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD gambar"
+
+#~ msgid "Super Video CD"
+#~ msgstr "CD Super Video"
+
+#~ msgid "Video CD"
+#~ msgstr "CD video"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Layar Dimatikan"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 detik"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 menit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 menit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 menit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 menit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 menit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 jam"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 menit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 menit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 menit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 menit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 menit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 menit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 menit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 menit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 menit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Tak pernah"
+
+#~ msgid "Select Location"
+#~ msgstr "Pilih Lokasi"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Tak menemukan aplikasi"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Tiada jaringan yang dipilih untuk berbagi"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Nyala"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Mati"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Diaktifkan"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktif"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Pilih Folder"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Aktifkan berbagi media"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Berbagi Pakai Berkas memungkinkan Anda berbagi pakai folder Publik Anda "
+#~ "dengan orang lain pada jaringan Anda kini memakai: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Bila log masuk jarak jauh difungsikan, pengguna jarak jauh dapat "
+#~ "menyambung memakai perintah Secure Shell:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Aktifkan berbagi media pribadi"
+
+#~ msgid "Device name copied"
+#~ msgstr "Nama perangkat disalin"
+
+#~ msgid "Device address copied"
+#~ msgstr "Alamat perangkat disalin"
+
+#~ msgid "Username copied"
+#~ msgstr "Nama pengguna disalin"
+
+#~ msgid "Password copied"
+#~ msgstr "Kata sandi disalin"
+
+#~ msgid "Custom"
+#~ msgstr "Gubahan"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Menguji %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Terputus"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Menyambung"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Tersambung"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Galat Autorisasi"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Mengotorisasi"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Fungsionalitas Dikurangi"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Tersambung & Terotorisasi"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Tidak Diketahui"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Diotorisasi di:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Tersambung pada:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Terdaftar di:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Gagal mengotorisasi perangkat: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Gagal melupakan perangkat: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Galat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Terotorisasi"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Subsistem Thunderbolt (boltd) tidak dipasang atau tidak diatur dengan "
+#~ "benar."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Hanya perangkat USB dan Display Port yang dapat dipasang."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt tidak dapat dideteksi.\n"
+#~ "Entah sistem tidak memiliki dukungan Thunderbolt, hal itu telah "
+#~ "dinonaktifkan di BIOS atau diatur ke tingkat keamanan yang tidak didukung "
+#~ "di BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Dukungan Thunderbolt telah dinonaktifkan di BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Tingkat keamanan thunderbolt tidak dapat ditentukan."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Galat saat mengalihkan mode langsung: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Bawaan"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Sedang"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Besar"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Lebih Besar"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Terbesar"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d piksel"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Pendek"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ Layar"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ Layar"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ Layar"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Panjang"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 jam"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 hari"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Kosongkan semua butir dari Tempat Sampah?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Semua butir dalam Tempat Sampah akan dihapus secara permanen."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Kosongkan Tempat Sampah"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Hapus semua berkas temporer?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Semua berkas temporer akan dihapus secara permanen."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Bersihkan Berkas Tem_porer"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 hari"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 hari"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 hari"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Selamanya"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Mesti cocok dengan alamat web dari penyedia log masuk Anda."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Gagal menambah akun"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Gagal mendaftarkan akun"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Tak ada cara yang didukung untuk mengautentikasi dengan domain ini"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Gagal bergabung ke domain"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Nama log masuk itu tak bekerja.\n"
+#~ "Harap coba lagi."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Kata sandi log masuk itu tak bekerja.\n"
+#~ "Harap coba lagi."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Gagal log masuk domain"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Tak bisa temukan domain. Mungkin Anda salah eja?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Ramban lebih banyak gambar"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "perangkat perlu diklaim untuk melakukan tindakan ini"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "perangkat sudah diklaim oleh proses lain"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "Anda tidak memiliki izin untuk melakukan tindakan"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "tidak ada sidik jari yang terdaftar"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Gagal berkomunikasi dengan perangkat selama pendaftaran"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Gagal berkomunikasi dengan pembaca sidik jari"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Gagal berkomunikasi dengan daemon sidik jari"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Gagal mencantumkan sidik jari: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Gagal menghapus sidik jari yang disimpan: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Jempol kiri"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Jari tengah kiri"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Telunjuk k_iri"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Jari manis kiri"
+
+#~ msgid "Left little finger"
+#~ msgstr "Kelingking kiri"
+
+#~ msgid "Right thumb"
+#~ msgstr "Jempol kanan"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Jari tengah kanan"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Telunjuk k_anan"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Jari manis kanan"
+
+#~ msgid "Right little finger"
+#~ msgstr "Kelingking kanan"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Jari Tidak Dikenal"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Komplit"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Perangkat sidik jari terputus"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Penyimpanan perangkat sidik jari penuh"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Gagal mendaftarkan sidik jari baru"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Gagal memulai pendaftaran: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Gagal mendaftarkan sidik jari baru"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Gagal menghentikan pendaftaran: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Angkat dan letakkan jari Anda berulang kali pada pembaca untuk "
+#~ "mendaftarkan sidik jari Anda"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Dafta_rkan ulang jari ini…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Pindai sidik jari baru"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Gagal melepaskan perangkat sidik jari %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Masalah pada Perangkat Membaca"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Gagal mengklaim perangkat sidik jari %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Gagal mendapatkan perangkat sidik jari: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Minggu Ini"
+
+#~ msgid "Last Week"
+#~ msgstr "Minggu Lalu"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sesi Berakhir"
+
+#~ msgid "Session Started"
+#~ msgstr "Sesi Dimulai"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Aktivitas Akun"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Silakan pilih kata sandi lain."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Silakan tik ulang kata sandi kini."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Kata sandi tak dapat diubah"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Tak bisa secara otomatis bergabung ke tipe domain ini"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Domain atau realm tersebut tak ditemukan"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Tak bisa log masuk sebagai %s pada domain %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Kata sandi salah, harap coba lagi"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Tak bisa menyambung ke domain %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Gagal menghapus pengguna"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Gagal mencabut pengguna yang dikelola jarak jauh"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Anda tak bisa menghapus akunmu sendiri."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s masih log masuk"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Menghapus pengguna saat mereka log masuk dapat menjerumuskan sistem ke "
+#~ "dalam keadaan tak konsisten."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Apakah Anda ingin mempertahankan berkas milik %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Dimungkinkan untuk mempertahankan direktori rumah, spool surel, dan "
+#~ "berkas temporer ketika menghapus suatu akun pengguna."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Hapus Berkas"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Biarkan Berkas"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Anda yakin ingin mencabut akun %s yang dikelola jarak jauh?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Hapus"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Akun dimatikan"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Untuk ditata saat log masuk berikutnya"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Tak ada"
+
+#~ msgid "Logged in"
+#~ msgstr "Log masuk"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Gagal menghubungi layanan akun"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Pastikan bahwa AccountService ini telah terpasang dan diaktifkan."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Panel ini harus dibuka untuk mengubah pengaturan ini"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Hapus akun pengguna yang dipilih"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Untuk menghapus akun pengguna yang dipilih,\n"
+#~ "pertama kali klik ikon *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Buka Kunci untuk Menambahkan Pengguna dan Mengubah Pengaturan"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Kata sandi baru perlu berbeda dengan yang lama."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Cobalah mengubah beberapa huruf dan angka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Cobalah mengubah kata sandi lebih banyak lagi."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Suatu kata sandi tanpa nama penggunamu akan lebih kuat."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Cobalah menghindari memakai nama Anda dalam kata sandi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Cobalah menghindari beberapa kata yang termasuk dalam kata sandi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Cobalah menghindari kata-kata umum."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Cobalah menghindari mengatur ulang urutan kata yang ada."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Cobalah memakai lebih banyak angka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Cobalah memakai lebih banyak huruf besar."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Cobalah memakai lebih banyak huruf kecil."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Cobalah memakai lebih banyak karakter khusus, seperti tanda baca."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Cobalah memakai campuran huruf, angka, dan tanda baca."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Cobalah menghindari pengulangan karakter yang sama."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Cobalah menghindari mengulang karakter bertipe sama: Anda perlu mencampur "
+#~ "huruf, angka, dan tanda baca."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Cobalah menghindari urutan seperti 1234 atau abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Kata sandi harus lebih panjang. Cobalah menambahkan lebih banyak huruf, "
+#~ "angka dan tanda baca."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Campurlah huruf besar dan kecil dan cobalah memakai satu atau dua angka."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Menambahkan lebih banyak huruf, angka dan tanda baca akan membuat kata "
+#~ "sandi lebih kuat."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autentikasi gagal"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Kata sandi baru terlalu pendek"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Kata sandi baru terlalu sederhana"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Kata sandi lama dan baru terlalu mirip"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Kata sandi baru pernah dipakai baru-baru ini."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Kata sandi baru harus mengandung angka atau karakter istimewa"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Kata sandi lama dan baru sama"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Kata sandi Anda telah diubah sejak dari Anda terautentikasi!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Kata sandi baru tidak memuat cukup banyak karakter berbeda"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Galat tak dikenal"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Nama pengguna hanya boleh terdiri dari huruf a-z besar dan kecil, angka, "
+#~ "dan karakter berikut: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Maaf, nama pengguna tersebut tidak tersedia. Harap coba yang lain."
+
+#~ msgid "The username is too long."
+#~ msgstr "Nama pengguna terlalu panjang."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Tombol %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Aplikasi yang didefinisikan"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Kirim Ketukan Tombol"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Tukar Monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Tampilkan Bantuan Pada Layar"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tablet dipasang pada panel laptop"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tablet yang dipasang pada layar eksternal"
+
+#~ msgid "External tablet device"
+#~ msgstr "Perangkat tablet eksternal"
+
+#~ msgid "All Displays"
+#~ msgstr "Semua Tampilan"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Stylus Airbrush dengan tekanan, kemiringan, dan slider terintegrasi"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Stylus airbrush dengan tekanan, kemiringan, dan rotasi"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Stylus standar dengan tekanan dan kemiringan"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Stylus standar dengan tekanan"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Pintasan baru…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operasi Dibatalkan"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Galat:</b> Akses ditolak saat mengubah pengaturan"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Galat:</b> Galat Peralatan Seluler"
+
+#~ msgid "Not Registered"
+#~ msgstr "Tidak Terdaftar"
+
+#~ msgid "Registered"
+#~ msgstr "Terdaftar"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Mencari"
+
+#~ msgid "Denied"
+#~ msgstr "Ditolak"
+
+#~ msgid "2G Only"
+#~ msgstr "Hanya 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Hanya 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Hanya 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Hanya 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (Disukai)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (Disukai), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (Disukai), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (Disukai), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Disukai)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Disukai), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Disukai), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (Disukai)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (Disukai), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (Disukai), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (Disukai)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (Disukai), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (Disukai), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 4G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (Disukai)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (Disukai), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (Disukai), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Disukai)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Disukai), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Disukai)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Disukai), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Disukai)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Disukai), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (Disukai)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (Disukai), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Disukai)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (Disukai), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (Disukai)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (Disukai), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Tak Dikenal"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Buka kunci kartu SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Harap berikan kode PIN untuk SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Masukkan PIN untuk membuka kunci kartu SIM Anda"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Harap berikan kode PUK untuk SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Masukkan PUK untuk membuka kunci kartu SIM Anda"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Kata sandi yang dimasukkan salah."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Kode PUK mesti berupa suatu angka 8 digit"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Masukkan PIN Baru"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Kode PIN mesti berupa suatu angka 4-8 digit"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Buka Kunci…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Kegagalan telepon"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Tidak ada koneksi ke telepon"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operasi tak diizinkan"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operasi tak didukung"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM tak dipasang"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Perlu PIN SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Perlu PUK SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Kegagalan SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM sibuk"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Kata sandi salah"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Perlu PIN2 SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Perlu PUK2 SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Tak ditemukan"
+
+#~ msgid "No network service"
+#~ msgstr "Tidak ada layanan jaringan"
+
+#~ msgid "Network timeout"
+#~ msgstr "Jaringan habis waktu"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Layanan GPS tak diizinkan"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming tak diizinkan di wilayah lokasi ini"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Galat GPS yang tak dinyatakan"
+
+#~ msgid "No Error"
+#~ msgstr "Tidak ada Galat"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Aksi Dibatalkan"
+
+#~ msgid "Access denied"
+#~ msgstr "Akses ditolak"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Galat Tak Dikenal"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Tampilkan nomor versi"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Aktifkan moda verbose"
+
+#~ msgid "Search for the string"
+#~ msgstr "Cari string"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Tampilkan daftar nama panel yang mungkin dan keluar"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel yang hendak ditampilkan"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMEN…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Panel yang tersedia:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Suara Sistem"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Galat: tidak dapat menentukan tingkat HSI."
 
 #~ msgid "Error: unable to determine Incorrect HSI level."
 #~ msgstr "Galat: tidak dapat menentukan tingkat HSI yang salah."
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Tambah Pencetak…"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "Sertifikat DER atau PEM  (*.der, *.pem, *.crt, *.cer)"
@@ -9819,11 +8509,11 @@ msgstr "Suara Sistem"
 #~ msgstr "Tidak bisa diubah"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "Izin individual untuk aplikasi dapat ditinjau dalam Pengaturan <a href="
-#~ "\"privacy\">Privasi</a>."
+#~ "Izin individual untuk aplikasi dapat ditinjau dalam Pengaturan <a "
+#~ "href=\"privacy\">Privasi</a>."
 
 #~ msgid "Integration"
 #~ msgstr "Integrasi"
@@ -9957,9 +8647,6 @@ msgstr "Suara Sistem"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablet (absolut)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Touchpad (relatif)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Preferensi Tablet"

--- a/po/id.po~
+++ b/po/id.po~
@@ -1,0 +1,10105 @@
+# Terjemahan Bahasa Indonesia dari gnome-control-center
+# Copyright (C) 2003 gnome-control-center's copyright holder
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Mohammad DAMT <mdamt@bisnisweb.com>, 2003.
+# Ahmad Riza H Nst  <rizahnst@gnome.org>, 2006.
+# Dirgita <dirgitadevina@yahoo.co.id>, 2010, 2012, 2014.
+# Andika Triwidada <andika@gmail.com>, 2009, 2011-2015, 2017, 2021.
+# Kukuh Syafaat <kukuhsyafaat@gnome.org>, 2017-2022.
+# Sofyan Sugianto <ssugianto@gnome.org>, 2020
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"PO-Revision-Date: 2022-08-26 09:03+0700\n"
+"Last-Translator: Kukuh Syafaat <kukuhsyafaat@gnome.org>\n"
+"Language-Team: Indonesian <gnome-l10n-id@googlegroups.com>\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Bus Sistem"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Akses penuh"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Bus Sesi"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Perangkat"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Akses penuh ke /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Jaringan"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Memiliki akses jaringan"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Rumah"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Hanya-baca"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Sistem Berkas"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Pengaturan"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Dapat mengubah pengaturan"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s memiliki izin berikut sebagai bawaan. Ini tidak dapat diubah. Jika Anda "
+"khawatir tentang izin ini, pertimbangkan untuk menghapus aplikasi ini."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u jenis berkas dan tautan yang dibuka oleh aplikasi"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> digunakan untuk membuka jenis berkas dan tautan berikut."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s ruang diska yang digunakan."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplikasi"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Tidak ada aplikasi"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Pasang beberapa…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Buka"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Tampilkan Rincian"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Cari"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Menerima pencarian sistem dan mengirim hasil."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Dimatikan"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notifikasi"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Tampilkan notifikasi sistem."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Jalankan di Latar Belakang"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Izinkan aktivitas saat aplikasi ditutup."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Cuplikan Layar"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Ambil gambar layar kapan saja."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Ubah Gambar Latar"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Ubah gambar latar destop."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Suara"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Mereproduksi suara."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Menghambat Pintasan"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Blokir pintasan papan tik standar."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Ambil gambar dengan kamera."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Rekam audio dengan mikrofon."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Layanan Lokasi"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Akses data lokasi perangkat."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Izin Bawaan"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Akses sistem yang diperlukan oleh aplikasi"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Asosiasi Berkas &amp; Tautan"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Penyimpanan"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Hasil tak ditemukan"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Cobalah pencarian lain"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Asosiasi Berkas & Tautan"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Jenis Berkas"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Jenis Tautan"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Atur Ulang"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Berapa banyak ruang diska yang ditempati aplikasi ini dengan data aplikasi "
+"dan tembolok."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplikasi"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Tembolok"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Bersihkan Tembolok…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Kontrol berbagai izin dan pengaturan aplikasi"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplikasi;flatpak;izin;pengaturan;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Pilih gambar"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Ba_tal"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Buka"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "ukuran berganda"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Tanpa Latar Belakang Desktop"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Latar belakang kini"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Gaya"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Bawaan"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Gelap"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Latar Belakang"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Tambah Gambar…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Penampilan"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Ubah gambar latar belakang Anda atau warna antarmuka"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Latar Belakang; Layar;Destop; Gaya; Terang;Gelap; Penampilan;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Aktifkan"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Bluetooth Tidak Ditemukan"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Tancapkan sebuah dongle untuk memakai Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth Dimatikan"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Nyalakan untuk menyambungkan perangkat dan menerima transfer berkas."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Mode Pesawat Terbang Aktif"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth dinonaktifkan ketika mode pesawat aktif."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Matikan Mode Pesawat Terbang"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Mode Pesawat Terbang Perangkat Keras Aktif"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Matikan saklar mode Pesawat Terbang untuk memfungsikan Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Nyalakan dan matikan Bluetooth dan sambungkan perangkat Anda"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "berbagi;bluetooth;obex;bersama;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera Dimatikan"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Tak menemukan aplikasi untuk mengambil foto atau video."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Penggunaan kamera memungkinkan aplikasi untuk mengambil foto dan video. "
+"Menonaktifkan kamera dapat menyebabkan beberapa aplikasi tidak berfungsi "
+"dengan benar.\n"
+"\n"
+"Izinkan aplikasi di bawah ini menggunakan kamera Anda."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Tidak Ada Aplikasi yang Meminta Akses Kamera"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Lindungi gambar Anda"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "kamera;foto;video;kamera web;kunci;pribadi;privasi;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Tempatkan perangkat kalibrasi di atas kotak dan tekan '\"Mulai'\""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Pindahkan perangkat kalibrasi ke posisi kalibrasi dan tekan \"Lanjutkan\""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Pindahkan perangkat kalibrasi ke posisi permukaan dan tekan \"Lanjutkan\""
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Tutup lid laptop"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Terjadi galat internal yang tak dapat dipulihkan."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Perkakas yang diperlukan untuk kalibrasi tak terpasang."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Profil tak dapat dijangkitkan."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Titik putik target tak dapat dicapai."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Komplit!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrasi gagal!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Anda dapat melepas perangkat kalibrasi."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Jangan mengganggu perangkat kalibrasi ketika tengah berlangsung"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Kalibrasi Tampilan"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Mulai"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "Lanjut_kan"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Selesai"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Layar Laptop"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Webcam Bawaan"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Pelarik %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Kamera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Pencetak %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webcam %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Fungsikan manajemen warna bagi %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Tampilkan profil warna bagi %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Tak dikalibrasi"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Baku: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Ruang warna: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Profil uji: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Pilih Berkas Profil ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Impor"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Profil ICC yang didukung"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Semua berkas"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Layar"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Simpan profil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Simpan"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Buat profil warna bagi perangkat yang dipilih"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Instrumen pengukur tak terdeteksi. Silakan periksa apakah sudah dinyalakan "
+"dari disambung dengan benar."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Instrumen pengukur tak mendukung pembuatan profil pencetak."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Jenis perangkat belum didukung."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Kalibrasi Layar"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kualitas Kalibrasi"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrasi akan menghasilkan suatu profil yang dapat Anda pakai untuk "
+"mengelola warna layar Anda. Lebih lama waktu yang Anda habiskan pada "
+"kalibrasi, kualitas dari profil warna akan lebih baik."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Anda tak akan bisa memakai komputer Anda ketika kalibrasi dilangsungkan."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kualitas"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Waktu Kira-kira"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Perangkat Kalibrasi"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Pilih perangkat sensor yang ingin Anda pakai untuk kalibrasi."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tipe Tampilan"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Pilih tipe tampilan yang tersambung."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Titik Putih Profil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Pilih suatu titik putih target tampilan. Kebanyakan tampilan mesti "
+"dikalibrasi ke iluminan D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Kecerahan Tampilan"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Harap atur tampilan ke suatu kecerahan yang biasa Anda pakai. Manajemen "
+"warna akan paling akurat pada tingkat kecerahan ini."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Sebagai alternatif, Anda dapat memakai tingkat kecerahan yang dipakai dengan "
+"satu dari profil lain bagi perangkat ini."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nama Profil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Anda dapat memakai suatu profil warna pada komputer lain, atau bahkan "
+"membuat profil bagi kondisi pencahayaan lain."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nama Profil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Ringkasan"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil sukses dibuat!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Salin profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Memerlukan media yang dapat ditulisi"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Mungkin instruksi tentang bagaimana memakai profil pada sistem <a href="
+"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a>, dan <a href="
+"\"windows\">Microsoft Windows</a> ini berguna."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Tambah profil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Masalah terdeteksi. Profil mungkin tak bekerja dengan benar. <a href="
+"\"\">Tampilkan rincian.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Impor Berkas…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "T_ambah"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Setiap perangkat perlu profil warna terkini untuk menjadi terkelola warnanya."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Pelajari lebih jauh"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Pelajari lebih jauh tentang manajemen warna"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Tata bagi _semua pengguna"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Tata profil ini bagi semua pengguna pada komputer ini"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "Akti_fkan"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "T_ambah profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrasi…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibrasikan perangkat"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Hapus p_rofil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "Lihat rin_cian"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Tak bisa mendeteksi sebarang perangkat yang dapat dikelola warnanya"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Proyektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (cahaya latar CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (cahaya lagar LED RGB)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (cahaya latar LED putih)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD gamut lebar (cahaya latar CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD gamut lebar (cahaya latar LED RGB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Tinggi"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 menit"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Sedang"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 menit"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Rendah"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 menit"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Asli ke tampilan"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Pencetakan dan penerbitan)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografi and grafis)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Ruang Standar"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Profil Uji"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Otomatis"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Kualitas Rendah"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Kualitas Sedang"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Kualitas Tinggi"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB bawaan"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK bawaan"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Kelabu bawaan"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Data kalibrasi dari pabrik yang disediakan oleh vendor"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Koreksi tampilan layar penuh tak mungkin dengan profil ini"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Profil ini mungkin tidak akurat lagi"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Warna"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Kalibrasikan warna perangkat Anda, seperti monitor, kamera, atau pencetak"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Warna;ICC;Profil;Kalibrasi;Pencetak;Tampilan;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Lainnya…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Pilih Bahasa"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Pilih"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Tak ada bahasa yang ditemukan"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Lebih banyak…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Buka Kunci untuk Mengubah Pengaturan"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Beberapa pengaturan harus dibuka kuncinya sebelum dapat diubah."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Buka Kunci…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Naikkan Jam"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Naikkan Menit"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Waktu"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Turunkan Jam"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Turunkan Menit"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Hari ini"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Kemarin"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d jam"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d menit"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d detik"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 detik"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-jam"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Tanggal & Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Tahun"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Bulan"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januari"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februari"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Maret"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mei"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juni"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juli"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Agustus"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Desember"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Hari"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Zona Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Cari kota"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Tanggal &amp; Waktu Otomatis"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Memerlukan koneksi Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Tanggal &amp; Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "_Zona Waktu Otomatis"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Membutuhkan layanan lokasi diaktifkan dan akses internet"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Diaktifkan"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Z_ona Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Format Waktu"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Ubah tanggal dan waktu, termasuk zona waktu"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Jam;Zona waktu;Lokasi;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Ubah pengaturan waktu dan tanggal sistem"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Untuk mengubah tatanan waktu atau tanggal, Anda perlu diautentikasi."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Surel"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalender"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usik"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Foto"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplikasi Baku"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Mengkonfigurasi Aplikasi Bawaan"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "bawaan;aplikasi;disukai;media;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Mengirim laporan masalah teknis membantu kami memperbaiki %s. Laporan "
+"dikirim secara anonim dan dibersihkan dari data pribadi. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Pelaporan Masalah"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Pelaporan Masalah Otom_atis"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostik"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Laporkan masalah Anda"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostik;kres;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Nyala"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Mati"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Terapkan Perubahan?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Perubahan Tidak Dapat Diterapkan"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Ini mungkin karena keterbatasan perangkat keras."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "Ter_apkan"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Mundur"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Pengaturan Tampilan Dinonaktifkan"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Beberapa Tampilan"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Gabung"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Cermin"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Berisi bilah atas dan Aktivitas"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Tampilan Primer"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Terang Malam"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Landsekap"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Potret Kanan"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Potret Kiri"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Landsekap (dijungkir)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientasi"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolusi"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Laju Penyegaran"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Setel untuk TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skala"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Terang Malam tidak tersedia"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Ini bisa jadi hasil dari penggerak grafis yang digunakan, atau destop yang "
+"digunakan dari jarak jauh"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Sementara Dinonaktifkan Sampai Besok"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Mulai Ulang Filter"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Cahaya malam membuat warna layar lebih hangat. Ini dapat membantu mencegah "
+"mata tegang dan mengantuk."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Jadwal"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Matahari Terbenam sampai Terbit"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Jadwal Manual"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Waktu"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Dari"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Jam"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Menit"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Dari"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatur Warna"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Tampilan"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Pilih bagaimana menggunakan monitor dan proyektor yang tersambung"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Proyektor;xrandr;Layar;Resolusi;Segarkan;Monitor;Malam;Terang;Biru;"
+"redshift;warna;matahari terbit;matahari tenggelam;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:109
+msgid "Secure Boot is Active"
+msgstr "Secure Boot Aktif"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat mulai. "
+"Saat ini dihidupkan dan berfungsi dengan benar."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Secure Boot Memiliki Masalah"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat mulai. "
+"Saat ini dihidupkan, tetapi tidak akan berfungsi karena memiliki kunci yang "
+"tidak valid."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Masalah secure boot seringkali dapat diselesaikan dari pengaturan perangkat "
+"tegar UEFI (BIOS) komputer Anda dan produsen perangkat keras Anda dapat "
+"memberikan informasi tentang cara melakukannya."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Untuk bantuan, hubungi produsen perangkat keras atau penyedia dukungan TI "
+"Anda."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Secure Boot Dimatikan"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat mulai. "
+"Saat ini dihidupkan dan berfungsi dengan benar."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Secure boot sering kali dapat dihidupkan dari pengaturan perangkat tegar "
+"UEFI (BIOS) komputer Anda. Untuk bantuan, hubungi produsen perangkat keras "
+"atau penyedia dukungan TI Anda."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Secure boot mencegah perangkat lunak berbahaya dimuat saat perangkat mulai.\n"
+"\n"
+"Untuk informasi lebih lanjut, hubungi produsen perangkat keras atau dukungan "
+"TI."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Lulus"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Gagal"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Perangkat sesuai dengan tingkat HSI %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:482
+msgid "Security Level 0"
+msgstr "Tingkat Keamanan 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Perangkat ini tidak memiliki perlindungan terhadap masalah keamanan "
+"perangkat keras. Ini bisa jadi karena masalah konfigurasi perangkat keras "
+"atau perangkat tegar. Disarankan untuk menghubungi penyedia dukungan TI Anda."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:489
+msgid "Security Level 1"
+msgstr "Tingkat Keamanan 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Perangkat ini memiliki perlindungan minimal terhadap masalah keamanan "
+"perangkat keras. Ini adalah tingkat keamanan perangkat terendah dan hanya "
+"memberikan perlindungan terhadap ancaman keamanan sederhana."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:496
+msgid "Security Level 2"
+msgstr "Tingkat Keamanan"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Perangkat ini memiliki perlindungan dasar terhadap masalah keamanan "
+"perangkat keras. Ini memberikan perlindungan terhadap beberapa ancaman "
+"keamanan umum."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:503
+msgid "Security Level 3"
+msgstr "Tingkat Keamanan 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Perangkat ini telah memperluas perlindungan terhadap masalah keamanan "
+"perangkat keras. Ini adalah tingkat keamanan perangkat tertinggi dan "
+"memberikan perlindungan terhadap ancaman keamanan tingkat lanjut."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:518
+msgid "Security Level"
+msgstr "Tingkat Keamanan"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:519
+msgid "Security levels are not available for this device."
+msgstr "Tingkat keamanan tidak tersedia untuk perangkat ini."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Hubungi produsen perangkat keras Anda untuk mendapatkan bantuan terkait "
+"pemutakhiran keamanan."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Dimungkinkan untuk mengatasi masalah ini di pengaturan perangkat tegar UEFI "
+"perangkat, atau oleh teknisi dukungan."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Dimungkinkan untuk mengatasi masalah ini di pengaturan perangkat tegar UEFI "
+"perangkat."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Mungkin saja teknisi dukungan dapat mengatasi masalah ini."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Level 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Level 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Level 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:110
+msgid "Protected against malicious software when the device starts."
+msgstr "Dilindungi dari perangkat lunak berbahaya saat perangkat dimulai."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:116
+msgid "Secure Boot has Problems"
+msgstr "Secure Boot memiliki Masalah"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:117
+msgid "Some protection when the device is started."
+msgstr "Beberapa perlindungan saat perangkat dimulai."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:122
+msgid "Secure Boot is Off"
+msgstr "Secure Boot Dimatikan"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:123
+msgid "No protection when the device is started."
+msgstr "Tidak ada perlindungan saat perangkat dimulai."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:142
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Masalah ini bisa disebabkan oleh perubahan pengaturan perangkat tegar UEFI, "
+"perubahan konfigurasi sistem operasi, atau karena perangkat lunak berbahaya "
+"pada sistem ini."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:150
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Masalah ini bisa disebabkan oleh perubahan dalam pengaturan perangkat tegar "
+"UEFI, atau karena perangkat lunak berbahaya pada sistem ini."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:157
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Masalah ini bisa disebabkan oleh perubahan konfigurasi sistem operasi, atau "
+"karena perangkat lunak berbahaya pada sistem ini."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:483
+msgid "Exposed to serious security threats."
+msgstr "Rentan terhadap ancaman keamanan."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:490
+msgid "Limited protection against simple security threats."
+msgstr "Perlindungan terbatas terhadap ancaman keamanan sederhana."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:497
+msgid "Protected against common security threats."
+msgstr "Dilindungi dari ancaman keamanan umum."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:504
+#: panels/firmware-security/cc-firmware-security-panel.c:512
+msgid "Protected against a wide range of security threats."
+msgstr "Dilindungi dari berbagai ancaman keamanan."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:511
+msgid "Comprehensive Protection"
+msgstr "Perlindungan Komprehensif"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Tak Ada Acara"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Perlindungan Tulis Perangkat Tegar"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Kunci Perlindungan Tulis Perangkat Tegar"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Wilayah Perangkat Tegar BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Deskriptor Perangkat Tegar BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Perlindungan DMA Pra-Boot"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Boot Terverifikasi Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM Dilindungi"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Kebijakan Kesalahan Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Fuse Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET Diaktifkan"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET Aktif"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "RAM terenkripsi"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Perlindungan IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Penguncian Kernel Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Verifikasi Kernel Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Swap Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Suspensi Ke RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Suspensi Ke Diam"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Kunci Platform UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Secure Boot UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Konfigurasi Platform TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Rekonstruksi TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Mode Pembuatan Mesin Manajemen Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Penggantian Mesin Manajemen Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Versi Mesin Manajemen Intel"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Pemutakhiran Perangkat Tegar"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Pengesahan Perangkat Tegar"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Verifikasi Pemutakhiran Perangkat Tegar"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Platform Pengawakutuan"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Pemeriksaan Keamanan Prosesor"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Perlindungan Rollback AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Perlindungan Replay Perangkat Tegar AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Perlindungan Tulis Perangkat Tegar AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Platform yang Menyatu"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Sah"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Tidak Valid"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Tidak Diaktifkan"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Terkunci"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Tidak Terkunci"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Dienkripsi"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Tidak Dienkripsi"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Tercemar"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Tidak Tercemar"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Ditemukan"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Tidak ditemukan"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Didukung"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Tidak Didukung"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Keamanan Perangkat"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Status keamanan firmware host"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"layar;kunci;diagnostik;crash;privat;terkini;temporer;tmp;indeks;nama;"
+"jaringan;identitas;privasi;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Unknown"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Tidak diketahui"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Tidak Tersedia"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo Sistem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nama Perangkat"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Model Perangkat Keras"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memori"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Prosesor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafik"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Kapasitas Diska"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Menghitung…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nama Sistem Operasi"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID Build OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tipe Sistem Operasi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Versi GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Memuat…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Sistem Jendela"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisasi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Pembaruan Perangkat Lunak"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Ubah Nama Perangkat"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Nama perangkat digunakan untuk mengidentifikasi perangkat ini ketika dilihat "
+"dalam jaringan, atau ketika memadukan perangkat Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nama perangkat"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "U_bah Nama"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Ihwal"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Tilik informasi tentang sistem Anda"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"perangkat;sistem;informasi;nama host;memori;prosesor;versi;baku;aplikasi;"
+"disukai;cd;dvd;usb;audio;video;cakram;dapat dicopot;media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Suara dan Media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Volume bisu/suarakan"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Kecilkan volume"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Besarkan volume"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Mikrofon bisu/suarakan"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Luncurkan pemutar media"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Putar (atau putar/istirahat)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Jeda memutar"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Berhenti memutar"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Trek sebelumnya"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Trek selanjutnya"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Keluarkan"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Mengetik"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Pindah ke sumber masukan selanjutnya"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Pindah ke sumber masukan sebelumnya"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Peluncur"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Tampilkan layar bantuan"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Luncurkan kalkulator"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Luncurkan klien surel"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Tampilkan peramban web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Folder rumah"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Cari"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistem"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Log keluar"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Kunci layar"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Aksesibilitas"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Nyalakan atau matikan zum"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Perbesar"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Perkecil"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Nyalakan atau matikan pembaca layar"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Nyalakan atau matikan papan tik di layar"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Perbesar ukuran teks"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Perkecil ukuran teks"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Nyalakan atau matikan kontras tinggi"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Sumber masukan tak ditemukan"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Lainnya"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Tambah Sumber Masukan"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Metoda masukan tak dapat dipakai pada layar log masuk"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Tak ada sumber masukan yang dipilih"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opsi"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Naik"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Turun"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferensi"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Tampilkan Tata Letak Papan Tik"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Hapus"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Tombol Pintas Gubahan"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tombol Karakter Alternatif"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Tombol karakter alternatif dapat digunakan untuk memasukkan karakter "
+"tambahan. Tombol ini biasanya dicetak sebagai opsi ketiga pada keyboard Anda."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt Kiri"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt Kanan"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super Kiri"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super Kanan"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tombol menu"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl Kanan"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tombol Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Tombol tulis memungkinkan berbagai macam karakter untuk dimasukkan. Untuk "
+"menggunakannya, tekan buat lalu masukkan karakter.  Misalnya, tombol tulis "
+"diikuti dengan <b>C</b> dan <b>o</b> akan menjadi <b>©</b>, <b>a</b> diikuti "
+"oleh <b> '</b> akan menjadi <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Sumber masukan dapat dialihkan menggunakan pintasan papan tik %s Anda.\n"
+"Ini dapat diubah di pengaturan pintasan papan tik."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Sumber Masukan"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Termasuk tata letak papan tik dan metode masukan."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Pengalihan Sumber Masukan"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Gunakan sumber yang _sama untuk semua jendela"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Ganti sumber masukan satu per satu untuk set_iap jendela"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Entri Karakter Khusus"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Metode untuk memasukkan simbol dan varian huruf menggunakan papan tik."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Tombol Pintas"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Tampilkan dan Ubah Pintasan"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d diubah"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Atur Ulang Semua Pintasan?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Atur ulang pintasan dapat mempengaruhi cara pintasan gubahan Anda. Hal ini "
+"tidak dapat dibatalkan."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Batal"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Atur Ulang Semua"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Atur Ulang Semua…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Atur ulang semua pintasan ke keybindings bawaan"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Bagian"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Pintasan"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Tambah pintasan"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Tambah Pintasan Gubahan"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Siapkan pintasan khusus untuk meluncurkan aplikasi, menjalankan skrip, dan "
+"lainnya."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Tambah Pintasan"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Tak ditemukan tombol pintas"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s telah dipakai untuk %s. Jika Anda menggantinya, %s akan dinonaktifkan"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Masukkan pintasan baru"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Atur Pintasan Ubahan"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Atur Pintasan"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Masukkan pintasan baru untuk mengubah %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Tambah Pintas Gubahan"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Hapus"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Gantikan"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "A_tur"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Tekan Esc untuk membatalkan atau Backspace untuk menonaktifkan pintasan "
+"papan tik."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nama"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Perintah"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Pintasan"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Atur Pintasan…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Tak Ada"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Tata ulang pintasan ke nilai baku"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Papan Ketik"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Ubah pintasan papan tik dan atur preferensi pengetikan, tata letak papan "
+"tik, dan sumber masukan"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Pintasan;Ruang Kerja;Jendela;Ubah Ukuran;Zum;Kontras;Masukan;Sumber;Kunci;"
+"Volume;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Layanan Lokasi Dimatikan"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Tak menemukan aplikasi untuk memperoleh informasi lokasi."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Layanan lokasi memungkinkan aplikasi mengetahui lokasi Anda. Menggunakan Wi-"
+"Fi dan broadband seluler meningkatkan akurasi.\n"
+"\n"
+"Menggunakan Layanan Lokasi Mozilla: <a href='https://location.services."
+"mozilla.com/privacy'>Kebijakan Privasi</a>\n"
+"\n"
+"Izinkan aplikasi di bawah ini untuk menentukan lokasi Anda."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Tak Ada Aplikasi yang Meminta Akses Lokasi"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Lindungi informasi lokasi Anda"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "lokasi;gps;pribadi;privasi;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofon Dimatikan"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Tak menemukan aplikasi untuk merekam suara."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Penggunaan mikrofon memungkinkan aplikasi untuk merekam dan mendengarkan "
+"suara. Menonaktifkan mikrofon dapat menyebabkan beberapa aplikasi tidak "
+"berfungsi dengan benar.\n"
+"\n"
+"Izinkan aplikasi di bawah ini untuk menggunakan mikrofon Anda."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Tak Ada Aplikasi yang Meminta Akses Mikrofon"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Lindungi percakapan Anda"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofon;rekaman;aplikasi;privasi;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Uji Penga_turan Anda"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Umum"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Tombol primer"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Atur urutan tombol fisik pada tetikus dan touchpad."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Kiri"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Kanan"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Tetikus"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Laju Tetikus"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Pengguliran Alami"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Pengguliran memindah isi, bukan tilikan."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Laju Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Ketuk untuk Mengklik"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Ketuk untuk mengklik"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Pengguliran Dua Jari"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Pengguliran Tepi"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Cobalah mengklik, klik ganda, menggulung"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Lima klik, waktunya GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Klik ganda, tombol primer"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Klik tunggal, tombol primer"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Klik ganda, tombol tengah"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Klik tunggal, tombol tengah"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Klik ganda, tombol sekunder"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Klik tunggal, tombol sekunder"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Tetikus & Touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Ubah sensitivitas tetikus atau touchpad Anda dan pilih kidal atau bukan"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Pointer;Klik;Sentuh;Ganda;Tombol;Trackball;Gulir;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Pojok Panas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Sentuh pojok kiri atas untuk membuka Ringkasan Aktivitas."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Tepi Layar _Aktif"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Seret jendela ke tepi layar puncak, kiri, dan kanan untuk mengubah ukuran "
+"mereka."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Ruang kerja"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "Ruang kerja _dinamis"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Secara otomatis menghapus ruang kerja yang kosong."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Cacah tetap ruang kerja"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Nyatakan banyaknya ruang kerja permanen."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "Cacah rua_ng kerja"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multi-Monitor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Ruang kerja hanya pada tampilan _primer"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Ruang kerja pada semua tampilan"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Pengalihan Aplikasi"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Sertakan aplikasi dari semua ruang _kerja"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Sertakan aplikasi dari ruang kerja saat _ini saja"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitasking"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Mengelola preferensi untuk produktivitas dan multitasking"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Produktivitas;Sesuaikan;Destop;Sudut Panas;Ruang "
+"kerja;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ups, ada sesuatu yang salah. Harap hubungi vendor perangkat lunak Anda."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager perlu berjalan."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Perangkat Lainnya"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Tambah koneksi"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Belum ditata"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Jaringan tidak aman (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Jaringan aman (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Jaringan aman (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Jaringan aman (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Jaringan aman"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Tersambung"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opsi…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Menyalakan hotspot akan memutuskan koneksi dari %s, dan tidak mungkin untuk "
+"mengakses internet melalui Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Harus memiliki minimal 8 karakter"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Harus memiliki minimal %d karakter"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Hidupkan Hotspot Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Hotspot Wi-Fi memungkinkan orang lain untuk membagikan koneksi internet "
+"Anda, dengan membuat jaringan Wi-Fi yang dapat mereka sambungkan. Untuk itu, "
+"Anda harus memiliki sumber koneksi internet selain Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nama Jaringan"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Kata Sandi"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Hasilkan Kata Sandi Acak"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Hasilkan Otomatis Kata Sandi"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "Ak_tifkan"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Hentikan hotspot dan putuskan semua pengguna?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Stop Hotspot"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Mode Pesawat Terbang"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Nonaktifkan Wi-Fi, Bluetooth, dan data seluler"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Tidak ada Adaptor Wifi yang Ditemukan"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Pastikan adaptor Wi-Fi terpasang dan dinyalakan"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Mode Pesawat Terbang Aktif"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Matikan untuk menggunakan Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Hotspot Wi-Fi Aktif"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Perangkat seluler dapat memindai kode QR untuk terhubung."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Matikan Hotspot Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Jaringan Terlihat"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager perlu berjalan"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Keamanan 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Keamanan"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Pertahankan"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanen"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Acak"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabil"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Alamat MAC yang dimasukkan di sini akan digunakan sebagai alamat perangkat "
+"keras untuk perangkat jaringan tempat koneksi ini diaktifkan. Fitur ini "
+"dikenal sebagai MAC cloning atau spoofing. Contoh: 00: 11: 22: 33: 44: 55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nihil"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Tak pernah"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i hari yang lalu"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nihil"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Lemah"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bagus"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Sempurna"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Alamat IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Alamat IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Alamat IP"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Lupakan Sambungan"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Hapus Profil Sambungan"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Hapus VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Rincian"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "otomatis"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitas"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Hapus Alamat"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Hapus Route"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Tak Ada"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Kunci WEP 40/128-bit (Heksa atau ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Frasa-sandi WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP Dinamik (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Pribadi"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Kuat Sinyal"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Kecepatan link"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Alamat Perangkat Keras"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Frekuensi Didukung"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Rute Utama"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Terakhir Dipakai"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Menyambung otom_atis"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Jadikan tersedia bagi pengg_una lain"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "Koneksi ber_meter: memiliki batas data atau dapat dikenakan biaya"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Pembaruan perangkat lunak dan unduhan besar lain tidak akan dimulai secara "
+"otomatis."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nama"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Alamat _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Alamat yang di_klon"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "byte"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Metode IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Otomatis (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Hanya Link-Lokal"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Nonaktifkan"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Berbagi dengan komputer lain"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Alamat"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Alamat"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Netmask"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Otomatis"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS Otomatis"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Alamat peladen DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Pisahkan alamat-alamat IP dengan koma"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Route"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Route Otomatis"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "G_unakan sambungan ini hanya untuk sumber daya pada jaringannya"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Metode IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Otomatis, hanya DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Awalan"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Tak bisa membuka penyunting koneksi"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Profil Baru"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Pengaturan tidak valid %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Pengaturan tidak valid %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Impor dari berkas…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Tambah VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "K_eamanan"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Tak dapat mengimpor sambungan VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Berkas \"%s\" tidak dapat dibaca atau tidak berisi informasi sambungan VPN "
+"yang dikenali\n"
+"\n"
+"Galat: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Pilih berkas untuk diimpor"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Berkas bernama \"%s\" sudah ada."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Gantikan"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+"Apakah Anda ingin menggantikan %s dengan sambungan VPN yang sedang Anda "
+"simpan?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Tak dapat mengekspor sambungan VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Sambungan VPN \"%s\" tidak dapat diekspor ke %s.\n"
+"\n"
+"Galat: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Ekspor sambungan VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Galat: tak bisa memuat penyunting sambungan VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Kendalikan bagaimana Anda menyambung ke Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Jaringan;IP;LAN;Proksi;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Kendalikan bagaimana Anda menyambung ke jaringan Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Jaringan;Nirkabel;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "tak pernah"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "hari ini"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "kemarin"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Terakhir dipakai"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Kabel"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Tambah sambungan baru"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Rincian jaringan bagi jaringan yang dipilih, termasuk kata sandi dan "
+"sebarang konfigurasi gubahan akan hilang."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Lupakan"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Jaringan Wi-Fi yang Dikenal"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Lupakan"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Kebijakan sistem melarang pemakaian sebagai Hotspot"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Perangkat nirkabel tak mendukung mode Hotspot"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Mencari Sendiri Proksi Web dipakai ketika URL Konfigurai tak diberikan."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Ini tak dianjurkan bagi jaringan publik yang tak terpercaya."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Matikan perangkat"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktif"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Penyedia"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proksi Jaringan"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proksi _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proksi H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proksi _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Host _Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "Aba_ikan Host"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Port proksi HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Port proksi HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Port proksi FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Port proksi SOCKS"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL _Konfigurasi"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Matikan koneksi VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nama Jaringan"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tipe keamanan"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Kata Sandi"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Matikan Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Lebih banyak opsi…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Menyambung ke Jaringan Tersembunyi…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Hidupkan Ho_tspot Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Jaringan Wi-Fi yang Di_kenal"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Status tak diketahui"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Tak dikelola"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Tak tersedia"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Menyambung"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Perlu autentikasi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Memutus"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Koneksi gagal"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Status tak diketahui (hilang)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Konfigurasi gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Konfigurasi IP gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Konfigurasi IP kadaluarsa"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Rahasia diperlukan, tapi tak disediakan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1X supplicant diputus"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Konfigurasi 802.1X supplicant gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1X supplicant gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1X supplicant makan waktu terlalu lama untuk mengautentikasi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Layanan PPP gagal dimulai"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Layanan PPP diputus"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Klien DHCP gagal dimulai"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Galat klien DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Klien DHCP gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Layanan koneksi bersama gagal dimulai"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Layanan koneksi bersama gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Layanan AutoIP gagal dimulai"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Galat layanan AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Layanan AutoIP gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Jalur sibuk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Tak ada nada panggil"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Carrier tak dapat dijalin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Permintaan pemanggilan habis waktu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Usaha memanggil gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Inisialisasi modem gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Gagal memilih APN yang dinyatakan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Tak mencari jaringan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Pendaftaran jaringan ditolak"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Pendaftaran jaringan habis waktu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Gagal mendaftar ke jaringan yang diminta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Uji PIN gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Firmware yang diperlukan bagi perangkat mungkin hilang"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Koneksi aktif perangkat menghilang"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Koneksi perangkat kini diasumsikan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem tak ditemukan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Koneksi Bluetooth gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Kartu SIM tak dipasang"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Perlu PIN SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Perlu PUK SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM salah"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Kebergantungan koneksi gagal"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Firmware hilang"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabel tercabut"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "galat tak terdefinisi dalam keamanan 802.1x (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "tak ada berkas yang dipilih"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "galat tak dispesifikasikan saat memvalidasi berkas eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Kunci privat DER, PEM, PKCS#12, atau PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Sertifikat DER atau PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "kurang berkas PAC EAP-FAST"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Berkas PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonim"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Terautentikasi"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Keduanya"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identitas anoni_m"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Berkas PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Pilih suatu berkas PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autent_ikasi dalam"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Izinkan pro_visi PAC otomatis"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "kurang nama pengguna EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "kurang kata sandi EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nama pengg_una"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "Kata _Sandi"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Tampilkan kata _sandi"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "sertifikat CA EAP-PEAP tak valid: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "sertifikat CA EAP-PEAP tak valid: tak ada sertifikat yang dinyatakan"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versi 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versi 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Sertifikat C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Pilih sebuah sertifikat Certificate Authority"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Tidak dipe_rlukan sertifikat CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Versi PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "kurang nama pengguna EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "kurang kata sandi EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "kurang identitas EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "sertifikat CA EAP-TLS tak valid: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "sertificat CA EAP-TLS tak valid: tak ada sertifikat yang dinyatakan"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "kunci privat EAP-TLS tak valid: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "sertifikat pengguna CA EAP-TLS tak valid: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Kunci privat tak tersandi itu tidak aman"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Kunci pribadi yang dipilih sepertinya tidak dilindungi oleh kata sandi. Ini "
+"dapat menyebabkan kredensial keamanan Anda disalahgunakan. Silakan pilih "
+"kunci pribadi yang diamankan oleh sandi.\n"
+"\n"
+"(Anda dapat melindungi kunci pribadi Anda dengan openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Pilih sertifikat pribadi Anda"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Pilih kunci privat Anda"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitas"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Sertifikat pengg_una"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Kunci privat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Kata sandi kunci _privat"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "sertifikat CA EAP-TTLS tak valid: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "sertificat CA EAP-TTLS tak valid: tak ada sertifikat yang dinyatakan"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (tanpa EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domain"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Galat tak diketahui saat memvalidasi keamanan 802.1x"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS Terterowong"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Protected EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "O_tentikasi"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Pilih berkas"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "kurang leap-username"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "kurang leap-password"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Kata sandi Wi-Fi hilang."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipe"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "kurang wep-key"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"wep-key tak valid: kunci dengan panjang %zu mesti hanya memuat dijit heksa"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"wep-key tak valid: kunci dengan panjang %zu mesti hanya memuat karakter ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"wep-key tak valid: panjang kunci %zu salah. Suatu kunci mesti sepanjang 5/13 "
+"(ascii) atau 10/26 (heksa)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "wep-key tak valid: frasa sandi tidak boleh kosong"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "wep-key tak valid: frasa sandi mesti kurang dari 64 karakter"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Bawaan)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistem Terbuka"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Kunci Bersama"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Kunci"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Tampilkan _kunci"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Inde_ks WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk tak valid: panjang kunci %zu tak valid. Mesti [8,63] byte atau 64 "
+"dijit heksa"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk tak valid: tak bisa interpretasikan kunci dengan 64 byte sebagai "
+"heksa"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notifikasi"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Pering_atan Suara"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Popup Notifikasi"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Notifikasi akan terus muncul didaftar notifikasi ketika popup dinonaktifkan."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Tam_pilkan Isi Pesan dalam Popup"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notifikasi _Layar Kunci"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "_Tampilkan Isi Pesan dalam Layar Kunci"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Jangan _Ganggu"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Notifikasi _Layar Kunci"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Kendalikan notifikasi mana yang ditampilkan dan apa yang ditunjukkan"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifikasi;Banner;Pesan;Baki;Popup;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Lainnya"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s dihapus"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Galat saat menghapus akun"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Tak Jadi"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Tutup notifikasi"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Hubungkan ke data Anda di awan"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Tidak ada koneksi internet — koneksikan untuk mengatur akun daring baru"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Tambah akun"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Akun %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Hapus Akun"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Akun Daring"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Sambung ke akun daring Anda dan tentukan mereka akan dipakai apa"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Daring;Obrolan;Kalender;Surel;Kontak;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Waktu tak diketahui"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i menit"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i jam"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "jam"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "menit"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s sampai terisi penuh"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Hati-hati: %s tersisa"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s tersisa"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Terisi penuh"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Tidak Mengisi"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Kosong"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Mengisi"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Mengosongkan"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Tetikus nirkabel"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Papan tik nirkabel"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Pasokan tenaga tak putus"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Asisten dijital pribadi"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Telepon seluler"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Pemutar media"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Komputer"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Perangkat masukan permainan"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterai"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Utama"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Ekstra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batera"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Ket_ika menganggur"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Suspensi"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Matikan"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernasi"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Bukan apapun"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Ketika memakai baterai"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Ketika ditancapkan"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Tak pernah"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Suspensi otomatis"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Mode kinerja dinonaktifkan sementara karena suhu pengoperasian yang tinggi."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Putaran terdeteksi: mode kinerja untuk sementara tidak tersedia. Pindahkan "
+"perangkat ke permukaan yang stabil untuk memulihkan."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Mode kinerja dinonaktifkan untuk sementara."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Baterai rendah: penghemat daya diaktifkan. Mode sebelumnya akan dipulihkan "
+"ketika baterai terisi cukup."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Mode Penghemat Daya diaktifkan oleh \"%s\"."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Mode kinerja diaktifkan oleh \"%s\"."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 menit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 menit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 menit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 menit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 menit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 jam"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 menit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 menit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 menit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 jam"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Mode Daya"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Mempengaruhi kinerja sistem dan penggunaan daya."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opsi Penghematan Daya"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Kecerahan Layar Otomatis"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Kecerahan layar menyesuaikan dengan cahaya di sekitarnya."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Redupkan Layar"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Mengurangi kecerahan layar saat komputer tidak aktif."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Pengosongan Layar"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Mematikan layar setelah periode tidak aktif."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Penghemat Daya Otomatis"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Mengaktifkan mode penghemat daya saat baterai rendah."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "Suspensi Otom_atis"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Menjeda komputer setelah periode tidak aktif."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Perilaku Tombol Da_ya"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Tampilkan _Persentase Baterai"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Suspensi Otomatis"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Ditanca_pkan"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Memakai Tenaga _Baterai"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Tunda"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Kinerja"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Kinerja tinggi dan penggunaan daya."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Seimbang"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Kinerja standar dan penggunaan daya."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Penghemat Daya"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Kurangi kinerja dan penggunaan daya."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Daya"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Tilik status baterai Anda dan ubah pengaturan penghematan daya"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Daya;Tidur;Suspensi;Hibernasi;Baterai;Kecerahan;Redup;Kosong;Monitor;DPMS;"
+"Menganggur;Energi;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Pencetak “%s” telah dihapus"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Gagal menambah pencetak baru."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Tak dapat memuat ui: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Buka Kunci untuk Menambahkan Pencetak dan Mengubah Pengaturan"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Pencetak"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Tambah pencetak, tilik tugas pencetak, dan menentukan bagaimana Anda ingin "
+"mencetak"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Pencetak;Antrian;Cetak;Kertas;Tinta;Pewarna;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Tambah Pencetak"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Buka Kunci"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Tak Ditemukan Pencetak"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Masukkan suatu alamat jaringan atau cari sebuah pencetak"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autentikasi Diperlukan"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Masukkan nama pengguna dan kata sandi Anda untuk melihat pencetak pada "
+"Peladen Pencetak."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nama Pengguna"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Rincian %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Tak ditemukan penggerak yang cocok"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Pilih Berkas PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Berkas Deskripsi Pencetak PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Nama pencetak tidak boleh berisi SPACE, TAB, #, atau /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Lokasi"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Penggerak"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Mencari penggerak yang disukai…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Mencari Penggerak"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Pilih dari Basis Data…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Pasang Berkas PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Pilih Penggerak Pencetak"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Memuat basis data penggerak…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Pilih"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Pencetak JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Pencetak LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Satu Sisi"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Sisi Panjang (Standar)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Sisi Pendek (Putar)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Potret"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Landskap"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Lansekap terbalik"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Potret terbalik"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Lanjutkan"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Jeda"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Ditunda"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Diistirahatkan"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Perlu autentikasi"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Diproses"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Berhenti"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Batal"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Dibatalkan"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Selesai"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Pindahkan pekerjaan ini ke urutan teratas antrean"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u Tugas Memerlukan Autentikasi"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Tugas Aktif"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Masukkan kredensial untuk mencetak dari %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domain"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utentikasikan"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Bersihkan Semua"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autentikasikan"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Tidak Ada Tugas Pencetak Yang Aktif"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Pilih Peladen Pencetak"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Buka Kunci %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Masukkan nama pengguna dan kata sandi Anda untuk melihat pencetak pada %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Mencari Pencetak"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Porta Serial"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Porta Paralel"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Lokasi: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Alamat: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Server memerlukan autentikasi"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dua Sisi"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Jenis Kertas"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Sumber Kertas"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Baki Keluaran"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolusi"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Pra penapisan GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Halaman per sisi"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dua Sisi"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientasi"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Umum"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Penyiapan Halaman"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opsi Dapat Dipasang"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Tugas"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Kualitas Gambar"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Warna"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Menyelesaikan"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Tingkat Lanjut"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Halaman Uji"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Halaman uji"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Pilih Otomatis"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Pencetak Baku"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Tempelkan fonta GhostScript saja"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Konversi ke PS tingkat 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Konversi ke PS tingkat 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Tanpa pra penapisan"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Pabrikan"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Tidak Ada Tugas Aktif"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u Tugas"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Bersihkan kepala cetak"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Pewarna sedikit"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Pewarna habis"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Developer sedikit"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Developer habis"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Asupan penanda sedikit"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Asupan penanda habis"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Buka penutup"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Buka pinta"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Kertas sedikit"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Kertas habis"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Luring"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Dihentikan"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Penampung sampah hampir penuh"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Penampung sampah penuh"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Penghantar foto optik hampir mati"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Penghantar foto optik tak berfungsi lagi"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Siap"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Tak menerima tugas"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Memroses"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Opsi Pencetakan"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Rincian Pencetak"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Secara Baku Memakai Pencetak"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Bersihkan Kepala Cetak"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Hapus Pencetak"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Aras Tinta"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Harap memulai ulang ketika masalah diselesaikan."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Nyalakan Ulang"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Tambah Pencetak…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Tidak ada pencetak"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Maaf! Layanan pencetakan sistem\n"
+"    sepertinya tak tersedia."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Format"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Cari locale…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Format Umum"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Semua Format"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Tak Ada Hasil Pencarian"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Pencarikan dapat berupa negara atau bahasa."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Pratayang"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Kerajaan"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Tanggal"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Tanggal & Waktu"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Angka"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Pengukuran"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Kertas"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Bahasa dan format akan diubah setelah log masuk berikutnya"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Keluar…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Pengaturan bahasa digunakan untuk teks antarmuka dan halaman web. Format "
+"digunakan untuk angka, tanggal, dan mata uang."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Akun Anda"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Bahasa"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Format"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Layar Log Masuk"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Wilayah & Bahasa"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Pilih bahasa dan format tampilan Anda"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Bahasa;Tata Letak;Papan Tik;Masukan;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Tanya apa yang akan dilakukan"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Jangan lakukan apa pun"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Buka folder"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Media Lain"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Pilih aplikasi bagi CD musik"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Pilih aplikasi bagi DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Pilih aplikasi yang dijalankan ketika pemutar musik disambungkan"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Pilih aplikasi yang dijalankan ketika kamera disambungkan"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Pilih aplikasi bagi CD perangkat lunak"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "diska Blu-ray kosong"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "diska CD kosong"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "diska DVD kosong"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "diska HD DVD kosong"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Diska video Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "pembaca e-book"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Diska video HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "CD gambar"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "CD Super Video"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "CD video"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Perangkat lunak Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Pilih bagaimana media mesti ditangani"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Audio CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "Video _DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Pemutar _musik"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Perangkat Lunak"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Media Lain…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "Ja_ngan bertanya atau menjalankan program saat media dimasukkan"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Pilih bagaimana media lain mesti ditangani"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Aksi:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Jenis:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Media Lepasan"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Mengkonfigurasi pengaturan Media Lepasan"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"perangkat;sistem;bawaan;aplikasi;disukai;cd;dvd;usb;audio;video;cakram;dapat "
+"dicopot;media;autorun;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Layar Dimatikan"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 detik"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 menit"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 menit"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 menit"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 menit"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 menit"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 jam"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 menit"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 menit"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 menit"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 menit"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 menit"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 menit"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 menit"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 menit"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 menit"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Tak pernah"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Kunci Layar"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Mengunci layar secara otomatis mencegah orang lain mengakses komputer saat "
+"Anda pergi."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Penundaan Layar Kosong"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Jeda setelah tidak ada aktivitas layar akan kosong."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Kuncian _Layar Otomatis"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Kuncian _Layar Otomatis"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Jeda setelah layar kosong kapan layar terkunci otomatis."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Tampilkan _Notifikasi pada Layar Kunci"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Larang perangkat _USB baru"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Cegah perangkat USB baru berinteraksi dengan sistem saat layar terkunci."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Privasi Layar"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Batasi Sudut Pandang"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Pengaturan Layar"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "layar;kunci;pribadi;privasi;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Pilih Lokasi"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Cari Lokasi"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Folder yang dicari oleh aplikasi sistem, seperti Berkas, Foto dan Video."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Tempat"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Markah"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Lainnya"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Tambah Lokasi"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Tak menemukan aplikasi"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Pencarian Aplikasi"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Sertakan hasil pencarian yang disediakan aplikasi."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Folder yang dicari oleh aplikasi sistem."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Hasil Pencarian"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Hasil ditampilkan sesuai dengan urutan daftar."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Kendalikan aplikasi mana yang menampilkan hasil pencarian dalam Ringkasan "
+"Aktivitas"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Cari;Temukan;Indeks;Sembunyikan;Privasi;Hasil;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Tiada jaringan yang dipilih untuk berbagi"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Jaringan"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Nyala"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Mati"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Diaktifkan"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktif"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Pilih Folder"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Tambah"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Aktifkan berbagi media"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Berbagi Pakai Berkas memungkinkan Anda berbagi pakai folder Publik Anda "
+"dengan orang lain pada jaringan Anda kini memakai: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Bila log masuk jarak jauh difungsikan, pengguna jarak jauh dapat menyambung "
+"memakai perintah Secure Shell:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Aktifkan berbagi media pribadi"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Nama perangkat disalin"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Alamat perangkat disalin"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Nama pengguna disalin"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Kata sandi disalin"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Berbagi Pakai"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Nama _Komputer"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Berbagi Berkas"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_Destop Jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Berbagi _Media"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Log Masuk Ja_rak Jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Berbagi Berkas"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Meme_rlukan Kata Sandi"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Log Masuk Jarak Jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Destop Jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Destop jauh memungkinkan melihat dan mengendalikan destop Anda dari komputer "
+"lain."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Aktifkan atau nonaktifkan koneksi destop jauh ke komputer ini."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Kendali Jarak Jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Izinkan koneksi mengendalikan layar."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Cara Menghubungkan"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Sambungkan ke komputer ini menggunakan nama perangkat atau alamat destop "
+"jauh."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Salin"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Alamat Destop Jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autentikasi"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Nama pengguna dan kata sandi diperlukan untuk terhubung ke komputer ini."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nama Pengguna"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Verifikasi Enkripsi"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Sidik Jari Enkripsi"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Sidik jari enkripsi dapat dilihat dalam menghubungkan klien dan harus "
+"identik."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Berbagi Pakai Media"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Berbagi pakai musik, foto, dan video melalui jaringan."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Folder"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Kendalikan apa yang ingin Anda bagikan dengan orang lain"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"berbagi;ssh;host;nama;jarak jauh;remote;desktop;media;audio;video;gambar;"
+"foto;film;server;perender;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Fungsikan atau matikan log masuk jarak jauh"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Autentikasi diperlukan untuk memfungsikan atau mematikan log masuk jarak jauh"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Gubahan"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klik"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "String"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Ayun"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Hum"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balans"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Fade"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Belakang"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Depan"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Menguji %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Klik speaker untuk menguji"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volume Sistem"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Volume master"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Tingkat Volume"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Keluaran"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Perangkat Keluaran"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Uji"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Konfigurasi"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Masukan"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Perangkat Masukan"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volume"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Suara Waspada"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Bisu"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Suara"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Mengubah aras suara, masukan, keluaran, dan suara peringatan"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kartu;Mikrofon;Volume;Fade;Balans;Bluetooth;Headset;Audio;Keluaran;Masukan;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Terputus"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Menyambung"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Tersambung"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Galat Autorisasi"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Mengotorisasi"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Fungsionalitas Dikurangi"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Tersambung & Terotorisasi"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Tidak Diketahui"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Diotorisasi di:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Tersambung pada:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Terdaftar di:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Gagal mengotorisasi perangkat: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Gagal melupakan perangkat: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Tergantung pada%u perangkat lain"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Tutup notifikasi"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nama:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Status:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autorisasikan dan Sambungkan"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Lupakan Perangkat"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Galat"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Terotorisasi"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Subsistem Thunderbolt (boltd) tidak dipasang atau tidak diatur dengan benar."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Izinkan akses langsung ke perangkat seperti dok dan GPU eksternal."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Hanya perangkat USB dan Display Port yang dapat dipasang."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt tidak dapat dideteksi.\n"
+"Entah sistem tidak memiliki dukungan Thunderbolt, hal itu telah "
+"dinonaktifkan di BIOS atau diatur ke tingkat keamanan yang tidak didukung di "
+"BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Dukungan Thunderbolt telah dinonaktifkan di BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Tingkat keamanan thunderbolt tidak dapat ditentukan."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Galat saat mengalihkan mode langsung: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Tidak Ada Dukungan Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Tak bisa menyambung ke subsistem thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Akses Langsung"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Perangkat Tertunda"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Tidak ada perangkat yang terpasang"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Kelola perangkat Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privasi;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Kursor Berkedip"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Kursor berkedip di ruas teks."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Laju"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Laju kedip kursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Ukuran Kursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Ukuran kursor bisa dikombinasikan dengan zum agar kursor lebih mudah dilihat."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Bantuan Klik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Klik _Sekunder Tersimulasi"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Picu klik sekunder dengan menahan tombol primer"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Tundaan penerimaan:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Singkat"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Tundaan klik sekunder"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lama"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Klik _Mengambang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Picu klik ketika penunjuk mengambang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "T_unda:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Singkat"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lama"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "A_mbang gerakan:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Kecil"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Besar"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Pengulangan Tombol"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Penekanan tombol akan diulang saat ditahan."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Tundaan pengulangan tombol"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Kecepatan pengulangan tombol"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Bantuan Mengetik"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Tombol _Lengket"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Perlakukan urutan tombol pengubah sebagai suatu kombinasi tombol"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Matikan bila _dua tombol ditekan bersamaan"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Bip ketika tombol _pengubah ditekan"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Tombol _Lambat"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Sisipkan jeda antara ketika suatu tombol ditekan dan ketika itu diterima"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Singkat"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Tundaan pengetikan tombol lambat"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lama"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Bip k_etika suatu tombol ditekan"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Bip ketika suatu tombol diterim_a"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Bip ketika tombol ditola_k"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Tom_bol Pantul"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Abaikan penekanan cepat tombol yang sama"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Singkat"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Tundaan pengetikan tombol pantul"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lama"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Aktifkan m_elalui Papan Tik"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Nyalakan dan matikan fitur aksesibilitas memakai papan tik"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Bawaan"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Sedang"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Besar"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Lebih Besar"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Terbesar"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d piksel"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Selalu Tampilkan Menu _Aksesibilitas"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Penglihatan"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Kontras _Tinggi"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Teks _Besar"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Fungsikan A_nimations"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Pembaca Laya_r"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Pembaca layar membaca teks yang ditampilkan ketika Anda memindah fokus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Suara Tombol"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Bip ketika Num Lock atau Caps Lock dinyalakan atau dimatikan."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Ukuran K_ursor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zum"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Pendengaran"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Peringatan _Visual"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Papan Ti_k di Layar"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "P_engulangan Tombol"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Kursor _Berkedip"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Bantuan Penge_tikan (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Menunjuk &amp; Mengklik"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "To_mbol Tetikus"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Temukan _Penunjuk"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Bantuan _Klik"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Tun_daan Klik Ganda"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Tundaan Klik Ganda"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Peringatan Visual"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Uji flash"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Gunakan indikasi visual ketika terjadi suara waspada."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Kedipkan _seluruh layar"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Kedipkan seluruh _jendela"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Pendek"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ Layar"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ Layar"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ Layar"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Panjang"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Layar Penuh"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Belahan Puncak"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Belahan Bawah"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Belahan Kiri"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Belahan Kanan"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Pilihan Zum"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "Per_besaran:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posisi Pembesar:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Ikuti kursor tetikus"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Bagian layar:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Pembesar meng_embang sampai ke luar layar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Jaga _kursor pembesar di tengah"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Kursor _pembesar mendorong isi ke sekitar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Kursor pembesar bergerak _dengan isi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Pembesar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Pem_bidik silang:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Kurs_or tetikus bertindih"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "Ke_tebalan:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tipis"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Tebal"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Panjang:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Warna:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Pembidik silang"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efek Warna:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Putih di atas hitam:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "Kecera_han:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontras:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Warna"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Tak Ada"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Penuh"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Rendah"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Tinggi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Rendah"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Tinggi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efek Warna"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"Membuat lebih mudah untuk melihat, mendengar, mengetik, menunjuk, dan "
+"mengklik"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Papan Tik;Tetikus;a11y;Aksesibilitas;Akses Universal ;Kontras;Kursor;Suara;"
+"Zum;Layar;Pembaca;besar;tinggi;besar;teks;fonta;ukuran;AccessX;Lengket;"
+"Tombol;Lambat;Pantul;Tetikus;Dobel;klik;Tunda;Kecepatan;Bantu;Ulangi; "
+"Berkedip;visual;mendengar;audio;mengetik;animasi;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 jam"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 hari"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 hari"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 hari"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 hari"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 hari"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 hari"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 hari"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 hari"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 hari"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Kosongkan semua butir dari Tempat Sampah?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Semua butir dalam Tempat Sampah akan dihapus secara permanen."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Kosongkan Tempat Sampah"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Hapus semua berkas temporer?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Semua berkas temporer akan dihapus secara permanen."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Bersihkan Berkas Tem_porer"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 hari"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 hari"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 hari"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Selamanya"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Riwayat Berkas"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Riwayat berkas mempertahankan catatan berkas yang telah Anda gunakan. "
+"Informasi ini dibagikan antar aplikasi, dan membuatnya mudah untuk menemukan "
+"berkas yang ingin Anda gunakan."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "R_iwayat Berkas"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "_Durasi Riwayat Berkas"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "B_ersihkan Riwayat…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Tempat Sampah &amp; Berkas Temporer"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Tempat sampah dan berkas temporer terkadang berisi informasi personal atau "
+"sensitif. Menghapusmya secara otomatis bisa membantu melindungi privasi."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Secara Otomatis Hapus Konten _Tempat Sampah"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Secara Otomatis Hapus _Berkas Temporer"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Jangka Waktu Ha_pus Otomatis"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Kosongkan Tempat Sampah…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Hapus Berkas Tem_porer…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Riwayat Berkas dan Tempat Sampah"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Jangan tinggalkan jejak"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"penggunaan;terkini;riwayat;berkas;sementara;tmp;pribadi;privasi;sampah;"
+"pembersihan;simpan;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Mesti cocok dengan alamat web dari penyedia log masuk Anda."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Gagal menambah akun"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Kata sandi tak cocok."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Gagal mendaftarkan akun"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Tak ada cara yang didukung untuk mengautentikasi dengan domain ini"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Gagal bergabung ke domain"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Nama log masuk itu tak bekerja.\n"
+"Harap coba lagi."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Kata sandi log masuk itu tak bekerja.\n"
+"Harap coba lagi."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Gagal log masuk domain"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Tak bisa temukan domain. Mungkin Anda salah eja?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Tambah Pengguna"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administrator dapat menambah dan menghapus pengguna lain, dan dapat mengubah "
+"pengaturan untuk semua pengguna. Kontrol orang tua tidak dapat diterapkan "
+"pada administrator."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Pengguna mengatur kata sandi pada log masuk pertama"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Atur kata sandi sekarang"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Konfirmasi"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Log Masuk Enterprise"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Akun pengguna yang dikelola oleh perusahaan atau organisasi."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Anda Luring"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Log masuk enterprise memungkinkan akun pengguna yang telah ada yang dikelola "
+"secara terpusat dipakai pada perangkat ini. Anda juga dapat memakai akun ini "
+"untuk mengakses sumber daya perusahaan di internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Ramban lebih banyak gambar"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Pilih Berkas…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Manajer Sidik Jari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Sidik Jari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Tidak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Ya"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Apakah Anda ingin menghapus sidik jari Anda yang telah terdaftar sehingga "
+"log masuk memakai sidik jari dimatikan?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Tidak ada perangkat sidik jari"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Tidak ada perangkat Sidik Jari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Pastikan perangkat terhubung dengan benar."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Perangkat Sidik Jari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Pilih perangkat sidik jari yang ingin Anda konfigurasi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Log Masuk Sidik Jari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Log masuk dengan sidik jari memungkinkan Anda untuk membuka kunci dan masuk "
+"ke komputer dengan jari Anda"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "Hapus Si_dik Jari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Pendaftaran Sidik Jari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "perangkat perlu diklaim untuk melakukan tindakan ini"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "perangkat sudah diklaim oleh proses lain"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "Anda tidak memiliki izin untuk melakukan tindakan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "tidak ada sidik jari yang terdaftar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Gagal berkomunikasi dengan perangkat selama pendaftaran"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Gagal berkomunikasi dengan pembaca sidik jari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Gagal berkomunikasi dengan daemon sidik jari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Gagal mencantumkan sidik jari: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Gagal menghapus sidik jari yang disimpan: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Jempol kiri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Jari tengah kiri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "Telunjuk k_iri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Jari manis kiri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Kelingking kiri"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Jempol kanan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Jari tengah kanan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Telunjuk k_anan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Jari manis kanan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Kelingking kanan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Jari Tidak Dikenal"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Komplit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Perangkat sidik jari terputus"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Penyimpanan perangkat sidik jari penuh"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Gagal mendaftarkan sidik jari baru"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Gagal memulai pendaftaran: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Gagal mendaftarkan sidik jari baru"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Gagal menghentikan pendaftaran: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Angkat dan letakkan jari Anda berulang kali pada pembaca untuk mendaftarkan "
+"sidik jari Anda"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Dafta_rkan ulang jari ini…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Pindai sidik jari baru"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Gagal melepaskan perangkat sidik jari %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Masalah pada Perangkat Membaca"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Gagal mengklaim perangkat sidik jari %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Gagal mendapatkan perangkat sidik jari: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Minggu Ini"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Minggu Lalu"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sesi Berakhir"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sesi Dimulai"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Aktivitas Akun"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Sebelumnya"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Selanjutnya"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Silakan pilih kata sandi lain."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Silakan tik ulang kata sandi kini."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Kata sandi tak dapat diubah"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Ubah Kata Sandi"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Ub_ah"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Kata Sandi Sekarang"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Kata Sandi Baru"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Konfirmasi Kata Sandi"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Izinkan pengguna mengubah kata sandi saat log masuk berikutnya"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Isi kata sandi sekarang"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Tak bisa secara otomatis bergabung ke tipe domain ini"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Domain atau realm tersebut tak ditemukan"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Tak bisa log masuk sebagai %s pada domain %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Kata sandi salah, harap coba lagi"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Tak bisa menyambung ke domain %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Gagal menghapus pengguna"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Gagal mencabut pengguna yang dikelola jarak jauh"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Anda tak bisa menghapus akunmu sendiri."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s masih log masuk"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Menghapus pengguna saat mereka log masuk dapat menjerumuskan sistem ke dalam "
+"keadaan tak konsisten."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Apakah Anda ingin mempertahankan berkas milik %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Dimungkinkan untuk mempertahankan direktori rumah, spool surel, dan berkas "
+"temporer ketika menghapus suatu akun pengguna."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Hapus Berkas"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "Biarkan Berkas"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Anda yakin ingin mencabut akun %s yang dikelola jarak jauh?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Hapus"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Akun dimatikan"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Untuk ditata saat log masuk berikutnya"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Tak ada"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Log masuk"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Gagal menghubungi layanan akun"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Pastikan bahwa AccountService ini telah terpasang dan diaktifkan."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Panel ini harus dibuka untuk mengubah pengaturan ini"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Hapus akun pengguna yang dipilih"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Untuk menghapus akun pengguna yang dipilih,\n"
+"pertama kali klik ikon *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Buka Kunci untuk Menambahkan Pengguna dan Mengubah Pengaturan"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Pengguna"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Sesi Anda perlu dimulai ulang agar perubahan berefek"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Nyalakan Ulang Sekarang"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Tutup"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Sunting avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Nama Lengkap"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Sunting"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Log Masuk _Sidik Jari"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Log Mas_uk Otomatis"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Aktivitas Akun"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administrator dapat menambah dan menghapus pengguna lain, dan dapat mengubah "
+"pengaturan untuk semua pengguna."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Pengawasan Orang Tua"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Buka aplikasi Kontrol Orang Tua."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Hapus Pengguna…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Pengguna Lain"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Tambah Pengguna…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Tak Ditemukan Pengguna"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Buka kunci untuk menambahkan akun pengguna."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Tambah atau hapus pengguna dan ubah kata sandi Anda"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Log Masuk; Nama;Sidik jari;Avatar;Logo;Wajah;Kata sandi;Kontrol Orang Tua;"
+"Waktu Layar;Pembatasan Aplikasi;Pembatasan Web;Penggunaan;Batas Penggunaan;"
+"Anak;Anak;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Daftarkan"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Log Masuk Administrator Domain"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Untuk memakai log masuk enterprise, komputer ini perlu\n"
+"didaftarkan dalam domain. Harap minta administrator jaringan Anda\n"
+"memasukkan kata sandi domain mereka di sini."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nama Administrator"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Kata Sandi Administrator"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Kelola akun pengguna"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Autentikasi diperlukan untuk mengubah data pengguna"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Kata sandi baru perlu berbeda dengan yang lama."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Cobalah mengubah beberapa huruf dan angka."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Cobalah mengubah kata sandi lebih banyak lagi."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Suatu kata sandi tanpa nama penggunamu akan lebih kuat."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Cobalah menghindari memakai nama Anda dalam kata sandi."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Cobalah menghindari beberapa kata yang termasuk dalam kata sandi."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Cobalah menghindari kata-kata umum."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Cobalah menghindari mengatur ulang urutan kata yang ada."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Cobalah memakai lebih banyak angka."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Cobalah memakai lebih banyak huruf besar."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Cobalah memakai lebih banyak huruf kecil."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Cobalah memakai lebih banyak karakter khusus, seperti tanda baca."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Cobalah memakai campuran huruf, angka, dan tanda baca."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Cobalah menghindari pengulangan karakter yang sama."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Cobalah menghindari mengulang karakter bertipe sama: Anda perlu mencampur "
+"huruf, angka, dan tanda baca."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Cobalah menghindari urutan seperti 1234 atau abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Kata sandi harus lebih panjang. Cobalah menambahkan lebih banyak huruf, "
+"angka dan tanda baca."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Campurlah huruf besar dan kecil dan cobalah memakai satu atau dua angka."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Menambahkan lebih banyak huruf, angka dan tanda baca akan membuat kata sandi "
+"lebih kuat."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Autentikasi gagal"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Kata sandi baru terlalu pendek"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Kata sandi baru terlalu sederhana"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Kata sandi lama dan baru terlalu mirip"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Kata sandi baru pernah dipakai baru-baru ini."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Kata sandi baru harus mengandung angka atau karakter istimewa"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Kata sandi lama dan baru sama"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Kata sandi Anda telah diubah sejak dari Anda terautentikasi!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Kata sandi baru tidak memuat cukup banyak karakter berbeda"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Galat tak dikenal"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Nama pengguna hanya boleh terdiri dari huruf a-z besar dan kecil, angka, dan "
+"karakter berikut: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Maaf, nama pengguna tersebut tidak tersedia. Harap coba yang lain."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Nama pengguna terlalu panjang."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Petakan Tombol"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Petaka tombol ke fungsi"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Untuk menyunting suatu tombol pintas, pilih aksi \"Kirim Ketukan Tombol\", "
+"tekan tombol pintasan papan tik dan tahan tombol baru atau tekan Backspace "
+"untuk menghapus."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Tutup"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Sentuhlah penanda target yang muncul pada layar untuk melakukan kalibrasi "
+"pada tablet."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Salah klik terdeteksi, memulai ulang…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Tombol %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplikasi yang didefinisikan"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Kirim Ketukan Tombol"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Tukar Monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Tampilkan Bantuan Pada Layar"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tablet dipasang pada panel laptop"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tablet yang dipasang pada layar eksternal"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Perangkat tablet eksternal"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Perangkat pad eksternal"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Semua Tampilan"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Mode Tablet"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Gunakan posisi absolut untuk pena"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientasi Kidal"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tablet dan Tombol™ Ekspres diputar untuk penggunaan tangan kiri"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Petakan ke Monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Jaga Rasio Aspek"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Hanya menggunakan sebagian dari permukaan tablet untuk menjaga rasio aspek "
+"monitor"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibrasikan"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Tablet tak terdeteksi"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Silakan tancapkan atau nyalakan tablet Wacom Anda."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Perasaan Tekanan Ujung"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Lembut"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Tekanan ujung stylus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Tegas"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Tombol 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Tombol 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Tombol 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Perasaan Tekanan Penghapus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Tekanan penghapus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Klik Tombol Tengah Tetikus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Klik Tombol Kanan Tetikus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Maju"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Stylus Airbrush dengan tekanan, kemiringan, dan slider terintegrasi"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Stylus airbrush dengan tekanan, kemiringan, dan rotasi"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Stylus standar dengan tekanan dan kemiringan"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Stylus standar dengan tekanan"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tablet Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Tata pemetaan tombol dan atur kepekaan stylus bagi tablet grafis"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Penghapus;Tetikus;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Pintasan baru…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Titik Akses"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operasi Dibatalkan"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Galat:</b> Akses ditolak saat mengubah pengaturan"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Galat:</b> Galat Peralatan Seluler"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Tidak Terdaftar"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Terdaftar"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Mencari"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Ditolak"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Rincian Modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Status Modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operator Seluler"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tipe Jaringan"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Status Jaringan"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Nomor Ini"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Rincian Peranti"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Versi Firmware"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Hanya 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Hanya 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Hanya 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Hanya 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (Disukai), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (Disukai), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (Disukai), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Disukai), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Disukai), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (Disukai), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (Disukai), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (Disukai), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (Disukai), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (Disukai), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (Disukai), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (Disukai), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (Disukai), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (Disukai), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (Disukai), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (Disukai), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (Disukai)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (Disukai), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Tak Dikenal"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Buka kunci kartu SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Buka Kunci"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Harap berikan kode PIN untuk SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Masukkan PIN untuk membuka kunci kartu SIM Anda"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Harap berikan kode PUK untuk SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Masukkan PUK untuk membuka kunci kartu SIM Anda"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Kata sandi yang dimasukkan salah. Anda punya sisa %1$u percobaan"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Anda punya sisa %u percobaan"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Kata sandi yang dimasukkan salah."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Kode PUK mesti berupa suatu angka 8 digit"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Masukkan PIN Baru"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Kode PIN mesti berupa suatu angka 4-8 digit"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Buka Kunci…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Tidak ada SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Pasang sebuah kartu SIM untuk memakai modem ini"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM Terkunci"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "Data _Seluler"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Akses data memakai jaringan data seluler"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "Roaming _Data"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Gunakan data seluler ketika roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Mode Jari_ngan"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "J_aringan"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Tingkat Lanjut"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Nama _Access Point"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Kunci _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Kunci SIM dengan PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Rincian Modem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Kegagalan telepon"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Tidak ada koneksi ke telepon"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operasi tak diizinkan"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operasi tak didukung"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM tak dipasang"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Perlu PIN SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Perlu PUK SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Kegagalan SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM sibuk"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Kata sandi salah"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Perlu PIN2 SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Perlu PUK2 SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Tak ditemukan"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Tidak ada layanan jaringan"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Jaringan habis waktu"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Layanan GPS tak diizinkan"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming tak diizinkan di wilayah lokasi ini"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Galat GPS yang tak dinyatakan"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Tidak ada Galat"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Aksi Dibatalkan"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Akses ditolak"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Galat Tak Dikenal"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Mode Jaringan"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "Otom_atis"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Pilih Jaringan"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Segarkan Penyedia Jaringan"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Fungsikan Jaringan Seluler"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Tidak Ditemukan Adaptor WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Pastikan Anda punya suatu perangkat Seluler/Wan Nirkabel"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Wan Nirkabel dinonaktifkan ketika mode pesawat aktif"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Ma_tikan Mode Pesawat Terbang"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Koneksi Data"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Kartu SIM dipakai untuk internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Kunci SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "Sela_njutnya"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Kunci SIM dengan PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Ubah PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Masukkan PIN saat ini untuk mengubah pengaturan kunci SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Jaringan Seluler"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Mengkonfigurasi koneksi data seluler dan telefoni"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "seluler;wwan;telefoni;sim;mobile;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilitas untuk mengonfigurasi destop GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Pengaturan adalah antarmuka utama untuk mengkonfigurasi sistem Anda."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Proyek GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Tampilkan nomor versi"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Aktifkan moda verbose"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Cari string"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Tampilkan daftar nama panel yang mungkin dan keluar"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel yang hendak ditampilkan"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMEN…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Kategori pengaturan"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privasi"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Panel yang tersedia:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Semua Pengaturan"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menu Primer"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Peringatan: Versi Pengembangan"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Versi Pengaturan ini hanya boleh digunakan untuk tujuan pengembangan. Anda "
+"mungkin mengalami perilaku sistem yang salah, kehilangan data, dan masalah "
+"tak terduga lainnya. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Bantuan"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Umum"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Keluar"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Cari"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panel"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Kembali ke panel sebelumnya"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Batalkan pencarian"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferensi;Pengaturan;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Pengenal panel Pengaturan terakhir akan dibuka"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Pengenal panel Pengaturan terakhir akan dibuka. Nilai yang tidak dikenal "
+"akan diabaikan dan panel pertama dalam daftar dipilih."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Tampilkan peringatan saat menjalankan hasil bangun pengembangan (development "
+"build) dari Pengaturan"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Apakah Pengaturan harus menampilkan peringatan saat menjalankan hasil bangun "
+"pengembangan (development build)."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Keadaan awal jendela"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Sebuah tuple yang berisi lebar awal, tinggi dan keadaan maksimal jendela "
+"aplikasi."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u Keluaran"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u Masukan"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Suara Sistem"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Galat: tidak dapat menentukan tingkat HSI."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Galat: tidak dapat menentukan tingkat HSI yang salah."
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Tambah Pencetak…"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Sertifikat DER atau PEM  (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Perlindungan Dasar"
+
+#~ msgid "Extended Protection"
+#~ msgstr "Perlindungan yang Diperpanjang"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Perlindungan Keamanan Dasar"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Perlindungan Keamanan yang Diperluas"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI tulis"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI kunci"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "Wilayah BIOS SPI"
+
+#~ msgid "Pre-boot DMA protection is"
+#~ msgstr "Perlindungan DMA pra-boot adalah"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "Kernel tercemar"
+
+#~ msgid "Suspend-to-ram"
+#~ msgstr "Suspensi-ke-ram"
+
+#~ msgid "All TPM PCRs are"
+#~ msgstr "Semua PCR TPM adalah"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "Mode manufaktur MEI"
+
+#~ msgid "MEI override"
+#~ msgstr "MEI menimpa"
+
+#~ msgid "MEI version"
+#~ msgstr "Versi MEI"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "pengaya fwupd"
+
+#~ msgid "Intel DCI debugger"
+#~ msgstr "Pengawakutu Intel DCI"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "Proteksi perangkat IOMMU diaktifkan"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "Proteksi perangkat IOMMU dinonaktifkan"
+
+#~ msgid "Kernel is no longer tainted"
+#~ msgstr "Kernel tidak lagi tercemar"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "Kernel tercemar"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "Penguncian kernel dinonaktifkan"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "Penguncian kernel diaktifkan"
+
+#~ msgid "Pre-boot DMA protection is disabled"
+#~ msgstr "Perlindungan DMA pra-boot dinonaktifkan"
+
+#~ msgid "Pre-boot DMA protection is enabled"
+#~ msgstr "Perlindungan DMA pra-boot diaktifkan"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "Secure Boot dinonaktifkan"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "Secure Boot diaktifkan"
+
+#~ msgid "All TPM PCRs are valid"
+#~ msgstr "Semua TPM PCR valid"
+
+#~ msgid "All TPM PCRs are now valid"
+#~ msgstr "Semua TPM PCR sekarang valid"
+
+#~ msgid "A TPM PCR is now an invalid value"
+#~ msgstr "TPM PCR sekarang menjadi nilai yang tidak valid"
+
+#~ msgid "TPM PCR0 reconstruction is invalid"
+#~ msgstr "Rekonstruksi TPM PCR0 tidak valid"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Kunci layar Anda"
+
+#~ msgid "Drip"
+#~ msgstr "Tetesan"
+
+#~ msgid "Glass"
+#~ msgstr "Gelas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "Light"
+#~ msgstr "Terang"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "layar;kunci;diagnostik;crash;privat;terkini;temporer;tmp;indeks;nama;"
+#~ "jaringan;identitas;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Pengaturan Tampilan"
+
+#~ msgid "Set"
+#~ msgstr "Atur"
+
+#~ msgid "Bark"
+#~ msgstr "Gonggong"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Panel Suara GNOME Pengaturan"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Tetikus &amp; Panel Sentuh GNOME Pengaturan"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Panel Latar Belakang GNOME Pengaturan"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Panel Papan Tik GNOME Pengaturan"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autentikasikan"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Berbagi layar memungkinkan pengguna jarak jauh menilik atau mengendalikan "
+#~ "layar Anda dengan menyambung ke %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Berbagi _Layar"
+
+#~ msgid "_Password:"
+#~ msgstr "Kata _Sandi:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Tampilkan Kata _Sandi"
+
+#~ msgid "Access Options"
+#~ msgstr "Opsi Akses"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Ko_neksi baru mesti meminta akses"
+
+#~ msgid "_Require a password"
+#~ msgstr "Meme_rlukan kata sandi"
+
+#~ msgid "More Warm"
+#~ msgstr "Lebih Hangat"
+
+#~ msgid "Less Warm"
+#~ msgstr "Kurang Hangat"
+
+#~ msgid "Show the screenshot UI"
+#~ msgstr "Tampilkan antarmuka cuplikan layar"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Ambil cuplikan layar"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "Ambil cuplikan layar dari suatu jendela"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "Tampilkan antarmuka perekaman layar"
+
+#~ msgid "Move up"
+#~ msgstr "Naikkan"
+
+#~ msgid "Move down"
+#~ msgstr "Turunkan"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Izinkan aplikasi berikut untuk menggunakan mikrofon Anda."
+
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "Web Links"
+#~ msgstr "Tautan Web"
+
+#~ msgid "Git Links"
+#~ msgstr "Tautan Git"
+
+#~ msgid "%s Links"
+#~ msgstr "%s Tautan"
+
+#~ msgid "Unset"
+#~ msgstr "Tidak Diatur"
+
+#~ msgid "Links"
+#~ msgstr "Tautan"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Berkas Hypertext"
+
+#~ msgid "Text Files"
+#~ msgstr "Berkas Teks"
+
+#~ msgid "Image Files"
+#~ msgstr "Berkas Citra"
+
+#~ msgid "Font Files"
+#~ msgstr "Berkas Fonta"
+
+#~ msgid "Archive Files"
+#~ msgstr "Berkas Arsip"
+
+#~ msgid "Package Files"
+#~ msgstr "Berkas Paket"
+
+#~ msgid "Audio Files"
+#~ msgstr "Berkas Audio"
+
+#~ msgid "Video Files"
+#~ msgstr "Berkas Video"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Izin & Akses"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Data dan layanan yang diminta aplikasi ini untuk akses dan izin yang "
+#~ "diperlukannya."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Tidak bisa diubah"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Izin individual untuk aplikasi dapat ditinjau dalam Pengaturan <a href="
+#~ "\"privacy\">Privasi</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integrasi"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Atur Belakang Destop"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Penangan Bawaan"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Jenis berkas dan tautan yang dibuka aplikasi ini."
+
+#~ msgid "Usage"
+#~ msgstr "Pemakaian"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Berapa banyak sumber daya yang digunakan aplikasi ini."
+
+#~ msgid "Open in Software"
+#~ msgstr "Buka di Perangkat Lunak"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Simpan cuplikan layar ke $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Simpan cuplikan layar dari suatu daerah ke $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Salin cuplikan layar ke papan klip"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Salin cuplikan layar dari suatu jendela ke papan klip"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Salin cuplikan layar dari suatu daerah ke papan klip"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Rekam suatu screencast singkat"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Pilih format untuk angka, tanggal, dan mata uang. Perubahan diterapkan "
+#~ "pada log masuk selanjutnya."
+
+#~ msgid "My Account"
+#~ msgstr "Akunku"
+
+#~ msgid "Language"
+#~ msgstr "Bahasa"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Bahasa yang digunakan untuk teks di jendela dan halaman web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Mulai ulang sesi agar perubahan diterapkan"
+
+#~ msgid "Restart…"
+#~ msgstr "Mulai Ulang…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Pengaturan log masuk dipakai oleh semua pengguna ketika log masuk ke "
+#~ "dalam sistem"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Kontrol hasil pencarian mana yang ditampilkan di Ikhtisar Aktivitas. "
+#~ "Urutan hasil pencarian juga dapat diubah dengan memindahkan baris dalam "
+#~ "daftar."
+
+#~ msgid "Standard"
+#~ msgstr "Standar"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Tipe Akun"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Izinkan pengguna mengatur kata sandi saat _log masuk berikutnya"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Isi kata sa_ndi sekarang"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Anda harus daring untuk menambah pengguna enterprise."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Ambil Foto…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Untuk melakukan perubahan,\n"
+#~ "pertama kali klik ikon *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Buat akun pengguna"
+
+#~ msgid "User Icon"
+#~ msgstr "Ikon Pengguna"
+
+#~ msgid "Account Settings"
+#~ msgstr "Pengaturan Akun"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autentikasi & Log Masuk"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Ini akan dipakai untuk menamai folder rumah Anda dan tak bisa diubah."
+
+#~ msgid "Output:"
+#~ msgstr "Keluaran:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Petakan ke monitor tunggal"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d dari %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Pemetaan Tampilan"
+
+#~ msgid "Stylus"
+#~ msgstr "Stylus"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (absolut)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Touchpad (relatif)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferensi Tablet"
+
+#~ msgid "_Help"
+#~ msgstr "_Bantuan"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Pengaturan Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Mode Pelacakan"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Petakan Tombol…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Setel pengaturan tetikus"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Setel resolusi tampilan"
+
+#~ msgid "Decouple Display"
+#~ msgstr "Tampilan Terpisah"
+
+#~ msgid "No stylus found"
+#~ msgstr "Tak ada stylus yang ditemukan"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Silakan pindah stylus ke dekat tablet untuk mengkonfigurasinya"
+
+#~ msgid "Top Button"
+#~ msgstr "Tombol Puncak"
+
+#~ msgid "Lower Button"
+#~ msgstr "Tombol Bawah"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Tombol Paling Bawah"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Izinkan aplikasi berikut untuk menggunakan kamera Anda."
+
+#~ msgid "Display Mode"
+#~ msgstr "Mode Tampilan"
+
+#~ msgid "Join Displays"
+#~ msgstr "Gabungkan Tampilan"
+
+#~ msgid "Single Display"
+#~ msgstr "Tampilan Tunggal"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Seret tampilan untuk mencocokkan pengaturan tampilan fisik Anda. Pilih "
+#~ "tampilan untuk mengubah pengaturannya."
+
+#~ msgid "Active Display"
+#~ msgstr "Tampilan Aktif"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Layanan lokasi mengizinkan aplikasi untuk tahu lokasi Anda. Memakai Wi-Fi "
+#~ "dan seluler meningkatkan ketepatan."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Menggunakan Layanan Lokasi Mozilla: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Kebijakan Privasi</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Izinkan aplikasi berikut untuk menentukan lokasi Anda."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Putaran terdeteksi: mode kinerja tidak tersedia"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Suhu perangkat keras tinggi: mode kinerja tidak tersedia"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Mode kinerja tidak tersedia"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Suara Tombol"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Pembaca Layar"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Pembaca Layar"
+
+#~ msgid "Activities"
+#~ msgstr "Aktivitas"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Gagal mengunggah berkas: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profil telah diunggah ke:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Catat URL ini."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Nyalakan ulang komputer ini dan boot sistem operasi normal Anda."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Ketikkan URL ke dalam peramban Anda untuk mengunduh dan memasang profil."
+
+#~ msgid "Upload profile"
+#~ msgstr "Unggah profil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Memerlukan koneksi Internet"
+
+#~ msgid "_Copy"
+#~ msgstr "Sali_n"
+
+#~ msgid "Select _All"
+#~ msgstr "Pilih Semu_a"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Tenggat klik ganda"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Tombol Suspensi & Daya"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Beberapa layanan dimatikan karena tidak ada akses jaringan."
+
+#~ msgid "Unlocking..."
+#~ msgstr "Membuka kunci..."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Login;Nama;Sidik jari;Avatar;Logo;Muka;Kata Sandi;"

--- a/po/ie.po
+++ b/po/ie.po
@@ -1,0 +1,7984 @@
+# Interlingue gnome-control-center translation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center 2.20\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-12-13 13:53+0700\n"
+"Last-Translator: OIS <mistresssilvara@hotmail.com>\n"
+"Language-Team: IE\n"
+"Language: ie\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.12\n"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Applicationes"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Null applicationes"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr ""
+"Vu posse crear un archive pos installation de programmas necessari per clicc "
+"del buton %s."
+
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
+msgstr "Aperter"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Vise detalliat"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Serchar"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Despermisset"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificationes"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Monstrar notificationes"
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Lansar in funde"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Capturas de ecran"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Cambiar li tapete"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Cambiar li tapete del pupitre"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sones"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reproducter sones"
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Inhibir suspension"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Rapid-tastes for capturas"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Cámera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+#, fuzzy
+msgid "Take pictures with the camera."
+msgstr "Images"
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microfon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+#, fuzzy
+msgid "Record audio with the microphone."
+msgstr "Rhythmbox ne successat registrar li audio-disco"
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Servicies de localisation"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+#, fuzzy
+msgid "Access device location data."
+msgstr "Ne posset accessar li aparate «%s»"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Standard"
+
+#: panels/applications/cc-applications-panel.ui:223
+#, fuzzy
+msgid "System access that is required by the app"
+msgstr "Un nómine e contrasigne es besonat por li accesse a «%s»"
+
+#: panels/applications/cc-applications-panel.ui:231
+#, fuzzy
+msgid "File &amp; Link Associations"
+msgstr "Associationes de file"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Magasinage"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Null resultates"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+#, fuzzy
+msgid "Try a different search"
+msgstr "Prova un altri sercha"
+
+#: panels/applications/cc-applications-panel.ui:351
+#, fuzzy
+msgid "File & Link Associations"
+msgstr "Associationes de file"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Tipes de file"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Tipes"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+#, fuzzy
+msgid "Reset"
+msgstr "Reverter"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Application"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Total:</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Vacuar li cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stil"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Predefinit"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Obscur"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Funde"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Adjunter un image…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aspecte"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Activar"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Null aparates Bluetooth es trovat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Conexer un adaptator por usa Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Mode de avion es activ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Mode de avion es ínactiv"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "Mode de avion es activ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Mode de avion es activ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+#, fuzzy
+msgid "share;sharing;bluetooth;obex;"
+msgstr "Partir public files per _Bluetooth"
+
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "null images"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+#, fuzzy
+msgid "Display Calibration"
+msgstr "Calibration"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Annular"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Startar"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Reprender"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Finir"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Calibration del ecran"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Qualitá del calibration"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Qualitá"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+#, fuzzy
+msgid "Approximate Time"
+msgstr "Aproximat"
+
+#: panels/color/cc-color-panel.ui:82
+#, fuzzy
+msgid "Calibration Device"
+msgstr "Calibration"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tip de monitor"
+
+#: panels/color/cc-color-panel.ui:125
+#, fuzzy
+msgid "Select the type of display that is connected."
+msgstr "Selecter un tip"
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Null profil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "<b>Luciditá del ecran</b>"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nómine de profil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nómine de profil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Compendie"
+
+#: panels/color/cc-color-panel.ui:259
+#, fuzzy
+msgid "Profile successfully created!"
+msgstr "Archive har esset creat con success"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copiar li profil"
+
+#: panels/color/cc-color-panel.ui:296
+#, fuzzy
+msgid "Requires writable media"
+msgstr "Scribil?"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Adjunter un profil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importar un file…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Adjunter"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr "Plu information"
+
+#: panels/color/cc-color-panel.ui:436
+#, fuzzy
+msgid "Learn more about color management"
+msgstr "(Plu information pri GNU gettext)"
+
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
+msgstr "Applicar por omni usatores"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+#, fuzzy
+msgid "Set this profile for all users on this computer"
+msgstr "Applicar por omni usatores"
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "P_ermisser"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Adjunter un profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibrar..."
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibrar li aparate"
+
+# CHECK
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Remover li profil"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "Vise detalliat"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projector"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+#, fuzzy
+msgid "LCD (CCFL backlight)"
+msgstr "Ilumination de tastatura"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alt"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutes"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Medie"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutes"
+
+# Mausempfindlichkeit
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Bass"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#: panels/color/cc-color-panel.ui:663
+#, fuzzy
+msgid "Native to display"
+msgstr "Nativ nómine"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Printation e edition)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Grafica e fotografie)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Color"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Selecter un lingue"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Selecter"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Null lingues trovat"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Plu..."
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "D_esserrar"
+
+#: panels/common/cc-time-editor.ui:25
+#, fuzzy
+msgid "Increment Hour"
+msgstr "Increment:"
+
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "Increment:"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Hora"
+
+#: panels/common/cc-time-editor.ui:94
+#, fuzzy
+msgid "Decrement Hour"
+msgstr "Diminuer li númere al cursore"
+
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "Diminuer li númere al cursore"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Date e hora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Annu"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mensu"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januar"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Marte"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "May"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Junio"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Julí"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Septembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Octobre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembre"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Decembre"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Die"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Zone horari"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Trovar un cité"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatic date e hora"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+#, fuzzy
+msgid "Requires internet access"
+msgstr "Applicationes por accesser Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Da_te e hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "Actual zone horari:"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Permisset"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Z_one horari"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desserrar"
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr "_Formate de hora"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dates"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 secondes"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calendare"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Numerós"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change the date and time, including time zone"
+msgstr "Cambiar li zone horari del sistema"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+#, fuzzy
+msgid "Clock;Timezone;Location;"
+msgstr "Horloge"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Gardar li parametres de date e hora"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_E-post"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendare"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usica"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Applicationes predefinit"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Applicationes predefinit"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+#, fuzzy
+msgid "default;application;preferred;media;"
+msgstr "Selecter un application predefinit"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+#, fuzzy
+msgid "Problem Reporting"
+msgstr "Raportante spam..."
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+#, fuzzy
+msgid "_Automatic Problem Reporting"
+msgstr "automatic"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostica"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Raportar vor problemas"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "Diagnostica:"
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Applicar"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Retro"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Configurar parametres de monitor..."
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Multiplic monitores"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Unir"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Duplicar"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Primari monitor"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "Nocte"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientation"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolution"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Refriscar chascun"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Adjustar por un TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Scale"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Rulament"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Índisponibil"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "&Filtre..."
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Plan"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Descension til ascension"
+
+#: panels/display/cc-night-light-page.ui:141
+#, fuzzy
+msgid "Manual Schedule"
+msgstr "Plan: "
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+#, fuzzy
+msgid "Times"
+msgstr "Témpores"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "De"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hor"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minute"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Til"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura de color"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Monitores"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr "Nivelle de securitá"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nivelle 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nivelle 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nivelle 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Null evenimentes"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Securitá del aparate"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nómine de aparate"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Modelle de aparatura"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memorie"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafica"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacitá del disco"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calculante..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nómine de OS"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "Construction"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tip de OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Version de GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Cargante..."
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Sistema de fenestres"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisation"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Actualisamentes de programmas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Renominar li aparate"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nómine de aparate"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Renominar"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Pri"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+#, fuzzy
+msgid "View information about your system"
+msgstr "Vider detalliat information pri files e fólderes"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Son e medies"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Assurdar"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Diminuer li volúmine"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Augmentar li volúmine"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "Assurdar"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+#, fuzzy
+msgid "Launch media player"
+msgstr "Lansar un reproductor de medie"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Reproducter (e pausar)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pausar li reproduction"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Stoppar reproduction"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Precedent track"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Sequent track"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Ejecter"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Tippada"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Orígin de digital intrada"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Ear al precedent págine"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lansatores"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Lansar un navigator de auxilie"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Parametres"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Lansar un calculator"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Lansar un client de e-post"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Lansar un navigator web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Hem fólder"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Serchar"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Cluder li session"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Serrar li ecran"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accessibilitá"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+#, fuzzy
+msgid "Turn zoom on or off"
+msgstr "Extinter li aparate"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Agrandar"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Diminuer"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+#, fuzzy
+msgid "Turn screen reader on or off"
+msgstr "Desactivar"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "Tastatura sur ecran"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Incrementar li grandore de textu"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Decrementar li grandore de textu"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+#, fuzzy
+msgid "High contrast on or off"
+msgstr "Tema de alt contraste"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+#, fuzzy
+msgid "Add an Input Source"
+msgstr "Orígin de digital intrada"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+#, fuzzy
+msgid "No input source selected"
+msgstr "Orígin de digital intrada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Optiones"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Mover ad-up"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Mover a-bass"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferenties"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Monstrar li arangeament de tastatura"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr "Remover"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "Orígines"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Orígin de digital intrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "Usar li sam arangeament por omni fenestres"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+#, fuzzy
+msgid "Special Character Entry"
+msgstr "Special &caracter..."
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "Alternativ:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Composir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Rapid-tastes"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Rapid-tastes"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+#, fuzzy
+msgid "Reset All…"
+msgstr "Reverter omni"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+#, fuzzy
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Reverter omni actiones al predefinit del sistema"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Section"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Rapid-tastes"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Ne successat adjuncter un nov rapid-taste"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Rapid-tastes personal"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Adjuncter un rapid-taste"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "_Rapid-taste:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Remover"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "_Vicear"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "A_ssignar"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nómine"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Comande"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Rapid-taste"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Rapid-taste:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Null"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Printator predefinit"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatura"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Protecter vor computator de usagie ínautorisat"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Registrar son med vor microfon e reproducter it"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your conversations"
+msgstr "Null conversationes trovat"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+#, fuzzy
+msgid "microphone;recording;application;privacy;"
+msgstr "Un son-registrator por GNOME"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Pro_var li configuration"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "General"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primari buton"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Levul"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Dextri"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Localisationes"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Mus"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "Velocitá del mus"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Section"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "Posse solmen vider li contenete"
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Posse solmen vider li contenete"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Activ"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Panel tactil"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Velocitá"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "Clic"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Clic"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Velocitá"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Along un bord"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Duplic"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mus e panel tactil"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+#, fuzzy
+msgid "_Hot Corner"
+msgstr "Rapid-tastes"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+#, fuzzy
+msgid "_Active Screen Edges"
+msgstr "Activ ecran"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Labor-spacies"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dinamic labor-spacies"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+#, fuzzy
+msgid "_Fixed number of workspaces"
+msgstr "Númere de _labor-spacies:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+#, fuzzy
+msgid "Specify a number of permanent workspaces."
+msgstr "Númere de labor-spacies: %d\n"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+#, fuzzy
+msgid "_Number of Workspaces"
+msgstr "Númere de _labor-spacies:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Installar li parametres multi-monitor por li tot sistema"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Monstrar icones sur li primari monitor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+#, fuzzy
+msgid "Workspaces on all d_isplays"
+msgstr "Númere de labor-spacies: %d\n"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Politica de alteration"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+#, fuzzy
+msgid "Include applications from all _workspaces"
+msgstr "Monstrar fenestres de _omni labor-spacies"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitache"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Altri aparates"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Adjuncter un connexion"
+
+#: panels/network/cc-network-panel.ui:62
+#, fuzzy
+msgid "Not set up"
+msgstr "Etablisser..."
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Conexet"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Optiones"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Desactivar Wi-Fi"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nómine de rete"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Contrasigne"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Generar un contrasigne"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Autogenerar un contrasigne"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Activar"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Mode de avion"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Retes Wi-Fi (%s)"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Mode de avion es activ"
+
+#: panels/network/cc-wifi-panel.ui:165
+#, fuzzy
+msgid "Turn off to use Wi-Fi"
+msgstr "Desactivar Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Hotspot Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "Extinter li aparate"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Visibil retes"
+
+#: panels/network/cc-wifi-panel.ui:297
+#, fuzzy
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager deve esser lansat."
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Securitá 802.1x"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "ante %i die"
+msgstr[1] "ante %i dies"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Intensitá de signale"
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "_Velocitá:"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Securitá"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Adresse IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adresse IPv6"
+
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr "Adresse de hardware"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Disponibil frequenties"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Rute predefinit"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Ultimmen usat"
+
+#: panels/network/connection-editor/details-page.ui:369
+#, fuzzy
+msgid "Connect _automatically"
+msgstr "Connexer _automaticmen"
+
+#: panels/network/connection-editor/details-page.ui:383
+#, fuzzy
+msgid "Make available to _other users"
+msgstr "Far disponibil por altri _usatores"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nómine"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Adresse _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Adresse _clonat"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "octetes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Metode IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatic (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+#, fuzzy
+msgid "Link-Local Only"
+msgstr "Solmen link-local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Depermisser"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "Partit con altri computatores"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresses"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Masca de rete"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Automatic"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatic DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+#, fuzzy
+msgid "DNS server address(es)"
+msgstr "Remover li adresse(s)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+#, fuzzy
+msgid "Separate IP addresses with commas"
+msgstr "Adresses IP posse usar mustres, quam 192.168.*.*"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rutes"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatic rutes"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrica"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Metode de IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatic, solmen DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefix"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_ecuritá"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rete"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Extinter li aparate"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Activ"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Provisor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adresse IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy de rete"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Socks v5"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorar hostes"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Portu de proxy HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Portu de proxy HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Portu de proxy FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Portu de proxy Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuration"
+
+#: panels/network/network-vpn.ui:11
+#, fuzzy
+msgid "Turn VPN connection off"
+msgstr "Desactivar connexion VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nómine de rete"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tip de securitá"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Contrasigne"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Desactivar Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "_Plu optiones"
+
+#: panels/network/network-wifi.ui:119
+#, fuzzy
+msgid "_Connect to Hidden Network…"
+msgstr "_Conexer a un celat rete..."
+
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Desactivar Wi-Fi"
+
+#: panels/network/network-wifi.ui:143
+#, fuzzy
+msgid "_Known Wi-Fi Networks"
+msgstr "Retes Wi-Fi (%s)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonim"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autenticat"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ambi"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+#, fuzzy
+msgid "Anony_mous identity"
+msgstr "&Identitá:"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_File PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Selecter un file PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "_Internal autentication"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Permisser automatic pro_vision PAC"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nómine de _usator"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Contrasigne"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Revelar li c_ontrasigne"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificate de C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+#, fuzzy
+msgid "Choose a Certificate Authority certificate"
+msgstr "Detallies del certificate:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Ne _besonar certificate de CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Version de PEAP"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitá"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificate de _usator"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Clave privat"
+
+# CHECK: area on dialog one char too short
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "Contrasigne del clave _privat"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (sin EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Dominia"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+#, fuzzy
+msgid "Tunneled TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+#, fuzzy
+msgid "Protected EAP (PEAP)"
+msgstr "EAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tentication"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tip"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (predefinit)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Aperter un diarium de journald"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+#, fuzzy
+msgid "Shared Key"
+msgstr "Clave comun"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Clave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+#, fuzzy
+msgid "Sho_w key"
+msgstr "Re_velar li clave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Índe_x WEP"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificationes"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "&Son:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Notification:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "&Ne monstrar ti avise denov"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Activar notificationes del volúmine sur li ecran."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Ne _disturbar"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Activar notificationes del volúmine sur li ecran."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Defar"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Minimisar in li area de notificationes in vice de cluder"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Adjunter un conto"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Contos online"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+#, fuzzy
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"google, facebook, twitter, yahoo, web, online, chat, calendar, post, e-post, "
+"contacte, owncloud, kerberos, imap, smtp, pocket, readitlater, conto"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minute"
+msgstr[1] "%i minutes"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hor"
+msgstr[1] "%i hores"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hor"
+msgstr[1] "hores"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minute"
+msgstr[1] "minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hor"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 hores"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batterie"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Aparates"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "_Accender"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Conservation de energie"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Automatic luciditá"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Obscurar li ecran"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Blanc ecran"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Garda-ecran"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "suspendente"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+#, fuzzy
+msgid "Show Battery _Percentage"
+msgstr "Frequentie quam _percentage"
+
+#: panels/power/cc-power-panel.ui:244
+#, fuzzy
+msgid "Automatic Suspend"
+msgstr "suspendente"
+
+#: panels/power/cc-power-panel.ui:267
+#, fuzzy
+msgid "_Plugged In"
+msgstr "Conexet al rete"
+
+#: panels/power/cc-power-panel.ui:279
+#, fuzzy
+msgid "On _Battery Power"
+msgstr "Batterie ea exhaustet"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Retarde"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energie"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Printatores"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr "Adjunter un printator"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "D_esserrar"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Null printatores trovat"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autentication es besonat"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nómine de usator"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Localisation"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:178
+#, fuzzy
+msgid "Searching for preferred drivers…"
+msgstr "Preferet"
+
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "Driveres"
+
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "S_electer ex:"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Installar un file PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "Null driver disponibil por ti-ci printator."
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "Base de data:"
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Anullar"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Selecter"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Dominia"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utenticar"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Vacuar omni"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autenticar"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "Printator"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Prov-págine"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u tache"
+msgstr[1] "%u taches"
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Printation..."
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Detallies"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Printator predefinit"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "Nettar"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Remover li printator"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Activ"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modelle"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nivelle de incre"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "Restarta"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr "Adjunter un printator…"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Adjunter un printator…"
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr "Null printatores"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formates"
+
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Configurante locales."
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Comun formates"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Omni formates"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "Resultates del sercha"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Previder"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Dates"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dates e horas"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Numerós"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mesuras"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papere"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Cluder li session…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr "Vor conto"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Lingue"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr "_Formates"
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Ecran de session"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Region e lingue"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "Selecte vor preferet lingue"
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+#, fuzzy
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Schema del layout"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Audio CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "Video _DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Reproductor de _musica"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Programmas"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Altri medies..."
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Action:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tip:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Medies removibil"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Configurar gerentie de removibil unités e medies"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr ""
+"Null serrures de ecran lansat successosimen e li ecran ne va esser serrat.\n"
+"Esque vu vole continuar suspender li sistema?"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "Blanc ecran"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+#, fuzzy
+msgid "Automatic Screen _Lock"
+msgstr "Serrar li ecran"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "Serrar li ecran _ante que somniar"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Monstrar notificationes"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Activar notificationes del volúmine sur li ecran."
+
+#: panels/screen/cc-screen-panel.ui:101
+#, fuzzy
+msgid "Forbid new _USB devices"
+msgstr "Aparates USB"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "_Privatie:"
+
+#: panels/screen/cc-screen-panel.ui:127
+#, fuzzy
+msgid "Restrict Viewing Angle"
+msgstr "Exhibition es activ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ecran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Parametres del ecran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+#, fuzzy
+msgid "screen;lock;private;privacy;"
+msgstr "Serrar li ecran _ante que somniar"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Localisationes"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Locs"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Marca-págines"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Altri"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Adjunter un localisation"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Ne successat serchar por un application"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Resultates del sercha"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Retes"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Partir"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Nómine de _computator"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Partition de files"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Cliente de lontan pupitre Remmina"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "Partir"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr ""
+"Esque vu have un conto sur servitore RDP, Lontan session lassa vos lansar "
+"applicationes de ti servitore."
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Partition de files"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Besonar un contrasigne:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+#, fuzzy
+msgid "Remote Login"
+msgstr ""
+"Esque vu have un conto sur servitore RDP, Lontan session lassa vos lansar "
+"applicationes de ti servitore."
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Assignar Remmina quam li predefinit cliente de lontan pupitre"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Telecomande"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Connexer a..."
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copiar"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Cliente de lontan pupitre Remmina"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autentication"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nómine de usator"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+#, fuzzy
+msgid "Verify Encryption"
+msgstr "Sin ciffration"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Ciffration"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "Partir"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Fólderes"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+#, fuzzy
+msgid "Enable or disable remote login"
+msgstr "Permisser aperter li session per un fingre-print"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+# CHECK
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Clic"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Catene"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balancie"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Evanescer"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Posteriori"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Frontal"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+#, fuzzy
+msgid "Click a speaker to test"
+msgstr "Alt-parlator"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volúmine del sistema"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Volúmine"
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Adjustar li volúmine"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Exeada"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Aparate de exeada"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Provar"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuration"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Intrada"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Aparate de intrada"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volúmine"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "S_electe un son de avise:"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Assurdar"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Son"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Minimisar in li area de notificationes in vice de cluder"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nómine:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Statu:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "_Autorisar..."
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Obliviar li aparate"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+#, fuzzy
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Ne successat conexer al gerente de session"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Direct image"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Atendente"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage Thunderbolt devices"
+msgstr "Gerentie de aparates Bluetooth"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+#, fuzzy
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "Cursore:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "_Velocitá:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocitá"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Apuntator"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Dimension de apuntator"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+#, fuzzy
+msgid "Click Assist"
+msgstr "o clicca li icone "
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Secundari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+#, fuzzy
+msgid "A_cceptance delay:"
+msgstr "Sin retarde"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "Retarde:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "Clic"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "R_etarde:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Lími_te de motion:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Micri"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grand"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetir tastes"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "_Retarde de repetition:"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+#, fuzzy
+msgid "Repeat keys speed"
+msgstr "Velocitá"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Tippada"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Restant tastes"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Desactivar restant tastes quande du tastes es _presset simultanmen."
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Clave"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "%s: multiplic claves por %s"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+#, fuzzy
+msgid "Slow keys typing delay"
+msgstr "Avise de lent tastes"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Clave"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Presset"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Presset"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Rest_ant tastes"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+#, fuzzy
+msgid "Bounce keys typing delay"
+msgstr "Usar _restant tastes"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+#, fuzzy
+msgid "_Enable by Keyboard"
+msgstr "Activar LEDs de tastatura"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Sempre monstrar li panel de cartes"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Alt contraste"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "G_rand textu"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+#, fuzzy
+msgid "Enable A_nimations"
+msgstr "P_ermisser"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Letor del ecran"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Claves"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "c"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Scale"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+#, fuzzy
+msgid "Hearing"
+msgstr "Por li malaudient"
+
+# CHECK
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Visual"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Tastatura sur ecran"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Int_ervalle de repetition:"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Cursore:"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
+msgstr "Statu de AccessX"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "apuntator"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Tastes del _mus"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Trovar _li apuntator"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+#, fuzzy
+msgid "_Click Assist"
+msgstr "o clicca li icone "
+
+# CHECK
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "A duplic clic: "
+
+# CHECK
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "A duplic clic: "
+
+# CHECK
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+#, fuzzy
+msgid "Visual Alerts"
+msgstr "Visual"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+#, fuzzy
+msgid "_Test flash"
+msgstr "Sin flash"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Capter li tot ecran"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Flash:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Plen-ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Alt midí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Bass midí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Levul midí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Dextri midí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "_Agrandar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "Agrandation"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "&Lupe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Apuntator del mus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Departion"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "Usar li L_upe del ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lupe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Reticul:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "Apuntator del mus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "S_pessore:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tenui"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Spess"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Longore:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Co_lor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Reticul"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efectes de color:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "Blan_c sur nigri:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Luciditá:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contraste:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+#, fuzzy
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Co_lor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Null"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Complet"
+
+# Mausempfindlichkeit
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Bass"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alt"
+
+# Mausempfindlichkeit
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Bass"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efectes de color"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Diarium de files"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "H"
+
+#: panels/usage/cc-usage-panel.ui:25
+#, fuzzy
+msgid "File _History Duration"
+msgstr "Diarium de files e li Paper-corb"
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "Vacuar li diarium…"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "<b>Temporari files</b>"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "_Deleter ex li Paper-corb"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Ne successat remover li temporari file"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "_Automaticmen"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Vacuar li _Paper-corb…"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "Ne successat remover li temporari file"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Diarium de files e li Paper-corb"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "Lassar it"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Adjunter un usator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Beim ersten Start _automatisch einen Benutzer anmelden"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Assignar un contrasigne"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Enterprise"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Ne in li rete"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Selecter un file…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Fingre-print:\n"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Fingre-print"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_No"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Yes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Fingre-print:\n"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Fingre-print:\n"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+#, fuzzy
+msgid "Ensure the device is properly connected."
+msgstr "Aparate es fidet e conexet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Fingre-print:\n"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Permisser aperter li session per un fingre-print"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+#, fuzzy
+msgid "_Delete Fingerprints"
+msgstr "_Deleter fingre-printes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Fingre-print:\n"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Precedent"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Sequent"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Cambiar li contrasigne"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "C_ambiar"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Actual contrasigne"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nov contrasigne"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Confirmar li contrasigne"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Contrasignes"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "Assignar un contrasigne"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Usatores"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Restartar nu"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Cluder"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Avatar:"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Nómine complet"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Redacter"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+#, fuzzy
+msgid "_Fingerprint Login"
+msgstr "Permisser aperter li session per un fingre-print"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+#, fuzzy
+msgid "A_utomatic Login"
+msgstr "A_utomatic"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "Activitá"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Controles"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Aperter per altri application..."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "_Remover..."
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Privilegies es besonat por controlar processus de altri usatores"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr ""
+"Un error evenit. Ples penar installar samba e adjunter vor usator in li "
+"gruppe «sambashare» manualmen."
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Usatores"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "&Adjunter un conto..."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+#, fuzzy
+msgid "Domain Administrator Login"
+msgstr "_Dominia"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+#, fuzzy
+msgid "Administrator _Name"
+msgstr "(quam Administrator)"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+#, fuzzy
+msgid "Administrator Password"
+msgstr "(quam Administrator)"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+#, fuzzy
+msgid "Manage user accounts"
+msgstr "Gerer contos"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Butones"
+
+#: panels/wacom/button-mapping.ui:26
+#, fuzzy
+msgid "Map buttons to functions"
+msgstr "Corespondentie"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+#, fuzzy
+msgid "_Close"
+msgstr "C_lusion"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "Extern"
+
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tabulette"
+
+#: panels/wacom/cc-wacom-page.ui:17
+#, fuzzy
+msgid "Use absolute positioning for the pen"
+msgstr "Plum (absolut)"
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Orientation por li levul manu"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "_Aspecte"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Calibrar"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+#, fuzzy
+msgid "No tablet detected"
+msgstr "Null tabulette detectet"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+#, fuzzy
+msgid "Tip Pressure Feel"
+msgstr "_Pression:"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+#, fuzzy
+msgid "Soft"
+msgstr "Soft"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+#, fuzzy
+msgid "Stylus tip pressure"
+msgstr "_Pression:"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Extra buton %1:"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "_Buton:"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+#, fuzzy
+msgid "Eraser Pressure Feel"
+msgstr "Pression"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Pression"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+#, fuzzy
+msgid "Middle Mouse Button Click"
+msgstr "Clic del dextri mus-buton"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+#, fuzzy
+msgid "Right Mouse Button Click"
+msgstr "Clic del dextri mus-buton"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+#, fuzzy
+msgid "Forward"
+msgstr "Avan"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tabulette Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Secundari"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Programma de Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr " in li printator «%s»"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Retarde:"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Programma de Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Adresse:"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Adjunter"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salvar"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+msgid "Modem Status"
+msgstr "Modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+#, fuzzy
+msgid "Carrier"
+msgstr "Portator"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Rete: "
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Statu: "
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Parte de un libre con su propri titul"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "_Detallies de aparate"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricator"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Version de firmware:"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+#, fuzzy
+msgid "No SIM"
+msgstr "PIN del SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "Serrat"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Mobil:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+#, fuzzy
+msgid "_Data Roaming"
+msgstr "Null data"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "mode"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "ID de r_ete"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Avansates"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Protocol Punctu-ad-punctu"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "SIM es íncorrect"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+#, fuzzy
+msgid "Lock SIM with PIN"
+msgstr "SIM: PIN es besonat"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "&Detallies"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "mode"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_Automatic"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Bitte wählen Sie einen Netzwerkrechner, zu dem verbunden werden soll."
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "Refriscar li liste de retes"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Mobil rete"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Adaptator:"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Mode de avion es activ"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Data"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM: null carte insertet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "SIM es íncorrect"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Sequent"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+#, fuzzy
+msgid "_Lock SIM with PIN"
+msgstr "SIM: PIN es besonat"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "PIN:"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobil rete"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+#, fuzzy
+msgid "Utility to configure the GNOME desktop"
+msgstr "Gerentie de discos por GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Li projecte GNOME"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categories de parametres"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "Privatie"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Omni parametres"
+
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Monstrar li primari menú"
+
+#: shell/cc-window.ui:152
+#, fuzzy
+msgid "Warning: Development Version"
+msgstr "Avise"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Auxilie"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "General"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Surtir"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Serchar"
+
+# CHECK
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneles"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Retornar al precedent menú"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "_Anullar"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "Parametres personal"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+#, fuzzy
+msgid "Initial state of the window"
+msgstr "Statu inicial del fenestre:"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#, fuzzy
+#~ msgid "System Bus"
+#~ msgstr "D-Bus"
+
+#, fuzzy
+#~| msgid "Full Name"
+#~ msgid "Full access"
+#~ msgstr "Accesse"
+
+#, fuzzy
+#~ msgid "Session Bus"
+#~ msgstr "Ne successat conexer al bus de session D-Bus."
+
+#, fuzzy
+#~ msgid "Full access to /dev"
+#~ msgstr "[dev]"
+
+#, fuzzy
+#~ msgid "Has network access"
+#~ msgstr "Permisser accesse al rete"
+
+#~ msgid "Home"
+#~ msgstr "Hem"
+
+#~ msgid "Read-only"
+#~ msgstr "Solmen letion"
+
+#~ msgid "File System"
+#~ msgstr "Sistema de files"
+
+#, fuzzy
+#~ msgid "Can change settings"
+#~ msgstr "Cambiar vor parametres de lingue e region"
+
+#, fuzzy, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "Disc-spacie de «%s» es bass"
+
+#~ msgid "Select a picture"
+#~ msgstr "Selecter un image"
+
+#~ msgid "_Open"
+#~ msgstr "_Aperter"
+
+#~ msgid "multiple sizes"
+#~ msgstr "multiplic dimensiones"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Null funde del Pupitre"
+
+#~ msgid "Current background"
+#~ msgstr "Li actual image de funde"
+
+#, fuzzy
+#~ msgid "Shut the laptop lid"
+#~ msgstr "<b>Covrette de portabile</b>"
+
+#, fuzzy
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Un errore intern evenit"
+
+#, fuzzy
+#~ msgid "The profile could not be generated."
+#~ msgstr "Generat"
+
+#, fuzzy
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Traduction:"
+
+#~ msgid "Complete!"
+#~ msgstr "Compleet!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Calibration ne successat!"
+
+#, fuzzy
+#~ msgid "You can remove the calibration device."
+#~ msgstr "vu posse remover ti file e repena denov"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Ecran de portatibile"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Integrat webcam"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Scannator %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Cámera %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Printator %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Web-cámera %s"
+
+#, fuzzy, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Activar gerentie de color por %s"
+
+#, fuzzy, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Assignar profiles de color"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Ne calibrat"
+
+#~ msgid "Default: "
+#~ msgstr "Predefinit: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Spacie de color: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Profil de prova: "
+
+#, fuzzy
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Selecter un file de profile ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importar"
+
+#, fuzzy
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Suportat profiles ICC"
+
+#~ msgid "All files"
+#~ msgstr "Omni files"
+
+#~ msgid "Save Profile"
+#~ msgstr "Gardar li profil"
+
+#, fuzzy
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Crear un profil de color por li selectet aparate"
+
+#, fuzzy
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Li tip de aparate es bentost ínsuportat."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standard spacie"
+
+#~ msgid "Test Profile"
+#~ msgstr "Profil de prova"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatic"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Bass qualitá"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Medie qualitá"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Alt qualitá"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Predefinit RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Predefinit CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Predefinit gris"
+
+#~ msgid "Other…"
+#~ msgstr "Altri…"
+
+#, fuzzy
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Ne successat cambiar parametres de NTP"
+
+#~ msgid "Today"
+#~ msgstr "Hodie"
+
+#~ msgid "Yesterday"
+#~ msgstr "Yer"
+
+#~ msgid "%b %e"
+#~ msgstr "%-e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-e %b  %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d hor"
+#~ msgstr[1] "%d hores"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minute"
+#~ msgstr[1] "%d minutes"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d seconde"
+#~ msgstr[1] "%d secondes"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24-hor"
+
+#, fuzzy
+#~ msgid "AM / PM"
+#~ msgstr "Mon_strar AM/PM"
+
+#, fuzzy
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%-e %b %Y %l:%M %p"
+
+#, fuzzy
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%A, %e %B %Y"
+
+#, fuzzy, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "\t%s%s%s%s%s\n"
+
+#, fuzzy, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "\t%s%s%s%s%s\n"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#, fuzzy
+#~ msgid "%l:%M %p"
+#~ msgstr "%H:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, fuzzy, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "\t%s%s%s%s%s\n"
+
+#, fuzzy
+#~ msgid "Off"
+#~ msgstr "No"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Applicar li alterationes?"
+
+#, fuzzy
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Alterationes es applicat"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Paisage"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portrete"
+
+#, fuzzy
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portrete"
+
+#, fuzzy
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Paisage"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#, fuzzy
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Secure Boot es ínactiv"
+
+#, fuzzy
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Secure Boot es ínactiv"
+
+#, fuzzy
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Secure Boot es ínactiv"
+
+#, fuzzy
+#~| msgid "_Password:"
+#~ msgid "Passed"
+#~ msgstr "Ínvalid argument del option \"sortby\"."
+
+#~ msgid "Failed"
+#~ msgstr "Ne successat"
+
+#, fuzzy
+#~ msgid "Security Level 0"
+#~ msgstr "Nivelle de securitá"
+
+#, fuzzy
+#~ msgid "Security Level 1"
+#~ msgstr "Nivelle de securitá"
+
+#, fuzzy
+#~ msgid "Security Level 2"
+#~ msgstr "Nivelle de securitá"
+
+#, fuzzy
+#~ msgid "Security Level 3"
+#~ msgstr "Nivelle 3"
+
+#, fuzzy
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Actualisamentes de securitá es disponibil"
+
+#, fuzzy
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Secure Boot es ínactiv"
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Secure Boot es ínactiv"
+
+#, fuzzy
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Protection de IOMMU"
+
+#, fuzzy
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Firmware"
+
+#, fuzzy
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Region"
+
+#, fuzzy
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "_Bootabil del Legacy BIOS"
+
+#, fuzzy
+#~ msgid "Intel BootGuard"
+#~ msgstr "file hexadecimal de objecte de Intel"
+
+#, fuzzy
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "FUSE"
+
+#, fuzzy
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Ínactiv"
+
+#, fuzzy
+#~ msgid "Intel CET Active"
+#~ msgstr "Activ"
+
+#, fuzzy
+#~ msgid "Intel SMAP"
+#~ msgstr "file hexadecimal de objecte de Intel"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Ciffrat RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Protection de IOMMU"
+
+#, fuzzy
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Li nucleo Linux."
+
+#, fuzzy
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Li nucleo Linux."
+
+#~ msgid "Linux Swap"
+#~ msgstr "Swap de Linux"
+
+#, fuzzy
+#~ msgid "Suspend To RAM"
+#~ msgstr "Esque vu vole suspender a RAM?"
+
+#, fuzzy
+#~ msgid "Suspend To Idle"
+#~ msgstr ""
+#~ "%s [OPTION...] COMANDE\n"
+#~ "\n"
+#~ "Executar COMANDE inhibiente alcun functionalitá de session.\n"
+#~ "\n"
+#~ "  -h, --help        Monstrar ti-ci textu\n"
+#~ "  --version         Monstrar li version de programma\n"
+#~ "  --app-id ID       ID de application a usar durante inhibition "
+#~ "(facult.)\n"
+#~ "  --reason CAUSE    Li cause de inhibition (facultatativ)\n"
+#~ "  --inhibit ARG     Quo inhibir, un liste separat per commas de:\n"
+#~ "                    logout (cluder li session), switch-user (cambiar li "
+#~ "usator),\n"
+#~ "                    suspend, idle (ínoperation), automount\n"
+#~ "\n"
+#~ "Si null parametre --inhibit es present, \"idle\" es suposit.\n"
+
+#, fuzzy
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Platforme"
+
+#, fuzzy
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Secure Boot es ínactiv"
+
+#, fuzzy
+#~| msgid "Proxy Configuration"
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM v2.0"
+
+#, fuzzy
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Actualisation del firmware"
+
+#, fuzzy
+#~ msgid "Firmware Attestation"
+#~ msgstr "Firmware"
+
+#, fuzzy
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Actualisation del fólderes de sercha"
+
+#, fuzzy
+#~ msgid "Platform Debugging"
+#~ msgstr "Platforme"
+
+#, fuzzy
+#~ msgid "Processor Security Checks"
+#~ msgstr "_Processor"
+
+#, fuzzy
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Protection per un contrasigne"
+
+#, fuzzy
+#~ msgid "Fused Platform"
+#~ msgstr "Platforme"
+
+#~ msgid "Valid"
+#~ msgstr "Valid"
+
+#~ msgid "Not Valid"
+#~ msgstr "Ínvalid"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Ínactiv"
+
+#~ msgid "Locked"
+#~ msgstr "Serrat"
+
+#, fuzzy
+#~ msgid "Not Locked"
+#~ msgstr "Serrat"
+
+#~ msgid "Encrypted"
+#~ msgstr "Ciffrat"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Ne ciffrat"
+
+#, fuzzy
+#~ msgid "Not Tainted"
+#~ msgstr "Ne conexet"
+
+#~ msgid "Found"
+#~ msgstr "trovat"
+
+#~ msgid "Not Found"
+#~ msgstr "Ne trovat"
+
+#~ msgid "Supported"
+#~ msgstr "Suportat"
+
+#~ msgid "Not Supported"
+#~ msgstr "Ínsuportat"
+
+#~ msgid "Unknown"
+#~ msgstr "Ínconosset"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Ínconosset"
+
+#~ msgid "Not Available"
+#~ msgstr "Índisponibil"
+
+#, fuzzy
+#~| msgid "System"
+#~ msgid "System Logo"
+#~ msgstr "Null logo"
+
+#, fuzzy
+#~ msgid "No input sources found"
+#~ msgstr "Trovat fontes de dictionariums"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr " Altri"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Rapid-tastes personal"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Levul Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Dextri Alt"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super A"
+
+#, fuzzy
+#~| msgid "Right"
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super A"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Taste Menú"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Dextri Ctrl"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~| msgid "Screen"
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificat"
+#~ msgstr[1] "%d modificat"
+
+#, fuzzy
+#~| msgid "Shortcut"
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr ""
+#~ "To va reverter omni rapid-tastes a su valores predefinit. Esque vu vole "
+#~ "far to?"
+
+#, fuzzy
+#~ msgid "Reset All"
+#~ msgstr "Reverter omni"
+
+#, fuzzy
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Nov abreviation de web"
+
+#, fuzzy
+#~| msgid "Shortcut"
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Personal rapid-taste"
+
+#, fuzzy
+#~| msgid "Shortcut"
+#~ msgid "Set Shortcut"
+#~ msgstr "Rapid-taste:"
+
+#, fuzzy, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Intra un nov pass-frase por «%s»"
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Adjunter un personal rapid-taste"
+
+#, fuzzy
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Rulament con du fingres"
+
+# CHECK
+#, fuzzy
+#~ msgid "Double click, primary button"
+#~ msgstr "_Duplic clic por activar elementes"
+
+#, fuzzy
+#~ msgid "Single click, primary button"
+#~ msgstr "Singul _clic por activar elementes"
+
+# CHECK
+#, fuzzy
+#~ msgid "Double click, middle button"
+#~ msgstr "Medial clic"
+
+#, fuzzy
+#~ msgid "Single click, middle button"
+#~ msgstr "Medial clic"
+
+# CHECK
+#, fuzzy
+#~ msgid "Double click, secondary button"
+#~ msgstr "_Duplic clic por activar elementes"
+
+#, fuzzy
+#~ msgid "Single click, secondary button"
+#~ msgstr "Singul _clic por activar elementes"
+
+#, fuzzy
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager deve esser lansat."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#, fuzzy
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "ínsecur."
+
+#, fuzzy
+#~ msgid "Secure network (WPA)"
+#~ msgstr "secur."
+
+#, fuzzy
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "WPA2"
+
+#, fuzzy
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "WPA3 personal"
+
+#~ msgid "Secure network"
+#~ msgstr "Secur rete"
+
+#, fuzzy
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Terminar hotspot"
+
+#~ msgid "Preserve"
+#~ msgstr "Preservar"
+
+#, fuzzy
+#~ msgid "Permanent"
+#~ msgstr "Memorar li conexion al ti-ci servitore"
+
+#~ msgid "Random"
+#~ msgstr "Hasardal"
+
+#~ msgid "Stable"
+#~ msgstr "Stabil"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#, fuzzy
+#~ msgid "Enhanced Open"
+#~ msgstr "Configurar li avansat functiones de navigation"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#, fuzzy
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Null"
+
+#~ msgid "Never"
+#~ msgstr "Nequande"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2,4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2,4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Necú"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Debil"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "OK"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bon"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excellent"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Obliviar li conexion"
+
+#, fuzzy
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Remover un profil"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Remover li VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detallies"
+
+#~ msgid "automatic"
+#~ msgstr "automatic"
+
+#~ msgid "Identity"
+#~ msgstr "Identitá"
+
+#~ msgid "Delete Address"
+#~ msgstr "Remover li adresse"
+
+#~ msgid "Delete Route"
+#~ msgstr "Remover li rute"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Null"
+
+#, fuzzy
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Pass-frase"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinamic (802.1x)"
+
+#, fuzzy
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA e WPA2 Enterprise"
+
+#, fuzzy
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA e WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 personal"
+
+#, fuzzy
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Aperter un conexion"
+
+#~ msgid "New Profile"
+#~ msgstr "Crear un profil"
+
+#, fuzzy, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "%s: codification ínvalid.\n"
+
+#, fuzzy, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Ínvalid nómine de file %s"
+
+#, fuzzy
+#~ msgid "Import from file…"
+#~ msgstr "Ne successat importar un bux del file «%s»."
+
+#~ msgid "Add VPN"
+#~ msgstr "Adjunter un VPN"
+
+#, fuzzy
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Desactivar connexion VPN"
+
+#, fuzzy
+#~| msgid "Select Image"
+#~ msgid "Select file to import"
+#~ msgstr "Selecte un file a importar"
+
+#, fuzzy, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr ""
+#~ "Un file nominat «%s» ja existe.\n"
+#~ "\n"
+#~ "%s"
+
+#, fuzzy
+#~ msgid "_Replace"
+#~ msgstr "Substituer?"
+
+#, fuzzy
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Desactivar connexion VPN"
+
+#, fuzzy
+#~ msgid "Export VPN connection"
+#~ msgstr "Un connexion VPN ne successat"
+
+#~ msgid "never"
+#~ msgstr "nequande"
+
+#~ msgid "today"
+#~ msgstr "hodie"
+
+#~ msgid "yesterday"
+#~ msgstr "yer"
+
+#~ msgid "Last used"
+#~ msgstr "Ultimmen usat"
+
+#~ msgid "Add new connection"
+#~ msgstr "Adjuncter un nov connexion"
+
+#~ msgid "_Forget"
+#~ msgstr "_Obliviar"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Conosset retes Wi-Fi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Obliviar"
+
+#, fuzzy
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "To ne es recomandat por ínfidet public retes."
+
+#~ msgid "Status unknown"
+#~ msgstr "Ínconosset statu"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Íngeret"
+
+#~ msgid "Unavailable"
+#~ msgstr "Índisponibil"
+
+#~ msgid "Connecting"
+#~ msgstr "Conexente"
+
+#~ msgid "Authentication required"
+#~ msgstr "Autentication es besonat"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Deconexente"
+
+#~ msgid "Connection failed"
+#~ msgstr "Conexion ne successat"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Ínconosset statu (mancant)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Configuration ne successat"
+
+#, fuzzy
+#~| msgid "Proxy Configuration"
+#~ msgid "IP configuration failed"
+#~ msgstr "Configuration de IP ne successat"
+
+#, fuzzy
+#~| msgid "Proxy Configuration"
+#~ msgid "IP configuration expired"
+#~ msgstr "Configuration de IP ha expirat"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Suplicante 802.1x ha deconexet"
+
+#, fuzzy
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Configuration del suplicante 802.1x ne successat"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Suplicante 802.1x ne successat"
+
+#, fuzzy
+#~ msgid "PPP service failed to start"
+#~ msgstr "Servicie PPP ne successat lansar"
+
+#, fuzzy
+#~ msgid "PPP service disconnected"
+#~ msgstr "Servicie PPP ha desconexet"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP ne successat"
+
+#, fuzzy
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Client DHCP ne successat lansar"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Errore de client DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Client DHCP ne successat"
+
+#, fuzzy
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Servicie AutoIP ne successat lansar"
+
+#, fuzzy
+#~ msgid "Shared connection service failed"
+#~ msgstr "Conexion ne successat"
+
+#, fuzzy
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Servicie AutoIP ne successat lansar"
+
+#, fuzzy
+#~ msgid "AutoIP service error"
+#~ msgstr "Errore del servicie AutoIP"
+
+#, fuzzy
+#~ msgid "AutoIP service failed"
+#~ msgstr "Servicie AutoIP ne successat"
+
+#~ msgid "Line busy"
+#~ msgstr "Linea es ocupat"
+
+#, fuzzy
+#~ msgid "No carrier could be established"
+#~ msgstr "Ne successat negociar un portator"
+
+#, fuzzy
+#~ msgid "Dialing request timed out"
+#~ msgstr "Timeout evenit durante de conexion."
+
+#, fuzzy
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Prova discar ne successat"
+
+#, fuzzy
+#~ msgid "Modem initialization failed"
+#~ msgstr "Inicialisation de modem ne successat"
+
+#, fuzzy
+#~ msgid "Not searching for networks"
+#~ msgstr "Sercha..."
+
+#, fuzzy
+#~ msgid "Network registration denied"
+#~ msgstr "Registration in li rete refusat"
+
+#, fuzzy
+#~ msgid "Network registration timed out"
+#~ msgstr "Timeout evenit durante de verification del session."
+
+#, fuzzy
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Ne successat registrar in li selectet rete"
+
+#, fuzzy
+#~ msgid "PIN check failed"
+#~ msgstr "Control de PIN ne successat"
+
+#, fuzzy
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Li firmware por li aparate posse esser mancant"
+
+#, fuzzy
+#~ msgid "Connection disappeared"
+#~ msgstr "Null conexion"
+
+#, fuzzy
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Un _existent album"
+
+#~ msgid "Modem not found"
+#~ msgstr "Null modem trovat"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Conexion Bluetooth ne successat"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM: null carte insertet"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM: PIN es besonat"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM: PUK es besonat"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM es íncorrect"
+
+#, fuzzy
+#~ msgid "Connection dependency failed"
+#~ msgstr "Ne successat resoluer problemas del dependenties!"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Firmware manca"
+
+#, fuzzy
+#~ msgid "Cable unplugged"
+#~ msgstr "Cable"
+
+#, fuzzy
+#~ msgid "no file selected"
+#~ msgstr "Null file selectet"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certificates DER o PEM"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Files PAC (*.pac)"
+
+#, fuzzy
+#~ msgid "missing EAP username"
+#~ msgstr "Nómine de _usator"
+
+#, fuzzy
+#~| msgid "Change password"
+#~ msgid "missing EAP password"
+#~ msgstr "MSCHAPv2 (sin EAP)"
+
+#, fuzzy
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Certificate personal"
+
+#, fuzzy
+#~ msgid "Choose your private key"
+#~ msgstr "Li clave privat"
+
+#~ msgid "Select a file"
+#~ msgstr "Selecter un file"
+
+#, fuzzy
+#~ msgid "missing leap-username"
+#~ msgstr "Nómine de _usator"
+
+#, fuzzy
+#~| msgid "Change password"
+#~ msgid "missing leap-password"
+#~ msgstr "Bissextil"
+
+#, fuzzy
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Contrasigne de Wi-Fi"
+
+#, fuzzy
+#~ msgid "missing wep-key"
+#~ msgstr "Li clave es mancant"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr " Altri"
+
+#, fuzzy, c-format
+#~ msgid "%s removed"
+#~ msgstr "Video «%s» esset removet."
+
+# CHECK
+#, fuzzy
+#~ msgid "Error removing account"
+#~ msgstr "Un errore evenit removente un conto"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Conto %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Remover li conto"
+
+#~ msgid "Unknown time"
+#~ msgstr "Ínconosset témpor"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, fuzzy, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr ""
+#~ "%s (%i%%)\n"
+#~ "%s til complet charge"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Avise: %s remane"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s remane"
+
+#~ msgid "Fully charged"
+#~ msgstr "Chargeat completmen"
+
+#~ msgid "Not charging"
+#~ msgstr "Ne chargeante"
+
+#~ msgid "Empty"
+#~ msgstr "Vacui"
+
+#~ msgid "Charging"
+#~ msgstr "Chargeante"
+
+#~ msgid "Discharging"
+#~ msgstr "Dechargeante"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Mus sin fil"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Tastatura sin fil"
+
+#, fuzzy
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Íninterruptibil fonte de energie"
+
+#, fuzzy
+#~ msgid "Personal digital assistant"
+#~ msgstr "Digital assistente personal (PDA)"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telefon cellulari"
+
+#~ msgid "Media player"
+#~ msgstr "Reproductor de medie"
+
+#~ msgid "Tablet"
+#~ msgstr "Tabulette"
+
+#~ msgid "Computer"
+#~ msgstr "Computator"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Aparate de intrada por ludes"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Primari"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Extra"
+
+#~ msgid "Batteries"
+#~ msgstr "Batteries"
+
+#~ msgid "When _idle"
+#~ msgstr "Pos ínact_ivitá"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspender"
+
+#~ msgid "Power Off"
+#~ msgstr "Extinter"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hivernar"
+
+#~ msgid "Nothing"
+#~ msgstr "Necós"
+
+#, fuzzy
+#~ msgid "When on battery power"
+#~ msgstr "Batterie ea exhaustet"
+
+#, fuzzy
+#~ msgid "When plugged in"
+#~ msgstr "Deconexet del rete"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nequande"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Suspender automaticmen"
+
+#, fuzzy
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Mode de avion es ínactiv"
+
+#, fuzzy, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Mode:        %s (%04o)"
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Productivitá"
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Garda-energie"
+
+#, fuzzy, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Li bux «%s» sta removet"
+
+#, fuzzy
+#~ msgid "Failed to add new printer."
+#~ msgstr "Ne successat adjuncter un nov rapid-taste"
+
+#, fuzzy, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Ne posset chargar li image «%s»"
+
+#, fuzzy, c-format
+#~| msgid "_Details"
+#~ msgid "%s Details"
+#~ msgstr ""
+#~ "Ne successat executer «%s»\n"
+#~ "\n"
+#~ "Detallies: %s"
+
+#, fuzzy
+#~ msgid "No suitable driver found"
+#~ msgstr "null apt driver de smartcartes esset trovat"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Selecter un file PPD"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Printator JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Printator LPD"
+
+#, fuzzy
+#~ msgid "One Sided"
+#~ msgstr "Duplic"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Long bord (standard)"
+
+#, fuzzy
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "EDGE"
+
+#~ msgid "Portrait"
+#~ msgstr "Portrete"
+
+#~ msgid "Landscape"
+#~ msgstr "Paisage"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Reversat paisage"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Reversat portrait"
+
+#~ msgid "Resume"
+#~ msgstr "Reprender"
+
+#~ msgid "Pause"
+#~ msgstr "Pause"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Atendente"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pausat"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autentication es besonat"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Processante"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Stoppat"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Anullat"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Interruptet"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Compleet"
+
+#, fuzzy
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Mover un fenestre al nord (alt) monitor"
+
+#, fuzzy, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "Activ fenestre: %s\n"
+
+#, fuzzy
+#~ msgid "Unlock Print Server"
+#~ msgstr "D_esserrar"
+
+#, fuzzy, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "D_esserrar"
+
+#, fuzzy
+#~ msgid "Searching for Printers"
+#~ msgstr "Sercha..."
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serial portu"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralel portu"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Localisation: %s"
+
+#, c-format
+#~| msgid "_Address:"
+#~ msgid "Address: %s"
+#~ msgstr "Adresse: %s"
+
+#, fuzzy
+#~ msgid "Server requires authentication"
+#~ msgstr "Autentication de servitor"
+
+#~ msgid "Two Sided"
+#~ msgstr "Duplic"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tip de papere"
+
+#, fuzzy
+#~ msgid "Paper Source"
+#~ msgstr "Papere"
+
+#, fuzzy
+#~ msgid "Output Tray"
+#~ msgstr "Minimisar a panel"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolution"
+
+#, fuzzy
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Prefiltration de GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Págines per látere"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientation"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "General"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Formate de págine"
+
+#, fuzzy
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Non-installabil"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Tache"
+
+#, fuzzy
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Qualitá de image"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Finalisation"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avansates"
+
+#, fuzzy
+#~| msgid "page"
+#~ msgid "Test page"
+#~ msgstr "Prov-págine"
+
+#~ msgid "Auto Select"
+#~ msgstr "Autoselecter"
+
+#~ msgid "Printer Default"
+#~ msgstr "Printator predefinit"
+
+#, fuzzy
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Converter a PS nivelle 1"
+
+#, fuzzy
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Converter a PS nivelle 2"
+
+#, fuzzy
+#~ msgid "No pre-filtering"
+#~ msgstr "Prefiltration de GhostScript"
+
+#, fuzzy
+#~ msgid "Clean print heads"
+#~ msgstr "Nettar"
+
+#, fuzzy
+#~ msgid "Out of toner"
+#~ msgstr "Vacui de tóner"
+
+#, fuzzy
+#~ msgid "Low on developer"
+#~ msgstr "Bass"
+
+#, fuzzy
+#~ msgid "Out of developer"
+#~ msgstr "Printator «%s» manca li developpator."
+
+#, fuzzy
+#~ msgid "Low on a marker supply"
+#~ msgstr "Bass"
+
+#, fuzzy
+#~ msgid "Out of a marker supply"
+#~ msgstr "Marca"
+
+#~ msgid "Open cover"
+#~ msgstr "Covrette es apert"
+
+#~ msgid "Open door"
+#~ msgstr "Luca apert"
+
+#, fuzzy
+#~ msgid "Low on paper"
+#~ msgstr "Papere del printator «%s» exhauste."
+
+#~ msgid "Out of paper"
+#~ msgstr "Manca papere"
+
+#, fuzzy
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Ne in li rete"
+
+#, fuzzy
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Stoppat"
+
+#, fuzzy
+#~ msgid "Waste receptacle full"
+#~ msgstr " - Complet"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Pret"
+
+#, fuzzy
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Acceptar"
+
+#, fuzzy
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Processante"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metric"
+
+#, fuzzy
+#~ msgid "Ask what to do"
+#~ msgstr "Questionar quo far"
+
+#, fuzzy
+#~ msgid "Do nothing"
+#~ msgstr "Far necós"
+
+#, fuzzy
+#~| msgid "Home folder"
+#~ msgid "Open folder"
+#~ msgstr "Aperter li fólder"
+
+#, fuzzy
+#~| msgid "Other"
+#~ msgid "Other Media"
+#~ msgstr "Altri medies"
+
+#, fuzzy
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Selecter un application por audio CDs"
+
+#, fuzzy
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Selecter un application por video DVDs"
+
+#, fuzzy
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Selecte un application por CDs de programmas"
+
+#, fuzzy
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+#, fuzzy
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "disco Blu-Ray blanc"
+
+#, fuzzy
+#~ msgid "blank CD disc"
+#~ msgstr "disco CD blanc"
+
+#, fuzzy
+#~ msgid "blank DVD disc"
+#~ msgstr "disco DVD blanc"
+
+#, fuzzy
+#~ msgid "blank HD DVD disc"
+#~ msgstr "disco HD DVD blanc"
+
+#, fuzzy
+#~ msgid "Blu-ray video disc"
+#~ msgstr "disco de video Blu-Ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "Letor de e-libres"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disco de video HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Image CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#, fuzzy
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Permisser o depermisser son de notification."
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 secondes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 hor"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutes"
+
+#~| msgid "minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutes"
+
+#~| msgid "minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutes"
+
+#~| msgid "minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutes"
+
+#~| msgid "minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutes"
+
+#~| msgid "minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutes"
+
+#~| msgid "minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nequande"
+
+#, fuzzy
+#~| msgid "_Acceleration:"
+#~ msgid "Select Location"
+#~ msgstr "Selecter ignorat localisationes"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#, fuzzy
+#~| msgid "_Application font:"
+#~ msgid "No applications found"
+#~ msgstr "Null applicationes trovat"
+
+#, fuzzy
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Partir"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Activ"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "No"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Activ"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Activ"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Selecte un fólder"
+
+#, fuzzy
+#~ msgid "Enable media sharing"
+#~ msgstr "Usar li media-biblioteca"
+
+#, fuzzy
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Partir personal files obexftp"
+
+#, fuzzy
+#~ msgid "Device name copied"
+#~ msgstr "Copiat"
+
+#, fuzzy
+#~ msgid "Device address copied"
+#~ msgstr "Adresse de aparate"
+
+#, fuzzy
+#~| msgid "U_sername:"
+#~ msgid "Username copied"
+#~ msgstr "Nómine de _usator"
+
+#, fuzzy
+#~| msgid "_Password:"
+#~ msgid "Password copied"
+#~ msgstr "Copiat"
+
+#~ msgid "Custom"
+#~ msgstr "Personalisat"
+
+#, fuzzy, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Prova de «%s»"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Deconexet"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Conexente"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Conexet"
+
+#, fuzzy
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Autorisation"
+
+#, fuzzy
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "_Reductet"
+
+#, fuzzy
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Es autorisat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Ínconosset"
+
+#, fuzzy
+#~ msgid "Authorized at:"
+#~ msgstr "Es autorisat"
+
+#, fuzzy
+#~ msgid "Connected at:"
+#~ msgstr "Ne conexet"
+
+#, fuzzy
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Ne successat installar paccages."
+
+#, fuzzy
+#~ msgid "Failed to forget device: "
+#~ msgstr "Obliviar ti aparate?"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Errore"
+
+#, fuzzy
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Es autorisat"
+
+#, fuzzy, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Un error evenit salvante li archive."
+
+#, fuzzy
+#~| msgid "Default"
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Predefinit"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Medie"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Grand"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Plu grand"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Grandissim"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixeles"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Curt"
+
+#, fuzzy
+#~| msgid "Screen"
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "_Ecran"
+
+#, fuzzy
+#~| msgid "Screen"
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "_Ecran"
+
+#, fuzzy
+#~| msgid "Screen"
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "_Ecran"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Long"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 hor"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 die"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dies"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dies"
+
+#, fuzzy
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Esque vacuar li Paper-corb?"
+
+#, fuzzy
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Omni elementes in li Paper-corb va esser irrevocabilmen deletet."
+
+#, fuzzy
+#~ msgid "_Empty Trash"
+#~ msgstr "Vacuar li _Paper-corb"
+
+#, fuzzy
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Temporari files"
+
+#, fuzzy
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Omni elementes in li Paper-corb va esser irrevocabilmen deletet."
+
+#, fuzzy
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Efaciar"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 die"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dies"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dies"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Permanentmen"
+
+#, fuzzy
+#~ msgid "Failed to add account"
+#~ msgstr "&Adjunter un conto..."
+
+#, fuzzy
+#~ msgid "Failed to register account"
+#~ msgstr "Ne successat registrar in li selectet rete"
+
+#, fuzzy
+#~ msgid "Failed to join domain"
+#~ msgstr "_Dominia"
+
+#, fuzzy
+#~ msgid "Failed to log into domain"
+#~ msgstr "<application>Git</application> diarium ne successat."
+
+#, fuzzy
+#~ msgid "Browse for more pictures"
+#~ msgstr "Trovar plu images..."
+
+#, fuzzy
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "<b>_Action de un duplic clic</b>"
+
+#, fuzzy
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "Li aparate ja es usat"
+
+#, fuzzy
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "Vu ne have permissiones por creation de ti fólder."
+
+#, fuzzy
+#~ msgid "no prints have been enrolled"
+#~ msgstr "Actualisamentes ha esset installat"
+
+#, fuzzy
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Ne posset assignar li Letor de postage predefinit"
+
+#, fuzzy
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Ne successat communicar con li servitor. Vi li textu de errore:"
+
+#, fuzzy, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Ne successat obtener li liste de fólderes"
+
+#, fuzzy, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Ne successat remover li file «%s». Cause: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Levul pollice"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Levul fingre medial"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Levul index"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Levul fingre annelari"
+
+#~ msgid "Left little finger"
+#~ msgstr "Levul fingre auriculari"
+
+#~ msgid "Right thumb"
+#~ msgstr "Dextri pollice"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Dextri fingre medial"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Dextri index"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Dextri fingre annelari"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dextri fingre auriculari"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Ínconosset fingre"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Compleet"
+
+#, fuzzy
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Aparate deconexet"
+
+#, fuzzy
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Nov fingre-print:"
+
+#, fuzzy, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Ne successat lansar li preferenties de son: %s"
+
+#, fuzzy
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Nov fingre-print:"
+
+#, fuzzy, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Ne successat haltar li servicie: %1"
+
+#, fuzzy
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Ínconosset fingre"
+
+#, fuzzy
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Nov fingre-print:"
+
+#, fuzzy
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problema"
+
+#, fuzzy, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Ne successat obtener li nómine de host: %s\n"
+
+#~ msgid "This Week"
+#~ msgstr "Ho-semane"
+
+#~ msgid "Last Week"
+#~ msgstr "Ultim semane"
+
+#, fuzzy
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%-e %b"
+
+#, fuzzy
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-e %b  %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#, fuzzy
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "k"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, fuzzy
+#~ msgid "Session Ended"
+#~ msgstr "finit"
+
+#, fuzzy
+#~ msgid "Session Started"
+#~ msgstr "Iniciat:"
+
+#, fuzzy, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "Conto %s"
+
+#, fuzzy
+#~ msgid "Please choose another password."
+#~ msgstr "Ples selecter un altri nómine"
+
+#, fuzzy
+#~ msgid "Password could not be changed"
+#~ msgstr "Li gruppe ne posse esset changeat."
+
+#, fuzzy
+#~ msgid "No such domain or realm found"
+#~ msgstr "_Dominia:"
+
+#, fuzzy, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Cluder li session de %s"
+
+#, fuzzy
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Contrasigne es íncorect, ples repena denov"
+
+#, fuzzy
+#~ msgid "Failed to delete user"
+#~ msgstr "Ne successar cambiar li usator"
+
+#, fuzzy, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "Avise: %d usator have un session ancor apert."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Esque vu vole retener li files de %s?"
+
+#~ msgid "_Delete Files"
+#~ msgstr "Remo_ver files"
+
+#~ msgid "_Keep Files"
+#~ msgstr "R_etener files"
+
+#, fuzzy, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Esque vu vole remover «%s» permanentmen?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Remover"
+
+#, fuzzy
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Conto"
+
+#, fuzzy
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Inregistration"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Null"
+
+#, fuzzy
+#~ msgid "Logged in"
+#~ msgstr ""
+#~ "\n"
+#~ "<i>session apertet</i>"
+
+#, fuzzy
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Ne successat conexer al servicie."
+
+#, fuzzy
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Stellen Sie sicher, dass die Dauerumschalttaste nicht aktiv ist"
+
+#, fuzzy
+#~ msgid "Delete the selected user account"
+#~ msgstr "Deleter selectet"
+
+#, fuzzy
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Parametres del sistema (quel afecte omni usatores)"
+
+#, fuzzy
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Li contrasigne es tro curt"
+
+#, fuzzy
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Usar _DHT por trovar extra peeres"
+
+#, fuzzy
+#~| msgid "Authenticated!"
+#~ msgid "Authentication failed"
+#~ msgstr "Autentication ne successat"
+
+#, fuzzy, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Li contrasigne es tro curt"
+
+#, fuzzy, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Li contrasigne es tro simplic"
+
+#, fuzzy, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Li contrasigne es tro simplic"
+
+#, fuzzy, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Alminu du nómines de file es identic."
+
+#, fuzzy, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Alminu du nómines de file es identic."
+
+#, fuzzy, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Vor contrasigne ha expirat."
+
+#, fuzzy, c-format
+#~| msgid "Unknown"
+#~ msgid "Unknown error"
+#~ msgstr "ínconosset errore"
+
+#, fuzzy
+#~ msgid "The username is too long."
+#~ msgstr "Li nómine de archive es tro long."
+
+#, fuzzy, c-format
+#~| msgid "Buttons"
+#~ msgid "Button %d"
+#~ msgstr "custom_cmd_button%d"
+
+#, fuzzy
+#~| msgid "_Application font:"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Null marca-págines definit"
+
+#, fuzzy
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Rular pos _tippa"
+
+#, fuzzy
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Cambiar li monitor"
+
+#, fuzzy
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Monstrar li págine de auxilie"
+
+#, fuzzy
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Sin extern monitor"
+
+#, fuzzy
+#~ msgid "External tablet device"
+#~ msgstr "Extern"
+
+#, fuzzy
+#~ msgid "All Displays"
+#~ msgstr "Monitores"
+
+#, fuzzy
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standard"
+
+#, fuzzy
+#~ msgid "New shortcut…"
+#~ msgstr "Nov rapid-taste…"
+
+#, fuzzy
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operation anullat"
+
+#, fuzzy
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "Un errore evenit durante copiation a «%B»."
+
+#, fuzzy
+#~ msgid "Not Registered"
+#~ msgstr "U_sator registrat"
+
+#, fuzzy
+#~ msgid "Registered"
+#~ msgstr "Function CSS '%s' es ja registrat."
+
+#, fuzzy
+#~| msgid "Search"
+#~ msgid "Searching"
+#~ msgstr "Sercha"
+
+#, fuzzy
+#~ msgid "Denied"
+#~ msgstr "Refusat"
+
+#, fuzzy
+#~ msgid "2G Only"
+#~ msgstr "solmen"
+
+#, fuzzy
+#~ msgid "3G Only"
+#~ msgstr "%3g ms"
+
+#, fuzzy
+#~ msgid "4G Only"
+#~ msgstr "solmen"
+
+#, fuzzy
+#~ msgid "5G Only"
+#~ msgstr "solmen"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#, fuzzy
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "%3g ms"
+
+#, fuzzy
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "%3g ms"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#, fuzzy
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "%3g ms"
+
+#, fuzzy
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "Preferet"
+
+#, fuzzy
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "Preferet"
+
+#, fuzzy
+#~ msgid "3G, 4G"
+#~ msgstr "%3g ms"
+
+#, fuzzy
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "Preferet"
+
+#, fuzzy
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "Preferet"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#, fuzzy
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "Preferet"
+
+#, fuzzy
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "Preferet"
+
+#, fuzzy
+#~ msgid "2G, 3G"
+#~ msgstr "%3g ms"
+
+#, fuzzy
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "Preferet"
+
+#, fuzzy
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "Preferet"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#, fuzzy
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "Preferet"
+
+#, fuzzy
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "Preferet"
+
+#, fuzzy
+#~ msgid "3G, 5G"
+#~ msgstr "%3g ms"
+
+#, fuzzy
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "Preferet"
+
+#, fuzzy
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "Preferet"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#, fuzzy
+#~| msgid "Unknown"
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Ínconosset"
+
+#, fuzzy
+#~ msgid "Unlock SIM card"
+#~ msgstr "SIM: null carte insertet"
+
+#, fuzzy
+#~ msgid "Wrong password entered."
+#~ msgstr "Contrasigne es ínvalid."
+
+#, fuzzy
+#~ msgid "Enter New PIN"
+#~ msgstr "Intra un code PIN"
+
+#, fuzzy
+#~ msgid "Phone failure"
+#~ msgstr "Telefon"
+
+#, fuzzy
+#~ msgid "No connection to phone"
+#~ msgstr "Telefon - intrada"
+
+#, fuzzy
+#~ msgid "Operation not allowed"
+#~ msgstr "Operation"
+
+#, fuzzy
+#~ msgid "Operation not supported"
+#~ msgstr "Operation ne es suportat"
+
+#, fuzzy
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM: null carte insertet"
+
+#, fuzzy
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM: PIN es besonat"
+
+#, fuzzy
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM: PUK es besonat"
+
+#, fuzzy
+#~ msgid "SIM failure"
+#~ msgstr "Dessuccesse"
+
+#, fuzzy
+#~ msgid "SIM busy"
+#~ msgstr "Ocupat"
+
+#, fuzzy
+#~ msgid "Incorrect password"
+#~ msgstr "Contrasigne es íncorect."
+
+#, fuzzy
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM: PIN es besonat"
+
+#, fuzzy
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM: PIN es besonat"
+
+#, fuzzy
+#~ msgid "Not found"
+#~ msgstr "Ne esset trovat"
+
+#, fuzzy
+#~| msgid "Network Servers"
+#~ msgid "No network service"
+#~ msgstr "Rete"
+
+#, fuzzy
+#~| msgid "Network Proxy"
+#~ msgid "Network timeout"
+#~ msgstr "Timeout"
+
+#, fuzzy
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS"
+
+#, fuzzy
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Ínspecificat errore"
+
+#, fuzzy
+#~ msgid "No Error"
+#~ msgstr "Null errore"
+
+#, fuzzy
+#~ msgid "Action Cancelled"
+#~ msgstr "Les anullat"
+
+#, fuzzy
+#~ msgid "Access denied"
+#~ msgstr "Accesse refusat"
+
+#, fuzzy
+#~| msgid "Unknown"
+#~ msgid "Unknown Error"
+#~ msgstr "ínconosset errore"
+
+#, fuzzy, c-format
+#~ msgid "SIM %d"
+#~ msgstr "PIN del SIM"
+
+#, fuzzy
+#~ msgid "Display version number"
+#~ msgstr "Monstra li numeró del version"
+
+#, fuzzy
+#~ msgid "Enable verbose mode"
+#~ msgstr "Activar &passiv mode (PASV)"
+
+#, fuzzy
+#~ msgid "Search for the string"
+#~ msgstr "Li serchat textu ne esset trovat"
+
+#, fuzzy
+#~ msgid "Panel to display"
+#~ msgstr "Monstrar sur panel"
+
+#, fuzzy
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "option %s besona un argument"
+
+#~ msgid "Available panels:"
+#~ msgstr "Disponibil paneles:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sones de sistema"

--- a/po/ie.po~
+++ b/po/ie.po~
@@ -1,0 +1,10141 @@
+# Interlingue gnome-control-center translation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center 2.20\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-12-12 07:03+0700\n"
+"PO-Revision-Date: 2022-12-13 13:53+0700\n"
+"Last-Translator: OIS <mistresssilvara@hotmail.com>\n"
+"Language-Team: IE\n"
+"Language: ie\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.12\n"
+
+#: panels/applications/cc-applications-panel.c:822
+#, fuzzy
+msgid "System Bus"
+msgstr "D-Bus"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+#, fuzzy
+#| msgid "Full Name"
+msgid "Full access"
+msgstr "Accesse"
+
+#: panels/applications/cc-applications-panel.c:824
+#, fuzzy
+msgid "Session Bus"
+msgstr "Ne successat conexer al bus de session D-Bus."
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Aparates"
+
+#: panels/applications/cc-applications-panel.c:828
+#, fuzzy
+msgid "Full access to /dev"
+msgstr "[dev]"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#| msgid "Network Proxy"
+msgid "Network"
+msgstr "Rete"
+
+#: panels/applications/cc-applications-panel.c:832
+#, fuzzy
+msgid "Has network access"
+msgstr "Permisser accesse al rete"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Hem"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Solmen letion"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Sistema de files"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Parametres"
+
+#: panels/applications/cc-applications-panel.c:848
+#, fuzzy
+msgid "Can change settings"
+msgstr "Cambiar vor parametres de lingue e region"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, fuzzy, c-format
+msgid "%s of disk space used."
+msgstr "Disc-spacie de «%s» es bass"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Applicationes"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Null applicationes"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+#| msgid "_Install..."
+msgid "Install some…"
+msgstr ""
+"Vu posse crear un archive pos installation de programmas necessari per clicc "
+"del buton %s."
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Aperter"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+#| msgid "_Details"
+msgid "View Details"
+msgstr "Vise detalliat"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Serchar"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Despermisset"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificationes"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Monstrar notificationes"
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Lansar in funde"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Capturas de ecran"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Cambiar li tapete"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Cambiar li tapete del pupitre"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sones"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reproducter sones"
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+#| msgid "Shortcut"
+msgid "Inhibit Shortcuts"
+msgstr "Inhibir suspension"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+#| msgid "Keyboard Shortcuts"
+msgid "Block standard keyboard shortcuts."
+msgstr "Rapid-tastes for capturas"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Cámera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+#, fuzzy
+msgid "Take pictures with the camera."
+msgstr "Images"
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microfon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+#, fuzzy
+msgid "Record audio with the microphone."
+msgstr "Rhythmbox ne successat registrar li audio-disco"
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Servicies de localisation"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+#, fuzzy
+msgid "Access device location data."
+msgstr "Ne posset accessar li aparate «%s»"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Standard"
+
+#: panels/applications/cc-applications-panel.ui:223
+#, fuzzy
+msgid "System access that is required by the app"
+msgstr "Un nómine e contrasigne es besonat por li accesse a «%s»"
+
+#: panels/applications/cc-applications-panel.ui:231
+#, fuzzy
+msgid "File &amp; Link Associations"
+msgstr "Associationes de file"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Magasinage"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Null resultates"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+#, fuzzy
+msgid "Try a different search"
+msgstr "Prova un altri sercha"
+
+#: panels/applications/cc-applications-panel.ui:351
+#, fuzzy
+msgid "File & Link Associations"
+msgstr "Associationes de file"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Tipes de file"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Tipes"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+#, fuzzy
+msgid "Reset"
+msgstr "Reverter"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Application"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+#| msgid "<b>Email</b>"
+msgid "<b>Total</b>"
+msgstr "<b>Total:</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Vacuar li cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Selecter un image"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Annular"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Aperter"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "multiplic dimensiones"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Null funde del Pupitre"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Li actual image de funde"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stil"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Predefinit"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Obscur"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Funde"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Adjunter un image…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aspecte"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Activar"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Null aparates Bluetooth es trovat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Conexer un adaptator por usa Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Mode de avion es activ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Mode de avion es ínactiv"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "Mode de avion es activ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Mode de avion es activ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+#, fuzzy
+msgid "share;sharing;bluetooth;obex;"
+msgstr "Partir public files per _Bluetooth"
+
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "null images"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+#, fuzzy
+msgid "Shut the laptop lid"
+msgstr "<b>Covrette de portabile</b>"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+#, fuzzy
+msgid "An internal error occurred that could not be recovered."
+msgstr "Un errore intern evenit"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr ""
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+#, fuzzy
+msgid "The profile could not be generated."
+msgstr "Generat"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+#, fuzzy
+msgid "The target whitepoint was not obtainable."
+msgstr "Traduction:"
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Compleet!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Calibration ne successat!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+#, fuzzy
+msgid "You can remove the calibration device."
+msgstr "vu posse remover ti file e repena denov"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+#, fuzzy
+msgid "Display Calibration"
+msgstr "Calibration"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Startar"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Reprender"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Finir"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Ecran de portatibile"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Integrat webcam"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Scannator %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Cámera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Printator %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Web-cámera %s"
+
+#: panels/color/cc-color-device.c:87
+#, fuzzy, c-format
+msgid "Enable color management for %s"
+msgstr "Activar gerentie de color por %s"
+
+#: panels/color/cc-color-device.c:92
+#, fuzzy, c-format
+msgid "Show color profiles for %s"
+msgstr "Assignar profiles de color"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Ne calibrat"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Predefinit: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Spacie de color: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Profil de prova: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+#, fuzzy
+msgid "Select ICC Profile File"
+msgstr "Selecter un file de profile ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importar"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+#, fuzzy
+msgid "Supported ICC profiles"
+msgstr "Suportat profiles ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Omni files"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ecran"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Gardar li profil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salvar"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+#, fuzzy
+msgid "Create a color profile for the selected device"
+msgstr "Crear un profil de color por li selectet aparate"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+#, fuzzy
+msgid "The device type is not currently supported."
+msgstr "Li tip de aparate es bentost ínsuportat."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Calibration del ecran"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Qualitá del calibration"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Qualitá"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+#, fuzzy
+msgid "Approximate Time"
+msgstr "Aproximat"
+
+#: panels/color/cc-color-panel.ui:82
+#, fuzzy
+msgid "Calibration Device"
+msgstr "Calibration"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tip de monitor"
+
+#: panels/color/cc-color-panel.ui:125
+#, fuzzy
+msgid "Select the type of display that is connected."
+msgstr "Selecter un tip"
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Null profil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "<b>Luciditá del ecran</b>"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nómine de profil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nómine de profil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Compendie"
+
+#: panels/color/cc-color-panel.ui:259
+#, fuzzy
+msgid "Profile successfully created!"
+msgstr "Archive har esset creat con success"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copiar li profil"
+
+#: panels/color/cc-color-panel.ui:296
+#, fuzzy
+msgid "Requires writable media"
+msgstr "Scribil?"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Adjunter un profil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importar un file…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Adjunter"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Plu information"
+
+#: panels/color/cc-color-panel.ui:436
+#, fuzzy
+msgid "Learn more about color management"
+msgstr "(Plu information pri GNU gettext)"
+
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
+msgstr "Applicar por omni usatores"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+#, fuzzy
+msgid "Set this profile for all users on this computer"
+msgstr "Applicar por omni usatores"
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+#| msgid "Disabled"
+msgid "_Enable"
+msgstr "P_ermisser"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Adjunter un profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibrar..."
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibrar li aparate"
+
+# CHECK
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Remover li profil"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+#| msgid "_Details"
+msgid "_View details"
+msgstr "Vise detalliat"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projector"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+#, fuzzy
+msgid "LCD (CCFL backlight)"
+msgstr "Ilumination de tastatura"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alt"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutes"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Medie"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutes"
+
+# Mausempfindlichkeit
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Bass"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#: panels/color/cc-color-panel.ui:663
+#, fuzzy
+msgid "Native to display"
+msgstr "Nativ nómine"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Printation e edition)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Grafica e fotografie)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standard spacie"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Profil de prova"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatic"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Bass qualitá"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Medie qualitá"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Alt qualitá"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Predefinit RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Predefinit CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Predefinit gris"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Color"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Altri…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Selecter un lingue"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Selecter"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Null lingues trovat"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Plu..."
+
+#: panels/common/cc-permission-infobar.c:109
+#, fuzzy
+msgid "Unlock to Change Settings"
+msgstr "Ne successat cambiar parametres de NTP"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "D_esserrar"
+
+#: panels/common/cc-time-editor.ui:25
+#, fuzzy
+msgid "Increment Hour"
+msgstr "Increment:"
+
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "Increment:"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Hora"
+
+#: panels/common/cc-time-editor.ui:94
+#, fuzzy
+msgid "Decrement Hour"
+msgstr "Diminuer li númere al cursore"
+
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "Diminuer li númere al cursore"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Hodie"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Yer"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%-e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%-e %b  %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hor"
+msgstr[1] "%d hores"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minute"
+msgstr[1] "%d minutes"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d seconde"
+msgstr[1] "%d secondes"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 secondes"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-hor"
+
+#: panels/datetime/cc-datetime-panel.c:177
+#, fuzzy
+msgid "AM / PM"
+msgstr "Mon_strar AM/PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+#, fuzzy
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%-e %b %Y %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+#, fuzzy
+msgid "%e %B %Y, %R"
+msgstr "%A, %e %B %Y"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, fuzzy, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "\t%s%s%s%s%s\n"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, fuzzy, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "\t%s%s%s%s%s\n"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+#, fuzzy
+msgid "%l:%M %p"
+msgstr "%H:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, fuzzy, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "\t%s%s%s%s%s\n"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Date e hora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Annu"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mensu"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januar"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Marte"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "May"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Junio"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Julí"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Septembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Octobre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembre"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Decembre"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Die"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Zone horari"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Trovar un cité"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatic date e hora"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+#, fuzzy
+msgid "Requires internet access"
+msgstr "Applicationes por accesser Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Da_te e hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "Actual zone horari:"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+#, fuzzy
+#| msgid "Disabled"
+msgid "Enabled"
+msgstr "Permisset"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Z_one horari"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Formate de hora"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change the date and time, including time zone"
+msgstr "Cambiar li zone horari del sistema"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+#, fuzzy
+msgid "Clock;Timezone;Location;"
+msgstr "Horloge"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Gardar li parametres de date e hora"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_E-post"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendare"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usica"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Applicationes predefinit"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Applicationes predefinit"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+#, fuzzy
+msgid "default;application;preferred;media;"
+msgstr "Selecter un application predefinit"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+#, fuzzy
+msgid "Problem Reporting"
+msgstr "Raportante spam..."
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+#, fuzzy
+msgid "_Automatic Problem Reporting"
+msgstr "automatic"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostica"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Raportar vor problemas"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "Diagnostica:"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+#, fuzzy
+msgid "Off"
+msgstr "No"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Applicar li alterationes?"
+
+#: panels/display/cc-display-panel.c:935
+#, fuzzy
+msgid "Changes Cannot be Applied"
+msgstr "Alterationes es applicat"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Applicar"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Retro"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Configurar parametres de monitor..."
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Multiplic monitores"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Unir"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Duplicar"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Primari monitor"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "Nocte"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Paisage"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portrete"
+
+#: panels/display/cc-display-settings.c:116
+#, fuzzy
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portrete"
+
+#: panels/display/cc-display-settings.c:119
+#, fuzzy
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Paisage"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientation"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolution"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Refriscar chascun"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Adjustar por un TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Scale"
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Índisponibil"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+#| msgid "Filter"
+msgid "Restart Filter"
+msgstr "&Filtre..."
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Plan"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Descension til ascension"
+
+#: panels/display/cc-night-light-page.ui:141
+#, fuzzy
+msgid "Manual Schedule"
+msgstr "Plan: "
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+#, fuzzy
+msgid "Times"
+msgstr "Témpores"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "De"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hor"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minute"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Til"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura de color"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Monitores"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+#, fuzzy
+msgid "Secure Boot is Active"
+msgstr "Secure Boot es ínactiv"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+#, fuzzy
+msgid "Secure Boot Has Problems"
+msgstr "Secure Boot es ínactiv"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+#, fuzzy
+msgid "Secure Boot is Turned Off"
+msgstr "Secure Boot es ínactiv"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#, fuzzy
+#| msgid "_Password:"
+msgid "Passed"
+msgstr "Ínvalid argument del option \"sortby\"."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Ne successat"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+#, fuzzy
+msgid "Security Level 0"
+msgstr "Nivelle de securitá"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+#, fuzzy
+msgid "Security Level 1"
+msgstr "Nivelle de securitá"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+#, fuzzy
+msgid "Security Level 2"
+msgstr "Nivelle de securitá"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+#, fuzzy
+msgid "Security Level 3"
+msgstr "Nivelle 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Nivelle de securitá"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+#, fuzzy
+msgid "Security levels are not available for this device."
+msgstr "Actualisamentes de securitá es disponibil"
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nivelle 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nivelle 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nivelle 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+#, fuzzy
+msgid "Secure Boot has Problems"
+msgstr "Secure Boot es ínactiv"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Secure Boot es ínactiv"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+#, fuzzy
+msgid "Comprehensive Protection"
+msgstr "Protection de IOMMU"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Null evenimentes"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+#, fuzzy
+msgid "Firmware Write Protection"
+msgstr "Firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr ""
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+#, fuzzy
+msgid "Firmware BIOS Region"
+msgstr "Region"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+#, fuzzy
+msgid "Firmware BIOS Descriptor"
+msgstr "_Bootabil del Legacy BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+#, fuzzy
+msgid "Intel BootGuard"
+msgstr "file hexadecimal de objecte de Intel"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+#, fuzzy
+msgid "Intel BootGuard Fuse"
+msgstr "FUSE"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+#, fuzzy
+msgid "Intel CET Enabled"
+msgstr "Ínactiv"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+#, fuzzy
+msgid "Intel CET Active"
+msgstr "Activ"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+#, fuzzy
+msgid "Intel SMAP"
+msgstr "file hexadecimal de objecte de Intel"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Ciffrat RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Protection de IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+#, fuzzy
+msgid "Linux Kernel Lockdown"
+msgstr "Li nucleo Linux."
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+#, fuzzy
+msgid "Linux Kernel Verification"
+msgstr "Li nucleo Linux."
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Swap de Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+#, fuzzy
+msgid "Suspend To RAM"
+msgstr "Esque vu vole suspender a RAM?"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+#, fuzzy
+msgid "Suspend To Idle"
+msgstr ""
+"%s [OPTION...] COMANDE\n"
+"\n"
+"Executar COMANDE inhibiente alcun functionalitá de session.\n"
+"\n"
+"  -h, --help        Monstrar ti-ci textu\n"
+"  --version         Monstrar li version de programma\n"
+"  --app-id ID       ID de application a usar durante inhibition (facult.)\n"
+"  --reason CAUSE    Li cause de inhibition (facultatativ)\n"
+"  --inhibit ARG     Quo inhibir, un liste separat per commas de:\n"
+"                    logout (cluder li session), switch-user (cambiar li "
+"usator),\n"
+"                    suspend, idle (ínoperation), automount\n"
+"\n"
+"Si null parametre --inhibit es present, \"idle\" es suposit.\n"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+#, fuzzy
+msgid "UEFI Platform Key"
+msgstr "Platforme"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+#, fuzzy
+msgid "UEFI Secure Boot"
+msgstr "Secure Boot es ínactiv"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+#, fuzzy
+#| msgid "Proxy Configuration"
+msgid "TPM Platform Configuration"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+#, fuzzy
+msgid "TPM Reconstruction"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Actualisation del firmware"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+#, fuzzy
+msgid "Firmware Attestation"
+msgstr "Firmware"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+#, fuzzy
+msgid "Firmware Updater Verification"
+msgstr "Actualisation del fólderes de sercha"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+#, fuzzy
+msgid "Platform Debugging"
+msgstr "Platforme"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+#, fuzzy
+msgid "Processor Security Checks"
+msgstr "_Processor"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+#, fuzzy
+msgid "AMD Rollback Protection"
+msgstr "Protection per un contrasigne"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+#, fuzzy
+msgid "Fused Platform"
+msgstr "Platforme"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Valid"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Ínvalid"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Ínactiv"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Serrat"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+#, fuzzy
+msgid "Not Locked"
+msgstr "Serrat"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Ciffrat"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Ne ciffrat"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr ""
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+#, fuzzy
+msgid "Not Tainted"
+msgstr "Ne conexet"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "trovat"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Ne trovat"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Suportat"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Ínsuportat"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Securitá del aparate"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Ínconosset"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Ínconosset"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Índisponibil"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+#, fuzzy
+#| msgid "System"
+msgid "System Logo"
+msgstr "Null logo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nómine de aparate"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Modelle de aparatura"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memorie"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafica"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacitá del disco"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calculante..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nómine de OS"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "Construction"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tip de OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Version de GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Cargante..."
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Sistema de fenestres"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisation"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Actualisamentes de programmas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Renominar li aparate"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nómine de aparate"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Renominar"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Pri"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+#, fuzzy
+msgid "View information about your system"
+msgstr "Vider detalliat information pri files e fólderes"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Son e medies"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Assurdar"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Diminuer li volúmine"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Augmentar li volúmine"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "Assurdar"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+#, fuzzy
+#| msgid "Media player"
+msgid "Launch media player"
+msgstr "Lansar un reproductor de medie"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Reproducter (e pausar)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pausar li reproduction"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Stoppar reproduction"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Precedent track"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Sequent track"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Ejecter"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Tippada"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Orígin de digital intrada"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Ear al precedent págine"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lansatores"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Lansar un navigator de auxilie"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Lansar un calculator"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Lansar un client de e-post"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Lansar un navigator web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Hem fólder"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Serchar"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Cluder li session"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Serrar li ecran"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accessibilitá"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+#, fuzzy
+msgid "Turn zoom on or off"
+msgstr "Extinter li aparate"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Agrandar"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Diminuer"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+#, fuzzy
+msgid "Turn screen reader on or off"
+msgstr "Desactivar"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "Tastatura sur ecran"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Incrementar li grandore de textu"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Decrementar li grandore de textu"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+#, fuzzy
+msgid "High contrast on or off"
+msgstr "Tema de alt contraste"
+
+#: panels/keyboard/cc-input-chooser.c:186
+#, fuzzy
+msgid "No input sources found"
+msgstr "Trovat fontes de dictionariums"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr " Altri"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+#, fuzzy
+msgid "Add an Input Source"
+msgstr "Orígin de digital intrada"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+#, fuzzy
+msgid "No input source selected"
+msgstr "Orígin de digital intrada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Optiones"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Mover ad-up"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Mover a-bass"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferenties"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Monstrar li arangeament de tastatura"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Remover"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Rapid-tastes personal"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "Alternativ:"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Levul Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Dextri Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super A"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+#, fuzzy
+#| msgid "Right"
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super A"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Taste Menú"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Dextri Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Composir"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+#| msgid "Screen"
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "Orígines"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Orígin de digital intrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "Usar li sam arangeament por omni fenestres"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+#, fuzzy
+msgid "Special Character Entry"
+msgstr "Special &caracter..."
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Rapid-tastes"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+#| msgid "Shortcut"
+msgid "View and Customize Shortcuts"
+msgstr "Rapid-tastes"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificat"
+msgstr[1] "%d modificat"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+#, fuzzy
+#| msgid "Shortcut"
+msgid "Reset All Shortcuts?"
+msgstr ""
+"To va reverter omni rapid-tastes a su valores predefinit. Esque vu vole far "
+"to?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Anullar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+#, fuzzy
+msgid "Reset All"
+msgstr "Reverter omni"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+#, fuzzy
+msgid "Reset All…"
+msgstr "Reverter omni"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+#, fuzzy
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Reverter omni actiones al predefinit del sistema"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Section"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Rapid-tastes"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+#| msgid "Shortcut"
+msgid "Add a shortcut"
+msgstr "Ne successat adjuncter un nov rapid-taste"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+#| msgid "Shortcut"
+msgid "Add Custom Shortcuts"
+msgstr "Rapid-tastes personal"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Adjuncter un rapid-taste"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+#| msgid "Keyboard Shortcuts"
+msgid "No keyboard shortcut found"
+msgstr "_Rapid-taste:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+#, fuzzy
+msgid "Enter the new shortcut"
+msgstr "Nov abreviation de web"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+#, fuzzy
+#| msgid "Shortcut"
+msgid "Set Custom Shortcut"
+msgstr "Personal rapid-taste"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+#, fuzzy
+#| msgid "Shortcut"
+msgid "Set Shortcut"
+msgstr "Rapid-taste:"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, fuzzy, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Intra un nov pass-frase por «%s»"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Adjunter un personal rapid-taste"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Remover"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "_Vicear"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "A_ssignar"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nómine"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Comande"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Rapid-taste"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+#| msgid "Shortcut"
+msgid "Set Shortcut…"
+msgstr "Rapid-taste:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Null"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatura"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Protecter vor computator de usagie ínautorisat"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Registrar son med vor microfon e reproducter it"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your conversations"
+msgstr "Null conversationes trovat"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+#, fuzzy
+msgid "microphone;recording;application;privacy;"
+msgstr "Un son-registrator por GNOME"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Pro_var li configuration"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "General"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primari buton"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Levul"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Dextri"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mus"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Velocitá del mus"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+#, fuzzy
+msgid "Natural Scrolling"
+msgstr "Rulament"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+#, fuzzy
+msgid "Scrolling moves the content, not the view."
+msgstr "Posse solmen vider li contenete"
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Panel tactil"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Velocitá"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+#, fuzzy
+msgid "Tap to Click"
+msgstr "Clic"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+#, fuzzy
+msgid "Tap to click"
+msgstr "Clic"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+#, fuzzy
+msgid "Two-finger Scrolling"
+msgstr "Rulament con du fingres"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+#, fuzzy
+msgid "Edge Scrolling"
+msgstr "Along un bord"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr ""
+
+# CHECK
+#: panels/mouse/cc-mouse-test.c:141
+#, fuzzy
+msgid "Double click, primary button"
+msgstr "_Duplic clic por activar elementes"
+
+#: panels/mouse/cc-mouse-test.c:141
+#, fuzzy
+msgid "Single click, primary button"
+msgstr "Singul _clic por activar elementes"
+
+# CHECK
+#: panels/mouse/cc-mouse-test.c:144
+#, fuzzy
+msgid "Double click, middle button"
+msgstr "Medial clic"
+
+#: panels/mouse/cc-mouse-test.c:144
+#, fuzzy
+msgid "Single click, middle button"
+msgstr "Medial clic"
+
+# CHECK
+#: panels/mouse/cc-mouse-test.c:147
+#, fuzzy
+msgid "Double click, secondary button"
+msgstr "_Duplic clic por activar elementes"
+
+#: panels/mouse/cc-mouse-test.c:147
+#, fuzzy
+msgid "Single click, secondary button"
+msgstr "Singul _clic por activar elementes"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mus e panel tactil"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+#, fuzzy
+msgid "_Hot Corner"
+msgstr "Rapid-tastes"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+#, fuzzy
+msgid "_Active Screen Edges"
+msgstr "Activ ecran"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Labor-spacies"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dinamic labor-spacies"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+#, fuzzy
+msgid "_Fixed number of workspaces"
+msgstr "Númere de _labor-spacies:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+#, fuzzy
+msgid "Specify a number of permanent workspaces."
+msgstr "Númere de labor-spacies: %d\n"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+#, fuzzy
+msgid "_Number of Workspaces"
+msgstr "Númere de _labor-spacies:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Installar li parametres multi-monitor por li tot sistema"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Monstrar icones sur li primari monitor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+#, fuzzy
+msgid "Workspaces on all d_isplays"
+msgstr "Númere de labor-spacies: %d\n"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+#| msgid "_Application font:"
+msgid "Application Switching"
+msgstr "Politica de alteration"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+#, fuzzy
+msgid "Include applications from all _workspaces"
+msgstr "Monstrar fenestres de _omni labor-spacies"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitache"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/cc-network-panel.c:669
+#, fuzzy
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager deve esser lansat."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Altri aparates"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Adjuncter un connexion"
+
+#: panels/network/cc-network-panel.ui:62
+#, fuzzy
+msgid "Not set up"
+msgstr "Etablisser..."
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+#, fuzzy
+msgid "Insecure network (WEP)"
+msgstr "ínsecur."
+
+#: panels/network/cc-wifi-connection-row.c:279
+#, fuzzy
+msgid "Secure network (WPA)"
+msgstr "secur."
+
+#: panels/network/cc-wifi-connection-row.c:283
+#, fuzzy
+msgid "Secure network (WPA2)"
+msgstr "WPA2"
+
+#: panels/network/cc-wifi-connection-row.c:287
+#, fuzzy
+msgid "Secure network (WPA3)"
+msgstr "WPA3 personal"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Secur rete"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Conexet"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+#| msgid "Options"
+msgid "Options…"
+msgstr "Optiones"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Desactivar Wi-Fi"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nómine de rete"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Contrasigne"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Generar un contrasigne"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Autogenerar un contrasigne"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Activar"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.c:887
+#, fuzzy
+msgid "_Stop Hotspot"
+msgstr "_Terminar hotspot"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Mode de avion"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Retes Wi-Fi (%s)"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Mode de avion es activ"
+
+#: panels/network/cc-wifi-panel.ui:165
+#, fuzzy
+msgid "Turn off to use Wi-Fi"
+msgstr "Desactivar Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Hotspot Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "Extinter li aparate"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Visibil retes"
+
+#: panels/network/cc-wifi-panel.ui:297
+#, fuzzy
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager deve esser lansat."
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Securitá 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Securitá"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Preservar"
+
+#: panels/network/connection-editor/ce-page.c:235
+#, fuzzy
+msgid "Permanent"
+msgstr "Memorar li conexion al ti-ci servitore"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Hasardal"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabil"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+#, fuzzy
+msgid "Enhanced Open"
+msgstr "Configurar li avansat functiones de navigation"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+#, fuzzy
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Null"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nequande"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "ante %i die"
+msgstr[1] "ante %i dies"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2,4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2,4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Necú"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Debil"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "OK"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bon"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excellent"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Adresse IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adresse IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adresse IP"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Obliviar li conexion"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+#, fuzzy
+msgid "Remove Connection Profile"
+msgstr "Remover un profil"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Remover li VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Detallies"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatic"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitá"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Remover li adresse"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Remover li rute"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Null"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:308
+#, fuzzy
+msgid "WEP 128-bit Passphrase"
+msgstr "Pass-frase"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinamic (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+#, fuzzy
+msgid "WPA & WPA2 Personal"
+msgstr "WPA e WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+#, fuzzy
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA e WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Intensitá de signale"
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "_Velocitá:"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Adresse de hardware"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Disponibil frequenties"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Rute predefinit"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Ultimmen usat"
+
+#: panels/network/connection-editor/details-page.ui:369
+#, fuzzy
+msgid "Connect _automatically"
+msgstr "Connexer _automaticmen"
+
+#: panels/network/connection-editor/details-page.ui:383
+#, fuzzy
+msgid "Make available to _other users"
+msgstr "Far disponibil por altri _usatores"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nómine"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Adresse _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Adresse _clonat"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "octetes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Metode IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatic (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+#, fuzzy
+msgid "Link-Local Only"
+msgstr "Solmen link-local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Depermisser"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "Partit con altri computatores"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresses"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Masca de rete"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatic"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatic DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+#, fuzzy
+msgid "DNS server address(es)"
+msgstr "Remover li adresse(s)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+#, fuzzy
+msgid "Separate IP addresses with commas"
+msgstr "Adresses IP posse usar mustres, quam 192.168.*.*"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rutes"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatic rutes"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrica"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Metode de IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatic, solmen DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefix"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+#, fuzzy
+msgid "Unable to open connection editor"
+msgstr "Aperter un conexion"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Crear un profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, fuzzy, c-format
+msgid "Invalid setting %s: %s"
+msgstr "%s: codification ínvalid.\n"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, fuzzy, c-format
+msgid "Invalid setting %s"
+msgstr "Ínvalid nómine de file %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+#, fuzzy
+msgid "Import from file…"
+msgstr "Ne successat importar un bux del file «%s»."
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Adjunter un VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_ecuritá"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+#, fuzzy
+msgid "Cannot import VPN connection"
+msgstr "Desactivar connexion VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+#, fuzzy
+#| msgid "Select Image"
+msgid "Select file to import"
+msgstr "Selecte un file a importar"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, fuzzy, c-format
+msgid "A file named “%s” already exists."
+msgstr ""
+"Un file nominat «%s» ja existe.\n"
+"\n"
+"%s"
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+#, fuzzy
+msgid "_Replace"
+msgstr "Substituer?"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+#, fuzzy
+msgid "Cannot export VPN connection"
+msgstr "Desactivar connexion VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+#, fuzzy
+msgid "Export VPN connection"
+msgstr "Un connexion VPN ne successat"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nequande"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "hodie"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "yer"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Ultimmen usat"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Adjuncter un nov connexion"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Obliviar"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Conosset retes Wi-Fi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Obliviar"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr ""
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+#, fuzzy
+msgid "This is not recommended for untrusted public networks."
+msgstr "To ne es recomandat por ínfidet public retes."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Extinter li aparate"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Activ"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Provisor"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy de rete"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Socks v5"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorar hostes"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Portu de proxy HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Portu de proxy HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Portu de proxy FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Portu de proxy Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuration"
+
+#: panels/network/network-vpn.ui:11
+#, fuzzy
+msgid "Turn VPN connection off"
+msgstr "Desactivar connexion VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nómine de rete"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tip de securitá"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Contrasigne"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Desactivar Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "_Plu optiones"
+
+#: panels/network/network-wifi.ui:119
+#, fuzzy
+msgid "_Connect to Hidden Network…"
+msgstr "_Conexer a un celat rete..."
+
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Desactivar Wi-Fi"
+
+#: panels/network/network-wifi.ui:143
+#, fuzzy
+msgid "_Known Wi-Fi Networks"
+msgstr "Retes Wi-Fi (%s)"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Ínconosset statu"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Íngeret"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Índisponibil"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Conexente"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Autentication es besonat"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Deconexente"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Conexion ne successat"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Ínconosset statu (mancant)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Configuration ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+#, fuzzy
+#| msgid "Proxy Configuration"
+msgid "IP configuration failed"
+msgstr "Configuration de IP ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+#, fuzzy
+#| msgid "Proxy Configuration"
+msgid "IP configuration expired"
+msgstr "Configuration de IP ha expirat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Suplicante 802.1x ha deconexet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+#, fuzzy
+msgid "802.1x supplicant configuration failed"
+msgstr "Configuration del suplicante 802.1x ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Suplicante 802.1x ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+#, fuzzy
+msgid "PPP service failed to start"
+msgstr "Servicie PPP ne successat lansar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+#, fuzzy
+msgid "PPP service disconnected"
+msgstr "Servicie PPP ha desconexet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+#, fuzzy
+msgid "DHCP client failed to start"
+msgstr "Client DHCP ne successat lansar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Errore de client DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Client DHCP ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+#, fuzzy
+msgid "Shared connection service failed to start"
+msgstr "Servicie AutoIP ne successat lansar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+#, fuzzy
+msgid "Shared connection service failed"
+msgstr "Conexion ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+#, fuzzy
+msgid "AutoIP service failed to start"
+msgstr "Servicie AutoIP ne successat lansar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+#, fuzzy
+msgid "AutoIP service error"
+msgstr "Errore del servicie AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+#, fuzzy
+msgid "AutoIP service failed"
+msgstr "Servicie AutoIP ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linea es ocupat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+#, fuzzy
+msgid "No carrier could be established"
+msgstr "Ne successat negociar un portator"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+#, fuzzy
+msgid "Dialing request timed out"
+msgstr "Timeout evenit durante de conexion."
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+#, fuzzy
+msgid "Dialing attempt failed"
+msgstr "Prova discar ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+#, fuzzy
+msgid "Modem initialization failed"
+msgstr "Inicialisation de modem ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+#, fuzzy
+msgid "Not searching for networks"
+msgstr "Sercha..."
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+#, fuzzy
+msgid "Network registration denied"
+msgstr "Registration in li rete refusat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+#, fuzzy
+msgid "Network registration timed out"
+msgstr "Timeout evenit durante de verification del session."
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+#, fuzzy
+msgid "Failed to register with the requested network"
+msgstr "Ne successat registrar in li selectet rete"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+#, fuzzy
+msgid "PIN check failed"
+msgstr "Control de PIN ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+#, fuzzy
+msgid "Firmware for the device may be missing"
+msgstr "Li firmware por li aparate posse esser mancant"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+#, fuzzy
+msgid "Connection disappeared"
+msgstr "Null conexion"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+#, fuzzy
+msgid "Existing connection was assumed"
+msgstr "Un _existent album"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Null modem trovat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Conexion Bluetooth ne successat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM: null carte insertet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM: PIN es besonat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM: PUK es besonat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM es íncorrect"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+#, fuzzy
+msgid "Connection dependency failed"
+msgstr "Ne successat resoluer problemas del dependenties!"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Firmware manca"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+#, fuzzy
+msgid "Cable unplugged"
+msgstr "Cable"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:196
+#, fuzzy
+msgid "no file selected"
+msgstr "Null file selectet"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certificates DER o PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Files PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonim"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autenticat"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ambi"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+#, fuzzy
+msgid "Anony_mous identity"
+msgstr "&Identitá:"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_File PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Selecter un file PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "_Internal autentication"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Permisser automatic pro_vision PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nómine de _usator"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Contrasigne"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Revelar li c_ontrasigne"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificate de C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+#, fuzzy
+msgid "Choose a Certificate Authority certificate"
+msgstr "Detallies del certificate:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Ne _besonar certificate de CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Version de PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+#, fuzzy
+msgid "missing EAP username"
+msgstr "Nómine de _usator"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+#, fuzzy
+#| msgid "Change password"
+msgid "missing EAP password"
+msgstr "MSCHAPv2 (sin EAP)"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+#, fuzzy
+msgid "Choose your personal certificate"
+msgstr "Certificate personal"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+#, fuzzy
+msgid "Choose your private key"
+msgstr "Li clave privat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitá"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificate de _usator"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Clave privat"
+
+# CHECK: area on dialog one char too short
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "Contrasigne del clave _privat"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (sin EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Dominia"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+#, fuzzy
+msgid "Tunneled TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+#, fuzzy
+msgid "Protected EAP (PEAP)"
+msgstr "EAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tentication"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Selecter un file"
+
+#: panels/network/wireless-security/ws-leap.c:66
+#, fuzzy
+msgid "missing leap-username"
+msgstr "Nómine de _usator"
+
+#: panels/network/wireless-security/ws-leap.c:81
+#, fuzzy
+#| msgid "Change password"
+msgid "missing leap-password"
+msgstr "Bissextil"
+
+#: panels/network/wireless-security/ws-sae.c:77
+#, fuzzy
+msgid "Wi-Fi password is missing."
+msgstr "Contrasigne de Wi-Fi"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tip"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+#, fuzzy
+msgid "missing wep-key"
+msgstr "Li clave es mancant"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (predefinit)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+#| msgid "File System"
+msgid "Open System"
+msgstr "Aperter un diarium de journald"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+#, fuzzy
+msgid "Shared Key"
+msgstr "Clave comun"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Clave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+#, fuzzy
+msgid "Sho_w key"
+msgstr "Re_velar li clave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Índe_x WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificationes"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+#| msgid "Sounds"
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "&Son:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Notification:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "&Ne monstrar ti avise denov"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Activar notificationes del volúmine sur li ecran."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Ne _disturbar"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Activar notificationes del volúmine sur li ecran."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr " Altri"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, fuzzy, c-format
+msgid "%s removed"
+msgstr "Video «%s» esset removet."
+
+# CHECK
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+#, fuzzy
+msgid "Error removing account"
+msgstr "Un errore evenit removente un conto"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Defar"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+#| msgid "_Acceleration:"
+msgid "Close the notification"
+msgstr "Minimisar in li area de notificationes in vice de cluder"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Adjunter un conto"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Conto %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Remover li conto"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Contos online"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+#, fuzzy
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"google, facebook, twitter, yahoo, web, online, chat, calendar, post, e-post, "
+"contacte, owncloud, kerberos, imap, smtp, pocket, readitlater, conto"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Ínconosset témpor"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minute"
+msgstr[1] "%i minutes"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hor"
+msgstr[1] "%i hores"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hor"
+msgstr[1] "hores"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minute"
+msgstr[1] "minutes"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, fuzzy, c-format
+msgid "%s until fully charged"
+msgstr ""
+"%s (%i%%)\n"
+"%s til complet charge"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Avise: %s remane"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s remane"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Chargeat completmen"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Ne chargeante"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Vacui"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Chargeante"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Dechargeante"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Mus sin fil"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Tastatura sin fil"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+#, fuzzy
+msgid "Uninterruptible power supply"
+msgstr "Íninterruptibil fonte de energie"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+#, fuzzy
+msgid "Personal digital assistant"
+msgstr "Digital assistente personal (PDA)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Telefon cellulari"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Reproductor de medie"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tabulette"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Computator"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Aparate de intrada por ludes"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batterie"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Primari"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Extra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batteries"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Pos ínact_ivitá"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Suspender"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Extinter"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hivernar"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Necós"
+
+#: panels/power/cc-power-panel.c:733
+#, fuzzy
+msgid "When on battery power"
+msgstr "Batterie ea exhaustet"
+
+#: panels/power/cc-power-panel.c:735
+#, fuzzy
+msgid "When plugged in"
+msgstr "Deconexet del rete"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nequande"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Suspender automaticmen"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1040
+#, fuzzy
+msgid "Performance mode temporarily disabled."
+msgstr "Mode de avion es ínactiv"
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, fuzzy, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Mode:        %s (%04o)"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#| msgid "minutes"
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#| msgid "minutes"
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#| msgid "minutes"
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#| msgid "minutes"
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#| msgid "minutes"
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hor"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#| msgid "minutes"
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#| msgid "minutes"
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#| msgid "minutes"
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 hores"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "_Accender"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Conservation de energie"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Automatic luciditá"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Obscurar li ecran"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+#| msgid "Screen Resolution"
+msgid "Screen _Blank"
+msgstr "Blanc ecran"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Garda-ecran"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "suspendente"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+#, fuzzy
+msgid "Show Battery _Percentage"
+msgstr "Frequentie quam _percentage"
+
+#: panels/power/cc-power-panel.ui:244
+#, fuzzy
+msgid "Automatic Suspend"
+msgstr "suspendente"
+
+#: panels/power/cc-power-panel.ui:267
+#, fuzzy
+msgid "_Plugged In"
+msgstr "Conexet al rete"
+
+#: panels/power/cc-power-panel.ui:279
+#, fuzzy
+msgid "On _Battery Power"
+msgstr "Batterie ea exhaustet"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Retarde"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Productivitá"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Garda-energie"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energie"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, fuzzy, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Li bux «%s» sta removet"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+#, fuzzy
+msgid "Failed to add new printer."
+msgstr "Ne successat adjuncter un nov rapid-taste"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, fuzzy, c-format
+msgid "Could not load ui: %s"
+msgstr "Ne posset chargar li image «%s»"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Printatores"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Adjunter un printator"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "D_esserrar"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Null printatores trovat"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autentication es besonat"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nómine de usator"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, fuzzy, c-format
+#| msgid "_Details"
+msgid "%s Details"
+msgstr ""
+"Ne successat executer «%s»\n"
+"\n"
+"Detallies: %s"
+
+#: panels/printers/pp-details-dialog.c:107
+#, fuzzy
+msgid "No suitable driver found"
+msgstr "null apt driver de smartcartes esset trovat"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Selecter un file PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Localisation"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:178
+#, fuzzy
+msgid "Searching for preferred drivers…"
+msgstr "Preferet"
+
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "Driveres"
+
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "S_electer ex:"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Installar un file PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+#| msgid "Select Image"
+msgid "Select Printer Driver"
+msgstr "Null driver disponibil por ti-ci printator."
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "Base de data:"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Selecter"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Printator JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Printator LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+#, fuzzy
+msgid "One Sided"
+msgstr "Duplic"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Long bord (standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+#, fuzzy
+msgid "Short Edge (Flip)"
+msgstr "EDGE"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portrete"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Paisage"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Reversat paisage"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Reversat portrait"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Reprender"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pause"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Atendente"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pausat"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autentication es besonat"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Processante"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Stoppat"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Anullat"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Interruptet"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Compleet"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+#, fuzzy
+msgid "Move this job to the top of the queue"
+msgstr "Mover un fenestre al nord (alt) monitor"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, fuzzy, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "Activ fenestre: %s\n"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Dominia"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utenticar"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Vacuar omni"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autenticar"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+#, fuzzy
+#| msgid "Large Pointer"
+msgid "No Active Printer Jobs"
+msgstr "Printator"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+#, fuzzy
+msgid "Unlock Print Server"
+msgstr "D_esserrar"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, fuzzy, c-format
+msgid "Unlock %s."
+msgstr "D_esserrar"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:578
+#, fuzzy
+msgid "Searching for Printers"
+msgstr "Sercha..."
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Serial portu"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Paralel portu"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Localisation: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+#| msgid "_Address:"
+msgid "Address: %s"
+msgstr "Adresse: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+#, fuzzy
+msgid "Server requires authentication"
+msgstr "Autentication de servitor"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Duplic"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tip de papere"
+
+#: panels/printers/pp-options-dialog.c:89
+#, fuzzy
+msgid "Paper Source"
+msgstr "Papere"
+
+#: panels/printers/pp-options-dialog.c:90
+#, fuzzy
+msgid "Output Tray"
+msgstr "Minimisar a panel"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolution"
+
+#: panels/printers/pp-options-dialog.c:92
+#, fuzzy
+msgid "GhostScript pre-filtering"
+msgstr "Prefiltration de GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Págines per látere"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Duplic"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientation"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "General"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Formate de págine"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+#, fuzzy
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Non-installabil"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Tache"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+#, fuzzy
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Qualitá de image"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Color"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Finalisation"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avansates"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Prov-págine"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+#, fuzzy
+#| msgid "page"
+msgid "Test page"
+msgstr "Prov-págine"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Autoselecter"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Printator predefinit"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+#, fuzzy
+msgid "Convert to PS level 1"
+msgstr "Converter a PS nivelle 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+#, fuzzy
+msgid "Convert to PS level 2"
+msgstr "Converter a PS nivelle 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+#, fuzzy
+msgid "No pre-filtering"
+msgstr "Prefiltration de GhostScript"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricator"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Activ"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u tache"
+msgstr[1] "%u taches"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+#, fuzzy
+msgid "Clean print heads"
+msgstr "Nettar"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+#, fuzzy
+msgid "Low on toner"
+msgstr " in li printator «%s»"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+#, fuzzy
+msgid "Out of toner"
+msgstr "Vacui de tóner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+#, fuzzy
+msgid "Low on developer"
+msgstr "Bass"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+#, fuzzy
+msgid "Out of developer"
+msgstr "Printator «%s» manca li developpator."
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+#, fuzzy
+msgid "Low on a marker supply"
+msgstr "Bass"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+#, fuzzy
+msgid "Out of a marker supply"
+msgstr "Marca"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Covrette es apert"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Luca apert"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+#, fuzzy
+msgid "Low on paper"
+msgstr "Papere del printator «%s» exhauste."
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Manca papere"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+#, fuzzy
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Ne in li rete"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+#, fuzzy
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Stoppat"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+#, fuzzy
+msgid "Waste receptacle full"
+msgstr " - Complet"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Pret"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+#, fuzzy
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Acceptar"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+#, fuzzy
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Processante"
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+#| msgid "Options"
+msgid "Printing Options"
+msgstr "Printation..."
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Detallies"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Printator predefinit"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "Nettar"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Remover li printator"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modelle"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nivelle de incre"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "Restarta"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Adjunter un printator…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Null printatores"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formates"
+
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Configurante locales."
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Comun formates"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Omni formates"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "Resultates del sercha"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Previder"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Dates"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dates e horas"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Numerós"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mesuras"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papere"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Cluder li session…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Vor conto"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Lingue"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formates"
+
+#: panels/region/cc-region-panel.ui:90
+#, fuzzy
+msgid "Login Screen"
+msgstr "Ecran de session"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Region e lingue"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "Selecte vor preferet lingue"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+#, fuzzy
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Schema del layout"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+#, fuzzy
+msgid "Ask what to do"
+msgstr "Questionar quo far"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+#, fuzzy
+msgid "Do nothing"
+msgstr "Far necós"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+#, fuzzy
+#| msgid "Home folder"
+msgid "Open folder"
+msgstr "Aperter li fólder"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+#, fuzzy
+#| msgid "Other"
+msgid "Other Media"
+msgstr "Altri medies"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+#, fuzzy
+msgid "Select an application for audio CDs"
+msgstr "Selecter un application por audio CDs"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+#, fuzzy
+msgid "Select an application for video DVDs"
+msgstr "Selecter un application por video DVDs"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+#, fuzzy
+msgid "Select an application for software CDs"
+msgstr "Selecte un application por CDs de programmas"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+#, fuzzy
+msgid "audio DVD"
+msgstr "audio DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+#, fuzzy
+msgid "blank Blu-ray disc"
+msgstr "disco Blu-Ray blanc"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+#, fuzzy
+msgid "blank CD disc"
+msgstr "disco CD blanc"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+#, fuzzy
+msgid "blank DVD disc"
+msgstr "disco DVD blanc"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+#, fuzzy
+msgid "blank HD DVD disc"
+msgstr "disco HD DVD blanc"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+#, fuzzy
+msgid "Blu-ray video disc"
+msgstr "disco de video Blu-Ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "Letor de e-libres"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Disco de video HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Image CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Programma de Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Audio CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "Video _DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Reproductor de _musica"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Programmas"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Altri medies..."
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Action:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tip:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Medies removibil"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Configurar gerentie de removibil unités e medies"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+#, fuzzy
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Permisser o depermisser son de notification."
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 secondes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minute"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 hor"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minute"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+#| msgid "minutes"
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+#| msgid "minutes"
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+#| msgid "minutes"
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+#| msgid "minutes"
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+#| msgid "minutes"
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+#| msgid "minutes"
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nequande"
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr ""
+"Null serrures de ecran lansat successosimen e li ecran ne va esser serrat.\n"
+"Esque vu vole continuar suspender li sistema?"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "Blanc ecran"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+#, fuzzy
+msgid "Automatic Screen _Lock"
+msgstr "Serrar li ecran"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "Serrar li ecran _ante que somniar"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Monstrar notificationes"
+
+#: panels/screen/cc-screen-panel.ui:87
+#, fuzzy
+msgid "Forbid new _USB devices"
+msgstr "Aparates USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:108
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "_Privatie:"
+
+#: panels/screen/cc-screen-panel.ui:113
+#, fuzzy
+msgid "Restrict Viewing Angle"
+msgstr "Exhibition es activ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Parametres del ecran"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+#, fuzzy
+msgid "screen;lock;private;privacy;"
+msgstr "Serrar li ecran _ante que somniar"
+
+#: panels/search/cc-search-locations-dialog.c:674
+#, fuzzy
+#| msgid "_Acceleration:"
+msgid "Select Location"
+msgstr "Selecter ignorat localisationes"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Localisationes"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Locs"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Marca-págines"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Altri"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Adjunter un localisation"
+
+#: panels/search/cc-search-panel.c:165
+#, fuzzy
+#| msgid "_Application font:"
+msgid "No applications found"
+msgstr "Null applicationes trovat"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+#| msgid "_Application font:"
+msgid "Application Search"
+msgstr "Ne successat serchar por un application"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Resultates del sercha"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+#, fuzzy
+msgid "No networks selected for sharing"
+msgstr "Partir"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Retes"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Activ"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "No"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Activ"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Activ"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Selecte un fólder"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Adjunter"
+
+#: panels/sharing/cc-sharing-panel.c:736
+#, fuzzy
+msgid "Enable media sharing"
+msgstr "Usar li media-biblioteca"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:942
+#, fuzzy
+msgid "Enable personal media sharing"
+msgstr "Partir personal files obexftp"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+#, fuzzy
+msgid "Device name copied"
+msgstr "Copiat"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+#, fuzzy
+msgid "Device address copied"
+msgstr "Adresse de aparate"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+#, fuzzy
+#| msgid "U_sername:"
+msgid "Username copied"
+msgstr "Nómine de _usator"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+#, fuzzy
+#| msgid "_Password:"
+msgid "Password copied"
+msgstr "Copiat"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Partir"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Nómine de _computator"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Partition de files"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+#| msgid "Desktop"
+msgid "Remote _Desktop"
+msgstr "Cliente de lontan pupitre Remmina"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+#| msgid "Media player"
+msgid "_Media Sharing"
+msgstr "Partir"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+#| msgid "_Acceleration:"
+msgid "_Remote Login"
+msgstr ""
+"Esque vu have un conto sur servitore RDP, Lontan session lassa vos lansar "
+"applicationes de ti servitore."
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Partition de files"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+#| msgid "_Password:"
+msgid "_Require Password"
+msgstr "_Besonar un contrasigne:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+#, fuzzy
+msgid "Remote Login"
+msgstr ""
+"Esque vu have un conto sur servitore RDP, Lontan session lassa vos lansar "
+"applicationes de ti servitore."
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+#| msgid "Desktop"
+msgid "Remote Desktop"
+msgstr "Assignar Remmina quam li predefinit cliente de lontan pupitre"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Telecomande"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Connexer a..."
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copiar"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Cliente de lontan pupitre Remmina"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autentication"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nómine de usator"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+#, fuzzy
+msgid "Verify Encryption"
+msgstr "Sin ciffration"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Ciffration"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+#| msgid "Media player"
+msgid "Media Sharing"
+msgstr "Partir"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Fólderes"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+#, fuzzy
+msgid "Enable or disable remote login"
+msgstr "Permisser aperter li session per un fingre-print"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Personalisat"
+
+# CHECK
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Clic"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Catene"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balancie"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Evanescer"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Posteriori"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Frontal"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, fuzzy, c-format
+msgid "Testing %s"
+msgstr "Prova de «%s»"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+#, fuzzy
+msgid "Click a speaker to test"
+msgstr "Alt-parlator"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volúmine del sistema"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Volúmine"
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Adjustar li volúmine"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Exeada"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Aparate de exeada"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Provar"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuration"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Intrada"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Aparate de intrada"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volúmine"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+#| msgid "Test Sound"
+msgid "Alert Sound"
+msgstr "S_electe un son de avise:"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Assurdar"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Son"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Deconexet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Conexente"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Conexet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+#, fuzzy
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Autorisation"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+#, fuzzy
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "_Reductet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+#, fuzzy
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Es autorisat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Ínconosset"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+#, fuzzy
+msgid "Authorized at:"
+msgstr "Es autorisat"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+#, fuzzy
+msgid "Connected at:"
+msgstr "Ne conexet"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+#, fuzzy
+msgid "Failed to authorize device: "
+msgstr "Ne successat installar paccages."
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+#, fuzzy
+msgid "Failed to forget device: "
+msgstr "Obliviar ti aparate?"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Minimisar in li area de notificationes in vice de cluder"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nómine:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Statu:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "_Autorisar..."
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Obliviar li aparate"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Errore"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+#, fuzzy
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Es autorisat"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, fuzzy, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Un error evenit salvante li archive."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+#, fuzzy
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Ne successat conexer al gerente de session"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Direct image"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+#| msgid "Devices"
+msgid "Pending Devices"
+msgstr "Atendente"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#| msgid "Thunderbird"
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage Thunderbolt devices"
+msgstr "Gerentie de aparates Bluetooth"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+#, fuzzy
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "Cursore:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "_Velocitá:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocitá"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Apuntator"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Dimension de apuntator"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+#, fuzzy
+msgid "Click Assist"
+msgstr "o clicca li icone "
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Secundari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+#, fuzzy
+msgid "A_cceptance delay:"
+msgstr "Sin retarde"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+#| msgid "Shortcut"
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "Retarde:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "Clic"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "R_etarde:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Lími_te de motion:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+#| msgid "Small"
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Micri"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+#| msgid "Large"
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grand"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetir tastes"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "_Retarde de repetition:"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+#, fuzzy
+msgid "Repeat keys speed"
+msgstr "Velocitá"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Tippada"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Restant tastes"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Desactivar restant tastes quande du tastes es _presset simultanmen."
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Clave"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "%s: multiplic claves por %s"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+#, fuzzy
+msgid "Slow keys typing delay"
+msgstr "Avise de lent tastes"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Clave"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Presset"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Presset"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Rest_ant tastes"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+#, fuzzy
+msgid "Bounce keys typing delay"
+msgstr "Usar _restant tastes"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+#, fuzzy
+msgid "_Enable by Keyboard"
+msgstr "Activar LEDs de tastatura"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+#, fuzzy
+#| msgid "Default"
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Predefinit"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Medie"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Grand"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Plu grand"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Grandissim"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixeles"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Sempre monstrar li panel de cartes"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Alt contraste"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "G_rand textu"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+#, fuzzy
+msgid "Enable A_nimations"
+msgstr "P_ermisser"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Letor del ecran"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Claves"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "c"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Scale"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+#, fuzzy
+msgid "Hearing"
+msgstr "Por li malaudient"
+
+# CHECK
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+#| msgid "Visual"
+msgid "_Visual Alerts"
+msgstr "Visual"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Tastatura sur ecran"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Int_ervalle de repetition:"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Cursore:"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
+msgstr "Statu de AccessX"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "apuntator"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Tastes del _mus"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Trovar _li apuntator"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+#, fuzzy
+msgid "_Click Assist"
+msgstr "o clicca li icone "
+
+# CHECK
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "A duplic clic: "
+
+# CHECK
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "A duplic clic: "
+
+# CHECK
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+#, fuzzy
+#| msgid "Visual"
+msgid "Visual Alerts"
+msgstr "Visual"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+#, fuzzy
+msgid "_Test flash"
+msgstr "Sin flash"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Capter li tot ecran"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Flash:"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Curt"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+#, fuzzy
+#| msgid "Screen"
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "_Ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+#, fuzzy
+#| msgid "Screen"
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "_Ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+#, fuzzy
+#| msgid "Screen"
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "_Ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Plen-ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Alt midí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Bass midí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Levul midí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Dextri midí"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+#| msgid "Options"
+msgid "Zoom Options"
+msgstr "_Agrandar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "Agrandation"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "&Lupe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Apuntator del mus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Departion"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "Usar li L_upe del ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lupe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Reticul:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "Apuntator del mus:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "S_pessore:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tenui"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Spess"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Longore:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Co_lor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Reticul"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efectes de color:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "Blan_c sur nigri:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Luciditá:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contraste:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+#, fuzzy
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Co_lor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+#| msgid "None"
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Null"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+#| msgid "_Full"
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Complet"
+
+# Mausempfindlichkeit
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Bass"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alt"
+
+# Mausempfindlichkeit
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Bass"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#| msgid "Colors"
+msgid "Color Effects"
+msgstr "Efectes de color"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 hor"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 die"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dies"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dies"
+
+#: panels/usage/cc-usage-panel.c:180
+#, fuzzy
+msgid "Empty all items from Trash?"
+msgstr "Esque vacuar li Paper-corb?"
+
+#: panels/usage/cc-usage-panel.c:181
+#, fuzzy
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Omni elementes in li Paper-corb va esser irrevocabilmen deletet."
+
+#: panels/usage/cc-usage-panel.c:182
+#, fuzzy
+msgid "_Empty Trash"
+msgstr "Vacuar li _Paper-corb"
+
+#: panels/usage/cc-usage-panel.c:218
+#, fuzzy
+msgid "Delete all the temporary files?"
+msgstr "Temporari files"
+
+#: panels/usage/cc-usage-panel.c:219
+#, fuzzy
+msgid "All the temporary files will be permanently deleted."
+msgstr "Omni elementes in li Paper-corb va esser irrevocabilmen deletet."
+
+#: panels/usage/cc-usage-panel.c:220
+#, fuzzy
+msgid "_Purge Temporary Files"
+msgstr "Efaciar"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 die"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dies"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dies"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Permanentmen"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Diarium de files"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "H"
+
+#: panels/usage/cc-usage-panel.ui:25
+#, fuzzy
+msgid "File _History Duration"
+msgstr "Diarium de files e li Paper-corb"
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "Vacuar li diarium…"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "<b>Temporari files</b>"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "_Deleter ex li Paper-corb"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Ne successat remover li temporari file"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "_Automaticmen"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Vacuar li _Paper-corb…"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "Ne successat remover li temporari file"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#| msgid "Move to Trash"
+msgid "File History & Trash"
+msgstr "Diarium de files e li Paper-corb"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "Lassar it"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+#, fuzzy
+msgid "Failed to add account"
+msgstr "&Adjunter un conto..."
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Contrasignes"
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+#, fuzzy
+msgid "Failed to register account"
+msgstr "Ne successat registrar in li selectet rete"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+#, fuzzy
+msgid "Failed to join domain"
+msgstr "_Dominia"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+#, fuzzy
+msgid "Failed to log into domain"
+msgstr "<application>Git</application> diarium ne successat."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Adjunter un usator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Beim ersten Start _automatisch einen Benutzer anmelden"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+#| msgid "_New password:"
+msgid "Set password now"
+msgstr "Assignar un contrasigne"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Enterprise"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Ne in li rete"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+#, fuzzy
+msgid "Browse for more pictures"
+msgstr "Trovar plu images..."
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Selecter un file…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Fingre-print:\n"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Fingre-print"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#| msgid "_None"
+msgid "_No"
+msgstr "_No"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Yes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Fingre-print:\n"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Fingre-print:\n"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+#, fuzzy
+msgid "Ensure the device is properly connected."
+msgstr "Aparate es fidet e conexet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Fingre-print:\n"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Permisser aperter li session per un fingre-print"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+#, fuzzy
+msgid "_Delete Fingerprints"
+msgstr "_Deleter fingre-printes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Fingre-print:\n"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+#, fuzzy
+msgid "the device needs to be claimed to perform this action"
+msgstr "<b>_Action de un duplic clic</b>"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+#, fuzzy
+msgid "the device is already claimed by another process"
+msgstr "Li aparate ja es usat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+#, fuzzy
+msgid "you do not have permission to perform the action"
+msgstr "Vu ne have permissiones por creation de ti fólder."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+#, fuzzy
+msgid "no prints have been enrolled"
+msgstr "Actualisamentes ha esset installat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+#, fuzzy
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Ne posset assignar li Letor de postage predefinit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+#, fuzzy
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Ne successat communicar con li servitor. Vi li textu de errore:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, fuzzy, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Ne successat obtener li liste de fólderes"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, fuzzy, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Ne successat remover li file «%s». Cause: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Levul pollice"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Levul fingre medial"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "Levul index"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Levul fingre annelari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Levul fingre auriculari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Dextri pollice"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Dextri fingre medial"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "Dextri index"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Dextri fingre annelari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Dextri fingre auriculari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Ínconosset fingre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Compleet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+#, fuzzy
+msgid "Fingerprint device disconnected"
+msgstr "Aparate deconexet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+#, fuzzy
+msgid "Failed to enroll new fingerprint"
+msgstr "Nov fingre-print:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, fuzzy, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Ne successat lansar li preferenties de son: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+#, fuzzy
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Nov fingre-print:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, fuzzy, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Ne successat haltar li servicie: %1"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+#, fuzzy
+msgid "_Re-enroll this finger…"
+msgstr "Ínconosset fingre"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+#, fuzzy
+msgid "Scan new fingerprint"
+msgstr "Nov fingre-print:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+#, fuzzy
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problema"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, fuzzy, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Ne successat obtener li nómine de host: %s\n"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Ho-semane"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Ultim semane"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+#, fuzzy
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%-e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+#, fuzzy
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%-e %b  %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+#, fuzzy
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "k"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+#, fuzzy
+msgid "Session Ended"
+msgstr "finit"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+#, fuzzy
+msgid "Session Started"
+msgstr "Iniciat:"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, fuzzy, c-format
+msgid "%s — Account Activity"
+msgstr "Conto %s"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Precedent"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Sequent"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+#, fuzzy
+msgid "Please choose another password."
+msgstr "Ples selecter un altri nómine"
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.c:142
+#, fuzzy
+msgid "Password could not be changed"
+msgstr "Li gruppe ne posse esset changeat."
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Cambiar li contrasigne"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "C_ambiar"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Actual contrasigne"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nov contrasigne"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Confirmar li contrasigne"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+#| msgid "_New password:"
+msgid "Set a password now"
+msgstr "Assignar un contrasigne"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:306
+#, fuzzy
+msgid "No such domain or realm found"
+msgstr "_Dominia:"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, fuzzy, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Cluder li session de %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+#, fuzzy
+msgid "Invalid password, please try again"
+msgstr "Contrasigne es íncorect, ples repena denov"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:356
+#, fuzzy
+msgid "Failed to delete user"
+msgstr "Ne successar cambiar li usator"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, fuzzy, c-format
+msgid "%s is still logged in"
+msgstr "Avise: %d usator have un session ancor apert."
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Esque vu vole retener li files de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "Remo_ver files"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "R_etener files"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, fuzzy, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Esque vu vole remover «%s» permanentmen?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Remover"
+
+#: panels/user-accounts/cc-user-panel.c:661
+#, fuzzy
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Conto"
+
+#: panels/user-accounts/cc-user-panel.c:669
+#, fuzzy
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Inregistration"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Null"
+
+#: panels/user-accounts/cc-user-panel.c:715
+#, fuzzy
+msgid "Logged in"
+msgstr ""
+"\n"
+"<i>session apertet</i>"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+#, fuzzy
+msgid "Failed to contact the accounts service"
+msgstr "Ne successat conexer al servicie."
+
+#: panels/user-accounts/cc-user-panel.c:1204
+#, fuzzy
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Stellen Sie sicher, dass die Dauerumschalttaste nicht aktiv ist"
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1293
+#, fuzzy
+msgid "Delete the selected user account"
+msgstr "Deleter selectet"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1455
+#, fuzzy
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Parametres del sistema (quel afecte omni usatores)"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Usatores"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Restartar nu"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Cluder"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Avatar:"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Nómine complet"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Redacter"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+#, fuzzy
+msgid "_Fingerprint Login"
+msgstr "Permisser aperter li session per un fingre-print"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+#, fuzzy
+msgid "A_utomatic Login"
+msgstr "A_utomatic"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "Activitá"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+#| msgid "Controls"
+msgid "_Parental Controls"
+msgstr "Controles"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Aperter per altri application..."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "_Remover..."
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Privilegies es besonat por controlar processus de altri usatores"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr ""
+"Un error evenit. Ples penar installar samba e adjunter vor usator in li "
+"gruppe «sambashare» manualmen."
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Usatores"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "&Adjunter un conto..."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+#, fuzzy
+msgid "Domain Administrator Login"
+msgstr "_Dominia"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+#, fuzzy
+msgid "Administrator _Name"
+msgstr "(quam Administrator)"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+#, fuzzy
+msgid "Administrator Password"
+msgstr "(quam Administrator)"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+#, fuzzy
+msgid "Manage user accounts"
+msgstr "Gerer contos"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+#, fuzzy
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Li contrasigne es tro curt"
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:112
+#, fuzzy
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Usar _DHT por trovar extra peeres"
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:401
+#, fuzzy
+#| msgid "Authenticated!"
+msgid "Authentication failed"
+msgstr "Autentication ne successat"
+
+#: panels/user-accounts/run-passwd.c:480
+#, fuzzy, c-format
+msgid "The new password is too short"
+msgstr "Li contrasigne es tro curt"
+
+#: panels/user-accounts/run-passwd.c:486
+#, fuzzy, c-format
+msgid "The new password is too simple"
+msgstr "Li contrasigne es tro simplic"
+
+#: panels/user-accounts/run-passwd.c:492
+#, fuzzy, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Li contrasigne es tro simplic"
+
+#: panels/user-accounts/run-passwd.c:495
+#, fuzzy, c-format
+msgid "The new password has already been used recently."
+msgstr "Alminu du nómines de file es identic."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:502
+#, fuzzy, c-format
+msgid "The old and new passwords are the same"
+msgstr "Alminu du nómines de file es identic."
+
+#: panels/user-accounts/run-passwd.c:506
+#, fuzzy, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Vor contrasigne ha expirat."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, fuzzy, c-format
+#| msgid "Unknown"
+msgid "Unknown error"
+msgstr "ínconosset errore"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:190
+#, fuzzy
+msgid "The username is too long."
+msgstr "Li nómine de archive es tro long."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+#| msgid "Buttons"
+msgid "Map Buttons"
+msgstr "Butones"
+
+#: panels/wacom/button-mapping.ui:26
+#, fuzzy
+msgid "Map buttons to functions"
+msgstr "Corespondentie"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+#, fuzzy
+msgid "_Close"
+msgstr "C_lusion"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, fuzzy, c-format
+#| msgid "Buttons"
+msgid "Button %d"
+msgstr "custom_cmd_button%d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+#, fuzzy
+#| msgid "_Application font:"
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Null marca-págines definit"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+#, fuzzy
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Rular pos _tippa"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+#, fuzzy
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Cambiar li monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+#, fuzzy
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Monstrar li págine de auxilie"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:433
+#, fuzzy
+msgid "Tablet mounted on external display"
+msgstr "Sin extern monitor"
+
+#: panels/wacom/cc-wacom-device.c:435
+#, fuzzy
+msgid "External tablet device"
+msgstr "Extern"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "Extern"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+#, fuzzy
+msgid "All Displays"
+msgstr "Monitores"
+
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tabulette"
+
+#: panels/wacom/cc-wacom-page.ui:17
+#, fuzzy
+msgid "Use absolute positioning for the pen"
+msgstr "Plum (absolut)"
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Orientation por li levul manu"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "_Aspecte"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Calibrar"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+#, fuzzy
+msgid "No tablet detected"
+msgstr "Null tabulette detectet"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+#, fuzzy
+msgid "Tip Pressure Feel"
+msgstr "_Pression:"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+#, fuzzy
+msgid "Soft"
+msgstr "Soft"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+#, fuzzy
+msgid "Stylus tip pressure"
+msgstr "_Pression:"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+#| msgid "Buttons"
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Extra buton %1:"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+#| msgid "Buttons"
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "_Buton:"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+#| msgid "Buttons"
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+#, fuzzy
+msgid "Eraser Pressure Feel"
+msgstr "Pression"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Pression"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+#, fuzzy
+msgid "Middle Mouse Button Click"
+msgstr "Clic del dextri mus-buton"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+#, fuzzy
+msgid "Right Mouse Button Click"
+msgstr "Clic del dextri mus-buton"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+#, fuzzy
+msgid "Forward"
+msgstr "Avan"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:327
+#, fuzzy
+msgid "Standard stylus with pressure"
+msgstr "Standard"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tabulette Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+#, fuzzy
+msgid "New shortcut…"
+msgstr "Nov rapid-taste…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Adresse:"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+#, fuzzy
+msgid "Operation Cancelled"
+msgstr "Operation anullat"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:548
+#, fuzzy
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "Un errore evenit durante copiation a «%B»."
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+#, fuzzy
+msgid "Not Registered"
+msgstr "U_sator registrat"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+#, fuzzy
+msgid "Registered"
+msgstr "Function CSS '%s' es ja registrat."
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+#, fuzzy
+#| msgid "Search"
+msgid "Searching"
+msgstr "Sercha"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+#, fuzzy
+msgid "Denied"
+msgstr "Refusat"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+#| msgid "_Details"
+msgid "Modem Details"
+msgstr "Modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+msgid "Modem Status"
+msgstr "Modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+#, fuzzy
+msgid "Carrier"
+msgstr "Portator"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+#| msgid "Network Proxy"
+msgid "Network Type"
+msgstr "Rete: "
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+#| msgid "Network Servers"
+msgid "Network Status"
+msgstr "Statu: "
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Parte de un libre con su propri titul"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+#| msgid "Devices"
+msgid "Device Details"
+msgstr "_Detallies de aparate"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Version de firmware:"
+
+#: panels/wwan/cc-wwan-device.c:988
+#, fuzzy
+msgid "2G Only"
+msgstr "solmen"
+
+#: panels/wwan/cc-wwan-device.c:991
+#, fuzzy
+msgid "3G Only"
+msgstr "%3g ms"
+
+#: panels/wwan/cc-wwan-device.c:994
+#, fuzzy
+msgid "4G Only"
+msgstr "solmen"
+
+#: panels/wwan/cc-wwan-device.c:997
+#, fuzzy
+msgid "5G Only"
+msgstr "solmen"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1028
+#, fuzzy
+msgid "2G, 3G, 4G"
+msgstr "%3g ms"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1041
+#, fuzzy
+msgid "3G, 4G, 5G"
+msgstr "%3g ms"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1067
+#, fuzzy
+msgid "2G, 3G, 5G"
+msgstr "%3g ms"
+
+#: panels/wwan/cc-wwan-device.c:1073
+#, fuzzy
+msgid "3G, 4G (Preferred)"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1075
+#, fuzzy
+msgid "3G (Preferred), 4G"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1077
+#, fuzzy
+msgid "3G, 4G"
+msgstr "%3g ms"
+
+#: panels/wwan/cc-wwan-device.c:1083
+#, fuzzy
+msgid "2G, 4G (Preferred)"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1085
+#, fuzzy
+msgid "2G (Preferred), 4G"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+#, fuzzy
+msgid "2G, 3G (Preferred)"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1095
+#, fuzzy
+msgid "2G (Preferred), 3G"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1097
+#, fuzzy
+msgid "2G, 3G"
+msgstr "%3g ms"
+
+#: panels/wwan/cc-wwan-device.c:1103
+#, fuzzy
+msgid "2G, 5G (Preferred)"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1105
+#, fuzzy
+msgid "2G (Preferred), 5G"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+#, fuzzy
+msgid "3G, 5G (Preferred)"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1115
+#, fuzzy
+msgid "3G (Preferred), 5G"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1117
+#, fuzzy
+msgid "3G, 5G"
+msgstr "%3g ms"
+
+#: panels/wwan/cc-wwan-device.c:1123
+#, fuzzy
+msgid "4G, 5G (Preferred)"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1125
+#, fuzzy
+msgid "4G (Preferred), 5G"
+msgstr "Preferet"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+#, fuzzy
+#| msgid "Unknown"
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Ínconosset"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+#, fuzzy
+msgid "Unlock SIM card"
+msgstr "SIM: null carte insertet"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+#, fuzzy
+msgid "Unlock"
+msgstr "Desserrar"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:225
+#, fuzzy
+msgid "Wrong password entered."
+msgstr "Contrasigne es ínvalid."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:294
+#, fuzzy
+msgid "Enter New PIN"
+msgstr "Intra un code PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+#, fuzzy
+msgid "No SIM"
+msgstr "PIN del SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "Serrat"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+#| msgid "_Mobile:"
+msgid "_Mobile Data"
+msgstr "_Mobil:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+#, fuzzy
+msgid "_Data Roaming"
+msgstr "Null data"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+#| msgid "Network Proxy"
+msgid "_Network Mode"
+msgstr "mode"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+#| msgid "Network Proxy"
+msgid "N_etwork"
+msgstr "ID de r_ete"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Avansates"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Protocol Punctu-ad-punctu"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "SIM es íncorrect"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+#, fuzzy
+msgid "Lock SIM with PIN"
+msgstr "SIM: PIN es besonat"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+#| msgid "_Details"
+msgid "M_odem Details"
+msgstr "&Detallies"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+#, fuzzy
+msgid "Phone failure"
+msgstr "Telefon"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+#, fuzzy
+msgid "No connection to phone"
+msgstr "Telefon - intrada"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+#, fuzzy
+msgid "Operation not allowed"
+msgstr "Operation"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+#, fuzzy
+msgid "Operation not supported"
+msgstr "Operation ne es suportat"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+#, fuzzy
+msgid "SIM not inserted"
+msgstr "SIM: null carte insertet"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+#, fuzzy
+msgid "SIM PIN required"
+msgstr "SIM: PIN es besonat"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+#, fuzzy
+msgid "SIM PUK required"
+msgstr "SIM: PUK es besonat"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+#, fuzzy
+msgid "SIM failure"
+msgstr "Dessuccesse"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+#, fuzzy
+msgid "SIM busy"
+msgstr "Ocupat"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+#, fuzzy
+msgid "Incorrect password"
+msgstr "Contrasigne es íncorect."
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+#, fuzzy
+msgid "SIM PIN2 required"
+msgstr "SIM: PIN es besonat"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+#, fuzzy
+msgid "SIM PUK2 required"
+msgstr "SIM: PIN es besonat"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+#, fuzzy
+msgid "Not found"
+msgstr "Ne esset trovat"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+#, fuzzy
+#| msgid "Network Servers"
+msgid "No network service"
+msgstr "Rete"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+#, fuzzy
+#| msgid "Network Proxy"
+msgid "Network timeout"
+msgstr "Timeout"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+#, fuzzy
+msgid "GPRS services not allowed"
+msgstr "GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+#, fuzzy
+msgid "Unspecified GPRS error"
+msgstr "Ínspecificat errore"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+#, fuzzy
+msgid "No Error"
+msgstr "Null errore"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+#, fuzzy
+msgid "Action Cancelled"
+msgstr "Les anullat"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+#, fuzzy
+msgid "Access denied"
+msgstr "Accesse refusat"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+#, fuzzy
+#| msgid "Unknown"
+msgid "Unknown Error"
+msgstr "ínconosset errore"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+#| msgid "Network Proxy"
+msgid "Network Mode"
+msgstr "mode"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+#| msgid "_Authenticate"
+msgid "_Automatic"
+msgstr "_Automatic"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Bitte wählen Sie einen Netzwerkrechner, zu dem verbunden werden soll."
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+#| msgid "Network Servers"
+msgid "Refresh Network Providers"
+msgstr "Refriscar li liste de retes"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, fuzzy, c-format
+msgid "SIM %d"
+msgstr "PIN del SIM"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Mobil rete"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Adaptator:"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Mode de avion es activ"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Data"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM: null carte insertet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "SIM es íncorrect"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Sequent"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+#, fuzzy
+msgid "_Lock SIM with PIN"
+msgstr "SIM: PIN es besonat"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "PIN:"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobil rete"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+#, fuzzy
+msgid "Utility to configure the GNOME desktop"
+msgstr "Gerentie de discos por GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Li projecte GNOME"
+
+#: shell/cc-application.c:59
+#, fuzzy
+msgid "Display version number"
+msgstr "Monstra li numeró del version"
+
+#: shell/cc-application.c:60
+#, fuzzy
+msgid "Enable verbose mode"
+msgstr "Activar &passiv mode (PASV)"
+
+#: shell/cc-application.c:61
+#, fuzzy
+msgid "Search for the string"
+msgstr "Li serchat textu ne esset trovat"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr ""
+
+#: shell/cc-application.c:63
+#, fuzzy
+msgid "Panel to display"
+msgstr "Monstrar sur panel"
+
+#: shell/cc-application.c:63
+#, fuzzy
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "option %s besona un argument"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categories de parametres"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privatie"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Disponibil paneles:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Omni parametres"
+
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Monstrar li primari menú"
+
+#: shell/cc-window.ui:152
+#, fuzzy
+msgid "Warning: Development Version"
+msgstr "Avise"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Auxilie"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "General"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Surtir"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Serchar"
+
+# CHECK
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneles"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Retornar al precedent menú"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "_Anullar"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+#| msgid "/_Preferences"
+msgid "Preferences;Settings;"
+msgstr "Parametres personal"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+#, fuzzy
+msgid "Initial state of the window"
+msgstr "Statu inicial del fenestre:"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sones de sistema"

--- a/po/is.po
+++ b/po/is.po
@@ -7,10 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.master.is\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issu"
-"es\n"
-"POT-Creation-Date: 2022-07-10 13:36+0000\n"
-"PO-Revision-Date: 2022-09-05 18:03+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-10-25 15:58+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic\n"
 "Language: is\n"
@@ -21,97 +20,7 @@ msgstr ""
 "X-Generator: Lokalize 21.12.3\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: panels/applications/cc-applications-panel.c:790
-msgid "System Bus"
-msgstr "Kerfisbraut"
-
-#: panels/applications/cc-applications-panel.c:790
-#: panels/applications/cc-applications-panel.c:792
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:810
-msgid "Full access"
-msgstr "Fullur aðgangur"
-
-#: panels/applications/cc-applications-panel.c:792
-msgid "Session Bus"
-msgstr "Setubraut"
-
-#: panels/applications/cc-applications-panel.c:796
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Tæki"
-
-#: panels/applications/cc-applications-panel.c:796
-msgid "Full access to /dev"
-msgstr "Fullur aðgangur að /dev"
-
-#: panels/applications/cc-applications-panel.c:800
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Netkerfi"
-
-#: panels/applications/cc-applications-panel.c:800
-msgid "Has network access"
-msgstr "Er með aðgang að netkerfi"
-
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:807
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Heim"
-
-#: panels/applications/cc-applications-panel.c:807
-#: panels/applications/cc-applications-panel.c:812
-msgid "Read-only"
-msgstr "Skrifvarið"
-
-#: panels/applications/cc-applications-panel.c:810
-#: panels/applications/cc-applications-panel.c:812
-msgid "File System"
-msgstr "Skráakerfi"
-
-#: panels/applications/cc-applications-panel.c:816
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Stillingar"
-
-#: panels/applications/cc-applications-panel.c:816
-msgid "Can change settings"
-msgstr "Má breyta stillingum"
-
-#: panels/applications/cc-applications-panel.c:818
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1154
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] ""
-msgstr[1] ""
-
-#: panels/applications/cc-applications-panel.c:1161
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1213
-#, c-format
-msgid "%s of disk space used"
-msgstr "%s af diskplássi verður notað"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1377
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -127,7 +36,6 @@ msgid "Install some…"
 msgstr "Settu upp eitthvað…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Opna"
 
@@ -138,6 +46,10 @@ msgstr "Skoða nánar"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Leita"
@@ -145,26 +57,15 @@ msgstr "Leita"
 #: panels/applications/cc-applications-panel.ui:113
 #: panels/applications/cc-applications-panel.ui:120
 msgid "Receive system searches and send results."
-msgstr ""
+msgstr "Taka við kerfisleitum og senda niðurstöður."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Óvirkt"
 
@@ -178,7 +79,7 @@ msgid "Show system notifications."
 msgstr "Birta kerfistilkynningar."
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+msgid "Run in Background"
 msgstr "Keyra í bakgrunni"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -186,132 +87,143 @@ msgid "Allow activity when the app is closed."
 msgstr "Leyfa virkni þegar forritið er lokað."
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Skjámyndir"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Taktu myndir af skjánum hvenær sem er."
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "Skipta um bakgrunnsmynd"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "Skipta um bakgrunnsmyndina á skjáborðinu."
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Hljóð"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "Framkallaðu hljóð."
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "Koma í veg fyrir notkun flýtilykla"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "Hindra staðlaðar flýtileiðir á lyklaborði"
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "Myndavél"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "Taktu myndir með myndavélinni."
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "Hljóðnemi"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "Taktu upp hljóð í gegnum hljóðnemann."
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Staðsetningarþjónustur"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "Fá aðgang að staðsetningum tækis."
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "Innbyggðar heimildir"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "Kerfisaðgangur sem þetta forrit krefst"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "Vensl skráa og tengla"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Geymsla"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Engar niðurstöður fundust"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Reyndu aðra leit"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "Vensl skráa og tengla"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "Skráartegundir"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "Tegundir tengla"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Endurstilla"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Hversu mikið diskpláss þetta forrit er að notað til að geyma forritsgögn og "
 "hrunupplýsingar."
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Forrit"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Gögn"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Skyndiminni"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Samtals</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Hreinsa skyndiminni…"
 
@@ -319,90 +231,32 @@ msgstr "Hreinsa skyndiminni…"
 msgid "Control various application permissions and settings"
 msgstr "Stýrir ýmsum heimildum og stillingum forrits"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "forrit;flatpak;heimild;stilling;"
-
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "Veldu mynd"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:519 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "_Hætta við"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:520
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Opna"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "margar stærðir"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Enginn skjáborðsbakgrunnur"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Núverandi bakgrunnur"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stíll"
 
-#: panels/background/cc-background-panel.ui:46
-msgid "Light"
-msgstr "Ljóst"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Sjálfgefið"
 
-#: panels/background/cc-background-panel.ui:73
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "Dökkt"
 
-#: panels/background/cc-background-panel.ui:92
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Bakgrunnur"
 
-#: panels/background/cc-background-panel.ui:98
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "Bæta við mynd…"
 
@@ -414,50 +268,57 @@ msgstr "Útlit"
 msgid "Change your background image or the UI colors"
 msgstr "Breyttu bakgrunnsmyndinni eða litum notandaviðmótsins"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
-msgstr "Bakgrunnur;Bakgrunnsmynd;Skjár;Skjáborð;Stíll;Ljóst;Dökkt;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Bakgrunnur;Bakgrunnsmynd;Skjár;Skjáborð;Stíll;Ljóst;Dökkt;Útlit;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Virkja"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Enginn Bluetooth-búnaður fannst"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Settu inn dingul til að nota Bluetooth"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth ekki í gangi"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Kveiktu á til að tengja tæki og stunda skráaskipti."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "Flugvélahamur er virkur"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth er óvirkt þegar flugvélahamur er virkur."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Slökkva á flugvélaham"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "Vélbúnaðarstuddur flugvélahamur er virkur"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Slökktu á rofanum fyrir flugvélaham til að virkja Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -465,28 +326,31 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Kveiktu og slökktu á Bluetooth og tengdu tækin þín"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "deila;sameign;tengja;bluetooth;obex;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "Slökkt er á myndavél"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Engin forrit geta tekið myndir eða myndskeið."
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
 "\n"
 "Allow the applications below to use your camera."
 msgstr ""
+"Heimild til að nota myndavélina gerir forritum kleift að taka myndir og "
+"myndskeið. Sé myndavélin gerð óvirk gætu sum forrit virkað óeðlilega.\n"
+"\n"
+"Leyfðu forritunum hér að neðan að nota myndavélina þína."
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Engin forrit hafa beðið um aðgang að myndavél"
 
@@ -494,96 +358,33 @@ msgstr "Engin forrit hafa beðið um aðgang að myndavél"
 msgid "Protect your pictures"
 msgstr "Verndaðu myndirnar þínar"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"skjár;læsa;greining;hrun;einka;nýlegt;bráðabirgða;tmp;yfirlit;nafn;netkerfi;"
-"auðkenna;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Settu litkvörðunartækið yfir ferninginn og ýttu svo á 'Byrja'"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Færðu litkvörðunartækið yfir á litkvörðunarstaðinn og ýttu svo á 'Halda "
-"áfram'"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Færðu litkvörðunartækið í yfirborðsstöðu og ýttu svo á 'Halda áfram'"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Loka fartölvuloki"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Innri villa kom upp sem ekki var hægt að laga."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Það er ekki búið að setja upp nauðsynleg tól til litkvörðunar."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Ekki var hægt að útbúa litasniðið."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Ekki var hægt að nálgast hvítpunkt úttakstækisins."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Fullklárað!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Litkvörðun mistókst!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Þú getur fjarlægt tæki til litkvörðunar."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ekki trufla litkvörðunartækið á meðan það er að vinna"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "myndavél;ljósmynd;myndskeið;vefmyndavél;læsing;gagnaleynd;friðhelgi;"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Litkvörðun skjátækis"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Hætta við"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -597,142 +398,9 @@ msgstr "_Halda áfram"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Lokið"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Fartölvuskjár"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Innbyggð vefmyndavél"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s skjár"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s skanni"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s myndavél"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s prentari"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s vefmyndavél"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Virkja litastýringu fyrir %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Birta litasnið fyrir %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Ekki litkvarðað"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Sjálfgefið: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Litavídd: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Prufu prófíll: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Veldu ICC-litasniðskrá"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "Flytja _inn"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Studd ICC litasnið"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Allar skrár"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Skjár"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Vista snið"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Vista"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Búa til litasnið fyrir valið tæki"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Mælitækið fannst ekki. Athugaðu hvort kveikt sé á því og hvort það sé rétt "
-"tengt."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Mælitækið styður ekki gerð litasniða fyrir prentara."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Þessi tegund tækis er ekki studd ennþá."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -849,9 +517,9 @@ msgstr "Þarfnast skrifanlegs gagnamiðils"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Þú gætir haft gagn af því að skoða þessar leiðbeiningar um hvernig nota eigi "
 "litasniðið á <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> "
@@ -874,8 +542,8 @@ msgid "_Import File…"
 msgstr "Flytja _inn skrá…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "_Bæta við"
@@ -885,9 +553,7 @@ msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Hvert tæki þarf nýlega uppfært litasnið til þess að geta verið litastýrt."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Vita meira"
 
@@ -1019,82 +685,6 @@ msgstr "D65 (ljósmyndun og myndvinnsla)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Stöðluð litrýmd"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Prófunarlitasnið"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Sjálfvirkt"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Lággæða"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Miðlungs gæði"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Hágæða"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Sjálfgefið RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Sjálfgefið CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Sjálfgefið grátóna"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Verksmiðjulitkvörðunargögn frá framleiðanda"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Skjáleiðrétting í heilskjásham er ekki möguleg með þessu litasniði"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Þetta litasnið er kannski ekki lengur mjög nákvæmt"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Litur"
@@ -1104,14 +694,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Kvarðaðu liti tækja á borð við skjái, myndavélar, skanna eða prentara"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Litur;ICC;Litasnið;Litkvörðun;Prentari;Skjár;Nákvæmni;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Annað…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1126,19 +711,14 @@ msgid "No languages found"
 msgstr "Engin tungumál fundust"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Meira…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Aflæstu til að breyta stillingum"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "Aflæsa þarf sumum stillingum áður en að hægt er að breyta þeim."
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "Aflæsa…"
 
@@ -1161,151 +741,6 @@ msgstr "Fækka klukkustundum"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Fækka mínútum"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:163
-msgid "Today"
-msgstr "Í dag"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:165
-msgid "Yesterday"
-msgstr "í gær"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d klukkustund"
-msgstr[1] "%d klukkustundir"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d mínúta"
-msgstr[1] "%d mínútur"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekúnda"
-msgstr[1] "%d sekúndur"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekúndur"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Tengipunktur (hotspot)"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-tíma"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "FH / EH"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1388,32 +823,67 @@ msgstr "Sjálfvirk _dagsetning og tími"
 msgid "Requires internet access"
 msgstr "Krefst internetaðgangs"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "Dagsetning og _tími"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Sjálfvirkt tíma_belti"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr ""
 "Krefst þess að staðsetningarþjónustur séu virkar og þarfnast internetaðgangs"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Virkt"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Tíma_belti"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Aflæsa"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Tí_masnið"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dagsetningar"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekúndur"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Dagatal"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Tölustafir"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Breyttu dagsetningu og tíma, þar með töldu tímabelti"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Klukka;Tímabelti;Staðsetning;"
@@ -1461,21 +931,9 @@ msgstr "Sjálfgefin forrit"
 msgid "Configure Default Applications"
 msgstr "Stilla sjálfgefin forrit"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "sjálfgefið;forrit;gagnamiðill;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Ef þú sendir okkur upplýsingar um tæknileg vandamál hjálpar okkur að bæta %s "
-"hugbúnaðinn. Skýrslur eru sendar nafnlaust og eru hreinsaðar af "
-"persónugreinanlegum gögnum. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1493,153 +951,116 @@ msgstr "Greining vandamála"
 msgid "Report your problems"
 msgstr "Tilkynntu vandamál"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"skjár;læsa;greining;hrun;einka;nýlegt;bráðabirgða;tmp;yfirlit;nafn;netkerfi;"
-"auðkenna;gagnaleynd;"
-
-#: panels/display/cc-display-panel.c:516
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Nota"
-
-#: panels/display/cc-display-panel.c:518 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Nota ekki"
-
-#: panels/display/cc-display-panel.c:949
-msgid "Apply Changes?"
-msgstr "Virkja breytingar?"
-
-#: panels/display/cc-display-panel.c:954
-msgid "Changes Cannot be Applied"
-msgstr "Ekki var hægt að framkvæma breytingar"
-
-#: panels/display/cc-display-panel.c:956
-msgid "This could be due to hardware limitations."
-msgstr "Þetta gæti verið vegna takmarkana í vélbúnaði."
+msgid "diagnostics;crash;"
+msgstr "greining;vandamál;hrun;"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Virkja"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Til baka"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr "Stillingar skjás eru óvirkar"
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "Fyrirkomulag á skjám"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "Margir skjáir"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "Setja saman"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Spegla"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Inniheldur toppstiku og virkni"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Aðalskjár"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Næturlýsing"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Lárétt"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Lóðrétt hægri"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Lóðrétt vinstri"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Lárétt (flett)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Stefna"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Upplausn"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Uppfærslutíðni"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Aðlaga fyrir sjónvarp"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Kvarða"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Eðlilegt skrun"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Næturlýsing ekki tiltæk"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Þetta gæti verið af völdum þess hvaða skjákortsrekill er notaður, eða að "
+"skjáborðið sé notað fjartengt"
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Tímabundið óvirkt þar til á morgun"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "Endurræsa síu"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1647,59 +1068,59 @@ msgstr ""
 "Næturlýsing stillir skjáinn á hlýrri liti. Þetta getur hjálpað til við að "
 "minnka þreytu í augum og svefntruflanir."
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Áætlun"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Sólarlag til sólarupprásar"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Áætla handvirkt"
 
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Tími"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Frá"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Klukkustund"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Mínúta"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "f.h."
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "e.h."
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Til"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Hitastig litar"
 
@@ -1711,7 +1132,6 @@ msgstr "Skjáir"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Veldu hvernig nota eigi tengda skjái og myndvarpa"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1720,54 +1140,52 @@ msgstr ""
 "Spjald;Skjávarpi;xrandr;Skjár;Skjáupplausn;Uppfærslutíðni;Gluggi;Nótt;nætur;"
 "ljós;litur;lýsing;sólarlag;sólarupprás;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Óþekkt"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; Byggingarauðkenni: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr "Öryggisstig"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64-bita"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Stig 1"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32-bita"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Stig 2"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Stig 3"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Engir atburðir"
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Óþekkt"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Öryggistæki"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Táknmerki kerfis"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Staða öryggis á fasthugbúnaði hýsivélar"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"skjár;læsa;greining;hrun;einka;nýlegt;bráðabirgða;tmp;yfirlit;nafn;netkerfi;"
+"auðkenna;gagnaleynd;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Heiti tækis"
 
@@ -1800,31 +1218,41 @@ msgstr "Reikna…"
 msgid "OS Name"
 msgstr "Nafn stýrikerfis"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Byggingarauðkenni stýrikerfis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Tegund stýrikerfis"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "GNOME útgáfa"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Hleð inn..."
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Gluggakerfi"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Sýndarvélar"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Hugbúnaðaruppfærslur"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Endurnefna tæki"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1832,7 +1260,11 @@ msgstr ""
 "Nafn tækisins er notað til að auðkenna tækið á netkerfinu, eða þegar verið "
 "er að para það við önnur Bluetooth-tæki."
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Heiti tækis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "Endu_rnefna"
 
@@ -1844,11 +1276,6 @@ msgstr "Um hugbúnaðinn"
 msgid "View information about your system"
 msgstr "Skoðaðu upplýsingar um kerfið þitt"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1926,6 +1353,12 @@ msgstr "Forritaræsar"
 msgid "Launch help browser"
 msgstr "Ræsa hjálparvafra"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Stillingar"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Ræsa reiknivél"
@@ -1947,7 +1380,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Leita"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Kerfið"
 
@@ -1996,20 +1429,11 @@ msgstr "Minnka stærð texta"
 msgid "High contrast on or off"
 msgstr "Hábirtuskil af eða á"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Engir inntaksgjafar fundust"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Annað"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Veldu inntaksgjafa"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Aðrar innsláttaraðferðir er ekki hægt að nota í innskráningarglugga"
 
@@ -2017,122 +1441,29 @@ msgstr "Aðrar innsláttaraðferðir er ekki hægt að nota í innskráningarglu
 msgid "No input source selected"
 msgstr "Enginn inntaksgjafi valinn"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Valkostir"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "Færa upp"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "Færa niður"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Stillingar"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Skoða lyklaborðsuppsetningu"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Fjarlægja"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Sérsniðinn flýtilykill"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "Vara-stafalykill (AltCharKey)"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Vara-stafalykilinn er hægt að nota til að setja inn viðbótar-staftákn. Þau "
-"eru stundum prentuð sem þriðji valmöguleiki á lyklaborðum."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Vinstri Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Hægri Alt-lykill"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Vinstri breytilykill"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Hægri breytilykill"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Valmyndarlykill"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Hægri Ctrl-lykill"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Samsetningarlykill"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Samsetningarlykillinn (compose key) gerir kleift að setja inn margvíslega "
-"stafi Hann er notaður með því að ýta á hann og síðan á runu af öðrum "
-"staftáknum.  Til dæmis, sé samsetningarlykli fylgt með <b>C</b> og <b>o</b> "
-"er sett inn <b>©</b> merki, <b>a</b> fylgt með <b>'</b> setur inn <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "CapsLock-hástafalás"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "ScrollLock-skrunlæsing"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Hægt er að skipta um inntaksgjafa með %s flýtilyklinum.\n"
-"Þessu er hægt að breyta í stillingum fyrir flýtivísanir lyklaborðs."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2154,54 +1485,29 @@ msgstr "Nota _sama inntaksgjafa fyrir alla glugga"
 msgid "Switch input sources _individually for each window"
 msgstr "Skipta um _inntaksgjafa fyrir hvern glugga"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Innsetning sértákna"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Aðferðir til að setja inn tákn og stafatilbrigði með lyklaborðinu."
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Vara-stafalykill (AltCharKey)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Samsetningarlykill"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Flýtilyklar"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Skoða og sérsníða flýtileiðir á lyklaborði"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d breytt"
-msgstr[1] "%d breytt"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Frumstilla alla flýtilykla?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Frumstilling flýtilykla gæti haft áhrif á sérsniðna flýtilykla sem þú hefur "
-"stillt. Ekki er hægt að taka þetta aftur."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Hætta við"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Frumstilla allt"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2211,98 +1517,88 @@ msgstr "Frumstilla allt…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Endurstilla alla flýtilykla á upprunaleg gildi þeirra"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Hluti"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Flýtilyklar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Bæta við flýtilykli"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Bæta við sérsniðnum flýtilyklum"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "Settu upp sérsniðna flýtilykla til að ræsa forrit, keyra skriftur og "
 "ýmislegt fleira."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Bæta við flýtilykli"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Enginn flýtilykill fannst"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s er nú þegar í notkun fyrir %s. Ef þú skiptir því út, verður %s gert óvirkt"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Fja_rlægja:"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Settu inn nýjan flýtilykil"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Ski_pta út"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Setja sérsniðinn flýtilykil"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "_Setja"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Setja flýtilykil"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Settu inn nýjan flýtilykil til að breyta %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Bæta við sérsniðnum flýtilykli"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Bæta við"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
-msgstr "Skipta út"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "Setja"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Ýttu á Esc til að hætta við eða á Backspace til að gera flýtilykilinn "
 "óvirkan."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Heiti"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Skipun"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Flýtilykill"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Setja flýtilykil…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Ekkert"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Endurstilla flýtilykilinn á sjálfgefin gildi"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Nota prentara sjálfgefið"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2316,7 +1612,6 @@ msgstr ""
 "Breyta flýtileiðum á lyklaborði og setja valkosti við stafainnsetningu, "
 "lyklaborðsframsetningu og inntaksleiðir"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2324,15 +1619,15 @@ msgstr ""
 "Flýtilykill;Vinnusvæði;Gluggi;Stærð;Aðdráttur;Birtuskil;Inntak;Uppruni;Læsa;"
 "Hljóðstyrkur;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "Slökkt er á staðsetningarþjónustum"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Engin forrit geta notað staðsetningarupplýsingar."
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2350,7 +1645,7 @@ msgstr ""
 "\n"
 "Leyfðu forritunum hér fyrir neðan að fá upplýsingar um staðsetninguna þína."
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Engin forrit hafa beðið um aðgang að staðsetningu"
 
@@ -2358,173 +1653,19 @@ msgstr "Engin forrit hafa beðið um aðgang að staðsetningu"
 msgid "Protect your location information"
 msgstr "Verndaðu upplýsingar um staðsetningu þína"
 
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Skjár slekkur á sér eftir"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "staðsetning;gps;gagnaleynd;friðhelgi;"
 
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekúndur"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 mínúta"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 mínútur"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 mínútur"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 mínútur"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 mínútur"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 klukkustund"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 mínúta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 mínútur"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 mínútur"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 mínútur"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 mínútur"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 mínútur"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 mínútur"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 mínútur"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 mínútur"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Aldrei"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "Töf áður en skjár er tæmdur"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Tímamörk aðgerðarleysis áður en skjárinn tæmist."
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "Sjálfvirk skjá_læsing"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "Töf fyrir _sjálfvirka skjálæsingu"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "_Birta tilkynningar á læsiskjá"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "Banna ný _USB-tæki"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Koma í veg fyrir að ný USB-tæki eigi í samskiptum við kerfið þegar skjárinn "
-"er læstur."
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Skjálæsing"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Læsa skjánum þínum"
-
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "Slökkt er á hljóðnema"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Engin forrit geta tekið upp hljóð."
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2533,13 +1674,17 @@ msgid ""
 "Allow the applications below to use your microphone."
 msgstr ""
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Engin forrit hafa beðið um aðgang að hljóðnema"
 
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:4
 msgid "Protect your conversations"
 msgstr "Verndaðu samskiptin þín"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "hljóðnemi;upptaka;forrit;gagnaleynd;"
 
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
@@ -2558,83 +1703,148 @@ msgstr "Aðalhnappur"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "Stillir uppröðun hnappa á mús eða snertiplatta"
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Vinstri"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Hægri"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Staðsetningar sem leitað er í"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mús"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Hraði músar"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "Eðlilegt skrun"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Skruna niður"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Skrun færir til innihaldið, ekki sýnina."
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Skrun færir til innihaldið, ekki sýnina."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Virkt"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Snertiplatti"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Hraði snertiplatta"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Sláðu á til að smella"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "Tveggja-fingra skrun"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr "Pikkaðu til að smella"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_Afvirkja snertiplatta á meðan skrifað er"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Snertiplatti (afstætt)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Skrun á jöðrum"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Skruna niður"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Tvíhliða"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Prófaðu að smella, tvísmella, skruna"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Fimm smellir, tími fyrir GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Tvísmella, aðalhnappur"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Einsmella, aðalhnappur"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Tvísmella, miðhnappur"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Einsmella, miðhnappur"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Tvísmella, aukahnappur"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Einsmella, aukahnappur"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2645,7 +1855,6 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "Breyttu næmni músar eða snertiplatta og veldu rétt- eða örvhent"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Snertiplatti;Bendill;Smella;Slá;Tvísmella;Hnappur;Bendilkúla;Skrun;"
@@ -2656,7 +1865,7 @@ msgstr "Virkni_horn"
 
 #: panels/multitasking/cc-multitasking-panel.ui:16
 msgid "Touch the top-left corner to open the Activities Overview."
-msgstr ""
+msgstr "Ýttu á hornið efst til vinstri til að opna aðgerðayfirlitið."
 
 #: panels/multitasking/cc-multitasking-panel.ui:42
 msgid "_Active Screen Edges"
@@ -2723,84 +1932,37 @@ msgstr "Fjölverkavinnsla"
 msgid "Manage preferences for productivity and multitasking"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Úbbs! Eitthvað hefur farið úrskeiðis núna. Hafðu samband við höfunda "
-"hugbúnaðarins."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager netstjórinn verður að vera í gangi."
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Önnur tæki"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Bæta við tengingu"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Ekki uppsett"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:266
-msgid "Insecure network (WEP)"
-msgstr "Ótryggt netkerfi (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:270
-msgid "Secure network (WPA)"
-msgstr "Öruggt netkerfi (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:274
-msgid "Secure network (WPA2)"
-msgstr "Öruggt netkerfi (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:278
-msgid "Secure network (WPA3)"
-msgstr "Öruggt netkerfi (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:282
-msgid "Secure network"
-msgstr "Öruggt netkerfi"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Tengt"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Valkostir…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr ""
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -2825,354 +1987,89 @@ msgid "Network Name"
 msgstr "Heiti netkerfis"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Lykilorð"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Útbúa slembilykilorð"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Útbúa sjálfvirkt lykilorð"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Kveikja á"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Þráðlaust net"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Stöðva tengipunkt og aftengja alla notendur?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Stöðva tengipunkt"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Flugvélahamur"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Gerir Wi-Fi, Bluetooth og ferðabreiðband óvirk"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Engin Wi-Fi netkort fundust"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Gangtu úr skugga um að Wi-Fi netkortið sé tengt og að kveikt sé á því"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Flugvélahamur virkur"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Slökktu til að nota Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Þráðlaus Wi-Fi-tengipunktur virkur"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Snjalltæki geta skannað QR-kóðann til að tengjast."
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Slökkva á þráðlausum Wi-Fi tengipunkti…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Sýnileg netkerfi"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager netstjórinn verður að vera í gangi"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Úbbs! Eitthvað hefur farið úrskeiðis núna. Hafðu samband við höfunda "
+"hugbúnaðarins."
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x öry_ggi"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Öryggi"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Varðveita"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Varanlegt"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Slembið"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stöðugt"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"MAC-vistfangið sem sett er inn hér verður notað sem vélbúnaðarvistfang fyrir "
-"nettækið sem þessi tenging er virkjuð á.  Sú aðgerð er þekkt undir nafninu "
-"MAC-klónun eða vélarstuldur.  Dæmi: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Snið %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:120
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:126
-msgid "Enterprise"
-msgstr "Fyrirtækis"
-
-#: panels/network/connection-editor/ce-page-details.c:131
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ekkert"
-
-#: panels/network/connection-editor/ce-page-details.c:152
-msgid "Never"
-msgstr "Aldrei"
-
-#: panels/network/connection-editor/ce-page-details.c:167
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "fyrir %i degi síðan"
 msgstr[1] "fyrir %i dögum síðan"
-
-#: panels/network/connection-editor/ce-page-details.c:294
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:296
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/sek"
-
-#: panels/network/connection-editor/ce-page-details.c:311
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:313
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:315
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:335
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Ekkert"
-
-#: panels/network/connection-editor/ce-page-details.c:337
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Veikt"
-
-#: panels/network/connection-editor/ce-page-details.c:339
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Í lagi"
-
-#: panels/network/connection-editor/ce-page-details.c:341
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Gott"
-
-#: panels/network/connection-editor/ce-page-details.c:343
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Frábært"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 vistfang"
-
-#: panels/network/connection-editor/ce-page-details.c:411
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "IPv6 vistfang"
-
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/connection-editor/ce-page-details.c:414
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP vistfang"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/ce-page-details.c:422
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:474
-msgid "Forget Connection"
-msgstr "Gleyma tengingu"
-
-#: panels/network/connection-editor/ce-page-details.c:476
-msgid "Remove Connection Profile"
-msgstr "Fjarlægja tengisnið"
-
-#: panels/network/connection-editor/ce-page-details.c:478
-msgid "Remove VPN"
-msgstr "Fjarlægja VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:496
-msgid "Details"
-msgstr "Nánar"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "sjálfvirkt"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Auðkenni"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Eyða vistfangi"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "Eyða beiningu (route)"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ekkert"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit lykill (Hex eða ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit lykilsetning"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Breytilegt (dynamic) WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA og WPA2 einka"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA og WPA2 fyrirtækja"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 einka"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3183,8 +2080,20 @@ msgstr "Styrkur merkis"
 msgid "Link speed"
 msgstr "Hraði tengis"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Öryggi"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 vistfang"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 vistfang"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Vistfang vélbúnaðar"
 
@@ -3193,12 +2102,17 @@ msgid "Supported Frequencies"
 msgstr "Studdar tíðnir"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Sjálfgefin tengileið (route)"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3215,8 +2129,10 @@ msgstr "Gera aðgengilegt öðrum n_otendum"
 #: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
+"_Mæld tenging: er með takmörk á gagnamagni eða getur haft kostnað í för með "
+"sér"
 
-#: panels/network/connection-editor/details-page.ui:422
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3259,7 +2175,7 @@ msgstr "Einungis staðvær tengi (link-local)"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Handvirkt"
 
@@ -3279,33 +2195,32 @@ msgid "Addresses"
 msgstr "Vistföng"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Vistfang"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Nethula (netmask)"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Netgátt (gateway)"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Sjálfvirkt"
 
@@ -3314,29 +2229,34 @@ msgstr "Sjálfvirkt"
 msgid "Automatic DNS"
 msgstr "Sjálfvirkt DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Vistföng DNS-þjóna"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Aðskildu IP-vistföng með kommum"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Beiningar"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Sjálfvirk beining"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Leiðargæði (metric)"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Nota þessa tengingu einungis fyrir efni af sínu eigin neti"
 
@@ -3349,83 +2269,13 @@ msgid "Automatic, DHCP only"
 msgstr "Sjálfvirkt, aðeins DHCP"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Forskeyti"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Get ekki opnað tengingaritil"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Nýtt snið"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Flytja inn úr skrá…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "Bæta við VPN"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Öry_ggi"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Get ekki flutt inn VPN-nettengingu"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Skráin '%s' var ekki lesanleg eða að hún inniheldur ekki þekkjanlegar VPN "
-"tengiupplýsingar\n"
-"\n"
-"Villa: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Veldu skrá til að flytja inn"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Skrá með heitinu '%s' er þegar til."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Skipta út"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Viltu skipta %s út fyrir VPN-nettenginguna sem þú ert að vista?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Get ekki flutt út VPN-nettengingu"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Ekki var hægt að flytja út VPN tenginguna '%s' til %s.\n"
-"\n"
-"Villa: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Flytja út VPN-nettengingu"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3439,107 +2289,49 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Netkerfi"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Stjórnaðu hvernig þú tengist internetinu"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Netkerfi;þráðlaust;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;breiðband;internet;mótald;"
 "Bluetooth;vpn;vlan;bridge;bond;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Þráðlaust net"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Stjórnaðu hvernig þú tengist þráðlausum Wi-Fi netkerfum"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Netkerfi;þráðlaust;Wi-Fi;Wifi;IP;LAN;breiðband;internet;mótald;Bluetooth;vpn;"
 "vlan;bridge;bond;DNS;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "aldrei"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "í dag"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "í gær"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Síðast notað"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Um kapal"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Bæta við nýrri tengingu"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Upplýsingar um valin netkerfi munu tapast, þar með talið lykilorð og aðrar "
-"sérsniðnar stillingar."
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "_Gleyma"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Þekkt Wi-Fi netkerfi"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Gleyma"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Kerfisheimildir heimila ekki notkun sem tengipunkts"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Þráðlaust tæki styður ekki tengipunkts-ham (hotspot)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Sjálfvirk leit með Web Proxy Autodiscovery er notað þegar stillingavistfang "
-"(configuration URL) er ekki gefið upp."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Ekki er mælt með þessu fyrir ótreyst almenningsnet."
-
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Slökkva á tæki"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Virkt"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3550,47 +2342,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Þjónustuveita"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP vistfang"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Milliþjónn, vefsel"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP milliþjónn (vefsel)"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "H_TTPS  milliþjónn (vefsel)"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "_FTP  milliþjónn"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "_SOCKS miðlari"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "_Hunsa vélar (hosts)"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Gátt HTTP milliþjóns (vefsels)"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Gátt HTTPS milliþjóns (vefsels)"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Gátt FTP milliþjóns"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Gátt Socks milliþjóns"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "S_lóð stillinga"
 
@@ -3617,300 +2413,21 @@ msgstr "Lykilorð"
 msgid "Turn Wi-Fi off"
 msgstr "Slökkva á þráðlausu neti"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Fleiri valkostir…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "Tengjast _földu netkerfi…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Kveikja á þráðlausum Wi-Fi tengipunkti…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "Þe_kkt Wi-Fi netkerfi"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Staða óþekkt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Óstýrt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Ekki tiltækt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Tengist"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Auðkenningar krafist"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Aftengist"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Tenging mistókst"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Staða óþekkt (vantar)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Stillingar brugðust"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP-stillingar brugðust"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP-stillingar úreltar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Dulritunarupplýsinga var krafist en virðast ekki koma fram"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x biðill ótengdur"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Stillingar 802.1x biðils brugðust"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x biðill brást"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x biðill var of lengi að auðkenna"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP þjónusta gat ekki hafist"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP þjónusta aftengd"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP brást"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP biðlari ræstist ekki"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Villa í DHCP biðlara"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP biðlari brást"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Þjónusta sameiginlegra tenginga ræstist ekki"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Þjónusta sameiginlegra tenginga brást"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP þjónusta ræstist ekki"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Villa í AutoIP þjónustu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP þjónusta brást"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Línan upptekin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Enginn sónn"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Ekki tókst að koma á tengingu."
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Hringing rann út á tíma"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Tilraun til tengingar mistókst"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Frumstilling mótalds mistókst"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Ekki tókst að velja tiltekið APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Ekki að leita að netkerfum"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Skráningu á netkerfi hafnað"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Skráning á netkerfi rann út á tíma"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Mistókst að skrá inn á umbeðið netkerfi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Athugun á PIN mistókst"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Grunnhugbúnað (firmware) tækis gæti vantað"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Tenging hvarf"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Gert var ráð fyrir tengingu sem þegar er til staðar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Mótald fannst ekki."
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth-tenging brást"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM-kort ekki til staðar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Krafist er PIN-númers SIM-korts"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Krafist er PUK-númers SIM-korts"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Rangt SIM-kort"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Það tókst ekki að uppfylla allar kerfiskröfur fyrir tengingu"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "grunnhugbúnað vantar (firmware)"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "kapall ekki tengdur"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "óskilgreind villa í öruggu 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "engin skrá valin"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "óskilgreind villa við sannvottun á eap-method skrá"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, eða PKCS#12 einkalyklar (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER eða PEM skilríki (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "vantar EAP-FAST PAC skrá"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC skrár (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -3960,14 +2477,6 @@ msgstr "_Innri auðkenning"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Leyfa sjálfvirka PAC _veitingu (provisioning)"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "vantar EAP-LEAP notandanafn"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "vantar EAP-LEAP lykilorð"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -3980,7 +2489,7 @@ msgstr "Notan_danafn"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "Lykil_orð"
 
@@ -3992,15 +2501,6 @@ msgstr "Lykil_orð"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Birta lykilorð"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "ógilt EAP-PEAP CA skilríki: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "ógilt EAP-PEAP CA skilríki: ekkert skilríki tiltekið"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4023,7 +2523,6 @@ msgid "C_A certificate"
 msgstr "C_A skilríki"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4038,63 +2537,6 @@ msgstr "CA skilríkis e_r ekki krafist"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_PEAP útgáfa"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "vantar EAP notandanafn"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "vantar EAP lykilorð"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "vantar EAP-TLS auðkenni"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "ógilt EAP-TLS CA skilríki: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "ógilt EAP-TLS CA skilríki: ekkert skilríki tiltekið"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "ógildur EAP-TLS einkalykill: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "ógilt EAP-TLS notanda-skilríki: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Ódulritaðir einkalyklar eru óöruggir"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Valinn einkalykill lítur ekki út fyrir að vera varinn af lykilorði. Þetta "
-"gæti sett öryggi þitt í hættu.  Endilega veldu einkalykil sem varinn er af "
-"lykilorði.\n"
-"\n"
-"(Þú getur sett lykilorð á einkalykla með openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Veldu þitt einkaskilríki"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Veldu þinn einkalykil"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4111,15 +2553,6 @@ msgstr "Ein_kalykill"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Lykilorð einkalykils"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "ógilt EAP-TTLS CA skilríki: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "ógilt EAP-TTLS CA skilríki: ekkert skilríki tiltekið"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4142,14 +2575,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Lén"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Óþekkt villa við að sannreyna 802.1x öryggi"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4177,62 +2611,10 @@ msgstr "Varið EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Auðkenning"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Veldu skrá"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "vantar leap-notandanafn"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "vantar leap-lykilorð"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Wi-Fi lykilorð vantar."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tegund:"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "vantar wep-lykil"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"ógildur wpa-key: lykill með lengdina %zu verður að innihalda eingöngu hex-"
-"tölustafi"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"ógildur wpa-key: lykill með lengdina %zu verður að innihalda eingöngu ascii-"
-"stafi"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"ógildur wpa-key: ógild lengd lykils %zu. Lykill verður að vera með lengd "
-"5/13 (ascii) eða 10/26 (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "ógildur wep-key: lykilfrasi má ekki vera tómur"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "ógildur wep-key: lykilfrasi verður að vera styttri en 64 stafir"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4257,19 +2639,6 @@ msgstr "_Birta lykil"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP l_ykilnúmer"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"ógilt wpa-psk: ógild lengd lykils %zu. Verður að vera [8,63] bæti eða 64 hex "
-"tölustafir"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "ógilt wpa-psk: get ekki túlkað lykil með 64 bætum sem hex"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4324,58 +2693,33 @@ msgstr "Tilkynningar um _læsingu skjás"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Stjórnaðu hvaða tilkynningar eru birtar og hvað þær innihalda"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Tilkynningar;Borði;Skilaboð;Kerfisbakki;Sprettgluggi;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "%s fjarlægt"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Annað"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Villa við að fjarlægja notandaaðgang"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Afturkalla"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Loka tilkynningunni"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "Tengstu gögnunum þínum í tölvuskýi"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "Engin internettenging — tengstu því til að setja upp nýja nettengda "
 "notendaaðganga"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Bæta við notandaaðgangi"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Aðgangur %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Fjarlægja notandaaðgang"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4386,10 +2730,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Tengstu notandaaðgöngum þínum á netinu og ákveddu til hvers eigi að nota þá"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4397,10 +2737,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Vefur;Netið;Spjall;Dagatal;Póstur;Tengiliðir;"
 "ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Óþekktur tími"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4416,13 +2752,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i klukkustund"
 msgstr[1] "%i klukkustundir"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4434,184 +2763,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "mínúta"
 msgstr[1] "mínútur"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s þar til rafhlaðan er fullhlaðin"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Varúð: %s eftir"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s eftir"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Full hleðsla"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Ekki í hleðslu"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Tóm"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Í hleðslu"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Afhleðst"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Þráðlaus mús"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Þráðlaust lyklaborð"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "UPS varaaflgjafi"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "PDA lófatölva"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Farsími"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Margmiðlunarspilari"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Spjaldtölva"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Tölva"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Leikjainntakstæki"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Rafhlaða"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Aðal"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Auka"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Rafhlöður"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "Við _iðjuleysi"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "Setja í bið"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "Slökkva"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "Leggja í dvala"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "Ekkert"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "Þegar notað er afl frá rafhlöðum"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "Þegar vélin er í sambandi"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Aldrei"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "Hætta sjálfvirkt"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Orkusparnaðarhamur virkjaður af “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Afkastahamur virkjaður af “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4673,6 +2824,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 klukkustundir"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Rafhlaða"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Tæki"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Orkusparnaðarhamur"
@@ -4693,89 +2853,62 @@ msgstr "Sjálfvirkt birtustig skjás"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "Birta skjás aðlagast umhverfislýsingu."
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Dimma skjá"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "Minnkar birtustig skjásins þegar tölvan er aðgerðarlaus."
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "Tæma skjá"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "Slekkur á skjánum eftir tímabil aðgerðarleysis."
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Sjálfvirkur orkusparnaður"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr "Virkjar orkusparnaðarham þegar lítið er eftir á rafhlöðunni."
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "Setja sjálfvirkt í bið"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "Setur tölvuna í bið eftir tímabil aðgerðarleysis."
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Hegðun K_veikja/Slökkva-hnapps"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Sýna hleðslu rafhlöðu í _prósentum"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Hætta sjálfvirkt"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "Í sam_bandi"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Notar afl frá _rafhlöðum"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Seinkun"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Afköst"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Mikil afköst og orkunotkun."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Jafnvægi"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Venjuleg afköst og orkunotkun."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Orkusparnaður"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Minnkuð afköst og orkunotkun."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4785,34 +2918,12 @@ msgstr "Aflstjórnun"
 msgid "View your battery status and change power saving settings"
 msgstr "Skoða ástand rafhlöðu og sýsla með orkustillingar"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
 msgstr ""
 "orka;svæfa;bið;dvali;rafhlaða;birta;dimma;slökkva;skjár;DPMS;afl;iðjulaus;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Prentaranum “%s” hefur verið eytt"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "Mistókst að bæta við nýjum prentara"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Gat ekki hlaðið inn ui-viðmóti: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr ""
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4823,7 +2934,6 @@ msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Bættu við prenturum, skoðaðu prentverk og veldu hvernig þú vilt haga prentun"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Prentari;prentröð;Prentun;Pappír;blek;prentduft;"
@@ -4831,92 +2941,70 @@ msgstr "Prentari;prentröð;Prentun;Pappír;blek;prentduft;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Bæta við prentara"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Aflæsa"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Engir prentarar fundust"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Settu inn netfang eða leitaðu að prentara"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Auðkenningar krafist"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Settu inn notandanafn og lykilorð til að skoða prentara á prentþjóninum."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Notandanafn"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "Nánar um %s"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Heiti prentara mega ekki innihalda BIL, DÁLKMERKI (TAB), # eða /"
 
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Enginn hentugur rekill fannst"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "Veldu PPD-skrá"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript prentlýsingarskrár (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Staðsetning"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Rekill"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Leitað að reklum sem mælt er með…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Leita að reklum"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Veldu úr gagnagrunni…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Setja upp PPD-skrá…"
 
@@ -4928,132 +3016,20 @@ msgstr "Veldu prentrekil"
 msgid "Loading drivers database…"
 msgstr "Hleð inn gagnagrunni um rekla…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Hætta við"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Velja"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect prentari"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD prentari"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Einhliða"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Langhlið (venjulegt)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Styttri brún (snúið)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Lóðrétt"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Lárétt"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Öfugt lárétt"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Öfugt lóðrétt"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "Í bið"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "Í bið"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Auðkenningar krafist"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "Í vinnslu"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Stöðvað"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Hætt við"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Farið út úr"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Lokið"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "Færa þetta verk fremst í biðröð"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u verk krefst auðkenningar"
 msgstr[1] "%u verk krefjast auðkenningar"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — virk verk"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Settu inn auðkenni til að prenta á %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5062,342 +3038,36 @@ msgid "Domain"
 msgstr "Lén"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "A_uðkenna"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Hreinsa allt"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Heimila"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Engin virk prentverk"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Aflæsa prentþjóni"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Aflæsa %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Settu inn notandanafn og lykilorð til að skoða þá prentara sem eru tiltækir "
-"á %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Leita að prenturum"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Raðtengi (serial)"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Hliðtengi (parallel)"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Staður: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Vistfang: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Miðlari krefst auðkenningar"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Tvíhliða"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Tegund pappírs"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Uppruni pappírs"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Úttaksbakki"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Upplausn"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Ghostscript forsíun"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Blaðsíður á hverja hlið"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Tvíhliða"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Stefna"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Almennt"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Uppsetning síðu"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Uppsetjanlegir hlutir"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Verk"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Myndgæði"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Litur"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Klára"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Nánar"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Prófunarsíða"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Prófunarsíða"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Velja sjálfvirkt"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Sjálfgefnar stillingar prentara"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Ígræða einungis GhostScript letur"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Breyta í PS-stig 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Breyta í PS-stig 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Engin forsíun"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Framleiðandi"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Engin virk prentverk"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u verk"
 msgstr[1] "%u verk"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Hreinsa prenthausa"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Lítið prentduft"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Búinn með prentduft"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Lítill framköllunarvökvi"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "marker supplyframköllunarvökvann"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Lítið eftir á fyllingu"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Búinn með fyllingu"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Opna lok"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Opna hlera"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Lítill pappír eftir"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Pappírslaus"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Ótengdur"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Stöðvaður"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Ruslabakki næstum fullur"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Ruslabakki fullur"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Prentkassettan er komin að lokum líftíma síns"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Prentkassettan virkar ekki lengur"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Tilbúinn"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Tekur ekki við verkum"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Í vinnslu"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5421,41 +3091,45 @@ msgstr "Hreinsa prenthausa"
 msgid "Remove Printer"
 msgstr "Fjarlægja prentara"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Engin virk prentverk"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Gerð"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Staða bleks"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Endurræstu þegar vandamálið er leyst."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Endurræsa"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Bæta við prentara…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Bæta við prentara…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Engir prentarar"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Bæta við prentara…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5463,50 +3137,33 @@ msgstr ""
 "Því miður! Prentþjónusta kerfis\n"
 "virðist ekki vera tiltæk."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Snið"
-
-#: panels/region/cc-format-chooser.ui:37
-#: panels/wacom/cc-wacom-stylus-page.ui:136
-#: panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "Til baka"
 
 #: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr "Leita að staðfærslum..."
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Algeng snið"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Öll snið"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Engar leitarniðurstöður"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Leitir geta verið að löndum eða tungumálum."
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Forskoðun"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Breskt kerfi"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrakerfi"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5538,24 +3195,28 @@ msgstr "Útskráning…"
 
 #: panels/region/cc-region-panel.ui:45
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Aðgangurinn þinn"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "Tungumá_l"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "S_nið"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Innskráningarskjár"
 
@@ -5567,99 +3228,9 @@ msgstr "Land & tungumál"
 msgid "Select your display language and formats"
 msgstr "Veldu tungumálið sem þú vilt nota fyrir skjáviðmót og snið"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Tungumál;Framsetning;Lyklaborð;Inntak;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Spyrja hvað skuli gera"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Gera ekkert"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Opna möppu"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Aðrir miðlar"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Veldu forrit fyrir CD-hljóðdiska"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Veldu forrit fyrir DVD-mynddiska"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Veldu forrit til að keyra þegar tónlistarspilari er tengdur"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Veldu forrit til að keyra þegar myndavél er tengd"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Veldu forrit fyrir CD-diska með hugbúnaði"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD hljóðdiskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "tómur Blu-Ray diskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "tómur CD geisladiskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "tómur DVD mynddiskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "tómur HD DVD diskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-Ray mynddiskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "rafbókalesari"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD mynddiskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD mynddiskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "CD Super Video mynddiskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD mynddiskur"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows hugbúnaður"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5709,7 +3280,6 @@ msgstr "Fjarlæganlegir miðlar"
 msgid "Configure Removable Media settings"
 msgstr "Stillingar útskiptanlegra gagnamiðla"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5718,13 +3288,76 @@ msgstr ""
 "tæki;kerfi;sjálfgefið;forrit;valið;cd;dvd;usb;hljóð;mynd;disk;útskiptanlegt;"
 "miðill;sjálfræsing;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Veldu staðsetningu"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Skjálæsing"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "Í _lagi"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Töf áður en skjár er tæmdur"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Tímamörk aðgerðarleysis áður en skjárinn tæmist."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Sjálfvirk skjá_læsing"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Töf fyrir _sjálfvirka skjálæsingu"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Birta tilkynningar á læsiskjá"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Læsa skjá"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Banna ný _USB-tæki"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Koma í veg fyrir að ný USB-tæki eigi í samskiptum við kerfið þegar skjárinn "
+"er læstur."
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr "Gagnaleynd á skjá"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr "Takmarka skoðunarhorn"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skjár"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Skjástillingar"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5741,21 +3374,17 @@ msgstr ""
 msgid "Places"
 msgstr "Staðir"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Bókamerki"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "Aðrir"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Bæta við staðsetningu"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Engin forrit fundust"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5782,65 +3411,13 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "Stjórnaðu hvaða forrit birta leitarniðurstöður í virkniyfirlitinu"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Leita;Finna;Yfirlit;Fela;Gagnaleynd;Niðurstöður;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "Engin netkerfi valin vegna deilingar gagna"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Netkerfi"
-
-#: panels/sharing/cc-sharing-panel.c:363
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Kveikt"
-
-#: panels/sharing/cc-sharing-panel.c:365 panels/sharing/cc-sharing-panel.c:392
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Slökkt"
-
-#: panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Virkjað"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is active"
-msgid "Active"
-msgstr "Virkt"
-
-#: panels/sharing/cc-sharing-panel.c:516
-msgid "Choose a Folder"
-msgstr "Veldu möppu"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:744
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Deiling skráa gerir þér kleift að deila \"Opið öllum\"-möppunni (Public) með "
-"öðrum á netinu þínu, með: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:750
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Þegar fjartengd innskráning er virk, geta fjartengdir notendur að tengst með "
-"Secure Shell skipun:\n"
-"%s"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -5880,78 +3457,85 @@ msgstr "K_refjast lykilorðs"
 msgid "Remote Login"
 msgstr "Fjartengd innskráning"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "Fjartengt skjáborð"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr "Virkja eða afvirkja tengingar fjartengdra skjáborða við þessa tölvu."
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "Fjarstýring"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
 msgstr "Leyfa fjartengingum að stýra skjánum."
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
 msgstr "Hvernig á að tengjast"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Afrita"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "Vistfang fjartengds skjáborðs"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "Auðkenning"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr "Krafist er notandanafns og lykilorðs til að tengjast við þessa tölvu."
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "Notandanafn"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "Sannprófa dulritun"
 
-#: panels/sharing/cc-sharing-panel.ui:428
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr "Fingrafar dulritunar"
 
-#: panels/sharing/cc-sharing-panel.ui:429
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
-"Fingrafar dulritunar geta sést í biðlurum sem tengjast og ættu að vera eins"
+"Fingraför dulritunar geta sést í biðlurum sem tengjast og ættu að vera eins."
 
-#: panels/sharing/cc-sharing-panel.ui:461
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Deiling gagnamiðla"
 
-#: panels/sharing/cc-sharing-panel.ui:483
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Deila tónlist, myndum og myndskeiðum á netinu."
 
-#: panels/sharing/cc-sharing-panel.ui:496
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Möppur"
 
@@ -5959,7 +3543,6 @@ msgstr "Möppur"
 msgid "Control what you want to share with others"
 msgstr "Stjórnaðu hverju þú vilt deila með öðrum"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -5977,38 +3560,37 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Þú þarft að auðkenna þig til að virkja eða afvirkja fjartengda innskráningu"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Sérsniðið"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Gelt"
+msgid "Click"
+msgstr "Smella"
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "Leki"
+msgid "String"
+msgstr "Strengur"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "Gler"
+msgid "Swing"
+msgstr "Sveifla"
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "Sónar"
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Jafnvægi"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Deyfa út"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Aftan"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Framan"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Prófa %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6018,58 +3600,53 @@ msgstr "Smelltu á hátalara til ap prófa"
 msgid "System Volume"
 msgstr "Kerfishljóð"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Aðalhljóðstyrkur"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Hljóðstyrkur"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Úttak"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Úttakstæki"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Prófa"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Uppsetning"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "Jafnvægi"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "Deyfa út"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Bassabox"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Inntak"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Inntakstæki"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Hljóðstyrkur"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Viðvörunarhljóð"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Þagga niður"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6079,83 +3656,12 @@ msgstr "Hljóð"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Breyta hljóðstyrk, inntaki, úttaki og aðvörunarhljóðum"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Hljóðkort;hljóðnemi;Hljóðstyrkur;Deyfing;Jafnvægi;Bluetooth;Heyrnartól;"
 "Hljóðkerfi;Inntak;Úttak;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Aftengt"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Tengist"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Tengt"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Villa í auðkenningu"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Auðkenning í gangi"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Takmörkuð virkni"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Tengt og auðkennt"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Óþekkt"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Auðkennt:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Tengt á:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Skráð þann:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Tókst ekki að auðkenna tæki: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Tókst ekki að gleyma tæki: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6164,95 +3670,54 @@ msgid_plural "Depends on %u other devices"
 msgstr[0] "Er háð %u öðrum tæki"
 msgstr[1] "Er háð %u öðrum tækjum"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Loka tilkynningu"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Heiti:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Staða:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Auðkenna og tengjast"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Gleyma tæki"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Villa"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Enginn stuðningur við Thunderbolt"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Auðkennt"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Gat ekki tengst thunderbolt-undirkerfinu"
 
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Thunderbolt undirkerfið (boltd) er ekki uppsett eða að uppsetningin er ekki "
-"rétt."
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Beinn aðgangur"
 
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 "Leyfir beinan aðgang að tækjum eins og tengikvíum (dock) og utanáliggjandi "
 "GPU-skjákortsörgjörvum."
 
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Aðeins USB og Display Port tæki geta tengst."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt fannst ekki.\n"
-"Annað hvort vantar stuðning við Thunderbolt í kerfið, hann hefur verið "
-"gerður óvirkur í BIOS-stillingum eða að hann er stilltur á óstutt "
-"öryggisstig í BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Stuðningur við Thunderbolt hefur verið gerður óvirkur í BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Ekki var hægt að ákvarða öryggisstig Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Villa við að skipta í beinan ham: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
-msgid "No Thunderbolt Support"
-msgstr "Enginn stuðningur við Thunderbolt"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:104
-msgid "Could not connect to the thunderbolt subsystem."
-msgstr "Gat ekki tengst thunderbolt-undirkerfinu"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:153
-msgid "Direct Access"
-msgstr "Beinn aðgangur"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Tæki í bið"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Engin tæki tengd"
 
@@ -6264,7 +3729,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Sýsla með Thunderbolt-tæki"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;gagnaleynd;"
@@ -6273,16 +3737,16 @@ msgstr "Thunderbolt;gagnaleynd;"
 msgid "Cursor Blinking"
 msgstr "Bendill blikkar"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Bendill blikkar í textareitum."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Hraði"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Blikktíðni bendils"
 
@@ -6368,15 +3832,15 @@ msgstr "Mikil"
 msgid "Repeat Keys"
 msgstr "Endurtekning lykla"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Innsláttur endurtekinn þegar lykli er haldið niðri."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Hraði á endurtekningu lykla"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Hraði á endurtekningu lykla"
 
@@ -6457,47 +3921,13 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Löng"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "Virkja _miðað við lyklaborð"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Kveikja og slökkva á aðgengisstillingum með lyklaborði"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Sjálfgefið"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Miðlungs"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Stórt"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Stærra"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Stærst"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d mynddíll"
-msgstr[1] "%d mynddílar"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6612,31 +4042,6 @@ msgstr "Blikka öllum _skjánum"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "_Blikka öllum skjánum"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Stutt"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ skjár"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ skjár"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ skjár"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Langt"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6793,7 +4198,6 @@ msgstr "Litáhrif"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Gerir auðveldara að sjá, heyra, slá inn, benda og smella"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -6804,114 +4208,6 @@ msgstr ""
 "Lyklaborð;Mús;a11y;Aðgengi;Algilt aðgengi;Birtuskil;Hljóð;Bendill;Aðdráttur;"
 "Skjár;Lesari;texti;letur;stærð;AccessX;Klístrað;Lyklar;Hægt;Endurtaka;"
 "Endurvarp;Tvísmella;smella;töf;hraði;Aðstoð;innsláttur;hreyfingar;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 klukkustund"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dagur"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dagar"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Tæma öll atriði úr ruslinu?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Öllum atriðum í ruslinu verður endanlega eytt."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Tæma ruslið"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Eyða öllum bráðabirgðaskrám?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Öllum bráðabirgðaskrám verður endanlega eytt."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Eyða bráðabirgðaskrám"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dagur"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dagar"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dagar"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Að eilífu"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -6974,56 +4270,10 @@ msgstr "Ferill skráa og rusl"
 msgid "Don't leave traces"
 msgstr "Ekki skilja eftir nein ummerki"
 
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Ætti að samsvara vefslóð á miðlarann fyrir notandaaðganginn þinn."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Mistókst að bæta við reikning"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr "Lykilorðin stemma ekki."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Mistókst að skrá aðgang"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Engin aðferð er studd til auðkenningar á þessu léni"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Mistókst að fá aðgang að léni"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Þetta innskráningarnafn virkaði ekki.\n"
-"Endilega reyndu aftur."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Þetta lykilorð virkaði ekki.\n"
-"Endilega reyndu aftur."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Mistókst að skrá inn á lén"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Ekki tókst að finna lénið. Er það rétt stafað?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7057,14 +4307,14 @@ msgid "Enterprise Login"
 msgstr "Innskráning í fyrirtæki"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+msgid "User accounts which are managed by a company or organization."
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "Tölvan er ekki tengd við netið"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7073,10 +4323,6 @@ msgstr ""
 "Innskráning í fyrirtæki þýðir að hægt er að nota miðlægt skráðan "
 "notandaaðgang á þessu tæki. Þú getur líka notað þennan notandaaðgang til að "
 "tengjast netlægum tilföngum viðkomandi fyrirtækis."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Finna fleiri myndir"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7090,15 +4336,15 @@ msgstr "Fingrafarastýring"
 msgid "Fingerprint"
 msgstr "Fingrafar"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_Nei"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Já"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7106,502 +4352,165 @@ msgstr ""
 "Viltu eyða skráðum fingraförum, sem gerir innskráningu með fingraförum "
 "óvirka?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Enginn fingrafaraskanni"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "Enginn fingrafaraskanni"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "Gakktu úr skugga um að tækið sé rétt tengt."
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Fingrafaraskanni"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "Veldu fingrafaraskannann sem þú ætlar að stilla"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "Innskráning með fingrafari"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
 msgstr ""
-"Skönnun með fingrafari/förum gerir kleift að aflæsa og skrá inn í tölvuna með"
-" fingurstroku"
+"Skönnun með fingrafari/förum gerir kleift að aflæsa og skrá inn í tölvuna "
+"með fingurstroku"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "_Eyða fingraförum"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Skráning fingrafars"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr ""
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Fyrra"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "tækið er nú þegar yfirtekið af öðru ferli"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "Þú hefur ekki heimild til að nota þessa aðgerð"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "engin fingraför hafa verið skráð"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Mistókst að eiga samskipti við tæki á meðan skráningu stóð"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Gat ekki átt samskipti við fingrafaralesara"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Gat ekki átt samskipti við fingrafaravöktunina"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Gat ekki gera lista yfir fingraför: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Gat ekki eytt vistuðum fingraförum: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Vinstri þumall"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Vinstri langatöng"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Vinstri vísifingur"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Vinstri baugfingur"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Vinstri litlifingur"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Hægri þumall"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Hægri langatöng"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Hæg_ri vísifingur"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Hægri baugfingur"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Hægri litlifingur"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Óþekktur fingur"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Fullklárað"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Fingrafaraskanni aftengdur"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Tæki til fingrafaraskönnunar er fullt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Mistókst að skrá nýtt fingrafar"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Mistókst að byrja skráningu: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Mistókst að skrá nýtt fingrafar"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Mistókst að stöðva skráningu: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Lyftu og leggðu fingurinn endurtekið á fingrafaralestarann til að skrá"
-" fingrafarið þitt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Sk_rá fingur aftur…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Skanna nýtt fingrafar"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Gat ekki sleppt fingrafaraskanna: %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Vandamál við að lesa tæki"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Gat ekki tekið yfir fingrafaraskanna: %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Gat ekki fundið fingrafaraskanna: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Í þessari viku"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Í síðustu viku"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Setu lokið"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Seta hafin"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Virkni aðgangs"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Veldu eitthvað annað lykilorð."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Sláðu aftur inn núverandi lykilorð."
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Ekki tókst að breyta lykilorðinu"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Næsta"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Breyta lykilorði"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "Bre_yta"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "Núverandi lykilorð"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "Nýtt lykilorð"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "Staðfestu lykilorð"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lykilorðin stemma ekki."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Leyfa notanda að stilla lykilorð við næstu innskráningu"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Setja lykilorð núna"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Get ekki tengst sjálfvirkt á þessa tegund léns"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Ekkert slíkt lén eða svæði fannst"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Get ekki skráðst inn sem %s á %s lénið"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Rangt lykilorð, reyndu aftur"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Gat ekki tengst %s léninu: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "Gat ekki eytt notandanum"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "Tókst ekki að afturkalla fjartengda notandaaðganginn"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "Þú getur ekki eytt þínum eigin aðgangi."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s er ennþá skráður inn"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Ef notandaaðgangi er eytt á meðan notandinn er skráður inn getur kerfið "
-"orðið mjög óstöðugt."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Viltu halda skrám %s?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Það er hægt að halda eftir heimamöppu, pósthólfi og bráðabirgðaskrám þegar "
-"notandaaðgangi er eytt."
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "_Eyða skrám"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "_Halda skrám"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Viltu örugglega afturkalla fjartengda %s aðganginn?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "_Eyða"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Notandaaðgangur óvirkur"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Stillt við næstu innskráningu"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Enginn"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Skráður inn"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "Virkt"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "Mistókst að tengjast við aðgangsþjónustuna"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Vinsamlegast gangið úr skugga um að AccountService sé rétt upp sett og sé "
-"virkt."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "Eyða völdum notandaaðgangi"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Til að eyða völdum notandaaðgangi,\n"
-"smelltu fyrst á * táknmyndina"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr ""
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Notendur"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "Endurræsa þarf setuna svo breytingarnar taki gildi"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Endurræsa núna"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Loka"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Skipta um auðkennismynd"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Fullt nafn"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Breyta"
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Innskráning með _fingrafari"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "S_jálfvirk innskráning"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "Virkni aðgangs"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Kerfisstjóri"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "Að_gangsstýringar foreldra"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Fjarlægja notandaaðgang…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "Aðrir notendur"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "Bæta við notanda…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Engir notendur fundust"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Aflæsa til að bæta við notandaaðgangi."
 
@@ -7609,14 +4518,13 @@ msgstr "Aflæsa til að bæta við notandaaðgangi."
 msgid "Add or remove users and change your password"
 msgstr "Bæta við eða fjarlægja notendur og breyta lykilorði"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
 "Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"Innskráning;Notandi;Nafn;Fingrafar;Persónutákn;Merki;Andlit;Lykilorð;Foreldral"
-"æsing;Skjátími;veftakmarkanir;notkun;takmörk notkunar;börn;krakkar;"
+"Innskráning;Notandi;Nafn;Fingrafar;Persónutákn;Merki;Andlit;Lykilorð;"
+"Foreldralæsing;Skjátími;veftakmarkanir;notkun;takmörk notkunar;börn;krakkar;"
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
 #: panels/user-accounts/data/join-dialog.ui:30
@@ -7653,182 +4561,8 @@ msgstr "Sýsla með notendaaðganga"
 msgid "Authentication is required to change user data"
 msgstr "Auðkenningar er krafist til að breyta gögnum notanda"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Nýja lykilorðið verður að vera ólíkt því gamla."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Reyndu að breyta einhverjum stöfum og tölum."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Reyndu að breyta lykilorðinu örlítið meira."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Lykilorð sem ekki inniheldur notandanafnið þitt væri sterkara."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Forðastu að nota nafnið þitt í lykilorðinu."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Forðastu að nota einhver orðanna sem eru í lykilorðinu."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Forðastu að nota algeng orð."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Forðastu að endurraða algengum orðum."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Reyndu að nota fleiri tölustafi."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Reyndu að nota fleiri hástafi."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Reyndu að nota fleiri lágstafi."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Reyndu að nota fleiri sértákn, eins og greinamerki."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Reyndu að blanda saman bókstöfum, tölustöfum og greinamerkjum."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Forðastu að endurtaka sama stafinn oft."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Forðastu að endurtaka sömu tegund stafa: best er að blanda saman bókstöfum, "
-"tölustöfum og greinamerkjum."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Forðastu að nota runur eins og 1234 eða abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Lykilorðið þarf að vera lengra. Reyndu að blanda saman bókstöfum, tölustöfum "
-"og greinamerkjum."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Blandaðu saman hástöfum, lágstöfum og reyndu að nota einn eða fleiri "
-"tölustafi."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Ef þú bætir við fleiri bókstöfum, tölustöfum og greinamerkjum verður "
-"lykilorðið ennþá sterkara."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Auðkenning mistókst"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Nýja lykilorðið er of stutt"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Nýja lykilorðið er of einfalt"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Gamla og nýja lykilorðið eru of lík"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Nýja lykilorðið hefur áður verið notað og það nýlega."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Nýja lykilorðið verður að innihalda tölur eða sérstafi"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Það er enginn munur á gamla og nýja lykilorðinu"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Lykilorðinu hefur verið breytt síðan þú auðkenndir þig!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Nýja lykilorðið inniheldur ekki nægilega marga mismunandi stafi"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Óþekkt villa"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Notandanafn ætti venjulega einungis að innihalda lág/hástafi frá a-z, "
-"tölustafi eða einhvern af eftirfarandi stöfum:  - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Því miður, þetta notandanafn er ekki tiltækt. Veldu eitthvað annað nafn."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Notandanafnið er of langt."
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Tengja hnappa"
 
@@ -7861,47 +4595,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Mis-smellur fannst, endurræsi…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Hnappur %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Forrit skilgreint"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Senda lyklaslátt"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Skipta um skjá"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Sýna upplýsingaglugga á skjá"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Utanáliggjandi teiknitafla"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Allir skjáir"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Utanáliggjandi platti"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -7911,28 +4608,28 @@ msgstr "Teiknitöfluhamur"
 msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "Örvhent (músarhnöppum víxlað)"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Tengja við skjá"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "Halda stærðarhlutföllum"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "Kvarða"
 
@@ -7985,10 +4682,6 @@ msgstr "Þrýstiskynjun útstrokunar"
 msgid "Eraser pressure"
 msgstr "Þrýstingur útstrokunar"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:133
-msgid "Default"
-msgstr "Sjálfgefið"
-
 #: panels/wacom/cc-wacom-stylus-page.ui:134
 msgid "Middle Mouse Button Click"
 msgstr "Miðju-músarsmellur"
@@ -8001,22 +4694,6 @@ msgstr "Hægri músarsmellur"
 msgid "Forward"
 msgstr "Áfram"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Staðlaður teiknipenni með þrýstingi"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom teiknitafla"
@@ -8025,54 +4702,95 @@ msgstr "Wacom teiknitafla"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Stilltu hnappavörpun og aðlagaðu næmni snertipenna fyrir teiknispjald"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Teiknispjald;Teiknitafla;Wacom;Snerti;Penni;Teikna;Mús;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Nýr flýtilykill..."
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Hermt eftir aukasmell"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows hugbúnaður"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Lítið prentduft"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Auka"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows hugbúnaður"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Aðgangsstaðir"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Bæta við"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Vista"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Hætt var við aðgerð"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Óskráð"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Skráð"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Reiki"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Leita"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Hafnað"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8102,111 +4820,20 @@ msgstr "Eigin númer"
 msgid "Device Details"
 msgstr "Nánar um tæki"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Framleiðandi"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Útgáfa grunnhugbúnaðar (firmware)"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Aðeins 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Aðeins 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Aðeins 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (forgangs)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (forgangs), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (forgangs), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (forgangs)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (forgangs), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (forgangs)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (forgangs), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (forgangs)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (forgangs), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Óþekkt"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Aflæsa SIM-korti"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Aflæsa"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Tilgreindu PIN-kóðann fyrir SIM-kortið %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Settu inn PIN til að aflæsa SIM-kortinu"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Tilgreindu PUK-kóðann fyrir SIM-kortið %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Settu inn PUK til að aflæsa SIM-kortinu"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
 msgid "Wrong password entered. You have %1$u try left"
 msgid_plural "Wrong password entered. You have %1$u tries left"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Rangt lykilorð var sett inn. Þú átt %1$u tilraun eftir"
+msgstr[1] "Rangt lykilorð var sett inn. Þú átt %1$u tilraunir eftir"
 
 #: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
@@ -8215,33 +4842,13 @@ msgid_plural "You have %u tries left"
 msgstr[0] "Þú átt %u tilraun eftir"
 msgstr[1] "Þú átt %u tilraunir eftir"
 
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Rangt lykilorð var sett inn."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Settu inn nýtt PIN-númer"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN-númer á að vera 4-8 tölustafir"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Aflæsi…"
-
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
 msgstr "Ekkert SIM-kort"
 
 #: panels/wwan/cc-wwan-device-page.ui:19
 msgid "Insert a SIM card to use this modem"
-msgstr ""
+msgstr "Settu inn SIM-kort til að nota þetta mótald"
 
 #: panels/wwan/cc-wwan-device-page.ui:33
 msgid "SIM Locked"
@@ -8253,7 +4860,7 @@ msgstr "_Farsímagögn"
 
 #: panels/wwan/cc-wwan-device-page.ui:78
 msgid "Access data using mobile network"
-msgstr ""
+msgstr "Hafa aðgang að gögnum í gegnum farsímanet"
 
 #: panels/wwan/cc-wwan-device-page.ui:88
 msgid "_Data Roaming"
@@ -8291,147 +4898,47 @@ msgstr "Læsa SIM-korti með PIN-númeri"
 msgid "M_odem Details"
 msgstr "Nánar um mótal_d"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Bilun í síma"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Engin tenging við  síma"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Aðgerðin er ekki leyfileg"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Aðgerðin er ekki studd"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM-kort ekki til staðar"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Krafist er PIN-númers SIM-korts"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Krafist er PUK-númers SIM-korts"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Bilun í SIM-korti"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM-kort upptekið"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Rangt lykilorð"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Krafist er PIN2-númers SIM-korts"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Krafist er PUK2-númers SIM-korts"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Fannst ekki"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Engin netþjónusta"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Netkerfi féll á tíma"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS-þjónustur ekki leyfðar"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Reiki er ekki leyft á þessu svæði"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Óskilgreind GPRS-villa"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "Hætt við aðgerð"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Aðgangi hafnað"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Óþekkt villa"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Hamur netkerfis"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "_Setja"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "Loka"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "Sjálfvir_kt"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Veldu netkerfi"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
+msgstr "Endurnýja lista yfir netþjónustur"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "Virkja farsímanet"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "Engin WWAN-netkort fundust"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "Gakktu úr skugga um að þú sért með þráðlaust WAN/farsímatæki"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "Þráðlaust WAN er óvirkt þegar flugvélahamur er virkur"
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "Slö_kkva á flugvélaham"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "Gagnatenging"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "SIM-kort notað fyrir internet"
 
@@ -8443,15 +4950,15 @@ msgstr "SIM-læsing"
 msgid "_Next"
 msgstr "_Næsta"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "_Læsa SIM-korti með PIN-númeri"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "Breyta PIN-númeri"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr "Settu inn núverandi PIN-kóða til að breyta stillingum SIM-læsingar"
 
@@ -8463,10 +4970,9 @@ msgstr "Farsímanet"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Stilla nettæki og farsímatengingar"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
-msgstr ""
+msgstr "þráðlaust;wwan;símkerfi;sim;farsími;"
 
 #: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
@@ -8474,43 +4980,19 @@ msgstr "Tól til að stilla GNOME skjáborðsumhverfið"
 
 #: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
-msgstr ""
+msgstr "Stillingar er aðalviðmótið til að laga stillingar kerfisins þíns."
 
 #: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "GNOME verkefnið"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Birta útgáfunúmer"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Flokkar stillinga"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Virkja ítarlegan ham"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Leita að strengnum"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Birta heiti allra mögulegra spjalda og hætta"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Spjald sem á að birta"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[SPJALD] [BREYTA…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Gagnaleynd"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Tiltæk spjöld:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8568,7 +5050,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Hætta við leit"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Kjörstillingar;Uppsetning;"
@@ -8605,9 +5086,9 @@ msgid ""
 "A tuple containing the initial width, height and maximized state of the "
 "application window."
 msgstr ""
+"Strengur sem inniheldur upprunalega breidd, hæð og hámörkunarstöðu "
+"forritsglugga."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -8615,8 +5096,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u úttak"
 msgstr[1] "%u úttök"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -8624,9 +5103,3000 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u inntak"
 msgstr[1] "%u inntök"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Kerfishljóð"
+#~ msgid "System Bus"
+#~ msgstr "Kerfisbraut"
+
+#~ msgid "Full access"
+#~ msgstr "Fullur aðgangur"
+
+#~ msgid "Session Bus"
+#~ msgstr "Setubraut"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Fullur aðgangur að /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Er með aðgang að netkerfi"
+
+#~ msgid "Home"
+#~ msgstr "Heim"
+
+#~ msgid "Read-only"
+#~ msgstr "Skrifvarið"
+
+#~ msgid "File System"
+#~ msgstr "Skráakerfi"
+
+#~ msgid "Can change settings"
+#~ msgstr "Má breyta stillingum"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s er með eftirfarandi heimildir innbyggðar. Þeim er ekki hægt að breyta. "
+#~ "Ef þú ert með áhyggjur af þessum heimildum, ættirðu að íhuga að fjarlægja "
+#~ "þetta forrit."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u tegund skráagerða og tengla sem þetta forrit opnar"
+#~ msgstr[1] "%u tegundir skráagerða og tengla sem þetta forrit opnar"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> er notað til að opna eftirfarandi skráagerðir og tengla."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s af diskplássi verður notað."
+
+#~ msgid "Select a picture"
+#~ msgstr "Veldu mynd"
+
+#~ msgid "_Open"
+#~ msgstr "_Opna"
+
+#~ msgid "multiple sizes"
+#~ msgstr "margar stærðir"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Enginn skjáborðsbakgrunnur"
+
+#~ msgid "Current background"
+#~ msgstr "Núverandi bakgrunnur"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Settu litkvörðunartækið yfir ferninginn og ýttu svo á 'Byrja'"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Færðu litkvörðunartækið yfir á litkvörðunarstaðinn og ýttu svo á 'Halda "
+#~ "áfram'"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Færðu litkvörðunartækið í yfirborðsstöðu og ýttu svo á 'Halda áfram'"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Loka fartölvuloki"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Innri villa kom upp sem ekki var hægt að laga."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Það er ekki búið að setja upp nauðsynleg tól til litkvörðunar."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Ekki var hægt að útbúa litasniðið."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Ekki var hægt að nálgast hvítpunkt úttakstækisins."
+
+#~ msgid "Complete!"
+#~ msgstr "Fullklárað!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Litkvörðun mistókst!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Þú getur fjarlægt tæki til litkvörðunar."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ekki trufla litkvörðunartækið á meðan það er að vinna"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Fartölvuskjár"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Innbyggð vefmyndavél"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s skjár"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s skanni"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s myndavél"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s prentari"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s vefmyndavél"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Virkja litastýringu fyrir %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Birta litasnið fyrir %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Ekki litkvarðað"
+
+#~ msgid "Default: "
+#~ msgstr "Sjálfgefið: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Litavídd: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Prufu prófíll: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Veldu ICC-litasniðskrá"
+
+#~ msgid "_Import"
+#~ msgstr "Flytja _inn"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Studd ICC litasnið"
+
+#~ msgid "All files"
+#~ msgstr "Allar skrár"
+
+#~ msgid "Save Profile"
+#~ msgstr "Vista snið"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Búa til litasnið fyrir valið tæki"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Mælitækið fannst ekki. Athugaðu hvort kveikt sé á því og hvort það sé "
+#~ "rétt tengt."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Mælitækið styður ekki gerð litasniða fyrir prentara."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Þessi tegund tækis er ekki studd ennþá."
+
+#~ msgid "Standard Space"
+#~ msgstr "Stöðluð litrýmd"
+
+#~ msgid "Test Profile"
+#~ msgstr "Prófunarlitasnið"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Sjálfvirkt"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Lággæða"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Miðlungs gæði"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Hágæða"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Sjálfgefið RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Sjálfgefið CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Sjálfgefið grátóna"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Verksmiðjulitkvörðunargögn frá framleiðanda"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Skjáleiðrétting í heilskjásham er ekki möguleg með þessu litasniði"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Þetta litasnið er kannski ekki lengur mjög nákvæmt"
+
+#~ msgid "Other…"
+#~ msgstr "Annað…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Aflæstu til að breyta stillingum"
+
+#~ msgid "Today"
+#~ msgstr "Í dag"
+
+#~ msgid "Yesterday"
+#~ msgstr "í gær"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d klukkustund"
+#~ msgstr[1] "%d klukkustundir"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d mínúta"
+#~ msgstr[1] "%d mínútur"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekúnda"
+#~ msgstr[1] "%d sekúndur"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Tengipunktur (hotspot)"
+
+#~ msgid "24-hour"
+#~ msgstr "24-tíma"
+
+#~ msgid "AM / PM"
+#~ msgstr "FH / EH"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Ef þú sendir okkur upplýsingar um tæknileg vandamál hjálpar okkur að bæta "
+#~ "%s hugbúnaðinn. Skýrslur eru sendar nafnlaust og eru hreinsaðar af "
+#~ "persónugreinanlegum gögnum. %s"
+
+#~ msgid "On"
+#~ msgstr "Nota"
+
+#~ msgid "Off"
+#~ msgstr "Nota ekki"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Virkja breytingar?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Ekki var hægt að framkvæma breytingar"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Þetta gæti verið vegna takmarkana í vélbúnaði."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Lárétt"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Lóðrétt hægri"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Lóðrétt vinstri"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Lárétt (flett)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Kveikt er á Secure Boot ræsingu"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Secure Boot kemur í veg fyrir að spilliforritum sé hlaðið inn við ræsingu "
+#~ "tækis. Í augnablikinu er kveikt á því og það virkar rétt."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Vandamál í Secure Boot ræsingu"
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Slökkt er á Secure Boot ræsingu"
+
+#~ msgid "Passed"
+#~ msgstr "Stóðst prófun"
+
+#~ msgid "Failed"
+#~ msgstr "Mistókst"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Tæki samsvarar HSI-stigi %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Öryggisstig 0"
+
+#~ msgid "Security Level 1"
+#~ msgstr "Öryggisstig 1"
+
+#~ msgid "Security Level 2"
+#~ msgstr "Öryggisstig 2"
+
+#~ msgid "Security Level 3"
+#~ msgstr "Öryggisstig 3"
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Öryggisstig eru ekki tiltæk fyrir þetta tæki."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Varið gegn spillihugbúnaði þegar tækið ræsist."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Vandamál í Secure Boot ræsingu"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Nokkur vörn þegar tæki er ræst."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Slökkt er á Secure Boot ræsingu"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Engin vörn þegar tæki er ræst."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Berskjaldað fyrir alvarlegum öryggisógnum."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Takmörkuð vörn gegn einföldum öryggisógnum."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Varið gegn algengum öryggisógnum."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Varið gegn margvíslegum öryggisógnum."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Alhliðavörn (Comprehensive Protection)"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "DMA-vörn for-ræsingar"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard Verified Boot"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM Protected"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Stefna Intel BootGuard varðandi villur"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard Fuse"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET er virkjað"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET virkt"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Dulritað RAM-vinnsluminni"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU-vörn"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Fastlæsing Linux-kjarna"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Sannvottun Linux-kjarna"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Swap-diskminni"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Svæfa í minni (RAM)"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Setja í bið í minni (RAM)"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI-kerfislykill"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI Secure Boot"
+
+#, fuzzy
+#~| msgid "Display Configuration"
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Stillingar skjátækis"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM-endurbygging"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Uppfærslur á fasthugbúnaði (firmware)"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Attestation"
+#~ msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Villukembing stýrikerfis"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Öryggisprófanir á örgjörva"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#~ msgid "Valid"
+#~ msgstr "Gilt"
+
+#~ msgid "Not Valid"
+#~ msgstr "Ekki gilt"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Ekki virkt"
+
+#~ msgid "Locked"
+#~ msgstr "Læst"
+
+#~ msgid "Not Locked"
+#~ msgstr "Ekki læst"
+
+#~ msgid "Encrypted"
+#~ msgstr "Dulritað"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Ekki dulritað"
+
+#, fuzzy
+#~| msgid "Not calibrated"
+#~ msgid "Not Tainted"
+#~ msgstr "Ekki litkvarðað"
+
+#~ msgid "Found"
+#~ msgstr "Fannst"
+
+#~ msgid "Not Found"
+#~ msgstr "Fannst ekki"
+
+#~ msgid "Supported"
+#~ msgstr "Með stuðning"
+
+#~ msgid "Not Supported"
+#~ msgstr "Ekki stutt"
+
+#~ msgid "Unknown"
+#~ msgstr "Óþekkt"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bita"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bita"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Óþekkt"
+
+#~ msgid "Not Available"
+#~ msgstr "Ekki tiltækt"
+
+#~ msgid "System Logo"
+#~ msgstr "Táknmerki kerfis"
+
+#~ msgid "No input sources found"
+#~ msgstr "Engir inntaksgjafar fundust"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Annað"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Sérsniðinn flýtilykill"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Vara-stafalykilinn er hægt að nota til að setja inn viðbótar-staftákn. "
+#~ "Þau eru stundum prentuð sem þriðji valmöguleiki á lyklaborðum."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Vinstri Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Hægri Alt-lykill"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Vinstri breytilykill"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Hægri breytilykill"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Valmyndarlykill"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Hægri Ctrl-lykill"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Samsetningarlykillinn (compose key) gerir kleift að setja inn margvíslega "
+#~ "stafi Hann er notaður með því að ýta á hann og síðan á runu af öðrum "
+#~ "staftáknum.  Til dæmis, sé samsetningarlykli fylgt með <b>C</b> og <b>o</"
+#~ "b> er sett inn <b>©</b> merki, <b>a</b> fylgt með <b>'</b> setur inn "
+#~ "<b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "CapsLock-hástafalás"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "ScrollLock-skrunlæsing"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Hægt er að skipta um inntaksgjafa með %s flýtilyklinum.\n"
+#~ "Þessu er hægt að breyta í stillingum fyrir flýtivísanir lyklaborðs."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d breytt"
+#~ msgstr[1] "%d breytt"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Frumstilla alla flýtilykla?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Frumstilling flýtilykla gæti haft áhrif á sérsniðna flýtilykla sem þú "
+#~ "hefur stillt. Ekki er hægt að taka þetta aftur."
+
+#~ msgid "Reset All"
+#~ msgstr "Frumstilla allt"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s er nú þegar í notkun fyrir %s. Ef þú skiptir því út, verður %s gert "
+#~ "óvirkt"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Settu inn nýjan flýtilykil"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Setja sérsniðinn flýtilykil"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Setja flýtilykil"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Settu inn nýjan flýtilykil til að breyta %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Bæta við sérsniðnum flýtilykli"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Tveggja-fingra skrun"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Fimm smellir, tími fyrir GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Tvísmella, aðalhnappur"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Einsmella, aðalhnappur"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Tvísmella, miðhnappur"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Einsmella, miðhnappur"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Tvísmella, aukahnappur"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Einsmella, aukahnappur"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager netstjórinn verður að vera í gangi."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Ótryggt netkerfi (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Öruggt netkerfi (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Öruggt netkerfi (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Öruggt netkerfi (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Öruggt netkerfi"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Stöðva tengipunkt og aftengja alla notendur?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Stöðva tengipunkt"
+
+#~ msgid "Preserve"
+#~ msgstr "Varðveita"
+
+#~ msgid "Permanent"
+#~ msgstr "Varanlegt"
+
+#~ msgid "Random"
+#~ msgstr "Slembið"
+
+#~ msgid "Stable"
+#~ msgstr "Stöðugt"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "MAC-vistfangið sem sett er inn hér verður notað sem vélbúnaðarvistfang "
+#~ "fyrir nettækið sem þessi tenging er virkjuð á.  Sú aðgerð er þekkt undir "
+#~ "nafninu MAC-klónun eða vélarstuldur.  Dæmi: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Snið %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Fyrirtækis"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ekkert"
+
+#~ msgid "Never"
+#~ msgstr "Aldrei"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/sek"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Ekkert"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Veikt"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Í lagi"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Gott"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Frábært"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Gleyma tengingu"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Fjarlægja tengisnið"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Fjarlægja VPN"
+
+#~ msgid "Details"
+#~ msgstr "Nánar"
+
+#~ msgid "automatic"
+#~ msgstr "sjálfvirkt"
+
+#~ msgid "Identity"
+#~ msgstr "Auðkenni"
+
+#~ msgid "Delete Address"
+#~ msgstr "Eyða vistfangi"
+
+#~ msgid "Delete Route"
+#~ msgstr "Eyða beiningu (route)"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ekkert"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit lykill (Hex eða ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit lykilsetning"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Breytilegt (dynamic) WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA og WPA2 einka"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA og WPA2 fyrirtækja"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 einka"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Get ekki opnað tengingaritil"
+
+#~ msgid "New Profile"
+#~ msgstr "Nýtt snið"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Ógild stilling %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Ógild stilling %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Flytja inn úr skrá…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Bæta við VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Get ekki flutt inn VPN-nettengingu"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Skráin '%s' var ekki lesanleg eða að hún inniheldur ekki þekkjanlegar VPN "
+#~ "tengiupplýsingar\n"
+#~ "\n"
+#~ "Villa: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Veldu skrá til að flytja inn"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Skrá með heitinu '%s' er þegar til."
+
+#~ msgid "_Replace"
+#~ msgstr "_Skipta út"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Viltu skipta %s út fyrir VPN-nettenginguna sem þú ert að vista?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Get ekki flutt út VPN-nettengingu"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Ekki var hægt að flytja út VPN tenginguna '%s' til %s.\n"
+#~ "\n"
+#~ "Villa: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Flytja út VPN-nettengingu"
+
+#~ msgid "never"
+#~ msgstr "aldrei"
+
+#~ msgid "today"
+#~ msgstr "í dag"
+
+#~ msgid "yesterday"
+#~ msgstr "í gær"
+
+#~ msgid "Last used"
+#~ msgstr "Síðast notað"
+
+#~ msgid "Add new connection"
+#~ msgstr "Bæta við nýrri tengingu"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Upplýsingar um valin netkerfi munu tapast, þar með talið lykilorð og "
+#~ "aðrar sérsniðnar stillingar."
+
+#~ msgid "_Forget"
+#~ msgstr "_Gleyma"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Þekkt Wi-Fi netkerfi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Gleyma"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Kerfisheimildir heimila ekki notkun sem tengipunkts"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Þráðlaust tæki styður ekki tengipunkts-ham (hotspot)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Sjálfvirk leit með Web Proxy Autodiscovery er notað þegar "
+#~ "stillingavistfang (configuration URL) er ekki gefið upp."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Ekki er mælt með þessu fyrir ótreyst almenningsnet."
+
+#~ msgid "Status unknown"
+#~ msgstr "Staða óþekkt"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Óstýrt"
+
+#~ msgid "Unavailable"
+#~ msgstr "Ekki tiltækt"
+
+#~ msgid "Connecting"
+#~ msgstr "Tengist"
+
+#~ msgid "Authentication required"
+#~ msgstr "Auðkenningar krafist"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Aftengist"
+
+#~ msgid "Connection failed"
+#~ msgstr "Tenging mistókst"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Staða óþekkt (vantar)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Stillingar brugðust"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP-stillingar brugðust"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP-stillingar úreltar"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Dulritunarupplýsinga var krafist en virðast ekki koma fram"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x biðill ótengdur"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Stillingar 802.1x biðils brugðust"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x biðill brást"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x biðill var of lengi að auðkenna"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP þjónusta gat ekki hafist"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP þjónusta aftengd"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP brást"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP biðlari ræstist ekki"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Villa í DHCP biðlara"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP biðlari brást"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Þjónusta sameiginlegra tenginga ræstist ekki"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Þjónusta sameiginlegra tenginga brást"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP þjónusta ræstist ekki"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Villa í AutoIP þjónustu"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP þjónusta brást"
+
+#~ msgid "Line busy"
+#~ msgstr "Línan upptekin"
+
+#~ msgid "No dial tone"
+#~ msgstr "Enginn sónn"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Ekki tókst að koma á tengingu."
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Hringing rann út á tíma"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Tilraun til tengingar mistókst"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Frumstilling mótalds mistókst"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Ekki tókst að velja tiltekið APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Ekki að leita að netkerfum"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Skráningu á netkerfi hafnað"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Skráning á netkerfi rann út á tíma"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Mistókst að skrá inn á umbeðið netkerfi"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Athugun á PIN mistókst"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Grunnhugbúnað (firmware) tækis gæti vantað"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Tenging hvarf"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Gert var ráð fyrir tengingu sem þegar er til staðar"
+
+#~ msgid "Modem not found"
+#~ msgstr "Mótald fannst ekki."
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth-tenging brást"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM-kort ekki til staðar"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Krafist er PIN-númers SIM-korts"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Krafist er PUK-númers SIM-korts"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Rangt SIM-kort"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Það tókst ekki að uppfylla allar kerfiskröfur fyrir tengingu"
+
+#~ msgid "Firmware missing"
+#~ msgstr "grunnhugbúnað vantar (firmware)"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "kapall ekki tengdur"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "óskilgreind villa í öruggu 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "engin skrá valin"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "óskilgreind villa við sannvottun á eap-method skrá"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 eða PGP-einkalyklar"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER eða PEM skilríki"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "vantar EAP-FAST PAC skrá"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC skrár (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "vantar EAP-LEAP notandanafn"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "vantar EAP-LEAP lykilorð"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "ógilt EAP-PEAP CA skilríki: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "ógilt EAP-PEAP CA skilríki: ekkert skilríki tiltekið"
+
+#~ msgid "missing EAP username"
+#~ msgstr "vantar EAP notandanafn"
+
+#~ msgid "missing EAP password"
+#~ msgstr "vantar EAP lykilorð"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "vantar EAP-TLS auðkenni"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "ógilt EAP-TLS CA skilríki: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "ógilt EAP-TLS CA skilríki: ekkert skilríki tiltekið"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "ógildur EAP-TLS einkalykill: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "ógilt EAP-TLS notanda-skilríki: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Ódulritaðir einkalyklar eru óöruggir"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Valinn einkalykill lítur ekki út fyrir að vera varinn af lykilorði. Þetta "
+#~ "gæti sett öryggi þitt í hættu.  Endilega veldu einkalykil sem varinn er "
+#~ "af lykilorði.\n"
+#~ "\n"
+#~ "(Þú getur sett lykilorð á einkalykla með openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Veldu þitt einkaskilríki"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Veldu þinn einkalykil"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "ógilt EAP-TTLS CA skilríki: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "ógilt EAP-TTLS CA skilríki: ekkert skilríki tiltekið"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Óþekkt villa við að sannreyna 802.1x öryggi"
+
+#~ msgid "Select a file"
+#~ msgstr "Veldu skrá"
+
+#~ msgid "missing leap-username"
+#~ msgstr "vantar leap-notandanafn"
+
+#~ msgid "missing leap-password"
+#~ msgstr "vantar leap-lykilorð"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Wi-Fi lykilorð vantar."
+
+#~ msgid "missing wep-key"
+#~ msgstr "vantar wep-lykil"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "ógildur wpa-key: lykill með lengdina %zu verður að innihalda eingöngu hex-"
+#~ "tölustafi"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "ógildur wpa-key: lykill með lengdina %zu verður að innihalda eingöngu "
+#~ "ascii-stafi"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "ógildur wpa-key: ógild lengd lykils %zu. Lykill verður að vera með lengd "
+#~ "5/13 (ascii) eða 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "ógildur wep-key: lykilfrasi má ekki vera tómur"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "ógildur wep-key: lykilfrasi verður að vera styttri en 64 stafir"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "ógilt wpa-psk: ógild lengd lykils %zu. Verður að vera [8,63] bæti eða 64 "
+#~ "hex tölustafir"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "ógilt wpa-psk: get ekki túlkað lykil með 64 bætum sem hex"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Annað"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s fjarlægt"
+
+#~ msgid "Error removing account"
+#~ msgstr "Villa við að fjarlægja notandaaðgang"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Aðgangur %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Fjarlægja notandaaðgang"
+
+#~ msgid "Unknown time"
+#~ msgstr "Óþekktur tími"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s þar til rafhlaðan er fullhlaðin"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Varúð: %s eftir"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s eftir"
+
+#~ msgid "Fully charged"
+#~ msgstr "Full hleðsla"
+
+#~ msgid "Not charging"
+#~ msgstr "Ekki í hleðslu"
+
+#~ msgid "Empty"
+#~ msgstr "Tóm"
+
+#~ msgid "Charging"
+#~ msgstr "Í hleðslu"
+
+#~ msgid "Discharging"
+#~ msgstr "Afhleðst"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Þráðlaus mús"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Þráðlaust lyklaborð"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "UPS varaaflgjafi"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "PDA lófatölva"
+
+#~ msgid "Cellphone"
+#~ msgstr "Farsími"
+
+#~ msgid "Media player"
+#~ msgstr "Margmiðlunarspilari"
+
+#~ msgid "Tablet"
+#~ msgstr "Spjaldtölva"
+
+#~ msgid "Computer"
+#~ msgstr "Tölva"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Leikjainntakstæki"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Aðal"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Auka"
+
+#~ msgid "Batteries"
+#~ msgstr "Rafhlöður"
+
+#~ msgid "When _idle"
+#~ msgstr "Við _iðjuleysi"
+
+#~ msgid "Suspend"
+#~ msgstr "Setja í bið"
+
+#~ msgid "Power Off"
+#~ msgstr "Slökkva"
+
+#~ msgid "Hibernate"
+#~ msgstr "Leggja í dvala"
+
+#~ msgid "Nothing"
+#~ msgstr "Ekkert"
+
+#~ msgid "When on battery power"
+#~ msgstr "Þegar notað er afl frá rafhlöðum"
+
+#~ msgid "When plugged in"
+#~ msgstr "Þegar vélin er í sambandi"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Aldrei"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Hætta sjálfvirkt"
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Orkusparnaðarhamur virkjaður af “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Afkastahamur virkjaður af “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Afköst"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Mikil afköst og orkunotkun."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Jafnvægi"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Venjuleg afköst og orkunotkun."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Orkusparnaður"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Minnkuð afköst og orkunotkun."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Prentaranum “%s” hefur verið eytt"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Mistókst að bæta við nýjum prentara"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Gat ekki hlaðið inn ui-viðmóti: %s"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Nánar um %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Enginn hentugur rekill fannst"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Veldu PPD-skrá"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript prentlýsingarskrár (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect prentari"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD prentari"
+
+#~ msgid "One Sided"
+#~ msgstr "Einhliða"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Langhlið (venjulegt)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Styttri brún (snúið)"
+
+#~ msgid "Portrait"
+#~ msgstr "Lóðrétt"
+
+#~ msgid "Landscape"
+#~ msgstr "Lárétt"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Öfugt lárétt"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Öfugt lóðrétt"
+
+#~ msgid "Resume"
+#~ msgstr "Halda áfram"
+
+#~ msgid "Pause"
+#~ msgstr "Í bið"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Í bið"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Í bið"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Auðkenningar krafist"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Í vinnslu"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Stöðvað"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Hætt við"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Farið út úr"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Lokið"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Færa þetta verk fremst í biðröð"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — virk verk"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Settu inn auðkenni til að prenta á %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Aflæsa prentþjóni"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Aflæsa %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Settu inn notandanafn og lykilorð til að skoða þá prentara sem eru "
+#~ "tiltækir á %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Leita að prenturum"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Raðtengi (serial)"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Hliðtengi (parallel)"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Staður: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Vistfang: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Miðlari krefst auðkenningar"
+
+#~ msgid "Two Sided"
+#~ msgstr "Tvíhliða"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tegund pappírs"
+
+#~ msgid "Paper Source"
+#~ msgstr "Uppruni pappírs"
+
+#~ msgid "Output Tray"
+#~ msgstr "Úttaksbakki"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Upplausn"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Ghostscript forsíun"
+
+#~ msgid "Pages per side"
+#~ msgstr "Blaðsíður á hverja hlið"
+
+#~ msgid "Orientation"
+#~ msgstr "Stefna"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Almennt"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Uppsetning síðu"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Uppsetjanlegir hlutir"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Verk"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Myndgæði"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Litur"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Klára"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Nánar"
+
+#~ msgid "Test page"
+#~ msgstr "Prófunarsíða"
+
+#~ msgid "Auto Select"
+#~ msgstr "Velja sjálfvirkt"
+
+#~ msgid "Printer Default"
+#~ msgstr "Sjálfgefnar stillingar prentara"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Ígræða einungis GhostScript letur"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Breyta í PS-stig 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Breyta í PS-stig 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Engin forsíun"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Hreinsa prenthausa"
+
+#~ msgid "Out of toner"
+#~ msgstr "Búinn með prentduft"
+
+#~ msgid "Low on developer"
+#~ msgstr "Lítill framköllunarvökvi"
+
+#~ msgid "Out of developer"
+#~ msgstr "marker supplyframköllunarvökvann"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Lítið eftir á fyllingu"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Búinn með fyllingu"
+
+#~ msgid "Open cover"
+#~ msgstr "Opna lok"
+
+#~ msgid "Open door"
+#~ msgstr "Opna hlera"
+
+#~ msgid "Low on paper"
+#~ msgstr "Lítill pappír eftir"
+
+#~ msgid "Out of paper"
+#~ msgstr "Pappírslaus"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Ótengdur"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Stöðvaður"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Ruslabakki næstum fullur"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Ruslabakki fullur"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Prentkassettan er komin að lokum líftíma síns"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Prentkassettan virkar ekki lengur"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Tilbúinn"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Tekur ekki við verkum"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Í vinnslu"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Breskt kerfi"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrakerfi"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Spyrja hvað skuli gera"
+
+#~ msgid "Do nothing"
+#~ msgstr "Gera ekkert"
+
+#~ msgid "Open folder"
+#~ msgstr "Opna möppu"
+
+#~ msgid "Other Media"
+#~ msgstr "Aðrir miðlar"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Veldu forrit fyrir CD-hljóðdiska"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Veldu forrit fyrir DVD-mynddiska"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Veldu forrit til að keyra þegar tónlistarspilari er tengdur"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Veldu forrit til að keyra þegar myndavél er tengd"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Veldu forrit fyrir CD-diska með hugbúnaði"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD hljóðdiskur"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "tómur Blu-Ray diskur"
+
+#~ msgid "blank CD disc"
+#~ msgstr "tómur CD geisladiskur"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "tómur DVD mynddiskur"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "tómur HD DVD diskur"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-Ray mynddiskur"
+
+#~ msgid "e-book reader"
+#~ msgstr "rafbókalesari"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD mynddiskur"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD mynddiskur"
+
+#~ msgid "Super Video CD"
+#~ msgstr "CD Super Video mynddiskur"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD mynddiskur"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Skjár slekkur á sér eftir"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekúndur"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 mínúta"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 mínútur"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 mínútur"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 mínútur"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 mínútur"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 klukkustund"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 mínúta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 mínútur"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 mínútur"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 mínútur"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 mínútur"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 mínútur"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 mínútur"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 mínútur"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 mínútur"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Aldrei"
+
+#~ msgid "Select Location"
+#~ msgstr "Veldu staðsetningu"
+
+#~ msgid "_OK"
+#~ msgstr "Í _lagi"
+
+#~ msgid "No applications found"
+#~ msgstr "Engin forrit fundust"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Engin netkerfi valin vegna deilingar gagna"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Kveikt"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Slökkt"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Virkjað"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Virkt"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Veldu möppu"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Virkja deilingu gagnamiðla"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Deiling skráa gerir þér kleift að deila \"Opið öllum\"-möppunni (Public) "
+#~ "með öðrum á netinu þínu, með: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Þegar fjartengd innskráning er virk, geta fjartengdir notendur að tengst "
+#~ "með Secure Shell skipun:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Virkja deilingu einkagagnamiðla"
+
+#~ msgid "Device name copied"
+#~ msgstr "Heiti tækis afritað"
+
+#~ msgid "Device address copied"
+#~ msgstr "Vistfang tækis afritað"
+
+#~ msgid "Username copied"
+#~ msgstr "Notandanafn afritað"
+
+#~ msgid "Password copied"
+#~ msgstr "Lykilorð afritað"
+
+#~ msgid "Custom"
+#~ msgstr "Sérsniðið"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Prófa %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Aftengt"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Tengist"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Tengt"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Villa í auðkenningu"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Auðkenning í gangi"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Takmörkuð virkni"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Tengt og auðkennt"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Óþekkt"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Auðkennt:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Tengt á:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Skráð þann:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Tókst ekki að auðkenna tæki: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Tókst ekki að gleyma tæki: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Villa"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Auðkennt"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt undirkerfið (boltd) er ekki uppsett eða að uppsetningin er "
+#~ "ekki rétt."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Aðeins USB og Display Port tæki geta tengst."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt fannst ekki.\n"
+#~ "Annað hvort vantar stuðning við Thunderbolt í kerfið, hann hefur verið "
+#~ "gerður óvirkur í BIOS-stillingum eða að hann er stilltur á óstutt "
+#~ "öryggisstig í BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Stuðningur við Thunderbolt hefur verið gerður óvirkur í BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Ekki var hægt að ákvarða öryggisstig Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Villa við að skipta í beinan ham: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Sjálfgefið"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Miðlungs"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Stórt"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Stærra"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Stærst"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d mynddíll"
+#~ msgstr[1] "%d mynddílar"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Stutt"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ skjár"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ skjár"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ skjár"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Langt"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 klukkustund"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dagur"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dagar"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Tæma öll atriði úr ruslinu?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Öllum atriðum í ruslinu verður endanlega eytt."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Tæma ruslið"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Eyða öllum bráðabirgðaskrám?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Öllum bráðabirgðaskrám verður endanlega eytt."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Eyða bráðabirgðaskrám"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dagur"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dagar"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dagar"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Að eilífu"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Ætti að samsvara vefslóð á miðlarann fyrir notandaaðganginn þinn."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Mistókst að bæta við reikning"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Mistókst að skrá aðgang"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Engin aðferð er studd til auðkenningar á þessu léni"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Mistókst að fá aðgang að léni"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Þetta innskráningarnafn virkaði ekki.\n"
+#~ "Endilega reyndu aftur."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Þetta lykilorð virkaði ekki.\n"
+#~ "Endilega reyndu aftur."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Mistókst að skrá inn á lén"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Ekki tókst að finna lénið. Er það rétt stafað?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Finna fleiri myndir"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "tækið er nú þegar yfirtekið af öðru ferli"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "Þú hefur ekki heimild til að nota þessa aðgerð"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "engin fingraför hafa verið skráð"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Mistókst að eiga samskipti við tæki á meðan skráningu stóð"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Gat ekki átt samskipti við fingrafaralesara"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Gat ekki átt samskipti við fingrafaravöktunina"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Gat ekki gera lista yfir fingraför: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Gat ekki eytt vistuðum fingraförum: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Vinstri þumall"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Vinstri langatöng"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Vinstri vísifingur"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Vinstri baugfingur"
+
+#~ msgid "Left little finger"
+#~ msgstr "Vinstri litlifingur"
+
+#~ msgid "Right thumb"
+#~ msgstr "Hægri þumall"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Hægri langatöng"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Hæg_ri vísifingur"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Hægri baugfingur"
+
+#~ msgid "Right little finger"
+#~ msgstr "Hægri litlifingur"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Óþekktur fingur"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Fullklárað"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Fingrafaraskanni aftengdur"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Tæki til fingrafaraskönnunar er fullt"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Mistókst að skrá nýtt fingrafar"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Mistókst að byrja skráningu: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Mistókst að skrá nýtt fingrafar"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Mistókst að stöðva skráningu: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Lyftu og leggðu fingurinn endurtekið á fingrafaralestarann til að skrá "
+#~ "fingrafarið þitt"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Sk_rá fingur aftur…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Skanna nýtt fingrafar"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Gat ekki sleppt fingrafaraskanna: %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Vandamál við að lesa tæki"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Gat ekki tekið yfir fingrafaraskanna: %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Gat ekki fundið fingrafaraskanna: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Í þessari viku"
+
+#~ msgid "Last Week"
+#~ msgstr "Í síðustu viku"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Setu lokið"
+
+#~ msgid "Session Started"
+#~ msgstr "Seta hafin"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Virkni aðgangs"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Veldu eitthvað annað lykilorð."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Sláðu aftur inn núverandi lykilorð."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Ekki tókst að breyta lykilorðinu"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Get ekki tengst sjálfvirkt á þessa tegund léns"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Ekkert slíkt lén eða svæði fannst"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Get ekki skráðst inn sem %s á %s lénið"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Rangt lykilorð, reyndu aftur"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Gat ekki tengst %s léninu: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Gat ekki eytt notandanum"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Tókst ekki að afturkalla fjartengda notandaaðganginn"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Þú getur ekki eytt þínum eigin aðgangi."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s er ennþá skráður inn"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Ef notandaaðgangi er eytt á meðan notandinn er skráður inn getur kerfið "
+#~ "orðið mjög óstöðugt."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Viltu halda skrám %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Það er hægt að halda eftir heimamöppu, pósthólfi og bráðabirgðaskrám "
+#~ "þegar notandaaðgangi er eytt."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Eyða skrám"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Halda skrám"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Viltu örugglega afturkalla fjartengda %s aðganginn?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Eyða"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Notandaaðgangur óvirkur"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Stillt við næstu innskráningu"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Enginn"
+
+#~ msgid "Logged in"
+#~ msgstr "Skráður inn"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Mistókst að tengjast við aðgangsþjónustuna"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Vinsamlegast gangið úr skugga um að AccountService sé rétt upp sett og sé "
+#~ "virkt."
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Eyða völdum notandaaðgangi"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Til að eyða völdum notandaaðgangi,\n"
+#~ "smelltu fyrst á * táknmyndina"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Aflæstu til að bæta við notendum og breyta stillingum"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Nýja lykilorðið verður að vera ólíkt því gamla."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Reyndu að breyta einhverjum stöfum og tölum."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Reyndu að breyta lykilorðinu örlítið meira."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Lykilorð sem ekki inniheldur notandanafnið þitt væri sterkara."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Forðastu að nota nafnið þitt í lykilorðinu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Forðastu að nota einhver orðanna sem eru í lykilorðinu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Forðastu að nota algeng orð."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Forðastu að endurraða algengum orðum."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Reyndu að nota fleiri tölustafi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Reyndu að nota fleiri hástafi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Reyndu að nota fleiri lágstafi."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Reyndu að nota fleiri sértákn, eins og greinamerki."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Reyndu að blanda saman bókstöfum, tölustöfum og greinamerkjum."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Forðastu að endurtaka sama stafinn oft."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Forðastu að endurtaka sömu tegund stafa: best er að blanda saman "
+#~ "bókstöfum, tölustöfum og greinamerkjum."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Forðastu að nota runur eins og 1234 eða abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Lykilorðið þarf að vera lengra. Reyndu að blanda saman bókstöfum, "
+#~ "tölustöfum og greinamerkjum."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Blandaðu saman hástöfum, lágstöfum og reyndu að nota einn eða fleiri "
+#~ "tölustafi."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Ef þú bætir við fleiri bókstöfum, tölustöfum og greinamerkjum verður "
+#~ "lykilorðið ennþá sterkara."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Auðkenning mistókst"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Nýja lykilorðið er of stutt"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Nýja lykilorðið er of einfalt"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Gamla og nýja lykilorðið eru of lík"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Nýja lykilorðið hefur áður verið notað og það nýlega."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Nýja lykilorðið verður að innihalda tölur eða sérstafi"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Það er enginn munur á gamla og nýja lykilorðinu"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Lykilorðinu hefur verið breytt síðan þú auðkenndir þig!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Nýja lykilorðið inniheldur ekki nægilega marga mismunandi stafi"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Óþekkt villa"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Notandanafn ætti venjulega einungis að innihalda lág/hástafi frá a-z, "
+#~ "tölustafi eða einhvern af eftirfarandi stöfum:  - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Því miður, þetta notandanafn er ekki tiltækt. Veldu eitthvað annað nafn."
+
+#~ msgid "The username is too long."
+#~ msgstr "Notandanafnið er of langt."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Hnappur %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Forrit skilgreint"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Senda lyklaslátt"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Skipta um skjá"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Sýna upplýsingaglugga á skjá"
+
+#~ msgid "External tablet device"
+#~ msgstr "Utanáliggjandi teiknitafla"
+
+#~ msgid "All Displays"
+#~ msgstr "Allir skjáir"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Loftsprautu-teiknipenni með þrýstingi, halla og innbyggðum sleða"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Loftsprautu-teiknipenni með þrýstingi, halla og snúningi"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Staðlaður teiknipenni með þrýstingi og halla"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Staðlaður teiknipenni með þrýstingi"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nýr flýtilykill..."
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Hætt var við aðgerð"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Villa:</b> Aðgangi hafnað við að breyta stillingum"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Villa:</b> villa í farsímatækjum"
+
+#~ msgid "Not Registered"
+#~ msgstr "Óskráð"
+
+#~ msgid "Registered"
+#~ msgstr "Skráð"
+
+#~ msgid "Roaming"
+#~ msgstr "Reiki"
+
+#~ msgid "Searching"
+#~ msgstr "Leita"
+
+#~ msgid "Denied"
+#~ msgstr "Hafnað"
+
+#~ msgid "2G Only"
+#~ msgstr "Aðeins 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Aðeins 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Aðeins 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Aðeins 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (forgangs)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (forgangs), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (forgangs), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (forgangs), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (forgangs)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (forgangs), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (forgangs), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (forgangs)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (forgangs), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (forgangs), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (forgangs)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (forgangs), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (forgangs), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (forgangs)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (forgangs), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (forgangs), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (forgangs)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (forgangs), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (forgangs)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (forgangs), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (forgangs)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (forgangs), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (forgangs)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (forgangs), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (forgangs)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (forgangs), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (forgangs)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (forgangs), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Óþekkt"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Aflæsa SIM-korti"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Tilgreindu PIN-kóðann fyrir SIM-kortið %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Settu inn PIN til að aflæsa SIM-kortinu"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Tilgreindu PUK-kóðann fyrir SIM-kortið %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Settu inn PUK til að aflæsa SIM-kortinu"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Rangt lykilorð var sett inn."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK-kóði á að vera 8 tölustafir"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Settu inn nýtt PIN-númer"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN-númer á að vera 4-8 tölustafir"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Aflæsi…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Bilun í síma"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Engin tenging við  síma"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Aðgerðin er ekki leyfileg"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Aðgerðin er ekki studd"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM-kort ekki til staðar"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Krafist er PIN-númers SIM-korts"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Krafist er PUK-númers SIM-korts"
+
+#~ msgid "SIM failure"
+#~ msgstr "Bilun í SIM-korti"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM-kort upptekið"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Rangt lykilorð"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Krafist er PIN2-númers SIM-korts"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Krafist er PUK2-númers SIM-korts"
+
+#~ msgid "Not found"
+#~ msgstr "Fannst ekki"
+
+#~ msgid "No network service"
+#~ msgstr "Engin netþjónusta"
+
+#~ msgid "Network timeout"
+#~ msgstr "Netkerfi féll á tíma"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS-þjónustur ekki leyfðar"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Reiki er ekki leyft á þessu svæði"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Óskilgreind GPRS-villa"
+
+#~ msgid "No Error"
+#~ msgstr "Engin villa"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Hætt við aðgerð"
+
+#~ msgid "Access denied"
+#~ msgstr "Aðgangi hafnað"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Óþekkt villa"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Birta útgáfunúmer"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Virkja ítarlegan ham"
+
+#~ msgid "Search for the string"
+#~ msgstr "Leita að strengnum"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Birta heiti allra mögulegra spjalda og hætta"
+
+#~ msgid "Panel to display"
+#~ msgstr "Spjald sem á að birta"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[SPJALD] [BREYTA…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Tiltæk spjöld:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Kerfishljóð"
+
+#~ msgid "Light"
+#~ msgstr "Ljóst"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "skjár;læsa;greining;hrun;einka;nýlegt;bráðabirgða;tmp;yfirlit;nafn;"
+#~ "netkerfi;auðkenna;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Fyrirkomulag á skjám"
+
+#~ msgid "Set"
+#~ msgstr "Setja"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Læsa skjánum þínum"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER eða PEM skilríki (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Bark"
+#~ msgstr "Gelt"
+
+#~ msgid "Drip"
+#~ msgstr "Leki"
+
+#~ msgid "Glass"
+#~ msgstr "Gler"
+
+#~ msgid "Sonar"
+#~ msgstr "Sónar"
 
 #~ msgid "Web Links"
 #~ msgstr "Veftenglar"
@@ -8723,17 +8193,11 @@ msgstr "Kerfishljóð"
 #~ msgid "Active Display"
 #~ msgstr "Virkur skjár"
 
-#~ msgid "Display Configuration"
-#~ msgstr "Stillingar skjátækis"
-
 #~ msgid "More Warm"
 #~ msgstr "Hlýrri"
 
 #~ msgid "Less Warm"
 #~ msgstr "Kaldari"
-
-#~ msgid "Screenshots"
-#~ msgstr "Skjámyndir"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "Vista skjámynd í $PICTURES"
@@ -8822,17 +8286,11 @@ msgstr "Kerfishljóð"
 #~ "Skjádeiling gerir fjartengdum notendum kleift að skoða eða stjórna "
 #~ "skjánum þínum með því að tengjast með %s"
 
-#~ msgid "Copy"
-#~ msgstr "Afrita"
-
 #~ msgid "_Screen Sharing"
 #~ msgstr "Deiling á _skjá"
 
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr "Sumar þjónustur eru óvirkar því nettenging er óvirk."
-
-#~ msgid "Screen Sharing"
-#~ msgstr "Deiling á skjá"
 
 #~ msgid "_Password:"
 #~ msgstr "L_ykilorð:"
@@ -8857,9 +8315,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "_Screen Reader"
 #~ msgstr "_Skjálesari"
-
-#~ msgid "_Full Name"
-#~ msgstr "_Fullt nafn"
 
 #~ msgid "Standard"
 #~ msgstr "Staðlað"
@@ -8923,9 +8378,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Teiknitafla (algild)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Snertiplatti (afstætt)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Stillingar teiknitöflu"
@@ -9007,9 +8459,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "Changes throughout the day"
 #~ msgstr "Breytist yfir daginn"
-
-#~ msgid "_Lock Screen"
-#~ msgstr "_Læsa skjá"
 
 #~ msgctxt "background, style"
 #~ msgid "Tile"
@@ -9684,9 +9133,6 @@ msgstr "Kerfishljóð"
 #~ msgid "Co­lor"
 #~ msgstr "Li­tur"
 
-#~ msgid "Section"
-#~ msgstr "Hluti"
-
 #~ msgid "Overview"
 #~ msgstr "Yfirlit"
 
@@ -9768,9 +9214,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "Mirrored"
 #~ msgstr "Speglað"
-
-#~ msgid "Secondary"
-#~ msgstr "Auka"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Hagræða samsettum skjám"
@@ -9912,9 +9355,6 @@ msgstr "Kerfishljóð"
 #~ msgid "4"
 #~ msgstr "4"
 
-#~ msgid "Loading options…"
-#~ msgstr "Hleðsluvalkostir…"
-
 #~ msgctxt "Password hint"
 #~ msgid "Try to add more letters, numbers and symbols."
 #~ msgstr "Reyndu að bæta við fleiri bókstöfum, tölustöfum og táknum."
@@ -9939,9 +9379,6 @@ msgstr "Kerfishljóð"
 #~ msgid "Strength: High"
 #~ msgstr "Styrkur: Mikill"
 
-#~ msgid "Edit"
-#~ msgstr "Breyta"
-
 #~ msgctxt "notifications"
 #~ msgid "Notification _Banners"
 #~ msgstr "Tilkynninga_borðar"
@@ -9954,10 +9391,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "Mail"
 #~ msgstr "Póstur"
-
-#~| msgid "_Calendar"
-#~ msgid "Calendar"
-#~ msgstr "Dagatal"
 
 #~ msgid "Contacts"
 #~ msgstr "Tengiliðir"
@@ -9973,9 +9406,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "Þetta mun ekki fjarlægja aðganginn af miðlaranum."
-
-#~ msgid "_Remove"
-#~ msgstr "Fja_rlægja:"
 
 #~ msgid "No online accounts configured"
 #~ msgstr "Engir aðgangar fyrir net uppsettir"
@@ -10023,9 +9453,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "label"
 #~ msgstr "skýring"
-
-#~ msgid "Setting new driver…"
-#~ msgstr "Set nýjan rekil..."
 
 #~ msgid "Print _Test Page"
 #~ msgstr "Pren_ta prófunarsíðu"
@@ -10105,9 +9532,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Skruna upp"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Skruna niður"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Skruna til hægri"
@@ -10243,9 +9667,6 @@ msgstr "Kerfishljóð"
 #~ msgid "Other"
 #~ msgstr "Annað"
 
-#~ msgid "Personal File Sharing"
-#~ msgstr "Deiling einkagagna"
-
 #~ msgid "_Verify"
 #~ msgstr "_Sannreyna"
 
@@ -10324,9 +9745,6 @@ msgstr "Kerfishljóð"
 #~ msgid "Fast"
 #~ msgstr "Hratt"
 
-#~ msgid "No printers available"
-#~ msgstr "Engir prentarar í boði"
-
 #~ msgid "Resume Printing"
 #~ msgstr "Halda áfram með prentun"
 
@@ -10348,9 +9766,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "Used to determine your geographical location"
 #~ msgstr "Notað til að finna út landfræðilega staðsetningu þína"
-
-#~ msgid "Options"
-#~ msgstr "Valkostir"
 
 #~ msgid "Password:"
 #~ msgstr "Lykilorð:"
@@ -10394,9 +9809,6 @@ msgstr "Kerfishljóð"
 
 #~ msgid "Turns off wireless devices"
 #~ msgstr "Slekkur á þráðlausum tækjum"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "_Afvirkja snertiplatta á meðan skrifað er"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "Netþjónustur kerfisins eru ekki samhæfðar þessari útgáfu."

--- a/po/is.po~
+++ b/po/is.po~
@@ -1,0 +1,11286 @@
+# translation of gnome-control-center.master.is.po to Íslenska
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Áki G. Karlsson  <aki@akademia.is>, 2003.
+# Sveinn í Felli <sv1@fellsnet.is>, 2015, 2016, 2017, 2019, 2021, 2022.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.master.is\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issu"
+"es\n"
+"POT-Creation-Date: 2022-10-24 10:28+0000\n"
+"PO-Revision-Date: 2022-10-25 15:58+0000\n"
+"Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
+"Language-Team: Icelandic\n"
+"Language: is\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PPlural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 21.12.3\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Kerfisbraut"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Fullur aðgangur"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Setubraut"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Tæki"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Fullur aðgangur að /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Netkerfi"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Er með aðgang að netkerfi"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Heim"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Skrifvarið"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Skráakerfi"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Stillingar"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Má breyta stillingum"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s er með eftirfarandi heimildir innbyggðar. Þeim er ekki hægt að breyta. Ef"
+" þú ert með áhyggjur af þessum heimildum, ættirðu að íhuga að fjarlægja þetta"
+" forrit."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u tegund skráagerða og tengla sem þetta forrit opnar"
+msgstr[1] "%u tegundir skráagerða og tengla sem þetta forrit opnar"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> er notað til að opna eftirfarandi skráagerðir og tengla."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s af diskplássi verður notað."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Forrit"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Engin forrit"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Settu upp eitthvað…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Opna"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Skoða nánar"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Leita"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Taka við kerfisleitum og senda niðurstöður."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Óvirkt"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Tilkynningar"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Birta kerfistilkynningar."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Keyra í bakgrunni"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Leyfa virkni þegar forritið er lokað."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Skjámyndir"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Taktu myndir af skjánum hvenær sem er."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Skipta um bakgrunnsmynd"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Skipta um bakgrunnsmyndina á skjáborðinu."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Hljóð"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Framkallaðu hljóð."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Koma í veg fyrir notkun flýtilykla"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Hindra staðlaðar flýtileiðir á lyklaborði"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Myndavél"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Taktu myndir með myndavélinni."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Hljóðnemi"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Taktu upp hljóð í gegnum hljóðnemann."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Staðsetningarþjónustur"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Fá aðgang að staðsetningum tækis."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Innbyggðar heimildir"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Kerfisaðgangur sem þetta forrit krefst"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Vensl skráa og tengla"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Geymsla"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Engar niðurstöður fundust"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Reyndu aðra leit"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Vensl skráa og tengla"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Skráartegundir"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Tegundir tengla"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Endurstilla"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Hversu mikið diskpláss þetta forrit er að notað til að geyma forritsgögn og "
+"hrunupplýsingar."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Forrit"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Gögn"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Skyndiminni"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Samtals</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Hreinsa skyndiminni…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Stýrir ýmsum heimildum og stillingum forrits"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "forrit;flatpak;heimild;stilling;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Veldu mynd"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Hætta við"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Opna"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "margar stærðir"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Enginn skjáborðsbakgrunnur"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Núverandi bakgrunnur"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stíll"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Sjálfgefið"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Dökkt"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Bakgrunnur"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Bæta við mynd…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Útlit"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Breyttu bakgrunnsmyndinni eða litum notandaviðmótsins"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Bakgrunnur;Bakgrunnsmynd;Skjár;Skjáborð;Stíll;Ljóst;Dökkt;Útlit;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Virkja"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Enginn Bluetooth-búnaður fannst"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Settu inn dingul til að nota Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth ekki í gangi"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Kveiktu á til að tengja tæki og stunda skráaskipti."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Flugvélahamur er virkur"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth er óvirkt þegar flugvélahamur er virkur."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Slökkva á flugvélaham"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Vélbúnaðarstuddur flugvélahamur er virkur"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Slökktu á rofanum fyrir flugvélaham til að virkja Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Kveiktu og slökktu á Bluetooth og tengdu tækin þín"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "deila;sameign;tengja;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Slökkt er á myndavél"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Engin forrit geta tekið myndir eða myndskeið."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Heimild til að nota myndavélina gerir forritum kleift að taka myndir og"
+" myndskeið. Sé myndavélin gerð óvirk gætu sum forrit virkað óeðlilega.\n"
+"\n"
+"Leyfðu forritunum hér að neðan að nota myndavélina þína."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Engin forrit hafa beðið um aðgang að myndavél"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Verndaðu myndirnar þínar"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "myndavél;ljósmynd;myndskeið;vefmyndavél;læsing;gagnaleynd;friðhelgi;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Settu litkvörðunartækið yfir ferninginn og ýttu svo á 'Byrja'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Færðu litkvörðunartækið yfir á litkvörðunarstaðinn og ýttu svo á 'Halda "
+"áfram'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Færðu litkvörðunartækið í yfirborðsstöðu og ýttu svo á 'Halda áfram'"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Loka fartölvuloki"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Innri villa kom upp sem ekki var hægt að laga."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Það er ekki búið að setja upp nauðsynleg tól til litkvörðunar."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Ekki var hægt að útbúa litasniðið."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Ekki var hægt að nálgast hvítpunkt úttakstækisins."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Fullklárað!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Litkvörðun mistókst!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Þú getur fjarlægt tæki til litkvörðunar."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ekki trufla litkvörðunartækið á meðan það er að vinna"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Litkvörðun skjátækis"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Byrja"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Halda áfram"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Lokið"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Fartölvuskjár"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Innbyggð vefmyndavél"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s skjár"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s skanni"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s myndavél"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s prentari"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s vefmyndavél"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Virkja litastýringu fyrir %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Birta litasnið fyrir %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Ekki litkvarðað"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Sjálfgefið: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Litavídd: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Prufu prófíll: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Veldu ICC-litasniðskrá"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "Flytja _inn"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Studd ICC litasnið"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Allar skrár"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skjár"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Vista snið"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Vista"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Búa til litasnið fyrir valið tæki"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Mælitækið fannst ekki. Athugaðu hvort kveikt sé á því og hvort það sé rétt "
+"tengt."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Mælitækið styður ekki gerð litasniða fyrir prentara."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Þessi tegund tækis er ekki studd ennþá."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Litkvörðun skjámyndar"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Gæði litkvörðunar"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Litkvörðun mun útbúa litasnið sem þú getur notað til að litastýra skjánum "
+"þínum. Því lengri tími sem þú notar í litkvörðun, því betri verða gæði "
+"litasniðsins."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "þú getur ekki notað tölvuna á meðan litkvörðun fer fram."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Gæði"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Áætlaður tími"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Tæki til litkvörðunar"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Veldu litnematækið sem þú vilt nota við litkvörðun."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tegund skjás"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Veldu tegund skjás sem er tengdur."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Hvítpunktur litasniðs"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Veldu úttakshvítpunkt skjás. Flestir skjáir ættu að vera kvarðaðir til að "
+"nota D65 dagsbirtuhvítpunkt."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Birta skjás"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Stilltu skjáinn á það birtustig sem þú notar venjulega. Litastýring verður "
+"nákvæmust við það birtustig."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Önnur leið er að nota það birtutig sem notað hefur verið með einhverju öðru "
+"af þeim litasniðum sem tækið notar."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Heiti litasniðs"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Þú getur notað litasnið á mismunandi tölvum, eða jafnvel búið til mismunandi "
+"litasnið fyrir ólíka umhverfislýsingu."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Heiti litasniðs:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Samantekt"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Tókst að búa til litasnið!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Afrita litasnið"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Þarfnast skrifanlegs gagnamiðils"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Þú gætir haft gagn af því að skoða þessar leiðbeiningar um hvernig nota eigi "
+"litasniðið á <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> "
+"og <a href=\"windows\">Microsoft Windows</a> kerfum."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Bæta við litasniði"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Vandamál fundust. Ekki er víst að litasniðið virki rétt. <a href=\"\">Sjá "
+"nánar.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "Flytja _inn skrá…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Bæta við"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Hvert tæki þarf nýlega uppfært litasnið til þess að geta verið litastýrt."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Vita meira"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Læra meira um litastýringu"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Stilla fyrir alla notendur"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Setja fyrir alla notendur á þessari tölvu"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "Vir_kja"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Bæt_a við litasniði"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kvarða…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kvarða tækið"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Fja_rlægja litasnið"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "Sjá _nánar"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Fann ekki nein tæki sem hægt er að litastýra"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Skjávarpi"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL baklýsing)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED baklýsing)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (hvít LED baklýsing)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD (Wide Gamut CCFL baklýsing)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD (Wide Gamut RGB LED baklýsing)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Mikil"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 mínútur"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Miðlungs"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 mínútur"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Lítil"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 mínútur"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Sambyggt við skjá"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (prentun og útgáfa)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (ljósmyndun og myndvinnsla)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Stöðluð litrýmd"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Prófunarlitasnið"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Sjálfvirkt"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Lággæða"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Miðlungs gæði"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Hágæða"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Sjálfgefið RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Sjálfgefið CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Sjálfgefið grátóna"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Verksmiðjulitkvörðunargögn frá framleiðanda"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Skjáleiðrétting í heilskjásham er ekki möguleg með þessu litasniði"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Þetta litasnið er kannski ekki lengur mjög nákvæmt"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Litur"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Kvarðaðu liti tækja á borð við skjái, myndavélar, skanna eða prentara"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Litur;ICC;Litasnið;Litkvörðun;Prentari;Skjár;Nákvæmni;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Annað…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Veldu tungumál"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Velja"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Engin tungumál fundust"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Meira…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Aflæstu til að breyta stillingum"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Aflæsa þarf sumum stillingum áður en að hægt er að breyta þeim."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Aflæsa…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Bæta við klukkustundum"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Bæta við mínútum"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Tími"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Fækka klukkustundum"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Fækka mínútum"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Í dag"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "í gær"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d klukkustund"
+msgstr[1] "%d klukkustundir"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d mínúta"
+msgstr[1] "%d mínútur"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekúnda"
+msgstr[1] "%d sekúndur"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekúndur"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Tengipunktur (hotspot)"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-tíma"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "FH / EH"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Dagsetning og tími"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Ár"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mánuður"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Janúar"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Febrúar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Mars"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Apríl"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maí"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Júní"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Júlí"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Ágúst"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Október"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Nóvember"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Desember"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dagur"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Tímabelti"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Leita að borg"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Sjálfvirk _dagsetning og tími"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Krefst internetaðgangs"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Dagsetning og _tími"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Sjálfvirkt tíma_belti"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+"Krefst þess að staðsetningarþjónustur séu virkar og þarfnast internetaðgangs"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Virkt"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Tíma_belti"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Tí_masnið"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Breyttu dagsetningu og tíma, þar með töldu tímabelti"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Klukka;Tímabelti;Staðsetning;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Breyta tíma og dagsetningarstillingum"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Til að breyta stillingum varðandi dagsetningu og tíma, þarft þú að auðkenna "
+"þig."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Vefur"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "Tölvu_póstur"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Dagatal"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Tónlist"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Myndskeið"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Myndir"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Sjálfgefin forrit"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Stilla sjálfgefin forrit"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "sjálfgefið;forrit;gagnamiðill;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Ef þú sendir okkur upplýsingar um tæknileg vandamál hjálpar okkur að bæta %s "
+"hugbúnaðinn. Skýrslur eru sendar nafnlaust og eru hreinsaðar af "
+"persónugreinanlegum gögnum. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Tilkynningar um vandamál"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Tilkynn_a sjálfkrafa um vandamál"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Greining vandamála"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Tilkynntu vandamál"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "greining;vandamál;hrun;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Nota"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Nota ekki"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Virkja breytingar?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Ekki var hægt að framkvæma breytingar"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Þetta gæti verið vegna takmarkana í vélbúnaði."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Virkja"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Til baka"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Stillingar skjás eru óvirkar"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Margir skjáir"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Setja saman"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Spegla"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Inniheldur toppstiku og virkni"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Aðalskjár"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Næturlýsing"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Lárétt"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Lóðrétt hægri"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Lóðrétt vinstri"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Lárétt (flett)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Stefna"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Upplausn"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Uppfærslutíðni"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Aðlaga fyrir sjónvarp"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Kvarða"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Næturlýsing ekki tiltæk"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Þetta gæti verið af völdum þess hvaða skjákortsrekill er notaður, eða að"
+" skjáborðið sé notað fjartengt"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Tímabundið óvirkt þar til á morgun"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Endurræsa síu"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Næturlýsing stillir skjáinn á hlýrri liti. Þetta getur hjálpað til við að "
+"minnka þreytu í augum og svefntruflanir."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Áætlun"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Sólarlag til sólarupprásar"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Áætla handvirkt"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Tími"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Frá"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Klukkustund"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Mínúta"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "f.h."
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "e.h."
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Til"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Hitastig litar"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Skjáir"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Veldu hvernig nota eigi tengda skjái og myndvarpa"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Spjald;Skjávarpi;xrandr;Skjár;Skjáupplausn;Uppfærslutíðni;Gluggi;Nótt;nætur;"
+"ljós;litur;lýsing;sólarlag;sólarupprás;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Kveikt er á Secure Boot ræsingu"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Secure Boot kemur í veg fyrir að spilliforritum sé hlaðið inn við ræsingu"
+" tækis. Í augnablikinu er kveikt á því og það virkar rétt."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Vandamál í Secure Boot ræsingu"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Slökkt er á Secure Boot ræsingu"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Stóðst prófun"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Mistókst"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Tæki samsvarar HSI-stigi %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Öryggisstig 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Öryggisstig 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Öryggisstig 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Öryggisstig 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Öryggisstig"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Öryggisstig eru ekki tiltæk fyrir þetta tæki."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Stig 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Stig 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Stig 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Varið gegn spillihugbúnaði þegar tækið ræsist."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Vandamál í Secure Boot ræsingu"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Nokkur vörn þegar tæki er ræst."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Slökkt er á Secure Boot ræsingu"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Engin vörn þegar tæki er ræst."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Berskjaldað fyrir alvarlegum öryggisógnum."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Takmörkuð vörn gegn einföldum öryggisógnum."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Varið gegn algengum öryggisógnum."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Varið gegn margvíslegum öryggisógnum."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Alhliðavörn (Comprehensive Protection)"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Engir atburðir"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection"
+msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection Lock"
+msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Region"
+msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Descriptor"
+msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "DMA-vörn for-ræsingar"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard Verified Boot"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM Protected"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Stefna Intel BootGuard varðandi villur"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard Fuse"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET er virkjað"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET virkt"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Dulritað RAM-vinnsluminni"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU-vörn"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Fastlæsing Linux-kjarna"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Sannvottun Linux-kjarna"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Swap-diskminni"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Svæfa í minni (RAM)"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Setja í bið í minni (RAM)"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI-kerfislykill"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI Secure Boot"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+#, fuzzy
+#| msgid "Display Configuration"
+msgid "TPM Platform Configuration"
+msgstr "Stillingar skjátækis"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM-endurbygging"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Uppfærslur á fasthugbúnaði (firmware)"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Attestation"
+msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Updater Verification"
+msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Villukembing stýrikerfis"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Öryggisprófanir á örgjörva"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "AMD Firmware Replay Protection"
+msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "AMD Firmware Write Protection"
+msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr ""
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Gilt"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Ekki gilt"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Ekki virkt"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Læst"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Ekki læst"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Dulritað"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Ekki dulritað"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr ""
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+#, fuzzy
+#| msgid "Not calibrated"
+msgid "Not Tainted"
+msgstr "Ekki litkvarðað"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Fannst"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Fannst ekki"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Með stuðning"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Ekki stutt"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Öryggistæki"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Staða öryggis á fasthugbúnaði hýsivélar"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"skjár;læsa;greining;hrun;einka;nýlegt;bráðabirgða;tmp;yfirlit;nafn;netkerfi;"
+"auðkenna;gagnaleynd;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Óþekkt"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bita"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bita"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Óþekkt"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Ekki tiltækt"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Táknmerki kerfis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Heiti tækis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Tegund vélbúnaðar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Minni"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Örgjörvi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Myndefni"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Rýmd disks"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Reikna…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nafn stýrikerfis"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Byggingarauðkenni stýrikerfis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tegund stýrikerfis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME útgáfa"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Hleð inn..."
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Gluggakerfi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Sýndarvélar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Hugbúnaðaruppfærslur"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Endurnefna tæki"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Nafn tækisins er notað til að auðkenna tækið á netkerfinu, eða þegar verið "
+"er að para það við önnur Bluetooth-tæki."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Heiti tækis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "Endu_rnefna"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Um hugbúnaðinn"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Skoðaðu upplýsingar um kerfið þitt"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"tæki;kerfi;upplýsingar;minni;örgjörvi;útgáfa;sjálfgefið;forrit;valið;cd;dvd;"
+"usb;hljóð;mynd;disk;útskiptanlegt;miðill;sjálfræsing;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Hljóð og mynd"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Þagga / kveikja á hljóði"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Lækka hljóðstyrk"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Hækka hljóðstyrk"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Þagga / kveikja á hljóðnema"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Ræsa margmiðlunarspilara"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Spila (eða spila/setja í bið)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Gera hlé á afspilun"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Stöðva afspilun"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Fyrra spor"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Næsta spor"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "_Spýta út"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Innsláttur"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Skipta á næsta innsetningarreit"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Skipta á fyrri innsetningarreit"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Forritaræsar"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Ræsa hjálparvafra"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Ræsa reiknivél"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Ræsa póstforrit"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Ræsa netvafra"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Heimamappa"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Leita"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Kerfið"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Skrá út"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Læsa skjá"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Aukið aðgengi"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Aðdráttur af eða á"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Renna að"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Renna frá"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Skjálesari af eða á"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Skjályklaborð af eða á"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Auka stærð texta"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Minnka stærð texta"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Hábirtuskil af eða á"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Engir inntaksgjafar fundust"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Annað"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Veldu inntaksgjafa"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Aðrar innsláttaraðferðir er ekki hægt að nota í innskráningarglugga"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Enginn inntaksgjafi valinn"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Valkostir"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Færa upp"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Færa niður"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Stillingar"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Skoða lyklaborðsuppsetningu"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Fjarlægja"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Sérsniðinn flýtilykill"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Vara-stafalykill (AltCharKey)"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Vara-stafalykilinn er hægt að nota til að setja inn viðbótar-staftákn. Þau "
+"eru stundum prentuð sem þriðji valmöguleiki á lyklaborðum."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Vinstri Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Hægri Alt-lykill"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Vinstri breytilykill"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Hægri breytilykill"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Valmyndarlykill"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Hægri Ctrl-lykill"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Samsetningarlykill"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Samsetningarlykillinn (compose key) gerir kleift að setja inn margvíslega "
+"stafi Hann er notaður með því að ýta á hann og síðan á runu af öðrum "
+"staftáknum.  Til dæmis, sé samsetningarlykli fylgt með <b>C</b> og <b>o</b> "
+"er sett inn <b>©</b> merki, <b>a</b> fylgt með <b>'</b> setur inn <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "CapsLock-hástafalás"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "ScrollLock-skrunlæsing"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Hægt er að skipta um inntaksgjafa með %s flýtilyklinum.\n"
+"Þessu er hægt að breyta í stillingum fyrir flýtivísanir lyklaborðs."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Inntaksgjafar"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Innifelur lyklaborðsuppsetningar og inntaksleiðir."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Skipta um inntaksgjafa"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Nota _sama inntaksgjafa fyrir alla glugga"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Skipta um _inntaksgjafa fyrir hvern glugga"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Innsetning sértákna"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Aðferðir til að setja inn tákn og stafatilbrigði með lyklaborðinu."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Flýtilyklar"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Skoða og sérsníða flýtileiðir á lyklaborði"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d breytt"
+msgstr[1] "%d breytt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Frumstilla alla flýtilykla?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Frumstilling flýtilykla gæti haft áhrif á sérsniðna flýtilykla sem þú hefur "
+"stillt. Ekki er hægt að taka þetta aftur."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Hætta við"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Frumstilla allt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Frumstilla allt…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Endurstilla alla flýtilykla á upprunaleg gildi þeirra"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Hluti"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Flýtilyklar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Bæta við flýtilykli"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Bæta við sérsniðnum flýtilyklum"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Settu upp sérsniðna flýtilykla til að ræsa forrit, keyra skriftur og "
+"ýmislegt fleira."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Bæta við flýtilykli"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Enginn flýtilykill fannst"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s er nú þegar í notkun fyrir %s. Ef þú skiptir því út, verður %s gert óvirkt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Settu inn nýjan flýtilykil"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Setja sérsniðinn flýtilykil"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Setja flýtilykil"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Settu inn nýjan flýtilykil til að breyta %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Bæta við sérsniðnum flýtilykli"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Fja_rlægja:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Ski_pta út"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Setja"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Ýttu á Esc til að hætta við eða á Backspace til að gera flýtilykilinn "
+"óvirkan."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Heiti"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Skipun"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Flýtilykill"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Setja flýtilykil…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ekkert"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Endurstilla flýtilykilinn á sjálfgefin gildi"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Lyklaborð"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Breyta flýtileiðum á lyklaborði og setja valkosti við stafainnsetningu, "
+"lyklaborðsframsetningu og inntaksleiðir"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Flýtilykill;Vinnusvæði;Gluggi;Stærð;Aðdráttur;Birtuskil;Inntak;Uppruni;Læsa;"
+"Hljóðstyrkur;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Slökkt er á staðsetningarþjónustum"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Engin forrit geta notað staðsetningarupplýsingar."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Staðsetningarþjónustur gera forritum kleift að finna út staðsetninguna þína. "
+"Notkun á þráðlausu WiFi og ferðabreiðbandi eykur nákvæmnina.\n"
+"\n"
+"Notar staðsetningarþjónustu Mozilla: <a href='https://location.services."
+"mozilla.com/privacy'>Meðferð persónuupplýsinga</a>\n"
+"\n"
+"Leyfðu forritunum hér fyrir neðan að fá upplýsingar um staðsetninguna þína."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Engin forrit hafa beðið um aðgang að staðsetningu"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Verndaðu upplýsingar um staðsetningu þína"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "staðsetning;gps;gagnaleynd;friðhelgi;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Slökkt er á hljóðnema"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Engin forrit geta tekið upp hljóð."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Engin forrit hafa beðið um aðgang að hljóðnema"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Verndaðu samskiptin þín"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "hljóðnemi;upptaka;forrit;gagnaleynd;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Prófa _stillingarnar þínar"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Almennt"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Aðalhnappur"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Stillir uppröðun hnappa á mús eða snertiplatta"
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Vinstri"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Hægri"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mús"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Hraði músar"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Eðlilegt skrun"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Skrun færir til innihaldið, ekki sýnina."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Snertiplatti"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Hraði snertiplatta"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Sláðu á til að smella"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Pikkaðu til að smella"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Tveggja-fingra skrun"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Skrun á jöðrum"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Prófaðu að smella, tvísmella, skruna"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Fimm smellir, tími fyrir GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Tvísmella, aðalhnappur"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Einsmella, aðalhnappur"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Tvísmella, miðhnappur"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Einsmella, miðhnappur"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Tvísmella, aukahnappur"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Einsmella, aukahnappur"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mús og snertiplatti"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "Breyttu næmni músar eða snertiplatta og veldu rétt- eða örvhent"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Snertiplatti;Bendill;Smella;Slá;Tvísmella;Hnappur;Bendilkúla;Skrun;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Virkni_horn"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Ýttu á hornið efst til vinstri til að opna aðgerðayfirlitið."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Virkir skjáj_aðrar"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Vinnusvæði"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Breytilegur földi vinnusvæða"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Fjarlægir tóm vinnusvæði sjálfkrafa."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Fastur fjöldi vinnusvæða"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Tilgreindu fjölda varanlegra vinnusvæða."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Fjöldi vinnusvæða"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Margir skjáir"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Vinnusvæði eingöngu á _aðalskjá"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "V_innusvæði á öllum skjám"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Skipting milli forrita"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Hafa með forrit frá öllum _vinnusvæðum"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "_Hafa einungis með forrit frá virku vinnusvæði"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Fjölverkavinnsla"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Úbbs! Eitthvað hefur farið úrskeiðis núna. Hafðu samband við höfunda "
+"hugbúnaðarins."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager netstjórinn verður að vera í gangi."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Önnur tæki"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Bæta við tengingu"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Ekki uppsett"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Ótryggt netkerfi (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Öruggt netkerfi (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Öruggt netkerfi (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Öruggt netkerfi (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Öruggt netkerfi"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Tengt"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Valkostir…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Má að hámarki hafa %d staf"
+msgstr[1] "Má að hámarki hafa %d stafi"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Kveikja á þráðlausum Wi-Fi tengipunkti?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Heiti netkerfis"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Lykilorð"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Útbúa slembilykilorð"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Útbúa sjálfvirkt lykilorð"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Kveikja á"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Þráðlaust net"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Stöðva tengipunkt og aftengja alla notendur?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Stöðva tengipunkt"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Flugvélahamur"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Gerir Wi-Fi, Bluetooth og ferðabreiðband óvirk"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Engin Wi-Fi netkort fundust"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Gangtu úr skugga um að Wi-Fi netkortið sé tengt og að kveikt sé á því"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Flugvélahamur virkur"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Slökktu til að nota Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Þráðlaus Wi-Fi-tengipunktur virkur"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Snjalltæki geta skannað QR-kóðann til að tengjast."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Slökkva á þráðlausum Wi-Fi tengipunkti…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Sýnileg netkerfi"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager netstjórinn verður að vera í gangi"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x öry_ggi"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Öryggi"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Varðveita"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Varanlegt"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Slembið"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stöðugt"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"MAC-vistfangið sem sett er inn hér verður notað sem vélbúnaðarvistfang fyrir "
+"nettækið sem þessi tenging er virkjuð á.  Sú aðgerð er þekkt undir nafninu "
+"MAC-klónun eða vélarstuldur.  Dæmi: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Snið %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Fyrirtækis"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ekkert"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Aldrei"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "fyrir %i degi síðan"
+msgstr[1] "fyrir %i dögum síðan"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/sek"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Ekkert"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Veikt"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Í lagi"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Gott"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Frábært"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 vistfang"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 vistfang"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP vistfang"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Gleyma tengingu"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Fjarlægja tengisnið"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Fjarlægja VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Nánar"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "sjálfvirkt"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Auðkenni"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Eyða vistfangi"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Eyða beiningu (route)"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ekkert"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit lykill (Hex eða ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit lykilsetning"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Breytilegt (dynamic) WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA og WPA2 einka"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA og WPA2 fyrirtækja"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 einka"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Styrkur merkis"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Hraði tengis"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Vistfang vélbúnaðar"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Studdar tíðnir"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Sjálfgefin tengileið (route)"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Síðast notað"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Tengjast _sjálfkrafa"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Gera aðgengilegt öðrum n_otendum"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Mæld tenging: er með takmörk á gagnamagni eða getur haft kostnað í för með"
+" sér"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Heiti"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC vistfang"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klónað vistfang"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bæti"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 aðferð"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Sjálfvirkt (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Einungis staðvær tengi (link-local)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Handvirkt"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Gera óvirkt"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Samnýtt með öðrum tölvum"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Vistföng"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Vistfang"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Nethula (netmask)"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Netgátt (gateway)"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Sjálfvirkt"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Sjálfvirkt DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Vistföng DNS-þjóna"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Aðskildu IP-vistföng með kommum"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Beiningar"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Sjálfvirk beining"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Leiðargæði (metric)"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Nota þessa tengingu einungis fyrir efni af sínu eigin neti"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 aðferð"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Sjálfvirkt, aðeins DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Forskeyti"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Get ekki opnað tengingaritil"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Nýtt snið"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Ógild stilling %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Ógild stilling %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Flytja inn úr skrá…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Bæta við VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Öry_ggi"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Get ekki flutt inn VPN-nettengingu"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Skráin '%s' var ekki lesanleg eða að hún inniheldur ekki þekkjanlegar VPN "
+"tengiupplýsingar\n"
+"\n"
+"Villa: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Veldu skrá til að flytja inn"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Skrá með heitinu '%s' er þegar til."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Skipta út"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Viltu skipta %s út fyrir VPN-nettenginguna sem þú ert að vista?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Get ekki flutt út VPN-nettengingu"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Ekki var hægt að flytja út VPN tenginguna '%s' til %s.\n"
+"\n"
+"Villa: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Flytja út VPN-nettengingu"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Villa: tókst ekki að hlaða inn ritli fyrir VPN-tengingar)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Stjórnaðu hvernig þú tengist internetinu"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Netkerfi;þráðlaust;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;breiðband;internet;mótald;"
+"Bluetooth;vpn;vlan;bridge;bond;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Stjórnaðu hvernig þú tengist þráðlausum Wi-Fi netkerfum"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Netkerfi;þráðlaust;Wi-Fi;Wifi;IP;LAN;breiðband;internet;mótald;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "aldrei"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "í dag"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "í gær"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Síðast notað"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Um kapal"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Bæta við nýrri tengingu"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Upplýsingar um valin netkerfi munu tapast, þar með talið lykilorð og aðrar "
+"sérsniðnar stillingar."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Gleyma"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Þekkt Wi-Fi netkerfi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Gleyma"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Kerfisheimildir heimila ekki notkun sem tengipunkts"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Þráðlaust tæki styður ekki tengipunkts-ham (hotspot)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Sjálfvirk leit með Web Proxy Autodiscovery er notað þegar stillingavistfang "
+"(configuration URL) er ekki gefið upp."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Ekki er mælt með þessu fyrir ótreyst almenningsnet."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Slökkva á tæki"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Virkt"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Þjónustuveita"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Milliþjónn, vefsel"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP milliþjónn (vefsel)"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS  milliþjónn (vefsel)"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP  milliþjónn"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_SOCKS miðlari"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Hunsa vélar (hosts)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Gátt HTTP milliþjóns (vefsels)"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Gátt HTTPS milliþjóns (vefsels)"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Gátt FTP milliþjóns"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Gátt Socks milliþjóns"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "S_lóð stillinga"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Slökkva á VPN-nettengingu"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Heiti netkerfis"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tegund öryggis"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Lykilorð"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Slökkva á þráðlausu neti"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Fleiri valkostir…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "Tengjast _földu netkerfi…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Kveikja á þráðlausum Wi-Fi tengipunkti…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Þe_kkt Wi-Fi netkerfi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Staða óþekkt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Óstýrt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Ekki tiltækt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Tengist"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Auðkenningar krafist"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Aftengist"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Tenging mistókst"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Staða óþekkt (vantar)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Stillingar brugðust"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP-stillingar brugðust"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP-stillingar úreltar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Dulritunarupplýsinga var krafist en virðast ekki koma fram"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x biðill ótengdur"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Stillingar 802.1x biðils brugðust"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x biðill brást"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x biðill var of lengi að auðkenna"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP þjónusta gat ekki hafist"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP þjónusta aftengd"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP brást"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP biðlari ræstist ekki"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Villa í DHCP biðlara"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP biðlari brást"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Þjónusta sameiginlegra tenginga ræstist ekki"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Þjónusta sameiginlegra tenginga brást"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP þjónusta ræstist ekki"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Villa í AutoIP þjónustu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP þjónusta brást"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Línan upptekin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Enginn sónn"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Ekki tókst að koma á tengingu."
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Hringing rann út á tíma"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Tilraun til tengingar mistókst"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Frumstilling mótalds mistókst"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Ekki tókst að velja tiltekið APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Ekki að leita að netkerfum"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Skráningu á netkerfi hafnað"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Skráning á netkerfi rann út á tíma"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Mistókst að skrá inn á umbeðið netkerfi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Athugun á PIN mistókst"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Grunnhugbúnað (firmware) tækis gæti vantað"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Tenging hvarf"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Gert var ráð fyrir tengingu sem þegar er til staðar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Mótald fannst ekki."
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth-tenging brást"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM-kort ekki til staðar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Krafist er PIN-númers SIM-korts"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Krafist er PUK-númers SIM-korts"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Rangt SIM-kort"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Það tókst ekki að uppfylla allar kerfiskröfur fyrir tengingu"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "grunnhugbúnað vantar (firmware)"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "kapall ekki tengdur"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "óskilgreind villa í öruggu 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "engin skrá valin"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "óskilgreind villa við sannvottun á eap-method skrá"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 eða PGP-einkalyklar"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER eða PEM skilríki"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "vantar EAP-FAST PAC skrá"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC skrár (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Nafnlaust"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Auðkennt"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Bæði"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_Nafnlaust auðkenni"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _skrá"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Veldu PAC-skrá"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Innri auðkenning"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Leyfa sjálfvirka PAC _veitingu (provisioning)"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "vantar EAP-LEAP notandanafn"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "vantar EAP-LEAP lykilorð"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Notan_danafn"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "Lykil_orð"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Birta lykilorð"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "ógilt EAP-PEAP CA skilríki: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "ógilt EAP-PEAP CA skilríki: ekkert skilríki tiltekið"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Útgáfa 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Útgáfa 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A skilríki"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Velja skilríki frá vottunarstöð (CA)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "CA skilríkis e_r ekki krafist"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_PEAP útgáfa"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "vantar EAP notandanafn"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "vantar EAP lykilorð"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "vantar EAP-TLS auðkenni"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "ógilt EAP-TLS CA skilríki: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "ógilt EAP-TLS CA skilríki: ekkert skilríki tiltekið"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "ógildur EAP-TLS einkalykill: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "ógilt EAP-TLS notanda-skilríki: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Ódulritaðir einkalyklar eru óöruggir"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Valinn einkalykill lítur ekki út fyrir að vera varinn af lykilorði. Þetta "
+"gæti sett öryggi þitt í hættu.  Endilega veldu einkalykil sem varinn er af "
+"lykilorði.\n"
+"\n"
+"(Þú getur sett lykilorð á einkalykla með openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Veldu þitt einkaskilríki"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Veldu þinn einkalykil"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Auðkenni"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Skilríki notanda"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Ein_kalykill"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Lykilorð einkalykils"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "ógilt EAP-TTLS CA skilríki: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "ógilt EAP-TTLS CA skilríki: ekkert skilríki tiltekið"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (ekkert EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Lén"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Óþekkt villa við að sannreyna 802.1x öryggi"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunneled TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Varið EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Auðkenning"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Veldu skrá"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "vantar leap-notandanafn"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "vantar leap-lykilorð"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Wi-Fi lykilorð vantar."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tegund:"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "vantar wep-lykil"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"ógildur wpa-key: lykill með lengdina %zu verður að innihalda eingöngu hex-"
+"tölustafi"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"ógildur wpa-key: lykill með lengdina %zu verður að innihalda eingöngu ascii-"
+"stafi"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"ógildur wpa-key: ógild lengd lykils %zu. Lykill verður að vera með lengd "
+"5/13 (ascii) eða 10/26 (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "ógildur wep-key: lykilfrasi má ekki vera tómur"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "ógildur wep-key: lykilfrasi verður að vera styttri en 64 stafir"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (sjálfgefið)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Opið kerfi"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Dreifilykill"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Lykill"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Birta lykil"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP l_ykilnúmer"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"ógilt wpa-psk: ógild lengd lykils %zu. Verður að vera [8,63] bæti eða 64 hex "
+"tölustafir"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "ógilt wpa-psk: get ekki túlkað lykil með 64 bætum sem hex"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Til_kynningar"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Hljóðviðv_aranir"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Til_kynningar í sprettgluggum"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Tilkynningar munu halda áfram að birtast í tilkynningalistanum þó svo "
+"sprettgluggar séu óvirkir."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Birta _innihald skilaboða í sprettgluggum"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Tilkynningar um _læsingu skjás"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Sýna innihald skilab_oða á læstum skjá"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Ekki trufla"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Tilkynningar um _læsingu skjás"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Stjórnaðu hvaða tilkynningar eru birtar og hvað þær innihalda"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Tilkynningar;Borði;Skilaboð;Kerfisbakki;Sprettgluggi;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Annað"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s fjarlægt"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Villa við að fjarlægja notandaaðgang"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Afturkalla"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Loka tilkynningunni"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Tengstu gögnunum þínum í tölvuskýi"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Engin internettenging — tengstu því til að setja upp nýja nettengda "
+"notendaaðganga"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Bæta við notandaaðgangi"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Aðgangur %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Fjarlægja notandaaðgang"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Aðgangar á neti"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Tengstu notandaaðgöngum þínum á netinu og ákveddu til hvers eigi að nota þá"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Vefur;Netið;Spjall;Dagatal;Póstur;Tengiliðir;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Óþekktur tími"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i mínúta"
+msgstr[1] "%i mínútur"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i klukkustund"
+msgstr[1] "%i klukkustundir"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "klukkustund"
+msgstr[1] "klukkustundir"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "mínúta"
+msgstr[1] "mínútur"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s þar til rafhlaðan er fullhlaðin"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Varúð: %s eftir"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s eftir"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Full hleðsla"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Ekki í hleðslu"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Tóm"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Í hleðslu"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Afhleðst"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Þráðlaus mús"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Þráðlaust lyklaborð"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "UPS varaaflgjafi"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "PDA lófatölva"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Farsími"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Margmiðlunarspilari"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Spjaldtölva"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Tölva"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Leikjainntakstæki"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Rafhlaða"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Aðal"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Auka"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Rafhlöður"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Við _iðjuleysi"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Setja í bið"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Slökkva"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Leggja í dvala"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ekkert"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Þegar notað er afl frá rafhlöðum"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Þegar vélin er í sambandi"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Aldrei"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Hætta sjálfvirkt"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Orkusparnaðarhamur virkjaður af “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Afkastahamur virkjaður af “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 mínútur"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "40 mínútur"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 mínútur"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 mínútur"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 mínútur"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 klukkustund"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 mínútur"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 mínútur"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 mínútur"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 klukkustundir"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Orkusparnaðarhamur"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Hefur áhrif á kerfisafköst og orkunotkun."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Valkostir orkustýringar"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Sjálfvirkt birtustig skjás"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Birta skjás aðlagast umhverfislýsingu."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Dimma skjá"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Minnkar birtustig skjásins þegar tölvan er aðgerðarlaus."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Tæma skjá"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Slekkur á skjánum eftir tímabil aðgerðarleysis."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Sjálfvirkur orkusparnaður"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Virkjar orkusparnaðarham þegar lítið er eftir á rafhlöðunni."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "Setja sjálfvirkt í bið"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Setur tölvuna í bið eftir tímabil aðgerðarleysis."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Hegðun K_veikja/Slökkva-hnapps"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Sýna hleðslu rafhlöðu í _prósentum"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Hætta sjálfvirkt"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Í sam_bandi"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Notar afl frá _rafhlöðum"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Seinkun"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Afköst"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Mikil afköst og orkunotkun."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Jafnvægi"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Venjuleg afköst og orkunotkun."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Orkusparnaður"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Minnkuð afköst og orkunotkun."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Aflstjórnun"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Skoða ástand rafhlöðu og sýsla með orkustillingar"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"orka;svæfa;bið;dvali;rafhlaða;birta;dimma;slökkva;skjár;DPMS;afl;iðjulaus;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Prentaranum “%s” hefur verið eytt"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Mistókst að bæta við nýjum prentara"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Gat ekki hlaðið inn ui-viðmóti: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Prentarar"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Bættu við prenturum, skoðaðu prentverk og veldu hvernig þú vilt haga prentun"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Prentari;prentröð;Prentun;Pappír;blek;prentduft;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Bæta við prentara"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Aflæsa"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Engir prentarar fundust"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Settu inn netfang eða leitaðu að prentara"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Auðkenningar krafist"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Settu inn notandanafn og lykilorð til að skoða prentara á prentþjóninum."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Notandanafn"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Nánar um %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Enginn hentugur rekill fannst"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Veldu PPD-skrá"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript prentlýsingarskrár (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Heiti prentara mega ekki innihalda BIL, DÁLKMERKI (TAB), # eða /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Staðsetning"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Rekill"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Leitað að reklum sem mælt er með…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Leita að reklum"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Veldu úr gagnagrunni…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Setja upp PPD-skrá…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Veldu prentrekil"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Hleð inn gagnagrunni um rekla…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Velja"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect prentari"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD prentari"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Einhliða"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Langhlið (venjulegt)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Styttri brún (snúið)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Lóðrétt"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Lárétt"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Öfugt lárétt"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Öfugt lóðrétt"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Halda áfram"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Í bið"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Í bið"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Í bið"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Auðkenningar krafist"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Í vinnslu"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Stöðvað"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Hætt við"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Farið út úr"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Lokið"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Færa þetta verk fremst í biðröð"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u verk krefst auðkenningar"
+msgstr[1] "%u verk krefjast auðkenningar"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — virk verk"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Settu inn auðkenni til að prenta á %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Lén"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_uðkenna"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Hreinsa allt"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Heimila"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Engin virk prentverk"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Aflæsa prentþjóni"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Aflæsa %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Settu inn notandanafn og lykilorð til að skoða þá prentara sem eru tiltækir "
+"á %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Leita að prenturum"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Raðtengi (serial)"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Hliðtengi (parallel)"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Staður: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Vistfang: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Miðlari krefst auðkenningar"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Tvíhliða"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tegund pappírs"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Uppruni pappírs"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Úttaksbakki"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Upplausn"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Ghostscript forsíun"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Blaðsíður á hverja hlið"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Tvíhliða"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Stefna"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Almennt"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Uppsetning síðu"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Uppsetjanlegir hlutir"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Verk"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Myndgæði"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Litur"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Klára"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Nánar"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Prófunarsíða"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Prófunarsíða"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Velja sjálfvirkt"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Sjálfgefnar stillingar prentara"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Ígræða einungis GhostScript letur"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Breyta í PS-stig 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Breyta í PS-stig 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Engin forsíun"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Framleiðandi"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Engin virk prentverk"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u verk"
+msgstr[1] "%u verk"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Hreinsa prenthausa"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Lítið prentduft"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Búinn með prentduft"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Lítill framköllunarvökvi"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "marker supplyframköllunarvökvann"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Lítið eftir á fyllingu"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Búinn með fyllingu"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Opna lok"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Opna hlera"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Lítill pappír eftir"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Pappírslaus"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Ótengdur"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Stöðvaður"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Ruslabakki næstum fullur"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Ruslabakki fullur"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Prentkassettan er komin að lokum líftíma síns"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Prentkassettan virkar ekki lengur"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Tilbúinn"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Tekur ekki við verkum"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Í vinnslu"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Valkostir prentunar"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Nánar um prentara"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Nota prentara sjálfgefið"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Hreinsa prenthausa"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Fjarlægja prentara"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Gerð"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Staða bleks"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Endurræstu þegar vandamálið er leyst."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Endurræsa"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Bæta við prentara…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Engir prentarar"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Því miður! Prentþjónusta kerfis\n"
+"virðist ekki vera tiltæk."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Snið"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Leita að staðfærslum..."
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Algeng snið"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Öll snið"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Engar leitarniðurstöður"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Leitir geta verið að löndum eða tungumálum."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Forskoðun"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Breskt kerfi"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrakerfi"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Dagsetningar"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dagsetningar og tími"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Tölustafir"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mælieiningar"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Pappír"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Tungumál og snið munu breytast eftir næstu innskráningu"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Útskráning…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Aðgangurinn þinn"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "Tungumá_l"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "S_nið"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Innskráningarskjár"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Land & tungumál"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Veldu tungumálið sem þú vilt nota fyrir skjáviðmót og snið"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Tungumál;Framsetning;Lyklaborð;Inntak;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Spyrja hvað skuli gera"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Gera ekkert"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Opna möppu"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Aðrir miðlar"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Veldu forrit fyrir CD-hljóðdiska"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Veldu forrit fyrir DVD-mynddiska"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Veldu forrit til að keyra þegar tónlistarspilari er tengdur"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Veldu forrit til að keyra þegar myndavél er tengd"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Veldu forrit fyrir CD-diska með hugbúnaði"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD hljóðdiskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "tómur Blu-Ray diskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "tómur CD geisladiskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "tómur DVD mynddiskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "tómur HD DVD diskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-Ray mynddiskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "rafbókalesari"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD mynddiskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD mynddiskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "CD Super Video mynddiskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD mynddiskur"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows hugbúnaður"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Veldu hvernig miðlar skuli meðhöndlaðir"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _hljóðdiskar"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD mynddiskar"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Tónlistarspilari"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "Hug_búnaður"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Aðrir miðlar…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "Aldrei se_nda áminningu eða ræsa forrit þegar miðlar tengjast tölvunni"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Veldu hvernig meðhöndla skuli aðra miðla"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "Aðgerð"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Gerð:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Fjarlæganlegir miðlar"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Stillingar útskiptanlegra gagnamiðla"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"tæki;kerfi;sjálfgefið;forrit;valið;cd;dvd;usb;hljóð;mynd;disk;útskiptanlegt;"
+"miðill;sjálfræsing;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Skjár slekkur á sér eftir"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekúndur"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 mínúta"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 mínútur"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 mínútur"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 mínútur"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 mínútur"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 klukkustund"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 mínúta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 mínútur"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 mínútur"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 mínútur"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 mínútur"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 mínútur"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 mínútur"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 mínútur"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 mínútur"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Aldrei"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Skjálæsing"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Töf áður en skjár er tæmdur"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Tímamörk aðgerðarleysis áður en skjárinn tæmist."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Sjálfvirk skjá_læsing"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Töf fyrir _sjálfvirka skjálæsingu"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Birta tilkynningar á læsiskjá"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Banna ný _USB-tæki"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Koma í veg fyrir að ný USB-tæki eigi í samskiptum við kerfið þegar skjárinn "
+"er læstur."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Gagnaleynd á skjá"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Takmarka skoðunarhorn"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Skjástillingar"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Veldu staðsetningu"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "Í _lagi"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Staðsetningar sem leitað er í"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Staðir"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Bókamerki"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Aðrir"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Bæta við staðsetningu"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Engin forrit fundust"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Leit í forritum"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Hafa með leitarniðurstöður úr forritum."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Leitarniðurstöður"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "Stjórnaðu hvaða forrit birta leitarniðurstöður í virkniyfirlitinu"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Leita;Finna;Yfirlit;Fela;Gagnaleynd;Niðurstöður;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Engin netkerfi valin vegna deilingar gagna"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Netkerfi"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Kveikt"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Slökkt"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Virkjað"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Virkt"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Veldu möppu"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Bæta við"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Virkja deilingu gagnamiðla"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Deiling skráa gerir þér kleift að deila \"Opið öllum\"-möppunni (Public) með "
+"öðrum á netinu þínu, með: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Þegar fjartengd innskráning er virk, geta fjartengdir notendur að tengst með "
+"Secure Shell skipun:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Virkja deilingu einkagagnamiðla"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Heiti tækis afritað"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Vistfang tækis afritað"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Notandanafn afritað"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Lykilorð afritað"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Deiling"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Heiti tölvu"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "S_kráadeiling"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Fjartengt skjá_borð"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Deiling gagna_miðla"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Fja_rtengd innskráning"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Skráadeiling"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "K_refjast lykilorðs"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Fjartengd innskráning"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Fjartengt skjáborð"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Virkja eða afvirkja tengingar fjartengdra skjáborða við þessa tölvu."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Fjarstýring"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Leyfa fjartengingum að stýra skjánum."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Hvernig á að tengjast"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Afrita"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Vistfang fjartengds skjáborðs"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Auðkenning"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "Krafist er notandanafns og lykilorðs til að tengjast við þessa tölvu."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Notandanafn"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Sannprófa dulritun"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Fingrafar dulritunar"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Fingraför dulritunar geta sést í biðlurum sem tengjast og ættu að vera eins."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Deiling gagnamiðla"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Deila tónlist, myndum og myndskeiðum á netinu."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Möppur"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Stjórnaðu hverju þú vilt deila með öðrum"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"sameign;deiling;ssh;hýsill;heiti;fjartengt;skjáborð;hljóð;myndskeið;mynd;"
+"ljósmynd;kvikmynd;þjónn;miðlari;myndgerð;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Virkja eða afvirkja fjartengda innskráningu"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Þú þarft að auðkenna þig til að virkja eða afvirkja fjartengda innskráningu"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Sérsniðið"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Smella"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Strengur"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Sveifla"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Jafnvægi"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Deyfa út"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Aftan"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Framan"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Prófa %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Smelltu á hátalara til ap prófa"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Kerfishljóð"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Aðalhljóðstyrkur"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Hljóðstyrkur"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Úttak"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Úttakstæki"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Prófa"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Uppsetning"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Bassabox"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Inntak"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Inntakstæki"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Hljóðstyrkur"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Viðvörunarhljóð"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Þagga niður"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Hljóð"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Breyta hljóðstyrk, inntaki, úttaki og aðvörunarhljóðum"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Hljóðkort;hljóðnemi;Hljóðstyrkur;Deyfing;Jafnvægi;Bluetooth;Heyrnartól;"
+"Hljóðkerfi;Inntak;Úttak;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Aftengt"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Tengist"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Tengt"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Villa í auðkenningu"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Auðkenning í gangi"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Takmörkuð virkni"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Tengt og auðkennt"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Óþekkt"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Auðkennt:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Tengt á:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Skráð þann:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Tókst ekki að auðkenna tæki: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Tókst ekki að gleyma tæki: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Er háð %u öðrum tæki"
+msgstr[1] "Er háð %u öðrum tækjum"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Loka tilkynningu"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Heiti:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Staða:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Auðkenna og tengjast"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Gleyma tæki"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Villa"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Auðkennt"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Thunderbolt undirkerfið (boltd) er ekki uppsett eða að uppsetningin er ekki "
+"rétt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Leyfir beinan aðgang að tækjum eins og tengikvíum (dock) og utanáliggjandi "
+"GPU-skjákortsörgjörvum."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Aðeins USB og Display Port tæki geta tengst."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt fannst ekki.\n"
+"Annað hvort vantar stuðning við Thunderbolt í kerfið, hann hefur verið "
+"gerður óvirkur í BIOS-stillingum eða að hann er stilltur á óstutt "
+"öryggisstig í BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Stuðningur við Thunderbolt hefur verið gerður óvirkur í BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Ekki var hægt að ákvarða öryggisstig Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Villa við að skipta í beinan ham: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Enginn stuðningur við Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Gat ekki tengst thunderbolt-undirkerfinu"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Beinn aðgangur"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Tæki í bið"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Engin tæki tengd"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Sýsla með Thunderbolt-tæki"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;gagnaleynd;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Bendill blikkar"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Bendill blikkar í textareitum."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Hraði"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Blikktíðni bendils"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Stærð bendils"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Stærð bendils er hægt að tengja við aðdrátt svo auðveldara sé að sjá hann.."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Smellihjálp"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Hermt eftir aukasmell"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Líkja eftir aukasmell með því að halda niðri aðalhnappi"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "S_amþykktartöf:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Stutt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Töf aukasmells"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Löng"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Smellur við _yfirsvif"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Virkja músarsmell við yfirsvif"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Tö_f:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Stutt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Löng"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Skynjunarmörk _hreyfingar:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Lítil"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Mikil"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Endurtekning lykla"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Innsláttur endurtekinn þegar lykli er haldið niðri."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Hraði á endurtekningu lykla"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Hraði á endurtekningu lykla"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Innsláttarhjálp"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Klístraðir lyklar"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Meðhondlar röð breytilykla sem lyklasamsetningu"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Afvirkja ef stutt er á tvo hnappa samtímis"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Gefa frá sér hljóð þegar ýtt er á _breytitakka"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Hægir lyklar"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Setur töf milli þess sem ýtt er á lykil þar til hann er samþykktur"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Stutt"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Innsláttartöf við notkun hægra lykla"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Löng"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Gefa frá sér hljóð þegar ýtt er á _takka"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Gefa frá sér hljóð þegar lykill er s_amþykktur"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Gefa frá sér hljóð þega_r lykli er hafnað"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Lyklaen_durvarp"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Hunsa þegar ýtt er hratt mörgum sinnum á sömu lykla"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Stutt"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Innsláttartöf við notkun lyklaendurvarps"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Löng"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Virkja _miðað við lyklaborð"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Kveikja og slökkva á aðgengisstillingum með lyklaborði"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Sjálfgefið"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Miðlungs"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Stórt"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Stærra"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Stærst"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d mynddíll"
+msgstr[1] "%d mynddílar"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Alltaf sýna valmynd fyrir altækan aðgang"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Sjónrænt"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Mikil birtuskil"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Stór texti"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Virkja hreyfimy_ndir"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Skjá_lesari"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Skjálesarinn les birtan texta um leið og þú færir virkt svæði."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Hljóðlyklar"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Gefa frá sér hljóð þegar ýtt er á NumLock eða CapsLock lykla."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Stærð ben_dils"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "Aðdrá_ttur"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Heyrn"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Sjónrænar _viðvaranir"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Skjály_klaborð"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Endurtekning lykla"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Bendill blikkar"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Innslá_ttarhjálp (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Bending og smellir"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Músarlyklar"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Staðsetja _bendil"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "S_mellihjálp"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Töf við tvísmell"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Töf við tvísmell"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Sjónrænar viðvaranir"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Prófaðu _blikk"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Sýna myndrænt samhliða viðvörunarhljóði."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Blikka öllum _skjánum"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "_Blikka öllum skjánum"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Stutt"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ skjár"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ skjár"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ skjár"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Langt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Skjáfylli"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Efri helmingur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Neðri helmingur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Vinstri helmingur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Hægri helmingur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Valkostir aðdráttar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "Stæ_kkun:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Staðsetning stækkunar:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Fylgja músarbendli"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Skjáhluti:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Stækkunarsvæði nær út _fyrir skjá"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Halda stækkunarbendli _miðjuðum"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Stækkunarbendill ýtir til inni_haldi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Stækkunarbendill færist með _innihaldi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Skjástækkun"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Krossmið:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Fellur _yfir músarbendil"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "Þy_kkt:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Mjótt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Þykkt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Lengd:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Litur:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Krossmið"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Litáhrif:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Hvítt á svörtu:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Birtustig:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "B_irtuskil:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Litur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ekkert"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Full"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Lág"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Há"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Lítil"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Mikil"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Litáhrif"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Gerir auðveldara að sjá, heyra, slá inn, benda og smella"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Lyklaborð;Mús;a11y;Aðgengi;Algilt aðgengi;Birtuskil;Hljóð;Bendill;Aðdráttur;"
+"Skjár;Lesari;texti;letur;stærð;AccessX;Klístrað;Lyklar;Hægt;Endurtaka;"
+"Endurvarp;Tvísmella;smella;töf;hraði;Aðstoð;innsláttur;hreyfingar;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 klukkustund"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dagur"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dagar"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Tæma öll atriði úr ruslinu?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Öllum atriðum í ruslinu verður endanlega eytt."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Tæma ruslið"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Eyða öllum bráðabirgðaskrám?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Öllum bráðabirgðaskrám verður endanlega eytt."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Eyða bráðabirgðaskrám"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dagur"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dagar"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dagar"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Að eilífu"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Ferill skráa"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Fer_ill skráa"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Tímalen_gd skráaferils"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Hreinsa feril…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Rusl og bráðabirgðaskrár"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "_Tæma rusl sjálfkrafa"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "_Eyða bráðabirgðaskrám sjálfkrafa"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Tæma rusl sjálf_krafa eftir"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Tæma ruslið…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Eyða bráðabirgðaskrám…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Ferill skráa og rusl"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Ekki skilja eftir nein ummerki"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Ætti að samsvara vefslóð á miðlarann fyrir notandaaðganginn þinn."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Mistókst að bæta við reikning"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lykilorðin stemma ekki."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Mistókst að skrá aðgang"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Engin aðferð er studd til auðkenningar á þessu léni"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Mistókst að fá aðgang að léni"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Þetta innskráningarnafn virkaði ekki.\n"
+"Endilega reyndu aftur."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Þetta lykilorð virkaði ekki.\n"
+"Endilega reyndu aftur."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Mistókst að skrá inn á lén"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Ekki tókst að finna lénið. Er það rétt stafað?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Bæta við notanda"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Kerfisstjóri"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Notandi stillir lykilorð við næstu innskráningu"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Setja lykilorð núna"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Staðfesta"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Innskráning í fyrirtæki"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Tölvan er ekki tengd við netið"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Innskráning í fyrirtæki þýðir að hægt er að nota miðlægt skráðan "
+"notandaaðgang á þessu tæki. Þú getur líka notað þennan notandaaðgang til að "
+"tengjast netlægum tilföngum viðkomandi fyrirtækis."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Finna fleiri myndir"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Veldu skrá…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Fingrafarastýring"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Fingrafar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Nei"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Já"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Viltu eyða skráðum fingraförum, sem gerir innskráningu með fingraförum "
+"óvirka?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Enginn fingrafaraskanni"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Enginn fingrafaraskanni"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Gakktu úr skugga um að tækið sé rétt tengt."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Fingrafaraskanni"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Veldu fingrafaraskannann sem þú ætlar að stilla"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Innskráning með fingrafari"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Skönnun með fingrafari/förum gerir kleift að aflæsa og skrá inn í tölvuna "
+"með fingurstroku"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Eyða fingraförum"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Skráning fingrafars"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "tækið er nú þegar yfirtekið af öðru ferli"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "Þú hefur ekki heimild til að nota þessa aðgerð"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "engin fingraför hafa verið skráð"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Mistókst að eiga samskipti við tæki á meðan skráningu stóð"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Gat ekki átt samskipti við fingrafaralesara"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Gat ekki átt samskipti við fingrafaravöktunina"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Gat ekki gera lista yfir fingraför: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Gat ekki eytt vistuðum fingraförum: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Vinstri þumall"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Vinstri langatöng"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "_Vinstri vísifingur"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Vinstri baugfingur"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Vinstri litlifingur"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Hægri þumall"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Hægri langatöng"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "Hæg_ri vísifingur"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Hægri baugfingur"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Hægri litlifingur"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Óþekktur fingur"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Fullklárað"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Fingrafaraskanni aftengdur"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Tæki til fingrafaraskönnunar er fullt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Mistókst að skrá nýtt fingrafar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Mistókst að byrja skráningu: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Mistókst að skrá nýtt fingrafar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Mistókst að stöðva skráningu: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Lyftu og leggðu fingurinn endurtekið á fingrafaralestarann til að skrá "
+"fingrafarið þitt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "Sk_rá fingur aftur…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Skanna nýtt fingrafar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Gat ekki sleppt fingrafaraskanna: %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Vandamál við að lesa tæki"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Gat ekki tekið yfir fingrafaraskanna: %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Gat ekki fundið fingrafaraskanna: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Í þessari viku"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Í síðustu viku"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Setu lokið"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Seta hafin"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Virkni aðgangs"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Fyrra"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Næsta"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Veldu eitthvað annað lykilorð."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Sláðu aftur inn núverandi lykilorð."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Ekki tókst að breyta lykilorðinu"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Breyta lykilorði"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Bre_yta"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Núverandi lykilorð"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nýtt lykilorð"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Staðfestu lykilorð"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Leyfa notanda að stilla lykilorð við næstu innskráningu"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Setja lykilorð núna"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Get ekki tengst sjálfvirkt á þessa tegund léns"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Ekkert slíkt lén eða svæði fannst"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Get ekki skráðst inn sem %s á %s lénið"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Rangt lykilorð, reyndu aftur"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Gat ekki tengst %s léninu: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Gat ekki eytt notandanum"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Tókst ekki að afturkalla fjartengda notandaaðganginn"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Þú getur ekki eytt þínum eigin aðgangi."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s er ennþá skráður inn"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Ef notandaaðgangi er eytt á meðan notandinn er skráður inn getur kerfið "
+"orðið mjög óstöðugt."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Viltu halda skrám %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Það er hægt að halda eftir heimamöppu, pósthólfi og bráðabirgðaskrám þegar "
+"notandaaðgangi er eytt."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Eyða skrám"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Halda skrám"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Viltu örugglega afturkalla fjartengda %s aðganginn?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Eyða"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Notandaaðgangur óvirkur"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Stillt við næstu innskráningu"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Enginn"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Skráður inn"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Mistókst að tengjast við aðgangsþjónustuna"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Vinsamlegast gangið úr skugga um að AccountService sé rétt upp sett og sé "
+"virkt."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Eyða völdum notandaaðgangi"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Til að eyða völdum notandaaðgangi,\n"
+"smelltu fyrst á * táknmyndina"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Aflæstu til að bæta við notendum og breyta stillingum"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Notendur"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Endurræsa þarf setuna svo breytingarnar taki gildi"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Endurræsa núna"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Loka"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Skipta um auðkennismynd"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Fullt nafn"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Breyta"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Innskráning með _fingrafari"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "S_jálfvirk innskráning"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Virkni aðgangs"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Kerfisstjóri"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "Að_gangsstýringar foreldra"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Fjarlægja notandaaðgang…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Aðrir notendur"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Bæta við notanda…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Engir notendur fundust"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Aflæsa til að bæta við notandaaðgangi."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Bæta við eða fjarlægja notendur og breyta lykilorði"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Innskráning;Notandi;Nafn;Fingrafar;Persónutákn;Merki;Andlit;Lykilorð;"
+"Foreldralæsing;Skjátími;veftakmarkanir;notkun;takmörk notkunar;börn;krakkar;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "S_etja á skrá"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Innskráning lénstjóra"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Til þess að geta notað fyrirtækjainnskráningu verður þessi\n"
+"tölva að vera skráð á lénið. Láttu stjórnanda netkerfisins\n"
+"setja inn viðeigandi lykilorð hérna."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nafn kerfisstjóra"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Lykilorð kerfisstjóra"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Sýsla með notendaaðganga"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Auðkenningar er krafist til að breyta gögnum notanda"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Nýja lykilorðið verður að vera ólíkt því gamla."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Reyndu að breyta einhverjum stöfum og tölum."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Reyndu að breyta lykilorðinu örlítið meira."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Lykilorð sem ekki inniheldur notandanafnið þitt væri sterkara."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Forðastu að nota nafnið þitt í lykilorðinu."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Forðastu að nota einhver orðanna sem eru í lykilorðinu."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Forðastu að nota algeng orð."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Forðastu að endurraða algengum orðum."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Reyndu að nota fleiri tölustafi."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Reyndu að nota fleiri hástafi."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Reyndu að nota fleiri lágstafi."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Reyndu að nota fleiri sértákn, eins og greinamerki."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Reyndu að blanda saman bókstöfum, tölustöfum og greinamerkjum."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Forðastu að endurtaka sama stafinn oft."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Forðastu að endurtaka sömu tegund stafa: best er að blanda saman bókstöfum, "
+"tölustöfum og greinamerkjum."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Forðastu að nota runur eins og 1234 eða abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Lykilorðið þarf að vera lengra. Reyndu að blanda saman bókstöfum, tölustöfum "
+"og greinamerkjum."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Blandaðu saman hástöfum, lágstöfum og reyndu að nota einn eða fleiri "
+"tölustafi."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Ef þú bætir við fleiri bókstöfum, tölustöfum og greinamerkjum verður "
+"lykilorðið ennþá sterkara."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Auðkenning mistókst"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Nýja lykilorðið er of stutt"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Nýja lykilorðið er of einfalt"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Gamla og nýja lykilorðið eru of lík"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Nýja lykilorðið hefur áður verið notað og það nýlega."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Nýja lykilorðið verður að innihalda tölur eða sérstafi"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Það er enginn munur á gamla og nýja lykilorðinu"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Lykilorðinu hefur verið breytt síðan þú auðkenndir þig!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Nýja lykilorðið inniheldur ekki nægilega marga mismunandi stafi"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Óþekkt villa"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Notandanafn ætti venjulega einungis að innihalda lág/hástafi frá a-z, "
+"tölustafi eða einhvern af eftirfarandi stöfum:  - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Því miður, þetta notandanafn er ekki tiltækt. Veldu eitthvað annað nafn."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Notandanafnið er of langt."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Tengja hnappa"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Tengja hnappa við aðgerðir"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Til þess að breyta flýtilykli, veldu \"Senda lyklastroku\"-aðgerðina, "
+"smelltu á flýtilyklahnappinn og haltu niðri nýju flýtilyklunum eða ýttu á "
+"Backspace til að eyða."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Loka"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Sláðu létt á viðmiðunarmerkin um leið og þau birtast á skjánum til að kvarða "
+"tækið."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Mis-smellur fannst, endurræsi…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Hnappur %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Forrit skilgreint"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Senda lyklaslátt"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Skipta um skjá"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Sýna upplýsingaglugga á skjá"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Utanáliggjandi teiknitafla"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Utanáliggjandi platti"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Allir skjáir"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Teiknitöfluhamur"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Örvhent (músarhnöppum víxlað)"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Tengja við skjá"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Halda stærðarhlutföllum"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kvarða"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Engin teiknitafla fannst"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Tengdu við eða kveiktu á Wacom teiknitöflunni."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Þrýstiskynjun odds"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Mjúkt"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Þrýstingur pennaodds"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Stíft"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Hnappur 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Hnappur 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Hnappur 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Þrýstiskynjun útstrokunar"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Þrýstingur útstrokunar"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Miðju-músarsmellur"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Hægri músarsmellur"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Áfram"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Loftsprautu-teiknipenni með þrýstingi, halla og innbyggðum sleða"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Loftsprautu-teiknipenni með þrýstingi, halla og snúningi"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Staðlaður teiknipenni með þrýstingi og halla"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Staðlaður teiknipenni með þrýstingi"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom teiknitafla"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Stilltu hnappavörpun og aðlagaðu næmni snertipenna fyrir teiknispjald"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Teiknispjald;Teiknitafla;Wacom;Snerti;Penni;Teikna;Mús;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Nýr flýtilykill..."
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Aðgangsstaðir"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Hætt var við aðgerð"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Villa:</b> Aðgangi hafnað við að breyta stillingum"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Villa:</b> villa í farsímatækjum"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Óskráð"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Skráð"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Reiki"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Leita"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Hafnað"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Nánar um mótald"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Staða mótalds"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Símkerfi"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tegund netkerfis"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Staða netkerfis"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Eigin númer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Nánar um tæki"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Útgáfa grunnhugbúnaðar (firmware)"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Aðeins 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Aðeins 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Aðeins 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Aðeins 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (forgangs), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (forgangs), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (forgangs), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (forgangs), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (forgangs), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (forgangs), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (forgangs), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (forgangs), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (forgangs), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (forgangs), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (forgangs), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (forgangs), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (forgangs), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (forgangs), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (forgangs), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (forgangs), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (forgangs)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (forgangs), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Óþekkt"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Aflæsa SIM-korti"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Aflæsa"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Tilgreindu PIN-kóðann fyrir SIM-kortið %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Settu inn PIN til að aflæsa SIM-kortinu"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Tilgreindu PUK-kóðann fyrir SIM-kortið %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Settu inn PUK til að aflæsa SIM-kortinu"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Rangt lykilorð var sett inn. Þú átt %1$u tilraun eftir"
+msgstr[1] "Rangt lykilorð var sett inn. Þú átt %1$u tilraunir eftir"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Þú átt %u tilraun eftir"
+msgstr[1] "Þú átt %u tilraunir eftir"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Rangt lykilorð var sett inn."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK-kóði á að vera 8 tölustafir"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Settu inn nýtt PIN-númer"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN-númer á að vera 4-8 tölustafir"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Aflæsi…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Ekkert SIM-kort"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Settu inn SIM-kort til að nota þetta mótald"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM er læst"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Farsímagögn"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Hafa aðgang að gögnum í gegnum farsímanet"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Gagnareiki"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Nota farsímagögn við reiki"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Hamur netkerfis"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "N_etkerfi"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Ítarlegt"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Nöfn _aðgangspunkts"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM-læsing"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Læsa SIM-korti með PIN-númeri"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Nánar um mótal_d"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Bilun í síma"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Engin tenging við  síma"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Aðgerðin er ekki leyfileg"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Aðgerðin er ekki studd"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM-kort ekki til staðar"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Krafist er PIN-númers SIM-korts"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Krafist er PUK-númers SIM-korts"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Bilun í SIM-korti"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM-kort upptekið"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Rangt lykilorð"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Krafist er PIN2-númers SIM-korts"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Krafist er PUK2-númers SIM-korts"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Fannst ekki"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Engin netþjónusta"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Netkerfi féll á tíma"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS-þjónustur ekki leyfðar"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Reiki er ekki leyft á þessu svæði"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Óskilgreind GPRS-villa"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Engin villa"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Hætt við aðgerð"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Aðgangi hafnað"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Óþekkt villa"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Hamur netkerfis"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "Sjálfvir_kt"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Veldu netkerfi"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Endurnýja lista yfir netþjónustur"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Virkja farsímanet"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Engin WWAN-netkort fundust"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Gakktu úr skugga um að þú sért með þráðlaust WAN/farsímatæki"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Þráðlaust WAN er óvirkt þegar flugvélahamur er virkur"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Slö_kkva á flugvélaham"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Gagnatenging"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM-kort notað fyrir internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM-læsing"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Næsta"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Læsa SIM-korti með PIN-númeri"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Breyta PIN-númeri"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Settu inn núverandi PIN-kóða til að breyta stillingum SIM-læsingar"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Farsímanet"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Stilla nettæki og farsímatengingar"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "þráðlaust;wwan;símkerfi;sim;farsími;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Tól til að stilla GNOME skjáborðsumhverfið"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Stillingar er aðalviðmótið til að laga stillingar kerfisins þíns."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME verkefnið"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Birta útgáfunúmer"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Virkja ítarlegan ham"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Leita að strengnum"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Birta heiti allra mögulegra spjalda og hætta"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Spjald sem á að birta"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[SPJALD] [BREYTA…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Flokkar stillinga"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Gagnaleynd"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Tiltæk spjöld:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Allar stillingar"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Aðalvalmynd"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Aðvörun: Þróunarútgáfa"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Þessa útgáfu af Settings-stillingaforritinu ætti einungis að nota í "
+"þróunartilgangi. Þú gætir fundið fyrir rangri kerfishegðun, gagnatapi og "
+"öðrum óvæntum vandamálum. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Hjálp"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Almennt"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Hætta"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Leita"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Spjöld"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Til baka"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Hætta við leit"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Kjörstillingar;Uppsetning;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Auðkenni síðast opnaða stillingaspjaldsins"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Auðkenni síðast opnaða stillingaspjaldsins. Óþekkt gildi verða hunsuð og "
+"fyrsta spjaldið í listanum verður valið."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Birta aðvörun þegar verið er að keyra þróunarútgáfu af Settings-stillingunum"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Hvort Settings eigi að birta aðvörun þegar verið er að keyra þróunarútgáfu."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Upprunaleg staða gluggans"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Strengur sem inniheldur upprunalega breidd, hæð og hámörkunarstöðu "
+"forritsglugga."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u úttak"
+msgstr[1] "%u úttök"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u inntak"
+msgstr[1] "%u inntök"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Kerfishljóð"
+
+#~ msgid "Light"
+#~ msgstr "Ljóst"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "skjár;læsa;greining;hrun;einka;nýlegt;bráðabirgða;tmp;yfirlit;nafn;"
+#~ "netkerfi;auðkenna;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Fyrirkomulag á skjám"
+
+#~ msgid "Set"
+#~ msgstr "Setja"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Læsa skjánum þínum"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER eða PEM skilríki (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Bæta við prentara…"
+
+#~ msgid "Bark"
+#~ msgstr "Gelt"
+
+#~ msgid "Drip"
+#~ msgstr "Leki"
+
+#~ msgid "Glass"
+#~ msgstr "Gler"
+
+#~ msgid "Sonar"
+#~ msgstr "Sónar"
+
+#~ msgid "Web Links"
+#~ msgstr "Veftenglar"
+
+#~ msgid "Git Links"
+#~ msgstr "Git-tenglar"
+
+#~ msgid "%s Links"
+#~ msgstr "%s tenglar"
+
+#~ msgid "Unset"
+#~ msgstr "Afskrá"
+
+#~ msgid "Links"
+#~ msgstr "Tenglar"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Vefskrár (HyperText)"
+
+#~ msgid "Text Files"
+#~ msgstr "Textaskrár"
+
+#~ msgid "Image Files"
+#~ msgstr "Myndskrár"
+
+#~ msgid "Font Files"
+#~ msgstr "Leturskrár"
+
+#~ msgid "Archive Files"
+#~ msgstr "Safnskrár"
+
+#~ msgid "Package Files"
+#~ msgstr "Pakkaskrár"
+
+#~ msgid "Audio Files"
+#~ msgstr "Hljóðskrár"
+
+#~ msgid "Video Files"
+#~ msgstr "Myndskeiðasskrár"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Heimildir og aðgangur"
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Ekki er hægt að breyta þessu"
+
+#~ msgid "Integration"
+#~ msgstr "Samþætting"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Stilla bakgrunnsmynd"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Sjálfgefið meðhöndlað af"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Skráagerðir og tenglar sem þetta forrit opnar."
+
+#~ msgid "Usage"
+#~ msgstr "Notkun"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Hve mikil tilföng þetta forrit er að nota."
+
+#~ msgid "Open in Software"
+#~ msgstr "Opna í hugbúnaðarstýringu"
+
+#~ msgid "Activities"
+#~ msgstr "Virkni"
+
+#~ msgid "_Copy"
+#~ msgstr "_Afrita"
+
+#~ msgid "Select _All"
+#~ msgstr "Velja _allt"
+
+#~ msgid "Single Display"
+#~ msgstr "Einn skjár"
+
+#~ msgid "Join Displays"
+#~ msgstr "Tengja skjái"
+
+#~ msgid "Display Mode"
+#~ msgstr "Birtingarhamur"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Dragðu skjái til svo þeir samsvari uppsetningunni hjá þér. Veldu svo skjá "
+#~ "til að breyta stillingum hans."
+
+#~| msgid "Single Display"
+#~ msgid "Active Display"
+#~ msgstr "Virkur skjár"
+
+#~ msgid "More Warm"
+#~ msgstr "Hlýrri"
+
+#~ msgid "Less Warm"
+#~ msgstr "Kaldari"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Vista skjámynd í $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Vista skjámynd af glugga í $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Vista skjámynd af svæði í $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Afrita skjámynd á klippispjald"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Afrita skjámynd af glugga á klippispjald"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Afrita skjámynd af svæði yfir á klippispjald"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Taka upp stutt skjámyndskeið"
+
+#~| msgid "Move Up"
+#~ msgid "Move up"
+#~ msgstr "Færa upp"
+
+#~| msgid "Move Down"
+#~ msgid "Move down"
+#~ msgstr "Færa niður"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Staðsetningarþjónustur gera forritum kleift að finna út staðsetninguna "
+#~ "þína. Notkun á þráðlausu WiFi og ferðabreiðbandi eykur nákvæmnina."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Notar Mozilla staðsetningarþjónustu: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Persónuverndarstefna</a>"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Tímamörk við tvísmell"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Bið og aflhnappar"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Auðkenna"
+
+#~| msgid "%s Account"
+#~ msgid "My Account"
+#~ msgstr "Aðgangurinn minn"
+
+#~| msgid "_Language"
+#~ msgid "Language"
+#~ msgstr "Tungumál"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Þú þarft að endurræsa setuna svo breytingarnar taki gildi"
+
+#~ msgid "Restart…"
+#~ msgstr "Endurræsa…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Innskráningarstillingar eru notaðar af öllum notendum þegar þeir skrá sig "
+#~ "inn í kerfið"
+
+#~| msgid ""
+#~| "Screen sharing allows remote users to view or control your screen by "
+#~| "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Skjádeiling gerir fjartengdum notendum kleift að skoða eða stjórna "
+#~ "skjánum þínum með því að tengjast með %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Deiling á _skjá"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Sumar þjónustur eru óvirkar því nettenging er óvirk."
+
+#~ msgid "_Password:"
+#~ msgstr "L_ykilorð:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Birta lykilorð"
+
+#~ msgid "Access Options"
+#~ msgstr "Valkostir við aðgengi"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Nýjar tengingar verða að biðja um aðgang"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Krefjast lykilorðs"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Hljóðlyklar"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Skjálesari"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Skjálesari"
+
+#~ msgid "Standard"
+#~ msgstr "Staðlað"
+
+#~ msgid "Account _Type"
+#~ msgstr "Tegund notandaaðgangs"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Leyfa notanda að stilla _lykilorð við næstu innskráningu"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Setja lykilorð _núna"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "Nettenging er nauðsynleg til að bæta við innskráningaraðgangi í fyrirtæki."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Taka mynd…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Til að gera breytingar,\n"
+#~ "smelltu fyrst á * táknmyndina"
+
+#~ msgid "Create a user account"
+#~ msgstr "Búa til notandaaðgang"
+
+#~ msgid "User Icon"
+#~ msgstr "Táknmynd notanda"
+
+#~| msgid "All Settings"
+#~ msgid "Account Settings"
+#~ msgstr "Stillingar aðgangs"
+
+#~| msgid "Au_thentication"
+#~ msgid "Authentication & Login"
+#~ msgstr "Auðkenning og innskráning"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Þetta verður notað til að nefna heimamöppuna þína og er ekki hægt að "
+#~ "breyta síðar."
+
+#~ msgid "Output:"
+#~ msgstr "Úttak:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Halda stærðarhlutföllum:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Varpa á einn skjá"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d af %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Birta vörpun"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Teiknitafla (algild)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Snertiplatti (afstætt)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Stillingar teiknitöflu"
+
+#~ msgid "_Help"
+#~ msgstr "_Hjálp"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Stillingar Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Fylgnihamur"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Tengja hnappa..."
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Breyta stillingum músar"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Stilla skjáupplausn"
+
+#~ msgid "No stylus found"
+#~ msgstr "Engin snertipenni fannst"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Færðu snertipennann nálægt teiknispjaldinu til að stilla það"
+
+#~ msgid "Top Button"
+#~ msgstr "Efsti hnappur"
+
+#~ msgid "Lower Button"
+#~ msgstr "Neðri hnappur"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Neðsti hnappur"
+
+#~| msgid "GNOME Settings"
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Hljóðflipi GNOME-stillinga"
+
+#~| msgid "GNOME Settings"
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Bakgrunnsflipi GNOME-stillinga"
+
+#~| msgid "GNOME Settings"
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Lyklaborðsflipi GNOME-stillinga"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Gat ekki sent skrá: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Litasniðið hefur verið sent til:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Skrifaðu niður þessa slóð."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Endurræstu þessa tölvu og ræstu upp venjulega stýrikerfið þitt."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Skrifaðu slóðina inn í vafra og náðu í  og settu upp litasniðið."
+
+#~ msgid "Upload profile"
+#~ msgstr "Senda litasnið"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Þarfnast internettengingar"
+
+#, fuzzy
+#~| msgid "Unlock %s."
+#~ msgid "Unlocking..."
+#~ msgstr "Aflæsa %s."
+
+#~ msgid "_Background"
+#~ msgstr "_Bakgrunnur"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Breytist yfir daginn"
+
+#~ msgid "_Lock Screen"
+#~ msgstr "_Læsa skjá"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Flísaleggja"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Aðdráttur"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Miðja"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Kvarða"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Fylla"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Spanna"
+
+#~ msgid "Colors"
+#~ msgstr "Litir"
+
+#~ msgid "Select Background"
+#~ msgstr "Veldu bakgrunn"
+
+#~ msgid "Pictures"
+#~ msgstr "Myndir"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Engar myndir fundust"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Þú getur bætt myndum í %s möppuna og þær munu birtast hérna"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "_Off"
+#~ msgstr "Slö_kkt"
+
+#~ msgid "Version %s"
+#~ msgstr "Útgáfa %s"
+
+#~ msgid "OS name"
+#~ msgstr "Nafn stýrikerfis"
+
+#~ msgid "OS type"
+#~ msgstr "Tegund stýrikerfis"
+
+#~ msgid "Disk"
+#~ msgstr "Diskur"
+
+#~ msgid "Check for updates"
+#~ msgstr "Leita að uppfærslum"
+
+#~ msgid "Universal Access"
+#~ msgstr "Altækur aðgangur"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Skipta á næsta inntaksgjafa einungis með breytilyklum"
+
+#~ msgid "Network proxy"
+#~ msgstr "Milliþjónn, netsel"
+
+#~| msgid "Connecting"
+#~ msgid "Connection/SSID"
+#~ msgstr "Tenging/SSID"
+
+#~ msgid "page 1"
+#~ msgstr "síða 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Innra _auðkenni"
+
+#~ msgid "page 2"
+#~ msgstr "síða 2"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "Takmarka gagnanotkun í bakgrunnsvinnslu"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr ""
+#~ "Tilvalið fyrir tengingar þar sem takmörk eða gjöld eru á gagnanotkun."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/sek"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/sek"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/sek"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/sek"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Við það að kveikja á þráðlausa tengipunktinum muntu aftengjast frá <b>%s</"
+#~ "b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Ekki er mögulegt að tengjast internetinu í gegnum þráðlausan búnað þinn á "
+#~ "meðan þráðlausi tengipunkturinn er virkur."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Þráðlausir Wi-Fi tengipunktar eru venjulega notaðir til að deila viðbótar "
+#~ "internettengingu yfir Wi-Fi."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "_Tengjast sjálfkrafa"
+
+#~ msgid "details"
+#~ msgstr "nánar"
+
+#~ msgid "Show P_assword"
+#~ msgstr "_Birta lykilorð"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Gera aðgengilegt öðrum notendum"
+
+#~ msgid "identity"
+#~ msgstr "auðkenni"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Vistföng"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Aðeins sjálfvirk (DHCP) vistföng"
+
+#~ msgid "Link-local only"
+#~ msgstr "Einungis staðvær tengi (link-local)"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Hunsa sjálfvirkt úthlutaðar beiningar"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Klónað MAC vistfang:"
+
+#~ msgid "_Reset"
+#~ msgstr "F_rumstilla"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Frumstilla allar stillingar á upprunaleg gildi, en muna það samt sem "
+#~ "forgangstengingu."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Fjarlægja allar upplýsingar varðandi þetta netkerfi og ekki reyna að "
+#~ "tengjast því sjálfkrafa."
+
+#~ msgid "Hardware"
+#~ msgstr "Vélbúnaður"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Endurstilla"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Slökkva til að tengjast þráðlausu neti"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Tengd tæki"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Lykilorð"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Beintengt (ad-hoc)"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Stoðkerfisnet (infrastructure)"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Til_kynningar í sprettgluggum"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Í hleðslu"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Varúð"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Lítil"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Góð"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Full hleðsla"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Tóm"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "Birta _skjás"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "Birta ly_klaborðs"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "_Dimma skjá þegar vélin er óvirk"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "Þráðlaust _Wi-Fi net"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Slökktu á Wi-Fi til að spara orku."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Slökktu á ferðabreiðbandi (3G, 4G, LTE, o.s.frv.) til að spara orku."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Slökktu á Bluetooth til að spara orku."
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "Hætta sjálfvir_kt"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "Þegar ýtt er á aflhnapp"
+
+#~ msgid "Add…"
+#~ msgstr "Bæta við…"
+
+#~ msgid "In use"
+#~ msgstr "Í notkun"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Nota"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Nota ekki"
+
+#~| msgid "Off"
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Slökkt"
+
+#~| msgid "On"
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Kveikt"
+
+#~| msgid "Off"
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Slökkt"
+
+#~| msgid "On"
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Kveikt"
+
+#~ msgid "Usage & History"
+#~ msgstr "Notkun og ferilskráning"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Persónuvernd"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Að muna ferilinn þinn gerir auðveldara að finna hluti. Upplýsingum um "
+#~ "slíkt er aldrei deilt á netinu."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Nýlega notað"
+
+#~ msgid "Retain _History"
+#~ msgstr "Geyma _feril"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Skjálæsing ver einkaupplýsingar þínar þegar þú ert í burtu."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Læs_a skjá eftir"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Eyðir sjálfkrafa skrám úr ruslinu og bráðabirgðaskrám til þess að halda "
+#~ "tölvunni þinni lausri við óþarfar viðkvæmar persónuupplýsingar."
+
+#~ msgid "Purge _After"
+#~ msgstr "_Eyða eftir"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Ef þú sendir okkur upplýsingar um hvaða hugbúnað þú notar, hjálpar það "
+#~ "okkur að koma með betri uppástungur. Það hjálpar okkur einnig að bæta "
+#~ "hugbúnaðinn.\n"
+#~ "\n"
+#~ "Allar þær upplýsingar sem við söfnum eru gerðar ópersónugreinanlegar, og "
+#~ "við munum aldrei deila gögnum um þig með þriðja aðila."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Senda tölfræði hugbúnaðarnotkunar"
+
+#~| msgid "%s Camera"
+#~ msgid "_Camera"
+#~ msgstr "M_yndavél"
+
+#~ msgid "_Microphone"
+#~ msgstr "Hl_jóðnemi"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Staðsetningarþjónustur"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Verndaðu einkaupplýsingar þínar og stjórnaðu því hvað aðrir gætu séð"
+
+#~ msgid "No regions found"
+#~ msgstr "Engin svæði fundust"
+
+#~| msgid "Previous track"
+#~ msgid "Previous source"
+#~ msgstr "Fyrra tilfang"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Ofurlykill(Win)+Shift+Bilslá"
+
+#~| msgid "Resources"
+#~ msgid "Next source"
+#~ msgstr "Næsta tilfang"
+
+#~ msgid "Super+Space"
+#~ msgstr "Ofurlykill(Win)+Bilslá"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Blikka _gluggatitli"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Til að búa til notandaaðgang,\n"
+#~ "smelltu fyrst á * táknmyndina"
+
+#~ msgid "Last Login"
+#~ msgstr "Síðasta innskráning"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Virkja innskráningu með fingrafari"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Annar fingur:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Fingrafarið þitt hefur verið vistað. Þú getur núna skráð þig inn með því "
+#~ "að nota fingrafaralesarann."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Innskráning;Notandi;Nafn;Fingrafar;Persónutákn;Merki;Andlit;Lykilorð;"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Notandanafn má ekki byrja með '-'."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Þú hefur ekki aðgang að þessum búnaði. Vinsamlegast hafðu samband við "
+#~ "kerfisstjóra."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Innri villa kom upp."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Viltu eyða skráðum fingraförum?"
+
+#~ msgid "Done!"
+#~ msgstr "Tilbúið!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Gat ekki tengst “%s” tækinu"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Gat ekki lesið fingrafar af tækinu '%s'"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr ""
+#~ "Vinsamlegast hafðu samband við kerfisstjóra til að fá frekari aðstoð."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Þú verður að vista eitt fingrafar með ‚%s‘ tækinu ef þú vilt leyfa "
+#~ "innskráningu með fingrafari."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Vel fingur"
+
+#~| msgid "Bluetooth"
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~| msgid "Preferences"
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Næturlýsing"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Gat ekki fengið upplýsingar um skjái"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~| msgid "No printers"
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Skipta á fyrri inntaksgjafa"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Skipta á næsta inntaksgjafa"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Varaskipting á næsta inntaksgjafa"
+
+#~ msgid "_Options"
+#~ msgstr "Valk_ostir"
+
+#~ msgid "Add input source"
+#~ msgstr "Bæta við inntaksgjafa"
+
+#~ msgid "Remove input source"
+#~ msgstr "Fjarlægja inntaksgjafa"
+
+#~ msgid "Move input source up"
+#~ msgstr "Færa inntaksgjafa upp"
+
+#~ msgid "Move input source down"
+#~ msgstr "Færa inntaksgjafa niður"
+
+#~ msgid "Configure input source"
+#~ msgstr "Stilla inntaksgjafa"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Sýna lyklaborðsuppsetningu inntaksgjafa"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Vinstri"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Hægri"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Lágmark"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Hámark"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Bassabox:"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Ómagnað"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Snið:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "Prófa _hátalara"
+
+#~ msgid "Peak detect"
+#~ msgstr "Nema toppa"
+
+#~ msgid "Device"
+#~ msgstr "Tæki"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Prófun hátalara %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Veldu tæki fyrir hljóðúttak:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Stillingar fyrir valið tæki:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Inntakshljóðstyrkur:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Veldu tæki fyrir hljóðinntak:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Hljóðbrellur"
+
+#~ msgid "Built-in"
+#~ msgstr "Innbyggt"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Hljóðstillingar"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Prófa hljóð fyrir atburði"
+
+#~ msgid "From theme"
+#~ msgstr "Frá þema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Vel_du viðvörunarhljóð:"
+
+#~ msgid "Stop"
+#~ msgstr "Stöðva"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Staðlað"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Kerfisstjóri"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME Stjórnborð"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Stjórnborðið er aðalviðmót GNOME til stillinga á hinum ýmsu þáttum "
+#~ "skjáborðsins."
+
+#~ msgid "Quit"
+#~ msgstr "Hætta"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "Back­ground"
+#~ msgstr "Bak­grunnur"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blue­tooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Li­tur"
+
+#~ msgid "Overview"
+#~ msgstr "Yfirlit"
+
+#~| msgid "Default Applications"
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Sjálfgefin forrit"
+
+#~ msgid "Ab­out"
+#~ msgstr "Um"
+
+#~ msgid "De­tails"
+#~ msgstr "Nánar"
+
+#~| msgid "Removable Media"
+#~ msgid "Remo­vable Media"
+#~ msgstr "Útskiptanlegir gagnamiðlar"
+
+#~ msgid "Net­work"
+#~ msgstr "Net­kerfi"
+
+#~ msgid "hardware"
+#~ msgstr "vélbúnaður"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Ti­lk­yn­ni­ngar"
+
+#~ msgid "Po­wer"
+#~ msgstr "Or­ka"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Gag­na­leynd"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Enska (Bretland)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Bretland"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Deiling"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Altækur aðgangur"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "Staðfestu nýja l_ykilorðið"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Lykilorðin stemma ekki"
+
+#~ msgid "Disable image"
+#~ msgstr "Gera mynd óvirka"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Finna fleiri myndir…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Notað af %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wa­com teiknitaf­la"
+
+#~ msgid "page 3"
+#~ msgstr "síða 3"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Vélbúnaður"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Kerfi"
+
+#~ msgid "Show the overview"
+#~ msgstr "Birta yfirlit"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Fartölvulok lokað"
+
+#~ msgid "Mirrored"
+#~ msgstr "Speglað"
+
+#~ msgid "Secondary"
+#~ msgstr "Auka"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Hagræða samsettum skjám"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Draga skjái til að stilla þeim upp"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Snúa rangsælis um 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Snúa um 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Snúa réttsælis um 90°"
+
+#~ msgid "Size"
+#~ msgstr "Stærð"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Birta toppstiku og virkniyfirlit á þessum skjá"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Bættu þessum skjá við annan til að búa til auka vinnusvæði"
+
+#~ msgid "Presentation"
+#~ msgstr "Kynning"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Sýna aðeins skyggnusýningar og gagnamiðla"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Birta núverandi sýn á báðum skjám"
+
+#~ msgid "Turn Off"
+#~ msgstr "Slökkva"
+
+#~| msgid "Don't use this display"
+#~ msgid "Don’t use this display"
+#~ msgstr "Ekki nota þennan skjá"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "H_agræða samsettum skjám"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bita (Byggingarauðkenni: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bita"
+
+#~ msgid "Base system"
+#~ msgstr "Grunnkerfi"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Flýtilykill;Endurtekning;Blikka;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Ýttu á ESC til að hætta við."
+
+#~ msgid "Server"
+#~ msgstr "Þjónn"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Eyða DNS þjóni"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Gera aðgengilegt öðrum notend_um"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Svæði í _eldvegg"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Sjálfgefið"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Svæðið skilgreinir traustið á tengingunni"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Frumstilla allar stillingar þessa netkerfis, þar með talin lykilorð, en "
+#~ "muna það samt sem forgangsnet."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Fjarlægja allar upplýsingar varðandi þetta netkerfi og ekki reyna að "
+#~ "tengjast því sjálfkrafa"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Ef þú ert með aðra internet-tengingu en þá þráðlausu, geturðu sett upp "
+#~ "tengipunkt og deilt tengingunni með öðrum."
+
+#~ msgid "Proxy"
+#~ msgstr "Milliþjónn"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Bæta við sniði…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Ekkert"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Handvirkt"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Sjálfvirkt"
+
+#~ msgid "Group Name"
+#~ msgstr "Heiti hóps"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Nota sem tengipunkt"
+
+#~ msgid "_History"
+#~ msgstr "_Ferill"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Reyndu að bæta við fleiri bókstöfum, tölustöfum og táknum."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Styrkur: Veikt"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Styrkur: Lítill"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Styrkur: Miðlungs"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Styrkur: Góður"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Styrkur: Mikill"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Tilkynninga_borðar"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Tilkynninga_borðar"
+
+#~ msgid "Add Account"
+#~ msgstr "Bæta við notandaaðgangi"
+
+#~ msgid "Mail"
+#~ msgstr "Póstur"
+
+#~| msgid "_Calendar"
+#~ msgid "Calendar"
+#~ msgstr "Dagatal"
+
+#~ msgid "Contacts"
+#~ msgstr "Tengiliðir"
+
+#~ msgid "Chat"
+#~ msgstr "Spjall"
+
+#~ msgid "Error creating account"
+#~ msgstr "Villa við að búa til notandaaðgang"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Ertu viss um að þú viljir fjarlægja notandaaðganginn?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Þetta mun ekki fjarlægja aðganginn af miðlaranum."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Engir aðgangar fyrir net uppsettir"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Að bæta við aðgangi gerir forritum kleift að nálgast skjöl, póst, "
+#~ "tengiliði, dagatal, spjall og fleira."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Stilli"
+
+#~ msgid "Toner Level"
+#~ msgstr "Staða prentdufts"
+
+#~ msgid "Supply Level"
+#~ msgstr "Staða fyllinga"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Uppsetning"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u virkur"
+#~ msgstr[1] "%u virkir"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Bæta við nýjum prentara"
+
+#~ msgid "No printers detected."
+#~ msgstr "Engir prentarar fundust"
+
+#~ msgid "Supply"
+#~ msgstr "Áfyllingar"
+
+#~ msgid "Jobs"
+#~ msgstr "Verk"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Sýn_a prentverk"
+
+#~ msgid "label"
+#~ msgstr "skýring"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Pren_ta prófunarsíðu"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Aðrir aðgangar"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Upp"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Niður"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Ekkert"
+
+#~ msgid "Left Ring"
+#~ msgstr "Vinstri hringur"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Hamur vinstri hrings #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Hamur hægri hrings #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Vinstri snertiborði"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Hamur vinstri snertiborða #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Hægri snertiborði"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Hamur hægri snertiborða #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Hamskipti vinstri snertihrings"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Hamskipti hægri snertihrings"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Hamskipti vinstri snertiborða"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Hamskipti hægri snertiborða"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Hamskipti #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Vinstrihnappur  #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Hægrihnappur  #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Efsti hnappur #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Neðsti hnappur #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Engin aðgerð"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Vinstri músarsmellur"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Skruna upp"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Skruna niður"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Skruna til hægri"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Fjarlægja flýtilykil"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Til þess að breyta flýtilykli, smelltu á röðina sem hann á við og sláðu "
+#~ "inn nýjan flýtilykil eða ýta á Backspace til að eyða."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Óþekkt aðgerð>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Ekki er hægt að nota flýtilykilinn „%s“ vegna þess að þá yrði ekki "
+#~ "mögulegt að skrifa með þessum lykli.\n"
+#~ "Reyndu að ýta á lykla eins og Control, Alt eða Shift á meðan."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Flýtilykillinn „%s“ er þegar notaður fyrir\n"
+#~ "„%s“"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Ef þú úthlutar flýtilyklinum til „%s“ þá mun flýtilykillinn „%s“ eyðast."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Úthluta upp á nýtt"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Flýtilykillinn \"%s\" er með úthlutuðum \"%s\" flýtilykli. Viltu setja "
+#~ "hann sjálfkrafa á \"%s\"?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" er núna úthlutað á \"%s\", þessi flýtilykill verður gerður óvirkur "
+#~ "ef þú heldur áfram."
+
+#~ msgid "_Assign"
+#~ msgstr "Úthlut_a"
+
+#~ msgid "Bond"
+#~ msgstr "Bundið"
+
+#~ msgid "Team"
+#~ msgstr "Hópað"
+
+#~ msgid "Bridge"
+#~ msgstr "Brúað"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Gat ekki hlaðið inn VPN-viðbótum"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Bæta við nettengingu"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Bundnir þrælar"
+
+#~ msgid "(none)"
+#~ msgstr "(ekkert)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Brúaðir þrælar"
+
+#~ msgid "Team slaves"
+#~ msgstr "Hópaðir þrælar"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand-tæki styður ekki tengdan ham"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Engin skilríkisvottunarstöð (CA) valin"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Það að nota ekki neina skilríkisvottunarstöð (CA) hefur í för með sér "
+#~ "mögulegar tengingar við óörugg netkerfi (t.d. þráðlaus WiFi-net). Viltu "
+#~ "velja skilríki frá vottunarstöð?"
+
+#~ msgid "Ignore"
+#~ msgstr "Hunsa"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Veldu CA skírteini"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Spyrja í _hvert sinn um þetta lykilorð"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "_Ekki vara mig við aftur"
+
+#~ msgid "Yes"
+#~ msgstr "Já"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Villa við innskráningu á aðganginn"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Auðkennin eru útrunnin"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Skráðu þig inn til að virkja þennan aðgang."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Skrá inn"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Annað"
+
+#~ msgid "_Verify"
+#~ msgstr "_Sannreyna"
+
+#~ msgid "Login History"
+#~ msgstr "Ferill innskráninga"
+
+#~ msgid "Add User Account"
+#~ msgstr "Bæta við notandaaðgangi"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Notandi með notandanafnið '%s' er þegar til."
+
+#~ msgid "Done"
+#~ msgstr "Lokið"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Tíma_belti"
+
+#~ msgid "_Delay:"
+#~ msgstr "Tö_f:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Stutt"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Hægt"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Löng"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Hratt"
+
+#~ msgid "S_peed:"
+#~ msgstr "H_raði:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Prófaðu stillingarnar þínar"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Hægt"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Hratt"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Vinstri"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Hægri"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "Hraði _bendils"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Hægt"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Hratt"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Hægt"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Hratt"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Halda áfram með prentun"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Gera hlé á prentun"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Haldið"
+
+#~ msgid "Job Title"
+#~ msgstr "Titill verks"
+
+#~ msgid "Job State"
+#~ msgstr "Staða verks"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Bæta við nýjum prentara"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Notað til að finna út landfræðilega staðsetningu þína"
+
+#~ msgid "Password:"
+#~ msgstr "Lykilorð:"
+
+#~ msgid "Zoom"
+#~ msgstr "Stækka"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Litur"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Tæki með þráðlausu neti þarfnast mikillar orku"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Deiling með Bluetooth gerir þér kleift að deila skrám með öðrum Bluetooth-"
+#~ "tækjum"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Eingöngu taka á móti frá treystum tækjum"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Vista mótteknar skrár í niðurhalsmöppu"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Þe_gar ástand rafhlöðu er við hættumörk"
+
+#~ msgid "Show help options"
+#~ msgstr "Birta hjálparmöguleika"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Keyrðu '%s --help' til að sjá lista með öllum mögulegum valkostum "
+#~ "skipanalínunnar.\n"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Slekkur á þráðlausum tækjum"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "_Afvirkja snertiplatta á meðan skrifað er"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Netþjónustur kerfisins eru ekki samhæfðar þessari útgáfu."

--- a/po/it.po
+++ b/po/it.po
@@ -11,9 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-06-14 15:29+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-06-14 17:28+0200\n"
 "Last-Translator: Milo Casagrande <milo@milo.name>\n"
 "Language-Team: Italiano <tp@lists.linux.it>\n"
@@ -24,100 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: panels/applications/cc-applications-panel.c:790
-msgid "System Bus"
-msgstr "Bus di sistema"
-
-#: panels/applications/cc-applications-panel.c:790
-#: panels/applications/cc-applications-panel.c:792
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:810
-msgid "Full access"
-msgstr "Accesso completo"
-
-#: panels/applications/cc-applications-panel.c:792
-msgid "Session Bus"
-msgstr "Bus di sessione"
-
-#: panels/applications/cc-applications-panel.c:796
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Dispositivi"
-
-#: panels/applications/cc-applications-panel.c:796
-msgid "Full access to /dev"
-msgstr "Accesso completo a /dev"
-
-#: panels/applications/cc-applications-panel.c:800
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Rete"
-
-#: panels/applications/cc-applications-panel.c:800
-msgid "Has network access"
-msgstr "Ha accesso alla rete"
-
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:807
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Home"
-
-#: panels/applications/cc-applications-panel.c:807
-#: panels/applications/cc-applications-panel.c:812
-msgid "Read-only"
-msgstr "Sola lettura"
-
-#: panels/applications/cc-applications-panel.c:810
-#: panels/applications/cc-applications-panel.c:812
-msgid "File System"
-msgstr "File system"
-
-#: panels/applications/cc-applications-panel.c:816
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Impostazioni"
-
-#: panels/applications/cc-applications-panel.c:816
-msgid "Can change settings"
-msgstr "Può modificare impostazioni"
-
-#: panels/applications/cc-applications-panel.c:818
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s dispone dei seguenti permessi integrati non modificabili. In caso di "
-"dubbi riguardo a questi permessi, è consigliabile rimuovere l'applicazione."
-
-#: panels/applications/cc-applications-panel.c:1154
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u file e collegamento aperto dall'app"
-msgstr[1] "%u file e collegamenti aperti dall'app"
-
-#: panels/applications/cc-applications-panel.c:1161
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> viene utilizzato per aprire i seguenti tipi di file e collegamenti."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1213
-#, c-format
-msgid "%s of disk space used"
-msgstr "%s di spazio su disco utilizzato"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1377
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -133,7 +39,6 @@ msgid "Install some…"
 msgstr "Installa…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Apri"
 
@@ -144,6 +49,10 @@ msgstr "Visualizza dettagli"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Cerca"
@@ -153,24 +62,13 @@ msgstr "Cerca"
 msgid "Receive system searches and send results."
 msgstr "Riceve ricerche di sistema e invia risultati"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1900
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Disabilitato"
 
@@ -184,7 +82,8 @@ msgid "Show system notifications."
 msgstr "Mostra le notifiche di sistema"
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+#, fuzzy
+msgid "Run in Background"
 msgstr "Esegue in background"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -192,130 +91,143 @@ msgid "Allow activity when the app is closed."
 msgstr "Consente attività quando l'app è chiusa"
 
 #: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Schermo"
+
+#: panels/applications/cc-applications-panel.ui:141
+#, fuzzy
+msgid "Take pictures of the screen at any time."
+msgstr "Scatta foto con la fotocamera"
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "Cambia sfondo"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "Cambia lo sfondo della scrivania"
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Suoni"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "Riproduce i suoni"
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "Blocca le scorciatoie"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "Blocca le scorciatoie da tastiera standard"
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "Fotocamera"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "Scatta foto con la fotocamera"
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "Microfono"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "Registra audio col microfono"
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Servizi di localizzazione"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "Accede ai dati sulla posizione del dispositivo"
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "Permessi integrati"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "Accessi di sistema richiesti dall'app"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "Associazioni di file e collegamenti"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Archivio"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Nessun risultato trovato"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Provare un altro criterio di ricerca"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "Associazioni di file e collegamenti"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "Tipi di file"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "Tipi di collegamento"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Azzera"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr "Lo spazio su disco utilizzato da questa applicazione per dati e cache."
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Applicazione"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Dati"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Cache"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Totale</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Pulisci cache…"
 
@@ -323,90 +235,32 @@ msgstr "Pulisci cache…"
 msgid "Control various application permissions and settings"
 msgstr "Controlla permessi e impostazioni delle applicazioni"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "applicazione;flatpak;permessi;impostazioni;"
-
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "Seleziona un'immagine"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:519 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "A_nnulla"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:520
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Apri"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "dimensioni multiple"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Nessuno sfondo per la scrivania"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Sfondo attuale"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stile"
 
-#: panels/background/cc-background-panel.ui:46
-msgid "Light"
-msgstr "Chiaro"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Predefinita"
 
-#: panels/background/cc-background-panel.ui:73
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "Scuro"
 
-#: panels/background/cc-background-panel.ui:92
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Sfondo"
 
-#: panels/background/cc-background-panel.ui:98
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "Aggiungi immagine…"
 
@@ -418,50 +272,59 @@ msgstr "Aspetto"
 msgid "Change your background image or the UI colors"
 msgstr "Cambia l'immagine di sfondo o i colori dell'interfaccia"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+#, fuzzy
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Rivestimento;Sfondo;Scrivania;Desktop;Wallpaper;Chiaro;Scuro;Stile;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "A_bilita"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Bluetooth non trovato"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Collegare un dispositivo per utilizzare Bluetooth."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth disattivato"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Attivare per collegare dispositivi e ricevere file."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "Modalità aereo attiva"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "In modalità aereo il Bluetooth è disabilitato."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Disattiva modalità aereo"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "Modalità aereo hardware attiva"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Disattivare la modalità aereo via hardware per abilitare il Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -469,20 +332,19 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Attiva e disattiva il Bluetooth e connette i propri dispositivi"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "condivisione;condividere;share;bluetooth;obex;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "La fotocamera è spenta"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Nessuna applicazione può catturare fotografie o video."
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
@@ -496,7 +358,7 @@ msgstr ""
 "Consentire alle applicazioni riportate di seguito di utilizzare la "
 "fotocamera."
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Nessuna applicazione ha richiesto accesso alla videocamera"
 
@@ -504,100 +366,33 @@ msgstr "Nessuna applicazione ha richiesto accesso alla videocamera"
 msgid "Protect your pictures"
 msgstr "Proteggere le proprie immagini"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"schermo;blocco;diagnostica;crash;privato;recente;temporaneo;tmp;indice;nome;"
-"rete;identità;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Posizionare il dispositivo di calibrazione sul quadrato e premere «Avvia»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Spostare il dispositivo di calibrazione nella posizione di calibrazione e "
-"premere «Continua»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Spostare il dispositivo di calibrazione nella posizione di superficie e "
-"premere «Continua»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Chiudere il coperchio del portatile"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Si è verificato un errore interno impossibile da correggere."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Gli strumenti necessari alla calibrazione non sono installati."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Non è possibile generare il profilo."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Non è stato possibile ottenere il punto bianco prefissato."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Completata"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Calibrazione non riuscita"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "È ora possibile rimuovere il dispositivo di calibrazione."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr ""
-"Non disturbare il dispositivo di calibrazione mentre il processo è in corso"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibrazione schermo"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "A_nnulla"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -611,144 +406,9 @@ msgstr "_Riprendi"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Fatto"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Schermo del portatile"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Webcam integrata"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Scanner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Fotocamera %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Stampante %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webcam %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Abilita la gestione del colore per %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Mostra i profili di colore per %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Non calibrato"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Predefinito: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Spazio colore: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Profilo di test: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Selezionare file profilo ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importa"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Profili ICC supportati"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Tutti i file"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Schermo"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Salva profilo"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Salva"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Crea un profilo di colore per il dispositivo selezionato"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Non è stato rilevato alcuno strumento di misura. Verificare che sia acceso e "
-"connesso nel modo corretto."
-
-# profiling?
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-"Lo strumento di misura non è in grado di creare un profilo della stampante."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Il tipo di dispositivo non è al momento supportato."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -870,13 +530,13 @@ msgstr "Richiede un supporto scrivibile"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"Potrebbero risultare utili le istruzioni su come usare il profilo su <a href="
-"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a href=\"windows"
-"\">Microsoft Windows</a>."
+"Potrebbero risultare utili le istruzioni su come usare il profilo su <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a "
+"href=\"windows\">Microsoft Windows</a>."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -895,8 +555,8 @@ msgid "_Import File…"
 msgstr "_Importa file…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "A_ggiungi"
@@ -907,9 +567,7 @@ msgstr ""
 "Ciascun dispositivo necessita di un profilo di colore aggiornato per poter "
 "gestire il colore."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Maggiori informazioni"
 
@@ -1042,84 +700,6 @@ msgstr "D65 (fotografia e grafica)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Spazio standard"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Prova profilo"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatico"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Qualità bassa"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Qualità media"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Qualità alta"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB predefinito"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK predefinito"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Grigio predefinito"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Dati di calibrazione di fabbrica forniti dal produttore"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-"Con questo profilo non è possibile la correzione dello schermo a schermo "
-"intero"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Questo profilo potrebbe non essere più accurato"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Colore"
@@ -1130,14 +710,9 @@ msgid ""
 msgstr ""
 "Calibra il colore dei dispositivi, come schermi, fotocamere o stampanti"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Colore;ICC;Profilo;Calibrazione;Stampante;Display;Schermo;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Altro…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1152,20 +727,15 @@ msgid "No languages found"
 msgstr "Nessuna lingua trovata"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Altro…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Sbloccare per modificare le impostazioni"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr ""
 "Alcune impostazioni devono essere sbloccate prima di poter essere modificate."
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "Sblocca…"
 
@@ -1188,151 +758,6 @@ msgstr "Diminuisci ora"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Diminuisci minuto"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Oggi"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Ieri"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%d %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d ora"
-msgstr[1] "%d ore"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuto"
-msgstr[1] "%d minuti"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d secondo"
-msgstr[1] "%d secondi"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 secondi"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 ore"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %I:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %H:%M"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%I:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%H:%M"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1415,31 +840,67 @@ msgstr "_Data e ora automatiche"
 msgid "Requires internet access"
 msgstr "Richiede accesso a Internet"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "Da_ta e ora"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "_Fuso orario automatico"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "Richiede servizi di localizzazione e accesso a Internet"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Abilitato"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Fus_o orario"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Sblocca"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "F_ormato ora"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Date"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 secondi"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calendario"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Numeri"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Cambia data e orario, così come fuso orario"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Orologio;Tempo;Data;Fuso;Posizione;Orario;"
@@ -1486,20 +947,9 @@ msgstr "Applicazioni predefinite"
 msgid "Configure Default Applications"
 msgstr "Configurazione applicazioni predefinite"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "predefinito;applicazione;preferite;dispositivo;media;multimedia;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"L'invio di segnalazioni consente di migliorare %s. Le segnalazioni vengono "
-"inviate anonimamente e qualsiasi dato personale viene prima eliminato (%s)."
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1517,153 +967,116 @@ msgstr "Diagnostica"
 msgid "Report your problems"
 msgstr "Segnala il problema"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"schermo;blocco;diagnostica;crash;privato;recente;temporaneo;tmp;indice;nome;"
-"rete;identità;privacy;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "On"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Off"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "Applicare le modifiche?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "Le modifiche non possono essere applicate"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "Ciò potrebbe essere dovuto a limitazioni hardware."
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "Diagnostica"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Applica"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Indietro"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr "Impostazioni schermo disabilitate"
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "Disposizione schermo"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "Schermi multipli"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "Unisci"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Duplica"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Contiene la barra superiore e Attività"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Schermo primario"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Modalità notturna"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Orizzontale"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Verticale destro"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Verticale sinistro"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Orizzontale (capovolto)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Orientamento"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Risoluzione"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Frequenza aggiornamento"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Regola per TV"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Scala"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Scorrimento naturale"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Modalità notturna"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Disabilita fino a domani"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "Riavvia filtro"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1671,59 +1084,59 @@ msgstr ""
 "La modalità notturna imposta lo schermo con un colore più caldo, aiutando a "
 "prevenire l'affaticamento degli occhi e l'insonnia."
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Pianifica"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Dal tramonto all'alba"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Pianificazione manuale"
 
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Orari"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Da"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Ora"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Minuto"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "am"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "pm"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "A"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Temperatura colore"
 
@@ -1735,7 +1148,6 @@ msgstr "Schermi"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Sceglie come usare i monitor e i proiettori connessi"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1744,54 +1156,57 @@ msgstr ""
 "Pannello;Proiettore;xrandr;Schermo;Risoluzione;Dimensioni;Refresh;Display;"
 "Monitor;Notte;Blu;colore;tramonto;alba;luce;notturna;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Sconosciuto"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; ID versione: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Tipo di sicurezza"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Livello inchiostro"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Livello inchiostro"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Livello inchiostro"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Sconosciuto"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Sicurezza"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo di sistema"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"schermo;blocco;diagnostica;crash;privato;recente;temporaneo;tmp;indice;nome;"
+"rete;identità;privacy;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Nome dispositivo"
 
@@ -1824,31 +1239,43 @@ msgstr "Calcolo…"
 msgid "OS Name"
 msgstr "Nome SO"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; ID versione: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Tipo SO"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Versione GNOME"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Sblocco…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Sistema grafico"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Virtualizzazione"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Aggiornamenti software"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Rinomina dispositivo"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1856,7 +1283,12 @@ msgstr ""
 "Il nome del dispositivo viene usato per identificarlo all'interno della rete "
 "o quando viene associato con dispositivi Bluetooth."
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Nome dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "_Rinomina"
 
@@ -1868,11 +1300,6 @@ msgstr "Informazioni"
 msgid "View information about your system"
 msgstr "Visualizza informazioni su questo sistema"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1951,6 +1378,12 @@ msgstr "Lanciatori"
 msgid "Launch help browser"
 msgstr "Lancia il visualizzatore di manuali"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Impostazioni"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Lancia la calcolatrice"
@@ -1972,7 +1405,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Cerca"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
@@ -2021,20 +1454,11 @@ msgstr "Diminuisci la dimensione del testo"
 msgid "High contrast on or off"
 msgstr "Attiva o disattiva il contrasto elevato"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nessuna sorgente di input trovata"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Altro"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Aggiungi una sorgente di input"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Non è possibile usare i metodi di input nella schermata di accesso"
 
@@ -2042,123 +1466,30 @@ msgstr "Non è possibile usare i metodi di input nella schermata di accesso"
 msgid "No input source selected"
 msgstr "Nessuna sorgente di input selezionata"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "Opzioni…"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "Sposta su"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "Sposta giù"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Visualizza disposizione tastiera"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Rimuovi"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Scorciatoie personalizzate"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "Tasti carattere alternativi"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"I tasti caratteri alternativi consentono di digitare caratteri aggiuntivi. "
-"Questi sono solitamente impressi sulla tastiera come terze opzioni."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt sinistro"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt destro"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Super sinistro"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Super destro"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tasto menù"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl destro"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Tasto Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Il tasto Compose consente di immettere un'ampia varietà di caratteri. Per "
-"usarlo, premere il tasto Compose quindi una sequenza di caratteri. Per "
-"esempio, tasto Compose seguito da <b>C</b> e <b>o</b> per immettere <b>©</"
-"b>, <b>a</b> seguito da <b>'</b> per immettere <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Bloc Maiusc"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Blocco scorrimento"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Stampa schermo"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Le sorgenti di input possono essere commutate utilizzando la scorciatoia "
-"%s.\n"
-"Ciò può essere modificato nelle impostazioni delle scorciatoie da tastiera."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2180,56 +1511,31 @@ msgstr "Usare la _stessa sorgente per tutte le finestre"
 msgid "Switch input sources _individually for each window"
 msgstr "Cam_biare sorgenti di ingresso per ciascuna finestra"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Immissione caratteri speciali"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Metodi per l'immissione di simboli e varianti di lettere utilizzando la "
 "tastiera"
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tasti carattere alternativi"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tasto Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Scorciatoie da tastiera"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Visualizza e personalizza le scorciatoie"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modificata"
-msgstr[1] "%d modificate"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Ripristinare tutte le scorciatoie?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Ripristinare le scorciatoie potrebbe causare problemi con quelle "
-"personalizzate. Questa azione non può essere annullata."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Annulla"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Ripristina tutte"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2239,95 +1545,91 @@ msgstr "Ripristina tutte…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Ripristina tutte le scorciatoie al loro valore predefinito"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "_Azione:"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Scorciatoia"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Aggiungi scorciatoia"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Aggiungi scorciatoie personalizzate"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "Configurare scorciatoie personalizzate per l'avvio di app, l'esecuzione di "
 "script e altro ancora."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Aggiungi scorciatoia"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Nessuna scorciatoia trovata"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s è già in uso per %s: se viene sostituita, %s verrà disabilitata"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "Rimuovi"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Inserire la nuova scorciatoia"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Imposta scorciatoia personalizzata"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Imposta scorciatoia"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Inserire la nuova scorciatoia per cambiare %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Aggiungi scorciatoia personalizzata"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Aggiungi"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
 msgstr "Sostituisci"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "Imposta"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "_Imposta"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr "Premere Esc per annullare o Backspace per disabilitare la scorciatoia."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Nome"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Comando"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Scorciatoia"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Imposta scorciatoia…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Nessuno"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Ripristina la scorciatoia al suo valore predefinito"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Usa stampante come predefinita"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2341,7 +1643,6 @@ msgstr ""
 "Modifica le scorciatoie da tastiera e imposta le preferenze di digitazione, "
 "disposizioni della tastiera e sorgenti di input"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2349,15 +1650,15 @@ msgstr ""
 "scorciatoia;spazio;lavoro;finestra;ridimensiona;ingrandimento;zoom;contrasto;"
 "input;ingresso;immissione;sorgente;blocco;volume;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "I servizi di posizionamento sono spenti"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Nessuna applicazione può ottenere informazioni sulla posizione."
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2377,7 +1678,7 @@ msgstr ""
 "Consentire alle applicazioni riportate di seguito di determinare la propria "
 "posizione."
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Nessuna applicazione ha richiesto accesso alla posizione"
 
@@ -2385,175 +1686,19 @@ msgstr "Nessuna applicazione ha richiesto accesso alla posizione"
 msgid "Protect your location information"
 msgstr "Proteggere le informazioni sulla posizione"
 
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Spegnimento dello schermo"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 secondi"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minuti"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minuti"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minuti"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minuti"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 ora"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minuti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minuti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minuti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minuti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minuti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minuti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minuti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minuti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Mai"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"Il blocco automatico dello schermo impedisce l'accesso al computer ad altri "
-"utenti."
 
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "Ritardo schermo nero"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Tempo di inattività dopo il quale lo schermo diventa nero."
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "B_locco schermo automatico"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "Ri_tardo blocco schermo automatico"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "Tempo dopo il quale lo schermo si blocca automaticamente."
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "Most_rare notifiche sullo schermo bloccato"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "Proibire nuovi _dispositivi USB"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Impedisce a nuovi dispositivi USB di interagire col sistema quando lo "
-"schermo è bloccato"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Blocco schermo"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Blocca lo schermo"
-
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "Il microfono è spento"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Nessuna applicazione può registrare suoni."
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2567,13 +1712,17 @@ msgstr ""
 "\n"
 "Consentire alle applicazioni riportate di seguito di utilizzare il telefono."
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Nessuna applicazione ha richiesto accesso al microfono"
 
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:4
 msgid "Protect your conversations"
 msgstr "Proteggere le proprie conversazioni"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
@@ -2592,83 +1741,147 @@ msgstr "Pulsante primario"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "Imposta l'ordine dei pulsanti fisici su mouse e touchpad."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Sinistra"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Destra"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Posizioni di ricerca"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mouse"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Velocità mouse"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "Scorrimento naturale"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Lo scorrimento sposta il contenuto non la vista."
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Lo scorrimento sposta il contenuto non la vista."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Attivo"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Velocità touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Toccare per fare clic"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "Scorrimento a due dita"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Toccare per fare clic"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Velocità touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Scorrimento sul bordo"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Blocco scorrimento"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Fronte-retro"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Provare a fare clic, doppio-clic o scorrere"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinque clic, è ora di GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Doppio-clic, pulsante primario"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Clic singolo, pulsante primario"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Doppio-clic, pulsante centrale"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Clic singolo, pulsante centrale"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Doppio-clic, pulsante secondario"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Clic singolo, pulsante secondario"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2682,7 +1895,6 @@ msgstr ""
 "sinistra"
 
 # NOTA: cursore non è corretto, ma gli utenti non lo sanno :(
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -2764,87 +1976,41 @@ msgstr "Multi-attività"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Gestire le preferenze per produttività e multi-attività"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+#, fuzzy
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "Multitasking;Multitask;Multiattività;Attività;Produttività;Personalizza;"
 "Desktop;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Oops, sembra si sia verificato un problema: contattare il fornitore software."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager deve essere in esecuzione."
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Altri dispositivi"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Aggiungi nuova connessione"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Non impostato"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:266
-msgid "Insecure network (WEP)"
-msgstr "Rete non sicura (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:270
-msgid "Secure network (WPA)"
-msgstr "Rete sicura (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:274
-msgid "Secure network (WPA2)"
-msgstr "Rete sicura (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:278
-msgid "Secure network (WPA3)"
-msgstr "Rete sicura (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:282
-msgid "Secure network"
-msgstr "Rete sicura"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Connesso"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opzioni…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Accendendo l'hotspot verrà persa la connessione a %s e non sarà possibile "
-"accedere a internet usando il Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Deve contenere almeno 8 caratteri"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -2873,355 +2039,88 @@ msgid "Network Name"
 msgstr "Nome della rete"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Password"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Genera password casuale"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Genera password"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "A_ttiva"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Interrompere l'hotspot e disconnettere tutti gli utenti?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "Ferma _hotspot"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Modalità aereo"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Disabilita Wi-Fi, Bluetooth e la connessione a banda larga mobile"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Nessuna adattatore Wi-Fi trovato"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Assicurarsi di avere un adattatore Wi-Fi collegato e accesso"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Modalità aereo attiva"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Spegnere per usare il Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Hotspot Wi-Fi attivo"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "I dispositivi mobili possono leggere il codice QR per connettersi."
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Spegni hotspot…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Reti visibili"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager deve essere in esecuzione"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Oops, sembra si sia verificato un problema: contattare il fornitore software."
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Sicurezza 802.1x"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Sicurezza"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Preserva"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanente"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Casuale"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabile"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"L'indirizzo MAC inserito qui sarà usato come indirizzo hardware per il "
-"dispositivo di rete su cui è attivata questa connessione. Questa "
-"funzionalità è conosciuta come MAC cloning o spoofing. Esempio: "
-"00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profilo %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nessuna"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Mai"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i giorno fa"
 msgstr[1] "%i giorni fa"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nessuna"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Debole"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Buona"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Eccellente"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Indirizzo IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "Indirizzo IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Indirizzo IP"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "Dimentica connessione"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "Rimuovi profilo connessione"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "Rimuovi VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "Dettagli"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatica"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identità"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Elimina indirizzo"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "Elimina instradamento"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Nessuna"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Chiave WEP 40/128-bit (Hex o ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Passphrase WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinamico (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3232,8 +2131,20 @@ msgstr "Potenza segnale"
 msgid "Link speed"
 msgstr "Velocità collegamento"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sicurezza"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Indirizzo IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Indirizzo IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Indirizzo hardware"
 
@@ -3242,12 +2153,17 @@ msgid "Supported Frequencies"
 msgstr "Frequenze supportate"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Instradamento predefinito"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3261,12 +2177,12 @@ msgstr "Connettere _automaticamente"
 msgid "Make available to _other users"
 msgstr "Rendere disponibile agli altri _utenti"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 "Connessione a consu_mo: ha un limite sui dati o può avere costi aggiuntivi"
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3311,7 +2227,7 @@ msgstr "Solo link-local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manuale"
 
@@ -3331,33 +2247,32 @@ msgid "Addresses"
 msgstr "Indirizzi"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Indirizzo"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Netmask"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Gateway"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -3366,29 +2281,34 @@ msgstr "Automatico"
 msgid "Automatic DNS"
 msgstr "DNS automatico"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Separare gli indirizzi IP con virgole"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Instradamenti"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Instradamenti automatici"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metrica"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Usare questa connessione s_olo per risorse nella sua rete"
 
@@ -3401,83 +2321,13 @@ msgid "Automatic, DHCP only"
 msgstr "Automatico, solo DHCP"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Prefisso"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Impossibile aprire l'editor di connessione"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Nuovo profilo"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Importa da file…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "Aggiungi VPN"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Sicur_ezza"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Impossibile importare la connessione VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Impossibile leggere il file «%s» oppure il file non contiene informazioni di "
-"connessione VPN riconoscibili\n"
-"\n"
-"Errore: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Selezione file da importare"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Esiste già un file con nome «%s»."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Sostituisci"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Sostituire %s con la connessione VPN che si sta salvando?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Impossibile esportare la connessione VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Impossibile esportare la connessione VPN «%s» su %s.\n"
-"\n"
-"Errore: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Esporta connessione VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3491,105 +2341,48 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rete"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controlla la connessione a Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "rete;network;IP;LAN;proxy;WAN;boradband;banda larga;modem;bluetooth;vpn;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controlla come ci si connette alle reti Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "rete;network;wireless;wi-fi;wifi;IP;LAN;broadband;banda larga;DNS;hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "mai"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "oggi"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "ieri"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Ultimo uso"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Cavo"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Aggiungi nuova connessione"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Saranno persi i dettagli per le reti selezionate, inclusi la password e ogni "
-"configurazione personalizzata."
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "_Dimentica"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Reti Wi-Fi conosciute"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Dimentica"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "La politica di sistema proibisce l'uso come Hotspot"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Il dispositivo wireless non supporta la modalità Hotspot"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"L'individuazione automatica del proxy web è usata quando non viene fornito "
-"l'URL di configurazione."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Non è consigliato per reti pubbliche non fidate."
-
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Spegne il dispositivo"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Attivo"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3600,47 +2393,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Provider"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Indirizzo IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Proxy di rete"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "Proxy _HTTP"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "Proxy H_TTPS"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "Proxy _FTP"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Host _SOCKS"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "Host da _ignorare"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Porta proxy HTTP"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Porta proxy HTTPS"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Porta proxy FTP"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Porta proxy SOCKS"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "URL di _configurazione"
 
@@ -3667,300 +2464,22 @@ msgstr "Password"
 msgid "Turn Wi-Fi off"
 msgstr "Spegne il Wi-Fi"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Opzioni…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Connetti a rete nascosta…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Attiva hotspot Wi-Fi…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Reti Wi-Fi conosciute"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Stato sconosciuto"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Non gestito"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Non disponibile"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "In connessione"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Richiesta autenticazione"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "In disconnessione"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Connessione non riuscita"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Stato sconosciuto (mancante)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Configurazione non riuscita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Configurazione IP non riuscita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Configurazione IP scaduta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Erano richiesti dei segreti, ma non ne sono stati forniti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Supplicant 802.1X scollegato"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Configurazione supplicant 802.1X non riuscita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Supplicant 802.1X non riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "L'autenticazione del supplicant 802.1X ha impiegato troppo tempo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Avvio del servizio PPP non riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Servizio PPP disconnesso"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP non riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Avvio del client DHCP non riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Errore client DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Client DHCP non riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Avvio del servizio di connessione condivisa non riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Servizio connessione condivisa non riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Avvio del servizio AutoIP non riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Errore servizio AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Servizio AutoIP non riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linea occupata"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Nessun segnale di chiamata"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Impossibile stabilire alcuna portante"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "La richiesta di selezione è scaduta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Il tentativo di selezione non è riuscito"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Inizializzazione modem non riuscita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Selezione dell'APN specificato non riuscita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Nessuna ricerca attiva di reti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Registrazione rete negata"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Registrazione rete scaduta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Registrazione sulla rete richiesta non riuscita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Verifica PIN non riuscita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Potrebbe mancare il firmware per il dispositivo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Connessione scomparsa"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "È stata considerata la connessione esistente"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem non trovato"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Connessione Bluetooth non riuscita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Scheda SIM non inserita"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Richiesto codice PIN della SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Richiesto codice PUK della SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Scheda SIM errata"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Dipendenza della connessione non riuscita"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Firmware mancante"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Cavo scollegato"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "errore non definito nella sicurezza 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "nessun file selezionato"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "errore non specificato nel validare il file eap-method"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "Chiavi private DER, PEM o PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Certificati DER o PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "file PAC EAP-FAST mancante"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "File PAC (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4010,14 +2529,6 @@ msgstr "Autenticazione _interna"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Fornire a_utomaticamente PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "manca il nome utente EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "manca la password EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4030,7 +2541,7 @@ msgstr "Nome _utente"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "Pass_word"
 
@@ -4042,15 +2553,6 @@ msgstr "Pass_word"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Mostra la pass_word"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "certificato CA EAP-PEAP non valido: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "certificato CA EAP-PEAP non valido: nessun certificato specificato"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4073,7 +2575,6 @@ msgid "C_A certificate"
 msgstr "Certificato C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4088,63 +2589,6 @@ msgstr "Nessun certificato CA _richiesto"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versione PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "manca il nome utente EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "manca la password EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "manca l'identità EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "certificato CA EAP-TLS non valido: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "certificato CA EAP-TLS non valido: nessun certificato specificato"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "chiave privata EAP-TLS non valida: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificato utente EAP-TLS non valido: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Le chiavi private non cifrate non sono sicure"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"La chiave privata selezionata non sembra essere protetta da una password. "
-"Ciò può compromettere le proprie credenziali di sicurezza. Selezionare una "
-"chiave privata protetta da password.\n"
-"\n"
-"(È possibile proteggere le proprie chiavi private con «openssl».)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Scegliere il certificato personale"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Scegliere la chiave privata personale"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4161,15 +2605,6 @@ msgstr "C_hiave privata"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Password chiave _privata"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "certificato CA EAP-TTLS non valido: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "certificato CA EAP-TTLS non valido: nessun certificato specificato"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4192,14 +2627,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Dominio"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Errore sconosciuto nel validare la sicurezza 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4227,63 +2663,10 @@ msgstr "PEAP (Protected EAP)"
 msgid "Au_thentication"
 msgstr "Au_tenticazione"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Seleziona un file"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "manca leap-username"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "manca leap-password"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Manca la password Wi-Fi."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipo"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "manca wep-key"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"wep-key non valida: una chiave di lunghezza %zu deve contenere solo cifre "
-"esadecimali"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"wep-key non valida: una chiave di lunghezza %zu deve contenere solo "
-"caratteri ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"wep-key non valida: lunghezza chiave %zu non valida. Una chiave deve essere "
-"di lunghezza 5/13 (ascii) o 10/26 (esadecimale)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "wep-key non valida: la passphrase non può essere vuota"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"wep-key non valida: la passphrase deve essere più corta di 64 caratteri"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4308,21 +2691,6 @@ msgstr "M_ostra la chiave"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Indi_ce WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk non valida: lunghezza chiave %zu non valida. Deve essere [8,63] byte "
-"o 64 cifre esadecimali"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk non valida: impossibile interpretare chiave con 64 byte come "
-"esadecimali"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4377,58 +2745,34 @@ msgstr "Notifiche _schermo bloccato"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controlla quali notifiche visualizzare e cosa esse mostrano"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifiche;Banner;Messaggio;Tray;Popup;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "%s rimosso"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Altro"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Errore nel rimuovere l'account"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Annulla"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Mostra le notifiche di sistema"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "Usare i propri dati nel cloud"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "Nessuna connessione a Internet — Collegarsi per configurare gli account "
 "online"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Aggiungi account"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Account %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Rimuovi account"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4438,10 +2782,6 @@ msgstr "Account online"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Connette ai propri account online e decide per cosa usarli"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4449,10 +2789,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Conversazioni;Calendario;Email;"
 "Posta;Contatto;Contatti;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Tempo sconosciuto"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4468,13 +2804,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i ora"
 msgstr[1] "%i ore"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s e %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4486,190 +2815,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minuti"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s alla carica completa"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Attenzione: ancora %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "ancora %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Carica"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Non in carica"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Scarica"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "In carica"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "In scarica"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Mouse wireless"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Tastiera wireless"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "UPS"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "PDA"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Cellulare"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Lettore multimediale"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Computer"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Periferiche di gioco"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batteria"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principale"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Aggiuntiva"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batterie"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "Quando _inattivo"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "Sospendere"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "Spegnere"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "Ibernare"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "Nessuna azione"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "Quando a batteria"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "Quando collegato"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Mai"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "Sospensione automatica"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Modalità prestazioni temporaneamente disabilitata a causa dell'elevata "
-"temperatura di esercizio."
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Modalità prestazioni temporaneamente non disponibile. Spostare il "
-"dispositivo su una superficie stabile per ripristinarlo."
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr "Modalità prestazioni temporaneamente disabilitata."
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Batteria scarica: risparmio energetico abilitato. La modalità precedente "
-"verrà ripristinata quando la batteria è sufficientemente carica."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Modalità risparmio energetico attivata da «%s»."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Modalità prestazioni attivata da «%s»."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4731,6 +2876,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 ore"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batteria"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositivi"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Modalità energetica"
@@ -4751,90 +2905,63 @@ msgstr "Luminosità schermo automatica"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "La luminosità dello schermo si adatta alla luce circostante"
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Oscura lo schermo"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "Riduce la luminosità dello schermo quando il computer è inattivo"
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "_Spegnere schermo"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "Oscura lo schermo dopo un periodo di inattività"
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Risparmio energetico automatico"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr ""
 "Abilita la modalità di risparmio energetico quando la batteria è scarica"
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "Sospensione _automatica"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "Mette in pausa il computer dopo un periodo di inattività"
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Comportamento _pulsante alimentazione"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Mostrare _percentuale della batteria"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Sospensione automatica"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "Quando _collegato"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Quando a _batteria"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Ritardo"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Prestazioni"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Alte prestazioni e consumo energetico"
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Bilanciato"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Prestazioni e consumo energetico normali"
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Risparmio energia"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Prestazioni e consumo energetico ridotti"
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4846,7 +2973,6 @@ msgstr ""
 "Visualizza lo stato della batteria e cambia le impostazioni di risparmio "
 "energetico"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4854,27 +2980,6 @@ msgid ""
 msgstr ""
 "alimentazione;power;sleep;sospensione;ibernazione;batteria;luminosità;"
 "monitor;schermo;dim;abbassare;oscurare;DPMS;inattivo;energia;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "La stampante «%s» è stata eliminata"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "Aggiunta della nuova stampante non riuscita."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Impossibile caricare l'interfaccia: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Sbloccare per aggiungere stampanti e modificare le impostazioni"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4884,7 +2989,6 @@ msgstr "Stampanti"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Aggiunge stampanti, visualizza lavori di stampa e decide come stampare"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Stampante;Coda;Stampa;Carta;Inchiostro;Toner;"
@@ -4892,94 +2996,71 @@ msgstr "Stampante;Coda;Stampa;Carta;Inchiostro;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Aggiungi stampante"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Sblocca"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Nessuna stampante trovata"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Inserire un indirizzo di rete o cercare una stampante"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Richiesta autenticazione"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Inserire nome utente e password per visualizzare le stampanti disponibili "
 "sul server di stampa."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Nome utente"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "Dettagli di %s"
-
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Nessun driver adatto trovato"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "Selezionare file PPD"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"File PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
 
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Collocazione"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Driver"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Ricerca driver preferiti…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Cerca driver"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Seleziona dal database…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Installa file PPD…"
 
@@ -4991,132 +3072,20 @@ msgstr "Selezione driver stampante"
 msgid "Loading drivers database…"
 msgstr "Caricamento database dei driver…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Annulla"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Seleziona"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Stampante JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Stampante LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Singola facciata"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Lato lungo (standard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Lato corto (ribaltato)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Verticale"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Orizzontale"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Orizzontale invertito"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Verticale invertito"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "In attesa"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "In pausa"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Richiesta autenticazione"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "In elaborazione"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Fermato"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Annullato"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Interrotto"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Completato"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "Spostare questo lavoro in cima alla coda"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u lavoro richiede autenticazione"
 msgstr[1] "%u lavori richiedono autenticazione"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Lavori attivi"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Inserire le credenziali per stampare da %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5125,344 +3094,36 @@ msgid "Domain"
 msgstr "Dominio"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "A_utentica"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Pulisci tutto"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Autentica"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Nessun lavoro attivo"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Sblocca server di stampa"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Sblocca %s"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Inserire nome utente e password per visualizzare le stampanti disponibili su "
-"%s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Ricerca stampanti"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Porta seriale"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Porta parallela"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Collocazione: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Indirizzo: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Il server richiede autenticazione"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Fronte-retro"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Tipo di carta"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Sorgente carta"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Cassetto di uscita"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Risoluzione"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Pre-filtraggio GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Pagine per foglio"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Fronte-retro"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientamento"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Generale"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Impostazioni pagina"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opzioni installabili"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Lavoro"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Qualità immagine"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Colore"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Finitura"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avanzate"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Pagina di test"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Pagina di test"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Automatica"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Impostazioni predefinite stampante"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Includere solo i caratteri GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Convertire a PS livello 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Convertire a PS livello 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Nessun pre-filtraggio"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Produttore"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Nessun lavoro attivo"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u lavoro"
 msgstr[1] "%u lavori"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Pulizia testine"
-
-# cfr traduzioni simili su gtk+
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Toner in esaurimento"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Toner esaurito"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Developer in esaurimento"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Developer esaurito"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Disponibilità di un inchiostro in esaurimento"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Disponibilità di un inchiostro esaurita"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Coperchio aperto"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Sportello aperto"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Carta in esaurimento"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Carta esaurita"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Fuori rete"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Ferma"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Contenitore rifiuti quasi pieno"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Contenitore rifiuti pieno"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-"Il fotoconduttore ottico sta per terminare il suo periodo di operatività"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Il fotoconduttore ottico non è più funzionante"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Pronta"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Non accetta lavori"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "In elaborazione"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5486,41 +3147,45 @@ msgstr "Pulisci testine stampante"
 msgid "Remove Printer"
 msgstr "Rimuovi stampante"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nessun lavoro attivo"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Modello"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Livello inchiostro"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Riavviare la stampante una volta risolto il problema."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Riavvia"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Aggiungi stampante…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Aggiungi stampante…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Nessuna stampante"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Aggiungi stampante…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5528,50 +3193,33 @@ msgstr ""
 "Il servizio di sistema per la stampa\n"
 "sembra non essere disponibile."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formati"
-
-#: panels/region/cc-format-chooser.ui:37
-#: panels/wacom/cc-wacom-stylus-page.ui:136
-#: panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "Indietro"
 
 #: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr "Cerca lingue…"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Formati comuni"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Tutti i formati"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Nessun risultato"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Le ricerche possono essere per paese o lingua."
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Anteprima"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperiali"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metriche"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5602,27 +3250,32 @@ msgid "Logout…"
 msgstr "Esci…"
 
 #: panels/region/cc-region-panel.ui:45
+#, fuzzy
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
 "L'impostazione della lingua è utilizzata per il testo dell'interfaccia e le "
 "pagine web; il formato per numeri, date e valute."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Il proprio account"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Lingua"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formati"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Schermata di accesso"
 
@@ -5634,103 +3287,9 @@ msgstr "Regione e lingua"
 msgid "Select your display language and formats"
 msgstr "Seleziona la lingua e i formati utilizzati"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Lingua;Disposizione;Layout;Tastiera;Input;"
-
-# modificato un po' rispetto originale per mantere "azione"
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Chiedere l'azione da intraprendere"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Nessuna azione"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Aprire la cartella"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Altri supporti"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Selezionare un'applicazione per i CD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Selezionare un'applicazione per i DVD video"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Selezionare un'applicazione da eseguire quando viene connesso un lettore "
-"musicale"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-"Selezionare un'applicazione da eseguire quando viene connessa una fotocamera"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Selezionare un'applicazione per i CD di software"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Disco vuoto Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "Disco vuoto CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "Disco vuoto DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "Disco vuoto HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Disco video Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "Lettore e-book"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Disco video HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Software Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5780,7 +3339,6 @@ msgstr "Dispositivi rimovibili"
 msgid "Configure Removable Media settings"
 msgstr "Configurazione dispositivi rimovibili"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5790,13 +3348,80 @@ msgstr ""
 "preferite;cd;dvd;usb;audio;video;disco;rimovibile;media;multimedia;"
 "esecuzione;autorun;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Seleziona posizione"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Blocco schermo"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Il blocco automatico dello schermo impedisce l'accesso al computer ad altri "
+"utenti."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Ritardo schermo nero"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Tempo di inattività dopo il quale lo schermo diventa nero."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "B_locco schermo automatico"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Ri_tardo blocco schermo automatico"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Tempo dopo il quale lo schermo si blocca automaticamente."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Most_rare notifiche sullo schermo bloccato"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Notifiche _schermo bloccato"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Proibire nuovi _dispositivi USB"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Impedisce a nuovi dispositivi USB di interagire col sistema quando lo "
+"schermo è bloccato"
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Privacy"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Schermo"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Impostazioni"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5815,21 +3440,17 @@ msgstr ""
 msgid "Places"
 msgstr "Risorse"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Segnalibri"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "Altro"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Aggiungi posizione"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nessuna applicazione"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5858,65 +3479,13 @@ msgstr ""
 "Controlla quali applicazioni mostrano risultati di ricerca nella panoramica "
 "attività"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Cerca;Trova;Indice;Nascondi;Privacy;Risultati;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "Nessuna rete selezionata per la condivisione"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Reti"
-
-#: panels/sharing/cc-sharing-panel.c:363
-msgctxt "service is enabled"
-msgid "On"
-msgstr "On"
-
-#: panels/sharing/cc-sharing-panel.c:365 panels/sharing/cc-sharing-panel.c:392
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Off"
-
-#: panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Abilitato"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is active"
-msgid "Active"
-msgstr "Attivo"
-
-#: panels/sharing/cc-sharing-panel.c:516
-msgid "Choose a Folder"
-msgstr "Scegliere una cartella"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:744
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"La condivisione di file permette di condividere con altri la propria "
-"cartella Pubblici sulla rete attuale usando: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:750
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Quanto l'accesso remoto è abilitato, consente a utenti remoti di connettersi "
-"usando il comando Secure Shell:\n"
-"%s"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -5956,12 +3525,12 @@ msgstr "Richiedere la pass_word"
 msgid "Remote Login"
 msgstr "Accesso remoto"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "Computer remoto"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
@@ -5969,71 +3538,79 @@ msgstr ""
 "Computer remoto consente di visualizzare e controllare il computer da un "
 "altro computer"
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr ""
 "Abilita o disabilita le connessioni da computer remoti verso questo computer"
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "Controllo remoto"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
 msgstr "Consente alle connessioni utenti di controllare lo schermo"
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
 msgstr "Come connettersi"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
 "Collegarsi a questo computer utilizzando il nome del dispositivo o "
 "l'indirizzo di computer remoto."
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "Indirizzo computer remoto"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "Autenticazione"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr "Nome utente e password sono richiesti per collegarsi a questo computer"
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "Nome utente"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "Verifica crittografia"
 
-#: panels/sharing/cc-sharing-panel.ui:428
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr "Impronta digitale crittografica"
 
-#: panels/sharing/cc-sharing-panel.ui:429
+#: panels/sharing/cc-sharing-panel.ui:435
+#, fuzzy
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
 "L'impronta digitale di crittografia può essere visualizzata nella "
 "connessione dei client e dovrebbe essere identica"
 
-#: panels/sharing/cc-sharing-panel.ui:461
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Condivisione multimediale"
 
-#: panels/sharing/cc-sharing-panel.ui:483
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Condivide musica, fotografie e video sulla rete"
 
-#: panels/sharing/cc-sharing-panel.ui:496
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Cartelle"
 
@@ -6041,7 +3618,6 @@ msgstr "Cartelle"
 msgid "Control what you want to share with others"
 msgstr "Controlla cosa si vuole condividere con altri"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6059,38 +3635,38 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "È necessario autenticarsi per abilitare o disabilitare l'accesso remoto"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Personalizzato"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Latrato"
+msgid "Click"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "Goccia"
+#, fuzzy
+msgid "String"
+msgstr "Condivisione"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "Vetro"
+msgid "Swing"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "Sonar"
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Bilanciamento"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Dissolvenza"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Retro"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Fronte"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Test di %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6100,58 +3676,54 @@ msgstr "Fare clic su un altoparlante per eseguire un test"
 msgid "System Volume"
 msgstr "Volume di sistema"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Volume di sistema"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Livelli volume"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Uscita"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Dispositivo di uscita"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Test"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Configurazione"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "Bilanciamento"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "Dissolvenza"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Ingresso"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Dispositivo d'ingresso"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Volume"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Suono di avviso"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6162,83 +3734,12 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Regola i livelli dell'audio, gli ingressi, le uscite e i suoni d'allerta"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Scheda;Microfono;Volume;Fade;Dissolvenza;Bilanciamento;Bluetooth;Headset;"
 "Auricolare;Cuffie;Suono;Audio;Output;Uscita;Ingresso;Input;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Disconnesso"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "In connessione"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Connesso"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Errore nell'autorizzazione"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autorizzazione in corso"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Funzionalità ridotte"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Connesso e autorizzato"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Sconosciuto"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autorizzato:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Connesso:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Registrato:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Autorizzazione dispositivo non riuscita: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Errore nel dimenticare il dispositivo: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6247,94 +3748,54 @@ msgid_plural "Depends on %u other devices"
 msgstr[0] "Dipende da %u altro dispositivo"
 msgstr[1] "Dipende da %u altri dispositivi"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Mostra le notifiche di sistema"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Nome:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Stato:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Autorizza e connetti"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Dimentica dispositivo"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Errore"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt non supportato"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorizzato"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Impossibile connettersi al sottosistema Thunderbolt"
 
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Il sotto sistema Thunderbolt (boltd) non è installato o non è configurato "
-"correttamente."
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Accesso diretto"
 
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 "Consente di accedere direttamente ai dispositivi come dock e GPU esterne."
 
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "È possibile collegare solo dispositivi USB o Display Port."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Impossibile rilevare il supporto per Thunderbolt.\n"
-"Ciò può essere causato dal sistema che non supporta Thunderbolt, dall'aver "
-"disabilitato il supporto nel BIOS o dall'aver impostato nel BIOS un livello "
-"di sicurezza non adatto."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Il supporto Thunderbolt è stato disabilitato nel BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Impossibile determinare il livello di sicurezza Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Errore nel passare alla modalità diretta: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
-msgid "No Thunderbolt Support"
-msgstr "Thunderbolt non supportato"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:104
-msgid "Could not connect to the thunderbolt subsystem."
-msgstr "Impossibile connettersi al sottosistema Thunderbolt"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:153
-msgid "Direct Access"
-msgstr "Accesso diretto"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Dispositivi in attesa"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Nessun dispositivo collegato"
 
@@ -6346,7 +3807,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Gestisce dispositivi Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;"
@@ -6355,16 +3815,16 @@ msgstr "Thunderbolt;privacy;"
 msgid "Cursor Blinking"
 msgstr "Intermittenza del cursore"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Il cursore è intermittente nei campi di testo"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Velocità"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Velocità lampeggiamento cursore"
 
@@ -6452,15 +3912,15 @@ msgstr "Grande"
 msgid "Repeat Keys"
 msgstr "Ripetizione dei tasti"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "La pressione dei tasti ripete il carattere finché il tasto è premuto."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Ritardo ripetizione tasti"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Velocità ripetizione tasti"
 
@@ -6542,47 +4002,13 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Lungo"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "Abilita da _tastiera"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Attiva e disattiva le funzioni di accessibilità usando la tastiera"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Predefinito"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Medio"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Grande"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Più grande"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Il più grande"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixel"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6699,31 +4125,6 @@ msgstr "Illuminare l'intero _schermo"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Illuminare la _finestra"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Breve"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ dello schermo"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ dello schermo"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ dello schermo"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Lunga"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6881,7 +4282,6 @@ msgstr "Effetti colore"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Rende più semplice vedere, ascoltare, digitare e fare clic"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -6894,114 +4294,6 @@ msgstr ""
 "testo;font;tipo di carattere;dimensione;AccessX;tasti;singoli;sticky;lenti;"
 "slow;rimbalzati;slow;mouse;doppio;clic;ritardo;lampeggiare;ascoltare;"
 "digitare;audio;animazioni;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 ora"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 giorno"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 giorni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 giorni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 giorni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 giorni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 giorni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 giorni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 giorni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 giorni"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Svuotare il cestino?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Tutti gli oggetti nel cestino saranno rimossi in maniera definitiva."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "S_vuota cestino"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Eliminare tutti i file temporanei?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Tutti i file temporanei verranno rimossi in maniera definitiva."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Pulisci file temporanei"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 giorno"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 giorni"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 giorni"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Per sempre"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7070,57 +4362,10 @@ msgstr "Cronologia file e cestino"
 msgid "Don't leave traces"
 msgstr "Non lasciare tracce"
 
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr ""
-"Dovrebbe corrispondere all'indirizzo web del proprio fornitore di accesso."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Aggiunta dell'account non riuscita"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr "Le password non corrispondono."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Registrazione dell'account non riuscita"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Nessun modo supportato per autenticarsi con questo dominio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Join al dominio non riuscita"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Nome di accesso non valido.\n"
-"Provare di nuovo."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Password non valida.\n"
-"Provare di nuovo."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Accesso al dominio non riuscito"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Impossibile trovare il dominio. È stato digitato in modo errato?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7157,14 +4402,15 @@ msgid "Enterprise Login"
 msgstr "Account enterprise"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+#, fuzzy
+msgid "User accounts which are managed by a company or organization."
 msgstr "Account utenti gestiti da un'azienda o un'organizzazione"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "Fuori rete"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7173,10 +4419,6 @@ msgstr ""
 "L'accesso enterprise consente di usare su questo dispositivo un preesistente "
 "account utente gestito centralmente. È possibile utilizzare questo account "
 "per accedere alle risorse aziendali su Internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Esplora altre immagini"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7190,15 +4432,15 @@ msgstr "Gestore impronte digitali"
 msgid "Fingerprint"
 msgstr "Impronta digitale"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_No"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Sì"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7206,32 +4448,32 @@ msgstr ""
 "Eliminare le impronte digitali registrate così da disabilitare l'accesso "
 "tramite impronta?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Nessun dispositivo per impronte digitali"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "Nessun dispositivo per impronte digitali"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "Assicurarsi che il dispositivo sia collegato correttamente."
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Dispositivo impronte digitali"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "Scegliere il dispositivo per impronte digitali da configurare"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "Accesso con impronta"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7239,438 +4481,104 @@ msgstr ""
 "L'accesso con impronta consente di sbloccare e accedere al computer con le "
 "proprie dita"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "_Elimina impronte"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Registra impronte"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr ""
-"per eseguire questa azione è necessario che il dispositivo sia registrato"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Traccia precedente"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "il dispositivo è già registrato da un altro processo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "autorizzazione non disponibile per eseguire l'azione"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "nessuna impronta è stata registrata"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Impossibile comunicare con il dispositivo durante la registrazione"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Impossibile comunicare con il lettore di impronte digitali"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Impossibile comunicare con il demone delle impronte digitali"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Recupero delle impronte non riuscito: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Eliminazione delle impronte salvate non riuscita: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Pollice sinistro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Medio sinistro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Dito indice _sinistro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Anulare sinistro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Mignolo sinistro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Pollice destro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Medio destro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Dito indice _destro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Anulare destro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Mignolo destro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Dito sconosciuto"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Completata"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Dispositivo impronte digitali scollegato"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Spazio sul dispositivo impronte digitali esaurito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Registrazione della nuova impronta non riuscita"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Avvio della registrazione non riuscito: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Registrazione della nuova impronta non riuscita"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Arresto della registrazione non riuscito: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Alzare e posizionare ripetutamente il dito sul lettore per registrarne "
-"l'impronta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Registra nuovamente questo dito…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Scansiona nuova impronta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Rilascio del dispositivo per impronte digitali %s non riuscito: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Errore nel leggere il dispositivo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Ottenimento del dispositivo per impronte digitali %s non riuscito: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Recupero dei dispositivi per impronte digitali non riuscito: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Questa settimana"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Ultima settimana"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%H:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sessione terminata"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sessione avviata"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Attività account"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Scegliere un'altra password."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Digitare nuovamente la propria password attuale."
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Impossibile cambiare la password"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "_Successivo"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Cambia password"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "C_ambia"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "Password attuale"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "Nuova password"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "Conferma password"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Le password non corrispondono."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Permette all'utente di modificare la password al prossimo accesso"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Impostare una password adesso"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Impossibile unirsi automaticamente a questo tipo di dominio"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Nessun dominio o realm trovati"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Impossibile eseguire l'accesso come %s al dominio %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Password non valida, provare di nuovo"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Impossibile connettersi al dominio %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "Eliminazione dell'utente non riuscita"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "Revoca dell'utente gestito da remoto non riuscita"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "Non è concesso eliminare il proprio account."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s non ha ancora terminato la sessione"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Eliminare un utente mentre è ancora in corso la sua sessione può lasciare il "
-"sistema in uno stato incoerente."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Mantenere i file di %s?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"È possibile mantenere la directory home, gli spool di posta e i vari file "
-"temporanei quando si elimina un account utente."
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "_Elimina file"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "Mantieni _file"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Revocare veramente l'account di %s gestito da remoto?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "_Elimina"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Account disabilitato"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Da impostare al prossimo accesso"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Nessuno"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Accesso eseguito"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "Abilitato"
-
-# Contatto mi pareva orrendo...
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "Comunicazione con servizio account non riuscita"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Assicurarsi che AccountService sia installato e abilitato."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "Sbloccare questo pannello per modificare l'impostazione"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "Elimina l'account utente selezionato"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Per eliminare l'account utente selezionato,\n"
-"fare prima clic sull'icona *"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Sbloccare per aggiungere utenti e modificare le impostazioni"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Utenti"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "È necessario riavviare la sessione per applicare le modifiche"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Riavvia adesso"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Chiudi"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Accesso completo"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Accesso con i_mpronta"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "Accesso a_utomatico"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "Attività account"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Amministratore"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7678,32 +4586,32 @@ msgstr ""
 "Gli amministratori possono aggiungere e rimuovere utenti e possono "
 "modificare le impostazioni di tutti gli utenti."
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "Controlli _parentali"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Apre l'applicazione «Controlli parentali»."
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Rimuovi utente…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "Altri utenti"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "Aggiungi utente…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Nessuna utente trovato"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Sbloccare per aggiungere un account utente"
 
@@ -7711,7 +4619,6 @@ msgstr "Sbloccare per aggiungere un account utente"
 msgid "Add or remove users and change your password"
 msgstr "Aggiunge o rimuove utenti e cambia la propria password"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7756,182 +4663,8 @@ msgstr "Gestisce gli account online"
 msgid "Authentication is required to change user data"
 msgstr "È necessario autenticarsi per cambiare i dati utente"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "La nuova password deve essere diversa dalla precedente."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Provare a cambiare alcune lettere e numeri."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Provare a cambiare la password un po' di più."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Una password che non contiene il proprio nome utente è più robusta."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Provare a evitare l'uso del proprio nome nella password."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Provare a evitare alcune delle parole incluse nella password."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Provare a evitare parole comuni."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Provare a evitare di riordinare parole esistenti."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Provare a usare più numeri."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Provare a usare più lettere maiuscole."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Provare a usare più lettere minuscole."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Provare a usare più caratteri speciali, come quelli di punteggiatura."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-"Provare a usare una combinazione di lettere, numeri e segni di punteggiatura."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Provare a evitare la ripetizione dello stesso carattere."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Provare a evitare di ripetere lo stesso tipo di carattere: combinare "
-"lettere, numeri e segni di punteggiatura."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Provare a evitare sequenze come 1234 o abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"La password deve essere più lunga. Provare ad aggiungere più lettere, numeri "
-"e segni di punteggiatura."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Combinare lettere maiuscole e minuscole e usare un numero o due."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Aggiungendo altre lettere, numeri e segni di punteggiatura si renderà la "
-"password ancora più robusta."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Autenticazione non riuscita"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "La nuova password è troppo corta"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "La nuova password è troppo semplice"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "La nuova password è troppo simile alla vecchia"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "La nuova password è già stata usata di recente."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "La nuova password deve contenere caratteri numerici o speciali"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "La nuova password coincide con la vecchia"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-"La propria password è cambiata da quando si è inizialmente effettuata "
-"l'autenticazione."
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "La nuova password non contiene abbastanza caratteri diversi"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Errore sconosciuto"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Il nome utente deve essere formato da lettere minuscole (dalla a alla z), "
-"numeri e dai seguenti caratteri: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Il nome utente non è disponibile, provare un altro."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Il nome utente è troppo lungo."
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Associa pulsanti"
 
@@ -7964,47 +4697,11 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Rilevato clic errato, riavvio…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Pulsante %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Definito dall'applicazione"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Invia pressione tasti"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Cambia monitor"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Mostra aiuto a schermo"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tavoletta montata sul pannello del portatile"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tavoletta montata sullo schermo esterno"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
 msgstr "Tavoletta esterna"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Tutti gli schermi"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8014,30 +4711,30 @@ msgstr "Modalità tavoletta"
 msgid "Use absolute positioning for the pen"
 msgstr "Usare il posizionamento assoluto per la penna"
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "Orientamento per mancini"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr "Tavoletta ed Express Key™ sono ruotati per l'uso a sinistra"
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Mappare su monitor"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "Mantenere proporzioni"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 "Usa solo una porzione della superficie della tavoletta per mantenere le "
 "proporzioni"
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "Calibra"
 
@@ -8092,10 +4789,6 @@ msgstr "Sensibilità della gomma"
 msgid "Eraser pressure"
 msgstr "Pressione della gomma"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:133
-msgid "Default"
-msgstr "Predefinita"
-
 #: panels/wacom/cc-wacom-stylus-page.ui:134
 msgid "Middle Mouse Button Click"
 msgstr "Clic pulsante centrale del mouse"
@@ -8108,22 +4801,6 @@ msgstr "Clic pulsante destro del mouse"
 msgid "Forward"
 msgstr "Avanti"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Stilo aerografo con pressione, inclinazione e cursore integrato"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Stilo aerografo con pressione, inclinazione e rotazione"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Stilo standard con pressione e inclinazione"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Stilo standard con pressione"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tavoletta Wacom"
@@ -8134,54 +4811,97 @@ msgstr ""
 "Imposta la mappatura dei pulsanti e regola la sensibilità del pennino per "
 "tavolette grafiche"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;Tavoletta;Penna;Gomma;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Nuova scorciatoia…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Clic secondario _simulato"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Software Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+# cfr traduzioni simili su gtk+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Toner in esaurimento"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Ritardo clic secondario"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Software Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Gestire le preferenze per produttività e multi-attività"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Punti d'accesso"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Aggiungi"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salva"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operazione annullata"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Errore:</b> accesso negato per la modifica delle impostazioni"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Errore:</b> errore dell'apparecchiature mobile"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Non registrato"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registrato"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Ricerca"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Negato"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8211,104 +4931,13 @@ msgstr "Proprio numero"
 msgid "Device Details"
 msgstr "Dettagli dispositivo"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Produttore"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Versione firmware"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Solo 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Solo 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Solo 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (preferito)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (preferito), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (preferito), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (preferito)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (preferito), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (preferito)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (preferito), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (preferito)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (preferito), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Sconosciuta"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Sblocca scheda SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Sblocca"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Fornire il codice PIN per la scheda SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Inserire il PIN per sbloccare la scheda SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Fornire il codice PUK per la scheda SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Inserire il PUK per sbloccare la scheda SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8323,26 +4952,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Ancora %u tentativo rimasto"
 msgstr[1] "Ancora %u tentativi rimasti"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Password errata."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Il codice PUK deve essere un numero di 8 cifre"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Inserire nuovo PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Il codice PIN deve essere un numero di 4-8 cifre"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Sblocco…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -8400,147 +5009,47 @@ msgstr "Blocca la SIM con un PIN"
 msgid "M_odem Details"
 msgstr "Dettagli m_odem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Errore del telefono"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Nessuna connessione al telefono"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operazione non consentita"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operazione non supportata"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM non inserita"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Richiesto codice PIN della SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Richiesto codice PUK della SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Errore della scheda SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM occupata"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Password errata"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Richiesto codice PIN2 della SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Richiesto codice PUK2 della SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Non trovata"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Nessun servizio di rete"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Timeout di rete"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Servizi GPRS non consentiti"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming non consentito in questa località"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Errore GPRS non specificato"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "Azione annullata"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Accesso negato"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Errore sconosciuto"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Modalità di rete"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "_Imposta"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "Chiudi"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Automatica"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Scegli rete"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Aggiorna fornitori di rete"
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "Abilita rete mobile"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "Nessun adattatore WWAN trovato"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "Assicurarsi di disporre di un dispositivo Wan/Cellular Wireless"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "Wireless Wan è disabilitato quando la modalità aereo è attiva"
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "_Disattiva modalità aereo"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "Connessione dati"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "Scheda SIM utilizzata per Internet"
 
@@ -8552,15 +5061,15 @@ msgstr "Blocco SIM"
 msgid "_Next"
 msgstr "_Successivo"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "_Blocca SIM con un PIN"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "Cambia PIN"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr ""
 "Immettere il PIN corrente per modificare le impostazioni di blocco della SIM"
@@ -8573,7 +5082,6 @@ msgstr "Rete mobile"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configura telefonia e connessioni dati mobili"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellulare;wwan;telephony;sim;mobile;"
@@ -8591,37 +5099,13 @@ msgstr ""
 msgid "The GNOME Project"
 msgstr "Il progetto GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Visualizza numero di versione"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Abilita la modalità prolissa"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Cerca la stringa"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Elenca i nomi dei pannelli disponibili ed esce"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Pannello da mostrare"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANNELLO] [ARGOMENTO..]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacy"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Pannelli disponibili:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8679,7 +5163,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Annulla la ricerca"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferenze;Impostazioni;"
@@ -8720,24 +5203,2722 @@ msgstr ""
 "Una tupla che contiene la larghezza, l'altezza e lo stato massimizzato "
 "iniziali della finestra dell'applicazione."
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u uscita"
 msgstr[1] "%u uscite"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u ingresso"
 msgstr[1] "%u ingressi"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "Suoni di sistema"
+#~ msgid "System Bus"
+#~ msgstr "Bus di sistema"
+
+#~ msgid "Session Bus"
+#~ msgstr "Bus di sessione"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Accesso completo a /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Ha accesso alla rete"
+
+#~ msgid "Home"
+#~ msgstr "Home"
+
+#~ msgid "Read-only"
+#~ msgstr "Sola lettura"
+
+#~ msgid "File System"
+#~ msgstr "File system"
+
+#~ msgid "Can change settings"
+#~ msgstr "Può modificare impostazioni"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s dispone dei seguenti permessi integrati non modificabili. In caso di "
+#~ "dubbi riguardo a questi permessi, è consigliabile rimuovere "
+#~ "l'applicazione."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u file e collegamento aperto dall'app"
+#~ msgstr[1] "%u file e collegamenti aperti dall'app"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> viene utilizzato per aprire i seguenti tipi di file e "
+#~ "collegamenti."
+
+#, c-format
+#~ msgid "%s of disk space used"
+#~ msgstr "%s di spazio su disco utilizzato"
+
+#~ msgid "Select a picture"
+#~ msgstr "Seleziona un'immagine"
+
+#~ msgid "_Open"
+#~ msgstr "_Apri"
+
+#~ msgid "multiple sizes"
+#~ msgstr "dimensioni multiple"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Nessuno sfondo per la scrivania"
+
+#~ msgid "Current background"
+#~ msgstr "Sfondo attuale"
+
+#~ msgid "Light"
+#~ msgstr "Chiaro"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "schermo;blocco;diagnostica;crash;privato;recente;temporaneo;tmp;indice;"
+#~ "nome;rete;identità;"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Posizionare il dispositivo di calibrazione sul quadrato e premere «Avvia»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Spostare il dispositivo di calibrazione nella posizione di calibrazione e "
+#~ "premere «Continua»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Spostare il dispositivo di calibrazione nella posizione di superficie e "
+#~ "premere «Continua»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Chiudere il coperchio del portatile"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Si è verificato un errore interno impossibile da correggere."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Gli strumenti necessari alla calibrazione non sono installati."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Non è possibile generare il profilo."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Non è stato possibile ottenere il punto bianco prefissato."
+
+#~ msgid "Complete!"
+#~ msgstr "Completata"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Calibrazione non riuscita"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "È ora possibile rimuovere il dispositivo di calibrazione."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr ""
+#~ "Non disturbare il dispositivo di calibrazione mentre il processo è in "
+#~ "corso"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Schermo del portatile"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Webcam integrata"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Scanner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Fotocamera %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Stampante %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webcam %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Abilita la gestione del colore per %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Mostra i profili di colore per %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Non calibrato"
+
+#~ msgid "Default: "
+#~ msgstr "Predefinito: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Spazio colore: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Profilo di test: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Selezionare file profilo ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importa"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Profili ICC supportati"
+
+#~ msgid "All files"
+#~ msgstr "Tutti i file"
+
+#~ msgid "Save Profile"
+#~ msgstr "Salva profilo"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Crea un profilo di colore per il dispositivo selezionato"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Non è stato rilevato alcuno strumento di misura. Verificare che sia "
+#~ "acceso e connesso nel modo corretto."
+
+# profiling?
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr ""
+#~ "Lo strumento di misura non è in grado di creare un profilo della "
+#~ "stampante."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Il tipo di dispositivo non è al momento supportato."
+
+#~ msgid "Standard Space"
+#~ msgstr "Spazio standard"
+
+#~ msgid "Test Profile"
+#~ msgstr "Prova profilo"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatico"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Qualità bassa"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Qualità media"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Qualità alta"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB predefinito"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK predefinito"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Grigio predefinito"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Dati di calibrazione di fabbrica forniti dal produttore"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "Con questo profilo non è possibile la correzione dello schermo a schermo "
+#~ "intero"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Questo profilo potrebbe non essere più accurato"
+
+#~ msgid "Other…"
+#~ msgstr "Altro…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Sbloccare per modificare le impostazioni"
+
+#~ msgid "Today"
+#~ msgstr "Oggi"
+
+#~ msgid "Yesterday"
+#~ msgstr "Ieri"
+
+#~ msgid "%b %e"
+#~ msgstr "%d %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d ora"
+#~ msgstr[1] "%d ore"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuto"
+#~ msgstr[1] "%d minuti"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d secondo"
+#~ msgstr[1] "%d secondi"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24 ore"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %I:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %H:%M"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%I:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%H:%M"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "L'invio di segnalazioni consente di migliorare %s. Le segnalazioni "
+#~ "vengono inviate anonimamente e qualsiasi dato personale viene prima "
+#~ "eliminato (%s)."
+
+#~ msgid "On"
+#~ msgstr "On"
+
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Applicare le modifiche?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Le modifiche non possono essere applicate"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Ciò potrebbe essere dovuto a limitazioni hardware."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Disposizione schermo"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Orizzontale"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Verticale destro"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Verticale sinistro"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Orizzontale (capovolto)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Unknown"
+#~ msgstr "Sconosciuto"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Sconosciuto"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo di sistema"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nessuna sorgente di input trovata"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Altro"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Scorciatoie personalizzate"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "I tasti caratteri alternativi consentono di digitare caratteri "
+#~ "aggiuntivi. Questi sono solitamente impressi sulla tastiera come terze "
+#~ "opzioni."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt sinistro"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt destro"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super sinistro"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super destro"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tasto menù"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl destro"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Il tasto Compose consente di immettere un'ampia varietà di caratteri. Per "
+#~ "usarlo, premere il tasto Compose quindi una sequenza di caratteri. Per "
+#~ "esempio, tasto Compose seguito da <b>C</b> e <b>o</b> per immettere <b>©</"
+#~ "b>, <b>a</b> seguito da <b>'</b> per immettere <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Bloc Maiusc"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Stampa schermo"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Le sorgenti di input possono essere commutate utilizzando la scorciatoia "
+#~ "%s.\n"
+#~ "Ciò può essere modificato nelle impostazioni delle scorciatoie da "
+#~ "tastiera."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificata"
+#~ msgstr[1] "%d modificate"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Ripristinare tutte le scorciatoie?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Ripristinare le scorciatoie potrebbe causare problemi con quelle "
+#~ "personalizzate. Questa azione non può essere annullata."
+
+#~ msgid "Reset All"
+#~ msgstr "Ripristina tutte"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s è già in uso per %s: se viene sostituita, %s verrà disabilitata"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Inserire la nuova scorciatoia"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Imposta scorciatoia personalizzata"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Imposta scorciatoia"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Inserire la nuova scorciatoia per cambiare %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Aggiungi scorciatoia personalizzata"
+
+#~ msgid "Set"
+#~ msgstr "Imposta"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Spegnimento dello schermo"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 secondi"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuti"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuti"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuti"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minuti"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 ora"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minuti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minuti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minuti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minuti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minuti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Blocca lo schermo"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Scorrimento a due dita"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinque clic, è ora di GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Doppio-clic, pulsante primario"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Clic singolo, pulsante primario"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Doppio-clic, pulsante centrale"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Clic singolo, pulsante centrale"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Doppio-clic, pulsante secondario"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Clic singolo, pulsante secondario"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager deve essere in esecuzione."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Rete non sicura (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Rete sicura (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Rete sicura (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Rete sicura (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Rete sicura"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Accendendo l'hotspot verrà persa la connessione a %s e non sarà possibile "
+#~ "accedere a internet usando il Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Deve contenere almeno 8 caratteri"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Interrompere l'hotspot e disconnettere tutti gli utenti?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "Ferma _hotspot"
+
+#~ msgid "Preserve"
+#~ msgstr "Preserva"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanente"
+
+#~ msgid "Random"
+#~ msgstr "Casuale"
+
+#~ msgid "Stable"
+#~ msgstr "Stabile"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "L'indirizzo MAC inserito qui sarà usato come indirizzo hardware per il "
+#~ "dispositivo di rete su cui è attivata questa connessione. Questa "
+#~ "funzionalità è conosciuta come MAC cloning o spoofing. Esempio: "
+#~ "00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profilo %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nessuna"
+
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nessuna"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Debole"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Buona"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Eccellente"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Dimentica connessione"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Rimuovi profilo connessione"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Rimuovi VPN"
+
+#~ msgid "Details"
+#~ msgstr "Dettagli"
+
+#~ msgid "automatic"
+#~ msgstr "automatica"
+
+#~ msgid "Identity"
+#~ msgstr "Identità"
+
+#~ msgid "Delete Address"
+#~ msgstr "Elimina indirizzo"
+
+#~ msgid "Delete Route"
+#~ msgstr "Elimina instradamento"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Nessuna"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Chiave WEP 40/128-bit (Hex o ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Passphrase WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinamico (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Impossibile aprire l'editor di connessione"
+
+#~ msgid "New Profile"
+#~ msgstr "Nuovo profilo"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importa da file…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Aggiungi VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Impossibile importare la connessione VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Impossibile leggere il file «%s» oppure il file non contiene informazioni "
+#~ "di connessione VPN riconoscibili\n"
+#~ "\n"
+#~ "Errore: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Selezione file da importare"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Esiste già un file con nome «%s»."
+
+#~ msgid "_Replace"
+#~ msgstr "_Sostituisci"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Sostituire %s con la connessione VPN che si sta salvando?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Impossibile esportare la connessione VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Impossibile esportare la connessione VPN «%s» su %s.\n"
+#~ "\n"
+#~ "Errore: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Esporta connessione VPN"
+
+#~ msgid "never"
+#~ msgstr "mai"
+
+#~ msgid "today"
+#~ msgstr "oggi"
+
+#~ msgid "yesterday"
+#~ msgstr "ieri"
+
+#~ msgid "Last used"
+#~ msgstr "Ultimo uso"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Saranno persi i dettagli per le reti selezionate, inclusi la password e "
+#~ "ogni configurazione personalizzata."
+
+#~ msgid "_Forget"
+#~ msgstr "_Dimentica"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Reti Wi-Fi conosciute"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Dimentica"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "La politica di sistema proibisce l'uso come Hotspot"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Il dispositivo wireless non supporta la modalità Hotspot"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "L'individuazione automatica del proxy web è usata quando non viene "
+#~ "fornito l'URL di configurazione."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Non è consigliato per reti pubbliche non fidate."
+
+#~ msgid "Status unknown"
+#~ msgstr "Stato sconosciuto"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Non gestito"
+
+#~ msgid "Unavailable"
+#~ msgstr "Non disponibile"
+
+#~ msgid "Connecting"
+#~ msgstr "In connessione"
+
+#~ msgid "Authentication required"
+#~ msgstr "Richiesta autenticazione"
+
+#~ msgid "Disconnecting"
+#~ msgstr "In disconnessione"
+
+#~ msgid "Connection failed"
+#~ msgstr "Connessione non riuscita"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Stato sconosciuto (mancante)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Configurazione non riuscita"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Configurazione IP non riuscita"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Configurazione IP scaduta"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Erano richiesti dei segreti, ma non ne sono stati forniti"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Supplicant 802.1X scollegato"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Configurazione supplicant 802.1X non riuscita"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Supplicant 802.1X non riuscito"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "L'autenticazione del supplicant 802.1X ha impiegato troppo tempo"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Avvio del servizio PPP non riuscito"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Servizio PPP disconnesso"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP non riuscito"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Avvio del client DHCP non riuscito"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Errore client DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Client DHCP non riuscito"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Avvio del servizio di connessione condivisa non riuscito"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Servizio connessione condivisa non riuscito"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Avvio del servizio AutoIP non riuscito"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Errore servizio AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Servizio AutoIP non riuscito"
+
+#~ msgid "Line busy"
+#~ msgstr "Linea occupata"
+
+#~ msgid "No dial tone"
+#~ msgstr "Nessun segnale di chiamata"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Impossibile stabilire alcuna portante"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "La richiesta di selezione è scaduta"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Il tentativo di selezione non è riuscito"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Inizializzazione modem non riuscita"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Selezione dell'APN specificato non riuscita"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Nessuna ricerca attiva di reti"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Registrazione rete negata"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Registrazione rete scaduta"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Registrazione sulla rete richiesta non riuscita"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Verifica PIN non riuscita"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Potrebbe mancare il firmware per il dispositivo"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Connessione scomparsa"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "È stata considerata la connessione esistente"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem non trovato"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Connessione Bluetooth non riuscita"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Scheda SIM non inserita"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Richiesto codice PIN della SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Richiesto codice PUK della SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Scheda SIM errata"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Dipendenza della connessione non riuscita"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Firmware mancante"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cavo scollegato"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "errore non definito nella sicurezza 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "nessun file selezionato"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "errore non specificato nel validare il file eap-method"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "Chiavi private DER, PEM o PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificati DER o PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "file PAC EAP-FAST mancante"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "File PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "manca il nome utente EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "manca la password EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "certificato CA EAP-PEAP non valido: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "certificato CA EAP-PEAP non valido: nessun certificato specificato"
+
+#~ msgid "missing EAP username"
+#~ msgstr "manca il nome utente EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "manca la password EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "manca l'identità EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "certificato CA EAP-TLS non valido: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "certificato CA EAP-TLS non valido: nessun certificato specificato"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "chiave privata EAP-TLS non valida: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificato utente EAP-TLS non valido: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Le chiavi private non cifrate non sono sicure"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "La chiave privata selezionata non sembra essere protetta da una password. "
+#~ "Ciò può compromettere le proprie credenziali di sicurezza. Selezionare "
+#~ "una chiave privata protetta da password.\n"
+#~ "\n"
+#~ "(È possibile proteggere le proprie chiavi private con «openssl».)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Scegliere il certificato personale"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Scegliere la chiave privata personale"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "certificato CA EAP-TTLS non valido: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "certificato CA EAP-TTLS non valido: nessun certificato specificato"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Errore sconosciuto nel validare la sicurezza 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Seleziona un file"
+
+#~ msgid "missing leap-username"
+#~ msgstr "manca leap-username"
+
+#~ msgid "missing leap-password"
+#~ msgstr "manca leap-password"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Manca la password Wi-Fi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "manca wep-key"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "wep-key non valida: una chiave di lunghezza %zu deve contenere solo cifre "
+#~ "esadecimali"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "wep-key non valida: una chiave di lunghezza %zu deve contenere solo "
+#~ "caratteri ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "wep-key non valida: lunghezza chiave %zu non valida. Una chiave deve "
+#~ "essere di lunghezza 5/13 (ascii) o 10/26 (esadecimale)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "wep-key non valida: la passphrase non può essere vuota"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "wep-key non valida: la passphrase deve essere più corta di 64 caratteri"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk non valida: lunghezza chiave %zu non valida. Deve essere [8,63] "
+#~ "byte o 64 cifre esadecimali"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk non valida: impossibile interpretare chiave con 64 byte come "
+#~ "esadecimali"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s rimosso"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Altro"
+
+#~ msgid "Error removing account"
+#~ msgstr "Errore nel rimuovere l'account"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Account %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Rimuovi account"
+
+#~ msgid "Unknown time"
+#~ msgstr "Tempo sconosciuto"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s e %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s alla carica completa"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Attenzione: ancora %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "ancora %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Carica"
+
+#~ msgid "Not charging"
+#~ msgstr "Non in carica"
+
+#~ msgid "Empty"
+#~ msgstr "Scarica"
+
+#~ msgid "Charging"
+#~ msgstr "In carica"
+
+#~ msgid "Discharging"
+#~ msgstr "In scarica"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Mouse wireless"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Tastiera wireless"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "UPS"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "PDA"
+
+#~ msgid "Cellphone"
+#~ msgstr "Cellulare"
+
+#~ msgid "Media player"
+#~ msgstr "Lettore multimediale"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Computer"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Periferiche di gioco"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principale"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Aggiuntiva"
+
+#~ msgid "Batteries"
+#~ msgstr "Batterie"
+
+#~ msgid "When _idle"
+#~ msgstr "Quando _inattivo"
+
+#~ msgid "Suspend"
+#~ msgstr "Sospendere"
+
+#~ msgid "Power Off"
+#~ msgstr "Spegnere"
+
+#~ msgid "Hibernate"
+#~ msgstr "Ibernare"
+
+#~ msgid "Nothing"
+#~ msgstr "Nessuna azione"
+
+#~ msgid "When on battery power"
+#~ msgstr "Quando a batteria"
+
+#~ msgid "When plugged in"
+#~ msgstr "Quando collegato"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Mai"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Sospensione automatica"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Modalità prestazioni temporaneamente disabilitata a causa dell'elevata "
+#~ "temperatura di esercizio."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Modalità prestazioni temporaneamente non disponibile. Spostare il "
+#~ "dispositivo su una superficie stabile per ripristinarlo."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Modalità prestazioni temporaneamente disabilitata."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Batteria scarica: risparmio energetico abilitato. La modalità precedente "
+#~ "verrà ripristinata quando la batteria è sufficientemente carica."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Modalità risparmio energetico attivata da «%s»."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Modalità prestazioni attivata da «%s»."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Prestazioni"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Alte prestazioni e consumo energetico"
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Bilanciato"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Prestazioni e consumo energetico normali"
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Risparmio energia"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Prestazioni e consumo energetico ridotti"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "La stampante «%s» è stata eliminata"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Aggiunta della nuova stampante non riuscita."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Impossibile caricare l'interfaccia: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Sbloccare per aggiungere stampanti e modificare le impostazioni"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Dettagli di %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nessun driver adatto trovato"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Selezionare file PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "File PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Stampante JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Stampante LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Singola facciata"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Lato lungo (standard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Lato corto (ribaltato)"
+
+#~ msgid "Portrait"
+#~ msgstr "Verticale"
+
+#~ msgid "Landscape"
+#~ msgstr "Orizzontale"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Orizzontale invertito"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Verticale invertito"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "In attesa"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "In pausa"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Richiesta autenticazione"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "In elaborazione"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Fermato"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Annullato"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Interrotto"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Completato"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Spostare questo lavoro in cima alla coda"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Lavori attivi"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Inserire le credenziali per stampare da %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Sblocca server di stampa"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Sblocca %s"
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Inserire nome utente e password per visualizzare le stampanti disponibili "
+#~ "su %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Ricerca stampanti"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Porta seriale"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Porta parallela"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Collocazione: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Indirizzo: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Il server richiede autenticazione"
+
+#~ msgid "Two Sided"
+#~ msgstr "Fronte-retro"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tipo di carta"
+
+#~ msgid "Paper Source"
+#~ msgstr "Sorgente carta"
+
+#~ msgid "Output Tray"
+#~ msgstr "Cassetto di uscita"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Risoluzione"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Pre-filtraggio GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Pagine per foglio"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientamento"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Generale"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Impostazioni pagina"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opzioni installabili"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Lavoro"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Qualità immagine"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Colore"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Finitura"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avanzate"
+
+#~ msgid "Test page"
+#~ msgstr "Pagina di test"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatica"
+
+#~ msgid "Printer Default"
+#~ msgstr "Impostazioni predefinite stampante"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Includere solo i caratteri GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Convertire a PS livello 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Convertire a PS livello 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Nessun pre-filtraggio"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Pulizia testine"
+
+#~ msgid "Out of toner"
+#~ msgstr "Toner esaurito"
+
+#~ msgid "Low on developer"
+#~ msgstr "Developer in esaurimento"
+
+#~ msgid "Out of developer"
+#~ msgstr "Developer esaurito"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Disponibilità di un inchiostro in esaurimento"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Disponibilità di un inchiostro esaurita"
+
+#~ msgid "Open cover"
+#~ msgstr "Coperchio aperto"
+
+#~ msgid "Open door"
+#~ msgstr "Sportello aperto"
+
+#~ msgid "Low on paper"
+#~ msgstr "Carta in esaurimento"
+
+#~ msgid "Out of paper"
+#~ msgstr "Carta esaurita"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Fuori rete"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Ferma"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Contenitore rifiuti quasi pieno"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Contenitore rifiuti pieno"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr ""
+#~ "Il fotoconduttore ottico sta per terminare il suo periodo di operatività"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Il fotoconduttore ottico non è più funzionante"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Pronta"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Non accetta lavori"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "In elaborazione"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperiali"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metriche"
+
+# modificato un po' rispetto originale per mantere "azione"
+#~ msgid "Ask what to do"
+#~ msgstr "Chiedere l'azione da intraprendere"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nessuna azione"
+
+#~ msgid "Open folder"
+#~ msgstr "Aprire la cartella"
+
+#~ msgid "Other Media"
+#~ msgstr "Altri supporti"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Selezionare un'applicazione per i CD audio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Selezionare un'applicazione per i DVD video"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Selezionare un'applicazione da eseguire quando viene connesso un lettore "
+#~ "musicale"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Selezionare un'applicazione da eseguire quando viene connessa una "
+#~ "fotocamera"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Selezionare un'applicazione per i CD di software"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD audio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Disco vuoto Blu-ray"
+
+#~ msgid "blank CD disc"
+#~ msgstr "Disco vuoto CD"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "Disco vuoto DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Disco vuoto HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disco video Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "Lettore e-book"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disco video HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "Select Location"
+#~ msgstr "Seleziona posizione"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Nessuna applicazione"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nessuna rete selezionata per la condivisione"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "On"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Abilitato"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Scegliere una cartella"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "La condivisione di file permette di condividere con altri la propria "
+#~ "cartella Pubblici sulla rete attuale usando: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Quanto l'accesso remoto è abilitato, consente a utenti remoti di "
+#~ "connettersi usando il comando Secure Shell:\n"
+#~ "%s"
+
+#~ msgid "Custom"
+#~ msgstr "Personalizzato"
+
+#~ msgid "Bark"
+#~ msgstr "Latrato"
+
+#~ msgid "Drip"
+#~ msgstr "Goccia"
+
+#~ msgid "Glass"
+#~ msgstr "Vetro"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Test di %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Disconnesso"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "In connessione"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Connesso"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Errore nell'autorizzazione"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autorizzazione in corso"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Funzionalità ridotte"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Connesso e autorizzato"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Sconosciuto"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorizzato:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Connesso:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Registrato:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Autorizzazione dispositivo non riuscita: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Errore nel dimenticare il dispositivo: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Errore"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorizzato"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Il sotto sistema Thunderbolt (boltd) non è installato o non è configurato "
+#~ "correttamente."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "È possibile collegare solo dispositivi USB o Display Port."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Impossibile rilevare il supporto per Thunderbolt.\n"
+#~ "Ciò può essere causato dal sistema che non supporta Thunderbolt, "
+#~ "dall'aver disabilitato il supporto nel BIOS o dall'aver impostato nel "
+#~ "BIOS un livello di sicurezza non adatto."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Il supporto Thunderbolt è stato disabilitato nel BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Impossibile determinare il livello di sicurezza Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Errore nel passare alla modalità diretta: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Predefinito"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Medio"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Grande"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Più grande"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Il più grande"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixel"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Breve"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ dello schermo"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ dello schermo"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ dello schermo"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Lunga"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 ora"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 giorno"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 giorni"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 giorni"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 giorni"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 giorni"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 giorni"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 giorni"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 giorni"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 giorni"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Svuotare il cestino?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr ""
+#~ "Tutti gli oggetti nel cestino saranno rimossi in maniera definitiva."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "S_vuota cestino"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Eliminare tutti i file temporanei?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Tutti i file temporanei verranno rimossi in maniera definitiva."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Pulisci file temporanei"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 giorno"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 giorni"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 giorni"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Per sempre"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr ""
+#~ "Dovrebbe corrispondere all'indirizzo web del proprio fornitore di accesso."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Aggiunta dell'account non riuscita"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Registrazione dell'account non riuscita"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nessun modo supportato per autenticarsi con questo dominio"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Join al dominio non riuscita"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Nome di accesso non valido.\n"
+#~ "Provare di nuovo."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Password non valida.\n"
+#~ "Provare di nuovo."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Accesso al dominio non riuscito"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Impossibile trovare il dominio. È stato digitato in modo errato?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Esplora altre immagini"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr ""
+#~ "per eseguire questa azione è necessario che il dispositivo sia registrato"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "il dispositivo è già registrato da un altro processo"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "autorizzazione non disponibile per eseguire l'azione"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "nessuna impronta è stata registrata"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Impossibile comunicare con il dispositivo durante la registrazione"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Impossibile comunicare con il lettore di impronte digitali"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Impossibile comunicare con il demone delle impronte digitali"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Recupero delle impronte non riuscito: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Eliminazione delle impronte salvate non riuscita: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Pollice sinistro"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Medio sinistro"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Dito indice _sinistro"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Anulare sinistro"
+
+#~ msgid "Left little finger"
+#~ msgstr "Mignolo sinistro"
+
+#~ msgid "Right thumb"
+#~ msgstr "Pollice destro"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Medio destro"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Dito indice _destro"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Anulare destro"
+
+#~ msgid "Right little finger"
+#~ msgstr "Mignolo destro"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Dito sconosciuto"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Completata"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Dispositivo impronte digitali scollegato"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Spazio sul dispositivo impronte digitali esaurito"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Registrazione della nuova impronta non riuscita"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Avvio della registrazione non riuscito: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Registrazione della nuova impronta non riuscita"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Arresto della registrazione non riuscito: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Alzare e posizionare ripetutamente il dito sul lettore per registrarne "
+#~ "l'impronta"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Registra nuovamente questo dito…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Scansiona nuova impronta"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Rilascio del dispositivo per impronte digitali %s non riuscito: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Errore nel leggere il dispositivo"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr ""
+#~ "Ottenimento del dispositivo per impronte digitali %s non riuscito: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Recupero dei dispositivi per impronte digitali non riuscito: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Questa settimana"
+
+#~ msgid "Last Week"
+#~ msgstr "Ultima settimana"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%H:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sessione terminata"
+
+#~ msgid "Session Started"
+#~ msgstr "Sessione avviata"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Attività account"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Scegliere un'altra password."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Digitare nuovamente la propria password attuale."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Impossibile cambiare la password"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Impossibile unirsi automaticamente a questo tipo di dominio"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nessun dominio o realm trovati"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Impossibile eseguire l'accesso come %s al dominio %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Password non valida, provare di nuovo"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Impossibile connettersi al dominio %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Eliminazione dell'utente non riuscita"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Revoca dell'utente gestito da remoto non riuscita"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Non è concesso eliminare il proprio account."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s non ha ancora terminato la sessione"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Eliminare un utente mentre è ancora in corso la sua sessione può lasciare "
+#~ "il sistema in uno stato incoerente."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Mantenere i file di %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "È possibile mantenere la directory home, gli spool di posta e i vari file "
+#~ "temporanei quando si elimina un account utente."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Elimina file"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Mantieni _file"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Revocare veramente l'account di %s gestito da remoto?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Elimina"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Account disabilitato"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Da impostare al prossimo accesso"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Nessuno"
+
+#~ msgid "Logged in"
+#~ msgstr "Accesso eseguito"
+
+# Contatto mi pareva orrendo...
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Comunicazione con servizio account non riuscita"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Assicurarsi che AccountService sia installato e abilitato."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Sbloccare questo pannello per modificare l'impostazione"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Elimina l'account utente selezionato"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Per eliminare l'account utente selezionato,\n"
+#~ "fare prima clic sull'icona *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Sbloccare per aggiungere utenti e modificare le impostazioni"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "La nuova password deve essere diversa dalla precedente."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Provare a cambiare alcune lettere e numeri."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Provare a cambiare la password un po' di più."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Una password che non contiene il proprio nome utente è più robusta."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Provare a evitare l'uso del proprio nome nella password."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Provare a evitare alcune delle parole incluse nella password."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Provare a evitare parole comuni."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Provare a evitare di riordinare parole esistenti."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Provare a usare più numeri."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Provare a usare più lettere maiuscole."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Provare a usare più lettere minuscole."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Provare a usare più caratteri speciali, come quelli di punteggiatura."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Provare a usare una combinazione di lettere, numeri e segni di "
+#~ "punteggiatura."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Provare a evitare la ripetizione dello stesso carattere."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Provare a evitare di ripetere lo stesso tipo di carattere: combinare "
+#~ "lettere, numeri e segni di punteggiatura."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Provare a evitare sequenze come 1234 o abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "La password deve essere più lunga. Provare ad aggiungere più lettere, "
+#~ "numeri e segni di punteggiatura."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Combinare lettere maiuscole e minuscole e usare un numero o due."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Aggiungendo altre lettere, numeri e segni di punteggiatura si renderà la "
+#~ "password ancora più robusta."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autenticazione non riuscita"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "La nuova password è troppo corta"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "La nuova password è troppo semplice"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "La nuova password è troppo simile alla vecchia"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "La nuova password è già stata usata di recente."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "La nuova password deve contenere caratteri numerici o speciali"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "La nuova password coincide con la vecchia"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "La propria password è cambiata da quando si è inizialmente effettuata "
+#~ "l'autenticazione."
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "La nuova password non contiene abbastanza caratteri diversi"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Errore sconosciuto"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Il nome utente deve essere formato da lettere minuscole (dalla a alla z), "
+#~ "numeri e dai seguenti caratteri: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Il nome utente non è disponibile, provare un altro."
+
+#~ msgid "The username is too long."
+#~ msgstr "Il nome utente è troppo lungo."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Pulsante %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Definito dall'applicazione"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Invia pressione tasti"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Cambia monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Mostra aiuto a schermo"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tavoletta montata sul pannello del portatile"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tavoletta montata sullo schermo esterno"
+
+#~ msgid "All Displays"
+#~ msgstr "Tutti gli schermi"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Stilo aerografo con pressione, inclinazione e cursore integrato"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Stilo aerografo con pressione, inclinazione e rotazione"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Stilo standard con pressione e inclinazione"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Stilo standard con pressione"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nuova scorciatoia…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operazione annullata"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Errore:</b> accesso negato per la modifica delle impostazioni"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Errore:</b> errore dell'apparecchiature mobile"
+
+#~ msgid "Not Registered"
+#~ msgstr "Non registrato"
+
+#~ msgid "Registered"
+#~ msgstr "Registrato"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Ricerca"
+
+#~ msgid "Denied"
+#~ msgstr "Negato"
+
+#~ msgid "2G Only"
+#~ msgstr "Solo 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Solo 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Solo 4G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (preferito)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (preferito), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (preferito), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (preferito)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (preferito), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (preferito)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (preferito), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (preferito)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (preferito), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Sconosciuta"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Sblocca scheda SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Fornire il codice PIN per la scheda SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Inserire il PIN per sbloccare la scheda SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Fornire il codice PUK per la scheda SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Inserire il PUK per sbloccare la scheda SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Password errata."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Il codice PUK deve essere un numero di 8 cifre"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Inserire nuovo PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Il codice PIN deve essere un numero di 4-8 cifre"
+
+#~ msgid "Phone failure"
+#~ msgstr "Errore del telefono"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Nessuna connessione al telefono"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operazione non consentita"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operazione non supportata"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM non inserita"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Richiesto codice PIN della SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Richiesto codice PUK della SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Errore della scheda SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM occupata"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Password errata"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Richiesto codice PIN2 della SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Richiesto codice PUK2 della SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Non trovata"
+
+#~ msgid "No network service"
+#~ msgstr "Nessun servizio di rete"
+
+#~ msgid "Network timeout"
+#~ msgstr "Timeout di rete"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Servizi GPRS non consentiti"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming non consentito in questa località"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Errore GPRS non specificato"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Azione annullata"
+
+#~ msgid "Access denied"
+#~ msgstr "Accesso negato"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Errore sconosciuto"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Visualizza numero di versione"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Abilita la modalità prolissa"
+
+#~ msgid "Search for the string"
+#~ msgstr "Cerca la stringa"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Elenca i nomi dei pannelli disponibili ed esce"
+
+#~ msgid "Panel to display"
+#~ msgstr "Pannello da mostrare"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANNELLO] [ARGOMENTO..]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Pannelli disponibili:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Suoni di sistema"

--- a/po/it.po~
+++ b/po/it.po~
@@ -1,0 +1,8743 @@
+# Italian translation for gnome-control-center
+# Copyright (C) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Free Software Foundation, Inc.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 Free Software Foundation, Inc.
+# Alcune traduzioni sono state riprese da gnome-media
+# This file is relased with the same licence of gnome-control-center-package
+# Christopher R. Gabriel, 2001, 2002.
+# Alessio Dessì <alkex@inwind.it>, 2003, 2004, 2005, 2006, 2007.
+# Milo Casagrande <milo@milo.name>, 2009, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022.
+# Luca Ferretti <elle.uca@infinito.it>, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-06-14 15:29+0000\n"
+"PO-Revision-Date: 2022-06-14 17:28+0200\n"
+"Last-Translator: Milo Casagrande <milo@milo.name>\n"
+"Language-Team: Italiano <tp@lists.linux.it>\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: panels/applications/cc-applications-panel.c:790
+msgid "System Bus"
+msgstr "Bus di sistema"
+
+#: panels/applications/cc-applications-panel.c:790
+#: panels/applications/cc-applications-panel.c:792
+#: panels/applications/cc-applications-panel.c:805
+#: panels/applications/cc-applications-panel.c:810
+msgid "Full access"
+msgstr "Accesso completo"
+
+#: panels/applications/cc-applications-panel.c:792
+msgid "Session Bus"
+msgstr "Bus di sessione"
+
+#: panels/applications/cc-applications-panel.c:796
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
+#: panels/thunderbolt/cc-bolt-panel.ui:310
+msgid "Devices"
+msgstr "Dispositivi"
+
+#: panels/applications/cc-applications-panel.c:796
+msgid "Full access to /dev"
+msgstr "Accesso completo a /dev"
+
+#: panels/applications/cc-applications-panel.c:800
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rete"
+
+#: panels/applications/cc-applications-panel.c:800
+msgid "Has network access"
+msgstr "Ha accesso alla rete"
+
+#: panels/applications/cc-applications-panel.c:805
+#: panels/applications/cc-applications-panel.c:807
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Home"
+
+#: panels/applications/cc-applications-panel.c:807
+#: panels/applications/cc-applications-panel.c:812
+msgid "Read-only"
+msgstr "Sola lettura"
+
+#: panels/applications/cc-applications-panel.c:810
+#: panels/applications/cc-applications-panel.c:812
+msgid "File System"
+msgstr "File system"
+
+#: panels/applications/cc-applications-panel.c:816
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:878 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Impostazioni"
+
+#: panels/applications/cc-applications-panel.c:816
+msgid "Can change settings"
+msgstr "Può modificare impostazioni"
+
+#: panels/applications/cc-applications-panel.c:818
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s dispone dei seguenti permessi integrati non modificabili. In caso di "
+"dubbi riguardo a questi permessi, è consigliabile rimuovere l'applicazione."
+
+#: panels/applications/cc-applications-panel.c:1154
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u file e collegamento aperto dall'app"
+msgstr[1] "%u file e collegamenti aperti dall'app"
+
+#: panels/applications/cc-applications-panel.c:1161
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> viene utilizzato per aprire i seguenti tipi di file e collegamenti."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1213
+#, c-format
+msgid "%s of disk space used"
+msgstr "%s di spazio su disco utilizzato"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1377
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Applicazioni"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Nessuna applicazione"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Installa…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Apri"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Visualizza dettagli"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Cerca"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Riceve ricerche di sistema e invia risultati"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/applications/cc-applications-panel.ui:177
+#: panels/applications/cc-applications-panel.ui:191
+#: panels/applications/cc-applications-panel.ui:205
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
+#: panels/user-accounts/cc-user-panel.c:789
+#: panels/user-accounts/cc-user-panel.c:879
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1900
+msgid "Disabled"
+msgstr "Disabilitato"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notifiche"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Mostra le notifiche di sistema"
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in background"
+msgstr "Esegue in background"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Consente attività quando l'app è chiusa"
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Change Wallpaper"
+msgstr "Cambia sfondo"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Change the desktop wallpaper."
+msgstr "Cambia lo sfondo della scrivania"
+
+#: panels/applications/cc-applications-panel.ui:147
+#: panels/applications/cc-applications-panel.ui:154
+msgid "Sounds"
+msgstr "Suoni"
+
+#: panels/applications/cc-applications-panel.ui:148
+#: panels/applications/cc-applications-panel.ui:155
+msgid "Reproduce sounds."
+msgstr "Riproduce i suoni"
+
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Inhibit Shortcuts"
+msgstr "Blocca le scorciatoie"
+
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Block standard keyboard shortcuts."
+msgstr "Blocca le scorciatoie da tastiera standard"
+
+#: panels/applications/cc-applications-panel.ui:168
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Fotocamera"
+
+#: panels/applications/cc-applications-panel.ui:169
+#: panels/applications/cc-applications-panel.ui:176
+msgid "Take pictures with the camera."
+msgstr "Scatta foto con la fotocamera"
+
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microfono"
+
+#: panels/applications/cc-applications-panel.ui:183
+#: panels/applications/cc-applications-panel.ui:190
+msgid "Record audio with the microphone."
+msgstr "Registra audio col microfono"
+
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Servizi di localizzazione"
+
+#: panels/applications/cc-applications-panel.ui:197
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Access device location data."
+msgstr "Accede ai dati sulla posizione del dispositivo"
+
+#: panels/applications/cc-applications-panel.ui:215
+#: panels/applications/cc-applications-panel.ui:319
+msgid "Built-in Permissions"
+msgstr "Permessi integrati"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System access that is required by the app"
+msgstr "Accessi di sistema richiesti dall'app"
+
+#: panels/applications/cc-applications-panel.ui:224
+msgid "File &amp; Link Associations"
+msgstr "Associazioni di file e collegamenti"
+
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:399
+msgid "Storage"
+msgstr "Archivio"
+
+#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+msgid "No results found"
+msgstr "Nessun risultato trovato"
+
+#: panels/applications/cc-applications-panel.ui:304
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
+#: shell/cc-panel-list.ui:114
+msgid "Try a different search"
+msgstr "Provare un altro criterio di ricerca"
+
+#: panels/applications/cc-applications-panel.ui:344
+msgid "File & Link Associations"
+msgstr "Associazioni di file e collegamenti"
+
+#: panels/applications/cc-applications-panel.ui:367
+msgid "File Types"
+msgstr "Tipi di file"
+
+#: panels/applications/cc-applications-panel.ui:373
+msgid "Link Types"
+msgstr "Tipi di collegamento"
+
+#: panels/applications/cc-applications-panel.ui:383
+msgid "Reset"
+msgstr "Azzera"
+
+#: panels/applications/cc-applications-panel.ui:410
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "Lo spazio su disco utilizzato da questa applicazione per dati e cache."
+
+#: panels/applications/cc-applications-panel.ui:413
+msgid "Application"
+msgstr "Applicazione"
+
+#: panels/applications/cc-applications-panel.ui:419
+msgid "Data"
+msgstr "Dati"
+
+#: panels/applications/cc-applications-panel.ui:425
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:431
+msgid "<b>Total</b>"
+msgstr "<b>Totale</b>"
+
+#: panels/applications/cc-applications-panel.ui:441
+msgid "Clear Cache…"
+msgstr "Pulisci cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Controlla permessi e impostazioni delle applicazioni"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "applicazione;flatpak;permessi;impostazioni;"
+
+#: panels/background/cc-background-chooser.c:307
+msgid "Select a picture"
+msgstr "Seleziona un'immagine"
+
+#: panels/background/cc-background-chooser.c:310
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:198
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/network/cc-wifi-hotspot-dialog.ui:123
+#: panels/network/cc-wifi-panel.c:881
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:860
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:263
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:519 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:18
+#: panels/user-accounts/cc-user-panel.c:579
+#: panels/user-accounts/cc-user-panel.c:597
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:139
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
+msgid "_Cancel"
+msgstr "A_nnulla"
+
+#: panels/background/cc-background-chooser.c:311
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:264
+#: panels/sharing/cc-sharing-panel.c:520
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Apri"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "dimensioni multiple"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Nessuno sfondo per la scrivania"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Sfondo attuale"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stile"
+
+#: panels/background/cc-background-panel.ui:46
+msgid "Light"
+msgstr "Chiaro"
+
+#: panels/background/cc-background-panel.ui:73
+msgid "Dark"
+msgstr "Scuro"
+
+#: panels/background/cc-background-panel.ui:92
+msgid "Background"
+msgstr "Sfondo"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Add Picture…"
+msgstr "Aggiungi immagine…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aspetto"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Cambia l'immagine di sfondo o i colori dell'interfaccia"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgstr "Rivestimento;Sfondo;Scrivania;Desktop;Wallpaper;Chiaro;Scuro;Stile;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:21
+msgid "No Bluetooth Found"
+msgstr "Bluetooth non trovato"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:22
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Collegare un dispositivo per utilizzare Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:28
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth disattivato"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:29
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Attivare per collegare dispositivi e ricevere file."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:35
+msgid "Airplane Mode is On"
+msgstr "Modalità aereo attiva"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:36
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "In modalità aereo il Bluetooth è disabilitato."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Turn Off Airplane Mode"
+msgstr "Disattiva modalità aereo"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:53
+msgid "Hardware Airplane Mode is On"
+msgstr "Modalità aereo hardware attiva"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:54
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Disattivare la modalità aereo via hardware per abilitare il Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Attiva e disattiva il Bluetooth e connette i propri dispositivi"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "condivisione;condividere;share;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:21
+msgid "Camera is Turned Off"
+msgstr "La fotocamera è spenta"
+
+#: panels/camera/cc-camera-panel.ui:22
+msgid "No applications can capture photos or video."
+msgstr "Nessuna applicazione può catturare fotografie o video."
+
+#: panels/camera/cc-camera-panel.ui:36
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"L'utilizzo della fotocamera consente alle applicazioni di catturare "
+"fotografie e video. Disabilitando la fotocamera, alcune applicazioni "
+"potrebbero non funzionare correttamente.\n"
+"\n"
+"Consentire alle applicazioni riportate di seguito di utilizzare la "
+"fotocamera."
+
+#: panels/camera/cc-camera-panel.ui:52
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Nessuna applicazione ha richiesto accesso alla videocamera"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Proteggere le proprie immagini"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"schermo;blocco;diagnostica;crash;privato;recente;temporaneo;tmp;indice;nome;"
+"rete;identità;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Posizionare il dispositivo di calibrazione sul quadrato e premere «Avvia»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Spostare il dispositivo di calibrazione nella posizione di calibrazione e "
+"premere «Continua»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Spostare il dispositivo di calibrazione nella posizione di superficie e "
+"premere «Continua»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Chiudere il coperchio del portatile"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Si è verificato un errore interno impossibile da correggere."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Gli strumenti necessari alla calibrazione non sono installati."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Non è possibile generare il profilo."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Non è stato possibile ottenere il punto bianco prefissato."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Completata"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Calibrazione non riuscita"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "È ora possibile rimuovere il dispositivo di calibrazione."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr ""
+"Non disturbare il dispositivo di calibrazione mentre il processo è in corso"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Calibrazione schermo"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Avvia"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Riprendi"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+msgid "_Done"
+msgstr "_Fatto"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Schermo del portatile"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Webcam integrata"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Scanner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Fotocamera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Stampante %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webcam %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Abilita la gestione del colore per %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Mostra i profili di colore per %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Non calibrato"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Predefinito: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Spazio colore: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Profilo di test: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Selezionare file profilo ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importa"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Profili ICC supportati"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Tutti i file"
+
+#: panels/color/cc-color-panel.c:586
+msgid "Screen"
+msgstr "Schermo"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Salva profilo"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salva"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Crea un profilo di colore per il dispositivo selezionato"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Non è stato rilevato alcuno strumento di misura. Verificare che sia acceso e "
+"connesso nel modo corretto."
+
+# profiling?
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+"Lo strumento di misura non è in grado di creare un profilo della stampante."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Il tipo di dispositivo non è al momento supportato."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Calibrazione schermo"
+
+# non messo l'articolo perché è titolo di uno step dell'assistente, meglio
+# tenerli corti
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Qualità calibrazione"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"La calibrazione produrrà un profilo che potrà essere usato per la gestione "
+"del colore dello schermo. Più tempo si dedica alla calibrazione, migliore "
+"sarà la qualità del profilo colore."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Non sarà possibile usare il computer mentre viene eseguita la calibrazione."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Qualità"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Tempo stimato"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Dispositivo calibrazione"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+"Selezionare il dispositivo sensore che si vuole usare per la calibrazione."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tipo di schermo"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Selezionare il tipo di schermo connesso."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Punto bianco del profilo"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Selezionare un punto bianco prefissato per lo schermo. La maggior parte "
+"degli schermi dovrebbe essere calibrata all'illuminante D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Luminosità schermo"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Regolare la luminosità dello schermo in modo che sia quella usata "
+"abitualmente. La gestione del colore sarà più accurata a tale livello di "
+"luminosità."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"In alternativa è possibile usare il livello di luminosità usato con uno "
+"degli altri profili per questo dispositivo."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nome del profilo"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"È possibile usare un profilo colore su diversi computer, o anche creare "
+"profili per diverse condizioni di illuminazione."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nome del profilo:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Riepilogo"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Creazione del profilo riuscita."
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copia profilo"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Richiede un supporto scrivibile"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Potrebbero risultare utili le istruzioni su come usare il profilo su <a href="
+"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a href=\"windows"
+"\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Aggiungi profilo"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Rilevato un problema. Il profilo potrebbe non funzionare correttamente. <a "
+"href=\"\">Mostra dettagli.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importa file…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/network/connection-editor/net-connection-editor.c:497
+#: panels/printers/new-printer-dialog.ui:84
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "A_ggiungi"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Ciascun dispositivo necessita di un profilo di colore aggiornato per poter "
+"gestire il colore."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Maggiori informazioni"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Maggiori informazioni sulla gestione del colore"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Imposta per _tutti gli utenti"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Imposta questo profilo per tutti gli utenti del computer"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "A_bilita"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Aggiungi _profilo"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibra…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibra il dispositivo"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Rimuovi profilo"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "Visualizza _dettagli"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+"Impossibile rilevare un dispositivo che supporti la gestione del colore"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Proiettore"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (retroilluminazione CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (retroilluminazione LED RGB)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (retroilluminazione LED bianco)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD wide gamut (retroilluminazione CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD wide gamut (retroilluminazione LED RGB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alta"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minuti"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Media"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minuti"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Bassa"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minuti"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Nativo allo schermo"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (stampa e pubblicazione)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografia e grafica)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Spazio standard"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Prova profilo"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatico"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Qualità bassa"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Qualità media"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Qualità alta"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB predefinito"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK predefinito"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Grigio predefinito"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Dati di calibrazione di fabbrica forniti dal produttore"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+"Con questo profilo non è possibile la correzione dello schermo a schermo "
+"intero"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Questo profilo potrebbe non essere più accurato"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Colore"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibra il colore dei dispositivi, come schermi, fotocamere o stampanti"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Colore;ICC;Profilo;Calibrazione;Stampante;Display;Schermo;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Altro…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Seleziona lingua"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Seleziona"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nessuna lingua trovata"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Altro…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Sbloccare per modificare le impostazioni"
+
+#: panels/common/cc-permission-infobar.ui:40
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+"Alcune impostazioni devono essere sbloccate prima di poter essere modificate."
+
+#: panels/common/cc-permission-infobar.ui:57
+msgid "Unlock…"
+msgstr "Sblocca…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Incrementa ora"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Incrementa minuto"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Orario"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Diminuisci ora"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Diminuisci minuto"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:162
+msgid "Today"
+msgstr "Oggi"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:164
+msgid "Yesterday"
+msgstr "Ieri"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%d %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d ora"
+msgstr[1] "%d ore"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuto"
+msgstr[1] "%d minuti"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d secondo"
+msgstr[1] "%d secondi"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 secondi"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 ore"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %I:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %H:%M"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%I:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%H:%M"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data e ora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Anno"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mese"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Gennaio"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Febbraio"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Marzo"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Aprile"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maggio"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Giugno"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Luglio"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Agosto"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Settembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Ottobre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembre"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Dicembre"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Giorno"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Fuso orario"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Cerca una città"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Data e ora automatiche"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Richiede accesso a Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:177
+msgid "Date &amp; _Time"
+msgstr "Da_ta e ora"
+
+#: panels/datetime/cc-datetime-panel.ui:201
+msgid "Automatic Time _Zone"
+msgstr "_Fuso orario automatico"
+
+#: panels/datetime/cc-datetime-panel.ui:202
+msgid "Requires location services enabled and internet access"
+msgstr "Richiede servizi di localizzazione e accesso a Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:214
+msgid "Time Z_one"
+msgstr "Fus_o orario"
+
+#: panels/datetime/cc-datetime-panel.ui:239
+msgid "Time _Format"
+msgstr "F_ormato ora"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Cambia data e orario, così come fuso orario"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Orologio;Tempo;Data;Fuso;Posizione;Orario;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Cambia le impostazioni di sistema per l'ora e la data"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Per cambiare le impostazioni dell'ora e della data è necessario autenticarsi."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "E_mail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendario"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usica"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotografie"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Applicazioni predefinite"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configurazione applicazioni predefinite"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "predefinito;applicazione;preferite;dispositivo;media;multimedia;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"L'invio di segnalazioni consente di migliorare %s. Le segnalazioni vengono "
+"inviate anonimamente e qualsiasi dato personale viene prima eliminato (%s)."
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Segnalazione problemi"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Segnalazione _automatica problemi"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostica"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Segnala il problema"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"schermo;blocco;diagnostica;crash;privato;recente;temporaneo;tmp;indice;nome;"
+"rete;identità;privacy;"
+
+#: panels/display/cc-display-panel.c:512
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "On"
+
+#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Off"
+
+#: panels/display/cc-display-panel.c:945
+msgid "Apply Changes?"
+msgstr "Applicare le modifiche?"
+
+#: panels/display/cc-display-panel.c:950
+msgid "Changes Cannot be Applied"
+msgstr "Le modifiche non possono essere applicate"
+
+#: panels/display/cc-display-panel.c:952
+msgid "This could be due to hardware limitations."
+msgstr "Ciò potrebbe essere dovuto a limitazioni hardware."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Applica"
+
+#: panels/display/cc-display-panel.ui:97
+msgid "Display Settings Disabled"
+msgstr "Impostazioni schermo disabilitate"
+
+#: panels/display/cc-display-panel.ui:113
+msgid "Display Arrangement"
+msgstr "Disposizione schermo"
+
+#: panels/display/cc-display-panel.ui:124
+msgid "Multiple Displays"
+msgstr "Schermi multipli"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:133
+msgid "Join"
+msgstr "Unisci"
+
+#: panels/display/cc-display-panel.ui:140
+msgid "Mirror"
+msgstr "Duplica"
+
+#: panels/display/cc-display-panel.ui:153
+msgid "Contains top bar and Activities"
+msgstr "Contiene la barra superiore e Attività"
+
+#: panels/display/cc-display-panel.ui:154
+msgid "Primary Display"
+msgstr "Schermo primario"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:175
+#: panels/display/cc-display-panel.ui:223
+#: panels/display/cc-night-light-page.ui:77
+msgid "Night Light"
+msgstr "Modalità notturna"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Orizzontale"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Verticale destro"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Verticale sinistro"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Orizzontale (capovolto)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:40
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientamento"
+
+#: panels/display/cc-display-settings.ui:47
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Risoluzione"
+
+#: panels/display/cc-display-settings.ui:54
+msgid "Refresh Rate"
+msgstr "Frequenza aggiornamento"
+
+#: panels/display/cc-display-settings.ui:61
+msgid "Adjust for TV"
+msgstr "Regola per TV"
+
+#: panels/display/cc-display-settings.ui:75
+#: panels/display/cc-display-settings.ui:90
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Scala"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:21
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Disabilita fino a domani"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:35
+msgid "Restart Filter"
+msgstr "Riavvia filtro"
+
+#: panels/display/cc-night-light-page.ui:57
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"La modalità notturna imposta lo schermo con un colore più caldo, aiutando a "
+"prevenire l'affaticamento degli occhi e l'insonnia."
+
+#: panels/display/cc-night-light-page.ui:91
+msgid "Schedule"
+msgstr "Pianifica"
+
+#: panels/display/cc-night-light-page.ui:99
+msgid "Sunset to Sunrise"
+msgstr "Dal tramonto all'alba"
+
+#: panels/display/cc-night-light-page.ui:100
+msgid "Manual Schedule"
+msgstr "Pianificazione manuale"
+
+#: panels/display/cc-night-light-page.ui:110
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Orari"
+
+#: panels/display/cc-night-light-page.ui:123
+msgid "From"
+msgstr "Da"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/display/cc-night-light-page.ui:235
+msgid "Hour"
+msgstr "Ora"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/display/cc-night-light-page.ui:241
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:171
+#: panels/display/cc-night-light-page.ui:258
+msgid "Minute"
+msgstr "Minuto"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:181
+#: panels/display/cc-night-light-page.ui:268
+msgid "AM"
+msgstr "am"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:193
+#: panels/display/cc-night-light-page.ui:280
+msgid "PM"
+msgstr "pm"
+
+#: panels/display/cc-night-light-page.ui:210
+msgid "To"
+msgstr "A"
+
+#: panels/display/cc-night-light-page.ui:316
+msgid "Color Temperature"
+msgstr "Temperatura colore"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Schermi"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Sceglie come usare i monitor e i proiettori connessi"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Pannello;Proiettore;xrandr;Schermo;Risoluzione;Dimensioni;Refresh;Display;"
+"Monitor;Notte;Blu;colore;tramonto;alba;luce;notturna;"
+
+#: panels/info-overview/cc-info-overview-panel.c:411
+#: panels/info-overview/cc-info-overview-panel.c:435
+#: panels/info-overview/cc-info-overview-panel.c:481
+#: panels/info-overview/cc-info-overview-panel.c:511
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:443
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; ID versione: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:458
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:461
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:720
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:724
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:726
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo di sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "Device Name"
+msgstr "Nome dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Modello hardware"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memoria"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processore"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafica"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacità disco"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calcolo…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nome SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:106
+msgid "OS Type"
+msgstr "Tipo SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:114
+msgid "GNOME Version"
+msgstr "Versione GNOME"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "Windowing System"
+msgstr "Sistema grafico"
+
+#: panels/info-overview/cc-info-overview-panel.ui:131
+msgid "Virtualization"
+msgstr "Virtualizzazione"
+
+#: panels/info-overview/cc-info-overview-panel.ui:139
+msgid "Software Updates"
+msgstr "Aggiornamenti software"
+
+#: panels/info-overview/cc-info-overview-panel.ui:158
+msgid "Rename Device"
+msgstr "Rinomina dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Il nome del dispositivo viene usato per identificarlo all'interno della rete "
+"o quando viene associato con dispositivi Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid "_Rename"
+msgstr "_Rinomina"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Informazioni"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Visualizza informazioni su questo sistema"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;informazioni;memoria;processore;versione;predefinito;"
+"applicazione;preferite;cd;dvd;usb;audio;video;disco;rimovibile;media;"
+"multimedia;esecuzione;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Audio e multimediali"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Azzera/Ripristina il volume"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Abbassa volume"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Alza il volume"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Azzera/Ripristina il microfono"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Lancia il lettore multimediale"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Riproduci (o riproduci/pausa)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pausa"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Ferma la riproduzione"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Traccia precedente"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Traccia successiva"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Espelli"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Digitazione"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Passa a sorgente di input successiva"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Passa a sorgente di input precedente"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lanciatori"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Lancia il visualizzatore di manuali"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Lancia la calcolatrice"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Lancia il client email"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Lancia il browser web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Cartella home"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Cerca"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Termina la sessione"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Blocca lo schermo"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accessibilità"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Attiva o disattiva l'ingrandimento"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Aumenta l'ingrandimento"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Riduci l'ingrandimento"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Attiva o disattiva il lettore di schermo"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Attiva o disattiva la tastiera a schermo"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Incrementa la dimensione del testo"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Diminuisci la dimensione del testo"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Attiva o disattiva il contrasto elevato"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nessuna sorgente di input trovata"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Altro"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Aggiungi una sorgente di input"
+
+#: panels/keyboard/cc-input-chooser.ui:81
+msgid "Input methods can’t be used on the login screen"
+msgstr "Non è possibile usare i metodi di input nella schermata di accesso"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nessuna sorgente di input selezionata"
+
+#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+msgid "Move Up"
+msgstr "Sposta su"
+
+#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+msgid "Move Down"
+msgstr "Sposta giù"
+
+#: panels/keyboard/cc-input-row.ui:38
+msgid "Preferences"
+msgstr "Preferenze"
+
+#: panels/keyboard/cc-input-row.ui:45
+msgid "View Keyboard Layout"
+msgstr "Visualizza disposizione tastiera"
+
+#: panels/keyboard/cc-input-row.ui:51
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+msgid "Remove"
+msgstr "Rimuovi"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Scorciatoie personalizzate"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:62
+msgid "Alternate Characters Key"
+msgstr "Tasti carattere alternativi"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"I tasti caratteri alternativi consentono di digitare caratteri aggiuntivi. "
+"Questi sono solitamente impressi sulla tastiera come terze opzioni."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt sinistro"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt destro"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super sinistro"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super destro"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tasto menù"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl destro"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:79
+msgid "Compose Key"
+msgstr "Tasto Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Il tasto Compose consente di immettere un'ampia varietà di caratteri. Per "
+"usarlo, premere il tasto Compose quindi una sequenza di caratteri. Per "
+"esempio, tasto Compose seguito da <b>C</b> e <b>o</b> per immettere <b>©</"
+"b>, <b>a</b> seguito da <b>'</b> per immettere <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Bloc Maiusc"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Blocco scorrimento"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Stampa schermo"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Le sorgenti di input possono essere commutate utilizzando la scorciatoia "
+"%s.\n"
+"Ciò può essere modificato nelle impostazioni delle scorciatoie da tastiera."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Sorgenti input"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Include le disposizioni di tastiera e i metodi di input"
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Cambio sorgente di ingresso"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Usare la _stessa sorgente per tutte le finestre"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Cam_biare sorgenti di ingresso per ciascuna finestra"
+
+#: panels/keyboard/cc-keyboard-panel.ui:58
+msgid "Special Character Entry"
+msgstr "Immissione caratteri speciali"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Metodi per l'immissione di simboli e varianti di lettere utilizzando la "
+"tastiera"
+
+#: panels/keyboard/cc-keyboard-panel.ui:97
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Scorciatoie da tastiera"
+
+#: panels/keyboard/cc-keyboard-panel.ui:100
+msgid "View and Customize Shortcuts"
+msgstr "Visualizza e personalizza le scorciatoie"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificata"
+msgstr[1] "%d modificate"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Ripristinare tutte le scorciatoie?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Ripristinare le scorciatoie potrebbe causare problemi con quelle "
+"personalizzate. Questa azione non può essere annullata."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Annulla"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Ripristina tutte"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Ripristina tutte…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Ripristina tutte le scorciatoie al loro valore predefinito"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+msgid "Add Custom Shortcuts"
+msgstr "Aggiungi scorciatoie personalizzate"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Configurare scorciatoie personalizzate per l'avvio di app, l'esecuzione di "
+"script e altro ancora."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+msgid "Add Shortcut"
+msgstr "Aggiungi scorciatoia"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+msgid "No keyboard shortcut found"
+msgstr "Nessuna scorciatoia trovata"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s è già in uso per %s: se viene sostituita, %s verrà disabilitata"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Inserire la nuova scorciatoia"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Imposta scorciatoia personalizzata"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Imposta scorciatoia"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Inserire la nuova scorciatoia per cambiare %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
+msgid "Add Custom Shortcut"
+msgstr "Aggiungi scorciatoia personalizzata"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Aggiungi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
+msgid "Replace"
+msgstr "Sostituisci"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
+msgid "Set"
+msgstr "Imposta"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Premere Esc per annullare o Backspace per disabilitare la scorciatoia."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nome"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+msgid "Command"
+msgstr "Comando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+msgid "Shortcut"
+msgstr "Scorciatoia"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+msgid "Set Shortcut…"
+msgstr "Imposta scorciatoia…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "Nessuno"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Ripristina la scorciatoia al suo valore predefinito"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastiera"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Modifica le scorciatoie da tastiera e imposta le preferenze di digitazione, "
+"disposizioni della tastiera e sorgenti di input"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"scorciatoia;spazio;lavoro;finestra;ridimensiona;ingrandimento;zoom;contrasto;"
+"input;ingresso;immissione;sorgente;blocco;volume;"
+
+#: panels/location/cc-location-panel.ui:20
+msgid "Location Services Turned Off"
+msgstr "I servizi di posizionamento sono spenti"
+
+#: panels/location/cc-location-panel.ui:21
+msgid "No applications can obtain location information."
+msgstr "Nessuna applicazione può ottenere informazioni sulla posizione."
+
+#: panels/location/cc-location-panel.ui:35
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"I servizi di posizionamento consento alle applicazioni di conoscere le "
+"propria posizione geografica. Utilizzando il Wi-Fi e la rete mobile aumenta "
+"la precisione.\n"
+"\n"
+"Viene utilizzato il Mozilla Location Service: <a href='https://location."
+"services.mozilla.com/privacy'>Informativa sulla privacy</a>\n"
+"\n"
+"Consentire alle applicazioni riportate di seguito di determinare la propria "
+"posizione."
+
+#: panels/location/cc-location-panel.ui:53
+msgid "No Applications Have Asked for Location Access"
+msgstr "Nessuna applicazione ha richiesto accesso alla posizione"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Proteggere le informazioni sulla posizione"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:62
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Spegnimento dello schermo"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:65
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 secondi"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:68
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:71
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minuti"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:74
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minuti"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:77
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minuti"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:80
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minuti"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:83
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 ora"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:126
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:129
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minuti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:132
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minuti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:135
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minuti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:138
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minuti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:141
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minuti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:144
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minuti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:147
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minuti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:150
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minuti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:153
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Mai"
+
+#: panels/lock/cc-lock-panel.ui:8
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Il blocco automatico dello schermo impedisce l'accesso al computer ad altri "
+"utenti."
+
+#: panels/lock/cc-lock-panel.ui:13
+msgid "Blank Screen Delay"
+msgstr "Ritardo schermo nero"
+
+#: panels/lock/cc-lock-panel.ui:14
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Tempo di inattività dopo il quale lo schermo diventa nero."
+
+#: panels/lock/cc-lock-panel.ui:32
+msgid "Automatic Screen _Lock"
+msgstr "B_locco schermo automatico"
+
+#: panels/lock/cc-lock-panel.ui:46
+msgid "Automatic _Screen Lock Delay"
+msgstr "Ri_tardo blocco schermo automatico"
+
+#: panels/lock/cc-lock-panel.ui:47
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Tempo dopo il quale lo schermo si blocca automaticamente."
+
+#: panels/lock/cc-lock-panel.ui:65
+msgid "Show _Notifications on Lock Screen"
+msgstr "Most_rare notifiche sullo schermo bloccato"
+
+#: panels/lock/cc-lock-panel.ui:80
+msgid "Forbid new _USB devices"
+msgstr "Proibire nuovi _dispositivi USB"
+
+#: panels/lock/cc-lock-panel.ui:81
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Impedisce a nuovi dispositivi USB di interagire col sistema quando lo "
+"schermo è bloccato"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "Blocco schermo"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr "Blocca lo schermo"
+
+#: panels/microphone/cc-microphone-panel.ui:20
+msgid "Microphone Turned Off"
+msgstr "Il microfono è spento"
+
+#: panels/microphone/cc-microphone-panel.ui:21
+msgid "No applications can record sound."
+msgstr "Nessuna applicazione può registrare suoni."
+
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"L'utilizzo del microfono consente alle applicazioni di registrare audio. "
+"Disabilitando il microfono, alcune applicazioni potrebbero non funzionare "
+"correttamente.\n"
+"\n"
+"Consentire alle applicazioni riportate di seguito di utilizzare il telefono."
+
+#: panels/microphone/cc-microphone-panel.ui:51
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Nessuna applicazione ha richiesto accesso al microfono"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Proteggere le proprie conversazioni"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Test _impostazioni"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Generali"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Pulsante primario"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Imposta l'ordine dei pulsanti fisici su mouse e touchpad."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Sinistra"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Destra"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mouse"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Velocità mouse"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
+msgid "Natural Scrolling"
+msgstr "Scorrimento naturale"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
+msgid "Scrolling moves the content, not the view."
+msgstr "Lo scorrimento sposta il contenuto non la vista."
+
+#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:119
+msgid "Touchpad Speed"
+msgstr "Velocità touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:136
+msgid "Tap to Click"
+msgstr "Toccare per fare clic"
+
+#: panels/mouse/cc-mouse-panel.ui:147
+msgid "Two-finger Scrolling"
+msgstr "Scorrimento a due dita"
+
+#: panels/mouse/cc-mouse-panel.ui:159
+msgid "Edge Scrolling"
+msgstr "Scorrimento sul bordo"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Provare a fare clic, doppio-clic o scorrere"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinque clic, è ora di GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Doppio-clic, pulsante primario"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Clic singolo, pulsante primario"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Doppio-clic, pulsante centrale"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Clic singolo, pulsante centrale"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Doppio-clic, pulsante secondario"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Clic singolo, pulsante secondario"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mouse e touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Cambia la sensibilità di mouse e touchpad e seleziona se per mano destra o "
+"sinistra"
+
+# NOTA: cursore non è corretto, ma gli utenti non lo sanno :(
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Puntatore;Click;Clic;Tap;Doppio;Pulsante;Trackball;Cursore;Scroll;"
+"Scorrimento;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Angolo attivo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Toccare l'angolo in alto a sinistra per aprire la panoramica Attività"
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Bordi dello schermo attivi"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Trascinare le finestre contro i bordi superiore, sinistro e destro dello "
+"schermo per ridimensionarle"
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Spazi di lavoro"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "Spazi di lavoro _dinamici"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Elimina automaticamente gli spazi di lavoro vuoti"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "Numero di spazi di lavoro _fisso"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Specifica un numero di spazi di lavoro permanenti"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Numero di spazi di lavoro"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multi-schermo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Spazi di lavoro sono solo sullo schermo _primario"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Spazi di lavoro su _tutti gli schermi"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Cambio applicazioni"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Includere applicazioni da _tutti gli spazi di lavoro"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Includere solo applicazioni dello spazio di lavoro _corrente"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multi-attività"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Gestire le preferenze per produttività e multi-attività"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgstr ""
+"Multitasking;Multitask;Multiattività;Attività;Produttività;Personalizza;"
+"Desktop;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Oops, sembra si sia verificato un problema: contattare il fornitore software."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager deve essere in esecuzione."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Altri dispositivi"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
+#: panels/network/connection-editor/net-connection-editor.c:580
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:70
+msgid "Not set up"
+msgstr "Non impostato"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:207
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:266
+msgid "Insecure network (WEP)"
+msgstr "Rete non sicura (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:270
+msgid "Secure network (WPA)"
+msgstr "Rete sicura (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:274
+msgid "Secure network (WPA2)"
+msgstr "Rete sicura (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:278
+msgid "Secure network (WPA3)"
+msgstr "Rete sicura (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:282
+msgid "Secure network"
+msgstr "Rete sicura"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Connesso"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
+#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opzioni…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Accendendo l'hotspot verrà persa la connessione a %s e non sarà possibile "
+"accedere a internet usando il Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Deve contenere almeno 8 caratteri"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Deve contenere almeno %d carattere"
+msgstr[1] "Deve contenere almeno %d caratteri"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Attivare l'hotspot Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Un hotspot Wi-Fi consente di condividere la propria connessione a internet "
+"con altre persone creando una rete Wi-Fi a cui potersi connettere. Per "
+"attivare un hotspot, è necessario disporre di un'altra connessione a "
+"internet che non sia Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nome della rete"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:74
+#: panels/printers/new-printer-dialog.ui:331
+#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:362
+#: panels/wwan/cc-wwan-apn-dialog.ui:172
+msgid "Password"
+msgstr "Password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:86
+msgid "Generate Random Password"
+msgstr "Genera password casuale"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:87
+msgid "Autogenerate Password"
+msgstr "Genera password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:129
+msgid "_Turn On"
+msgstr "A_ttiva"
+
+#: panels/network/cc-wifi-panel.c:544
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:879
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Interrompere l'hotspot e disconnettere tutti gli utenti?"
+
+#: panels/network/cc-wifi-panel.c:882
+msgid "_Stop Hotspot"
+msgstr "Ferma _hotspot"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Airplane Mode"
+msgstr "Modalità aereo"
+
+#: panels/network/cc-wifi-panel.ui:73
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Disabilita Wi-Fi, Bluetooth e la connessione a banda larga mobile"
+
+#: panels/network/cc-wifi-panel.ui:110
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nessuna adattatore Wi-Fi trovato"
+
+#: panels/network/cc-wifi-panel.ui:120
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Assicurarsi di avere un adattatore Wi-Fi collegato e accesso"
+
+#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+msgid "Airplane Mode On"
+msgstr "Modalità aereo attiva"
+
+#: panels/network/cc-wifi-panel.ui:162
+msgid "Turn off to use Wi-Fi"
+msgstr "Spegnere per usare il Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:199
+msgid "Wi-Fi Hotspot Active"
+msgstr "Hotspot Wi-Fi attivo"
+
+#: panels/network/cc-wifi-panel.ui:209
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "I dispositivi mobili possono leggere il codice QR per connettersi."
+
+#: panels/network/cc-wifi-panel.ui:217
+msgid "Turn Off Hotspot…"
+msgstr "Spegni hotspot…"
+
+#: panels/network/cc-wifi-panel.ui:237
+msgid "Visible Networks"
+msgstr "Reti visibili"
+
+#: panels/network/cc-wifi-panel.ui:294
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager deve essere in esecuzione"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Sicurezza 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sicurezza"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Preserva"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanente"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Casuale"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabile"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"L'indirizzo MAC inserito qui sarà usato come indirizzo hardware per il "
+"dispositivo di rete su cui è attivata questa connessione. Questa "
+"funzionalità è conosciuta come MAC cloning o spoofing. Esempio: "
+"00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profilo %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:101
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:107
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:112
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:119
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:130
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nessuna"
+
+#: panels/network/connection-editor/ce-page-details.c:151
+msgid "Never"
+msgstr "Mai"
+
+#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i giorno fa"
+msgstr[1] "%i giorni fa"
+
+#: panels/network/connection-editor/ce-page-details.c:293
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:295
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:312
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nessuna"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Debole"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Buona"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Eccellente"
+
+#: panels/network/connection-editor/ce-page-details.c:409
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Indirizzo IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:410
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
+msgid "IPv6 Address"
+msgstr "Indirizzo IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:412
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Indirizzo IP"
+
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:420
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
+#: panels/network/network-mobile.ui:217
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:473
+msgid "Forget Connection"
+msgstr "Dimentica connessione"
+
+#: panels/network/connection-editor/ce-page-details.c:475
+msgid "Remove Connection Profile"
+msgstr "Rimuovi profilo connessione"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Remove VPN"
+msgstr "Rimuovi VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:495
+msgid "Details"
+msgstr "Dettagli"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatica"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identità"
+
+#: panels/network/connection-editor/ce-page-ip4.c:245
+#: panels/network/connection-editor/ce-page-ip6.c:226
+msgid "Delete Address"
+msgstr "Elimina indirizzo"
+
+#: panels/network/connection-editor/ce-page-ip4.c:392
+#: panels/network/connection-editor/ce-page-ip6.c:361
+msgid "Delete Route"
+msgstr "Elimina instradamento"
+
+#: panels/network/connection-editor/ce-page-ip4.c:742
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:712
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Nessuna"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Chiave WEP 40/128-bit (Hex o ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Passphrase WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinamico (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Potenza segnale"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Velocità collegamento"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Indirizzo hardware"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Frequenze supportate"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:189
+msgid "Default Route"
+msgstr "Instradamento predefinito"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Ultimo uso"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Connettere _automaticamente"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Rendere disponibile agli altri _utenti"
+
+#: panels/network/connection-editor/details-page.ui:412
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"Connessione a consu_mo: ha un limite sui dati o può avere costi aggiuntivi"
+
+#: panels/network/connection-editor/details-page.ui:421
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Gli aggiornamenti software, e altri scaricamenti di dati, non verranno "
+"avviati automaticamente."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nome"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Indirizzo _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Indirizzo _clonato"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "byte"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Metodo IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatico (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Solo link-local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+msgid "Manual"
+msgstr "Manuale"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Disabilita"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Condivisa con altri computer"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Indirizzi"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:255
+#: panels/printers/pp-details-dialog.ui:90
+msgid "Address"
+msgstr "Indirizzo"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:258
+msgid "Netmask"
+msgstr "Netmask"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:279
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:232
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automatico"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automatico"
+
+#: panels/network/connection-editor/ip4-page.ui:196
+#: panels/network/connection-editor/ip6-page.ui:205
+msgid "Separate IP addresses with commas"
+msgstr "Separare gli indirizzi IP con virgole"
+
+#: panels/network/connection-editor/ip4-page.ui:213
+#: panels/network/connection-editor/ip6-page.ui:222
+msgid "Routes"
+msgstr "Instradamenti"
+
+#: panels/network/connection-editor/ip4-page.ui:231
+#: panels/network/connection-editor/ip6-page.ui:240
+msgid "Automatic Routes"
+msgstr "Instradamenti automatici"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:281
+#: panels/network/connection-editor/ip6-page.ui:290
+msgid "Metric"
+msgstr "Metrica"
+
+#: panels/network/connection-editor/ip4-page.ui:304
+#: panels/network/connection-editor/ip6-page.ui:313
+msgid "Use this connection _only for resources on its network"
+msgstr "Usare questa connessione s_olo per risorse nella sua rete"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Metodo IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatico, solo DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:267
+msgid "Prefix"
+msgstr "Prefisso"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Impossibile aprire l'editor di connessione"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Nuovo profilo"
+
+#: panels/network/connection-editor/net-connection-editor.c:715
+msgid "Import from file…"
+msgstr "Importa da file…"
+
+#: panels/network/connection-editor/net-connection-editor.c:741
+msgid "Add VPN"
+msgstr "Aggiungi VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Sicur_ezza"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Impossibile importare la connessione VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Impossibile leggere il file «%s» oppure il file non contiene informazioni di "
+"connessione VPN riconoscibili\n"
+"\n"
+"Errore: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Selezione file da importare"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Esiste già un file con nome «%s»."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Sostituisci"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Sostituire %s con la connessione VPN che si sta salvando?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Impossibile esportare la connessione VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Impossibile esportare la connessione VPN «%s» su %s.\n"
+"\n"
+"Errore: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Esporta connessione VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Errore: impossibile caricare l'editor di connessioni VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Controlla la connessione a Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"rete;network;IP;LAN;proxy;WAN;boradband;banda larga;modem;bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controlla come ci si connette alle reti Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"rete;network;wireless;wi-fi;wifi;IP;LAN;broadband;banda larga;DNS;hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "mai"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "oggi"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "ieri"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Ultimo uso"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Cavo"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Aggiungi nuova connessione"
+
+#: panels/network/net-device-wifi.c:857
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Saranno persi i dettagli per le reti selezionate, inclusi la password e ogni "
+"configurazione personalizzata."
+
+#: panels/network/net-device-wifi.c:861
+msgid "_Forget"
+msgstr "_Dimentica"
+
+#: panels/network/net-device-wifi.c:1041
+msgid "Known Wi-Fi Networks"
+msgstr "Reti Wi-Fi conosciute"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1073
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Dimentica"
+
+#: panels/network/net-device-wifi.c:1216
+msgid "System policy prohibits use as a Hotspot"
+msgstr "La politica di sistema proibisce l'uso come Hotspot"
+
+#: panels/network/net-device-wifi.c:1219
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Il dispositivo wireless non supporta la modalità Hotspot"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"L'individuazione automatica del proxy web è usata quando non viene fornito "
+"l'URL di configurazione."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Non è consigliato per reti pubbliche non fidate."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Spegne il dispositivo"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Provider"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+msgid "Network Proxy"
+msgstr "Proxy di rete"
+
+#: panels/network/network-proxy.ui:139
+msgid "_HTTP Proxy"
+msgstr "Proxy _HTTP"
+
+#: panels/network/network-proxy.ui:156
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTPS"
+
+#: panels/network/network-proxy.ui:173
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP"
+
+#: panels/network/network-proxy.ui:190
+msgid "_Socks Host"
+msgstr "Host _SOCKS"
+
+#: panels/network/network-proxy.ui:207
+msgid "_Ignore Hosts"
+msgstr "Host da _ignorare"
+
+#: panels/network/network-proxy.ui:244
+msgid "HTTP proxy port"
+msgstr "Porta proxy HTTP"
+
+#: panels/network/network-proxy.ui:307
+msgid "HTTPS proxy port"
+msgstr "Porta proxy HTTPS"
+
+#: panels/network/network-proxy.ui:322
+msgid "FTP proxy port"
+msgstr "Porta proxy FTP"
+
+#: panels/network/network-proxy.ui:337
+msgid "Socks proxy port"
+msgstr "Porta proxy SOCKS"
+
+#: panels/network/network-proxy.ui:357
+msgid "_Configuration URL"
+msgstr "URL di _configurazione"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Spegne la connessione VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nome della rete"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tipo di sicurezza"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Password"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Spegne il Wi-Fi"
+
+#: panels/network/network-wifi.ui:121
+msgid "_Connect to Hidden Network…"
+msgstr "_Connetti a rete nascosta…"
+
+#: panels/network/network-wifi.ui:128
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Attiva hotspot Wi-Fi…"
+
+#: panels/network/network-wifi.ui:135
+msgid "_Known Wi-Fi Networks"
+msgstr "_Reti Wi-Fi conosciute"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Stato sconosciuto"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Non gestito"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Non disponibile"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "In connessione"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Richiesta autenticazione"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "In disconnessione"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Connessione non riuscita"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Stato sconosciuto (mancante)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Configurazione non riuscita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Configurazione IP non riuscita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Configurazione IP scaduta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Erano richiesti dei segreti, ma non ne sono stati forniti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Supplicant 802.1X scollegato"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Configurazione supplicant 802.1X non riuscita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Supplicant 802.1X non riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "L'autenticazione del supplicant 802.1X ha impiegato troppo tempo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Avvio del servizio PPP non riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Servizio PPP disconnesso"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP non riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Avvio del client DHCP non riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Errore client DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Client DHCP non riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Avvio del servizio di connessione condivisa non riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Servizio connessione condivisa non riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Avvio del servizio AutoIP non riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Errore servizio AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Servizio AutoIP non riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linea occupata"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Nessun segnale di chiamata"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Impossibile stabilire alcuna portante"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "La richiesta di selezione è scaduta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Il tentativo di selezione non è riuscito"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Inizializzazione modem non riuscita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Selezione dell'APN specificato non riuscita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Nessuna ricerca attiva di reti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Registrazione rete negata"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Registrazione rete scaduta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Registrazione sulla rete richiesta non riuscita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Verifica PIN non riuscita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Potrebbe mancare il firmware per il dispositivo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Connessione scomparsa"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "È stata considerata la connessione esistente"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem non trovato"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Connessione Bluetooth non riuscita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Scheda SIM non inserita"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Richiesto codice PIN della SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Richiesto codice PUK della SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Scheda SIM errata"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Dipendenza della connessione non riuscita"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Firmware mancante"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Cavo scollegato"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "errore non definito nella sicurezza 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "nessun file selezionato"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "errore non specificato nel validare il file eap-method"
+
+#: panels/network/wireless-security/eap-method.c:389
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "Chiavi private DER, PEM o PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:392
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "Certificati DER o PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "file PAC EAP-FAST mancante"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "File PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonimo"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autenticazione"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Entrambi"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identità anoni_ma"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_File PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Scegliere un file PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autenticazione _interna"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Fornire a_utomaticamente PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "manca il nome utente EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "manca la password EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nome _utente"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:175
+msgid "_Password"
+msgstr "Pass_word"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Mostra la pass_word"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "certificato CA EAP-PEAP non valido: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "certificato CA EAP-PEAP non valido: nessun certificato specificato"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versione 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versione 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificato C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Scegliere un certificato di un'Autorità di Certificazione"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Nessun certificato CA _richiesto"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Versione PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "manca il nome utente EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "manca la password EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "manca l'identità EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "certificato CA EAP-TLS non valido: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "certificato CA EAP-TLS non valido: nessun certificato specificato"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "chiave privata EAP-TLS non valida: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificato utente EAP-TLS non valido: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Le chiavi private non cifrate non sono sicure"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"La chiave privata selezionata non sembra essere protetta da una password. "
+"Ciò può compromettere le proprie credenziali di sicurezza. Selezionare una "
+"chiave privata protetta da password.\n"
+"\n"
+"(È possibile proteggere le proprie chiavi private con «openssl».)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Scegliere il certificato personale"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Scegliere la chiave privata personale"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentità"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificato _utente"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "C_hiave privata"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Password chiave _privata"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "certificato CA EAP-TTLS non valido: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "certificato CA EAP-TTLS non valido: nessun certificato specificato"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (senza EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Dominio"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Errore sconosciuto nel validare la sicurezza 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS con tunnel"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "PEAP (Protected EAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tenticazione"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Seleziona un file"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "manca leap-username"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "manca leap-password"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Manca la password Wi-Fi."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipo"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "manca wep-key"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"wep-key non valida: una chiave di lunghezza %zu deve contenere solo cifre "
+"esadecimali"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"wep-key non valida: una chiave di lunghezza %zu deve contenere solo "
+"caratteri ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"wep-key non valida: lunghezza chiave %zu non valida. Una chiave deve essere "
+"di lunghezza 5/13 (ascii) o 10/26 (esadecimale)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "wep-key non valida: la passphrase non può essere vuota"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"wep-key non valida: la passphrase deve essere più corta di 64 caratteri"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (predefinito)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Open System"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Chiave condivisa"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "C_hiave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "M_ostra la chiave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Indi_ce WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk non valida: lunghezza chiave %zu non valida. Deve essere [8,63] byte "
+"o 64 cifre esadecimali"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk non valida: impossibile interpretare chiave con 64 byte come "
+"esadecimali"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notifiche"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "A_vvisi audio"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Notifiche pop-up"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Le notifiche vengono visualizzate nell'elenco delle notifiche anche quando i "
+"pop-up sono disabilitati."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Mostrare _contenuto messaggi nei pop-up"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Notifiche sullo schermo bloccato"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Most_rare contenuto messaggi sullo schermo bloccato"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Non _disturbare"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Notifiche _schermo bloccato"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controlla quali notifiche visualizzare e cosa esse mostrano"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifiche;Banner;Messaggio;Tray;Popup;"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:277
+#, c-format
+msgid "%s removed"
+msgstr "%s rimosso"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:406
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Altro"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "Errore nel rimuovere l'account"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:51
+msgid "Undo"
+msgstr "Annulla"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:55
+msgid "Connect to your data in the cloud"
+msgstr "Usare i propri dati nel cloud"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:66
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Nessuna connessione a Internet — Collegarsi per configurare gli account "
+"online"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:93
+msgid "Add an account"
+msgstr "Aggiungi account"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Account %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Rimuovi account"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Account online"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Connette ai propri account online e decide per cosa usarli"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Conversazioni;Calendario;Email;"
+"Posta;Contatto;Contatti;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Tempo sconosciuto"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuto"
+msgstr[1] "%i minuti"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ora"
+msgstr[1] "%i ore"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s e %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ora"
+msgstr[1] "ore"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuto"
+msgstr[1] "minuti"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s alla carica completa"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Attenzione: ancora %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "ancora %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Carica"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Non in carica"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Scarica"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "In carica"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "In scarica"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Mouse wireless"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Tastiera wireless"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "UPS"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "PDA"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Cellulare"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Lettore multimediale"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Computer"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Periferiche di gioco"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batteria"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principale"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Aggiuntiva"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batterie"
+
+#: panels/power/cc-power-panel.c:511
+msgid "When _idle"
+msgstr "Quando _inattivo"
+
+#: panels/power/cc-power-panel.c:671
+msgid "Suspend"
+msgstr "Sospendere"
+
+#: panels/power/cc-power-panel.c:672
+msgid "Power Off"
+msgstr "Spegnere"
+
+#: panels/power/cc-power-panel.c:673
+msgid "Hibernate"
+msgstr "Ibernare"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Nothing"
+msgstr "Nessuna azione"
+
+#: panels/power/cc-power-panel.c:730
+msgid "When on battery power"
+msgstr "Quando a batteria"
+
+#: panels/power/cc-power-panel.c:732
+msgid "When plugged in"
+msgstr "Quando collegato"
+
+#: panels/power/cc-power-panel.c:853
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Mai"
+
+#: panels/power/cc-power-panel.c:937
+msgid "Automatic suspend"
+msgstr "Sospensione automatica"
+
+#: panels/power/cc-power-panel.c:1030
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Modalità prestazioni temporaneamente disabilitata a causa dell'elevata "
+"temperatura di esercizio."
+
+#: panels/power/cc-power-panel.c:1032
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Modalità prestazioni temporaneamente non disponibile. Spostare il "
+"dispositivo su una superficie stabile per ripristinarlo."
+
+#: panels/power/cc-power-panel.c:1034
+msgid "Performance mode temporarily disabled."
+msgstr "Modalità prestazioni temporaneamente disabilitata."
+
+#: panels/power/cc-power-panel.c:1076
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Batteria scarica: risparmio energetico abilitato. La modalità precedente "
+"verrà ripristinata quando la batteria è sufficientemente carica."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1084
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Modalità risparmio energetico attivata da «%s»."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1088
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Modalità prestazioni attivata da «%s»."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minuti"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minuti"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minuti"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minuti"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minuti"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 ora"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minuti"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minuti"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minuti"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 ore"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Modalità energetica"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Influisce sulle prestazioni del sistema e sul consumo energetico"
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opzioni risparmio energetico"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Luminosità schermo automatica"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "La luminosità dello schermo si adatta alla luce circostante"
+
+#: panels/power/cc-power-panel.ui:138
+msgid "Dim Screen"
+msgstr "Oscura lo schermo"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Riduce la luminosità dello schermo quando il computer è inattivo"
+
+#: panels/power/cc-power-panel.ui:150
+msgid "Screen _Blank"
+msgstr "_Spegnere schermo"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Oscura lo schermo dopo un periodo di inattività"
+
+#: panels/power/cc-power-panel.ui:159
+msgid "Automatic Power Saver"
+msgstr "Risparmio energetico automatico"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+"Abilita la modalità di risparmio energetico quando la batteria è scarica"
+
+#: panels/power/cc-power-panel.ui:173
+msgid "_Automatic Suspend"
+msgstr "Sospensione _automatica"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Mette in pausa il computer dopo un periodo di inattività"
+
+#: panels/power/cc-power-panel.ui:199
+msgid "Po_wer Button Behavior"
+msgstr "Comportamento _pulsante alimentazione"
+
+#: panels/power/cc-power-panel.ui:207
+msgid "Show Battery _Percentage"
+msgstr "Mostrare _percentuale della batteria"
+
+#: panels/power/cc-power-panel.ui:243
+msgid "Automatic Suspend"
+msgstr "Sospensione automatica"
+
+#: panels/power/cc-power-panel.ui:266
+msgid "_Plugged In"
+msgstr "Quando _collegato"
+
+#: panels/power/cc-power-panel.ui:278
+msgid "On _Battery Power"
+msgstr "Quando a _batteria"
+
+#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
+#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+msgid "Delay"
+msgstr "Ritardo"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Prestazioni"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Alte prestazioni e consumo energetico"
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Bilanciato"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Prestazioni e consumo energetico normali"
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Risparmio energia"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Prestazioni e consumo energetico ridotti"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energia"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Visualizza lo stato della batteria e cambia le impostazioni di risparmio "
+"energetico"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"alimentazione;power;sleep;sospensione;ibernazione;batteria;luminosità;"
+"monitor;schermo;dim;abbassare;oscurare;DPMS;inattivo;energia;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:676
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "La stampante «%s» è stata eliminata"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:928
+msgid "Failed to add new printer."
+msgstr "Aggiunta della nuova stampante non riuscita."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1229
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Impossibile caricare l'interfaccia: %s"
+
+#: panels/printers/cc-printers-panel.c:1297
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Sbloccare per aggiungere stampanti e modificare le impostazioni"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Stampanti"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Aggiunge stampanti, visualizza lavori di stampa e decide come stampare"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Stampante;Coda;Stampa;Carta;Inchiostro;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Aggiungi stampante"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:100
+#: panels/printers/new-printer-dialog.ui:115
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Sblocca"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:194
+msgid "No Printers Found"
+msgstr "Nessuna stampante trovata"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:244
+msgid "Enter a network address or search for a printer"
+msgstr "Inserire un indirizzo di rete o cercare una stampante"
+
+#: panels/printers/new-printer-dialog.ui:286
+msgid "Authentication Required"
+msgstr "Richiesta autenticazione"
+
+#: panels/printers/new-printer-dialog.ui:302
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Inserire nome utente e password per visualizzare le stampanti disponibili "
+"sul server di stampa."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:311
+#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:148
+msgid "Username"
+msgstr "Nome utente"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:365
+#, c-format
+msgid "%s Details"
+msgstr "Dettagli di %s"
+
+#: panels/printers/pp-details-dialog.c:101
+msgid "No suitable driver found"
+msgstr "Nessun driver adatto trovato"
+
+#: panels/printers/pp-details-dialog.c:260
+msgid "Select PPD File"
+msgstr "Selezionare file PPD"
+
+#: panels/printers/pp-details-dialog.c:269
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"File PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+msgid "Location"
+msgstr "Collocazione"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:115
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:154
+msgid "Searching for preferred drivers…"
+msgstr "Ricerca driver preferiti…"
+
+#: panels/printers/pp-details-dialog.ui:173
+msgid "Search for Drivers"
+msgstr "Cerca driver"
+
+#: panels/printers/pp-details-dialog.ui:181
+msgid "Select from Database…"
+msgstr "Seleziona dal database…"
+
+#: panels/printers/pp-details-dialog.ui:189
+msgid "Install PPD File…"
+msgstr "Installa file PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Selezione driver stampante"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Caricamento database dei driver…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Seleziona"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Stampante JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Stampante LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Singola facciata"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Lato lungo (standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Lato corto (ribaltato)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Verticale"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Orizzontale"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Orizzontale invertito"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Verticale invertito"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:134
+msgctxt "print job"
+msgid "Pending"
+msgstr "In attesa"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:140
+msgctxt "print job"
+msgid "Paused"
+msgstr "In pausa"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:145
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Richiesta autenticazione"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "In elaborazione"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Fermato"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Annullato"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Interrotto"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "Completato"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:176
+msgid "Move this job to the top of the queue"
+msgstr "Spostare questo lavoro in cima alla coda"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u lavoro richiede autenticazione"
+msgstr[1] "%u lavori richiedono autenticazione"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Lavori attivi"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Inserire le credenziali per stampare da %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Dominio"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:100
+msgid "A_uthenticate"
+msgstr "A_utentica"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:128
+msgid "Clear All"
+msgstr "Pulisci tutto"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:173
+msgid "_Authenticate"
+msgstr "_Autentica"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:214
+msgid "No Active Printer Jobs"
+msgstr "Nessun lavoro attivo"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Sblocca server di stampa"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Sblocca %s"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Inserire nome utente e password per visualizzare le stampanti disponibili su "
+"%s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Ricerca stampanti"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Porta seriale"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Porta parallela"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Collocazione: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Indirizzo: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Il server richiede autenticazione"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Fronte-retro"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tipo di carta"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Sorgente carta"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Cassetto di uscita"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Risoluzione"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Pre-filtraggio GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Pagine per foglio"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Fronte-retro"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientamento"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Generale"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Impostazioni pagina"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opzioni installabili"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Lavoro"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Qualità immagine"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Colore"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Finitura"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avanzate"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Pagina di test"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Pagina di test"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Automatica"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Impostazioni predefinite stampante"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Includere solo i caratteri GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Convertire a PS livello 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Convertire a PS livello 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Nessun pre-filtraggio"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Produttore"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nessun lavoro attivo"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u lavoro"
+msgstr[1] "%u lavori"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Pulizia testine"
+
+# cfr traduzioni simili su gtk+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Toner in esaurimento"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Toner esaurito"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Developer in esaurimento"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Developer esaurito"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Disponibilità di un inchiostro in esaurimento"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Disponibilità di un inchiostro esaurita"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Coperchio aperto"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Sportello aperto"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Carta in esaurimento"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Carta esaurita"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Fuori rete"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Ferma"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Contenitore rifiuti quasi pieno"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Contenitore rifiuti pieno"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+"Il fotoconduttore ottico sta per terminare il suo periodo di operatività"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Il fotoconduttore ottico non è più funzionante"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Pronta"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Non accetta lavori"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "In elaborazione"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Opzioni di stampa"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Dettagli stampante"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Usa stampante come predefinita"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Pulisci testine stampante"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Rimuovi stampante"
+
+#: panels/printers/printer-entry.ui:187
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modello"
+
+#: panels/printers/printer-entry.ui:242
+msgid "Ink Level"
+msgstr "Livello inchiostro"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:304
+msgid "Please restart when the problem is resolved."
+msgstr "Riavviare la stampante una volta risolto il problema."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:310
+msgid "Restart"
+msgstr "Riavvia"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10
+msgid "Add Printer…"
+msgstr "Aggiungi stampante…"
+
+#: panels/printers/printers.ui:168
+msgid "No printers"
+msgstr "Nessuna stampante"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:179
+msgid "Add a Printer…"
+msgstr "Aggiungi stampante…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:204
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Il servizio di sistema per la stampa\n"
+"sembra non essere disponibile."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formati"
+
+#: panels/region/cc-format-chooser.ui:37
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Indietro"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Cerca lingue…"
+
+#: panels/region/cc-format-chooser.ui:113
+msgid "Common Formats"
+msgstr "Formati comuni"
+
+#: panels/region/cc-format-chooser.ui:140
+msgid "All Formats"
+msgstr "Tutti i formati"
+
+#: panels/region/cc-format-chooser.ui:188
+msgid "No Search Results"
+msgstr "Nessun risultato"
+
+#: panels/region/cc-format-chooser.ui:200
+msgid "Searches can be for countries or languages."
+msgstr "Le ricerche possono essere per paese o lingua."
+
+#: panels/region/cc-format-chooser.ui:236
+msgid "Preview"
+msgstr "Anteprima"
+
+#: panels/region/cc-format-preview.c:135
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperiali"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metriche"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Date"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Date e orari"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Numeri"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Unità di misura"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Carta"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "La lingua e il formato verranno modificati dopo il prossimo accesso"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Esci…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats is "
+"used for numbers, dates, and currencies."
+msgstr ""
+"L'impostazione della lingua è utilizzata per il testo dell'interfaccia e le "
+"pagine web; il formato per numeri, date e valute."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Il proprio account"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:299
+msgid "_Language"
+msgstr "_Lingua"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formati"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Schermata di accesso"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Regione e lingua"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Seleziona la lingua e i formati utilizzati"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Lingua;Disposizione;Layout;Tastiera;Input;"
+
+# modificato un po' rispetto originale per mantere "azione"
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Chiedere l'azione da intraprendere"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Nessuna azione"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Aprire la cartella"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Altri supporti"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Selezionare un'applicazione per i CD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Selezionare un'applicazione per i DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Selezionare un'applicazione da eseguire quando viene connesso un lettore "
+"musicale"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+"Selezionare un'applicazione da eseguire quando viene connessa una fotocamera"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Selezionare un'applicazione per i CD di software"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Disco vuoto Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "Disco vuoto CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "Disco vuoto DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "Disco vuoto HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Disco video Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "Lettore e-book"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Disco video HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Software Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Selezionare come gestire i supporti"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _audio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Lettore _musicale"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Altri supporti…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Non chiedere o avviare programmi all'inserimento di supporti"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Selezionare come gestire altri supporti"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Azione:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipo:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Dispositivi rimovibili"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configurazione dispositivi rimovibili"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;predefinita;predefinito;predefinita;applicazione;"
+"preferite;cd;dvd;usb;audio;video;disco;rimovibile;media;multimedia;"
+"esecuzione;autorun;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Seleziona posizione"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Posizioni di ricerca"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Cartelle a cui le applicazioni di sistema hanno accesso in ricerca, come "
+"File, Foto e Video."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Risorse"
+
+#: panels/search/cc-search-locations-dialog.ui:33
+msgid "Bookmarks"
+msgstr "Segnalibri"
+
+#: panels/search/cc-search-locations-dialog.ui:48
+msgid "Others"
+msgstr "Altro"
+
+#: panels/search/cc-search-locations-dialog.ui:55
+msgid "Add Location"
+msgstr "Aggiungi posizione"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nessuna applicazione"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Ricerca applicazioni"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Include i risultati di ricerca forniti dalle applicazioni"
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Cartelle ricercate dalle applicazioni di sistema"
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Risultati ricerca"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "I risultati vengono visualizzati in base all'ordine di elenco"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controlla quali applicazioni mostrano risultati di ricerca nella panoramica "
+"attività"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Cerca;Trova;Indice;Nascondi;Privacy;Risultati;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:265
+msgid "No networks selected for sharing"
+msgstr "Nessuna rete selezionata per la condivisione"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Reti"
+
+#: panels/sharing/cc-sharing-panel.c:363
+msgctxt "service is enabled"
+msgid "On"
+msgstr "On"
+
+#: panels/sharing/cc-sharing-panel.c:365 panels/sharing/cc-sharing-panel.c:392
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Off"
+
+#: panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Abilitato"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is active"
+msgid "Active"
+msgstr "Attivo"
+
+#: panels/sharing/cc-sharing-panel.c:516
+msgid "Choose a Folder"
+msgstr "Scegliere una cartella"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:744
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"La condivisione di file permette di condividere con altri la propria "
+"cartella Pubblici sulla rete attuale usando: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:750
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Quanto l'accesso remoto è abilitato, consente a utenti remoti di connettersi "
+"usando il comando Secure Shell:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Condivisione"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Nome del computer"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Condivisione _file"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Computer _remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Condivisione _multimediale"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Accesso _remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Condivisione file"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Richiedere la pass_word"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Accesso remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:250
+#: panels/sharing/cc-sharing-panel.ui:267
+msgid "Remote Desktop"
+msgstr "Computer remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:263
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Computer remoto consente di visualizzare e controllare il computer da un "
+"altro computer"
+
+#: panels/sharing/cc-sharing-panel.ui:268
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Abilita o disabilita le connessioni da computer remoti verso questo computer"
+
+#: panels/sharing/cc-sharing-panel.ui:280
+msgid "Remote Control"
+msgstr "Controllo remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:281
+msgid "Allows remote connections to control the screen."
+msgstr "Consente alle connessioni utenti di controllare lo schermo"
+
+#: panels/sharing/cc-sharing-panel.ui:294
+msgid "How to Connect"
+msgstr "Come connettersi"
+
+#: panels/sharing/cc-sharing-panel.ui:295
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Collegarsi a questo computer utilizzando il nome del dispositivo o "
+"l'indirizzo di computer remoto."
+
+#: panels/sharing/cc-sharing-panel.ui:323
+msgid "Remote Desktop Address"
+msgstr "Indirizzo computer remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:350
+msgid "Authentication"
+msgstr "Autenticazione"
+
+#: panels/sharing/cc-sharing-panel.ui:351
+msgid "The user name and password are required to connect to this computer."
+msgstr "Nome utente e password sono richiesti per collegarsi a questo computer"
+
+#: panels/sharing/cc-sharing-panel.ui:355
+msgid "User Name"
+msgstr "Nome utente"
+
+#: panels/sharing/cc-sharing-panel.ui:401
+msgid "Verify Encryption"
+msgstr "Verifica crittografia"
+
+#: panels/sharing/cc-sharing-panel.ui:428
+msgid "Encryption Fingerprint"
+msgstr "Impronta digitale crittografica"
+
+#: panels/sharing/cc-sharing-panel.ui:429
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical"
+msgstr ""
+"L'impronta digitale di crittografia può essere visualizzata nella "
+"connessione dei client e dovrebbe essere identica"
+
+#: panels/sharing/cc-sharing-panel.ui:461
+msgid "Media Sharing"
+msgstr "Condivisione multimediale"
+
+#: panels/sharing/cc-sharing-panel.ui:483
+msgid "Share music, photos and videos over the network."
+msgstr "Condivide musica, fotografie e video sulla rete"
+
+#: panels/sharing/cc-sharing-panel.ui:496
+msgid "Folders"
+msgstr "Cartelle"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controlla cosa si vuole condividere con altri"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"condivisione;share;ssh;host;nome;remoto;desktop;bluetooth;obex;media;"
+"multimedia;audio;video;immagini;foto;film;server;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Abilita o disabilita l'accesso remoto"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"È necessario autenticarsi per abilitare o disabilitare l'accesso remoto"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Personalizzato"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr "Latrato"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "Drip"
+msgstr "Goccia"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Glass"
+msgstr "Vetro"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Sonar"
+msgstr "Sonar"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "Retro"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "Fronte"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Test di %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Fare clic su un altoparlante per eseguire un test"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volume di sistema"
+
+#: panels/sound/cc-sound-panel.ui:25
+msgid "Volume Levels"
+msgstr "Livelli volume"
+
+#: panels/sound/cc-sound-panel.ui:35
+msgid "Output"
+msgstr "Uscita"
+
+#: panels/sound/cc-sound-panel.ui:56
+msgid "Output Device"
+msgstr "Dispositivo di uscita"
+
+#: panels/sound/cc-sound-panel.ui:75
+msgid "Test"
+msgstr "Test"
+
+#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+msgid "Configuration"
+msgstr "Configurazione"
+
+#: panels/sound/cc-sound-panel.ui:135
+msgid "Balance"
+msgstr "Bilanciamento"
+
+#: panels/sound/cc-sound-panel.ui:161
+msgid "Fade"
+msgstr "Dissolvenza"
+
+#: panels/sound/cc-sound-panel.ui:187
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:205
+msgid "Input"
+msgstr "Ingresso"
+
+#: panels/sound/cc-sound-panel.ui:226
+msgid "Input Device"
+msgstr "Dispositivo d'ingresso"
+
+#: panels/sound/cc-sound-panel.ui:294
+msgid "Volume"
+msgstr "Volume"
+
+#: panels/sound/cc-sound-panel.ui:312
+msgid "Alert Sound"
+msgstr "Suono di avviso"
+
+#: panels/sound/cc-volume-slider.c:117
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Audio"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Regola i livelli dell'audio, gli ingressi, le uscite e i suoni d'allerta"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Scheda;Microfono;Volume;Fade;Dissolvenza;Bilanciamento;Bluetooth;Headset;"
+"Auricolare;Cuffie;Suono;Audio;Output;Uscita;Ingresso;Input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Disconnesso"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "In connessione"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Connesso"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Errore nell'autorizzazione"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autorizzazione in corso"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Funzionalità ridotte"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Connesso e autorizzato"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autorizzato:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Connesso:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Registrato:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Autorizzazione dispositivo non riuscita: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Errore nel dimenticare il dispositivo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Dipende da %u altro dispositivo"
+msgstr[1] "Dipende da %u altri dispositivi"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+msgid "Name:"
+msgstr "Nome:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+msgid "Status:"
+msgstr "Stato:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+msgid "Authorize and Connect"
+msgstr "Autorizza e connetti"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+msgid "Forget Device"
+msgstr "Dimentica dispositivo"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Errore"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorizzato"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Il sotto sistema Thunderbolt (boltd) non è installato o non è configurato "
+"correttamente."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:157
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Consente di accedere direttamente ai dispositivi come dock e GPU esterne."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "È possibile collegare solo dispositivi USB o Display Port."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Impossibile rilevare il supporto per Thunderbolt.\n"
+"Ciò può essere causato dal sistema che non supporta Thunderbolt, dall'aver "
+"disabilitato il supporto nel BIOS o dall'aver impostato nel BIOS un livello "
+"di sicurezza non adatto."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Il supporto Thunderbolt è stato disabilitato nel BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Impossibile determinare il livello di sicurezza Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Errore nel passare alla modalità diretta: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt non supportato"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:104
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Impossibile connettersi al sottosistema Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:153
+msgid "Direct Access"
+msgstr "Accesso diretto"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:225
+msgid "Pending Devices"
+msgstr "Dispositivi in attesa"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:319
+msgid "No devices attached"
+msgstr "Nessun dispositivo collegato"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Gestisce dispositivi Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Intermittenza del cursore"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+msgid "Cursor blinks in text fields."
+msgstr "Il cursore è intermittente nei campi di testo"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
+#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+msgid "Speed"
+msgstr "Velocità"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+msgid "Cursor blinking speed"
+msgstr "Velocità lampeggiamento cursore"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Dimensione cursore"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"La dimensione del cursore può essere combinata con il livello "
+"d'ingrandimento per vedere meglio il cursore."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Assistente clic"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Clic secondario _simulato"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Esegue un clic secondario tenendo premuto il pulsante primario"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Ritardo di a_ccettazione:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Breve"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Ritardo clic secondario"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lungo"
+
+# non corretto, ma era così in precedenza
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Clic a_utomatico"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Esegue automaticamente un clic quando si ferma il puntatore"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Ritar_do:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Breve"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lungo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "S_oglia di movimento:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Piccolo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Ripetizione dei tasti"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+msgid "Key presses repeat when key is held down."
+msgstr "La pressione dei tasti ripete il carattere finché il tasto è premuto."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+msgid "Repeat keys delay"
+msgstr "Ritardo ripetizione tasti"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+msgid "Repeat keys speed"
+msgstr "Velocità ripetizione tasti"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Assistente di digitazione"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Tasti _singoli"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Tratta una sequenza di tasti modificatori come una combinazione di tasti"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Disabilitare se due tasti sono premuti insieme"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Avviso sonoro quando viene premuto un tasto _modificatore"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Tasti _lenti"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Imposta un ritardo tra la pressione di un tasto e la sua accettazione"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Breve"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Ritardo digitazione tasti lenti"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lungo"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Avviso sonoro quando un tasto è _premuto"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Avviso sonoro quando un tasto è _accettato"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Avviso sonoro quando un tasto è _rifiutato"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Tasti rim_balzati"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignora veloci pressioni duplicate di tasti"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Breve"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Ritardo digitazione tasti rimbalzati"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lungo"
+
+#: panels/universal-access/cc-typing-dialog.ui:326
+msgid "_Enable by Keyboard"
+msgstr "Abilita da _tastiera"
+
+#: panels/universal-access/cc-typing-dialog.ui:336
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Attiva e disattiva le funzioni di accessibilità usando la tastiera"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Predefinito"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Medio"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Più grande"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Il più grande"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixel"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Mostrare sempre il menù accessibilità"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Vista"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Contrasto _elevato"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Testo _grande"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Abilitare a_nimazioni"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Lettore schermo"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Il lettore di schermo legge il testo visualizzato allo spostamento del focus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Tasti udibili"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Emette un suono quando BlocNum o BlocMaiusc vengono attivati o disattivati."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Dimensione c_ursore"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "I_ngrandimento"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Udito"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Avvisi _visibili"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Tastiera a schermo"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Ripetizione dei _tasti"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Intermitten_za del cursore"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Assistente digitazione (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Puntamento e clic"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Mouse da tastiera"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Trova _puntatore"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Assistente _clic"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Ritardo do_ppio clic"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Ritardo doppio clic"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Avvisi visibili"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Prova lampeggiamento"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Usa un'indicazione visiva in presenza di un avviso audio."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Illuminare l'intero _schermo"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Illuminare la _finestra"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Breve"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ dello schermo"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ dello schermo"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ dello schermo"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Lunga"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Schermo intero"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Metà superiore"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Metà inferiore"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Metà sinistra"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Metà destra"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Opzioni di ingrandimento"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "In_grandimento:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posizione dell'ingranditore:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Segue il cursore del mouse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Parte dello schermo:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "L'ingranditore si _estende all'esterno dello schermo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Mantenere il cursore dell'ingranditore centrato"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Il cursore dell'ingranditore _spinge il contenuto"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Il curs_ore dell'ingranditore si sposta con il contenuto"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Ingranditore"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Mi_rino:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "So_vrapposto al cursore del mouse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "S_pessore:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Sottile"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Spesso"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "Lung_hezza:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "C_olore:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Mirini"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Effetti colore:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Bianco su nero:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "Lu_minosità:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "Contra_sto:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Co_lore"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Nessuno"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Pieno"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Bassa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Ridotto"
+
+# rotazione
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Elevato"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Effetti colore"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Rende più semplice vedere, ascoltare, digitare e fare clic"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"tastiera;mouse;a11y;accessibilità;accesso universale;contrasto;cursore;audio;"
+"suono;ingrandimento;high;elevato;grande;zoom;screen;reader;lettore;schermo;"
+"testo;font;tipo di carattere;dimensione;AccessX;tasti;singoli;sticky;lenti;"
+"slow;rimbalzati;slow;mouse;doppio;clic;ritardo;lampeggiare;ascoltare;"
+"digitare;audio;animazioni;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 ora"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 giorno"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 giorni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 giorni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 giorni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 giorni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 giorni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 giorni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 giorni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 giorni"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Svuotare il cestino?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Tutti gli oggetti nel cestino saranno rimossi in maniera definitiva."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "S_vuota cestino"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Eliminare tutti i file temporanei?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Tutti i file temporanei verranno rimossi in maniera definitiva."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Pulisci file temporanei"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 giorno"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 giorni"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 giorni"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Per sempre"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Cronologia file"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"La cronologia dei file mantiene informazioni sui file utilizzati. Queste "
+"informazioni sono condivise con altre applicazioni e facilita il "
+"ritrovamento di file da poter utilizzare."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Cronolo_gia file"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "_Durata cronologia file"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Pulisci cronologia…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Cestino e file temporanei"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Il cestino e i file temporanei a volte possono contenere informazioni "
+"personali o private. L'eliminazione automatica consente di proteggere la "
+"propria privacy."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Eliminare a_utomaticamente il contenuto del cestino"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Eliminare automaticamente i file _temporanei"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Periodo eliminazione automatica"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "S_vuota cestino…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Eli_mina file temporanei…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Cronologia file e cestino"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Non lasciare tracce"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr ""
+"Dovrebbe corrispondere all'indirizzo web del proprio fornitore di accesso."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Aggiunta dell'account non riuscita"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.c:260
+msgid "The passwords do not match."
+msgstr "Le password non corrispondono."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Registrazione dell'account non riuscita"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Nessun modo supportato per autenticarsi con questo dominio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Join al dominio non riuscita"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Nome di accesso non valido.\n"
+"Provare di nuovo."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Password non valida.\n"
+"Provare di nuovo."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Accesso al dominio non riuscito"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Impossibile trovare il dominio. È stato digitato in modo errato?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Aggiungi utente"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Amministratore"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Gli amministratori possono aggiungere e rimuovere utenti e possono "
+"modificare le impostazioni di tutti gli utenti. I controlli parentali non "
+"possono essere applicati agli amministratori."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "L'utente imposta una password al prossimo accesso"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Impostare una password adesso"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Conferma"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Account enterprise"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organisation."
+msgstr "Account utenti gestiti da un'azienda o un'organizzazione"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:385
+msgid "You are Offline"
+msgstr "Fuori rete"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:386
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"L'accesso enterprise consente di usare su questo dispositivo un preesistente "
+"account utente gestito centralmente. È possibile utilizzare questo account "
+"per accedere alle risorse aziendali su Internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Esplora altre immagini"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Seleziona un file…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Gestore impronte digitali"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Impronta digitale"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+msgid "_No"
+msgstr "_No"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+msgid "_Yes"
+msgstr "_Sì"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Eliminare le impronte digitali registrate così da disabilitare l'accesso "
+"tramite impronta?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+msgid "No fingerprint device"
+msgstr "Nessun dispositivo per impronte digitali"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+msgid "No Fingerprint device"
+msgstr "Nessun dispositivo per impronte digitali"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+msgid "Ensure the device is properly connected."
+msgstr "Assicurarsi che il dispositivo sia collegato correttamente."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+msgid "Fingerprint Device"
+msgstr "Dispositivo impronte digitali"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Scegliere il dispositivo per impronte digitali da configurare"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+msgid "Fingerprint Login"
+msgstr "Accesso con impronta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"L'accesso con impronta consente di sbloccare e accedere al computer con le "
+"proprie dita"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+msgid "_Delete Fingerprints"
+msgstr "_Elimina impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+msgid "Fingerprint Enroll"
+msgstr "Registra impronte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr ""
+"per eseguire questa azione è necessario che il dispositivo sia registrato"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "il dispositivo è già registrato da un altro processo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "autorizzazione non disponibile per eseguire l'azione"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "nessuna impronta è stata registrata"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Impossibile comunicare con il dispositivo durante la registrazione"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Impossibile comunicare con il lettore di impronte digitali"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Impossibile comunicare con il demone delle impronte digitali"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Recupero delle impronte non riuscito: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Eliminazione delle impronte salvate non riuscita: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Pollice sinistro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Medio sinistro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "Dito indice _sinistro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Anulare sinistro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Mignolo sinistro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Pollice destro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Medio destro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Dito indice _destro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Anulare destro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Mignolo destro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Dito sconosciuto"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Completata"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Dispositivo impronte digitali scollegato"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Spazio sul dispositivo impronte digitali esaurito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Registrazione della nuova impronta non riuscita"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Avvio della registrazione non riuscito: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Registrazione della nuova impronta non riuscita"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Arresto della registrazione non riuscito: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Alzare e posizionare ripetutamente il dito sul lettore per registrarne "
+"l'impronta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Registra nuovamente questo dito…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Scansiona nuova impronta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Rilascio del dispositivo per impronte digitali %s non riuscito: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Errore nel leggere il dispositivo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Ottenimento del dispositivo per impronte digitali %s non riuscito: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Recupero dei dispositivi per impronte digitali non riuscito: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Questa settimana"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Ultima settimana"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:712
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%H:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:716
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sessione terminata"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sessione avviata"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Attività account"
+
+#: panels/user-accounts/cc-password-dialog.c:133
+msgid "Please choose another password."
+msgstr "Scegliere un'altra password."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Please type your current password again."
+msgstr "Digitare nuovamente la propria password attuale."
+
+#: panels/user-accounts/cc-password-dialog.c:148
+msgid "Password could not be changed"
+msgstr "Impossibile cambiare la password"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Cambia password"
+
+#: panels/user-accounts/cc-password-dialog.ui:32
+msgid "Ch_ange"
+msgstr "C_ambia"
+
+#: panels/user-accounts/cc-password-dialog.ui:51
+msgid "Current Password"
+msgstr "Password attuale"
+
+#: panels/user-accounts/cc-password-dialog.ui:76
+msgid "New Password"
+msgstr "Nuova password"
+
+#: panels/user-accounts/cc-password-dialog.ui:121
+msgid "Confirm Password"
+msgstr "Conferma password"
+
+#: panels/user-accounts/cc-password-dialog.ui:175
+msgid "Allow user to change their password on next login"
+msgstr "Permette all'utente di modificare la password al prossimo accesso"
+
+#: panels/user-accounts/cc-password-dialog.ui:186
+msgid "Set a password now"
+msgstr "Impostare una password adesso"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Impossibile unirsi automaticamente a questo tipo di dominio"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Nessun dominio o realm trovati"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Impossibile eseguire l'accesso come %s al dominio %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Password non valida, provare di nuovo"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Impossibile connettersi al dominio %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:341
+msgid "Failed to delete user"
+msgstr "Eliminazione dell'utente non riuscita"
+
+#: panels/user-accounts/cc-user-panel.c:398
+#: panels/user-accounts/cc-user-panel.c:453
+#: panels/user-accounts/cc-user-panel.c:499
+msgid "Failed to revoke remotely managed user"
+msgstr "Revoca dell'utente gestito da remoto non riuscita"
+
+#: panels/user-accounts/cc-user-panel.c:548
+msgid "You cannot delete your own account."
+msgstr "Non è concesso eliminare il proprio account."
+
+#: panels/user-accounts/cc-user-panel.c:557
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s non ha ancora terminato la sessione"
+
+#: panels/user-accounts/cc-user-panel.c:561
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Eliminare un utente mentre è ancora in corso la sua sessione può lasciare il "
+"sistema in uno stato incoerente."
+
+#: panels/user-accounts/cc-user-panel.c:570
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Mantenere i file di %s?"
+
+#: panels/user-accounts/cc-user-panel.c:574
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"È possibile mantenere la directory home, gli spool di posta e i vari file "
+"temporanei quando si elimina un account utente."
+
+#: panels/user-accounts/cc-user-panel.c:577
+msgid "_Delete Files"
+msgstr "_Elimina file"
+
+#: panels/user-accounts/cc-user-panel.c:578
+msgid "_Keep Files"
+msgstr "Mantieni _file"
+
+#: panels/user-accounts/cc-user-panel.c:592
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Revocare veramente l'account di %s gestito da remoto?"
+
+#: panels/user-accounts/cc-user-panel.c:596
+msgid "_Delete"
+msgstr "_Elimina"
+
+#: panels/user-accounts/cc-user-panel.c:646
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Account disabilitato"
+
+#: panels/user-accounts/cc-user-panel.c:654
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Da impostare al prossimo accesso"
+
+#: panels/user-accounts/cc-user-panel.c:657
+msgctxt "Password mode"
+msgid "None"
+msgstr "Nessuno"
+
+#: panels/user-accounts/cc-user-panel.c:700
+msgid "Logged in"
+msgstr "Accesso eseguito"
+
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:787
+#: panels/user-accounts/cc-user-panel.c:876
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Abilitato"
+
+# Contatto mi pareva orrendo...
+#: panels/user-accounts/cc-user-panel.c:1173
+msgid "Failed to contact the accounts service"
+msgstr "Comunicazione con servizio account non riuscita"
+
+#: panels/user-accounts/cc-user-panel.c:1175
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Assicurarsi che AccountService sia installato e abilitato."
+
+#: panels/user-accounts/cc-user-panel.c:1197
+msgid "This panel must be unlocked to change this setting"
+msgstr "Sbloccare questo pannello per modificare l'impostazione"
+
+#: panels/user-accounts/cc-user-panel.c:1264
+msgid "Delete the selected user account"
+msgstr "Elimina l'account utente selezionato"
+
+#: panels/user-accounts/cc-user-panel.c:1268
+#: panels/user-accounts/cc-user-panel.c:1377
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Per eliminare l'account utente selezionato,\n"
+"fare prima clic sull'icona *"
+
+#: panels/user-accounts/cc-user-panel.c:1423
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Sbloccare per aggiungere utenti e modificare le impostazioni"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Utenti"
+
+#: panels/user-accounts/cc-user-panel.ui:60
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "È necessario riavviare la sessione per applicare le modifiche"
+
+#: panels/user-accounts/cc-user-panel.ui:67
+msgid "Restart Now"
+msgstr "Riavvia adesso"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:195
+msgid "_Fingerprint Login"
+msgstr "Accesso con i_mpronta"
+
+#: panels/user-accounts/cc-user-panel.ui:218
+msgid "A_utomatic Login"
+msgstr "Accesso a_utomatico"
+
+#: panels/user-accounts/cc-user-panel.ui:231
+msgid "Account Activity"
+msgstr "Attività account"
+
+#: panels/user-accounts/cc-user-panel.ui:259
+msgid "_Administrator"
+msgstr "_Amministratore"
+
+#: panels/user-accounts/cc-user-panel.ui:260
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Gli amministratori possono aggiungere e rimuovere utenti e possono "
+"modificare le impostazioni di tutti gli utenti."
+
+#: panels/user-accounts/cc-user-panel.ui:276
+msgid "_Parental Controls"
+msgstr "Controlli _parentali"
+
+#: panels/user-accounts/cc-user-panel.ui:277
+msgid "Open the Parental Controls application."
+msgstr "Apre l'applicazione «Controlli parentali»."
+
+#: panels/user-accounts/cc-user-panel.ui:328
+msgid "Remove User…"
+msgstr "Rimuovi utente…"
+
+#: panels/user-accounts/cc-user-panel.ui:340
+msgid "Other Users"
+msgstr "Altri utenti"
+
+#: panels/user-accounts/cc-user-panel.ui:353
+msgid "Add User…"
+msgstr "Aggiungi utente…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:381
+msgid "No Users Found"
+msgstr "Nessuna utente trovato"
+
+#: panels/user-accounts/cc-user-panel.ui:390
+msgid "Unlock to add a user account."
+msgstr "Sbloccare per aggiungere un account utente"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Aggiunge o rimuove utenti e cambia la propria password"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Accesso;Nome;Impronta;Digitale;Avatar;Immagine;Logo;Volto;Password;"
+"Controlli parentali;Tempo;Schermo;Restrizioni App;Restrizioni Web;Utilizzo;"
+"Limiti utilizzo;Bambini;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Registra"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Accesso amministratore dominio"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Per poter utilizzare gli accessi enterprise, il computer deve essere\n"
+"registrato nel dominio. Chiedere all'amministratore di rete\n"
+"di digitare la password per il dominio in questo campo."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nome amministratore"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Password amministratore"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Gestisce gli account online"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "È necessario autenticarsi per cambiare i dati utente"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "La nuova password deve essere diversa dalla precedente."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Provare a cambiare alcune lettere e numeri."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Provare a cambiare la password un po' di più."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Una password che non contiene il proprio nome utente è più robusta."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Provare a evitare l'uso del proprio nome nella password."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Provare a evitare alcune delle parole incluse nella password."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Provare a evitare parole comuni."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Provare a evitare di riordinare parole esistenti."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Provare a usare più numeri."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Provare a usare più lettere maiuscole."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Provare a usare più lettere minuscole."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Provare a usare più caratteri speciali, come quelli di punteggiatura."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+"Provare a usare una combinazione di lettere, numeri e segni di punteggiatura."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Provare a evitare la ripetizione dello stesso carattere."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Provare a evitare di ripetere lo stesso tipo di carattere: combinare "
+"lettere, numeri e segni di punteggiatura."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Provare a evitare sequenze come 1234 o abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"La password deve essere più lunga. Provare ad aggiungere più lettere, numeri "
+"e segni di punteggiatura."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Combinare lettere maiuscole e minuscole e usare un numero o due."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Aggiungendo altre lettere, numeri e segni di punteggiatura si renderà la "
+"password ancora più robusta."
+
+#: panels/user-accounts/run-passwd.c:413
+msgid "Authentication failed"
+msgstr "Autenticazione non riuscita"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The new password is too short"
+msgstr "La nuova password è troppo corta"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password is too simple"
+msgstr "La nuova password è troppo semplice"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "La nuova password è troppo simile alla vecchia"
+
+#: panels/user-accounts/run-passwd.c:507
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "La nuova password è già stata usata di recente."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "La nuova password deve contenere caratteri numerici o speciali"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "La nuova password coincide con la vecchia"
+
+#: panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+"La propria password è cambiata da quando si è inizialmente effettuata "
+"l'autenticazione."
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "La nuova password non contiene abbastanza caratteri diversi"
+
+#: panels/user-accounts/run-passwd.c:526
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Errore sconosciuto"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Il nome utente deve essere formato da lettere minuscole (dalla a alla z), "
+"numeri e dai seguenti caratteri: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Il nome utente non è disponibile, provare un altro."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Il nome utente è troppo lungo."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+msgid "Map Buttons"
+msgstr "Associa pulsanti"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Associa i pulsanti alle funzioni"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Per modificare una scorciatoia, scegliere l'azione «Invia pressione tasti», "
+"premere la scorciatoia da tastiera e tenere premuti i nuovi tasti, oppure "
+"premere Backspace per cancellarla."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Chiudi"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Toccare i segnaposto quando appaiono sullo schermo per calibrare la "
+"tavoletta grafica."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Rilevato clic errato, riavvio…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Pulsante %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Definito dall'applicazione"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Invia pressione tasti"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Cambia monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Mostra aiuto a schermo"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tavoletta montata sul pannello del portatile"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tavoletta montata sullo schermo esterno"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Tavoletta esterna"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Tutti gli schermi"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Modalità tavoletta"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Usare il posizionamento assoluto per la penna"
+
+#: panels/wacom/cc-wacom-page.ui:27
+msgid "Left Hand Orientation"
+msgstr "Orientamento per mancini"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tavoletta ed Express Key™ sono ruotati per l'uso a sinistra"
+
+#: panels/wacom/cc-wacom-page.ui:56
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mappare su monitor"
+
+#: panels/wacom/cc-wacom-page.ui:62
+msgid "Keep Aspect Ratio"
+msgstr "Mantenere proporzioni"
+
+#: panels/wacom/cc-wacom-page.ui:63
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Usa solo una porzione della superficie della tavoletta per mantenere le "
+"proporzioni"
+
+#: panels/wacom/cc-wacom-page.ui:73
+msgid "Calibrate"
+msgstr "Calibra"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nessuna tavoletta rilevata"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Collegare o accendere la tavoletta Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensibilità della punta"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Leggera"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pressione della punta dello stilo"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Pesante"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Pulsante 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Pulsante 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Pulsante 3"
+
+# è ciò che appare nel tool per windows, come mostrato nel PDF di documentazione delle tavolette Bamboo
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilità della gomma"
+
+# è ciò che appare nel tool per windows, come mostrato nel PDF di documentazione delle tavolette Bamboo
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pressione della gomma"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Predefinita"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Clic pulsante centrale del mouse"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Clic pulsante destro del mouse"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Avanti"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Stilo aerografo con pressione, inclinazione e cursore integrato"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Stilo aerografo con pressione, inclinazione e rotazione"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Stilo standard con pressione e inclinazione"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Stilo standard con pressione"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tavoletta Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Imposta la mappatura dei pulsanti e regola la sensibilità del pennino per "
+"tavolette grafiche"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;Tavoletta;Penna;Gomma;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Nuova scorciatoia…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Punti d'accesso"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:122
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operazione annullata"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Errore:</b> accesso negato per la modifica delle impostazioni"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Errore:</b> errore dell'apparecchiature mobile"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Non registrato"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registrato"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Ricerca"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Negato"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Dettagli modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Stato modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Portante"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tipo di rete"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Stato della rete"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Proprio numero"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Dettagli dispositivo"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Versione firmware"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Solo 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Solo 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Solo 4G"
+
+#: panels/wwan/cc-wwan-device.c:1003
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (preferito)"
+
+#: panels/wwan/cc-wwan-device.c:1005
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (preferito), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (preferito), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (preferito)"
+
+#: panels/wwan/cc-wwan-device.c:1017
+msgid "3G (Preferred), 4G"
+msgstr "3G (preferito), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1019
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1025
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (preferito)"
+
+#: panels/wwan/cc-wwan-device.c:1027
+msgid "2G (Preferred), 4G"
+msgstr "2G (preferito), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1029
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (preferito)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "2G (Preferred), 3G"
+msgstr "2G (preferito), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1043
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Sconosciuta"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Sblocca scheda SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Sblocca"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Fornire il codice PIN per la scheda SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Inserire il PIN per sbloccare la scheda SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Fornire il codice PUK per la scheda SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Inserire il PUK per sbloccare la scheda SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Password errata. Ancora %1$u tentativo rimasto"
+msgstr[1] "Password errata. Ancora %1$u tentativi rimasti"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Ancora %u tentativo rimasto"
+msgstr[1] "Ancora %u tentativi rimasti"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Password errata."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Il codice PUK deve essere un numero di 8 cifre"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Inserire nuovo PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Il codice PIN deve essere un numero di 4-8 cifre"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Sblocco…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Nessuna SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Inserire una scheda SIM per utilizzare questo modem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM bloccata"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Rete mobile"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Accede ai dati utilizzando la rete mobile"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Roaming dati"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Utilizza i dati mobili durante il roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Modalità di rete"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "R_ete"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avanzate"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Nomi punti d'_accesso"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_Blocco SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Blocca la SIM con un PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Dettagli m_odem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Errore del telefono"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Nessuna connessione al telefono"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operazione non consentita"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operazione non supportata"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM non inserita"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Richiesto codice PIN della SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Richiesto codice PUK della SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Errore della scheda SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM occupata"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Password errata"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Richiesto codice PIN2 della SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Richiesto codice PUK2 della SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Non trovata"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Nessun servizio di rete"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Timeout di rete"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Servizi GPRS non consentiti"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming non consentito in questa località"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Errore GPRS non specificato"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "Action Cancelled"
+msgstr "Azione annullata"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Access denied"
+msgstr "Accesso negato"
+
+#: panels/wwan/cc-wwan-errors-private.h:103
+msgid "Unknown Error"
+msgstr "Errore sconosciuto"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Modalità di rete"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:146
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Imposta"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
+msgid "Close"
+msgstr "Chiudi"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:69
+msgid "_Automatic"
+msgstr "_Automatica"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:84
+msgid "Choose Network"
+msgstr "Scegli rete"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:99
+msgid "Refresh Network Providers"
+msgstr "Aggiorna fornitori di rete"
+
+#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Abilita rete mobile"
+
+#: panels/wwan/cc-wwan-panel.ui:94
+msgid "No WWAN Adapter Found"
+msgstr "Nessun adattatore WWAN trovato"
+
+#: panels/wwan/cc-wwan-panel.ui:104
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Assicurarsi di disporre di un dispositivo Wan/Cellular Wireless"
+
+#: panels/wwan/cc-wwan-panel.ui:145
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Wireless Wan è disabilitato quando la modalità aereo è attiva"
+
+#: panels/wwan/cc-wwan-panel.ui:153
+msgid "_Turn off Airplane Mode"
+msgstr "_Disattiva modalità aereo"
+
+#: panels/wwan/cc-wwan-panel.ui:184
+msgid "Data Connection"
+msgstr "Connessione dati"
+
+#: panels/wwan/cc-wwan-panel.ui:185
+msgid "SIM card used for internet"
+msgstr "Scheda SIM utilizzata per Internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Blocco SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Successivo"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+msgid "_Lock SIM with PIN"
+msgstr "_Blocca SIM con un PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+msgid "Change PIN"
+msgstr "Cambia PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+"Immettere il PIN corrente per modificare le impostazioni di blocco della SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Rete mobile"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configura telefonia e connessioni dati mobili"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellulare;wwan;telephony;sim;mobile;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Applicazione per configurare l'ambiente grafico GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+"«Impostazioni» è il programma principale per la configurazione del sistema."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Il progetto GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Visualizza numero di versione"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Abilita la modalità prolissa"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Cerca la stringa"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Elenca i nomi dei pannelli disponibili ed esce"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Pannello da mostrare"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANNELLO] [ARGOMENTO..]"
+
+#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privacy"
+
+#: shell/cc-panel-loader.c:301
+msgid "Available panels:"
+msgstr "Pannelli disponibili:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Tutte le impostazioni"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menù primario"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Attenzione: versione di sviluppo"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Questa versione di Impostazioni dovrebbe essere usata solamente in fase di "
+"sviluppo. È possibile incorrere in problemi di sistema, perdita di dati e "
+"altri problemi inattesi. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Aiuto"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Generale"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Esce"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Cerca"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Pannelli"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Torna al riquadro precedente"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Annulla la ricerca"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferenze;Impostazioni;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "L'identificatore per l'ultimo riquadro delle impostazioni da aprire"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"L'identificatore per l'ultimo riquadro delle impostazioni da aprire. Valori "
+"non riconosciuti vengono ignorati e viene selezionato il primo riquadro "
+"nella lista."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Mostra avviso quando si esegue una versione di sviluppo"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Indica se il programma debba mostrare un avviso quando viene eseguita una "
+"versione di sviluppo."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Stato iniziale della finestra"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Una tupla che contiene la larghezza, l'altezza e lo stato massimizzato "
+"iniziali della finestra dell'applicazione."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1907
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u uscita"
+msgstr[1] "%u uscite"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1917
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ingresso"
+msgstr[1] "%u ingressi"
+
+#: subprojects/gvc/gvc-mixer-control.c:2867
+msgid "System Sounds"
+msgstr "Suoni di sistema"

--- a/po/ja.po
+++ b/po/ja.po
@@ -31,9 +31,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-03-10 12:54+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-03-16 20:30+0900\n"
 "Last-Translator: sicklylife <translation@sicklylife.jp>\n"
 "Language-Team: Japanese <gnome-translation@gnome.gr.jp>\n"
@@ -43,98 +42,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: panels/applications/cc-applications-panel.c:803
-msgid "System Bus"
-msgstr "システムバス"
-
-#: panels/applications/cc-applications-panel.c:803
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:823
-msgid "Full access"
-msgstr "フルアクセス"
-
-#: panels/applications/cc-applications-panel.c:805
-msgid "Session Bus"
-msgstr "セッションバス"
-
-#: panels/applications/cc-applications-panel.c:809
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "デバイス"
-
-#: panels/applications/cc-applications-panel.c:809
-msgid "Full access to /dev"
-msgstr "/dev へのフルアクセス"
-
-#: panels/applications/cc-applications-panel.c:813
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "ネットワーク"
-
-#: panels/applications/cc-applications-panel.c:813
-msgid "Has network access"
-msgstr "ネットワークアクセス"
-
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:820
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "ホーム"
-
-#: panels/applications/cc-applications-panel.c:820
-#: panels/applications/cc-applications-panel.c:825
-msgid "Read-only"
-msgstr "読み取り専用"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-msgid "File System"
-msgstr "ファイルシステム"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "設定"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Can change settings"
-msgstr "設定の変更"
-
-#: panels/applications/cc-applications-panel.c:831
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s には次の変更できない権限が組み込まれています。これらの権限に問題がある場合"
-"は、このアプリケーションの削除を検討してください。"
-
-#: panels/applications/cc-applications-panel.c:1164
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u 種類のファイル/リンクをアプリで開くことができます"
-
-#: panels/applications/cc-applications-panel.c:1171
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> は次の種類のファイルとリンクを開くのに使用されます。"
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1223
-#, c-format
-msgid "%s of disk space used"
-msgstr "ディスク容量の %s を使用中"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1387
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -150,7 +58,6 @@ msgid "Install some…"
 msgstr "インストール…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "開く"
 
@@ -161,6 +68,10 @@ msgstr "詳細を表示"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "検索"
@@ -170,24 +81,13 @@ msgstr "検索"
 msgid "Receive system searches and send results."
 msgstr "システム検索を受け取り、検索結果を送ります。"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1900
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "無効"
 
@@ -201,7 +101,8 @@ msgid "Show system notifications."
 msgstr "システムの通知を表示します。"
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+#, fuzzy
+msgid "Run in Background"
 msgstr "バックグラウンドで実行"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -209,131 +110,142 @@ msgid "Allow activity when the app is closed."
 msgstr "アプリを閉じても実行し続けることを許可します。"
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "スクリーンショット"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "壁紙を変更"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "デスクトップの壁紙を変更します。"
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "サウンド"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "音を再生します。"
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "ショートカットを抑制"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "標準のキーボードショートカットをブロックします。"
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "カメラ"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "マイク"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "位置情報サービス"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "デバイスの位置データにアクセスします。"
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "組み込みの権限"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "アプリが要求しているシステムアクセス"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "ファイルとリンクの関連付け"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "ストレージ"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "結果がありません"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "他のキーワードを試してください"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "ファイルとリンクの関連付け"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "ファイルの種類"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "リンクの種類"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "リセット"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "このアプリケーションがデータとキャッシュで占有しているディスク容量です。"
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "アプリケーション"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "データ"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "キャッシュ"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>合計</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "キャッシュを消去…"
 
@@ -341,93 +253,34 @@ msgstr "キャッシュを消去…"
 msgid "Control various application permissions and settings"
 msgstr "アプリケーションの権限や設定を変更します"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "application;flatpak;permission;setting;アプリケーション;パーミッション;許可;"
 "権限;設定;snap;"
 
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "画像を選択"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:226
-#: panels/network/connection-editor/vpn-helpers.c:346
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "キャンセル(_C)"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:227
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:524
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "開く(_O)"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "複数のサイズ"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "デスクトップの背景が見つかりません"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "現在の背景"
-
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "スタイル"
 
-#: panels/background/cc-background-panel.ui:45
-msgid "Light"
-msgstr "明るい"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "デフォルト"
 
-#: panels/background/cc-background-panel.ui:72
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "暗い"
 
-#: panels/background/cc-background-panel.ui:91
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "背景"
 
-#: panels/background/cc-background-panel.ui:97
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "画像を追加…"
 
@@ -439,53 +292,62 @@ msgstr "外観"
 msgid "Change your background image or the UI colors"
 msgstr "背景画像や UI の色を変更します"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+#, fuzzy
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
-"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;背景;壁紙;スクリーン;"
-"デスクトップ;スタイル;ライト;明るい;ダーク;暗い;"
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;背景;壁紙;スクリーン;デ"
+"スクトップ;スタイル;ライト;明るい;ダーク;暗い;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "有効にする(_E)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Bluetooth が見つかりませんでした"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Bluetooth を使用するにはドングルを接続してください。"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth がオフになっています"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 "デバイスの接続やファイルの受信を行うには Bluetooth をオンにしてください。"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "機内モードがオンになっています"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "機内モードがオンの場合、Bluetooth は使用できません。"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "機内モードをオフにする"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "ハードウェアの機内モードがオンになっています"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Bluetooth を使用するには機内モードスイッチをオフにしてください。"
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -493,20 +355,19 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Bluetooth のオン/オフやデバイスへの接続を行います"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;共有;シェアリング;ブルートゥース;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "カメラがオフになっています"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "アプリケーションが写真や動画を撮影できません。"
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
@@ -518,7 +379,7 @@ msgstr ""
 "\n"
 "以下のアプリケーションがカメラを使用することを許可します。"
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "カメラへのアクセスを要求しているアプリケーションはありません"
 
@@ -526,96 +387,33 @@ msgstr "カメラへのアクセスを要求しているアプリケーション
 msgid "Protect your pictures"
 msgstr "写真を保護します"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;画面;スクリーン;ロック;診断;クラッシュ;プライベート;最近;テ"
-"ンポラリー;一時;インデックス;索引;名前;ネットワーク;Privacy;プライバシー;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "キャリブレーション装置を四角形に合わせて“開始”を押してください"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "キャリブレーション装置を測定位置に移動して“次へ”を押してください"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "キャリブレーション装置を表面の位置に移動して“次へ”を押してください"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "ノート PC を閉じてください"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "回復不能なエラーが発生しました。"
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "キャリブレーションに必要なツールがインストールされていません。"
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "プロファイルを生成できません。"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "対象の白色点は取得できません。"
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "完了しました!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "キャリブレーションに失敗しました!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "キャリブレーション装置を取り外せます。"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "測定中はキャリブレーション装置に触らないでください"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "キャリブレーションの表示"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "キャンセル(_C)"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -629,143 +427,9 @@ msgstr "再開(_R)"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "完了(_D)"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "ラップトップ画面"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "組み込みのウェブカム"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s モニター"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s スキャナー"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s カメラ"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s プリンター"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s ウェブカム"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s のカラーマネージメントを有効にする"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s のカラープロファイルを表示する"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "未較正"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "デフォルト: "
-
-# ref. gnome-color-manager
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "色空間: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "テスト用プロファイル: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "ICC プロファイルを選択"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "インポート(_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "サポートする ICC プロファイル"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "すべてのファイル"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "画面"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "プロファイルを保存"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:347
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "保存(_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "選択したデバイスのカラープロファイルを作成"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"計測器を検出できません。電源が入っていること、正しく接続されていることを確認"
-"してください。"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "計測器がプリンターのプロファイルをサポートしていません。"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "このデバイスの形式は現在サポートしていません。"
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -880,13 +544,13 @@ msgstr "書き込み可能メディアが必要です"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"<a href=\"linux\">GNU/Linux</a> や <a href=\"osx\">Apple OS X</a>、<a href="
-"\"windows\">Microsoft Windows</a> システムでのプロファイルの利用方法が役立つ"
-"かもしません。"
+"<a href=\"linux\">GNU/Linux</a> や <a href=\"osx\">Apple OS X</a>、<a "
+"href=\"windows\">Microsoft Windows</a> システムでのプロファイルの利用方法が役"
+"立つかもしません。"
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -905,8 +569,8 @@ msgid "_Import File…"
 msgstr "ファイルを読み込む(_I)…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "追加(_A)"
@@ -917,9 +581,7 @@ msgstr ""
 "カラーマネージメントを行うには、各デバイスの最新のカラープロファイルが必要に"
 "なります。"
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "もっと詳しく"
 
@@ -1051,82 +713,6 @@ msgstr "D65 (写真とグラフィック)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "標準の色空間"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "テスト用プロファイル"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "自動"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "低品質"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "中品質"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "高品質"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "デフォルト RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "デフォルト CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "デフォルトグレー"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "ベンダーが提供している工場でのキャリブレーションデータ"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "このプロファイルでは全画面表示での補正はできません"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "このプロファイルはもう正確ではなくなっているかもしれません。"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "色"
@@ -1136,16 +722,11 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "ディスプレイやカメラ、プリンター等のデバイスのキャリブレート"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Color;ICC;Profile;Calibrate;Printer;Display;色;ICC;プロファイル;キャリブレー"
 "ション;プリンター;ディスプレイ;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "その他…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1160,19 +741,14 @@ msgid "No languages found"
 msgstr "言語が見つかりません"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "さらに…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "設定を変更する場合はロックを解除してください"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "一部の設定は変更する前にロックを解除しておく必要があります。"
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "ロック解除…"
 
@@ -1195,148 +771,6 @@ msgstr "一時間単位で時刻を戻す"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "一分単位で時刻を戻す"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "今日"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "昨日"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%B%-e日"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%Y年%B%-e日"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d 時間"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d 分"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d 秒"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 秒"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "ホットスポット"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24時制"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "午前/午後"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%Y年%B%-e日 %p %I:%M"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%Y年%B%-e日 %H:%M"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%2$s, %1$s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%p %I:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%H:%M"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1419,31 +853,67 @@ msgstr "自動日時設定(_D)"
 msgid "Requires internet access"
 msgstr "インターネットアクセスが必要です"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "日付と時刻(_T)"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "自動タイムゾーン設定(_Z)"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "位置サービスの有効化とインターネットアクセスが必要です"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "有効"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "タイムゾーン(_O)"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ロック解除"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "日時書式(_F)"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "日付"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 秒"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "カレンダー(_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "数字"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "日付、時刻、タイムゾーンを変更します。"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr ""
@@ -1490,23 +960,11 @@ msgstr "既定のアプリケーション"
 msgid "Configure Default Applications"
 msgstr "既定のアプリケーションを設定します"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "default;application;preferred;media;デフォルト;既定;アプリケーション;メディ"
 "ア;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"技術的な問題に遭遇した場合、問題に関するレポートを送信することで %s の改善に"
-"役立てることができます。レポートは匿名で送信され、個人データは取り除かれま"
-"す。%s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1524,155 +982,116 @@ msgstr "診断"
 msgid "Report your problems"
 msgstr "問題を報告します"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;画面;スクリーン;ロック;診断;クラッシュ;プライベート;"
-"最近;テンポラリー;一時;インデックス;索引;名前;ネットワーク;プライバシー;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:337
-#: panels/universal-access/cc-ua-panel.c:469
-#: panels/universal-access/cc-ua-panel.c:479
-#: panels/universal-access/cc-ua-panel.c:491
-#: panels/universal-access/cc-ua-panel.c:527
-msgid "On"
-msgstr "オン"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:337
-#: panels/universal-access/cc-ua-panel.c:469
-#: panels/universal-access/cc-ua-panel.c:479
-#: panels/universal-access/cc-ua-panel.c:491
-#: panels/universal-access/cc-ua-panel.c:527
-msgid "Off"
-msgstr "オフ"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "変更を適用しますか?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "変更を適用できません"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "この原因はハードウェアの制限にある可能性があります。"
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "診断"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "適用(_A)"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "戻る"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "ディスプレイの配置"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "マルチディスプレイ"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "拡張"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "ミラー"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "トップバーとアクティビティボタンを含みます"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "プライマリディスプレイ"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "夜間モード"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "横方向"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "縦方向 (右向き)"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "縦方向 (左向き)"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "横方向 (逆向き)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "向き"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "解像度"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "リフレッシュレート"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "TV 向けに調整"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "サイズ調整"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "ナチュラルスクロール"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "夜間モード"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "明日まで一時的に無効にする"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "フィルターを再始動"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1680,59 +1099,59 @@ msgstr ""
 "夜間モードは画面の色を少し暖色にします。これは目の疲れを緩和し、不眠を防ぐの"
 "に役立ちます。"
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "スケジュール"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "日没から日の出まで"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "手動スケジュール"
 
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "時刻"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "開始"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "時"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "分"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "午前"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "午後"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "終了"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "色温度"
 
@@ -1744,7 +1163,6 @@ msgstr "ディスプレイ"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "接続したモニターやプロジェクターの使用方法を変更します"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1755,54 +1173,58 @@ msgstr ""
 "モニター;ナイトライト;夜間モード;ブルーライト;色管理;ディスプレイ;ディスプ"
 "レー;Displays;日没;日の出;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "不明"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s (ビルド ID: %s)"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "セキュリティタイプ"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64 ビット"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "インクの量"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32 ビット"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "インクの量"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "インクの量"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "不明"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "セキュリティ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "システムロゴ"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;画面;スクリーン;ロック;診断;クラッシュ;プライベート;"
+"最近;テンポラリー;一時;インデックス;索引;名前;ネットワーク;プライバシー;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "デバイス名"
 
@@ -1835,31 +1257,43 @@ msgstr "計算中…"
 msgid "OS Name"
 msgstr "OS 名"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s (ビルド ID: %s)"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "OS の種類"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "GNOME のバージョン"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "ロック解除…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "ウィンドウシステム"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "仮想化"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "ソフトウェアのアップデート"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "デバイス名を変更"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1867,7 +1301,12 @@ msgstr ""
 "デバイス名は、ネットワーク上での表示や Bluetooth デバイスのペアリングにおい"
 "て、このデバイスを識別するのに使用されます。"
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "デバイス名"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "名前を変更(_R)"
 
@@ -1879,11 +1318,6 @@ msgstr "このシステムについて"
 msgid "View information about your system"
 msgstr "システム情報を表示します"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1964,6 +1398,12 @@ msgstr "ランチャー"
 msgid "Launch help browser"
 msgstr "ヘルプブラウザーを起動"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "設定"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "電卓を起動"
@@ -1985,7 +1425,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "検索"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "システム"
 
@@ -2034,20 +1474,11 @@ msgstr "文字サイズを縮小"
 msgid "High contrast on or off"
 msgstr "ハイコントラストのオン/オフを切り替える"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "入力ソースが見つかりませんでした"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "その他"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "入力ソースを追加"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "インプットメソッドはログイン画面では使用できません"
 
@@ -2055,118 +1486,30 @@ msgstr "インプットメソッドはログイン画面では使用できませ
 msgid "No input source selected"
 msgstr "入力ソースを選択していません"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "オプション…"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "上へ"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "下へ"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "設定"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "キーボードレイアウトを表示"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "削除"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "独自のショートカット"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "代替文字キー"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"代替文字キーを使用すると追加の文字を入力できます。追加の文字はキーボード上に "
-"3 番目のオプションとして印刷されている場合があります。"
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "左 Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "右 Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "左 Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "右 Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "メニューキー"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "右 Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Compose キー"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"入力ソースはキーボードショートカット (%s) で切り替えることができます。\n"
-"キーはキーボードショートカットの設定で変更可能です。"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2188,53 +1531,29 @@ msgstr "すべてのウィンドウで同じソースを使用する(_S)"
 msgid "Switch input sources _individually for each window"
 msgstr "ウィンドウごとに個別に入力ソースを切り替える(_I)"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "特殊文字の入力"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "キーボードで記号や文字の異体字を入力する方法です。"
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "代替文字キー"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose キー"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "キーボードショートカット"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "ショートカットの表示とカスタマイズ"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d 個変更"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
-msgid "Reset All Shortcuts?"
-msgstr "すべてのショートカットをリセットしますか?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"ショートカットをリセットするとカスタムショートカットが影響を受ける可能性があ"
-"ります。この処理を元に戻すことはできません。"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "キャンセル"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
-msgid "Reset All"
-msgstr "すべてリセット"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2244,98 +1563,92 @@ msgstr "すべてリセット…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "すべてのショートカットをデフォルトのキーバインディングにリセットします"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "アクション(_A):"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "ショートカット"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "ショートカットを追加"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "独自のショートカットを追加"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "アプリを起動したりスクリプトを実行したりする独自のショートカットを設定しま"
 "す。"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "ショートカットを追加"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "キーボードショートカットがありません"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"すでに %s は %s のために使用されています。もし入れ替えなければ %s が無効化さ"
-"れます。"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "削除"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "新しいショートカットキーを入力してください"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "独自のショートカットを設定"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "ショートカットを設定"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "%s の新しいショートカットを入力してください。"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "独自のショートカットを追加"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "追加"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
 msgstr "入れ替え"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "設定"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "設定(_S)"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Esc でキャンセル、Backspace でキーボードショートカットを無効にできます。"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "名前"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "コマンド"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "ショートカット"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "ショートカットを設定…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "何もしない"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "ショートカットをデフォルトの値にリセットします"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "カメラの使用"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2349,7 +1662,6 @@ msgstr ""
 "キーボードショートカットや入力設定 (キーボードレイアウトや入力ソース) の変更"
 "を行います"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2358,15 +1670,15 @@ msgstr ""
 "ショートカット;ワークスペース;ウィンドウ;リサイズ;サイズ変更;ズーム;コントラ"
 "スト;入力;インプット;ソース;ロック;ボリューム;音量;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "位置情報サービスがオフになっています"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "アプリケーションが位置情報を取得できません。"
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2384,7 +1696,7 @@ msgstr ""
 "\n"
 "以下のアプリケーションが現在地を特定することを許可します。"
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "位置情報へのアクセスを要求しているアプリケーションはありません"
 
@@ -2392,169 +1704,19 @@ msgstr "位置情報へのアクセスを要求しているアプリケーショ
 msgid "Protect your location information"
 msgstr "位置情報を保護します"
 
-#. FIXME
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "画面オフのとき"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 秒"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 分"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 分"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74 panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 分"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 分"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 時間"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 分"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 分"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 分"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 分"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 分"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 分"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 分"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 分"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 分"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "しない"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"画面の自動ロックは、離席中に他の誰かがコンピューターにアクセスするのを防ぎま"
-"す。"
 
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "ブランクスクリーンの遅延"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "指定した時間、何もしないと画面がブランクになります。"
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "自動画面ロック(_L)"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "自動画面ロックの遅延(_S)"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "画面がブランクになったあと、指定した条件で自動的に画面をロックします。"
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "ロック画面に通知を表示する(_N)"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "新しい USB デバイスを認識しない(_U)"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr "画面をロックしているときは、新しい USB デバイスとの通信を行いません。"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "画面ロック"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "画面をロックします"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "マイクがオフになっています"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "アプリケーションが録音できません。"
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2567,7 +1729,7 @@ msgstr ""
 "\n"
 "以下のアプリケーションがマイクを使用することを許可します。"
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "マイクへのアクセスを要求しているアプリケーションはありません"
 
@@ -2575,8 +1737,11 @@ msgstr "マイクへのアクセスを要求しているアプリケーション
 msgid "Protect your conversations"
 msgstr "会話を保護します"
 
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
 # Button Label
-#. FIXME
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "設定を確認(_S)"
@@ -2594,83 +1759,148 @@ msgstr "主ボタン"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "マウス、タッチパッドのボタンの順位を設定します。"
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "左"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "右"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "検索する場所"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "マウス"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "マウスの速度"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "ナチュラルスクロール"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "スクロールする方向にコンテンツが移動します。"
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "スクロールする方向にコンテンツが移動します。"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "アクティブ"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "タッチパッド"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "タッチパッドの速度"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "メソッド(_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "タップでクリックする"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "2 本指でのスクロール"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "タップでクリックする"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "タッチパッド(相対座標)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "エッジスクロール"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "両面"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "クリック、ダブルクリック、スクロールを試してください"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "クリック 5 回、GEGL タイム"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "ダブルクリック、主ボタン"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "シングルクリック、主ボタン"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "ダブルクリック、中央ボタン"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "シングルクリック、中央ボタン"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "ダブルクリック、副ボタン"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "シングルクリック、副ボタン"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2681,7 +1911,6 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "マウスやタッチパッドの感度の変更、利き手の選択をします"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -2765,86 +1994,41 @@ msgstr "マルチタスク"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "プロダクティビティとマルチタスクに関する設定を管理します"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+#, fuzzy
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;マルチタスク;プロダク"
 "ティビティ;カスタマイズ;デスクトップ;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "問題に遭遇しました。ソフトウェアベンダーに報告してください。"
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager が動作している必要があります。"
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "その他のデバイス"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "新しい接続を追加"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "未設定"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "安全ではないネットワーク (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "安全なネットワーク (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "安全なネットワーク (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "安全なネットワーク (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "安全なネットワーク"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "接続"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "オプション…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"アクセスポイントをオンにすると %s から切断され、Wi-Fi でのインターネットアク"
-"セスができなくなります。"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "8 文字以上にしてください"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -2871,353 +2055,86 @@ msgid "Network Name"
 msgstr "ネットワーク名"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "パスワード"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "ランダムパスワードを生成します"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "パスワードを自動生成できます"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "オン(_T)"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "アクセスポイントを停止し、ユーザーを切断しますか?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "停止(_S)"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "機内モード"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Wi-Fi、Bluetooth、モバイルブロードバンドを無効にします"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Wi-Fi アダプターが見つかりませんでした"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Wi-Fi アダプターが接続されオンになっているか確認してください"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "機内モードオン"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Wi-Fi を使用する場合はオフにしてください"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Wi-Fi アクセスポイント有効"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "モバイルデバイスで QR コードをスキャンすると接続できます。"
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "アクセスポイントをオフにする…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "ネットワーク一覧"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager が動作している必要があります"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "問題に遭遇しました。ソフトウェアベンダーに報告してください。"
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x セキュリティ(_S)"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "セキュリティ"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"ここに入力した MAC アドレスは、現在の接続で利用しているネットワークデバイスの"
-"ハードウェアアドレスとして使用されます。この機能は MAC アドレスのクローニン"
-"グ、またはスプーフィングとして知られています。例: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "プロファイル %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "なし"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "しない"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i 日前"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "なし"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "弱い"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "OK"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "良い"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "非常に良い"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 アドレス"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "IPv6 アドレス"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP アドレス"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "接続情報を破棄"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "接続プロファイルを削除"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "VPN を削除"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "詳細"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "自動"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identity"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "アドレスを削除"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "ルートを削除"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "なし"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit キー (HEX または ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit パスフレーズ"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "動的 WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 パーソナル"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3228,8 +2145,20 @@ msgstr "信号強度"
 msgid "Link speed"
 msgstr "リンクの速度"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "セキュリティ"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 アドレス"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 アドレス"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "ハードウェアアドレス"
 
@@ -3238,12 +2167,17 @@ msgid "Supported Frequencies"
 msgstr "サポートする周波数帯"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "デフォルトルート"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3257,11 +2191,11 @@ msgstr "自動接続する(_A)"
 msgid "Make available to _other users"
 msgstr "他のユーザーも利用できるようにする(_O)"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr "従量制接続(_M): データ通信量に上限がある、または通信料がかかります"
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3306,7 +2240,7 @@ msgstr "リンクローカルのみ"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "手動"
 
@@ -3326,33 +2260,32 @@ msgid "Addresses"
 msgstr "アドレス"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "アドレス"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "ネットマスク"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "ゲートウェイ"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "自動"
 
@@ -3361,29 +2294,34 @@ msgstr "自動"
 msgid "Automatic DNS"
 msgstr "自動 DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "複数の IP アドレスを指定する場合はそれぞれコンマで区切ってください"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "ルート"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "自動ルート"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "メトリック"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "この接続はネットワーク上のリソースのためだけに使用する(_O)"
 
@@ -3396,82 +2334,13 @@ msgid "Automatic, DHCP only"
 msgstr "自動、DHCP のみ"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "プレフィックス"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "接続エディターを起動できません"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "新しいプロファイル"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "ファイルからインポート…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "VPN を追加"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "セキュリティ(_E)"
-
-#: panels/network/connection-editor/vpn-helpers.c:191
-msgid "Cannot import VPN connection"
-msgstr "VPN 接続をインポートできません"
-
-#: panels/network/connection-editor/vpn-helpers.c:193
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"ファイル“%s”は読み取れなかったか、または処理できる VPN 接続情報がありません\n"
-"\n"
-"エラー: %s"
-
-#: panels/network/connection-editor/vpn-helpers.c:223
-msgid "Select file to import"
-msgstr "インポートするファイルを選択"
-
-#: panels/network/connection-editor/vpn-helpers.c:276
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "ファイル“%s”はすでに存在します。"
-
-#: panels/network/connection-editor/vpn-helpers.c:278
-msgid "_Replace"
-msgstr "入れ替え(_R)"
-
-#: panels/network/connection-editor/vpn-helpers.c:280
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "%s を、保存している VPN 接続に入れ替えますか?"
-
-#: panels/network/connection-editor/vpn-helpers.c:315
-msgid "Cannot export VPN connection"
-msgstr "VPN 接続をエクスポートできません"
-
-#: panels/network/connection-editor/vpn-helpers.c:317
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN 接続“%s”を %s にエクスポートできませんでした。\n"
-"\n"
-"エラー: %s"
-
-#: panels/network/connection-editor/vpn-helpers.c:343
-msgid "Export VPN connection"
-msgstr "VPN 接続をエクスポート"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3485,11 +2354,16 @@ msgstr "SSID(_S)"
 msgid "_BSSID"
 msgstr "BSSID(_B)"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "ネットワーク"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "ネットワークへの接続方法を設定します"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
@@ -3497,94 +2371,34 @@ msgstr ""
 "ターネット;有線;プロキシー;プロキシ;ブロードバンド;モデム;ブルートゥース;VPN;"
 "ドメイン名;ドメインネームサーバー;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Wi-Fi ネットワークへの接続方法を設定します"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;ネットワーク;無線;ワ"
 "イヤレス;ブロードバンド;ホットスポット;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "未接続"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "今日"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "昨日"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "最後の利用"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "有線"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "新しい接続を追加"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr "パスワードや独自の設定など、選択したネットワークの詳細は失われます。"
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "破棄(_F)"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "既知の Wi-Fi ネットワーク"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "破棄(_F)"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "システムのポリシーによりホットスポットとしての利用は禁止されています"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "ワイヤレスデバイスがホットスポットモードに対応していません"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"設定ファイルの URL が指定されていない場合 Web Proxy Autodiscovery が使用され"
-"ます。"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "信頼できない公衆ネットワークでは推奨されません。"
-
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "デバイスをオフにする"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "アクティブ"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3595,47 +2409,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "プロバイダー"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP アドレス"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "ネットワークプロキシ"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "HTTP プロキシ(_H)"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "HTTPS プロキシ(_T)"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "FTP プロキシ(_F)"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Socks ホスト(_S)"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "次のホストを無視する(_I)"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "HTTP プロキシポート"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "HTTPS プロキシポート"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "FTP プロキシポート"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Socks プロキシポート"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "設定 URL(_C)"
 
@@ -3662,300 +2480,22 @@ msgstr "パスワード"
 msgid "Turn Wi-Fi off"
 msgstr "Wi-Fi をオフにする"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "オプション…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "非表示のネットワークに接続(_C)…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Wi-Fi アクセスポイントをオンにする(_T)…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "既知の Wi-Fi ネットワーク(_K)"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "ステータス不明"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "管理対象外"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "利用不可"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "接続中"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "認証が必要です"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "切断中"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "接続失敗"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "ステータス不明 (見つかりません)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "設定に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP 設定に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP 設定の期限切れです"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "秘密の情報が必要でしたが入力されませんでした"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x サプリカントが切断されました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x サプリカントの設定に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x サプリカントが失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x サプリカントの認証に時間がかかりすぎました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP サービスの起動に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP サービスの接続を切断しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP が失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP クライアントの起動に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP クライアントにエラーが発生しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP クライアントが失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "共有接続サービスの起動に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "共有接続サービスが失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP サービスの起動に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP サービスにエラーが発生しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP サービスが失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "回線が使用中です"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "発信音がありません"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "キャリアの確立ができませんでした"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "発信要求がタイムアウトしました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "発信の試行に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "モデムの初期化に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "指定された APN の選択に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "ネットワーク検索をしていません"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "ネットワーク登録が拒否されました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "ネットワーク登録がタイムアウトしました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "要求されたネットワークへの登録に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN チェックに失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "このデバイスのファームウェアがないようです"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "接続が消失しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "既存の接続とみなされました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "モデムが見つかりませんでした"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth 接続に失敗しました"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM カードが挿入されていません"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM の PIN 番号が必要です"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM の PUK が必要です"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM が違います"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "接続が依存するデバイスなどの準備ができません"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "ファームウェア未検出"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "ケーブル非接続"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "802.1X セキュリティ (wpa-eap) で未定義のエラーが発生しました"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "ファイルが選択されていません"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "EAP メソッドファイルの検証中に特定できないエラーが発生しました"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, PKCS#12 の秘密鍵 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER か PEM の証明書 (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "EAP-FAST PAC ファイルがありません"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC ファイル (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4005,14 +2545,6 @@ msgstr "内部認証(_I)"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "自動的な PAC プロビジョニングを許可する(_V)"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "EAP-LEAP ユーザー名がありません"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "EAP-LEAP パスワードがありません"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4025,7 +2557,7 @@ msgstr "ユーザー名(_U)"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "パスワード(_P)"
 
@@ -4037,15 +2569,6 @@ msgstr "パスワード(_P)"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "パスワードを表示する(_W)"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "無効な EAP-PEAP CA 証明書: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "無効な EAP-PEAP CA 証明書: 認証書が指定されていません"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4068,7 +2591,6 @@ msgid "C_A certificate"
 msgstr "CA 証明書(_A)"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4083,62 +2605,6 @@ msgstr "CA 証明書が要求されましたが存在しません(_R)"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP バージョン(_V)"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "EAP ユーザー名がありません"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "EAP パスワードがありません"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "EAP-TLS Identity がありません"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "無効な EAP-TLS CA 証明書: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "無効な EAP-TLS CA 証明書: 認証書が指定されていません"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "無効な EAP-TLS 秘密鍵: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "無効な EAP-TLS ユーザー証明書: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "暗号化されていない秘密鍵は安全ではありません"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"選択した秘密鍵はパスワードで保護されていないようです。この状態は信用情報の侵"
-"害を許してしまいます。パスワード保護のある秘密鍵を選択してください。\n"
-"\n"
-"(秘密鍵は openssl を使用してパスワード保護ができます)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "個人用証明書を選択する"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "秘密鍵を選択する"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4155,15 +2621,6 @@ msgstr "秘密鍵(_K)"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "秘密鍵のパスワード(_P)"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "無効な EAP-TTLS CA 証明書: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "無効な EAP-TTLS CA 証明書: 証明書が指定されていません"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4186,14 +2643,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "ドメイン(_D)"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "802.1X セキュリティの検証中に不明なエラーが発生しました"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4221,62 +2679,10 @@ msgstr "保護つき EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "認証(_T)"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "ファイルを選択"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "LEAP ユーザー名がありません"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "LEAP パスワードがありません"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Wi-Fi パスワードがありません。"
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "種類(_T)"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "WEP キーがありません"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"無効な WEP キー: キーの長さが %zu 文字の場合、16 進数字以外は使用できません"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"無効な WEP キー: キーの長さが %zu 文字の場合、アスキー文字以外は使用できませ"
-"ん"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"無効な WEP キー: キーの長さ %zu は使用できません。WEP キーは長さ 5 文字か 13 "
-"文字のアスキー文字、または 10 文字か 26 文字の 16 進数字のどちらかでなければ"
-"なりません"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "無効な WEP キー: パスフレーズには必ず何か入力してください"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "無効な WEP キー: パスフレーズは 64 文字未満でなければなりません"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4301,19 +2707,6 @@ msgstr "キーを表示する(_W)"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP インデックス(_X)"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"無効な WPA PSK: キーの長さ %zu は無効です。8 〜 63 文字、または 16 進数表記"
-"で 64 文字でなければなりません"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "無効な WPA PSK: キーが 64 文字の場合、16 進数字以外は使用できません"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4366,60 +2759,36 @@ msgstr "ロック画面での通知(_L)"
 msgid "Control which notifications are displayed and what they show"
 msgstr "表示する通知およびその表示方法について設定します"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Notifications;Banner;Message;Tray;Popup;通知;バナー;メッセージ;トレイ;ポップ"
 "アップ;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "%s を削除しました"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "その他"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "アカウントの削除に失敗しました"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "元に戻す"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "システムの通知を表示します。"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "クラウド上のあなたのデータと接続します"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "インターネット接続がありません — 新しいオンラインアカウントのセットアップのた"
 "めに接続してください"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "アカウントの追加"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:426
-#, c-format
-msgid "%s Account"
-msgstr "%s アカウント"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:429
-msgid "Remove Account"
-msgstr "アカウントを削除"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4429,10 +2798,6 @@ msgstr "オンラインアカウント"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "オンラインアカウントへの接続や利用方法を設定します"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4442,10 +2807,6 @@ msgstr ""
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;グーグル;フェイスブック;ツイッター;ヤ"
 "フー;ウェブ;オンライン;チャット;カレンダー;メール;連絡先;Flickr;"
 "OnlineAccounts;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "残り時間は不明"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4459,13 +2820,6 @@ msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i 時間"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4475,186 +2829,6 @@ msgstr[0] "時間"
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "分"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "フル充電まで %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "注意: 残り %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "残り %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "フル充電"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "充電していません"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "空"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "充電中"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "放電中"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "ワイヤレスマウス"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "ワイヤレスキーボード"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "無停電電源装置"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "携帯情報端末"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "携帯電話"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "音楽プレーヤー"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "タブレット"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "コンピューター"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "ゲーム用入力デバイス"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "バッテリー"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "主"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "予備"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "バッテリー"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "アイドル時(_I)"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "サスペンド"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "電源オフ"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "ハイバネート"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "なにもしない"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "バッテリー動作時"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "電源接続時"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "しない"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "自動サスペンド"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "動作温度が高いためパフォーマンスモードが一時的に無効になりました。"
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr "パフォーマンスモードが一時的に無効になりました。"
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"バッテリー低下: 省電力が有効になりました。バッテリーが十分に充電されると以前"
-"のモードに戻ります。"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "“%s”によって省電力モードがアクティブになります。"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "“%s”によってパフォーマンスモードがアクティブになります。"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4716,6 +2890,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 時間"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "バッテリー"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "デバイス"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "電源モード"
@@ -4736,89 +2919,62 @@ msgstr "画面の明るさを自動調整する"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "周囲光で画面の明るさを調節します。"
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "画面を暗くする"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "コンピューターが非アクティブなときに画面の明るさを下げます。"
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "画面のブランク(_B)"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "何もしない状態が一定時間続いたら画面をオフにします。"
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "自動的に消費電力を抑える"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr "バッテリーが低下したときに省電力モードを有効にします。"
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "自動サスペンド(_A)"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "何もしない状態が一定時間続いたらコンピューターを休止します。"
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "電源ボタンの挙動(_W)"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "バッテリー残量を表示する(_P)"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "自動サスペンド"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "電源接続時(_P)"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "バッテリー動作時(_B)"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "時間"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "パフォーマンス"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "高いパフォーマンスと消費電力です。"
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "バランス"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "標準的なパフォーマンスと消費電力です。"
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "省電力"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "パフォーマンスと消費電力を抑えます。"
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4828,7 +2984,6 @@ msgstr "電源"
 msgid "View your battery status and change power saving settings"
 msgstr "バッテリー状態の表示、省電力の設定をします"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4838,27 +2993,6 @@ msgstr ""
 "Energy;電源;スリープ;サスペンド;ハイバネート;バッテリー;明るさ;ブランクスク"
 "リーン;モニター;画面;ディスプレイ;アイドル;待機;電力;エネルギー;"
 
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "プリンター“%s”を削除しました"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "新しいプリンターを追加できませんでした。"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui ファイルを読み込めませんでした: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "設定の変更やプリンターを追加する場合はロックを解除してください"
-
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "プリンター"
@@ -4867,7 +3001,6 @@ msgstr "プリンター"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "プリンターの追加、プリンタージョブの表示、印刷方法の設定を行います。"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -4876,94 +3009,71 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "プリンターを追加"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "ロック解除(_U)"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "プリンターが見つかりませんでした"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "ネットワークアドレスを入力するかプリンターを検索してください"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "認証が必要です"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "プリンターサーバーで利用可能なプリンターを表示するにはユーザー名とパスワード"
 "を入力してください。"
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "ユーザー名"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "%s の詳細"
-
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "適切なドライバーが見つかりませんでした"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "PPD ファイルを選択"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"PostScript Printer Description ファイル(*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
 
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "場所"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "ドライバー"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "推奨ドライバーの検索中…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "ドライバーを検索する"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "データベースから選択…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "PPD ファイルをインストール…"
 
@@ -4975,131 +3085,19 @@ msgstr "プリンタードライバーを選択"
 msgid "Loading drivers database…"
 msgstr "ドライバーのデータベースを読み込み中…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "キャンセル"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "選択"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect プリンター"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD プリンター"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "片面"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "長辺とじ (標準)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "短辺とじ (フリップ)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "縦方向"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "横方向"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "横方向 (逆向き)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "縦方向 (逆向き)"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "待機中"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "一時停止"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "認証が必要です"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "印刷中"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "停止"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "キャンセル"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "中止"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "完了"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "このジョブをキューの先頭へ移動する"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u 件のジョブで認証が要求されています"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — アクティブなジョブ"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "%s から印刷するにはユーザー名とパスワードを入力してください。"
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5108,341 +3106,35 @@ msgid "Domain"
 msgstr "ドメイン"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "認証(_U)"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "すべて消去"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "認証(_A)"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "アクティブなジョブはありません"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "プリンターサーバーのロック解除"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s のロック解除"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"%s で利用可能なプリンターを表示するにはユーザー名とパスワードを入力してくださ"
-"い。"
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "プリンターの検索"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "シリアルポート"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "パラレルポート"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "場所: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "アドレス: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "サーバーが認証を要求しています"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "両面"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "用紙の種類"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "給紙元"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "出力トレイ"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "解像度"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript のプレフィルタリング"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "片面のページ数"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "両面"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "向き"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "汎用"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "ページ設定"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "インストール可能なオプション"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "ジョブ"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "画質"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "色"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "表面処理"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "高度"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "テストページ"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "テストページ"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "自動選択"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "プリンターのデフォルト"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "内蔵 GhostScript フォントのみ"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "PS レベル 1 に変換"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "PS レベル 2 に変換"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "プレフィルタリングなし"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "製造元"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "アクティブなジョブがありません"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u ジョブ"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "ヘッドクリーニング"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "トナーの残量が少なくなっています"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "トナーが空です"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "現像液が少なくなっています"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "現像液が空です"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "インクが少なくなっています"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "インクが切れています"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "カバーが開いています"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "扉が開いています"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "紙が少なくなっています"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "紙が空です"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "オフライン"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "停止中"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "廃インクタンクがもう少しでいっぱいです"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "廃インクタンクがいっぱいです"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "感光体の寿命が近づいています"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "感光体の寿命です"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "準備完了"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "ジョブ受付不可"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "処理中"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5466,41 +3158,45 @@ msgstr "ヘッドクリーニング"
 msgid "Remove Printer"
 msgstr "プリンターを削除"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "アクティブなジョブがありません"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "型式"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "インクの量"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "問題が解決した場合、再起動してください。"
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "再起動"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "プリンターを追加…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "プリンターを追加…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "プリンターが見つかりません"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "プリンターを追加…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5508,48 +3204,33 @@ msgstr ""
 "申し訳ありません! システムの印刷サービスは\n"
 "    現在、利用できないようです。"
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "フォーマット"
-
-#: panels/region/cc-format-chooser.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "戻る"
 
 #: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr "地域を検索…"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "一般的な形式"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "すべての形式"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "検索結果はありません"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "国または言語を検索できます。"
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "プレビュー"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ヤード・ポンド法"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "メートル法"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5580,27 +3261,32 @@ msgid "Logout…"
 msgstr "ログアウト…"
 
 #: panels/region/cc-region-panel.ui:45
+#, fuzzy
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
 "設定した言語でインターフェースやウェブページのテキストが表示されます。フォー"
 "マットは数値、日時、通貨の形式に使用されます。"
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "あなたのアカウント"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "言語(_L)"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "フォーマット(_F)"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "ログイン画面"
 
@@ -5612,101 +3298,11 @@ msgstr "地域と言語"
 msgid "Select your display language and formats"
 msgstr "表示される言語や日付などの形式を選択します"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 "Language;Layout;Keyboard;Input;言語;レイアウト;キーボード;入力;インプット;"
 "Region;地域;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "どうするか確認する"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "なにもしない"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "フォルダーを開く"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "他のメディア"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "オーディオ CD 用のアプリケーションを選択"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "ビデオ DVD 用のアプリケーションを選択"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "音楽プレーヤーが接続されたときに起動するアプリケーションを選択"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "カメラが接続されたときに起動するアプリケーションを選択"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "ソフトウェアの CD を開くアプリケーションを選択"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "オーディオ DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "空のブルーレイディスク"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "空の CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "空の DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "空の HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "ブルーレイビデオディスク"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "電子書籍リーダー"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD ビデオディスク"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "ピクチャー CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "スーパービデオ CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "ビデオ CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows ソフトウェア"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5757,7 +3353,6 @@ msgstr "リムーバブルメディア"
 msgid "Configure Removable Media settings"
 msgstr "リムーバブルメディアを設定します"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5768,13 +3363,78 @@ msgstr ""
 "定;オーディオ;音声;音楽;ミュージック;ビデオ;動画;ディスク;リムーバブルメディ"
 "ア;媒体;自動起動;オートラン;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "場所を選択"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "画面ロック"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "OK(_O)"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"画面の自動ロックは、離席中に他の誰かがコンピューターにアクセスするのを防ぎま"
+"す。"
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "ブランクスクリーンの遅延"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "指定した時間、何もしないと画面がブランクになります。"
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "自動画面ロック(_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "自動画面ロックの遅延(_S)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "画面がブランクになったあと、指定した条件で自動的に画面をロックします。"
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "ロック画面に通知を表示する(_N)"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "ロック画面での通知(_L)"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "新しい USB デバイスを認識しない(_U)"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "画面をロックしているときは、新しい USB デバイスとの通信を行いません。"
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "プライバシー"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "画面"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "画面共有"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5793,21 +3453,17 @@ msgstr ""
 msgid "Places"
 msgstr "場所"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "ブックマーク"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "その他"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "場所を追加"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "アプリケーションが見つかりませんでした"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5834,67 +3490,15 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "アクティビティ画面で検索結果を表示するアプリケーションを設定します"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Search;Find;Index;Hide;Privacy;Results;サーチ;検索;インデックス;索引;非表示;"
 "プライバシー;結果;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "共有するネットワークを選択していません"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "ネットワーク"
-
-#: panels/sharing/cc-sharing-panel.c:367
-msgctxt "service is enabled"
-msgid "On"
-msgstr "オン"
-
-#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "オフ"
-
-#: panels/sharing/cc-sharing-panel.c:399
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "有効"
-
-#: panels/sharing/cc-sharing-panel.c:402
-msgctxt "service is active"
-msgid "Active"
-msgstr "アクティブ"
-
-#: panels/sharing/cc-sharing-panel.c:520
-msgid "Choose a Folder"
-msgstr "フォルダーを選択"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:748
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"ファイル共有を使用して、現在のネットワークの他ユーザーが次の URI に接続し、あ"
-"なたの公開フォルダーを共有できるようにします: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:754
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"リモートログインを有効にした場合、リモートユーザーによる Secure Shell コマン"
-"ドを使用した接続を許可します:\n"
-"%s"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -5934,82 +3538,89 @@ msgstr "パスワードを要求する(_R)"
 msgid "Remote Login"
 msgstr "リモートログイン"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "リモートデスクトップ"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
 msgstr ""
-"リモートデスクトップは、他のコンピューターからあなたのデスクトップを表示"
-"したり操作したりできるようにします。"
+"リモートデスクトップは、他のコンピューターからあなたのデスクトップを表示した"
+"り操作したりできるようにします。"
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr ""
 "このコンピューターへのリモートデスクトップ接続の有効/無効を切り替えます。"
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "リモートコントロール"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
 msgstr "リモート接続で画面を操作することを許可します。"
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
 msgstr "接続方法"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
-"このコンピューターに接続するには、デバイス名かリモートデスクトップアドレ"
-"スを使用します。"
+"このコンピューターに接続するには、デバイス名かリモートデスクトップアドレスを"
+"使用します。"
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "コピー"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "リモートデスクトップアドレス"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "認証"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr "このコンピューターへの接続にはユーザー名とパスワードが必要です。"
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "ユーザー名"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "暗号化を検証"
 
-#: panels/sharing/cc-sharing-panel.ui:430
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:431
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:463
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "メディア共有"
 
-#: panels/sharing/cc-sharing-panel.ui:485
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "音楽や写真、ビデオをネットワーク上で共有できます。"
 
-#: panels/sharing/cc-sharing-panel.ui:498
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "フォルダー"
 
@@ -6017,7 +3628,6 @@ msgstr "フォルダー"
 msgid "Control what you want to share with others"
 msgstr "他のユーザーと共有するものを設定します"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6036,38 +3646,38 @@ msgstr "リモートログインの有効化/無効化"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "リモートログインを有効化または無効化するには認証が必要になります"
 
-#: panels/sound/cc-alert-chooser.c:150
-msgid "Custom"
-msgstr "その他"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "犬が吠える音"
+msgid "Click"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "水が滴る音"
+#, fuzzy
+msgid "String"
+msgstr "共有"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "ガラスを叩く音"
+msgid "Swing"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "ソナーのピング音"
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "バランス"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "フェード"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "リア"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "フロント"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s のテスト中"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6077,58 +3687,54 @@ msgstr "スピーカーをクリックしてテストしてください"
 msgid "System Volume"
 msgstr "システムの音量"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "システムの音量"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "音量レベル"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "出力"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "出力デバイス"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "テスト"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "設定"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "バランス"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "フェード"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "サブウーファー"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "入力"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "入力デバイス"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "音量"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "警告音"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6138,7 +3744,6 @@ msgstr "サウンド"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "サウンドレベルや入力、出力、警告音を設定します"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6147,169 +3752,59 @@ msgstr ""
 "ド;マイク;音量;フェード;バランス;ブルートゥース;ヘッドセット;オーディオ;"
 "Sound;サウンド;アウトプット;インプット;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "切断"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "接続中"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "接続"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "認証エラー"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "認証中"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "接続 & 認証"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "不明"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "認証日時:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "接続日時:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "登録日時:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "デバイスの認証に失敗しました: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "デバイスの削除に失敗しました: "
-
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "システムの通知を表示します。"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "名前:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "ステータス:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "認証と接続"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "デバイスを削除"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "エラー"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "認証"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Thunderbolt サブシステム (boltd) がインストールされていないか、正しくセット"
-"アップされていません。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "ドックや外付け GPU などのデバイスへのダイレクトアクセスを許可します。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "USB デバイスと DisplayPort デバイスのみ接続できます。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt を検出できませんでした。\n"
-"システムが Thunderbolt に対応していないか、または BIOS で Thunderbolt が無効"
-"になっているか、もしくは BIOS で Thunderbolt のセキュリティレベルが対応してい"
-"ない設定になっているかのいずれかです。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt サポートは BIOS で無効化されています。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Thunderbolt のセキュリティレベルを確認できませんでした。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "ダイレクトモードの切り替え中にエラーが発生しました: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
+#: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Thunderbolt サポートがありません"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:104
+#: panels/thunderbolt/cc-bolt-panel.ui:103
 msgid "Could not connect to the thunderbolt subsystem."
 msgstr "Thunderbolt サブシステムに接続できませんでした。"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:153
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "ダイレクトアクセス"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "ドックや外付け GPU などのデバイスへのダイレクトアクセスを許可します。"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "保留中のデバイス"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "デバイスが接続されていません"
 
@@ -6321,7 +3816,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Thunderbolt デバイスを管理します"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;プライバシー;"
@@ -6330,16 +3824,16 @@ msgstr "Thunderbolt;privacy;プライバシー;"
 msgid "Cursor Blinking"
 msgstr "カーソルの点滅"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "テキストフィールドでカーソルを点滅させます。"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "速度"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "カーソルが点滅する速さです"
 
@@ -6427,15 +3921,15 @@ msgstr "大"
 msgid "Repeat Keys"
 msgstr "リピートキー"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "キーを長押しすると繰り返しキー入力を行います。"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "リピートキーが行われるまでの時間です"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "押したキーをリピートするときの速さです"
 
@@ -6517,46 +4011,13 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "長い"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "キーボードから有効化できるようにする(_E)"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "アクセシビリティ機能のオン/オフをキーボードで切り替える"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Default"
-msgstr "デフォルト"
-
-#: panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "中"
-
-#: panels/universal-access/cc-ua-panel.c:363
-msgctxt "cursor size"
-msgid "Large"
-msgstr "大"
-
-#: panels/universal-access/cc-ua-panel.c:366
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "特大"
-
-#: panels/universal-access/cc-ua-panel.c:369
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "最大"
-
-#: panels/universal-access/cc-ua-panel.c:373
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d ピクセル"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6673,31 +4134,6 @@ msgstr "画面全体をひらめかせる(_S)"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "ウィンドウ全体をひらめかせる(_W)"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "短い"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "画面の¼"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "画面の½"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "画面の¾"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "長い"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6859,7 +4295,6 @@ msgstr ""
 "見る、聞く、タイピング、クリック操作など、コンピューターを簡単に使えるように"
 "します"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -6875,114 +4310,6 @@ msgstr ""
 "サイズ;固定;キー;スロー;バウンス;ダブルクリック;ディレイ;遅延;速度;スピード;"
 "ユーザー支援;リピート;点滅;ビジュアル;視覚;ヒアリング;聴覚;音声;タイピング;ユ"
 "ニバーサルアクセス;animations;アニメーション;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 時間"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 日"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 日"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 日"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 日"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 日"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 日"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 日"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 日"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 日"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "ゴミ箱からすべてのアイテムを削除しますか?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "ここでアイテムを削除すると元に戻すことはできません。"
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "ゴミ箱を空にする(_E)"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "一時ファイルをすべて削除しますか?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "一時ファイルは完全に削除されます。"
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "一時ファイルを削除する(_P)"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 日"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 日"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 日"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "無期限"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7050,57 +4377,10 @@ msgstr "ファイルの履歴と削除"
 msgid "Don't leave traces"
 msgstr "痕跡を残さないようにします"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "ログイン提供者のウェブアドレスと一致させる必要があります。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "アカウントの追加に失敗しました"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:258
-msgid "The passwords do not match."
-msgstr "パスワードが一致しません。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "アカウントの登録に失敗しました"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "このドメインで認証を行う方法はサポートしていません"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "ドメインの参加に失敗しました"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"ログイン名に問題がありました。\n"
-"やり直してください。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"パスワードに問題がありました。\n"
-"やり直してください。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "ドメインへのログインに失敗しました"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "ドメインを見つけられません。スペルミスがないか確認してください。"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7136,14 +4416,15 @@ msgid "Enterprise Login"
 msgstr "エンタープライズログイン"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+#, fuzzy
+msgid "User accounts which are managed by a company or organization."
 msgstr "会社や組織に管理されているユーザーアカウントです。"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "現在オフラインです"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7152,10 +4433,6 @@ msgstr ""
 "エンタープライズログインでは、中央管理された既存のユーザーアカウントをこのデ"
 "バイスで使用できます。このアカウントを使用して、インターネット上の企業内の各"
 "種リソースにアクセスすることができます。"
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "他の画像を参照"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7169,46 +4446,46 @@ msgstr "指紋認証マネージャー"
 msgid "Fingerprint"
 msgstr "指紋認証"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "いいえ(_N)"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "はい(_Y)"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
 msgstr "登録済みの指紋情報を削除して指紋認証を無効にしますか?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "指紋認証デバイスがありません"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "指紋認証デバイスがありません"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "デバイスが正しく接続されていることを確認してください。"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "指紋認証デバイス"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "設定する指紋認証デバイスを選択してください"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "指紋認証ログイン"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7216,468 +4493,136 @@ msgstr ""
 "指紋認証ログインは指を使ってコンピューターにログインしたりロックを解除したり"
 "できるようにします"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "指紋情報を削除(_D)"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "指紋の登録"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr ""
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "前のトラック"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "指紋リーダーとの通信に失敗しました"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "指紋認証デーモンとの通信に失敗しました"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "指紋情報の一覧を表示できませんでした: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "保存された指紋情報の削除に失敗しました: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "左の親指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "左の中指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "左の人差し指(_L)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "左の薬指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "左の小指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "右の親指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "右の中指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "右の人差し指(_R)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "右の薬指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "右の小指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "不明な指です"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "完了"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "指紋認証デバイスが切断されました"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "指紋認証デバイスの登録数が上限に達しています"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "新しい指紋の登録に失敗しました"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "登録を開始できませんでした: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "新しい指紋の登録に失敗しました"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "登録を停止できませんでした: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr "指紋リーダーに指を何度か押し付けて指紋を登録してください"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "この指を再登録(_R)…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "新しい指紋の採取"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "デバイスの読み取りに問題があります"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "指紋認証デバイスの取得に失敗しました: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "今週"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "先週"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%B%-e日"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%Y年%B%-e日"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-# %k:%M よりも %H:%M の方がガタガタしていなくて見やすい (sicklylife)
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%H:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "セッション終了"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "セッション開始"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — アカウントのアクティビティ"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "他のパスワードを選択してください。"
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "現在のパスワードを再度入力してください。"
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "パスワードを変更できません"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "次へ(_N)"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "パスワードを変更"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "変更(_A)"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "現在のパスワード"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "新しいパスワード"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "パスワードの確認"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "パスワードが一致しません。"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "次回ログイン時にユーザー自身にパスワードを設定させる"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "今すぐパスワードを設定する"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "このタイプのドメインは自動で参加できません"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "そのようなドメインやレルムは見つかりませんでした"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%2$s ドメインに %1$s としてログインできません"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "不正なパスワードです、やり直してください"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "%s ドメインに接続できませんでした: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "ユーザーの削除に失敗しました"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "リモート管理ユーザーの削除に失敗しました"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "自分自身のアカウントは削除できません。"
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s はまだログインしています"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"ログイン中のユーザーを削除すると、システムが不整合な状態になることがありま"
-"す。"
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "%s のファイルを残しますか?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"ユーザーアカウントを削除するときに、ユーザーのホームディレクトリ、メールス"
-"プールおよび一時ファイルを残しておくことができます。"
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "ファイルを削除(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "ファイルを残す(_K)"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "本当にリモート管理の %s のアカウントを削除しますか?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "削除(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "無効アカウント"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "次回ログイン時に設定"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "なし"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "ログイン中"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "有効"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "アカウントサービスの接続に失敗しました"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"AccountService がインストールされ、有効になっているか確認してください。"
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "この設定を変更するにはパネルのロックを解除する必要があります"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "選択したユーザーアカウントを削除します"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"選択したユーザーアカウントを削除するには、\n"
-"まず * アイコンをクリックしてください"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "設定の変更やユーザーを追加する場合はロックを解除してください"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "ユーザー"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "変更内容を反映させるにはログインし直す必要があります"
 
 # ユーザー設定を変更すると表示されるボタンのラベル。クリックするとログアウトダイアログが表示されます。
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "ログアウト"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "閉じる"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "フルネーム(_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "指紋認証ログイン(_F)"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "自動ログイン(_U)"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "アカウントのアクティビティ"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "管理者(_A)"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
 msgstr "管理者は他のユーザーの追加、削除、設定の変更ができます。"
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "ペアレンタルコントロール(_P)"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "ペアレンタルコントロールアプリケーションを開きます。"
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "ユーザーを削除…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "他のユーザー"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "ユーザーを追加…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "ユーザーが見つかりませんでした"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "ユーザーアカウントのロックを解除します。"
 
@@ -7685,7 +4630,6 @@ msgstr "ユーザーアカウントのロックを解除します。"
 msgid "Add or remove users and change your password"
 msgstr "ユーザーの追加と削除、パスワードの変更を行います"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7731,182 +4675,8 @@ msgstr "ユーザーアカウントの管理"
 msgid "Authentication is required to change user data"
 msgstr "ユーザーのデータを変更するには認証が必要になります"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr ""
-"新しいパスワードは、現在のパスワードとは異なるものを指定する必要があります。"
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "いくつかの文字や数字を変更してください。"
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr ""
-"新しいパスワードが現在のものと似すぎています。もう少し異なるものを使用してく"
-"ださい。"
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "パスワードからユーザー名を取り除くともっと強くなるでしょう。"
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "パスワード中にユーザーの氏名を使うのは避けるようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "パスワードにある一部の単語を使わないようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "一般的な単語は避けるようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "既存の単語の文字を並べ替えたものは使わないようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "数字をもっと使うようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "大文字をもっと使うようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "小文字をもっと使うようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "記号など特殊文字をもっと使うようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "アルファベット、数字、記号を混在させるようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "同じ文字を連続して使わないようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"同じ種類の文字の繰り返しは避けるようにしてください。アルファベット、数字、記"
-"号を混ぜてください。"
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 や abcd などの連続した並びは避けるようにしてください。"
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"パスワードが短すぎます。アルファベット、数字、記号をもっと追加するようにして"
-"ください。"
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "大文字、小文字を混在させ、さらに数字を 1 つか 2 つ含めてください。"
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "さらに文字や数字、記号を追加すると、もっと強くなります。"
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "認証に失敗しました"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "新しいパスワードは短すぎます"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "新しいパスワードは単純すぎます"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "新旧 2 つのパスワードが似すぎています"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "新しいパスワードは最近使用したものです。"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "新しいパスワードには数字または特殊文字を含めてください"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "新旧のパスワードが同一です"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "最初に認証を行った以降にパスワードが変更されています!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "新しいパスワードには十分な種類の文字が含まれていません"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "原因不明のエラー"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"ユーザー名には小文字の“a”から“z”、数字の“0”から“9”、記号の“-”と“_”のみを使用"
-"してください。"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"申し訳ありませんが、そのユーザー名は使用できません。他の名前を試してくださ"
-"い。"
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "ユーザー名が長すぎます。"
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "ボタン割り当て"
 
@@ -7939,47 +4709,11 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "誤クリックを検出しました。再起動します…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "ボタン %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "アプリケーション定義"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "キー入力の送信"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "モニターの切り替え"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "オンスクリーンヘルプの表示"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
 msgstr "外付けのタブレットデバイス"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "すべてのディスプレイ"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -7989,29 +4723,29 @@ msgstr "タブレットモード"
 msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "左手用"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
 # 参考: intuos 5 のマニュアル p.57
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "画面にマッピング"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "縦横比を保持"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "キャリブレート"
 
@@ -8026,6 +4760,20 @@ msgstr "ワコムタブレットを接続するか、電源を入れてくださ
 #: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "ペン先の感触"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "柔らかい"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "硬い"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:54
 msgctxt "display setting"
@@ -8046,21 +4794,22 @@ msgstr "ボタン 3"
 msgid "Eraser Pressure Feel"
 msgstr "消しゴムの感触"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "消しゴムの感触"
 
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr ""
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "マウスの中ボタンクリック"
 
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr ""
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "マウスの右ボタンクリック"
 
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr ""
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "進む"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
@@ -8071,56 +4820,98 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "グラフィックスタブレットのボタン割り当てやスタイラスの感度の設定をします。"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 "Tablet;Wacom;Stylus;Eraser;Mouse;タブレット;スタイラスペン;ペン;消しゴム;マウ"
 "ス;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "新しいショートカット…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "副ボタンのクリックの代替(_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows ソフトウェア"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "トナーの残量が少なくなっています"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "副ボタンのクリックの間隔"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows ソフトウェア"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "プロダクティビティとマルチタスクに関する設定を管理します"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "アクセスポイント"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "追加"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "保存(_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr ""
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8150,104 +4941,13 @@ msgstr ""
 msgid "Device Details"
 msgstr "デバイスの詳細"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "製造元"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "ファームウェアのバージョン"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G のみ"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G のみ"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G のみ"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (優先)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (優先), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (優先), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (優先)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (優先), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (優先)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (優先), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (優先)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (優先), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "不明"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "SIM カードのロック解除"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "ロック解除"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "SIM %d の PIN コードが必要です"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "SIM カードのロックを解除する PIN を入力してください"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "SIM %d の PUK コードが必要です"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "SIM カードのロックを解除する PUK を入力してください"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8260,26 +4960,6 @@ msgstr[0] "違うパスワードを入力しました (残り %1$u 回)"
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "残り %u 回"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "違うパスワードを入力しました。"
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK コードは 8 桁です"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "新しい PIN を入力してください"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN コードは 4-8 桁です"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "ロック解除…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -8337,147 +5017,47 @@ msgstr "PIN で SIM をロックします"
 msgid "M_odem Details"
 msgstr "モデムの詳細(_O)"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "携帯端末に接続していません"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "操作の許可がありません"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "操作をサポートしていません"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM が挿入されていません"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "SIM の PIN が必要です"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "SIM の PUK が必要です"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM がビジーです"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "パスワードが違います"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIM の PIN2 が必要です"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIM の PUK2 が必要です"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "見つかりませんでした"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "ネットワークサービスがありません"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "ネットワークがタイムアウトしました"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS サービスの許可がありません"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "このエリアでのローミングの許可がありません"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "特定できない GPRS エラー"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "原因不明のエラー"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "ネットワークモード"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "設定(_S)"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "閉じる"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "自動(_A)"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "ネットワークを選択"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "ネットワークプロバイダーを更新"
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "モバイルネットワークを有効にする"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "WWAN アダプターが見つかりませんでした"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "ワイヤレス Wan/Cellular デバイスを確認してください"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "機内モードがオンの場合ワイヤレス WAN は使用できません"
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "機内モードをオフにする(_T)"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "データ接続"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "SIM カードをインターネットに使用します"
 
@@ -8489,15 +5069,15 @@ msgstr "SIM ロック"
 msgid "_Next"
 msgstr "次へ(_N)"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "PIN で SIM をロックする(_L)"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "PIN を変更"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr "SIM ロック設定の変更のために現在の PIN を入力してください"
 
@@ -8509,8 +5089,6 @@ msgstr "モバイルネットワーク"
 msgid "Configure Telephony and mobile data connections"
 msgstr "モバイルデータ接続やテレフォニー接続を設定します"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -8525,57 +5103,17 @@ msgstr "GNOME デスクトップの設定ユーティリティ"
 msgid "Settings is the primary interface for configuring your system."
 msgstr "“設定”はシステム設定用のプライマリインターフェースです。"
 
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:17
-msgid "GNOME Settings Sound Panel"
-msgstr "GNOME Settings サウンドパネル"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:21
-msgid "GNOME Settings Mouse &amp; Touchpad Panel"
-msgstr "GNOME Settings マウス &amp; タッチパッドパネル"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:25
-msgid "GNOME Settings Background Panel"
-msgstr "GNOME Settings 背景パネル"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:29
-msgid "GNOME Settings Keyboard Panel"
-msgstr "GNOME Settings キーボードパネル"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:38
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "The GNOME Project"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "バージョン番号を表示する"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "冗長モードを有効にする"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "キーワードで検索する"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "利用可能なパネル名をリスト表示して終了する"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "表示するパネル"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "プライバシー"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "利用可能なパネル:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8632,7 +5170,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "検索をキャンセルする"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;Settings;設定;"
@@ -8666,28 +5203,2589 @@ msgstr "ウィンドウの初期状態"
 msgid ""
 "A tuple containing the initial width, height and maximized state of the "
 "application window."
-msgstr ""
-"アプリケーションの初期幅、初期高さ、最大化状態を含むタプルです。"
+msgstr "アプリケーションの初期幅、初期高さ、最大化状態を含むタプルです。"
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u 出力"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u 入力"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "システムのサウンド"
+#~ msgid "System Bus"
+#~ msgstr "システムバス"
+
+#~ msgid "Full access"
+#~ msgstr "フルアクセス"
+
+#~ msgid "Session Bus"
+#~ msgstr "セッションバス"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "/dev へのフルアクセス"
+
+#~ msgid "Has network access"
+#~ msgstr "ネットワークアクセス"
+
+#~ msgid "Home"
+#~ msgstr "ホーム"
+
+#~ msgid "Read-only"
+#~ msgstr "読み取り専用"
+
+#~ msgid "File System"
+#~ msgstr "ファイルシステム"
+
+#~ msgid "Can change settings"
+#~ msgstr "設定の変更"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s には次の変更できない権限が組み込まれています。これらの権限に問題がある"
+#~ "場合は、このアプリケーションの削除を検討してください。"
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u 種類のファイル/リンクをアプリで開くことができます"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> は次の種類のファイルとリンクを開くのに使用されます。"
+
+#, c-format
+#~ msgid "%s of disk space used"
+#~ msgstr "ディスク容量の %s を使用中"
+
+#~ msgid "Select a picture"
+#~ msgstr "画像を選択"
+
+#~ msgid "_Open"
+#~ msgstr "開く(_O)"
+
+#~ msgid "multiple sizes"
+#~ msgstr "複数のサイズ"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "デスクトップの背景が見つかりません"
+
+#~ msgid "Current background"
+#~ msgstr "現在の背景"
+
+#~ msgid "Light"
+#~ msgstr "明るい"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;画面;スクリーン;ロック;診断;クラッシュ;プライベート;最近;"
+#~ "テンポラリー;一時;インデックス;索引;名前;ネットワーク;Privacy;プライバ"
+#~ "シー;"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "キャリブレーション装置を四角形に合わせて“開始”を押してください"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "キャリブレーション装置を測定位置に移動して“次へ”を押してください"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "キャリブレーション装置を表面の位置に移動して“次へ”を押してください"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "ノート PC を閉じてください"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "回復不能なエラーが発生しました。"
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "キャリブレーションに必要なツールがインストールされていません。"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "プロファイルを生成できません。"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "対象の白色点は取得できません。"
+
+#~ msgid "Complete!"
+#~ msgstr "完了しました!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "キャリブレーションに失敗しました!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "キャリブレーション装置を取り外せます。"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "測定中はキャリブレーション装置に触らないでください"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "ラップトップ画面"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "組み込みのウェブカム"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s モニター"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s スキャナー"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s カメラ"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s プリンター"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s ウェブカム"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s のカラーマネージメントを有効にする"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s のカラープロファイルを表示する"
+
+#~ msgid "Not calibrated"
+#~ msgstr "未較正"
+
+#~ msgid "Default: "
+#~ msgstr "デフォルト: "
+
+# ref. gnome-color-manager
+#~ msgid "Colorspace: "
+#~ msgstr "色空間: "
+
+#~ msgid "Test profile: "
+#~ msgstr "テスト用プロファイル: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC プロファイルを選択"
+
+#~ msgid "_Import"
+#~ msgstr "インポート(_I)"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "サポートする ICC プロファイル"
+
+#~ msgid "All files"
+#~ msgstr "すべてのファイル"
+
+#~ msgid "Save Profile"
+#~ msgstr "プロファイルを保存"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "選択したデバイスのカラープロファイルを作成"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "計測器を検出できません。電源が入っていること、正しく接続されていることを確"
+#~ "認してください。"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "計測器がプリンターのプロファイルをサポートしていません。"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "このデバイスの形式は現在サポートしていません。"
+
+#~ msgid "Standard Space"
+#~ msgstr "標準の色空間"
+
+#~ msgid "Test Profile"
+#~ msgstr "テスト用プロファイル"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "自動"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "低品質"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "中品質"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "高品質"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "デフォルト RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "デフォルト CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "デフォルトグレー"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "ベンダーが提供している工場でのキャリブレーションデータ"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "このプロファイルでは全画面表示での補正はできません"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "このプロファイルはもう正確ではなくなっているかもしれません。"
+
+#~ msgid "Other…"
+#~ msgstr "その他…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "設定を変更する場合はロックを解除してください"
+
+#~ msgid "Today"
+#~ msgstr "今日"
+
+#~ msgid "Yesterday"
+#~ msgstr "昨日"
+
+#~ msgid "%b %e"
+#~ msgstr "%B%-e日"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y年%B%-e日"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d 時間"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d 分"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d 秒"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "ホットスポット"
+
+#~ msgid "24-hour"
+#~ msgstr "24時制"
+
+#~ msgid "AM / PM"
+#~ msgstr "午前/午後"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%Y年%B%-e日 %p %I:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%Y年%B%-e日 %H:%M"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%2$s, %1$s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%p %I:%M"
+
+#~ msgid "%R"
+#~ msgstr "%H:%M"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "技術的な問題に遭遇した場合、問題に関するレポートを送信することで %s の改善"
+#~ "に役立てることができます。レポートは匿名で送信され、個人データは取り除かれ"
+#~ "ます。%s"
+
+#~ msgid "On"
+#~ msgstr "オン"
+
+#~ msgid "Off"
+#~ msgstr "オフ"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "変更を適用しますか?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "変更を適用できません"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "この原因はハードウェアの制限にある可能性があります。"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "ディスプレイの配置"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "横方向"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "縦方向 (右向き)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "縦方向 (左向き)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "横方向 (逆向き)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Unknown"
+#~ msgstr "不明"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 ビット"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 ビット"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "不明"
+
+#~ msgid "System Logo"
+#~ msgstr "システムロゴ"
+
+#~ msgid "No input sources found"
+#~ msgstr "入力ソースが見つかりませんでした"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "その他"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "独自のショートカット"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "代替文字キーを使用すると追加の文字を入力できます。追加の文字はキーボード上"
+#~ "に 3 番目のオプションとして印刷されている場合があります。"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "左 Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "右 Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "左 Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "右 Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "メニューキー"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "右 Ctrl"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "入力ソースはキーボードショートカット (%s) で切り替えることができます。\n"
+#~ "キーはキーボードショートカットの設定で変更可能です。"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d 個変更"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "すべてのショートカットをリセットしますか?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "ショートカットをリセットするとカスタムショートカットが影響を受ける可能性が"
+#~ "あります。この処理を元に戻すことはできません。"
+
+#~ msgid "Reset All"
+#~ msgstr "すべてリセット"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "すでに %s は %s のために使用されています。もし入れ替えなければ %s が無効化"
+#~ "されます。"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "新しいショートカットキーを入力してください"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "独自のショートカットを設定"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "ショートカットを設定"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "%s の新しいショートカットを入力してください。"
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "独自のショートカットを追加"
+
+#~ msgid "Set"
+#~ msgstr "設定"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "画面オフのとき"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 秒"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 分"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 分"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 分"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 分"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 時間"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 分"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 分"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 分"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 分"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 分"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 分"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 分"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 分"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 分"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "しない"
+
+#~ msgid "Lock your screen"
+#~ msgstr "画面をロックします"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "2 本指でのスクロール"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "クリック 5 回、GEGL タイム"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "ダブルクリック、主ボタン"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "シングルクリック、主ボタン"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "ダブルクリック、中央ボタン"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "シングルクリック、中央ボタン"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "ダブルクリック、副ボタン"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "シングルクリック、副ボタン"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager が動作している必要があります。"
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "安全ではないネットワーク (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "安全なネットワーク (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "安全なネットワーク (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "安全なネットワーク (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "安全なネットワーク"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "アクセスポイントをオンにすると %s から切断され、Wi-Fi でのインターネットア"
+#~ "クセスができなくなります。"
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "8 文字以上にしてください"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "アクセスポイントを停止し、ユーザーを切断しますか?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "停止(_S)"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "ここに入力した MAC アドレスは、現在の接続で利用しているネットワークデバイ"
+#~ "スのハードウェアアドレスとして使用されます。この機能は MAC アドレスのク"
+#~ "ローニング、またはスプーフィングとして知られています。例: "
+#~ "00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "プロファイル %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "なし"
+
+#~ msgid "Never"
+#~ msgstr "しない"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "なし"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "弱い"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "OK"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "良い"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "非常に良い"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "接続情報を破棄"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "接続プロファイルを削除"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN を削除"
+
+#~ msgid "Details"
+#~ msgstr "詳細"
+
+#~ msgid "automatic"
+#~ msgstr "自動"
+
+#~ msgid "Identity"
+#~ msgstr "Identity"
+
+#~ msgid "Delete Address"
+#~ msgstr "アドレスを削除"
+
+#~ msgid "Delete Route"
+#~ msgstr "ルートを削除"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "なし"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit キー (HEX または ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit パスフレーズ"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "動的 WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 パーソナル"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "接続エディターを起動できません"
+
+#~ msgid "New Profile"
+#~ msgstr "新しいプロファイル"
+
+#~ msgid "Import from file…"
+#~ msgstr "ファイルからインポート…"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN を追加"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN 接続をインポートできません"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "ファイル“%s”は読み取れなかったか、または処理できる VPN 接続情報がありませ"
+#~ "ん\n"
+#~ "\n"
+#~ "エラー: %s"
+
+#~ msgid "Select file to import"
+#~ msgstr "インポートするファイルを選択"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "ファイル“%s”はすでに存在します。"
+
+#~ msgid "_Replace"
+#~ msgstr "入れ替え(_R)"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "%s を、保存している VPN 接続に入れ替えますか?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN 接続をエクスポートできません"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN 接続“%s”を %s にエクスポートできませんでした。\n"
+#~ "\n"
+#~ "エラー: %s"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN 接続をエクスポート"
+
+#~ msgid "never"
+#~ msgstr "未接続"
+
+#~ msgid "today"
+#~ msgstr "今日"
+
+#~ msgid "yesterday"
+#~ msgstr "昨日"
+
+#~ msgid "Last used"
+#~ msgstr "最後の利用"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "パスワードや独自の設定など、選択したネットワークの詳細は失われます。"
+
+#~ msgid "_Forget"
+#~ msgstr "破棄(_F)"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "既知の Wi-Fi ネットワーク"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "破棄(_F)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr ""
+#~ "システムのポリシーによりホットスポットとしての利用は禁止されています"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "ワイヤレスデバイスがホットスポットモードに対応していません"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "設定ファイルの URL が指定されていない場合 Web Proxy Autodiscovery が使用さ"
+#~ "れます。"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "信頼できない公衆ネットワークでは推奨されません。"
+
+#~ msgid "Status unknown"
+#~ msgstr "ステータス不明"
+
+#~ msgid "Unmanaged"
+#~ msgstr "管理対象外"
+
+#~ msgid "Unavailable"
+#~ msgstr "利用不可"
+
+#~ msgid "Connecting"
+#~ msgstr "接続中"
+
+#~ msgid "Authentication required"
+#~ msgstr "認証が必要です"
+
+#~ msgid "Disconnecting"
+#~ msgstr "切断中"
+
+#~ msgid "Connection failed"
+#~ msgstr "接続失敗"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "ステータス不明 (見つかりません)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "設定に失敗しました"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP 設定に失敗しました"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP 設定の期限切れです"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "秘密の情報が必要でしたが入力されませんでした"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x サプリカントが切断されました"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x サプリカントの設定に失敗しました"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x サプリカントが失敗しました"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x サプリカントの認証に時間がかかりすぎました"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP サービスの起動に失敗しました"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP サービスの接続を切断しました"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP が失敗しました"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP クライアントの起動に失敗しました"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP クライアントにエラーが発生しました"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP クライアントが失敗しました"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "共有接続サービスの起動に失敗しました"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "共有接続サービスが失敗しました"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP サービスの起動に失敗しました"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP サービスにエラーが発生しました"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP サービスが失敗しました"
+
+#~ msgid "Line busy"
+#~ msgstr "回線が使用中です"
+
+#~ msgid "No dial tone"
+#~ msgstr "発信音がありません"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "キャリアの確立ができませんでした"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "発信要求がタイムアウトしました"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "発信の試行に失敗しました"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "モデムの初期化に失敗しました"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "指定された APN の選択に失敗しました"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "ネットワーク検索をしていません"
+
+#~ msgid "Network registration denied"
+#~ msgstr "ネットワーク登録が拒否されました"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "ネットワーク登録がタイムアウトしました"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "要求されたネットワークへの登録に失敗しました"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN チェックに失敗しました"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "このデバイスのファームウェアがないようです"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "接続が消失しました"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "既存の接続とみなされました"
+
+#~ msgid "Modem not found"
+#~ msgstr "モデムが見つかりませんでした"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth 接続に失敗しました"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM カードが挿入されていません"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM の PIN 番号が必要です"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM の PUK が必要です"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM が違います"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "接続が依存するデバイスなどの準備ができません"
+
+#~ msgid "Firmware missing"
+#~ msgstr "ファームウェア未検出"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "ケーブル非接続"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "802.1X セキュリティ (wpa-eap) で未定義のエラーが発生しました"
+
+#~ msgid "no file selected"
+#~ msgstr "ファイルが選択されていません"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "EAP メソッドファイルの検証中に特定できないエラーが発生しました"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "DER, PEM, PKCS#12 の秘密鍵 (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER か PEM の証明書 (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "EAP-FAST PAC ファイルがありません"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ファイル (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "EAP-LEAP ユーザー名がありません"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "EAP-LEAP パスワードがありません"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "無効な EAP-PEAP CA 証明書: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "無効な EAP-PEAP CA 証明書: 認証書が指定されていません"
+
+#~ msgid "missing EAP username"
+#~ msgstr "EAP ユーザー名がありません"
+
+#~ msgid "missing EAP password"
+#~ msgstr "EAP パスワードがありません"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "EAP-TLS Identity がありません"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "無効な EAP-TLS CA 証明書: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "無効な EAP-TLS CA 証明書: 認証書が指定されていません"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "無効な EAP-TLS 秘密鍵: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "無効な EAP-TLS ユーザー証明書: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "暗号化されていない秘密鍵は安全ではありません"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "選択した秘密鍵はパスワードで保護されていないようです。この状態は信用情報の"
+#~ "侵害を許してしまいます。パスワード保護のある秘密鍵を選択してください。\n"
+#~ "\n"
+#~ "(秘密鍵は openssl を使用してパスワード保護ができます)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "個人用証明書を選択する"
+
+#~ msgid "Choose your private key"
+#~ msgstr "秘密鍵を選択する"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "無効な EAP-TTLS CA 証明書: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "無効な EAP-TTLS CA 証明書: 証明書が指定されていません"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "802.1X セキュリティの検証中に不明なエラーが発生しました"
+
+#~ msgid "Select a file"
+#~ msgstr "ファイルを選択"
+
+#~ msgid "missing leap-username"
+#~ msgstr "LEAP ユーザー名がありません"
+
+#~ msgid "missing leap-password"
+#~ msgstr "LEAP パスワードがありません"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Wi-Fi パスワードがありません。"
+
+#~ msgid "missing wep-key"
+#~ msgstr "WEP キーがありません"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "無効な WEP キー: キーの長さが %zu 文字の場合、16 進数字以外は使用できませ"
+#~ "ん"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "無効な WEP キー: キーの長さが %zu 文字の場合、アスキー文字以外は使用できま"
+#~ "せん"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "無効な WEP キー: キーの長さ %zu は使用できません。WEP キーは長さ 5 文字か "
+#~ "13 文字のアスキー文字、または 10 文字か 26 文字の 16 進数字のどちらかでな"
+#~ "ければなりません"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "無効な WEP キー: パスフレーズには必ず何か入力してください"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "無効な WEP キー: パスフレーズは 64 文字未満でなければなりません"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "無効な WPA PSK: キーの長さ %zu は無効です。8 〜 63 文字、または 16 進数表"
+#~ "記で 64 文字でなければなりません"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "無効な WPA PSK: キーが 64 文字の場合、16 進数字以外は使用できません"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s を削除しました"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "その他"
+
+#~ msgid "Error removing account"
+#~ msgstr "アカウントの削除に失敗しました"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s アカウント"
+
+#~ msgid "Remove Account"
+#~ msgstr "アカウントを削除"
+
+#~ msgid "Unknown time"
+#~ msgstr "残り時間は不明"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "フル充電まで %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "注意: 残り %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "残り %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "フル充電"
+
+#~ msgid "Not charging"
+#~ msgstr "充電していません"
+
+#~ msgid "Empty"
+#~ msgstr "空"
+
+#~ msgid "Charging"
+#~ msgstr "充電中"
+
+#~ msgid "Discharging"
+#~ msgstr "放電中"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "ワイヤレスマウス"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "ワイヤレスキーボード"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "無停電電源装置"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "携帯情報端末"
+
+#~ msgid "Cellphone"
+#~ msgstr "携帯電話"
+
+#~ msgid "Media player"
+#~ msgstr "音楽プレーヤー"
+
+#~ msgid "Tablet"
+#~ msgstr "タブレット"
+
+#~ msgid "Computer"
+#~ msgstr "コンピューター"
+
+#~ msgid "Gaming input device"
+#~ msgstr "ゲーム用入力デバイス"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "主"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "予備"
+
+#~ msgid "Batteries"
+#~ msgstr "バッテリー"
+
+#~ msgid "When _idle"
+#~ msgstr "アイドル時(_I)"
+
+#~ msgid "Suspend"
+#~ msgstr "サスペンド"
+
+#~ msgid "Power Off"
+#~ msgstr "電源オフ"
+
+#~ msgid "Hibernate"
+#~ msgstr "ハイバネート"
+
+#~ msgid "Nothing"
+#~ msgstr "なにもしない"
+
+#~ msgid "When on battery power"
+#~ msgstr "バッテリー動作時"
+
+#~ msgid "When plugged in"
+#~ msgstr "電源接続時"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "しない"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "自動サスペンド"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "動作温度が高いためパフォーマンスモードが一時的に無効になりました。"
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "パフォーマンスモードが一時的に無効になりました。"
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "バッテリー低下: 省電力が有効になりました。バッテリーが十分に充電されると以"
+#~ "前のモードに戻ります。"
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "“%s”によって省電力モードがアクティブになります。"
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "“%s”によってパフォーマンスモードがアクティブになります。"
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "パフォーマンス"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "高いパフォーマンスと消費電力です。"
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "バランス"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "標準的なパフォーマンスと消費電力です。"
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "省電力"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "パフォーマンスと消費電力を抑えます。"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "プリンター“%s”を削除しました"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "新しいプリンターを追加できませんでした。"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui ファイルを読み込めませんでした: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "設定の変更やプリンターを追加する場合はロックを解除してください"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s の詳細"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "適切なドライバーが見つかりませんでした"
+
+#~ msgid "Select PPD File"
+#~ msgstr "PPD ファイルを選択"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript Printer Description ファイル(*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+#~ "*.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect プリンター"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD プリンター"
+
+#~ msgid "One Sided"
+#~ msgstr "片面"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "長辺とじ (標準)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "短辺とじ (フリップ)"
+
+#~ msgid "Portrait"
+#~ msgstr "縦方向"
+
+#~ msgid "Landscape"
+#~ msgstr "横方向"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "横方向 (逆向き)"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "縦方向 (逆向き)"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "待機中"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "一時停止"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "認証が必要です"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "印刷中"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "停止"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "キャンセル"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "中止"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "完了"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "このジョブをキューの先頭へ移動する"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — アクティブなジョブ"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "%s から印刷するにはユーザー名とパスワードを入力してください。"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "プリンターサーバーのロック解除"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s のロック解除"
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "%s で利用可能なプリンターを表示するにはユーザー名とパスワードを入力してく"
+#~ "ださい。"
+
+#~ msgid "Searching for Printers"
+#~ msgstr "プリンターの検索"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "シリアルポート"
+
+#~ msgid "Parallel Port"
+#~ msgstr "パラレルポート"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "場所: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "アドレス: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "サーバーが認証を要求しています"
+
+#~ msgid "Two Sided"
+#~ msgstr "両面"
+
+#~ msgid "Paper Type"
+#~ msgstr "用紙の種類"
+
+#~ msgid "Paper Source"
+#~ msgstr "給紙元"
+
+#~ msgid "Output Tray"
+#~ msgstr "出力トレイ"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "解像度"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript のプレフィルタリング"
+
+#~ msgid "Pages per side"
+#~ msgstr "片面のページ数"
+
+#~ msgid "Orientation"
+#~ msgstr "向き"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "汎用"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "ページ設定"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "インストール可能なオプション"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "ジョブ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "画質"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "色"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "表面処理"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "高度"
+
+#~ msgid "Test page"
+#~ msgstr "テストページ"
+
+#~ msgid "Auto Select"
+#~ msgstr "自動選択"
+
+#~ msgid "Printer Default"
+#~ msgstr "プリンターのデフォルト"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "内蔵 GhostScript フォントのみ"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS レベル 1 に変換"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS レベル 2 に変換"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "プレフィルタリングなし"
+
+#~ msgid "Clean print heads"
+#~ msgstr "ヘッドクリーニング"
+
+#~ msgid "Out of toner"
+#~ msgstr "トナーが空です"
+
+#~ msgid "Low on developer"
+#~ msgstr "現像液が少なくなっています"
+
+#~ msgid "Out of developer"
+#~ msgstr "現像液が空です"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "インクが少なくなっています"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "インクが切れています"
+
+#~ msgid "Open cover"
+#~ msgstr "カバーが開いています"
+
+#~ msgid "Open door"
+#~ msgstr "扉が開いています"
+
+#~ msgid "Low on paper"
+#~ msgstr "紙が少なくなっています"
+
+#~ msgid "Out of paper"
+#~ msgstr "紙が空です"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "オフライン"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "停止中"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "廃インクタンクがもう少しでいっぱいです"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "廃インクタンクがいっぱいです"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "感光体の寿命が近づいています"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "感光体の寿命です"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "準備完了"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "ジョブ受付不可"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "処理中"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ヤード・ポンド法"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "メートル法"
+
+#~ msgid "Ask what to do"
+#~ msgstr "どうするか確認する"
+
+#~ msgid "Do nothing"
+#~ msgstr "なにもしない"
+
+#~ msgid "Open folder"
+#~ msgstr "フォルダーを開く"
+
+#~ msgid "Other Media"
+#~ msgstr "他のメディア"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "オーディオ CD 用のアプリケーションを選択"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "ビデオ DVD 用のアプリケーションを選択"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "音楽プレーヤーが接続されたときに起動するアプリケーションを選択"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "カメラが接続されたときに起動するアプリケーションを選択"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "ソフトウェアの CD を開くアプリケーションを選択"
+
+#~ msgid "audio DVD"
+#~ msgstr "オーディオ DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "空のブルーレイディスク"
+
+#~ msgid "blank CD disc"
+#~ msgstr "空の CD"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "空の DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "空の HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "ブルーレイビデオディスク"
+
+#~ msgid "e-book reader"
+#~ msgstr "電子書籍リーダー"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD ビデオディスク"
+
+#~ msgid "Picture CD"
+#~ msgstr "ピクチャー CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "スーパービデオ CD"
+
+#~ msgid "Video CD"
+#~ msgstr "ビデオ CD"
+
+#~ msgid "Select Location"
+#~ msgstr "場所を選択"
+
+#~ msgid "_OK"
+#~ msgstr "OK(_O)"
+
+#~ msgid "No applications found"
+#~ msgstr "アプリケーションが見つかりませんでした"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "共有するネットワークを選択していません"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "オン"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "オフ"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "有効"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "フォルダーを選択"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "ファイル共有を使用して、現在のネットワークの他ユーザーが次の URI に接続"
+#~ "し、あなたの公開フォルダーを共有できるようにします: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "リモートログインを有効にした場合、リモートユーザーによる Secure Shell コマ"
+#~ "ンドを使用した接続を許可します:\n"
+#~ "%s"
+
+#~ msgid "Custom"
+#~ msgstr "その他"
+
+#~ msgid "Bark"
+#~ msgstr "犬が吠える音"
+
+#~ msgid "Drip"
+#~ msgstr "水が滴る音"
+
+#~ msgid "Glass"
+#~ msgstr "ガラスを叩く音"
+
+#~ msgid "Sonar"
+#~ msgstr "ソナーのピング音"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s のテスト中"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "切断"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "接続中"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "接続"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "認証エラー"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "認証中"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "接続 & 認証"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "不明"
+
+#~ msgid "Authorized at:"
+#~ msgstr "認証日時:"
+
+#~ msgid "Connected at:"
+#~ msgstr "接続日時:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "登録日時:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "デバイスの認証に失敗しました: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "デバイスの削除に失敗しました: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "エラー"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "認証"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt サブシステム (boltd) がインストールされていないか、正しくセッ"
+#~ "トアップされていません。"
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "USB デバイスと DisplayPort デバイスのみ接続できます。"
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt を検出できませんでした。\n"
+#~ "システムが Thunderbolt に対応していないか、または BIOS で Thunderbolt が無"
+#~ "効になっているか、もしくは BIOS で Thunderbolt のセキュリティレベルが対応"
+#~ "していない設定になっているかのいずれかです。"
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt サポートは BIOS で無効化されています。"
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Thunderbolt のセキュリティレベルを確認できませんでした。"
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "ダイレクトモードの切り替え中にエラーが発生しました: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "デフォルト"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "中"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "大"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "特大"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "最大"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d ピクセル"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "短い"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "画面の¼"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "画面の½"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "画面の¾"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "長い"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 時間"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 日"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 日"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 日"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 日"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 日"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 日"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 日"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 日"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 日"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "ゴミ箱からすべてのアイテムを削除しますか?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "ここでアイテムを削除すると元に戻すことはできません。"
+
+#~ msgid "_Empty Trash"
+#~ msgstr "ゴミ箱を空にする(_E)"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "一時ファイルをすべて削除しますか?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "一時ファイルは完全に削除されます。"
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "一時ファイルを削除する(_P)"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 日"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 日"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 日"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "無期限"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "ログイン提供者のウェブアドレスと一致させる必要があります。"
+
+#~ msgid "Failed to add account"
+#~ msgstr "アカウントの追加に失敗しました"
+
+#~ msgid "Failed to register account"
+#~ msgstr "アカウントの登録に失敗しました"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "このドメインで認証を行う方法はサポートしていません"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "ドメインの参加に失敗しました"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ログイン名に問題がありました。\n"
+#~ "やり直してください。"
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "パスワードに問題がありました。\n"
+#~ "やり直してください。"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "ドメインへのログインに失敗しました"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "ドメインを見つけられません。スペルミスがないか確認してください。"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "他の画像を参照"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "指紋リーダーとの通信に失敗しました"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "指紋認証デーモンとの通信に失敗しました"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "指紋情報の一覧を表示できませんでした: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "保存された指紋情報の削除に失敗しました: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "左の親指"
+
+#~ msgid "Left middle finger"
+#~ msgstr "左の中指"
+
+#~ msgid "_Left index finger"
+#~ msgstr "左の人差し指(_L)"
+
+#~ msgid "Left ring finger"
+#~ msgstr "左の薬指"
+
+#~ msgid "Left little finger"
+#~ msgstr "左の小指"
+
+#~ msgid "Right thumb"
+#~ msgstr "右の親指"
+
+#~ msgid "Right middle finger"
+#~ msgstr "右の中指"
+
+#~ msgid "_Right index finger"
+#~ msgstr "右の人差し指(_R)"
+
+#~ msgid "Right ring finger"
+#~ msgstr "右の薬指"
+
+#~ msgid "Right little finger"
+#~ msgstr "右の小指"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "不明な指です"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "完了"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "指紋認証デバイスが切断されました"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "指紋認証デバイスの登録数が上限に達しています"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "新しい指紋の登録に失敗しました"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "登録を開始できませんでした: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "新しい指紋の登録に失敗しました"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "登録を停止できませんでした: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr "指紋リーダーに指を何度か押し付けて指紋を登録してください"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "この指を再登録(_R)…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "新しい指紋の採取"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "デバイスの読み取りに問題があります"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "指紋認証デバイスの取得に失敗しました: %s"
+
+#~ msgid "This Week"
+#~ msgstr "今週"
+
+#~ msgid "Last Week"
+#~ msgstr "先週"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%B%-e日"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y年%B%-e日"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+# %k:%M よりも %H:%M の方がガタガタしていなくて見やすい (sicklylife)
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%H:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "セッション終了"
+
+#~ msgid "Session Started"
+#~ msgstr "セッション開始"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — アカウントのアクティビティ"
+
+#~ msgid "Please choose another password."
+#~ msgstr "他のパスワードを選択してください。"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "現在のパスワードを再度入力してください。"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "パスワードを変更できません"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "このタイプのドメインは自動で参加できません"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "そのようなドメインやレルムは見つかりませんでした"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%2$s ドメインに %1$s としてログインできません"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "不正なパスワードです、やり直してください"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "%s ドメインに接続できませんでした: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ユーザーの削除に失敗しました"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "リモート管理ユーザーの削除に失敗しました"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "自分自身のアカウントは削除できません。"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s はまだログインしています"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "ログイン中のユーザーを削除すると、システムが不整合な状態になることがありま"
+#~ "す。"
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "%s のファイルを残しますか?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ユーザーアカウントを削除するときに、ユーザーのホームディレクトリ、メールス"
+#~ "プールおよび一時ファイルを残しておくことができます。"
+
+#~ msgid "_Delete Files"
+#~ msgstr "ファイルを削除(_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "ファイルを残す(_K)"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "本当にリモート管理の %s のアカウントを削除しますか?"
+
+#~ msgid "_Delete"
+#~ msgstr "削除(_D)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "無効アカウント"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "次回ログイン時に設定"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "なし"
+
+#~ msgid "Logged in"
+#~ msgstr "ログイン中"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "アカウントサービスの接続に失敗しました"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "AccountService がインストールされ、有効になっているか確認してください。"
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "この設定を変更するにはパネルのロックを解除する必要があります"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "選択したユーザーアカウントを削除します"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "選択したユーザーアカウントを削除するには、\n"
+#~ "まず * アイコンをクリックしてください"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "設定の変更やユーザーを追加する場合はロックを解除してください"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr ""
+#~ "新しいパスワードは、現在のパスワードとは異なるものを指定する必要がありま"
+#~ "す。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "いくつかの文字や数字を変更してください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr ""
+#~ "新しいパスワードが現在のものと似すぎています。もう少し異なるものを使用して"
+#~ "ください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "パスワードからユーザー名を取り除くともっと強くなるでしょう。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "パスワード中にユーザーの氏名を使うのは避けるようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "パスワードにある一部の単語を使わないようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "一般的な単語は避けるようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "既存の単語の文字を並べ替えたものは使わないようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "数字をもっと使うようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "大文字をもっと使うようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "小文字をもっと使うようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "記号など特殊文字をもっと使うようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "アルファベット、数字、記号を混在させるようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "同じ文字を連続して使わないようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "同じ種類の文字の繰り返しは避けるようにしてください。アルファベット、数字、"
+#~ "記号を混ぜてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 や abcd などの連続した並びは避けるようにしてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "パスワードが短すぎます。アルファベット、数字、記号をもっと追加するようにし"
+#~ "てください。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "大文字、小文字を混在させ、さらに数字を 1 つか 2 つ含めてください。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "さらに文字や数字、記号を追加すると、もっと強くなります。"
+
+#~ msgid "Authentication failed"
+#~ msgstr "認証に失敗しました"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "新しいパスワードは短すぎます"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "新しいパスワードは単純すぎます"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "新旧 2 つのパスワードが似すぎています"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "新しいパスワードは最近使用したものです。"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "新しいパスワードには数字または特殊文字を含めてください"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "新旧のパスワードが同一です"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "最初に認証を行った以降にパスワードが変更されています!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "新しいパスワードには十分な種類の文字が含まれていません"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "原因不明のエラー"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "ユーザー名には小文字の“a”から“z”、数字の“0”から“9”、記号の“-”と“_”のみを使"
+#~ "用してください。"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "申し訳ありませんが、そのユーザー名は使用できません。他の名前を試してくださ"
+#~ "い。"
+
+#~ msgid "The username is too long."
+#~ msgstr "ユーザー名が長すぎます。"
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "ボタン %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "アプリケーション定義"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "キー入力の送信"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "モニターの切り替え"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "オンスクリーンヘルプの表示"
+
+#~ msgid "All Displays"
+#~ msgstr "すべてのディスプレイ"
+
+#~ msgid "New shortcut…"
+#~ msgstr "新しいショートカット…"
+
+#~ msgid "2G Only"
+#~ msgstr "2G のみ"
+
+#~ msgid "3G Only"
+#~ msgstr "3G のみ"
+
+#~ msgid "4G Only"
+#~ msgstr "4G のみ"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (優先)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (優先), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (優先), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (優先)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (優先), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (優先)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (優先), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (優先)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (優先), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "不明"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "SIM カードのロック解除"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "SIM %d の PIN コードが必要です"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "SIM カードのロックを解除する PIN を入力してください"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "SIM %d の PUK コードが必要です"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "SIM カードのロックを解除する PUK を入力してください"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "違うパスワードを入力しました。"
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK コードは 8 桁です"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "新しい PIN を入力してください"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN コードは 4-8 桁です"
+
+#~ msgid "No connection to phone"
+#~ msgstr "携帯端末に接続していません"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "操作の許可がありません"
+
+#~ msgid "Operation not supported"
+#~ msgstr "操作をサポートしていません"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM が挿入されていません"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM の PIN が必要です"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM の PUK が必要です"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM がビジーです"
+
+#~ msgid "Incorrect password"
+#~ msgstr "パスワードが違います"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM の PIN2 が必要です"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM の PUK2 が必要です"
+
+#~ msgid "Not found"
+#~ msgstr "見つかりませんでした"
+
+#~ msgid "No network service"
+#~ msgstr "ネットワークサービスがありません"
+
+#~ msgid "Network timeout"
+#~ msgstr "ネットワークがタイムアウトしました"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS サービスの許可がありません"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "このエリアでのローミングの許可がありません"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "特定できない GPRS エラー"
+
+#~ msgid "Unknown Error"
+#~ msgstr "原因不明のエラー"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "GNOME Settings サウンドパネル"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "GNOME Settings マウス &amp; タッチパッドパネル"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "GNOME Settings 背景パネル"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "GNOME Settings キーボードパネル"
+
+#~ msgid "Display version number"
+#~ msgstr "バージョン番号を表示する"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "冗長モードを有効にする"
+
+#~ msgid "Search for the string"
+#~ msgstr "キーワードで検索する"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "利用可能なパネル名をリスト表示して終了する"
+
+#~ msgid "Panel to display"
+#~ msgstr "表示するパネル"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "利用可能なパネル:"
+
+#~ msgid "System Sounds"
+#~ msgstr "システムのサウンド"
 
 #~ msgid "Web Links"
 #~ msgstr "ウェブリンク"
@@ -8743,8 +7841,8 @@ msgstr "システムのサウンド"
 #~ msgstr "変更できません"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "アプリケーションごとの権限設定は<a href=\"privacy\">プライバシー</a>設定に"
 #~ "もあります。"
@@ -8837,9 +7935,6 @@ msgstr "システムのサウンド"
 
 #~ msgid "Less Warm"
 #~ msgstr "薄い暖色"
-
-#~ msgid "Screenshots"
-#~ msgstr "スクリーンショット"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "スクリーンショットを$PICTURESフォルダーに保存する"
@@ -8936,18 +8031,12 @@ msgstr "システムのサウンド"
 #~ "スクリーン共有を許可した場合、リモートユーザーは次の URI に接続して画面の"
 #~ "表示や操作を行うことができます: %s"
 
-#~ msgid "Copy"
-#~ msgstr "コピー"
-
 #~ msgid "_Screen Sharing"
 #~ msgstr "画面共有(_S)"
 
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr ""
 #~ "ネットワークに接続していないため無効になっているサービスがあります。"
-
-#~ msgid "Screen Sharing"
-#~ msgstr "画面共有"
 
 #~ msgid "_Allow connections to control the screen"
 #~ msgstr "このスクリーンを操作する接続を許可する(_A)"
@@ -8980,9 +8069,6 @@ msgstr "システムのサウンド"
 
 #~ msgid "_Screen Reader"
 #~ msgstr "スクリーンリーダー(_S)"
-
-#~ msgid "_Full Name"
-#~ msgstr "フルネーム(_F)"
 
 #~ msgid "Standard"
 #~ msgstr "標準"
@@ -9059,9 +8145,6 @@ msgstr "システムのサウンド"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "タブレット(絶対座標)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "タッチパッド(相対座標)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "タブレット設定"
 
@@ -9093,30 +8176,12 @@ msgstr "システムのサウンド"
 #~ msgid "Adjust display resolution"
 #~ msgstr "ディスプレイの解像度を調整"
 
-#~ msgid "Default"
-#~ msgstr "デフォルト"
-
-#~ msgid "Middle Mouse Button Click"
-#~ msgstr "マウスの中ボタンクリック"
-
-#~ msgid "Right Mouse Button Click"
-#~ msgstr "マウスの右ボタンクリック"
-
-#~ msgid "Forward"
-#~ msgstr "進む"
-
 #~ msgid "No stylus found"
 #~ msgstr "スタイラスペンが見つかりません"
 
 #~ msgid ""
 #~ "Please move your stylus to the proximity of the tablet to configure it"
 #~ msgstr "スタイラスペンをタブレットの近くに移動して設定を行ってください"
-
-#~ msgid "Soft"
-#~ msgstr "柔らかい"
-
-#~ msgid "Firm"
-#~ msgstr "硬い"
 
 #~ msgid "Top Button"
 #~ msgstr "上のサイドスイッチ"
@@ -9306,9 +8371,6 @@ msgstr "システムのサウンド"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Bluetooth ハードウェアへの直接アクセス"
-
-#~ msgid "Use your camera"
-#~ msgstr "カメラの使用"
 
 #~ msgid "Print documents"
 #~ msgstr "ドキュメントの印刷"
@@ -9705,9 +8767,6 @@ msgstr "システムのサウンド"
 
 #~ msgid "_Arrange Combined Displays"
 #~ msgstr "ディスプレイの配置を調整(_A)"
-
-#~ msgid "_Method"
-#~ msgstr "メソッド(_M)"
 
 #~ msgid "_Use as Hotspot…"
 #~ msgstr "アクセスポイントとして使用(_U)…"

--- a/po/ja.po~
+++ b/po/ja.po~
@@ -1,0 +1,9839 @@
+# gnome-control-center ja.po.
+# Copyright (C) 1998-2001, 2003-2022 Free Software Foundation, Inc.
+# Yukihiro Nakai <Nakai@abricot.co.jp>, 1998.
+# Eiichiro ITANI <emu@ceres.dti.ne.jp>, 1999.
+# Takayuki KUSANO <AE5T-KSN@asahi-net.or.jp>, 2000, 2009, 2010-2013.
+# Akira TAGOH <tagoh@gnome.gr.jp>, 2001.
+# KAMAGASAKO Masatoshi <emerald@gnome.gr.jp>, 2003.
+# Takeshi AIHANA <takeshi.aihana@gmail.com>, 2003-2008.
+# Satoru SATOH <ss@gnome.gr.jp>, 2006.
+# Hiyoko Torisaki <torisaki.hiyoko@gmail.com>, 2009.
+# Hideki Yamane (Debian-JP) <henrich@debian.or.jp>, 2009.
+# Shushi Kurose <md81bird@hitaki.net>, 2009-2012, 2014, 2016.
+# Yasumichi Akahoshi <yasumichi@vinelinux.org>, 2010.
+# Jiro Matsuzawa <jmatsuzawa@gnome.org>, 2010-2017.
+# GEN SAKASHITA <Unknown>, 2011.
+# Takashi Sakamoto <Unknown>, 2011.
+# Kiyotaka NISHIBORI <ml.nishibori.kiyotaka@gmail.com>, 2011.
+# Hideki Yamnane <henrich@debian.org>, 2011.
+# Noriko Mizumoto <noriko@fedoraproject.org>, 2012.
+# Koichi Akabe <vbkaisetsu@debian.or.jp>, 2012.
+# Kentaro KAZUHAMA <kazken3@gmail.com>, 2012, 2018, 2020.
+# Ikuya Awashiro <ikuya@fruitsbasket.info>, 2014, 2017.
+# Hajime Taira <htaira@redhat.com>, 2015-2018.
+# TakashiUshikoshi <adoredirectg59@gmail.com>, 2016.
+# Shinichirou Yamada <yamada_strong_yamada_nice_64bit@yahoo.co.jp>, 2017-2018.
+# Kenichi Ito <ken.i54k@gmail.com>, 2018.
+# sicklylife <translation@sicklylife.jp>, 2019-2020, 2022.
+# sujiniku <sujinikusityuu@gmail.com>, 2021.
+# 小山田 純 <oyamadajun@outlook.jp>, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-03-10 12:54+0000\n"
+"PO-Revision-Date: 2022-03-16 20:30+0900\n"
+"Last-Translator: sicklylife <translation@sicklylife.jp>\n"
+"Language-Team: Japanese <gnome-translation@gnome.gr.jp>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: panels/applications/cc-applications-panel.c:803
+msgid "System Bus"
+msgstr "システムバス"
+
+#: panels/applications/cc-applications-panel.c:803
+#: panels/applications/cc-applications-panel.c:805
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:823
+msgid "Full access"
+msgstr "フルアクセス"
+
+#: panels/applications/cc-applications-panel.c:805
+msgid "Session Bus"
+msgstr "セッションバス"
+
+#: panels/applications/cc-applications-panel.c:809
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
+#: panels/thunderbolt/cc-bolt-panel.ui:310
+msgid "Devices"
+msgstr "デバイス"
+
+#: panels/applications/cc-applications-panel.c:809
+msgid "Full access to /dev"
+msgstr "/dev へのフルアクセス"
+
+#: panels/applications/cc-applications-panel.c:813
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "ネットワーク"
+
+#: panels/applications/cc-applications-panel.c:813
+msgid "Has network access"
+msgstr "ネットワークアクセス"
+
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:820
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "ホーム"
+
+#: panels/applications/cc-applications-panel.c:820
+#: panels/applications/cc-applications-panel.c:825
+msgid "Read-only"
+msgstr "読み取り専用"
+
+#: panels/applications/cc-applications-panel.c:823
+#: panels/applications/cc-applications-panel.c:825
+msgid "File System"
+msgstr "ファイルシステム"
+
+#: panels/applications/cc-applications-panel.c:829
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:878 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "設定"
+
+#: panels/applications/cc-applications-panel.c:829
+msgid "Can change settings"
+msgstr "設定の変更"
+
+#: panels/applications/cc-applications-panel.c:831
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s には次の変更できない権限が組み込まれています。これらの権限に問題がある場合"
+"は、このアプリケーションの削除を検討してください。"
+
+#: panels/applications/cc-applications-panel.c:1164
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u 種類のファイル/リンクをアプリで開くことができます"
+
+#: panels/applications/cc-applications-panel.c:1171
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> は次の種類のファイルとリンクを開くのに使用されます。"
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1223
+#, c-format
+msgid "%s of disk space used"
+msgstr "ディスク容量の %s を使用中"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1387
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "アプリケーション"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "アプリケーションがありません"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "インストール…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "開く"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "詳細を表示"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "検索"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "システム検索を受け取り、検索結果を送ります。"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/applications/cc-applications-panel.ui:177
+#: panels/applications/cc-applications-panel.ui:191
+#: panels/applications/cc-applications-panel.ui:205
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
+#: panels/user-accounts/cc-user-panel.c:789
+#: panels/user-accounts/cc-user-panel.c:879
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1900
+msgid "Disabled"
+msgstr "無効"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "通知"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "システムの通知を表示します。"
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in background"
+msgstr "バックグラウンドで実行"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "アプリを閉じても実行し続けることを許可します。"
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Change Wallpaper"
+msgstr "壁紙を変更"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Change the desktop wallpaper."
+msgstr "デスクトップの壁紙を変更します。"
+
+#: panels/applications/cc-applications-panel.ui:147
+#: panels/applications/cc-applications-panel.ui:154
+msgid "Sounds"
+msgstr "サウンド"
+
+#: panels/applications/cc-applications-panel.ui:148
+#: panels/applications/cc-applications-panel.ui:155
+msgid "Reproduce sounds."
+msgstr "音を再生します。"
+
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Inhibit Shortcuts"
+msgstr "ショートカットを抑制"
+
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Block standard keyboard shortcuts."
+msgstr "標準のキーボードショートカットをブロックします。"
+
+#: panels/applications/cc-applications-panel.ui:168
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "カメラ"
+
+#: panels/applications/cc-applications-panel.ui:169
+#: panels/applications/cc-applications-panel.ui:176
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "マイク"
+
+#: panels/applications/cc-applications-panel.ui:183
+#: panels/applications/cc-applications-panel.ui:190
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "位置情報サービス"
+
+#: panels/applications/cc-applications-panel.ui:197
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Access device location data."
+msgstr "デバイスの位置データにアクセスします。"
+
+#: panels/applications/cc-applications-panel.ui:215
+#: panels/applications/cc-applications-panel.ui:319
+msgid "Built-in Permissions"
+msgstr "組み込みの権限"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System access that is required by the app"
+msgstr "アプリが要求しているシステムアクセス"
+
+#: panels/applications/cc-applications-panel.ui:224
+msgid "File &amp; Link Associations"
+msgstr "ファイルとリンクの関連付け"
+
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:399
+msgid "Storage"
+msgstr "ストレージ"
+
+#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+msgid "No results found"
+msgstr "結果がありません"
+
+#: panels/applications/cc-applications-panel.ui:304
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
+#: shell/cc-panel-list.ui:114
+msgid "Try a different search"
+msgstr "他のキーワードを試してください"
+
+#: panels/applications/cc-applications-panel.ui:344
+msgid "File & Link Associations"
+msgstr "ファイルとリンクの関連付け"
+
+#: panels/applications/cc-applications-panel.ui:367
+msgid "File Types"
+msgstr "ファイルの種類"
+
+#: panels/applications/cc-applications-panel.ui:373
+msgid "Link Types"
+msgstr "リンクの種類"
+
+#: panels/applications/cc-applications-panel.ui:383
+msgid "Reset"
+msgstr "リセット"
+
+#: panels/applications/cc-applications-panel.ui:410
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"このアプリケーションがデータとキャッシュで占有しているディスク容量です。"
+
+#: panels/applications/cc-applications-panel.ui:413
+msgid "Application"
+msgstr "アプリケーション"
+
+#: panels/applications/cc-applications-panel.ui:419
+msgid "Data"
+msgstr "データ"
+
+#: panels/applications/cc-applications-panel.ui:425
+msgid "Cache"
+msgstr "キャッシュ"
+
+#: panels/applications/cc-applications-panel.ui:431
+msgid "<b>Total</b>"
+msgstr "<b>合計</b>"
+
+#: panels/applications/cc-applications-panel.ui:441
+msgid "Clear Cache…"
+msgstr "キャッシュを消去…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "アプリケーションの権限や設定を変更します"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"application;flatpak;permission;setting;アプリケーション;パーミッション;許可;"
+"権限;設定;snap;"
+
+#: panels/background/cc-background-chooser.c:307
+msgid "Select a picture"
+msgstr "画像を選択"
+
+#: panels/background/cc-background-chooser.c:310
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:198
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/network/cc-wifi-hotspot-dialog.ui:123
+#: panels/network/cc-wifi-panel.c:881
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:226
+#: panels/network/connection-editor/vpn-helpers.c:346
+#: panels/network/net-device-wifi.c:860
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:263
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:18
+#: panels/user-accounts/cc-user-panel.c:579
+#: panels/user-accounts/cc-user-panel.c:597
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:139
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
+msgid "_Cancel"
+msgstr "キャンセル(_C)"
+
+#: panels/background/cc-background-chooser.c:311
+#: panels/network/connection-editor/vpn-helpers.c:227
+#: panels/printers/pp-details-dialog.c:264
+#: panels/sharing/cc-sharing-panel.c:524
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "開く(_O)"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "複数のサイズ"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "デスクトップの背景が見つかりません"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "現在の背景"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "スタイル"
+
+#: panels/background/cc-background-panel.ui:45
+msgid "Light"
+msgstr "明るい"
+
+#: panels/background/cc-background-panel.ui:72
+msgid "Dark"
+msgstr "暗い"
+
+#: panels/background/cc-background-panel.ui:91
+msgid "Background"
+msgstr "背景"
+
+#: panels/background/cc-background-panel.ui:97
+msgid "Add Picture…"
+msgstr "画像を追加…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "外観"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "背景画像や UI の色を変更します"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgstr ""
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;背景;壁紙;スクリーン;"
+"デスクトップ;スタイル;ライト;明るい;ダーク;暗い;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:21
+msgid "No Bluetooth Found"
+msgstr "Bluetooth が見つかりませんでした"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:22
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Bluetooth を使用するにはドングルを接続してください。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:28
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth がオフになっています"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:29
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"デバイスの接続やファイルの受信を行うには Bluetooth をオンにしてください。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:35
+msgid "Airplane Mode is On"
+msgstr "機内モードがオンになっています"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:36
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "機内モードがオンの場合、Bluetooth は使用できません。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Turn Off Airplane Mode"
+msgstr "機内モードをオフにする"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:53
+msgid "Hardware Airplane Mode is On"
+msgstr "ハードウェアの機内モードがオンになっています"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:54
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Bluetooth を使用するには機内モードスイッチをオフにしてください。"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Bluetooth のオン/オフやデバイスへの接続を行います"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;共有;シェアリング;ブルートゥース;"
+
+#: panels/camera/cc-camera-panel.ui:21
+msgid "Camera is Turned Off"
+msgstr "カメラがオフになっています"
+
+#: panels/camera/cc-camera-panel.ui:22
+msgid "No applications can capture photos or video."
+msgstr "アプリケーションが写真や動画を撮影できません。"
+
+#: panels/camera/cc-camera-panel.ui:36
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"アプリケーションがカメラで写真や動画を撮影できます。カメラを無効にすると一部"
+"のアプリケーションが正常に機能しなくなるかもしれません。\n"
+"\n"
+"以下のアプリケーションがカメラを使用することを許可します。"
+
+#: panels/camera/cc-camera-panel.ui:52
+msgid "No Applications Have Asked for Camera Access"
+msgstr "カメラへのアクセスを要求しているアプリケーションはありません"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "写真を保護します"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;画面;スクリーン;ロック;診断;クラッシュ;プライベート;最近;テ"
+"ンポラリー;一時;インデックス;索引;名前;ネットワーク;Privacy;プライバシー;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "キャリブレーション装置を四角形に合わせて“開始”を押してください"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "キャリブレーション装置を測定位置に移動して“次へ”を押してください"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "キャリブレーション装置を表面の位置に移動して“次へ”を押してください"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "ノート PC を閉じてください"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "回復不能なエラーが発生しました。"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "キャリブレーションに必要なツールがインストールされていません。"
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "プロファイルを生成できません。"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "対象の白色点は取得できません。"
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "完了しました!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "キャリブレーションに失敗しました!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "キャリブレーション装置を取り外せます。"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "測定中はキャリブレーション装置に触らないでください"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "キャリブレーションの表示"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "開始(_S)"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "再開(_R)"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+msgid "_Done"
+msgstr "完了(_D)"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "ラップトップ画面"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "組み込みのウェブカム"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s モニター"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s スキャナー"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s カメラ"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s プリンター"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s ウェブカム"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s のカラーマネージメントを有効にする"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s のカラープロファイルを表示する"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "未較正"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "デフォルト: "
+
+# ref. gnome-color-manager
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "色空間: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "テスト用プロファイル: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "ICC プロファイルを選択"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "インポート(_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "サポートする ICC プロファイル"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "すべてのファイル"
+
+#: panels/color/cc-color-panel.c:586
+msgid "Screen"
+msgstr "画面"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "プロファイルを保存"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:347
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "保存(_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "選択したデバイスのカラープロファイルを作成"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"計測器を検出できません。電源が入っていること、正しく接続されていることを確認"
+"してください。"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "計測器がプリンターのプロファイルをサポートしていません。"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "このデバイスの形式は現在サポートしていません。"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "画面位置調整"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "キャリブレーション品質"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"キャリブレーションは画面の色管理に利用できるプロファイルを作成します。キャリ"
+"ブレーションに時間をかけるほど色プロファイルの品質は向上します。"
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "キャリブレーション処理中はコンピューターを使えなくなります。"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "品質"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "予測時間"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "キャリブレーション装置"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "キャリブレーションに使用するセンサーデバイスを選択してください。"
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "ディスプレイの種類"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "接続しているディスプレイの種類を選択してください。"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "白色点のプロファイル作成"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"表示対象の白色点を選択してください。ほとんどのディスプレイが D65 光源に対して"
+"キャリブレーションを行えばいいはずです。"
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "ディスプレイの明るさ"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"ディスプレイを標準的に使っている輝度に設定してください。色管理はこの輝度で最"
+"も正確になります。 "
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"他のプロファイルで使っている輝度をこのデバイス用に利用することもできます。"
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "プロファイル名"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"異なるコンピューターの色プロファイルを利用したり、異なる照明条件のプロファイ"
+"ルを作成することもできます。"
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "プロファイル名:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "概要"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "プロファイルが正常に作成されました!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "プロファイルの複製"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "書き込み可能メディアが必要です"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a> や <a href=\"osx\">Apple OS X</a>、<a href="
+"\"windows\">Microsoft Windows</a> システムでのプロファイルの利用方法が役立つ"
+"かもしません。"
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "プロファイルを追加"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"問題が検出されました。プロファイルは正しく動作しない可能性があります。<a "
+"href=\"\">詳細を表示する。</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "ファイルを読み込む(_I)…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/network/connection-editor/net-connection-editor.c:497
+#: panels/printers/new-printer-dialog.ui:84
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "追加(_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"カラーマネージメントを行うには、各デバイスの最新のカラープロファイルが必要に"
+"なります。"
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "もっと詳しく"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "カラーマネージメントについてもっと詳しく知る"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "全ユーザー用に設定(_S)"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "コンピューターのすべてのユーザーでプロファイルを利用"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "有効にする(_E)"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "プロファイルを追加(_A)"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "キャリブレート(_C)…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "デバイスのキャリブレート"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "プロファイルを削除(_R)"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "詳細を表示(_V)"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "カラーマネジメント対象のデバイスを検出できません"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "プロジェクター"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "プラズマ"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL バックライト)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED バックライト)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (白色 LED バックライト)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "広色域 LCD (CCFL バックライト)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "広色域 LCD (RGB LED バックライト)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "高"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 分"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "中"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 分"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "低"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 分"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "ディスプレイ本来の設定"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (印刷および出版)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (写真とグラフィック)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "標準の色空間"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "テスト用プロファイル"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "自動"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "低品質"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "中品質"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "高品質"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "デフォルト RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "デフォルト CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "デフォルトグレー"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "ベンダーが提供している工場でのキャリブレーションデータ"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "このプロファイルでは全画面表示での補正はできません"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "このプロファイルはもう正確ではなくなっているかもしれません。"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "色"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "ディスプレイやカメラ、プリンター等のデバイスのキャリブレート"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Color;ICC;Profile;Calibrate;Printer;Display;色;ICC;プロファイル;キャリブレー"
+"ション;プリンター;ディスプレイ;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "その他…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "言語を選択"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "選択(_S)"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "言語が見つかりません"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "さらに…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "設定を変更する場合はロックを解除してください"
+
+#: panels/common/cc-permission-infobar.ui:40
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "一部の設定は変更する前にロックを解除しておく必要があります。"
+
+#: panels/common/cc-permission-infobar.ui:57
+msgid "Unlock…"
+msgstr "ロック解除…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "一時間単位で時刻を進める"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "一分単位で時刻を進める"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "時刻"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "一時間単位で時刻を戻す"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "一分単位で時刻を戻す"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:162
+msgid "Today"
+msgstr "今日"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:164
+msgid "Yesterday"
+msgstr "昨日"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%B%-e日"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%Y年%B%-e日"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d 時間"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d 分"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d 秒"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 秒"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "ホットスポット"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24時制"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "午前/午後"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%Y年%B%-e日 %p %I:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%Y年%B%-e日 %H:%M"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%2$s, %1$s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%p %I:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%H:%M"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "日付と時刻"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "年"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "月"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "1月"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "2月"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "3月"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "4月"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "5月"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "6月"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "7月"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "8月"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "9月"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "10月"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "11月"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "12月"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "日"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "タイムゾーン"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "都市を検索する"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "自動日時設定(_D)"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "インターネットアクセスが必要です"
+
+#: panels/datetime/cc-datetime-panel.ui:177
+msgid "Date &amp; _Time"
+msgstr "日付と時刻(_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:201
+msgid "Automatic Time _Zone"
+msgstr "自動タイムゾーン設定(_Z)"
+
+#: panels/datetime/cc-datetime-panel.ui:202
+msgid "Requires location services enabled and internet access"
+msgstr "位置サービスの有効化とインターネットアクセスが必要です"
+
+#: panels/datetime/cc-datetime-panel.ui:214
+msgid "Time Z_one"
+msgstr "タイムゾーン(_O)"
+
+#: panels/datetime/cc-datetime-panel.ui:239
+msgid "Time _Format"
+msgstr "日時書式(_F)"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "日付、時刻、タイムゾーンを変更します。"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+"Clock;Timezone;Location;時計;日付;時刻;時間;日時;タイムゾーン;場所;Date;Time;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "システムの時刻と日付の設定を変更"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "時刻と日付の設定を変更するには、認証が必要です。"
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "ウェブ(_W)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "メール(_M)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "カレンダー(_C)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "音楽(_U)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "ビデオ(_V)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "写真(_P)"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "既定のアプリケーション"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "既定のアプリケーションを設定します"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"default;application;preferred;media;デフォルト;既定;アプリケーション;メディ"
+"ア;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"技術的な問題に遭遇した場合、問題に関するレポートを送信することで %s の改善に"
+"役立てることができます。レポートは匿名で送信され、個人データは取り除かれま"
+"す。%s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "問題報告"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "問題のレポートを自動で送信する(_A)"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "診断"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "問題を報告します"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;画面;スクリーン;ロック;診断;クラッシュ;プライベート;"
+"最近;テンポラリー;一時;インデックス;索引;名前;ネットワーク;プライバシー;"
+
+#: panels/display/cc-display-panel.c:512
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
+#: panels/universal-access/cc-ua-panel.c:337
+#: panels/universal-access/cc-ua-panel.c:469
+#: panels/universal-access/cc-ua-panel.c:479
+#: panels/universal-access/cc-ua-panel.c:491
+#: panels/universal-access/cc-ua-panel.c:527
+msgid "On"
+msgstr "オン"
+
+#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:337
+#: panels/universal-access/cc-ua-panel.c:469
+#: panels/universal-access/cc-ua-panel.c:479
+#: panels/universal-access/cc-ua-panel.c:491
+#: panels/universal-access/cc-ua-panel.c:527
+msgid "Off"
+msgstr "オフ"
+
+#: panels/display/cc-display-panel.c:945
+msgid "Apply Changes?"
+msgstr "変更を適用しますか?"
+
+#: panels/display/cc-display-panel.c:950
+msgid "Changes Cannot be Applied"
+msgstr "変更を適用できません"
+
+#: panels/display/cc-display-panel.c:952
+msgid "This could be due to hardware limitations."
+msgstr "この原因はハードウェアの制限にある可能性があります。"
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "適用(_A)"
+
+#: panels/display/cc-display-panel.ui:97
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:113
+msgid "Display Arrangement"
+msgstr "ディスプレイの配置"
+
+#: panels/display/cc-display-panel.ui:124
+msgid "Multiple Displays"
+msgstr "マルチディスプレイ"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:133
+msgid "Join"
+msgstr "拡張"
+
+#: panels/display/cc-display-panel.ui:140
+msgid "Mirror"
+msgstr "ミラー"
+
+#: panels/display/cc-display-panel.ui:153
+msgid "Contains top bar and Activities"
+msgstr "トップバーとアクティビティボタンを含みます"
+
+#: panels/display/cc-display-panel.ui:154
+msgid "Primary Display"
+msgstr "プライマリディスプレイ"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:175
+#: panels/display/cc-display-panel.ui:223
+#: panels/display/cc-night-light-page.ui:77
+msgid "Night Light"
+msgstr "夜間モード"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "横方向"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "縦方向 (右向き)"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "縦方向 (左向き)"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "横方向 (逆向き)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:40
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "向き"
+
+#: panels/display/cc-display-settings.ui:47
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "解像度"
+
+#: panels/display/cc-display-settings.ui:54
+msgid "Refresh Rate"
+msgstr "リフレッシュレート"
+
+#: panels/display/cc-display-settings.ui:61
+msgid "Adjust for TV"
+msgstr "TV 向けに調整"
+
+#: panels/display/cc-display-settings.ui:75
+#: panels/display/cc-display-settings.ui:90
+msgctxt "display setting"
+msgid "Scale"
+msgstr "サイズ調整"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:21
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "明日まで一時的に無効にする"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:35
+msgid "Restart Filter"
+msgstr "フィルターを再始動"
+
+#: panels/display/cc-night-light-page.ui:57
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"夜間モードは画面の色を少し暖色にします。これは目の疲れを緩和し、不眠を防ぐの"
+"に役立ちます。"
+
+#: panels/display/cc-night-light-page.ui:91
+msgid "Schedule"
+msgstr "スケジュール"
+
+#: panels/display/cc-night-light-page.ui:99
+msgid "Sunset to Sunrise"
+msgstr "日没から日の出まで"
+
+#: panels/display/cc-night-light-page.ui:100
+msgid "Manual Schedule"
+msgstr "手動スケジュール"
+
+#: panels/display/cc-night-light-page.ui:110
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "時刻"
+
+#: panels/display/cc-night-light-page.ui:123
+msgid "From"
+msgstr "開始"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/display/cc-night-light-page.ui:235
+msgid "Hour"
+msgstr "時"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/display/cc-night-light-page.ui:241
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:171
+#: panels/display/cc-night-light-page.ui:258
+msgid "Minute"
+msgstr "分"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:181
+#: panels/display/cc-night-light-page.ui:268
+msgid "AM"
+msgstr "午前"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:193
+#: panels/display/cc-night-light-page.ui:280
+msgid "PM"
+msgstr "午後"
+
+#: panels/display/cc-night-light-page.ui:210
+msgid "To"
+msgstr "終了"
+
+#: panels/display/cc-night-light-page.ui:316
+msgid "Color Temperature"
+msgstr "色温度"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "ディスプレイ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "接続したモニターやプロジェクターの使用方法を変更します"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;パネル;プロジェクター;画面;解像度;リフレッシュ;"
+"モニター;ナイトライト;夜間モード;ブルーライト;色管理;ディスプレイ;ディスプ"
+"レー;Displays;日没;日の出;"
+
+#: panels/info-overview/cc-info-overview-panel.c:411
+#: panels/info-overview/cc-info-overview-panel.c:435
+#: panels/info-overview/cc-info-overview-panel.c:481
+#: panels/info-overview/cc-info-overview-panel.c:511
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "不明"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:443
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s (ビルド ID: %s)"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:458
+#, c-format
+msgid "64-bit"
+msgstr "64 ビット"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:461
+#, c-format
+msgid "32-bit"
+msgstr "32 ビット"
+
+#: panels/info-overview/cc-info-overview-panel.c:720
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:724
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:726
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "不明"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "システムロゴ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "Device Name"
+msgstr "デバイス名"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "ハードウェアモデル"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "メモリ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "プロセッサー"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "グラフィック"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "ディスク容量"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "計算中…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "OS 名"
+
+#: panels/info-overview/cc-info-overview-panel.ui:106
+msgid "OS Type"
+msgstr "OS の種類"
+
+#: panels/info-overview/cc-info-overview-panel.ui:114
+msgid "GNOME Version"
+msgstr "GNOME のバージョン"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "Windowing System"
+msgstr "ウィンドウシステム"
+
+#: panels/info-overview/cc-info-overview-panel.ui:131
+msgid "Virtualization"
+msgstr "仮想化"
+
+#: panels/info-overview/cc-info-overview-panel.ui:139
+msgid "Software Updates"
+msgstr "ソフトウェアのアップデート"
+
+#: panels/info-overview/cc-info-overview-panel.ui:158
+msgid "Rename Device"
+msgstr "デバイス名を変更"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"デバイス名は、ネットワーク上での表示や Bluetooth デバイスのペアリングにおい"
+"て、このデバイスを識別するのに使用されます。"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid "_Rename"
+msgstr "名前を変更(_R)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "このシステムについて"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "システム情報を表示します"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;デ"
+"バイス;システム;情報;メモリ;プロセッサ;バージョン;デフォルト;アプリケーショ"
+"ン;設定;オーディオ;音声;音楽;ミュージック;ビデオ;動画;ディスク;リムーバブルメ"
+"ディア;媒体;自動起動;オートラン;Details;詳細;ホスト名;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "音とメディア"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "ミュートを切り替える"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "音量を下げる"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "音量を上げる"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "マイクのミュートを切り替える"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "メディアプレーヤーを起動"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "再生 (あるいは再生/一時停止)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "再生を一時停止"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "再生を停止"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "前のトラック"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "次のトラック"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "取り出し"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "タイピング"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "次の入力ソースへ切り替える"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "前の入力ソースへ切り替える"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "ランチャー"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "ヘルプブラウザーを起動"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "電卓を起動"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "メールクライアントを起動"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "ウェブブラウザーを起動"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "ホームフォルダー"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "検索"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "システム"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "ログアウト"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "画面をロック"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "アクセシビリティ"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "ズームのオン/オフを切り替える"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "ズームイン"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "ズームアウト"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "スクリーンリーダーのオン/オフを切り替える"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "オンスクリーンキーボードのオン/オフを切り替える"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "文字サイズを拡大"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "文字サイズを縮小"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "ハイコントラストのオン/オフを切り替える"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "入力ソースが見つかりませんでした"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "その他"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "入力ソースを追加"
+
+#: panels/keyboard/cc-input-chooser.ui:81
+msgid "Input methods can’t be used on the login screen"
+msgstr "インプットメソッドはログイン画面では使用できません"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "入力ソースを選択していません"
+
+#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+msgid "Move Up"
+msgstr "上へ"
+
+#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+msgid "Move Down"
+msgstr "下へ"
+
+#: panels/keyboard/cc-input-row.ui:38
+msgid "Preferences"
+msgstr "設定"
+
+#: panels/keyboard/cc-input-row.ui:45
+msgid "View Keyboard Layout"
+msgstr "キーボードレイアウトを表示"
+
+#: panels/keyboard/cc-input-row.ui:51
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+msgid "Remove"
+msgstr "削除"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "独自のショートカット"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:62
+msgid "Alternate Characters Key"
+msgstr "代替文字キー"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"代替文字キーを使用すると追加の文字を入力できます。追加の文字はキーボード上に "
+"3 番目のオプションとして印刷されている場合があります。"
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "左 Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "右 Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "左 Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "右 Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "メニューキー"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "右 Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:79
+msgid "Compose Key"
+msgstr "Compose キー"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"入力ソースはキーボードショートカット (%s) で切り替えることができます。\n"
+"キーはキーボードショートカットの設定で変更可能です。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "入力ソース"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "キーボードレイアウトとインプットメソッドを含みます。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "入力ソースの切り替え"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "すべてのウィンドウで同じソースを使用する(_S)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "ウィンドウごとに個別に入力ソースを切り替える(_I)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:58
+msgid "Special Character Entry"
+msgstr "特殊文字の入力"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "キーボードで記号や文字の異体字を入力する方法です。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:97
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "キーボードショートカット"
+
+#: panels/keyboard/cc-keyboard-panel.ui:100
+msgid "View and Customize Shortcuts"
+msgstr "ショートカットの表示とカスタマイズ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d 個変更"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
+msgid "Reset All Shortcuts?"
+msgstr "すべてのショートカットをリセットしますか?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"ショートカットをリセットするとカスタムショートカットが影響を受ける可能性があ"
+"ります。この処理を元に戻すことはできません。"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
+msgid "Reset All"
+msgstr "すべてリセット"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "すべてリセット…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "すべてのショートカットをデフォルトのキーバインディングにリセットします"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+msgid "Add Custom Shortcuts"
+msgstr "独自のショートカットを追加"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"アプリを起動したりスクリプトを実行したりする独自のショートカットを設定しま"
+"す。"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+msgid "Add Shortcut"
+msgstr "ショートカットを追加"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+msgid "No keyboard shortcut found"
+msgstr "キーボードショートカットがありません"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"すでに %s は %s のために使用されています。もし入れ替えなければ %s が無効化さ"
+"れます。"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "新しいショートカットキーを入力してください"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "独自のショートカットを設定"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "ショートカットを設定"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "%s の新しいショートカットを入力してください。"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
+msgid "Add Custom Shortcut"
+msgstr "独自のショートカットを追加"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "追加"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
+msgid "Replace"
+msgstr "入れ替え"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
+msgid "Set"
+msgstr "設定"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Esc でキャンセル、Backspace でキーボードショートカットを無効にできます。"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "名前"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+msgid "Command"
+msgstr "コマンド"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+msgid "Shortcut"
+msgstr "ショートカット"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+msgid "Set Shortcut…"
+msgstr "ショートカットを設定…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "何もしない"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "ショートカットをデフォルトの値にリセットします"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "キーボード"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"キーボードショートカットや入力設定 (キーボードレイアウトや入力ソース) の変更"
+"を行います"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+"ショートカット;ワークスペース;ウィンドウ;リサイズ;サイズ変更;ズーム;コントラ"
+"スト;入力;インプット;ソース;ロック;ボリューム;音量;"
+
+#: panels/location/cc-location-panel.ui:20
+msgid "Location Services Turned Off"
+msgstr "位置情報サービスがオフになっています"
+
+#: panels/location/cc-location-panel.ui:21
+msgid "No applications can obtain location information."
+msgstr "アプリケーションが位置情報を取得できません。"
+
+#: panels/location/cc-location-panel.ui:35
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"アプリケーションが位置情報サービスから現在の位置情報を取得できます。Wi-Fi や"
+"モバイルブロードバンドを使用している場合、より正確な位置を取得できます。\n"
+"\n"
+"Mozilla Location Service を使用します: <a href='https://location.services."
+"mozilla.com/privacy'>プライバシーポリシー</a>\n"
+"\n"
+"以下のアプリケーションが現在地を特定することを許可します。"
+
+#: panels/location/cc-location-panel.ui:53
+msgid "No Applications Have Asked for Location Access"
+msgstr "位置情報へのアクセスを要求しているアプリケーションはありません"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "位置情報を保護します"
+
+#. FIXME
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:62
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "画面オフのとき"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:65
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 秒"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:68
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 分"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:71
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 分"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:74 panels/lock/cc-lock-panel.c:77
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 分"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:80
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 分"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:83
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 時間"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:126
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 分"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:129
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 分"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:132
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 分"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:135
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 分"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:138
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 分"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:141
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 分"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:144
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 分"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:147
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 分"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:150
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 分"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:153
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "しない"
+
+#: panels/lock/cc-lock-panel.ui:8
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"画面の自動ロックは、離席中に他の誰かがコンピューターにアクセスするのを防ぎま"
+"す。"
+
+#: panels/lock/cc-lock-panel.ui:13
+msgid "Blank Screen Delay"
+msgstr "ブランクスクリーンの遅延"
+
+#: panels/lock/cc-lock-panel.ui:14
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "指定した時間、何もしないと画面がブランクになります。"
+
+#: panels/lock/cc-lock-panel.ui:32
+msgid "Automatic Screen _Lock"
+msgstr "自動画面ロック(_L)"
+
+#: panels/lock/cc-lock-panel.ui:46
+msgid "Automatic _Screen Lock Delay"
+msgstr "自動画面ロックの遅延(_S)"
+
+#: panels/lock/cc-lock-panel.ui:47
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "画面がブランクになったあと、指定した条件で自動的に画面をロックします。"
+
+#: panels/lock/cc-lock-panel.ui:65
+msgid "Show _Notifications on Lock Screen"
+msgstr "ロック画面に通知を表示する(_N)"
+
+#: panels/lock/cc-lock-panel.ui:80
+msgid "Forbid new _USB devices"
+msgstr "新しい USB デバイスを認識しない(_U)"
+
+#: panels/lock/cc-lock-panel.ui:81
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "画面をロックしているときは、新しい USB デバイスとの通信を行いません。"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "画面ロック"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr "画面をロックします"
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:20
+msgid "Microphone Turned Off"
+msgstr "マイクがオフになっています"
+
+#: panels/microphone/cc-microphone-panel.ui:21
+msgid "No applications can record sound."
+msgstr "アプリケーションが録音できません。"
+
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"アプリケーションがマイクで録音したりすることができます。マイクを無効にすると"
+"一部のアプリケーションが正常に機能しなくなるかもしれません。\n"
+"\n"
+"以下のアプリケーションがマイクを使用することを許可します。"
+
+#: panels/microphone/cc-microphone-panel.ui:51
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "マイクへのアクセスを要求しているアプリケーションはありません"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "会話を保護します"
+
+# Button Label
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "設定を確認(_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "全般"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "主ボタン"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "マウス、タッチパッドのボタンの順位を設定します。"
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "左"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "右"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "マウス"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "マウスの速度"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
+msgid "Natural Scrolling"
+msgstr "ナチュラルスクロール"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
+msgid "Scrolling moves the content, not the view."
+msgstr "スクロールする方向にコンテンツが移動します。"
+
+#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+msgid "Touchpad"
+msgstr "タッチパッド"
+
+#: panels/mouse/cc-mouse-panel.ui:119
+msgid "Touchpad Speed"
+msgstr "タッチパッドの速度"
+
+#: panels/mouse/cc-mouse-panel.ui:136
+msgid "Tap to Click"
+msgstr "タップでクリックする"
+
+#: panels/mouse/cc-mouse-panel.ui:147
+msgid "Two-finger Scrolling"
+msgstr "2 本指でのスクロール"
+
+#: panels/mouse/cc-mouse-panel.ui:159
+msgid "Edge Scrolling"
+msgstr "エッジスクロール"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "クリック、ダブルクリック、スクロールを試してください"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "クリック 5 回、GEGL タイム"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "ダブルクリック、主ボタン"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "シングルクリック、主ボタン"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "ダブルクリック、中央ボタン"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "シングルクリック、中央ボタン"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "ダブルクリック、副ボタン"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "シングルクリック、副ボタン"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "マウスとタッチパッド"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "マウスやタッチパッドの感度の変更、利き手の選択をします"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;トラックパッド;ポイ"
+"ンター;クリック;タップ;ダブル;ボタン;トラックボール;スクロール;Mouse;"
+"Touchpad;マウス;タッチパッド;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "ホットコーナー(_H)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "画面左上隅にタッチするとアクティビティ画面を開きます。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "スクリーンエッジを有効にする(_A)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"ウィンドウを画面上部、画面左端、画面右端にドラッグすることでウィンドウサイズ"
+"を変更できるようにします。"
+
+# ref. gnome-color-manager
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "ワークスペース"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "動的ワークスペース(_D)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "空のワークスペースを自動的に削除します。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "ワークスペースの数を指定する(_F)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "常に指定した数のワークスペースが用意されます。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "ワークスペースの数(_N)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "マルチモニター"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "プライマリーディスプレイにのみワークスペースを表示する(_P)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "すべてのディスプレイにワークスペースを表示する(_I)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "アプリケーションの切り替え"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "すべてのワークスペースのアプリケーションを含む(_W)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "現在のワークスペースのアプリケーションのみを含む(_C)"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "マルチタスク"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "プロダクティビティとマルチタスクに関する設定を管理します"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;マルチタスク;プロダク"
+"ティビティ;カスタマイズ;デスクトップ;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "問題に遭遇しました。ソフトウェアベンダーに報告してください。"
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager が動作している必要があります。"
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "その他のデバイス"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
+#: panels/network/connection-editor/net-connection-editor.c:580
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:70
+msgid "Not set up"
+msgstr "未設定"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:207
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:263
+msgid "Insecure network (WEP)"
+msgstr "安全ではないネットワーク (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:267
+msgid "Secure network (WPA)"
+msgstr "安全なネットワーク (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:271
+msgid "Secure network (WPA2)"
+msgstr "安全なネットワーク (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Secure network (WPA3)"
+msgstr "安全なネットワーク (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network"
+msgstr "安全なネットワーク"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "接続"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
+#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "オプション…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"アクセスポイントをオンにすると %s から切断され、Wi-Fi でのインターネットアク"
+"セスができなくなります。"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "8 文字以上にしてください"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "%d 文字以下にしてください"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi アクセスポイントをオンにしますか?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-Fi アクセスポイントは周囲の人が接続できる Wi-Fi ネットワークを作成し、あな"
+"たのインターネット接続を全員で共有できるようにします。これには、Wi-Fi 以外の"
+"方法でのインターネット接続が必要です。"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "ネットワーク名"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:74
+#: panels/printers/new-printer-dialog.ui:331
+#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:362
+#: panels/wwan/cc-wwan-apn-dialog.ui:172
+msgid "Password"
+msgstr "パスワード"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:86
+msgid "Generate Random Password"
+msgstr "ランダムパスワードを生成します"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:87
+msgid "Autogenerate Password"
+msgstr "パスワードを自動生成できます"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:129
+msgid "_Turn On"
+msgstr "オン(_T)"
+
+#: panels/network/cc-wifi-panel.c:544
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:879
+msgid "Stop hotspot and disconnect any users?"
+msgstr "アクセスポイントを停止し、ユーザーを切断しますか?"
+
+#: panels/network/cc-wifi-panel.c:882
+msgid "_Stop Hotspot"
+msgstr "停止(_S)"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Airplane Mode"
+msgstr "機内モード"
+
+#: panels/network/cc-wifi-panel.ui:73
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Wi-Fi、Bluetooth、モバイルブロードバンドを無効にします"
+
+#: panels/network/cc-wifi-panel.ui:110
+msgid "No Wi-Fi Adapter Found"
+msgstr "Wi-Fi アダプターが見つかりませんでした"
+
+#: panels/network/cc-wifi-panel.ui:120
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Wi-Fi アダプターが接続されオンになっているか確認してください"
+
+#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+msgid "Airplane Mode On"
+msgstr "機内モードオン"
+
+#: panels/network/cc-wifi-panel.ui:162
+msgid "Turn off to use Wi-Fi"
+msgstr "Wi-Fi を使用する場合はオフにしてください"
+
+#: panels/network/cc-wifi-panel.ui:199
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi アクセスポイント有効"
+
+#: panels/network/cc-wifi-panel.ui:209
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "モバイルデバイスで QR コードをスキャンすると接続できます。"
+
+#: panels/network/cc-wifi-panel.ui:217
+msgid "Turn Off Hotspot…"
+msgstr "アクセスポイントをオフにする…"
+
+#: panels/network/cc-wifi-panel.ui:237
+msgid "Visible Networks"
+msgstr "ネットワーク一覧"
+
+#: panels/network/cc-wifi-panel.ui:294
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager が動作している必要があります"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x セキュリティ(_S)"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "セキュリティ"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"ここに入力した MAC アドレスは、現在の接続で利用しているネットワークデバイスの"
+"ハードウェアアドレスとして使用されます。この機能は MAC アドレスのクローニン"
+"グ、またはスプーフィングとして知られています。例: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "プロファイル %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:101
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:107
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:112
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:119
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:130
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "なし"
+
+#: panels/network/connection-editor/ce-page-details.c:151
+msgid "Never"
+msgstr "しない"
+
+#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i 日前"
+
+#: panels/network/connection-editor/ce-page-details.c:293
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:295
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:312
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "None"
+msgstr "なし"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "弱い"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "OK"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "良い"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "非常に良い"
+
+#: panels/network/connection-editor/ce-page-details.c:409
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 アドレス"
+
+#: panels/network/connection-editor/ce-page-details.c:410
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
+msgid "IPv6 Address"
+msgstr "IPv6 アドレス"
+
+#: panels/network/connection-editor/ce-page-details.c:412
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP アドレス"
+
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:420
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
+#: panels/network/network-mobile.ui:217
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:473
+msgid "Forget Connection"
+msgstr "接続情報を破棄"
+
+#: panels/network/connection-editor/ce-page-details.c:475
+msgid "Remove Connection Profile"
+msgstr "接続プロファイルを削除"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Remove VPN"
+msgstr "VPN を削除"
+
+#: panels/network/connection-editor/ce-page-details.c:495
+msgid "Details"
+msgstr "詳細"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "自動"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identity"
+
+#: panels/network/connection-editor/ce-page-ip4.c:245
+#: panels/network/connection-editor/ce-page-ip6.c:226
+msgid "Delete Address"
+msgstr "アドレスを削除"
+
+#: panels/network/connection-editor/ce-page-ip4.c:392
+#: panels/network/connection-editor/ce-page-ip6.c:361
+msgid "Delete Route"
+msgstr "ルートを削除"
+
+#: panels/network/connection-editor/ce-page-ip4.c:742
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:712
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "なし"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit キー (HEX または ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit パスフレーズ"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "動的 WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 パーソナル"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "信号強度"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "リンクの速度"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "ハードウェアアドレス"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "サポートする周波数帯"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:189
+msgid "Default Route"
+msgstr "デフォルトルート"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "前回の使用"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "自動接続する(_A)"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "他のユーザーも利用できるようにする(_O)"
+
+#: panels/network/connection-editor/details-page.ui:412
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "従量制接続(_M): データ通信量に上限がある、または通信料がかかります"
+
+#: panels/network/connection-editor/details-page.ui:421
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"ソフトウェアのアップデートや、その他のサイズが大きいもののダウンロードは、自"
+"動的に開始されません。"
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "名前(_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC アドレス(_M)"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "MTU(_T)"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "クローンしたアドレス(_C)"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "バイト"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv4 メソッド(_4)"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "自動 (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "リンクローカルのみ"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+msgid "Manual"
+msgstr "手動"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "無効"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "他のコンピューターと共有"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "アドレス"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:255
+#: panels/printers/pp-details-dialog.ui:90
+msgid "Address"
+msgstr "アドレス"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:258
+msgid "Netmask"
+msgstr "ネットマスク"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:279
+msgid "Gateway"
+msgstr "ゲートウェイ"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:232
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "自動"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "自動 DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:196
+#: panels/network/connection-editor/ip6-page.ui:205
+msgid "Separate IP addresses with commas"
+msgstr "複数の IP アドレスを指定する場合はそれぞれコンマで区切ってください"
+
+#: panels/network/connection-editor/ip4-page.ui:213
+#: panels/network/connection-editor/ip6-page.ui:222
+msgid "Routes"
+msgstr "ルート"
+
+#: panels/network/connection-editor/ip4-page.ui:231
+#: panels/network/connection-editor/ip6-page.ui:240
+msgid "Automatic Routes"
+msgstr "自動ルート"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:281
+#: panels/network/connection-editor/ip6-page.ui:290
+msgid "Metric"
+msgstr "メトリック"
+
+#: panels/network/connection-editor/ip4-page.ui:304
+#: panels/network/connection-editor/ip6-page.ui:313
+msgid "Use this connection _only for resources on its network"
+msgstr "この接続はネットワーク上のリソースのためだけに使用する(_O)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv6 メソッド(_6)"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "自動、DHCP のみ"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:267
+msgid "Prefix"
+msgstr "プレフィックス"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "接続エディターを起動できません"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "新しいプロファイル"
+
+#: panels/network/connection-editor/net-connection-editor.c:715
+msgid "Import from file…"
+msgstr "ファイルからインポート…"
+
+#: panels/network/connection-editor/net-connection-editor.c:741
+msgid "Add VPN"
+msgstr "VPN を追加"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "セキュリティ(_E)"
+
+#: panels/network/connection-editor/vpn-helpers.c:191
+msgid "Cannot import VPN connection"
+msgstr "VPN 接続をインポートできません"
+
+#: panels/network/connection-editor/vpn-helpers.c:193
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"ファイル“%s”は読み取れなかったか、または処理できる VPN 接続情報がありません\n"
+"\n"
+"エラー: %s"
+
+#: panels/network/connection-editor/vpn-helpers.c:223
+msgid "Select file to import"
+msgstr "インポートするファイルを選択"
+
+#: panels/network/connection-editor/vpn-helpers.c:276
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "ファイル“%s”はすでに存在します。"
+
+#: panels/network/connection-editor/vpn-helpers.c:278
+msgid "_Replace"
+msgstr "入れ替え(_R)"
+
+#: panels/network/connection-editor/vpn-helpers.c:280
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "%s を、保存している VPN 接続に入れ替えますか?"
+
+#: panels/network/connection-editor/vpn-helpers.c:315
+msgid "Cannot export VPN connection"
+msgstr "VPN 接続をエクスポートできません"
+
+#: panels/network/connection-editor/vpn-helpers.c:317
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN 接続“%s”を %s にエクスポートできませんでした。\n"
+"\n"
+"エラー: %s"
+
+#: panels/network/connection-editor/vpn-helpers.c:343
+msgid "Export VPN connection"
+msgstr "VPN 接続をエクスポート"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(エラー: VPN 接続エディターを読み込めません)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "SSID(_S)"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "BSSID(_B)"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "ネットワークへの接続方法を設定します"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;ネットワーク;イン"
+"ターネット;有線;プロキシー;プロキシ;ブロードバンド;モデム;ブルートゥース;VPN;"
+"ドメイン名;ドメインネームサーバー;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Wi-Fi ネットワークへの接続方法を設定します"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;ネットワーク;無線;ワ"
+"イヤレス;ブロードバンド;ホットスポット;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "未接続"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "今日"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "昨日"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "最後の利用"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "有線"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "新しい接続を追加"
+
+#: panels/network/net-device-wifi.c:857
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr "パスワードや独自の設定など、選択したネットワークの詳細は失われます。"
+
+#: panels/network/net-device-wifi.c:861
+msgid "_Forget"
+msgstr "破棄(_F)"
+
+#: panels/network/net-device-wifi.c:1041
+msgid "Known Wi-Fi Networks"
+msgstr "既知の Wi-Fi ネットワーク"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1073
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "破棄(_F)"
+
+#: panels/network/net-device-wifi.c:1216
+msgid "System policy prohibits use as a Hotspot"
+msgstr "システムのポリシーによりホットスポットとしての利用は禁止されています"
+
+#: panels/network/net-device-wifi.c:1219
+msgid "Wireless device does not support Hotspot mode"
+msgstr "ワイヤレスデバイスがホットスポットモードに対応していません"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"設定ファイルの URL が指定されていない場合 Web Proxy Autodiscovery が使用され"
+"ます。"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "信頼できない公衆ネットワークでは推奨されません。"
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "デバイスをオフにする"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "プロバイダー"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+msgid "Network Proxy"
+msgstr "ネットワークプロキシ"
+
+#: panels/network/network-proxy.ui:139
+msgid "_HTTP Proxy"
+msgstr "HTTP プロキシ(_H)"
+
+#: panels/network/network-proxy.ui:156
+msgid "H_TTPS Proxy"
+msgstr "HTTPS プロキシ(_T)"
+
+#: panels/network/network-proxy.ui:173
+msgid "_FTP Proxy"
+msgstr "FTP プロキシ(_F)"
+
+#: panels/network/network-proxy.ui:190
+msgid "_Socks Host"
+msgstr "Socks ホスト(_S)"
+
+#: panels/network/network-proxy.ui:207
+msgid "_Ignore Hosts"
+msgstr "次のホストを無視する(_I)"
+
+#: panels/network/network-proxy.ui:244
+msgid "HTTP proxy port"
+msgstr "HTTP プロキシポート"
+
+#: panels/network/network-proxy.ui:307
+msgid "HTTPS proxy port"
+msgstr "HTTPS プロキシポート"
+
+#: panels/network/network-proxy.ui:322
+msgid "FTP proxy port"
+msgstr "FTP プロキシポート"
+
+#: panels/network/network-proxy.ui:337
+msgid "Socks proxy port"
+msgstr "Socks プロキシポート"
+
+#: panels/network/network-proxy.ui:357
+msgid "_Configuration URL"
+msgstr "設定 URL(_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN 接続をオフにする"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "ネットワーク名"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "セキュリティタイプ"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "パスワード"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi をオフにする"
+
+#: panels/network/network-wifi.ui:121
+msgid "_Connect to Hidden Network…"
+msgstr "非表示のネットワークに接続(_C)…"
+
+#: panels/network/network-wifi.ui:128
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi アクセスポイントをオンにする(_T)…"
+
+#: panels/network/network-wifi.ui:135
+msgid "_Known Wi-Fi Networks"
+msgstr "既知の Wi-Fi ネットワーク(_K)"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "ステータス不明"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "管理対象外"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "利用不可"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "接続中"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "認証が必要です"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "切断中"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "接続失敗"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "ステータス不明 (見つかりません)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "設定に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP 設定に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP 設定の期限切れです"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "秘密の情報が必要でしたが入力されませんでした"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x サプリカントが切断されました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x サプリカントの設定に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x サプリカントが失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x サプリカントの認証に時間がかかりすぎました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP サービスの起動に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP サービスの接続を切断しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP が失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP クライアントの起動に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP クライアントにエラーが発生しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP クライアントが失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "共有接続サービスの起動に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "共有接続サービスが失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP サービスの起動に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP サービスにエラーが発生しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP サービスが失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "回線が使用中です"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "発信音がありません"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "キャリアの確立ができませんでした"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "発信要求がタイムアウトしました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "発信の試行に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "モデムの初期化に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "指定された APN の選択に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "ネットワーク検索をしていません"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "ネットワーク登録が拒否されました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "ネットワーク登録がタイムアウトしました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "要求されたネットワークへの登録に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN チェックに失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "このデバイスのファームウェアがないようです"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "接続が消失しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "既存の接続とみなされました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "モデムが見つかりませんでした"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth 接続に失敗しました"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM カードが挿入されていません"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM の PIN 番号が必要です"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM の PUK が必要です"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM が違います"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "接続が依存するデバイスなどの準備ができません"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "ファームウェア未検出"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "ケーブル非接続"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "802.1X セキュリティ (wpa-eap) で未定義のエラーが発生しました"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "ファイルが選択されていません"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "EAP メソッドファイルの検証中に特定できないエラーが発生しました"
+
+#: panels/network/wireless-security/eap-method.c:389
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "DER, PEM, PKCS#12 の秘密鍵 (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:392
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER か PEM の証明書 (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "EAP-FAST PAC ファイルがありません"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC ファイル (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "匿名"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "認証"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "両方"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "匿名の識別子(_M)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC ファイル(_F)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PAC ファイルを選択"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "内部認証(_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "自動的な PAC プロビジョニングを許可する(_V)"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "EAP-LEAP ユーザー名がありません"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "EAP-LEAP パスワードがありません"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "ユーザー名(_U)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:175
+msgid "_Password"
+msgstr "パスワード(_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "パスワードを表示する(_W)"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "無効な EAP-PEAP CA 証明書: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "無効な EAP-PEAP CA 証明書: 認証書が指定されていません"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "バージョン 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "バージョン 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "CA 証明書(_A)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "認証局 (CA) 証明書を選択"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "CA 証明書が要求されましたが存在しません(_R)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP バージョン(_V)"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "EAP ユーザー名がありません"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "EAP パスワードがありません"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "EAP-TLS Identity がありません"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "無効な EAP-TLS CA 証明書: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "無効な EAP-TLS CA 証明書: 認証書が指定されていません"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "無効な EAP-TLS 秘密鍵: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "無効な EAP-TLS ユーザー証明書: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "暗号化されていない秘密鍵は安全ではありません"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"選択した秘密鍵はパスワードで保護されていないようです。この状態は信用情報の侵"
+"害を許してしまいます。パスワード保護のある秘密鍵を選択してください。\n"
+"\n"
+"(秘密鍵は openssl を使用してパスワード保護ができます)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "個人用証明書を選択する"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "秘密鍵を選択する"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "Identity(_D)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "ユーザー証明書(_U)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "秘密鍵(_K)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "秘密鍵のパスワード(_P)"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "無効な EAP-TTLS CA 証明書: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "無効な EAP-TTLS CA 証明書: 証明書が指定されていません"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "ドメイン(_D)"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "802.1X セキュリティの検証中に不明なエラーが発生しました"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "トンネル化 TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "保護つき EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "認証(_T)"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "ファイルを選択"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "LEAP ユーザー名がありません"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "LEAP パスワードがありません"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Wi-Fi パスワードがありません。"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "種類(_T)"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "WEP キーがありません"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"無効な WEP キー: キーの長さが %zu 文字の場合、16 進数字以外は使用できません"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"無効な WEP キー: キーの長さが %zu 文字の場合、アスキー文字以外は使用できませ"
+"ん"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"無効な WEP キー: キーの長さ %zu は使用できません。WEP キーは長さ 5 文字か 13 "
+"文字のアスキー文字、または 10 文字か 26 文字の 16 進数字のどちらかでなければ"
+"なりません"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "無効な WEP キー: パスフレーズには必ず何か入力してください"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "無効な WEP キー: パスフレーズは 64 文字未満でなければなりません"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (デフォルト)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "オープンシステム"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "共有鍵"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "キー(_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "キーを表示する(_W)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP インデックス(_X)"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"無効な WPA PSK: キーの長さ %zu は無効です。8 〜 63 文字、または 16 進数表記"
+"で 64 文字でなければなりません"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "無効な WPA PSK: キーが 64 文字の場合、16 進数字以外は使用できません"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "通知(_N)"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "サウンドアラート(_A)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "通知ポップアップ(_P)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr "ポップアップを無効にすると、通知リストに通知が表示され続けます。"
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "ポップアップにメッセージの内容を表示する(_C)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "ロック画面での通知(_L)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "ロック画面にメッセージの内容を表示する(_O)"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "通知ポップアップを表示しない(_D)"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "ロック画面での通知(_L)"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "表示する通知およびその表示方法について設定します"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;Banner;Message;Tray;Popup;通知;バナー;メッセージ;トレイ;ポップ"
+"アップ;"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:277
+#, c-format
+msgid "%s removed"
+msgstr "%s を削除しました"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:406
+msgctxt "Online Account"
+msgid "Other"
+msgstr "その他"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "アカウントの削除に失敗しました"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:51
+msgid "Undo"
+msgstr "元に戻す"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:55
+msgid "Connect to your data in the cloud"
+msgstr "クラウド上のあなたのデータと接続します"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:66
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"インターネット接続がありません — 新しいオンラインアカウントのセットアップのた"
+"めに接続してください"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:93
+msgid "Add an account"
+msgstr "アカウントの追加"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:426
+#, c-format
+msgid "%s Account"
+msgstr "%s アカウント"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:429
+msgid "Remove Account"
+msgstr "アカウントを削除"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "オンラインアカウント"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "オンラインアカウントへの接続や利用方法を設定します"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;グーグル;フェイスブック;ツイッター;ヤ"
+"フー;ウェブ;オンライン;チャット;カレンダー;メール;連絡先;Flickr;"
+"OnlineAccounts;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "残り時間は不明"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i 分"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i 時間"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "時間"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "分"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "フル充電まで %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "注意: 残り %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "残り %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "フル充電"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "充電していません"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "空"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "充電中"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "放電中"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "ワイヤレスマウス"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "ワイヤレスキーボード"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "無停電電源装置"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "携帯情報端末"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "携帯電話"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "音楽プレーヤー"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "タブレット"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "コンピューター"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "ゲーム用入力デバイス"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "バッテリー"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "主"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "予備"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "バッテリー"
+
+#: panels/power/cc-power-panel.c:511
+msgid "When _idle"
+msgstr "アイドル時(_I)"
+
+#: panels/power/cc-power-panel.c:671
+msgid "Suspend"
+msgstr "サスペンド"
+
+#: panels/power/cc-power-panel.c:672
+msgid "Power Off"
+msgstr "電源オフ"
+
+#: panels/power/cc-power-panel.c:673
+msgid "Hibernate"
+msgstr "ハイバネート"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Nothing"
+msgstr "なにもしない"
+
+#: panels/power/cc-power-panel.c:730
+msgid "When on battery power"
+msgstr "バッテリー動作時"
+
+#: panels/power/cc-power-panel.c:732
+msgid "When plugged in"
+msgstr "電源接続時"
+
+#: panels/power/cc-power-panel.c:853
+msgctxt "Idle time"
+msgid "Never"
+msgstr "しない"
+
+#: panels/power/cc-power-panel.c:937
+msgid "Automatic suspend"
+msgstr "自動サスペンド"
+
+#: panels/power/cc-power-panel.c:1030
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "動作温度が高いためパフォーマンスモードが一時的に無効になりました。"
+
+#: panels/power/cc-power-panel.c:1032
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1034
+msgid "Performance mode temporarily disabled."
+msgstr "パフォーマンスモードが一時的に無効になりました。"
+
+#: panels/power/cc-power-panel.c:1076
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"バッテリー低下: 省電力が有効になりました。バッテリーが十分に充電されると以前"
+"のモードに戻ります。"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1084
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "“%s”によって省電力モードがアクティブになります。"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1088
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "“%s”によってパフォーマンスモードがアクティブになります。"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 分"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 分"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 分"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 分"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 分"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 時間"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 分"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 分"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 分"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 時間"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "電源モード"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "システムのパフォーマンスと消費電力に関係します。"
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "省電力オプション"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "画面の明るさを自動調整する"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "周囲光で画面の明るさを調節します。"
+
+#: panels/power/cc-power-panel.ui:138
+msgid "Dim Screen"
+msgstr "画面を暗くする"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "コンピューターが非アクティブなときに画面の明るさを下げます。"
+
+#: panels/power/cc-power-panel.ui:150
+msgid "Screen _Blank"
+msgstr "画面のブランク(_B)"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Turns the screen off after a period of inactivity."
+msgstr "何もしない状態が一定時間続いたら画面をオフにします。"
+
+#: panels/power/cc-power-panel.ui:159
+msgid "Automatic Power Saver"
+msgstr "自動的に消費電力を抑える"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Enables power saver mode when battery is low."
+msgstr "バッテリーが低下したときに省電力モードを有効にします。"
+
+#: panels/power/cc-power-panel.ui:173
+msgid "_Automatic Suspend"
+msgstr "自動サスペンド(_A)"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "Pauses the computer after a period of inactivity."
+msgstr "何もしない状態が一定時間続いたらコンピューターを休止します。"
+
+#: panels/power/cc-power-panel.ui:199
+msgid "Po_wer Button Behavior"
+msgstr "電源ボタンの挙動(_W)"
+
+#: panels/power/cc-power-panel.ui:207
+msgid "Show Battery _Percentage"
+msgstr "バッテリー残量を表示する(_P)"
+
+#: panels/power/cc-power-panel.ui:243
+msgid "Automatic Suspend"
+msgstr "自動サスペンド"
+
+#: panels/power/cc-power-panel.ui:266
+msgid "_Plugged In"
+msgstr "電源接続時(_P)"
+
+#: panels/power/cc-power-panel.ui:278
+msgid "On _Battery Power"
+msgstr "バッテリー動作時(_B)"
+
+#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
+#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+msgid "Delay"
+msgstr "時間"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "パフォーマンス"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "高いパフォーマンスと消費電力です。"
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "バランス"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "標準的なパフォーマンスと消費電力です。"
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "省電力"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "パフォーマンスと消費電力を抑えます。"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "電源"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "バッテリー状態の表示、省電力の設定をします"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;電源;スリープ;サスペンド;ハイバネート;バッテリー;明るさ;ブランクスク"
+"リーン;モニター;画面;ディスプレイ;アイドル;待機;電力;エネルギー;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:676
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "プリンター“%s”を削除しました"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:928
+msgid "Failed to add new printer."
+msgstr "新しいプリンターを追加できませんでした。"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1229
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui ファイルを読み込めませんでした: %s"
+
+#: panels/printers/cc-printers-panel.c:1297
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "設定の変更やプリンターを追加する場合はロックを解除してください"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "プリンター"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "プリンターの追加、プリンタージョブの表示、印刷方法の設定を行います。"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"Printer;Queue;Print;Paper;Ink;Toner;プリンター;キュー;印刷;紙;インク;トナー;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "プリンターを追加"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:100
+#: panels/printers/new-printer-dialog.ui:115
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "ロック解除(_U)"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:194
+msgid "No Printers Found"
+msgstr "プリンターが見つかりませんでした"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:244
+msgid "Enter a network address or search for a printer"
+msgstr "ネットワークアドレスを入力するかプリンターを検索してください"
+
+#: panels/printers/new-printer-dialog.ui:286
+msgid "Authentication Required"
+msgstr "認証が必要です"
+
+#: panels/printers/new-printer-dialog.ui:302
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"プリンターサーバーで利用可能なプリンターを表示するにはユーザー名とパスワード"
+"を入力してください。"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:311
+#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:148
+msgid "Username"
+msgstr "ユーザー名"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:365
+#, c-format
+msgid "%s Details"
+msgstr "%s の詳細"
+
+#: panels/printers/pp-details-dialog.c:101
+msgid "No suitable driver found"
+msgstr "適切なドライバーが見つかりませんでした"
+
+#: panels/printers/pp-details-dialog.c:260
+msgid "Select PPD File"
+msgstr "PPD ファイルを選択"
+
+#: panels/printers/pp-details-dialog.c:269
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript Printer Description ファイル(*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+msgid "Location"
+msgstr "場所"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:115
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "ドライバー"
+
+#: panels/printers/pp-details-dialog.ui:154
+msgid "Searching for preferred drivers…"
+msgstr "推奨ドライバーの検索中…"
+
+#: panels/printers/pp-details-dialog.ui:173
+msgid "Search for Drivers"
+msgstr "ドライバーを検索する"
+
+#: panels/printers/pp-details-dialog.ui:181
+msgid "Select from Database…"
+msgstr "データベースから選択…"
+
+#: panels/printers/pp-details-dialog.ui:189
+msgid "Install PPD File…"
+msgstr "PPD ファイルをインストール…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "プリンタードライバーを選択"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "ドライバーのデータベースを読み込み中…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "選択"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect プリンター"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD プリンター"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "片面"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "長辺とじ (標準)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "短辺とじ (フリップ)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "縦方向"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "横方向"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "横方向 (逆向き)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "縦方向 (逆向き)"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:134
+msgctxt "print job"
+msgid "Pending"
+msgstr "待機中"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:140
+msgctxt "print job"
+msgid "Paused"
+msgstr "一時停止"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:145
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "認証が必要です"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "印刷中"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "停止"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "キャンセル"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "中止"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "完了"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:176
+msgid "Move this job to the top of the queue"
+msgstr "このジョブをキューの先頭へ移動する"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u 件のジョブで認証が要求されています"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — アクティブなジョブ"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "%s から印刷するにはユーザー名とパスワードを入力してください。"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "ドメイン"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:100
+msgid "A_uthenticate"
+msgstr "認証(_U)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:128
+msgid "Clear All"
+msgstr "すべて消去"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:173
+msgid "_Authenticate"
+msgstr "認証(_A)"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:214
+msgid "No Active Printer Jobs"
+msgstr "アクティブなジョブはありません"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "プリンターサーバーのロック解除"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s のロック解除"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"%s で利用可能なプリンターを表示するにはユーザー名とパスワードを入力してくださ"
+"い。"
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "プリンターの検索"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "シリアルポート"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "パラレルポート"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "場所: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "アドレス: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "サーバーが認証を要求しています"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "両面"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "用紙の種類"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "給紙元"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "出力トレイ"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "解像度"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript のプレフィルタリング"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "片面のページ数"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "両面"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "向き"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "汎用"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "ページ設定"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "インストール可能なオプション"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "ジョブ"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "画質"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "色"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "表面処理"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "高度"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "テストページ"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "テストページ"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "自動選択"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "プリンターのデフォルト"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "内蔵 GhostScript フォントのみ"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "PS レベル 1 に変換"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "PS レベル 2 に変換"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "プレフィルタリングなし"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "製造元"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "アクティブなジョブがありません"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u ジョブ"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "ヘッドクリーニング"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "トナーの残量が少なくなっています"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "トナーが空です"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "現像液が少なくなっています"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "現像液が空です"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "インクが少なくなっています"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "インクが切れています"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "カバーが開いています"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "扉が開いています"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "紙が少なくなっています"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "紙が空です"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "オフライン"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "停止中"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "廃インクタンクがもう少しでいっぱいです"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "廃インクタンクがいっぱいです"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "感光体の寿命が近づいています"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "感光体の寿命です"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "準備完了"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "ジョブ受付不可"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "処理中"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "プリンターのオプション"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "プリンターの詳細"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "デフォルトプリンター"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "ヘッドクリーニング"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "プリンターを削除"
+
+#: panels/printers/printer-entry.ui:187
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "型式"
+
+#: panels/printers/printer-entry.ui:242
+msgid "Ink Level"
+msgstr "インクの量"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:304
+msgid "Please restart when the problem is resolved."
+msgstr "問題が解決した場合、再起動してください。"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:310
+msgid "Restart"
+msgstr "再起動"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10
+msgid "Add Printer…"
+msgstr "プリンターを追加…"
+
+#: panels/printers/printers.ui:168
+msgid "No printers"
+msgstr "プリンターが見つかりません"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:179
+msgid "Add a Printer…"
+msgstr "プリンターを追加…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:204
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"申し訳ありません! システムの印刷サービスは\n"
+"    現在、利用できないようです。"
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "フォーマット"
+
+#: panels/region/cc-format-chooser.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "戻る"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "地域を検索…"
+
+#: panels/region/cc-format-chooser.ui:113
+msgid "Common Formats"
+msgstr "一般的な形式"
+
+#: panels/region/cc-format-chooser.ui:140
+msgid "All Formats"
+msgstr "すべての形式"
+
+#: panels/region/cc-format-chooser.ui:188
+msgid "No Search Results"
+msgstr "検索結果はありません"
+
+#: panels/region/cc-format-chooser.ui:200
+msgid "Searches can be for countries or languages."
+msgstr "国または言語を検索できます。"
+
+#: panels/region/cc-format-chooser.ui:236
+msgid "Preview"
+msgstr "プレビュー"
+
+#: panels/region/cc-format-preview.c:135
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ヤード・ポンド法"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "メートル法"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "日付"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "日付と時刻"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "数字"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "計量単位"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "用紙サイズ"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "言語とフォーマットの設定は次回ログイン時に適用されます"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "ログアウト…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats is "
+"used for numbers, dates, and currencies."
+msgstr ""
+"設定した言語でインターフェースやウェブページのテキストが表示されます。フォー"
+"マットは数値、日時、通貨の形式に使用されます。"
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "あなたのアカウント"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:299
+msgid "_Language"
+msgstr "言語(_L)"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "フォーマット(_F)"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "ログイン画面"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "地域と言語"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "表示される言語や日付などの形式を選択します"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+"Language;Layout;Keyboard;Input;言語;レイアウト;キーボード;入力;インプット;"
+"Region;地域;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "どうするか確認する"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "なにもしない"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "フォルダーを開く"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "他のメディア"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "オーディオ CD 用のアプリケーションを選択"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "ビデオ DVD 用のアプリケーションを選択"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "音楽プレーヤーが接続されたときに起動するアプリケーションを選択"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "カメラが接続されたときに起動するアプリケーションを選択"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "ソフトウェアの CD を開くアプリケーションを選択"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "オーディオ DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "空のブルーレイディスク"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "空の CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "空の DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "空の HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "ブルーレイビデオディスク"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "電子書籍リーダー"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD ビデオディスク"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "ピクチャー CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "スーパービデオ CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "ビデオ CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows ソフトウェア"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "メディアの処理方法を選択してください"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD オーディオ(_A)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "DVD ビデオ(_D)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "音楽プレーヤー(_M)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "ソフトウェア(_S)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "他のメディア(_O)…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"メディア挿入時にどう処理するか確認したり、プログラムを実行したりしない(_N)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "他のメディアの処理を選択してください"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "アクション(_A):"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "種類(_T):"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "リムーバブルメディア"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "リムーバブルメディアを設定します"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;デバイス;システム;デフォルト;既定;アプリケーション;設"
+"定;オーディオ;音声;音楽;ミュージック;ビデオ;動画;ディスク;リムーバブルメディ"
+"ア;媒体;自動起動;オートラン;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "場所を選択"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "OK(_O)"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "検索する場所"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"システムアプリケーション (ファイル、ビデオ、写真など) が検索対象にするフォル"
+"ダーです。"
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "場所"
+
+#: panels/search/cc-search-locations-dialog.ui:33
+msgid "Bookmarks"
+msgstr "ブックマーク"
+
+#: panels/search/cc-search-locations-dialog.ui:48
+msgid "Others"
+msgstr "その他"
+
+#: panels/search/cc-search-locations-dialog.ui:55
+msgid "Add Location"
+msgstr "場所を追加"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "アプリケーションが見つかりませんでした"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "アプリケーション検索"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "アプリケーション提供の検索結果を含みます。"
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "システムアプリケーションが検索対象にするフォルダーです。"
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "検索結果"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "検索結果はリストの順に表示されます。"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "アクティビティ画面で検索結果を表示するアプリケーションを設定します"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Find;Index;Hide;Privacy;Results;サーチ;検索;インデックス;索引;非表示;"
+"プライバシー;結果;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:265
+msgid "No networks selected for sharing"
+msgstr "共有するネットワークを選択していません"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "ネットワーク"
+
+#: panels/sharing/cc-sharing-panel.c:367
+msgctxt "service is enabled"
+msgid "On"
+msgstr "オン"
+
+#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "オフ"
+
+#: panels/sharing/cc-sharing-panel.c:399
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "有効"
+
+#: panels/sharing/cc-sharing-panel.c:402
+msgctxt "service is active"
+msgid "Active"
+msgstr "アクティブ"
+
+#: panels/sharing/cc-sharing-panel.c:520
+msgid "Choose a Folder"
+msgstr "フォルダーを選択"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:748
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"ファイル共有を使用して、現在のネットワークの他ユーザーが次の URI に接続し、あ"
+"なたの公開フォルダーを共有できるようにします: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:754
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"リモートログインを有効にした場合、リモートユーザーによる Secure Shell コマン"
+"ドを使用した接続を許可します:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "共有"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "コンピューター名(_C)"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "ファイル共有(_F)"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "リモートデスクトップ(_D)"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "メディア共有(_M)"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "リモートログイン(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "ファイル共有"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "パスワードを要求する(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "リモートログイン"
+
+#: panels/sharing/cc-sharing-panel.ui:250
+#: panels/sharing/cc-sharing-panel.ui:267
+msgid "Remote Desktop"
+msgstr "リモートデスクトップ"
+
+#: panels/sharing/cc-sharing-panel.ui:263
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"リモートデスクトップは、他のコンピューターからあなたのデスクトップを表示"
+"したり操作したりできるようにします。"
+
+#: panels/sharing/cc-sharing-panel.ui:268
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"このコンピューターへのリモートデスクトップ接続の有効/無効を切り替えます。"
+
+#: panels/sharing/cc-sharing-panel.ui:280
+msgid "Remote Control"
+msgstr "リモートコントロール"
+
+#: panels/sharing/cc-sharing-panel.ui:281
+msgid "Allows remote connections to control the screen."
+msgstr "リモート接続で画面を操作することを許可します。"
+
+#: panels/sharing/cc-sharing-panel.ui:294
+msgid "How to Connect"
+msgstr "接続方法"
+
+#: panels/sharing/cc-sharing-panel.ui:295
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"このコンピューターに接続するには、デバイス名かリモートデスクトップアドレ"
+"スを使用します。"
+
+#: panels/sharing/cc-sharing-panel.ui:323
+msgid "Remote Desktop Address"
+msgstr "リモートデスクトップアドレス"
+
+#: panels/sharing/cc-sharing-panel.ui:350
+msgid "Authentication"
+msgstr "認証"
+
+#: panels/sharing/cc-sharing-panel.ui:351
+msgid "The user name and password are required to connect to this computer."
+msgstr "このコンピューターへの接続にはユーザー名とパスワードが必要です。"
+
+#: panels/sharing/cc-sharing-panel.ui:355
+msgid "User Name"
+msgstr "ユーザー名"
+
+#: panels/sharing/cc-sharing-panel.ui:401
+msgid "Verify Encryption"
+msgstr "暗号化を検証"
+
+#: panels/sharing/cc-sharing-panel.ui:430
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:431
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:463
+msgid "Media Sharing"
+msgstr "メディア共有"
+
+#: panels/sharing/cc-sharing-panel.ui:485
+msgid "Share music, photos and videos over the network."
+msgstr "音楽や写真、ビデオをネットワーク上で共有できます。"
+
+#: panels/sharing/cc-sharing-panel.ui:498
+msgid "Folders"
+msgstr "フォルダー"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "他のユーザーと共有するものを設定します"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;共有;シェアリング;セキュアシェル;ホスト;名前;リモート;"
+"遠隔;デスクトップ;メディア;コンテンツ;オーディオ;音声;音楽;楽曲;ミュージック;"
+"ビデオ;動画;映像;画像;静止画;写真;フォト;ムービー;映画;サーバー;レンダラー;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "リモートログインの有効化/無効化"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "リモートログインを有効化または無効化するには認証が必要になります"
+
+#: panels/sound/cc-alert-chooser.c:150
+msgid "Custom"
+msgstr "その他"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr "犬が吠える音"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "Drip"
+msgstr "水が滴る音"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Glass"
+msgstr "ガラスを叩く音"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Sonar"
+msgstr "ソナーのピング音"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "リア"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "フロント"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s のテスト中"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "スピーカーをクリックしてテストしてください"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "システムの音量"
+
+#: panels/sound/cc-sound-panel.ui:25
+msgid "Volume Levels"
+msgstr "音量レベル"
+
+#: panels/sound/cc-sound-panel.ui:35
+msgid "Output"
+msgstr "出力"
+
+#: panels/sound/cc-sound-panel.ui:56
+msgid "Output Device"
+msgstr "出力デバイス"
+
+#: panels/sound/cc-sound-panel.ui:75
+msgid "Test"
+msgstr "テスト"
+
+#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+msgid "Configuration"
+msgstr "設定"
+
+#: panels/sound/cc-sound-panel.ui:135
+msgid "Balance"
+msgstr "バランス"
+
+#: panels/sound/cc-sound-panel.ui:161
+msgid "Fade"
+msgstr "フェード"
+
+#: panels/sound/cc-sound-panel.ui:187
+msgid "Subwoofer"
+msgstr "サブウーファー"
+
+#: panels/sound/cc-sound-panel.ui:205
+msgid "Input"
+msgstr "入力"
+
+#: panels/sound/cc-sound-panel.ui:226
+msgid "Input Device"
+msgstr "入力デバイス"
+
+#: panels/sound/cc-sound-panel.ui:294
+msgid "Volume"
+msgstr "音量"
+
+#: panels/sound/cc-sound-panel.ui:312
+msgid "Alert Sound"
+msgstr "警告音"
+
+#: panels/sound/cc-volume-slider.c:117
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "サウンド"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "サウンドレベルや入力、出力、警告音を設定します"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;カー"
+"ド;マイク;音量;フェード;バランス;ブルートゥース;ヘッドセット;オーディオ;"
+"Sound;サウンド;アウトプット;インプット;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "切断"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "接続中"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "接続"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "認証エラー"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "認証中"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "接続 & 認証"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "不明"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "認証日時:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "接続日時:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "登録日時:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "デバイスの認証に失敗しました: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "デバイスの削除に失敗しました: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+msgid "Name:"
+msgstr "名前:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+msgid "Status:"
+msgstr "ステータス:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+msgid "Authorize and Connect"
+msgstr "認証と接続"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+msgid "Forget Device"
+msgstr "デバイスを削除"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "エラー"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "認証"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Thunderbolt サブシステム (boltd) がインストールされていないか、正しくセット"
+"アップされていません。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:157
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "ドックや外付け GPU などのデバイスへのダイレクトアクセスを許可します。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "USB デバイスと DisplayPort デバイスのみ接続できます。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt を検出できませんでした。\n"
+"システムが Thunderbolt に対応していないか、または BIOS で Thunderbolt が無効"
+"になっているか、もしくは BIOS で Thunderbolt のセキュリティレベルが対応してい"
+"ない設定になっているかのいずれかです。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt サポートは BIOS で無効化されています。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Thunderbolt のセキュリティレベルを確認できませんでした。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "ダイレクトモードの切り替え中にエラーが発生しました: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt サポートがありません"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:104
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Thunderbolt サブシステムに接続できませんでした。"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:153
+msgid "Direct Access"
+msgstr "ダイレクトアクセス"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:225
+msgid "Pending Devices"
+msgstr "保留中のデバイス"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:319
+msgid "No devices attached"
+msgstr "デバイスが接続されていません"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Thunderbolt デバイスを管理します"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;プライバシー;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "カーソルの点滅"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+msgid "Cursor blinks in text fields."
+msgstr "テキストフィールドでカーソルを点滅させます。"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
+#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+msgid "Speed"
+msgstr "速度"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+msgid "Cursor blinking speed"
+msgstr "カーソルが点滅する速さです"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "カーソルの大きさ"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"ズーム機能と組み合わせてカーソルの大きさを設定することでカーソルがより見やす"
+"くなります。"
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "クリック支援"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "副ボタンのクリックの代替(_S)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "主ボタンを押したままにすると副ボタンのクリックとみなす"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "認識するまでの間隔(_C):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "短い"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "副ボタンのクリックの間隔"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "長い"
+
+# See also ja.po of mousetweak
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "ホバークリック(_H)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "ポインターの移動を停止したらクリック動作を行う"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "認識するまでの間隔(_E):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "短い"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "長い"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "ジェスチャーのしきい値(_T):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "小"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "大"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "リピートキー"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+msgid "Key presses repeat when key is held down."
+msgstr "キーを長押しすると繰り返しキー入力を行います。"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+msgid "Repeat keys delay"
+msgstr "リピートキーが行われるまでの時間です"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+msgid "Repeat keys speed"
+msgstr "押したキーをリピートするときの速さです"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "タイピング支援"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "固定キー(_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"修飾キーに続いてキーを押したらそのキーと修飾キーを同時に押したものと扱う"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "同時に 2 つのキーを押したら無効にする(_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "修飾キーを押したらビープ音を鳴らす(_M)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "スローキー(_L)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "キーを押下してから入力と認識されるまでに一定の間隔を設定する"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "短い"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "スローキーの入力間隔"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "長い"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "キーが押されたらビープ音を鳴らす(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "キー入力が受け付けられたらビープ音を鳴らす(_A)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "キー入力が拒否されたらビープ音を鳴らす(_R)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "バウンスキー(_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "同じキーを繰り返し押した場合は無視する"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "短い"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "バウンスキーの入力間隔"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "長い"
+
+#: panels/universal-access/cc-typing-dialog.ui:326
+msgid "_Enable by Keyboard"
+msgstr "キーボードから有効化できるようにする(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:336
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "アクセシビリティ機能のオン/オフをキーボードで切り替える"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:357
+msgctxt "cursor size"
+msgid "Default"
+msgstr "デフォルト"
+
+#: panels/universal-access/cc-ua-panel.c:360
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "中"
+
+#: panels/universal-access/cc-ua-panel.c:363
+msgctxt "cursor size"
+msgid "Large"
+msgstr "大"
+
+#: panels/universal-access/cc-ua-panel.c:366
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "特大"
+
+#: panels/universal-access/cc-ua-panel.c:369
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "最大"
+
+#: panels/universal-access/cc-ua-panel.c:373
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d ピクセル"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "常にアクセシビリティメニューを表示する(_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "見る"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "ハイコントラスト(_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "大きな文字(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "アニメーションを有効にする(_N)"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "スクリーンリーダー(_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"スクリーンリーダーを有効にすると、フォーカスのある画面のテキストを音声で読み"
+"上げます。"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "切り替えキー(_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Caps Lock と Num Lock の ON/OFF が切り替わるとビープ音を鳴らします。"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "カーソルの大きさ(_U)"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "ズーム(_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "聞く"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "視覚警告(_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "スクリーンキーボード(_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "リピートキー(_E)"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "カーソルの点滅(_B)"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "タイピング支援 [AccessX](_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "ポインター操作とクリック"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "マウスキー(_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "ポインターの位置確認(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "クリック支援(_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "ダブルクリックと認識する間隔(_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "ダブルクリックと認識する間隔"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "視覚警告"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "動作確認(_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "警告音が鳴った場合に視覚的に警告を表示します。"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "画面全体をひらめかせる(_S)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "ウィンドウ全体をひらめかせる(_W)"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "短い"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "画面の¼"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "画面の½"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "画面の¾"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "長い"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "フルスクリーン"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "上半分"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "下半分"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "左半分"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "右半分"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "ズームオプション"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "拡大率(_M):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "拡大領域の位置:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "マウスカーソルの動きを追う(_F)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "拡大部分(_S):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "画面の外側も表示する(_E)"
+
+# 旧来のユーザーのために旧Orcaでの名称を括弧内に併記
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "カーソルを画面中央にキープする (中央)(_K)"
+
+# 旧来のユーザーのために旧Orcaでの名称を括弧内に併記
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "拡大領域を押し出すように移動する (プッシュ)(_P)"
+
+# 旧来のユーザーのために旧Orcaでの名称を括弧内に併記
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "カーソルの動きに拡大領域を移動する (プロポーショナル)(_C)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "拡大鏡"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "照準線(_C):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "マウスカーソルに重ねる(_O)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "太さ(_T):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "細い"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "太い"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "長さ(_L):"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "色(_L):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "照準線"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "色の設定:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "反転(_W):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "明るさ(_B):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "コントラスト(_C):"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "色(_L)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "白黒"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "カラー"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "暗い"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "明るい"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "低い"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "高い"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "色の設定"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"見る、聞く、タイピング、クリック操作など、コンピューターを簡単に使えるように"
+"します"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;キーボード;マウス;アクセシビリティ;コントラスト;カーソル;サウン"
+"ド;ズーム;拡大鏡;スクリーンリーダー;大きい;高;大きさ;テキスト;文字;フォント;"
+"サイズ;固定;キー;スロー;バウンス;ダブルクリック;ディレイ;遅延;速度;スピード;"
+"ユーザー支援;リピート;点滅;ビジュアル;視覚;ヒアリング;聴覚;音声;タイピング;ユ"
+"ニバーサルアクセス;animations;アニメーション;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 時間"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 日"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 日"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 日"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 日"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 日"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 日"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 日"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 日"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 日"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "ゴミ箱からすべてのアイテムを削除しますか?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "ここでアイテムを削除すると元に戻すことはできません。"
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "ゴミ箱を空にする(_E)"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "一時ファイルをすべて削除しますか?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "一時ファイルは完全に削除されます。"
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "一時ファイルを削除する(_P)"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 日"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 日"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 日"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "無期限"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "ファイル履歴"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"ファイルを使用するとファイル履歴に記録されます。この情報はアプリケーション間"
+"で共有されるため、使用したいファイルを見つけやすくなります。"
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "ファイル履歴(_I)"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "ファイル履歴の期間(_H)"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "履歴を消去(_C)…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "ゴミ箱と一時ファイル"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"ゴミ箱へ移動したファイルや一時ファイルを自動的に削除するようにしておくと、そ"
+"こに個人情報や機密情報が含まれていたとしても、プライバシーを保つことができま"
+"す。"
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "ゴミ箱の内容を自動的に削除する(_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "一時ファイルを自動的に削除する(_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "自動的に削除する期間(_P)"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "ゴミ箱を空にする(_E)…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "一時ファイルを削除する(_D)…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "ファイルの履歴と削除"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "痕跡を残さないようにします"
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "ログイン提供者のウェブアドレスと一致させる必要があります。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "アカウントの追加に失敗しました"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.c:258
+msgid "The passwords do not match."
+msgstr "パスワードが一致しません。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "アカウントの登録に失敗しました"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "このドメインで認証を行う方法はサポートしていません"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "ドメインの参加に失敗しました"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"ログイン名に問題がありました。\n"
+"やり直してください。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"パスワードに問題がありました。\n"
+"やり直してください。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "ドメインへのログインに失敗しました"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "ドメインを見つけられません。スペルミスがないか確認してください。"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "ユーザーを追加"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "管理者"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"管理者は他のユーザーの追加、削除、設定の変更ができます。管理者をペアレンタル"
+"コントロールで管理することはできません。"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "ユーザーの初回ログイン時にパスワードを設定する"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "今すぐパスワードを設定する"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "確認"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "エンタープライズログイン"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organisation."
+msgstr "会社や組織に管理されているユーザーアカウントです。"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:385
+msgid "You are Offline"
+msgstr "現在オフラインです"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:386
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"エンタープライズログインでは、中央管理された既存のユーザーアカウントをこのデ"
+"バイスで使用できます。このアカウントを使用して、インターネット上の企業内の各"
+"種リソースにアクセスすることができます。"
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "他の画像を参照"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "ファイルを選択…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "指紋認証マネージャー"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "指紋認証"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+msgid "_No"
+msgstr "いいえ(_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+msgid "_Yes"
+msgstr "はい(_Y)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "登録済みの指紋情報を削除して指紋認証を無効にしますか?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+msgid "No fingerprint device"
+msgstr "指紋認証デバイスがありません"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+msgid "No Fingerprint device"
+msgstr "指紋認証デバイスがありません"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+msgid "Ensure the device is properly connected."
+msgstr "デバイスが正しく接続されていることを確認してください。"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+msgid "Fingerprint Device"
+msgstr "指紋認証デバイス"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+msgid "Choose the fingerprint device you want to configure"
+msgstr "設定する指紋認証デバイスを選択してください"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+msgid "Fingerprint Login"
+msgstr "指紋認証ログイン"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"指紋認証ログインは指を使ってコンピューターにログインしたりロックを解除したり"
+"できるようにします"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+msgid "_Delete Fingerprints"
+msgstr "指紋情報を削除(_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+msgid "Fingerprint Enroll"
+msgstr "指紋の登録"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "指紋リーダーとの通信に失敗しました"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "指紋認証デーモンとの通信に失敗しました"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "指紋情報の一覧を表示できませんでした: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "保存された指紋情報の削除に失敗しました: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "左の親指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "左の中指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "左の人差し指(_L)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "左の薬指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "左の小指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "右の親指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "右の中指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "右の人差し指(_R)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "右の薬指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "右の小指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "不明な指です"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "完了"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "指紋認証デバイスが切断されました"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "指紋認証デバイスの登録数が上限に達しています"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "新しい指紋の登録に失敗しました"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "登録を開始できませんでした: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "新しい指紋の登録に失敗しました"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "登録を停止できませんでした: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr "指紋リーダーに指を何度か押し付けて指紋を登録してください"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "この指を再登録(_R)…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "新しい指紋の採取"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "デバイスの読み取りに問題があります"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "指紋認証デバイスの取得に失敗しました: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "今週"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "先週"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%B%-e日"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%Y年%B%-e日"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+# %k:%M よりも %H:%M の方がガタガタしていなくて見やすい (sicklylife)
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:712
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%H:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:716
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "セッション終了"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "セッション開始"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — アカウントのアクティビティ"
+
+#: panels/user-accounts/cc-password-dialog.c:133
+msgid "Please choose another password."
+msgstr "他のパスワードを選択してください。"
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Please type your current password again."
+msgstr "現在のパスワードを再度入力してください。"
+
+#: panels/user-accounts/cc-password-dialog.c:148
+msgid "Password could not be changed"
+msgstr "パスワードを変更できません"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "パスワードを変更"
+
+#: panels/user-accounts/cc-password-dialog.ui:32
+msgid "Ch_ange"
+msgstr "変更(_A)"
+
+#: panels/user-accounts/cc-password-dialog.ui:51
+msgid "Current Password"
+msgstr "現在のパスワード"
+
+#: panels/user-accounts/cc-password-dialog.ui:76
+msgid "New Password"
+msgstr "新しいパスワード"
+
+#: panels/user-accounts/cc-password-dialog.ui:121
+msgid "Confirm Password"
+msgstr "パスワードの確認"
+
+#: panels/user-accounts/cc-password-dialog.ui:175
+msgid "Allow user to change their password on next login"
+msgstr "次回ログイン時にユーザー自身にパスワードを設定させる"
+
+#: panels/user-accounts/cc-password-dialog.ui:186
+msgid "Set a password now"
+msgstr "今すぐパスワードを設定する"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "このタイプのドメインは自動で参加できません"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "そのようなドメインやレルムは見つかりませんでした"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%2$s ドメインに %1$s としてログインできません"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "不正なパスワードです、やり直してください"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "%s ドメインに接続できませんでした: %s"
+
+#: panels/user-accounts/cc-user-panel.c:341
+msgid "Failed to delete user"
+msgstr "ユーザーの削除に失敗しました"
+
+#: panels/user-accounts/cc-user-panel.c:398
+#: panels/user-accounts/cc-user-panel.c:453
+#: panels/user-accounts/cc-user-panel.c:499
+msgid "Failed to revoke remotely managed user"
+msgstr "リモート管理ユーザーの削除に失敗しました"
+
+#: panels/user-accounts/cc-user-panel.c:548
+msgid "You cannot delete your own account."
+msgstr "自分自身のアカウントは削除できません。"
+
+#: panels/user-accounts/cc-user-panel.c:557
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s はまだログインしています"
+
+#: panels/user-accounts/cc-user-panel.c:561
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"ログイン中のユーザーを削除すると、システムが不整合な状態になることがありま"
+"す。"
+
+#: panels/user-accounts/cc-user-panel.c:570
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "%s のファイルを残しますか?"
+
+#: panels/user-accounts/cc-user-panel.c:574
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"ユーザーアカウントを削除するときに、ユーザーのホームディレクトリ、メールス"
+"プールおよび一時ファイルを残しておくことができます。"
+
+#: panels/user-accounts/cc-user-panel.c:577
+msgid "_Delete Files"
+msgstr "ファイルを削除(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:578
+msgid "_Keep Files"
+msgstr "ファイルを残す(_K)"
+
+#: panels/user-accounts/cc-user-panel.c:592
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "本当にリモート管理の %s のアカウントを削除しますか?"
+
+#: panels/user-accounts/cc-user-panel.c:596
+msgid "_Delete"
+msgstr "削除(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:646
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "無効アカウント"
+
+#: panels/user-accounts/cc-user-panel.c:654
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "次回ログイン時に設定"
+
+#: panels/user-accounts/cc-user-panel.c:657
+msgctxt "Password mode"
+msgid "None"
+msgstr "なし"
+
+#: panels/user-accounts/cc-user-panel.c:700
+msgid "Logged in"
+msgstr "ログイン中"
+
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:787
+#: panels/user-accounts/cc-user-panel.c:876
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "有効"
+
+#: panels/user-accounts/cc-user-panel.c:1173
+msgid "Failed to contact the accounts service"
+msgstr "アカウントサービスの接続に失敗しました"
+
+#: panels/user-accounts/cc-user-panel.c:1175
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"AccountService がインストールされ、有効になっているか確認してください。"
+
+#: panels/user-accounts/cc-user-panel.c:1197
+msgid "This panel must be unlocked to change this setting"
+msgstr "この設定を変更するにはパネルのロックを解除する必要があります"
+
+#: panels/user-accounts/cc-user-panel.c:1264
+msgid "Delete the selected user account"
+msgstr "選択したユーザーアカウントを削除します"
+
+#: panels/user-accounts/cc-user-panel.c:1268
+#: panels/user-accounts/cc-user-panel.c:1377
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"選択したユーザーアカウントを削除するには、\n"
+"まず * アイコンをクリックしてください"
+
+#: panels/user-accounts/cc-user-panel.c:1423
+msgid "Unlock to Add Users and Change Settings"
+msgstr "設定の変更やユーザーを追加する場合はロックを解除してください"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "ユーザー"
+
+#: panels/user-accounts/cc-user-panel.ui:60
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "変更内容を反映させるにはログインし直す必要があります"
+
+# ユーザー設定を変更すると表示されるボタンのラベル。クリックするとログアウトダイアログが表示されます。
+#: panels/user-accounts/cc-user-panel.ui:67
+msgid "Restart Now"
+msgstr "ログアウト"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:195
+msgid "_Fingerprint Login"
+msgstr "指紋認証ログイン(_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:218
+msgid "A_utomatic Login"
+msgstr "自動ログイン(_U)"
+
+#: panels/user-accounts/cc-user-panel.ui:231
+msgid "Account Activity"
+msgstr "アカウントのアクティビティ"
+
+#: panels/user-accounts/cc-user-panel.ui:259
+msgid "_Administrator"
+msgstr "管理者(_A)"
+
+#: panels/user-accounts/cc-user-panel.ui:260
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr "管理者は他のユーザーの追加、削除、設定の変更ができます。"
+
+#: panels/user-accounts/cc-user-panel.ui:276
+msgid "_Parental Controls"
+msgstr "ペアレンタルコントロール(_P)"
+
+#: panels/user-accounts/cc-user-panel.ui:277
+msgid "Open the Parental Controls application."
+msgstr "ペアレンタルコントロールアプリケーションを開きます。"
+
+#: panels/user-accounts/cc-user-panel.ui:328
+msgid "Remove User…"
+msgstr "ユーザーを削除…"
+
+#: panels/user-accounts/cc-user-panel.ui:340
+msgid "Other Users"
+msgstr "他のユーザー"
+
+#: panels/user-accounts/cc-user-panel.ui:353
+msgid "Add User…"
+msgstr "ユーザーを追加…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:381
+msgid "No Users Found"
+msgstr "ユーザーが見つかりませんでした"
+
+#: panels/user-accounts/cc-user-panel.ui:390
+msgid "Unlock to add a user account."
+msgstr "ユーザーアカウントのロックを解除します。"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "ユーザーの追加と削除、パスワードの変更を行います"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;ログイン;"
+"名前;指紋認証;アバター;ロゴ;顔;パスワード;ペアレンタルコントロール;スクリーン"
+"タイム;アプリの使用制限;ウェブの閲覧制限;使用量;使用制限;使用上限;子供;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "登録(_E)"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "ドメイン管理者のログイン"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"エンタープライズログインを使用するには、このコンピューターを\n"
+"ドメインに登録する必要があります。ネットワーク管理者にドメインの\n"
+"パスワード入力を行ってもらってください。"
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "管理者名(_N)"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "管理者のパスワード"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "ユーザーアカウントの管理"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "ユーザーのデータを変更するには認証が必要になります"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr ""
+"新しいパスワードは、現在のパスワードとは異なるものを指定する必要があります。"
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "いくつかの文字や数字を変更してください。"
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr ""
+"新しいパスワードが現在のものと似すぎています。もう少し異なるものを使用してく"
+"ださい。"
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "パスワードからユーザー名を取り除くともっと強くなるでしょう。"
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "パスワード中にユーザーの氏名を使うのは避けるようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "パスワードにある一部の単語を使わないようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "一般的な単語は避けるようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "既存の単語の文字を並べ替えたものは使わないようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "数字をもっと使うようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "大文字をもっと使うようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "小文字をもっと使うようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "記号など特殊文字をもっと使うようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "アルファベット、数字、記号を混在させるようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "同じ文字を連続して使わないようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"同じ種類の文字の繰り返しは避けるようにしてください。アルファベット、数字、記"
+"号を混ぜてください。"
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 や abcd などの連続した並びは避けるようにしてください。"
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"パスワードが短すぎます。アルファベット、数字、記号をもっと追加するようにして"
+"ください。"
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "大文字、小文字を混在させ、さらに数字を 1 つか 2 つ含めてください。"
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "さらに文字や数字、記号を追加すると、もっと強くなります。"
+
+#: panels/user-accounts/run-passwd.c:413
+msgid "Authentication failed"
+msgstr "認証に失敗しました"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The new password is too short"
+msgstr "新しいパスワードは短すぎます"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password is too simple"
+msgstr "新しいパスワードは単純すぎます"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "新旧 2 つのパスワードが似すぎています"
+
+#: panels/user-accounts/run-passwd.c:507
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "新しいパスワードは最近使用したものです。"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "新しいパスワードには数字または特殊文字を含めてください"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "新旧のパスワードが同一です"
+
+#: panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "最初に認証を行った以降にパスワードが変更されています!"
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "新しいパスワードには十分な種類の文字が含まれていません"
+
+#: panels/user-accounts/run-passwd.c:526
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "原因不明のエラー"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"ユーザー名には小文字の“a”から“z”、数字の“0”から“9”、記号の“-”と“_”のみを使用"
+"してください。"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"申し訳ありませんが、そのユーザー名は使用できません。他の名前を試してくださ"
+"い。"
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "ユーザー名が長すぎます。"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+msgid "Map Buttons"
+msgstr "ボタン割り当て"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "ボタンへ機能を割り当て"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ショートカットを編集するには、“キー入力の送信”を選択し、キーボードショート"
+"カットボタンを押して、新しいキー組み合わせを入力するか、[BS] キーで取り消して"
+"ください。"
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "閉じる(_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"タブレットの位置調整を行いますので、画面に出現するマーカーをタップしてくださ"
+"い。"
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "誤クリックを検出しました。再起動します…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "ボタン %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "アプリケーション定義"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "キー入力の送信"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "モニターの切り替え"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "オンスクリーンヘルプの表示"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "外付けのタブレットデバイス"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "すべてのディスプレイ"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "タブレットモード"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:27
+msgid "Left Hand Orientation"
+msgstr "左手用"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+# 参考: intuos 5 のマニュアル p.57
+#: panels/wacom/cc-wacom-page.ui:56
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "画面にマッピング"
+
+#: panels/wacom/cc-wacom-page.ui:62
+msgid "Keep Aspect Ratio"
+msgstr "縦横比を保持"
+
+#: panels/wacom/cc-wacom-page.ui:63
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:73
+msgid "Calibrate"
+msgstr "キャリブレート"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "タブレットを検出できません"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "ワコムタブレットを接続するか、電源を入れてください。"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "ペン先の感触"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "ボタン 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ボタン 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ボタン 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "消しゴムの感触"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "ワコムタブレット"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"グラフィックスタブレットのボタン割り当てやスタイラスの感度の設定をします。"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+"Tablet;Wacom;Stylus;Eraser;Mouse;タブレット;スタイラスペン;ペン;消しゴム;マウ"
+"ス;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "新しいショートカット…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "アクセスポイント"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:122
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "モデムの詳細"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "モデムの状態"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "キャリア"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "ネットワークの種類"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "ネットワークの状態"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "デバイスの詳細"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "ファームウェアのバージョン"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G のみ"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G のみ"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G のみ"
+
+#: panels/wwan/cc-wwan-device.c:1003
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (優先)"
+
+#: panels/wwan/cc-wwan-device.c:1005
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (優先), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (優先), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (優先)"
+
+#: panels/wwan/cc-wwan-device.c:1017
+msgid "3G (Preferred), 4G"
+msgstr "3G (優先), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1019
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1025
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (優先)"
+
+#: panels/wwan/cc-wwan-device.c:1027
+msgid "2G (Preferred), 4G"
+msgstr "2G (優先), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1029
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (優先)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "2G (Preferred), 3G"
+msgstr "2G (優先), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1043
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "不明"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "SIM カードのロック解除"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "ロック解除"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "SIM %d の PIN コードが必要です"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "SIM カードのロックを解除する PIN を入力してください"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "SIM %d の PUK コードが必要です"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "SIM カードのロックを解除する PUK を入力してください"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "違うパスワードを入力しました (残り %1$u 回)"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "残り %u 回"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "違うパスワードを入力しました。"
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK コードは 8 桁です"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "新しい PIN を入力してください"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN コードは 4-8 桁です"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "ロック解除…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "SIM なし"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "モデムに SIM カードを挿入してください"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM はロックされています"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "モバイルデータ(_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "モバイルネットワークでデータにアクセスします"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "データローミング(_D)"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "ローミング時にモバイルデータを使用します"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "ネットワークモード(_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "ネットワーク(_E)"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "高度"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "アクセスポイント名(_A)"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "SIM ロック(_S)"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "PIN で SIM をロックします"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "モデムの詳細(_O)"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "携帯端末に接続していません"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "操作の許可がありません"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "操作をサポートしていません"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM が挿入されていません"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIM の PIN が必要です"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIM の PUK が必要です"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM がビジーです"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "パスワードが違います"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM の PIN2 が必要です"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM の PUK2 が必要です"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "見つかりませんでした"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "ネットワークサービスがありません"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "ネットワークがタイムアウトしました"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS サービスの許可がありません"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "このエリアでのローミングの許可がありません"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "特定できない GPRS エラー"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "Action Cancelled"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Access denied"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:103
+msgid "Unknown Error"
+msgstr "原因不明のエラー"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "ネットワークモード"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:146
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "設定(_S)"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
+msgid "Close"
+msgstr "閉じる"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:69
+msgid "_Automatic"
+msgstr "自動(_A)"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:84
+msgid "Choose Network"
+msgstr "ネットワークを選択"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:99
+msgid "Refresh Network Providers"
+msgstr "ネットワークプロバイダーを更新"
+
+#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "モバイルネットワークを有効にする"
+
+#: panels/wwan/cc-wwan-panel.ui:94
+msgid "No WWAN Adapter Found"
+msgstr "WWAN アダプターが見つかりませんでした"
+
+#: panels/wwan/cc-wwan-panel.ui:104
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "ワイヤレス Wan/Cellular デバイスを確認してください"
+
+#: panels/wwan/cc-wwan-panel.ui:145
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "機内モードがオンの場合ワイヤレス WAN は使用できません"
+
+#: panels/wwan/cc-wwan-panel.ui:153
+msgid "_Turn off Airplane Mode"
+msgstr "機内モードをオフにする(_T)"
+
+#: panels/wwan/cc-wwan-panel.ui:184
+msgid "Data Connection"
+msgstr "データ接続"
+
+#: panels/wwan/cc-wwan-panel.ui:185
+msgid "SIM card used for internet"
+msgstr "SIM カードをインターネットに使用します"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM ロック"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "次へ(_N)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+msgid "_Lock SIM with PIN"
+msgstr "PIN で SIM をロックする(_L)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+msgid "Change PIN"
+msgstr "PIN を変更"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "SIM ロック設定の変更のために現在の PIN を入力してください"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "モバイルネットワーク"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "モバイルデータ接続やテレフォニー接続を設定します"
+
+#. FIXME
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+"cellular;wwan;telephony;sim;mobile;セルラー;ワイヤレスワイドエリアネットワー"
+"ク;テレフォニー;モバイル;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "GNOME デスクトップの設定ユーティリティ"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "“設定”はシステム設定用のプライマリインターフェースです。"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:17
+msgid "GNOME Settings Sound Panel"
+msgstr "GNOME Settings サウンドパネル"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:21
+msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+msgstr "GNOME Settings マウス &amp; タッチパッドパネル"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:25
+msgid "GNOME Settings Background Panel"
+msgstr "GNOME Settings 背景パネル"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:29
+msgid "GNOME Settings Keyboard Panel"
+msgstr "GNOME Settings キーボードパネル"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:38
+msgid "The GNOME Project"
+msgstr "The GNOME Project"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "バージョン番号を表示する"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "冗長モードを有効にする"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "キーワードで検索する"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "利用可能なパネル名をリスト表示して終了する"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "表示するパネル"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "プライバシー"
+
+#: shell/cc-panel-loader.c:301
+msgid "Available panels:"
+msgstr "利用可能なパネル:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "すべての設定"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "プライマリメニュー"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "警告: 開発版です"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"このバージョンの“設定”は、開発目的の場合にのみ使用してください。システムの不"
+"正動作、データ消失、その他の予期せぬ不具合が発生する可能性があります。"
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "ヘルプ"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "全般"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "終了する"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "検索"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "パネル"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "前の画面に戻る"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "検索をキャンセルする"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;設定;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "最後に開いた設定パネルの識別子"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"最後に開いた設定パネルの識別子です。値を認識できない場合は無視して一覧の最初"
+"のパネルを選択します。"
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "“設定”の開発版を起動したときに警告を表示する"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "開発版を起動したときに“設定”が警告を表示するかどうかです。"
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "ウィンドウの初期状態"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"アプリケーションの初期幅、初期高さ、最大化状態を含むタプルです。"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1907
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u 出力"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1917
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u 入力"
+
+#: subprojects/gvc/gvc-mixer-control.c:2867
+msgid "System Sounds"
+msgstr "システムのサウンド"
+
+#~ msgid "Web Links"
+#~ msgstr "ウェブリンク"
+
+#~ msgid "Git Links"
+#~ msgstr "Git リンク"
+
+#~ msgid "%s Links"
+#~ msgstr "%s リンク"
+
+#~ msgid "Unset"
+#~ msgstr "削除"
+
+#~ msgid "Links"
+#~ msgstr "リンク"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "ハイパーテキストファイル"
+
+#~ msgid "Text Files"
+#~ msgstr "テキストファイル"
+
+#~ msgid "Image Files"
+#~ msgstr "画像ファイル"
+
+#~ msgid "Font Files"
+#~ msgstr "フォントファイル"
+
+#~ msgid "Archive Files"
+#~ msgstr "アーカイブファイル"
+
+#~ msgid "Package Files"
+#~ msgstr "パッケージファイル"
+
+#~ msgid "Audio Files"
+#~ msgstr "オーディオファイル"
+
+#~ msgid "Video Files"
+#~ msgstr "ビデオファイル"
+
+#~ msgid "Other Files"
+#~ msgstr "その他のファイル"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "パーミッションとアクセス"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr "このアプリが要求している権限です。"
+
+#~ msgid "Cannot be changed"
+#~ msgstr "変更できません"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "アプリケーションごとの権限設定は<a href=\"privacy\">プライバシー</a>設定に"
+#~ "もあります。"
+
+#~ msgid "Integration"
+#~ msgstr "統合"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "デスクトップの背景の設定"
+
+#~ msgid "Default Handlers"
+#~ msgstr "デフォルトのハンドラ"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "このアプリケーションで開くファイルとリンクの種類です。"
+
+#~ msgid "Usage"
+#~ msgstr "使用"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "このアプリケーションが使用中のリソース量です。"
+
+#~ msgid "Open in Software"
+#~ msgstr "“ソフトウェア”で開く"
+
+#~ msgid "Activities"
+#~ msgstr "アクティビティ"
+
+#~ msgid "Change your background image to a wallpaper or photo"
+#~ msgstr "背景画像を壁紙や写真に変更します"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "以下のアプリケーションがカメラを使用することを許可します。"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "ファイルのアップロードに失敗しました: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "プロファイルがアップロードされました:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "この URL をメモしてください。"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "このコンピューターを再起動して通常のオペレーティングシステムを起動してくだ"
+#~ "さい。"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "ブラウザーで URL を入力し、プロファイルをダウンロードしてインストールして"
+#~ "ください。"
+
+#~ msgid "Upload profile"
+#~ msgstr "プロファイルのアップロード"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "インターネット接続が必要です"
+
+#~ msgid "_Copy"
+#~ msgstr "コピー(_C)"
+
+#~ msgid "Select _All"
+#~ msgstr "すべて選択(_A)"
+
+#~ msgid "Single Display"
+#~ msgstr "シングルディスプレイ"
+
+#~ msgid "Join Displays"
+#~ msgstr "画面を拡張"
+
+#~ msgid "Display Mode"
+#~ msgstr "ディスプレイモード"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "実際の配置に合わせてディスプレイをドラッグしてください。設定を変更するに"
+#~ "は、ディスプレイを選択してください。"
+
+#~ msgid "Active Display"
+#~ msgstr "アクティブディスプレイ"
+
+#~ msgid "Display Configuration"
+#~ msgstr "ディスプレイの設定"
+
+#~ msgid "More Warm"
+#~ msgstr "濃い暖色"
+
+#~ msgid "Less Warm"
+#~ msgstr "薄い暖色"
+
+#~ msgid "Screenshots"
+#~ msgstr "スクリーンショット"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "スクリーンショットを$PICTURESフォルダーに保存する"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "ウィンドウのスクリーンショットを$PICTURESフォルダーに保存する"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "選択領域のスクリーンショットを$PICTURESフォルダーに保存する"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "スクリーンショットをクリップボードにコピーする"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "ウィンドウのスクリーンショットをクリップボードにコピーする"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "選択領域のスクリーンショットをクリップボードにコピーする"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "スクリーンキャストを撮る"
+
+#~ msgid "Move up"
+#~ msgstr "上へ"
+
+#~ msgid "Move down"
+#~ msgstr "下へ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 分"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "ダブルクリックと認識される最長クリック間隔"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "サスペンド, 電源ボタン"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "ハードウェアが高温です: パフォーマンスモードは利用できません"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "パフォーマンスモードは利用できません"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "認証"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "数値、日時、通貨の形式を選択してください。変更は次回ログイン時に反映されま"
+#~ "す。"
+
+#~ msgid "My Account"
+#~ msgstr "自分のアカウント"
+
+#~ msgid "Language"
+#~ msgstr "言語"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "ウェブページやウィンドウのテキストで使われる言語です。"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "変更内容を反映させるにはログインし直す必要があります"
+
+# 言語設定を変更すると表示されるボタンのラベル。クリックするとログアウトダイアログが表示されます。
+#~ msgid "Restart…"
+#~ msgstr "ログアウト…"
+
+#~ msgid "The format used for numbers, dates, and currencies."
+#~ msgstr "数値、日時、通貨の形式です。"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "ログイン画面の設定はすべてのユーザーがログイン時に使用します"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "アクティビティ画面で、どれの検索結果を表示するかを設定します。一覧の項目を"
+#~ "入れ替えると、検索結果の表示順が変更されます。"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "スクリーン共有を許可した場合、リモートユーザーは次の URI に接続して画面の"
+#~ "表示や操作を行うことができます: %s"
+
+#~ msgid "Copy"
+#~ msgstr "コピー"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "画面共有(_S)"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "ネットワークに接続していないため無効になっているサービスがあります。"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "画面共有"
+
+#~ msgid "_Allow connections to control the screen"
+#~ msgstr "このスクリーンを操作する接続を許可する(_A)"
+
+#~ msgid "_Password:"
+#~ msgstr "パスワード(_P):"
+
+#~ msgid "_Show Password"
+#~ msgstr "パスワードを表示する(_S)"
+
+#~ msgid "Access Options"
+#~ msgstr "アクセスオプション"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "新規接続の場合アクセス要求を必要とする(_N)"
+
+#~ msgid "_Require a password"
+#~ msgstr "パスワードを要求する(_R)"
+
+# 直訳するなら「サウンドキー」のようになるが、この直訳ではユーザーに意味を誤解されるおそれがある。
+# Windows では、これに相当する機能は「Toggle Keys」と呼ばれており[1]、その日本語訳は「切り替えキー」である[2]。
+# 「切り替えキー」もわかりやすいとは言いづらいが、Windows側の機能を知っているユーザーには類推できること、またWeb検索などで機能を特定しやすいこと、「サウンドキー」よりかは幾分ましであること、などを考慮し「切り替えキー」を採用する。
+# [1] http://windows.microsoft.com/en-us/Windows7/Make-the-keyboard-easier-to-use
+# [2] http://windows.microsoft.com/ja-JP/Windows7/Make-the-keyboard-easier-to-use
+#~ msgid "Sound Keys"
+#~ msgstr "切り替えキー"
+
+#~ msgid "Screen Reader"
+#~ msgstr "スクリーンリーダー"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "スクリーンリーダー(_S)"
+
+#~ msgid "_Full Name"
+#~ msgstr "フルネーム(_F)"
+
+#~ msgid "Standard"
+#~ msgstr "標準"
+
+#~ msgid "Account _Type"
+#~ msgstr "アカウントの種類(_T)"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "次回ログイン時にユーザー自身にパスワードを設定させる(_L)"
+
+#~ msgid "Set a password _now"
+#~ msgstr "今パスワードを設定する(_N)"
+
+#~ msgid "_Confirm"
+#~ msgstr "確認(_C)"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "エンタープライズユーザーを追加するには、システムをオンラインにする必要があ"
+#~ "ります。"
+
+#~ msgid "_Enterprise Login"
+#~ msgstr "エンタープライズログイン(_E)"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "写真を撮る…"
+
+#~ msgid "Your account"
+#~ msgstr "あなたのアカウント"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr "変更するには、まず * アイコンをクリックしてください"
+
+#~ msgid "Create a user account"
+#~ msgstr "ユーザーアカウントを作成します"
+
+#~ msgid "User Icon"
+#~ msgstr "ユーザーアイコン"
+
+#~ msgid "Account Settings"
+#~ msgstr "アカウント設定"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "認証とログイン"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "ユーザー名はホームフォルダーの名前に使用されます。これは変更できません。"
+
+#~ msgid "Output:"
+#~ msgstr "出力:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "縦横比を保持 (レターボックス):"
+
+# 参考: intuos 5 のマニュアル p.57
+#~ msgid "Map to single monitor"
+#~ msgstr "単一画面にマッピング"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d / %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "画面のマッピング"
+
+#~ msgid "Stylus"
+#~ msgstr "ペン"
+
+#~ msgid "Button"
+#~ msgstr "ボタン"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "タブレット(絶対座標)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "タッチパッド(相対座標)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "タブレット設定"
+
+#~ msgid "_Help"
+#~ msgstr "ヘルプ(_H)"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth の設定"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "検出モード"
+
+#~ msgid "Left-Handed Orientation"
+#~ msgstr "左手用"
+
+# 参考: intuos 5 のマニュアル p.57
+#~ msgid "Map to Monitor…"
+#~ msgstr "画面にマッピング…"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "ボタン割り当て…"
+
+#~ msgid "Calibrate…"
+#~ msgstr "キャリブレート…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "マウス設定の調整"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "ディスプレイの解像度を調整"
+
+#~ msgid "Default"
+#~ msgstr "デフォルト"
+
+#~ msgid "Middle Mouse Button Click"
+#~ msgstr "マウスの中ボタンクリック"
+
+#~ msgid "Right Mouse Button Click"
+#~ msgstr "マウスの右ボタンクリック"
+
+#~ msgid "Forward"
+#~ msgstr "進む"
+
+#~ msgid "No stylus found"
+#~ msgstr "スタイラスペンが見つかりません"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "スタイラスペンをタブレットの近くに移動して設定を行ってください"
+
+#~ msgid "Soft"
+#~ msgstr "柔らかい"
+
+#~ msgid "Firm"
+#~ msgstr "硬い"
+
+#~ msgid "Top Button"
+#~ msgstr "上のサイドスイッチ"
+
+#~ msgid "Lower Button"
+#~ msgstr "下のサイドスイッチ"
+
+#~ msgid "Lowest Button"
+#~ msgstr "一番下のボタン"
+
+#~ msgid "Left Alt"
+#~ msgstr "左 Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "右 Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "左 Super"
+
+#~ msgid "Right Super"
+#~ msgstr "右 Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "右 Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "代替文字キー"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "次の入力ソースへ切り替える (修飾キーのみ)"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "メニューキー"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "押下しながらキー入力すると別の文字を入力できます"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "充電中"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "注意"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "少ない"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "充分"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "フル充電"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "空"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "画面の明るさ(_S)"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "キーボードの明るさ(_K)"
+
+#~ msgid "_Dim Screen When Inactive"
+#~ msgstr "操作していないときに画面を暗くする(_D)"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "ブランクスクリーン(_B)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "Wi-Fi(_W)"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wi-Fi をオフにすると節電できます。"
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "モバイルブロードバンド (LTE、4G、3G など) をオフにすると節電できます。"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "Bluetooth(_B)"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth をオフにすると節電できます。"
+
+#~ msgid "Add…"
+#~ msgstr "追加…"
+
+#~ msgid "Previous source"
+#~ msgstr "前のソース"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "次のソース"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "左Alt+右Alt"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;ログイン;名前;指紋;アバ"
+#~ "ター;ロゴ;顔;パスワード;Users;ユーザー;"
+
+#~ msgid "Universal Access"
+#~ msgstr "ユニバーサルアクセス"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Wi-Fi ネットワークに接続する場合はスイッチをオフにしてください"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "パスワード"
+
+#~ msgid "∶"
+#~ msgstr ":"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "指紋認証ログインを有効にする"
+
+#~ msgid "_Other finger:"
+#~ msgstr "別の指(_O):"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "あなたの指紋を登録しました。今後は指紋リーダーを使用してログインできるよう"
+#~ "になりました。"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "デバイスへのアクセスが許可されていません。システム管理者に連絡してくださ"
+#~ "い。"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "システム内部のエラーが発生しました。"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "登録した指紋情報を削除しますか?"
+
+#~ msgid "Done!"
+#~ msgstr "完了です!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "“%s”というデバイスにアクセスできませんでした"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "“%s”デバイスで指紋を読み取れませんでした"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "指紋リーダーにアクセスできませんでした"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "システム管理者に連絡してください。"
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "指紋認証ログインを有効にするには、“%s”のデバイスを使用して指紋を登録する必"
+#~ "要があります。"
+
+#~ msgid "Selecting finger"
+#~ msgstr "指の選択"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "ユーザーアカウントの追加とパスワードの変更"
+
+#~ msgid "Play and record sound"
+#~ msgstr "音の再生や録音"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "mDNS/DNS-SD (Bonjour/zeroconf) を使用してのネットワークの検出"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Bluetooth ハードウェアへの直接アクセス"
+
+#~ msgid "Use your camera"
+#~ msgstr "カメラの使用"
+
+#~ msgid "Print documents"
+#~ msgstr "ドキュメントの印刷"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "接続されたジョイスティックの使用"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Docker サービスへの接続の許可"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "ネットワークファイアウォールの設定"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "このデバイス上でのファームウェアの更新"
+
+#~ msgid "Access hardware information"
+#~ msgstr "ハードウェア情報へのアクセス"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "ハードウェア乱数ジェネレーターへのエントロピーの提供"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "ハードウェア生成の乱数の使用"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "ホームフォルダー内のファイルへのアクセス"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "libvirt サービスへのアクセス"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "システム言語と地域設定の変更"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "位置設定と位置プロバイダーの変更"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "システムログとアプリケーションログの読み取り"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "Media Hub サービスへのアクセス"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "モデムの設定と使用"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "システムのマウント情報とディスククォータの読み取り"
+
+#~ msgid "Control music and video players"
+#~ msgstr "音楽プレーヤーと動画プレーヤーの制御"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "ローレベルネットワーク設定の変更"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "ネットワーク設定の読み取りと変更のための NetworkManager サービスへのアクセ"
+#~ "ス"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "ネットワーク設定の読み取りアクセス"
+
+#~ msgid "Change network settings"
+#~ msgstr "ネットワーク設定の変更"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "モバイル通信用のネットワーク設定の読み取りと変更のための ofono サービスへ"
+#~ "のアクセス"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Open vSwitch ハードウェアの制御"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "CD/DVD の読み取り"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "保存されたパスワードの読み取り、追加、変更、削除"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Point-to-Point プロトコル接続の設定のための pppd と PPP デバイスへのアクセ"
+#~ "ス"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "システムのプロセスの停止と終了"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "USB ハードウェアへの直接アクセス"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "リムーバブルストレージデバイス上のファイルの読み取り/書き込み"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "画面のスリープ/ロックの防止"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "シリアルポートハードウェアへのアクセス"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "デバイスの電源オフと再起動"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "ソフトウェアのインストール、削除、設定"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "ストレージフレームワークサービスへのアクセス"
+
+#~ msgid "Read process and system information"
+#~ msgstr "プロセスとシステム情報の読み取り"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "実行中のプログラムの監視と制御"
+
+#~ msgid "Change the date and time"
+#~ msgstr "日付と時刻の変更"
+
+#~ msgid "Change time server settings"
+#~ msgstr "時刻サーバーの設定の変更"
+
+#~ msgid "Change the time zone"
+#~ msgstr "タイムゾーンの変更"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "ディスクとリムーバブルメディアの設定のための UDisks2 サービスへのアクセス"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "電力使用データへのアクセス"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ユーザーアカウントを作成するには、\n"
+#~ "まず * アイコンをクリックしてください"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "背景とロック画面に設定"
+
+#~ msgid "Set Background"
+#~ msgstr "背景に設定"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "ロック画面に設定"
+
+#~ msgid "Remove Background"
+#~ msgstr "背景から削除"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "内部認証(_A)"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "バックグラウンドデータの使用を制限する(_B)"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "従量制課金接続のような制限のある接続に適しています。"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "ワイヤレスホットスポットをオンにすると <b>%s</b> の接続が切断されます。"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "ホットスポットがアクティブな場合、ワイヤレスによるインターネット接続はでき"
+#~ "ません。"
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Wi-Fi アクセスポイント機能は、追加のインターネット接続を Wi-Fi 経由で共有"
+#~ "するために使用されます。"
+
+#~ msgid "Make available to other users"
+#~ msgstr "他のユーザーに利用可能にする"
+
+#~ msgid "identity"
+#~ msgstr "識別情報"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "自動 (DHCP) アドレスのみ"
+
+#~ msgid "Link-local only"
+#~ msgstr "リンクローカルのみ"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "自動的に得られたルートを無視する(_I)"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "クローンした MAC アドレス(_C)"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "この接続の設定をデフォルトにリセットしますが、推奨接続であることは記憶しま"
+#~ "す。"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "このネットワークに関する詳細はすべて削除して、自動的に接続しないようにしま"
+#~ "す。"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "アドホック"
+
+#~ msgid "Infrastructure"
+#~ msgstr "インフラストラクチャ"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "通知ポップアップ(_P)"
+
+#~ msgid "In use"
+#~ msgstr "使用中"
+
+#~ msgid "Usage & History"
+#~ msgstr "使用と履歴"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "履歴を記憶しておくと、以前の作業を探し出すのが簡単になります。これらの項目"
+#~ "はネットワークを越えて共有されることはありません。"
+
+#~ msgid "Retain _History"
+#~ msgstr "記憶する期間(_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "画面をロックして離席中もプライバシーを保護します。"
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "画面オフ後にロックするまでの時間(_A)"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "ロック画面での通知(_N)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "ゴミ箱や一時ファイルを自動的に削除することで、不要になった機密情報が残った"
+#~ "ままにならないようにします。"
+
+#~ msgid "Purge _After"
+#~ msgstr "次の時間経過後に削除する(_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "利用しているソフトウェアについての情報を私たちに送ることで、より適切な提案"
+#~ "を私たちができるようになります。また、ソフトウェアの改善にも役立てられま"
+#~ "す。\n"
+#~ "\n"
+#~ "私たちが収集する情報はすべて匿名であり、また収集したデータを第三者と共有す"
+#~ "ることはありません。"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "ソフトウェアの使用統計情報を送信する(_S)"
+
+#~ msgid "_Location Services"
+#~ msgstr "位置情報サービス(_L)"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "個人情報の保護と外部からの見え方を設定します"
+
+#~ msgid "Last Login"
+#~ msgstr "最終ログイン"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "ユーザー名の先頭文字に“-”は使えません。"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "時間の経過とともに画像が変化します"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "並べる"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "サイズ調整"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "引き伸ばす"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "スパン (複数に跨げる)"
+
+#~ msgid "Drag displays to match your setup."
+#~ msgstr "あなたの調整に合うようにディスプレイをドラッグしてください。"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "最小"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "最大"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "サブウーファー(_S):"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "非増幅"
+
+#~ msgid "Peak detect"
+#~ msgstr "ピークの検出"
+
+#~ msgid "_Input volume:"
+#~ msgstr "入力の音量(_I):"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "サウンド入力デバイスの選択(_H):"
+
+#~ msgid "Sound Effects"
+#~ msgstr "音響効果"
+
+#~ msgid "Testing event sound"
+#~ msgstr "イベント音のテスト中"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "警告音の選択(_H):"
+
+#~ msgid "Add input source"
+#~ msgstr "入力ソースを追加する"
+
+#~ msgid "Remove input source"
+#~ msgstr "入力ソースを削除する"
+
+#~ msgid "Move input source up"
+#~ msgstr "入力ソースを上に移動する"
+
+#~ msgid "Move input source down"
+#~ msgstr "入力ソースを下に移動する"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "コントロールセンターは、デスクトップの各種設定を行う GNOME のメインイン"
+#~ "ターフェースです。"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "次のソースへ切り替える (代替)"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "パスワードが一致しません。"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "標準"
+
+#~ msgid "Used by %s"
+#~ msgstr "%s に使用されています"
+
+#~ msgid "Show the overview"
+#~ msgstr "全体を表示する"
+
+#~ msgid "Lid Closed"
+#~ msgstr "蓋が閉じています"
+
+#~ msgid "Mirrored"
+#~ msgstr "ミラー済み"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "ディスプレイの配置の調整"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "このディスプレイをつなげて拡張ワークスペースとして使用する"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "既存の画面をすべてのディスプレイに表示する"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "ディスプレイの配置を調整(_A)"
+
+#~ msgid "_Method"
+#~ msgstr "メソッド(_M)"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "アクセスポイントとして使用(_U)…"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "他のユーザーにも利用可能にする(_U)"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "ゾーンは接続の信頼レベルを定義します"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "パスワードを含め、このネットワークの設定をリセットします。ただし、推奨ネッ"
+#~ "トワークであることは記憶"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "このネットワークに関する詳細を削除し、自動的に接続しないようにします"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "ワイヤレス以外のインターネット接続がある場合には、 ワイヤレスホットスポッ"
+#~ "トを設定し、他の人とインターネット接続を共有することができます。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "文字、数字、記号をもっと追加するようにしてください。"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "強度: 弱"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "強度: 良"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "ショートカットを編集するには、対応する行をクリックし、新しいキーの組み合わ"
+#~ "せを押すか、[BS] キーで取り消してください。"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "このキーでは入力できないので \"%s\" というショートカットキーは利用できませ"
+#~ "ん。\n"
+#~ "[Ctrl] や [Alt] や [Shift] といった修飾キーを併用するようにしてください。"
+
+#~ msgid "_Reassign"
+#~ msgstr "割り当てる(_R)"
+
+#~ msgid "_Assign"
+#~ msgstr "割り当てる(_A)"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Bond のスレーブ"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "ブリッジのスレーブ"
+
+#~ msgid "Team slaves"
+#~ msgstr "チームのスレーブ"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "認証局 (CA) の証明書が選択されていません"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "認証局 (CA) 証明書を使用しなければ接続は安全でなく、危険な W-Fi ネットワー"
+#~ "クになってしまいます。認証局証明書を選択しますか?"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA 証明書を選択する"
+
+#~ msgid "Toner Level"
+#~ msgstr "トナーの量"
+
+#~ msgid "Supply Level"
+#~ msgstr "サプライの量"
+
+#~ msgid "Supply"
+#~ msgstr "サプライ"
+
+#~ msgid "Jobs"
+#~ msgstr "ジョブ"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "ジョブを表示(_J)"
+
+# この Ring は Intuos 4 や Cintiq 24HD の Touch Ring のこと。日本版ではタッチホイール。
+# libwacom のソースコードも参照のこと。
+#~ msgid "Left Ring"
+#~ msgstr "左タッチホイール"
+
+# この Ring は Intuos 4 や Cintiq 24HD の Touch Ring のこと。日本版ではタッチホイール。
+# libwacom のソースコードも参照のこと。
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "左タッチホイールのモード #%d"
+
+# Touch Strip はトラックパッド。Cintiq の日英のマニュアルを参照
+#~ msgid "Left Touchstrip"
+#~ msgstr "左トラックパッド"
+
+# Touch Strip はトラックパッド。Cintiq の日英のマニュアルを参照
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "左トラックパッドのモード #%d"
+
+# Touch Ring はタッチホイール。Intuos 4 の日英のマニュアルを参照
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "左タッチホイールのモードスイッチ"
+
+#~ msgid "No Action"
+#~ msgstr "何もしない"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "マウスの左ボタンクリック"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,14 +7,14 @@
 # Vladimer Sichinava ვლადიმერ სიჭინავა <vsichi@gnome.org>, 2007.
 # Vladimer Sichinava <vsichi@gnome.org>, 2008.
 # Vladimer Sichinava  ვლადიმერ სიჭინავა <vsichi@gnome.org>, 2008.
+# Ekaterine Papava <papava.e@gtu.ge>, 2022.
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-05 19:41+0000\n"
-"PO-Revision-Date: 2022-09-06 18:33+0200\n"
-"Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-12-05 17:30+0100\n"
+"Last-Translator: Ekaterine Papava <papava.e@gtu.ge>\n"
 "Language-Team: Georgian <http://mail.gnome.org/mailman/listinfo/gnome-ge-"
 "list>\n"
 "Language: ka\n"
@@ -22,100 +22,9 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.1.1\n"
-
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "სისტემური მატარებელი"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "სრული წვდომა"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "სესიების მატარებელი"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "მოწყობილობა"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "სრული წვდომა /dev-თან"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "ქსელი"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "აქვს ქსელთან წვდომა"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "სახლი"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "მხოლოდ წაკითხვა"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "ფაილური სისტემა"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "მორგება"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "პარამეტრები შეცვლადია"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s-ს შემდეგი წვდოები გააჩნია. მათი შეცვლა შეუძლებელია. თუ ნერვიულობთ "
-"უსაფრთხოებაზე, სჯობს წაშალოთ ეს აპლიკაცია."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u ფაილი და ბმულის ტიპები აპლიკაციით გაიხსნება"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> გამოიყენება შემდეგი ტიპის ფაილებისა და ბმულების გასახსნელად."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "დისკზე დაკავებული ადგილი: %s."
+"X-Generator: Poedit 3.2.2\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -131,7 +40,6 @@ msgid "Install some…"
 msgstr "დაყენება…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "გახსნა"
 
@@ -155,24 +63,13 @@ msgstr "ძებნა"
 msgid "Receive system searches and send results."
 msgstr "სისტემის ძებნის მიღება და პასუხების გაგზავნა."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "გამორთული"
 
@@ -336,80 +233,20 @@ msgstr "ქეშის გასუფთავება…"
 msgid "Control various application permissions and settings"
 msgstr "აპლიკაციის სხვადასხვა პარამეტრებისა და წვდომების კონტროლი"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "application;flatpak;permission;setting;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "აირჩიეთ სურათი"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_გაუქმება"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_გახსნა"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "მრავალი ზომა"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "სამუშაო მაგიდის ფონის გარეშე"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "მიმდინარე ფონი"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "სტილი"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "ნაგულისხმევი"
 
@@ -433,7 +270,6 @@ msgstr "გარემოს იერსახე"
 msgid "Change your background image or the UI colors"
 msgstr "შეცვალეთ ფონის სურათი ან ინტერფეისის ფერები"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
@@ -478,15 +314,13 @@ msgstr "თვითმფრინავის რეჟმის გამო�
 
 #: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
-msgstr ""
+msgstr "აპარატურული თვითმფრინავის რეჟიმი ჩართულია"
 
 #: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -494,10 +328,9 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
-msgstr ""
+msgstr "share;sharing;bluetooth;obex;"
 
 #: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
@@ -523,89 +356,33 @@ msgstr ""
 msgid "Protect your pictures"
 msgstr "დაიცავით თქვენი სურათები"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "დახურეთ ნოუთბუქი"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr ""
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr ""
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "პროფილის გენერაცია შეუძლებელია."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr ""
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "დასურლდა!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "კალიბრაციის შეცდომა!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "კალიბრაციის მოწყობილობა შეგიძლიათ მოაცილოთ."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "არ შეაწუხოთ მოწყობილობის კალიბრაცია, სანამ ის მიმდინარეობს"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "ეკრანის კალიბრაცია"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_გაუქმება"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -623,145 +400,13 @@ msgstr "_გაგრძელება"
 msgid "_Done"
 msgstr "_დასრულებულია"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "ნოუთბუქის ეკრანი"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "ჩაშენებული ვებკამერა"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s ეკრანი"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s სკანერი"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s კამერა"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s პრინტერი"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s ვებკამერა"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s-სთვის ფერების მართვის ჩართვა"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s-თვის ფერის პროფილების ნახვა"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "კალიბრირებული არაა"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "ნაგულისხმები: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "ფერების სივრცე: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "სატესტო პროფილი: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "აირჩიეთ ICC პროფილის ფაილი"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_შემოტანა"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "მხარდაჭერილი ICC profilebi"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "ყველა ფაილი"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "ეკრანი"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "პროფილის შენახვა"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "შ_ენახვა"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "მოწყობილობის ტიპი ამჟამად მხარდაჭერილი არაა."
-
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "ეკრანის კალიბრაცია"
 
 #: panels/color/cc-color-panel.ui:12
 msgid "Calibration Quality"
-msgstr ""
+msgstr "კალიბრაციის ხარისხი"
 
 #: panels/color/cc-color-panel.ui:21
 msgid ""
@@ -847,7 +492,7 @@ msgstr "შეჯამება"
 
 #: panels/color/cc-color-panel.ui:259
 msgid "Profile successfully created!"
-msgstr ""
+msgstr "პროფილი წარმატებით შეიქმნა!"
 
 #: panels/color/cc-color-panel.ui:290
 msgid "Copy profile"
@@ -855,13 +500,13 @@ msgstr "პროფილის კოპირება"
 
 #: panels/color/cc-color-panel.ui:296
 msgid "Requires writable media"
-msgstr ""
+msgstr "ესაჭიროება ჩაწერადი მედია"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 
 #: panels/color/cc-color-panel.ui:335
@@ -880,7 +525,6 @@ msgstr "_ფაილის შემოტანა…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -890,9 +534,7 @@ msgstr "დ_ამატება"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "მეტის გაგება"
 
@@ -1024,82 +666,6 @@ msgstr ""
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "სტანდარტული სივრცე"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "პროფილის შემოწმება"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "ავტომატური"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "დაბალ ხარისხი"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "საშუალო ხარისხი"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "მაღალი ხარისხი"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "ნაგულისხმები RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "ნაგულისხმები CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "ნაგულისხმები ნაცრისფერი"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr ""
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "ფერი"
@@ -1109,14 +675,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "სხვა…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1131,13 +692,8 @@ msgid "No languages found"
 msgstr "ენები ნაპოვნი არაა"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "მეტი…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr ""
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1166,148 +722,6 @@ msgstr "საათის შემცირება"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "წუთის შემცირება"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "დღეს"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "გუშინ"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d საათი"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d წუთი"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d წამი"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 წამი"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "ჰოტსპოტი"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-სთ"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1402,17 +816,11 @@ msgstr "დროის სარტყელის ავტომატურ�
 msgid "Requires location services enabled and internet access"
 msgstr ""
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "ჩართულია"
 
@@ -1420,22 +828,50 @@ msgstr "ჩართულია"
 msgid "Time Z_one"
 msgstr "დროის სარტყელი"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "განბლოკვა"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "დროის ფორმატი"
 
-#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
-msgid "Change the date and time, including time zone"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
 msgstr ""
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "თარიღები"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 წამი"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "კალე_ნდარი"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "რიცხვები"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "დროისა და თარიღის ცვლილება, დროის სარტყელის ჩატვლით"
+
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "საათი;დროის სარტყელი;მდებარეობა;"
 
 #: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
-msgstr ""
+msgstr "სისტემის დროისა და თარიღის პარამეტრების მორგება"
 
 #: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
@@ -1474,18 +910,9 @@ msgstr "ნაგულისხმევი აპლიკაციები"
 msgid "Configure Default Applications"
 msgstr "ნაგულისხმევი აპლიკაციების მორგება"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
-msgstr ""
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
+msgstr "default;application;preferred;media;"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1493,7 +920,7 @@ msgstr "პრობლემის გადაგზავნა"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:11
 msgid "_Automatic Problem Reporting"
-msgstr ""
+msgstr "პრობლემის ავტომატური _ანგარიში"
 
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
 msgid "Diagnostics"
@@ -1501,46 +928,11 @@ msgstr "დიაგნოსტიკა"
 
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
 msgid "Report your problems"
-msgstr ""
+msgstr "პრობლემის შესახებ შეტყობინება"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "დიაგნოსტიკა;ავარია;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "ჩართული"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "გამორთული"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "გადავატარო ცვლილებები?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "ცვლილებების გადატარება შეუძლებელია"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr ""
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1560,7 +952,7 @@ msgstr "უკან"
 
 #: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
-msgstr ""
+msgstr "ეკრანის მორგება გათიშულია"
 
 #: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
@@ -1590,31 +982,6 @@ msgstr "ძირითად ეკრანი"
 msgid "Night Light"
 msgstr "ღამის სინათლე"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "ლანდშაფტი"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf ჰც"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1631,13 +998,24 @@ msgstr "განახლების სიხშირე"
 
 #: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
-msgstr ""
+msgstr "TV-სთვის მორგება"
 
 #: panels/display/cc-display-settings.ui:78
 #: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "გადიდება"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "ნაწილი დასრულებულია"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1729,70 +1107,10 @@ msgstr "ეკრანები"
 msgid "Choose how to use connected monitors and projectors"
 msgstr ""
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "დაცული ჩატვირთვა ჩართულია"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "დაცული ჩარტვირთვის პრობლემები"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "დაცული ჩატვირთვა გამორთულია"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
 msgstr ""
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
@@ -1803,115 +1121,9 @@ msgid ""
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "გაიარა"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "ჩაიშალა"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "უსაფრთხოების დონე 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "უსაფრთხოების დონე 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "უსაფრთხოების დონე 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "უსაფრთხოების დონე 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "უსაფრთხოების დონე"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr ""
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -1925,331 +1137,9 @@ msgstr "დონე 2"
 msgid "Level 3"
 msgstr "დონე 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "დაცული ჩარტვირთვის პრობლემები"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "დაცული ჩატვირთვა გამორთულია"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "ღონისძიებების გარეშე"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "მიკროკოდის ჩაწერის დაცვა"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "მიკროკოდის ჩაწერის დაცვის დაბლოკვა"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "მიკროკოდის BIOS-ის რეგიონი"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "მიკროკოდის BIOS-ის დესკრიპტორი"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "ჩატვირთვამდელი DMA-ის დაცვა"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard-ით შემოწმებული ჩატვირთვა"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM-ით დაცული"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard-ის შეცდომების პოლიტიკა"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard-ის პატრუქი"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET ჩართულია"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET ჩართულია"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "დაშიფრული RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU უსაფრთხოება"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux-ის ბირთვის დაბლოკვა"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr ""
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux Swap"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "RAM-ში შეჩერება"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "უქმობამდე შეჩერება"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI პლატფორმის გასაღები"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI უსაფრთხო ჩატვირთვა"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TPM პლატფორმის მორგება"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr ""
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "მიკროკოდის განახლებები"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "მიკროკოდის ატესტაცია"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "მიკროკოდის გამნახლებლის შემოწმება"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr ""
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD-ის მიკროკოდის ვერსიის ჩამოწევისგან დაცვა"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD-ის მიკროკოდის თავიდან ჩაწერისგან დაცვა"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "AMD-ის მიკროკოდში ჩაწერისგან დაცვა"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr ""
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr ""
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "არასწორია"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "არ არის ჩართული"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr ""
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "დაბლოკილი არაა"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "დაშიფრული"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "არ არის დაშიფრული"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr ""
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "ყველა მოდული ლიცენზირებულია"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "ნაპოვნი"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "ნაპოვნი არაა"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "მხარდაჭერილი"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "მხარდაუჭერელია"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2257,57 +1147,13 @@ msgstr "მოწყობილობის უსაფრთხოება"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
 msgid "Host firmware security status"
-msgstr ""
+msgstr "ჰოსტის მიკროკოდის უსაფრთხოების მდგომარეობა"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
 "network;identity;privacy;"
 msgstr ""
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "უცნობი"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-ბიტიანი"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-ბიტიანი"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "უცნობია"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "მიუწვდომელია"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "სისტემის ლოგო"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2397,13 +1243,8 @@ msgstr "შესახებ"
 
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
-msgstr ""
+msgstr "ინფორმაცია ამ სისტემის შესახებ"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2428,7 +1269,7 @@ msgstr "ხმის აწევა"
 
 #: panels/keyboard/00-multimedia.xml.in:10
 msgid "Microphone mute/unmute"
-msgstr ""
+msgstr "მიკროფონის დადუმება/დადუმების მოხსნა"
 
 #: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
@@ -2479,6 +1320,12 @@ msgstr "გამშვებები"
 msgid "Launch help browser"
 msgstr "დახმარების ბრაუზერის გაშვება"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "მორგება"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "კალკულატორის გაშვება"
@@ -2500,7 +1347,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "ძებნა"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "სისტემა"
 
@@ -2531,11 +1378,11 @@ msgstr "დაპატარავება"
 
 #: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
-msgstr ""
+msgstr "ეკრანის წამკითხველის ჩართვა/გამორთვა"
 
 #: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
-msgstr ""
+msgstr "ეკრანზე ნაჩვენებ კლავიატურის ჩართვა/გამორთვა"
 
 #: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
@@ -2547,20 +1394,11 @@ msgstr "ტექსტის ზომის შემცირება"
 
 #: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
-msgstr ""
-
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr ""
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "სხვა"
+msgstr "მაღალი კონტრასტის ჩართვა და გამორთვა"
 
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
-msgstr ""
+msgstr "შეყვანის წყაროს დამატება"
 
 #: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
@@ -2590,98 +1428,9 @@ msgstr "გამართვა"
 msgid "View Keyboard Layout"
 msgstr "კლავიატურის განლაგების გადახედვა"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "წაშლა"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "საკუთარი მალსახმობი"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "მარცხენა Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "მარჯვენა Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "მარჯვენა Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "მენიუს ღილაკი"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "მარჯვენა Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "თაგუნას ღილაკები"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "ეკრანის დაბეჭდვა"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2705,48 +1454,27 @@ msgstr ""
 
 #: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
-msgstr ""
+msgstr "სპეციალური სიმბოლოს ჩანაწერი"
 
 #: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "თაგუნას ღილაკები"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "კლავიატურის მალსახმობები"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "მალსახმობების ნახვა და მორცება"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d შეცვლილია"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "დავაბრუნო ყველა მალსახმობი საწყის მნიშვნელობაზე?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "გაუქმება"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "ყველა საწყისი მნიშვნელობის დაბრუნება"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2784,33 +1512,6 @@ msgstr "მალსახმობის დამატება"
 msgid "No keyboard shortcut found"
 msgstr "კლავიატურის მალსახმობები ნაპოვნი არაა"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "შეიყვანეთ ახალი მალსახმობი"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "საკუთარი მალსახმობის დაყენება"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "მალსახმობის დაყენება"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "%s-ის შესაცვლელად შეიყვანეთ ახალი მალსახმობი."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "საკუთარი მალსახმობის დამატება"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_წაშლა"
@@ -2822,7 +1523,6 @@ msgstr "_ჩანაცვლება"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_დაყენება"
 
@@ -2858,6 +1558,11 @@ msgstr "არა"
 msgid "Reset the shortcut to its default value"
 msgstr ""
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "ნა_გულისხმევზე დაყენება"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "კლავიატურა"
@@ -2868,7 +1573,6 @@ msgid ""
 "and input sources"
 msgstr ""
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2876,7 +1580,7 @@ msgstr ""
 
 #: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
-msgstr ""
+msgstr "მდებარეობის სერვისები გამორთულია"
 
 #: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
@@ -2901,7 +1605,6 @@ msgstr ""
 msgid "Protect your location information"
 msgstr "თქვენი მდებარეობის ინფორმაციის დაცვა"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr ""
@@ -2931,7 +1634,6 @@ msgstr ""
 msgid "Protect your conversations"
 msgstr ""
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
@@ -2961,81 +1663,138 @@ msgstr "მარცხნივ"
 msgid "Right"
 msgstr "მარჯვნივ"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "მდებარეობა"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "თაგუნა"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "თაგუნას სიჩქარე"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "სექცია"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_აჩქარება:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "აქტიური"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "თაჩპედი"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
+msgstr "თაჩპედის სიჩქარე"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "დასაწკაპუნებლად დაატყაპუნეთ"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "დასაწკაპუნებლად შეეხეთ"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_აჩქარება:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "კიდით აწევ-ჩამოწევა"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "ორმხრივი"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
 msgstr ""
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "ორმაგი წკაპი, ძირითადი ღილაკი"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "ერთი წკაპი, ძირითადი ღილაკი"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "ორმაგი წკაპი, შუა ღილაკი"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "ერთი წკაპი, შუა ღილაკი"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "ორი წკაპი, მეორე ღილაკი"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "ერთი წკაპი, მეორე ღილაკი"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3046,14 +1805,13 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 
 #: panels/multitasking/cc-multitasking-panel.ui:15
 msgid "_Hot Corner"
-msgstr ""
+msgstr "_ცხელი კუთხე"
 
 #: panels/multitasking/cc-multitasking-panel.ui:16
 msgid "Touch the top-left corner to open the Activities Overview."
@@ -3124,18 +1882,9 @@ msgstr "მრავალამოცანიანობა"
 msgid "Manage preferences for productivity and multitasking"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
-msgstr ""
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
 msgstr ""
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
@@ -3143,7 +1892,6 @@ msgid "Other Devices"
 msgstr "სხვა მოწყობილობები"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3155,57 +1903,16 @@ msgstr "შეერთების დამატება"
 msgid "Not set up"
 msgstr "მორგებული არაა"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "დაკავშირებულია"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "პარამეტრები…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr ""
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3251,20 +1958,6 @@ msgstr "პაროლის ავტომატური გენერა�
 msgid "_Turn On"
 msgstr "_ჩართვა"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr ""
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "თვითმფრინავის რეჟიმი"
@@ -3303,92 +1996,19 @@ msgstr ""
 
 #: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
-msgstr ""
+msgstr "ხილული ქსელები"
 
 #: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr ""
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "უსაფრთხოება"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "შენარჩუნება"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "სამუდამო"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "შემთხვევითი"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "სტაბილური"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "პროფილი %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "კომპანიის"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "არა"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "არასდროს"
+msgstr "802.1x _უსაფრთხოება"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3396,183 +2016,6 @@ msgstr "არასდროს"
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i დღის წინ"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d მბ/წმ (%1.1f გჰც)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d მბ/წმ"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 გჰც / 5 გჰც"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 გჰც"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 გჰც"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "არა"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "სუსტი"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "დიახ"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "კარგი"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "გადასარევი"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 მისამართი"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 მისამართი"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP მისამართი"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "შეერთების დავიწყება"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "VPN-ის წაშლა"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "დეტალები"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "ავტომატური"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "იდენტიფიკაცია"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "მისამართის წაშლა"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "რაუტის წაშლა"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "არა"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit Key (Hex or ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit Passphrase"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "დინამიკური WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 პერსონალური"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 საწარმოო"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 პერსონალური"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3583,22 +2026,39 @@ msgstr "სიგნალის სიძლიერე"
 msgid "Link speed"
 msgstr "შეერთების სიჩქარე"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "უსაფრთხოება"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 მისამართი"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 მისამართი"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "აპარატურული მისამართი"
 
 #: panels/network/connection-editor/details-page.ui:142
 msgid "Supported Frequencies"
-msgstr ""
+msgstr "მხარდაჭერილი სიხშირეები"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "ნაგულისხმები რაუტი"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3606,7 +2066,7 @@ msgstr "ბოლოს გამოყენებული"
 
 #: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
-msgstr ""
+msgstr "_ავტომატურად დაკავშირება"
 
 #: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
@@ -3659,7 +2119,7 @@ msgstr "Link-Local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "ხელით"
 
@@ -3703,9 +2163,8 @@ msgstr "ნაგულისხმები რაუტერი"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "ავტომატური"
 
@@ -3717,7 +2176,7 @@ msgstr "ავტომატური DNS"
 #: panels/network/connection-editor/ip4-page.ui:192
 #: panels/network/connection-editor/ip6-page.ui:202
 msgid "DNS server address(es)"
-msgstr ""
+msgstr "DNS სერვერის მისამართები"
 
 #: panels/network/connection-editor/ip4-page.ui:200
 #: panels/network/connection-editor/ip6-page.ui:210
@@ -3758,82 +2217,9 @@ msgstr "ავტომატური (მხოლოდ DHCP)"
 msgid "Prefix"
 msgstr "პრეფიქსი"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "შეერთების ჩამსწორებლის გახსნის შეცდომა"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "ახალი პროფილი"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "არასწორი პარამეტრი: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "ფაილიდან შემოტანა…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "_VPN-ის დამატება"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_უსაფრთხოება"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "VPN შეერთების შემოტანის შეცდომა"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "აირჩიეთ შემოსატანი ფაილი"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "ფაილი სახელით %s უკვე არსებობს."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_შეცვლა"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "VPN შეერთების გატანის შეცდომა"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "VPN შეერთების გატანა"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3847,95 +2233,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "ქსელი"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr ""
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr ""
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "არასოდეს"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "დღეს"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "გუშინ"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "ბოლოს გამოყენებული"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "მავთულით"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "ახალი შეერთების დამატება"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_დავიწყება"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "ნაცნობი Wi-Fi ქსელები"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_დავიწყება"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr ""
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr ""
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -3954,6 +2281,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "სერვისის მომწოდებელი"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP მისამართი"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -3993,7 +2324,7 @@ msgstr "_FTP პროქსის პორტი"
 
 #: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
-msgstr ""
+msgstr "SOCKS პროქსის პორტი"
 
 #: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
@@ -4038,289 +2369,6 @@ msgstr ""
 msgid "_Known Wi-Fi Networks"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "სტატუსი უცნობია"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "უმართავი"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "მიუწვდომელია"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "დაკავშირება"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "საჭროა ავთენტიკაცია"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "გათიშვა"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "შეერთების შეცდომა"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "სტატუსი უცნობია (აკლია)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "კონფიგურაციის შეცდომა"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP კონფიგურაციის შეცდომა"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP კონფიგურაციის ვადა გასულია"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP სერვისი გაითიშა"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP-ის შეცდომა"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP-ის კლიენტის შეცდომა"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP-ის კლიენტის ავარია"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "ხაზი დაკავებულია"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "ზუმერის გარეშე"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "ქსელში რეგისტრაცია უარყოფილია"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN-ის შემოწმების შეცდომა"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "მოდემის პოვნა შეუძლებელია"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "BT შეერთების შეცდომა"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "მიკროკოდის გარეშე"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "კაბელი გამოერთებულია"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "ფაილი არჩეული არაა"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER ან PEM სერტიფიკატები"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC ფაილები (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4349,7 +2397,7 @@ msgstr "ორივე"
 #: panels/network/wireless-security/eap-method-peap.ui:49
 #: panels/network/wireless-security/eap-method-ttls.ui:48
 msgid "Anony_mous identity"
-msgstr ""
+msgstr "ანონიმური იდენტიფიკატორი"
 
 #: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
@@ -4357,7 +2405,7 @@ msgstr "_PAC ფაილი"
 
 #: panels/network/wireless-security/eap-method-fast.ui:79
 msgid "Choose a PAC file"
-msgstr ""
+msgstr "აირჩიეთ PAC ფაილი"
 
 #: panels/network/wireless-security/eap-method-fast.ui:99
 #: panels/network/wireless-security/eap-method-peap.ui:131
@@ -4367,15 +2415,7 @@ msgstr "_შიდა ავთენტიკაცია"
 
 #: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr ""
+msgstr "PAC-ით ავტომატური მორგების ჩართვა"
 
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
@@ -4402,15 +2442,6 @@ msgstr "_პაროლი"
 msgid "Sho_w password"
 msgstr "პაროლის _ჩვენება"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4432,7 +2463,6 @@ msgid "C_A certificate"
 msgstr "_CA სერტიფიკატი"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4442,88 +2472,27 @@ msgstr ""
 #: panels/network/wireless-security/eap-method-tls.ui:75
 #: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
-msgstr ""
+msgstr "CA სერტიფიკატი _საჭირო არაა"
 
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "აკლია EAP-ის პაროლი"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "აირჩიეთ პირადი სერტიფიკატი"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr ""
+msgstr "PEAP-ის ვერსია"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
-msgstr ""
+msgstr "_იდენტიფიკატორი"
 
 #: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
-msgstr ""
+msgstr "მომხმარებლის _სერტიფიკატი"
 
 #: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
-msgstr ""
+msgstr "პირადი _გასაღები"
 
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_პირადი გასაღების პაროლი"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4535,7 +2504,7 @@ msgstr "MSCHAP"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:25
 msgid "MSCHAPv2 (no EAP)"
-msgstr ""
+msgstr "MSCHAPv2 (არა- EAP)"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
@@ -4546,14 +2515,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_დომენი"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr ""
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4568,7 +2538,7 @@ msgstr "FAST"
 #: panels/network/wireless-security/ws-dynamic-wep.ui:35
 #: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
-msgstr ""
+msgstr "TLS გვირაბი (TTLS)"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:40
 #: panels/network/wireless-security/ws-wpa-eap.ui:45
@@ -4581,56 +2551,10 @@ msgstr "დაცული EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_ავთენტიკაცია"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "აირჩიეთ ფაილი"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr ""
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "აკლია LEAP-ის პაროლი"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "აკლია Wi-Fi-ის პაროლი."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_ტიპი"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4646,26 +2570,15 @@ msgstr "გაზიარებული გასაღები"
 
 #: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
-msgstr ""
+msgstr "_გასაღები"
 
 #: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
-msgstr ""
+msgstr "გასაღების _ჩვენება"
 
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
+msgstr "WEP-ის ინდექსი"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4718,26 +2631,8 @@ msgstr "_ეკრანის ბლოკირების გაფრთხ
 msgid "Control which notifications are displayed and what they show"
 msgstr ""
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
-msgstr ""
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "სხვა"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "\"%s\" წაშლილია"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
 msgstr ""
 
 #. Translators: This is the button which allows undoing the removal of the printer.
@@ -4762,17 +2657,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "ახალი ანგარიშის დამატება"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s ანგარიში"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "ანგარიშის წაშლა"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "ონლაინ ანგარიშები"
@@ -4781,19 +2665,11 @@ msgstr "ონლაინ ანგარიშები"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "უცნობი დრო"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4807,13 +2683,6 @@ msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i საათი"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4823,184 +2692,6 @@ msgstr[0] "საათი"
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "წუთი"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "დარჩენილია %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "სრულად დატენილი"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "არ იტენება"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "ცარიელი"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "იტენება"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "იცლება"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "უსადენო თაგუნა"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "უსადენო კლავიატურა"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "შეუფერხებელი კვების წყარო"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "მედია დამკვრელი"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "ტაბლეტი"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "კომპიუტერი"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr ""
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "ელემენტი"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "მთავარი"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "დამატებით"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "ელემენტები"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "უქმობისას"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "ძილი"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "გამორთვა"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "პროგრამული ძილი"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "არაფერი"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "ელემენტიდან კვებისას"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "შეერთებული"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "არასდროს"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "ავტომატურად შეჩერება"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr ""
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5062,6 +2753,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 საათი"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "ელემენტი"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "მოწყობილობა"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "კვების რეჟიმი"
@@ -5072,11 +2772,11 @@ msgstr ""
 
 #: panels/power/cc-power-panel.ui:123
 msgid "Power Saving Options"
-msgstr ""
+msgstr "ენერგიის დაზოგვის მორგება"
 
 #: panels/power/cc-power-panel.ui:126
 msgid "Automatic Screen Brightness"
-msgstr ""
+msgstr "ეკრანის ავტომატური სიკაშკაშე"
 
 #: panels/power/cc-power-panel.ui:127
 msgid "Screen brightness adjusts to the surrounding light."
@@ -5116,7 +2816,7 @@ msgstr ""
 
 #: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
-msgstr ""
+msgstr "_ჩართვის ღილაკის ქცევა"
 
 #: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
@@ -5139,33 +2839,6 @@ msgstr "იკვებება _ელემენტიდან"
 msgid "Delay"
 msgstr "დაყოვნება"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "წარმადობა"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "ბალანსირებული"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "ელემენტის შენახვის რეჟიმი"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr ""
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "კვება"
@@ -5174,32 +2847,10 @@ msgstr "კვება"
 msgid "View your battery status and change power saving settings"
 msgstr ""
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
-msgstr ""
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr ""
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr ""
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "UI-ის ჩატვირთვის შეცდომა: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
 msgstr ""
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
@@ -5210,7 +2861,6 @@ msgstr "პრინტერები"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -5218,8 +2868,6 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "პრინტერის დამატება"
 
@@ -5258,29 +2906,6 @@ msgstr ""
 msgid "Username"
 msgstr "მომხმარებლის სახელი"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s-ის დეტალები"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "აირჩიეთ PPD ფაილი"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript პრინტერის აღწერის ფაილები (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
@@ -5289,169 +2914,47 @@ msgstr ""
 msgid "Location"
 msgstr "მდებარეობა"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "დრაივერი"
 
 #: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
-msgstr ""
+msgstr "სასურველი დრაივერების ძებნა…"
 
 #: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
-msgstr ""
+msgstr "დრაივერების ძებნა"
 
 #: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
-msgstr ""
+msgstr "აირჩიეთ ბაზიდან…"
 
 #: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
-msgstr ""
+msgstr "PPD ფაილის დაყენება…"
 
 #: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
-msgstr ""
+msgstr "აირჩიეთ პრინტერის დრაივერი"
 
 #: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
-msgstr ""
+msgstr "დრაივერების ბაზის ჩატვირთვა"
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "გაუქმება"
 
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "_არჩევა"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect ტიპის პრინტერი"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD პრინტერი"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "ერთმხრიანი"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "გრძელი წიბო (სტანდარტული)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "მოკლე წიბო (გადაბრუნება)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "პორტრეტი"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "ლანდშაფტი"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "ლანდშაფტის შებრუნება"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "პორტრეტის შებრუნება"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "გაგრძელება"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "შეჩერება"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "დარჩენილი"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "შეჩერებულია"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "საჭროა ავთენტიკაცია"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "დამუშავება"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "გაჩერებულია"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "გაუქმებულია"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "შეწყვეტილია"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "დასრულებულია"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr ""
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] ""
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr ""
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr ""
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5479,320 +2982,16 @@ msgstr "_ავთენტიკაცია"
 msgid "No Active Printer Jobs"
 msgstr ""
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "ბეჭდვის სერვერის განბლოკვა"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s-ის განბლოკვა."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "პრინტერების ძებნა"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "სერიული პორტი"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "პარალელური პორტი"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "მდებარეობა: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "მისამართი: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "სერვერი ითხოვს ავთენტიკაციას"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "ორმხრივი"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "ფურცლის ტიპი"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "ქაღალდის წყარო"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "გამოტანის თარო"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "გარჩევადობა"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript-ის პრეფილტრი"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr ""
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "ორმხრივი"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "ორიენტაცია"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "ზოგადი"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "გვერდის მორგება"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "დაყენების ვარიანტები"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "დავალება"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "გამოსახულების ხარისხი"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "ფერი"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "სრულდება"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "დამატებით"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "სატესტო გვერდი"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "სატესტო გვერდი"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "ავტომატური არჩევა"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "პრინტერის ნაგულისხმები"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr ""
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "მწარმოებელი"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr ""
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
-msgstr[0] ""
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr ""
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "პრინტერში ტონერი ცოტაღაა"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "ტონერი გათავდა"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr ""
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "თავსახური ღიაა"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "კარის გაღება"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "ფურცლები ცოტაა"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "ქაღალდი გათავდა"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "გათიშული"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "გაჩერებულია"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr ""
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "მზადაა"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr ""
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "დამუშავება"
+msgstr[0] "%u დავალება"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5816,6 +3015,10 @@ msgstr "თავაკების გაწმენდა"
 msgid "Remove Printer"
 msgstr "პრინტერის წაშლა"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -5836,22 +3039,26 @@ msgid "Restart"
 msgstr "გადატვრთვა"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "პრინტერის დამატება…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "პრინტერის დამატება…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "პრინტერები ნაპოვნი არაა"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
 msgstr ""
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ფორმატები"
@@ -5879,16 +3086,6 @@ msgstr ""
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "გადახედვა"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "იმპერიული"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "მეტრული სისტემა"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5924,124 +3121,38 @@ msgid ""
 "used for numbers, dates, and currencies."
 msgstr ""
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "თქვენი ანგარიში"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "ე_ნა"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
-msgstr ""
+msgstr "_ფორმატები"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "შესვლის ეკრანი"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
-msgstr ""
+msgstr "რეგიონი და ენა"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
 msgid "Select your display language and formats"
-msgstr ""
+msgstr "აირჩიეთ ინტერფეისის სასურველი ენა და ფორმატები"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "გვკითხეთ რჩევა"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "არაფრის გაკეთება"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "საქაღალდის გახსნა"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "სხვა მედია"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "პროგრამის ამორჩევა აუდიო CD-ებისთვის"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "პროგრამის ამორჩევა ვიდეო DVD-ებისთვის"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "პროგრამის ამორჩევა პროგრამული CD-ებისთვის"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "აუდიო DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "ცარიელი Blu-ray დისკი"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "ცარიელი CD დისკი"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "ცარიელი DVD დისკი"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "ცარიელი HD DVD დისკი"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray ვიდეო დისკი"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "ელწიგნების წამკითხავი"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD ვიდეო დისკი"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "ფოტო სურათებიანი CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "ვიდეო CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows-ის პროგრამა"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6085,126 +3196,17 @@ msgstr "_ტიპი:"
 
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
 msgid "Removable Media"
-msgstr ""
+msgstr "გამოერთებადი მედია"
 
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
 msgid "Configure Removable Media settings"
 msgstr ""
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;"
 msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 წამი"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 წუთი"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 წუთი"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 წუთი"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 წუთი"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 წუთი"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 საათი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 წუთი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 წუთი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 წუთი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 წუთი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 წუთი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 წუთი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 წუთი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 წუთი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 წუთი"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "არასდროს"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6240,40 +3242,40 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "_გაფრთხილებების დაბლოკილ ეკრანზე ჩვენება"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_ეკრანის ბლოკირების გაფრთხილებები"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr ""
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr ""
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "ეკრანის კონფიდენციალობა"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "ეკრანი"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "ეკრანის მორგება"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr ""
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "მდებარეობის არჩევა"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_დიახ"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6302,10 +3304,6 @@ msgstr "სხვები"
 msgid "Add Location"
 msgstr "მდებარეობის დამატება"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "აპლიკაციები ნაპოვნი არაა"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "აპლიკაციის მოძებნა"
@@ -6331,88 +3329,13 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr ""
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
 msgstr ""
 
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "ქსელები"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "გამორთული"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "ჩართულია"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "აქტიური"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "აირჩიეთ საქაღალდე"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "დამატება"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "მედიის გაზიარების ჩართვა"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "მოწყობილობის სახელი კოპირებული"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "მომხმარებლის სახელი კოპირებულია"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "პაროლი დაკოპირდა"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6537,7 +3460,6 @@ msgstr "საქაღალდეები"
 msgid "Control what you want to share with others"
 msgstr ""
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6552,13 +3474,9 @@ msgstr ""
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "სხვა"
-
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
-msgstr ""
+msgstr "დააწკაპუნეთ"
 
 #: panels/sound/cc-alert-chooser.ui:20
 msgid "String"
@@ -6566,7 +3484,7 @@ msgstr "სტრიქონი"
 
 #: panels/sound/cc-alert-chooser.ui:28
 msgid "Swing"
-msgstr ""
+msgstr "სვინგი"
 
 #: panels/sound/cc-alert-chooser.ui:36
 msgid "Hum"
@@ -6587,11 +3505,6 @@ msgstr "უკანა"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "წინა"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s_ის ტესტირება"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6645,11 +3558,6 @@ msgstr "ხმის სიმაღლე"
 msgid "Alert Sound"
 msgstr "განგაშის ხმა"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "დადუმება"
@@ -6662,80 +3570,9 @@ msgstr "ხმა"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "გათიშულია"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "დაკავშირება"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "დაკავშირებულია"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "უცნობია"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr ""
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "დაკავშირებულია:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
 msgstr ""
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
@@ -6769,50 +3606,6 @@ msgstr ""
 msgid "Forget Device"
 msgstr "მოწყობილობის დავიწყება"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "შეცდომა"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "ავტორიზებული"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "შეცდომა მიმართვის რეჟიმის შეცვლისას: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr ""
@@ -6824,6 +3617,10 @@ msgstr ""
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "პირდაპირი წვდომა"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -6841,7 +3638,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Thunderbolt მოწყობილობის მართვა"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;"
@@ -7036,46 +3832,13 @@ msgstr "გრძელი"
 
 #: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
-msgstr ""
+msgstr "_კლავიატურით ჩართვა"
 
 #: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr ""
 "_წვდომადობის თვისებების ჩართვა და გამორთვა კლავიატურის მალსახმობებითაცაა "
 "შესაძლებელი"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "ნაგულისხმები"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "საშუალო"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "დიდი"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "უფრო დიდი"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "უდიდესი"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d პიქსელი"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -7087,7 +3850,7 @@ msgstr ""
 
 #: panels/universal-access/cc-ua-panel.ui:34
 msgid "_High Contrast"
-msgstr ""
+msgstr "_მაღალი კონტრასტი"
 
 #: panels/universal-access/cc-ua-panel.ui:46
 msgid "_Large Text"
@@ -7095,7 +3858,7 @@ msgstr "_დიდი ტექსტი"
 
 #: panels/universal-access/cc-ua-panel.ui:58
 msgid "Enable A_nimations"
-msgstr ""
+msgstr "_ანიმაციების ჩართვა"
 
 #: panels/universal-access/cc-ua-panel.ui:70
 msgid "Screen _Reader"
@@ -7115,7 +3878,7 @@ msgstr "პიპინი NumLock ან CapsLock-ის ჩართვის 
 
 #: panels/universal-access/cc-ua-panel.ui:96
 msgid "C_ursor Size"
-msgstr ""
+msgstr "_კურსორის ზომა"
 
 #: panels/universal-access/cc-ua-panel.ui:116
 #: panels/universal-access/cc-zoom-options-dialog.ui:82
@@ -7145,7 +3908,7 @@ msgstr "_კურსორის ციმციმი"
 
 #: panels/universal-access/cc-ua-panel.ui:218
 msgid "_Typing Assist (AccessX)"
-msgstr ""
+msgstr "_კრეფის დამხმარე (AccessX)"
 
 #: panels/universal-access/cc-ua-panel.ui:240
 msgid "Pointing &amp; Clicking"
@@ -7161,7 +3924,7 @@ msgstr "_მაჩვენებლის მოძებნა"
 
 #: panels/universal-access/cc-ua-panel.ui:267
 msgid "_Click Assist"
-msgstr ""
+msgstr "_წკაპების დამხმარე"
 
 #: panels/universal-access/cc-ua-panel.ui:287
 msgid "_Double-Click Delay"
@@ -7177,7 +3940,7 @@ msgstr "ვიზუალური გართხილებები"
 
 #: panels/universal-access/cc-visual-alerts-dialog.ui:14
 msgid "_Test flash"
-msgstr ""
+msgstr "განათების _გამოცდა"
 
 #: panels/universal-access/cc-visual-alerts-dialog.ui:38
 msgid "Use a visual indication when an alert sound occurs."
@@ -7191,42 +3954,17 @@ msgstr "მთლიანი _ეკრანის ციმციმი"
 msgid "Flash the entire _window"
 msgstr "მთლიანი _ფანჯრის ციმციმი"
 
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "მოკლე"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ეკრანი"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ეკრანი"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ეკრანი"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "გრძელი"
-
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "სრულეკრანიანი რეჟიმი"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
-msgstr ""
+msgstr "ზედა ნახევარი"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
-msgstr ""
+msgstr "ქვედა ნახევარი"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
@@ -7242,19 +3980,19 @@ msgstr "გადიდების მორგება"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
-msgstr ""
+msgstr "_გადიდება:"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
-msgstr ""
+msgstr "გამადიდებლის მდებარეობა"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:163
 msgid "_Follow mouse cursor"
-msgstr ""
+msgstr "თაგუნას კურსორზე _მიყოლა"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:174
 msgid "_Screen part:"
-msgstr ""
+msgstr "_ეკრანის ნაწილი:"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:208
 msgid "Magnifier _extends outside of screen"
@@ -7317,7 +4055,7 @@ msgstr "ფერის ეფექტები:"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
-msgstr ""
+msgstr "_თეთრი შავ ფონზე:"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
@@ -7371,7 +4109,6 @@ msgstr "ფერის ეფექტები"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7379,115 +4116,6 @@ msgid ""
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
 "audio;typing;animations;"
 msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 საათი"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 დღე"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 დღე"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 დღე"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 დღე"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 დღე"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 დღე"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 დღე"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr ""
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 დღე"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "გნებავთ სანაგვე ყუთიდან ყველა ელემენტის წაშლა?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr ""
-"მისამართების სიის გასუფთავების შემთხვევაში, თქვენ მათ სამუდამოდ წაშლით."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "ნაგვის _ყუთის დაცარიელება"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr ""
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 დღე"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 დღე"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 დღე"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "სამუდამოდ"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7502,15 +4130,15 @@ msgstr ""
 
 #: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
-msgstr ""
+msgstr "_ფაილის ისტორია"
 
 #: panels/usage/cc-usage-panel.ui:25
 msgid "File _History Duration"
-msgstr ""
+msgstr "ფაილის _ისტორიის ხანგრძლივობა"
 
 #: panels/usage/cc-usage-panel.ui:48
 msgid "_Clear History…"
-msgstr ""
+msgstr "ისტორიის _გასუფთავება…"
 
 #: panels/usage/cc-usage-panel.ui:63
 msgid "Trash &amp; Temporary Files"
@@ -7540,7 +4168,7 @@ msgstr "_ნაგვის ყუთის დაცარიელება…
 
 #: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
-msgstr ""
+msgstr "_დროებითი ფაილების წაშლა…"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
@@ -7550,57 +4178,9 @@ msgstr "ფაილის ისტორია & ნაგავი"
 msgid "Don't leave traces"
 msgstr "კვალის არ დატოვება"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "პაროლები არ ემთხვევა."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "ანგარიშის რეგისტრაციის შეცდომა"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "ამ დომენში ავთენტიკაციის არცერთი ხერხი მხარდაჭერილი არაა"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "დომენზე დაერთების შეცდომა"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "დომენში შესვლის შეცდომა"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
 msgstr ""
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
@@ -7640,7 +4220,7 @@ msgstr ""
 
 #: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
-msgstr ""
+msgstr "ხაზზე არ ბრძანდებით"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
@@ -7652,17 +4232,13 @@ msgstr ""
 "ცენტრალურად მართული მომხმარებლის ანგარიშები. ასევე შეგიძლიათ წვდომა იქონიოთ "
 "კომპანიის რესურსებთანაც."
 
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "მეტი სურათი"
-
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "აირჩიეთ ფაილი…"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:8
 msgid "Fingerprint Manager"
-msgstr ""
+msgstr "ანაბეჭდების მმართველი"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:20
 msgid "Fingerprint"
@@ -7715,224 +4291,10 @@ msgstr ""
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
-msgstr ""
+msgstr "ანაბეჭდების _წაშლა"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "ამ ქმედების შესასრულებლად საჭიროა მოწყობილობის გამოთხოვა"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "მარცხენა შუა თითი"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "მარცხენა ბეჭედი თითი"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "მარცხენა პატარა თითი"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "მარჯვენა ცერა"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "მარჯვენა შუა თითი"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "მარჯვენა ბეჭედი თითი"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "მარჯვენა პატარა თითი"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "უცნობი თითი"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "დასრულებულია"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr ""
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "ამ კვირაში"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "ბოლო კვირა"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr ""
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr ""
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr ""
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr ""
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
 msgstr ""
 
 #: panels/user-accounts/cc-login-history-dialog.ui:30
@@ -7942,18 +4304,6 @@ msgstr "წინა"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "შემდეგი"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr ""
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "მეორედ შეიყვანეთ თქვენი მიმდინარე პაროლი."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "პაროლის შეცვლა შეუძლებელია"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -7975,6 +4325,10 @@ msgstr "_ახალი პაროლი"
 msgid "Confirm Password"
 msgstr "პაროლის დადასტურება"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "პაროლები არ ემთხვევა."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
@@ -7982,128 +4336,6 @@ msgstr ""
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "დააყენეთ პაროლი ახლა"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "ამ ტიპის დომენზე ავტომატური დაერთება შეუძლებელია"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "დომენი ან რეალმის სახელი ნაპოვნი არაა"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s-ში %s დომენით შესვლა შეუძლებელია"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "არასწორი პაროლი. თავიდან სცადეთ"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "დომენთან დაკავშირების პრობლემა (%s): %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "გნებავთ %s-ის ფაილების შენარჩუნება?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_ფაილების წაშლა"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_ფაილების შენარჩუნება"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "დარწმუნებული ხართ, რომ გსურთ %s-ის სამუდამოდ წაშლა?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_წაშლა"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "არა"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "შესული"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "ანგარიშების სერვისთან კავშირის შეცდომა"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "გთხოვთ დარწმუნდეთ, რომ AccountService სწორადაა დაყენებული და ჩართულია."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr ""
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8124,14 +4356,13 @@ msgstr "დახურვა"
 
 #: panels/user-accounts/cc-user-panel.ui:120
 msgid "Edit avatar"
-msgstr ""
+msgstr "ავატარის ჩასწორება"
 
 #: panels/user-accounts/cc-user-panel.ui:152
 msgid "Full name"
 msgstr "სრული სახელი"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "რედაქტირება"
 
@@ -8191,7 +4422,6 @@ msgstr ""
 msgid "Add or remove users and change your password"
 msgstr ""
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8230,170 +4460,6 @@ msgstr "მომხმარებლის ანაგარიშები�
 msgid "Authentication is required to change user data"
 msgstr "მომხმარებლის ანგარიშების სამართავად საჭიროა ავთენტიკაცია"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "საჭიროა, რომ პაროლი განსხვავდებოდეს იმისგან, რაც ეყენა."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "სცადეთ კიდევ ოდნავ შეცვალოთ პაროლი."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "შეურიეთ დიდი და პატარა ასოები და სცადეთ გამოიყენოთ რამდენიმე ციფრი."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "მეტი ციფრები, ასოები და პუნქტუაციის ნიშნები პაროლს უფრო გააძლიერებს."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "ავთენტიკაციის შეცდომა"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "ახალი პაროლი ძალიან მოკლეა"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "ახალი პაროლი ძალიან მარტივია"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "ახალი და ძველი პაროლები ერთმანეთს ჰგვანან"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "ეს პაროლი ახლახანს გამოიყენეთ."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "ახალი პაროლი ციფრებს ან სიმბოლოებს უნდა შეიცავდეს"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "ძველი და ახალი პაროლი ერთი და იგივიეა"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "უკანასკნელი ავტორიზაციის შემდეგ თქვენი პაროლი შეიცვალა!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "ახალი პაროლი საკმარისად განსხვავებულ სიბოლოებს არ შეიცავს"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "უცნობი შეცდომა"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "მომხმარებლის სახელი მიუწვდომელია. სხვა სცადეთ."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "მომხმარებლის სახელი ძალიან გრძელია."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8425,56 +4491,14 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "ღილაკი %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "აპლიკაციის განსაზღვრულია"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr ""
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "ეკრანის გადარტვა"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr ""
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr ""
 
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "ყველა ეკრანი"
-
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
-msgstr ""
+msgstr "ტაბლეტის რეჟიმი"
 
 #: panels/wacom/cc-wacom-page.ui:17
 msgid "Use absolute positioning for the pen"
@@ -8482,7 +4506,7 @@ msgstr ""
 
 #: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
-msgstr ""
+msgstr "მარცხენა ხელის ორიენტაცია"
 
 #: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
@@ -8495,7 +4519,7 @@ msgstr "ეკრანზე მიბმა"
 
 #: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
-msgstr ""
+msgstr "საწყისი ფარდობის შენარჩუნება"
 
 #: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
@@ -8507,11 +4531,11 @@ msgstr "კალიბრაცია"
 
 #: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
-msgstr ""
+msgstr "ტაბლეტის ვერ ვიპოვე"
 
 #: panels/wacom/cc-wacom-panel.ui:57
 msgid "Please plug in or turn on your Wacom tablet."
-msgstr ""
+msgstr "შეაერთეთ ან ჩართეთ თქვენი Wacom-ის ტაბლეტი."
 
 #: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
@@ -8556,88 +4580,114 @@ msgstr ""
 
 #: panels/wacom/cc-wacom-stylus-page.ui:134
 msgid "Middle Mouse Button Click"
-msgstr ""
+msgstr "თაგუნას შუა წკაპი"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:135
 msgid "Right Mouse Button Click"
-msgstr ""
+msgstr "თაგუნას მარჯვენა წკაპი"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:137
 msgid "Forward"
 msgstr "წინ"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr ""
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
-msgstr ""
+msgstr "Wacom -ის ტაბლეტი"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "ახალი მალსახმობი…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "განლაგება"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "დედობილი ფანჯარა"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_მეორადი წკაპის სიმულირება"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "ფანჯრები"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "\"დიახ\" ტესტის დასრულებისთვის."
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "პრინტერში ტონერი ცოტაღაა"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "_მეორადი წკაპის დაყოვნება"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "ფანჯრები"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "წვდომის წერტილები"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "დამატება"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "შ_ენახვა"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "რეგისტრირებულია"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "როუმინგი"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "ძებნა"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Უარყოფილი"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8645,7 +4695,7 @@ msgstr "მოდემის დეტალები"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:16
 msgid "Modem Status"
-msgstr ""
+msgstr "მოდემის სტატუსი"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:25
 msgid "Carrier"
@@ -8661,224 +4711,19 @@ msgstr "ქსელის მდგომარეობა"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:122
 msgid "Own Number"
-msgstr ""
+msgstr "საკუთარი ნომერი"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:151
 msgid "Device Details"
 msgstr "მოწყობილობის დეტალები"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "მწარმოებელი"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "მიკროკოდის ვერსია"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1015
-#| msgid "3G, 4G"
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1041
-#| msgid "3G, 4G"
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1054
-#| msgid "2G, 4G"
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1067
-#| msgid "2G, 3G"
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1107
-#| msgid "2G, 4G"
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1117
-#| msgid "3G, 4G"
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "უცნობია"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "განბლოკვა"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8890,31 +4735,11 @@ msgstr[0] ""
 #, c-format
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
-msgstr[0] ""
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr ""
+msgstr[0] "დაგრჩათ %u ცდა"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
-msgstr ""
+msgstr "SIM ბარათის გარეშე"
 
 #: panels/wwan/cc-wwan-device-page.ui:19
 msgid "Insert a SIM card to use this modem"
@@ -8922,7 +4747,7 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:33
 msgid "SIM Locked"
-msgstr ""
+msgstr "SIM-ი დაბლოკილია"
 
 #: panels/wwan/cc-wwan-device-page.ui:77
 msgid "_Mobile Data"
@@ -8934,11 +4759,11 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:88
 msgid "_Data Roaming"
-msgstr ""
+msgstr "_ინტერნეტის როუმინგი"
 
 #: panels/wwan/cc-wwan-device-page.ui:89
 msgid "Use mobile data when roaming"
-msgstr ""
+msgstr "როუმინგისას მობილური ინტერნეტის გამოყენება"
 
 #: panels/wwan/cc-wwan-device-page.ui:115
 msgid "_Network Mode"
@@ -8954,11 +4779,11 @@ msgstr "დამატებით"
 
 #: panels/wwan/cc-wwan-device-page.ui:146
 msgid "_Access Point Names"
-msgstr ""
+msgstr "_წვდომის წერტილის სახელები"
 
 #: panels/wwan/cc-wwan-device-page.ui:155
 msgid "_SIM Lock"
-msgstr ""
+msgstr "_SIM-ის ბლოკირება"
 
 #: panels/wwan/cc-wwan-device-page.ui:156
 msgid "Lock SIM with PIN"
@@ -8967,94 +4792,6 @@ msgstr ""
 #: panels/wwan/cc-wwan-device-page.ui:165
 msgid "M_odem Details"
 msgstr "მ_ოდემის დეტალები"
-
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "ტელეფონთან კავშირი არ არსებობს"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "ოპერაცია მხარდაუჭერელია"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "არასწორი პაროლი"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "ნაპოვნი არაა"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "ქსელის სერვისის გარეშე"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "ქსელის მოლოდინის ვადა გავიდა"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "შეცდომის გარეშე"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "წვდომა აკრძალულია"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "უცნობი შეცდომა"
 
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
@@ -9066,16 +4803,11 @@ msgstr "ავთ_ენტიკაცია"
 
 #: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
-msgstr ""
+msgstr "აირჩიეთ ქსელი"
 
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "ქსელის მომწოდებლების განახლება"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr ""
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9127,13 +4859,12 @@ msgstr ""
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:3
 msgid "Mobile Network"
-msgstr ""
+msgstr "მობილური ქსელის"
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:4
 msgid "Configure Telephony and mobile data connections"
 msgstr ""
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -9150,41 +4881,13 @@ msgstr ""
 msgid "The GNOME Project"
 msgstr "პროექტი \"GNOME\""
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "ვერსიის ინფორმაციის ჩვენება"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "დამატებითი შეტყობინებების ჩართვა"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr ""
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr ""
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr ""
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr ""
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
-msgstr ""
+msgstr "პარამეტრების კატეგორიები"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "პირადი ინფორმაცია"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "ხელმისაწვდომი პანელები:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9196,7 +4899,7 @@ msgstr "ძირითადი მენიუს"
 
 #: shell/cc-window.ui:152
 msgid "Warning: Development Version"
-msgstr ""
+msgstr "გაფრთხილება: სატესტო ვერსია"
 
 #: shell/cc-window.ui:153
 msgid ""
@@ -9237,9 +4940,8 @@ msgstr "წინა პანელზე დაბრუნება"
 #: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
-msgstr ""
+msgstr "ძებნის გაუქმება"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "მორგება;"
@@ -9265,7 +4967,7 @@ msgstr ""
 
 #: shell/org.gnome.Settings.gschema.xml:20
 msgid "Initial state of the window"
-msgstr ""
+msgstr "ფანჯრის საწყისი მდგომარეობა"
 
 #: shell/org.gnome.Settings.gschema.xml:21
 msgid ""
@@ -9273,25 +4975,2255 @@ msgid ""
 "application window."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u გამოტანა"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u შეტანა"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "სისტემური ხმები"
+#~ msgid "System Bus"
+#~ msgstr "სისტემური მატარებელი"
+
+#~ msgid "Full access"
+#~ msgstr "სრული წვდომა"
+
+#~ msgid "Session Bus"
+#~ msgstr "სესიების მატარებელი"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "სრული წვდომა /dev-თან"
+
+#~ msgid "Has network access"
+#~ msgstr "აქვს ქსელთან წვდომა"
+
+#~ msgid "Home"
+#~ msgstr "სახლი"
+
+#~ msgid "Read-only"
+#~ msgstr "მხოლოდ წაკითხვა"
+
+#~ msgid "File System"
+#~ msgstr "ფაილური სისტემა"
+
+#~ msgid "Can change settings"
+#~ msgstr "პარამეტრები შეცვლადია"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s-ს შემდეგი წვდოები გააჩნია. მათი შეცვლა შეუძლებელია. თუ ნერვიულობთ "
+#~ "უსაფრთხოებაზე, სჯობს წაშალოთ ეს აპლიკაცია."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u ფაილი და ბმულის ტიპები აპლიკაციით გაიხსნება"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> გამოიყენება შემდეგი ტიპის ფაილებისა და ბმულების გასახსნელად."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "დისკზე დაკავებული ადგილი: %s."
+
+#~ msgid "Select a picture"
+#~ msgstr "აირჩიეთ სურათი"
+
+#~ msgid "_Open"
+#~ msgstr "_გახსნა"
+
+#~ msgid "multiple sizes"
+#~ msgstr "მრავალი ზომა"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "სამუშაო მაგიდის ფონის გარეშე"
+
+#~ msgid "Current background"
+#~ msgstr "მიმდინარე ფონი"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "დახურეთ ნოუთბუქი"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "პროფილის გენერაცია შეუძლებელია."
+
+#~ msgid "Complete!"
+#~ msgstr "დასურლდა!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "კალიბრაციის შეცდომა!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "კალიბრაციის მოწყობილობა შეგიძლიათ მოაცილოთ."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "არ შეაწუხოთ მოწყობილობის კალიბრაცია, სანამ ის მიმდინარეობს"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "ნოუთბუქის ეკრანი"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "ჩაშენებული ვებკამერა"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s ეკრანი"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s სკანერი"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s კამერა"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s პრინტერი"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s ვებკამერა"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s-სთვის ფერების მართვის ჩართვა"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s-თვის ფერის პროფილების ნახვა"
+
+#~ msgid "Not calibrated"
+#~ msgstr "კალიბრირებული არაა"
+
+#~ msgid "Default: "
+#~ msgstr "ნაგულისხმები: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "ფერების სივრცე: "
+
+#~ msgid "Test profile: "
+#~ msgstr "სატესტო პროფილი: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "აირჩიეთ ICC პროფილის ფაილი"
+
+#~ msgid "_Import"
+#~ msgstr "_შემოტანა"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "მხარდაჭერილი ICC profilebi"
+
+#~ msgid "All files"
+#~ msgstr "ყველა ფაილი"
+
+#~ msgid "Save Profile"
+#~ msgstr "პროფილის შენახვა"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "მონიშნული  მოწყობილობისთვის ფერის პროფილის შექმნა"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "გამზომი ინსტრუმენტი ვერ ვიპოვე. დარწმუნდით, რომ ის ჩართული და სწორად "
+#~ "მიერთებულია."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "მზომავ მოწყობილობას პრინტერის პროფილირების მხარდაჭერა არ გააჩნია."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "მოწყობილობის ტიპი ამჟამად მხარდაჭერილი არაა."
+
+#~ msgid "Standard Space"
+#~ msgstr "სტანდარტული სივრცე"
+
+#~ msgid "Test Profile"
+#~ msgstr "პროფილის შემოწმება"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "ავტომატური"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "დაბალ ხარისხი"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "საშუალო ხარისხი"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "მაღალი ხარისხი"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "ნაგულისხმები RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "ნაგულისხმები CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "ნაგულისხმები ნაცრისფერი"
+
+#~ msgid "Other…"
+#~ msgstr "სხვა…"
+
+#~ msgid "Today"
+#~ msgstr "დღეს"
+
+#~ msgid "Yesterday"
+#~ msgstr "გუშინ"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d საათი"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d წუთი"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d წამი"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "ჰოტსპოტი"
+
+#~ msgid "24-hour"
+#~ msgstr "24-სთ"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "On"
+#~ msgstr "ჩართული"
+
+#~ msgid "Off"
+#~ msgstr "გამორთული"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "გადავატარო ცვლილებები?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "ცვლილებების გადატარება შეუძლებელია"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "ლანდშაფტი"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "პორტრეტი მარჯვნივ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "პორტრეტი მარცხნივ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "ლანდშაფტი (გადაბრუნებული)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf ჰც"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "დაცული ჩატვირთვა ჩართულია"
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "დაცული ჩარტვირთვის პრობლემები"
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "დაცული ჩატვირთვა გამორთულია"
+
+#~ msgid "Passed"
+#~ msgstr "გაიარა"
+
+#~ msgid "Failed"
+#~ msgstr "ჩაიშალა"
+
+#~ msgid "Security Level 0"
+#~ msgstr "უსაფრთხოების დონე 0"
+
+#~ msgid "Security Level 1"
+#~ msgstr "უსაფრთხოების დონე 1"
+
+#~ msgid "Security Level 2"
+#~ msgstr "უსაფრთხოების დონე 2"
+
+#~ msgid "Security Level 3"
+#~ msgstr "უსაფრთხოების დონე 3"
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "დაცული ჩარტვირთვის პრობლემები"
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "დაცული ჩატვირთვა გამორთულია"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "მიკროკოდის ჩაწერის დაცვა"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "მიკროკოდის ჩაწერის დაცვის დაბლოკვა"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "მიკროკოდის BIOS-ის რეგიონი"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "მიკროკოდის BIOS-ის დესკრიპტორი"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "ჩატვირთვამდელი DMA-ის დაცვა"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard-ით შემოწმებული ჩატვირთვა"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM-ით დაცული"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard-ის შეცდომების პოლიტიკა"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard-ის პატრუქი"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET ჩართულია"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET ჩართულია"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "დაშიფრული RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU უსაფრთხოება"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux-ის ბირთვის დაბლოკვა"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux-ის ბირთვის შემოწმება"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "RAM-ში შეჩერება"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "უქმობამდე შეჩერება"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI პლატფორმის გასაღები"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI უსაფრთხო ჩატვირთვა"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM პლატფორმის მორგება"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM -ის რემონტი"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine -ისმწარმოებლის რეჟიმი"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine -ის გადაფარვა"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine -ის ვერსია"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "მიკროკოდის განახლებები"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "მიკროკოდის ატესტაცია"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "მიკროკოდის გამნახლებლის შემოწმება"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "პლატფორმის გამართვა"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "პროცესორის უსაფრთხოების შემოწმება"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD-ის მიკროკოდის ვერსიის ჩამოწევისგან დაცვა"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD-ის მიკროკოდის თავიდან ჩაწერისგან დაცვა"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD-ის მიკროკოდში ჩაწერისგან დაცვა"
+
+#~ msgid "Valid"
+#~ msgstr "სწორი"
+
+#~ msgid "Not Valid"
+#~ msgstr "არასწორია"
+
+#~ msgid "Not Enabled"
+#~ msgstr "არ არის ჩართული"
+
+#~ msgid "Locked"
+#~ msgstr "დაბლოკილი"
+
+#~ msgid "Not Locked"
+#~ msgstr "დაბლოკილი არაა"
+
+#~ msgid "Encrypted"
+#~ msgstr "დაშიფრული"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "არ არის დაშიფრული"
+
+#~ msgid "Not Tainted"
+#~ msgstr "ყველა მოდული ლიცენზირებულია"
+
+#~ msgid "Found"
+#~ msgstr "ნაპოვნი"
+
+#~ msgid "Not Found"
+#~ msgstr "ნაპოვნი არაა"
+
+#~ msgid "Supported"
+#~ msgstr "მხარდაჭერილი"
+
+#~ msgid "Not Supported"
+#~ msgstr "მხარდაუჭერელია"
+
+#~ msgid "Unknown"
+#~ msgstr "უცნობი"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-ბიტიანი"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-ბიტიანი"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "უცნობია"
+
+#~ msgid "Not Available"
+#~ msgstr "მიუწვდომელია"
+
+#~ msgid "System Logo"
+#~ msgstr "სისტემის ლოგო"
+
+#~ msgid "No input sources found"
+#~ msgstr "შეყვანის წყაროების გარეშე"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "სხვა"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "საკუთარი მალსახმობი"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "მარცხენა Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "მარჯვენა Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "მარცხენა Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "მარჯვენა Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "მენიუს ღილაკი"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "მარჯვენა Ctrl"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "ეკრანის დაბეჭდვა"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d შეცვლილია"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "დავაბრუნო ყველა მალსახმობი საწყის მნიშვნელობაზე?"
+
+#~ msgid "Reset All"
+#~ msgstr "ყველა საწყისი მნიშვნელობის დაბრუნება"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "შეიყვანეთ ახალი მალსახმობი"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "საკუთარი მალსახმობის დაყენება"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "მალსახმობის დაყენება"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "%s-ის შესაცვლელად შეიყვანეთ ახალი მალსახმობი."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "საკუთარი მალსახმობის დამატება"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "ორი თითით აწევ-ჩამოწევა"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "ორმაგი წკაპი, ძირითადი ღილაკი"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "ერთი წკაპი, ძირითადი ღილაკი"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "ორმაგი წკაპი, შუა ღილაკი"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "ერთი წკაპი, შუა ღილაკი"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "ორი წკაპი, მეორე ღილაკი"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "ერთი წკაპი, მეორე ღილაკი"
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "დაუცველი ქსელი (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "დაცული ქსელი (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "დაცული ქსელი (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "დაცული ქსელი (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "დაცული ქსელი"
+
+#~ msgid "Preserve"
+#~ msgstr "შენარჩუნება"
+
+#~ msgid "Permanent"
+#~ msgstr "სამუდამო"
+
+#~ msgid "Random"
+#~ msgstr "შემთხვევითი"
+
+#~ msgid "Stable"
+#~ msgstr "სტაბილური"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "პროფილი %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "დამატებითი გახსნა"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "კომპანიის"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "არა"
+
+#~ msgid "Never"
+#~ msgstr "არასდროს"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d მბ/წმ (%1.1f გჰც)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d მბ/წმ"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 გჰც / 5 გჰც"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 გჰც"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 გჰც"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "არა"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "სუსტი"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "დიახ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "კარგი"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "გადასარევი"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "შეერთების დავიწყება"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN-ის წაშლა"
+
+#~ msgid "Details"
+#~ msgstr "დეტალები"
+
+#~ msgid "automatic"
+#~ msgstr "ავტომატური"
+
+#~ msgid "Identity"
+#~ msgstr "იდენტიფიკაცია"
+
+#~ msgid "Delete Address"
+#~ msgstr "მისამართის წაშლა"
+
+#~ msgid "Delete Route"
+#~ msgstr "რაუტის წაშლა"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "არა"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit Passphrase"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "დინამიკური WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 პერსონალური"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 საწარმოო"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 პერსონალური"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "შეერთების ჩამსწორებლის გახსნის შეცდომა"
+
+#~ msgid "New Profile"
+#~ msgstr "ახალი პროფილი"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "არასწორი პარამეტრი %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "არასწორი პარამეტრი: %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "ფაილიდან შემოტანა…"
+
+#~ msgid "Add VPN"
+#~ msgstr "_VPN-ის დამატება"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN შეერთების შემოტანის შეცდომა"
+
+#~ msgid "Select file to import"
+#~ msgstr "აირჩიეთ შემოსატანი ფაილი"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "ფაილი სახელით %s უკვე არსებობს."
+
+#~ msgid "_Replace"
+#~ msgstr "_შეცვლა"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN შეერთების გატანის შეცდომა"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN შეერთების გატანა"
+
+#~ msgid "never"
+#~ msgstr "არასოდეს"
+
+#~ msgid "today"
+#~ msgstr "დღეს"
+
+#~ msgid "yesterday"
+#~ msgstr "გუშინ"
+
+#~ msgid "Last used"
+#~ msgstr "ბოლოს გამოყენებული"
+
+#~ msgid "Add new connection"
+#~ msgstr "ახალი შეერთების დამატება"
+
+#~ msgid "_Forget"
+#~ msgstr "_დავიწყება"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "ნაცნობი Wi-Fi ქსელები"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_დავიწყება"
+
+#~ msgid "Status unknown"
+#~ msgstr "სტატუსი უცნობია"
+
+#~ msgid "Unmanaged"
+#~ msgstr "უმართავი"
+
+#~ msgid "Unavailable"
+#~ msgstr "მიუწვდომელია"
+
+#~ msgid "Connecting"
+#~ msgstr "დაკავშირება"
+
+#~ msgid "Authentication required"
+#~ msgstr "საჭროა ავთენტიკაცია"
+
+#~ msgid "Disconnecting"
+#~ msgstr "გათიშვა"
+
+#~ msgid "Connection failed"
+#~ msgstr "შეერთების შეცდომა"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "სტატუსი უცნობია (აკლია)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "კონფიგურაციის შეცდომა"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP კონფიგურაციის შეცდომა"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP კონფიგურაციის ვადა გასულია"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP სერვისი გაითიშა"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP-ის შეცდომა"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP-ის კლიენტის შეცდომა"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-ის კლიენტის ავარია"
+
+#~ msgid "Line busy"
+#~ msgstr "ხაზი დაკავებულია"
+
+#~ msgid "No dial tone"
+#~ msgstr "ზუმერის გარეშე"
+
+#~ msgid "Network registration denied"
+#~ msgstr "ქსელში რეგისტრაცია უარყოფილია"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN-ის შემოწმების შეცდომა"
+
+#~ msgid "Modem not found"
+#~ msgstr "მოდემის პოვნა შეუძლებელია"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "BT შეერთების შეცდომა"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM ბარათი არ დევს"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM Pin აუცილებელია"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk აუცილებელია"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM არასწორია"
+
+#~ msgid "Firmware missing"
+#~ msgstr "მიკროკოდის გარეშე"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "კაბელი გამოერთებულია"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "უცნობი შეცდომა 802.1X უსაფრთხოებაში (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "ფაილი არჩეული არაა"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER ან PEM სერტიფიკატები"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "ცარიელი EAP-FAST PAC ფაილი"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ფაილები (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "აკლია EAP-LEAP მომხმარებლის სახელი"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "აკლია EAP-LEAP პაროლი"
+
+#~ msgid "missing EAP username"
+#~ msgstr "აკლია EAP მომხმარებლის სახელი"
+
+#~ msgid "missing EAP password"
+#~ msgstr "აკლია EAP-ის პაროლი"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "აკლია EAP-TLS იდენტიფიკატორი"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "აირჩიეთ პირადი სერტიფიკატი"
+
+#~ msgid "Choose your private key"
+#~ msgstr "აირჩეთ თქვენი პირადი გასაღები"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "უცნობი შეცდომა 802.1X უსაფრთხოების დადასტურებისას"
+
+#~ msgid "Select a file"
+#~ msgstr "აირჩიეთ ფაილი"
+
+#~ msgid "missing leap-username"
+#~ msgstr "აკლია leap-ის მომხმარებლის სახელი"
+
+#~ msgid "missing leap-password"
+#~ msgstr "აკლია LEAP-ის პაროლი"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "აკლია Wi-Fi-ის პაროლი."
+
+#~ msgid "missing wep-key"
+#~ msgstr "აკლია wep-key"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "არასწორი wep-key: გასაღები სიგრძით %zu მხოლოდ თექვსმეტობით ციფრებს უნდა "
+#~ "შეიცავდეს"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "არასწორი wep-key: გასაღების სიგრძით %zu მხოლოდ ASCII სიმბოლოებს უნდა "
+#~ "შეიცავდეს"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "არასწორი wep-key: გასაღების არასწორი სიგრძე %zu. გასაღები ან სიგრძის 5/13 "
+#~ "(ascii) უნდა იყოს, ან 10/26 (თექვსმეტობითი)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "არასწორი wep-key: საიდუმლო ფრაზა ცარიელი ვერ იქნება"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "არასწორი wep-key: საიდუმლო ფრაზა 64 სიმბოლოზე მოკლე უნდა იყოს"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "არასწორი wpa-psk: გასაღების არასწორი სიგრძე %zu. უნდა იყოს [8,63] ბაიტი, "
+#~ "ან 64 თექვსმეტობითი ციფრი"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "არასწორი wpa-psk: 64 ბაიტიანი გასაღების, როგორც ტექვსმეტობითის აღქმა "
+#~ "შეუძლებელია"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "სხვა"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "\"%s\" წაშლილია"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s ანგარიში"
+
+#~ msgid "Remove Account"
+#~ msgstr "ანგარიშის წაშლა"
+
+#~ msgid "Unknown time"
+#~ msgstr "უცნობი დრო"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "გაფრთხილება: დარჩენილია %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "დარჩენილია %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "სრულად დატენილი"
+
+#~ msgid "Not charging"
+#~ msgstr "არ იტენება"
+
+#~ msgid "Empty"
+#~ msgstr "ცარიელი"
+
+#~ msgid "Charging"
+#~ msgstr "იტენება"
+
+#~ msgid "Discharging"
+#~ msgstr "იცლება"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "უსადენო თაგუნა"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "უსადენო კლავიატურა"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "შეუფერხებელი კვების წყარო"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "პირადი ციფრული დამხმარე"
+
+#~ msgid "Cellphone"
+#~ msgstr "მობილური ტელეფონი"
+
+#~ msgid "Media player"
+#~ msgstr "მედია დამკვრელი"
+
+#~ msgid "Tablet"
+#~ msgstr "ტაბლეტი"
+
+#~ msgid "Computer"
+#~ msgstr "კომპიუტერი"
+
+#~ msgid "Gaming input device"
+#~ msgstr "სათამაშო შემყვანი მოწყობილობა"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "მთავარი"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "დამატებით"
+
+#~ msgid "Batteries"
+#~ msgstr "ელემენტები"
+
+#~ msgid "When _idle"
+#~ msgstr "უქმობისას"
+
+#~ msgid "Suspend"
+#~ msgstr "ძილი"
+
+#~ msgid "Power Off"
+#~ msgstr "გამორთვა"
+
+#~ msgid "Hibernate"
+#~ msgstr "პროგრამული ძილი"
+
+#~ msgid "Nothing"
+#~ msgstr "არაფერი"
+
+#~ msgid "When on battery power"
+#~ msgstr "ელემენტიდან კვებისას"
+
+#~ msgid "When plugged in"
+#~ msgstr "შეერთებული"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "არასდროს"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "ავტომატურად შეჩერება"
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "წარმადობა"
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "ბალანსირებული"
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "ელემენტის შენახვის რეჟიმი"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "ახალი პრინტერის დამატების შეცდომა"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "UI-ის ჩატვირთვის შეცდომა: %s"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s-ის დეტალები"
+
+#~ msgid "Select PPD File"
+#~ msgstr "აირჩიეთ PPD ფაილი"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript პრინტერის აღწერის ფაილები (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect ტიპის პრინტერი"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD პრინტერი"
+
+#~ msgid "One Sided"
+#~ msgstr "ერთმხრიანი"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "გრძელი წიბო (სტანდარტული)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "მოკლე წიბო (გადაბრუნება)"
+
+#~ msgid "Portrait"
+#~ msgstr "პორტრეტი"
+
+#~ msgid "Landscape"
+#~ msgstr "ლანდშაფტი"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "ლანდშაფტის შებრუნება"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "პორტრეტის შებრუნება"
+
+#~ msgid "Resume"
+#~ msgstr "გაგრძელება"
+
+#~ msgid "Pause"
+#~ msgstr "შეჩერება"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "დარჩენილი"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "შეჩერებულია"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "საჭროა ავთენტიკაცია"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "დამუშავება"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "გაჩერებულია"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "გაუქმებულია"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "შეწყვეტილია"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "დასრულებულია"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — აქტიური დავალებები"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "ბეჭდვის სერვერის განბლოკვა"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s-ის განბლოკვა."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "პრინტერების ძებნა"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "სერიული პორტი"
+
+#~ msgid "Parallel Port"
+#~ msgstr "პარალელური პორტი"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "მდებარეობა: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "მისამართი: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "სერვერი ითხოვს ავთენტიკაციას"
+
+#~ msgid "Two Sided"
+#~ msgstr "ორმხრივი"
+
+#~ msgid "Paper Type"
+#~ msgstr "ფურცლის ტიპი"
+
+#~ msgid "Paper Source"
+#~ msgstr "ქაღალდის წყარო"
+
+#~ msgid "Output Tray"
+#~ msgstr "გამოტანის თარო"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "გარჩევადობა"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript-ის პრეფილტრი"
+
+#~ msgid "Orientation"
+#~ msgstr "ორიენტაცია"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "ზოგადი"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "გვერდის მორგება"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "დაყენების ვარიანტები"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "დავალება"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "გამოსახულების ხარისხი"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "ფერი"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "სრულდება"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "დამატებით"
+
+#~ msgid "Test page"
+#~ msgstr "სატესტო გვერდი"
+
+#~ msgid "Auto Select"
+#~ msgstr "ავტომატური არჩევა"
+
+#~ msgid "Printer Default"
+#~ msgstr "პრინტერის ნაგულისხმები"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "მხოლოდ GhostScript-ის ფონტების ჩაშენება"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "პირველი დონის PS-ზე გადაყვანა"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "მეორე დონის PS-ზე გადაყვანა"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "პრეფილტრის გარეშე"
+
+#~ msgid "Out of toner"
+#~ msgstr "ტონერი გათავდა"
+
+#~ msgid "Open cover"
+#~ msgstr "თავსახური ღიაა"
+
+#~ msgid "Open door"
+#~ msgstr "კარის გაღება"
+
+#~ msgid "Low on paper"
+#~ msgstr "ფურცლები ცოტაა"
+
+#~ msgid "Out of paper"
+#~ msgstr "ქაღალდი გათავდა"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "გათიშული"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "გაჩერებულია"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "მზადაა"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "დავალებებს არ იღებს"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "დამუშავება"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "იმპერიული"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "მეტრული სისტემა"
+
+#~ msgid "Ask what to do"
+#~ msgstr "გვკითხეთ რჩევა"
+
+#~ msgid "Do nothing"
+#~ msgstr "არაფრის გაკეთება"
+
+#~ msgid "Open folder"
+#~ msgstr "საქაღალდის გახსნა"
+
+#~ msgid "Other Media"
+#~ msgstr "სხვა მედია"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "პროგრამის ამორჩევა აუდიო CD-ებისთვის"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "პროგრამის ამორჩევა ვიდეო DVD-ებისთვის"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "პროგრამის ამორჩევა პროგრამული CD-ებისთვის"
+
+#~ msgid "audio DVD"
+#~ msgstr "აუდიო DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "ცარიელი Blu-ray დისკი"
+
+#~ msgid "blank CD disc"
+#~ msgstr "ცარიელი CD დისკი"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "ცარიელი DVD დისკი"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "ცარიელი HD DVD დისკი"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray ვიდეო დისკი"
+
+#~ msgid "e-book reader"
+#~ msgstr "ელწიგნების წამკითხავი"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD ვიდეო დისკი"
+
+#~ msgid "Picture CD"
+#~ msgstr "ფოტო სურათებიანი CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "ვიდეო CD"
+
+#~ msgid "Windows software"
+#~ msgstr "Windows-ის პროგრამა"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "ეკრანი გაითიშება"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 წამი"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 წუთი"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 წუთი"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 წუთი"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 წუთი"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 წუთი"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 საათი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 წუთი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 წუთი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 წუთი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 წუთი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 წუთი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 წუთი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 წუთი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 წუთი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 წუთი"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "არასდროს"
+
+#~ msgid "Select Location"
+#~ msgstr "მდებარეობის არჩევა"
+
+#~ msgid "_OK"
+#~ msgstr "_დიახ"
+
+#~ msgid "No applications found"
+#~ msgstr "აპლიკაციები ნაპოვნი არაა"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "ჩართული"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "გამორთული"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "ჩართულია"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "აქტიური"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "აირჩიეთ საქაღალდე"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "მედიის გაზიარების ჩართვა"
+
+#~ msgid "Device name copied"
+#~ msgstr "მოწყობილობის სახელი კოპირებული"
+
+#~ msgid "Username copied"
+#~ msgstr "მომხმარებლის სახელი კოპირებულია"
+
+#~ msgid "Password copied"
+#~ msgstr "პაროლი დაკოპირდა"
+
+#~ msgid "Custom"
+#~ msgstr "სხვა"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s_ის ტესტირება"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "გათიშულია"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "დაკავშირება"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "დაკავშირებულია"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "ავტორიზაციის შეცდომა"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "ავტრიზაცია"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "შეზღუდული ფუნქციონალი"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "მიერთებული და ავტორიზებული"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "უცნობია"
+
+#~ msgid "Authorized at:"
+#~ msgstr "ავტორიზებული:"
+
+#~ msgid "Connected at:"
+#~ msgstr "დაკავშირებულია:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "მიერთებულია:"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "შეცდომა"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "ავტორიზებული"
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "შეცდომა მიმართვის რეჟიმის შეცვლისას: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "ნაგულისხმები"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "საშუალო"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "დიდი"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "უფრო დიდი"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "უდიდესი"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d პიქსელი"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "მოკლე"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ეკრანი"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ეკრანი"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ეკრანი"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "გრძელი"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 საათი"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 დღე"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 დღე"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 დღე"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 დღე"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 დღე"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 დღე"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 დღე"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 დღე"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 დღე"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "გნებავთ სანაგვე ყუთიდან ყველა ელემენტის წაშლა?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr ""
+#~ "მისამართების სიის გასუფთავების შემთხვევაში, თქვენ მათ სამუდამოდ წაშლით."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "ნაგვის _ყუთის დაცარიელება"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 დღე"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 დღე"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 დღე"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "სამუდამოდ"
+
+#~ msgid "Failed to add account"
+#~ msgstr "ანგარიშის დამატების შეცდომა"
+
+#~ msgid "Failed to register account"
+#~ msgstr "ანგარიშის რეგისტრაციის შეცდომა"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "ამ დომენში ავთენტიკაციის არცერთი ხერხი მხარდაჭერილი არაა"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "დომენზე დაერთების შეცდომა"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "დომენში შესვლის შეცდომა"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "მეტი სურათი"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "ამ ქმედების შესასრულებლად საჭიროა მოწყობილობის გამოთხოვა"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "ანაბეჭდების ჩამოთვლის შეცდომა: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "მარცხენა ცერა"
+
+#~ msgid "Left middle finger"
+#~ msgstr "მარცხენა შუა თითი"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_მარცხენა საჩვენებელი თითი"
+
+#~ msgid "Left ring finger"
+#~ msgstr "მარცხენა ბეჭედი თითი"
+
+#~ msgid "Left little finger"
+#~ msgstr "მარცხენა პატარა თითი"
+
+#~ msgid "Right thumb"
+#~ msgstr "მარჯვენა ცერა"
+
+#~ msgid "Right middle finger"
+#~ msgstr "მარჯვენა შუა თითი"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_მარჯვენა საჩვენებელი თითი"
+
+#~ msgid "Right ring finger"
+#~ msgstr "მარჯვენა ბეჭედი თითი"
+
+#~ msgid "Right little finger"
+#~ msgstr "მარჯვენა პატარა თითი"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "უცნობი თითი"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "დასრულებულია"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "ახალი ანაბეჭდის სკანირება"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "მოწყობილობის წაკითხვის შეცდოა"
+
+#~ msgid "This Week"
+#~ msgstr "ამ კვირაში"
+
+#~ msgid "Last Week"
+#~ msgstr "ბოლო კვირა"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "სესია დასრულდა"
+
+#~ msgid "Session Started"
+#~ msgstr "სესია დაიწყო"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — ანგარშის აქტივობა"
+
+#~ msgid "Please choose another password."
+#~ msgstr "აირჩიეთ სხვა პაროლი."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "მეორედ შეიყვანეთ თქვენი მიმდინარე პაროლი."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "პაროლის შეცვლა შეუძლებელია"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "ამ ტიპის დომენზე ავტომატური დაერთება შეუძლებელია"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "დომენი ან რეალმის სახელი ნაპოვნი არაა"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s-ში %s დომენით შესვლა შეუძლებელია"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "არასწორი პაროლი. თავიდან სცადეთ"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "დომენთან დაკავშირების პრობლემა (%s): %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "მომხმარებლის წაშლის შეცდომა"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "საკუთარ ანგარიშს ვერ წაშლით."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ჯერ კიდევ შესულია"
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "გნებავთ %s-ის ფაილების შენარჩუნება?"
+
+#~ msgid "_Delete Files"
+#~ msgstr "_ფაილების წაშლა"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_ფაილების შენარჩუნება"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "დარწმუნებული ხართ, რომ გსურთ %s-ის სამუდამოდ წაშლა?"
+
+#~ msgid "_Delete"
+#~ msgstr "_წაშლა"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "ანგარიში გათიშულია"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "დაყენებული იქნება შემდეგი შემოსვლისას"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "არა"
+
+#~ msgid "Logged in"
+#~ msgstr "შესული"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "ანგარიშების სერვისთან კავშირის შეცდომა"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "გთხოვთ დარწმუნდეთ, რომ AccountService სწორადაა დაყენებული და ჩართულია."
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "საჭიროა, რომ პაროლი განსხვავდებოდეს იმისგან, რაც ეყენა."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "სცადეთ კიდევ ოდნავ შეცვალოთ პაროლი."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "შეურიეთ დიდი და პატარა ასოები და სცადეთ გამოიყენოთ რამდენიმე ციფრი."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "მეტი ციფრები, ასოები და პუნქტუაციის ნიშნები პაროლს უფრო გააძლიერებს."
+
+#~ msgid "Authentication failed"
+#~ msgstr "ავთენტიკაციის შეცდომა"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "ახალი პაროლი ძალიან მოკლეა"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "ახალი პაროლი ძალიან მარტივია"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "ახალი და ძველი პაროლები ერთმანეთს ჰგვანან"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "ეს პაროლი ახლახანს გამოიყენეთ."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "ახალი პაროლი ციფრებს ან სიმბოლოებს უნდა შეიცავდეს"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "ძველი და ახალი პაროლი ერთი და იგივიეა"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "უკანასკნელი ავტორიზაციის შემდეგ თქვენი პაროლი შეიცვალა!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "ახალი პაროლი საკმარისად განსხვავებულ სიბოლოებს არ შეიცავს"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "უცნობი შეცდომა"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "მომხმარებლის სახელი მიუწვდომელია. სხვა სცადეთ."
+
+#~ msgid "The username is too long."
+#~ msgstr "მომხმარებლის სახელი ძალიან გრძელია."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "ღილაკი %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "აპლიკაციის განსაზღვრულია"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "ეკრანის გადარტვა"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "ეკრანზე დახმარების ჩვენება"
+
+#~ msgid "All Displays"
+#~ msgstr "ყველა ეკრანი"
+
+#~ msgid "New shortcut…"
+#~ msgstr "ახალი მალსახმობი…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "ოპერაცია გაუქმდა"
+
+#~ msgid "Not Registered"
+#~ msgstr "არაა რეგისტრირებული"
+
+#~ msgid "Registered"
+#~ msgstr "რეგისტრირებულია"
+
+#~ msgid "Roaming"
+#~ msgstr "როუმინგი"
+
+#~ msgid "Searching"
+#~ msgstr "ძებნა"
+
+#~ msgid "Denied"
+#~ msgstr "Უარყოფილი"
+
+#~ msgid "2G Only"
+#~ msgstr "მხოლოდ 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "მხოლოდ 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "მხოლოდ 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "მხოლოდ 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (პრივილეგირებული)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (პრივილეგირებული), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (პრივილეგირებული), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (პრივილეგირებული), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (პრივილეგირებული)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (პრივილეგირებული), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (პრივილეგირებული), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (პრივილეგირებული)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (პრივილეგირებული), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (პრივილეგირებული), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (პრივილეგირებული)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (პრივილეგირებული), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (პრივილეგირებული), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (პრივილეგირებული)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (პრივილეგირებული), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (პრივილეგირებული), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (პრივილეგირებული)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (პრივილეგირებული), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (პრივილეგირებული)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (პრივილეგირებული), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (პრივილეგირებული)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (პრივილეგირებული), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (პრივილეგირებული)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (პრივილეგირებული), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (პრივილეგირებული)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (პრივილეგირებული), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (პრივილეგირებული)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (პრივილეგირებული), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "უცნობია"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "SIM-ის განბლოკვა"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "შეყვანილი პაროლი არასწორია."
+
+#~ msgid "Enter New PIN"
+#~ msgstr "შეიყვანეთ ახალი PIN კოდი"
+
+#~ msgid "Unlocking…"
+#~ msgstr "განბლოკვა…"
+
+#~ msgid "Phone failure"
+#~ msgstr "ტელეფონის შეცდომა"
+
+#~ msgid "No connection to phone"
+#~ msgstr "ტელეფონთან კავშირი არ არსებობს"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "ოპერაცია დაუშვებელია"
+
+#~ msgid "Operation not supported"
+#~ msgstr "ოპერაცია მხარდაუჭერელია"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM ბარათი არ დევს"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM Pin აუცილებელია"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM Puk აუცილებელია"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM ბარათის შეცდომა"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM დაკავებულია"
+
+#~ msgid "Incorrect password"
+#~ msgstr "არასწორი პაროლი"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM PIN2 აუცილებელია"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM PUK2 აუცილებელია"
+
+#~ msgid "Not found"
+#~ msgstr "ნაპოვნი არაა"
+
+#~ msgid "No network service"
+#~ msgstr "ქსელის სერვისის გარეშე"
+
+#~ msgid "Network timeout"
+#~ msgstr "ქსელის მოლოდინის ვადა გავიდა"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS სერვისი დაუშვებელია"
+
+#~ msgid "No Error"
+#~ msgstr "შეცდომის გარეშე"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "ქმედება გაუქმდა"
+
+#~ msgid "Access denied"
+#~ msgstr "წვდომა აკრძალულია"
+
+#~ msgid "Unknown Error"
+#~ msgstr "უცნობი შეცდომა"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "ვერსიის ინფორმაციის ჩვენება"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "დამატებითი შეტყობინებების ჩართვა"
+
+#~ msgid "Search for the string"
+#~ msgstr "საძებნი სტრიქონი"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "შესაძლო პანელების სიის გამოტანა და გასვლა"
+
+#~ msgid "Panel to display"
+#~ msgstr "საჩვენებელი პანელი"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[პანელი] [არგუმენტი…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "ხელმისაწვდომი პანელები:"
+
+#~ msgid "System Sounds"
+#~ msgstr "სისტემური ხმები"
 
 #~ msgid "Secure Boot is Inactive"
 #~ msgstr "დაცული ჩატვირთვა გამორთულია"
@@ -9334,9 +7266,6 @@ msgstr "სისტემური ხმები"
 
 #~ msgid "Lock your screen"
 #~ msgstr "ეკრანის დაბლოკვა"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "პრინტერის დამატება…"
 
 #~ msgid "Drip"
 #~ msgstr "წვეთი"
@@ -10030,9 +7959,6 @@ msgstr "სისტემური ხმები"
 #~ msgid "Copying '%s'"
 #~ msgstr "ვაკოპირებ '%s'"
 
-#~ msgid "Parent Window"
-#~ msgstr "დედობილი ფანჯარა"
-
 #~ msgid "Parent window of the dialog"
 #~ msgstr "დიალოგის დედობილი ფანჯარა"
 
@@ -10044,9 +7970,6 @@ msgstr "სისტემური ხმები"
 
 #~ msgid "URI currently transferring to"
 #~ msgstr "URI, ჩაწერის დანიშნულება"
-
-#~ msgid "Fraction completed"
-#~ msgstr "ნაწილი დასრულებულია"
 
 #~ msgid "Fraction of transfer currently completed"
 #~ msgstr "ნაწილის გადატანა ჩატარებულია"
@@ -10580,9 +8503,6 @@ msgstr "სისტემური ხმები"
 #~ "ეკრანის ბლოკირება გარკვეული დროის შემდეგ, კლავიშების განმეორებითი დაჭერის "
 #~ "მიერ გამოწვეული ზიანის თავიდან აცილების მიზნით"
 
-#~ msgid "Reset to De_faults"
-#~ msgstr "ნა_გულისხმევზე დაყენება"
-
 #~ msgid "S_peed:"
 #~ msgstr "_სიჩქარე:"
 
@@ -10624,9 +8544,6 @@ msgstr "სისტემური ხმები"
 
 #~ msgid "_Work interval lasts:"
 #~ msgstr "_სამუშაო ინტერვალი გრძელდება:"
-
-#~ msgid "Layout"
-#~ msgstr "განლაგება"
 
 #~ msgid "Vendors"
 #~ msgstr "მწარმოებელი"
@@ -10706,9 +8623,6 @@ msgstr "სისტემური ხმები"
 
 #~ msgid "Thr_eshold:"
 #~ msgstr "_ზღვარი:"
-
-#~ msgid "_Acceleration:"
-#~ msgstr "_აჩქარება:"
 
 #~ msgid "_Left-handed"
 #~ msgstr "_ცაცია თაგვი"
@@ -10800,9 +8714,6 @@ msgstr "სისტემური ხმები"
 
 #~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
 #~ msgstr "<span weight=\"bold\" size=\"larger\">შემოწმება...</span>"
-
-#~ msgid "Click OK to finish."
-#~ msgstr "\"დიახ\" ტესტის დასრულებისთვის."
 
 #~ msgid "Play _alert sound"
 #~ msgstr "სისტემური ხმის _დაკვრა"
@@ -10931,9 +8842,6 @@ msgstr "სისტემური ხმები"
 
 #~ msgid "Set your window properties"
 #~ msgstr "თქვენი ფანჯრის პარამეტრების მითითება"
-
-#~ msgid "Windows"
-#~ msgstr "ფანჯრები"
 
 #, c-format
 #~ msgid "<b>Start %s</b>"

--- a/po/ka.po~
+++ b/po/ka.po~
@@ -1,0 +1,11847 @@
+# translation of gnome-control-center.po to Georgian
+# Georgian translation for Gnome Control Centre.
+#
+# Alexander Didebulidze <didebuli@in.tum.de>, 2005, 2006.
+# Vladimer Sichinava <alinux@siena.linux.it>, 2006.
+# Zviad Sulaberidze <zviad@osgf.ge>, 2006.
+# Vladimer Sichinava ვლადიმერ სიჭინავა <vsichi@gnome.org>, 2007.
+# Vladimer Sichinava <vsichi@gnome.org>, 2008.
+# Vladimer Sichinava  ვლადიმერ სიჭინავა <vsichi@gnome.org>, 2008.
+# Ekaterine Papava <papava.e@gtu.ge>, 2022.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-10-25 14:38+0000\n"
+"PO-Revision-Date: 2022-12-05 17:30+0100\n"
+"Last-Translator: Ekaterine Papava <papava.e@gtu.ge>\n"
+"Language-Team: Georgian <http://mail.gnome.org/mailman/listinfo/gnome-ge-"
+"list>\n"
+"Language: ka\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "სისტემური მატარებელი"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "სრული წვდომა"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "სესიების მატარებელი"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "მოწყობილობა"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "სრული წვდომა /dev-თან"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "ქსელი"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "აქვს ქსელთან წვდომა"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "სახლი"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "მხოლოდ წაკითხვა"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "ფაილური სისტემა"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "მორგება"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "პარამეტრები შეცვლადია"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s-ს შემდეგი წვდოები გააჩნია. მათი შეცვლა შეუძლებელია. თუ ნერვიულობთ "
+"უსაფრთხოებაზე, სჯობს წაშალოთ ეს აპლიკაცია."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u ფაილი და ბმულის ტიპები აპლიკაციით გაიხსნება"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> გამოიყენება შემდეგი ტიპის ფაილებისა და ბმულების გასახსნელად."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "დისკზე დაკავებული ადგილი: %s."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "აპლიკაციები"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "აპლიკაციების გარეშე"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "დაყენება…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "გახსნა"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "დეტალური ხედი"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "ძებნა"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "სისტემის ძებნის მიღება და პასუხების გაგზავნა."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "გამორთული"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "გაფრთხილებები"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "სისტემური შეტყობინებების ჩვენება."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "ფონურად გაშვება"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "აქტივობების დაშვება მაშინაც კი, როცა აპლიკაცია დახურულია."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "ეკრანის ანაბეჭდები"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "გადაიღეთ ეკრანის ანაბეჭდები ნებისმიერ დროს."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "ფონის სურათის შეცვლა"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "ფონის სურათის შეცვლა."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "ხმები"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "ხმების გამოცემა."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "მალსახმობების გათიშვა"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "კლავიატურის სტანდართული მალსახმობების დაბლოკვა."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "კამერა"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "კამერით სურათების ჩაწერა."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "მიკროფონი"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "მიკროფონით ხმის ჩაწერა."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "მდებარეობის სერვისები"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "მოწყობილობის მდებარეობის მონაცემებთან წვდომა."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "ჩაშენებული წვდომები"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "აპლიკაციისთვის საჭირო სისტემური წვდომები"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "ფაილების &amp ბმულების მიბმები"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "საცავი"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "შედეგების გარეშე"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "სცადეთ სხვა ძებნა"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "ფაილების & ბმულების მიბმები"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "ფაილის ტიპები"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "ბმულის ტიპები"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "საწყისი პარამეტრები"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "რამდენი ადგილი მიაქვს აპლიკაციას, მონაცემების და ქეშის ჩათვლით."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "აპლიკაცია"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "მონაცემები"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "კეში"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>ჯამში</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "ქეშის გასუფთავება…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "აპლიკაციის სხვადასხვა პარამეტრებისა და წვდომების კონტროლი"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "application;flatpak;permission;setting;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "აირჩიეთ სურათი"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_გაუქმება"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_გახსნა"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "მრავალი ზომა"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "სამუშაო მაგიდის ფონის გარეშე"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "მიმდინარე ფონი"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "სტილი"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "ნაგულისხმევი"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "ბნელი"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "ფონი"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "სურათის დამატება…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "გარემოს იერსახე"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "შეცვალეთ ფონის სურათი ან ინტერფეისის ფერები"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "ჩართვა"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Bluetooth ნაპოვნი არაა"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Bluetooth-ის გამოსაყენებლად შეაერთეთ ის."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth გამორთულია"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "თვითმფრინავის რეჟიმი ჩართულია"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "თვითმფრინავის რეჟმის გამორთვა"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "აპარატურული თვითმფრინავის რეჟიმი ჩართულია"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "კამერა გამოღთულია"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "დაიცავით თქვენი სურათები"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "დახურეთ ნოუთბუქი"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr ""
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr ""
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "პროფილის გენერაცია შეუძლებელია."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr ""
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "დასურლდა!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "კალიბრაციის შეცდომა!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "კალიბრაციის მოწყობილობა შეგიძლიათ მოაცილოთ."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "არ შეაწუხოთ მოწყობილობის კალიბრაცია, სანამ ის მიმდინარეობს"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "ეკრანის კალიბრაცია"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_დაწყება"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_გაგრძელება"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_დასრულებულია"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "ნოუთბუქის ეკრანი"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "ჩაშენებული ვებკამერა"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s ეკრანი"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s სკანერი"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s კამერა"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s პრინტერი"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s ვებკამერა"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s-სთვის ფერების მართვის ჩართვა"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s-თვის ფერის პროფილების ნახვა"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "კალიბრირებული არაა"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "ნაგულისხმები: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "ფერების სივრცე: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "სატესტო პროფილი: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "აირჩიეთ ICC პროფილის ფაილი"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_შემოტანა"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "მხარდაჭერილი ICC profilebi"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "ყველა ფაილი"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "ეკრანი"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "პროფილის შენახვა"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "შ_ენახვა"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "მონიშნული  მოწყობილობისთვის ფერის პროფილის შექმნა"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"გამზომი ინსტრუმენტი ვერ ვიპოვე. დარწმუნდით, რომ ის ჩართული და სწორად "
+"მიერთებულია."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "მზომავ მოწყობილობას პრინტერის პროფილირების მხარდაჭერა არ გააჩნია."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "მოწყობილობის ტიპი ამჟამად მხარდაჭერილი არაა."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "ეკრანის კალიბრაცია"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "კალიბრაციის ხარისხი"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "ხარისხი"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "დაახლოებითი დრო"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "მოწყობილობის კალიბრაცია"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "ეკრანის ტიპი"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "პროფილის თეთრი წერტილი"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "ეკრანს სიკაშკაშე"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "პროფილის სახელი"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "პროფილის სახელი:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "შეჯამება"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "პროფილი წარმატებით შეიქმნა!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "პროფილის კოპირება"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "ესაჭიროება ჩაწერადი მედია"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "პროფილის დამატება"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_ფაილის შემოტანა…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "დ_ამატება"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "მეტის გაგება"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_ყველა მომხმარებლისთვის დაყენება"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_ჩართვა"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_პროფილის დამატება"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_კალიბრაცია…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "ამ მოწყობილობის კალიბრაცია"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_პროფილის წაშლა"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_დეტალური ხედი"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "პროექტორი"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "მაღალი"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 წუთი"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "საშუალო"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 წუთი"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "დაბალი"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 წუთი"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "ადგილობრივი ეკრანი"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "სტანდარტული სივრცე"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "პროფილის შემოწმება"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "ავტომატური"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "დაბალ ხარისხი"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "საშუალო ხარისხი"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "მაღალი ხარისხი"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "ნაგულისხმები RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "ნაგულისხმები CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "ნაგულისხმები ნაცრისფერი"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "ფერი"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "სხვა…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "აირჩიეთ ენა"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_არჩევა"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "ენები ნაპოვნი არაა"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "მეტი…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "განბლოკვა…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "საათის გაზრდა"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "წუთის გაზრდა"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "დრო"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "საათის შემცირება"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "წუთის შემცირება"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "დღეს"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "გუშინ"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d საათი"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d წუთი"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d წამი"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 წამი"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "ჰოტსპოტი"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-სთ"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "თარიღი & დრო"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "წელი"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "თვე"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "იანვარი"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "თებერვალი"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "მარტი"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "აპრილი"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "მაისი"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "ივნისი"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "ივლისი"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "აგვისტო"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "სექტემბერი"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ოქტომბერი"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "ნოემბერი"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "დეკემბერი"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "დღე"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "დროის სარტყელი"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "ქალაქის მოძებნა"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "თარიღი და დრო"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "დროის სარტყელის ავტომატურად დაყენება"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "ჩართულია"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "დროის სარტყელი"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "დროის ფორმატი"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "დროისა და თარიღის ცვლილება, დროის სარტყელის ჩატვლით"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "საათი;დროის სარტყელი;მდებარეობა;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "სისტემის დროისა და თარიღის პარამეტრების მორგება"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_ვები"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_ფოსტა"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "კალე_ნდარი"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_მუსიკა"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_ვიდეო"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_ფოტოები"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "ნაგულისხმევი აპლიკაციები"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "ნაგულისხმევი აპლიკაციების მორგება"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "პრობლემის გადაგზავნა"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "პრობლემის ავტომატური _ანგარიში"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "დიაგნოსტიკა"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "პრობლემის შესახებ შეტყობინება"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "დიაგნოსტიკა;ავარია;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "ჩართული"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "გამორთული"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "გადავატარო ცვლილებები?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "ცვლილებების გადატარება შეუძლებელია"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_გადატარება"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "უკან"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "ეკრანის მორგება გათიშულია"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "ბევრი ეკრანი"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "შეერთება"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "სარკე"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "ძირითად ეკრანი"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "ღამის სინათლე"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "ლანდშაფტი"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "პორტრეტი მარჯვნივ"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "პორტრეტი მარცხნივ"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "ლანდშაფტი (გადაბრუნებული)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf ჰც"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "ორიენტაცია"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "გარჩევადობა"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "განახლების სიხშირე"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "TV-სთვის მორგება"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "გადიდება"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "ღამის სინათლე მიუწვდომელია"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "ფილტრის გადატვირთვა"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "განრიგი"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "დაისიდან აისამდე"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "ხელით მითითება"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "-ჯერ"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "URI-დან"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "საათი"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "წუთი"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "ფერის ტერმპერატურა"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "ეკრანები"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "დაცული ჩატვირთვა ჩართულია"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "დაცული ჩარტვირთვის პრობლემები"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "დაცული ჩატვირთვა გამორთულია"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "გაიარა"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "ჩაიშალა"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "უსაფრთხოების დონე 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "უსაფრთხოების დონე 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "უსაფრთხოების დონე 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "უსაფრთხოების დონე 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "უსაფრთხოების დონე"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr ""
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "დონე 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "დონე 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "დონე 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "დაცული ჩარტვირთვის პრობლემები"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "დაცული ჩატვირთვა გამორთულია"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "ღონისძიებების გარეშე"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "მიკროკოდის ჩაწერის დაცვა"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "მიკროკოდის ჩაწერის დაცვის დაბლოკვა"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "მიკროკოდის BIOS-ის რეგიონი"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "მიკროკოდის BIOS-ის დესკრიპტორი"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "ჩატვირთვამდელი DMA-ის დაცვა"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard-ით შემოწმებული ჩატვირთვა"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM-ით დაცული"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard-ის შეცდომების პოლიტიკა"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard-ის პატრუქი"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET ჩართულია"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET ჩართულია"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "დაშიფრული RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU უსაფრთხოება"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux-ის ბირთვის დაბლოკვა"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux-ის ბირთვის შემოწმება"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "RAM-ში შეჩერება"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "უქმობამდე შეჩერება"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI პლატფორმის გასაღები"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI უსაფრთხო ჩატვირთვა"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM პლატფორმის მორგება"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM -ის რემონტი"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine -ისმწარმოებლის რეჟიმი"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine -ის გადაფარვა"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine -ის ვერსია"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "მიკროკოდის განახლებები"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "მიკროკოდის ატესტაცია"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "მიკროკოდის გამნახლებლის შემოწმება"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "პლატფორმის გამართვა"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "პროცესორის უსაფრთხოების შემოწმება"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD-ის მიკროკოდის ვერსიის ჩამოწევისგან დაცვა"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD-ის მიკროკოდის თავიდან ჩაწერისგან დაცვა"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD-ის მიკროკოდში ჩაწერისგან დაცვა"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr ""
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "სწორი"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "არასწორია"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "არ არის ჩართული"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "დაბლოკილი"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "დაბლოკილი არაა"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "დაშიფრული"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "არ არის დაშიფრული"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr ""
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "ყველა მოდული ლიცენზირებულია"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "ნაპოვნი"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "ნაპოვნი არაა"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "მხარდაჭერილი"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "მხარდაუჭერელია"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "მოწყობილობის უსაფრთხოება"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "ჰოსტის მიკროკოდის უსაფრთხოების მდგომარეობა"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "უცნობი"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-ბიტიანი"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-ბიტიანი"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "უცნობია"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "მიუწვდომელია"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "სისტემის ლოგო"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "მოწყობილობის სახელი"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "აპარატურის მოდელი"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "მეხსიერება"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "პროცესორი"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "გრაფიკა"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "დისკის მოცულობა"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "გამოთვლა…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "ოს-ის სახელი"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ოს-ის აგების ID"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "ოს-ის ტიპი"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME-ის ვერსია"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "ჩატვირთვა…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "ფანჯრული სისტემა"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "ვირტუალიზაცია"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "პროგრამული განახლებები"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "მოწყობილობის სახელის გადარქმევა"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "მოწყობილობის სახელი"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_გადარქმევა"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "შესახებ"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "ინფორმაცია ამ სისტემის შესახებ"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "ხმა და მედია"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "ხმის დადუმება/ხმის აწევა"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "ხმის ჩაწევა"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "ხმის აწევა"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "მიკროფონის დადუმება/დადუმების მოხსნა"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "მედია დამკვრელი"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "დაკვრა (ან დაკვრა/პაუზა)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "დაკვრის შეჩერება"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "დაკვრის გაჩერება"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "წინა აუდიობილიკი"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "შემდეგი აუდიობილიკი"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "მოხსნა"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "აკრეფა"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "შემოტანის შემდეგ წყაროზე გადართვა"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "შემოტანის წინა წყაროზე გადართვა"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "გამშვებები"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "დახმარების ბრაუზერის გაშვება"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "კალკულატორის გაშვება"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "ელფოსტის კლიენტის გაშვება"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "ბრაუზერის გაშვება"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "საწყისი საქაღალდე"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ძებნა"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "სისტემა"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "გასვლა"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "ეკრანის დაბლოკვა"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "_დამხმარე საშუალებები"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "გადიდების ჩართვა/გამორთვა"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "&გადიდება"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "დაპატარავება"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "ეკრანის წამკითხველის ჩართვა/გამორთვა"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "ეკრანზე ნაჩვენებ კლავიატურის ჩართვა/გამორთვა"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "ტექსტის ზომის გადიდება"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "ტექსტის ზომის შემცირება"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "მაღალი კონტრასტის ჩართვა და გამორთვა"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "შეყვანის წყაროების გარეშე"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "სხვა"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "შეყვანის წყაროს დამატება"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "პარამეტრები"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "აწევა"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "ჩამოწევა"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "გამართვა"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "კლავიატურის განლაგების გადახედვა"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "წაშლა"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "საკუთარი მალსახმობი"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "მარცხენა Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "მარჯვენა Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "მარცხენა Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "მარჯვენა Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "მენიუს ღილაკი"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "მარჯვენა Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "თაგუნას ღილაკები"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "ეკრანის დაბეჭდვა"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "შემოტანის წყაროები"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "შემოტანის წყაროს გადართვა"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "ყველა პროტოკოლისთვის იგივე პროქსის _გამოყენება"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "სპეციალური სიმბოლოს ჩანაწერი"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "კლავიატურის მალსახმობები"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "მალსახმობების ნახვა და მორცება"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d შეცვლილია"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "დავაბრუნო ყველა მალსახმობი საწყის მნიშვნელობაზე?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "გაუქმება"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "ყველა საწყისი მნიშვნელობის დაბრუნება"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "სექცია"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "მალსახმობები"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "მალსახმობის დამატება"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "საკუთარი მალსახმობების დამატება"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "მალსახმობის დამატება"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "კლავიატურის მალსახმობები ნაპოვნი არაა"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "შეიყვანეთ ახალი მალსახმობი"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "საკუთარი მალსახმობის დაყენება"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "მალსახმობის დაყენება"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "%s-ის შესაცვლელად შეიყვანეთ ახალი მალსახმობი."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "საკუთარი მალსახმობის დამატება"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_წაშლა"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_ჩანაცვლება"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_დაყენება"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "სახელი"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "ბრძანება"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "მალსახმობი"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "მალსახმობის დაყენება…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "არა"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "კლავიატურა"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "მდებარეობის სერვისები გამორთულია"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "თქვენი მდებარეობის ინფორმაციის დაცვა"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "მიკროფონი გამორთულია"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "პარამეტრების _შემოწმება"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "საერთო"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "ძირითადი ღილაკი"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "მარცხნივ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "მარჯვნივ"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "თაგუნა"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "თაგუნას სიჩქარე"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "თაჩპედი"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "თაჩპედის სიჩქარე"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "დასაწკაპუნებლად დაატყაპუნეთ"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "დასაწკაპუნებლად შეეხეთ"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "ორი თითით აწევ-ჩამოწევა"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "კიდით აწევ-ჩამოწევა"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "ორმაგი წკაპი, ძირითადი ღილაკი"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "ერთი წკაპი, ძირითადი ღილაკი"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "ორმაგი წკაპი, შუა ღილაკი"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "ერთი წკაპი, შუა ღილაკი"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "ორი წკაპი, მეორე ღილაკი"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "ერთი წკაპი, მეორე ღილაკი"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "თაგუნა & თაჩპედი"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_ცხელი კუთხე"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "სამუშაო სივრცეები"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "მრავალი ეკრანი"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "აპლიკაციების გადართვა"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "მრავალამოცანიანობა"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "სხვა მოწყობილობები"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "შეერთების დამატება"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "მორგებული არაა"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "დაუცველი ქსელი (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "დაცული ქსელი (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "დაცული ქსელი (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "დაცული ქსელი (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "დაცული ქსელი"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "დაკავშირებულია"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "პარამეტრები…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "ქსელის სახელი"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "პაროლი"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "პაროლის ავტომატური გენერაცია"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_ჩართვა"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "თვითმფრინავის რეჟიმი"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "თვითმფრინავის რეჟიმი ჩართულია"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "ხილული ქსელები"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x _უსაფრთხოება"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "უსაფრთხოება"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "შენარჩუნება"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "სამუდამო"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "შემთხვევითი"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "სტაბილური"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "პროფილი %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "დამატებითი გახსნა"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "კომპანიის"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "არა"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "არასდროს"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i დღის წინ"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d მბ/წმ (%1.1f გჰც)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d მბ/წმ"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 გჰც / 5 გჰც"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 გჰც"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 გჰც"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "არა"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "სუსტი"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "დიახ"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "კარგი"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "გადასარევი"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 მისამართი"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 მისამართი"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP მისამართი"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "შეერთების დავიწყება"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "VPN-ის წაშლა"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "დეტალები"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "ავტომატური"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "იდენტიფიკაცია"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "მისამართის წაშლა"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "რაუტის წაშლა"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "არა"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit Passphrase"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "დინამიკური WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 პერსონალური"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 საწარმოო"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 პერსონალური"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "სიგნალის სიძლიერე"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "შეერთების სიჩქარე"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "აპარატურული მისამართი"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "მხარდაჭერილი სიხშირეები"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "ნაგულისხმები რაუტი"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "ბოლოს გამოყენებული"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "_ავტომატურად დაკავშირება"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_სახელი"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC მისამართი"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_კლონირებული მისამართი"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "ბაიტები"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "_IPv4-ის მეთოდი"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "ავტომატური (მხოლოდ DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Link-Local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "ხელით"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "გამორთვა"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "გაზიარებული სხვა კომპიუტერებთან"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "მისამართები"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "მისამართი"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "ქსელური ნიღაბი"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "ნაგულისხმები რაუტერი"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "ავტომატური"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "ავტომატური DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS სერვერის მისამართები"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "რაუტები"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "ავტომატური რაუტები"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "მეტრული სისტემა"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "_IPv6-ის მეთოდი"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "ავტომატური (მხოლოდ DHCP)"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "პრეფიქსი"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "შეერთების ჩამსწორებლის გახსნის შეცდომა"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "ახალი პროფილი"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "არასწორი პარამეტრი %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "არასწორი პარამეტრი: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "ფაილიდან შემოტანა…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "_VPN-ის დამატება"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_უსაფრთხოება"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "VPN შეერთების შემოტანის შეცდომა"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "აირჩიეთ შემოსატანი ფაილი"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "ფაილი სახელით %s უკვე არსებობს."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_შეცვლა"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "VPN შეერთების გატანის შეცდომა"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "VPN შეერთების გატანა"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "არასოდეს"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "დღეს"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "გუშინ"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "ბოლოს გამოყენებული"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "მავთულით"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "ახალი შეერთების დამატება"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_დავიწყება"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "ნაცნობი Wi-Fi ქსელები"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_დავიწყება"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr ""
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "მოწყობილობის გამორთვა"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "აქტიური"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "სერვისის მომწოდებელი"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "ქსელის პროქსი"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP პროქსი"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTP პროქსი"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP პროქსი"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Socks _ჰოსტი"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_იგნორირებული ჰოსტები"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "H_TTP პროქსის პორტი"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "H_TTPS პროქსის პორტი"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "_FTP პროქსის პორტი"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "SOCKS პროქსის პორტი"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_კონფიგურაციის URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN შეერთებების გამორთვა"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "ქსელის სახელი"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "დაცვის ტიპი"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "პაროლი"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi-ის გამორთვა"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "მეტი პარამეტრი…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_დამალულ ქსელთან მიერთება…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "სტატუსი უცნობია"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "უმართავი"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "მიუწვდომელია"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "დაკავშირება"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "საჭროა ავთენტიკაცია"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "გათიშვა"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "შეერთების შეცდომა"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "სტატუსი უცნობია (აკლია)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "კონფიგურაციის შეცდომა"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP კონფიგურაციის შეცდომა"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP კონფიგურაციის ვადა გასულია"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP სერვისი გაითიშა"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP-ის შეცდომა"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP-ის კლიენტის შეცდომა"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP-ის კლიენტის ავარია"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "ხაზი დაკავებულია"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "ზუმერის გარეშე"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "ქსელში რეგისტრაცია უარყოფილია"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN-ის შემოწმების შეცდომა"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "მოდემის პოვნა შეუძლებელია"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "BT შეერთების შეცდომა"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM ბარათი არ დევს"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM Pin აუცილებელია"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM Puk აუცილებელია"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM არასწორია"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "მიკროკოდის გარეშე"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "კაბელი გამოერთებულია"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "უცნობი შეცდომა 802.1X უსაფრთხოებაში (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "ფაილი არჩეული არაა"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER ან PEM სერტიფიკატები"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "ცარიელი EAP-FAST PAC ფაილი"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC ფაილები (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "ანონიმურად"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "ავთენტიფიცირებული"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "ორივე"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "ანონიმური იდენტიფიკატორი"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_PAC ფაილი"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "აირჩიეთ PAC ფაილი"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_შიდა ავთენტიკაცია"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC-ით ავტომატური მორგების ჩართვა"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "აკლია EAP-LEAP მომხმარებლის სახელი"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "აკლია EAP-LEAP პაროლი"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_მომხმარებელი"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_პაროლი"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "პაროლის _ჩვენება"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "ვერსია 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "ვერსია 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "_CA სერტიფიკატი"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "CA სერტიფიკატი _საჭირო არაა"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP-ის ვერსია"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "აკლია EAP მომხმარებლის სახელი"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "აკლია EAP-ის პაროლი"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "აკლია EAP-TLS იდენტიფიკატორი"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "აირჩიეთ პირადი სერტიფიკატი"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "აირჩეთ თქვენი პირადი გასაღები"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_იდენტიფიკატორი"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "მომხმარებლის _სერტიფიკატი"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "პირადი _გასაღები"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_პირადი გასაღების პაროლი"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (არა- EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_დომენი"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "უცნობი შეცდომა 802.1X უსაფრთხოების დადასტურებისას"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS გვირაბი (TTLS)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "დაცული EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_ავთენტიკაცია"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "აირჩიეთ ფაილი"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "აკლია leap-ის მომხმარებლის სახელი"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "აკლია LEAP-ის პაროლი"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "აკლია Wi-Fi-ის პაროლი."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_ტიპი"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "აკლია wep-key"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"არასწორი wep-key: გასაღები სიგრძით %zu მხოლოდ თექვსმეტობით ციფრებს უნდა "
+"შეიცავდეს"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"არასწორი wep-key: გასაღების სიგრძით %zu მხოლოდ ASCII სიმბოლოებს უნდა "
+"შეიცავდეს"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"არასწორი wep-key: გასაღების არასწორი სიგრძე %zu. გასაღები ან სიგრძის 5/13 "
+"(ascii) უნდა იყოს, ან 10/26 (თექვსმეტობითი)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "არასწორი wep-key: საიდუმლო ფრაზა ცარიელი ვერ იქნება"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "არასწორი wep-key: საიდუმლო ფრაზა 64 სიმბოლოზე მოკლე უნდა იყოს"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (ნაგულისხმები)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "ღია სისტემა"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "გაზიარებული გასაღები"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_გასაღები"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "გასაღების _ჩვენება"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP-ის ინდექსი"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"არასწორი wpa-psk: გასაღების არასწორი სიგრძე %zu. უნდა იყოს [8,63] ბაიტი, ან "
+"64 თექვსმეტობითი ციფრი"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"არასწორი wpa-psk: 64 ბაიტიანი გასაღების, როგორც ტექვსმეტობითის აღქმა "
+"შეუძლებელია"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "შეტყობინებები"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "ხმოვანი _გაფრთხილებები"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_ეკრანის ბლოკირების გაფრთხილებები"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_არ შემაწუხო"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_ეკრანის ბლოკირების გაფრთხილებები"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "სხვა"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "\"%s\" წაშლილია"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "დაბრუნება"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "შეტყობინების დახურვა"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "ახალი ანგარიშის დამატება"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s ანგარიში"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "ანგარიშის წაშლა"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "ონლაინ ანგარიშები"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "უცნობი დრო"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i წუთი"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i საათი"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "საათი"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "წუთი"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "გაფრთხილება: დარჩენილია %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "დარჩენილია %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "სრულად დატენილი"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "არ იტენება"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "ცარიელი"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "იტენება"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "იცლება"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "უსადენო თაგუნა"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "უსადენო კლავიატურა"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "შეუფერხებელი კვების წყარო"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "პირადი ციფრული დამხმარე"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "მობილური ტელეფონი"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "მედია დამკვრელი"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "ტაბლეტი"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "კომპიუტერი"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "სათამაშო შემყვანი მოწყობილობა"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "ელემენტი"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "მთავარი"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "დამატებით"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "ელემენტები"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "უქმობისას"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "ძილი"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "გამორთვა"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "პროგრამული ძილი"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "არაფერი"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "ელემენტიდან კვებისას"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "შეერთებული"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "არასდროს"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "ავტომატურად შეჩერება"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 წუთი"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 წუთი"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 წუთი"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 წუთი"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 წუთი"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 საათი"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 წუთი"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 წუთი"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 წუთი"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 საათი"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "კვების რეჟიმი"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "ენერგიის დაზოგვის მორგება"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "ეკრანის ავტომატური სიკაშკაშე"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "ეკრანის ჩაქრობა"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "ეკრანის _გასუფთავება"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "_ჩართვის ღილაკის ქცევა"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_შეერთებული"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "იკვებება _ელემენტიდან"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "დაყოვნება"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "წარმადობა"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "ბალანსირებული"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "ელემენტის შენახვის რეჟიმი"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "კვება"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr ""
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "ახალი პრინტერის დამატების შეცდომა"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "UI-ის ჩატვირთვის შეცდომა: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "პრინტერები"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "პრინტერის დამატება"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_განბლოკვა"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "პრინტერები ნაპოვნი არაა"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "საჭროა ავთენტიკაცია"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "მომხმარებლის სახელი"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s-ის დეტალები"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "აირჩიეთ PPD ფაილი"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript პრინტერის აღწერის ფაილები (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "მდებარეობა"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "დრაივერი"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "სასურველი დრაივერების ძებნა…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "დრაივერების ძებნა"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "აირჩიეთ ბაზიდან…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "PPD ფაილის დაყენება…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "აირჩიეთ პრინტერის დრაივერი"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "დრაივერების ბაზის ჩატვირთვა"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "_არჩევა"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect ტიპის პრინტერი"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD პრინტერი"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "ერთმხრიანი"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "გრძელი წიბო (სტანდარტული)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "მოკლე წიბო (გადაბრუნება)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "პორტრეტი"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "ლანდშაფტი"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "ლანდშაფტის შებრუნება"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "პორტრეტის შებრუნება"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "გაგრძელება"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "შეჩერება"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "დარჩენილი"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "შეჩერებულია"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "საჭროა ავთენტიკაცია"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "დამუშავება"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "გაჩერებულია"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "გაუქმებულია"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "შეწყვეტილია"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "დასრულებულია"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr ""
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — აქტიური დავალებები"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "დომენი"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "ავ_თენტიკაცია"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "ყველას გასუფთავება"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_ავთენტიკაცია"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "ბეჭდვის სერვერის განბლოკვა"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s-ის განბლოკვა."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "პრინტერების ძებნა"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "სერიული პორტი"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "პარალელური პორტი"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "მდებარეობა: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "მისამართი: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "სერვერი ითხოვს ავთენტიკაციას"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "ორმხრივი"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "ფურცლის ტიპი"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "ქაღალდის წყარო"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "გამოტანის თარო"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "გარჩევადობა"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript-ის პრეფილტრი"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr ""
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "ორმხრივი"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "ორიენტაცია"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "ზოგადი"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "გვერდის მორგება"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "დაყენების ვარიანტები"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "დავალება"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "გამოსახულების ხარისხი"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "ფერი"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "სრულდება"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "დამატებით"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "სატესტო გვერდი"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "სატესტო გვერდი"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "ავტომატური არჩევა"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "პრინტერის ნაგულისხმები"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "მხოლოდ GhostScript-ის ფონტების ჩაშენება"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "პირველი დონის PS-ზე გადაყვანა"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "მეორე დონის PS-ზე გადაყვანა"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "პრეფილტრის გარეშე"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "მწარმოებელი"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u დავალება"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr ""
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "პრინტერში ტონერი ცოტაღაა"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "ტონერი გათავდა"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr ""
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "თავსახური ღიაა"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "კარის გაღება"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "ფურცლები ცოტაა"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "ქაღალდი გათავდა"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "გათიშული"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "გაჩერებულია"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "მზადაა"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "დავალებებს არ იღებს"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "დამუშავება"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "ბეჭდვის მორგება"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "პრინტერის დეტალები"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "პრინტერის ნაგულისხმებად გამოყენება"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "თავაკების გაწმენდა"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "პრინტერის წაშლა"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "მოდელი"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "მელნის დონე"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "გადატვირთეთ, როცა პრობლემა მოგვარდება."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "გადატვრთვა"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "პრინტერის დამატება…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "პრინტერები ნაპოვნი არაა"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "ფორმატები"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "ენების ძებნა…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "საერთო ფორმატები"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "ყველა ფორმატი"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "ძებნის შედეგების გარეშე"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "გადახედვა"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "იმპერიული"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "მეტრული სისტემა"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "თარიღები"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "დროები და თარიღები"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "რიცხვები"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "საზომი ერთეული"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "ქაღალდი"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "გამოსვლა…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "თქვენი ანგარიში"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "ე_ნა"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_ფორმატები"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "შესვლის ეკრანი"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "რეგიონი და ენა"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "აირჩიეთ ინტერფეისის სასურველი ენა და ფორმატები"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "გვკითხეთ რჩევა"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "არაფრის გაკეთება"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "საქაღალდის გახსნა"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "სხვა მედია"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "პროგრამის ამორჩევა აუდიო CD-ებისთვის"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "პროგრამის ამორჩევა ვიდეო DVD-ებისთვის"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "პროგრამის ამორჩევა პროგრამული CD-ებისთვის"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "აუდიო DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "ცარიელი Blu-ray დისკი"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "ცარიელი CD დისკი"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "ცარიელი DVD დისკი"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "ცარიელი HD DVD დისკი"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray ვიდეო დისკი"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "ელწიგნების წამკითხავი"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD ვიდეო დისკი"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "ფოტო სურათებიანი CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "ვიდეო CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows-ის პროგრამა"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _აუდიო"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD ვიდეო"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_მედია დამკვრელი"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_პროგრამები"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_სხვა მედია…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_ქმედება:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_ტიპი:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "გამოერთებადი მედია"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "ეკრანი გაითიშება"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 წამი"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 წუთი"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 წუთი"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 წუთი"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 წუთი"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 წუთი"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 საათი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 წუთი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 წუთი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 წუთი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 წუთი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 წუთი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 წუთი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 წუთი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 წუთი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 წუთი"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "არასდროს"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "ეკრანის დაბლოკვა"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_გაფრთხილებების დაბლოკილ ეკრანზე ჩვენება"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "ეკრანის კონფიდენციალობა"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "ეკრანის მორგება"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "მდებარეობის არჩევა"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_დიახ"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "ადგილები"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "სანიშნები"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "სხვები"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "მდებარეობის დამატება"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "აპლიკაციები ნაპოვნი არაა"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "აპლიკაციის მოძებნა"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "ძებნის შედეგები"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "ქსელები"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "ჩართული"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "გამორთული"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "ჩართულია"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "აქტიური"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "აირჩიეთ საქაღალდე"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "დამატება"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "მედიის გაზიარების ჩართვა"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "მოწყობილობის სახელი კოპირებული"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "მომხმარებლის სახელი კოპირებულია"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "პაროლი დაკოპირდა"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "გაზიარება"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_კომპიუტერის სახელი"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_ფაილების გაზიარება"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "დაშორებული _სამუშაო მაგიდა"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_მედიის გაზიარება"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_დაშორებული ჰოსტი"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "ფაილების გაზიარება"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_პაროლის აუცილებლად მოთხოვნა"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "დაშორებული ჰოსტი"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "დაშორებული სამუშაო მაგიდა"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "დაშორებული მართვა"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "როგორ დავუკავშირდე"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "კოპირება"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "ავთენტიკაცია"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "მომხმარებლის სახელი"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "შიფრაციის შემოწმება"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "შიფრაციის ანაბეჭდი"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "მედიის გაზიარება"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "საქაღალდეები"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "სხვა"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "დააწკაპუნეთ"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "სტრიქონი"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "სვინგი"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "ბალანსი"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "მინავლება"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "უკანა"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "წინა"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s_ის ტესტირება"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "დააწკაპუნეთ დასატესტ დინამიკზე"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "სისტემური საცავი"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "ძირითადი ტომი"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "ხმის დონეები"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "გამოტანა"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "გამოტანის მოწყობილობები"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "შემოწმება"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "გამართვა"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "საბვუფერი"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "შეყვანა"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "შეყვანის მოწყობილობა"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "ხმის სიმაღლე"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "განგაშის ხმა"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "დადუმება"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ხმა"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "გათიშულია"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "დაკავშირება"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "დაკავშირებულია"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "ავტორიზაციის შეცდომა"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "ავტრიზაცია"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "შეზღუდული ფუნქციონალი"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "მიერთებული და ავტორიზებული"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "უცნობია"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "ავტორიზებული:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "დაკავშირებულია:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "მიერთებულია:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "შეტყობინების დახურვა"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "სახელი:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "მდგომარეობა:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "მოწყობილობის დავიწყება"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "შეცდომა"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "ავტორიზებული"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "შეცდომა მიმართვის რეჟიმის შეცვლისას: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "პირდაპირი წვდომა"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "დარჩენილი მოწყობილობები"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "მოწყობილობები მიერთებული არაა"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Thunderbolt მოწყობილობის მართვა"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "კურსორის ციმციმი"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "ტექსტის ველებში კურსორის _ციმციმი."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "სიჩქარე"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "კურსორის ციმციმცის სიჩქარე"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "კურსორის ზომა"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "წკაპების დამხმარე"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_მეორადი წკაპის სიმულირება"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "_მეორე წკაპის ინიცირება პირველის შემდეგ ღილაკის გრძელი დაჭერით"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "მოკლე"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "_მეორადი წკაპის დაყოვნება"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "გრძელი"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_გადატარება წკაპი"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "თაგუნას მაჩვენებლის გადატარება ნიშნავს _წკაპს"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "დ_აყოვნება:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "მოკლე"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "გრძელი"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "მოძ_რაობის ზღვარი:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "პატარა"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "დიდი"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "ღილაკების გამეორება"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+"კლავიშის დაჭერების _გამეორება, როცა ღილაკი დაჭერილ მდგომარეობაშია გაჩერებული."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "ღილაკების გამეორების სიჩქარე"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "ღილაკების გამეორების სიჩქარე"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "კრეფის დამხმარე"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_წებოვანი ღილაკები"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_გათიშვა ორი კლავიშის ერთდროული დაჭერის შემთხვევაში"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "პიპინი, თუ მა_რთვის ღილაკი დაჭერილია"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "ნელი _კლავიშები"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "მოკლე"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "გრძელი"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "პიპინი, თუ ღილაკი დაჭერილია"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "პიპინი,როდესაც ღილაკი _მიღებულია"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "პიპინი ღილაკის _უარყოფის შემთხვევაში"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "მხტუნავი ღილაკები"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "ღილაკების სწრაფი ორმაგი დაჭერის იგნორი"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "მოკლე"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "გრძელი"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_კლავიატურით ჩართვა"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"_წვდომადობის თვისებების ჩართვა და გამორთვა კლავიატურის მალსახმობებითაცაა "
+"შესაძლებელი"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "ნაგულისხმები"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "საშუალო"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "დიდი"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "უფრო დიდი"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "უდიდესი"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d პიქსელი"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_წვდომადობის მენიუ ყოველთვის იქნება ნაჩვენები"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_მაღალი კონტრასტი"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_დიდი ტექსტი"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "_ანიმაციების ჩართვა"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "ეკრანის _მკითხველი"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_ხმის ღილაკები"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "პიპინი NumLock ან CapsLock-ის ჩართვის ან გამორთვის დროს."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "_კურსორის ზომა"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_გადიდება"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_ვიზუალური გართხილებები"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "კლავიატურა ეკრანზე"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_ღილაკების გამეორება"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_კურსორის ციმციმი"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_კრეფის დამხმარე (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_თაგუნას ღილაკები"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_მაჩვენებლის მოძებნა"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_წკაპების დამხმარე"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_ორმაგი წკაპი ელემენტების გასახსნელად"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "_ორმაგი წკაპის დაყოვნება"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "ვიზუალური გართხილებები"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "განათების _გამოცდა"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "მთლიანი _ეკრანის ციმციმი"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "მთლიანი _ფანჯრის ციმციმი"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "მოკლე"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ეკრანი"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ეკრანი"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ეკრანი"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "გრძელი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "სრულეკრანიანი რეჟიმი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "ზედა ნახევარი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "ქვედა ნახევარი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "მარცხენა ნახევარი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "მარჯვენა ნახევარი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "გადიდების მორგება"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_გადიდება:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "გამადიდებლის მდებარეობა"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "თაგუნას კურსორზე _მიყოლა"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_ეკრანის ნაწილი:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "გამადიდებელი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_სისქე:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "თხელი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "სქელი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "სიგრძე:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_ფერი:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "ფერის ეფექტები:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_თეთრი შავ ფონზე:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "სიკა_შკაშე:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_კონტრასტი:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_ფერი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "არა"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "სრული"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "დაბალი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "მაღალი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "დაბალი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "მაღალი"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "ფერის ეფექტები"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 საათი"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 დღე"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 დღე"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 დღე"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 დღე"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 დღე"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 დღე"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 დღე"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 დღე"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 დღე"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "გნებავთ სანაგვე ყუთიდან ყველა ელემენტის წაშლა?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr ""
+"მისამართების სიის გასუფთავების შემთხვევაში, თქვენ მათ სამუდამოდ წაშლით."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "ნაგვის _ყუთის დაცარიელება"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr ""
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 დღე"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 დღე"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 დღე"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "სამუდამოდ"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "ფაილის ისტორია"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "_ფაილის ისტორია"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "ფაილის _ისტორიის ხანგრძლივობა"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "ისტორიის _გასუფთავება…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_ნაგვის ყუთის დაცარიელება…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_დროებითი ფაილების წაშლა…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "ფაილის ისტორია & ნაგავი"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "კვალის არ დატოვება"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "ანგარიშის დამატების შეცდომა"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "პაროლები არ ემთხვევა."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "ანგარიშის რეგისტრაციის შეცდომა"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "ამ დომენში ავთენტიკაციის არცერთი ხერხი მხარდაჭერილი არაა"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "დომენზე დაერთების შეცდომა"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "დომენში შესვლის შეცდომა"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "მომხმარებლის დამატება"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "ადმინისტრატორი"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "_პაროლის დაყენება"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "დადასტურება"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "კომპანიის საიტზე შესვლა"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "ხაზზე არ ბრძანდებით"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"კომპანიის საიტზე შესვლა საშუალებას გაძლევთ ამ მოწყობილობაზე გამოიყენოთ "
+"ცენტრალურად მართული მომხმარებლის ანგარიშები. ასევე შეგიძლიათ წვდომა იქონიოთ "
+"კომპანიის რესურსებთანაც."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "მეტი სურათი"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "აირჩიეთ ფაილი…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "ანაბეჭდების მმართველი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "თითის ანაბეჭდი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_არა"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "დიახ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "ანაბეჭდების წამკითხველი მოწყობილობა ნაპოვნი არაა"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "ანაბეჭდების წამკითხველი მოწყობილობა ნაპოვნი არაა"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "ანაბეჭდების წამკითხველი მოწყობილობა"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "ანაბეჭდით შესვლა"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "ანაბეჭდების _წაშლა"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "ამ ქმედების შესასრულებლად საჭიროა მოწყობილობის გამოთხოვა"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "ანაბეჭდების ჩამოთვლის შეცდომა: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "მარცხენა ცერა"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "მარცხენა შუა თითი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "_მარცხენა საჩვენებელი თითი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "მარცხენა ბეჭედი თითი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "მარცხენა პატარა თითი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "მარჯვენა ცერა"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "მარჯვენა შუა თითი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "_მარჯვენა საჩვენებელი თითი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "მარჯვენა ბეჭედი თითი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "მარჯვენა პატარა თითი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "უცნობი თითი"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "დასრულებულია"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr ""
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "ახალი ანაბეჭდის სკანირება"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "მოწყობილობის წაკითხვის შეცდოა"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "ამ კვირაში"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "ბოლო კვირა"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "სესია დასრულდა"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "სესია დაიწყო"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — ანგარშის აქტივობა"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "წინა"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "შემდეგი"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "აირჩიეთ სხვა პაროლი."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "მეორედ შეიყვანეთ თქვენი მიმდინარე პაროლი."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "პაროლის შეცვლა შეუძლებელია"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "პაროლის შეცვლა"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_შეცვლა"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "მიმდინარე პაროლი"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "_ახალი პაროლი"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "პაროლის დადასტურება"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "დააყენეთ პაროლი ახლა"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "ამ ტიპის დომენზე ავტომატური დაერთება შეუძლებელია"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "დომენი ან რეალმის სახელი ნაპოვნი არაა"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s-ში %s დომენით შესვლა შეუძლებელია"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "არასწორი პაროლი. თავიდან სცადეთ"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "დომენთან დაკავშირების პრობლემა (%s): %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "მომხმარებლის წაშლის შეცდომა"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "საკუთარ ანგარიშს ვერ წაშლით."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ჯერ კიდევ შესულია"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "გნებავთ %s-ის ფაილების შენარჩუნება?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_ფაილების წაშლა"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_ფაილების შენარჩუნება"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "დარწმუნებული ხართ, რომ გსურთ %s-ის სამუდამოდ წაშლა?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_წაშლა"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "ანგარიში გათიშულია"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "დაყენებული იქნება შემდეგი შემოსვლისას"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "არა"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "შესული"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "ანგარიშების სერვისთან კავშირის შეცდომა"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "გთხოვთ დარწმუნდეთ, რომ AccountService სწორადაა დაყენებული და ჩართულია."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "მომხმარებლები"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "ახლა გადატვირთვა"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "დახურვა"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "ავატარის ჩასწორება"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "სრული სახელი"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "რედაქტირება"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_ანაბეჭდით შესვლა"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "ავტომატური შესვლა"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "ანგარიშის აქტიურობა"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "ადმინისტრატორი"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "მშობლის კონტროლი"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "მშობლის კონტროლის აპლიკაციის გახსნა."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "მომხმარებლის წაშლა…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "სხვა მომხმარებლები"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "მომხმარებლის დამატება…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "მომხმარებლები ნაპოვნი არაა"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "დომენის ადმინისტრატორის მომხმარებელი"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "ადმინისტრატორის _სახელი"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "ადმინისტრატორის -პაროლი"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "მომხმარებლის ანაგარიშების მართვა"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "მომხმარებლის ანგარიშების სამართავად საჭიროა ავთენტიკაცია"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "საჭიროა, რომ პაროლი განსხვავდებოდეს იმისგან, რაც ეყენა."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "სცადეთ კიდევ ოდნავ შეცვალოთ პაროლი."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "შეურიეთ დიდი და პატარა ასოები და სცადეთ გამოიყენოთ რამდენიმე ციფრი."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "მეტი ციფრები, ასოები და პუნქტუაციის ნიშნები პაროლს უფრო გააძლიერებს."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "ავთენტიკაციის შეცდომა"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "ახალი პაროლი ძალიან მოკლეა"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "ახალი პაროლი ძალიან მარტივია"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "ახალი და ძველი პაროლები ერთმანეთს ჰგვანან"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "ეს პაროლი ახლახანს გამოიყენეთ."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "ახალი პაროლი ციფრებს ან სიმბოლოებს უნდა შეიცავდეს"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "ძველი და ახალი პაროლი ერთი და იგივიეა"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "უკანასკნელი ავტორიზაციის შემდეგ თქვენი პაროლი შეიცვალა!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "ახალი პაროლი საკმარისად განსხვავებულ სიბოლოებს არ შეიცავს"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "უცნობი შეცდომა"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "მომხმარებლის სახელი მიუწვდომელია. სხვა სცადეთ."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "მომხმარებლის სახელი ძალიან გრძელია."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "ღილაკების მიმაგრება"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ახალი მალსახლობების დასაყენებლად დააწკაპუნეთ შესაბამის სტრიქონს და აკრიფეთ "
+"ახალი კომბინაცია. გასასუფთაებლად დააჭირეთ Backspace-ს."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_დახურვა"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "ღილაკი %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "აპლიკაციის განსაზღვრულია"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "ეკრანის გადარტვა"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "ეკრანზე დახმარების ჩვენება"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "ყველა ეკრანი"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "ტაბლეტის რეჟიმი"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "მარცხენა ხელის ორიენტაცია"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "ეკრანზე მიბმა"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "საწყისი ფარდობის შენარჩუნება"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "კალიბრაცია"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "ტაბლეტის ვერ ვიპოვე"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "შეაერთეთ ან ჩართეთ თქვენი Wacom-ის ტაბლეტი."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "რბილი"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "ღილაკი 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ღილაკი 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ღილაკი 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "თაგუნას შუა წკაპი"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "თაგუნას მარჯვენა წკაპი"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "წინ"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom -ის ტაბლეტი"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "ახალი მალსახმობი…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "წვდომის წერტილები"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "ოპერაცია გაუქმდა"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "არაა რეგისტრირებული"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "რეგისტრირებულია"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "როუმინგი"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "ძებნა"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Უარყოფილი"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "მოდემის დეტალები"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "მოდემის სტატუსი"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "გადამზიდი"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "ქსელის ტიპი"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "ქსელის მდგომარეობა"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "საკუთარი ნომერი"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "მოწყობილობის დეტალები"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "მიკროკოდის ვერსია"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "მხოლოდ 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "მხოლოდ 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "მხოლოდ 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "მხოლოდ 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (პრივილეგირებული), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (პრივილეგირებული), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (პრივილეგირებული), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (პრივილეგირებული), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (პრივილეგირებული), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (პრივილეგირებული), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (პრივილეგირებული), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (პრივილეგირებული), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (პრივილეგირებული), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (პრივილეგირებული), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (პრივილეგირებული), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (პრივილეგირებული), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (პრივილეგირებული), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (პრივილეგირებული), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (პრივილეგირებული), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (პრივილეგირებული), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (პრივილეგირებული)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (პრივილეგირებული), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "უცნობია"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "SIM-ის განბლოკვა"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "განბლოკვა"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "დაგრჩათ %u ცდა"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "შეყვანილი პაროლი არასწორია."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "შეიყვანეთ ახალი PIN კოდი"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "განბლოკვა…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "SIM ბარათის გარეშე"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM-ი დაბლოკილია"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_მობილური ინტერნეტი"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_ინტერნეტის როუმინგი"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "როუმინგისას მობილური ინტერნეტის გამოყენება"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_ქსელის რეჟიმი"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_ქსელი"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "დამატებით"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_წვდომის წერტილის სახელები"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM-ის ბლოკირება"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "მ_ოდემის დეტალები"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "ტელეფონის შეცდომა"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "ტელეფონთან კავშირი არ არსებობს"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "ოპერაცია დაუშვებელია"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "ოპერაცია მხარდაუჭერელია"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM ბარათი არ დევს"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIM Pin აუცილებელია"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIM Puk აუცილებელია"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM ბარათის შეცდომა"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM დაკავებულია"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "არასწორი პაროლი"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM PIN2 აუცილებელია"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM PUK2 აუცილებელია"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "ნაპოვნი არაა"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "ქსელის სერვისის გარეშე"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "ქსელის მოლოდინის ვადა გავიდა"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS სერვისი დაუშვებელია"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "შეცდომის გარეშე"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "ქმედება გაუქმდა"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "წვდომა აკრძალულია"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "უცნობი შეცდომა"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "ქსელის რეჟიმი"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "ავთ_ენტიკაცია"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "აირჩიეთ ქსელი"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "ქსელის მომწოდებლების განახლება"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "მობილური ქსელის ჩართვა"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "მონაცემების შეერთება"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM-ის ბლოკირება"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_შემდეგი"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "PIN კოდის შეცვლა"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "მობილური ქსელის"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "პროექტი \"GNOME\""
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "ვერსიის ინფორმაციის ჩვენება"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "დამატებითი შეტყობინებების ჩართვა"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "საძებნი სტრიქონი"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "შესაძლო პანელების სიის გამოტანა და გასვლა"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "საჩვენებელი პანელი"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[პანელი] [არგუმენტი…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "პარამეტრების კატეგორიები"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "პირადი ინფორმაცია"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "ხელმისაწვდომი პანელები:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "ყველა პარამეტრი"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "ძირითადი მენიუს"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "გაფრთხილება: სატესტო ვერსია"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "დახმარება"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "ზოგადი"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "გასვლა"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "ძებნა"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "პანელები"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "წინა პანელზე დაბრუნება"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "ძებნის გაუქმება"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "მორგება;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "ფანჯრის საწყისი მდგომარეობა"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u გამოტანა"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u შეტანა"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "სისტემური ხმები"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "დაცული ჩატვირთვა გამორთულია"
+
+#~ msgid "Basic Protection"
+#~ msgstr "ბაზისური უსაფრთხოება"
+
+#~ msgid "Extended Protection"
+#~ msgstr "გაფართებული დაცვა"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI ჩაწერა"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI ბლოკი"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "SPI BIOS-ის რეგიონი"
+
+#~ msgid "Suspend-to-ram"
+#~ msgstr "RAM-ში შეჩერება"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "MEI მწარმოებლის რეჟიმი"
+
+#~ msgid "MEI version"
+#~ msgstr "MEI-ის ვერსია"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "fwupd დამატებები"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "IOMMU მოწყობილობის უსაფრთხოება ჩართულია"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "IOMMU მოწყობილობის უსაფრთხოება გამორთულია"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "დაცული ჩატვირთვა გამორთულია"
+
+#~ msgid "Lock your screen"
+#~ msgstr "ეკრანის დაბლოკვა"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "პრინტერის დამატება…"
+
+#~ msgid "Drip"
+#~ msgstr "წვეთი"
+
+#~ msgid "Glass"
+#~ msgstr "მინა"
+
+#~ msgid "Sonar"
+#~ msgstr "სონარი"
+
+#~ msgid "Light"
+#~ msgstr "მსუბუქი"
+
+#~ msgid "Set"
+#~ msgstr "დაყენება"
+
+#~ msgid "Image/label border"
+#~ msgstr "ნახატის/წარწერის ჩარჩო"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "გაფრთხილების ფანჯარაში წარწერისა და ნახატის ირგვლივ ჩარჩოს სიგანე"
+
+#~ msgid "The type of alert"
+#~ msgstr "გაფრთხილების ტიპი"
+
+#~ msgid "Alert Buttons"
+#~ msgstr "გაფრთხილების ღილაკები"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "გაფრთხილების ფანჯარაზე გამოსახული ღილაკები"
+
+#~ msgid "Show more _details"
+#~ msgstr "_დამატებითი ცნობები"
+
+#~ msgid "No Image"
+#~ msgstr "არავითარი სურათი"
+
+#~ msgid "Images"
+#~ msgstr "სურათები"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "შეცდომა მისამართების წიგნაკიდან ინფორმაციის მიღებისას\n"
+#~ "Evolution-ის მონაცემთა სერვერი ვერ უმკლავდება პროტოკოლს"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "უცნობი ID სახელი, შესაძლოა მომხმარებლების ბაზა დაზიანებულია"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "%s-ის შესახებ"
+
+#~ msgid "About Me"
+#~ msgstr "ჩემს შესახებ"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>ბინა</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>მყისიერი მიმოწერა</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>თანამდებობა</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>ტელეფონი</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>WWW</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>სამსახური</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">პაროლის შეცვლა</span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "მის_ამართი:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "ა_სისტენტი:"
+
+#~ msgid "C_ity:"
+#~ msgstr "ქალაქ_ი:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "კ_ომპანია:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "_პაროლის შეცვლა..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "პაროლის შ_ეცვლა"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "ქა_ლაქი:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "ქვ_ეყანა:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "ქვეყა_ნა:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "_სახლი:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "სა_ფოსთო ყუთი:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "_საფოსტო ყუთი:"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "გთხოვთ ხელახლა აკრიფოთ პაროლი ველში <b>ხელახალი აკრეფა</b>."
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "მხარე/პროვინცია:"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "პაროლის შესაცვლელად გთხოვთ შეიყვანოთ ქვემოთ მოცემულ ველში მიმდინარე "
+#~ "პაროლი და დააჭირეთ <b>ავტორიზაცია</b>-ს.\n"
+#~ "აუტენტიფიკაციის შემდგომ, თქვენი ახალი პაროლი დამოწმების მიზნით ორჯერ "
+#~ "აკრიფეთ და დააწკაპეთ <b>პაროლის შეცვლა</b>-ს."
+
+#~ msgid "Web _log:"
+#~ msgstr "ვებ ჟურნა_ლი:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_სამსახური:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "სამსახურის _ფაქსი:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "საფოსტო ინ_დექსი:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_დაჯგუფება:"
+
+#~ msgid "_Home page:"
+#~ msgstr "პირადი ვე_ბგვერდი:"
+
+#~ msgid "_Home:"
+#~ msgstr "სახ_ლი:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "მ_მართველი:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "მხარე/პრ_ოვინცია:"
+
+#~ msgid "_Title:"
+#~ msgstr "_სათაური:"
+
+#~ msgid "_Work:"
+#~ msgstr "_სამსახური:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "საფოსტო _ინდექსი:"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "შვილი პროცესი უცაბედად გაითიშა"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "შეუძლებელია შვილი პროცესის შეყვანის არხის დახურვა: %s"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "შეუძლებელია შვილი პროცესის გამოყვანის არხის დახურვა: %s"
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "სისტემური შეცდომა: %s."
+
+#, c-format
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "შეუძლებელია გაშვება %s: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "შეუძლებელია შიდა პროგრამის გაშვება"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "დაიშვა სისტემური შეცდომა"
+
+#~ msgid "Checking password..."
+#~ msgstr "პაროლის შემოწმება..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "პაროლის შესაცვლელად დააწკაპუნეთ <b>პაროლის შეცვლა</b>-ს."
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>დამხმარე ტექნოლოგია</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>პარამეტრები</b>"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "დამხმარე ტექნოლოგიების პარამეტრები"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr "დამხმარე ტექნოლოგია არ ჩაირთვება თქვენს მომავალ შემოსვლამდე."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "დახურვა და გასვლა"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "სასურველი პროგრამების დიალოგ ფანჯარაზე გადასვლა"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "მომხმარებლის შემოსასვლელ დიალოგ ფანჯარაზე გადასვლა"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "კლავიატურის წვდომის საშუალებების ფანჯარაზე გადასვლა"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "თაგუნაზე წვდომის საშუალებების ფანჯარაზე გადასვლა"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "დამხმარე ტ_ექნოლოგიების ჩართვა"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "_თაგუნას დამხმარე საშუალებები"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "სასურველი _პროგრამები"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "<b>დამხმარე ტექნოლოგიები</b>"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "აირჩიეთ, შესვლისას წვდომადობის რომელი თვისებები ჩაირთოს"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "ფონური სურათის დამატება"
+
+#~ msgid "Font may be too large"
+#~ msgstr "შესაძლოა ფონტი საკმარისზე დიდი იყოს"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "არჩეული ფონტი არის %d წერტილიანი და შესაძლოა კომპიუტერის ეფექტური "
+#~ "მოხმარება გააძნელოს. რეკომენდებულია, რომ აირჩეს %d-ზე მცირე ზომა."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "არჩეული ფონტი არის %d წერტილით დიდი და შესაძლოა კომპიუტერის ეფექტური "
+#~ "მოხმარება გააძნელოს. რეკომენდებულია, რომ აირჩეს უფრო მცირე ზომის ფონტი."
+
+#~ msgid "Use previous font"
+#~ msgstr "წინა ფონტის გამოყენება"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "გაფორმების თემის ფაილის სახელის მითითება დასაყენებლად"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "საჩვენებელი გვერდის სახელის მითითება (theme|background|fonts|interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "თემას არ ექნება ისეთი გარეგნობა, როგორიც გგონია, იმითომ, რომ GTK+-ის "
+#~ "თემის ძრავი '%s' დაყენებული არაა."
+
+#~ msgid "Apply Font"
+#~ msgstr "ფონტის გადატარება"
+
+#~ msgid "Revert Font"
+#~ msgstr "ფონტის დაბრუნება"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "მიმდინარე გაფორმებისთვის სასურველი ფონი და ფონტი. ასევე შეიძლება "
+#~ "დააბრუნოთ ფონტის ბოლო შემოთავაზება."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "მიმდინარე გაფორმებისთვის სასურველი ფონი და ფონტი. ასევე შეიძლება "
+#~ "დააბრუნოთ ფონტის ბოლო შემოთავაზება."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "მიმდინარე გაფორმებისთვის სასურველი ფონი და ფონტი."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "მიმდინარე გაფორმებისათვის სასურველი ფონტი. ასევე შეიძლება დააბრუნოთ "
+#~ "ფონტის ბოლო შემოთავაზება."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "მიმდინარე გაფორმებისთვის სასურველი ფონი."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "ბოლოს გადატარებული ფონტის დაბრუნება შესაძლებელია."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "მიმდინარე გაფორმებისთვის სასურველი ფონტი."
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>ფერ_ი</b>"
+
+#~ msgid "<b>Hinting</b>"
+#~ msgstr "<b>ჰინტირება</b>"
+
+#~ msgid "<b>Menus and Toolbars</b>"
+#~ msgstr "<b>პულტები და მენიუები</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>ნიმუში</b>"
+
+#~ msgid "<b>Rendering</b>"
+#~ msgstr "<b>რენდერინგი</b>"
+
+#~ msgid "<b>Smoothing</b>"
+#~ msgstr "<b>დაგლუვება</b>"
+
+#~ msgid "<b>Subpixel Order</b>"
+#~ msgstr "<b>ქვეპიქსელების მიმდევრობა</b>"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>ფონური _სურათი</b>"
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "იერსახის პარამეტრები"
+
+#~ msgid "Best _shapes"
+#~ msgstr "საუკეთესო _მოყვანილობა"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "საუკეთესო _კონტრასტი"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "გა_მართვა..."
+
+#~ msgid "C_ut"
+#~ msgstr "ამ_ოჭრა"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr ""
+#~ "კურსორის გაფორმების ცვლილების დამტკიცება სეანსში ხელახალი შემოსვლით "
+#~ "მტკიცდება."
+
+#~ msgid "Customize Theme"
+#~ msgstr "გაფორმების დამუშავება"
+
+#~ msgid "D_etails..."
+#~ msgstr "_დეტალები..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "სამუშაო მაგ_იდის შროფტი:"
+
+#~ msgid "Fonts"
+#~ msgstr "შრიფტები"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "სე_რის ტონები"
+
+#~ msgid "Icons"
+#~ msgstr "ხატულები"
+
+#~ msgid "Interface"
+#~ msgstr "ინტერფეისი"
+
+#~ msgid "N_one"
+#~ msgstr "არა_ფერი"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "გახსენი ფერის მისათითებლად დიალოგური ფანჯარა"
+
+#~ msgid "R_esolution:"
+#~ msgstr "გარჩ_ევადობა:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "გაფორმების დამახსოვრება როგორც..."
+
+#~ msgid "Save _As..."
+#~ msgstr "დ_ამახსოვრება როგორც..."
+
+#~ msgid "Save _background image"
+#~ msgstr "ფონის _სურათის დამახსოვრება"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "მენუში _ხატულების ჩვენება"
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "მყარი ფერი\n"
+#~ "ჰორიზონტალური გრადაცია\n"
+#~ "ვერტიკალური გრადაცია"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "ქვე_პიქსელი (LCDთვის)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "ქვე_პიქსელების დაგლუვება (LCD-ები)"
+
+#~ msgid "Text"
+#~ msgstr "ტექსტი"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "ტექსტი ელემენტებს ქვეშ\n"
+#~ "ტექსტი ელემენტების გვერდზე\n"
+#~ "მხოლოდ ხატულები\n"
+#~ "მხოლოდ ტექსტი"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "მიმდინარე თემას არ გააჩნია ფერების სქემის მხარდაჭერა."
+
+#~ msgid "Theme"
+#~ msgstr "გაფორმების თემა"
+
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "მინიატურული\n"
+#~ "გადიდებული\n"
+#~ "ცენტრში\n"
+#~ "გაჭიმული\n"
+#~ "ეკრანის შევსება"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "პანელის ღ_ილაკის წარწერა:"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "_აღწერილობა:"
+
+#~ msgid "_Document font:"
+#~ msgstr "_დოკუმენტის ფონტი:"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "_რედაქტირებადი მენიუს დამაჩქარებლები"
+
+#~ msgid "_File"
+#~ msgstr "_ფაილი"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_ფიქსირებული სიგანის ფონტი:"
+
+#~ msgid "_Install..."
+#~ msgstr "_დაყენება..."
+
+#~ msgid "_Monochrome"
+#~ msgstr "_მონოქრომატული"
+
+#~ msgid "_New"
+#~ msgstr "_ახალი"
+
+#~ msgid "_Paste"
+#~ msgstr "_ჩასმა"
+
+#~ msgid "_Print"
+#~ msgstr "_ბეჭდვა"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Selected items:"
+#~ msgstr "_მონიშნული ელემენტი:"
+
+#~ msgid "_Size:"
+#~ msgstr "_ზომა:"
+
+#~ msgid "_Slight"
+#~ msgstr "მსუ_ბუქი"
+
+#~ msgid "_Style:"
+#~ msgstr "_სტილი:"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "_კარნახები:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_ფანჯრის სათაურის ფონტი:"
+
+#~ msgid "_Windows:"
+#~ msgstr "ფა_ნჯრები:"
+
+#~ msgid "dots per inch"
+#~ msgstr "წერტილი დუიმში"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "სამუშაო მაგიდის ხედის გალამაზება"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "აყენებს სამუშაო მაგიდის სხვადასხვა ნაწილების თემებს"
+
+#~ msgid "Theme Installer"
+#~ msgstr "გაფორმების დამყენებელი"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "გნომის გაფორმებების პაკეტი"
+
+#~ msgid "Slide Show"
+#~ msgstr "სლაიდების ჩვენება"
+
+#, c-format
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s by %d %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s მიერ %d %s\n"
+#~ "დასტა: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "თემის დაყენება შეუძლებელია"
+
+#, c-format
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s უტილიტა დაყენებული არაა."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "თემის გაშლის შეცდომა."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "არჩეული ფაილის დაყენების შეცდომა"
+
+#, c-format
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" არ წარმოადგენს სწორ თემას."
+
+#, c-format
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" არ წარმოადგენს სწორ თემას. ის შეიძლება წარმოადგენდეს თემის ძრავს, "
+#~ "რომელსაც კომპილაცია სჭირდება."
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME-ის თემა %s მართებულად დაყენდა"
+
+#, c-format
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "თემა %s-ის დაყენების შეცდომა."
+
+#, c-format
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "გაფორმების თემა \"%s\" მართებულად დაყენდა."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "გნებავთ მოცემული გაფორმების დამტკიცება, თუ წინას დაბრუნება ?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "მიმდინარე გაფორმების დამახსოვრება"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "ახალი გაფორმების გამოყენება"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "ვერ მოხდა დროებითი დირექტორის შექმნა"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "თემები წარმატებულად დადგა."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "არ არის მითითებული დასაყებელი თემის ფაილის მდებარეობა"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "არასაკმარისი ნებართვებია, რომ დაყენდეს თემა აქ:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "გაფორმების ამორჩევა"
+
+#~ msgid "Theme Packages"
+#~ msgstr "გაფორმების პაკეტები"
+
+#, c-format
+#~ msgid "Theme name must be present"
+#~ msgstr "თემა უნდა არსებობდეს"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "თემა უკვე არსებობს. გნებავთ შეცვალოთ იგი?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_ზედგადაწერა"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "გნებავთ მოცემული გაფორმების ამოშლა?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "თემის ძრავის დაყენების შეცდომა"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "ვერ ვუშვებ პარამეტრების მმართველს 'gnome-settings-daemon'.\n"
+#~ "გნომის პარამეტრების მმართველის გაშვების გარეშე ზოგმა პარამეტრმა შეიძლება "
+#~ "ეფექტი არ იქონიოს. ეს შეიძლება ნიშნავდეს პრობლემებს ბონობოსთან (Bonobo), "
+#~ "ან უკვე გაშვებულია არა გნომის (მაგალითად KDE) პარამეტრების მმართველი და "
+#~ "ის კონფლიქტობს გნომის პარამეტრების მმართველთან."
+
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "შეუძლებელია მიბმული ხატულას ჩატვირთვა '%s'\n"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "დახმარების გამოძახებისას მოხდა შეცდომა: %s"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "ფაილის ასლი: %u - %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "ვაკოპირებ '%s'"
+
+#~ msgid "Parent Window"
+#~ msgstr "დედობილი ფანჯარა"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "დიალოგის დედობილი ფანჯარა"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI, საიდანაც მიმდონარეობს გადაწერა"
+
+#~ msgid "To URI"
+#~ msgstr "URI-ზე"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI, ჩაწერის დანიშნულება"
+
+#~ msgid "Fraction completed"
+#~ msgstr "ნაწილი დასრულებულია"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "ნაწილის გადატანა ჩატარებულია"
+
+#~ msgid "Current URI index"
+#~ msgstr "მიმდინარე URI-ის ინდექსი"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "მიმდინარე URI-ინდექსი - 1-დან იწყება"
+
+#~ msgid "Total URIs"
+#~ msgstr "ჯამში URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "URI-ების ჯამური რაოდენობა"
+
+#, c-format
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "ფაილი '%s' უკვე არსებობს. გნებავთ გადააწეროთ?"
+
+#~ msgid "_Skip"
+#~ msgstr "_გამოტოვება"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "ყველ_ას ზედგადაწერა"
+
+#~ msgid "Key"
+#~ msgstr "გასაღები"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf გასაღები, რომელთანაც ეს თვისებების რედაქტორია მიბმული"
+
+#~ msgid "Callback"
+#~ msgstr "უკუგამოძახება"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "გაეცი ეს უკუგამოძახილი, როდესაც გასაღებთან ასოცირებული მნიშვნელობა "
+#~ "შეიცვლება"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf-ის ცვლილებების კრებული, რომელიც შეიცავს მონაცემებს, რომელიც "
+#~ "გადატარებისას გაეგზავნება gconf-ის კლიენტს"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "ელემენტში გარდაქმნის უკუგამოძახება"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "უკუგამოძახება უნდა გაიცეს, როდესაც მონაცემები უნდა გარდაიქმნას GConf-დან "
+#~ "ელემენტში"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "ელემენტიდან გარდაქმნის უკუგამოძახილი"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "უკუგამოძახება უნდა გაიცეს, როდესაც მონაცემები უნდა გარდაიქმნას ელემნტიდან "
+#~ "GConf-ში"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "თვისებების მაკონტროლებელი ობიექტი (ხშირად წარმოადგენს ვიჯეთს)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "თვისებების რედაქტორის ობიექტების მონაცემები"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr ""
+#~ "საჭიროა ინდივიდუალური მონაცემები სპეციფიური თვისებების რედაქტორისთვის"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "თვისებების რედაქტორის მონაცემთა გამონთავისუფლების უკუგამოძახება"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "უკუგამოძახება უნდა გაიცეს, მაშინ, როდესაც თვისებების რედაქტორის "
+#~ "ობიექტების მონაცემები უნდა გამონთავისუფლდეს"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "'%s' ფაილი ვერ მოიძებნა.\n"
+#~ "\n"
+#~ "დარწმუნდით, რომ იგი არსებობს და სცადეთ თავიდან, ან აირჩიეთ სხვა ფონური "
+#~ "სურათი."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "არ ვიცი '%s' ფაილი როგორ გავხსნა.\n"
+#~ "შესაძლოა, სურათის ასეთი ტიპი ჯერ არაა მხარდაჭერილი.\n"
+#~ "\n"
+#~ "გთხოვთ ამის მაგივრად აირჩიოთ სხვა სურათი."
+
+#~ msgid "Please select an image."
+#~ msgstr "გთხოვთ აირჩიოთ ნახატი."
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "ნაგულისხმევი მიმთითებელი - მიმდინარე"
+
+#~ msgid "White Pointer"
+#~ msgstr "თეთრი კურსორი"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "თეთრი კურსორი - მიმდინარე"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "დიდი კურსორი - მიმდინარე"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "დიდი თეთრი კურსორი - მიმდინარე"
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "თემას არ ექნება ისეთი გარეგნობა, როგორიც გგონია, იმითომ, რომ GTK+-ის თემა "
+#~ "'%s' დაყენებული არაა."
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "თემას არ ექნება ისეთი გარეგნობა, როგორიც გგონია, იმითომ, რომ ფანჯრების "
+#~ "მმართველის თემა '%s' დაყენებული არაა."
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "თემას არ ექნება ისეთი გარეგნობა, როგორიც გგონია, იმითომ, რომ ხატულების "
+#~ "თემა '%s' დაყენებული არაა."
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "აირჩიეთ თქვენი ვიზუალური დახმარების ტექნოლოგია"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "ვიზუალური დახმარება"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "საჩვენებელი გვერდის სახელის მითითება (internet|multimedia|system|a11y)"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>სურათების მნახველი</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>მყისიერი შეტყობინება</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b> ფოსტის წამკითხავი</b>"
+
+#~ msgid "<b>Mobility</b>"
+#~ msgstr "<b>მობილითი</b>"
+
+#~ msgid "<b>Multimedia Player</b>"
+#~ msgstr "<b>მულტიმედიის დამკვრელი</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>ტერმინალის ემულატორი</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>ტექსტური რედაქტორი</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>ვიდეო დამკვრელი</b>"
+
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b>ვიზუალი</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>ვებ ბროუზერი</b>"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "ყველა %s დამთხვევა შეიცვლება შესაბამისი ბმულით"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "ბრძა_ნება:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "გაშვების ალამი:"
+
+#~ msgid "Internet"
+#~ msgstr "ინტერნეტი"
+
+#~ msgid "Multimedia"
+#~ msgstr "მულტიმედია"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "ბმულის ახალ _ფანჯარაში გახსნა"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "ბმულის ახალ _ფანჯარაში გახსნა"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "ბმულის _ნაგულისხმევ ვებ ბრაუზერში გახსნა"
+
+#~ msgid "Run at st_art"
+#~ msgstr "დაწყებისას გ_აშვება"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "ტ_ერმინალში გაშვება"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee მუსიკის დამკვრელი"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian Sensible Browser"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "დებიანის ტერმინალის ემულატორი"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "ეპიფანია ვებ ბროუზერი"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "ევოლუშენ ფოსტის მკითხველი"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "ფაირფოქსი"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "გნომის ლუპა ეკრანის მკითხველის გარეშე"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus ლუპითურთ"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape Mail"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "კდე-ს ლუპა ეკრანის მკითხველის გარეშე"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "ლინუქსის ეკრან მკითხველი ლუპით"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "მოზილა"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "Muine Music Player"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "რითმბოქს მუსიკის დამკვრელი"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey Mail"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem ფილმების დამკვრელი"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Include _Panel"
+#~ msgstr "_პანელის ჩართვა"
+
+#~ msgid "Monitor Resolution Settings"
+#~ msgstr "მონიტორის გარჩევადობის პარამეტრები"
+
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "ნორმალური\n"
+#~ "მარცხნივ\n"
+#~ "მარჯვნივ\n"
+#~ "ზემოდან-ქვემოთ\n"
+
+#~ msgid "_Show Displays in Panel"
+#~ msgstr "_პანელზე მონიტორების ჩვენება"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "ეკრანის გარჩევადობის შეცვლა"
+
+#~ msgid "Upside Down"
+#~ msgstr "ქვემოდან ზემოთ"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d ჰერცი"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid ""
+#~ "The X server does not support the XRANDR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "X სერვერს არ გააჩნია XRandR გაფართოვების მხარდაჭერა. X-ის აქტიურ "
+#~ "მდგომარეობაში ყოფნის დროს შეუძლებელია გარჩევადობის გასწორება."
+
+#~ msgid "Accelerator key"
+#~ msgstr "ამაჩარებლის ღილაკი"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "ამაჩქარებლის მმართველები"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "ამაჩქარებლის keycode"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "ამაჩქარებლის ტიპი."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "შეუძლებელია \"%s\" კლავიშის გამოყენება, რადგანაც მისი გამოყენების "
+#~ "შემთხვევაში შეუძლებელი გახდება ჩვეულებრივი ტექსტის აკრეფვა.\n"
+#~ "გთხოვთ სცადოთ Control, Alt , ან Shift კლავიშების ერთდროული კომბინაციები."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "მალსახმობი კლავიშები \"%s\" უკვე გამოყენებულია აქ:\n"
+#~ " \"%s\""
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "თუ თქვენ თავიდან მიანიჭებთ მალსახმობს '%s'-ს \"%s\" მალსახმობი გაითიშება."
+
+#~ msgid "_Reassign"
+#~ msgstr "_გადაბარება"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "შეცდომა ამაჩქარებლის მოხსნისას კონფიგურაციის ბაზაში: %s"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "ბრძანებისთვის სხარტი კლავიშის მინიჭება"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "გამოყენება და გასვლა"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "არსებული პარამეტრების მოძიება და შენახვა"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "გვერდის დაწყება აკრეფის დასრულების ფანჯრის ჩვენებით"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "გვერდის დაწყება წვდომადობის პარამეტრების ჩვენებით"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- გნომის კლავიატურის პარამეტრები"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>საერთო</b>"
+
+#~ msgid "<b>Slow Keys</b>"
+#~ msgstr "<b>ნელი კლავიშები</b>"
+
+#~ msgid "<b>Sticky Keys</b>"
+#~ msgstr "<b>წ_ებოვანი კლავიშები</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>სწრაფი</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>გრძლად</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>მოკლედ</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>ნელა</i></small>"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "_აჩქარება:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "წყვეტების გადადების დაშ_ვება"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "უკუ ხ_მოვანი სიგნალი..."
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "პიპინი, თუ გადართ_ვის კლავიში დაჭერილია"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "პიპინი, კლავიშის _უარყოფის შემთხვევაში"
+
+#~ msgid "By _country"
+#~ msgstr "ქ_ვეყნის მიხედვით"
+
+#~ msgid "By _language"
+#~ msgstr "_ენის მიხედვით"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "შემოწმება, დაშვებულია თუ არა წყვეტების გადადება"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "კლავიატურის მოდელის არჩევა"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "წყვეტის ხანგრძლივობა, როდესაც აკრეფვა აკრძალულია"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "მუშაობის ხანგრძლივობა წყვეტის გააქტიურებამდე"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "კლავიატურის წვდომადობის აუდიო გამოხმაურება"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "კლავიატურის პარამეტრები"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "კლავიატურის _მოდელი:"
+
+#~ msgid "Layout _Options..."
+#~ msgstr "განლაგების _პარამეტრები..."
+
+#~ msgid "Layouts"
+#~ msgstr "განლაგებები"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "ეკრანის ბლოკირება გარკვეული დროის შემდეგ, კლავიშების განმეორებითი დაჭერის "
+#~ "მიერ გამოწვეული ზიანის თავიდან აცილების მიზნით"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "ნა_გულისხმევზე დაყენება"
+
+#~ msgid "S_peed:"
+#~ msgstr "_სიჩქარე:"
+
+#~ msgid "Separate _layout for each window"
+#~ msgstr "ცალკეული ფანჯრისთვის _განლაგების შეცვლა"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_წყვეტის ინტერვალი გრძელდება:"
+
+#~ msgid "_Country:"
+#~ msgstr "ქვ_ეყანა:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "კრეფის დასასრულებლად _ეკრანის ჩაკეტვა"
+
+#~ msgid "_Models:"
+#~ msgstr "_მოდელები:"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "მხოლოდ ხანგრძლივი დაჭერის მიღება"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "_მაცვენებლის მართვა შესაძლებელია ასევე პატარა კლავიატურიდან"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_არჩეული განლაგებები:"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "ღილაკების დაჭერის სიმულაცი_ა"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "პარამე_ტრების შესამოწმებელი ველი:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_ვარიანტი:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_მწარმოებლები:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_სამუშაო ინტერვალი გრძელდება:"
+
+#~ msgid "Layout"
+#~ msgstr "განლაგება"
+
+#~ msgid "Vendors"
+#~ msgstr "მწარმოებელი"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "კლავიატურის პარამეტრების დაყენება"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "თაგუნა მარცხნივ"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "თაგუნა მარჯვნივ"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "თაგუნა ზემოთ"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr ""
+#~ "საჩვენებელი გვერდის სახელის მითითება (theme|background|fonts|interface)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- გნომის თაგუნას პარამეტრები"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>გადათრევა და გაშვება</b>"
+
+#~ msgid "<b>Dwell Click</b>"
+#~ msgstr "<b>დაყოვნებული წკაი</b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>მაჩვენებლის მოძებნა</b>"
+
+#~ msgid "<b>Pointer Speed</b>"
+#~ msgstr "<b>მაჩვენებლის სიჩქარე</b>"
+
+#~ msgid ""
+#~ "<i>To test your double-click settings, try to double-click on the light "
+#~ "bulb.</i>"
+#~ msgstr "<I>ორმაგი წკაპის მორგების დასატესტად ორჯერ დააწკაპეთ ნათურას.</i>"
+
+#~ msgid ""
+#~ "<i>You can also use the Dwell Click panel applet to choose the click type."
+#~ "</i>"
+#~ msgstr ""
+#~ "<I>ასევე შეგიძლიათ აირჩიოთ დაგვიანებული წკაპის პანელი და აირჩიოთ წკაპის "
+#~ "სტილი. </I>"
+
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i>მაღალ</i></small>"
+
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i>დიდი</i></small>"
+
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>დაბალი</i></small>"
+
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i>პატარა</i></small>"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "წინასწარ აირჩიეთ წკაპის ტიპი"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "აირჩიეთ თაგუნის ჟესტების ტი_პი"
+
+#~ msgid "D_rag click:"
+#~ msgstr "წკაპი გადათ_რევით:"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "თაგვის პარამეტრები"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "_Control ღილაკის დაჭერისას თაგუნას მაჩვენებლის მდებარეობის ჩვენება"
+
+#~ msgid "Show click type _window"
+#~ msgstr "აირჩიეთ წკაპის ტიპის ფანჯარა"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "_ზღვარი:"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "_აჩქარება:"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_ცაცია თაგვი"
+
+#~ msgid "_Right-handed"
+#~ msgstr "მა_რჯვენა ხელზე"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_მგრძნობელობა:"
+
+#~ msgid "_Single click:"
+#~ msgstr "_ერთმაგი წკაპი:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "თაგვის პარამეტრების დაყენება"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "თვენი ქსელის პროქსის პარამეტრების დაყენება"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>ინტერნეტში პირდაპირი შ_ეერთება</b>"
+
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>ჰოსტების ნუსხის იგნორირება</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>პროქრის _ავტომატური კონფიგურირება</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>პროქსის _ხელით კონფიგურირება</b>"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP პროქსის დეტალები"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "ქსელის პროქსის პარამეტრები"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "უსაფრთხო _HTTP პროქსი:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "ხმის ჩართვა და მის სისტემის მოვლენებთან ასოციაცია"
+
+#, c-format
+#~ msgid "Unknown Volume Control %d"
+#~ msgstr "უცნობი ხმის სიმძლავრის რეგულატორი %d"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - Advanced Linux Sound Architecture"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART Sound Daemon"
+
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ESD - Enlightened Sound Daemon"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - Open Sound System"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "PulseAudio Sound Server"
+
+#~ msgid "Test Sound"
+#~ msgstr "ტესტ ხმა"
+
+#~ msgid "Silence"
+#~ msgstr "სიჩუმე"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "- გნომის ხმის პარამეტრები"
+
+#~ msgid "<b>Alerts and Sound Effects</b>"
+#~ msgstr "<b>განგაში და ხმოვანი ეფექტები</b>"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>აუდიო კონფერენცია</b>"
+
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>მიქშერის ნაგულისხმევი არხები</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>მუსიკა და ფილმი</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>ხმოვანი მოვლენები</b>"
+
+#~ msgid "<b>Sound Theme</b>"
+#~ msgstr "<b>ხმოვანი მოვლენები</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">შემოწმება...</span>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "\"დიახ\" ტესტის დასრულებისთვის."
+
+#~ msgid "Play _alert sound"
+#~ msgstr "სისტემური ხმის _დაკვრა"
+
+#~ msgid "Play _sound effects when buttons are clicked"
+#~ msgstr "ხმის დაკვრა ღილაკებზე დაწკაპუნებისას"
+
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+#~ msgstr ""
+#~ "მოწყობილობების და არხების ამორჩევა კლავიატურის დახმარებით ხდება. "
+#~ "გამოიყენეთ Shift ან Control ღილაკები, ერთი ან მეტი არხის ამოსარჩევად."
+
+#~ msgid "So_und playback:"
+#~ msgstr "ხ_მის დაკვრა:"
+
+#~ msgid "Sou_nd capture:"
+#~ msgstr "ხმის ჩაწე_რა:"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ხმის პარამეტრები"
+
+#~ msgid "_Device:"
+#~ msgstr "_მოწყობილობა:"
+
+#~ msgid "_Play alerts and sound effects"
+#~ msgstr "_გაფრთხილებებისა და ხმოვანი ეფექტების დაკვრა"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "ხმი_ს დაკვრა:"
+
+#~ msgctxt "Sound event"
+#~ msgid "Windows and Buttons"
+#~ msgstr "ფანჯრები და ღილაკები"
+
+#~ msgctxt "Sound event"
+#~ msgid "Toggle button clicked"
+#~ msgstr "დაჭერილი ღილაკის გადართვა"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window maximized"
+#~ msgstr "გადიდებული ფანჯარა"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window unmaximized"
+#~ msgstr "ფანჯარა განდიდებულია"
+
+#~ msgctxt "Sound event"
+#~ msgid "Desktop"
+#~ msgstr "სამუშაო მაგიდა"
+
+#~ msgctxt "Sound event"
+#~ msgid "Login"
+#~ msgstr "შესვლა"
+
+#~ msgctxt "Sound event"
+#~ msgid "Logout"
+#~ msgstr "გამოსვლა"
+
+#~ msgctxt "Sound event"
+#~ msgid "New e-mail"
+#~ msgstr "ახალი იმეილი"
+
+#~ msgctxt "Sound event"
+#~ msgid "Long action completed (download, CD burning, etc.)"
+#~ msgstr "დასრულდა ხანგრძლივი ოპერაცია (გადმოწერა, დისკის ჩაწერა და ა.შ.)"
+
+#~ msgctxt "Sound event"
+#~ msgid "Alerts"
+#~ msgstr "გაფრთხილება"
+
+#~ msgctxt "Sound event"
+#~ msgid "Information or question"
+#~ msgstr "ინფორმაცია ან კითხვა"
+
+#~ msgctxt "Sound event"
+#~ msgid "Warning"
+#~ msgstr "შეტყობინება"
+
+#~ msgid "Custom..."
+#~ msgstr "გა_მართვა..."
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "შეუძლებელია ფანჯრების მმართველისთვის პარამეტრების გაშვება"
+
+#~ msgid "C_ontrol"
+#~ msgstr "_Ctrl"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "_ტირე"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "_ზედა (ან \"ფანჯრის ლოგო\")"
+
+#~ msgid "_Meta"
+#~ msgstr "_მეტა"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>მოძრაობის ღილაკი</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>თავსართს მოქმედება</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>მონიშვნა ფანჯარაში</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "ფანჯარის გადასაადგილებლად, დააჭირეთ და დაჭერილზე გადაიტანეთ ფანჯარა:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "ფანჯარის პარამეტრები"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_ინტერვალი ამოწევამდე:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "მონიშნული ფანჯრის _ამოტანა ინტერვალის მერე"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "ფანჯრის მონიშვნა ზედ თაგვის გადატარებისას"
+
+#~ msgid "Set your window properties"
+#~ msgstr "თქვენი ფანჯრის პარამეტრების მითითება"
+
+#~ msgid "Windows"
+#~ msgstr "ფანჯრები"
+
+#, c-format
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>გაშვება %s</b>"
+
+#~ msgid "Upgrade"
+#~ msgstr "განახლება"
+
+#~ msgid "Uninstall"
+#~ msgstr "ამოშლა"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "რჩეულებში დამატება"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "ავტოგაშვებიდან ამოშლა"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "<ავტოგაშვებაში დამატება"
+
+#, c-format
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>არავითარი ნაპოვნი დამთხვევა.</b> </span><span>\n"
+#~ "\n"
+#~ " არც ერთი ელემენტი არ შეესაბამება თქვენს ფილტრს. \"<b>%s</b>\"</span>"
+
+#~ msgid "Shutdown"
+#~ msgstr "გამორთვა"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "ახალი ელცხრილი"
+
+#~ msgid "New Document"
+#~ msgstr "ახალი დოკუმენტი"
+
+#~ msgid "Documents"
+#~ msgstr "დოკუმენტები"
+
+#, c-format
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>გახსნა</b>"
+
+#~ msgid "Send To..."
+#~ msgstr "გაგზავნა..."
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "თუ წაშლით ელემენტს, ის სამუდამოდ დაიკარგება."
+
+#, c-format
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>გახსნა მეშვეობით \"%s\"</b>"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "ფაილთა მმართველში გახსნა"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "დღეს %l:%M %p"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "მყისვე პოვნა"
+
+#, c-format
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>გახსნა %s</b>"
+
+#, c-format
+#~ msgid "Remove from System Items"
+#~ msgstr "სისტემური ელემენტებიდან ამოღება"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "ფანჯრების მმართველმა \"%s\" არ დაარეგისტრირა კონფიგურირების ხელსაწყო\n"
+
+#~ msgid "Maximize"
+#~ msgstr "გაშლა"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "ვერტიკალურად გადიდება"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "ჰორიზონტალურად გადიდება"
+
+#~ msgid "Minimize"
+#~ msgstr "ჩაკეცვა"
+
+#~ msgid "Roll up"
+#~ msgstr "ზემოთ აკეცვა"
+
+#~ msgid "Groups"
+#~ msgstr "ჯგუფები"
+
+#~ msgid "Control Center"
+#~ msgstr "მართვის ცენტრი"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "მართვის ცენტრის დახურვა, ამოცანის აქტივირებისას"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "დამატების ან წაშლის ყოველი ოპერაციის შემდეგ საჭიროა გარსის დატოვება"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "დახმარების ოპერაციის შემდეგ გარსის დატოვება"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "გაშვების ოპერაცის შემდეგ გარსის დატოვება"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "განახლების ან წაშლის ოპერაციის შემდეგ გარსის დატოვება"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "აღნიშნავს, რომ გარსი გაითიშება დახმარების მოქმედების შესრულებისას."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "აღნიშნავს, რომ გარსი გაითიშება გაშვების მოქმედების შესრულებისას."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "აღნიშნავს, რომ გარსი გაითიშება დამატების ან წაშლის მოქმედების "
+#~ "შესრულებისას."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "აღნიშნავს, რომ გარსი გაითიშება განახლების ან წაშლის მოქმედების "
+#~ "შესრულებისას."
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "ამოცანების სახელები და მათთან ასოცირებული .desktop ფაილები"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "ამოცანის სახელი გამოჩნდება control-center-ში, მოგყვება \";\" და სამუშაო "
+#~ "მაგიდის სახელი ამ ამოცანის გასაშვებად."
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[მაგიდის ფონის შეცვლა;background.desktop,გაფორმების შეცვლა;gtk-theme-"
+#~ "selector.desktop,სასურველი პროგრამების განსაზღვრა;default-applications."
+#~ "desktop,პრინტერის დამატება;gnome-cups-manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr "მართვის ცენტრის დახურვა, ამოცანის აქტივირებისას."
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "გნომის კონფიგურაციის ხელსაწყო"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "/_დასვენების გადადება"
+
+#~ msgid "Take a break!"
+#~ msgstr "ცოტა დაისვენეთ!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/და_სვენება"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d წუთი მომავალ პაუზამდე"
+
+#, c-format
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "რჩება წუთზე ნაკლები მომავალ პაუზამდე"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "შეუძლებელია აკრეფის შესვენების თვისებების ფანჯრის გამოტანა შემდეგი "
+#~ "შეცდომით: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "ავტორი Richard Hult <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "დიზაინი Anders Carlsson"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "დასვენების შეტყობინების პროგრამა."
+
+#~ msgid "translator-credits"
+#~ msgstr "ვლადიმერ სიჭინავა Vladimer Sichinava <vlsichinava@gmail.com>"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "არ შეამოწმო, არსებობს თუა რა გაფრთხილებების პანელი"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "აკრეფის მონიტორი ინფორმაციის საჩვენებლად შეტყობინებების ზონას იყენებს. "
+#~ "როგორც ჩანს, თქვენ არ გაქვთ შეტყობინებების ზონა თქვენს პანელზე. თქვენ "
+#~ "შეგიძლიათ დაამატოთ ის თქვენს პანელზე მაუსის მარჯვენა ღილაკით და აირჩიეთ "
+#~ "„პანელზე დამატება“, აირჩიეთ „შეტყობინებების ზონა“ და დააწკაპუნეთ "
+#~ "„დამატებაზე“."
+
+#~ msgid " "
+#~ msgstr "."
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr ""
+#~ "სისტემაში შემოსვლისთანავე, გნომის დამხმარე ტექნოლოგიების მხარდაჭერის "
+#~ "ჩართვა"
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "დაიშვა შეცდომა თაგუნას პარამეტრების გაშვებისას: %s"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "შეუძლებელია AccessX-ის პარამეტრების '%s' ფაილიდან იმპორტირება"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "პარამეტრების ფაილის იმპორტირება"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "კლავიატურით წვდომის პარამეტრების დაყენება"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "სისტემას არ გააჩნია XKB-ის გაფართოება. მის გარეშე შეუძლებელია კლავიატურის "
+#~ "სპეც შესაძლებლობების ამუშავება."
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>თაგ_უნას კლავიშების ჩართვა</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>კლავიშების გ_ამეორების ჩართვა</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>ფუნქციები</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>გადამრთველი კლავიშები</b>"
+
+#~ msgid "Basic"
+#~ msgstr "ძირითადი"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "პიპინი, როდესაც ნათურის LED-ი ირთვება, 2ჯერ პიპინი როდესაც ითიშება."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "დაყოვნება ღილაკზე დაჭერასა და კურსორის მ_ოძრაობას შორის:"
+
+#~ msgid "Filters"
+#~ msgstr "ფილტრები"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "ერთი და იგივე კლავიშის თანმიმდევრული დაჭერის იგნორირება, მომხმარებლის "
+#~ "მიერ მითითებული დროის პერიოდში."
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "კლავიატურის სპეც საშუალებების პარამეტრების გამართვა (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "კ_ურსორის მაქსიმალური სიჩქარე:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "თაგვის _პარამეტრები..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "მხოლოდ იმ კლავიშების დაშვება, რომლებსაც დაეჭირათ მომხმარებლის მიერ "
+#~ "განსაზღვრული დროის მერე."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "მრავალი ერთდროული კლავიშების დაჭერა, მოდიფიკატორის კლავიშების "
+#~ "მიმდევრობითი დაჭერისას"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "აჩქარების დრო მაქსიმა_ლურ სიჩქარემდე:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "ციფრული ველის კლავიშების თაგვის მმართველად ჩართვა."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_გათიშვა, თუ არ გამოიყენება:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "კლავიატურით წვდომის შესაძლებლობების დაშ_ვება"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "შესაძლებლობების პარამეტრების _იმპორტი..."
+
+#~ msgid "_accepted"
+#~ msgstr "მ_იღებული"
+
+#~ msgid "_pressed"
+#~ msgstr "_დაჭერილი"
+
+#~ msgid "_rejected"
+#~ msgstr "_უარყოფილი"
+
+#~ msgid "characters/second"
+#~ msgstr "ასო-ნიშანი წამში"
+
+#~ msgid "milliseconds"
+#~ msgstr "მილიწამები"
+
+#~ msgid "pixels/second"
+#~ msgstr "პიქსელი/წამში"
+
+#~ msgid ""
+#~ "Centered\n"
+#~ "Fill screen\n"
+#~ "Scaled\n"
+#~ "Zoom\n"
+#~ "Tiled"
+#~ msgstr ""
+#~ "ცენტრში\n"
+#~ "ეკრანის შევსება\n"
+#~ "მაშტაბირებული\n"
+#~ "გადიდებული\n"
+#~ "მოზაიკისებრი"
+
+#~ msgid "Go _to Fonts Folder"
+#~ msgstr "შრიფტების დას_ტაში გადასვლა"
+
+#~ msgid "The theme is an engine. You need to compile it."
+#~ msgstr "გაფორმება კოდის წყაროს წარმოადგენს. საჭიროა მისი კომპილირება."
+
+#~ msgid "The file format is invalid"
+#~ msgstr "ფაილის ფორმატი მცდარია"
+
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s ეს არის მდებარეობა, სადაც თემის ფაილები დაყენდება. ეს არ შეიძლება "
+#~ "ამორჩეულ იქნას, როგორც წყაროს მდებარეობა"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "ფაილის არამართებული ფორმატი."
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "მხოლოდ დაყენებულის გამოყენება და გასვლა"
+
+#~ msgid "Autostart the preferred AT"
+#~ msgstr "არჩეული AT-ს ავტოგაშვება"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "Evolution საფოსტო კლიენტი 1.4"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "Evolution საფოსტო კლიენტი 1.5"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "Evolution საფოსტო კლიენტი 1.6"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "Evolution საფოსტო კლიენტი 2.0"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "Evolution საფოსტო კლიენტი 2.2"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "Evolution საფოსტო კლიენტი 2.4"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Links ტექსტ ბროუზერი"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Lynx ტექსტ ბროუზერი"
+
+#~ msgid "Simple OnScreen Keyboard"
+#~ msgstr "ჩვეულებრივი ეკრან კლავიატურა"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "ტექსტური ბროუზერი W3M"
+
+#~ msgid "Inverted"
+#~ msgstr "ინვერტირებული"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "ეკრანის გარჩევადობის პარამეტრები"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "ა_ქციე ნაგულისხმევად მხოლოდ ამ (%s) კომპიუტერისთვის"
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "მიმდინარეობს ახალი პარამეტრების ტესტირება. თუ არ უპასუხებთ %d წამში, "
+#~ "აღდგება თავდაპირველი პარამეტრები."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "გარჩევადობის დატოვება"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "წინა გარჩევადობის გამოყ_ენება"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_გარჩევადობის დატოვება"
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "XRandR გაფართოვების ვერსია ამ პროგრამასთან შეუთავსებელია. X-ის აქტიურ "
+#~ "მდგომარეობაში ყოფნის დროს შეუძლებელია გარჩევადობის გასწორება."
+
+#~ msgid "New accelerator..."
+#~ msgstr "ახალი ამაჩქარებელი..."
+
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "შეცდომა ახალი ამაჩქარებლის დაყენებისას კონფიგურაციის ბაზაში: %s\n"
+
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "კლავიატურის ინსტრუმენტის გაშვებისას შეცდომა მოხდა: %s"
+
+#~ msgid "Choose..."
+#~ msgstr "ამორჩევა..."
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "მაიკროსოფტის კლავიატურა"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_დამხმარე საშუალებები."
+
+#~ msgid "_Layouts:"
+#~ msgstr "_განლაგებები:"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>სწრაფი</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>მაღალი</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>დიდი</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>დაბალი</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>ნელა</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>პატარა</i>"
+
+#~ msgid "Motion"
+#~ msgstr "მოძრაობა"
+
+#~ msgid "      "
+#~ msgstr "......"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "დამატებითი პარამეტრები"
+
+#~ msgid "E_nable software sound mixing (ESD)"
+#~ msgstr "ხმის პროგრამული მიქშირების _დაშვება (ESD)"
+
+#~ msgid "System Beep"
+#~ msgstr "სისტემური პიპინი"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "_სისტემური პიპინის დაშვება"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "თქვენ გეწირათ Shift კლავიშზე 8 წამი, ეს გამოიყენება ნელი კლავიშების "
+#~ "შესაძლებლობებისთვის, რაც თქვენი კლავიატურის მუშაობის სტილზე ახდენს "
+#~ "გავლენას."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "გნებავთ ნელი კლავიშების ჩართვა?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "გნებავთ ნელი კლავიშების გამორთვა?"
+
+#~ msgid "_Deactivate"
+#~ msgstr "_გამორთვა"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "ა_რ ჩართო"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "თქვენ 5-ჯერ მიყოლებით დააჭირეთ Shift კლავიშს, ეს გამოიყენება დარჭობილი "
+#~ "კლავიშების შესაძლებლობებისათვის, რაც თქვენი კლავიტურის მუშაობის სტილზე "
+#~ "ახდენს გავლენას."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "თქვენ დააჭირეთ ორ კლავიშს ერდროულად ან 5-ჯერ მიყოლებით დააჭირეთ Shift "
+#~ "კლავიშს. ეს თიშავს დარჭობილი კლავიშების შესაძლებლობებს, რაც თქვენი "
+#~ "კლავიატურის მუშაობის სტილზე ახდენს გავლენას."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "გნებავთ \"წებოვანი\" კლავიშების გააქტიურება?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "გნებავთ \"წებოვანი\" კლავიშების გამორთვა?"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "შეუძლებელია \"%s\" დასტის შექმნა.\n"
+#~ "საჭიროა კურსორის გაფორმების თემის შესაცვლელად."
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "შეუძლებელია დასტის შექმნა \"%s\".\n"
+#~ "საჭიროა კურსორის შეცვლისათვის."
+
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "ღილაკების კომბინაცია (%s) განსაზღვრულია ზოგიერთი ქმედებისთვის.\n"
+
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "ღილაკების კომბინაცია (%s) განსაზღვრულია რამოდენჯერმე\n"
+
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "ღილაკების კომბინაცია (%s) არ არის განსაზღვრული\n"
+
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "ღილაკების კომბინაცია (%s) დაუშვებელია\n"
+
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr "შესაძლებელია რომ სხვა პროგრამა უკვე იყენებს '%u' ღილაკს."
+
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "ღილაკების კომბინაცია (%s) უკვე გამოყენებაშია\n"
+
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "შეცდომა (%s)-ის გაშვების მცდელობისას\n"
+#~ "რომელიც შეესაბამება ღილაკს (%s)"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "აღ_არ მაჩვენო მოცემული გაფრთხილების შეტყობინება"
+
+#~ msgid ""
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.</b>\n"
+#~ "\n"
+#~ "Expected was %s, but the the following settings were found: %s.\n"
+#~ "\n"
+#~ "Which set would you like to use?"
+#~ msgstr ""
+#~ "<b>X სისტემის კლავიატური განლაგება განსხვავდება თქვენს GNOME კლავიატურის "
+#~ "განლაგებასთან.</b>\n"
+#~ "\n"
+#~ "მოსალოდნელი იყო %s, მაგრამ ნაპოვნია: %s.\n"
+#~ "\n"
+#~ "რომლის გამოყენება გსურთ?"
+
+#~ msgid "Use X settings"
+#~ msgstr "X-ის პარამეტრების გამოყენება"
+
+#~ msgid "Keep GNOME settings"
+#~ msgstr "გნომის პარამეტრების დატოვება"
+
+#~ msgid ""
+#~ "Could not get default terminal. Verify that your default terminal command "
+#~ "is set and points to a valid application."
+#~ msgstr ""
+#~ "ვერ ვრთავ ნაგულისხმევ ტერმინალს. დარწმუნდით რომ თქვენი ნაგულისხმევი "
+#~ "ტერმინალის პროგრამა მონიშნულია."
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this is a valid command."
+#~ msgstr ""
+#~ "შეუძლებელია ბრძანების გაშვება: %s\n"
+#~ "შეამოწმეთ შეყვანილი ბრძანების მართებულობაში."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "შეუძლებელია მძინარე რეჟიმში გადასვლა.\n"
+#~ "დარწმუნდით რომ კომპიუტერი სწორედაა კონფიგურირებული."
+
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "დაიშვა შეცდომა ეკრანმზოგის გაშვებისას:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "მიმდინარე სესიაში ეკრანმზოგი ვერ იმუშავებს."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_არ ანახო ხელახლა მოცემული შეტყობინება"
+
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "შეუძლებელია ხმოვანი ფაილის %s გაშვება, მაგალითად:%s"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "შეუძლებელია მომხმარებლის სახლის დასტის დადგენა"
+
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "GConf გასაღები %s-ის მნიშვნელობა %s-ია, მაგრამ მოსალოდნელი მნიშვნელობა %s-"
+#~ "ია\n"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "არ ა_ნახო ხელახლა მოცემული გაფრთხილების შეტყობინება."
+
+#~ msgid "Load modmap files"
+#~ msgstr "modmap ფაილების ჩატვირთვა"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "გნებავთ modmap ფაილების ჩატვირთვა?"
+
+#~ msgid "_Load"
+#~ msgstr "_ჩატვირთვა"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "შეცდომა სიგნალური არხის შექმნისას."
+
+#~ msgid "Preview Width"
+#~ msgstr "ესკიზის სიგანე"
+
+#~ msgid "Preview Height"
+#~ msgstr "ესკიზის სიმაღლე"
+
+#~ msgid "Edited %m/%d/%Y"
+#~ msgstr "შეცვლილი %m/%d/%Y"
+
+#~ msgid "Unexpected attribute '%s' for element '%s'"
+#~ msgstr "მოულოდნელი ატრიბუტი '%s' ელემენტ '%s'-თვის"
+
+#~ msgid "Attribute '%s' of element '%s' not found"
+#~ msgstr "ატრიბუტი'%s' ელემენტისთვის '%s' ვერ მოიძებნა"
+
+#~ msgid "Unexpected tag '%s', tag '%s' expected"
+#~ msgstr "უცნობი ჭდე '%s', მოსალოდნელი იყო '%s'"
+
+#~ msgid "Unexpected tag '%s' inside '%s'"
+#~ msgstr "უცნობი ჭდე '%s' - '%s'"
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "მონაცემთა დასტებში მართებული საკვანძო ფაილი ვერ მოიძებნა"
+
+#~ msgid "A bookmark for URI '%s' already exists"
+#~ msgstr "URI '%s' სანიშნე უკვე არსებობს"
+
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "URI '%s' სანიშნე ვერ მოიძებნა"
+
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "URI '%s' სანიშნეში MIME ტიპი არ მითითებულა"
+
+#~ msgid "No private flag has been defined in bookmark for URI '%s'"
+#~ msgstr "URI '%s' სანიშნეში პირადი ალამი არ მითითებულა"
+
+#~ msgid "No groups set in bookmark for URI '%s'"
+#~ msgstr "URI '%s' სანიშნეში ჯგუფები არ მითითებულა"
+
+#~ msgid "No application with name '%s' registered a bookmark for '%s'"
+#~ msgstr "პროგრამისთვის სახელწოდებით '%s' არ მითითებულა სანიშნე '%s'"
+
+#~ msgid "Boing"
+#~ msgstr "ბოინგი"
+
+#~ msgid "Siren"
+#~ msgstr "სირენა"
+
+#~ msgid "Clink"
+#~ msgstr "წკაპუნი"
+
+#~ msgid "Beep"
+#~ msgstr "პიპინი"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "არავითარი ხმა მოცემული მოვლენისთვის."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "არ არსებობს ხმოვანი ფაილი მოცემული მოვლენისთვის.\n"
+#~ "საჭიროა gnome-audio პაკეტის დაყენება, სტანდარტული ხმებისთვის."
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "არ არსებობს ხმოვანი ფაილი მოცემული მოვლენისთვის."
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "ფაილი %s არამართებული wav ფაილია"
+
+#~ msgid "Select sound file..."
+#~ msgstr "ხმოვანი ფაილის არჩევა..."
+
+#~ msgid "E-mail"
+#~ msgstr "ელფოსტა"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "ელფოსტის პროგრამის მალსახმობი."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "სახლის დასტის მალსახმობი."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "დახმარების ბროუზერის მალსახმობი."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "ვებ ბრაუზერის მალსახმობის გაშვება."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "სეანსის დასრულების მალსახმობი."
+
+#~ msgid "Media player key's shortcut."
+#~ msgstr "მედია დამკვრელის მალსახმობი"
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "შემდგომ აუდიოკვალზე გადასვლის მალსახმობი."
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "პაუზის მალსახმობი."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "დაკვრა (ან დაკვრა/პაუზა) მალსახმობი."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "წინა აუდიოკვალზე გადასვლის მალსახმობი."
+
+#~ msgid "Sleep"
+#~ msgstr "მძინარე რეჟიმი"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "მძინარე რეჟიმში გადასვლის მალსახმობი"
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "შეჩერების მალსახმობი."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "ხმის ჩაწევის მალმხმობი."
+
+#~ msgid "Volume mute's shortcut."
+#~ msgstr "ხმის გათიშვის მალსახმობი."
+
+#~ msgid "Volume step"
+#~ msgstr "ხმის რეგულაციის ბიჯი"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "ხმის ცვლის პროცენტების სახით."
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "ხმის აწევის მალსახმობი."
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr ""
+#~ "დიალოგ სარკმლის გამოსახვა, ეკრანმზოგის გაშვების დროს წარმოჩენილი "
+#~ "შეცდომების შემთხვევაში"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "სეანსის დაწყებისთანავე ეკრანმზოგის გაშვება"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "სისტემის გაშვებისას შეცდომების ჩვენება"
+
+#~ msgid "Start screensaver"
+#~ msgstr "ეკრანმზოგის გაშვება"
+
+#~ msgid "Sets the default application font"
+#~ msgstr "პროგრამების ნაგულისხმევი შრიფტის სახით მითითება"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "იყო არაბეთს როსტევან, მეფე ღმრთისაგან სვიანი! 0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "ზომა:"
+
+#~ msgid "Copyright:"
+#~ msgstr "საავტორო უფლება:"
+
+#~ msgid "Description:"
+#~ msgstr "აღწერა:"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "გამოყენება: %s _შრიფტის ფაილი\n"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "გნომის შრიფტის მნახველი"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "ესკიზის ტექსტი (default: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "ტექსტი"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "შრიფტის ზომა (ნაგულისხმევი: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">გნებავთ ახალი შრიფტის გამოყენება?</"
+#~ "span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "შრიფტის უა_რყოფა"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "თქვენს მიერ ამორჩეული გაფორმებას სჭირდება ახალი შრიფტი. შრიფტის ესკიზი "
+#~ "იხილეთ ქვემოთ."
+
+#~ msgid "Themes"
+#~ msgstr "გაფორმება"
+
+#~ msgid "Window border theme"
+#~ msgstr "ფანჯრის ჩარჩოს გაფორმება"
+
+#~ msgid "Icon theme"
+#~ msgstr "ხატულას გაფორმება"
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "გაფორმების ესკიზების შემქმნელი პროგრამა დაყენებული გაფორმებისთვის"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "გაფორმების ესკიზების შემქმნელი პროგრამა"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "გაფორმების ესკიზების ჩვენება/არ ჩვენება"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "გაფორმების ესკიზების შექმნა/არ შექმნა"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ႠႡႢႣႤႥႦႧႨႩႪ"
+
+#~ msgid "[FILE]"
+#~ msgstr "[FILE]"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "აყენებს ნაგულისხმევ გაფორმებას"

--- a/po/kab.po
+++ b/po/kab.po
@@ -6,326 +6,228 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2021-11-16 14:40+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2021-11-18 08:11+0100\n"
+"Last-Translator: Slimane Selyan Amiri <selyan.kab@protonmail.com>\n"
 "Language-Team: \n"
+"Language: kab_DZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0\n"
-"Last-Translator: Slimane Selyan Amiri <selyan.kab@protonmail.com>\n"
-"Language: kab_DZ\n"
-
-#: panels/applications/cc-applications-panel.c:823
-msgid "System Bus"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-#: panels/applications/cc-applications-panel.c:838
-#: panels/applications/cc-applications-panel.c:843
-msgid "Full access"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:825
-msgid "Session Bus"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/power/cc-power-panel.ui:85 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525
-msgid "Devices"
-msgstr "Ibenkan"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Full access to /dev"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:833
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:288 panels/wwan/cc-wwan-device-page.ui:114
-#: panels/wwan/cc-wwan-network-dialog.ui:4
-msgid "Network"
-msgstr "Aẓeṭṭa"
-
-#: panels/applications/cc-applications-panel.c:833
-msgid "Has network access"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:838
-#: panels/applications/cc-applications-panel.c:840
-#: panels/search/cc-search-locations-dialog.c:362
-msgid "Home"
-msgstr "Agejdan"
-
-#: panels/applications/cc-applications-panel.c:840
-#: panels/applications/cc-applications-panel.c:845
-msgid "Read-only"
-msgstr "Tɣuri kan"
-
-#: panels/applications/cc-applications-panel.c:843
-#: panels/applications/cc-applications-panel.c:845
-msgid "File System"
-msgstr "Anagraw n ifuyla"
-
-#: panels/applications/cc-applications-panel.c:849
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/gnome-control-center.appdata.xml.in:7 shell/cc-window.c:313
-#: shell/cc-window.c:1043 shell/cc-window.ui:121
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr "Iɣewaren"
-
-#: panels/applications/cc-applications-panel.c:849
-msgid "Can change settings"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:851
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1024
-msgid "Web Links"
-msgstr "Iseɣwan n Web"
-
-#: panels/applications/cc-applications-panel.c:1034
-msgid "Git Links"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1040
-#, c-format
-msgid "%s Links"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1048
-#: panels/applications/cc-applications-panel.c:1084
-msgid "Unset"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1139
-msgid "Links"
-msgstr "Iseɣwan"
-
-#: panels/applications/cc-applications-panel.c:1147
-msgid "Hypertext Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1161
-msgid "Text Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1175
-msgid "Image Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1191
-msgid "Font Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1252
-msgid "Archive Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1272
-msgid "Package Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1295
-msgid "Audio Files"
-msgstr "Ifuyla imeslawen"
-
-#: panels/applications/cc-applications-panel.c:1312
-msgid "Video Files"
-msgstr "Ifuyla timwaliyin"
-
-#: panels/applications/cc-applications-panel.c:1320
-msgid "Other Files"
-msgstr ""
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1660
-#: panels/applications/cc-applications-panel.ui:416
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:70
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr "Isnasen"
 
-#: panels/applications/cc-applications-panel.ui:43
+#: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:57
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr ""
 
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Ldi"
+
 #: panels/applications/cc-applications-panel.ui:94
-msgid "Permissions & Access"
-msgstr ""
+#, fuzzy
+msgid "View Details"
+msgstr "Talqayt"
 
-#: panels/applications/cc-applications-panel.ui:106
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:127
-#: panels/camera/gnome-camera-panel.desktop.in.in:3
-msgid "Camera"
-msgstr "Takamiṛat"
-
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:128
-#: panels/applications/cc-applications-panel.ui:140
-#: panels/applications/cc-applications-panel.ui:152
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:262
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:85
-#: panels/keyboard/cc-xkb-modifier-dialog.c:353
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:129
-#: panels/user-accounts/cc-user-panel.c:848
-#: panels/user-accounts/cc-user-panel.c:938
-#: panels/wwan/cc-wwan-device-page.c:479
-#: subprojects/gvc/gvc-mixer-control.c:1900
-msgid "Disabled"
-msgstr "Yensa"
-
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:139
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
-msgid "Microphone"
-msgstr "Asawaḍ"
-
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:151
-#: panels/location/gnome-location-panel.desktop.in.in:3
-msgid "Location Services"
-msgstr "Imeẓla n wadig"
-
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:500
-msgid "Built-in Permissions"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:158
-msgid "Cannot be changed"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:175
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:199
-msgid "Integration"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:211
-msgid "System features used by this application."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:225
-#: panels/applications/cc-applications-panel.ui:231
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:151
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Anadi"
 
-#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Yensa"
+
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr "Tilɣa"
 
-#: panels/applications/cc-applications-panel.ui:243
-msgid "Run in background"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Tilɣa"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Agilal"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:249
-msgid "Set Desktop Background"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Tuṭṭfiwin n ugdil"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:255
-#: panels/applications/cc-applications-panel.ui:261
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Imeslan"
 
-#: panels/applications/cc-applications-panel.ui:267
-msgid "Inhibit system keyboard shortcuts"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:300
-msgid "Default Handlers"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Inegzumen Yugnen"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Inegzumen n unasiw"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Takamiṛat"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:312
-msgid "Types of files and links that this application opens."
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Asawaḍ"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:328
-msgid "Reset"
-msgstr "Wennez"
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Imeẓla n wadig"
 
-#: panels/applications/cc-applications-panel.ui:364
-msgid "Usage"
-msgstr "Aseqdec"
-
-#: panels/applications/cc-applications-panel.ui:376
-msgid "How much resources this application is using."
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:391
-#: panels/applications/cc-applications-panel.ui:537
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Asekles"
 
-#: panels/applications/cc-applications-panel.ui:424
-msgid "Open in Software"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:474 shell/cc-panel-list.ui:121
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Ulac igmaḍ"
 
-#: panels/applications/cc-applications-panel.ui:485
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:177
-#: shell/cc-panel-list.ui:132
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Ɛreḍ inadiyen yemgaraden"
 
-#: panels/applications/cc-applications-panel.ui:555
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Anagraw n ifuyla"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Iseɣwan"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Wennez"
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:564
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Asnas"
 
-#: panels/applications/cc-applications-panel.ui:570
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Isefka"
 
-#: panels/applications/cc-applications-panel.ui:576
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Tuffirt"
 
-#: panels/applications/cc-applications-panel.ui:582
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:599
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr ""
 
@@ -333,135 +235,95 @@ msgstr ""
 msgid "Control various application permissions and settings"
 msgstr ""
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 
-#: panels/background/cc-background-chooser.c:344
-msgid "Select a picture"
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
 msgstr ""
 
-#: panels/background/cc-background-chooser.c:347
-#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:238
-#: panels/color/cc-color-panel.c:886 panels/color/cc-color-panel.ui:657
-#: panels/common/cc-language-chooser.ui:25
-#: panels/display/cc-display-panel.c:1023
-#: panels/info-overview/cc-info-overview-panel.ui:243
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:122
-#: panels/network/cc-wifi-panel.c:866
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:176
-#: panels/network/connection-editor/vpn-helpers.c:299
-#: panels/network/net-device-wifi.c:854
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:235
-#: panels/region/cc-format-chooser.ui:28
-#: panels/search/cc-search-locations-dialog.c:639
-#: panels/sharing/cc-sharing-panel.c:396 panels/usage/cc-usage-panel.c:133
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:105
-#: panels/user-accounts/cc-avatar-chooser.c:228
-#: panels/user-accounts/cc-fingerprint-dialog.ui:36
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:638
-#: panels/user-accounts/cc-user-panel.c:656
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/wwan/cc-wwan-mode-dialog.ui:35
-#: panels/wwan/cc-wwan-network-dialog.ui:166
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:297
-msgid "_Cancel"
-msgstr "Sefsex (_C)"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Amezwer"
 
-#: panels/background/cc-background-chooser.c:348
-#: panels/network/connection-editor/vpn-helpers.c:177
-#: panels/printers/pp-details-dialog.c:236
-#: panels/sharing/cc-sharing-panel.c:397
-#: panels/user-accounts/cc-avatar-chooser.c:229
-msgid "_Open"
-msgstr "_Ldi"
-
-#: panels/background/cc-background-item.c:140
-msgid "multiple sizes"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
 
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:144
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:282
-msgid "No Desktop Background"
-msgstr ""
-
-#: panels/background/cc-background-panel.c:110
-msgid "Current background"
-msgstr ""
-
-#: panels/background/cc-background-panel.ui:55
-msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Irmad"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Agilal"
 
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+msgid "Change your background image or the UI colors"
 msgstr ""
 
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "Yermed"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:69
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:80
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:107
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:118
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:124
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:154
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:165
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1392
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -469,30 +331,27 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 
-#: panels/camera/cc-camera-panel.ui:34
-msgid "Camera is turned off"
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
 msgstr ""
 
-#: panels/camera/cc-camera-panel.ui:43
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr ""
 
-#: panels/camera/cc-camera-panel.ui:75
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 
-#: panels/camera/cc-camera-panel.ui:85
-msgid "Allow the applications below to use your camera."
-msgstr ""
-
-#: panels/camera/cc-camera-panel.ui:105
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr ""
 
@@ -500,616 +359,314 @@ msgstr ""
 msgid "Protect your pictures"
 msgstr ""
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr ""
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr ""
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr ""
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr ""
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr ""
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr ""
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr ""
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr ""
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr ""
-
-#: panels/color/cc-color-calibrate.ui:7
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr ""
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Sefsex (_C)"
+
 #. This starts the calibration process
-#: panels/color/cc-color-calibrate.ui:40
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "_Sekker"
 
 #. This resumes the calibration process
-#: panels/color/cc-color-calibrate.ui:54
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "_Kemmel"
 
 #. This button returns the user back to the color control panel
-#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
-#: panels/user-accounts/cc-fingerprint-dialog.ui:73
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr ""
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr ""
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr ""
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr ""
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr ""
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr ""
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr ""
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr ""
-
-#: panels/color/cc-color-device.c:90
-#, c-format
-msgid "Enable color management for %s"
-msgstr ""
-
-#: panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr ""
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:167
-msgid "Default: "
-msgstr "Amezwer: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:175
-msgid "Colorspace: "
-msgstr "Tallunt n yiniten: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:182
-msgid "Test profile: "
-msgstr ""
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:236
-msgid "Select ICC Profile File"
-msgstr ""
-
-#: panels/color/cc-color-panel.c:239
-msgid "_Import"
-msgstr "_Kter"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:250
-msgid "Supported ICC profiles"
-msgstr ""
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:257
-#: panels/network/wireless-security/eap-method-fast.c:356
-msgid "All files"
-msgstr "Akk ifuyla"
-
-#: panels/color/cc-color-panel.c:549
-msgid "Screen"
-msgstr "Agdil"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:839
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr ""
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:851
-msgid "The profile has been uploaded to:"
-msgstr ""
-
-#: panels/color/cc-color-panel.c:853
-msgid "Write down this URL."
-msgstr ""
-
-#: panels/color/cc-color-panel.c:854
-msgid "Restart this computer and boot your normal operating system."
-msgstr ""
-
-#: panels/color/cc-color-panel.c:855
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:883
-msgid "Save Profile"
-msgstr ""
-
-#: panels/color/cc-color-panel.c:887
-#: panels/network/connection-editor/vpn-helpers.c:300
-#: panels/wwan/cc-wwan-apn-dialog.ui:64
-msgid "_Save"
-msgstr "_Sekles"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1196
-msgid "Create a color profile for the selected device"
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1211 panels/color/cc-color-panel.c:1235
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1245
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1256
-msgid "The device type is not currently supported."
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr ""
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Taɣara"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr ""
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Isem n umaγnu"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "Isem n umaγnu"
-
-#: panels/color/cc-color-panel.ui:392
-msgid "Profile successfully created!"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:443
-msgid "Copy profile"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:456
-msgid "Requires writable media"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:607
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Agzul"
 
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:643
-msgid "_Import File…"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:672 panels/keyboard/cc-input-chooser.ui:20
-#: panels/network/connection-editor/net-connection-editor.c:504
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr "_Rnu"
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:788
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Rnu"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 
-#. translators: Text used in link to privacy policy
-#: panels/color/cc-color-panel.ui:810
-#: panels/diagnostics/cc-diagnostics-panel.c:144
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Issin ugar"
 
-#: panels/color/cc-color-panel.ui:815
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:863
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:867 panels/color/cc-color-panel.ui:882
-#: panels/color/cc-color-panel.ui:883
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:878
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:909
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:922
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:926
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:937
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:950
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:986
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1030
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1035
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1040
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1045
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1050
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1055
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1060
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1065
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1070
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1075
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1092
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Haut"
 
-#: panels/color/cc-color-panel.ui:1093
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1097
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "D alemmas"
 
-#: panels/color/cc-color-panel.ui:1098
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 n tesdatin"
 
-#: panels/color/cc-color-panel.ui:1102
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Yuder"
 
-#: panels/color/cc-color-panel.ui:1103
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 n tesdatin"
 
-#: panels/color/cc-color-panel.ui:1125
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1129
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1133
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1137
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1141
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
-msgstr ""
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Tallunt talugant"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Sekyed amaɣnu"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Awurman"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Taɣara taddayt"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr ""
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr ""
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr ""
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr ""
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
 msgstr ""
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
@@ -1121,14 +678,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Wayeḍ..."
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1138,306 +690,184 @@ msgstr ""
 msgid "_Select"
 msgstr ""
 
-#: panels/common/cc-language-chooser.ui:69
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Ulac tutlaying i yettwafen"
 
-#: panels/common/cc-language-chooser.ui:82
-#: panels/keyboard/cc-input-chooser.c:178
+#: panels/common/cc-language-chooser.ui:69
 msgid "More…"
 msgstr ""
 
-#: panels/common/cc-permission-infobar.c:107
-msgid "Unlock to Change Settings"
-msgstr ""
-
-#: panels/common/cc-permission-infobar.ui:20
-msgid "Unlock…"
-msgstr ""
-
-#: panels/common/cc-permission-infobar.ui:56
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr ""
 
-#: panels/common/cc-time-editor.ui:33
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
 msgid "Increment Hour"
 msgstr ""
 
-#: panels/common/cc-time-editor.ui:65
+#: panels/common/cc-time-editor.ui:53
 msgid "Increment Minute"
 msgstr ""
 
-#: panels/common/cc-time-editor.ui:80
+#: panels/common/cc-time-editor.ui:73
 msgid "Time"
 msgstr "Akud"
 
-#: panels/common/cc-time-editor.ui:113
+#: panels/common/cc-time-editor.ui:94
 msgid "Decrement Hour"
 msgstr ""
 
-#: panels/common/cc-time-editor.ui:145
+#: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr ""
 
-#: panels/common/cc-time-entry.c:219
-msgid "_Copy"
-msgstr "_Lesser"
-
-#: panels/common/cc-time-entry.c:225
-msgid "Select _All"
-msgstr "Fren a_kk"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Ass-a"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Iḍelli"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr ""
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr ""
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d n usrag"
-msgstr[1] "%d n isragen"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:973
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d tsedat"
-msgstr[1] "%d tsedatin"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d tasint"
-msgstr[1] "%d tasinin"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr ""
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr ""
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr ""
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr ""
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 n tasint"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr ""
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:262
-msgid "%e %B %Y, %l:%M %p"
-msgstr ""
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:267
-msgid "%e %B %Y, %R"
-msgstr ""
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:449
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:476
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:483
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:488
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:493
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:498
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "January"
-msgstr "yennayer"
-
-#: panels/datetime/cc-datetime-panel.ui:46
-msgid "February"
-msgstr "Fuṛar"
-
-#: panels/datetime/cc-datetime-panel.ui:54
-msgid "March"
-msgstr "Meɣres"
-
-#: panels/datetime/cc-datetime-panel.ui:62
-msgid "April"
-msgstr "Yebrir"
-
-#: panels/datetime/cc-datetime-panel.ui:70
-msgid "May"
-msgstr "Mayyu"
-
-#: panels/datetime/cc-datetime-panel.ui:78
-msgid "June"
-msgstr "Yunyu"
-
-#: panels/datetime/cc-datetime-panel.ui:86
-msgid "July"
-msgstr "Yulyu"
-
-#: panels/datetime/cc-datetime-panel.ui:94
-msgid "August"
-msgstr "Ɣuct"
-
-#: panels/datetime/cc-datetime-panel.ui:102
-msgid "September"
-msgstr "Ctamber"
-
-#: panels/datetime/cc-datetime-panel.ui:110
-msgid "October"
-msgstr "Tuber"
-
-#: panels/datetime/cc-datetime-panel.ui:118
-msgid "November"
-msgstr "Wamber"
-
-#: panels/datetime/cc-datetime-panel.ui:126
-msgid "December"
-msgstr "Dujamber"
-
-#: panels/datetime/cc-datetime-panel.ui:136
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Azemz & Akud"
 
-#: panels/datetime/cc-datetime-panel.ui:187
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "Iseggasen"
 
-#: panels/datetime/cc-datetime-panel.ui:220
+#: panels/datetime/cc-datetime-panel.ui:66
 msgid "Month"
 msgstr "Aggur"
 
-#: panels/datetime/cc-datetime-panel.ui:257
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "yennayer"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Fuṛar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Meɣres"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Yebrir"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mayyu"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Yunyu"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Yulyu"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Ɣuct"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Ctamber"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Tuber"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Wamber"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Dujamber"
+
+#: panels/datetime/cc-datetime-panel.ui:92
 msgid "Day"
 msgstr "Ass"
 
-#: panels/datetime/cc-datetime-panel.ui:286
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Tamnaḍt tasragant"
 
-#: panels/datetime/cc-datetime-panel.ui:307
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:375
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:376
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:396
-msgid "Date & _Time"
-msgstr ""
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Azemz & Akud"
 
-#: panels/datetime/cc-datetime-panel.ui:430
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:431
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:446
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Yermed"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:481
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Serreḥ"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:490
-msgid "24-hour"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:491
-msgid "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
 msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 n tasint"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Lexṣas"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Imiḍanen"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr ""
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr ""
@@ -1450,28 +880,28 @@ msgstr ""
 msgid "To change time or date settings, you need to authenticate."
 msgstr ""
 
-#: panels/default-apps/cc-default-apps-panel.ui:31
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "_Web"
 
-#: panels/default-apps/cc-default-apps-panel.ui:43
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr ""
 
-#: panels/default-apps/cc-default-apps-panel.ui:59
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr ""
 
-#: panels/default-apps/cc-default-apps-panel.ui:75
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "A_ẓawan"
 
-#: panels/default-apps/cc-default-apps-panel.ui:91
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "_tavidyut"
 
-#: panels/default-apps/cc-default-apps-panel.ui:162
-#: panels/removable-media/cc-removable-media-panel.ui:162
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "_Tiwlafin"
 
@@ -1483,24 +913,15 @@ msgstr ""
 msgid "Configure Default Applications"
 msgstr ""
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:146
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:28
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
 msgstr ""
 
-#: panels/diagnostics/cc-diagnostics-panel.ui:65
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
 msgid "_Automatic Problem Reporting"
 msgstr ""
 
@@ -1512,334 +933,312 @@ msgstr ""
 msgid "Report your problems"
 msgstr ""
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
+msgid "diagnostics;crash;"
 msgstr ""
 
-#: panels/display/cc-display-panel.c:1034
-#: panels/network/connection-editor/connection-editor.ui:27
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr ""
 
-#: panels/display/cc-display-panel.c:1055
-msgid "Apply Changes?"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Uɣal"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
 msgstr ""
 
-#: panels/display/cc-display-panel.c:1060
-msgid "Changes Cannot be Applied"
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
 msgstr ""
 
-#: panels/display/cc-display-panel.c:1061
-msgid "This could be due to hardware limitations."
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:89
-msgid "Single Display"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:108
-#: panels/display/cc-display-panel.ui:310
-msgid "Join Displays"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:126
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:151
-msgid "Display Mode"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:220
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:243
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:250
-msgid "Display Arrangement"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:374
-msgid "Active Display"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:421
-msgid "Display Configuration"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:440
-#: panels/display/gnome-display-panel.desktop.in.in:3
-msgid "Displays"
-msgstr ""
-
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:451
-#: panels/display/cc-night-light-page.ui:111
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr ""
 
-#: panels/display/cc-display-settings.c:109
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "S tehri"
-
-#: panels/display/cc-display-settings.c:112
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:115
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:118
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:192
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:15
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Taɣda"
 
-#: panels/display/cc-display-settings.ui:24
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Afray"
 
-#: panels/display/cc-display-settings.ui:33
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Afmidi n usmiren"
 
-#: panels/display/cc-display-settings.ui:42
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr ""
 
-#: panels/display/cc-display-settings.ui:59
-#: panels/display/cc-display-settings.ui:76
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Sellum"
 
-#: panels/display/cc-night-light-page.c:627
-msgid "More Warm"
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
 msgstr ""
 
-#: panels/display/cc-night-light-page.c:639
-msgid "Less Warm"
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
 msgstr ""
 
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:28
-msgid "Restart Filter"
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
 msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:61
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:88
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:127
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Sɣiwes"
 
-#: panels/display/cc-night-light-page.ui:136
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:137
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/region/cc-format-preview.ui:40
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Akud"
 
-#: panels/display/cc-night-light-page.ui:165
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Seg"
 
-#: panels/display/cc-night-light-page.ui:194
-#: panels/display/cc-night-light-page.ui:297
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Asrag"
 
-#: panels/display/cc-night-light-page.ui:203
-#: panels/display/cc-night-light-page.ui:306
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:222
-#: panels/display/cc-night-light-page.ui:325
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Tasdidt"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:234
-#: panels/display/cc-night-light-page.ui:337
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "FT"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:247
-#: panels/display/cc-night-light-page.ui:350
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "MD"
 
-#: panels/display/cc-night-light-page.ui:267
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "I"
 
-#: panels/display/cc-night-light-page.ui:374
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
 msgstr ""
 
 #: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr ""
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:413
-#: panels/info-overview/cc-info-overview-panel.c:437
-#: panels/info-overview/cc-info-overview-panel.c:483
-#: panels/info-overview/cc-info-overview-panel.c:513
-#: panels/wwan/cc-wwan-details-dialog.c:101
-msgid "Unknown"
-msgstr "Arussin"
-
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:445
-#, c-format
-msgid "%s; Build ID: %s"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
 msgstr ""
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:460
-#, c-format
-msgid "64-bit"
-msgstr "64-ibiten"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Taɣellist"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:463
-#, c-format
-msgid "32-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Arussin"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:52
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Taɣellist"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Isem n yibenk"
 
-#: panels/info-overview/cc-info-overview-panel.ui:74
+#: panels/info-overview/cc-info-overview-panel.ui:50
 msgid "Hardware Model"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:83
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "Takatut"
 
-#: panels/info-overview/cc-info-overview-panel.ui:92
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "Asasker"
 
-#: panels/info-overview/cc-info-overview-panel.ui:101
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "Udlifen"
 
-#: panels/info-overview/cc-info-overview-panel.ui:110
+#: panels/info-overview/cc-info-overview-panel.ui:82
 msgid "Disk Capacity"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:111
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr ""
 
 #. translators: this field contains the distro name and version
-#: panels/info-overview/cc-info-overview-panel.ui:133
+#: panels/info-overview/cc-info-overview-panel.ui:98
 msgid "OS Name"
 msgstr "Isem n OS"
 
-#: panels/info-overview/cc-info-overview-panel.ui:142
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:151
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:161
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:169
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:178
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Ileqqman n useɣzan"
 
-#: panels/info-overview/cc-info-overview-panel.ui:199
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:216
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:234
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Isem n yibenk"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr ""
 
@@ -1851,11 +1250,6 @@ msgstr "Γef"
 msgid "View information about your system"
 msgstr ""
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1911,7 +1305,7 @@ msgid "Eject"
 msgstr "Ḍeqqer-d"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:580
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Ajerred"
 
@@ -1930,6 +1324,12 @@ msgstr "Imsinḍen"
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Serreḥ i iminig n uεiwen"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Iɣewaren"
 
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -1952,39 +1352,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Anadi"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "Tuṭṭfiwin n ugdil"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "Nɣel tuddma n wegdil ɣer umendad ufus"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Nɣel tuddma n wegdil n kra n usfaylu ɣer umendad ufus"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Nɣel tuddma n wegdil n kra n wegdil ɣer umendad ufus"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr ""
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Anagraw"
 
@@ -2033,303 +1401,176 @@ msgstr "Simecṭuḥ tiddi n uḍris"
 msgid "High contrast on or off"
 msgstr "Rmed neɣ ssens tanmarit εlayen"
 
-#: panels/keyboard/cc-input-chooser.c:193
-msgid "No input sources found"
-msgstr ""
-
-#: panels/keyboard/cc-input-chooser.c:964
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Nniḍen"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr ""
 
-#: panels/keyboard/cc-input-chooser.ui:77
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr ""
 
-#: panels/keyboard/cc-input-list-box.ui:23
+#: panels/keyboard/cc-input-list-box.ui:24
 msgid "No input source selected"
 msgstr ""
 
-#: panels/keyboard/cc-input-row.ui:75
-msgid "Move up"
-msgstr "Ali d asawen"
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "Isnasen"
 
-#: panels/keyboard/cc-input-row.ui:86
-msgid "Move down"
-msgstr "Ader d akesser"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
 
-#: panels/keyboard/cc-input-row.ui:103
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Ismenyifen"
 
-#: panels/keyboard/cc-input-row.ui:120
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr ""
 
-#: panels/keyboard/cc-input-row.ui:137
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:286
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "kkes"
 
-#: panels/keyboard/cc-keyboard-manager.c:486
-#: panels/keyboard/cc-keyboard-manager.c:494
-#: panels/keyboard/cc-keyboard-manager.c:779
-msgid "Custom Shortcuts"
-msgstr "Inegzumen Yugnen"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.ui:213
-msgid "Alternate Characters Key"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:73
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:74
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:75
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tasarut n wumuɣ"
-
-#: panels/keyboard/cc-keyboard-panel.c:76
-#: panels/keyboard/cc-keyboard-panel.c:94
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:84
-#: panels/keyboard/cc-keyboard-panel.ui:237
-msgid "Compose Key"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:95
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Asekkeṛ n yisekkilen imeqqranen"
-
-#: panels/keyboard/cc-keyboard-panel.c:96
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:97
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:233
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.ui:48
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:18
 msgid "Includes keyboard layouts and input methods."
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:85
+#: panels/keyboard/cc-keyboard-panel.ui:28
 msgid "Input Source Switching"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:131
+#: panels/keyboard/cc-keyboard-panel.ui:31
 msgid "Use the _same source for all windows"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:158
+#: panels/keyboard/cc-keyboard-panel.ui:43
 msgid "Switch input sources _individually for each window"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:177
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:188
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:263
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:306
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:322 shell/cc-window.ui:326
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Inegzumen n unasiw"
 
-#: panels/keyboard/cc-keyboard-panel.ui:283
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:283
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] ""
-msgstr[1] ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:428
-msgid "Reset All Shortcuts?"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:431
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:435
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:275
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-#: panels/wwan/cc-wwan-device-page.c:190
-msgid "Cancel"
-msgstr "Sefex"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:436
-msgid "Reset All"
-msgstr "Err-d akk"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:115
-msgid "Add Custom Shortcuts"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:124
-msgid "Set up custom shortcuts for launching apps, running scripts, and more."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:131
-msgid "Add Shortcut"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:166
-msgid "No keyboard shortcut found"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:211
-#: panels/region/cc-format-chooser.ui:48
-#: panels/user-accounts/cc-fingerprint-dialog.ui:53
-#: panels/wacom/wacom-stylus-page.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
-#: shell/cc-window.ui:230
-msgid "Back"
-msgstr "Uɣal"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:235
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:236
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
 msgid "Reset all shortcuts to their default keybindings"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:391
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Ti_gawt:"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Anegzum"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Anegzum"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:535
-msgid "Enter the new shortcut"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
-msgid "Set Custom Shortcut"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
-msgid "Set Shortcut"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
 msgstr ""
 
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:561
-#, c-format
-msgid "Enter new shortcut to change %s."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "kkes"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "Semselsi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:987
-msgid "Add Custom Shortcut"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:60
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:135
-#: panels/printers/pp-details-dialog.ui:40
-#: panels/wwan/cc-wwan-apn-dialog.ui:132
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Isem"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:147
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Anezḍay"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:159
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Anegzum"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:238
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Ulac"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:296
-#: panels/wwan/cc-wwan-apn-dialog.ui:44
-msgid "Add"
-msgstr "Rnu"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:311
-msgid "Replace"
-msgstr "Semselsi"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:325
-msgid "Set"
-msgstr "Sbadu"
-
-#: panels/keyboard/cc-keyboard-shortcut-row.ui:27
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
 msgstr ""
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
@@ -2342,37 +1583,32 @@ msgid ""
 "and input sources"
 msgstr ""
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:31
-msgid "Location services turned off"
-msgstr ""
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "Imeẓla n wadig"
 
-#: panels/location/cc-location-panel.ui:40
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:72
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-
-#: panels/location/cc-location-panel.ui:81
-msgid ""
+"mobile broadband increases accuracy.\n"
+"\n"
 "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:94
-msgid "Allow the applications below to determine your location."
-msgstr ""
-
-#: panels/location/cc-location-panel.ui:114
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr ""
 
@@ -2380,184 +1616,29 @@ msgstr ""
 msgid "Protect your location information"
 msgstr ""
 
-#. FIXME
-#: panels/lock/cc-lock-panel.ui:27
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
 
-#: panels/lock/cc-lock-panel.ui:44
-msgid "Blank Screen Delay"
-msgstr ""
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Asawaḍ"
 
-#: panels/lock/cc-lock-panel.ui:45
-msgid "Period of inactivity after which the screen will go blank."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:66
-msgid "Automatic Screen _Lock"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:83
-msgid "Automatic _Screen Lock Delay"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:84
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:105
-msgid "Show _Notifications on Lock Screen"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:122
-msgid "Forbid new _USB devices"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:123
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:169
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:173
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 n tsinin"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:177
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 n tesdat"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:181
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 n tesdatin"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:185
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 n tesdatin"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:189
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 n tesdatin"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:193
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 n tesdatin"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:197
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 n usrag"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:212
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 n tesdat"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:216
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 n tesdatin"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:220
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 n tesdatin"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:224
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:228
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 n tesdatin"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:232
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:236
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 n tesdatin"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:240
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr ""
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:244
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 n tesdatin"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:248
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Weṛǧin"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr ""
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr ""
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:34
-msgid "Microphone is turned off"
-msgstr ""
-
-#: panels/microphone/cc-microphone-panel.ui:43
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr ""
 
-#: panels/microphone/cc-microphone-panel.ui:75
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
-"properly."
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
 msgstr ""
 
-#: panels/microphone/cc-microphone-panel.ui:85
-msgid "Allow the applications below to use your microphone."
-msgstr ""
-
-#: panels/microphone/cc-microphone-panel.ui:105
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr ""
 
@@ -2565,104 +1646,160 @@ msgstr ""
 msgid "Protect your conversations"
 msgstr ""
 
-#. FIXME
-#: panels/mouse/cc-mouse-panel.ui:37
-#: panels/multitasking/cc-multitasking-panel.ui:31
-msgid "General"
-msgstr "Amatu"
-
-#: panels/mouse/cc-mouse-panel.ui:57
-msgid "Primary Button"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:58
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:84 panels/sound/cc-balance-slider.ui:13
-msgid "Left"
-msgstr "Zelmaḍ"
-
-#: panels/mouse/cc-mouse-panel.ui:94 panels/sound/cc-balance-slider.ui:15
-msgid "Right"
-msgstr "Yefus"
-
-#: panels/mouse/cc-mouse-panel.ui:122
-msgid "Mouse"
-msgstr "Taɣerdayt"
-
-#: panels/mouse/cc-mouse-panel.ui:142
-msgid "Mouse Speed"
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:154 panels/mouse/cc-mouse-panel.ui:258
-msgid "Double-click timeout"
-msgstr ""
-
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:166 panels/mouse/cc-mouse-panel.ui:230
-msgid "Natural Scrolling"
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:231
-msgid "Scrolling moves the content, not the view."
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:193 panels/mouse/cc-mouse-panel.ui:213
-msgid "Touchpad"
-msgstr "Talwiḥt tawallsant"
-
-#: panels/mouse/cc-mouse-panel.ui:247
-msgid "Touchpad Speed"
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:270
-msgid "Tap to Click"
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:286
-msgid "Two-finger Scrolling"
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:303
-msgid "Edge Scrolling"
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:335 panels/wacom/cc-wacom-panel.c:441
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr ""
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:25
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Amatu"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Zelmaḍ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Yefus"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Adig"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Taɣerdayt"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Irmed"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Talwiḥt tawallsant"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
 msgstr ""
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
@@ -2674,73 +1811,72 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:56
+#: panels/multitasking/cc-multitasking-panel.ui:15
 msgid "_Hot Corner"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:57
+#: panels/multitasking/cc-multitasking-panel.ui:16
 msgid "Touch the top-left corner to open the Activities Overview."
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:84
+#: panels/multitasking/cc-multitasking-panel.ui:42
 msgid "_Active Screen Edges"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:85
+#: panels/multitasking/cc-multitasking-panel.ui:43
 msgid ""
 "Drag windows against the top, left, and right screen edges to resize them."
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:114
+#: panels/multitasking/cc-multitasking-panel.ui:70
 msgid "Workspaces"
 msgstr "Tallunin n umahil"
 
-#: panels/multitasking/cc-multitasking-panel.ui:139
+#: panels/multitasking/cc-multitasking-panel.ui:76
 msgid "_Dynamic workspaces"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:140
+#: panels/multitasking/cc-multitasking-panel.ui:77
 msgid "Automatically removes empty workspaces."
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:158
+#: panels/multitasking/cc-multitasking-panel.ui:91
 msgid "_Fixed number of workspaces"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:159
+#: panels/multitasking/cc-multitasking-panel.ui:92
 msgid "Specify a number of permanent workspaces."
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:179
+#: panels/multitasking/cc-multitasking-panel.ui:108
 msgid "_Number of Workspaces"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:200
+#: panels/multitasking/cc-multitasking-panel.ui:124
 msgid "Multi-Monitor"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:225
+#: panels/multitasking/cc-multitasking-panel.ui:130
 msgid "Workspaces on _primary display only"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:252
+#: panels/multitasking/cc-multitasking-panel.ui:156
 msgid "Workspaces on all d_isplays"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:282
+#: panels/multitasking/cc-multitasking-panel.ui:184
 msgid "Application Switching"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:307
+#: panels/multitasking/cc-multitasking-panel.ui:190
 msgid "Include applications from all _workspaces"
 msgstr ""
 
-#: panels/multitasking/cc-multitasking-panel.ui:325
+#: panels/multitasking/cc-multitasking-panel.ui:204
 msgid "Include applications from the _current workspace only"
 msgstr ""
 
@@ -2752,1205 +1888,495 @@ msgstr ""
 msgid "Manage preferences for productivity and multitasking"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 
-#: panels/network/cc-network-panel.c:686 panels/network/cc-wifi-panel.ui:307
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-
-#: panels/network/cc-network-panel.c:692
-msgid "NetworkManager needs to be running."
-msgstr ""
-
-#: panels/network/cc-network-panel.ui:66
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Inuḍaf-nniḍen"
 
-#: panels/network/cc-network-panel.ui:107
-#: panels/network/connection-editor/net-connection-editor.c:587
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:151
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Tufɣa"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr ""
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:262
-msgid "Insecure network (WEP)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:272
-msgid "Secure network (WPA2)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:277
-msgid "Secure network (WPA3)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:282
-msgid "Secure network"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:68 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Iqqen"
 
-#: panels/network/cc-wifi-connection-row.ui:102
-#: panels/network/net-device-ethernet.c:333
-#: panels/network/network-bluetooth.ui:76
-#: panels/network/network-ethernet.ui:111 panels/network/network-mobile.ui:450
-#: panels/network/network-vpn.ui:77
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr ""
 
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:134
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.c:267
-msgid "Must have a minimum of 8 characters"
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.c:272
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
 msgid "Must have a maximum of %d character"
 msgid_plural "Must have a maximum of %d characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/network/cc-wifi-hotspot-dialog.c:489
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
 msgid "Turn On Wi-Fi Hotspot?"
 msgstr ""
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:19
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
 "Wi-Fi hotspot allows others to share your internet connection, by creating a "
 "Wi-Fi network that they can connect to. To do this, you must have an "
 "internet connection through a source other than Wi-Fi."
 msgstr ""
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:44
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
 msgstr ""
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:69
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:389
-#: panels/printers/pp-jobs-dialog.ui:70
-#: panels/user-accounts/cc-add-user-dialog.ui:249
-#: panels/wwan/cc-wwan-apn-dialog.ui:214
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Awal n uɛeddi"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:83
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr ""
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:84
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr ""
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:130
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:53
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:864
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-
-#: panels/network/cc-wifi-panel.c:867
-msgid "_Stop Hotspot"
-msgstr ""
-
-#: panels/network/cc-wifi-panel.ui:46
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:47
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:87
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:99
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:134 panels/wwan/cc-wwan-panel.ui:143
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:146
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:184
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:195
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:205
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:227
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:296
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr ""
 
-#: panels/network/connection-editor/8021x-security-page.ui:20
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr ""
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:112
-#: panels/network/connection-editor/ce-page-security.c:424
-#: panels/network/connection-editor/details-page.ui:90
-msgid "Security"
-msgstr "Taɣellist"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Ameɣlal"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Agacuran"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr ""
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:228
-msgid "WEP"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:233
-msgid "WPA"
-msgstr ""
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr ""
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:279
-msgid "Enhanced Open"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr ""
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Takebbanit"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:218
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ulac"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Weṛǧin"
-
-#: panels/network/connection-editor/ce-page-details.c:166
-#: panels/network/net-device-ethernet.c:108
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr ""
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:220
-#, c-format
-msgid "%d Mb/s"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:308
-msgid "2.4 GHz / 5 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "5 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:332
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Ulac"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "D uḍɛif"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ih"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Igerrez"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:407
-#: panels/network/connection-editor/details-page.ui:108
-#: panels/network/net-device-ethernet.c:147
-#: panels/network/net-device-mobile.c:442
-msgid "IPv4 Address"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:408
-#: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-mobile.c:443 panels/network/network-mobile.ui:218
-msgid "IPv6 Address"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/ce-page-details.c:411
-#: panels/network/net-device-ethernet.c:152
-#: panels/network/net-device-ethernet.c:154
-#: panels/network/net-device-mobile.c:446
-#: panels/network/net-device-mobile.c:447 panels/network/network-mobile.ui:201
-msgid "IP Address"
-msgstr "Tansa  IP"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-mobile.c:451
-msgid "DNS4"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/net-device-ethernet.c:170
-#: panels/network/net-device-mobile.c:452
-msgid "DNS6"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/connection-editor/details-page.ui:199
-#: panels/network/connection-editor/details-page.ui:218
-#: panels/network/connection-editor/ip4-page.ui:211
-#: panels/network/connection-editor/ip6-page.ui:225
-#: panels/network/net-device-ethernet.c:172
-#: panels/network/net-device-ethernet.c:174
-#: panels/network/net-device-mobile.c:454
-#: panels/network/net-device-mobile.c:455 panels/network/network-mobile.ui:253
-#: panels/network/network-mobile.ui:271
-msgid "DNS"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:471
-msgid "Forget Connection"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Remove Connection Profile"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove VPN"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:493
-msgid "Details"
-msgstr "Talqayt"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "Awurman"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:150
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Tamagit"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ip4.c:400
-#: panels/network/connection-editor/ce-page-ip6.c:370
-msgid "Delete Route"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ip4.c:754
-msgid "IPv4"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ip6.c:726
-msgid "IPv6"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:268
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ulac"
-
-#: panels/network/connection-editor/ce-page-security.c:303
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:313
-msgid "WEP 128-bit Passphrase"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:326
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:339
-msgid "Dynamic WEP (802.1x)"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:353
-msgid "WPA & WPA2 Personal"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:367
-msgid "WPA & WPA2 Enterprise"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-security.c:381
-msgid "WPA3 Personal"
-msgstr ""
-
-#: panels/network/connection-editor/details-page.ui:18
-#: panels/wwan/cc-wwan-details-dialog.ui:105
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:54
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:144
-#: panels/network/net-device-ethernet.c:157
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Taɣellist"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:162
+#: panels/network/connection-editor/details-page.ui:142
 msgid "Supported Frequencies"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:180
-#: panels/network/net-device-ethernet.c:161
-#: panels/network/net-device-ethernet.c:163
-#: panels/network/net-device-ethernet.c:165
-#: panels/network/network-mobile.ui:235
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:236
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Aseqdec anneggaru"
 
-#: panels/network/connection-editor/details-page.ui:415
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:434
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:467
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:478
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:25
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Isem"
 
-#: panels/network/connection-editor/ethernet-page.ui:54
-#: panels/network/connection-editor/wifi-page.ui:67
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:105
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:122
-#: panels/network/connection-editor/wifi-page.ui:102
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:137
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:118
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "S ufus"
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "Sexsi"
 
-#: panels/network/connection-editor/ip4-page.ui:97
-#: panels/network/connection-editor/ip6-page.ui:111
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
 msgid "Shared to other computers"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:125
-#: panels/network/connection-editor/ip6-page.ui:139
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "Tansiwin"
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
-#: panels/printers/pp-details-dialog.ui:95
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Tansa"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:171
-#: panels/network/connection-editor/ip4-page.ui:355
-#: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:369
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:223
-#: panels/network/connection-editor/ip4-page.ui:291
-#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/connection-editor/ip6-page.ui:305
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:107
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "Awurman"
 
-#: panels/network/connection-editor/ip4-page.ui:234
-#: panels/network/connection-editor/ip6-page.ui:248
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:258
-#: panels/network/connection-editor/ip6-page.ui:272
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:279
-#: panels/network/connection-editor/ip6-page.ui:293
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Iberdan"
 
-#: panels/network/connection-editor/ip4-page.ui:302
-#: panels/network/connection-editor/ip6-page.ui:316
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr ""
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:368
-#: panels/network/connection-editor/ip6-page.ui:382
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:398
-#: panels/network/connection-editor/ip6-page.ui:412
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr ""
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr ""
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr ""
 
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Adat"
 
-#: panels/network/connection-editor/net-connection-editor.c:280
-msgid "Unable to open connection editor"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:296
-msgid "New Profile"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:731
-msgid "Import from file…"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:763
-msgid "Add VPN"
-msgstr ""
-
-#: panels/network/connection-editor/security-page.ui:20
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr ""
 
-#: panels/network/connection-editor/vpn-helpers.c:139
-msgid "Cannot import VPN connection"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:141
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:173
-msgid "Select file to import"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:225
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:227
-msgid "_Replace"
-msgstr "_Semselsi"
-
-#: panels/network/connection-editor/vpn-helpers.c:229
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:264
-msgid "Cannot export VPN connection"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:266
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:296
-msgid "Export VPN connection"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr ""
 
-#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr ""
 
-#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Aẓeṭṭa"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr ""
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr ""
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 
-#: panels/network/net-device-ethernet.c:96
-msgid "never"
-msgstr ""
-
-#: panels/network/net-device-ethernet.c:104
-msgid "today"
-msgstr "ass-a"
-
-#: panels/network/net-device-ethernet.c:106
-msgid "yesterday"
-msgstr "Iḍelli"
-
-#: panels/network/net-device-ethernet.c:180
-msgid "Last used"
-msgstr ""
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:267
-#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "S ugatu"
 
-#: panels/network/net-device-mobile.c:209
-msgid "Add new connection"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:851
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-
-#: panels/network/net-device-wifi.c:855
-msgid "_Forget"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1034 panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr ""
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1076
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1217
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1220
-msgid "Wireless device does not support Hotspot mode"
-msgstr ""
-
-#: panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:260
-#: panels/power/cc-power-panel.c:856 panels/power/cc-power-panel.c:867
-#: panels/universal-access/cc-ua-panel.c:331
-#: panels/universal-access/cc-ua-panel.c:612
-#: panels/universal-access/cc-ua-panel.c:622
-#: panels/universal-access/cc-ua-panel.c:634
-#: panels/universal-access/cc-ua-panel.c:677
-#: panels/universal-access/cc-ua-panel.ui:338
-#: panels/universal-access/cc-ua-panel.ui:384
-#: panels/universal-access/cc-ua-panel.ui:430
-#: panels/universal-access/cc-ua-panel.ui:536
-#: panels/universal-access/cc-ua-panel.ui:689
-#: panels/universal-access/cc-ua-panel.ui:735
-#: panels/universal-access/cc-ua-panel.ui:781
-#: panels/universal-access/cc-ua-panel.ui:965
-msgid "Off"
-msgstr "Ur irmid ara"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr ""
-
-#. update title
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/net-vpn.c:65 panels/network/net-vpn.c:158
-#, c-format
-msgid "%s VPN"
-msgstr ""
-
-#: panels/network/network-bluetooth.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr ""
 
-#: panels/network/network-mobile.ui:29
-#: panels/wwan/cc-wwan-details-dialog.ui:286
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Irmed"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr ""
 
-#: panels/network/network-mobile.ui:47
+#: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Imfeki"
 
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:96
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Tansa  IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr ""
 
-#: panels/network/network-proxy.ui:180
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr ""
 
-#: panels/network/network-proxy.ui:199
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr ""
 
-#: panels/network/network-proxy.ui:218
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr ""
 
-#: panels/network/network-proxy.ui:237
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr ""
 
-#: panels/network/network-proxy.ui:256
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr ""
 
-#: panels/network/network-proxy.ui:294
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr ""
 
-#: panels/network/network-proxy.ui:371
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr ""
 
-#: panels/network/network-proxy.ui:392
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr ""
 
-#: panels/network/network-proxy.ui:413
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr ""
 
-#: panels/network/network-proxy.ui:442
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr ""
 
-#: panels/network/network-vpn.ui:56
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
-msgstr ""
-
-#: panels/network/network-wifi.ui:22
-msgctxt "Wi-Fi Hotspot"
-msgid "Network Name"
-msgstr ""
-
-#: panels/network/network-wifi.ui:28
-msgctxt "Wi-Fi Hotspot"
-msgid "Security type"
 msgstr ""
 
 #: panels/network/network-wifi.ui:34
 msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr ""
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Awal n uɛeddi"
 
-#: panels/network/network-wifi.ui:84
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr ""
 
-#: panels/network/network-wifi.ui:116
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr ""
 
-#: panels/network/network-wifi.ui:127
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr ""
 
-#: panels/network/network-wifi.ui:138
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Ulac-it"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Tuqqna ɣer"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Tlaq tuqqna"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Tufɣa"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Tuqna ur teddi yara"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:195
-msgid "no file selected"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:222
-msgid "unspecified error validating eap-method file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:400
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:87
-msgid "missing EAP-FAST PAC file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:347
-msgid "Choose a PAC file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:352
-msgid "PAC files (*.pac)"
 msgstr ""
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
@@ -3977,76 +2403,53 @@ msgstr ""
 msgid "Both"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.ui:49
-#: panels/network/wireless-security/eap-method-peap.ui:52
-#: panels/network/wireless-security/eap-method-ttls.ui:51
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
 msgid "Anony_mous identity"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.ui:75
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.ui:115
-#: panels/network/wireless-security/eap-method-peap.ui:150
-#: panels/network/wireless-security/eap-method-ttls.ui:143
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.ui:144
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.ui:17
-#: panels/network/wireless-security/eap-method-simple.ui:17
-#: panels/network/wireless-security/ws-leap.ui:18
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_Isem n useqdac"
 
-#: panels/network/wireless-security/eap-method-leap.ui:31
-#: panels/network/wireless-security/eap-method-simple.ui:31
-#: panels/network/wireless-security/ws-leap.ui:32
-#: panels/network/wireless-security/ws-sae.ui:14
-#: panels/network/wireless-security/ws-wpa-psk.ui:14
-#: panels/sharing/cc-sharing-panel.ui:202
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:365
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-leap.ui:55
-#: panels/network/wireless-security/eap-method-simple.ui:73
-#: panels/network/wireless-security/eap-method-tls.ui:157
-#: panels/network/wireless-security/ws-leap.ui:56
-#: panels/network/wireless-security/ws-sae.ui:54
-#: panels/network/wireless-security/ws-wpa-psk.ui:64
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:87
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:96
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:328
-#: panels/network/wireless-security/eap-method-tls.c:513
-#: panels/network/wireless-security/eap-method-ttls.c:336
-msgid "Choose a Certificate Authority certificate"
 msgstr ""
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
@@ -4063,97 +2466,42 @@ msgstr ""
 msgid "Version 1"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-peap.ui:78
-#: panels/network/wireless-security/eap-method-tls.ui:68
-#: panels/network/wireless-security/eap-method-ttls.ui:102
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-peap.ui:100
-#: panels/network/wireless-security/eap-method-tls.ui:90
-#: panels/network/wireless-security/eap-method-ttls.ui:125
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-peap.ui:118
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:92
-msgid "missing EAP-TLS identity"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:102
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:112
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:129
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:139
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:272
-msgid "Unencrypted private keys are insecure"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:275
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:506
-msgid "Choose your personal certificate"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:520
-msgid "Choose your private key"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.ui:17
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-tls.ui:43
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-tls.ui:108
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-tls.ui:133
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:98
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:106
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
 msgstr ""
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
@@ -4172,20 +2520,20 @@ msgstr ""
 msgid "CHAP"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-ttls.ui:76
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
 msgid "_Domain"
 msgstr "_Taɣult"
-
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr ""
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4207,57 +2555,15 @@ msgstr ""
 msgid "Protected EAP (PEAP)"
 msgstr ""
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:56
-#: panels/network/wireless-security/ws-wep-key.ui:102
-#: panels/network/wireless-security/ws-wpa-eap.ui:61
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr ""
 
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr ""
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr ""
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr ""
-
-#: panels/network/wireless-security/ws-sae.ui:42
-#: panels/network/wireless-security/ws-wpa-psk.ui:42
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
 msgstr ""
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
@@ -4272,83 +2578,62 @@ msgstr ""
 msgid "Shared Key"
 msgstr ""
 
-#: panels/network/wireless-security/ws-wep-key.ui:48
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr ""
 
-#: panels/network/wireless-security/ws-wep-key.ui:84
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr ""
 
-#: panels/network/wireless-security/ws-wep-key.ui:134
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr ""
 
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:60
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr ""
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:112
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr ""
 
-#: panels/notifications/cc-app-notifications-dialog.ui:168
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr ""
 
-#: panels/notifications/cc-app-notifications-dialog.ui:184
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
 msgstr ""
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:249
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr ""
 
-#: panels/notifications/cc-app-notifications-dialog.ui:300
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr ""
 
-#: panels/notifications/cc-app-notifications-dialog.ui:351
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr ""
 
-#: panels/notifications/cc-notifications-panel.c:260
-#: panels/power/cc-power-panel.c:862 panels/power/cc-power-panel.c:869
-#: panels/universal-access/cc-ua-panel.c:331
-#: panels/universal-access/cc-ua-panel.c:612
-#: panels/universal-access/cc-ua-panel.c:622
-#: panels/universal-access/cc-ua-panel.c:634
-#: panels/universal-access/cc-ua-panel.c:677
-msgid "On"
-msgstr ""
-
-#: panels/notifications/cc-notifications-panel.ui:44
+#: panels/notifications/cc-notifications-panel.ui:10
 msgid "_Do Not Disturb"
 msgstr ""
 
-#: panels/notifications/cc-notifications-panel.ui:52
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr ""
 
@@ -4356,34 +2641,32 @@ msgstr ""
 msgid "Control which notifications are displayed and what they show"
 msgstr ""
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 
-#: panels/online-accounts/cc-online-accounts-panel.c:148
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Nniḍen"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Err-d"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:576
-#, c-format
-msgid "%s Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Tilɣa"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
 msgstr ""
 
-#: panels/online-accounts/cc-online-accounts-panel.c:870
-msgid "Error removing account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:936
-#, c-format
-msgid "%s removed"
-msgstr "%s yettwakkes"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4393,40 +2676,11 @@ msgstr "Imiḍanen ɣef uẓeḍḍa"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:61
-msgid "Undo"
-msgstr "Err-d"
-
-#: panels/online-accounts/online-accounts.ui:94
-msgid "Connect to your data in the cloud"
-msgstr ""
-
-#: panels/online-accounts/online-accounts.ui:109
-msgid "No internet connection — connect to set up new online accounts"
-msgstr ""
-
-#: panels/online-accounts/online-accounts.ui:134
-msgid "Add an account"
-msgstr ""
-
-#: panels/online-accounts/online-accounts.ui:223
-msgid "Remove Account"
-msgstr ""
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Akud arussin"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4442,13 +2696,6 @@ msgid_plural "%i hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr ""
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4461,364 +2708,151 @@ msgid_plural "minutes"
 msgstr[0] "tisdatin"
 msgstr[1] "tisdatin"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Dayen yeččur"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Ilem"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "La d-yettali"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Taɣerdayt mebla tinelwa"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Amdeswal"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Amallal umḍin udmawan"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Tiliɣri n ufus"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Imeɣri n ugetmedia"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209 panels/wacom/cc-wacom-panel.c:728
-msgid "Tablet"
-msgstr "Taṭablit"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Aselkim"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr ""
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:384
-#: panels/power/cc-power-panel.ui:63
-msgid "Battery"
-msgstr "Aẓru"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Agejdan"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Ayen-nniḍen"
-
-#: panels/power/cc-power-panel.c:382
-msgid "Batteries"
-msgstr "Tibaṭriyin"
-
-#: panels/power/cc-power-panel.c:644
-msgid "When _idle"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:796
-msgid "Suspend"
-msgstr "Ḥbes di leεḍil"
-
-#: panels/power/cc-power-panel.c:797
-msgid "Power Off"
-msgstr "Sens"
-
-#: panels/power/cc-power-panel.c:798
-msgid "Hibernate"
-msgstr "Sgen"
-
-#: panels/power/cc-power-panel.c:799
-msgid "Nothing"
-msgstr "Ulac"
-
-#: panels/power/cc-power-panel.c:858
-msgid "When on battery power"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:860
-msgid "When plugged in"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:980
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Weṛǧin"
-
-#: panels/power/cc-power-panel.c:1066
-msgid "Automatic suspend"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1171
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1173
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1175
-msgid "Performance mode temporarily disabled."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1218
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1226
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1230
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr ""
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "15 n tesdatin"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "20 n tisdatin"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr ""
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 n tesdatin"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 ntesdatin"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 n usrag"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr ""
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 n tesdatin"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr ""
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 n isragen"
 
-#: panels/power/cc-power-panel.ui:107
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Aẓru"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Ibenkan"
+
+#: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:108
+#: panels/power/cc-power-panel.ui:94
 msgid "Affects system performance and power usage."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:142
+#: panels/power/cc-power-panel.ui:123
 msgid "Power Saving Options"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:146
+#: panels/power/cc-power-panel.ui:126
 msgid "Automatic Screen Brightness"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:147
+#: panels/power/cc-power-panel.ui:127
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:161
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:175
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:183
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:184
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:198
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:217
-msgid "Suspend & Power Button"
-msgstr ""
-
-#: panels/power/cc-power-panel.ui:221
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:229
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:268
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:293
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:309
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:354 panels/power/cc-power-panel.ui:414
-#: panels/universal-access/cc-repeat-keys-dialog.ui:74
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Amenḍaṛ"
-
-#: panels/power/cc-power-profile-row.c:61
-msgid "Lap detected: performance mode unavailable"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:63
-msgid "High hardware temperature: performance mode unavailable"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:64
-msgid "Performance mode unavailable"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:86
-#: panels/power/cc-power-profile-row.c:185
-msgid "High performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:184
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Atwal"
-
-#: panels/power/cc-power-profile-row.c:188
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:189
-msgid "Standard performance and power usage."
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:192
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr ""
-
-#: panels/power/cc-power-profile-row.c:193
-msgid "Reduced performance and power usage."
-msgstr ""
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4828,52 +2862,10 @@ msgstr "Tazmert"
 msgid "View your battery status and change power saving settings"
 msgstr ""
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
-msgstr ""
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "Sesteb"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/new-printer-dialog.ui:366
-#: panels/printers/pp-jobs-dialog.ui:57 panels/wwan/cc-wwan-apn-dialog.ui:188
-msgid "Username"
-msgstr "Isem n useqdac"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:339
-msgid "Authentication Required"
-msgstr ""
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:683
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr ""
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:927
-msgid "Failed to add new printer."
-msgstr ""
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1226
-#, c-format
-msgid "Could not load ui: %s"
-msgstr ""
-
-#: panels/printers/cc-printers-panel.c:1294
-msgid "Unlock to Add Printers and Change Settings"
 msgstr ""
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
@@ -4884,729 +2876,287 @@ msgstr "Tisaggazin"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
 
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:254
-#: panels/printers/pp-new-printer-dialog.c:311
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr ""
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
-#: panels/wwan/cc-wwan-device-page.ui:90
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr ""
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr ""
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr ""
 
-#: panels/printers/new-printer-dialog.ui:356
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:351
-#, c-format
-msgid "%s Details"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Isem n useqdac"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
 
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.c:232
-msgid "Select PPD File"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.c:241
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Adig"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:122
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr ""
 
-#: panels/printers/pp-details-dialog.ui:162
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr ""
 
-#: panels/printers/pp-details-dialog.ui:183
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr ""
 
-#: panels/printers/pp-details-dialog.ui:192
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr ""
 
-#: panels/printers/pp-details-dialog.ui:201
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr ""
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr ""
-
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:107
-msgid "Select"
-msgstr "Fren"
 
 #: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr ""
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr ""
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Sefex"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr ""
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Fren"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr ""
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "S teẓɣzi"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "S tehri"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr ""
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:137
-msgctxt "print job"
-msgid "Pending"
-msgstr "Yegguni"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:143
-msgctxt "print job"
-msgid "Paused"
-msgstr "Yettṛaǧu"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:148
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Tlaq tuqqna"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:153
-msgctxt "print job"
-msgid "Processing"
-msgstr "Asesfer"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:157
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Yeḥbes"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:161
-msgctxt "print job"
-msgid "Canceled"
-msgstr ""
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:165
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Ittwasefsex"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:169
-msgctxt "print job"
-msgid "Completed"
-msgstr "Yemmed"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:179
-msgid "Move this job to the top of the queue"
-msgstr ""
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:319
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:471
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr ""
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:475
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr ""
-
 #. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/pp-jobs-dialog.ui:44
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
 msgid "Domain"
 msgstr "Taɣult"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:129
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr ""
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:169
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Sfeḍ meṛṛa"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:232
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr ""
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:358
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr ""
 
-#: panels/printers/pp-new-printer-dialog.c:269
-msgid "Unlock Print Server"
-msgstr ""
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:273
-#, c-format
-msgid "Unlock %s."
-msgstr ""
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:277
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-
-#: panels/printers/pp-new-printer-dialog.c:587
-msgid "Searching for Printers"
-msgstr ""
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1375
-msgid "USB"
-msgstr ""
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1380
-msgid "Serial Port"
-msgstr ""
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1387
-msgid "Parallel Port"
-msgstr ""
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1429
-#, c-format
-msgid "Location: %s"
-msgstr ""
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1434
-#, c-format
-msgid "Address: %s"
-msgstr ""
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1461
-msgid "Server requires authentication"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Taɣbalut n taferkit"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Afray"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr ""
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:530
-msgid "Pages per side"
-msgstr ""
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:542
-msgid "Two-sided"
-msgstr ""
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:554
-msgid "Orientation"
-msgstr "Taɣda"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:651
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Amatu"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Tawila n usebtar"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr ""
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Tawiri"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr ""
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Ini"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr ""
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Talqayt"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:857
-#: panels/printers/pp-options-dialog.ui:18
+#: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr ""
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:870
-msgid "Test page"
-msgstr ""
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr ""
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Ulac asizdeg yezwaren"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:203
-msgid "Manufacturer"
-msgstr ""
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:523 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr ""
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:528
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:648
-msgid "Clean print heads"
-msgstr ""
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:713
-msgid "Low on toner"
-msgstr ""
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:715
-msgid "Out of toner"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:718
-msgid "Low on developer"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of developer"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:723
-msgid "Low on a marker supply"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:725
-msgid "Out of a marker supply"
-msgstr ""
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:727
-msgid "Open cover"
-msgstr ""
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:729
-msgid "Open door"
-msgstr ""
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:731
-msgid "Low on paper"
-msgstr ""
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:733
-msgid "Out of paper"
-msgstr ""
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:735
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Beṛṛa n tuqqna"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:737
-#: panels/printers/pp-printer-entry.c:880
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Yeḥbes"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:739
-msgid "Waste receptacle almost full"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:741
-msgid "Waste receptacle full"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:743
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:745
-msgid "The optical photo conductor is no longer functioning"
-msgstr ""
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:866
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Iwjed"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:871
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr ""
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:876
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Asesfer"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr ""
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr ""
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr ""
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr ""
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr ""
 
-#: panels/printers/printer-entry.ui:193
-#: panels/wwan/cc-wwan-details-dialog.ui:229
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Taneɣruft"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr ""
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:313
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr ""
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:320
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Ales tanekra"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:12
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr ""
 
-#: panels/printers/printers.ui:187
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr ""
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:201
-msgid "Add a Printer…"
-msgstr ""
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:233
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:189
-#: panels/region/cc-format-chooser.ui:6 panels/region/cc-region-panel.ui:203
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Imusal"
 
-#: panels/region/cc-format-chooser.ui:101
-msgid ""
-"Choose the format for numbers, dates and currencies. Changes take effect on "
-"next login."
-msgstr ""
-
-#: panels/region/cc-format-chooser.ui:117
+#: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:158
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:189
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:242
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:255
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:300
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Timeẓriwt"
 
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr ""
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr ""
-
-#: panels/region/cc-format-preview.ui:18
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr ""
 
-#: panels/region/cc-format-preview.ui:62
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr ""
 
-#: panels/region/cc-format-preview.ui:84
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Imiḍanen"
 
-#: panels/region/cc-format-preview.ui:106
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr ""
 
-#: panels/region/cc-format-preview.ui:128
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Lkaɣeḍ"
 
-#: panels/region/cc-region-panel.ui:42
-msgid "My Account"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
 msgstr "Amiḍan-inu"
 
-#: panels/region/cc-region-panel.ui:53
-msgid "Login Screen"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:78
-msgid "Language"
-msgstr "Tameslayt"
-
-#: panels/region/cc-region-panel.ui:89
-msgid "The language used for text in windows and web pages."
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:129
-#: panels/user-accounts/cc-user-panel.ui:311
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Tutlayt"
 
-#: panels/region/cc-region-panel.ui:164
-msgid "Restart the session for changes to take effect"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:179
-msgid "Restart…"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:214
-msgid "The format used for numbers, dates, and currencies."
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:248
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr ""
 
-#: panels/region/cc-region-panel.ui:275
-msgid "Login settings are used by all users when logging into the system"
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
 msgstr ""
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
@@ -5617,137 +3167,47 @@ msgstr ""
 msgid "Select your display language and formats"
 msgstr ""
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.c:267
-msgid "Ask what to do"
-msgstr "Steqsi d acu ara tgeḍ"
-
-#: panels/removable-media/cc-removable-media-panel.c:271
-msgid "Do nothing"
-msgstr "Ur tegg acmek"
-
-#: panels/removable-media/cc-removable-media-panel.c:275
-msgid "Open folder"
-msgstr "Ldi akaram"
-
-#: panels/removable-media/cc-removable-media-panel.c:341
-msgid "Other Media"
-msgstr "Amidya-nniḍen"
-
-#: panels/removable-media/cc-removable-media-panel.c:362
-msgid "Select an application for audio CDs"
-msgstr "Fren asnas i CDs asfeldan"
-
-#: panels/removable-media/cc-removable-media-panel.c:363
-msgid "Select an application for video DVDs"
-msgstr "Fren asnan i uvidyu DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:364
-msgid "Select an application to run when a music player is connected"
-msgstr "Fren asnas iwumi ara tserrḥeḍ m'ara yili yeqqen kra n yimeɣri n uẓawan"
-
-#: panels/removable-media/cc-removable-media-panel.c:365
-msgid "Select an application to run when a camera is connected"
-msgstr "Fren asnas ad tt-seduḍ m'ara ad tens takamirat"
-
-#: panels/removable-media/cc-removable-media-panel.c:366
-msgid "Select an application for software CDs"
-msgstr "Fran asnas i iCD-iyen ideg llan iseɣẓanen"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "audio DVD"
-msgstr "DVD asfeldan"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "blank Blu-ray disc"
-msgstr "aḍebsi Blu-ray d ilem"
-
-#: panels/removable-media/cc-removable-media-panel.c:380
-msgid "blank CD disc"
-msgstr "aḍebsi CD d ilem"
-
-#: panels/removable-media/cc-removable-media-panel.c:381
-msgid "blank DVD disc"
-msgstr "aḍebsi DVD d ilem"
-
-#: panels/removable-media/cc-removable-media-panel.c:382
-msgid "blank HD DVD disc"
-msgstr "aḍebsi HD DVD d ilem"
-
-#: panels/removable-media/cc-removable-media-panel.c:383
-msgid "Blu-ray video disc"
-msgstr "aḍebsi Blu-ray uvidyu"
-
-#: panels/removable-media/cc-removable-media-panel.c:384
-msgid "e-book reader"
-msgstr "imeɣri n e-book"
-
-#: panels/removable-media/cc-removable-media-panel.c:385
-msgid "HD DVD video disc"
-msgstr "aḍebsi HD DVD uvidyu"
-
-#: panels/removable-media/cc-removable-media-panel.c:386
-msgid "Picture CD"
-msgstr "Aḍebsi CD n tungniwin"
-
-#: panels/removable-media/cc-removable-media-panel.c:387
-msgid "Super Video CD"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:388
-msgid "Video CD"
-msgstr "Vidyu CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:389
-msgid "Windows software"
-msgstr "Iseɣẓanen n Windows"
-
-#: panels/removable-media/cc-removable-media-panel.ui:44
+#: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.ui:75
+#: panels/removable-media/cc-removable-media-panel.ui:52
 msgid "CD _audio"
 msgstr "CD_n tesfelda"
 
-#: panels/removable-media/cc-removable-media-panel.ui:92
+#: panels/removable-media/cc-removable-media-panel.ui:67
 msgid "_DVD video"
 msgstr "_DVD n uvidyu"
 
-#: panels/removable-media/cc-removable-media-panel.ui:133
+#: panels/removable-media/cc-removable-media-panel.ui:102
 msgid "_Music player"
 msgstr "Imeɣri n_uẓawan"
 
-#: panels/removable-media/cc-removable-media-panel.ui:191
+#: panels/removable-media/cc-removable-media-panel.ui:152
 msgid "_Software"
 msgstr "_Aseɣẓan"
 
-#: panels/removable-media/cc-removable-media-panel.ui:229
+#: panels/removable-media/cc-removable-media-panel.ui:178
 msgid "_Other Media…"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.ui:288
+#: panels/removable-media/cc-removable-media-panel.ui:195
 msgid "_Never prompt or start programs on media insertion"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.ui:342
+#: panels/removable-media/cc-removable-media-panel.ui:225
 msgid "Select how other media should be handled"
 msgstr "Fren amek ara ttusferken imidyaten-nniḍen"
 
-#: panels/removable-media/cc-removable-media-panel.ui:389
+#: panels/removable-media/cc-removable-media-panel.ui:259
 msgid "_Action:"
 msgstr "Ti_gawt:"
 
-#: panels/removable-media/cc-removable-media-panel.ui:412
+#: panels/removable-media/cc-removable-media-panel.ui:278
 msgid "_Type:"
 msgstr "Anaw:"
 
@@ -5759,62 +3219,132 @@ msgstr ""
 msgid "Configure Removable Media settings"
 msgstr ""
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:636
-msgid "Select Location"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:640
-msgid "_OK"
-msgstr "_IH"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
 
-#: panels/search/cc-search-locations-dialog.ui:9
-#: panels/search/cc-search-panel.ui:57
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Isekkeṛ ugdil"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Tabaḍnit"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Agdil"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Iɣewwaṛen n Umiḍan"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.ui:32
-#: panels/search/cc-search-locations-dialog.ui:69
-#: panels/search/cc-search-locations-dialog.ui:107
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.ui:52
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr "Imukan"
 
-#: panels/search/cc-search-locations-dialog.ui:91
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Ticraḍ"
 
-#: panels/search/cc-search-locations-dialog.ui:156
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Nniḍen"
 
-#: panels/search/cc-search-panel.c:151
-msgid "No applications found"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Adig"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Asnas"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
 msgstr ""
 
-#: panels/search/cc-search-panel-row.ui:92
-msgid "Move Up"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
 msgstr ""
 
-#: panels/search/cc-search-panel-row.ui:102
-msgid "Move Down"
-msgstr ""
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Anadi"
 
-#: panels/search/cc-search-panel.ui:31
-msgid ""
-"Control which search results are shown in the Activities Overview. The order "
-"of search results can also be changed by moving rows in the list."
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
 msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
@@ -5822,155 +3352,134 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:306
-msgid "No networks selected for sharing"
-msgstr ""
-
-#: panels/sharing/cc-sharing-networks.ui:19
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.c:289
-msgctxt "service is enabled"
-msgid "On"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:291 panels/sharing/cc-sharing-panel.c:318
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Ur irmid ara"
-
-#: panels/sharing/cc-sharing-panel.c:321
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Yermed"
-
-#: panels/sharing/cc-sharing-panel.c:324
-msgctxt "service is active"
-msgid "Active"
-msgstr "Irmed"
-
-#: panels/sharing/cc-sharing-panel.c:393
-msgid "Choose a Folder"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:696
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:702
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:708
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to %s"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:813
-msgid "Copy"
-msgstr "Nɣel"
-
-#: panels/sharing/cc-sharing-panel.c:1203
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Beṭṭu"
 
-#: panels/sharing/cc-sharing-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:79
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:87
-msgid "_Screen Sharing"
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:95
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:103
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:119
-msgid "Some services are disabled because of no network access."
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.ui:137
-#: panels/sharing/cc-sharing-panel.ui:264
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:184
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:275
-#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:368
-#: panels/sharing/cc-sharing-panel.ui:590
-msgid "Screen Sharing"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:422
-msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:447
-msgid "_Password:"
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:477
-msgid "_Show Password"
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:508
-msgid "Access Options"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:522
-msgid "_New connections must ask for access"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Iqqen"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:540
-msgid "_Require a password"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Nɣel"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:601
-#: panels/sharing/cc-sharing-panel.ui:695
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Sesteb"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Isem n useqdac"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Adsil umdin"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:634
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:649
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Ikaramen"
 
@@ -5978,7 +3487,6 @@ msgstr "Ikaramen"
 msgid "Control what you want to share with others"
 msgstr ""
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -5993,99 +3501,94 @@ msgstr ""
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 
-#: panels/sound/cc-alert-chooser.c:151
-msgid "Custom"
-msgstr "Yugen"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
+msgid "Click"
 msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:19
-msgid "Drip"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Beṭṭu"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:26
-msgid "Glass"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
 msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:33
-msgid "Sonar"
-msgstr ""
-
-#: panels/sound/cc-fade-slider.ui:13
-msgid "Rear"
-msgstr "Deffir"
-
-#: panels/sound/cc-fade-slider.ui:15
-msgid "Front"
-msgstr "Sdat"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr ""
-
-#: panels/sound/cc-output-test-dialog.ui:127
-msgid "Click a speaker to test"
-msgstr ""
-
-#: panels/sound/cc-sound-panel.ui:27
-msgid "System Volume"
-msgstr ""
-
-#: panels/sound/cc-sound-panel.ui:43
-msgid "Volume Levels"
-msgstr ""
-
-#: panels/sound/cc-sound-panel.ui:63
-msgid "Output"
-msgstr "Tuffɣa"
-
-#: panels/sound/cc-sound-panel.ui:90
-msgid "Output Device"
-msgstr ""
-
-#: panels/sound/cc-sound-panel.ui:113
-msgid "Test"
-msgstr "Akayad"
-
-#: panels/sound/cc-sound-panel.ui:144 panels/sound/cc-sound-panel.ui:319
-msgid "Configuration"
-msgstr "Tawila"
-
-#: panels/sound/cc-sound-panel.ui:177
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 msgid "Balance"
 msgstr "Awliwal"
 
-#: panels/sound/cc-sound-panel.ui:204
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 msgid "Fade"
 msgstr "Tifsit"
 
-#: panels/sound/cc-sound-panel.ui:231
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Deffir"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Sdat"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Tuffɣa"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Akayad"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Tawila"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Imsemɣer n imesli  azuran"
 
-#: panels/sound/cc-sound-panel.ui:251
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Anekcum"
 
-#: panels/sound/cc-sound-panel.ui:278
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr ""
 
-#: panels/sound/cc-sound-panel.ui:352
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Ableɣ"
 
-#: panels/sound/cc-sound-panel.ui:372
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6095,165 +3598,66 @@ msgstr "Imesli"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Ur yeqqin ara"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Tuqqna ɣer"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Iqqen"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Arussin"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr ""
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-msgid "Connected at:"
-msgstr ""
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-msgid "Enrolled at:"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-msgid "Failed to authorize device: "
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-msgid "Failed to forget device: "
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Tilɣa"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Isem:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Tuccḍa"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.c:175
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Ur nezmir ara ad neqqen ɣer taɣult %s: %s"
 
-#: panels/thunderbolt/cc-bolt-panel.c:468
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:512
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:516
-msgid "Thunderbolt security level could not be determined."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:621
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:246
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr ""
 
@@ -6265,391 +3669,318 @@ msgstr ""
 msgid "Manage Thunderbolt devices"
 msgstr ""
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr ""
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:7
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 msgid "Cursor Blinking"
 msgstr ""
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:37
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr ""
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:74
-#: panels/universal-access/cc-repeat-keys-dialog.ui:145
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Arured"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:101
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr ""
 
-#: panels/universal-access/cc-cursor-size-dialog.ui:7
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr ""
 
-#: panels/universal-access/cc-cursor-size-dialog.ui:29
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 
-#: panels/universal-access/cc-pointing-dialog.ui:7
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr ""
 
-#: panels/universal-access/cc-pointing-dialog.ui:43
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr ""
 
-#: panels/universal-access/cc-pointing-dialog.ui:56
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "Ssker-d anqab wis sin s tqeffalt tagejdant ara teǧǧeḍ tṣubb"
 
-#: panels/universal-access/cc-pointing-dialog.ui:79
-#: panels/universal-access/cc-typing-dialog.ui:158
-#: panels/universal-access/cc-typing-dialog.ui:307
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
 msgid "A_cceptance delay:"
 msgstr ""
 
-#: panels/universal-access/cc-pointing-dialog.ui:95
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Wezzil"
 
-#: panels/universal-access/cc-pointing-dialog.ui:110
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr ""
 
-#: panels/universal-access/cc-pointing-dialog.ui:120
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Ɣezzif"
 
-#: panels/universal-access/cc-pointing-dialog.ui:157
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr ""
 
-#: panels/universal-access/cc-pointing-dialog.ui:170
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "Ssker-d anqab s tqeffalt tagejdant ara teǧǧeḍ tṣubb"
 
-#: panels/universal-access/cc-pointing-dialog.ui:193
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr ""
 
-#: panels/universal-access/cc-pointing-dialog.ui:210
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Wezzil"
 
-#: panels/universal-access/cc-pointing-dialog.ui:232
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Ɣezzif"
 
-#: panels/universal-access/cc-pointing-dialog.ui:253
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr ""
 
-#: panels/universal-access/cc-pointing-dialog.ui:270
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Amecṭuḥ"
 
-#: panels/universal-access/cc-pointing-dialog.ui:292
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Ameqran"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:7
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
 msgid "Repeat Keys"
 msgstr ""
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:37
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr ""
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:102
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr ""
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:174
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr ""
 
-#: panels/universal-access/cc-sound-keys-dialog.ui:7
-msgid "Sound Keys"
-msgstr ""
-
-#: panels/universal-access/cc-sound-keys-dialog.ui:25
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr ""
-
-#: panels/universal-access/cc-sound-keys-dialog.ui:45
-#: panels/universal-access/cc-ua-panel.ui:412
-msgid "_Sound Keys"
-msgstr ""
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:7
-msgid "Screen Reader"
-msgstr "Imeɣri n wegdil"
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:24
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr ""
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:52
-msgid "_Screen Reader"
-msgstr ""
-
-#: panels/universal-access/cc-typing-dialog.ui:7
+#: panels/universal-access/cc-typing-dialog.ui:4
 msgid "Typing Assist"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:46
+#: panels/universal-access/cc-typing-dialog.ui:41
 msgid "_Sticky Keys"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:58
+#: panels/universal-access/cc-typing-dialog.ui:51
 msgid "Treats a sequence of modifier keys as a key combination"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:72
+#: panels/universal-access/cc-typing-dialog.ui:63
 msgid "_Disable if two keys are pressed together"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:85
+#: panels/universal-access/cc-typing-dialog.ui:71
 msgid "Beep when a _modifier key is pressed"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:96
 msgid "S_low Keys"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:135
+#: panels/universal-access/cc-typing-dialog.ui:106
 msgid "Puts a delay between when a key is pressed and when it is accepted"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:175
+#: panels/universal-access/cc-typing-dialog.ui:135
 msgctxt "slow keys delay"
 msgid "Short"
 msgstr "Wezzil"
 
-#: panels/universal-access/cc-typing-dialog.ui:190
+#: panels/universal-access/cc-typing-dialog.ui:147
 msgid "Slow keys typing delay"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:200
+#: panels/universal-access/cc-typing-dialog.ui:154
 msgctxt "slow keys delay"
 msgid "Long"
 msgstr "Ɣezzif"
 
-#: panels/universal-access/cc-typing-dialog.ui:212
+#: panels/universal-access/cc-typing-dialog.ui:166
 msgid "Beep when a key is pr_essed"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:224
+#: panels/universal-access/cc-typing-dialog.ui:173
 msgid "Beep when a key is _accepted"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:236
-#: panels/universal-access/cc-typing-dialog.ui:361
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
 msgid "Beep when a key is _rejected"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:272
+#: panels/universal-access/cc-typing-dialog.ui:203
 msgid "_Bounce Keys"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:284
+#: panels/universal-access/cc-typing-dialog.ui:213
 msgid "Ignores fast duplicate keypresses"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:324
+#: panels/universal-access/cc-typing-dialog.ui:242
 msgctxt "bounce keys delay"
 msgid "Short"
 msgstr "Wezzil"
 
-#: panels/universal-access/cc-typing-dialog.ui:339
+#: panels/universal-access/cc-typing-dialog.ui:254
 msgid "Bounce keys typing delay"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:349
+#: panels/universal-access/cc-typing-dialog.ui:261
 msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Ɣezzif"
 
-#: panels/universal-access/cc-typing-dialog.ui:437
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr ""
 
-#: panels/universal-access/cc-typing-dialog.ui:449
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr ""
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:351
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Amezwer"
-
-#: panels/universal-access/cc-ua-panel.c:354
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "D alemmas"
-
-#: panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Ameqran"
-
-#: panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Meqqer ugar"
-
-#: panels/universal-access/cc-ua-panel.c:363
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Ahrawan maḍi"
-
-#: panels/universal-access/cc-ua-panel.c:367
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d n upiksil"
-msgstr[1] "%d n ipiksilen"
-
-#: panels/universal-access/cc-ua-panel.ui:55
+#: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:97
+#: panels/universal-access/cc-ua-panel.ui:31
 msgid "Seeing"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:143
+#: panels/universal-access/cc-ua-panel.ui:34
 msgid "_High Contrast"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:190
+#: panels/universal-access/cc-ua-panel.ui:46
 msgid "_Large Text"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:238
+#: panels/universal-access/cc-ua-panel.ui:58
 msgid "Enable A_nimations"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:273
-msgid "C_ursor Size"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:320
-#: panels/universal-access/cc-zoom-options-dialog.ui:91
-msgid "_Zoom"
-msgstr "_Semɣer/Semẓi"
-
-#: panels/universal-access/cc-ua-panel.ui:366
+#: panels/universal-access/cc-ua-panel.ui:70
 msgid "Screen _Reader"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:474
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Semɣer/Semẓi"
+
+#: panels/universal-access/cc-ua-panel.ui:138
 msgid "Hearing"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:518
-#: panels/universal-access/cc-visual-alerts-dialog.ui:68
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
 msgid "_Visual Alerts"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:626
+#: panels/universal-access/cc-ua-panel.ui:166
 msgid "Screen _Keyboard"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:671
+#: panels/universal-access/cc-ua-panel.ui:178
 msgid "R_epeat Keys"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:717
+#: panels/universal-access/cc-ua-panel.ui:198
 msgid "Cursor _Blinking"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:763
+#: panels/universal-access/cc-ua-panel.ui:218
 msgid "_Typing Assist (AccessX)"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:824
-msgid "Pointing & Clicking"
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:870
+#: panels/universal-access/cc-ua-panel.ui:243
 msgid "_Mouse Keys"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:915
+#: panels/universal-access/cc-ua-panel.ui:255
 msgid "_Locate Pointer"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:947
+#: panels/universal-access/cc-ua-panel.ui:267
 msgid "_Click Assist"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:993
+#: panels/universal-access/cc-ua-panel.ui:287
 msgid "_Double-Click Delay"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:1013
+#: panels/universal-access/cc-ua-panel.ui:297
 msgid "Double-Click Delay"
 msgstr ""
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:15
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
 msgid "Visual Alerts"
 msgstr ""
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:19
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
 msgid "_Test flash"
 msgstr ""
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:48
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
 msgid "Use a visual indication when an alert sound occurs."
 msgstr ""
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:94
-msgid "Flash the entire _window"
-msgstr ""
-
-#: panels/universal-access/cc-visual-alerts-dialog.ui:112
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
 msgid "Flash the entire _screen"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.c:303
-msgctxt "Distance"
-msgid "Short"
-msgstr "Wezzil"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:304
-msgctxt "Distance"
-msgid "¼ Screen"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
 msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.c:305
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "Long"
-msgstr "Ɣezzif"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6671,134 +4002,134 @@ msgstr ""
 msgid "Right Half"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:70
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:151
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:201
-msgid "_Follow mouse cursor"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:221
-msgid "_Screen part:"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:278
-msgid "Magnifier _extends outside of screen"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:292
-msgid "_Keep magnifier cursor centered"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:307
-msgid "Magnifier cursor _pushes contents around"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:322
-msgid "Magnifier cursor moves with _contents"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:347
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:362
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Tasemɣert"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:410
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:436
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:458
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Zzur"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:479
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
 msgstr ""
 
 #. The color of the accessibility crosshair
-#: panels/universal-access/cc-zoom-options-dialog.ui:523
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:577
-msgid "_Crosshairs:"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:610
-msgid "_Overlaps mouse cursor"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:634
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:683
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:703
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:724
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
 msgstr ""
 
 #. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/cc-zoom-options-dialog.ui:744
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
 msgid "Co_lor"
 msgstr ""
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:769
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Ulac"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:791
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Ačuran"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:844
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Yuder"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:867
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Haut"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:893
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Yuder"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:916
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Haut"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:942
-msgid "Color Effects:"
-msgstr ""
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:958
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr ""
 
@@ -6806,175 +4137,66 @@ msgstr ""
 msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
-"audio;typing;"
+"audio;typing;animations;"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.c:154
-msgid "Empty all items from Trash?"
-msgstr "Ad tekkseḍ akk iferdisen n tqecwalt?"
-
-#: panels/usage/cc-usage-panel.c:155
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Akk iferdisen n tqecwalt ad ṛuḥen i lebda."
-
-#: panels/usage/cc-usage-panel.c:156
-msgid "_Empty Trash"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:177
-msgid "Delete all the temporary files?"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:178
-msgid "All the temporary files will be permanently deleted."
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:179
-msgid "_Purge Temporary Files"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.ui:29
+#: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:41
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
 "File history keeps a record of files that you have used. This information is "
 "shared between applications, and makes it easier to find files that you "
 "might want to use."
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:56
+#: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:78
+#: panels/usage/cc-usage-panel.ui:25
 msgid "File _History Duration"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:119
+#: panels/usage/cc-usage-panel.ui:48
 msgid "_Clear History…"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:135
-msgid "Trash & Temporary Files"
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:145
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:159
+#: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:174
+#: panels/usage/cc-usage-panel.ui:79
 msgid "Automatically Delete Temporary _Files"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:196
+#: panels/usage/cc-usage-panel.ui:91
 msgid "Automatically Delete _Period"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:238
+#: panels/usage/cc-usage-panel.ui:115
 msgid "_Empty Trash…"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:250
+#: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
 msgstr ""
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:278
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 n usrag"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:282
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 n wass"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:286
-msgctxt "purge_files"
-msgid "2 days"
-msgstr ""
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:290
-msgctxt "purge_files"
-msgid "3 days"
-msgstr ""
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:294
-msgctxt "purge_files"
-msgid "4 days"
-msgstr ""
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:298
-msgctxt "purge_files"
-msgid "5 days"
-msgstr ""
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:302
-msgctxt "purge_files"
-msgid "6 days"
-msgstr ""
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:306
-msgctxt "purge_files"
-msgid "7 days"
-msgstr ""
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:310
-msgctxt "purge_files"
-msgid "14 days"
-msgstr ""
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:314
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 n wussan"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:329
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 n wass"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:333
-msgctxt "retain_history"
-msgid "7 days"
-msgstr ""
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:337
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 n wussan"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:341
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Yal tikelt"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
@@ -6984,89 +4206,54 @@ msgstr ""
 msgid "Don't leave traces"
 msgstr ""
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:204
-msgid "Failed to add account"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:661
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "Awalen n uɛeddi ur nmeɣran ara."
-
-#: panels/user-accounts/cc-add-user-dialog.c:875
-#: panels/user-accounts/cc-add-user-dialog.c:914
-#: panels/user-accounts/cc-add-user-dialog.c:932
-msgid "Failed to register account"
-msgstr "Asekles n umiḍan ur yeddi ara"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1047
-msgid "No supported way to authenticate with this domain"
-msgstr "Ulac abrid n usefrek i usesteb d taɣult-a"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1111
-msgid "Failed to join domain"
-msgstr "Timerna ɣer taɣult ur teddi ara"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1166
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.c:1173
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid "Failed to log into domain"
-msgstr "Anekcum ɣer taɣult ur yeddi ara"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1236
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Rnu aseqdac"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-msgid "Standard"
-msgstr "Lexṣas"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "Anedbal"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-msgid "Account _Type"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-msgid "Allow user to set a password when they next _login"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
-msgid "Set a password _now"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Awal uffir d arameɣtu"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "Tawila"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_Anekcam n tkebbanit"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7076,27 +4263,7 @@ msgstr ""
 "agensan ɣef yibenk-a. Tzemreḍ daɣen ad tesqedceḍ amiḍan-a i unekcum ɣer "
 "teɣbula n tkebbant deg internet."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:732
-msgid "You are Offline"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-msgid "You must be online in order to add enterprise users."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "_Anekcam n tkebbanit"
-
-#: panels/user-accounts/cc-avatar-chooser.c:225
-msgid "Browse for more pictures"
-msgstr "Inig i wugar n tugniwin"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:39
-msgid "Take a Picture…"
-msgstr "Ṭṭef tawlaft..."
-
-#: panels/user-accounts/cc-avatar-chooser.ui:46
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "Fren afaylu..."
 
@@ -7104,537 +4271,196 @@ msgstr "Fren afaylu..."
 msgid "Fingerprint Manager"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:23
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
 msgid "Fingerprint"
 msgstr "Adsil umdin"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:118
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:128
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:155
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
 msgstr ""
 
-#. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
-msgid "No Fingerprint device"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:259
-msgid "Ensure the device is properly connected."
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:264
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:280
-msgid "Choose the fingerprint device you want to configure"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:309
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:322
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:352
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:363
-msgid "Fingerprint Login"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:412
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr ""
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:436
-msgid "_Re-enroll this finger…"
-msgstr ""
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Tafuɣalt tuzwirt"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:236
-msgid "the device needs to be claimed to perform this action"
-msgstr ""
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "_Uḍfir"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:238
-msgid "the device is already claimed by another process"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:240
-msgid "you do not have permission to perform the action"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:242
-msgid "no prints have been enrolled"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:251
-msgid "Failed to communicate with the device during enrollment"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:255
-msgid "Failed to communicate with the fingerprint reader"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:257
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:585
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:652
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:683
-msgid "Left thumb"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:685
-msgid "Left middle finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:687
-msgid "_Left index finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:689
-msgid "Left ring finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:691
-msgid "Left little finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:693
-msgid "Right thumb"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:695
-msgid "Right middle finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:697
-msgid "_Right index finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:699
-msgid "Right ring finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:701
-msgid "Right little finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:703
-msgid "Unknown Finger"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:837
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Yemmed"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:848
-msgid "Fingerprint device disconnected"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:854
-msgid "Fingerprint device storage is full"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:858
-msgid "Failed to enroll new fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:889
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:897
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:974
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1118
-msgid "Scan new fingerprint"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1157
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1229
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1264
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1413
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "Dduṛt-agi"
-
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
-msgstr ""
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr ""
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr ""
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:771
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr ""
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:775
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr ""
-
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr ""
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
-msgstr ""
-
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr ""
-
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
-msgstr ""
-
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
-msgstr ""
-
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Snifel awal uffir"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr ""
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Snifel awal uffir"
 
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr ""
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Awal n uɛeddi"
 
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
-msgstr ""
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Snifel awal uffir"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Awalen n uɛeddi ur nmeɣran ara."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr ""
 
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Ulamek timerna ɣer wanaw-a n taɣult s wudem awurman"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Iseqdacen"
 
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Ulac anekcam n tkebbanit neɣ isem n taɣult i yettwafen"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Ur tezmireḍ ara ad tkecmeḍ d %s ɣer taɣult %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr ""
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Ur nezmir ara ad neqqen ɣer taɣult %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:222
-msgid "Your account"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:402
-msgid "Failed to delete user"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:457
-#: panels/user-accounts/cc-user-panel.c:512
-#: panels/user-accounts/cc-user-panel.c:558
-msgid "Failed to revoke remotely managed user"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:607
-msgid "You cannot delete your own account."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:616
-#, c-format
-msgid "%s is still logged in"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:620
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:629
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:633
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:636
-msgid "_Delete Files"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:637
-msgid "_Keep Files"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:651
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:655
-msgid "_Delete"
-msgstr "_Kkes"
-
-#: panels/user-accounts/cc-user-panel.c:705
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:713
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:716
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ulac"
-
-#: panels/user-accounts/cc-user-panel.c:759
-msgid "Logged in"
-msgstr "Taqqneḍ"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:846
-#: panels/user-accounts/cc-user-panel.c:935
-#: panels/wwan/cc-wwan-device-page.c:477
-msgid "Enabled"
-msgstr "Yermed"
-
-#: panels/user-accounts/cc-user-panel.c:1259
-msgid "Failed to contact the accounts service"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1261
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1366
-msgid "Delete the selected user account"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1378
-#: panels/user-accounts/cc-user-panel.c:1489
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1535
-msgid "Unlock to Add Users and Change Settings"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:6
-msgid "_Add User…"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:9
-msgid "Create a user account"
-msgstr "Rnu amiḍan n useqdac"
-
-#: panels/user-accounts/cc-user-panel.ui:64
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:72
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:157
-#: panels/user-accounts/cc-user-panel.ui:173
-msgid "User Icon"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Mdel"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:249
-msgid "Account Settings"
-msgstr "Iɣewwaṛen n Umiḍan"
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Dayen yeččur"
 
-#: panels/user-accounts/cc-user-panel.ui:267
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:268
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:284
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:285
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:347
-msgid "Authentication & Login"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:390
-msgid "_Fingerprint Login"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:415
-msgid "A_utomatic Login"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:430
-msgid "Account Activity"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:461
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr ""
 
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Inuḍaf-nniḍen"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "Rnu aseqdac"
+
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:502
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:512
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr ""
-
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
-msgid "Users"
-msgstr "Iseqdacen"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr ""
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7642,26 +4468,26 @@ msgid ""
 msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr ""
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Anekcam n unedbal n taɣult"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here."
 msgstr ""
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr ""
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr ""
 
@@ -7673,267 +4499,140 @@ msgstr ""
 msgid "Authentication is required to change user data"
 msgstr ""
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Awal uffi amaynut yewwi-d ad yemgarad ɣef winna yellan d aqbur."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Sexleḍ gar yisekkilen imeqqranen d yimeẓẓyanen, tmuqleḍ amek ara ternuḍ "
-"amḍan neɣ sin."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Timerna n waṭas n yisekkilen, imḍanen d usigez ad yerr awal uffir yeǧhed "
-"aṭas."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Asesteb ur yeddi ara"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Tuccḍa tarussint"
-
-#: panels/user-accounts/user-utils.c:432
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-
-#: panels/user-accounts/user-utils.c:436
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Nesḥassef, isem-a n useqdac ulac-it. Ma ulac aɣilif ɛreḍ wayeḍ."
-
-#: panels/user-accounts/user-utils.c:478
-msgid "The username is too long."
-msgstr "Isem n useqdac ɣezzif aṭas."
-
-#: panels/user-accounts/user-utils.c:537
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr ""
-"Ad yettuseqdec i usemmi n ukaram-inek·inem agejdan yerna yezmer ad "
-"yettusnifel."
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr ""
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "_Mdel"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr ""
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 
-#: panels/wacom/calibrator/calibrator.ui:61
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Mdel"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
 
-#: panels/wacom/calibrator/calibrator.ui:78
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Taṭablit"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Taɣda"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
 msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:245
-msgid "Output:"
-msgstr "Tuffɣa:"
-
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:257
-msgid "Keep aspect ratio (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:268
-msgid "Map to single monitor"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
 msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.c:516
-msgid "Display Mapping"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr ""
 
-#: panels/wacom/cc-wacom-panel.c:725 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
 msgstr ""
 
-#: panels/wacom/cc-wacom-stylus-page.c:357
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "lewwaɣ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Taqfalt"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Taqfalt"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Taqfalt"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Ɣer zdat"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr ""
 
@@ -7941,546 +4640,260 @@ msgstr ""
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "Ta_llalt"
-
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:296
-#: panels/wacom/gnome-wacom-properties.ui:401
-msgid "Map to Monitor…"
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Iseɣẓanen n Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Iseɣẓanen n Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:376
-msgid "Decouple Display"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
 msgstr ""
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "Amezwer"
-
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "Ɣer zdat"
-
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
-msgid "Soft"
-msgstr "lewwaɣ"
-
-#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
-msgid "Firm"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:234
-msgid "Top Button"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:263
-msgid "Lower Button"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:292
-msgid "Lowest Button"
-msgstr ""
-
-#: panels/wacom/wacom-stylus-page.ui:321
-msgid "Tip Pressure Feel"
-msgstr ""
-
-#: panels/wwan/cc-wwan-apn-dialog.ui:11
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr ""
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:160
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Rnu"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Sekles"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr ""
 
-#: panels/wwan/cc-wwan-data.c:543
-msgid "Operation Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:546
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:549
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:81
-msgid "Not Registered"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:85
-msgid "Registered"
-msgstr "Aklas"
-
-#: panels/wwan/cc-wwan-details-dialog.c:89
-msgid "Roaming"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:93
-msgid "Searching"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:97
-msgid "Denied"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.ui:4
+#: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
 msgstr ""
 
-#: panels/wwan/cc-wwan-details-dialog.ui:33
+#: panels/wwan/cc-wwan-details-dialog.ui:16
 msgid "Modem Status"
 msgstr ""
 
-#: panels/wwan/cc-wwan-details-dialog.ui:53
+#: panels/wwan/cc-wwan-details-dialog.ui:25
 msgid "Carrier"
 msgstr ""
 
-#: panels/wwan/cc-wwan-details-dialog.ui:79
+#: panels/wwan/cc-wwan-details-dialog.ui:49
 msgid "Network Type"
 msgstr ""
 
-#: panels/wwan/cc-wwan-details-dialog.ui:131
+#: panels/wwan/cc-wwan-details-dialog.ui:97
 msgid "Network Status"
 msgstr ""
 
-#: panels/wwan/cc-wwan-details-dialog.ui:158
+#: panels/wwan/cc-wwan-details-dialog.ui:122
 msgid "Own Number"
 msgstr ""
 
-#: panels/wwan/cc-wwan-details-dialog.ui:185
+#: panels/wwan/cc-wwan-details-dialog.ui:151
 msgid "Device Details"
 msgstr ""
 
-#: panels/wwan/cc-wwan-details-dialog.ui:257
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Arussin"
-
-#: panels/wwan/cc-wwan-device-page.c:188
-msgid "Unlock SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:189 panels/wwan/cc-wwan-device-page.c:237
-msgid "Unlock"
-msgstr "Serreḥ"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:195
-msgid "Enter PIN to unlock your SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:199
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:200
-msgid "Enter PUK to unlock your SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:218
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
 msgid "Wrong password entered. You have %1$u try left"
 msgid_plural "Wrong password entered. You have %1$u tries left"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/wwan/cc-wwan-device-page.c:221
+#: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/wwan/cc-wwan-device-page.c:226
-msgid "Wrong password entered."
-msgstr "Yettwasekcem yir awal uffir."
-
-#: panels/wwan/cc-wwan-device-page.c:271
-msgid "PUK code should be an 8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:295
-msgid "Enter New PIN"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:299
-msgid "PIN code should be a 4-8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:317
-msgid "Unlocking…"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.ui:34
+#: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:45
+#: panels/wwan/cc-wwan-device-page.ui:19
 msgid "Insert a SIM card to use this modem"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:78
+#: panels/wwan/cc-wwan-device-page.ui:33
 msgid "SIM Locked"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:139
+#: panels/wwan/cc-wwan-device-page.ui:77
 msgid "_Mobile Data"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:140
+#: panels/wwan/cc-wwan-device-page.ui:78
 msgid "Access data using mobile network"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:151
+#: panels/wwan/cc-wwan-device-page.ui:88
 msgid "_Data Roaming"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:152
+#: panels/wwan/cc-wwan-device-page.ui:89
 msgid "Use mobile data when roaming"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:177
+#: panels/wwan/cc-wwan-device-page.ui:115
 msgid "_Network Mode"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:187
+#: panels/wwan/cc-wwan-device-page.ui:122
 msgid "N_etwork"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:199
+#: panels/wwan/cc-wwan-device-page.ui:132
 msgid "Advanced"
 msgstr "Talqayt"
 
-#: panels/wwan/cc-wwan-device-page.ui:225
+#: panels/wwan/cc-wwan-device-page.ui:146
 msgid "_Access Point Names"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:235
+#: panels/wwan/cc-wwan-device-page.ui:155
 msgid "_SIM Lock"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:236
+#: panels/wwan/cc-wwan-device-page.ui:156
 msgid "Lock SIM with PIN"
 msgstr ""
 
-#: panels/wwan/cc-wwan-device-page.ui:246
+#: panels/wwan/cc-wwan-device-page.ui:165
 msgid "M_odem Details"
 msgstr ""
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Tamhelt ur tettusefrak ara"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Awal uffir d arameɣtu"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Ur yettwaf ara"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Addaf yugwi"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Tuccḍa tarussint"
-
-#: panels/wwan/cc-wwan-mode-dialog.ui:4
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr ""
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:44
-#: panels/wwan/cc-wwan-network-dialog.ui:175
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:230
-msgid "_Set"
-msgstr ""
-
-#: panels/wwan/cc-wwan-network-dialog.ui:46 panels/wwan/cc-wwan-panel.ui:39
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:101
-msgid "Close"
-msgstr "Mdel"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Awurman"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:100
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr ""
 
-#: panels/wwan/cc-wwan-network-dialog.ui:118
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr ""
 
-#: panels/wwan/cc-wwan-panel.c:453 panels/wwan/cc-wwan-panel.c:482
-#, c-format
-msgid "SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.ui:101
-msgid "No WWAN Adapter Found"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.ui:112
-msgid "Make sure you have a Wireless Wan/Cellular device"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.ui:154
-msgid "Wireless Wan is disabled when airplane mode is on"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.ui:163
-msgid "_Turn off Airplane Mode"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.ui:210
-msgid "Data Connection"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.ui:224
-msgid "SIM card used for internet"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.ui:332
+#: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr ""
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:11
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
 msgid "SIM Lock"
 msgstr ""
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:22
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
 msgid "_Next"
 msgstr "_Uḍfir"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:141
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr ""
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:158
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr ""
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:256
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr ""
 
@@ -8492,99 +4905,52 @@ msgstr ""
 msgid "Configure Telephony and mobile data connections"
 msgstr ""
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
 msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:17
-msgid "GNOME Settings Sound Panel"
-msgstr ""
-
-#: shell/appdata/gnome-control-center.appdata.xml.in:21
-msgid "GNOME Settings Mouse &amp; Touchpad Panel"
-msgstr ""
-
-#: shell/appdata/gnome-control-center.appdata.xml.in:25
-msgid "GNOME Settings Background Panel"
-msgstr ""
-
-#: shell/appdata/gnome-control-center.appdata.xml.in:29
-msgid "GNOME Settings Keyboard Panel"
-msgstr ""
-
-#: shell/appdata/gnome-control-center.appdata.xml.in:38
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr ""
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Sken amḍan n lqem"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
 msgstr ""
 
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr ""
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr ""
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr ""
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr ""
-
-#: shell/cc-panel-list.ui:45 shell/cc-window.c:309
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Tabaḍnit"
 
-#: shell/cc-panel-loader.c:299
-msgid "Available panels:"
-msgstr ""
-
-#: shell/cc-window.ui:136
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Iɣewwaṛen akk"
 
-#: shell/cc-window.ui:174
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr ""
 
-#: shell/cc-window.ui:318
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr ""
 
-#: shell/cc-window.ui:319
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
 "issues. "
 msgstr ""
 
-#: shell/cc-window.ui:330
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Tallelt"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr ""
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -8616,6 +4982,10 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Sefsex anadi"
 
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr ""
+
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
 msgstr ""
@@ -8645,24 +5015,746 @@ msgid ""
 "application window."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u n tuffɣa"
 msgstr[1] "%u n tuffɣiwin"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u n unekcum"
 msgstr[1] "%u n yinekcumen"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr ""
+#~ msgid "Home"
+#~ msgstr "Agejdan"
+
+#~ msgid "Read-only"
+#~ msgstr "Tɣuri kan"
+
+#~ msgid "Web Links"
+#~ msgstr "Iseɣwan n Web"
+
+#~ msgid "Audio Files"
+#~ msgstr "Ifuyla imeslawen"
+
+#~ msgid "Video Files"
+#~ msgstr "Ifuyla timwaliyin"
+
+#~ msgid "Usage"
+#~ msgstr "Aseqdec"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "Activities"
+#~ msgstr "Irmad"
+
+#~ msgid "Default: "
+#~ msgstr "Amezwer: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Tallunt n yiniten: "
+
+#~ msgid "_Import"
+#~ msgstr "_Kter"
+
+#~ msgid "All files"
+#~ msgstr "Akk ifuyla"
+
+#~ msgid "Standard Space"
+#~ msgstr "Tallunt talugant"
+
+#~ msgid "Test Profile"
+#~ msgstr "Sekyed amaɣnu"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Awurman"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Taɣara taddayt"
+
+#~ msgid "Other…"
+#~ msgstr "Wayeḍ..."
+
+#~ msgid "_Copy"
+#~ msgstr "_Lesser"
+
+#~ msgid "Select _All"
+#~ msgstr "Fren a_kk"
+
+#~ msgid "Today"
+#~ msgstr "Ass-a"
+
+#~ msgid "Yesterday"
+#~ msgstr "Iḍelli"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d n usrag"
+#~ msgstr[1] "%d n isragen"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d tsedat"
+#~ msgstr[1] "%d tsedatin"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d tasint"
+#~ msgstr[1] "%d tasinin"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "S tehri"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Unknown"
+#~ msgstr "Arussin"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-ibiten"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Arussin"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Nɣel tuddma n wegdil ɣer umendad ufus"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Nɣel tuddma n wegdil n kra n usfaylu ɣer umendad ufus"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Nɣel tuddma n wegdil n kra n wegdil ɣer umendad ufus"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Nniḍen"
+
+#~ msgid "Move up"
+#~ msgstr "Ali d asawen"
+
+#~ msgid "Move down"
+#~ msgstr "Ader d akesser"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tasarut n wumuɣ"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Asekkeṛ n yisekkilen imeqqranen"
+
+#~ msgid "Reset All"
+#~ msgstr "Err-d akk"
+
+#~ msgid "Set"
+#~ msgstr "Sbadu"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 n tsinin"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 n tesdat"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 n tesdatin"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 n tesdatin"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 n tesdatin"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 n tesdatin"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 n usrag"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 n tesdat"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 n tesdatin"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 n tesdatin"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 n tesdatin"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 n tesdatin"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 n tesdatin"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Weṛǧin"
+
+#~ msgid "Permanent"
+#~ msgstr "Ameɣlal"
+
+#~ msgid "Random"
+#~ msgstr "Agacuran"
+
+#~ msgid "Enterprise"
+#~ msgstr "Takebbanit"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ulac"
+
+#~ msgid "Never"
+#~ msgstr "Weṛǧin"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Ulac"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "D uḍɛif"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ih"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Igerrez"
+
+#~ msgid "automatic"
+#~ msgstr "Awurman"
+
+#~ msgid "Identity"
+#~ msgstr "Tamagit"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ulac"
+
+#~ msgid "_Replace"
+#~ msgstr "_Semselsi"
+
+#~ msgid "today"
+#~ msgstr "ass-a"
+
+#~ msgid "yesterday"
+#~ msgstr "Iḍelli"
+
+#~ msgid "Off"
+#~ msgstr "Ur irmid ara"
+
+#~ msgid "Unavailable"
+#~ msgstr "Ulac-it"
+
+#~ msgid "Connecting"
+#~ msgstr "Tuqqna ɣer"
+
+#~ msgid "Authentication required"
+#~ msgstr "Tlaq tuqqna"
+
+#~ msgid "Connection failed"
+#~ msgstr "Tuqna ur teddi yara"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Nniḍen"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s yettwakkes"
+
+#~ msgid "Unknown time"
+#~ msgstr "Akud arussin"
+
+#~ msgid "Empty"
+#~ msgstr "Ilem"
+
+#~ msgid "Charging"
+#~ msgstr "La d-yettali"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Taɣerdayt mebla tinelwa"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Amdeswal"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Amallal umḍin udmawan"
+
+#~ msgid "Cellphone"
+#~ msgstr "Tiliɣri n ufus"
+
+#~ msgid "Media player"
+#~ msgstr "Imeɣri n ugetmedia"
+
+#~ msgid "Computer"
+#~ msgstr "Aselkim"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Agejdan"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Ayen-nniḍen"
+
+#~ msgid "Batteries"
+#~ msgstr "Tibaṭriyin"
+
+#~ msgid "Suspend"
+#~ msgstr "Ḥbes di leεḍil"
+
+#~ msgid "Power Off"
+#~ msgstr "Sens"
+
+#~ msgid "Hibernate"
+#~ msgstr "Sgen"
+
+#~ msgid "Nothing"
+#~ msgstr "Ulac"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Weṛǧin"
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Atwal"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Portrait"
+#~ msgstr "S teẓɣzi"
+
+#~ msgid "Landscape"
+#~ msgstr "S tehri"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Yegguni"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Yettṛaǧu"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Tlaq tuqqna"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Asesfer"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Yeḥbes"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Ittwasefsex"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Yemmed"
+
+#~ msgid "Paper Source"
+#~ msgstr "Taɣbalut n taferkit"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Afray"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Amatu"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Tawila n usebtar"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Tawiri"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Ini"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Talqayt"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Ulac asizdeg yezwaren"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Beṛṛa n tuqqna"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Yeḥbes"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Iwjed"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Asesfer"
+
+#~ msgid "Language"
+#~ msgstr "Tameslayt"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Steqsi d acu ara tgeḍ"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ur tegg acmek"
+
+#~ msgid "Open folder"
+#~ msgstr "Ldi akaram"
+
+#~ msgid "Other Media"
+#~ msgstr "Amidya-nniḍen"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Fren asnas i CDs asfeldan"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Fren asnan i uvidyu DVD"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Fren asnas iwumi ara tserrḥeḍ m'ara yili yeqqen kra n yimeɣri n uẓawan"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Fren asnas ad tt-seduḍ m'ara ad tens takamirat"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Fran asnas i iCD-iyen ideg llan iseɣẓanen"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD asfeldan"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "aḍebsi Blu-ray d ilem"
+
+#~ msgid "blank CD disc"
+#~ msgstr "aḍebsi CD d ilem"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "aḍebsi DVD d ilem"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "aḍebsi HD DVD d ilem"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "aḍebsi Blu-ray uvidyu"
+
+#~ msgid "e-book reader"
+#~ msgstr "imeɣri n e-book"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "aḍebsi HD DVD uvidyu"
+
+#~ msgid "Picture CD"
+#~ msgstr "Aḍebsi CD n tungniwin"
+
+#~ msgid "Video CD"
+#~ msgstr "Vidyu CD"
+
+#~ msgid "_OK"
+#~ msgstr "_IH"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Ur irmid ara"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Yermed"
+
+#~ msgid "Custom"
+#~ msgstr "Yugen"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Ur yeqqin ara"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Tuqqna ɣer"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Iqqen"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Arussin"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Tuccḍa"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Imeɣri n wegdil"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Amezwer"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "D alemmas"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Ameqran"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Meqqer ugar"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Ahrawan maḍi"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d n upiksil"
+#~ msgstr[1] "%d n ipiksilen"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Wezzil"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Ɣezzif"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Ad tekkseḍ akk iferdisen n tqecwalt?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Akk iferdisen n tqecwalt ad ṛuḥen i lebda."
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 n usrag"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 n wass"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 n wussan"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 n wass"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 n wussan"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Yal tikelt"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Asekles n umiḍan ur yeddi ara"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Ulac abrid n usefrek i usesteb d taɣult-a"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Timerna ɣer taɣult ur teddi ara"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Anekcum ɣer taɣult ur yeddi ara"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Inig i wugar n tugniwin"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Ṭṭef tawlaft..."
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Yemmed"
+
+#~ msgid "This Week"
+#~ msgstr "Dduṛt-agi"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Ulamek timerna ɣer wanaw-a n taɣult s wudem awurman"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Ulac anekcam n tkebbanit neɣ isem n taɣult i yettwafen"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Ur tezmireḍ ara ad tkecmeḍ d %s ɣer taɣult %s"
+
+#~ msgid "_Delete"
+#~ msgstr "_Kkes"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ulac"
+
+#~ msgid "Logged in"
+#~ msgstr "Taqqneḍ"
+
+#~ msgid "Create a user account"
+#~ msgstr "Rnu amiḍan n useqdac"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Awal uffi amaynut yewwi-d ad yemgarad ɣef winna yellan d aqbur."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Sexleḍ gar yisekkilen imeqqranen d yimeẓẓyanen, tmuqleḍ amek ara ternuḍ "
+#~ "amḍan neɣ sin."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Timerna n waṭas n yisekkilen, imḍanen d usigez ad yerr awal uffir yeǧhed "
+#~ "aṭas."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Asesteb ur yeddi ara"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Tuccḍa tarussint"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Nesḥassef, isem-a n useqdac ulac-it. Ma ulac aɣilif ɛreḍ wayeḍ."
+
+#~ msgid "The username is too long."
+#~ msgstr "Isem n useqdac ɣezzif aṭas."
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Ad yettuseqdec i usemmi n ukaram-inek·inem agejdan yerna yezmer ad "
+#~ "yettusnifel."
+
+#~ msgid "Output:"
+#~ msgstr "Tuffɣa:"
+
+#~ msgid "_Help"
+#~ msgstr "Ta_llalt"
+
+#~ msgid "Registered"
+#~ msgstr "Aklas"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Arussin"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Yettwasekcem yir awal uffir."
+
+#~ msgid "Operation not supported"
+#~ msgstr "Tamhelt ur tettusefrak ara"
+
+#~ msgid "Not found"
+#~ msgstr "Ur yettwaf ara"
+
+#~ msgid "Access denied"
+#~ msgstr "Addaf yugwi"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Tuccḍa tarussint"
+
+#~ msgid "Display version number"
+#~ msgstr "Sken amḍan n lqem"

--- a/po/kab.po~
+++ b/po/kab.po~
@@ -1,0 +1,8668 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2021-11-16 14:40+0000\n"
+"PO-Revision-Date: 2021-11-18 08:11+0100\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.0\n"
+"Last-Translator: Slimane Selyan Amiri <selyan.kab@protonmail.com>\n"
+"Language: kab_DZ\n"
+
+#: panels/applications/cc-applications-panel.c:823
+msgid "System Bus"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:823
+#: panels/applications/cc-applications-panel.c:825
+#: panels/applications/cc-applications-panel.c:838
+#: panels/applications/cc-applications-panel.c:843
+msgid "Full access"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:825
+msgid "Session Bus"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:829
+#: panels/power/cc-power-panel.ui:85 panels/thunderbolt/cc-bolt-panel.ui:466
+#: panels/thunderbolt/cc-bolt-panel.ui:525
+msgid "Devices"
+msgstr "Ibenkan"
+
+#: panels/applications/cc-applications-panel.c:829
+msgid "Full access to /dev"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:833
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:288 panels/wwan/cc-wwan-device-page.ui:114
+#: panels/wwan/cc-wwan-network-dialog.ui:4
+msgid "Network"
+msgstr "Aẓeṭṭa"
+
+#: panels/applications/cc-applications-panel.c:833
+msgid "Has network access"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:838
+#: panels/applications/cc-applications-panel.c:840
+#: panels/search/cc-search-locations-dialog.c:362
+msgid "Home"
+msgstr "Agejdan"
+
+#: panels/applications/cc-applications-panel.c:840
+#: panels/applications/cc-applications-panel.c:845
+msgid "Read-only"
+msgstr "Tɣuri kan"
+
+#: panels/applications/cc-applications-panel.c:843
+#: panels/applications/cc-applications-panel.c:845
+msgid "File System"
+msgstr "Anagraw n ifuyla"
+
+#: panels/applications/cc-applications-panel.c:849
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/gnome-control-center.appdata.xml.in:7 shell/cc-window.c:313
+#: shell/cc-window.c:1043 shell/cc-window.ui:121
+#: shell/gnome-control-center.desktop.in.in:3
+msgid "Settings"
+msgstr "Iɣewaren"
+
+#: panels/applications/cc-applications-panel.c:849
+msgid "Can change settings"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:851
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1024
+msgid "Web Links"
+msgstr "Iseɣwan n Web"
+
+#: panels/applications/cc-applications-panel.c:1034
+msgid "Git Links"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1040
+#, c-format
+msgid "%s Links"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1048
+#: panels/applications/cc-applications-panel.c:1084
+msgid "Unset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1139
+msgid "Links"
+msgstr "Iseɣwan"
+
+#: panels/applications/cc-applications-panel.c:1147
+msgid "Hypertext Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1161
+msgid "Text Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1175
+msgid "Image Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1191
+msgid "Font Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1252
+msgid "Archive Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1272
+msgid "Package Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1295
+msgid "Audio Files"
+msgstr "Ifuyla imeslawen"
+
+#: panels/applications/cc-applications-panel.c:1312
+msgid "Video Files"
+msgstr "Ifuyla timwaliyin"
+
+#: panels/applications/cc-applications-panel.c:1320
+msgid "Other Files"
+msgstr ""
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1660
+#: panels/applications/cc-applications-panel.ui:416
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:70
+msgid "Applications"
+msgstr "Isnasen"
+
+#: panels/applications/cc-applications-panel.ui:43
+msgid "No applications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:57
+msgid "Install some…"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "Permissions & Access"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:106
+msgid ""
+"Data and services that this app has asked for access to and permissions that "
+"it requires."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:127
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Takamiṛat"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:128
+#: panels/applications/cc-applications-panel.ui:140
+#: panels/applications/cc-applications-panel.ui:152
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:262
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:85
+#: panels/keyboard/cc-xkb-modifier-dialog.c:353
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:129
+#: panels/user-accounts/cc-user-panel.c:848
+#: panels/user-accounts/cc-user-panel.c:938
+#: panels/wwan/cc-wwan-device-page.c:479
+#: subprojects/gvc/gvc-mixer-control.c:1900
+msgid "Disabled"
+msgstr "Yensa"
+
+#: panels/applications/cc-applications-panel.ui:133
+#: panels/applications/cc-applications-panel.ui:139
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Asawaḍ"
+
+#: panels/applications/cc-applications-panel.ui:145
+#: panels/applications/cc-applications-panel.ui:151
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Imeẓla n wadig"
+
+#: panels/applications/cc-applications-panel.ui:157
+#: panels/applications/cc-applications-panel.ui:500
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:158
+msgid "Cannot be changed"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:175
+msgid ""
+"Individual permissions for applications can be reviewed in the <a href="
+"\"privacy\">Privacy</a> Settings."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:199
+msgid "Integration"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:211
+msgid "System features used by this application."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:225
+#: panels/applications/cc-applications-panel.ui:231
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:151
+msgid "Search"
+msgstr "Anadi"
+
+#: panels/applications/cc-applications-panel.ui:237
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Tilɣa"
+
+#: panels/applications/cc-applications-panel.ui:243
+msgid "Run in background"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:249
+msgid "Set Desktop Background"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:255
+#: panels/applications/cc-applications-panel.ui:261
+msgid "Sounds"
+msgstr "Imeslan"
+
+#: panels/applications/cc-applications-panel.ui:267
+msgid "Inhibit system keyboard shortcuts"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:300
+msgid "Default Handlers"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:312
+msgid "Types of files and links that this application opens."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:328
+msgid "Reset"
+msgstr "Wennez"
+
+#: panels/applications/cc-applications-panel.ui:364
+msgid "Usage"
+msgstr "Aseqdec"
+
+#: panels/applications/cc-applications-panel.ui:376
+msgid "How much resources this application is using."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:391
+#: panels/applications/cc-applications-panel.ui:537
+msgid "Storage"
+msgstr "Asekles"
+
+#: panels/applications/cc-applications-panel.ui:424
+msgid "Open in Software"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:474 shell/cc-panel-list.ui:121
+msgid "No results found"
+msgstr "Ulac igmaḍ"
+
+#: panels/applications/cc-applications-panel.ui:485
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:177
+#: shell/cc-panel-list.ui:132
+msgid "Try a different search"
+msgstr "Ɛreḍ inadiyen yemgaraden"
+
+#: panels/applications/cc-applications-panel.ui:555
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:564
+msgid "Application"
+msgstr "Asnas"
+
+#: panels/applications/cc-applications-panel.ui:570
+msgid "Data"
+msgstr "Isefka"
+
+#: panels/applications/cc-applications-panel.ui:576
+msgid "Cache"
+msgstr "Tuffirt"
+
+#: panels/applications/cc-applications-panel.ui:582
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:599
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-chooser.c:344
+msgid "Select a picture"
+msgstr ""
+
+#: panels/background/cc-background-chooser.c:347
+#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:238
+#: panels/color/cc-color-panel.c:886 panels/color/cc-color-panel.ui:657
+#: panels/common/cc-language-chooser.ui:25
+#: panels/display/cc-display-panel.c:1023
+#: panels/info-overview/cc-info-overview-panel.ui:243
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/network/cc-wifi-hotspot-dialog.ui:122
+#: panels/network/cc-wifi-panel.c:866
+#: panels/network/connection-editor/connection-editor.ui:17
+#: panels/network/connection-editor/vpn-helpers.c:176
+#: panels/network/connection-editor/vpn-helpers.c:299
+#: panels/network/net-device-wifi.c:854
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:235
+#: panels/region/cc-format-chooser.ui:28
+#: panels/search/cc-search-locations-dialog.c:639
+#: panels/sharing/cc-sharing-panel.c:396 panels/usage/cc-usage-panel.c:133
+#: panels/user-accounts/cc-add-user-dialog.ui:28
+#: panels/user-accounts/cc-avatar-chooser.c:105
+#: panels/user-accounts/cc-avatar-chooser.c:228
+#: panels/user-accounts/cc-fingerprint-dialog.ui:36
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:638
+#: panels/user-accounts/cc-user-panel.c:656
+#: panels/user-accounts/data/join-dialog.ui:20
+#: panels/wwan/cc-wwan-mode-dialog.ui:35
+#: panels/wwan/cc-wwan-network-dialog.ui:166
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:297
+msgid "_Cancel"
+msgstr "Sefsex (_C)"
+
+#: panels/background/cc-background-chooser.c:348
+#: panels/network/connection-editor/vpn-helpers.c:177
+#: panels/printers/pp-details-dialog.c:236
+#: panels/sharing/cc-sharing-panel.c:397
+#: panels/user-accounts/cc-avatar-chooser.c:229
+msgid "_Open"
+msgstr "_Ldi"
+
+#: panels/background/cc-background-item.c:140
+msgid "multiple sizes"
+msgstr ""
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:144
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:282
+msgid "No Desktop Background"
+msgstr ""
+
+#: panels/background/cc-background-panel.c:110
+msgid "Current background"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:55
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/cc-background-preview.ui:55
+msgid "Activities"
+msgstr "Irmad"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "Agilal"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr ""
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:69
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:80
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:107
+msgid "Airplane Mode is on"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:118
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:124
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:154
+msgid "Hardware Airplane Mode is on"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:165
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1392
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:34
+msgid "Camera is turned off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:43
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:75
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:85
+msgid "Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:105
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr ""
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr ""
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr ""
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr ""
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr ""
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr ""
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr ""
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr ""
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:40
+msgid "_Start"
+msgstr "_Sekker"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:54
+msgid "_Resume"
+msgstr "_Kemmel"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
+#: panels/user-accounts/cc-fingerprint-dialog.ui:73
+msgid "_Done"
+msgstr ""
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr ""
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr ""
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr ""
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr ""
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr ""
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr ""
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr ""
+
+#: panels/color/cc-color-device.c:90
+#, c-format
+msgid "Enable color management for %s"
+msgstr ""
+
+#: panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr ""
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:167
+msgid "Default: "
+msgstr "Amezwer: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:175
+msgid "Colorspace: "
+msgstr "Tallunt n yiniten: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:182
+msgid "Test profile: "
+msgstr ""
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:236
+msgid "Select ICC Profile File"
+msgstr ""
+
+#: panels/color/cc-color-panel.c:239
+msgid "_Import"
+msgstr "_Kter"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:250
+msgid "Supported ICC profiles"
+msgstr ""
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:257
+#: panels/network/wireless-security/eap-method-fast.c:356
+msgid "All files"
+msgstr "Akk ifuyla"
+
+#: panels/color/cc-color-panel.c:549
+msgid "Screen"
+msgstr "Agdil"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:839
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr ""
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:851
+msgid "The profile has been uploaded to:"
+msgstr ""
+
+#: panels/color/cc-color-panel.c:853
+msgid "Write down this URL."
+msgstr ""
+
+#: panels/color/cc-color-panel.c:854
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+
+#: panels/color/cc-color-panel.c:855
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:883
+msgid "Save Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.c:887
+#: panels/network/connection-editor/vpn-helpers.c:300
+#: panels/wwan/cc-wwan-apn-dialog.ui:64
+msgid "_Save"
+msgstr "_Sekles"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1196
+msgid "Create a color profile for the selected device"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1211 panels/color/cc-color-panel.c:1235
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1245
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1256
+msgid "The device type is not currently supported."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:58
+msgid "Quality"
+msgstr "Taɣara"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:75
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:121
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:174
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:189
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:226
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:278
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:318
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:348
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:377
+msgid "Profile Name"
+msgstr "Isem n umaγnu"
+
+#: panels/color/cc-color-panel.ui:392
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:443
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:456
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:519
+msgid "Upload profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:532
+msgid "Requires Internet connection"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:607
+msgid "Summary"
+msgstr "Agzul"
+
+#: panels/color/cc-color-panel.ui:621
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:643
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:672 panels/keyboard/cc-input-chooser.ui:20
+#: panels/network/connection-editor/net-connection-editor.c:504
+#: panels/printers/new-printer-dialog.ui:80
+#: panels/user-accounts/cc-add-user-dialog.ui:47
+msgid "_Add"
+msgstr "_Rnu"
+
+#: panels/color/cc-color-panel.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:788
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:810
+#: panels/diagnostics/cc-diagnostics-panel.c:144
+msgid "Learn more"
+msgstr "Issin ugar"
+
+#: panels/color/cc-color-panel.ui:815
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:863
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:867 panels/color/cc-color-panel.ui:882
+#: panels/color/cc-color-panel.ui:883
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:878
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:909
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:922
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:926
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:937
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:950
+msgid "_View details"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:986
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1030
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1035
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1040
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1045
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1050
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1055
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1060
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1065
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1070
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1075
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1092
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Haut"
+
+#: panels/color/cc-color-panel.ui:1093
+msgid "40 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1097
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "D alemmas"
+
+#: panels/color/cc-color-panel.ui:1098
+msgid "30 minutes"
+msgstr "30 n tesdatin"
+
+#: panels/color/cc-color-panel.ui:1102
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Yuder"
+
+#: panels/color/cc-color-panel.ui:1103
+msgid "15 minutes"
+msgstr "15 n tesdatin"
+
+#: panels/color/cc-color-panel.ui:1125
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1129
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1133
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1137
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1141
+msgid "D75"
+msgstr ""
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Tallunt talugant"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Sekyed amaɣnu"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Awurman"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Taɣara taddayt"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr ""
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr ""
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr ""
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr ""
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Ini"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Wayeḍ..."
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "No languages found"
+msgstr "Ulac tutlaying i yettwafen"
+
+#: panels/common/cc-language-chooser.ui:82
+#: panels/keyboard/cc-input-chooser.c:178
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.c:107
+msgid "Unlock to Change Settings"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:20
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:56
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:33
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:65
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:80
+msgid "Time"
+msgstr "Akud"
+
+#: panels/common/cc-time-editor.ui:113
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:145
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/common/cc-time-entry.c:219
+msgid "_Copy"
+msgstr "_Lesser"
+
+#: panels/common/cc-time-entry.c:225
+msgid "Select _All"
+msgstr "Fren a_kk"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:162
+msgid "Today"
+msgstr "Ass-a"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:164
+msgid "Yesterday"
+msgstr "Iḍelli"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr ""
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d n usrag"
+msgstr[1] "%d n isragen"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:973
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d tsedat"
+msgstr[1] "%d tsedatin"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d tasint"
+msgstr[1] "%d tasinin"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr ""
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr ""
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr ""
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr ""
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 n tasint"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr ""
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:262
+msgid "%e %B %Y, %l:%M %p"
+msgstr ""
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:267
+msgid "%e %B %Y, %R"
+msgstr ""
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:449
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:476
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:483
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:488
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:493
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:498
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:38
+msgid "January"
+msgstr "yennayer"
+
+#: panels/datetime/cc-datetime-panel.ui:46
+msgid "February"
+msgstr "Fuṛar"
+
+#: panels/datetime/cc-datetime-panel.ui:54
+msgid "March"
+msgstr "Meɣres"
+
+#: panels/datetime/cc-datetime-panel.ui:62
+msgid "April"
+msgstr "Yebrir"
+
+#: panels/datetime/cc-datetime-panel.ui:70
+msgid "May"
+msgstr "Mayyu"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "June"
+msgstr "Yunyu"
+
+#: panels/datetime/cc-datetime-panel.ui:86
+msgid "July"
+msgstr "Yulyu"
+
+#: panels/datetime/cc-datetime-panel.ui:94
+msgid "August"
+msgstr "Ɣuct"
+
+#: panels/datetime/cc-datetime-panel.ui:102
+msgid "September"
+msgstr "Ctamber"
+
+#: panels/datetime/cc-datetime-panel.ui:110
+msgid "October"
+msgstr "Tuber"
+
+#: panels/datetime/cc-datetime-panel.ui:118
+msgid "November"
+msgstr "Wamber"
+
+#: panels/datetime/cc-datetime-panel.ui:126
+msgid "December"
+msgstr "Dujamber"
+
+#: panels/datetime/cc-datetime-panel.ui:136
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Azemz & Akud"
+
+#: panels/datetime/cc-datetime-panel.ui:187
+msgid "Year"
+msgstr "Iseggasen"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Month"
+msgstr "Aggur"
+
+#: panels/datetime/cc-datetime-panel.ui:257
+msgid "Day"
+msgstr "Ass"
+
+#: panels/datetime/cc-datetime-panel.ui:286
+msgid "Time Zone"
+msgstr "Tamnaḍt tasragant"
+
+#: panels/datetime/cc-datetime-panel.ui:307
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:375
+msgid "Automatic _Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:376
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:396
+msgid "Date & _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:430
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:431
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:446
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:481
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:490
+msgid "24-hour"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:491
+msgid "AM / PM"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:31
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:43
+msgid "_Mail"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:59
+msgid "_Calendar"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "M_usic"
+msgstr "A_ẓawan"
+
+#: panels/default-apps/cc-default-apps-panel.ui:91
+msgid "_Video"
+msgstr "_tavidyut"
+
+#: panels/default-apps/cc-default-apps-panel.ui:162
+#: panels/removable-media/cc-removable-media-panel.ui:162
+msgid "_Photos"
+msgstr "_Tiwlafin"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr ""
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:146
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:28
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:65
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:1034
+#: panels/network/connection-editor/connection-editor.ui:27
+msgid "_Apply"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:1055
+msgid "Apply Changes?"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:1060
+msgid "Changes Cannot be Applied"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:1061
+msgid "This could be due to hardware limitations."
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:89
+msgid "Single Display"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:108
+#: panels/display/cc-display-panel.ui:310
+msgid "Join Displays"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:126
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:151
+msgid "Display Mode"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:220
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:221
+msgid "Primary Display"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:243
+msgid ""
+"Drag displays to match your physical display setup. Select a display to "
+"change its settings."
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:250
+msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:374
+msgid "Active Display"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:421
+msgid "Display Configuration"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:440
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:451
+#: panels/display/cc-night-light-page.ui:111
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:109
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "S tehri"
+
+#: panels/display/cc-display-settings.c:112
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:115
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:118
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:192
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:15
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Taɣda"
+
+#: panels/display/cc-display-settings.ui:24
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Afray"
+
+#: panels/display/cc-display-settings.ui:33
+msgid "Refresh Rate"
+msgstr "Afmidi n usmiren"
+
+#: panels/display/cc-display-settings.ui:42
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:59
+#: panels/display/cc-display-settings.ui:76
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Sellum"
+
+#: panels/display/cc-night-light-page.c:627
+msgid "More Warm"
+msgstr ""
+
+#: panels/display/cc-night-light-page.c:639
+msgid "Less Warm"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:28
+msgid "Restart Filter"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:61
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:88
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:127
+msgid "Schedule"
+msgstr "Sɣiwes"
+
+#: panels/display/cc-night-light-page.ui:136
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:137
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/region/cc-format-preview.ui:40
+msgid "Times"
+msgstr "Akud"
+
+#: panels/display/cc-night-light-page.ui:165
+msgid "From"
+msgstr "Seg"
+
+#: panels/display/cc-night-light-page.ui:194
+#: panels/display/cc-night-light-page.ui:297
+msgid "Hour"
+msgstr "Asrag"
+
+#: panels/display/cc-night-light-page.ui:203
+#: panels/display/cc-night-light-page.ui:306
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:222
+#: panels/display/cc-night-light-page.ui:325
+msgid "Minute"
+msgstr "Tasdidt"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:234
+#: panels/display/cc-night-light-page.ui:337
+msgid "AM"
+msgstr "FT"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:247
+#: panels/display/cc-night-light-page.ui:350
+msgid "PM"
+msgstr "MD"
+
+#: panels/display/cc-night-light-page.ui:267
+msgid "To"
+msgstr "I"
+
+#: panels/display/cc-night-light-page.ui:374
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.c:413
+#: panels/info-overview/cc-info-overview-panel.c:437
+#: panels/info-overview/cc-info-overview-panel.c:483
+#: panels/info-overview/cc-info-overview-panel.c:513
+#: panels/wwan/cc-wwan-details-dialog.c:101
+msgid "Unknown"
+msgstr "Arussin"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:445
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr ""
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:460
+#, c-format
+msgid "64-bit"
+msgstr "64-ibiten"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:463
+#, c-format
+msgid "32-bit"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.c:720
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:724
+msgid "Wayland"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.c:726
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Arussin"
+
+#: panels/info-overview/cc-info-overview-panel.ui:52
+msgid "Device Name"
+msgstr "Isem n yibenk"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Memory"
+msgstr "Takatut"
+
+#: panels/info-overview/cc-info-overview-panel.ui:92
+msgid "Processor"
+msgstr "Asasker"
+
+#: panels/info-overview/cc-info-overview-panel.ui:101
+msgid "Graphics"
+msgstr "Udlifen"
+
+#: panels/info-overview/cc-info-overview-panel.ui:110
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:111
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "OS Name"
+msgstr "Isem n OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:142
+msgid "OS Type"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:151
+msgid "GNOME Version"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:161
+msgid "Windowing System"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:169
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:178
+msgid "Software Updates"
+msgstr "Ileqqman n useɣzan"
+
+#: panels/info-overview/cc-info-overview-panel.ui:199
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:216
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:234
+msgid "_Rename"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Γef"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Imesli aked umidya"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Ssider-as i ubleɣ"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Rnu-yas i ubleɣ"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Sekker ameɣri n umidya"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Sesganfi taɣuri"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Ḥbes taɣuri"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Tafuɣalt tuzwirt"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Tafuɣalt tuḍfirt"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Ḍeqqer-d"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:580
+msgid "Typing"
+msgstr "Ajerred"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Imsinḍen"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Serreḥ i iminig n uεiwen"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Sekker taselkimt"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Sekker amsaɣ n tirawt"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Sekker iminig n web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Akaram umager"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Anadi"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "Tuṭṭfiwin n ugdil"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "Nɣel tuddma n wegdil ɣer umendad ufus"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Nɣel tuddma n wegdil n kra n usfaylu ɣer umendad ufus"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Nɣel tuddma n wegdil n kra n wegdil ɣer umendad ufus"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Anagraw"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Senser"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Isekkeṛ ugdil"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Tuffart"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Semɣeṛ"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Semẓi"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Rmed neɣ ssens taɣuri n wegdil"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Rmed neɣ ssens anasiw amwalan"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Simɣur tiddi n uḍris"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Simecṭuḥ tiddi n uḍris"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Rmed neɣ ssens tanmarit εlayen"
+
+#: panels/keyboard/cc-input-chooser.c:193
+msgid "No input sources found"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.c:964
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Nniḍen"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:77
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:23
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:75
+msgid "Move up"
+msgstr "Ali d asawen"
+
+#: panels/keyboard/cc-input-row.ui:86
+msgid "Move down"
+msgstr "Ader d akesser"
+
+#: panels/keyboard/cc-input-row.ui:103
+msgid "Preferences"
+msgstr "Ismenyifen"
+
+#: panels/keyboard/cc-input-row.ui:120
+msgid "View Keyboard Layout"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:137
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:286
+msgid "Remove"
+msgstr "kkes"
+
+#: panels/keyboard/cc-keyboard-manager.c:486
+#: panels/keyboard/cc-keyboard-manager.c:494
+#: panels/keyboard/cc-keyboard-manager.c:779
+msgid "Custom Shortcuts"
+msgstr "Inegzumen Yugnen"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.ui:213
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:73
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:74
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:75
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tasarut n wumuɣ"
+
+#: panels/keyboard/cc-keyboard-panel.c:76
+#: panels/keyboard/cc-keyboard-panel.c:94
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:84
+#: panels/keyboard/cc-keyboard-panel.ui:237
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:95
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Asekkeṛ n yisekkilen imeqqranen"
+
+#: panels/keyboard/cc-keyboard-panel.c:96
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:97
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:233
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:48
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:85
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:131
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:158
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:177
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:188
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:263
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:306
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:322 shell/cc-window.ui:326
+msgid "Keyboard Shortcuts"
+msgstr "Inegzumen n unasiw"
+
+#: panels/keyboard/cc-keyboard-panel.ui:283
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:283
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:428
+msgid "Reset All Shortcuts?"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:431
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:435
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:275
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+#: panels/wwan/cc-wwan-device-page.c:190
+msgid "Cancel"
+msgstr "Sefex"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:436
+msgid "Reset All"
+msgstr "Err-d akk"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:115
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:124
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:131
+msgid "Add Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:166
+msgid "No keyboard shortcut found"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:211
+#: panels/region/cc-format-chooser.ui:48
+#: panels/user-accounts/cc-fingerprint-dialog.ui:53
+#: panels/wacom/wacom-stylus-page.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
+#: shell/cc-window.ui:230
+msgid "Back"
+msgstr "Uɣal"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:235
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:236
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:391
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:535
+msgid "Enter the new shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
+msgid "Set Custom Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
+msgid "Set Shortcut"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:561
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:987
+msgid "Add Custom Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:60
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:135
+#: panels/printers/pp-details-dialog.ui:40
+#: panels/wwan/cc-wwan-apn-dialog.ui:132
+msgid "Name"
+msgstr "Isem"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:147
+msgid "Command"
+msgstr "Anezḍay"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:159
+msgid "Shortcut"
+msgstr "Anegzum"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:238
+msgid "Set Shortcut…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "Ulac"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:296
+#: panels/wwan/cc-wwan-apn-dialog.ui:44
+msgid "Add"
+msgstr "Rnu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:311
+msgid "Replace"
+msgstr "Semselsi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:325
+msgid "Set"
+msgstr "Sbadu"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:27
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Anasiw"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:31
+msgid "Location services turned off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:40
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:72
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:81
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:94
+msgid "Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:114
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#. FIXME
+#: panels/lock/cc-lock-panel.ui:27
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:44
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:45
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:66
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:83
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:84
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:105
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:122
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:123
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:169
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:173
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 n tsinin"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:177
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 n tesdat"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:181
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 n tesdatin"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:185
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 n tesdatin"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:189
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 n tesdatin"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:193
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 n tesdatin"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:197
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 n usrag"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:212
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 n tesdat"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:216
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 n tesdatin"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:220
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 n tesdatin"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:224
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:228
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 n tesdatin"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:232
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:236
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 n tesdatin"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:240
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr ""
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:244
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 n tesdatin"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:248
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Weṛǧin"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr ""
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid "Microphone is turned off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:43
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:75
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:85
+msgid "Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:105
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:37
+#: panels/multitasking/cc-multitasking-panel.ui:31
+msgid "General"
+msgstr "Amatu"
+
+#: panels/mouse/cc-mouse-panel.ui:57
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:58
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:84 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Zelmaḍ"
+
+#: panels/mouse/cc-mouse-panel.ui:94 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Yefus"
+
+#: panels/mouse/cc-mouse-panel.ui:122
+msgid "Mouse"
+msgstr "Taɣerdayt"
+
+#: panels/mouse/cc-mouse-panel.ui:142
+msgid "Mouse Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:154 panels/mouse/cc-mouse-panel.ui:258
+msgid "Double-click timeout"
+msgstr ""
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:166 panels/mouse/cc-mouse-panel.ui:230
+msgid "Natural Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:231
+msgid "Scrolling moves the content, not the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:193 panels/mouse/cc-mouse-panel.ui:213
+msgid "Touchpad"
+msgstr "Talwiḥt tawallsant"
+
+#: panels/mouse/cc-mouse-panel.ui:247
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:270
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:286
+msgid "Two-finger Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:303
+msgid "Edge Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:335 panels/wacom/cc-wacom-panel.c:441
+msgid "Test Your _Settings"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:25
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:56
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:57
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:84
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:85
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:114
+msgid "Workspaces"
+msgstr "Tallunin n umahil"
+
+#: panels/multitasking/cc-multitasking-panel.ui:139
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:140
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:158
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:159
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:179
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:200
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:225
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:252
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:282
+msgid "Application Switching"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:307
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:325
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgstr ""
+
+#: panels/network/cc-network-panel.c:686 panels/network/cc-wifi-panel.ui:307
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/cc-network-panel.c:692
+msgid "NetworkManager needs to be running."
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:66
+msgid "Other Devices"
+msgstr "Inuḍaf-nniḍen"
+
+#: panels/network/cc-network-panel.ui:107
+#: panels/network/connection-editor/net-connection-editor.c:587
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:151
+msgid "Not set up"
+msgstr ""
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:207
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:262
+msgid "Insecure network (WEP)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:267
+msgid "Secure network (WPA)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:272
+msgid "Secure network (WPA2)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:277
+msgid "Secure network (WPA3)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:282
+msgid "Secure network"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:68 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Iqqen"
+
+#: panels/network/cc-wifi-connection-row.ui:102
+#: panels/network/net-device-ethernet.c:333
+#: panels/network/network-bluetooth.ui:76
+#: panels/network/network-ethernet.ui:111 panels/network/network-mobile.ui:450
+#: panels/network/network-vpn.ui:77
+msgid "Options…"
+msgstr ""
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:134
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:267
+msgid "Must have a minimum of 8 characters"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:272
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:489
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:19
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:44
+msgid "Network Name"
+msgstr ""
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:69
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:389
+#: panels/printers/pp-jobs-dialog.ui:70
+#: panels/user-accounts/cc-add-user-dialog.ui:249
+#: panels/wwan/cc-wwan-apn-dialog.ui:214
+msgid "Password"
+msgstr "Awal n uɛeddi"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:83
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:84
+msgid "Autogenerate Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:130
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.c:544
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:53
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:864
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.c:867
+msgid "_Stop Hotspot"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:46
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:47
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:87
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:99
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:134 panels/wwan/cc-wwan-panel.ui:143
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:146
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:184
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:195
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:205
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:227
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:296
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:20
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:112
+#: panels/network/connection-editor/ce-page-security.c:424
+#: panels/network/connection-editor/details-page.ui:90
+msgid "Security"
+msgstr "Taɣellist"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Ameɣlal"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Agacuran"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr ""
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:228
+msgid "WEP"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:101
+#: panels/network/net-device-wifi.c:233
+msgid "WPA"
+msgstr ""
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:107
+msgid "WPA3"
+msgstr ""
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:112
+#: panels/network/connection-editor/ce-page-security.c:279
+msgid "Enhanced Open"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:119
+msgid "WPA2"
+msgstr ""
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "Enterprise"
+msgstr "Takebbanit"
+
+#: panels/network/connection-editor/ce-page-details.c:130
+#: panels/network/net-device-wifi.c:218
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ulac"
+
+#: panels/network/connection-editor/ce-page-details.c:151
+msgid "Never"
+msgstr "Weṛǧin"
+
+#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/net-device-ethernet.c:108
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/ce-page-details.c:293
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr ""
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:295
+#: panels/network/net-device-ethernet.c:220
+#, c-format
+msgid "%d Mb/s"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:308
+msgid "2.4 GHz / 5 GHz"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "2.4 GHz"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:312
+msgid "5 GHz"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:332
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Ulac"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "D uḍɛif"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ih"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Igerrez"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:407
+#: panels/network/connection-editor/details-page.ui:108
+#: panels/network/net-device-ethernet.c:147
+#: panels/network/net-device-mobile.c:442
+msgid "IPv4 Address"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:408
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-mobile.c:443 panels/network/network-mobile.ui:218
+msgid "IPv6 Address"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:410
+#: panels/network/connection-editor/ce-page-details.c:411
+#: panels/network/net-device-ethernet.c:152
+#: panels/network/net-device-ethernet.c:154
+#: panels/network/net-device-mobile.c:446
+#: panels/network/net-device-mobile.c:447 panels/network/network-mobile.ui:201
+msgid "IP Address"
+msgstr "Tansa  IP"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-mobile.c:451
+msgid "DNS4"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/net-device-ethernet.c:170
+#: panels/network/net-device-mobile.c:452
+msgid "DNS6"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/connection-editor/details-page.ui:199
+#: panels/network/connection-editor/details-page.ui:218
+#: panels/network/connection-editor/ip4-page.ui:211
+#: panels/network/connection-editor/ip6-page.ui:225
+#: panels/network/net-device-ethernet.c:172
+#: panels/network/net-device-ethernet.c:174
+#: panels/network/net-device-mobile.c:454
+#: panels/network/net-device-mobile.c:455 panels/network/network-mobile.ui:253
+#: panels/network/network-mobile.ui:271
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:471
+msgid "Forget Connection"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:473
+msgid "Remove Connection Profile"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:475
+msgid "Remove VPN"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:493
+msgid "Details"
+msgstr "Talqayt"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "Awurman"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:150
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Tamagit"
+
+#: panels/network/connection-editor/ce-page-ip4.c:245
+#: panels/network/connection-editor/ce-page-ip6.c:226
+msgid "Delete Address"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ip4.c:400
+#: panels/network/connection-editor/ce-page-ip6.c:370
+msgid "Delete Route"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ip4.c:754
+msgid "IPv4"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ip6.c:726
+msgid "IPv6"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:268
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ulac"
+
+#: panels/network/connection-editor/ce-page-security.c:303
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:313
+msgid "WEP 128-bit Passphrase"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:326
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:339
+msgid "Dynamic WEP (802.1x)"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:353
+msgid "WPA & WPA2 Personal"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:367
+msgid "WPA & WPA2 Enterprise"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-security.c:381
+msgid "WPA3 Personal"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:18
+#: panels/wwan/cc-wwan-details-dialog.ui:105
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:54
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:144
+#: panels/network/net-device-ethernet.c:157
+msgid "Hardware Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:162
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:180
+#: panels/network/net-device-ethernet.c:161
+#: panels/network/net-device-ethernet.c:163
+#: panels/network/net-device-ethernet.c:165
+#: panels/network/network-mobile.ui:235
+msgid "Default Route"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:236
+msgid "Last Used"
+msgstr "Aseqdec anneggaru"
+
+#: panels/network/connection-editor/details-page.ui:415
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:434
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:467
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:478
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "_Isem"
+
+#: panels/network/connection-editor/ethernet-page.ui:54
+#: panels/network/connection-editor/wifi-page.ui:67
+msgid "_MAC Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:105
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:122
+#: panels/network/connection-editor/wifi-page.ui:102
+msgid "_Cloned Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:137
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:42
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:118
+msgid "Manual"
+msgstr "S ufus"
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr "Sexsi"
+
+#: panels/network/connection-editor/ip4-page.ui:97
+#: panels/network/connection-editor/ip6-page.ui:111
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:125
+#: panels/network/connection-editor/ip6-page.ui:139
+msgid "Addresses"
+msgstr "Tansiwin"
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/printers/pp-details-dialog.ui:95
+msgid "Address"
+msgstr "Tansa"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:171
+#: panels/network/connection-editor/ip4-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:369
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:291
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/connection-editor/ip6-page.ui:305
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:107
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Awurman"
+
+#: panels/network/connection-editor/ip4-page.ui:234
+#: panels/network/connection-editor/ip6-page.ui:248
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:293
+msgid "Routes"
+msgstr "Iberdan"
+
+#: panels/network/connection-editor/ip4-page.ui:302
+#: panels/network/connection-editor/ip6-page.ui:316
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:368
+#: panels/network/connection-editor/ip6-page.ui:382
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:398
+#: panels/network/connection-editor/ip6-page.ui:412
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Prefix"
+msgstr "Adat"
+
+#: panels/network/connection-editor/net-connection-editor.c:280
+msgid "Unable to open connection editor"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:296
+msgid "New Profile"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:731
+msgid "Import from file…"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:763
+msgid "Add VPN"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:20
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:139
+msgid "Cannot import VPN connection"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:173
+msgid "Select file to import"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:225
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:227
+msgid "_Replace"
+msgstr "_Semselsi"
+
+#: panels/network/connection-editor/vpn-helpers.c:229
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:264
+msgid "Cannot export VPN connection"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:266
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:296
+msgid "Export VPN connection"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:20
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:36
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/net-device-ethernet.c:96
+msgid "never"
+msgstr ""
+
+#: panels/network/net-device-ethernet.c:104
+msgid "today"
+msgstr "ass-a"
+
+#: panels/network/net-device-ethernet.c:106
+msgid "yesterday"
+msgstr "Iḍelli"
+
+#: panels/network/net-device-ethernet.c:180
+msgid "Last used"
+msgstr ""
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:267
+#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+msgid "Wired"
+msgstr "S ugatu"
+
+#: panels/network/net-device-mobile.c:209
+msgid "Add new connection"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:851
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+
+#: panels/network/net-device-wifi.c:855
+msgid "_Forget"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1034 panels/network/net-device-wifi.c:1041
+msgid "Known Wi-Fi Networks"
+msgstr ""
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1076
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1217
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1220
+msgid "Wireless device does not support Hotspot mode"
+msgstr ""
+
+#: panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:260
+#: panels/power/cc-power-panel.c:856 panels/power/cc-power-panel.c:867
+#: panels/universal-access/cc-ua-panel.c:331
+#: panels/universal-access/cc-ua-panel.c:612
+#: panels/universal-access/cc-ua-panel.c:622
+#: panels/universal-access/cc-ua-panel.c:634
+#: panels/universal-access/cc-ua-panel.c:677
+#: panels/universal-access/cc-ua-panel.ui:338
+#: panels/universal-access/cc-ua-panel.ui:384
+#: panels/universal-access/cc-ua-panel.ui:430
+#: panels/universal-access/cc-ua-panel.ui:536
+#: panels/universal-access/cc-ua-panel.ui:689
+#: panels/universal-access/cc-ua-panel.ui:735
+#: panels/universal-access/cc-ua-panel.ui:781
+#: panels/universal-access/cc-ua-panel.ui:965
+msgid "Off"
+msgstr "Ur irmid ara"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#. update title
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/net-vpn.c:65 panels/network/net-vpn.c:158
+#, c-format
+msgid "%s VPN"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:50
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-mobile.ui:29
+#: panels/wwan/cc-wwan-details-dialog.ui:286
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:47
+msgid "Provider"
+msgstr "Imfeki"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:96
+msgid "Network Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:180
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:199
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:218
+msgid "_FTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:237
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:256
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:294
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:371
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:392
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:413
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:442
+msgid "_Configuration URL"
+msgstr ""
+
+#: panels/network/network-vpn.ui:56
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:22
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr ""
+
+#: panels/network/network-wifi.ui:28
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Awal n uɛeddi"
+
+#: panels/network/network-wifi.ui:84
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:116
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:127
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:138
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Ulac-it"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Tuqqna ɣer"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Tlaq tuqqna"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Tufɣa"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Tuqna ur teddi yara"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:195
+msgid "no file selected"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:222
+msgid "unspecified error validating eap-method file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:400
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:87
+msgid "missing EAP-FAST PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:347
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:352
+msgid "PAC files (*.pac)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Udrig"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:49
+#: panels/network/wireless-security/eap-method-peap.ui:52
+#: panels/network/wireless-security/eap-method-ttls.ui:51
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:75
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:115
+#: panels/network/wireless-security/eap-method-peap.ui:150
+#: panels/network/wireless-security/eap-method-ttls.ui:143
+msgid "_Inner authentication"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:144
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:17
+#: panels/network/wireless-security/eap-method-simple.ui:17
+#: panels/network/wireless-security/ws-leap.ui:18
+#: panels/user-accounts/cc-add-user-dialog.ui:146
+#: panels/user-accounts/cc-add-user-dialog.ui:527
+msgid "_Username"
+msgstr "_Isem n useqdac"
+
+#: panels/network/wireless-security/eap-method-leap.ui:31
+#: panels/network/wireless-security/eap-method-simple.ui:31
+#: panels/network/wireless-security/ws-leap.ui:32
+#: panels/network/wireless-security/ws-sae.ui:14
+#: panels/network/wireless-security/ws-wpa-psk.ui:14
+#: panels/sharing/cc-sharing-panel.ui:202
+#: panels/user-accounts/cc-add-user-dialog.ui:310
+#: panels/user-accounts/cc-add-user-dialog.ui:547
+#: panels/user-accounts/cc-user-panel.ui:365
+msgid "_Password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:55
+#: panels/network/wireless-security/eap-method-simple.ui:73
+#: panels/network/wireless-security/eap-method-tls.ui:157
+#: panels/network/wireless-security/ws-leap.ui:56
+#: panels/network/wireless-security/ws-sae.ui:54
+#: panels/network/wireless-security/ws-wpa-psk.ui:64
+msgid "Sho_w password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:87
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:96
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:328
+#: panels/network/wireless-security/eap-method-tls.c:513
+#: panels/network/wireless-security/eap-method-ttls.c:336
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:78
+#: panels/network/wireless-security/eap-method-tls.ui:68
+#: panels/network/wireless-security/eap-method-ttls.ui:102
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:100
+#: panels/network/wireless-security/eap-method-tls.ui:90
+#: panels/network/wireless-security/eap-method-ttls.ui:125
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:118
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:92
+msgid "missing EAP-TLS identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:102
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:112
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:129
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:139
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:272
+msgid "Unencrypted private keys are insecure"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:275
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:506
+msgid "Choose your personal certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:520
+msgid "Choose your private key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:17
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:43
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:133
+msgid "_Private key password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:98
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:106
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:76
+#: panels/user-accounts/cc-add-user-dialog.ui:507
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "_Taɣult"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:102
+#: panels/network/wireless-security/ws-wpa-eap.ui:61
+msgid "Au_thentication"
+msgstr ""
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr ""
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr ""
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr ""
+
+#: panels/network/wireless-security/ws-sae.ui:42
+#: panels/network/wireless-security/ws-wpa-psk.ui:42
+msgid "_Type"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:48
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:84
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:134
+msgid "WEP inde_x"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:60
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr ""
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:112
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:168
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:184
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:249
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:300
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:351
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.c:260
+#: panels/power/cc-power-panel.c:862 panels/power/cc-power-panel.c:869
+#: panels/universal-access/cc-ua-panel.c:331
+#: panels/universal-access/cc-ua-panel.c:612
+#: panels/universal-access/cc-ua-panel.c:622
+#: panels/universal-access/cc-ua-panel.c:634
+#: panels/universal-access/cc-ua-panel.c:677
+msgid "On"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:44
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:52
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.c:148
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Nniḍen"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:576
+#, c-format
+msgid "%s Account"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.c:870
+msgid "Error removing account"
+msgstr ""
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:936
+#, c-format
+msgid "%s removed"
+msgstr "%s yettwakkes"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Imiḍanen ɣef uẓeḍḍa"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:61
+msgid "Undo"
+msgstr "Err-d"
+
+#: panels/online-accounts/online-accounts.ui:94
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/online-accounts.ui:109
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/online-accounts.ui:134
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/online-accounts.ui:223
+msgid "Remove Account"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Akud arussin"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "srag"
+msgstr[1] "isragen"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "tisdatin"
+msgstr[1] "tisdatin"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Dayen yeččur"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Ilem"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "La d-yettali"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Taɣerdayt mebla tinelwa"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Amdeswal"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Amallal umḍin udmawan"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Tiliɣri n ufus"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Imeɣri n ugetmedia"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209 panels/wacom/cc-wacom-panel.c:728
+msgid "Tablet"
+msgstr "Taṭablit"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Aselkim"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr ""
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:384
+#: panels/power/cc-power-panel.ui:63
+msgid "Battery"
+msgstr "Aẓru"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Agejdan"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Ayen-nniḍen"
+
+#: panels/power/cc-power-panel.c:382
+msgid "Batteries"
+msgstr "Tibaṭriyin"
+
+#: panels/power/cc-power-panel.c:644
+msgid "When _idle"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:796
+msgid "Suspend"
+msgstr "Ḥbes di leεḍil"
+
+#: panels/power/cc-power-panel.c:797
+msgid "Power Off"
+msgstr "Sens"
+
+#: panels/power/cc-power-panel.c:798
+msgid "Hibernate"
+msgstr "Sgen"
+
+#: panels/power/cc-power-panel.c:799
+msgid "Nothing"
+msgstr "Ulac"
+
+#: panels/power/cc-power-panel.c:858
+msgid "When on battery power"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:860
+msgid "When plugged in"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:980
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Weṛǧin"
+
+#: panels/power/cc-power-panel.c:1066
+msgid "Automatic suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1171
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1173
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1175
+msgid "Performance mode temporarily disabled."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1218
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1226
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1230
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:13
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 n tesdatin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:17
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 n tisdatin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:21
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:25
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 n tesdatin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:29
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 ntesdatin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:33
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 n usrag"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:37
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:41
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 n tesdatin"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:45
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:49
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 n isragen"
+
+#: panels/power/cc-power-panel.ui:107
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:108
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:142
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:146
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:147
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Dim Screen"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "Screen _Blank"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:183
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:184
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:198
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:199
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:217
+msgid "Suspend & Power Button"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:221
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:229
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:268
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:293
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:309
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:354 panels/power/cc-power-panel.ui:414
+#: panels/universal-access/cc-repeat-keys-dialog.ui:74
+msgid "Delay"
+msgstr "Amenḍaṛ"
+
+#: panels/power/cc-power-profile-row.c:61
+msgid "Lap detected: performance mode unavailable"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:63
+msgid "High hardware temperature: performance mode unavailable"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:64
+msgid "Performance mode unavailable"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:86
+#: panels/power/cc-power-profile-row.c:185
+msgid "High performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:184
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Atwal"
+
+#: panels/power/cc-power-profile-row.c:188
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:189
+msgid "Standard performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:192
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-profile-row.c:193
+msgid "Reduced performance and power usage."
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Tazmert"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "Sesteb"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/new-printer-dialog.ui:366
+#: panels/printers/pp-jobs-dialog.ui:57 panels/wwan/cc-wwan-apn-dialog.ui:188
+msgid "Username"
+msgstr "Isem n useqdac"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:339
+msgid "Authentication Required"
+msgstr ""
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:683
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr ""
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:927
+msgid "Failed to add new printer."
+msgstr ""
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1226
+#, c-format
+msgid "Could not load ui: %s"
+msgstr ""
+
+#: panels/printers/cc-printers-panel.c:1294
+msgid "Unlock to Add Printers and Change Settings"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Tisaggazin"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:254
+#: panels/printers/pp-new-printer-dialog.c:311
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+#: panels/wwan/cc-wwan-device-page.ui:90
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:211
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:284
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:356
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:351
+#, c-format
+msgid "%s Details"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:101
+msgid "No suitable driver found"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:232
+msgid "Select PPD File"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:241
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "Adig"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:122
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:162
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:183
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:192
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:201
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/cc-avatar-chooser.c:107
+msgid "Select"
+msgstr "Fren"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr ""
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "S teẓɣzi"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "S tehri"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr ""
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:137
+msgctxt "print job"
+msgid "Pending"
+msgstr "Yegguni"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:143
+msgctxt "print job"
+msgid "Paused"
+msgstr "Yettṛaǧu"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:148
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Tlaq tuqqna"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:153
+msgctxt "print job"
+msgid "Processing"
+msgstr "Asesfer"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:157
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Yeḥbes"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:161
+msgctxt "print job"
+msgid "Canceled"
+msgstr ""
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:165
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Ittwasefsex"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:169
+msgctxt "print job"
+msgid "Completed"
+msgstr "Yemmed"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:179
+msgid "Move this job to the top of the queue"
+msgstr ""
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:319
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:471
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr ""
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:475
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:44
+msgid "Domain"
+msgstr "Taɣult"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:129
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:169
+msgid "Clear All"
+msgstr "Sfeḍ meṛṛa"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:232
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:358
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:269
+msgid "Unlock Print Server"
+msgstr ""
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:273
+#, c-format
+msgid "Unlock %s."
+msgstr ""
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:277
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:587
+msgid "Searching for Printers"
+msgstr ""
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1375
+msgid "USB"
+msgstr ""
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1380
+msgid "Serial Port"
+msgstr ""
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1387
+msgid "Parallel Port"
+msgstr ""
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1429
+#, c-format
+msgid "Location: %s"
+msgstr ""
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1434
+#, c-format
+msgid "Address: %s"
+msgstr ""
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1461
+msgid "Server requires authentication"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Taɣbalut n taferkit"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Afray"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr ""
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:530
+msgid "Pages per side"
+msgstr ""
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:542
+msgid "Two-sided"
+msgstr ""
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:554
+msgid "Orientation"
+msgstr "Taɣda"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:651
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Amatu"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Tawila n usebtar"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr ""
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Tawiri"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr ""
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Ini"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr ""
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Talqayt"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:857
+#: panels/printers/pp-options-dialog.ui:18
+msgid "Test Page"
+msgstr ""
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:870
+msgid "Test page"
+msgstr ""
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr ""
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Ulac asizdeg yezwaren"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:203
+msgid "Manufacturer"
+msgstr ""
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:523 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr ""
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:528
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:648
+msgid "Clean print heads"
+msgstr ""
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:713
+msgid "Low on toner"
+msgstr ""
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:715
+msgid "Out of toner"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:718
+msgid "Low on developer"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of developer"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:723
+msgid "Low on a marker supply"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:725
+msgid "Out of a marker supply"
+msgstr ""
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:727
+msgid "Open cover"
+msgstr ""
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:729
+msgid "Open door"
+msgstr ""
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:731
+msgid "Low on paper"
+msgstr ""
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:733
+msgid "Out of paper"
+msgstr ""
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:735
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Beṛṛa n tuqqna"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:737
+#: panels/printers/pp-printer-entry.c:880
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Yeḥbes"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:739
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:741
+msgid "Waste receptacle full"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:743
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:745
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:866
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Iwjed"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:871
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr ""
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:876
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Asesfer"
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr ""
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:193
+#: panels/wwan/cc-wwan-details-dialog.ui:229
+msgid "Model"
+msgstr "Taneɣruft"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:313
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:320
+msgid "Restart"
+msgstr "Ales tanekra"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:12
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:187
+msgid "No printers"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:201
+msgid "Add a Printer…"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:233
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:189
+#: panels/region/cc-format-chooser.ui:6 panels/region/cc-region-panel.ui:203
+msgid "Formats"
+msgstr "Imusal"
+
+#: panels/region/cc-format-chooser.ui:101
+msgid ""
+"Choose the format for numbers, dates and currencies. Changes take effect on "
+"next login."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:117
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:158
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:189
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:242
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:255
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:300
+msgid "Preview"
+msgstr "Timeẓriwt"
+
+#: panels/region/cc-format-preview.c:135
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr ""
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Metric"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:18
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:62
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:84
+msgid "Numbers"
+msgstr "Imiḍanen"
+
+#: panels/region/cc-format-preview.ui:106
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:128
+msgid "Paper"
+msgstr "Lkaɣeḍ"
+
+#: panels/region/cc-region-panel.ui:42
+msgid "My Account"
+msgstr "Amiḍan-inu"
+
+#: panels/region/cc-region-panel.ui:53
+msgid "Login Screen"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:78
+msgid "Language"
+msgstr "Tameslayt"
+
+#: panels/region/cc-region-panel.ui:89
+msgid "The language used for text in windows and web pages."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:129
+#: panels/user-accounts/cc-user-panel.ui:311
+msgid "_Language"
+msgstr "_Tutlayt"
+
+#: panels/region/cc-region-panel.ui:164
+msgid "Restart the session for changes to take effect"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:179
+msgid "Restart…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:214
+msgid "The format used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:248
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:275
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:267
+msgid "Ask what to do"
+msgstr "Steqsi d acu ara tgeḍ"
+
+#: panels/removable-media/cc-removable-media-panel.c:271
+msgid "Do nothing"
+msgstr "Ur tegg acmek"
+
+#: panels/removable-media/cc-removable-media-panel.c:275
+msgid "Open folder"
+msgstr "Ldi akaram"
+
+#: panels/removable-media/cc-removable-media-panel.c:341
+msgid "Other Media"
+msgstr "Amidya-nniḍen"
+
+#: panels/removable-media/cc-removable-media-panel.c:362
+msgid "Select an application for audio CDs"
+msgstr "Fren asnas i CDs asfeldan"
+
+#: panels/removable-media/cc-removable-media-panel.c:363
+msgid "Select an application for video DVDs"
+msgstr "Fren asnan i uvidyu DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:364
+msgid "Select an application to run when a music player is connected"
+msgstr "Fren asnas iwumi ara tserrḥeḍ m'ara yili yeqqen kra n yimeɣri n uẓawan"
+
+#: panels/removable-media/cc-removable-media-panel.c:365
+msgid "Select an application to run when a camera is connected"
+msgstr "Fren asnas ad tt-seduḍ m'ara ad tens takamirat"
+
+#: panels/removable-media/cc-removable-media-panel.c:366
+msgid "Select an application for software CDs"
+msgstr "Fran asnas i iCD-iyen ideg llan iseɣẓanen"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "audio DVD"
+msgstr "DVD asfeldan"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "blank Blu-ray disc"
+msgstr "aḍebsi Blu-ray d ilem"
+
+#: panels/removable-media/cc-removable-media-panel.c:380
+msgid "blank CD disc"
+msgstr "aḍebsi CD d ilem"
+
+#: panels/removable-media/cc-removable-media-panel.c:381
+msgid "blank DVD disc"
+msgstr "aḍebsi DVD d ilem"
+
+#: panels/removable-media/cc-removable-media-panel.c:382
+msgid "blank HD DVD disc"
+msgstr "aḍebsi HD DVD d ilem"
+
+#: panels/removable-media/cc-removable-media-panel.c:383
+msgid "Blu-ray video disc"
+msgstr "aḍebsi Blu-ray uvidyu"
+
+#: panels/removable-media/cc-removable-media-panel.c:384
+msgid "e-book reader"
+msgstr "imeɣri n e-book"
+
+#: panels/removable-media/cc-removable-media-panel.c:385
+msgid "HD DVD video disc"
+msgstr "aḍebsi HD DVD uvidyu"
+
+#: panels/removable-media/cc-removable-media-panel.c:386
+msgid "Picture CD"
+msgstr "Aḍebsi CD n tungniwin"
+
+#: panels/removable-media/cc-removable-media-panel.c:387
+msgid "Super Video CD"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:388
+msgid "Video CD"
+msgstr "Vidyu CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:389
+msgid "Windows software"
+msgstr "Iseɣẓanen n Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:44
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:75
+msgid "CD _audio"
+msgstr "CD_n tesfelda"
+
+#: panels/removable-media/cc-removable-media-panel.ui:92
+msgid "_DVD video"
+msgstr "_DVD n uvidyu"
+
+#: panels/removable-media/cc-removable-media-panel.ui:133
+msgid "_Music player"
+msgstr "Imeɣri n_uẓawan"
+
+#: panels/removable-media/cc-removable-media-panel.ui:191
+msgid "_Software"
+msgstr "_Aseɣẓan"
+
+#: panels/removable-media/cc-removable-media-panel.ui:229
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:288
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:342
+msgid "Select how other media should be handled"
+msgstr "Fren amek ara ttusferken imidyaten-nniḍen"
+
+#: panels/removable-media/cc-removable-media-panel.ui:389
+msgid "_Action:"
+msgstr "Ti_gawt:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:412
+msgid "_Type:"
+msgstr "Anaw:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.c:636
+msgid "Select Location"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.c:640
+msgid "_OK"
+msgstr "_IH"
+
+#: panels/search/cc-search-locations-dialog.ui:9
+#: panels/search/cc-search-panel.ui:57
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:32
+#: panels/search/cc-search-locations-dialog.ui:69
+#: panels/search/cc-search-locations-dialog.ui:107
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Places"
+msgstr "Imukan"
+
+#: panels/search/cc-search-locations-dialog.ui:91
+msgid "Bookmarks"
+msgstr "Ticraḍ"
+
+#: panels/search/cc-search-locations-dialog.ui:156
+msgid "Other"
+msgstr "Nniḍen"
+
+#: panels/search/cc-search-panel.c:151
+msgid "No applications found"
+msgstr ""
+
+#: panels/search/cc-search-panel-row.ui:92
+msgid "Move Up"
+msgstr ""
+
+#: panels/search/cc-search-panel-row.ui:102
+msgid "Move Down"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:31
+msgid ""
+"Control which search results are shown in the Activities Overview. The order "
+"of search results can also be changed by moving rows in the list."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:306
+msgid "No networks selected for sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:19
+msgid "Networks"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:289
+msgctxt "service is enabled"
+msgid "On"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:291 panels/sharing/cc-sharing-panel.c:318
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Ur irmid ara"
+
+#: panels/sharing/cc-sharing-panel.c:321
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Yermed"
+
+#: panels/sharing/cc-sharing-panel.c:324
+msgctxt "service is active"
+msgid "Active"
+msgstr "Irmed"
+
+#: panels/sharing/cc-sharing-panel.c:393
+msgid "Choose a Folder"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:696
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:702
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:708
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to %s"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:813
+msgid "Copy"
+msgstr "Nɣel"
+
+#: panels/sharing/cc-sharing-panel.c:1203
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Beṭṭu"
+
+#: panels/sharing/cc-sharing-panel.ui:32
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:87
+msgid "_Screen Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:95
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:103
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:119
+msgid "Some services are disabled because of no network access."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:137
+#: panels/sharing/cc-sharing-panel.ui:264
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:184
+msgid "_Require Password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:275
+#: panels/sharing/cc-sharing-panel.ui:345
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:368
+#: panels/sharing/cc-sharing-panel.ui:590
+msgid "Screen Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:422
+msgid "_Allow connections to control the screen"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:447
+msgid "_Password:"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:477
+msgid "_Show Password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:508
+msgid "Access Options"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:522
+msgid "_New connections must ask for access"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:540
+msgid "_Require a password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:601
+#: panels/sharing/cc-sharing-panel.ui:695
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:634
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:649
+msgid "Folders"
+msgstr "Ikaramen"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.c:151
+msgid "Custom"
+msgstr "Yugen"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:19
+msgid "Drip"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:26
+msgid "Glass"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:33
+msgid "Sonar"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "Deffir"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "Sdat"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:127
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:27
+msgid "System Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:43
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:63
+msgid "Output"
+msgstr "Tuffɣa"
+
+#: panels/sound/cc-sound-panel.ui:90
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:113
+msgid "Test"
+msgstr "Akayad"
+
+#: panels/sound/cc-sound-panel.ui:144 panels/sound/cc-sound-panel.ui:319
+msgid "Configuration"
+msgstr "Tawila"
+
+#: panels/sound/cc-sound-panel.ui:177
+msgid "Balance"
+msgstr "Awliwal"
+
+#: panels/sound/cc-sound-panel.ui:204
+msgid "Fade"
+msgstr "Tifsit"
+
+#: panels/sound/cc-sound-panel.ui:231
+msgid "Subwoofer"
+msgstr "Imsemɣer n imesli  azuran"
+
+#: panels/sound/cc-sound-panel.ui:251
+msgid "Input"
+msgstr "Anekcum"
+
+#: panels/sound/cc-sound-panel.ui:278
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:352
+msgid "Volume"
+msgstr "Ableɣ"
+
+#: panels/sound/cc-sound-panel.ui:372
+msgid "Alert Sound"
+msgstr ""
+
+#: panels/sound/cc-volume-slider.c:117
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Imesli"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:94
+#: panels/thunderbolt/cc-bolt-device-entry.c:125
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Ur yeqqin ara"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:97
+#: panels/thunderbolt/cc-bolt-device-entry.c:128
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Tuqqna ɣer"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:100
+#: panels/thunderbolt/cc-bolt-device-entry.c:132
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Iqqen"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:103
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:106
+#: panels/thunderbolt/cc-bolt-device-entry.c:138
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:115
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:121
+#: panels/thunderbolt/cc-bolt-device-entry.c:152
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Arussin"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:177
+msgid "Authorized at:"
+msgstr ""
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:183
+msgid "Connected at:"
+msgstr ""
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:190
+msgid "Enrolled at:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:264
+msgid "Failed to authorize device: "
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:333
+msgid "Failed to forget device: "
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+msgid "Name:"
+msgstr "Isem:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:135
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Tuccḍa"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:146
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:175
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:468
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:512
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:516
+msgid "Thunderbolt security level could not be determined."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:621
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:143
+msgid "No Thunderbolt support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:246
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:269
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:289
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:397
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:535
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:7
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:37
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:74
+#: panels/universal-access/cc-repeat-keys-dialog.ui:145
+msgid "Speed"
+msgstr "Arured"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:101
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:7
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:29
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:7
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:43
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:56
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Ssker-d anqab wis sin s tqeffalt tagejdant ara teǧǧeḍ tṣubb"
+
+#: panels/universal-access/cc-pointing-dialog.ui:79
+#: panels/universal-access/cc-typing-dialog.ui:158
+#: panels/universal-access/cc-typing-dialog.ui:307
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:95
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Wezzil"
+
+#: panels/universal-access/cc-pointing-dialog.ui:110
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:120
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Ɣezzif"
+
+#: panels/universal-access/cc-pointing-dialog.ui:157
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:170
+msgid "Trigger a click when the pointer hovers"
+msgstr "Ssker-d anqab s tqeffalt tagejdant ara teǧǧeḍ tṣubb"
+
+#: panels/universal-access/cc-pointing-dialog.ui:193
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:210
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Wezzil"
+
+#: panels/universal-access/cc-pointing-dialog.ui:232
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Ɣezzif"
+
+#: panels/universal-access/cc-pointing-dialog.ui:253
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:270
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Amecṭuḥ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:292
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Ameqran"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:7
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:37
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:102
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:174
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-sound-keys-dialog.ui:7
+msgid "Sound Keys"
+msgstr ""
+
+#: panels/universal-access/cc-sound-keys-dialog.ui:25
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-sound-keys-dialog.ui:45
+#: panels/universal-access/cc-ua-panel.ui:412
+msgid "_Sound Keys"
+msgstr ""
+
+#: panels/universal-access/cc-screen-reader-dialog.ui:7
+msgid "Screen Reader"
+msgstr "Imeɣri n wegdil"
+
+#: panels/universal-access/cc-screen-reader-dialog.ui:24
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-screen-reader-dialog.ui:52
+msgid "_Screen Reader"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:7
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:46
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:58
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:72
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:85
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:123
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:175
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Wezzil"
+
+#: panels/universal-access/cc-typing-dialog.ui:190
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:200
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Ɣezzif"
+
+#: panels/universal-access/cc-typing-dialog.ui:212
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:224
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:236
+#: panels/universal-access/cc-typing-dialog.ui:361
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:272
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:284
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:324
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Wezzil"
+
+#: panels/universal-access/cc-typing-dialog.ui:339
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:349
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Ɣezzif"
+
+#: panels/universal-access/cc-typing-dialog.ui:437
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:449
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:351
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Amezwer"
+
+#: panels/universal-access/cc-ua-panel.c:354
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "D alemmas"
+
+#: panels/universal-access/cc-ua-panel.c:357
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Ameqran"
+
+#: panels/universal-access/cc-ua-panel.c:360
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Meqqer ugar"
+
+#: panels/universal-access/cc-ua-panel.c:363
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Ahrawan maḍi"
+
+#: panels/universal-access/cc-ua-panel.c:367
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d n upiksil"
+msgstr[1] "%d n ipiksilen"
+
+#: panels/universal-access/cc-ua-panel.ui:55
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:97
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:143
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:190
+msgid "_Large Text"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:238
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:273
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:320
+#: panels/universal-access/cc-zoom-options-dialog.ui:91
+msgid "_Zoom"
+msgstr "_Semɣer/Semẓi"
+
+#: panels/universal-access/cc-ua-panel.ui:366
+msgid "Screen _Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:474
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:518
+#: panels/universal-access/cc-visual-alerts-dialog.ui:68
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:626
+msgid "Screen _Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:671
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:717
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:763
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:824
+msgid "Pointing & Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:870
+msgid "_Mouse Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:915
+msgid "_Locate Pointer"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:947
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:993
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1013
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:15
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:19
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:48
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:94
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:112
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.c:303
+msgctxt "Distance"
+msgid "Short"
+msgstr "Wezzil"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:304
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.c:305
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "Long"
+msgstr "Ɣezzif"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:70
+msgid "Zoom Options"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:151
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:201
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:221
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:278
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:292
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:307
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:322
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:347
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:362
+msgid "Magnifier"
+msgstr "Tasemɣert"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:410
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:436
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:458
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Zzur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:479
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:523
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:577
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:610
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:634
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:683
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:703
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:724
+msgid "_Contrast:"
+msgstr ""
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:744
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:769
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ulac"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:791
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Ačuran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:844
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Yuder"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:867
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Haut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:893
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Yuder"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:916
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Haut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:942
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:958
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:154
+msgid "Empty all items from Trash?"
+msgstr "Ad tekkseḍ akk iferdisen n tqecwalt?"
+
+#: panels/usage/cc-usage-panel.c:155
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Akk iferdisen n tqecwalt ad ṛuḥen i lebda."
+
+#: panels/usage/cc-usage-panel.c:156
+msgid "_Empty Trash"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:177
+msgid "Delete all the temporary files?"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:178
+msgid "All the temporary files will be permanently deleted."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:179
+msgid "_Purge Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:29
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:41
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:56
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:78
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:119
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:135
+msgid "Trash & Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:145
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:159
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:174
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:196
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:238
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:250
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:278
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 n usrag"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:282
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 n wass"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:286
+msgctxt "purge_files"
+msgid "2 days"
+msgstr ""
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:290
+msgctxt "purge_files"
+msgid "3 days"
+msgstr ""
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:294
+msgctxt "purge_files"
+msgid "4 days"
+msgstr ""
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:298
+msgctxt "purge_files"
+msgid "5 days"
+msgstr ""
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:302
+msgctxt "purge_files"
+msgid "6 days"
+msgstr ""
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:306
+msgctxt "purge_files"
+msgid "7 days"
+msgstr ""
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:310
+msgctxt "purge_files"
+msgid "14 days"
+msgstr ""
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:314
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 n wussan"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:329
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 n wass"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:333
+msgctxt "retain_history"
+msgid "7 days"
+msgstr ""
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:337
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 n wussan"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:341
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Yal tikelt"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:204
+msgid "Failed to add account"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:661
+#: panels/user-accounts/cc-password-dialog.c:261
+msgid "The passwords do not match."
+msgstr "Awalen n uɛeddi ur nmeɣran ara."
+
+#: panels/user-accounts/cc-add-user-dialog.c:875
+#: panels/user-accounts/cc-add-user-dialog.c:914
+#: panels/user-accounts/cc-add-user-dialog.c:932
+msgid "Failed to register account"
+msgstr "Asekles n umiḍan ur yeddi ara"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1047
+msgid "No supported way to authenticate with this domain"
+msgstr "Ulac abrid n usefrek i usesteb d taɣult-a"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1111
+msgid "Failed to join domain"
+msgstr "Timerna ɣer taɣult ur teddi ara"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1166
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1173
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid "Failed to log into domain"
+msgstr "Anekcum ɣer taɣult ur yeddi ara"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1236
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "Rnu aseqdac"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:180
+msgid "_Full Name"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:206
+msgid "Standard"
+msgstr "Lexṣas"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:216
+msgid "Administrator"
+msgstr "Anedbal"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:232
+msgid "Account _Type"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:269
+msgid "Allow user to set a password when they next _login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:283
+msgid "Set a password _now"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:405
+msgid "_Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:485
+#: panels/user-accounts/cc-add-user-dialog.ui:692
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Anekcam n tkebbanit ad yeǧǧ aseqdec n umḍan n useqdac yettusefrak s wudem "
+"agensan ɣef yibenk-a. Tzemreḍ daɣen ad tesqedceḍ amiḍan-a i unekcum ɣer "
+"teɣbula n tkebbant deg internet."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:732
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:751
+msgid "You must be online in order to add enterprise users."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:782
+msgid "_Enterprise Login"
+msgstr "_Anekcam n tkebbanit"
+
+#: panels/user-accounts/cc-avatar-chooser.c:225
+msgid "Browse for more pictures"
+msgstr "Inig i wugar n tugniwin"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:39
+msgid "Take a Picture…"
+msgstr "Ṭṭef tawlaft..."
+
+#: panels/user-accounts/cc-avatar-chooser.ui:46
+msgid "Select a File…"
+msgstr "Fren afaylu..."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:23
+msgid "Fingerprint"
+msgstr "Adsil umdin"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:118
+msgid "_No"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:128
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:155
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:259
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:264
+msgid "No fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:280
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:309
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:322
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:352
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:363
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:412
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:436
+msgid "_Re-enroll this finger…"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:236
+msgid "the device needs to be claimed to perform this action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:238
+msgid "the device is already claimed by another process"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:240
+msgid "you do not have permission to perform the action"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:242
+msgid "no prints have been enrolled"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:251
+msgid "Failed to communicate with the device during enrollment"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:255
+msgid "Failed to communicate with the fingerprint reader"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:257
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:585
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:652
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:683
+msgid "Left thumb"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:685
+msgid "Left middle finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:687
+msgid "_Left index finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:689
+msgid "Left ring finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:691
+msgid "Left little finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:693
+msgid "Right thumb"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:695
+msgid "Right middle finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:697
+msgid "_Right index finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:699
+msgid "Right ring finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:701
+msgid "Right little finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:703
+msgid "Unknown Finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:837
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Yemmed"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:848
+msgid "Fingerprint device disconnected"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:854
+msgid "Fingerprint device storage is full"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:858
+msgid "Failed to enroll new fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:889
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:897
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:974
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1118
+msgid "Scan new fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1157
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1229
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1264
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1413
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.c:69
+msgid "This Week"
+msgstr "Dduṛt-agi"
+
+#: panels/user-accounts/cc-login-history-dialog.c:72
+msgid "Last Week"
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:82
+#: panels/user-accounts/cc-login-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr ""
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:91
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr ""
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:96
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:173
+#: panels/user-accounts/cc-user-panel.c:771
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr ""
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:176
+#: panels/user-accounts/cc-user-panel.c:775
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:243
+msgid "Session Ended"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.c:249
+msgid "Session Started"
+msgstr ""
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:343
+#, c-format
+msgid "%s — Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.c:125
+msgid "Please choose another password."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.c:134
+msgid "Please type your current password again."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.c:140
+msgid "Password could not be changed"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:7
+msgid "Change Password"
+msgstr "Snifel awal uffir"
+
+#: panels/user-accounts/cc-password-dialog.ui:37
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:145
+msgid "_Confirm New Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:162
+msgid "_New Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:216
+msgid "Current _Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:254
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:267
+msgid "Set a password now"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Ulamek timerna ɣer wanaw-a n taɣult s wudem awurman"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Ulac anekcam n tkebbanit neɣ isem n taɣult i yettwafen"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Ur tezmireḍ ara ad tkecmeḍ d %s ɣer taɣult %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Ur nezmir ara ad neqqen ɣer taɣult %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:222
+msgid "Your account"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:402
+msgid "Failed to delete user"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:457
+#: panels/user-accounts/cc-user-panel.c:512
+#: panels/user-accounts/cc-user-panel.c:558
+msgid "Failed to revoke remotely managed user"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:607
+msgid "You cannot delete your own account."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:616
+#, c-format
+msgid "%s is still logged in"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:620
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:629
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:633
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:636
+msgid "_Delete Files"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:637
+msgid "_Keep Files"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:651
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:655
+msgid "_Delete"
+msgstr "_Kkes"
+
+#: panels/user-accounts/cc-user-panel.c:705
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:713
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:716
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ulac"
+
+#: panels/user-accounts/cc-user-panel.c:759
+msgid "Logged in"
+msgstr "Taqqneḍ"
+
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:846
+#: panels/user-accounts/cc-user-panel.c:935
+#: panels/wwan/cc-wwan-device-page.c:477
+msgid "Enabled"
+msgstr "Yermed"
+
+#: panels/user-accounts/cc-user-panel.c:1259
+msgid "Failed to contact the accounts service"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1261
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1366
+msgid "Delete the selected user account"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1378
+#: panels/user-accounts/cc-user-panel.c:1489
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1535
+msgid "Unlock to Add Users and Change Settings"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:6
+msgid "_Add User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:9
+msgid "Create a user account"
+msgstr "Rnu amiḍan n useqdac"
+
+#: panels/user-accounts/cc-user-panel.ui:64
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:72
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:157
+#: panels/user-accounts/cc-user-panel.ui:173
+msgid "User Icon"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:249
+msgid "Account Settings"
+msgstr "Iɣewwaṛen n Umiḍan"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:268
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:285
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Authentication & Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:390
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:415
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:430
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:461
+msgid "Remove User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:502
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:512
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Iseqdacen"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "Anekcam n unedbal n taɣult"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Awal uffi amaynut yewwi-d ad yemgarad ɣef winna yellan d aqbur."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Sexleḍ gar yisekkilen imeqqranen d yimeẓẓyanen, tmuqleḍ amek ara ternuḍ "
+"amḍan neɣ sin."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Timerna n waṭas n yisekkilen, imḍanen d usigez ad yerr awal uffir yeǧhed "
+"aṭas."
+
+#: panels/user-accounts/run-passwd.c:413
+msgid "Authentication failed"
+msgstr "Asesteb ur yeddi ara"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The new password is too short"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password is too simple"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:507
+#, c-format
+msgid "The new password has already been used recently."
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:526
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Tuccḍa tarussint"
+
+#: panels/user-accounts/user-utils.c:432
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:436
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Nesḥassef, isem-a n useqdac ulac-it. Ma ulac aɣilif ɛreḍ wayeḍ."
+
+#: panels/user-accounts/user-utils.c:478
+msgid "The username is too long."
+msgstr "Isem n useqdac ɣezzif aṭas."
+
+#: panels/user-accounts/user-utils.c:537
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr ""
+"Ad yettuseqdec i usemmi n ukaram-inek·inem agejdan yerna yezmer ad "
+"yettusnifel."
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "_Mdel"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:61
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:78
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr ""
+
+#: panels/wacom/cc-wacom-mapping-panel.c:245
+msgid "Output:"
+msgstr "Tuffɣa:"
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:257
+msgid "Keep aspect ratio (letterbox):"
+msgstr ""
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:268
+msgid "Map to single monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-nav-button.c:84
+#, c-format
+msgid "%d of %d"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.c:516
+msgid "Display Mapping"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.c:725 panels/wacom/wacom-stylus-page.ui:119
+msgid "Stylus"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.c:357
+msgid "Button"
+msgstr "Taqfalt"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:200
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "Ta_llalt"
+
+#: panels/wacom/gnome-wacom-properties.ui:125
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:141
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:161
+msgid "Bluetooth Settings"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:238
+msgid "Tracking Mode"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:266
+msgid "Left-Handed Orientation"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:296
+#: panels/wacom/gnome-wacom-properties.ui:401
+msgid "Map to Monitor…"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:309
+msgid "Map Buttons…"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:322
+msgid "Calibrate…"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:340
+msgid "Adjust mouse settings"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Adjust display resolution"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:376
+msgid "Decouple Display"
+msgstr ""
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
+msgid "New shortcut…"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "Amezwer"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "Ɣer zdat"
+
+#: panels/wacom/wacom-stylus-page.ui:79
+msgid "No stylus found"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:93
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:159
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
+msgid "Soft"
+msgstr "lewwaɣ"
+
+#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:234
+msgid "Top Button"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:263
+msgid "Lower Button"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:292
+msgid "Lowest Button"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:321
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:11
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:160
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:543
+msgid "Operation Cancelled"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:546
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:549
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:81
+msgid "Not Registered"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:85
+msgid "Registered"
+msgstr "Aklas"
+
+#: panels/wwan/cc-wwan-details-dialog.c:89
+msgid "Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:93
+msgid "Searching"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:97
+msgid "Denied"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:4
+msgid "Modem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:33
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:53
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:79
+msgid "Network Type"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:131
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:158
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:185
+msgid "Device Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:257
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1003
+msgid "2G, 3G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1005
+msgid "2G, 3G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G (Preferred), 3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "3G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1017
+msgid "3G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1019
+msgid "3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1025
+msgid "2G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1027
+msgid "2G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1029
+msgid "2G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "2G, 3G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "2G (Preferred), 3G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "2G, 3G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1043
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Arussin"
+
+#: panels/wwan/cc-wwan-device-page.c:188
+msgid "Unlock SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:189 panels/wwan/cc-wwan-device-page.c:237
+msgid "Unlock"
+msgstr "Serreḥ"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:195
+msgid "Enter PIN to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:199
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:200
+msgid "Enter PUK to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:218
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:221
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:226
+msgid "Wrong password entered."
+msgstr "Yettwasekcem yir awal uffir."
+
+#: panels/wwan/cc-wwan-device-page.c:271
+msgid "PUK code should be an 8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:295
+msgid "Enter New PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:299
+msgid "PIN code should be a 4-8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:317
+msgid "Unlocking…"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:34
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:45
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:139
+msgid "_Mobile Data"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:140
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:151
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:152
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:177
+msgid "_Network Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:187
+msgid "N_etwork"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:199
+msgid "Advanced"
+msgstr "Talqayt"
+
+#: panels/wwan/cc-wwan-device-page.ui:225
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:235
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:236
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:246
+msgid "M_odem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Tamhelt ur tettusefrak ara"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Awal uffir d arameɣtu"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Ur yettwaf ara"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "Action Cancelled"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Access denied"
+msgstr "Addaf yugwi"
+
+#: panels/wwan/cc-wwan-errors-private.h:103
+msgid "Unknown Error"
+msgstr "Tuccḍa tarussint"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:4
+msgid "Network Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:44
+#: panels/wwan/cc-wwan-network-dialog.ui:175
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:230
+msgid "_Set"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:46 panels/wwan/cc-wwan-panel.ui:39
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:101
+msgid "Close"
+msgstr "Mdel"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:84
+msgid "_Automatic"
+msgstr "_Awurman"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:100
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:118
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.c:453 panels/wwan/cc-wwan-panel.c:482
+#, c-format
+msgid "SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:101
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:154
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:163
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:210
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:224
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:332
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:11
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:22
+msgid "_Next"
+msgstr "_Uḍfir"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:141
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:158
+msgid "Change PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:256
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#. FIXME
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:17
+msgid "GNOME Settings Sound Panel"
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:21
+msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:25
+msgid "GNOME Settings Background Panel"
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:29
+msgid "GNOME Settings Keyboard Panel"
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:38
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Sken amḍan n lqem"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr ""
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr ""
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr ""
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr ""
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr ""
+
+#: shell/cc-panel-list.ui:45 shell/cc-window.c:309
+msgid "Privacy"
+msgstr "Tabaḍnit"
+
+#: shell/cc-panel-loader.c:299
+msgid "Available panels:"
+msgstr ""
+
+#: shell/cc-window.ui:136
+msgid "All Settings"
+msgstr "Iɣewwaṛen akk"
+
+#: shell/cc-window.ui:174
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:318
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:319
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:330
+msgid "Help"
+msgstr "Tallelt"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Amatu"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Ffeɣ"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Anadi"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Sefsex anadi"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1907
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u n tuffɣa"
+msgstr[1] "%u n tuffɣiwin"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1917
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u n unekcum"
+msgstr[1] "%u n yinekcumen"
+
+#: subprojects/gvc/gvc-mixer-control.c:2867
+msgid "System Sounds"
+msgstr ""

--- a/po/kk.po
+++ b/po/kk.po
@@ -6,10 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-03-11 12:34+0000\n"
-"PO-Revision-Date: 2022-03-12 19:05+0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-09-18 13:06+0600\n"
 "Last-Translator: Baurzhan Muftakhidinov <baurthefirst@gmail.com>\n"
 "Language-Team: Kazakh <kk_KZ@googlegroups.com>\n"
 "Language: kk\n"
@@ -17,102 +16,9 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.0.1\n"
-
-#: panels/applications/cc-applications-panel.c:803
-msgid "System Bus"
-msgstr "Жүйелік шина"
-
-#: panels/applications/cc-applications-panel.c:803
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:823
-msgid "Full access"
-msgstr "Толық қатынау құқығы"
-
-#: panels/applications/cc-applications-panel.c:805
-msgid "Session Bus"
-msgstr "Сессия шинасы"
-
-#: panels/applications/cc-applications-panel.c:809
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Құрылғылар"
-
-#: panels/applications/cc-applications-panel.c:809
-msgid "Full access to /dev"
-msgstr "/dev бумасына толық қатынау құқығы"
-
-#: panels/applications/cc-applications-panel.c:813
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Желі"
-
-#: panels/applications/cc-applications-panel.c:813
-msgid "Has network access"
-msgstr "Желіге қатынау құқығы бар"
-
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:820
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Үй"
-
-#: panels/applications/cc-applications-panel.c:820
-#: panels/applications/cc-applications-panel.c:825
-msgid "Read-only"
-msgstr "Тек оқу үшін"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-msgid "File System"
-msgstr "Файлдық жүйе"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Баптаулар"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Can change settings"
-msgstr "Баптауларды өзгерте алады"
-
-#: panels/applications/cc-applications-panel.c:831
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s келесі құрамындағы рұқсаттарға ие. Оларды өзгерту мүмкін емес. Бұл "
-"рұқсаттар жөнінде қобалжысаңыз, бұл қолданбаны өшіру мүмкіндігін "
-"қарастырыңыз."
-
-#: panels/applications/cc-applications-panel.c:1164
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "Қолданбамен ашылатын %u файл және сілтеме түрлері"
-
-#: panels/applications/cc-applications-panel.c:1171
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> келесі түрдегі файлдар және сілтемелерді ашу үшін қолданылады."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1223
-#, c-format
-msgid "%s of disk space used"
-msgstr "Диск орнынан %s қолданылуда"
+"X-Generator: Poedit 3.1.1\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1387
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -128,7 +34,6 @@ msgid "Install some…"
 msgstr "Бірнешеуін орнату…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Ашу"
 
@@ -139,6 +44,10 @@ msgstr "Көбірек ақпарат"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Іздеу"
@@ -148,24 +57,13 @@ msgstr "Іздеу"
 msgid "Receive system searches and send results."
 msgstr "Жүйелік іздеулерді алу және нәтижелерді жіберу."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1900
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Сөндірулі"
 
@@ -179,7 +77,7 @@ msgid "Show system notifications."
 msgstr "Жүйелік хабарламаларды көрсету."
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+msgid "Run in Background"
 msgstr "Фонда орындау"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -187,131 +85,142 @@ msgid "Allow activity when the app is closed."
 msgstr "Қолданба жабылған кезде белсенділікті рұқсат ету."
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Скриншоттар"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Экран скриншоттарын кез келген уақытта түсіріңіз."
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "Тұсқағазды өзгерту"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "Жұмыс үстелі тұсқағазын өзгерту."
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Дыбыстар"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "Дыбыстарды ойнату."
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "Жарлықтарды басу"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "Жүйелік пернетақта жарлықтарын басу."
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "Камера"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "Суреттерді камерамен түсіру."
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "Микрофон"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "Дыбысты микрофонмен жазу."
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Орналасулар қызметі"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "Құрылғының орналасу деректеріне қатынау."
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "Құрамындағы рұқсаттар"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "Қолданба талап ететін жүйелік рұқсат"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "Файлдар мен сілтемелер ассоциациялары"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Сақтау құрылғылары"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Нәтижелер табылмады"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Басқа сөздерді іздеп көріңіз"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "Файлдар мен сілтемелер ассоциациялары"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "Файл түрлері"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "Сілтеме түрлері"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Тастау"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Бұл қолданба өз деректері мен кэш деректерімен қанша диск орнын алып тұр."
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Қолданба"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Деректер"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Кэш"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Жалпы</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Кэшті тазарту…"
 
@@ -319,91 +228,32 @@ msgstr "Кэшті тазарту…"
 msgid "Control various application permissions and settings"
 msgstr "Қолданбалардың түрлі рұқсаттарын және баптауларын басқару"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "application;flatpak;permission;setting;қолданба;рұқсат;баптау;"
-
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "Суретті таңдау"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:226
-#: panels/network/connection-editor/vpn-helpers.c:346
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "Ба_с тарту"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:227
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:524
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "А_шу"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "бірнеше өлшемдер"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Түсқағаз жоқ"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Ағымдағы фон"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Стиль"
 
-#: panels/background/cc-background-panel.ui:45
-msgid "Light"
-msgstr "Ашық түсті"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Бастапқы"
 
-#: panels/background/cc-background-panel.ui:72
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "Қараңғы"
 
-#: panels/background/cc-background-panel.ui:91
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Фон"
 
-#: panels/background/cc-background-panel.ui:97
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "Суретті қосу…"
 
@@ -415,52 +265,59 @@ msgstr "Сыртқы түрі"
 msgid "Change your background image or the UI colors"
 msgstr "Фон суретін немесе интерфейс түстерін өзгерту"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
-"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Фон;Түсқағаз;Экран;"
-"Жұмыс үстелі;Стиль;Ашық түсті;Қараңғы түсті;"
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;Фон;Түсқағаз;"
+"Экран;Жұмыс үстелі;Стиль;Ашық түсті;Қараңғы түсті;Сыртқы түрі;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Іске қосу"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Bluetooth адаптерлері табылмады"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Bluetooth қолдану үшін адаптер салыңыз."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth сөндірілген"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Құрылғылармен байланысу және файларды қабылдау үшін іске қосыңыз."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "Ұшақтағы режим іске қосулы тұр"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Ұшақтағы режим іске қосулы кезінде Bluetooth сөндірілген болады."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Ұшақтағы режимді сөндіру"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "Құрылғылық ұшақтағы режим іске қосулы тұр"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Bluetooth іске қосу үшін ұшақтағы режимді сөндіріңіз."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -469,20 +326,19 @@ msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 "Bluetooth-ды іске қосыңыз немесе сөндіріңіз және құрылғыларды байланыстырыңыз"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;бөлісу;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "Камера сөндірілген"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Суреттерді немесе видеоны ешбір қолданба түсіре алмайды."
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
@@ -494,7 +350,7 @@ msgstr ""
 "мүмкін.\n"
 "Төмендегі қолданбаларға камераны қолдануды рұқсат етіңіз."
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Ешбір қолданба Камераға қатынау рұқсатын сұрамады"
 
@@ -502,96 +358,35 @@ msgstr "Ешбір қолданба Камераға қатынау рұқсат
 msgid "Protect your pictures"
 msgstr "Суреттерді қорғау"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;экран;блоктау;диагностика;құлау;жеке;жуырдағы;уақытша;"
-"индекс;аты;желі;анықтағыш;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Калибрация құрылғысын шаршыға апарып, \"Бастау\" басыңыз"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "Калибрация құрылғысын калибрация орнына апарып, \"Жалғастыру\" басыңыз"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Калибрация құрылғысын бет орнына апарып, \"Жалғастыру\" басыңыз"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Қақпақты жабыңыз"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Өндеуге келмейтін ішкі қате орын алды."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Калибрация үшін керек саймандар орнатылмаған."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Профильді жасау мүмкін емес."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Мақсат ақ нүктесіне жету мүмкін емес."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Аяқталды!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Калибрация сәтсіз аяқталды!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Калибрация құрылғысын алып тастауға болады."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Үрдіс жүру кезінде калибрация құрылғысына тиіспеңіз"
+"camera;photos;video;webcam;lock;private;privacy;камера;фото;видео;веб-камера;"
+"блоктау;жеке;жекелік;"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Экран калибрациясы"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Ба_с тарту"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -605,142 +400,9 @@ msgstr "Жа_лғастыру"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Дайын"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Ноутбук экраны"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Құрамындағы вебкамера"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s мониторы"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s сканері"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s камерасы"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s принтері"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s вебкамерасы"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s үшін түстерді басқаруды іске қосу"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s үшін түстер профильдерін көрсету"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Калибрацияланбаған"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Бастапқы: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Түстер кеңістігі: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Сынама профилі: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "ICC профилі файлын таңдаңыз"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "И_мпорттау"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Қолдауы бар ICC профильдері"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Барлық файлдар"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Экран"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Профильді сақтау"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:347
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Сақтау"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Таңдалған құрылғы үшін түстер профилін жасау"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Өлшеу құрылғысы анықталмады, Оның іске қосулы екенін және дұрыс жалғанып "
-"тұрғанын тексеріңіз."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Өлшеу құрылғысы принтерлерді профильдеуді қолдамайды."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Құрылғының бұл түріне ағымда қолдау жоқ."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -858,9 +520,9 @@ msgstr "Жазуға болатын тасушыны талап етеді"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Түс профилін <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> "
 "және <a href=\"windows\">Microsoft Windows</a> жүйелерінде қалай пайдалану "
@@ -875,16 +537,16 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Мәселелер анықталды. Профиль дұрыс жұмыс жасамауы мүмкін. <a href="
-"\"\">Ақпаратын көрсету.</a>"
+"Мәселелер анықталды. Профиль дұрыс жұмыс жасамауы мүмкін. <a "
+"href=\"\">Ақпаратын көрсету.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
 msgstr "Файлды _импорттау…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "Қ_осу"
@@ -895,9 +557,7 @@ msgstr ""
 "Түстерін басқару үшін әр құрылғыда жаңа болып тұрған түстер профилі болуы "
 "керек."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Көбірек білу"
 
@@ -1029,82 +689,6 @@ msgstr "D65 (Фотосуреттер және графика)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Қалыпты кеңістік"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Профильді сынау"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Автоматты түрде"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Төмен сапалы"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Орташа сапалы"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Жоғары сапалы"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Бастапқы RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Бастапқы CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Бастапқы сұр"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Жасаушы ұсынған зауыттық калибрация ақпараты"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Бұл профильмен толық экран мониторын түзету мүмкін емес"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Бұл профиль дұрыс емес болуы мүмкін"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Түс"
@@ -1116,16 +700,11 @@ msgstr ""
 "Экрандар, камералар және принтерлер сияқты құрылғыларыңыздың түстерін "
 "калибрациялаңыз"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Color;ICC;Profile;Calibrate;Printer;Display;Түс;ICC;Профиль;Калибрациялау;"
 "Принтер;Экран;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Басқа…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1140,19 +719,14 @@ msgid "No languages found"
 msgstr "Тілдер табылмады"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Көбірек…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Параметрлерді өзгерту үшін бұғаттауын шешу"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "Кейбір баптауларды өзгерту үшін олардың бұғаттауын шешу керек."
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "Бұғаттауды шешу…"
 
@@ -1175,148 +749,6 @@ msgstr "Сағатты кеміту"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Минутты кеміту"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Бүгін"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Кеше"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d сағат"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d минут"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d секунд"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 секунд"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Қатынау нүктесі"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 сағат"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1399,32 +831,67 @@ msgstr "Автоматты түрде _күн және уақыт"
 msgid "Requires internet access"
 msgstr "Интернетпен байланысты талап етеді"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "Күн және уақы_т"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Автоматты түрде _уақыт белдеуі"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr ""
 "Орналасулар қызметінің іске қосылуын және интернетке қатынауды талап етеді"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Іске қосулы"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Уақыт бе_лдеуі"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Бұғаттауды шешу"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Уақыт пі_шімі"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Күндер"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 секунд"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Күнтізбе"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Сандар"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Күн мен уақытты (уақыт белдеуімен қоса) өзгерту"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;Сағат;Уақыт белдеуі;Орналасу;"
@@ -1470,22 +937,10 @@ msgstr "Үнсіз келісім қолданбалары"
 msgid "Configure Default Applications"
 msgstr "Үнсіз келісім қолданбаларын баптау"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "default;application;preferred;media;үнсіз келісім;қолданба;таңдамалы;тасушы;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Техникалық мәселелер жөнінде хабарламаларды жіберу бізге %s жақсартуға "
-"көмектеседі. Хабарламалар анонимды түрде жіберіледі және олардан жеке "
-"деректер кетіріледі. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1503,155 +958,116 @@ msgstr "Диагностика"
 msgid "Report your problems"
 msgstr "Мәселелер туралы хабарлау"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;экран;блоктау;диагностика;құлау;жеке;жуырдағы;"
-"уақытша;индекс;аты;желі;анықтағыш;жекелік;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:337
-#: panels/universal-access/cc-ua-panel.c:469
-#: panels/universal-access/cc-ua-panel.c:479
-#: panels/universal-access/cc-ua-panel.c:491
-#: panels/universal-access/cc-ua-panel.c:527
-msgid "On"
-msgstr "Іске қосулы"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:337
-#: panels/universal-access/cc-ua-panel.c:469
-#: panels/universal-access/cc-ua-panel.c:479
-#: panels/universal-access/cc-ua-panel.c:491
-#: panels/universal-access/cc-ua-panel.c:527
-msgid "Off"
-msgstr "Off"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "Өзгеірстерді іске асыру керек пе?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "Өзгерістерді іске асыру мүмкін емес"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "Бұл құрылғылық шектеулерден болуы мүмкін."
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;диагностика;құлау;"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "Іске _асыру"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Артқа"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr "Экран баптаулары сөндірулі тұр"
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "Экрандар орналасуы"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "Бірнеше экран"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "Қосылу"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Айналы"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Жоғарғы жолақ пен Белсенділіктерді қамтиды"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Біріншілік экран"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Түнгі жарық"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Жатық"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Тік, оң жақ"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Тік, сол жақ"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Жатық (айналған)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Гц"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Бағдары"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Ажыратылымдығы"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Жаңарту жиілігі"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Теледидар үшін баптау"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Масштабтау"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Табиғи айналдыру"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Түнгі жарық қолжетімді емес"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Бұл қолданылатын графикалық драйвердің немесе жұмыс үстелінің қашықтан "
+"қолданылуының нәтижесі болуы мүмкін"
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Ертеңге дейін уақытша сөндірілген"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "Сүзгіні қайта іске қосу"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1659,59 +1075,59 @@ msgstr ""
 "Түнгі жарық экран түстерін жылы қылады. Бұл көз тігуін және ұйқышылдыққа жол "
 "бермеуге көмектесуі мүмкін."
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Жоспар"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Күн батуынан күн шығысына дейін"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Қолмен жоспарлау"
 
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Уақыттар"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Бастап"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Сағат"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Минут"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "AM"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PM"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Дейін"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Түстік температурасы"
 
@@ -1723,7 +1139,6 @@ msgstr "Экран­дар"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Жалғанған мониторлар мен проекторларды қолдану тәсілін таңдаңыз"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1733,54 +1148,53 @@ msgstr ""
 "redshift;color;sunset;sunrise;Панель;Проектор;xrandr;Экран;Ажыратылымдығы;"
 "Жаңарту;Монитор;Түн;Жарық;Көк;түс;күннің шығуы;күннің батуы;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Белгісіз"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; Жинақ ID: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr "Қауіпсіздік деңгейі"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64-биттік"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Деңгей 1"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32-биттік"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Деңгей 2"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Деңгей 3"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Оқиғалар жоқ"
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Белгісіз"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Қолдауы жоқ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Жүйелік логотип"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;экран;блоктау;диагностика;құлау;жеке;жуырдағы;"
+"уақытша;индекс;аты;желі;анықтағыш;жекелік;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Құрылғы атауы"
 
@@ -1813,31 +1227,41 @@ msgstr "Есептеу…"
 msgid "OS Name"
 msgstr "ОЖ атауы"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ОЖ жинақ ID-і"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "ОЖ түрі"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "GNOME нұсқасы"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Жүктеу…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Терезе жүйесі"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Виртуализация"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Бағд. қамтама жаңартулары"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Құрылғы атын ауыстыру"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1845,7 +1269,11 @@ msgstr ""
 "Құрылғы атауы бұл құрылғыны желі арқылы қараған кезде немесе Bluetooth "
 "құрылғыларымен жұпталып жатқанда анықтау үшін қолданылады."
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Құрылғы атауы"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "Атын ауысты_ру"
 
@@ -1857,11 +1285,6 @@ msgstr "Осы туралы"
 msgid "View information about your system"
 msgstr "Жүйеңіз туралы ақпаратты қараңыз"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1941,6 +1364,12 @@ msgstr "Жөнелткіштер"
 msgid "Launch help browser"
 msgstr "Көмек шолушысын жөнелту"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Баптаулар"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Калькуляторды жөнелту"
@@ -1962,7 +1391,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Іздеу"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Жүйелік"
 
@@ -2011,20 +1440,11 @@ msgstr "Мәтін өлшемін кішірейту"
 msgid "High contrast on or off"
 msgstr "Жоғары контраст іске қосулы/сөндірулі"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Кіріс қайнар көздері табылмады"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Басқа"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Кіріс қайнар көзін қосу"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Енгізу тәсілдерін жүйеге кіру экранында қолдануға болмайды"
 
@@ -2032,122 +1452,29 @@ msgstr "Енгізу тәсілдерін жүйеге кіру экранынд
 msgid "No input source selected"
 msgstr "Кіріс қайнар көзді таңдалмады"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Опциялар"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "Жоғары жылжыту"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "Төмен жылжыту"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Баптаулар"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Пернетақта жаймасын қарау"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Өшіру"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Таңдауыңызша жарлықтар"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "Альтернативті таңбалар пернесі"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Балама таңбалар пернесін қосымша таңбаларды енгізу үшін пайдалануға болады. "
-"Олар кейде пернетақтадағы үшінші параметр ретінде көрсетіледі."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Сол жақ Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Оң жақ Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Сол жақ Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Оң жақ Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menu пернесі"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Оң жақ Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Compose пернесі"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Түрлендіру пернесі таңбалардың кең жиынтығын енгізуді мүмкін қылады. Оны "
-"қолдану үшін, түрлендіру пернесін басып, одан кейін таңдалар тізбегін "
-"теріңіз. Мысалы, түрлендіру пернесінен кейін <b>C</b> және <b>o</b> басылса, "
-"<b>©</b> енгізіледі, <b>a</b> мен <b>'</b> басылса, <b>á</b> егізіледі."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Енгізу қайнар көздерін %s пернетақта жарлығы көмегімен ауыстыруға болады.\n"
-"Бұл жарлықты пернетақта баптауларында өзгертуге болады."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2169,53 +1496,29 @@ msgstr "Бір кірі_с қайнар көзін барлық терезеле
 msgid "Switch input sources _individually for each window"
 msgstr "Әр терезе үшін кіріс қайнар көзін бө_лек өзгерту"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Арнайы таңбаларды енгізу"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Пернетақтаны пайдаланып таңбалар мен әріп нұсқаларын енгізу әдістері."
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Альтернативті таңбалар пернесі"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose пернесі"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Пернетақта жарлықтары"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Жарлықтарды қарау және баптау"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d өзгертілген"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
-msgid "Reset All Shortcuts?"
-msgstr "Барлық жарлықтарды тастау керек пе?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Жарлықтарды тастау таңдауыңызша жарлықтарды кетіруі мүмкін. Бұл әрекетті "
-"болдырмау мүмкін болмайды."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Болдырмау"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
-msgid "Reset All"
-msgstr "Барлығын тастау"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2225,98 +1528,87 @@ msgstr "Барлығын тастау…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Барлық жарлықтарды бастапқы мәндеріне тастау"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Санат"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Жарлықтар"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Жарлықты қосу"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Таңдауыңызша жарлықтарды қосу"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "Қолданбаларды жөнелту, скриптерді орындау және т.б. үшін таңдауыңызша "
 "жарлықтарды баптау."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Жарлықты қосу"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Пернетақта жарлықтары табылмады"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s жарлығы %s үшін қолданылуда болып тұр. Оны алмастырсаңыз, %s сөндірілетін "
-"болады"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Ө_шіру"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Жаңа пернетақта жарлығын енгізіңіз"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Ал_мастыру"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Таңдауыңызша жарлықты орнату"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "_Орнату"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Жарлықты орнату"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "%s өзгерту үшін жаңа жарлықты енгізіңіз."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Таңдауыңызша жарлықты қосу"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Қосу"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
-msgstr "Алмастыру"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "Орнату"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Бас тарту үшін Esc, ал, пернетақта жарлығын сөндіру үшін Backspace басыңыз."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Аты"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Команда"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Жарлық"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Жарлықты орнату…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Ешнәрсе"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Жарлықты бастапқы мәніне тастау"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_Бастапқы түріне келтіру"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2330,7 +1622,6 @@ msgstr ""
 "Пернетақта жарлықтарын өзгерту және теру баптауларын, пернетақта жаймаларын "
 "және кіріс қайнар көздерін орнату"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2339,15 +1630,15 @@ msgstr ""
 "Жарлық;Жұмыс орны;Терезе;Өлшемді өзгерту;Масштаб;Контраст;Енгізу;Қайнар көзі;"
 "Блоктау;Дыбыс;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "Орналасулар қызметі сөндірулі тұр"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Орналасу ақпаратын ешбір қолданба ала алмайды."
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2365,7 +1656,7 @@ msgstr ""
 "\n"
 "Төмендегі қолданбаларға орналасуыңызды қолдануды рұқсат етіңіз."
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Ешбір қолданба Орналасуға қатынау рұқсатын сұрамады"
 
@@ -2373,172 +1664,19 @@ msgstr "Ешбір қолданба Орналасуға қатынау рұқс
 msgid "Protect your location information"
 msgstr "Орналасу ақпаратын қорғау"
 
-#. FIXME
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Экран сөнеді"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;орналасу;жеке;жекелік;"
 
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 секунд"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 минут"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 минут"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74 panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 минут"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 минут"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 сағат"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Ешқашан"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
-msgstr ""
-"Экранды автоматты түрде бұғаттау басқалардың компьютерге кіруіне жол "
-"бермейді."
-
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "Экранды тазарту кідірісі"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Экран тазартылу үшін өтуі керек белсенсіздік мерзімі."
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "Экранды автоматты б_локтау"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "Экранды автоматты б_локтау кідірісі"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-"Экран тазартылғаннан кейін ол автоматты түрде бұғатталғанға дейінгі мерзімі."
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "_Хабарламаларды бұғаттау экранында көрсету"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "Жаңа USB құр_ылғыларын рұқсат етпеу"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Экран бұғатталған кезде жаңа USB құрылғыларының жүйемен өзара әрекеттесуін "
-"болдырмау."
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Экранды блоктау"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Экранды бұғаттау"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "Микрофон сөндірулі тұр"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Дыбыс жаза алатын қолданбалар табылмады."
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2551,7 +1689,7 @@ msgstr ""
 "соғуы мүмкін.\n"
 "Төмендегі қолданбаларға микрофонды қолдануды рұқсат етіңіз."
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Ешбір қолданба Микрофонға қатынау рұқсатын сұрамады"
 
@@ -2559,7 +1697,11 @@ msgstr "Ешбір қолданба Микрофонға қатынау рұқс
 msgid "Protect your conversations"
 msgstr "Сөйлесулерді қорғау"
 
-#. FIXME
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"microphone;recording;application;privacy;микрофон;жазу;қолданба;жекелік;"
+
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Ба_птауларды тексеру"
@@ -2577,83 +1719,150 @@ msgstr "Біріншілік батырма"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "Тышқандар және тачпадтарда физикалық батырмалар ретін орнатады."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Сол жақ"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Оң жақ"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Іздеу орналасулары"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Тышқан"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Тышқан курсорының жылдамдығы"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "Табиғи айналдыру"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Төмен айналдыру"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Айналдыру көріністі емес, құраманы жылжытады."
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Айналдыру көріністі емес, құраманы жылжытады."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "Үд_ету:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Белсенді"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Тачпад"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Тачпад жылдамдығы"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "Тә_сіл"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Шерту үшін тию"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "Қос саусақпен айналдыру"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr "Шерту үшін тию"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_Теру кезінде сөндіру"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Планшет (салыстырмалы)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Бұрышпен айналдыру"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Төмен айналдыру"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Екі жақты"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Шерту, қос шерту, айналдыруды көріңіз"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Бес рет шерту, GEGL уақыты!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Қос шерту, біріншілік батырма"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Бірлік шерту, біріншілік батырма"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Қос шерту, орта батырмасы"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Бірлік шерту, орта батырмасы"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Қос шерту, екіншілік батырма"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Бірлік шерту, екіншілік батырма"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2666,7 +1875,6 @@ msgstr ""
 "Тышқан немесе тачпад сезімталдығын өзгертіңіз және оң немесе солақай режимін "
 "көрсетіңіз"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -2748,86 +1956,39 @@ msgstr "Көптапсырмалылық"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Өнімділік және көптапсырмалылық баптауларын басқару"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
-"Multitasking;Multitask;Productivity;Customize;Desktop;көптапсырмалылық;"
-"өнімділік;баптау;жұмыс үстелі;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Қап, бірнәрсе қате кетті. БҚ өндірушісіне хабарласыңыз."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager орындалып тұруы тиіс."
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"көптапсырмалылық;өнімділік;баптау;жұмыс үстелі;ыстық бұрыш;жұмыс орындары;"
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Басқа құрылғылар"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Байланысты қосу"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Бапталмаған"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "Қорғалмаған желі (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "Қауіпсіз желі (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "Қауіпсіз желі (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "Қауіпсіз желі (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "Қауіпсіз желі"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Байланысқан"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Опциялар…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Қатынау нүктесін іске қосу нәтежесінде %s желісі ажыратылады, интернетке Wi-"
-"Fi арқылы байланысуға мүмкін болмайды."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Кем дегенде 8 таңбадан тұруы тиіс"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -2854,354 +2015,87 @@ msgid "Network Name"
 msgstr "Желі атауы"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Пароль"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Кездейсоқ парольді генерациялау"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Парольді автогенерациялау"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "Іс_ке қосу"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Қатынау нүктесін тоқтатып, барлық пайдаланушыларды үзу керек пе?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "Қа_тынау нүктесін тоқтату"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Ұшақтағы режимі"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Wi-Fi, Bluetooth және мобильді кеңжолақты байланыстарды сөндіреді"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Wi-Fi адаптерлері табылмады"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr ""
 "Сізде Wi-Fi адаптерінің бар болғанын, және оның іске қосылғанын тексеріңіз"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Ұшақтағы режимі іске қосулы"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Wi-Fi қолдану үшін сөндіру"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Wi-Fi қатынау нүктесі белсенді"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Мобильді құрылғылар байланысу үшін QR кодын сканерлей алады."
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Қатынау нүктесін сөндіру…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Көрінетін желілер"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager орындалып тұруы тиіс"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Қап, бірнәрсе қате кетті. БҚ өндірушісіне хабарласыңыз."
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x қауі_псіздігі"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Қауіпсіздік"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Сақтап қалу"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Тұрақты"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Кездейсоқ"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Тұрақты"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Осында енгізілген MAC адресі осы байланысты қолданатын желі құрылғысы үшін "
-"аппараттық мекенжай ретінде пайдаланылады. Бұл мүмкіндік MAC клондау немесе "
-"спуфинг ретінде белгілі. Мысалы: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Профиль %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Жақсартылған ашық"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Кәсіпорын"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Жоқ"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Ешқашан"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i күн бұрын"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Мб/с (%1.1f ГГц)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Мб/с"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Жоқ"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Әлсіз"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ОК"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Жақсы"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Тамаша"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 адресі"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "IPv6 адресі"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP адресі"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "Байланысты ұмыту"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "Байланыс профилін өшіру"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "VPN өшіру"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "Көбірек білу"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "автоматты"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Идентификация"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Адресті өшіру"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "Маршрутты өшіру"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ешнәрсе"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128 биттік кілті (Hex немесе ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128 биттік кілттік фразасы"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Динамикалық WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "Жеке WPA3"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3212,8 +2106,20 @@ msgstr "Сигнал деңгейі"
 msgid "Link speed"
 msgstr "Деректерді өткізу жылдамдығы"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Қауіпсіздік"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 адресі"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 адресі"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Құрылғы адресі"
 
@@ -3222,12 +2128,17 @@ msgid "Supported Frequencies"
 msgstr "Қолдауы бар жиіліктер"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Үнсіз келісім бойынша маршруты"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3241,12 +2152,12 @@ msgstr "_Автоматты түрде байланысу"
 msgid "Make available to _other users"
 msgstr "Басқа па_йдаланушыларға қолжетерлік қылу"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 "Өл_шенетін байланыс: деректер шектеулері бар немесе ақыны талап етуі мүмкін"
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3291,7 +2202,7 @@ msgstr "Тек жергілікті желі үшін"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Қолмен"
 
@@ -3311,33 +2222,32 @@ msgid "Addresses"
 msgstr "Адрестер"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Адрес"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Желі маскасы"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Шлюз"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Автоматты түрде"
 
@@ -3346,29 +2256,34 @@ msgstr "Автоматты түрде"
 msgid "Automatic DNS"
 msgstr "Автоматты DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS сервері мекенжай(лар)ы"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "IP адрестерін үтірлермен ажыратыңыз"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Бағдарлар"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Автоматты бағдарлар"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Метрика"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Бұл байланысты тек ол өзі жатқан желі ішіндегі ресурстар үшін қ_олдану"
 
@@ -3381,83 +2296,13 @@ msgid "Automatic, DHCP only"
 msgstr "Автоматты түрде, тек DHCP"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Префикс"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Байланыстар түзеткішін ашу мүмкін емес"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Жаңа профиль"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Файлдан импорттау…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "VPN қосу"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Қауі_псіздік"
-
-#: panels/network/connection-editor/vpn-helpers.c:191
-msgid "Cannot import VPN connection"
-msgstr "VPN байланысын импорттау мүмкін емес"
-
-#: panels/network/connection-editor/vpn-helpers.c:193
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"\"%s\" файлын оқу мүмкін емес, немесе оның ішінде танылған VPN байланыс "
-"ақпараты жоқ\n"
-"\n"
-"Қате: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:223
-msgid "Select file to import"
-msgstr "Импорттау үшін файлды таңдаңыз"
-
-#: panels/network/connection-editor/vpn-helpers.c:276
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "\"%s\" аты бар файл бар болып тұр."
-
-#: panels/network/connection-editor/vpn-helpers.c:278
-msgid "_Replace"
-msgstr "А_лмастыру"
-
-#: panels/network/connection-editor/vpn-helpers.c:280
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "%s орнына сіз сақтаймын деген VPN байланысын сақтау керек пе?"
-
-#: panels/network/connection-editor/vpn-helpers.c:315
-msgid "Cannot export VPN connection"
-msgstr "VPN байланысын экспорттау мүмкін емес"
-
-#: panels/network/connection-editor/vpn-helpers.c:317
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"\"%s\" VPN байланысын %s ішіне экспорттау мүмкін емес.\n"
-"\n"
-"Қате: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:343
-msgid "Export VPN connection"
-msgstr "VPN байланысын экспорттау"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3471,106 +2316,49 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Желі"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Интернетке қалай байланысатыныңызды басқару"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;Желі;Сымсыз;"
 "Прокси;Кеңжолақты;Модем;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Wi-Fi желілеріне қалай байланысатыныңызды басқару"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;Желі;Сымсыз;"
 "Кеңжолақты;Қатынау;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "ешқашан"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "бүгін"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "кеше"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Соңғы қолданылған"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Сымды"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Жаңа байланысты қосу"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Таңдалған желілер үшін желі ақпараты, парольдер және таңдауыңызша жасалған "
-"баптаулар жоғалатын болады."
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "Ұ_мыту"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Белгілі Wi-Fi желілері"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "Ұ_мыту"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Қатынау нүктесі ретінде қолдануды жүйелік саясат рұқсат етпейді"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Сымсыз құрылғы қатынау нүкте режимін қолдамайды"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Баптау сілтемесі көрсетілмеген кезде веб проксиін автоанықтау қолданылады."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Бұл әрекет сенімсіз ортақ желілері үшін ұсынылмайды."
-
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Құрылғыны сөндіру"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Белсенді"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3581,47 +2369,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Провайдер"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP адресі"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Желілік прокси"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP прокси"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "HTTPS п_роксиі"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "FTP пр_оксиі"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Socks _хосты"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "Хо_сттарды елемеу"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "HTTP прокси порты"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "HTTPS прокси порты"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "FTP прокси порты"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Socks прокси порты"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "_Баптау URL-ы"
 
@@ -3648,300 +2440,21 @@ msgstr "Пароль"
 msgid "Turn Wi-Fi off"
 msgstr "Wi-Fi сөндіру"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Көбірек опциялар…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "Жасырын желісіне байланы_су…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Wi-Fi қатынау нүктесін іске қ_осу…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "Бел_гілі Wi-Fi желілері"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Қалып-күйі белгісіз"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Басқарылмайтын"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Қолжетерсіз"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Қосылуда"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Аутентификация керек"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Байланысты үзу"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Байланыс орнату сәтсіз"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Қалып-күйі белгісіз (жоқ болып тұр)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Баптау сәтсіз"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP баптауы сәтсіз"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP баптауы ескірген"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Құпия кілттері сұралды, бірақ ұсынылмады"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x supplicant байланысы ажыратылған"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x supplicant баптауы сәтсіз"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x supplicant сәтсіз"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant аутентификация үшін тым көп уақыт алған"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP қызметі іске қосыла алмады"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP қызметі байланысты үзген"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP сәтсіз аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP клиенті іске қосылу қатесі"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP клиент қатесі"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP клиенті сәтсіз аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Ортақ етілген байланыс қызметінің іске қосылу қатесі"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Ортақ етілген байланыс қызметі сәтсіз аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP қызметінің іске қосылу қатесі"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP қызметінің қатесі"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP қызметі сәтсіз аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Арна бос емес"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Арнада гудок жоқ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Тасушыны орнату мүмкін емес"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Қоңырауға бөлінген уақыт аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Қоңырау соғу сәтсіз аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Модемді іске қосу сәтсіз аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Көрсетілген APN таңдау сәтсіз аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Желілерді іздемеу"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Желіге тіркелу тайдырылған"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Желіге тіркелудің мерзімі біткен"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Сұралған желіге тіркелу сәтсіз аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN кодын тексеру сәтсіз"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Құрылғы үшін бинарлық кодтар жоқ болуы мүмкін"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Байланыс жоғалды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Бар болып тұрған байланыс алынды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Модем табылмады"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth байланысы сәтсіз аяқталды"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM картасы салынбаған"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM Pin коды керек"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM Puk коды керек"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM қате"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Байланыс тәуелділігі сәтсіз аяқталды"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Бинарлы кодтары жоқ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Кабель ажыратылған"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "802.1X қауіпсіздігі (wpa-eap) ішіндегі анықталмаған қате"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "файл таңдалмады"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "eap-method файлын растаудағы анықталмаған қате"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, немесе PKCS#12 жеке кілттері (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER немесе PEM сертификаттары (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "EAP-FAST PAC файлы жоқ"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC файлдары (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -3991,14 +2504,6 @@ msgstr "Ішкі _аутентификация"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Автоматты PAC ұсы_нуды рұқсат ету"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "EAP-LEAP пайдаланушы аты жоқ"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "EAP-LEAP паролі жоқ"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4011,7 +2516,7 @@ msgstr "Па_йдаланушы аты"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Пароль"
 
@@ -4023,15 +2528,6 @@ msgstr "_Пароль"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Пар_ольді көрсету"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "жарамсыз EAP-PEAP CA сертификаты: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "жарамсыз EAP-PEAP CA сертификаты: сертификат көрсетілмеген"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4054,7 +2550,6 @@ msgid "C_A certificate"
 msgstr "С_О сертификаты"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4069,63 +2564,6 @@ msgstr "СО сертификаты _керек емес"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _нұсқасы"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "EAP пайдаланушы аты жоқ"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "EAP паролі жоқ"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "EAP-TLS identity жоқ"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "жарамсыз EAP-TLS CA сертификаты: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "жарамсыз EAP-TLS CA сертификаты: сертификат көрсетілмеген"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "жарамсыз EAP-TLS жеке кілті: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "жарамсыз EAP-TLS пайдаланушы сертификаты: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Шифрленбеген жеке кілттері қауіпсіз емес болады"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Таңдалған жеке кілт парольмен қорғалмаған сияқты. Бұл сіздің қауіпсіздік "
-"есептік жазба деректерінің әшкерелеуіне әкеп соғуы мүмкін. Парольмен "
-"қорғалған жеке кілтті таңдаңыз.\n"
-"\n"
-"(Сіз жеке кілтіңізді openssl көмегімен парольмен қорғай аласыз)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Жеке сертификатыңызды таңдаңыз"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Жеке кілтіңізді таңдаңыз"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4142,15 +2580,6 @@ msgstr "Жеке _кілт"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Жеке _кілт паролі"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "жарамсыз EAP-TTLS CA сертификаты: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "жарамсыз EAP-TTLS CA сертификаты: сертификат көрсетілмеген"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4173,14 +2602,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "До_мен"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "802.1X қауіпсіздігін тексерудің белгісіз қатесі"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4208,60 +2638,10 @@ msgstr "Қорғалған EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "Аутен_тификация"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Файлды таңдау"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "leap-username жоқ"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "leap-password жоқ"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Wi-Fi паролі жоқ."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "Тү_рі"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "wep-key жоқ"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"жарамсыз wep-key: ұзындығы %zu кілт ішінде тек оналтылық сандар болуы тиіс"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"жарамсыз wep-key: ұзындығы %zu кілт ішінде тек ascii таңбалары болуы тиіс"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"жарамсыз wep-key: кілт ұзындығы %zu қате. Кілт ұзындығы 5/13 (ascii) немесе "
-"10/26 (оналтылық) болуы тиіс"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "жарамсыз wep-key: кілттік фраза бос емес болуы тиіс"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "жарамсыз wep-key: кілттік фраза 64 таңбадан аз болуы тиіс"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4286,21 +2666,6 @@ msgstr "Кіл_тті көрсету"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP и_ндексі"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"жарамсыз wpa-psk: кілт ұзындығы %zu жарамсыз. Ол [8,63] байт немесе 64 "
-"оналтылық сан болуы тиіс"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"жарамсыз wpa-psk: 64 байты бар кілтті он алтылық кілт ретінде талдау мүмкін "
-"емес"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4355,60 +2720,35 @@ msgstr "Б_локтау экранының хабарламалары"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Қай хабарламалар және олар нені көрсететінін басқару"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Notifications;Banner;Message;Tray;Popup;Хабарлаулар;Баннер;Хабарлама;Трей;"
 "Қалқымалы;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "%s өшірілді"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Басқа"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Тіркелгіні өшіру қатесі"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Болдырмау"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Хабарламаны жабу"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "Бұлттық қызметтердегі деректеріңізге байланысыңыз"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "Интернетпен байланыс жоқ — желілік тіркелгілерді баптау үшін интернетке "
 "байланысты орнатыңыз"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Тіркелгіні қосу"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:426
-#, c-format
-msgid "%s Account"
-msgstr "%s тіркелгісі"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:429
-msgid "Remove Account"
-msgstr "Тіркелгіні өшіру"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4420,10 +2760,6 @@ msgstr ""
 "Желілік тіркелгілеріңізге байланыс орнатыңыз және олар не үшін "
 "қолданылатынын шешіңіз"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4432,10 +2768,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;Веб;Онлайн;Чат;Күнтізбе;Эл. пошта;"
 "Контакт;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Уақыты белгісіз"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4449,13 +2781,6 @@ msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i сағат"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4465,188 +2790,6 @@ msgstr[0] "сағат"
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "минут"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s толық зарядқа дейін"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Ескерту: %s қалды"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s қалды"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Толық зарядталған"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Зарядталуда емес"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Бос"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Зарядталуда"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Зарядын беруде"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Сымсыз тышқан"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Сымсыз пернетақта"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Үзіліссіз эл. қорек көзі"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Жеке цифрлық көмекші"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Ұялы телефон"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Медиа плеері"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Планшет"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Компьютер"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Ойын құрылғысы"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Батарея"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Басты"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Қосымша"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Батареялар"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "І_ссіз кезінде"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "Ұйықтату"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "Сөндіру"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "Гибернация"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "Ешнәрсе"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "Батареядан жұмыс істеген кезде"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "Эл. желісінде"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Ешқашан"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "Автоматты түрде ұйықтату"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "Өнімділік режимі уақытша жоғары температура салдарынан сөндірілген."
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Тізе анықталды: өнімділік режимі уақытша қолжетімсіз. Оны қалпына келтіру "
-"үшін, құрылғыны тұрақты жерге ораластырыңыз."
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr "Өнімділік режимі уақытша сөндірілген."
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Батарея заряды аз: эл. қорегін үнемдеу іске қосылған. Батарея жеткілікті "
-"зарядталған кезде алдыңғы режим қалпына келтіріледі."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Эл. корегін сақтау режимін \"%s\" белсендірген."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Өнімділік режимін \"%s\" белсендірген."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4708,6 +2851,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 сағат"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батарея"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Құрылғылар"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Эл. қуаты режимі"
@@ -4728,89 +2880,62 @@ msgstr "Автоматты экран жарықтылығы"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "Экран жарықтылығы айналадағы жарыққа бейімделеді."
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Экранды бәсеңдету"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "Компьютер жұмыс істемей тұрғанда экран жарықтығын төмендетеді."
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "Экранды _бос қылу"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "Әрекетсіздік кезеңінен кейін экранды сөндіреді."
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Автоматты түрде эл. қорегін сақтау"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr "Батарея төмен болғанда эл. қорек үнемдеу режимін іске қосу."
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "_Автоматты түрде ұйықтату"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "Компьютерді әрекетсіздік кезеңнен кейін аялдатады."
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Эл. қ_орегі батырмасының мінез-құлығы"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Батарея _пайызын көрсету"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Автоматты түрде ұйықтату"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "Эл. желісіне қосы_лған кезде"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "_Батареядан жұмыс істеу кезінде"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Кідіріс"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Өнімділік"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Жоғары өнімділік және қуатты пайдалану."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Баланс"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Стандартты өнімділік және қуатты пайдалану."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Қорек үнемдеу"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Төмендетілген өнімділік және қуатты пайдалану."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4820,7 +2945,6 @@ msgstr "Эл. қорегі"
 msgid "View your battery status and change power saving settings"
 msgstr "Батарея қалып-күйін және эл. қорегін сақтауды баптау"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4829,27 +2953,6 @@ msgstr ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;Эл. қорегі;Ұйқы;Ұйықтату;Гибернация;Батарея;Жарықтылық;Басу;Бос;"
 "Монитор;Іссіз;Энергия;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "\"%s\" принтері өшірілді"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "Жаңа принтерді қосу сәтсіз аяқталды."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui жүктеу мүмкін емес: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Принтерлерді қосу және параметрлерді өзгерту үшін бұғаттауын шешіңіз"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4861,7 +2964,6 @@ msgstr ""
 "Принтерлерді қосу, принтер тапсырмаларын қарау және баспаға шығарылатын "
 "нәрсені таңдау"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -4871,94 +2973,71 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Принтерді қосу"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Босату"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Принтерлер табылмады"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Желілік адресін енгізіңіз немесе принтерді іздеп көріңіз"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Аутентификация керек"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Баспаға шығару серверіндегі принтерлерді қарау үшін пайдаланушы атын және "
 "пароліңізді енгізіңіз."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Пайдаланушы аты"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "%s ақпараты"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Принтер атауында БОС_АРАЛЫҚ, ТАБУЛЯЦИЯ, # немесе / болмауы тиіс"
 
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Сәйкес келетін драйвер табылмады"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "PPD айлын таңдаңыз"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript принтер сипаттау файлдары (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Орналасуы"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Драйвер"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Таңдаулы драйверлерді іздеу…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Драйверлерді іздеу"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Дерекқордан таңдау…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "PPD файлын орнату…"
 
@@ -4970,132 +3049,19 @@ msgstr "Принтер драйверін таңдау"
 msgid "Loading drivers database…"
 msgstr "Драйверлер дерекқорын жүктеу…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Болдырмау"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Таңдау"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect принтері"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD принтері"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Бір жақты"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Ұзын жағымен"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Қысқа жағымен"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Тік"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Жатық"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Теріс жатық"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Теріс тік"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "Кезекте"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "Аялдатылған"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Аутентификация керек"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "Өңдеуде"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Тоқтатылды"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Бас тартылған"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Үзілді"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Аяқталған"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "Бұл тапсырманы кезек басына жылжыту"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u тапсырма аутентификацияны талап етеді"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Белсенді тапсырмалар"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr ""
-"%s жерінде баспаға шығару үшін пайдаланушы атын және пароліңізді енгізіңіз."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5104,341 +3070,35 @@ msgid "Domain"
 msgstr "Домен"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "Аут_ентификация"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Барлығын тазарту"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Аутентификациялау"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Белсенді принтер тапсырмалары жоқ"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Баспаға шығару серверін блоктаудан босату"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s босату."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"%s жеріндегі принтерлерді қарау үшін пайдаланушы атын және пароліңізді "
-"енгізіңіз."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Принтерлерді іздеу"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Тізбектей порт"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Параллельді порт"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Орналасуы: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Адресі: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Сервер аутентификацияны талап етеді"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Екі жақты"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Қағаз түрі"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Қағаз көзі"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Шығыс сөресі"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Ажыратылымдығы"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript алдын-ала сүзгілеу"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Бір жақтағы парақтар"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Екі жақты"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Бағдары"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Жалпы"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Парақ баптаулары"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Орнатуға келетін опциялар"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Тапсырма"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Сурет сапасы"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Түс"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Аяқтау"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Кеңейтілген"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Сынау парағы"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Сынау парағы"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Авто таңдау"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Принтердің негізгісі"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Тек GhostScript қаріптерін ілестіру"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "PS 1 деңгейіне түрлендіру"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "PS 2 деңгейіне түрлендіру"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Алдын-ала сүзгілеу жоқ"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Шығарушы"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Белсенді тапсырмалар жоқ"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u тапсырма"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Баспа бастиектерін тазарту"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Тонер аз"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Тонер жоқ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Айқындауышы аз"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Айқындауышы бітті"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Тонер бітіп жатыр"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Тонер бітті"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Қақпағы ашық"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Есігі ашық"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Қағазы аз"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Қағаз бітті"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Желіде емес"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Тоқтатылды"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Қоқысты қабылдағыш толуға жақын"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Қоқысты қабылдағыш толып қалды"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Фоторезист жақында жарамсыз болып қалады"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Фоторезист жұмыс істемейді"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Дайын"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Тапрсырмаларды қабылдамайды"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Өңдеуде"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5462,41 +3122,45 @@ msgstr "Баспа бастиектерін тазарту"
 msgid "Remove Printer"
 msgstr "Принтерді өшіру"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Белсенді тапсырмалар жоқ"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Модель"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Сия деңгейі"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Мәселе шешілген кезде жүйені қайта іске қосыңыз."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Қайта қосу"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Принтерді қосу…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Принтерді қосу…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Принтерлер жоқ"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Принтерді қосу…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5504,48 +3168,33 @@ msgstr ""
 "Кешіріңіз! Жүйелік баспаға шығару қызметі\n"
 "    қолжетімді емес сияқты."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Пішімдер"
-
-#: panels/region/cc-format-chooser.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "Артқа"
 
 #: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr "Локальдерді іздеу…"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Жалпы пішімдер"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Барлық пішімдер"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Іздеу нәтижелері жоқ"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Іздеулер елдер немесе тілдер үшін болуы мүмкін."
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Алдын-ала қарау"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Империялық"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Метрлік"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5577,26 +3226,31 @@ msgstr "Жүйеден шығу…"
 
 #: panels/region/cc-region-panel.ui:45
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
 "Интерфейс мәтіні және веб-беттер үшін қолданылатын тіл. Пішімдер сандар, "
 "күндер және валюталар үшін қолданылады."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Тілдерді орнату..."
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Сіздің тіркелгіңіз"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Тіл"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Пішімдер"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Жүйеге кіру экраны"
 
@@ -5608,99 +3262,9 @@ msgstr "Аймақ және тіл баптаулары"
 msgid "Select your display language and formats"
 msgstr "Экран тілі және пішімдерді таңдаңыз"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;Тіл;Жайма;Пернетақта;Енгізу;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Не істеуді сұрау"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Ешнәрсе жасамау"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Буманы ашу"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Басқа тасушылар"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Аудио CD үшін қолданбаны таңдаңыз"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Видео DVD үшін қолданбаны таңдаңыз"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Музыкалық плеері салынған кезде жөнелтілетін қолданбаны таңдаңыз"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Камера байланысқан кезде жөнелтілетін қолданбаны таңдаңыз"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "БҚ CD дискілері үшін қолданбаны таңдаңыз"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "аудио DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "таза Blu-Ray дискі"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "таза CD-R дискі"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "таза DVD+R дискі"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "таза HD DVD дискі"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray видео дискі"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "электронды кітаптарды оқу құрылғысы"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD видео дискі"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows БҚ"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5750,7 +3314,6 @@ msgstr "Ауыстырмалы тасушылар"
 msgid "Configure Removable Media settings"
 msgstr "Ауыстырмалы тасушыларды баптау"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5760,13 +3323,79 @@ msgstr ""
 "removable;media;autorun;құрылғы;жүйе;үнсіз келісім;қолданба;таңдамалы;аудио;"
 "видео;диск;ауыстырмалы;тасушы;автожөнелту;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Орналасуды таңдау"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Экранды блоктау"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_ОК"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Экранды автоматты түрде бұғаттау басқалардың компьютерге кіруіне жол "
+"бермейді."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Экранды тазарту кідірісі"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Экран тазартылу үшін өтуі керек белсенсіздік мерзімі."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Экранды автоматты б_локтау"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Экранды автоматты б_локтау кідірісі"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Экран тазартылғаннан кейін ол автоматты түрде бұғатталғанға дейінгі мерзімі."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Хабарламаларды бұғаттау экранында көрсету"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Б_локтау экраны"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Жаңа USB құр_ылғыларын рұқсат етпеу"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Экран бұғатталған кезде жаңа USB құрылғыларының жүйемен өзара әрекеттесуін "
+"болдырмау."
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr "Экран жекелігі"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr "Көру бұрышын шектеу"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Экран"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Экран баптаулары"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;экран;блоктау;жеке;жекелік;"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5784,21 +3413,17 @@ msgstr ""
 msgid "Places"
 msgstr "Орындар"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Бетбелгілер"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "Басқалар"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Орналасуды қосу"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Қолданбалар табылмады"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5825,67 +3450,15 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "Көріністе қай қолданбалар іздеу нәтижелерін көрсететінінді басқарыңыз"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Search;Find;Index;Hide;Privacy;Results;Іздеу;Табу;Индекс;Жасыру;Жекелік;"
 "Нәтижелер;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "Бөлісу үшін желілер таңдалмады"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Желілер"
-
-#: panels/sharing/cc-sharing-panel.c:367
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Іске қосулы"
-
-#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Сөнд."
-
-#: panels/sharing/cc-sharing-panel.c:399
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Іске қосулы"
-
-#: panels/sharing/cc-sharing-panel.c:402
-msgctxt "service is active"
-msgid "Active"
-msgstr "Белсенді"
-
-#: panels/sharing/cc-sharing-panel.c:520
-msgid "Choose a Folder"
-msgstr "Буманы таңдау"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:748
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Файлдармен бөлісу көмегімен ағымдағы желіде сіздің Ортақ бумаңызды келесі "
-"адрес арқылы бөлісе аласыз: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:754
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Қашықтан байланысу іске қосылған болса, қашықтағы пайдаланушылар Secure "
-"Shell командасы көмегімен байланыса алады:\n"
-"%s"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -5925,12 +3498,12 @@ msgstr "Парольді _талап ету"
 msgid "Remote Login"
 msgstr "Қашықтан кіру"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "Қашықтағы жұмыс үстелі"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
@@ -5938,71 +3511,78 @@ msgstr ""
 "Қашықтағы жұмыс үстелі жұмыс үстелін басқа компьютерден көруге және "
 "басқаруға мүмкіндік береді."
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr "Бұл компьютерге қашықтан кіруді іске қосу немесе сөндіру."
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "Қашықтан басқару"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
 msgstr "Бұл экранды басқаруға қашықтан байланыстарды рұқсат ету."
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
 msgstr "Байланысу жолы"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
 "Құрылғы атауын немесе қашықтағы жұмыс үстелі адресін пайдаланып осы "
 "компьютерге қосылу."
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Көшіру"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "Қашықтағы жұмыс үстел адресі"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "Аутентификация"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr ""
 "Осы компьютерге қосылу үшін пайдаланушы аты мен пароль міндетті түрде керек."
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "Пайдаланушы аты"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "Шифрлеуді тексеру"
 
-#: panels/sharing/cc-sharing-panel.ui:430
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr "Шифрлеу баспасы"
 
-#: panels/sharing/cc-sharing-panel.ui:431
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
 "Шифрлеу баспасы байланысатын клиенттерде көрінеді және өзара бірдеу болуы "
-"тиіс"
+"тиіс."
 
-#: panels/sharing/cc-sharing-panel.ui:463
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Медиамен бөлісу"
 
-#: panels/sharing/cc-sharing-panel.ui:485
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Музыка, фотосуреттер және видеолармен желі арқылы бөлісу."
 
-#: panels/sharing/cc-sharing-panel.ui:498
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Бумалар"
 
@@ -6010,7 +3590,6 @@ msgstr "Бумалар"
 msgid "Control what you want to share with others"
 msgstr "Басқалармен немен бөлісуді таңдау"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6028,38 +3607,37 @@ msgstr "Қашықтан кіруді іске қосу немесе сөнді�
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Қашықтан кіруді іске қосу немесе сөндіру үшін аутентификация керек"
 
-#: panels/sound/cc-alert-chooser.c:150
-msgid "Custom"
-msgstr "Таңдауыңызша"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Иттің үруі"
+msgid "Click"
+msgstr "Шерту"
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "Тамшылау"
+msgid "String"
+msgstr "Жол"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "Шыны"
+msgid "Swing"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "Сонар"
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Теңгерім"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Сөндіру"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Артқы"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Бет жағы"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Сынау \"%s\""
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6069,58 +3647,53 @@ msgstr "Сынау үшін динамикті таңдаңыз"
 msgid "System Volume"
 msgstr "Жұйелік дыбыс"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Негізгі дыбыс"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Дыбыс деңгейлері"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Шығыс"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Шығыс құрылғысы"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Сынау"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Баптаулар"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "Теңгерім"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "Сөндіру"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Сабвуфер"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Кіріс"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Енгізу құрылғысы"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Том"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Хабарлама дыбысы"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Дыбысты өшіру"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6130,7 +3703,6 @@ msgstr "Дыбыс"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Дыбыс деңгейлерін, кіріс, шығыстарын және дыбыспен хабарлауды өзгерту"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6138,169 +3710,60 @@ msgstr ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 "Карта;Микрофон;Дыбыс;Басылу;Баланс;Құлаққап;Аудио;Шығыс;Кіріс;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Ажыратылған"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Байланысуда"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Байланысқан"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Авторизация қатесі"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Авторизациялауда"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Мүмкіндіктері шектелген"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Байланысқан және авторизацияланған"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Белгісіз"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Авторизацияланған уақыты:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Байланысқан уақыты:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Тіркелген уақыты:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Құрылғыны авторизациялау қатесі: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Құрылғыны ұмыту қатесі: "
-
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] "Басқа %u құрылғыға тәуелді"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Хабарламаны жабу"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Аты:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Қалып-күйі:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Авторизациялау және байланысу"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Құрылғыны ұмыту"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Қате"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt қолдауы жоқ"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Авторизацияланған"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Thunderbolt ішкі жүйесіне байланысу мүмкін емес."
 
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Thunderbolt қолдау жүйесі (boltd) орнатылмаған, немесе дұрыс бапталмаған."
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Тікелей қатынау"
 
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 "Док станциялар және сыртқы видеокарталар сияқты құрылғылар үшін тікелей "
 "режимін рұқсат ету."
 
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Тек USB және Display Port құрылғыларын жалғауға болады."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt анықтау мүмкін емес.\n"
-"Жүйеде Thunderbolt қолдауы жоқ, немесе ол BIOS-та сөндірілген болуы мүмкін, "
-"немесе BIOS-та қолдауы жоқ қауіпсіздік деңгейі орнатылған болуы мүмкін."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt қолдауы BIOS-та сөндірілген."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Thunderbolt қауіпсіздік деңгейін анықтау мүмкін емес."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Тікелей режимін ауыстыру қатесі: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
-msgid "No Thunderbolt Support"
-msgstr "Thunderbolt қолдауы жоқ"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:104
-msgid "Could not connect to the thunderbolt subsystem."
-msgstr "Thunderbolt ішкі жүйесіне байланысу мүмкін емес."
-
-#: panels/thunderbolt/cc-bolt-panel.ui:153
-msgid "Direct Access"
-msgstr "Тікелей қатынау"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Кезектегі құрылғылар"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Жалғанған құрылғылар жоқ"
 
@@ -6312,7 +3775,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Thunderbolt құрылғыларын басқару"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;жекелік;"
@@ -6321,16 +3783,16 @@ msgstr "Thunderbolt;privacy;жекелік;"
 msgid "Cursor Blinking"
 msgstr "Курсор жыпылықтауы"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Курсор мәтіндік өрістерде жыпылықтайды."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Жылдамдығы"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Курсордың жыпылықтау жиілігі"
 
@@ -6417,15 +3879,15 @@ msgstr "Үлкен"
 msgid "Repeat Keys"
 msgstr "Пернелер қайталануы"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Перне басулы кезінде перне басулары қайталанады."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Қайталану кідірісі"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Қайталану жылдамдығы"
 
@@ -6507,46 +3969,13 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Ұзақ"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "Пернетақтамен іск_е қосу"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Арнайы мүмкіндіктерді пернетақта көмегімен іске қосу және сөндіру"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Бастапқы"
-
-#: panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Орташа"
-
-#: panels/universal-access/cc-ua-panel.c:363
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Үлкен"
-
-#: panels/universal-access/cc-ua-panel.c:366
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Үлкенірек"
-
-#: panels/universal-access/cc-ua-panel.c:369
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Ең үлкен"
-
-#: panels/universal-access/cc-ua-panel.c:373
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d пиксель"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6662,31 +4091,6 @@ msgstr "Толық _экранмен жыпылықтау"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Толық _тереземен жыпылықтау"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Қысқа"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "Экранның ¼ бөлігі"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "Экранның ½ бөлігі"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "Экранның ¾ бөлігі"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Ұзақ"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6843,7 +4247,6 @@ msgstr "Түс эффектілері"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Көру, есту, теру, көрсету және шертуді жеңілдету"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -6858,114 +4261,6 @@ msgstr ""
 "контраст;курсор;дыбыс;масштаб;экран;оқу;үлкен;жоғары;мәтін;қаріп;өлшем;"
 "жабысқақ;баяу;қайталанатын;қос;шерту;кідіріс;жылдамдық;көмекші;қайталау;"
 "жыпылықтау;визуалды;есту;аудио;теру;анимациялар;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 сағат"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 күн"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 күн"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 күн"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 күн"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 күн"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 күн"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 күн"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 күн"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 күн"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Қоқыс шелегінен барлық нәрсені өшіру керек пе?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Қоқыс шелегінен барлық нәрселер толығымен өшіріледі."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Қоқыс шел_егін тазарту"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Барлық уақытша файлдарды өшіру керек пе?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Барлық уақытша файлдар толығымен өшіріледі."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Уақытша файлдарды _тазарту"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 күн"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 күн"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 күн"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Мәңгі"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7034,57 +4329,13 @@ msgstr "Файлдар тарихы және қоқыс шелегі"
 msgid "Don't leave traces"
 msgstr "Із қалдырмау"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Логинді ұсынушының веб адресіне сәйкес болуы тиіс."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Тіркелгіні қосу сәтсіз"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:258
-msgid "The passwords do not match."
-msgstr "Парольдер өзара сәйкес емес."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Тіркелгіні тіркеу сәтсіз аяқталды"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Бұл доменде аутентификациялаудың қолдауы бар тәсілдері жоқ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Доменде тіркелу сәтсіз"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Бұл логин fns жасамады.\n"
-"Қайталап көріңіз."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Бұл логин паролі жасамады.\n"
-"Қайталап көріңіз."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Доменге кіру сәтсіз аяқталды"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Доменді табу мүмкін емес. Оны дұрыс көрсеттіңіз бе?"
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"қолданылу;жуырдағы;тарих;файлдар;уақытша;жеке;жекелік;қоқыс шелегі;тазарту;"
+"қалдыру;"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7121,14 +4372,14 @@ msgid "Enterprise Login"
 msgstr "Кәсіпорын тіркелгісі"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+msgid "User accounts which are managed by a company or organization."
 msgstr "Компания немесе ұйым басқаратын пайдаланушы тіркелгілері."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "Сіз желіде емессіз"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7138,10 +4389,6 @@ msgstr ""
 "тіркелгісіне бұл құрылғыда қолданылуды мүмкін етеді. Сонымен қатар, сіз бұл "
 "тіркелгіні кәсіпорынның интернеттегі ресурстарына қатынау үшін қолдана "
 "аласыз."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Көбірек суретті шолу"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7155,15 +4402,15 @@ msgstr "Саусақ іздерін басқарушы"
 msgid "Fingerprint"
 msgstr "Саусақ ізі"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_Жоқ"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Иә"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7171,32 +4418,32 @@ msgstr ""
 "Тіркелген саусақтар іздерін өшіріп, саусақ ізі арқылы жүйеге кіруді сөндіру "
 "керек пе?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Саусақ ізін оқу құрылғысы жоқ"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "Саусақ ізін оқу құрылғысы жоқ"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "Құрылғының дұрыс жалғанғанын тексеріңіз."
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Саусақ ізін оқу құрылғысы"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "Баптау үшін саусақ ізін оқу құрылғысын таңдаңыз"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "Саусақ ізімен кіру"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7204,438 +4451,102 @@ msgstr ""
 "Саусақ ізімен кіру сізге саусақ көмегімен бұғаттауды шешіп, компьютерге кіру "
 "мүмкіндігін береді"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "Саусақ іздерін ө_шіру"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Саусақ ізін түсіру"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "осы әрекетті орындау үшін құрылғы иелену қажет"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Алдыңғы"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "бұл құрылғыны басқа үрдіс иеленіп отыр"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "әрекетті орындауға рұқсатыңыз жоқ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "саусақ іздері тіркелмеген"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Тіркелу кезінде құрылғымен байланысу сәтсіз аяқталды"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Саусақ ізін оқу құрылғысымен байланысу сәтсіз аяқталды"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Саусақ ізі қызметіне байланысу сәтсіз аяқталды"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Саусақ іздерін тізіп шығару сәтсіз аяқталды: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Сақталған саусақ іздерін өшіру сәтсіз аяқталды: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Сол жақ бас бармағы"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Сол жақ ортаңғы саусақ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Сол жақ сұқ саусақ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Сол жақ аты жоқ саусақ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Сол жақ кішкентай саусақ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Оң жақ бас бармағы"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Оң жақ ортаңғы саусақ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Оң жақ сұқ саусақ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Оң жақ аты жоқ саусақ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Оң жақ кішкентай саусақ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Белгісіз саусақ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Аяқталды"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Саусақ ізін оқу құрылғысы ажыратылған"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Саусақ ізін оқу құрылғысының жады толық"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Жаңа саусақ ізін қосу сәтсіз аяқталды"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Саусақ ізін қосуды бастау сәтсіз аяқталды: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Жаңа саусақ ізін қосу сәтсіз аяқталды"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Саусақ ізін қосуды тоқтату сәтсіз аяқталды: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Саусақ ізін тіркеу үшін саусақты бірнеше рет оқу құралынан көтеріңіз және "
-"орналастырыңыз"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Бұл саусақты қа_йта өткізу…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Жаңа саусақ ізін сканерлеу"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Саусақ ізін оқу %s құрылғысын босату сәтсіз аяқталды: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Құрылғыдан оқу мәселесі"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Саусақ ізін оқу %s құрылғысын талап ету сәтсіз аяқталды: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Саусақ ізін оқу құрылғыларын алу сәтсіз аяқталды: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Осы аптада"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Өткен апта"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Сессия аяқталды"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Сессия басталды"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Тіркелгі белсенділігі"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Басқа парольді таңдаңыз."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Ағымдағы пароліңізді қайта енгізіңіз."
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Парольді өзгерту мүмкін емес"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Келесі"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Парольді өзгерту"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "Өз_герту"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "Ағымдағы пароль"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "Жаңа пароль"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "Парольді растау"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Парольдер өзара сәйкес емес."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
 "Пайдаланушы жүйеге келесі рет кірген кезде оған парольді өзгертуге рұқсат ету"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Парольді қазір орнату"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Доменнің бұл түріне автоматты түрде кіру мүмкін емес"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Ондай домен (realm) табылмады"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s ретінде %s доменіне кіру мүмкін емес"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Пароль қате, қайтадан көріңіз"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "%s доменіне байланысу мүмкін емес: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "Пайдаланушыны өшіру сәтсіз аяқталды"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "Қашықтағы пайдаланушының күшін жою сәтсіз аяқталды"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "Өз тіркелгіңізді өшіре алмайсыз."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s жүйеге кіріп тұр"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Жүйеге кіріп тұрған кезде пайдаланушыны өшіру жүйені екімәнді күйде қалдыруы "
-"мүмкін."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "%s файлдарын алып қалуды қалайсыз ба?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Пайдаланушы тіркелгісін өшіру кезінде оның үй бумасын, пошта кезегін және "
-"уақытша файлдарын алып қалу мүмкіндігі бар."
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "Файлдарды ө_шіру"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "Ф_айлдарды қалдыру"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Қашықтан басқарылатын %s тіркелгісін өшіруді шынымен қалайсыз ба?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "Ө_шіру"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Тіркелгі сөндірілген"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Келесі рет кірген кезде орнатылады"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ешнәрсе"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Жүйеге кіріп тұр"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "Іске қосулы"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "Тіркелгілер қызметімен байланыс орнату қатесі"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "AccountService орнатылған және іске қосылғанына көз жеткізіңіз."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "Бұл баптауды өзгерту үшін бұл панель құлыптан босатылуы тиіс"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "Таңдалған пайдаланушы тіркелгісін өшіру"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Таңдалған пайдаланушы тіркелгісін өшіру үшін,\n"
-"алдымен * таңбашасына шертіңіз"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr ""
-"Пайдаланушыларды қосу және параметрлерді өзгерту үшін бұғаттауын шешіңіз"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Пайдаланушылар"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "Өзгерістер іске асуы үшін сессияңызды қайта бастау керек"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Қазір қайта қосу"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Жабу"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Аватарды түзету"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Толық аты"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Түзету"
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Са_усақ ізімен кіру"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "А_втокіру"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "Тіркелгі белсенділігі"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "Ә_кімші"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7643,32 +4554,32 @@ msgstr ""
 "Әкімшілер басқа пайдаланушыларды қосып, өшіре алады және барлық "
 "пайдаланушылар үшін параметрлерді өзгерте алады."
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "А_та-ана бақылауы"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Ата-ана бақылауы қолданбасын ашу."
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Пайдаланушыны өшіру…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "Басқа пайдаланушылар"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "Пайдаланушыны қосу…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Пайдаланушылар табылмады"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Пайдаланушы тіркелгісін жасау үшін босатыңыз."
 
@@ -7676,7 +4587,6 @@ msgstr "Пайдаланушы тіркелгісін жасау үшін бос
 msgid "Add or remove users and change your password"
 msgstr "Пайдаланушыларды қосу/өшіру және пароліңізді өзгерту"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7722,182 +4632,10 @@ msgstr "Пайдаланушылар тіркелгілерін басқару"
 msgid "Authentication is required to change user data"
 msgstr "Пайдаланушы ақпаратын өзгерту үшін аутентификация керек"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Жаңа пароль ескі парольден басқа болуы тиіс."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Кейбір әріптер немесе сандарды өзгертіп көріңіз."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Парольді тағы да өзгертіп көріңіз."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Пароліңізде сіздің атыңыз қолданбаса, ол күштірек болады."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Парольде өз атыңызды қолданбауға тырысыңыз."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Парольде бар кейбір сөздерді қолданбауға тырысыңыз."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Кең қолданылатын сөздерді қолданбаңыз."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Бар сөздердің ретін ауыстыруды қолданбауға тырысыңыз."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Көбірек сандарды қолданып көріңіз."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Көбірек бас әріпті қолданып көріңіз."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Көбірек кіші әріпті қолданып көріңіз."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Көбірек арнайы белгілерді (тыныс) қолданып көріңіз."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Әріптер, сандар және тыныс белгілерінің қосындысын қолданып көріңіз."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Бір таңбаны қайталанбауға тырысыңыз."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Таңбалардың бір түрін қайталанбауға тырысыңыз: сізге әріптер, сандар және "
-"тыныс белгілерін араластырып қолдану керек."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 немесе аәбв сияқты тізбектерді қолданбауға тырысыңыз."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Пароль ұзынырақ болуы тиіс. Көбірек әріптер, сандар және тыныс белгілерін "
-"қосып көріңіз."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Бас және кіші әріптерді араластырыңыз және бір-екі санды қолдануға тырысыңыз."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Көбірек әріптер, сандар және тыныс белгілерін қосу арқылы парольді күштірек "
-"қылуға болады."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Аутентификация сәтсіз"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "Жаңа пароль тым қысқа"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "Жаңа пароль тым қарапайым"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Ескі және жаңа парольдер өзара ұқсайды"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Жаңа пароль жақында қолданылған болып тұр."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Жаңа парольде сандар немесе арнайы таңбалар болуы тиіс"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Ескі және жаңа парольдер өзара сәйкес келеді"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Басында аутентификацияланғаннан кейін пароліңіз өзгерген сияқты!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Жаңа парольде жеткілікті түрде әр түрлі таңбалар жоқ"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Белгісіз қате"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Пайдаланушы атында тек ағылшын әліппесінің a-z арасындағы кіші әріптері, "
-"сандар, және келесі таңбалар болуы мүмкін: . - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Кешіріңіз, бұл пайдаланушы аты қолжетерсіз. Басқасын көріңіз."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Пайдаланушы аты тым ұзын."
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
-msgstr "Пернелер бейнеленуі"
+msgstr "Пернелерді сәйкестеу"
 
 #: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
@@ -7928,47 +4666,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Қате шерту анықталды, қайтадан бастау…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Батырма %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Тағайындалған қолданбалар"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Пернені басу оқиғасы"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Мониторды ауыстыру"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Экрандағы көмекті көрсету"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Ноутбук панеліне орнатылған планшет"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Сыртқы дисплейге орнатылған планшет"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Сыртқы планшет құрылғысы"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Барлық экрандар"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Сыртқы салынбалы құрылғысы"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -7978,30 +4679,30 @@ msgstr "Планшет режимі"
 msgid "Use absolute positioning for the pen"
 msgstr "Қалам үшін абсолютті позициялауды пайдалану"
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "Сол қол (солақай) бағдары"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr "Планшет пен Express Keys™ сол қолды пайдалану үшін бұрылады"
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Экранға бейнелеу"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "Жақтар арақатынасын сақтау"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 "Монитор жақтары арақатынасын сақтау үшін планшет бетінің бір бөлігін ғана "
 "пайдалану"
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "Калибрациялау"
 
@@ -8016,6 +4717,20 @@ msgstr "Wacom планшетіңізді компьютерге жалғаңыз
 #: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "Қалам басуының сезімталдылығы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Жоғары"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Стилус басының қысымы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Төмен"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:54
 msgctxt "display setting"
@@ -8036,21 +4751,21 @@ msgstr "Батырма 3"
 msgid "Eraser Pressure Feel"
 msgstr "Өшіргіштің қысымға сезімталдылығы"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Басу, еңкею функциялары және құрамындағы слайдері бар аэрограф стилусы"
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Өшіргіш қысымы"
 
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Басу, еңкею және айналдыру функциялары бар аэрограф стилусы"
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Тышқанның орта батырма шертуі"
 
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Басу, еңкею функциялары бар қалыпты стилусы"
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Тышқанның оң жақ батырма шертуі"
 
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Басу функциясы бар қалыпты стилусы"
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Алға"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
@@ -8062,54 +4777,96 @@ msgstr ""
 "Графикалық планшеттер үшін батырмалар сәйкестіктерін және стилус "
 "сезімталдылығын баптау"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;Планшет;Стилус;Өшіргіш;Тышқан;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Жаңа жарлық…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Жайма"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Симуляцияланған ккіншілік шерту"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "_Терезелер:"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Тонер аз"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Екіншілік"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "_Терезелер:"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Өнімділік және көптапсырмалылық баптауларын басқару"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Қатынау нүктелері"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Қосу"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Сақтау"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Әрекеттен бас тартылды"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Қате:</b> Баптауларды өзгерту рұқсат етілмеген"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Қате:</b> Мобильді құрылғылық қамтама қатесі"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Тіркелмеген"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Тіркелген"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Роуминг"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Іздеу"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Рұқсат етілмеген"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8139,104 +4896,13 @@ msgstr "Өз нөмірі"
 msgid "Device Details"
 msgstr "Құрылғы ақпараты"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Шығарушы"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Бинарлы кодтар нұсқасы"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Тек 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Тек 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Тек 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (таңдамалы)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (таңдамалы), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (таңдамалы), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (таңдамалы)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (таңдамалы), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (таңдамалы)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (таңдамалы), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (таңдамалы)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (таңдамалы), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Белгісіз"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "SIM карта бұғаттауын шешу"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Бұғаттауды шешу"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "%d SIM картасы үшін PIN кодын енгізіңіз"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "SIM картаңыздың бұғаттауын шешу үшін PIN кодын енгізіңіз"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "%d SIM картасы үшін PUK кодын енгізіңіз"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "SIM картаңыздың бұғаттауын шешу үшін PUK кодын енгізіңіз"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8249,26 +4915,6 @@ msgstr[0] "Қате пароль енгізілген. Сізде %1$u қайт�
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Сізде %1$u қайталау талабы қалды"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Қате пароль енгізілген."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK коды 8 цифрлық сан болуы тиіс"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Жаңа PIN кодын енгізіңіз"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN коды 4-8 цифрлық сан болуы тиіс"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Бұғаттауды шешу…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -8326,147 +4972,47 @@ msgstr "SIM картаны PIN кодымен бұғаттау"
 msgid "M_odem Details"
 msgstr "М_одем ақпараты"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Телефон ақаулығы"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Телефонға байланыспаған"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Әрекетке рұқсат жоқ"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Әрекетке қолдау жоқ"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM картасы салынбаған"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "SIM PIN коды керек"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "SIM PUK коды керек"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM ақаулығы"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM бос емес"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Пароль қате"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIM PIN2 коды керек"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIM PUK2 коды керек"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Табылмады"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Желілік қызметі жоқ"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Желі күту уақыты аяқталды"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS қызметтері рұқсат етілмеген"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Роуминг бұл аймақта рұқсат етілмеген"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Көрсетілмеген GPRS қатесі"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "Әрекеттен бас тартылған"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Қатынауға тыйым салынған"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Белгісіз қате"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Желі режимі"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "_Орнату"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "Жабу"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Автоматты түрде"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Желіні таңдау"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Желілік провайдерлерді жаңарту"
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "Мобильді желіні іске қосу"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "WWAN адаптерлері табылмады"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "Сізде сымсыз Wan/ұялы құрылғының бар болғанын тексеріңіз"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "Ұшақтағы режим іске қосулы кезінде сымсыз Wan сөндірілген болады"
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "Ұшақтағы режимді _сөндіру"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "Деректер байланысы"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "Интернет үшін қолданылатын SIM картасы"
 
@@ -8478,15 +5024,15 @@ msgstr "SIM құлыптау"
 msgid "_Next"
 msgstr "_Келесі"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "SIM картаны PIN кодымен _бұғаттау"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "PIN кодын өзгерту"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr "SIM құылыптау баптауларын өзгерту үшін, ағымдағы PIN кодын енгізіңіз"
 
@@ -8498,8 +5044,6 @@ msgstr "Мобильді желі"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Телефония және мобильді деректер байланыстарын баптау"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;wwan;telephony;sim;mobile;ұялы;телефония;сим;мобильді;"
@@ -8513,57 +5057,17 @@ msgid "Settings is the primary interface for configuring your system."
 msgstr ""
 "Баптаулар қолданбасы жүйеңізді баптаудың негізгі сайманы болып табылады."
 
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:17
-msgid "GNOME Settings Sound Panel"
-msgstr "GNOME баптаулары дыбыс панелі"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:21
-msgid "GNOME Settings Mouse &amp; Touchpad Panel"
-msgstr "GNOME баптаулары тышқан және тачпад панелі"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:25
-msgid "GNOME Settings Background Panel"
-msgstr "GNOME баптаулары фон панелі"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:29
-msgid "GNOME Settings Keyboard Panel"
-msgstr "GNOME баптаулары пернетақта панелі"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:38
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "GNOME жобасы"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Нұсқа нөмірін көрсету"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Баптаулар санаттары"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Кеңейтілген режимді іске қосу"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Жолды іздеу"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Мүмкін панельдер атауларын шығару және шығу"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Көрсетілетін панель"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[ПАНЕЛЬ] [АРГУМЕНТ…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Жекелік"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Қолжетерлік панельдер:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8621,7 +5125,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Іздеуді тоқтату"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;Settings;Баптаулар;Қалаулар;"
@@ -8661,25 +5164,3018 @@ msgstr ""
 "Қолданба терезесінің бастапқы енін, биіктігін және максималды күйін "
 "сақтайтын кортеж."
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u шығыс"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u кіріс"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "Жүйелік дыбыстар"
+#~ msgid "System Bus"
+#~ msgstr "Жүйелік шина"
+
+#~ msgid "Full access"
+#~ msgstr "Толық қатынау құқығы"
+
+#~ msgid "Session Bus"
+#~ msgstr "Сессия шинасы"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "/dev бумасына толық қатынау құқығы"
+
+#~ msgid "Has network access"
+#~ msgstr "Желіге қатынау құқығы бар"
+
+#~ msgid "Home"
+#~ msgstr "Үй"
+
+#~ msgid "Read-only"
+#~ msgstr "Тек оқу үшін"
+
+#~ msgid "File System"
+#~ msgstr "Файлдық жүйе"
+
+#~ msgid "Can change settings"
+#~ msgstr "Баптауларды өзгерте алады"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s келесі құрамындағы рұқсаттарға ие. Оларды өзгерту мүмкін емес. Бұл "
+#~ "рұқсаттар жөнінде қобалжысаңыз, бұл қолданбаны өшіру мүмкіндігін "
+#~ "қарастырыңыз."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "Қолданбамен ашылатын %u файл және сілтеме түрлері"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> келесі түрдегі файлдар және сілтемелерді ашу үшін қолданылады."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "Диск орнынан %s қолданылуда."
+
+#~ msgid "Select a picture"
+#~ msgstr "Суретті таңдау"
+
+#~ msgid "_Open"
+#~ msgstr "А_шу"
+
+#~ msgid "multiple sizes"
+#~ msgstr "бірнеше өлшемдер"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Түсқағаз жоқ"
+
+#~ msgid "Current background"
+#~ msgstr "Ағымдағы фон"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Калибрация құрылғысын шаршыға апарып, \"Бастау\" басыңыз"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Калибрация құрылғысын калибрация орнына апарып, \"Жалғастыру\" басыңыз"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "Калибрация құрылғысын бет орнына апарып, \"Жалғастыру\" басыңыз"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Қақпақты жабыңыз"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Өндеуге келмейтін ішкі қате орын алды."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Калибрация үшін керек саймандар орнатылмаған."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Профильді жасау мүмкін емес."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Мақсат ақ нүктесіне жету мүмкін емес."
+
+#~ msgid "Complete!"
+#~ msgstr "Аяқталды!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Калибрация сәтсіз аяқталды!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Калибрация құрылғысын алып тастауға болады."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Үрдіс жүру кезінде калибрация құрылғысына тиіспеңіз"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Ноутбук экраны"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Құрамындағы вебкамера"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s мониторы"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s сканері"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s камерасы"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s принтері"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s вебкамерасы"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s үшін түстерді басқаруды іске қосу"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s үшін түстер профильдерін көрсету"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Калибрацияланбаған"
+
+#~ msgid "Default: "
+#~ msgstr "Бастапқы: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Түстер кеңістігі: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Сынама профилі: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC профилі файлын таңдаңыз"
+
+#~ msgid "_Import"
+#~ msgstr "И_мпорттау"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Қолдауы бар ICC профильдері"
+
+#~ msgid "All files"
+#~ msgstr "Барлық файлдар"
+
+#~ msgid "Save Profile"
+#~ msgstr "Профильді сақтау"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Таңдалған құрылғы үшін түстер профилін жасау"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Өлшеу құрылғысы анықталмады, Оның іске қосулы екенін және дұрыс жалғанып "
+#~ "тұрғанын тексеріңіз."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Өлшеу құрылғысы принтерлерді профильдеуді қолдамайды."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Құрылғының бұл түріне ағымда қолдау жоқ."
+
+#~ msgid "Standard Space"
+#~ msgstr "Қалыпты кеңістік"
+
+#~ msgid "Test Profile"
+#~ msgstr "Профильді сынау"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Автоматты түрде"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Төмен сапалы"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Орташа сапалы"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Жоғары сапалы"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Бастапқы RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Бастапқы CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Бастапқы сұр"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Жасаушы ұсынған зауыттық калибрация ақпараты"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Бұл профильмен толық экран мониторын түзету мүмкін емес"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Бұл профиль дұрыс емес болуы мүмкін"
+
+#~ msgid "Other…"
+#~ msgstr "Басқа…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Параметрлерді өзгерту үшін бұғаттауын шешу"
+
+#~ msgid "Today"
+#~ msgstr "Бүгін"
+
+#~ msgid "Yesterday"
+#~ msgstr "Кеше"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d сағат"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d минут"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d секунд"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Қатынау нүктесі"
+
+#~ msgid "24-hour"
+#~ msgstr "24 сағат"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Техникалық мәселелер жөнінде хабарламаларды жіберу бізге %s жақсартуға "
+#~ "көмектеседі. Хабарламалар анонимды түрде жіберіледі және олардан жеке "
+#~ "деректер кетіріледі. %s"
+
+#~ msgid "On"
+#~ msgstr "Іске қосулы"
+
+#~ msgid "Off"
+#~ msgstr "Off"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Өзгеірстерді іске асыру керек пе?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Өзгерістерді іске асыру мүмкін емес"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Бұл құрылғылық шектеулерден болуы мүмкін."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Жатық"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Тік, оң жақ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Тік, сол жақ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Жатық (айналған)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Гц"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Қауіпсіз жүктеу белсенді"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Қауіпсіз жүктеу құрылғы іске қосылғанда зиянды бағдарламалық қамтаманың "
+#~ "жүктелуіне жол бермейді. Қазіргі уақытта ол іске қосылған, дұрыс жұмыс "
+#~ "істейді."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Қауіпсіз жүктеуде мәселелер бар"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Қауіпсіз жүктеу құрылғы іске қосылғанда зиянды бағдарламалық қамтаманың "
+#~ "жүктелуіне жол бермейді. Қазіргі уақытта ол іске қосылған, бірақ кілттің "
+#~ "жарамсыз болуына байланысты жұмыс істемейді."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Қауіпсіз жүктеу сөндірілген"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Қауіпсіз жүктеу құрылғы іске қосылғанда зиянды бағдарламалық қамтаманың "
+#~ "жүктелуіне жол бермейді. Қазіргі уақытта ол сөндірілген."
+
+#~ msgid "Passed"
+#~ msgstr "Сәтті"
+
+#~ msgid "Failed"
+#~ msgstr "Сәтсіз"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Қауіпсіздік деңгейі 0"
+
+#~ msgid "Security Level 1"
+#~ msgstr "Қауіпсіздік деңгейі 1"
+
+#~ msgid "Security Level 2"
+#~ msgstr "Қауіпсіздік деңгейі 2"
+
+#~ msgid "Security Level 3"
+#~ msgstr "Қауіпсіздік деңгейі 3"
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Қауіпсіз жүктеуде мәселелер бар"
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Қауіпсіз жүктеу сөндірулі"
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Кешенді қорғау"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Бинарлы кодтарды жазудан қорғанысы"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Бинарлы кодтарды жазудан қорғанысының бұғаты"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Бинарлы кодтар BIOS аймағы"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Бинарлы кодтар BIOS дескрипторы"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET іске қосылған"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET белсенді"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Шифрленген жады"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU қорғанысы"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux ядросын тексеру"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Жадыға ұйықтату"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Бос етіп ұйықтату"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI платформа кілті"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI қауіпсіз жүктеуі"
+
+#~| msgid "Display Configuration"
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM платформасы баптаулары"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM қайта құруы"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Бинарлы кодтар жаңартулары"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Бинарлы кодтар аттестациясы"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Бинарлы кодтар жаңартушы тексерісі"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD бинарлы кодтар қайта ойнату"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD Firmware жазу қорғанысы"
+
+#~ msgid "Valid"
+#~ msgstr "Жарамды"
+
+#~ msgid "Not Valid"
+#~ msgstr "Жарамды емес"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Іске қосылмаған"
+
+#~ msgid "Locked"
+#~ msgstr "Бұғатталған"
+
+#~ msgid "Not Locked"
+#~ msgstr "Бұғатталмаған"
+
+#~ msgid "Encrypted"
+#~ msgstr "Шифрленген"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Шифрленген емес"
+
+#~ msgid "Found"
+#~ msgstr "Табылған"
+
+#~ msgid "Not Found"
+#~ msgstr "Табылмаған"
+
+#~ msgid "Supported"
+#~ msgstr "Қолдауы бар"
+
+#~ msgid "Not Supported"
+#~ msgstr "Қолдауы жоқ"
+
+#~ msgid "Unknown"
+#~ msgstr "Белгісіз"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-биттік"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-биттік"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Белгісіз"
+
+#~ msgid "Not Available"
+#~ msgstr "Қолжетімді емес"
+
+#~ msgid "System Logo"
+#~ msgstr "Жүйелік логотип"
+
+#~ msgid "No input sources found"
+#~ msgstr "Кіріс қайнар көздері табылмады"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Басқа"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Таңдауыңызша жарлықтар"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Балама таңбалар пернесін қосымша таңбаларды енгізу үшін пайдалануға "
+#~ "болады. Олар кейде пернетақтадағы үшінші параметр ретінде көрсетіледі."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Сол жақ Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Оң жақ Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Сол жақ Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Оң жақ Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menu пернесі"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Оң жақ Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Түрлендіру пернесі таңбалардың кең жиынтығын енгізуді мүмкін қылады. Оны "
+#~ "қолдану үшін, түрлендіру пернесін басып, одан кейін таңдалар тізбегін "
+#~ "теріңіз. Мысалы, түрлендіру пернесінен кейін <b>C</b> және <b>o</b> "
+#~ "басылса, <b>©</b> енгізіледі, <b>a</b> мен <b>'</b> басылса, <b>á</b> "
+#~ "егізіледі."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Енгізу қайнар көздерін %s пернетақта жарлығы көмегімен ауыстыруға "
+#~ "болады.\n"
+#~ "Бұл жарлықты пернетақта баптауларында өзгертуге болады."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d өзгертілген"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Барлық жарлықтарды тастау керек пе?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Жарлықтарды тастау таңдауыңызша жарлықтарды кетіруі мүмкін. Бұл әрекетті "
+#~ "болдырмау мүмкін болмайды."
+
+#~ msgid "Reset All"
+#~ msgstr "Барлығын тастау"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s жарлығы %s үшін қолданылуда болып тұр. Оны алмастырсаңыз, %s "
+#~ "сөндірілетін болады"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Жаңа пернетақта жарлығын енгізіңіз"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Таңдауыңызша жарлықты орнату"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Жарлықты орнату"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "%s өзгерту үшін жаңа жарлықты енгізіңіз."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Таңдауыңызша жарлықты қосу"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Қос саусақпен айналдыру"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Бес рет шерту, GEGL уақыты!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Қос шерту, біріншілік батырма"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Бірлік шерту, біріншілік батырма"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Қос шерту, орта батырмасы"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Бірлік шерту, орта батырмасы"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Қос шерту, екіншілік батырма"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Бірлік шерту, екіншілік батырма"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager орындалып тұруы тиіс."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Қорғалмаған желі (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Қауіпсіз желі (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Қауіпсіз желі (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Қауіпсіз желі (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Қауіпсіз желі"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Қатынау нүктесін іске қосу нәтежесінде %s желісі ажыратылады, интернетке "
+#~ "Wi-Fi арқылы байланысуға мүмкін болмайды."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Кем дегенде 8 таңбадан тұруы тиіс"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Қатынау нүктесін тоқтатып, барлық пайдаланушыларды үзу керек пе?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "Қа_тынау нүктесін тоқтату"
+
+#~ msgid "Preserve"
+#~ msgstr "Сақтап қалу"
+
+#~ msgid "Permanent"
+#~ msgstr "Тұрақты"
+
+#~ msgid "Random"
+#~ msgstr "Кездейсоқ"
+
+#~ msgid "Stable"
+#~ msgstr "Тұрақты"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Осында енгізілген MAC адресі осы байланысты қолданатын желі құрылғысы "
+#~ "үшін аппараттық мекенжай ретінде пайдаланылады. Бұл мүмкіндік MAC клондау "
+#~ "немесе спуфинг ретінде белгілі. Мысалы: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Профиль %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Жақсартылған ашық"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Кәсіпорын"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Жоқ"
+
+#~ msgid "Never"
+#~ msgstr "Ешқашан"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Мб/с (%1.1f ГГц)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Мб/с"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Жоқ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Әлсіз"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ОК"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Жақсы"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Тамаша"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Байланысты ұмыту"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Байланыс профилін өшіру"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN өшіру"
+
+#~ msgid "Details"
+#~ msgstr "Көбірек білу"
+
+#~ msgid "automatic"
+#~ msgstr "автоматты"
+
+#~ msgid "Identity"
+#~ msgstr "Идентификация"
+
+#~ msgid "Delete Address"
+#~ msgstr "Адресті өшіру"
+
+#~ msgid "Delete Route"
+#~ msgstr "Маршрутты өшіру"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ешнәрсе"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128 биттік кілті (Hex немесе ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128 биттік кілттік фразасы"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Динамикалық WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "Жеке WPA3"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Байланыстар түзеткішін ашу мүмкін емес"
+
+#~ msgid "New Profile"
+#~ msgstr "Жаңа профиль"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Жарамсыз баптау %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Жарамсыз баптау %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Файлдан импорттау…"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN қосу"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN байланысын импорттау мүмкін емес"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "\"%s\" файлын оқу мүмкін емес, немесе оның ішінде танылған VPN байланыс "
+#~ "ақпараты жоқ\n"
+#~ "\n"
+#~ "Қате: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Импорттау үшін файлды таңдаңыз"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "\"%s\" аты бар файл бар болып тұр."
+
+#~ msgid "_Replace"
+#~ msgstr "А_лмастыру"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "%s орнына сіз сақтаймын деген VPN байланысын сақтау керек пе?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN байланысын экспорттау мүмкін емес"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "\"%s\" VPN байланысын %s ішіне экспорттау мүмкін емес.\n"
+#~ "\n"
+#~ "Қате: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN байланысын экспорттау"
+
+#~ msgid "never"
+#~ msgstr "ешқашан"
+
+#~ msgid "today"
+#~ msgstr "бүгін"
+
+#~ msgid "yesterday"
+#~ msgstr "кеше"
+
+#~ msgid "Last used"
+#~ msgstr "Соңғы қолданылған"
+
+#~ msgid "Add new connection"
+#~ msgstr "Жаңа байланысты қосу"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Таңдалған желілер үшін желі ақпараты, парольдер және таңдауыңызша "
+#~ "жасалған баптаулар жоғалатын болады."
+
+#~ msgid "_Forget"
+#~ msgstr "Ұ_мыту"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Белгілі Wi-Fi желілері"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "Ұ_мыту"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Қатынау нүктесі ретінде қолдануды жүйелік саясат рұқсат етпейді"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Сымсыз құрылғы қатынау нүкте режимін қолдамайды"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Баптау сілтемесі көрсетілмеген кезде веб проксиін автоанықтау қолданылады."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Бұл әрекет сенімсіз ортақ желілері үшін ұсынылмайды."
+
+#~ msgid "Status unknown"
+#~ msgstr "Қалып-күйі белгісіз"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Басқарылмайтын"
+
+#~ msgid "Unavailable"
+#~ msgstr "Қолжетерсіз"
+
+#~ msgid "Connecting"
+#~ msgstr "Қосылуда"
+
+#~ msgid "Authentication required"
+#~ msgstr "Аутентификация керек"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Байланысты үзу"
+
+#~ msgid "Connection failed"
+#~ msgstr "Байланыс орнату сәтсіз"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Қалып-күйі белгісіз (жоқ болып тұр)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Баптау сәтсіз"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP баптауы сәтсіз"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP баптауы ескірген"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Құпия кілттері сұралды, бірақ ұсынылмады"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x supplicant байланысы ажыратылған"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x supplicant баптауы сәтсіз"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x supplicant сәтсіз"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant аутентификация үшін тым көп уақыт алған"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP қызметі іске қосыла алмады"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP қызметі байланысты үзген"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP сәтсіз аяқталды"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP клиенті іске қосылу қатесі"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP клиент қатесі"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP клиенті сәтсіз аяқталды"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Ортақ етілген байланыс қызметінің іске қосылу қатесі"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Ортақ етілген байланыс қызметі сәтсіз аяқталды"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP қызметінің іске қосылу қатесі"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP қызметінің қатесі"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP қызметі сәтсіз аяқталды"
+
+#~ msgid "Line busy"
+#~ msgstr "Арна бос емес"
+
+#~ msgid "No dial tone"
+#~ msgstr "Арнада гудок жоқ"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Тасушыны орнату мүмкін емес"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Қоңырауға бөлінген уақыт аяқталды"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Қоңырау соғу сәтсіз аяқталды"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Модемді іске қосу сәтсіз аяқталды"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Көрсетілген APN таңдау сәтсіз аяқталды"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Желілерді іздемеу"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Желіге тіркелу тайдырылған"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Желіге тіркелудің мерзімі біткен"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Сұралған желіге тіркелу сәтсіз аяқталды"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN кодын тексеру сәтсіз"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Құрылғы үшін бинарлық кодтар жоқ болуы мүмкін"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Байланыс жоғалды"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Бар болып тұрған байланыс алынды"
+
+#~ msgid "Modem not found"
+#~ msgstr "Модем табылмады"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth байланысы сәтсіз аяқталды"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM картасы салынбаған"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM Pin коды керек"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk коды керек"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM қате"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Байланыс тәуелділігі сәтсіз аяқталды"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Бинарлы кодтары жоқ"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Кабель ажыратылған"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "802.1X қауіпсіздігі (wpa-eap) ішіндегі анықталмаған қате"
+
+#~ msgid "no file selected"
+#~ msgstr "файл таңдалмады"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "eap-method файлын растаудағы анықталмаған қате"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 немесе PGP жеке кілттері"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER немесе PEM сертификаттары"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "EAP-FAST PAC файлы жоқ"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC файлдары (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "EAP-LEAP пайдаланушы аты жоқ"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "EAP-LEAP паролі жоқ"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "жарамсыз EAP-PEAP CA сертификаты: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "жарамсыз EAP-PEAP CA сертификаты: сертификат көрсетілмеген"
+
+#~ msgid "missing EAP username"
+#~ msgstr "EAP пайдаланушы аты жоқ"
+
+#~ msgid "missing EAP password"
+#~ msgstr "EAP паролі жоқ"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "EAP-TLS identity жоқ"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "жарамсыз EAP-TLS CA сертификаты: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "жарамсыз EAP-TLS CA сертификаты: сертификат көрсетілмеген"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "жарамсыз EAP-TLS жеке кілті: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "жарамсыз EAP-TLS пайдаланушы сертификаты: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Шифрленбеген жеке кілттері қауіпсіз емес болады"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Таңдалған жеке кілт парольмен қорғалмаған сияқты. Бұл сіздің қауіпсіздік "
+#~ "есептік жазба деректерінің әшкерелеуіне әкеп соғуы мүмкін. Парольмен "
+#~ "қорғалған жеке кілтті таңдаңыз.\n"
+#~ "\n"
+#~ "(Сіз жеке кілтіңізді openssl көмегімен парольмен қорғай аласыз)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Жеке сертификатыңызды таңдаңыз"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Жеке кілтіңізді таңдаңыз"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "жарамсыз EAP-TTLS CA сертификаты: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "жарамсыз EAP-TTLS CA сертификаты: сертификат көрсетілмеген"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "802.1X қауіпсіздігін тексерудің белгісіз қатесі"
+
+#~ msgid "Select a file"
+#~ msgstr "Файлды таңдау"
+
+#~ msgid "missing leap-username"
+#~ msgstr "leap-username жоқ"
+
+#~ msgid "missing leap-password"
+#~ msgstr "leap-password жоқ"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Wi-Fi паролі жоқ."
+
+#~ msgid "missing wep-key"
+#~ msgstr "wep-key жоқ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "жарамсыз wep-key: ұзындығы %zu кілт ішінде тек оналтылық сандар болуы тиіс"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "жарамсыз wep-key: ұзындығы %zu кілт ішінде тек ascii таңбалары болуы тиіс"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "жарамсыз wep-key: кілт ұзындығы %zu қате. Кілт ұзындығы 5/13 (ascii) "
+#~ "немесе 10/26 (оналтылық) болуы тиіс"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "жарамсыз wep-key: кілттік фраза бос емес болуы тиіс"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "жарамсыз wep-key: кілттік фраза 64 таңбадан аз болуы тиіс"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "жарамсыз wpa-psk: кілт ұзындығы %zu жарамсыз. Ол [8,63] байт немесе 64 "
+#~ "оналтылық сан болуы тиіс"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "жарамсыз wpa-psk: 64 байты бар кілтті он алтылық кілт ретінде талдау "
+#~ "мүмкін емес"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Басқа"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s өшірілді"
+
+#~ msgid "Error removing account"
+#~ msgstr "Тіркелгіні өшіру қатесі"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s тіркелгісі"
+
+#~ msgid "Remove Account"
+#~ msgstr "Тіркелгіні өшіру"
+
+#~ msgid "Unknown time"
+#~ msgstr "Уақыты белгісіз"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s толық зарядқа дейін"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Ескерту: %s қалды"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s қалды"
+
+#~ msgid "Fully charged"
+#~ msgstr "Толық зарядталған"
+
+#~ msgid "Not charging"
+#~ msgstr "Зарядталуда емес"
+
+#~ msgid "Empty"
+#~ msgstr "Бос"
+
+#~ msgid "Charging"
+#~ msgstr "Зарядталуда"
+
+#~ msgid "Discharging"
+#~ msgstr "Зарядын беруде"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Сымсыз тышқан"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Сымсыз пернетақта"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Үзіліссіз эл. қорек көзі"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Жеке цифрлық көмекші"
+
+#~ msgid "Cellphone"
+#~ msgstr "Ұялы телефон"
+
+#~ msgid "Media player"
+#~ msgstr "Медиа плеері"
+
+#~ msgid "Tablet"
+#~ msgstr "Планшет"
+
+#~ msgid "Computer"
+#~ msgstr "Компьютер"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Ойын құрылғысы"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Басты"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Қосымша"
+
+#~ msgid "Batteries"
+#~ msgstr "Батареялар"
+
+#~ msgid "When _idle"
+#~ msgstr "І_ссіз кезінде"
+
+#~ msgid "Suspend"
+#~ msgstr "Ұйықтату"
+
+#~ msgid "Power Off"
+#~ msgstr "Сөндіру"
+
+#~ msgid "Hibernate"
+#~ msgstr "Гибернация"
+
+#~ msgid "Nothing"
+#~ msgstr "Ешнәрсе"
+
+#~ msgid "When on battery power"
+#~ msgstr "Батареядан жұмыс істеген кезде"
+
+#~ msgid "When plugged in"
+#~ msgstr "Эл. желісінде"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Ешқашан"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Автоматты түрде ұйықтату"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "Өнімділік режимі уақытша жоғары температура салдарынан сөндірілген."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Тізе анықталды: өнімділік режимі уақытша қолжетімсіз. Оны қалпына келтіру "
+#~ "үшін, құрылғыны тұрақты жерге ораластырыңыз."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Өнімділік режимі уақытша сөндірілген."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Батарея заряды аз: эл. қорегін үнемдеу іске қосылған. Батарея жеткілікті "
+#~ "зарядталған кезде алдыңғы режим қалпына келтіріледі."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Эл. корегін сақтау режимін \"%s\" белсендірген."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Өнімділік режимін \"%s\" белсендірген."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Өнімділік"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Жоғары өнімділік және қуатты пайдалану."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Баланс"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Стандартты өнімділік және қуатты пайдалану."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Қорек үнемдеу"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Төмендетілген өнімділік және қуатты пайдалану."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "\"%s\" принтері өшірілді"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Жаңа принтерді қосу сәтсіз аяқталды."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui жүктеу мүмкін емес: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr ""
+#~ "Принтерлерді қосу және параметрлерді өзгерту үшін бұғаттауын шешіңіз"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s ақпараты"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Сәйкес келетін драйвер табылмады"
+
+#~ msgid "Select PPD File"
+#~ msgstr "PPD айлын таңдаңыз"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript принтер сипаттау файлдары (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect принтері"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD принтері"
+
+#~ msgid "One Sided"
+#~ msgstr "Бір жақты"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Ұзын жағымен"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Қысқа жағымен"
+
+#~ msgid "Portrait"
+#~ msgstr "Тік"
+
+#~ msgid "Landscape"
+#~ msgstr "Жатық"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Теріс жатық"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Теріс тік"
+
+#~ msgid "Resume"
+#~ msgstr "Жалғастыру"
+
+#~ msgid "Pause"
+#~ msgstr "Аялдату"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Кезекте"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Аялдатылған"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Аутентификация керек"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Өңдеуде"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Тоқтатылды"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Бас тартылған"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Үзілді"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Аяқталған"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Бұл тапсырманы кезек басына жылжыту"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Белсенді тапсырмалар"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr ""
+#~ "%s жерінде баспаға шығару үшін пайдаланушы атын және пароліңізді "
+#~ "енгізіңіз."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Баспаға шығару серверін блоктаудан босату"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s босату."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "%s жеріндегі принтерлерді қарау үшін пайдаланушы атын және пароліңізді "
+#~ "енгізіңіз."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Принтерлерді іздеу"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Тізбектей порт"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Параллельді порт"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Орналасуы: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Адресі: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Сервер аутентификацияны талап етеді"
+
+#~ msgid "Two Sided"
+#~ msgstr "Екі жақты"
+
+#~ msgid "Paper Type"
+#~ msgstr "Қағаз түрі"
+
+#~ msgid "Paper Source"
+#~ msgstr "Қағаз көзі"
+
+#~ msgid "Output Tray"
+#~ msgstr "Шығыс сөресі"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Ажыратылымдығы"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript алдын-ала сүзгілеу"
+
+#~ msgid "Pages per side"
+#~ msgstr "Бір жақтағы парақтар"
+
+#~ msgid "Orientation"
+#~ msgstr "Бағдары"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Жалпы"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Парақ баптаулары"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Орнатуға келетін опциялар"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Тапсырма"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Сурет сапасы"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Түс"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Аяқтау"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Кеңейтілген"
+
+#~ msgid "Test page"
+#~ msgstr "Сынау парағы"
+
+#~ msgid "Auto Select"
+#~ msgstr "Авто таңдау"
+
+#~ msgid "Printer Default"
+#~ msgstr "Принтердің негізгісі"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Тек GhostScript қаріптерін ілестіру"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS 1 деңгейіне түрлендіру"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS 2 деңгейіне түрлендіру"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Алдын-ала сүзгілеу жоқ"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Баспа бастиектерін тазарту"
+
+#~ msgid "Out of toner"
+#~ msgstr "Тонер жоқ"
+
+#~ msgid "Low on developer"
+#~ msgstr "Айқындауышы аз"
+
+#~ msgid "Out of developer"
+#~ msgstr "Айқындауышы бітті"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Тонер бітіп жатыр"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Тонер бітті"
+
+#~ msgid "Open cover"
+#~ msgstr "Қақпағы ашық"
+
+#~ msgid "Open door"
+#~ msgstr "Есігі ашық"
+
+#~ msgid "Low on paper"
+#~ msgstr "Қағазы аз"
+
+#~ msgid "Out of paper"
+#~ msgstr "Қағаз бітті"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Желіде емес"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Тоқтатылды"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Қоқысты қабылдағыш толуға жақын"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Қоқысты қабылдағыш толып қалды"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Фоторезист жақында жарамсыз болып қалады"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Фоторезист жұмыс істемейді"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Дайын"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Тапрсырмаларды қабылдамайды"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Өңдеуде"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Империялық"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Метрлік"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Не істеуді сұрау"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ешнәрсе жасамау"
+
+#~ msgid "Open folder"
+#~ msgstr "Буманы ашу"
+
+#~ msgid "Other Media"
+#~ msgstr "Басқа тасушылар"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Аудио CD үшін қолданбаны таңдаңыз"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Видео DVD үшін қолданбаны таңдаңыз"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Музыкалық плеері салынған кезде жөнелтілетін қолданбаны таңдаңыз"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Камера байланысқан кезде жөнелтілетін қолданбаны таңдаңыз"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "БҚ CD дискілері үшін қолданбаны таңдаңыз"
+
+#~ msgid "audio DVD"
+#~ msgstr "аудио DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "таза Blu-Ray дискі"
+
+#~ msgid "blank CD disc"
+#~ msgstr "таза CD-R дискі"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "таза DVD+R дискі"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "таза HD DVD дискі"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray видео дискі"
+
+#~ msgid "e-book reader"
+#~ msgstr "электронды кітаптарды оқу құрылғысы"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD видео дискі"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "Windows software"
+#~ msgstr "Windows БҚ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Экран сөнеді"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 секунд"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 минут"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 минут"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 минут"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 минут"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 минут"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 сағат"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Ешқашан"
+
+#~ msgid "Select Location"
+#~ msgstr "Орналасуды таңдау"
+
+#~ msgid "_OK"
+#~ msgstr "_ОК"
+
+#~ msgid "No applications found"
+#~ msgstr "Қолданбалар табылмады"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Бөлісу үшін желілер таңдалмады"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Іске қосулы"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Сөнд."
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Іске қосулы"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Белсенді"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Буманы таңдау"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Медиамен бөлісуді іске қосу"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Файлдармен бөлісу көмегімен ағымдағы желіде сіздің Ортақ бумаңызды келесі "
+#~ "адрес арқылы бөлісе аласыз: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Қашықтан байланысу іске қосылған болса, қашықтағы пайдаланушылар Secure "
+#~ "Shell командасы көмегімен байланыса алады:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Жеке медиамен бөлісуді іске қосу"
+
+#~ msgid "Device name copied"
+#~ msgstr "Құрылғы атауы көшірілді"
+
+#~ msgid "Device address copied"
+#~ msgstr "Құрылғы адресі көшірілді"
+
+#~ msgid "Username copied"
+#~ msgstr "Пайдаланушы аты көшірілді"
+
+#~ msgid "Password copied"
+#~ msgstr "Пароль көшірілді"
+
+#~ msgid "Custom"
+#~ msgstr "Таңдауыңызша"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Сынау \"%s\""
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Ажыратылған"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Байланысуда"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Байланысқан"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Авторизация қатесі"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Авторизациялауда"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Мүмкіндіктері шектелген"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Байланысқан және авторизацияланған"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Белгісіз"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Авторизацияланған уақыты:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Байланысқан уақыты:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Тіркелген уақыты:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Құрылғыны авторизациялау қатесі: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Құрылғыны ұмыту қатесі: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Қате"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Авторизацияланған"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt қолдау жүйесі (boltd) орнатылмаған, немесе дұрыс бапталмаған."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Тек USB және Display Port құрылғыларын жалғауға болады."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt анықтау мүмкін емес.\n"
+#~ "Жүйеде Thunderbolt қолдауы жоқ, немесе ол BIOS-та сөндірілген болуы "
+#~ "мүмкін, немесе BIOS-та қолдауы жоқ қауіпсіздік деңгейі орнатылған болуы "
+#~ "мүмкін."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt қолдауы BIOS-та сөндірілген."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Thunderbolt қауіпсіздік деңгейін анықтау мүмкін емес."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Тікелей режимін ауыстыру қатесі: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Бастапқы"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Орташа"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Үлкен"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Үлкенірек"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Ең үлкен"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d пиксель"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Қысқа"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "Экранның ¼ бөлігі"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "Экранның ½ бөлігі"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "Экранның ¾ бөлігі"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Ұзақ"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 сағат"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 күн"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 күн"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 күн"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 күн"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 күн"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 күн"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 күн"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 күн"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 күн"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Қоқыс шелегінен барлық нәрсені өшіру керек пе?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Қоқыс шелегінен барлық нәрселер толығымен өшіріледі."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Қоқыс шел_егін тазарту"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Барлық уақытша файлдарды өшіру керек пе?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Барлық уақытша файлдар толығымен өшіріледі."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Уақытша файлдарды _тазарту"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 күн"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 күн"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 күн"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Мәңгі"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Логинді ұсынушының веб адресіне сәйкес болуы тиіс."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Тіркелгіні қосу сәтсіз"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Тіркелгіні тіркеу сәтсіз аяқталды"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Бұл доменде аутентификациялаудың қолдауы бар тәсілдері жоқ"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Доменде тіркелу сәтсіз"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Бұл логин fns жасамады.\n"
+#~ "Қайталап көріңіз."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Бұл логин паролі жасамады.\n"
+#~ "Қайталап көріңіз."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Доменге кіру сәтсіз аяқталды"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Доменді табу мүмкін емес. Оны дұрыс көрсеттіңіз бе?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Көбірек суретті шолу"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "осы әрекетті орындау үшін құрылғы иелену қажет"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "бұл құрылғыны басқа үрдіс иеленіп отыр"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "әрекетті орындауға рұқсатыңыз жоқ"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "саусақ іздері тіркелмеген"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Тіркелу кезінде құрылғымен байланысу сәтсіз аяқталды"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Саусақ ізін оқу құрылғысымен байланысу сәтсіз аяқталды"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Саусақ ізі қызметіне байланысу сәтсіз аяқталды"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Саусақ іздерін тізіп шығару сәтсіз аяқталды: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Сақталған саусақ іздерін өшіру сәтсіз аяқталды: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Сол жақ бас бармағы"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Сол жақ ортаңғы саусақ"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Сол жақ сұқ саусақ"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Сол жақ аты жоқ саусақ"
+
+#~ msgid "Left little finger"
+#~ msgstr "Сол жақ кішкентай саусақ"
+
+#~ msgid "Right thumb"
+#~ msgstr "Оң жақ бас бармағы"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Оң жақ ортаңғы саусақ"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Оң жақ сұқ саусақ"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Оң жақ аты жоқ саусақ"
+
+#~ msgid "Right little finger"
+#~ msgstr "Оң жақ кішкентай саусақ"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Белгісіз саусақ"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Аяқталды"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Саусақ ізін оқу құрылғысы ажыратылған"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Саусақ ізін оқу құрылғысының жады толық"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Жаңа саусақ ізін қосу сәтсіз аяқталды"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Саусақ ізін қосуды бастау сәтсіз аяқталды: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Жаңа саусақ ізін қосу сәтсіз аяқталды"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Саусақ ізін қосуды тоқтату сәтсіз аяқталды: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Саусақ ізін тіркеу үшін саусақты бірнеше рет оқу құралынан көтеріңіз және "
+#~ "орналастырыңыз"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Бұл саусақты қа_йта өткізу…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Жаңа саусақ ізін сканерлеу"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Саусақ ізін оқу %s құрылғысын босату сәтсіз аяқталды: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Құрылғыдан оқу мәселесі"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Саусақ ізін оқу %s құрылғысын талап ету сәтсіз аяқталды: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Саусақ ізін оқу құрылғыларын алу сәтсіз аяқталды: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Осы аптада"
+
+#~ msgid "Last Week"
+#~ msgstr "Өткен апта"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Сессия аяқталды"
+
+#~ msgid "Session Started"
+#~ msgstr "Сессия басталды"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Тіркелгі белсенділігі"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Басқа парольді таңдаңыз."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Ағымдағы пароліңізді қайта енгізіңіз."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Парольді өзгерту мүмкін емес"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Доменнің бұл түріне автоматты түрде кіру мүмкін емес"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Ондай домен (realm) табылмады"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s ретінде %s доменіне кіру мүмкін емес"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Пароль қате, қайтадан көріңіз"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "%s доменіне байланысу мүмкін емес: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Пайдаланушыны өшіру сәтсіз аяқталды"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Қашықтағы пайдаланушының күшін жою сәтсіз аяқталды"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Өз тіркелгіңізді өшіре алмайсыз."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s жүйеге кіріп тұр"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Жүйеге кіріп тұрған кезде пайдаланушыны өшіру жүйені екімәнді күйде "
+#~ "қалдыруы мүмкін."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "%s файлдарын алып қалуды қалайсыз ба?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Пайдаланушы тіркелгісін өшіру кезінде оның үй бумасын, пошта кезегін және "
+#~ "уақытша файлдарын алып қалу мүмкіндігі бар."
+
+#~ msgid "_Delete Files"
+#~ msgstr "Файлдарды ө_шіру"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Ф_айлдарды қалдыру"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Қашықтан басқарылатын %s тіркелгісін өшіруді шынымен қалайсыз ба?"
+
+#~ msgid "_Delete"
+#~ msgstr "Ө_шіру"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Тіркелгі сөндірілген"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Келесі рет кірген кезде орнатылады"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ешнәрсе"
+
+#~ msgid "Logged in"
+#~ msgstr "Жүйеге кіріп тұр"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Тіркелгілер қызметімен байланыс орнату қатесі"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "AccountService орнатылған және іске қосылғанына көз жеткізіңіз."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Бұл баптауды өзгерту үшін бұл панель құлыптан босатылуы тиіс"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Таңдалған пайдаланушы тіркелгісін өшіру"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Таңдалған пайдаланушы тіркелгісін өшіру үшін,\n"
+#~ "алдымен * таңбашасына шертіңіз"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr ""
+#~ "Пайдаланушыларды қосу және параметрлерді өзгерту үшін бұғаттауын шешіңіз"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Жаңа пароль ескі парольден басқа болуы тиіс."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Кейбір әріптер немесе сандарды өзгертіп көріңіз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Парольді тағы да өзгертіп көріңіз."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Пароліңізде сіздің атыңыз қолданбаса, ол күштірек болады."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Парольде өз атыңызды қолданбауға тырысыңыз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Парольде бар кейбір сөздерді қолданбауға тырысыңыз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Кең қолданылатын сөздерді қолданбаңыз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Бар сөздердің ретін ауыстыруды қолданбауға тырысыңыз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Көбірек сандарды қолданып көріңіз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Көбірек бас әріпті қолданып көріңіз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Көбірек кіші әріпті қолданып көріңіз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Көбірек арнайы белгілерді (тыныс) қолданып көріңіз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Әріптер, сандар және тыныс белгілерінің қосындысын қолданып көріңіз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Бір таңбаны қайталанбауға тырысыңыз."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Таңбалардың бір түрін қайталанбауға тырысыңыз: сізге әріптер, сандар және "
+#~ "тыныс белгілерін араластырып қолдану керек."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 немесе аәбв сияқты тізбектерді қолданбауға тырысыңыз."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Пароль ұзынырақ болуы тиіс. Көбірек әріптер, сандар және тыныс белгілерін "
+#~ "қосып көріңіз."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Бас және кіші әріптерді араластырыңыз және бір-екі санды қолдануға "
+#~ "тырысыңыз."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Көбірек әріптер, сандар және тыныс белгілерін қосу арқылы парольді "
+#~ "күштірек қылуға болады."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Аутентификация сәтсіз"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Жаңа пароль тым қысқа"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Жаңа пароль тым қарапайым"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Ескі және жаңа парольдер өзара ұқсайды"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Жаңа пароль жақында қолданылған болып тұр."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Жаңа парольде сандар немесе арнайы таңбалар болуы тиіс"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Ескі және жаңа парольдер өзара сәйкес келеді"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Басында аутентификацияланғаннан кейін пароліңіз өзгерген сияқты!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Жаңа парольде жеткілікті түрде әр түрлі таңбалар жоқ"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Белгісіз қате"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Пайдаланушы атында тек ағылшын әліппесінің a-z арасындағы кіші әріптері, "
+#~ "сандар, және келесі таңбалар болуы мүмкін: . - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Кешіріңіз, бұл пайдаланушы аты қолжетерсіз. Басқасын көріңіз."
+
+#~ msgid "The username is too long."
+#~ msgstr "Пайдаланушы аты тым ұзын."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Батырма %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Тағайындалған қолданбалар"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Пернені басу оқиғасы"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Мониторды ауыстыру"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Экрандағы көмекті көрсету"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Ноутбук панеліне орнатылған планшет"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Сыртқы дисплейге орнатылған планшет"
+
+#~ msgid "External tablet device"
+#~ msgstr "Сыртқы планшет құрылғысы"
+
+#~ msgid "All Displays"
+#~ msgstr "Барлық экрандар"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Басу, еңкею функциялары және құрамындағы слайдері бар аэрограф стилусы"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Басу, еңкею және айналдыру функциялары бар аэрограф стилусы"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Басу, еңкею функциялары бар қалыпты стилусы"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Басу функциясы бар қалыпты стилусы"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Жаңа жарлық…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Әрекеттен бас тартылды"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Қате:</b> Баптауларды өзгерту рұқсат етілмеген"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Қате:</b> Мобильді құрылғылық қамтама қатесі"
+
+#~ msgid "Not Registered"
+#~ msgstr "Тіркелмеген"
+
+#~ msgid "Registered"
+#~ msgstr "Тіркелген"
+
+#~ msgid "Roaming"
+#~ msgstr "Роуминг"
+
+#~ msgid "Searching"
+#~ msgstr "Іздеу"
+
+#~ msgid "Denied"
+#~ msgstr "Рұқсат етілмеген"
+
+#~ msgid "2G Only"
+#~ msgstr "Тек 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Тек 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Тек 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Тек 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (таңдамалы)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (таңдамалы), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (таңдамалы), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (таңдамалы), 3G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (таңдамалы)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (таңдамалы), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (таңдамалы), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (таңдамалы)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (таңдамалы), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (таңдамалы), 4G, 5G"
+
+#~| msgid "3G, 4G"
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (таңдамалы)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (таңдамалы), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (таңдамалы), 4G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (таңдамалы)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (таңдамалы), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (таңдамалы), 3G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (таңдамалы)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (таңдамалы), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (таңдамалы)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (таңдамалы), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (таңдамалы)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (таңдамалы), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (таңдамалы)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (таңдамалы), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (таңдамалы)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (таңдамалы), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (таңдамалы)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (таңдамалы), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Белгісіз"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "SIM карта бұғаттауын шешу"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "%d SIM картасы үшін PIN кодын енгізіңіз"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "SIM картаңыздың бұғаттауын шешу үшін PIN кодын енгізіңіз"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "%d SIM картасы үшін PUK кодын енгізіңіз"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "SIM картаңыздың бұғаттауын шешу үшін PUK кодын енгізіңіз"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Қате пароль енгізілген."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK коды 8 цифрлық сан болуы тиіс"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Жаңа PIN кодын енгізіңіз"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN коды 4-8 цифрлық сан болуы тиіс"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Бұғаттауды шешу…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Телефон ақаулығы"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Телефонға байланыспаған"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Әрекетке рұқсат жоқ"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Әрекетке қолдау жоқ"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM картасы салынбаған"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM PIN коды керек"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM PUK коды керек"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM ақаулығы"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM бос емес"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Пароль қате"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM PIN2 коды керек"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM PUK2 коды керек"
+
+#~ msgid "Not found"
+#~ msgstr "Табылмады"
+
+#~ msgid "No network service"
+#~ msgstr "Желілік қызметі жоқ"
+
+#~ msgid "Network timeout"
+#~ msgstr "Желі күту уақыты аяқталды"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS қызметтері рұқсат етілмеген"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Роуминг бұл аймақта рұқсат етілмеген"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Көрсетілмеген GPRS қатесі"
+
+#~ msgid "No Error"
+#~ msgstr "Қате жоқ"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Әрекеттен бас тартылған"
+
+#~ msgid "Access denied"
+#~ msgstr "Қатынауға тыйым салынған"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Белгісіз қате"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Нұсқа нөмірін көрсету"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Кеңейтілген режимді іске қосу"
+
+#~ msgid "Search for the string"
+#~ msgstr "Жолды іздеу"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Мүмкін панельдер атауларын шығару және шығу"
+
+#~ msgid "Panel to display"
+#~ msgstr "Көрсетілетін панель"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[ПАНЕЛЬ] [АРГУМЕНТ…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Қолжетерлік панельдер:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Жүйелік дыбыстар"
+
+#~ msgid "Light"
+#~ msgstr "Ашық түсті"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;экран;блоктау;диагностика;құлау;жеке;жуырдағы;уақытша;"
+#~ "индекс;аты;желі;анықтағыш;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Экрандар орналасуы"
+
+#~ msgid "Set"
+#~ msgstr "Орнату"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Экранды бұғаттау"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER немесе PEM сертификаттары (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Bark"
+#~ msgstr "Иттің үруі"
+
+#~ msgid "Drip"
+#~ msgstr "Тамшылау"
+
+#~ msgid "Glass"
+#~ msgstr "Шыны"
+
+#~ msgid "Sonar"
+#~ msgstr "Сонар"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "GNOME баптаулары дыбыс панелі"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "GNOME баптаулары тышқан және тачпад панелі"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "GNOME баптаулары фон панелі"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "GNOME баптаулары пернетақта панелі"
 
 #~ msgid "Web Links"
 #~ msgstr "Веб сілтемелері"
@@ -8734,8 +8230,8 @@ msgstr "Жүйелік дыбыстар"
 #~ msgstr "Зарядтау мүмкін емес"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Қолданбалардың жеке-жеке рұқсаттарын <a href=\"privacy\">Жекелік</a> "
 #~ "баптауларында қарауға болады."
@@ -8815,17 +8311,11 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "Active Display"
 #~ msgstr "Белсенді экран"
 
-#~ msgid "Display Configuration"
-#~ msgstr "Экран баптаулары"
-
 #~ msgid "More Warm"
 #~ msgstr "Көбірек жылы"
 
 #~ msgid "Less Warm"
 #~ msgstr "Азырақ жылы"
-
-#~ msgid "Screenshots"
-#~ msgstr "Скриншоттар"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "Скриншотты $PICTURES ішіне сақтау"
@@ -8871,10 +8361,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "Allow the applications below to determine your location."
 #~ msgstr "Төмендегі қолданбаларға орналасуыңызды анықтауды рұқсат ету."
-
-#~ msgctxt "lock_screen"
-#~ msgid "5 minutes"
-#~ msgstr "5 минут"
 
 #~ msgid "Allow the applications below to use your microphone."
 #~ msgstr "Төмендегі қолданбаларға микрофоныңызды қолдануды рұқсат ету."
@@ -8945,17 +8431,11 @@ msgstr "Жүйелік дыбыстар"
 #~ "Экранмен бөлісу көмегімен қашықтағы пайдаланушылар %s адресіне байланысу "
 #~ "арқылы экраныңызды қарай немесе басқара алады"
 
-#~ msgid "Copy"
-#~ msgstr "Көшіру"
-
 #~ msgid "_Screen Sharing"
 #~ msgstr "Э_кранмен бөлісу"
 
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr "Желі болмаған соң кейбір қызметтер сөндірілген."
-
-#~ msgid "Screen Sharing"
-#~ msgstr "Экранмен бөлісу"
 
 #~ msgid "_Password:"
 #~ msgstr "_Пароль:"
@@ -8980,9 +8460,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "_Screen Reader"
 #~ msgstr "Экра_ннан оқитын қолданба"
-
-#~ msgid "_Full Name"
-#~ msgstr "То_лық аты"
 
 #~ msgid "Standard"
 #~ msgstr "Қалыпты"
@@ -9049,9 +8526,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Планшет (абсолютті)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Планшет (салыстырмалы)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Планшет баптаулары"
 
@@ -9073,30 +8547,12 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "Adjust display resolution"
 #~ msgstr "Экран ажыратымдылығын баптау"
 
-#~ msgid "Default"
-#~ msgstr "Бастапқы"
-
-#~ msgid "Middle Mouse Button Click"
-#~ msgstr "Тышқанның орта батырма шертуі"
-
-#~ msgid "Right Mouse Button Click"
-#~ msgstr "Тышқанның оң жақ батырма шертуі"
-
-#~ msgid "Forward"
-#~ msgstr "Алға"
-
 #~ msgid "No stylus found"
 #~ msgstr "Стилус табылмады"
 
 #~ msgid ""
 #~ "Please move your stylus to the proximity of the tablet to configure it"
 #~ msgstr "Планшетті баптау үшін стилусты оған жақындатыңыз"
-
-#~ msgid "Soft"
-#~ msgstr "Жоғары"
-
-#~ msgid "Firm"
-#~ msgstr "Төмен"
 
 #~ msgid "Top Button"
 #~ msgstr "Жоғарғы батырма"
@@ -9472,9 +8928,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "Changes throughout the day"
 #~ msgstr "Ауыстырып отыру"
-
-#~ msgid "_Lock Screen"
-#~ msgstr "Б_локтау экраны"
 
 #~ msgctxt "background, style"
 #~ msgid "Tile"
@@ -10015,9 +9468,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "Co­lor"
 #~ msgstr "Түс"
 
-#~ msgid "Section"
-#~ msgstr "Санат"
-
 #~ msgid "Overview"
 #~ msgstr "Шолу"
 
@@ -10079,9 +9529,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "Mirrored"
 #~ msgstr "Айналы"
-
-#~ msgid "Secondary"
-#~ msgstr "Екіншілік"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Топталған экрандарды реттеу"
@@ -10158,9 +9605,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "Automatic"
 #~ msgstr "Автоматты"
 
-#~ msgid "_Method"
-#~ msgstr "Тә_сіл"
-
 #~ msgid "VPN Type"
 #~ msgstr "VPN түрі"
 
@@ -10192,9 +9636,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgstr ""
 #~ "Бұл желі үшін барлық баптауларды тастау және автобайланысу талаптарын "
 #~ "жасамау"
-
-#~ msgid "Loading options…"
-#~ msgstr "Жүктеу опциялары…"
 
 #~ msgid ""
 #~ "If you have a connection to the Internet other than wireless, you can set "
@@ -10274,9 +9715,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "Mail"
 #~ msgstr "Эл. пошта"
 
-#~ msgid "Calendar"
-#~ msgstr "Күнтізбе"
-
 #~ msgid "Contacts"
 #~ msgstr "Контакттар"
 
@@ -10313,9 +9751,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "label"
 #~ msgstr "белгі"
 
-#~ msgid "Setting new driver…"
-#~ msgstr "Жаңа драйверді орнату…"
-
 #~ msgid "Print _Test Page"
 #~ msgstr "Сы_ану парағын баспаға шығару"
 
@@ -10325,9 +9760,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "Other Accounts"
 #~ msgstr "Басқа тіркелгілер"
-
-#~ msgid "Edit"
-#~ msgstr "Түзету"
 
 #~ msgctxt "button"
 #~ msgid "Set Shortcut"
@@ -10348,9 +9780,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "Бұл әрекет нәтижесінде тіркелгі серверден өшірілмейді."
-
-#~ msgid "_Remove"
-#~ msgstr "Ө_шіру"
 
 #~ msgid "No online accounts configured"
 #~ msgstr "Желілік тіркелгілер бапталмады"
@@ -10433,9 +9862,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Жоғары айналдыру"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Төмен айналдыру"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Оңға айналдыру"
@@ -10552,9 +9978,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "_Sign In"
 #~ msgstr "_Кіру"
 
-#~ msgid "Personal File Sharing"
-#~ msgstr "Жеке файлдармен бөлісу"
-
 #~ msgid "Login History"
 #~ msgstr "Жүйеге кіру тарихы"
 
@@ -10632,9 +10055,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "Job State"
 #~ msgstr "Тапсырма күйі"
 
-#~ msgid "Options"
-#~ msgstr "Опциялар"
-
 #~ msgid "Password:"
 #~ msgstr "Пароль:"
 
@@ -10711,9 +10131,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "Fast"
 #~ msgstr "Жылдам"
 
-#~ msgid "No printers available"
-#~ msgstr "Қолжетерлік принтерлер жоқ"
-
 #~ msgid "Add New Printer"
 #~ msgstr "Жаңа принтерді қосу"
 
@@ -10761,9 +10178,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "China"
 #~ msgstr "Қытай"
 
-#~ msgid "Disable while _typing"
-#~ msgstr "_Теру кезінде сөндіру"
-
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "Жүйелік желілік қызметтер бұл нұсқасымен үйлеспейді."
 
@@ -10786,9 +10200,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "Sorry"
 #~ msgstr "Кешіріңіз"
-
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "Жаңа құрылғыны орнату"
@@ -11094,10 +10505,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "C_ontinue"
 #~ msgstr "Жа_лғастыру"
 
-#~| msgid "Preview"
-#~ msgid "Previous Week"
-#~ msgstr "Алдыңғы апта"
-
 #~ msgid "Next week"
 #~ msgstr "Келесі апта"
 
@@ -11277,9 +10684,6 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "Add Language"
 #~ msgstr "Тілді қосу"
 
-#~ msgid "Install languages..."
-#~ msgstr "Тілдерді орнату..."
-
 #~ msgid "Select a region (change will be applied the next time you log in)"
 #~ msgstr ""
 #~ "Аймақты таңдаңыз (өзгерістер сіз жүйеге келесі рет кіргенде іске асады)"
@@ -11314,9 +10718,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "Жөндеу кодын іске қосу"
-
-#~ msgid "_Mute"
-#~ msgstr "_Басу"
 
 #~ msgid "_Sound Preferences"
 #~ msgstr "Д_ыбыс баптаулары"
@@ -11362,10 +10763,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "_Left-handed"
 #~ msgstr "_Солақай"
-
-#~| msgid "_Acceleration:"
-#~ msgid "A_cceleration:"
-#~ msgstr "Үд_ету:"
 
 #~ msgid "Drag and Drop"
 #~ msgstr "Ұстап апару мен тастау"
@@ -11431,9 +10828,6 @@ msgstr "Жүйелік дыбыстар"
 
 #~ msgid "Layouts"
 #~ msgstr "Жаймалар"
-
-#~ msgid "Layout"
-#~ msgstr "Жайма"
 
 #~ msgid "Dasher"
 #~ msgstr "Dasher"
@@ -11522,17 +10916,11 @@ msgstr "Жүйелік дыбыстар"
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "_Бастапқы түріне келтіру"
-
 #~ msgid "_Size:"
 #~ msgstr "Ө_лшемі:"
 
 #~ msgid "_Slight"
 #~ msgstr "Әл_сіз"
-
-#~ msgid "_Windows:"
-#~ msgstr "_Терезелер:"
 
 #~ msgid "Image"
 #~ msgstr "Сурет"

--- a/po/kk.po~
+++ b/po/kk.po~
@@ -1,0 +1,12591 @@
+# Kazakh translation for gnome-control-center.
+# Copyright (C) 2017 gnome-control-center's COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center package.
+# Baurzhan Muftakhidinov <baurthefirst@gmail.com>, 2010-2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"PO-Revision-Date: 2022-09-18 13:06+0600\n"
+"Last-Translator: Baurzhan Muftakhidinov <baurthefirst@gmail.com>\n"
+"Language-Team: Kazakh <kk_KZ@googlegroups.com>\n"
+"Language: kk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Жүйелік шина"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Толық қатынау құқығы"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Сессия шинасы"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Құрылғылар"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "/dev бумасына толық қатынау құқығы"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Желі"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Желіге қатынау құқығы бар"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Үй"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Тек оқу үшін"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Файлдық жүйе"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Баптаулар"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Баптауларды өзгерте алады"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s келесі құрамындағы рұқсаттарға ие. Оларды өзгерту мүмкін емес. Бұл "
+"рұқсаттар жөнінде қобалжысаңыз, бұл қолданбаны өшіру мүмкіндігін "
+"қарастырыңыз."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "Қолданбамен ашылатын %u файл және сілтеме түрлері"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> келесі түрдегі файлдар және сілтемелерді ашу үшін қолданылады."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "Диск орнынан %s қолданылуда."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Қолданбалар"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Қолданбалар жоқ"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Бірнешеуін орнату…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Ашу"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Көбірек ақпарат"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Іздеу"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Жүйелік іздеулерді алу және нәтижелерді жіберу."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Сөндірулі"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Хабарламалар"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Жүйелік хабарламаларды көрсету."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Фонда орындау"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Қолданба жабылған кезде белсенділікті рұқсат ету."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Скриншоттар"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Экран скриншоттарын кез келген уақытта түсіріңіз."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Тұсқағазды өзгерту"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Жұмыс үстелі тұсқағазын өзгерту."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Дыбыстар"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Дыбыстарды ойнату."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Жарлықтарды басу"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Жүйелік пернетақта жарлықтарын басу."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Камера"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Суреттерді камерамен түсіру."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Микрофон"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Дыбысты микрофонмен жазу."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Орналасулар қызметі"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Құрылғының орналасу деректеріне қатынау."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Құрамындағы рұқсаттар"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Қолданба талап ететін жүйелік рұқсат"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Файлдар мен сілтемелер ассоциациялары"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Сақтау құрылғылары"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Нәтижелер табылмады"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Басқа сөздерді іздеп көріңіз"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Файлдар мен сілтемелер ассоциациялары"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Файл түрлері"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Сілтеме түрлері"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Тастау"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Бұл қолданба өз деректері мен кэш деректерімен қанша диск орнын алып тұр."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Қолданба"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Деректер"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Кэш"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Жалпы</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Кэшті тазарту…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Қолданбалардың түрлі рұқсаттарын және баптауларын басқару"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "application;flatpak;permission;setting;қолданба;рұқсат;баптау;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Суретті таңдау"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Ба_с тарту"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "А_шу"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "бірнеше өлшемдер"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Түсқағаз жоқ"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Ағымдағы фон"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Стиль"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Бастапқы"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Қараңғы"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Фон"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Суретті қосу…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Сыртқы түрі"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Фон суретін немесе интерфейс түстерін өзгерту"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;Фон;Түсқағаз;"
+"Экран;Жұмыс үстелі;Стиль;Ашық түсті;Қараңғы түсті;Сыртқы түрі;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Іске қосу"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Bluetooth адаптерлері табылмады"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Bluetooth қолдану үшін адаптер салыңыз."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth сөндірілген"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Құрылғылармен байланысу және файларды қабылдау үшін іске қосыңыз."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Ұшақтағы режим іске қосулы тұр"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Ұшақтағы режим іске қосулы кезінде Bluetooth сөндірілген болады."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Ұшақтағы режимді сөндіру"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Құрылғылық ұшақтағы режим іске қосулы тұр"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Bluetooth іске қосу үшін ұшақтағы режимді сөндіріңіз."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+"Bluetooth-ды іске қосыңыз немесе сөндіріңіз және құрылғыларды байланыстырыңыз"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;бөлісу;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Камера сөндірілген"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Суреттерді немесе видеоны ешбір қолданба түсіре алмайды."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Камераны қолдану қолданбаларға фото және видеоны түсіру мүмкіндігін береді. "
+"Камераны сөндіру кейбір қолданбалардың дұрыс жұмыс жасамауына әкеп соғуы "
+"мүмкін.\n"
+"Төмендегі қолданбаларға камераны қолдануды рұқсат етіңіз."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Ешбір қолданба Камераға қатынау рұқсатын сұрамады"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Суреттерді қорғау"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;камера;фото;видео;веб-камера;"
+"блоктау;жеке;жекелік;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Калибрация құрылғысын шаршыға апарып, \"Бастау\" басыңыз"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "Калибрация құрылғысын калибрация орнына апарып, \"Жалғастыру\" басыңыз"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Калибрация құрылғысын бет орнына апарып, \"Жалғастыру\" басыңыз"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Қақпақты жабыңыз"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Өндеуге келмейтін ішкі қате орын алды."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Калибрация үшін керек саймандар орнатылмаған."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Профильді жасау мүмкін емес."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Мақсат ақ нүктесіне жету мүмкін емес."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Аяқталды!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Калибрация сәтсіз аяқталды!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Калибрация құрылғысын алып тастауға болады."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Үрдіс жүру кезінде калибрация құрылғысына тиіспеңіз"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Экран калибрациясы"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "Ба_стау"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "Жа_лғастыру"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Дайын"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Ноутбук экраны"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Құрамындағы вебкамера"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s мониторы"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s сканері"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s камерасы"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s принтері"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s вебкамерасы"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s үшін түстерді басқаруды іске қосу"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s үшін түстер профильдерін көрсету"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Калибрацияланбаған"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Бастапқы: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Түстер кеңістігі: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Сынама профилі: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "ICC профилі файлын таңдаңыз"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "И_мпорттау"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Қолдауы бар ICC профильдері"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Барлық файлдар"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Экран"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Профильді сақтау"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Сақтау"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Таңдалған құрылғы үшін түстер профилін жасау"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Өлшеу құрылғысы анықталмады, Оның іске қосулы екенін және дұрыс жалғанып "
+"тұрғанын тексеріңіз."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Өлшеу құрылғысы принтерлерді профильдеуді қолдамайды."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Құрылғының бұл түріне ағымда қолдау жоқ."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Экран калибрациясы"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Калибрация сапасы"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Калибрация монитордың түсін басқару үшін қолдануға болатын профильді "
+"жасайды. Калибрация неғұрлым көбірек уақытты алса, соғұрлым түс профилінің "
+"сапасы жақсылау болады."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Калибрация орындалып жатқан кезде компьютеріңізді қолдана алмайтын боласыз."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Сапасы"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Шамамен уақыты"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Калибрация құрылғысы"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Калибрация үшін қолданғыңыз келетін сенсорлық құрылғыны таңдаңыз."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Экран түрі"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Жалғанған экран түрін таңдаңыз."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Ақ нүкте профилі"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Экранның мақсат ақ нүктесін таңдаңыз. Экрандардың көбі D65 жарықтанудың түс "
+"температурасына бапталған болуы тиіс."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Экран жарықтылығы"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Экран жарықтылығын өзіңізге лайық шамаға орнатыңыз. Түсті басқару "
+"жарықтылықтың сол деңгейінде ең дәл болады."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Немесе, бұл құрылғыға арналған басқа түстер профильдері қолданатын "
+"жарықтылық деңгейін қолдана аласыз."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Профиль атауы"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Сіз басқа компьютерлерде де түс профилін қолдана аласыз, және де басқа "
+"жарықтану деңгейлері үшін де профильдерді жасай аласыз."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Профиль атауы:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Қорытынды"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Профиль сәтті жасалды!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Профильді көшіру"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Жазуға болатын тасушыны талап етеді"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Түс профилін <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> "
+"және <a href=\"windows\">Microsoft Windows</a> жүйелерінде қалай пайдалану "
+"туралы ақпаратты қолдана аласыз."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Профильді қосу"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Мәселелер анықталды. Профиль дұрыс жұмыс жасамауы мүмкін. <a href="
+"\"\">Ақпаратын көрсету.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "Файлды _импорттау…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "Қ_осу"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Түстерін басқару үшін әр құрылғыда жаңа болып тұрған түстер профилі болуы "
+"керек."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Көбірек білу"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Түсті басқару туралы көбірек біліңіз"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Барлық пайдаланушылар үшін _орнату"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Бұл профильді осы компьютердегі барлық пайдаланушылары үшін орнату"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "Іск_е қосу"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Профильді қ_осу"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Калибрациялау…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Құрылғыны калибрациялау"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Профильді ө_шіру"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Көбірек ақпарат"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Түстерін басқаруға болатын бірде-бір құрылғы табылмады"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Проектор"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL жарықтануы)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED жарықтануы)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (ақ LED жарықтануы)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Кең түсті палитралы LCD (CCFL жарықтануы)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Кең түсті палитралы LCD (RGB LED жарықтануы)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Жоғары"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 минут"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Орташа"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 минут"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Төмен"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 минут"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Экранның өздік"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Баспаға шығару және жариялау)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Фотосуреттер және графика)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Қалыпты кеңістік"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Профильді сынау"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Автоматты түрде"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Төмен сапалы"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Орташа сапалы"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Жоғары сапалы"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Бастапқы RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Бастапқы CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Бастапқы сұр"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Жасаушы ұсынған зауыттық калибрация ақпараты"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Бұл профильмен толық экран мониторын түзету мүмкін емес"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Бұл профиль дұрыс емес болуы мүмкін"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Түс"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Экрандар, камералар және принтерлер сияқты құрылғыларыңыздың түстерін "
+"калибрациялаңыз"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Color;ICC;Profile;Calibrate;Printer;Display;Түс;ICC;Профиль;Калибрациялау;"
+"Принтер;Экран;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Басқа…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Тілді таңдау"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "Таң_дау"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Тілдер табылмады"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Көбірек…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Параметрлерді өзгерту үшін бұғаттауын шешу"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Кейбір баптауларды өзгерту үшін олардың бұғаттауын шешу керек."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Бұғаттауды шешу…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Сағатты арттыру"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Минутты арттыру"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Уақыт"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Сағатты кеміту"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Минутты кеміту"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Бүгін"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Кеше"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d сағат"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d минут"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d секунд"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 секунд"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Қатынау нүктесі"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 сағат"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Күн және уақыт"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Жыл"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Ай"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Қаңтар"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Ақпан"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Наурыз"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Сәуір"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Мамыр"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Маусым"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Шілде"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Тамыз"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Қыркүйек"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Қазан"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Қараша"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Желтоқсан"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Күн"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Уақыт белдеуі"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Қаланы іздеу"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Автоматты түрде _күн және уақыт"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Интернетпен байланысты талап етеді"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Күн және уақы_т"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Автоматты түрде _уақыт белдеуі"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+"Орналасулар қызметінің іске қосылуын және интернетке қатынауды талап етеді"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Іске қосулы"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Уақыт бе_лдеуі"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Уақыт пі_шімі"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Күн мен уақытты (уақыт белдеуімен қоса) өзгерту"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;Сағат;Уақыт белдеуі;Орналасу;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Жүйелік уақыт пен күнді өзгерту"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Уақыт немесе күн баптауларын өзгерту үшін аутентификация керек."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "В_еб"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Пошта"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Күнтізбе"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "Му_зыка"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "В_идео"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "Фо_толар"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Үнсіз келісім қолданбалары"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Үнсіз келісім қолданбаларын баптау"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"default;application;preferred;media;үнсіз келісім;қолданба;таңдамалы;тасушы;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Техникалық мәселелер жөнінде хабарламаларды жіберу бізге %s жақсартуға "
+"көмектеседі. Хабарламалар анонимды түрде жіберіледі және олардан жеке "
+"деректер кетіріледі. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Мәселелерді хабарлау"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Мәселелер жөнінде _автохабарлау"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Диагностика"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Мәселелер туралы хабарлау"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#| msgid "Diagnostics"
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;диагностика;құлау;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Іске қосулы"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Off"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Өзгеірстерді іске асыру керек пе?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Өзгерістерді іске асыру мүмкін емес"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Бұл құрылғылық шектеулерден болуы мүмкін."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "Іске _асыру"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Артқа"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Экран баптаулары сөндірулі тұр"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Бірнеше экран"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Қосылу"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Айналы"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Жоғарғы жолақ пен Белсенділіктерді қамтиды"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Біріншілік экран"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Түнгі жарық"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Жатық"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Тік, оң жақ"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Тік, сол жақ"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Жатық (айналған)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Гц"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Бағдары"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Ажыратылымдығы"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Жаңарту жиілігі"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Теледидар үшін баптау"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Масштабтау"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Түнгі жарық қолжетімді емес"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Бұл қолданылатын графикалық драйвердің немесе жұмыс үстелінің қашықтан "
+"қолданылуының нәтижесі болуы мүмкін"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Ертеңге дейін уақытша сөндірілген"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Сүзгіні қайта іске қосу"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Түнгі жарық экран түстерін жылы қылады. Бұл көз тігуін және ұйқышылдыққа жол "
+"бермеуге көмектесуі мүмкін."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Жоспар"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Күн батуынан күн шығысына дейін"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Қолмен жоспарлау"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Уақыттар"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Бастап"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Сағат"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Минут"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Дейін"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Түстік температурасы"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Экран­дар"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Жалғанған мониторлар мен проекторларды қолдану тәсілін таңдаңыз"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;Панель;Проектор;xrandr;Экран;Ажыратылымдығы;"
+"Жаңарту;Монитор;Түн;Жарық;Көк;түс;күннің шығуы;күннің батуы;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:109
+msgid "Secure Boot is Active"
+msgstr "Қауіпсіз жүктеу белсенді"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Қауіпсіз жүктеу құрылғы іске қосылғанда зиянды бағдарламалық қамтаманың "
+"жүктелуіне жол бермейді. Қазіргі уақытта ол іске қосылған, дұрыс жұмыс "
+"істейді."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Қауіпсіз жүктеуде мәселелер бар"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Қауіпсіз жүктеу құрылғы іске қосылғанда зиянды бағдарламалық қамтаманың "
+"жүктелуіне жол бермейді. Қазіргі уақытта ол іске қосылған, бірақ кілттің "
+"жарамсыз болуына байланысты жұмыс істемейді."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Қауіпсіз жүктеу сөндірілген"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Қауіпсіз жүктеу құрылғы іске қосылғанда зиянды бағдарламалық қамтаманың "
+"жүктелуіне жол бермейді. Қазіргі уақытта ол сөндірілген."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Сәтті"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Сәтсіз"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:482
+msgid "Security Level 0"
+msgstr "Қауіпсіздік деңгейі 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:489
+msgid "Security Level 1"
+msgstr "Қауіпсіздік деңгейі 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:496
+msgid "Security Level 2"
+msgstr "Қауіпсіздік деңгейі 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:503
+msgid "Security Level 3"
+msgstr "Қауіпсіздік деңгейі 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:518
+msgid "Security Level"
+msgstr "Қауіпсіздік деңгейі"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:519
+msgid "Security levels are not available for this device."
+msgstr ""
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Деңгей 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Деңгей 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Деңгей 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:110
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:116
+msgid "Secure Boot has Problems"
+msgstr "Қауіпсіз жүктеуде мәселелер бар"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:117
+msgid "Some protection when the device is started."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:122
+msgid "Secure Boot is Off"
+msgstr "Қауіпсіз жүктеу сөндірулі"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:123
+msgid "No protection when the device is started."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:142
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:150
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:157
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:483
+msgid "Exposed to serious security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:490
+msgid "Limited protection against simple security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:497
+msgid "Protected against common security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:504
+#: panels/firmware-security/cc-firmware-security-panel.c:512
+msgid "Protected against a wide range of security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:511
+msgid "Comprehensive Protection"
+msgstr "Кешенді қорғау"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Оқиғалар жоқ"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Бинарлы кодтарды жазудан қорғанысы"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Бинарлы кодтарды жазудан қорғанысының бұғаты"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Бинарлы кодтар BIOS аймағы"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Бинарлы кодтар BIOS дескрипторы"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr ""
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET іске қосылған"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET белсенді"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Шифрленген жады"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU қорғанысы"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr ""
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux ядросын тексеру"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Жадыға ұйықтату"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Бос етіп ұйықтату"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI платформа кілті"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI қауіпсіз жүктеуі"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+#| msgid "Display Configuration"
+msgid "TPM Platform Configuration"
+msgstr "TPM платформасы баптаулары"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM қайта құруы"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Бинарлы кодтар жаңартулары"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Бинарлы кодтар аттестациясы"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Бинарлы кодтар жаңартушы тексерісі"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr ""
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD бинарлы кодтар қайта ойнату"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD Firmware жазу қорғанысы"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr ""
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Жарамды"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Жарамды емес"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Іске қосылмаған"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Бұғатталған"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Бұғатталмаған"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Шифрленген"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Шифрленген емес"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr ""
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+#| msgid "Not calibrated"
+msgid "Not Tainted"
+msgstr ""
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Табылған"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Табылмаған"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Қолдауы бар"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Қолдауы жоқ"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Қолдауы жоқ"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;экран;блоктау;диагностика;құлау;жеке;жуырдағы;"
+"уақытша;индекс;аты;желі;анықтағыш;жекелік;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Белгісіз"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-биттік"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-биттік"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Белгісіз"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Қолжетімді емес"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Жүйелік логотип"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Құрылғы атауы"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Құрылғы моделі"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Жады"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Процессор"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Графика"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Диск сыйымдылығы"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Есептеу…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "ОЖ атауы"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ОЖ жинақ ID-і"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "ОЖ түрі"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME нұсқасы"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Жүктеу…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Терезе жүйесі"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Виртуализация"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Бағд. қамтама жаңартулары"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Құрылғы атын ауыстыру"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Құрылғы атауы бұл құрылғыны желі арқылы қараған кезде немесе Bluetooth "
+"құрылғыларымен жұпталып жатқанда анықтау үшін қолданылады."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Құрылғы атауы"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "Атын ауысты_ру"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Осы туралы"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Жүйеңіз туралы ақпаратты қараңыз"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"құрылғы;жүйе;ақпарат;хост;жады;процессор;нұсқасы;үнсіз келісім;қолданба;"
+"таңдамалы;аудио;видео;диск;ауыстырмалы;тасушы;автожөнелту;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Дыбыс және медиа"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Дыбысты басу/іске қосу"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Дыбысты азайту"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Дыбысты көтеру"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Микрофон дыбысын өшіру/іске қосу"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Медиа ойнатқышын жөнелту"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Ойнату (не ойнату/аялдату)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Ойнатуды аялдату"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Ойнатуды тоқтату"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Алдыңғы трек"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Келесі трек"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Шығару"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Теру"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Келесі кіріс көзіне ауысу"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Алдыңғы кіріс көзіне ауысу"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Жөнелткіштер"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Көмек шолушысын жөнелту"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Калькуляторды жөнелту"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Эл. пошта клиентін жөнелту"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Веб браузерін жөнелту"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Үй бумасы"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Іздеу"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Жүйелік"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Шығу"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Блоктау экраны"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Қолжетерлілік"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Масштабтауды іске қосу/сөндіру"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Үлкейту"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Кішірейту"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Экраннан оқитын қолданбаны іске қосу/сөндіру"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Экрандағы пернетақтаны іске қосу/сөндіру"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Мәтін өлшемін үлкейту"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Мәтін өлшемін кішірейту"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Жоғары контраст іске қосулы/сөндірулі"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Кіріс қайнар көздері табылмады"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Басқа"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Кіріс қайнар көзін қосу"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Енгізу тәсілдерін жүйеге кіру экранында қолдануға болмайды"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Кіріс қайнар көзді таңдалмады"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Опциялар"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Жоғары жылжыту"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Төмен жылжыту"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Баптаулар"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Пернетақта жаймасын қарау"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Өшіру"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Таңдауыңызша жарлықтар"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Альтернативті таңбалар пернесі"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Балама таңбалар пернесін қосымша таңбаларды енгізу үшін пайдалануға болады. "
+"Олар кейде пернетақтадағы үшінші параметр ретінде көрсетіледі."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Сол жақ Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Оң жақ Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Сол жақ Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Оң жақ Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menu пернесі"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Оң жақ Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose пернесі"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Түрлендіру пернесі таңбалардың кең жиынтығын енгізуді мүмкін қылады. Оны "
+"қолдану үшін, түрлендіру пернесін басып, одан кейін таңдалар тізбегін "
+"теріңіз. Мысалы, түрлендіру пернесінен кейін <b>C</b> және <b>o</b> басылса, "
+"<b>©</b> енгізіледі, <b>a</b> мен <b>'</b> басылса, <b>á</b> егізіледі."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Енгізу қайнар көздерін %s пернетақта жарлығы көмегімен ауыстыруға болады.\n"
+"Бұл жарлықты пернетақта баптауларында өзгертуге болады."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Кіріс қайнар көздері"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Пернетақта жаймалары және енгізу тәсілдерін қамтиды."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Кіріс қайнар көзін ауыстыру"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Бір кірі_с қайнар көзін барлық терезелер үшін қолдану"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Әр терезе үшін кіріс қайнар көзін бө_лек өзгерту"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Арнайы таңбаларды енгізу"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Пернетақтаны пайдаланып таңбалар мен әріп нұсқаларын енгізу әдістері."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Пернетақта жарлықтары"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Жарлықтарды қарау және баптау"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d өзгертілген"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Барлық жарлықтарды тастау керек пе?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Жарлықтарды тастау таңдауыңызша жарлықтарды кетіруі мүмкін. Бұл әрекетті "
+"болдырмау мүмкін болмайды."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Болдырмау"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Барлығын тастау"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Барлығын тастау…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Барлық жарлықтарды бастапқы мәндеріне тастау"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Санат"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Жарлықтар"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Жарлықты қосу"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Таңдауыңызша жарлықтарды қосу"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Қолданбаларды жөнелту, скриптерді орындау және т.б. үшін таңдауыңызша "
+"жарлықтарды баптау."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Жарлықты қосу"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Пернетақта жарлықтары табылмады"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s жарлығы %s үшін қолданылуда болып тұр. Оны алмастырсаңыз, %s сөндірілетін "
+"болады"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Жаңа пернетақта жарлығын енгізіңіз"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Таңдауыңызша жарлықты орнату"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Жарлықты орнату"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "%s өзгерту үшін жаңа жарлықты енгізіңіз."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Таңдауыңызша жарлықты қосу"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Ө_шіру"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Ал_мастыру"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Орнату"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Бас тарту үшін Esc, ал, пернетақта жарлығын сөндіру үшін Backspace басыңыз."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Аты"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Команда"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Жарлық"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Жарлықты орнату…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ешнәрсе"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Жарлықты бастапқы мәніне тастау"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Пернетақта"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Пернетақта жарлықтарын өзгерту және теру баптауларын, пернетақта жаймаларын "
+"және кіріс қайнар көздерін орнату"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+"Жарлық;Жұмыс орны;Терезе;Өлшемді өзгерту;Масштаб;Контраст;Енгізу;Қайнар көзі;"
+"Блоктау;Дыбыс;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Орналасулар қызметі сөндірулі тұр"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Орналасу ақпаратын ешбір қолданба ала алмайды."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Орналасу қызметтері бағдарламаларға орналасуыңызды білуге мүмкіндік береді. "
+"Wi-Fi және мобильді кеңжолақты байланысты пайдалану дәлдікті арттырады.\n"
+"\n"
+"Mozilla орналасулар қызметін пайдаланады: <a href='https://location.services."
+"mozilla.com/privacy'>Құпиялылық саясаты</a>\n"
+"\n"
+"Төмендегі қолданбаларға орналасуыңызды қолдануды рұқсат етіңіз."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Ешбір қолданба Орналасуға қатынау рұқсатын сұрамады"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Орналасу ақпаратын қорғау"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;орналасу;жеке;жекелік;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Микрофон сөндірулі тұр"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Дыбыс жаза алатын қолданбалар табылмады."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Микрофонды қолдану қолданбаларға аудионы тыңдау және жазу мүмкіндігін "
+"береді. Микрофонды сөндіру кейбір қолданбалардың дұрыс жұмыс жасамауына әкеп "
+"соғуы мүмкін.\n"
+"Төмендегі қолданбаларға микрофонды қолдануды рұқсат етіңіз."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Ешбір қолданба Микрофонға қатынау рұқсатын сұрамады"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Сөйлесулерді қорғау"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"microphone;recording;application;privacy;микрофон;жазу;қолданба;жекелік;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Ба_птауларды тексеру"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Жалпы"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Біріншілік батырма"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Тышқандар және тачпадтарда физикалық батырмалар ретін орнатады."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Сол жақ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Оң жақ"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Тышқан"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Тышқан курсорының жылдамдығы"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Табиғи айналдыру"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Айналдыру көріністі емес, құраманы жылжытады."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Тачпад"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Тачпад жылдамдығы"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Шерту үшін тию"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Шерту үшін тию"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Қос саусақпен айналдыру"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Бұрышпен айналдыру"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Шерту, қос шерту, айналдыруды көріңіз"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Бес рет шерту, GEGL уақыты!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Қос шерту, біріншілік батырма"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Бірлік шерту, біріншілік батырма"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Қос шерту, орта батырмасы"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Бірлік шерту, орта батырмасы"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Қос шерту, екіншілік батырма"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Бірлік шерту, екіншілік батырма"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Тышқан және тач­пад"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Тышқан немесе тачпад сезімталдығын өзгертіңіз және оң немесе солақай режимін "
+"көрсетіңіз"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;Трекпад;Курсор;"
+"Шерту;Тию;Қос;Батырма;Трекбол;Скролл;Айналдыру;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Ыстық бұрыш"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Белсенділіктер көрінісін ашу үшін, жоғарғы сол жақ бұрышына тиіңіз."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Белсенді экран шеттері"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Терезелер өлшемін өзгерту үшін оларды жоғарғы, сол және оң жақ экран "
+"шеттеріне тартып апарыңыз."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Жұмыс орындары"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Динамикалық жұмыс орындары"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Бос жұмыс орындарын автоматты түрде өшіреді."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "Жұмыс орындарының _бекітілген саны"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Тұрақты жұмыс орындар санын көрсетіңіз."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "Жұмыс орындар са_ны"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Көпмониторлы"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Жұмыс орындары тек _біріншілік экранда"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Жұмыс орындары барлық э_крандарда"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Қолданбалар арасында ауысу"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Барлық _жұмыс орындарынан қолданбаларды есепке алу"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Тек ағымдағы _жұмыс орнынан қолданбаларды есепке алу"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Көптапсырмалылық"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Өнімділік және көптапсырмалылық баптауларын басқару"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"көптапсырмалылық;өнімділік;баптау;жұмыс үстелі;ыстық бұрыш;жұмыс орындары;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Қап, бірнәрсе қате кетті. БҚ өндірушісіне хабарласыңыз."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager орындалып тұруы тиіс."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Басқа құрылғылар"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Байланысты қосу"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Бапталмаған"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Қорғалмаған желі (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Қауіпсіз желі (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Қауіпсіз желі (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Қауіпсіз желі (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Қауіпсіз желі"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Байланысқан"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Опциялар…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Қатынау нүктесін іске қосу нәтежесінде %s желісі ажыратылады, интернетке Wi-"
+"Fi арқылы байланысуға мүмкін болмайды."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Кем дегенде 8 таңбадан тұруы тиіс"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Кем дегенде %d таңбадан тұруы тиіс"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi қатынау нүктесін іске қосу керек пе?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-Fi қатынау нүктесі қосылуға болатын Wi-Fi желісін жасау арқылы басқаларға "
+"интернет байланысын ортақ пайдалануға мүмкіндік береді. Ол үшін Wi-Fi-ден "
+"басқа дереккөз арқылы интернет байланысы болуы керек."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Желі атауы"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Кездейсоқ парольді генерациялау"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Парольді автогенерациялау"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "Іс_ке қосу"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Қатынау нүктесін тоқтатып, барлық пайдаланушыларды үзу керек пе?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "Қа_тынау нүктесін тоқтату"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Ұшақтағы режимі"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Wi-Fi, Bluetooth және мобильді кеңжолақты байланыстарды сөндіреді"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Wi-Fi адаптерлері табылмады"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+"Сізде Wi-Fi адаптерінің бар болғанын, және оның іске қосылғанын тексеріңіз"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Ұшақтағы режимі іске қосулы"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Wi-Fi қолдану үшін сөндіру"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi қатынау нүктесі белсенді"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Мобильді құрылғылар байланысу үшін QR кодын сканерлей алады."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Қатынау нүктесін сөндіру…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Көрінетін желілер"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager орындалып тұруы тиіс"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x қауі_псіздігі"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Қауіпсіздік"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Сақтап қалу"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Тұрақты"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Кездейсоқ"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Тұрақты"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Осында енгізілген MAC адресі осы байланысты қолданатын желі құрылғысы үшін "
+"аппараттық мекенжай ретінде пайдаланылады. Бұл мүмкіндік MAC клондау немесе "
+"спуфинг ретінде белгілі. Мысалы: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Профиль %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Жақсартылған ашық"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Кәсіпорын"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Жоқ"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Ешқашан"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i күн бұрын"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Мб/с (%1.1f ГГц)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Мб/с"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Жоқ"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Әлсіз"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ОК"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Жақсы"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Тамаша"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 адресі"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 адресі"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP адресі"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Байланысты ұмыту"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Байланыс профилін өшіру"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "VPN өшіру"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Көбірек білу"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "автоматты"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Идентификация"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Адресті өшіру"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Маршрутты өшіру"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ешнәрсе"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128 биттік кілті (Hex немесе ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128 биттік кілттік фразасы"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Динамикалық WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "Жеке WPA3"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Сигнал деңгейі"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Деректерді өткізу жылдамдығы"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Құрылғы адресі"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Қолдауы бар жиіліктер"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Үнсіз келісім бойынша маршруты"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Соңғы қолданылған"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "_Автоматты түрде байланысу"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Басқа па_йдаланушыларға қолжетерлік қылу"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"Өл_шенетін байланыс: деректер шектеулері бар немесе ақыны талап етуі мүмкін"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Бағдарламалық қамтама жаңартулары және басқа да үлкен жүктеулер автоматты "
+"түрде іске қосылмайды."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Аты"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC _адресі"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Клондалған адрес"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "байт"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 тәсілі"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Автоматты түрде (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Тек жергілікті желі үшін"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Қолмен"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Сөндіру"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Басқа компьютерлерге бөлісілген"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Адрестер"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Адрес"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Желі маскасы"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Автоматты түрде"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Автоматты DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS сервері мекенжай(лар)ы"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "IP адрестерін үтірлермен ажыратыңыз"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Бағдарлар"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Автоматты бағдарлар"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Метрика"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Бұл байланысты тек ол өзі жатқан желі ішіндегі ресурстар үшін қ_олдану"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 тәсілі"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Автоматты түрде, тек DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Префикс"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Байланыстар түзеткішін ашу мүмкін емес"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Жаңа профиль"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Жарамсыз баптау %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Жарамсыз баптау %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Файлдан импорттау…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "VPN қосу"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Қауі_псіздік"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "VPN байланысын импорттау мүмкін емес"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"\"%s\" файлын оқу мүмкін емес, немесе оның ішінде танылған VPN байланыс "
+"ақпараты жоқ\n"
+"\n"
+"Қате: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Импорттау үшін файлды таңдаңыз"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "\"%s\" аты бар файл бар болып тұр."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "А_лмастыру"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "%s орнына сіз сақтаймын деген VPN байланысын сақтау керек пе?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "VPN байланысын экспорттау мүмкін емес"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"\"%s\" VPN байланысын %s ішіне экспорттау мүмкін емес.\n"
+"\n"
+"Қате: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "VPN байланысын экспорттау"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Қате: VPN байланыстары түзетушісін жүктеу мүмкін емес)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Интернетке қалай байланысатыныңызды басқару"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;Желі;Сымсыз;"
+"Прокси;Кеңжолақты;Модем;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Wi-Fi желілеріне қалай байланысатыныңызды басқару"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;Желі;Сымсыз;"
+"Кеңжолақты;Қатынау;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "ешқашан"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "бүгін"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "кеше"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Соңғы қолданылған"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Сымды"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Жаңа байланысты қосу"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Таңдалған желілер үшін желі ақпараты, парольдер және таңдауыңызша жасалған "
+"баптаулар жоғалатын болады."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "Ұ_мыту"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Белгілі Wi-Fi желілері"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "Ұ_мыту"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Қатынау нүктесі ретінде қолдануды жүйелік саясат рұқсат етпейді"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Сымсыз құрылғы қатынау нүкте режимін қолдамайды"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Баптау сілтемесі көрсетілмеген кезде веб проксиін автоанықтау қолданылады."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Бұл әрекет сенімсіз ортақ желілері үшін ұсынылмайды."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Құрылғыны сөндіру"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Белсенді"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Провайдер"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Желілік прокси"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP прокси"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTPS п_роксиі"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "FTP пр_оксиі"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Socks _хосты"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "Хо_сттарды елемеу"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP прокси порты"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS прокси порты"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP прокси порты"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks прокси порты"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Баптау URL-ы"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN байланысын сөндіру"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Желі атауы"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Қауіпсіздік түрі"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Пароль"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi сөндіру"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Көбірек опциялар…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "Жасырын желісіне байланы_су…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi қатынау нүктесін іске қ_осу…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Бел_гілі Wi-Fi желілері"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Қалып-күйі белгісіз"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Басқарылмайтын"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Қолжетерсіз"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Қосылуда"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Аутентификация керек"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Байланысты үзу"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Байланыс орнату сәтсіз"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Қалып-күйі белгісіз (жоқ болып тұр)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Баптау сәтсіз"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP баптауы сәтсіз"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP баптауы ескірген"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Құпия кілттері сұралды, бірақ ұсынылмады"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x supplicant байланысы ажыратылған"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x supplicant баптауы сәтсіз"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x supplicant сәтсіз"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant аутентификация үшін тым көп уақыт алған"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP қызметі іске қосыла алмады"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP қызметі байланысты үзген"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP сәтсіз аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP клиенті іске қосылу қатесі"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP клиент қатесі"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP клиенті сәтсіз аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Ортақ етілген байланыс қызметінің іске қосылу қатесі"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Ортақ етілген байланыс қызметі сәтсіз аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP қызметінің іске қосылу қатесі"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP қызметінің қатесі"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP қызметі сәтсіз аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Арна бос емес"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Арнада гудок жоқ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Тасушыны орнату мүмкін емес"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Қоңырауға бөлінген уақыт аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Қоңырау соғу сәтсіз аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Модемді іске қосу сәтсіз аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Көрсетілген APN таңдау сәтсіз аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Желілерді іздемеу"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Желіге тіркелу тайдырылған"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Желіге тіркелудің мерзімі біткен"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Сұралған желіге тіркелу сәтсіз аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN кодын тексеру сәтсіз"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Құрылғы үшін бинарлық кодтар жоқ болуы мүмкін"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Байланыс жоғалды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Бар болып тұрған байланыс алынды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Модем табылмады"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth байланысы сәтсіз аяқталды"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM картасы салынбаған"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM Pin коды керек"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM Puk коды керек"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM қате"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Байланыс тәуелділігі сәтсіз аяқталды"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Бинарлы кодтары жоқ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Кабель ажыратылған"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "802.1X қауіпсіздігі (wpa-eap) ішіндегі анықталмаған қате"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "файл таңдалмады"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "eap-method файлын растаудағы анықталмаған қате"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 немесе PGP жеке кілттері"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER немесе PEM сертификаттары"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "EAP-FAST PAC файлы жоқ"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC файлдары (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Анонимды"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Аутентификациядан өткен"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Екеуі де"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "А_нонимды аутентификация"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _файлы"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PAC файлын таңдаңыз"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Ішкі _аутентификация"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Автоматты PAC ұсы_нуды рұқсат ету"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "EAP-LEAP пайдаланушы аты жоқ"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "EAP-LEAP паролі жоқ"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Па_йдаланушы аты"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Пароль"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Пар_ольді көрсету"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "жарамсыз EAP-PEAP CA сертификаты: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "жарамсыз EAP-PEAP CA сертификаты: сертификат көрсетілмеген"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Нұсқасы 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Нұсқасы 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "С_О сертификаты"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Сертификаттау орталығының сертификатын таңдаңыз"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "СО сертификаты _керек емес"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP _нұсқасы"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "EAP пайдаланушы аты жоқ"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "EAP паролі жоқ"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "EAP-TLS identity жоқ"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "жарамсыз EAP-TLS CA сертификаты: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "жарамсыз EAP-TLS CA сертификаты: сертификат көрсетілмеген"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "жарамсыз EAP-TLS жеке кілті: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "жарамсыз EAP-TLS пайдаланушы сертификаты: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Шифрленбеген жеке кілттері қауіпсіз емес болады"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Таңдалған жеке кілт парольмен қорғалмаған сияқты. Бұл сіздің қауіпсіздік "
+"есептік жазба деректерінің әшкерелеуіне әкеп соғуы мүмкін. Парольмен "
+"қорғалған жеке кілтті таңдаңыз.\n"
+"\n"
+"(Сіз жеке кілтіңізді openssl көмегімен парольмен қорғай аласыз)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Жеке сертификатыңызды таңдаңыз"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Жеке кілтіңізді таңдаңыз"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Шындылық"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Па_йдаланушы сертификаты"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Жеке _кілт"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Жеке _кілт паролі"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "жарамсыз EAP-TTLS CA сертификаты: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "жарамсыз EAP-TTLS CA сертификаты: сертификат көрсетілмеген"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (EAP емес)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "До_мен"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "802.1X қауіпсіздігін тексерудің белгісіз қатесі"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Туннельденген TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Қорғалған EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Аутен_тификация"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Файлды таңдау"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "leap-username жоқ"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "leap-password жоқ"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Wi-Fi паролі жоқ."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "Тү_рі"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "wep-key жоқ"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"жарамсыз wep-key: ұзындығы %zu кілт ішінде тек оналтылық сандар болуы тиіс"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"жарамсыз wep-key: ұзындығы %zu кілт ішінде тек ascii таңбалары болуы тиіс"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"жарамсыз wep-key: кілт ұзындығы %zu қате. Кілт ұзындығы 5/13 (ascii) немесе "
+"10/26 (оналтылық) болуы тиіс"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "жарамсыз wep-key: кілттік фраза бос емес болуы тиіс"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "жарамсыз wep-key: кілттік фраза 64 таңбадан аз болуы тиіс"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Бастапқы)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Ашық жүйе"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Ортақ кілт"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Кілт"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Кіл_тті көрсету"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP и_ндексі"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"жарамсыз wpa-psk: кілт ұзындығы %zu жарамсыз. Ол [8,63] байт немесе 64 "
+"оналтылық сан болуы тиіс"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"жарамсыз wpa-psk: 64 байты бар кілтті он алтылық кілт ретінде талдау мүмкін "
+"емес"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Хабарламалар"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Дыбыстық х_абарламалар"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Хабарламалық _баннерлер"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Баннерлер сөндірілген кезде хабарламалар хабарламалар тізімінде көрсетілетін "
+"болады."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Баннерде хабарлама құр_амасын көрсету"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Б_локтау экранының хабарламалары"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Блоктау экранында хабарлама құра_масын көрсету"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Мазаламаңыз"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Б_локтау экранының хабарламалары"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Қай хабарламалар және олар нені көрсететінін басқару"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;Banner;Message;Tray;Popup;Хабарлаулар;Баннер;Хабарлама;Трей;"
+"Қалқымалы;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Басқа"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s өшірілді"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Тіркелгіні өшіру қатесі"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Болдырмау"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Хабарламаны жабу"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Бұлттық қызметтердегі деректеріңізге байланысыңыз"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Интернетпен байланыс жоқ — желілік тіркелгілерді баптау үшін интернетке "
+"байланысты орнатыңыз"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Тіркелгіні қосу"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s тіркелгісі"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Тіркелгіні өшіру"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Желілік тіркелгілер"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Желілік тіркелгілеріңізге байланыс орнатыңыз және олар не үшін "
+"қолданылатынын шешіңіз"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;Веб;Онлайн;Чат;Күнтізбе;Эл. пошта;"
+"Контакт;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Уақыты белгісіз"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i минут"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i сағат"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "сағат"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "минут"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s толық зарядқа дейін"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Ескерту: %s қалды"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s қалды"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Толық зарядталған"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Зарядталуда емес"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Бос"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Зарядталуда"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Зарядын беруде"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Сымсыз тышқан"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Сымсыз пернетақта"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Үзіліссіз эл. қорек көзі"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Жеке цифрлық көмекші"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Ұялы телефон"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Медиа плеері"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Планшет"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Компьютер"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Ойын құрылғысы"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батарея"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Басты"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Қосымша"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Батареялар"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "І_ссіз кезінде"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Ұйықтату"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Сөндіру"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Гибернация"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ешнәрсе"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Батареядан жұмыс істеген кезде"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Эл. желісінде"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Ешқашан"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Автоматты түрде ұйықтату"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "Өнімділік режимі уақытша жоғары температура салдарынан сөндірілген."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Тізе анықталды: өнімділік режимі уақытша қолжетімсіз. Оны қалпына келтіру "
+"үшін, құрылғыны тұрақты жерге ораластырыңыз."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Өнімділік режимі уақытша сөндірілген."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Батарея заряды аз: эл. қорегін үнемдеу іске қосылған. Батарея жеткілікті "
+"зарядталған кезде алдыңғы режим қалпына келтіріледі."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Эл. корегін сақтау режимін \"%s\" белсендірген."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Өнімділік режимін \"%s\" белсендірген."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 сағат"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 сағат"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Эл. қуаты режимі"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Жүйе өнімділігіне мен қуат қолданысына әсер етеді."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Эл. қорегін сақтау опциялары"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Автоматты экран жарықтылығы"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Экран жарықтылығы айналадағы жарыққа бейімделеді."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Экранды бәсеңдету"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Компьютер жұмыс істемей тұрғанда экран жарықтығын төмендетеді."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Экранды _бос қылу"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Әрекетсіздік кезеңінен кейін экранды сөндіреді."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Автоматты түрде эл. қорегін сақтау"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Батарея төмен болғанда эл. қорек үнемдеу режимін іске қосу."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Автоматты түрде ұйықтату"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Компьютерді әрекетсіздік кезеңнен кейін аялдатады."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Эл. қ_орегі батырмасының мінез-құлығы"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Батарея _пайызын көрсету"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Автоматты түрде ұйықтату"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Эл. желісіне қосы_лған кезде"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "_Батареядан жұмыс істеу кезінде"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Кідіріс"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Өнімділік"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Жоғары өнімділік және қуатты пайдалану."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Баланс"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Стандартты өнімділік және қуатты пайдалану."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Қорек үнемдеу"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Төмендетілген өнімділік және қуатты пайдалану."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Эл. қорегі"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Батарея қалып-күйін және эл. қорегін сақтауды баптау"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;Эл. қорегі;Ұйқы;Ұйықтату;Гибернация;Батарея;Жарықтылық;Басу;Бос;"
+"Монитор;Іссіз;Энергия;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "\"%s\" принтері өшірілді"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Жаңа принтерді қосу сәтсіз аяқталды."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui жүктеу мүмкін емес: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Принтерлерді қосу және параметрлерді өзгерту үшін бұғаттауын шешіңіз"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Принтерлер"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Принтерлерді қосу, принтер тапсырмаларын қарау және баспаға шығарылатын "
+"нәрсені таңдау"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"Printer;Queue;Print;Paper;Ink;Toner;Принтер;Кезек;Баспаға шығару;Қағаз;Сия;"
+"Тонер;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Принтерді қосу"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Босату"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Принтерлер табылмады"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Желілік адресін енгізіңіз немесе принтерді іздеп көріңіз"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Аутентификация керек"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Баспаға шығару серверіндегі принтерлерді қарау үшін пайдаланушы атын және "
+"пароліңізді енгізіңіз."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Пайдаланушы аты"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s ақпараты"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Сәйкес келетін драйвер табылмады"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "PPD айлын таңдаңыз"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript принтер сипаттау файлдары (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Принтер атауында БОС_АРАЛЫҚ, ТАБУЛЯЦИЯ, # немесе / болмауы тиіс"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Орналасуы"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Драйвер"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Таңдаулы драйверлерді іздеу…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Драйверлерді іздеу"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Дерекқордан таңдау…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "PPD файлын орнату…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Принтер драйверін таңдау"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Драйверлер дерекқорын жүктеу…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Таңдау"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect принтері"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD принтері"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Бір жақты"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Ұзын жағымен"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Қысқа жағымен"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Тік"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Жатық"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Теріс жатық"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Теріс тік"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Жалғастыру"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Аялдату"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Кезекте"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Аялдатылған"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Аутентификация керек"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Өңдеуде"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Тоқтатылды"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Бас тартылған"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Үзілді"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Аяқталған"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Бұл тапсырманы кезек басына жылжыту"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u тапсырма аутентификацияны талап етеді"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Белсенді тапсырмалар"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+"%s жерінде баспаға шығару үшін пайдаланушы атын және пароліңізді енгізіңіз."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Домен"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "Аут_ентификация"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Барлығын тазарту"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Аутентификациялау"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Белсенді принтер тапсырмалары жоқ"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Баспаға шығару серверін блоктаудан босату"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s босату."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"%s жеріндегі принтерлерді қарау үшін пайдаланушы атын және пароліңізді "
+"енгізіңіз."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Принтерлерді іздеу"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Тізбектей порт"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Параллельді порт"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Орналасуы: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Адресі: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Сервер аутентификацияны талап етеді"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Екі жақты"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Қағаз түрі"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Қағаз көзі"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Шығыс сөресі"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Ажыратылымдығы"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript алдын-ала сүзгілеу"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Бір жақтағы парақтар"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Екі жақты"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Бағдары"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Жалпы"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Парақ баптаулары"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Орнатуға келетін опциялар"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Тапсырма"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Сурет сапасы"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Түс"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Аяқтау"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Кеңейтілген"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Сынау парағы"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Сынау парағы"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Авто таңдау"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Принтердің негізгісі"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Тек GhostScript қаріптерін ілестіру"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "PS 1 деңгейіне түрлендіру"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "PS 2 деңгейіне түрлендіру"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Алдын-ала сүзгілеу жоқ"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Шығарушы"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Белсенді тапсырмалар жоқ"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u тапсырма"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Баспа бастиектерін тазарту"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Тонер аз"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Тонер жоқ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Айқындауышы аз"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Айқындауышы бітті"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Тонер бітіп жатыр"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Тонер бітті"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Қақпағы ашық"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Есігі ашық"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Қағазы аз"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Қағаз бітті"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Желіде емес"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Тоқтатылды"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Қоқысты қабылдағыш толуға жақын"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Қоқысты қабылдағыш толып қалды"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Фоторезист жақында жарамсыз болып қалады"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Фоторезист жұмыс істемейді"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Дайын"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Тапрсырмаларды қабылдамайды"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Өңдеуде"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Баспа баптаулары"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Принтер ақпараты"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Принтерді негізгі ретінде қолдану"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Баспа бастиектерін тазарту"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Принтерді өшіру"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Модель"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Сия деңгейі"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Мәселе шешілген кезде жүйені қайта іске қосыңыз."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Қайта қосу"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Принтерді қосу…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Принтерлер жоқ"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Кешіріңіз! Жүйелік баспаға шығару қызметі\n"
+"    қолжетімді емес сияқты."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Пішімдер"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Локальдерді іздеу…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Жалпы пішімдер"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Барлық пішімдер"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Іздеу нәтижелері жоқ"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Іздеулер елдер немесе тілдер үшін болуы мүмкін."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Алдын-ала қарау"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Империялық"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Метрлік"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Күндер"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Күндер және уақыттар"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Сандар"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Өлшем бірліктері"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Қағаз"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Тіл мен пішімдер жүйеге келесі рет кіру кезінде ауыстырылатын болады"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Жүйеден шығу…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Интерфейс мәтіні және веб-беттер үшін қолданылатын тіл. Пішімдер сандар, "
+"күндер және валюталар үшін қолданылады."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Сіздің тіркелгіңіз"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Тіл"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Пішімдер"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Жүйеге кіру экраны"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Аймақ және тіл баптаулары"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Экран тілі және пішімдерді таңдаңыз"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;Тіл;Жайма;Пернетақта;Енгізу;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Не істеуді сұрау"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Ешнәрсе жасамау"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Буманы ашу"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Басқа тасушылар"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Аудио CD үшін қолданбаны таңдаңыз"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Видео DVD үшін қолданбаны таңдаңыз"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Музыкалық плеері салынған кезде жөнелтілетін қолданбаны таңдаңыз"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Камера байланысқан кезде жөнелтілетін қолданбаны таңдаңыз"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "БҚ CD дискілері үшін қолданбаны таңдаңыз"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "аудио DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "таза Blu-Ray дискі"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "таза CD-R дискі"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "таза DVD+R дискі"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "таза HD DVD дискі"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray видео дискі"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "электронды кітаптарды оқу құрылғысы"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD видео дискі"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows БҚ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Медиа қалай өнделетінін таңдаңыз"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _аудио"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "DVD ви_део"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Музыка плеері"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "Б_ағд. қамтамасы"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "Б_асқа медиа…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "Тасушы са_лынған кезде ешқашан сұрамау және бағдарламаларды жөнелтпеу"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Басқа медиа қалай өнделетінін таңдаңыз"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "Әр_екет:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "Тү_рі:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Ауыстырмалы тасушылар"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Ауыстырмалы тасушыларды баптау"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;құрылғы;жүйе;үнсіз келісім;қолданба;таңдамалы;аудио;"
+"видео;диск;ауыстырмалы;тасушы;автожөнелту;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Экран сөнеді"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 секунд"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 минут"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 минут"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 минут"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 минут"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 минут"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 сағат"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Ешқашан"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Экранды блоктау"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Экранды автоматты түрде бұғаттау басқалардың компьютерге кіруіне жол "
+"бермейді."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Экранды тазарту кідірісі"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Экран тазартылу үшін өтуі керек белсенсіздік мерзімі."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Экранды автоматты б_локтау"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Экранды автоматты б_локтау кідірісі"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Экран тазартылғаннан кейін ол автоматты түрде бұғатталғанға дейінгі мерзімі."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Хабарламаларды бұғаттау экранында көрсету"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Жаңа USB құр_ылғыларын рұқсат етпеу"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Экран бұғатталған кезде жаңа USB құрылғыларының жүйемен өзара әрекеттесуін "
+"болдырмау."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Экран жекелігі"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Көру бұрышын шектеу"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Экран баптаулары"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;экран;блоктау;жеке;жекелік;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Орналасуды таңдау"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_ОК"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Іздеу орналасулары"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Файлдар, Суреттер және Видеолар сияқты жүйелік қолданбалар іздейтін бумалар."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Орындар"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Бетбелгілер"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Басқалар"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Орналасуды қосу"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Қолданбалар табылмады"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Қолданбалардан іздеу"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Қолданбалар ұсынатын іздеу нәтижелерін есепке алу."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Жүйелік қолданбалар іздейтін бумалар."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Іздеу нәтижелері"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Нәтижелер тізімдік ретке сәйкес көрсетіледі."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "Көріністе қай қолданбалар іздеу нәтижелерін көрсететінінді басқарыңыз"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Find;Index;Hide;Privacy;Results;Іздеу;Табу;Индекс;Жасыру;Жекелік;"
+"Нәтижелер;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Бөлісу үшін желілер таңдалмады"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Желілер"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Іске қосулы"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Сөнд."
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Іске қосулы"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Белсенді"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Буманы таңдау"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Қосу"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Медиамен бөлісуді іске қосу"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Файлдармен бөлісу көмегімен ағымдағы желіде сіздің Ортақ бумаңызды келесі "
+"адрес арқылы бөлісе аласыз: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Қашықтан байланысу іске қосылған болса, қашықтағы пайдаланушылар Secure "
+"Shell командасы көмегімен байланыса алады:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Жеке медиамен бөлісуді іске қосу"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Құрылғы атауы көшірілді"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Құрылғы адресі көшірілді"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Пайдаланушы аты көшірілді"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Пароль көшірілді"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Бөлісу"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Компьютер аты"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Файлдармен бөлісу"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Қашықтағы жұ_мыс үстелі"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Медиамен бөлісу"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Қа_шықтан кіру"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Файлдармен бөлісу"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Парольді _талап ету"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Қашықтан кіру"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Қашықтағы жұмыс үстелі"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Қашықтағы жұмыс үстелі жұмыс үстелін басқа компьютерден көруге және "
+"басқаруға мүмкіндік береді."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Бұл компьютерге қашықтан кіруді іске қосу немесе сөндіру."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Қашықтан басқару"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Бұл экранды басқаруға қашықтан байланыстарды рұқсат ету."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Байланысу жолы"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Құрылғы атауын немесе қашықтағы жұмыс үстелі адресін пайдаланып осы "
+"компьютерге қосылу."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Көшіру"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Қашықтағы жұмыс үстел адресі"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Аутентификация"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Осы компьютерге қосылу үшін пайдаланушы аты мен пароль міндетті түрде керек."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Пайдаланушы аты"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Шифрлеуді тексеру"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Шифрлеу баспасы"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Шифрлеу баспасы байланысатын клиенттерде көрінеді және өзара бірдеу болуы "
+"тиіс."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Медиамен бөлісу"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Музыка, фотосуреттер және видеолармен желі арқылы бөлісу."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Бумалар"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Басқалармен немен бөлісуді таңдау"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;бөлісу;торап;аты;қашықтағы;жұмыс үстелі;медиа;аудио;"
+"видео;суреттер;фотолар;кинолар;сервер;өндегіш;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Қашықтан кіруді іске қосу немесе сөндіру"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Қашықтан кіруді іске қосу немесе сөндіру үшін аутентификация керек"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Таңдауыңызша"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Шерту"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Жол"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Теңгерім"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Сөндіру"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Артқы"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Бет жағы"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Сынау \"%s\""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Сынау үшін динамикті таңдаңыз"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Жұйелік дыбыс"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Негізгі дыбыс"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Дыбыс деңгейлері"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Шығыс"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Шығыс құрылғысы"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Сынау"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Баптаулар"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Сабвуфер"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Кіріс"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Енгізу құрылғысы"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Том"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Хабарлама дыбысы"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Дыбысты өшіру"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Дыбыс"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Дыбыс деңгейлерін, кіріс, шығыстарын және дыбыспен хабарлауды өзгерту"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+"Карта;Микрофон;Дыбыс;Басылу;Баланс;Құлаққап;Аудио;Шығыс;Кіріс;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Ажыратылған"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Байланысуда"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Байланысқан"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Авторизация қатесі"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Авторизациялауда"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Мүмкіндіктері шектелген"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Байланысқан және авторизацияланған"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Белгісіз"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Авторизацияланған уақыты:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Байланысқан уақыты:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Тіркелген уақыты:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Құрылғыны авторизациялау қатесі: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Құрылғыны ұмыту қатесі: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Басқа %u құрылғыға тәуелді"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Хабарламаны жабу"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Аты:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Қалып-күйі:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Авторизациялау және байланысу"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Құрылғыны ұмыту"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Қате"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Авторизацияланған"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Thunderbolt қолдау жүйесі (boltd) орнатылмаған, немесе дұрыс бапталмаған."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Док станциялар және сыртқы видеокарталар сияқты құрылғылар үшін тікелей "
+"режимін рұқсат ету."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Тек USB және Display Port құрылғыларын жалғауға болады."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt анықтау мүмкін емес.\n"
+"Жүйеде Thunderbolt қолдауы жоқ, немесе ол BIOS-та сөндірілген болуы мүмкін, "
+"немесе BIOS-та қолдауы жоқ қауіпсіздік деңгейі орнатылған болуы мүмкін."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt қолдауы BIOS-та сөндірілген."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Thunderbolt қауіпсіздік деңгейін анықтау мүмкін емес."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Тікелей режимін ауыстыру қатесі: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt қолдауы жоқ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Thunderbolt ішкі жүйесіне байланысу мүмкін емес."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Тікелей қатынау"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Кезектегі құрылғылар"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Жалғанған құрылғылар жоқ"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Thunderbolt құрылғыларын басқару"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;жекелік;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Курсор жыпылықтауы"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Курсор мәтіндік өрістерде жыпылықтайды."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Жылдамдығы"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Курсордың жыпылықтау жиілігі"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Курсор өлшемі"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Курсорды көруді жақсарту үшін курсор өлшемін масштабпен бірге қолдануға "
+"болады."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Шертулер көмекшісі"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Симуляцияланған ккіншілік шерту"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Біріншілік батырманы басып ұстау арқылы екіншілік шертуді генерациялау"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Қа_былдау кідірісі:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Қысқа"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Екіншілік шерту кідірісі"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Ұзақ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Үстінен өткенде _шерту"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Курсор үстінен өткен кезде шерту оқиғасын жіберу"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Кі_діріс:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Қысқа"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Ұзақ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Жылжудың _табалдырықты мәні:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Кішкентай"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Үлкен"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Пернелер қайталануы"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Перне басулы кезінде перне басулары қайталанады."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Қайталану кідірісі"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Қайталану жылдамдығы"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Теру көмекшісі"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Жабы_сқақ пернелер"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Түрлендіргіш пернелер басылу тізбегін пернелер комбинациясы ретінде талдайды"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Екі перне бірдей басылса, сөн_діру"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "_Түрлендіргіш перне басылған кезде дыбысты беру"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Ба_яу пернелер"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Перне басылған және қабылданған кездері арасында кідірісті орнатады"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Қысқа"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Баяу пернелер теру кідірісі"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Ұзақ"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Перне _басылған кезде дыбыс беру"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Перне қ_абылданған кезде дыбыс беру"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Перне та_йдырылған кезде дыбыс беру"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Қа_йталанатын пернелер"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Жылдам қайталатын пернелер басуларын елемейді"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Қысқа"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Қайталанатын пернелер теру кідірісі"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Ұзақ"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Пернетақтамен іск_е қосу"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Арнайы мүмкіндіктерді пернетақта көмегімен іске қосу және сөндіру"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Бастапқы"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Орташа"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Үлкен"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Үлкенірек"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Ең үлкен"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d пиксель"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Қолжетімділік мәзірін әрқ_ашан көрсету"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Көру"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Ж_оғары контраст"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Ү_лкен мәтін"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "А_нимацияларды іске қосу"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Экраннан оқитын қол_данба"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Экраннан оқу қолданбасы фокус ауысу кезінде көрсетілетін мәтінді оқиды."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Дыбыс пернелері"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num Lock немесе Caps Lock іске қосулы/сөндірулі кезінде дыбыс беру."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "К_урсор өлшемі"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Масштаб"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Есту"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Визуалды хабарлаулар"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Экрандағы перне_тақта"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "П_ернелер қайталануы"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Курсор _жыпылықтауы"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Теру көмекшісі (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Көрсету және шерту"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Ты_шқан пернелері"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Курсорды _табу"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Шертулер көмекшісі"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Қ_ос шерту кідірісі"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Қос шерту кідірісі"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Бейнелік хабарлау"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Жыпылықтауды сы_нау"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Хабарлау дыбысы кезінде визуалды хабарлауды көрсету."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Толық _экранмен жыпылықтау"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Толық _тереземен жыпылықтау"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Қысқа"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "Экранның ¼ бөлігі"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "Экранның ½ бөлігі"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "Экранның ¾ бөлігі"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Ұзақ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Толық экран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Жоғары жартысы"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Төменгі жартысы"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Сол жақ жартысы"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Оң жақ жартысы"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Масштабтау баптаулары"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "Үлке_йту:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Үлкейткіш орны:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "Тышқан курсоры соңынан _еру"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Э_кран бөлігі:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Үлкейту аймағы экран сыртына ш_ығады"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Үлкейткіш курсорын ортасында ұс_тау"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Үлкейткіш курсоры құраманы _жылжытады"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Үлкейткіш курсоры құра_мамен бірге жылжиды"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Үлкейткіш"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Қ_иылысу:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Тышқан курсорының үстін _басу"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "Қ_алыңдығы:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Жұқа"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Қалың"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "Ұз_ақтығы:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Түс:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Қиылысу"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Түс эффектілері:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "Қара үстіндегі _ақ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "Жар_ықтылығы:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Контраст:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Түсі"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Жоқ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Толық"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Төмен"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Жоғары"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Төмен"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Жоғары"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Түс эффектілері"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Көру, есту, теру, көрсету және шертуді жеңілдету"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;пернетақта;тышқан;қолжетерлілік;әмбепап қатынау;"
+"контраст;курсор;дыбыс;масштаб;экран;оқу;үлкен;жоғары;мәтін;қаріп;өлшем;"
+"жабысқақ;баяу;қайталанатын;қос;шерту;кідіріс;жылдамдық;көмекші;қайталау;"
+"жыпылықтау;визуалды;есту;аудио;теру;анимациялар;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 сағат"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 күн"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 күн"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 күн"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 күн"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 күн"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 күн"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 күн"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 күн"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 күн"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Қоқыс шелегінен барлық нәрсені өшіру керек пе?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Қоқыс шелегінен барлық нәрселер толығымен өшіріледі."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Қоқыс шел_егін тазарту"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Барлық уақытша файлдарды өшіру керек пе?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Барлық уақытша файлдар толығымен өшіріледі."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Уақытша файлдарды _тазарту"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 күн"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 күн"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 күн"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Мәңгі"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Файлдар тарихы"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Файл журналы пайдаланылған файлдардың жазбасын сақтайды. Бұл ақпарат "
+"бағдарламалар арасында ортақ болып, пайдаланғыңыз келетін файлдарды табуды "
+"жеңілдетеді."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Файлдар тар_ихы"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Файлдар тар_ихының ұзақтығы"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Тарихты та_зарту…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Қоқыс шелегі және уақытша файлдар"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Қоқыс шелегі мен уақытша файлдар құрамында кейде жеке немесе сезімтал "
+"ақпараты болуы мүмкін. Оларды автоматты түрде өшіру жекелікті қорғауға "
+"көмектеседі."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Қоқыс шелегін ав_томатты тазарту"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Уақытша _файлдарды автоматты түрде өшіру"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Автоматты түрде өшіру _мерзімі"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Қоқыс шел_егін тазарту…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Уақытша файлдарды ө_шіру…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Файлдар тарихы және қоқыс шелегі"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Із қалдырмау"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"қолданылу;жуырдағы;тарих;файлдар;уақытша;жеке;жекелік;қоқыс шелегі;тазарту;"
+"қалдыру;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Логинді ұсынушының веб адресіне сәйкес болуы тиіс."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Тіркелгіні қосу сәтсіз"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Парольдер өзара сәйкес емес."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Тіркелгіні тіркеу сәтсіз аяқталды"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Бұл доменде аутентификациялаудың қолдауы бар тәсілдері жоқ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Доменде тіркелу сәтсіз"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Бұл логин fns жасамады.\n"
+"Қайталап көріңіз."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Бұл логин паролі жасамады.\n"
+"Қайталап көріңіз."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Доменге кіру сәтсіз аяқталды"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Доменді табу мүмкін емес. Оны дұрыс көрсеттіңіз бе?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Пайдаланушыны қосу"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Әкімші"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Әкімшілер басқа пайдаланушыларды қосып, өшіре алады және барлық "
+"пайдаланушылар үшін параметрлерді өзгерте алады. Ата-аналық басқару "
+"әкімшілер үшін іске асыру мүмкін емес."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Пайдаланушы парольді жүйеге бірінші рет кірген кезде орнатады"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Парольді қазір орнату"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Растау"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Кәсіпорын тіркелгісі"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Компания немесе ұйым басқаратын пайдаланушы тіркелгілері."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Сіз желіде емессіз"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Кәсіпорындық кіру бар болып тұрған және орталықтан басқарылатын пайданушы "
+"тіркелгісіне бұл құрылғыда қолданылуды мүмкін етеді. Сонымен қатар, сіз бұл "
+"тіркелгіні кәсіпорынның интернеттегі ресурстарына қатынау үшін қолдана "
+"аласыз."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Көбірек суретті шолу"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Файлды таңдау…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Саусақ іздерін басқарушы"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Саусақ ізі"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Жоқ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Иә"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Тіркелген саусақтар іздерін өшіріп, саусақ ізі арқылы жүйеге кіруді сөндіру "
+"керек пе?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Саусақ ізін оқу құрылғысы жоқ"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Саусақ ізін оқу құрылғысы жоқ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Құрылғының дұрыс жалғанғанын тексеріңіз."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Саусақ ізін оқу құрылғысы"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Баптау үшін саусақ ізін оқу құрылғысын таңдаңыз"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Саусақ ізімен кіру"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Саусақ ізімен кіру сізге саусақ көмегімен бұғаттауды шешіп, компьютерге кіру "
+"мүмкіндігін береді"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "Саусақ іздерін ө_шіру"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Саусақ ізін түсіру"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "осы әрекетті орындау үшін құрылғы иелену қажет"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "бұл құрылғыны басқа үрдіс иеленіп отыр"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "әрекетті орындауға рұқсатыңыз жоқ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "саусақ іздері тіркелмеген"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Тіркелу кезінде құрылғымен байланысу сәтсіз аяқталды"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Саусақ ізін оқу құрылғысымен байланысу сәтсіз аяқталды"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Саусақ ізі қызметіне байланысу сәтсіз аяқталды"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Саусақ іздерін тізіп шығару сәтсіз аяқталды: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Сақталған саусақ іздерін өшіру сәтсіз аяқталды: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Сол жақ бас бармағы"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Сол жақ ортаңғы саусақ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Сол жақ сұқ саусақ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Сол жақ аты жоқ саусақ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Сол жақ кішкентай саусақ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Оң жақ бас бармағы"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Оң жақ ортаңғы саусақ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Оң жақ сұқ саусақ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Оң жақ аты жоқ саусақ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Оң жақ кішкентай саусақ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Белгісіз саусақ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Аяқталды"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Саусақ ізін оқу құрылғысы ажыратылған"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Саусақ ізін оқу құрылғысының жады толық"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Жаңа саусақ ізін қосу сәтсіз аяқталды"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Саусақ ізін қосуды бастау сәтсіз аяқталды: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Жаңа саусақ ізін қосу сәтсіз аяқталды"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Саусақ ізін қосуды тоқтату сәтсіз аяқталды: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Саусақ ізін тіркеу үшін саусақты бірнеше рет оқу құралынан көтеріңіз және "
+"орналастырыңыз"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Бұл саусақты қа_йта өткізу…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Жаңа саусақ ізін сканерлеу"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Саусақ ізін оқу %s құрылғысын босату сәтсіз аяқталды: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Құрылғыдан оқу мәселесі"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Саусақ ізін оқу %s құрылғысын талап ету сәтсіз аяқталды: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Саусақ ізін оқу құрылғыларын алу сәтсіз аяқталды: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Осы аптада"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Өткен апта"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Сессия аяқталды"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Сессия басталды"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Тіркелгі белсенділігі"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Алдыңғы"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Келесі"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Басқа парольді таңдаңыз."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Ағымдағы пароліңізді қайта енгізіңіз."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Парольді өзгерту мүмкін емес"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Парольді өзгерту"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Өз_герту"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Ағымдағы пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Жаңа пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Парольді растау"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Пайдаланушы жүйеге келесі рет кірген кезде оған парольді өзгертуге рұқсат ету"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Парольді қазір орнату"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Доменнің бұл түріне автоматты түрде кіру мүмкін емес"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Ондай домен (realm) табылмады"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s ретінде %s доменіне кіру мүмкін емес"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Пароль қате, қайтадан көріңіз"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "%s доменіне байланысу мүмкін емес: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Пайдаланушыны өшіру сәтсіз аяқталды"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Қашықтағы пайдаланушының күшін жою сәтсіз аяқталды"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Өз тіркелгіңізді өшіре алмайсыз."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s жүйеге кіріп тұр"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Жүйеге кіріп тұрған кезде пайдаланушыны өшіру жүйені екімәнді күйде қалдыруы "
+"мүмкін."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "%s файлдарын алып қалуды қалайсыз ба?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Пайдаланушы тіркелгісін өшіру кезінде оның үй бумасын, пошта кезегін және "
+"уақытша файлдарын алып қалу мүмкіндігі бар."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "Файлдарды ө_шіру"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "Ф_айлдарды қалдыру"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Қашықтан басқарылатын %s тіркелгісін өшіруді шынымен қалайсыз ба?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "Ө_шіру"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Тіркелгі сөндірілген"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Келесі рет кірген кезде орнатылады"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ешнәрсе"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Жүйеге кіріп тұр"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Тіркелгілер қызметімен байланыс орнату қатесі"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "AccountService орнатылған және іске қосылғанына көз жеткізіңіз."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Бұл баптауды өзгерту үшін бұл панель құлыптан босатылуы тиіс"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Таңдалған пайдаланушы тіркелгісін өшіру"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Таңдалған пайдаланушы тіркелгісін өшіру үшін,\n"
+"алдымен * таңбашасына шертіңіз"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr ""
+"Пайдаланушыларды қосу және параметрлерді өзгерту үшін бұғаттауын шешіңіз"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Пайдаланушылар"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Өзгерістер іске асуы үшін сессияңызды қайта бастау керек"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Қазір қайта қосу"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Жабу"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Аватарды түзету"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Толық аты"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Түзету"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Са_усақ ізімен кіру"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "А_втокіру"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Тіркелгі белсенділігі"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "Ә_кімші"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Әкімшілер басқа пайдаланушыларды қосып, өшіре алады және барлық "
+"пайдаланушылар үшін параметрлерді өзгерте алады."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "А_та-ана бақылауы"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Ата-ана бақылауы қолданбасын ашу."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Пайдаланушыны өшіру…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Басқа пайдаланушылар"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Пайдаланушыны қосу…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Пайдаланушылар табылмады"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Пайдаланушы тіркелгісін жасау үшін босатыңыз."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Пайдаланушыларды қосу/өшіру және пароліңізді өзгерту"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;Логин;Аты;"
+"Баспа;Аватар;Лого;Бет;Пароль;Ата-ана бақылауы;Экран уақыты;Қолданба шектеуі;"
+"Интернет шектеуі;Қолдану;Қолдануды шектеу;Бала;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "Тірк_еу"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Домен әкімшісінің логині"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Кәсіпорындық тіркелгілерін қолдану үшін, бұл компьютерді\n"
+"доменге тіркеу керек. Желілік әкімші осы жерде домен паролін\n"
+"енгізуі тиіс."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Әкімші а_ты"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Әкімші паролі"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Пайдаланушылар тіркелгілерін басқару"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Пайдаланушы ақпаратын өзгерту үшін аутентификация керек"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Жаңа пароль ескі парольден басқа болуы тиіс."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Кейбір әріптер немесе сандарды өзгертіп көріңіз."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Парольді тағы да өзгертіп көріңіз."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Пароліңізде сіздің атыңыз қолданбаса, ол күштірек болады."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Парольде өз атыңызды қолданбауға тырысыңыз."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Парольде бар кейбір сөздерді қолданбауға тырысыңыз."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Кең қолданылатын сөздерді қолданбаңыз."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Бар сөздердің ретін ауыстыруды қолданбауға тырысыңыз."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Көбірек сандарды қолданып көріңіз."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Көбірек бас әріпті қолданып көріңіз."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Көбірек кіші әріпті қолданып көріңіз."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Көбірек арнайы белгілерді (тыныс) қолданып көріңіз."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Әріптер, сандар және тыныс белгілерінің қосындысын қолданып көріңіз."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Бір таңбаны қайталанбауға тырысыңыз."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Таңбалардың бір түрін қайталанбауға тырысыңыз: сізге әріптер, сандар және "
+"тыныс белгілерін араластырып қолдану керек."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 немесе аәбв сияқты тізбектерді қолданбауға тырысыңыз."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Пароль ұзынырақ болуы тиіс. Көбірек әріптер, сандар және тыныс белгілерін "
+"қосып көріңіз."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Бас және кіші әріптерді араластырыңыз және бір-екі санды қолдануға тырысыңыз."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Көбірек әріптер, сандар және тыныс белгілерін қосу арқылы парольді күштірек "
+"қылуға болады."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Аутентификация сәтсіз"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Жаңа пароль тым қысқа"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Жаңа пароль тым қарапайым"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Ескі және жаңа парольдер өзара ұқсайды"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Жаңа пароль жақында қолданылған болып тұр."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Жаңа парольде сандар немесе арнайы таңбалар болуы тиіс"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Ескі және жаңа парольдер өзара сәйкес келеді"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Басында аутентификацияланғаннан кейін пароліңіз өзгерген сияқты!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Жаңа парольде жеткілікті түрде әр түрлі таңбалар жоқ"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Белгісіз қате"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Пайдаланушы атында тек ағылшын әліппесінің a-z арасындағы кіші әріптері, "
+"сандар, және келесі таңбалар болуы мүмкін: . - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Кешіріңіз, бұл пайдаланушы аты қолжетерсіз. Басқасын көріңіз."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Пайдаланушы аты тым ұзын."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Пернелерді сәйкестеу"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Пернелер және функциялар сәйкестігі"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Жарлықты түзету үшін, \"Пернені басу оқиғасы\" әрекетін таңдап, пернетақта "
+"жарлық батырмасын басып, жаңа пернелерді басыңыз, немесе, тазарту үшін "
+"Backspace басыңыз."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "Жа_бу"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Планшетті калибрациялау үшін, экранда пайда болатын маркерлерге шертіп "
+"отырыңыз."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Қате шерту анықталды, қайтадан бастау…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Батырма %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Тағайындалған қолданбалар"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Пернені басу оқиғасы"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Мониторды ауыстыру"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Экрандағы көмекті көрсету"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Ноутбук панеліне орнатылған планшет"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Сыртқы дисплейге орнатылған планшет"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Сыртқы планшет құрылғысы"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Сыртқы салынбалы құрылғысы"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Барлық экрандар"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Планшет режимі"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Қалам үшін абсолютті позициялауды пайдалану"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Сол қол (солақай) бағдары"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Планшет пен Express Keys™ сол қолды пайдалану үшін бұрылады"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Экранға бейнелеу"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Жақтар арақатынасын сақтау"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Монитор жақтары арақатынасын сақтау үшін планшет бетінің бір бөлігін ғана "
+"пайдалану"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Калибрациялау"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Планшет анықталмады"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Wacom планшетіңізді компьютерге жалғаңыз немесе іске қосыңыз."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Қалам басуының сезімталдылығы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Жоғары"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Стилус басының қысымы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Төмен"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Батырма 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Батырма 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Батырма 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Өшіргіштің қысымға сезімталдылығы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Өшіргіш қысымы"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Тышқанның орта батырма шертуі"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Тышқанның оң жақ батырма шертуі"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Алға"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Басу, еңкею функциялары және құрамындағы слайдері бар аэрограф стилусы"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Басу, еңкею және айналдыру функциялары бар аэрограф стилусы"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Басу, еңкею функциялары бар қалыпты стилусы"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Басу функциясы бар қалыпты стилусы"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom планшеті"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Графикалық планшеттер үшін батырмалар сәйкестіктерін және стилус "
+"сезімталдылығын баптау"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;Планшет;Стилус;Өшіргіш;Тышқан;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Жаңа жарлық…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Қатынау нүктелері"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Әрекеттен бас тартылды"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Қате:</b> Баптауларды өзгерту рұқсат етілмеген"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Қате:</b> Мобильді құрылғылық қамтама қатесі"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Тіркелмеген"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Тіркелген"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Роуминг"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Іздеу"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Рұқсат етілмеген"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Модем ақпараты"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Модем қалып-күйі"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Қызмет көрсетуші"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Желі түрі"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Желі қалып-күйі"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Өз нөмірі"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Құрылғы ақпараты"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Бинарлы кодтар нұсқасы"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Тек 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Тек 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Тек 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Тек 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (таңдамалы), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (таңдамалы), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (таңдамалы), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+#| msgid "2G, 3G, 4G"
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (таңдамалы), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (таңдамалы), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (таңдамалы), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (таңдамалы), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+#| msgid "3G, 4G"
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (таңдамалы), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (таңдамалы), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+#| msgid "2G, 3G, 4G"
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (таңдамалы), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (таңдамалы), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+#| msgid "2G, 3G, 4G"
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (таңдамалы), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (таңдамалы), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (таңдамалы), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (таңдамалы), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (таңдамалы), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (таңдамалы)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (таңдамалы), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Белгісіз"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "SIM карта бұғаттауын шешу"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Бұғаттауды шешу"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "%d SIM картасы үшін PIN кодын енгізіңіз"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "SIM картаңыздың бұғаттауын шешу үшін PIN кодын енгізіңіз"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "%d SIM картасы үшін PUK кодын енгізіңіз"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "SIM картаңыздың бұғаттауын шешу үшін PUK кодын енгізіңіз"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Қате пароль енгізілген. Сізде %1$u қайталау талабы қалды"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Сізде %1$u қайталау талабы қалды"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Қате пароль енгізілген."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK коды 8 цифрлық сан болуы тиіс"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Жаңа PIN кодын енгізіңіз"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN коды 4-8 цифрлық сан болуы тиіс"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Бұғаттауды шешу…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "SIM картасы жоқ"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Бұл модемді пайдалану үшін SIM-картаны салыңыз"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM құлыпталған"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Мобильді деректер"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Деректерге мобильді желі арқылы қатынау"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Деректер роумингі"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Роуминг кезінде мобильді деректерді пайдалану"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Желі режимі"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "Ж_елі"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Кеңейтілген"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Қ_атынау нүкте атаулары"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM құлыптау"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "SIM картаны PIN кодымен бұғаттау"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "М_одем ақпараты"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Телефон ақаулығы"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Телефонға байланыспаған"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Әрекетке рұқсат жоқ"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Әрекетке қолдау жоқ"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM картасы салынбаған"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIM PIN коды керек"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIM PUK коды керек"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM ақаулығы"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM бос емес"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Пароль қате"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM PIN2 коды керек"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM PUK2 коды керек"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Табылмады"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Желілік қызметі жоқ"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Желі күту уақыты аяқталды"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS қызметтері рұқсат етілмеген"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Роуминг бұл аймақта рұқсат етілмеген"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Көрсетілмеген GPRS қатесі"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Қате жоқ"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Әрекеттен бас тартылған"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Қатынауға тыйым салынған"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Белгісіз қате"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Желі режимі"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Автоматты түрде"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Желіні таңдау"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Желілік провайдерлерді жаңарту"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Мобильді желіні іске қосу"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "WWAN адаптерлері табылмады"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Сізде сымсыз Wan/ұялы құрылғының бар болғанын тексеріңіз"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Ұшақтағы режим іске қосулы кезінде сымсыз Wan сөндірілген болады"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Ұшақтағы режимді _сөндіру"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Деректер байланысы"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Интернет үшін қолданылатын SIM картасы"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM құлыптау"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Келесі"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "SIM картаны PIN кодымен _бұғаттау"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "PIN кодын өзгерту"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "SIM құылыптау баптауларын өзгерту үшін, ағымдағы PIN кодын енгізіңіз"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Мобильді желі"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Телефония және мобильді деректер байланыстарын баптау"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;wwan;telephony;sim;mobile;ұялы;телефония;сим;мобильді;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "GNOME жұмыс үстелін баптау утилитасы"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+"Баптаулар қолданбасы жүйеңізді баптаудың негізгі сайманы болып табылады."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME жобасы"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Нұсқа нөмірін көрсету"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Кеңейтілген режимді іске қосу"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Жолды іздеу"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Мүмкін панельдер атауларын шығару және шығу"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Көрсетілетін панель"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[ПАНЕЛЬ] [АРГУМЕНТ…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Баптаулар санаттары"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Жекелік"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Қолжетерлік панельдер:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Барлық баптаулар"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Басты мәзір"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Ескерту: Әзірлеушілер нұсқасы"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Баптаулардың бұл нұсқасы тек әзірлеу мақсатында қолданылуы тиіс. Жүйенің "
+"қате мінез-құлығы, деректерді жоғалу және басқа күтілмеген жағдайларды "
+"кездестіруге болады. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Көмек"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Жалпы"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Шығу"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Іздеу"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Панельдер"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Алдыңғы панельге оралу"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Іздеуді тоқтату"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;Баптаулар;Қалаулар;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Ашылу үшін соңғы Баптаулар панелінің анықтағышы"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Ашылу үшін соңғы Баптаулар панелінің анықтағышы. Танылмаған мәндерді "
+"елемейміз, ол кезде тізімдегі бірінші панель ашылады."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Баптаулардың әзірлеушілер нұсқасын орындау кезінде ескертуді көрсету"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Баптаулардың әзірлеушілер нұсқасын орындау кезінде ескертуді көрсету керек "
+"пе."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Терезенің бастапқы күйі"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Қолданба терезесінің бастапқы енін, биіктігін және максималды күйін "
+"сақтайтын кортеж."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u шығыс"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u кіріс"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Жүйелік дыбыстар"
+
+#~ msgid "Light"
+#~ msgstr "Ашық түсті"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;экран;блоктау;диагностика;құлау;жеке;жуырдағы;уақытша;"
+#~ "индекс;аты;желі;анықтағыш;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Экрандар орналасуы"
+
+#~ msgid "Set"
+#~ msgstr "Орнату"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Экранды бұғаттау"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER немесе PEM сертификаттары (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Принтерді қосу…"
+
+#~ msgid "Bark"
+#~ msgstr "Иттің үруі"
+
+#~ msgid "Drip"
+#~ msgstr "Тамшылау"
+
+#~ msgid "Glass"
+#~ msgstr "Шыны"
+
+#~ msgid "Sonar"
+#~ msgstr "Сонар"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "GNOME баптаулары дыбыс панелі"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "GNOME баптаулары тышқан және тачпад панелі"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "GNOME баптаулары фон панелі"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "GNOME баптаулары пернетақта панелі"
+
+#~ msgid "Web Links"
+#~ msgstr "Веб сілтемелері"
+
+#~ msgid "Git Links"
+#~ msgstr "Git сілтемелері"
+
+#~ msgid "%s Links"
+#~ msgstr "%s сілтемелері"
+
+#~ msgid "Unset"
+#~ msgstr "Орнатылмаған"
+
+#~ msgid "Links"
+#~ msgstr "Сілтемелер"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Гипермәтін файлдары"
+
+#~ msgid "Text Files"
+#~ msgstr "Мәтіндік файлдар"
+
+#~ msgid "Image Files"
+#~ msgstr "Сурет файлдары"
+
+#~ msgid "Font Files"
+#~ msgstr "Қаріп файлдары"
+
+#~ msgid "Archive Files"
+#~ msgstr "Архив файлдары"
+
+#~ msgid "Package Files"
+#~ msgstr "Десте файлдары"
+
+#~ msgid "Audio Files"
+#~ msgstr "Аудио файлдары"
+
+#~ msgid "Video Files"
+#~ msgstr "Видео файлдары"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Рұқсаттар және қатынау"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Бұл қолданба қатынауға сұраған деректер мен қызметтер және ол талап "
+#~ "ететін рұқсаттар."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Зарядтау мүмкін емес"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Қолданбалардың жеке-жеке рұқсаттарын <a href=\"privacy\">Жекелік</a> "
+#~ "баптауларында қарауға болады."
+
+#~ msgid "Integration"
+#~ msgstr "Интеграция"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Жұмыс үстел тұсқағазын орнату"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Үнсіз келісім талдаушылар"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Бұл қолданба ашатын файл және сілтемелер түрлері."
+
+#~ msgid "Usage"
+#~ msgstr "Қолданылуы"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Бұл қолданба қолданатын ресурстар шамасы."
+
+#~ msgid "Open in Software"
+#~ msgstr "БҚ қолданбасында ашу"
+
+#~ msgid "Activities"
+#~ msgstr "Белсенділіктер"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Төмендегі қолданбаларға камераңызды қолдануды рұқсат ету."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Файлды жүктеп жіберу мүмкін емес: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Профиль келесі жерге жүктелді:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Бұл сілтемені жазып алыңыз."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Бұл компьютерді қайта қосып, қалыпты операциялық жүйеңізді жүктеңіз."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Профильді жүктеп алып, орнату үшін, браузеріңізде бұл сілтемені теріңіз."
+
+#~ msgid "Upload profile"
+#~ msgstr "Профильді жүктеп жіберу"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Интернетпен байланысты талап етеді"
+
+#~ msgid "_Copy"
+#~ msgstr "_Көшіру"
+
+#~ msgid "Select _All"
+#~ msgstr "Б_арлығын таңдау"
+
+#~ msgid "Single Display"
+#~ msgstr "Дара экран"
+
+#~ msgid "Join Displays"
+#~ msgstr "Экран­дарды біріктіру"
+
+#~ msgid "Display Mode"
+#~ msgstr "Экран режимі"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Экрандары физикалық орналасуына сәйкестеу үшін тартып реттеңіз. Экран "
+#~ "баптауларын өзгерту үшін, оны таңдаңыз."
+
+#~ msgid "Active Display"
+#~ msgstr "Белсенді экран"
+
+#~ msgid "More Warm"
+#~ msgstr "Көбірек жылы"
+
+#~ msgid "Less Warm"
+#~ msgstr "Азырақ жылы"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Скриншотты $PICTURES ішіне сақтау"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Терезе скриншотын $PICTURES ішіне сақтау"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Аймақ скриншотын $PICTURES ішіне сақтау"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Скриншотты алмасу буферіне көшіріп алу"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Терезе скриншотын алмасу буферіне көшіріп алу"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Аймақ скриншотын алмасу буферіне көшіріп алу"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Қысқа скринкастты жазып алу"
+
+#~ msgid "Move up"
+#~ msgstr "Жоғары жылжыту"
+
+#~ msgid "Move down"
+#~ msgstr "Төмен жылжыту"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Орналасулар қызметі қолданбаларға сіздің орналасуыңызды білуге мүмкіндік "
+#~ "береді. Дәлдікті WiFi және мобильді деректерді іске қосу арқылы көтеруге "
+#~ "болады."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Mozilla орналасулар қызметін қолданады: <a href='https://location."
+#~ "services.mozilla.com/privacy'>Жекелік саясаты</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Төмендегі қолданбаларға орналасуыңызды анықтауды рұқсат ету."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Төмендегі қолданбаларға микрофоныңызды қолдануды рұқсат ету."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Қос шерту кідірісі"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Ұйықтату және сөндіру батырмасы"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Қабаттасу анықталды: өнімділік режимі қолжетімсіз"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Құрылғылық температура жоғары: өнімділік режимі қолжетімсіз"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Өнімділік режимі қолжетімсіз"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Аутентификация"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Сандар, күндер және валюталар пішімін таңдаңыз. Өзгерістер келесі жүйеге "
+#~ "кіру кезінде іске асады."
+
+#~ msgid "My Account"
+#~ msgstr "Менің тіркелгім"
+
+#~ msgid "Language"
+#~ msgstr "Тіл"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Терезелер мен веб-беттердегі мәтін үшін қолданылатын тіл."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Өзгерістер іске асуы үшін сессияңызды қайта қосу керек"
+
+#~ msgid "Restart…"
+#~ msgstr "Қайта қосу…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Жүйеге кіру баптаулары осы жүйеге кіретін барлық пайдаланушылармен "
+#~ "қолданылады"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Белсенділіктер көрінісінде қай іздеу нәтижелері көрсетілетінін басқару. "
+#~ "Іздеу нәтижелерінің ретін тізімдегі жолдарды жылжыту арқылы да өзгертуге "
+#~ "болады."
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Экранмен бөлісу көмегімен қашықтағы пайдаланушылар %s адресіне байланысу "
+#~ "арқылы экраныңызды қарай немесе басқара алады"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Э_кранмен бөлісу"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Желі болмаған соң кейбір қызметтер сөндірілген."
+
+#~ msgid "_Password:"
+#~ msgstr "_Пароль:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Парольді көр_сету"
+
+#~ msgid "Access Options"
+#~ msgstr "Қатынау баптаулары"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Жаңа байланыстар рұқсатты сұрау керек"
+
+#~ msgid "_Require a password"
+#~ msgstr "Парольді _талап ету"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Дыбыс пернелері"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Экраннан оқитын қолданба"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Экра_ннан оқитын қолданба"
+
+#~ msgid "Standard"
+#~ msgstr "Қалыпты"
+
+#~ msgid "Account _Type"
+#~ msgstr "Тіркелгі _түрі"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Пайдаланушы жүйеге келесі рет _кірген кезде оған парольді орнатуға рұқсат "
+#~ "ету"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Парольді қ_азір орнату"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Кәсіпорын пайдаланушыларын қосу үшін желіге байланысыңыз."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Фото түсіру…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Өзгерістерді жасау үшін,\n"
+#~ "алдымен * таңбашасына шертіңіз"
+
+#~ msgid "Create a user account"
+#~ msgstr "Пайдаланушы тіркелгісін жасау"
+
+#~ msgid "User Icon"
+#~ msgstr "Пайдаланушы таңбашасы"
+
+#~ msgid "Account Settings"
+#~ msgstr "Тіркелгі баптаулары"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Аутентификация және жүйеге кіру"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Бұл сіздің үй бумаңыздың аты ретінде қолданылады, және оны кейін "
+#~ "өзгертуге болмайды."
+
+#~ msgid "Output:"
+#~ msgstr "Шығыс:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Жақтар арақатынасын сақтап отыру:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Бір экранға бейнелеу"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d, барлығы %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Экранға бейнелеу"
+
+#~ msgid "Stylus"
+#~ msgstr "Стилус"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Планшет (абсолютті)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Планшет (салыстырмалы)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Планшет баптаулары"
+
+#~ msgid "_Help"
+#~ msgstr "Кө_мек"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth баптаулары"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Бақылау режимі"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Пернелер бейнеленуі…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Тышқан баптауларын басқару"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Экран ажыратымдылығын баптау"
+
+#~ msgid "No stylus found"
+#~ msgstr "Стилус табылмады"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Планшетті баптау үшін стилусты оған жақындатыңыз"
+
+#~ msgid "Top Button"
+#~ msgstr "Жоғарғы батырма"
+
+#~ msgid "Lower Button"
+#~ msgstr "Төменгі батырма"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Төменгі батырма"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Бұғаттауын шешу..."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Кіру;Аты;Саусақ ізі;"
+#~ "Аватар;Логотип;Бет;Пароль;"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Пернетақта жарлығы"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Бұны Жарлықтарды баптауда өзгертуге болады"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Әр түрлі таңбаларды енгізу үшін басып ұстап, теріңіз"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Э_кран жарықтылығы"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Пер_нетақта жарықтылығы"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Белсенді емес экранды бәсеңдету"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "Экранды _тазарту"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Эл. қорегін үнемдеу үшін Wi-Fi сөндіруге болады."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Эл. қорегін үнемдеу үшін сымсыз кеңжолақты құрылғыларды (3G, 4G, LTE, т."
+#~ "б.) сөндіруге болады."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Эл. қорегін үнемдеу үшін Bluetooth сөндіруге болады."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Теңгерімді қуат"
+
+#~ msgid "Add…"
+#~ msgstr "Қосу…"
+
+#~ msgid "Left Alt"
+#~ msgstr "Сол жақ"
+
+#~ msgid "Right Alt"
+#~ msgstr "Оң жақ"
+
+#~ msgid "Left Super"
+#~ msgstr "Сол жақ Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Оң жақ Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Оң жақ"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Альтернативті таңбалар пернесі"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Түрлендіргіш пернесі келесі кіріс көзіне ауыстырады"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Menu пернесі"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Зарядталуда"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Назарыңызға"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Төмен"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Жақсы"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Толық зарядталған"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Бос"
+
+#~ msgid "Previous source"
+#~ msgstr "Алдыңғы қайнар көзі"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "Келесі қайнар көзі"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Сол+Оң жақ Alt"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Wi-Fi желісіне байланысу үшін сөндіру"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Пароль"
+
+#~ msgid "Universal Access"
+#~ msgstr "Арнайы мүмкіндіктер"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Пайдаланушы тіркелгілерін қосу және парольдерді өзгерту"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Дыбысты ойнату және жазу"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr ""
+#~ "Желілік құрылғыларды mDNS/DNS-SD (Bonjour/zeroconf) қолданып, анықтау"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Bluetooth аппараттық құрылғыларға тікелей қатынау"
+
+#~ msgid "Use your camera"
+#~ msgstr "Камераңыщлы қолдану"
+
+#~ msgid "Print documents"
+#~ msgstr "Құжаттарды басып шығару"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Кез келген қосылған джойстик қолдану"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Docker қызметіне байланысуға рұқсат беру"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Желі брандмауэрін баптау"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Привилегияланған FUSE файлдық жүйелерін баптау және қолдану"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Құрылғы үшін бинарлық кодтарды жаңарту"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Құрылғылар ақпаратына қатынау"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Құрылғылық кездейсоқ сандар генераторына энтропияны қамтамасыз ету"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Құрылғылық генерацияланған кездейсоқ сандарды қолдану"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Үй бумаңыздағы файлдарға қатынау"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Libvirt қызметіне қатынау"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Жүйелік тіл мен аймақ баптауларын өзгерту"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Орналасу баптауларын және ұсынушыларын өзгерту"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Жүйелік және қолданба журналдарын оқу"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "media-hub қызметіне қатынау"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Модемдерді қолдану және баптау"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Жүйелік тіркеу ақпаратын және диск квоталарын оқу"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Музыка және видео плеерлерін басқару"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Төмен деңгейлі желі параметрлерін өзгерту"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "NetworkManager қызметіне желі баптауларын оқу және өзгерту үшін қатынау"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Желі баптауларын оқу рұқсаты"
+
+#~ msgid "Change network settings"
+#~ msgstr "Желі баптауларын өзгерту"
+
+#~ msgid "Read network settings"
+#~ msgstr "Желі баптауларын оқу"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Ұялы телефония үшін желі баптауларын оқу және өзгерту үшін ofono "
+#~ "қызметіне қатынау"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Open vSwitch аппараттық құрылғыларын басқару"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "CD/DVD дискіден оқу"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Сақталған парольдерді оқу, қосу немесе оларды өшіру"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Point-to-Point хаттамасы байланыстарын баптау үшін pppd және ppp "
+#~ "құрылғыларына қатынау"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Жүйедегі кез келген процесті кідірту немесе аяқтау"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "USB аппараттық құрылғыларға тікелей қатынау"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Ауыстырмалы сақтау құрылғыларында файлдарды оқу/жазу"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Экранның ұйқысы/құлыптауын болдырмау"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Тізбекті порттың аппараттық құрылғыларға тікелей қатынау"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Құрылғыны қайта іске қосу немесе сөндіру"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Бағдарламалық қамтаманы орнату, өшіру және баптау"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Storage Framework қызметіне қатынау"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Процесс және жүйелік ақпаратты оқу"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Кез келген орындалып тұрған бағдарламаны бақылау және басқару"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Күн мен уақытты өзгерту"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Уақыт сервері баптауларын өзгерту"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Уақыт белдеуін өзгерту"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Дискілер мен ауыстырмалы тасушыларды баптау үшін UDisks2 қызметіне қатынау"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr ""
+#~ "Ubuntu Unity 8 бағдарламасында бөлісілген күнтізбе оқиғаларын оқу/өзгерту"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Ubuntu Unity 8 бағдарламасында бөлісілген контакттарды оқу/өзгерту"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Энергияны пайдалану деректеріне қатынау"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Шығарылған U2F құрылғыларына оқу/жазу қатынау рұқсаты"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~| msgid "Thunderbolt"
+#~ msgid "Thunderbolt;"
+#~ msgstr "Thunderbolt;"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Пайдаланушы тіркелгісін жасау үшін,\n"
+#~ "алдымен * таңбашасына шертіңіз"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Саусақ ізімен кіруді іске қосу"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Басқа саусақ:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Саусақтың ізі сәтті сақталды. Енді саусақ ізін оқитын құрылғы көмегімен "
+#~ "жүйеге кіре аласыз."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Сіздің бұл құрылғыны қолдану құқығыңыз жоқ. Жүйелік әкімшіге хабарлаңыз."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Ішкі қате орын алды."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Тіркелген саусақ іздерін өшіру керек пе?"
+
+#~ msgid "Done!"
+#~ msgstr "Дайын!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "\"%s\" құрылғысына қатынау мүмкін емес"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "\"%s\" құрылғысында саусақ ізін түсіруді бастау мүмкін емес"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Бірде-бір саусақ ізін оқу құрылғысына қатынау мүмкін емес"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Көмек үшін жүйелік әкімшіңізге хабарласыңыз."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Саусақ ізі арқылы кіруді іске қосу үшін, сізге \"%s\" құрылғысын "
+#~ "қолданып, бір не бірнеше саусақ іздерін сақтау керек."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Саусақты таңдау"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "_Background"
+#~ msgstr "_Фон"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Ауыстырып отыру"
+
+#~ msgid "_Lock Screen"
+#~ msgstr "Б_локтау экраны"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Сыйдыру"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Масштабтау"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Ортасынан"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Созу"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Толтыру"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Мозаика"
+
+#~ msgid "Colors"
+#~ msgstr "Түстер"
+
+#~ msgid "Select Background"
+#~ msgstr "Фонды таңдау"
+
+#~ msgid "Pictures"
+#~ msgstr "Суреттер"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Суреттер табылмады"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Сіз суреттерді %s бумасына қоса аласыз, одан кейін олар осында көрсетіледі"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "_Off"
+#~ msgstr "_Сөнд."
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "Version %s"
+#~ msgstr "Нұсқасы %s"
+
+#~ msgid "OS name"
+#~ msgstr "ОЖ атауы"
+
+#~ msgid "OS type"
+#~ msgstr "ОЖ түрі"
+
+#~ msgid "Disk"
+#~ msgstr "Диск"
+
+#~ msgid "Check for updates"
+#~ msgstr "Жаңартуларға тексеру"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Network proxy"
+#~ msgstr "Желілік прокси"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Байланыс/SSID"
+
+#~ msgid "page 1"
+#~ msgstr "бет 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Ішкі _аутентификация"
+
+#~ msgid "page 2"
+#~ msgstr "бет 2"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "Фондағы деректерді қолдануды шектеу"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr ""
+#~ "Деректер үшін ақша алатын немесе шектейтін байланыстар үшін арналған."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Еспе жұп"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "AUI интерфейсі"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "MII интерфейсі"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Мб/с"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Мб/с"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Гб/с"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Гб/с"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Сымсыз қатынау нүктесін іске қосу нәтижесінде <b>%s</b> желісіне байланыс "
+#~ "үзіледі."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Бұл сымсыз қатынау нүктесі белсенді болып тұрған кезде, сымсыз "
+#~ "байланысыңыз арқылы Интернетке қатынау мүмкін емес."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Wi-Fi қатынау нүктелері әдетте қосымша Интернет байланысымен Wi-Fi арқылы "
+#~ "бөлісу үшін қолданылады."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Автоматты байланы_су"
+
+#~ msgid "details"
+#~ msgstr "ақпараты"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Пар_ольді көрсету"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Басқа пайдаланушыларға қолжетерлік қылу"
+
+#~ msgid "identity"
+#~ msgstr "идентификация"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Адрестер"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Автоматты (DHCP), тек адрестер"
+
+#~ msgid "Link-local only"
+#~ msgstr "Тек жергілікті желі үшін"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "Автоматты алынан бағдарларды еле_меу"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Кл_ондалған MAC адресі"
+
+#~ msgid "_Reset"
+#~ msgstr "_Тастау"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Бұл байланыс үшін баптауларды бастапқы мәндеріне тастау, бірақ, "
+#~ "байланыстың өзін таңдамалы ретінде есте сақтау."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Бұл желіге байланысты барлық ақпаратты өшіру және оған автобайланыспау."
+
+#~ msgid "Hardware"
+#~ msgstr "Құрылғы"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Тастау"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Байланысқан құрылғылар"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Инфраструктура"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Хабарламалық _баннерлер"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Автоматты түрде ұйықтату"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "Қ_орек батырмасы басылған кезде"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "In use"
+#~ msgstr "Қолдануда"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Іске қосулы"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Сөндірулі"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Сөнд."
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Іске қосылған"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Сөнд."
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Іске қосылған"
+
+#~ msgid "Usage & History"
+#~ msgstr "Қолдану тарихы"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Жекелік саясаты"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Тарихыңызды сақтау нәрселерді қайта іздеген кезде пайдалы болады. Ол "
+#~ "тарих желі арқылы ешқашан да берілмейді."
+
+#~ msgid "_Recently Used"
+#~ msgstr "Жақ_ында қолданылған"
+
+#~ msgid "Retain _History"
+#~ msgstr "Тарихты _сақтау"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Экранды блоктау мүмкіндігі сіз кетіп қалған кезде қауіпсіздігіңізді "
+#~ "қорғайды."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Бос болған э_кранды кейін блоктау"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Компьютеріңізді керек емес және сезімтал ақпараттан бос ұстау үшін қоқыс "
+#~ "шелегін және уақытша файлдарды автоматты түрде тазарту."
+
+#~ msgid "Purge _After"
+#~ msgstr "Ке_йін тазарту"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Сіз қолданатын БҚ туралы ақпаратты бізге жіберу нақтырақ ұсыныстарды "
+#~ "жасауға көмектеседі. Сонымен бірге, біздің БҚ-ны жақсартуға көмектеседі.\n"
+#~ "\n"
+#~ "Біз жинайтын барлық ақпарат анонимды, және біз ол ақпаратпен үшінші "
+#~ "жақтармен ешқашан бөліспейміз."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "БҚ қолдану статистикасын жі_беру"
+
+#~ msgid "_Camera"
+#~ msgstr "_Камера"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Микрофон"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Орналасулар қызметі"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Жеке ақпаратыңызды қорғаңыз және басқалар не көре алатынын басқарыңыз"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "No regions found"
+#~ msgstr "Аймақтар табылмады"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Тере_зе атауын жыпылықтау"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "Last Login"
+#~ msgstr "Соңғы рет жүйеге кіру"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Пайдаланушы аты \"-\" таңбасынан басталмауы тиіс."
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Түнгі жарық"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Экран ақпаратын алу мүмкін емес"
+
+#~ msgid "hardware"
+#~ msgstr "құрылғы"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Алдыңғы қайнар көзіне ауысу"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Келесі қайнар көзіне ауысу"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Келесі қайнар көзіне ауысудың альтернативті жолы"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Ағылшын (Ұлыбритания)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Ұлыбритания"
+
+#~ msgid "_Options"
+#~ msgstr "_Опциялар"
+
+#~ msgid "Add input source"
+#~ msgstr "Кіріс қайнар көзін қосу"
+
+#~ msgid "Remove input source"
+#~ msgstr "Кіріс қайнар көзін өшіру"
+
+#~ msgid "Move input source up"
+#~ msgstr "Кіріс қайнар көзін жоғары жылжыту"
+
+#~ msgid "Move input source down"
+#~ msgstr "Кіріс қайнар көзін төмен жылжыту"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Кіріс қайнар көзінің пернетақта жаймасын көрсету"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Сол жақ"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Оң жақ"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Минимум"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Максимум"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Сабвуфер:"
+
+#~ msgid "_Profile:"
+#~ msgstr "Проф_иль:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "Ди_намиктерді тексеру"
+
+#~ msgid "Peak detect"
+#~ msgstr "Пиктер анықтағышы"
+
+#~ msgid "Device"
+#~ msgstr "Құрылғы"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s үшін динамикті тексеру"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Дыбыс шығаратын құры_лғыны таңдаңыз:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Таңдалған құрылғы баптаулары:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Кіріс дыбысы:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Дыбыс жазатын құры_лғыны таңдаңыз:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Дыбыс эффектілері"
+
+#~ msgid "Built-in"
+#~ msgstr "Құрамындағы"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Дыбыс баптаулары"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Оқиға дыбысын сынау"
+
+#~ msgid "From theme"
+#~ msgstr "Темадан"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Ес_керту дыбысын таңдау:"
+
+#~ msgid "Stop"
+#~ msgstr "Тоқтату"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Қалыпты"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Әкімші"
+
+#~ msgid "page 3"
+#~ msgstr "бет 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME басқару орталығы"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Басқару орталығы - жұмыс үстеліңіздің түрлі баптауларын жасауға арналған "
+#~ "GNOME жүйесінің басты интерфейсі."
+
+#~ msgid "Quit"
+#~ msgstr "Шығу"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "Жаңа парольді ра_стау"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Парольдер өзара сәйкес келмейді."
+
+#~ msgid "Show the overview"
+#~ msgstr "Шолуды көрсету"
+
+#~ msgid "Back­ground"
+#~ msgstr "Фон"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blue­tooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Түс"
+
+#~ msgid "Overview"
+#~ msgstr "Шолу"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Үнсіз келісім қолданбалары"
+
+#~ msgid "Ab­out"
+#~ msgstr "Осы туралы"
+
+#~ msgid "De­tails"
+#~ msgstr "Көбі­рек білу"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Ауыстырмалы тасушылар"
+
+#~ msgid "Net­work"
+#~ msgstr "Же­лі"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Ха­бар­ла­ма­лар"
+
+#~ msgid "Po­wer"
+#~ msgstr "Эл. қо­регі"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Жеке­лік"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Бө­лі­су"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Ар­найы мүм­кін­дік­тер"
+
+#~ msgid "Disable image"
+#~ msgstr "Суретті сөндіру"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Көбірек суретті шолу…"
+
+#~ msgid "Used by %s"
+#~ msgstr "%s қолданған"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wa­com план­шеті"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Құрылғылар"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Жүйелік"
+
+#~ msgid "Apply"
+#~ msgstr "Іске асыру"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Қақпағы жабық"
+
+#~ msgid "Mirrored"
+#~ msgstr "Айналы"
+
+#~ msgid "Secondary"
+#~ msgstr "Екіншілік"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Топталған экрандарды реттеу"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Экрандарды реттеу үшін оларды тартып жылжытыңыз"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Гц (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Гц"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Сағат тілі бағытына қарсы 90°-қа бұру"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "180°-қа бұру"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Сағат тілі бойымен 90°-қа бұру"
+
+#~ msgid "Size"
+#~ msgstr "Өлшемі"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Жоғарғы панельді және белсенділік көрінісін бұл экранда көрсету"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Бұл экранды көбірек жұмыс орнын жасау үшін басқа экранмен біріктіру"
+
+#~ msgid "Presentation"
+#~ msgstr "Презентация"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Тек слайдшоулар және медианы көрсету"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Бар болып тұрған көріністі екі экранда бірдей көрсету"
+
+#~ msgid "Turn Off"
+#~ msgstr "Сөндіру"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Бұл экранды қолданбау"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "Топталған экрандарды р_еттеу"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "Ұ_шақтағы режимі"
+
+#~ msgid "Server"
+#~ msgstr "Сервер"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS серверін өшіру"
+
+#~ msgid "Proxy"
+#~ msgstr "Прокси"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "Профильді қ_осу…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Жоқ"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Қолмен"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Автоматты"
+
+#~ msgid "_Method"
+#~ msgstr "Тә_сіл"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN түрі"
+
+#~ msgid "Group Name"
+#~ msgstr "Топ аты"
+
+#~ msgid "Group Password"
+#~ msgstr "Топ паролі"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "Қа_тынау нүктесі ретінде қолдану…"
+
+#~ msgid "_History"
+#~ msgstr "_Тарихы"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Басқа па_йдаланушыларға қолжетерлік қылу"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Бұл желі үшін барлық баптауларды тастау (парольді қоса), бірақ, оны "
+#~ "таңдамалы желі ретінде есте сақтау"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Бұл желі үшін барлық баптауларды тастау және автобайланысу талаптарын "
+#~ "жасамау"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Егер сізде сымсыз байланыстан басқа Интернетпен байланысыңыз бар болса, "
+#~ "ол байланыспен басқа пайдаланушылармен бөлісу үшін, сымсыз қатынау "
+#~ "нүктесін жасауға болады."
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Бас тарту үшін Esc басыңыз."
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-бит (Жинақ ID: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-бит"
+
+#~ msgid "Base system"
+#~ msgstr "Базалық жүйе"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;Жарлық;Қайталау;Жыпылықтау;"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Файрволл _зонасы"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Бастапқы"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Зона байланыстың сенімділік деңгейін анықтайды"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Көбірек әріптер, сандар және белгілерді қосып көріңіз."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Деңгейі: Әлсіз"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Мықтылығы: Төмен"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Деңгейі: Орташа"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Деңгейі: Жақсы"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Деңгейі: Жоғары"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Сіздің тіркелгіңіз</small>"
+
+#~ msgid "0"
+#~ msgstr "0"
+
+#~ msgid "Add Account"
+#~ msgstr "Тіркелгіні қосу"
+
+#~ msgid "Mail"
+#~ msgstr "Эл. пошта"
+
+#~ msgid "Calendar"
+#~ msgstr "Күнтізбе"
+
+#~ msgid "Contacts"
+#~ msgstr "Контакттар"
+
+#~ msgid "Chat"
+#~ msgstr "Чат"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Баптау"
+
+#~ msgid "Toner Level"
+#~ msgstr "Тонер деңгейі"
+
+#~ msgid "Supply Level"
+#~ msgstr "Жаратылатын заттар деңгейі"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Орнатылуда"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u белсенді"
+
+#~ msgid "Supply"
+#~ msgstr "Жаратылатын заттар"
+
+#~ msgid "Jobs"
+#~ msgstr "Тапсырмалар"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Та_псырмаларды көрсету"
+
+#~ msgid "label"
+#~ msgstr "белгі"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Сы_ану парағын баспаға шығару"
+
+#~ msgctxt "button"
+#~ msgid "Add Printer"
+#~ msgstr "Принтерді қосу"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Басқа тіркелгілер"
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Жарлықты орнату"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Хабарламалық _баннерлер"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Хабарламалық _баннерлер"
+
+#~ msgid "Error creating account"
+#~ msgstr "Тіркелгіні жасау қатесі"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Тіркелгіні өшіруді шынымен қалайсыз ба?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Бұл әрекет нәтижесінде тіркелгі серверден өшірілмейді."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Желілік тіркелгілер бапталмады"
+
+#~ msgid "Add an online account"
+#~ msgstr "Желілік тіркелгіні қосу"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Тіркелгіні қосу нәтижесінде қолданбалар ол тіркелгінің құжаттар, эл. "
+#~ "пошта, контакттар, күнтізбе, чат және т.б. қатынауға мүмкіндік береді."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Жоғары"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Төмен"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Жоқ"
+
+#~ msgid "Left Ring"
+#~ msgstr "Сол жақ сақина"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Сол жақ сақина режимі #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Оң жақ сақина режимі #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Сол жақтағы сенсорлы жолақ"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Сол жақтағы сенсорлы жолақ режимі #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Оң жақтағы сенсорлы жолақ"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Оң жақтағы сенсорлы жолақ режимі #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Сол жақтағы сенсорлық сақина режимін ауыстырғышы"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Оң жақтағы сенсорлық сақина режимін ауыстырғышы"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Сол жақтағы сенсорлық жолақ режимін ауыстырғышы"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Оң жақтағы сенсорлық жолақ режимін ауыстырғышы"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Режимді ауыстырғыш #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Сол жақ батырма #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Оң жақ батырма #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Жоғарғы батырма #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Төменгі батырма #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Әрекет жоқ"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Тышқанның сол жақ батырма шертуі"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Жоғары айналдыру"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Төмен айналдыру"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Оңға айналдыру"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Жаңа принтерді қосу"
+
+#~ msgid "No printers detected."
+#~ msgstr "Принтерлер табылмады."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr ""
+#~ "<b>%s</b> үшін пернетақта жарлығы. Өзгерту үшін жаңа жарлықты енгізіңіз."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Жарлықты түзету үшін, оның жолын таңдап, жаңа пернелерді басыңыз немесе "
+#~ "тазарту үшін Backspace басыңыз."
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Жарлықты өшіру"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Белгісіз әрекет>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "\"%s\" жарлығын қолдану мүмкін емес, өйткені бұл пернемен теру мүмкін "
+#~ "емес болады.\n"
+#~ "Онымен бірге бір уақытта Control, Alt не Shift басып көріңіз."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "\"%s\" жарлығы келесі үшін қолданылуда:\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Егер сіз жарлық мәнін \"%s\" етіп орнатсағыз, онда \"%s\" жарлығы "
+#~ "сөндірілетін болады."
+
+#~ msgid "_Reassign"
+#~ msgstr "Қа_йта тағайындау"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" жарлығында сәйкестелген \"%s\" жарлығы бар. Оны автоматты түрде "
+#~ "\"%s\" етіп орнату керек пе?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" қазір \"%s\" жарлығымен сәйкестелген, жалғастырсаңыз, бұл жарлық "
+#~ "сөндірілетін болады."
+
+#~ msgid "_Assign"
+#~ msgstr "Т_ағайындау"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Желілік байланысты қосу"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Сертификаттау орталығының  (CA) сертификаты таңдалмады"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Сертификаттау орталығының (CA) сертификатын қолданбау қауіпсіздік "
+#~ "мәселелеріне әкеп соғуы мүмкін. Сертификаттау орталығының сертификатын "
+#~ "таңдауды қалайсыз ба?"
+
+#~ msgid "Ignore"
+#~ msgstr "Елемеу"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "СО сертификатын таңдаңыз"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Әр р_ет парольді сұрап отыру"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Мені келесіде е_скертпеу"
+
+#~ msgid "Yes"
+#~ msgstr "Иә"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Тіркелгіге кіру сәтсіз ақталды"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Кіру ақпараты ескірген."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Бұл тіркелгіні іске қосу үшін кіріңіз."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Кіру"
+
+#~ msgid "Login History"
+#~ msgstr "Жүйеге кіру тарихы"
+
+#~ msgid "Add User Account"
+#~ msgstr "Пайдаланушы тіркелгісін қосу"
+
+#~ msgid "Welcome to the Control Center"
+#~ msgstr "Басқару орталығына қош келдіңіз"
+
+#~ msgid "Select a panel in the sidelist to see the available options"
+#~ msgstr "Қолжетерлік опцияларды қарау үшін бүйір тізімнен панельді таңдаңыз"
+
+#~ msgid "Bond"
+#~ msgstr "Агрегацияланған (Bond)"
+
+#~ msgid "Team"
+#~ msgstr "Агрегацияланған (Team)"
+
+#~ msgid "Bridge"
+#~ msgstr "Көпір"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN плагиндерін жүктеу мүмкін емес"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Агрегацияланған байланыс слейвтері (Bond)"
+
+#~ msgid "(none)"
+#~ msgstr "(ешнәрсе)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Желілік көпір слейвтері"
+
+#~ msgid "Team slaves"
+#~ msgstr "Агрегацияланған байланыс слейвтері (Team)"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand құрылғысы байланысқан күйін қолдамайды"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Басқа"
+
+#~ msgid "_Verify"
+#~ msgstr "_Растау"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Пайдаланушы аты '%s' болып тұрған пайдаланушы бар болып тұр."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Географиялық орналасуыңызды анықтау үшін қолданылады"
+
+#~ msgid "Done"
+#~ msgstr "Дайын"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Уақыт _белдеуі"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Баспаға шығаруды жалғастыру"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Баспаға шығаруды аялдату"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Тұрып қалған"
+
+#~ msgid "Job Title"
+#~ msgstr "Тапсырма атауы"
+
+#~ msgid "Job State"
+#~ msgstr "Тапсырма күйі"
+
+#~ msgid "Password:"
+#~ msgstr "Пароль:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "Пернелер қа_йталануы"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "_Курсор жыпылықтауы"
+
+#~ msgid "Zoom"
+#~ msgstr "Үлкейту"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Түс"
+
+#~ msgid "_Delay:"
+#~ msgstr "Күт_у:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Қысқа"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Баяу"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Ұзақ"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Жылдам"
+
+#~ msgid "S_peed:"
+#~ msgstr "Жы_лдамдығы:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Баптауларды тексеру"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Баяу"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Жылдам"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Сол жақ"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Оң жақ"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "Кур_сор жылдамдығы"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Баяу"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Жылдам"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Баяу"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Жылдам"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Жаңа принтерді қосу"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Сымсыз құрылғылар қосымша қоректі талап етеді"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Батарея заряд шамасы тым а_з болса"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Bluetooth арқылы бөлісу көмегімен басқа Bluetooth құрылғыларымен "
+#~ "файлдармен алмаса аласыз"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Тек сенімді құрылғылардан қабылдау"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Қабылданған файлдарды Жүктемелер бумасына сақтау"
+
+#~ msgid "Show help options"
+#~ msgstr "Көмек опцияларын көрсету"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Қолжетерлік командалық жол опцияларын көру үшін, '%s --help' жөнелтіңіз.\n"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Сымсыз құрылғыларды сөндіреді"
+
+#~ msgid "United States"
+#~ msgstr "АҚШ"
+
+#~ msgid "Germany"
+#~ msgstr "Германия"
+
+#~ msgid "Spain"
+#~ msgstr "Испания"
+
+#~ msgid "China"
+#~ msgstr "Қытай"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "_Теру кезінде сөндіру"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Жүйелік желілік қызметтер бұл нұсқасымен үйлеспейді."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Қалқымалы баннерлерді көрсету"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Блоктау экранында қарау"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Қалқымалы баннерлерді көрсету"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "Блоктау экранында көрсету"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Принтер адресін немесе сүзгілеу үшін мәтінді енгізіңіз"
+
+#~ msgid "Sorry"
+#~ msgstr "Кешіріңіз"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Жаңа құрылғыны орнату"
+
+#~ msgid "Paired"
+#~ msgstr "Жұпталған"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Тышқан және тачпад баптаулары"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Пернетақта баптаулары"
+
+#~ msgid "Send Files…"
+#~ msgstr "Файлдарды жіберу..."
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” көрінуі"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "'%s' құрылғылар тізімінен өшіру керек пе?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Егер құрылғыны алып тастасаңыз, оны келесі рет қолдану алдында тағы да "
+#~ "баптау керек болады."
+
+#~ msgid "Device type:"
+#~ msgstr "Құрылғы түрі:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Шығарушы:"
+
+#~ msgid "Model:"
+#~ msgstr "Моделі:"
+
+#~ msgid "Combine"
+#~ msgstr "Біріктіру"
+
+#~ msgid "Don't use the display"
+#~ msgstr "Экранды қолданбау"
+
+#~ msgid "Install Updates"
+#~ msgstr "Жаңартуларды орнату"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Жүйе жаңа"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Тышқан баптаулары"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Жаңа қызмет үшін қолданылатын интерфейсті таңдаңыз"
+
+#~ msgid "C_reate…"
+#~ msgstr "Жаса_у…"
+
+#~ msgid "_Interface"
+#~ msgstr "_Интерфейс"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Желідегі принтерлерді іздеу немесе нәтижелерді сүзгілеу"
+
+#~ msgid "_Default"
+#~ msgstr "_Негізгі"
+
+#~ msgid "Immediately"
+#~ msgstr "Қолма-қол"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Ешнәрсе"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Ортақ бумамен бөлісу"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Тек сенімді құрылғылармен бөлісу"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Бұл желіде медиамен бөлісу"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Ортақ бумалар"
+
+#~ msgid "column"
+#~ msgstr "баған"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Буманы өшіру"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Ортақ бумаңызды бұл желіде ортақ қылу"
+
+#~ msgid "Remote View"
+#~ msgstr "Қашықтан көрініс"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Барлық байланыстарды рұқсат ету"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Фотосуретті өзгерту:"
+
+#~ msgid "Gallery"
+#~ msgstr "Галерея"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Фотосуретті түсіру"
+
+#~ msgid "Browse"
+#~ msgstr "Шолу"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM және PM арасында ауысу."
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "Батареяның шамамен заряды: %s"
+
+#, fuzzy
+#~ msgid "Export"
+#~ msgstr "И_мпорт"
+
+#~| msgid "Left"
+#~ msgid "Left Shift"
+#~ msgstr "Сол жақ"
+
+#~| msgid "Right"
+#~ msgid "Right Shift"
+#~ msgstr "Оң жақ"
+
+#~| msgid "Left"
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Сол жақ"
+
+#~| msgid "Right"
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Оң жақ"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Сол жақ Ctrl+Shift"
+
+#~| msgid "Right"
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Оң жақ"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Сол+Оң жақ Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Сол+Оң жақ Ctrl"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "_Region:"
+#~ msgstr "А_ймақ:"
+
+#~ msgid "_City:"
+#~ msgstr "Қа_ла:"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Қалыпты"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Сағат тілі бағытымен"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 градус"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#, fuzzy
+#~ msgid "_Resolution"
+#~ msgstr "Ажыратылымдығы"
+
+#, fuzzy
+#~ msgid "R_otation"
+#~ msgstr "Кең_ейтілуі:"
+
+#~| msgid "Slow Keys"
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "Баяу пернелер"
+
+#, fuzzy
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "Жылдам"
+
+#~| msgid "_Options"
+#~ msgid "_Options…"
+#~ msgstr "_Опциялар"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~| msgid "Visibility"
+#~ msgid "Visible"
+#~ msgstr "Көрінуі"
+
+#~| msgid "Visibility"
+#~ msgid "Name & Visibility"
+#~ msgstr "Көрінуі"
+
+#~| msgid "None"
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "Ешнәрсе"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Қалыпты"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Экрандағы пернетақта"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Қалыпты"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~| msgid "Zoom"
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Үлкейту"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Үлкейту:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Кішірейту:"
+
+#~| msgid "Short"
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "<i>Қысқа</i>"
+
+#~| msgid "Long"
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "Ұзақ"
+
+#, fuzzy
+#~ msgid "rejected"
+#~ msgstr "Тайдырылған"
+
+#~| msgid "Mouse"
+#~ msgid "Video Mouse"
+#~ msgstr "Тышқан"
+
+#~| msgid "Small"
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "Кішкентай"
+
+#~| msgid "Large"
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "Үлкен"
+
+#~| msgid "Remove Account"
+#~ msgid "_Local Account"
+#~ msgstr "Тіркелгіні өшіру"
+
+#~ msgid "C_ontinue"
+#~ msgstr "Жа_лғастыру"
+
+#~ msgid "Next week"
+#~ msgstr "Келесі апта"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Жүйеге парольсіз кіру"
+
+#~ msgid "Disable this account"
+#~ msgstr "Бұл тіркелгіні сөндіру"
+
+#~ msgid "Enable this account"
+#~ msgstr "Бұл тіркелгіні іске қосу"
+
+#~ msgid "_Action"
+#~ msgstr "Әре_кет"
+
+#~ msgid "_Show password"
+#~ msgstr "Пар_ольді көрсету"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Тым қысқа"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Әлсіз"
+
+#~| msgid "Filter"
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Фильтр"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Жақсы"
+
+#~| msgid "Scrolling"
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Айналдыру"
+
+#~| msgid "Set a password now"
+#~ msgid "_Generate a password"
+#~ msgstr "Парольді қазір орнату"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "Сізге жаңа парольді енгізу керек"
+
+#~| msgid "The current password is not correct"
+#~ msgid "The new password is not strong enough"
+#~ msgstr "Ағымдағы пароль дұрыс көрсетілмеді"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "Сізге парольді растау керек"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "Сізге ағымдағы пароліңізді енгізу керек"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "Ағымдағы пароль дұрыс көрсетілмеді"
+
+#~ msgid "Action"
+#~ msgstr "Әрекет"
+
+#, fuzzy
+#~ msgid "Browse Files..."
+#~ msgstr "_Файлдарды қарап шығу"
+
+#, fuzzy
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+#, fuzzy
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "Жыл:"
+
+#, fuzzy
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "MONTH"
+
+#, fuzzy
+#~ msgid "English"
+#~ msgstr "Ағылшын"
+
+#, fuzzy
+#~ msgid "French"
+#~ msgstr "Француз"
+
+#, fuzzy
+#~ msgid "Spanish"
+#~ msgstr "Испаниялық"
+
+#, fuzzy
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Қытайша оңайлатылған"
+
+#~ msgid "Russian"
+#~ msgstr "Орысша"
+
+#~ msgid "Arabic"
+#~ msgstr "Арабша"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~| msgid "Unknown"
+#~ msgid "Unknown model"
+#~ msgstr "Белгісіз"
+
+#~| msgid "Appearance"
+#~ msgid "Experience"
+#~ msgstr "Сыртқы түрі"
+
+#~| msgid "Out of toner"
+#~ msgid "Out of range"
+#~ msgstr "Тонер жоқ"
+
+#~ msgid "_Options..."
+#~ msgstr "_Опциялар..."
+
+#~| msgid "Create..."
+#~ msgid "C_reate..."
+#~ msgstr "Жаса_у..."
+
+#~| msgid "Hinting"
+#~ msgid "_Disconnect"
+#~ msgstr "Б_айланысты үзу"
+
+#~| msgid "Contact"
+#~ msgid "_Connect"
+#~ msgstr "<u>Байланысу</u>"
+
+#~| msgid "_Options..."
+#~ msgid "_Settings..."
+#~ msgstr "Ба_птаулар"
+
+#, fuzzy
+#~ msgid "_Log In"
+#~ msgstr "Жүйеге кіру"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "Желідегі тіркелгілерді басқару"
+
+#~| msgid "On battery power"
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "Батареядан"
+
+#~| msgid "On battery power"
+#~ msgid "Using battery power"
+#~ msgstr "Батареядан"
+
+#~| msgid "Suspend when inactive for:"
+#~ msgid "Suspend when inactive for"
+#~ msgstr "Ұйықтату үшін белсенді емес уақыты:"
+
+#~ msgid "Manufacturers"
+#~ msgstr "Өндірушілер"
+
+#~| msgid "_Show..."
+#~ msgid "_Show"
+#~ msgstr "Көр_сету"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "Аймақ пен тіл баптауларын өзгерту"
+
+#~ msgid "Region and Language"
+#~ msgstr "Аймақ пен тіл"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Экрандағы тілді таңдаңыз (өзгерістер сіз жүйеге келесі рет кіргенде іске "
+#~ "асады)"
+
+#~ msgid "Add Language"
+#~ msgstr "Тілді қосу"
+
+#~ msgid "Install languages..."
+#~ msgstr "Тілдерді орнату..."
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr ""
+#~ "Аймақты таңдаңыз (өзгерістер сіз жүйеге келесі рет кіргенде іске асады)"
+
+#~ msgid "Add Region"
+#~ msgstr "Аймақты қосу"
+
+#~ msgid "Currency"
+#~ msgstr "Ақша"
+
+#~ msgid "Examples"
+#~ msgstr "Мысалдар"
+
+#~ msgid "Format:"
+#~ msgstr "Пішімі:"
+
+#~ msgid "System settings"
+#~ msgstr "Жүйелік баптаулар"
+
+#~| msgid "Brightness and Lock"
+#~ msgid "Brightness & Lock"
+#~ msgstr "Жарықтылық пен блоктау"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "Эл. қоре_гін сақтау үшін экран жарықтылығын азайту"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "Үйде болғанда, блоктамау"
+
+#~ msgid "Locations..."
+#~ msgstr "Орналасу..."
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Жөндеу кодын іске қосу"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "Д_ыбыс баптаулары"
+
+#~ msgid "Muted"
+#~ msgstr "Басылған"
+
+#~ msgid "Options..."
+#~ msgstr "Опциялар..."
+
+#~| msgid "Filter"
+#~ msgid "Fair"
+#~ msgstr "Фильтр"
+
+#~| msgid "_Options..."
+#~ msgid "Map Buttons..."
+#~ msgstr "_Опциялар..."
+
+#~ msgid "Add wallpaper"
+#~ msgstr "Түсқағазды қосу"
+
+#~ msgid "Swap colors"
+#~ msgstr "Түстерді алмастыру"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Горизонталды градиент"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Вертикалды градиент"
+
+#~ msgid "Solid Color"
+#~ msgstr "Бүтін түс"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "Түстер мен градиенттер"
+
+#~| msgid "Action"
+#~ msgid "Acti_on:"
+#~ msgstr "Әре_кет:"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_Оңақай"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Солақай"
+
+#~| msgid "_Acceleration:"
+#~ msgid "A_cceleration:"
+#~ msgstr "Үд_ету:"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "Ұстап апару мен тастау"
+
+#~ msgid "_Disabled"
+#~ msgstr "Сөн_дірулі"
+
+#~| msgid "Other"
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "Басқа..."
+
+#~| msgid "Disabled"
+#~ msgid "Disable VPN"
+#~ msgstr "Сөндірулі"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "Тіркелгіні қосу үшін, алдымен оның түрін таңдаңыз"
+
+#~ msgid "_Add..."
+#~ msgstr "Қ_осу..."
+
+#~ msgid "Battery discharging"
+#~ msgstr "Батарея зарядын беруде"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s заряды біткенше дейін (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% зарядталған"
+
+#~| msgid "_Language:"
+#~ msgid "Remove Language"
+#~ msgstr "Тілді өшіру"
+
+#~| msgid "Layout"
+#~ msgid "Add Layout"
+#~ msgstr "Жайманы қосу"
+
+#~| msgid "Layout"
+#~ msgid "Remove Layout"
+#~ msgstr "Жайманы өшіру"
+
+#~| msgid "Preview:"
+#~ msgid "Preview Layout"
+#~ msgstr "Жайманы алдын-ала қарау"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "Жаңа терезелер негізгі жайманы қолданады"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "Жаңа терезелер алдыңғы терезенің жаймасын қолданады"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "Баста_пқыға тастау"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Ағымдағы пернетақта жаймасы баптауларын\n"
+#~ "үнсіз келісіз бойынша баптауларымен алмастыру"
+
+#~ msgid "Layouts"
+#~ msgstr "Жаймалар"
+
+#~ msgid "Layout"
+#~ msgstr "Жайма"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~| msgid "None"
+#~ msgid "Nomon"
+#~ msgstr "Ешнәрсе"
+
+#~| msgid "Change your password"
+#~ msgid "Change contrast:"
+#~ msgstr "Контрастты өзгерту"
+
+#~| msgid "Zoom"
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "Масштаб"
+
+#~ msgid "Account _type"
+#~ msgstr "Тіркелгі _түрі"
+
+#~ msgid "System Settings"
+#~ msgstr "Жүйелік баптаулар"
+
+#~ msgid "No Image"
+#~ msgstr "Сурет жоқ"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Қал_а:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "Е_л:"
+
+#~ msgid "Email"
+#~ msgstr "Эл. пошта"
+
+#~ msgid "Work"
+#~ msgstr "Жұмыс"
+
+#, fuzzy
+#~ msgid "_Home:"
+#~ msgstr "Үйге"
+
+#~ msgid "_Work:"
+#~ msgstr "Жұ_мыс:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "Yahoo а_дресі:"
+
+#~ msgid "System error: %s."
+#~ msgstr "Жүйелік қате: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%s жөнелту қатесі: %s"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "Таңд_амалы қолданбалар"
+
+#~ msgid "Icons"
+#~ msgstr "Таңбашалар"
+
+#~ msgid "Icons only"
+#~ msgstr "Тек таңбашалар"
+
+#, fuzzy
+#~ msgid "N_one"
+#~ msgstr "бір"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Түсті таңдау үшін сұхбат терезесін ашу"
+
+#~ msgid "Save _As..."
+#~ msgstr "Қала_йша сақтау..."
+
+#~ msgid "Text only"
+#~ msgstr "Тек мәтін"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "Ан_ықтамасы:"
+
+#~ msgid "_None"
+#~ msgstr "_Ешнәрсе"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "_Бастапқы түріне келтіру"
+
+#~ msgid "_Size:"
+#~ msgstr "Ө_лшемі:"
+
+#~ msgid "_Slight"
+#~ msgstr "Әл_сіз"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Терезелер:"
+
+#~ msgid "Image"
+#~ msgstr "Сурет"
+
+#~ msgid "Select Theme"
+#~ msgstr "Теманы таңдаңыз"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Көмекті көрсету кезінде қате кетті: %s"
+
+#~ msgid "_Skip"
+#~ msgstr "А_ттап кету"
+
+#~ msgid "Key"
+#~ msgstr "Кілт"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Коман_да:"
+
+#~ msgid "Mail Reader"
+#~ msgstr "Пошта қолданбасы"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "Терминал эмуляторы"
+
+#~ msgid "Text Editor"
+#~ msgstr "Мәтін түзетушісі"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee Music Player"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian Sensible Browser"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian терминал эмуляторы"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution Mail Reader"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape Mail"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "Rxvt"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox Music Player"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey Mail"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem Movie Player"
+
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "%s/%s ашу мүмкін емес: %s\n"
+
+#, fuzzy
+#~ msgid "Could not rename %s to %s: %s\n"
+#~ msgstr "%s атын жаңа %s атына ауыстыру мүмкін емес: %s\n"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "Монитор: %s"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Пернетақта _түрі:"
+
+#~ msgid "_Single click:"
+#~ msgstr "Бі_рлік шерту:"
+
+#~ msgid "_Alt"
+#~ msgstr "Alt"
+
+#~ msgid "Groups"
+#~ msgstr "Топтар"
+
+#~ msgid "_Take a Break"
+#~ msgstr "Де_малу уақыты"
+
+#~ msgid "translator-credits"
+#~ msgstr "Baurzhan Muftakhidinov <baurthefirst@gmail.com>, 2010"
+
+#~ msgid "Copyright:"
+#~ msgstr "Copyright:"
+
+#~ msgid "Description:"
+#~ msgstr "Анықтамасы:"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "Таңдамалыларға қосу"
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "\"%s\" көмегімен ашу"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "Файлдық шолушысында ашу"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Today %l:%M %p"
+
+#, fuzzy
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "Кеше"
+
+#~ msgid "Find Now"
+#~ msgstr "Қазір табу"
+
+#, fuzzy
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "А_шу..."

--- a/po/km.po
+++ b/po/km.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: po_gnome-control-center-2.0-km\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2012-09-10 13:48+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2012-04-19 02:15+0000\n"
 "Last-Translator: Khoem Sokhem <khoemsokhem@khmeros.info>\n"
 "Language-Team: Khmer <support@khmeros.info>\n"
@@ -21,5370 +21,7689 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-09-03 19:12+0000\n"
 "X-Language: km-KH\n"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:2
-msgid "Changes throughout the day"
-msgstr "ផ្លាស់ប្ដូរ​រាល់​ថ្ងៃ"
-
-#: ../panels/background/background.ui.h:3
-#| msgid "Tile"
-msgctxt "background, style"
-msgid "Tile"
-msgstr "ក្រឡា​ក្បឿង"
-
-#: ../panels/background/background.ui.h:4
-#| msgid "Zoom"
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "ពង្រីក"
-
-#: ../panels/background/background.ui.h:5
-#| msgid "Center"
-msgctxt "background, style"
-msgid "Center"
-msgstr "កណ្ដាល"
-
-#: ../panels/background/background.ui.h:6
-#| msgid "Scale"
-msgctxt "background, style"
-msgid "Scale"
-msgstr "មាត្រដ្ឋាន"
-
-#: ../panels/background/background.ui.h:7
-#| msgid "Fill"
-msgctxt "background, style"
-msgid "Fill"
-msgstr "បំពេញ"
-
-#: ../panels/background/background.ui.h:8
-#| msgid "Span"
-msgctxt "background, style"
-msgid "Span"
-msgstr "វិសាលភាព"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:199
-#| msgid "Select an account"
-msgid "Select Background"
-msgstr "ជ្រើស​ផ្ទៃ​ខា​ងក្រោយ"
-
-#: ../panels/background/cc-background-chooser-dialog.c:218
-msgid "Wallpapers"
-msgstr "ផ្ទាំង​រូបភាព"
-
-#: ../panels/background/cc-background-chooser-dialog.c:227
-#| msgid "Picture CD"
-msgid "Pictures"
-msgstr "រូបភាព"
-
-#: ../panels/background/cc-background-chooser-dialog.c:235
-#| msgid "Color"
-msgid "Colors"
-msgstr "ពណ៌"
-
-#: ../panels/background/cc-background-chooser-dialog.c:244
-msgid "Flickr"
-msgstr "Flickr"
-
-#: ../panels/background/cc-background-chooser-dialog.c:286
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-#: ../panels/user-accounts/um-photo-dialog.c:98
-msgid "Select"
-msgstr "ជ្រើស"
-
-#: ../panels/background/cc-background-item.c:148
-msgid "multiple sizes"
-msgstr "ទំហំ​ជាច្រើន"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:152
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:281
-msgid "No Desktop Background"
-msgstr "គ្មាន​ផ្ទៃខាងក្រោយ​របស់​ផ្ទៃតុ"
-
-#: ../panels/background/cc-background-panel.c:387
-msgid "Current background"
-msgstr "ផ្ទៃខាងក្រោយ​បច្ចុប្បន្ន"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
-#| msgid "<b>Background</b>"
-msgid "Background"
-msgstr "ផ្ទៃ​ខាង​ក្រោយ"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-#| msgid "Change the background and theme"
-msgid "Change the background"
-msgstr "ផ្លាស់ប្ដូរ​ផ្ទៃខាងក្រោយ"
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-#, fuzzy
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "ផ្ទាំង​រូបភាព អេក្រង់ ផ្ទៃតុ"
-
-#. TRANSLATORS: device type
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
-#: ../panels/network/panel-common.c:102
-msgid "Bluetooth"
-msgstr "ប៊្លូធូស"
-
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
-msgid "Configure Bluetooth settings"
-msgstr "កំណត់​រចនាសម្ព័ន្ធ​នៃ​ការ​កំណត់​ប៊្លូធូស"
-
-#: ../panels/bluetooth/bluetooth.ui.h:1
-msgid "Set Up New Device"
-msgstr "រៀបចំ​ឧបករណ៍​ថ្មី"
-
-#: ../panels/bluetooth/bluetooth.ui.h:2 ../panels/network/network.ui.h:9
-msgid "Remove Device"
-msgstr "យក​ឧបករណ៍​ចេញ"
-
-#: ../panels/bluetooth/bluetooth.ui.h:3
-msgid "Connection"
-msgstr "ការ​តភ្ជាប់"
-
-#: ../panels/bluetooth/bluetooth.ui.h:4
-msgid "Paired"
-msgstr "បាន​ផ្គូ"
-
-#: ../panels/bluetooth/bluetooth.ui.h:5 ../panels/wacom/cc-wacom-page.c:756
-msgid "Type"
-msgstr "ប្រភេទ"
-
-#: ../panels/bluetooth/bluetooth.ui.h:6
-msgid "Address"
-msgstr "អាសយដ្ឋាន"
-
-#: ../panels/bluetooth/bluetooth.ui.h:7
-msgid "Mouse and Touchpad Settings"
-msgstr "ការ​កំណត់​កណ្ដុរ និង​បន្ទះ​ប៉ះ"
-
-#: ../panels/bluetooth/bluetooth.ui.h:8 ../panels/universal-access/uap.ui.h:38
-msgid "Sound Settings"
-msgstr "ការ​កំណត់​សំឡេង"
-
-#: ../panels/bluetooth/bluetooth.ui.h:9
-msgid "Keyboard Settings"
-msgstr "ការ​កំណត់​ក្ដារចុច"
-
-#: ../panels/bluetooth/bluetooth.ui.h:10
-msgid "Send Files..."
-msgstr "ផ្ញើ​ឯកសារ..."
-
-#: ../panels/bluetooth/bluetooth.ui.h:11
-msgid "Browse Files..."
-msgstr "រកមើល​ឯកសារ..."
-
-#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
-#: ../panels/bluetooth/bluetooth.ui.h:13
-msgctxt "Power"
-msgid "Bluetooth"
-msgstr "ប៊្លូធូស"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:290
-msgid "Yes"
-msgstr "បាទ/ចាស"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:290
-msgid "No"
-msgstr "ទេ"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:405
-msgid "Bluetooth is disabled"
-msgstr "ប៊្លូធូស​ត្រូវ​បាន​បិទ"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:410
-msgid "Bluetooth is disabled by hardware switch"
-msgstr "ប៊្លូធូស​ត្រូវ​បាន​បិទ​ដោយ​កុងតាក់​ផ្នែក​រឹង"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:414
-msgid "No Bluetooth adapters found"
-msgstr "រក​មិន​ឃើញ​អាដាប់ទ័រ​ប៊្លូធូស"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:547
-msgid "Visibility"
-msgstr "ភាព​អាច​មើល​ឃើ"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:551
-#, c-format
-msgid "Visibility of “%s”"
-msgstr "ភាព​អាច​មើល​ឃើញ​នៃ “%s”"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:595
-#, c-format
-msgid "Remove '%s' from the list of devices?"
-msgstr "យក '%s' ចេញ​ពី​បញ្ជី​ឧបករណ៍​ឬ ?"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:597
-msgid ""
-"If you remove the device, you will have to set it up again before next use."
-msgstr "ប្រសិនបើ​អ្នក​យក​ឧបករណ៍​ចេញ អ្នក​ត្រូវតែ​រៀបចំ​វា​ម្ដងទៀត មុន​នឹង​ប្រើ​នៅ​ពេលក្រោយ ។"
-
-#. TRANSLATORS: this is where the user can click and import a profile
-#: ../panels/color/cc-color-panel.c:106
-msgid "Other profile…"
-msgstr "ទម្រង់​ផ្សេងទៀត…"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:119
-msgid "Default: "
-msgstr "លំនាំដើម ៖ "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:126
-msgid "Colorspace: "
-msgstr "គំរូ​ពណ៌ ៖ "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:132
-msgid "Test profile: "
-msgstr "ទម្រង់​សាកល្បង ៖ "
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:185 ../panels/color/color.ui.h:11
-msgid "Set for all users"
-msgstr "កំណត់​សម្រាប់​អ្នកប្រើ​ទាំងអស់"
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:192
-msgid "Create virtual device"
-msgstr "បង្កើត​ឧបករណ៍​និម្មិត"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:227
-msgid "Select ICC Profile File"
-msgstr "ជ្រើស​ឯកសារ​ទម្រង់ ICC"
-
-#: ../panels/color/cc-color-panel.c:230
-msgid "_Import"
-msgstr "នាំចូល"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:241
-msgid "Supported ICC profiles"
-msgstr "គាំទ្រ​ទម្រង់ ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:248
-msgid "All files"
-msgstr "ឯកសារ​ទាំងអស់"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:522
-msgid "Available Profiles for Displays"
-msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ការ​បង្ហាញ"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:526
-msgid "Available Profiles for Scanners"
-msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ម៉ាស៊ីន​ស្កេន"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:530
-msgid "Available Profiles for Printers"
-msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ម៉ាស៊ីន​បោះពុម្ព"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:534
-msgid "Available Profiles for Cameras"
-msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ម៉ាស៊ីន​ថត"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:538
-msgid "Available Profiles for Webcams"
-msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​វិបខេម"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#. * where the device type is not recognised
-#. Profiles that can be added to the device
-#: ../panels/color/cc-color-panel.c:543 ../panels/color/color.ui.h:2
-msgid "Available Profiles"
-msgstr "ទម្រង់​ដែល​អាច​ប្រើ​បាន"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:824
-#: ../panels/sound/gvc-mixer-dialog.c:1525
-msgid "Device"
-msgstr "ឧបករណ៍"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:859
-msgid "Calibration"
-msgstr "ការ​ក្រិត​ខ្នាត"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:891
-msgid "Create a color profile for the selected device"
-msgstr "បង្កើត​ទម្រង់​ពណ៌​សម្រាប់​ឧបករណ៍​ដែល​បាន​ជ្រើស"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:905 ../panels/color/cc-color-panel.c:929
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "ឧបករណ៍​វាស់​មិន​ត្រូវ​បាន​រក​ឃើញ ។ សូម​ពិនិត្យមើល​ថា វា​ត្រូវ​បាន​បើក និង​ត្រូវ​បាន​តភ្ជាប់​ត្រឹមត្រូវ ។"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:938
-msgid "The measuring instrument does not support printer profiling."
-msgstr "ឧបករណ៍​វាស់​មិន​គាំទ្រ​ការ​រៀបចំ​ទម្រង់​ម៉ាស៊ីន​បោះពុម្ព​ទេ ។"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:949
-msgid "The device type is not currently supported."
-msgstr "ប្រភេទ​ឧបករណ៍​បច្ចុប្បន្ន​មិន​ត្រូវ​បាន​គាំទ្រ ។"
-
-#. TRANSLATORS: this is when an auto-added profile cannot be removed
-#: ../panels/color/cc-color-panel.c:1022
-msgid "Cannot remove automatically added profile"
-msgstr "មិន​អាច​យក​ទម្រង់​ដែល​បាន​បន្ថែម​ដោយ​ស្វ័យប្រវត្តិ​ចេញ​បាន​ទេ"
-
-#. TRANSLATORS: this is when there is no profile for the device
-#: ../panels/color/cc-color-panel.c:1359
-msgid "No profile"
-msgstr "គ្មាន​ទម្រង់"
-
-#: ../panels/color/cc-color-panel.c:1390
-#, c-format
-msgid "%i year"
-msgid_plural "%i years"
-msgstr[0] "%i ឆ្នាំ"
-
-#: ../panels/color/cc-color-panel.c:1401
-#, c-format
-msgid "%i month"
-msgid_plural "%i months"
-msgstr[0] "%i ខែ"
-
-#: ../panels/color/cc-color-panel.c:1412
-#, c-format
-msgid "%i week"
-msgid_plural "%i weeks"
-msgstr[0] "%i សប្ដាហ៍"
-
-#. fallback
-#: ../panels/color/cc-color-panel.c:1419
-#, c-format
-msgid "Less than 1 week"
-msgstr "តិច​ជាង ១ សប្ដាហ៍"
-
-#: ../panels/color/cc-color-panel.c:1481
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB លំនាំដើម"
-
-#: ../panels/color/cc-color-panel.c:1486
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK លំនាំដើម"
-
-#: ../panels/color/cc-color-panel.c:1491
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "ប្រផេះ​តាម​លំនាំដើម"
-
-#: ../panels/color/cc-color-panel.c:1609 ../panels/color/cc-color-panel.c:1650
-#: ../panels/color/cc-color-panel.c:1661 ../panels/color/cc-color-panel.c:1672
-msgid "Uncalibrated"
-msgstr "មិន​បាន​ក្រិត​ខ្នាត"
-
-#: ../panels/color/cc-color-panel.c:1612
-msgid "This device is not color managed."
-msgstr "ឧបករណ៍​នេះ​មិន​ត្រូវ​បាន​គ្រប់គ្រង​តាម​ពណ៌ ។"
-
-#: ../panels/color/cc-color-panel.c:1653
-msgid "This device is using manufacturing calibrated data."
-msgstr "ឧបករណ៍​នេះ​កំពុង​ប្រើ​ទិន្នន័យ​ដែល​បាន​ក្រិត​ខ្នាត​ពី​ក្រុមហ៊ុន​ផលិត ។"
-
-#: ../panels/color/cc-color-panel.c:1664
-msgid ""
-"This device does not have a profile suitable for whole-screen color "
-"correction."
-msgstr "ឧបករណ៍​នេះ​មិន​មាន​ទម្រង់​ដែល​សមស្រប​សម្រាប់​ការ​កែតម្រូវ​ពណ៌​អេក្រង់​ទាំងមូល​ទេ ។"
-
-#: ../panels/color/cc-color-panel.c:1697
-msgid "This device has an old profile that may no longer be accurate."
-msgstr "ឧបករណ៍​នេះ​មាន​ទម្រង់​ចាស់​ដែល​អាច​នឹង​លែង​មាន​សុក្រឹតភាព​ទៀត ។"
-
-#. TRANSLATORS: this is when the calibration profile age is not
-#. * specified as it has been autogenerated from the hardware
-#: ../panels/color/cc-color-panel.c:1725
-msgid "Not specified"
-msgstr "មិន​ត្រូវ​បាន​បញ្ជាក់"
-
-#. add the 'No devices detected' entry
-#: ../panels/color/cc-color-panel.c:1910
-msgid "No devices supporting color management detected"
-msgstr "រក​មិន​ឃើញ​ឧបករណ៍​ដែល​គាំទ្រ​ការ​គ្រប់គ្រង​ពណ៌​ទេ"
-
-#: ../panels/color/cc-color-panel.c:2139
-msgctxt "Device kind"
-msgid "Display"
-msgstr "ការ​បង្ហាញ"
-
-#: ../panels/color/cc-color-panel.c:2141
-msgctxt "Device kind"
-msgid "Scanner"
-msgstr "ម៉ាស៊ីន​ស្កេន"
-
-#: ../panels/color/cc-color-panel.c:2143
-msgctxt "Device kind"
-msgid "Printer"
-msgstr "ម៉ាស៊ីន​បោះពុម្ព"
-
-#: ../panels/color/cc-color-panel.c:2145
-msgctxt "Device kind"
-msgid "Camera"
-msgstr "ម៉ាស៊ីន​ថត"
-
-#: ../panels/color/cc-color-panel.c:2147
-msgctxt "Device kind"
-msgid "Webcam"
-msgstr "វិបខេម"
-
-#: ../panels/color/color.ui.h:3
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
-msgid "Color"
-msgstr "ពណ៌"
-
-#: ../panels/color/color.ui.h:4
-msgid "Each device needs an up to date color profile to be color managed."
-msgstr "ឧបករណ៍​នីមួយ​ៗ​ទាមទារ​ឲ្យ​គ្រប់គ្រង​ទម្រង់​ពណ៌​ដែល​ទាន់​សម័យ​តាម​ពណ៌ ។"
-
-#: ../panels/color/color.ui.h:5
-msgid "Learn more"
-msgstr "ស្វែងយល់​បន្ថែម"
-
-#: ../panels/color/color.ui.h:6
-msgid "Learn more about color management"
-msgstr "ស្វែងយល់​បន្ថែម​អំពី​ការ​គ្រប់គ្រង​ពណ៌"
-
-#: ../panels/color/color.ui.h:7
-msgid "Add device"
-msgstr "បន្ថែម​ឧបករណ៍"
-
-#: ../panels/color/color.ui.h:8
-msgid "Add a virtual device"
-msgstr "បន្ថែម​ឧបករណ៍​និម្មិត"
-
-#: ../panels/color/color.ui.h:9
-msgid "Delete device"
-msgstr "លុប​ឧបករណ៍"
-
-#: ../panels/color/color.ui.h:10
-msgid "Remove a device"
-msgstr "យក​ឧបករណ៍​ចេញ"
-
-#: ../panels/color/color.ui.h:12
-#| msgid "Set this device for all users on this computer"
-msgid "Set this profile for all users on this computer"
-msgstr "កំណត់​ប្រវត្តិ​សម្រាប់​អ្នក​ប្រើ​ទាំងអស់​នៅ​ក្នុង​កុំព្យូទ័រ​នេះ"
-
-#: ../panels/color/color.ui.h:13
-msgid "Add profile"
-msgstr "បន្ថែម​ទម្រង់"
-
-#: ../panels/color/color.ui.h:14
-msgid "Calibrate…"
-msgstr "ក្រិត​ខ្នាត…"
-
-#: ../panels/color/color.ui.h:15
-msgid "Calibrate the device"
-msgstr "ក្រិត​ខ្នាត​ឧបករណ៍"
-
-#: ../panels/color/color.ui.h:16
-msgid "Remove profile"
-msgstr "យក​ទម្រង់​ចេញ"
-
-#: ../panels/color/color.ui.h:17
-msgid "View details"
-msgstr "មើល​សេចក្ដី​លម្អិត"
-
-#: ../panels/color/color.ui.h:18
-msgid "Device type:"
-msgstr "ប្រភេទ​ឧបករណ៍ ៖"
-
-#: ../panels/color/color.ui.h:19
-msgid "Manufacturer:"
-msgstr "ក្រុមហ៊ុនផលិត ៖"
-
-#: ../panels/color/color.ui.h:20
-msgid "Model:"
-msgstr "ម៉ូដែល ៖"
-
-#: ../panels/color/color.ui.h:21
-msgid ""
-"Image files can be dragged on this window to auto-complete the above fields."
-msgstr "ឯកសារ​រូបភាព​អាច​ត្រូវ​បាន​អូស​នៅ​លើ​បង្អួច​នេះ ដើម្បី​បំពេញ​វាល​ខាងលើ​ដោយ​ស្វ័យប្រវត្តិ ។"
-
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Color management settings"
-msgstr "ការ​កំណត់​ការ​គ្រប់គ្រង​ពណ៌"
-
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
-msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
-msgstr "Color;ICC;Profile;Calibrate;Printer;Display;"
-
-#. Add some common languages first
-#: ../panels/common/cc-common-language.c:523
-msgid "English"
-msgstr "អង់គ្លេស"
-
-#: ../panels/common/cc-common-language.c:525
-msgid "British English"
-msgstr "ចក្រភព​អង់គ្លេស"
-
-#: ../panels/common/cc-common-language.c:528
-#| msgid "Germany"
-msgid "German"
-msgstr "អាល្លឺម៉ង់"
-
-#: ../panels/common/cc-common-language.c:531
-msgid "French"
-msgstr "បារាំង"
-
-#: ../panels/common/cc-common-language.c:534
-#| msgid "Span"
-msgid "Spanish"
-msgstr "អេស្ប៉ាញ"
-
-#: ../panels/common/cc-common-language.c:536
-msgid "Chinese (simplified)"
-msgstr "ចិន (អក្សរ​កាត់)"
-
-#: ../panels/common/cc-common-language.c:539
-msgid "Russian"
-msgstr "រុស្ស៊ី"
-
-#: ../panels/common/cc-common-language.c:542
-msgid "Arabic"
-msgstr "អារ៉ាប់"
-
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:571
-msgid "United States"
-msgstr "សហរដ្ឋ​អាមេរិក"
-
-#: ../panels/common/cc-common-language.c:572
-msgid "Germany"
-msgstr "អាល្លឺម៉ង់"
-
-#: ../panels/common/cc-common-language.c:573
-msgid "France"
-msgstr "បារាំង"
-
-#: ../panels/common/cc-common-language.c:574
-msgid "Spain"
-msgstr "អេស្ប៉ាញ"
-
-#: ../panels/common/cc-common-language.c:575
-msgid "China"
-msgstr "ចិន"
-
-#: ../panels/common/cc-language-chooser.c:122
-#| msgctxt "Wireless access point"
-#| msgid "Other..."
-msgid "Other..."
-msgstr "ផ្សេងទៀត..."
-
-#: ../panels/common/cc-language-chooser.c:296
-msgid "Select a region"
-msgstr "ជ្រើស​តំបន់"
-
-#: ../panels/common/gdm-languages.c:781
-msgid "Unspecified"
-msgstr "មិន​បាន​បញ្ជាក់"
-
-#: ../panels/common/language-chooser.ui.h:1
-msgid "Select a language"
-msgstr "ជ្រើស​ភាសា"
-
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/printers/new-printer-dialog.ui.h:1
-#: ../panels/user-accounts/um-user-panel.c:462
-msgid "_Cancel"
-msgstr "បោះបង់"
-
-#: ../panels/common/language-chooser.ui.h:3
-msgid "_Select"
-msgstr "ជ្រើស"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "_Region:"
-msgstr "តំបន់ ៖"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "_City:"
-msgstr "ទីក្រុង ៖"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "_Network Time"
-msgstr "ពេលវេលា​តាម​បណ្ដាញ"
-
-#. Translator: this is the separator between hours and minutes, like in HH:MM
-#: ../panels/datetime/datetime.ui.h:5
-msgid ":"
-msgstr ":"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "Set the time one hour ahead."
-msgstr "កំណត់​ពេលវេលា​ទៅ​មុខ​មួយ​ម៉ោង ។"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "Set the time one hour back."
-msgstr "កំណត់​ពេលវេលា​ថយ​ក្រោយ​មួយ​ម៉ោង ។"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "Set the time one minute ahead."
-msgstr "កំណត់​ពេលវេលា​ទៅ​មុខ​មួយ​នាទី ។"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "Set the time one minute back."
-msgstr "កំណត់​ពេលវេលា​ថយក្រោយ​មួយ​នាទី ។"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "Switch between AM and PM."
-msgstr "ប្ដូរ​ឆ្លាស់​រវាង​ ព្រឹក និង​ល្ងាច ។"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "Month"
-msgstr "ខែ"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "Day"
-msgstr "ថ្ងៃ"
-
-#: ../panels/datetime/datetime.ui.h:13
-msgid "Year"
-msgstr "ឆ្នាំ"
-
-#: ../panels/datetime/datetime.ui.h:14
-msgid "24-hour"
-msgstr "២៤ ម៉ោង"
-
-#: ../panels/datetime/datetime.ui.h:15
-msgid "AM/PM"
-msgstr "ព្រឹក/ល្ងាច"
-
-#: ../panels/datetime/datetime.ui.h:16
-msgid "January"
-msgstr "មករា"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "February"
-msgstr "កុម្ភៈ"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "March"
-msgstr "មីនា"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "April"
-msgstr "មេសា"
-
-#: ../panels/datetime/datetime.ui.h:20
-msgid "May"
-msgstr "ឧសភា"
-
-#: ../panels/datetime/datetime.ui.h:21
-msgid "June"
-msgstr "មិថុនា"
-
-#: ../panels/datetime/datetime.ui.h:22
-msgid "July"
-msgstr "កក្កដា"
-
-#: ../panels/datetime/datetime.ui.h:23
-msgid "August"
-msgstr "សីហា"
-
-#: ../panels/datetime/datetime.ui.h:24
-msgid "September"
-msgstr "កញ្ញា"
-
-#: ../panels/datetime/datetime.ui.h:25
-msgid "October"
-msgstr "តុលា"
-
-#: ../panels/datetime/datetime.ui.h:26
-msgid "November"
-msgstr "វិច្ឆិកា"
-
-#: ../panels/datetime/datetime.ui.h:27
-msgid "December"
-msgstr "ធ្នូ"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
-#| msgid "Date and Time"
-msgid "Date & Time"
-msgstr "កាលបរិច្ឆេទ និង​ពេលវេលា"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Date and Time preferences panel"
-msgstr "ផ្ទាំង​ចំណូលចិត្ត​កាលបរិច្ឆេទ និង​ពេលវេលា"
-
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
-msgid "Clock;Timezone;Location;"
-msgstr "Clock;Timezone;Location;"
-
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
-#| msgid "Change your region and language settings"
-msgid "Change system time and date settings"
-msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​ពេលវេលា និង​កាលបរិច្ឆេទ​​ប្រព័ន្ធ"
-
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
-msgid "To change time or date settings, you need to authenticate."
-msgstr ""
-"ដើម្បី​ផ្លាស់ប្ដូរ​កា​រកំណត់​ពេលវាលា ឬ​កាលបរិច្ឆេទ "
-"អ្នក​ត្រូវ​តែ​ផ្ទៀតផ្ទាត់​ ។"
-
-#: ../panels/display/cc-display-panel.c:481
-msgctxt "display panel, rotation"
-msgid "Normal"
-msgstr "ធម្មតា"
-
-#: ../panels/display/cc-display-panel.c:482
-msgctxt "display panel, rotation"
-msgid "Counterclockwise"
-msgstr "ច្រាស​ទ្រនិច​នាឡិកា"
-
-#: ../panels/display/cc-display-panel.c:483
-msgctxt "display panel, rotation"
-msgid "Clockwise"
-msgstr "ស្រប​ទ្រនិច​នាឡិកា"
-
-#: ../panels/display/cc-display-panel.c:484
-msgctxt "display panel, rotation"
-msgid "180 Degrees"
-msgstr "១៨០ ដឺក្រេ"
-
-#. Keep this string in sync with gnome-desktop/libgnome-desktop/gnome-rr-labeler.c
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external projector.  Here, "Mirrored" is being
-#. * used as an adjective.  For example, the Spanish translation could be
-#. * "Pantallas en Espejo".
-#.
-#: ../panels/display/cc-display-panel.c:623
-#| msgid "Mirror Displays"
-msgid "Mirrored Displays"
-msgstr "ទិដ្ឋភាព​ឆ្លុះ"
-
-#: ../panels/display/cc-display-panel.c:647
-#: ../panels/display/display-capplet.ui.h:1
-msgid "Monitor"
-msgstr "ម៉ូនីទ័រ"
-
-#: ../panels/display/cc-display-panel.c:748
-#, c-format
-msgid "%d x %d (%s)"
-msgstr "%d x %d (%s)"
-
-#: ../panels/display/cc-display-panel.c:750
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#: ../panels/display/cc-display-panel.c:1659
-msgid "Drag to change primary display."
-msgstr "អូស ដើម្បី​ផ្លាស់ប្ដូរ​ទិដ្ឋភាព​ចម្បង ។"
-
-#: ../panels/display/cc-display-panel.c:1717
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr "ជ្រើស​ម៉ូនីទ័រ ដើម្បី​ផ្លាស់ប្ដូរ​លក្ខណសម្បត្តិ​របស់​វា អូស​វា ដើម្បី​រៀបចំ​ទីតាំង​របស់​វា​ជា​ថ្មី ។"
-
-#: ../panels/display/cc-display-panel.c:2105
-msgid "%a %R"
-msgstr "%a %R"
-
-#: ../panels/display/cc-display-panel.c:2107
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
-
-#: ../panels/display/cc-display-panel.c:2269
-#: ../panels/display/cc-display-panel.c:2321
-#, c-format
-msgid "Failed to apply configuration: %s"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​អនុវត្ត​ការ​កំណត់​រចនាសម្ព័ន្ធ ៖ %s"
-
-#: ../panels/display/cc-display-panel.c:2349
-msgid "Could not save the monitor configuration"
-msgstr "មិន​អាច​រក្សាទុក​ការ​កំណត់​រចនាសម្ព័ន្ធ​ម៉ូនីទ័រ​បាន​ឡើយ"
-
-#: ../panels/display/cc-display-panel.c:2409
-msgid "Could not detect displays"
-msgstr "រក​មិន​ឃើញ​ទិដ្ឋភាព"
-
-#: ../panels/display/cc-display-panel.c:2603
-msgid "Could not get screen information"
-msgstr "មិន​អាច​ទទួល​បាន​ព័ត៌មាន​អេក្រង់"
-
-#: ../panels/display/display-capplet.ui.h:2
-msgid "_Resolution"
-msgstr "គុណភាព​បង្ហាញ"
-
-#: ../panels/display/display-capplet.ui.h:3
-msgid "R_otation"
-msgstr "ការ​បង្វិល"
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:5
-msgid "_Mirror displays"
-msgstr "បង្ហាញ​ទិដ្ឋភាព"
-
-#: ../panels/display/display-capplet.ui.h:6
-msgid "Note: may limit resolution options"
-msgstr "ចំណាំ ៖ អាច​នឹង​កំណត់​ជម្រើស​គុណភាព​បង្ហាញ"
-
-#: ../panels/display/display-capplet.ui.h:7
-msgid "_Detect Displays"
-msgstr "រក​ឃើញ​ទិដ្ឋភាព"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "ទិដ្ឋភាព"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Change resolution and position of monitors and projectors"
-msgstr "ផ្លាស់ប្ដូរ​គុណភាព​បង្ហាញ និង​ទីតាំង​របស់​ម៉ូនីទ័រ និង​ឧបករណ៍​បញ្ចាំង​ស្លាយ"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-
-#. Translators: VESA is an techncial acronym, don't translate it.
-#: ../panels/info/cc-info-panel.c:413
-#, c-format
-msgid "VESA: %s"
-msgstr "VESA ៖ %s"
-
-#. TRANSLATORS: device type
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:437 ../panels/network/panel-common.c:82
-#: ../panels/network/panel-common.c:162
-msgid "Unknown"
-msgstr "មិន​ស្គាល់"
-
-#. translators: This is the type of architecture, for example:
-#. * "64-bit" or "32-bit"
-#: ../panels/info/cc-info-panel.c:593
-#, c-format
-msgid "%d-bit"
-msgstr "%d ប៊ីត"
-
-#: ../panels/info/cc-info-panel.c:752
-msgid "Unknown model"
-msgstr "មិន​ស្គាល់​ម៉ូដែល"
-
-#: ../panels/info/cc-info-panel.c:835
-msgid "The next login will attempt to use the standard experience."
-msgstr "ការ​ចូល​បន្ទាប់​នឹង​ប៉ុនប៉ង​ប្រើ​កម្រិត​ស្ដង់ដារ ។"
-
-#: ../panels/info/cc-info-panel.c:837
-msgid ""
-"The next login will use the fallback mode intended for unsupported graphics "
-"hardware."
-msgstr "ការ​ចូល​បន្ទាប់​នឹង​ប្រើ​របៀប fallback ដែល​បម្រុងទុក​សម្រាប់​ផ្នែក​រឹង​ក្រាហ្វិក​ដែល​មិន​គាំទ្រ ។"
-
-#. translators: The hardware is not able to run GNOME 3's
-#. * shell, so we use the GNOME "Fallback" session
-#: ../panels/info/cc-info-panel.c:879
-msgctxt "Experience"
-msgid "Fallback"
-msgstr "Fallback"
-
-#. translators: The hardware is able to run GNOME 3's
-#. * shell, also called "Standard" experience
-#: ../panels/info/cc-info-panel.c:885
-msgctxt "Experience"
-msgid "Standard"
-msgstr "ស្ដង់ដារ"
-
-#: ../panels/info/cc-info-panel.c:1227
-msgid "Ask what to do"
-msgstr "សួរ​អ្វី​ដែល​ត្រូវ​ធ្វើ"
-
-#: ../panels/info/cc-info-panel.c:1231
-msgid "Do nothing"
-msgstr "មិន​ធ្វើ​អ្វី​ទាំងអស់"
-
-#: ../panels/info/cc-info-panel.c:1235
-msgid "Open folder"
-msgstr "បើក​ថត"
-
-#: ../panels/info/cc-info-panel.c:1326
-#| msgid "_Other Media..."
-msgid "Other Media"
-msgstr "មេឌៀ​ផ្សេងទៀត..."
-
-#: ../panels/info/cc-info-panel.c:1357
-msgid "Select an application for audio CDs"
-msgstr "ជ្រើស​កម្មវិធី​សម្រាប់​ស៊ីឌី​អូឌីយ៉ូ"
-
-#: ../panels/info/cc-info-panel.c:1358
-msgid "Select an application for video DVDs"
-msgstr "ជ្រើស​កម្មវិធី​សម្រាប់​ឌីវីឌី​វីដេអូ"
-
-#: ../panels/info/cc-info-panel.c:1359
-msgid "Select an application to run when a music player is connected"
-msgstr "ជ្រើស​កម្មវិធី​ដែល​ត្រូវ​ដំណើរការ នៅ​ពេល​កម្មវិធី​ចាក់​តន្ត្រី​ត្រូវ​បាន​តភ្ជាប់"
-
-#: ../panels/info/cc-info-panel.c:1360
-msgid "Select an application to run when a camera is connected"
-msgstr "ជ្រើស​កម្មវិធី​ដែល​ត្រូវ​ដំណើរការ នៅ​ពេល​ម៉ាស៊ីន​ថត​ត្រូវ​បាន​តភ្ជាប់"
-
-#: ../panels/info/cc-info-panel.c:1361
-msgid "Select an application for software CDs"
-msgstr "ជ្រើស​កម្មវិធី​សម្រាប់​ស៊ីឌី​កម្មវិធី"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1373
-msgid "audio DVD"
-msgstr "ឌីវីឌី​អូឌីយ៉ូ"
-
-#: ../panels/info/cc-info-panel.c:1374
-msgid "blank Blu-ray disc"
-msgstr "ថាស​ប៊្លូរ៉េយ៍​ទទេ"
-
-#: ../panels/info/cc-info-panel.c:1375
-msgid "blank CD disc"
-msgstr "ថាស​ស៊ីឌី​ទទេ"
-
-#: ../panels/info/cc-info-panel.c:1376
-msgid "blank DVD disc"
-msgstr "ថាស​ឌីវីឌី​ទទេ"
-
-#: ../panels/info/cc-info-panel.c:1377
-msgid "blank HD DVD disc"
-msgstr "ថាស​ឌីវីឌី HD ទទេ"
-
-#: ../panels/info/cc-info-panel.c:1378
-msgid "Blu-ray video disc"
-msgstr "ថាស​វីដេអូ​ប៊្លូរ៉េយ៍"
-
-#: ../panels/info/cc-info-panel.c:1379
-msgid "e-book reader"
-msgstr "កម្មវិធី​អាន​សៀវភៅ​អេឡិចត្រូនិក"
-
-#: ../panels/info/cc-info-panel.c:1380
-msgid "HD DVD video disc"
-msgstr "ថាស​វីដេអូ​ឌីវីឌី HD"
-
-#: ../panels/info/cc-info-panel.c:1381
-msgid "Picture CD"
-msgstr "ស៊ីឌី​រូបភាព"
-
-#: ../panels/info/cc-info-panel.c:1382
-msgid "Super Video CD"
-msgstr "ស៊ីឌី​វីដេអូ​កម្រិតខ្ពស់"
-
-#: ../panels/info/cc-info-panel.c:1383
-msgid "Video CD"
-msgstr "ស៊ីឌី​វីដេអូ"
-
-#: ../panels/info/cc-info-panel.c:1384
-msgid "Windows software"
-msgstr "កម្មវិធី​សម្រាប់​វីនដូ"
-
-#: ../panels/info/cc-info-panel.c:1385
-#| msgid "_Software"
-msgid "Software"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
 msgstr "កម្មវិធី"
 
-#: ../panels/info/cc-info-panel.c:1508
-#: ../panels/keyboard/keyboard-shortcuts.c:1647
-msgid "Section"
-msgstr "ភាគ"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "កម្មវិធី"
 
-#: ../panels/info/cc-info-panel.c:1517 ../panels/info/info.ui.h:11
-msgid "Overview"
-msgstr "ទិដ្ឋភាព​ទូទៅ"
-
-#: ../panels/info/cc-info-panel.c:1523 ../panels/info/info.ui.h:18
-msgid "Default Applications"
-msgstr "កម្មវិធី​លំនាំដើម"
-
-#: ../panels/info/cc-info-panel.c:1528 ../panels/info/info.ui.h:26
-msgid "Removable Media"
-msgstr "មេឌៀ​ចល័ត"
-
-#: ../panels/info/cc-info-panel.c:1533 ../panels/info/info.ui.h:10
-msgid "Graphics"
-msgstr "ក្រាហ្វិក"
-
-#: ../panels/info/cc-info-panel.c:1735
-#, c-format
-msgid "Version %s"
-msgstr "កំណែ %s"
-
-#: ../panels/info/cc-info-panel.c:1785
-msgid "Install Updates"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
 msgstr "ដំឡើង​បច្ចុប្បន្នភាព"
 
-#: ../panels/info/cc-info-panel.c:1789
-msgid "System Up-To-Date"
-msgstr "ប្រព័ន្ធ​ទាន់សម័យ"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "បើក​គម្រប"
 
-#: ../panels/info/cc-info-panel.c:1793
-msgid "Checking for Updates"
-msgstr "រកមើល​បច្ចុប្បន្នភាព"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "មើល​សេចក្ដី​លម្អិត"
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-msgid "Details"
-msgstr "សេចក្ដី​លម្អិត"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "System Information"
-msgstr "ព័ត៌មាន​ប្រព័ន្ធ"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"device;system;information;memory;processor;version;default;application;"
-"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "ជ្រើស​របៀប​គ្រប់គ្រង​មេឌៀ​ផ្សេងទៀត"
-
-#: ../panels/info/info.ui.h:2
-#| msgid "_Action"
-msgid "_Action:"
-msgstr "សកម្មភាព ៖"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "ប្រភេទ ៖"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "ឈ្មោះ​ឧបករណ៍"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "អង្គ​ចងចាំ"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "កម្មវិធី​ដំណើរការ"
-
-#: ../panels/info/info.ui.h:7
-msgid "OS type"
-msgstr "ប្រភេទ​ប្រព័ន្ធ​ដំណើរការ"
-
-#: ../panels/info/info.ui.h:8
-msgid "Disk"
-msgstr "ថាស"
-
-#: ../panels/info/info.ui.h:9
-msgid "Calculating..."
-msgstr "កំពុង​គណនា..."
-
-#: ../panels/info/info.ui.h:12
-msgid "_Web"
-msgstr "បណ្ដាញ"
-
-#: ../panels/info/info.ui.h:13
-msgid "_Mail"
-msgstr "សំបុត្រ"
-
-#: ../panels/info/info.ui.h:14
-msgid "_Calendar"
-msgstr "ប្រតិទិន"
-
-#: ../panels/info/info.ui.h:15
-msgid "M_usic"
-msgstr "តន្ត្រី"
-
-#: ../panels/info/info.ui.h:16
-msgid "_Video"
-msgstr "វីដេអូ"
-
-#: ../panels/info/info.ui.h:17
-msgid "_Photos"
-msgstr "រូបថត"
-
-#: ../panels/info/info.ui.h:19
-msgid "Select how media should be handled"
-msgstr "ជ្រើស​របៀប​គ្រប់គ្រង​មេឌៀ"
-
-#: ../panels/info/info.ui.h:20
-msgid "CD _audio"
-msgstr "អូឌីយ៉ូ​ស៊ីឌី"
-
-#: ../panels/info/info.ui.h:21
-msgid "_DVD video"
-msgstr "វីដេអូ​ឌីវីឌី"
-
-#: ../panels/info/info.ui.h:22
-msgid "_Music player"
-msgstr "កម្មវិធី​ចាក់​​តន្ត្រី"
-
-#: ../panels/info/info.ui.h:23
-msgid "_Software"
-msgstr "កម្មវិធី"
-
-#: ../panels/info/info.ui.h:24
-msgid "_Other Media..."
-msgstr "មេឌៀ​ផ្សេងទៀត..."
-
-#: ../panels/info/info.ui.h:25
-msgid "_Never prompt or start programs on media insertion"
-msgstr "កុំ​សួរ ឬ​ចាប់ផ្ដើម​កម្មវិធី នៅ​ពេល​បញ្ចូល​មេឌៀ"
-
-#: ../panels/info/info.ui.h:27
-msgid "Driver"
-msgstr "កម្មវិធី​បញ្ជា"
-
-#: ../panels/info/info.ui.h:28
-msgid "Experience"
-msgstr "ជាន់ខ្ពស់"
-
-#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
-#: ../panels/info/info.ui.h:30
-msgid "Forced _Fallback Mode"
-msgstr "របៀប Forced _Fallback"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
-msgid "Sound and Media"
-msgstr "សំឡេង និង​មេឌៀ"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
-msgstr "ស្ងាត់"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
-msgid "Volume down"
-msgstr "បន្ថយ​កម្រិត​សំឡេង"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
-msgid "Volume up"
-msgstr "បង្កើន​កម្រិត​សំឡេង"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
-msgid "Launch media player"
-msgstr "បើក​ដំណើរការ​កម្មវិធី​ចាក់​មេឌៀ"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
-msgid "Play (or play/pause)"
-msgstr "ចាក់ (ឬ​ចាក់/ផ្អាក)"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
-msgid "Pause playback"
-msgstr "ផ្អាក​ការ​ចាក់​សារ​ថ្មី"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
-msgid "Stop playback"
-msgstr "បញ្ឈប់​ការ​ចាក់​សារ​ថ្មី"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
-msgid "Previous track"
-msgstr "បទ​មុន"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
-msgid "Next track"
-msgstr "បទ​បន្ទាប់"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
-msgid "Eject"
-msgstr "ច្រានចេញ"
-
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/keyboard/keyboard-shortcuts.c:858
-#: ../panels/universal-access/uap.ui.h:68
-msgid "Typing"
-msgstr "វាយ"
-
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
-#: ../panels/region/gnome-region-panel.ui.h:26
-#| msgid "Switch Modes"
-msgid "Switch to next source"
-msgstr "ប្ដូរ​ទៅ​ប្រភព​បន្ទាប់"
-
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
-#: ../panels/region/gnome-region-panel.ui.h:24
-msgid "Switch to previous source"
-msgstr "ប្ដូរ​ទៅ​ប្រភព​មុន"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:1
-msgid "Launchers"
-msgstr "កម្មវិធី​បើក​ដំណើរការ"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:2
-msgid "Launch help browser"
-msgstr "បើក​ដំណើរការ​កម្មវិធី​រុករក​បណ្ដាញ"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:3
-msgid "Launch calculator"
-msgstr "បើក​ដំណើរការ​ម៉ាស៊ីន​គណនា"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:4
-msgid "Launch email client"
-msgstr "បើក​ដំណើរការ​កម្មវិធី​អ៊ីមែល"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:5
-msgid "Launch web browser"
-msgstr "បើក​ដំណើរការ​កម្មវិធី​រុករក​បណ្ដាញ"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:6
-msgid "Home folder"
-msgstr "ថត​ផ្ទះ"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "ស្វែងរក"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "រូបថត​អេក្រង់"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
 
-#. translators: Pictures is the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-#| msgid "Take a screenshot of an area"
-msgid "Save a screenshot to Pictures"
-msgstr "ថត​រូប​អេក្រង់​​ជា​រូបភាព"
-
-#. translators: Pictures is the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-#| msgid "Take a screenshot of a window"
-msgid "Save a screenshot of a window to Pictures"
-msgstr "រក្សាទុក​រូបថត​​អេក្រង់​របស់​វីនដូ​ជា​រូបភាព"
-
-#. translators: Pictures is the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-#| msgid "Take a screenshot of an area"
-msgid "Save a screenshot of an area to Pictures"
-msgstr "រក្សាទុក​រូបថត​អេក្រង់​នៃ​ផ្ទៃ​ជា​រូបភាព"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "ចម្លង​រូបថត​អេក្រង់​ទៅកាន់​ក្ដារ​តម្បៀត​ខ្ទាស់"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "ចម្លង​រូបថត​អេក្រង់​បង្អួច​ទៅកាន់​ក្ដារ​តម្បៀត​ខ្ទាស់"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "ចម្លង​រូបថត​អេក្រង់​នៃ​ផ្ទៃ​ទៅកាន់​ក្ដារ​តម្បៀត​ខ្ទាស់"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
-#: ../panels/region/gnome-region-panel.ui.h:39
-msgid "System"
-msgstr "ប្រព័ន្ធ"
-
-#: ../panels/keyboard/01-system.xml.in.h:2
-msgid "Log out"
-msgstr "ចេញ"
-
-#: ../panels/keyboard/01-system.xml.in.h:3
-msgid "Lock screen"
-msgstr "ចាក់​សោ​អេក្រង់"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "ចូល​ដំណើរការ​សកល"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
-msgid "Turn zoom on or off"
-msgstr "បើក ឬ​បិទ​ការ​ពង្រីក"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
-msgid "Zoom in"
-msgstr "ពង្រីក"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
-msgid "Zoom out"
-msgstr "បង្រួម"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
-msgid "Turn screen reader on or off"
-msgstr "បើក ឬ​បិទ​កម្មវិធី​អាន​អេក្រង់"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
-msgid "Turn on-screen keyboard on or off"
-msgstr "បើក ឬ​បិទ​ក្ដារចុច​នៅ​លើ​អេក្រង់"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
-msgid "Increase text size"
-msgstr "បង្កើន​ទំហំ​អត្ថបទ"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
-msgid "Decrease text size"
-msgstr "បន្ថយ​ទំហំ​អត្ថបទ"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
-msgid "High contrast on or off"
-msgstr "បើក ឬ​បិទ​កម្រិត​ពណ៌​ខ្ពស់"
-
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:241
-#: ../panels/keyboard/cc-keyboard-option.c:347
-#: ../panels/keyboard/keyboard-shortcuts.c:1112
-#: ../panels/sound/gvc-mixer-control.c:1834
-#: ../panels/user-accounts/um-fingerprint-dialog.c:215
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "បាន​បិទ"
 
-#: ../panels/keyboard/cc-keyboard-option.c:315
-msgid "Alternative Characters Key"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "ការ​ពង្រីក ៖"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "ព័ត៌មាន​ប្រព័ន្ធ"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "ផ្ទៃ​ខាង​ក្រោយ"
+
+#: panels/applications/cc-applications-panel.ui:134
+#, fuzzy
+msgid "Allow activity when the app is closed."
+msgstr "នៅ​ពេល​គម្រប​ត្រូវ​បាន​បិទ"
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "រូបថត​អេក្រង់"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "ផ្ទាំង​រូបភាព"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "សំឡេង"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "ផ្លូវកាត់"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "ម៉ាស៊ីន​ថត"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "កម្រិត​សំឡេង​មីក្រូហ្វូន"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "ទីតាំង"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "សាកល្បង​សំឡេង"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "ប្រភេទ​ឧបករណ៍"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "ល្បឿនតំណ"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "កម្មវិធី"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>ស្បែក</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "ដែកចារ"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "លំនាំដើម"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "ផ្ទៃ​ខាង​ក្រោយ"
+
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "រូបរាង"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "បាន​បើក"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
+msgstr "រក​មិន​ឃើញ​អាដាប់ទ័រ​ប៊្លូធូស"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "ប៊្លូធូស"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "នៅ​ពេល​ជិះ​យន្ដហោះ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "ប៊្លូធូស​ត្រូវ​បាន​បិទ​ដោយ​កុងតាក់​ផ្នែក​រឹង"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "នៅ​ពេល​ជិះ​យន្ដហោះ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "នៅ​ពេល​ជិះ​យន្ដហោះ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr "ប៊្លូធូស"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "បច្ចុប្បន្ន​គ្មាន​កម្មវិធី​ដែល​កំពុង​ចាក់ ឬ​ថត​ចម្លង​អូឌីយ៉ូ​ទេ ។"
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "រកមើល​រូបភាព​ផ្សេងទៀត"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+#, fuzzy
+msgid "Display Calibration"
+msgstr "ការ​ក្រិត​ខ្នាត"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "បោះបង់"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "ធ្វើ​រួច !"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "ការ​ក្រិត​ខ្នាត​អេក្រង់"
+
+#: panels/color/cc-color-panel.ui:12
+#, fuzzy
+msgid "Calibration Quality"
+msgstr "ការ​ក្រិត​ខ្នាត"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+#, fuzzy
+msgid "Quality"
+msgstr "គុណភាព​រូបភាព"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+#, fuzzy
+msgid "Calibration Device"
+msgstr "ការ​ក្រិត​ខ្នាត"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "ការ​បង្ហាញ"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "ពន្លឺ"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "ទម្រង់ ៖"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "ទម្រង់ ៖"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "សង្ខេប"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "គ្មាន​ទម្រង់"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "បន្ថែម​ទម្រង់"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "នាំចូល"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "បន្ថែម"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "ឧបករណ៍​នីមួយ​ៗ​ទាមទារ​ឲ្យ​គ្រប់គ្រង​ទម្រង់​ពណ៌​ដែល​ទាន់​សម័យ​តាម​ពណ៌ ។"
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr "ស្វែងយល់​បន្ថែម"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "ស្វែងយល់​បន្ថែម​អំពី​ការ​គ្រប់គ្រង​ពណ៌"
+
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
+msgstr "កំណត់​សម្រាប់​អ្នកប្រើ​ទាំងអស់"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "កំណត់​ប្រវត្តិ​សម្រាប់​អ្នក​ប្រើ​ទាំងអស់​នៅ​ក្នុង​កុំព្យូទ័រ​នេះ"
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "បាន​បើក"
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "បន្ថែម​ទម្រង់"
+
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
+msgstr "ក្រិត​ខ្នាត…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "ក្រិត​ខ្នាត​ឧបករណ៍"
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "យក​ទម្រង់​ចេញ"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "មើល​សេចក្ដី​លម្អិត"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+#, fuzzy
+msgid "Projector"
+msgstr "បន្ទាត់​តភ្ជាប់ ៖"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "ខ្ពស់"
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "១០ នាទី"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "៣០ នាទី"
+
+#: panels/color/cc-color-panel.ui:640
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "ទាប"
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "៥ នាទី"
+
+#: panels/color/cc-color-panel.ui:663
+#, fuzzy
+msgid "Native to display"
+msgstr "បន្ទះ​ត្រូវ​បង្ហាញ"
+
+#: panels/color/cc-color-panel.ui:667
+#, fuzzy
+msgid "D50 (Printing and publishing)"
+msgstr "ចង្អុល និង​ចុច"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+#, fuzzy
+msgid "D75"
+msgstr "៧៥%"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "ពណ៌"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Profile;Calibrate;Printer;Display;"
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "ជ្រើស​ភាសា"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "ជ្រើស"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "រក​មិន​ឃើញ​អាដាប់ទ័រ​ប៊្លូធូស"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "បង្កើន​ទំហំ ៖"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "ពេលវេលា"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "បន្ថយ​ទំហំ ៖"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "កាលបរិច្ឆេទ និង​ពេលវេលា"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "ឆ្នាំ"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "ខែ"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "មករា"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "កុម្ភៈ"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "មីនា"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "មេសា"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "ឧសភា"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "មិថុនា"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "កក្កដា"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "សីហា"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "កញ្ញា"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "តុលា"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "វិច្ឆិកា"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ធ្នូ"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "ថ្ងៃ"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#, fuzzy
+msgid "Time Zone"
+msgstr "ពេលវេលា"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "កាលបរិច្ឆេទ និង​ពេលវេលា"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "ចូល​ស្វ័យប្រវត្តិ"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "បាន​បើក"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ស្រប​ទ្រនិច​នាឡិកា"
+
+#: panels/datetime/cc-datetime-panel.ui:246
+#, fuzzy
+msgid "Time _Format"
+msgstr "ទ្រង់ទ្រាយ"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "កាលបរិច្ឆេទ"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "៣០ វិនាទី"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "ប្រតិទិន"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "លេខ"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​ពេលវេលា និង​កាលបរិច្ឆេទ​​ប្រព័ន្ធ"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "ដើម្បី​ផ្លាស់ប្ដូរ​កា​រកំណត់​ពេលវាលា ឬ​កាលបរិច្ឆេទ អ្នក​ត្រូវ​តែ​ផ្ទៀតផ្ទាត់​ ។"
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "បណ្ដាញ"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "សំបុត្រ"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "ប្រតិទិន"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "តន្ត្រី"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "វីដេអូ"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "រូបថត"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "កម្មវិធី​លំនាំដើម"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "កម្មវិធី​លំនាំដើម"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "ការ​ផ្គត់ផ្គង់"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "ថយក្រោយ"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "ប៊្លូធូស​ត្រូវ​បាន​បិទ"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "ទិដ្ឋភាព​ឆ្លុះ"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "ការ​បង្ហាញ"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "ទិស​"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "គុណភាព​បង្ហាញ"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "មាត្រដ្ឋាន"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "គ្មាន​ម៉ាស៊ីន​បោះពុម្ព​ដែល​អាច​ប្រើ​បាន"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "ពេលវេលា"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "នាទី"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "ទិដ្ឋភាព"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+#, fuzzy
+msgid "Choose how to use connected monitors and projectors"
+msgstr "ផ្លាស់ប្ដូរ​គុណភាព​បង្ហាញ និង​ទីតាំង​របស់​ម៉ូនីទ័រ និង​ឧបករណ៍​បញ្ចាំង​ស្លាយ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "សោ​សុវត្ថិភាព"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "កម្រិត​ទឹក​ខ្មៅ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "កម្រិត​ទឹក​ខ្មៅ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "កម្រិត​ទឹក​ខ្មៅ"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "សុវត្ថិភាព"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ឈ្មោះ​ឧបករណ៍"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "អាសយដ្ឋាន​ផ្នែក​រឹង"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "អង្គ​ចងចាំ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "កម្មវិធី​ដំណើរការ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "ក្រាហ្វិក"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+#, fuzzy
+msgid "Calculating…"
+msgstr "កំពុង​គណនា..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "ឈ្មោះ"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "ប្រភេទ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "កំណែ %s"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "កម្មវិធី​សម្រាប់​វីនដូ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+#, fuzzy
+msgid "Virtualization"
+msgstr "ការ​ក្រិត​ខ្នាត"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "កម្មវិធី"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "យក​ឧបករណ៍​ចេញ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ឈ្មោះ​ឧបករណ៍"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "ឈ្មោះ​អ្នកប្រើ"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "សំឡេង និង​មេឌៀ"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "ស្ងាត់"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "បន្ថយ​កម្រិត​សំឡេង"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "បង្កើន​កម្រិត​សំឡេង"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "កម្រិត​សំឡេង​មីក្រូហ្វូន"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "បើក​ដំណើរការ​កម្មវិធី​ចាក់​មេឌៀ"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "ចាក់ (ឬ​ចាក់/ផ្អាក)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "ផ្អាក​ការ​ចាក់​សារ​ថ្មី"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "បញ្ឈប់​ការ​ចាក់​សារ​ថ្មី"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "បទ​មុន"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "បទ​បន្ទាប់"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "ច្រានចេញ"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "វាយ"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "ប្ដូរ​ទៅ​ប្រភព​បន្ទាប់"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "ប្ដូរ​ទៅ​ប្រភព​មុន"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "កម្មវិធី​បើក​ដំណើរការ"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "បើក​ដំណើរការ​កម្មវិធី​រុករក​បណ្ដាញ"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "ការ​កំណត់..."
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "បើក​ដំណើរការ​ម៉ាស៊ីន​គណនា"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "បើក​ដំណើរការ​កម្មវិធី​អ៊ីមែល"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "បើក​ដំណើរការ​កម្មវិធី​រុករក​បណ្ដាញ"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "ថត​ផ្ទះ"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ស្វែងរក"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "ប្រព័ន្ធ"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "ចេញ"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "ចាក់​សោ​អេក្រង់"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "ភាព​អាច​មើល​ឃើ"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "បើក ឬ​បិទ​ការ​ពង្រីក"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "ពង្រីក"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "បង្រួម"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "បើក ឬ​បិទ​កម្មវិធី​អាន​អេក្រង់"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "បើក ឬ​បិទ​ក្ដារចុច​នៅ​លើ​អេក្រង់"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "បង្កើន​ទំហំ​អត្ថបទ"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "បន្ថយ​ទំហំ​អត្ថបទ"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "បើក ឬ​បិទ​កម្រិត​ពណ៌​ខ្ពស់"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+#, fuzzy
+msgid "Add an Input Source"
+msgstr "បន្ថែម​ប្រភព​បញ្ចូល"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+#, fuzzy
+msgid "No input source selected"
+msgstr "រក​មិ​ន​ឃើញ​ម៉ាស៊ីន​បោះពុម្ព"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "ជម្រើស"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "ផ្លាស់ទី​ឡើងលើ"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "ផ្លាស់ទី​ចុះក្រោម"
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "ចំណូលចិត្ត​កណ្ដុរ"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "បង្ហាញ​ប្លង់​ក្ដារចុច"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "យកចេញ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "ប្រភព​បញ្ចូល"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "បញ្ចូល​ការ​កំណត់​ប្រភព"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "ប្រើ​ប្លង់​តែមួយ​សម្រាប់​បង្អួច​ទាំងអស់"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "គន្លឹះ​តួអក្សរ​ជំនួស"
 
-#: ../panels/keyboard/cc-keyboard-option.c:320
-#| msgid "Mouse Keys"
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "គ្រាប់​ចុច​តែង"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "Keyboard"
-msgstr "ក្ដារចុច"
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+#, fuzzy
+msgid "Keyboard Shortcuts"
+msgstr "ការ​កំណត់​ក្ដារចុច"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "Change keyboard settings"
-msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​ក្ដារចុច"
-
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Shortcut;Repeat;Blink;"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
 msgstr "ផ្លូវកាត់​ផ្ទាល់ខ្លួន"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "_Name:"
-msgstr "ឈ្មោះ ៖"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "C_ommand:"
-msgstr "ពាក្យបញ្ជា ៖"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "Repeat Keys"
-msgstr "គ្រាប់ចុច​ធ្វើ​ម្ដងទៀត"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Key presses _repeat when key is held down"
-msgstr "គ្រាប់ចុច presses _repeat នៅ​ពេល​គ្រាប់ចុច​ត្រូវ​បាន​សង្កត់"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "_Delay:"
-msgstr "ពន្យារពេល ៖"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Speed:"
-msgstr "ល្បឿន ៖"
-
-#. short delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-#: ../panels/universal-access/uap.ui.h:49
-msgid "Short"
-msgstr "ខ្លី"
-
-#. slow acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Slow"
-msgstr "យឺត"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgid "Repeat keys speed"
-msgstr "ល្បឿន​គ្រាប់ចុច​ធ្វើ​ម្ដងទៀត"
-
-#. long delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Long"
-msgstr "យូរ"
-
-#. fast acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Fast"
-msgstr "លឿន"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgid "Cursor Blinking"
-msgstr "ទស្សន៍ទ្រនិច​លោត​ភ្លឹបភ្លែត"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor _blinks in text fields"
-msgstr "ទស្សន៍ទ្រនិច​លោត​ភ្លឹបភ្លែត​នៅ​ក្នុង​វាល​អត្ថបទ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "S_peed:"
-msgstr "ល្បឿន ៖"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "Cursor blink speed"
-msgstr "ល្បឿន​លោត​ភ្លឹបភ្លែត​របស់​ទស្សន៍ទ្រនិច"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Layout Settings"
-msgstr "ការ​កំណត់​ប្លង់"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-msgid "Add Shortcut"
-msgstr "បន្ថែម​ផ្លូវកាត់"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Remove Shortcut"
-msgstr "យក​ផ្លូវកាត់​ចេញ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-#: ../panels/wacom/button-mapping.ui.h:3
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
 msgstr ""
-"ដើម្បី​កែសម្រួល​ផ្លូវកាត់ ចុច​ជួរ​ដេក និង​សង្កត់​គ្រាប់ចុច​ថ្មី ឬ​ចុច លុប​ថយក្រោយ (Backspace) ដើម្បី​សម្អាត ។"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-#: ../panels/region/gnome-region-panel.ui.h:29
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "ភាគ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "ផ្លូវកាត់"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:552
-#: ../panels/keyboard/keyboard-shortcuts.c:560
-#: ../panels/keyboard/keyboard-shortcuts.c:942
-#: ../panels/keyboard/keyboard-shortcuts.c:1414
-#: ../panels/keyboard/keyboard-shortcuts.c:1418
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "បន្ថែម​ផ្លូវកាត់"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "ផ្លូវកាត់​ផ្ទាល់ខ្លួន"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:756
-msgid "<Unknown Action>"
-msgstr "<មិន​ស្គាល់​សកម្មភាព>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1253
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"មិន​អាច​ប្រើ​ផ្លូវកាត់ \"%s\" បាន​ទេ ពីព្រោះ​វា​នឹង​ធ្វើឲ្យ​មិន​អាច​វាយ​ដោយ​ប្រើ​គ្រាប់​ចុច​នេះ​បាន ។\n"
-"សូម​ព្យាយាម​ប្រើ​គ្រាប់ចុច​ដូចជា បញ្ជា (Control) ជំនួស (Alt) ឬ​ប្ដូរ (Shift) ក្នុង​ពេល​តែមួយ ។"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1285
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "បន្ថែម​ផ្លូវកាត់"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
 msgstr ""
-"ផ្លូវកាត់ \"%s\" ត្រូវ​បាន​ប្រើ​សម្រាប់\n"
-"\"%s\" រួចហើយ"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1290
-#, c-format
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "យកចេញ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "ឈ្មោះ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "ពាក្យបញ្ជា ៖"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "ផ្លូវកាត់"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "ផ្លូវកាត់"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "គ្មាន"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "កំណត់​ឡើង​វិញ​ទៅ​ជា​លំនាំដើម"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "ក្ដារចុច"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
 msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "ប្រសិនបើ​អ្នក​កំណត់​ផ្លូវកាត់​ឡើងវិញ​ទៅជា \"%s\" ផ្លូវកាត់ \"%s\" នឹង​ត្រូវ​បាន​បិទ ។"
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1296
-msgid "_Reassign"
-msgstr "កំណត់​ឡើងវិញ"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
 
-#: ../panels/mouse/cc-mouse-panel.c:152
-#| msgid "Your settings"
-msgid "_Test Your Settings"
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "បច្ចុប្បន្ន​គ្មាន​កម្មវិធី​ដែល​កំពុង​ចាក់ ឬ​ថត​ចម្លង​អូឌីយ៉ូ​ទេ ។"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "កម្រិត​សំឡេង​មីក្រូហ្វូន"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "បច្ចុប្បន្ន​គ្មាន​កម្មវិធី​ដែល​កំពុង​ចាក់ ឬ​ថត​ចម្លង​អូឌីយ៉ូ​ទេ ។"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
 msgstr "សាកល្បង​ការ​កំណត់​របស់​អ្នក"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-#| msgid "Mouse and Touchpad"
-msgid "Mouse & Touchpad"
-msgstr "កណ្ដុរ និង​បន្ទះ​ប៉ះ"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Set your mouse and touchpad preferences"
-msgstr "កំណត់​ចំណូលចិត្ត​កណ្ដុរ និង​បន្ទះ​ប៉ះ​របស់​អ្នក"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "Mouse Preferences"
-msgstr "ចំណូលចិត្ត​កណ្ដុរ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
 msgid "General"
 msgstr "ទូទៅ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "Double-click timeout"
-msgstr "អស់​ពេល​ចុច​ទ្វេ​ដង"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-#| msgid "Double-click timeout"
-msgid "_Double-click"
-msgstr "ចុច​ទ្វេ​ដង"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-#| msgid "Primary Color"
-msgid "Primary _button"
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
 msgstr "ប៊ូតុង​ចម្បង"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-#| msgctxt "balance"
-#| msgid "Left"
-msgid "_Left"
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
 msgstr "ឆ្វេង"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-#| msgctxt "balance"
-#| msgid "Right"
-msgid "_Right"
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
 msgstr "ស្ដាំ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "ទីតាំង"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "កណ្ដុរ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-#| msgid "Pointer Speed"
-msgid "_Pointer speed"
-msgstr "ល្បឿន​ព្រួញ​កណ្ដុរ"
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "គ្រាប់ចុច​កណ្ដុរ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "រមូរ​ចុះក្រោម"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​ផ្លាស់ទី​ជាមួយ​មាតិកា"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "ការ​បង្កើន​ល្បឿន ៖"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "បន្ទះ​ប៉ះ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-#| msgid "Disable _touchpad while typing"
-msgid "Disable while _typing"
-msgstr "បិទ​​ខណៈ​ពេល​វាយ"
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "បន្ទះ​ប៉ះ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Tap to _click"
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "វិធីសាស្ត្រ"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
 msgstr "ថេប​ដើម្បី​ចុច"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-#| msgid "Two-_finger scrolling"
-msgid "Two _finger scroll"
-msgstr "រមូរ​ដោយ​ប្រើម្រាមដៃ​ពីរ"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "C_ontent sticks to fingers"
-msgstr "មាតិកា​ជាប់​នឹង​ម្រាមដៃ"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "ថេប​ដើម្បី​ចុច"
 
-#: ../panels/mouse/gnome-mouse-test.c:134
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "បិទ​​ខណៈ​ពេល​វាយ"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "បន្ទះ​ប៉ះ (ធៀប)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "រមូរ"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "រមូរ​ទៅ​ឆ្វេង"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "ទាំង​សងខាង"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "ព្យាយាម​ចុច ចុច​ទ្វេ​ដង រមូរ"
 
-#: ../panels/mouse/gnome-mouse-test.c:139
-msgid "Five clicks, GEGL time!"
-msgstr "ចុច​ប្រាំ​ដង GEGL ដង !"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "កណ្ដុរ និង​បន្ទះ​ប៉ះ"
 
-#: ../panels/mouse/gnome-mouse-test.c:144
-#| msgid "Double-click timeout"
-msgid "Double click, primary button"
-msgstr "​ចុច​ទ្វេ​ដង ប៊ូតុង​ចម្បង"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:144
-msgid "Single click, primary button"
-msgstr "ចុច​ម្ដង​ប៊ូតុង​សំខាន់"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+#, fuzzy
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
 
-#: ../panels/mouse/gnome-mouse-test.c:147
-#| msgid "Double-click timeout"
-msgid "Double click, middle button"
-msgstr "ចុច​ទ្វេ​ដង ប៊ូតុង​កណ្ដាល"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+#, fuzzy
+msgid "_Hot Corner"
+msgstr "ជ្រុង​ខាងលើ​ផ្នែក​ខាងឆ្វេង"
 
-#: ../panels/mouse/gnome-mouse-test.c:147
-msgid "Single click, middle button"
-msgstr "ចុច​ម្ដង ប៊ូតុង​កណ្ដាល"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:150
-#| msgid "Double-click timeout"
-msgid "Double click, secondary button"
-msgstr "​ចុច​ទ្វេ​ដង ប៊ូតុង​រង"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:150
-msgid "Single click, secondary button"
-msgstr "ចុច​ម្ដង​ប៊ូតុង​រង"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: ../panels/network/cc-network-panel.c:615
-msgid "Network proxy"
-msgstr "ប្រូកស៊ី​បណ្ដាញ"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "គំរូ​ពណ៌ ៖ "
 
-#: ../panels/network/cc-network-panel.c:799 ../panels/network/net-vpn.c:278
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:866
-msgid "The system network services are not compatible with this version."
-msgstr "សេវា​បណ្ដាញ​ប្រព័ន្ធ​មិន​ឆប​ជាមួយ​កំណែ​នេះ​ទេ ។"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:1001
-#| msgid "Airplane Mode"
-msgid "Air_plane Mode"
-msgstr "នៅ​ពេល​ជិះ​យន្ដហោះ"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "បណ្ដាញ"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Network settings"
-msgstr "ការ​កំណត់​បណ្ដាញ"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid "Network;Wireless;IP;LAN;Proxy;"
-msgstr "Network;Wireless;IP;LAN;Proxy;"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "ម៉ូនីទ័រ"
 
-#: ../panels/network/net-device-mobile.c:222
-#| msgid "Connection"
-msgid "Add new connection"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "អូស ដើម្បី​ផ្លាស់ប្ដូរ​ទិដ្ឋភាព​ចម្បង ។"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "ម៉ឺនុយ​កម្មវិធី"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ឧបករណ៍"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
 msgstr "បន្ថែម​ការ​តភ្ជាប់​ថ្មី"
 
-#. Translators: network device speed
-#: ../panels/network/net-device-mobile.c:261
-#: ../panels/network/net-device-wifi.c:699
-#: ../panels/network/net-device-wired.c:126
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "បាន​តភ្ជាប់"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "ជម្រើស"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
 
-#. TRANSLATORS: this is when the access point is not listed in
-#. *  the dropdown (or hidden) and the user has to select another
-#. *  entry manually
-#: ../panels/network/net-device-wifi.c:196
-msgid "Connect to a Hidden Network"
-msgstr "តភ្ជាប់​ទៅ​បណ្ដាញ​ដែល​លាក់"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
 
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/net-device-wifi.c:293
-#: ../panels/network/net-device-wifi.c:472
-msgid "WEP"
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "ឈ្មោះ​បណ្ដាញ"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "ពាក្យ​សម្ងាត់"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "បង្កើត​ពាក្យ​សម្ងាត់"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "បង្កើត​ពាក្យ​សម្ងាត់"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "បើក"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "នៅ​ពេល​ជិះ​យន្ដហោះ"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "រក​មិន​ឃើញ​អាដាប់ទ័រ​ប៊្លូធូស"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "នៅ​ពេល​ជិះ​យន្ដហោះ"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
 msgstr "បណ្ដាញ"
 
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/net-device-wifi.c:297
-#: ../panels/network/net-device-wifi.c:476
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/net-device-wifi.c:301
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/net-device-wifi.c:306
-msgid "Enterprise"
-msgstr "សហគ្រាស"
-
-#: ../panels/network/net-device-wifi.c:311
-#: ../panels/network/net-device-wifi.c:467
-#| msgid "None"
-msgctxt "Wifi security"
-msgid "None"
-msgstr "គ្មាន"
-
-#: ../panels/network/net-device-wifi.c:733
-#| msgid "None"
-msgctxt "Signal strength"
-msgid "None"
-msgstr "គ្មាន"
-
-#: ../panels/network/net-device-wifi.c:735
-#| msgctxt "Password strength"
-#| msgid "Weak"
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "ខ្សោយ"
-
-#: ../panels/network/net-device-wifi.c:737
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "គ្មាន​បញ្ហា"
-
-#: ../panels/network/net-device-wifi.c:739
-#| msgid "Good"
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "ល្អ"
-
-#: ../panels/network/net-device-wifi.c:741
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "ប្រសើរ​ណាស់"
-
-#: ../panels/network/net-device-wifi.c:901
-#, c-format
-msgid ""
-"Network details for %s including password and any custom configuration will "
-"be lost"
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
 msgstr ""
-"សេចក្ដី​លម្អិត​អំពី​បណ្ដាញ​សម្រាប់ %s ដែល​រួម​មាន​ពាក្យសម្ងាត់ និង​ការ​កំណត់​រចនាសម្ព័ន្ធ​ផ្ទាល់ខ្លួន​ណាមួយ​នឹង​ត្រូវ​"
-"បាត់បង់"
 
-#: ../panels/network/net-device-wifi.c:912
-msgid "Forget"
-msgstr "ភ្លេច"
-
-#: ../panels/network/net-device-wifi.c:1437
-msgid ""
-"If you have a connection to the Internet other than wireless, you can use it "
-"to share your internet connection with others."
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr ""
-"ប្រសិន​បើ​អ្នក​មាន​ការ​តភ្ជាប់​​អ៊ីនធឺណិត​ក្រៅ​ពី​​ប្រើ​ប្រព័ន្ធ​ឥត​ខ្សែ "
-"អ្នក​អាច​ប្រើ​វា ដើម្បី​ចែករំលែក​ការ​តភ្ជាប់​អ៊ីនធឺណីត​ជា​មួយ​អ្នក​ផ្សេង ។"
 
-#: ../panels/network/net-device-wifi.c:1441
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "បើក​ hotspot ឥតខ្សែ​នឹង​ផ្ដាច់​អ្នក​ពី <b>%s</b> ។"
+#: panels/network/connection-editor/8021x-security-page.ui:16
+#, fuzzy
+msgid "802.1x _Security"
+msgstr "សុវត្ថិភាព"
 
-#: ../panels/network/net-device-wifi.c:1445
-msgid ""
-"It is not possible to access the internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"មិនអាច​ចូលប្រើ​អ៊ីនធឺណិត​តាមរយៈ​ប្រព័ន្ធ​ឥតខ្សែ​របស់​អ្នក​បាន​ទេ ខណៈ​ដែល​ "
-"hotspot សកម្ម ។"
-
-#: ../panels/network/net-device-wifi.c:1511
-msgid "Stop hotspot and disconnect any users?"
-msgstr "បញ្ឈប់ hotspot និង​ផ្ដាច់​អ្នកប្រើ​ណា​ម្នាក់​ឬ ?"
-
-#: ../panels/network/net-device-wifi.c:1514
-msgid "_Stop Hotspot"
-msgstr "បញ្ឈប់ Hotspot"
-
-#: ../panels/network/net-device-wifi.c:1579
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i ថ្ងៃ​មុន"
 
-#: ../panels/network/net-device-wifi.c:1933
-#: ../panels/network/network-wifi.ui.h:19
-#| msgid "Out of toner"
-msgid "Out of range"
-msgstr "ក្រៅ​ជួរ"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"ការ​រក​ឃើញ​ប្រូកស៊ី​បណ្ដាញ​ស្វ័យប្រវត្តិ​នឹង​ត្រូវ​បាន​ប្រើ នៅ​ពេល​ URL កំណត់​រចនាសម្ព័ន្ធ​មិន​ត្រូវ​បាន​ផ្ដល់ ។"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "វា​មិន​ត្រូវ​បាន​ផ្ដល់​អនុសាសន៍​សម្រាប់​បណ្ដាញ​សាធារណៈ​ដែល​មិន​គួរ​ទុកចិត្ត​នោះ​ទេ ។"
-
-#: ../panels/network/net-proxy.c:367
-msgid "Proxy"
-msgstr "ប្រូកស៊ី"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "ក្រុមហ៊ុន​ផ្ដល់"
-
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:697 ../panels/network/panel-common.c:699
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "អាសយដ្ឋាន IP"
-
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-wifi.ui.h:7
-#: ../panels/network/network-wired.ui.h:3 ../panels/network/panel-common.c:695
-msgid "IPv6 Address"
-msgstr "អាសយដ្ឋាន IPv6"
-
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-wifi.ui.h:8
-#: ../panels/network/network-wired.ui.h:5
-msgid "Default Route"
-msgstr "ផ្លូវ​លំនាំដើម"
-
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-wifi.ui.h:9
-#: ../panels/network/network-wired.ui.h:6
-msgid "DNS"
-msgstr "DNS"
-
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-wired.ui.h:7
-msgid "_Options..."
-msgstr "ជម្រើស..."
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:5
-msgctxt "proxy method"
-msgid "None"
-msgstr "គ្មាន"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:6
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "ដោយដៃ"
-
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:7
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "ស្វ័យប្រវត្តិ"
-
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
-msgstr "វិធីសាស្ត្រ"
-
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "URL កំណត់​រចនាសម្ព័ន្ធ"
-
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "ប្រូកស៊ី HTTP"
-
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "ប្រូកស៊ី HTTPS"
-
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "ប្រូកស៊ី FTP"
-
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "ម៉ាស៊ីន​រន្ធ"
-
-#: ../panels/network/network.ui.h:1
-msgid "Select the interface to use for the new service"
-msgstr "ជ្រើស​ចំណុច​ប្រទាក់​ដែល​ត្រូវ​ប្រើ​សម្រាប់​សេវា​ថ្មី"
-
-#: ../panels/network/network.ui.h:2
-#| msgid "Create..."
-msgid "C_reate..."
-msgstr "បង្កើត..."
-
-#: ../panels/network/network.ui.h:3
-#| msgid "Interface"
-msgid "_Interface"
-msgstr "ចំណុច​ប្រទាក់"
-
-#: ../panels/network/network.ui.h:4 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/network.ui.h:8
-msgid "Add Device"
-msgstr "បន្ថែម​ឧបករណ៍"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "ប្រភេទ VPN"
-
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "ផ្លូវ​ចេញចូល"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "ឈ្មោះ​ក្រុម"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "ពាក្យសម្ងាត់​ជា​ក្រុម"
-
-#: ../panels/network/network-vpn.ui.h:6
-msgid "Username"
-msgstr "ឈ្មោះ​អ្នកប្រើ"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "_Configure..."
-msgstr "កំណត់​រចនាសម្ព័ន្ធ..."
-
-#: ../panels/network/network-wifi.ui.h:1
-#| msgid "Wireless mouse"
-msgid "Wireless Hotspot"
-msgstr "otspot ​ឥត​ខ្សែ"
-
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Turn On"
-msgstr "បើក"
-
-#. TRANSLATORS: device type
-#: ../panels/network/network-wifi.ui.h:3 ../panels/network/panel-common.c:90
-msgid "Wireless"
-msgstr "ឥត​ខ្សែ"
-
-#: ../panels/network/network-wifi.ui.h:4
-msgid "_Use as Hotspot..."
-msgstr "ប្រើ​ជា Hotspot..."
-
-#: ../panels/network/network-wifi.ui.h:5
-#: ../panels/network/network-wired.ui.h:1
-msgid "Hardware Address"
-msgstr "អាសយដ្ឋាន​ផ្នែក​រឹង"
-
-#: ../panels/network/network-wifi.ui.h:6
-#: ../panels/network/network-wired.ui.h:2 ../panels/network/panel-common.c:694
-msgid "IPv4 Address"
-msgstr "អាសយដ្ឋាន IPv4"
-
-#: ../panels/network/network-wifi.ui.h:10
-msgid "Security"
-msgstr "សុវត្ថិភាព"
-
-#: ../panels/network/network-wifi.ui.h:11
-#| msgid "Length:"
-msgid "Strength"
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+#, fuzzy
+msgid "Signal Strength"
 msgstr "ប្រវែង"
 
-#: ../panels/network/network-wifi.ui.h:12
-#| msgid "Cursor blink speed"
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "ល្បឿនតំណ"
 
-#: ../panels/network/network-wifi.ui.h:13
-#| msgid "Copy Settings..."
-msgid "_Settings..."
-msgstr "ការ​កំណត់..."
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "សុវត្ថិភាព"
 
-#: ../panels/network/network-wifi.ui.h:14
-msgid "Switch off to connect to a wireless network"
-msgstr "បិទ ដើម្បី​តភ្ជាប់​ទៅ​បណ្ដាញ​ឥត​ខ្សែ"
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "អាសយដ្ឋាន IPv4"
 
-#: ../panels/network/network-wifi.ui.h:15
-msgid "Network Name"
-msgstr "ឈ្មោះ​បណ្ដាញ"
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "អាសយដ្ឋាន IPv6"
 
-#: ../panels/network/network-wifi.ui.h:16
-#| msgid "Connected"
-msgid "Connected Devices"
-msgstr "ឧបករណ៍​ដែល​បាន​តភ្ជាប់"
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr "អាសយដ្ឋាន​ផ្នែក​រឹង"
 
-#: ../panels/network/network-wifi.ui.h:17
-#| msgid "Security Key"
-msgid "Security type"
-msgstr "ប្រភេទ​សុវត្ថិភាព"
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "គាំទ្រ​ទម្រង់ ICC"
 
-#: ../panels/network/network-wifi.ui.h:18
-#| msgid "Security Key"
-msgid "Security key"
-msgstr "សោ​សុវត្ថិភាព"
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "ផ្លូវ​លំនាំដើម"
 
-#: ../panels/network/network-wifi.ui.h:20
-msgid "Security Key"
-msgstr "សោ​សុវត្ថិភាព"
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
-#: ../panels/network/network-wifi.ui.h:21
-#| msgctxt "printer state"
-#| msgid "Paused"
-msgid "Last used"
+#: panels/network/connection-editor/details-page.ui:208
+#, fuzzy
+msgid "Last Used"
 msgstr "បានប្រើ​ចុងក្រោយ"
 
-#: ../panels/network/network-wifi.ui.h:22
-#| msgid "Forget Network"
-msgid "_Forget Network"
-msgstr "ភ្លេច​បណ្ដាញ"
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
 
-#: ../panels/network/network-wired.ui.h:4
-msgid "Subnet Mask"
-msgstr "របាំង​បណ្ដាញ​រង"
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:86
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "ឈ្មោះ ៖"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "អាសយដ្ឋាន"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "អាសយដ្ឋាន IP"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "វិធីសាស្ត្រ"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+#, fuzzy
+msgid "Automatic (DHCP)"
+msgstr "ស្វ័យប្រវត្តិ"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+#, fuzzy
+msgid "Manual"
+msgstr "ដោយដៃ"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "បាន​បិទ"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "អាសយដ្ឋាន"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "អាសយដ្ឋាន"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "ផ្លូវ​ចេញចូល"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "ស្វ័យប្រវត្តិ"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+#, fuzzy
+msgid "Automatic DNS"
+msgstr "ស្វ័យប្រវត្តិ"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+#, fuzzy
+msgid "Automatic Routes"
+msgstr "ស្វ័យប្រវត្តិ"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "ម៉ែត្រ"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "វិធីសាស្ត្រ"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+#, fuzzy
+msgid "Automatic, DHCP only"
+msgstr "ចូល​ស្វ័យប្រវត្តិ"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+#, fuzzy
+msgid "S_ecurity"
+msgstr "សុវត្ថិភាព"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "បណ្ដាញ"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to the Internet"
+msgstr "មិន​ត្រូវ​បាន​តភ្ជាប់​ទៅ​អ៊ីនធឺណិត ។"
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "បិទ ដើម្បី​តភ្ជាប់​ទៅ​បណ្ដាញ​ឥត​ខ្សែ"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Network;Wireless;IP;LAN;Proxy;"
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "មាន​ខ្សែ"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:97
-msgid "Mobile broadband"
-msgstr "រលក​អាកាស​ចល័ត"
+#: panels/network/network-bluetooth.ui:11
+#, fuzzy
+msgid "Turn device off"
+msgstr "បិទ​ឧបករណ៍"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:106
-msgid "Mesh"
-msgstr "សំណាញ់"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "ការងារសកម្ម"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:166
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:170
-msgid "Infrastructure"
-msgstr "ហេដ្ឋារចនាសម្ព័ន្ធ"
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "ក្រុមហ៊ុន​ផ្ដល់"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:194 ../panels/network/panel-common.c:255
-msgid "Status unknown"
-msgstr "មិន​ស្គាល់​ស្ថានភាព"
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "អាសយដ្ឋាន IP"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:198
-msgid "Unmanaged"
-msgstr "មិនបាន​គ្រប់គ្រង"
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "ប្រូកស៊ី​បណ្ដាញ"
 
-#: ../panels/network/panel-common.c:203
-msgid "Firmware missing"
-msgstr "បាត់​កម្មវិធី​បង្កប់"
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "ប្រូកស៊ី HTTP"
 
-#: ../panels/network/panel-common.c:206
-msgid "Cable unplugged"
-msgstr "ខ្សែ​ត្រូវ​បាន​ដក"
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "ប្រូកស៊ី HTTPS"
 
-#: ../panels/network/panel-common.c:208
-msgid "Unavailable"
-msgstr "មិន​អាច​ប្រើ​បាន"
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "ប្រូកស៊ី FTP"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:212
-msgid "Disconnected"
-msgstr "បាន​ផ្ដាច់"
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "ម៉ាស៊ីន​រន្ធ"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
-msgid "Connecting"
-msgstr "តភ្ជាប់"
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
-msgid "Authentication required"
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "ប្រូកស៊ី HTTP"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "ប្រូកស៊ី HTTPS"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "ប្រូកស៊ី FTP"
+
+#: panels/network/network-proxy.ui:339
+#, fuzzy
+msgid "Socks proxy port"
+msgstr "ច្រក​រន្ធ"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL កំណត់​រចនាសម្ព័ន្ធ"
+
+#: panels/network/network-vpn.ui:11
+#, fuzzy
+msgid "Turn VPN connection off"
+msgstr "បើក ឬ​បិទ"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "ឈ្មោះ​បណ្ដាញ"
+
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "ប្រភេទ​សុវត្ថិភាព"
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "ពាក្យ​សម្ងាត់"
+
+#: panels/network/network-wifi.ui:90
+#, fuzzy
+msgid "Turn Wi-Fi off"
+msgstr "បើក ឬ​បិទ"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "បង្ហាញ​ជម្រើស​ជំនួយ"
+
+#: panels/network/network-wifi.ui:119
+#, fuzzy
+msgid "_Connect to Hidden Network…"
+msgstr "តភ្ជាប់​ទៅ​បណ្ដាញ​ដែល​លាក់"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ផ្ទៀងផ្ទាត់"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "ឯកសារ​ទាំងអស់"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ផ្ទៀងផ្ទាត់"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "ឈ្មោះ​អ្នកប្រើ"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "ពាក្យ​សម្ងាត់"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "បង្ហាញ​ពាក្យសម្ងាត់"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "កំណែ %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "កំណែ %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
 msgstr "តម្រូវឲ្យ​ផ្ទៀងផ្ទាត់​ភាព​ត្រឹមត្រូវ"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227 ../panels/network/panel-common.c:269
-msgid "Connected"
-msgstr "បាន​តភ្ជាប់"
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:231
-msgid "Disconnecting"
-msgstr "ផ្ដាច់"
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:273
-msgid "Connection failed"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​តភ្ជាប់"
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:239 ../panels/network/panel-common.c:281
-msgid "Status unknown (missing)"
-msgstr "(បាត់) មិន​ស្គាល់​ស្ថានភាព"
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
 
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:277
-msgid "Not connected"
-msgstr "មិន​ត្រូវ​បាន​តភ្ជាប់"
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "បង្កើត​ពាក្យ​សម្ងាត់"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:301
-#| msgid "Connection failed"
-msgid "Configuration failed"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​កំណត់​រចនាសម្ព័ន្ធ"
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+#, fuzzy
+msgid "PAP"
+msgstr "WPA"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:305
-#| msgid "Connection failed"
-msgid "IP configuration failed"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​កំណត់​រចនាសម្ព័ន្ធ IP"
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:309
-#| msgid "_Configuration URL"
-msgid "IP configuration expired"
-msgstr "ការ​កំណត់​រចនាសម្ព័ន្ធ IP បាន​ផុត​កំណត់"
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:313
-msgid "Secrets were required, but not provided"
-msgstr "ទាមទារ​ភាព​សម្ងាត់ ប៉ុន្តែ​មិន​បាន​ផ្ដល់​ទេ"
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:317
-msgid "802.1x supplicant disconnected"
-msgstr "បាន​ផ្ដាច់ 802.1x supplicant"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "ដែន"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:321
-msgid "802.1x supplicant configuration failed"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​កំណត់​រចនាសម្ព័ន្ធ 802.1x supplicant"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:325
-msgid "802.1x supplicant failed"
-msgstr "បាន​បរាជ័យ 802.1x supplicant"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:329
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant ត្រូវ​ការ​ពេលវាលា​ច្រើន​ ដើម្បី​ផ្ទៀងផ្ទាត់"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:333
-msgid "PPP service failed to start"
-msgstr "សកម្ម PPP បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:337
-#| msgid "Disconnected"
-msgid "PPP service disconnected"
-msgstr "បាន​ផ្ដាច់​សេវាកម្ម PPP"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:341
-msgid "PPP failed"
-msgstr "PPP បាន​បរាជ័យ"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:345
-msgid "DHCP client failed to start"
-msgstr "ម៉ាស៊ីន​ភ្ញៀវ DHCP បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ផ្ទៀងផ្ទាត់"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:349
-msgid "DHCP client error"
-msgstr "កំហុស​ម៉ាស៊ីន​ភ្ញៀវ DHCP"
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "ប្រភេទ ៖"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:353
-#| msgid "Connection failed"
-msgid "DHCP client failed"
-msgstr "ម៉ាស៊ីន​ភ្ញៀវ DHCP បាន​បរាជ័យ"
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "លំនាំដើម"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:357
-msgid "Shared connection service failed to start"
-msgstr "សេវាកម្ម​តភ្ជាប់​ដែល​បាន​ចែក​រំលែក​បាន​បរាជ័យ​ក្នុងការ​ចាប់ផ្ដើម"
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "ប្រព័ន្ធ"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:361
-#| msgid "Connection failed"
-msgid "Shared connection service failed"
-msgstr "សេវាកម្ម​តភ្ជាប់​ដែល​បាន​ចែករំលែក​បាន​បរាជ័យ"
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:365
-msgid "AutoIP service failed to start"
-msgstr "សេវាកម្ម AutoIP បាន​បរាជ័យ​ក្នុងការ​ចាប់ផ្ដើម"
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:369
-msgid "AutoIP service error"
-msgstr "កំហុស​សេវាកម្ម AutoIP"
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:373
-#| msgid "Authentication failed"
-msgid "AutoIP service failed"
-msgstr "សេវាកម្ម AutoIP បាន​បរាជ័យ"
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:377
-msgid "Line busy"
-msgstr "ជាប់​រវល់"
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "ការ​បង្វិល"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:381
-msgid "No dial tone"
-msgstr "គ្មាន​សំឡេង​ចុច"
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "បែបផែន​សំឡេង"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:385
-msgid "No carrier could be established"
-msgstr "គ្មានភ្នាក់ងារ​បញ្ជូន​អាច​ត្រូវ​បាន​បង្កើត"
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:389
-msgid "Dialing request timed out"
-msgstr "សំណើរ​ហៅ​អស់​ពេល"
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:393
-msgid "Dialing attempt failed"
-msgstr "បាន​បរាជ័យ​ក្នុងការ​ប៉ុនប៉ង​ហៅ"
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:397
-#| msgid "Authentication failed"
-msgid "Modem initialization failed"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម​ម៉ូដឹម"
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "ចាក់​សោ​អេក្រង់​បន្ទាប់ពី ៖"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:401
-#| msgid "Failed to delete user"
-msgid "Failed to select the specified APN"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ជ្រើស​ APN ដែល​បាន​បញ្ជាក់"
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:405
-msgid "Not searching for networks"
-msgstr "មិន​ស្វែងរក​បណ្ដាញ"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:409
-#| msgid "Network settings"
-msgid "Network registration denied"
-msgstr "បាន​បដិសេធ​ការ​ចុះឈ្មោះ​​បណ្ដាញ"
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "ចាក់​សោ​អេក្រង់​បន្ទាប់ពី ៖"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:413
-msgid "Network registration timed out"
-msgstr "ការ​ចុះ​ឈ្មោះ​បណ្ដាញ​បាន​អស់​ពេល"
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:417
-msgid "Failed to register with the requested network"
-msgstr "បាន​បរាជ័យ​ក្នុងការ​ចុះឈ្មោះ​ជា​មួយ​បណ្ដាញ​ដែល​បាន​ស្នើ"
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:421
-msgid "PIN check failed"
-msgstr "ការ​ពិនិត្យ​​មើល PIN បាន​បរាជ័យ"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:425
-msgid "Firmware for the device may be missing"
-msgstr "Firmware សម្រាប់​ឧបករណ៍​អាច​បាត់"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "មិន​អាច​រក្សាទុក​ការ​កំណត់​រចនាសម្ព័ន្ធ​ម៉ូនីទ័រ​បាន​ឡើយ"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:429
-#| msgid "Connection failed"
-msgid "Connection disappeared"
-msgstr "ការ​ត​ភ្ជាប់​មិន​បាន​បង្ហាញ​ទេ"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+#, fuzzy
+msgid "Connect to your data in the cloud"
+msgstr "តភ្ជាប់​ទៅ​បណ្ដាញ​ដែល​លាក់"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:433
-msgid "Carrier/link changed"
-msgstr "បាន​ផ្លាស់ប្ដូរ​ភ្នាក់ងារ​បញ្ជូន/តំណ"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:437
-msgid "Existing connection was assumed"
-msgstr "បាន​សន្មត​ការ​តភ្ជាប់​ដែល​មាន​ស្រាប់"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:441
-msgid "Modem not found"
-msgstr "រក​មិន​ឃើញ​ម៉ូដឹម"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:445
-#| msgid "Connection failed"
-msgid "Bluetooth connection failed"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​តភ្ជាប់​ប៊្លូធូស"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:449
-msgid "SIM Card not inserted"
-msgstr "មិន​បាន​បញ្ចូល​ស៊ីមកាត"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:453
-msgid "SIM Pin required"
-msgstr "ទាមទារ PIN ស៊ីមកាត​"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:457
-msgid "SIM Puk required"
-msgstr "ទាមទារ Puk ស៊ីមកាត​"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:461
-#| msgctxt "Password strength"
-#| msgid "Strong"
-msgid "SIM wrong"
-msgstr "ស៊ីម​កាត​មិន​ត្រឹមត្រូវ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:465
-msgid "InfiniBand device does not support connected mode"
-msgstr "ឧបករណ៍ InfiniBand មិន​គាំទ្រ​របៀប​ដែល​បាន​​តភ្ជាប់​ទេ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:469
-#| msgid "Connection failed"
-msgid "Connection dependency failed"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​តភ្ជាប់​ភាព​អាស្រ័យ"
-
-#. translators: This is the title of the "Add Account" dialogue.
-#. * The title is not visible when using GNOME Shell
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:252
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:263
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "បន្ថែម​គណនី"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:383
-msgid "Error logging into the account"
-msgstr "កំហុស​ក្នុង​ការ​ចូល​ទៅ​ក្នុង​គណនី"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:437
-msgid "Expired credentials. Please log in again."
-msgstr "លិខិត​សម្គាល់​បាន​ផុត​កំណត់ ។ សូម​ចូល​ម្ដងទៀត ។"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:440
-msgid "_Log In"
-msgstr "ចូល"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:676
-msgid "Error creating account"
-msgstr "កំហុស​ក្នុង​ការ​បង្កើត​គណនី"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:718
-msgid "Error removing account"
-msgstr "កំហុស​ក្នុង​ការ​យក​គណនី​ចេញ"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:754
-msgid "Are you sure you want to remove the account?"
-msgstr "តើ​អ្នក​ពិតជា​ចង់​យក​គណនី​ចេញ​ឬ ?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:756
-msgid "This will not remove the account on the server."
-msgstr "វា​នឹង​មិន​យក​គណនី​នៅ​លើ​ម៉ាស៊ីន​បម្រើ​ចេញ​ទេ ។"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:757
-msgid "_Remove"
-msgstr "យកចេញ"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "គណនី​លើ​បណ្ដាញ"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "Manage online accounts"
-msgstr "គ្រប់គ្រង​គណនី​លើ​បណ្ដាញ"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
 
-#. Translators: those are keywords for the online-accounts control-center panel
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+#, fuzzy
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-#| msgid "Manage online accounts"
-msgid "No online accounts configured"
-msgstr "គ្មាន​គណនី​លើ​បណ្ដាញ​បាន​កំណត់​រចនាសម្ព័ន្ធទេ"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "យក​គណនី​ចេញ"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-#| msgid "Manage online accounts"
-msgid "Add an online account"
-msgstr "បន្ថែម​គណនី​​លើ​បណ្ដាញ"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"ការ​បន្ថែម​គណនី អនុញ្ញាត​ឲ្យ​​កម្មវិធី​របស់​អ្នក​ចូល​មើល​ឯកសារ អ៊ីមែល "
-"ទំនាក់ទំនង ប្រតិទិន ជជែក និង​ផ្សេងៗ​ទៀត។"
-
-#: ../panels/power/cc-power-panel.c:157
-msgid "Unknown time"
-msgstr "មិន​ស្គាល់​ពេលវេលា"
-
-#: ../panels/power/cc-power-panel.c:163
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i នាទី"
 
-#: ../panels/power/cc-power-panel.c:175
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i ម៉ោង"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:183
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:184
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ម៉ោង"
 
-#: ../panels/power/cc-power-panel.c:185
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "នាទី"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:228
-#, c-format
-msgid "Charging - %s until fully charged"
-msgstr "បញ្ចូល​ថ្ម - %s រហូត​ដល់​​ពេញ"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:236
-#, c-format
-msgid "Caution low battery, %s remaining"
-msgstr "ជិត​អស់​ថ្ម  នៅ​សល់ %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:244
-#, c-format
-msgid "Using battery power - %s remaining"
-msgstr "ប្រើ​ថាមពល​ថ្ម - នៅ​សល់  %s"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:261
-msgid "Charging"
-msgstr "បញ្ចូល​ថ្ម"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Using battery power"
-msgstr "ប្រើ​ថាមពល​ថ្ម"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:270
-msgid "Charging - fully charged"
-msgstr "បញ្ចូល​ថ្ម - ពេញ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:274
-msgid "Empty"
-msgstr "អស់"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:342
-#, c-format
-msgid "Caution low UPS, %s remaining"
-msgstr "យូភីអេស​ខ្សោយ​ថាមពល នៅ​សល់ %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:348
-#, c-format
-msgid "Using UPS power - %s remaining"
-msgstr "ប្រើ​ថាមពល​យូភីអេស -នៅ​សល់ %s"
-
-#. TRANSLATORS: UPS battery
-#: ../panels/power/cc-power-panel.c:366
-msgid "Caution low UPS"
-msgstr "យូភីអេស​ខ្សោយ​ថាមពល"
-
-#. TRANSLATORS: UPS battery
-#: ../panels/power/cc-power-panel.c:371
-msgid "Using UPS power"
-msgstr "ប្រើ​ថាមពល​យូភីអេស"
-
-#. TRANSLATORS: secondary battery is normally in the media bay
-#: ../panels/power/cc-power-panel.c:423
-msgid "Your secondary battery is fully charged"
-msgstr "ថ្ម​ទី​ពីរ​របស់​អ្នក​ពេញ"
-
-#. TRANSLATORS: secondary battery is normally in the media bay
-#: ../panels/power/cc-power-panel.c:427
-msgid "Your secondary battery is empty"
-msgstr "ថ្ម​ទីពីរ​របស់​អ្នក​អស់ថាមពល"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:510
-msgid "Wireless mouse"
-msgstr "កណ្ដុរ​ឥត​ខ្សែ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:514
-msgid "Wireless keyboard"
-msgstr "ក្ដារ​ចុច​ឥត​ខ្សែ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:518
-msgid "Uninterruptible power supply"
-msgstr "ការ​ផ្គត់ផ្គង់​ថាមពល​ដែល​មិន​អាច​ផ្អាក​បាន"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:522
-msgid "Personal digital assistant"
-msgstr "អ្នក​ជំនួយការ​ឌីជីថល​ផ្ទាល់ខ្លួន"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:526
-msgid "Cellphone"
-msgstr "ទូរស័ព្ទ​ចល័ត"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:530
-msgid "Media player"
-msgstr "កម្មវិធី​ចាក់​មេឌៀ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:534
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:538
-msgid "Computer"
-msgstr "កុំព្យូទ័រ"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:542
-msgid "Battery"
-msgstr "ថ្ម"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:553
-#| msgid "Charging"
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "បញ្ចូល​ថ្ម"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:560
-#| msgid "Caution"
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "ប្រយ័ត្ន"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:565
-#| msgid "Low"
-msgctxt "Battery power"
-msgid "Low"
-msgstr "ទាប"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:570
-#| msgid "Good"
-msgctxt "Battery power"
-msgid "Good"
-msgstr "ល្អ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:575
-#| msgid "Charging - fully charged"
-msgctxt "Battery power"
-msgid "Charging - fully charged"
-msgstr "បញ្ចូល​ថ្ម - ពេញ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:579
-#| msgid "Empty"
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "អស់"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "ថាមពល"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Power management settings"
-msgstr "ការ​កំណត់​ការ​គ្រប់គ្រង​ថាមពល"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid "Power;Sleep;Suspend;Hibernate;Battery;"
-msgstr "Power;Sleep;Suspend;Hibernate;Battery;"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "សម្ងំ"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "បិទ​ថាមពល"
-
-#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
-msgid "5 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
 msgstr "៥ នាទី"
 
-#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:7
-msgid "10 minutes"
-msgstr "១០ នាទី"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "២ នាទី"
 
-#: ../panels/power/power.ui.h:5 ../panels/screen/screen.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "៥ នាទី"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "៣០ នាទី"
 
-#: ../panels/power/power.ui.h:6 ../panels/screen/screen.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "៥ នាទី"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "១ ម៉ោង"
 
-#: ../panels/power/power.ui.h:7
-msgid "Don't suspend"
-msgstr "កុំ​ផ្អាក"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "១០ នាទី"
 
-#: ../panels/power/power.ui.h:8
-msgid "On battery power"
-msgstr "នៅ​លើ​ថាមពល​ថ្ម"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "១០ នាទី"
 
-#: ../panels/power/power.ui.h:9
-msgid "When plugged in"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "១០ នាទី"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "១ ម៉ោង"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "ថ្ម"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ឧបករណ៍"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "បិទ​ថាមពល"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "ជម្រើស​ចូល"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "ការ​កំណត់​រចនាសម្ព័ន្ធ​ស្វ័យប្រវត្តិ"
+
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "ការ​កំណត់​ពន្លឺ​អេក្រង់ និង​ការ​ចាក់សោ"
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "អេក្រង់ ១/៤"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "ការ​ក្រិត​ខ្នាត​អេក្រង់"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "ស្វ័យប្រវត្តិ"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "ប៊ូតុង​ខាងក្រោម"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+#, fuzzy
+msgid "Automatic Suspend"
+msgstr "ស្វ័យប្រវត្តិ"
+
+#: panels/power/cc-power-panel.ui:267
+#, fuzzy
+msgid "_Plugged In"
 msgstr "នៅ​ពេល​បាន​ដោត"
 
-#: ../panels/power/power.ui.h:10
-msgid "Suspend when inactive for"
-msgstr "ផ្អាក នៅ​ពេល​អសកម្ម"
+#: panels/power/cc-power-panel.ui:279
+#, fuzzy
+msgid "On _Battery Power"
+msgstr "នៅ​លើ​ថាមពល​ថ្ម"
 
-#: ../panels/power/power.ui.h:11
-msgid "When power is _critically low"
-msgstr "នៅ​ពេល​ថាមពល​កាន់​តែ​ខ្សោយ​ខ្លាំង"
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "ពន្យារពេល ៖"
 
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:589
-msgid "Low on toner"
-msgstr "ជិត​អស់​ទឹក​ថ្នាំ"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "ថាមពល"
 
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:591
-msgid "Out of toner"
-msgstr "អស់​ទឹក​ថ្នាំ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:594
-msgid "Low on developer"
-msgstr "ជិត​អស់​ទឹក​ថ្នាំ​លាង​ហ្វីល"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:597
-msgid "Out of developer"
-msgstr "អស់​ទឹក​ថ្នាំ​លាង​ហ្វីល"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:599
-msgid "Low on a marker supply"
-msgstr "ជិត​អស់​សញ្ញា​សម្គាល់"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:601
-msgid "Out of a marker supply"
-msgstr "អស់​សញ្ញា​សម្គាល់"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:603
-msgid "Open cover"
-msgstr "បើក​គម្រប"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:605
-msgid "Open door"
-msgstr "បើក​គម្រប"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:607
-msgid "Low on paper"
-msgstr "ជិត​អស់​ក្រដាស"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:609
-msgid "Out of paper"
-msgstr "អស់​ក្រដាស"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:611
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ក្រៅបណ្ដាញ"
-
-#. Translators: Someone has paused the Printer
-#: ../panels/printers/cc-printers-panel.c:613
-msgctxt "printer state"
-msgid "Paused"
-msgstr "បាន​ផ្អាក"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:615
-msgid "Waste receptacle almost full"
-msgstr "ធុងសំរាម​ជិត​ពេញ"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:617
-msgid "Waste receptacle full"
-msgstr "ធុងសំរាម​ពេញ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:619
-msgid "The optical photo conductor is near end of life"
-msgstr "អង្គធាតុ​ចម្លង​រូបថត​អុបទិក​ជិត​អស់​អាយុកាល"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:621
-msgid "The optical photo conductor is no longer functioning"
-msgstr "អង្គធាតុ​ចម្លង​រូបថត​អុបទិក​លែង​ដំណើរការ"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:724
-#| msgid "_Configuration URL"
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "កំណត់​រចនាសម្ព័ន្ធ"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:781
-msgctxt "printer state"
-msgid "Ready"
-msgstr "រួចហើយ"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:785
-msgctxt "printer state"
-msgid "Processing"
-msgstr "ដំណើរការ"
-
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:789
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "បញ្ឈប់"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:906
-msgid "Toner Level"
-msgstr "កម្រិត​ទឹកថ្នាំ"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:909
-msgid "Ink Level"
-msgstr "កម្រិត​ទឹក​ខ្មៅ"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:912
-msgid "Supply Level"
-msgstr "កម្រិត​ផ្គត់ផ្គង់"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:930
-#| msgid "Install languages..."
-msgctxt "printer state"
-msgid "Installing"
-msgstr "ដំឡើង​"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1107
-msgid "No printers available"
-msgstr "គ្មាន​ម៉ាស៊ីន​បោះពុម្ព​ដែល​អាច​ប្រើ​បាន"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1411
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u សកម្ម"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1731
-msgid "Failed to add new printer."
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព​ថ្មី ។"
-
-#: ../panels/printers/cc-printers-panel.c:1896
-#| msgid "Select ICC Profile File"
-msgid "Select PPD File"
-msgstr "ជ្រើស​ឯកសារ​ PPD"
-
-#: ../panels/printers/cc-printers-panel.c:1905
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
 msgstr ""
-"ឯកសារ​ពណ៌នា​​របស់​ម៉ាស៊ីន​បោះពុម្ព PostScript (*.ppd, *.PPD, *.ppd.gz, "
-"*.PPD.gz, *.PPD.GZ)"
 
-#: ../panels/printers/cc-printers-panel.c:2210
-#| msgid "No local printers found"
-msgid "No suitable driver found"
-msgstr "រក​មិន​ឃើញ​កម្មវិធី​បញ្ជា​សមរម្យ"
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "Power;Sleep;Suspend;Hibernate;Battery;"
 
-#: ../panels/printers/cc-printers-panel.c:2279
-msgid "Searching for preferred drivers..."
-msgstr "កំពុង​ស្វែងរក​កម្មវិធី​បញ្ជា​ដែល​​ចង់​បាន..."
-
-#: ../panels/printers/cc-printers-panel.c:2294
-msgid "Select from database..."
-msgstr "ជ្រើស​ពី​មូលដ្ឋាន​ទិន្នន័យ..."
-
-#: ../panels/printers/cc-printers-panel.c:2303
-#| msgid "Browse Files..."
-msgid "Provide PPD File..."
-msgstr "ផ្ដល់​ឯកសារ PPD..."
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2454
-#: ../panels/printers/cc-printers-panel.c:2477
-msgid "Test page"
-msgstr "ទំព័រ​សាកល្បង"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2880
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "មិន​អាច​ផ្ទុក ui ៖ %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "ម៉ាស៊ីន​បោះពុម្ព"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
-msgid "Change printer settings"
-msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​ម៉ាស៊ីន​បោះពុម្ព"
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
 
-#: ../panels/printers/jobs-dialog.ui.h:1
-#: ../panels/printers/options-dialog.ui.h:1
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/printers/jobs-dialog.ui.h:2
-#: ../panels/printers/options-dialog.ui.h:4
-msgid "Close"
-msgstr "បិទ"
-
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:4
-#| msgid "Active Print Jobs"
-msgid "Active Jobs"
-msgstr "ការងារសកម្ម"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Resume Printing"
-msgstr "បន្ត​ការ​បោះពុម្ព"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Pause Printing"
-msgstr "ផ្អាក​ការ​បោះពុម្ព"
-
-#: ../panels/printers/jobs-dialog.ui.h:7
-msgid "Cancel Print Job"
-msgstr "បោះបង់​ការងារ​បោះពុម្ព"
-
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1017
-msgid "_Add"
-msgstr "បន្ថែម"
-
-#: ../panels/printers/new-printer-dialog.ui.h:3
-msgid "Add a New Printer"
-msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព​ថ្មី"
-
-#: ../panels/printers/new-printer-dialog.ui.h:4
-#| msgid "No network printers found"
-msgid "Search for network printers or filter result"
-msgstr "ស្វែងរក​ម៉ាស៊ីន​បោះពុម្ព​បណ្ដាញ​ ឬ​លទ្ធផល​តម្រង"
-
-#: ../panels/printers/options-dialog.ui.h:2
-#| msgid "_Options"
-msgid "Options"
-msgstr "ជម្រើស"
-
-#: ../panels/printers/options-dialog.ui.h:3
-#| msgid "Locations..."
-msgid "Loading options..."
-msgstr "កំពុង​ផ្ទុក​ជម្រើស..."
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-#: ../panels/user-accounts/um-account-dialog.c:1016
-msgid "Cancel"
-msgstr "បោះបង់"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "កំពុង​ផ្ទុក​មូលដ្ឋាន​ទិន្នន័យ​កម្មវិធី​បញ្ជា..."
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:5
-#| msgid "Selecting finger"
-msgid "Select Printer Driver"
-msgstr "ជ្រើស​កម្មវិធី​បញ្ហា​ម៉ាស៊ីន​បោះពុម្ព"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:65
-#: ../panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "តែ​ម្ខាង"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:67
-#: ../panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Long Edge (ស្តង់ដារ)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:69
-#: ../panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Short Edge (ត្រឡប់)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:71
-msgid "Portrait"
-msgstr "បញ្ឈរ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:73
-msgid "Landscape"
-msgstr "ផ្ដេក"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:75
-msgid "Reverse landscape"
-msgstr "បញ្ច្រាស​ផ្ដេក"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:77
-msgid "Reverse portrait"
-msgstr "បញ្ច្រាស​បញ្ឈរ"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:143
-msgctxt "print job"
-msgid "Pending"
-msgstr "កំពុង​រង់ចាំ"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:147
-msgctxt "print job"
-msgid "Held"
-msgstr "រង់ចាំ"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:151
-msgctxt "print job"
-msgid "Processing"
-msgstr "ដំណើរការ"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:155
-msgctxt "print job"
-msgid "Stopped"
-msgstr "បញ្ឈប់"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:159
-msgctxt "print job"
-msgid "Canceled"
-msgstr "បោះបង់"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:163
-msgctxt "print job"
-msgid "Aborted"
-msgstr "បោះបង់"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:167
-msgctxt "print job"
-msgid "Completed"
-msgstr "បាន​បញ្ចប់"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:289
-msgid "Job Title"
-msgstr "ចំណងជើង​ការងារ"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:298
-msgid "Job State"
-msgstr "ស្ថានភាព​ការងារ"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:304
-msgid "Time"
-msgstr "ពេលវេលា"
-
-#: ../panels/printers/pp-jobs-dialog.c:484
-#, c-format
-#| msgid "Active Print Jobs"
-msgid "%s Active Jobs"
-msgstr "ការងារ​សកម្ម %s"
-
-#. Translators: No printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1291
-#| msgid "No tablet detected"
-msgid "No printers detected."
-msgstr "រក​មិ​ន​ឃើញ​ម៉ាស៊ីន​បោះពុម្ព"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Two Sided"
-msgstr "ទាំង​សងខាង"
-
-#: ../panels/printers/pp-options-dialog.c:83
-#| msgid "VPN Type"
-msgid "Paper Type"
-msgstr "ប្រភេទ​ក្រដាស"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Paper Source"
-msgstr "ប្រភព​ក្រដាស"
-
-#: ../panels/printers/pp-options-dialog.c:85
-#| msgid "Output"
-msgid "Output Tray"
-msgstr "ថាស​លទ្ធផល"
-
-#: ../panels/printers/pp-options-dialog.c:86
-#| msgid "_Resolution"
-msgid "Resolution"
-msgstr "គុណភាព​បង្ហាញ"
-
-#: ../panels/printers/pp-options-dialog.c:87
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript pre-filtering"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:533
-msgid "Pages per side"
-msgstr "ទំព័រ​ក្នុង​ម្ខាង"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:545
-msgid "Two-sided"
-msgstr "ទាំង​សងខាង"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:557
-#| msgid "Left-Handed Orientation"
-msgid "Orientation"
-msgstr "ទិស​"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:654
-#| msgid "General"
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "ទូទៅ"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "រៀបចំ​ទំព័រ"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:660
-#| msgid "Printer Options"
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "ជម្រើស​បាន​ដំឡើង"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:663
-#| msgid "Jobs"
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "ការងារ"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "គុណភាព​រូបភាព"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:669
-#| msgid "Color"
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "ពណ៌"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "បញ្ចប់"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:675
-#| msgctxt "print job"
-#| msgid "Canceled"
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "កម្រិត​ខ្ពស់"
-
-#. Translators: Options of given printer (e.g. "MyPrinter Options")
-#: ../panels/printers/pp-options-dialog.c:936
-#, c-format
-#| msgid "_Options"
-msgid "%s Options"
-msgstr "%s ជម្រើស"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:75
-#: ../panels/printers/pp-ppd-option-widget.c:77
-#: ../panels/printers/pp-ppd-option-widget.c:85
-#| msgid "Select"
-msgid "Auto Select"
-msgstr "ជ្រើស​ស្វ័យ​ប្រវត្តិ"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:79
-#: ../panels/printers/pp-ppd-option-widget.c:81
-#: ../panels/printers/pp-ppd-option-widget.c:83
-#: ../panels/printers/pp-ppd-option-widget.c:87
-#| msgid "Default"
-msgid "Printer Default"
-msgstr "ម៉ាស៊ីន​បោះពុម្ព​លំនាំដើម"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "បញ្ចប់​តែ​ពុម្ពអក្សរ GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "បម្លែង​ទៅ PS កម្រិត ១"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "បម្លែង​ទៅជា PS កម្រិត​ ២"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:95
-#| msgid "No profile"
-msgid "No pre-filtering"
-msgstr "គ្មាន​​តម្រង​ជា​មុន"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:230
-#| msgid "Manufacturer:"
-msgid "Manufacturers"
-msgstr "ក្រុមហ៊ុនផលិត"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:242
-#| msgid "Driver"
-msgid "Drivers"
-msgstr "កម្មវិធី​បញ្ជា"
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "យក​ម៉ាស៊ីន​បោះពុម្ព​ចេញ"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "ការ​ផ្គត់ផ្គង់"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "ម៉ាស៊ីន​បោះពុម្ព"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "តម្រូវឲ្យ​ផ្ទៀងផ្ទាត់​ភាព​ត្រឹមត្រូវ"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ឈ្មោះ​អ្នកប្រើ"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "ទីតាំង"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default"
-msgstr "លំនាំដើម"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "កម្មវិធី​បញ្ជា"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "ការងារ"
+#: panels/printers/pp-details-dialog.ui:178
+#, fuzzy
+msgid "Searching for preferred drivers…"
+msgstr "កំពុង​ស្វែងរក​កម្មវិធី​បញ្ជា​ដែល​​ចង់​បាន..."
 
-#. Tanslators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "_Show"
-msgstr "បង្ហាញ"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "កំពុង​ស្វែងរក​កម្មវិធី​បញ្ជា​ដែល​​ចង់​បាន..."
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "ជ្រើស​ពី​មូលដ្ឋាន​ទិន្នន័យ..."
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "ជ្រើស​កម្មវិធី​បញ្ហា​ម៉ាស៊ីន​បោះពុម្ព"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "កំពុង​ផ្ទុក​មូលដ្ឋាន​ទិន្នន័យ​កម្មវិធី​បញ្ជា..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "បោះបង់"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "ជ្រើស"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "ដែន"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ផ្ទៀងផ្ទាត់"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ផ្ទៀងផ្ទាត់"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "ការងារ​សកម្ម %s"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "ទំព័រ​សាកល្បង"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "ជម្រើស​ចូល"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "ម៉ាស៊ីន​បោះពុម្ព​លំនាំដើម"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "ម៉ាស៊ីន​បោះពុម្ព​លំនាំដើម"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "បោះបង់​ការងារ​បោះពុម្ព"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "យក​ម៉ាស៊ីន​បោះពុម្ព​ចេញ"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "ការងារសកម្ម"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "ម៉ូដែល"
 
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "ទំព័រ ១"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "កម្រិត​ទឹក​ខ្មៅ"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "ស្លាក"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "ទំព័រ ២"
-
-#: ../panels/printers/printers.ui.h:17
-#| msgid "Getting devices..."
-msgid "Setting new driver..."
-msgstr "កំពុង​កំណត់​កម្មវិធី​បញ្ជា​ថ្មី..."
-
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "ទំព័រ​ ៣"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "បោះពុម្ព​ទំព័រ​សាកល្បង"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "ជម្រើស"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព​ថ្មី"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​ម៉ាស៊ីន​បោះពុម្ព"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "ម៉ាស៊ីន​បោះពុម្ព"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "សូម​អភ័យទោស ! សេវា​បោះពុម្ព​តាម​ប្រព័ន្ធ\n"
 "ហាក់​ដូចជា​មិន​ដំណើរការ ។"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
-#| msgid "Region and Language"
-msgid "Region & Language"
-msgstr "តំបន់ និង​ភាសា"
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid "Change your region and language settings"
-msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​តំបន់ និង​ភាសា​របស់​អ្នក"
-
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-msgid "Language;Layout;Keyboard;"
-msgstr "Language;Layout;Keyboard;"
-
-#: ../panels/region/gnome-region-panel-formats.c:142
-msgid "Imperial"
-msgstr "កម្រិត​ខ្ពស់"
-
-#: ../panels/region/gnome-region-panel-formats.c:144
-msgid "Metric"
-msgstr "ម៉ែត្រ"
-
-#: ../panels/region/gnome-region-panel-input-chooser.ui.h:1
-#| msgid "Select an input source to add"
-msgid "Choose an input source"
-msgstr "ជ្រើស​ប្រភព​បញ្ចូល"
-
-#: ../panels/region/gnome-region-panel-input-chooser.ui.h:2
-msgid "Select an input source to add"
-msgstr "ជ្រើស​ប្រភព​បញ្ចូល ដើម្បី​បន្ថែម"
-
-#: ../panels/region/gnome-region-panel-system.c:330
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings."
-msgstr "អេក្រង់​ចូល គណនី​ប្រព័ន្ធ និង​គណនី​អ្នកប្រើ​ថ្មី​ប្រើ​ការ​កំណត់​តំបន់ និង​ភាសា​ទូទាំង​ប្រព័ន្ធ ។"
-
-#: ../panels/region/gnome-region-panel-system.c:335
-#: ../panels/region/gnome-region-panel.ui.h:31
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings. You may change the system settings to match "
-"yours."
-msgstr ""
-"អេក្រង់​ចូល គណនី​ប្រព័ន្ធ និង​គណនី​អ្នកប្រើ​ថ្មី​ប្រើ​ការ​កំណត់​តំបន់ និង​ភាសា​ទូទាំង​ប្រព័ន្ធ ។ អ្នក​អាច​ផ្លាស់ប្ដូរ​ការ​"
-"កំណត់​ប្រព័ន្ធ​ទៅតាម​តម្រូវការ​របស់​អ្នក​បាន ។"
-
-#: ../panels/region/gnome-region-panel-system.c:338
-msgid "Copy Settings"
-msgstr "ចម្លង​ការ​កំណត់"
-
-#: ../panels/region/gnome-region-panel-system.c:341
-#: ../panels/region/gnome-region-panel.ui.h:38
-msgid "Copy Settings..."
-msgstr "ចម្លង​ការ​កំណត់..."
-
-#: ../panels/region/gnome-region-panel.ui.h:1
-msgid "Region and Language"
-msgstr "តំបន់ និង​ភាសា"
-
-#: ../panels/region/gnome-region-panel.ui.h:2
-msgid "Select a display language (change will be applied next time you log in)"
-msgstr "ជ្រើស​ភាសា (ការ​ផ្លាស់ប្ដូរ​នឹង​ត្រូវ​បាន​អនុវត្ត​ នៅ​ពេល​ដែល​អ្នក​ចូល​លើក​ក្រោយ)"
-
-#: ../panels/region/gnome-region-panel.ui.h:3
-msgid "Add Language"
-msgstr "បន្ថែម​ភាសា"
-
-#: ../panels/region/gnome-region-panel.ui.h:4
-msgid "Remove Language"
-msgstr "យក​ភាសា​ចេញ"
-
-#: ../panels/region/gnome-region-panel.ui.h:5
-msgid "Install languages..."
-msgstr "ដំឡើង​ភាសា..."
-
-#: ../panels/region/gnome-region-panel.ui.h:6
-msgid "Language"
-msgstr "ភាសា"
-
-#: ../panels/region/gnome-region-panel.ui.h:7
-msgid "Select a region (change will be applied the next time you log in)"
-msgstr "ជ្រើស​តំបន់ (ការ​ផ្លាស់ប្ដូរ​នឹង​ត្រូវ​បាន​អនុវត្ត នៅ​ពេល​ដែល​អ្នក​ចូល​លើកក្រោយ)"
-
-#: ../panels/region/gnome-region-panel.ui.h:8
-msgid "Add Region"
-msgstr "បន្ថែម​តំបន់"
-
-#: ../panels/region/gnome-region-panel.ui.h:9
-msgid "Remove Region"
-msgstr "យក​តំបន់​ចេញ"
-
-#: ../panels/region/gnome-region-panel.ui.h:10
-msgid "Dates"
-msgstr "កាលបរិច្ឆេទ"
-
-#: ../panels/region/gnome-region-panel.ui.h:11
-msgid "Times"
-msgstr "ពេលវេលា"
-
-#: ../panels/region/gnome-region-panel.ui.h:12
-msgid "Numbers"
-msgstr "លេខ"
-
-#: ../panels/region/gnome-region-panel.ui.h:13
-msgid "Currency"
-msgstr "រូបិយប័ណ្ណ"
-
-#: ../panels/region/gnome-region-panel.ui.h:14
-msgid "Measurement"
-msgstr "រង្វាស់"
-
-#: ../panels/region/gnome-region-panel.ui.h:15
-msgid "Examples"
-msgstr "ឧទាហរណ៍"
-
-#: ../panels/region/gnome-region-panel.ui.h:16
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ទ្រង់ទ្រាយ"
 
-#: ../panels/region/gnome-region-panel.ui.h:17
-#| msgid "Select an input source to add"
-msgid "Select keyboards or other input sources"
-msgstr "ជ្រើស​ក្ដារចុច ឬ​ប្រភព​បញ្ចូល​ផ្សេង​ទៀត"
-
-#: ../panels/region/gnome-region-panel.ui.h:18
-#| msgid "Input source:"
-msgid "Add Input Source"
-msgstr "បន្ថែម​ប្រភព​បញ្ចូល"
-
-#: ../panels/region/gnome-region-panel.ui.h:19
-#| msgid "Input source:"
-msgid "Remove Input Source"
-msgstr "យក​ប្រភព​បញ្ចូល​ចេញ"
-
-#: ../panels/region/gnome-region-panel.ui.h:20
-#| msgid "Input source:"
-msgid "Move Input Source Up"
-msgstr "ផ្លាស់ទី​ប្រភព​បញ្ចូល​ឡើង​លើ"
-
-#: ../panels/region/gnome-region-panel.ui.h:21
-#| msgid "Input source:"
-msgid "Move Input Source Down"
-msgstr "ផ្លាស់ទី​ប្រភព​បញ្ចូល​ចុះក្រោម"
-
-#: ../panels/region/gnome-region-panel.ui.h:22
-#| msgid "Mouse Settings"
-msgid "Input Source Settings"
-msgstr "បញ្ចូល​ការ​កំណត់​ប្រភព"
-
-#: ../panels/region/gnome-region-panel.ui.h:23
-#| msgid "Keyboard Layout"
-msgid "Show Keyboard Layout"
-msgstr "បង្ហាញ​ប្លង់​ក្ដារចុច"
-
-#: ../panels/region/gnome-region-panel.ui.h:25
-msgid "Ctrl+Alt+Space"
-msgstr "បញ្ជា (Ctrl)+ជំនួស (Alt)+ដកឃ្លា (Space)"
-
-#: ../panels/region/gnome-region-panel.ui.h:27
-msgid "Ctrl+Alt+Shift+Space"
-msgstr "បញ្ជា(Ctrl)+ជំនួស(Alt)+ប្ដូរ(Shift)+ដកឃ្លា(Space)"
-
-#: ../panels/region/gnome-region-panel.ui.h:28
-#| msgid "Sound Settings"
-msgid "Shortcut Settings"
-msgstr "ការ​កំណត់​ផ្លូវ​កាត់"
-
-#: ../panels/region/gnome-region-panel.ui.h:30
-#| msgid "Input source:"
-msgid "Input Sources"
-msgstr "ប្រភព​បញ្ចូល"
-
-#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
-#: ../panels/region/gnome-region-panel.ui.h:33
-msgid "Display language:"
-msgstr "ភាសា​បង្ហាញ ៖"
-
-#: ../panels/region/gnome-region-panel.ui.h:34
-msgid "Input source:"
-msgstr "ប្រភព​បញ្ចូល ៖"
-
-#: ../panels/region/gnome-region-panel.ui.h:35
-msgid "Format:"
-msgstr "ទ្រង់ទ្រាយ ៖"
-
-#: ../panels/region/gnome-region-panel.ui.h:36
-msgid "Your settings"
-msgstr "ការ​កំណត់​របស់​អ្នក"
-
-#: ../panels/region/gnome-region-panel.ui.h:37
-msgid "System settings"
-msgstr "ការ​កំណត់​ប្រព័ន្ធ"
-
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:1
-#| msgid "Brightness and Lock"
-msgid "Brightness & Lock"
-msgstr "ពន្លឺ និង​ការ​ចាក់សោ"
-
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
-msgid "Screen brightness and lock settings"
-msgstr "ការ​កំណត់​ពន្លឺ​អេក្រង់ និង​ការ​ចាក់សោ"
-
-#. Translators: those are keywords for the brightness and lock control-center panel
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
-msgid "Brightness;Lock;Dim;Blank;Monitor;"
-msgstr "Brightness;Lock;Dim;Blank;Monitor;"
-
-#: ../panels/screen/screen.ui.h:1
-msgid "Screen turns off"
-msgstr "បិទ​អេក្រង់"
-
-#: ../panels/screen/screen.ui.h:2
-msgid "30 seconds"
-msgstr "៣០ វិនាទី"
-
-#: ../panels/screen/screen.ui.h:3
-msgid "1 minute"
-msgstr "១ នាទី"
-
-#: ../panels/screen/screen.ui.h:4
-msgid "2 minutes"
-msgstr "២ នាទី"
-
-#: ../panels/screen/screen.ui.h:5
-msgid "3 minutes"
-msgstr "៣ នាទី"
-
-#: ../panels/screen/screen.ui.h:10
-msgid "_Dim screen to save power"
-msgstr "ធ្វើឲ្យ​អេក្រង់​ស្រអាប់ ដើម្បី​សន្សំ​ថាមពល"
-
-#: ../panels/screen/screen.ui.h:11
-msgid "Brightness"
-msgstr "ពន្លឺ"
-
-#: ../panels/screen/screen.ui.h:12
-msgid "_Turn screen off when inactive for:"
-msgstr "បិទ​អេក្រង់ នៅ​ពេល​អសកម្ម ៖"
-
-#: ../panels/screen/screen.ui.h:13
-msgid "_Lock screen after:"
-msgstr "ចាក់​សោ​អេក្រង់​បន្ទាប់ពី ៖"
-
-#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
-#: ../panels/screen/screen.ui.h:15
-msgid "Don't lock when at home"
-msgstr "កុំ​ចាក់​សោ នៅ​ពេល​អ្នក​នៅ​ផ្ទះ"
-
-#: ../panels/screen/screen.ui.h:16
-msgid "Locations..."
-msgstr "ទីតាំង..."
-
-#: ../panels/screen/screen.ui.h:17
-msgid "Show _notifications when locked"
-msgstr "បង្ហាញ​ការ​ជូន​ដំណឹង​នៅ​ពេល​ចាក់សោ"
-
-#: ../panels/screen/screen.ui.h:18
-msgid "Lock"
-msgstr "ចាក់សោ"
-
-#: ../panels/sound/applet-main.c:49
-msgid "Enable debugging code"
-msgstr "បើក​កូដ​បំបាត់​កំហុស"
-
-#: ../panels/sound/applet-main.c:50
-msgid "Version of this application"
-msgstr "កំណែ​កម្មវិធី​នេះ"
-
-#: ../panels/sound/applet-main.c:62
-msgid " — GNOME Volume Control Applet"
-msgstr " អាប់ភ្លេត​គ្រប់គ្រង​កម្រិត​សំឡេង​របស់  — GNOME"
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
-msgid "Volume Control"
-msgstr "កា​រ​គ្រប់គ្រង​កម្រិត​សំឡេង"
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
-msgid "Show desktop volume control"
-msgstr "បង្ហាញ​ការ​គ្រប់គ្រង​កម្រិត​សំឡេង​នៅ​លើ​ផ្ទៃតុ"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "សំឡេង"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound volume and sound events"
-msgstr "ផ្លាស់ប្ដូរ​កម្រិត​សំឡេង ​និង​ព្រឹត្តិការណ៍​សំឡេង"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-#| msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
-
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "ឆ្កែ​ព្រុស"
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "តំណក់​ទឹក"
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "គោះ​កែវ"
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "សូរណា"
-
-#: ../panels/sound/gvc-applet.c:270 ../panels/sound/gvc-mixer-dialog.c:1656
-msgid "Output"
-msgstr "បញ្ចេញ"
-
-#: ../panels/sound/gvc-applet.c:272
-msgid "Sound Output Volume"
-msgstr "កម្រិត​បញ្ចេញ​សំឡេង"
-
-#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1697
-msgid "Input"
-msgstr "បញ្ចូល"
-
-#: ../panels/sound/gvc-applet.c:278
-msgid "Microphone Volume"
-msgstr "កម្រិត​សំឡេង​មីក្រូហ្វូន"
-
-#: ../panels/sound/gvc-balance-bar.c:111
-msgctxt "balance"
-msgid "Left"
-msgstr "ឆ្វេង"
-
-#: ../panels/sound/gvc-balance-bar.c:112
-msgctxt "balance"
-msgid "Right"
-msgstr "ស្ដាំ"
-
-#: ../panels/sound/gvc-balance-bar.c:115
-msgctxt "balance"
-msgid "Rear"
-msgstr "ខាង​ក្រោយ"
-
-#: ../panels/sound/gvc-balance-bar.c:116
-msgctxt "balance"
-msgid "Front"
-msgstr "ខាងមុខ"
-
-#: ../panels/sound/gvc-balance-bar.c:119
-msgctxt "balance"
-msgid "Minimum"
-msgstr "អប្បបរមា"
-
-#: ../panels/sound/gvc-balance-bar.c:120
-msgctxt "balance"
-msgid "Maximum"
-msgstr "អតិបរមា"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Balance:"
-msgstr "តុល្យភាព ៖"
-
-#: ../panels/sound/gvc-balance-bar.c:298
-msgid "_Fade:"
-msgstr "សំឡេង​ថយ ៖"
-
-#: ../panels/sound/gvc-balance-bar.c:301
-msgid "_Subwoofer:"
-msgstr "Subwoofer ៖"
-
-#: ../panels/sound/gvc-channel-bar.c:613 ../panels/sound/gvc-channel-bar.c:622
-msgctxt "volume"
-msgid "100%"
-msgstr "១០០%"
-
-#: ../panels/sound/gvc-channel-bar.c:617
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "មិន​ពង្រីក"
-
-#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:521
-msgid "_Profile:"
-msgstr "ទម្រង់ ៖"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1841
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "បញ្ចេញ %u"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1851
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "បញ្ចូល %u"
-
-#: ../panels/sound/gvc-mixer-control.c:2375
-msgid "System Sounds"
-msgstr "សំឡេង​របស់​ប្រព័ន្ធ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "សាកល្បង​ធុងបាស"
-
-#: ../panels/sound/gvc-mixer-dialog.c:426
-msgid "Peak detect"
-msgstr "រក​ឃើញ​កម្រិត​សំឡេង​ខ្ពស់​បំផុត"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1506
-#: ../panels/sound/gvc-sound-theme-chooser.c:595
-msgid "Name"
-msgstr "ឈ្មោះ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1588
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "សាកល្បង​ធុងបាស​សម្រាប់ %s"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1642
-msgid "_Output volume:"
-msgstr "កម្រិត​បញ្ចេញ​សំឡេង ៖"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1661
-msgid "C_hoose a device for sound output:"
-msgstr "ជ្រើស​ឧបករណ៍​សម្រាប់​​បញ្ចេញ​សំឡេង ៖"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1686
-msgid "Settings for the selected device:"
-msgstr "ការ​កំណត់​សម្រាប់​ឧបករណ៍​ដែល​បាន​ជ្រើស ៖"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "_Input volume:"
-msgstr "កម្រិត​បញ្ចូល​សំឡេង ៖"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1727
-msgid "Input level:"
-msgstr "កម្រិត​បញ្ចូល ៖"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1755
-msgid "C_hoose a device for sound input:"
-msgstr "ជ្រើស​ឧបករណ៍​សម្រាប់​បញ្ចូល​សំឡេង ៖"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1782
-msgid "Sound Effects"
-msgstr "បែបផែន​សំឡេង"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "_Alert volume:"
-msgstr "កម្រិត​សំឡេង​ព្រមាន ៖"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1802
-msgid "Applications"
-msgstr "កម្មវិធី"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1806
-msgid "No application is currently playing or recording audio."
-msgstr "បច្ចុប្បន្ន​គ្មាន​កម្មវិធី​ដែល​កំពុង​ចាក់ ឬ​ថត​ចម្លង​អូឌីយ៉ូ​ទេ ។"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:189
-msgid "Built-in"
-msgstr "ភ្ជាប់​មក​ជាមួយ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:455
-#: ../panels/sound/gvc-sound-theme-chooser.c:467
-#: ../panels/sound/gvc-sound-theme-chooser.c:479
-msgid "Sound Preferences"
-msgstr "ចំណូលចិត្ត​សំឡេង"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:458
-#: ../panels/sound/gvc-sound-theme-chooser.c:469
-#: ../panels/sound/gvc-sound-theme-chooser.c:481
-msgid "Testing event sound"
-msgstr "សាកល្បង​សំឡេង​ព្រឹត្តិការណ៍"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "Default"
-msgstr "លំនាំដើម"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:586
-msgid "From theme"
-msgstr "ពី​ស្បែក"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:770
-msgid "C_hoose an alert sound:"
-msgstr "ជ្រើស​សំឡេង​ព្រមាន ៖"
-
-#: ../panels/sound/gvc-speaker-test.c:220
-msgid "Stop"
-msgstr "បញ្ឈប់"
-
-#: ../panels/sound/gvc-speaker-test.c:220
-#: ../panels/sound/gvc-speaker-test.c:332
-msgid "Test"
-msgstr "សាកល្បង"
-
-#: ../panels/sound/gvc-speaker-test.c:228
-msgid "Subwoofer"
-msgstr "Subwoofer"
-
-#: ../panels/sound/gvc-stream-status-icon.c:236
-#, c-format
-msgid "Failed to start Sound Preferences: %s"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម​ចំណូលចិត្ត​សំឡេង ៖ %s"
-
-#: ../panels/sound/gvc-stream-status-icon.c:262
-msgid "_Mute"
-msgstr "ស្ងាត់"
-
-#: ../panels/sound/gvc-stream-status-icon.c:271
-msgid "_Sound Preferences"
-msgstr "ចំណូលចិត្ត​សំឡេង"
-
-#: ../panels/sound/gvc-stream-status-icon.c:416
-msgid "Muted"
-msgstr "ស្ងាត់"
-
-#: ../panels/sound/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr "ផ្ទាល់ខ្លួន"
-
-#: ../panels/universal-access/cc-ua-panel.c:286
-#: ../panels/universal-access/cc-ua-panel.c:292
-msgid "No shortcut set"
-msgstr "គ្មាន​ការ​កំណត់​ផ្លូវកាត់"
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Universal Access Preferences"
-msgstr "ចំណូលចិត្ត​ចូល​ដំណើរការ​សកល"
-
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
-msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
-"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
 msgstr ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
-"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "ទាប"
-
-#: ../panels/universal-access/uap.ui.h:2
-msgctxt "universal access, contrast"
-msgid "Normal"
-msgstr "ធម្មតា"
-
-#: ../panels/universal-access/uap.ui.h:3
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "ខ្ពស់"
-
-#: ../panels/universal-access/uap.ui.h:4
-msgctxt "universal access, contrast"
-msgid "High/Inverse"
-msgstr "ខ្ពស់/ច្រាស"
-
-#: ../panels/universal-access/uap.ui.h:5
-msgid "On screen keyboard"
-msgstr "ក្ដារចុច​លើ​អេក្រង់"
-
-#: ../panels/universal-access/uap.ui.h:6
-msgid "GOK"
-msgstr "GOK"
-
-#: ../panels/universal-access/uap.ui.h:7
-msgid "OnBoard"
-msgstr "OnBoard"
-
-#: ../panels/universal-access/uap.ui.h:8
-msgid "None"
-msgstr "គ្មាន"
-
-#: ../panels/universal-access/uap.ui.h:10
-#, no-c-format
-msgid "75%"
-msgstr "៧៥%"
-
-#: ../panels/universal-access/uap.ui.h:11
-msgctxt "universal access, text size"
-msgid "Small"
-msgstr "តូច"
-
-#: ../panels/universal-access/uap.ui.h:13
-#, no-c-format
-msgid "100%"
-msgstr "១០០%"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgctxt "universal access, text size"
-msgid "Normal"
-msgstr "ធម្មតា"
-
-#: ../panels/universal-access/uap.ui.h:16
-#, no-c-format
-msgid "125%"
-msgstr "១២៥%"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgctxt "universal access, text size"
-msgid "Large"
-msgstr "ធំ"
-
-#: ../panels/universal-access/uap.ui.h:19
-#, no-c-format
-msgid "150%"
-msgstr "១៥០%"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgctxt "universal access, text size"
-msgid "Larger"
-msgstr "ធំជាង"
-
-#: ../panels/universal-access/uap.ui.h:21
-#| msgid "_Contrast:"
-msgid "High Contrast"
-msgstr "កម្រិត​ពណ៌"
-
-#: ../panels/universal-access/uap.ui.h:22
-#| msgid "Beep when Caps and Num Lock are used"
-msgid "Beep on Caps and Num Lock"
-msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​ប្ដូរ​ជាប់ និង​លេខ​ ( Caps and Num Lock) ត្រូវ​បាន​ប្រើ"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "Options..."
-msgstr "ជម្រើស..."
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Screen Reader"
-msgstr "កម្មវិធី​អាន​អេក្រង់"
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Turn on or off:"
-msgstr "បើក ឬ​បិទ"
-
-#: ../panels/universal-access/uap.ui.h:26
-#| msgid "Zoom"
-msgctxt "universal access, zoom"
-msgid "Zoom"
-msgstr "ពង្រីក"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Zoom in:"
-msgstr "ពង្រីក ៖"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "Zoom out:"
-msgstr "បង្រួម ៖"
-
-#: ../panels/universal-access/uap.ui.h:29
-#| msgid "Large"
-msgid "Large Text"
-msgstr "អត្ថបទ​ធំ"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "Seeing"
-msgstr "មើលឃើញ"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Visual Alerts"
-msgstr "ការ​ព្រមាន​ដែល​មើល​ឃើញ"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Use a visual indication when an alert sound occurs"
-msgstr "ប្រើ​ការ​បង្ហាញ​ដែល​មើល​ឃើញ នៅ​ពេល​សំឡេង​ព្រមាន​កើត​ឡើង"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Flash the window title"
-msgstr "បញ្ចេញ​ពន្លឺ​លើ​ចំណង​ជើង​បង្អួច"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Flash the entire screen"
-msgstr "បញ្ចេញ​ពន្លឺ​ទូទាំង​អេក្រង់"
-
-#: ../panels/universal-access/uap.ui.h:35
-msgid "Closed Captioning"
-msgstr "បាន​បិទ​ដាក់​ចំណងជើង"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Display a textual description of speech and sounds"
-msgstr "បង្ហាញ​សេចក្ដី​ពិពណ៌នា​ជា​អត្ថបទ​អំពី​ពាក្យសម្ដី និង​សំឡេង"
-
-#: ../panels/universal-access/uap.ui.h:37
-msgid "_Test flash"
-msgstr "សាកល្បង​ការ​បញ្ចេញ​ពន្លឺ"
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Hearing"
-msgstr "ស្ដាប់"
-
-#: ../panels/universal-access/uap.ui.h:40
-#| msgid "On screen keyboard"
-msgid "On Screen Keyboard"
-msgstr "ក្ដារចុច​លើ​អេក្រង់"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "Sticky Keys"
-msgstr "គ្រាប់ចុច​ស្អិត"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "ចាត់​ទុក​លំដាប់​នៃ​គ្រាប់ចុច​កម្មវិធី​កែប្រែ​ជា​បន្សំ​គ្រាប់ចុច"
-
-#: ../panels/universal-access/uap.ui.h:43
-msgid "_Disable if two keys are pressed together"
-msgstr "បិទ ប្រសិនបើ​គ្រាប់ចុច​ទាំងពីរ​ត្រូវ​បាន​ចុច​ព្រម​គ្នា"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Beep when a _modifer key is pressed"
-msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​កម្មវិធី​កែប្រែ​ត្រូវ​បាន​ចុច"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "Slow Keys"
-msgstr "គ្រាប់ចុច​យឺត"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "កំណត់​ការ​ពន្យារពេល​រវាង​ពេល​ដែល​គ្រាប់ចុច​ត្រូវ​បាន​ចុច និង​ពេល​ដែល​វា​ត្រូវ​បាន​ទទួល​យក"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "A_cceptance delay:"
-msgstr "ពន្យារ​ពេល​ក្នុង​ការ​ទទួលយក ៖"
-
-#: ../panels/universal-access/uap.ui.h:50
-msgid "Slow keys typing delay"
-msgstr "ពន្យារពេល​ក្នុង​ការ​វាយ​ដោយ​ប្រើ​គ្រាប់ចុច​យឺត"
-
-#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
-#: ../panels/universal-access/uap.ui.h:54
-msgid "Beep when a key is"
-msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:56
-msgid "pressed"
-msgstr "ត្រូវ​បាន​ចុច"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:58
-msgid "accepted"
-msgstr "ទទួលយក"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:60
-msgid "rejected"
-msgstr "បដិសេធ"
-
-#: ../panels/universal-access/uap.ui.h:61
-msgid "Bounce Keys"
-msgstr "គ្រាប់ចុច​លោត"
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "Ignores fast duplicate keypresses"
-msgstr "មិន​អើពើ​ការ​ចុច​គ្រាប់ចុច​ស្ទួន​គ្នា"
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "Acc_eptance delay:"
-msgstr "ពន្យារពេល​ក្នុង​ការ​ទទួល​យក ៖"
-
-#: ../panels/universal-access/uap.ui.h:64
-msgid "Bounce keys typing delay"
-msgstr "ពន្យារពេល​ក្នុង​ការ​វាយ​ដោយ​ប្រើ​គ្រាប់ចុច​លោត"
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "Beep when a key is _rejected"
-msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​ត្រូវ​បាន​បដិសេធ"
-
-#: ../panels/universal-access/uap.ui.h:66
-#| msgid "Keyboard"
-msgid "Enable by Keyboard"
-msgstr "បើក​ដោយ​ក្ដារចុច"
-
-#: ../panels/universal-access/uap.ui.h:67
-#| msgid "_Turn on accessibility features from the keyboard"
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "បើក​លក្ខណ​ពិសេស​នៃ​មធ្យោបាយ​ងាយស្រួល​ប្រើ​ពី​ក្ដារចុច"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Mouse Keys"
-msgstr "គ្រាប់ចុច​កណ្ដុរ"
-
-#: ../panels/universal-access/uap.ui.h:70
-msgid "Control the pointer using the keypad"
-msgstr "គ្រប់គ្រង​ព្រួញកណ្ដុរ​ដោយ​ប្រើ​បន្ទះ​គ្រាប់ចុច"
-
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Video Mouse"
-msgstr "កណ្ដុរ​ជា​វីដេអូ"
-
-#: ../panels/universal-access/uap.ui.h:72
-msgid "Control the pointer using the video camera."
-msgstr "គ្រប់គ្រង​ព្រួញ​កណ្ដុរ​ដោយ​ប្រើ​ម៉ាស៊ីន​ថត​វីដេអូ ។"
-
-#: ../panels/universal-access/uap.ui.h:73
-msgid "Simulated Secondary Click"
-msgstr "ត្រាប់តាម​ការ​ចុច​លើក​ទី​ពីរ"
-
-#: ../panels/universal-access/uap.ui.h:74
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "ធ្វើការ​ចុច​លើក​ទីពីរ ដោយ​សង្កត់​ប៊ូតុង​ចុច​លើក​ទី​មួយ"
-
-#: ../panels/universal-access/uap.ui.h:75
-msgid "Secondary click delay"
-msgstr "ពន្យារពេល​ក្នុង​ការ​ចុច​លើក​ទី​ពីរ"
-
-#: ../panels/universal-access/uap.ui.h:76
-msgid "Hover Click"
-msgstr "ចុច​នៅ​ពេល​សំកាំង"
-
-#: ../panels/universal-access/uap.ui.h:77
-msgid "Trigger a click when the pointer hovers"
-msgstr "ធ្វើ​ការ​ចុច នៅ​ពេល​ព្រួញ​កណ្ដុរ​សំកាំង"
-
-#: ../panels/universal-access/uap.ui.h:78
-msgid "D_elay:"
-msgstr "ពន្យារពេល ៖"
-
-#: ../panels/universal-access/uap.ui.h:79
-msgid "Motion _threshold:"
-msgstr "កម្រិត​ពន្លឺ​ចលនា ៖"
-
-#. small threshold
-#: ../panels/universal-access/uap.ui.h:81
-msgid "Small"
-msgstr "តូច"
-
-#. large threshold
-#: ../panels/universal-access/uap.ui.h:83
-msgid "Large"
-msgstr "ធំ"
-
-#: ../panels/universal-access/uap.ui.h:84
-msgid "Mouse Settings"
-msgstr "ការ​កំណត់​កណ្ដុរ"
-
-#: ../panels/universal-access/uap.ui.h:85
-msgid "Pointing and Clicking"
-msgstr "ចង្អុល និង​ចុច"
-
-#: ../panels/universal-access/zoom-options.c:357
-#| msgid "Short"
-msgctxt "Distance"
-msgid "Short"
-msgstr "ខ្លី"
-
-#: ../panels/universal-access/zoom-options.c:358
-#| msgid "1/4 Screen"
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "អេក្រង់ ១/៤"
-
-#: ../panels/universal-access/zoom-options.c:359
-#| msgid "1/4 Screen"
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "អេក្រង់ ១/២"
-
-#: ../panels/universal-access/zoom-options.c:360
-#| msgid "1/4 Screen"
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "អេក្រង់ ៣/៤"
-
-#: ../panels/universal-access/zoom-options.c:361
-#| msgid "Long"
-msgctxt "Distance"
-msgid "Long"
-msgstr "វែង"
-
-#: ../panels/universal-access/zoom-options.ui.h:1
-msgid "Full Screen"
-msgstr "ពេញ​អេក្រង់"
-
-#: ../panels/universal-access/zoom-options.ui.h:2
-msgid "Top Half"
-msgstr "ពាក់​កណ្ដាល​ផ្នែកខាងលើ"
-
-#: ../panels/universal-access/zoom-options.ui.h:3
-msgid "Bottom Half"
-msgstr "ពាក់​កណ្ដាល​ផ្នែក​ខាងក្រោម"
-
-#: ../panels/universal-access/zoom-options.ui.h:4
-msgid "Left Half"
-msgstr "ពាក់កណ្ដាល​ខាង​ឆ្វេង"
-
-#: ../panels/universal-access/zoom-options.ui.h:5
-msgid "Right Half"
-msgstr "ពាក់កណ្ដាល​ខាង​ស្ដាំ"
-
-#: ../panels/universal-access/zoom-options.ui.h:6
-msgid "Zoom Options"
-msgstr "ជម្រើស​ពង្រីក"
-
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "ពង្រីក"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
-msgstr "ការ​ពង្រីក ៖"
-
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "អនុវត្ត​តាម​ព្រួញ​កណ្ដុរ"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "ភាគ​អេក្រង់ ៖"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "កម្មវិធី​ពង្រីក​ពង្រីក​ចេញ​ពី​អេក្រង់"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "រក្សាទុក​ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​ឲ្យ​ចំកណ្ដាល"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​រុញ​មាតិកា​ជុំវិញ"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​ផ្លាស់ទី​ជាមួយ​មាតិកា"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
-msgid "Magnifier Position:"
-msgstr "ទីតាំង​របស់​កម្មវិធី​ពង្រីក ៖"
-
-#: ../panels/universal-access/zoom-options.ui.h:16
-#| msgid "Magnifier Position:"
-msgid "Magnifier"
-msgstr "កម្មវិធី​ពង្រីក"
-
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
-msgstr "កម្រាស់ ៖"
-
-#. short delay
-#: ../panels/universal-access/zoom-options.ui.h:19
-msgid "Thin"
-msgstr "ស្ដើង"
-
-#. long delay
-#: ../panels/universal-access/zoom-options.ui.h:21
-msgid "Thick"
-msgstr "ក្រាស់"
-
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Length:"
-msgstr "ប្រវែង ៖"
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Color:"
-msgstr "ពណ៌ ៖"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Crosshairs:"
-msgstr "សញ្ញា​ខ្វែង ៖"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
-msgid "Overlaps mouse cursor"
-msgstr "ដាក់​ព្រួញ​កណ្ដុរ​ត្រួតគ្នា"
-
-#: ../panels/universal-access/zoom-options.ui.h:26
-#| msgid "Crosshairs:"
-msgid "Crosshairs"
-msgstr "សញ្ញា​ខ្វែង"
-
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "White on black:"
-msgstr "ពណ៌​ស​នៅ​លើខ្មៅ"
-
-#: ../panels/universal-access/zoom-options.ui.h:28
-#| msgid "Brightness"
-msgid "Brightness:"
-msgstr "ពន្លឺ ៖"
-
-#: ../panels/universal-access/zoom-options.ui.h:29
-#| msgid "_Contrast:"
-msgid "Contrast:"
-msgstr "កម្រិត​ពណ៌ ៖"
-
-#: ../panels/universal-access/zoom-options.ui.h:30
-#| msgid "Color"
-msgctxt "Zoom Grayscale"
-msgid "Color"
-msgstr "ពណ៌"
-
-#: ../panels/universal-access/zoom-options.ui.h:31
-#| msgid "None"
-msgctxt "Zoom Grayscale"
-msgid "None"
-msgstr "គ្មាន"
-
-#: ../panels/universal-access/zoom-options.ui.h:32
-msgctxt "Zoom Grayscale"
-msgid "Full"
-msgstr "ពេញ"
-
-#. short delay
-#: ../panels/universal-access/zoom-options.ui.h:34
-msgid "Low"
-msgstr "ទាប"
-
-#. long delay
-#: ../panels/universal-access/zoom-options.ui.h:36
-msgid "High"
-msgstr "ខ្ពស់"
-
-#: ../panels/universal-access/zoom-options.ui.h:37
-#| msgid "Sound Effects"
-msgid "Color Effects:"
-msgstr "បែបផែន​ពណ៌ ៖"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
-#| msgid "Sound Effects"
-msgid "Color Effects"
-msgstr "បែបផែន​ពណ៌"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:35
-msgctxt "Account type"
-msgid "Standard"
-msgstr "ស្ដង់ដារ"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:37
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "អ្នក​គ្រប់គ្រង"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-#| msgid "Add Account"
-msgid "Add account"
-msgstr "បន្ថែម​គណនី"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-#| msgid "My Account"
-msgid "_Local Account"
-msgstr "គណនី​​មូលដ្ឋាន"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#| msgid "_Fingerprint Login"
-msgid "_Enterprise Login"
-msgstr "ចូល​ជា​សហគ្រាស"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "_Username"
-msgstr "ឈ្មោះ​អ្នកប្រើ"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-msgid "_Full name"
-msgstr "ឈ្មោះពេញ"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-#| msgid "Account Type:"
-msgid "Account _Type"
-msgstr "ប្រភេទ​គណនី"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-msgid "_Domain"
-msgstr "ដែន"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Login Name"
-msgstr "ឈ្មោះ​ចូល"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "_Password"
-msgstr "ពាក្យ​សម្ងាត់"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "Tip: Enterprise domain or realm name"
-msgstr "ជំនួយ ៖ ដែន​សហគ្រាស​ ឬ​ឈ្មោះតំបន់"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid "C_ontinue"
-msgstr "បន្ត"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:14
-#| msgctxt "Account type"
-#| msgid "Administrator"
-msgid "Domain Administrator Login"
-msgstr "ចូល​ជា​​អ្នក​គ្រប់គ្រង​ដែន"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid ""
-"In order to use enterpise logins, this computer needs to be\n"
-"enrolled in the domain. Please have your network administrator\n"
-"type their domain password here."
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "ទ្រង់ទ្រាយ"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "ទ្រង់ទ្រាយ"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
 msgstr ""
-"ដើម្បី​ប្រើ​ឈ្មោះ​ចូល​សហគ្រាស "
-"កុំព្យូទ័រ​នេះ​តម្រូវ​ឲ្យ​\nចុះឈ្មោះ​នៅ​ក្នុង​ដែន ។ "
-"សូម​ឲ្យ​អ្នក​គ្រប់គ្រង​បណ្ដាញ​របស់​អ្នក\nវាយ​ពាក្យ​សម្ងាត់​ដែន​នៅ​ទី​នេះ ។"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:18
-#| msgctxt "Account type"
-#| msgid "Administrator"
-msgid "Administrator _Name"
-msgstr "ឈ្មោះ​អ្នក​គ្រប់គ្រង"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
-#| msgctxt "Account type"
-#| msgid "Administrator"
-msgid "Administrator Password"
-msgstr "ពាក្យសម្ងាត់​អ្នក​គ្រប់គ្រង"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "មេដៃ​ឆ្វេង"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "ម្រាមដៃ​កណ្ដាល​ខាងឆ្វេង"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "ម្រាម​នាងដៃ​ខាង​ឆ្វេង"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "ម្រាម​កូនដៃ​ខាង​ឆ្វេង"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "មេ​ដៃ​ស្ដាំ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "ម្រាមដៃ​កណ្ដាល​ខាង​ស្ដាំ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "ម្រាម​នាង​ដៃ​ខាង​ស្ដាំ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "ម្រាម​កូនដៃ​ខាង​ស្ដាំ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:706
-msgid "Enable Fingerprint Login"
-msgstr "បើក​ការ​ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "ចង្អុល​ដៃ​ស្ដាំ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "ចង្អុល​ដៃ​ឆ្វេង"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "ម្រាម​ផ្សេងទៀត ៖"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
 msgstr ""
-"ស្នាម​ម្រាមដៃ​របស់​អ្នក​ត្រូវ​បាន​រក្សាទុក​ដោយ​ជោគជ័យ ។  ឥឡូវនេះ អ្នក​អាច​នឹង​ចូល​ដោយ​ប្រើ​កម្មវិធី​អាន​ស្នាម​"
-"ម្រាមដៃ​របស់​អ្នក​បាន ។"
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "User Accounts"
-msgstr "គណនី​អ្នកប្រើ"
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "មើល​ជាមុន"
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users"
-msgstr "បន្ថែម ឬ​យក​គណនី​អ្នកប្រើ​ចេញ"
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "កាលបរិច្ឆេទ"
 
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "កាលបរិច្ឆេទ និង​ពេលវេលា"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Set a password now"
-msgstr "កំណត់​ពាក្យសម្ងាត់​ឥឡូវនេះ"
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "លេខ"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-msgid "Choose password at next login"
-msgstr "ជ្រើស​ពាក្យសម្ងាត់ នៅ​ពេល​ចូល​លើកក្រោយ"
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "រង្វាស់"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Log in without a password"
-msgstr "ចូល​ដោយ​មិន​ប្រើ​ពាក្យសម្ងាត់"
+#: panels/region/cc-format-preview.ui:107
+#, fuzzy
+msgid "Paper"
+msgstr "ប្រភេទ​ក្រដាស"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "Disable this account"
-msgstr "បិទ​គណនី​នេះ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Enable this account"
-msgstr "បើក​គណនី​នេះ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "_Hint"
-msgstr "ពាក្យគន្លឹះ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid ""
-"This hint may be displayed at the login screen.  It will be visible to all "
-"users of this system.  Do <b>not</b> include the password here."
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
 msgstr ""
-"ពាក្យ​គន្លឹះ​អាច​នឹង​ត្រូវ​បង្ហាញ​នៅ​កន្លែង​អេក្រង់​ចូល ។ អ្នកប្រើ​ប្រព័ន្ធ​នេះ​ទាំងអស់​អាច​មើល​ឃើញ​វា ។   "
-"<b>កុំ</b> រួមបញ្ចូល​ពាក្យសម្ងាត់​នៅ​ទីនេះ ។"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "C_onfirm password"
-msgstr "អះអាង​ពាក្យសម្ងាត់"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-msgid "_New password"
-msgstr "ពាក្យសម្ងាត់​ថ្មី"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-#| msgid "Set a password now"
-msgid "Generate a password"
-msgstr "បង្កើត​ពាក្យ​សម្ងាត់"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-msgid "Fair"
-msgstr "ល្មម"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-msgid "Current _password"
-msgstr "ពាក្យសម្ងាត់​បច្ចុប្បន្ន"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid "_Action"
-msgstr "សកម្មភាព"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-msgid "Changing password for"
-msgstr "ផ្លាស់ប្ដូរ​ពាក្យសម្ងាត់"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:15
-msgid "_Show password"
-msgstr "បង្ហាញ​ពាក្យសម្ងាត់"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:16
-msgid "How to choose a strong password"
-msgstr "របៀប​ជ្រើស​ពាក្យសម្ងាត់​ខ្លាំង"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:17
-msgid "Ch_ange"
-msgstr "ផ្លាស់ប្ដូរ"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-msgid "Changing photo for:"
-msgstr "ផ្លាស់ប្ដូរ​រូបថត ៖"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+#: panels/region/cc-region-panel.ui:45
 msgid ""
-"Choose a picture that will be shown at the login screen for this account."
-msgstr "ជ្រើស​រូបភាព​ដែល​នឹង​ត្រូវ​បង្ហាញ​នៅ​ត្រង់​អេក្រង់​ចូល​សម្រាប់​គណនី​នេះ ។"
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-msgid "Gallery"
-msgstr "វិចិត្រសាល"
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "ដំឡើង​ភាសា..."
 
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "Browse for more pictures"
-msgstr "រកមើល​រូបភាព​ផ្សេងទៀត"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "គណនី​របស់​ខ្ញុំ"
 
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-msgid "Take a photograph"
-msgstr "ថត​រូប"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-msgid "Browse"
-msgstr "រកមើល"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr "រូបថត"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Account Information"
-msgstr "ព័ត៌មាន​គណនី"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Add User Account"
-msgstr "បន្ថែម​គណនី​អ្នកប្រើ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Remove User Account"
-msgstr "យក​គណនី​អ្នកប្រើ​ចេញ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "Login Options"
-msgstr "ជម្រើស​ចូល"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "A_utomatic Login"
-msgstr "ចូល​ស្វ័យប្រវត្តិ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "_Fingerprint Login"
-msgstr "ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "User Icon"
-msgstr "រូបតំណាង​អ្នកប្រើ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "ភាសា"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
-#| msgid "Manage online accounts"
-msgid "Manage user accounts"
-msgstr "គ្រប់គ្រង​គណនី​អ្នក​ប្រើ"
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "ទ្រង់ទ្រាយ"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
-#| msgid "Authentication required"
-msgid "Authentication is required to change user data"
-msgstr "តម្រូវ​ឲ្យ​ផ្ទៀងផ្ទាត់ ដើម្បី​ផ្លាស់ប្ដូរ​ទិន្នន័យ​អ្នក​ប្រើ"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "ចាក់​សោ​អេក្រង់"
 
-#: ../panels/user-accounts/pw-utils.c:94
-#: ../panels/user-accounts/um-password-dialog.c:569
-msgctxt "Password strength"
-msgid "Too short"
-msgstr "ខ្លី​ពេក"
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "តំបន់ និង​ភាសា"
 
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password strength"
-msgid "Not good enough"
-msgstr "មិន​ល្អ​ទេ"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
 
-#: ../panels/user-accounts/pw-utils.c:108
-#: ../panels/user-accounts/um-password-dialog.c:570
-msgctxt "Password strength"
-msgid "Weak"
-msgstr "ខ្សោយ"
+#: panels/region/gnome-region-panel.desktop.in.in:19
+#, fuzzy
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;"
 
-#: ../panels/user-accounts/pw-utils.c:111
-#: ../panels/user-accounts/um-password-dialog.c:571
-msgctxt "Password strength"
-msgid "Fair"
-msgstr "ល្មម"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "ជ្រើស​របៀប​គ្រប់គ្រង​មេឌៀ"
 
-#: ../panels/user-accounts/pw-utils.c:114
-#: ../panels/user-accounts/um-password-dialog.c:572
-msgctxt "Password strength"
-msgid "Good"
-msgstr "ល្អ"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "អូឌីយ៉ូ​ស៊ីឌី"
 
-#: ../panels/user-accounts/pw-utils.c:117
-#: ../panels/user-accounts/um-password-dialog.c:573
-msgctxt "Password strength"
-msgid "Strong"
-msgstr "ខ្លាំង"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "វីដេអូ​ឌីវីឌី"
 
-#: ../panels/user-accounts/run-passwd.c:424
-msgid "Authentication failed"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "កម្មវិធី​ចាក់​​តន្ត្រី"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "កម្មវិធី"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+#, fuzzy
+msgid "_Other Media…"
+msgstr "មេឌៀ​ផ្សេងទៀត..."
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "កុំ​សួរ ឬ​ចាប់ផ្ដើម​កម្មវិធី នៅ​ពេល​បញ្ចូល​មេឌៀ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "ជ្រើស​របៀប​គ្រប់គ្រង​មេឌៀ​ផ្សេងទៀត"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "សកម្មភាព ៖"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "ប្រភេទ ៖"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "មេឌៀ​ចល័ត"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "កំណត់​រចនាសម្ព័ន្ធ​នៃ​ការ​កំណត់​ប៊្លូធូស"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "រូបថត​អេក្រង់"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "ក្ដារចុច​លើ​អេក្រង់"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+#, fuzzy
+msgid "Automatic Screen _Lock"
+msgstr "ចូល​ស្វ័យប្រវត្តិ"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "បង្ហាញ​ការ​ជូន​ដំណឹង​នៅ​ពេល​ចាក់សោ"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "ចាក់​សោ​អេក្រង់"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "ភាគ​អេក្រង់ ៖"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+#, fuzzy
+msgid "Screen"
+msgstr "អេក្រង់ ១/៤"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "ការ​កំណត់​សំឡេង"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "ទីតាំង"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "ផ្សេងទៀត..."
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "ទីតាំង"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "ម៉ឺនុយ​កម្មវិធី"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "ស្វែងរក​តាម​អាសយដ្ឋាន"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "បណ្ដាញ"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+#, fuzzy
+msgid "Sharing"
+msgstr "ស្ដាប់"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
+msgstr "កុំព្យូទ័រ"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "ស្ដាប់"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "កម្មវិធី​ចាក់​មេឌៀ"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "យក​តំបន់​ចេញ"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "ស្ដាប់"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "ពាក្យ​សម្ងាត់"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+#, fuzzy
+msgid "Remote Login"
+msgstr "យក​តំបន់​ចេញ"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "កា​រ​គ្រប់គ្រង​កម្រិត​សំឡេង"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "មិន​ត្រូវ​បាន​តភ្ជាប់"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
 msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ផ្ទៀងផ្ទាត់"
 
-#: ../panels/user-accounts/run-passwd.c:504
-#: ../panels/user-accounts/um-password-dialog.c:239
-#, c-format
-msgid "The new password is too short"
-msgstr "ពាក្យសម្ងាត់​ថ្មី​ខ្លី​ពេក"
-
-#: ../panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password is too simple"
-msgstr "ពាក្យសម្ងាត់​ថ្មី​សាមញ្ញ​ពេក"
-
-#: ../panels/user-accounts/run-passwd.c:516
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "ពាក្យសម្ងាត់​ចាស់ និង​ថ្មី​ស្រដៀង​គ្នា​ពេក"
-
-#: ../panels/user-accounts/run-passwd.c:519
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "ពាក្យសម្ងាត់​ថ្មី​ត្រូវ​បាន​គេ​ប្រើ​ហើយ ។"
-
-#: ../panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "ពាក្យសម្ងាត់​ថ្មី​ត្រូវតែ​មាន​តួអក្សរ​ជា​លេខ ឬ​តួអក្សរ​ពិសេស"
-
-#: ../panels/user-accounts/run-passwd.c:526
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "ពាក្យសម្ងាត់​ចាស់ និង​ថ្មី​ដូចគ្នា"
-
-#: ../panels/user-accounts/run-passwd.c:530
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
 msgstr ""
-"ពាក្យសម្ងាត់​របស់​អ្នក​ត្រូវ​បាន​ផ្លាស់ប្ដូរ តាំងពី​អ្នក​បាន​ចាប់ផ្ដើម​ផ្ទៀងផ្ទាត់​ភាព​ត្រឹមត្រូវ​ពី​ដំបូង​ម្លេះ !"
 
-#: ../panels/user-accounts/run-passwd.c:534
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "ពាក្យសម្ងាត់​ថ្មី​មិន​មាន​តួអក្សរ​ផ្សេង​ៗ​គ្នា​ឲ្យ​បាន​គ្រប់គ្រាន់"
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ឈ្មោះ​អ្នកប្រើ"
 
-#: ../panels/user-accounts/run-passwd.c:538
-#, c-format
-msgid "Unknown error"
-msgstr "មិន​ស្គាល់​កំហុស"
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
 
-#: ../panels/user-accounts/um-account-dialog.c:175
-#| msgid "Select an account"
-msgid "Failed to add account"
-msgstr "បាន​បរាជ័យ​ក្នុងការ​បន្ថែម​គណនី"
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "ចុះឈ្មោះ​ស្នាម​ម្រាមដៃ"
 
-#: ../panels/user-accounts/um-account-dialog.c:366
-#: ../panels/user-accounts/um-account-dialog.c:405
-#| msgid "Failed to create user"
-msgid "Failed to register account"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចុះ​ឈ្មោះ​គណនី"
-
-#: ../panels/user-accounts/um-account-dialog.c:530
-msgid "No supported way to authenticate with this domain"
-msgstr "គ្មាន​វិធី​ដែល​បាន​គាំទ្រ​ ដើម្បី​ផ្ទៀងផ្ទាត់​ជា​មួយ​ដែន​នេះ"
-
-#: ../panels/user-accounts/um-account-dialog.c:582
-msgid "Failed to join domain"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចូល​ដែន"
-
-#: ../panels/user-accounts/um-account-dialog.c:635
-msgid "Failed to log into domain"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចុះ​កំណត់ហេតុ​ដែន"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr "អ្នក​មិន​ត្រូវ​បាន​អនុញ្ញាត​ឲ្យ​ចូល​ដំណើរការ​ឧបករណ៍​នេះ​ទេ ។ សូម​ទាក់ទង​អ្នក​គ្រប់គ្រង​ប្រព័ន្ធ​របស់​អ្នក ។"
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "ឧបករណ៍​កំពុង​ត្រូវ​បាន​ប្រើ ។"
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "កម្មវិធី​ចាក់​មេឌៀ"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr "កំហុស​ខាងក្នុង​បាន​កើតឡើង ។"
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:219
-#: ../panels/user-accounts/um-fingerprint-dialog.c:220
-msgid "Enabled"
-msgstr "បាន​បើក"
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:268
-msgid "Delete registered fingerprints?"
-msgstr "លុប​ស្នាម​ម្រាមដៃ​ដែល​បាន​ចុះ​ឈ្មោះ​ឬ ?"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:272
-msgid "_Delete Fingerprints"
-msgstr "លុប​ស្នាម​ម្រាមដៃ"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:279
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+#, fuzzy
+msgid "Enable or disable remote login"
+msgstr "បើក​ការ​រមូរ​ផ្ដេក"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+#, fuzzy
+msgid "Authentication is required to enable or disable remote login"
+msgstr "តម្រូវ​ឲ្យ​ផ្ទៀងផ្ទាត់ ដើម្បី​ផ្លាស់ប្ដូរ​ទិន្នន័យ​អ្នក​ប្រើ"
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "ស្ដាប់"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "តុល្យភាព ៖"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "សំឡេង​ថយ ៖"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
+msgid "Rear"
+msgstr "ខាង​ក្រោយ"
+
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
+msgid "Front"
+msgstr "ខាងមុខ"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "សំឡេង​របស់​ប្រព័ន្ធ"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "កម្រិត​សំឡេង​ព្រមាន ៖"
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "ស្ងាត់"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "បញ្ចេញ"
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "កម្រិត​បញ្ចេញ​សំឡេង ៖"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "សាកល្បង"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "URL កំណត់​រចនាសម្ព័ន្ធ"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "បញ្ចូល"
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "កម្រិត​បញ្ចូល ៖"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "បង្កើន​កម្រិត​សំឡេង"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "សាកល្បង​សំឡេង"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "ស្ងាត់"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "សំឡេង"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ផ្លាស់ប្ដូរ​កម្រិត​សំឡេង ​និង​ព្រឹត្តិការណ៍​សំឡេង"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, fuzzy, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "លុប​ឧបករណ៍"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "បាន​បិទ​ដាក់​ចំណងជើង"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "ឈ្មោះ ៖"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "យក​ឧបករណ៍​ចេញ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "មិន​អាច​តភ្ជាប់​ទៅ %s បាន​ទេ ៖ %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "ចូល​ដំណើរការ​សកល"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "បន្ថែម​ឧបករណ៍"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "ទស្សន៍ទ្រនិច​លោត​ភ្លឹបភ្លែត"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "ទស្សន៍ទ្រនិច​លោត​ភ្លឹបភ្លែត​នៅ​ក្នុង​វាល​អត្ថបទ"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "ល្បឿន ៖"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "ល្បឿន​លោត​ភ្លឹបភ្លែត​របស់​ទស្សន៍ទ្រនិច"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "ល្បឿន​លោត​ភ្លឹបភ្លែត​របស់​ទស្សន៍ទ្រនិច"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "ត្រាប់តាម​ការ​ចុច​លើក​ទី​ពីរ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "ធ្វើការ​ចុច​លើក​ទីពីរ ដោយ​សង្កត់​ប៊ូតុង​ចុច​លើក​ទី​មួយ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "ពន្យារ​ពេល​ក្នុង​ការ​ទទួលយក ៖"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "ខ្លី"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "ពន្យារពេល​ក្នុង​ការ​ចុច​លើក​ទី​ពីរ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "យូរ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "ចុច​នៅ​ពេល​សំកាំង"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "ធ្វើ​ការ​ចុច នៅ​ពេល​ព្រួញ​កណ្ដុរ​សំកាំង"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "ពន្យារពេល ៖"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "ខ្លី"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "យូរ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "កម្រិត​ពន្លឺ​ចលនា ៖"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "តូច"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "ធំ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "គ្រាប់ចុច​ធ្វើ​ម្ដងទៀត"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "គ្រាប់ចុច presses _repeat នៅ​ពេល​គ្រាប់ចុច​ត្រូវ​បាន​សង្កត់"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "ល្បឿន​គ្រាប់ចុច​ធ្វើ​ម្ដងទៀត"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "ល្បឿន​គ្រាប់ចុច​ធ្វើ​ម្ដងទៀត"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "អ្នក​ជំនួយការ​ក្នុង​ការ​វាយ"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "គ្រាប់ចុច​ស្អិត"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "ចាត់​ទុក​លំដាប់​នៃ​គ្រាប់ចុច​កម្មវិធី​កែប្រែ​ជា​បន្សំ​គ្រាប់ចុច"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "បិទ ប្រសិនបើ​គ្រាប់ចុច​ទាំងពីរ​ត្រូវ​បាន​ចុច​ព្រម​គ្នា"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​កម្មវិធី​កែប្រែ​ត្រូវ​បាន​ចុច"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "គ្រាប់ចុច​យឺត"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "កំណត់​ការ​ពន្យារពេល​រវាង​ពេល​ដែល​គ្រាប់ចុច​ត្រូវ​បាន​ចុច និង​ពេល​ដែល​វា​ត្រូវ​បាន​ទទួល​យក"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "ខ្លី"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "ពន្យារពេល​ក្នុង​ការ​វាយ​ដោយ​ប្រើ​គ្រាប់ចុច​យឺត"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "យូរ"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​កម្មវិធី​កែប្រែ​ត្រូវ​បាន​ចុច"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​ត្រូវ​បាន​បដិសេធ"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​ត្រូវ​បាន​បដិសេធ"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "គ្រាប់ចុច​លោត"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "មិន​អើពើ​ការ​ចុច​គ្រាប់ចុច​ស្ទួន​គ្នា"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "ខ្លី"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "ពន្យារពេល​ក្នុង​ការ​វាយ​ដោយ​ប្រើ​គ្រាប់ចុច​លោត"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "យូរ"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+#, fuzzy
+msgid "_Enable by Keyboard"
+msgstr "បើក​ដោយ​ក្ដារចុច"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "បើក​លក្ខណ​ពិសេស​នៃ​មធ្យោបាយ​ងាយស្រួល​ប្រើ​ពី​ក្ដារចុច"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "មើលឃើញ"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "កម្រិត​ពណ៌"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "អត្ថបទ​ធំ"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "កម្មវិធី​អាន​អេក្រង់"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "គ្រាប់ចុច​លោត"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "ល្បឿន​លោត​ភ្លឹបភ្លែត​របស់​ទស្សន៍ទ្រនិច"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "ពង្រីក"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "ស្ដាប់"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "ការ​ព្រមាន​ដែល​មើល​ឃើញ"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "ក្ដារចុច​លើ​អេក្រង់"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "គ្រាប់ចុច​ធ្វើ​ម្ដងទៀត"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "ទស្សន៍ទ្រនិច​លោត​ភ្លឹបភ្លែត"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
+msgstr "អ្នក​ជំនួយការ​ក្នុង​ការ​វាយ"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "ចង្អុល និង​ចុច"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "គ្រាប់ចុច​កណ្ដុរ"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "យក​ម៉ាស៊ីន​បោះពុម្ព​ចេញ"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "ចុច​ទ្វេ​ដង"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "អស់​ពេល​ចុច​ទ្វេដង"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "ការ​ព្រមាន​ដែល​មើល​ឃើញ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "សាកល្បង​ការ​បញ្ចេញ​ពន្លឺ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+#, fuzzy
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ប្រើ​ការ​បង្ហាញ​ដែល​មើល​ឃើញ នៅ​ពេល​សំឡេង​ព្រមាន​កើត​ឡើង"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "បញ្ចេញ​ពន្លឺ​ទូទាំង​អេក្រង់"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "បញ្ចេញ​ពន្លឺ​ទូទាំង​អេក្រង់"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "ពេញ​អេក្រង់"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "ពាក់​កណ្ដាល​ផ្នែកខាងលើ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "ពាក់​កណ្ដាល​ផ្នែក​ខាងក្រោម"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "ពាក់កណ្ដាល​ខាង​ឆ្វេង"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "ពាក់កណ្ដាល​ខាង​ស្ដាំ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "ជម្រើស​ពង្រីក"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "ការ​ពង្រីក ៖"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "ទីតាំង​របស់​កម្មវិធី​ពង្រីក ៖"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "អនុវត្ត​តាម​ព្រួញ​កណ្ដុរ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "ភាគ​អេក្រង់ ៖"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "កម្មវិធី​ពង្រីក​ពង្រីក​ចេញ​ពី​អេក្រង់"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "រក្សាទុក​ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​ឲ្យ​ចំកណ្ដាល"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​រុញ​មាតិកា​ជុំវិញ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​ផ្លាស់ទី​ជាមួយ​មាតិកា"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "កម្មវិធី​ពង្រីក"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "សញ្ញា​ខ្វែង ៖"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "ដាក់​ព្រួញ​កណ្ដុរ​ត្រួតគ្នា"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
+msgstr "កម្រាស់ ៖"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+#, fuzzy
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "ស្ដើង"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+#, fuzzy
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "ក្រាស់"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
+msgstr "ប្រវែង ៖"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
+msgstr "ពណ៌ ៖"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "សញ្ញា​ខ្វែង"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "បែបផែន​ពណ៌ ៖"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
+msgstr "ពណ៌​ស​នៅ​លើខ្មៅ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "ពន្លឺ ៖"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "កម្រិត​ពណ៌ ៖"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "គ្មាន"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "ពេញ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "ទាប"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "ខ្ពស់"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "ទាប"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "ខ្ពស់"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "បែបផែន​ពណ៌"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
+"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "លុប​ឯកសារ"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "បន្ថែម​អ្នកប្រើ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "អ្នក​គ្រប់គ្រង"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "ជ្រើស​ពាក្យសម្ងាត់ នៅ​ពេល​ចូល​លើកក្រោយ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "កំណត់​ពាក្យសម្ងាត់​ឥឡូវនេះ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "កំណត់​រចនាសម្ព័ន្ធ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "ចូល​ជា​សហគ្រាស"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "ក្រៅបណ្ដាញ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "ជ្រើស​ឯកសារ​ PPD"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "ទេ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
 msgstr ""
 "តើ​អ្នក​ចង់​លុប​ស្នាម​ម្រាមដៃ​ដែល​បាន​ចុះ​ឈ្មោះ ដើម្បី​ឲ្យ​ការ​ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាមដៃ​ត្រូវ​បិទ​ដែរ​ឬ​ទេ ?"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:455
-msgid "Done!"
-msgstr "ធ្វើ​រួច !"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "រក​មិ​ន​ឃើញ​ម៉ាស៊ីន​បោះពុម្ព"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:516
-#: ../panels/user-accounts/um-fingerprint-dialog.c:558
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "មិន​អាច​ចូល​ដំណើរការ​ឧបករណ៍ '%s'"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:603
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "មិន​អាច​ចាប់ផ្ដើមការ​​ចាប់​យក​ស្នាម​ម្រាមដៃ​នៅ​លើ​ឧបករណ៍ '%s' បាន​ឡើយ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:655
-msgid "Could not access any fingerprint readers"
-msgstr "មិន​អាច​ចូល​ដំណើរការ​​កម្មវិធី​អាន​ស្នាម​ម្រាមដៃ​ណាមួយ​បាន​ឡើយ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:656
-msgid "Please contact your system administrator for help."
-msgstr "សម្រាប់​ជំនួយ សូម​ទាក់ទង​អ្នក​គ្រប់គ្រង​ប្រព័ន្ធ​របស់​អ្នក ។"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:740
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
 msgstr ""
-"ដើម្បី​បើក​ការ​ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាមដៃ អ្នក​ចាំបាច់​ត្រូវ​រក្សាទុក​ស្នាម​ម្រាមដៃ​ណាមួយ ដោយ​ប្រើ​ឧបករណ៍ "
-"'%s' ។"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:747
-msgid "Selecting finger"
-msgstr "ជ្រើស​ម្រាមដៃ"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:748
-msgid "Enrolling fingerprints"
-msgstr "ចុះឈ្មោះ​ស្នាម​ម្រាមដៃ"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "ជ្រើស​ឧបករណ៍ ដើម្បី​កំណត់​រចនាសម្ព័ន្ធ ៖"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:749
-msgid "Summary"
-msgstr "សង្ខេប"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
 
-#: ../panels/user-accounts/um-password-dialog.c:96
-#| msgid "Set a password now"
-msgid "_Generate a password"
-msgstr "បង្កើត​ពាក្យ​សម្ងាត់"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
 
-#: ../panels/user-accounts/um-password-dialog.c:150
-msgid "Please choose another password."
-msgstr "សូម​ជ្រើស​ពាក្យសម្ងាត់​ផ្សេងទៀត ។"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "លុប​ស្នាម​ម្រាមដៃ"
 
-#: ../panels/user-accounts/um-password-dialog.c:159
-msgid "Please type your current password again."
-msgstr "សូម​វាយ​បញ្ចូល​ពាក្យសម្ងាត់​បច្ចុប្បន្ន​របស់​អ្នក​ម្ដងទៀត ។"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
 
-#: ../panels/user-accounts/um-password-dialog.c:165
-msgid "Password could not be changed"
-msgstr "មិន​អាច​ផ្លាស់ប្ដូរ​ពាក្យសម្ងាត់​បាន​ឡើយ"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "បទ​មុន"
 
-#: ../panels/user-accounts/um-password-dialog.c:236
-msgid "You need to enter a new password"
-msgstr "អ្នក​ត្រូវតែ​បញ្ចូល​ពាក្យសម្ងាត់​ថ្មី"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
 
-#: ../panels/user-accounts/um-password-dialog.c:245
-msgid "You need to confirm the password"
-msgstr "អ្នក​​ត្រូវតែ​អះអាង​ពាក្យសម្ងាត់"
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "ផ្លាស់ប្ដូរ​ពាក្យសម្ងាត់"
 
-#: ../panels/user-accounts/um-password-dialog.c:248
-msgid "The passwords do not match"
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "ផ្លាស់ប្ដូរ"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "ពាក្យសម្ងាត់​បច្ចុប្បន្ន"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "ពាក្យសម្ងាត់​ថ្មី"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "អះអាង​ពាក្យសម្ងាត់"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
 msgstr "ពាក្យសម្ងាត់​មិន​ផ្គូផ្គង​គ្នា"
 
-#: ../panels/user-accounts/um-password-dialog.c:254
-msgid "You need to enter your current password"
-msgstr "អ្នក​​ត្រូវតែ​បញ្ចូល​ពាក្យសម្ងាត់​បច្ចុប្បន្ន​របស់​អ្នក"
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "ជ្រើស​ពាក្យសម្ងាត់ នៅ​ពេល​ចូល​លើកក្រោយ"
 
-#: ../panels/user-accounts/um-password-dialog.c:257
-msgid "The current password is not correct"
-msgstr "ពាក្យសម្ងាត់​បច្ចុប្បន្ន​មិន​ត្រឹមត្រូវ"
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "កំណត់​ពាក្យសម្ងាត់​ឥឡូវនេះ"
 
-#: ../panels/user-accounts/um-password-dialog.c:347
-msgid "Passwords do not match"
-msgstr "ពាក្យសម្ងាត់​មិន​ផ្គូផ្គង​គ្នា"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Users"
+msgstr "ឈ្មោះ​អ្នកប្រើ"
 
-#: ../panels/user-accounts/um-password-dialog.c:409
-msgid "Wrong password"
-msgstr "ពាក្យសម្ងាត់​មិន​ត្រឹមត្រូវ"
-
-#: ../panels/user-accounts/um-photo-dialog.c:443
-msgid "Disable image"
-msgstr "បិទ​រូបភាព"
-
-#: ../panels/user-accounts/um-photo-dialog.c:461
-msgid "Take a photo..."
-msgstr "ថត​រូប..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:479
-msgid "Browse for more pictures..."
-msgstr "រកមើល​រូប​ជាច្រើន​ទៀត..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:704
-#, c-format
-msgid "Used by %s"
-msgstr "ត្រូវ​បាន​ប្រើ​ដោយ %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:368
-#, c-format
-msgid "No such domain or realm found"
-msgstr "រក​មិនឃើញ​ដែន ឬ​តំបន់​បែប​នេះ​ទេ​"
-
-#: ../panels/user-accounts/um-realm-manager.c:743
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "មិន​អាច​ចូល​ជា %s នៅ​ដែន %s បាន​ទេ"
-
-#: ../panels/user-accounts/um-realm-manager.c:748
-msgid "Invalid password, please try again"
-msgstr "ពាក្យ​សម្ងាត់​មិន​ត្រឹមត្រូវ សូម​ព្យាយាម​ម្ដង​ទៀត"
-
-#: ../panels/user-accounts/um-realm-manager.c:752
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "មិន​អាច​តភ្ជាប់​ទៅ %s បាន​ទេ ៖ %s"
-
-#: ../panels/user-accounts/um-user-manager.c:466
-#, c-format
-msgid "A user with name '%s' already exists."
-msgstr "មាន​អ្នក​ប្រើ​ដែល​មាន​ឈ្មោះ​ '%s' នោះ​រួចហើយ ។"
-
-#: ../panels/user-accounts/um-user-manager.c:473
-#, c-format
-#| msgid "A user with the username '%s' already exists"
-msgid "No user with the name '%s' exists."
-msgstr "មិនមាន​អ្នក​ប្រើ​ដែល​មាន​ឈ្មោះ '%s' ។"
-
-#: ../panels/user-accounts/um-user-manager.c:631
-msgid "This user does not exist."
-msgstr "មិន​មាន​អ្នកប្រើ​នេះ​ទេ ។"
-
-#: ../panels/user-accounts/um-user-panel.c:371
-msgid "Failed to delete user"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​លុប​អ្នកប្រើ"
-
-#: ../panels/user-accounts/um-user-panel.c:431
-msgid "You cannot delete your own account."
-msgstr "អ្នក​មិន​អាច​លុប​គណនី​ផ្ទាល់ខ្លួន​របស់​អ្នក​បាន​ទេ ។"
-
-#: ../panels/user-accounts/um-user-panel.c:440
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s នៅ​តែ​ត្រូវ​បាន​ចូល"
-
-#: ../panels/user-accounts/um-user-panel.c:444
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "ការ​លុប​អ្នកប្រើ ខណៈ​ដែល​ពួកគេ​ចូល​អាច​ធ្វើឲ្យ​ប្រព័ន្ធ​ស្ថិត​ក្នុង​ស្ថានភាព​មិន​ប្រក្រតី ។"
-
-#: ../panels/user-accounts/um-user-panel.c:453
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "តើ​អ្នក​ចង់​រក្សាទុក​ឯកសារ​របស់ %s ដែរ​ឬ​ទេ ?"
-
-#: ../panels/user-accounts/um-user-panel.c:457
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
-"វា​ពិបាក​ក្នុង​ការ​រក្សាទុក​ថត​ផ្ទះ ស្ពូល​អ៊ីមែល និង​ឯកសារ​បណ្ដោះអាសន្ន​ណាស់ នៅ​ពេល​ដែល​លុប​គណនី​អ្នកប្រើ ។"
 
-#: ../panels/user-accounts/um-user-panel.c:460
-msgid "_Delete Files"
-msgstr "លុប​ឯកសារ"
-
-#: ../panels/user-accounts/um-user-panel.c:461
-msgid "_Keep Files"
-msgstr "រក្សាទុក​ឯកសារ"
-
-#: ../panels/user-accounts/um-user-panel.c:513
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "គណនី​​ត្រូវ​បាន​បិទ"
-
-#: ../panels/user-accounts/um-user-panel.c:521
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "ត្រូវ​កំណត់ នៅ​ពេល​ចូល​លើកក្រោយ"
-
-#: ../panels/user-accounts/um-user-panel.c:524
-msgctxt "Password mode"
-msgid "None"
-msgstr "គ្មាន"
-
-#: ../panels/user-accounts/um-user-panel.c:869
-msgid "Failed to contact the accounts service"
-msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ទាក់ទង​សេវា​គណនី"
-
-#: ../panels/user-accounts/um-user-panel.c:871
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "សូម​ប្រាកដ​ថា AccountService ត្រូវ​បាន​ដំឡើង និង​បើក ។"
-
-#: ../panels/user-accounts/um-user-panel.c:911
-msgid ""
-"To make changes,\n"
-"click the * icon first"
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
 msgstr ""
-"ដើម្បី​ធ្វើការ​ផ្លាស់ប្ដូរ\n"
-"ចុចរូប​តំណាង * ជាមុន​សិន"
 
-#: ../panels/user-accounts/um-user-panel.c:949
-msgid "Create a user account"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "បិទ"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "ឈ្មោះពេញ"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "ចូល​ស្វ័យប្រវត្តិ"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "ប្រភេទ​គណនី"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "អ្នក​គ្រប់គ្រង"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "យក​អ្នកប្រើ​ចេញ"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "ម្រាម​ផ្សេងទៀត ៖"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "បន្ថែម​អ្នកប្រើ"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "រូបតំណាង​អ្នកប្រើ"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
 msgstr "បង្កើត​គណនី​អ្នកប្រើ"
 
-#: ../panels/user-accounts/um-user-panel.c:960
-#: ../panels/user-accounts/um-user-panel.c:1271
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+#, fuzzy
+msgid "Add or remove users and change your password"
+msgstr "បន្ថែម ឬ​យក​គណនី​អ្នកប្រើ​ចេញ"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"To create a user account,\n"
-"click the * icon first"
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"ដើម្បី​បង្កើត​គណនី​អ្នកប្រើ\n"
-"ចុច​រូប​តំណាង * ជាមុន"
 
-#: ../panels/user-accounts/um-user-panel.c:969
-msgid "Delete the selected user account"
-msgstr "លុប​គណនី​អ្នកប្រើ​ដែល​បាន​ជ្រើស"
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:981
-#: ../panels/user-accounts/um-user-panel.c:1276
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "ចូល​ជា​​អ្នក​គ្រប់គ្រង​ដែន"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+#, fuzzy
 msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
-"ដើម្បី​លុប​គណនី​អ្នកប្រើ​ដែល​បាន​ជ្រើស\n"
-"ចុច​រូប​តំណាង * ជាមុន"
+"ដើម្បី​ប្រើ​ឈ្មោះ​ចូល​សហគ្រាស កុំព្យូទ័រ​នេះ​តម្រូវ​ឲ្យ​\n"
+"ចុះឈ្មោះ​នៅ​ក្នុង​ដែន ។ សូម​ឲ្យ​អ្នក​គ្រប់គ្រង​បណ្ដាញ​របស់​អ្នក\n"
+"វាយ​ពាក្យ​សម្ងាត់​ដែន​នៅ​ទី​នេះ ។"
 
-#: ../panels/user-accounts/um-user-panel.c:1174
-msgid "My Account"
-msgstr "គណនី​របស់​ខ្ញុំ"
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "ឈ្មោះ​អ្នក​គ្រប់គ្រង"
 
-#: ../panels/user-accounts/um-user-panel.c:1184
-msgid "Other Accounts"
-msgstr "គណនី​ផ្សេងទៀត"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "ពាក្យសម្ងាត់​អ្នក​គ្រប់គ្រង"
 
-#: ../panels/user-accounts/um-utils.c:512
-#, c-format
-msgid "A user with the username '%s' already exists"
-msgstr "មាន​អ្នកប្រើ​ដែល​មាន​ឈ្មោះ '%s' នោះ​រួច​ហើយ"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "គ្រប់គ្រង​គណនី​អ្នក​ប្រើ"
 
-#: ../panels/user-accounts/um-utils.c:516
-#, c-format
-msgid "The username is too long"
-msgstr "ឈ្មោះ​អ្នកប្រើ​វែង​ពេក"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "តម្រូវ​ឲ្យ​ផ្ទៀងផ្ទាត់ ដើម្បី​ផ្លាស់ប្ដូរ​ទិន្នន័យ​អ្នក​ប្រើ"
 
-#: ../panels/user-accounts/um-utils.c:519
-msgid "The username cannot start with a '-'"
-msgstr "ឈ្មោះ​អ្នកប្រើ​មិន​អាច​ចាប់ផ្ដើម​ដោយ '-' បាន​ឡើយ"
-
-#: ../panels/user-accounts/um-utils.c:522
-msgid ""
-"The username must only consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-"ឈ្មោះ​អ្នកប្រើ​អាច​មាន​តែ ៖\n"
-" ➣ តួអក្សរ​មក​ពី​អក្ខរក្រម​អង់គ្លេស\n"
-" ➣ តួ​លេខ\n"
-" ➣ តួអក្សរ​ណាមួយ '.', '-' និង '_'"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "ប៊ូតុង​ផែនទី"
 
-#: ../panels/wacom/button-mapping.ui.h:2
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "ប៊ូតុង​ផែនទី​ត្រូវ​ដំណើរការ"
 
-#. Text printed on screen
-#: ../panels/wacom/calibrator/gui_gtk.c:78
-msgid "Screen Calibration"
-msgstr "ការ​ក្រិត​ខ្នាត​អេក្រង់"
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ដើម្បី​កែសម្រួល​ផ្លូវកាត់ ចុច​ជួរ​ដេក និង​សង្កត់​គ្រាប់ចុច​ថ្មី ឬ​ចុច លុប​ថយក្រោយ (Backspace) ដើម្បី​សម្អាត ។"
 
-#: ../panels/wacom/calibrator/gui_gtk.c:79
+#: panels/wacom/button-mapping.ui:66
+#, fuzzy
+msgid "_Close"
+msgstr "បិទ"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr "សូម​ប្រើ​សញ្ញា​សម្គាល់​គោលដៅ នៅ​ពេល​ដែល​ពួកវា​បង្ហាញ​នៅ​លើ​អេក្រង់ ដើម្បី​ក្រិត​ខ្នាត tablet ។"
 
-#: ../panels/wacom/calibrator/gui_gtk.c:368
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "បាន​រក​ឃើញ​ការ​ចុច​មិន​ត្រឹមត្រូវ កំពុង​ចាប់ផ្ដើម​ឡើងវិញ..."
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Output:"
-msgstr "លទ្ធផល​ ៖"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "បង្កើត​ឧបករណ៍​និម្មិត"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:287
-msgid "Keep aspect ratio (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tablet"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "ទិស​ខាង​ឆ្វេង"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "ផែនទី​ត្រូវ​គ្រប់គ្រង..."
+
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
 msgstr "រក្សា​សមាមាត្រ (ប្រអប់​អក្សរ) ៖"
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:298
-msgid "Map to single monitor"
-msgstr "ផ្គូផ្គង​ទៅ​ម៉ូនីទ័រ​មួយ"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-nav-button.c:89
-#, c-format
-msgid "%d of %d"
-msgstr "%d នៃ %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "ក្រិត​ខ្នាត…"
 
-#: ../panels/wacom/cc-wacom-page.c:118 ../panels/wacom/cc-wacom-page.c:371
-#| msgid "None"
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "គ្មាន"
-
-#: ../panels/wacom/cc-wacom-page.c:119
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "ផ្ញើ​ការ​ចុច​គ្រាប់ចុច"
-
-#: ../panels/wacom/cc-wacom-page.c:120
-#| msgid "Switch Modes"
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "ប្ដូរ​ម៉ូនីទ័រ"
-
-#: ../panels/wacom/cc-wacom-page.c:601
-msgid "Up"
-msgstr "ឡើងលើ"
-
-#: ../panels/wacom/cc-wacom-page.c:601
-msgid "Down"
-msgstr "ចុះ​ក្រោម"
-
-#: ../panels/wacom/cc-wacom-page.c:638
-msgid "Switch Modes"
-msgstr "របៀប​ប្ដូរ"
-
-#: ../panels/wacom/cc-wacom-page.c:724
-#: ../panels/wacom/cc-wacom-stylus-page.c:376
-msgid "Button"
-msgstr "ប៊ូតុង"
-
-#: ../panels/wacom/cc-wacom-page.c:777
-msgid "Action"
-msgstr "សកម្មភាព"
-
-#: ../panels/wacom/cc-wacom-page.c:886
-msgid "Display Mapping"
-msgstr "ការ​ផ្គូផ្គង​ទិដ្ឋភាព"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr "Wacom Tablet"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set your Wacom tablet preferences"
-msgstr "កំណត់​ចំណូលចិត្ត Wacom tablet របស់​អ្នក"
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "Tablet (ដាច់ខាត)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "បន្ទះ​ប៉ះ (ធៀប)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "ចំណូលចិត្ត Tablet"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "រក​មិន​ឃើញ tablet ទេ"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "សូម​ដោត ឬ​បើក Wacom tablet របស់​អ្នក"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr "ការ​កំណត់​ប៊្លូធូស"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Map to Monitor..."
-msgstr "ផែនទី​ត្រូវ​គ្រប់គ្រង..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map Buttons..."
-msgstr "ប៊ូតុង​ផែនទី..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate..."
-msgstr "ក្រិត​ខ្នាត..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr "លៃ​តម្រូវ​គុណភាព​បង្ហាញ"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Tracking Mode"
-msgstr "របៀប​តាមដាន"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Left-Handed Orientation"
-msgstr "ទិស​ខាង​ឆ្វេង"
-
-#: ../panels/wacom/gsd-wacom-device.c:1010
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "របៀប​រង្វង់​ខាងឆ្វេង #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1019
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "របៀប​រង្វង់​ខាង​ស្ដាំ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1049
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "របៀប Touchstrip ខាង​ឆ្វេង #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1058
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "របៀប Touchstrip ខាង​ស្ដាំ#%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1075
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "ប្ដូរ​​របៀប Touchring ខាង​ឆ្វេង"
-
-#: ../panels/wacom/gsd-wacom-device.c:1077
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "ប្ដូរ​របៀប Touchring ខាង​ស្ដាំ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1080
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "ប្ដូរ​របៀប Touchstrip ខាង​ឆ្វេង"
-
-#: ../panels/wacom/gsd-wacom-device.c:1082
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "ប្ដូរ​របៀប Touchstrip ខាង​ស្ដាំ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1087
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "ប្ដូរ​របៀប #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1159
-#, c-format
-msgid "Left Button #%d"
-msgstr "ប៊ូតុង​ឆ្វេង #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1162
-#, c-format
-msgid "Right Button #%d"
-msgstr "ប៊ូតុង​ស្ដាំ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1165
-#, c-format
-msgid "Top Button #%d"
-msgstr "ប៊ូតុង​ខាង​លើ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1168
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "ប៊ូតុង​ខាងក្រោម #%d"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "គ្មាន​សកម្មភាព"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "ចុច​ប៊ូតុង​កណ្ដុរ​ឆ្វេង"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "ចុច​ប៊ូតុង​កណ្ដុរ​ស្ដាំ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "ចុច​ប៊ូតុង​កណ្ដុរ​ស្ដាំ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "រមូរ​ឡើងលើ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "រមូរ​ចុះក្រោម"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "រមូរ​ទៅ​ឆ្វេង"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "រមូរ​ទៅ​ស្ដាំ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "ថយក្រោយ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "ទៅមុខ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "ដែកចារ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "រូបរាង​របស់​ជ័រលុប"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "ទន់"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "រឹង"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "ប៊ូតុង​ខាងលើ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "ប៊ូតុង​ខាងក្រោម"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "រូបរាង​ចុង​ប៊ិក"
 
-#: ../shell/control-center.c:58
-msgid "Enable verbose mode"
-msgstr "បើក​របៀប​បរិយាយ"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "ទន់"
 
-#: ../shell/control-center.c:59
-msgid "Show the overview"
-msgstr "បង្ហាញ​ទិដ្ឋភាព​ទូទៅ"
-
-#: ../shell/control-center.c:60 ../shell/control-center.c:61
-#: ../shell/control-center.c:62
-msgid "Show help options"
-msgstr "បង្ហាញ​ជម្រើស​ជំនួយ"
-
-#: ../shell/control-center.c:63
-msgid "Panel to display"
-msgstr "បន្ទះ​ត្រូវ​បង្ហាញ"
-
-#: ../shell/control-center.c:85
-msgid "- System Settings"
-msgstr "ការ​កំណត់​ប្រព័ន្ធ"
-
-#: ../shell/control-center.c:93
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-"%s\n"
-"ដំណើរការ '%s --help' ដើម្បី​មើល​បញ្ជី​ទាំងមូល​នៃ​ជម្រើស​បន្ទាត់​ពាក្យ​បញ្ជា​ដែល​មាន ។\n"
 
-#: ../shell/control-center.c:211
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "រឹង"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "ប៊ូតុង"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ប៊ូតុង"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ប៊ូតុង"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "រូបរាង​របស់​ជ័រលុប"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "រូបរាង​របស់​ជ័រលុប"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "ចុច​ប៊ូតុង​កណ្ដុរ​ស្ដាំ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "ចុច​ប៊ូតុង​កណ្ដុរ​ស្ដាំ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "ទៅមុខ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "ប្លង់"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+#, fuzzy
+msgid "Behaviour"
+msgstr "ឥរិយាបថ"
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "ត្រាប់តាម​ការ​ចុច​លើក​ទី​ពីរ"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "កម្មវិធី​សម្រាប់​វីនដូ"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "ជិត​អស់​ទឹក​ថ្នាំ"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "ពន្យារពេល​ក្នុង​ការ​ចុច​លើក​ទី​ពីរ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "កម្មវិធី​សម្រាប់​វីនដូ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "បន្ថែម"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "សេចក្ដី​លម្អិត"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "ពេលវេលា​តាម​បណ្ដាញ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "ការ​កំណត់​បណ្ដាញ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "លេខ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "ប្រភេទ​ឧបករណ៍"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+#, fuzzy
+msgid "Manufacturer"
+msgstr "ក្រុមហ៊ុនផលិត ៖"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "បាត់​កម្មវិធី​បង្កប់"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "រលក​អាកាស​ចល័ត"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "ពេលវេលា​តាម​បណ្ដាញ"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "បណ្ដាញ"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "កម្រិត​ខ្ពស់"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "ឈ្មោះ​ចូល"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "ចាក់សោ"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "សេចក្ដី​លម្អិត"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "ឈ្មោះ​បណ្ដាញ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "ស្វ័យប្រវត្តិ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "ភ្លេច​បណ្ដាញ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "បើក​ដោយ​ក្ដារចុច"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "រក​មិន​ឃើញ​អាដាប់ទ័រ​ប៊្លូធូស"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "នៅ​ពេល​ជិះ​យន្ដហោះ"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "ការ​តភ្ជាប់"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "មិន​បាន​បញ្ចូល​ស៊ីមកាត"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "ចាក់សោ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "ផ្លាស់ប្ដូរ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "ភ្លេច​បណ្ដាញ"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "ការ​កំណត់ %s"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "ការ​កំណត់​ទាំងអស់"
+
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "ប៊ូតុង​ចម្បង"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "ជំនួយ"
 
-#: ../shell/control-center.c:212
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "ទូទៅ"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Quit"
 msgstr "ចេញ"
 
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "មជ្ឈមណ្ឌល​បញ្ជា"
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "ស្វែងរក"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
-msgid "System Settings"
-msgstr "ការ​កំណត់​ប្រព័ន្ធ"
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "ប្ដូរ​ទៅ​ប្រភព​មុន"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "បោះបង់"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "ចំណូលចិត្ត;ការ​កំណត់;"
 
-#: ../shell/shell.ui.h:2
-#| msgid "_All Settings"
-msgid "All Settings"
-msgstr "ការ​កំណត់​ទាំងអស់"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "បញ្ចេញ %u"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "បញ្ចូល %u"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "ផ្លាស់ប្ដូរ​រាល់​ថ្ងៃ"
+
+#~| msgid "Tile"
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "ក្រឡា​ក្បឿង"
+
+#~| msgid "Zoom"
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "ពង្រីក"
+
+#~| msgid "Center"
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "កណ្ដាល"
+
+#~| msgid "Fill"
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "បំពេញ"
+
+#~| msgid "Span"
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "វិសាលភាព"
+
+#~| msgid "Select an account"
+#~ msgid "Select Background"
+#~ msgstr "ជ្រើស​ផ្ទៃ​ខា​ងក្រោយ"
+
+#~| msgid "Picture CD"
+#~ msgid "Pictures"
+#~ msgstr "រូបភាព"
+
+#~| msgid "Color"
+#~ msgid "Colors"
+#~ msgstr "ពណ៌"
+
+#~ msgid "multiple sizes"
+#~ msgstr "ទំហំ​ជាច្រើន"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "គ្មាន​ផ្ទៃខាងក្រោយ​របស់​ផ្ទៃតុ"
+
+#~ msgid "Current background"
+#~ msgstr "ផ្ទៃខាងក្រោយ​បច្ចុប្បន្ន"
+
+#~| msgid "Change the background and theme"
+#~ msgid "Change the background"
+#~ msgstr "ផ្លាស់ប្ដូរ​ផ្ទៃខាងក្រោយ"
+
+#, fuzzy
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "ផ្ទាំង​រូបភាព អេក្រង់ ផ្ទៃតុ"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "រៀបចំ​ឧបករណ៍​ថ្មី"
+
+#~ msgid "Paired"
+#~ msgstr "បាន​ផ្គូ"
+
+#~ msgid "Mouse and Touchpad Settings"
+#~ msgstr "ការ​កំណត់​កណ្ដុរ និង​បន្ទះ​ប៉ះ"
+
+#~ msgid "Send Files..."
+#~ msgstr "ផ្ញើ​ឯកសារ..."
+
+#~ msgid "Browse Files..."
+#~ msgstr "រកមើល​ឯកសារ..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "ប៊្លូធូស"
+
+#~ msgid "Yes"
+#~ msgstr "បាទ/ចាស"
+
+#, c-format
+#~ msgid "Visibility of “%s”"
+#~ msgstr "ភាព​អាច​មើល​ឃើញ​នៃ “%s”"
+
+#, c-format
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "យក '%s' ចេញ​ពី​បញ្ជី​ឧបករណ៍​ឬ ?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr "ប្រសិនបើ​អ្នក​យក​ឧបករណ៍​ចេញ អ្នក​ត្រូវតែ​រៀបចំ​វា​ម្ដងទៀត មុន​នឹង​ប្រើ​នៅ​ពេលក្រោយ ។"
+
+#~ msgid "Other profile…"
+#~ msgstr "ទម្រង់​ផ្សេងទៀត…"
+
+#~ msgid "Default: "
+#~ msgstr "លំនាំដើម ៖ "
+
+#~ msgid "Test profile: "
+#~ msgstr "ទម្រង់​សាកល្បង ៖ "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ជ្រើស​ឯកសារ​ទម្រង់ ICC"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ការ​បង្ហាញ"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ម៉ាស៊ីន​ស្កេន"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ម៉ាស៊ីន​បោះពុម្ព"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ម៉ាស៊ីន​ថត"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​វិបខេម"
+
+#~ msgid "Available Profiles"
+#~ msgstr "ទម្រង់​ដែល​អាច​ប្រើ​បាន"
+
+#~ msgid "Device"
+#~ msgstr "ឧបករណ៍"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "បង្កើត​ទម្រង់​ពណ៌​សម្រាប់​ឧបករណ៍​ដែល​បាន​ជ្រើស"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "ឧបករណ៍​វាស់​មិន​ត្រូវ​បាន​រក​ឃើញ ។ សូម​ពិនិត្យមើល​ថា វា​ត្រូវ​បាន​បើក និង​ត្រូវ​បាន​តភ្ជាប់​ត្រឹមត្រូវ ។"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "ឧបករណ៍​វាស់​មិន​គាំទ្រ​ការ​រៀបចំ​ទម្រង់​ម៉ាស៊ីន​បោះពុម្ព​ទេ ។"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "ប្រភេទ​ឧបករណ៍​បច្ចុប្បន្ន​មិន​ត្រូវ​បាន​គាំទ្រ ។"
+
+#~ msgid "Cannot remove automatically added profile"
+#~ msgstr "មិន​អាច​យក​ទម្រង់​ដែល​បាន​បន្ថែម​ដោយ​ស្វ័យប្រវត្តិ​ចេញ​បាន​ទេ"
+
+#, c-format
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i ឆ្នាំ"
+
+#, c-format
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i ខែ"
+
+#, c-format
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i សប្ដាហ៍"
+
+#, c-format
+#~ msgid "Less than 1 week"
+#~ msgstr "តិច​ជាង ១ សប្ដាហ៍"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB លំនាំដើម"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK លំនាំដើម"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "ប្រផេះ​តាម​លំនាំដើម"
+
+#~ msgid "Uncalibrated"
+#~ msgstr "មិន​បាន​ក្រិត​ខ្នាត"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "ឧបករណ៍​នេះ​មិន​ត្រូវ​បាន​គ្រប់គ្រង​តាម​ពណ៌ ។"
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "ឧបករណ៍​នេះ​កំពុង​ប្រើ​ទិន្នន័យ​ដែល​បាន​ក្រិត​ខ្នាត​ពី​ក្រុមហ៊ុន​ផលិត ។"
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "ឧបករណ៍​នេះ​មិន​មាន​ទម្រង់​ដែល​សមស្រប​សម្រាប់​ការ​កែតម្រូវ​ពណ៌​អេក្រង់​ទាំងមូល​ទេ ។"
+
+#~ msgid "This device has an old profile that may no longer be accurate."
+#~ msgstr "ឧបករណ៍​នេះ​មាន​ទម្រង់​ចាស់​ដែល​អាច​នឹង​លែង​មាន​សុក្រឹតភាព​ទៀត ។"
+
+#~ msgid "Not specified"
+#~ msgstr "មិន​ត្រូវ​បាន​បញ្ជាក់"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "រក​មិន​ឃើញ​ឧបករណ៍​ដែល​គាំទ្រ​ការ​គ្រប់គ្រង​ពណ៌​ទេ"
+
+#~ msgctxt "Device kind"
+#~ msgid "Scanner"
+#~ msgstr "ម៉ាស៊ីន​ស្កេន"
+
+#~ msgctxt "Device kind"
+#~ msgid "Printer"
+#~ msgstr "ម៉ាស៊ីន​បោះពុម្ព"
+
+#~ msgctxt "Device kind"
+#~ msgid "Webcam"
+#~ msgstr "វិបខេម"
+
+#~ msgid "Add device"
+#~ msgstr "បន្ថែម​ឧបករណ៍"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "បន្ថែម​ឧបករណ៍​និម្មិត"
+
+#~ msgid "Remove a device"
+#~ msgstr "យក​ឧបករណ៍​ចេញ"
+
+#~ msgid "Device type:"
+#~ msgstr "ប្រភេទ​ឧបករណ៍ ៖"
+
+#~ msgid "Model:"
+#~ msgstr "ម៉ូដែល ៖"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "ឯកសារ​រូបភាព​អាច​ត្រូវ​បាន​អូស​នៅ​លើ​បង្អួច​នេះ ដើម្បី​បំពេញ​វាល​ខាងលើ​ដោយ​ស្វ័យប្រវត្តិ ។"
+
+#~ msgid "Color management settings"
+#~ msgstr "ការ​កំណត់​ការ​គ្រប់គ្រង​ពណ៌"
+
+#~ msgid "English"
+#~ msgstr "អង់គ្លេស"
+
+#~ msgid "British English"
+#~ msgstr "ចក្រភព​អង់គ្លេស"
+
+#~| msgid "Germany"
+#~ msgid "German"
+#~ msgstr "អាល្លឺម៉ង់"
+
+#~ msgid "French"
+#~ msgstr "បារាំង"
+
+#~| msgid "Span"
+#~ msgid "Spanish"
+#~ msgstr "អេស្ប៉ាញ"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "ចិន (អក្សរ​កាត់)"
+
+#~ msgid "Russian"
+#~ msgstr "រុស្ស៊ី"
+
+#~ msgid "Arabic"
+#~ msgstr "អារ៉ាប់"
+
+#~ msgid "United States"
+#~ msgstr "សហរដ្ឋ​អាមេរិក"
+
+#~ msgid "Germany"
+#~ msgstr "អាល្លឺម៉ង់"
+
+#~ msgid "France"
+#~ msgstr "បារាំង"
+
+#~ msgid "Spain"
+#~ msgstr "អេស្ប៉ាញ"
+
+#~ msgid "China"
+#~ msgstr "ចិន"
+
+#~ msgid "Select a region"
+#~ msgstr "ជ្រើស​តំបន់"
+
+#~ msgid "Unspecified"
+#~ msgstr "មិន​បាន​បញ្ជាក់"
+
+#~ msgid "_Region:"
+#~ msgstr "តំបន់ ៖"
+
+#~ msgid "_City:"
+#~ msgstr "ទីក្រុង ៖"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "កំណត់​ពេលវេលា​ទៅ​មុខ​មួយ​ម៉ោង ។"
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "កំណត់​ពេលវេលា​ថយ​ក្រោយ​មួយ​ម៉ោង ។"
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "កំណត់​ពេលវេលា​ទៅ​មុខ​មួយ​នាទី ។"
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "កំណត់​ពេលវេលា​ថយក្រោយ​មួយ​នាទី ។"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "ប្ដូរ​ឆ្លាស់​រវាង​ ព្រឹក និង​ល្ងាច ។"
+
+#~ msgid "24-hour"
+#~ msgstr "២៤ ម៉ោង"
+
+#~ msgid "AM/PM"
+#~ msgstr "ព្រឹក/ល្ងាច"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "ផ្ទាំង​ចំណូលចិត្ត​កាលបរិច្ឆេទ និង​ពេលវេលា"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "ធម្មតា"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "ច្រាស​ទ្រនិច​នាឡិកា"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "១៨០ ដឺក្រេ"
+
+#, c-format
+#~ msgid "%d x %d (%s)"
+#~ msgstr "%d x %d (%s)"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "ជ្រើស​ម៉ូនីទ័រ ដើម្បី​ផ្លាស់ប្ដូរ​លក្ខណសម្បត្តិ​របស់​វា អូស​វា ដើម្បី​រៀបចំ​ទីតាំង​របស់​វា​ជា​ថ្មី ។"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#, c-format
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​អនុវត្ត​ការ​កំណត់​រចនាសម្ព័ន្ធ ៖ %s"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "រក​មិន​ឃើញ​ទិដ្ឋភាព"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "មិន​អាច​ទទួល​បាន​ព័ត៌មាន​អេក្រង់"
+
+#~ msgid "_Resolution"
+#~ msgstr "គុណភាព​បង្ហាញ"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "បង្ហាញ​ទិដ្ឋភាព"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "ចំណាំ ៖ អាច​នឹង​កំណត់​ជម្រើស​គុណភាព​បង្ហាញ"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "រក​ឃើញ​ទិដ្ឋភាព"
+
+#, c-format
+#~ msgid "VESA: %s"
+#~ msgstr "VESA ៖ %s"
+
+#~ msgid "Unknown"
+#~ msgstr "មិន​ស្គាល់"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d ប៊ីត"
+
+#~ msgid "Unknown model"
+#~ msgstr "មិន​ស្គាល់​ម៉ូដែល"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "ការ​ចូល​បន្ទាប់​នឹង​ប៉ុនប៉ង​ប្រើ​កម្រិត​ស្ដង់ដារ ។"
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr "ការ​ចូល​បន្ទាប់​នឹង​ប្រើ​របៀប fallback ដែល​បម្រុងទុក​សម្រាប់​ផ្នែក​រឹង​ក្រាហ្វិក​ដែល​មិន​គាំទ្រ ។"
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Fallback"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "ស្ដង់ដារ"
+
+#~ msgid "Ask what to do"
+#~ msgstr "សួរ​អ្វី​ដែល​ត្រូវ​ធ្វើ"
+
+#~ msgid "Do nothing"
+#~ msgstr "មិន​ធ្វើ​អ្វី​ទាំងអស់"
+
+#~ msgid "Open folder"
+#~ msgstr "បើក​ថត"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ជ្រើស​កម្មវិធី​សម្រាប់​ស៊ីឌី​អូឌីយ៉ូ"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "ជ្រើស​កម្មវិធី​សម្រាប់​ឌីវីឌី​វីដេអូ"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "ជ្រើស​កម្មវិធី​ដែល​ត្រូវ​ដំណើរការ នៅ​ពេល​កម្មវិធី​ចាក់​តន្ត្រី​ត្រូវ​បាន​តភ្ជាប់"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "ជ្រើស​កម្មវិធី​ដែល​ត្រូវ​ដំណើរការ នៅ​ពេល​ម៉ាស៊ីន​ថត​ត្រូវ​បាន​តភ្ជាប់"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "ជ្រើស​កម្មវិធី​សម្រាប់​ស៊ីឌី​កម្មវិធី"
+
+#~ msgid "audio DVD"
+#~ msgstr "ឌីវីឌី​អូឌីយ៉ូ"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "ថាស​ប៊្លូរ៉េយ៍​ទទេ"
+
+#~ msgid "blank CD disc"
+#~ msgstr "ថាស​ស៊ីឌី​ទទេ"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "ថាស​ឌីវីឌី​ទទេ"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "ថាស​ឌីវីឌី HD ទទេ"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "ថាស​វីដេអូ​ប៊្លូរ៉េយ៍"
+
+#~ msgid "e-book reader"
+#~ msgstr "កម្មវិធី​អាន​សៀវភៅ​អេឡិចត្រូនិក"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "ថាស​វីដេអូ​ឌីវីឌី HD"
+
+#~ msgid "Picture CD"
+#~ msgstr "ស៊ីឌី​រូបភាព"
+
+#~ msgid "Super Video CD"
+#~ msgstr "ស៊ីឌី​វីដេអូ​កម្រិតខ្ពស់"
+
+#~ msgid "Video CD"
+#~ msgstr "ស៊ីឌី​វីដេអូ"
+
+#~ msgid "Overview"
+#~ msgstr "ទិដ្ឋភាព​ទូទៅ"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "ប្រព័ន្ធ​ទាន់សម័យ"
+
+#~ msgid "Checking for Updates"
+#~ msgstr "រកមើល​បច្ចុប្បន្នភាព"
+
+#~ msgid "OS type"
+#~ msgstr "ប្រភេទ​ប្រព័ន្ធ​ដំណើរការ"
+
+#~ msgid "Disk"
+#~ msgstr "ថាស"
+
+#~ msgid "_Other Media..."
+#~ msgstr "មេឌៀ​ផ្សេងទៀត..."
+
+#~ msgid "Experience"
+#~ msgstr "ជាន់ខ្ពស់"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "របៀប Forced _Fallback"
+
+#~| msgid "Take a screenshot of an area"
+#~ msgid "Save a screenshot to Pictures"
+#~ msgstr "ថត​រូប​អេក្រង់​​ជា​រូបភាព"
+
+#~| msgid "Take a screenshot of a window"
+#~ msgid "Save a screenshot of a window to Pictures"
+#~ msgstr "រក្សាទុក​រូបថត​​អេក្រង់​របស់​វីនដូ​ជា​រូបភាព"
+
+#~| msgid "Take a screenshot of an area"
+#~ msgid "Save a screenshot of an area to Pictures"
+#~ msgstr "រក្សាទុក​រូបថត​អេក្រង់​នៃ​ផ្ទៃ​ជា​រូបភាព"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "ចម្លង​រូបថត​អេក្រង់​ទៅកាន់​ក្ដារ​តម្បៀត​ខ្ទាស់"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "ចម្លង​រូបថត​អេក្រង់​បង្អួច​ទៅកាន់​ក្ដារ​តម្បៀត​ខ្ទាស់"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "ចម្លង​រូបថត​អេក្រង់​នៃ​ផ្ទៃ​ទៅកាន់​ក្ដារ​តម្បៀត​ខ្ទាស់"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​ក្ដារចុច"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "ផ្លូវកាត់​ផ្ទាល់ខ្លួន"
+
+#~ msgid "Slow"
+#~ msgstr "យឺត"
+
+#~ msgid "Fast"
+#~ msgstr "លឿន"
+
+#~ msgid "S_peed:"
+#~ msgstr "ល្បឿន ៖"
+
+#~ msgid "Layout Settings"
+#~ msgstr "ការ​កំណត់​ប្លង់"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "យក​ផ្លូវកាត់​ចេញ"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<មិន​ស្គាល់​សកម្មភាព>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "មិន​អាច​ប្រើ​ផ្លូវកាត់ \"%s\" បាន​ទេ ពីព្រោះ​វា​នឹង​ធ្វើឲ្យ​មិន​អាច​វាយ​ដោយ​ប្រើ​គ្រាប់​ចុច​នេះ​បាន ។\n"
+#~ "សូម​ព្យាយាម​ប្រើ​គ្រាប់ចុច​ដូចជា បញ្ជា (Control) ជំនួស (Alt) ឬ​ប្ដូរ (Shift) ក្នុង​ពេល​តែមួយ ។"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "ផ្លូវកាត់ \"%s\" ត្រូវ​បាន​ប្រើ​សម្រាប់\n"
+#~ "\"%s\" រួចហើយ"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "ប្រសិនបើ​អ្នក​កំណត់​ផ្លូវកាត់​ឡើងវិញ​ទៅជា \"%s\" ផ្លូវកាត់ \"%s\" នឹង​ត្រូវ​បាន​បិទ ។"
+
+#~ msgid "_Reassign"
+#~ msgstr "កំណត់​ឡើងវិញ"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "កំណត់​ចំណូលចិត្ត​កណ្ដុរ និង​បន្ទះ​ប៉ះ​របស់​អ្នក"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "អស់​ពេល​ចុច​ទ្វេ​ដង"
+
+#~| msgctxt "balance"
+#~| msgid "Left"
+#~ msgid "_Left"
+#~ msgstr "ឆ្វេង"
+
+#~| msgctxt "balance"
+#~| msgid "Right"
+#~ msgid "_Right"
+#~ msgstr "ស្ដាំ"
+
+#~| msgid "Pointer Speed"
+#~ msgid "_Pointer speed"
+#~ msgstr "ល្បឿន​ព្រួញ​កណ្ដុរ"
+
+#~| msgid "Two-_finger scrolling"
+#~ msgid "Two _finger scroll"
+#~ msgstr "រមូរ​ដោយ​ប្រើម្រាមដៃ​ពីរ"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "មាតិកា​ជាប់​នឹង​ម្រាមដៃ"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "ចុច​ប្រាំ​ដង GEGL ដង !"
+
+#~| msgid "Double-click timeout"
+#~ msgid "Double click, primary button"
+#~ msgstr "​ចុច​ទ្វេ​ដង ប៊ូតុង​ចម្បង"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "ចុច​ម្ដង​ប៊ូតុង​សំខាន់"
+
+#~| msgid "Double-click timeout"
+#~ msgid "Double click, middle button"
+#~ msgstr "ចុច​ទ្វេ​ដង ប៊ូតុង​កណ្ដាល"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "ចុច​ម្ដង ប៊ូតុង​កណ្ដាល"
+
+#~| msgid "Double-click timeout"
+#~ msgid "Double click, secondary button"
+#~ msgstr "​ចុច​ទ្វេ​ដង ប៊ូតុង​រង"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "ចុច​ម្ដង​ប៊ូតុង​រង"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "សេវា​បណ្ដាញ​ប្រព័ន្ធ​មិន​ឆប​ជាមួយ​កំណែ​នេះ​ទេ ។"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "WEP"
+#~ msgstr "បណ្ដាញ"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "សហគ្រាស"
+
+#~| msgid "None"
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "គ្មាន"
+
+#~| msgid "None"
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "គ្មាន"
+
+#~| msgctxt "Password strength"
+#~| msgid "Weak"
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "ខ្សោយ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "គ្មាន​បញ្ហា"
+
+#~| msgid "Good"
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "ល្អ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "ប្រសើរ​ណាស់"
+
+#, c-format
+#~ msgid ""
+#~ "Network details for %s including password and any custom configuration "
+#~ "will be lost"
+#~ msgstr ""
+#~ "សេចក្ដី​លម្អិត​អំពី​បណ្ដាញ​សម្រាប់ %s ដែល​រួម​មាន​ពាក្យសម្ងាត់ និង​ការ​កំណត់​រចនាសម្ព័ន្ធ​ផ្ទាល់ខ្លួន​ណាមួយ​នឹង​"
+#~ "ត្រូវ​បាត់បង់"
+
+#~ msgid "Forget"
+#~ msgstr "ភ្លេច"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can use "
+#~ "it to share your internet connection with others."
+#~ msgstr ""
+#~ "ប្រសិន​បើ​អ្នក​មាន​ការ​តភ្ជាប់​​អ៊ីនធឺណិត​ក្រៅ​ពី​​ប្រើ​ប្រព័ន្ធ​ឥត​ខ្សែ អ្នក​អាច​ប្រើ​វា ដើម្បី​ចែករំលែក​ការ​តភ្ជាប់​"
+#~ "អ៊ីនធឺណីត​ជា​មួយ​អ្នក​ផ្សេង ។"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "បើក​ hotspot ឥតខ្សែ​នឹង​ផ្ដាច់​អ្នក​ពី <b>%s</b> ។"
+
+#~ msgid ""
+#~ "It is not possible to access the internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "មិនអាច​ចូលប្រើ​អ៊ីនធឺណិត​តាមរយៈ​ប្រព័ន្ធ​ឥតខ្សែ​របស់​អ្នក​បាន​ទេ ខណៈ​ដែល​ hotspot សកម្ម ។"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "បញ្ឈប់ hotspot និង​ផ្ដាច់​អ្នកប្រើ​ណា​ម្នាក់​ឬ ?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "បញ្ឈប់ Hotspot"
+
+#~| msgid "Out of toner"
+#~ msgid "Out of range"
+#~ msgstr "ក្រៅ​ជួរ"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "ការ​រក​ឃើញ​ប្រូកស៊ី​បណ្ដាញ​ស្វ័យប្រវត្តិ​នឹង​ត្រូវ​បាន​ប្រើ នៅ​ពេល​ URL កំណត់​រចនាសម្ព័ន្ធ​មិន​ត្រូវ​បាន​ផ្ដល់ ។"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "វា​មិន​ត្រូវ​បាន​ផ្ដល់​អនុសាសន៍​សម្រាប់​បណ្ដាញ​សាធារណៈ​ដែល​មិន​គួរ​ទុកចិត្ត​នោះ​ទេ ។"
+
+#~ msgid "Proxy"
+#~ msgstr "ប្រូកស៊ី"
+
+#~ msgid "_Options..."
+#~ msgstr "ជម្រើស..."
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "គ្មាន"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "ជ្រើស​ចំណុច​ប្រទាក់​ដែល​ត្រូវ​ប្រើ​សម្រាប់​សេវា​ថ្មី"
+
+#~| msgid "Create..."
+#~ msgid "C_reate..."
+#~ msgstr "បង្កើត..."
+
+#~| msgid "Interface"
+#~ msgid "_Interface"
+#~ msgstr "ចំណុច​ប្រទាក់"
+
+#~ msgid "VPN Type"
+#~ msgstr "ប្រភេទ VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "ឈ្មោះ​ក្រុម"
+
+#~ msgid "Group Password"
+#~ msgstr "ពាក្យសម្ងាត់​ជា​ក្រុម"
+
+#~ msgid "_Configure..."
+#~ msgstr "កំណត់​រចនាសម្ព័ន្ធ..."
+
+#~| msgid "Wireless mouse"
+#~ msgid "Wireless Hotspot"
+#~ msgstr "otspot ​ឥត​ខ្សែ"
+
+#~ msgid "Wireless"
+#~ msgstr "ឥត​ខ្សែ"
+
+#~ msgid "_Use as Hotspot..."
+#~ msgstr "ប្រើ​ជា Hotspot..."
+
+#~| msgid "Connected"
+#~ msgid "Connected Devices"
+#~ msgstr "ឧបករណ៍​ដែល​បាន​តភ្ជាប់"
+
+#~ msgid "Security Key"
+#~ msgstr "សោ​សុវត្ថិភាព"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "របាំង​បណ្ដាញ​រង"
+
+#~ msgid "Mesh"
+#~ msgstr "សំណាញ់"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "ហេដ្ឋារចនាសម្ព័ន្ធ"
+
+#~ msgid "Status unknown"
+#~ msgstr "មិន​ស្គាល់​ស្ថានភាព"
+
+#~ msgid "Unmanaged"
+#~ msgstr "មិនបាន​គ្រប់គ្រង"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "ខ្សែ​ត្រូវ​បាន​ដក"
+
+#~ msgid "Unavailable"
+#~ msgstr "មិន​អាច​ប្រើ​បាន"
+
+#~ msgid "Disconnected"
+#~ msgstr "បាន​ផ្ដាច់"
+
+#~ msgid "Connecting"
+#~ msgstr "តភ្ជាប់"
+
+#~ msgid "Disconnecting"
+#~ msgstr "ផ្ដាច់"
+
+#~ msgid "Connection failed"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​តភ្ជាប់"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "(បាត់) មិន​ស្គាល់​ស្ថានភាព"
+
+#~| msgid "Connection failed"
+#~ msgid "Configuration failed"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​កំណត់​រចនាសម្ព័ន្ធ"
+
+#~| msgid "Connection failed"
+#~ msgid "IP configuration failed"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​កំណត់​រចនាសម្ព័ន្ធ IP"
+
+#~| msgid "_Configuration URL"
+#~ msgid "IP configuration expired"
+#~ msgstr "ការ​កំណត់​រចនាសម្ព័ន្ធ IP បាន​ផុត​កំណត់"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "ទាមទារ​ភាព​សម្ងាត់ ប៉ុន្តែ​មិន​បាន​ផ្ដល់​ទេ"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "បាន​ផ្ដាច់ 802.1x supplicant"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​កំណត់​រចនាសម្ព័ន្ធ 802.1x supplicant"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "បាន​បរាជ័យ 802.1x supplicant"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant ត្រូវ​ការ​ពេលវាលា​ច្រើន​ ដើម្បី​ផ្ទៀងផ្ទាត់"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "សកម្ម PPP បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម"
+
+#~| msgid "Disconnected"
+#~ msgid "PPP service disconnected"
+#~ msgstr "បាន​ផ្ដាច់​សេវាកម្ម PPP"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP បាន​បរាជ័យ"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "ម៉ាស៊ីន​ភ្ញៀវ DHCP បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម"
+
+#~ msgid "DHCP client error"
+#~ msgstr "កំហុស​ម៉ាស៊ីន​ភ្ញៀវ DHCP"
+
+#~| msgid "Connection failed"
+#~ msgid "DHCP client failed"
+#~ msgstr "ម៉ាស៊ីន​ភ្ញៀវ DHCP បាន​បរាជ័យ"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "សេវាកម្ម​តភ្ជាប់​ដែល​បាន​ចែក​រំលែក​បាន​បរាជ័យ​ក្នុងការ​ចាប់ផ្ដើម"
+
+#~| msgid "Connection failed"
+#~ msgid "Shared connection service failed"
+#~ msgstr "សេវាកម្ម​តភ្ជាប់​ដែល​បាន​ចែករំលែក​បាន​បរាជ័យ"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "សេវាកម្ម AutoIP បាន​បរាជ័យ​ក្នុងការ​ចាប់ផ្ដើម"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "កំហុស​សេវាកម្ម AutoIP"
+
+#~| msgid "Authentication failed"
+#~ msgid "AutoIP service failed"
+#~ msgstr "សេវាកម្ម AutoIP បាន​បរាជ័យ"
+
+#~ msgid "Line busy"
+#~ msgstr "ជាប់​រវល់"
+
+#~ msgid "No dial tone"
+#~ msgstr "គ្មាន​សំឡេង​ចុច"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "គ្មានភ្នាក់ងារ​បញ្ជូន​អាច​ត្រូវ​បាន​បង្កើត"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "សំណើរ​ហៅ​អស់​ពេល"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "បាន​បរាជ័យ​ក្នុងការ​ប៉ុនប៉ង​ហៅ"
+
+#~| msgid "Authentication failed"
+#~ msgid "Modem initialization failed"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម​ម៉ូដឹម"
+
+#~| msgid "Failed to delete user"
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ជ្រើស​ APN ដែល​បាន​បញ្ជាក់"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "មិន​ស្វែងរក​បណ្ដាញ"
+
+#~| msgid "Network settings"
+#~ msgid "Network registration denied"
+#~ msgstr "បាន​បដិសេធ​ការ​ចុះឈ្មោះ​​បណ្ដាញ"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "ការ​ចុះ​ឈ្មោះ​បណ្ដាញ​បាន​អស់​ពេល"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "បាន​បរាជ័យ​ក្នុងការ​ចុះឈ្មោះ​ជា​មួយ​បណ្ដាញ​ដែល​បាន​ស្នើ"
+
+#~ msgid "PIN check failed"
+#~ msgstr "ការ​ពិនិត្យ​​មើល PIN បាន​បរាជ័យ"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firmware សម្រាប់​ឧបករណ៍​អាច​បាត់"
+
+#~| msgid "Connection failed"
+#~ msgid "Connection disappeared"
+#~ msgstr "ការ​ត​ភ្ជាប់​មិន​បាន​បង្ហាញ​ទេ"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "បាន​ផ្លាស់ប្ដូរ​ភ្នាក់ងារ​បញ្ជូន/តំណ"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "បាន​សន្មត​ការ​តភ្ជាប់​ដែល​មាន​ស្រាប់"
+
+#~ msgid "Modem not found"
+#~ msgstr "រក​មិន​ឃើញ​ម៉ូដឹម"
+
+#~| msgid "Connection failed"
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​តភ្ជាប់​ប៊្លូធូស"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "ទាមទារ PIN ស៊ីមកាត​"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "ទាមទារ Puk ស៊ីមកាត​"
+
+#~| msgctxt "Password strength"
+#~| msgid "Strong"
+#~ msgid "SIM wrong"
+#~ msgstr "ស៊ីម​កាត​មិន​ត្រឹមត្រូវ"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "ឧបករណ៍ InfiniBand មិន​គាំទ្រ​របៀប​ដែល​បាន​​តភ្ជាប់​ទេ"
+
+#~| msgid "Connection failed"
+#~ msgid "Connection dependency failed"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​តភ្ជាប់​ភាព​អាស្រ័យ"
+
+#~ msgid "Add Account"
+#~ msgstr "បន្ថែម​គណនី"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "កំហុស​ក្នុង​ការ​ចូល​ទៅ​ក្នុង​គណនី"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "លិខិត​សម្គាល់​បាន​ផុត​កំណត់ ។ សូម​ចូល​ម្ដងទៀត ។"
+
+#~ msgid "_Log In"
+#~ msgstr "ចូល"
+
+#~ msgid "Error creating account"
+#~ msgstr "កំហុស​ក្នុង​ការ​បង្កើត​គណនី"
+
+#~ msgid "Error removing account"
+#~ msgstr "កំហុស​ក្នុង​ការ​យក​គណនី​ចេញ"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "តើ​អ្នក​ពិតជា​ចង់​យក​គណនី​ចេញ​ឬ ?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "វា​នឹង​មិន​យក​គណនី​នៅ​លើ​ម៉ាស៊ីន​បម្រើ​ចេញ​ទេ ។"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "គ្រប់គ្រង​គណនី​លើ​បណ្ដាញ"
+
+#~| msgid "Manage online accounts"
+#~ msgid "No online accounts configured"
+#~ msgstr "គ្មាន​គណនី​លើ​បណ្ដាញ​បាន​កំណត់​រចនាសម្ព័ន្ធទេ"
+
+#~ msgid "Remove Account"
+#~ msgstr "យក​គណនី​ចេញ"
+
+#~| msgid "Manage online accounts"
+#~ msgid "Add an online account"
+#~ msgstr "បន្ថែម​គណនី​​លើ​បណ្ដាញ"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "ការ​បន្ថែម​គណនី អនុញ្ញាត​ឲ្យ​​កម្មវិធី​របស់​អ្នក​ចូល​មើល​ឯកសារ អ៊ីមែល ទំនាក់ទំនង ប្រតិទិន ជជែក និង​ផ្សេងៗ​"
+#~ "ទៀត។"
+
+#~ msgid "Unknown time"
+#~ msgstr "មិន​ស្គាល់​ពេលវេលា"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "Charging - %s until fully charged"
+#~ msgstr "បញ្ចូល​ថ្ម - %s រហូត​ដល់​​ពេញ"
+
+#, c-format
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "ជិត​អស់​ថ្ម  នៅ​សល់ %s"
+
+#, c-format
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "ប្រើ​ថាមពល​ថ្ម - នៅ​សល់  %s"
+
+#~ msgid "Charging"
+#~ msgstr "បញ្ចូល​ថ្ម"
+
+#~ msgid "Using battery power"
+#~ msgstr "ប្រើ​ថាមពល​ថ្ម"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "បញ្ចូល​ថ្ម - ពេញ"
+
+#~ msgid "Empty"
+#~ msgstr "អស់"
+
+#, c-format
+#~ msgid "Caution low UPS, %s remaining"
+#~ msgstr "យូភីអេស​ខ្សោយ​ថាមពល នៅ​សល់ %s"
+
+#, c-format
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "ប្រើ​ថាមពល​យូភីអេស -នៅ​សល់ %s"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "យូភីអេស​ខ្សោយ​ថាមពល"
+
+#~ msgid "Using UPS power"
+#~ msgstr "ប្រើ​ថាមពល​យូភីអេស"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "ថ្ម​ទី​ពីរ​របស់​អ្នក​ពេញ"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "ថ្ម​ទីពីរ​របស់​អ្នក​អស់ថាមពល"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "កណ្ដុរ​ឥត​ខ្សែ"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "ក្ដារ​ចុច​ឥត​ខ្សែ"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "ការ​ផ្គត់ផ្គង់​ថាមពល​ដែល​មិន​អាច​ផ្អាក​បាន"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "អ្នក​ជំនួយការ​ឌីជីថល​ផ្ទាល់ខ្លួន"
+
+#~ msgid "Cellphone"
+#~ msgstr "ទូរស័ព្ទ​ចល័ត"
+
+#~| msgid "Charging"
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "បញ្ចូល​ថ្ម"
+
+#~| msgid "Caution"
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "ប្រយ័ត្ន"
+
+#~| msgid "Low"
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "ទាប"
+
+#~| msgid "Good"
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "ល្អ"
+
+#~| msgid "Charging - fully charged"
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "បញ្ចូល​ថ្ម - ពេញ"
+
+#~| msgid "Empty"
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "អស់"
+
+#~ msgid "Power management settings"
+#~ msgstr "ការ​កំណត់​ការ​គ្រប់គ្រង​ថាមពល"
+
+#~ msgid "Hibernate"
+#~ msgstr "សម្ងំ"
+
+#~ msgid "Don't suspend"
+#~ msgstr "កុំ​ផ្អាក"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "ផ្អាក នៅ​ពេល​អសកម្ម"
+
+#~ msgid "When power is _critically low"
+#~ msgstr "នៅ​ពេល​ថាមពល​កាន់​តែ​ខ្សោយ​ខ្លាំង"
+
+#~ msgid "Out of toner"
+#~ msgstr "អស់​ទឹក​ថ្នាំ"
+
+#~ msgid "Low on developer"
+#~ msgstr "ជិត​អស់​ទឹក​ថ្នាំ​លាង​ហ្វីល"
+
+#~ msgid "Out of developer"
+#~ msgstr "អស់​ទឹក​ថ្នាំ​លាង​ហ្វីល"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "ជិត​អស់​សញ្ញា​សម្គាល់"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "អស់​សញ្ញា​សម្គាល់"
+
+#~ msgid "Open cover"
+#~ msgstr "បើក​គម្រប"
+
+#~ msgid "Low on paper"
+#~ msgstr "ជិត​អស់​ក្រដាស"
+
+#~ msgid "Out of paper"
+#~ msgstr "អស់​ក្រដាស"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "បាន​ផ្អាក"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "ធុងសំរាម​ជិត​ពេញ"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "ធុងសំរាម​ពេញ"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "អង្គធាតុ​ចម្លង​រូបថត​អុបទិក​ជិត​អស់​អាយុកាល"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "អង្គធាតុ​ចម្លង​រូបថត​អុបទិក​លែង​ដំណើរការ"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "រួចហើយ"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "ដំណើរការ"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "បញ្ឈប់"
+
+#~ msgid "Toner Level"
+#~ msgstr "កម្រិត​ទឹកថ្នាំ"
+
+#~ msgid "Supply Level"
+#~ msgstr "កម្រិត​ផ្គត់ផ្គង់"
+
+#~| msgid "Install languages..."
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "ដំឡើង​"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u សកម្ម"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព​ថ្មី ។"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "ឯកសារ​ពណ៌នា​​របស់​ម៉ាស៊ីន​បោះពុម្ព PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~| msgid "No local printers found"
+#~ msgid "No suitable driver found"
+#~ msgstr "រក​មិន​ឃើញ​កម្មវិធី​បញ្ជា​សមរម្យ"
+
+#~| msgid "Browse Files..."
+#~ msgid "Provide PPD File..."
+#~ msgstr "ផ្ដល់​ឯកសារ PPD..."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "មិន​អាច​ផ្ទុក ui ៖ %s"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Resume Printing"
+#~ msgstr "បន្ត​ការ​បោះពុម្ព"
+
+#~ msgid "Pause Printing"
+#~ msgstr "ផ្អាក​ការ​បោះពុម្ព"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព​ថ្មី"
+
+#~| msgid "No network printers found"
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "ស្វែងរក​ម៉ាស៊ីន​បោះពុម្ព​បណ្ដាញ​ ឬ​លទ្ធផល​តម្រង"
+
+#~| msgid "Locations..."
+#~ msgid "Loading options..."
+#~ msgstr "កំពុង​ផ្ទុក​ជម្រើស..."
+
+#~ msgid "One Sided"
+#~ msgstr "តែ​ម្ខាង"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Long Edge (ស្តង់ដារ)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Short Edge (ត្រឡប់)"
+
+#~ msgid "Portrait"
+#~ msgstr "បញ្ឈរ"
+
+#~ msgid "Landscape"
+#~ msgstr "ផ្ដេក"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "បញ្ច្រាស​ផ្ដេក"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "បញ្ច្រាស​បញ្ឈរ"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "កំពុង​រង់ចាំ"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "រង់ចាំ"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "ដំណើរការ"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "បញ្ឈប់"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "បោះបង់"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "បាន​បញ្ចប់"
+
+#~ msgid "Job Title"
+#~ msgstr "ចំណងជើង​ការងារ"
+
+#~ msgid "Job State"
+#~ msgstr "ស្ថានភាព​ការងារ"
+
+#~ msgid "Two Sided"
+#~ msgstr "ទាំង​សងខាង"
+
+#~ msgid "Paper Source"
+#~ msgstr "ប្រភព​ក្រដាស"
+
+#~| msgid "Output"
+#~ msgid "Output Tray"
+#~ msgstr "ថាស​លទ្ធផល"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript pre-filtering"
+
+#~ msgid "Pages per side"
+#~ msgstr "ទំព័រ​ក្នុង​ម្ខាង"
+
+#~| msgid "General"
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "ទូទៅ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "រៀបចំ​ទំព័រ"
+
+#~| msgid "Printer Options"
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "ជម្រើស​បាន​ដំឡើង"
+
+#~| msgid "Jobs"
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "ការងារ"
+
+#~| msgid "Color"
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "ពណ៌"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "បញ្ចប់"
+
+#, c-format
+#~| msgid "_Options"
+#~ msgid "%s Options"
+#~ msgstr "%s ជម្រើស"
+
+#~| msgid "Select"
+#~ msgid "Auto Select"
+#~ msgstr "ជ្រើស​ស្វ័យ​ប្រវត្តិ"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "បញ្ចប់​តែ​ពុម្ពអក្សរ GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "បម្លែង​ទៅ PS កម្រិត ១"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "បម្លែង​ទៅជា PS កម្រិត​ ២"
+
+#~| msgid "No profile"
+#~ msgid "No pre-filtering"
+#~ msgstr "គ្មាន​​តម្រង​ជា​មុន"
+
+#~| msgid "Manufacturer:"
+#~ msgid "Manufacturers"
+#~ msgstr "ក្រុមហ៊ុនផលិត"
+
+#~| msgid "Driver"
+#~ msgid "Drivers"
+#~ msgstr "កម្មវិធី​បញ្ជា"
+
+#~ msgid "_Default"
+#~ msgstr "លំនាំដើម"
+
+#~ msgid "Jobs"
+#~ msgstr "ការងារ"
+
+#~ msgid "_Show"
+#~ msgstr "បង្ហាញ"
+
+#~ msgid "page 1"
+#~ msgstr "ទំព័រ ១"
+
+#~ msgid "label"
+#~ msgstr "ស្លាក"
+
+#~ msgid "page 2"
+#~ msgstr "ទំព័រ ២"
+
+#~| msgid "Getting devices..."
+#~ msgid "Setting new driver..."
+#~ msgstr "កំពុង​កំណត់​កម្មវិធី​បញ្ជា​ថ្មី..."
+
+#~ msgid "page 3"
+#~ msgstr "ទំព័រ​ ៣"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "បោះពុម្ព​ទំព័រ​សាកល្បង"
+
+#~ msgid "_Options"
+#~ msgstr "ជម្រើស"
+
+#~ msgid "Add New Printer"
+#~ msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព​ថ្មី"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​តំបន់ និង​ភាសា​របស់​អ្នក"
+
+#~ msgid "Imperial"
+#~ msgstr "កម្រិត​ខ្ពស់"
+
+#~| msgid "Select an input source to add"
+#~ msgid "Choose an input source"
+#~ msgstr "ជ្រើស​ប្រភព​បញ្ចូល"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "ជ្រើស​ប្រភព​បញ្ចូល ដើម្បី​បន្ថែម"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr "អេក្រង់​ចូល គណនី​ប្រព័ន្ធ និង​គណនី​អ្នកប្រើ​ថ្មី​ប្រើ​ការ​កំណត់​តំបន់ និង​ភាសា​ទូទាំង​ប្រព័ន្ធ ។"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "អេក្រង់​ចូល គណនី​ប្រព័ន្ធ និង​គណនី​អ្នកប្រើ​ថ្មី​ប្រើ​ការ​កំណត់​តំបន់ និង​ភាសា​ទូទាំង​ប្រព័ន្ធ ។ អ្នក​អាច​ផ្លាស់ប្ដូរ​"
+#~ "ការ​កំណត់​ប្រព័ន្ធ​ទៅតាម​តម្រូវការ​របស់​អ្នក​បាន ។"
+
+#~ msgid "Copy Settings"
+#~ msgstr "ចម្លង​ការ​កំណត់"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "ចម្លង​ការ​កំណត់..."
+
+#~ msgid "Region and Language"
+#~ msgstr "តំបន់ និង​ភាសា"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr "ជ្រើស​ភាសា (ការ​ផ្លាស់ប្ដូរ​នឹង​ត្រូវ​បាន​អនុវត្ត​ នៅ​ពេល​ដែល​អ្នក​ចូល​លើក​ក្រោយ)"
+
+#~ msgid "Add Language"
+#~ msgstr "បន្ថែម​ភាសា"
+
+#~ msgid "Remove Language"
+#~ msgstr "យក​ភាសា​ចេញ"
+
+#~ msgid "Language"
+#~ msgstr "ភាសា"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "ជ្រើស​តំបន់ (ការ​ផ្លាស់ប្ដូរ​នឹង​ត្រូវ​បាន​អនុវត្ត នៅ​ពេល​ដែល​អ្នក​ចូល​លើកក្រោយ)"
+
+#~ msgid "Add Region"
+#~ msgstr "បន្ថែម​តំបន់"
+
+#~ msgid "Currency"
+#~ msgstr "រូបិយប័ណ្ណ"
+
+#~ msgid "Examples"
+#~ msgstr "ឧទាហរណ៍"
+
+#~| msgid "Select an input source to add"
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "ជ្រើស​ក្ដារចុច ឬ​ប្រភព​បញ្ចូល​ផ្សេង​ទៀត"
+
+#~| msgid "Input source:"
+#~ msgid "Remove Input Source"
+#~ msgstr "យក​ប្រភព​បញ្ចូល​ចេញ"
+
+#~| msgid "Input source:"
+#~ msgid "Move Input Source Up"
+#~ msgstr "ផ្លាស់ទី​ប្រភព​បញ្ចូល​ឡើង​លើ"
+
+#~| msgid "Input source:"
+#~ msgid "Move Input Source Down"
+#~ msgstr "ផ្លាស់ទី​ប្រភព​បញ្ចូល​ចុះក្រោម"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "បញ្ជា (Ctrl)+ជំនួស (Alt)+ដកឃ្លា (Space)"
+
+#~ msgid "Ctrl+Alt+Shift+Space"
+#~ msgstr "បញ្ជា(Ctrl)+ជំនួស(Alt)+ប្ដូរ(Shift)+ដកឃ្លា(Space)"
+
+#~| msgid "Sound Settings"
+#~ msgid "Shortcut Settings"
+#~ msgstr "ការ​កំណត់​ផ្លូវ​កាត់"
+
+#~ msgid "Display language:"
+#~ msgstr "ភាសា​បង្ហាញ ៖"
+
+#~ msgid "Input source:"
+#~ msgstr "ប្រភព​បញ្ចូល ៖"
+
+#~ msgid "Format:"
+#~ msgstr "ទ្រង់ទ្រាយ ៖"
+
+#~ msgid "Your settings"
+#~ msgstr "ការ​កំណត់​របស់​អ្នក"
+
+#~ msgid "System settings"
+#~ msgstr "ការ​កំណត់​ប្រព័ន្ធ"
+
+#~| msgid "Brightness and Lock"
+#~ msgid "Brightness & Lock"
+#~ msgstr "ពន្លឺ និង​ការ​ចាក់សោ"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Brightness;Lock;Dim;Blank;Monitor;"
+
+#~ msgid "Screen turns off"
+#~ msgstr "បិទ​អេក្រង់"
+
+#~ msgid "1 minute"
+#~ msgstr "១ នាទី"
+
+#~ msgid "3 minutes"
+#~ msgstr "៣ នាទី"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "ធ្វើឲ្យ​អេក្រង់​ស្រអាប់ ដើម្បី​សន្សំ​ថាមពល"
+
+#~ msgid "_Turn screen off when inactive for:"
+#~ msgstr "បិទ​អេក្រង់ នៅ​ពេល​អសកម្ម ៖"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "កុំ​ចាក់​សោ នៅ​ពេល​អ្នក​នៅ​ផ្ទះ"
+
+#~ msgid "Locations..."
+#~ msgstr "ទីតាំង..."
+
+#~ msgid "Enable debugging code"
+#~ msgstr "បើក​កូដ​បំបាត់​កំហុស"
+
+#~ msgid "Version of this application"
+#~ msgstr "កំណែ​កម្មវិធី​នេះ"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " អាប់ភ្លេត​គ្រប់គ្រង​កម្រិត​សំឡេង​របស់  — GNOME"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "បង្ហាញ​ការ​គ្រប់គ្រង​កម្រិត​សំឡេង​នៅ​លើ​ផ្ទៃតុ"
+
+#~ msgid "Bark"
+#~ msgstr "ឆ្កែ​ព្រុស"
+
+#~ msgid "Drip"
+#~ msgstr "តំណក់​ទឹក"
+
+#~ msgid "Glass"
+#~ msgstr "គោះ​កែវ"
+
+#~ msgid "Sonar"
+#~ msgstr "សូរណា"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "កម្រិត​បញ្ចេញ​សំឡេង"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "អប្បបរមា"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "អតិបរមា"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "Subwoofer ៖"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "១០០%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "មិន​ពង្រីក"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "សាកល្បង​ធុងបាស"
+
+#~ msgid "Peak detect"
+#~ msgstr "រក​ឃើញ​កម្រិត​សំឡេង​ខ្ពស់​បំផុត"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "សាកល្បង​ធុងបាស​សម្រាប់ %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "ជ្រើស​ឧបករណ៍​សម្រាប់​​បញ្ចេញ​សំឡេង ៖"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "ការ​កំណត់​សម្រាប់​ឧបករណ៍​ដែល​បាន​ជ្រើស ៖"
+
+#~ msgid "_Input volume:"
+#~ msgstr "កម្រិត​បញ្ចូល​សំឡេង ៖"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "ជ្រើស​ឧបករណ៍​សម្រាប់​បញ្ចូល​សំឡេង ៖"
+
+#~ msgid "Built-in"
+#~ msgstr "ភ្ជាប់​មក​ជាមួយ"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ចំណូលចិត្ត​សំឡេង"
+
+#~ msgid "Testing event sound"
+#~ msgstr "សាកល្បង​សំឡេង​ព្រឹត្តិការណ៍"
+
+#~ msgid "From theme"
+#~ msgstr "ពី​ស្បែក"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "ជ្រើស​សំឡេង​ព្រមាន ៖"
+
+#~ msgid "Stop"
+#~ msgstr "បញ្ឈប់"
+
+#, c-format
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម​ចំណូលចិត្ត​សំឡេង ៖ %s"
+
+#~ msgid "_Mute"
+#~ msgstr "ស្ងាត់"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "ចំណូលចិត្ត​សំឡេង"
+
+#~ msgid "Muted"
+#~ msgstr "ស្ងាត់"
+
+#~ msgid "Custom"
+#~ msgstr "ផ្ទាល់ខ្លួន"
+
+#~ msgid "No shortcut set"
+#~ msgstr "គ្មាន​ការ​កំណត់​ផ្លូវកាត់"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "ចំណូលចិត្ត​ចូល​ដំណើរការ​សកល"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "ធម្មតា"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "ខ្ពស់/ច្រាស"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "ក្ដារចុច​លើ​អេក្រង់"
+
+#~ msgid "GOK"
+#~ msgstr "GOK"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Small"
+#~ msgstr "តូច"
+
+#, no-c-format
+#~ msgid "100%"
+#~ msgstr "១០០%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "ធម្មតា"
+
+#, no-c-format
+#~ msgid "125%"
+#~ msgstr "១២៥%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Large"
+#~ msgstr "ធំ"
+
+#, no-c-format
+#~ msgid "150%"
+#~ msgstr "១៥០%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "ធំជាង"
+
+#~| msgid "Beep when Caps and Num Lock are used"
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​ប្ដូរ​ជាប់ និង​លេខ​ ( Caps and Num Lock) ត្រូវ​បាន​ប្រើ"
+
+#~ msgid "Options..."
+#~ msgstr "ជម្រើស..."
+
+#~| msgid "Zoom"
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "ពង្រីក"
+
+#~ msgid "Zoom in:"
+#~ msgstr "ពង្រីក ៖"
+
+#~ msgid "Zoom out:"
+#~ msgstr "បង្រួម ៖"
+
+#~ msgid "Flash the window title"
+#~ msgstr "បញ្ចេញ​ពន្លឺ​លើ​ចំណង​ជើង​បង្អួច"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "បង្ហាញ​សេចក្ដី​ពិពណ៌នា​ជា​អត្ថបទ​អំពី​ពាក្យសម្ដី និង​សំឡេង"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច"
+
+#~ msgid "pressed"
+#~ msgstr "ត្រូវ​បាន​ចុច"
+
+#~ msgid "accepted"
+#~ msgstr "ទទួលយក"
+
+#~ msgid "rejected"
+#~ msgstr "បដិសេធ"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "ពន្យារពេល​ក្នុង​ការ​ទទួល​យក ៖"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "គ្រប់គ្រង​ព្រួញកណ្ដុរ​ដោយ​ប្រើ​បន្ទះ​គ្រាប់ចុច"
+
+#~ msgid "Video Mouse"
+#~ msgstr "កណ្ដុរ​ជា​វីដេអូ"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "គ្រប់គ្រង​ព្រួញ​កណ្ដុរ​ដោយ​ប្រើ​ម៉ាស៊ីន​ថត​វីដេអូ ។"
+
+#~ msgid "Mouse Settings"
+#~ msgstr "ការ​កំណត់​កណ្ដុរ"
+
+#~| msgid "Short"
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "ខ្លី"
+
+#~| msgid "1/4 Screen"
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "អេក្រង់ ១/២"
+
+#~| msgid "1/4 Screen"
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "អេក្រង់ ៣/៤"
+
+#~| msgid "Long"
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "វែង"
+
+#~| msgid "Color"
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "ពណ៌"
+
+#~| msgid "None"
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "គ្មាន"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "ស្ដង់ដារ"
+
+#~| msgid "My Account"
+#~ msgid "_Local Account"
+#~ msgstr "គណនី​​មូលដ្ឋាន"
+
+#~| msgid "Account Type:"
+#~ msgid "Account _Type"
+#~ msgstr "ប្រភេទ​គណនី"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "ជំនួយ ៖ ដែន​សហគ្រាស​ ឬ​ឈ្មោះតំបន់"
+
+#~ msgid "C_ontinue"
+#~ msgstr "បន្ត"
+
+#~ msgid "Left thumb"
+#~ msgstr "មេដៃ​ឆ្វេង"
+
+#~ msgid "Left middle finger"
+#~ msgstr "ម្រាមដៃ​កណ្ដាល​ខាងឆ្វេង"
+
+#~ msgid "Left ring finger"
+#~ msgstr "ម្រាម​នាងដៃ​ខាង​ឆ្វេង"
+
+#~ msgid "Left little finger"
+#~ msgstr "ម្រាម​កូនដៃ​ខាង​ឆ្វេង"
+
+#~ msgid "Right thumb"
+#~ msgstr "មេ​ដៃ​ស្ដាំ"
+
+#~ msgid "Right middle finger"
+#~ msgstr "ម្រាមដៃ​កណ្ដាល​ខាង​ស្ដាំ"
+
+#~ msgid "Right ring finger"
+#~ msgstr "ម្រាម​នាង​ដៃ​ខាង​ស្ដាំ"
+
+#~ msgid "Right little finger"
+#~ msgstr "ម្រាម​កូនដៃ​ខាង​ស្ដាំ"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "បើក​ការ​ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
+
+#~ msgid "_Right index finger"
+#~ msgstr "ចង្អុល​ដៃ​ស្ដាំ"
+
+#~ msgid "_Left index finger"
+#~ msgstr "ចង្អុល​ដៃ​ឆ្វេង"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "ស្នាម​ម្រាមដៃ​របស់​អ្នក​ត្រូវ​បាន​រក្សាទុក​ដោយ​ជោគជ័យ ។  ឥឡូវនេះ អ្នក​អាច​នឹង​ចូល​ដោយ​ប្រើ​កម្មវិធី​អាន​"
+#~ "ស្នាម​ម្រាមដៃ​របស់​អ្នក​បាន ។"
+
+#~ msgid "User Accounts"
+#~ msgstr "គណនី​អ្នកប្រើ"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+
+#~ msgid "Log in without a password"
+#~ msgstr "ចូល​ដោយ​មិន​ប្រើ​ពាក្យសម្ងាត់"
+
+#~ msgid "Disable this account"
+#~ msgstr "បិទ​គណនី​នេះ"
+
+#~ msgid "Enable this account"
+#~ msgstr "បើក​គណនី​នេះ"
+
+#~ msgid "_Hint"
+#~ msgstr "ពាក្យគន្លឹះ"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "ពាក្យ​គន្លឹះ​អាច​នឹង​ត្រូវ​បង្ហាញ​នៅ​កន្លែង​អេក្រង់​ចូល ។ អ្នកប្រើ​ប្រព័ន្ធ​នេះ​ទាំងអស់​អាច​មើល​ឃើញ​វា ។   "
+#~ "<b>កុំ</b> រួមបញ្ចូល​ពាក្យសម្ងាត់​នៅ​ទីនេះ ។"
+
+#~ msgid "Fair"
+#~ msgstr "ល្មម"
+
+#~ msgid "_Action"
+#~ msgstr "សកម្មភាព"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "របៀប​ជ្រើស​ពាក្យសម្ងាត់​ខ្លាំង"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "ផ្លាស់ប្ដូរ​រូបថត ៖"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "ជ្រើស​រូបភាព​ដែល​នឹង​ត្រូវ​បង្ហាញ​នៅ​ត្រង់​អេក្រង់​ចូល​សម្រាប់​គណនី​នេះ ។"
+
+#~ msgid "Gallery"
+#~ msgstr "វិចិត្រសាល"
+
+#~ msgid "Take a photograph"
+#~ msgstr "ថត​រូប"
+
+#~ msgid "Browse"
+#~ msgstr "រកមើល"
+
+#~ msgid "Photograph"
+#~ msgstr "រូបថត"
+
+#~ msgid "Account Information"
+#~ msgstr "ព័ត៌មាន​គណនី"
+
+#~ msgid "Add User Account"
+#~ msgstr "បន្ថែម​គណនី​អ្នកប្រើ"
+
+#~ msgid "Remove User Account"
+#~ msgstr "យក​គណនី​អ្នកប្រើ​ចេញ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "ខ្លី​ពេក"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "មិន​ល្អ​ទេ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "ខ្សោយ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "ល្មម"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "ល្អ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "ខ្លាំង"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "ពាក្យសម្ងាត់​ថ្មី​ខ្លី​ពេក"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "ពាក្យសម្ងាត់​ថ្មី​សាមញ្ញ​ពេក"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "ពាក្យសម្ងាត់​ចាស់ និង​ថ្មី​ស្រដៀង​គ្នា​ពេក"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "ពាក្យសម្ងាត់​ថ្មី​ត្រូវ​បាន​គេ​ប្រើ​ហើយ ។"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "ពាក្យសម្ងាត់​ថ្មី​ត្រូវតែ​មាន​តួអក្សរ​ជា​លេខ ឬ​តួអក្សរ​ពិសេស"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "ពាក្យសម្ងាត់​ចាស់ និង​ថ្មី​ដូចគ្នា"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "ពាក្យសម្ងាត់​របស់​អ្នក​ត្រូវ​បាន​ផ្លាស់ប្ដូរ តាំងពី​អ្នក​បាន​ចាប់ផ្ដើម​ផ្ទៀងផ្ទាត់​ភាព​ត្រឹមត្រូវ​ពី​ដំបូង​ម្លេះ !"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "ពាក្យសម្ងាត់​ថ្មី​មិន​មាន​តួអក្សរ​ផ្សេង​ៗ​គ្នា​ឲ្យ​បាន​គ្រប់គ្រាន់"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "មិន​ស្គាល់​កំហុស"
+
+#~| msgid "Select an account"
+#~ msgid "Failed to add account"
+#~ msgstr "បាន​បរាជ័យ​ក្នុងការ​បន្ថែម​គណនី"
+
+#~| msgid "Failed to create user"
+#~ msgid "Failed to register account"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចុះ​ឈ្មោះ​គណនី"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "គ្មាន​វិធី​ដែល​បាន​គាំទ្រ​ ដើម្បី​ផ្ទៀងផ្ទាត់​ជា​មួយ​ដែន​នេះ"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចូល​ដែន"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចុះ​កំណត់ហេតុ​ដែន"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "អ្នក​មិន​ត្រូវ​បាន​អនុញ្ញាត​ឲ្យ​ចូល​ដំណើរការ​ឧបករណ៍​នេះ​ទេ ។ សូម​ទាក់ទង​អ្នក​គ្រប់គ្រង​ប្រព័ន្ធ​របស់​អ្នក ។"
+
+#~ msgid "The device is already in use."
+#~ msgstr "ឧបករណ៍​កំពុង​ត្រូវ​បាន​ប្រើ ។"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "កំហុស​ខាងក្នុង​បាន​កើតឡើង ។"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "លុប​ស្នាម​ម្រាមដៃ​ដែល​បាន​ចុះ​ឈ្មោះ​ឬ ?"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "មិន​អាច​ចូល​ដំណើរការ​ឧបករណ៍ '%s'"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "មិន​អាច​ចាប់ផ្ដើមការ​​ចាប់​យក​ស្នាម​ម្រាមដៃ​នៅ​លើ​ឧបករណ៍ '%s' បាន​ឡើយ"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "មិន​អាច​ចូល​ដំណើរការ​​កម្មវិធី​អាន​ស្នាម​ម្រាមដៃ​ណាមួយ​បាន​ឡើយ"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "សម្រាប់​ជំនួយ សូម​ទាក់ទង​អ្នក​គ្រប់គ្រង​ប្រព័ន្ធ​របស់​អ្នក ។"
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "ដើម្បី​បើក​ការ​ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាមដៃ អ្នក​ចាំបាច់​ត្រូវ​រក្សាទុក​ស្នាម​ម្រាមដៃ​ណាមួយ ដោយ​ប្រើ​ឧបករណ៍ "
+#~ "'%s' ។"
+
+#~ msgid "Selecting finger"
+#~ msgstr "ជ្រើស​ម្រាមដៃ"
+
+#~ msgid "Please choose another password."
+#~ msgstr "សូម​ជ្រើស​ពាក្យសម្ងាត់​ផ្សេងទៀត ។"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "សូម​វាយ​បញ្ចូល​ពាក្យសម្ងាត់​បច្ចុប្បន្ន​របស់​អ្នក​ម្ដងទៀត ។"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "មិន​អាច​ផ្លាស់ប្ដូរ​ពាក្យសម្ងាត់​បាន​ឡើយ"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "អ្នក​ត្រូវតែ​បញ្ចូល​ពាក្យសម្ងាត់​ថ្មី"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "អ្នក​​ត្រូវតែ​អះអាង​ពាក្យសម្ងាត់"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "អ្នក​​ត្រូវតែ​បញ្ចូល​ពាក្យសម្ងាត់​បច្ចុប្បន្ន​របស់​អ្នក"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "ពាក្យសម្ងាត់​បច្ចុប្បន្ន​មិន​ត្រឹមត្រូវ"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "ពាក្យសម្ងាត់​មិន​ផ្គូផ្គង​គ្នា"
+
+#~ msgid "Wrong password"
+#~ msgstr "ពាក្យសម្ងាត់​មិន​ត្រឹមត្រូវ"
+
+#~ msgid "Disable image"
+#~ msgstr "បិទ​រូបភាព"
+
+#~ msgid "Take a photo..."
+#~ msgstr "ថត​រូប..."
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "រកមើល​រូប​ជាច្រើន​ទៀត..."
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "ត្រូវ​បាន​ប្រើ​ដោយ %s"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "រក​មិនឃើញ​ដែន ឬ​តំបន់​បែប​នេះ​ទេ​"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "មិន​អាច​ចូល​ជា %s នៅ​ដែន %s បាន​ទេ"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "ពាក្យ​សម្ងាត់​មិន​ត្រឹមត្រូវ សូម​ព្យាយាម​ម្ដង​ទៀត"
+
+#, c-format
+#~ msgid "A user with name '%s' already exists."
+#~ msgstr "មាន​អ្នក​ប្រើ​ដែល​មាន​ឈ្មោះ​ '%s' នោះ​រួចហើយ ។"
+
+#, c-format
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "មិនមាន​អ្នក​ប្រើ​ដែល​មាន​ឈ្មោះ '%s' ។"
+
+#~ msgid "This user does not exist."
+#~ msgstr "មិន​មាន​អ្នកប្រើ​នេះ​ទេ ។"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​លុប​អ្នកប្រើ"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "អ្នក​មិន​អាច​លុប​គណនី​ផ្ទាល់ខ្លួន​របស់​អ្នក​បាន​ទេ ។"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s នៅ​តែ​ត្រូវ​បាន​ចូល"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "ការ​លុប​អ្នកប្រើ ខណៈ​ដែល​ពួកគេ​ចូល​អាច​ធ្វើឲ្យ​ប្រព័ន្ធ​ស្ថិត​ក្នុង​ស្ថានភាព​មិន​ប្រក្រតី ។"
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "តើ​អ្នក​ចង់​រក្សាទុក​ឯកសារ​របស់ %s ដែរ​ឬ​ទេ ?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "វា​ពិបាក​ក្នុង​ការ​រក្សាទុក​ថត​ផ្ទះ ស្ពូល​អ៊ីមែល និង​ឯកសារ​បណ្ដោះអាសន្ន​ណាស់ នៅ​ពេល​ដែល​លុប​គណនី​អ្នកប្រើ ។"
+
+#~ msgid "_Keep Files"
+#~ msgstr "រក្សាទុក​ឯកសារ"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "គណនី​​ត្រូវ​បាន​បិទ"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "ត្រូវ​កំណត់ នៅ​ពេល​ចូល​លើកក្រោយ"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "គ្មាន"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ទាក់ទង​សេវា​គណនី"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "សូម​ប្រាកដ​ថា AccountService ត្រូវ​បាន​ដំឡើង និង​បើក ។"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ដើម្បី​ធ្វើការ​ផ្លាស់ប្ដូរ\n"
+#~ "ចុចរូប​តំណាង * ជាមុន​សិន"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ដើម្បី​បង្កើត​គណនី​អ្នកប្រើ\n"
+#~ "ចុច​រូប​តំណាង * ជាមុន"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "លុប​គណនី​អ្នកប្រើ​ដែល​បាន​ជ្រើស"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ដើម្បី​លុប​គណនី​អ្នកប្រើ​ដែល​បាន​ជ្រើស\n"
+#~ "ចុច​រូប​តំណាង * ជាមុន"
+
+#~ msgid "Other Accounts"
+#~ msgstr "គណនី​ផ្សេងទៀត"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists"
+#~ msgstr "មាន​អ្នកប្រើ​ដែល​មាន​ឈ្មោះ '%s' នោះ​រួច​ហើយ"
+
+#, c-format
+#~ msgid "The username is too long"
+#~ msgstr "ឈ្មោះ​អ្នកប្រើ​វែង​ពេក"
+
+#~ msgid "The username cannot start with a '-'"
+#~ msgstr "ឈ្មោះ​អ្នកប្រើ​មិន​អាច​ចាប់ផ្ដើម​ដោយ '-' បាន​ឡើយ"
+
+#~ msgid ""
+#~ "The username must only consist of:\n"
+#~ " ➣ letters from the English alphabet\n"
+#~ " ➣ digits\n"
+#~ " ➣ any of the characters '.', '-' and '_'"
+#~ msgstr ""
+#~ "ឈ្មោះ​អ្នកប្រើ​អាច​មាន​តែ ៖\n"
+#~ " ➣ តួអក្សរ​មក​ពី​អក្ខរក្រម​អង់គ្លេស\n"
+#~ " ➣ តួ​លេខ\n"
+#~ " ➣ តួអក្សរ​ណាមួយ '.', '-' និង '_'"
+
+#~ msgid "Output:"
+#~ msgstr "លទ្ធផល​ ៖"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "ផ្គូផ្គង​ទៅ​ម៉ូនីទ័រ​មួយ"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d នៃ %d"
+
+#~| msgid "None"
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "គ្មាន"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "ផ្ញើ​ការ​ចុច​គ្រាប់ចុច"
+
+#~| msgid "Switch Modes"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "ប្ដូរ​ម៉ូនីទ័រ"
+
+#~ msgid "Up"
+#~ msgstr "ឡើងលើ"
+
+#~ msgid "Down"
+#~ msgstr "ចុះ​ក្រោម"
+
+#~ msgid "Switch Modes"
+#~ msgstr "របៀប​ប្ដូរ"
+
+#~ msgid "Action"
+#~ msgstr "សកម្មភាព"
+
+#~ msgid "Display Mapping"
+#~ msgstr "ការ​ផ្គូផ្គង​ទិដ្ឋភាព"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "កំណត់​ចំណូលចិត្ត Wacom tablet របស់​អ្នក"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (ដាច់ខាត)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "ចំណូលចិត្ត Tablet"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ការ​កំណត់​ប៊្លូធូស"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "ប៊ូតុង​ផែនទី..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "ក្រិត​ខ្នាត..."
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "លៃ​តម្រូវ​គុណភាព​បង្ហាញ"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "របៀប​តាមដាន"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "របៀប​រង្វង់​ខាងឆ្វេង #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "របៀប​រង្វង់​ខាង​ស្ដាំ #%d"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "របៀប Touchstrip ខាង​ឆ្វេង #%d"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "របៀប Touchstrip ខាង​ស្ដាំ#%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "ប្ដូរ​​របៀប Touchring ខាង​ឆ្វេង"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "ប្ដូរ​របៀប Touchring ខាង​ស្ដាំ"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "ប្ដូរ​របៀប Touchstrip ខាង​ឆ្វេង"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "ប្ដូរ​របៀប Touchstrip ខាង​ស្ដាំ"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "ប្ដូរ​របៀប #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "ប៊ូតុង​ឆ្វេង #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "ប៊ូតុង​ស្ដាំ #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "ប៊ូតុង​ខាង​លើ #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "ប៊ូតុង​ខាងក្រោម #%d"
+
+#~ msgid "No Action"
+#~ msgstr "គ្មាន​សកម្មភាព"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "ចុច​ប៊ូតុង​កណ្ដុរ​ឆ្វេង"
+
+#~ msgid "Scroll Up"
+#~ msgstr "រមូរ​ឡើងលើ"
+
+#~ msgid "Scroll Right"
+#~ msgstr "រមូរ​ទៅ​ស្ដាំ"
+
+#~ msgid "Top Button"
+#~ msgstr "ប៊ូតុង​ខាងលើ"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "បើក​របៀប​បរិយាយ"
+
+#~ msgid "Show the overview"
+#~ msgstr "បង្ហាញ​ទិដ្ឋភាព​ទូទៅ"
+
+#~ msgid "- System Settings"
+#~ msgstr "ការ​កំណត់​ប្រព័ន្ធ"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "ដំណើរការ '%s --help' ដើម្បី​មើល​បញ្ជី​ទាំងមូល​នៃ​ជម្រើស​បន្ទាត់​ពាក្យ​បញ្ជា​ដែល​មាន ។\n"
+
+#~ msgid "Control Center"
+#~ msgstr "មជ្ឈមណ្ឌល​បញ្ជា"
+
+#~ msgid "System Settings"
+#~ msgstr "ការ​កំណត់​ប្រព័ន្ធ"
 
 #~ msgid "Swap colors"
 #~ msgstr "ដូរ​ពណ៌"
@@ -5400,9 +7719,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 
 #~ msgid "Add dots"
 #~ msgstr "បន្ថែម​ចំណុច"
-
-#~ msgid "<b>Theme</b>"
-#~ msgstr "<b>ស្បែក</b>"
 
 #~ msgid "<b>Launcher icon size</b>"
 #~ msgstr "<b>ទំហំ​រូបតំណាង​កម្មវិធី​បើក​ដំណើរការ</b>"
@@ -5425,9 +7741,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 
 #~ msgid "Left side"
 #~ msgstr "ផ្នែក​ខាងឆ្វេង"
-
-#~ msgid "Top left corner"
-#~ msgstr "ជ្រុង​ខាងលើ​ផ្នែក​ខាងឆ្វេង"
 
 #~ msgid "Other reveal option"
 #~ msgstr "ជម្រើស​បង្ហាញ​ផ្សេងទៀត"
@@ -5452,9 +7765,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "Restore Default Behaviours"
 #~ msgstr "ស្ដារ​ឥរិយាបថ​លំនាំដើម"
 
-#~ msgid "Behavior"
-#~ msgstr "ឥរិយាបថ"
-
 #~ msgid "Horizontal Gradient"
 #~ msgstr "ជម្រាល​ផ្ដេក"
 
@@ -5472,9 +7782,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 
 #~ msgid "Colors & Gradients"
 #~ msgstr "ពណ៌ ​និង​ជម្រាល"
-
-#~ msgid "Appearance"
-#~ msgstr "រូបរាង"
 
 #~ msgid "Wallpaper;Screen;Desktop;Theme;Appearance;Launcher;Unity;Menus;"
 #~ msgstr "Wallpaper;Screen;Desktop;Theme;Appearance;Launcher;Unity;Menus;"
@@ -5494,9 +7801,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "Take a screenshot"
 #~ msgstr "ថត​រូប​អេក្រង់"
 
-#~ msgid "Shortcut"
-#~ msgstr "ផ្លូវកាត់"
-
 #~ msgid "_Right-handed"
 #~ msgstr "ខាង​ស្ដាំ"
 
@@ -5505,9 +7809,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 
 #~ msgid "Sh_ow position of pointer when the Control key is pressed"
 #~ msgstr "បង្ហាញ​ទីតាំង​ព្រួញកណ្ដុរ នៅ​ពេល​ចុច​គ្រាប់ចុច​បញ្ជា (Control)"
-
-#~ msgid "A_cceleration:"
-#~ msgstr "ការ​បង្កើន​ល្បឿន ៖"
 
 #~ msgid "_Sensitivity:"
 #~ msgstr "កម្រិត​ប្រែប្រួល ៖"
@@ -5521,9 +7822,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "Drag Threshold"
 #~ msgstr "អូស​កម្រិត​ពន្លឺ"
 
-#~ msgid "Double-Click Timeout"
-#~ msgstr "អស់​ពេល​ចុច​ទ្វេដង"
-
 #~ msgid "_Timeout:"
 #~ msgstr "អស់ពេល ៖"
 
@@ -5533,23 +7831,14 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "បើក​ការ​ចុច​កណ្ដុរ​ដោយ​ប្រើ​បន្ទះ​ប៉ះ"
 
-#~ msgid "Scrolling"
-#~ msgstr "រមូរ"
-
 #~ msgid "_Disabled"
 #~ msgstr "បាន​បិទ"
 
 #~ msgid "_Edge scrolling"
 #~ msgstr "រមូរ​គែម"
 
-#~ msgid "Enable h_orizontal scrolling"
-#~ msgstr "បើក​ការ​រមូរ​ផ្ដេក"
-
 #~ msgid "Hotspot"
 #~ msgstr "Hotspot"
-
-#~ msgid "Not connected to the internet."
-#~ msgstr "មិន​ត្រូវ​បាន​តភ្ជាប់​ទៅ​អ៊ីនធឺណិត ។"
 
 #~ msgid "Create the hotspot anyway?"
 #~ msgstr "យ៉ាងណា បង្កើត hotspot ឬ ?"
@@ -5562,9 +7851,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 
 #~ msgid "Create _Hotspot"
 #~ msgstr "បង្កើត Hotspot"
-
-#~ msgid "Device Off"
-#~ msgstr "បិទ​ឧបករណ៍"
 
 #~ msgid "_Network Name"
 #~ msgstr "ឈ្មោះ​បណ្ដាញ"
@@ -5583,9 +7869,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 
 #~ msgid "FTP Port"
 #~ msgstr "ច្រក FTP"
-
-#~ msgid "Socks Port"
-#~ msgstr "ច្រក​រន្ធ"
 
 #~ msgid "Apply system wide"
 #~ msgstr "អនុវត្ត​ទូទាំង​ប្រព័ន្ធ"
@@ -5617,17 +7900,11 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "Never"
 #~ msgstr "មិន​កំណត់"
 
-#~ msgid "When the lid is closed"
-#~ msgstr "នៅ​ពេល​គម្រប​ត្រូវ​បាន​បិទ"
-
 #~ msgid "Show battery status in the _menu bar"
 #~ msgstr "បង្ហាញ​ស្ថានភាព​ថ្ម​នៅ​ក្នុង​របារ​ម៉ឺនុយ"
 
 #~ msgid "A_ddress:"
 #~ msgstr "អាសយដ្ឋាន ៖"
-
-#~ msgid "_Search by Address"
-#~ msgstr "ស្វែងរក​តាម​អាសយដ្ឋាន"
 
 #~ msgid ""
 #~ "FirewallD is not running. Network printer detection needs services mdns, "
@@ -5636,9 +7913,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ "FirewallD មិន​កំពុង​ដំណើរការ ។ការ​ស្វែងរក​ម៉ាស៊ីន​បោះពុម្ព​តាម​បណ្ដាញ​ត្រូវការ​​សេវា mdns, ipp "
 #~ "កម្មវិធី ipp និង​កម្មវិធី samba ដែល​បើក​នៅ​លើ​ជញ្ជាំង​ភ្លើង ។"
 
-#~ msgid "Devices"
-#~ msgstr "ឧបករណ៍"
-
 #~ msgctxt "printer type"
 #~ msgid "Local"
 #~ msgstr "មូលដ្ឋាន"
@@ -5646,12 +7920,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgctxt "printer type"
 #~ msgid "Network"
 #~ msgstr "បណ្ដាញ"
-
-#~ msgid "Device types"
-#~ msgstr "ប្រភេទ​ឧបករណ៍"
-
-#~ msgid "Automatic configuration"
-#~ msgstr "ការ​កំណត់​រចនាសម្ព័ន្ធ​ស្វ័យប្រវត្តិ"
 
 #~ msgid "Opening firewall for mDNS connections"
 #~ msgstr "បើក​ជញ្ជាំង​ភ្លើង​សម្រាប់​ការ​តភ្ជាប់ mDNS"
@@ -5665,20 +7933,11 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "_Back"
 #~ msgstr "ត្រឡប់"
 
-#~ msgid "Add User"
-#~ msgstr "បន្ថែម​អ្នកប្រើ"
-
-#~ msgid "Remove User"
-#~ msgstr "យក​អ្នកប្រើ​ចេញ"
-
 #~ msgid "Allowed users"
 #~ msgstr "អ្នក​ប្រើ​ដែល​​អនុញ្ញាត"
 
 #~ msgid "Choose a Layout"
 #~ msgstr "ជ្រើស​ប្លង់"
-
-#~ msgid "Preview"
-#~ msgstr "មើល​ជាមុន"
 
 #~ msgid "Keyboard Layout Options"
 #~ msgstr "ជម្រើស​ប្លង់​ក្ដារចុច"
@@ -5689,17 +7948,8 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "Remove Layout"
 #~ msgstr "យក​ប្លង់​ចេញ"
 
-#~ msgid "Move Up"
-#~ msgstr "ផ្លាស់ទី​ឡើងលើ"
-
-#~ msgid "Move Down"
-#~ msgstr "ផ្លាស់ទី​ចុះក្រោម"
-
 #~ msgid "Preview Layout"
 #~ msgstr "មើល​ប្លង់​ជាមុន"
-
-#~ msgid "Use the same layout for all windows"
-#~ msgstr "ប្រើ​ប្លង់​តែមួយ​សម្រាប់​បង្អួច​ទាំងអស់"
 
 #~ msgid "Allow different layouts for individual windows"
 #~ msgstr "អនុញ្ញាត​ប្លង់​ផ្សេងៗ​សម្រាប់​បង្អួច​នីមួយ​ៗ"
@@ -5713,9 +7963,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "View and edit keyboard layout options"
 #~ msgstr "មើល ហើយ​កែសម្រួល​ជម្រើស​ប្លង់​ក្ដារចុច"
 
-#~ msgid "Reset to De_faults"
-#~ msgstr "កំណត់​ឡើង​វិញ​ទៅ​ជា​លំនាំដើម"
-
 #~ msgid ""
 #~ "Replace the current keyboard layout settings with the\n"
 #~ "default settings"
@@ -5726,20 +7973,11 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "Layouts"
 #~ msgstr "ប្លង់ ៖"
 
-#~ msgid "Layout"
-#~ msgstr "ប្លង់"
-
 #~ msgid "Require my password when waking from suspend"
 #~ msgstr "ទាមទារ​ពាក្យសម្ងាត់ នៅ​ពេល​ដាស់​ពី​ការផ្អាក"
 
-#~ msgid "Co_nnector:"
-#~ msgstr "បន្ទាត់​តភ្ជាប់ ៖"
-
 #~ msgid "Hardware"
 #~ msgstr "ផ្នែករឹង"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "ជ្រើស​ឧបករណ៍ ដើម្បី​កំណត់​រចនាសម្ព័ន្ធ ៖"
 
 #~ msgid "Dasher"
 #~ msgstr "Dasher"
@@ -5756,12 +7994,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "_Text size:"
 #~ msgstr "ទំហំ​អត្ថបទ ៖"
 
-#~ msgid "Increase size:"
-#~ msgstr "បង្កើន​ទំហំ ៖"
-
-#~ msgid "Decrease size:"
-#~ msgstr "បន្ថយ​ទំហំ ៖"
-
 #~ msgctxt "universal access, seeing"
 #~ msgid "Display"
 #~ msgstr "ការ​បង្ហាញ"
@@ -5769,12 +8001,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgctxt "universal access, seeing"
 #~ msgid "Zoom"
 #~ msgstr "ពង្រីក"
-
-#~ msgid "Screen keyboard"
-#~ msgstr "ក្ដារចុច​លើ​អេក្រង់"
-
-#~ msgid "Typing Assistant"
-#~ msgstr "អ្នក​ជំនួយការ​ក្នុង​ការ​វាយ"
 
 #~ msgid "Type here to test settings"
 #~ msgstr "វាយ​ទីនេះ ដើម្បី​សាកល្បង​ការ​កំណត់"
@@ -5797,20 +8023,11 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 #~ msgid "Choose a generated password"
 #~ msgstr "ជ្រើស​ពាក្យសម្ងាត់​ដែល​បាន​បង្កើត"
 
-#~ msgid "Account _type"
-#~ msgstr "ប្រភេទ​គណនី"
-
 #~ msgid "More choices..."
 #~ msgstr "ជម្រើស​ជាច្រើន​ទៀត..."
 
 #~ msgid "Wacom Graphics Tablet"
 #~ msgstr "Wacom Graphics Tablet"
-
-#~ msgid "Mute"
-#~ msgstr "ស្ងាត់"
-
-#~ msgid "Settings for %s"
-#~ msgstr "ការ​កំណត់ %s"
 
 #~ msgid "Mode:"
 #~ msgstr "របៀប ៖"
@@ -5823,9 +8040,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 
 #~ msgid "Test:"
 #~ msgstr "សាកល្បង ៖"
-
-#~ msgid "Test Sound"
-#~ msgstr "សាកល្បង​សំឡេង"
 
 #~ msgid "Record sound from"
 #~ msgstr "ថតចម្លង​សំឡេង​ពី"
@@ -5919,9 +8133,6 @@ msgstr "ការ​កំណត់​ទាំងអស់"
 
 #~ msgid "Please select an image."
 #~ msgstr "សូម​ជ្រើស​រូបភាព ។"
-
-#~ msgid "Application Menu"
-#~ msgstr "ម៉ឺនុយ​កម្មវិធី"
 
 #~ msgid "Integrated in menu bar and hidden"
 #~ msgstr "រួមបញ្ចូល​នៅ​ក្នុង​របារ​ម៉ឺនុយ និងលាក់"

--- a/po/km.po~
+++ b/po/km.po~
@@ -1,0 +1,5930 @@
+# translation of po_gnome-control-center-2.0-km.po to Khmer
+# Khmer translation for gnome-control-center
+# Copyright (c) 2008 Rosetta Contributors and Canonical Ltd 2008
+# This file is distributed under the same license as the gnome-control-center package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2008.
+# Khoem Sokhem <khoemsokhem@khmeros.info>, 2012.
+msgid ""
+msgstr ""
+"Project-Id-Version: po_gnome-control-center-2.0-km\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2012-09-10 13:48+0000\n"
+"PO-Revision-Date: 2012-04-19 02:15+0000\n"
+"Last-Translator: Khoem Sokhem <khoemsokhem@khmeros.info>\n"
+"Language-Team: Khmer <support@khmeros.info>\n"
+"Language: km\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Launchpad (build 15890)\n"
+"X-Launchpad-Export-Date: 2012-09-03 19:12+0000\n"
+"X-Language: km-KH\n"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:2
+msgid "Changes throughout the day"
+msgstr "ផ្លាស់ប្ដូរ​រាល់​ថ្ងៃ"
+
+#: ../panels/background/background.ui.h:3
+#| msgid "Tile"
+msgctxt "background, style"
+msgid "Tile"
+msgstr "ក្រឡា​ក្បឿង"
+
+#: ../panels/background/background.ui.h:4
+#| msgid "Zoom"
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "ពង្រីក"
+
+#: ../panels/background/background.ui.h:5
+#| msgid "Center"
+msgctxt "background, style"
+msgid "Center"
+msgstr "កណ្ដាល"
+
+#: ../panels/background/background.ui.h:6
+#| msgid "Scale"
+msgctxt "background, style"
+msgid "Scale"
+msgstr "មាត្រដ្ឋាន"
+
+#: ../panels/background/background.ui.h:7
+#| msgid "Fill"
+msgctxt "background, style"
+msgid "Fill"
+msgstr "បំពេញ"
+
+#: ../panels/background/background.ui.h:8
+#| msgid "Span"
+msgctxt "background, style"
+msgid "Span"
+msgstr "វិសាលភាព"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:199
+#| msgid "Select an account"
+msgid "Select Background"
+msgstr "ជ្រើស​ផ្ទៃ​ខា​ងក្រោយ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:218
+msgid "Wallpapers"
+msgstr "ផ្ទាំង​រូបភាព"
+
+#: ../panels/background/cc-background-chooser-dialog.c:227
+#| msgid "Picture CD"
+msgid "Pictures"
+msgstr "រូបភាព"
+
+#: ../panels/background/cc-background-chooser-dialog.c:235
+#| msgid "Color"
+msgid "Colors"
+msgstr "ពណ៌"
+
+#: ../panels/background/cc-background-chooser-dialog.c:244
+msgid "Flickr"
+msgstr "Flickr"
+
+#: ../panels/background/cc-background-chooser-dialog.c:286
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+#: ../panels/user-accounts/um-photo-dialog.c:98
+msgid "Select"
+msgstr "ជ្រើស"
+
+#: ../panels/background/cc-background-item.c:148
+msgid "multiple sizes"
+msgstr "ទំហំ​ជាច្រើន"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:152
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:281
+msgid "No Desktop Background"
+msgstr "គ្មាន​ផ្ទៃខាងក្រោយ​របស់​ផ្ទៃតុ"
+
+#: ../panels/background/cc-background-panel.c:387
+msgid "Current background"
+msgstr "ផ្ទៃខាងក្រោយ​បច្ចុប្បន្ន"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#| msgid "<b>Background</b>"
+msgid "Background"
+msgstr "ផ្ទៃ​ខាង​ក្រោយ"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+#| msgid "Change the background and theme"
+msgid "Change the background"
+msgstr "ផ្លាស់ប្ដូរ​ផ្ទៃខាងក្រោយ"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+#, fuzzy
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "ផ្ទាំង​រូបភាព អេក្រង់ ផ្ទៃតុ"
+
+#. TRANSLATORS: device type
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
+#: ../panels/network/panel-common.c:102
+msgid "Bluetooth"
+msgstr "ប៊្លូធូស"
+
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
+msgid "Configure Bluetooth settings"
+msgstr "កំណត់​រចនាសម្ព័ន្ធ​នៃ​ការ​កំណត់​ប៊្លូធូស"
+
+#: ../panels/bluetooth/bluetooth.ui.h:1
+msgid "Set Up New Device"
+msgstr "រៀបចំ​ឧបករណ៍​ថ្មី"
+
+#: ../panels/bluetooth/bluetooth.ui.h:2 ../panels/network/network.ui.h:9
+msgid "Remove Device"
+msgstr "យក​ឧបករណ៍​ចេញ"
+
+#: ../panels/bluetooth/bluetooth.ui.h:3
+msgid "Connection"
+msgstr "ការ​តភ្ជាប់"
+
+#: ../panels/bluetooth/bluetooth.ui.h:4
+msgid "Paired"
+msgstr "បាន​ផ្គូ"
+
+#: ../panels/bluetooth/bluetooth.ui.h:5 ../panels/wacom/cc-wacom-page.c:756
+msgid "Type"
+msgstr "ប្រភេទ"
+
+#: ../panels/bluetooth/bluetooth.ui.h:6
+msgid "Address"
+msgstr "អាសយដ្ឋាន"
+
+#: ../panels/bluetooth/bluetooth.ui.h:7
+msgid "Mouse and Touchpad Settings"
+msgstr "ការ​កំណត់​កណ្ដុរ និង​បន្ទះ​ប៉ះ"
+
+#: ../panels/bluetooth/bluetooth.ui.h:8 ../panels/universal-access/uap.ui.h:38
+msgid "Sound Settings"
+msgstr "ការ​កំណត់​សំឡេង"
+
+#: ../panels/bluetooth/bluetooth.ui.h:9
+msgid "Keyboard Settings"
+msgstr "ការ​កំណត់​ក្ដារចុច"
+
+#: ../panels/bluetooth/bluetooth.ui.h:10
+msgid "Send Files..."
+msgstr "ផ្ញើ​ឯកសារ..."
+
+#: ../panels/bluetooth/bluetooth.ui.h:11
+msgid "Browse Files..."
+msgstr "រកមើល​ឯកសារ..."
+
+#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
+#: ../panels/bluetooth/bluetooth.ui.h:13
+msgctxt "Power"
+msgid "Bluetooth"
+msgstr "ប៊្លូធូស"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:290
+msgid "Yes"
+msgstr "បាទ/ចាស"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:290
+msgid "No"
+msgstr "ទេ"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:405
+msgid "Bluetooth is disabled"
+msgstr "ប៊្លូធូស​ត្រូវ​បាន​បិទ"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:410
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "ប៊្លូធូស​ត្រូវ​បាន​បិទ​ដោយ​កុងតាក់​ផ្នែក​រឹង"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:414
+msgid "No Bluetooth adapters found"
+msgstr "រក​មិន​ឃើញ​អាដាប់ទ័រ​ប៊្លូធូស"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:547
+msgid "Visibility"
+msgstr "ភាព​អាច​មើល​ឃើ"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:551
+#, c-format
+msgid "Visibility of “%s”"
+msgstr "ភាព​អាច​មើល​ឃើញ​នៃ “%s”"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:595
+#, c-format
+msgid "Remove '%s' from the list of devices?"
+msgstr "យក '%s' ចេញ​ពី​បញ្ជី​ឧបករណ៍​ឬ ?"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:597
+msgid ""
+"If you remove the device, you will have to set it up again before next use."
+msgstr "ប្រសិនបើ​អ្នក​យក​ឧបករណ៍​ចេញ អ្នក​ត្រូវតែ​រៀបចំ​វា​ម្ដងទៀត មុន​នឹង​ប្រើ​នៅ​ពេលក្រោយ ។"
+
+#. TRANSLATORS: this is where the user can click and import a profile
+#: ../panels/color/cc-color-panel.c:106
+msgid "Other profile…"
+msgstr "ទម្រង់​ផ្សេងទៀត…"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:119
+msgid "Default: "
+msgstr "លំនាំដើម ៖ "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:126
+msgid "Colorspace: "
+msgstr "គំរូ​ពណ៌ ៖ "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:132
+msgid "Test profile: "
+msgstr "ទម្រង់​សាកល្បង ៖ "
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:185 ../panels/color/color.ui.h:11
+msgid "Set for all users"
+msgstr "កំណត់​សម្រាប់​អ្នកប្រើ​ទាំងអស់"
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:192
+msgid "Create virtual device"
+msgstr "បង្កើត​ឧបករណ៍​និម្មិត"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:227
+msgid "Select ICC Profile File"
+msgstr "ជ្រើស​ឯកសារ​ទម្រង់ ICC"
+
+#: ../panels/color/cc-color-panel.c:230
+msgid "_Import"
+msgstr "នាំចូល"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:241
+msgid "Supported ICC profiles"
+msgstr "គាំទ្រ​ទម្រង់ ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:248
+msgid "All files"
+msgstr "ឯកសារ​ទាំងអស់"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:522
+msgid "Available Profiles for Displays"
+msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ការ​បង្ហាញ"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:526
+msgid "Available Profiles for Scanners"
+msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ម៉ាស៊ីន​ស្កេន"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:530
+msgid "Available Profiles for Printers"
+msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ម៉ាស៊ីន​បោះពុម្ព"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:534
+msgid "Available Profiles for Cameras"
+msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​ម៉ាស៊ីន​ថត"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:538
+msgid "Available Profiles for Webcams"
+msgstr "ទម្រង់​ដែល​អាច​ប្រើ​សម្រាប់​វិបខេម"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#. * where the device type is not recognised
+#. Profiles that can be added to the device
+#: ../panels/color/cc-color-panel.c:543 ../panels/color/color.ui.h:2
+msgid "Available Profiles"
+msgstr "ទម្រង់​ដែល​អាច​ប្រើ​បាន"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:824
+#: ../panels/sound/gvc-mixer-dialog.c:1525
+msgid "Device"
+msgstr "ឧបករណ៍"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:859
+msgid "Calibration"
+msgstr "ការ​ក្រិត​ខ្នាត"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:891
+msgid "Create a color profile for the selected device"
+msgstr "បង្កើត​ទម្រង់​ពណ៌​សម្រាប់​ឧបករណ៍​ដែល​បាន​ជ្រើស"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:905 ../panels/color/cc-color-panel.c:929
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "ឧបករណ៍​វាស់​មិន​ត្រូវ​បាន​រក​ឃើញ ។ សូម​ពិនិត្យមើល​ថា វា​ត្រូវ​បាន​បើក និង​ត្រូវ​បាន​តភ្ជាប់​ត្រឹមត្រូវ ។"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:938
+msgid "The measuring instrument does not support printer profiling."
+msgstr "ឧបករណ៍​វាស់​មិន​គាំទ្រ​ការ​រៀបចំ​ទម្រង់​ម៉ាស៊ីន​បោះពុម្ព​ទេ ។"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:949
+msgid "The device type is not currently supported."
+msgstr "ប្រភេទ​ឧបករណ៍​បច្ចុប្បន្ន​មិន​ត្រូវ​បាន​គាំទ្រ ។"
+
+#. TRANSLATORS: this is when an auto-added profile cannot be removed
+#: ../panels/color/cc-color-panel.c:1022
+msgid "Cannot remove automatically added profile"
+msgstr "មិន​អាច​យក​ទម្រង់​ដែល​បាន​បន្ថែម​ដោយ​ស្វ័យប្រវត្តិ​ចេញ​បាន​ទេ"
+
+#. TRANSLATORS: this is when there is no profile for the device
+#: ../panels/color/cc-color-panel.c:1359
+msgid "No profile"
+msgstr "គ្មាន​ទម្រង់"
+
+#: ../panels/color/cc-color-panel.c:1390
+#, c-format
+msgid "%i year"
+msgid_plural "%i years"
+msgstr[0] "%i ឆ្នាំ"
+
+#: ../panels/color/cc-color-panel.c:1401
+#, c-format
+msgid "%i month"
+msgid_plural "%i months"
+msgstr[0] "%i ខែ"
+
+#: ../panels/color/cc-color-panel.c:1412
+#, c-format
+msgid "%i week"
+msgid_plural "%i weeks"
+msgstr[0] "%i សប្ដាហ៍"
+
+#. fallback
+#: ../panels/color/cc-color-panel.c:1419
+#, c-format
+msgid "Less than 1 week"
+msgstr "តិច​ជាង ១ សប្ដាហ៍"
+
+#: ../panels/color/cc-color-panel.c:1481
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB លំនាំដើម"
+
+#: ../panels/color/cc-color-panel.c:1486
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK លំនាំដើម"
+
+#: ../panels/color/cc-color-panel.c:1491
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "ប្រផេះ​តាម​លំនាំដើម"
+
+#: ../panels/color/cc-color-panel.c:1609 ../panels/color/cc-color-panel.c:1650
+#: ../panels/color/cc-color-panel.c:1661 ../panels/color/cc-color-panel.c:1672
+msgid "Uncalibrated"
+msgstr "មិន​បាន​ក្រិត​ខ្នាត"
+
+#: ../panels/color/cc-color-panel.c:1612
+msgid "This device is not color managed."
+msgstr "ឧបករណ៍​នេះ​មិន​ត្រូវ​បាន​គ្រប់គ្រង​តាម​ពណ៌ ។"
+
+#: ../panels/color/cc-color-panel.c:1653
+msgid "This device is using manufacturing calibrated data."
+msgstr "ឧបករណ៍​នេះ​កំពុង​ប្រើ​ទិន្នន័យ​ដែល​បាន​ក្រិត​ខ្នាត​ពី​ក្រុមហ៊ុន​ផលិត ។"
+
+#: ../panels/color/cc-color-panel.c:1664
+msgid ""
+"This device does not have a profile suitable for whole-screen color "
+"correction."
+msgstr "ឧបករណ៍​នេះ​មិន​មាន​ទម្រង់​ដែល​សមស្រប​សម្រាប់​ការ​កែតម្រូវ​ពណ៌​អេក្រង់​ទាំងមូល​ទេ ។"
+
+#: ../panels/color/cc-color-panel.c:1697
+msgid "This device has an old profile that may no longer be accurate."
+msgstr "ឧបករណ៍​នេះ​មាន​ទម្រង់​ចាស់​ដែល​អាច​នឹង​លែង​មាន​សុក្រឹតភាព​ទៀត ។"
+
+#. TRANSLATORS: this is when the calibration profile age is not
+#. * specified as it has been autogenerated from the hardware
+#: ../panels/color/cc-color-panel.c:1725
+msgid "Not specified"
+msgstr "មិន​ត្រូវ​បាន​បញ្ជាក់"
+
+#. add the 'No devices detected' entry
+#: ../panels/color/cc-color-panel.c:1910
+msgid "No devices supporting color management detected"
+msgstr "រក​មិន​ឃើញ​ឧបករណ៍​ដែល​គាំទ្រ​ការ​គ្រប់គ្រង​ពណ៌​ទេ"
+
+#: ../panels/color/cc-color-panel.c:2139
+msgctxt "Device kind"
+msgid "Display"
+msgstr "ការ​បង្ហាញ"
+
+#: ../panels/color/cc-color-panel.c:2141
+msgctxt "Device kind"
+msgid "Scanner"
+msgstr "ម៉ាស៊ីន​ស្កេន"
+
+#: ../panels/color/cc-color-panel.c:2143
+msgctxt "Device kind"
+msgid "Printer"
+msgstr "ម៉ាស៊ីន​បោះពុម្ព"
+
+#: ../panels/color/cc-color-panel.c:2145
+msgctxt "Device kind"
+msgid "Camera"
+msgstr "ម៉ាស៊ីន​ថត"
+
+#: ../panels/color/cc-color-panel.c:2147
+msgctxt "Device kind"
+msgid "Webcam"
+msgstr "វិបខេម"
+
+#: ../panels/color/color.ui.h:3
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "ពណ៌"
+
+#: ../panels/color/color.ui.h:4
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "ឧបករណ៍​នីមួយ​ៗ​ទាមទារ​ឲ្យ​គ្រប់គ្រង​ទម្រង់​ពណ៌​ដែល​ទាន់​សម័យ​តាម​ពណ៌ ។"
+
+#: ../panels/color/color.ui.h:5
+msgid "Learn more"
+msgstr "ស្វែងយល់​បន្ថែម"
+
+#: ../panels/color/color.ui.h:6
+msgid "Learn more about color management"
+msgstr "ស្វែងយល់​បន្ថែម​អំពី​ការ​គ្រប់គ្រង​ពណ៌"
+
+#: ../panels/color/color.ui.h:7
+msgid "Add device"
+msgstr "បន្ថែម​ឧបករណ៍"
+
+#: ../panels/color/color.ui.h:8
+msgid "Add a virtual device"
+msgstr "បន្ថែម​ឧបករណ៍​និម្មិត"
+
+#: ../panels/color/color.ui.h:9
+msgid "Delete device"
+msgstr "លុប​ឧបករណ៍"
+
+#: ../panels/color/color.ui.h:10
+msgid "Remove a device"
+msgstr "យក​ឧបករណ៍​ចេញ"
+
+#: ../panels/color/color.ui.h:12
+#| msgid "Set this device for all users on this computer"
+msgid "Set this profile for all users on this computer"
+msgstr "កំណត់​ប្រវត្តិ​សម្រាប់​អ្នក​ប្រើ​ទាំងអស់​នៅ​ក្នុង​កុំព្យូទ័រ​នេះ"
+
+#: ../panels/color/color.ui.h:13
+msgid "Add profile"
+msgstr "បន្ថែម​ទម្រង់"
+
+#: ../panels/color/color.ui.h:14
+msgid "Calibrate…"
+msgstr "ក្រិត​ខ្នាត…"
+
+#: ../panels/color/color.ui.h:15
+msgid "Calibrate the device"
+msgstr "ក្រិត​ខ្នាត​ឧបករណ៍"
+
+#: ../panels/color/color.ui.h:16
+msgid "Remove profile"
+msgstr "យក​ទម្រង់​ចេញ"
+
+#: ../panels/color/color.ui.h:17
+msgid "View details"
+msgstr "មើល​សេចក្ដី​លម្អិត"
+
+#: ../panels/color/color.ui.h:18
+msgid "Device type:"
+msgstr "ប្រភេទ​ឧបករណ៍ ៖"
+
+#: ../panels/color/color.ui.h:19
+msgid "Manufacturer:"
+msgstr "ក្រុមហ៊ុនផលិត ៖"
+
+#: ../panels/color/color.ui.h:20
+msgid "Model:"
+msgstr "ម៉ូដែល ៖"
+
+#: ../panels/color/color.ui.h:21
+msgid ""
+"Image files can be dragged on this window to auto-complete the above fields."
+msgstr "ឯកសារ​រូបភាព​អាច​ត្រូវ​បាន​អូស​នៅ​លើ​បង្អួច​នេះ ដើម្បី​បំពេញ​វាល​ខាងលើ​ដោយ​ស្វ័យប្រវត្តិ ។"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Color management settings"
+msgstr "ការ​កំណត់​ការ​គ្រប់គ្រង​ពណ៌"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Profile;Calibrate;Printer;Display;"
+
+#. Add some common languages first
+#: ../panels/common/cc-common-language.c:523
+msgid "English"
+msgstr "អង់គ្លេស"
+
+#: ../panels/common/cc-common-language.c:525
+msgid "British English"
+msgstr "ចក្រភព​អង់គ្លេស"
+
+#: ../panels/common/cc-common-language.c:528
+#| msgid "Germany"
+msgid "German"
+msgstr "អាល្លឺម៉ង់"
+
+#: ../panels/common/cc-common-language.c:531
+msgid "French"
+msgstr "បារាំង"
+
+#: ../panels/common/cc-common-language.c:534
+#| msgid "Span"
+msgid "Spanish"
+msgstr "អេស្ប៉ាញ"
+
+#: ../panels/common/cc-common-language.c:536
+msgid "Chinese (simplified)"
+msgstr "ចិន (អក្សរ​កាត់)"
+
+#: ../panels/common/cc-common-language.c:539
+msgid "Russian"
+msgstr "រុស្ស៊ី"
+
+#: ../panels/common/cc-common-language.c:542
+msgid "Arabic"
+msgstr "អារ៉ាប់"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:571
+msgid "United States"
+msgstr "សហរដ្ឋ​អាមេរិក"
+
+#: ../panels/common/cc-common-language.c:572
+msgid "Germany"
+msgstr "អាល្លឺម៉ង់"
+
+#: ../panels/common/cc-common-language.c:573
+msgid "France"
+msgstr "បារាំង"
+
+#: ../panels/common/cc-common-language.c:574
+msgid "Spain"
+msgstr "អេស្ប៉ាញ"
+
+#: ../panels/common/cc-common-language.c:575
+msgid "China"
+msgstr "ចិន"
+
+#: ../panels/common/cc-language-chooser.c:122
+#| msgctxt "Wireless access point"
+#| msgid "Other..."
+msgid "Other..."
+msgstr "ផ្សេងទៀត..."
+
+#: ../panels/common/cc-language-chooser.c:296
+msgid "Select a region"
+msgstr "ជ្រើស​តំបន់"
+
+#: ../panels/common/gdm-languages.c:781
+msgid "Unspecified"
+msgstr "មិន​បាន​បញ្ជាក់"
+
+#: ../panels/common/language-chooser.ui.h:1
+msgid "Select a language"
+msgstr "ជ្រើស​ភាសា"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/printers/new-printer-dialog.ui.h:1
+#: ../panels/user-accounts/um-user-panel.c:462
+msgid "_Cancel"
+msgstr "បោះបង់"
+
+#: ../panels/common/language-chooser.ui.h:3
+msgid "_Select"
+msgstr "ជ្រើស"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "_Region:"
+msgstr "តំបន់ ៖"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "_City:"
+msgstr "ទីក្រុង ៖"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "_Network Time"
+msgstr "ពេលវេលា​តាម​បណ្ដាញ"
+
+#. Translator: this is the separator between hours and minutes, like in HH:MM
+#: ../panels/datetime/datetime.ui.h:5
+msgid ":"
+msgstr ":"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "Set the time one hour ahead."
+msgstr "កំណត់​ពេលវេលា​ទៅ​មុខ​មួយ​ម៉ោង ។"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "Set the time one hour back."
+msgstr "កំណត់​ពេលវេលា​ថយ​ក្រោយ​មួយ​ម៉ោង ។"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "Set the time one minute ahead."
+msgstr "កំណត់​ពេលវេលា​ទៅ​មុខ​មួយ​នាទី ។"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "Set the time one minute back."
+msgstr "កំណត់​ពេលវេលា​ថយក្រោយ​មួយ​នាទី ។"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "Switch between AM and PM."
+msgstr "ប្ដូរ​ឆ្លាស់​រវាង​ ព្រឹក និង​ល្ងាច ។"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "Month"
+msgstr "ខែ"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "Day"
+msgstr "ថ្ងៃ"
+
+#: ../panels/datetime/datetime.ui.h:13
+msgid "Year"
+msgstr "ឆ្នាំ"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "24-hour"
+msgstr "២៤ ម៉ោង"
+
+#: ../panels/datetime/datetime.ui.h:15
+msgid "AM/PM"
+msgstr "ព្រឹក/ល្ងាច"
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "January"
+msgstr "មករា"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "February"
+msgstr "កុម្ភៈ"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "March"
+msgstr "មីនា"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "April"
+msgstr "មេសា"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "May"
+msgstr "ឧសភា"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "June"
+msgstr "មិថុនា"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "July"
+msgstr "កក្កដា"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "August"
+msgstr "សីហា"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "September"
+msgstr "កញ្ញា"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "October"
+msgstr "តុលា"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "November"
+msgstr "វិច្ឆិកា"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "December"
+msgstr "ធ្នូ"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#| msgid "Date and Time"
+msgid "Date & Time"
+msgstr "កាលបរិច្ឆេទ និង​ពេលវេលា"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Date and Time preferences panel"
+msgstr "ផ្ទាំង​ចំណូលចិត្ត​កាលបរិច្ឆេទ និង​ពេលវេលា"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#| msgid "Change your region and language settings"
+msgid "Change system time and date settings"
+msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​ពេលវេលា និង​កាលបរិច្ឆេទ​​ប្រព័ន្ធ"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"ដើម្បី​ផ្លាស់ប្ដូរ​កា​រកំណត់​ពេលវាលា ឬ​កាលបរិច្ឆេទ "
+"អ្នក​ត្រូវ​តែ​ផ្ទៀតផ្ទាត់​ ។"
+
+#: ../panels/display/cc-display-panel.c:481
+msgctxt "display panel, rotation"
+msgid "Normal"
+msgstr "ធម្មតា"
+
+#: ../panels/display/cc-display-panel.c:482
+msgctxt "display panel, rotation"
+msgid "Counterclockwise"
+msgstr "ច្រាស​ទ្រនិច​នាឡិកា"
+
+#: ../panels/display/cc-display-panel.c:483
+msgctxt "display panel, rotation"
+msgid "Clockwise"
+msgstr "ស្រប​ទ្រនិច​នាឡិកា"
+
+#: ../panels/display/cc-display-panel.c:484
+msgctxt "display panel, rotation"
+msgid "180 Degrees"
+msgstr "១៨០ ដឺក្រេ"
+
+#. Keep this string in sync with gnome-desktop/libgnome-desktop/gnome-rr-labeler.c
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external projector.  Here, "Mirrored" is being
+#. * used as an adjective.  For example, the Spanish translation could be
+#. * "Pantallas en Espejo".
+#.
+#: ../panels/display/cc-display-panel.c:623
+#| msgid "Mirror Displays"
+msgid "Mirrored Displays"
+msgstr "ទិដ្ឋភាព​ឆ្លុះ"
+
+#: ../panels/display/cc-display-panel.c:647
+#: ../panels/display/display-capplet.ui.h:1
+msgid "Monitor"
+msgstr "ម៉ូនីទ័រ"
+
+#: ../panels/display/cc-display-panel.c:748
+#, c-format
+msgid "%d x %d (%s)"
+msgstr "%d x %d (%s)"
+
+#: ../panels/display/cc-display-panel.c:750
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#: ../panels/display/cc-display-panel.c:1659
+msgid "Drag to change primary display."
+msgstr "អូស ដើម្បី​ផ្លាស់ប្ដូរ​ទិដ្ឋភាព​ចម្បង ។"
+
+#: ../panels/display/cc-display-panel.c:1717
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr "ជ្រើស​ម៉ូនីទ័រ ដើម្បី​ផ្លាស់ប្ដូរ​លក្ខណសម្បត្តិ​របស់​វា អូស​វា ដើម្បី​រៀបចំ​ទីតាំង​របស់​វា​ជា​ថ្មី ។"
+
+#: ../panels/display/cc-display-panel.c:2105
+msgid "%a %R"
+msgstr "%a %R"
+
+#: ../panels/display/cc-display-panel.c:2107
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../panels/display/cc-display-panel.c:2269
+#: ../panels/display/cc-display-panel.c:2321
+#, c-format
+msgid "Failed to apply configuration: %s"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​អនុវត្ត​ការ​កំណត់​រចនាសម្ព័ន្ធ ៖ %s"
+
+#: ../panels/display/cc-display-panel.c:2349
+msgid "Could not save the monitor configuration"
+msgstr "មិន​អាច​រក្សាទុក​ការ​កំណត់​រចនាសម្ព័ន្ធ​ម៉ូនីទ័រ​បាន​ឡើយ"
+
+#: ../panels/display/cc-display-panel.c:2409
+msgid "Could not detect displays"
+msgstr "រក​មិន​ឃើញ​ទិដ្ឋភាព"
+
+#: ../panels/display/cc-display-panel.c:2603
+msgid "Could not get screen information"
+msgstr "មិន​អាច​ទទួល​បាន​ព័ត៌មាន​អេក្រង់"
+
+#: ../panels/display/display-capplet.ui.h:2
+msgid "_Resolution"
+msgstr "គុណភាព​បង្ហាញ"
+
+#: ../panels/display/display-capplet.ui.h:3
+msgid "R_otation"
+msgstr "ការ​បង្វិល"
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:5
+msgid "_Mirror displays"
+msgstr "បង្ហាញ​ទិដ្ឋភាព"
+
+#: ../panels/display/display-capplet.ui.h:6
+msgid "Note: may limit resolution options"
+msgstr "ចំណាំ ៖ អាច​នឹង​កំណត់​ជម្រើស​គុណភាព​បង្ហាញ"
+
+#: ../panels/display/display-capplet.ui.h:7
+msgid "_Detect Displays"
+msgstr "រក​ឃើញ​ទិដ្ឋភាព"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "ទិដ្ឋភាព"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Change resolution and position of monitors and projectors"
+msgstr "ផ្លាស់ប្ដូរ​គុណភាព​បង្ហាញ និង​ទីតាំង​របស់​ម៉ូនីទ័រ និង​ឧបករណ៍​បញ្ចាំង​ស្លាយ"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+
+#. Translators: VESA is an techncial acronym, don't translate it.
+#: ../panels/info/cc-info-panel.c:413
+#, c-format
+msgid "VESA: %s"
+msgstr "VESA ៖ %s"
+
+#. TRANSLATORS: device type
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:437 ../panels/network/panel-common.c:82
+#: ../panels/network/panel-common.c:162
+msgid "Unknown"
+msgstr "មិន​ស្គាល់"
+
+#. translators: This is the type of architecture, for example:
+#. * "64-bit" or "32-bit"
+#: ../panels/info/cc-info-panel.c:593
+#, c-format
+msgid "%d-bit"
+msgstr "%d ប៊ីត"
+
+#: ../panels/info/cc-info-panel.c:752
+msgid "Unknown model"
+msgstr "មិន​ស្គាល់​ម៉ូដែល"
+
+#: ../panels/info/cc-info-panel.c:835
+msgid "The next login will attempt to use the standard experience."
+msgstr "ការ​ចូល​បន្ទាប់​នឹង​ប៉ុនប៉ង​ប្រើ​កម្រិត​ស្ដង់ដារ ។"
+
+#: ../panels/info/cc-info-panel.c:837
+msgid ""
+"The next login will use the fallback mode intended for unsupported graphics "
+"hardware."
+msgstr "ការ​ចូល​បន្ទាប់​នឹង​ប្រើ​របៀប fallback ដែល​បម្រុងទុក​សម្រាប់​ផ្នែក​រឹង​ក្រាហ្វិក​ដែល​មិន​គាំទ្រ ។"
+
+#. translators: The hardware is not able to run GNOME 3's
+#. * shell, so we use the GNOME "Fallback" session
+#: ../panels/info/cc-info-panel.c:879
+msgctxt "Experience"
+msgid "Fallback"
+msgstr "Fallback"
+
+#. translators: The hardware is able to run GNOME 3's
+#. * shell, also called "Standard" experience
+#: ../panels/info/cc-info-panel.c:885
+msgctxt "Experience"
+msgid "Standard"
+msgstr "ស្ដង់ដារ"
+
+#: ../panels/info/cc-info-panel.c:1227
+msgid "Ask what to do"
+msgstr "សួរ​អ្វី​ដែល​ត្រូវ​ធ្វើ"
+
+#: ../panels/info/cc-info-panel.c:1231
+msgid "Do nothing"
+msgstr "មិន​ធ្វើ​អ្វី​ទាំងអស់"
+
+#: ../panels/info/cc-info-panel.c:1235
+msgid "Open folder"
+msgstr "បើក​ថត"
+
+#: ../panels/info/cc-info-panel.c:1326
+#| msgid "_Other Media..."
+msgid "Other Media"
+msgstr "មេឌៀ​ផ្សេងទៀត..."
+
+#: ../panels/info/cc-info-panel.c:1357
+msgid "Select an application for audio CDs"
+msgstr "ជ្រើស​កម្មវិធី​សម្រាប់​ស៊ីឌី​អូឌីយ៉ូ"
+
+#: ../panels/info/cc-info-panel.c:1358
+msgid "Select an application for video DVDs"
+msgstr "ជ្រើស​កម្មវិធី​សម្រាប់​ឌីវីឌី​វីដេអូ"
+
+#: ../panels/info/cc-info-panel.c:1359
+msgid "Select an application to run when a music player is connected"
+msgstr "ជ្រើស​កម្មវិធី​ដែល​ត្រូវ​ដំណើរការ នៅ​ពេល​កម្មវិធី​ចាក់​តន្ត្រី​ត្រូវ​បាន​តភ្ជាប់"
+
+#: ../panels/info/cc-info-panel.c:1360
+msgid "Select an application to run when a camera is connected"
+msgstr "ជ្រើស​កម្មវិធី​ដែល​ត្រូវ​ដំណើរការ នៅ​ពេល​ម៉ាស៊ីន​ថត​ត្រូវ​បាន​តភ្ជាប់"
+
+#: ../panels/info/cc-info-panel.c:1361
+msgid "Select an application for software CDs"
+msgstr "ជ្រើស​កម្មវិធី​សម្រាប់​ស៊ីឌី​កម្មវិធី"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1373
+msgid "audio DVD"
+msgstr "ឌីវីឌី​អូឌីយ៉ូ"
+
+#: ../panels/info/cc-info-panel.c:1374
+msgid "blank Blu-ray disc"
+msgstr "ថាស​ប៊្លូរ៉េយ៍​ទទេ"
+
+#: ../panels/info/cc-info-panel.c:1375
+msgid "blank CD disc"
+msgstr "ថាស​ស៊ីឌី​ទទេ"
+
+#: ../panels/info/cc-info-panel.c:1376
+msgid "blank DVD disc"
+msgstr "ថាស​ឌីវីឌី​ទទេ"
+
+#: ../panels/info/cc-info-panel.c:1377
+msgid "blank HD DVD disc"
+msgstr "ថាស​ឌីវីឌី HD ទទេ"
+
+#: ../panels/info/cc-info-panel.c:1378
+msgid "Blu-ray video disc"
+msgstr "ថាស​វីដេអូ​ប៊្លូរ៉េយ៍"
+
+#: ../panels/info/cc-info-panel.c:1379
+msgid "e-book reader"
+msgstr "កម្មវិធី​អាន​សៀវភៅ​អេឡិចត្រូនិក"
+
+#: ../panels/info/cc-info-panel.c:1380
+msgid "HD DVD video disc"
+msgstr "ថាស​វីដេអូ​ឌីវីឌី HD"
+
+#: ../panels/info/cc-info-panel.c:1381
+msgid "Picture CD"
+msgstr "ស៊ីឌី​រូបភាព"
+
+#: ../panels/info/cc-info-panel.c:1382
+msgid "Super Video CD"
+msgstr "ស៊ីឌី​វីដេអូ​កម្រិតខ្ពស់"
+
+#: ../panels/info/cc-info-panel.c:1383
+msgid "Video CD"
+msgstr "ស៊ីឌី​វីដេអូ"
+
+#: ../panels/info/cc-info-panel.c:1384
+msgid "Windows software"
+msgstr "កម្មវិធី​សម្រាប់​វីនដូ"
+
+#: ../panels/info/cc-info-panel.c:1385
+#| msgid "_Software"
+msgid "Software"
+msgstr "កម្មវិធី"
+
+#: ../panels/info/cc-info-panel.c:1508
+#: ../panels/keyboard/keyboard-shortcuts.c:1647
+msgid "Section"
+msgstr "ភាគ"
+
+#: ../panels/info/cc-info-panel.c:1517 ../panels/info/info.ui.h:11
+msgid "Overview"
+msgstr "ទិដ្ឋភាព​ទូទៅ"
+
+#: ../panels/info/cc-info-panel.c:1523 ../panels/info/info.ui.h:18
+msgid "Default Applications"
+msgstr "កម្មវិធី​លំនាំដើម"
+
+#: ../panels/info/cc-info-panel.c:1528 ../panels/info/info.ui.h:26
+msgid "Removable Media"
+msgstr "មេឌៀ​ចល័ត"
+
+#: ../panels/info/cc-info-panel.c:1533 ../panels/info/info.ui.h:10
+msgid "Graphics"
+msgstr "ក្រាហ្វិក"
+
+#: ../panels/info/cc-info-panel.c:1735
+#, c-format
+msgid "Version %s"
+msgstr "កំណែ %s"
+
+#: ../panels/info/cc-info-panel.c:1785
+msgid "Install Updates"
+msgstr "ដំឡើង​បច្ចុប្បន្នភាព"
+
+#: ../panels/info/cc-info-panel.c:1789
+msgid "System Up-To-Date"
+msgstr "ប្រព័ន្ធ​ទាន់សម័យ"
+
+#: ../panels/info/cc-info-panel.c:1793
+msgid "Checking for Updates"
+msgstr "រកមើល​បច្ចុប្បន្នភាព"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+msgid "Details"
+msgstr "សេចក្ដី​លម្អិត"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "System Information"
+msgstr "ព័ត៌មាន​ប្រព័ន្ធ"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "ជ្រើស​របៀប​គ្រប់គ្រង​មេឌៀ​ផ្សេងទៀត"
+
+#: ../panels/info/info.ui.h:2
+#| msgid "_Action"
+msgid "_Action:"
+msgstr "សកម្មភាព ៖"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "ប្រភេទ ៖"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "ឈ្មោះ​ឧបករណ៍"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "អង្គ​ចងចាំ"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "កម្មវិធី​ដំណើរការ"
+
+#: ../panels/info/info.ui.h:7
+msgid "OS type"
+msgstr "ប្រភេទ​ប្រព័ន្ធ​ដំណើរការ"
+
+#: ../panels/info/info.ui.h:8
+msgid "Disk"
+msgstr "ថាស"
+
+#: ../panels/info/info.ui.h:9
+msgid "Calculating..."
+msgstr "កំពុង​គណនា..."
+
+#: ../panels/info/info.ui.h:12
+msgid "_Web"
+msgstr "បណ្ដាញ"
+
+#: ../panels/info/info.ui.h:13
+msgid "_Mail"
+msgstr "សំបុត្រ"
+
+#: ../panels/info/info.ui.h:14
+msgid "_Calendar"
+msgstr "ប្រតិទិន"
+
+#: ../panels/info/info.ui.h:15
+msgid "M_usic"
+msgstr "តន្ត្រី"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Video"
+msgstr "វីដេអូ"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Photos"
+msgstr "រូបថត"
+
+#: ../panels/info/info.ui.h:19
+msgid "Select how media should be handled"
+msgstr "ជ្រើស​របៀប​គ្រប់គ្រង​មេឌៀ"
+
+#: ../panels/info/info.ui.h:20
+msgid "CD _audio"
+msgstr "អូឌីយ៉ូ​ស៊ីឌី"
+
+#: ../panels/info/info.ui.h:21
+msgid "_DVD video"
+msgstr "វីដេអូ​ឌីវីឌី"
+
+#: ../panels/info/info.ui.h:22
+msgid "_Music player"
+msgstr "កម្មវិធី​ចាក់​​តន្ត្រី"
+
+#: ../panels/info/info.ui.h:23
+msgid "_Software"
+msgstr "កម្មវិធី"
+
+#: ../panels/info/info.ui.h:24
+msgid "_Other Media..."
+msgstr "មេឌៀ​ផ្សេងទៀត..."
+
+#: ../panels/info/info.ui.h:25
+msgid "_Never prompt or start programs on media insertion"
+msgstr "កុំ​សួរ ឬ​ចាប់ផ្ដើម​កម្មវិធី នៅ​ពេល​បញ្ចូល​មេឌៀ"
+
+#: ../panels/info/info.ui.h:27
+msgid "Driver"
+msgstr "កម្មវិធី​បញ្ជា"
+
+#: ../panels/info/info.ui.h:28
+msgid "Experience"
+msgstr "ជាន់ខ្ពស់"
+
+#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
+#: ../panels/info/info.ui.h:30
+msgid "Forced _Fallback Mode"
+msgstr "របៀប Forced _Fallback"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "សំឡេង និង​មេឌៀ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "ស្ងាត់"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "បន្ថយ​កម្រិត​សំឡេង"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "បង្កើន​កម្រិត​សំឡេង"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "បើក​ដំណើរការ​កម្មវិធី​ចាក់​មេឌៀ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "ចាក់ (ឬ​ចាក់/ផ្អាក)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "ផ្អាក​ការ​ចាក់​សារ​ថ្មី"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "បញ្ឈប់​ការ​ចាក់​សារ​ថ្មី"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "បទ​មុន"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "បទ​បន្ទាប់"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "ច្រានចេញ"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/keyboard/keyboard-shortcuts.c:858
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Typing"
+msgstr "វាយ"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: ../panels/region/gnome-region-panel.ui.h:26
+#| msgid "Switch Modes"
+msgid "Switch to next source"
+msgstr "ប្ដូរ​ទៅ​ប្រភព​បន្ទាប់"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: ../panels/region/gnome-region-panel.ui.h:24
+msgid "Switch to previous source"
+msgstr "ប្ដូរ​ទៅ​ប្រភព​មុន"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "កម្មវិធី​បើក​ដំណើរការ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "បើក​ដំណើរការ​កម្មវិធី​រុករក​បណ្ដាញ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3
+msgid "Launch calculator"
+msgstr "បើក​ដំណើរការ​ម៉ាស៊ីន​គណនា"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch email client"
+msgstr "បើក​ដំណើរការ​កម្មវិធី​អ៊ីមែល"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch web browser"
+msgstr "បើក​ដំណើរការ​កម្មវិធី​រុករក​បណ្ដាញ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Home folder"
+msgstr "ថត​ផ្ទះ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Search"
+msgstr "ស្វែងរក"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "រូបថត​អេក្រង់"
+
+#. translators: Pictures is the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+#| msgid "Take a screenshot of an area"
+msgid "Save a screenshot to Pictures"
+msgstr "ថត​រូប​អេក្រង់​​ជា​រូបភាព"
+
+#. translators: Pictures is the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+#| msgid "Take a screenshot of a window"
+msgid "Save a screenshot of a window to Pictures"
+msgstr "រក្សាទុក​រូបថត​​អេក្រង់​របស់​វីនដូ​ជា​រូបភាព"
+
+#. translators: Pictures is the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+#| msgid "Take a screenshot of an area"
+msgid "Save a screenshot of an area to Pictures"
+msgstr "រក្សាទុក​រូបថត​អេក្រង់​នៃ​ផ្ទៃ​ជា​រូបភាព"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "ចម្លង​រូបថត​អេក្រង់​ទៅកាន់​ក្ដារ​តម្បៀត​ខ្ទាស់"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "ចម្លង​រូបថត​អេក្រង់​បង្អួច​ទៅកាន់​ក្ដារ​តម្បៀត​ខ្ទាស់"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "ចម្លង​រូបថត​អេក្រង់​នៃ​ផ្ទៃ​ទៅកាន់​ក្ដារ​តម្បៀត​ខ្ទាស់"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+#: ../panels/region/gnome-region-panel.ui.h:39
+msgid "System"
+msgstr "ប្រព័ន្ធ"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "ចេញ"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "ចាក់​សោ​អេក្រង់"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "ចូល​ដំណើរការ​សកល"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "បើក ឬ​បិទ​ការ​ពង្រីក"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "ពង្រីក"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "បង្រួម"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "បើក ឬ​បិទ​កម្មវិធី​អាន​អេក្រង់"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "បើក ឬ​បិទ​ក្ដារចុច​នៅ​លើ​អេក្រង់"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "បង្កើន​ទំហំ​អត្ថបទ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "បន្ថយ​ទំហំ​អត្ថបទ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "បើក ឬ​បិទ​កម្រិត​ពណ៌​ខ្ពស់"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:241
+#: ../panels/keyboard/cc-keyboard-option.c:347
+#: ../panels/keyboard/keyboard-shortcuts.c:1112
+#: ../panels/sound/gvc-mixer-control.c:1834
+#: ../panels/user-accounts/um-fingerprint-dialog.c:215
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Disabled"
+msgstr "បាន​បិទ"
+
+#: ../panels/keyboard/cc-keyboard-option.c:315
+msgid "Alternative Characters Key"
+msgstr "គន្លឹះ​តួអក្សរ​ជំនួស"
+
+#: ../panels/keyboard/cc-keyboard-option.c:320
+#| msgid "Mouse Keys"
+msgid "Compose Key"
+msgstr "គ្រាប់​ចុច​តែង"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "Keyboard"
+msgstr "ក្ដារចុច"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "Change keyboard settings"
+msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​ក្ដារចុច"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Shortcut;Repeat;Blink;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "ផ្លូវកាត់​ផ្ទាល់ខ្លួន"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "_Name:"
+msgstr "ឈ្មោះ ៖"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "C_ommand:"
+msgstr "ពាក្យបញ្ជា ៖"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "Repeat Keys"
+msgstr "គ្រាប់ចុច​ធ្វើ​ម្ដងទៀត"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Key presses _repeat when key is held down"
+msgstr "គ្រាប់ចុច presses _repeat នៅ​ពេល​គ្រាប់ចុច​ត្រូវ​បាន​សង្កត់"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "_Delay:"
+msgstr "ពន្យារពេល ៖"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Speed:"
+msgstr "ល្បឿន ៖"
+
+#. short delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Short"
+msgstr "ខ្លី"
+
+#. slow acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Slow"
+msgstr "យឺត"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgid "Repeat keys speed"
+msgstr "ល្បឿន​គ្រាប់ចុច​ធ្វើ​ម្ដងទៀត"
+
+#. long delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Long"
+msgstr "យូរ"
+
+#. fast acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Fast"
+msgstr "លឿន"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgid "Cursor Blinking"
+msgstr "ទស្សន៍ទ្រនិច​លោត​ភ្លឹបភ្លែត"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor _blinks in text fields"
+msgstr "ទស្សន៍ទ្រនិច​លោត​ភ្លឹបភ្លែត​នៅ​ក្នុង​វាល​អត្ថបទ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "S_peed:"
+msgstr "ល្បឿន ៖"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "Cursor blink speed"
+msgstr "ល្បឿន​លោត​ភ្លឹបភ្លែត​របស់​ទស្សន៍ទ្រនិច"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Layout Settings"
+msgstr "ការ​កំណត់​ប្លង់"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+msgid "Add Shortcut"
+msgstr "បន្ថែម​ផ្លូវកាត់"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Remove Shortcut"
+msgstr "យក​ផ្លូវកាត់​ចេញ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"ដើម្បី​កែសម្រួល​ផ្លូវកាត់ ចុច​ជួរ​ដេក និង​សង្កត់​គ្រាប់ចុច​ថ្មី ឬ​ចុច លុប​ថយក្រោយ (Backspace) ដើម្បី​សម្អាត ។"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+#: ../panels/region/gnome-region-panel.ui.h:29
+msgid "Shortcuts"
+msgstr "ផ្លូវកាត់"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:552
+#: ../panels/keyboard/keyboard-shortcuts.c:560
+#: ../panels/keyboard/keyboard-shortcuts.c:942
+#: ../panels/keyboard/keyboard-shortcuts.c:1414
+#: ../panels/keyboard/keyboard-shortcuts.c:1418
+msgid "Custom Shortcuts"
+msgstr "ផ្លូវកាត់​ផ្ទាល់ខ្លួន"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:756
+msgid "<Unknown Action>"
+msgstr "<មិន​ស្គាល់​សកម្មភាព>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1253
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"មិន​អាច​ប្រើ​ផ្លូវកាត់ \"%s\" បាន​ទេ ពីព្រោះ​វា​នឹង​ធ្វើឲ្យ​មិន​អាច​វាយ​ដោយ​ប្រើ​គ្រាប់​ចុច​នេះ​បាន ។\n"
+"សូម​ព្យាយាម​ប្រើ​គ្រាប់ចុច​ដូចជា បញ្ជា (Control) ជំនួស (Alt) ឬ​ប្ដូរ (Shift) ក្នុង​ពេល​តែមួយ ។"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1285
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"ផ្លូវកាត់ \"%s\" ត្រូវ​បាន​ប្រើ​សម្រាប់\n"
+"\"%s\" រួចហើយ"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1290
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "ប្រសិនបើ​អ្នក​កំណត់​ផ្លូវកាត់​ឡើងវិញ​ទៅជា \"%s\" ផ្លូវកាត់ \"%s\" នឹង​ត្រូវ​បាន​បិទ ។"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1296
+msgid "_Reassign"
+msgstr "កំណត់​ឡើងវិញ"
+
+#: ../panels/mouse/cc-mouse-panel.c:152
+#| msgid "Your settings"
+msgid "_Test Your Settings"
+msgstr "សាកល្បង​ការ​កំណត់​របស់​អ្នក"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#| msgid "Mouse and Touchpad"
+msgid "Mouse & Touchpad"
+msgstr "កណ្ដុរ និង​បន្ទះ​ប៉ះ"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Set your mouse and touchpad preferences"
+msgstr "កំណត់​ចំណូលចិត្ត​កណ្ដុរ និង​បន្ទះ​ប៉ះ​របស់​អ្នក"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "Mouse Preferences"
+msgstr "ចំណូលចិត្ត​កណ្ដុរ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "General"
+msgstr "ទូទៅ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "Double-click timeout"
+msgstr "អស់​ពេល​ចុច​ទ្វេ​ដង"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+#| msgid "Double-click timeout"
+msgid "_Double-click"
+msgstr "ចុច​ទ្វេ​ដង"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+#| msgid "Primary Color"
+msgid "Primary _button"
+msgstr "ប៊ូតុង​ចម្បង"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+#| msgctxt "balance"
+#| msgid "Left"
+msgid "_Left"
+msgstr "ឆ្វេង"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+#| msgctxt "balance"
+#| msgid "Right"
+msgid "_Right"
+msgstr "ស្ដាំ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgid "Mouse"
+msgstr "កណ្ដុរ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+#| msgid "Pointer Speed"
+msgid "_Pointer speed"
+msgstr "ល្បឿន​ព្រួញ​កណ្ដុរ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgid "Touchpad"
+msgstr "បន្ទះ​ប៉ះ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+#| msgid "Disable _touchpad while typing"
+msgid "Disable while _typing"
+msgstr "បិទ​​ខណៈ​ពេល​វាយ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Tap to _click"
+msgstr "ថេប​ដើម្បី​ចុច"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+#| msgid "Two-_finger scrolling"
+msgid "Two _finger scroll"
+msgstr "រមូរ​ដោយ​ប្រើម្រាមដៃ​ពីរ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "C_ontent sticks to fingers"
+msgstr "មាតិកា​ជាប់​នឹង​ម្រាមដៃ"
+
+#: ../panels/mouse/gnome-mouse-test.c:134
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ព្យាយាម​ចុច ចុច​ទ្វេ​ដង រមូរ"
+
+#: ../panels/mouse/gnome-mouse-test.c:139
+msgid "Five clicks, GEGL time!"
+msgstr "ចុច​ប្រាំ​ដង GEGL ដង !"
+
+#: ../panels/mouse/gnome-mouse-test.c:144
+#| msgid "Double-click timeout"
+msgid "Double click, primary button"
+msgstr "​ចុច​ទ្វេ​ដង ប៊ូតុង​ចម្បង"
+
+#: ../panels/mouse/gnome-mouse-test.c:144
+msgid "Single click, primary button"
+msgstr "ចុច​ម្ដង​ប៊ូតុង​សំខាន់"
+
+#: ../panels/mouse/gnome-mouse-test.c:147
+#| msgid "Double-click timeout"
+msgid "Double click, middle button"
+msgstr "ចុច​ទ្វេ​ដង ប៊ូតុង​កណ្ដាល"
+
+#: ../panels/mouse/gnome-mouse-test.c:147
+msgid "Single click, middle button"
+msgstr "ចុច​ម្ដង ប៊ូតុង​កណ្ដាល"
+
+#: ../panels/mouse/gnome-mouse-test.c:150
+#| msgid "Double-click timeout"
+msgid "Double click, secondary button"
+msgstr "​ចុច​ទ្វេ​ដង ប៊ូតុង​រង"
+
+#: ../panels/mouse/gnome-mouse-test.c:150
+msgid "Single click, secondary button"
+msgstr "ចុច​ម្ដង​ប៊ូតុង​រង"
+
+#: ../panels/network/cc-network-panel.c:615
+msgid "Network proxy"
+msgstr "ប្រូកស៊ី​បណ្ដាញ"
+
+#: ../panels/network/cc-network-panel.c:799 ../panels/network/net-vpn.c:278
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:866
+msgid "The system network services are not compatible with this version."
+msgstr "សេវា​បណ្ដាញ​ប្រព័ន្ធ​មិន​ឆប​ជាមួយ​កំណែ​នេះ​ទេ ។"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:1001
+#| msgid "Airplane Mode"
+msgid "Air_plane Mode"
+msgstr "នៅ​ពេល​ជិះ​យន្ដហោះ"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "បណ្ដាញ"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Network settings"
+msgstr "ការ​កំណត់​បណ្ដាញ"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid "Network;Wireless;IP;LAN;Proxy;"
+msgstr "Network;Wireless;IP;LAN;Proxy;"
+
+#: ../panels/network/net-device-mobile.c:222
+#| msgid "Connection"
+msgid "Add new connection"
+msgstr "បន្ថែម​ការ​តភ្ជាប់​ថ្មី"
+
+#. Translators: network device speed
+#: ../panels/network/net-device-mobile.c:261
+#: ../panels/network/net-device-wifi.c:699
+#: ../panels/network/net-device-wired.c:126
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#. TRANSLATORS: this is when the access point is not listed in
+#. *  the dropdown (or hidden) and the user has to select another
+#. *  entry manually
+#: ../panels/network/net-device-wifi.c:196
+msgid "Connect to a Hidden Network"
+msgstr "តភ្ជាប់​ទៅ​បណ្ដាញ​ដែល​លាក់"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/net-device-wifi.c:293
+#: ../panels/network/net-device-wifi.c:472
+msgid "WEP"
+msgstr "បណ្ដាញ"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/net-device-wifi.c:297
+#: ../panels/network/net-device-wifi.c:476
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/net-device-wifi.c:301
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/net-device-wifi.c:306
+msgid "Enterprise"
+msgstr "សហគ្រាស"
+
+#: ../panels/network/net-device-wifi.c:311
+#: ../panels/network/net-device-wifi.c:467
+#| msgid "None"
+msgctxt "Wifi security"
+msgid "None"
+msgstr "គ្មាន"
+
+#: ../panels/network/net-device-wifi.c:733
+#| msgid "None"
+msgctxt "Signal strength"
+msgid "None"
+msgstr "គ្មាន"
+
+#: ../panels/network/net-device-wifi.c:735
+#| msgctxt "Password strength"
+#| msgid "Weak"
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "ខ្សោយ"
+
+#: ../panels/network/net-device-wifi.c:737
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "គ្មាន​បញ្ហា"
+
+#: ../panels/network/net-device-wifi.c:739
+#| msgid "Good"
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "ល្អ"
+
+#: ../panels/network/net-device-wifi.c:741
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "ប្រសើរ​ណាស់"
+
+#: ../panels/network/net-device-wifi.c:901
+#, c-format
+msgid ""
+"Network details for %s including password and any custom configuration will "
+"be lost"
+msgstr ""
+"សេចក្ដី​លម្អិត​អំពី​បណ្ដាញ​សម្រាប់ %s ដែល​រួម​មាន​ពាក្យសម្ងាត់ និង​ការ​កំណត់​រចនាសម្ព័ន្ធ​ផ្ទាល់ខ្លួន​ណាមួយ​នឹង​ត្រូវ​"
+"បាត់បង់"
+
+#: ../panels/network/net-device-wifi.c:912
+msgid "Forget"
+msgstr "ភ្លេច"
+
+#: ../panels/network/net-device-wifi.c:1437
+msgid ""
+"If you have a connection to the Internet other than wireless, you can use it "
+"to share your internet connection with others."
+msgstr ""
+"ប្រសិន​បើ​អ្នក​មាន​ការ​តភ្ជាប់​​អ៊ីនធឺណិត​ក្រៅ​ពី​​ប្រើ​ប្រព័ន្ធ​ឥត​ខ្សែ "
+"អ្នក​អាច​ប្រើ​វា ដើម្បី​ចែករំលែក​ការ​តភ្ជាប់​អ៊ីនធឺណីត​ជា​មួយ​អ្នក​ផ្សេង ។"
+
+#: ../panels/network/net-device-wifi.c:1441
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "បើក​ hotspot ឥតខ្សែ​នឹង​ផ្ដាច់​អ្នក​ពី <b>%s</b> ។"
+
+#: ../panels/network/net-device-wifi.c:1445
+msgid ""
+"It is not possible to access the internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"មិនអាច​ចូលប្រើ​អ៊ីនធឺណិត​តាមរយៈ​ប្រព័ន្ធ​ឥតខ្សែ​របស់​អ្នក​បាន​ទេ ខណៈ​ដែល​ "
+"hotspot សកម្ម ។"
+
+#: ../panels/network/net-device-wifi.c:1511
+msgid "Stop hotspot and disconnect any users?"
+msgstr "បញ្ឈប់ hotspot និង​ផ្ដាច់​អ្នកប្រើ​ណា​ម្នាក់​ឬ ?"
+
+#: ../panels/network/net-device-wifi.c:1514
+msgid "_Stop Hotspot"
+msgstr "បញ្ឈប់ Hotspot"
+
+#: ../panels/network/net-device-wifi.c:1579
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i ថ្ងៃ​មុន"
+
+#: ../panels/network/net-device-wifi.c:1933
+#: ../panels/network/network-wifi.ui.h:19
+#| msgid "Out of toner"
+msgid "Out of range"
+msgstr "ក្រៅ​ជួរ"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"ការ​រក​ឃើញ​ប្រូកស៊ី​បណ្ដាញ​ស្វ័យប្រវត្តិ​នឹង​ត្រូវ​បាន​ប្រើ នៅ​ពេល​ URL កំណត់​រចនាសម្ព័ន្ធ​មិន​ត្រូវ​បាន​ផ្ដល់ ។"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "វា​មិន​ត្រូវ​បាន​ផ្ដល់​អនុសាសន៍​សម្រាប់​បណ្ដាញ​សាធារណៈ​ដែល​មិន​គួរ​ទុកចិត្ត​នោះ​ទេ ។"
+
+#: ../panels/network/net-proxy.c:367
+msgid "Proxy"
+msgstr "ប្រូកស៊ី"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "ក្រុមហ៊ុន​ផ្ដល់"
+
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:697 ../panels/network/panel-common.c:699
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "អាសយដ្ឋាន IP"
+
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-wifi.ui.h:7
+#: ../panels/network/network-wired.ui.h:3 ../panels/network/panel-common.c:695
+msgid "IPv6 Address"
+msgstr "អាសយដ្ឋាន IPv6"
+
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-wifi.ui.h:8
+#: ../panels/network/network-wired.ui.h:5
+msgid "Default Route"
+msgstr "ផ្លូវ​លំនាំដើម"
+
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-wifi.ui.h:9
+#: ../panels/network/network-wired.ui.h:6
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-wired.ui.h:7
+msgid "_Options..."
+msgstr "ជម្រើស..."
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:5
+msgctxt "proxy method"
+msgid "None"
+msgstr "គ្មាន"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:6
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "ដោយដៃ"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:7
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "ស្វ័យប្រវត្តិ"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "វិធីសាស្ត្រ"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "URL កំណត់​រចនាសម្ព័ន្ធ"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "ប្រូកស៊ី HTTP"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "ប្រូកស៊ី HTTPS"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "ប្រូកស៊ី FTP"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "ម៉ាស៊ីន​រន្ធ"
+
+#: ../panels/network/network.ui.h:1
+msgid "Select the interface to use for the new service"
+msgstr "ជ្រើស​ចំណុច​ប្រទាក់​ដែល​ត្រូវ​ប្រើ​សម្រាប់​សេវា​ថ្មី"
+
+#: ../panels/network/network.ui.h:2
+#| msgid "Create..."
+msgid "C_reate..."
+msgstr "បង្កើត..."
+
+#: ../panels/network/network.ui.h:3
+#| msgid "Interface"
+msgid "_Interface"
+msgstr "ចំណុច​ប្រទាក់"
+
+#: ../panels/network/network.ui.h:4 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/network.ui.h:8
+msgid "Add Device"
+msgstr "បន្ថែម​ឧបករណ៍"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "ប្រភេទ VPN"
+
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "ផ្លូវ​ចេញចូល"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "ឈ្មោះ​ក្រុម"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "ពាក្យសម្ងាត់​ជា​ក្រុម"
+
+#: ../panels/network/network-vpn.ui.h:6
+msgid "Username"
+msgstr "ឈ្មោះ​អ្នកប្រើ"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "_Configure..."
+msgstr "កំណត់​រចនាសម្ព័ន្ធ..."
+
+#: ../panels/network/network-wifi.ui.h:1
+#| msgid "Wireless mouse"
+msgid "Wireless Hotspot"
+msgstr "otspot ​ឥត​ខ្សែ"
+
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Turn On"
+msgstr "បើក"
+
+#. TRANSLATORS: device type
+#: ../panels/network/network-wifi.ui.h:3 ../panels/network/panel-common.c:90
+msgid "Wireless"
+msgstr "ឥត​ខ្សែ"
+
+#: ../panels/network/network-wifi.ui.h:4
+msgid "_Use as Hotspot..."
+msgstr "ប្រើ​ជា Hotspot..."
+
+#: ../panels/network/network-wifi.ui.h:5
+#: ../panels/network/network-wired.ui.h:1
+msgid "Hardware Address"
+msgstr "អាសយដ្ឋាន​ផ្នែក​រឹង"
+
+#: ../panels/network/network-wifi.ui.h:6
+#: ../panels/network/network-wired.ui.h:2 ../panels/network/panel-common.c:694
+msgid "IPv4 Address"
+msgstr "អាសយដ្ឋាន IPv4"
+
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Security"
+msgstr "សុវត្ថិភាព"
+
+#: ../panels/network/network-wifi.ui.h:11
+#| msgid "Length:"
+msgid "Strength"
+msgstr "ប្រវែង"
+
+#: ../panels/network/network-wifi.ui.h:12
+#| msgid "Cursor blink speed"
+msgid "Link speed"
+msgstr "ល្បឿនតំណ"
+
+#: ../panels/network/network-wifi.ui.h:13
+#| msgid "Copy Settings..."
+msgid "_Settings..."
+msgstr "ការ​កំណត់..."
+
+#: ../panels/network/network-wifi.ui.h:14
+msgid "Switch off to connect to a wireless network"
+msgstr "បិទ ដើម្បី​តភ្ជាប់​ទៅ​បណ្ដាញ​ឥត​ខ្សែ"
+
+#: ../panels/network/network-wifi.ui.h:15
+msgid "Network Name"
+msgstr "ឈ្មោះ​បណ្ដាញ"
+
+#: ../panels/network/network-wifi.ui.h:16
+#| msgid "Connected"
+msgid "Connected Devices"
+msgstr "ឧបករណ៍​ដែល​បាន​តភ្ជាប់"
+
+#: ../panels/network/network-wifi.ui.h:17
+#| msgid "Security Key"
+msgid "Security type"
+msgstr "ប្រភេទ​សុវត្ថិភាព"
+
+#: ../panels/network/network-wifi.ui.h:18
+#| msgid "Security Key"
+msgid "Security key"
+msgstr "សោ​សុវត្ថិភាព"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "Security Key"
+msgstr "សោ​សុវត្ថិភាព"
+
+#: ../panels/network/network-wifi.ui.h:21
+#| msgctxt "printer state"
+#| msgid "Paused"
+msgid "Last used"
+msgstr "បានប្រើ​ចុងក្រោយ"
+
+#: ../panels/network/network-wifi.ui.h:22
+#| msgid "Forget Network"
+msgid "_Forget Network"
+msgstr "ភ្លេច​បណ្ដាញ"
+
+#: ../panels/network/network-wired.ui.h:4
+msgid "Subnet Mask"
+msgstr "របាំង​បណ្ដាញ​រង"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:86
+msgid "Wired"
+msgstr "មាន​ខ្សែ"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:97
+msgid "Mobile broadband"
+msgstr "រលក​អាកាស​ចល័ត"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:106
+msgid "Mesh"
+msgstr "សំណាញ់"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:166
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:170
+msgid "Infrastructure"
+msgstr "ហេដ្ឋារចនាសម្ព័ន្ធ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:194 ../panels/network/panel-common.c:255
+msgid "Status unknown"
+msgstr "មិន​ស្គាល់​ស្ថានភាព"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:198
+msgid "Unmanaged"
+msgstr "មិនបាន​គ្រប់គ្រង"
+
+#: ../panels/network/panel-common.c:203
+msgid "Firmware missing"
+msgstr "បាត់​កម្មវិធី​បង្កប់"
+
+#: ../panels/network/panel-common.c:206
+msgid "Cable unplugged"
+msgstr "ខ្សែ​ត្រូវ​បាន​ដក"
+
+#: ../panels/network/panel-common.c:208
+msgid "Unavailable"
+msgstr "មិន​អាច​ប្រើ​បាន"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:212
+msgid "Disconnected"
+msgstr "បាន​ផ្ដាច់"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
+msgid "Connecting"
+msgstr "តភ្ជាប់"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
+msgid "Authentication required"
+msgstr "តម្រូវឲ្យ​ផ្ទៀងផ្ទាត់​ភាព​ត្រឹមត្រូវ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227 ../panels/network/panel-common.c:269
+msgid "Connected"
+msgstr "បាន​តភ្ជាប់"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:231
+msgid "Disconnecting"
+msgstr "ផ្ដាច់"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:273
+msgid "Connection failed"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​តភ្ជាប់"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:239 ../panels/network/panel-common.c:281
+msgid "Status unknown (missing)"
+msgstr "(បាត់) មិន​ស្គាល់​ស្ថានភាព"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:277
+msgid "Not connected"
+msgstr "មិន​ត្រូវ​បាន​តភ្ជាប់"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:301
+#| msgid "Connection failed"
+msgid "Configuration failed"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​កំណត់​រចនាសម្ព័ន្ធ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:305
+#| msgid "Connection failed"
+msgid "IP configuration failed"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​កំណត់​រចនាសម្ព័ន្ធ IP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:309
+#| msgid "_Configuration URL"
+msgid "IP configuration expired"
+msgstr "ការ​កំណត់​រចនាសម្ព័ន្ធ IP បាន​ផុត​កំណត់"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:313
+msgid "Secrets were required, but not provided"
+msgstr "ទាមទារ​ភាព​សម្ងាត់ ប៉ុន្តែ​មិន​បាន​ផ្ដល់​ទេ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:317
+msgid "802.1x supplicant disconnected"
+msgstr "បាន​ផ្ដាច់ 802.1x supplicant"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:321
+msgid "802.1x supplicant configuration failed"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​កំណត់​រចនាសម្ព័ន្ធ 802.1x supplicant"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:325
+msgid "802.1x supplicant failed"
+msgstr "បាន​បរាជ័យ 802.1x supplicant"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:329
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant ត្រូវ​ការ​ពេលវាលា​ច្រើន​ ដើម្បី​ផ្ទៀងផ្ទាត់"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:333
+msgid "PPP service failed to start"
+msgstr "សកម្ម PPP បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:337
+#| msgid "Disconnected"
+msgid "PPP service disconnected"
+msgstr "បាន​ផ្ដាច់​សេវាកម្ម PPP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:341
+msgid "PPP failed"
+msgstr "PPP បាន​បរាជ័យ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:345
+msgid "DHCP client failed to start"
+msgstr "ម៉ាស៊ីន​ភ្ញៀវ DHCP បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:349
+msgid "DHCP client error"
+msgstr "កំហុស​ម៉ាស៊ីន​ភ្ញៀវ DHCP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:353
+#| msgid "Connection failed"
+msgid "DHCP client failed"
+msgstr "ម៉ាស៊ីន​ភ្ញៀវ DHCP បាន​បរាជ័យ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:357
+msgid "Shared connection service failed to start"
+msgstr "សេវាកម្ម​តភ្ជាប់​ដែល​បាន​ចែក​រំលែក​បាន​បរាជ័យ​ក្នុងការ​ចាប់ផ្ដើម"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:361
+#| msgid "Connection failed"
+msgid "Shared connection service failed"
+msgstr "សេវាកម្ម​តភ្ជាប់​ដែល​បាន​ចែករំលែក​បាន​បរាជ័យ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:365
+msgid "AutoIP service failed to start"
+msgstr "សេវាកម្ម AutoIP បាន​បរាជ័យ​ក្នុងការ​ចាប់ផ្ដើម"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:369
+msgid "AutoIP service error"
+msgstr "កំហុស​សេវាកម្ម AutoIP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:373
+#| msgid "Authentication failed"
+msgid "AutoIP service failed"
+msgstr "សេវាកម្ម AutoIP បាន​បរាជ័យ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:377
+msgid "Line busy"
+msgstr "ជាប់​រវល់"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:381
+msgid "No dial tone"
+msgstr "គ្មាន​សំឡេង​ចុច"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:385
+msgid "No carrier could be established"
+msgstr "គ្មានភ្នាក់ងារ​បញ្ជូន​អាច​ត្រូវ​បាន​បង្កើត"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:389
+msgid "Dialing request timed out"
+msgstr "សំណើរ​ហៅ​អស់​ពេល"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:393
+msgid "Dialing attempt failed"
+msgstr "បាន​បរាជ័យ​ក្នុងការ​ប៉ុនប៉ង​ហៅ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:397
+#| msgid "Authentication failed"
+msgid "Modem initialization failed"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម​ម៉ូដឹម"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:401
+#| msgid "Failed to delete user"
+msgid "Failed to select the specified APN"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ជ្រើស​ APN ដែល​បាន​បញ្ជាក់"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:405
+msgid "Not searching for networks"
+msgstr "មិន​ស្វែងរក​បណ្ដាញ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:409
+#| msgid "Network settings"
+msgid "Network registration denied"
+msgstr "បាន​បដិសេធ​ការ​ចុះឈ្មោះ​​បណ្ដាញ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:413
+msgid "Network registration timed out"
+msgstr "ការ​ចុះ​ឈ្មោះ​បណ្ដាញ​បាន​អស់​ពេល"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:417
+msgid "Failed to register with the requested network"
+msgstr "បាន​បរាជ័យ​ក្នុងការ​ចុះឈ្មោះ​ជា​មួយ​បណ្ដាញ​ដែល​បាន​ស្នើ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:421
+msgid "PIN check failed"
+msgstr "ការ​ពិនិត្យ​​មើល PIN បាន​បរាជ័យ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:425
+msgid "Firmware for the device may be missing"
+msgstr "Firmware សម្រាប់​ឧបករណ៍​អាច​បាត់"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:429
+#| msgid "Connection failed"
+msgid "Connection disappeared"
+msgstr "ការ​ត​ភ្ជាប់​មិន​បាន​បង្ហាញ​ទេ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:433
+msgid "Carrier/link changed"
+msgstr "បាន​ផ្លាស់ប្ដូរ​ភ្នាក់ងារ​បញ្ជូន/តំណ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:437
+msgid "Existing connection was assumed"
+msgstr "បាន​សន្មត​ការ​តភ្ជាប់​ដែល​មាន​ស្រាប់"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:441
+msgid "Modem not found"
+msgstr "រក​មិន​ឃើញ​ម៉ូដឹម"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:445
+#| msgid "Connection failed"
+msgid "Bluetooth connection failed"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​តភ្ជាប់​ប៊្លូធូស"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:449
+msgid "SIM Card not inserted"
+msgstr "មិន​បាន​បញ្ចូល​ស៊ីមកាត"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:453
+msgid "SIM Pin required"
+msgstr "ទាមទារ PIN ស៊ីមកាត​"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:457
+msgid "SIM Puk required"
+msgstr "ទាមទារ Puk ស៊ីមកាត​"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:461
+#| msgctxt "Password strength"
+#| msgid "Strong"
+msgid "SIM wrong"
+msgstr "ស៊ីម​កាត​មិន​ត្រឹមត្រូវ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:465
+msgid "InfiniBand device does not support connected mode"
+msgstr "ឧបករណ៍ InfiniBand មិន​គាំទ្រ​របៀប​ដែល​បាន​​តភ្ជាប់​ទេ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:469
+#| msgid "Connection failed"
+msgid "Connection dependency failed"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​តភ្ជាប់​ភាព​អាស្រ័យ"
+
+#. translators: This is the title of the "Add Account" dialogue.
+#. * The title is not visible when using GNOME Shell
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:252
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:263
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "បន្ថែម​គណនី"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:383
+msgid "Error logging into the account"
+msgstr "កំហុស​ក្នុង​ការ​ចូល​ទៅ​ក្នុង​គណនី"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:437
+msgid "Expired credentials. Please log in again."
+msgstr "លិខិត​សម្គាល់​បាន​ផុត​កំណត់ ។ សូម​ចូល​ម្ដងទៀត ។"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:440
+msgid "_Log In"
+msgstr "ចូល"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:676
+msgid "Error creating account"
+msgstr "កំហុស​ក្នុង​ការ​បង្កើត​គណនី"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:718
+msgid "Error removing account"
+msgstr "កំហុស​ក្នុង​ការ​យក​គណនី​ចេញ"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:754
+msgid "Are you sure you want to remove the account?"
+msgstr "តើ​អ្នក​ពិតជា​ចង់​យក​គណនី​ចេញ​ឬ ?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:756
+msgid "This will not remove the account on the server."
+msgstr "វា​នឹង​មិន​យក​គណនី​នៅ​លើ​ម៉ាស៊ីន​បម្រើ​ចេញ​ទេ ។"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:757
+msgid "_Remove"
+msgstr "យកចេញ"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "គណនី​លើ​បណ្ដាញ"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Manage online accounts"
+msgstr "គ្រប់គ្រង​គណនី​លើ​បណ្ដាញ"
+
+#. Translators: those are keywords for the online-accounts control-center panel
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+msgstr "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+#| msgid "Manage online accounts"
+msgid "No online accounts configured"
+msgstr "គ្មាន​គណនី​លើ​បណ្ដាញ​បាន​កំណត់​រចនាសម្ព័ន្ធទេ"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "យក​គណនី​ចេញ"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+#| msgid "Manage online accounts"
+msgid "Add an online account"
+msgstr "បន្ថែម​គណនី​​លើ​បណ្ដាញ"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"ការ​បន្ថែម​គណនី អនុញ្ញាត​ឲ្យ​​កម្មវិធី​របស់​អ្នក​ចូល​មើល​ឯកសារ អ៊ីមែល "
+"ទំនាក់ទំនង ប្រតិទិន ជជែក និង​ផ្សេងៗ​ទៀត។"
+
+#: ../panels/power/cc-power-panel.c:157
+msgid "Unknown time"
+msgstr "មិន​ស្គាល់​ពេលវេលា"
+
+#: ../panels/power/cc-power-panel.c:163
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i នាទី"
+
+#: ../panels/power/cc-power-panel.c:175
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ម៉ោង"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:183
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:184
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ម៉ោង"
+
+#: ../panels/power/cc-power-panel.c:185
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "នាទី"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:228
+#, c-format
+msgid "Charging - %s until fully charged"
+msgstr "បញ្ចូល​ថ្ម - %s រហូត​ដល់​​ពេញ"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:236
+#, c-format
+msgid "Caution low battery, %s remaining"
+msgstr "ជិត​អស់​ថ្ម  នៅ​សល់ %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:244
+#, c-format
+msgid "Using battery power - %s remaining"
+msgstr "ប្រើ​ថាមពល​ថ្ម - នៅ​សល់  %s"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:261
+msgid "Charging"
+msgstr "បញ្ចូល​ថ្ម"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Using battery power"
+msgstr "ប្រើ​ថាមពល​ថ្ម"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:270
+msgid "Charging - fully charged"
+msgstr "បញ្ចូល​ថ្ម - ពេញ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:274
+msgid "Empty"
+msgstr "អស់"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:342
+#, c-format
+msgid "Caution low UPS, %s remaining"
+msgstr "យូភីអេស​ខ្សោយ​ថាមពល នៅ​សល់ %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:348
+#, c-format
+msgid "Using UPS power - %s remaining"
+msgstr "ប្រើ​ថាមពល​យូភីអេស -នៅ​សល់ %s"
+
+#. TRANSLATORS: UPS battery
+#: ../panels/power/cc-power-panel.c:366
+msgid "Caution low UPS"
+msgstr "យូភីអេស​ខ្សោយ​ថាមពល"
+
+#. TRANSLATORS: UPS battery
+#: ../panels/power/cc-power-panel.c:371
+msgid "Using UPS power"
+msgstr "ប្រើ​ថាមពល​យូភីអេស"
+
+#. TRANSLATORS: secondary battery is normally in the media bay
+#: ../panels/power/cc-power-panel.c:423
+msgid "Your secondary battery is fully charged"
+msgstr "ថ្ម​ទី​ពីរ​របស់​អ្នក​ពេញ"
+
+#. TRANSLATORS: secondary battery is normally in the media bay
+#: ../panels/power/cc-power-panel.c:427
+msgid "Your secondary battery is empty"
+msgstr "ថ្ម​ទីពីរ​របស់​អ្នក​អស់ថាមពល"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:510
+msgid "Wireless mouse"
+msgstr "កណ្ដុរ​ឥត​ខ្សែ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:514
+msgid "Wireless keyboard"
+msgstr "ក្ដារ​ចុច​ឥត​ខ្សែ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:518
+msgid "Uninterruptible power supply"
+msgstr "ការ​ផ្គត់ផ្គង់​ថាមពល​ដែល​មិន​អាច​ផ្អាក​បាន"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:522
+msgid "Personal digital assistant"
+msgstr "អ្នក​ជំនួយការ​ឌីជីថល​ផ្ទាល់ខ្លួន"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:526
+msgid "Cellphone"
+msgstr "ទូរស័ព្ទ​ចល័ត"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:530
+msgid "Media player"
+msgstr "កម្មវិធី​ចាក់​មេឌៀ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:534
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:538
+msgid "Computer"
+msgstr "កុំព្យូទ័រ"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:542
+msgid "Battery"
+msgstr "ថ្ម"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:553
+#| msgid "Charging"
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "បញ្ចូល​ថ្ម"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:560
+#| msgid "Caution"
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "ប្រយ័ត្ន"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:565
+#| msgid "Low"
+msgctxt "Battery power"
+msgid "Low"
+msgstr "ទាប"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:570
+#| msgid "Good"
+msgctxt "Battery power"
+msgid "Good"
+msgstr "ល្អ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:575
+#| msgid "Charging - fully charged"
+msgctxt "Battery power"
+msgid "Charging - fully charged"
+msgstr "បញ្ចូល​ថ្ម - ពេញ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:579
+#| msgid "Empty"
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "អស់"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "ថាមពល"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Power management settings"
+msgstr "ការ​កំណត់​ការ​គ្រប់គ្រង​ថាមពល"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+msgstr "Power;Sleep;Suspend;Hibernate;Battery;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "សម្ងំ"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "បិទ​ថាមពល"
+
+#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
+msgid "5 minutes"
+msgstr "៥ នាទី"
+
+#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:7
+msgid "10 minutes"
+msgstr "១០ នាទី"
+
+#: ../panels/power/power.ui.h:5 ../panels/screen/screen.ui.h:8
+msgid "30 minutes"
+msgstr "៣០ នាទី"
+
+#: ../panels/power/power.ui.h:6 ../panels/screen/screen.ui.h:9
+msgid "1 hour"
+msgstr "១ ម៉ោង"
+
+#: ../panels/power/power.ui.h:7
+msgid "Don't suspend"
+msgstr "កុំ​ផ្អាក"
+
+#: ../panels/power/power.ui.h:8
+msgid "On battery power"
+msgstr "នៅ​លើ​ថាមពល​ថ្ម"
+
+#: ../panels/power/power.ui.h:9
+msgid "When plugged in"
+msgstr "នៅ​ពេល​បាន​ដោត"
+
+#: ../panels/power/power.ui.h:10
+msgid "Suspend when inactive for"
+msgstr "ផ្អាក នៅ​ពេល​អសកម្ម"
+
+#: ../panels/power/power.ui.h:11
+msgid "When power is _critically low"
+msgstr "នៅ​ពេល​ថាមពល​កាន់​តែ​ខ្សោយ​ខ្លាំង"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:589
+msgid "Low on toner"
+msgstr "ជិត​អស់​ទឹក​ថ្នាំ"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:591
+msgid "Out of toner"
+msgstr "អស់​ទឹក​ថ្នាំ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:594
+msgid "Low on developer"
+msgstr "ជិត​អស់​ទឹក​ថ្នាំ​លាង​ហ្វីល"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:597
+msgid "Out of developer"
+msgstr "អស់​ទឹក​ថ្នាំ​លាង​ហ្វីល"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:599
+msgid "Low on a marker supply"
+msgstr "ជិត​អស់​សញ្ញា​សម្គាល់"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:601
+msgid "Out of a marker supply"
+msgstr "អស់​សញ្ញា​សម្គាល់"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:603
+msgid "Open cover"
+msgstr "បើក​គម្រប"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:605
+msgid "Open door"
+msgstr "បើក​គម្រប"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:607
+msgid "Low on paper"
+msgstr "ជិត​អស់​ក្រដាស"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:609
+msgid "Out of paper"
+msgstr "អស់​ក្រដាស"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:611
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ក្រៅបណ្ដាញ"
+
+#. Translators: Someone has paused the Printer
+#: ../panels/printers/cc-printers-panel.c:613
+msgctxt "printer state"
+msgid "Paused"
+msgstr "បាន​ផ្អាក"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:615
+msgid "Waste receptacle almost full"
+msgstr "ធុងសំរាម​ជិត​ពេញ"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:617
+msgid "Waste receptacle full"
+msgstr "ធុងសំរាម​ពេញ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:619
+msgid "The optical photo conductor is near end of life"
+msgstr "អង្គធាតុ​ចម្លង​រូបថត​អុបទិក​ជិត​អស់​អាយុកាល"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:621
+msgid "The optical photo conductor is no longer functioning"
+msgstr "អង្គធាតុ​ចម្លង​រូបថត​អុបទិក​លែង​ដំណើរការ"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:724
+#| msgid "_Configuration URL"
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "កំណត់​រចនាសម្ព័ន្ធ"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:781
+msgctxt "printer state"
+msgid "Ready"
+msgstr "រួចហើយ"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:785
+msgctxt "printer state"
+msgid "Processing"
+msgstr "ដំណើរការ"
+
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:789
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "បញ្ឈប់"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:906
+msgid "Toner Level"
+msgstr "កម្រិត​ទឹកថ្នាំ"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:909
+msgid "Ink Level"
+msgstr "កម្រិត​ទឹក​ខ្មៅ"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:912
+msgid "Supply Level"
+msgstr "កម្រិត​ផ្គត់ផ្គង់"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:930
+#| msgid "Install languages..."
+msgctxt "printer state"
+msgid "Installing"
+msgstr "ដំឡើង​"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1107
+msgid "No printers available"
+msgstr "គ្មាន​ម៉ាស៊ីន​បោះពុម្ព​ដែល​អាច​ប្រើ​បាន"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1411
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u សកម្ម"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1731
+msgid "Failed to add new printer."
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព​ថ្មី ។"
+
+#: ../panels/printers/cc-printers-panel.c:1896
+#| msgid "Select ICC Profile File"
+msgid "Select PPD File"
+msgstr "ជ្រើស​ឯកសារ​ PPD"
+
+#: ../panels/printers/cc-printers-panel.c:1905
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"ឯកសារ​ពណ៌នា​​របស់​ម៉ាស៊ីន​បោះពុម្ព PostScript (*.ppd, *.PPD, *.ppd.gz, "
+"*.PPD.gz, *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2210
+#| msgid "No local printers found"
+msgid "No suitable driver found"
+msgstr "រក​មិន​ឃើញ​កម្មវិធី​បញ្ជា​សមរម្យ"
+
+#: ../panels/printers/cc-printers-panel.c:2279
+msgid "Searching for preferred drivers..."
+msgstr "កំពុង​ស្វែងរក​កម្មវិធី​បញ្ជា​ដែល​​ចង់​បាន..."
+
+#: ../panels/printers/cc-printers-panel.c:2294
+msgid "Select from database..."
+msgstr "ជ្រើស​ពី​មូលដ្ឋាន​ទិន្នន័យ..."
+
+#: ../panels/printers/cc-printers-panel.c:2303
+#| msgid "Browse Files..."
+msgid "Provide PPD File..."
+msgstr "ផ្ដល់​ឯកសារ PPD..."
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2454
+#: ../panels/printers/cc-printers-panel.c:2477
+msgid "Test page"
+msgstr "ទំព័រ​សាកល្បង"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2880
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "មិន​អាច​ផ្ទុក ui ៖ %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "ម៉ាស៊ីន​បោះពុម្ព"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Change printer settings"
+msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​ម៉ាស៊ីន​បោះពុម្ព"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
+
+#: ../panels/printers/jobs-dialog.ui.h:1
+#: ../panels/printers/options-dialog.ui.h:1
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/printers/jobs-dialog.ui.h:2
+#: ../panels/printers/options-dialog.ui.h:4
+msgid "Close"
+msgstr "បិទ"
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:4
+#| msgid "Active Print Jobs"
+msgid "Active Jobs"
+msgstr "ការងារសកម្ម"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Resume Printing"
+msgstr "បន្ត​ការ​បោះពុម្ព"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Pause Printing"
+msgstr "ផ្អាក​ការ​បោះពុម្ព"
+
+#: ../panels/printers/jobs-dialog.ui.h:7
+msgid "Cancel Print Job"
+msgstr "បោះបង់​ការងារ​បោះពុម្ព"
+
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1017
+msgid "_Add"
+msgstr "បន្ថែម"
+
+#: ../panels/printers/new-printer-dialog.ui.h:3
+msgid "Add a New Printer"
+msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព​ថ្មី"
+
+#: ../panels/printers/new-printer-dialog.ui.h:4
+#| msgid "No network printers found"
+msgid "Search for network printers or filter result"
+msgstr "ស្វែងរក​ម៉ាស៊ីន​បោះពុម្ព​បណ្ដាញ​ ឬ​លទ្ធផល​តម្រង"
+
+#: ../panels/printers/options-dialog.ui.h:2
+#| msgid "_Options"
+msgid "Options"
+msgstr "ជម្រើស"
+
+#: ../panels/printers/options-dialog.ui.h:3
+#| msgid "Locations..."
+msgid "Loading options..."
+msgstr "កំពុង​ផ្ទុក​ជម្រើស..."
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+#: ../panels/user-accounts/um-account-dialog.c:1016
+msgid "Cancel"
+msgstr "បោះបង់"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "កំពុង​ផ្ទុក​មូលដ្ឋាន​ទិន្នន័យ​កម្មវិធី​បញ្ជា..."
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:5
+#| msgid "Selecting finger"
+msgid "Select Printer Driver"
+msgstr "ជ្រើស​កម្មវិធី​បញ្ហា​ម៉ាស៊ីន​បោះពុម្ព"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:65
+#: ../panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "តែ​ម្ខាង"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:67
+#: ../panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Long Edge (ស្តង់ដារ)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:69
+#: ../panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Short Edge (ត្រឡប់)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:71
+msgid "Portrait"
+msgstr "បញ្ឈរ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:73
+msgid "Landscape"
+msgstr "ផ្ដេក"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:75
+msgid "Reverse landscape"
+msgstr "បញ្ច្រាស​ផ្ដេក"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:77
+msgid "Reverse portrait"
+msgstr "បញ្ច្រាស​បញ្ឈរ"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:143
+msgctxt "print job"
+msgid "Pending"
+msgstr "កំពុង​រង់ចាំ"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:147
+msgctxt "print job"
+msgid "Held"
+msgstr "រង់ចាំ"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:151
+msgctxt "print job"
+msgid "Processing"
+msgstr "ដំណើរការ"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:155
+msgctxt "print job"
+msgid "Stopped"
+msgstr "បញ្ឈប់"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:159
+msgctxt "print job"
+msgid "Canceled"
+msgstr "បោះបង់"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:163
+msgctxt "print job"
+msgid "Aborted"
+msgstr "បោះបង់"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:167
+msgctxt "print job"
+msgid "Completed"
+msgstr "បាន​បញ្ចប់"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:289
+msgid "Job Title"
+msgstr "ចំណងជើង​ការងារ"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:298
+msgid "Job State"
+msgstr "ស្ថានភាព​ការងារ"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:304
+msgid "Time"
+msgstr "ពេលវេលា"
+
+#: ../panels/printers/pp-jobs-dialog.c:484
+#, c-format
+#| msgid "Active Print Jobs"
+msgid "%s Active Jobs"
+msgstr "ការងារ​សកម្ម %s"
+
+#. Translators: No printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1291
+#| msgid "No tablet detected"
+msgid "No printers detected."
+msgstr "រក​មិ​ន​ឃើញ​ម៉ាស៊ីន​បោះពុម្ព"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Two Sided"
+msgstr "ទាំង​សងខាង"
+
+#: ../panels/printers/pp-options-dialog.c:83
+#| msgid "VPN Type"
+msgid "Paper Type"
+msgstr "ប្រភេទ​ក្រដាស"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Paper Source"
+msgstr "ប្រភព​ក្រដាស"
+
+#: ../panels/printers/pp-options-dialog.c:85
+#| msgid "Output"
+msgid "Output Tray"
+msgstr "ថាស​លទ្ធផល"
+
+#: ../panels/printers/pp-options-dialog.c:86
+#| msgid "_Resolution"
+msgid "Resolution"
+msgstr "គុណភាព​បង្ហាញ"
+
+#: ../panels/printers/pp-options-dialog.c:87
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript pre-filtering"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:533
+msgid "Pages per side"
+msgstr "ទំព័រ​ក្នុង​ម្ខាង"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:545
+msgid "Two-sided"
+msgstr "ទាំង​សងខាង"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:557
+#| msgid "Left-Handed Orientation"
+msgid "Orientation"
+msgstr "ទិស​"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:654
+#| msgid "General"
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "ទូទៅ"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "រៀបចំ​ទំព័រ"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:660
+#| msgid "Printer Options"
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "ជម្រើស​បាន​ដំឡើង"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:663
+#| msgid "Jobs"
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "ការងារ"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "គុណភាព​រូបភាព"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:669
+#| msgid "Color"
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "ពណ៌"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "បញ្ចប់"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:675
+#| msgctxt "print job"
+#| msgid "Canceled"
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "កម្រិត​ខ្ពស់"
+
+#. Translators: Options of given printer (e.g. "MyPrinter Options")
+#: ../panels/printers/pp-options-dialog.c:936
+#, c-format
+#| msgid "_Options"
+msgid "%s Options"
+msgstr "%s ជម្រើស"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:75
+#: ../panels/printers/pp-ppd-option-widget.c:77
+#: ../panels/printers/pp-ppd-option-widget.c:85
+#| msgid "Select"
+msgid "Auto Select"
+msgstr "ជ្រើស​ស្វ័យ​ប្រវត្តិ"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:79
+#: ../panels/printers/pp-ppd-option-widget.c:81
+#: ../panels/printers/pp-ppd-option-widget.c:83
+#: ../panels/printers/pp-ppd-option-widget.c:87
+#| msgid "Default"
+msgid "Printer Default"
+msgstr "ម៉ាស៊ីន​បោះពុម្ព​លំនាំដើម"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "បញ្ចប់​តែ​ពុម្ពអក្សរ GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "បម្លែង​ទៅ PS កម្រិត ១"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "បម្លែង​ទៅជា PS កម្រិត​ ២"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:95
+#| msgid "No profile"
+msgid "No pre-filtering"
+msgstr "គ្មាន​​តម្រង​ជា​មុន"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:230
+#| msgid "Manufacturer:"
+msgid "Manufacturers"
+msgstr "ក្រុមហ៊ុនផលិត"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:242
+#| msgid "Driver"
+msgid "Drivers"
+msgstr "កម្មវិធី​បញ្ជា"
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "យក​ម៉ាស៊ីន​បោះពុម្ព​ចេញ"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "ការ​ផ្គត់ផ្គង់"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "ទីតាំង"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default"
+msgstr "លំនាំដើម"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "ការងារ"
+
+#. Tanslators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "_Show"
+msgstr "បង្ហាញ"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "ម៉ូដែល"
+
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "ទំព័រ ១"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "ស្លាក"
+
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "ទំព័រ ២"
+
+#: ../panels/printers/printers.ui.h:17
+#| msgid "Getting devices..."
+msgid "Setting new driver..."
+msgstr "កំពុង​កំណត់​កម្មវិធី​បញ្ជា​ថ្មី..."
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "ទំព័រ​ ៣"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "បោះពុម្ព​ទំព័រ​សាកល្បង"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "ជម្រើស"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "បន្ថែម​ម៉ាស៊ីន​បោះពុម្ព​ថ្មី"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"សូម​អភ័យទោស ! សេវា​បោះពុម្ព​តាម​ប្រព័ន្ធ\n"
+"ហាក់​ដូចជា​មិន​ដំណើរការ ។"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#| msgid "Region and Language"
+msgid "Region & Language"
+msgstr "តំបន់ និង​ភាសា"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid "Change your region and language settings"
+msgstr "ផ្លាស់ប្ដូរ​ការ​កំណត់​តំបន់ និង​ភាសា​របស់​អ្នក"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;"
+msgstr "Language;Layout;Keyboard;"
+
+#: ../panels/region/gnome-region-panel-formats.c:142
+msgid "Imperial"
+msgstr "កម្រិត​ខ្ពស់"
+
+#: ../panels/region/gnome-region-panel-formats.c:144
+msgid "Metric"
+msgstr "ម៉ែត្រ"
+
+#: ../panels/region/gnome-region-panel-input-chooser.ui.h:1
+#| msgid "Select an input source to add"
+msgid "Choose an input source"
+msgstr "ជ្រើស​ប្រភព​បញ្ចូល"
+
+#: ../panels/region/gnome-region-panel-input-chooser.ui.h:2
+msgid "Select an input source to add"
+msgstr "ជ្រើស​ប្រភព​បញ្ចូល ដើម្បី​បន្ថែម"
+
+#: ../panels/region/gnome-region-panel-system.c:330
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings."
+msgstr "អេក្រង់​ចូល គណនី​ប្រព័ន្ធ និង​គណនី​អ្នកប្រើ​ថ្មី​ប្រើ​ការ​កំណត់​តំបន់ និង​ភាសា​ទូទាំង​ប្រព័ន្ធ ។"
+
+#: ../panels/region/gnome-region-panel-system.c:335
+#: ../panels/region/gnome-region-panel.ui.h:31
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings. You may change the system settings to match "
+"yours."
+msgstr ""
+"អេក្រង់​ចូល គណនី​ប្រព័ន្ធ និង​គណនី​អ្នកប្រើ​ថ្មី​ប្រើ​ការ​កំណត់​តំបន់ និង​ភាសា​ទូទាំង​ប្រព័ន្ធ ។ អ្នក​អាច​ផ្លាស់ប្ដូរ​ការ​"
+"កំណត់​ប្រព័ន្ធ​ទៅតាម​តម្រូវការ​របស់​អ្នក​បាន ។"
+
+#: ../panels/region/gnome-region-panel-system.c:338
+msgid "Copy Settings"
+msgstr "ចម្លង​ការ​កំណត់"
+
+#: ../panels/region/gnome-region-panel-system.c:341
+#: ../panels/region/gnome-region-panel.ui.h:38
+msgid "Copy Settings..."
+msgstr "ចម្លង​ការ​កំណត់..."
+
+#: ../panels/region/gnome-region-panel.ui.h:1
+msgid "Region and Language"
+msgstr "តំបន់ និង​ភាសា"
+
+#: ../panels/region/gnome-region-panel.ui.h:2
+msgid "Select a display language (change will be applied next time you log in)"
+msgstr "ជ្រើស​ភាសា (ការ​ផ្លាស់ប្ដូរ​នឹង​ត្រូវ​បាន​អនុវត្ត​ នៅ​ពេល​ដែល​អ្នក​ចូល​លើក​ក្រោយ)"
+
+#: ../panels/region/gnome-region-panel.ui.h:3
+msgid "Add Language"
+msgstr "បន្ថែម​ភាសា"
+
+#: ../panels/region/gnome-region-panel.ui.h:4
+msgid "Remove Language"
+msgstr "យក​ភាសា​ចេញ"
+
+#: ../panels/region/gnome-region-panel.ui.h:5
+msgid "Install languages..."
+msgstr "ដំឡើង​ភាសា..."
+
+#: ../panels/region/gnome-region-panel.ui.h:6
+msgid "Language"
+msgstr "ភាសា"
+
+#: ../panels/region/gnome-region-panel.ui.h:7
+msgid "Select a region (change will be applied the next time you log in)"
+msgstr "ជ្រើស​តំបន់ (ការ​ផ្លាស់ប្ដូរ​នឹង​ត្រូវ​បាន​អនុវត្ត នៅ​ពេល​ដែល​អ្នក​ចូល​លើកក្រោយ)"
+
+#: ../panels/region/gnome-region-panel.ui.h:8
+msgid "Add Region"
+msgstr "បន្ថែម​តំបន់"
+
+#: ../panels/region/gnome-region-panel.ui.h:9
+msgid "Remove Region"
+msgstr "យក​តំបន់​ចេញ"
+
+#: ../panels/region/gnome-region-panel.ui.h:10
+msgid "Dates"
+msgstr "កាលបរិច្ឆេទ"
+
+#: ../panels/region/gnome-region-panel.ui.h:11
+msgid "Times"
+msgstr "ពេលវេលា"
+
+#: ../panels/region/gnome-region-panel.ui.h:12
+msgid "Numbers"
+msgstr "លេខ"
+
+#: ../panels/region/gnome-region-panel.ui.h:13
+msgid "Currency"
+msgstr "រូបិយប័ណ្ណ"
+
+#: ../panels/region/gnome-region-panel.ui.h:14
+msgid "Measurement"
+msgstr "រង្វាស់"
+
+#: ../panels/region/gnome-region-panel.ui.h:15
+msgid "Examples"
+msgstr "ឧទាហរណ៍"
+
+#: ../panels/region/gnome-region-panel.ui.h:16
+msgid "Formats"
+msgstr "ទ្រង់ទ្រាយ"
+
+#: ../panels/region/gnome-region-panel.ui.h:17
+#| msgid "Select an input source to add"
+msgid "Select keyboards or other input sources"
+msgstr "ជ្រើស​ក្ដារចុច ឬ​ប្រភព​បញ្ចូល​ផ្សេង​ទៀត"
+
+#: ../panels/region/gnome-region-panel.ui.h:18
+#| msgid "Input source:"
+msgid "Add Input Source"
+msgstr "បន្ថែម​ប្រភព​បញ្ចូល"
+
+#: ../panels/region/gnome-region-panel.ui.h:19
+#| msgid "Input source:"
+msgid "Remove Input Source"
+msgstr "យក​ប្រភព​បញ្ចូល​ចេញ"
+
+#: ../panels/region/gnome-region-panel.ui.h:20
+#| msgid "Input source:"
+msgid "Move Input Source Up"
+msgstr "ផ្លាស់ទី​ប្រភព​បញ្ចូល​ឡើង​លើ"
+
+#: ../panels/region/gnome-region-panel.ui.h:21
+#| msgid "Input source:"
+msgid "Move Input Source Down"
+msgstr "ផ្លាស់ទី​ប្រភព​បញ្ចូល​ចុះក្រោម"
+
+#: ../panels/region/gnome-region-panel.ui.h:22
+#| msgid "Mouse Settings"
+msgid "Input Source Settings"
+msgstr "បញ្ចូល​ការ​កំណត់​ប្រភព"
+
+#: ../panels/region/gnome-region-panel.ui.h:23
+#| msgid "Keyboard Layout"
+msgid "Show Keyboard Layout"
+msgstr "បង្ហាញ​ប្លង់​ក្ដារចុច"
+
+#: ../panels/region/gnome-region-panel.ui.h:25
+msgid "Ctrl+Alt+Space"
+msgstr "បញ្ជា (Ctrl)+ជំនួស (Alt)+ដកឃ្លា (Space)"
+
+#: ../panels/region/gnome-region-panel.ui.h:27
+msgid "Ctrl+Alt+Shift+Space"
+msgstr "បញ្ជា(Ctrl)+ជំនួស(Alt)+ប្ដូរ(Shift)+ដកឃ្លា(Space)"
+
+#: ../panels/region/gnome-region-panel.ui.h:28
+#| msgid "Sound Settings"
+msgid "Shortcut Settings"
+msgstr "ការ​កំណត់​ផ្លូវ​កាត់"
+
+#: ../panels/region/gnome-region-panel.ui.h:30
+#| msgid "Input source:"
+msgid "Input Sources"
+msgstr "ប្រភព​បញ្ចូល"
+
+#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
+#: ../panels/region/gnome-region-panel.ui.h:33
+msgid "Display language:"
+msgstr "ភាសា​បង្ហាញ ៖"
+
+#: ../panels/region/gnome-region-panel.ui.h:34
+msgid "Input source:"
+msgstr "ប្រភព​បញ្ចូល ៖"
+
+#: ../panels/region/gnome-region-panel.ui.h:35
+msgid "Format:"
+msgstr "ទ្រង់ទ្រាយ ៖"
+
+#: ../panels/region/gnome-region-panel.ui.h:36
+msgid "Your settings"
+msgstr "ការ​កំណត់​របស់​អ្នក"
+
+#: ../panels/region/gnome-region-panel.ui.h:37
+msgid "System settings"
+msgstr "ការ​កំណត់​ប្រព័ន្ធ"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:1
+#| msgid "Brightness and Lock"
+msgid "Brightness & Lock"
+msgstr "ពន្លឺ និង​ការ​ចាក់សោ"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
+msgid "Screen brightness and lock settings"
+msgstr "ការ​កំណត់​ពន្លឺ​អេក្រង់ និង​ការ​ចាក់សោ"
+
+#. Translators: those are keywords for the brightness and lock control-center panel
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
+msgid "Brightness;Lock;Dim;Blank;Monitor;"
+msgstr "Brightness;Lock;Dim;Blank;Monitor;"
+
+#: ../panels/screen/screen.ui.h:1
+msgid "Screen turns off"
+msgstr "បិទ​អេក្រង់"
+
+#: ../panels/screen/screen.ui.h:2
+msgid "30 seconds"
+msgstr "៣០ វិនាទី"
+
+#: ../panels/screen/screen.ui.h:3
+msgid "1 minute"
+msgstr "១ នាទី"
+
+#: ../panels/screen/screen.ui.h:4
+msgid "2 minutes"
+msgstr "២ នាទី"
+
+#: ../panels/screen/screen.ui.h:5
+msgid "3 minutes"
+msgstr "៣ នាទី"
+
+#: ../panels/screen/screen.ui.h:10
+msgid "_Dim screen to save power"
+msgstr "ធ្វើឲ្យ​អេក្រង់​ស្រអាប់ ដើម្បី​សន្សំ​ថាមពល"
+
+#: ../panels/screen/screen.ui.h:11
+msgid "Brightness"
+msgstr "ពន្លឺ"
+
+#: ../panels/screen/screen.ui.h:12
+msgid "_Turn screen off when inactive for:"
+msgstr "បិទ​អេក្រង់ នៅ​ពេល​អសកម្ម ៖"
+
+#: ../panels/screen/screen.ui.h:13
+msgid "_Lock screen after:"
+msgstr "ចាក់​សោ​អេក្រង់​បន្ទាប់ពី ៖"
+
+#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
+#: ../panels/screen/screen.ui.h:15
+msgid "Don't lock when at home"
+msgstr "កុំ​ចាក់​សោ នៅ​ពេល​អ្នក​នៅ​ផ្ទះ"
+
+#: ../panels/screen/screen.ui.h:16
+msgid "Locations..."
+msgstr "ទីតាំង..."
+
+#: ../panels/screen/screen.ui.h:17
+msgid "Show _notifications when locked"
+msgstr "បង្ហាញ​ការ​ជូន​ដំណឹង​នៅ​ពេល​ចាក់សោ"
+
+#: ../panels/screen/screen.ui.h:18
+msgid "Lock"
+msgstr "ចាក់សោ"
+
+#: ../panels/sound/applet-main.c:49
+msgid "Enable debugging code"
+msgstr "បើក​កូដ​បំបាត់​កំហុស"
+
+#: ../panels/sound/applet-main.c:50
+msgid "Version of this application"
+msgstr "កំណែ​កម្មវិធី​នេះ"
+
+#: ../panels/sound/applet-main.c:62
+msgid " — GNOME Volume Control Applet"
+msgstr " អាប់ភ្លេត​គ្រប់គ្រង​កម្រិត​សំឡេង​របស់  — GNOME"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
+msgid "Volume Control"
+msgstr "កា​រ​គ្រប់គ្រង​កម្រិត​សំឡេង"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
+msgid "Show desktop volume control"
+msgstr "បង្ហាញ​ការ​គ្រប់គ្រង​កម្រិត​សំឡេង​នៅ​លើ​ផ្ទៃតុ"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "សំឡេង"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound volume and sound events"
+msgstr "ផ្លាស់ប្ដូរ​កម្រិត​សំឡេង ​និង​ព្រឹត្តិការណ៍​សំឡេង"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+#| msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "ឆ្កែ​ព្រុស"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "តំណក់​ទឹក"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "គោះ​កែវ"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "សូរណា"
+
+#: ../panels/sound/gvc-applet.c:270 ../panels/sound/gvc-mixer-dialog.c:1656
+msgid "Output"
+msgstr "បញ្ចេញ"
+
+#: ../panels/sound/gvc-applet.c:272
+msgid "Sound Output Volume"
+msgstr "កម្រិត​បញ្ចេញ​សំឡេង"
+
+#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1697
+msgid "Input"
+msgstr "បញ្ចូល"
+
+#: ../panels/sound/gvc-applet.c:278
+msgid "Microphone Volume"
+msgstr "កម្រិត​សំឡេង​មីក្រូហ្វូន"
+
+#: ../panels/sound/gvc-balance-bar.c:111
+msgctxt "balance"
+msgid "Left"
+msgstr "ឆ្វេង"
+
+#: ../panels/sound/gvc-balance-bar.c:112
+msgctxt "balance"
+msgid "Right"
+msgstr "ស្ដាំ"
+
+#: ../panels/sound/gvc-balance-bar.c:115
+msgctxt "balance"
+msgid "Rear"
+msgstr "ខាង​ក្រោយ"
+
+#: ../panels/sound/gvc-balance-bar.c:116
+msgctxt "balance"
+msgid "Front"
+msgstr "ខាងមុខ"
+
+#: ../panels/sound/gvc-balance-bar.c:119
+msgctxt "balance"
+msgid "Minimum"
+msgstr "អប្បបរមា"
+
+#: ../panels/sound/gvc-balance-bar.c:120
+msgctxt "balance"
+msgid "Maximum"
+msgstr "អតិបរមា"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Balance:"
+msgstr "តុល្យភាព ៖"
+
+#: ../panels/sound/gvc-balance-bar.c:298
+msgid "_Fade:"
+msgstr "សំឡេង​ថយ ៖"
+
+#: ../panels/sound/gvc-balance-bar.c:301
+msgid "_Subwoofer:"
+msgstr "Subwoofer ៖"
+
+#: ../panels/sound/gvc-channel-bar.c:613 ../panels/sound/gvc-channel-bar.c:622
+msgctxt "volume"
+msgid "100%"
+msgstr "១០០%"
+
+#: ../panels/sound/gvc-channel-bar.c:617
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "មិន​ពង្រីក"
+
+#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:521
+msgid "_Profile:"
+msgstr "ទម្រង់ ៖"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1841
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "បញ្ចេញ %u"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1851
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "បញ្ចូល %u"
+
+#: ../panels/sound/gvc-mixer-control.c:2375
+msgid "System Sounds"
+msgstr "សំឡេង​របស់​ប្រព័ន្ធ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "សាកល្បង​ធុងបាស"
+
+#: ../panels/sound/gvc-mixer-dialog.c:426
+msgid "Peak detect"
+msgstr "រក​ឃើញ​កម្រិត​សំឡេង​ខ្ពស់​បំផុត"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1506
+#: ../panels/sound/gvc-sound-theme-chooser.c:595
+msgid "Name"
+msgstr "ឈ្មោះ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1588
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "សាកល្បង​ធុងបាស​សម្រាប់ %s"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1642
+msgid "_Output volume:"
+msgstr "កម្រិត​បញ្ចេញ​សំឡេង ៖"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1661
+msgid "C_hoose a device for sound output:"
+msgstr "ជ្រើស​ឧបករណ៍​សម្រាប់​​បញ្ចេញ​សំឡេង ៖"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1686
+msgid "Settings for the selected device:"
+msgstr "ការ​កំណត់​សម្រាប់​ឧបករណ៍​ដែល​បាន​ជ្រើស ៖"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "_Input volume:"
+msgstr "កម្រិត​បញ្ចូល​សំឡេង ៖"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1727
+msgid "Input level:"
+msgstr "កម្រិត​បញ្ចូល ៖"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1755
+msgid "C_hoose a device for sound input:"
+msgstr "ជ្រើស​ឧបករណ៍​សម្រាប់​បញ្ចូល​សំឡេង ៖"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1782
+msgid "Sound Effects"
+msgstr "បែបផែន​សំឡេង"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "_Alert volume:"
+msgstr "កម្រិត​សំឡេង​ព្រមាន ៖"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1802
+msgid "Applications"
+msgstr "កម្មវិធី"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1806
+msgid "No application is currently playing or recording audio."
+msgstr "បច្ចុប្បន្ន​គ្មាន​កម្មវិធី​ដែល​កំពុង​ចាក់ ឬ​ថត​ចម្លង​អូឌីយ៉ូ​ទេ ។"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:189
+msgid "Built-in"
+msgstr "ភ្ជាប់​មក​ជាមួយ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:455
+#: ../panels/sound/gvc-sound-theme-chooser.c:467
+#: ../panels/sound/gvc-sound-theme-chooser.c:479
+msgid "Sound Preferences"
+msgstr "ចំណូលចិត្ត​សំឡេង"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:458
+#: ../panels/sound/gvc-sound-theme-chooser.c:469
+#: ../panels/sound/gvc-sound-theme-chooser.c:481
+msgid "Testing event sound"
+msgstr "សាកល្បង​សំឡេង​ព្រឹត្តិការណ៍"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "Default"
+msgstr "លំនាំដើម"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:586
+msgid "From theme"
+msgstr "ពី​ស្បែក"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:770
+msgid "C_hoose an alert sound:"
+msgstr "ជ្រើស​សំឡេង​ព្រមាន ៖"
+
+#: ../panels/sound/gvc-speaker-test.c:220
+msgid "Stop"
+msgstr "បញ្ឈប់"
+
+#: ../panels/sound/gvc-speaker-test.c:220
+#: ../panels/sound/gvc-speaker-test.c:332
+msgid "Test"
+msgstr "សាកល្បង"
+
+#: ../panels/sound/gvc-speaker-test.c:228
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: ../panels/sound/gvc-stream-status-icon.c:236
+#, c-format
+msgid "Failed to start Sound Preferences: %s"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចាប់ផ្ដើម​ចំណូលចិត្ត​សំឡេង ៖ %s"
+
+#: ../panels/sound/gvc-stream-status-icon.c:262
+msgid "_Mute"
+msgstr "ស្ងាត់"
+
+#: ../panels/sound/gvc-stream-status-icon.c:271
+msgid "_Sound Preferences"
+msgstr "ចំណូលចិត្ត​សំឡេង"
+
+#: ../panels/sound/gvc-stream-status-icon.c:416
+msgid "Muted"
+msgstr "ស្ងាត់"
+
+#: ../panels/sound/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr "ផ្ទាល់ខ្លួន"
+
+#: ../panels/universal-access/cc-ua-panel.c:286
+#: ../panels/universal-access/cc-ua-panel.c:292
+msgid "No shortcut set"
+msgstr "គ្មាន​ការ​កំណត់​ផ្លូវកាត់"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Universal Access Preferences"
+msgstr "ចំណូលចិត្ត​ចូល​ដំណើរការ​សកល"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
+"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
+"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "ទាប"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgctxt "universal access, contrast"
+msgid "Normal"
+msgstr "ធម្មតា"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "ខ្ពស់"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgctxt "universal access, contrast"
+msgid "High/Inverse"
+msgstr "ខ្ពស់/ច្រាស"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "On screen keyboard"
+msgstr "ក្ដារចុច​លើ​អេក្រង់"
+
+#: ../panels/universal-access/uap.ui.h:6
+msgid "GOK"
+msgstr "GOK"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "OnBoard"
+msgstr "OnBoard"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "None"
+msgstr "គ្មាន"
+
+#: ../panels/universal-access/uap.ui.h:10
+#, no-c-format
+msgid "75%"
+msgstr "៧៥%"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgctxt "universal access, text size"
+msgid "Small"
+msgstr "តូច"
+
+#: ../panels/universal-access/uap.ui.h:13
+#, no-c-format
+msgid "100%"
+msgstr "១០០%"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgctxt "universal access, text size"
+msgid "Normal"
+msgstr "ធម្មតា"
+
+#: ../panels/universal-access/uap.ui.h:16
+#, no-c-format
+msgid "125%"
+msgstr "១២៥%"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgctxt "universal access, text size"
+msgid "Large"
+msgstr "ធំ"
+
+#: ../panels/universal-access/uap.ui.h:19
+#, no-c-format
+msgid "150%"
+msgstr "១៥០%"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgctxt "universal access, text size"
+msgid "Larger"
+msgstr "ធំជាង"
+
+#: ../panels/universal-access/uap.ui.h:21
+#| msgid "_Contrast:"
+msgid "High Contrast"
+msgstr "កម្រិត​ពណ៌"
+
+#: ../panels/universal-access/uap.ui.h:22
+#| msgid "Beep when Caps and Num Lock are used"
+msgid "Beep on Caps and Num Lock"
+msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​ប្ដូរ​ជាប់ និង​លេខ​ ( Caps and Num Lock) ត្រូវ​បាន​ប្រើ"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "Options..."
+msgstr "ជម្រើស..."
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Screen Reader"
+msgstr "កម្មវិធី​អាន​អេក្រង់"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Turn on or off:"
+msgstr "បើក ឬ​បិទ"
+
+#: ../panels/universal-access/uap.ui.h:26
+#| msgid "Zoom"
+msgctxt "universal access, zoom"
+msgid "Zoom"
+msgstr "ពង្រីក"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Zoom in:"
+msgstr "ពង្រីក ៖"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Zoom out:"
+msgstr "បង្រួម ៖"
+
+#: ../panels/universal-access/uap.ui.h:29
+#| msgid "Large"
+msgid "Large Text"
+msgstr "អត្ថបទ​ធំ"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "Seeing"
+msgstr "មើលឃើញ"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Visual Alerts"
+msgstr "ការ​ព្រមាន​ដែល​មើល​ឃើញ"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Use a visual indication when an alert sound occurs"
+msgstr "ប្រើ​ការ​បង្ហាញ​ដែល​មើល​ឃើញ នៅ​ពេល​សំឡេង​ព្រមាន​កើត​ឡើង"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Flash the window title"
+msgstr "បញ្ចេញ​ពន្លឺ​លើ​ចំណង​ជើង​បង្អួច"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Flash the entire screen"
+msgstr "បញ្ចេញ​ពន្លឺ​ទូទាំង​អេក្រង់"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgid "Closed Captioning"
+msgstr "បាន​បិទ​ដាក់​ចំណងជើង"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Display a textual description of speech and sounds"
+msgstr "បង្ហាញ​សេចក្ដី​ពិពណ៌នា​ជា​អត្ថបទ​អំពី​ពាក្យសម្ដី និង​សំឡេង"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgid "_Test flash"
+msgstr "សាកល្បង​ការ​បញ្ចេញ​ពន្លឺ"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Hearing"
+msgstr "ស្ដាប់"
+
+#: ../panels/universal-access/uap.ui.h:40
+#| msgid "On screen keyboard"
+msgid "On Screen Keyboard"
+msgstr "ក្ដារចុច​លើ​អេក្រង់"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "Sticky Keys"
+msgstr "គ្រាប់ចុច​ស្អិត"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "ចាត់​ទុក​លំដាប់​នៃ​គ្រាប់ចុច​កម្មវិធី​កែប្រែ​ជា​បន្សំ​គ្រាប់ចុច"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgid "_Disable if two keys are pressed together"
+msgstr "បិទ ប្រសិនបើ​គ្រាប់ចុច​ទាំងពីរ​ត្រូវ​បាន​ចុច​ព្រម​គ្នា"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Beep when a _modifer key is pressed"
+msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​កម្មវិធី​កែប្រែ​ត្រូវ​បាន​ចុច"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "Slow Keys"
+msgstr "គ្រាប់ចុច​យឺត"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "កំណត់​ការ​ពន្យារពេល​រវាង​ពេល​ដែល​គ្រាប់ចុច​ត្រូវ​បាន​ចុច និង​ពេល​ដែល​វា​ត្រូវ​បាន​ទទួល​យក"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "A_cceptance delay:"
+msgstr "ពន្យារ​ពេល​ក្នុង​ការ​ទទួលយក ៖"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Slow keys typing delay"
+msgstr "ពន្យារពេល​ក្នុង​ការ​វាយ​ដោយ​ប្រើ​គ្រាប់ចុច​យឺត"
+
+#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
+#: ../panels/universal-access/uap.ui.h:54
+msgid "Beep when a key is"
+msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:56
+msgid "pressed"
+msgstr "ត្រូវ​បាន​ចុច"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:58
+msgid "accepted"
+msgstr "ទទួលយក"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:60
+msgid "rejected"
+msgstr "បដិសេធ"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgid "Bounce Keys"
+msgstr "គ្រាប់ចុច​លោត"
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "Ignores fast duplicate keypresses"
+msgstr "មិន​អើពើ​ការ​ចុច​គ្រាប់ចុច​ស្ទួន​គ្នា"
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Acc_eptance delay:"
+msgstr "ពន្យារពេល​ក្នុង​ការ​ទទួល​យក ៖"
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "Bounce keys typing delay"
+msgstr "ពន្យារពេល​ក្នុង​ការ​វាយ​ដោយ​ប្រើ​គ្រាប់ចុច​លោត"
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Beep when a key is _rejected"
+msgstr "បញ្ចេញ​សំឡេង​ប៊ីប នៅ​ពេល​គ្រាប់ចុច​ត្រូវ​បាន​បដិសេធ"
+
+#: ../panels/universal-access/uap.ui.h:66
+#| msgid "Keyboard"
+msgid "Enable by Keyboard"
+msgstr "បើក​ដោយ​ក្ដារចុច"
+
+#: ../panels/universal-access/uap.ui.h:67
+#| msgid "_Turn on accessibility features from the keyboard"
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "បើក​លក្ខណ​ពិសេស​នៃ​មធ្យោបាយ​ងាយស្រួល​ប្រើ​ពី​ក្ដារចុច"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Mouse Keys"
+msgstr "គ្រាប់ចុច​កណ្ដុរ"
+
+#: ../panels/universal-access/uap.ui.h:70
+msgid "Control the pointer using the keypad"
+msgstr "គ្រប់គ្រង​ព្រួញកណ្ដុរ​ដោយ​ប្រើ​បន្ទះ​គ្រាប់ចុច"
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Video Mouse"
+msgstr "កណ្ដុរ​ជា​វីដេអូ"
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "Control the pointer using the video camera."
+msgstr "គ្រប់គ្រង​ព្រួញ​កណ្ដុរ​ដោយ​ប្រើ​ម៉ាស៊ីន​ថត​វីដេអូ ។"
+
+#: ../panels/universal-access/uap.ui.h:73
+msgid "Simulated Secondary Click"
+msgstr "ត្រាប់តាម​ការ​ចុច​លើក​ទី​ពីរ"
+
+#: ../panels/universal-access/uap.ui.h:74
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "ធ្វើការ​ចុច​លើក​ទីពីរ ដោយ​សង្កត់​ប៊ូតុង​ចុច​លើក​ទី​មួយ"
+
+#: ../panels/universal-access/uap.ui.h:75
+msgid "Secondary click delay"
+msgstr "ពន្យារពេល​ក្នុង​ការ​ចុច​លើក​ទី​ពីរ"
+
+#: ../panels/universal-access/uap.ui.h:76
+msgid "Hover Click"
+msgstr "ចុច​នៅ​ពេល​សំកាំង"
+
+#: ../panels/universal-access/uap.ui.h:77
+msgid "Trigger a click when the pointer hovers"
+msgstr "ធ្វើ​ការ​ចុច នៅ​ពេល​ព្រួញ​កណ្ដុរ​សំកាំង"
+
+#: ../panels/universal-access/uap.ui.h:78
+msgid "D_elay:"
+msgstr "ពន្យារពេល ៖"
+
+#: ../panels/universal-access/uap.ui.h:79
+msgid "Motion _threshold:"
+msgstr "កម្រិត​ពន្លឺ​ចលនា ៖"
+
+#. small threshold
+#: ../panels/universal-access/uap.ui.h:81
+msgid "Small"
+msgstr "តូច"
+
+#. large threshold
+#: ../panels/universal-access/uap.ui.h:83
+msgid "Large"
+msgstr "ធំ"
+
+#: ../panels/universal-access/uap.ui.h:84
+msgid "Mouse Settings"
+msgstr "ការ​កំណត់​កណ្ដុរ"
+
+#: ../panels/universal-access/uap.ui.h:85
+msgid "Pointing and Clicking"
+msgstr "ចង្អុល និង​ចុច"
+
+#: ../panels/universal-access/zoom-options.c:357
+#| msgid "Short"
+msgctxt "Distance"
+msgid "Short"
+msgstr "ខ្លី"
+
+#: ../panels/universal-access/zoom-options.c:358
+#| msgid "1/4 Screen"
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "អេក្រង់ ១/៤"
+
+#: ../panels/universal-access/zoom-options.c:359
+#| msgid "1/4 Screen"
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "អេក្រង់ ១/២"
+
+#: ../panels/universal-access/zoom-options.c:360
+#| msgid "1/4 Screen"
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "អេក្រង់ ៣/៤"
+
+#: ../panels/universal-access/zoom-options.c:361
+#| msgid "Long"
+msgctxt "Distance"
+msgid "Long"
+msgstr "វែង"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "ពេញ​អេក្រង់"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "ពាក់​កណ្ដាល​ផ្នែកខាងលើ"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "ពាក់​កណ្ដាល​ផ្នែក​ខាងក្រោម"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "ពាក់កណ្ដាល​ខាង​ឆ្វេង"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "ពាក់កណ្ដាល​ខាង​ស្ដាំ"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "ជម្រើស​ពង្រីក"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "ពង្រីក"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "ការ​ពង្រីក ៖"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "អនុវត្ត​តាម​ព្រួញ​កណ្ដុរ"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "ភាគ​អេក្រង់ ៖"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "កម្មវិធី​ពង្រីក​ពង្រីក​ចេញ​ពី​អេក្រង់"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "រក្សាទុក​ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​ឲ្យ​ចំកណ្ដាល"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​រុញ​មាតិកា​ជុំវិញ"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "ព្រួញ​កណ្ដុរ​កម្មវិធី​ពង្រីក​ផ្លាស់ទី​ជាមួយ​មាតិកា"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "ទីតាំង​របស់​កម្មវិធី​ពង្រីក ៖"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+#| msgid "Magnifier Position:"
+msgid "Magnifier"
+msgstr "កម្មវិធី​ពង្រីក"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "កម្រាស់ ៖"
+
+#. short delay
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgid "Thin"
+msgstr "ស្ដើង"
+
+#. long delay
+#: ../panels/universal-access/zoom-options.ui.h:21
+msgid "Thick"
+msgstr "ក្រាស់"
+
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Length:"
+msgstr "ប្រវែង ៖"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Color:"
+msgstr "ពណ៌ ៖"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Crosshairs:"
+msgstr "សញ្ញា​ខ្វែង ៖"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Overlaps mouse cursor"
+msgstr "ដាក់​ព្រួញ​កណ្ដុរ​ត្រួតគ្នា"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+#| msgid "Crosshairs:"
+msgid "Crosshairs"
+msgstr "សញ្ញា​ខ្វែង"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "White on black:"
+msgstr "ពណ៌​ស​នៅ​លើខ្មៅ"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+#| msgid "Brightness"
+msgid "Brightness:"
+msgstr "ពន្លឺ ៖"
+
+#: ../panels/universal-access/zoom-options.ui.h:29
+#| msgid "_Contrast:"
+msgid "Contrast:"
+msgstr "កម្រិត​ពណ៌ ៖"
+
+#: ../panels/universal-access/zoom-options.ui.h:30
+#| msgid "Color"
+msgctxt "Zoom Grayscale"
+msgid "Color"
+msgstr "ពណ៌"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+#| msgid "None"
+msgctxt "Zoom Grayscale"
+msgid "None"
+msgstr "គ្មាន"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "Zoom Grayscale"
+msgid "Full"
+msgstr "ពេញ"
+
+#. short delay
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgid "Low"
+msgstr "ទាប"
+
+#. long delay
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgid "High"
+msgstr "ខ្ពស់"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+#| msgid "Sound Effects"
+msgid "Color Effects:"
+msgstr "បែបផែន​ពណ៌ ៖"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+#| msgid "Sound Effects"
+msgid "Color Effects"
+msgstr "បែបផែន​ពណ៌"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:35
+msgctxt "Account type"
+msgid "Standard"
+msgstr "ស្ដង់ដារ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:37
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "អ្នក​គ្រប់គ្រង"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#| msgid "Add Account"
+msgid "Add account"
+msgstr "បន្ថែម​គណនី"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+#| msgid "My Account"
+msgid "_Local Account"
+msgstr "គណនី​​មូលដ្ឋាន"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#| msgid "_Fingerprint Login"
+msgid "_Enterprise Login"
+msgstr "ចូល​ជា​សហគ្រាស"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "_Username"
+msgstr "ឈ្មោះ​អ្នកប្រើ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+msgid "_Full name"
+msgstr "ឈ្មោះពេញ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+#| msgid "Account Type:"
+msgid "Account _Type"
+msgstr "ប្រភេទ​គណនី"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+msgid "_Domain"
+msgstr "ដែន"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Login Name"
+msgstr "ឈ្មោះ​ចូល"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "_Password"
+msgstr "ពាក្យ​សម្ងាត់"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "Tip: Enterprise domain or realm name"
+msgstr "ជំនួយ ៖ ដែន​សហគ្រាស​ ឬ​ឈ្មោះតំបន់"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid "C_ontinue"
+msgstr "បន្ត"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:14
+#| msgctxt "Account type"
+#| msgid "Administrator"
+msgid "Domain Administrator Login"
+msgstr "ចូល​ជា​​អ្នក​គ្រប់គ្រង​ដែន"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid ""
+"In order to use enterpise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"ដើម្បី​ប្រើ​ឈ្មោះ​ចូល​សហគ្រាស "
+"កុំព្យូទ័រ​នេះ​តម្រូវ​ឲ្យ​\nចុះឈ្មោះ​នៅ​ក្នុង​ដែន ។ "
+"សូម​ឲ្យ​អ្នក​គ្រប់គ្រង​បណ្ដាញ​របស់​អ្នក\nវាយ​ពាក្យ​សម្ងាត់​ដែន​នៅ​ទី​នេះ ។"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:18
+#| msgctxt "Account type"
+#| msgid "Administrator"
+msgid "Administrator _Name"
+msgstr "ឈ្មោះ​អ្នក​គ្រប់គ្រង"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#| msgctxt "Account type"
+#| msgid "Administrator"
+msgid "Administrator Password"
+msgstr "ពាក្យសម្ងាត់​អ្នក​គ្រប់គ្រង"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "មេដៃ​ឆ្វេង"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "ម្រាមដៃ​កណ្ដាល​ខាងឆ្វេង"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "ម្រាម​នាងដៃ​ខាង​ឆ្វេង"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "ម្រាម​កូនដៃ​ខាង​ឆ្វេង"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "មេ​ដៃ​ស្ដាំ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "ម្រាមដៃ​កណ្ដាល​ខាង​ស្ដាំ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "ម្រាម​នាង​ដៃ​ខាង​ស្ដាំ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "ម្រាម​កូនដៃ​ខាង​ស្ដាំ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:706
+msgid "Enable Fingerprint Login"
+msgstr "បើក​ការ​ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "ចង្អុល​ដៃ​ស្ដាំ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "ចង្អុល​ដៃ​ឆ្វេង"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "ម្រាម​ផ្សេងទៀត ៖"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"ស្នាម​ម្រាមដៃ​របស់​អ្នក​ត្រូវ​បាន​រក្សាទុក​ដោយ​ជោគជ័យ ។  ឥឡូវនេះ អ្នក​អាច​នឹង​ចូល​ដោយ​ប្រើ​កម្មវិធី​អាន​ស្នាម​"
+"ម្រាមដៃ​របស់​អ្នក​បាន ។"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "User Accounts"
+msgstr "គណនី​អ្នកប្រើ"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users"
+msgstr "បន្ថែម ឬ​យក​គណនី​អ្នកប្រើ​ចេញ"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Set a password now"
+msgstr "កំណត់​ពាក្យសម្ងាត់​ឥឡូវនេះ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+msgid "Choose password at next login"
+msgstr "ជ្រើស​ពាក្យសម្ងាត់ នៅ​ពេល​ចូល​លើកក្រោយ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Log in without a password"
+msgstr "ចូល​ដោយ​មិន​ប្រើ​ពាក្យសម្ងាត់"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "Disable this account"
+msgstr "បិទ​គណនី​នេះ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Enable this account"
+msgstr "បើក​គណនី​នេះ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "_Hint"
+msgstr "ពាក្យគន្លឹះ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid ""
+"This hint may be displayed at the login screen.  It will be visible to all "
+"users of this system.  Do <b>not</b> include the password here."
+msgstr ""
+"ពាក្យ​គន្លឹះ​អាច​នឹង​ត្រូវ​បង្ហាញ​នៅ​កន្លែង​អេក្រង់​ចូល ។ អ្នកប្រើ​ប្រព័ន្ធ​នេះ​ទាំងអស់​អាច​មើល​ឃើញ​វា ។   "
+"<b>កុំ</b> រួមបញ្ចូល​ពាក្យសម្ងាត់​នៅ​ទីនេះ ។"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "C_onfirm password"
+msgstr "អះអាង​ពាក្យសម្ងាត់"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+msgid "_New password"
+msgstr "ពាក្យសម្ងាត់​ថ្មី"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+#| msgid "Set a password now"
+msgid "Generate a password"
+msgstr "បង្កើត​ពាក្យ​សម្ងាត់"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+msgid "Fair"
+msgstr "ល្មម"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+msgid "Current _password"
+msgstr "ពាក្យសម្ងាត់​បច្ចុប្បន្ន"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid "_Action"
+msgstr "សកម្មភាព"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+msgid "Changing password for"
+msgstr "ផ្លាស់ប្ដូរ​ពាក្យសម្ងាត់"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:15
+msgid "_Show password"
+msgstr "បង្ហាញ​ពាក្យសម្ងាត់"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:16
+msgid "How to choose a strong password"
+msgstr "របៀប​ជ្រើស​ពាក្យសម្ងាត់​ខ្លាំង"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:17
+msgid "Ch_ange"
+msgstr "ផ្លាស់ប្ដូរ"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+msgid "Changing photo for:"
+msgstr "ផ្លាស់ប្ដូរ​រូបថត ៖"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+msgid ""
+"Choose a picture that will be shown at the login screen for this account."
+msgstr "ជ្រើស​រូបភាព​ដែល​នឹង​ត្រូវ​បង្ហាញ​នៅ​ត្រង់​អេក្រង់​ចូល​សម្រាប់​គណនី​នេះ ។"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+msgid "Gallery"
+msgstr "វិចិត្រសាល"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "Browse for more pictures"
+msgstr "រកមើល​រូបភាព​ផ្សេងទៀត"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+msgid "Take a photograph"
+msgstr "ថត​រូប"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+msgid "Browse"
+msgstr "រកមើល"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr "រូបថត"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Account Information"
+msgstr "ព័ត៌មាន​គណនី"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Add User Account"
+msgstr "បន្ថែម​គណនី​អ្នកប្រើ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Remove User Account"
+msgstr "យក​គណនី​អ្នកប្រើ​ចេញ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "Login Options"
+msgstr "ជម្រើស​ចូល"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "A_utomatic Login"
+msgstr "ចូល​ស្វ័យប្រវត្តិ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "_Fingerprint Login"
+msgstr "ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាម​ដៃ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "User Icon"
+msgstr "រូបតំណាង​អ្នកប្រើ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "_Language"
+msgstr "ភាសា"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#| msgid "Manage online accounts"
+msgid "Manage user accounts"
+msgstr "គ្រប់គ្រង​គណនី​អ្នក​ប្រើ"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#| msgid "Authentication required"
+msgid "Authentication is required to change user data"
+msgstr "តម្រូវ​ឲ្យ​ផ្ទៀងផ្ទាត់ ដើម្បី​ផ្លាស់ប្ដូរ​ទិន្នន័យ​អ្នក​ប្រើ"
+
+#: ../panels/user-accounts/pw-utils.c:94
+#: ../panels/user-accounts/um-password-dialog.c:569
+msgctxt "Password strength"
+msgid "Too short"
+msgstr "ខ្លី​ពេក"
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password strength"
+msgid "Not good enough"
+msgstr "មិន​ល្អ​ទេ"
+
+#: ../panels/user-accounts/pw-utils.c:108
+#: ../panels/user-accounts/um-password-dialog.c:570
+msgctxt "Password strength"
+msgid "Weak"
+msgstr "ខ្សោយ"
+
+#: ../panels/user-accounts/pw-utils.c:111
+#: ../panels/user-accounts/um-password-dialog.c:571
+msgctxt "Password strength"
+msgid "Fair"
+msgstr "ល្មម"
+
+#: ../panels/user-accounts/pw-utils.c:114
+#: ../panels/user-accounts/um-password-dialog.c:572
+msgctxt "Password strength"
+msgid "Good"
+msgstr "ល្អ"
+
+#: ../panels/user-accounts/pw-utils.c:117
+#: ../panels/user-accounts/um-password-dialog.c:573
+msgctxt "Password strength"
+msgid "Strong"
+msgstr "ខ្លាំង"
+
+#: ../panels/user-accounts/run-passwd.c:424
+msgid "Authentication failed"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ផ្ទៀងផ្ទាត់"
+
+#: ../panels/user-accounts/run-passwd.c:504
+#: ../panels/user-accounts/um-password-dialog.c:239
+#, c-format
+msgid "The new password is too short"
+msgstr "ពាក្យសម្ងាត់​ថ្មី​ខ្លី​ពេក"
+
+#: ../panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password is too simple"
+msgstr "ពាក្យសម្ងាត់​ថ្មី​សាមញ្ញ​ពេក"
+
+#: ../panels/user-accounts/run-passwd.c:516
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "ពាក្យសម្ងាត់​ចាស់ និង​ថ្មី​ស្រដៀង​គ្នា​ពេក"
+
+#: ../panels/user-accounts/run-passwd.c:519
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "ពាក្យសម្ងាត់​ថ្មី​ត្រូវ​បាន​គេ​ប្រើ​ហើយ ។"
+
+#: ../panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "ពាក្យសម្ងាត់​ថ្មី​ត្រូវតែ​មាន​តួអក្សរ​ជា​លេខ ឬ​តួអក្សរ​ពិសេស"
+
+#: ../panels/user-accounts/run-passwd.c:526
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "ពាក្យសម្ងាត់​ចាស់ និង​ថ្មី​ដូចគ្នា"
+
+#: ../panels/user-accounts/run-passwd.c:530
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+"ពាក្យសម្ងាត់​របស់​អ្នក​ត្រូវ​បាន​ផ្លាស់ប្ដូរ តាំងពី​អ្នក​បាន​ចាប់ផ្ដើម​ផ្ទៀងផ្ទាត់​ភាព​ត្រឹមត្រូវ​ពី​ដំបូង​ម្លេះ !"
+
+#: ../panels/user-accounts/run-passwd.c:534
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "ពាក្យសម្ងាត់​ថ្មី​មិន​មាន​តួអក្សរ​ផ្សេង​ៗ​គ្នា​ឲ្យ​បាន​គ្រប់គ្រាន់"
+
+#: ../panels/user-accounts/run-passwd.c:538
+#, c-format
+msgid "Unknown error"
+msgstr "មិន​ស្គាល់​កំហុស"
+
+#: ../panels/user-accounts/um-account-dialog.c:175
+#| msgid "Select an account"
+msgid "Failed to add account"
+msgstr "បាន​បរាជ័យ​ក្នុងការ​បន្ថែម​គណនី"
+
+#: ../panels/user-accounts/um-account-dialog.c:366
+#: ../panels/user-accounts/um-account-dialog.c:405
+#| msgid "Failed to create user"
+msgid "Failed to register account"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចុះ​ឈ្មោះ​គណនី"
+
+#: ../panels/user-accounts/um-account-dialog.c:530
+msgid "No supported way to authenticate with this domain"
+msgstr "គ្មាន​វិធី​ដែល​បាន​គាំទ្រ​ ដើម្បី​ផ្ទៀងផ្ទាត់​ជា​មួយ​ដែន​នេះ"
+
+#: ../panels/user-accounts/um-account-dialog.c:582
+msgid "Failed to join domain"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចូល​ដែន"
+
+#: ../panels/user-accounts/um-account-dialog.c:635
+msgid "Failed to log into domain"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ចុះ​កំណត់ហេតុ​ដែន"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr "អ្នក​មិន​ត្រូវ​បាន​អនុញ្ញាត​ឲ្យ​ចូល​ដំណើរការ​ឧបករណ៍​នេះ​ទេ ។ សូម​ទាក់ទង​អ្នក​គ្រប់គ្រង​ប្រព័ន្ធ​របស់​អ្នក ។"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "ឧបករណ៍​កំពុង​ត្រូវ​បាន​ប្រើ ។"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr "កំហុស​ខាងក្នុង​បាន​កើតឡើង ។"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:219
+#: ../panels/user-accounts/um-fingerprint-dialog.c:220
+msgid "Enabled"
+msgstr "បាន​បើក"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:268
+msgid "Delete registered fingerprints?"
+msgstr "លុប​ស្នាម​ម្រាមដៃ​ដែល​បាន​ចុះ​ឈ្មោះ​ឬ ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:272
+msgid "_Delete Fingerprints"
+msgstr "លុប​ស្នាម​ម្រាមដៃ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:279
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"តើ​អ្នក​ចង់​លុប​ស្នាម​ម្រាមដៃ​ដែល​បាន​ចុះ​ឈ្មោះ ដើម្បី​ឲ្យ​ការ​ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាមដៃ​ត្រូវ​បិទ​ដែរ​ឬ​ទេ ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:455
+msgid "Done!"
+msgstr "ធ្វើ​រួច !"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:516
+#: ../panels/user-accounts/um-fingerprint-dialog.c:558
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "មិន​អាច​ចូល​ដំណើរការ​ឧបករណ៍ '%s'"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:603
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "មិន​អាច​ចាប់ផ្ដើមការ​​ចាប់​យក​ស្នាម​ម្រាមដៃ​នៅ​លើ​ឧបករណ៍ '%s' បាន​ឡើយ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:655
+msgid "Could not access any fingerprint readers"
+msgstr "មិន​អាច​ចូល​ដំណើរការ​​កម្មវិធី​អាន​ស្នាម​ម្រាមដៃ​ណាមួយ​បាន​ឡើយ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:656
+msgid "Please contact your system administrator for help."
+msgstr "សម្រាប់​ជំនួយ សូម​ទាក់ទង​អ្នក​គ្រប់គ្រង​ប្រព័ន្ធ​របស់​អ្នក ។"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"ដើម្បី​បើក​ការ​ចូល​ដោយ​ប្រើ​ស្នាម​ម្រាមដៃ អ្នក​ចាំបាច់​ត្រូវ​រក្សាទុក​ស្នាម​ម្រាមដៃ​ណាមួយ ដោយ​ប្រើ​ឧបករណ៍ "
+"'%s' ។"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:747
+msgid "Selecting finger"
+msgstr "ជ្រើស​ម្រាមដៃ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:748
+msgid "Enrolling fingerprints"
+msgstr "ចុះឈ្មោះ​ស្នាម​ម្រាមដៃ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:749
+msgid "Summary"
+msgstr "សង្ខេប"
+
+#: ../panels/user-accounts/um-password-dialog.c:96
+#| msgid "Set a password now"
+msgid "_Generate a password"
+msgstr "បង្កើត​ពាក្យ​សម្ងាត់"
+
+#: ../panels/user-accounts/um-password-dialog.c:150
+msgid "Please choose another password."
+msgstr "សូម​ជ្រើស​ពាក្យសម្ងាត់​ផ្សេងទៀត ។"
+
+#: ../panels/user-accounts/um-password-dialog.c:159
+msgid "Please type your current password again."
+msgstr "សូម​វាយ​បញ្ចូល​ពាក្យសម្ងាត់​បច្ចុប្បន្ន​របស់​អ្នក​ម្ដងទៀត ។"
+
+#: ../panels/user-accounts/um-password-dialog.c:165
+msgid "Password could not be changed"
+msgstr "មិន​អាច​ផ្លាស់ប្ដូរ​ពាក្យសម្ងាត់​បាន​ឡើយ"
+
+#: ../panels/user-accounts/um-password-dialog.c:236
+msgid "You need to enter a new password"
+msgstr "អ្នក​ត្រូវតែ​បញ្ចូល​ពាក្យសម្ងាត់​ថ្មី"
+
+#: ../panels/user-accounts/um-password-dialog.c:245
+msgid "You need to confirm the password"
+msgstr "អ្នក​​ត្រូវតែ​អះអាង​ពាក្យសម្ងាត់"
+
+#: ../panels/user-accounts/um-password-dialog.c:248
+msgid "The passwords do not match"
+msgstr "ពាក្យសម្ងាត់​មិន​ផ្គូផ្គង​គ្នា"
+
+#: ../panels/user-accounts/um-password-dialog.c:254
+msgid "You need to enter your current password"
+msgstr "អ្នក​​ត្រូវតែ​បញ្ចូល​ពាក្យសម្ងាត់​បច្ចុប្បន្ន​របស់​អ្នក"
+
+#: ../panels/user-accounts/um-password-dialog.c:257
+msgid "The current password is not correct"
+msgstr "ពាក្យសម្ងាត់​បច្ចុប្បន្ន​មិន​ត្រឹមត្រូវ"
+
+#: ../panels/user-accounts/um-password-dialog.c:347
+msgid "Passwords do not match"
+msgstr "ពាក្យសម្ងាត់​មិន​ផ្គូផ្គង​គ្នា"
+
+#: ../panels/user-accounts/um-password-dialog.c:409
+msgid "Wrong password"
+msgstr "ពាក្យសម្ងាត់​មិន​ត្រឹមត្រូវ"
+
+#: ../panels/user-accounts/um-photo-dialog.c:443
+msgid "Disable image"
+msgstr "បិទ​រូបភាព"
+
+#: ../panels/user-accounts/um-photo-dialog.c:461
+msgid "Take a photo..."
+msgstr "ថត​រូប..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:479
+msgid "Browse for more pictures..."
+msgstr "រកមើល​រូប​ជាច្រើន​ទៀត..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:704
+#, c-format
+msgid "Used by %s"
+msgstr "ត្រូវ​បាន​ប្រើ​ដោយ %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:368
+#, c-format
+msgid "No such domain or realm found"
+msgstr "រក​មិនឃើញ​ដែន ឬ​តំបន់​បែប​នេះ​ទេ​"
+
+#: ../panels/user-accounts/um-realm-manager.c:743
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "មិន​អាច​ចូល​ជា %s នៅ​ដែន %s បាន​ទេ"
+
+#: ../panels/user-accounts/um-realm-manager.c:748
+msgid "Invalid password, please try again"
+msgstr "ពាក្យ​សម្ងាត់​មិន​ត្រឹមត្រូវ សូម​ព្យាយាម​ម្ដង​ទៀត"
+
+#: ../panels/user-accounts/um-realm-manager.c:752
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "មិន​អាច​តភ្ជាប់​ទៅ %s បាន​ទេ ៖ %s"
+
+#: ../panels/user-accounts/um-user-manager.c:466
+#, c-format
+msgid "A user with name '%s' already exists."
+msgstr "មាន​អ្នក​ប្រើ​ដែល​មាន​ឈ្មោះ​ '%s' នោះ​រួចហើយ ។"
+
+#: ../panels/user-accounts/um-user-manager.c:473
+#, c-format
+#| msgid "A user with the username '%s' already exists"
+msgid "No user with the name '%s' exists."
+msgstr "មិនមាន​អ្នក​ប្រើ​ដែល​មាន​ឈ្មោះ '%s' ។"
+
+#: ../panels/user-accounts/um-user-manager.c:631
+msgid "This user does not exist."
+msgstr "មិន​មាន​អ្នកប្រើ​នេះ​ទេ ។"
+
+#: ../panels/user-accounts/um-user-panel.c:371
+msgid "Failed to delete user"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​លុប​អ្នកប្រើ"
+
+#: ../panels/user-accounts/um-user-panel.c:431
+msgid "You cannot delete your own account."
+msgstr "អ្នក​មិន​អាច​លុប​គណនី​ផ្ទាល់ខ្លួន​របស់​អ្នក​បាន​ទេ ។"
+
+#: ../panels/user-accounts/um-user-panel.c:440
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s នៅ​តែ​ត្រូវ​បាន​ចូល"
+
+#: ../panels/user-accounts/um-user-panel.c:444
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "ការ​លុប​អ្នកប្រើ ខណៈ​ដែល​ពួកគេ​ចូល​អាច​ធ្វើឲ្យ​ប្រព័ន្ធ​ស្ថិត​ក្នុង​ស្ថានភាព​មិន​ប្រក្រតី ។"
+
+#: ../panels/user-accounts/um-user-panel.c:453
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "តើ​អ្នក​ចង់​រក្សាទុក​ឯកសារ​របស់ %s ដែរ​ឬ​ទេ ?"
+
+#: ../panels/user-accounts/um-user-panel.c:457
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"វា​ពិបាក​ក្នុង​ការ​រក្សាទុក​ថត​ផ្ទះ ស្ពូល​អ៊ីមែល និង​ឯកសារ​បណ្ដោះអាសន្ន​ណាស់ នៅ​ពេល​ដែល​លុប​គណនី​អ្នកប្រើ ។"
+
+#: ../panels/user-accounts/um-user-panel.c:460
+msgid "_Delete Files"
+msgstr "លុប​ឯកសារ"
+
+#: ../panels/user-accounts/um-user-panel.c:461
+msgid "_Keep Files"
+msgstr "រក្សាទុក​ឯកសារ"
+
+#: ../panels/user-accounts/um-user-panel.c:513
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "គណនី​​ត្រូវ​បាន​បិទ"
+
+#: ../panels/user-accounts/um-user-panel.c:521
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "ត្រូវ​កំណត់ នៅ​ពេល​ចូល​លើកក្រោយ"
+
+#: ../panels/user-accounts/um-user-panel.c:524
+msgctxt "Password mode"
+msgid "None"
+msgstr "គ្មាន"
+
+#: ../panels/user-accounts/um-user-panel.c:869
+msgid "Failed to contact the accounts service"
+msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ទាក់ទង​សេវា​គណនី"
+
+#: ../panels/user-accounts/um-user-panel.c:871
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "សូម​ប្រាកដ​ថា AccountService ត្រូវ​បាន​ដំឡើង និង​បើក ។"
+
+#: ../panels/user-accounts/um-user-panel.c:911
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"ដើម្បី​ធ្វើការ​ផ្លាស់ប្ដូរ\n"
+"ចុចរូប​តំណាង * ជាមុន​សិន"
+
+#: ../panels/user-accounts/um-user-panel.c:949
+msgid "Create a user account"
+msgstr "បង្កើត​គណនី​អ្នកប្រើ"
+
+#: ../panels/user-accounts/um-user-panel.c:960
+#: ../panels/user-accounts/um-user-panel.c:1271
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"ដើម្បី​បង្កើត​គណនី​អ្នកប្រើ\n"
+"ចុច​រូប​តំណាង * ជាមុន"
+
+#: ../panels/user-accounts/um-user-panel.c:969
+msgid "Delete the selected user account"
+msgstr "លុប​គណនី​អ្នកប្រើ​ដែល​បាន​ជ្រើស"
+
+#: ../panels/user-accounts/um-user-panel.c:981
+#: ../panels/user-accounts/um-user-panel.c:1276
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"ដើម្បី​លុប​គណនី​អ្នកប្រើ​ដែល​បាន​ជ្រើស\n"
+"ចុច​រូប​តំណាង * ជាមុន"
+
+#: ../panels/user-accounts/um-user-panel.c:1174
+msgid "My Account"
+msgstr "គណនី​របស់​ខ្ញុំ"
+
+#: ../panels/user-accounts/um-user-panel.c:1184
+msgid "Other Accounts"
+msgstr "គណនី​ផ្សេងទៀត"
+
+#: ../panels/user-accounts/um-utils.c:512
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr "មាន​អ្នកប្រើ​ដែល​មាន​ឈ្មោះ '%s' នោះ​រួច​ហើយ"
+
+#: ../panels/user-accounts/um-utils.c:516
+#, c-format
+msgid "The username is too long"
+msgstr "ឈ្មោះ​អ្នកប្រើ​វែង​ពេក"
+
+#: ../panels/user-accounts/um-utils.c:519
+msgid "The username cannot start with a '-'"
+msgstr "ឈ្មោះ​អ្នកប្រើ​មិន​អាច​ចាប់ផ្ដើម​ដោយ '-' បាន​ឡើយ"
+
+#: ../panels/user-accounts/um-utils.c:522
+msgid ""
+"The username must only consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr ""
+"ឈ្មោះ​អ្នកប្រើ​អាច​មាន​តែ ៖\n"
+" ➣ តួអក្សរ​មក​ពី​អក្ខរក្រម​អង់គ្លេស\n"
+" ➣ តួ​លេខ\n"
+" ➣ តួអក្សរ​ណាមួយ '.', '-' និង '_'"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "ប៊ូតុង​ផែនទី"
+
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr "ប៊ូតុង​ផែនទី​ត្រូវ​ដំណើរការ"
+
+#. Text printed on screen
+#: ../panels/wacom/calibrator/gui_gtk.c:78
+msgid "Screen Calibration"
+msgstr "ការ​ក្រិត​ខ្នាត​អេក្រង់"
+
+#: ../panels/wacom/calibrator/gui_gtk.c:79
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "សូម​ប្រើ​សញ្ញា​សម្គាល់​គោលដៅ នៅ​ពេល​ដែល​ពួកវា​បង្ហាញ​នៅ​លើ​អេក្រង់ ដើម្បី​ក្រិត​ខ្នាត tablet ។"
+
+#: ../panels/wacom/calibrator/gui_gtk.c:368
+msgid "Mis-click detected, restarting..."
+msgstr "បាន​រក​ឃើញ​ការ​ចុច​មិន​ត្រឹមត្រូវ កំពុង​ចាប់ផ្ដើម​ឡើងវិញ..."
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Output:"
+msgstr "លទ្ធផល​ ៖"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:287
+msgid "Keep aspect ratio (letterbox):"
+msgstr "រក្សា​សមាមាត្រ (ប្រអប់​អក្សរ) ៖"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:298
+msgid "Map to single monitor"
+msgstr "ផ្គូផ្គង​ទៅ​ម៉ូនីទ័រ​មួយ"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:89
+#, c-format
+msgid "%d of %d"
+msgstr "%d នៃ %d"
+
+#: ../panels/wacom/cc-wacom-page.c:118 ../panels/wacom/cc-wacom-page.c:371
+#| msgid "None"
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "គ្មាន"
+
+#: ../panels/wacom/cc-wacom-page.c:119
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "ផ្ញើ​ការ​ចុច​គ្រាប់ចុច"
+
+#: ../panels/wacom/cc-wacom-page.c:120
+#| msgid "Switch Modes"
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "ប្ដូរ​ម៉ូនីទ័រ"
+
+#: ../panels/wacom/cc-wacom-page.c:601
+msgid "Up"
+msgstr "ឡើងលើ"
+
+#: ../panels/wacom/cc-wacom-page.c:601
+msgid "Down"
+msgstr "ចុះ​ក្រោម"
+
+#: ../panels/wacom/cc-wacom-page.c:638
+msgid "Switch Modes"
+msgstr "របៀប​ប្ដូរ"
+
+#: ../panels/wacom/cc-wacom-page.c:724
+#: ../panels/wacom/cc-wacom-stylus-page.c:376
+msgid "Button"
+msgstr "ប៊ូតុង"
+
+#: ../panels/wacom/cc-wacom-page.c:777
+msgid "Action"
+msgstr "សកម្មភាព"
+
+#: ../panels/wacom/cc-wacom-page.c:886
+msgid "Display Mapping"
+msgstr "ការ​ផ្គូផ្គង​ទិដ្ឋភាព"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set your Wacom tablet preferences"
+msgstr "កំណត់​ចំណូលចិត្ត Wacom tablet របស់​អ្នក"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "Tablet (ដាច់ខាត)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "បន្ទះ​ប៉ះ (ធៀប)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "ចំណូលចិត្ត Tablet"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr "រក​មិន​ឃើញ tablet ទេ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "សូម​ដោត ឬ​បើក Wacom tablet របស់​អ្នក"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr "ការ​កំណត់​ប៊្លូធូស"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Map to Monitor..."
+msgstr "ផែនទី​ត្រូវ​គ្រប់គ្រង..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map Buttons..."
+msgstr "ប៊ូតុង​ផែនទី..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate..."
+msgstr "ក្រិត​ខ្នាត..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr "លៃ​តម្រូវ​គុណភាព​បង្ហាញ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Tracking Mode"
+msgstr "របៀប​តាមដាន"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Left-Handed Orientation"
+msgstr "ទិស​ខាង​ឆ្វេង"
+
+#: ../panels/wacom/gsd-wacom-device.c:1010
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "របៀប​រង្វង់​ខាងឆ្វេង #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1019
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "របៀប​រង្វង់​ខាង​ស្ដាំ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1049
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "របៀប Touchstrip ខាង​ឆ្វេង #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1058
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "របៀប Touchstrip ខាង​ស្ដាំ#%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1075
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "ប្ដូរ​​របៀប Touchring ខាង​ឆ្វេង"
+
+#: ../panels/wacom/gsd-wacom-device.c:1077
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "ប្ដូរ​របៀប Touchring ខាង​ស្ដាំ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1080
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "ប្ដូរ​របៀប Touchstrip ខាង​ឆ្វេង"
+
+#: ../panels/wacom/gsd-wacom-device.c:1082
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "ប្ដូរ​របៀប Touchstrip ខាង​ស្ដាំ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1087
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "ប្ដូរ​របៀប #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1159
+#, c-format
+msgid "Left Button #%d"
+msgstr "ប៊ូតុង​ឆ្វេង #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1162
+#, c-format
+msgid "Right Button #%d"
+msgstr "ប៊ូតុង​ស្ដាំ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1165
+#, c-format
+msgid "Top Button #%d"
+msgstr "ប៊ូតុង​ខាង​លើ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1168
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "ប៊ូតុង​ខាងក្រោម #%d"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "គ្មាន​សកម្មភាព"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "ចុច​ប៊ូតុង​កណ្ដុរ​ឆ្វេង"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "ចុច​ប៊ូតុង​កណ្ដុរ​ស្ដាំ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "ចុច​ប៊ូតុង​កណ្ដុរ​ស្ដាំ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "រមូរ​ឡើងលើ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "រមូរ​ចុះក្រោម"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "រមូរ​ទៅ​ឆ្វេង"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "រមូរ​ទៅ​ស្ដាំ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "ថយក្រោយ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "ទៅមុខ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "ដែកចារ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "រូបរាង​របស់​ជ័រលុប"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "ទន់"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "រឹង"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "ប៊ូតុង​ខាងលើ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "ប៊ូតុង​ខាងក្រោម"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "រូបរាង​ចុង​ប៊ិក"
+
+#: ../shell/control-center.c:58
+msgid "Enable verbose mode"
+msgstr "បើក​របៀប​បរិយាយ"
+
+#: ../shell/control-center.c:59
+msgid "Show the overview"
+msgstr "បង្ហាញ​ទិដ្ឋភាព​ទូទៅ"
+
+#: ../shell/control-center.c:60 ../shell/control-center.c:61
+#: ../shell/control-center.c:62
+msgid "Show help options"
+msgstr "បង្ហាញ​ជម្រើស​ជំនួយ"
+
+#: ../shell/control-center.c:63
+msgid "Panel to display"
+msgstr "បន្ទះ​ត្រូវ​បង្ហាញ"
+
+#: ../shell/control-center.c:85
+msgid "- System Settings"
+msgstr "ការ​កំណត់​ប្រព័ន្ធ"
+
+#: ../shell/control-center.c:93
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"ដំណើរការ '%s --help' ដើម្បី​មើល​បញ្ជី​ទាំងមូល​នៃ​ជម្រើស​បន្ទាត់​ពាក្យ​បញ្ជា​ដែល​មាន ។\n"
+
+#: ../shell/control-center.c:211
+msgid "Help"
+msgstr "ជំនួយ"
+
+#: ../shell/control-center.c:212
+msgid "Quit"
+msgstr "ចេញ"
+
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "មជ្ឈមណ្ឌល​បញ្ជា"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
+msgid "System Settings"
+msgstr "ការ​កំណត់​ប្រព័ន្ធ"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "ចំណូលចិត្ត;ការ​កំណត់;"
+
+#: ../shell/shell.ui.h:2
+#| msgid "_All Settings"
+msgid "All Settings"
+msgstr "ការ​កំណត់​ទាំងអស់"
+
+#~ msgid "Swap colors"
+#~ msgstr "ដូរ​ពណ៌"
+
+#~ msgid "Secondary color"
+#~ msgstr "ពណ៌​បន្ទាប់បន្សំ"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "បន្ថែម​ផ្ទាំង​រូបភាព"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "យក​ផ្ទាំង​រូបភាព​ចេញ"
+
+#~ msgid "Add dots"
+#~ msgstr "បន្ថែម​ចំណុច"
+
+#~ msgid "<b>Theme</b>"
+#~ msgstr "<b>ស្បែក</b>"
+
+#~ msgid "<b>Launcher icon size</b>"
+#~ msgstr "<b>ទំហំ​រូបតំណាង​កម្មវិធី​បើក​ដំណើរការ</b>"
+
+#~ msgid "Look"
+#~ msgstr "មើល"
+
+#~ msgid "<b>Auto-hide the Launcher</b>"
+#~ msgstr "<b>លាក់​កម្មវិធី​បើក​ដំណើរការ​ស្វ័យប្រវត្តិ</b>"
+
+#~ msgid ""
+#~ "<span size=\"small\">The launcher will reveal when moving the pointer to "
+#~ "the defined hot spot.</span>"
+#~ msgstr ""
+#~ "<span size=\"small\">កម្មវិធី​បើក​ដំណើរការ​នឹង​បង្ហាញ នៅ​ពេល​ផ្លាស់ទី​ព្រួញ​កណ្ដុរ​ទៅកាន់ hot "
+#~ "spot ដែល​បាន​កំណត់ ។</span>"
+
+#~ msgid "Reveal location:"
+#~ msgstr "បង្ហាញ​ទីតាំង ៖"
+
+#~ msgid "Left side"
+#~ msgstr "ផ្នែក​ខាងឆ្វេង"
+
+#~ msgid "Top left corner"
+#~ msgstr "ជ្រុង​ខាងលើ​ផ្នែក​ខាងឆ្វេង"
+
+#~ msgid "Other reveal option"
+#~ msgstr "ជម្រើស​បង្ហាញ​ផ្សេងទៀត"
+
+#~ msgid "Reveal sensitivity"
+#~ msgstr "កម្រិត​បង្ហាញ"
+
+#~ msgid "<small>Low</small>"
+#~ msgstr "<small>ទាប</small>"
+
+#~ msgid "<small>High</small>"
+#~ msgstr "<small>ខ្ពស់</small>"
+
+#~ msgid ""
+#~ "Some settings have been overriden by an external program, press \"Restore "
+#~ "Default Behaviors\"  to reset the behavior and return control to this "
+#~ "panel."
+#~ msgstr ""
+#~ "ការ​កំណត់​មួយ​ចំនួន​ត្រូវ​បាន​បដិសេធ​ដោយ​កម្មវិធី​ខាង​ក្រៅ ចុច \"ស្ដារ​ឥរិយាបថ​លំនាំដើម\"  ដើម្បី​កំណត់​"
+#~ "ឥរិយាបថ​ឡើងវិញ និង​ត្រឡប់​វត្ថុ​បញ្ជា​ទៅកាន់​បន្ទះ​នេះ ។"
+
+#~ msgid "Restore Default Behaviours"
+#~ msgstr "ស្ដារ​ឥរិយាបថ​លំនាំដើម"
+
+#~ msgid "Behavior"
+#~ msgstr "ឥរិយាបថ"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "ជម្រាល​ផ្ដេក"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "ជម្រាល​បញ្ឈរ"
+
+#~ msgid "Solid Color"
+#~ msgstr "ពណ៌​តាន់"
+
+#~ msgid "default"
+#~ msgstr "លំនាំដើម"
+
+#~ msgid "Pictures Folder"
+#~ msgstr "ថត​រូបភាព"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "ពណ៌ ​និង​ជម្រាល"
+
+#~ msgid "Appearance"
+#~ msgstr "រូបរាង"
+
+#~ msgid "Wallpaper;Screen;Desktop;Theme;Appearance;Launcher;Unity;Menus;"
+#~ msgstr "Wallpaper;Screen;Desktop;Theme;Appearance;Launcher;Unity;Menus;"
+
+#~ msgid "All displays"
+#~ msgstr "ទិដ្ឋភាព​ទាំងអស់"
+
+#~ msgid "L_auncher placement"
+#~ msgstr "កន្លែង​របស់​កម្មវិធី​បើក​ដំណើកការ"
+
+#~ msgid "S_ticky edges"
+#~ msgstr "គែម​ស្អិត"
+
+#~ msgid "Acti_on:"
+#~ msgstr "សកម្មភាព ៖"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "ថត​រូប​អេក្រង់"
+
+#~ msgid "Shortcut"
+#~ msgstr "ផ្លូវកាត់"
+
+#~ msgid "_Right-handed"
+#~ msgstr "ខាង​ស្ដាំ"
+
+#~ msgid "_Left-handed"
+#~ msgstr "ខាង​ឆ្វេង"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "បង្ហាញ​ទីតាំង​ព្រួញកណ្ដុរ នៅ​ពេល​ចុច​គ្រាប់ចុច​បញ្ជា (Control)"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "ការ​បង្កើន​ល្បឿន ៖"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "កម្រិត​ប្រែប្រួល ៖"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "អូស ហើយ​ទម្លាក់"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "កម្រិត​ពន្លឺ ៖"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "អូស​កម្រិត​ពន្លឺ"
+
+#~ msgid "Double-Click Timeout"
+#~ msgstr "អស់​ពេល​ចុច​ទ្វេដង"
+
+#~ msgid "_Timeout:"
+#~ msgstr "អស់ពេល ៖"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "ដើម្បី​សាកល្បង​ការ​កំណត់​របស់​អ្នក សូម​ព្យាយាម​ចុច​ទ្វេដង​លើ​ផ្ទៃ​មុខ ។"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "បើក​ការ​ចុច​កណ្ដុរ​ដោយ​ប្រើ​បន្ទះ​ប៉ះ"
+
+#~ msgid "Scrolling"
+#~ msgstr "រមូរ"
+
+#~ msgid "_Disabled"
+#~ msgstr "បាន​បិទ"
+
+#~ msgid "_Edge scrolling"
+#~ msgstr "រមូរ​គែម"
+
+#~ msgid "Enable h_orizontal scrolling"
+#~ msgstr "បើក​ការ​រមូរ​ផ្ដេក"
+
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "Not connected to the internet."
+#~ msgstr "មិន​ត្រូវ​បាន​តភ្ជាប់​ទៅ​អ៊ីនធឺណិត ។"
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "យ៉ាងណា បង្កើត hotspot ឬ ?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "ផ្ដាច់​ពី %s ហើយ​បង្កើត hotspot ថ្មី​ឬ ?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "នេះ​គឺជា​ការ​តភ្ជាប់​ទៅកាន់​អ៊ីនធឺណិត​តែមួយ​គត់​របស់​អ្នក ។"
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "បង្កើត Hotspot"
+
+#~ msgid "Device Off"
+#~ msgstr "បិទ​ឧបករណ៍"
+
+#~ msgid "_Network Name"
+#~ msgstr "ឈ្មោះ​បណ្ដាញ"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "បញ្ឈប់ Hotspot..."
+
+#~ msgid "Disable VPN"
+#~ msgstr "បិទ VPN"
+
+#~ msgid "HTTP Port"
+#~ msgstr "ច្រក HTTP"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "ច្រក HTTPS"
+
+#~ msgid "FTP Port"
+#~ msgstr "ច្រក FTP"
+
+#~ msgid "Socks Port"
+#~ msgstr "ច្រក​រន្ធ"
+
+#~ msgid "Apply system wide"
+#~ msgstr "អនុវត្ត​ទូទាំង​ប្រព័ន្ធ"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "ដើម្បី​បន្ថែម​គណនី​ថ្មី សូម​ជ្រើស​ប្រភេទ​គណនី​ជាមុន​សិន"
+
+#~ msgid "_Add..."
+#~ msgstr "បន្ថែម..."
+
+#~ msgid "Tip:"
+#~ msgstr "ព័ត៌មានជំនួយ ៖"
+
+#~ msgid "Brightness Settings"
+#~ msgstr "ការ​កំណត់​ពន្លឺ"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "ប៉ះពាល់​ដល់​កម្រិត​ថាមពល​ដែលត្រូវប្រើ"
+
+#~ msgid "Suspend"
+#~ msgstr "ផ្អាក"
+
+#~ msgid "When battery is present"
+#~ msgstr "ពេល​នៅ​មាន​ថ្ម"
+
+#~ msgid "When battery is charging/in use"
+#~ msgstr "ពេល​ថ្ម​កំពុង​បញ្ចូល/ប្រើ"
+
+#~ msgid "Never"
+#~ msgstr "មិន​កំណត់"
+
+#~ msgid "When the lid is closed"
+#~ msgstr "នៅ​ពេល​គម្រប​ត្រូវ​បាន​បិទ"
+
+#~ msgid "Show battery status in the _menu bar"
+#~ msgstr "បង្ហាញ​ស្ថានភាព​ថ្ម​នៅ​ក្នុង​របារ​ម៉ឺនុយ"
+
+#~ msgid "A_ddress:"
+#~ msgstr "អាសយដ្ឋាន ៖"
+
+#~ msgid "_Search by Address"
+#~ msgstr "ស្វែងរក​តាម​អាសយដ្ឋាន"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD មិន​កំពុង​ដំណើរការ ។ការ​ស្វែងរក​ម៉ាស៊ីន​បោះពុម្ព​តាម​បណ្ដាញ​ត្រូវការ​​សេវា mdns, ipp "
+#~ "កម្មវិធី ipp និង​កម្មវិធី samba ដែល​បើក​នៅ​លើ​ជញ្ជាំង​ភ្លើង ។"
+
+#~ msgid "Devices"
+#~ msgstr "ឧបករណ៍"
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "មូលដ្ឋាន"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "បណ្ដាញ"
+
+#~ msgid "Device types"
+#~ msgstr "ប្រភេទ​ឧបករណ៍"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "ការ​កំណត់​រចនាសម្ព័ន្ធ​ស្វ័យប្រវត្តិ"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "បើក​ជញ្ជាំង​ភ្លើង​សម្រាប់​ការ​តភ្ជាប់ mDNS"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "បើក​ជញ្ជាំង​ភ្លើង​សម្រាប់​ការ​តភ្ជាប់ Samba"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "បើក​ជញ្ជាំង​ភ្លើង​សម្រាប់​ការ​តភ្ជាប់ IPP"
+
+#~ msgid "_Back"
+#~ msgstr "ត្រឡប់"
+
+#~ msgid "Add User"
+#~ msgstr "បន្ថែម​អ្នកប្រើ"
+
+#~ msgid "Remove User"
+#~ msgstr "យក​អ្នកប្រើ​ចេញ"
+
+#~ msgid "Allowed users"
+#~ msgstr "អ្នក​ប្រើ​ដែល​​អនុញ្ញាត"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "ជ្រើស​ប្លង់"
+
+#~ msgid "Preview"
+#~ msgstr "មើល​ជាមុន"
+
+#~ msgid "Keyboard Layout Options"
+#~ msgstr "ជម្រើស​ប្លង់​ក្ដារចុច"
+
+#~ msgid "Add Layout"
+#~ msgstr "បន្ថែម​ប្លង់"
+
+#~ msgid "Remove Layout"
+#~ msgstr "យក​ប្លង់​ចេញ"
+
+#~ msgid "Move Up"
+#~ msgstr "ផ្លាស់ទី​ឡើងលើ"
+
+#~ msgid "Move Down"
+#~ msgstr "ផ្លាស់ទី​ចុះក្រោម"
+
+#~ msgid "Preview Layout"
+#~ msgstr "មើល​ប្លង់​ជាមុន"
+
+#~ msgid "Use the same layout for all windows"
+#~ msgstr "ប្រើ​ប្លង់​តែមួយ​សម្រាប់​បង្អួច​ទាំងអស់"
+
+#~ msgid "Allow different layouts for individual windows"
+#~ msgstr "អនុញ្ញាត​ប្លង់​ផ្សេងៗ​សម្រាប់​បង្អួច​នីមួយ​ៗ"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "បង្អួច​ថ្មី​ប្រើ​ប្លង់​លំនាំដើម"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "បង្អួច​ថ្មី​ប្រើ​ប្លង់​របស់​បង្អួច​មុន"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "មើល ហើយ​កែសម្រួល​ជម្រើស​ប្លង់​ក្ដារចុច"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "កំណត់​ឡើង​វិញ​ទៅ​ជា​លំនាំដើម"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "ជំនួស​ការ​កំណត់​ប្លង់​ក្ដារចុច​បច្ចុប្បន្ន​ដោយ​\n"
+#~ "ការ​កំណត់​លំនាំដើម"
+
+#~ msgid "Layouts"
+#~ msgstr "ប្លង់ ៖"
+
+#~ msgid "Layout"
+#~ msgstr "ប្លង់"
+
+#~ msgid "Require my password when waking from suspend"
+#~ msgstr "ទាមទារ​ពាក្យសម្ងាត់ នៅ​ពេល​ដាស់​ពី​ការផ្អាក"
+
+#~ msgid "Co_nnector:"
+#~ msgstr "បន្ទាត់​តភ្ជាប់ ៖"
+
+#~ msgid "Hardware"
+#~ msgstr "ផ្នែករឹង"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "ជ្រើស​ឧបករណ៍ ដើម្បី​កំណត់​រចនាសម្ព័ន្ធ ៖"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~ msgid "Change contrast:"
+#~ msgstr "ផ្លាស់ប្ដូរ​កម្រិត​ពណ៌ ៖"
+
+#~ msgid "_Text size:"
+#~ msgstr "ទំហំ​អត្ថបទ ៖"
+
+#~ msgid "Increase size:"
+#~ msgstr "បង្កើន​ទំហំ ៖"
+
+#~ msgid "Decrease size:"
+#~ msgstr "បន្ថយ​ទំហំ ៖"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "ការ​បង្ហាញ"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "ពង្រីក"
+
+#~ msgid "Screen keyboard"
+#~ msgstr "ក្ដារចុច​លើ​អេក្រង់"
+
+#~ msgid "Typing Assistant"
+#~ msgstr "អ្នក​ជំនួយការ​ក្នុង​ការ​វាយ"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "វាយ​ទីនេះ ដើម្បី​សាកល្បង​ការ​កំណត់"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "អេក្រង់ ១/២"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "អេក្រង់ ៣/៤"
+
+#~ msgid "Create new account"
+#~ msgstr "បង្កើត​គណនី​ថ្មី"
+
+#~ msgid "_Account Type"
+#~ msgstr "ប្រភេទ​គណនី"
+
+#~ msgid "Cr_eate"
+#~ msgstr "បង្កើត"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "ជ្រើស​ពាក្យសម្ងាត់​ដែល​បាន​បង្កើត"
+
+#~ msgid "Account _type"
+#~ msgstr "ប្រភេទ​គណនី"
+
+#~ msgid "More choices..."
+#~ msgstr "ជម្រើស​ជាច្រើន​ទៀត..."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Wacom Graphics Tablet"
+
+#~ msgid "Mute"
+#~ msgstr "ស្ងាត់"
+
+#~ msgid "Settings for %s"
+#~ msgstr "ការ​កំណត់ %s"
+
+#~ msgid "Mode:"
+#~ msgstr "របៀប ៖"
+
+#~ msgid "Play sound through"
+#~ msgstr "ចាក់​សំឡេង​តាម​រយៈ"
+
+#~ msgid "Settings for the selected device"
+#~ msgstr "ការ​កំណត់​សម្រាប់​ឧបករណ៍​ដែល​បាន​ជ្រើស"
+
+#~ msgid "Test:"
+#~ msgstr "សាកល្បង ៖"
+
+#~ msgid "Test Sound"
+#~ msgstr "សាកល្បង​សំឡេង"
+
+#~ msgid "Record sound from"
+#~ msgstr "ថតចម្លង​សំឡេង​ពី"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "កំហុស​ក្នុង​ការ​រក្សាទុក​ផ្លូវកាត់​ថ្មី"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "មាន​ផ្លូវកាត់​ផ្ទាល់ខ្លួនច្រើនពេក"
+
+#~ msgid "Key"
+#~ msgstr "គ្រាប់ចុច"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "គ្រាប់ចុច GConf ដែល​ត្រូវ​ភ្ជាប់​ជាមួយ​កម្មវិធី​កែសម្រួល​លក្ខណសម្បត្តិ​នេះ"
+
+#~ msgid "Callback"
+#~ msgstr "ហៅ​ត្រឡប់វិញ"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "ចេញ​ផ្សាយ​ការ​ហៅ​ត្រឡប់​វិញ នៅ​ពេល​តម្លៃ​ដែល​ទាក់ទង​ជាមួយ​គ្រាប់ចុច​ផ្លាស់ប្ដូរ"
+
+#~ msgid "Change set"
+#~ msgstr "ការ​កំណត់​ការ​ផ្លាស់ប្ដូរ"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "ការ​កំណត់​ការ​ផ្លាស់ប្ដូរ GConf ដែល​មាន​ទិន្នន័យ​ត្រូវ​បញ្ជូន​បន្ត​ទៅកាន់​កម្មវិធី gconf នៅ​ពេល​អនុវត្ត"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "ការ​បម្លែង​ទៅជា​ការ​ហៅ​ធាតុ​ក្រាហ្វិក​ត្រឡប់​វិញ"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "ការ​ហៅ​ត្រឡប់​វិញ​ត្រូវ​បាន​ចេញផ្សាយ នៅ​ពេល​ដែល​ទិន្នន័យ​ត្រូវ​បាន​បម្លែង​ពី GConf ទៅជា​ធាតុ​ក្រាហ្វិក"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "ការ​បម្លែង​ពី​ការ​ហៅ​ធាតុ​ក្រាហ្វិក​ត្រឡប់វិញ"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "ការ​ហៅ​ត្រឡប់​វិញ​ត្រូវ​បាន​ចេញផ្សាយ នៅ​ពេល​ដែល​ទិន្នន័យ​ត្រូវ​បាន​បម្លែង​ទៅជា GConf ពី​ធាតុ​ក្រាហ្វិក"
+
+#~ msgid "UI Control"
+#~ msgstr "ការ​គ្រប់គ្រង​ចំណុច​ប្រទាក់​អ្នកប្រើ"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "វត្ថុ​ដែល​គ្រប់គ្រង​លក្ខណសម្បត្តិ (ជាទូទៅ គឺជា​ធាតុ​ក្រាហ្វិក)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "ទិន្នន័យ​វត្ថុ​របស់​កម្មវិធី​កែសម្រួល​លក្ខណសម្បត្តិ"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "ទិន្នន័យ​ផ្ទាល់ខ្លួន​ត្រូវ​បាន​ទាមទារ​ដោយ​កម្មវិធី​កែសម្រួល​លក្ខណសម្បត្តិ​ជាក់លាក់"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "ការ​ហៅ​ត្រឡប់​វិញ​ដោយ​គ្មាន​ទិន្នន័យ​កម្មវិធី​កែសម្រួល​លក្ខណសម្បត្តិ"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "ការ​ហៅ​ត្រឡប់​វិញ​ត្រូវ​បាន​ចេញផ្សាយ នៅ​ពេល​ទិន្នន័យ​វត្ថុ​របស់​កម្មវិធី​កែសម្រួល​លក្ខណសម្បត្តិ​ត្រូវ​បាន​ធ្វើឲ្យ​"
+#~ "ទំនេរ"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "រក​មិន​ឃើញ​ឯកសារ '%s' ។\n"
+#~ "\n"
+#~ "សូម​ប្រាកដ​ថា វា​មាន រួច​ព្យាយាម​ម្ដងទៀត ឬ​ជ្រើស​រូបភាព​ផ្ទៃខាងក្រោយ​ផ្សេងទៀត ។"
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "ខ្ញុំ​មិន​ដឹង​អំពី​របៀប​បើក​ឯកសារ '%s' ។\n"
+#~ "ប្រហែល​វា​គឺជា​ប្រភេទ​រូបភាព​ដែល​មិន​​​​ទាន់​បាន​ទទួល​ការ​គាំទ្រ ។\n"
+#~ "\n"
+#~ "សូម​ជ្រើស​រូបភាព​​ផ្សេងទៀត​ជំនួស​វិញ ។"
+
+#~ msgid "Please select an image."
+#~ msgstr "សូម​ជ្រើស​រូបភាព ។"
+
+#~ msgid "Application Menu"
+#~ msgstr "ម៉ឺនុយ​កម្មវិធី"
+
+#~ msgid "Integrated in menu bar and hidden"
+#~ msgstr "រួមបញ្ចូល​នៅ​ក្នុង​របារ​ម៉ឺនុយ និងលាក់"
+
+#~ msgid "Integrated in menu bar and visible"
+#~ msgstr "រួមបញ្ចូល​នៅ​ក្នុង​របារ​ម៉ឺនុយ និង​​មើល​ឃើញ"

--- a/po/kn.po
+++ b/po/kn.po
@@ -8,9 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-12-24 07:27+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-12-24 15:59+0530\n"
 "Last-Translator: Shankar Prasad <svenkate AT redhat Dot com>\n"
 "Language-Team: American English <kde-i18n-doc@kde.org>\n"
@@ -21,593 +20,487 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "ಅನ್ವಯಗಳು"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "ಯಾವುದೆ ಅನ್ವಯಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "ಅಪ್‌ಡೇಟ್‌ಗಳನ್ನು ಅನುಸ್ಥಾಪಿಸು"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "ತೆರೆ (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "ವಿವರಗಳನ್ನು ನೋಡು"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "ಹುಡುಕು"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "ಅಶಕ್ತಗೊಂಡ"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "ಸೂಚನೆಗಳು"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "ಸೂಚನೆಗಳನ್ನು ತೋರಿಸು (_ N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "ಹಿನ್ನಲೆ ಚಿತ್ರ"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "ತೆರೆಚಿತ್ರಗಳು"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "ವಾಲ್‌ಪೇಪರುಗಳು"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "ಧ್ವನಿ"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "ಶಾರ್ಟ್-ಕಟ್‌ಗಳು"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "ಕೀಲಿಮಣೆ-ಸುಲಭ ಆಯ್ಕೆಗಳು"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s ಕ್ಯಾಮೆರಾ"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "ಸ್ಥಳದ ಸೇವೆಗಳು (_L)"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "ಒಳನಿರ್ಮಿತ ವೆಬ್‌-ಕ್ಯಾಮ್"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "ಯಾವುದೆ ಜಾಗಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "ಪ್ರದರ್ಶಕದ ಬಗೆ"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "ಕೊಂಡಿಯ ವೇಗ"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "ಮರುಹೊಂದಿಸು"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "ಅನ್ವಯಗಳು"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "ಸ್ಟೈಲಸ್"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "ಹಿನ್ನಲೆ ಚಿತ್ರ"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "ದಿನಪೂರ್ತಿ ಬದಲಾಯಿಸುತ್ತದೆ"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "ಪ್ರೊಫೈಲನ್ನು ಸೇರಿಸು (_A)..."
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "Lock Screen"
-msgstr "ಲಾಕ್ ತೆರೆ"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "ಫ್ರಾನ್ಸ್‍"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "ಚೌಕ"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "ಗಾತ್ರಬದಲಿಸು"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "ಮಧ್ಯಕ್ಕೆ"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "ಗಾತ್ರ ಬದಲಾವಣೆ"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "ತುಂಬಿಸು"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "ಹರಡು"
-
-#: ../panels/background/cc-background-chooser-dialog.c:437
-msgid "Wallpapers"
-msgstr "ವಾಲ್‌ಪೇಪರುಗಳು"
-
-#: ../panels/background/cc-background-chooser-dialog.c:446
-msgid "Colors"
-msgstr "ಬಣ್ಣಗಳು"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:483
-msgid "Select Background"
-msgstr "ಹಿನ್ನಲೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡು"
-
-#: ../panels/background/cc-background-chooser-dialog.c:511
-msgid "Pictures"
-msgstr "ಚಿತ್ರಗಳು"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:543
-msgid "No Pictures Found"
-msgstr "ಯಾವುದೆ ಚಿತ್ರಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:561
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "ನೆಲೆ"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:573
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr ""
-"ನೀವು ಚಿತ್ರಗಳನ್ನು ನಿಮ್ಮ %s ಕಡತಕೋಶಕ್ಕೆ ಸೇರಿಸಬಹುದು ಮತ್ತು ಅವುಗಳು ಇಲ್ಲಿ ಕಾಣಿಸುತ್ತವೆ"
-
-#: ../panels/background/cc-background-chooser-dialog.c:580
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1514
-#: ../panels/display/cc-display-panel.c:1951
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1247
-#: ../panels/network/net-device-wifi.c:1440
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/cc-printers-panel.c:1945
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-#: ../panels/user-accounts/um-photo-dialog.c:94
-#: ../panels/user-accounts/um-photo-dialog.c:217
-#: ../panels/user-accounts/um-user-panel.c:708
-#: ../panels/user-accounts/um-user-panel.c:726
-msgid "_Cancel"
-msgstr "ರದ್ದು ಮಾಡು (_C)"
-
-#: ../panels/background/cc-background-chooser-dialog.c:581
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:96
-msgid "Select"
-msgstr "ಆರಿಸು"
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "ಅನೇಕ ಗಾತ್ರಗಳು"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "ಯಾವುದೆ ಗಣಕತೆರೆ ಹಿನ್ನಲೆ ಚಿತ್ರವಿಲ್ಲ"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "ಈಗಿನ ಹಿನ್ನಲೆ ಚಿತ್ರ"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "ನಿಮ್ಮ ಹಿನ್ನಲೆ ಚಿತ್ರವನ್ನು ಒಂದು ವಾಲ್‌ಪೇಪರ್ ಅಥವ ಫೋಟೊದಿಂದ ಬದಲಾಯಿಸಿ"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "ವಾಲ್‌ಪೇಪರ್;ತೆರೆ;ಗಣಕತೆರೆ;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "ಬ್ಲೂಟೂತ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "ಸಕ್ರಿಯ"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "ಯಾವುದೇ ಬ್ಲೂಟೂತ್ ಅಡಾಪ್ಟರುಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "ಬ್ಲೂಟೂತ್ ಹಂಚಿಕೆ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "ವಿಮಾನದ ಸ್ಥಿತಿ (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "ಯಂತ್ರಾಂಶ ಸ್ವಿಚ್‌ನಿಂದ ಬ್ಲೂಟೂತ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1637
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "ವಿಮಾನದ ಸ್ಥಿತಿ (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "ವಿಮಾನದ ಸ್ಥಿತಿ (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "ಬ್ಲೂಟೂತ್"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
-msgstr ""
-"ಬ್ಲೂಟೂತ್ ಅನ್ನು ಆನ್ ಮತ್ತು ಆಫ್ ಮಾಡಿ ಹಾಗೂ ನಿಮ್ಮ ಸಾಧನಗಳೊಂದಿಗೆ ಸಂಪರ್ಕ ಸಾಧಿಸಿ"
+msgstr "ಬ್ಲೂಟೂತ್ ಅನ್ನು ಆನ್ ಮತ್ತು ಆಫ್ ಮಾಡಿ ಹಾಗೂ ನಿಮ್ಮ ಸಾಧನಗಳೊಂದಿಗೆ ಸಂಪರ್ಕ ಸಾಧಿಸಿ"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
-"ನಿಮ್ಮ ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಸಾಧನವನ್ನು ಚೌಕದ ಮೇಲೆ ಇರಿಸಿ ಮತ್ತು 'ಪ್ರಾರಂಭಿಸು' ಅನ್ನು ಒತ್ತಿ"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "ಯಾವುದೆ ಅನ್ವಯವು ಪ್ರಸ್ತುತ ಧ್ವನಿಯನ್ನು ಚಲಾಯಿಸುತ್ತಿಲ್ಲ."
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"ಕ್ಯಾಲಿಬ್ರೇಟ್ ಸ್ಥಾನಕ್ಕೆ ನಿಮ್ಮ ಸಾಧನವನ್ನು ಜರುಗಿಸಿ ಮತ್ತು 'ಮುಂದುವರೆ' ಅನ್ನು ಒತ್ತಿ"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr "ಮೇಲ್ಮೈ ಸ್ಥಾನಕ್ಕೆ ನಿಮ್ಮ ಸಾಧನವನ್ನು ಜರುಗಿಸಿ ಮತ್ತು 'ಮುಂದುವರೆ' ಅನ್ನು ಒತ್ತಿ"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "ಲ್ಯಾಪ್‌ಟಾಪ್‌ನ ಮುಚ್ಚುಳವನ್ನು ಮುಚ್ಚು"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "ಚೇತರಿಸಕೊಳ್ಳಲಲು ಸಾಧ್ಯವಾಗದಂತಹ ಒಂದು ಆಂತರಿಕ ದೋಷ ಸಂಭವಿಸಿದೆ."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ಗಾಗಿ ಅಗತ್ಯವಿರುವ ತಂತ್ರಾಂಶವನ್ನು ಅನುಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಉತ್ಪಾದಿಸಲಾಗಿಲ್ಲ."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "ಗುರಿಯ ಶ್ವೇತಬಿಂದುವನ್ನು ಪಡೆಯಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "ಪೂರ್ಣಗೊಂಡಿದೆ!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ವಿಫಲಗೊಂಡಿದೆ!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "ನೀವು ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕಬಹುದು."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಪ್ರಗತಿಯಲ್ಲಿರುವಾಗ ಸಾಧನವನ್ನು ಸ್ಥಳಾಂತರಿಸಬೇಡಿ"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "ಲ್ಯಾಪ್‌ಟಾಪ್ ತೆರೆ"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "ಒಳನಿರ್ಮಿತ ವೆಬ್‌-ಕ್ಯಾಮ್"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s ಪರದೆ"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s ಸ್ಕ್ಯಾನರ್"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s ಕ್ಯಾಮೆರಾ"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s ಮುದ್ರಕ"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s ವೆಬ್‌ಕ್ಯಾಮ್"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s ಗಾಗಿ ಬಣ್ಣದ ನಿರ್ವಹಣೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸು"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s ಗಾಗಿ ಬಣ್ಣದ ಪ್ರೊಫೈಲ್ ಅನ್ನು ತೋರಿಸು"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:323
-msgid "Not calibrated"
-msgstr "ಕ್ಯಾಲಿಬ್ರೇಟ್ ಮಾಡದಿರುವ"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "ಪೂರ್ವನಿಯೋಜಿತ: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "ವರ್ಣಸ್ಥಳ: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "ಪ್ರಾಯೋಗಿಕ ಪ್ರೊಫೈಲ್: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "ICC ಪ್ರೊಫೈಲ್ ಕಡತವನ್ನು ಆರಿಸು"
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "ಆಮದು ಮಾಡು (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "ಬೆಂಬಲಿಸಲಾಗುವ ICC ಪ್ರೊಫೈಲುಗಳು"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "ಎಲ್ಲಾ ಕಡತಗಳು"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "ತೆರೆ"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "ಕಡತವನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡುವಲ್ಲಿ ವಿಫಲತೆ: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಇಲ್ಲಿಗೆ ಅಪ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ:"
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "ಈ URL ಅನ್ನು ಬರೆ."
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-"ಈ ಗಣಕವನ್ನು ಮರಳಿ ಆರಂಭಿಸು ಹಾಗು ನಿಮ್ಮ ಸಾಮಾನ್ಯ ಕಾರ್ಯಾಚರಣೆ ವ್ಯವಸ್ಥೆಯನ್ನು ಬೂಟ್ ಮಾಡಿ."
 
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "ಹೆಚ್ಚಿನ ಚಿತ್ರಗಳಿಗಾಗಿ ನೋಡು"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"ಪ್ರೊಫೈಲ್ ಅನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಮತ್ತು ಅನುಸ್ಥಾಪಿಸಲು ನಿಮ್ಮ ಜಾಲವೀಕ್ಷಕಕ್ಕೆ URL "
-"ಅನ್ನು ನಮೂದಿಸಿ."
 
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "ಪ್ರೊಫೈಲನ್ನು ಉಳಿಸು"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "ಉಳಿಸು (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "ಆಯ್ಕೆ ಮಾಡಿದ ಸಾಧನಕ್ಕಾಗಿ ಒಂದು ವರ್ಣ ಪ್ರೊಫೈಲನ್ನು ರಚಿಸು"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"ಅಳತೆ ಮಾಡುವ ಉಪಕರಣವನ್ನು ಪತ್ತೆ ಮಾಡಲಾಗಿಲ್ಲ. ದಯವಿಟ್ಟು ಅದನ್ನು ಆನ್ ಮಾಡಲಾಗಿದೆ ಮತ್ತು "
-"ಸರಿಯಾಗಿದೆಯೆ ಎಂದು ಪರೀಕ್ಷಿಸಿ."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "ಅಳೆಯುವ ಉಪಕರಣವು ಮುದ್ರಕ ಪ್ರೊಫೈಲ್ ಅನ್ನು ಬೆಂಬಲಿಸುವುದಿಲ್ಲ."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "ಸಾಧನದ ಬಗೆಗೆ ಪ್ರಸಕ್ತ ಬೆಂಬಲವಿಲ್ಲ."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "ಶಿಷ್ಟ ಅಂತರ"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "ಪ್ರಾಯೋಗಿಕ ಪ್ರೊಫೈಲ್"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "ಸ್ವಯಂಚಾಲಿತ"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "ಕಳಪೆ ಗುಣಮಟ್ಟ"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "ಮಧ್ಯಮ ಗುಣಮಟ್ಟ"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "ಉತ್ತಮ ಗುಣಮಟ್ಟ"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "ಪೂರ್ವನಿಯೋಜಿತ RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "ಪೂರ್ವನಿಯೋಜಿತ CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಬೂದು"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "ಮಾರಾಟಗಾರನು ಫ್ಯಾಕ್ಟರಿ ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಡೇಟಾವನ್ನು ಒದಗಿಸಿದ್ದಾರೆ"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "ಈ ಪ್ರೊಫೈಲಿನಿಂದ ಪೂರ್ಣ-ತೆರೆ ಪ್ರದರ್ಶಕ ಸರಿಪಡಿಕೆಯು ಸಾಧ್ಯವಿಲ್ಲ"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "ಈ ಪ್ರೊಫೈಲ್ ಇನ್ನು ಮುಂದೆ ನಿಖರವಾಗಿರುವುದಿಲ್ಲ"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಅನ್ನು ತೋರಿಸು"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr "ರದ್ದು ಮಾಡು"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "ರದ್ದು ಮಾಡು (_C)"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "ಆರಂಭ"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "ಮರಳಿ ಆರಂಭಿಸು"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "ಆಯಿತು"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "ಆಯಿತು (_D)"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "ತೆರೆಯ ಕ್ಯಾಲಿಬ್ರೇಶನ್"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಗುಣಮಟ್ಟ"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ನಿಂದಾಗಿ ನಿಮ್ಮ ತೆರೆಯ ಬಣ್ಣವನ್ನು ವ್ಯವಸ್ಥಾಪಿಸಲು ಅಗತ್ಯವಿರುವ ಪ್ರೊಫೈಲ್ "
-"ಒಂದು ನಿಮಗೆ "
-"ದೊರೆಯುತ್ತದೆ. ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ಗಾಗಿ ಹೆಚ್ಚು ಹೊತ್ತು ವ್ಯಯಿಸಿದಷ್ಟೂ ಬಣ್ಣದ ಪ್ರೊಫೈಲ್‌ನ "
-"ಗುಣಮಟ್ಟ "
+"ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ನಿಂದಾಗಿ ನಿಮ್ಮ ತೆರೆಯ ಬಣ್ಣವನ್ನು ವ್ಯವಸ್ಥಾಪಿಸಲು ಅಗತ್ಯವಿರುವ ಪ್ರೊಫೈಲ್ ಒಂದು ನಿಮಗೆ "
+"ದೊರೆಯುತ್ತದೆ. ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ಗಾಗಿ ಹೆಚ್ಚು ಹೊತ್ತು ವ್ಯಯಿಸಿದಷ್ಟೂ ಬಣ್ಣದ ಪ್ರೊಫೈಲ್‌ನ ಗುಣಮಟ್ಟ "
 "ಉತ್ತಮಗೊಳ್ಳುತ್ತದೆ."
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ ನಡೆಯುವಾಗ ನೀವು ನಿಮ್ಮ ಗಣಕವನ್ನು ಬಳಸಲು ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "ಗುಣಮಟ್ಟ"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "ಅಂದಾಜು ಸಮಯ"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಗುಣಮಟ್ಟ"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr ""
-"ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ಗಾಗಿ ನೀವು ಬಳಸಲು ಬಯಸುವ ಸಂವೇದಿ (ಸೆನ್ಸರ್) ಸಾಧನವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ."
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಸಾಧನ"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "ಸಂಪರ್ಕ ಜೋಡಿಸಲಾದ ಪ್ರದರ್ಶಕದ ಬಗೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿ."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ಗಾಗಿ ನೀವು ಬಳಸಲು ಬಯಸುವ ಸಂವೇದಿ (ಸೆನ್ಸರ್) ಸಾಧನವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ."
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "ಪ್ರದರ್ಶಕದ ಬಗೆ"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "ಸಂಪರ್ಕ ಜೋಡಿಸಲಾದ ಪ್ರದರ್ಶಕದ ಬಗೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿ."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "ಶ್ವೇತಬಿಂದು ಪ್ರೊಫೈಲ್"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
-"ಪ್ರದರ್ಶಕ ಗುರಿ ಶ್ವೇತ ಬಿಂದುವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ. ಹೆಚ್ಚಿನ ಪ್ರದರ್ಶಕಗಳನ್ನು ಒಂದು D65 "
-"ಪ್ರಕಾಶತೆಗೆ "
+"ಪ್ರದರ್ಶಕ ಗುರಿ ಶ್ವೇತ ಬಿಂದುವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ. ಹೆಚ್ಚಿನ ಪ್ರದರ್ಶಕಗಳನ್ನು ಒಂದು D65 ಪ್ರಕಾಶತೆಗೆ "
 "ಸರಿಹೊಂದಿಸಬೇಕಾಗಿರುತ್ತದೆ."
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "ಶ್ವೇತಬಿಂದು ಪ್ರೊಫೈಲ್"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "ಪ್ರದರ್ಶಕದ ಪ್ರಕಾಶತೆ"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"ಪ್ರದರ್ಶಕವನ್ನು ನಿಮಗೆ ಸಾಮಾನ್ಯವೆನಿಸುವ ಪ್ರಕಾಶತೆಗೆ ಹೊಂದಿಸಿ. ಈ ಪ್ರಕಾಶತೆಯ ಮಟ್ಟದಲ್ಲಿ "
-"ಬಣ್ಣ "
+"ಪ್ರದರ್ಶಕವನ್ನು ನಿಮಗೆ ಸಾಮಾನ್ಯವೆನಿಸುವ ಪ್ರಕಾಶತೆಗೆ ಹೊಂದಿಸಿ. ಈ ಪ್ರಕಾಶತೆಯ ಮಟ್ಟದಲ್ಲಿ ಬಣ್ಣ "
 "ವ್ಯವಸ್ಥಾಪನೆಯು ಅತ್ಯಂತ ನಿಖರವಾಗಿರುತ್ತದೆ."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -615,3087 +508,2338 @@ msgstr ""
 "ಪರ್ಯಾಯವಾಗಿ, ಈ ಸಾಧನಕ್ಕಾಗಿ ಬೇರೆ ಪ್ರೊಫೈಲ್‌ಗಳಲ್ಲಿ ಬಳಸಲಾದ ಪ್ರಕಾಶತೆಯ ಮಟ್ಟವನ್ನು ನೀವು "
 "ಬಳಸಬಹುದು."
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "ಪ್ರದರ್ಶಕದ ಪ್ರಕಾಶತೆ"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "ಪ್ರೊಫೈಲ್ ಹೆಸರು"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
-"ನೀವು ಬಣ್ಣದ ಪ್ರೊಫೈಲ್ ಅನ್ನು ಬೇರೊಂದು ಗಣಕದಲ್ಲಿ, ಅಥವ ವಿವಿಧ ಬೆಳಕಿನ ಸ್ಥಿತಿಗಳಿಗಾಗಿನ "
-"ಪ್ರೊಫೈಲ್ "
+"ನೀವು ಬಣ್ಣದ ಪ್ರೊಫೈಲ್ ಅನ್ನು ಬೇರೊಂದು ಗಣಕದಲ್ಲಿ, ಅಥವ ವಿವಿಧ ಬೆಳಕಿನ ಸ್ಥಿತಿಗಳಿಗಾಗಿನ ಪ್ರೊಫೈಲ್ "
 "ಅನ್ನು ರಚಿಸಲು ಬಳಸಬಹುದು."
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "ಪ್ರೊಫೈಲ್ ಹೆಸರು:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "ಪ್ರೊಫೈಲ್ ಹೆಸರು"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಯಶಸ್ವಿಯಾಗಿ ರಚಿಸಲಾಗಿದೆ!"
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "ಪ್ರೊಫೈಲನ್ನು ಪ್ರತಿ ಮಾಡು"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "ಬರೆಯಬಹುದಾದ ಮಾಧ್ಯಮದ ಅಗತ್ಯವಿದೆ"
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "ಪ್ರೊಫೈಲನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡು"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "ಅಂತರಜಾಲ ಸಂಪರ್ಕದ ಅಗತ್ಯವಿದೆ"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href="
-"\"windows\">Microsoft Windows</a> ವ್ಯವಸ್ಥೆಗಳಲ್ಲಿ ಪ್ರೊಫೈಲ್ ಅನ್ನು ಹೇಗೆ ಬಳಸುವುದು "
-"ಎಂದು "
-"ತಿಳಿಯಲು ಈ ವಿವರಗಳು ಉಪಯುಕ್ತವೆನಿಸುತ್ತದೆ."
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:732
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "ಸಾರಾಂಶ"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "ಕಡತವನ್ನು ಆಮದು ಮಾಡಿಕೊಳ್ಳಿ…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಯಶಸ್ವಿಯಾಗಿ ರಚಿಸಲಾಗಿದೆ!"
 
-#: ../panels/color/color.ui.h:30
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
-msgstr "ಸೇರಿಸು (_A)"
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "ಪ್ರೊಫೈಲನ್ನು ಪ್ರತಿ ಮಾಡು"
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "ಬರೆಯಬಹುದಾದ ಮಾಧ್ಯಮದ ಅಗತ್ಯವಿದೆ"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> ವ್ಯವಸ್ಥೆಗಳಲ್ಲಿ ಪ್ರೊಫೈಲ್ ಅನ್ನು ಹೇಗೆ ಬಳಸುವುದು "
+"ಎಂದು ತಿಳಿಯಲು ಈ ವಿವರಗಳು ಉಪಯುಕ್ತವೆನಿಸುತ್ತದೆ."
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "ಪ್ರೊಫೈಲನ್ನು ಸೇರಿಸು"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"ತೊಂದರೆಯು ಕಂಡುಬಂದಿದೆ. ಪ್ರೊಫೈಲ್ ಸರಿಯಾಗಿ ಕೆಲಸ ಮಾಡುವುದಿಲ್ಲ. <a href=\"\">"
-"ವಿವರಗಳನ್ನು "
+"ತೊಂದರೆಯು ಕಂಡುಬಂದಿದೆ. ಪ್ರೊಫೈಲ್ ಸರಿಯಾಗಿ ಕೆಲಸ ಮಾಡುವುದಿಲ್ಲ. <a href=\"\">ವಿವರಗಳನ್ನು "
 "ತೋರಿಸು.</a>"
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "ಕಡತವನ್ನು ಆಮದು ಮಾಡಿಕೊಳ್ಳಿ…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "ಸೇರಿಸು (_A)"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
-"ಪ್ರತಿಯೊಂದು ಸಾಧನದಲ್ಲಿ ಬಣ್ಣವನ್ನು ನಿರ್ವಹಿಸಲು ಅದಕ್ಕೆ ಇತ್ತೀಚಿನ (ಅಪ್‌ ಟು ಡೇಟ್) ಬಣ್ಣ "
-"ಪ್ರೊಫೈಲಿನ "
+"ಪ್ರತಿಯೊಂದು ಸಾಧನದಲ್ಲಿ ಬಣ್ಣವನ್ನು ನಿರ್ವಹಿಸಲು ಅದಕ್ಕೆ ಇತ್ತೀಚಿನ (ಅಪ್‌ ಟು ಡೇಟ್) ಬಣ್ಣ ಪ್ರೊಫೈಲಿನ "
 "ಅಗತ್ಯವಿರುತ್ತದೆ."
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "ಬಣ್ಣದ ನಿರ್ವಹಣೆಯ ಕುರಿತು ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ"
 
-#: ../panels/color/color.ui.h:35
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "ಎಲ್ಲಾ ಬಳಕೆದಾರರಿಗೂ ಹೊಂದಿಸು"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "ಈ ಪ್ರೊಫೈಲನ್ನು ಈ ಗಣಕದಲ್ಲಿನ ಎಲ್ಲಾ ಬಳಕೆದಾರರಿಗಾಗಿ ಹೊಂದಿಸು"
 
-#: ../panels/color/color.ui.h:37
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "ಸಕ್ರಿಯ"
 
-#: ../panels/color/color.ui.h:38
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "ಪ್ರೊಫೈಲನ್ನು ಸೇರಿಸು"
 
-#: ../panels/color/color.ui.h:39
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "ಕ್ಯಾಲಿಬ್ರೇಟ್..."
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "ಸಾಧನವನ್ನು ಕ್ಯಾಲಿಬ್ರೇಟ್ ಮಾಡು"
 
-#: ../panels/color/color.ui.h:41
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "ಪ್ರೊಫೈಲನ್ನು ತೆಗೆದು ಹಾಕು"
 
-#: ../panels/color/color.ui.h:42
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "ವಿವರಗಳನ್ನು ನೋಡು"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "ಬಣ್ಣವನ್ನು ವ್ಯವಸ್ಥಾಪಿಸಲು ಯಾವುದೆ ಸಾಧನಗಳನ್ನು ಪತ್ತೆ ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "ಪ್ರೊಜೆಕ್ಟರ್"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "ಪ್ಲಾಸ್ಮಾ"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL ಹಿಂಬೆಳಕು)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED ಹಿಂಬೆಳಕು)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (ಬಿಳಿಯ LED ಹಿಂಬೆಳಕು)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "ಅಗಲ ಗ್ಯಾಮುಟ್ LCD (CCFL ಹಿಂಬೆಳಕು)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "ಅಗಲ ಗ್ಯಾಮುಟ್ LCD (RGB LED ಹಿಂಬೆಳಕು)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "ಉತ್ತಮ"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 ನಿಮಿಷಗಳು"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "ಮಧ್ಯಮ"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 ನಿಮಿಷಗಳು"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "ಕೆಳ ಮಟ್ಟದ"
 
-#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 ನಿಮಿಷಗಳು"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "ತೋರಿಸಬೇಕಿರುವ ನೇಟೀವ್"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (ಮುದ್ರಣ ಮತ್ತು ಪ್ರಕಟಣೆ)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (ಫೊಟೊಗ್ರಾಫಿ ಮತ್ತು ಗ್ರಾಫಿಕ್ಸ್)"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "ಬಣ್ಣ"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
-msgstr ""
-"ನಿಮ್ಮ ಸಾಧನಗಳು, ಪ್ರದರ್ಶಕಗಳು, ಕ್ಯಾಮೆರಾಗಳು ಅಥವ ಮುದ್ರಕಗಳ ಬಣ್ನವನ್ನು ಕ್ಯಾಲಿಬ್ರೇಟ್ "
-"ಮಾಡು"
+msgstr "ನಿಮ್ಮ ಸಾಧನಗಳು, ಪ್ರದರ್ಶಕಗಳು, ಕ್ಯಾಮೆರಾಗಳು ಅಥವ ಮುದ್ರಕಗಳ ಬಣ್ನವನ್ನು ಕ್ಯಾಲಿಬ್ರೇಟ್ ಮಾಡು"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "ಬಣ್ಣ;ICC;ಪ್ರೊಫೈಲ್;ಕ್ಯಾಲಿಬ್ರೇಟ್;ಮುದ್ರಕ;ಪ್ರದರ್ಶಕ;"
 
-#: ../panels/common/cc-common-language.c:323
-msgid "Other…"
-msgstr "ಇತರೆ…"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "ಭಾಷೆ"
 
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr "ಇನ್ನಷ್ಟು …"
+#: panels/common/cc-language-chooser.ui:13
+#, fuzzy
+msgid "_Select"
+msgstr "ಆರಿಸು"
 
-#: ../panels/common/cc-language-chooser.c:139
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "ಯಾವುದೆ ಭಾಷೆಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "ಭಾಷೆ"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "ಇನ್ನಷ್ಟು …"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "ಆಯಿತು (_D)"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "ಸಮಯ"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "ಜನವರಿ"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "ಫೆಬ್ರವರಿ"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "ಮಾರ್ಚ್"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "ಏಪ್ರಿಲ್"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "ಮೇ"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "ಜೂನ್"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "ಜುಲೈ"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "ಆಗಸ್ಟ್‍"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "ಸಪ್ಟೆಂಬರ್"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "ಅಕ್ಟೋಬರ್"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "ನವೆಂಬರ್"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "ಡಿಸೆಂಬರ್"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "ದಿನಾಂಕ ಮತ್ತು ಸಮಯ"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "ಗಂಟೆ"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "ನಿಮಿಷ"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "ದಿನ"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "ತಿಂಗಳು"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "ವರ್ಷ"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "ತಿಂಗಳು"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "ಜನವರಿ"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ಫೆಬ್ರವರಿ"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "ಮಾರ್ಚ್"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "ಏಪ್ರಿಲ್"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "ಮೇ"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "ಜೂನ್"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "ಜುಲೈ"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "ಆಗಸ್ಟ್‍"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "ಸಪ್ಟೆಂಬರ್"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ಅಕ್ಟೋಬರ್"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "ನವೆಂಬರ್"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ಡಿಸೆಂಬರ್"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "ದಿನ"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "ಕಾಲ ವಲಯ"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "ಊರಿಗಾಗಿ ಹುಡುಕು"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "ಸ್ವಯಂಚಾಲಿತ ದಿನಾಂಕ ಮತ್ತು ಸಮಯ (_D)"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "ಅಂತರಜಾಲ ನಿಲುಕಿನ ಅಗತ್ಯವಿರುತ್ತದೆ"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "ದಿನಾಂಕ ಮತ್ತು ಸಮಯ (_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "ಸ್ವಯಂಚಾಲಿತ ಕಾಲ ವಲಯ (_Z)"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "Date & _Time"
-msgstr "ದಿನಾಂಕ ಮತ್ತು ಸಮಯ (_T)"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "ಅಂತರಜಾಲ ನಿಲುಕಿನ ಅಗತ್ಯವಿರುತ್ತದೆ"
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
-msgstr "ಕಾಲ ವಲಯ (_Z)"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "ಸಕ್ರಿಯಗೊಂಡ"
 
-#: ../panels/datetime/datetime.ui.h:28
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "ಕಾಲ ವಲಯ"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ಪ್ರದಕ್ಷಿಣೆ"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "ಸಮಯದ ಶೈಲಿಗಳು (_F)"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24-ಗಂಟೆ"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "ದಿನಾಂಕಗಳು"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "ದ್ವಿತೀಯ"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "ಕ್ಯಾಲೆಂಡರ್ (_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "ಸಂಖ್ಯೆಗಳು"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "ಕಾಲವಲಯವೂ ಸೇರಿದಂತೆ ದಿನಾಂಕ ಮತ್ತು ಸಮಯವನ್ನು ಬದಲಾಯಿಸು"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "ಗಡಿಯಾರ;ಕಾಲವಲಯ;ಸ್ಥಳ;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "ನಿಮ್ಮ ಪ್ರದೇಶ ಹಾಗೆ ಭಾಷೆಯ ಸಿದ್ಧತೆಗಳನ್ನು ಬದಲಾಯಿಸಿ"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "ಸಮಯ ಅಥವ ದಿನಾಂಕದ ಸಿದ್ಧತೆಗಳನ್ನು ಬದಲಾಯಿಸಲು, ನೀವು ದೃಢೀಕರಿಸಬೇಕಾಗುತ್ತದೆ."
 
-#: ../panels/display/cc-display-panel.c:487
-msgid "Lid Closed"
-msgstr "ಮುಚ್ಚುಳ ಮುಚ್ಚಿದೆ"
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-msgid "Mirrored"
-msgstr "ಪ್ರತಿಬಿಂಬಿತ"
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2120
-msgid "Primary"
-msgstr "ಪ್ರಾಥಮಿಕ"
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1695 ../panels/power/cc-power-panel.c:1706
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "ಆಫ್"
-
-#: ../panels/display/cc-display-panel.c:497
-msgid "Secondary"
-msgstr "ದ್ವಿತೀಯ"
-
-#: ../panels/display/cc-display-panel.c:1510
-msgid "Arrange Combined Displays"
-msgstr "ಸಂಯೋಜಿತ ಪ್ರದರ್ಶಕಗಳನ್ನು ಜೋಡಿಸು"
-
-#: ../panels/display/cc-display-panel.c:1516
-#: ../panels/display/cc-display-panel.c:1954
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr "ಅನ್ವಯಿಸು (_A)"
-
-#: ../panels/display/cc-display-panel.c:1537
-msgid "Drag displays to rearrange them"
-msgstr "ಪ್ರದರ್ಶಕಗಳನ್ನು ಮರಳಿಹೊಂದಿಸಲು ಎಳೆದುಸೇರಿಸಿ"
-
-#: ../panels/display/cc-display-panel.c:2056
-msgid "Size"
-msgstr "ಗಾತ್ರ"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2069
-msgid "Aspect Ratio"
-msgstr "ಆಕಾರ ಅನುಪಾತ"
-
-#: ../panels/display/cc-display-panel.c:2090
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "ರೆಸಲ್ಯೂಶನ್"
-
-#: ../panels/display/cc-display-panel.c:2121
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "ಮೇಲಿನ ಪಟ್ಟಿ ಮತ್ತು ಚಟುವಟಿಕೆ ಅವಲೋಕಗಳನ್ನು ಈ ಪ್ರದರ್ಶಕದಲ್ಲಿ ತೋರಿಸು"
-
-#: ../panels/display/cc-display-panel.c:2127
-msgid "Secondary Display"
-msgstr "ಎರಡನೆಯ ಪ್ರದರ್ಶಕ"
-
-#: ../panels/display/cc-display-panel.c:2128
-msgid "Join this display with another to create an extra workspace"
-msgstr ""
-"ಒಂದು ಹೆಚ್ಚುವರಿ ಕಾರ್ಯಸ್ಥಳವನ್ನು ರಚಿಸಲು ಈ ಪ್ರದರ್ಶಕವನ್ನು ಇನ್ನೊಂದಕ್ಕೆ ಜೋಡಿಸು"
-
-#: ../panels/display/cc-display-panel.c:2135
-msgid "Presentation"
-msgstr "ಪ್ರಸ್ತುತಿ"
-
-#: ../panels/display/cc-display-panel.c:2136
-msgid "Show slideshows and media only"
-msgstr "ಸ್ಲೈಡ್‌ಶೋಗಳನ್ನು ಮತ್ತು ಮಾಧ್ಯಮವನ್ನು ಮಾತ್ರ ತೋರಿಸು"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2141
-msgid "Mirror"
-msgstr "ಬಿಂಬ"
-
-#: ../panels/display/cc-display-panel.c:2142
-msgid "Show your existing view on both displays"
-msgstr "ಎರಡೂ ಪ್ರದರ್ಶಕಗಳಲ್ಲಿ ನಿಮ್ಮ ಈಗಿನ ನೋಟವನ್ನು ತೋರಿಸಿ"
-
-#: ../panels/display/cc-display-panel.c:2148
-msgid "Turn Off"
-msgstr "ನಿಷ್ಕ್ರಿಯಗೊಳಿಸು"
-
-#: ../panels/display/cc-display-panel.c:2149
-msgid "Don't use this display"
-msgstr "ಈ ಪ್ರದರ್ಶಕವನ್ನು ಬಳಸಬೇಡ"
-
-#: ../panels/display/cc-display-panel.c:2358
-msgid "Could not get screen information"
-msgstr "ತೆರೆಯ ಮಾಹಿತಿಯನ್ನು ಪಡೆಯಲಾಗಲಿಲ್ಲ"
-
-#: ../panels/display/cc-display-panel.c:2389
-msgid "_Arrange Combined Displays"
-msgstr "ಸಂಯೋಜಿತತ ಪ್ರದರ್ಶಕಗಳನ್ನು ಜೋಡಿಸು (_A)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "ಪ್ರದರ್ಶಕಗಳು"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr ""
-"ಸಂಪರ್ಕಿತಗೊಳಿಸಲಾದ ಮಾನಿಟರುಗಳ ಹಾಗು ಪ್ರೊಜೆಕ್ಟರುಗಳನ್ನು ಹೇಗೆ ಬಳಸಬೇಕು ಎನ್ನುವುದನ್ನು "
-"ಆರಿಸಿ"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "ಪ್ಯಾನಲ್;ಪ್ರೊಜೆಕ್ಟರ್;xrandr;ತೆರೆ;ರೆಸಲ್ಯೂಶನ್;ಪುನಶ್ಚೇತನ;ಪರದೆ;"
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr "ವೇಲ್ಯಾಂಡ್"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "ಗೊತ್ತಿರದ"
-
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-bit"
-
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr "%d-ಬಿಟ್"
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr "ಏನು ಮಾಡಬೇಕು ಎಂದು ಕೇಳು"
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr "ಏನೂ ಮಾಡಬೇಡ"
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr "ಕಡತಕೋಶವನ್ನು ತೆರೆ"
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr "ಇತರೆ ಮಾಧ್ಯಮ"
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr "ಆಡಿಯೊ CD ಗಳಿಗಾಗಿ ಒಂದು ಅನ್ವಯವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr "ವೀಡಿಯೊ DVD ಗಳಿಗಾಗಿ ಒಂದು ಅನ್ವಯವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr "ಸಂಗೀತದ ಪ್ಲೇಯರನ್ನು ಜೋಡಿಸಿದಾಗ ಚಲಾಯಿಸಲು ಒಂದು ಅನ್ವಯವನ್ನು ಆರಿಸಿ"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr "ಕ್ಯಾಮೆರವನ್ನು ಜೋಡಿಸಿದಾಗ ಚಲಾಯಿಸಲು ಒಂದು ಅನ್ವಯವನ್ನು ಆರಿಸಿ"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr "ತಂತ್ರಾಂಶ CD ಗಳಿಗಾಗಿ ಒಂದು ಅನ್ವಯವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr "audio DVD"
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr "ಖಾಲಿ ಬ್ಲೂ-ರೇ ಡಿಸ್ಕ್"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr "ಖಾಲಿ CD ಡಿಸ್ಕ್"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr "ಖಾಲಿ DVD ಡಿಸ್ಕ್"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr "ಖಾಲಿ HD DVD ಡಿಸ್ಕ್"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr "ಬ್ಲೂ-ರೇ ವೀಡಿಯೊ ಡಿಸ್ಕ್"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr "ಇ-ಪುಸ್ತಕ ಓದುಗ"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr "HD DVD ವಿಡಿಯೋ ಡಿಸ್ಕ್ "
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr "ಚಿತ್ರ CD"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr "ಸೂಪರ ವೀಡಿಯೊ CD"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr "ವೀಡಿಯೊ CD"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr "ಕಿಟಕಿ ಅಂಚು"
-
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1932
-msgid "Section"
-msgstr "ವಿಭಾಗ"
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "ಅವಲೋಕನ"
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಅನ್ವಯಗಳು"
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "ತೆಗೆಯಬಹುದಾದ ಮಾಧ್ಯಮ"
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr "ಆವೃತ್ತಿ %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:46
-msgid "Details"
-msgstr "ವಿವರಗಳು"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr "ನಿಮ್ಮ ವ್ಯವಸ್ಥೆಯ ಬಗೆಗಿನ ಮಾಹಿತಿಯನ್ನು ನೋಡಿ"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"ಸಾಧನ;ವ್ಯವಸ್ಥೆ;ಮಾಹಿತಿ;ಮೆಮೊರಿ;ಸಂಸ್ಕಾರಕ;ಆವೃತ್ತಿ;ಪೂರ್ವನಿಯೋಜಿತ;ಅನ್ವಯ;ಇಚ್ಛೆಯ;cd;dvd;"
-"usb;"
-"ಆಡಿಯೊ;ವೀಡಿಯೊ;ಡಿಸ್ಕ್‍;ತೆಗೆಯಬಹುದಾದ;ಮಾಧ್ಯಮ;ಸ್ವಯಂಚಾಲನೆ;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "ಬೇರೆ ಮಾಧ್ಯಮವನ್ನು ಹೇಗೆ ನಿಭಾಯಿಸಬೇಕೆಂದು ಆಯ್ಕೆ ಮಾಡಿ"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "ಕ್ರಿಯೆ (_A):"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "ಬಗೆ (_T):"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "ಸಾಧನದ ಹೆಸರು"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "ಮೆಮೊರಿ"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "ಸಂಸ್ಕಾರಕ"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "ಮೂಲ ವ್ಯವಸ್ಥೆ"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "ಡಿಸ್ಕ್‍"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "ಲೆಕ್ಕಹಾಕಲಾಗುತ್ತಿದೆ..."
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "ಗ್ರಾಫಿಕ್ಸ್‍"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "ವರ್ಚುವಲೈಸೇಶನ್"
-
-#: ../panels/info/info.ui.h:13
-msgid "Check for updates"
-msgstr "ಅಪ್‌ಡೇಟ್‌ಗಳಿಗಾಗಿ ಪರೀಕ್ಷಿಸು"
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "ಜಾಲ (_W)"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "ಮೈಲ್ (_M)"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "ಕ್ಯಾಲೆಂಡರ್ (_C)"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "ಸಂಗೀತ (_u)"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "ವೀಡಿಯೊ (_V)"
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "ಫೋಟೊಗಳು (_P)"
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "ಮಾಧ್ಯಮವನ್ನು ಹೇಗೆ ನಿಭಾಯಿಸಬೇಕೆಂದು ಆಯ್ಕೆ ಮಾಡಿ"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಅನ್ವಯಗಳು"
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "CD ಆಡಿಯೊ  (_a)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಅನ್ವಯಗಳು"
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "_DVD ವೀಡಿಯೊ"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "ಸಂಗೀತ ಚಾಲಕ (_M)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "ತಂತ್ರಾಂಶ (_S)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "ಇತರೆ ಮಾಧ್ಯಮ (_O)…"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr "ಮಾಧ್ಯಮವನ್ನು ತೂರಿಸಿದಾಗ ಕೇಳಬೇಡ ಅಥವ ಪ್ರೊಗ್ರಾಮ್ ಅನ್ನು ಆರಂಭಿಸಬೇಡ (_N)"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "ಅನ್ವಯಿಸು (_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "ಹಿಂದಕ್ಕೆ"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "ಬ್ಲೂಟೂತ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "ಪ್ರದರ್ಶಕಗಳನ್ನು ಪತ್ತೆ ಮಾಡು (_D)"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "ಬಿಂಬ"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "ಎರಡನೆಯ ಪ್ರದರ್ಶಕ"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "ಬಲ ರಿಂಗ್"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "ಅಭಿಮುಖ"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "ರೆಸಲ್ಯೂಶನ್"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "ಗಾತ್ರ ಬದಲಾವಣೆ"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "ಯಾವುದೆ ಮುದ್ರಕ ಲಭ್ಯವಿಲ್ಲ"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "ಈಗಲೆ ಮರಳಿ ಆರಂಭಿಸು"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "ಸಮಯಗಳು"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "ಗಂಟೆ"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "ನಿಮಿಷ"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "ಪ್ರದರ್ಶಕಗಳು"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+"ಸಂಪರ್ಕಿತಗೊಳಿಸಲಾದ ಮಾನಿಟರುಗಳ ಹಾಗು ಪ್ರೊಜೆಕ್ಟರುಗಳನ್ನು ಹೇಗೆ ಬಳಸಬೇಕು ಎನ್ನುವುದನ್ನು ಆರಿಸಿ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "ಪ್ಯಾನಲ್;ಪ್ರೊಜೆಕ್ಟರ್;xrandr;ತೆರೆ;ರೆಸಲ್ಯೂಶನ್;ಪುನಶ್ಚೇತನ;ಪರದೆ;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "ಸುರಕ್ಷತೆಯ ಕೀಲಿ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "ಶಾಯಿಯ ಮಟ್ಟ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "ಶಾಯಿಯ ಮಟ್ಟ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "ಶಾಯಿಯ ಮಟ್ಟ"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "ಸುರಕ್ಷತೆ"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ತೆರೆ;ಲಾಕ್;ದೋಷಪತ್ತೆ;ಕುಸಿತ;ಖಾಸಗಿ;ಇತ್ತೀಚಿನ;ತಾತ್ಕಾಲಿಕ;tmp;ಸೂಚಿ;ಹೆಸರು;ಜಾಲಬಂಧ;ಗುರುತು;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ಸಾಧನದ ಹೆಸರು"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "ಯಂತ್ರಾಂಶ ವಿಳಾಸ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "ಮೆಮೊರಿ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "ಸಂಸ್ಕಾರಕ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "ಗ್ರಾಫಿಕ್ಸ್‍"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "ಲೆಕ್ಕಹಾಕಲಾಗುತ್ತಿದೆ..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "ಹೆಸರು"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0, author Shankar
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "OS ಬಗೆ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "ಆವೃತ್ತಿ 0"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "ಆಯ್ಕೆಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.."
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "ಕಿಟಕಿ ಅಂಚು"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "ವರ್ಚುವಲೈಸೇಶನ್"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "ತಂತ್ರಾಂಶದ ಬಳಕೆ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕು"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ಸಾಧನದ ಹೆಸರು"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "ಬಳಕೆದಾರ ಹೆಸರು (_U)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "ನಿಮ್ಮ ವ್ಯವಸ್ಥೆಯ ಬಗೆಗಿನ ಮಾಹಿತಿಯನ್ನು ನೋಡಿ"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ಸಾಧನ;ವ್ಯವಸ್ಥೆ;ಮಾಹಿತಿ;ಮೆಮೊರಿ;ಸಂಸ್ಕಾರಕ;ಆವೃತ್ತಿ;ಪೂರ್ವನಿಯೋಜಿತ;ಅನ್ವಯ;ಇಚ್ಛೆಯ;cd;dvd;usb;"
+"ಆಡಿಯೊ;ವೀಡಿಯೊ;ಡಿಸ್ಕ್‍;ತೆಗೆಯಬಹುದಾದ;ಮಾಧ್ಯಮ;ಸ್ವಯಂಚಾಲನೆ;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "ಧ್ವನಿ ಹಾಗು ಮಾಧ್ಯಮ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "ಧ್ವನಿ ಮೂಕ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "ಧ್ವನಿ ಕಡಿಮೆ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "ಧ್ವನಿ ಹೆಚ್ಚು"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "ಮೀಡಿಯಾ ಪ್ಲೇಯರ್ ಅನ್ನು ಆರಂಭಿಸು"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "ಚಲಾಯಿಸು (ಅಥವ ಚಲಾಯಿಸು/ವಿರಮಿಸು)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "ಪ್ಲೇಬ್ಯಾಕ್‌ ಅನ್ನು ವಿರಮಿಸು"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "ಪ್ಲೇಬ್ಯಾಕ್‌ ಅನ್ನು ನಿಲ್ಲಿಸು"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "ಹಿಂದಿನ ಹಾಡು"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "ಮುಂದಿನ ಹಾಡು"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "ಹೊರತಳ್ಳು"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "ಟೈಪಿಂಗ್"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "ಮುಂದಿನ ಇನ್‌ಪುಟ್ ಆಕರವನ್ನು ಬದಲಿಸು"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "ಹಿಂದಿನ ಇನ್‌ಪುಟ್ ಆಕರವನ್ನು ಬದಲಿಸು"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "ಆರಂಭಕಗಳು"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "ನೆರವಿನ ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸಿ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1604
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "ಸಿದ್ಧತೆಗಳು"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "ಕ್ಯಾಲ್ಕುಲೇಟರ್ ಅನ್ನು ಆರಂಭಿಸಿ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "ಇಮೈಲ್ ಕ್ಲೈಂಟ್ ಅನ್ನು ಆರಂಭಿಸಿ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "ಜಾಲ ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸಿ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "ನೆಲೆ ಕಡತಕೋಶ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "ಹುಡುಕು"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "ತೆರೆಚಿತ್ರಗಳು"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "ಒಂದು ತೆರೆಚಿತ್ರವನ್ನು $PICTURES ಎಂಬಲ್ಲಿ ಉಳಿಸು"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "ಕಿಟಕಿಯ ತೆರೆಚಿತ್ರವನ್ನು  $PICTURES ಎಂಬಲ್ಲಿ ಉಳಿಸು"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "ಒಂದು ಸ್ಥಳದ ತೆರೆಚಿತ್ರವನ್ನು $PICTURES ಎಂಬಲ್ಲಿ ಉಳಿಸು"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "ತೆರೆಚಿತ್ರವನ್ನು ಕ್ಲಿಪ್‌ಬೋರ್ಡಿಗೆ ಪ್ರತಿ ಮಾಡು"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "ಕಿಟಕಿಯ ತೆರೆಚಿತ್ರವನ್ನು ಕ್ಲಿಪ್‌ಬೋರ್ಡಿಗೆ ಪ್ರತಿ ಮಾಡು"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "ಒಂದು ಜಾಗದ ತೆರೆಚಿತ್ರವನ್ನು ಕ್ಲಿಪ್‌ಬೋರ್ಡಿಗೆ ಪ್ರತಿ ಮಾಡು"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "ಒಂದು ಸಣ್ಣ ಸ್ಕ್ರೀನ್‌ಕ್ಯಾಸ್ಟ್‌ ಅನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡು"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "ವ್ಯವಸ್ಥೆ"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "ಹೊರಗೆ ನಡೆ"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "ತೆರೆಯನ್ನು ಲಾಕ್ ಮಾಡಿ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "ಜಾಗತಿಕ ನಿಲುಕಣೆ"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "ಗೋಚರಿಕೆ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "ಹಿಗ್ಗಿಸುವಿಕೆಯನ್ನು ಆನ್ ಅಥವ ಆಫ್ ಮಾಡು"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "ಹಿಗ್ಗಿಸು"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "ಕುಗ್ಗಿಸು"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "ತೆರೆಓದುಗನನ್ನು ಆನ್ ಅಥವ ಆಫ್ ಮಾಡಿ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "ತೆರೆ ಕೀಲಿಮಣೆಯನ್ನು ಆನ್ ಅಥವ ಆಫ್ ಮಾಡಿ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "ಪಠ್ಯದ ಗಾತ್ರವನ್ನು ಹೆಚ್ಚಿಸು"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "ಪಠ್ಯದ ಗಾತ್ರವನ್ನು ಕುಗ್ಗಿಸು"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "ಅತ್ಯಂತ ವೈದೃಶ್ಯ ಆನ್ ಅಥವ ಆಫ್"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1218
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-msgid "Disabled"
-msgstr "ಅಶಕ್ತಗೊಂಡ"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "ಒಂದು ಇನ್‌ಪುಟ್‌ ಮೂಲವನ್ನು ಸೇರಿಸಿ"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "ಪರ್ಯಾಯ ಅಕ್ಷರಗಳ ಕೀಲಿ"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "ಪ್ರವೇಶ ತೆರೆಯಲ್ಲಿ ಇನ್‌ಪುಟ್ ವಿಧಾನಗಳನ್ನು ಬಳಸಲು ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "ಕಂಪೋಸ್ ಕೀಲಿ"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "ಯಾವುದೆ ಇನ್‌ಪುಟ್ ಮೂಲವನ್ನು ಆಯ್ಕೆ ಮಾಡಲಾಗಿಲ್ಲ"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "ಮಾರ್ಪಡಕ-ಕೇವಲ ಮುಂದಿನ ಆಕರಕ್ಕೆ ಬದಲಾಯಿಸು"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "ಆಯ್ಕೆಗಳು"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "ಕೀಲಿಮಣೆ"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "ಮೇಲೆ ಜರುಗಿಸು"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr ""
-"ಕೀಲಿಮಣೆ ಸುಲಭಆಯ್ಕೆಗಳನ್ನು ನೋಡು ಹಾಗೂ ಬದಲಾಯಿಸು ಮತ್ತು ನಿಮ್ಮ ಟೈಪಿಂಗ್ ಆದ್ಯತೆಗಳನ್ನು "
-"ಹೊಂದಿಸು"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "ಕೆಳಗೆ ಜರುಗಿಸು"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "ಶಾರ್ಟ್-ಕಟ್;ಪುನರಾವರ್ತನೆ;ಮಿಟುಕಿಸು;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "ಆದ್ಯತೆಗಳು"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "ಇಚ್ಛೆಯ ಶಾರ್ಟ್-ಕಟ್"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "ಕೀಲಿಮಣೆ-ಸುಲಭ ಆಯ್ಕೆಗಳು"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "ಹೆಸರು (_N):"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "ತೆಗೆದು ಹಾಕು (_R)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "ಆಜ್ಞೆ (_o):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "ಪುನರಾವರ್ತನಾ ಕೀಲಿಗಳು"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "ಕೀಲಿಯನ್ನು ಒತ್ತಿ ಹಿಡಿದಾಗ ಕೀಲಿಗಳ ಒತ್ತುವಿಕೆಯನ್ನು ಪುನರಾವರ್ತಿಸು (_r)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "ವಿಳಂಬ (_D):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "ವೇಗ (_S):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "ಚಿಕ್ಕದಾದ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "ನಿಧಾನ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "ಪುನರಾವರ್ತನೆಯ ಕೀಲಿಗಳ ವೇಗ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "ಉದ್ದವಾದ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "ವೇಗ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "ತೆರೆಸೂಚಕದ ಮಿನುಗುವಿಕೆ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "ತೆರೆಸೂಚಕವು ಪಠ್ಯ ಕ್ಷೇತ್ರಗಳಲ್ಲಿ ಮಿನುಗುತ್ತದೆ (_b)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "ವೇಗ (_p):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "ತೆರೆಸೂಚಕದ ಮಿನುಗುವ ವೇಗ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "ಇನ್‌ಪುಟ್‌ ಆಕರಗಳು"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "ಸುಲಭಆಯ್ಕೆಯನ್ನು ಸೇರಿಸು"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "ಸುಲಭಆಯ್ಕೆಯನ್ನು ತೆಗೆದುಹಾಕು"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"ಒಂದು ಶಾರ್ಟ್-ಕಟ್ ಕೀಲಿಯನ್ನು ಸಂಪಾದಿಸಲು, ಸಾಲಿನಲ್ಲಿ ಕ್ಲಿಕ್ಕಿಸಿ ಹಾಗು ಹೊಸ ಕೀಲಿಗಳನ್ನು "
-"ಒತ್ತಿಹಿಡಿಯಿರಿ ಅಥವ ಅಳಿಸಲು ಬ್ಯಾಕ್‍ಸ್ಪೇಸನ್ನು ಒತ್ತಿ."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "ಇನ್‌ಪುಟ್‌ ಮೂಲದ ಆಯ್ಕೆಗಳು"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "ಎಲ್ಲಾ ಕಿಟಕಿಗಳಿಗೂ ಒಂದೇ ರೀತಿಯ ಮೂಲವನ್ನು ಬಳಸು (_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "ಪ್ರತಿ ಕಿಟಕಿಗೂ ಸಹ ಪ್ರತ್ಯೇಕ ಮೂಲಗಳನ್ನು ಅನುಮತಿಸು (_d)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "ಪರ್ಯಾಯ ಅಕ್ಷರಗಳ ಕೀಲಿ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "ಕಂಪೋಸ್ ಕೀಲಿ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "ಕೀಲಿಮಣೆ-ಸುಲಭ ಆಯ್ಕೆಗಳು"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "ಇಚ್ಛೆಯ ಶಾರ್ಟ್-ಕಟ್‌ಗಳು"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "ವಿಭಾಗ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "ಶಾರ್ಟ್-ಕಟ್‌ಗಳು"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:635
-#: ../panels/keyboard/keyboard-shortcuts.c:643
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "ಸುಲಭಆಯ್ಕೆಯನ್ನು ಸೇರಿಸು"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "ಇಚ್ಛೆಯ ಶಾರ್ಟ್-ಕಟ್‌ಗಳು"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:860
-msgid "<Unknown Action>"
-msgstr "<ಗೊತ್ತಿರದ ಕ್ರಿಯೆ>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1357
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"ಶಾರ್ಟ್-ಕಟ್ \"%s\" ಅನ್ನು ಬಳಸಲಾಗುವುದಿಲ್ಲ ಏಕೆಂದರೆ ಈ ಕೀಲಿಯನ್ನು ಬಳಸಿಕೊಂಡು ಇದನ್ನು "
-"ಟೈಪ್ "
-"ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ.\n"
-"ದಯವಿಟ್ಟು ಒಂದೆ ಸಮಯದಲ್ಲಿ Control, Alt ಅಥವ Shift ನಂತಹ ಕೀಲಿಯನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1387
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "ಸುಲಭಆಯ್ಕೆಯನ್ನು ಸೇರಿಸು"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "ಕೀಲಿಮಣೆ-ಸುಲಭ ಆಯ್ಕೆಗಳು"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "ತೆಗೆದು ಹಾಕು (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "ಬದಲಾಯಿಸು (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"\"%s\" ಶಾರ್ಟ್-ಕಟ್ ಅನ್ನು ಇದಕ್ಕಾಗಿ ಈಗಾಗಲೆ ಬಳಸಲಾಗಿದೆ\n"
-"\"%s\""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1392
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"ಶಾರ್ಟ್-ಕಟ್‌ ಅನ್ನು \"%s\" ಗೆ ನಿಯೋಜಿಸಿದಲ್ಲಿ, \"%s\" ಶಾರ್ಟ್-ಕಟ್‌ "
-"ಅಶಕ್ತಗೊಳ್ಳುತ್ತದೆ."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1398
-msgid "_Reassign"
-msgstr "ಮರಳಿ ನಿಯೋಜಿಸು (_R)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "ಹೆಸರು"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1439
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
-msgstr ""
-"\"%s\" ಸಮೀಪಮಾರ್ಗವು ಒಂದು ಸಂಬಂಧಿಸಿದ \"%s\" ಸಮೀಪಮಾರ್ಗವನ್ನು ಹೊಂದಿದೆ. ನೀವು ಇದನ್ನು "
-"\"%s"
-"\" ಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊಂದಿಸಲು ಬಯಸುವಿರಾ?"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "ಆಜ್ಞೆ (_o):"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1449
-#, c-format
-msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
-msgstr ""
-"\"%s\" ಎನ್ನುವುದು ಪ್ರಸಕ್ತ \"%s\" ಎನ್ನುವುದಕ್ಕೆ ಸಂಬಂಧಿಸಿದೆ, ನೀವು ಮುಂದಕ್ಕೆ "
-"ಹೋದಲ್ಲಿ ಈ "
-"ಸಮೀಪಮಾರ್ಗವನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗುತ್ತದೆ."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+#, fuzzy
+msgid "Shortcut"
+msgstr "ಶಾರ್ಟ್-ಕಟ್‌ಗಳು"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1456
-msgid "_Assign"
-msgstr "ನಿಯೋಜಿಸು (_A)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "ಹೊಸ ಸಮೀಪಮಾರ್ಗ..."
 
-#: ../panels/mouse/cc-mouse-panel.c:94
-msgid "Test Your _Settings"
-msgstr "ನಿಮ್ಮ ಸಿದ್ಧತೆಗಳನ್ನು ಪರೀಕ್ಷಿಸಿ (_S)"
-
-#: ../panels/mouse/cc-mouse-panel.c:107
-msgid "Test Your Settings"
-msgstr "ನಿಮ್ಮ ಸಿದ್ಧತೆಗಳನ್ನು ಪರೀಕ್ಷಿಸಿ"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse & Touchpad"
-msgstr "ಮೌಸ್‌ ಹಾಗು ಟಚ್‌ಪ್ಯಾಡ್"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid ""
-"Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr ""
-"ನಿಮ್ಮ ಮೌಸ್‌ ಅಥವ ಟಚ್‌ಪ್ಯಾಡ್ ಸಂವೇದಶೀಲನೆ  ಅನ್ನು ಬದಲಾಯಿಸಿ ಮತ್ತು ಬಲ ಅಥವ ಎಡ-ಕೈ "
-"ಅನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-msgstr "ಟ್ರ್ಯಾಕ್‌ಪ್ಯಾಡ್;ಸೂಚಕ;ಕ್ಲಿಕ್;ಟ್ಯಾಪ್;ಜೋಡಿ;ಗುಂಡಿ;ಟ್ರ್ಯಾಕ್‌ಬಾಲ್;ಸ್ಕ್ರಾಲ್;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "ಸಾಮಾನ್ಯ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "ನಿಧಾನ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "ಎರಡು-ಬಾರಿ ಕ್ಲಿಕ್ಕಿಸುವ ಕಾಲಾವಧಿ ಮೀರಿಕೆ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "ವೇಗ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "ಜೋಡಿ ಕ್ಲಿಕ್ (_D)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "ಪ್ರಾಥಮಿಕ ಗುಂಡಿ (_b)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "ಎಡ (_L)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "ಬಲ (_R)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "ಮೌಸ್"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "ಸೂಚಕದ ವೇಗ (_P)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "ನಿಧಾನ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "ವೇಗ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "ಟಚ್‌ಪ್ಯಾಡ್"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "ನಿಧಾನ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "ವೇಗ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
-msgstr "ಟೈಪಿಸುವಾಗ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸು (_t)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
-msgstr "ಕ್ಲಿಕ್ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ (_c)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
-msgstr "ಎರಡು ಬೆರಳಿನ ಚಲನೆ (_f)"
-
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "_Natural scrolling"
-msgstr "ಸಾಮಾನ್ಯವೇಗದ ಸ್ಕ್ರಾಲಿಂಗ್ (_N)"
-
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "ಕ್ಲಿಕ್ ಮಾಡಲು, ಎರಡುಬಾರಿ ಕ್ಲಿಕ್ ಮಾಡಲು, ಚಲಾಯಿಸಲು ಪ್ರಯತ್ನಿಸಿ"
-
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "ಐದು ಕ್ಲಿಕ್‌ಗಳು, GEGL ಸಮಯ!"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "ಎರಡು-ಬಾರಿಯ ಕ್ಲಿಕ್, ಪ್ರಾಥಮಿಕ ಗುಂಡಿ"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "ಒಂದೇ ಕ್ಲಿಕ್, ಪ್ರಾಥಮಿಕ ಗುಂಡಿ"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "ಎರಡು-ಬಾರಿಯ ಕ್ಲಿಕ್, ಮಧ್ಯದ ಗುಂಡಿ"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "ಒಂದೇ ಕ್ಲಿಕ್, ಪ್ರಾಥಮಿಕ ಗುಂಡಿ"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "ಎರಡು-ಬಾರಿಯ ಕ್ಲಿಕ್, ಎರಡನೆಯ ಗುಂಡಿ"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "ಒಂದೇ ಕ್ಲಿಕ್, ಎರಡನೆಯ ಗುಂಡಿ"
-
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:369
-msgid "Air_plane Mode"
-msgstr "ವಿಮಾನದ ಸ್ಥಿತಿ (_p)"
-
-#: ../panels/network/cc-network-panel.c:977
-msgid "Network proxy"
-msgstr "ಜಾಲಬಂಧ ಪ್ರಾಕ್ಸಿ"
-
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1156 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1301
-msgid "The system network services are not compatible with this version."
-msgstr "ವ್ಯವಸ್ಥೆಯ ಜಾಲಬಂಧ ಸೇವೆಗಳು ಈ ಆವೃತ್ತಿಯೊಂದಿಗೆ ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ."
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
-msgid "802.1x _Security"
-msgstr "802.1x ಸುರಕ್ಷತೆ (_S)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "ಪುಟ 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "ಅಜ್ಞಾತ ಗುರುತು (_m)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "ಆಂತರಿಕ ದೃಢೀಕರಣ (_U)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "ಪುಟ 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "ಸುರಕ್ಷತೆ"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "ಸ್ವಯಂಚಾಲಿತ"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:218
-#: ../panels/network/net-device-wifi.c:382
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:222
-#: ../panels/network/net-device-wifi.c:387
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:226
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:231
-msgid "Enterprise"
-msgstr "ಎಂಟರ್ಪ್ರೈಸ್"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:236
-#: ../panels/network/net-device-wifi.c:372
-msgctxt "Wifi security"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "ಯಾವುದೂ ಇಲ್ಲ"
 
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "ಎಂದೂ ಬೇಡ"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
 
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:815
-msgid "Today"
-msgstr "ಇಂದು"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
 
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:818
-msgid "Yesterday"
-msgstr "ನಿನ್ನೆ"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "ಕೀಲಿಮಣೆ"
 
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:476
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"ಕೀಲಿಮಣೆ ಸುಲಭಆಯ್ಕೆಗಳನ್ನು ನೋಡು ಹಾಗೂ ಬದಲಾಯಿಸು ಮತ್ತು ನಿಮ್ಮ ಟೈಪಿಂಗ್ ಆದ್ಯತೆಗಳನ್ನು ಹೊಂದಿಸು"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "ಸ್ಥಳದ ಸೇವೆಗಳು (_L)"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "ಯಾವುದೆ ಅನ್ವಯವು ಪ್ರಸ್ತುತ ಧ್ವನಿಯನ್ನು ಚಲಾಯಿಸುತ್ತಿಲ್ಲ."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "ತೆರೆಯು ಆಫ್ ಆಗುತ್ತದೆ"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "ಯಾವುದೆ ಅನ್ವಯಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "ನಿಮ್ಮ ಸಿದ್ಧತೆಗಳನ್ನು ಪರೀಕ್ಷಿಸಿ (_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "ಸಾಮಾನ್ಯ"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "ಪ್ರಾಥಮಿಕ ಗುಂಡಿ (_b)"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "ಎಡ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "ಬಲ"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "ಸ್ಥಳಗಳನ್ನು ಹುಡುಕು"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "ಮೌಸ್"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "ಮೌಸ್ ಕೀಲಿಗಳು (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "ಕೆಳಕ್ಕೆ ಚಲಿಸು"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವು ವಿಷಯಗಳೊಂದಿಗೆ ಸ್ಥಳಾಂತರಗೊಳ್ಳುತ್ತದೆ"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "ಸಕ್ರಿಯ"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "ಟಚ್‌ಪ್ಯಾಡ್"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "ಟಚ್‌ಪ್ಯಾಡ್"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "ವಿಧಾನ (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "ಕ್ಲಿಕ್ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "ಕ್ಲಿಕ್ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "ಟೈಪಿಸುವಾಗ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸು (_t)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "ಟಚ್‌ಪ್ಯಾಡ್ (ತುಲನಾತ್ಮಕ)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "ಬಲಕ್ಕೆ ಚಲಿಸು"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "ಎಡಕ್ಕೆ ಚಲಿಸು"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "ಎರಡೂ-ಬದಿಯ"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ಕ್ಲಿಕ್ ಮಾಡಲು, ಎರಡುಬಾರಿ ಕ್ಲಿಕ್ ಮಾಡಲು, ಚಲಾಯಿಸಲು ಪ್ರಯತ್ನಿಸಿ"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "ಮೌಸ್‌ ಹಾಗು ಟಚ್‌ಪ್ಯಾಡ್"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"ನಿಮ್ಮ ಮೌಸ್‌ ಅಥವ ಟಚ್‌ಪ್ಯಾಡ್ ಸಂವೇದಶೀಲನೆ  ಅನ್ನು ಬದಲಾಯಿಸಿ ಮತ್ತು ಬಲ ಅಥವ ಎಡ-ಕೈ ಅನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ಟ್ರ್ಯಾಕ್‌ಪ್ಯಾಡ್;ಸೂಚಕ;ಕ್ಲಿಕ್;ಟ್ಯಾಪ್;ಜೋಡಿ;ಗುಂಡಿ;ಟ್ರ್ಯಾಕ್‌ಬಾಲ್;ಸ್ಕ್ರಾಲ್;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "ವರ್ಣಸ್ಥಳ: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "ಕಸದ ಬುಟ್ಟಿಯನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಖಾಲಿ ಮಾಡು (_T)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "ಪರದೆ"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "ಪ್ರಾಥಮಿಕ ಪ್ರದರ್ಶಕವನ್ನು ಬದಲಾಯಿಸಲು ಎಳೆಯಿರಿ."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "ಅನ್ವಯಗಳು"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ಸಾಧನಗಳು"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "ಹೊಸ ಸಂಪರ್ಕವನ್ನು ಸೇರಿಸು"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "ಸಂಪರ್ಕಗೊಂಡಿದೆ"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "ಆಯ್ಕೆಗಳು…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "ವೈ-ಫೈ ಹಾಟ್‌ಸ್ಪಾಟ್"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "ಜಾಲಬಂಧ ಹೆಸರು"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "ಗುಪ್ತಪದ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "ಗುಪ್ತಪದವನ್ನು ಉತ್ಪಾದಿಸಿ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "ಗುಪ್ತಪದವನ್ನು ಉತ್ಪಾದಿಸಿ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "ಚಾಲನೆಗೊಳಿಸು (_T)"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "ವಿಮಾನದ ಸ್ಥಿತಿ (_p)"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "ಯಾವುದೆ ಚಿತ್ರಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "ವಿಮಾನದ ಸ್ಥಿತಿ (_p)"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "ವೈ-ಫೈ ಹಾಟ್‌ಸ್ಪಾಟ್"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್ ಅನ್ನು ಬಳಸು (_U)..."
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "ಜಾಲಬಂಧಗಳು"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x ಸುರಕ್ಷತೆ (_S)"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i ದಿನದ ಹಿಂದೆ"
 msgstr[1] "%i ದಿನಗಳ ಹಿಂದೆ"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:533
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "None"
-msgstr "ಯಾವುದೂ ಇಲ್ಲ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "ದುರ್ಬಲ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ಸರಿ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:568
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "ಉತ್ತಮ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:570
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "ಅತ್ಯುತ್ತಮ"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "ಗುರುತು"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "ವಿಳಾಸ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "ನೆಟ್‌ಮಾಸ್ಕ್‍"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "ಗೇಟ್‌ವೇ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "ವಿಳಾಸವನ್ನು ಅಳಿಸು"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "ಸೇರಿಸು"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "ಪೂರೈಕೆಗಣಕ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "DNS ಸಾಧನವನ್ನು ಅಳಿಸು"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "ಮೆಟ್ರಿಕ್"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "ರೌಟ್ ಅನ್ನು ಅಳಿಸು"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP)"
-msgstr "ಸ್ವಯಂಚಾಲಿತ (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Manual"
-msgstr "ಕೈಯಾರೆ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "ಸ್ಥಳೀಯ-ಕೊಂಡಿ ಮಾತ್ರ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "ಪ್ರಿಫಿಕ್ಸ್‍"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "ಸ್ವಯಂಚಾಲಿತ"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "ಸ್ವಯಂಚಾಲಿತ, DHCP ಮಾತ್ರ"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:51
-msgid "Reset"
-msgstr "ಮರುಹೊಂದಿಸು"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "ಯಾವುದೂ ಇಲ್ಲ"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-ಬಿಟ್ ಕೀಲಿ (ಹೆಕ್ಸ್‍ ಅಥವ ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-ಬಿಟ್‌ ಗುಪ್ತವಾಕ್ಯಾಂಶ"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "ಡೈನಮಿಕ್ WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 ಪರ್ಸನಲ್"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 ಎಂಟರ್ಪ್ರೈಸ್"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "ಸಿಗ್ನಲ್‌ನ ಸಾಮರ್ಥ್ಯ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "ಕೊಂಡಿಯ ವೇಗ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:157
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "ಸುರಕ್ಷತೆ"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 ವಿಳಾಸ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:158
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 ವಿಳಾಸ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:165
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "ಯಂತ್ರಾಂಶ ವಿಳಾಸ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:169
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "ಬೆಂಬಲಿಸಲಾಗುವ ICC ಪ್ರೊಫೈಲುಗಳು"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "ಪೂರ್ವನಿಯೋಜಿತ ರೌಟ್"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "ಕೊನೆಯ ಬಾರಿಗೆ ಬಳಸಿದ್ದು"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "ಟ್ವಿಸ್ಟೆಡ್ ಪೇರ್ (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "ಅಟ್ಯಾಚ್‌ಮೆಂಟ್ ಯುನಿಟ್ ಇಂಟರ್ಫೇಸ್ (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "ಮೀಡಿಯಾ ಇಂಡಿಪೆಂಡೆಂಟ್ ಇಂಟರ್ಫೇಸ್ (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "ಹೆಸರು (_N)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
-msgid "_MAC Address"
-msgstr "_MAC ವಿಳಾಸ"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "M_TU"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "ತದ್ರೂಪುಗೊಳಿಸಿದ ವಿಳಾಸ (_C)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "ಬೈಟ್‌ಗಳು"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "ಇತರೆ ಬಳಕೆದಾರರಿಗೆ ಲಭ್ಯವಾಗುವಂತೆ ಮಾಡು (_u)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಂಪರ್ಕಸಾಧಿಸು (_a)"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "ಫೈರ್ವಾಲ್ ವಲಯ (_Z)"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "ಪೂರ್ವನಿಯೋಜಿತ"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "ವಲಯವು ಸಂಪರ್ಕದ ನಂಬಿಕೆಯ ಮಟ್ಟವನ್ನು ವಿವರಿಸುತ್ತದೆ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
-msgstr "ವಿಳಾಸ (_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "ಸ್ವಯಂಚಾಲಿತ DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Routes"
-msgstr "ರೌಟ್‌ಗಳು"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "ಸ್ವಯಂಚಾಲಿತ ರೌಟ್‌ಗಳು"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:34
-msgid "Use this connection _only for resources on its network"
-msgstr "ಅದರ ಜಾಲಬಂಧದಲ್ಲಿರುವ ಸಂಪನ್ಮೂಲಗಳಿಗಾಗಿ ಮಾತ್ರ ಈ ಸಂಪರ್ಕವನ್ನು ಬಳಸು (_o)"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "ಸಂಪರ್ಕ ಸಂಪಾದಕವನ್ನು ತೆರೆಯಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "ಹೊಸ ಪ್ರೊಫೈಲ್"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "ಬಾಂಡ್"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "ಟೀಮ್"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "ಬ್ರಿಜ್"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "VPN ಪ್ಲಗ್‌ಇನ್‌ಗಳನ್ನು ಲೋಡ್‌ ಮಾಡಲಾಗಲಿಲ್ಲ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "ಕಡತದಿಂದ ಆಮದು ಮಾಡು..."
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "ಜಾಲಬಂಧ ಸಂಪರ್ಕವನ್ನು ಸೇರಿಸು"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "ಮರಳಿ ಅಣಿಗೊಳಿಸು (_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1441
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "ಮರೆತುಬಿಡು (_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"ಈ ಜಾಲಬಂಧಕ್ಕಾಗಿನ ಗುಪ್ತಪದಗಳನ್ನೂ ಸೇರಿದಂತೆ ಸಿದ್ಧತೆಗಳನ್ನು ಮರುಹೊಂದಿಸು, ಆದರೆ ಇದನ್ನು "
-"ಆದ್ಯತೆಯ ಜಾಲಬಂಧ ಎಂದು ನೆನಪಿಟ್ಟುಕೊ"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"ಈ ಜಾಲಬಂಧಕ್ಕೆ ಸಂಬಂಧಿಸದ ಎಲ್ಲಾ ವಿವರಗಳನ್ನು ತೆಗೆದುಹಾಕು ಮತ್ತು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಂಪರ್ಕ "
-"ಸಾಧಿಸಲು ಪ್ರಯತ್ನಿಸಬೇಡ"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
-msgid "S_ecurity"
-msgstr "ಸುರಕ್ಷತೆ (_e)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "VPN ಸಂಪರ್ಕವನ್ನು ಆಮದು ಮಾಡಲಾಗಿಲ್ಲ"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"'%s' ಕಡತವನ್ನು ಓದಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ ಅಥವ ಗುರುತಿಸಲಾದ VPN ಸಂಪರ್ಕ ಮಾಹಿತಿಯನ್ನು "
-"ಹೊಂದಿಲ್ಲ\n"
-"\n"
-"ದೋಷ: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "ಆಮದು ಮಾಡಲು ಕಡತವನ್ನು ಆರಿಸಿ"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1946
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "_Open"
-msgstr "ತೆರೆ (_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "\"%s\" ಎಂಬ ಹೆಸರಿನ ಕಡತವು ಈಗಾಗಲೆ ಅಸ್ತಿತ್ವದಲ್ಲಿದೆ."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "ಬದಲಾಯಿಸು (_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "%s ಅನ್ನು ನೀವು ಉಳಿಸುತ್ತಿರುವ VPN ಸಂಪರ್ಕದಿಂದ ಬದಲಾಯಿಸಲು ಬಯಸುವಿರಾ?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "VPN ಸಂಪರ್ಕವನ್ನು ರಫ್ತು ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"'%s' VPN ಸಂಪರ್ಕವನ್ನು %s ಎಂಬಲ್ಲಿಗೆ ರಫ್ತು ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ.\n"
-"\n"
-"ದೋಷ: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-msgid "Export VPN connection"
-msgstr "VPN ಸಂಪರ್ಕವನ್ನು ರಫ್ತುಮಾಡು"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(ದೋಷ: VPN ಸಂಪರ್ಕ ಸಂಪಾದಕವನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "_SSID"
-msgstr "_SSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
-msgid "_BSSID"
-msgstr "_BSSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "ನನ್ನ ನೆಲೆ ಜಾಲಬಂಧ"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "ಇತರೆ ಬಳಕೆದಾರರಿಗೆ ಲಭ್ಯವಾಗುವಂತೆ ಮಾಡು (_o)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "ಜಾಲಬಂಧ"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Control how you connect to the Internet"
-msgstr "ಅಂತರಜಾಲದೊಂದಿಗೆ ನೀವು ಹೇಗೆ ಸಂಪರ್ಕಗೊಳ್ಳುತ್ತೀರಿ ಎನ್ನುವುದನ್ನು ನಿಯಂತ್ರಿಸಿ"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
-"ಜಾಲಬಂಧ;ವೈರ್ಲೆಸ್;ವೈ-ಫೈ;ವೈಫೈ;IP;LAN;ಪ್ರಾಕ್ಸಿ;WAN;ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್;ಮಾಡೆಮ್;ಬ್ಲೂಟೂತ್;"
-"vpn;vlan;"
-"ಬ್ರಿಜ್;ಬಾಂಡ್;DNS;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "ಬಾಂಡ್‌ ಸ್ಲೇವ್‌ಗಳು"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "ಹೆಸರು (_N)"
 
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(ಯಾವುದೂ ಇಲ್ಲ)"
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC ವಿಳಾಸ"
 
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "ಬ್ರಿಜ್‌ ಸ್ಲೇವ್‌ಗಳು"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
 
-#: ../panels/network/net-device-ethernet.c:110
-#: ../panels/network/net-device-wifi.c:462
-msgid "never"
-msgstr "ಎಂದಿಗೂ ಬೇಡ"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "ತದ್ರೂಪುಗೊಳಿಸಿದ ವಿಳಾಸ (_C)"
 
-#: ../panels/network/net-device-ethernet.c:120
-#: ../panels/network/net-device-wifi.c:472
-msgid "today"
-msgstr "ಇಂದು"
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "ಬೈಟ್‌ಗಳು"
 
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:474
-msgid "yesterday"
-msgstr "ನಿನ್ನೆ"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "ವಿಧಾನ (_M)"
 
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP ವಿಳಾಸ"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "ಸ್ವಯಂಚಾಲಿತ (DHCP)"
 
-#: ../panels/network/net-device-ethernet.c:176
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "ಕೊನೆಯ ಬಾರಿಗೆ ಬಳಸಿದ್ದು"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "ಸ್ಥಳೀಯ-ಕೊಂಡಿ ಮಾತ್ರ"
 
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:286
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "ತಂತಿಯುಕ್ತ"
-
-#: ../panels/network/net-device-ethernet.c:354
-#: ../panels/network/net-device-wifi.c:1596
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "ಆಯ್ಕೆಗಳು…"
-
-#: ../panels/network/net-device-ethernet.c:472
-#, c-format
-msgid "Profile %d"
-msgstr "ಪ್ರೊಫೈಲ್ %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "ಹೊಸ ಸಂಪರ್ಕವನ್ನು ಸೇರಿಸು"
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr "ಟೀಮ್‌ ಸ್ಲೇವ್‌ಗಳು"
-
-#: ../panels/network/net-device-wifi.c:1154
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-"ನೀವು ವೈರ್ಲೆಸ್ ಅನ್ನು ಹೊರತುಪಡಿಸಿ ಬೇರೇ ರೀತಿಯ ಅಂತರಜಾಲ ಸಂಪರ್ಕವನ್ನು ಹೊಂದಿದ್ದಲ್ಲಿ, "
-"ನಿಮ್ಮ "
-"ಅಂತರಜಾಲ ಸಂಪರ್ಕವನ್ನು ಇತರರೊಂದಿಗೆ ಹಂಚಿಕೊಳ್ಳಲು ನೀವು ಒಂದು ವೈರ್ಲೆಸ್ ಬಹುದಾಗಿರುತ್ತದೆ."
-
-#: ../panels/network/net-device-wifi.c:1158
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-"ವೈರ್ಲೆಸ್ ಹಾಟ್‌ಸ್ಪಾಟ್‌ಗೆ ಬದಲಾಯಿಸಿದಲ್ಲಿ <b>%s</b> ದೊಂದಿಗಿನ ನಿಮ್ಮ ಸಂಪರ್ಕವು "
-"ಕಡಿದುಹೋಗುತ್ತದೆ."
-
-#: ../panels/network/net-device-wifi.c:1162
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"ಹಾಟ್‌ಸ್ಪಾಟ್ ಸಕ್ರಿಯವಾಗಿದ್ದಾಗ ನಿಮ್ಮ ವೈರ್ಲೆಸ್‌ ಮುಖಾಂತರ ಅಂತರಜಾಲದೊಂದಿಗೆ ಸಂಪರ್ಕ "
-"ಜೋಡಿಸುವುದು "
-"ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ."
-
-#: ../panels/network/net-device-wifi.c:1245
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-"ಹಾಟ್‌ಸ್ಪಾಟ್‌ ಅನ್ನು ನಿಲ್ಲಿಸಲು ಮತ್ತು ಅದರ ಯಾವುದೆ ಬಳಕೆದಾರರನ್ನು ಸಂಪರ್ಕ ತಪ್ಪಿಸಬೇಕೆ?"
-
-#: ../panels/network/net-device-wifi.c:1248
-msgid "_Stop Hotspot"
-msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್ ಅನ್ನು ನಿಲ್ಲಿಸು (_S):"
-
-#: ../panels/network/net-device-wifi.c:1305
-msgid "System policy prohibits use as a Hotspot"
-msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್ ಆಗಿ ಬಳಸುವುದಂತೆ ವ್ಯವಸ್ಥೆಯ ಪಾಲಿಯು ತಡೆಯುತ್ತಿದೆ"
-
-#: ../panels/network/net-device-wifi.c:1308
-msgid "Wireless device does not support Hotspot mode"
-msgstr "ವೈರ್ಲೆಸ್ ಸಾಧನವು ಹಾಟ್‌ಸ್ಪಾಟ್ ಕ್ರಮವನ್ನು ಬೆಂಬಲಿಸುವುದಿಲ್ಲ"
-
-#: ../panels/network/net-device-wifi.c:1437
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"ಗುಪ್ತಪದಗಳು ಮತ್ತು ಯಾವುದೆ ಅಗತ್ಯಾನುಗುಣ ಸಂರಚನೆಯೂ ಸಹ ಸೇರಿದಂತೆ  ಆಯ್ಕೆ ಮಾಡಲಾದ "
-"ಜಾಲಬಂಧಗಳಿಗಾಗಿ ಜಾಲಬಂಧ ವಿವರಗಳು ನಾಶಗೊಳ್ಳುತ್ತವೆ."
-
-#: ../panels/network/net-device-wifi.c:1745
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "ಇತಿಹಾಸ"
-
-#: ../panels/network/net-device-wifi.c:1749
-#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
-#: ../panels/wacom/cc-wacom-page.c:533
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Close"
-msgstr "ಮುಚ್ಚು (_C)"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1757
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "ಮರೆತುಬಿಡು (_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"ಸಂರಚನಾ URL ಅನ್ನು ಒದಗಿಸದೇ ಇದ್ದಲ್ಲಿ ವೆಬ್ ಪ್ರಾಕ್ಸಿ ಆಟೋಡಿಸ್ಕವರಿಯನ್ನು ಬಳಸಲಾಗುತ್ತದೆ."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "ಇದನ್ನು ನಂಬಿಕೆಗೆ ಅನರ್ಹವಾದ ಸಾರ್ವಜನಿಕ ಜಾಲಬಂಧಗಳಲ್ಲಿ ಇದು ಒಳ್ಳೆಯದಲ್ಲ"
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "ಪ್ರಾಕ್ಸಿ"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "ಪ್ರೊಫೈಲನ್ನು ಸೇರಿಸು (_A)..."
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "ಒದಗಿಸುವವರು"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "ಯಾವುದೂ ಇಲ್ಲ"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "ಕೈಯಾರೆ"
 
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "ಅಶಕ್ತಗೊಂಡ"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "ಇತರೆ ಗಣಕಗಳೊಡನೆ ಹಂಚಿಕೊಳ್ಳಲಾದ"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "ವಿಳಾಸ (_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ವಿಳಾಸ"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "ನೆಟ್‌ಮಾಸ್ಕ್‍"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "ಗೇಟ್‌ವೇ"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "ಸ್ವಯಂಚಾಲಿತ"
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "ಸ್ವಯಂಚಾಲಿತ DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "ರೌಟ್‌ಗಳು"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ರೌಟ್‌ಗಳು"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "ಮೆಟ್ರಿಕ್"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "ಅದರ ಜಾಲಬಂಧದಲ್ಲಿರುವ ಸಂಪನ್ಮೂಲಗಳಿಗಾಗಿ ಮಾತ್ರ ಈ ಸಂಪರ್ಕವನ್ನು ಬಳಸು (_o)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
 msgstr "ವಿಧಾನ (_M)"
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "ಸ್ವಯಂಸಂರಚನಾ URL (_C)"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "ಸ್ವಯಂಚಾಲಿತ, DHCP ಮಾತ್ರ"
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "_HTTP ಪ್ರಾಕ್ಸಿ"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "ಪ್ರಿಫಿಕ್ಸ್‍"
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "H_TTPS ಪ್ರಾಕ್ಸಿ"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "ಸುರಕ್ಷತೆ (_e)"
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "_FTP ಪ್ರಾಕ್ಸಿ"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ದೋಷ: VPN ಸಂಪರ್ಕ ಸಂಪಾದಕವನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ)"
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "ಸಾಕ್ಸ್‌ ಅತಿಥೇಯ (_S):"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "ಕಡೆಗಣಿಸಲಾದ ಆತಿಥೇಯಗಳು (_I)"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
 
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "HTTP ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "ಜಾಲಬಂಧ"
 
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "HTTPS ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "ಅಂತರಜಾಲದೊಂದಿಗೆ ನೀವು ಹೇಗೆ ಸಂಪರ್ಕಗೊಳ್ಳುತ್ತೀರಿ ಎನ್ನುವುದನ್ನು ನಿಯಂತ್ರಿಸಿ"
 
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "FTP ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "Socks ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "ಸಾಧನವನ್ನು ಆಫ್‌ ಮಾಡು"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "ಸಾಧನವನ್ನು ಸೇರಿಸು"
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕು"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN ಬಗೆ"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "ಗುಂಪಿನ ಹೆಸರು"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "ಗುಂಪನ ಗುಪ್ತಪದ"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "ಬಳಕೆದಾರಹೆಸರು"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr "VPN ಸಂಪರ್ಕವನ್ನು ಆಫ್ ಮಾಡು"
-
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "ಸ್ವಯಂಚಾಲಿತ ಸಂಪರ್ಕ (_C)"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "ವಿವರಗಳು"
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "ದಾಟುಪದ (_P)"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "ಯಾವುದೂ ಇಲ್ಲ"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "ಗುಪ್ತಪದವನ್ನು ತೋರಿಸು (_a)"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr "ಇತರೆ ಬಳಕೆದಾರರಿಗೆ ಲಭ್ಯವಾಗುವಂತೆ ಮಾಡು"
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "ಗುರುತು"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr "ಸ್ವಯಂಚಾಲಿತ (DHCP) ವಿಳಾಸಗಳು ಮಾತ್ರ"
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr "ಸ್ಥಳೀಯ-ಕೊಂಡಿ ಮಾತ್ರ"
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr "ಇತರೆ ಗಣಕಗಳೊಡನೆ ಹಂಚಿಕೊಳ್ಳಲಾದ"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr "ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪಡೆಯಲಾದ ರೌಟ್‌ಗಳನ್ನು ಕಡೆಗಣಿಸು (_I)"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr "ತದ್ರೂಪುಗೊಳಿಸಲಾದ MA_C ವಿಳಾಸ"
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr "ಯಂತ್ರಾಂಶ"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
-"ಈ ಸಂಪರ್ಕಕ್ಕಾಗಿನ ಸಿದ್ಧತೆಗಳನ್ನು ಅವುಗಳ ಪೂರ್ವನಿಯೋಜಿತಕ್ಕೆ ಮರುಹೊಂದಿಸು, ಆದರೆ ಆದ್ಯತೆಯ "
-"ಸಂಪರ್ಕ "
-"ಎಂದು ನೆನಪಿಡು."
+"ಜಾಲಬಂಧ;ವೈರ್ಲೆಸ್;ವೈ-ಫೈ;ವೈಫೈ;IP;LAN;ಪ್ರಾಕ್ಸಿ;WAN;ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್;ಮಾಡೆಮ್;ಬ್ಲೂಟೂತ್;vpn;vlan;"
+"ಬ್ರಿಜ್;ಬಾಂಡ್;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"ಈ ಜಾಲಬಂಧಕ್ಕೆ ಸಂಬಂಧಿಸಿದ ಎಲ್ಲಾ ವಿವರಗಳನ್ನು ತೆಗೆದುಹಾಕು ಮತ್ತು ಸ್ವಯಂಚಾಲಿತವಾಗಿ "
-"ಸಂಪರ್ಕ "
-"ಸಾಧಿಸಲು ಪ್ರಯತ್ನಿಸಬೇಡ."
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "ಮರುಹೊಂದಿಸು"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "ಯಂತ್ರಾಂಶ"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr "ವೈ-ಫೈ ಹಾಟ್‌ಸ್ಪಾಟ್"
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Turn On"
-msgstr "ಚಾಲನೆಗೊಳಿಸು (_T)"
-
-#: ../panels/network/network-wifi.ui.h:54
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "ವೈ-ಫೈ"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Turn Wi-Fi off"
-msgstr "ವೈ-ಫೈ ಅನ್ನು ಆಫ್ ಮಾಡಿ"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "ಅಂತರಜಾಲದೊಂದಿಗೆ ನೀವು ಹೇಗೆ ಸಂಪರ್ಕಗೊಳ್ಳುತ್ತೀರಿ ಎನ್ನುವುದನ್ನು ನಿಯಂತ್ರಿಸಿ"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_Use as Hotspot…"
-msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್ ಅನ್ನು ಬಳಸು (_U)..."
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"ಜಾಲಬಂಧ;ವೈರ್ಲೆಸ್;ವೈ-ಫೈ;ವೈಫೈ;IP;LAN;ಪ್ರಾಕ್ಸಿ;WAN;ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್;ಮಾಡೆಮ್;ಬ್ಲೂಟೂತ್;vpn;vlan;"
+"ಬ್ರಿಜ್;ಬಾಂಡ್;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "_Connect to Hidden Network…"
-msgstr "ಅಡಗಿಸಲಾದ ಜಾಲಬಂಧದೊಂದಿಗೆ ಸಂಪರ್ಕಸಾಧಿಸು (_C)..."
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "ತಂತಿಯುಕ್ತ"
 
-#: ../panels/network/network-wifi.ui.h:58
-msgid "_History"
-msgstr "ಇತಿಹಾಸ (_H)"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "ಸಾಧನವನ್ನು ಆಫ್‌ ಮಾಡು"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "ವೈ-ಫೈ ಜಾಲಬಂಧದೊಂದಿಗೆ ಸಂಪರ್ಕ ಹೊಂದಲು ಸ್ವಿಚ್ ಅನ್ನು ಆಫ್ ಮಾಡು"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "ಸಕ್ರಿಯ"
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "ಒದಗಿಸುವವರು"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP ವಿಳಾಸ"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "ಜಾಲಬಂಧ ಪ್ರಾಕ್ಸಿ"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP ಪ್ರಾಕ್ಸಿ"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS ಪ್ರಾಕ್ಸಿ"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP ಪ್ರಾಕ್ಸಿ"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "ಸಾಕ್ಸ್‌ ಅತಿಥೇಯ (_S):"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "ಕಡೆಗಣಿಸಲಾದ ಆತಿಥೇಯಗಳು (_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "ಸ್ವಯಂಸಂರಚನಾ URL (_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN ಸಂಪರ್ಕವನ್ನು ಆಫ್ ಮಾಡು"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "ಜಾಲಬಂಧ ಹೆಸರು"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Connected Devices"
-msgstr "ಸಂಪರ್ಕಗೊಂಡಿರುವ ಸಾಧನ"
-
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "ಸುರಕ್ಷತೆಯ ಬಗೆ"
 
-#: ../panels/network/network-wifi.ui.h:63
-msgid "Security key"
-msgstr "ಸುರಕ್ಷತೆಯ ಕೀಲಿ"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "ಗುಪ್ತಪದ"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "ತಾತ್ಕಾಲಿಕ"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "ವೈ-ಫೈ ಅನ್ನು ಆಫ್ ಮಾಡಿ"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "ಮೂಲಭೂತ ವ್ಯವಸ್ಥೆ"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "ಆಯ್ಕೆಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.."
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "ಗೊತ್ತಿರದ ಸ್ಥಿತಿ"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "ಅಡಗಿಸಲಾದ ಜಾಲಬಂಧದೊಂದಿಗೆ ಸಂಪರ್ಕಸಾಧಿಸು (_C)..."
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "ನಿರ್ವಹಿಸದೆ ಇರುವ"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "ವೈ-ಫೈ ಹಾಟ್‌ಸ್ಪಾಟ್"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "ಲಭ್ಯವಿಲ್ಲ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "ಸಂಪರ್ಕ ಕಲ್ಪಿಸಲಾಗುತ್ತಿದೆ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "ಸಂಪರ್ಕಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "ಸಂಪರ್ಕ ಕಡಿದುಹಾಕಲಾಗುತ್ತಿದೆ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "ಸಂಪರ್ಕವು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "ಗೊತ್ತಿರದ ಸ್ಥಿತಿ (ಕಾಣೆಯಾಗಿದೆ)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "ಸಂಪರ್ಕಗೊಂಡಿಲ್ಲ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "ಸಂರಚನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "IP ಸಂರಚನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "IP ಸಂರಚನೆಯ ವಾಯಿದೆ ತೀರಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "ರಹಸ್ಯಗಳ ಅಗತ್ಯವಿದೆ, ಆದರೆ ಅದನ್ನು ಒದಗಿಸಲಾಗಿಲ್ಲ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x ಸಪ್ಲಿಕ್ಯಾಂಟ್‌ನಿಂದ ಸಂಪರ್ಕ ಕಡಿದಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x ಸಪ್ಲಿಕೆಂಟ್ ಸಂರಚನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1x ಸಪ್ಲಿಕೆಂಟ್ ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x ಸಪ್ಲಿಕೆಂಟ್ ದೃಢೀಕರಿಸಲು ಬಹಳ ಹೊತ್ತು ತೆಗೆದುಕೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "PPP ಸೇವೆಯನ್ನು ಆರಂಭಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "PPP ಸಂಪರ್ಕವನ್ನು ಕಡಿದು ಹಾಕಲಾಗಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "DHCP ಕ್ಲೈಂಟ್ ಆರಂಭಗೊಳ್ಳಲು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP ಕ್ಲೈಂಟ್‌ ದೋಷ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP ಕ್ಲೈಂಟ್ ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "ಹಂಚಲಾದ ಸಂಪರ್ಕ ಸೇವೆಯು ಆರಂಭಗೊಳ್ಳುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "ಹಂಚಲಾದ ಸಂಪರ್ಕ ಸೇವೆಯು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "AutoIP ಸೇವೆಯು ಆರಂಭಗೊಳ್ಳುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "AutoIP ಸೇವೆಯ ದೋಷ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "AutoIP ಸೇವೆಯು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "ಮಾರ್ಗವು ಕಾರ್ಯನಿರತವಾಗಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "ಯಾವುದೆ ಡಯಲ್ ಟೋನ್ ಇಲ್ಲ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "ಯಾವುದೆ ವಾಹಕವನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "ಡಯಲ್ ಮಾಡುವ ಮನವಿಯ ಸಮಯ ಮೀರಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "ಡಯಲ್ ಮಾಡುವ ಪ್ರಯತ್ನವು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "ಮಾಡೆಮ್ ಆರಂಭಗೊಳ್ಳುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "ನಿಶ್ಚಿತ APN ಅನ್ನು ಆರಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "ಜಾಲಬಂಧಗಳಿಗಾಗಿ ಹುಡುಕಲಾಗುತ್ತಿಲ್ಲ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "ಜಾಲಬಂಧ ನೋಂದಣಿಯನ್ನು ನಿರಾಕರಿಸಲಾಗಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "ಜಾಲಬಂಧ ನೋಂದಣಿಯ ಸಮಯ ಮೀರಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "ಮನವಿ ಮಾಡಲಾದ ಜಾಲಬಂಧದೊಂದಿಗೆ ನೋಂದಾಯಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "PIN ಪರಿಶೀಲನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "ಸಾಧನದ ಫರ್ಮವೇರ್ ಕಾಣಿಸುತ್ತಿಲ್ಲ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "ಸಂಪರ್ಕವು ಕಾಣೆಯಾಗಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "ಈಗಿರುವ ಸಂಪರ್ಕವನ್ನು ಊಹಿಸಲಾಗಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "ಮಾಡೆಮ್ ಕಂಡು ಬಂದಿಲ್ಲ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "ಬ್ಲೂಟೂತ್ ಸಂಪರ್ಕವು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "ಸಿಮ್ ಕಾರ್ಡನ್ನು ಹಾಕಲಾಗಿಲ್ಲ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "ಸಿಮ್‌ ಪಿನ್ ಅಗತ್ಯವಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "ಸಿಮ್‌ Puk ಅಗತ್ಯವಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "ಸಿಮ್‌ ತಪ್ಪಾಗಿದೆ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "ಸಂಪರ್ಕಿತಗೊಂಡ ಕ್ರಮದಲ್ಲಿ InfiniBand ಸಾಧನಕ್ಕೆ ಬೆಂಬಲವಿರುವುದಿಲ್ಲ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "ಸಂಪರ್ಕದ ಅವಲಂಬನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "ಫರ್ಮ್-ವೇರ್ ಕಾಣಿಸುತ್ತಿಲ್ಲ"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "ಕೇಬಲ್‌ ಅನ್ನು ತೆಗೆಯಲಾಗಿದೆ"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "ಯಾವುದೆ ಸರ್ಟಿಫಿಕೇಟ್ ಅಥಾರಿಟಿ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆ ಮಾಡಲಾಗಿಲ್ಲ"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"ಸರ್ಟಿಫಿಕೇಟ್ ಅತಾರಿಟಿ (CA) ಪ್ರಮಾಣಪತ್ರವನ್ನು ಬಳಸದೆ ಇದ್ದಲ್ಲಿ ಸಂಪರ್ಕಗಳು ಅಸುರಕ್ಷಿತ, "
-"ದುಷ್ಟ Wi-"
-"Fi ಜಾಲಬಂಧಗಳಾಗಲು ಕಾರಣವಾಗಬಹುದು. ನೀವು ಸರ್ಟಿಫಿಕೇಟ್ ಅತಾರಿಟಿ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆ "
-"ಮಾಡಲು "
-"ಬಯಸುವಿರಾ?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "ಕಡೆಗಣಿಸು"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "CA ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆ ಮಾಡು"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, ಅಥವ PKCS#12 ಖಾಸಗಿ ಕೀಲಿಗಳು (*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER ಅಥವ PEM ಪ್ರಮಾಣಪತ್ರಗಳು (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-msgid "Choose a PAC file"
-msgstr "ಒಂದು PAC ಕಡತವನ್ನು ಆರಿಸು"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC ಕಡತಗಳು (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC ಕಡತಗಳು (_f)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "ಒಳಗಿನ ದೃಢೀಕರಣವನ್ನು (_I)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "PAC ಪ್ರಾವಿಶನಿಂಗ್ (_v)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "ಅನಾಮಧೇಯ"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "ದೃಡೀಕರಿಸಿದ"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "ಎರಡೂ"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "ಅಜ್ಞಾತ ಗುರುತು (_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC ಕಡತಗಳು (_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "ಒಂದು PAC ಕಡತವನ್ನು ಆರಿಸು"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "ಒಳಗಿನ ದೃಢೀಕರಣವನ್ನು (_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC ಪ್ರಾವಿಶನಿಂಗ್ (_v)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "ಬಳಕೆದಾರ ಹೆಸರು (_U)"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "ದಾಟುಪದ (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "ಗುಪ್ತಪದವನ್ನು ತೋರಿಸು (_w)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate"
-msgstr "ಸರ್ಟಿಫಿಕೇಟ್ ಅಥಾರಿಟಿ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆರಿಸಿ"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "ಆವೃತ್ತಿ 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "ಆವೃತ್ತಿ 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "C_A ಪ್ರಮಾಣಪತ್ರ"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "ಸರ್ಟಿಫಿಕೇಟ್ ಅಥಾರಿಟಿ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆರಿಸಿ"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP ಆವೃತ್ತಿ (_v)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "ಪ್ರತಿ ಬಾರಿಯೂ ಸಹ ಈ ಗುಪ್ತಪದಕ್ಕಾಗಿ ಕೇಳು (_k)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "ಗೂಢಲಿಪೀಕರಿಸದ ಖಾಸಗಿ ಕೀಲಿಗಳು ಅಸುರಕ್ಷಿತವಾಗಿರುತ್ತವೆ"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"ಆಯ್ಕೆ ಮಾಡಲಾದ ಖಾಸಗಿ ಕೀಲಿಯು ಒಂದು ಗುಪ್ತಪದದಿಂದ ಸಂರಕ್ಷಿತಗೊಂಡಿರುವಂತೆ ಕಾಣಿಸುತ್ತಿಲ್ಲ. "
-" "
-"ಇದರಿಂದಾಗಿ ನಿಮ್ಮ ಸುರಕ್ಷತಾ ರುಜುವಾತನ್ನು ರಾಜಿ ಮಾಡಿಕೊಂಡಂತಾಗುತ್ತದೆ.  ದಯವಿಟ್ಟು ಒಂದು "
-"ಗುಪ್ತಪದದಿಂದ ಸಂರಿಕ್ಷಿತಗೊಂಡಂತಹ ಖಾಸಗಿ ಕೀಲಿಯನ್ನು ಒದಗಿಸಿ.\n"
-"\n"
-"(ನೀವು ನಿಮ್ಮ ಖಾಸಗಿ ಕೀಲಿಯನ್ನು openssl ಬಳಸಿಕೊಂಡು ಸಂರಕ್ಷಿಸಿ)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-msgid "Choose your personal certificate"
-msgstr "ನಿಮ್ಮ ವೈಯಕ್ತಿಕ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆರಿಸಿ"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-msgid "Choose your private key"
-msgstr "ನಿಮ್ಮ ಖಾಸಗಿ ಕೀಲಿಯನ್ನು ಆರಿಸಿ"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "ಗುರುತು (_d)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "ಬಳಕೆದಾರ ಪ್ರಮಾಣಪತ್ರ (_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "ಖಾಸಗಿ ಕೀಲಿ (_k)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "ಖಾಸಗಿ ಕೀಲಿ ಗುಪ್ತಪದ (_P)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "ನನ್ನನ್ನು ಇನ್ನೊಮ್ಮೆ ಎಚ್ಚರಿಸಬೇಡ (_w)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "ಡೊಮೈನ್ (_D)"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "ಇಲ್ಲ"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "ಹೌದು"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "ಟನಲ್ಡ್ TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "ಪ್ರೊಟೆಕ್ಟೆಡ್ EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "ದೃಢೀಕರಣ (_t)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (ಪೂರ್ವನಿಯೋಜಿತ)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "ಮುಕ್ತ ವ್ಯವಸ್ಥೆ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "ಹಂಚಲಾದ ಕೀಲಿ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "ಕೀಲಿ (_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "ಕೀಲಿಯನ್ನು ತೋರಿಸು (_w)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP ಸೂಚಿ (_x)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "ಬಗೆ (_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (ಪೂರ್ವನಿಯೋಜಿತ)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "ಮುಕ್ತ ವ್ಯವಸ್ಥೆ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "ಹಂಚಲಾದ ಕೀಲಿ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "ಕೀಲಿ (_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "ಕೀಲಿಯನ್ನು ತೋರಿಸು (_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP ಸೂಚಿ (_x)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "ಸೂಚನೆಗಳು"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "ಶಬ್ಧ ರೂಪದ ಎಚ್ಚರಿಕೆಗಳು"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "ಪಾಪ್ಅಪ್ ಬ್ಯಾನರುಗಳನ್ನು ತೋರಿಸು"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "ವಿವರಗಳನ್ನು ಬ್ಯಾನರುಗಳಲ್ಲಿ ತೋರಿಸು"
-
-#: ../panels/notifications/cc-edit-dialog.c:43
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ನೋಡು"
-
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ವಿವರಗಳನ್ನು ತೋರಿಸು"
-
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1701 ../panels/power/cc-power-panel.c:1708
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "ಚಾಲಿತ"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "ಸೂಚನೆಗಳು"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "ಸೂಚನೆಗಳು"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ವಿವರಗಳನ್ನು ತೋರಿಸು"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "ಸೂಚನೆಗಳು"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr ""
-"ಯಾವ ಸೂಚನೆಗಳನ್ನು ತೋರಿಸಬೇಕು ಮತ್ತು ಅವು ಏನನ್ನು ತೋರಿಸಬೇಕು ಎನ್ನುವುದನ್ನು "
-"ನಿಯಂತ್ರಿಸುತ್ತದೆ"
+"ಯಾವ ಸೂಚನೆಗಳನ್ನು ತೋರಿಸಬೇಕು ಮತ್ತು ಅವು ಏನನ್ನು ತೋರಿಸಬೇಕು ಎನ್ನುವುದನ್ನು ನಿಯಂತ್ರಿಸುತ್ತದೆ"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "ಸೂಚನೆಗಳು;ಬ್ಯಾನರ್;ಸಂದೇಶ;ಟ್ರೇ;ಪಾಪ್ಅಪ್;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "ಪಾಪ್ ಅಪ್ ಬ್ಯಾನರುಗಳನ್ನು ತೋರಿಸು"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ತೋರಿಸು"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "ಆಂತರಿಕ ದೃಢೀಕರಣ (_U)"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-msgctxt "Online Account"
-msgid "Other"
-msgstr "ಇತರೆ"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "ಖಾತೆಯನ್ನು ಸೇರಿಸು"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
-msgstr "ಅಂಚೆ"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr "ಸಂಪರ್ಕವಿಳಾಸಗಳು"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "ಚಾಟ್"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "ಸಂಪನ್ಮೂಲಗಳು"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "ಖಾತೆಗೆ ದಾಖಲಾಗುವಲ್ಲಿ ದೋಷ ಉಂಟಾಗಿದೆ"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "ರುಜುವಾತುಗಳ ವಾಯಿದೆ ತೀರಿದೆ."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr "ಈ ಖಾತೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಸೈನ್ ಇನ್ ಆಗಿ."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr "ಸೈನ್ ಇನ್ (_S)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "ಖಾತೆಯನ್ನು ರಚಿಸುವಲ್ಲಿ ದೋಷ"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕುವಲ್ಲಿ ದೋಷ"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕಲು ನೀವು ಖಚಿತವೆ?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "ಇದು ಪರಿಚಾರಕದಿಂದ ಖಾತೆಯನ್ನು ತೆಗೆದು ಹಾಕುವುದಿಲ್ಲ."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "ತೆಗೆದು ಹಾಕು (_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "ಅಂತರಜಾಲದಲ್ಲಿನ ಖಾತೆಗಳು"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
-"ನಿಮ್ಮ ಆನ್‌ಲೈನ್ ಖಾತೆಗಳೊಂದಿಗೆ ಸಂಪರ್ಕ ಜೋಡಿಸಿ ಮತ್ತು ಅವುಗಳನ್ನು ಯಾವ ಕೆಲಸಕ್ಕೆ "
-"ಬಳಸಬೇಕು "
+"ನಿಮ್ಮ ಆನ್‌ಲೈನ್ ಖಾತೆಗಳೊಂದಿಗೆ ಸಂಪರ್ಕ ಜೋಡಿಸಿ ಮತ್ತು ಅವುಗಳನ್ನು ಯಾವ ಕೆಲಸಕ್ಕೆ ಬಳಸಬೇಕು "
 "ಎನ್ನುವುದನ್ನು ನಿರ್ಧರಿಸಿ"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -3703,2342 +2847,1962 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "ಯಾವುದೆ ಆನ್‌ಲೈನ್ ಖಾತೆಗಳನ್ನು ಸಂರಚಿಸಲಾಗಿಲ್ಲ"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕು"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "ಅಂತರಜಾಲದಲ್ಲಿನ ಖಾತೆಯನ್ನು ಸೇರಿಸು"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"ಒಂದು ಖಾತೆಯನ್ನು ಸೇರಿಸುವುದರಿಂದ ಅದನ್ನು ನಿಮ್ಮ ಅನ್ವಯಗಳನ್ನು ದಸ್ತಾವೇಜುಗಳಿಗೆ, ಅಂಚೆಗೆ, "
-"ಸಂಪರ್ಕವಿಳಾಸಗಳಿಗೆ, ಕ್ಯಾಲೆಂಡರಿಗೆ, ಹರಟೆ ಮತ್ತು ಮುಂತಾದವುಗಳಿಗಾಗಿ ನಿಲುಕಿಸಿಕೊಳ್ಳಲು "
-"ಸಾಧ್ಯವಾಗುತ್ತದೆ."
-
-#: ../panels/power/cc-power-panel.c:192
-msgid "Unknown time"
-msgstr "ಗೊತ್ತಿರದ ಸಮಯ"
-
-#: ../panels/power/cc-power-panel.c:198
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i ನಿಮಿಷ"
 msgstr[1] "%i ನಿಮಿಷಗಳು"
 
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i ಗಂಟೆ"
 msgstr[1] "%i ಗಂಟೆಗಳು"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:218
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:219
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ಗಂಟೆ"
 msgstr[1] "ಗಂಟೆಗಳು"
 
-#: ../panels/power/cc-power-panel.c:220
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "ನಿಮಿಷ"
 msgstr[1] "ನಿಮಿಷಗಳು"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:239
-#, c-format
-msgid "%s until fully charged"
-msgstr "ಚಾರ್ಜ್ ಮಾಡಿದಾಗಿನಿಂದ  %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 ನಿಮಿಷಗಳು"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:246
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "ಎಚ್ಚರಿಕೆ, %s ಬಾಕಿ ಇದೆ"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 ನಿಮಿಷಗಳು"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:251
-#, c-format
-msgid "%s remaining"
-msgstr "%s ಬಾಕಿ ಇದೆ"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 ನಿಮಿಷಗಳು"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:256 ../panels/power/cc-power-panel.c:284
-msgid "Fully charged"
-msgstr "ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 ನಿಮಿಷಗಳು"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:260 ../panels/power/cc-power-panel.c:288
-msgid "Empty"
-msgstr "ಖಾಲಿ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:275
-msgid "Charging"
-msgstr "ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:280
-msgid "Discharging"
-msgstr "ಡಿಸ್‌ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ"
-
-#: ../panels/power/cc-power-panel.c:405
-msgctxt "Battery name"
-msgid "Main"
-msgstr "ಮುಖ್ಯ"
-
-#: ../panels/power/cc-power-panel.c:407
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "ಹೆಚ್ಚುವರಿ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Wireless mouse"
-msgstr "ತಂತಿರಹಿತ ಮೌಸ್"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Wireless keyboard"
-msgstr "ತಂತಿರಹಿತ ಕೀಲಿಮಣೆ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Uninterruptible power supply"
-msgstr "ತಡೆರಹಿತ ವಿದ್ಯುತ್ ಪೂರೈಕೆ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Personal digital assistant"
-msgstr "ವೈಯಕ್ತಿಕ ಡಿಜಿಟಲ್ ಸಹಾಯಕ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Cellphone"
-msgstr "ಸೆಲ್‌ಫೋನ್"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:494
-msgid "Media player"
-msgstr "ಮಾಧ್ಯಮ ಚಾಲಕ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:497
-msgid "Tablet"
-msgstr "ಕಿಸೆಗಣಕ (ಟ್ಯಾಬ್ಲೆಟ್)"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:500
-msgid "Computer"
-msgstr "ಗಣಕ"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:503 ../panels/power/cc-power-panel.c:726
-#: ../panels/power/cc-power-panel.c:2030
-msgid "Battery"
-msgstr "ಬ್ಯಾಟರಿ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:549
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:556
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "ಎಚ್ಚರಿಕೆ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:561
-msgctxt "Battery power"
-msgid "Low"
-msgstr "ಕೆಳ ಮಟ್ಟದ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Good"
-msgstr "ಉತ್ತಮ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:571
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "ಸಂಪುರ್ಣವಾಗಿ ಚಾರ್ಜ್ ಆಗಿದೆ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:575
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "ಖಾಲಿ"
-
-#: ../panels/power/cc-power-panel.c:724
-msgid "Batteries"
-msgstr "ಬ್ಯಾಟರಿಗಳು"
-
-#: ../panels/power/cc-power-panel.c:1126
-msgid "When _idle"
-msgstr "ಜಡವಾಗಿದ್ದಾಗ (_i)"
-
-#: ../panels/power/cc-power-panel.c:1454
-msgid "Power Saving"
-msgstr "ವಿದ್ಯುಚ್ಛಕ್ತಿ ಉಳಿತಾಯ"
-
-#: ../panels/power/cc-power-panel.c:1482
-msgid "_Screen brightness"
-msgstr "ತೆರೆಯ ಪ್ರಕಾಶತೆ (_S)"
-
-#: ../panels/power/cc-power-panel.c:1488
-msgid "_Keyboard brightness"
-msgstr "ಕೀಲಿಮಣೆ ಪ್ರಕಾಶತೆ (_K)"
-
-#: ../panels/power/cc-power-panel.c:1498
-msgid "_Dim screen when inactive"
-msgstr "ಚಟುವಟಿಕೆ ಇಲ್ಲದಾಗ ತೆರೆಯನ್ನು ಮಂದಗೊಳಿಸು (_D)"
-
-#: ../panels/power/cc-power-panel.c:1523
-msgid "_Blank screen"
-msgstr "ಖಾಲಿ ತೆರೆ (_B)"
-
-#: ../panels/power/cc-power-panel.c:1560
-msgid "_Wi-Fi"
-msgstr "ವೈ-ಫೈ (_W)"
-
-#: ../panels/power/cc-power-panel.c:1565
-msgid "Turns off wireless devices"
-msgstr "ವೈರ್ಲೆಸ್ ಸಾಧನಗಳನ್ನು ಆಫ್ ಮಾಡುತ್ತದೆ"
-
-#: ../panels/power/cc-power-panel.c:1590
-msgid "_Mobile broadband"
-msgstr "ಮೊಬೈಲ್ ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್ (_M)"
-
-#: ../panels/power/cc-power-panel.c:1595
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "ಮೊಬೈಲ್ ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್‌ (3G, 4G, WiMax, ಇತರೆ.) ಸಾಧನಗಳನ್ನು ಆಫ್ ಮಾಡುತ್ತದೆ"
-
-#: ../panels/power/cc-power-panel.c:1645
-msgid "_Bluetooth"
-msgstr "ಬ್ಲೂಟೂತ್ (_B)"
-
-#: ../panels/power/cc-power-panel.c:1697
-msgid "When on battery power"
-msgstr "ಬ್ಯಾಟರಿ ವಿದ್ಯುಚ್ಛಕ್ತಿಯನ್ನು ಬಳಸುವಾಗ"
-
-#: ../panels/power/cc-power-panel.c:1699
-msgid "When plugged in"
-msgstr "ವಿದ್ಯುಚ್ಧಕ್ತಿ ಸಂಪರ್ಕ ಜೋಡಿಸಿದಾಗ"
-
-#: ../panels/power/cc-power-panel.c:1829
-msgid "Suspend & Power Off"
-msgstr "ಅಮಾನತುಗೊಳಿಸು ಮತ್ತು ಆಫ್ ಮಾಡು"
-
-#: ../panels/power/cc-power-panel.c:1862
-msgid "_Automatic suspend"
-msgstr "ಸ್ವಯಂಚಾಲಿತ ಅಮಾನತು (_A)"
-
-#: ../panels/power/cc-power-panel.c:1886
-msgid "When battery power is _critical"
-msgstr "ಬ್ಯಾಟರಿಯ ವಿದ್ಯುಚ್ಛಕ್ತಿಯು ಸಂದಿಗ್ಧ ಮಟ್ಟದಲ್ಲಿದ್ದಾಗ (_c)"
-
-#: ../panels/power/cc-power-panel.c:1941
-msgid "Power Off"
-msgstr "ಆಫ್ ಮಾಡು"
-
-#: ../panels/power/cc-power-panel.c:2077
-msgid "Devices"
-msgstr "ಸಾಧನಗಳು"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "ವಿದ್ಯುಚ್ಛಕ್ತಿ"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr ""
-"ಬ್ಯಾಟರಿ ಸ್ಥಿತಿಯನ್ನು ನೋಡು ಮತ್ತು ವಿದ್ಯುಚ್ಛಕ್ತಿ ಉಳಿಸುವ ಸಿದ್ಧತೆಗಳನ್ನು ಬದಲಾಯಿಸು"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-"ವಿದ್ಯುಚ್ಛಕ್ತಿ;ನಿದ್ರಿಸು;ಅಮಾನತು;ಹೈಬರ್ನೇಟ್;ಬ್ಯಾಟರಿ;ಪ್ರಕಾಶತೆ;ಮಂದ;ಖಾಲಿ;ತೆರೆ;DPMS;ಜಡ"
-";"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "ಹೈಬರ್ನೇಟ್"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "ಸ್ಥಗಿತಗೊಳಿಸು"
-
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 ನಿಮಿಷಗಳು"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 ಗಂಟೆ"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 ನಿಮಿಷಗಳು"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 ನಿಮಿಷಗಳು"
 
-#: ../panels/power/power.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 ನಿಮಿಷಗಳು"
 
-#: ../panels/power/power.ui.h:10
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 ಗಂಟೆಗಳು"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 ನಿಮಿಷ"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "ಬ್ಯಾಟರಿ"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 ನಿಮಿಷಗಳು"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ಸಾಧನಗಳು"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 ನಿಮಿಷಗಳು"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "ಸ್ಥಗಿತಗೊಳಿಸು"
 
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "4 ನಿಮಿಷಗಳು"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 ನಿಮಿಷಗಳು"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "ವಿದ್ಯುಚ್ಛಕ್ತಿ ಉಳಿತಾಯ"
 
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "8 ನಿಮಿಷಗಳು"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "ತೆರೆಯ ಪ್ರಕಾಶತೆ (_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 ನಿಮಿಷಗಳು"
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
 
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "12 ನಿಮಿಷಗಳು"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "ತೆರೆ"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "ತೆರೆ ಓದುಗ (_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ರೌಟ್‌ಗಳು"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ಅಮಾನತು"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "ಕೆಳಗಿನ ಗುಂಡಿ"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "ಸ್ವಯಂಚಾಲಿತ ಅಮಾನತು"
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "ಸಂಪರ್ಕ ಜೋಡಿಸಲಾಗಿದೆ (_P)"
 
-#: ../panels/power/power.ui.h:22
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "ಬ್ಯಾಟರಿ ವಿದ್ಯುಚ್ಛಕ್ತಿಯಲ್ಲಿದ್ದಾಗ (_B)"
 
-#: ../panels/power/power.ui.h:23
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "ವಿಳಂಬ"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "ದೃಢೀಕರಿಸು"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "ವಿದ್ಯುಚ್ಛಕ್ತಿ"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "ಗುಪ್ತಪದ"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "ಬ್ಯಾಟರಿ ಸ್ಥಿತಿಯನ್ನು ನೋಡು ಮತ್ತು ವಿದ್ಯುಚ್ಛಕ್ತಿ ಉಳಿಸುವ ಸಿದ್ಧತೆಗಳನ್ನು ಬದಲಾಯಿಸು"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr "ಟೋನರ್ ಕಡಿಮೆ ಇದೆ"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr "ಟೋನರ್ ಖಾಲಿಯಾಗಿದೆ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr "ವಿಕಸನೆಗಾರ ಕಡಿಮೆ ಇದೆ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr "ವಿಕಸನೆಗಾರ ಖಾಲಿಯಾಗಿದೆ"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr "ಮಾರ್ಕರ್ ಪೂರೈಕೆಯಲ್ಲಿ ಕೊರತೆಯಿದೆ"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr "ಮಾರ್ಕರ್ ಪೂರೈಕೆ ಇಲ್ಲವಾಗಿದೆ"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr "ಮುಚ್ಚಣ ತೆರೆದಿದೆ"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr "ಬಾಗಿಲು ತೆರೆದಿದೆ"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr "ಕಾಗದ ಕಡಿಮೆ ಇದೆ"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr "ಕಾಗದದ ಖಾಲಿಯಾಗಿದೆ"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ಆಫ್‌ಲೈನ್"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "ನಿಲ್ಲಿಸಲಾಗಿದೆ"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr "ಕಸದ ಬುಟ್ಟಿಯು ಬಹುಪಾಲು ತುಂಬಿದೆ"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr "ಕಸದ ಬುಟ್ಟಿ ತುಂಬಿದೆ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr "ಆಪ್ಟಿಕಲ್ ಫೋಟೊ ಕಂಡಕ್ಟರ್ ಸ್ಥಗಿತಗೊಳ್ಳುವ ಹಂತದಲ್ಲಿದೆ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ಆಪ್ಟಿಕಲ್ ಫೋಟೊ ಕಂಡಕ್ಟರ್ ಕೆಲಸ ಮಾಡುತ್ತಿಲ್ಲ"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "ಸಂರಚಿಸಲಾಗುತ್ತಿದೆ"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr "ಸಿದ್ಧಗೊಂಡಿದೆ"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "ಕಾರ್ಯಗಳನ್ನು ಸ್ವೀಕರಿಸುವುದಿಲ್ಲ"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr "ಸಂಸ್ಕರಿಸಲಾಗುತ್ತಿದೆ"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:921
-msgid "Toner Level"
-msgstr "ಟೋನರ್ ಮಟ್ಟ"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:924
-msgid "Ink Level"
-msgstr "ಶಾಯಿಯ ಮಟ್ಟ"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:927
-msgid "Supply Level"
-msgstr "ಒದಗಣೆಯ ಮಟ್ಟ"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:945
-msgctxt "printer state"
-msgid "Installing"
-msgstr "ಅನುಸ್ಥಾಪಿಸಲಾಗುತ್ತಿದೆ"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1121
-msgid "No printers available"
-msgstr "ಯಾವುದೆ ಮುದ್ರಕ ಲಭ್ಯವಿಲ್ಲ"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1431
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u ಸಕ್ರಿಯ"
-msgstr[1] "%u ಸಕ್ರಿಯ"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1775
-msgid "Failed to add new printer."
-msgstr "ಹೊಸ ಮುದ್ರಕವನ್ನು ಸೇರಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ."
-
-#: ../panels/printers/cc-printers-panel.c:1942
-msgid "Select PPD File"
-msgstr "PPD ಕಡತವನ್ನು ಆರಿಸು"
-
-#: ../panels/printers/cc-printers-panel.c:1951
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
-"PostScript ಪ್ರಿಂಟರ್ ಡಿಸ್ಕ್ರಿಪ್ಶನ್ ಕಡತಗಳು (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD."
-"GZ)"
+"ವಿದ್ಯುಚ್ಛಕ್ತಿ;ನಿದ್ರಿಸು;ಅಮಾನತು;ಹೈಬರ್ನೇಟ್;ಬ್ಯಾಟರಿ;ಪ್ರಕಾಶತೆ;ಮಂದ;ಖಾಲಿ;ತೆರೆ;DPMS;ಜಡ;"
 
-#: ../panels/printers/cc-printers-panel.c:2256
-msgid "No suitable driver found"
-msgstr "ಯಾವುದೆ ಸೂಕ್ತ ಚಾಲಕವು ಕಂಡು ಬಂದಿಲ್ಲ"
-
-#: ../panels/printers/cc-printers-panel.c:2325
-msgid "Searching for preferred drivers…"
-msgstr "ಇಚ್ಛೆಯ ಚಾಲಕಕ್ಕಾಗಿ ಹುಡುಕಲಾಗುತ್ತಿದೆ..."
-
-#: ../panels/printers/cc-printers-panel.c:2340
-msgid "Select from database…"
-msgstr "ದತ್ತಸಂಚಯದಿಂದ ಆಯ್ಕೆ ಮಾಡು..."
-
-#: ../panels/printers/cc-printers-panel.c:2349
-msgid "Provide PPD File…"
-msgstr "PPD ಕಡತವನ್ನು ಒದಗಿಸು..."
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2500
-#: ../panels/printers/cc-printers-panel.c:2523
-msgid "Test page"
-msgstr "ಪ್ರಾಯೋಗಿಕ ಪುಟ"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2937
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui ಅನ್ನುಲೋಡ್‌ ಮಾಡಲಾಗಲಿಲ್ಲ: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "ಮುದ್ರಕಗಳು"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
-"ಮುದ್ರಕಗಳನ್ನು ಸೇರಿಸಿ, ಮುದ್ರಣ ಕಾರ್ಯಗಳನ್ನು ನೋಡಿ ಮತ್ತು ನೀವು ಹೇಗೆ ಮುದ್ರಿಸಲು "
-"ಬಯಸುವಿರಿ "
+"ಮುದ್ರಕಗಳನ್ನು ಸೇರಿಸಿ, ಮುದ್ರಣ ಕಾರ್ಯಗಳನ್ನು ನೋಡಿ ಮತ್ತು ನೀವು ಹೇಗೆ ಮುದ್ರಿಸಲು ಬಯಸುವಿರಿ "
 "ಎನ್ನುವುದನ್ನು ನಿರ್ಧರಿಸಿ"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "ಮುದ್ರಕ;ಸರತಿ;ಮುದ್ರಣ;ಕಾಗದ;ಶಾಯಿ;ಟೋನರ್;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "ಸಕ್ರಿಯ ಕಾರ್ಯಗಳು"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "ಮುಚ್ಚು"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "ಮುದ್ರಣವನ್ನು ಮರುಆರಂಭಿಸು"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "ಮುದ್ರಣವನ್ನು ತಾತ್ಕಾಲಿಕ ನಿಲ್ಲಿಸು"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "ಮುದ್ರಣ ಕಾರ್ಯವನ್ನು ರದ್ದುಗೊಳಿಸು"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "ಒಂದು ಹೊಸ ಮುದ್ರಕವನ್ನು ಸೇರಿಸಿ"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "A_uthenticate"
-msgstr "ದೃಢೀಕರಿಸು (_u)"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "ಯಾವುದೆ ಮುದ್ರಕಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-msgid "Enter address of a printer or a text to filter results"
-msgstr ""
-"ಫಲಿತಾಂಶಗಳನ್ನು ಫಿಲ್ಟರ್‌ ಮಾಡಲು ಒಂದು ಮುದ್ರಕದ ವಿಳಾಸ ಅಥವ ಒಂದು ಪಠ್ಯವನ್ನು ನಮೂದಿಸಿ"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "ಆಯ್ಕೆಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.."
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "ಮುದ್ರಕದ ಚಾಲಕವನ್ನು ಆರಿಸು"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "ಚಾಲಕಗಳ ದತ್ತಸಂಚಯವನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ..."
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-msgid "JetDirect Printer"
-msgstr "JetDirect ಮುದ್ರಕ"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-msgid "LPD Printer"
-msgstr "LPD ಮುದ್ರಕ"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "ಒಂದು ಬದಿಯ"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "ಉದ್ದನೆಯ ಅಂಚು (ಶಿಷ್ಟ)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "ಚಿಕ್ಕ ಅಂಚು (ಹೊರಳಿಸು)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "ಭಾವಚಿತ್ರ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "ಪ್ರಕೃತಿ ಚಿತ್ರ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "ವಿಲೋಮ ಪ್ರಕೃತಿ ಚಿತ್ರ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "ವಿಲೋಮ ಭಾವಚಿತ್ರ"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "ಬಾಕಿ ಇದೆ"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "ತಡೆಹಿಡಿಯಲಾಗಿದೆ"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "ಸಂಸ್ಕರಿಸಲಾಗುತ್ತಿದೆ"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "ನಿಲ್ಲಿಸಲಾಗಿದೆ"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "ರದ್ದು ಮಾಡಲಾಗಿದೆ"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "ವಿಫಲಗೊಳಿಸಲಾಗಿದೆ"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "ಪೂರ್ಣಗೊಂಡಿದೆ"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "ಕೆಲಸದ ಶೀರ್ಷಿಕೆ"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "ಕೆಲಸದ ಸ್ಥಿತಿ"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "ಸಮಯ"
-
-#: ../panels/printers/pp-jobs-dialog.c:451
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s ಸಕ್ರಿಯ ಕಾರ್ಯಗಳು"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1620
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1625
-msgid "Serial Port"
-msgstr "ಅನುಕ್ರಮಿತ ಸಂಪರ್ಕಸ್ಥಾನ"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1632
-msgid "Parallel Port"
-msgstr "ಸಮಾನಾಂತರ ಸಂಪರ್ಕಸ್ಥಾನ"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1688
-#, c-format
-msgid "Location: %s"
-msgstr "ಸ್ಥಳ: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1693
-#, c-format
-msgid "Address: %s"
-msgstr "ವಿಳಾಸ: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1717
-msgid "Server requires authentication"
-msgstr "ಪೂರೈಕೆಗಣಕಕ್ಕೆ ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "ಎರಡೂ ಬದಿಯ"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "ಪೇಪರಿನ ಬಗೆ"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "ಪೇಪರಿನ ಆಕರ"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "ಔಟ್‌ಪುಟ್ ಟ್ರೇ"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript ಪೂರ್ವ-ಸೋಸುವಿಕೆ"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:533
-msgid "Pages per side"
-msgstr "ಪ್ರತಿ ಬದಿಯ ಪುಟಗಳು"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:545
-msgid "Two-sided"
-msgstr "ಎರಡೂ-ಬದಿಯ"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:557
-msgid "Orientation"
-msgstr "ಅಭಿಮುಖ"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "ಸಾಮಾನ್ಯ"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "ಪುಟ ಸಿದ್ಧತೆ"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "ಅನುಸ್ಥಾಪನೆಯ ಆಯ್ಕೆಗಳು"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "ಕಾರ್ಯ"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "ಚಿತ್ರದ ಗುಣಮಟ್ಟ"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "ಬಣ್ಣ"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "ಪೂರ್ಣಗೊಳಿಕೆ"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:675
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "ಸುಧಾರಿತ"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "ಸ್ವಯಂ ಆಯ್ಕೆ"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "ಮುದ್ರಕದ ಪೂರ್ವನಿಯೋಜಿತ"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "ಅಡಕಗೊಳಿಸಲಾದ GhostScript ಅಕ್ಷರಶೈಲಿಗಳು ಮಾತ್ರ"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "PS ಹಂತ 1 ಕ್ಕೆ ಪರಿವರ್ತಿಸು"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "PS ಹಂತ 2 ಕ್ಕೆ ಪರಿವರ್ತಿಸು"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "ಯಾವುದೆ ಪೂರ್ವ-ಫಿಲ್ಟರಿಂಗ್ ಇಲ್ಲ"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "ಉತ್ಪಾದಕರು"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "ಚಾಲಕ"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-"%s ನಲ್ಲಿ ಲಭ್ಯವಿರುವ ಮುದ್ರಕಗಳನ್ನು ನೋಡಲು ನಿಮ್ಮ ಬಳಕೆದಾರಹೆಸರು ಹಾಗು ಗುಪ್ತಪದವನ್ನು "
-"ನಮೂದಿಸಿ."
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "ಮುದ್ರಕವನ್ನು ಸೇರಿಸಿ"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "ಮುದ್ರಕವನ್ನು ತೆಗೆದುಹಾಕಿ"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "ಪೂರೈಕೆ"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "ಯಾವುದೆ ಚಿತ್ರಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"%s ನಲ್ಲಿ ಲಭ್ಯವಿರುವ ಮುದ್ರಕಗಳನ್ನು ನೋಡಲು ನಿಮ್ಮ ಬಳಕೆದಾರಹೆಸರು ಹಾಗು ಗುಪ್ತಪದವನ್ನು ನಮೂದಿಸಿ."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ಬಳಕೆದಾರಹೆಸರು"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "ಸ್ಥಳ"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default printer"
-msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಮುದ್ರಕ (_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "ಚಾಲಕ"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "ಕಾರ್ಯಗಳು"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "ಇಚ್ಛೆಯ ಚಾಲಕಕ್ಕಾಗಿ ಹುಡುಕಲಾಗುತ್ತಿದೆ..."
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "ಕೆಲಸಗಳನ್ನು ತೋರಿಸು (_J)"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "ಊರಿಗಾಗಿ ಹುಡುಕು"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "ದತ್ತಸಂಚಯದಿಂದ ಆಯ್ಕೆ ಮಾಡು..."
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "PPD ಕಡತವನ್ನು ಒದಗಿಸು..."
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "ಮುದ್ರಕದ ಚಾಲಕವನ್ನು ಆರಿಸು"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "ಚಾಲಕಗಳ ದತ್ತಸಂಚಯವನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "ರದ್ದು ಮಾಡು"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "ಆರಿಸು"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "ಪೂರೈಕೆಗಣಕಕ್ಕೆ ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+msgstr[1] "ಪೂರೈಕೆಗಣಕಕ್ಕೆ ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "ಡೊಮೈನ್ (_D)"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "ದೃಢೀಕರಿಸು (_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "ದೃಢೀಕರಿಸು"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s ಸಕ್ರಿಯ ಕಾರ್ಯಗಳು"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "ಪ್ರಾಯೋಗಿಕ ಪುಟ"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "ಪ್ರವೇಶದ ಆಯ್ಕೆಗಳು"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "ಮುದ್ರಕದ ಪೂರ್ವನಿಯೋಜಿತ"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "ಮುದ್ರಕದ ಪೂರ್ವನಿಯೋಜಿತ"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "ಮುದ್ರಣ ಕಾರ್ಯವನ್ನು ರದ್ದುಗೊಳಿಸು"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "ಮುದ್ರಕವನ್ನು ತೆಗೆದುಹಾಕಿ"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "ಸಕ್ರಿಯ ಕಾರ್ಯಗಳು"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "ಮಾದರಿ"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "ಲೇಬಲ್"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "ಶಾಯಿಯ ಮಟ್ಟ"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "ಹೊಸ ಚಾಲಕನ್ನು ಸಿದ್ಧಗೊಳಿಸಲಾಗುತ್ತಿದೆ..."
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "ಪುಟ 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "ಪ್ರಾಯೋಗಿಕ ಪುಟವನ್ನು ಮುದ್ರಿಸು (_T)"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "ಆಯ್ಕೆಗಳು (_O)"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "ಈಗಲೆ ಮರಳಿ ಆರಂಭಿಸು"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "ಹೊಸ ಮುದ್ರಕವನ್ನು ಸೇರಿಸಿ"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "ಮುದ್ರಕವನ್ನು ಸೇರಿಸಿ"
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "ಮುದ್ರಕಗಳು"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "ಕ್ಷಮಿಸಿ! ವ್ಯವಸ್ಥೆಯ ಮುದ್ರಣ ಸೇವೆಯು\n"
 "ಲಭ್ಯವಿರುವಂತೆ ತೋರುತ್ತಿಲ್ಲ."
 
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "ತೆರೆ ಲಾಕ್"
-
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "ಬಳಕೆ ಮತ್ತು ಇತಿಹಾಸ"
-
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
-msgstr "ಕಸದ ಬುಟ್ಟಿಯಿಂದ ಎಲ್ಲಾ ಅಂಶಗಳನ್ನು ಖಾಲಿ ಮಾಡಬೇಕೆ?"
-
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
-msgstr "ಕಸದ ಬುಟ್ಟಿಯಲ್ಲಿನ ಎಲ್ಲಾ ಅಂಶಗಳನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲಾಗುತ್ತದೆ."
-
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "ಕಸದ ಬುಟ್ಟಿಯನ್ನು ಖಾಲಿ ಮಾಡು (_E)"
-
-#: ../panels/privacy/cc-privacy-panel.c:512
-msgid "Delete all the temporary files?"
-msgstr "ಎಲ್ಲಾ ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಅಳಿಸಬೇಕೆ?"
-
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
-msgstr "ಎಲ್ಲಾ ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲಾಗುತ್ತದೆ."
-
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಹೊರತಳ್ಳು (_P)"
-
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "ಕಸ ಮತ್ತು ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಹೊರತಳ್ಳು"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr "ತಂತ್ರಾಂಶದ ಬಳಕೆ"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "ಗೌಪ್ಯತೆ"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-"ನಿಮ್ಮ ವೈಯಕ್ತಿಕ ಮಾಹಿತಿಗಳನ್ನು ಸಂರಕ್ಷಿಸಿ ಮತ್ತು ಬೇರೆಯವರು ಏನನ್ನು ನೋಡುತ್ತಾರೆ "
-"ಎನ್ನುವುದನ್ನು "
-"ನಿಯಂತ್ರಿಸಿ"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"ತೆರೆ;ಲಾಕ್;ದೋಷಪತ್ತೆ;ಕುಸಿತ;ಖಾಸಗಿ;ಇತ್ತೀಚಿನ;ತಾತ್ಕಾಲಿಕ;tmp;ಸೂಚಿ;ಹೆಸರು;ಜಾಲಬಂಧ;ಗುರುತು"
-";"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "ತೆರೆಯು ಆಫ್ ಆಗುತ್ತದೆ"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 ಸೆಕೆಂಡುಗಳು"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 ದಿನ"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 ದಿನಗಳು"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 ದಿನಗಳು"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 ದಿನಗಳು"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 ದಿನಗಳು"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 ದಿನಗಳು"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 ದಿನಗಳು"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 ದಿನಗಳು"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 ದಿನಗಳು"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "ಯಾವಾಗಲೂ"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"ನಿಮ್ಮ ವ್ಯವಸ್ಥೆಯ ಇತಿಹಾಸವನ್ನು ನೆನಪಿಟ್ಟುಕೊಳ್ಳುವುದರಿಂದ ಅಗತ್ಯವಾದ ವಸ್ತುಗಳನ್ನು ಮತ್ತೆ "
-"ಹುಡುಕಲು "
-"ಸುಲಭವಾಗಿರುತ್ತದೆ. ಈ ಅಂಶಗಳನ್ನು ಎಂದಿಗೂ ಸಹ ಜಾಲಬಂಧದ ಮುಖಾಂತರ ಹಂಚಿಕೊಳ್ಳಲಾಗುವುದಿಲ್ಲ."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "ಇತ್ತೀಚಿಗೆ ಬಳಸಲಾದ (_R)"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "ಇತಿಹಾಸವನ್ನು ಉಳಿಸಕೊ (_H)"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "ಇತ್ತೀಚಿನ ಇತಿಹಾಸವನ್ನು ಅಳಿಸು (_e)"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr ""
-"ತೆರೆಯನ್ನು ಲಾಕ್‌ ಮಾಡುವಿಕೆಯು ನೀವು ಆದೆ ಹೋದಾಗ ನಿಮ್ಮ ಗೌಪ್ಯತೆಯನ್ನು ಕಾಪಾಡುತ್ತದೆ."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "ಸ್ವಯಂಚಾಲಿತ ತೆರೆಯ ಲಾಕ್ (_L)"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "ಇಷ್ಟು ಸಮಯ ಖಾಲಿ ಬಿಟ್ಟಲ್ಲಿ ತೆರೆಯನ್ನು ಲಾಕ್ ಮಾಡು (_a)"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "ಸೂಚನೆಗಳನ್ನು ತೋರಿಸು (_ N)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"ನಿಮ್ಮ ಗಣಕವು ಅನಗತ್ಯವಾದ ಸಂವೇದನಾ ಮಾಹಿತಿಯನ್ನು ಇರಿಸಿಕೊಳ್ಳುವುದನ್ನು ತಪ್ಪಿಸಲು ಕಸ "
-"(ಟ್ರ್ಯಾಶ್) "
-"ಮತ್ತು ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊರತಳ್ಳಿ."
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "ಕಸದ ಬುಟ್ಟಿಯನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಖಾಲಿ ಮಾಡು (_T)"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊರತಳ್ಳು (_F)"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "ಇದರ ನಂತರ ಹೊರತಳ್ಳು (_A)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"ನೀವು ಯಾವ ತಂತ್ರಾಂಶವನ್ನು ಬಳಸುತ್ತೀರಿ ಎಂಬುದರ ಬಗೆಗಿನ ಮಾಹಿತಿಯನ್ನು ಕಳುಹಿಸುವುದರಿಂದ "
-"ನಿಮಗೆ "
-"ಖಚಿತವಾದ ಸಲಹೆಗಳನ್ನು ಒದಗಿಸಲು ನಮಗೆ ಸಹಾಯವಾಗುತ್ತದೆ. ಇದು ನಮ್ಮ ತಂತ್ರಾಂಶವನ್ನೂ ಸಹ "
-"ಸುಧಾರಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.\n"
-"\n"
-"ನಾವು ಸಂಗ್ರಹಿಸುವ ಎಲ್ಲಾ ಮಾಹಿತಿಯನ್ನು ಅಜ್ಞಾತವಾಗಿರಿಸಲಾಗುತ್ತದೆ, ಮತ್ತು ನಾವು ಇದನ್ನು "
-"ಮೂರನೆಯ "
-"ವ್ಯಕ್ತಿಗಳೊಂದಿಗೆ ಎಂದಿಗೂ ಹಂಚಿಕೊಳ್ಳುವುದಿಲ್ಲ."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "ತಂತ್ರಾಂಶ ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳನ್ನು ಕಳುಹಿಸು (_S)"
-
-#: ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "ಗೌಪ್ಯತಾ ನಿಯಮ"
-
-#: ../panels/privacy/privacy.ui.h:42
-msgid "_Location Services"
-msgstr "ಸ್ಥಳದ ಸೇವೆಗಳು (_L)"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "ನಿಮ್ಮ ಭೂಸ್ಥಳದ ಕುರಿತು ನಿರ್ಧರಿಸಲು ಬಳಸಲಾಗುತ್ತದೆ"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ಇಂಪೀರಿಯಲ್"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "ಮೆಟ್ರಿಕ್"
-
-#: ../panels/region/cc-format-chooser.c:283
-msgid "No regions found"
-msgstr "ಯಾವುದೆ ಜಾಗಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
-
-#: ../panels/region/cc-input-chooser.c:178
-msgid "No input sources found"
-msgstr "ಯಾವುದೆ ಇನ್‌ಪುಟ್‌ ಮೂಲಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
-
-#: ../panels/region/cc-input-chooser.c:1082
-msgctxt "Input Source"
-msgid "Other"
-msgstr "ಇತರೆ"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:1068
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "ಬದಲಾವಣೆಗಳು ಕಾರ್ಯರೂಪಕ್ಕೆ ಬರಲು ನಿಮ್ಮ ಅಧಿವೇಶನವನ್ನು ಮರಳಿ ಆರಂಭಿಸಬೇಕಾಗುತ್ತದೆ"
-
-#: ../panels/region/cc-region-panel.c:243
-#: ../panels/user-accounts/um-user-panel.c:1072
-msgid "Restart Now"
-msgstr "ಈಗಲೆ ಮರಳಿ ಆರಂಭಿಸು"
-
-#: ../panels/region/cc-region-panel.c:862
-msgid "No input source selected"
-msgstr "ಯಾವುದೆ ಇನ್‌ಪುಟ್ ಮೂಲವನ್ನು ಆಯ್ಕೆ ಮಾಡಲಾಗಿಲ್ಲ"
-
-#: ../panels/region/cc-region-panel.c:1092
-msgid "Sorry"
-msgstr "ಕ್ಷಮಿಸಿ"
-
-#: ../panels/region/cc-region-panel.c:1094
-msgid "Input methods can't be used on the login screen"
-msgstr "ಪ್ರವೇಶ ತೆರೆಯಲ್ಲಿ ಇನ್‌ಪುಟ್ ವಿಧಾನಗಳನ್ನು ಬಳಸಲು ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ"
-
-#: ../panels/region/cc-region-panel.c:1731
-msgid "Login Screen"
-msgstr "ಪ್ರವೇಶ ತೆರೆ"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ವಿನ್ಯಾಸಗಳು"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "ಸ್ಥಳಗಳನ್ನು ಹುಡುಕು"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "ವಿನ್ಯಾಸಗಳು"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "ವಿನ್ಯಾಸಗಳು"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "ಮುನ್ನೋಟ"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "ದಿನಾಂಕಗಳು"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "ಸಮಯಗಳು"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "ದಿನಾಂಕ ಮತ್ತು ಸಮಯ"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "ಸಂಖ್ಯೆಗಳು"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "ಅಳತೆ"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "ಕಾಗದ"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "ನನ್ನ ಖಾತೆ"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "ಭಾಷೆ (_L)"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "ವಿನ್ಯಾಸಗಳು"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "ಪ್ರವೇಶ ತೆರೆ"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "ಪ್ರದೇಶ ಹಾಗು ಭಾಷೆ"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr ""
-"ನಿಮ್ಮ ಪ್ರದರ್ಶನದ ಭಾಷೆ, ವಿನ್ಯಾಸಗಳು, ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸಗಳು ಮತ್ತು ಇನ್‌ಪುಟ್ ಮೂಲಗಳನ್ನು "
-"ಆರಿಸಿ"
+"ನಿಮ್ಮ ಪ್ರದರ್ಶನದ ಭಾಷೆ, ವಿನ್ಯಾಸಗಳು, ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸಗಳು ಮತ್ತು ಇನ್‌ಪುಟ್ ಮೂಲಗಳನ್ನು ಆರಿಸಿ"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ಭಾಷೆ;ವಿನ್ಯಾಸ;ಕೀಲಿಮಣೆ;ಇನ್‌ಪುಟ್;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "ಒಂದು ಇನ್‌ಪುಟ್‌ ಮೂಲವನ್ನು ಸೇರಿಸಿ"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "ಮಾಧ್ಯಮವನ್ನು ಹೇಗೆ ನಿಭಾಯಿಸಬೇಕೆಂದು ಆಯ್ಕೆ ಮಾಡಿ"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "ಇನ್‌ಪುಟ್‌ ಮೂಲದ ಆಯ್ಕೆಗಳು"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD ಆಡಿಯೊ  (_a)"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Use the _same source for all windows"
-msgstr "ಎಲ್ಲಾ ಕಿಟಕಿಗಳಿಗೂ ಒಂದೇ ರೀತಿಯ ಮೂಲವನ್ನು ಬಳಸು (_s)"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD ವೀಡಿಯೊ"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Allow _different sources for each window"
-msgstr "ಪ್ರತಿ ಕಿಟಕಿಗೂ ಸಹ ಪ್ರತ್ಯೇಕ ಮೂಲಗಳನ್ನು ಅನುಮತಿಸು (_d)"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "ಸಂಗೀತ ಚಾಲಕ (_M)"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Keyboard Shortcuts"
-msgstr "ಕೀಲಿಮಣೆ-ಸುಲಭ ಆಯ್ಕೆಗಳು"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "ತಂತ್ರಾಂಶ (_S)"
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Switch to previous source"
-msgstr "ಹಿಂದಿನ ಆಕರಕ್ಕೆ ಬದಲಾಯಿಸು"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "ಇತರೆ ಮಾಧ್ಯಮ (_O)…"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "ಮಾಧ್ಯಮವನ್ನು ತೂರಿಸಿದಾಗ ಕೇಳಬೇಡ ಅಥವ ಪ್ರೊಗ್ರಾಮ್ ಅನ್ನು ಆರಂಭಿಸಬೇಡ (_N)"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Switch to next source"
-msgstr "ಮುಂದಿನ ಆಕರಕ್ಕೆ ಬದಲಾಯಿಸು"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "ಬೇರೆ ಮಾಧ್ಯಮವನ್ನು ಹೇಗೆ ನಿಭಾಯಿಸಬೇಕೆಂದು ಆಯ್ಕೆ ಮಾಡಿ"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "Super+Space"
-msgstr "Super+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "ಕ್ರಿಯೆ (_A):"
 
-#: ../panels/region/input-options.ui.h:10
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "ನೀವು ಈ ಸುಲಭಆಯ್ಕೆಗಳನ್ನು ಕೀಲಿಮಣೆ ಸಿದ್ಧತೆಗಳಲ್ಲಿ ಬದಲಾಯಿಸಬಹುದು"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "ಬಗೆ (_T):"
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Alternative switch to next source"
-msgstr "ಮುಂದಿನ ಮೂಲಕ್ಕೆ ಪರ್ಯಾಯ ಸ್ವಿಚ್"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "ತೆಗೆಯಬಹುದಾದ ಮಾಧ್ಯಮ"
 
-#: ../panels/region/input-options.ui.h:12
-msgid "Left+Right Alt"
-msgstr "ಎಡ+ಬಲ Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "ತೆಗೆಯಬಹುದಾದ ಮಾಧ್ಯಮ"
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "ಇಂಗ್ಲೀಷ್ (ಯುನೈಟೆಡ್ ಕಿಂಗ್‌ಡಮ್)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "ಯುನೈಟೆಡ್ ಕಿಂಗ್‌ಡಮ್"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "ಆಯ್ಕೆಗಳು"
-
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
-msgstr "ವ್ಯವಸ್ಥೆಗೆ ಪ್ರವೇಶಿಸುವಾಗ ಎಲ್ಲಾ ಬಳಕೆದಾರರಿಂದ ಬಳಸಲಾಗುವ ಪ್ರವೇಶದ ಸಿದ್ಧತೆಗಳು"
-
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
-msgid "Places"
-msgstr "ಸ್ಥಳಗಳು"
-
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
-msgid "Bookmarks"
-msgstr "ಪುಟಗುರುತುಗಳು"
-
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
-msgstr "ಇತರೆ"
-
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "ಸ್ಥಳವನ್ನು ಆರಿಸಿ"
-
-#: ../panels/search/cc-search-locations-dialog.c:682
-msgid "_OK"
-msgstr "ಸರಿ (_O)"
-
-#: ../panels/search/cc-search-panel.c:177
-msgid "No applications found"
-msgstr "ಯಾವುದೆ ಅನ್ವಯಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "ಹುಡುಕು"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Control which applications show search results in the Activities Overview"
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"ಯಾವ ಅನ್ವಯಗಳು ಚಟುವಟಿಕೆಗಳ ಅವಲೋಕನದಲ್ಲಿ ಹುಡುಕು ಫಲಿತಾಂಶವನ್ನು ತೋರಿಸುತ್ತದೆ "
-"ಎನ್ನುವುದನ್ನು "
-"ನಿಯಂತ್ರಿಸಿ"
+"ಸಾಧನ;ವ್ಯವಸ್ಥೆ;ಮಾಹಿತಿ;ಮೆಮೊರಿ;ಸಂಸ್ಕಾರಕ;ಆವೃತ್ತಿ;ಪೂರ್ವನಿಯೋಜಿತ;ಅನ್ವಯ;ಇಚ್ಛೆಯ;cd;dvd;usb;"
+"ಆಡಿಯೊ;ವೀಡಿಯೊ;ಡಿಸ್ಕ್‍;ತೆಗೆಯಬಹುದಾದ;ಮಾಧ್ಯಮ;ಸ್ವಯಂಚಾಲನೆ;"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
-msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "ಶೋಧಿಸು;ಹುಡುಕು;ಸೂಚಿ;ಅಡಗಿಸು;ಗೌಪ್ಯತೆ;ಫಲಿತಾಂಶಗಳು;"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "ತೆರೆ ಲಾಕ್"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "ಖಾಲಿ ತೆರೆ (_B)"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ತೆರೆಯ ಲಾಕ್ (_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ತೆರೆಯ ಲಾಕ್ (_L)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ವಿವರಗಳನ್ನು ತೋರಿಸು"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "ಲಾಕ್ ತೆರೆ"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "ಗೌಪ್ಯತೆ"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "ತೆರೆ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "ಧ್ವನಿ ಸಿದ್ಧತೆಗಳು"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "ಸ್ಥಳಗಳನ್ನು ಹುಡುಕು"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "ಮೇಲೆ ಜರುಗಿಸು"
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
 
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "ಕೆಳಗೆ ಜರುಗಿಸು"
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
+msgid "Places"
+msgstr "ಸ್ಥಳಗಳು"
 
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "ಆದ್ಯತೆಗಳು"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
+msgid "Bookmarks"
+msgstr "ಪುಟಗುರುತುಗಳು"
 
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "ಆನ್"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "ಇತರೆ"
 
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "ಆಫ್"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "ಸ್ಥಳ"
 
-#: ../panels/sharing/cc-sharing-panel.c:304
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "ಸಕ್ರಿಯಗೊಂಡ"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "ಅನ್ವಯಗಳು"
 
-#: ../panels/sharing/cc-sharing-panel.c:307
-msgctxt "service is active"
-msgid "Active"
-msgstr "ಸಕ್ರಿಯ"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "ಒಂದು ಕಡತಕೋಶವನ್ನು ಆರಿಸು"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "ಪ್ರತಿಮಾಡು"
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "ಸ್ಥಳಗಳನ್ನು ಹುಡುಕು"
 
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"ಯಾವ ಅನ್ವಯಗಳು ಚಟುವಟಿಕೆಗಳ ಅವಲೋಕನದಲ್ಲಿ ಹುಡುಕು ಫಲಿತಾಂಶವನ್ನು ತೋರಿಸುತ್ತದೆ ಎನ್ನುವುದನ್ನು "
+"ನಿಯಂತ್ರಿಸಿ"
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "ಶೋಧಿಸು;ಹುಡುಕು;ಸೂಚಿ;ಅಡಗಿಸು;ಗೌಪ್ಯತೆ;ಫಲಿತಾಂಶಗಳು;"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "ಜಾಲಬಂಧಗಳು"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "ಹಂಚಿಕೆ"
 
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
+msgstr "ಗಣಕದ ಹೆಸರು"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "ವೈಯಕ್ತಿಕ ಕಡತ ವಿನಿಮಯ"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "ದೂರಸ್ಥ ನೋಟ"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "ಮಾಧ್ಯಮ ಹಂಚಿಕೊಳ್ಳುವಿಕೆ"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "ದೂರಸ್ಥ ಪ್ರವೇಶ"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "ಹಂಚಿಕೆ"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "ಗುಪ್ತಪದದ ಅಗತ್ಯವಿದೆ"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "ದೂರಸ್ಥ ಪ್ರವೇಶ"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "ದೂರಸ್ಥ ನೋಟ"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "ದೂರಸ್ಥ ಪ್ರವೇಶವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ ಅಥವ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "ದೂರಸ್ಥ ನಿಯಂತ್ರಣವನ್ನು ಅನುಮತಿಸು"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "ಸಂಪರ್ಕಗೊಂಡಿಲ್ಲ"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "ಪ್ರತಿಮಾಡು"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "ವಿಳಾಸವನ್ನು ಅಳಿಸು"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "ದೃಢೀಕರಣ (_t)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ಬಳಕೆದಾರಹೆಸರು"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "ಬೆರಳಗುರುತುಗಳನ್ನು ದಾಖಲಿಸುವಿಕೆ"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "ಮಾಧ್ಯಮ ಹಂಚಿಕೊಳ್ಳುವಿಕೆ"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "ಜಾಲಬಂಧದ ಮುಖಾಂತರ ಸಂಗೀತ, ಚಿತ್ರಗಳು ಮತ್ತು ವೀಡಿಯೊಗಳನ್ನು ಹಂಚಿಕೊಳ್ಳಿ."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "ಕಡತಕೋಶಗಳು"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
 msgstr "ನೀವು ಬೇರೆಯವರೊಂದಿಗೆ ಏನನ್ನು ಹಂಚಿಕೊಳ್ಳಲು ಬಯಸುವಿರಿ ಎನ್ನುವುದನ್ನು ನಿಯಂತ್ರಿಸಿ"
 
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 msgstr ""
 "ಹಂಚು;ಹಂಚಿಕೆ;ssh;ಆತಿಥೇಯ;ಹೆಸರು;ದೂರಸ್ಥ;ಗಣಕತೆರೆ;ಬ್ಲೂಟೂತ್;obex;ಮಾಧ್ಯಮ;ಆಡಿಯೊ;ವೀಡಿಯೊ;"
 "ಚಿತ್ರಗಳು;ಫೋಟೊಗಳು;ಚಲನಚಿತ್ರಗಳು;ಪೂರೈಕೆಗಣಕ;ನಿರೂಪಕ;"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
 msgstr "ದೂರಸ್ಥ ಪ್ರವೇಶವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ ಅಥವ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
+msgstr "ದೂರಸ್ಥ ಪ್ರವೇಶವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಅಥವ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲು ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "ಹಂಚಿಕೆ"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
-"ದೂರಸ್ಥ ಪ್ರವೇಶವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಅಥವ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲು ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
 
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:303
-msgid "No networks selected for sharing"
-msgstr "ಹಂಚಿಕೊಳ್ಳಲು ಯಾವುದೆ ಜಾಲಬಂಧಗಳನ್ನು ಆರಿಸಲಾಗಿಲ್ಲ"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
-msgid "Networks"
-msgstr "ಜಾಲಬಂಧಗಳು"
-
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "ಬ್ಲೂಟೂತ್ ಹಂಚಿಕೆ"
-
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
 msgstr ""
-"ಬ್ಲೂಟೂತ್ ಹಂಚಿಕೆಯು ಕಡತಗಳನ್ನು ಇತರೆ ಬ್ಲೂಟೂತ್ ಸಕ್ರಿಯಗೊಳಿಸಲಾದ ಸಾಧನಗಳೊಂದಿಗೆ "
-"ಹಂಚಿಕೊಳ್ಳಲು "
-"ಅನುವು ಮಾಡಿಕೊಡುತ್ತದೆ"
 
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "ನಂಬಿಕಸ್ತ ಸಾಧನಗಳಿಂದ ಮಾತ್ರ ಸ್ವೀಕರಿಸು"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "ಸಮತೋಲನ (_B):"
 
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "ಸ್ವೀಕರಿಸಲಾದ ಕಡತಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಕಡತಕೋಶಕ್ಕೆ ಉಳಿಸು"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "ಮಬ್ಬುಗೊಳಿಸು (_F):"
 
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
-msgstr "ಗಣಕದ ಹೆಸರು"
-
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
-msgstr "ವೈಯಕ್ತಿಕ ಕಡತ ವಿನಿಮಯ"
-
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "ತೆರೆ ಹಂಚಿಕೆ"
-
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
-msgstr "ಮಾಧ್ಯಮ ಹಂಚಿಕೊಳ್ಳುವಿಕೆ"
-
-#: ../panels/sharing/sharing.ui.h:9
-msgid "Remote Login"
-msgstr "ದೂರಸ್ಥ ಪ್ರವೇಶ"
-
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "ಯಾವುದೆ ಜಾಲಬಂಧ ಸೇವೆಯು ಇರದ ಕಾರಣ ಕೆಲವು ಸೇವೆಗಳು ನಿಷ್ಕ್ರಿಯವಾಗಿರುತ್ತವೆ."
-
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
-msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr ""
-"ವೈಯಕ್ತಿಕ ಕಡತ ಹಂಚಿಕೆಯನ್ನು ಬಳಸಿಕೊಂಡು ನೀವು ಸಾರ್ವಜನಿಕ ಕಡತಕೋಶವನ್ನು ನಿಮ್ಮ ಪ್ರಸಕ್ತ "
-"ಜಾಲಬಂಧದಲ್ಲಿರುವವರೊಂದಿಗೆ ಹಂಚಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಿರುತ್ತದೆ: <a href=\"dav://%s\">dav://"
-"%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr "ಗುಪ್ತಪದದ ಅಗತ್ಯವಿದೆ"
-
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"ಈ ಸೆಕ್ಯೂರ್ ಶೆಲ್ ಆದೇಶವನ್ನು ಬಳಸಿಕೊಂಡು ದೂರಸ್ಥ ಬಳಕೆದಾರರು ಸಂಪರ್ಕಸಾಧಿಸಲು ಅನುಮತಿಸಿ:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"ಇದಕ್ಕೆ ಸಂಪರ್ಕ ಸಾಧಿಸುವ ಮುಖಾಂತರ ದೂರಸ್ಥ ಬಳಕೆದಾರರು ನಿಮ್ಮ ತೆರೆಯನ್ನು ನೋಡಲು ಅಥವ "
-"ನಿಯಂತ್ರಿಸಲು ಅನುಮತಿಸಿ: <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Allow Remote Control"
-msgstr "ದೂರಸ್ಥ ನಿಯಂತ್ರಣವನ್ನು ಅನುಮತಿಸು"
-
-#: ../panels/sharing/sharing.ui.h:21
-msgid "Password:"
-msgstr "ಗುಪ್ತಪದ:"
-
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "ಗುಪ್ತಪದವನ್ನು ತೋರಿಸು"
-
-#: ../panels/sharing/sharing.ui.h:23
-msgid "Access Options"
-msgstr "ನಿಲುಕು ಆಯ್ಕೆಗಳು"
-
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "ಹೊಸ ಸಂಪರ್ಕಗಳು ನಿಲುಕಿಗಾಗಿ ಕೇಳಬೇಕು"
-
-#: ../panels/sharing/sharing.ui.h:25
-msgid "Require a password"
-msgstr "ಒಂದು ಗುಪ್ತಪದದ ಅಗತ್ಯವಿದೆ"
-
-#: ../panels/sharing/sharing.ui.h:26
-msgid "Share music, photos and videos over the network."
-msgstr "ಜಾಲಬಂಧದ ಮುಖಾಂತರ ಸಂಗೀತ, ಚಿತ್ರಗಳು ಮತ್ತು ವೀಡಿಯೊಗಳನ್ನು ಹಂಚಿಕೊಳ್ಳಿ."
-
-#: ../panels/sharing/sharing.ui.h:27
-msgid "Folders"
-msgstr "ಕಡತಕೋಶಗಳು"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "ಧ್ವನಿ"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr ""
-"ಧ್ವನಿಯ ಪ್ರಮಾಣಗಳು, ಇನ್‌ಪುಟ್‌ಗಳು, ಔಟ್‌ಪುಟ್‌ಗಳು ಮತ್ತು ಎಚ್ಚರಿಕೆ ಸದ್ದುಗಳನ್ನು "
-"ಬದಲಾಯಿಸಿ"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "ಕಾರ್ಡ್;ಧ್ವನಿವರ್ಧಕ;ಧ್ವನಿಪ್ರಮಾಣ;ಮಬ್ಬು;ಸಮತೋಲನ;ಬ್ಲೂಟೂತ್;ಹೆಡ್‌ಸೆಟ್;ಆಡಿಯೊ;"
-
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "ಬೊಗಳು"
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "ತೊಟ್ಟಿಕ್ಕು"
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "ಗಾಜು"
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "ಸೋನಾರ್"
-
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "ಎಡ"
-
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "ಬಲ"
-
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "ಹಿಂಬದಿ"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "ಎದುರು"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "ಕನಿಷ್ಟ"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "ಗರಿಷ್ಟ"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "ಸಮತೋಲನ (_B):"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "ಮಬ್ಬುಗೊಳಿಸು (_F):"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "ಸಬ್‌ವೂಫರ್ (_S):"
-
-#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:615
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "ವರ್ಧಿಸದ"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "ಪ್ರೊಫೈಲ್ (_P):"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u ಔಟ್‌ಪುಟ್"
-msgstr[1] "%u ಔಟ್‌ಪುಟ್‌ಗಳು"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u ಇನ್‌ಪುಟ್"
-msgstr[1] "%u ಇನ್‌ಪುಟ್‌ಗಳು"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "ವ್ಯವಸ್ಥೆಯ ಧ್ವನಿಗಳು"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "ಸ್ಪೀಕರುಗಳನ್ನು ಪರೀಕ್ಷಿಸು (_T)"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "ಎಚ್ಚರಿಕೆ ಧ್ವನಿ ಪ್ರಮಾಣ (_A):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "ಉತ್ತುಂಗದ ಪತ್ತೆ"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "ಧ್ವನಿ ಮೂಕ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1491
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "ಹೆಸರು"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1510
-msgid "Device"
-msgstr "ಸಾಧನ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1573
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s ಗಾಗಿನ ಸ್ಪೀಕರುಗಳ ಪರೀಕ್ಷೆ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1629
-msgid "_Output volume:"
-msgstr "ಔಟ್‌ಪುಟ್ ಧ್ವನಿ ಪ್ರಮಾಣ (_O):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1643
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "ಔಟ್‌ಪುಟ್"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1648
-msgid "C_hoose a device for sound output:"
-msgstr "ಧ್ವನಿಯ ಇನ್‌ಪುಟ್‌ಗಾಗಿ ಒಂದು ಸಾಧನವನ್ನು ಆರಿಸಿ (_h):"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "ಔಟ್‌ಪುಟ್ ಧ್ವನಿ ಪ್ರಮಾಣ (_O):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1670
-msgid "Settings for the selected device:"
-msgstr "ಆಯ್ಕೆ ಮಾಡಿದ ಸಾಧನದ ಸಿದ್ಧತೆಗಳು:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1681
-msgid "Input"
-msgstr "ಇನ್‌ಪುಟ್"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1688
-msgid "_Input volume:"
-msgstr "ಇನ್‌ಪುಟ್‌ ಧ್ವನಿ ಪ್ರಮಾಣ (_I):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1709
-msgid "Input level:"
-msgstr "ಇನ್‌ಪುಟ್‌ ಹಂತ:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1737
-msgid "C_hoose a device for sound input:"
-msgstr "ಧ್ವನಿಯ ಔಟ್‌ಪುಟ್‌ಗಾಗಿ ಒಂದು ಸಾಧನವನ್ನು ಆರಿಸಿ (_h):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1761
-msgid "Sound Effects"
-msgstr "ಧ್ವನಿ ಪರಿಣಾಮಗಳು"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1768
-msgid "_Alert volume:"
-msgstr "ಎಚ್ಚರಿಕೆ ಧ್ವನಿ ಪ್ರಮಾಣ (_A):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1781
-msgid "Applications"
-msgstr "ಅನ್ವಯಗಳು"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1785
-msgid "No application is currently playing or recording audio."
-msgstr "ಯಾವುದೆ ಅನ್ವಯವು ಪ್ರಸ್ತುತ ಧ್ವನಿಯನ್ನು ಚಲಾಯಿಸುತ್ತಿಲ್ಲ."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "ಒಳನಿರ್ಮಿತ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "ಧ್ವನಿಯ ಆದ್ಯತೆಗಳು"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "ಘಟನೆ ಶಬ್ಧವನ್ನು ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "ಪೂರ್ವನಿಯೋಜಿತ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "ಪರಿಸರವಿನ್ಯಾಸದಿಂದ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:770
-msgid "C_hoose an alert sound:"
-msgstr "ಒಂದು ಎಚ್ಚರಿಕೆ ಧ್ವನಿಯನ್ನು ಆರಿಸಿ (_h):"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "ನಿಲ್ಲಿಸು"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "ಪರೀಕ್ಷೆ"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "ಸ್ವಯಂಸಂರಚನಾ URL (_C)"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "ಸಬ್‌ವೂಫರ್"
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "ಇಚ್ಛೆಯ"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "ಇನ್‌ಪುಟ್"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "ನೋಡಲು, ಕೇಳಲು, ಬರೆಯಲು, ತೋರಿಸಲು ಮತ್ತು ಕ್ಲಿಕ್ ಮಾಡಲು ಸುಲಭಗೊಳಿಸು"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "ಇನ್‌ಪುಟ್‌ ಹಂತ:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "ಧ್ವನಿ ಹೆಚ್ಚು"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "ಎಚ್ಚರಿಕೆ ಧ್ವನಿ ಪ್ರಮಾಣ (_A):"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ಧ್ವನಿ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ಧ್ವನಿಯ ಪ್ರಮಾಣಗಳು, ಇನ್‌ಪುಟ್‌ಗಳು, ಔಟ್‌ಪುಟ್‌ಗಳು ಮತ್ತು ಎಚ್ಚರಿಕೆ ಸದ್ದುಗಳನ್ನು ಬದಲಾಯಿಸಿ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "ಕಾರ್ಡ್;ಧ್ವನಿವರ್ಧಕ;ಧ್ವನಿಪ್ರಮಾಣ;ಮಬ್ಬು;ಸಮತೋಲನ;ಬ್ಲೂಟೂತ್;ಹೆಡ್‌ಸೆಟ್;ಆಡಿಯೊ;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "ಸೂಚನೆಗಳು"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "ಹೆಸರು (_N):"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"ಕೀಲಿಮಣೆ;ಮೌಸ್;a11y;ನಿಲುಕು;ಕಾಂಟ್ರಾಸ್ಟ್;ಗಾತ್ರಬದಲಾವಣೆ;ತೆರೆ "
-"ಓದುಗ;ಪಠ್ಯ;ಅಕ್ಷರಶೈಲಿ;ಗಾತ್ರ;"
-"AccessX;ಸ್ಟಿಕಿ;ಕೀಲಿಗಳು;ನಿಧಾನಗತಿ;ಪುಟಿಯುವ;ಮೌಸ್‌;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "ಯಾವಾಗಲೂ ಜಾಗತಿಕ ನಿಲುಕಣೆ ಪರಿವಿಡಿಯನ್ನು ತೋರಿಸು (_A)"
-
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "ನೋಡುವಿಕೆ"
-
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "ಅತಿಹೆಚ್ಚು ಕಾಂಟ್ರಾಸ್ಟ್ (_H)"
-
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "ದೊಡ್ಡ ಪಠ್ಯ (_L)"
-
-#: ../panels/universal-access/uap.ui.h:5
-msgid "_Zoom"
-msgstr "ಹಿಗ್ಗಿಸು (_Z)"
-
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr "ತೆರೆ ಓದುಗ (_R)"
-
-#: ../panels/universal-access/uap.ui.h:8
-msgid "_Sound Keys"
-msgstr "ಧ್ವನಿ ಕೀಲಿಗಳು (_S)"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "ಆಲಿಸುವಿಕೆ"
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
-msgstr "ವೀಶುವಲ್ ಎಚ್ಚರಿಕೆಗಳು (_V)"
-
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Screen _Keyboard"
-msgstr "ತೆರೆ ಮೇಲಿನ ಕೀಲಿಮಣೆ (_K)"
-
-#: ../panels/universal-access/uap.ui.h:13
-msgid "_Typing Assist (AccessX)"
-msgstr "ಟೈಪಿಂಗ್ ಸಹಾಯ (_T) (AccessX)"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Pointing & Clicking"
-msgstr "ತೆರೆಸೂಚಕವನ್ನು ಇರಿಸುವಿಕೆ ಮತ್ತು ಕ್ಲಿಕ್ ಮಾಡುವಿಕೆ"
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "_Mouse Keys"
-msgstr "ಮೌಸ್ ಕೀಲಿಗಳು (_M)"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "ಕ್ಲಿಕ್ ಸಹಾಯ (_C)"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "ತೆರೆ ಓದುಗ"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
 msgstr ""
-"ನೀವು ಗಮನವನ್ನು ಬದಲಾಯಿಸಿದಂತೆಲ್ಲಾ ತೆರೆಯ ಓದುಗವು ತೋರಿಸಲಾಗುತ್ತಿರುವ ಪಠ್ಯವನ್ನು "
-"ಓದುತ್ತದೆ."
 
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Screen Reader"
-msgstr "ತೆರೆ ಓದುಗ (_S)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ಸಂಪರ್ಕ (_C)"
 
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Sound Keys"
-msgstr "ಧ್ವನಿ ಕೀಲಿಗಳು"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕು"
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "Num Lock ಅಥವ Caps Lock ಅನ್ನು ಆನ್ ಮಾಡಿದಾಗ ಬೀಪ್ ಶಬ್ಧ ಮಾಡು."
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "ದೃಷ್ಟಿಗೋಚರ ಎಚ್ಚರಿಕೆಗಳು"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "ಪ್ರಾಯೋಗಿಕ ಫ್ಲ್ಯಾಶ್ (_T)"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "ಒಂದು ಎಚ್ಚರಿಕೆಯ ಸದ್ದನ್ನು ಮಾಡಿದಾಗ ಒಂದು ಸೂಚನೆಯನ್ನು ತೋರಿಸು."
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Flash the _window title"
-msgstr "ಕಿಟಕಿ ಶೀರ್ಷಿಕೆ ಪಟ್ಟಿಯನ್ನು ಹೊಳೆಯುವಂತೆ ಮಾಡು (_w)"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Flash the entire _screen"
-msgstr "ಸಂಪೂರ್ಣ ತೆರೆಯನ್ನು ಹೊಳೆಯುವಂತೆ ಮಾಡಿ (_s)"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Typing Assist"
-msgstr "ಟೈಪಿಂಗ್ ಸಹಾಯ"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "_Sticky Keys"
-msgstr "ಸ್ಟಿಕಿ ಕೀಲಿಗಳು (_S)"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "ಮಾರ್ಪಡಕ ಕೀಲಿಗಳ ಒಂದು ಸರಣಿಯನ್ನು ಕೀಲಿ ಸಂಯೋಜನೆಯಾಗಿ ಪರಿಗಣಿಸುತ್ತದೆ"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "ಎರಡು ಕೀಲಿಗಳನ್ನು ಒಟ್ಟಿಗೆ ಒತ್ತಿದಲ್ಲಿ ಅಶಕ್ತಗೊಳಿಸು (_D)s"
-
-#: ../panels/universal-access/uap.ui.h:31
-#| msgid "Beep when a _modifer key is pressed"
-msgid "Beep when a _modifier key is pressed"
-msgstr "ಮಾರ್ಪಡಕ ಕೀಲಿಯನ್ನು ಒತ್ತಿದಾಗ ಬೀಪ್ ಶಬ್ಧ ಮಾಡು (_m)"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "S_low Keys"
-msgstr "ನಿಧಾನಗತಿಯ ಕೀಲಿಗಳು (_l)"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
 msgstr ""
-"ಕೀಲಿಯನ್ನು ಯಾವಾಗ ಒತ್ತಲಾಗುತ್ತದೆ ಮತ್ತು ಯಾವಾಗ ಅಂಗೀಕರಿಸಲ್ಪಡುತ್ತದೆ ಎನ್ನುವುದರ ನಡುವೆ "
-"ಒಂದು "
-"ವಿಳಂಬವನ್ನು ಸೇರಿಸುತ್ತದೆ"
 
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "ಅಂಗೀಕರಿಸಬಹುದಾದ ವಿಳಂಬ (_c):"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s ಡೊಮೈನ್‌ಗೆ ಸಂಪರ್ಕಿತಗೊಳಿಸಲಾಗಿಲ್ಲ: %s"
 
-#: ../panels/universal-access/uap.ui.h:35
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "ಚಿಕ್ಕದಾದ"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "ಜಾಗತಿಕ ನಿಲುಕಣೆ"
 
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "ನಿಧಾನಗತಿಯ ಕೀಲಿಗಳ ನಮೂದಿಸುವ ವಿಳಂಬ"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:37
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "ಉದ್ದವಾದ"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "ಸಾಧನವನ್ನು ಸೇರಿಸು"
 
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Beep when a key is pr_essed"
-msgstr "ಒಂದು ಕೀಲಿಯನ್ನು ಒತ್ತಿದಾಗ ಬೀಪ್ ಶಬ್ಧ ಮಾಡು (_e)"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Beep when a key is _accepted"
-msgstr "ಒಂದು ಕೀಲಿಯು ಅಂಗೀಕರಿಸಿದಾಗ ಬೀಪ್ ಸದ್ದನ್ನು ಮಾಡು (_a)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "ಒಂದು ಕೀಲಿಯು ತಿರಸ್ಕರಿಸಲ್ಪಟ್ಟಾಗ ಬೀಪ್ ಸದ್ದನ್ನು ಮಾಡು (_r)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:41
-msgid "_Bounce Keys"
-msgstr "ಪುಟಿಯುವ ಕೀಲಿಗಳು (_B)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "ವೇಗವಾದ ನಕಲಿ ಕೀಲಿಒತ್ತುವಿಕೆಗಳನ್ನು ಕಡೆಗಣಿಸಿ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "ತೆರೆಸೂಚಕದ ಮಿನುಗುವಿಕೆ"
 
-#: ../panels/universal-access/uap.ui.h:43
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "ಚಿಕ್ಕದಾದ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "ತೆರೆಸೂಚಕವು ಪಠ್ಯ ಕ್ಷೇತ್ರಗಳಲ್ಲಿ ಮಿನುಗುತ್ತದೆ (_b)"
 
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "ಪುಟಿಕೆ ಕೀಲಿಗಳನ್ನು ನಮೂದಿಸುವಲ್ಲಿ ವಿಳಂಬ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "ವೇಗ (_S):"
 
-#: ../panels/universal-access/uap.ui.h:45
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "ಉದ್ದವಾದ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "ತೆರೆಸೂಚಕದ ಮಿನುಗುವ ವೇಗ"
 
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Enable by Keyboard"
-msgstr "ಕೀಲಿಮಣೆಯಿಂದ ಸಕ್ರಿಯಗೊಳಿಸು (_E)"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "ತೆರೆಸೂಚಕದ ಮಿನುಗುವ ವೇಗ"
 
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "ಕೀಲಿಮಣೆಯಿಂದ ನಿಲುಕಣಾ ಸವಲತ್ತುಗಳನ್ನು ಆನ್ ಮತ್ತು ಆಫ್ ಮಾಡಿ"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "ಕ್ಲಿಕ್ ಸಹಾಯಕ"
 
-#: ../panels/universal-access/uap.ui.h:49
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "ಸಿಮುಲೇಟ್ ಆದ ದ್ವಿತೀಯ ಕ್ಲಿಕ್ (_S)"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "ಪ್ರಾಥಮಿಕ ಗುಂಡಿಯನ್ನು ಒತ್ತಿ ಹಿಡಿಯುವ ಮೂಲಕ ಅಪ್ರಮುಖ ಕ್ಲಿಕ್‌ ಅನ್ನು ಆರಂಭಿಸಿ"
 
-#: ../panels/universal-access/uap.ui.h:51
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "ಅಂಗೀಕರಿಸಬಹುದಾದ ವಿಳಂಬ (_c):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "ಚಿಕ್ಕದಾದ"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "ಅಪ್ರಮುಖ ಕ್ಲಿಕ್ ವಿಳಂಬ"
 
-#: ../panels/universal-access/uap.ui.h:53
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "ಉದ್ದವಾದ"
 
-#: ../panels/universal-access/uap.ui.h:54
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "ಸುಳಿದಾಡಿಕೆಯ ಕ್ಲಿಕ್ (_H)"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "ಸೂಚಕವನ್ನು ಸುಳಿದಾಡಿಸಿದಾಗ ಕ್ಲಿಕ್‌ ಆಗುವಂತೆ ಮಾಡಿ"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "ವಿಳಂಬ (_e):"
 
-#: ../panels/universal-access/uap.ui.h:57
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "ಚಿಕ್ಕದಾದ"
 
-#: ../panels/universal-access/uap.ui.h:58
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "ಉದ್ದವಾದ"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "ಚಲನೆಯ ಮಿತಿ (_T):"
 
-#: ../panels/universal-access/uap.ui.h:60
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "ಅತಿಚಿಕ್ಕ"
 
-#: ../panels/universal-access/uap.ui.h:61
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "ಅತಿದೊಡ್ಡ"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "ಪುನರಾವರ್ತನಾ ಕೀಲಿಗಳು"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "ಕೀಲಿಯನ್ನು ಒತ್ತಿ ಹಿಡಿದಾಗ ಕೀಲಿಗಳ ಒತ್ತುವಿಕೆಯನ್ನು ಪುನರಾವರ್ತಿಸು (_r)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "ಪುನರಾವರ್ತನೆಯ ಕೀಲಿಗಳ ವೇಗ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "ಪುನರಾವರ್ತನೆಯ ಕೀಲಿಗಳ ವೇಗ"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "ಟೈಪಿಂಗ್ ಸಹಾಯ"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "ಸ್ಟಿಕಿ ಕೀಲಿಗಳು (_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "ಮಾರ್ಪಡಕ ಕೀಲಿಗಳ ಒಂದು ಸರಣಿಯನ್ನು ಕೀಲಿ ಸಂಯೋಜನೆಯಾಗಿ ಪರಿಗಣಿಸುತ್ತದೆ"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "ಎರಡು ಕೀಲಿಗಳನ್ನು ಒಟ್ಟಿಗೆ ಒತ್ತಿದಲ್ಲಿ ಅಶಕ್ತಗೊಳಿಸು (_D)s"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "ಮಾರ್ಪಡಕ ಕೀಲಿಯನ್ನು ಒತ್ತಿದಾಗ ಬೀಪ್ ಶಬ್ಧ ಮಾಡು (_m)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "ನಿಧಾನಗತಿಯ ಕೀಲಿಗಳು (_l)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"ಕೀಲಿಯನ್ನು ಯಾವಾಗ ಒತ್ತಲಾಗುತ್ತದೆ ಮತ್ತು ಯಾವಾಗ ಅಂಗೀಕರಿಸಲ್ಪಡುತ್ತದೆ ಎನ್ನುವುದರ ನಡುವೆ ಒಂದು "
+"ವಿಳಂಬವನ್ನು ಸೇರಿಸುತ್ತದೆ"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
-msgstr "ಕಿರು"
+msgstr "ಚಿಕ್ಕದಾದ"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "ತೆರೆಯ ¼"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "ನಿಧಾನಗತಿಯ ಕೀಲಿಗಳ ನಮೂದಿಸುವ ವಿಳಂಬ"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "ತೆರೆಯ ½"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "ತೆರೆಯ ¾"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
-msgstr "ಉದ್ದ"
+msgstr "ಉದ್ದವಾದ"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "ಒಂದು ಕೀಲಿಯನ್ನು ಒತ್ತಿದಾಗ ಬೀಪ್ ಶಬ್ಧ ಮಾಡು (_e)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "ಒಂದು ಕೀಲಿಯು ಅಂಗೀಕರಿಸಿದಾಗ ಬೀಪ್ ಸದ್ದನ್ನು ಮಾಡು (_a)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "ಒಂದು ಕೀಲಿಯು ತಿರಸ್ಕರಿಸಲ್ಪಟ್ಟಾಗ ಬೀಪ್ ಸದ್ದನ್ನು ಮಾಡು (_r)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "ಪುಟಿಯುವ ಕೀಲಿಗಳು (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "ವೇಗವಾದ ನಕಲಿ ಕೀಲಿಒತ್ತುವಿಕೆಗಳನ್ನು ಕಡೆಗಣಿಸಿ"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "ಚಿಕ್ಕದಾದ"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "ಪುಟಿಕೆ ಕೀಲಿಗಳನ್ನು ನಮೂದಿಸುವಲ್ಲಿ ವಿಳಂಬ"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "ಉದ್ದವಾದ"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "ಕೀಲಿಮಣೆಯಿಂದ ಸಕ್ರಿಯಗೊಳಿಸು (_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "ಕೀಲಿಮಣೆಯಿಂದ ನಿಲುಕಣಾ ಸವಲತ್ತುಗಳನ್ನು ಆನ್ ಮತ್ತು ಆಫ್ ಮಾಡಿ"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "ಯಾವಾಗಲೂ ಜಾಗತಿಕ ನಿಲುಕಣೆ ಪರಿವಿಡಿಯನ್ನು ತೋರಿಸು (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "ನೋಡುವಿಕೆ"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "ಅತಿಹೆಚ್ಚು ಕಾಂಟ್ರಾಸ್ಟ್ (_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "ದೊಡ್ಡ ಪಠ್ಯ (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "ತೆರೆ ಓದುಗ (_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"ನೀವು ಗಮನವನ್ನು ಬದಲಾಯಿಸಿದಂತೆಲ್ಲಾ ತೆರೆಯ ಓದುಗವು ತೋರಿಸಲಾಗುತ್ತಿರುವ ಪಠ್ಯವನ್ನು ಓದುತ್ತದೆ."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "ಧ್ವನಿ ಕೀಲಿಗಳು (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num Lock ಅಥವ Caps Lock ಅನ್ನು ಆನ್ ಮಾಡಿದಾಗ ಬೀಪ್ ಶಬ್ಧ ಮಾಡು."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "ತೆರೆಸೂಚಕದ ಮಿನುಗುವ ವೇಗ"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "ಹಿಗ್ಗಿಸು (_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "ಆಲಿಸುವಿಕೆ"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "ವೀಶುವಲ್ ಎಚ್ಚರಿಕೆಗಳು (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "ತೆರೆ ಮೇಲಿನ ಕೀಲಿಮಣೆ (_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "ಪುನರಾವರ್ತನಾ ಕೀಲಿಗಳು"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "ತೆರೆಸೂಚಕದ ಮಿನುಗುವಿಕೆ"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "ಟೈಪಿಂಗ್ ಸಹಾಯ (_T) (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "ತೆರೆಸೂಚಕವನ್ನು ಇರಿಸುವಿಕೆ ಮತ್ತು ಕ್ಲಿಕ್ ಮಾಡುವಿಕೆ"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "ಮೌಸ್ ಕೀಲಿಗಳು (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "ಮುದ್ರಕವನ್ನು ತೆಗೆದುಹಾಕಿ"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "ಕ್ಲಿಕ್ ಸಹಾಯ (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "ಜೋಡಿ ಕ್ಲಿಕ್ (_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "ಜೋಡಿ ಕ್ಲಿಕ್ (_D)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "ದೃಷ್ಟಿಗೋಚರ ಎಚ್ಚರಿಕೆಗಳು"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "ಪ್ರಾಯೋಗಿಕ ಫ್ಲ್ಯಾಶ್ (_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ಒಂದು ಎಚ್ಚರಿಕೆಯ ಸದ್ದನ್ನು ಮಾಡಿದಾಗ ಒಂದು ಸೂಚನೆಯನ್ನು ತೋರಿಸು."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "ಸಂಪೂರ್ಣ ತೆರೆಯನ್ನು ಹೊಳೆಯುವಂತೆ ಮಾಡಿ (_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "ಸಂಪೂರ್ಣ ತೆರೆಯನ್ನು ಹೊಳೆಯುವಂತೆ ಮಾಡಿ (_s)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "ಪೂರ್ಣ ತೆರೆ"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "ಮೇಲಿನ ಅರ್ಧ"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "ಕೆಳಗಿನ ಅರ್ಧ"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "ಎಡ ಅರ್ಧ"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "ಬಲ ಅರ್ಧ"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "ಹಿಗ್ಗಿಸುವ ಆಯ್ಕೆಗಳು"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "ಹಿಗ್ಗಿಸು"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "ಮ್ಯಾಗ್ನಿಫಿಕೇಶನ್:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "ಮೌಸ್‌ನ ಸೂಚಕವನ್ನು ಅನುಸರಿಸು"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "ತೆರೆಯ ಭಾಗ:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "ಮ್ಯಾಗ್ನಿಫಯರ್ ತೆರೆಯ ಹೊರಗೆ ವ್ಯಾಪಿಸುತ್ತದೆ"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವನ್ನು ಮಧ್ಯಕ್ಕೆ ಹೊಂದಿಸು"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವು ವಿಷಯಗಳನ್ನು ಸುತ್ತಲೂ ತಳ್ಳುತ್ತದೆ"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವು ವಿಷಯಗಳೊಂದಿಗೆ ಸ್ಥಳಾಂತರಗೊಳ್ಳುತ್ತದೆ"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ಸ್ಥಾನ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "ಮೌಸ್‌ನ ಸೂಚಕವನ್ನು ಅನುಸರಿಸು"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "ತೆರೆಯ ಭಾಗ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "ಮ್ಯಾಗ್ನಿಫಯರ್ ತೆರೆಯ ಹೊರಗೆ ವ್ಯಾಪಿಸುತ್ತದೆ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವನ್ನು ಮಧ್ಯಕ್ಕೆ ಹೊಂದಿಸು"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವು ವಿಷಯಗಳನ್ನು ಸುತ್ತಲೂ ತಳ್ಳುತ್ತದೆ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವು ವಿಷಯಗಳೊಂದಿಗೆ ಸ್ಥಳಾಂತರಗೊಳ್ಳುತ್ತದೆ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "ಅಡ್ಡಗೆರೆಗಳು:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "ಮೌಸ್‌ನ ತೆರೆಸೂಚಕದ ಮೇಲೆ ಆವರಿಸುತ್ತದೆ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "ದಪ್ಪ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "ತೆಳುವಾದ"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "ದಪ್ಪವಾದ"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "ಉದ್ದ:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "ಬಣ್ಣ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "ಅಡ್ಡಗೆರೆಗಳು:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "ಮೌಸ್‌ನ ತೆರೆಸೂಚಕದ ಮೇಲೆ ಆವರಿಸುತ್ತದೆ"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "ಅಡ್ಡಗೆರೆಗಳು:"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "ಬಣ್ಣದ ಪರಿಣಾಮಗಳು:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "ಕಪ್ಪು ಬಣ್ಣದಲ್ಲಿ ಬಿಳಿ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "ಪ್ರಕಾಶ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "ವೈದೃಶ್ಯ:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "ಬಣ್ಣ"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "ಯಾವುದೂ ಇಲ್ಲ"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "ಸಂಪೂರ್ಣ"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "ಕೆಳ ಮಟ್ಟದ"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "ಉತ್ತಮ"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "ಕೆಳ ಮಟ್ಟದ"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "ಉತ್ತಮ"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "ಬಣ್ಣದ ಪರಿಣಾಮಗಳು:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "ಬಣ್ಣದ ಪರಿಣಾಮಗಳು"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "ಶಿಷ್ಟ"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "ನೋಡಲು, ಕೇಳಲು, ಬರೆಯಲು, ತೋರಿಸಲು ಮತ್ತು ಕ್ಲಿಕ್ ಮಾಡಲು ಸುಲಭಗೊಳಿಸು"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "ವ್ಯವಸ್ಥಾಪಕ"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Full Name"
-msgstr "ಪೂರ್ಣ ಹೆಸರು (_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "ಖಾತೆಯ ಬಗೆ (_T):"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to set a password when they next login"
-msgstr "ಬಳಕೆದಾರರು ಮುಂದಿನ ಬಾರಿ ಪ್ರವೇಶಿಸಿದಾಗ ಗುಪ್ತಪದವನ್ನು ಹೊಂದಿಸಲು ಅವಕಾಶ ನೀಡು"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "ಈಗಲೆ ಗುಪ್ತಪದವನ್ನು ಹೊಂದಿಸಿ"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "ಪರಿಶೀಲಿಸು (_V)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"ಎಂಟರ್‌ಪ್ರೈಸ್‌ ಲಾಗಿನ್ ಈ ಸಾಧನದಲ್ಲಿ ಈಗಿರುವ ಕೇಂದ್ರೀಕೃತ ವ್ಯವಸ್ಥೆಯಲ್ಲಿ ಬಳಕೆದಾರ "
-"ಖಾತೆಯನ್ನು "
-"ನಿರ್ವಹಿಸಲು ಅವಕಾಶ ಒದಗಿಸುತ್ತದೆ."
+"ಕೀಲಿಮಣೆ;ಮೌಸ್;a11y;ನಿಲುಕು;ಕಾಂಟ್ರಾಸ್ಟ್;ಗಾತ್ರಬದಲಾವಣೆ;ತೆರೆ ಓದುಗ;ಪಠ್ಯ;ಅಕ್ಷರಶೈಲಿ;ಗಾತ್ರ;"
+"AccessX;ಸ್ಟಿಕಿ;ಕೀಲಿಗಳು;ನಿಧಾನಗತಿ;ಪುಟಿಯುವ;ಮೌಸ್‌;"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "ಡೊಮೈನ್ (_D)"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ಇತಿಹಾಸ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"ಎಂಟರ್‌ಪ್ರೈಸ್ ಲಾಗಿನ್‌\n"
-"ಖಾತೆಗಳನ್ನು ಸೇರಿಸಲು ಆನ್‌ಲೈನ್‌ಗೆ ತೆರಳಿ."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "ಎಂಟರ್ಪ್ರೈಸ್ ಪ್ರವೇಶ (_E)"
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "ಇತಿಹಾಸ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "ಇತ್ತೀಚಿನ ಇತಿಹಾಸವನ್ನು ಅಳಿಸು (_e)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "ಕಸ ಮತ್ತು ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಹೊರತಳ್ಳು"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "ಕಸದ ಬುಟ್ಟಿಯನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಖಾಲಿ ಮಾಡು (_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊರತಳ್ಳು (_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "ಕಸದ ಬುಟ್ಟಿಯನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಖಾಲಿ ಮಾಡು (_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "ಕಸದ ಬುಟ್ಟಿಯನ್ನು ಖಾಲಿ ಮಾಡು (_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಹೊರತಳ್ಳು (_P)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "ಬಳಕೆದಾರರನ್ನು ಸೇರಿಸು"
 
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "ವ್ಯವಸ್ಥಾಪಕ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "ಬಳಕೆದಾರರು ಮುಂದಿನ ಬಾರಿ ಪ್ರವೇಶಿಸಿದಾಗ ಗುಪ್ತಪದವನ್ನು ಹೊಂದಿಸಲು ಅವಕಾಶ ನೀಡು"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "ಈಗಲೆ ಗುಪ್ತಪದವನ್ನು ಹೊಂದಿಸಿ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "ಸಂರಚಿಸಲಾಗುತ್ತಿದೆ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "ಎಂಟರ್ಪ್ರೈಸ್ ಪ್ರವೇಶ (_E)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "ಆಫ್‌ಲೈನ್"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"ಎಂಟರ್‌ಪ್ರೈಸ್‌ ಲಾಗಿನ್ ಈ ಸಾಧನದಲ್ಲಿ ಈಗಿರುವ ಕೇಂದ್ರೀಕೃತ ವ್ಯವಸ್ಥೆಯಲ್ಲಿ ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು "
+"ನಿರ್ವಹಿಸಲು ಅವಕಾಶ ಒದಗಿಸುತ್ತದೆ."
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PPD ಕಡತವನ್ನು ಆರಿಸು"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "ಬೆರಳಗುರುತಿನೊಂದಿಗೆ ಪ್ರವೇಶ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "ಬೆರಳಗುರುತಿನೊಂದಿಗೆ ಪ್ರವೇಶ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "ಇಲ್ಲ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"ನೀವು ನೋಂದಾಯಿಸಲಾದ ಬೆರಳಗುರುತುಗಳನ್ನು ಅಳಿಸಿ ಆ ಮೂಲಕ ಬೆರಳಗುರುತಿನ ಪ್ರವೇಶವನ್ನು "
+"ಅಶಕ್ತಗೊಳಿಸಲು ಬಯಸುತ್ತೀರೆ?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "ಯಾವುದೆ ಮುದ್ರಕಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "ಬೆರಳಗುರುತಿನೊಂದಿಗೆ ಪ್ರವೇಶ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "ಬೆರಳಗುರುತಿನೊಂದಿಗೆ ಪ್ರವೇಶ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "ಬೆರಳಗುರುತಿನೊಂದಿಗೆ ಪ್ರವೇಶ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "ಬೆರಳಗುರುತುಗಳನ್ನು ಅಳಿಸು (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "ಬೆರಳಗುರುತಿನೊಂದಿಗೆ ಪ್ರವೇಶ (_F)"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "ಹಿಂದಿನ ವಾರ"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "ಮುಂದಿನ ವಾರ"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "ಗುಪ್ತಪದವನ್ನು ಬದಲಾಯಿಸು"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "ಬದಲಾಯಿಸಿ (_a)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "ಈಗಿನ ಗುಪ್ತಪದ (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "ಹೊಸ ಗುಪ್ತಪದ (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "ಗುಪ್ತಪದವನ್ನು ಖಚಿತಪಡಿಸಿ (_o)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "ಗುಪ್ತಪದಗಳು ಹೊಂದಿಕೆಯಾಗುತ್ತಿಲ್ಲ."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "ಬಳಕೆದಾರರು ಮುಂದಿನ ಬಾರಿ ಪ್ರವೇಶಿಸಿದಾಗ ಗುಪ್ತಪದವನ್ನು ಹೊಂದಿಸಲು ಅವಕಾಶ ನೀಡು"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "ಈಗಲೆ ಗುಪ್ತಪದವನ್ನು ಹೊಂದಿಸಿ"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "ಬಳಕೆದಾರರು"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "ಬದಲಾವಣೆಗಳು ಕಾರ್ಯರೂಪಕ್ಕೆ ಬರಲು ನಿಮ್ಮ ಅಧಿವೇಶನವನ್ನು ಮರಳಿ ಆರಂಭಿಸಬೇಕಾಗುತ್ತದೆ"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "ಈಗಲೆ ಮರಳಿ ಆರಂಭಿಸು"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "ಮುಚ್ಚು"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "ಪೂರ್ಣ ಹೆಸರು (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "ಬೆರಳಗುರುತಿನೊಂದಿಗೆ ಪ್ರವೇಶ (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ಪ್ರವೇಶ (_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "ಖಾತೆಯ ಬಗೆ (_T):"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "ವ್ಯವಸ್ಥಾಪಕ"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕು"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "ಇತರೆ ಬೆರಳು (_O): "
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "ಬಳಕೆದಾರರನ್ನು ಸೇರಿಸು"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "ಯಾವುದೆ ಚಿತ್ರಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "ಬಳಕೆದಾರನನ್ನು ರಚಿಸು"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "ಬಳಕೆದಾರರನ್ನು ಸೇರಿಸಿ ಅಥವ ತೆಗೆದುಹಾಕಿ ಮತ್ತು ಗುಪ್ತಪದವನ್ನು ಬದಲಾಯಿಸಿ"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "ನೋಂದಾಯಿಸು (_E)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "ಡೊಮೈನ್ ವ್ಯವಸ್ಥಾಪಕನ ಪ್ರವೇಶ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6048,1148 +4812,3330 @@ msgstr ""
 "ನೋಂದಾಯಿಸಬೇಕಾಗುತ್ತದೆ. ನಿಮ್ಮ ಜಾಲಬಂಧ ವ್ಯವಸ್ಥಾಪಕರು ತಮ್ಮ\n"
 "ಡೊಮೈನ್ ಗುಪ್ತಪದವನ್ನು ಇಲ್ಲಿ ನಮೂದಿಸಲು ಮನವಿ ಮಾಡಿ."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "ವ್ಯವಸ್ಥಾಪಕನ ಹೆಸರು (_N)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "ವ್ಯವಸ್ಥಾಪಕ ಗುಪ್ತಪದ"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "ಎಡ ಹೆಬ್ಬೆರಳು"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "ಎಡ ಮಧ್ಯ ಬೆರಳು"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "ಎಡ ಉಂಗುರದ ಬೆರಳು"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "ಎಡ ಕಿರು ಬೆರಳು"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "ಬಲ ಹೆಬ್ಬೆರಳು"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "ಬಲ ಮಧ್ಯ ಬೆರಳು"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "ಬಲ ಉಂಗುರದ ಬೆರಳು"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "ಬಲ ಕಿರು ಬೆರಳು"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:689
-msgid "Enable Fingerprint Login"
-msgstr "ಬೆರಳಗುರುತು ಪ್ರವೇಶವನ್ನು ಶಕ್ತಗೊಳಿಸಿ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "ಬಲ ತೋರು ಬೆರಳು (_R)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "ಎಡ ತೋರು ಬೆರಳು (_L)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "ಇತರೆ ಬೆರಳು (_O): "
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"ನಿಮ್ಮ ಬೆರಳಗುರುತನ್ನು ಯಶಸ್ವಿಯಾಗಿ ಉಳಿಸಲಾಗಿದೆ. ಈಗ ನೀವು ನಿಮ್ಮ ಬೆರಳಗುರುತಿನ "
-"ಓದುಗನನ್ನು "
-"ಬಳಸಿಕೊಂಡು ಪ್ರವೇಶಿಸಬಹುದಾಗಿದೆ."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "ಬಳಕೆದಾರರು"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr "ಬಳಕೆದಾರರನ್ನು ಸೇರಿಸಿ ಅಥವ ತೆಗೆದುಹಾಕಿ ಮತ್ತು ಗುಪ್ತಪದವನ್ನು ಬದಲಾಯಿಸಿ"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "ಪ್ರವೇಶ;ಹೆಸರು;ಬೆರಳಗುರುತ;ಅವತಾರ;ಲಾಂಛನ;ಮುಖ;ಗುಪ್ತಪದ;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "ಪ್ರವೇಶದ ಇತಿಹಾಸ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr "ಗುಪ್ತಪದವನ್ನು ಬದಲಾಯಿಸು"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "ಬದಲಾಯಿಸಿ (_a)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "ಹೊಸ ಗುಪ್ತಪದವನ್ನು ಪರಿಶೀಲಿಸು (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "ಹೊಸ ಗುಪ್ತಪದ (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "ಈಗಿನ ಗುಪ್ತಪದ (_P)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ಸೇರಿಸು"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕು"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "ಪ್ರವೇಶದ ಆಯ್ಕೆಗಳು"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "ಸ್ವಯಂಚಾಲಿತ ಪ್ರವೇಶ (_u)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "ಬೆರಳಗುರುತಿನೊಂದಿಗೆ ಪ್ರವೇಶ (_F)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "ಬಳಕೆದಾರನ ಚಿಹ್ನೆ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "ಭಾಷೆ (_L)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "ಕೊನೆಯ ಪ್ರವೇಶ"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "ಬಳಕೆದಾರ ಖಾತೆಗಳನ್ನು ನಿರ್ವಹಿಸಿ"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "ಬಳಕೆದಾರರ ಮಾಹಿತಿಯನ್ನು ಬದಲಾಯಿಸಲು ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
 
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಹಳೆಯದಕ್ಕಿಂತ ಭಿನ್ನವಾಗಿರಬೇಕು."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "ಕೆಲವು ಅಕ್ಷರಗಳು ಮತ್ತು ಅಂಕಿಗಳನ್ನು ಬದಲಾಯಿಸಲು ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "ಗುಪ್ತಪದವನ್ನು ಇನ್ನಷ್ಟು ಬದಲಾಯಿಸಲು ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "ನಿಮ್ಮ ಬಳಕೆದಾರ ಹೆಸರು ಇಲ್ಲದ ಗುಪ್ತಪದವು ಸದೃಢವಾಗಿರುತ್ತದೆ."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "ನಿಮ್ಮ ಹೆಸರನ್ನು ಗುಪ್ತಪದದಲ್ಲಿ ಬಳಸದೇ ಇರಲು ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "ಗುಪ್ತಪದದಲ್ಲಿ ಕೆಲವು ಪದಗಳನ್ನು ಬಳಸದೆ ಇರಲು ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "ಸಾಮಾನ್ಯವಾದ ಪದಗಳನ್ನು ಬಳಸಬೇಡಿ."
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "ಈಗಿರುವ ಪದದ ಅಕ್ಷರಗಳನ್ನೆ ಅದಲು ಬದಲು ಮಾಡಿ ಬಳಸಬೇಡಿ."
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "ಹೆಚ್ಚು ಸಂಖ್ಯೆಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "ಹೆಚ್ಚು ದೊಡ್ಡಕ್ಷರಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "ಹೆಚ್ಚು ಸಣ್ಣಕ್ಷರಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "ಹೆಚ್ಚು  ವಿರಾಮ ಚಿಹ್ನೆಗಳಂತಹ ವಿಶೇಷ ಅಕ್ಷರಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ವಿರಾಮಚಿಹ್ನೆಗಳ ಮಿಶ್ರಣವನ್ನು ಬಳಸಿ ನೋಡಿ."
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "ಒಂದೇ ಅಕ್ಷರವನ್ನು ಪುನರಾವರ್ತಿಸುವುದನ್ನು ತಪ್ಪಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"ಒಂದೇ ರೀತಿಯ ಚಿಹ್ನೆಯನ್ನು ಬಳಸುವುದನ್ನು ತಪ್ಪಿಸಲು ಪ್ರಯತ್ನಿಸಿ: ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು "
-"ಮತ್ತು "
-"ವಿರಾಮಚಿಹ್ನೆಗಳ ಮಿಶ್ರಣವನ್ನು ಬಳಸಿ ನೋಡಿ."
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 ಅಥವ abcd ಯಂತಹ ಸರಣಿಯನ್ನು ಬಳಸಬೇಡಿ."
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "ಹೆಚ್ಚು ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ಸಂಕೇತಗಳನ್ನು ಸೇರಿಸಲು ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr ""
-"ದೊಡ್ಡಕ್ಷರ ಮತ್ತು ಸಣ್ಣಕ್ಷರವನ್ನು ಜೊತೆಗೆ ಬಳಸಿ ಮತ್ತು ಒಂದು ಅಥವ ಎರಡು ಸಂಖ್ಯೆಯನ್ನು "
-"ಬಳಸಿ."
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-"ಉತ್ತಮವಾದ ಗುಪ್ತಪದ! ಹೆಚ್ಚಿನ ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ವಿರಾಮಚಿಹ್ನೆಗಳನ್ನು "
-"ಸೇರಿಸುವುದರಿಂದ "
-"ಇದು ಇನ್ನಷ್ಟು ಬಲಗೊಳ್ಳುತ್ತದೆ."
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "ಬಲಿಷ್ಟತೆ: ದುರ್ಬಲ"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "ಬಲಿಷ್ಟತೆ: ಕಡಿಮೆ"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "ಬಲಿಷ್ಟತೆ: ಮಧ್ಯಮ"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "ಬಲಿಷ್ಟತೆ: ಉತ್ತಮ"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "ಬಲಿಷ್ಟತೆ: ಅತ್ಯುತ್ತಮ"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "ದೃಢೀಕರಣ ವಿಫಲಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಬಹಳ ಚಿಕ್ಕದಾಗಿದೆ"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಬಹಳ ಸರಳವಾಗಿದೆ."
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "ಹೊಸ ಹಾಗು ಹಳೆಯ ಗುಪ್ತಪದಗಳು ಒಂದನ್ನೊಂದು ಬಹಳ ಹೋಲುತ್ತವೆ"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "ಹೊಸ ಗುಪ್ತಪದವನ್ನು ಈಗಾಗಲೆ ಇತ್ತೀಚೆಗೆ ಬಳಸಲಾಗಿದೆ."
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಒಂದು ಅಂಕೆ ಅಥವ ವಿಶೇಷ ಅಕ್ಷರಗಳನ್ನು ಹೊಂದಿರಲೇಬೇಕು"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "ಹೊಸ ಹಾಗು ಹಳೆಯ ಗುಪ್ತಪದಗಳು ಒಂದೇ ಆಗಿವೆ"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "ನಿಮ್ಮ ಗುಪ್ತಪದವನ್ನು ನೀವು ಆರಂಭದಲ್ಲಿ ದೃಢೀಕರಿಸಿದ ನಂತರ ಬದಲಾಯಿಸಲ್ಪಟ್ಟಿದೆ!"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಸಾಕಷ್ಟು ವಿಭಿನ್ನ ಅಕ್ಷರಗಳನ್ನು ಹೊಂದಿಲ್ಲ"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "ಗೊತ್ತಿಲ್ಲದ ದೋಷ"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "ನಿಮ್ಮ ಖಾತೆ ಒದಗಿಸುವವರ ಜಾಲ ವಿಳಾಸಕ್ಕೆ ಹೊಂದಿಕೆಯಾಗಬೇಕು."
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "ಖಾತೆಯನ್ನು ಸೇರಿಸಲು ವಿಫಲಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-msgid "Passwords do not match."
-msgstr "ಗುಪ್ತಪದಗಳು ಒಂದೇ ಸಮನಾಗಿಲ್ಲ."
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr "ಖಾತೆಯನ್ನು ನೋಂದಾಯಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr "ಈ ಡೊಮೈನ್‌ನೊಂದಿಗೆ ದೃಢೀಕರಿಸಲು ಯಾವುದೆ ಮಾರ್ಗವಿಲ್ಲ"
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr "ಡೊಮೈನ್ ಅನ್ನು ಸೇರುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"ಆ ಲಾಗಿನ್ ಹೆಸರು ಕೆಲಸ ಮಾಡುತ್ತಿಲ್ಲ.\n"
-"ದಯವಿಟ್ಟು ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"ಆ ಲಾಗಿನ್ ಗುಪ್ತಪದ ಕೆಲಸ ಮಾಡುತ್ತಿಲ್ಲ.\n"
-"ದಯವಿಟ್ಟು ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ."
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr "ಡೊಮೈನ್ ಅನ್ನು ಪ್ರವೇಶಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "ಡೊಮೇನ್‌ ಕಂಡುಬಂದಿಲ್ಲ. ಬಹುಷಃ ನೀವು ತಪ್ಪಾಗಿ ನಮೂದಿಸಿರಬೇಕು?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:138
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"ನೀವು ಈ ಸಾಧನವನ್ನು ನಿಲುಕಿಸಿಕೊಳ್ಳುವಂತಿಲ್ಲ. ನಿಮ್ಮ ಗಣಕ ವ್ಯವಸ್ಥಾಪಕರನ್ನು ಸಂಪರ್ಕಿಸಿ."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:140
-msgid "The device is already in use."
-msgstr "ಸಾಧನವು ಈಗಾಗಲೆ ಬಳಕೆಯಲ್ಲಿದೆ."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid "An internal error occurred."
-msgstr "ಒಂದು ಆಂತರಿಕ ದೋಷ ಸಂಭವಿಸಿದೆ."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Enabled"
-msgstr "ಸಕ್ರಿಯಗೊಂಡ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr "ನೋಂದಾಯಿಸಲಾದ ಬೆರಳಗುರುತುಗಳನ್ನು ಅಳಿಸಬೇಕೆ?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
-msgstr "ಬೆರಳಗುರುತುಗಳನ್ನು ಅಳಿಸು (_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"ನೀವು ನೋಂದಾಯಿಸಲಾದ ಬೆರಳಗುರುತುಗಳನ್ನು ಅಳಿಸಿ ಆ ಮೂಲಕ ಬೆರಳಗುರುತಿನ ಪ್ರವೇಶವನ್ನು "
-"ಅಶಕ್ತಗೊಳಿಸಲು ಬಯಸುತ್ತೀರೆ?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:446
-msgid "Done!"
-msgstr "ಆಯಿತು!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:507
-#: ../panels/user-accounts/um-fingerprint-dialog.c:549
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' ಸಾಧನವನ್ನು ನಿಲುಕಿಸಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:590
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr ""
-"'%s' ಸಾಧನದಲ್ಲಿ ಬೆರಳಿನ ಗುರುತನ್ನು ತೆಗೆದುಕೊಳ್ಳುವುದನ್ನು ಆರಂಭಿಸು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:640
-msgid "Could not access any fingerprint readers"
-msgstr "ಯಾವುದೆ ಬೆರಳಗುರುತು ಓದುಗನನ್ನು ನಿಲುಕಿಸಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:641
-msgid "Please contact your system administrator for help."
-msgstr "ನೆರವಿಗಾಗಿ ನಿಮ್ಮ ಗಣಕ ವ್ಯವಸ್ಥಾಪಕರನ್ನು ಕೇಳಿ."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:723
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"ಬೆರಳಗುರುತಿನ ಪ್ರವೇಶವನ್ನು ಶಕ್ತಗೊಳಿಸಲು, '%s' ಸಾಧನವನ್ನು ಬಳಸಿಕೊಂಡು ನೀವು ನಿಮ್ಮ "
-"ಬೆರಳಗುರುತುಗಳನ್ನು ಉಳಿಸಬೇಕಾಗುತ್ತದೆ."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:730
-msgid "Selecting finger"
-msgstr "ಬೆರಳನ್ನು ಆರಿಸುವಿಕೆ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:731
-msgid "Enrolling fingerprints"
-msgstr "ಬೆರಳಗುರುತುಗಳನ್ನು ದಾಖಲಿಸುವಿಕೆ"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "ಈ ವಾರ"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "ಹಿಂದಿನ ವಾರ"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:844
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:848
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "ಅಧಿವೇಶನ ಕೊನೆಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "ಅಧಿವೇಶನ ಆರಂಭಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "ದಯವಿಟ್ಟು ಬೇರೊಂದು ಗುಪ್ತಪದವನ್ನು ಆರಿಸಿ."
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "ದಯವಿಟ್ಟು ನಿಮ್ಮ ಈಗಿನ ಗುಪ್ತಪದವನ್ನು ಇನ್ನೊಮ್ಮೆ ದಾಖಲಿಸಿ."
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "ಗುಪ್ತಪದವನ್ನು ಬದಲಾಯಿಸಲಾಗಿಲ್ಲ."
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-msgid "The passwords do not match."
-msgstr "ಗುಪ್ತಪದಗಳು ಹೊಂದಿಕೆಯಾಗುತ್ತಿಲ್ಲ."
-
-#: ../panels/user-accounts/um-photo-dialog.c:214
-msgid "Browse for more pictures"
-msgstr "ಹೆಚ್ಚಿನ ಚಿತ್ರಗಳಿಗಾಗಿ ನೋಡು"
-
-#: ../panels/user-accounts/um-photo-dialog.c:448
-msgid "Disable image"
-msgstr "ಚಿತ್ರವನ್ನು ಅಶಕ್ತಗೊಳಿಸು"
-
-#: ../panels/user-accounts/um-photo-dialog.c:466
-msgid "Take a photo…"
-msgstr "ಒಂದು ಚಿತ್ರವನ್ನು ತೆಗೆದುಕೊಳ್ಳಿ..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:484
-msgid "Browse for more pictures…"
-msgstr "ಹೆಚ್ಚಿನ ಚಿತ್ರಗಳಿಗಾಗಿ ನೋಡು…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:708
-#, c-format
-msgid "Used by %s"
-msgstr "%s ಇಂದ ಬಳಸಲಾಗಿದೆ"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "ಈ ಬಗೆಯ ಡೊಮೇನ್‌ ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸೇರಿಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "ಯಾವುದೆ ಅಂತಹ ಡೊಮೈನ್ ಅಥವ ಕ್ಷೇತ್ರ ಕಂಡುಬಂದಿಲ್ಲ"
-
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s ಎಂದು %s ಡೊಮೈನಿನಲ್ಲಿ ಪ್ರವೇಶಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ"
-
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
-msgstr "ಗುಪ್ತಪದ ತಪ್ಪಾಗಿದೆ; ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ"
-
-#: ../panels/user-accounts/um-realm-manager.c:832
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "%s ಡೊಮೈನ್‌ಗೆ ಸಂಪರ್ಕಿತಗೊಳಿಸಲಾಗಿಲ್ಲ: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:239
-msgid "Other Accounts"
-msgstr "ಇತರೆ ಖಾತೆಗಳು"
-
-#: ../panels/user-accounts/um-user-panel.c:453
-msgid "Failed to delete user"
-msgstr "ಬಳಕೆದಾರನನ್ನು ಅಳಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/um-user-panel.c:513
-#: ../panels/user-accounts/um-user-panel.c:569
-#: ../panels/user-accounts/um-user-panel.c:621
-#| msgid "Failed to delete user"
-msgid "Failed to revoke remotely managed user"
-msgstr "ದೂರದಿಂದ ನೋಡಿಕೊಳ್ಳಲಾಗುವ ಬಳಕೆದಾರನನ್ನು ರದ್ದುಗೊಳಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/um-user-panel.c:677
-msgid "You cannot delete your own account."
-msgstr "ನೀವು ನಿಮ್ಮದೆ ಖಾತೆಯನ್ನು ಅಳಿಸಲು ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ"
-
-#: ../panels/user-accounts/um-user-panel.c:686
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s ಇನ್ನೂ ಸಹ ಒಳಗಿದ್ದಾರೆ"
-
-#: ../panels/user-accounts/um-user-panel.c:690
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"ಬಳಕೆದಾರರು ಒಳಗೆ ಪ್ರವೇಶಿಸಿದಾಗ ಅವರನ್ನು ಅಳಿಸುವುದರಿಂದ ವ್ಯವಸ್ಥೆಯು ಒಂದು ಅಸ್ಥಿರ "
-"ಸ್ಥಿತಿಯಲ್ಲಿ "
-"ಇರಿಸುತ್ತದೆ."
-
-#: ../panels/user-accounts/um-user-panel.c:699
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "ನೀವು %s ರವರ ಕಡತಗಳನ್ನು ಇರಿಸಿಕೊಳ್ಳಲು ಬಯಸುವಿರಾ?"
-
-#: ../panels/user-accounts/um-user-panel.c:703
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"ಬಳಕೆದಾರರ ಖಾತೆಯನ್ನು ಅಳಿಸುವಾಗ ನೆಲೆ ಕೋಶವನ್ನು, ಅಂಚೆ ಸ್ಪೂಲ್ ಅನ್ನು ಮತ್ತು ತಾತ್ಕಾಲಿಕ "
-"ಕಡತಗಳನ್ನು ಹಾಗೆಯೆ ಇರಿಸಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಿರುತ್ತದೆ."
-
-#: ../panels/user-accounts/um-user-panel.c:706
-msgid "_Delete Files"
-msgstr "ಕಡತಗಳನ್ನು ಅಳಿಸು (_D)"
-
-#: ../panels/user-accounts/um-user-panel.c:707
-msgid "_Keep Files"
-msgstr "ಕಡತಗಳನ್ನು ಇರಿಸಿಕೊ (_K)"
-
-#: ../panels/user-accounts/um-user-panel.c:721
-#, c-format
-#| msgid "Are you sure you want to remove the account?"
-msgid "Are you sure you want to revoke remotely managed %s's account?"
-msgstr "ದೂರದಿಂದ ನೋಡಿಕೊಳ್ಳಲಾಗುವ %s ನ ಖಾತೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲು ನೀವು ಖಚಿತವೆ?"
-
-#: ../panels/user-accounts/um-user-panel.c:725
-#| msgid "_Delete Files"
-msgid "_Delete"
-msgstr "ಅಳಿಸು (_D)"
-
-#: ../panels/user-accounts/um-user-panel.c:777
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "ಖಾತೆಯನ್ನು ಅಶಕ್ತಗೊಳಿಸಲಾಗಿದೆ"
-
-#: ../panels/user-accounts/um-user-panel.c:785
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "ಮುಂದಿನ ಬಾರಿ ಪ್ರವೇಶಿಸಿದಾಗ ಹೊಂದಿಸಲಾಗುತ್ತದೆ"
-
-#: ../panels/user-accounts/um-user-panel.c:788
-msgctxt "Password mode"
-msgid "None"
-msgstr "ಯಾವುದೂ ಇಲ್ಲ"
-
-#: ../panels/user-accounts/um-user-panel.c:837
-msgid "Logged in"
-msgstr "ಪ್ರವೇಶಿಸಲಾಗಿದೆ"
-
-#: ../panels/user-accounts/um-user-panel.c:1269
-msgid "Failed to contact the accounts service"
-msgstr "ಖಾತೆಗಳ ಸೇವೆಯನ್ನು ಸಂಪರ್ಕಿಸಲು ವಿಫಲಗೊಂಡಿದೆ"
-
-#: ../panels/user-accounts/um-user-panel.c:1271
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"AccountService ಅನ್ನು ಅನುಸ್ಥಾಪಿಸಲಾಗಿದೆಯೆ ಮತ್ತು ಸಕ್ರಿಯಗೊಂಡಿದೆಯೆ ಎಂದು "
-"ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ."
-
-#: ../panels/user-accounts/um-user-panel.c:1312
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"ಬದಲಾವಣೆಗಳನ್ನು ಮಾಡಲು,\n"
-"* ಚಿಹ್ನೆಯ ಮೇಲೆ ಮೊದಲು ಕ್ಲಿಕ್ ಮಾಡಿ"
-
-#: ../panels/user-accounts/um-user-panel.c:1350
-msgid "Create a user account"
-msgstr "ಬಳಕೆದಾರನನ್ನು ರಚಿಸು"
-
-#: ../panels/user-accounts/um-user-panel.c:1361
-#: ../panels/user-accounts/um-user-panel.c:1674
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ರಚಿಸಲು,\n"
-"ಮೊದಲು * ಚಿಹ್ನೆಯ ಮೇಲೆ ಕ್ಲಿಕ್ ಮಾಡಿ"
-
-#: ../panels/user-accounts/um-user-panel.c:1371
-msgid "Delete the selected user account"
-msgstr "ಆಯ್ದ ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ಅಳಿಸಿ"
-
-#: ../panels/user-accounts/um-user-panel.c:1383
-#: ../panels/user-accounts/um-user-panel.c:1679
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"ಆಯ್ದ ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ಅಳಿಸಲು,\n"
-"ಮೊದಲು * ಚಿಹ್ನೆಯ ಮೇಲೆ ಕ್ಲಿಕ್ ಮಾಡಿ"
-
-#: ../panels/user-accounts/um-user-panel.c:1588
-msgid "My Account"
-msgstr "ನನ್ನ ಖಾತೆ"
-
-#: ../panels/user-accounts/um-utils.c:563
-#, c-format
-msgid "A user with the username '%s' already exists."
-msgstr "'%s' ಎಂಬ ಹೆಸರಿನ ಒಬ್ಬ ಬಳಕೆದಾರ ಈಗಾಗಲೆ ಅಸ್ತಿತ್ವದಲ್ಲಿದ್ದಾರೆ."
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-msgid "The username is too long."
-msgstr "ಬಳಕೆದಾರ ಹೆಸರು ಬಹಳ ಉದ್ದವಾಗಿದೆ."
-
-#: ../panels/user-accounts/um-utils.c:570
-msgid "The username cannot start with a '-'."
-msgstr "ಬಳಕೆದಾರ ಹೆಸರು '-' ಇಂದ ಆರಂಭಗೊಳ್ಳುವಂತಿಲ್ಲ."
-
-#: ../panels/user-accounts/um-utils.c:573
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"ಬಳಕೆದಾರ ಹೆಸರು ಕೇವಲ a-z ವರೆಗಿನ ಅಕ್ಷರಗಳು, ಅಂಕಿಗಳು, ಮತ್ತು '.', '-' ಹಾಗು '_' "
-"ನಲ್ಲಿ "
-"ಒಂದಾದರೂ ಚಿಹ್ನೆಗಳನ್ನು ಮಾತ್ರ ಹೊಂದಿರಬೇಕು."
-
-#: ../panels/user-accounts/um-utils.c:577
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-"ಇದನ್ನು ನಿಮ್ಮ ನೆಲೆ ಕೋಶವನ್ನು ಹೆಸರಿಸಲು ಬಳಸಲಾಗುತ್ತದೆ ಮತ್ತು ಬದಲಾಯಿಸಲು "
-"ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ."
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:823
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "ಮ್ಯಾಪ್ ಗುಂಡಿಗಳು"
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "ಕಾರ್ಯಭಾರಗಳ ಮ್ಯಾಪ್ ಗುಂಡಿಗಳು"
 
-#: ../panels/wacom/button-mapping.ui.h:4
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"ಒಂದು ಸಮೀಪಮಾರ್ಗ ಕೀಲಿಯನ್ನು ಸಂಪಾದಿಸಲು, \"ಕೀಲಿಹೊಡೆತವನ್ನು ಕಳುಹಿಸು\" ಕ್ರಿಯೆಯನ್ನು "
-"ಆರಿಸಿ, "
-"ಕೀಲಿಮಣೆ ಸಮೀಪಮಾರ್ಗ ಗುಂಡಿಯನ್ನು ಒತ್ತಿ ನಂತರ ಹೊಸ ಕೀಲಿಗಳನ್ನು ಒತ್ತಿಹಿಡಿಯಿರಿ ಅಥವ "
-"ಅಳಿಸಲು "
+"ಒಂದು ಸಮೀಪಮಾರ್ಗ ಕೀಲಿಯನ್ನು ಸಂಪಾದಿಸಲು, \"ಕೀಲಿಹೊಡೆತವನ್ನು ಕಳುಹಿಸು\" ಕ್ರಿಯೆಯನ್ನು ಆರಿಸಿ, "
+"ಕೀಲಿಮಣೆ ಸಮೀಪಮಾರ್ಗ ಗುಂಡಿಯನ್ನು ಒತ್ತಿ ನಂತರ ಹೊಸ ಕೀಲಿಗಳನ್ನು ಒತ್ತಿಹಿಡಿಯಿರಿ ಅಥವ ಅಳಿಸಲು "
 "ಬ್ಯಾಕ್‍ಸ್ಪೇಸನ್ನು ಒತ್ತಿ."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "ಮುಚ್ಚು (_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
-"ಟ್ಯಾಬ್ಲೆಟ್ ಅನ್ನು ಕ್ಯಾಲಿಬ್ರೇಟ್ ಮಾಡಲು ತೆರೆಯ ಮೇಲೆ ಗುರಿಯ ಗುರುತುಗಳು ಕಾಣಿಸಿಕೊಂಡಾಗ "
-"ಅವುಗಳ "
+"ಟ್ಯಾಬ್ಲೆಟ್ ಅನ್ನು ಕ್ಯಾಲಿಬ್ರೇಟ್ ಮಾಡಲು ತೆರೆಯ ಮೇಲೆ ಗುರಿಯ ಗುರುತುಗಳು ಕಾಣಿಸಿಕೊಂಡಾಗ ಅವುಗಳ "
 "ಮೇಲೆ ಮೆಲ್ಲಗೆ ತಟ್ಟಿ."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "ತಪ್ಪು-ಕ್ಲಿಕ್ ಕಂಡುಬಂದಿದೆ, ಮರಳಿ ಆರಂಭಿಸಲಾಗುತ್ತಿದೆ..."
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "ಮೇಲೆ"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "ಕೆಳಕ್ಕೆ"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "ಕಿಸೆಗಣಕ (ಟ್ಯಾಬ್ಲೆಟ್)"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "ಕೀಲಿಹೊಡೆತವನ್ನು ಕಳುಹಿಸು"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "ಎಡ-ಭಾಗದ ವಾಲಿಕೆ"
 
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "ತೆರೆಯನ್ನು ಬದಲಿಸು"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "ತೆರೆಯ ಮೇಲಣ ನೆರವನ್ನು ತೋರಿಸು"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "ತೆರೆಗೆ ಮ್ಯಾಪ್ ಮಾಡು..."
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "ಔಟ್‌ಪುಟ್:"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "ಆಕಾರ ಅನುಪಾತ"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "ರೂಪದ ಅನುಪಾತವನ್ನು ಹಾಗೆಯೆ ಇರಿಸಿಕೊ (ಓಲೆಪೆಟ್ಟಿಗೆ):"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "ಒಂದು ತೆರೆಗೆ ಮ್ಯಾಪ್ ಮಾಡು"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಟ್..."
 
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d, %d ರಲ್ಲಿ"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "ಯಾವುದೆ ಕಿಸೆಗಣಕವು (ಟ್ಯಾಬ್ಲೆಟ್) ಕಂಡುಬಂದಿಲ್ಲ"
 
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "ಪ್ರದರ್ಶಕ ಮ್ಯಾಪಿಂಗ್"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "ನಿಮ್ಮ ವೇಕಾಮ್ ಕಿಸೆಗಣಕದೊಂದಿಗೆ (ಟ್ಯಾಬ್ಲೆಟ್) ಸಂಪರ್ಕಜೋಡಿಸಿ ಅಥವ ಅದನ್ನು ಚಾಲನೆಗೊಳಿಸಿ"
 
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "ತುದಿಯ ಒತ್ತಡದ ಅನುಭವ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "ಮೃದು"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "ಭದ್ರ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "ಗುಂಡಿ"
 
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ಗುಂಡಿ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ಗುಂಡಿ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "ಉಜ್ಜುಗದ ಒತ್ತಡದ ಅನುಭವ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "ಉಜ್ಜುಗದ ಒತ್ತಡದ ಅನುಭವ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "ಮೌಸ್‌ನ ಮಧ್ಯ ಗುಂಡಿಯ ಕ್ಲಿಕ್"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "ಮೌಸ್‌ನ ಬಲ ಗುಂಡಿಯ ಕ್ಲಿಕ್"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "ಮುಂದಕ್ಕೆ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "ವೇಕಾಮ್ ಕಿಸೆಗಣಕ (ಟ್ಯಾಬ್ಲೆಟ್)"
 
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "ಗ್ರಾಫಿಕ್ಸ್ ಟ್ಯಾಬ್ಲೆಟ್‌ಗಳಿಗಾಗಿ ಗುಂಡಿಯ ಮ್ಯಾಪಿಂಗ್ ಅನ್ನು ಹೊಂದಿಸಿ ಮತ್ತು ಸ್ಟೈಲಸ್ "
 "ಸಂವೇದಿಸೂಕ್ಷ್ಮತೆಯನ್ನು ಹೊಂದಿಸಿ"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "ಟ್ಯಾಬ್ಲೆಟ್;ವೇಕಾಮ್;ಸ್ಟೈಲಸ್;ಉಜ್ಜುಗ;ಮೌಸ್;"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "ಟ್ಯಾಬ್ಲೆಟ್ (ಪರಿಪೂರ್ಣ)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "ಟಚ್‌ಪ್ಯಾಡ್ (ತುಲನಾತ್ಮಕ)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "ಕಿಸಗಣಕದ ಆದ್ಯತೆಗಳು"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "No tablet detected"
-msgstr "ಯಾವುದೆ ಕಿಸೆಗಣಕವು (ಟ್ಯಾಬ್ಲೆಟ್) ಕಂಡುಬಂದಿಲ್ಲ"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
 msgstr ""
-"ನಿಮ್ಮ ವೇಕಾಮ್ ಕಿಸೆಗಣಕದೊಂದಿಗೆ (ಟ್ಯಾಬ್ಲೆಟ್) ಸಂಪರ್ಕಜೋಡಿಸಿ ಅಥವ ಅದನ್ನು ಚಾಲನೆಗೊಳಿಸಿ"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Bluetooth Settings"
-msgstr "ಬ್ಲೂಟೂತ್ ಸಿದ್ಧತೆಗಳು"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map to Monitor…"
-msgstr "ತೆರೆಗೆ ಮ್ಯಾಪ್ ಮಾಡು..."
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map Buttons…"
-msgstr "ಗುಂಡಿಗಳನ್ನು ಮ್ಯಾಪ್ ಮಾಡು"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust display resolution"
-msgstr "ಪ್ರದರ್ಶಕದ ರೆಸಲ್ಯೂಶನ್ ಅನ್ನು ಸರಿಹೊಂದಿಸು"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust mouse settings"
-msgstr "ಮೌಸ್‌ನ ಸಿದ್ಧತೆಗಳನ್ನು ಸರಿಹೊಂದಿಸು"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Tracking Mode"
-msgstr "ಜಾಡು ಇರಿಸುವ ಕ್ರಮ"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Left-Handed Orientation"
-msgstr "ಎಡ-ಭಾಗದ ವಾಲಿಕೆ"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-msgid "Left Ring"
-msgstr "ಎಡ ರಿಂಗ್"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "ಎಡ ರಿಂಗ್ ವಿಧಾನ #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-msgid "Right Ring"
-msgstr "ಬಲ ರಿಂಗ್"
-
-#: ../panels/wacom/gsd-wacom-device.c:1104
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "ಬಲ ರಿಂಗ್ ವಿಧಾನ #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-msgid "Left Touchstrip"
-msgstr "ಎಡ ಟಚ್‌ಸ್ಟ್ರಿಪ್"
-
-#: ../panels/wacom/gsd-wacom-device.c:1157
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "ಎಡ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-msgid "Right Touchstrip"
-msgstr "ಬಲ ಟಚ್‌ಸ್ಟ್ರಿಪ್"
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "ಬಲ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1214
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "ಎಡ ಟಚ್‌ರಿಂಗ್ ವಿಧಾನ ಬದಲಾವಣೆ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1216
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "ಬಲ ಟಚ್‌ರಿಂಗ್ ವಿಧಾನ ಬದಲಾವಣೆ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1219
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "ಎಡ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ ಬದಲಾವಣೆ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1221
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "ಬಲ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ ಬದಲಾವಣೆ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1226
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "ವಿಧಾನದ ಬದಲಾವಣೆ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1334
-#, c-format
-msgid "Left Button #%d"
-msgstr "ಎಡ ಗುಂಡಿ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1337
-#, c-format
-msgid "Right Button #%d"
-msgstr "ಬಲ ಗುಂಡಿ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1340
-#, c-format
-msgid "Top Button #%d"
-msgstr "ಮೇಲಿನ ಗುಂಡಿ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1343
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "ಕೆಳಗಿನ ಗುಂಡಿ #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "ಹೊಸ ಸಮೀಪಮಾರ್ಗ..."
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "ಯಾವುದೆ ಕ್ರಿಯೆಯಿಲ್ಲ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "ಮೌಸ್‌ನ ಎಡ ಗುಂಡಿಯ ಕ್ಲಿಕ್"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "ಮೌಸ್‌ನ ಮಧ್ಯ ಗುಂಡಿಯ ಕ್ಲಿಕ್"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "ಮೌಸ್‌ನ ಬಲ ಗುಂಡಿಯ ಕ್ಲಿಕ್"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "ಮೇಲಕ್ಕೆ ಚಲಿಸು"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "ಕೆಳಕ್ಕೆ ಚಲಿಸು"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "ಎಡಕ್ಕೆ ಚಲಿಸು"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "ಬಲಕ್ಕೆ ಚಲಿಸು"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "ಹಿಂದಕ್ಕೆ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "ಮುಂದಕ್ಕೆ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "ಸ್ಟೈಲಸ್"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "ಉಜ್ಜುಗದ ಒತ್ತಡದ ಅನುಭವ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "ಮೃದು"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "ಭದ್ರ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "ಮೇಲಿನ ಗುಂಡಿ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "ಕೆಳಗಿನ ಗುಂಡಿ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
-msgid "Tip Pressure Feel"
-msgstr "ತುದಿಯ ಒತ್ತಡದ ಅನುಭವ"
-
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "ವರ್ಬೋಸ್ ಕ್ರಮವನ್ನು ಶಕ್ತಗೊಳಿಸಿ"
-
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "ಅವಲೋಕನವನ್ನು ತೋರಿಸು"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "ವಾಕ್ಯಾಂಶಕ್ಕಾಗಿ ಹುಡುಕು"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "ಸಾಧ್ಯವಿರುವ ಫಲಕದ ಹೆಸರುಗಳನ್ನು ಪಟ್ಟಿ ಮಾಡಿ ನಿರ್ಗಮಿಸು"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "ಸಹಾಯ ಆಯ್ಕೆಯನ್ನು ತೋರಿಸು"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "ತೋರಿಸಬೇಕಿರುವ ಫಲಕ"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- ಸಿದ್ಧತೆಗಳು"
-
-#: ../shell/cc-application.c:163
-#, c-format
+#: panels/windows/cc-windows-panel.ui:68
 msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
-"%s\n"
-"ಲಭ್ಯವಿರುವ ಎಲ್ಲಾ ಆಜ್ಞಾ ಸಾಲಿನ ಆಯ್ಕೆಗಳನ್ನು ನೋಡಲು '%s --help' ಅನ್ನು ಚಲಾಯಿಸಿ.\n"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "ಲಭ್ಯವಿರುವ ಪ್ಯಾನಲ್‌ಗಳು:"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "ನೆರವು"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "ಸಿಮುಲೇಟ್ ಆದ ದ್ವಿತೀಯ ಕ್ಲಿಕ್ (_S)"
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "ನಿರ್ಗಮಿಸು"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "ಕಿಟಕಿ ಅಂಚು"
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1493
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "ಟೋನರ್ ಕಡಿಮೆ ಇದೆ"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "ದ್ವಿತೀಯ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "ಕಿಟಕಿ ಅಂಚು"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "ನಿಲುಕು ಆಯ್ಕೆಗಳು"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "ಸೇರಿಸು"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "ಉಳಿಸು (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "ವಿವರಗಳು"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "ಜಾಲಬಂಧ ಸಮಯ (_N)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "ಜಾಲಬಂಧಗಳು"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "ಸಂಖ್ಯೆಗಳು"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "ವಿವರಗಳನ್ನು ನೋಡು"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "ಉತ್ಪಾದಕರು"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "ಫರ್ಮ್-ವೇರ್ ಕಾಣಿಸುತ್ತಿಲ್ಲ"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "ಮೊಬೈಲ್ ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್ (_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "ಜಾಲಬಂಧ ಸಮಯ (_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "ಜಾಲಬಂಧ"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "ಸುಧಾರಿತ"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "ನಿಲುಕು ಆಯ್ಕೆಗಳು"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "ತೆರೆ ಲಾಕ್"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "ವಿವರಗಳು"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "ಜಾಲಬಂಧ ಹೆಸರು"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "ಸ್ವಯಂಚಾಲಿತ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "ನನ್ನ ನೆಲೆ ಜಾಲಬಂಧ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "ನನ್ನ ನೆಲೆ ಜಾಲಬಂಧ"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "ಯಾವುದೇ ಬ್ಲೂಟೂತ್ ಅಡಾಪ್ಟರುಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "ವಿಮಾನದ ಸ್ಥಿತಿ (_p)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "ಸಂಪರ್ಕ"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "ಸಿಮ್ ಕಾರ್ಡನ್ನು ಹಾಕಲಾಗಿಲ್ಲ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "ತೆರೆ ಲಾಕ್"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "ಬದಲಾಯಿಸಿ (_a)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "ನನ್ನ ನೆಲೆ ಜಾಲಬಂಧ"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "ಹೊಸ ಚಾಲಕನ್ನು ಸಿದ್ಧಗೊಳಿಸಲಾಗುತ್ತಿದೆ..."
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "ಗೌಪ್ಯತೆ"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "ಎಲ್ಲಾ ಸಿದ್ಧತೆಗಳು"
 
-#. Add categories
-#: ../shell/cc-window.c:879
-msgctxt "category"
-msgid "Personal"
-msgstr "ವೈಯಕ್ತಿಕ"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "ಪ್ರಾಥಮಿಕ"
 
-#: ../shell/cc-window.c:880
-msgctxt "category"
-msgid "Hardware"
-msgstr "ಯಂತ್ರಾಂಶ"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:881
-msgctxt "category"
-msgid "System"
-msgstr "ವ್ಯವಸ್ಥೆ"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "ನೆರವು"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "ಸಾಮಾನ್ಯ"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "ನಿರ್ಗಮಿಸು"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "ಹುಡುಕು"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "ಹಿಂದಿನ ಆಕರಕ್ಕೆ ಬದಲಾಯಿಸು"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "ರದ್ದು ಮಾಡಲಾಗಿದೆ"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u ಔಟ್‌ಪುಟ್"
+msgstr[1] "%u ಔಟ್‌ಪುಟ್‌ಗಳು"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ಇನ್‌ಪುಟ್"
+msgstr[1] "%u ಇನ್‌ಪುಟ್‌ಗಳು"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "ದಿನಪೂರ್ತಿ ಬದಲಾಯಿಸುತ್ತದೆ"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "ಚೌಕ"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "ಗಾತ್ರಬದಲಿಸು"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "ಮಧ್ಯಕ್ಕೆ"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "ತುಂಬಿಸು"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "ಹರಡು"
+
+#~ msgid "Colors"
+#~ msgstr "ಬಣ್ಣಗಳು"
+
+#~ msgid "Select Background"
+#~ msgstr "ಹಿನ್ನಲೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡು"
+
+#~ msgid "Pictures"
+#~ msgstr "ಚಿತ್ರಗಳು"
+
+#~ msgid "Home"
+#~ msgstr "ನೆಲೆ"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "ನೀವು ಚಿತ್ರಗಳನ್ನು ನಿಮ್ಮ %s ಕಡತಕೋಶಕ್ಕೆ ಸೇರಿಸಬಹುದು ಮತ್ತು ಅವುಗಳು ಇಲ್ಲಿ ಕಾಣಿಸುತ್ತವೆ"
+
+#~ msgid "multiple sizes"
+#~ msgstr "ಅನೇಕ ಗಾತ್ರಗಳು"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "ಯಾವುದೆ ಗಣಕತೆರೆ ಹಿನ್ನಲೆ ಚಿತ್ರವಿಲ್ಲ"
+
+#~ msgid "Current background"
+#~ msgstr "ಈಗಿನ ಹಿನ್ನಲೆ ಚಿತ್ರ"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "ವಾಲ್‌ಪೇಪರ್;ತೆರೆ;ಗಣಕತೆರೆ;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "ನಿಮ್ಮ ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಸಾಧನವನ್ನು ಚೌಕದ ಮೇಲೆ ಇರಿಸಿ ಮತ್ತು 'ಪ್ರಾರಂಭಿಸು' ಅನ್ನು ಒತ್ತಿ"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "ಕ್ಯಾಲಿಬ್ರೇಟ್ ಸ್ಥಾನಕ್ಕೆ ನಿಮ್ಮ ಸಾಧನವನ್ನು ಜರುಗಿಸಿ ಮತ್ತು 'ಮುಂದುವರೆ' ಅನ್ನು ಒತ್ತಿ"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "ಮೇಲ್ಮೈ ಸ್ಥಾನಕ್ಕೆ ನಿಮ್ಮ ಸಾಧನವನ್ನು ಜರುಗಿಸಿ ಮತ್ತು 'ಮುಂದುವರೆ' ಅನ್ನು ಒತ್ತಿ"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "ಲ್ಯಾಪ್‌ಟಾಪ್‌ನ ಮುಚ್ಚುಳವನ್ನು ಮುಚ್ಚು"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "ಚೇತರಿಸಕೊಳ್ಳಲಲು ಸಾಧ್ಯವಾಗದಂತಹ ಒಂದು ಆಂತರಿಕ ದೋಷ ಸಂಭವಿಸಿದೆ."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ಗಾಗಿ ಅಗತ್ಯವಿರುವ ತಂತ್ರಾಂಶವನ್ನು ಅನುಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಉತ್ಪಾದಿಸಲಾಗಿಲ್ಲ."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "ಗುರಿಯ ಶ್ವೇತಬಿಂದುವನ್ನು ಪಡೆಯಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ."
+
+#~ msgid "Complete!"
+#~ msgstr "ಪೂರ್ಣಗೊಂಡಿದೆ!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ವಿಫಲಗೊಂಡಿದೆ!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "ನೀವು ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕಬಹುದು."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಪ್ರಗತಿಯಲ್ಲಿರುವಾಗ ಸಾಧನವನ್ನು ಸ್ಥಳಾಂತರಿಸಬೇಡಿ"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "ಲ್ಯಾಪ್‌ಟಾಪ್ ತೆರೆ"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s ಪರದೆ"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s ಸ್ಕ್ಯಾನರ್"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s ಮುದ್ರಕ"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s ವೆಬ್‌ಕ್ಯಾಮ್"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s ಗಾಗಿ ಬಣ್ಣದ ನಿರ್ವಹಣೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸು"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s ಗಾಗಿ ಬಣ್ಣದ ಪ್ರೊಫೈಲ್ ಅನ್ನು ತೋರಿಸು"
+
+#~ msgid "Not calibrated"
+#~ msgstr "ಕ್ಯಾಲಿಬ್ರೇಟ್ ಮಾಡದಿರುವ"
+
+#~ msgid "Default: "
+#~ msgstr "ಪೂರ್ವನಿಯೋಜಿತ: "
+
+#~ msgid "Test profile: "
+#~ msgstr "ಪ್ರಾಯೋಗಿಕ ಪ್ರೊಫೈಲ್: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC ಪ್ರೊಫೈಲ್ ಕಡತವನ್ನು ಆರಿಸು"
+
+#~ msgid "_Import"
+#~ msgstr "ಆಮದು ಮಾಡು (_I)"
+
+#~ msgid "All files"
+#~ msgstr "ಎಲ್ಲಾ ಕಡತಗಳು"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "ಕಡತವನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡುವಲ್ಲಿ ವಿಫಲತೆ: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಇಲ್ಲಿಗೆ ಅಪ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "ಈ URL ಅನ್ನು ಬರೆ."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "ಈ ಗಣಕವನ್ನು ಮರಳಿ ಆರಂಭಿಸು ಹಾಗು ನಿಮ್ಮ ಸಾಮಾನ್ಯ ಕಾರ್ಯಾಚರಣೆ ವ್ಯವಸ್ಥೆಯನ್ನು ಬೂಟ್ ಮಾಡಿ."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಮತ್ತು ಅನುಸ್ಥಾಪಿಸಲು ನಿಮ್ಮ ಜಾಲವೀಕ್ಷಕಕ್ಕೆ URL ಅನ್ನು "
+#~ "ನಮೂದಿಸಿ."
+
+#~ msgid "Save Profile"
+#~ msgstr "ಪ್ರೊಫೈಲನ್ನು ಉಳಿಸು"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "ಆಯ್ಕೆ ಮಾಡಿದ ಸಾಧನಕ್ಕಾಗಿ ಒಂದು ವರ್ಣ ಪ್ರೊಫೈಲನ್ನು ರಚಿಸು"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "ಅಳತೆ ಮಾಡುವ ಉಪಕರಣವನ್ನು ಪತ್ತೆ ಮಾಡಲಾಗಿಲ್ಲ. ದಯವಿಟ್ಟು ಅದನ್ನು ಆನ್ ಮಾಡಲಾಗಿದೆ ಮತ್ತು "
+#~ "ಸರಿಯಾಗಿದೆಯೆ ಎಂದು ಪರೀಕ್ಷಿಸಿ."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "ಅಳೆಯುವ ಉಪಕರಣವು ಮುದ್ರಕ ಪ್ರೊಫೈಲ್ ಅನ್ನು ಬೆಂಬಲಿಸುವುದಿಲ್ಲ."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "ಸಾಧನದ ಬಗೆಗೆ ಪ್ರಸಕ್ತ ಬೆಂಬಲವಿಲ್ಲ."
+
+#~ msgid "Standard Space"
+#~ msgstr "ಶಿಷ್ಟ ಅಂತರ"
+
+#~ msgid "Test Profile"
+#~ msgstr "ಪ್ರಾಯೋಗಿಕ ಪ್ರೊಫೈಲ್"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "ಸ್ವಯಂಚಾಲಿತ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "ಕಳಪೆ ಗುಣಮಟ್ಟ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "ಮಧ್ಯಮ ಗುಣಮಟ್ಟ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "ಉತ್ತಮ ಗುಣಮಟ್ಟ"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "ಪೂರ್ವನಿಯೋಜಿತ RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "ಪೂರ್ವನಿಯೋಜಿತ CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಬೂದು"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "ಮಾರಾಟಗಾರನು ಫ್ಯಾಕ್ಟರಿ ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಡೇಟಾವನ್ನು ಒದಗಿಸಿದ್ದಾರೆ"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "ಈ ಪ್ರೊಫೈಲಿನಿಂದ ಪೂರ್ಣ-ತೆರೆ ಪ್ರದರ್ಶಕ ಸರಿಪಡಿಕೆಯು ಸಾಧ್ಯವಿಲ್ಲ"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "ಈ ಪ್ರೊಫೈಲ್ ಇನ್ನು ಮುಂದೆ ನಿಖರವಾಗಿರುವುದಿಲ್ಲ"
+
+#~ msgid "Done"
+#~ msgstr "ಆಯಿತು"
+
+#~ msgid "Upload profile"
+#~ msgstr "ಪ್ರೊಫೈಲನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡು"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "ಅಂತರಜಾಲ ಸಂಪರ್ಕದ ಅಗತ್ಯವಿದೆ"
+
+#~ msgid "Other…"
+#~ msgstr "ಇತರೆ…"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "ಕಾಲ ವಲಯ (_Z)"
+
+#~ msgid "24-hour"
+#~ msgstr "24-ಗಂಟೆ"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "Lid Closed"
+#~ msgstr "ಮುಚ್ಚುಳ ಮುಚ್ಚಿದೆ"
+
+#~ msgid "Mirrored"
+#~ msgstr "ಪ್ರತಿಬಿಂಬಿತ"
+
+#~ msgid "Off"
+#~ msgstr "ಆಫ್"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "ಸಂಯೋಜಿತ ಪ್ರದರ್ಶಕಗಳನ್ನು ಜೋಡಿಸು"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "ಪ್ರದರ್ಶಕಗಳನ್ನು ಮರಳಿಹೊಂದಿಸಲು ಎಳೆದುಸೇರಿಸಿ"
+
+#~ msgid "Size"
+#~ msgstr "ಗಾತ್ರ"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "ಮೇಲಿನ ಪಟ್ಟಿ ಮತ್ತು ಚಟುವಟಿಕೆ ಅವಲೋಕಗಳನ್ನು ಈ ಪ್ರದರ್ಶಕದಲ್ಲಿ ತೋರಿಸು"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "ಒಂದು ಹೆಚ್ಚುವರಿ ಕಾರ್ಯಸ್ಥಳವನ್ನು ರಚಿಸಲು ಈ ಪ್ರದರ್ಶಕವನ್ನು ಇನ್ನೊಂದಕ್ಕೆ ಜೋಡಿಸು"
+
+#~ msgid "Presentation"
+#~ msgstr "ಪ್ರಸ್ತುತಿ"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "ಸ್ಲೈಡ್‌ಶೋಗಳನ್ನು ಮತ್ತು ಮಾಧ್ಯಮವನ್ನು ಮಾತ್ರ ತೋರಿಸು"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "ಎರಡೂ ಪ್ರದರ್ಶಕಗಳಲ್ಲಿ ನಿಮ್ಮ ಈಗಿನ ನೋಟವನ್ನು ತೋರಿಸಿ"
+
+#~ msgid "Turn Off"
+#~ msgstr "ನಿಷ್ಕ್ರಿಯಗೊಳಿಸು"
+
+#~ msgid "Don't use this display"
+#~ msgstr "ಈ ಪ್ರದರ್ಶಕವನ್ನು ಬಳಸಬೇಡ"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "ತೆರೆಯ ಮಾಹಿತಿಯನ್ನು ಪಡೆಯಲಾಗಲಿಲ್ಲ"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "ಸಂಯೋಜಿತತ ಪ್ರದರ್ಶಕಗಳನ್ನು ಜೋಡಿಸು (_A)"
+
+#~ msgid "Wayland"
+#~ msgstr "ವೇಲ್ಯಾಂಡ್"
+
+#~ msgid "Unknown"
+#~ msgstr "ಗೊತ್ತಿರದ"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-ಬಿಟ್"
+
+#~ msgid "Ask what to do"
+#~ msgstr "ಏನು ಮಾಡಬೇಕು ಎಂದು ಕೇಳು"
+
+#~ msgid "Do nothing"
+#~ msgstr "ಏನೂ ಮಾಡಬೇಡ"
+
+#~ msgid "Open folder"
+#~ msgstr "ಕಡತಕೋಶವನ್ನು ತೆರೆ"
+
+#~ msgid "Other Media"
+#~ msgstr "ಇತರೆ ಮಾಧ್ಯಮ"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ಆಡಿಯೊ CD ಗಳಿಗಾಗಿ ಒಂದು ಅನ್ವಯವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "ವೀಡಿಯೊ DVD ಗಳಿಗಾಗಿ ಒಂದು ಅನ್ವಯವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "ಸಂಗೀತದ ಪ್ಲೇಯರನ್ನು ಜೋಡಿಸಿದಾಗ ಚಲಾಯಿಸಲು ಒಂದು ಅನ್ವಯವನ್ನು ಆರಿಸಿ"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "ಕ್ಯಾಮೆರವನ್ನು ಜೋಡಿಸಿದಾಗ ಚಲಾಯಿಸಲು ಒಂದು ಅನ್ವಯವನ್ನು ಆರಿಸಿ"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "ತಂತ್ರಾಂಶ CD ಗಳಿಗಾಗಿ ಒಂದು ಅನ್ವಯವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "ಖಾಲಿ ಬ್ಲೂ-ರೇ ಡಿಸ್ಕ್"
+
+#~ msgid "blank CD disc"
+#~ msgstr "ಖಾಲಿ CD ಡಿಸ್ಕ್"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "ಖಾಲಿ DVD ಡಿಸ್ಕ್"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "ಖಾಲಿ HD DVD ಡಿಸ್ಕ್"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "ಬ್ಲೂ-ರೇ ವೀಡಿಯೊ ಡಿಸ್ಕ್"
+
+#~ msgid "e-book reader"
+#~ msgstr "ಇ-ಪುಸ್ತಕ ಓದುಗ"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD ವಿಡಿಯೋ ಡಿಸ್ಕ್ "
+
+#~ msgid "Picture CD"
+#~ msgstr "ಚಿತ್ರ CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "ಸೂಪರ ವೀಡಿಯೊ CD"
+
+#~ msgid "Video CD"
+#~ msgstr "ವೀಡಿಯೊ CD"
+
+#~ msgid "Overview"
+#~ msgstr "ಅವಲೋಕನ"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "ಆವೃತ್ತಿ %s"
+
+#~ msgid "Base system"
+#~ msgstr "ಮೂಲ ವ್ಯವಸ್ಥೆ"
+
+#~ msgid "Disk"
+#~ msgstr "ಡಿಸ್ಕ್‍"
+
+#~ msgid "Check for updates"
+#~ msgstr "ಅಪ್‌ಡೇಟ್‌ಗಳಿಗಾಗಿ ಪರೀಕ್ಷಿಸು"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "ಒಂದು ತೆರೆಚಿತ್ರವನ್ನು $PICTURES ಎಂಬಲ್ಲಿ ಉಳಿಸು"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "ಕಿಟಕಿಯ ತೆರೆಚಿತ್ರವನ್ನು  $PICTURES ಎಂಬಲ್ಲಿ ಉಳಿಸು"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "ಒಂದು ಸ್ಥಳದ ತೆರೆಚಿತ್ರವನ್ನು $PICTURES ಎಂಬಲ್ಲಿ ಉಳಿಸು"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "ತೆರೆಚಿತ್ರವನ್ನು ಕ್ಲಿಪ್‌ಬೋರ್ಡಿಗೆ ಪ್ರತಿ ಮಾಡು"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "ಕಿಟಕಿಯ ತೆರೆಚಿತ್ರವನ್ನು ಕ್ಲಿಪ್‌ಬೋರ್ಡಿಗೆ ಪ್ರತಿ ಮಾಡು"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "ಒಂದು ಜಾಗದ ತೆರೆಚಿತ್ರವನ್ನು ಕ್ಲಿಪ್‌ಬೋರ್ಡಿಗೆ ಪ್ರತಿ ಮಾಡು"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "ಒಂದು ಸಣ್ಣ ಸ್ಕ್ರೀನ್‌ಕ್ಯಾಸ್ಟ್‌ ಅನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡು"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "ಮಾರ್ಪಡಕ-ಕೇವಲ ಮುಂದಿನ ಆಕರಕ್ಕೆ ಬದಲಾಯಿಸು"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "ಶಾರ್ಟ್-ಕಟ್;ಪುನರಾವರ್ತನೆ;ಮಿಟುಕಿಸು;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "ಇಚ್ಛೆಯ ಶಾರ್ಟ್-ಕಟ್"
+
+#~ msgid "_Delay:"
+#~ msgstr "ವಿಳಂಬ (_D):"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "ಚಿಕ್ಕದಾದ"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "ನಿಧಾನ"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "ಉದ್ದವಾದ"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "ವೇಗ"
+
+#~ msgid "S_peed:"
+#~ msgstr "ವೇಗ (_p):"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "ಸುಲಭಆಯ್ಕೆಯನ್ನು ತೆಗೆದುಹಾಕು"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "ಒಂದು ಶಾರ್ಟ್-ಕಟ್ ಕೀಲಿಯನ್ನು ಸಂಪಾದಿಸಲು, ಸಾಲಿನಲ್ಲಿ ಕ್ಲಿಕ್ಕಿಸಿ ಹಾಗು ಹೊಸ ಕೀಲಿಗಳನ್ನು "
+#~ "ಒತ್ತಿಹಿಡಿಯಿರಿ ಅಥವ ಅಳಿಸಲು ಬ್ಯಾಕ್‍ಸ್ಪೇಸನ್ನು ಒತ್ತಿ."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<ಗೊತ್ತಿರದ ಕ್ರಿಯೆ>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "ಶಾರ್ಟ್-ಕಟ್ \"%s\" ಅನ್ನು ಬಳಸಲಾಗುವುದಿಲ್ಲ ಏಕೆಂದರೆ ಈ ಕೀಲಿಯನ್ನು ಬಳಸಿಕೊಂಡು ಇದನ್ನು ಟೈಪ್ "
+#~ "ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ.\n"
+#~ "ದಯವಿಟ್ಟು ಒಂದೆ ಸಮಯದಲ್ಲಿ Control, Alt ಅಥವ Shift ನಂತಹ ಕೀಲಿಯನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "\"%s\" ಶಾರ್ಟ್-ಕಟ್ ಅನ್ನು ಇದಕ್ಕಾಗಿ ಈಗಾಗಲೆ ಬಳಸಲಾಗಿದೆ\n"
+#~ "\"%s\""
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "ಶಾರ್ಟ್-ಕಟ್‌ ಅನ್ನು \"%s\" ಗೆ ನಿಯೋಜಿಸಿದಲ್ಲಿ, \"%s\" ಶಾರ್ಟ್-ಕಟ್‌ ಅಶಕ್ತಗೊಳ್ಳುತ್ತದೆ."
+
+#~ msgid "_Reassign"
+#~ msgstr "ಮರಳಿ ನಿಯೋಜಿಸು (_R)"
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" ಸಮೀಪಮಾರ್ಗವು ಒಂದು ಸಂಬಂಧಿಸಿದ \"%s\" ಸಮೀಪಮಾರ್ಗವನ್ನು ಹೊಂದಿದೆ. ನೀವು ಇದನ್ನು "
+#~ "\"%s\" ಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊಂದಿಸಲು ಬಯಸುವಿರಾ?"
+
+#, c-format
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" ಎನ್ನುವುದು ಪ್ರಸಕ್ತ \"%s\" ಎನ್ನುವುದಕ್ಕೆ ಸಂಬಂಧಿಸಿದೆ, ನೀವು ಮುಂದಕ್ಕೆ ಹೋದಲ್ಲಿ ಈ "
+#~ "ಸಮೀಪಮಾರ್ಗವನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗುತ್ತದೆ."
+
+#~ msgid "_Assign"
+#~ msgstr "ನಿಯೋಜಿಸು (_A)"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "ನಿಮ್ಮ ಸಿದ್ಧತೆಗಳನ್ನು ಪರೀಕ್ಷಿಸಿ"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "ನಿಧಾನ"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "ಎರಡು-ಬಾರಿ ಕ್ಲಿಕ್ಕಿಸುವ ಕಾಲಾವಧಿ ಮೀರಿಕೆ"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "ವೇಗ"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "ಎಡ (_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "ಬಲ (_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "ಸೂಚಕದ ವೇಗ (_P)"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ನಿಧಾನ"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "ವೇಗ"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ನಿಧಾನ"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "ವೇಗ"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "ಎರಡು ಬೆರಳಿನ ಚಲನೆ (_f)"
+
+#~ msgid "_Natural scrolling"
+#~ msgstr "ಸಾಮಾನ್ಯವೇಗದ ಸ್ಕ್ರಾಲಿಂಗ್ (_N)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "ಐದು ಕ್ಲಿಕ್‌ಗಳು, GEGL ಸಮಯ!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "ಎರಡು-ಬಾರಿಯ ಕ್ಲಿಕ್, ಪ್ರಾಥಮಿಕ ಗುಂಡಿ"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "ಒಂದೇ ಕ್ಲಿಕ್, ಪ್ರಾಥಮಿಕ ಗುಂಡಿ"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "ಎರಡು-ಬಾರಿಯ ಕ್ಲಿಕ್, ಮಧ್ಯದ ಗುಂಡಿ"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "ಒಂದೇ ಕ್ಲಿಕ್, ಪ್ರಾಥಮಿಕ ಗುಂಡಿ"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "ಎರಡು-ಬಾರಿಯ ಕ್ಲಿಕ್, ಎರಡನೆಯ ಗುಂಡಿ"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "ಒಂದೇ ಕ್ಲಿಕ್, ಎರಡನೆಯ ಗುಂಡಿ"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "ವ್ಯವಸ್ಥೆಯ ಜಾಲಬಂಧ ಸೇವೆಗಳು ಈ ಆವೃತ್ತಿಯೊಂದಿಗೆ ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ."
+
+#~ msgid "page 1"
+#~ msgstr "ಪುಟ 1"
+
+#~ msgid "page 2"
+#~ msgstr "ಪುಟ 2"
+
+#~ msgid "automatic"
+#~ msgstr "ಸ್ವಯಂಚಾಲಿತ"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "ಎಂಟರ್ಪ್ರೈಸ್"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#~ msgid "Never"
+#~ msgstr "ಎಂದೂ ಬೇಡ"
+
+#~ msgid "Today"
+#~ msgstr "ಇಂದು"
+
+#~ msgid "Yesterday"
+#~ msgstr "ನಿನ್ನೆ"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "ದುರ್ಬಲ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ಸರಿ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "ಉತ್ತಮ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "ಅತ್ಯುತ್ತಮ"
+
+#~ msgid "Identity"
+#~ msgstr "ಗುರುತು"
+
+#~ msgid "Server"
+#~ msgstr "ಪೂರೈಕೆಗಣಕ"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS ಸಾಧನವನ್ನು ಅಳಿಸು"
+
+#~ msgid "Delete Route"
+#~ msgstr "ರೌಟ್ ಅನ್ನು ಅಳಿಸು"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-ಬಿಟ್ ಕೀಲಿ (ಹೆಕ್ಸ್‍ ಅಥವ ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-ಬಿಟ್‌ ಗುಪ್ತವಾಕ್ಯಾಂಶ"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "ಡೈನಮಿಕ್ WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 ಪರ್ಸನಲ್"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 ಎಂಟರ್ಪ್ರೈಸ್"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "ಟ್ವಿಸ್ಟೆಡ್ ಪೇರ್ (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "ಅಟ್ಯಾಚ್‌ಮೆಂಟ್ ಯುನಿಟ್ ಇಂಟರ್ಫೇಸ್ (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "ಮೀಡಿಯಾ ಇಂಡಿಪೆಂಡೆಂಟ್ ಇಂಟರ್ಫೇಸ್ (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "ಇತರೆ ಬಳಕೆದಾರರಿಗೆ ಲಭ್ಯವಾಗುವಂತೆ ಮಾಡು (_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "ಫೈರ್ವಾಲ್ ವಲಯ (_Z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "ಪೂರ್ವನಿಯೋಜಿತ"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "ವಲಯವು ಸಂಪರ್ಕದ ನಂಬಿಕೆಯ ಮಟ್ಟವನ್ನು ವಿವರಿಸುತ್ತದೆ"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "ಸಂಪರ್ಕ ಸಂಪಾದಕವನ್ನು ತೆರೆಯಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#~ msgid "New Profile"
+#~ msgstr "ಹೊಸ ಪ್ರೊಫೈಲ್"
+
+#~ msgid "Bond"
+#~ msgstr "ಬಾಂಡ್"
+
+#~ msgid "Team"
+#~ msgstr "ಟೀಮ್"
+
+#~ msgid "Bridge"
+#~ msgstr "ಬ್ರಿಜ್"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN ಪ್ಲಗ್‌ಇನ್‌ಗಳನ್ನು ಲೋಡ್‌ ಮಾಡಲಾಗಲಿಲ್ಲ"
+
+#~ msgid "Import from file…"
+#~ msgstr "ಕಡತದಿಂದ ಆಮದು ಮಾಡು..."
+
+#~ msgid "Add Network Connection"
+#~ msgstr "ಜಾಲಬಂಧ ಸಂಪರ್ಕವನ್ನು ಸೇರಿಸು"
+
+#~ msgid "_Reset"
+#~ msgstr "ಮರಳಿ ಅಣಿಗೊಳಿಸು (_R)"
+
+#~ msgid "_Forget"
+#~ msgstr "ಮರೆತುಬಿಡು (_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "ಈ ಜಾಲಬಂಧಕ್ಕಾಗಿನ ಗುಪ್ತಪದಗಳನ್ನೂ ಸೇರಿದಂತೆ ಸಿದ್ಧತೆಗಳನ್ನು ಮರುಹೊಂದಿಸು, ಆದರೆ ಇದನ್ನು "
+#~ "ಆದ್ಯತೆಯ ಜಾಲಬಂಧ ಎಂದು ನೆನಪಿಟ್ಟುಕೊ"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "ಈ ಜಾಲಬಂಧಕ್ಕೆ ಸಂಬಂಧಿಸದ ಎಲ್ಲಾ ವಿವರಗಳನ್ನು ತೆಗೆದುಹಾಕು ಮತ್ತು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಂಪರ್ಕ "
+#~ "ಸಾಧಿಸಲು ಪ್ರಯತ್ನಿಸಬೇಡ"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN ಸಂಪರ್ಕವನ್ನು ಆಮದು ಮಾಡಲಾಗಿಲ್ಲ"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "'%s' ಕಡತವನ್ನು ಓದಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ ಅಥವ ಗುರುತಿಸಲಾದ VPN ಸಂಪರ್ಕ ಮಾಹಿತಿಯನ್ನು ಹೊಂದಿಲ್ಲ\n"
+#~ "\n"
+#~ "ದೋಷ: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "ಆಮದು ಮಾಡಲು ಕಡತವನ್ನು ಆರಿಸಿ"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "\"%s\" ಎಂಬ ಹೆಸರಿನ ಕಡತವು ಈಗಾಗಲೆ ಅಸ್ತಿತ್ವದಲ್ಲಿದೆ."
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "%s ಅನ್ನು ನೀವು ಉಳಿಸುತ್ತಿರುವ VPN ಸಂಪರ್ಕದಿಂದ ಬದಲಾಯಿಸಲು ಬಯಸುವಿರಾ?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN ಸಂಪರ್ಕವನ್ನು ರಫ್ತು ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "'%s' VPN ಸಂಪರ್ಕವನ್ನು %s ಎಂಬಲ್ಲಿಗೆ ರಫ್ತು ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ.\n"
+#~ "\n"
+#~ "ದೋಷ: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN ಸಂಪರ್ಕವನ್ನು ರಫ್ತುಮಾಡು"
+
+#~ msgid "Bond slaves"
+#~ msgstr "ಬಾಂಡ್‌ ಸ್ಲೇವ್‌ಗಳು"
+
+#~ msgid "(none)"
+#~ msgstr "(ಯಾವುದೂ ಇಲ್ಲ)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "ಬ್ರಿಜ್‌ ಸ್ಲೇವ್‌ಗಳು"
+
+#~ msgid "never"
+#~ msgstr "ಎಂದಿಗೂ ಬೇಡ"
+
+#~ msgid "today"
+#~ msgstr "ಇಂದು"
+
+#~ msgid "yesterday"
+#~ msgstr "ನಿನ್ನೆ"
+
+#~ msgid "Last used"
+#~ msgstr "ಕೊನೆಯ ಬಾರಿಗೆ ಬಳಸಿದ್ದು"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "ಪ್ರೊಫೈಲ್ %d"
+
+#~ msgid "Team slaves"
+#~ msgstr "ಟೀಮ್‌ ಸ್ಲೇವ್‌ಗಳು"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "ನೀವು ವೈರ್ಲೆಸ್ ಅನ್ನು ಹೊರತುಪಡಿಸಿ ಬೇರೇ ರೀತಿಯ ಅಂತರಜಾಲ ಸಂಪರ್ಕವನ್ನು ಹೊಂದಿದ್ದಲ್ಲಿ, ನಿಮ್ಮ "
+#~ "ಅಂತರಜಾಲ ಸಂಪರ್ಕವನ್ನು ಇತರರೊಂದಿಗೆ ಹಂಚಿಕೊಳ್ಳಲು ನೀವು ಒಂದು ವೈರ್ಲೆಸ್ ಬಹುದಾಗಿರುತ್ತದೆ."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "ವೈರ್ಲೆಸ್ ಹಾಟ್‌ಸ್ಪಾಟ್‌ಗೆ ಬದಲಾಯಿಸಿದಲ್ಲಿ <b>%s</b> ದೊಂದಿಗಿನ ನಿಮ್ಮ ಸಂಪರ್ಕವು "
+#~ "ಕಡಿದುಹೋಗುತ್ತದೆ."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "ಹಾಟ್‌ಸ್ಪಾಟ್ ಸಕ್ರಿಯವಾಗಿದ್ದಾಗ ನಿಮ್ಮ ವೈರ್ಲೆಸ್‌ ಮುಖಾಂತರ ಅಂತರಜಾಲದೊಂದಿಗೆ ಸಂಪರ್ಕ ಜೋಡಿಸುವುದು "
+#~ "ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್‌ ಅನ್ನು ನಿಲ್ಲಿಸಲು ಮತ್ತು ಅದರ ಯಾವುದೆ ಬಳಕೆದಾರರನ್ನು ಸಂಪರ್ಕ ತಪ್ಪಿಸಬೇಕೆ?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್ ಅನ್ನು ನಿಲ್ಲಿಸು (_S):"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್ ಆಗಿ ಬಳಸುವುದಂತೆ ವ್ಯವಸ್ಥೆಯ ಪಾಲಿಯು ತಡೆಯುತ್ತಿದೆ"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "ವೈರ್ಲೆಸ್ ಸಾಧನವು ಹಾಟ್‌ಸ್ಪಾಟ್ ಕ್ರಮವನ್ನು ಬೆಂಬಲಿಸುವುದಿಲ್ಲ"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "ಗುಪ್ತಪದಗಳು ಮತ್ತು ಯಾವುದೆ ಅಗತ್ಯಾನುಗುಣ ಸಂರಚನೆಯೂ ಸಹ ಸೇರಿದಂತೆ  ಆಯ್ಕೆ ಮಾಡಲಾದ "
+#~ "ಜಾಲಬಂಧಗಳಿಗಾಗಿ ಜಾಲಬಂಧ ವಿವರಗಳು ನಾಶಗೊಳ್ಳುತ್ತವೆ."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "ಮರೆತುಬಿಡು (_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "ಸಂರಚನಾ URL ಅನ್ನು ಒದಗಿಸದೇ ಇದ್ದಲ್ಲಿ ವೆಬ್ ಪ್ರಾಕ್ಸಿ ಆಟೋಡಿಸ್ಕವರಿಯನ್ನು ಬಳಸಲಾಗುತ್ತದೆ."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "ಇದನ್ನು ನಂಬಿಕೆಗೆ ಅನರ್ಹವಾದ ಸಾರ್ವಜನಿಕ ಜಾಲಬಂಧಗಳಲ್ಲಿ ಇದು ಒಳ್ಳೆಯದಲ್ಲ"
+
+#~ msgid "Proxy"
+#~ msgstr "ಪ್ರಾಕ್ಸಿ"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "ಕೈಯಾರೆ"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "ಸ್ವಯಂಚಾಲಿತ"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN ಬಗೆ"
+
+#~ msgid "Group Name"
+#~ msgstr "ಗುಂಪಿನ ಹೆಸರು"
+
+#~ msgid "Group Password"
+#~ msgstr "ಗುಂಪನ ಗುಪ್ತಪದ"
+
+#~ msgid "details"
+#~ msgstr "ವಿವರಗಳು"
+
+#~ msgid "Show P_assword"
+#~ msgstr "ಗುಪ್ತಪದವನ್ನು ತೋರಿಸು (_a)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "ಇತರೆ ಬಳಕೆದಾರರಿಗೆ ಲಭ್ಯವಾಗುವಂತೆ ಮಾಡು"
+
+#~ msgid "identity"
+#~ msgstr "ಗುರುತು"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "ಸ್ವಯಂಚಾಲಿತ (DHCP) ವಿಳಾಸಗಳು ಮಾತ್ರ"
+
+#~ msgid "Link-local only"
+#~ msgstr "ಸ್ಥಳೀಯ-ಕೊಂಡಿ ಮಾತ್ರ"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪಡೆಯಲಾದ ರೌಟ್‌ಗಳನ್ನು ಕಡೆಗಣಿಸು (_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "ತದ್ರೂಪುಗೊಳಿಸಲಾದ MA_C ವಿಳಾಸ"
+
+#~ msgid "hardware"
+#~ msgstr "ಯಂತ್ರಾಂಶ"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "ಈ ಸಂಪರ್ಕಕ್ಕಾಗಿನ ಸಿದ್ಧತೆಗಳನ್ನು ಅವುಗಳ ಪೂರ್ವನಿಯೋಜಿತಕ್ಕೆ ಮರುಹೊಂದಿಸು, ಆದರೆ ಆದ್ಯತೆಯ "
+#~ "ಸಂಪರ್ಕ ಎಂದು ನೆನಪಿಡು."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "ಈ ಜಾಲಬಂಧಕ್ಕೆ ಸಂಬಂಧಿಸಿದ ಎಲ್ಲಾ ವಿವರಗಳನ್ನು ತೆಗೆದುಹಾಕು ಮತ್ತು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಂಪರ್ಕ "
+#~ "ಸಾಧಿಸಲು ಪ್ರಯತ್ನಿಸಬೇಡ."
+
+#~ msgid "reset"
+#~ msgstr "ಮರುಹೊಂದಿಸು"
+
+#~ msgid "Hardware"
+#~ msgstr "ಯಂತ್ರಾಂಶ"
+
+#~ msgid "_History"
+#~ msgstr "ಇತಿಹಾಸ (_H)"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "ವೈ-ಫೈ ಜಾಲಬಂಧದೊಂದಿಗೆ ಸಂಪರ್ಕ ಹೊಂದಲು ಸ್ವಿಚ್ ಅನ್ನು ಆಫ್ ಮಾಡು"
+
+#~ msgid "Connected Devices"
+#~ msgstr "ಸಂಪರ್ಕಗೊಂಡಿರುವ ಸಾಧನ"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "ತಾತ್ಕಾಲಿಕ"
+
+#~ msgid "Infrastructure"
+#~ msgstr "ಮೂಲಭೂತ ವ್ಯವಸ್ಥೆ"
+
+#~ msgid "Status unknown"
+#~ msgstr "ಗೊತ್ತಿರದ ಸ್ಥಿತಿ"
+
+#~ msgid "Unmanaged"
+#~ msgstr "ನಿರ್ವಹಿಸದೆ ಇರುವ"
+
+#~ msgid "Unavailable"
+#~ msgstr "ಲಭ್ಯವಿಲ್ಲ"
+
+#~ msgid "Connecting"
+#~ msgstr "ಸಂಪರ್ಕ ಕಲ್ಪಿಸಲಾಗುತ್ತಿದೆ"
+
+#~ msgid "Disconnecting"
+#~ msgstr "ಸಂಪರ್ಕ ಕಡಿದುಹಾಕಲಾಗುತ್ತಿದೆ"
+
+#~ msgid "Connection failed"
+#~ msgstr "ಸಂಪರ್ಕವು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "ಗೊತ್ತಿರದ ಸ್ಥಿತಿ (ಕಾಣೆಯಾಗಿದೆ)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "ಸಂರಚನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP ಸಂರಚನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP ಸಂರಚನೆಯ ವಾಯಿದೆ ತೀರಿದೆ"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "ರಹಸ್ಯಗಳ ಅಗತ್ಯವಿದೆ, ಆದರೆ ಅದನ್ನು ಒದಗಿಸಲಾಗಿಲ್ಲ"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x ಸಪ್ಲಿಕ್ಯಾಂಟ್‌ನಿಂದ ಸಂಪರ್ಕ ಕಡಿದಿದೆ"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x ಸಪ್ಲಿಕೆಂಟ್ ಸಂರಚನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x ಸಪ್ಲಿಕೆಂಟ್ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x ಸಪ್ಲಿಕೆಂಟ್ ದೃಢೀಕರಿಸಲು ಬಹಳ ಹೊತ್ತು ತೆಗೆದುಕೊಂಡಿದೆ"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP ಸೇವೆಯನ್ನು ಆರಂಭಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP ಸಂಪರ್ಕವನ್ನು ಕಡಿದು ಹಾಕಲಾಗಿದೆ"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP ಕ್ಲೈಂಟ್ ಆರಂಭಗೊಳ್ಳಲು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP ಕ್ಲೈಂಟ್‌ ದೋಷ"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP ಕ್ಲೈಂಟ್ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "ಹಂಚಲಾದ ಸಂಪರ್ಕ ಸೇವೆಯು ಆರಂಭಗೊಳ್ಳುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "ಹಂಚಲಾದ ಸಂಪರ್ಕ ಸೇವೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP ಸೇವೆಯು ಆರಂಭಗೊಳ್ಳುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP ಸೇವೆಯ ದೋಷ"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP ಸೇವೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Line busy"
+#~ msgstr "ಮಾರ್ಗವು ಕಾರ್ಯನಿರತವಾಗಿದೆ"
+
+#~ msgid "No dial tone"
+#~ msgstr "ಯಾವುದೆ ಡಯಲ್ ಟೋನ್ ಇಲ್ಲ"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "ಯಾವುದೆ ವಾಹಕವನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "ಡಯಲ್ ಮಾಡುವ ಮನವಿಯ ಸಮಯ ಮೀರಿದೆ"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "ಡಯಲ್ ಮಾಡುವ ಪ್ರಯತ್ನವು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "ಮಾಡೆಮ್ ಆರಂಭಗೊಳ್ಳುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "ನಿಶ್ಚಿತ APN ಅನ್ನು ಆರಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "ಜಾಲಬಂಧಗಳಿಗಾಗಿ ಹುಡುಕಲಾಗುತ್ತಿಲ್ಲ"
+
+#~ msgid "Network registration denied"
+#~ msgstr "ಜಾಲಬಂಧ ನೋಂದಣಿಯನ್ನು ನಿರಾಕರಿಸಲಾಗಿದೆ"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "ಜಾಲಬಂಧ ನೋಂದಣಿಯ ಸಮಯ ಮೀರಿದೆ"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "ಮನವಿ ಮಾಡಲಾದ ಜಾಲಬಂಧದೊಂದಿಗೆ ನೋಂದಾಯಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN ಪರಿಶೀಲನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "ಸಾಧನದ ಫರ್ಮವೇರ್ ಕಾಣಿಸುತ್ತಿಲ್ಲ"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "ಸಂಪರ್ಕವು ಕಾಣೆಯಾಗಿದೆ"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "ಈಗಿರುವ ಸಂಪರ್ಕವನ್ನು ಊಹಿಸಲಾಗಿದೆ"
+
+#~ msgid "Modem not found"
+#~ msgstr "ಮಾಡೆಮ್ ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ಬ್ಲೂಟೂತ್ ಸಂಪರ್ಕವು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "ಸಿಮ್‌ ಪಿನ್ ಅಗತ್ಯವಿದೆ"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "ಸಿಮ್‌ Puk ಅಗತ್ಯವಿದೆ"
+
+#~ msgid "SIM wrong"
+#~ msgstr "ಸಿಮ್‌ ತಪ್ಪಾಗಿದೆ"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "ಸಂಪರ್ಕಿತಗೊಂಡ ಕ್ರಮದಲ್ಲಿ InfiniBand ಸಾಧನಕ್ಕೆ ಬೆಂಬಲವಿರುವುದಿಲ್ಲ"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "ಸಂಪರ್ಕದ ಅವಲಂಬನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "ಕೇಬಲ್‌ ಅನ್ನು ತೆಗೆಯಲಾಗಿದೆ"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "ಯಾವುದೆ ಸರ್ಟಿಫಿಕೇಟ್ ಅಥಾರಿಟಿ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆ ಮಾಡಲಾಗಿಲ್ಲ"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "ಸರ್ಟಿಫಿಕೇಟ್ ಅತಾರಿಟಿ (CA) ಪ್ರಮಾಣಪತ್ರವನ್ನು ಬಳಸದೆ ಇದ್ದಲ್ಲಿ ಸಂಪರ್ಕಗಳು ಅಸುರಕ್ಷಿತ, ದುಷ್ಟ "
+#~ "Wi-Fi ಜಾಲಬಂಧಗಳಾಗಲು ಕಾರಣವಾಗಬಹುದು. ನೀವು ಸರ್ಟಿಫಿಕೇಟ್ ಅತಾರಿಟಿ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆ "
+#~ "ಮಾಡಲು ಬಯಸುವಿರಾ?"
+
+#~ msgid "Ignore"
+#~ msgstr "ಕಡೆಗಣಿಸು"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆ ಮಾಡು"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, ಅಥವ PKCS#12 ಖಾಸಗಿ ಕೀಲಿಗಳು (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER ಅಥವ PEM ಪ್ರಮಾಣಪತ್ರಗಳು (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ಕಡತಗಳು (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "ಪ್ರತಿ ಬಾರಿಯೂ ಸಹ ಈ ಗುಪ್ತಪದಕ್ಕಾಗಿ ಕೇಳು (_k)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "ಗೂಢಲಿಪೀಕರಿಸದ ಖಾಸಗಿ ಕೀಲಿಗಳು ಅಸುರಕ್ಷಿತವಾಗಿರುತ್ತವೆ"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "ಆಯ್ಕೆ ಮಾಡಲಾದ ಖಾಸಗಿ ಕೀಲಿಯು ಒಂದು ಗುಪ್ತಪದದಿಂದ ಸಂರಕ್ಷಿತಗೊಂಡಿರುವಂತೆ ಕಾಣಿಸುತ್ತಿಲ್ಲ.  "
+#~ "ಇದರಿಂದಾಗಿ ನಿಮ್ಮ ಸುರಕ್ಷತಾ ರುಜುವಾತನ್ನು ರಾಜಿ ಮಾಡಿಕೊಂಡಂತಾಗುತ್ತದೆ.  ದಯವಿಟ್ಟು ಒಂದು "
+#~ "ಗುಪ್ತಪದದಿಂದ ಸಂರಿಕ್ಷಿತಗೊಂಡಂತಹ ಖಾಸಗಿ ಕೀಲಿಯನ್ನು ಒದಗಿಸಿ.\n"
+#~ "\n"
+#~ "(ನೀವು ನಿಮ್ಮ ಖಾಸಗಿ ಕೀಲಿಯನ್ನು openssl ಬಳಸಿಕೊಂಡು ಸಂರಕ್ಷಿಸಿ)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "ನಿಮ್ಮ ವೈಯಕ್ತಿಕ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆರಿಸಿ"
+
+#~ msgid "Choose your private key"
+#~ msgstr "ನಿಮ್ಮ ಖಾಸಗಿ ಕೀಲಿಯನ್ನು ಆರಿಸಿ"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "ನನ್ನನ್ನು ಇನ್ನೊಮ್ಮೆ ಎಚ್ಚರಿಸಬೇಡ (_w)"
+
+#~ msgid "Yes"
+#~ msgstr "ಹೌದು"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "ಪಾಪ್ಅಪ್ ಬ್ಯಾನರುಗಳನ್ನು ತೋರಿಸು"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "ವಿವರಗಳನ್ನು ಬ್ಯಾನರುಗಳಲ್ಲಿ ತೋರಿಸು"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ನೋಡು"
+
+#~ msgid "On"
+#~ msgstr "ಚಾಲಿತ"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "ಪಾಪ್ ಅಪ್ ಬ್ಯಾನರುಗಳನ್ನು ತೋರಿಸು"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ತೋರಿಸು"
+
+#~ msgid "Add Account"
+#~ msgstr "ಖಾತೆಯನ್ನು ಸೇರಿಸು"
+
+#~ msgid "Mail"
+#~ msgstr "ಅಂಚೆ"
+
+#~ msgid "Contacts"
+#~ msgstr "ಸಂಪರ್ಕವಿಳಾಸಗಳು"
+
+#~ msgid "Chat"
+#~ msgstr "ಚಾಟ್"
+
+#~ msgid "Resources"
+#~ msgstr "ಸಂಪನ್ಮೂಲಗಳು"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "ಖಾತೆಗೆ ದಾಖಲಾಗುವಲ್ಲಿ ದೋಷ ಉಂಟಾಗಿದೆ"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "ರುಜುವಾತುಗಳ ವಾಯಿದೆ ತೀರಿದೆ."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "ಈ ಖಾತೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಸೈನ್ ಇನ್ ಆಗಿ."
+
+#~ msgid "_Sign In"
+#~ msgstr "ಸೈನ್ ಇನ್ (_S)"
+
+#~ msgid "Error creating account"
+#~ msgstr "ಖಾತೆಯನ್ನು ರಚಿಸುವಲ್ಲಿ ದೋಷ"
+
+#~ msgid "Error removing account"
+#~ msgstr "ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕುವಲ್ಲಿ ದೋಷ"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕಲು ನೀವು ಖಚಿತವೆ?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "ಇದು ಪರಿಚಾರಕದಿಂದ ಖಾತೆಯನ್ನು ತೆಗೆದು ಹಾಕುವುದಿಲ್ಲ."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "ಯಾವುದೆ ಆನ್‌ಲೈನ್ ಖಾತೆಗಳನ್ನು ಸಂರಚಿಸಲಾಗಿಲ್ಲ"
+
+#~ msgid "Remove Account"
+#~ msgstr "ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕು"
+
+#~ msgid "Add an online account"
+#~ msgstr "ಅಂತರಜಾಲದಲ್ಲಿನ ಖಾತೆಯನ್ನು ಸೇರಿಸು"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "ಒಂದು ಖಾತೆಯನ್ನು ಸೇರಿಸುವುದರಿಂದ ಅದನ್ನು ನಿಮ್ಮ ಅನ್ವಯಗಳನ್ನು ದಸ್ತಾವೇಜುಗಳಿಗೆ, ಅಂಚೆಗೆ, "
+#~ "ಸಂಪರ್ಕವಿಳಾಸಗಳಿಗೆ, ಕ್ಯಾಲೆಂಡರಿಗೆ, ಹರಟೆ ಮತ್ತು ಮುಂತಾದವುಗಳಿಗಾಗಿ ನಿಲುಕಿಸಿಕೊಳ್ಳಲು "
+#~ "ಸಾಧ್ಯವಾಗುತ್ತದೆ."
+
+#~ msgid "Unknown time"
+#~ msgstr "ಗೊತ್ತಿರದ ಸಮಯ"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "ಚಾರ್ಜ್ ಮಾಡಿದಾಗಿನಿಂದ  %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "ಎಚ್ಚರಿಕೆ, %s ಬಾಕಿ ಇದೆ"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s ಬಾಕಿ ಇದೆ"
+
+#~ msgid "Fully charged"
+#~ msgstr "ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ"
+
+#~ msgid "Empty"
+#~ msgstr "ಖಾಲಿ"
+
+#~ msgid "Charging"
+#~ msgstr "ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ"
+
+#~ msgid "Discharging"
+#~ msgstr "ಡಿಸ್‌ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "ಮುಖ್ಯ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "ಹೆಚ್ಚುವರಿ"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "ತಂತಿರಹಿತ ಮೌಸ್"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "ತಂತಿರಹಿತ ಕೀಲಿಮಣೆ"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "ತಡೆರಹಿತ ವಿದ್ಯುತ್ ಪೂರೈಕೆ"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "ವೈಯಕ್ತಿಕ ಡಿಜಿಟಲ್ ಸಹಾಯಕ"
+
+#~ msgid "Cellphone"
+#~ msgstr "ಸೆಲ್‌ಫೋನ್"
+
+#~ msgid "Media player"
+#~ msgstr "ಮಾಧ್ಯಮ ಚಾಲಕ"
+
+#~ msgid "Computer"
+#~ msgstr "ಗಣಕ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "ಎಚ್ಚರಿಕೆ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "ಕೆಳ ಮಟ್ಟದ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "ಉತ್ತಮ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "ಸಂಪುರ್ಣವಾಗಿ ಚಾರ್ಜ್ ಆಗಿದೆ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "ಖಾಲಿ"
+
+#~ msgid "Batteries"
+#~ msgstr "ಬ್ಯಾಟರಿಗಳು"
+
+#~ msgid "When _idle"
+#~ msgstr "ಜಡವಾಗಿದ್ದಾಗ (_i)"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "ಕೀಲಿಮಣೆ ಪ್ರಕಾಶತೆ (_K)"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "ಚಟುವಟಿಕೆ ಇಲ್ಲದಾಗ ತೆರೆಯನ್ನು ಮಂದಗೊಳಿಸು (_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "ವೈ-ಫೈ (_W)"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "ವೈರ್ಲೆಸ್ ಸಾಧನಗಳನ್ನು ಆಫ್ ಮಾಡುತ್ತದೆ"
+
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "ಮೊಬೈಲ್ ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್‌ (3G, 4G, WiMax, ಇತರೆ.) ಸಾಧನಗಳನ್ನು ಆಫ್ ಮಾಡುತ್ತದೆ"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "ಬ್ಲೂಟೂತ್ (_B)"
+
+#~ msgid "When on battery power"
+#~ msgstr "ಬ್ಯಾಟರಿ ವಿದ್ಯುಚ್ಛಕ್ತಿಯನ್ನು ಬಳಸುವಾಗ"
+
+#~ msgid "When plugged in"
+#~ msgstr "ವಿದ್ಯುಚ್ಧಕ್ತಿ ಸಂಪರ್ಕ ಜೋಡಿಸಿದಾಗ"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "ಅಮಾನತುಗೊಳಿಸು ಮತ್ತು ಆಫ್ ಮಾಡು"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "ಸ್ವಯಂಚಾಲಿತ ಅಮಾನತು (_A)"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "ಬ್ಯಾಟರಿಯ ವಿದ್ಯುಚ್ಛಕ್ತಿಯು ಸಂದಿಗ್ಧ ಮಟ್ಟದಲ್ಲಿದ್ದಾಗ (_c)"
+
+#~ msgid "Power Off"
+#~ msgstr "ಆಫ್ ಮಾಡು"
+
+#~ msgid "Hibernate"
+#~ msgstr "ಹೈಬರ್ನೇಟ್"
+
+#~ msgid "1 minute"
+#~ msgstr "1 ನಿಮಿಷ"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 ನಿಮಿಷಗಳು"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 ನಿಮಿಷಗಳು"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 ನಿಮಿಷಗಳು"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 ನಿಮಿಷಗಳು"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 ನಿಮಿಷಗಳು"
+
+#~ msgid "Out of toner"
+#~ msgstr "ಟೋನರ್ ಖಾಲಿಯಾಗಿದೆ"
+
+#~ msgid "Low on developer"
+#~ msgstr "ವಿಕಸನೆಗಾರ ಕಡಿಮೆ ಇದೆ"
+
+#~ msgid "Out of developer"
+#~ msgstr "ವಿಕಸನೆಗಾರ ಖಾಲಿಯಾಗಿದೆ"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "ಮಾರ್ಕರ್ ಪೂರೈಕೆಯಲ್ಲಿ ಕೊರತೆಯಿದೆ"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "ಮಾರ್ಕರ್ ಪೂರೈಕೆ ಇಲ್ಲವಾಗಿದೆ"
+
+#~ msgid "Open cover"
+#~ msgstr "ಮುಚ್ಚಣ ತೆರೆದಿದೆ"
+
+#~ msgid "Open door"
+#~ msgstr "ಬಾಗಿಲು ತೆರೆದಿದೆ"
+
+#~ msgid "Low on paper"
+#~ msgstr "ಕಾಗದ ಕಡಿಮೆ ಇದೆ"
+
+#~ msgid "Out of paper"
+#~ msgstr "ಕಾಗದದ ಖಾಲಿಯಾಗಿದೆ"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "ನಿಲ್ಲಿಸಲಾಗಿದೆ"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "ಕಸದ ಬುಟ್ಟಿಯು ಬಹುಪಾಲು ತುಂಬಿದೆ"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "ಕಸದ ಬುಟ್ಟಿ ತುಂಬಿದೆ"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ಆಪ್ಟಿಕಲ್ ಫೋಟೊ ಕಂಡಕ್ಟರ್ ಸ್ಥಗಿತಗೊಳ್ಳುವ ಹಂತದಲ್ಲಿದೆ"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ಆಪ್ಟಿಕಲ್ ಫೋಟೊ ಕಂಡಕ್ಟರ್ ಕೆಲಸ ಮಾಡುತ್ತಿಲ್ಲ"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "ಸಿದ್ಧಗೊಂಡಿದೆ"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "ಕಾರ್ಯಗಳನ್ನು ಸ್ವೀಕರಿಸುವುದಿಲ್ಲ"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "ಸಂಸ್ಕರಿಸಲಾಗುತ್ತಿದೆ"
+
+#~ msgid "Toner Level"
+#~ msgstr "ಟೋನರ್ ಮಟ್ಟ"
+
+#~ msgid "Supply Level"
+#~ msgstr "ಒದಗಣೆಯ ಮಟ್ಟ"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "ಅನುಸ್ಥಾಪಿಸಲಾಗುತ್ತಿದೆ"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u ಸಕ್ರಿಯ"
+#~ msgstr[1] "%u ಸಕ್ರಿಯ"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "ಹೊಸ ಮುದ್ರಕವನ್ನು ಸೇರಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ."
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript ಪ್ರಿಂಟರ್ ಡಿಸ್ಕ್ರಿಪ್ಶನ್ ಕಡತಗಳು (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "ಯಾವುದೆ ಸೂಕ್ತ ಚಾಲಕವು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui ಅನ್ನುಲೋಡ್‌ ಮಾಡಲಾಗಲಿಲ್ಲ: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "ಮುದ್ರಣವನ್ನು ಮರುಆರಂಭಿಸು"
+
+#~ msgid "Pause Printing"
+#~ msgstr "ಮುದ್ರಣವನ್ನು ತಾತ್ಕಾಲಿಕ ನಿಲ್ಲಿಸು"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "ಒಂದು ಹೊಸ ಮುದ್ರಕವನ್ನು ಸೇರಿಸಿ"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "ಫಲಿತಾಂಶಗಳನ್ನು ಫಿಲ್ಟರ್‌ ಮಾಡಲು ಒಂದು ಮುದ್ರಕದ ವಿಳಾಸ ಅಥವ ಒಂದು ಪಠ್ಯವನ್ನು ನಮೂದಿಸಿ"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect ಮುದ್ರಕ"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD ಮುದ್ರಕ"
+
+#~ msgid "One Sided"
+#~ msgstr "ಒಂದು ಬದಿಯ"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "ಉದ್ದನೆಯ ಅಂಚು (ಶಿಷ್ಟ)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "ಚಿಕ್ಕ ಅಂಚು (ಹೊರಳಿಸು)"
+
+#~ msgid "Portrait"
+#~ msgstr "ಭಾವಚಿತ್ರ"
+
+#~ msgid "Landscape"
+#~ msgstr "ಪ್ರಕೃತಿ ಚಿತ್ರ"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "ವಿಲೋಮ ಪ್ರಕೃತಿ ಚಿತ್ರ"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "ವಿಲೋಮ ಭಾವಚಿತ್ರ"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "ಬಾಕಿ ಇದೆ"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "ತಡೆಹಿಡಿಯಲಾಗಿದೆ"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "ಸಂಸ್ಕರಿಸಲಾಗುತ್ತಿದೆ"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "ನಿಲ್ಲಿಸಲಾಗಿದೆ"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "ವಿಫಲಗೊಳಿಸಲಾಗಿದೆ"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "ಪೂರ್ಣಗೊಂಡಿದೆ"
+
+#~ msgid "Job Title"
+#~ msgstr "ಕೆಲಸದ ಶೀರ್ಷಿಕೆ"
+
+#~ msgid "Job State"
+#~ msgstr "ಕೆಲಸದ ಸ್ಥಿತಿ"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "ಅನುಕ್ರಮಿತ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#~ msgid "Parallel Port"
+#~ msgstr "ಸಮಾನಾಂತರ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "ಸ್ಥಳ: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "ವಿಳಾಸ: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "ಎರಡೂ ಬದಿಯ"
+
+#~ msgid "Paper Type"
+#~ msgstr "ಪೇಪರಿನ ಬಗೆ"
+
+#~ msgid "Paper Source"
+#~ msgstr "ಪೇಪರಿನ ಆಕರ"
+
+#~ msgid "Output Tray"
+#~ msgstr "ಔಟ್‌ಪುಟ್ ಟ್ರೇ"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript ಪೂರ್ವ-ಸೋಸುವಿಕೆ"
+
+#~ msgid "Pages per side"
+#~ msgstr "ಪ್ರತಿ ಬದಿಯ ಪುಟಗಳು"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "ಸಾಮಾನ್ಯ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "ಪುಟ ಸಿದ್ಧತೆ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "ಅನುಸ್ಥಾಪನೆಯ ಆಯ್ಕೆಗಳು"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "ಕಾರ್ಯ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "ಚಿತ್ರದ ಗುಣಮಟ್ಟ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "ಬಣ್ಣ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "ಪೂರ್ಣಗೊಳಿಕೆ"
+
+#~ msgid "Auto Select"
+#~ msgstr "ಸ್ವಯಂ ಆಯ್ಕೆ"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "ಅಡಕಗೊಳಿಸಲಾದ GhostScript ಅಕ್ಷರಶೈಲಿಗಳು ಮಾತ್ರ"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS ಹಂತ 1 ಕ್ಕೆ ಪರಿವರ್ತಿಸು"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS ಹಂತ 2 ಕ್ಕೆ ಪರಿವರ್ತಿಸು"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "ಯಾವುದೆ ಪೂರ್ವ-ಫಿಲ್ಟರಿಂಗ್ ಇಲ್ಲ"
+
+#~ msgid "Supply"
+#~ msgstr "ಪೂರೈಕೆ"
+
+#~ msgid "_Default printer"
+#~ msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಮುದ್ರಕ (_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "ಕಾರ್ಯಗಳು"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "ಕೆಲಸಗಳನ್ನು ತೋರಿಸು (_J)"
+
+#~ msgid "label"
+#~ msgstr "ಲೇಬಲ್"
+
+#~ msgid "page 3"
+#~ msgstr "ಪುಟ 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "ಪ್ರಾಯೋಗಿಕ ಪುಟವನ್ನು ಮುದ್ರಿಸು (_T)"
+
+#~ msgid "_Options"
+#~ msgstr "ಆಯ್ಕೆಗಳು (_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "ಹೊಸ ಮುದ್ರಕವನ್ನು ಸೇರಿಸಿ"
+
+#~ msgid "Usage & History"
+#~ msgstr "ಬಳಕೆ ಮತ್ತು ಇತಿಹಾಸ"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "ಕಸದ ಬುಟ್ಟಿಯಿಂದ ಎಲ್ಲಾ ಅಂಶಗಳನ್ನು ಖಾಲಿ ಮಾಡಬೇಕೆ?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "ಕಸದ ಬುಟ್ಟಿಯಲ್ಲಿನ ಎಲ್ಲಾ ಅಂಶಗಳನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲಾಗುತ್ತದೆ."
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "ಎಲ್ಲಾ ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಅಳಿಸಬೇಕೆ?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "ಎಲ್ಲಾ ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲಾಗುತ್ತದೆ."
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "ನಿಮ್ಮ ವೈಯಕ್ತಿಕ ಮಾಹಿತಿಗಳನ್ನು ಸಂರಕ್ಷಿಸಿ ಮತ್ತು ಬೇರೆಯವರು ಏನನ್ನು ನೋಡುತ್ತಾರೆ "
+#~ "ಎನ್ನುವುದನ್ನು ನಿಯಂತ್ರಿಸಿ"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 ಸೆಕೆಂಡುಗಳು"
+
+#~ msgid "1 day"
+#~ msgstr "1 ದಿನ"
+
+#~ msgid "2 days"
+#~ msgstr "2 ದಿನಗಳು"
+
+#~ msgid "3 days"
+#~ msgstr "3 ದಿನಗಳು"
+
+#~ msgid "4 days"
+#~ msgstr "4 ದಿನಗಳು"
+
+#~ msgid "5 days"
+#~ msgstr "5 ದಿನಗಳು"
+
+#~ msgid "6 days"
+#~ msgstr "6 ದಿನಗಳು"
+
+#~ msgid "7 days"
+#~ msgstr "7 ದಿನಗಳು"
+
+#~ msgid "14 days"
+#~ msgstr "14 ದಿನಗಳು"
+
+#~ msgid "30 days"
+#~ msgstr "30 ದಿನಗಳು"
+
+#~ msgid "Forever"
+#~ msgstr "ಯಾವಾಗಲೂ"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "ನಿಮ್ಮ ವ್ಯವಸ್ಥೆಯ ಇತಿಹಾಸವನ್ನು ನೆನಪಿಟ್ಟುಕೊಳ್ಳುವುದರಿಂದ ಅಗತ್ಯವಾದ ವಸ್ತುಗಳನ್ನು ಮತ್ತೆ "
+#~ "ಹುಡುಕಲು ಸುಲಭವಾಗಿರುತ್ತದೆ. ಈ ಅಂಶಗಳನ್ನು ಎಂದಿಗೂ ಸಹ ಜಾಲಬಂಧದ ಮುಖಾಂತರ "
+#~ "ಹಂಚಿಕೊಳ್ಳಲಾಗುವುದಿಲ್ಲ."
+
+#~ msgid "_Recently Used"
+#~ msgstr "ಇತ್ತೀಚಿಗೆ ಬಳಸಲಾದ (_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "ಇತಿಹಾಸವನ್ನು ಉಳಿಸಕೊ (_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "ತೆರೆಯನ್ನು ಲಾಕ್‌ ಮಾಡುವಿಕೆಯು ನೀವು ಆದೆ ಹೋದಾಗ ನಿಮ್ಮ ಗೌಪ್ಯತೆಯನ್ನು ಕಾಪಾಡುತ್ತದೆ."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "ಇಷ್ಟು ಸಮಯ ಖಾಲಿ ಬಿಟ್ಟಲ್ಲಿ ತೆರೆಯನ್ನು ಲಾಕ್ ಮಾಡು (_a)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "ನಿಮ್ಮ ಗಣಕವು ಅನಗತ್ಯವಾದ ಸಂವೇದನಾ ಮಾಹಿತಿಯನ್ನು ಇರಿಸಿಕೊಳ್ಳುವುದನ್ನು ತಪ್ಪಿಸಲು ಕಸ "
+#~ "(ಟ್ರ್ಯಾಶ್) ಮತ್ತು ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊರತಳ್ಳಿ."
+
+#~ msgid "Purge _After"
+#~ msgstr "ಇದರ ನಂತರ ಹೊರತಳ್ಳು (_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "ನೀವು ಯಾವ ತಂತ್ರಾಂಶವನ್ನು ಬಳಸುತ್ತೀರಿ ಎಂಬುದರ ಬಗೆಗಿನ ಮಾಹಿತಿಯನ್ನು ಕಳುಹಿಸುವುದರಿಂದ "
+#~ "ನಿಮಗೆ ಖಚಿತವಾದ ಸಲಹೆಗಳನ್ನು ಒದಗಿಸಲು ನಮಗೆ ಸಹಾಯವಾಗುತ್ತದೆ. ಇದು ನಮ್ಮ ತಂತ್ರಾಂಶವನ್ನೂ ಸಹ "
+#~ "ಸುಧಾರಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.\n"
+#~ "\n"
+#~ "ನಾವು ಸಂಗ್ರಹಿಸುವ ಎಲ್ಲಾ ಮಾಹಿತಿಯನ್ನು ಅಜ್ಞಾತವಾಗಿರಿಸಲಾಗುತ್ತದೆ, ಮತ್ತು ನಾವು ಇದನ್ನು "
+#~ "ಮೂರನೆಯ ವ್ಯಕ್ತಿಗಳೊಂದಿಗೆ ಎಂದಿಗೂ ಹಂಚಿಕೊಳ್ಳುವುದಿಲ್ಲ."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "ತಂತ್ರಾಂಶ ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳನ್ನು ಕಳುಹಿಸು (_S)"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "ಗೌಪ್ಯತಾ ನಿಯಮ"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "ನಿಮ್ಮ ಭೂಸ್ಥಳದ ಕುರಿತು ನಿರ್ಧರಿಸಲು ಬಳಸಲಾಗುತ್ತದೆ"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ಇಂಪೀರಿಯಲ್"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "ಮೆಟ್ರಿಕ್"
+
+#~ msgid "No input sources found"
+#~ msgstr "ಯಾವುದೆ ಇನ್‌ಪುಟ್‌ ಮೂಲಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "ಇತರೆ"
+
+#~ msgid "Sorry"
+#~ msgstr "ಕ್ಷಮಿಸಿ"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "ಮುಂದಿನ ಆಕರಕ್ಕೆ ಬದಲಾಯಿಸು"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "ನೀವು ಈ ಸುಲಭಆಯ್ಕೆಗಳನ್ನು ಕೀಲಿಮಣೆ ಸಿದ್ಧತೆಗಳಲ್ಲಿ ಬದಲಾಯಿಸಬಹುದು"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "ಮುಂದಿನ ಮೂಲಕ್ಕೆ ಪರ್ಯಾಯ ಸ್ವಿಚ್"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "ಎಡ+ಬಲ Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "ಇಂಗ್ಲೀಷ್ (ಯುನೈಟೆಡ್ ಕಿಂಗ್‌ಡಮ್)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "ಯುನೈಟೆಡ್ ಕಿಂಗ್‌ಡಮ್"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "ವ್ಯವಸ್ಥೆಗೆ ಪ್ರವೇಶಿಸುವಾಗ ಎಲ್ಲಾ ಬಳಕೆದಾರರಿಂದ ಬಳಸಲಾಗುವ ಪ್ರವೇಶದ ಸಿದ್ಧತೆಗಳು"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "ಇತರೆ"
+
+#~ msgid "Select Location"
+#~ msgstr "ಸ್ಥಳವನ್ನು ಆರಿಸಿ"
+
+#~ msgid "_OK"
+#~ msgstr "ಸರಿ (_O)"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "ಆನ್"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "ಆಫ್"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "ಸಕ್ರಿಯಗೊಂಡ"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "ಒಂದು ಕಡತಕೋಶವನ್ನು ಆರಿಸು"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "ಹಂಚಿಕೊಳ್ಳಲು ಯಾವುದೆ ಜಾಲಬಂಧಗಳನ್ನು ಆರಿಸಲಾಗಿಲ್ಲ"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "ಬ್ಲೂಟೂತ್ ಹಂಚಿಕೆಯು ಕಡತಗಳನ್ನು ಇತರೆ ಬ್ಲೂಟೂತ್ ಸಕ್ರಿಯಗೊಳಿಸಲಾದ ಸಾಧನಗಳೊಂದಿಗೆ "
+#~ "ಹಂಚಿಕೊಳ್ಳಲು ಅನುವು ಮಾಡಿಕೊಡುತ್ತದೆ"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "ನಂಬಿಕಸ್ತ ಸಾಧನಗಳಿಂದ ಮಾತ್ರ ಸ್ವೀಕರಿಸು"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "ಸ್ವೀಕರಿಸಲಾದ ಕಡತಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಕಡತಕೋಶಕ್ಕೆ ಉಳಿಸು"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "ತೆರೆ ಹಂಚಿಕೆ"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "ಯಾವುದೆ ಜಾಲಬಂಧ ಸೇವೆಯು ಇರದ ಕಾರಣ ಕೆಲವು ಸೇವೆಗಳು ನಿಷ್ಕ್ರಿಯವಾಗಿರುತ್ತವೆ."
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "ವೈಯಕ್ತಿಕ ಕಡತ ಹಂಚಿಕೆಯನ್ನು ಬಳಸಿಕೊಂಡು ನೀವು ಸಾರ್ವಜನಿಕ ಕಡತಕೋಶವನ್ನು ನಿಮ್ಮ ಪ್ರಸಕ್ತ "
+#~ "ಜಾಲಬಂಧದಲ್ಲಿರುವವರೊಂದಿಗೆ ಹಂಚಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಿರುತ್ತದೆ: <a href=\"dav://%s\">dav://"
+#~ "%s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "ಈ ಸೆಕ್ಯೂರ್ ಶೆಲ್ ಆದೇಶವನ್ನು ಬಳಸಿಕೊಂಡು ದೂರಸ್ಥ ಬಳಕೆದಾರರು ಸಂಪರ್ಕಸಾಧಿಸಲು ಅನುಮತಿಸಿ:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "ಇದಕ್ಕೆ ಸಂಪರ್ಕ ಸಾಧಿಸುವ ಮುಖಾಂತರ ದೂರಸ್ಥ ಬಳಕೆದಾರರು ನಿಮ್ಮ ತೆರೆಯನ್ನು ನೋಡಲು ಅಥವ "
+#~ "ನಿಯಂತ್ರಿಸಲು ಅನುಮತಿಸಿ: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "Password:"
+#~ msgstr "ಗುಪ್ತಪದ:"
+
+#~ msgid "Show Password"
+#~ msgstr "ಗುಪ್ತಪದವನ್ನು ತೋರಿಸು"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "ಹೊಸ ಸಂಪರ್ಕಗಳು ನಿಲುಕಿಗಾಗಿ ಕೇಳಬೇಕು"
+
+#~ msgid "Require a password"
+#~ msgstr "ಒಂದು ಗುಪ್ತಪದದ ಅಗತ್ಯವಿದೆ"
+
+#~ msgid "Bark"
+#~ msgstr "ಬೊಗಳು"
+
+#~ msgid "Drip"
+#~ msgstr "ತೊಟ್ಟಿಕ್ಕು"
+
+#~ msgid "Glass"
+#~ msgstr "ಗಾಜು"
+
+#~ msgid "Sonar"
+#~ msgstr "ಸೋನಾರ್"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "ಕನಿಷ್ಟ"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "ಗರಿಷ್ಟ"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "ಸಬ್‌ವೂಫರ್ (_S):"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "ವರ್ಧಿಸದ"
+
+#~ msgid "_Profile:"
+#~ msgstr "ಪ್ರೊಫೈಲ್ (_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "ಸ್ಪೀಕರುಗಳನ್ನು ಪರೀಕ್ಷಿಸು (_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "ಉತ್ತುಂಗದ ಪತ್ತೆ"
+
+#~ msgid "Device"
+#~ msgstr "ಸಾಧನ"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s ಗಾಗಿನ ಸ್ಪೀಕರುಗಳ ಪರೀಕ್ಷೆ"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "ಧ್ವನಿಯ ಇನ್‌ಪುಟ್‌ಗಾಗಿ ಒಂದು ಸಾಧನವನ್ನು ಆರಿಸಿ (_h):"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "ಆಯ್ಕೆ ಮಾಡಿದ ಸಾಧನದ ಸಿದ್ಧತೆಗಳು:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "ಇನ್‌ಪುಟ್‌ ಧ್ವನಿ ಪ್ರಮಾಣ (_I):"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "ಧ್ವನಿಯ ಔಟ್‌ಪುಟ್‌ಗಾಗಿ ಒಂದು ಸಾಧನವನ್ನು ಆರಿಸಿ (_h):"
+
+#~ msgid "Sound Effects"
+#~ msgstr "ಧ್ವನಿ ಪರಿಣಾಮಗಳು"
+
+#~ msgid "Built-in"
+#~ msgstr "ಒಳನಿರ್ಮಿತ"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ಧ್ವನಿಯ ಆದ್ಯತೆಗಳು"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ಘಟನೆ ಶಬ್ಧವನ್ನು ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ"
+
+#~ msgid "From theme"
+#~ msgstr "ಪರಿಸರವಿನ್ಯಾಸದಿಂದ"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "ಒಂದು ಎಚ್ಚರಿಕೆ ಧ್ವನಿಯನ್ನು ಆರಿಸಿ (_h):"
+
+#~ msgid "Stop"
+#~ msgstr "ನಿಲ್ಲಿಸು"
+
+#~ msgid "Custom"
+#~ msgstr "ಇಚ್ಛೆಯ"
+
+#~ msgid "Screen Reader"
+#~ msgstr "ತೆರೆ ಓದುಗ"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "ತೆರೆ ಓದುಗ (_S)"
+
+#~ msgid "Sound Keys"
+#~ msgstr "ಧ್ವನಿ ಕೀಲಿಗಳು"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "ಕಿಟಕಿ ಶೀರ್ಷಿಕೆ ಪಟ್ಟಿಯನ್ನು ಹೊಳೆಯುವಂತೆ ಮಾಡು (_w)"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "ಕಿರು"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "ತೆರೆಯ ¼"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "ತೆರೆಯ ½"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "ತೆರೆಯ ¾"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "ಉದ್ದ"
+
+#~ msgid "Zoom"
+#~ msgstr "ಹಿಗ್ಗಿಸು"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "ಬಣ್ಣ"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "ಶಿಷ್ಟ"
+
+#~ msgid "_Verify"
+#~ msgstr "ಪರಿಶೀಲಿಸು (_V)"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "ಎಂಟರ್‌ಪ್ರೈಸ್ ಲಾಗಿನ್‌\n"
+#~ "ಖಾತೆಗಳನ್ನು ಸೇರಿಸಲು ಆನ್‌ಲೈನ್‌ಗೆ ತೆರಳಿ."
+
+#~ msgid "Left thumb"
+#~ msgstr "ಎಡ ಹೆಬ್ಬೆರಳು"
+
+#~ msgid "Left middle finger"
+#~ msgstr "ಎಡ ಮಧ್ಯ ಬೆರಳು"
+
+#~ msgid "Left ring finger"
+#~ msgstr "ಎಡ ಉಂಗುರದ ಬೆರಳು"
+
+#~ msgid "Left little finger"
+#~ msgstr "ಎಡ ಕಿರು ಬೆರಳು"
+
+#~ msgid "Right thumb"
+#~ msgstr "ಬಲ ಹೆಬ್ಬೆರಳು"
+
+#~ msgid "Right middle finger"
+#~ msgstr "ಬಲ ಮಧ್ಯ ಬೆರಳು"
+
+#~ msgid "Right ring finger"
+#~ msgstr "ಬಲ ಉಂಗುರದ ಬೆರಳು"
+
+#~ msgid "Right little finger"
+#~ msgstr "ಬಲ ಕಿರು ಬೆರಳು"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "ಬೆರಳಗುರುತು ಪ್ರವೇಶವನ್ನು ಶಕ್ತಗೊಳಿಸಿ"
+
+#~ msgid "_Right index finger"
+#~ msgstr "ಬಲ ತೋರು ಬೆರಳು (_R)"
+
+#~ msgid "_Left index finger"
+#~ msgstr "ಎಡ ತೋರು ಬೆರಳು (_L)"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "ನಿಮ್ಮ ಬೆರಳಗುರುತನ್ನು ಯಶಸ್ವಿಯಾಗಿ ಉಳಿಸಲಾಗಿದೆ. ಈಗ ನೀವು ನಿಮ್ಮ ಬೆರಳಗುರುತಿನ ಓದುಗನನ್ನು "
+#~ "ಬಳಸಿಕೊಂಡು ಪ್ರವೇಶಿಸಬಹುದಾಗಿದೆ."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "ಪ್ರವೇಶ;ಹೆಸರು;ಬೆರಳಗುರುತ;ಅವತಾರ;ಲಾಂಛನ;ಮುಖ;ಗುಪ್ತಪದ;"
+
+#~ msgid "Login History"
+#~ msgstr "ಪ್ರವೇಶದ ಇತಿಹಾಸ"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "ಹೊಸ ಗುಪ್ತಪದವನ್ನು ಪರಿಶೀಲಿಸು (_N)"
+
+#~ msgid "Add User Account"
+#~ msgstr "ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ಸೇರಿಸು"
+
+#~ msgid "User Icon"
+#~ msgstr "ಬಳಕೆದಾರನ ಚಿಹ್ನೆ"
+
+#~ msgid "Last Login"
+#~ msgstr "ಕೊನೆಯ ಪ್ರವೇಶ"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಹಳೆಯದಕ್ಕಿಂತ ಭಿನ್ನವಾಗಿರಬೇಕು."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "ಕೆಲವು ಅಕ್ಷರಗಳು ಮತ್ತು ಅಂಕಿಗಳನ್ನು ಬದಲಾಯಿಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "ಗುಪ್ತಪದವನ್ನು ಇನ್ನಷ್ಟು ಬದಲಾಯಿಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "ನಿಮ್ಮ ಬಳಕೆದಾರ ಹೆಸರು ಇಲ್ಲದ ಗುಪ್ತಪದವು ಸದೃಢವಾಗಿರುತ್ತದೆ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "ನಿಮ್ಮ ಹೆಸರನ್ನು ಗುಪ್ತಪದದಲ್ಲಿ ಬಳಸದೇ ಇರಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "ಗುಪ್ತಪದದಲ್ಲಿ ಕೆಲವು ಪದಗಳನ್ನು ಬಳಸದೆ ಇರಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "ಸಾಮಾನ್ಯವಾದ ಪದಗಳನ್ನು ಬಳಸಬೇಡಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "ಈಗಿರುವ ಪದದ ಅಕ್ಷರಗಳನ್ನೆ ಅದಲು ಬದಲು ಮಾಡಿ ಬಳಸಬೇಡಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "ಹೆಚ್ಚು ಸಂಖ್ಯೆಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "ಹೆಚ್ಚು ದೊಡ್ಡಕ್ಷರಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "ಹೆಚ್ಚು ಸಣ್ಣಕ್ಷರಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "ಹೆಚ್ಚು  ವಿರಾಮ ಚಿಹ್ನೆಗಳಂತಹ ವಿಶೇಷ ಅಕ್ಷರಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ವಿರಾಮಚಿಹ್ನೆಗಳ ಮಿಶ್ರಣವನ್ನು ಬಳಸಿ ನೋಡಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "ಒಂದೇ ಅಕ್ಷರವನ್ನು ಪುನರಾವರ್ತಿಸುವುದನ್ನು ತಪ್ಪಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "ಒಂದೇ ರೀತಿಯ ಚಿಹ್ನೆಯನ್ನು ಬಳಸುವುದನ್ನು ತಪ್ಪಿಸಲು ಪ್ರಯತ್ನಿಸಿ: ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು "
+#~ "ವಿರಾಮಚಿಹ್ನೆಗಳ ಮಿಶ್ರಣವನ್ನು ಬಳಸಿ ನೋಡಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 ಅಥವ abcd ಯಂತಹ ಸರಣಿಯನ್ನು ಬಳಸಬೇಡಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "ಹೆಚ್ಚು ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ಸಂಕೇತಗಳನ್ನು ಸೇರಿಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr ""
+#~ "ದೊಡ್ಡಕ್ಷರ ಮತ್ತು ಸಣ್ಣಕ್ಷರವನ್ನು ಜೊತೆಗೆ ಬಳಸಿ ಮತ್ತು ಒಂದು ಅಥವ ಎರಡು ಸಂಖ್ಯೆಯನ್ನು ಬಳಸಿ."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr ""
+#~ "ಉತ್ತಮವಾದ ಗುಪ್ತಪದ! ಹೆಚ್ಚಿನ ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ವಿರಾಮಚಿಹ್ನೆಗಳನ್ನು "
+#~ "ಸೇರಿಸುವುದರಿಂದ ಇದು ಇನ್ನಷ್ಟು ಬಲಗೊಳ್ಳುತ್ತದೆ."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "ಬಲಿಷ್ಟತೆ: ದುರ್ಬಲ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "ಬಲಿಷ್ಟತೆ: ಕಡಿಮೆ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "ಬಲಿಷ್ಟತೆ: ಮಧ್ಯಮ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "ಬಲಿಷ್ಟತೆ: ಉತ್ತಮ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "ಬಲಿಷ್ಟತೆ: ಅತ್ಯುತ್ತಮ"
+
+#~ msgid "Authentication failed"
+#~ msgstr "ದೃಢೀಕರಣ ವಿಫಲಗೊಂಡಿದೆ"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಬಹಳ ಚಿಕ್ಕದಾಗಿದೆ"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಬಹಳ ಸರಳವಾಗಿದೆ."
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "ಹೊಸ ಹಾಗು ಹಳೆಯ ಗುಪ್ತಪದಗಳು ಒಂದನ್ನೊಂದು ಬಹಳ ಹೋಲುತ್ತವೆ"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "ಹೊಸ ಗುಪ್ತಪದವನ್ನು ಈಗಾಗಲೆ ಇತ್ತೀಚೆಗೆ ಬಳಸಲಾಗಿದೆ."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಒಂದು ಅಂಕೆ ಅಥವ ವಿಶೇಷ ಅಕ್ಷರಗಳನ್ನು ಹೊಂದಿರಲೇಬೇಕು"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "ಹೊಸ ಹಾಗು ಹಳೆಯ ಗುಪ್ತಪದಗಳು ಒಂದೇ ಆಗಿವೆ"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "ನಿಮ್ಮ ಗುಪ್ತಪದವನ್ನು ನೀವು ಆರಂಭದಲ್ಲಿ ದೃಢೀಕರಿಸಿದ ನಂತರ ಬದಲಾಯಿಸಲ್ಪಟ್ಟಿದೆ!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಸಾಕಷ್ಟು ವಿಭಿನ್ನ ಅಕ್ಷರಗಳನ್ನು ಹೊಂದಿಲ್ಲ"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "ಗೊತ್ತಿಲ್ಲದ ದೋಷ"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "ನಿಮ್ಮ ಖಾತೆ ಒದಗಿಸುವವರ ಜಾಲ ವಿಳಾಸಕ್ಕೆ ಹೊಂದಿಕೆಯಾಗಬೇಕು."
+
+#~ msgid "Failed to add account"
+#~ msgstr "ಖಾತೆಯನ್ನು ಸೇರಿಸಲು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "ಗುಪ್ತಪದಗಳು ಒಂದೇ ಸಮನಾಗಿಲ್ಲ."
+
+#~ msgid "Failed to register account"
+#~ msgstr "ಖಾತೆಯನ್ನು ನೋಂದಾಯಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "ಈ ಡೊಮೈನ್‌ನೊಂದಿಗೆ ದೃಢೀಕರಿಸಲು ಯಾವುದೆ ಮಾರ್ಗವಿಲ್ಲ"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "ಡೊಮೈನ್ ಅನ್ನು ಸೇರುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ಆ ಲಾಗಿನ್ ಹೆಸರು ಕೆಲಸ ಮಾಡುತ್ತಿಲ್ಲ.\n"
+#~ "ದಯವಿಟ್ಟು ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ಆ ಲಾಗಿನ್ ಗುಪ್ತಪದ ಕೆಲಸ ಮಾಡುತ್ತಿಲ್ಲ.\n"
+#~ "ದಯವಿಟ್ಟು ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "ಡೊಮೈನ್ ಅನ್ನು ಪ್ರವೇಶಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "ಡೊಮೇನ್‌ ಕಂಡುಬಂದಿಲ್ಲ. ಬಹುಷಃ ನೀವು ತಪ್ಪಾಗಿ ನಮೂದಿಸಿರಬೇಕು?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "ನೀವು ಈ ಸಾಧನವನ್ನು ನಿಲುಕಿಸಿಕೊಳ್ಳುವಂತಿಲ್ಲ. ನಿಮ್ಮ ಗಣಕ ವ್ಯವಸ್ಥಾಪಕರನ್ನು ಸಂಪರ್ಕಿಸಿ."
+
+#~ msgid "The device is already in use."
+#~ msgstr "ಸಾಧನವು ಈಗಾಗಲೆ ಬಳಕೆಯಲ್ಲಿದೆ."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "ಒಂದು ಆಂತರಿಕ ದೋಷ ಸಂಭವಿಸಿದೆ."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "ನೋಂದಾಯಿಸಲಾದ ಬೆರಳಗುರುತುಗಳನ್ನು ಅಳಿಸಬೇಕೆ?"
+
+#~ msgid "Done!"
+#~ msgstr "ಆಯಿತು!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' ಸಾಧನವನ್ನು ನಿಲುಕಿಸಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' ಸಾಧನದಲ್ಲಿ ಬೆರಳಿನ ಗುರುತನ್ನು ತೆಗೆದುಕೊಳ್ಳುವುದನ್ನು ಆರಂಭಿಸು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "ಯಾವುದೆ ಬೆರಳಗುರುತು ಓದುಗನನ್ನು ನಿಲುಕಿಸಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "ನೆರವಿಗಾಗಿ ನಿಮ್ಮ ಗಣಕ ವ್ಯವಸ್ಥಾಪಕರನ್ನು ಕೇಳಿ."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "ಬೆರಳಗುರುತಿನ ಪ್ರವೇಶವನ್ನು ಶಕ್ತಗೊಳಿಸಲು, '%s' ಸಾಧನವನ್ನು ಬಳಸಿಕೊಂಡು ನೀವು ನಿಮ್ಮ "
+#~ "ಬೆರಳಗುರುತುಗಳನ್ನು ಉಳಿಸಬೇಕಾಗುತ್ತದೆ."
+
+#~ msgid "Selecting finger"
+#~ msgstr "ಬೆರಳನ್ನು ಆರಿಸುವಿಕೆ"
+
+#~ msgid "This Week"
+#~ msgstr "ಈ ವಾರ"
+
+#~ msgid "Last Week"
+#~ msgstr "ಹಿಂದಿನ ವಾರ"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "ಅಧಿವೇಶನ ಕೊನೆಗೊಂಡಿದೆ"
+
+#~ msgid "Session Started"
+#~ msgstr "ಅಧಿವೇಶನ ಆರಂಭಗೊಂಡಿದೆ"
+
+#~ msgid "Please choose another password."
+#~ msgstr "ದಯವಿಟ್ಟು ಬೇರೊಂದು ಗುಪ್ತಪದವನ್ನು ಆರಿಸಿ."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "ದಯವಿಟ್ಟು ನಿಮ್ಮ ಈಗಿನ ಗುಪ್ತಪದವನ್ನು ಇನ್ನೊಮ್ಮೆ ದಾಖಲಿಸಿ."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "ಗುಪ್ತಪದವನ್ನು ಬದಲಾಯಿಸಲಾಗಿಲ್ಲ."
+
+#~ msgid "Disable image"
+#~ msgstr "ಚಿತ್ರವನ್ನು ಅಶಕ್ತಗೊಳಿಸು"
+
+#~ msgid "Take a photo…"
+#~ msgstr "ಒಂದು ಚಿತ್ರವನ್ನು ತೆಗೆದುಕೊಳ್ಳಿ..."
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "ಹೆಚ್ಚಿನ ಚಿತ್ರಗಳಿಗಾಗಿ ನೋಡು…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s ಇಂದ ಬಳಸಲಾಗಿದೆ"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "ಈ ಬಗೆಯ ಡೊಮೇನ್‌ ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸೇರಿಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "ಯಾವುದೆ ಅಂತಹ ಡೊಮೈನ್ ಅಥವ ಕ್ಷೇತ್ರ ಕಂಡುಬಂದಿಲ್ಲ"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s ಎಂದು %s ಡೊಮೈನಿನಲ್ಲಿ ಪ್ರವೇಶಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "ಗುಪ್ತಪದ ತಪ್ಪಾಗಿದೆ; ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ"
+
+#~ msgid "Other Accounts"
+#~ msgstr "ಇತರೆ ಖಾತೆಗಳು"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ಬಳಕೆದಾರನನ್ನು ಅಳಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~| msgid "Failed to delete user"
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "ದೂರದಿಂದ ನೋಡಿಕೊಳ್ಳಲಾಗುವ ಬಳಕೆದಾರನನ್ನು ರದ್ದುಗೊಳಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "ನೀವು ನಿಮ್ಮದೆ ಖಾತೆಯನ್ನು ಅಳಿಸಲು ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ಇನ್ನೂ ಸಹ ಒಳಗಿದ್ದಾರೆ"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "ಬಳಕೆದಾರರು ಒಳಗೆ ಪ್ರವೇಶಿಸಿದಾಗ ಅವರನ್ನು ಅಳಿಸುವುದರಿಂದ ವ್ಯವಸ್ಥೆಯು ಒಂದು ಅಸ್ಥಿರ "
+#~ "ಸ್ಥಿತಿಯಲ್ಲಿ ಇರಿಸುತ್ತದೆ."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "ನೀವು %s ರವರ ಕಡತಗಳನ್ನು ಇರಿಸಿಕೊಳ್ಳಲು ಬಯಸುವಿರಾ?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ಬಳಕೆದಾರರ ಖಾತೆಯನ್ನು ಅಳಿಸುವಾಗ ನೆಲೆ ಕೋಶವನ್ನು, ಅಂಚೆ ಸ್ಪೂಲ್ ಅನ್ನು ಮತ್ತು ತಾತ್ಕಾಲಿಕ "
+#~ "ಕಡತಗಳನ್ನು ಹಾಗೆಯೆ ಇರಿಸಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಿರುತ್ತದೆ."
+
+#~ msgid "_Delete Files"
+#~ msgstr "ಕಡತಗಳನ್ನು ಅಳಿಸು (_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "ಕಡತಗಳನ್ನು ಇರಿಸಿಕೊ (_K)"
+
+#, c-format
+#~| msgid "Are you sure you want to remove the account?"
+#~ msgid "Are you sure you want to revoke remotely managed %s's account?"
+#~ msgstr "ದೂರದಿಂದ ನೋಡಿಕೊಳ್ಳಲಾಗುವ %s ನ ಖಾತೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲು ನೀವು ಖಚಿತವೆ?"
+
+#~| msgid "_Delete Files"
+#~ msgid "_Delete"
+#~ msgstr "ಅಳಿಸು (_D)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "ಖಾತೆಯನ್ನು ಅಶಕ್ತಗೊಳಿಸಲಾಗಿದೆ"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "ಮುಂದಿನ ಬಾರಿ ಪ್ರವೇಶಿಸಿದಾಗ ಹೊಂದಿಸಲಾಗುತ್ತದೆ"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#~ msgid "Logged in"
+#~ msgstr "ಪ್ರವೇಶಿಸಲಾಗಿದೆ"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "ಖಾತೆಗಳ ಸೇವೆಯನ್ನು ಸಂಪರ್ಕಿಸಲು ವಿಫಲಗೊಂಡಿದೆ"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "AccountService ಅನ್ನು ಅನುಸ್ಥಾಪಿಸಲಾಗಿದೆಯೆ ಮತ್ತು ಸಕ್ರಿಯಗೊಂಡಿದೆಯೆ ಎಂದು "
+#~ "ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ಬದಲಾವಣೆಗಳನ್ನು ಮಾಡಲು,\n"
+#~ "* ಚಿಹ್ನೆಯ ಮೇಲೆ ಮೊದಲು ಕ್ಲಿಕ್ ಮಾಡಿ"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ರಚಿಸಲು,\n"
+#~ "ಮೊದಲು * ಚಿಹ್ನೆಯ ಮೇಲೆ ಕ್ಲಿಕ್ ಮಾಡಿ"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "ಆಯ್ದ ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ಅಳಿಸಿ"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ಆಯ್ದ ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ಅಳಿಸಲು,\n"
+#~ "ಮೊದಲು * ಚಿಹ್ನೆಯ ಮೇಲೆ ಕ್ಲಿಕ್ ಮಾಡಿ"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "'%s' ಎಂಬ ಹೆಸರಿನ ಒಬ್ಬ ಬಳಕೆದಾರ ಈಗಾಗಲೆ ಅಸ್ತಿತ್ವದಲ್ಲಿದ್ದಾರೆ."
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "ಬಳಕೆದಾರ ಹೆಸರು ಬಹಳ ಉದ್ದವಾಗಿದೆ."
+
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "ಬಳಕೆದಾರ ಹೆಸರು '-' ಇಂದ ಆರಂಭಗೊಳ್ಳುವಂತಿಲ್ಲ."
+
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "ಬಳಕೆದಾರ ಹೆಸರು ಕೇವಲ a-z ವರೆಗಿನ ಅಕ್ಷರಗಳು, ಅಂಕಿಗಳು, ಮತ್ತು '.', '-' ಹಾಗು '_' "
+#~ "ನಲ್ಲಿ ಒಂದಾದರೂ ಚಿಹ್ನೆಗಳನ್ನು ಮಾತ್ರ ಹೊಂದಿರಬೇಕು."
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr ""
+#~ "ಇದನ್ನು ನಿಮ್ಮ ನೆಲೆ ಕೋಶವನ್ನು ಹೆಸರಿಸಲು ಬಳಸಲಾಗುತ್ತದೆ ಮತ್ತು ಬದಲಾಯಿಸಲು "
+#~ "ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ."
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "ಮೇಲೆ"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "ಕೆಳಕ್ಕೆ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "ಕೀಲಿಹೊಡೆತವನ್ನು ಕಳುಹಿಸು"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "ತೆರೆಯನ್ನು ಬದಲಿಸು"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "ತೆರೆಯ ಮೇಲಣ ನೆರವನ್ನು ತೋರಿಸು"
+
+#~ msgid "Output:"
+#~ msgstr "ಔಟ್‌ಪುಟ್:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "ರೂಪದ ಅನುಪಾತವನ್ನು ಹಾಗೆಯೆ ಇರಿಸಿಕೊ (ಓಲೆಪೆಟ್ಟಿಗೆ):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "ಒಂದು ತೆರೆಗೆ ಮ್ಯಾಪ್ ಮಾಡು"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d, %d ರಲ್ಲಿ"
+
+#~ msgid "Display Mapping"
+#~ msgstr "ಪ್ರದರ್ಶಕ ಮ್ಯಾಪಿಂಗ್"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "ಟ್ಯಾಬ್ಲೆಟ್ (ಪರಿಪೂರ್ಣ)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "ಕಿಸಗಣಕದ ಆದ್ಯತೆಗಳು"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ಬ್ಲೂಟೂತ್ ಸಿದ್ಧತೆಗಳು"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "ಗುಂಡಿಗಳನ್ನು ಮ್ಯಾಪ್ ಮಾಡು"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "ಪ್ರದರ್ಶಕದ ರೆಸಲ್ಯೂಶನ್ ಅನ್ನು ಸರಿಹೊಂದಿಸು"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "ಮೌಸ್‌ನ ಸಿದ್ಧತೆಗಳನ್ನು ಸರಿಹೊಂದಿಸು"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ಜಾಡು ಇರಿಸುವ ಕ್ರಮ"
+
+#~ msgid "Left Ring"
+#~ msgstr "ಎಡ ರಿಂಗ್"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "ಎಡ ರಿಂಗ್ ವಿಧಾನ #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "ಬಲ ರಿಂಗ್ ವಿಧಾನ #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "ಎಡ ಟಚ್‌ಸ್ಟ್ರಿಪ್"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "ಎಡ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "ಬಲ ಟಚ್‌ಸ್ಟ್ರಿಪ್"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "ಬಲ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "ಎಡ ಟಚ್‌ರಿಂಗ್ ವಿಧಾನ ಬದಲಾವಣೆ"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "ಬಲ ಟಚ್‌ರಿಂಗ್ ವಿಧಾನ ಬದಲಾವಣೆ"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "ಎಡ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ ಬದಲಾವಣೆ"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "ಬಲ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ ಬದಲಾವಣೆ"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "ವಿಧಾನದ ಬದಲಾವಣೆ #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "ಎಡ ಗುಂಡಿ #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "ಬಲ ಗುಂಡಿ #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "ಮೇಲಿನ ಗುಂಡಿ #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "ಕೆಳಗಿನ ಗುಂಡಿ #%d"
+
+#~ msgid "No Action"
+#~ msgstr "ಯಾವುದೆ ಕ್ರಿಯೆಯಿಲ್ಲ"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "ಮೌಸ್‌ನ ಎಡ ಗುಂಡಿಯ ಕ್ಲಿಕ್"
+
+#~ msgid "Scroll Up"
+#~ msgstr "ಮೇಲಕ್ಕೆ ಚಲಿಸು"
+
+#~ msgid "Top Button"
+#~ msgstr "ಮೇಲಿನ ಗುಂಡಿ"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "ವರ್ಬೋಸ್ ಕ್ರಮವನ್ನು ಶಕ್ತಗೊಳಿಸಿ"
+
+#~ msgid "Show the overview"
+#~ msgstr "ಅವಲೋಕನವನ್ನು ತೋರಿಸು"
+
+#~ msgid "Search for the string"
+#~ msgstr "ವಾಕ್ಯಾಂಶಕ್ಕಾಗಿ ಹುಡುಕು"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "ಸಾಧ್ಯವಿರುವ ಫಲಕದ ಹೆಸರುಗಳನ್ನು ಪಟ್ಟಿ ಮಾಡಿ ನಿರ್ಗಮಿಸು"
+
+#~ msgid "Show help options"
+#~ msgstr "ಸಹಾಯ ಆಯ್ಕೆಯನ್ನು ತೋರಿಸು"
+
+#~ msgid "Panel to display"
+#~ msgstr "ತೋರಿಸಬೇಕಿರುವ ಫಲಕ"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- ಸಿದ್ಧತೆಗಳು"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "ಲಭ್ಯವಿರುವ ಎಲ್ಲಾ ಆಜ್ಞಾ ಸಾಲಿನ ಆಯ್ಕೆಗಳನ್ನು ನೋಡಲು '%s --help' ಅನ್ನು ಚಲಾಯಿಸಿ.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "ಲಭ್ಯವಿರುವ ಪ್ಯಾನಲ್‌ಗಳು:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "ವೈಯಕ್ತಿಕ"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "ಯಂತ್ರಾಂಶ"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "ವ್ಯವಸ್ಥೆ"
 
 #~ msgid "United States"
 #~ msgstr "ಯುನೈಟೆಡ್ ಸ್ಟೇಟ್ಸ್‍"
@@ -7197,23 +8143,14 @@ msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
 #~ msgid "Germany"
 #~ msgstr "ಜರ್ಮನಿ"
 
-#~ msgid "France"
-#~ msgstr "ಫ್ರಾನ್ಸ್‍"
-
 #~ msgid "Spain"
 #~ msgstr "ಸ್ಪೇನ್"
 
 #~ msgid "China"
 #~ msgstr "ಚೈನಾ"
 
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
-
 #~ msgid "Set Up New Device"
 #~ msgstr "ಹೊಸ ಸಾಧನವನ್ನು ಸಿದ್ಧಗೊಳಿಸು"
-
-#~ msgid "Connection"
-#~ msgstr "ಸಂಪರ್ಕ"
 
 #~ msgid "Paired"
 #~ msgstr "ಜೋಡಿಸಿದ"
@@ -7224,14 +8161,8 @@ msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "ಮೌಸ್‌ ಮತ್ತು ಟಚ್‌ಪ್ಯಾಡ್ ಸಿದ್ಧತೆಗಳು"
 
-#~ msgid "Sound Settings"
-#~ msgstr "ಧ್ವನಿ ಸಿದ್ಧತೆಗಳು"
-
 #~ msgid "Send Files…"
 #~ msgstr "ಕಡತಗಳನ್ನು ಕಳುಹಿಸು…"
-
-#~ msgid "Visibility"
-#~ msgstr "ಗೋಚರಿಕೆ"
 
 #~ msgid "Visibility of “%s”"
 #~ msgstr "“%s” ನ ಗೋಚರಿಕೆ"
@@ -7316,12 +8247,6 @@ msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
 #~ msgid "_City:"
 #~ msgstr "ಊರು (_C):"
 
-#~ msgid "_Network Time"
-#~ msgstr "ಜಾಲಬಂಧ ಸಮಯ (_N)"
-
-#~ msgid ":"
-#~ msgstr ":"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "ಗಂಟೆಯನ್ನು ಒಂದು ಗಂಟೆ ಮುಂದಕ್ಕೆ ಹೊಂದಿಸಿ."
 
@@ -7349,18 +8274,8 @@ msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
 #~ msgstr "ಅಪ್ರದಕ್ಷಿಣೆ"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "ಪ್ರದಕ್ಷಿಣೆ"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 ಡಿಗ್ರಿಗಳು"
-
-#~ msgid "Monitor"
-#~ msgstr "ಪರದೆ"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "ಪ್ರಾಥಮಿಕ ಪ್ರದರ್ಶಕವನ್ನು ಬದಲಾಯಿಸಲು ಎಳೆಯಿರಿ."
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -7390,18 +8305,8 @@ msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "ಸೂಚನೆ: ರೆಸಲ್ಯೂಶನ್ ಆಯ್ಕೆಗಳನ್ನು ಮಿತಿಗೊಳಿಸಬಹುದು"
 
-#~ msgid "_Detect Displays"
-#~ msgstr "ಪ್ರದರ್ಶಕಗಳನ್ನು ಪತ್ತೆ ಮಾಡು (_D)"
-
-#~ msgid "Install Updates"
-#~ msgstr "ಅಪ್‌ಡೇಟ್‌ಗಳನ್ನು ಅನುಸ್ಥಾಪಿಸು"
-
 #~ msgid "System Up-To-Date"
 #~ msgstr "ವ್ಯವಸ್ಥೆಯು ಅಪ್-ಟು-ಡೇಟ್ ಆಗಿದೆ"
-
-# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0, author Shankar
-#~ msgid "OS Type"
-#~ msgstr "OS ಬಗೆ"
 
 #~ msgid "Mouse Preferences"
 #~ msgstr "ಮೌಸ್ ಆದ್ಯತೆಗಳು"
@@ -7482,9 +8387,6 @@ msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
 
 #~ msgid "Share Public Folder On This Network"
 #~ msgstr "ಸಾರ್ವಜನಿಕ ಕಡತಕೋಶವನ್ನು ಈ ಜಾಲಬಂಧದಲ್ಲಿ ಹಂಚಿಕೊಳ್ಳಿ"
-
-#~ msgid "Remote View"
-#~ msgstr "ದೂರಸ್ಥ ನೋಟ"
 
 #~ msgid "Approve All Connections"
 #~ msgstr "ಎಲ್ಲಾ ಸಂಪರ್ಕಗಳನ್ನು ಅಂಗೀಕರಿಸು"
@@ -7585,9 +8487,6 @@ msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
 #~ msgid "Large"
 #~ msgstr "ದೊಡ್ಡದಾದ"
 
-#~ msgid "Add account"
-#~ msgstr "ಖಾತೆಯನ್ನು ಸೇರಿಸು"
-
 #~ msgid "_Local Account"
 #~ msgstr "ಸ್ಥಳೀಯ ಖಾತೆ (_L)"
 
@@ -7600,12 +8499,6 @@ msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
 #~ msgid "C_ontinue"
 #~ msgstr "ಮುಂದುವರೆ (_o)"
 
-#~ msgid "Previous Week"
-#~ msgstr "ಹಿಂದಿನ ವಾರ"
-
-#~ msgid "Next Week"
-#~ msgstr "ಮುಂದಿನ ವಾರ"
-
 #~ msgid "Next week"
 #~ msgstr "ಮುಂದಿನ ವಾರ"
 
@@ -7617,12 +8510,6 @@ msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
 
 #~ msgid "Enable this account"
 #~ msgstr "ಈ ಖಾತೆಯನ್ನು ಶಕ್ತಗೊಳಿಸು"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "ಗುಪ್ತಪದವನ್ನು ಖಚಿತಪಡಿಸಿ (_o)"
-
-#~ msgid "Generate a password"
-#~ msgstr "ಗುಪ್ತಪದವನ್ನು ಉತ್ಪಾದಿಸಿ"
 
 #~ msgid "_Action"
 #~ msgstr "ಕ್ರಿಯೆ (_A)"

--- a/po/kn.po~
+++ b/po/kn.po~
@@ -1,0 +1,7707 @@
+# translation of gnome-control-center.master.kn.po to Kannada
+# translation of gnome-control-center.HEAD.po to
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Shankar Prasad <svenkate@redhat.com>, 2008, 2009, 2010, 2011, 2012, 2013, 2014.
+# Shankar <svenkate@redhat.com>, 2013, 2014. #zanata.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-12-24 07:27+0000\n"
+"PO-Revision-Date: 2014-12-24 15:59+0530\n"
+"Last-Translator: Shankar Prasad <svenkate AT redhat Dot com>\n"
+"Language-Team: American English <kde-i18n-doc@kde.org>\n"
+"Language: kn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 1.5\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "ಹಿನ್ನಲೆ ಚಿತ್ರ"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "ದಿನಪೂರ್ತಿ ಬದಲಾಯಿಸುತ್ತದೆ"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "Lock Screen"
+msgstr "ಲಾಕ್ ತೆರೆ"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "ಚೌಕ"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "ಗಾತ್ರಬದಲಿಸು"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "ಮಧ್ಯಕ್ಕೆ"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "ಗಾತ್ರ ಬದಲಾವಣೆ"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "ತುಂಬಿಸು"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "ಹರಡು"
+
+#: ../panels/background/cc-background-chooser-dialog.c:437
+msgid "Wallpapers"
+msgstr "ವಾಲ್‌ಪೇಪರುಗಳು"
+
+#: ../panels/background/cc-background-chooser-dialog.c:446
+msgid "Colors"
+msgstr "ಬಣ್ಣಗಳು"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:483
+msgid "Select Background"
+msgstr "ಹಿನ್ನಲೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡು"
+
+#: ../panels/background/cc-background-chooser-dialog.c:511
+msgid "Pictures"
+msgstr "ಚಿತ್ರಗಳು"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:543
+msgid "No Pictures Found"
+msgstr "ಯಾವುದೆ ಚಿತ್ರಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:561
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "ನೆಲೆ"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:573
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr ""
+"ನೀವು ಚಿತ್ರಗಳನ್ನು ನಿಮ್ಮ %s ಕಡತಕೋಶಕ್ಕೆ ಸೇರಿಸಬಹುದು ಮತ್ತು ಅವುಗಳು ಇಲ್ಲಿ ಕಾಣಿಸುತ್ತವೆ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:580
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1514
+#: ../panels/display/cc-display-panel.c:1951
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1247
+#: ../panels/network/net-device-wifi.c:1440
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/cc-printers-panel.c:1945
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+#: ../panels/user-accounts/um-photo-dialog.c:94
+#: ../panels/user-accounts/um-photo-dialog.c:217
+#: ../panels/user-accounts/um-user-panel.c:708
+#: ../panels/user-accounts/um-user-panel.c:726
+msgid "_Cancel"
+msgstr "ರದ್ದು ಮಾಡು (_C)"
+
+#: ../panels/background/cc-background-chooser-dialog.c:581
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:96
+msgid "Select"
+msgstr "ಆರಿಸು"
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "ಅನೇಕ ಗಾತ್ರಗಳು"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "ಯಾವುದೆ ಗಣಕತೆರೆ ಹಿನ್ನಲೆ ಚಿತ್ರವಿಲ್ಲ"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "ಈಗಿನ ಹಿನ್ನಲೆ ಚಿತ್ರ"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "ನಿಮ್ಮ ಹಿನ್ನಲೆ ಚಿತ್ರವನ್ನು ಒಂದು ವಾಲ್‌ಪೇಪರ್ ಅಥವ ಫೋಟೊದಿಂದ ಬದಲಾಯಿಸಿ"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "ವಾಲ್‌ಪೇಪರ್;ತೆರೆ;ಗಣಕತೆರೆ;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "ಬ್ಲೂಟೂತ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "ಯಾವುದೇ ಬ್ಲೂಟೂತ್ ಅಡಾಪ್ಟರುಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "ಯಂತ್ರಾಂಶ ಸ್ವಿಚ್‌ನಿಂದ ಬ್ಲೂಟೂತ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1637
+msgid "Bluetooth"
+msgstr "ಬ್ಲೂಟೂತ್"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+"ಬ್ಲೂಟೂತ್ ಅನ್ನು ಆನ್ ಮತ್ತು ಆಫ್ ಮಾಡಿ ಹಾಗೂ ನಿಮ್ಮ ಸಾಧನಗಳೊಂದಿಗೆ ಸಂಪರ್ಕ ಸಾಧಿಸಿ"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr ""
+"ನಿಮ್ಮ ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಸಾಧನವನ್ನು ಚೌಕದ ಮೇಲೆ ಇರಿಸಿ ಮತ್ತು 'ಪ್ರಾರಂಭಿಸು' ಅನ್ನು ಒತ್ತಿ"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+"ಕ್ಯಾಲಿಬ್ರೇಟ್ ಸ್ಥಾನಕ್ಕೆ ನಿಮ್ಮ ಸಾಧನವನ್ನು ಜರುಗಿಸಿ ಮತ್ತು 'ಮುಂದುವರೆ' ಅನ್ನು ಒತ್ತಿ"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr "ಮೇಲ್ಮೈ ಸ್ಥಾನಕ್ಕೆ ನಿಮ್ಮ ಸಾಧನವನ್ನು ಜರುಗಿಸಿ ಮತ್ತು 'ಮುಂದುವರೆ' ಅನ್ನು ಒತ್ತಿ"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "ಲ್ಯಾಪ್‌ಟಾಪ್‌ನ ಮುಚ್ಚುಳವನ್ನು ಮುಚ್ಚು"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "ಚೇತರಿಸಕೊಳ್ಳಲಲು ಸಾಧ್ಯವಾಗದಂತಹ ಒಂದು ಆಂತರಿಕ ದೋಷ ಸಂಭವಿಸಿದೆ."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ಗಾಗಿ ಅಗತ್ಯವಿರುವ ತಂತ್ರಾಂಶವನ್ನು ಅನುಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಉತ್ಪಾದಿಸಲಾಗಿಲ್ಲ."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "ಗುರಿಯ ಶ್ವೇತಬಿಂದುವನ್ನು ಪಡೆಯಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "ಪೂರ್ಣಗೊಂಡಿದೆ!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ವಿಫಲಗೊಂಡಿದೆ!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "ನೀವು ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕಬಹುದು."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಪ್ರಗತಿಯಲ್ಲಿರುವಾಗ ಸಾಧನವನ್ನು ಸ್ಥಳಾಂತರಿಸಬೇಡಿ"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "ಲ್ಯಾಪ್‌ಟಾಪ್ ತೆರೆ"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "ಒಳನಿರ್ಮಿತ ವೆಬ್‌-ಕ್ಯಾಮ್"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s ಪರದೆ"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s ಸ್ಕ್ಯಾನರ್"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s ಕ್ಯಾಮೆರಾ"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s ಮುದ್ರಕ"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s ವೆಬ್‌ಕ್ಯಾಮ್"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s ಗಾಗಿ ಬಣ್ಣದ ನಿರ್ವಹಣೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸು"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s ಗಾಗಿ ಬಣ್ಣದ ಪ್ರೊಫೈಲ್ ಅನ್ನು ತೋರಿಸು"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:323
+msgid "Not calibrated"
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಟ್ ಮಾಡದಿರುವ"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "ವರ್ಣಸ್ಥಳ: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "ಪ್ರಾಯೋಗಿಕ ಪ್ರೊಫೈಲ್: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "ICC ಪ್ರೊಫೈಲ್ ಕಡತವನ್ನು ಆರಿಸು"
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "ಆಮದು ಮಾಡು (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "ಬೆಂಬಲಿಸಲಾಗುವ ICC ಪ್ರೊಫೈಲುಗಳು"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "ಎಲ್ಲಾ ಕಡತಗಳು"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "ತೆರೆ"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "ಕಡತವನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡುವಲ್ಲಿ ವಿಫಲತೆ: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಇಲ್ಲಿಗೆ ಅಪ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ:"
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "ಈ URL ಅನ್ನು ಬರೆ."
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+"ಈ ಗಣಕವನ್ನು ಮರಳಿ ಆರಂಭಿಸು ಹಾಗು ನಿಮ್ಮ ಸಾಮಾನ್ಯ ಕಾರ್ಯಾಚರಣೆ ವ್ಯವಸ್ಥೆಯನ್ನು ಬೂಟ್ ಮಾಡಿ."
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+"ಪ್ರೊಫೈಲ್ ಅನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಮತ್ತು ಅನುಸ್ಥಾಪಿಸಲು ನಿಮ್ಮ ಜಾಲವೀಕ್ಷಕಕ್ಕೆ URL "
+"ಅನ್ನು ನಮೂದಿಸಿ."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "ಪ್ರೊಫೈಲನ್ನು ಉಳಿಸು"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "ಉಳಿಸು (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "ಆಯ್ಕೆ ಮಾಡಿದ ಸಾಧನಕ್ಕಾಗಿ ಒಂದು ವರ್ಣ ಪ್ರೊಫೈಲನ್ನು ರಚಿಸು"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"ಅಳತೆ ಮಾಡುವ ಉಪಕರಣವನ್ನು ಪತ್ತೆ ಮಾಡಲಾಗಿಲ್ಲ. ದಯವಿಟ್ಟು ಅದನ್ನು ಆನ್ ಮಾಡಲಾಗಿದೆ ಮತ್ತು "
+"ಸರಿಯಾಗಿದೆಯೆ ಎಂದು ಪರೀಕ್ಷಿಸಿ."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "ಅಳೆಯುವ ಉಪಕರಣವು ಮುದ್ರಕ ಪ್ರೊಫೈಲ್ ಅನ್ನು ಬೆಂಬಲಿಸುವುದಿಲ್ಲ."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "ಸಾಧನದ ಬಗೆಗೆ ಪ್ರಸಕ್ತ ಬೆಂಬಲವಿಲ್ಲ."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "ಶಿಷ್ಟ ಅಂತರ"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "ಪ್ರಾಯೋಗಿಕ ಪ್ರೊಫೈಲ್"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "ಸ್ವಯಂಚಾಲಿತ"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "ಕಳಪೆ ಗುಣಮಟ್ಟ"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "ಮಧ್ಯಮ ಗುಣಮಟ್ಟ"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "ಉತ್ತಮ ಗುಣಮಟ್ಟ"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಬೂದು"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "ಮಾರಾಟಗಾರನು ಫ್ಯಾಕ್ಟರಿ ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಡೇಟಾವನ್ನು ಒದಗಿಸಿದ್ದಾರೆ"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "ಈ ಪ್ರೊಫೈಲಿನಿಂದ ಪೂರ್ಣ-ತೆರೆ ಪ್ರದರ್ಶಕ ಸರಿಪಡಿಕೆಯು ಸಾಧ್ಯವಿಲ್ಲ"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "ಈ ಪ್ರೊಫೈಲ್ ಇನ್ನು ಮುಂದೆ ನಿಖರವಾಗಿರುವುದಿಲ್ಲ"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಅನ್ನು ತೋರಿಸು"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr "ರದ್ದು ಮಾಡು"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "ಆರಂಭ"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "ಮರಳಿ ಆರಂಭಿಸು"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "ಆಯಿತು"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "ತೆರೆಯ ಕ್ಯಾಲಿಬ್ರೇಶನ್"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ನಿಂದಾಗಿ ನಿಮ್ಮ ತೆರೆಯ ಬಣ್ಣವನ್ನು ವ್ಯವಸ್ಥಾಪಿಸಲು ಅಗತ್ಯವಿರುವ ಪ್ರೊಫೈಲ್ "
+"ಒಂದು ನಿಮಗೆ "
+"ದೊರೆಯುತ್ತದೆ. ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ಗಾಗಿ ಹೆಚ್ಚು ಹೊತ್ತು ವ್ಯಯಿಸಿದಷ್ಟೂ ಬಣ್ಣದ ಪ್ರೊಫೈಲ್‌ನ "
+"ಗುಣಮಟ್ಟ "
+"ಉತ್ತಮಗೊಳ್ಳುತ್ತದೆ."
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ ನಡೆಯುವಾಗ ನೀವು ನಿಮ್ಮ ಗಣಕವನ್ನು ಬಳಸಲು ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "ಗುಣಮಟ್ಟ"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "ಅಂದಾಜು ಸಮಯ"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಗುಣಮಟ್ಟ"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+"ಕ್ಯಾಲಿಬ್ರೇಶನ್‌ಗಾಗಿ ನೀವು ಬಳಸಲು ಬಯಸುವ ಸಂವೇದಿ (ಸೆನ್ಸರ್) ಸಾಧನವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ."
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಶನ್ ಸಾಧನ"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "ಸಂಪರ್ಕ ಜೋಡಿಸಲಾದ ಪ್ರದರ್ಶಕದ ಬಗೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿ."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "ಪ್ರದರ್ಶಕದ ಬಗೆ"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"ಪ್ರದರ್ಶಕ ಗುರಿ ಶ್ವೇತ ಬಿಂದುವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ. ಹೆಚ್ಚಿನ ಪ್ರದರ್ಶಕಗಳನ್ನು ಒಂದು D65 "
+"ಪ್ರಕಾಶತೆಗೆ "
+"ಸರಿಹೊಂದಿಸಬೇಕಾಗಿರುತ್ತದೆ."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "ಶ್ವೇತಬಿಂದು ಪ್ರೊಫೈಲ್"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"ಪ್ರದರ್ಶಕವನ್ನು ನಿಮಗೆ ಸಾಮಾನ್ಯವೆನಿಸುವ ಪ್ರಕಾಶತೆಗೆ ಹೊಂದಿಸಿ. ಈ ಪ್ರಕಾಶತೆಯ ಮಟ್ಟದಲ್ಲಿ "
+"ಬಣ್ಣ "
+"ವ್ಯವಸ್ಥಾಪನೆಯು ಅತ್ಯಂತ ನಿಖರವಾಗಿರುತ್ತದೆ."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"ಪರ್ಯಾಯವಾಗಿ, ಈ ಸಾಧನಕ್ಕಾಗಿ ಬೇರೆ ಪ್ರೊಫೈಲ್‌ಗಳಲ್ಲಿ ಬಳಸಲಾದ ಪ್ರಕಾಶತೆಯ ಮಟ್ಟವನ್ನು ನೀವು "
+"ಬಳಸಬಹುದು."
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "ಪ್ರದರ್ಶಕದ ಪ್ರಕಾಶತೆ"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"ನೀವು ಬಣ್ಣದ ಪ್ರೊಫೈಲ್ ಅನ್ನು ಬೇರೊಂದು ಗಣಕದಲ್ಲಿ, ಅಥವ ವಿವಿಧ ಬೆಳಕಿನ ಸ್ಥಿತಿಗಳಿಗಾಗಿನ "
+"ಪ್ರೊಫೈಲ್ "
+"ಅನ್ನು ರಚಿಸಲು ಬಳಸಬಹುದು."
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "ಪ್ರೊಫೈಲ್ ಹೆಸರು:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "ಪ್ರೊಫೈಲ್ ಹೆಸರು"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "ಪ್ರೊಫೈಲ್ ಅನ್ನು ಯಶಸ್ವಿಯಾಗಿ ರಚಿಸಲಾಗಿದೆ!"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "ಪ್ರೊಫೈಲನ್ನು ಪ್ರತಿ ಮಾಡು"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "ಬರೆಯಬಹುದಾದ ಮಾಧ್ಯಮದ ಅಗತ್ಯವಿದೆ"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "ಪ್ರೊಫೈಲನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡು"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "ಅಂತರಜಾಲ ಸಂಪರ್ಕದ ಅಗತ್ಯವಿದೆ"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href="
+"\"windows\">Microsoft Windows</a> ವ್ಯವಸ್ಥೆಗಳಲ್ಲಿ ಪ್ರೊಫೈಲ್ ಅನ್ನು ಹೇಗೆ ಬಳಸುವುದು "
+"ಎಂದು "
+"ತಿಳಿಯಲು ಈ ವಿವರಗಳು ಉಪಯುಕ್ತವೆನಿಸುತ್ತದೆ."
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:732
+msgid "Summary"
+msgstr "ಸಾರಾಂಶ"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "ಕಡತವನ್ನು ಆಮದು ಮಾಡಿಕೊಳ್ಳಿ…"
+
+#: ../panels/color/color.ui.h:30
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr "ಸೇರಿಸು (_A)"
+
+#: ../panels/color/color.ui.h:31
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"ತೊಂದರೆಯು ಕಂಡುಬಂದಿದೆ. ಪ್ರೊಫೈಲ್ ಸರಿಯಾಗಿ ಕೆಲಸ ಮಾಡುವುದಿಲ್ಲ. <a href=\"\">"
+"ವಿವರಗಳನ್ನು "
+"ತೋರಿಸು.</a>"
+
+#: ../panels/color/color.ui.h:32
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"ಪ್ರತಿಯೊಂದು ಸಾಧನದಲ್ಲಿ ಬಣ್ಣವನ್ನು ನಿರ್ವಹಿಸಲು ಅದಕ್ಕೆ ಇತ್ತೀಚಿನ (ಅಪ್‌ ಟು ಡೇಟ್) ಬಣ್ಣ "
+"ಪ್ರೊಫೈಲಿನ "
+"ಅಗತ್ಯವಿರುತ್ತದೆ."
+
+#: ../panels/color/color.ui.h:33
+msgid "Learn more"
+msgstr "ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more about color management"
+msgstr "ಬಣ್ಣದ ನಿರ್ವಹಣೆಯ ಕುರಿತು ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ"
+
+#: ../panels/color/color.ui.h:35
+msgid "Set for all users"
+msgstr "ಎಲ್ಲಾ ಬಳಕೆದಾರರಿಗೂ ಹೊಂದಿಸು"
+
+#: ../panels/color/color.ui.h:36
+msgid "Set this profile for all users on this computer"
+msgstr "ಈ ಪ್ರೊಫೈಲನ್ನು ಈ ಗಣಕದಲ್ಲಿನ ಎಲ್ಲಾ ಬಳಕೆದಾರರಿಗಾಗಿ ಹೊಂದಿಸು"
+
+#: ../panels/color/color.ui.h:37
+msgid "Enable"
+msgstr "ಸಕ್ರಿಯ"
+
+#: ../panels/color/color.ui.h:38
+msgid "Add profile"
+msgstr "ಪ್ರೊಫೈಲನ್ನು ಸೇರಿಸು"
+
+#: ../panels/color/color.ui.h:39
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Calibrate…"
+msgstr "ಕ್ಯಾಲಿಬ್ರೇಟ್..."
+
+#: ../panels/color/color.ui.h:40
+msgid "Calibrate the device"
+msgstr "ಸಾಧನವನ್ನು ಕ್ಯಾಲಿಬ್ರೇಟ್ ಮಾಡು"
+
+#: ../panels/color/color.ui.h:41
+msgid "Remove profile"
+msgstr "ಪ್ರೊಫೈಲನ್ನು ತೆಗೆದು ಹಾಕು"
+
+#: ../panels/color/color.ui.h:42
+msgid "View details"
+msgstr "ವಿವರಗಳನ್ನು ನೋಡು"
+
+#: ../panels/color/color.ui.h:43
+msgid "Unable to detect any devices that can be color managed"
+msgstr "ಬಣ್ಣವನ್ನು ವ್ಯವಸ್ಥಾಪಿಸಲು ಯಾವುದೆ ಸಾಧನಗಳನ್ನು ಪತ್ತೆ ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#: ../panels/color/color.ui.h:44
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:45
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:46
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:47
+msgid "Projector"
+msgstr "ಪ್ರೊಜೆಕ್ಟರ್"
+
+#: ../panels/color/color.ui.h:48
+msgid "Plasma"
+msgstr "ಪ್ಲಾಸ್ಮಾ"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL ಹಿಂಬೆಳಕು)"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED ಹಿಂಬೆಳಕು)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (white LED backlight)"
+msgstr "LCD (ಬಿಳಿಯ LED ಹಿಂಬೆಳಕು)"
+
+#: ../panels/color/color.ui.h:52
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "ಅಗಲ ಗ್ಯಾಮುಟ್ LCD (CCFL ಹಿಂಬೆಳಕು)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "ಅಗಲ ಗ್ಯಾಮುಟ್ LCD (RGB LED ಹಿಂಬೆಳಕು)"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "ಉತ್ತಮ"
+
+#: ../panels/color/color.ui.h:55
+msgid "40 minutes"
+msgstr "40 ನಿಮಿಷಗಳು"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "ಮಧ್ಯಮ"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 ನಿಮಿಷಗಳು"
+
+#: ../panels/color/color.ui.h:58
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "ಕೆಳ ಮಟ್ಟದ"
+
+#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 ನಿಮಿಷಗಳು"
+
+#: ../panels/color/color.ui.h:60
+msgid "Native to display"
+msgstr "ತೋರಿಸಬೇಕಿರುವ ನೇಟೀವ್"
+
+#: ../panels/color/color.ui.h:61
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (ಮುದ್ರಣ ಮತ್ತು ಪ್ರಕಟಣೆ)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:63
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (ಫೊಟೊಗ್ರಾಫಿ ಮತ್ತು ಗ್ರಾಫಿಕ್ಸ್)"
+
+#: ../panels/color/color.ui.h:64
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "ಬಣ್ಣ"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"ನಿಮ್ಮ ಸಾಧನಗಳು, ಪ್ರದರ್ಶಕಗಳು, ಕ್ಯಾಮೆರಾಗಳು ಅಥವ ಮುದ್ರಕಗಳ ಬಣ್ನವನ್ನು ಕ್ಯಾಲಿಬ್ರೇಟ್ "
+"ಮಾಡು"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "ಬಣ್ಣ;ICC;ಪ್ರೊಫೈಲ್;ಕ್ಯಾಲಿಬ್ರೇಟ್;ಮುದ್ರಕ;ಪ್ರದರ್ಶಕ;"
+
+#: ../panels/common/cc-common-language.c:323
+msgid "Other…"
+msgstr "ಇತರೆ…"
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr "ಇನ್ನಷ್ಟು …"
+
+#: ../panels/common/cc-language-chooser.c:139
+msgid "No languages found"
+msgstr "ಯಾವುದೆ ಭಾಷೆಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "ಭಾಷೆ"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "ಆಯಿತು (_D)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "ಜನವರಿ"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "ಫೆಬ್ರವರಿ"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "ಮಾರ್ಚ್"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "ಏಪ್ರಿಲ್"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "ಮೇ"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "ಜೂನ್"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "ಜುಲೈ"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "ಆಗಸ್ಟ್‍"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "ಸಪ್ಟೆಂಬರ್"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "ಅಕ್ಟೋಬರ್"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "ನವೆಂಬರ್"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "ಡಿಸೆಂಬರ್"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "ದಿನಾಂಕ ಮತ್ತು ಸಮಯ"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "ಗಂಟೆ"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "ನಿಮಿಷ"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "ದಿನ"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "ತಿಂಗಳು"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "ವರ್ಷ"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Time Zone"
+msgstr "ಕಾಲ ವಲಯ"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Search for a city"
+msgstr "ಊರಿಗಾಗಿ ಹುಡುಕು"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Automatic _Date & Time"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ದಿನಾಂಕ ಮತ್ತು ಸಮಯ (_D)"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr "ಅಂತರಜಾಲ ನಿಲುಕಿನ ಅಗತ್ಯವಿರುತ್ತದೆ"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Automatic Time _Zone"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ಕಾಲ ವಲಯ (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "Date & _Time"
+msgstr "ದಿನಾಂಕ ಮತ್ತು ಸಮಯ (_T)"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr "ಕಾಲ ವಲಯ (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:28
+msgid "Time _Format"
+msgstr "ಸಮಯದ ಶೈಲಿಗಳು (_F)"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24-ಗಂಟೆ"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "ಕಾಲವಲಯವೂ ಸೇರಿದಂತೆ ದಿನಾಂಕ ಮತ್ತು ಸಮಯವನ್ನು ಬದಲಾಯಿಸು"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "ಗಡಿಯಾರ;ಕಾಲವಲಯ;ಸ್ಥಳ;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "ನಿಮ್ಮ ಪ್ರದೇಶ ಹಾಗೆ ಭಾಷೆಯ ಸಿದ್ಧತೆಗಳನ್ನು ಬದಲಾಯಿಸಿ"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "ಸಮಯ ಅಥವ ದಿನಾಂಕದ ಸಿದ್ಧತೆಗಳನ್ನು ಬದಲಾಯಿಸಲು, ನೀವು ದೃಢೀಕರಿಸಬೇಕಾಗುತ್ತದೆ."
+
+#: ../panels/display/cc-display-panel.c:487
+msgid "Lid Closed"
+msgstr "ಮುಚ್ಚುಳ ಮುಚ್ಚಿದೆ"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+msgid "Mirrored"
+msgstr "ಪ್ರತಿಬಿಂಬಿತ"
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2120
+msgid "Primary"
+msgstr "ಪ್ರಾಥಮಿಕ"
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1695 ../panels/power/cc-power-panel.c:1706
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "ಆಫ್"
+
+#: ../panels/display/cc-display-panel.c:497
+msgid "Secondary"
+msgstr "ದ್ವಿತೀಯ"
+
+#: ../panels/display/cc-display-panel.c:1510
+msgid "Arrange Combined Displays"
+msgstr "ಸಂಯೋಜಿತ ಪ್ರದರ್ಶಕಗಳನ್ನು ಜೋಡಿಸು"
+
+#: ../panels/display/cc-display-panel.c:1516
+#: ../panels/display/cc-display-panel.c:1954
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "ಅನ್ವಯಿಸು (_A)"
+
+#: ../panels/display/cc-display-panel.c:1537
+msgid "Drag displays to rearrange them"
+msgstr "ಪ್ರದರ್ಶಕಗಳನ್ನು ಮರಳಿಹೊಂದಿಸಲು ಎಳೆದುಸೇರಿಸಿ"
+
+#: ../panels/display/cc-display-panel.c:2056
+msgid "Size"
+msgstr "ಗಾತ್ರ"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2069
+msgid "Aspect Ratio"
+msgstr "ಆಕಾರ ಅನುಪಾತ"
+
+#: ../panels/display/cc-display-panel.c:2090
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "ರೆಸಲ್ಯೂಶನ್"
+
+#: ../panels/display/cc-display-panel.c:2121
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "ಮೇಲಿನ ಪಟ್ಟಿ ಮತ್ತು ಚಟುವಟಿಕೆ ಅವಲೋಕಗಳನ್ನು ಈ ಪ್ರದರ್ಶಕದಲ್ಲಿ ತೋರಿಸು"
+
+#: ../panels/display/cc-display-panel.c:2127
+msgid "Secondary Display"
+msgstr "ಎರಡನೆಯ ಪ್ರದರ್ಶಕ"
+
+#: ../panels/display/cc-display-panel.c:2128
+msgid "Join this display with another to create an extra workspace"
+msgstr ""
+"ಒಂದು ಹೆಚ್ಚುವರಿ ಕಾರ್ಯಸ್ಥಳವನ್ನು ರಚಿಸಲು ಈ ಪ್ರದರ್ಶಕವನ್ನು ಇನ್ನೊಂದಕ್ಕೆ ಜೋಡಿಸು"
+
+#: ../panels/display/cc-display-panel.c:2135
+msgid "Presentation"
+msgstr "ಪ್ರಸ್ತುತಿ"
+
+#: ../panels/display/cc-display-panel.c:2136
+msgid "Show slideshows and media only"
+msgstr "ಸ್ಲೈಡ್‌ಶೋಗಳನ್ನು ಮತ್ತು ಮಾಧ್ಯಮವನ್ನು ಮಾತ್ರ ತೋರಿಸು"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2141
+msgid "Mirror"
+msgstr "ಬಿಂಬ"
+
+#: ../panels/display/cc-display-panel.c:2142
+msgid "Show your existing view on both displays"
+msgstr "ಎರಡೂ ಪ್ರದರ್ಶಕಗಳಲ್ಲಿ ನಿಮ್ಮ ಈಗಿನ ನೋಟವನ್ನು ತೋರಿಸಿ"
+
+#: ../panels/display/cc-display-panel.c:2148
+msgid "Turn Off"
+msgstr "ನಿಷ್ಕ್ರಿಯಗೊಳಿಸು"
+
+#: ../panels/display/cc-display-panel.c:2149
+msgid "Don't use this display"
+msgstr "ಈ ಪ್ರದರ್ಶಕವನ್ನು ಬಳಸಬೇಡ"
+
+#: ../panels/display/cc-display-panel.c:2358
+msgid "Could not get screen information"
+msgstr "ತೆರೆಯ ಮಾಹಿತಿಯನ್ನು ಪಡೆಯಲಾಗಲಿಲ್ಲ"
+
+#: ../panels/display/cc-display-panel.c:2389
+msgid "_Arrange Combined Displays"
+msgstr "ಸಂಯೋಜಿತತ ಪ್ರದರ್ಶಕಗಳನ್ನು ಜೋಡಿಸು (_A)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "ಪ್ರದರ್ಶಕಗಳು"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+"ಸಂಪರ್ಕಿತಗೊಳಿಸಲಾದ ಮಾನಿಟರುಗಳ ಹಾಗು ಪ್ರೊಜೆಕ್ಟರುಗಳನ್ನು ಹೇಗೆ ಬಳಸಬೇಕು ಎನ್ನುವುದನ್ನು "
+"ಆರಿಸಿ"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "ಪ್ಯಾನಲ್;ಪ್ರೊಜೆಕ್ಟರ್;xrandr;ತೆರೆ;ರೆಸಲ್ಯೂಶನ್;ಪುನಶ್ಚೇತನ;ಪರದೆ;"
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr "ವೇಲ್ಯಾಂಡ್"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "ಗೊತ್ತಿರದ"
+
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-bit"
+
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr "%d-ಬಿಟ್"
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr "ಏನು ಮಾಡಬೇಕು ಎಂದು ಕೇಳು"
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr "ಏನೂ ಮಾಡಬೇಡ"
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr "ಕಡತಕೋಶವನ್ನು ತೆರೆ"
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr "ಇತರೆ ಮಾಧ್ಯಮ"
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr "ಆಡಿಯೊ CD ಗಳಿಗಾಗಿ ಒಂದು ಅನ್ವಯವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr "ವೀಡಿಯೊ DVD ಗಳಿಗಾಗಿ ಒಂದು ಅನ್ವಯವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr "ಸಂಗೀತದ ಪ್ಲೇಯರನ್ನು ಜೋಡಿಸಿದಾಗ ಚಲಾಯಿಸಲು ಒಂದು ಅನ್ವಯವನ್ನು ಆರಿಸಿ"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr "ಕ್ಯಾಮೆರವನ್ನು ಜೋಡಿಸಿದಾಗ ಚಲಾಯಿಸಲು ಒಂದು ಅನ್ವಯವನ್ನು ಆರಿಸಿ"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr "ತಂತ್ರಾಂಶ CD ಗಳಿಗಾಗಿ ಒಂದು ಅನ್ವಯವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr "audio DVD"
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr "ಖಾಲಿ ಬ್ಲೂ-ರೇ ಡಿಸ್ಕ್"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr "ಖಾಲಿ CD ಡಿಸ್ಕ್"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr "ಖಾಲಿ DVD ಡಿಸ್ಕ್"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr "ಖಾಲಿ HD DVD ಡಿಸ್ಕ್"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr "ಬ್ಲೂ-ರೇ ವೀಡಿಯೊ ಡಿಸ್ಕ್"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr "ಇ-ಪುಸ್ತಕ ಓದುಗ"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr "HD DVD ವಿಡಿಯೋ ಡಿಸ್ಕ್ "
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr "ಚಿತ್ರ CD"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr "ಸೂಪರ ವೀಡಿಯೊ CD"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr "ವೀಡಿಯೊ CD"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr "ಕಿಟಕಿ ಅಂಚು"
+
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1932
+msgid "Section"
+msgstr "ವಿಭಾಗ"
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "ಅವಲೋಕನ"
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಅನ್ವಯಗಳು"
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "ತೆಗೆಯಬಹುದಾದ ಮಾಧ್ಯಮ"
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr "ಆವೃತ್ತಿ %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:46
+msgid "Details"
+msgstr "ವಿವರಗಳು"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "ನಿಮ್ಮ ವ್ಯವಸ್ಥೆಯ ಬಗೆಗಿನ ಮಾಹಿತಿಯನ್ನು ನೋಡಿ"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ಸಾಧನ;ವ್ಯವಸ್ಥೆ;ಮಾಹಿತಿ;ಮೆಮೊರಿ;ಸಂಸ್ಕಾರಕ;ಆವೃತ್ತಿ;ಪೂರ್ವನಿಯೋಜಿತ;ಅನ್ವಯ;ಇಚ್ಛೆಯ;cd;dvd;"
+"usb;"
+"ಆಡಿಯೊ;ವೀಡಿಯೊ;ಡಿಸ್ಕ್‍;ತೆಗೆಯಬಹುದಾದ;ಮಾಧ್ಯಮ;ಸ್ವಯಂಚಾಲನೆ;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "ಬೇರೆ ಮಾಧ್ಯಮವನ್ನು ಹೇಗೆ ನಿಭಾಯಿಸಬೇಕೆಂದು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "ಕ್ರಿಯೆ (_A):"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "ಬಗೆ (_T):"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "ಸಾಧನದ ಹೆಸರು"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "ಮೆಮೊರಿ"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "ಸಂಸ್ಕಾರಕ"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "ಮೂಲ ವ್ಯವಸ್ಥೆ"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "ಡಿಸ್ಕ್‍"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "ಲೆಕ್ಕಹಾಕಲಾಗುತ್ತಿದೆ..."
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "ಗ್ರಾಫಿಕ್ಸ್‍"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "ವರ್ಚುವಲೈಸೇಶನ್"
+
+#: ../panels/info/info.ui.h:13
+msgid "Check for updates"
+msgstr "ಅಪ್‌ಡೇಟ್‌ಗಳಿಗಾಗಿ ಪರೀಕ್ಷಿಸು"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "ಜಾಲ (_W)"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "ಮೈಲ್ (_M)"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "ಕ್ಯಾಲೆಂಡರ್ (_C)"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "ಸಂಗೀತ (_u)"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "ವೀಡಿಯೊ (_V)"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "ಫೋಟೊಗಳು (_P)"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "ಮಾಧ್ಯಮವನ್ನು ಹೇಗೆ ನಿಭಾಯಿಸಬೇಕೆಂದು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "CD ಆಡಿಯೊ  (_a)"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "_DVD ವೀಡಿಯೊ"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "ಸಂಗೀತ ಚಾಲಕ (_M)"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "ತಂತ್ರಾಂಶ (_S)"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "ಇತರೆ ಮಾಧ್ಯಮ (_O)…"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr "ಮಾಧ್ಯಮವನ್ನು ತೂರಿಸಿದಾಗ ಕೇಳಬೇಡ ಅಥವ ಪ್ರೊಗ್ರಾಮ್ ಅನ್ನು ಆರಂಭಿಸಬೇಡ (_N)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "ಧ್ವನಿ ಹಾಗು ಮಾಧ್ಯಮ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "ಧ್ವನಿ ಮೂಕ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "ಧ್ವನಿ ಕಡಿಮೆ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "ಧ್ವನಿ ಹೆಚ್ಚು"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "ಮೀಡಿಯಾ ಪ್ಲೇಯರ್ ಅನ್ನು ಆರಂಭಿಸು"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "ಚಲಾಯಿಸು (ಅಥವ ಚಲಾಯಿಸು/ವಿರಮಿಸು)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "ಪ್ಲೇಬ್ಯಾಕ್‌ ಅನ್ನು ವಿರಮಿಸು"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "ಪ್ಲೇಬ್ಯಾಕ್‌ ಅನ್ನು ನಿಲ್ಲಿಸು"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "ಹಿಂದಿನ ಹಾಡು"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "ಮುಂದಿನ ಹಾಡು"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "ಹೊರತಳ್ಳು"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "ಟೈಪಿಂಗ್"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "ಮುಂದಿನ ಇನ್‌ಪುಟ್ ಆಕರವನ್ನು ಬದಲಿಸು"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "ಹಿಂದಿನ ಇನ್‌ಪುಟ್ ಆಕರವನ್ನು ಬದಲಿಸು"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "ಆರಂಭಕಗಳು"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "ನೆರವಿನ ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸಿ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1604
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "ಸಿದ್ಧತೆಗಳು"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "ಕ್ಯಾಲ್ಕುಲೇಟರ್ ಅನ್ನು ಆರಂಭಿಸಿ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "ಇಮೈಲ್ ಕ್ಲೈಂಟ್ ಅನ್ನು ಆರಂಭಿಸಿ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "ಜಾಲ ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸಿ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "ನೆಲೆ ಕಡತಕೋಶ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ಹುಡುಕು"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "ತೆರೆಚಿತ್ರಗಳು"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "ಒಂದು ತೆರೆಚಿತ್ರವನ್ನು $PICTURES ಎಂಬಲ್ಲಿ ಉಳಿಸು"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "ಕಿಟಕಿಯ ತೆರೆಚಿತ್ರವನ್ನು  $PICTURES ಎಂಬಲ್ಲಿ ಉಳಿಸು"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "ಒಂದು ಸ್ಥಳದ ತೆರೆಚಿತ್ರವನ್ನು $PICTURES ಎಂಬಲ್ಲಿ ಉಳಿಸು"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "ತೆರೆಚಿತ್ರವನ್ನು ಕ್ಲಿಪ್‌ಬೋರ್ಡಿಗೆ ಪ್ರತಿ ಮಾಡು"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "ಕಿಟಕಿಯ ತೆರೆಚಿತ್ರವನ್ನು ಕ್ಲಿಪ್‌ಬೋರ್ಡಿಗೆ ಪ್ರತಿ ಮಾಡು"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "ಒಂದು ಜಾಗದ ತೆರೆಚಿತ್ರವನ್ನು ಕ್ಲಿಪ್‌ಬೋರ್ಡಿಗೆ ಪ್ರತಿ ಮಾಡು"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "ಒಂದು ಸಣ್ಣ ಸ್ಕ್ರೀನ್‌ಕ್ಯಾಸ್ಟ್‌ ಅನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡು"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "ವ್ಯವಸ್ಥೆ"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "ಹೊರಗೆ ನಡೆ"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "ತೆರೆಯನ್ನು ಲಾಕ್ ಮಾಡಿ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "ಜಾಗತಿಕ ನಿಲುಕಣೆ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "ಹಿಗ್ಗಿಸುವಿಕೆಯನ್ನು ಆನ್ ಅಥವ ಆಫ್ ಮಾಡು"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "ಹಿಗ್ಗಿಸು"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "ಕುಗ್ಗಿಸು"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "ತೆರೆಓದುಗನನ್ನು ಆನ್ ಅಥವ ಆಫ್ ಮಾಡಿ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "ತೆರೆ ಕೀಲಿಮಣೆಯನ್ನು ಆನ್ ಅಥವ ಆಫ್ ಮಾಡಿ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "ಪಠ್ಯದ ಗಾತ್ರವನ್ನು ಹೆಚ್ಚಿಸು"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "ಪಠ್ಯದ ಗಾತ್ರವನ್ನು ಕುಗ್ಗಿಸು"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "ಅತ್ಯಂತ ವೈದೃಶ್ಯ ಆನ್ ಅಥವ ಆಫ್"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1218
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+msgid "Disabled"
+msgstr "ಅಶಕ್ತಗೊಂಡ"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "ಪರ್ಯಾಯ ಅಕ್ಷರಗಳ ಕೀಲಿ"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "ಕಂಪೋಸ್ ಕೀಲಿ"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "ಮಾರ್ಪಡಕ-ಕೇವಲ ಮುಂದಿನ ಆಕರಕ್ಕೆ ಬದಲಾಯಿಸು"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "ಕೀಲಿಮಣೆ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"ಕೀಲಿಮಣೆ ಸುಲಭಆಯ್ಕೆಗಳನ್ನು ನೋಡು ಹಾಗೂ ಬದಲಾಯಿಸು ಮತ್ತು ನಿಮ್ಮ ಟೈಪಿಂಗ್ ಆದ್ಯತೆಗಳನ್ನು "
+"ಹೊಂದಿಸು"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "ಶಾರ್ಟ್-ಕಟ್;ಪುನರಾವರ್ತನೆ;ಮಿಟುಕಿಸು;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "ಇಚ್ಛೆಯ ಶಾರ್ಟ್-ಕಟ್"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "ಹೆಸರು (_N):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "ಆಜ್ಞೆ (_o):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "ಪುನರಾವರ್ತನಾ ಕೀಲಿಗಳು"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "ಕೀಲಿಯನ್ನು ಒತ್ತಿ ಹಿಡಿದಾಗ ಕೀಲಿಗಳ ಒತ್ತುವಿಕೆಯನ್ನು ಪುನರಾವರ್ತಿಸು (_r)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "ವಿಳಂಬ (_D):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "ವೇಗ (_S):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "ಚಿಕ್ಕದಾದ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "ನಿಧಾನ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "ಪುನರಾವರ್ತನೆಯ ಕೀಲಿಗಳ ವೇಗ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "ಉದ್ದವಾದ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "ವೇಗ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "ತೆರೆಸೂಚಕದ ಮಿನುಗುವಿಕೆ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "ತೆರೆಸೂಚಕವು ಪಠ್ಯ ಕ್ಷೇತ್ರಗಳಲ್ಲಿ ಮಿನುಗುತ್ತದೆ (_b)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "ವೇಗ (_p):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "ತೆರೆಸೂಚಕದ ಮಿನುಗುವ ವೇಗ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "ಇನ್‌ಪುಟ್‌ ಆಕರಗಳು"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "ಸುಲಭಆಯ್ಕೆಯನ್ನು ಸೇರಿಸು"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "ಸುಲಭಆಯ್ಕೆಯನ್ನು ತೆಗೆದುಹಾಕು"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"ಒಂದು ಶಾರ್ಟ್-ಕಟ್ ಕೀಲಿಯನ್ನು ಸಂಪಾದಿಸಲು, ಸಾಲಿನಲ್ಲಿ ಕ್ಲಿಕ್ಕಿಸಿ ಹಾಗು ಹೊಸ ಕೀಲಿಗಳನ್ನು "
+"ಒತ್ತಿಹಿಡಿಯಿರಿ ಅಥವ ಅಳಿಸಲು ಬ್ಯಾಕ್‍ಸ್ಪೇಸನ್ನು ಒತ್ತಿ."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "ಶಾರ್ಟ್-ಕಟ್‌ಗಳು"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:635
+#: ../panels/keyboard/keyboard-shortcuts.c:643
+msgid "Custom Shortcuts"
+msgstr "ಇಚ್ಛೆಯ ಶಾರ್ಟ್-ಕಟ್‌ಗಳು"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:860
+msgid "<Unknown Action>"
+msgstr "<ಗೊತ್ತಿರದ ಕ್ರಿಯೆ>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1357
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"ಶಾರ್ಟ್-ಕಟ್ \"%s\" ಅನ್ನು ಬಳಸಲಾಗುವುದಿಲ್ಲ ಏಕೆಂದರೆ ಈ ಕೀಲಿಯನ್ನು ಬಳಸಿಕೊಂಡು ಇದನ್ನು "
+"ಟೈಪ್ "
+"ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ.\n"
+"ದಯವಿಟ್ಟು ಒಂದೆ ಸಮಯದಲ್ಲಿ Control, Alt ಅಥವ Shift ನಂತಹ ಕೀಲಿಯನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1387
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"\"%s\" ಶಾರ್ಟ್-ಕಟ್ ಅನ್ನು ಇದಕ್ಕಾಗಿ ಈಗಾಗಲೆ ಬಳಸಲಾಗಿದೆ\n"
+"\"%s\""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1392
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"ಶಾರ್ಟ್-ಕಟ್‌ ಅನ್ನು \"%s\" ಗೆ ನಿಯೋಜಿಸಿದಲ್ಲಿ, \"%s\" ಶಾರ್ಟ್-ಕಟ್‌ "
+"ಅಶಕ್ತಗೊಳ್ಳುತ್ತದೆ."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1398
+msgid "_Reassign"
+msgstr "ಮರಳಿ ನಿಯೋಜಿಸು (_R)"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1439
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"\"%s\" ಸಮೀಪಮಾರ್ಗವು ಒಂದು ಸಂಬಂಧಿಸಿದ \"%s\" ಸಮೀಪಮಾರ್ಗವನ್ನು ಹೊಂದಿದೆ. ನೀವು ಇದನ್ನು "
+"\"%s"
+"\" ಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊಂದಿಸಲು ಬಯಸುವಿರಾ?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1449
+#, c-format
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"\"%s\" ಎನ್ನುವುದು ಪ್ರಸಕ್ತ \"%s\" ಎನ್ನುವುದಕ್ಕೆ ಸಂಬಂಧಿಸಿದೆ, ನೀವು ಮುಂದಕ್ಕೆ "
+"ಹೋದಲ್ಲಿ ಈ "
+"ಸಮೀಪಮಾರ್ಗವನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗುತ್ತದೆ."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1456
+msgid "_Assign"
+msgstr "ನಿಯೋಜಿಸು (_A)"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "ನಿಮ್ಮ ಸಿದ್ಧತೆಗಳನ್ನು ಪರೀಕ್ಷಿಸಿ (_S)"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+msgid "Test Your Settings"
+msgstr "ನಿಮ್ಮ ಸಿದ್ಧತೆಗಳನ್ನು ಪರೀಕ್ಷಿಸಿ"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "ಮೌಸ್‌ ಹಾಗು ಟಚ್‌ಪ್ಯಾಡ್"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"ನಿಮ್ಮ ಮೌಸ್‌ ಅಥವ ಟಚ್‌ಪ್ಯಾಡ್ ಸಂವೇದಶೀಲನೆ  ಅನ್ನು ಬದಲಾಯಿಸಿ ಮತ್ತು ಬಲ ಅಥವ ಎಡ-ಕೈ "
+"ಅನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ಟ್ರ್ಯಾಕ್‌ಪ್ಯಾಡ್;ಸೂಚಕ;ಕ್ಲಿಕ್;ಟ್ಯಾಪ್;ಜೋಡಿ;ಗುಂಡಿ;ಟ್ರ್ಯಾಕ್‌ಬಾಲ್;ಸ್ಕ್ರಾಲ್;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "ಸಾಮಾನ್ಯ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "ನಿಧಾನ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "ಎರಡು-ಬಾರಿ ಕ್ಲಿಕ್ಕಿಸುವ ಕಾಲಾವಧಿ ಮೀರಿಕೆ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "ವೇಗ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "ಜೋಡಿ ಕ್ಲಿಕ್ (_D)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "ಪ್ರಾಥಮಿಕ ಗುಂಡಿ (_b)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "ಎಡ (_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "ಬಲ (_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "ಮೌಸ್"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "ಸೂಚಕದ ವೇಗ (_P)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "ನಿಧಾನ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "ವೇಗ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "ಟಚ್‌ಪ್ಯಾಡ್"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "ನಿಧಾನ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "ವೇಗ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr "ಟೈಪಿಸುವಾಗ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸು (_t)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr "ಕ್ಲಿಕ್ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ (_c)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr "ಎರಡು ಬೆರಳಿನ ಚಲನೆ (_f)"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "_Natural scrolling"
+msgstr "ಸಾಮಾನ್ಯವೇಗದ ಸ್ಕ್ರಾಲಿಂಗ್ (_N)"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ಕ್ಲಿಕ್ ಮಾಡಲು, ಎರಡುಬಾರಿ ಕ್ಲಿಕ್ ಮಾಡಲು, ಚಲಾಯಿಸಲು ಪ್ರಯತ್ನಿಸಿ"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "ಐದು ಕ್ಲಿಕ್‌ಗಳು, GEGL ಸಮಯ!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "ಎರಡು-ಬಾರಿಯ ಕ್ಲಿಕ್, ಪ್ರಾಥಮಿಕ ಗುಂಡಿ"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "ಒಂದೇ ಕ್ಲಿಕ್, ಪ್ರಾಥಮಿಕ ಗುಂಡಿ"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "ಎರಡು-ಬಾರಿಯ ಕ್ಲಿಕ್, ಮಧ್ಯದ ಗುಂಡಿ"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "ಒಂದೇ ಕ್ಲಿಕ್, ಪ್ರಾಥಮಿಕ ಗುಂಡಿ"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "ಎರಡು-ಬಾರಿಯ ಕ್ಲಿಕ್, ಎರಡನೆಯ ಗುಂಡಿ"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "ಒಂದೇ ಕ್ಲಿಕ್, ಎರಡನೆಯ ಗುಂಡಿ"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:369
+msgid "Air_plane Mode"
+msgstr "ವಿಮಾನದ ಸ್ಥಿತಿ (_p)"
+
+#: ../panels/network/cc-network-panel.c:977
+msgid "Network proxy"
+msgstr "ಜಾಲಬಂಧ ಪ್ರಾಕ್ಸಿ"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1156 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1301
+msgid "The system network services are not compatible with this version."
+msgstr "ವ್ಯವಸ್ಥೆಯ ಜಾಲಬಂಧ ಸೇವೆಗಳು ಈ ಆವೃತ್ತಿಯೊಂದಿಗೆ ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ."
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x ಸುರಕ್ಷತೆ (_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "ಪುಟ 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "ಅಜ್ಞಾತ ಗುರುತು (_m)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "ಆಂತರಿಕ ದೃಢೀಕರಣ (_U)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "ಪುಟ 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "ಸುರಕ್ಷತೆ"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "ಸ್ವಯಂಚಾಲಿತ"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:218
+#: ../panels/network/net-device-wifi.c:382
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:222
+#: ../panels/network/net-device-wifi.c:387
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:226
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:231
+msgid "Enterprise"
+msgstr "ಎಂಟರ್ಪ್ರೈಸ್"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:236
+#: ../panels/network/net-device-wifi.c:372
+msgctxt "Wifi security"
+msgid "None"
+msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "ಎಂದೂ ಬೇಡ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:815
+msgid "Today"
+msgstr "ಇಂದು"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:818
+msgid "Yesterday"
+msgstr "ನಿನ್ನೆ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:476
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i ದಿನದ ಹಿಂದೆ"
+msgstr[1] "%i ದಿನಗಳ ಹಿಂದೆ"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:533
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "None"
+msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "ದುರ್ಬಲ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ಸರಿ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:568
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "ಉತ್ತಮ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:570
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "ಅತ್ಯುತ್ತಮ"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "ಗುರುತು"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "ವಿಳಾಸ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "ನೆಟ್‌ಮಾಸ್ಕ್‍"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "ಗೇಟ್‌ವೇ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "ವಿಳಾಸವನ್ನು ಅಳಿಸು"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "ಸೇರಿಸು"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "ಪೂರೈಕೆಗಣಕ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "DNS ಸಾಧನವನ್ನು ಅಳಿಸು"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "ಮೆಟ್ರಿಕ್"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "ರೌಟ್ ಅನ್ನು ಅಳಿಸು"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "ಸ್ವಯಂಚಾಲಿತ (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Manual"
+msgstr "ಕೈಯಾರೆ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "ಸ್ಥಳೀಯ-ಕೊಂಡಿ ಮಾತ್ರ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "ಪ್ರಿಫಿಕ್ಸ್‍"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "ಸ್ವಯಂಚಾಲಿತ"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "ಸ್ವಯಂಚಾಲಿತ, DHCP ಮಾತ್ರ"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:51
+msgid "Reset"
+msgstr "ಮರುಹೊಂದಿಸು"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-ಬಿಟ್ ಕೀಲಿ (ಹೆಕ್ಸ್‍ ಅಥವ ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-ಬಿಟ್‌ ಗುಪ್ತವಾಕ್ಯಾಂಶ"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "ಡೈನಮಿಕ್ WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 ಪರ್ಸನಲ್"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 ಎಂಟರ್ಪ್ರೈಸ್"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr "ಸಿಗ್ನಲ್‌ನ ಸಾಮರ್ಥ್ಯ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "ಕೊಂಡಿಯ ವೇಗ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:157
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 ವಿಳಾಸ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:158
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 ವಿಳಾಸ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:165
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "ಯಂತ್ರಾಂಶ ವಿಳಾಸ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:169
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ ರೌಟ್"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "ಕೊನೆಯ ಬಾರಿಗೆ ಬಳಸಿದ್ದು"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "ಟ್ವಿಸ್ಟೆಡ್ ಪೇರ್ (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "ಅಟ್ಯಾಚ್‌ಮೆಂಟ್ ಯುನಿಟ್ ಇಂಟರ್ಫೇಸ್ (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "ಮೀಡಿಯಾ ಇಂಡಿಪೆಂಡೆಂಟ್ ಇಂಟರ್ಫೇಸ್ (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "ಹೆಸರು (_N)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "_MAC ವಿಳಾಸ"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "ತದ್ರೂಪುಗೊಳಿಸಿದ ವಿಳಾಸ (_C)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "ಬೈಟ್‌ಗಳು"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "ಇತರೆ ಬಳಕೆದಾರರಿಗೆ ಲಭ್ಯವಾಗುವಂತೆ ಮಾಡು (_u)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಂಪರ್ಕಸಾಧಿಸು (_a)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "ಫೈರ್ವಾಲ್ ವಲಯ (_Z)"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "ವಲಯವು ಸಂಪರ್ಕದ ನಂಬಿಕೆಯ ಮಟ್ಟವನ್ನು ವಿವರಿಸುತ್ತದೆ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "ವಿಳಾಸ (_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "ಸ್ವಯಂಚಾಲಿತ DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "ರೌಟ್‌ಗಳು"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ರೌಟ್‌ಗಳು"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr "ಅದರ ಜಾಲಬಂಧದಲ್ಲಿರುವ ಸಂಪನ್ಮೂಲಗಳಿಗಾಗಿ ಮಾತ್ರ ಈ ಸಂಪರ್ಕವನ್ನು ಬಳಸು (_o)"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "ಸಂಪರ್ಕ ಸಂಪಾದಕವನ್ನು ತೆರೆಯಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "ಹೊಸ ಪ್ರೊಫೈಲ್"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "ಬಾಂಡ್"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "ಟೀಮ್"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "ಬ್ರಿಜ್"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "VPN ಪ್ಲಗ್‌ಇನ್‌ಗಳನ್ನು ಲೋಡ್‌ ಮಾಡಲಾಗಲಿಲ್ಲ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "ಕಡತದಿಂದ ಆಮದು ಮಾಡು..."
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "ಜಾಲಬಂಧ ಸಂಪರ್ಕವನ್ನು ಸೇರಿಸು"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "ಮರಳಿ ಅಣಿಗೊಳಿಸು (_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1441
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "ಮರೆತುಬಿಡು (_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"ಈ ಜಾಲಬಂಧಕ್ಕಾಗಿನ ಗುಪ್ತಪದಗಳನ್ನೂ ಸೇರಿದಂತೆ ಸಿದ್ಧತೆಗಳನ್ನು ಮರುಹೊಂದಿಸು, ಆದರೆ ಇದನ್ನು "
+"ಆದ್ಯತೆಯ ಜಾಲಬಂಧ ಎಂದು ನೆನಪಿಟ್ಟುಕೊ"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"ಈ ಜಾಲಬಂಧಕ್ಕೆ ಸಂಬಂಧಿಸದ ಎಲ್ಲಾ ವಿವರಗಳನ್ನು ತೆಗೆದುಹಾಕು ಮತ್ತು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಂಪರ್ಕ "
+"ಸಾಧಿಸಲು ಪ್ರಯತ್ನಿಸಬೇಡ"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "ಸುರಕ್ಷತೆ (_e)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "VPN ಸಂಪರ್ಕವನ್ನು ಆಮದು ಮಾಡಲಾಗಿಲ್ಲ"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"'%s' ಕಡತವನ್ನು ಓದಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ ಅಥವ ಗುರುತಿಸಲಾದ VPN ಸಂಪರ್ಕ ಮಾಹಿತಿಯನ್ನು "
+"ಹೊಂದಿಲ್ಲ\n"
+"\n"
+"ದೋಷ: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "ಆಮದು ಮಾಡಲು ಕಡತವನ್ನು ಆರಿಸಿ"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1946
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "_Open"
+msgstr "ತೆರೆ (_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "\"%s\" ಎಂಬ ಹೆಸರಿನ ಕಡತವು ಈಗಾಗಲೆ ಅಸ್ತಿತ್ವದಲ್ಲಿದೆ."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "ಬದಲಾಯಿಸು (_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "%s ಅನ್ನು ನೀವು ಉಳಿಸುತ್ತಿರುವ VPN ಸಂಪರ್ಕದಿಂದ ಬದಲಾಯಿಸಲು ಬಯಸುವಿರಾ?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "VPN ಸಂಪರ್ಕವನ್ನು ರಫ್ತು ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"'%s' VPN ಸಂಪರ್ಕವನ್ನು %s ಎಂಬಲ್ಲಿಗೆ ರಫ್ತು ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ.\n"
+"\n"
+"ದೋಷ: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+msgid "Export VPN connection"
+msgstr "VPN ಸಂಪರ್ಕವನ್ನು ರಫ್ತುಮಾಡು"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ದೋಷ: VPN ಸಂಪರ್ಕ ಸಂಪಾದಕವನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "ನನ್ನ ನೆಲೆ ಜಾಲಬಂಧ"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "ಇತರೆ ಬಳಕೆದಾರರಿಗೆ ಲಭ್ಯವಾಗುವಂತೆ ಮಾಡು (_o)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "ಜಾಲಬಂಧ"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "ಅಂತರಜಾಲದೊಂದಿಗೆ ನೀವು ಹೇಗೆ ಸಂಪರ್ಕಗೊಳ್ಳುತ್ತೀರಿ ಎನ್ನುವುದನ್ನು ನಿಯಂತ್ರಿಸಿ"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"ಜಾಲಬಂಧ;ವೈರ್ಲೆಸ್;ವೈ-ಫೈ;ವೈಫೈ;IP;LAN;ಪ್ರಾಕ್ಸಿ;WAN;ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್;ಮಾಡೆಮ್;ಬ್ಲೂಟೂತ್;"
+"vpn;vlan;"
+"ಬ್ರಿಜ್;ಬಾಂಡ್;DNS;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "ಬಾಂಡ್‌ ಸ್ಲೇವ್‌ಗಳು"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(ಯಾವುದೂ ಇಲ್ಲ)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "ಬ್ರಿಜ್‌ ಸ್ಲೇವ್‌ಗಳು"
+
+#: ../panels/network/net-device-ethernet.c:110
+#: ../panels/network/net-device-wifi.c:462
+msgid "never"
+msgstr "ಎಂದಿಗೂ ಬೇಡ"
+
+#: ../panels/network/net-device-ethernet.c:120
+#: ../panels/network/net-device-wifi.c:472
+msgid "today"
+msgstr "ಇಂದು"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:474
+msgid "yesterday"
+msgstr "ನಿನ್ನೆ"
+
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP ವಿಳಾಸ"
+
+#: ../panels/network/net-device-ethernet.c:176
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "ಕೊನೆಯ ಬಾರಿಗೆ ಬಳಸಿದ್ದು"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:286
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "ತಂತಿಯುಕ್ತ"
+
+#: ../panels/network/net-device-ethernet.c:354
+#: ../panels/network/net-device-wifi.c:1596
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "ಆಯ್ಕೆಗಳು…"
+
+#: ../panels/network/net-device-ethernet.c:472
+#, c-format
+msgid "Profile %d"
+msgstr "ಪ್ರೊಫೈಲ್ %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "ಹೊಸ ಸಂಪರ್ಕವನ್ನು ಸೇರಿಸು"
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr "ಟೀಮ್‌ ಸ್ಲೇವ್‌ಗಳು"
+
+#: ../panels/network/net-device-wifi.c:1154
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"ನೀವು ವೈರ್ಲೆಸ್ ಅನ್ನು ಹೊರತುಪಡಿಸಿ ಬೇರೇ ರೀತಿಯ ಅಂತರಜಾಲ ಸಂಪರ್ಕವನ್ನು ಹೊಂದಿದ್ದಲ್ಲಿ, "
+"ನಿಮ್ಮ "
+"ಅಂತರಜಾಲ ಸಂಪರ್ಕವನ್ನು ಇತರರೊಂದಿಗೆ ಹಂಚಿಕೊಳ್ಳಲು ನೀವು ಒಂದು ವೈರ್ಲೆಸ್ ಬಹುದಾಗಿರುತ್ತದೆ."
+
+#: ../panels/network/net-device-wifi.c:1158
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+"ವೈರ್ಲೆಸ್ ಹಾಟ್‌ಸ್ಪಾಟ್‌ಗೆ ಬದಲಾಯಿಸಿದಲ್ಲಿ <b>%s</b> ದೊಂದಿಗಿನ ನಿಮ್ಮ ಸಂಪರ್ಕವು "
+"ಕಡಿದುಹೋಗುತ್ತದೆ."
+
+#: ../panels/network/net-device-wifi.c:1162
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"ಹಾಟ್‌ಸ್ಪಾಟ್ ಸಕ್ರಿಯವಾಗಿದ್ದಾಗ ನಿಮ್ಮ ವೈರ್ಲೆಸ್‌ ಮುಖಾಂತರ ಅಂತರಜಾಲದೊಂದಿಗೆ ಸಂಪರ್ಕ "
+"ಜೋಡಿಸುವುದು "
+"ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ."
+
+#: ../panels/network/net-device-wifi.c:1245
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+"ಹಾಟ್‌ಸ್ಪಾಟ್‌ ಅನ್ನು ನಿಲ್ಲಿಸಲು ಮತ್ತು ಅದರ ಯಾವುದೆ ಬಳಕೆದಾರರನ್ನು ಸಂಪರ್ಕ ತಪ್ಪಿಸಬೇಕೆ?"
+
+#: ../panels/network/net-device-wifi.c:1248
+msgid "_Stop Hotspot"
+msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್ ಅನ್ನು ನಿಲ್ಲಿಸು (_S):"
+
+#: ../panels/network/net-device-wifi.c:1305
+msgid "System policy prohibits use as a Hotspot"
+msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್ ಆಗಿ ಬಳಸುವುದಂತೆ ವ್ಯವಸ್ಥೆಯ ಪಾಲಿಯು ತಡೆಯುತ್ತಿದೆ"
+
+#: ../panels/network/net-device-wifi.c:1308
+msgid "Wireless device does not support Hotspot mode"
+msgstr "ವೈರ್ಲೆಸ್ ಸಾಧನವು ಹಾಟ್‌ಸ್ಪಾಟ್ ಕ್ರಮವನ್ನು ಬೆಂಬಲಿಸುವುದಿಲ್ಲ"
+
+#: ../panels/network/net-device-wifi.c:1437
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"ಗುಪ್ತಪದಗಳು ಮತ್ತು ಯಾವುದೆ ಅಗತ್ಯಾನುಗುಣ ಸಂರಚನೆಯೂ ಸಹ ಸೇರಿದಂತೆ  ಆಯ್ಕೆ ಮಾಡಲಾದ "
+"ಜಾಲಬಂಧಗಳಿಗಾಗಿ ಜಾಲಬಂಧ ವಿವರಗಳು ನಾಶಗೊಳ್ಳುತ್ತವೆ."
+
+#: ../panels/network/net-device-wifi.c:1745
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "ಇತಿಹಾಸ"
+
+#: ../panels/network/net-device-wifi.c:1749
+#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
+#: ../panels/wacom/cc-wacom-page.c:533
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Close"
+msgstr "ಮುಚ್ಚು (_C)"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1757
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "ಮರೆತುಬಿಡು (_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"ಸಂರಚನಾ URL ಅನ್ನು ಒದಗಿಸದೇ ಇದ್ದಲ್ಲಿ ವೆಬ್ ಪ್ರಾಕ್ಸಿ ಆಟೋಡಿಸ್ಕವರಿಯನ್ನು ಬಳಸಲಾಗುತ್ತದೆ."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "ಇದನ್ನು ನಂಬಿಕೆಗೆ ಅನರ್ಹವಾದ ಸಾರ್ವಜನಿಕ ಜಾಲಬಂಧಗಳಲ್ಲಿ ಇದು ಒಳ್ಳೆಯದಲ್ಲ"
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "ಪ್ರಾಕ್ಸಿ"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "ಪ್ರೊಫೈಲನ್ನು ಸೇರಿಸು (_A)..."
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "ಒದಗಿಸುವವರು"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "ಕೈಯಾರೆ"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "ಸ್ವಯಂಚಾಲಿತ"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "ವಿಧಾನ (_M)"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "ಸ್ವಯಂಸಂರಚನಾ URL (_C)"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "_HTTP ಪ್ರಾಕ್ಸಿ"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS ಪ್ರಾಕ್ಸಿ"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "_FTP ಪ್ರಾಕ್ಸಿ"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "ಸಾಕ್ಸ್‌ ಅತಿಥೇಯ (_S):"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "ಕಡೆಗಣಿಸಲಾದ ಆತಿಥೇಯಗಳು (_I)"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "HTTP ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "HTTPS ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "FTP ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "Socks ಪ್ರಾಕ್ಸಿ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "ಸಾಧನವನ್ನು ಆಫ್‌ ಮಾಡು"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "ಸಾಧನವನ್ನು ಸೇರಿಸು"
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕು"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN ಬಗೆ"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "ಗುಂಪಿನ ಹೆಸರು"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "ಗುಂಪನ ಗುಪ್ತಪದ"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "ಬಳಕೆದಾರಹೆಸರು"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "VPN ಸಂಪರ್ಕವನ್ನು ಆಫ್ ಮಾಡು"
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ಸಂಪರ್ಕ (_C)"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "ವಿವರಗಳು"
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "ದಾಟುಪದ (_P)"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "ಗುಪ್ತಪದವನ್ನು ತೋರಿಸು (_a)"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr "ಇತರೆ ಬಳಕೆದಾರರಿಗೆ ಲಭ್ಯವಾಗುವಂತೆ ಮಾಡು"
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "ಗುರುತು"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr "ಸ್ವಯಂಚಾಲಿತ (DHCP) ವಿಳಾಸಗಳು ಮಾತ್ರ"
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr "ಸ್ಥಳೀಯ-ಕೊಂಡಿ ಮಾತ್ರ"
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr "ಇತರೆ ಗಣಕಗಳೊಡನೆ ಹಂಚಿಕೊಳ್ಳಲಾದ"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr "ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪಡೆಯಲಾದ ರೌಟ್‌ಗಳನ್ನು ಕಡೆಗಣಿಸು (_I)"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr "ತದ್ರೂಪುಗೊಳಿಸಲಾದ MA_C ವಿಳಾಸ"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr "ಯಂತ್ರಾಂಶ"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"ಈ ಸಂಪರ್ಕಕ್ಕಾಗಿನ ಸಿದ್ಧತೆಗಳನ್ನು ಅವುಗಳ ಪೂರ್ವನಿಯೋಜಿತಕ್ಕೆ ಮರುಹೊಂದಿಸು, ಆದರೆ ಆದ್ಯತೆಯ "
+"ಸಂಪರ್ಕ "
+"ಎಂದು ನೆನಪಿಡು."
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"ಈ ಜಾಲಬಂಧಕ್ಕೆ ಸಂಬಂಧಿಸಿದ ಎಲ್ಲಾ ವಿವರಗಳನ್ನು ತೆಗೆದುಹಾಕು ಮತ್ತು ಸ್ವಯಂಚಾಲಿತವಾಗಿ "
+"ಸಂಪರ್ಕ "
+"ಸಾಧಿಸಲು ಪ್ರಯತ್ನಿಸಬೇಡ."
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "ಮರುಹೊಂದಿಸು"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "ಯಂತ್ರಾಂಶ"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr "ವೈ-ಫೈ ಹಾಟ್‌ಸ್ಪಾಟ್"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Turn On"
+msgstr "ಚಾಲನೆಗೊಳಿಸು (_T)"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Wi-Fi"
+msgstr "ವೈ-ಫೈ"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Turn Wi-Fi off"
+msgstr "ವೈ-ಫೈ ಅನ್ನು ಆಫ್ ಮಾಡಿ"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_Use as Hotspot…"
+msgstr "ಹಾಟ್‌ಸ್ಪಾಟ್ ಅನ್ನು ಬಳಸು (_U)..."
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "_Connect to Hidden Network…"
+msgstr "ಅಡಗಿಸಲಾದ ಜಾಲಬಂಧದೊಂದಿಗೆ ಸಂಪರ್ಕಸಾಧಿಸು (_C)..."
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "_History"
+msgstr "ಇತಿಹಾಸ (_H)"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "ವೈ-ಫೈ ಜಾಲಬಂಧದೊಂದಿಗೆ ಸಂಪರ್ಕ ಹೊಂದಲು ಸ್ವಿಚ್ ಅನ್ನು ಆಫ್ ಮಾಡು"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Network Name"
+msgstr "ಜಾಲಬಂಧ ಹೆಸರು"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Connected Devices"
+msgstr "ಸಂಪರ್ಕಗೊಂಡಿರುವ ಸಾಧನ"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "Security type"
+msgstr "ಸುರಕ್ಷತೆಯ ಬಗೆ"
+
+#: ../panels/network/network-wifi.ui.h:63
+msgid "Security key"
+msgstr "ಸುರಕ್ಷತೆಯ ಕೀಲಿ"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "ತಾತ್ಕಾಲಿಕ"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "ಮೂಲಭೂತ ವ್ಯವಸ್ಥೆ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "ಗೊತ್ತಿರದ ಸ್ಥಿತಿ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "ನಿರ್ವಹಿಸದೆ ಇರುವ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "ಲಭ್ಯವಿಲ್ಲ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "ಸಂಪರ್ಕ ಕಲ್ಪಿಸಲಾಗುತ್ತಿದೆ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "ಸಂಪರ್ಕಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "ಸಂಪರ್ಕ ಕಡಿದುಹಾಕಲಾಗುತ್ತಿದೆ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "ಸಂಪರ್ಕವು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "ಗೊತ್ತಿರದ ಸ್ಥಿತಿ (ಕಾಣೆಯಾಗಿದೆ)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "ಸಂಪರ್ಕಗೊಂಡಿಲ್ಲ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "ಸಂರಚನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "IP ಸಂರಚನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "IP ಸಂರಚನೆಯ ವಾಯಿದೆ ತೀರಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "ರಹಸ್ಯಗಳ ಅಗತ್ಯವಿದೆ, ಆದರೆ ಅದನ್ನು ಒದಗಿಸಲಾಗಿಲ್ಲ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x ಸಪ್ಲಿಕ್ಯಾಂಟ್‌ನಿಂದ ಸಂಪರ್ಕ ಕಡಿದಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x ಸಪ್ಲಿಕೆಂಟ್ ಸಂರಚನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1x ಸಪ್ಲಿಕೆಂಟ್ ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x ಸಪ್ಲಿಕೆಂಟ್ ದೃಢೀಕರಿಸಲು ಬಹಳ ಹೊತ್ತು ತೆಗೆದುಕೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "PPP ಸೇವೆಯನ್ನು ಆರಂಭಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "PPP ಸಂಪರ್ಕವನ್ನು ಕಡಿದು ಹಾಕಲಾಗಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "DHCP ಕ್ಲೈಂಟ್ ಆರಂಭಗೊಳ್ಳಲು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP ಕ್ಲೈಂಟ್‌ ದೋಷ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP ಕ್ಲೈಂಟ್ ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "ಹಂಚಲಾದ ಸಂಪರ್ಕ ಸೇವೆಯು ಆರಂಭಗೊಳ್ಳುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "ಹಂಚಲಾದ ಸಂಪರ್ಕ ಸೇವೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "AutoIP ಸೇವೆಯು ಆರಂಭಗೊಳ್ಳುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "AutoIP ಸೇವೆಯ ದೋಷ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "AutoIP ಸೇವೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "ಮಾರ್ಗವು ಕಾರ್ಯನಿರತವಾಗಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "ಯಾವುದೆ ಡಯಲ್ ಟೋನ್ ಇಲ್ಲ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "ಯಾವುದೆ ವಾಹಕವನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "ಡಯಲ್ ಮಾಡುವ ಮನವಿಯ ಸಮಯ ಮೀರಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "ಡಯಲ್ ಮಾಡುವ ಪ್ರಯತ್ನವು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "ಮಾಡೆಮ್ ಆರಂಭಗೊಳ್ಳುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "ನಿಶ್ಚಿತ APN ಅನ್ನು ಆರಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "ಜಾಲಬಂಧಗಳಿಗಾಗಿ ಹುಡುಕಲಾಗುತ್ತಿಲ್ಲ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "ಜಾಲಬಂಧ ನೋಂದಣಿಯನ್ನು ನಿರಾಕರಿಸಲಾಗಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "ಜಾಲಬಂಧ ನೋಂದಣಿಯ ಸಮಯ ಮೀರಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "ಮನವಿ ಮಾಡಲಾದ ಜಾಲಬಂಧದೊಂದಿಗೆ ನೋಂದಾಯಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "PIN ಪರಿಶೀಲನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "ಸಾಧನದ ಫರ್ಮವೇರ್ ಕಾಣಿಸುತ್ತಿಲ್ಲ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "ಸಂಪರ್ಕವು ಕಾಣೆಯಾಗಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "ಈಗಿರುವ ಸಂಪರ್ಕವನ್ನು ಊಹಿಸಲಾಗಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "ಮಾಡೆಮ್ ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "ಬ್ಲೂಟೂತ್ ಸಂಪರ್ಕವು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "ಸಿಮ್ ಕಾರ್ಡನ್ನು ಹಾಕಲಾಗಿಲ್ಲ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "ಸಿಮ್‌ ಪಿನ್ ಅಗತ್ಯವಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "ಸಿಮ್‌ Puk ಅಗತ್ಯವಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "ಸಿಮ್‌ ತಪ್ಪಾಗಿದೆ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "ಸಂಪರ್ಕಿತಗೊಂಡ ಕ್ರಮದಲ್ಲಿ InfiniBand ಸಾಧನಕ್ಕೆ ಬೆಂಬಲವಿರುವುದಿಲ್ಲ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "ಸಂಪರ್ಕದ ಅವಲಂಬನೆಯು ವಿಫಲಗೊಂಡಿದೆ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "ಫರ್ಮ್-ವೇರ್ ಕಾಣಿಸುತ್ತಿಲ್ಲ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "ಕೇಬಲ್‌ ಅನ್ನು ತೆಗೆಯಲಾಗಿದೆ"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "ಯಾವುದೆ ಸರ್ಟಿಫಿಕೇಟ್ ಅಥಾರಿಟಿ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆ ಮಾಡಲಾಗಿಲ್ಲ"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"ಸರ್ಟಿಫಿಕೇಟ್ ಅತಾರಿಟಿ (CA) ಪ್ರಮಾಣಪತ್ರವನ್ನು ಬಳಸದೆ ಇದ್ದಲ್ಲಿ ಸಂಪರ್ಕಗಳು ಅಸುರಕ್ಷಿತ, "
+"ದುಷ್ಟ Wi-"
+"Fi ಜಾಲಬಂಧಗಳಾಗಲು ಕಾರಣವಾಗಬಹುದು. ನೀವು ಸರ್ಟಿಫಿಕೇಟ್ ಅತಾರಿಟಿ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆ "
+"ಮಾಡಲು "
+"ಬಯಸುವಿರಾ?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "ಕಡೆಗಣಿಸು"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "CA ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆ ಮಾಡು"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, ಅಥವ PKCS#12 ಖಾಸಗಿ ಕೀಲಿಗಳು (*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER ಅಥವ PEM ಪ್ರಮಾಣಪತ್ರಗಳು (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+msgid "Choose a PAC file"
+msgstr "ಒಂದು PAC ಕಡತವನ್ನು ಆರಿಸು"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC ಕಡತಗಳು (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC ಕಡತಗಳು (_f)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "ಒಳಗಿನ ದೃಢೀಕರಣವನ್ನು (_I)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "PAC ಪ್ರಾವಿಶನಿಂಗ್ (_v)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "ಅನಾಮಧೇಯ"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "ದೃಡೀಕರಿಸಿದ"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "ಎರಡೂ"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "ಬಳಕೆದಾರ ಹೆಸರು (_U)"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "ಗುಪ್ತಪದವನ್ನು ತೋರಿಸು (_w)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate"
+msgstr "ಸರ್ಟಿಫಿಕೇಟ್ ಅಥಾರಿಟಿ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆರಿಸಿ"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "ಆವೃತ್ತಿ 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "ಆವೃತ್ತಿ 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "C_A ಪ್ರಮಾಣಪತ್ರ"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP ಆವೃತ್ತಿ (_v)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "ಪ್ರತಿ ಬಾರಿಯೂ ಸಹ ಈ ಗುಪ್ತಪದಕ್ಕಾಗಿ ಕೇಳು (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "ಗೂಢಲಿಪೀಕರಿಸದ ಖಾಸಗಿ ಕೀಲಿಗಳು ಅಸುರಕ್ಷಿತವಾಗಿರುತ್ತವೆ"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"ಆಯ್ಕೆ ಮಾಡಲಾದ ಖಾಸಗಿ ಕೀಲಿಯು ಒಂದು ಗುಪ್ತಪದದಿಂದ ಸಂರಕ್ಷಿತಗೊಂಡಿರುವಂತೆ ಕಾಣಿಸುತ್ತಿಲ್ಲ. "
+" "
+"ಇದರಿಂದಾಗಿ ನಿಮ್ಮ ಸುರಕ್ಷತಾ ರುಜುವಾತನ್ನು ರಾಜಿ ಮಾಡಿಕೊಂಡಂತಾಗುತ್ತದೆ.  ದಯವಿಟ್ಟು ಒಂದು "
+"ಗುಪ್ತಪದದಿಂದ ಸಂರಿಕ್ಷಿತಗೊಂಡಂತಹ ಖಾಸಗಿ ಕೀಲಿಯನ್ನು ಒದಗಿಸಿ.\n"
+"\n"
+"(ನೀವು ನಿಮ್ಮ ಖಾಸಗಿ ಕೀಲಿಯನ್ನು openssl ಬಳಸಿಕೊಂಡು ಸಂರಕ್ಷಿಸಿ)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+msgid "Choose your personal certificate"
+msgstr "ನಿಮ್ಮ ವೈಯಕ್ತಿಕ ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆರಿಸಿ"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+msgid "Choose your private key"
+msgstr "ನಿಮ್ಮ ಖಾಸಗಿ ಕೀಲಿಯನ್ನು ಆರಿಸಿ"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "ಗುರುತು (_d)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "ಬಳಕೆದಾರ ಪ್ರಮಾಣಪತ್ರ (_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "ಖಾಸಗಿ ಕೀಲಿ (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "ಖಾಸಗಿ ಕೀಲಿ ಗುಪ್ತಪದ (_P)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "ನನ್ನನ್ನು ಇನ್ನೊಮ್ಮೆ ಎಚ್ಚರಿಸಬೇಡ (_w)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "ಇಲ್ಲ"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "ಹೌದು"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "ಟನಲ್ಡ್ TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "ಪ್ರೊಟೆಕ್ಟೆಡ್ EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "ದೃಢೀಕರಣ (_t)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (ಪೂರ್ವನಿಯೋಜಿತ)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "ಮುಕ್ತ ವ್ಯವಸ್ಥೆ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "ಹಂಚಲಾದ ಕೀಲಿ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "ಕೀಲಿ (_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "ಕೀಲಿಯನ್ನು ತೋರಿಸು (_w)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP ಸೂಚಿ (_x)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "ಬಗೆ (_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "ಸೂಚನೆಗಳು"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "ಶಬ್ಧ ರೂಪದ ಎಚ್ಚರಿಕೆಗಳು"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "ಪಾಪ್ಅಪ್ ಬ್ಯಾನರುಗಳನ್ನು ತೋರಿಸು"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "ವಿವರಗಳನ್ನು ಬ್ಯಾನರುಗಳಲ್ಲಿ ತೋರಿಸು"
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ನೋಡು"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ವಿವರಗಳನ್ನು ತೋರಿಸು"
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1701 ../panels/power/cc-power-panel.c:1708
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "ಚಾಲಿತ"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "ಸೂಚನೆಗಳು"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+"ಯಾವ ಸೂಚನೆಗಳನ್ನು ತೋರಿಸಬೇಕು ಮತ್ತು ಅವು ಏನನ್ನು ತೋರಿಸಬೇಕು ಎನ್ನುವುದನ್ನು "
+"ನಿಯಂತ್ರಿಸುತ್ತದೆ"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "ಸೂಚನೆಗಳು;ಬ್ಯಾನರ್;ಸಂದೇಶ;ಟ್ರೇ;ಪಾಪ್ಅಪ್;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "ಪಾಪ್ ಅಪ್ ಬ್ಯಾನರುಗಳನ್ನು ತೋರಿಸು"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "ಲಾಕ್ ಮಾಡಿದ ತೆರೆಯಲ್ಲಿ ತೋರಿಸು"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+msgctxt "Online Account"
+msgid "Other"
+msgstr "ಇತರೆ"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "ಖಾತೆಯನ್ನು ಸೇರಿಸು"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr "ಅಂಚೆ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr "ಸಂಪರ್ಕವಿಳಾಸಗಳು"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "ಚಾಟ್"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "ಸಂಪನ್ಮೂಲಗಳು"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "ಖಾತೆಗೆ ದಾಖಲಾಗುವಲ್ಲಿ ದೋಷ ಉಂಟಾಗಿದೆ"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "ರುಜುವಾತುಗಳ ವಾಯಿದೆ ತೀರಿದೆ."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr "ಈ ಖಾತೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಸೈನ್ ಇನ್ ಆಗಿ."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr "ಸೈನ್ ಇನ್ (_S)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "ಖಾತೆಯನ್ನು ರಚಿಸುವಲ್ಲಿ ದೋಷ"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕುವಲ್ಲಿ ದೋಷ"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕಲು ನೀವು ಖಚಿತವೆ?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "ಇದು ಪರಿಚಾರಕದಿಂದ ಖಾತೆಯನ್ನು ತೆಗೆದು ಹಾಕುವುದಿಲ್ಲ."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "ತೆಗೆದು ಹಾಕು (_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "ಅಂತರಜಾಲದಲ್ಲಿನ ಖಾತೆಗಳು"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"ನಿಮ್ಮ ಆನ್‌ಲೈನ್ ಖಾತೆಗಳೊಂದಿಗೆ ಸಂಪರ್ಕ ಜೋಡಿಸಿ ಮತ್ತು ಅವುಗಳನ್ನು ಯಾವ ಕೆಲಸಕ್ಕೆ "
+"ಬಳಸಬೇಕು "
+"ಎನ್ನುವುದನ್ನು ನಿರ್ಧರಿಸಿ"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "ಯಾವುದೆ ಆನ್‌ಲೈನ್ ಖಾತೆಗಳನ್ನು ಸಂರಚಿಸಲಾಗಿಲ್ಲ"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕು"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "ಅಂತರಜಾಲದಲ್ಲಿನ ಖಾತೆಯನ್ನು ಸೇರಿಸು"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"ಒಂದು ಖಾತೆಯನ್ನು ಸೇರಿಸುವುದರಿಂದ ಅದನ್ನು ನಿಮ್ಮ ಅನ್ವಯಗಳನ್ನು ದಸ್ತಾವೇಜುಗಳಿಗೆ, ಅಂಚೆಗೆ, "
+"ಸಂಪರ್ಕವಿಳಾಸಗಳಿಗೆ, ಕ್ಯಾಲೆಂಡರಿಗೆ, ಹರಟೆ ಮತ್ತು ಮುಂತಾದವುಗಳಿಗಾಗಿ ನಿಲುಕಿಸಿಕೊಳ್ಳಲು "
+"ಸಾಧ್ಯವಾಗುತ್ತದೆ."
+
+#: ../panels/power/cc-power-panel.c:192
+msgid "Unknown time"
+msgstr "ಗೊತ್ತಿರದ ಸಮಯ"
+
+#: ../panels/power/cc-power-panel.c:198
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i ನಿಮಿಷ"
+msgstr[1] "%i ನಿಮಿಷಗಳು"
+
+#: ../panels/power/cc-power-panel.c:210
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ಗಂಟೆ"
+msgstr[1] "%i ಗಂಟೆಗಳು"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:218
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:219
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ಗಂಟೆ"
+msgstr[1] "ಗಂಟೆಗಳು"
+
+#: ../panels/power/cc-power-panel.c:220
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "ನಿಮಿಷ"
+msgstr[1] "ನಿಮಿಷಗಳು"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:239
+#, c-format
+msgid "%s until fully charged"
+msgstr "ಚಾರ್ಜ್ ಮಾಡಿದಾಗಿನಿಂದ  %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:246
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "ಎಚ್ಚರಿಕೆ, %s ಬಾಕಿ ಇದೆ"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:251
+#, c-format
+msgid "%s remaining"
+msgstr "%s ಬಾಕಿ ಇದೆ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:256 ../panels/power/cc-power-panel.c:284
+msgid "Fully charged"
+msgstr "ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:260 ../panels/power/cc-power-panel.c:288
+msgid "Empty"
+msgstr "ಖಾಲಿ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:275
+msgid "Charging"
+msgstr "ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:280
+msgid "Discharging"
+msgstr "ಡಿಸ್‌ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ"
+
+#: ../panels/power/cc-power-panel.c:405
+msgctxt "Battery name"
+msgid "Main"
+msgstr "ಮುಖ್ಯ"
+
+#: ../panels/power/cc-power-panel.c:407
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "ಹೆಚ್ಚುವರಿ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Wireless mouse"
+msgstr "ತಂತಿರಹಿತ ಮೌಸ್"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Wireless keyboard"
+msgstr "ತಂತಿರಹಿತ ಕೀಲಿಮಣೆ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Uninterruptible power supply"
+msgstr "ತಡೆರಹಿತ ವಿದ್ಯುತ್ ಪೂರೈಕೆ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Personal digital assistant"
+msgstr "ವೈಯಕ್ತಿಕ ಡಿಜಿಟಲ್ ಸಹಾಯಕ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Cellphone"
+msgstr "ಸೆಲ್‌ಫೋನ್"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:494
+msgid "Media player"
+msgstr "ಮಾಧ್ಯಮ ಚಾಲಕ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:497
+msgid "Tablet"
+msgstr "ಕಿಸೆಗಣಕ (ಟ್ಯಾಬ್ಲೆಟ್)"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:500
+msgid "Computer"
+msgstr "ಗಣಕ"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:503 ../panels/power/cc-power-panel.c:726
+#: ../panels/power/cc-power-panel.c:2030
+msgid "Battery"
+msgstr "ಬ್ಯಾಟರಿ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:549
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:556
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "ಎಚ್ಚರಿಕೆ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:561
+msgctxt "Battery power"
+msgid "Low"
+msgstr "ಕೆಳ ಮಟ್ಟದ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Good"
+msgstr "ಉತ್ತಮ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:571
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "ಸಂಪುರ್ಣವಾಗಿ ಚಾರ್ಜ್ ಆಗಿದೆ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:575
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "ಖಾಲಿ"
+
+#: ../panels/power/cc-power-panel.c:724
+msgid "Batteries"
+msgstr "ಬ್ಯಾಟರಿಗಳು"
+
+#: ../panels/power/cc-power-panel.c:1126
+msgid "When _idle"
+msgstr "ಜಡವಾಗಿದ್ದಾಗ (_i)"
+
+#: ../panels/power/cc-power-panel.c:1454
+msgid "Power Saving"
+msgstr "ವಿದ್ಯುಚ್ಛಕ್ತಿ ಉಳಿತಾಯ"
+
+#: ../panels/power/cc-power-panel.c:1482
+msgid "_Screen brightness"
+msgstr "ತೆರೆಯ ಪ್ರಕಾಶತೆ (_S)"
+
+#: ../panels/power/cc-power-panel.c:1488
+msgid "_Keyboard brightness"
+msgstr "ಕೀಲಿಮಣೆ ಪ್ರಕಾಶತೆ (_K)"
+
+#: ../panels/power/cc-power-panel.c:1498
+msgid "_Dim screen when inactive"
+msgstr "ಚಟುವಟಿಕೆ ಇಲ್ಲದಾಗ ತೆರೆಯನ್ನು ಮಂದಗೊಳಿಸು (_D)"
+
+#: ../panels/power/cc-power-panel.c:1523
+msgid "_Blank screen"
+msgstr "ಖಾಲಿ ತೆರೆ (_B)"
+
+#: ../panels/power/cc-power-panel.c:1560
+msgid "_Wi-Fi"
+msgstr "ವೈ-ಫೈ (_W)"
+
+#: ../panels/power/cc-power-panel.c:1565
+msgid "Turns off wireless devices"
+msgstr "ವೈರ್ಲೆಸ್ ಸಾಧನಗಳನ್ನು ಆಫ್ ಮಾಡುತ್ತದೆ"
+
+#: ../panels/power/cc-power-panel.c:1590
+msgid "_Mobile broadband"
+msgstr "ಮೊಬೈಲ್ ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್ (_M)"
+
+#: ../panels/power/cc-power-panel.c:1595
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "ಮೊಬೈಲ್ ಬ್ರಾಡ್‌ಬ್ಯಾಂಡ್‌ (3G, 4G, WiMax, ಇತರೆ.) ಸಾಧನಗಳನ್ನು ಆಫ್ ಮಾಡುತ್ತದೆ"
+
+#: ../panels/power/cc-power-panel.c:1645
+msgid "_Bluetooth"
+msgstr "ಬ್ಲೂಟೂತ್ (_B)"
+
+#: ../panels/power/cc-power-panel.c:1697
+msgid "When on battery power"
+msgstr "ಬ್ಯಾಟರಿ ವಿದ್ಯುಚ್ಛಕ್ತಿಯನ್ನು ಬಳಸುವಾಗ"
+
+#: ../panels/power/cc-power-panel.c:1699
+msgid "When plugged in"
+msgstr "ವಿದ್ಯುಚ್ಧಕ್ತಿ ಸಂಪರ್ಕ ಜೋಡಿಸಿದಾಗ"
+
+#: ../panels/power/cc-power-panel.c:1829
+msgid "Suspend & Power Off"
+msgstr "ಅಮಾನತುಗೊಳಿಸು ಮತ್ತು ಆಫ್ ಮಾಡು"
+
+#: ../panels/power/cc-power-panel.c:1862
+msgid "_Automatic suspend"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ಅಮಾನತು (_A)"
+
+#: ../panels/power/cc-power-panel.c:1886
+msgid "When battery power is _critical"
+msgstr "ಬ್ಯಾಟರಿಯ ವಿದ್ಯುಚ್ಛಕ್ತಿಯು ಸಂದಿಗ್ಧ ಮಟ್ಟದಲ್ಲಿದ್ದಾಗ (_c)"
+
+#: ../panels/power/cc-power-panel.c:1941
+msgid "Power Off"
+msgstr "ಆಫ್ ಮಾಡು"
+
+#: ../panels/power/cc-power-panel.c:2077
+msgid "Devices"
+msgstr "ಸಾಧನಗಳು"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "ವಿದ್ಯುಚ್ಛಕ್ತಿ"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"ಬ್ಯಾಟರಿ ಸ್ಥಿತಿಯನ್ನು ನೋಡು ಮತ್ತು ವಿದ್ಯುಚ್ಛಕ್ತಿ ಉಳಿಸುವ ಸಿದ್ಧತೆಗಳನ್ನು ಬದಲಾಯಿಸು"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"ವಿದ್ಯುಚ್ಛಕ್ತಿ;ನಿದ್ರಿಸು;ಅಮಾನತು;ಹೈಬರ್ನೇಟ್;ಬ್ಯಾಟರಿ;ಪ್ರಕಾಶತೆ;ಮಂದ;ಖಾಲಿ;ತೆರೆ;DPMS;ಜಡ"
+";"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "ಹೈಬರ್ನೇಟ್"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "ಸ್ಥಗಿತಗೊಳಿಸು"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "45 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 ಗಂಟೆ"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "80 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "90 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "100 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "2 ಗಂಟೆಗಳು"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 ನಿಮಿಷ"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "4 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "8 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "12 ನಿಮಿಷಗಳು"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ಅಮಾನತು"
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr "ಸಂಪರ್ಕ ಜೋಡಿಸಲಾಗಿದೆ (_P)"
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr "ಬ್ಯಾಟರಿ ವಿದ್ಯುಚ್ಛಕ್ತಿಯಲ್ಲಿದ್ದಾಗ (_B)"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "ವಿಳಂಬ"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "ದೃಢೀಕರಿಸು"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "ಗುಪ್ತಪದ"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr "ಟೋನರ್ ಕಡಿಮೆ ಇದೆ"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr "ಟೋನರ್ ಖಾಲಿಯಾಗಿದೆ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr "ವಿಕಸನೆಗಾರ ಕಡಿಮೆ ಇದೆ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr "ವಿಕಸನೆಗಾರ ಖಾಲಿಯಾಗಿದೆ"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr "ಮಾರ್ಕರ್ ಪೂರೈಕೆಯಲ್ಲಿ ಕೊರತೆಯಿದೆ"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr "ಮಾರ್ಕರ್ ಪೂರೈಕೆ ಇಲ್ಲವಾಗಿದೆ"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr "ಮುಚ್ಚಣ ತೆರೆದಿದೆ"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr "ಬಾಗಿಲು ತೆರೆದಿದೆ"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr "ಕಾಗದ ಕಡಿಮೆ ಇದೆ"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr "ಕಾಗದದ ಖಾಲಿಯಾಗಿದೆ"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ಆಫ್‌ಲೈನ್"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "ನಿಲ್ಲಿಸಲಾಗಿದೆ"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr "ಕಸದ ಬುಟ್ಟಿಯು ಬಹುಪಾಲು ತುಂಬಿದೆ"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr "ಕಸದ ಬುಟ್ಟಿ ತುಂಬಿದೆ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr "ಆಪ್ಟಿಕಲ್ ಫೋಟೊ ಕಂಡಕ್ಟರ್ ಸ್ಥಗಿತಗೊಳ್ಳುವ ಹಂತದಲ್ಲಿದೆ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ಆಪ್ಟಿಕಲ್ ಫೋಟೊ ಕಂಡಕ್ಟರ್ ಕೆಲಸ ಮಾಡುತ್ತಿಲ್ಲ"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "ಸಂರಚಿಸಲಾಗುತ್ತಿದೆ"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr "ಸಿದ್ಧಗೊಂಡಿದೆ"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "ಕಾರ್ಯಗಳನ್ನು ಸ್ವೀಕರಿಸುವುದಿಲ್ಲ"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr "ಸಂಸ್ಕರಿಸಲಾಗುತ್ತಿದೆ"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:921
+msgid "Toner Level"
+msgstr "ಟೋನರ್ ಮಟ್ಟ"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:924
+msgid "Ink Level"
+msgstr "ಶಾಯಿಯ ಮಟ್ಟ"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:927
+msgid "Supply Level"
+msgstr "ಒದಗಣೆಯ ಮಟ್ಟ"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:945
+msgctxt "printer state"
+msgid "Installing"
+msgstr "ಅನುಸ್ಥಾಪಿಸಲಾಗುತ್ತಿದೆ"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1121
+msgid "No printers available"
+msgstr "ಯಾವುದೆ ಮುದ್ರಕ ಲಭ್ಯವಿಲ್ಲ"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1431
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u ಸಕ್ರಿಯ"
+msgstr[1] "%u ಸಕ್ರಿಯ"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1775
+msgid "Failed to add new printer."
+msgstr "ಹೊಸ ಮುದ್ರಕವನ್ನು ಸೇರಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ."
+
+#: ../panels/printers/cc-printers-panel.c:1942
+msgid "Select PPD File"
+msgstr "PPD ಕಡತವನ್ನು ಆರಿಸು"
+
+#: ../panels/printers/cc-printers-panel.c:1951
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript ಪ್ರಿಂಟರ್ ಡಿಸ್ಕ್ರಿಪ್ಶನ್ ಕಡತಗಳು (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD."
+"GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2256
+msgid "No suitable driver found"
+msgstr "ಯಾವುದೆ ಸೂಕ್ತ ಚಾಲಕವು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#: ../panels/printers/cc-printers-panel.c:2325
+msgid "Searching for preferred drivers…"
+msgstr "ಇಚ್ಛೆಯ ಚಾಲಕಕ್ಕಾಗಿ ಹುಡುಕಲಾಗುತ್ತಿದೆ..."
+
+#: ../panels/printers/cc-printers-panel.c:2340
+msgid "Select from database…"
+msgstr "ದತ್ತಸಂಚಯದಿಂದ ಆಯ್ಕೆ ಮಾಡು..."
+
+#: ../panels/printers/cc-printers-panel.c:2349
+msgid "Provide PPD File…"
+msgstr "PPD ಕಡತವನ್ನು ಒದಗಿಸು..."
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2500
+#: ../panels/printers/cc-printers-panel.c:2523
+msgid "Test page"
+msgstr "ಪ್ರಾಯೋಗಿಕ ಪುಟ"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2937
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui ಅನ್ನುಲೋಡ್‌ ಮಾಡಲಾಗಲಿಲ್ಲ: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "ಮುದ್ರಕಗಳು"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"ಮುದ್ರಕಗಳನ್ನು ಸೇರಿಸಿ, ಮುದ್ರಣ ಕಾರ್ಯಗಳನ್ನು ನೋಡಿ ಮತ್ತು ನೀವು ಹೇಗೆ ಮುದ್ರಿಸಲು "
+"ಬಯಸುವಿರಿ "
+"ಎನ್ನುವುದನ್ನು ನಿರ್ಧರಿಸಿ"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "ಮುದ್ರಕ;ಸರತಿ;ಮುದ್ರಣ;ಕಾಗದ;ಶಾಯಿ;ಟೋನರ್;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "ಸಕ್ರಿಯ ಕಾರ್ಯಗಳು"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "ಮುಚ್ಚು"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "ಮುದ್ರಣವನ್ನು ಮರುಆರಂಭಿಸು"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "ಮುದ್ರಣವನ್ನು ತಾತ್ಕಾಲಿಕ ನಿಲ್ಲಿಸು"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "ಮುದ್ರಣ ಕಾರ್ಯವನ್ನು ರದ್ದುಗೊಳಿಸು"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "ಒಂದು ಹೊಸ ಮುದ್ರಕವನ್ನು ಸೇರಿಸಿ"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "A_uthenticate"
+msgstr "ದೃಢೀಕರಿಸು (_u)"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "ಯಾವುದೆ ಮುದ್ರಕಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter address of a printer or a text to filter results"
+msgstr ""
+"ಫಲಿತಾಂಶಗಳನ್ನು ಫಿಲ್ಟರ್‌ ಮಾಡಲು ಒಂದು ಮುದ್ರಕದ ವಿಳಾಸ ಅಥವ ಒಂದು ಪಠ್ಯವನ್ನು ನಮೂದಿಸಿ"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "ಆಯ್ಕೆಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.."
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "ಮುದ್ರಕದ ಚಾಲಕವನ್ನು ಆರಿಸು"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "ಚಾಲಕಗಳ ದತ್ತಸಂಚಯವನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+msgid "JetDirect Printer"
+msgstr "JetDirect ಮುದ್ರಕ"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+msgid "LPD Printer"
+msgstr "LPD ಮುದ್ರಕ"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "ಒಂದು ಬದಿಯ"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "ಉದ್ದನೆಯ ಅಂಚು (ಶಿಷ್ಟ)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "ಚಿಕ್ಕ ಅಂಚು (ಹೊರಳಿಸು)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "ಭಾವಚಿತ್ರ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "ಪ್ರಕೃತಿ ಚಿತ್ರ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "ವಿಲೋಮ ಪ್ರಕೃತಿ ಚಿತ್ರ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "ವಿಲೋಮ ಭಾವಚಿತ್ರ"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "ಬಾಕಿ ಇದೆ"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "ತಡೆಹಿಡಿಯಲಾಗಿದೆ"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "ಸಂಸ್ಕರಿಸಲಾಗುತ್ತಿದೆ"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "ನಿಲ್ಲಿಸಲಾಗಿದೆ"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "ರದ್ದು ಮಾಡಲಾಗಿದೆ"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "ವಿಫಲಗೊಳಿಸಲಾಗಿದೆ"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "ಪೂರ್ಣಗೊಂಡಿದೆ"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "ಕೆಲಸದ ಶೀರ್ಷಿಕೆ"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "ಕೆಲಸದ ಸ್ಥಿತಿ"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "ಸಮಯ"
+
+#: ../panels/printers/pp-jobs-dialog.c:451
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s ಸಕ್ರಿಯ ಕಾರ್ಯಗಳು"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1620
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1625
+msgid "Serial Port"
+msgstr "ಅನುಕ್ರಮಿತ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1632
+msgid "Parallel Port"
+msgstr "ಸಮಾನಾಂತರ ಸಂಪರ್ಕಸ್ಥಾನ"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+#, c-format
+msgid "Location: %s"
+msgstr "ಸ್ಥಳ: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1693
+#, c-format
+msgid "Address: %s"
+msgstr "ವಿಳಾಸ: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1717
+msgid "Server requires authentication"
+msgstr "ಪೂರೈಕೆಗಣಕಕ್ಕೆ ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "ಎರಡೂ ಬದಿಯ"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "ಪೇಪರಿನ ಬಗೆ"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "ಪೇಪರಿನ ಆಕರ"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "ಔಟ್‌ಪುಟ್ ಟ್ರೇ"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript ಪೂರ್ವ-ಸೋಸುವಿಕೆ"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:533
+msgid "Pages per side"
+msgstr "ಪ್ರತಿ ಬದಿಯ ಪುಟಗಳು"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:545
+msgid "Two-sided"
+msgstr "ಎರಡೂ-ಬದಿಯ"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:557
+msgid "Orientation"
+msgstr "ಅಭಿಮುಖ"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "ಸಾಮಾನ್ಯ"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "ಪುಟ ಸಿದ್ಧತೆ"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "ಅನುಸ್ಥಾಪನೆಯ ಆಯ್ಕೆಗಳು"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "ಕಾರ್ಯ"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "ಚಿತ್ರದ ಗುಣಮಟ್ಟ"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "ಬಣ್ಣ"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "ಪೂರ್ಣಗೊಳಿಕೆ"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:675
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "ಸುಧಾರಿತ"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "ಸ್ವಯಂ ಆಯ್ಕೆ"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "ಮುದ್ರಕದ ಪೂರ್ವನಿಯೋಜಿತ"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "ಅಡಕಗೊಳಿಸಲಾದ GhostScript ಅಕ್ಷರಶೈಲಿಗಳು ಮಾತ್ರ"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "PS ಹಂತ 1 ಕ್ಕೆ ಪರಿವರ್ತಿಸು"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "PS ಹಂತ 2 ಕ್ಕೆ ಪರಿವರ್ತಿಸು"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "ಯಾವುದೆ ಪೂರ್ವ-ಫಿಲ್ಟರಿಂಗ್ ಇಲ್ಲ"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "ಉತ್ಪಾದಕರು"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "ಚಾಲಕ"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"%s ನಲ್ಲಿ ಲಭ್ಯವಿರುವ ಮುದ್ರಕಗಳನ್ನು ನೋಡಲು ನಿಮ್ಮ ಬಳಕೆದಾರಹೆಸರು ಹಾಗು ಗುಪ್ತಪದವನ್ನು "
+"ನಮೂದಿಸಿ."
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "ಮುದ್ರಕವನ್ನು ಸೇರಿಸಿ"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "ಮುದ್ರಕವನ್ನು ತೆಗೆದುಹಾಕಿ"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "ಪೂರೈಕೆ"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "ಸ್ಥಳ"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default printer"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ ಮುದ್ರಕ (_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "ಕಾರ್ಯಗಳು"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "ಕೆಲಸಗಳನ್ನು ತೋರಿಸು (_J)"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "ಮಾದರಿ"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "ಲೇಬಲ್"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "ಹೊಸ ಚಾಲಕನ್ನು ಸಿದ್ಧಗೊಳಿಸಲಾಗುತ್ತಿದೆ..."
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "ಪುಟ 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "ಪ್ರಾಯೋಗಿಕ ಪುಟವನ್ನು ಮುದ್ರಿಸು (_T)"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "ಆಯ್ಕೆಗಳು (_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "ಹೊಸ ಮುದ್ರಕವನ್ನು ಸೇರಿಸಿ"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"ಕ್ಷಮಿಸಿ! ವ್ಯವಸ್ಥೆಯ ಮುದ್ರಣ ಸೇವೆಯು\n"
+"ಲಭ್ಯವಿರುವಂತೆ ತೋರುತ್ತಿಲ್ಲ."
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "ತೆರೆ ಲಾಕ್"
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "ಬಳಕೆ ಮತ್ತು ಇತಿಹಾಸ"
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr "ಕಸದ ಬುಟ್ಟಿಯಿಂದ ಎಲ್ಲಾ ಅಂಶಗಳನ್ನು ಖಾಲಿ ಮಾಡಬೇಕೆ?"
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr "ಕಸದ ಬುಟ್ಟಿಯಲ್ಲಿನ ಎಲ್ಲಾ ಅಂಶಗಳನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲಾಗುತ್ತದೆ."
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "ಕಸದ ಬುಟ್ಟಿಯನ್ನು ಖಾಲಿ ಮಾಡು (_E)"
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+msgid "Delete all the temporary files?"
+msgstr "ಎಲ್ಲಾ ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಅಳಿಸಬೇಕೆ?"
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr "ಎಲ್ಲಾ ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲಾಗುತ್ತದೆ."
+
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಹೊರತಳ್ಳು (_P)"
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "ಕಸ ಮತ್ತು ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಹೊರತಳ್ಳು"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr "ತಂತ್ರಾಂಶದ ಬಳಕೆ"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "ಗೌಪ್ಯತೆ"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+"ನಿಮ್ಮ ವೈಯಕ್ತಿಕ ಮಾಹಿತಿಗಳನ್ನು ಸಂರಕ್ಷಿಸಿ ಮತ್ತು ಬೇರೆಯವರು ಏನನ್ನು ನೋಡುತ್ತಾರೆ "
+"ಎನ್ನುವುದನ್ನು "
+"ನಿಯಂತ್ರಿಸಿ"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"ತೆರೆ;ಲಾಕ್;ದೋಷಪತ್ತೆ;ಕುಸಿತ;ಖಾಸಗಿ;ಇತ್ತೀಚಿನ;ತಾತ್ಕಾಲಿಕ;tmp;ಸೂಚಿ;ಹೆಸರು;ಜಾಲಬಂಧ;ಗುರುತು"
+";"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "ತೆರೆಯು ಆಫ್ ಆಗುತ್ತದೆ"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 ಸೆಕೆಂಡುಗಳು"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 ದಿನ"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 ದಿನಗಳು"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 ದಿನಗಳು"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 ದಿನಗಳು"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 ದಿನಗಳು"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 ದಿನಗಳು"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 ದಿನಗಳು"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 ದಿನಗಳು"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 ದಿನಗಳು"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "ಯಾವಾಗಲೂ"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"ನಿಮ್ಮ ವ್ಯವಸ್ಥೆಯ ಇತಿಹಾಸವನ್ನು ನೆನಪಿಟ್ಟುಕೊಳ್ಳುವುದರಿಂದ ಅಗತ್ಯವಾದ ವಸ್ತುಗಳನ್ನು ಮತ್ತೆ "
+"ಹುಡುಕಲು "
+"ಸುಲಭವಾಗಿರುತ್ತದೆ. ಈ ಅಂಶಗಳನ್ನು ಎಂದಿಗೂ ಸಹ ಜಾಲಬಂಧದ ಮುಖಾಂತರ ಹಂಚಿಕೊಳ್ಳಲಾಗುವುದಿಲ್ಲ."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "ಇತ್ತೀಚಿಗೆ ಬಳಸಲಾದ (_R)"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "ಇತಿಹಾಸವನ್ನು ಉಳಿಸಕೊ (_H)"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "ಇತ್ತೀಚಿನ ಇತಿಹಾಸವನ್ನು ಅಳಿಸು (_e)"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr ""
+"ತೆರೆಯನ್ನು ಲಾಕ್‌ ಮಾಡುವಿಕೆಯು ನೀವು ಆದೆ ಹೋದಾಗ ನಿಮ್ಮ ಗೌಪ್ಯತೆಯನ್ನು ಕಾಪಾಡುತ್ತದೆ."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ತೆರೆಯ ಲಾಕ್ (_L)"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "ಇಷ್ಟು ಸಮಯ ಖಾಲಿ ಬಿಟ್ಟಲ್ಲಿ ತೆರೆಯನ್ನು ಲಾಕ್ ಮಾಡು (_a)"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "ಸೂಚನೆಗಳನ್ನು ತೋರಿಸು (_ N)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"ನಿಮ್ಮ ಗಣಕವು ಅನಗತ್ಯವಾದ ಸಂವೇದನಾ ಮಾಹಿತಿಯನ್ನು ಇರಿಸಿಕೊಳ್ಳುವುದನ್ನು ತಪ್ಪಿಸಲು ಕಸ "
+"(ಟ್ರ್ಯಾಶ್) "
+"ಮತ್ತು ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊರತಳ್ಳಿ."
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "ಕಸದ ಬುಟ್ಟಿಯನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಖಾಲಿ ಮಾಡು (_T)"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "ತಾತ್ಕಾಲಿಕ ಕಡತಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊರತಳ್ಳು (_F)"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "ಇದರ ನಂತರ ಹೊರತಳ್ಳು (_A)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"ನೀವು ಯಾವ ತಂತ್ರಾಂಶವನ್ನು ಬಳಸುತ್ತೀರಿ ಎಂಬುದರ ಬಗೆಗಿನ ಮಾಹಿತಿಯನ್ನು ಕಳುಹಿಸುವುದರಿಂದ "
+"ನಿಮಗೆ "
+"ಖಚಿತವಾದ ಸಲಹೆಗಳನ್ನು ಒದಗಿಸಲು ನಮಗೆ ಸಹಾಯವಾಗುತ್ತದೆ. ಇದು ನಮ್ಮ ತಂತ್ರಾಂಶವನ್ನೂ ಸಹ "
+"ಸುಧಾರಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.\n"
+"\n"
+"ನಾವು ಸಂಗ್ರಹಿಸುವ ಎಲ್ಲಾ ಮಾಹಿತಿಯನ್ನು ಅಜ್ಞಾತವಾಗಿರಿಸಲಾಗುತ್ತದೆ, ಮತ್ತು ನಾವು ಇದನ್ನು "
+"ಮೂರನೆಯ "
+"ವ್ಯಕ್ತಿಗಳೊಂದಿಗೆ ಎಂದಿಗೂ ಹಂಚಿಕೊಳ್ಳುವುದಿಲ್ಲ."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "ತಂತ್ರಾಂಶ ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳನ್ನು ಕಳುಹಿಸು (_S)"
+
+#: ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "ಗೌಪ್ಯತಾ ನಿಯಮ"
+
+#: ../panels/privacy/privacy.ui.h:42
+msgid "_Location Services"
+msgstr "ಸ್ಥಳದ ಸೇವೆಗಳು (_L)"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "ನಿಮ್ಮ ಭೂಸ್ಥಳದ ಕುರಿತು ನಿರ್ಧರಿಸಲು ಬಳಸಲಾಗುತ್ತದೆ"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ಇಂಪೀರಿಯಲ್"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "ಮೆಟ್ರಿಕ್"
+
+#: ../panels/region/cc-format-chooser.c:283
+msgid "No regions found"
+msgstr "ಯಾವುದೆ ಜಾಗಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#: ../panels/region/cc-input-chooser.c:178
+msgid "No input sources found"
+msgstr "ಯಾವುದೆ ಇನ್‌ಪುಟ್‌ ಮೂಲಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
+
+#: ../panels/region/cc-input-chooser.c:1082
+msgctxt "Input Source"
+msgid "Other"
+msgstr "ಇತರೆ"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:1068
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "ಬದಲಾವಣೆಗಳು ಕಾರ್ಯರೂಪಕ್ಕೆ ಬರಲು ನಿಮ್ಮ ಅಧಿವೇಶನವನ್ನು ಮರಳಿ ಆರಂಭಿಸಬೇಕಾಗುತ್ತದೆ"
+
+#: ../panels/region/cc-region-panel.c:243
+#: ../panels/user-accounts/um-user-panel.c:1072
+msgid "Restart Now"
+msgstr "ಈಗಲೆ ಮರಳಿ ಆರಂಭಿಸು"
+
+#: ../panels/region/cc-region-panel.c:862
+msgid "No input source selected"
+msgstr "ಯಾವುದೆ ಇನ್‌ಪುಟ್ ಮೂಲವನ್ನು ಆಯ್ಕೆ ಮಾಡಲಾಗಿಲ್ಲ"
+
+#: ../panels/region/cc-region-panel.c:1092
+msgid "Sorry"
+msgstr "ಕ್ಷಮಿಸಿ"
+
+#: ../panels/region/cc-region-panel.c:1094
+msgid "Input methods can't be used on the login screen"
+msgstr "ಪ್ರವೇಶ ತೆರೆಯಲ್ಲಿ ಇನ್‌ಪುಟ್ ವಿಧಾನಗಳನ್ನು ಬಳಸಲು ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ"
+
+#: ../panels/region/cc-region-panel.c:1731
+msgid "Login Screen"
+msgstr "ಪ್ರವೇಶ ತೆರೆ"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "ವಿನ್ಯಾಸಗಳು"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "ಮುನ್ನೋಟ"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "ದಿನಾಂಕಗಳು"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "ಸಮಯಗಳು"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "ಸಂಖ್ಯೆಗಳು"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "ಅಳತೆ"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "ಕಾಗದ"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "ಪ್ರದೇಶ ಹಾಗು ಭಾಷೆ"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"ನಿಮ್ಮ ಪ್ರದರ್ಶನದ ಭಾಷೆ, ವಿನ್ಯಾಸಗಳು, ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸಗಳು ಮತ್ತು ಇನ್‌ಪುಟ್ ಮೂಲಗಳನ್ನು "
+"ಆರಿಸಿ"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "ಭಾಷೆ;ವಿನ್ಯಾಸ;ಕೀಲಿಮಣೆ;ಇನ್‌ಪುಟ್;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "ಒಂದು ಇನ್‌ಪುಟ್‌ ಮೂಲವನ್ನು ಸೇರಿಸಿ"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "ಇನ್‌ಪುಟ್‌ ಮೂಲದ ಆಯ್ಕೆಗಳು"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Use the _same source for all windows"
+msgstr "ಎಲ್ಲಾ ಕಿಟಕಿಗಳಿಗೂ ಒಂದೇ ರೀತಿಯ ಮೂಲವನ್ನು ಬಳಸು (_s)"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Allow _different sources for each window"
+msgstr "ಪ್ರತಿ ಕಿಟಕಿಗೂ ಸಹ ಪ್ರತ್ಯೇಕ ಮೂಲಗಳನ್ನು ಅನುಮತಿಸು (_d)"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Keyboard Shortcuts"
+msgstr "ಕೀಲಿಮಣೆ-ಸುಲಭ ಆಯ್ಕೆಗಳು"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Switch to previous source"
+msgstr "ಹಿಂದಿನ ಆಕರಕ್ಕೆ ಬದಲಾಯಿಸು"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Switch to next source"
+msgstr "ಮುಂದಿನ ಆಕರಕ್ಕೆ ಬದಲಾಯಿಸು"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "ನೀವು ಈ ಸುಲಭಆಯ್ಕೆಗಳನ್ನು ಕೀಲಿಮಣೆ ಸಿದ್ಧತೆಗಳಲ್ಲಿ ಬದಲಾಯಿಸಬಹುದು"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Alternative switch to next source"
+msgstr "ಮುಂದಿನ ಮೂಲಕ್ಕೆ ಪರ್ಯಾಯ ಸ್ವಿಚ್"
+
+#: ../panels/region/input-options.ui.h:12
+msgid "Left+Right Alt"
+msgstr "ಎಡ+ಬಲ Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "ಇಂಗ್ಲೀಷ್ (ಯುನೈಟೆಡ್ ಕಿಂಗ್‌ಡಮ್)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "ಯುನೈಟೆಡ್ ಕಿಂಗ್‌ಡಮ್"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "ಆಯ್ಕೆಗಳು"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr "ವ್ಯವಸ್ಥೆಗೆ ಪ್ರವೇಶಿಸುವಾಗ ಎಲ್ಲಾ ಬಳಕೆದಾರರಿಂದ ಬಳಸಲಾಗುವ ಪ್ರವೇಶದ ಸಿದ್ಧತೆಗಳು"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr "ಸ್ಥಳಗಳು"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "ಪುಟಗುರುತುಗಳು"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr "ಇತರೆ"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "ಸ್ಥಳವನ್ನು ಆರಿಸಿ"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+msgid "_OK"
+msgstr "ಸರಿ (_O)"
+
+#: ../panels/search/cc-search-panel.c:177
+msgid "No applications found"
+msgstr "ಯಾವುದೆ ಅನ್ವಯಗಳು ಕಂಡು ಬಂದಿಲ್ಲ"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "ಹುಡುಕು"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"ಯಾವ ಅನ್ವಯಗಳು ಚಟುವಟಿಕೆಗಳ ಅವಲೋಕನದಲ್ಲಿ ಹುಡುಕು ಫಲಿತಾಂಶವನ್ನು ತೋರಿಸುತ್ತದೆ "
+"ಎನ್ನುವುದನ್ನು "
+"ನಿಯಂತ್ರಿಸಿ"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "ಶೋಧಿಸು;ಹುಡುಕು;ಸೂಚಿ;ಅಡಗಿಸು;ಗೌಪ್ಯತೆ;ಫಲಿತಾಂಶಗಳು;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "ಸ್ಥಳಗಳನ್ನು ಹುಡುಕು"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "ಮೇಲೆ ಜರುಗಿಸು"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "ಕೆಳಗೆ ಜರುಗಿಸು"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "ಆದ್ಯತೆಗಳು"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "ಆನ್"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "ಆಫ್"
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "ಸಕ್ರಿಯಗೊಂಡ"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+msgctxt "service is active"
+msgid "Active"
+msgstr "ಸಕ್ರಿಯ"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "ಒಂದು ಕಡತಕೋಶವನ್ನು ಆರಿಸು"
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "ಪ್ರತಿಮಾಡು"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "ಹಂಚಿಕೆ"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "ನೀವು ಬೇರೆಯವರೊಂದಿಗೆ ಏನನ್ನು ಹಂಚಿಕೊಳ್ಳಲು ಬಯಸುವಿರಿ ಎನ್ನುವುದನ್ನು ನಿಯಂತ್ರಿಸಿ"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"ಹಂಚು;ಹಂಚಿಕೆ;ssh;ಆತಿಥೇಯ;ಹೆಸರು;ದೂರಸ್ಥ;ಗಣಕತೆರೆ;ಬ್ಲೂಟೂತ್;obex;ಮಾಧ್ಯಮ;ಆಡಿಯೊ;ವೀಡಿಯೊ;"
+"ಚಿತ್ರಗಳು;ಫೋಟೊಗಳು;ಚಲನಚಿತ್ರಗಳು;ಪೂರೈಕೆಗಣಕ;ನಿರೂಪಕ;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "ದೂರಸ್ಥ ಪ್ರವೇಶವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ ಅಥವ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"ದೂರಸ್ಥ ಪ್ರವೇಶವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಅಥವ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲು ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:303
+msgid "No networks selected for sharing"
+msgstr "ಹಂಚಿಕೊಳ್ಳಲು ಯಾವುದೆ ಜಾಲಬಂಧಗಳನ್ನು ಆರಿಸಲಾಗಿಲ್ಲ"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "ಜಾಲಬಂಧಗಳು"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "ಬ್ಲೂಟೂತ್ ಹಂಚಿಕೆ"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"ಬ್ಲೂಟೂತ್ ಹಂಚಿಕೆಯು ಕಡತಗಳನ್ನು ಇತರೆ ಬ್ಲೂಟೂತ್ ಸಕ್ರಿಯಗೊಳಿಸಲಾದ ಸಾಧನಗಳೊಂದಿಗೆ "
+"ಹಂಚಿಕೊಳ್ಳಲು "
+"ಅನುವು ಮಾಡಿಕೊಡುತ್ತದೆ"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "ನಂಬಿಕಸ್ತ ಸಾಧನಗಳಿಂದ ಮಾತ್ರ ಸ್ವೀಕರಿಸು"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "ಸ್ವೀಕರಿಸಲಾದ ಕಡತಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಕಡತಕೋಶಕ್ಕೆ ಉಳಿಸು"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "ಗಣಕದ ಹೆಸರು"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "ವೈಯಕ್ತಿಕ ಕಡತ ವಿನಿಮಯ"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "ತೆರೆ ಹಂಚಿಕೆ"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "ಮಾಧ್ಯಮ ಹಂಚಿಕೊಳ್ಳುವಿಕೆ"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "ದೂರಸ್ಥ ಪ್ರವೇಶ"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "ಯಾವುದೆ ಜಾಲಬಂಧ ಸೇವೆಯು ಇರದ ಕಾರಣ ಕೆಲವು ಸೇವೆಗಳು ನಿಷ್ಕ್ರಿಯವಾಗಿರುತ್ತವೆ."
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"ವೈಯಕ್ತಿಕ ಕಡತ ಹಂಚಿಕೆಯನ್ನು ಬಳಸಿಕೊಂಡು ನೀವು ಸಾರ್ವಜನಿಕ ಕಡತಕೋಶವನ್ನು ನಿಮ್ಮ ಪ್ರಸಕ್ತ "
+"ಜಾಲಬಂಧದಲ್ಲಿರುವವರೊಂದಿಗೆ ಹಂಚಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಿರುತ್ತದೆ: <a href=\"dav://%s\">dav://"
+"%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr "ಗುಪ್ತಪದದ ಅಗತ್ಯವಿದೆ"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"ಈ ಸೆಕ್ಯೂರ್ ಶೆಲ್ ಆದೇಶವನ್ನು ಬಳಸಿಕೊಂಡು ದೂರಸ್ಥ ಬಳಕೆದಾರರು ಸಂಪರ್ಕಸಾಧಿಸಲು ಅನುಮತಿಸಿ:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"ಇದಕ್ಕೆ ಸಂಪರ್ಕ ಸಾಧಿಸುವ ಮುಖಾಂತರ ದೂರಸ್ಥ ಬಳಕೆದಾರರು ನಿಮ್ಮ ತೆರೆಯನ್ನು ನೋಡಲು ಅಥವ "
+"ನಿಯಂತ್ರಿಸಲು ಅನುಮತಿಸಿ: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Allow Remote Control"
+msgstr "ದೂರಸ್ಥ ನಿಯಂತ್ರಣವನ್ನು ಅನುಮತಿಸು"
+
+#: ../panels/sharing/sharing.ui.h:21
+msgid "Password:"
+msgstr "ಗುಪ್ತಪದ:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "ಗುಪ್ತಪದವನ್ನು ತೋರಿಸು"
+
+#: ../panels/sharing/sharing.ui.h:23
+msgid "Access Options"
+msgstr "ನಿಲುಕು ಆಯ್ಕೆಗಳು"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "ಹೊಸ ಸಂಪರ್ಕಗಳು ನಿಲುಕಿಗಾಗಿ ಕೇಳಬೇಕು"
+
+#: ../panels/sharing/sharing.ui.h:25
+msgid "Require a password"
+msgstr "ಒಂದು ಗುಪ್ತಪದದ ಅಗತ್ಯವಿದೆ"
+
+#: ../panels/sharing/sharing.ui.h:26
+msgid "Share music, photos and videos over the network."
+msgstr "ಜಾಲಬಂಧದ ಮುಖಾಂತರ ಸಂಗೀತ, ಚಿತ್ರಗಳು ಮತ್ತು ವೀಡಿಯೊಗಳನ್ನು ಹಂಚಿಕೊಳ್ಳಿ."
+
+#: ../panels/sharing/sharing.ui.h:27
+msgid "Folders"
+msgstr "ಕಡತಕೋಶಗಳು"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "ಧ್ವನಿ"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"ಧ್ವನಿಯ ಪ್ರಮಾಣಗಳು, ಇನ್‌ಪುಟ್‌ಗಳು, ಔಟ್‌ಪುಟ್‌ಗಳು ಮತ್ತು ಎಚ್ಚರಿಕೆ ಸದ್ದುಗಳನ್ನು "
+"ಬದಲಾಯಿಸಿ"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "ಕಾರ್ಡ್;ಧ್ವನಿವರ್ಧಕ;ಧ್ವನಿಪ್ರಮಾಣ;ಮಬ್ಬು;ಸಮತೋಲನ;ಬ್ಲೂಟೂತ್;ಹೆಡ್‌ಸೆಟ್;ಆಡಿಯೊ;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "ಬೊಗಳು"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "ತೊಟ್ಟಿಕ್ಕು"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "ಗಾಜು"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "ಸೋನಾರ್"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "ಎಡ"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "ಬಲ"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "ಹಿಂಬದಿ"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "ಎದುರು"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "ಕನಿಷ್ಟ"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "ಗರಿಷ್ಟ"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "ಸಮತೋಲನ (_B):"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "ಮಬ್ಬುಗೊಳಿಸು (_F):"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "ಸಬ್‌ವೂಫರ್ (_S):"
+
+#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:615
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "ವರ್ಧಿಸದ"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "ಪ್ರೊಫೈಲ್ (_P):"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u ಔಟ್‌ಪುಟ್"
+msgstr[1] "%u ಔಟ್‌ಪುಟ್‌ಗಳು"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ಇನ್‌ಪುಟ್"
+msgstr[1] "%u ಇನ್‌ಪುಟ್‌ಗಳು"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "ವ್ಯವಸ್ಥೆಯ ಧ್ವನಿಗಳು"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "ಸ್ಪೀಕರುಗಳನ್ನು ಪರೀಕ್ಷಿಸು (_T)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "ಉತ್ತುಂಗದ ಪತ್ತೆ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1491
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "ಹೆಸರು"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1510
+msgid "Device"
+msgstr "ಸಾಧನ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1573
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s ಗಾಗಿನ ಸ್ಪೀಕರುಗಳ ಪರೀಕ್ಷೆ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1629
+msgid "_Output volume:"
+msgstr "ಔಟ್‌ಪುಟ್ ಧ್ವನಿ ಪ್ರಮಾಣ (_O):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1643
+msgid "Output"
+msgstr "ಔಟ್‌ಪುಟ್"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1648
+msgid "C_hoose a device for sound output:"
+msgstr "ಧ್ವನಿಯ ಇನ್‌ಪುಟ್‌ಗಾಗಿ ಒಂದು ಸಾಧನವನ್ನು ಆರಿಸಿ (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1670
+msgid "Settings for the selected device:"
+msgstr "ಆಯ್ಕೆ ಮಾಡಿದ ಸಾಧನದ ಸಿದ್ಧತೆಗಳು:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1681
+msgid "Input"
+msgstr "ಇನ್‌ಪುಟ್"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1688
+msgid "_Input volume:"
+msgstr "ಇನ್‌ಪುಟ್‌ ಧ್ವನಿ ಪ್ರಮಾಣ (_I):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1709
+msgid "Input level:"
+msgstr "ಇನ್‌ಪುಟ್‌ ಹಂತ:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1737
+msgid "C_hoose a device for sound input:"
+msgstr "ಧ್ವನಿಯ ಔಟ್‌ಪುಟ್‌ಗಾಗಿ ಒಂದು ಸಾಧನವನ್ನು ಆರಿಸಿ (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1761
+msgid "Sound Effects"
+msgstr "ಧ್ವನಿ ಪರಿಣಾಮಗಳು"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1768
+msgid "_Alert volume:"
+msgstr "ಎಚ್ಚರಿಕೆ ಧ್ವನಿ ಪ್ರಮಾಣ (_A):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1781
+msgid "Applications"
+msgstr "ಅನ್ವಯಗಳು"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1785
+msgid "No application is currently playing or recording audio."
+msgstr "ಯಾವುದೆ ಅನ್ವಯವು ಪ್ರಸ್ತುತ ಧ್ವನಿಯನ್ನು ಚಲಾಯಿಸುತ್ತಿಲ್ಲ."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "ಒಳನಿರ್ಮಿತ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "ಧ್ವನಿಯ ಆದ್ಯತೆಗಳು"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "ಘಟನೆ ಶಬ್ಧವನ್ನು ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "ಪೂರ್ವನಿಯೋಜಿತ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "ಪರಿಸರವಿನ್ಯಾಸದಿಂದ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:770
+msgid "C_hoose an alert sound:"
+msgstr "ಒಂದು ಎಚ್ಚರಿಕೆ ಧ್ವನಿಯನ್ನು ಆರಿಸಿ (_h):"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "ನಿಲ್ಲಿಸು"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "ಪರೀಕ್ಷೆ"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "ಸಬ್‌ವೂಫರ್"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "ಇಚ್ಛೆಯ"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "ನೋಡಲು, ಕೇಳಲು, ಬರೆಯಲು, ತೋರಿಸಲು ಮತ್ತು ಕ್ಲಿಕ್ ಮಾಡಲು ಸುಲಭಗೊಳಿಸು"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"ಕೀಲಿಮಣೆ;ಮೌಸ್;a11y;ನಿಲುಕು;ಕಾಂಟ್ರಾಸ್ಟ್;ಗಾತ್ರಬದಲಾವಣೆ;ತೆರೆ "
+"ಓದುಗ;ಪಠ್ಯ;ಅಕ್ಷರಶೈಲಿ;ಗಾತ್ರ;"
+"AccessX;ಸ್ಟಿಕಿ;ಕೀಲಿಗಳು;ನಿಧಾನಗತಿ;ಪುಟಿಯುವ;ಮೌಸ್‌;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "ಯಾವಾಗಲೂ ಜಾಗತಿಕ ನಿಲುಕಣೆ ಪರಿವಿಡಿಯನ್ನು ತೋರಿಸು (_A)"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "ನೋಡುವಿಕೆ"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "ಅತಿಹೆಚ್ಚು ಕಾಂಟ್ರಾಸ್ಟ್ (_H)"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "ದೊಡ್ಡ ಪಠ್ಯ (_L)"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "_Zoom"
+msgstr "ಹಿಗ್ಗಿಸು (_Z)"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr "ತೆರೆ ಓದುಗ (_R)"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "_Sound Keys"
+msgstr "ಧ್ವನಿ ಕೀಲಿಗಳು (_S)"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "ಆಲಿಸುವಿಕೆ"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr "ವೀಶುವಲ್ ಎಚ್ಚರಿಕೆಗಳು (_V)"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Screen _Keyboard"
+msgstr "ತೆರೆ ಮೇಲಿನ ಕೀಲಿಮಣೆ (_K)"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "_Typing Assist (AccessX)"
+msgstr "ಟೈಪಿಂಗ್ ಸಹಾಯ (_T) (AccessX)"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Pointing & Clicking"
+msgstr "ತೆರೆಸೂಚಕವನ್ನು ಇರಿಸುವಿಕೆ ಮತ್ತು ಕ್ಲಿಕ್ ಮಾಡುವಿಕೆ"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "_Mouse Keys"
+msgstr "ಮೌಸ್ ಕೀಲಿಗಳು (_M)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "ಕ್ಲಿಕ್ ಸಹಾಯ (_C)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "ತೆರೆ ಓದುಗ"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"ನೀವು ಗಮನವನ್ನು ಬದಲಾಯಿಸಿದಂತೆಲ್ಲಾ ತೆರೆಯ ಓದುಗವು ತೋರಿಸಲಾಗುತ್ತಿರುವ ಪಠ್ಯವನ್ನು "
+"ಓದುತ್ತದೆ."
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Screen Reader"
+msgstr "ತೆರೆ ಓದುಗ (_S)"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Sound Keys"
+msgstr "ಧ್ವನಿ ಕೀಲಿಗಳು"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "Num Lock ಅಥವ Caps Lock ಅನ್ನು ಆನ್ ಮಾಡಿದಾಗ ಬೀಪ್ ಶಬ್ಧ ಮಾಡು."
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "ದೃಷ್ಟಿಗೋಚರ ಎಚ್ಚರಿಕೆಗಳು"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "ಪ್ರಾಯೋಗಿಕ ಫ್ಲ್ಯಾಶ್ (_T)"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ಒಂದು ಎಚ್ಚರಿಕೆಯ ಸದ್ದನ್ನು ಮಾಡಿದಾಗ ಒಂದು ಸೂಚನೆಯನ್ನು ತೋರಿಸು."
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Flash the _window title"
+msgstr "ಕಿಟಕಿ ಶೀರ್ಷಿಕೆ ಪಟ್ಟಿಯನ್ನು ಹೊಳೆಯುವಂತೆ ಮಾಡು (_w)"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Flash the entire _screen"
+msgstr "ಸಂಪೂರ್ಣ ತೆರೆಯನ್ನು ಹೊಳೆಯುವಂತೆ ಮಾಡಿ (_s)"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Typing Assist"
+msgstr "ಟೈಪಿಂಗ್ ಸಹಾಯ"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "_Sticky Keys"
+msgstr "ಸ್ಟಿಕಿ ಕೀಲಿಗಳು (_S)"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "ಮಾರ್ಪಡಕ ಕೀಲಿಗಳ ಒಂದು ಸರಣಿಯನ್ನು ಕೀಲಿ ಸಂಯೋಜನೆಯಾಗಿ ಪರಿಗಣಿಸುತ್ತದೆ"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "ಎರಡು ಕೀಲಿಗಳನ್ನು ಒಟ್ಟಿಗೆ ಒತ್ತಿದಲ್ಲಿ ಅಶಕ್ತಗೊಳಿಸು (_D)s"
+
+#: ../panels/universal-access/uap.ui.h:31
+#| msgid "Beep when a _modifer key is pressed"
+msgid "Beep when a _modifier key is pressed"
+msgstr "ಮಾರ್ಪಡಕ ಕೀಲಿಯನ್ನು ಒತ್ತಿದಾಗ ಬೀಪ್ ಶಬ್ಧ ಮಾಡು (_m)"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "S_low Keys"
+msgstr "ನಿಧಾನಗತಿಯ ಕೀಲಿಗಳು (_l)"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"ಕೀಲಿಯನ್ನು ಯಾವಾಗ ಒತ್ತಲಾಗುತ್ತದೆ ಮತ್ತು ಯಾವಾಗ ಅಂಗೀಕರಿಸಲ್ಪಡುತ್ತದೆ ಎನ್ನುವುದರ ನಡುವೆ "
+"ಒಂದು "
+"ವಿಳಂಬವನ್ನು ಸೇರಿಸುತ್ತದೆ"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "ಅಂಗೀಕರಿಸಬಹುದಾದ ವಿಳಂಬ (_c):"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "ಚಿಕ್ಕದಾದ"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "ನಿಧಾನಗತಿಯ ಕೀಲಿಗಳ ನಮೂದಿಸುವ ವಿಳಂಬ"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "ಉದ್ದವಾದ"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Beep when a key is pr_essed"
+msgstr "ಒಂದು ಕೀಲಿಯನ್ನು ಒತ್ತಿದಾಗ ಬೀಪ್ ಶಬ್ಧ ಮಾಡು (_e)"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Beep when a key is _accepted"
+msgstr "ಒಂದು ಕೀಲಿಯು ಅಂಗೀಕರಿಸಿದಾಗ ಬೀಪ್ ಸದ್ದನ್ನು ಮಾಡು (_a)"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "ಒಂದು ಕೀಲಿಯು ತಿರಸ್ಕರಿಸಲ್ಪಟ್ಟಾಗ ಬೀಪ್ ಸದ್ದನ್ನು ಮಾಡು (_r)"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "_Bounce Keys"
+msgstr "ಪುಟಿಯುವ ಕೀಲಿಗಳು (_B)"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "ವೇಗವಾದ ನಕಲಿ ಕೀಲಿಒತ್ತುವಿಕೆಗಳನ್ನು ಕಡೆಗಣಿಸಿ"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "ಚಿಕ್ಕದಾದ"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "ಪುಟಿಕೆ ಕೀಲಿಗಳನ್ನು ನಮೂದಿಸುವಲ್ಲಿ ವಿಳಂಬ"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "ಉದ್ದವಾದ"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Enable by Keyboard"
+msgstr "ಕೀಲಿಮಣೆಯಿಂದ ಸಕ್ರಿಯಗೊಳಿಸು (_E)"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "ಕೀಲಿಮಣೆಯಿಂದ ನಿಲುಕಣಾ ಸವಲತ್ತುಗಳನ್ನು ಆನ್ ಮತ್ತು ಆಫ್ ಮಾಡಿ"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "ಕ್ಲಿಕ್ ಸಹಾಯಕ"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "_Simulated Secondary Click"
+msgstr "ಸಿಮುಲೇಟ್ ಆದ ದ್ವಿತೀಯ ಕ್ಲಿಕ್ (_S)"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "ಪ್ರಾಥಮಿಕ ಗುಂಡಿಯನ್ನು ಒತ್ತಿ ಹಿಡಿಯುವ ಮೂಲಕ ಅಪ್ರಮುಖ ಕ್ಲಿಕ್‌ ಅನ್ನು ಆರಂಭಿಸಿ"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "secondary click"
+msgid "Short"
+msgstr "ಚಿಕ್ಕದಾದ"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "ಅಪ್ರಮುಖ ಕ್ಲಿಕ್ ವಿಳಂಬ"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "ಉದ್ದವಾದ"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "_Hover Click"
+msgstr "ಸುಳಿದಾಡಿಕೆಯ ಕ್ಲಿಕ್ (_H)"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "ಸೂಚಕವನ್ನು ಸುಳಿದಾಡಿಸಿದಾಗ ಕ್ಲಿಕ್‌ ಆಗುವಂತೆ ಮಾಡಿ"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "ವಿಳಂಬ (_e):"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "ಚಿಕ್ಕದಾದ"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "ಉದ್ದವಾದ"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "ಚಲನೆಯ ಮಿತಿ (_T):"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "ಅತಿಚಿಕ್ಕ"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "ಅತಿದೊಡ್ಡ"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "ಕಿರು"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "ತೆರೆಯ ¼"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "ತೆರೆಯ ½"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "ತೆರೆಯ ¾"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "ಉದ್ದ"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "ಪೂರ್ಣ ತೆರೆ"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "ಮೇಲಿನ ಅರ್ಧ"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "ಕೆಳಗಿನ ಅರ್ಧ"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "ಎಡ ಅರ್ಧ"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "ಬಲ ಅರ್ಧ"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "ಹಿಗ್ಗಿಸುವ ಆಯ್ಕೆಗಳು"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "ಹಿಗ್ಗಿಸು"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "ಮ್ಯಾಗ್ನಿಫಿಕೇಶನ್:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "ಮೌಸ್‌ನ ಸೂಚಕವನ್ನು ಅನುಸರಿಸು"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "ತೆರೆಯ ಭಾಗ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "ಮ್ಯಾಗ್ನಿಫಯರ್ ತೆರೆಯ ಹೊರಗೆ ವ್ಯಾಪಿಸುತ್ತದೆ"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವನ್ನು ಮಧ್ಯಕ್ಕೆ ಹೊಂದಿಸು"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವು ವಿಷಯಗಳನ್ನು ಸುತ್ತಲೂ ತಳ್ಳುತ್ತದೆ"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ತೆರೆಸೂಚಕವು ವಿಷಯಗಳೊಂದಿಗೆ ಸ್ಥಳಾಂತರಗೊಳ್ಳುತ್ತದೆ"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್ ಸ್ಥಾನ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "ಮ್ಯಾಗ್ನಿಫೈರ್"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "ದಪ್ಪ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "ತೆಳುವಾದ"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "ದಪ್ಪವಾದ"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "ಉದ್ದ:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "ಬಣ್ಣ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "ಅಡ್ಡಗೆರೆಗಳು:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "ಮೌಸ್‌ನ ತೆರೆಸೂಚಕದ ಮೇಲೆ ಆವರಿಸುತ್ತದೆ"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "ಅಡ್ಡಗೆರೆಗಳು:"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "ಕಪ್ಪು ಬಣ್ಣದಲ್ಲಿ ಬಿಳಿ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "ಪ್ರಕಾಶ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "ವೈದೃಶ್ಯ:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "ಬಣ್ಣ"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "ಸಂಪೂರ್ಣ"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "ಕೆಳ ಮಟ್ಟದ"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "ಉತ್ತಮ"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "ಕೆಳ ಮಟ್ಟದ"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "ಉತ್ತಮ"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "ಬಣ್ಣದ ಪರಿಣಾಮಗಳು:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "ಬಣ್ಣದ ಪರಿಣಾಮಗಳು"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "ಶಿಷ್ಟ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "ವ್ಯವಸ್ಥಾಪಕ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Full Name"
+msgstr "ಪೂರ್ಣ ಹೆಸರು (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "ಖಾತೆಯ ಬಗೆ (_T):"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to set a password when they next login"
+msgstr "ಬಳಕೆದಾರರು ಮುಂದಿನ ಬಾರಿ ಪ್ರವೇಶಿಸಿದಾಗ ಗುಪ್ತಪದವನ್ನು ಹೊಂದಿಸಲು ಅವಕಾಶ ನೀಡು"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "ಈಗಲೆ ಗುಪ್ತಪದವನ್ನು ಹೊಂದಿಸಿ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "ಪರಿಶೀಲಿಸು (_V)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"ಎಂಟರ್‌ಪ್ರೈಸ್‌ ಲಾಗಿನ್ ಈ ಸಾಧನದಲ್ಲಿ ಈಗಿರುವ ಕೇಂದ್ರೀಕೃತ ವ್ಯವಸ್ಥೆಯಲ್ಲಿ ಬಳಕೆದಾರ "
+"ಖಾತೆಯನ್ನು "
+"ನಿರ್ವಹಿಸಲು ಅವಕಾಶ ಒದಗಿಸುತ್ತದೆ."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "ಡೊಮೈನ್ (_D)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"ಎಂಟರ್‌ಪ್ರೈಸ್ ಲಾಗಿನ್‌\n"
+"ಖಾತೆಗಳನ್ನು ಸೇರಿಸಲು ಆನ್‌ಲೈನ್‌ಗೆ ತೆರಳಿ."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "ಎಂಟರ್ಪ್ರೈಸ್ ಪ್ರವೇಶ (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "ಬಳಕೆದಾರರನ್ನು ಸೇರಿಸು"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "ನೋಂದಾಯಿಸು (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "ಡೊಮೈನ್ ವ್ಯವಸ್ಥಾಪಕನ ಪ್ರವೇಶ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"ಎಂಟರ್ಪ್ರೈಸ್ ಲಾಗಿನ್‌ಗಳನ್ನು ಬಳಸಲು, ಈ ಗಣಕವನ್ನು ಡೊಮೈನ್‌ನಲ್ಲಿ\n"
+"ನೋಂದಾಯಿಸಬೇಕಾಗುತ್ತದೆ. ನಿಮ್ಮ ಜಾಲಬಂಧ ವ್ಯವಸ್ಥಾಪಕರು ತಮ್ಮ\n"
+"ಡೊಮೈನ್ ಗುಪ್ತಪದವನ್ನು ಇಲ್ಲಿ ನಮೂದಿಸಲು ಮನವಿ ಮಾಡಿ."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "ವ್ಯವಸ್ಥಾಪಕನ ಹೆಸರು (_N)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "ವ್ಯವಸ್ಥಾಪಕ ಗುಪ್ತಪದ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "ಎಡ ಹೆಬ್ಬೆರಳು"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "ಎಡ ಮಧ್ಯ ಬೆರಳು"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "ಎಡ ಉಂಗುರದ ಬೆರಳು"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "ಎಡ ಕಿರು ಬೆರಳು"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "ಬಲ ಹೆಬ್ಬೆರಳು"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "ಬಲ ಮಧ್ಯ ಬೆರಳು"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "ಬಲ ಉಂಗುರದ ಬೆರಳು"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "ಬಲ ಕಿರು ಬೆರಳು"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:689
+msgid "Enable Fingerprint Login"
+msgstr "ಬೆರಳಗುರುತು ಪ್ರವೇಶವನ್ನು ಶಕ್ತಗೊಳಿಸಿ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "ಬಲ ತೋರು ಬೆರಳು (_R)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "ಎಡ ತೋರು ಬೆರಳು (_L)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "ಇತರೆ ಬೆರಳು (_O): "
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"ನಿಮ್ಮ ಬೆರಳಗುರುತನ್ನು ಯಶಸ್ವಿಯಾಗಿ ಉಳಿಸಲಾಗಿದೆ. ಈಗ ನೀವು ನಿಮ್ಮ ಬೆರಳಗುರುತಿನ "
+"ಓದುಗನನ್ನು "
+"ಬಳಸಿಕೊಂಡು ಪ್ರವೇಶಿಸಬಹುದಾಗಿದೆ."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "ಬಳಕೆದಾರರು"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "ಬಳಕೆದಾರರನ್ನು ಸೇರಿಸಿ ಅಥವ ತೆಗೆದುಹಾಕಿ ಮತ್ತು ಗುಪ್ತಪದವನ್ನು ಬದಲಾಯಿಸಿ"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "ಪ್ರವೇಶ;ಹೆಸರು;ಬೆರಳಗುರುತ;ಅವತಾರ;ಲಾಂಛನ;ಮುಖ;ಗುಪ್ತಪದ;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "ಪ್ರವೇಶದ ಇತಿಹಾಸ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr "ಗುಪ್ತಪದವನ್ನು ಬದಲಾಯಿಸು"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "ಬದಲಾಯಿಸಿ (_a)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "ಹೊಸ ಗುಪ್ತಪದವನ್ನು ಪರಿಶೀಲಿಸು (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "ಹೊಸ ಗುಪ್ತಪದ (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "ಈಗಿನ ಗುಪ್ತಪದ (_P)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ಸೇರಿಸು"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ತೆಗೆದುಹಾಕು"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "ಪ್ರವೇಶದ ಆಯ್ಕೆಗಳು"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "ಸ್ವಯಂಚಾಲಿತ ಪ್ರವೇಶ (_u)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "ಬೆರಳಗುರುತಿನೊಂದಿಗೆ ಪ್ರವೇಶ (_F)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "ಬಳಕೆದಾರನ ಚಿಹ್ನೆ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "ಭಾಷೆ (_L)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "ಕೊನೆಯ ಪ್ರವೇಶ"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "ಬಳಕೆದಾರ ಖಾತೆಗಳನ್ನು ನಿರ್ವಹಿಸಿ"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "ಬಳಕೆದಾರರ ಮಾಹಿತಿಯನ್ನು ಬದಲಾಯಿಸಲು ದೃಢೀಕರಣದ ಅಗತ್ಯವಿದೆ"
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಹಳೆಯದಕ್ಕಿಂತ ಭಿನ್ನವಾಗಿರಬೇಕು."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "ಕೆಲವು ಅಕ್ಷರಗಳು ಮತ್ತು ಅಂಕಿಗಳನ್ನು ಬದಲಾಯಿಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "ಗುಪ್ತಪದವನ್ನು ಇನ್ನಷ್ಟು ಬದಲಾಯಿಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "ನಿಮ್ಮ ಬಳಕೆದಾರ ಹೆಸರು ಇಲ್ಲದ ಗುಪ್ತಪದವು ಸದೃಢವಾಗಿರುತ್ತದೆ."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "ನಿಮ್ಮ ಹೆಸರನ್ನು ಗುಪ್ತಪದದಲ್ಲಿ ಬಳಸದೇ ಇರಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "ಗುಪ್ತಪದದಲ್ಲಿ ಕೆಲವು ಪದಗಳನ್ನು ಬಳಸದೆ ಇರಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "ಸಾಮಾನ್ಯವಾದ ಪದಗಳನ್ನು ಬಳಸಬೇಡಿ."
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "ಈಗಿರುವ ಪದದ ಅಕ್ಷರಗಳನ್ನೆ ಅದಲು ಬದಲು ಮಾಡಿ ಬಳಸಬೇಡಿ."
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "ಹೆಚ್ಚು ಸಂಖ್ಯೆಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "ಹೆಚ್ಚು ದೊಡ್ಡಕ್ಷರಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "ಹೆಚ್ಚು ಸಣ್ಣಕ್ಷರಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "ಹೆಚ್ಚು  ವಿರಾಮ ಚಿಹ್ನೆಗಳಂತಹ ವಿಶೇಷ ಅಕ್ಷರಗಳನ್ನು ಬಳಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ವಿರಾಮಚಿಹ್ನೆಗಳ ಮಿಶ್ರಣವನ್ನು ಬಳಸಿ ನೋಡಿ."
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "ಒಂದೇ ಅಕ್ಷರವನ್ನು ಪುನರಾವರ್ತಿಸುವುದನ್ನು ತಪ್ಪಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"ಒಂದೇ ರೀತಿಯ ಚಿಹ್ನೆಯನ್ನು ಬಳಸುವುದನ್ನು ತಪ್ಪಿಸಲು ಪ್ರಯತ್ನಿಸಿ: ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು "
+"ಮತ್ತು "
+"ವಿರಾಮಚಿಹ್ನೆಗಳ ಮಿಶ್ರಣವನ್ನು ಬಳಸಿ ನೋಡಿ."
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 ಅಥವ abcd ಯಂತಹ ಸರಣಿಯನ್ನು ಬಳಸಬೇಡಿ."
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "ಹೆಚ್ಚು ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ಸಂಕೇತಗಳನ್ನು ಸೇರಿಸಲು ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr ""
+"ದೊಡ್ಡಕ್ಷರ ಮತ್ತು ಸಣ್ಣಕ್ಷರವನ್ನು ಜೊತೆಗೆ ಬಳಸಿ ಮತ್ತು ಒಂದು ಅಥವ ಎರಡು ಸಂಖ್ಯೆಯನ್ನು "
+"ಬಳಸಿ."
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+"ಉತ್ತಮವಾದ ಗುಪ್ತಪದ! ಹೆಚ್ಚಿನ ಅಕ್ಷರಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ವಿರಾಮಚಿಹ್ನೆಗಳನ್ನು "
+"ಸೇರಿಸುವುದರಿಂದ "
+"ಇದು ಇನ್ನಷ್ಟು ಬಲಗೊಳ್ಳುತ್ತದೆ."
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "ಬಲಿಷ್ಟತೆ: ದುರ್ಬಲ"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "ಬಲಿಷ್ಟತೆ: ಕಡಿಮೆ"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "ಬಲಿಷ್ಟತೆ: ಮಧ್ಯಮ"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "ಬಲಿಷ್ಟತೆ: ಉತ್ತಮ"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "ಬಲಿಷ್ಟತೆ: ಅತ್ಯುತ್ತಮ"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "ದೃಢೀಕರಣ ವಿಫಲಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಬಹಳ ಚಿಕ್ಕದಾಗಿದೆ"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಬಹಳ ಸರಳವಾಗಿದೆ."
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "ಹೊಸ ಹಾಗು ಹಳೆಯ ಗುಪ್ತಪದಗಳು ಒಂದನ್ನೊಂದು ಬಹಳ ಹೋಲುತ್ತವೆ"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "ಹೊಸ ಗುಪ್ತಪದವನ್ನು ಈಗಾಗಲೆ ಇತ್ತೀಚೆಗೆ ಬಳಸಲಾಗಿದೆ."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಒಂದು ಅಂಕೆ ಅಥವ ವಿಶೇಷ ಅಕ್ಷರಗಳನ್ನು ಹೊಂದಿರಲೇಬೇಕು"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "ಹೊಸ ಹಾಗು ಹಳೆಯ ಗುಪ್ತಪದಗಳು ಒಂದೇ ಆಗಿವೆ"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "ನಿಮ್ಮ ಗುಪ್ತಪದವನ್ನು ನೀವು ಆರಂಭದಲ್ಲಿ ದೃಢೀಕರಿಸಿದ ನಂತರ ಬದಲಾಯಿಸಲ್ಪಟ್ಟಿದೆ!"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಸಾಕಷ್ಟು ವಿಭಿನ್ನ ಅಕ್ಷರಗಳನ್ನು ಹೊಂದಿಲ್ಲ"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "ಗೊತ್ತಿಲ್ಲದ ದೋಷ"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "ನಿಮ್ಮ ಖಾತೆ ಒದಗಿಸುವವರ ಜಾಲ ವಿಳಾಸಕ್ಕೆ ಹೊಂದಿಕೆಯಾಗಬೇಕು."
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "ಖಾತೆಯನ್ನು ಸೇರಿಸಲು ವಿಫಲಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+msgid "Passwords do not match."
+msgstr "ಗುಪ್ತಪದಗಳು ಒಂದೇ ಸಮನಾಗಿಲ್ಲ."
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr "ಖಾತೆಯನ್ನು ನೋಂದಾಯಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr "ಈ ಡೊಮೈನ್‌ನೊಂದಿಗೆ ದೃಢೀಕರಿಸಲು ಯಾವುದೆ ಮಾರ್ಗವಿಲ್ಲ"
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr "ಡೊಮೈನ್ ಅನ್ನು ಸೇರುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"ಆ ಲಾಗಿನ್ ಹೆಸರು ಕೆಲಸ ಮಾಡುತ್ತಿಲ್ಲ.\n"
+"ದಯವಿಟ್ಟು ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"ಆ ಲಾಗಿನ್ ಗುಪ್ತಪದ ಕೆಲಸ ಮಾಡುತ್ತಿಲ್ಲ.\n"
+"ದಯವಿಟ್ಟು ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ."
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr "ಡೊಮೈನ್ ಅನ್ನು ಪ್ರವೇಶಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "ಡೊಮೇನ್‌ ಕಂಡುಬಂದಿಲ್ಲ. ಬಹುಷಃ ನೀವು ತಪ್ಪಾಗಿ ನಮೂದಿಸಿರಬೇಕು?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:138
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"ನೀವು ಈ ಸಾಧನವನ್ನು ನಿಲುಕಿಸಿಕೊಳ್ಳುವಂತಿಲ್ಲ. ನಿಮ್ಮ ಗಣಕ ವ್ಯವಸ್ಥಾಪಕರನ್ನು ಸಂಪರ್ಕಿಸಿ."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:140
+msgid "The device is already in use."
+msgstr "ಸಾಧನವು ಈಗಾಗಲೆ ಬಳಕೆಯಲ್ಲಿದೆ."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid "An internal error occurred."
+msgstr "ಒಂದು ಆಂತರಿಕ ದೋಷ ಸಂಭವಿಸಿದೆ."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Enabled"
+msgstr "ಸಕ್ರಿಯಗೊಂಡ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr "ನೋಂದಾಯಿಸಲಾದ ಬೆರಳಗುರುತುಗಳನ್ನು ಅಳಿಸಬೇಕೆ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr "ಬೆರಳಗುರುತುಗಳನ್ನು ಅಳಿಸು (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"ನೀವು ನೋಂದಾಯಿಸಲಾದ ಬೆರಳಗುರುತುಗಳನ್ನು ಅಳಿಸಿ ಆ ಮೂಲಕ ಬೆರಳಗುರುತಿನ ಪ್ರವೇಶವನ್ನು "
+"ಅಶಕ್ತಗೊಳಿಸಲು ಬಯಸುತ್ತೀರೆ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:446
+msgid "Done!"
+msgstr "ಆಯಿತು!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:507
+#: ../panels/user-accounts/um-fingerprint-dialog.c:549
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' ಸಾಧನವನ್ನು ನಿಲುಕಿಸಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:590
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr ""
+"'%s' ಸಾಧನದಲ್ಲಿ ಬೆರಳಿನ ಗುರುತನ್ನು ತೆಗೆದುಕೊಳ್ಳುವುದನ್ನು ಆರಂಭಿಸು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:640
+msgid "Could not access any fingerprint readers"
+msgstr "ಯಾವುದೆ ಬೆರಳಗುರುತು ಓದುಗನನ್ನು ನಿಲುಕಿಸಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:641
+msgid "Please contact your system administrator for help."
+msgstr "ನೆರವಿಗಾಗಿ ನಿಮ್ಮ ಗಣಕ ವ್ಯವಸ್ಥಾಪಕರನ್ನು ಕೇಳಿ."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:723
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"ಬೆರಳಗುರುತಿನ ಪ್ರವೇಶವನ್ನು ಶಕ್ತಗೊಳಿಸಲು, '%s' ಸಾಧನವನ್ನು ಬಳಸಿಕೊಂಡು ನೀವು ನಿಮ್ಮ "
+"ಬೆರಳಗುರುತುಗಳನ್ನು ಉಳಿಸಬೇಕಾಗುತ್ತದೆ."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+msgid "Selecting finger"
+msgstr "ಬೆರಳನ್ನು ಆರಿಸುವಿಕೆ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:731
+msgid "Enrolling fingerprints"
+msgstr "ಬೆರಳಗುರುತುಗಳನ್ನು ದಾಖಲಿಸುವಿಕೆ"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "ಈ ವಾರ"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "ಹಿಂದಿನ ವಾರ"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:844
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:848
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "ಅಧಿವೇಶನ ಕೊನೆಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "ಅಧಿವೇಶನ ಆರಂಭಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "ದಯವಿಟ್ಟು ಬೇರೊಂದು ಗುಪ್ತಪದವನ್ನು ಆರಿಸಿ."
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "ದಯವಿಟ್ಟು ನಿಮ್ಮ ಈಗಿನ ಗುಪ್ತಪದವನ್ನು ಇನ್ನೊಮ್ಮೆ ದಾಖಲಿಸಿ."
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "ಗುಪ್ತಪದವನ್ನು ಬದಲಾಯಿಸಲಾಗಿಲ್ಲ."
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "The passwords do not match."
+msgstr "ಗುಪ್ತಪದಗಳು ಹೊಂದಿಕೆಯಾಗುತ್ತಿಲ್ಲ."
+
+#: ../panels/user-accounts/um-photo-dialog.c:214
+msgid "Browse for more pictures"
+msgstr "ಹೆಚ್ಚಿನ ಚಿತ್ರಗಳಿಗಾಗಿ ನೋಡು"
+
+#: ../panels/user-accounts/um-photo-dialog.c:448
+msgid "Disable image"
+msgstr "ಚಿತ್ರವನ್ನು ಅಶಕ್ತಗೊಳಿಸು"
+
+#: ../panels/user-accounts/um-photo-dialog.c:466
+msgid "Take a photo…"
+msgstr "ಒಂದು ಚಿತ್ರವನ್ನು ತೆಗೆದುಕೊಳ್ಳಿ..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:484
+msgid "Browse for more pictures…"
+msgstr "ಹೆಚ್ಚಿನ ಚಿತ್ರಗಳಿಗಾಗಿ ನೋಡು…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:708
+#, c-format
+msgid "Used by %s"
+msgstr "%s ಇಂದ ಬಳಸಲಾಗಿದೆ"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "ಈ ಬಗೆಯ ಡೊಮೇನ್‌ ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸೇರಿಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "ಯಾವುದೆ ಅಂತಹ ಡೊಮೈನ್ ಅಥವ ಕ್ಷೇತ್ರ ಕಂಡುಬಂದಿಲ್ಲ"
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s ಎಂದು %s ಡೊಮೈನಿನಲ್ಲಿ ಪ್ರವೇಶಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ"
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr "ಗುಪ್ತಪದ ತಪ್ಪಾಗಿದೆ; ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ"
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "%s ಡೊಮೈನ್‌ಗೆ ಸಂಪರ್ಕಿತಗೊಳಿಸಲಾಗಿಲ್ಲ: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:239
+msgid "Other Accounts"
+msgstr "ಇತರೆ ಖಾತೆಗಳು"
+
+#: ../panels/user-accounts/um-user-panel.c:453
+msgid "Failed to delete user"
+msgstr "ಬಳಕೆದಾರನನ್ನು ಅಳಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/um-user-panel.c:513
+#: ../panels/user-accounts/um-user-panel.c:569
+#: ../panels/user-accounts/um-user-panel.c:621
+#| msgid "Failed to delete user"
+msgid "Failed to revoke remotely managed user"
+msgstr "ದೂರದಿಂದ ನೋಡಿಕೊಳ್ಳಲಾಗುವ ಬಳಕೆದಾರನನ್ನು ರದ್ದುಗೊಳಿಸುವಲ್ಲಿ ವಿಫಲಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/um-user-panel.c:677
+msgid "You cannot delete your own account."
+msgstr "ನೀವು ನಿಮ್ಮದೆ ಖಾತೆಯನ್ನು ಅಳಿಸಲು ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ"
+
+#: ../panels/user-accounts/um-user-panel.c:686
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ಇನ್ನೂ ಸಹ ಒಳಗಿದ್ದಾರೆ"
+
+#: ../panels/user-accounts/um-user-panel.c:690
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"ಬಳಕೆದಾರರು ಒಳಗೆ ಪ್ರವೇಶಿಸಿದಾಗ ಅವರನ್ನು ಅಳಿಸುವುದರಿಂದ ವ್ಯವಸ್ಥೆಯು ಒಂದು ಅಸ್ಥಿರ "
+"ಸ್ಥಿತಿಯಲ್ಲಿ "
+"ಇರಿಸುತ್ತದೆ."
+
+#: ../panels/user-accounts/um-user-panel.c:699
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "ನೀವು %s ರವರ ಕಡತಗಳನ್ನು ಇರಿಸಿಕೊಳ್ಳಲು ಬಯಸುವಿರಾ?"
+
+#: ../panels/user-accounts/um-user-panel.c:703
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"ಬಳಕೆದಾರರ ಖಾತೆಯನ್ನು ಅಳಿಸುವಾಗ ನೆಲೆ ಕೋಶವನ್ನು, ಅಂಚೆ ಸ್ಪೂಲ್ ಅನ್ನು ಮತ್ತು ತಾತ್ಕಾಲಿಕ "
+"ಕಡತಗಳನ್ನು ಹಾಗೆಯೆ ಇರಿಸಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಿರುತ್ತದೆ."
+
+#: ../panels/user-accounts/um-user-panel.c:706
+msgid "_Delete Files"
+msgstr "ಕಡತಗಳನ್ನು ಅಳಿಸು (_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:707
+msgid "_Keep Files"
+msgstr "ಕಡತಗಳನ್ನು ಇರಿಸಿಕೊ (_K)"
+
+#: ../panels/user-accounts/um-user-panel.c:721
+#, c-format
+#| msgid "Are you sure you want to remove the account?"
+msgid "Are you sure you want to revoke remotely managed %s's account?"
+msgstr "ದೂರದಿಂದ ನೋಡಿಕೊಳ್ಳಲಾಗುವ %s ನ ಖಾತೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲು ನೀವು ಖಚಿತವೆ?"
+
+#: ../panels/user-accounts/um-user-panel.c:725
+#| msgid "_Delete Files"
+msgid "_Delete"
+msgstr "ಅಳಿಸು (_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:777
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "ಖಾತೆಯನ್ನು ಅಶಕ್ತಗೊಳಿಸಲಾಗಿದೆ"
+
+#: ../panels/user-accounts/um-user-panel.c:785
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "ಮುಂದಿನ ಬಾರಿ ಪ್ರವೇಶಿಸಿದಾಗ ಹೊಂದಿಸಲಾಗುತ್ತದೆ"
+
+#: ../panels/user-accounts/um-user-panel.c:788
+msgctxt "Password mode"
+msgid "None"
+msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#: ../panels/user-accounts/um-user-panel.c:837
+msgid "Logged in"
+msgstr "ಪ್ರವೇಶಿಸಲಾಗಿದೆ"
+
+#: ../panels/user-accounts/um-user-panel.c:1269
+msgid "Failed to contact the accounts service"
+msgstr "ಖಾತೆಗಳ ಸೇವೆಯನ್ನು ಸಂಪರ್ಕಿಸಲು ವಿಫಲಗೊಂಡಿದೆ"
+
+#: ../panels/user-accounts/um-user-panel.c:1271
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"AccountService ಅನ್ನು ಅನುಸ್ಥಾಪಿಸಲಾಗಿದೆಯೆ ಮತ್ತು ಸಕ್ರಿಯಗೊಂಡಿದೆಯೆ ಎಂದು "
+"ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ."
+
+#: ../panels/user-accounts/um-user-panel.c:1312
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"ಬದಲಾವಣೆಗಳನ್ನು ಮಾಡಲು,\n"
+"* ಚಿಹ್ನೆಯ ಮೇಲೆ ಮೊದಲು ಕ್ಲಿಕ್ ಮಾಡಿ"
+
+#: ../panels/user-accounts/um-user-panel.c:1350
+msgid "Create a user account"
+msgstr "ಬಳಕೆದಾರನನ್ನು ರಚಿಸು"
+
+#: ../panels/user-accounts/um-user-panel.c:1361
+#: ../panels/user-accounts/um-user-panel.c:1674
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ರಚಿಸಲು,\n"
+"ಮೊದಲು * ಚಿಹ್ನೆಯ ಮೇಲೆ ಕ್ಲಿಕ್ ಮಾಡಿ"
+
+#: ../panels/user-accounts/um-user-panel.c:1371
+msgid "Delete the selected user account"
+msgstr "ಆಯ್ದ ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ಅಳಿಸಿ"
+
+#: ../panels/user-accounts/um-user-panel.c:1383
+#: ../panels/user-accounts/um-user-panel.c:1679
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"ಆಯ್ದ ಬಳಕೆದಾರ ಖಾತೆಯನ್ನು ಅಳಿಸಲು,\n"
+"ಮೊದಲು * ಚಿಹ್ನೆಯ ಮೇಲೆ ಕ್ಲಿಕ್ ಮಾಡಿ"
+
+#: ../panels/user-accounts/um-user-panel.c:1588
+msgid "My Account"
+msgstr "ನನ್ನ ಖಾತೆ"
+
+#: ../panels/user-accounts/um-utils.c:563
+#, c-format
+msgid "A user with the username '%s' already exists."
+msgstr "'%s' ಎಂಬ ಹೆಸರಿನ ಒಬ್ಬ ಬಳಕೆದಾರ ಈಗಾಗಲೆ ಅಸ್ತಿತ್ವದಲ್ಲಿದ್ದಾರೆ."
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+msgid "The username is too long."
+msgstr "ಬಳಕೆದಾರ ಹೆಸರು ಬಹಳ ಉದ್ದವಾಗಿದೆ."
+
+#: ../panels/user-accounts/um-utils.c:570
+msgid "The username cannot start with a '-'."
+msgstr "ಬಳಕೆದಾರ ಹೆಸರು '-' ಇಂದ ಆರಂಭಗೊಳ್ಳುವಂತಿಲ್ಲ."
+
+#: ../panels/user-accounts/um-utils.c:573
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"ಬಳಕೆದಾರ ಹೆಸರು ಕೇವಲ a-z ವರೆಗಿನ ಅಕ್ಷರಗಳು, ಅಂಕಿಗಳು, ಮತ್ತು '.', '-' ಹಾಗು '_' "
+"ನಲ್ಲಿ "
+"ಒಂದಾದರೂ ಚಿಹ್ನೆಗಳನ್ನು ಮಾತ್ರ ಹೊಂದಿರಬೇಕು."
+
+#: ../panels/user-accounts/um-utils.c:577
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+"ಇದನ್ನು ನಿಮ್ಮ ನೆಲೆ ಕೋಶವನ್ನು ಹೆಸರಿಸಲು ಬಳಸಲಾಗುತ್ತದೆ ಮತ್ತು ಬದಲಾಯಿಸಲು "
+"ಸಾಧ್ಯವಿರುವುದಿಲ್ಲ."
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:823
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "ಮ್ಯಾಪ್ ಗುಂಡಿಗಳು"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr "ಕಾರ್ಯಭಾರಗಳ ಮ್ಯಾಪ್ ಗುಂಡಿಗಳು"
+
+#: ../panels/wacom/button-mapping.ui.h:4
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ಒಂದು ಸಮೀಪಮಾರ್ಗ ಕೀಲಿಯನ್ನು ಸಂಪಾದಿಸಲು, \"ಕೀಲಿಹೊಡೆತವನ್ನು ಕಳುಹಿಸು\" ಕ್ರಿಯೆಯನ್ನು "
+"ಆರಿಸಿ, "
+"ಕೀಲಿಮಣೆ ಸಮೀಪಮಾರ್ಗ ಗುಂಡಿಯನ್ನು ಒತ್ತಿ ನಂತರ ಹೊಸ ಕೀಲಿಗಳನ್ನು ಒತ್ತಿಹಿಡಿಯಿರಿ ಅಥವ "
+"ಅಳಿಸಲು "
+"ಬ್ಯಾಕ್‍ಸ್ಪೇಸನ್ನು ಒತ್ತಿ."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"ಟ್ಯಾಬ್ಲೆಟ್ ಅನ್ನು ಕ್ಯಾಲಿಬ್ರೇಟ್ ಮಾಡಲು ತೆರೆಯ ಮೇಲೆ ಗುರಿಯ ಗುರುತುಗಳು ಕಾಣಿಸಿಕೊಂಡಾಗ "
+"ಅವುಗಳ "
+"ಮೇಲೆ ಮೆಲ್ಲಗೆ ತಟ್ಟಿ."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "ತಪ್ಪು-ಕ್ಲಿಕ್ ಕಂಡುಬಂದಿದೆ, ಮರಳಿ ಆರಂಭಿಸಲಾಗುತ್ತಿದೆ..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "ಮೇಲೆ"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "ಕೆಳಕ್ಕೆ"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "ಕೀಲಿಹೊಡೆತವನ್ನು ಕಳುಹಿಸು"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "ತೆರೆಯನ್ನು ಬದಲಿಸು"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "ತೆರೆಯ ಮೇಲಣ ನೆರವನ್ನು ತೋರಿಸು"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "ಔಟ್‌ಪುಟ್:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "ರೂಪದ ಅನುಪಾತವನ್ನು ಹಾಗೆಯೆ ಇರಿಸಿಕೊ (ಓಲೆಪೆಟ್ಟಿಗೆ):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "ಒಂದು ತೆರೆಗೆ ಮ್ಯಾಪ್ ಮಾಡು"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d, %d ರಲ್ಲಿ"
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "ಪ್ರದರ್ಶಕ ಮ್ಯಾಪಿಂಗ್"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "ಗುಂಡಿ"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Wacom Tablet"
+msgstr "ವೇಕಾಮ್ ಕಿಸೆಗಣಕ (ಟ್ಯಾಬ್ಲೆಟ್)"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"ಗ್ರಾಫಿಕ್ಸ್ ಟ್ಯಾಬ್ಲೆಟ್‌ಗಳಿಗಾಗಿ ಗುಂಡಿಯ ಮ್ಯಾಪಿಂಗ್ ಅನ್ನು ಹೊಂದಿಸಿ ಮತ್ತು ಸ್ಟೈಲಸ್ "
+"ಸಂವೇದಿಸೂಕ್ಷ್ಮತೆಯನ್ನು ಹೊಂದಿಸಿ"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "ಟ್ಯಾಬ್ಲೆಟ್;ವೇಕಾಮ್;ಸ್ಟೈಲಸ್;ಉಜ್ಜುಗ;ಮೌಸ್;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "ಟ್ಯಾಬ್ಲೆಟ್ (ಪರಿಪೂರ್ಣ)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "ಟಚ್‌ಪ್ಯಾಡ್ (ತುಲನಾತ್ಮಕ)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "ಕಿಸಗಣಕದ ಆದ್ಯತೆಗಳು"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "No tablet detected"
+msgstr "ಯಾವುದೆ ಕಿಸೆಗಣಕವು (ಟ್ಯಾಬ್ಲೆಟ್) ಕಂಡುಬಂದಿಲ್ಲ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr ""
+"ನಿಮ್ಮ ವೇಕಾಮ್ ಕಿಸೆಗಣಕದೊಂದಿಗೆ (ಟ್ಯಾಬ್ಲೆಟ್) ಸಂಪರ್ಕಜೋಡಿಸಿ ಅಥವ ಅದನ್ನು ಚಾಲನೆಗೊಳಿಸಿ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Bluetooth Settings"
+msgstr "ಬ್ಲೂಟೂತ್ ಸಿದ್ಧತೆಗಳು"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map to Monitor…"
+msgstr "ತೆರೆಗೆ ಮ್ಯಾಪ್ ಮಾಡು..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map Buttons…"
+msgstr "ಗುಂಡಿಗಳನ್ನು ಮ್ಯಾಪ್ ಮಾಡು"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust display resolution"
+msgstr "ಪ್ರದರ್ಶಕದ ರೆಸಲ್ಯೂಶನ್ ಅನ್ನು ಸರಿಹೊಂದಿಸು"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust mouse settings"
+msgstr "ಮೌಸ್‌ನ ಸಿದ್ಧತೆಗಳನ್ನು ಸರಿಹೊಂದಿಸು"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Tracking Mode"
+msgstr "ಜಾಡು ಇರಿಸುವ ಕ್ರಮ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Left-Handed Orientation"
+msgstr "ಎಡ-ಭಾಗದ ವಾಲಿಕೆ"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+msgid "Left Ring"
+msgstr "ಎಡ ರಿಂಗ್"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "ಎಡ ರಿಂಗ್ ವಿಧಾನ #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+msgid "Right Ring"
+msgstr "ಬಲ ರಿಂಗ್"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "ಬಲ ರಿಂಗ್ ವಿಧಾನ #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+msgid "Left Touchstrip"
+msgstr "ಎಡ ಟಚ್‌ಸ್ಟ್ರಿಪ್"
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "ಎಡ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+msgid "Right Touchstrip"
+msgstr "ಬಲ ಟಚ್‌ಸ್ಟ್ರಿಪ್"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "ಬಲ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "ಎಡ ಟಚ್‌ರಿಂಗ್ ವಿಧಾನ ಬದಲಾವಣೆ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "ಬಲ ಟಚ್‌ರಿಂಗ್ ವಿಧಾನ ಬದಲಾವಣೆ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "ಎಡ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ ಬದಲಾವಣೆ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "ಬಲ ಟಚ್‌ಸ್ಟ್ರಿಪ್ ವಿಧಾನ ಬದಲಾವಣೆ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "ವಿಧಾನದ ಬದಲಾವಣೆ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr "ಎಡ ಗುಂಡಿ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr "ಬಲ ಗುಂಡಿ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr "ಮೇಲಿನ ಗುಂಡಿ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "ಕೆಳಗಿನ ಗುಂಡಿ #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "ಹೊಸ ಸಮೀಪಮಾರ್ಗ..."
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "ಯಾವುದೆ ಕ್ರಿಯೆಯಿಲ್ಲ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "ಮೌಸ್‌ನ ಎಡ ಗುಂಡಿಯ ಕ್ಲಿಕ್"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "ಮೌಸ್‌ನ ಮಧ್ಯ ಗುಂಡಿಯ ಕ್ಲಿಕ್"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "ಮೌಸ್‌ನ ಬಲ ಗುಂಡಿಯ ಕ್ಲಿಕ್"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "ಮೇಲಕ್ಕೆ ಚಲಿಸು"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "ಕೆಳಕ್ಕೆ ಚಲಿಸು"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "ಎಡಕ್ಕೆ ಚಲಿಸು"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "ಬಲಕ್ಕೆ ಚಲಿಸು"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "ಹಿಂದಕ್ಕೆ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "ಮುಂದಕ್ಕೆ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "ಸ್ಟೈಲಸ್"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "ಉಜ್ಜುಗದ ಒತ್ತಡದ ಅನುಭವ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "ಮೃದು"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "ಭದ್ರ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "ಮೇಲಿನ ಗುಂಡಿ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "ಕೆಳಗಿನ ಗುಂಡಿ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "ತುದಿಯ ಒತ್ತಡದ ಅನುಭವ"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "ವರ್ಬೋಸ್ ಕ್ರಮವನ್ನು ಶಕ್ತಗೊಳಿಸಿ"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "ಅವಲೋಕನವನ್ನು ತೋರಿಸು"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "ವಾಕ್ಯಾಂಶಕ್ಕಾಗಿ ಹುಡುಕು"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "ಸಾಧ್ಯವಿರುವ ಫಲಕದ ಹೆಸರುಗಳನ್ನು ಪಟ್ಟಿ ಮಾಡಿ ನಿರ್ಗಮಿಸು"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "ಸಹಾಯ ಆಯ್ಕೆಯನ್ನು ತೋರಿಸು"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "ತೋರಿಸಬೇಕಿರುವ ಫಲಕ"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- ಸಿದ್ಧತೆಗಳು"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"ಲಭ್ಯವಿರುವ ಎಲ್ಲಾ ಆಜ್ಞಾ ಸಾಲಿನ ಆಯ್ಕೆಗಳನ್ನು ನೋಡಲು '%s --help' ಅನ್ನು ಚಲಾಯಿಸಿ.\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "ಲಭ್ಯವಿರುವ ಪ್ಯಾನಲ್‌ಗಳು:"
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "ನೆರವು"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "ನಿರ್ಗಮಿಸು"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1493
+msgid "All Settings"
+msgstr "ಎಲ್ಲಾ ಸಿದ್ಧತೆಗಳು"
+
+#. Add categories
+#: ../shell/cc-window.c:879
+msgctxt "category"
+msgid "Personal"
+msgstr "ವೈಯಕ್ತಿಕ"
+
+#: ../shell/cc-window.c:880
+msgctxt "category"
+msgid "Hardware"
+msgstr "ಯಂತ್ರಾಂಶ"
+
+#: ../shell/cc-window.c:881
+msgctxt "category"
+msgid "System"
+msgstr "ವ್ಯವಸ್ಥೆ"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "ಆದ್ಯತೆಗಳು;ಸಿದ್ಧತೆಗಳು;"
+
+#~ msgid "United States"
+#~ msgstr "ಯುನೈಟೆಡ್ ಸ್ಟೇಟ್ಸ್‍"
+
+#~ msgid "Germany"
+#~ msgstr "ಜರ್ಮನಿ"
+
+#~ msgid "France"
+#~ msgstr "ಫ್ರಾನ್ಸ್‍"
+
+#~ msgid "Spain"
+#~ msgstr "ಸ್ಪೇನ್"
+
+#~ msgid "China"
+#~ msgstr "ಚೈನಾ"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "ಹೊಸ ಸಾಧನವನ್ನು ಸಿದ್ಧಗೊಳಿಸು"
+
+#~ msgid "Connection"
+#~ msgstr "ಸಂಪರ್ಕ"
+
+#~ msgid "Paired"
+#~ msgstr "ಜೋಡಿಸಿದ"
+
+#~ msgid "Type"
+#~ msgstr "ಬಗೆ"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "ಮೌಸ್‌ ಮತ್ತು ಟಚ್‌ಪ್ಯಾಡ್ ಸಿದ್ಧತೆಗಳು"
+
+#~ msgid "Sound Settings"
+#~ msgstr "ಧ್ವನಿ ಸಿದ್ಧತೆಗಳು"
+
+#~ msgid "Send Files…"
+#~ msgstr "ಕಡತಗಳನ್ನು ಕಳುಹಿಸು…"
+
+#~ msgid "Visibility"
+#~ msgstr "ಗೋಚರಿಕೆ"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” ನ ಗೋಚರಿಕೆ"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "'%s' ಅನ್ನು ಸಾಧನಗಳ ಪಟ್ಟಿಯಿಂದ ತೆಗೆದುಹಾಕಬೇಕೆ?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "ನೀವು ಈ ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕಿದಲ್ಲಿ, ಮುಂದಿನ ಬಾರಿ ಬಳಸುವ ಮೊದಲು ಇದನ್ನು ಪುನಃ "
+#~ "ಇನ್ನೊಮ್ಮೆ ಸಿದ್ಧಗೊಳಿಸಬೇಕಾಗುತ್ತದೆ."
+
+#~ msgid "Export"
+#~ msgstr "ರಫ್ತು"
+
+#~ msgid "Device type:"
+#~ msgstr "ಸಾಧನದ ಬಗೆ:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "ತಯಾರಕರು:"
+
+#~ msgid "Model:"
+#~ msgstr "ಮಾದರಿ:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "ಮೇಲಿನ ಸ್ಥಳಗಳನ್ನು ಸ್ವಯಂ ಪೂರ್ಣಗೊಳ್ಳುವಂತೆ ಮಾಡಲು ಚಿತ್ರಗಳ ಕಡತಗಳನ್ನು ಈ ಕಿಟಕಿಗೆ "
+#~ "ಸೇರಿಸಬಹುದು"
+
+#~ msgid "Left Shift"
+#~ msgstr "ಎಡ Shift"
+
+#~ msgid "Left Alt"
+#~ msgstr "ಎಡ Alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "ಎಡ Ctrl"
+
+#~ msgid "Right Shift"
+#~ msgstr "ಬಲ Shift"
+
+#~ msgid "Right Alt"
+#~ msgstr "ಬಲ Alt"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "ಬಲ Ctrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "ಎಡ Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "ಎಡ Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "ಬಲ Ctrl+Shift"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "ಕ್ಯಾಪ್ಸ್"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+ಕ್ಯಾಪ್ಸ್‍"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+ಕ್ಯಾಪ್ಸ್"
+
+#~ msgid "_Region:"
+#~ msgstr "ಪ್ರದೇಶ (_R):"
+
+#~ msgid "_City:"
+#~ msgstr "ಊರು (_C):"
+
+#~ msgid "_Network Time"
+#~ msgstr "ಜಾಲಬಂಧ ಸಮಯ (_N)"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "ಗಂಟೆಯನ್ನು ಒಂದು ಗಂಟೆ ಮುಂದಕ್ಕೆ ಹೊಂದಿಸಿ."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "ಗಂಟೆಯನ್ನು ಒಂದು ಗಂಟೆ ಹಿಂದಕ್ಕೆ ಹೊಂದಿಸಿ."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "ಗಂಟೆಯನ್ನು ಒಂದು ನಿಮಿಷ ಮುಂದಕ್ಕೆ ಹೊಂದಿಸಿ."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "ಗಂಟೆಯನ್ನು ಒಂದು ನಿಮಿಷ ಹಿಂದಕ್ಕೆ ಹೊಂದಿಸಿ."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM ಮತ್ತು PM ನಡುವೆ ಬದಲಾಯಿಸು."
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "ಸಾಮಾನ್ಯ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "ಅಪ್ರದಕ್ಷಿಣೆ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "ಪ್ರದಕ್ಷಿಣೆ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 ಡಿಗ್ರಿಗಳು"
+
+#~ msgid "Monitor"
+#~ msgstr "ಪರದೆ"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "ಪ್ರಾಥಮಿಕ ಪ್ರದರ್ಶಕವನ್ನು ಬದಲಾಯಿಸಲು ಎಳೆಯಿರಿ."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "ಒಂದು ತೆರೆಯ ಗುಣಗಳನ್ನು ಬದಲಾಯಿಸಲು ಅದನ್ನು ಆಯ್ಕೆ ಮಾಡಿ; ಅದರ ಸ್ಥಾನವನ್ನು ಬದಲಾಯಿಸಲು "
+#~ "ಅದನ್ನು ಎಳೆಯಿರಿ."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "ತೆರೆಯ ಸಂರಚನೆಯನ್ನು ಉಳಿಸಲು ಆಗಲಿಲ್ಲ"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "ಪ್ರದರ್ಶಕಗಳನ್ನು ಪತ್ತೆ ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
+
+#~ msgid "_Resolution"
+#~ msgstr "ರೆಸಲ್ಯೂಶನ್ (_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "ತಿರುಗಿಸುವಿಕೆ (_o)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "ಪ್ರತಿಬಿಂಬಿತ ಪ್ರದರ್ಶಕಗಳು (_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "ಸೂಚನೆ: ರೆಸಲ್ಯೂಶನ್ ಆಯ್ಕೆಗಳನ್ನು ಮಿತಿಗೊಳಿಸಬಹುದು"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "ಪ್ರದರ್ಶಕಗಳನ್ನು ಪತ್ತೆ ಮಾಡು (_D)"
+
+#~ msgid "Install Updates"
+#~ msgstr "ಅಪ್‌ಡೇಟ್‌ಗಳನ್ನು ಅನುಸ್ಥಾಪಿಸು"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "ವ್ಯವಸ್ಥೆಯು ಅಪ್-ಟು-ಡೇಟ್ ಆಗಿದೆ"
+
+# translation auto-copied from project control-center, version 3.8.3, document gnome-control-center-2.0, author Shankar
+#~ msgid "OS Type"
+#~ msgstr "OS ಬಗೆ"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "ಮೌಸ್ ಆದ್ಯತೆಗಳು"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "ನಿಧಾನ"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "ವೇಗ"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "ವಿಷಯಗಳು ಬೆರಳಿಗೆ ಅಂಟಿಕೊಳ್ಳುತ್ತವೆ (_o)"
+
+#~ msgid "_Options…"
+#~ msgstr "ಆಯ್ಕೆಗಳು (_O)…"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "ಹೊಸ ಸೇವೆಯಲ್ಲಿ ಬಳಸಬೇಕಿರುವ ಸಂಪರ್ಕಸಾಧನವನ್ನು ಆರಿಸಿ"
+
+#~ msgid "C_reate…"
+#~ msgstr "ರಚಿಸು (_r)…"
+
+#~ msgid "_Interface"
+#~ msgstr "ಸಂಪರ್ಕಸಾಧನ (_I)"
+
+#~ msgid "_Default"
+#~ msgstr "ಪೂರ್ವನಿಯೋಜಿತ (_D)"
+
+#~ msgid "Hidden"
+#~ msgstr "ಅಡಗಿಸಲಾದ"
+
+#~ msgid "Visible"
+#~ msgstr "ಗೋಚರ"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "ಹೆಸರು ಮತ್ತು ಗೋಚರಿಕೆ"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr ""
+#~ "ತೆರೆಯ ಮೇಲೆ ಮತ್ತು ಜಾಲಬಂಧದಲ್ಲಿ ನೀವು ಹೇಗೆ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತೀರಿ ಎನ್ನುವುದನ್ನು "
+#~ "ನಿಯಂತ್ರಿಸಿ."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "ಸಂಪೂರ್ಣ ಹೆಸರನ್ನು ಮೇಲಿನ ಪಟ್ಟಿಯಲ್ಲಿ ತೋರಿಸು (_f)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "ಸಂಪೂರ್ಣ ಹೆಸರನ್ನು ಲಾಕ್ ತೆರೆಯಲ್ಲಿ ತೋರಿಸು (_l)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "ರಹಸ್ಯವಾದ ವಿಧಾನ (_S)"
+
+#~ msgid "Immediately"
+#~ msgstr "ತಕ್ಷಣ"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "ಯಾವುದೂ ಇಲ್ಲ"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "ಸಾರ್ವಜನಿಕೆ ಕಡತಕೋಶವನ್ನು ಹಂಚಿಕೊ"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "ಕೇವಲ ನಂಬಿಕಸ್ತ ಸಾಧನಗಳೊಂದಿಗೆ ಮಾತ್ರ ಹಂಚಿಕೊ"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "ಈ ಜಾಲಬಂಧದಲ್ಲಿ ಮಾಧ್ಯಮವನ್ನು ಹಂಚಿಕೊಳ್ಳಿ"
+
+#~ msgid "Shared Folders"
+#~ msgstr "ಹಂಚಲಾದ ಕಡತಕೋಶಗಳು"
+
+#~ msgid "column"
+#~ msgstr "ಉದ್ದಸಾಲು"
+
+#~ msgid "Remove Folder"
+#~ msgstr "ಕಡತಕೋಶವನ್ನು ತೆಗೆದುಹಾಕು"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "ಸಾರ್ವಜನಿಕ ಕಡತಕೋಶವನ್ನು ಈ ಜಾಲಬಂಧದಲ್ಲಿ ಹಂಚಿಕೊಳ್ಳಿ"
+
+#~ msgid "Remote View"
+#~ msgstr "ದೂರಸ್ಥ ನೋಟ"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "ಎಲ್ಲಾ ಸಂಪರ್ಕಗಳನ್ನು ಅಂಗೀಕರಿಸು"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "ಸಾಮಾನ್ಯ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "ಉತ್ತಮ/ವಿಲೋಮ"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "ತೆರೆ ಮೇಲಿನ ಕೀಲಿಮಣೆ"
+
+#~ msgid "OnBoard"
+#~ msgstr "ಆನ್‌ಬೋರ್ಡ್"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "ಸಾಮಾನ್ಯ"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "ದೊಡ್ಡದಾದ"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "ಕ್ಯಾಪ್ಸ್‍ ಮತ್ತು ನಮ್ ಲಾಕ್‌ ಸಕ್ರಿಯವಾಗಿದ್ದಾಗ ಬೀಪ್"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "ಆನ್ ಅಥವ ಆಫ್ ಮಾಡಿ:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "ಗಾತ್ರಬದಲಿಸು"
+
+#~ msgid "Zoom in:"
+#~ msgstr "ಹಿಗ್ಗಿಸು:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "ಕುಗ್ಗಿಸು:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "ಮುಚ್ಚಿದ ಶೀರ್ಷಿಕೆ ನೀಡಿಕೆ"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "ವಾಕ್ ಮತ್ತು ಧ್ವನಿಗಳ ಪಠ್ಯ ರೂಪದ ವಿವರವನ್ನು ತೋರಿಸು"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "ಚಿಕ್ಕದಾದ"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "ಉದ್ದವಾದ"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "ಕೀಲಿಯ ಸ್ಥಿತಿಯು ಹೀಗಿದ್ದಾಗ ಬೀಪ್ ಸದ್ದನ್ನು ಮಾಡು"
+
+#~ msgid "pressed"
+#~ msgstr "ಒತ್ತಲಾಗಿದೆ"
+
+#~ msgid "accepted"
+#~ msgstr "ಅಂಗೀಕರಿಸಲಾಗಿದೆ"
+
+#~ msgid "rejected"
+#~ msgstr "ತಿರಸ್ಕರಿಸಲಾಗಿದೆ"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "ಅಂಗೀಕರಿಸಬಹುದಾದ ವಿಳಂಬ (_e):"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "ಕೀಪ್ಯಾಡ್‌ ಅನ್ನು ಬಳಸಿಕೊಂಡು ಸೂಚಕವನ್ನು ನಿಯಂತ್ರಿಸಿ"
+
+#~ msgid "Video Mouse"
+#~ msgstr "ವೀಡಿಯೊ ಮೌಸ್"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "ವೀಡಿಯೊ ಕ್ಯಾಮೆರಾ ಬಳಸಿಕೊಂಡು ಸೂಚಕವನ್ನು ನಿಯಂತ್ರಿಸು."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "ಚಿಕ್ಕದಾದ"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "ದೊಡ್ಡದಾದ"
+
+#~ msgid "Add account"
+#~ msgstr "ಖಾತೆಯನ್ನು ಸೇರಿಸು"
+
+#~ msgid "_Local Account"
+#~ msgstr "ಸ್ಥಳೀಯ ಖಾತೆ (_L)"
+
+#~ msgid "_Login Name"
+#~ msgstr "ಪ್ರವೇಶದ ಹೆಸರು (_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "ಸುಳಿವು: ಎಂಟರ್ಪ್ರೈಸ್ ಡೊಮೈನ್ ಅಥವ ಕ್ಷೇತ್ರ ಹೆಸರು"
+
+#~ msgid "C_ontinue"
+#~ msgstr "ಮುಂದುವರೆ (_o)"
+
+#~ msgid "Previous Week"
+#~ msgstr "ಹಿಂದಿನ ವಾರ"
+
+#~ msgid "Next Week"
+#~ msgstr "ಮುಂದಿನ ವಾರ"
+
+#~ msgid "Next week"
+#~ msgstr "ಮುಂದಿನ ವಾರ"
+
+#~ msgid "Log in without a password"
+#~ msgstr "ಗುಪ್ತಪದವಿಲ್ಲದೆ ಪ್ರವೇಶಿಸಿ"
+
+#~ msgid "Disable this account"
+#~ msgstr "ಈ ಖಾತೆಯನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ"
+
+#~ msgid "Enable this account"
+#~ msgstr "ಈ ಖಾತೆಯನ್ನು ಶಕ್ತಗೊಳಿಸು"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "ಗುಪ್ತಪದವನ್ನು ಖಚಿತಪಡಿಸಿ (_o)"
+
+#~ msgid "Generate a password"
+#~ msgstr "ಗುಪ್ತಪದವನ್ನು ಉತ್ಪಾದಿಸಿ"
+
+#~ msgid "_Action"
+#~ msgstr "ಕ್ರಿಯೆ (_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "ಗುಪ್ತಪದವನ್ನು ತೋರಿಸು (_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "ಸದೃಢವಾದ ಗುಪ್ತಪದವನ್ನು ಹೇಗೆ ಆರಿಸಿಬೇಕು"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "ಇವರ ಚಿತ್ರವನ್ನು ಬದಲಾಯಿಸಲಾಗುತ್ತಿದೆ:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "ಈ ಖಾತೆಗಾಗಿ ಪ್ರವೇಶ ತೆರೆಯಲ್ಲಿ ತೋರಿಸಲಾಗುವ ಒಂದು ಚಿತ್ರವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ."
+
+#~ msgid "Gallery"
+#~ msgstr "ಸಂಗ್ರಹ"
+
+#~ msgid "Take a photograph"
+#~ msgstr "ಒಂದು ಚಿತ್ರವನ್ನು ತೆಗೆದುಕೊಳ್ಳಿ"
+
+#~ msgid "Browse"
+#~ msgstr "ವೀಕ್ಷಿಸಿ"
+
+#~ msgid "Photograph"
+#~ msgstr "ಚಿತ್ರ"
+
+#~ msgid "Account Information"
+#~ msgstr "ಖಾತೆಯ ಮಾಹಿತಿ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "ಬಹಳ ಚಿಕ್ಕದಾಗಿದೆ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "ಸಾಕಷ್ಟು ಉತ್ತಮವಾಗಿಲ್ಲ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "ದುರ್ಬಲ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "ಪರವಾಗಿಲ್ಲ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "ಉತ್ತಮ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "ಸದೃಢ"
+
+#~ msgid "_Generate a password"
+#~ msgstr "ಗುಪ್ತಪದವನ್ನು ಉತ್ಪಾದಿಸು (_G)"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "ನೀವು ಒಂದು ಹೊಸ ಗುಪ್ತಪದವನ್ನು ನಮೂದಿಸಿಬೇಕು"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "ಹೊಸ ಗುಪ್ತಪದವು ಸಾಕಷ್ಟು ದೃಢವಾಗಿದೆ"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "ನೀವು ಒಂದು ಗುಪ್ತಪದವನ್ನು ಖಚಿತಪಡಿಸಬೇಕು"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "ನಿಮ್ಮ ಈಗಿನ ಗುಪ್ತಪದವನ್ನು ನಮೂದಿಸಿಬೇಕು"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "ನಿಮ್ಮ ಈಗಿನ ಗುಪ್ತಪದವು ಸರಿಯಾಗಿಲ್ಲ"
+
+#~ msgid "Wrong password"
+#~ msgstr "ಗುಪ್ತಪದ ತಪ್ಪಾಗಿದೆ"
+
+#~ msgid "Switch Modes"
+#~ msgstr "ವಿಧಾನಗಳನ್ನು ಬದಲಾಯಿಸು"
+
+#~ msgid "Action"
+#~ msgstr "ಕಾರ್ಯ"

--- a/po/ko.po
+++ b/po/ko.po
@@ -31,9 +31,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-03 22:48+0900\n"
 "Last-Translator: Changwoo Ryu <cwryu@debian.org>\n"
 "Language-Team: GNOME Korea <gnome-kr@googlegroups.com>\n"
@@ -44,97 +43,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.5.3\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "시스템 버스"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "완전히 접근"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "세션 버스"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "장치"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "/dev에 완전히 접근"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "네트워크"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "네트워크 접근 가능"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "내 폴더"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "읽기 전용"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "파일 시스템"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "설정"
-
-# 권한 이름
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "설정 바꾸기 가능"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr "%s 앱에 다음 권한이 내장되어 있습니다. 이 권한은 바꿀 수 없습니다. 이 권한이 염려스럽다면 이 앱 삭제를 고려해 보십시오."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "앱이 여는 %u개 파일 및 링크 종류"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> 앱은 다음 종류의 파일 및 링크를 여는데 사용됩니다."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "디스크 공간의 %s 사용."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -150,7 +59,6 @@ msgid "Install some…"
 msgstr "앱 설치…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "열기"
 
@@ -174,24 +82,13 @@ msgstr "검색"
 msgid "Receive system searches and send results."
 msgstr "시스템 검색을 받아서 결과를 보냅니다."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "사용 않음"
 
@@ -358,81 +255,21 @@ msgstr "캐시 지우기…"
 msgid "Control various application permissions and settings"
 msgstr "여러가지 앱 권한과 설정 조정"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "application;애플리케이션;앱;프로그램;flatpak;permission;권한;setting;설정;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "사진을 고르십시오"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "취소(_C)"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "열기(_O)"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "여러 개 크기"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "바탕 화면 배경 없음"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "현재 배경"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "모양새"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "기본값"
 
@@ -456,10 +293,11 @@ msgstr "모양"
 msgid "Change your background image or the UI colors"
 msgstr "배경 이미지 또는 UI 색을 바꿉니다"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
-msgstr "Background;Wallpaper;배경;월페이퍼;Screen;화면;Desktop;바탕 화면;Style;스타일;모양;Light;밝게;Dark;어둡게;다크;Appearance;"
+msgstr ""
+"Background;Wallpaper;배경;월페이퍼;Screen;화면;Desktop;바탕 화면;Style;스타"
+"일;모양;Light;밝게;Dark;어둡게;다크;Appearance;"
 
 #: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
 #: panels/datetime/cc-datetime-panel.ui:172
@@ -507,9 +345,7 @@ msgstr "하드웨어 비행기 모드가 켜져 있습니다"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "블루투스를 사용하려면 비행기 모드 스위치를 끄십시오."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "블루투스"
 
@@ -517,7 +353,6 @@ msgstr "블루투스"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "블루투스를 켜거나 끄고 블루투스 장치에 연결합니다"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;공유;bluetooth;블루투스;obex;"
@@ -537,7 +372,8 @@ msgid ""
 "\n"
 "Allow the applications below to use your camera."
 msgstr ""
-"카메라를 사용하면 사진이나 영상을 찍을 수 있습니다. 카메라를 사용하지 않으면 일부 앱이 제대로 동작하지 않을 수 있습니다.\n"
+"카메라를 사용하면 사진이나 영상을 찍을 수 있습니다. 카메라를 사용하지 않으면 "
+"일부 앱이 제대로 동작하지 않을 수 있습니다.\n"
 "\n"
 "카메라를 사용하려면 아래에서 앱을 허용하십시오."
 
@@ -549,89 +385,35 @@ msgstr "카메라 접근을 요청한 앱이 없습니다"
 msgid "Protect your pictures"
 msgstr "내 사진을 보호합니다"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
-msgstr "camera;카메라;photos;사진;video;비디오;webcam;웹캠;캠;lock;잠금;private;privacy;개인;정보;사생활;프라이버시;보호;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "보정 장치를 사각형 구역에 놓고 “시작”을 누르십시오"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "보정 장치를 보정 위치에 놓고 “계속”을 누르십시오"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "보정 장치를 평면 위치에 놓고 “계속”을 누르십시오"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "노트북 덮개를 닫으십시오"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "내부 오류가 발생했지만 복구할 수 없습니다."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "보정에 필요한 앱을 설치하지 않았습니다."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "프로파일을 만들 수 없습니다."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "대상 화이트포인트을 얻을 수 없습니다."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "완료!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "보정에 실패했습니다"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "보정 장치를 제거할 수 있습니다."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "진행 중에는 보정 장치를 방해하지 마십시오."
+msgstr ""
+"camera;카메라;photos;사진;video;비디오;webcam;웹캠;캠;lock;잠금;private;"
+"privacy;개인;정보;사생활;프라이버시;보호;"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "디스플레이 보정"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "취소(_C)"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -648,140 +430,6 @@ msgstr "다시 시작(_R)"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "완료(_D)"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "노트북 화면"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "내장 웹캠"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s 모니터"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s 스캐너"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s 카메라"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s 프린터"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s 웹캠"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s에 색상 관리 사용"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s의 색 프로파일 표시"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "보정되지 않음"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "기본값:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "색 영역: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "시험용 프로파일: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "ICC 프로파일 파일 선택"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "가져오기(_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "지원하는 ICC 프로파일"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "모든 파일"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "화면"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "프로파일 저장"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "저장(_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "선택한 장치에 대한 색 프로파일 만들기"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"측정 장치가 감지되지 않았습니다. 장치가 켜져 있고 제대로 연결되었는지 확인하"
-"십시오."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "이 측정 장치는 프린터 프로파일링을 지원하지 않습니다."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "이 종류의 장치는 현재 지원하지 않습니다."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -897,13 +545,13 @@ msgstr "쓰기 가능 미디어 필요"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"<a href=\"linux\">GNU/리눅스</a>, <a href=\"osx\">애플 OS X</a> 및 <a href="
-"\"windows\">마이크로소프트 윈도우Microsoft Windows</a> 시스템의 프로파일 사용"
-"법 안내를 읽어보면 도움이 됩니다."
+"<a href=\"linux\">GNU/리눅스</a>, <a href=\"osx\">애플 OS X</a> 및 <a "
+"href=\"windows\">마이크로소프트 윈도우Microsoft Windows</a> 시스템의 프로파"
+"일 사용법 안내를 읽어보면 도움이 됩니다."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -923,7 +571,6 @@ msgstr "파일 가져오기(_I)…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -933,9 +580,7 @@ msgstr "추가(_A)"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "색상 관리 기능을 사용하려면 각 장치는 최신 색상 프로파일이 필요합니다."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "더 알아보기"
 
@@ -1067,82 +712,6 @@ msgstr "D65 (사진 및 그래픽)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "표준 색 공간"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "시험용 프로파일"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "자동"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "낮은 품질"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "중간 품질"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "높은 품질"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "기본 RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "기본 CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "기본 Gray"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "제조사가 제공한 공장 출고 보정 데이터"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "이 프로파일에서는 전체 화면 교정이 불가합니다."
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "이 프로필은 이제 정확하지 않을 수도 있습니다"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "색"
@@ -1152,16 +721,11 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "디스플레이, 카메라, 프린터같은 장치의 색을 보정합니다"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Color;색;ICC;Profile;프로파일;Calibrate;보정;Printer;프린터;Display;디스플레"
 "이;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "기타…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1176,13 +740,8 @@ msgid "No languages found"
 msgstr "언어 없음"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "기타…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "설정을 바꾸려면 잠금을 해제하십시오"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1211,148 +770,6 @@ msgstr "시간 감소"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "분 감소"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "오늘"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "어제"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e일"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%Y년 %b %e일"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d시간"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d분"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d초"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0초"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "핫스팟"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24시간"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "오전 / 오후"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%Y년 %B %e일, %p %l:%M"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%Y년 %B %e일, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%p %l:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1448,17 +865,11 @@ msgstr "표준 시간대 자동(_Z)"
 msgid "Requires location services enabled and internet access"
 msgstr "위치 서비스를 켜야 하고 인터넷 접근이 필요"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "사용"
 
@@ -1466,15 +877,43 @@ msgstr "사용"
 msgid "Time Z_one"
 msgstr "표준 시간대(_O)"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "잠금 해제"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "시각 형식(_F)"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "날짜"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0초"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "달력(_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "숫자"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "날짜와 시각(표준 시간대 포함)을 바꿉니다"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;시계;Timezone;시간대;Location;위치;"
@@ -1520,22 +959,11 @@ msgstr "기본 앱"
 msgid "Configure Default Applications"
 msgstr "기본 앱 설정"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "default;기본;기본값;application;프로그램;앱;애플리케이션;preferred;media;미디"
 "어;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"기술적인 문제점에 대한 보고서를 보내면 %s 개선에 도움이 됩니다. 보고서는 익명"
-"으로 전송되고 개인 정보는 가려집니다. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1553,44 +981,9 @@ msgstr "진단"
 msgid "Report your problems"
 msgstr "문제점 보고하기"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostics;진단;검사;crash;크래시;이상종료;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "켬"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "끔"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "바뀐 사항을 적용하시겠습니까?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "바뀐 사항을 적용할 수 없습니다"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "하드웨어 제한 때문에 문제가 발생할 수도 있습니다."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1641,31 +1034,6 @@ msgstr "주 디스플레이"
 msgid "Night Light"
 msgstr "야간 모드"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "가로"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "세로 오른쪽"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "세로 왼쪽"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "가로 (뒤집힘)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1690,6 +1058,17 @@ msgctxt "display setting"
 msgid "Scale"
 msgstr "비율 조정"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "스크롤 방향 뒤바꾸기"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
 msgstr "야간 모드를 사용할 수 없습니다"
@@ -1698,7 +1077,9 @@ msgstr "야간 모드를 사용할 수 없습니다"
 msgid ""
 "This could be the result of the graphics driver being used, or the desktop "
 "being used remotely"
-msgstr "사용하는 그래픽 드라이버 때문이거나, 데스크톱을 원격에서 사용해서 그럴 수 있습니다"
+msgstr ""
+"사용하는 그래픽 드라이버 때문이거나, 데스크톱을 원격에서 사용해서 그럴 수 있"
+"습니다"
 
 #. Inhibit the redshift functionality until the next day starts
 #: panels/display/cc-night-light-page.ui:58
@@ -1782,7 +1163,6 @@ msgstr "디스플레이"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "연결한 모니터와 프로젝터 사용법을 정합니다"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1792,65 +1172,6 @@ msgstr ""
 "사율;Monitor;모니터;Night;Light;야간;모드;조명;Blue;파란빛;redshift;적색편이;"
 "color;색;sunset;일몰;sunrise;일출;"
 
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "보안 부팅이 동작 중입니다"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr "보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 막습니다. 현재 이 기능은 켜져 있고 올바르게 동작 중입니다."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "보안 부팅에 문제 있음"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr "보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 막습니다. 현재 이 기능은 켜져 있지만, 키가 잘못되어 동작하지 않습니다."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr "보안 부팅 문제는 컴퓨터의 UEFI 펌웨어 설정에서 (BIOS) 해결할 수도 있고, 하드웨어 제조사에서 어떻게 설정하는지 정보를 제공합니다."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "도움이 필요하면 하드웨어 제조사나 IT 지원 공급자에게 문의하십시오."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "보안 부팅이 꺼졌습니다"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr "보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 막습니다. 현재 이 기능은 꺼져 있습니다."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr "보안 부팅 기능은 컴퓨터의 UEFI 펌웨어 설정에서 (BIOS) 켤 수도 있습니다. 도움이 필요하면 하드웨어 제조사나 IT 지원 공급자에게 문의하십시오."
-
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
 "Secure boot prevents malicious software from being loaded when the device "
@@ -1858,119 +1179,14 @@ msgid ""
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
-"보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 막습니다.\n"
+"보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 막"
+"습니다.\n"
 "\n"
 "더 자세히 알고 싶으면, 하드웨어 제조사나 IT 지원 공급자에 문의하십시오."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "통과"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "실패"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "장치가 HSI %d 단계를 준수합니다"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "보안 단계 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr "이 장치는 하드웨어 보안 문제에 대한 보호 기능이 없습니다. 하드웨어 또는 펌웨어 설정 문제일 수 있습니다. IT 지원 공급자에게 문의하기를 권장합니다."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "보안 단계 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr "이 장치는 하드웨어 보안 문제에 대한 최소한의 보호 기능이 있습니다. 가장 낮은 수준의 장치 보안 단계이므로, 단순한 보안 위협에 대한 보호만을 제공합니다."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "보안 단계 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr "이 장치는 하드웨어 보안 문제에 대한 기초적인 보호 기능이 있습니다. 일부 흔한 보안 위협에 대한 보호를 제공합니다."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "보안 단계 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr "이 장치는 하드웨어 보안 문제에 대한 확장된 보호 기능이 있습니다. 가장 높은 수준의 장치 보안 단계이므로, 고급 보안 위협에 대한 보호를 제공합니다."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "보안 단계"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr "이 장치에 보안 단계를 사용할 수 없습니다."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr "하드웨어 제조사에 연락해 보안 업데이트하는데 도움을 받으십시오."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr "이 문제는 장치의 UEFI 펌웨어 설정에서 해결할 수도 있고, 지원 전문가가 해결할 수 있을지도 모릅니다."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr "이 문제는 장치의 UEFI 펌웨어 설정에서 해결할 수 있을지도 모릅니다."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "지원 전문가가 이 문제를 해결할 수 있을지도 모릅니다."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -1984,333 +1200,9 @@ msgstr "단계 2"
 msgid "Level 3"
 msgstr "단계 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr "장치가 시작할 때 악의적인 소프트웨어로부터 보호합니다."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "보안 부팅에 문제 있음"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "장치가 시작할 때 일부분을 보호합니다."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "보안 부팅 꺼짐"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "장치가 시작할 때 보호하지 않습니다."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr "이 문제는 UEFI 펌웨어 설정을 바꿔서 발생했을 수도 있고, 운영체제 설정을 바꿔서 발생했거나, 시스템의 악의적인 소프트웨어 때문에 발생했을 수도 있습니다."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr "이 문제는 UEFI 펌웨어 설정을 바꿔서 발생했을 수도 있고, 시스템의 악의적인 소프트웨어 때문에 발생했을 수도 있습니다."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr "이 문제는 운영체제 설정을 바꿔서 발생했거나, 시스템의 악의적인 소프트웨어 때문에 발생했을 수도 있습니다."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "심각한 보안 위협에 노출됨."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "간단한 보안 위협에 대한 보호 제한적임."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "흔한 보안 위협에 대해 보호."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "넓은 범위의 보안 위협에 대해 보호."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "종합적인 보호"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "이벤트 없음"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "펌웨어 쓰기 보호"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "펌웨어 쓰기 보호 잠금"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "펌웨어 바이오스 지역"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "펌웨어 바이오스 설명"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "부팅 전 DMA 보호"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "인텔 부트가드"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "인텔 부트가드 검증 부팅"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "인텔 부트가드 ACM 보호"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "인텔 부트가드 오류 정책"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "인텔 부트가드 퓨즈"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "인텔 CET 사용"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "인텔 CET 동작"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "인텔 SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "RAM 암호화"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU 보호"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "리눅스 커널 잠김"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "리눅스 커널 검증"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "리눅스 스왑"
-
-# /sys/power/state 상태
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "대기모드, RAM에 저장"
-
-# /sys/power/state 상태
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "대기모드, 사용 중지"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI 플랫폼 키"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI 보안 부팅"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TPM 플랫폼 설정"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM 재구성"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "인텔 관리 엔진 제조 모드"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "인텔 관리 엔진 재정의"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "인텔 관리 엔진 버전"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "펌웨어 업데이트"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "펌웨어 증명"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "펌웨어 업데이터 검증"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "플랫폼 디버깅"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "프로세서 보안 확인"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD 롤백 보호"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD 펌웨어 리플레이 보호"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "AMD 펌웨어 쓰기 보호"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "퓨즈 설정된 플랫폼"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "올바름"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "올바르지 않음"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "사용하지 않음"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "잠겼음"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "안 잠겼음"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "암호화됨"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "암호화되지 않음"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "오염됨"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "오염되지 않음"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "발견됨"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "발견되지 않음"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "지원함"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "지원하지 않음"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2320,55 +1212,14 @@ msgstr "장치 보안"
 msgid "Host firmware security status"
 msgstr "호스트 펌웨어 보안 상태"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
 "network;identity;privacy;"
-msgstr "screen;화면;lock;잠그기;diagnostics;진단;crash;private;recent;최근;temporary;tmp;임시;index;색인;name;이름;network;네트워크;identity;신원;privacy;개인;정보;사생활;프라이버시;보호;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "알 수 없음"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64비트"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32비트"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "웨일랜드"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "알 수 없음"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "사용할 수 없음"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "시스템 로고"
+msgstr ""
+"screen;화면;lock;잠그기;diagnostics;진단;crash;private;recent;최근;temporary;"
+"tmp;임시;index;색인;name;이름;network;네트워크;identity;신원;privacy;개인;정"
+"보;사생활;프라이버시;보호;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2462,11 +1313,6 @@ msgstr "정보"
 msgid "View information about your system"
 msgstr "시스템의 정보를 봅니다"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2546,6 +1392,12 @@ msgstr "실행 아이콘"
 msgid "Launch help browser"
 msgstr "도움말 보기 실행"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "설정"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "계산기 실행"
@@ -2567,7 +1419,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "검색"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "시스템"
 
@@ -2616,15 +1468,6 @@ msgstr "글자 크기 줄이기"
 msgid "High contrast on or off"
 msgstr "고대비 켜거나 끄기"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "입력 소스가 없습니다"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "기타"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "입력 소스 추가"
@@ -2657,106 +1500,9 @@ msgstr "기본 설정"
 msgid "View Keyboard Layout"
 msgstr "키보드 배치 표시"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "제거"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "바로 가기 사용자 설정"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "대체 문자 키"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"대체 문자 키를 이용해 추가 문자를 입력할 수 있습니다. 이 문자는 키보드에 3번"
-"째 옵션으로 인쇄되어 있는 경우도 있습니다."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "왼쪽 Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "오른쪽 Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "왼쪽 Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "오른쪽 Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menu 키"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "오른쪽 Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "구성 키"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"조합 키를 사용하면 여러가지 종류의 문자를 입력할 수 있습니다. 조합 키를 사용"
-"하려면, 조합 키와 문자의 연속을 누릅니다. 예를 들어, 조합 키 다음에 <b>C</b> "
-"및 <b>o</b>를 누르면 <b>©</b> 문자를 입력하고, <b>a</b>와 <b>'</b>를 누르면 "
-"<b>á</b> 문자를 입력합니다."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"입력 소스는 %s 키보드 바로 가기를 사용해 전환할 수 있습니다.\n"
-"키보드 바로 가기 설정에서 바꿀 수 있습니다."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2786,44 +1532,21 @@ msgstr "특수 문자 입력"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "키보드로 기호와 액센트 문자를 입력하는 방식."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "대체 문자 키"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "구성 키"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "키보드 바로 가기"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "바로 가기 보기 및 사용자 설정"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d개 수정됨"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "모든 바로 가기를 초기화하시겠습니까?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"바로 가기를 초기화하면 사용자 추가한 바로 가기에도 영향을 미칩니다. 이 동작"
-"은 되돌릴 수 없습니다."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "취소"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "모두 초기화"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2861,33 +1584,6 @@ msgstr "바로 가기 추가"
 msgid "No keyboard shortcut found"
 msgstr "키보드 바로 가기가 없습니다"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s은(는) %s 용도로 사용 중입니다. 바꾸면 %s이(가) 사용 중지됩니다"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "새 바로 가기 입력"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "사용자 설정 바로 가기 설정"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "바로 가기 설정"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "%s 항목을 바꾸려면 새 바로 가기를 입력하십시오."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "사용자 설정 바로 가기 키 추가"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "제거(_R)"
@@ -2899,7 +1595,6 @@ msgstr "바꾸기(_P)"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "설정(_S)"
 
@@ -2937,6 +1632,11 @@ msgstr "없음"
 msgid "Reset the shortcut to its default value"
 msgstr "바로 가기 키 기본값으로 초기화"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "기본 프린터로 사용"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "키보드"
@@ -2949,7 +1649,6 @@ msgstr ""
 "키보드 바로 가기를 바꾸고 키보드 타이핑, 키보드 배치, 입력 소스를 설정합니다."
 
 # 주의: 키워드이므로 번역될 수 있는 용어 적기
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2976,9 +1675,11 @@ msgid ""
 "\n"
 "Allow the applications below to determine your location."
 msgstr ""
-"위치 서비스를 사용하면 앱에서 현재 위치를 알 수 있습니다. 와이파이 및 휴대전화 인터넷을 사용하면 정확도가 올라갑니다.\n"
+"위치 서비스를 사용하면 앱에서 현재 위치를 알 수 있습니다. 와이파이 및 휴대전"
+"화 인터넷을 사용하면 정확도가 올라갑니다.\n"
 "\n"
-"모질라 위치 서비스를 사용합니다: <a href='https://location.services.mozilla.com/privacy'>개인정보 보호 정책</a>\n"
+"모질라 위치 서비스를 사용합니다: <a href='https://location.services.mozilla."
+"com/privacy'>개인정보 보호 정책</a>\n"
 "\n"
 "현재 위치를 알려면 아래에서 앱을 허용하십시오."
 
@@ -2990,10 +1691,10 @@ msgstr "위치 정보를 요청한 앱이 없습니다"
 msgid "Protect your location information"
 msgstr "위치 정보를 보호합니다"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
-msgstr "location;위치;좌표;gps;private;privacy;개인;정보;사생활;프라이버시;보호;"
+msgstr ""
+"location;위치;좌표;gps;private;privacy;개인;정보;사생활;프라이버시;보호;"
 
 #: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
@@ -3024,10 +1725,11 @@ msgstr "마이크 접근을 요청한 앱이 없습니다"
 msgid "Protect your conversations"
 msgstr "대화를 보호합니다"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
-msgstr "microphone;마이크;recording;녹음;application;privacy;개인;정보;사생활;프라이버시;보호;"
+msgstr ""
+"microphone;마이크;recording;녹음;application;privacy;개인;정보;사생활;프라이"
+"버시;보호;"
 
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
@@ -3054,81 +1756,139 @@ msgstr "왼쪽"
 msgid "Right"
 msgstr "오른쪽"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "검색 위치"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "마우스"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "마우스 속도"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "스크롤 방향 뒤바꾸기"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "구분"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "스크롤하면 내용을 옮기고, 뷰를 옮기지 않습니다."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "스크롤하면 내용을 옮기고, 뷰를 옮기지 않습니다."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "동작"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "터치패드"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "터치패드 속도"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "터치패드 두드리면 단추 누름으로 취급"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "터치패드 두드리면 단추 누름으로 취급"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "두손가락 스크롤"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "터치패드 속도"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "가장자리 스크롤"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "양면"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "한번 누르기, 두번 누르기, 스크롤을 해 보십시오"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "다섯번 누름, 게글 타임!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "두번 누르기, 첫번째 단추"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "한번 누르기, 첫번째 단추"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "두번 누르기, 가운데 단추"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "한번 누르기, 가운데 단추"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "두번 누르기, 두번째 단추"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "한번 누르기, 두번째 단추"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3140,7 +1900,6 @@ msgid ""
 msgstr ""
 "마우스 및 터치패드 민감도를 바꾸고 오른손잡이용인지 왼손잡이용인지 설정합니다"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3220,26 +1979,19 @@ msgstr "다중 작업"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "생산성 및 다중 작업에 대한 설정을 관리합니다"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
-msgstr "Multitasking;다중작업;다중 작업;멀티태스킹;Multitask;멀티태스크;Productivity;생산성;Customize;사용자설정;사용자 설정;Desktop;데스크톱;Hot Corner;핫코너;Workspaces;작업공간;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "앗, 뭔가 잘못됐습니다. 소프트웨어 공급자에게 문의하십시오."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager가 동작해야 합니다."
+msgstr ""
+"Multitasking;다중작업;다중 작업;멀티태스킹;Multitask;멀티태스크;Productivity;"
+"생산성;Customize;사용자설정;사용자 설정;Desktop;데스크톱;Hot Corner;핫코너;"
+"Workspaces;작업공간;"
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "기타 장치"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN(가상사설망)"
 
@@ -3251,59 +2003,16 @@ msgstr "연결 추가"
 msgid "Not set up"
 msgstr "설정되지 않음"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "안전하지 않은 네트워크 (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "안전한 네트워크 (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "안전한 네트워크 (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "안전한 네트워크 (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "안전한 네트워크"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "연결됨"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "옵션…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"핫스팟을 켜면 %s에서 연결이 끊기고, 와이파이를 통한 인터넷 접근이 불가능합니"
-"다."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "길이가 최소 8자가 되야 합니다"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3352,20 +2061,6 @@ msgstr "암호 자동 생성"
 msgid "_Turn On"
 msgstr "켜기(_T)"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "와이파이"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "핫스팟을 중지하고 연결 중인 사용자를 끊으시겠습니까?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "핫스팟 중지(_S)"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "비행기 모드"
@@ -3410,90 +2105,13 @@ msgstr "보이는 네트워크"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager가 동작해야 합니다"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "앗, 뭔가 잘못됐습니다. 소프트웨어 공급자에게 문의하십시오."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x 보안(_S)"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "보안"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "보존"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "영구"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "임의"
-
-# 태블릿 PC
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "안정"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"여기 입력하는 MAC 주소는 이 연결을 활성화할 때 해당 네트워크 장치의 하드웨어 "
-"주소로 사용합니다. 이 기능은 MAC 복제 또는 스푸핑이라고 부릅니다. 예를 들어: "
-"00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "프로파일 %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "발전된 오픈 네트워크"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "기업용"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "없음"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "안 함"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3501,183 +2119,6 @@ msgstr "안 함"
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] " %i일 전"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "없음"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "약함"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "좋음"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "좋음"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "최상"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 주소"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 주소"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP 주소"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "네임서버(DNS)"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "연결 저장 지우기"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "연결 프로파일 제거"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "VPN(가상사설망) 제거"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "자세히 보기"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "자동"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "신원"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "주소 삭제"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "라우팅 삭제"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "와이파이/이더넷 보안"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128비트 키(16진수 또는 ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128비트 암호글"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "동적 WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA 및 WPA2 개인용"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA 및 WPA2 기업용"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 개인용"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3688,8 +2129,20 @@ msgstr "신호 세기"
 msgid "Link speed"
 msgstr "연결 속도"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "보안"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 주소"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 주소"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "하드웨어 주소"
 
@@ -3698,12 +2151,17 @@ msgid "Supported Frequencies"
 msgstr "지원하는 주파수"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "기본 라우팅"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "네임서버(DNS)"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3765,7 +2223,7 @@ msgstr "링크 로컬만"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "수동"
 
@@ -3809,9 +2267,8 @@ msgstr "게이트웨이"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "자동"
 
@@ -3866,89 +2323,9 @@ msgstr "자동, DHCP 전용"
 msgid "Prefix"
 msgstr "프리픽스"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "연결 편집을 열 수 없습니다"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "새 프로파일"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "잘못된 설정 %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "잘못된 설정 %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "파일에서 가져오기…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "VPN(가상사설망) 추가"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "보안(_E)"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "VPN(가상사설망) 연결을 가져올 수 없습니다"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"“%s” 파일을 읽을 수가 없거나, 파일에 알려진 VPN(가상사설망) 연결 정보가 들어 "
-"있지 않습니다\n"
-"\n"
-"오류: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "가져올 파일을 선택하십시오"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "이름이 “%s”인 파일이 이미 있습니다."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "바꾸기(_R)"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "%s 연결을 저장한 VPN(가상사설망) 연결로 바꾸시겠습니까?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "VPN(가상사설망) 연결을 내보낼 수 없습니다"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"“%s” VPN(가상사설망) 연결을 %s에 내보낼 수 없습니다.\n"
-"\n"
-"오류: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "VPN(가상사설망) 연결 내보내기"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3962,100 +2339,40 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "네트워크"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "어떻게 인터넷에 연결할지 정합니다"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;네트워크;IP;LAN;랜;Proxy;프록시;WAN;인터넷;Broadband;브로드밴드;"
 "Modem;모뎀;Bluetooth;블루투스;vpn;가상사설망;;DNS;네임서버;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "와이파이"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "어떻게 와이파이 네트워크에 연결할지 정합니다"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;네트워크;Wireless;무선;Wi-Fi;Wifi;와이파이;IP;LAN;Broadband;브로드밴"
 "드;DNS;네임서버;Hotspot;핫스팟;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "안 함"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "오늘"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "어제"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "최근 사용"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "유선"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "새 연결 추가"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"선택한 네트워크의 상세 정보(암호 및 기타 사용자 설정 정보 포함)가 지워집니다."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "저장 지우기(_F)"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "알려진 와이파이 네트워크"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "지우기(_F)"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "시스템 정책이 핫스팟 사용을 막습니다"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "무선 장치에서 핫스팟 모드를 지원하지 않습니다"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "설정 URL을 지정하지 않으면 웹 프록시 자동 검색을 사용합니다."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "신뢰할 수 없는 공용 네트워크 사용은 추천하지 않습니다."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4074,6 +2391,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "공급처"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP 주소"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4159,289 +2480,6 @@ msgstr "와이파이 핫스팟 켜기(_T)…"
 msgid "_Known Wi-Fi Networks"
 msgstr "알려진 와이파이 네트워크(_K)"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "상태 알 수 없음"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "관리 안 됨"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "사용할 수 없음"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "연결 중"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "인증 필요"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "연결 끊는 중"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "연결 실패"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "상태 알 수 없음(빠짐)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "설정에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP 설정에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP 설정 기한이 지났습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "비밀 데이터가 필요하지만 전송하지 않았습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x 요청의 연결이 끊겼습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x 요청 설정에 실패했습니다."
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x 요청에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x 요청이 인증에 너무 오래 걸립니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP 서비스 시작해 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP 서비스 연결이 끊어졌습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP 동작 실패"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP 클라이언트 시작에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP 클라이언트 오류"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP 클라이언트 동작에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "연결 공유 서비스 시작에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "연결 공유 서비스 동작에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "자동IP 서비스 시작에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP 서비스 오류"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "자동IP 서비스 동작에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "회선 사용중"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "전화 걸기 신호음 없음"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "서비스에 연결할 수 없습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "전화 걸기 요청 시간을 초과했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "전화 걸기 시도에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "모뎀 초기화 실패"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "지정한 APN 선택에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "네트워크 검색 요소가 없습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "네트워크 등록이 거부되었습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "네트워크 등록 시간을 초과했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "요청 받은 네트워크 등록에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN 확인 실패"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "장치 펌웨어가 빠진 것 같음"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "연결이 사라졌습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "기존 연결을 가정합니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "모뎀을 찾을 수 없습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "블루투스 연결에 실패했습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM 카드 삽입하지 않았습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM PIN이 필요합니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM의 PIN 잠금 해제 키 코드 필요합니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM이 잘못되었습니다"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "연결 의존성 설정에 실패했습니다"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "펌웨어 없음"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "케이블 분리됨"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "802.1X 보안에 (WPA-EAP) 정의하지 않은 오류"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "파일을 선택하지 않았습니다"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "EAP-METHOD 파일을 검증하는 중 지정하지 않은 오류"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12 또는 PGP 개인 키"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER 또는 PEM 인증서"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "EAP-FAST PAC 파일이 없습니다"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC 파일(*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4491,14 +2529,6 @@ msgstr "내부 인증(_I)"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "자동 PAC 프로비저닝 허용(_V)"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "EAP-LEAP 사용자 이름이 없습니다"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "EAP-LEAP 암호가 없습니다"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4524,15 +2554,6 @@ msgstr "암호(_P)"
 msgid "Sho_w password"
 msgstr "암호 보이기(_W)"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "잘못된 EAP-PEAP 인증 기관 인증서: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "잘못된 EAP-PEAP 인증 기관 인증서: 인증서를 지정하지 않았습니다"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4554,7 +2575,6 @@ msgid "C_A certificate"
 msgstr "인증 기관 인증서(_A)"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4569,62 +2589,6 @@ msgstr "인증 기관 인증서 불필요(_R)"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP 버전(_V)"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "EAP 사용자 이름 없음"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "EAP 암호 없음"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "EAP-TLS 신원 정보 없음"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "잘못된 EAP-TLS 인증 기관 인증서: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "잘못된 EAP-TLS 인증 기관 인증서: 인증서를 지정하지 않았습니다"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "잘못된 EAP-TLS 개인 키: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "잘못된 EAP-TLS 사용자 인증서: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "암호화하지 않은 개인 키는 보안상 위험합니다"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"선택한 개인 키는 암호로 보호하지 않았습니다. 이러면 비밀 정보가 유출될 수 있"
-"습니다. 암호로 보호한 개인 키를 선택하십시오.\n"
-"\n"
-"(OpenSSL로 개인 키를 암호로 보호할 수도 있습니다)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "개인 인증서 선택"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "개인 키 선택"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4641,15 +2605,6 @@ msgstr "개인 키(_K)"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "개인 키 암호(_P)"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "잘못된 EAP-TTLS 인증기관 인증서: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "잘못된 EAP-TTLS 인증기관 인증서: 인증서를 지정하지 않았습니다"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4672,14 +2627,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "도메인(_D)"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "802.1X 보안을 검증하는 중 알 수 없는 오류"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4707,58 +2663,10 @@ msgstr "PEAP(Protected EAP)"
 msgid "Au_thentication"
 msgstr "인증(_T)"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "파일 선택"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "LEAP 사용자 이름이 없음"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "LEAP 암호가 없음"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "와이파이 암호가 없습니다."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "종류(_T)"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "WEP 키가 없음"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "잘못된 WEP 키: 길이가 %zu인 키에는 16진수 숫자만 들어 있어야 합니다"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "잘못된 WEP 키: 길이가 %zu인 키에는 ASCII 문자만 들어 있어야 합니다"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"잘못된 WEP 키: 잘못된 키 길이 %zu. 키 길이는 5/13 (ASCII) 또는 10/26 (16진"
-"수) 중 하나여야 합니다"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "잘못된 WEP 키: 암호글이 비어 있으면 안 됩니다"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "잘못된 WEP 키: 암호글은 64자보다 짧아야 합니다"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4783,19 +2691,6 @@ msgstr "키 보이기(_W)"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP 인덱스(_X)"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"잘못된 WPA-PSK: 잘못된 키 길이 %zu. [8,64] 바이트 또는 64개 16진수 숫자여야 "
-"합니다"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "잘못된 WPA-PSK: 64개 16진수 숫자를 키로 해석할 수 없습니다"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4848,28 +2743,10 @@ msgstr "잠금 화면 알림(_L)"
 msgid "Control which notifications are displayed and what they show"
 msgstr "어떤 알림을 표시할지 및 무엇을 표시할지 설정합니다"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Notifications;알림;Banner;안내판;Message;메시지;Tray;트레이;Popup;팝업;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "기타"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s 제거함"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "계정 제거 오류"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4893,17 +2770,6 @@ msgstr "인터넷 연결이 없습니다 — 새 온라인 계정을 설정하�
 msgid "Add an account"
 msgstr "계정 추가"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s 계정"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "계정 제거"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "온라인 계정"
@@ -4912,10 +2778,6 @@ msgstr "온라인 계정"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "온라인 계정에 연결하고 그 계정을 어디에 이용할지 설정합니다"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4924,10 +2786,6 @@ msgstr ""
 "Google;구글;Facebook;페이스북;Twitter;트위터;Yahoo;야후;Web;웹;Online;온라인;"
 "Chat;채팅;Calendar;달력;Mail;메일;Contact;연락처;ownCloud;Kerberos;케르베로"
 "스;IMAP;SMTP;;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "시간 알 수 없음"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4941,13 +2799,6 @@ msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i시간"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i%s %i%s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4957,189 +2808,6 @@ msgstr[0] "시간"
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "분"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "완전 충전까지 %s 남음"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "주의: %s 남음"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s 남음"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "완전 충전"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "충전 중 아님"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "비었음"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "충전 중"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "방전 중"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "무선 마우스"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "무선 키보드"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "무정전 전원 장치"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "개인 휴대 정보 단말기"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "휴대전화"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "미디어 플레이어"
-
-# 태블릿 PC
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "태블릿"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "컴퓨터"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "게임 입력 장치"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "배터리"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "1차"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "추가"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "배터리"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "입력이 없을 때(_I)"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "대기 모드"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "전원 끄기"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "최대 절전"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "아무것도 하지 않기"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "배터리 전원 사용할 때"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "전원이 연결되었을 때"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "안 함"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "자동 대기 모드"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "동작 온도가 높아 성능 모드를 임시로 사용하지 않습니다."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"무릎 감지: 성능 모드를 임시로 사용할 수 없습니다. 성능 모드를 다시 사용하려"
-"면 안정된 바닥으로 옮기십시오."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "성능 모드를 임시로 사용하지 않습니다."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"배터리 부족: 전기 절약 모드를 사용합니다. 배터리가 충분히 충전되면 이전 모드"
-"가 복구됩니다."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "전기 절약 모드를 “%s”에서 활성화했습니다."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "성능 모드를 “%s”에서 활성화했습니다."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5200,6 +2868,15 @@ msgstr "100분"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2시간"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "배터리"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "장치"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5278,33 +2955,6 @@ msgstr "배터리 전원 사용(_B)"
 msgid "Delay"
 msgstr "지연 시간"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "성능"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "성능도 높고 전력 소모도 높습니다."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "균형"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "표준의 성능 및 전력 사용입니다."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "전기 절약"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "성능이 줄어들고 전력 소모도 줄어듭니다."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "전원"
@@ -5313,7 +2963,6 @@ msgstr "전원"
 msgid "View your battery status and change power saving settings"
 msgstr "배터리 상태를 보고 절전 설정을 바꿉니다"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5323,27 +2972,6 @@ msgstr ""
 "Brightness;밝기;Dim;어둡게;Blank;Monitor;모니터;DPMS;Idle;입력;Energy;에너지;"
 "절약;"
 
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "“%s” 프린터를 삭제했습니다"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "새 프린터 추가에 실패했습니다."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "UI를 읽어들일 수 없습니다: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "프린터를 추가하고 설정을 바꾸려면 잠금을 해제하십시오"
-
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "프린터"
@@ -5352,7 +2980,6 @@ msgstr "프린터"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "프린터 추가, 인쇄 작업 보기, 어떻게 인쇄할지 설정"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -5361,8 +2988,6 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "프린터 추가"
 
@@ -5401,28 +3026,6 @@ msgstr "인쇄 서버의 프린터를 보려면 사용자 이름과 암호를 �
 msgid "Username"
 msgstr "사용자 이름"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s 자세히 보기"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "적당한 드라이버가 없습니다"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "PPD 파일 선택"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"포스트스크립트 프린터 기술 파일(*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "프린터 이름에 공백, 탭, #, / 문자는 들어갈 수 없습니다"
@@ -5431,9 +3034,7 @@ msgstr "프린터 이름에 공백, 탭, #, / 문자는 들어갈 수 없습니�
 msgid "Location"
 msgstr "위치"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "드라이버"
 
@@ -5461,139 +3062,19 @@ msgstr "프린터 드라이버 선택"
 msgid "Loading drivers database…"
 msgstr "드라이버 데이터베이스 불러오는 중…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "취소"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "선택"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect 프린터"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD 프린터"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "단면"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "긴 모서리 방향(표준)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "짧은 모서리 방향(뒤집기)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "세로"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "가로"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "세로 방향 뒤집기"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "가로 방향 뒤집기"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "다시 시작"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "일시 중지"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "대기"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "일시 중지 상태"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "인증 필요"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "처리 중"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "중지"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "취소"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "중지됨"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "완료"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "이 작업을 대기열의 맨 앞으로 이동"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "작업 %u개에 인증이 필요합니다"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — 활성 작업"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "%s에서 인쇄하려면 인증 정보가 필요합니다."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5621,320 +3102,16 @@ msgstr "인증(_A)"
 msgid "No Active Printer Jobs"
 msgstr "프린터 활성 작업 없음"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "프린터 서버 잠금 해제"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s 잠금 해제."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "%s의 프린터를 보려면 사용자 이름과 암호를 입력하십시오."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "프린터 검색 중"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "직렬 포트"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "병렬 포트"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "위치: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "주소: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "서버에 인증이 필요합니다"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "양면"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "용지 형식"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "용지 서랍"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "출력 표시줄"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "해상도"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "고스트스크립트 우선 필터링"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "장당 페이지 수"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "양면"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "방향"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "일반"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "페이지 설정"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "설치 가능한 옵션"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "작업"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "이미지 화질"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "색"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "마감"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "고급"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "테스트 페이지"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "테스트 페이지"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "자동 선택"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "프린터 기본값"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "고스트스크립트 글꼴만 포함"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "PS 레벨 1로 변환"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "PS 레벨 2로 변환"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "우선 필터링 안함"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "제조사"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "활성 작업 없음"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "작업 %u개"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "인쇄 헤드 청소"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "토너 부족"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "토너 없음"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "현상액 부족"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "현상액 없음"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "마커 내용물 부족"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "마커 내용물 없음"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "덮개 열림"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "문 열림"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "용지 부족"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "용지 없음"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "연결 끊김"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "중지"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "찌꺼기 보관함이 거의 가득 찼습니다"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "찌꺼기 보관함이 가득 찼습니다"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "감광 반도체의 수명이 거의 다 되었습니다"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "감광 반도체가 이제 동작하지 않습니다"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "준비"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "인쇄 작업 받지 않음"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "처리중"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5958,6 +3135,10 @@ msgstr "인쇄 헤드 청소"
 msgid "Remove Printer"
 msgstr "프린터 제거"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "활성 작업 없음"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -5978,16 +3159,21 @@ msgid "Restart"
 msgstr "다시 시작"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "프린터 추가…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "프린터 추가…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "프린터 없음"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5995,7 +3181,6 @@ msgstr ""
 "죄송합니다. 시스템 인쇄 서비스가\n"
 "    없는 것 같습니다."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "형식"
@@ -6025,16 +3210,6 @@ msgstr "국가 또는 언어로 검색할 수 있습니다."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "미리 보기"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "야드파운드법"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "미터법"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6072,20 +3247,24 @@ msgstr ""
 "언어 설정은 인터페이스 텍스트 및 웹페이지에 사용됩니다. 형식은 숫자, 날짜, 화"
 "폐 통화에 사용됩니다."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "내 계정"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "언어(_L)"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "형식(_F)"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "로그인 화면"
 
@@ -6097,99 +3276,9 @@ msgstr "지역 및 언어"
 msgid "Select your display language and formats"
 msgstr "표시할 언어와 여러가지 형식을 선택합니다."
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;언어;Layout;배치;Keyboard;키보드;Input;입력;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "어떻게 할지 물어보기"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "아무것도 하지 않기"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "폴더 열기"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "기타 미디어"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "오디오 CD에 사용할 앱을 선택하십시오"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "비디오 DVD에 사용할 앱을 선택하십시오"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "음악 플레이어를 연결했을 때 실행할 앱을 선택하십시오"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "카메라를 연결했을 때 실행할 앱을 선택하십시오"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "소프트웨어 CD에 사용할 앱을 선택하십시오"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "오디오 DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "빈 Blu-ray 디스크"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "빈 CD 디스크"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "빈 DVD 디스크"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "빈 HD DVD 디스크"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray 비디오 디스크"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "전자책 읽기 프로그램"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD 비디오 디스크"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "사진 CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "수퍼 비디오 CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "비디오 CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "윈도우 소프트웨어"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6239,7 +3328,6 @@ msgstr "이동식 미디어"
 msgid "Configure Removable Media settings"
 msgstr "이동식 미디어 설정"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6248,114 +3336,6 @@ msgstr ""
 "device;장치;system;시스템;default;기본값;application;앱;애플리케이션;응용 프"
 "로그램;preferred;우선;cd;dvd;usb;audio;오디오;video;비디오;disc;디스크;"
 "removable;이동식;media;미디어;autorun;자동 실행;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "화면 끄기"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30초"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1분"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2분"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3분"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5분"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30분"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1시간"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1분"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2분"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3분"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4분"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5분"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8분"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10분"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12분"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15분"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "안 함"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6392,40 +3372,41 @@ msgstr "빈 화면이 된 후에 화면이 자동으로 잠길 때까지의 시�
 msgid "Show _Notifications on Lock Screen"
 msgstr "알림 표시 및 화면 잠그기(_N)"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "잠금 화면 알림(_L)"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "새 USB 장치 금지(_U)"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr "화면이 잠겨 있을 때 새로운 USB 장치와 시스템의 상호 작용을 금지합니다."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "화면 개인 정보 보호"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "시야각 제한"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "화면"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "화면 설정"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
-msgstr "screen;화면;lock;잠금;private;privacy;개인;정보;사생활;프라이버시;보호;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "위치 선택"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "확인(_O)"
+msgstr ""
+"screen;화면;lock;잠금;private;privacy;개인;정보;사생활;프라이버시;보호;"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6454,10 +3435,6 @@ msgstr "기타"
 msgid "Add Location"
 msgstr "위치 추가"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "앱 없음"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "앱 검색"
@@ -6483,93 +3460,15 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "어떤 앱에서 활동 내역에 검색 결과를 표시할지 설정합니다."
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "Search;검색;Find;찾기;Index;인덱스;색인;Hide;숨기기;Privacy;개인;정보;사생활;프라이버시;보호;Results;결과;"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "공유에 사용할 네트워크를 선택하지 않았습니다"
+msgstr ""
+"Search;검색;Find;찾기;Index;인덱스;색인;Hide;숨기기;Privacy;개인;정보;사생활;"
+"프라이버시;보호;Results;결과;"
 
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "네트워크"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "켬"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "끔"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "사용"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "동작"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "폴더 선택"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "추가"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "미디어 공유 사용"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"파일 공유를 사용하면, 현재 네트워크에 있는 다른 사람이 다음 URL을 사용해 공"
-"유 폴더를 공유할 수 있습니다: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"원격 로그인을 사용하면, 원격 사용자가 다음 보안 셸 명령으로 연결할 수 있습니"
-"다:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "개인 미디어 공유 사용"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "장치 이름 복사함"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "장치 주소 복사함"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "사용자 이름 복사함"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "암호 복사함"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6697,7 +3596,6 @@ msgstr "폴더"
 msgid "Control what you want to share with others"
 msgstr "다른 사람과 공유할 사항을 정합니다"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6714,10 +3612,6 @@ msgstr "원격 로그인 사용 여부"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "원격 로그인 사용 여부를 바꾸려면 인증이 필요합니다"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "사용자 설정"
 
 # 효과음 종류
 #: panels/sound/cc-alert-chooser.ui:12
@@ -6754,11 +3648,6 @@ msgstr "후방"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "전방"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s 시험 중"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6812,11 +3701,6 @@ msgstr "음량"
 msgid "Alert Sound"
 msgstr "경보음"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "무음"
@@ -6829,83 +3713,12 @@ msgstr "소리"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "사운드 음량과, 입력, 출력, 경고음을 바꿉니다"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Card;카드;Microphone;마이크;Volume;볼륨;음량;Fade;페이드;Balance;균형;밸런스;"
 "Bluetooth;블루투스;Headset;헤드셋;Audio;오디오;Output;출력;Input;입력;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "연결 끊김"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "연결 중"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "연결됨"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "인증 오류"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "인증 중"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "기능 줄어듬"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "연결 및 인증된 장치"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "알 수 없음"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "인증 시각:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "연결 시각:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "등록 시각:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "장치 인증에 실패했습니다: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "장치 정보 삭제에 실패했습니다: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6938,54 +3751,6 @@ msgstr "인증 및 연결"
 msgid "Forget Device"
 msgstr "장치 정보 삭제"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "오류"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "인증됨"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"썬더볼트 서브시스템을 (boltd) 설치하지 않았거나 제대로 준비하지 않았습니다."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "도크나 외부 GPU같은 장치에 직접 접근을 허용합니다."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "USB와 디스플레이 포트 장치만 붙일 수 있습니다."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"썬더볼트를 찾을 수 없습니다.\n"
-"시스템에서 썬더볼트를 지원하지 않거나, BIOS에서 썬더볼트를 껐거나, BIOS에서 "
-"지원하지 않는 보안 레벨을 설정했습니다."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "썬더볼트 지원 기능이 BIOS에서 꺼져 있습니다."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "썬더볼트 보안 단계를 결정할 수 없습니다."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "직접 접근 모드로 전환하는데 오류: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "썬더볼트 지원 기능이 없습니다"
@@ -6997,6 +3762,10 @@ msgstr "썬더볼트 서브시스템에 연결할 수 없습니다."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "직접 접근"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "도크나 외부 GPU같은 장치에 직접 접근을 허용합니다."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7014,10 +3783,10 @@ msgstr "썬더볼트"
 msgid "Manage Thunderbolt devices"
 msgstr "썬더볼트 장치를 관리합니다"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
-msgstr "Thunderbolt;썬더볼트;선더볼트;privacy;개인;정보;사생활;프라이버시;보호;"
+msgstr ""
+"Thunderbolt;썬더볼트;선더볼트;privacy;개인;정보;사생활;프라이버시;보호;"
 
 #: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 msgid "Cursor Blinking"
@@ -7214,39 +3983,6 @@ msgstr "키보드로 활성화(_E)"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "키보드로 접근성 기능을 켜고 끕니다"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "기본값"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "중간"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "크게"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "더 크게"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "매우 크게"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d픽셀"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "항상 접근성 메뉴 표시(_A)"
@@ -7360,31 +4096,6 @@ msgstr "전체 화면 번쩍이기(_S)"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "전체 창 번쩍이기(_W)"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "짧게"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "화면의 1/4"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "화면의 1/2"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "화면의 3/4"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "길게"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7542,7 +4253,6 @@ msgid "Make it easier to see, hear, type, point and click"
 msgstr "보기, 듣기, 타이핑, 누르기 편의 사항"
 
 # 주의: 원문이 'Mouse' 키워드 중복
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7557,114 +4267,6 @@ msgstr ""
 "Double;click;두번;누르기;Delay;Speed;Assist;지연;도우미;Repeat;반복;Blink;깜"
 "박;visual;hearing;audio;typing;시각;hearing;듣기;audio;오디오;typing;타이핑;"
 "animations;애니메이션;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1시간"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1일"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2일"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3일"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4일"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5일"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6일"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7일"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14일"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30일"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "휴지통의 모든 항목을 비우시겠습니까?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "휴지통의 모든 항목을 완전히 삭제합니다."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "휴지통 비우기(_E)"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "모든 임시 파일을 지우시겠습니까?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "모든 임시 파일을 완전히 삭제합니다."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "임시 파일 지우기(_P)"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1일"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7일"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30일"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "계속"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7731,62 +4333,13 @@ msgstr "파일 사용 내역 및 휴지통"
 msgid "Don't leave traces"
 msgstr "흔적 남기지 않기"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
-msgstr "usage;사용;recent;최근;history;기록;내역;히스토리;files;파일;temporary;tmp;임시;private;privacy;;보안;개인;정보;보호;trash;휴지통;purge;비우기;retain;유지;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "로그인을 제공하는 곳의 웹 주소."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "계정 추가에 실패했습니다"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "암호가 다릅니다."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "계정 등록에 실패했습니다"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "이 도메인에 대해 인증하기 위한 방법을 지원하지 않습니다"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "도메인 참여에 실패했습니다"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
 msgstr ""
-"이 로그인 이름은 쓸 수 없습니다.\n"
-"다시 시도해 보십시오."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"이 로그인 암호는 쓸 수 없습니다.\n"
-"다시 시도해 보십시오."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "도메인에 로그를 남기는데 실패했습니다"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "도메인을 찾을 수 없습니다. 잘못 쓰신 것이 아닙니까?"
+"usage;사용;recent;최근;history;기록;내역;히스토리;files;파일;temporary;tmp;임"
+"시;private;privacy;;보안;개인;정보;보호;trash;휴지통;purge;비우기;retain;유"
+"지;"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7837,10 +4390,6 @@ msgid ""
 msgstr ""
 "기업 로그인에서는 중앙에서 관리하는 사용자 계정을 이 장치에서 사용합니다. 이 "
 "계정을 사용해서 인터넷에서 회사의 자원에 접근할 수 잇습니다."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "다른 사진 찾아보기"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7908,221 +4457,6 @@ msgstr "지문 삭제(_D)"
 msgid "Fingerprint Enroll"
 msgstr "지문 등록"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "이 동작을 수행하려면 장치를 선점해야 합니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "장치를 이미 다른 프로세스에서 선점했습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "이 동작을 수행할 권한이 없습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "지문을 하나도 등록하지 않았습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "지문 등록 중에 장치와 통신이 실패했습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "지문 리더와 통신이 실패했습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "지문 데몬과 통신이 실패했습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "지문 목록 표시에 실패했습니다: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "저장한 지문 삭제에 실패했습니다: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "왼쪽 엄지"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "왼쪽 중지"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "왼쪽 검지(_L)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "왼쪽 약지"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "왼쪽 새끼"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "오른쪽 엄지"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "오른쪽 중지"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "오른쪽 검지(_R)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "오른쪽 약지"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "오른쪽 새끼"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "손가락 알 수 없음"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "완료"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "지문 입력 장치 연결이 끊어졌습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "지문 입력 장치의 저장소가 가득 찼습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "새 지문 등록에 실패했습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "등록 시작에 실패했습니다: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "새 지문 등록에 실패했습니다"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "지문 등록 중지에 실패했습니다: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"지문을 등록하려면 반복해서 지문을 입력 센서에 올려놓고 위치를 잡으십시오"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "이 지문 다시 등록(_R)…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "새 지문 스캔"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "지문 입력 장치 %s 해제에 실패했습니다: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "장치 읽기에 문제 발생"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "지문 입력 장치 %s 할당에 실패했습니다: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "지문 입력 장치 정보 가져오기에 실패했습니다: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "이번 주"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "지난 주"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e일"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%Y년 %b %e일"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "세션이 끝났습니다"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "세션이 시작했습니다"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — 계정 활동"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "이전"
@@ -8130,18 +4464,6 @@ msgstr "이전"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "다음"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "다른 암호를 입력하십시오."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "현재 암호를 다시 입력하십시오."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "암호를 바꿀 수 없습니다"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8163,6 +4485,10 @@ msgstr "새 암호"
 msgid "Confirm Password"
 msgstr "암호 확인"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "암호가 다릅니다."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "다음 로그인에 암호를 바꾸도록 허용"
@@ -8170,132 +4496,6 @@ msgstr "다음 로그인에 암호를 바꾸도록 허용"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "지금 암호 설정"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "이 종류의 도메인에 자동으로 들어갈 수 없습니다"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "도메인 또는 영역을 찾지 못했습니다"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%2$s 도메인에서 %1$s(으)로 로그인할 수 없습니다"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "암호가 잘못되었으니 다시 시도해주십시오"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "%s 도메인에 연결할 수 없습니다: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "사용자 삭제에 실패했습니다"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "원격에서 관리하는 사용자를 철회하는데 실패했습니다"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "자기 계정은 삭제할 수 없습니다."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s 사용자가 아직 로그인 중입니다"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "로그인 중인 사용자를 삭제하면 시스템이 불안정한 상태가 될 수 있습니다."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "%s 사용자의 파일을 유지하시겠습니까?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"사용자 계정을 삭제할 때 홈 디렉터리, 메일 스풀, 임시 파일을 유지할 수 있습니"
-"다."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "파일 삭제(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "파일 유지(_K)"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "정말로 원격에서 관리하는 %s의 계정을 철회하시겠습니까?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "삭제(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "계정 사용 중지됨"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "다음 로그인에 설정 예정"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "없음"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "로그인함"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "계정 서비스 연결에 실패했습니다"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "AccountService를 설치하고 사용 표시했는지 확인하십시오."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "이 설정을 바꾸려면 이 패널의 잠금을 풀어야 합니다."
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "선택한 사용자 계정 삭제"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"선택한 사용자 계정을 삭제하려면,\n"
-"먼저 * 아이콘을 누르십시오"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "사용자를 추가하고 설정을 바꾸려면 잠금을 해제하십시오"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8323,7 +4523,6 @@ msgid "Full name"
 msgstr "전체 이름"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "편집"
 
@@ -8385,7 +4584,6 @@ msgstr "사용자 계정을 추가하려면 잠금을 푸십시오."
 msgid "Add or remove users and change your password"
 msgstr "사용자 추가/제거 및 암호 바꾸기"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8430,175 +4628,6 @@ msgstr "사용자 계정 관리"
 msgid "Authentication is required to change user data"
 msgstr "사용자 데이터를 바꾸려면 인증이 필요합니다"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "새 암호는 과거 암호와 달라야 합니다."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "영문자와 숫자를 바꿔 보십시오."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "암호를 약간 바꿔 보십시오."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "이름이 들어 있지 않은 암호가 더 강력합니다."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "암호에 이름을 사용하지 말아 보십시오."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "암호에 포함된 단어를 사용하지 말아 보십시오."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "일반적인 단어를 피해 보십시오."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "단어를 조합하지 말아 보십시오."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "숫자를 더 사용해 보십시오."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "대문자를 더 사용해 보십시오."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "소문자를 더 사용해 보십시오."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "문장 기호 등 특수 문자를 더 사용해 보십시오."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "영문자, 숫자, 문장 기호를 섞어 사용해 보십시오."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "같은 글자 반복을 피해 보십시오."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"같은 종류의 문자의 반복을 피해 보십시오. 영문자, 숫자, 문장 기호를 섞어 써야 "
-"합니다."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 또는 abcd와 같은 연속된 문자를 피해 보십시오."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"암호가 더 길어야 합니다. 영문자, 숫자, 문장 기호를 섞어 사용해 보십시오."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "대소문자를 섞어서 쓰고 숫자를 사용하십시오."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "영문자, 숫자, 문장 기호를 더 쓰면 더 강력합니다."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "인증 실패"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "새 암호가 너무 짧습니다"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "새 암호가 너무 간단합니다"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "예전 암호와 새 암호가 너무 비슷합니다"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "새 암호는 이미 최근에 사용한 암호입니다."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "새 암호에 숫자나 특수 문자가 들어있어야 합니다"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "예전 암호와 새 암호가 같습니다"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "최초에 인증한 뒤에 암호가 바뀌었습니다!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "새 암호에 문자 종류가 너무 적습니다"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "알 수 없는 오류"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"사용자 이름은 보통 a-z까지 대소문자와 숫자, 그리고 다음 문자만으로 만들어야 "
-"합니다: . - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "그 사용자 이름은 사용할 수 없습니다. 다른 이름을 사용하십시오."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "사용자 이름이 너무 깁니다."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8631,55 +4660,10 @@ msgstr "디지타이저를 보정하려면 화면에 나타난 표시를 누르�
 msgid "Mis-click detected, restarting…"
 msgstr "잘못된 누름이 감지되었습니다, 다시 시작중…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "단추 %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "정의한 앱"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "키 누름 보내기"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "모니터 바꾸기"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "화면 도움말 표시"
-
-# 그래픽 태블릿
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "노트북 디스플레이에 부착된 디지타이저"
-
-# 그래픽 태블릿
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "외부 디스플레이에 부착된 디지타이저"
-
-# 그래픽 태블릿
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "외부 디지타이저 장치"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "외부 패드 장치"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "모든 디스플레이"
 
 # 그래픽 태블릿
 #: panels/wacom/cc-wacom-page.ui:16
@@ -8779,22 +4763,6 @@ msgstr "오른쪽 마우스 단추 누르기"
 msgid "Forward"
 msgstr "앞으로"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "압력, 기울임, 내장 슬라이더 포함 에어브러시 스타일러스"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "압력, 기울임, 회전 포함 에어브러시 스타일러스"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "압력 및 기울임 포함 표준 스타일러스"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "압력 포함 표준 스타일러스"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "와콤 디지타이저"
@@ -8804,56 +4772,98 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "그래픽 디지타이저의 단추 매핑을 설정하고 스타일러스의 민감도를 조정합니다"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 "Tablet;태블릿;타블렛;디지타이저;Wacom;와콤;Stylus;스타일러스;Eraser;지우개;"
 "Mouse;마우스;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "새 바로 가기…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "두 번째 누르기 흉내 내기(_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "윈도우 소프트웨어"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "토너 부족"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "두 번째 누르기 지연 시간"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "윈도우 소프트웨어"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "생산성 및 다중 작업에 대한 설정을 관리합니다"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "액세스 포인트"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "추가"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "저장(_S)"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "작업이 취소되었습니다"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>오류:</b> 설정 바꾸는 접근이 거부되었습니다"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>오류:</b> 휴대전화 장치 오류"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "등록되지 않음"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "등록됨"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "로밍"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "검색 중"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "거부됨"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8883,212 +4893,13 @@ msgstr "내 전화번호"
 msgid "Device Details"
 msgstr "장치 자세히 보기"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "제조사"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "펌웨어 버전"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G 전용"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G 전용"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G 전용"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "5G 전용"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (기본값), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (기본값), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (기본값), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (기본값), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (기본값), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (기본값), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (기본값), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (기본값), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (기본값), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (기본값), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (기본값), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (기본값), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (기본값), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (기본값), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (기본값), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (기본값), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (기본값)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (기본값), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "알 수 없음"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "SIM 카드 잠금 해제"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "잠금 해제"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "SIM %d에 대한 PIN 코드를 입력하십시오"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "SIM 카드 잠금을 해제하려면 PIN을 입력하십시오"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "SIM %d에 대한 PUK 코드를 입력하십시오"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "SIM 카드 잠금을 해제하려면 PUK를 입력하십시오"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9101,26 +4912,6 @@ msgstr[0] "잘못된 암호를 입력했습니다. %u번 시도가 남았습니�
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "%u번 시도가 남았습니다"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "잘못된 압호를 입력했습니다."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK 코드는 8자리 숫자여야 합니다"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "새 PIN 입력"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN 코드는 4-8자 사이의 숫자여야 합니다"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "잠금 해제 중…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9178,95 +4969,6 @@ msgstr "PIN으로 SIM 잠그기"
 msgid "M_odem Details"
 msgstr "모뎀 자세히 보기(_O)"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "휴대전화 실패"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "휴대전화에 연결되지 않음"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "동작을 허용하지 않습니다"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "동작을 지원하지 않습니다"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM 삽입하지 않았습니다"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "SIM PIN이 필요합니다"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "SIM PUK가 필요합니다"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM 실패"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM 다른 작업 중"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "잘못된 암호"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIM PIN2가 필요합니다"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIM PUK2가 필요합니다"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "없음"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "네트워크 서비스 없음"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "네트워크 제한 시간 초과"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS 서비스를 허용하지 않습니다"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "현재 위치의 지역에서는 로밍이 허용되지 않습니다"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "지정하지 않은 GPRS 오류"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "오류 없음"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "동작 취소"
-
-# 권한 이름
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "접근 거부"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "알 수 없는 오류"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "네트워크 모드"
@@ -9282,11 +4984,6 @@ msgstr "네트워크 선택"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "네트워크 공급자 새로고침"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9344,7 +5041,6 @@ msgstr "휴대전화 네트워크"
 msgid "Configure Telephony and mobile data connections"
 msgstr "텔레포니 및 휴대전화 데이터 연결 설정"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -9362,45 +5058,13 @@ msgstr "설정은 시스템을 설정하는 주요 인터페이스 프로그램�
 msgid "The GNOME Project"
 msgstr "그놈 프로젝트"
 
-# 커맨드라인 설명. 문장으로 번역
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "버전 번호를 표시합니다"
-
-# 커맨드라인 설명. 문장으로 번역
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "자세히 표시 모드를 사용합니다"
-
-# 커맨드라인 설명. 문장으로 번역
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "문자열을 검색합니다"
-
-# 커맨드라인 설명. 문장으로 번역
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "패널 이름 목록을 표시하고 끝냅니다"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "표시할 패널"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[패널] [인수…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "설정 분류"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "개인 정보"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "사용 가능 패널:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9457,7 +5121,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "검색 취소"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;기본 설정;Settings;설정;"
@@ -9493,22 +5156,3103 @@ msgid ""
 "application window."
 msgstr "앱 창의 최초 너비, 높이, 최대화 상태가 들어 있는 튜플."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u개 출력"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u개 입력"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "시스템 사운드"
+#~ msgid "System Bus"
+#~ msgstr "시스템 버스"
+
+#~ msgid "Full access"
+#~ msgstr "완전히 접근"
+
+#~ msgid "Session Bus"
+#~ msgstr "세션 버스"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "/dev에 완전히 접근"
+
+#~ msgid "Has network access"
+#~ msgstr "네트워크 접근 가능"
+
+#~ msgid "Home"
+#~ msgstr "내 폴더"
+
+#~ msgid "Read-only"
+#~ msgstr "읽기 전용"
+
+#~ msgid "File System"
+#~ msgstr "파일 시스템"
+
+# 권한 이름
+#~ msgid "Can change settings"
+#~ msgstr "설정 바꾸기 가능"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s 앱에 다음 권한이 내장되어 있습니다. 이 권한은 바꿀 수 없습니다. 이 권한"
+#~ "이 염려스럽다면 이 앱 삭제를 고려해 보십시오."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "앱이 여는 %u개 파일 및 링크 종류"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> 앱은 다음 종류의 파일 및 링크를 여는데 사용됩니다."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "디스크 공간의 %s 사용."
+
+#~ msgid "Select a picture"
+#~ msgstr "사진을 고르십시오"
+
+#~ msgid "_Open"
+#~ msgstr "열기(_O)"
+
+#~ msgid "multiple sizes"
+#~ msgstr "여러 개 크기"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "바탕 화면 배경 없음"
+
+#~ msgid "Current background"
+#~ msgstr "현재 배경"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "보정 장치를 사각형 구역에 놓고 “시작”을 누르십시오"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "보정 장치를 보정 위치에 놓고 “계속”을 누르십시오"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "보정 장치를 평면 위치에 놓고 “계속”을 누르십시오"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "노트북 덮개를 닫으십시오"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "내부 오류가 발생했지만 복구할 수 없습니다."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "보정에 필요한 앱을 설치하지 않았습니다."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "프로파일을 만들 수 없습니다."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "대상 화이트포인트을 얻을 수 없습니다."
+
+#~ msgid "Complete!"
+#~ msgstr "완료!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "보정에 실패했습니다"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "보정 장치를 제거할 수 있습니다."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "진행 중에는 보정 장치를 방해하지 마십시오."
+
+#~ msgid "Laptop Screen"
+#~ msgstr "노트북 화면"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "내장 웹캠"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s 모니터"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s 스캐너"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s 카메라"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s 프린터"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s 웹캠"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s에 색상 관리 사용"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s의 색 프로파일 표시"
+
+#~ msgid "Not calibrated"
+#~ msgstr "보정되지 않음"
+
+#~ msgid "Default: "
+#~ msgstr "기본값:"
+
+#~ msgid "Colorspace: "
+#~ msgstr "색 영역: "
+
+#~ msgid "Test profile: "
+#~ msgstr "시험용 프로파일: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC 프로파일 파일 선택"
+
+#~ msgid "_Import"
+#~ msgstr "가져오기(_I)"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "지원하는 ICC 프로파일"
+
+#~ msgid "All files"
+#~ msgstr "모든 파일"
+
+#~ msgid "Save Profile"
+#~ msgstr "프로파일 저장"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "선택한 장치에 대한 색 프로파일 만들기"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "측정 장치가 감지되지 않았습니다. 장치가 켜져 있고 제대로 연결되었는지 확인"
+#~ "하십시오."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "이 측정 장치는 프린터 프로파일링을 지원하지 않습니다."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "이 종류의 장치는 현재 지원하지 않습니다."
+
+#~ msgid "Standard Space"
+#~ msgstr "표준 색 공간"
+
+#~ msgid "Test Profile"
+#~ msgstr "시험용 프로파일"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "자동"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "낮은 품질"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "중간 품질"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "높은 품질"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "기본 RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "기본 CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "기본 Gray"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "제조사가 제공한 공장 출고 보정 데이터"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "이 프로파일에서는 전체 화면 교정이 불가합니다."
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "이 프로필은 이제 정확하지 않을 수도 있습니다"
+
+#~ msgid "Other…"
+#~ msgstr "기타…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "설정을 바꾸려면 잠금을 해제하십시오"
+
+#~ msgid "Today"
+#~ msgstr "오늘"
+
+#~ msgid "Yesterday"
+#~ msgstr "어제"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e일"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y년 %b %e일"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d시간"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d분"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d초"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "핫스팟"
+
+#~ msgid "24-hour"
+#~ msgstr "24시간"
+
+#~ msgid "AM / PM"
+#~ msgstr "오전 / 오후"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%Y년 %B %e일, %p %l:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%Y년 %B %e일, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%p %l:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "기술적인 문제점에 대한 보고서를 보내면 %s 개선에 도움이 됩니다. 보고서는 "
+#~ "익명으로 전송되고 개인 정보는 가려집니다. %s"
+
+#~ msgid "On"
+#~ msgstr "켬"
+
+#~ msgid "Off"
+#~ msgstr "끔"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "바뀐 사항을 적용하시겠습니까?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "바뀐 사항을 적용할 수 없습니다"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "하드웨어 제한 때문에 문제가 발생할 수도 있습니다."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "가로"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "세로 오른쪽"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "세로 왼쪽"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "가로 (뒤집힘)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "보안 부팅이 동작 중입니다"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 "
+#~ "막습니다. 현재 이 기능은 켜져 있고 올바르게 동작 중입니다."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "보안 부팅에 문제 있음"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 "
+#~ "막습니다. 현재 이 기능은 켜져 있지만, 키가 잘못되어 동작하지 않습니다."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "보안 부팅 문제는 컴퓨터의 UEFI 펌웨어 설정에서 (BIOS) 해결할 수도 있고, 하"
+#~ "드웨어 제조사에서 어떻게 설정하는지 정보를 제공합니다."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr "도움이 필요하면 하드웨어 제조사나 IT 지원 공급자에게 문의하십시오."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "보안 부팅이 꺼졌습니다"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 "
+#~ "막습니다. 현재 이 기능은 꺼져 있습니다."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "보안 부팅 기능은 컴퓨터의 UEFI 펌웨어 설정에서 (BIOS) 켤 수도 있습니다. 도"
+#~ "움이 필요하면 하드웨어 제조사나 IT 지원 공급자에게 문의하십시오."
+
+#~ msgid "Passed"
+#~ msgstr "통과"
+
+#~ msgid "Failed"
+#~ msgstr "실패"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "장치가 HSI %d 단계를 준수합니다"
+
+#~ msgid "Security Level 0"
+#~ msgstr "보안 단계 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "이 장치는 하드웨어 보안 문제에 대한 보호 기능이 없습니다. 하드웨어 또는 펌"
+#~ "웨어 설정 문제일 수 있습니다. IT 지원 공급자에게 문의하기를 권장합니다."
+
+#~ msgid "Security Level 1"
+#~ msgstr "보안 단계 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "이 장치는 하드웨어 보안 문제에 대한 최소한의 보호 기능이 있습니다. 가장 낮"
+#~ "은 수준의 장치 보안 단계이므로, 단순한 보안 위협에 대한 보호만을 제공합니"
+#~ "다."
+
+#~ msgid "Security Level 2"
+#~ msgstr "보안 단계 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "이 장치는 하드웨어 보안 문제에 대한 기초적인 보호 기능이 있습니다. 일부 흔"
+#~ "한 보안 위협에 대한 보호를 제공합니다."
+
+#~ msgid "Security Level 3"
+#~ msgstr "보안 단계 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "이 장치는 하드웨어 보안 문제에 대한 확장된 보호 기능이 있습니다. 가장 높"
+#~ "은 수준의 장치 보안 단계이므로, 고급 보안 위협에 대한 보호를 제공합니다."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "이 장치에 보안 단계를 사용할 수 없습니다."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr "하드웨어 제조사에 연락해 보안 업데이트하는데 도움을 받으십시오."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "이 문제는 장치의 UEFI 펌웨어 설정에서 해결할 수도 있고, 지원 전문가가 해결"
+#~ "할 수 있을지도 모릅니다."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr "이 문제는 장치의 UEFI 펌웨어 설정에서 해결할 수 있을지도 모릅니다."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "지원 전문가가 이 문제를 해결할 수 있을지도 모릅니다."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "장치가 시작할 때 악의적인 소프트웨어로부터 보호합니다."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "보안 부팅에 문제 있음"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "장치가 시작할 때 일부분을 보호합니다."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "보안 부팅 꺼짐"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "장치가 시작할 때 보호하지 않습니다."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "이 문제는 UEFI 펌웨어 설정을 바꿔서 발생했을 수도 있고, 운영체제 설정을 바"
+#~ "꿔서 발생했거나, 시스템의 악의적인 소프트웨어 때문에 발생했을 수도 있습니"
+#~ "다."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "이 문제는 UEFI 펌웨어 설정을 바꿔서 발생했을 수도 있고, 시스템의 악의적인 "
+#~ "소프트웨어 때문에 발생했을 수도 있습니다."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "이 문제는 운영체제 설정을 바꿔서 발생했거나, 시스템의 악의적인 소프트웨어 "
+#~ "때문에 발생했을 수도 있습니다."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "심각한 보안 위협에 노출됨."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "간단한 보안 위협에 대한 보호 제한적임."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "흔한 보안 위협에 대해 보호."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "넓은 범위의 보안 위협에 대해 보호."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "종합적인 보호"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "펌웨어 쓰기 보호"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "펌웨어 쓰기 보호 잠금"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "펌웨어 바이오스 지역"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "펌웨어 바이오스 설명"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "부팅 전 DMA 보호"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "인텔 부트가드"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "인텔 부트가드 검증 부팅"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "인텔 부트가드 ACM 보호"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "인텔 부트가드 오류 정책"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "인텔 부트가드 퓨즈"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "인텔 CET 사용"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "인텔 CET 동작"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "인텔 SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "RAM 암호화"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU 보호"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "리눅스 커널 잠김"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "리눅스 커널 검증"
+
+#~ msgid "Linux Swap"
+#~ msgstr "리눅스 스왑"
+
+# /sys/power/state 상태
+#~ msgid "Suspend To RAM"
+#~ msgstr "대기모드, RAM에 저장"
+
+# /sys/power/state 상태
+#~ msgid "Suspend To Idle"
+#~ msgstr "대기모드, 사용 중지"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI 플랫폼 키"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI 보안 부팅"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM 플랫폼 설정"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM 재구성"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "인텔 관리 엔진 제조 모드"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "인텔 관리 엔진 재정의"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "인텔 관리 엔진 버전"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "펌웨어 업데이트"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "펌웨어 증명"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "펌웨어 업데이터 검증"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "플랫폼 디버깅"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "프로세서 보안 확인"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD 롤백 보호"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD 펌웨어 리플레이 보호"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD 펌웨어 쓰기 보호"
+
+#~ msgid "Fused Platform"
+#~ msgstr "퓨즈 설정된 플랫폼"
+
+#~ msgid "Valid"
+#~ msgstr "올바름"
+
+#~ msgid "Not Valid"
+#~ msgstr "올바르지 않음"
+
+#~ msgid "Not Enabled"
+#~ msgstr "사용하지 않음"
+
+#~ msgid "Locked"
+#~ msgstr "잠겼음"
+
+#~ msgid "Not Locked"
+#~ msgstr "안 잠겼음"
+
+#~ msgid "Encrypted"
+#~ msgstr "암호화됨"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "암호화되지 않음"
+
+#~ msgid "Tainted"
+#~ msgstr "오염됨"
+
+#~ msgid "Not Tainted"
+#~ msgstr "오염되지 않음"
+
+#~ msgid "Found"
+#~ msgstr "발견됨"
+
+#~ msgid "Not Found"
+#~ msgstr "발견되지 않음"
+
+#~ msgid "Supported"
+#~ msgstr "지원함"
+
+#~ msgid "Not Supported"
+#~ msgstr "지원하지 않음"
+
+#~ msgid "Unknown"
+#~ msgstr "알 수 없음"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64비트"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32비트"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "웨일랜드"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "알 수 없음"
+
+#~ msgid "Not Available"
+#~ msgstr "사용할 수 없음"
+
+#~ msgid "System Logo"
+#~ msgstr "시스템 로고"
+
+#~ msgid "No input sources found"
+#~ msgstr "입력 소스가 없습니다"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "기타"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "바로 가기 사용자 설정"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "대체 문자 키를 이용해 추가 문자를 입력할 수 있습니다. 이 문자는 키보드에 3"
+#~ "번째 옵션으로 인쇄되어 있는 경우도 있습니다."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "왼쪽 Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "오른쪽 Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "왼쪽 Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "오른쪽 Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menu 키"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "오른쪽 Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "조합 키를 사용하면 여러가지 종류의 문자를 입력할 수 있습니다. 조합 키를 사"
+#~ "용하려면, 조합 키와 문자의 연속을 누릅니다. 예를 들어, 조합 키 다음에 "
+#~ "<b>C</b> 및 <b>o</b>를 누르면 <b>©</b> 문자를 입력하고, <b>a</b>와 <b>'</"
+#~ "b>를 누르면 <b>á</b> 문자를 입력합니다."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "입력 소스는 %s 키보드 바로 가기를 사용해 전환할 수 있습니다.\n"
+#~ "키보드 바로 가기 설정에서 바꿀 수 있습니다."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d개 수정됨"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "모든 바로 가기를 초기화하시겠습니까?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "바로 가기를 초기화하면 사용자 추가한 바로 가기에도 영향을 미칩니다. 이 동"
+#~ "작은 되돌릴 수 없습니다."
+
+#~ msgid "Reset All"
+#~ msgstr "모두 초기화"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s은(는) %s 용도로 사용 중입니다. 바꾸면 %s이(가) 사용 중지됩니다"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "새 바로 가기 입력"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "사용자 설정 바로 가기 설정"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "바로 가기 설정"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "%s 항목을 바꾸려면 새 바로 가기를 입력하십시오."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "사용자 설정 바로 가기 키 추가"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "두손가락 스크롤"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "다섯번 누름, 게글 타임!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "두번 누르기, 첫번째 단추"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "한번 누르기, 첫번째 단추"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "두번 누르기, 가운데 단추"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "한번 누르기, 가운데 단추"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "두번 누르기, 두번째 단추"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "한번 누르기, 두번째 단추"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager가 동작해야 합니다."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "안전하지 않은 네트워크 (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "안전한 네트워크 (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "안전한 네트워크 (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "안전한 네트워크 (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "안전한 네트워크"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "핫스팟을 켜면 %s에서 연결이 끊기고, 와이파이를 통한 인터넷 접근이 불가능합"
+#~ "니다."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "길이가 최소 8자가 되야 합니다"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "핫스팟을 중지하고 연결 중인 사용자를 끊으시겠습니까?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "핫스팟 중지(_S)"
+
+#~ msgid "Preserve"
+#~ msgstr "보존"
+
+#~ msgid "Permanent"
+#~ msgstr "영구"
+
+#~ msgid "Random"
+#~ msgstr "임의"
+
+# 태블릿 PC
+#~ msgid "Stable"
+#~ msgstr "안정"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "여기 입력하는 MAC 주소는 이 연결을 활성화할 때 해당 네트워크 장치의 하드웨"
+#~ "어 주소로 사용합니다. 이 기능은 MAC 복제 또는 스푸핑이라고 부릅니다. 예를 "
+#~ "들어: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "프로파일 %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "발전된 오픈 네트워크"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "기업용"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "없음"
+
+#~ msgid "Never"
+#~ msgstr "안 함"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "없음"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "약함"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "좋음"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "좋음"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "최상"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "연결 저장 지우기"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "연결 프로파일 제거"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN(가상사설망) 제거"
+
+#~ msgid "Details"
+#~ msgstr "자세히 보기"
+
+#~ msgid "automatic"
+#~ msgstr "자동"
+
+#~ msgid "Identity"
+#~ msgstr "신원"
+
+#~ msgid "Delete Address"
+#~ msgstr "주소 삭제"
+
+#~ msgid "Delete Route"
+#~ msgstr "라우팅 삭제"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "와이파이/이더넷 보안"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128비트 키(16진수 또는 ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128비트 암호글"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "동적 WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA 및 WPA2 개인용"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA 및 WPA2 기업용"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 개인용"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "연결 편집을 열 수 없습니다"
+
+#~ msgid "New Profile"
+#~ msgstr "새 프로파일"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "잘못된 설정 %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "잘못된 설정 %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "파일에서 가져오기…"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN(가상사설망) 추가"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN(가상사설망) 연결을 가져올 수 없습니다"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "“%s” 파일을 읽을 수가 없거나, 파일에 알려진 VPN(가상사설망) 연결 정보가 들"
+#~ "어 있지 않습니다\n"
+#~ "\n"
+#~ "오류: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "가져올 파일을 선택하십시오"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "이름이 “%s”인 파일이 이미 있습니다."
+
+#~ msgid "_Replace"
+#~ msgstr "바꾸기(_R)"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "%s 연결을 저장한 VPN(가상사설망) 연결로 바꾸시겠습니까?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN(가상사설망) 연결을 내보낼 수 없습니다"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "“%s” VPN(가상사설망) 연결을 %s에 내보낼 수 없습니다.\n"
+#~ "\n"
+#~ "오류: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN(가상사설망) 연결 내보내기"
+
+#~ msgid "never"
+#~ msgstr "안 함"
+
+#~ msgid "today"
+#~ msgstr "오늘"
+
+#~ msgid "yesterday"
+#~ msgstr "어제"
+
+#~ msgid "Last used"
+#~ msgstr "최근 사용"
+
+#~ msgid "Add new connection"
+#~ msgstr "새 연결 추가"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "선택한 네트워크의 상세 정보(암호 및 기타 사용자 설정 정보 포함)가 지워집니"
+#~ "다."
+
+#~ msgid "_Forget"
+#~ msgstr "저장 지우기(_F)"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "알려진 와이파이 네트워크"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "지우기(_F)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "시스템 정책이 핫스팟 사용을 막습니다"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "무선 장치에서 핫스팟 모드를 지원하지 않습니다"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "설정 URL을 지정하지 않으면 웹 프록시 자동 검색을 사용합니다."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "신뢰할 수 없는 공용 네트워크 사용은 추천하지 않습니다."
+
+#~ msgid "Status unknown"
+#~ msgstr "상태 알 수 없음"
+
+#~ msgid "Unmanaged"
+#~ msgstr "관리 안 됨"
+
+#~ msgid "Unavailable"
+#~ msgstr "사용할 수 없음"
+
+#~ msgid "Connecting"
+#~ msgstr "연결 중"
+
+#~ msgid "Authentication required"
+#~ msgstr "인증 필요"
+
+#~ msgid "Disconnecting"
+#~ msgstr "연결 끊는 중"
+
+#~ msgid "Connection failed"
+#~ msgstr "연결 실패"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "상태 알 수 없음(빠짐)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "설정에 실패했습니다"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP 설정에 실패했습니다"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP 설정 기한이 지났습니다"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "비밀 데이터가 필요하지만 전송하지 않았습니다"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x 요청의 연결이 끊겼습니다"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x 요청 설정에 실패했습니다."
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x 요청에 실패했습니다"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x 요청이 인증에 너무 오래 걸립니다"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP 서비스 시작해 실패했습니다"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP 서비스 연결이 끊어졌습니다"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP 동작 실패"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP 클라이언트 시작에 실패했습니다"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP 클라이언트 오류"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP 클라이언트 동작에 실패했습니다"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "연결 공유 서비스 시작에 실패했습니다"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "연결 공유 서비스 동작에 실패했습니다"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "자동IP 서비스 시작에 실패했습니다"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP 서비스 오류"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "자동IP 서비스 동작에 실패했습니다"
+
+#~ msgid "Line busy"
+#~ msgstr "회선 사용중"
+
+#~ msgid "No dial tone"
+#~ msgstr "전화 걸기 신호음 없음"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "서비스에 연결할 수 없습니다"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "전화 걸기 요청 시간을 초과했습니다"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "전화 걸기 시도에 실패했습니다"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "모뎀 초기화 실패"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "지정한 APN 선택에 실패했습니다"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "네트워크 검색 요소가 없습니다"
+
+#~ msgid "Network registration denied"
+#~ msgstr "네트워크 등록이 거부되었습니다"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "네트워크 등록 시간을 초과했습니다"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "요청 받은 네트워크 등록에 실패했습니다"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN 확인 실패"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "장치 펌웨어가 빠진 것 같음"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "연결이 사라졌습니다"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "기존 연결을 가정합니다"
+
+#~ msgid "Modem not found"
+#~ msgstr "모뎀을 찾을 수 없습니다"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "블루투스 연결에 실패했습니다"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM 카드 삽입하지 않았습니다"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM PIN이 필요합니다"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM의 PIN 잠금 해제 키 코드 필요합니다"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM이 잘못되었습니다"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "연결 의존성 설정에 실패했습니다"
+
+#~ msgid "Firmware missing"
+#~ msgstr "펌웨어 없음"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "케이블 분리됨"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "802.1X 보안에 (WPA-EAP) 정의하지 않은 오류"
+
+#~ msgid "no file selected"
+#~ msgstr "파일을 선택하지 않았습니다"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "EAP-METHOD 파일을 검증하는 중 지정하지 않은 오류"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 또는 PGP 개인 키"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER 또는 PEM 인증서"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "EAP-FAST PAC 파일이 없습니다"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC 파일(*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "EAP-LEAP 사용자 이름이 없습니다"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "EAP-LEAP 암호가 없습니다"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "잘못된 EAP-PEAP 인증 기관 인증서: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "잘못된 EAP-PEAP 인증 기관 인증서: 인증서를 지정하지 않았습니다"
+
+#~ msgid "missing EAP username"
+#~ msgstr "EAP 사용자 이름 없음"
+
+#~ msgid "missing EAP password"
+#~ msgstr "EAP 암호 없음"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "EAP-TLS 신원 정보 없음"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "잘못된 EAP-TLS 인증 기관 인증서: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "잘못된 EAP-TLS 인증 기관 인증서: 인증서를 지정하지 않았습니다"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "잘못된 EAP-TLS 개인 키: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "잘못된 EAP-TLS 사용자 인증서: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "암호화하지 않은 개인 키는 보안상 위험합니다"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "선택한 개인 키는 암호로 보호하지 않았습니다. 이러면 비밀 정보가 유출될 수 "
+#~ "있습니다. 암호로 보호한 개인 키를 선택하십시오.\n"
+#~ "\n"
+#~ "(OpenSSL로 개인 키를 암호로 보호할 수도 있습니다)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "개인 인증서 선택"
+
+#~ msgid "Choose your private key"
+#~ msgstr "개인 키 선택"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "잘못된 EAP-TTLS 인증기관 인증서: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "잘못된 EAP-TTLS 인증기관 인증서: 인증서를 지정하지 않았습니다"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "802.1X 보안을 검증하는 중 알 수 없는 오류"
+
+#~ msgid "Select a file"
+#~ msgstr "파일 선택"
+
+#~ msgid "missing leap-username"
+#~ msgstr "LEAP 사용자 이름이 없음"
+
+#~ msgid "missing leap-password"
+#~ msgstr "LEAP 암호가 없음"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "와이파이 암호가 없습니다."
+
+#~ msgid "missing wep-key"
+#~ msgstr "WEP 키가 없음"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr "잘못된 WEP 키: 길이가 %zu인 키에는 16진수 숫자만 들어 있어야 합니다"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr "잘못된 WEP 키: 길이가 %zu인 키에는 ASCII 문자만 들어 있어야 합니다"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "잘못된 WEP 키: 잘못된 키 길이 %zu. 키 길이는 5/13 (ASCII) 또는 10/26 (16진"
+#~ "수) 중 하나여야 합니다"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "잘못된 WEP 키: 암호글이 비어 있으면 안 됩니다"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "잘못된 WEP 키: 암호글은 64자보다 짧아야 합니다"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "잘못된 WPA-PSK: 잘못된 키 길이 %zu. [8,64] 바이트 또는 64개 16진수 숫자여"
+#~ "야 합니다"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "잘못된 WPA-PSK: 64개 16진수 숫자를 키로 해석할 수 없습니다"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "기타"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s 제거함"
+
+#~ msgid "Error removing account"
+#~ msgstr "계정 제거 오류"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s 계정"
+
+#~ msgid "Remove Account"
+#~ msgstr "계정 제거"
+
+#~ msgid "Unknown time"
+#~ msgstr "시간 알 수 없음"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i%s %i%s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "완전 충전까지 %s 남음"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "주의: %s 남음"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s 남음"
+
+#~ msgid "Fully charged"
+#~ msgstr "완전 충전"
+
+#~ msgid "Not charging"
+#~ msgstr "충전 중 아님"
+
+#~ msgid "Empty"
+#~ msgstr "비었음"
+
+#~ msgid "Charging"
+#~ msgstr "충전 중"
+
+#~ msgid "Discharging"
+#~ msgstr "방전 중"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "무선 마우스"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "무선 키보드"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "무정전 전원 장치"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "개인 휴대 정보 단말기"
+
+#~ msgid "Cellphone"
+#~ msgstr "휴대전화"
+
+#~ msgid "Media player"
+#~ msgstr "미디어 플레이어"
+
+# 태블릿 PC
+#~ msgid "Tablet"
+#~ msgstr "태블릿"
+
+#~ msgid "Computer"
+#~ msgstr "컴퓨터"
+
+#~ msgid "Gaming input device"
+#~ msgstr "게임 입력 장치"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "1차"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "추가"
+
+#~ msgid "Batteries"
+#~ msgstr "배터리"
+
+#~ msgid "When _idle"
+#~ msgstr "입력이 없을 때(_I)"
+
+#~ msgid "Suspend"
+#~ msgstr "대기 모드"
+
+#~ msgid "Power Off"
+#~ msgstr "전원 끄기"
+
+#~ msgid "Hibernate"
+#~ msgstr "최대 절전"
+
+#~ msgid "Nothing"
+#~ msgstr "아무것도 하지 않기"
+
+#~ msgid "When on battery power"
+#~ msgstr "배터리 전원 사용할 때"
+
+#~ msgid "When plugged in"
+#~ msgstr "전원이 연결되었을 때"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "안 함"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "자동 대기 모드"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "동작 온도가 높아 성능 모드를 임시로 사용하지 않습니다."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "무릎 감지: 성능 모드를 임시로 사용할 수 없습니다. 성능 모드를 다시 사용하"
+#~ "려면 안정된 바닥으로 옮기십시오."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "성능 모드를 임시로 사용하지 않습니다."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "배터리 부족: 전기 절약 모드를 사용합니다. 배터리가 충분히 충전되면 이전 모"
+#~ "드가 복구됩니다."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "전기 절약 모드를 “%s”에서 활성화했습니다."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "성능 모드를 “%s”에서 활성화했습니다."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "성능"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "성능도 높고 전력 소모도 높습니다."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "균형"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "표준의 성능 및 전력 사용입니다."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "전기 절약"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "성능이 줄어들고 전력 소모도 줄어듭니다."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "“%s” 프린터를 삭제했습니다"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "새 프린터 추가에 실패했습니다."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "UI를 읽어들일 수 없습니다: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "프린터를 추가하고 설정을 바꾸려면 잠금을 해제하십시오"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s 자세히 보기"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "적당한 드라이버가 없습니다"
+
+#~ msgid "Select PPD File"
+#~ msgstr "PPD 파일 선택"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "포스트스크립트 프린터 기술 파일(*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+#~ "GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect 프린터"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD 프린터"
+
+#~ msgid "One Sided"
+#~ msgstr "단면"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "긴 모서리 방향(표준)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "짧은 모서리 방향(뒤집기)"
+
+#~ msgid "Portrait"
+#~ msgstr "세로"
+
+#~ msgid "Landscape"
+#~ msgstr "가로"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "세로 방향 뒤집기"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "가로 방향 뒤집기"
+
+#~ msgid "Resume"
+#~ msgstr "다시 시작"
+
+#~ msgid "Pause"
+#~ msgstr "일시 중지"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "대기"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "일시 중지 상태"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "인증 필요"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "처리 중"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "중지"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "취소"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "중지됨"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "완료"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "이 작업을 대기열의 맨 앞으로 이동"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — 활성 작업"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "%s에서 인쇄하려면 인증 정보가 필요합니다."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "프린터 서버 잠금 해제"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s 잠금 해제."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "%s의 프린터를 보려면 사용자 이름과 암호를 입력하십시오."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "프린터 검색 중"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "직렬 포트"
+
+#~ msgid "Parallel Port"
+#~ msgstr "병렬 포트"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "위치: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "주소: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "서버에 인증이 필요합니다"
+
+#~ msgid "Two Sided"
+#~ msgstr "양면"
+
+#~ msgid "Paper Type"
+#~ msgstr "용지 형식"
+
+#~ msgid "Paper Source"
+#~ msgstr "용지 서랍"
+
+#~ msgid "Output Tray"
+#~ msgstr "출력 표시줄"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "해상도"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "고스트스크립트 우선 필터링"
+
+#~ msgid "Pages per side"
+#~ msgstr "장당 페이지 수"
+
+#~ msgid "Orientation"
+#~ msgstr "방향"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "일반"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "페이지 설정"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "설치 가능한 옵션"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "작업"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "이미지 화질"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "색"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "마감"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "고급"
+
+#~ msgid "Test page"
+#~ msgstr "테스트 페이지"
+
+#~ msgid "Auto Select"
+#~ msgstr "자동 선택"
+
+#~ msgid "Printer Default"
+#~ msgstr "프린터 기본값"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "고스트스크립트 글꼴만 포함"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS 레벨 1로 변환"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS 레벨 2로 변환"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "우선 필터링 안함"
+
+#~ msgid "Clean print heads"
+#~ msgstr "인쇄 헤드 청소"
+
+#~ msgid "Out of toner"
+#~ msgstr "토너 없음"
+
+#~ msgid "Low on developer"
+#~ msgstr "현상액 부족"
+
+#~ msgid "Out of developer"
+#~ msgstr "현상액 없음"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "마커 내용물 부족"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "마커 내용물 없음"
+
+#~ msgid "Open cover"
+#~ msgstr "덮개 열림"
+
+#~ msgid "Open door"
+#~ msgstr "문 열림"
+
+#~ msgid "Low on paper"
+#~ msgstr "용지 부족"
+
+#~ msgid "Out of paper"
+#~ msgstr "용지 없음"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "연결 끊김"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "중지"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "찌꺼기 보관함이 거의 가득 찼습니다"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "찌꺼기 보관함이 가득 찼습니다"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "감광 반도체의 수명이 거의 다 되었습니다"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "감광 반도체가 이제 동작하지 않습니다"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "준비"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "인쇄 작업 받지 않음"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "처리중"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "야드파운드법"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "미터법"
+
+#~ msgid "Ask what to do"
+#~ msgstr "어떻게 할지 물어보기"
+
+#~ msgid "Do nothing"
+#~ msgstr "아무것도 하지 않기"
+
+#~ msgid "Open folder"
+#~ msgstr "폴더 열기"
+
+#~ msgid "Other Media"
+#~ msgstr "기타 미디어"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "오디오 CD에 사용할 앱을 선택하십시오"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "비디오 DVD에 사용할 앱을 선택하십시오"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "음악 플레이어를 연결했을 때 실행할 앱을 선택하십시오"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "카메라를 연결했을 때 실행할 앱을 선택하십시오"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "소프트웨어 CD에 사용할 앱을 선택하십시오"
+
+#~ msgid "audio DVD"
+#~ msgstr "오디오 DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "빈 Blu-ray 디스크"
+
+#~ msgid "blank CD disc"
+#~ msgstr "빈 CD 디스크"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "빈 DVD 디스크"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "빈 HD DVD 디스크"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray 비디오 디스크"
+
+#~ msgid "e-book reader"
+#~ msgstr "전자책 읽기 프로그램"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD 비디오 디스크"
+
+#~ msgid "Picture CD"
+#~ msgstr "사진 CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "수퍼 비디오 CD"
+
+#~ msgid "Video CD"
+#~ msgstr "비디오 CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "화면 끄기"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30초"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1분"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2분"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3분"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5분"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30분"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1시간"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1분"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2분"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3분"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4분"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5분"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8분"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10분"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12분"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15분"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "안 함"
+
+#~ msgid "Select Location"
+#~ msgstr "위치 선택"
+
+#~ msgid "_OK"
+#~ msgstr "확인(_O)"
+
+#~ msgid "No applications found"
+#~ msgstr "앱 없음"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "공유에 사용할 네트워크를 선택하지 않았습니다"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "켬"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "끔"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "사용"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "동작"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "폴더 선택"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "미디어 공유 사용"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "파일 공유를 사용하면, 현재 네트워크에 있는 다른 사람이 다음 URL을 사용해 "
+#~ "공유 폴더를 공유할 수 있습니다: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "원격 로그인을 사용하면, 원격 사용자가 다음 보안 셸 명령으로 연결할 수 있습"
+#~ "니다:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "개인 미디어 공유 사용"
+
+#~ msgid "Device name copied"
+#~ msgstr "장치 이름 복사함"
+
+#~ msgid "Device address copied"
+#~ msgstr "장치 주소 복사함"
+
+#~ msgid "Username copied"
+#~ msgstr "사용자 이름 복사함"
+
+#~ msgid "Password copied"
+#~ msgstr "암호 복사함"
+
+#~ msgid "Custom"
+#~ msgstr "사용자 설정"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s 시험 중"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "연결 끊김"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "연결 중"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "연결됨"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "인증 오류"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "인증 중"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "기능 줄어듬"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "연결 및 인증된 장치"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "알 수 없음"
+
+#~ msgid "Authorized at:"
+#~ msgstr "인증 시각:"
+
+#~ msgid "Connected at:"
+#~ msgstr "연결 시각:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "등록 시각:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "장치 인증에 실패했습니다: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "장치 정보 삭제에 실패했습니다: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "오류"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "인증됨"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "썬더볼트 서브시스템을 (boltd) 설치하지 않았거나 제대로 준비하지 않았습니"
+#~ "다."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "USB와 디스플레이 포트 장치만 붙일 수 있습니다."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "썬더볼트를 찾을 수 없습니다.\n"
+#~ "시스템에서 썬더볼트를 지원하지 않거나, BIOS에서 썬더볼트를 껐거나, BIOS에"
+#~ "서 지원하지 않는 보안 레벨을 설정했습니다."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "썬더볼트 지원 기능이 BIOS에서 꺼져 있습니다."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "썬더볼트 보안 단계를 결정할 수 없습니다."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "직접 접근 모드로 전환하는데 오류: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "기본값"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "중간"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "크게"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "더 크게"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "매우 크게"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d픽셀"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "짧게"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "화면의 1/4"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "화면의 1/2"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "화면의 3/4"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "길게"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1시간"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1일"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2일"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3일"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4일"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5일"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6일"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7일"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14일"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30일"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "휴지통의 모든 항목을 비우시겠습니까?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "휴지통의 모든 항목을 완전히 삭제합니다."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "휴지통 비우기(_E)"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "모든 임시 파일을 지우시겠습니까?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "모든 임시 파일을 완전히 삭제합니다."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "임시 파일 지우기(_P)"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1일"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7일"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30일"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "계속"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "로그인을 제공하는 곳의 웹 주소."
+
+#~ msgid "Failed to add account"
+#~ msgstr "계정 추가에 실패했습니다"
+
+#~ msgid "Failed to register account"
+#~ msgstr "계정 등록에 실패했습니다"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "이 도메인에 대해 인증하기 위한 방법을 지원하지 않습니다"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "도메인 참여에 실패했습니다"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "이 로그인 이름은 쓸 수 없습니다.\n"
+#~ "다시 시도해 보십시오."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "이 로그인 암호는 쓸 수 없습니다.\n"
+#~ "다시 시도해 보십시오."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "도메인에 로그를 남기는데 실패했습니다"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "도메인을 찾을 수 없습니다. 잘못 쓰신 것이 아닙니까?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "다른 사진 찾아보기"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "이 동작을 수행하려면 장치를 선점해야 합니다"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "장치를 이미 다른 프로세스에서 선점했습니다"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "이 동작을 수행할 권한이 없습니다"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "지문을 하나도 등록하지 않았습니다"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "지문 등록 중에 장치와 통신이 실패했습니다"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "지문 리더와 통신이 실패했습니다"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "지문 데몬과 통신이 실패했습니다"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "지문 목록 표시에 실패했습니다: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "저장한 지문 삭제에 실패했습니다: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "왼쪽 엄지"
+
+#~ msgid "Left middle finger"
+#~ msgstr "왼쪽 중지"
+
+#~ msgid "_Left index finger"
+#~ msgstr "왼쪽 검지(_L)"
+
+#~ msgid "Left ring finger"
+#~ msgstr "왼쪽 약지"
+
+#~ msgid "Left little finger"
+#~ msgstr "왼쪽 새끼"
+
+#~ msgid "Right thumb"
+#~ msgstr "오른쪽 엄지"
+
+#~ msgid "Right middle finger"
+#~ msgstr "오른쪽 중지"
+
+#~ msgid "_Right index finger"
+#~ msgstr "오른쪽 검지(_R)"
+
+#~ msgid "Right ring finger"
+#~ msgstr "오른쪽 약지"
+
+#~ msgid "Right little finger"
+#~ msgstr "오른쪽 새끼"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "손가락 알 수 없음"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "완료"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "지문 입력 장치 연결이 끊어졌습니다"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "지문 입력 장치의 저장소가 가득 찼습니다"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "새 지문 등록에 실패했습니다"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "등록 시작에 실패했습니다: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "새 지문 등록에 실패했습니다"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "지문 등록 중지에 실패했습니다: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "지문을 등록하려면 반복해서 지문을 입력 센서에 올려놓고 위치를 잡으십시오"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "이 지문 다시 등록(_R)…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "새 지문 스캔"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "지문 입력 장치 %s 해제에 실패했습니다: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "장치 읽기에 문제 발생"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "지문 입력 장치 %s 할당에 실패했습니다: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "지문 입력 장치 정보 가져오기에 실패했습니다: %s"
+
+#~ msgid "This Week"
+#~ msgstr "이번 주"
+
+#~ msgid "Last Week"
+#~ msgstr "지난 주"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e일"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y년 %b %e일"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "세션이 끝났습니다"
+
+#~ msgid "Session Started"
+#~ msgstr "세션이 시작했습니다"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — 계정 활동"
+
+#~ msgid "Please choose another password."
+#~ msgstr "다른 암호를 입력하십시오."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "현재 암호를 다시 입력하십시오."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "암호를 바꿀 수 없습니다"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "이 종류의 도메인에 자동으로 들어갈 수 없습니다"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "도메인 또는 영역을 찾지 못했습니다"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%2$s 도메인에서 %1$s(으)로 로그인할 수 없습니다"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "암호가 잘못되었으니 다시 시도해주십시오"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "%s 도메인에 연결할 수 없습니다: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "사용자 삭제에 실패했습니다"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "원격에서 관리하는 사용자를 철회하는데 실패했습니다"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "자기 계정은 삭제할 수 없습니다."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s 사용자가 아직 로그인 중입니다"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "로그인 중인 사용자를 삭제하면 시스템이 불안정한 상태가 될 수 있습니다."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "%s 사용자의 파일을 유지하시겠습니까?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "사용자 계정을 삭제할 때 홈 디렉터리, 메일 스풀, 임시 파일을 유지할 수 있습"
+#~ "니다."
+
+#~ msgid "_Delete Files"
+#~ msgstr "파일 삭제(_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "파일 유지(_K)"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "정말로 원격에서 관리하는 %s의 계정을 철회하시겠습니까?"
+
+#~ msgid "_Delete"
+#~ msgstr "삭제(_D)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "계정 사용 중지됨"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "다음 로그인에 설정 예정"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "없음"
+
+#~ msgid "Logged in"
+#~ msgstr "로그인함"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "계정 서비스 연결에 실패했습니다"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "AccountService를 설치하고 사용 표시했는지 확인하십시오."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "이 설정을 바꾸려면 이 패널의 잠금을 풀어야 합니다."
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "선택한 사용자 계정 삭제"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "선택한 사용자 계정을 삭제하려면,\n"
+#~ "먼저 * 아이콘을 누르십시오"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "사용자를 추가하고 설정을 바꾸려면 잠금을 해제하십시오"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "새 암호는 과거 암호와 달라야 합니다."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "영문자와 숫자를 바꿔 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "암호를 약간 바꿔 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "이름이 들어 있지 않은 암호가 더 강력합니다."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "암호에 이름을 사용하지 말아 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "암호에 포함된 단어를 사용하지 말아 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "일반적인 단어를 피해 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "단어를 조합하지 말아 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "숫자를 더 사용해 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "대문자를 더 사용해 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "소문자를 더 사용해 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "문장 기호 등 특수 문자를 더 사용해 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "영문자, 숫자, 문장 기호를 섞어 사용해 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "같은 글자 반복을 피해 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "같은 종류의 문자의 반복을 피해 보십시오. 영문자, 숫자, 문장 기호를 섞어 써"
+#~ "야 합니다."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 또는 abcd와 같은 연속된 문자를 피해 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "암호가 더 길어야 합니다. 영문자, 숫자, 문장 기호를 섞어 사용해 보십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "대소문자를 섞어서 쓰고 숫자를 사용하십시오."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "영문자, 숫자, 문장 기호를 더 쓰면 더 강력합니다."
+
+#~ msgid "Authentication failed"
+#~ msgstr "인증 실패"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "새 암호가 너무 짧습니다"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "새 암호가 너무 간단합니다"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "예전 암호와 새 암호가 너무 비슷합니다"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "새 암호는 이미 최근에 사용한 암호입니다."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "새 암호에 숫자나 특수 문자가 들어있어야 합니다"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "예전 암호와 새 암호가 같습니다"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "최초에 인증한 뒤에 암호가 바뀌었습니다!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "새 암호에 문자 종류가 너무 적습니다"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "알 수 없는 오류"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "사용자 이름은 보통 a-z까지 대소문자와 숫자, 그리고 다음 문자만으로 만들어"
+#~ "야 합니다: . - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "그 사용자 이름은 사용할 수 없습니다. 다른 이름을 사용하십시오."
+
+#~ msgid "The username is too long."
+#~ msgstr "사용자 이름이 너무 깁니다."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "단추 %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "정의한 앱"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "키 누름 보내기"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "모니터 바꾸기"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "화면 도움말 표시"
+
+# 그래픽 태블릿
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "노트북 디스플레이에 부착된 디지타이저"
+
+# 그래픽 태블릿
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "외부 디스플레이에 부착된 디지타이저"
+
+# 그래픽 태블릿
+#~ msgid "External tablet device"
+#~ msgstr "외부 디지타이저 장치"
+
+#~ msgid "All Displays"
+#~ msgstr "모든 디스플레이"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "압력, 기울임, 내장 슬라이더 포함 에어브러시 스타일러스"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "압력, 기울임, 회전 포함 에어브러시 스타일러스"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "압력 및 기울임 포함 표준 스타일러스"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "압력 포함 표준 스타일러스"
+
+#~ msgid "New shortcut…"
+#~ msgstr "새 바로 가기…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "작업이 취소되었습니다"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>오류:</b> 설정 바꾸는 접근이 거부되었습니다"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>오류:</b> 휴대전화 장치 오류"
+
+#~ msgid "Not Registered"
+#~ msgstr "등록되지 않음"
+
+#~ msgid "Registered"
+#~ msgstr "등록됨"
+
+#~ msgid "Roaming"
+#~ msgstr "로밍"
+
+#~ msgid "Searching"
+#~ msgstr "검색 중"
+
+#~ msgid "Denied"
+#~ msgstr "거부됨"
+
+#~ msgid "2G Only"
+#~ msgstr "2G 전용"
+
+#~ msgid "3G Only"
+#~ msgstr "3G 전용"
+
+#~ msgid "4G Only"
+#~ msgstr "4G 전용"
+
+#~ msgid "5G Only"
+#~ msgstr "5G 전용"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (기본값)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (기본값), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (기본값), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (기본값), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (기본값)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (기본값), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (기본값), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (기본값)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (기본값), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (기본값), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (기본값)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (기본값), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (기본값), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (기본값)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (기본값), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (기본값), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (기본값)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (기본값), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (기본값)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (기본값), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (기본값)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (기본값), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (기본값)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (기본값), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (기본값)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (기본값), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (기본값)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (기본값), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "알 수 없음"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "SIM 카드 잠금 해제"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "SIM %d에 대한 PIN 코드를 입력하십시오"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "SIM 카드 잠금을 해제하려면 PIN을 입력하십시오"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "SIM %d에 대한 PUK 코드를 입력하십시오"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "SIM 카드 잠금을 해제하려면 PUK를 입력하십시오"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "잘못된 압호를 입력했습니다."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK 코드는 8자리 숫자여야 합니다"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "새 PIN 입력"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN 코드는 4-8자 사이의 숫자여야 합니다"
+
+#~ msgid "Unlocking…"
+#~ msgstr "잠금 해제 중…"
+
+#~ msgid "Phone failure"
+#~ msgstr "휴대전화 실패"
+
+#~ msgid "No connection to phone"
+#~ msgstr "휴대전화에 연결되지 않음"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "동작을 허용하지 않습니다"
+
+#~ msgid "Operation not supported"
+#~ msgstr "동작을 지원하지 않습니다"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM 삽입하지 않았습니다"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM PIN이 필요합니다"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM PUK가 필요합니다"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM 실패"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM 다른 작업 중"
+
+#~ msgid "Incorrect password"
+#~ msgstr "잘못된 암호"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM PIN2가 필요합니다"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM PUK2가 필요합니다"
+
+#~ msgid "Not found"
+#~ msgstr "없음"
+
+#~ msgid "No network service"
+#~ msgstr "네트워크 서비스 없음"
+
+#~ msgid "Network timeout"
+#~ msgstr "네트워크 제한 시간 초과"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS 서비스를 허용하지 않습니다"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "현재 위치의 지역에서는 로밍이 허용되지 않습니다"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "지정하지 않은 GPRS 오류"
+
+#~ msgid "No Error"
+#~ msgstr "오류 없음"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "동작 취소"
+
+# 권한 이름
+#~ msgid "Access denied"
+#~ msgstr "접근 거부"
+
+#~ msgid "Unknown Error"
+#~ msgstr "알 수 없는 오류"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+# 커맨드라인 설명. 문장으로 번역
+#~ msgid "Display version number"
+#~ msgstr "버전 번호를 표시합니다"
+
+# 커맨드라인 설명. 문장으로 번역
+#~ msgid "Enable verbose mode"
+#~ msgstr "자세히 표시 모드를 사용합니다"
+
+# 커맨드라인 설명. 문장으로 번역
+#~ msgid "Search for the string"
+#~ msgstr "문자열을 검색합니다"
+
+# 커맨드라인 설명. 문장으로 번역
+#~ msgid "List possible panel names and exit"
+#~ msgstr "패널 이름 목록을 표시하고 끝냅니다"
+
+#~ msgid "Panel to display"
+#~ msgstr "표시할 패널"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[패널] [인수…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "사용 가능 패널:"
+
+#~ msgid "System Sounds"
+#~ msgstr "시스템 사운드"

--- a/po/ko.po~
+++ b/po/ko.po~
@@ -1,0 +1,9514 @@
+# gnome-control-center Korean message translation
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Young-Ho Cha <ganadist@chollian.net>, 2002, 2006.
+# Seong-ho Cho <darkcircle.0426@gmail.com>, 2011, 2012.
+# Changwoo Ryu <cwryu@debian.org>, 2002-2022.
+#
+#
+# - 주의: 여러가지 분야의 어려운 용어가 많습니다. 충분히 시간을 두고 실제 의미가
+#   무엇인지, UI에 어떻게 나타나는지 이해하고 번역해 주세요. 기계적인 번역은
+#   품질 저하의 지름길입니다. 모를 만한 용어는 아래에 기록.
+#
+# - 이 프로그램의 이름인 "Control Center"는 "제어 센터"로 번역.
+# - 용어
+#   - Airplane Mode: 비행기 모드
+#   - Express Keys™: 익스프레스키 (Wacom 설정에서 쓰는 용어 그대로)
+#   - fuse: 퓨즈 (보안 기능 관련, one time programmable option, 한번 바꾸면 되돌릴 수 없는 세팅)
+#   - input source: 입력 소스 ("source"라고만 써져 있어도 "입력 소스"로 번역)
+#   - night light: 야간 모드
+#   - parental control: 자녀 보호 기능
+#   - prefix (ipv6 관련): 프리픽스
+#   - tablet: 태블릿 (tablet PC의 경우), 디지타이저 (graphics tablet) 구분하도록 주의
+#   - VPN: "VPN(가상사설망)"
+#   - wide gamut: 광색역 (LCD 디스플레이 종류)
+#
+# - 검색 키워드는 원문과 번역문을 같이 세미콜론으로 구분해 기입한다. 예를 들어:
+#
+#   msgid "Wallpaper;Screen;Desktop;"
+#   msgstr "Wallpaper;배경 이미지;Screen;화면;Desktop;바탕 화면;"
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"PO-Revision-Date: 2022-09-03 22:48+0900\n"
+"Last-Translator: Changwoo Ryu <cwryu@debian.org>\n"
+"Language-Team: GNOME Korea <gnome-kr@googlegroups.com>\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 1.5.3\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "시스템 버스"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "완전히 접근"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "세션 버스"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "장치"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "/dev에 완전히 접근"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "네트워크"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "네트워크 접근 가능"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "내 폴더"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "읽기 전용"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "파일 시스템"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "설정"
+
+# 권한 이름
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "설정 바꾸기 가능"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr "%s 앱에 다음 권한이 내장되어 있습니다. 이 권한은 바꿀 수 없습니다. 이 권한이 염려스럽다면 이 앱 삭제를 고려해 보십시오."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "앱이 여는 %u개 파일 및 링크 종류"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> 앱은 다음 종류의 파일 및 링크를 여는데 사용됩니다."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "디스크 공간의 %s 사용."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "앱"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "앱 없음"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "앱 설치…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "열기"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "자세히 보기"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "검색"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "시스템 검색을 받아서 결과를 보냅니다."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "사용 않음"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "알림"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "시스템 알림을 표시합니다."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "백그라운드에서 실행"
+
+# 백그라운드 실행 설명
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "앱을 닫았을 때 활동을 허용합니다."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "스크린샷"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "언제든지 화면의 사진을 찍습니다."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "배경 바꾸기"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "데스크톱 배경을 바꿉니다."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "소리"
+
+# 권한 설명
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "소리를 낼 수 있습니다."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "바로 가기 금지"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "표준 키보드 바로 가기를 금지합니다."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "카메라"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "카메라로 사진을 찍습니다."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "마이크"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "마이크로 오디오를 녹음합니다."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "위치 서비스"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "장치의 위치 정보에 접근합니다."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "내장 권한"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "앱에서 필요한 시스템 권한"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "파일 및 링크 연결"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "저장 공간"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "결과가 없습니다"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "다르게 검색해 보십시오"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "파일 및 링크 연결"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "파일 종류"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "링크 종류"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "초기화"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "이 앱이 데이터와 캐시에 사용하고 있는 디스크 공간의 크기."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "앱"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "데이터"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "캐시"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>전체</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "캐시 지우기…"
+
+# 권한 이름
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "여러가지 앱 권한과 설정 조정"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"application;애플리케이션;앱;프로그램;flatpak;permission;권한;setting;설정;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "사진을 고르십시오"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "취소(_C)"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "열기(_O)"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "여러 개 크기"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "바탕 화면 배경 없음"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "현재 배경"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "모양새"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "기본값"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "어둡게"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "배경"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "사진 추가…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "모양"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "배경 이미지 또는 UI 색을 바꿉니다"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Background;Wallpaper;배경;월페이퍼;Screen;화면;Desktop;바탕 화면;Style;스타일;모양;Light;밝게;Dark;어둡게;다크;Appearance;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "사용"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "블루투스 없음"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "블루투스를 사용하려면 동글을 연결하십시오."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "블루투스 꺼짐"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "장치에 연결하고 파일 전송을 받으려면 켜십시오."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "비행기 모드가 켜져 있습니다"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "비행기 모드가 켜져 있을 때 블루투스가 꺼집니다."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "비행기 모드 끄기"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "하드웨어 비행기 모드가 켜져 있습니다"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "블루투스를 사용하려면 비행기 모드 스위치를 끄십시오."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "블루투스"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "블루투스를 켜거나 끄고 블루투스 장치에 연결합니다"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;공유;bluetooth;블루투스;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "카메라가 꺼졌습니다"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "어떤 앱도 사진이나 영상을 찍을 수 없습니다."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"카메라를 사용하면 사진이나 영상을 찍을 수 있습니다. 카메라를 사용하지 않으면 일부 앱이 제대로 동작하지 않을 수 있습니다.\n"
+"\n"
+"카메라를 사용하려면 아래에서 앱을 허용하십시오."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "카메라 접근을 요청한 앱이 없습니다"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "내 사진을 보호합니다"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "camera;카메라;photos;사진;video;비디오;webcam;웹캠;캠;lock;잠금;private;privacy;개인;정보;사생활;프라이버시;보호;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "보정 장치를 사각형 구역에 놓고 “시작”을 누르십시오"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "보정 장치를 보정 위치에 놓고 “계속”을 누르십시오"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "보정 장치를 평면 위치에 놓고 “계속”을 누르십시오"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "노트북 덮개를 닫으십시오"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "내부 오류가 발생했지만 복구할 수 없습니다."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "보정에 필요한 앱을 설치하지 않았습니다."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "프로파일을 만들 수 없습니다."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "대상 화이트포인트을 얻을 수 없습니다."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "완료!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "보정에 실패했습니다"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "보정 장치를 제거할 수 있습니다."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "진행 중에는 보정 장치를 방해하지 마십시오."
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "디스플레이 보정"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "시작(_S)"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "다시 시작(_R)"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "완료(_D)"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "노트북 화면"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "내장 웹캠"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s 모니터"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s 스캐너"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s 카메라"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s 프린터"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s 웹캠"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s에 색상 관리 사용"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s의 색 프로파일 표시"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "보정되지 않음"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "기본값:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "색 영역: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "시험용 프로파일: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "ICC 프로파일 파일 선택"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "가져오기(_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "지원하는 ICC 프로파일"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "모든 파일"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "화면"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "프로파일 저장"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "저장(_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "선택한 장치에 대한 색 프로파일 만들기"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"측정 장치가 감지되지 않았습니다. 장치가 켜져 있고 제대로 연결되었는지 확인하"
+"십시오."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "이 측정 장치는 프린터 프로파일링을 지원하지 않습니다."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "이 종류의 장치는 현재 지원하지 않습니다."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "화면 보정"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "보정 품질"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"보정을 할 때 만드는 프로파일을 사용해 화면의 색을 관리할 수 있습니다. 보정에 "
+"많은 시간을 들일 수록 색 프로파일의 품질이 좋아집니다."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "보정이 진행 중일 때는 컴퓨터를 사용할 수 없습니다."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "품질"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "예상 시간"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "보정 장치"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "보정에 사용할 센서 장치를 선택하십시오."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "디스플레이 종류"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "연결된 디스플레이 종류를 선택하십시오."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "프로파일 화이트 포인트"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"디스플레이의 목표 화이트 포인트를 선택하십시오. 대부분의 디스플레이는 경우 "
+"Illuminant D65로 보정합니다."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "화면 밝기"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"화면을 자기에 맞는 밝기로 맞추십시오. 색 관리가 이 밝기 수준에 맞게 조정됩니"
+"다."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"아니면 이 장치에 대한 다른 프로파일에 사용한 밝기 단계를 사용할 수도 있습니"
+"다."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "프로파일 이름"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"다른 컴퓨터의 색 프로파일을 사용할 수도 있고, 다른 조명에 대한 프로파일을 만"
+"들 수도 있습니다."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "프로파일 이름:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "요약"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "프로파일을 성공적으로 만들었습니다!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "프로파일 복사"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "쓰기 가능 미디어 필요"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/리눅스</a>, <a href=\"osx\">애플 OS X</a> 및 <a href="
+"\"windows\">마이크로소프트 윈도우Microsoft Windows</a> 시스템의 프로파일 사용"
+"법 안내를 읽어보면 도움이 됩니다."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "프로파일 추가"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"문제가 발생했습니다. 프로파일이 동작하지 않을 수도 있습니다. <a href=\"\">자"
+"세히 보기.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "파일 가져오기(_I)…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "추가(_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "색상 관리 기능을 사용하려면 각 장치는 최신 색상 프로파일이 필요합니다."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "더 알아보기"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "색상 관리에 대해 더 알아봅니다"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "모든 사용자에 대해 설정(_S)"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "이 컴퓨터의 모든 사용자가 사용할 프로파일을 설정합니다"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "사용(_E)"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "프로파일 추가(_A)"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "보정(_C)…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "장치 보정"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "프로파일 제거(_R)"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "자세히 보기(_V)"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "색 관리가 되는 장치를 검색할 수 없습니다"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "프로젝터"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "플라스마"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD(CCFL 백라이트)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD(RGB LED 백라이트)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD(백색 LED 백라이트)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "광색역 LCD(CCFL 백라이트)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "광색역 LCD(RGB LED 백라이트)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "높게"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40분"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "중간"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30분"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "낮게"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15분"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "디스플레이에 따라"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (인쇄 및 출판)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (사진 및 그래픽)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "표준 색 공간"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "시험용 프로파일"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "자동"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "낮은 품질"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "중간 품질"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "높은 품질"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "기본 RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "기본 CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "기본 Gray"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "제조사가 제공한 공장 출고 보정 데이터"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "이 프로파일에서는 전체 화면 교정이 불가합니다."
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "이 프로필은 이제 정확하지 않을 수도 있습니다"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "색"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "디스플레이, 카메라, 프린터같은 장치의 색을 보정합니다"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Color;색;ICC;Profile;프로파일;Calibrate;보정;Printer;프린터;Display;디스플레"
+"이;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "기타…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "언어 선택"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "선택(_S)"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "언어 없음"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "기타…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "설정을 바꾸려면 잠금을 해제하십시오"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "일부 설정은 바꾸려면 먼저 잠금을 해제해야 합니다."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "잠금 해제…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "시간 증가"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "분 증가"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "시각"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "시간 감소"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "분 감소"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "오늘"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "어제"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e일"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%Y년 %b %e일"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d시간"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d분"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d초"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0초"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "핫스팟"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24시간"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "오전 / 오후"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%Y년 %B %e일, %p %l:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%Y년 %B %e일, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%p %l:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "날짜 및 시각"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "연"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "월"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "1월"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "2월"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "3월"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "4월"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "5월"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "6월"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "7월"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "8월"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "9월"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "10월"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "11월"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "12월"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "일"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "표준 시간대"
+
+# 커맨드라인 설명. 문장으로 번역
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "도시를 검색합니다"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "날짜 및 시각 자동(_D)"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "인터넷 연결 필요"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "날짜 및 시각(_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "표준 시간대 자동(_Z)"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "위치 서비스를 켜야 하고 인터넷 접근이 필요"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "사용"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "표준 시간대(_O)"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "시각 형식(_F)"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "날짜와 시각(표준 시간대 포함)을 바꿉니다"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;시계;Timezone;시간대;Location;위치;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "시스템의 날짜와 시간 설정을 바꿉니다"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "시간 또는 날짜 설정을 바꾸려면 인증이 필요합니다."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "웹(_W)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "메일(_M)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "달력(_C)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "음악(_U)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "영상(_V)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "사진(_P)"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "기본 앱"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "기본 앱 설정"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"default;기본;기본값;application;프로그램;앱;애플리케이션;preferred;media;미디"
+"어;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"기술적인 문제점에 대한 보고서를 보내면 %s 개선에 도움이 됩니다. 보고서는 익명"
+"으로 전송되고 개인 정보는 가려집니다. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "문제점 보고"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "문제점 보고서 자동(_A)"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "진단"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "문제점 보고하기"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;진단;검사;crash;크래시;이상종료;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "켬"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "끔"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "바뀐 사항을 적용하시겠습니까?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "바뀐 사항을 적용할 수 없습니다"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "하드웨어 제한 때문에 문제가 발생할 수도 있습니다."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "적용(_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "뒤로"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "디스플레이 설정 불가"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "다중 디스플레이"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "연결"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "동일 화면"
+
+# top bar: gnome-shell과 일치
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "위 막대 및 현재활동 포함"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "주 디스플레이"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "야간 모드"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "가로"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "세로 오른쪽"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "세로 왼쪽"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "가로 (뒤집힘)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "방향"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "해상도"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "주사율"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "TV에 맞게 조정"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "비율 조정"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "야간 모드를 사용할 수 없습니다"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr "사용하는 그래픽 드라이버 때문이거나, 데스크톱을 원격에서 사용해서 그럴 수 있습니다"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "내일까지 임시로 사용 않기"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "필터 다시 시작"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"야간 모드 기능은 화면 색을 따뜻하게 만듭니다. 이 기능을 사용하면 눈의 부담과 "
+"피로를 덜어줍니다."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "일정"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "일몰에서 일출"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "일정 수동 설정"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "시각"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "시작"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "시간"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "분"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "오전"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "오후"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "끝"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "색 온도"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "디스플레이"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "연결한 모니터와 프로젝터 사용법을 정합니다"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;패널;Projector;프로젝터;xrandr;Screen;화면;Resolution;해상도;Refresh;주"
+"사율;Monitor;모니터;Night;Light;야간;모드;조명;Blue;파란빛;redshift;적색편이;"
+"color;색;sunset;일몰;sunrise;일출;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:109
+msgid "Secure Boot is Active"
+msgstr "보안 부팅이 동작 중입니다"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr "보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 막습니다. 현재 이 기능은 켜져 있고 올바르게 동작 중입니다."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "보안 부팅에 문제 있음"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr "보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 막습니다. 현재 이 기능은 켜져 있지만, 키가 잘못되어 동작하지 않습니다."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr "보안 부팅 문제는 컴퓨터의 UEFI 펌웨어 설정에서 (BIOS) 해결할 수도 있고, 하드웨어 제조사에서 어떻게 설정하는지 정보를 제공합니다."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "도움이 필요하면 하드웨어 제조사나 IT 지원 공급자에게 문의하십시오."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "보안 부팅이 꺼졌습니다"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr "보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 막습니다. 현재 이 기능은 꺼져 있습니다."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr "보안 부팅 기능은 컴퓨터의 UEFI 펌웨어 설정에서 (BIOS) 켤 수도 있습니다. 도움이 필요하면 하드웨어 제조사나 IT 지원 공급자에게 문의하십시오."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"보안 부팅 기능은 장치가 시작할 때 악의적인 소프트웨어를 읽어들이지 못하게 막습니다.\n"
+"\n"
+"더 자세히 알고 싶으면, 하드웨어 제조사나 IT 지원 공급자에 문의하십시오."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "통과"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "실패"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "장치가 HSI %d 단계를 준수합니다"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:482
+msgid "Security Level 0"
+msgstr "보안 단계 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr "이 장치는 하드웨어 보안 문제에 대한 보호 기능이 없습니다. 하드웨어 또는 펌웨어 설정 문제일 수 있습니다. IT 지원 공급자에게 문의하기를 권장합니다."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:489
+msgid "Security Level 1"
+msgstr "보안 단계 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr "이 장치는 하드웨어 보안 문제에 대한 최소한의 보호 기능이 있습니다. 가장 낮은 수준의 장치 보안 단계이므로, 단순한 보안 위협에 대한 보호만을 제공합니다."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:496
+msgid "Security Level 2"
+msgstr "보안 단계 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr "이 장치는 하드웨어 보안 문제에 대한 기초적인 보호 기능이 있습니다. 일부 흔한 보안 위협에 대한 보호를 제공합니다."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:503
+msgid "Security Level 3"
+msgstr "보안 단계 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr "이 장치는 하드웨어 보안 문제에 대한 확장된 보호 기능이 있습니다. 가장 높은 수준의 장치 보안 단계이므로, 고급 보안 위협에 대한 보호를 제공합니다."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:518
+msgid "Security Level"
+msgstr "보안 단계"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:519
+msgid "Security levels are not available for this device."
+msgstr "이 장치에 보안 단계를 사용할 수 없습니다."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr "하드웨어 제조사에 연락해 보안 업데이트하는데 도움을 받으십시오."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr "이 문제는 장치의 UEFI 펌웨어 설정에서 해결할 수도 있고, 지원 전문가가 해결할 수 있을지도 모릅니다."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "이 문제는 장치의 UEFI 펌웨어 설정에서 해결할 수 있을지도 모릅니다."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "지원 전문가가 이 문제를 해결할 수 있을지도 모릅니다."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "단계 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "단계 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "단계 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:110
+msgid "Protected against malicious software when the device starts."
+msgstr "장치가 시작할 때 악의적인 소프트웨어로부터 보호합니다."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:116
+msgid "Secure Boot has Problems"
+msgstr "보안 부팅에 문제 있음"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:117
+msgid "Some protection when the device is started."
+msgstr "장치가 시작할 때 일부분을 보호합니다."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:122
+msgid "Secure Boot is Off"
+msgstr "보안 부팅 꺼짐"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:123
+msgid "No protection when the device is started."
+msgstr "장치가 시작할 때 보호하지 않습니다."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:142
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr "이 문제는 UEFI 펌웨어 설정을 바꿔서 발생했을 수도 있고, 운영체제 설정을 바꿔서 발생했거나, 시스템의 악의적인 소프트웨어 때문에 발생했을 수도 있습니다."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:150
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr "이 문제는 UEFI 펌웨어 설정을 바꿔서 발생했을 수도 있고, 시스템의 악의적인 소프트웨어 때문에 발생했을 수도 있습니다."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:157
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr "이 문제는 운영체제 설정을 바꿔서 발생했거나, 시스템의 악의적인 소프트웨어 때문에 발생했을 수도 있습니다."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:483
+msgid "Exposed to serious security threats."
+msgstr "심각한 보안 위협에 노출됨."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:490
+msgid "Limited protection against simple security threats."
+msgstr "간단한 보안 위협에 대한 보호 제한적임."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:497
+msgid "Protected against common security threats."
+msgstr "흔한 보안 위협에 대해 보호."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:504
+#: panels/firmware-security/cc-firmware-security-panel.c:512
+msgid "Protected against a wide range of security threats."
+msgstr "넓은 범위의 보안 위협에 대해 보호."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:511
+msgid "Comprehensive Protection"
+msgstr "종합적인 보호"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "이벤트 없음"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "펌웨어 쓰기 보호"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "펌웨어 쓰기 보호 잠금"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "펌웨어 바이오스 지역"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "펌웨어 바이오스 설명"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "부팅 전 DMA 보호"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "인텔 부트가드"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "인텔 부트가드 검증 부팅"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "인텔 부트가드 ACM 보호"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "인텔 부트가드 오류 정책"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "인텔 부트가드 퓨즈"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "인텔 CET 사용"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "인텔 CET 동작"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "인텔 SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "RAM 암호화"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU 보호"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "리눅스 커널 잠김"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "리눅스 커널 검증"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "리눅스 스왑"
+
+# /sys/power/state 상태
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "대기모드, RAM에 저장"
+
+# /sys/power/state 상태
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "대기모드, 사용 중지"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI 플랫폼 키"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI 보안 부팅"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM 플랫폼 설정"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM 재구성"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "인텔 관리 엔진 제조 모드"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "인텔 관리 엔진 재정의"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "인텔 관리 엔진 버전"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "펌웨어 업데이트"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "펌웨어 증명"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "펌웨어 업데이터 검증"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "플랫폼 디버깅"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "프로세서 보안 확인"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD 롤백 보호"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD 펌웨어 리플레이 보호"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD 펌웨어 쓰기 보호"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "퓨즈 설정된 플랫폼"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "올바름"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "올바르지 않음"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "사용하지 않음"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "잠겼음"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "안 잠겼음"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "암호화됨"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "암호화되지 않음"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "오염됨"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "오염되지 않음"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "발견됨"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "발견되지 않음"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "지원함"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "지원하지 않음"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "장치 보안"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "호스트 펌웨어 보안 상태"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr "screen;화면;lock;잠그기;diagnostics;진단;crash;private;recent;최근;temporary;tmp;임시;index;색인;name;이름;network;네트워크;identity;신원;privacy;개인;정보;사생활;프라이버시;보호;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64비트"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32비트"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "웨일랜드"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "사용할 수 없음"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "시스템 로고"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "장치 이름"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "하드웨어 모델"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "메모리"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "프로세서"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "그래픽"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "디스크 용량"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "계산 중…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "운영 체제 이름"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "운영체제 빌드 ID"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "운영 체제 종류"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "그놈 버전"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "읽어들이는 중…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "윈도우 시스템"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "가상화"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "소프트웨어 업데이트"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "장치 이름 바꾸기"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"장치 이름은 네트워크나 블루투스 페어링할 때 이 장치를 식별하는데 사용되는 이"
+"름입니다."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "장치 이름"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "이름 바꾸기(_R)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "정보"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "시스템의 정보를 봅니다"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;장치;system;시스템;information;정보;hostname;호스트;이름;memory;메모"
+"리;processor;프로세서;version;버전;default;기본값;application;응용 프로그램;"
+"preferred;우선;cd;dvd;usb;audio;오디오;video;비디오;disc;디스크;removable;이"
+"동식;media;미디어;autorun;자동;실행;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "사운드 및 미디어"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "음량 묵음/해제"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "음량 낮추기"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "음량 높이기"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "마이크 묵음/해제"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "미디어 플레이어 실행"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "재생(또는 재생/일시 중지)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "재생 일시 중지"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "재생 중지"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "이전 트랙"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "다음 트랙"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "빼기"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "자판 입력"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "다음 입력 소스로 전환"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "이전 입력 소스로 전환"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "실행 아이콘"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "도움말 보기 실행"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "계산기 실행"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "전자메일 읽기 실행"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "웹 브라우저 실행"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "내 폴더"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "검색"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "시스템"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "로그아웃"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "화면 잠그기"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "접근성"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "확대 켜기 또는 끄기"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "확대"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "축소"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "화면 읽기 켜거나 끄기"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "화면 키보드를 켜거나 끄기"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "글자 크기 늘이기"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "글자 크기 줄이기"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "고대비 켜거나 끄기"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "입력 소스가 없습니다"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "기타"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "입력 소스 추가"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "로그인 화면에서는 입력기를 사용할 수 없습니다"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "입력 소스를 선택하지 않았습니다"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "옵션"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "위로 이동"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "아래로 이동"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "기본 설정"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "키보드 배치 표시"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "제거"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "바로 가기 사용자 설정"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "대체 문자 키"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"대체 문자 키를 이용해 추가 문자를 입력할 수 있습니다. 이 문자는 키보드에 3번"
+"째 옵션으로 인쇄되어 있는 경우도 있습니다."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "왼쪽 Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "오른쪽 Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "왼쪽 Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "오른쪽 Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menu 키"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "오른쪽 Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "구성 키"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"조합 키를 사용하면 여러가지 종류의 문자를 입력할 수 있습니다. 조합 키를 사용"
+"하려면, 조합 키와 문자의 연속을 누릅니다. 예를 들어, 조합 키 다음에 <b>C</b> "
+"및 <b>o</b>를 누르면 <b>©</b> 문자를 입력하고, <b>a</b>와 <b>'</b>를 누르면 "
+"<b>á</b> 문자를 입력합니다."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"입력 소스는 %s 키보드 바로 가기를 사용해 전환할 수 있습니다.\n"
+"키보드 바로 가기 설정에서 바꿀 수 있습니다."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "입력 소스"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "키보드 배치 및 입력기가 해당됩니다."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "입력 소스 전환"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "모든 창에 대해 같은 입력 소스 사용(_S)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "창마다 별개로 입력 소스 전환(_I)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "특수 문자 입력"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "키보드로 기호와 액센트 문자를 입력하는 방식."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "키보드 바로 가기"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "바로 가기 보기 및 사용자 설정"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d개 수정됨"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "모든 바로 가기를 초기화하시겠습니까?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"바로 가기를 초기화하면 사용자 추가한 바로 가기에도 영향을 미칩니다. 이 동작"
+"은 되돌릴 수 없습니다."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "취소"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "모두 초기화"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "모두 초기화…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "모든 바로 가기 키 기본값 키바인딩으로 초기화"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "구분"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "바로 가기"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "바로 가기 추가"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "사용자 설정 바로 가기 키 추가"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "앱 실행, 스크립트 실행 등의 바로 가기를 사용자 설정합니다."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "바로 가기 추가"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "키보드 바로 가기가 없습니다"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s은(는) %s 용도로 사용 중입니다. 바꾸면 %s이(가) 사용 중지됩니다"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "새 바로 가기 입력"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "사용자 설정 바로 가기 설정"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "바로 가기 설정"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "%s 항목을 바꾸려면 새 바로 가기를 입력하십시오."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "사용자 설정 바로 가기 키 추가"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "제거(_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "바꾸기(_P)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "설정(_S)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"키보드 바로 가기 입력에서 Esc를 누르면 취소하고, 백스페이스를 누르면 사용하"
+"지 않습니다."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "이름"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "명령"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "바로 가기"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "바로 가기 설정…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "없음"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "바로 가기 키 기본값으로 초기화"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "키보드"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"키보드 바로 가기를 바꾸고 키보드 타이핑, 키보드 배치, 입력 소스를 설정합니다."
+
+# 주의: 키워드이므로 번역될 수 있는 용어 적기
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;바로;가기;단축키;Workspace;작업;공간;Window;창;윈도우;Resize;Zoom;크"
+"기;조정;줌;Contrast;대비;고대비;Input;입력;Source;Lock;잠금;잠그기;Volume;볼"
+"륨;소리;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "위치 서비스가 꺼져 있습니다"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "어떤 앱도 위치 정보를 받을 수 없습니다."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"위치 서비스를 사용하면 앱에서 현재 위치를 알 수 있습니다. 와이파이 및 휴대전화 인터넷을 사용하면 정확도가 올라갑니다.\n"
+"\n"
+"모질라 위치 서비스를 사용합니다: <a href='https://location.services.mozilla.com/privacy'>개인정보 보호 정책</a>\n"
+"\n"
+"현재 위치를 알려면 아래에서 앱을 허용하십시오."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "위치 정보를 요청한 앱이 없습니다"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "위치 정보를 보호합니다"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;위치;좌표;gps;private;privacy;개인;정보;사생활;프라이버시;보호;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "마이크가 꺼져 있습니다"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "어떤 앱도 녹음을 할 수 없습니다."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"마이크를 사용하면 오디오를 듣고 녹음할 수 있습니다. 마이크를 사용하지 않으면 "
+"일부 앱이 제대로 동작하지 않을 수 있습니다.\n"
+"\n"
+"마이크를 사용하려면 아래에서 앱을 허용하십시오."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "마이크 접근을 요청한 앱이 없습니다"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "대화를 보호합니다"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "microphone;마이크;recording;녹음;application;privacy;개인;정보;사생활;프라이버시;보호;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "설정 검사(_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "일반"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "기본 단추"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "마우스 및 터치패드의 물리적 단추의 순서를 설정합니다."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "왼쪽"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "오른쪽"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "마우스"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "마우스 속도"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "스크롤 방향 뒤바꾸기"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "스크롤하면 내용을 옮기고, 뷰를 옮기지 않습니다."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "터치패드"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "터치패드 속도"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "터치패드 두드리면 단추 누름으로 취급"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "터치패드 두드리면 단추 누름으로 취급"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "두손가락 스크롤"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "가장자리 스크롤"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "한번 누르기, 두번 누르기, 스크롤을 해 보십시오"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "다섯번 누름, 게글 타임!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "두번 누르기, 첫번째 단추"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "한번 누르기, 첫번째 단추"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "두번 누르기, 가운데 단추"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "한번 누르기, 가운데 단추"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "두번 누르기, 두번째 단추"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "한번 누르기, 두번째 단추"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "마우스 및 터치패드"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"마우스 및 터치패드 민감도를 바꾸고 오른손잡이용인지 왼손잡이용인지 설정합니다"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;트랙패드;Pointer;포인터;Click;클릭;누르기;Tap;두드리기;Double;더블;"
+"Button;버튼;단추;Trackball;트랙볼;Scroll;스크롤;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "구석 누르기(_H)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "위 왼쪽 구석을 터치해 현재 활동 요약 화면을 엽니다."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "화면 가장자리로 끌기(_A)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr "창을 위, 왼쪽, 오른쪽 화면 가장자리로 끌어서 창 크기를 조절합니다."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "작업 공간"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "동적 작업 공간(_D)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "자동으로 빈 작업 공간을 제거합니다."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "고정된 작업 공간 개수(_F)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "영구적인 작업 공간의 개수를 지정합니다."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "작업 공간 개수(_N)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "다중 모니터"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "주 디스플레이만 작업 공간 사용(_P)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "모든 디스플레이에 작업 공간 사용(_I)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "앱 전환"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "모든 작업 공간의 앱을 포함(_W)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "현재 작업 공간의 앱만 포함(_C)"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "다중 작업"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "생산성 및 다중 작업에 대한 설정을 관리합니다"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr "Multitasking;다중작업;다중 작업;멀티태스킹;Multitask;멀티태스크;Productivity;생산성;Customize;사용자설정;사용자 설정;Desktop;데스크톱;Hot Corner;핫코너;Workspaces;작업공간;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "앗, 뭔가 잘못됐습니다. 소프트웨어 공급자에게 문의하십시오."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager가 동작해야 합니다."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "기타 장치"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN(가상사설망)"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "연결 추가"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "설정되지 않음"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "안전하지 않은 네트워크 (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "안전한 네트워크 (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "안전한 네트워크 (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "안전한 네트워크 (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "안전한 네트워크"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "연결됨"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "옵션…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"핫스팟을 켜면 %s에서 연결이 끊기고, 와이파이를 통한 인터넷 접근이 불가능합니"
+"다."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "길이가 최소 8자가 되야 합니다"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "길이가 최대 %d자가 되야 합니다"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "와이파이 핫스팟을 켜시겠습니까?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"와이파이 핫스팟을 사용하면 다른 사람이 연결할 수 있는 와이파이 네트워크를 만"
+"들어서 다른 사람이 나의 인터넷 연결을 공유할 수 있습니다. 이 기능을 사용하려"
+"면, 와이파이가 아닌 수단으로 인터넷 연결이 되어 있어야 합니다."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "네트워크 이름"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "암호"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "임의의 암호 생성"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "암호 자동 생성"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "켜기(_T)"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "와이파이"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "핫스팟을 중지하고 연결 중인 사용자를 끊으시겠습니까?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "핫스팟 중지(_S)"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "비행기 모드"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "와이파이, 블루투스, 휴대전화 인터넷을 끕니다"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "와이파이 어댑터가 없습니다"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "와이파이 어댑터를 연결하고 켰는지 확인하십시오"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "비행기 모드 켬"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "와이파이를 사용하려면 끄십시오"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "와이파이 핫스팟 사용 중"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "모바일 장치가 QR 코드를 스캔해 연결할 수 있습니다."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "핫스팟 끄기…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "보이는 네트워크"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager가 동작해야 합니다"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x 보안(_S)"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "보안"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "보존"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "영구"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "임의"
+
+# 태블릿 PC
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "안정"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"여기 입력하는 MAC 주소는 이 연결을 활성화할 때 해당 네트워크 장치의 하드웨어 "
+"주소로 사용합니다. 이 기능은 MAC 복제 또는 스푸핑이라고 부릅니다. 예를 들어: "
+"00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "프로파일 %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "발전된 오픈 네트워크"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "기업용"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "없음"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "안 함"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] " %i일 전"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "없음"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "약함"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "좋음"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "좋음"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "최상"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 주소"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 주소"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP 주소"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "네임서버(DNS)"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "연결 저장 지우기"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "연결 프로파일 제거"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "VPN(가상사설망) 제거"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "자세히 보기"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "자동"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "신원"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "주소 삭제"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "라우팅 삭제"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "와이파이/이더넷 보안"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128비트 키(16진수 또는 ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128비트 암호글"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "동적 WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA 및 WPA2 개인용"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA 및 WPA2 기업용"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 개인용"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "신호 세기"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "연결 속도"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "하드웨어 주소"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "지원하는 주파수"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "기본 라우팅"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "최근 사용"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "자동으로 연결(_A)"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "다른 사용자가 사용할 수 있게 허용(_O)"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "종량제 연결: 데이터 제한이 있거나 요금이 청구될 수 있음(_M)"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"소프트웨어 업데이트 및 기타 대용량 다운로드는 자동으로 시작하지 않습니다."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "이름(_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC 주소"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "복제한 주소(_C)"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "바이트"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 방식"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "자동(DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "링크 로컬만"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "수동"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "사용 않기"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "다른 컴퓨터에 공유"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "주소"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "주소"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "네트마스크"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "게이트웨이"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "자동"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "자동 DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS 서버 주소"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "IP 주소 여러 개는 쉼표로 구분합니다"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "라우팅"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "자동 라우팅"
+
+# 주의: 미터법 아님
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "계측"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "이 연결을 이 네트워크의 리소스에 대해서만 사용(_O)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 방식"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "자동, DHCP 전용"
+
+# IPv6 네트워크 프리픽스
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "프리픽스"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "연결 편집을 열 수 없습니다"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "새 프로파일"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "잘못된 설정 %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "잘못된 설정 %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "파일에서 가져오기…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "VPN(가상사설망) 추가"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "보안(_E)"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "VPN(가상사설망) 연결을 가져올 수 없습니다"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"“%s” 파일을 읽을 수가 없거나, 파일에 알려진 VPN(가상사설망) 연결 정보가 들어 "
+"있지 않습니다\n"
+"\n"
+"오류: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "가져올 파일을 선택하십시오"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "이름이 “%s”인 파일이 이미 있습니다."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "바꾸기(_R)"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "%s 연결을 저장한 VPN(가상사설망) 연결로 바꾸시겠습니까?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "VPN(가상사설망) 연결을 내보낼 수 없습니다"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"“%s” VPN(가상사설망) 연결을 %s에 내보낼 수 없습니다.\n"
+"\n"
+"오류: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "VPN(가상사설망) 연결 내보내기"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(오류: VPN(가상사설망) 연결 편집을 읽어들일 수 없습니다)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "어떻게 인터넷에 연결할지 정합니다"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;네트워크;IP;LAN;랜;Proxy;프록시;WAN;인터넷;Broadband;브로드밴드;"
+"Modem;모뎀;Bluetooth;블루투스;vpn;가상사설망;;DNS;네임서버;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "어떻게 와이파이 네트워크에 연결할지 정합니다"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;네트워크;Wireless;무선;Wi-Fi;Wifi;와이파이;IP;LAN;Broadband;브로드밴"
+"드;DNS;네임서버;Hotspot;핫스팟;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "안 함"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "오늘"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "어제"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "최근 사용"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "유선"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "새 연결 추가"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"선택한 네트워크의 상세 정보(암호 및 기타 사용자 설정 정보 포함)가 지워집니다."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "저장 지우기(_F)"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "알려진 와이파이 네트워크"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "지우기(_F)"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "시스템 정책이 핫스팟 사용을 막습니다"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "무선 장치에서 핫스팟 모드를 지원하지 않습니다"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "설정 URL을 지정하지 않으면 웹 프록시 자동 검색을 사용합니다."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "신뢰할 수 없는 공용 네트워크 사용은 추천하지 않습니다."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "장치 끄기"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "동작"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "공급처"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "네트워크 프록시"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "HTTP 프록시(_H)"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTPS 프록시(_T)"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "FTP 프록시(_F)"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Socks 호스트(_S)"
+
+# 프록시를 사용하지 않을 호스트 목록 입력
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "무시할 호스트(_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP 프록시 포트"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS 프록시 포트"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP 프록시 포트"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "SOCKS 프록시 포트"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "설정 URL(_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN(가상사설망) 끄기"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "네트워크 이름"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "보안 방식"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "암호"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "와이파이 끄기"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "기타 옵션…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "숨겨진 네트워크에 연결(_C)…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "와이파이 핫스팟 켜기(_T)…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "알려진 와이파이 네트워크(_K)"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "상태 알 수 없음"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "관리 안 됨"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "사용할 수 없음"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "연결 중"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "인증 필요"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "연결 끊는 중"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "연결 실패"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "상태 알 수 없음(빠짐)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "설정에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP 설정에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP 설정 기한이 지났습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "비밀 데이터가 필요하지만 전송하지 않았습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x 요청의 연결이 끊겼습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x 요청 설정에 실패했습니다."
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x 요청에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x 요청이 인증에 너무 오래 걸립니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP 서비스 시작해 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP 서비스 연결이 끊어졌습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP 동작 실패"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP 클라이언트 시작에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP 클라이언트 오류"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP 클라이언트 동작에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "연결 공유 서비스 시작에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "연결 공유 서비스 동작에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "자동IP 서비스 시작에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP 서비스 오류"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "자동IP 서비스 동작에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "회선 사용중"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "전화 걸기 신호음 없음"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "서비스에 연결할 수 없습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "전화 걸기 요청 시간을 초과했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "전화 걸기 시도에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "모뎀 초기화 실패"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "지정한 APN 선택에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "네트워크 검색 요소가 없습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "네트워크 등록이 거부되었습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "네트워크 등록 시간을 초과했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "요청 받은 네트워크 등록에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN 확인 실패"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "장치 펌웨어가 빠진 것 같음"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "연결이 사라졌습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "기존 연결을 가정합니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "모뎀을 찾을 수 없습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "블루투스 연결에 실패했습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM 카드 삽입하지 않았습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM PIN이 필요합니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM의 PIN 잠금 해제 키 코드 필요합니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM이 잘못되었습니다"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "연결 의존성 설정에 실패했습니다"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "펌웨어 없음"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "케이블 분리됨"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "802.1X 보안에 (WPA-EAP) 정의하지 않은 오류"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "파일을 선택하지 않았습니다"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "EAP-METHOD 파일을 검증하는 중 지정하지 않은 오류"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 또는 PGP 개인 키"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER 또는 PEM 인증서"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "EAP-FAST PAC 파일이 없습니다"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC 파일(*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "익명"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "인증됨"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "둘 모두"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "익명 신원(_M)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC 파일(_F)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PAC 파일 선택"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "내부 인증(_I)"
+
+# provided authenticated credential
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "자동 PAC 프로비저닝 허용(_V)"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "EAP-LEAP 사용자 이름이 없습니다"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "EAP-LEAP 암호가 없습니다"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "사용자 이름(_U)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "암호(_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "암호 보이기(_W)"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "잘못된 EAP-PEAP 인증 기관 인증서: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "잘못된 EAP-PEAP 인증 기관 인증서: 인증서를 지정하지 않았습니다"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "버전 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "버전 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "인증 기관 인증서(_A)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "인증 기관 인증서 선택"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "인증 기관 인증서 불필요(_R)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP 버전(_V)"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "EAP 사용자 이름 없음"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "EAP 암호 없음"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "EAP-TLS 신원 정보 없음"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "잘못된 EAP-TLS 인증 기관 인증서: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "잘못된 EAP-TLS 인증 기관 인증서: 인증서를 지정하지 않았습니다"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "잘못된 EAP-TLS 개인 키: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "잘못된 EAP-TLS 사용자 인증서: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "암호화하지 않은 개인 키는 보안상 위험합니다"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"선택한 개인 키는 암호로 보호하지 않았습니다. 이러면 비밀 정보가 유출될 수 있"
+"습니다. 암호로 보호한 개인 키를 선택하십시오.\n"
+"\n"
+"(OpenSSL로 개인 키를 암호로 보호할 수도 있습니다)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "개인 인증서 선택"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "개인 키 선택"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "신원(_D)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "사용자 인증서(_U)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "개인 키(_K)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "개인 키 암호(_P)"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "잘못된 EAP-TTLS 인증기관 인증서: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "잘못된 EAP-TTLS 인증기관 인증서: 인증서를 지정하지 않았습니다"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (EAP 없음)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "도메인(_D)"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "802.1X 보안을 검증하는 중 알 수 없는 오류"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS 터널링"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "PEAP(Protected EAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "인증(_T)"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "파일 선택"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "LEAP 사용자 이름이 없음"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "LEAP 암호가 없음"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "와이파이 암호가 없습니다."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "종류(_T)"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "WEP 키가 없음"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "잘못된 WEP 키: 길이가 %zu인 키에는 16진수 숫자만 들어 있어야 합니다"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "잘못된 WEP 키: 길이가 %zu인 키에는 ASCII 문자만 들어 있어야 합니다"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"잘못된 WEP 키: 잘못된 키 길이 %zu. 키 길이는 5/13 (ASCII) 또는 10/26 (16진"
+"수) 중 하나여야 합니다"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "잘못된 WEP 키: 암호글이 비어 있으면 안 됩니다"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "잘못된 WEP 키: 암호글은 64자보다 짧아야 합니다"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (기본값)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "공개 시스템"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "공유 키"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "키(_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "키 보이기(_W)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP 인덱스(_X)"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"잘못된 WPA-PSK: 잘못된 키 길이 %zu. [8,64] 바이트 또는 64개 16진수 숫자여야 "
+"합니다"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "잘못된 WPA-PSK: 64개 16진수 숫자를 키로 해석할 수 없습니다"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "알림(_N)"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "경고음(_A)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "알림 팝업(_P)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr "팝업을 꺼도 알림은 알림 목록에 계속 나타납니다."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "팝업에 메시지 내용 표시(_C)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "잠금 화면 알림(_L)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "잠금 화면에서 메시지 내용 표시(_O)"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "방해 금지(_D)"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "잠금 화면 알림(_L)"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "어떤 알림을 표시할지 및 무엇을 표시할지 설정합니다"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;알림;Banner;안내판;Message;메시지;Tray;트레이;Popup;팝업;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "기타"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s 제거함"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "계정 제거 오류"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "실행 취소"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "알림을 닫습니다"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "클라우드의 데이터에 연결합니다"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "인터넷 연결이 없습니다 — 새 온라인 계정을 설정하려면 연결하십시오"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "계정 추가"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s 계정"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "계정 제거"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "온라인 계정"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "온라인 계정에 연결하고 그 계정을 어디에 이용할지 설정합니다"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;구글;Facebook;페이스북;Twitter;트위터;Yahoo;야후;Web;웹;Online;온라인;"
+"Chat;채팅;Calendar;달력;Mail;메일;Contact;연락처;ownCloud;Kerberos;케르베로"
+"스;IMAP;SMTP;;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "시간 알 수 없음"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i분"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i시간"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i%s %i%s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "시간"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "분"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "완전 충전까지 %s 남음"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "주의: %s 남음"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s 남음"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "완전 충전"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "충전 중 아님"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "비었음"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "충전 중"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "방전 중"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "무선 마우스"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "무선 키보드"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "무정전 전원 장치"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "개인 휴대 정보 단말기"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "휴대전화"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "미디어 플레이어"
+
+# 태블릿 PC
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "태블릿"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "컴퓨터"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "게임 입력 장치"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "배터리"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "1차"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "추가"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "배터리"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "입력이 없을 때(_I)"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "대기 모드"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "전원 끄기"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "최대 절전"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "아무것도 하지 않기"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "배터리 전원 사용할 때"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "전원이 연결되었을 때"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "안 함"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "자동 대기 모드"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "동작 온도가 높아 성능 모드를 임시로 사용하지 않습니다."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"무릎 감지: 성능 모드를 임시로 사용할 수 없습니다. 성능 모드를 다시 사용하려"
+"면 안정된 바닥으로 옮기십시오."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "성능 모드를 임시로 사용하지 않습니다."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"배터리 부족: 전기 절약 모드를 사용합니다. 배터리가 충분히 충전되면 이전 모드"
+"가 복구됩니다."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "전기 절약 모드를 “%s”에서 활성화했습니다."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "성능 모드를 “%s”에서 활성화했습니다."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15분"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20분"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25분"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30분"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45분"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1시간"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80분"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90분"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100분"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2시간"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "전원 모드"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "시스템 성능과 전력 사용에 영향을 미칩니다."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "전기 절약 옵션"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "자동 화면 밝기 조절"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "화면 밝기가 주위 밝기에 따라 조절됩니다."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "화면 어둡게"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "컴퓨터를 사용하지 않을 때 화면 밝기를 줄입니다."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "검은 화면(_B)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "일정 시간 사용하지 않으면 화면을 끕니다."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "자동 전기 절약"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "배터리가 부족할 때 전기 절약 모드를 사용합니다."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "자동 대기 모드(_A)"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "일정 시간 사용하지 않으면 컴퓨터를 일시 중지합니다."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "전원 단추 동작(_W)"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "배터리 백분율 표시(_P)"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "자동 대기 모드"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "전원 연결(_P)"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "배터리 전원 사용(_B)"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "지연 시간"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "성능"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "성능도 높고 전력 소모도 높습니다."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "균형"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "표준의 성능 및 전력 사용입니다."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "전기 절약"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "성능이 줄어들고 전력 소모도 줄어듭니다."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "전원"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "배터리 상태를 보고 절전 설정을 바꿉니다"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;전원;Sleep;절전;Suspend;대기 모드;Hibernate;최대 절전;Battery;배터리;"
+"Brightness;밝기;Dim;어둡게;Blank;Monitor;모니터;DPMS;Idle;입력;Energy;에너지;"
+"절약;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "“%s” 프린터를 삭제했습니다"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "새 프린터 추가에 실패했습니다."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "UI를 읽어들일 수 없습니다: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "프린터를 추가하고 설정을 바꾸려면 잠금을 해제하십시오"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "프린터"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "프린터 추가, 인쇄 작업 보기, 어떻게 인쇄할지 설정"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"Printer;프린터;Queue;대기열;Print;인쇄;Paper;용지;종이;Ink;잉크;Toner;토너;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "프린터 추가"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "잠금 해제(_U)"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "프린터가 없습니다"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "프린터의 네트워크 주소를 입력하거나 프린터를 찾아보십시오"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "인증 필요"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr "인쇄 서버의 프린터를 보려면 사용자 이름과 암호를 입력하십시오."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "사용자 이름"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s 자세히 보기"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "적당한 드라이버가 없습니다"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "PPD 파일 선택"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"포스트스크립트 프린터 기술 파일(*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "프린터 이름에 공백, 탭, #, / 문자는 들어갈 수 없습니다"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "위치"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "드라이버"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "준비된 드라이버 검색중…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "드라이버 검색"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "데이터베이스에서 선택…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "PPD 파일 설치…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "프린터 드라이버 선택"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "드라이버 데이터베이스 불러오는 중…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "선택"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect 프린터"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD 프린터"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "단면"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "긴 모서리 방향(표준)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "짧은 모서리 방향(뒤집기)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "세로"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "가로"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "세로 방향 뒤집기"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "가로 방향 뒤집기"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "다시 시작"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "일시 중지"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "대기"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "일시 중지 상태"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "인증 필요"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "처리 중"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "중지"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "취소"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "중지됨"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "완료"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "이 작업을 대기열의 맨 앞으로 이동"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "작업 %u개에 인증이 필요합니다"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — 활성 작업"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "%s에서 인쇄하려면 인증 정보가 필요합니다."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "도메인"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "인증(_U)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "모두 지우기"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "인증(_A)"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "프린터 활성 작업 없음"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "프린터 서버 잠금 해제"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s 잠금 해제."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "%s의 프린터를 보려면 사용자 이름과 암호를 입력하십시오."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "프린터 검색 중"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "직렬 포트"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "병렬 포트"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "위치: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "주소: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "서버에 인증이 필요합니다"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "양면"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "용지 형식"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "용지 서랍"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "출력 표시줄"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "해상도"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "고스트스크립트 우선 필터링"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "장당 페이지 수"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "양면"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "방향"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "일반"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "페이지 설정"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "설치 가능한 옵션"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "작업"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "이미지 화질"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "색"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "마감"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "고급"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "테스트 페이지"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "테스트 페이지"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "자동 선택"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "프린터 기본값"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "고스트스크립트 글꼴만 포함"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "PS 레벨 1로 변환"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "PS 레벨 2로 변환"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "우선 필터링 안함"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "제조사"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "활성 작업 없음"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "작업 %u개"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "인쇄 헤드 청소"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "토너 부족"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "토너 없음"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "현상액 부족"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "현상액 없음"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "마커 내용물 부족"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "마커 내용물 없음"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "덮개 열림"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "문 열림"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "용지 부족"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "용지 없음"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "연결 끊김"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "중지"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "찌꺼기 보관함이 거의 가득 찼습니다"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "찌꺼기 보관함이 가득 찼습니다"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "감광 반도체의 수명이 거의 다 되었습니다"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "감광 반도체가 이제 동작하지 않습니다"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "준비"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "인쇄 작업 받지 않음"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "처리중"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "인쇄 옵션"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "프린터 자세히 보기"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "기본 프린터로 사용"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "인쇄 헤드 청소"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "프린터 제거"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "모델"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "남은 잉크"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "문제가 해결되면 다시 시작하십시오."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "다시 시작"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "프린터 추가…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "프린터 없음"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"죄송합니다. 시스템 인쇄 서비스가\n"
+"    없는 것 같습니다."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "형식"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "로캘 검색…"
+
+# date format 등 locale
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "자주 쓰는 형식"
+
+# date format 등 locale
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "모든 형식"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "검색 결과가 없습니다"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "국가 또는 언어로 검색할 수 있습니다."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "미리 보기"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "야드파운드법"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "미터법"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "날짜"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "날짜 및 시각"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "숫자"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "단위"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "용지"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "언어 및 형식은 다음 로그인 뒤에 바뀝니다"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "로그아웃…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"언어 설정은 인터페이스 텍스트 및 웹페이지에 사용됩니다. 형식은 숫자, 날짜, 화"
+"폐 통화에 사용됩니다."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "내 계정"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "언어(_L)"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "형식(_F)"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "로그인 화면"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "지역 및 언어"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "표시할 언어와 여러가지 형식을 선택합니다."
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;언어;Layout;배치;Keyboard;키보드;Input;입력;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "어떻게 할지 물어보기"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "아무것도 하지 않기"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "폴더 열기"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "기타 미디어"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "오디오 CD에 사용할 앱을 선택하십시오"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "비디오 DVD에 사용할 앱을 선택하십시오"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "음악 플레이어를 연결했을 때 실행할 앱을 선택하십시오"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "카메라를 연결했을 때 실행할 앱을 선택하십시오"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "소프트웨어 CD에 사용할 앱을 선택하십시오"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "오디오 DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "빈 Blu-ray 디스크"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "빈 CD 디스크"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "빈 DVD 디스크"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "빈 HD DVD 디스크"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray 비디오 디스크"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "전자책 읽기 프로그램"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD 비디오 디스크"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "사진 CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "수퍼 비디오 CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "비디오 CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "윈도우 소프트웨어"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "미디어를 어떻게 처리할지 고르십시오"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD 오디오(_A)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "DVD 비디오(_D)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "음악 재생기(_M)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "소프트웨어(_S)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "기타 미디어(_O)…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "미디어가 연결되어도 물어보거나 프로그램 시작하지 않기(_N)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "기타 미디어를 어떻게 처리할지 고르십시오"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "동작(_A):"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "종류(_T):"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "이동식 미디어"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "이동식 미디어 설정"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;장치;system;시스템;default;기본값;application;앱;애플리케이션;응용 프"
+"로그램;preferred;우선;cd;dvd;usb;audio;오디오;video;비디오;disc;디스크;"
+"removable;이동식;media;미디어;autorun;자동 실행;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "화면 끄기"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30초"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1분"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2분"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3분"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5분"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30분"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1시간"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1분"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2분"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3분"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4분"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5분"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8분"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10분"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12분"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15분"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "안 함"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "화면 잠금"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"화면을 자동으로 잠궈서 자리를 비운 동안 컴퓨터에 접근하지 못하도록 합니다."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "빈 화면 지연 시간"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "빈 화면이 될 때까지 입력이 없는 시간."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "자동 화면 잠금(_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "자동 화면 잠금 지연 시간(_S)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "빈 화면이 된 후에 화면이 자동으로 잠길 때까지의 시간."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "알림 표시 및 화면 잠그기(_N)"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "새 USB 장치 금지(_U)"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "화면이 잠겨 있을 때 새로운 USB 장치와 시스템의 상호 작용을 금지합니다."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "화면 개인 정보 보호"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "시야각 제한"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "화면 설정"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;화면;lock;잠금;private;privacy;개인;정보;사생활;프라이버시;보호;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "위치 선택"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "확인(_O)"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "검색 위치"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr "시스템 앱에서 검색할 폴더, 예를 들어 파일, 사진, 동영상 따위."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "위치"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "책갈피"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "기타"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "위치 추가"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "앱 없음"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "앱 검색"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "앱에서 제공한 검색 결과를 포함합니다."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "시스템 앱이 검색하는 폴더."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "검색 결과"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "결과는 목록의 순서대로 표시됩니다."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "어떤 앱에서 활동 내역에 검색 결과를 표시할지 설정합니다."
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;검색;Find;찾기;Index;인덱스;색인;Hide;숨기기;Privacy;개인;정보;사생활;프라이버시;보호;Results;결과;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "공유에 사용할 네트워크를 선택하지 않았습니다"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "네트워크"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "켬"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "끔"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "사용"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "동작"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "폴더 선택"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "추가"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "미디어 공유 사용"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"파일 공유를 사용하면, 현재 네트워크에 있는 다른 사람이 다음 URL을 사용해 공"
+"유 폴더를 공유할 수 있습니다: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"원격 로그인을 사용하면, 원격 사용자가 다음 보안 셸 명령으로 연결할 수 있습니"
+"다:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "개인 미디어 공유 사용"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "장치 이름 복사함"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "장치 주소 복사함"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "사용자 이름 복사함"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "암호 복사함"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "공유"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "컴퓨터 이름(_C)"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "파일 공유(_F)"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "원격 데스크톱(_D)"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "미디어 공유(_M)"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "원격 로그인(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "파일 공유"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "암호 필요(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "원격 로그인"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "원격 데스크톱"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"원격 데스크톱을 이용해 다른 컴퓨터에서 이 데스크톱을 보고 조작할 수 있습니다."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "이 컴퓨터에 원격 데스크톱 연결을 사용할지 여부."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "원격 조작"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "원격 연결에서 화면 조작을 허용합니다."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "연결 방식"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr "장치 이름 또는 원격 데스크톱 주소를 사용해 이 컴퓨터에 연결합니다."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "복사"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "원격 데스크톱 주소"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "인증"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "이 컴퓨터에 연결하려면 사용자 이름과 암호가 필요합니다."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "사용자 이름"
+
+# 핑거프린트가 동일한지 확인을 말함
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "암호화 확인"
+
+# 손가락 지문 아님
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "암호화 핑거프린트"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr "암호화 핑거프린트는 클라이언트가 연결할 때 볼 수 있고 동일해야 합니다."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "미디어 공유"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "네트워크를 통해 음악, 사진, 영상을 공유합니다."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "폴더"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "다른 사람과 공유할 사항을 정합니다"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;공유;ssh;보안쉘;host;name;호스트;이름;remote;desktop;원격;데스"
+"크톱;media;미디어;audio;오디오;video;비디오;pictures;photos;사진;movies;영상;"
+"동영상;server;서버;renderer;렌더러;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "원격 로그인 사용 여부"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "원격 로그인 사용 여부를 바꾸려면 인증이 필요합니다"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "사용자 설정"
+
+# 효과음 종류
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "딸깍"
+
+# 효과음 종류
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "현악기"
+
+# 효과음 종류
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "휘두르기"
+
+# 효과음 종류
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "허밍"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "균형"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "페이드"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "후방"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "전방"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s 시험 중"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "시험하려는 스피커를 누르십시오"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "시스템 음량"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "주 음량"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "음량 수준"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "출력"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "출력 장치"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "시험"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "설정"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "서브우퍼"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "입력"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "입력 장치"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "음량"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "경보음"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "무음"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "소리"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "사운드 음량과, 입력, 출력, 경고음을 바꿉니다"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;카드;Microphone;마이크;Volume;볼륨;음량;Fade;페이드;Balance;균형;밸런스;"
+"Bluetooth;블루투스;Headset;헤드셋;Audio;오디오;Output;출력;Input;입력;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "연결 끊김"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "연결 중"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "연결됨"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "인증 오류"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "인증 중"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "기능 줄어듬"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "연결 및 인증된 장치"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "인증 시각:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "연결 시각:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "등록 시각:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "장치 인증에 실패했습니다: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "장치 정보 삭제에 실패했습니다: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "기타 장치 %u개에 의존"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "알림 닫기"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "이름:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "상태:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "인증 및 연결"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "장치 정보 삭제"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "오류"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "인증됨"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"썬더볼트 서브시스템을 (boltd) 설치하지 않았거나 제대로 준비하지 않았습니다."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "도크나 외부 GPU같은 장치에 직접 접근을 허용합니다."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "USB와 디스플레이 포트 장치만 붙일 수 있습니다."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"썬더볼트를 찾을 수 없습니다.\n"
+"시스템에서 썬더볼트를 지원하지 않거나, BIOS에서 썬더볼트를 껐거나, BIOS에서 "
+"지원하지 않는 보안 레벨을 설정했습니다."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "썬더볼트 지원 기능이 BIOS에서 꺼져 있습니다."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "썬더볼트 보안 단계를 결정할 수 없습니다."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "직접 접근 모드로 전환하는데 오류: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "썬더볼트 지원 기능이 없습니다"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "썬더볼트 서브시스템에 연결할 수 없습니다."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "직접 접근"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "지연된 장치"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "연결한 장치가 없습니다"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "썬더볼트"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "썬더볼트 장치를 관리합니다"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;썬더볼트;선더볼트;privacy;개인;정보;사생활;프라이버시;보호;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "커서 깜빡이기"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "텍스트 입력란에서 커서를 깜박입니다."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "속도"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "커서 깜빡임 빠르기"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "커서 크기"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "커서 크기와 크기 조정을 결합하면 커서를 보기 쉽게 조정할 수 있습니다."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "누르기 도움"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "두 번째 누르기 흉내 내기(_S)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "단추를 누르고 있으면 두 번째 누르기로 취급"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "허용 지연 시간(_C):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "짧게"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "두 번째 누르기 지연 시간"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "길게"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "자동 누르기(_H)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "포인터가 멈추면 누른 것으로 취급"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "지연 시간(_E):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "짧게"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "길게"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "움직임 임계값(_T):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "작게"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "크게"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "반복 키"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "키를 누르고 있을 때 키를 반복합니다."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "반복 키 지연시간"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "반복 키 빠르기"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "자판 도움"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "고정 키(_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "변경 키와 다른 키를 연속해서 누를 때 키 조합으로 취급"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "키 두개를 같이 누르면 사용 중지(_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "변경 키를 눌렀을 때 삑 소리(_M)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "느린 키(_L)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "키를 누르고 허용하는 사이에 지연 시간을 넣습니다"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "짧게"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "느린 키 입력 지연시간"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "길게"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "키를 눌렀을 때 삑 소리(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "키가 허용되었을 때 삑 소리(_A)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "키가 거부되었을 때 삑 소리(_R)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "탄력 키(_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "빠르게 중복된 키 누름 무시"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "짧게"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "탄력 키 입력 지연 시간"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "길게"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "키보드로 활성화(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "키보드로 접근성 기능을 켜고 끕니다"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "기본값"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "중간"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "크게"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "더 크게"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "매우 크게"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d픽셀"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "항상 접근성 메뉴 표시(_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "보기"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "고대비(_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "큰 글씨(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "애니메이션 사용(_N)"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "화면 읽기 프로그램(_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "화면 읽기 프로그램은 포커스를 옮길 때마다 표시되 텍스트를 읽습니다."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "소리 키(_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num Lock 또는 Caps Lock 키를 켤 때나 끌 때 소리를 냅니다."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "커서 크기(_U)"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "확대(_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "듣기"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "시각 알림(_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "화면 키보드(_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "반복 키(_E)"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "커서 깜빡이기(_B)"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "타이핑 도움(AccessX)(_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "마우스 이동 및 누르기"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "마우스 키(_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "포인터 찾기(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "누르기 도움(_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "두번 누르기 지연시간(_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "두번 누르기 지연시간"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "시각 알림"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "번쩍이기 시험(_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "경보가 울리면 화면으로 보이게 알립니다."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "전체 화면 번쩍이기(_S)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "전체 창 번쩍이기(_W)"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "짧게"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "화면의 1/4"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "화면의 1/2"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "화면의 3/4"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "길게"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "전체 화면"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "위 절반"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "아래 절반"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "왼쪽 절반"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "오른쪽 절반"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "확대 옵션"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "확대(_M):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "돋보기 위치:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "마우스 커서 따라가기(_F)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "화면 나누기(_S):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "돋보기를 화면 밖 영역으로 확장(_E)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "커서를 중심으로 돋보기를 유지(_K)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "확대 커서를 내용 밖으로 밀어내기(_P)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "확대 커서를 내용에 따라 이동(_C)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "돋보기"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "십자선(_C):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "마우스 커서 겹치기(_O)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "두께(_T):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "얇게"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "두껍게"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "길이(_L):"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "색(_L):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "십자선"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "색상 효과:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "검은 바탕 흰색(_W):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "밝기(_B):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "대비(_C):"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "색(_L)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "없음"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "전체"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "낮게"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "높게"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "낮게"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "높게"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "색상 효과"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "보기, 듣기, 타이핑, 누르기 편의 사항"
+
+# 주의: 원문이 'Mouse' 키워드 중복
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;키보드;Mouse;마우스;a11y;Accessibility;접근성;Universal Access;보편"
+"적 접근;Contrast;대비;Cursor;커서;Sound;소리;사운드;Zoom;확대;축소;Screen;"
+"Reader;스크린;리더;화면;읽기;big;high;large;text;큰;텍스트;font;size;폰트;글"
+"꼴;크기;AccessX;Sticky;Keys;고정;키;Slow;느린;Bounce;탄력;Mouse;마우스;"
+"Double;click;두번;누르기;Delay;Speed;Assist;지연;도우미;Repeat;반복;Blink;깜"
+"박;visual;hearing;audio;typing;시각;hearing;듣기;audio;오디오;typing;타이핑;"
+"animations;애니메이션;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1시간"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1일"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2일"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3일"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4일"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5일"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6일"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7일"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14일"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30일"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "휴지통의 모든 항목을 비우시겠습니까?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "휴지통의 모든 항목을 완전히 삭제합니다."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "휴지통 비우기(_E)"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "모든 임시 파일을 지우시겠습니까?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "모든 임시 파일을 완전히 삭제합니다."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "임시 파일 지우기(_P)"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1일"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7일"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30일"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "계속"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "파일 사용 내역"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"파일 사용 내역은 사용한 파일의 기록을 유지하고 있습니다. 이 정보는 응용 프로"
+"그램 사이에 공유되므로, 사용하려는 파일을 쉽게 찾을 수 있습니다."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "파일 사용 내역(_I)"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "파일 사용 내역 기간(_H)"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "기록 지우기(_C)…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "휴지통 및 임시 파일"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"휴지통 및 임시 파일에는 개인적이거나 민감한 정보가 들어 있을 수도 있습니다. "
+"이 파일을 지우면 개인 정보 보호에 도움이 됩니다."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "자동으로 휴지통 내용 삭제(_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "자동으로 임시 파일 삭제(_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "자동 삭제 기간(_P)"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "휴지통 비우기(_E)…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "임시 파일 삭제(_D)…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "파일 사용 내역 및 휴지통"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "흔적 남기지 않기"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr "usage;사용;recent;최근;history;기록;내역;히스토리;files;파일;temporary;tmp;임시;private;privacy;;보안;개인;정보;보호;trash;휴지통;purge;비우기;retain;유지;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "로그인을 제공하는 곳의 웹 주소."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "계정 추가에 실패했습니다"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "암호가 다릅니다."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "계정 등록에 실패했습니다"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "이 도메인에 대해 인증하기 위한 방법을 지원하지 않습니다"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "도메인 참여에 실패했습니다"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"이 로그인 이름은 쓸 수 없습니다.\n"
+"다시 시도해 보십시오."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"이 로그인 암호는 쓸 수 없습니다.\n"
+"다시 시도해 보십시오."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "도메인에 로그를 남기는데 실패했습니다"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "도메인을 찾을 수 없습니다. 잘못 쓰신 것이 아닙니까?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "사용자 추가"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "관리자"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"관리자는 다른 사용자를 추가하거나 제거할 수 있고, 모든 사용자에 대한 설정을 "
+"바꿀 수 있습니다. 자녀 보호 기능은 관리자에게 적용될 수 없습니다."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "사용자가 첫 로그인에 암호 설정"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "지금 암호 설정"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "확인"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "기업 로그인"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "회사 또는 기관에서 관리하는 사용자 계정."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "연결이 끊겼습니다"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"기업 로그인에서는 중앙에서 관리하는 사용자 계정을 이 장치에서 사용합니다. 이 "
+"계정을 사용해서 인터넷에서 회사의 자원에 접근할 수 잇습니다."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "다른 사진 찾아보기"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "파일 선택…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "지문 관리"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "지문"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "아니요(_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "예(_Y)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "등록한 지문을 삭제하고 지문 로그인을 사용하지 않습니까?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "지문 입력 장치 없음"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "지문 입력 장치 없음"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "장치를 제대로 연결했는지 확인하십시오."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "지문 입력 장치"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "설정하려는 지문 입력 장치를 선택하십시오"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "지문 로그인"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"지문 로그인을 이용하면 지문으로 잠금을 풀고 컴퓨터에 로그인할 수 있습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "지문 삭제(_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "지문 등록"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "이 동작을 수행하려면 장치를 선점해야 합니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "장치를 이미 다른 프로세스에서 선점했습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "이 동작을 수행할 권한이 없습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "지문을 하나도 등록하지 않았습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "지문 등록 중에 장치와 통신이 실패했습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "지문 리더와 통신이 실패했습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "지문 데몬과 통신이 실패했습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "지문 목록 표시에 실패했습니다: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "저장한 지문 삭제에 실패했습니다: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "왼쪽 엄지"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "왼쪽 중지"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "왼쪽 검지(_L)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "왼쪽 약지"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "왼쪽 새끼"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "오른쪽 엄지"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "오른쪽 중지"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "오른쪽 검지(_R)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "오른쪽 약지"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "오른쪽 새끼"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "손가락 알 수 없음"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "완료"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "지문 입력 장치 연결이 끊어졌습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "지문 입력 장치의 저장소가 가득 찼습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "새 지문 등록에 실패했습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "등록 시작에 실패했습니다: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "새 지문 등록에 실패했습니다"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "지문 등록 중지에 실패했습니다: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"지문을 등록하려면 반복해서 지문을 입력 센서에 올려놓고 위치를 잡으십시오"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "이 지문 다시 등록(_R)…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "새 지문 스캔"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "지문 입력 장치 %s 해제에 실패했습니다: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "장치 읽기에 문제 발생"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "지문 입력 장치 %s 할당에 실패했습니다: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "지문 입력 장치 정보 가져오기에 실패했습니다: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "이번 주"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "지난 주"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e일"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%Y년 %b %e일"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "세션이 끝났습니다"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "세션이 시작했습니다"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — 계정 활동"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "이전"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "다음"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "다른 암호를 입력하십시오."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "현재 암호를 다시 입력하십시오."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "암호를 바꿀 수 없습니다"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "암호 바꾸기"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "바꾸기(_A)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "현재 암호"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "새 암호"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "암호 확인"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "다음 로그인에 암호를 바꾸도록 허용"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "지금 암호 설정"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "이 종류의 도메인에 자동으로 들어갈 수 없습니다"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "도메인 또는 영역을 찾지 못했습니다"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%2$s 도메인에서 %1$s(으)로 로그인할 수 없습니다"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "암호가 잘못되었으니 다시 시도해주십시오"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "%s 도메인에 연결할 수 없습니다: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "사용자 삭제에 실패했습니다"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "원격에서 관리하는 사용자를 철회하는데 실패했습니다"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "자기 계정은 삭제할 수 없습니다."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s 사용자가 아직 로그인 중입니다"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "로그인 중인 사용자를 삭제하면 시스템이 불안정한 상태가 될 수 있습니다."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "%s 사용자의 파일을 유지하시겠습니까?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"사용자 계정을 삭제할 때 홈 디렉터리, 메일 스풀, 임시 파일을 유지할 수 있습니"
+"다."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "파일 삭제(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "파일 유지(_K)"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "정말로 원격에서 관리하는 %s의 계정을 철회하시겠습니까?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "삭제(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "계정 사용 중지됨"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "다음 로그인에 설정 예정"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "없음"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "로그인함"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "계정 서비스 연결에 실패했습니다"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "AccountService를 설치하고 사용 표시했는지 확인하십시오."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "이 설정을 바꾸려면 이 패널의 잠금을 풀어야 합니다."
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "선택한 사용자 계정 삭제"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"선택한 사용자 계정을 삭제하려면,\n"
+"먼저 * 아이콘을 누르십시오"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "사용자를 추가하고 설정을 바꾸려면 잠금을 해제하십시오"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "사용자"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "바뀐 사항을 적용하려면 세션을 다시 시작해야 합니다."
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "지금 다시 시작"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "닫기"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "아바타 편집"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "전체 이름"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "편집"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "지문 로그인(_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "자동 로그인(_U)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "계정 활동"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "관리자(_A)"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"관리자는 다른 사용자를 추가하거나 제거할 수 있고, 모든 사용자에 대한 설정을 "
+"바꿀 수 있습니다."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "자녀 보호 기능(_P)"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "자녀 보호 기능 프로그램을 엽니다."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "사용자 제거…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "기타 사용자"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "사용자 추가…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "사용자가 없습니다"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "사용자 계정을 추가하려면 잠금을 푸십시오."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "사용자 추가/제거 및 암호 바꾸기"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;로그인;Name;이름;Fingerprint;지문;Avatar;아바타;Logo;로고;Face;얼굴;"
+"Password;암호;비밀 번호;비밀번호;Parental Controls;부모;자녀;보호;Screen "
+"Time;화면 시간;App Restrictions;앱 제한;앱 제약;Web Restrictions;웹 제한;웹 "
+"제약;Usage;Usage Limit;사용 제한;Kid;Child;아이;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "등록(_E)"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "도메인 관리자 로그인"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"기업 로그인을 사용하려면, 이 컴퓨터는 도메인에 참여해야 합니다.\n"
+"네트워크 관리자에게 이곳에 도메인 암호를 입력하라고 요청하십시오."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "관리자 이름(_N)"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "관리자 암호"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "사용자 계정 관리"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "사용자 데이터를 바꾸려면 인증이 필요합니다"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "새 암호는 과거 암호와 달라야 합니다."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "영문자와 숫자를 바꿔 보십시오."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "암호를 약간 바꿔 보십시오."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "이름이 들어 있지 않은 암호가 더 강력합니다."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "암호에 이름을 사용하지 말아 보십시오."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "암호에 포함된 단어를 사용하지 말아 보십시오."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "일반적인 단어를 피해 보십시오."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "단어를 조합하지 말아 보십시오."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "숫자를 더 사용해 보십시오."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "대문자를 더 사용해 보십시오."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "소문자를 더 사용해 보십시오."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "문장 기호 등 특수 문자를 더 사용해 보십시오."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "영문자, 숫자, 문장 기호를 섞어 사용해 보십시오."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "같은 글자 반복을 피해 보십시오."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"같은 종류의 문자의 반복을 피해 보십시오. 영문자, 숫자, 문장 기호를 섞어 써야 "
+"합니다."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 또는 abcd와 같은 연속된 문자를 피해 보십시오."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"암호가 더 길어야 합니다. 영문자, 숫자, 문장 기호를 섞어 사용해 보십시오."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "대소문자를 섞어서 쓰고 숫자를 사용하십시오."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "영문자, 숫자, 문장 기호를 더 쓰면 더 강력합니다."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "인증 실패"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "새 암호가 너무 짧습니다"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "새 암호가 너무 간단합니다"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "예전 암호와 새 암호가 너무 비슷합니다"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "새 암호는 이미 최근에 사용한 암호입니다."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "새 암호에 숫자나 특수 문자가 들어있어야 합니다"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "예전 암호와 새 암호가 같습니다"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "최초에 인증한 뒤에 암호가 바뀌었습니다!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "새 암호에 문자 종류가 너무 적습니다"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "알 수 없는 오류"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"사용자 이름은 보통 a-z까지 대소문자와 숫자, 그리고 다음 문자만으로 만들어야 "
+"합니다: . - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "그 사용자 이름은 사용할 수 없습니다. 다른 이름을 사용하십시오."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "사용자 이름이 너무 깁니다."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "단추 연결"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "단추를 기능에 연결"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"바로 가기 키를 편집하려면, “키 누름 보내기” 동작을 선택하고, 새 키를 누르십시"
+"오. 지우려면 백스페이스를 누르십시오."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "닫기(_C)"
+
+# tablet - 디지타이저
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "디지타이저를 보정하려면 화면에 나타난 표시를 누르십시오."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "잘못된 누름이 감지되었습니다, 다시 시작중…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "단추 %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "정의한 앱"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "키 누름 보내기"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "모니터 바꾸기"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "화면 도움말 표시"
+
+# 그래픽 태블릿
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "노트북 디스플레이에 부착된 디지타이저"
+
+# 그래픽 태블릿
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "외부 디스플레이에 부착된 디지타이저"
+
+# 그래픽 태블릿
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "외부 디지타이저 장치"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "외부 패드 장치"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "모든 디스플레이"
+
+# 그래픽 태블릿
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "디지타이저 모드"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "펜에 대해 절대 좌표를 사용합니다"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "왼손잡이 방향"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "디지타이저와 익스프레스키를 왼손잡이에 맞게 회전합니다"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "모니터에 매핑"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "가로세로비 유지"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "디지타이저 표면의 일부만 사용해 모니터 가로세로비를 유지합니다"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "보정"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "디지타이저가 검색되지 않았습니다"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "와콤 디지타이저를 연결하고 전원을 켜십시오."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "팁 압력 감도"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "부드러움"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "스타일러스 팁 압력"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "단단함"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "단추 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "단추 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "단추 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "지우개 압력 감도"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "지우개 압력"
+
+# stylus button 눌렀을 때 동작
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "가운데 마우스 단추 누르기"
+
+# stylus button 눌렀을 때 동작
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "오른쪽 마우스 단추 누르기"
+
+# stylus button 눌렀을 때 동작
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "앞으로"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "압력, 기울임, 내장 슬라이더 포함 에어브러시 스타일러스"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "압력, 기울임, 회전 포함 에어브러시 스타일러스"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "압력 및 기울임 포함 표준 스타일러스"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "압력 포함 표준 스타일러스"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "와콤 디지타이저"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"그래픽 디지타이저의 단추 매핑을 설정하고 스타일러스의 민감도를 조정합니다"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+"Tablet;태블릿;타블렛;디지타이저;Wacom;와콤;Stylus;스타일러스;Eraser;지우개;"
+"Mouse;마우스;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "새 바로 가기…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "액세스 포인트"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "작업이 취소되었습니다"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>오류:</b> 설정 바꾸는 접근이 거부되었습니다"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>오류:</b> 휴대전화 장치 오류"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "등록되지 않음"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "등록됨"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "로밍"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "검색 중"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "거부됨"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "모뎀 자세히 보기"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "모뎀 상태:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "통신사"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "네트워크 종류"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "네트워크 상태"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "내 전화번호"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "장치 자세히 보기"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "펌웨어 버전"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G 전용"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G 전용"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G 전용"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "5G 전용"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (기본값), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (기본값), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (기본값), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (기본값), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (기본값), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (기본값), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (기본값), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (기본값), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (기본값), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (기본값), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (기본값), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (기본값), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (기본값), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (기본값), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (기본값), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (기본값), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (기본값)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (기본값), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "SIM 카드 잠금 해제"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "잠금 해제"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "SIM %d에 대한 PIN 코드를 입력하십시오"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "SIM 카드 잠금을 해제하려면 PIN을 입력하십시오"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "SIM %d에 대한 PUK 코드를 입력하십시오"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "SIM 카드 잠금을 해제하려면 PUK를 입력하십시오"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "잘못된 암호를 입력했습니다. %u번 시도가 남았습니다"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "%u번 시도가 남았습니다"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "잘못된 압호를 입력했습니다."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK 코드는 8자리 숫자여야 합니다"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "새 PIN 입력"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN 코드는 4-8자 사이의 숫자여야 합니다"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "잠금 해제 중…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "SIM 없음"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "이 모뎀을 사용하려면 SIM 카드를 삽입하십시오"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM 잠겼음"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "휴대전화 데이터(_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "휴대전화 네트워크를 사용해 데이터 접근"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "데이터 로밍(_D)"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "로밍할 때 휴대전화 네트워크 사용"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "네트워크 모드(_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "네트워크(_E)"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "고급"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "액세스 포인트 이름(_A)"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "SIM 잠금(_S)"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "PIN으로 SIM 잠그기"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "모뎀 자세히 보기(_O)"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "휴대전화 실패"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "휴대전화에 연결되지 않음"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "동작을 허용하지 않습니다"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "동작을 지원하지 않습니다"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM 삽입하지 않았습니다"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIM PIN이 필요합니다"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIM PUK가 필요합니다"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM 실패"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM 다른 작업 중"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "잘못된 암호"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM PIN2가 필요합니다"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM PUK2가 필요합니다"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "없음"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "네트워크 서비스 없음"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "네트워크 제한 시간 초과"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS 서비스를 허용하지 않습니다"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "현재 위치의 지역에서는 로밍이 허용되지 않습니다"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "지정하지 않은 GPRS 오류"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "오류 없음"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "동작 취소"
+
+# 권한 이름
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "접근 거부"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "알 수 없는 오류"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "네트워크 모드"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "자동(_A)"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "네트워크 선택"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "네트워크 공급자 새로고침"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "휴대전화 네트워크 사용"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "무선 WAN 어댑터가 없습니다"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "무선 WAN/휴대전화 장치가 있는지 확인하십시오"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "비행기 모드가 켜져 있을 때 무선 WAN이 꺼집니다."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "비행기 모드 끄기(_T)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "데이터 연결"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "인터넷에 사용할 SIM 카드"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM 잠금"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "다음(_N)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "PIN으로 SIM 잠그기(_L)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "PIN 바꾸기"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "SIM 잠금 설정을 바꾸려면 현재 PIN을 입력하십시오"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "휴대전화 네트워크"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "텔레포니 및 휴대전화 데이터 연결 설정"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+"cellular;휴대전화;셀룰러;wwan;무선;telephony;텔레포니;sim;mobile;모바일;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "그놈 데스크톱 설정 프로그램"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "설정은 시스템을 설정하는 주요 인터페이스 프로그램입니다."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "그놈 프로젝트"
+
+# 커맨드라인 설명. 문장으로 번역
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "버전 번호를 표시합니다"
+
+# 커맨드라인 설명. 문장으로 번역
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "자세히 표시 모드를 사용합니다"
+
+# 커맨드라인 설명. 문장으로 번역
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "문자열을 검색합니다"
+
+# 커맨드라인 설명. 문장으로 번역
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "패널 이름 목록을 표시하고 끝냅니다"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "표시할 패널"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[패널] [인수…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "설정 분류"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "개인 정보"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "사용 가능 패널:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "전체 설정"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "기본 메뉴"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "경고: 개발 버전"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"이 버전의 설정은 개발 목적으로만 사용해야 합니다. 잘못된 시스템 동작, 데이터 "
+"손실, 기타 예상치 못한 문제를 겪을 수 있습니다."
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "도움말"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "일반"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "끝내기"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "검색"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "패널"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "이전 창으로 돌아가기"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "검색 취소"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;기본 설정;Settings;설정;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "마지막 설정 패널을 연 아이디"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"마지막에 연 설정 패널 아이디. 알 수 없는 값이면 무시하고 목록에서 첫 번째 패"
+"널을 선택합니다."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "설정의 개발 빌드를 실행할 때 경고 표시"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "설정에서 개발 버전을 실행할 때 경고를 표시할지 여부."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "창의 최초 상태"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr "앱 창의 최초 너비, 높이, 최대화 상태가 들어 있는 튜플."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u개 출력"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u개 입력"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "시스템 사운드"

--- a/po/ku.po
+++ b/po/ku.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.HEAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-10-18 15:38+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2011-10-18 16:05+0200\n"
 "Last-Translator: Erdal Ronahî <erdal dot ronahi at gmail dot com>\n"
 "Language-Team: Kurdish Team http://pckurd.net\n"
@@ -20,4457 +20,6212 @@ msgstr ""
 "X-Generator: Virtaal 0.6.1\n"
 "X-Rosetta-Export-Date: 2007-03-04 16:18+0000\n"
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
-msgid "Background"
-msgstr "Rûerd"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change the background"
-msgstr "Rûerdî biguherîne"
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Kaxiza dîwar;Dîmender;Sermasê;"
-
-#: ../panels/background/background.ui.h:1
-msgid "Add wallpaper"
-msgstr "Kaxiza dîwar lê zêde bike"
-
-#: ../panels/background/background.ui.h:2
-msgid "Center"
-msgstr "Navîn"
-
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:4
-msgid "Changes throughout the day"
-msgstr ""
-
-#: ../panels/background/background.ui.h:5
-msgid "Fill"
-msgstr "Tijîkirin"
-
-#: ../panels/background/background.ui.h:6
-msgid "Remove wallpaper"
-msgstr "Kaxiza dîwar rake"
-
-#: ../panels/background/background.ui.h:7
-msgid "Scale"
-msgstr "Rêjekirî"
-
-#: ../panels/background/background.ui.h:8
-msgid "Span"
-msgstr ""
-
-#: ../panels/background/background.ui.h:9
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
 #, fuzzy
-msgid "Tile"
-msgstr "Raxistî"
+msgid "Applications"
+msgstr "<b>Bername</b>"
 
-#: ../panels/background/background.ui.h:10
-msgid "Zoom"
-msgstr "Mezinkirin"
-
-#: ../panels/background/bg-colors-source.c:46
-msgid "Horizontal Gradient"
-msgstr "Derbasbûna Serpahnayê"
-
-#: ../panels/background/bg-colors-source.c:47
-msgid "Vertical Gradient"
-msgstr "Gradyana Tîkane"
-
-#: ../panels/background/bg-colors-source.c:48
-msgid "Solid Color"
-msgstr "Rengê Tampon"
-
-#: ../panels/background/cc-background-panel.c:1001
-#: ../panels/user-accounts/um-photo-dialog.c:217
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
-msgid "Browse for more pictures"
-msgstr ""
-
-#: ../panels/background/cc-background-panel.c:1093
+#: panels/applications/cc-applications-panel.ui:31
 #, fuzzy
-msgid "Current background"
-msgstr "Rûerdê Sermasê"
+msgid "No applications"
+msgstr "<b>Bername</b>"
 
-#: ../panels/background/cc-background-panel.c:1203
+#: panels/applications/cc-applications-panel.ui:34
 #, fuzzy
-msgid "Wallpapers"
-msgstr "Kaxiza Dîwar Tuneye"
-
-#: ../panels/background/cc-background-panel.c:1210
-msgid "Pictures Folder"
-msgstr ""
-
-#: ../panels/background/cc-background-panel.c:1217
-msgid "Colors & Gradients"
-msgstr ""
-
-#: ../panels/background/cc-background-panel.c:1225
-msgid "Flickr"
-msgstr "Flickr"
-
-#: ../panels/background/cc-background-item.c:148
-msgid "multiple sizes"
-msgstr ""
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:152
-#, c-format
-msgid "%d × %d"
-msgstr ""
-
-#: ../panels/background/cc-background-item.c:281
-msgid "No Desktop Background"
-msgstr "Rûerdê sermasê tunebe"
-
-#. Add some common languages first
-#: ../panels/common/cc-common-language.c:513
-msgid "English"
-msgstr "Îngilîzî"
-
-#: ../panels/common/cc-common-language.c:515
-msgid "British English"
-msgstr "Îngilîziya Brîtanyayê"
-
-#: ../panels/common/cc-common-language.c:517
-msgid "German"
-msgstr "Almanî"
-
-#: ../panels/common/cc-common-language.c:519
-msgid "French"
-msgstr "Fransî"
-
-#: ../panels/common/cc-common-language.c:521
-msgid "Spanish"
-msgstr "Spanî"
-
-#: ../panels/common/cc-common-language.c:523
-msgid "Chinese (simplified)"
-msgstr "Çîniya hêsankirî"
-
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:552
-msgid "United States"
-msgstr "Dewletên Yekbuyî (yên Emerîqa)"
-
-#: ../panels/common/cc-common-language.c:553
-msgid "Germany"
-msgstr "Almanya"
-
-#: ../panels/common/cc-common-language.c:554
-msgid "France"
-msgstr "Fransa"
-
-#: ../panels/common/cc-common-language.c:555
-msgid "Spain"
-msgstr "Spanya"
-
-#: ../panels/common/cc-common-language.c:556
-msgid "China"
-msgstr "Çîn"
-
-#: ../panels/common/cc-language-chooser.c:119
-msgid "Other..."
-msgstr "Yên din..."
-
-#: ../panels/common/cc-language-chooser.c:290
-msgid "Select a region"
-msgstr "Herêm hilbijêre"
-
-#: ../panels/common/gdm-languages.c:774
-msgid "Unspecified"
-msgstr "Nediyar"
-
-#: ../panels/common/language-chooser.ui.h:1
-msgid "Select a language"
-msgstr "Zimanî hilbijêre"
-
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/printers/new-printer-dialog.ui.h:4
-#: ../panels/user-accounts/um-user-panel.c:448
-msgid "_Cancel"
-msgstr "_Betal"
-
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/universal-access/gconf-property-editor.c:1609
-msgid "_Select"
-msgstr "_Hilbijartin"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "24-hour"
-msgstr ""
-
-#. Translator: this is the separator between hours and minutes, like in HH:MM
-#: ../panels/datetime/datetime.ui.h:3
-msgid ":"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "AM/PM"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "April"
-msgstr "nîsan"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "August"
-msgstr "tebax"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "Day"
-msgstr "roj"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "December"
-msgstr "kanûn"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "February"
-msgstr "sibat"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "January"
-msgstr "çile"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "July"
-msgstr "tîrmeh"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "June"
-msgstr "hezîran"
-
-#: ../panels/datetime/datetime.ui.h:13
-msgid "March"
-msgstr "adar"
-
-#: ../panels/datetime/datetime.ui.h:14
-msgid "May"
-msgstr "gulan"
-
-#: ../panels/datetime/datetime.ui.h:15
-msgid "Month"
-msgstr "meh"
-
-#: ../panels/datetime/datetime.ui.h:16
-msgid "November"
-msgstr "mijdar"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "October"
-msgstr "cotmeh"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "September"
-msgstr "îlon"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Set the time one hour ahead."
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:20
-msgid "Set the time one hour back."
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:21
-msgid "Set the time one minute ahead."
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:22
-msgid "Set the time one minute back."
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Switch between AM and PM."
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:24
-msgid "Year"
-msgstr ""
-
-#: ../panels/datetime/datetime.ui.h:25
-msgid "_City:"
-msgstr "_Bajar:"
-
-#: ../panels/datetime/datetime.ui.h:26
-msgid "_Network Time"
-msgstr "Dema _torê"
-
-#: ../panels/datetime/datetime.ui.h:27
-msgid "_Region:"
-msgstr "_Herêm:"
-
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Clock;Timezone;Location;"
-msgstr "Demjimêr;Herêma demê;Cih;"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
-msgid "Date and Time"
-msgstr "Roj û dem"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
-msgid "Date and Time preferences panel"
-msgstr "Darikê vebijêrkên roj û demê"
-
-#: ../panels/display/display-capplet.ui.h:1
-#: ../panels/display/cc-display-panel.c:641
-msgid "Monitor"
-msgstr "Dîmender"
-
-#: ../panels/display/display-capplet.ui.h:2
-msgid "Note: may limit resolution options"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:3
-msgid "R_otation:"
-msgstr "Bi_nobedarî:"
-
-#: ../panels/display/display-capplet.ui.h:4
-msgid "_Detect Displays"
-msgstr ""
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:6
-msgid "_Mirror displays"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:7
-msgid "_Resolution:"
-msgstr "_Xuyakirin:"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Change resolution and position of monitors and projectors"
-msgstr ""
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Displays"
-msgstr "Dîmender"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:477
-msgctxt "display panel, rotation"
-msgid "Normal"
-msgstr "Asayî"
-
-#: ../panels/display/cc-display-panel.c:478
-msgctxt "display panel, rotation"
-msgid "Counterclockwise"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:479
-msgctxt "display panel, rotation"
-msgid "Clockwise"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:480
-msgctxt "display panel, rotation"
-msgid "180 Degrees"
-msgstr ""
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../panels/display/cc-display-panel.c:617
-msgid "Mirror Displays"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:747
-#, c-format
-msgid "%d x %d (%s)"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:749
-#, c-format
-msgid "%d x %d"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:1656
-msgid "Drag to change primary display."
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:1714
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2102
-msgid "%a %R"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2104
-msgid "%a %l:%M %p"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2350
-#, fuzzy
-msgid "Could not save the monitor configuration"
-msgstr "Dirûvê navîn yê mak nehate barkirin"
-
-#: ../panels/display/cc-display-panel.c:2375
-msgid "Could not get session bus while applying display configuration"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2420
-msgid "Could not detect displays"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2614
-#, fuzzy
-msgid "Could not get screen information"
-msgstr "Xuyakirina dîmender biguherîne"
-
-#. Translators: VESA is an techncial acronym, don't translate it.
-#: ../panels/info/cc-info-panel.c:402
-#, c-format
-msgid "VESA: %s"
-msgstr ""
-
-#. TRANSLATORS: device type
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:426 ../panels/network/panel-common.c:79
-#: ../panels/network/panel-common.c:158
-msgid "Unknown"
-msgstr "Nenas"
-
-#. translators: This is the type of architecture, for example:
-#. * "64-bit" or "32-bit"
-#: ../panels/info/cc-info-panel.c:587
-#, c-format
-msgid "%d-bit"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:744
-#, fuzzy
-msgid "Unknown model"
-msgstr "Nîşankereke Nenas"
-
-#: ../panels/info/cc-info-panel.c:827
-msgid "The next login will attempt to use the standard experience."
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:829
-msgid ""
-"The next login will use the fallback mode intended for unsupported graphics "
-"hardware."
-msgstr ""
-
-#. translators: The hardware is not able to run GNOME 3's
-#. * shell, so we use the GNOME "Fallback" session
-#: ../panels/info/cc-info-panel.c:871
-#, fuzzy
-msgctxt "Experience"
-msgid "Fallback"
-msgstr "Careke din bang bike"
-
-#. translators: The hardware is able to run GNOME 3's
-#. * shell, also called "Standard" experience
-#: ../panels/info/cc-info-panel.c:877
-#, fuzzy
-msgctxt "Experience"
-msgid "Standard"
-msgstr "Termînala Xê ya Standart"
-
-#: ../panels/info/cc-info-panel.c:1200
-msgid "Ask what to do"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1204
-msgid "Do nothing"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1208
-#, fuzzy
-msgid "Open folder"
-msgstr "Peldanka mal"
-
-#: ../panels/info/cc-info-panel.c:1319
-#, fuzzy
-msgid "Select an application for audio CDs"
-msgstr "Sepanên xwe yên pêşdanasînî hilbijêre"
-
-#: ../panels/info/cc-info-panel.c:1320
-#, fuzzy
-msgid "Select an application for video DVDs"
-msgstr "Sepanên xwe yên pêşdanasînî hilbijêre"
-
-#: ../panels/info/cc-info-panel.c:1321
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1322
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1323
-#, fuzzy
-msgid "Select an application for software CDs"
-msgstr "Wekî Curenivîsa Bernameyê Mîheng Bike"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1335
-msgid "audio DVD"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1336
-msgid "blank Blu-ray disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1337
-msgid "blank CD disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1338
-msgid "blank DVD disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1339
-msgid "blank HD DVD disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1340
-msgid "Blu-ray video disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1341
-msgid "e-book reader"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1342
-msgid "HD DVD video disc"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1343
-msgid "Picture CD"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1344
-msgid "Super Video CD"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1345
-msgid "Video CD"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1474
-#: ../panels/keyboard/keyboard-shortcuts.c:1772
-msgid "Section"
-msgstr "Beş"
-
-#: ../panels/info/cc-info-panel.c:1483 ../panels/info/info.ui.h:15
-#, fuzzy
-msgid "Overview"
-msgstr "Pêşdîtin:"
-
-#: ../panels/info/cc-info-panel.c:1489 ../panels/info/info.ui.h:4
-msgid "Default Applications"
-msgstr "Sepanên standard"
-
-#: ../panels/info/cc-info-panel.c:1494 ../panels/info/info.ui.h:17
-msgid "Removable Media"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1499 ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "Grafîk"
-
-#: ../panels/info/cc-info-panel.c:1700
-#, c-format
-msgid "Version %s"
-msgstr "Guhertoya %s"
-
-#: ../panels/info/cc-info-panel.c:1750
-msgid "Install Updates"
+msgid "Install some…"
 msgstr "Rojanekirinan saz bike"
 
-#: ../panels/info/cc-info-panel.c:1754
-msgid "System Up-To-Date"
-msgstr "Pergal rojane ye"
-
-#: ../panels/info/cc-info-panel.c:1758
-msgid "Checking for Updates"
-msgstr "Rojanekirin tê kontrolkirin"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-msgid "System Info"
-msgstr "Agahiyên pergalî"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "System Information"
-msgstr "Agahiyên pergalî"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-
-#: ../panels/info/info.ui.h:1
-msgid "Acti_on:"
-msgstr "Çala_kî:"
-
-#: ../panels/info/info.ui.h:2
-msgid "CD _audio:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:3
+#: panels/applications/cc-applications-panel.ui:84
 #, fuzzy
-msgid "Calculating..."
-msgstr "Girêdide..."
+msgid "Open"
+msgstr "_Veke"
 
-#: ../panels/info/info.ui.h:5
-msgid "Device name"
-msgstr "Navê alavê"
-
-#: ../panels/info/info.ui.h:6
-msgid "Disk"
-msgstr "Dîsk"
-
-#: ../panels/info/info.ui.h:7
-msgid "Driver"
-msgstr "Ajoger"
-
-#: ../panels/info/info.ui.h:8
-msgid "Experience"
-msgstr ""
-
-#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
-#: ../panels/info/info.ui.h:10
-msgid "Forced _Fallback Mode"
-msgstr ""
-
-#: ../panels/info/info.ui.h:12
-msgid "M_usic"
-msgstr "Mûzîk"
-
-#: ../panels/info/info.ui.h:13
-msgid "Memory"
-msgstr "Bîr"
-
-#: ../panels/info/info.ui.h:14
-msgid "OS type"
-msgstr ""
-
-#: ../panels/info/info.ui.h:16
-msgid "Processor"
-msgstr ""
-
-#: ../panels/info/info.ui.h:18
-msgid "Select how media should be handled"
-msgstr ""
-
-#: ../panels/info/info.ui.h:19
-msgid "Select how other media should be handled"
-msgstr ""
-
-#: ../panels/info/info.ui.h:20
-msgid "_Calendar"
-msgstr "Sal_name"
-
-#: ../panels/info/info.ui.h:21
-msgid "_DVD video:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:22
-msgid "_Mail"
-msgstr "_Posta"
-
-#: ../panels/info/info.ui.h:23
-msgid "_Music player:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:24
-msgid "_Never prompt or start programs on media insertion"
-msgstr ""
-
-#: ../panels/info/info.ui.h:25
-msgid "_Other Media..."
-msgstr ""
-
-#: ../panels/info/info.ui.h:26
-msgid "_Photos"
-msgstr ""
-
-#: ../panels/info/info.ui.h:27
-msgid "_Photos:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:28
-msgid "_Software:"
-msgstr ""
-
-#: ../panels/info/info.ui.h:29
-msgid "_Type:"
-msgstr "_Cure:"
-
-#: ../panels/info/info.ui.h:30
-msgid "_Video"
-msgstr ""
-
-#: ../panels/info/info.ui.h:31
-msgid "_Web"
-msgstr ""
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
-msgid "Eject"
-msgstr "Bavêje"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
+#: panels/applications/cc-applications-panel.ui:94
 #, fuzzy
-msgid "Launch media player"
-msgstr "Jimêreyê bide xebitandin"
+msgid "View Details"
+msgstr "Kîtekîtên Dirban"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
-#, fuzzy
-msgid "Next track"
-msgstr "Here parçeyê din"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
-#, fuzzy
-msgid "Pause playback"
-msgstr "Dîsa lêdana deng:"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
-msgid "Play (or play/pause)"
-msgstr "Lê bide (an jî lê bide/rawestîne)"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
-#, fuzzy
-msgid "Previous track"
-msgstr "Vegere parçeyê berê"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
-msgid "Sound and Media"
-msgstr "Deng û medya"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
-msgid "Stop playback"
-msgstr "Rawestandina lêdanê"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
-msgid "Volume down"
-msgstr "Deng kêm bike"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
-msgid "Volume mute"
-msgstr "Deng bibire"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
-msgid "Volume up"
-msgstr "Deng zêde bike"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:1
-msgid "Home folder"
-msgstr "Peldanka mal"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:2
-msgid "Launch calculator"
-msgstr "Jimêreyê bide xebitandin"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:3
-#, fuzzy
-msgid "Launch email client"
-msgstr "Jimêreyê bide xebitandin"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:4
-msgid "Launch help browser"
-msgstr "Gerokê alîkariyê veke"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:5
-msgid "Launch web browser"
-msgstr "Geroka webê veke"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:6
-#, fuzzy
-msgid "Launchers"
-msgstr "Geroka webê veke"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Lê bigere"
 
-#: ../panels/keyboard/01-system.xml.in.h:1
-msgid "Lock screen"
-msgstr "Ekranê qifil bike"
-
-#: ../panels/keyboard/01-system.xml.in.h:2
-msgid "Log out"
-msgstr "Derkeve"
-
-#: ../panels/keyboard/01-system.xml.in.h:3
-#: ../panels/region/gnome-region-panel.ui.h:24
-msgid "System"
-msgstr "Pergal"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-msgid "Decrease text size"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
-msgid "Increase text size"
-msgstr ""
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
-#, fuzzy
-msgid "Magnifier zoom in"
-msgstr "_Girdok"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
-#, fuzzy
-msgid "Magnifier zoom out"
-msgstr "_Girdok"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
-#, fuzzy
-msgid "Toggle contrast"
-msgstr "_Tarîbûna herî baş"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
-#, fuzzy
-msgid "Toggle magnifier"
-msgstr "_Girdok"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
-#, fuzzy
-msgid "Toggle on-screen keyboard"
-msgstr "Klavyeya _dîmenderê"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
-#, fuzzy
-msgid "Toggle screen reader"
-msgstr "_Xwînerê dîmenderê"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
-msgid "Universal Access"
-msgstr ""
-
-#: ../panels/keyboard/eggcellrendererkeys.c:21
-#, fuzzy
-msgid "New shortcut..."
-msgstr "Kurteriya derxe."
-
-#: ../panels/keyboard/eggcellrendererkeys.c:164
-#: ../panels/keyboard/eggcellrendererkeys.c:165
-msgid "Accelerator key"
-msgstr "Bişkoka Lezker"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:174
-#: ../panels/keyboard/eggcellrendererkeys.c:175
-msgid "Accelerator modifiers"
-msgstr "Sererastkerên lezkeran"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:183
-#: ../panels/keyboard/eggcellrendererkeys.c:184
-msgid "Accelerator keycode"
-msgstr "Koda bişkokên lezkeran"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:194
-msgid "Accel Mode"
-msgstr "Moda Lezandinê"
-
-#: ../panels/keyboard/eggcellrendererkeys.c:195
-msgid "The type of accelerator."
-msgstr "Cureyê Lezkeran"
-
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/eggcellrendererkeys.c:243
-#: ../panels/keyboard/keyboard-shortcuts.c:1193
-#: ../panels/sound/gvc-mixer-control.c:1086
-#: ../panels/user-accounts/um-fingerprint-dialog.c:177
-#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Neçalak"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 #, fuzzy
-msgid "Change keyboard settings"
-msgstr "Taybetmendiyên Rûerd yên Sermasê Biguherîne"
+msgid "Notifications"
+msgstr "_Girdok"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "Keyboard"
-msgstr "Klavye"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Agahiyên pergalî"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Rûerd"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:646
-#: ../panels/keyboard/keyboard-shortcuts.c:654
-#: ../panels/keyboard/keyboard-shortcuts.c:968
-#: ../panels/keyboard/keyboard-shortcuts.c:1566
-#: ../panels/keyboard/keyboard-shortcuts.c:1570
+#: panels/applications/cc-applications-panel.ui:140
 #, fuzzy
-msgid "Custom Shortcuts"
+msgid "Screenshots"
+msgstr "Dîmen"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Kaxiza Dîwar Tuneye"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Deng"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
 msgstr "Kurterê"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:814
-msgid "<Unknown Action>"
-msgstr "<Çalakiya nenas>"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Kurteriyên Klavyeyê"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1219
-msgid "Error saving the new shortcut"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1352
-#, c-format
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "Cih"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Bêdeng"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Cureyên alavan"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+"How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1382
-#, fuzzy, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-"Kurteriya \"%s\" ji bo vî karî tê bikaranîn:\n"
-"\"%s\"\n"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "<b>Bername</b>"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1387
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1393
-msgid "_Reassign"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1505
+#: panels/applications/cc-applications-panel.ui:438
 #, fuzzy
-msgid "Too many custom shortcuts"
-msgstr "Kurteriya deng zêde bike."
+msgid "<b>Total</b>"
+msgstr "<b>Eposte</b>"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1825
-msgid "Action"
-msgstr "Çalakî"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1848
-msgid "Shortcut"
-msgstr "Kurterê"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "C_ommand:"
-msgstr "_Ferman:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#, fuzzy
-msgid "Cursor Blinking"
-msgstr "<b>Nîşankerê vêxistin/vemirandê</b>"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#, fuzzy
-msgid "Cursor _blinks in text fields"
-msgstr "Nîşan_kerê vêxistin/vemirandê di qutiyên nivîsan û qadan de"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Cursor blinks speed"
-msgstr "Nîşanek"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-#, fuzzy
-msgid "Custom Shortcut"
-msgstr "Kurterê"
-
-#. fast acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Fast"
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "Dema bişkoj _pêlêkirî be bila klavye dubare bike"
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
 #, fuzzy
-msgid "Layout Settings"
+msgid "Style"
+msgstr "_Teşe:Di"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Wekî heyî"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Rûerd"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "Fransa"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "Neçalak"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "Mîhengên Pêşdanasînî"
 
-#. long delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-#: ../panels/universal-access/uap.ui.h:38
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Long"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-#, fuzzy
-msgid "Repeat Keys"
-msgstr "<b>Bişkokên Dubarekirinê</b>"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "Leza dubarekirina bişkokan"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgid "S_peed:"
-msgstr "_Lez:"
-
-#. short delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-#: ../panels/mouse/gnome-mouse-properties.ui.h:23
-#: ../panels/universal-access/uap.ui.h:53
-#: ../panels/universal-access/zoom-options.ui.h:22
-#, fuzzy
-msgid "Short"
-msgstr "Kurterê"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-#, fuzzy
-msgid "Shortcuts"
-msgstr "Kurterê"
-
-#. slow acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-#: ../panels/mouse/gnome-mouse-properties.ui.h:25
-msgid "Slow"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-#, fuzzy
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"Ji bo guherandina bişkokên kurteriyan, pêl rêzika guncav bike û pêl bişkokên "
-"kurteriya nû bike, yan jî bi backspace kurteriya heyî jê bibe."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-#: ../panels/universal-access/uap.ui.h:65
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Betal"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
 #, fuzzy
-msgid "Typing"
-msgstr "Bêhnvedana Nivîsînê"
+msgid "_Start"
+msgstr "Destpêk"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-msgid "_Delay:"
-msgstr "_Derengmayîn:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-msgid "_Name:"
-msgstr "_Nav:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "_Speed:"
-msgstr "_Lez:"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:305
-msgid "Error logging into the account"
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:351
-msgid "Expired credentials. Please log in again."
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:354
-msgid "_Log In"
-msgstr ""
-
-#. translators: This is the title of the "Add Account" dialogue.
-#. * The title is not visible when using GNOME Shell
-#: ../panels/online-accounts/cc-online-accounts-panel.c:461
-msgid "Add Account"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:466
-msgid "To add a new account, first select the account type"
-msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:469
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 #, fuzzy
-msgid "Account Type:"
-msgstr "Cureyê Hişyariyê"
+msgid "Screen Calibration"
+msgstr "Xuyakirina dîmender"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Add..."
-msgstr "_Têxê..."
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:555
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
 #, fuzzy
-msgid "Error creating account"
-msgstr "Dema veavakirin dihate tomarkirin çewtî: %s"
+msgid "Display Type"
+msgstr "Dîmender"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:589
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
 #, fuzzy
-msgid "Error removing account"
-msgstr "Dema veavakirin dihate tomarkirin çewtî: %s"
+msgid "Profile Whitepoint"
+msgstr "Nîşankerê Sipî yê Mezin"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:625
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
 #, fuzzy
-msgid "Are you sure you want to remove the account?"
-msgstr "Tu dixwazî van xuyakirinan tomar bikî?"
+msgid "Display Brightness"
+msgstr "Biriqandinê zêde bike"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:627
-msgid "This will not remove the account on the server."
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:628
-msgid "_Remove"
-msgstr "_Rakirin"
-
-#. Translators: those are keywords for the online-accounts control-center panel
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
 msgstr ""
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
-msgid "Manage online accounts"
-msgstr ""
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-msgid "Online Accounts"
-msgstr ""
-
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "Select an account"
-msgstr "Hesabekê hilbijêre"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:520
-msgid "Low on toner"
-msgstr ""
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:522
-msgid "Out of toner"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:525
-msgid "Low on developer"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:528
-msgid "Out of developer"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:530
-msgid "Low on a marker supply"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:532
-msgid "Out of a marker supply"
-msgstr ""
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:534
+#: panels/color/cc-color-panel.ui:214
 #, fuzzy
-msgid "Open cover"
-msgstr "Pelî Veke"
+msgid "Profile Name"
+msgstr "navê pelî"
 
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:536
-msgid "Open door"
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
 msgstr ""
 
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:538
-msgid "Low on paper"
-msgstr ""
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:540
-msgid "Out of paper"
-msgstr ""
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:542
-msgctxt "printer state"
-msgid "Offline"
-msgstr ""
-
-#. Translators: Someone has paused the Printer
-#: ../panels/printers/cc-printers-panel.c:544
+#: panels/color/cc-color-panel.ui:229
 #, fuzzy
-msgctxt "printer state"
-msgid "Paused"
-msgstr "Navber"
+msgid "Profile Name:"
+msgstr "_Mobîl:"
 
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:546
-msgid "Waste receptacle almost full"
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
 msgstr ""
 
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:548
-msgid "Waste receptacle full"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
 msgstr ""
 
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:550
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:552
-msgid "The optical photo conductor is no longer functioning"
-msgstr ""
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:724
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Amade"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:728
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Tê xebitandin"
-
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Rawestandî"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:851
-msgid "Toner Level"
-msgstr ""
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:854
-msgid "Ink Level"
-msgstr ""
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:857
+#: panels/color/cc-color-panel.ui:290
 #, fuzzy
-msgid "Supply Level"
-msgstr "Dirb bi kar bîne"
+msgid "Copy profile"
+msgstr "Pel tên jibergirtin"
 
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:872
-#: ../panels/printers/cc-printers-panel.c:1258
-#, fuzzy, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "_Neçalak bike"
-msgstr[1] "_Neçalak bike"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:977
-msgid "No printers available"
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
 msgstr ""
 
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/cc-printers-panel.c:1301
-msgctxt "print job"
-msgid "Pending"
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/cc-printers-panel.c:1305
-msgctxt "print job"
-msgid "Held"
-msgstr ""
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/cc-printers-panel.c:1309
+#: panels/color/cc-color-panel.ui:335
 #, fuzzy
-msgctxt "print job"
-msgid "Processing"
-msgstr "_Pisporî:"
+msgid "Add Profile"
+msgstr "_Mobîl:"
 
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/cc-printers-panel.c:1313
-msgctxt "print job"
-msgid "Stopped"
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
 msgstr ""
 
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/cc-printers-panel.c:1317
-msgctxt "print job"
-msgid "Canceled"
-msgstr ""
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/cc-printers-panel.c:1321
-msgctxt "print job"
-msgid "Aborted"
-msgstr ""
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/cc-printers-panel.c:1325
-msgctxt "print job"
-msgid "Completed"
-msgstr ""
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/cc-printers-panel.c:1408
+#: panels/color/cc-color-panel.ui:384
 #, fuzzy
-msgid "Job Title"
-msgstr "_Sernav:"
+msgid "_Import File…"
+msgstr "_Veguhezîne Hundir"
 
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/cc-printers-panel.c:1417
-msgid "Job State"
-msgstr ""
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/cc-printers-panel.c:1423
-#, fuzzy
-msgid "Time"
-msgstr "-Dembûrî:"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:2019
-msgid "Failed to add new printer."
-msgstr ""
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2223
-#: ../panels/printers/cc-printers-panel.c:2237
-#, fuzzy
-msgid "Test page"
-msgstr "Ceribandin"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2484
-#, fuzzy, c-format
-msgid "Could not load ui: %s"
-msgstr "Dirûvê navîn yê mak nehate barkirin"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
-#, fuzzy
-msgid "Change printer settings"
-msgstr "Taybetmendiyên Rûerd yên Sermasê Biguherîne"
-
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
-msgid "Printer;Queue;Print;Paper;Ink;Toner;"
-msgstr ""
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
-#: ../panels/printers/pp-new-printer-dialog.c:148
-msgid "Printers"
-msgstr "Çaper"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "A_ddress:"
-msgstr "_Navnîşan:"
-
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#, fuzzy
-msgid "Add a New Printer"
-msgstr "Nîşankerê Mezin"
-
-#: ../panels/printers/new-printer-dialog.ui.h:3
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
 #, fuzzy
 msgid "_Add"
 msgstr "_Têxê..."
 
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "_Search by Address"
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 
-#: ../panels/printers/pp-new-printer-dialog.c:654
-msgid "Getting devices..."
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
 msgstr ""
 
-#. Translators: No localy connected printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1230
-msgid "No local printers found"
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
 msgstr ""
 
-#. Translators: No network printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1243
-msgid "No network printers found"
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
 msgstr ""
 
-#: ../panels/printers/pp-new-printer-dialog.c:1335
-msgid ""
-"FirewallD is not running. Network printer detection needs services mdns, "
-"ipp, ipp-client and samba-client enabled on firewall."
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
 msgstr ""
 
-#. Translators: Column of devices which can be installed
-#: ../panels/printers/pp-new-printer-dialog.c:1363
-#: ../panels/printers/pp-new-printer-dialog.c:1368
-msgid "Devices"
-msgstr "Alav"
-
-#. Translators: Local means local printers
-#: ../panels/printers/pp-new-printer-dialog.c:1393
-msgctxt "printer type"
-msgid "Local"
-msgstr "Herêmî"
-
-#. Translators: Network means network printers
-#: ../panels/printers/pp-new-printer-dialog.c:1395
-msgctxt "printer type"
-msgid "Network"
-msgstr "Tor"
-
-#. Translators: Device types column (network or local)
-#: ../panels/printers/pp-new-printer-dialog.c:1436
-msgid "Device types"
-msgstr "Cureyên alavan"
-
-#. Translators: Name of job which makes printer to autoconfigure itself
-#: ../panels/printers/pp-new-printer-dialog.c:1737
-msgid "Automatic configuration"
-msgstr "Mîhengên bixweber"
-
-#: ../panels/printers/pp-new-printer-dialog.c:1818
-msgid "Opening firewall for mDNS connections"
-msgstr ""
-
-#: ../panels/printers/pp-new-printer-dialog.c:1827
-msgid "Opening firewall for Samba connections"
-msgstr ""
-
-#: ../panels/printers/pp-new-printer-dialog.c:1836
-msgid "Opening firewall for IPP connections"
-msgstr ""
-
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:2
-msgid "Active Print Jobs"
-msgstr ""
-
-#. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:4
-msgid "Add New Printer"
-msgstr ""
-
-#: ../panels/printers/printers.ui.h:5
-msgid "Allowed users"
-msgstr ""
-
-#: ../panels/printers/printers.ui.h:6
-#: ../panels/network/cc-network-panel.c:1990
-#: ../panels/network/cc-network-panel.c:1993 ../panels/network/network.ui.h:11
-msgid "IP Address"
-msgstr "Navnîşana IP"
-
-#: ../panels/printers/printers.ui.h:7
-msgid "Jobs"
-msgstr "Kar"
-
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:9
-msgid "Location"
-msgstr "Cih"
-
-#: ../panels/printers/printers.ui.h:10
+#: panels/color/cc-color-panel.ui:481
 #, fuzzy
-msgid "Model"
-msgstr "Model"
+msgid "_Enable"
+msgstr "Neçalak"
 
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:12
-msgid "Print _Test Page"
-msgstr ""
-
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:14
+#: panels/color/cc-color-panel.ui:497
 #, fuzzy
-msgid "Printer Options"
-msgstr "Vebijêrk"
+msgid "_Add profile"
+msgstr "_Mobîl:"
 
-#. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:16
-msgid ""
-"Sorry! The system printing service\n"
-"doesn't seem to be available."
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
 msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:19
-msgid "Supply"
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
 msgstr ""
 
-#. Translators: Switch back to printer's info tab
-#: ../panels/printers/printers.ui.h:21
-msgid "_Back"
-msgstr ""
-
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:23
+#: panels/color/cc-color-panel.ui:511
 #, fuzzy
-msgid "_Default"
-msgstr "Wekî heyî"
+msgid "_Remove profile"
+msgstr "_Rakirin"
 
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:25
+#: panels/color/cc-color-panel.ui:517
 #, fuzzy
-msgid "_Options"
-msgstr "Vebijêrk"
+msgid "_View details"
+msgstr "Kîtekîtên Dirban"
 
-#. Tanslators: Switch to tab containing printer's jobs
-#: ../panels/printers/printers.ui.h:27
-msgid "_Show"
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel-formats.c:142
-msgid "Imperial"
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel-formats.c:144
-msgid "Metric"
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
-msgid "Choose a Layout"
-msgstr "Nexşeya Bişkokan Hilbijêre"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
-#, fuzzy
-msgid "Preview"
-msgstr "Pêşdîtin:"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
-msgid "Select an input source to add"
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
-#, fuzzy
-msgid "Keyboard Layout Options"
-msgstr "Bijarekên klavye"
-
-#: ../panels/region/gnome-region-panel.ui.h:1
-msgid "Allow different layouts for individual windows"
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:2
-#: ../panels/region/gnome-region-panel-system.c:406
-#, fuzzy
-msgid "Copy Settings..."
-msgstr "Girêdide..."
-
-#: ../panels/region/gnome-region-panel.ui.h:3
-msgid "Currency"
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:4
-msgid "Dates"
-msgstr "Roj"
-
-#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
-#: ../panels/region/gnome-region-panel.ui.h:6
-msgid "Display language:"
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:7
-msgid "Examples"
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:8
-#, fuzzy
-msgid "Format:"
-msgstr "asayî"
-
-#: ../panels/region/gnome-region-panel.ui.h:9
-#, fuzzy
-msgid "Formats"
-msgstr "asayî"
-
-#: ../panels/region/gnome-region-panel.ui.h:10
-msgid "Input source:"
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:11
-#, fuzzy
-msgid "Install languages..."
-msgstr "Dirban _Saz Bike..."
-
-#: ../panels/region/gnome-region-panel.ui.h:12
-msgid "Language"
-msgstr "Ziman"
-
-#: ../panels/region/gnome-region-panel.ui.h:13
-msgid "Layouts"
-msgstr "Pergal"
-
-#: ../panels/region/gnome-region-panel.ui.h:14
-msgid "Measurement"
-msgstr "Pîvan"
-
-#: ../panels/region/gnome-region-panel.ui.h:15
-msgid "New windows use the default layout"
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:16
-msgid "New windows use the previous window's layout"
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:17
-msgid "Numbers"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:18
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-msgid "Region and Language"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:19
-msgid ""
-"Replace the current keyboard layout settings with the\n"
-"default settings"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:21
-#, fuzzy
-msgid "Reset to De_faults"
-msgstr "Vegere S_tandardan"
-
-#: ../panels/region/gnome-region-panel.ui.h:22
-msgid "Select a display language (change will be applied next time you log in)"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:23
-msgid "Select a region (change will be applied the next time you log in)"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:25
-#, fuzzy
-msgid "System settings"
-msgstr "Mîhengên X bikar bîne"
-
-#: ../panels/region/gnome-region-panel.ui.h:26
-#: ../panels/region/gnome-region-panel-system.c:400
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings. You may change the system settings to match "
-"yours."
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:27
-msgid "Times"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:28
-msgid "Use the same layout for all windows"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:29
-msgid "View and edit keyboard layout options"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:30
-#, fuzzy
-msgid "Your settings"
-msgstr "Mîhengên X bikar bîne"
-
-#: ../panels/region/gnome-region-panel.ui.h:31
-#, fuzzy
-msgid "_Options..."
-msgstr "Vebijêrk"
-
-#: ../panels/region/gnome-region-panel-system.c:395
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings."
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-system.c:403
-#, fuzzy
-msgid "Copy Settings"
-msgstr "Mîheng"
-
-#: ../panels/region/gnome-region-panel-xkblt.c:210
-msgid "Layout"
-msgstr "Bicihkirin"
-
-#: ../panels/region/gnome-region-panel-xkbot.c:229
-#: ../panels/sound/gvc-sound-theme-chooser.c:586
-msgid "Default"
-msgstr "Wekî heyî"
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
-#, fuzzy
-msgid "Change your region and language settings"
-msgstr "Taybetmendiyên Rûerd yên Sermasê Biguherîne"
-
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
-msgid "Language;Layout;Keyboard;"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-#, fuzzy
-msgid "A_cceleration:"
-msgstr "_Lezkirin:"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Disable _touchpad while typing"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-#, fuzzy
-msgid "Double-Click Timeout"
-msgstr "<b>Navbera Demê ya Tikandina Cot</b>"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-#, fuzzy
-msgid "Drag and Drop"
-msgstr "<b>Xwêr Bikşîne Berde</b>"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Enable _mouse clicks with touchpad"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Enable h_orizontal scrolling"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "General"
-msgstr "Giştî"
-
-#. high sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
 msgid "High"
 msgstr ""
 
-#. large threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Large"
-msgstr "Mezin"
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "xulek"
 
-#. low sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Navîn"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "xulek"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
 msgid "Low"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "xulek"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Nîşanker"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Zimanî hilbijêre"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Hilbijartin"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Bêdeng"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "-Dembûrî:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+#, fuzzy
+msgid "Date & Time"
+msgstr "Roj û dem"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "meh"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "çile"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "sibat"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "adar"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "nîsan"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "gulan"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "hezîran"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "tîrmeh"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "tebax"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "îlon"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "cotmeh"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "mijdar"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "kanûn"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "roj"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#, fuzzy
+msgid "Time Zone"
+msgstr "-Dembûrî:"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "Kurteriya lêgerînan."
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Roj û dem"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "_Belgekirin"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Neçalak"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+#, fuzzy
+msgid "Time _Format"
+msgstr "asayî"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Roj"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "çirke"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Sal_name"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "kanûn"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Demjimêr;Herêma demê;Cih;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Taybetmendiyên Rûerd yên Sermasê Biguherîne"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Posta"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "Sal_name"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "Mûzîk"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Sepanên standard"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Sepanên standard"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Curetîp _bisepîne"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Dîmender"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Dîmender"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<b>Bicihbûna Mişk</b>"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Xuyakirin:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Leze _Tezekirinan:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Rêjekirî"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Kar nehate temamkirin"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Fîltre"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Ji:"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "xulek"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "Ji kê re dişîne:"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Dîmender"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Mifteya ewlehiyê"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+#, fuzzy
+msgid "No Events"
+msgstr "Buyêr"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Ewlehî"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Navê alavê"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Navnîşan"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Bîr"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafîk"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+#, fuzzy
+msgid "Calculating…"
+msgstr "Girêdide..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Nav:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Cure"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Termînala GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Pencere"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Rojanekirinan saz bike"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Alav"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Navê alavê"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "N_avê Bikarhêner:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Der barê"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Deng û medya"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Deng bibire"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Deng kêm bike"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Deng zêde bike"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+#, fuzzy
+msgid "Launch media player"
+msgstr "Jimêreyê bide xebitandin"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Lê bide (an jî lê bide/rawestîne)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+#, fuzzy
+msgid "Pause playback"
+msgstr "Dîsa lêdana deng:"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Rawestandina lêdanê"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Vegere parçeyê berê"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Here parçeyê din"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Bavêje"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "Bêhnvedana Nivîsînê"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Geroka webê veke"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Gerokê alîkariyê veke"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Mîheng"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Jimêreyê bide xebitandin"
+
+#: panels/keyboard/01-launchers.xml.in:10
+#, fuzzy
+msgid "Launch email client"
+msgstr "Jimêreyê bide xebitandin"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Geroka webê veke"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Peldanka mal"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Lê bigere"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Pergal"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Derkeve"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Ekranê qifil bike"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Gihîştin"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "Mezinkirin"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Derkeve"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+#, fuzzy
+msgid "Turn screen reader on or off"
+msgstr "_Xwînerê dîmenderê"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "Klavyeya _dîmenderê"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "Vebijêrk"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Vebijêrk"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Rengê klavyeyê"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Rakirin"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Bişkokên Mişk"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Kurteriyên Klavyeyê"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Kurterê"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Beş"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Kurterê"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Kurterê"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Kurterê"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Kurterê"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Kurteriyên Klavyeyê"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Rakirin"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Nav:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "_Ferman:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Kurterê"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Kurterê"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_Tune"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Vegere S_tandardan"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klavye"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Agahiyên xwe yên şexsî mîheng bike"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Mîhengên X bikar bîne"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Giştî"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "Bişkokên Hişyariyê"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "rastê"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Vebijêrk"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mişk"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
-msgid "Mouse Preferences"
-msgstr "Vebijêrkên mikşê"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+#: panels/mouse/cc-mouse-panel.ui:90
 #, fuzzy
-msgid "Pointer Speed"
+msgid "Mouse Speed"
 msgstr "Dirbê nîşanekê"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:21
-msgid "Scrolling"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:22
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr ""
-
-#. small threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:27
-#: ../panels/universal-access/uap.ui.h:57
-msgid "Small"
-msgstr "Biçûk"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:28
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
 #, fuzzy
-msgid "Thr_eshold:"
-msgstr "_Dergeh:"
+msgid "Scroll Direction"
+msgstr "_Sivik"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:29
-msgid "To test your settings, try to double-click on the face."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:30
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Lezkirin:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:31
-msgid "Two-_finger scrolling"
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:32
-msgid "_Disabled"
-msgstr "_Neçalak"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:33
-msgid "_Edge scrolling"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:34
+#: panels/mouse/cc-mouse-panel.ui:294
 #, fuzzy
-msgid "_Left-handed"
-msgstr "_Mişkê destê çepê"
+msgid "Click Method"
+msgstr "Meta"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:35
-msgid "_Right-handed"
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:36
-msgid "_Sensitivity:"
-msgstr "_Hestyarî:"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:37
-msgid "_Timeout:"
-msgstr "-Dembûrî:"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse and Touchpad"
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
 #, fuzzy
-msgid "Set your mouse and touchpad preferences"
-msgstr "Tercîhên mişk bike"
+msgid "Disable While Typing"
+msgstr "Neçalak"
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Lezkirin:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
 msgstr ""
 
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/cc-network-panel.c:269
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "_Sivik"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+"Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/cc-network-panel.c:277
-msgid "This is not recommended for untrusted public networks."
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 
-#. TRANSLATORS: this is when the access point is not listed
-#. * in the dropdown (or hidden) and the user has to select
-#. * another entry manually
-#: ../panels/network/cc-network-panel.c:949
-msgctxt "Wireless access point"
-msgid "Other..."
-msgstr "Yekê din..."
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/cc-network-panel.c:1107
-#: ../panels/network/cc-network-panel.c:1514
-msgid "WEP"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
 msgstr ""
 
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:1111
-#: ../panels/network/cc-network-panel.c:1518
-msgid "WPA"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
 msgstr ""
 
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:1115
-msgid "WPA2"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
 msgstr ""
 
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/cc-network-panel.c:1120
-msgid "Enterprise"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
 msgstr ""
 
-#. TRANSLATORS: this no (!) WiFi security
-#: ../panels/network/cc-network-panel.c:1126
-#: ../panels/network/cc-network-panel.c:1509
-#: ../panels/universal-access/uap.ui.h:43
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/multitasking/cc-multitasking-panel.ui:70
 #, fuzzy
-msgid "None"
-msgstr "_Tune"
+msgid "Workspaces"
+msgstr "Nîşanker"
 
-#: ../panels/network/cc-network-panel.c:1577
-msgid "Hotspot"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
 msgstr ""
 
-#. Translators: network device speed
-#: ../panels/network/cc-network-panel.c:1643
-#: ../panels/network/cc-network-panel.c:1731
-#, c-format
-msgid "%d Mb/s"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
 msgstr ""
 
-#: ../panels/network/cc-network-panel.c:1986 ../panels/network/network.ui.h:12
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
 #, fuzzy
-msgid "IPv4 Address"
-msgstr "Navnîşan"
+msgid "Multi-Monitor"
+msgstr "Dîmender"
 
-#: ../panels/network/cc-network-panel.c:1987 ../panels/network/network.ui.h:13
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
 #, fuzzy
-msgid "IPv6 Address"
-msgstr "Navnîşan"
+msgid "Application Switching"
+msgstr "Curetîpa _Sepanê:"
 
-#: ../panels/network/cc-network-panel.c:2040
-#: ../panels/network/cc-network-panel.c:2413
-#, c-format
-msgid "%s VPN"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
 msgstr ""
 
-#: ../panels/network/cc-network-panel.c:2148
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 #, fuzzy
-msgid "Proxy"
-msgstr "Cîgirê _FTPê:"
+msgid "Other Devices"
+msgstr "Alav"
 
-#: ../panels/network/cc-network-panel.c:2222
-#, fuzzy
-msgid "Network proxy"
-msgstr "Cîgirê Toreyê"
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:2480
-msgid "The system network services are not compatible with this version."
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3095
-#, fuzzy
-msgid "Not connected to the internet."
-msgstr "Nehate girêdan"
-
-#: ../panels/network/cc-network-panel.c:3096
-msgid "Create the hotspot anyway?"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3114
-#, c-format
-msgid "Disconnect from %s and create a new hotspot?"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3117
-msgid "This is your only connection to the internet."
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3135
-msgid "Create _Hotspot"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3195
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3198
-msgid "_Stop Hotspot"
-msgstr ""
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#, fuzzy
-msgid "Network"
-msgstr "Cîgirê Toreyê"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-#, fuzzy
-msgid "Network settings"
-msgstr "Mîhengên X bikar bîne"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid "Network;Wireless;IP;LAN;"
-msgstr ""
-
-#: ../panels/network/network.ui.h:1
-msgid "Air_plane Mode"
-msgstr ""
-
-#: ../panels/network/network.ui.h:2
-#, fuzzy
-msgid "Create..."
-msgstr "Nav biguherîne..."
-
-#: ../panels/network/network.ui.h:3
-msgid "DNS"
-msgstr ""
-
-#: ../panels/network/network.ui.h:4
-#, fuzzy
-msgid "Default Route"
-msgstr "Nîşankerê bi Pêşdanasîn"
-
-#: ../panels/network/network.ui.h:5
-msgid "Gateway"
-msgstr ""
-
-#: ../panels/network/network.ui.h:6
-msgid "Group Name"
-msgstr "Navê komê"
-
-#: ../panels/network/network.ui.h:7
-msgid "Group Password"
-msgstr "Şî_freya komê"
-
-#: ../panels/network/network.ui.h:8
-#, fuzzy
-msgid "H_TTPS Proxy"
-msgstr "Cîgirê H_TTPê"
-
-#: ../panels/network/network.ui.h:9
-#, fuzzy
-msgid "Hardware Address"
-msgstr "Navnîşan"
-
-#: ../panels/network/network.ui.h:10
-msgid "IMEI"
-msgstr ""
-
-#: ../panels/network/network.ui.h:14
-#, fuzzy
-msgid "Interface"
-msgstr "Înternet"
-
-#: ../panels/network/network.ui.h:15
-#, fuzzy
-msgid "Network Name"
-msgstr "Cîgirê Toreyê"
-
-#: ../panels/network/network.ui.h:16
-msgid "Provider"
-msgstr ""
-
-#: ../panels/network/network.ui.h:17
-msgid "Security"
-msgstr "Ewlehî"
-
-#: ../panels/network/network.ui.h:18
-msgid "Security Key"
-msgstr "Mifteya ewlehiyê"
-
-#: ../panels/network/network.ui.h:19
-msgid "Select the interface to use for the new service"
-msgstr ""
-
-#: ../panels/network/network.ui.h:20
-#, fuzzy
-msgid "Speed"
-msgstr "_Lez:"
-
-#: ../panels/network/network.ui.h:21
-msgid "Subnet Mask"
-msgstr ""
-
-#: ../panels/network/network.ui.h:22
-msgid "Unlock"
-msgstr ""
-
-#: ../panels/network/network.ui.h:23
-#, fuzzy
-msgid "Username"
-msgstr "N_avê Bikarhêner:"
-
-#: ../panels/network/network.ui.h:24
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr ""
 
-#: ../panels/network/network.ui.h:25
+#: panels/network/cc-network-panel.ui:42
 #, fuzzy
-msgid "VPN Type"
-msgstr "Cure"
-
-#: ../panels/network/network.ui.h:26
-#, fuzzy
-msgid "_Configuration URL"
-msgstr "_URLya veavakirina bixweber:"
-
-#: ../panels/network/network.ui.h:27
-msgid "_Configure..."
-msgstr ""
-
-#: ../panels/network/network.ui.h:28
-#, fuzzy
-msgid "_FTP Proxy"
-msgstr "Cîgirê _FTPê:"
-
-#: ../panels/network/network.ui.h:29
-#, fuzzy
-msgid "_HTTP Proxy"
-msgstr "Cîgirê H_TTPê"
-
-#: ../panels/network/network.ui.h:30
-#, fuzzy
-msgid "_Method"
-msgstr "Meta"
-
-#: ../panels/network/network.ui.h:31
-#, fuzzy
-msgid "_Network Name"
-msgstr "Cîgirê Toreyê"
-
-#: ../panels/network/network.ui.h:32
-#, fuzzy
-msgid "_Socks Host"
-msgstr "Makîneya S_ocks:"
-
-#: ../panels/network/network.ui.h:33
-msgid "_Stop Hotspot..."
-msgstr ""
-
-#: ../panels/network/network.ui.h:34
-msgid "_Use as Hotspot..."
-msgstr ""
-
-#: ../panels/network/network.ui.h:35
-#, fuzzy
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "_Belgekirin"
-
-#: ../panels/network/network.ui.h:36
-msgctxt "proxy method"
-msgid "Manual"
-msgstr ""
-
-#: ../panels/network/network.ui.h:37
-#, fuzzy
-msgctxt "proxy method"
-msgid "None"
-msgstr "_Tune"
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:83
-msgid "Wired"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:87
-msgid "Wireless"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:94
-msgid "Mobile broadband"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:99
-msgid "Bluetooth"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:103
-msgid "Mesh"
-msgstr ""
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:162
-msgid "Ad-hoc"
-msgstr ""
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:166
-msgid "Infrastructure"
-msgstr ""
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:190 ../panels/network/panel-common.c:251
-msgid "Status unknown"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:194
-msgid "Unmanaged"
-msgstr ""
-
-#: ../panels/network/panel-common.c:199
-msgid "Firmware missing"
-msgstr ""
-
-#: ../panels/network/panel-common.c:202
-msgid "Cable unplugged"
-msgstr ""
-
-#: ../panels/network/panel-common.c:204
-msgid "Unavailable"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:208
-#, fuzzy
-msgid "Disconnected"
-msgstr "Nehate girêdan"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:215 ../panels/network/panel-common.c:257
-#, fuzzy
-msgid "Connecting"
+msgid "Add connection"
 msgstr "Girêdide..."
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
-#, fuzzy
-msgid "Authentication required"
-msgstr "Belgekirî!"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
+#: panels/network/cc-wifi-connection-row.ui:41
 #, fuzzy
 msgid "Connected"
 msgstr "Nehate girêdan"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:227
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 #, fuzzy
-msgid "Disconnecting"
-msgstr "Girêdide..."
+msgid "Options…"
+msgstr "Vebijêrk"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:231 ../panels/network/panel-common.c:269
-#, fuzzy
-msgid "Connection failed"
-msgstr "Sazkirin Ne Serketî ye"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:277
-msgid "Status unknown (missing)"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
 msgstr ""
 
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:273
-msgid "Not connected"
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Cîgirê Toreyê"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "Şî_fre"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Şî_freya komê"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Şîfreyê biguhêre"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Moda Lezandinê"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Cîgirê Toreyê"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+#, fuzzy
+msgid "802.1x _Security"
+msgstr "Ewlehî"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Nîşanek"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Ewlehî"
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Navnîşan"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Navnîşan"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Navnîşan"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Nîşankerê bi Pêşdanasîn"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Nav:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Navnîşan:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Navnîşan:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "Meta"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+#, fuzzy
+msgid "Automatic (DHCP)"
+msgstr "_Belgekirin"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+#, fuzzy
+msgid "Manual"
+msgstr "çile"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Neçalak"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_Navnîşan:"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+#, fuzzy
+msgid "Address"
+msgstr "_Navnîşan:"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "_Belgekirin"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+#, fuzzy
+msgid "Automatic DNS"
+msgstr "_Belgekirin"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+#, fuzzy
+msgid "Automatic Routes"
+msgstr "_Belgekirin"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "Meta"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+#, fuzzy
+msgid "Automatic, DHCP only"
+msgstr "_Belgekirin"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+#, fuzzy
+msgid "S_ecurity"
+msgstr "Ewlehî"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Cîgirê Toreyê"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to the Internet"
 msgstr "Nehate girêdan"
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Power management settings"
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
 msgstr ""
 
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
 msgstr ""
 
-#: ../panels/power/cc-power-panel.c:160
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
 #, fuzzy
-msgid "Unknown time"
-msgstr "Nîşankereke Nenas"
+msgid "Active"
+msgstr "_Çalak bike"
 
-#: ../panels/power/cc-power-panel.c:166
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Navnîşana IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Cîgirê Toreyê"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "Cîgirê H_TTPê"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "Cîgirê H_TTPê"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "Cîgirê _FTPê:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Makîneya S_ocks:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "<b>Guh Nede Lîsteya Makîneyan</b>"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "Cîgirê H_TTPê"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "Cîgirê H_TTPê"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "Cîgirê _FTPê:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "_URLya veavakirina bixweber:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Cîgirê Toreyê"
+
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Mifteya ewlehiyê"
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Şî_fre"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Vebijêrk"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "_Belgekirin"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "Hemû Pel"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Pelgekirinê bikar bîne</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "N_avê Bikarhêner:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "Şî_fre"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "Şîfreya _Nû:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Guhertoya %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Guhertoya %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_Belgekirin"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Belgekirî!"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "Şîfreya _Nû:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_Belgekirin"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "_Cure:"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Wekî heyî"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Pergal"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Girdok"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Dosiyê _Dengê"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Ekranê qifil bike"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Ekranê qifil bike"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Pelgekirinê bikar bîne</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Hesabekê hilbijêre"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
 #, fuzzy, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "xulek"
 msgstr[1] "xulek"
 
-#: ../panels/power/cc-power-panel.c:178
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:186
-#, c-format
-msgid "%i %s %i %s"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:187
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/power/cc-power-panel.c:188
+#: panels/power/cc-battery-row.c:100
 #, fuzzy
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "xulek"
 msgstr[1] "xulek"
 
-#: ../panels/power/cc-power-panel.c:265
-msgid "Battery charging"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:268
-msgid "Battery discharging"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:279
-msgid "UPS charging"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:282
-msgid "UPS discharging"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:300
-#, c-format
-msgid "%s until charged (%.0lf%%)"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:306
-#, c-format
-msgid "%s until empty (%.0lf%%)"
-msgstr ""
-
-#. TRANSLATORS: %1 is a percentage value. Note: this string is only
-#. * used when we don't have a time value
-#: ../panels/power/cc-power-panel.c:314
-#, c-format
-msgid "%.0lf%% charged"
-msgstr ""
-
-#: ../panels/power/power.ui.h:1 ../panels/screen/screen.ui.h:1
-msgid "1 hour"
-msgstr ""
-
-#: ../panels/power/power.ui.h:2 ../panels/screen/screen.ui.h:3
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
 #, fuzzy
-msgid "10 minutes"
+msgctxt "automatic_suspend"
+msgid "15 minutes"
 msgstr "xulek"
 
-#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
 #, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "xulek"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "xulek"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "xulek"
 
-#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
 #, fuzzy
-msgid "5 minutes"
+msgctxt "automatic_suspend"
+msgid "45 minutes"
 msgstr "xulek"
 
-#: ../panels/power/power.ui.h:5
-msgid "Don't suspend"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
 msgstr ""
 
-#: ../panels/power/power.ui.h:6
-msgid "Hibernate"
-msgstr ""
-
-#: ../panels/power/power.ui.h:7
-msgid "On battery power"
-msgstr ""
-
-#: ../panels/power/power.ui.h:8
-msgid "Power off"
-msgstr ""
-
-#: ../panels/power/power.ui.h:9
-msgid "Suspend when inactive for:"
-msgstr ""
-
-#: ../panels/power/power.ui.h:10
-msgid "When plugged in"
-msgstr ""
-
-#: ../panels/power/power.ui.h:11
-msgid "When power is _critically low:"
-msgstr ""
-
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
-#: ../panels/color/color.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
 #, fuzzy
-msgid "Color"
-msgstr "Nîşanker"
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "xulek"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Color management settings"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "xulek"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "xulek"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
 msgstr ""
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
-msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
 msgstr ""
 
-#. TRANSLATORS: this is where the user can click and import a profile
-#: ../panels/color/cc-color-panel.c:106
-msgid "Other profile…"
-msgstr "Profîla din..."
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:119
-#, fuzzy
-msgid "Default: "
-msgstr "Wekî heyî"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:126
-#, fuzzy
-msgid "Colorspace: "
-msgstr "Nîşanker"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:132
-msgid "Test profile: "
-msgstr ""
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:185 ../panels/color/color.ui.h:19
-msgid "Set for all users"
-msgstr ""
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:192
-msgid "Create virtual device"
-msgstr ""
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:227
-#, fuzzy
-msgid "Select ICC Profile File"
-msgstr "Pelê Dengê Hilbijêre"
-
-#: ../panels/color/cc-color-panel.c:230
-msgid "_Import"
-msgstr "_Veguhezîne Hundir"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:241
-msgid "Supported ICC profiles"
-msgstr ""
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:248
-#, fuzzy
-msgid "All files"
-msgstr "Hemû Pel"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:504
-#, fuzzy
-msgid "Available Profiles for Displays"
-msgstr "Pelên _heyî:"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:508
-#, fuzzy
-msgid "Available Profiles for Scanners"
-msgstr "Pelên _heyî:"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:512
-#, fuzzy
-msgid "Available Profiles for Printers"
-msgstr "Pelên _heyî:"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:516
-#, fuzzy
-msgid "Available Profiles for Cameras"
-msgstr "Pelên _heyî:"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:520
-#, fuzzy
-msgid "Available Profiles for Webcams"
-msgstr "Pelên _heyî:"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#. * where the device type is not recognised
-#. Profiles that can be added to the device
-#: ../panels/color/cc-color-panel.c:525 ../panels/color/color.ui.h:5
-#, fuzzy
-msgid "Available Profiles"
-msgstr "Pelên _heyî:"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:795
-#: ../panels/sound/gvc-mixer-dialog.c:1515
-#, fuzzy
-msgid "Device"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
 msgstr "Alav"
 
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:830
-msgid "Calibration"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Moda Lezandinê"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
 msgstr ""
 
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:862
-msgid "Create a color profile for the selected device"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Vebijêrk"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Mîhengên bixweber"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
 msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:876 ../panels/color/cc-color-panel.c:900
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Dîmen"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Dîmen"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "_Belgekirin"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Bişkokên Hişyariyê"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+#, fuzzy
+msgid "Automatic Suspend"
+msgstr "_Belgekirin"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Derengmayîn:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:909
-msgid "The measuring instrument does not support printer profiling."
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Çaper"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:920
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 #, fuzzy
-msgid "The device type is not currently supported."
-msgstr "Ev dirb ne di celebekî tê destekkirin de ye."
+msgid "Add Printer"
+msgstr "Nîşankerê Mezin"
 
-#. TRANSLATORS: this is when an auto-added profile cannot be removed
-#: ../panels/color/cc-color-panel.c:993
-msgid "Cannot remove automatically added profile"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
 msgstr ""
 
-#. TRANSLATORS: this is when there is no profile for the device
-#: ../panels/color/cc-color-panel.c:1327
-msgid "No profile"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Çaper"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
 msgstr ""
 
-#: ../panels/color/cc-color-panel.c:1358
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Belgekirî!"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "N_avê Bikarhêner:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Cih"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Ajoger"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "Wêne Hilbijêre"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Hilbijartin"
+
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
-msgid "%i year"
-msgid_plural "%i years"
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/color/cc-color-panel.c:1369
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_Belgekirin"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Belgekirin"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Ceribandin"
+
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
-msgid "%i month"
-msgid_plural "%i months"
+msgid "%u Job"
+msgid_plural "%u Jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/color/cc-color-panel.c:1380
-#, c-format
-msgid "%i week"
-msgid_plural "%i weeks"
-msgstr[0] ""
-msgstr[1] ""
-
-#. fallback
-#: ../panels/color/cc-color-panel.c:1387
-#, c-format
-msgid "Less than 1 week"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1447
+#: panels/printers/printer-entry.ui:18
 #, fuzzy
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Wekî heyî"
+msgid "Printing Options"
+msgstr "Vebijêrk"
 
-#: ../panels/color/cc-color-panel.c:1452
+#: panels/printers/printer-entry.ui:29
 #, fuzzy
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Wekî heyî"
+msgid "Printer Details"
+msgstr "Vebijêrk"
 
-#: ../panels/color/cc-color-panel.c:1457
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
 #, fuzzy
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Wekî heyî"
+msgid "Use Printer by Default"
+msgstr "Vegere S_tandardan"
 
-#: ../panels/color/cc-color-panel.c:1572 ../panels/color/cc-color-panel.c:1604
-#: ../panels/color/cc-color-panel.c:1615 ../panels/color/cc-color-panel.c:1626
-msgid "Uncalibrated"
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
 msgstr ""
 
-#: ../panels/color/cc-color-panel.c:1575
-msgid "This device is not color managed."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1607
-msgid "This device is using manufacturing calibrated data."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1618
-msgid ""
-"This device does not have a profile suitable for whole-screen color "
-"correction."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1651
-msgid "This device has an old profile that may no longer be accurate."
-msgstr ""
-
-#. TRANSLATORS: this is when the calibration profile age is not
-#. * specified as it has been autogenerated from the hardware
-#: ../panels/color/cc-color-panel.c:1679
+#: panels/printers/printer-entry.ui:62
 #, fuzzy
-msgid "Not specified"
-msgstr "Nehate girêdan"
-
-#. add the 'No devices detected' entry
-#: ../panels/color/cc-color-panel.c:1864
-msgid "No devices supporting color management detected"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:2093
-msgctxt "Device kind"
-msgid "Display"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:2095
-msgctxt "Device kind"
-msgid "Scanner"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:2097
-#, fuzzy
-msgctxt "Device kind"
-msgid "Printer"
+msgid "Remove Printer"
 msgstr "Nîşanek"
 
-#: ../panels/color/cc-color-panel.c:2099
-msgctxt "Device kind"
-msgid "Camera"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:2101
-msgctxt "Device kind"
-msgid "Webcam"
-msgstr ""
-
-#: ../panels/color/color.ui.h:1
-msgid "Add a virtual device"
-msgstr ""
-
-#: ../panels/color/color.ui.h:2
-msgid "Add device"
-msgstr ""
-
-#: ../panels/color/color.ui.h:3
-msgid "Add profile"
-msgstr ""
-
-#: ../panels/color/color.ui.h:6
-msgid "Calibrate the device"
-msgstr ""
-
-#: ../panels/color/color.ui.h:7
-msgid "Calibrate…"
-msgstr ""
-
-#: ../panels/color/color.ui.h:9
+#: panels/printers/printer-entry.ui:167
 #, fuzzy
-msgid "Delete device"
-msgstr "Jê bibe"
+msgid "No Active Jobs"
+msgstr "Çalakî"
 
-#: ../panels/color/color.ui.h:10
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 #, fuzzy
-msgid "Device type:"
-msgstr "Alav"
+msgid "Model"
+msgstr "Model"
 
-#: ../panels/color/color.ui.h:11
-msgid "Each device needs an up to date color profile to be color managed."
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
 msgstr ""
 
-#: ../panels/color/color.ui.h:12
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "Destpêk"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Nîşankerê Mezin"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Taybetmendiyên Rûerd yên Sermasê Biguherîne"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Çaper"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
 msgid ""
-"Image files can be dragged on this window to auto-complete the above fields."
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
 msgstr ""
 
-#: ../panels/color/color.ui.h:13
-msgid "Learn more"
-msgstr ""
-
-#: ../panels/color/color.ui.h:14
-msgid "Learn more about color management"
-msgstr ""
-
-#: ../panels/color/color.ui.h:15
-msgid "Manufacturer:"
-msgstr ""
-
-#: ../panels/color/color.ui.h:16
+#: panels/region/cc-format-chooser.ui:4
 #, fuzzy
-msgid "Model:"
-msgstr "_Model:"
+msgid "Formats"
+msgstr "asayî"
 
-#: ../panels/color/color.ui.h:17
-msgid "Remove a device"
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
 msgstr ""
 
-#: ../panels/color/color.ui.h:18
-msgid "Remove profile"
-msgstr ""
-
-#: ../panels/color/color.ui.h:20
-msgid "Set this device for all users on this computer"
-msgstr ""
-
-#: ../panels/color/color.ui.h:21
+#: panels/region/cc-format-chooser.ui:116
 #, fuzzy
-msgid "View details"
-msgstr "Kîtekîtên Dirban"
+msgid "Common Formats"
+msgstr "Pewirên Asayî"
 
-#. Translators: those are keywords for the brightness and lock control-center panel
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
-msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "asayî"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
 msgstr ""
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Pêşdîtin:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Roj"
+
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Roj û dem"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Pîvan"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "Derketin"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Dirban _Saz Bike..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Hesaba min"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "asayî"
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Ekranê qifil bike"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+#, fuzzy
+msgid "Region & Language"
+msgstr "Ziman"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+#, fuzzy
+msgid "_Software"
+msgstr "Nerm"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+#, fuzzy
+msgid "_Other Media…"
+msgstr "Profîla din..."
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Çalakî"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Cure:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Taybetmendiyên Rûerd yên Sermasê Biguherîne"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Dîmen"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Ekranê qifil bike"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Dîmen"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
 msgid "Screen"
 msgstr "Dîmen"
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
-msgid "Screen brightness and lock settings"
-msgstr ""
-
-#: ../panels/screen/screen.ui.h:2
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
 #, fuzzy
-msgid "1 minute"
-msgstr "xulek"
+msgid "Screen Settings"
+msgstr "%d Mîhengên Dîmender\n"
 
-#: ../panels/screen/screen.ui.h:4
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 #, fuzzy
-msgid "2 minutes"
-msgstr "xulek"
+msgid "Search Locations"
+msgstr "Cih"
 
-#: ../panels/screen/screen.ui.h:5
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
 #, fuzzy
-msgid "3 minutes"
-msgstr "xulek"
+msgid "Others"
+msgstr "Yên din..."
 
-#: ../panels/screen/screen.ui.h:7
+#: panels/search/cc-search-locations-dialog.ui:59
 #, fuzzy
-msgid "30 seconds"
-msgstr "çirke"
+msgid "Add Location"
+msgstr "Cih"
 
-#: ../panels/screen/screen.ui.h:9
+#: panels/search/cc-search-panel.ui:10
 #, fuzzy
-msgid "Brightness"
-msgstr "Biriqandinê zêde bike"
+msgid "Application Search"
+msgstr "<b>Bername</b>"
 
-#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
-#: ../panels/screen/screen.ui.h:11
-msgid "Don't lock when at home"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:12
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
 #, fuzzy
-msgid "Locations..."
-msgstr "_Cih:"
+msgid "Search Results"
+msgstr "Kurteriya lêgerînan."
 
-#: ../panels/screen/screen.ui.h:13
-msgid "Lock"
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:14
-msgid "Screen turns off"
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:15
-msgid "_Dim screen to save power"
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:16
+#: panels/sharing/cc-sharing-networks.ui:15
 #, fuzzy
-msgid "_Lock screen after:"
-msgstr "Ekranê qifil bike"
+msgid "Networks"
+msgstr "Cîgirê Toreyê"
 
-#: ../panels/screen/screen.ui.h:17
-msgid "_Turn screen off when inactive for:"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
 msgstr ""
 
-#: ../panels/sound/applet-main.c:49
-msgid "Enable debugging code"
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
 msgstr ""
 
-#: ../panels/sound/applet-main.c:50
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
 #, fuzzy
-msgid "Version of this application"
-msgstr "Curetîpa sepanê ya pêşdanasînî hilbijêre"
+msgid "Remote _Desktop"
+msgstr "Sermasê"
 
-#: ../panels/sound/applet-main.c:62
-msgid " — GNOME Volume Control Applet"
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
 msgstr ""
 
-#: ../panels/sound/gvc-applet.c:270 ../panels/sound/gvc-mixer-dialog.c:1767
-msgid "Output"
-msgstr ""
-
-#: ../panels/sound/gvc-applet.c:272
-msgid "Sound Output Volume"
-msgstr ""
-
-#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1807
-msgid "Input"
-msgstr ""
-
-#: ../panels/sound/gvc-applet.c:278
-msgid "Microphone Volume"
-msgstr ""
-
-#: ../panels/sound/gvc-balance-bar.c:111
-msgctxt "balance"
-msgid "Left"
-msgstr ""
-
-#: ../panels/sound/gvc-balance-bar.c:112
+#: panels/sharing/cc-sharing-panel.ui:79
 #, fuzzy
-msgctxt "balance"
-msgid "Right"
-msgstr "rastê"
+msgid "_Remote Login"
+msgstr "_Rakirin"
 
-#: ../panels/sound/gvc-balance-bar.c:115
-msgctxt "balance"
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "Şî_fre"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Sermasê"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Deng kêm bike"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Nehate girêdan"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Ji ber bigire"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Belgekirin"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Nave bikarhêner:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "Fransa"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:116
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:119
-msgctxt "balance"
-msgid "Minimum"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:120
+#: panels/sound/cc-sound-panel.ui:8
 #, fuzzy
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Mêzîn bîkê"
+msgid "System Volume"
+msgstr "Dengên Pergalê"
 
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Balance:"
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:298
-msgid "_Fade:"
-msgstr ""
-
-#: ../panels/sound/gvc-balance-bar.c:301
-msgid "_Subwoofer:"
-msgstr ""
-
-#: ../panels/sound/gvc-channel-bar.c:603 ../panels/sound/gvc-channel-bar.c:612
-msgctxt "volume"
-msgid "100%"
-msgstr ""
-
-#: ../panels/sound/gvc-channel-bar.c:607
-msgctxt "volume"
-msgid "Unamplified"
-msgstr ""
-
-#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:1621
+#: panels/sound/cc-sound-panel.ui:28
 #, fuzzy
-msgid "_Profile:"
-msgstr "_Mobîl:"
+msgid "Volume Levels"
+msgstr "Deng bibire"
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1093
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Alav"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Ceribandin"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "_URLya veavakirina bixweber:"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Alav"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Deng"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Deng"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Deng"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Deng çalak bike û deng û çalakiyan bi hev re têkildar bike"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, fuzzy, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Jê bibe"
+msgstr[1] "Jê bibe"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "_Girdok"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Nav:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Alav"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Alav"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>Nîşankerê vêxistin/vemirandê</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Nîşan_kerê vêxistin/vemirandê di qutiyên nivîsan û qadan de"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Lez:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Nîşanek"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Mezinahiya Nîşankerê:"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kurterê"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Derengmayîn:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kurterê"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Dergeh:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Biçûk"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Mezin"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Bişkokên Dubarekirinê</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Dema bişkoj _pêlêkirî be bila klavye dubare bike"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Leza dubarekirina bişkokan"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Leza dubarekirina bişkokan"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "_Alîkar:"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Hişyariya Bişkokên Mezeloqî"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Heke _bi hev re pêl bişkokan were kirin bandora wê rake"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Di dema pêlkirina guhestinan de bi deng hişyarî bide"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Hişyariya Hêdîkirina Bişkokan"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kurterê"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Di dema pêlkirina guhestinan de bi deng hişyarî bide"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Dema bişkok nehate _qebûlkirin bike tûtût"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Dema bişkok nehate _qebûlkirin bike tûtût"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Bişkokên Mişk"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "dubare pêlkirina mifteyan piştguh bike dema:"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kurterê"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "_Taybetmendiyên gihîştina klavyeyê çalak bike"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Gihîştin"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "Tekilî"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Mezin"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "_Xwînerê dîmenderê"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "_Deng:"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Mezinahiya Nîşankerê:"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Mezinkirin"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Klavyeya _dîmenderê"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Bişkokên Dubarekirinê</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Nîşankerê vêxistin/vemirandê</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
+msgstr "_Alîkar:"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Bişkokên Mişk"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "<b>Nîşanekê bi cih bike</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "<b>Navbera Demê ya Tikandina Cot</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<b>Navbera Demê ya Tikandina Cot</b>"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Hemû dîmenderê bike _flaş"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Hemû dîmenderê bike _flaş"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Dîmenderê Tije Bike"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Vebijêrk"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_Girdok"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "_Girdok"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "_Xwînerê dîmenderê"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "_Girdok"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "Tercîhên Deng"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Biriqandinê zêde bike"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Tekilî"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Tune"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Tam"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "Tercîhên Deng"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "Pelan _jê bibe"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "Biavêje Çopê"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "Ra_newestîne"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Şîfreya _Nû:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Zimanî hilbijêre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Menajerê Paceyan"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Vegere parçeyê berê"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Şîfreyê Biguherîne"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Tîma guherandinê"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Şîfreya _heyî:"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Şîfreya _Nû:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Şîfreyê biguhêre"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Şîfre pir kurte."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "Şîfreya _Nû:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Users"
+msgstr "N_avê Bikarhêner:"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Nav û Paşnav"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_Sererast bike"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "Cureyê Hişyariyê"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Kontrolkirin"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Curetîpa sepanê ya pêşdanasînî hilbijêre"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Kaxiza dîwar rake"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Tiliya _din:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Bêdeng"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+#, fuzzy
+msgid "Administrator Password"
+msgstr "Şî_freya komê"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+#, fuzzy
+msgid "Manage user accounts"
+msgstr "Hesabên bikarhêner"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+#, fuzzy
+msgid "Authentication is required to change user data"
+msgstr "Belgekirî!"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Bişkok"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Ji bo guherandina bişkokên kurteriyan, pêl rêzika guncav bike û pêl bişkokên "
+"kurteriya nû bike, yan jî bi backspace kurteriya heyî jê bibe."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Dîmender"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Nerm"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Bişkok"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Bişkok"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Bişkok"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Bicihkirin"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Pencere"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Pencere"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Ji bo bidawîkirinê Temam Bitikîne"
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Pencere"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "_Têxê..."
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Tomar bike"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Kîtekîtên Dirban"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Dema _torê"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Mîhengên X bikar bîne"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "_Kîtekîtên Dirban"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Dema _torê"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Cîgirê Toreyê"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Hûragahî"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Cîgirê Toreyê"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_Belgekirin"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Cîgirê Toreyê"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Bişkokên _Veke/Bigire Çalak Bike"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Girêdide..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Tîma guherandinê"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Cîgirê Toreyê"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "_Hemû mîheng"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Alîkarî"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Giştî"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Derkeve"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Lê bigere"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "_Betal"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Vebijêrk"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1103
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../panels/sound/gvc-mixer-control.c:1401
-msgid "System Sounds"
-msgstr "Dengên Pergalê"
+#~ msgid "Change the background"
+#~ msgstr "Rûerdî biguherîne"
 
-#: ../panels/sound/gvc-mixer-dialog.c:323
-#: ../panels/sound/gvc-mixer-dialog.c:634
-msgid "Co_nnector:"
-msgstr ""
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Kaxiza dîwar;Dîmender;Sermasê;"
 
-#: ../panels/sound/gvc-mixer-dialog.c:540
-msgid "Peak detect"
-msgstr ""
+#~ msgid "Add wallpaper"
+#~ msgstr "Kaxiza dîwar lê zêde bike"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1496
-#: ../panels/sound/gvc-mixer-dialog.c:1709
-#: ../panels/sound/gvc-sound-theme-chooser.c:596
+#~ msgid "Center"
+#~ msgstr "Navîn"
+
+#~ msgid "Fill"
+#~ msgstr "Tijîkirin"
+
 #, fuzzy
-msgid "Name"
-msgstr "Nav:"
+#~ msgid "Tile"
+#~ msgstr "Raxistî"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1563
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Derbasbûna Serpahnayê"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Gradyana Tîkane"
+
+#~ msgid "Solid Color"
+#~ msgstr "Rengê Tampon"
+
+#, fuzzy
+#~ msgid "Current background"
+#~ msgstr "Rûerdê Sermasê"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Rûerdê sermasê tunebe"
+
+#~ msgid "English"
+#~ msgstr "Îngilîzî"
+
+#~ msgid "British English"
+#~ msgstr "Îngilîziya Brîtanyayê"
+
+#~ msgid "German"
+#~ msgstr "Almanî"
+
+#~ msgid "French"
+#~ msgstr "Fransî"
+
+#~ msgid "Spanish"
+#~ msgstr "Spanî"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Çîniya hêsankirî"
+
+#~ msgid "United States"
+#~ msgstr "Dewletên Yekbuyî (yên Emerîqa)"
+
+#~ msgid "Germany"
+#~ msgstr "Almanya"
+
+#~ msgid "Spain"
+#~ msgstr "Spanya"
+
+#~ msgid "China"
+#~ msgstr "Çîn"
+
+#~ msgid "Select a region"
+#~ msgstr "Herêm hilbijêre"
+
+#~ msgid "Unspecified"
+#~ msgstr "Nediyar"
+
+#~ msgid "_City:"
+#~ msgstr "_Bajar:"
+
+#~ msgid "_Region:"
+#~ msgstr "_Herêm:"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Darikê vebijêrkên roj û demê"
+
+#~ msgid "R_otation:"
+#~ msgstr "Bi_nobedarî:"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Asayî"
+
+#, fuzzy
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Dirûvê navîn yê mak nehate barkirin"
+
+#, fuzzy
+#~ msgid "Could not get screen information"
+#~ msgstr "Xuyakirina dîmender biguherîne"
+
+#~ msgid "Unknown"
+#~ msgstr "Nenas"
+
+#, fuzzy
+#~ msgid "Unknown model"
+#~ msgstr "Nîşankereke Nenas"
+
+#, fuzzy
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Careke din bang bike"
+
+#, fuzzy
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "Termînala Xê ya Standart"
+
+#, fuzzy
+#~ msgid "Open folder"
+#~ msgstr "Peldanka mal"
+
+#, fuzzy
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Sepanên xwe yên pêşdanasînî hilbijêre"
+
+#, fuzzy
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Sepanên xwe yên pêşdanasînî hilbijêre"
+
+#, fuzzy
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Wekî Curenivîsa Bernameyê Mîheng Bike"
+
+#, fuzzy
+#~ msgid "Overview"
+#~ msgstr "Pêşdîtin:"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Pergal rojane ye"
+
+#~ msgid "Checking for Updates"
+#~ msgstr "Rojanekirin tê kontrolkirin"
+
+#~ msgid "System Info"
+#~ msgstr "Agahiyên pergalî"
+
+#~ msgid "Acti_on:"
+#~ msgstr "Çala_kî:"
+
+#~ msgid "Disk"
+#~ msgstr "Dîsk"
+
+#, fuzzy
+#~ msgid "Magnifier zoom out"
+#~ msgstr "_Girdok"
+
+#, fuzzy
+#~ msgid "Toggle contrast"
+#~ msgstr "_Tarîbûna herî baş"
+
+#, fuzzy
+#~ msgid "Toggle magnifier"
+#~ msgstr "_Girdok"
+
+#, fuzzy
+#~ msgid "New shortcut..."
+#~ msgstr "Kurteriya derxe."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Bişkoka Lezker"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Sererastkerên lezkeran"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Koda bişkokên lezkeran"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Cureyê Lezkeran"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Çalakiya nenas>"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Kurteriya \"%s\" ji bo vî karî tê bikaranîn:\n"
+#~ "\"%s\"\n"
+
+#, fuzzy
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Kurteriya deng zêde bike."
+
+#~ msgid "Action"
+#~ msgstr "Çalakî"
+
+#, fuzzy
+#~ msgid "Custom Shortcut"
+#~ msgstr "Kurterê"
+
+#, fuzzy
+#~ msgid "Layout Settings"
+#~ msgstr "Mîhengên Pêşdanasînî"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Lez:"
+
+#~ msgid "_Speed:"
+#~ msgstr "_Lez:"
+
+#~ msgid "_Add..."
+#~ msgstr "_Têxê..."
+
+#, fuzzy
+#~ msgid "Error creating account"
+#~ msgstr "Dema veavakirin dihate tomarkirin çewtî: %s"
+
+#, fuzzy
+#~ msgid "Error removing account"
+#~ msgstr "Dema veavakirin dihate tomarkirin çewtî: %s"
+
+#, fuzzy
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Tu dixwazî van xuyakirinan tomar bikî?"
+
+#, fuzzy
+#~ msgid "Open cover"
+#~ msgstr "Pelî Veke"
+
+#, fuzzy
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "Navber"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Amade"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Tê xebitandin"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Rawestandî"
+
+#, fuzzy
+#~ msgid "Supply Level"
+#~ msgstr "Dirb bi kar bîne"
+
+#, fuzzy, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "_Neçalak bike"
+#~ msgstr[1] "_Neçalak bike"
+
+#, fuzzy
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "_Pisporî:"
+
+#, fuzzy
+#~ msgid "Job Title"
+#~ msgstr "_Sernav:"
+
+#, fuzzy, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Dirûvê navîn yê mak nehate barkirin"
+
+#~ msgid "A_ddress:"
+#~ msgstr "_Navnîşan:"
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "Herêmî"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "Tor"
+
+#~ msgid "Jobs"
+#~ msgstr "Kar"
+
+#, fuzzy
+#~ msgid "_Default"
+#~ msgstr "Wekî heyî"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Nexşeya Bişkokan Hilbijêre"
+
+#, fuzzy
+#~ msgid "Keyboard Layout Options"
+#~ msgstr "Bijarekên klavye"
+
+#, fuzzy
+#~ msgid "Copy Settings..."
+#~ msgstr "Girêdide..."
+
+#~ msgid "Layouts"
+#~ msgstr "Pergal"
+
+#, fuzzy
+#~ msgid "System settings"
+#~ msgstr "Mîhengên X bikar bîne"
+
+#, fuzzy
+#~ msgid "_Options..."
+#~ msgstr "Vebijêrk"
+
+#, fuzzy
+#~ msgid "Drag and Drop"
+#~ msgstr "<b>Xwêr Bikşîne Berde</b>"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Vebijêrkên mikşê"
+
+#, fuzzy
+#~ msgid "Thr_eshold:"
+#~ msgstr "_Dergeh:"
+
+#~ msgid "_Disabled"
+#~ msgstr "_Neçalak"
+
+#, fuzzy
+#~ msgid "_Left-handed"
+#~ msgstr "_Mişkê destê çepê"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Hestyarî:"
+
+#~ msgid "_Timeout:"
+#~ msgstr "-Dembûrî:"
+
+#, fuzzy
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Tercîhên mişk bike"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "Yekê din..."
+
+#, fuzzy
+#~ msgid "Proxy"
+#~ msgstr "Cîgirê _FTPê:"
+
+#, fuzzy
+#~ msgid "Create..."
+#~ msgstr "Nav biguherîne..."
+
+#~ msgid "Group Name"
+#~ msgstr "Navê komê"
+
+#, fuzzy
+#~ msgid "Interface"
+#~ msgstr "Înternet"
+
+#, fuzzy
+#~ msgid "_Network Name"
+#~ msgstr "Cîgirê Toreyê"
+
+#, fuzzy
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "_Tune"
+
+#, fuzzy
+#~ msgid "Disconnected"
+#~ msgstr "Nehate girêdan"
+
+#, fuzzy
+#~ msgid "Connection failed"
+#~ msgstr "Sazkirin Ne Serketî ye"
+
+#, fuzzy
+#~ msgid "Unknown time"
+#~ msgstr "Nîşankereke Nenas"
+
+#, fuzzy
+#~ msgid "Default: "
+#~ msgstr "Wekî heyî"
+
+#, fuzzy
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Pelê Dengê Hilbijêre"
+
+#, fuzzy
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Pelên _heyî:"
+
+#, fuzzy
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Pelên _heyî:"
+
+#, fuzzy
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Pelên _heyî:"
+
+#, fuzzy
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Pelên _heyî:"
+
+#, fuzzy
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Pelên _heyî:"
+
+#, fuzzy
+#~ msgid "Available Profiles"
+#~ msgstr "Pelên _heyî:"
+
+#, fuzzy
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Ev dirb ne di celebekî tê destekkirin de ye."
+
+#, fuzzy
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Wekî heyî"
+
+#, fuzzy
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Wekî heyî"
+
+#, fuzzy
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Wekî heyî"
+
+#, fuzzy
+#~ msgid "Not specified"
+#~ msgstr "Nehate girêdan"
+
+#, fuzzy
+#~ msgid "Device type:"
+#~ msgstr "Alav"
+
+#, fuzzy
+#~ msgid "Model:"
+#~ msgstr "_Model:"
+
+#, fuzzy
+#~ msgid "1 minute"
+#~ msgstr "xulek"
+
+#, fuzzy
+#~ msgid "3 minutes"
+#~ msgstr "xulek"
+
+#, fuzzy
+#~ msgid "Locations..."
+#~ msgstr "_Cih:"
+
+#, fuzzy
+#~ msgid "Version of this application"
+#~ msgstr "Curetîpa sepanê ya pêşdanasînî hilbijêre"
+
+#, fuzzy
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Mêzîn bîkê"
+
+#, fuzzy, c-format
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "Tercîhên Rûerdê Sermaseyê"
+
+#, fuzzy
+#~ msgid "_Sound Preferences"
+#~ msgstr "Tercîhên Deng"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Tercîhên Deng"
+
+#, fuzzy
+#~ msgid "Testing event sound"
+#~ msgstr "Dengên Pergalê"
+
+#, fuzzy
+#~ msgid "From theme"
+#~ msgstr "Dirbê Taybet"
+
+#, fuzzy
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Nexşeya Bişkokan Hilbijêre"
+
+#~ msgid "Custom"
+#~ msgstr "Taybet"
+
+#, fuzzy
+#~ msgid "No shortcut set"
+#~ msgstr "Kurterê"
+
+#~ msgid "Key"
+#~ msgstr "Mifte"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Bişkoka Gconf ya sererastkerê vê taybetmendiyê girêdayî wê ye"
+
+#~ msgid "Callback"
+#~ msgstr "Careke din bang bike"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Vê bangkirinê dema nirxa ku bi mifteyê re têkildar e guherî bikar bîne"
+
+#~ msgid "Change set"
+#~ msgstr "Tîma guherandinê"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Daneyên ku dema koma guhertinê ya GConf li daxwazkarê gconf hate sepandin "
+#~ "dê bêne bervêvekirin dihundirîne."
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Lêvegera paşdevegerîna parçekan"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Paşdevegerîna ku dema dane ji GConf vegere parçekan dê bête sepandin"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Paşdevegerandina veguhartina parçekan"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Paşdevegerandina ku dema dane ji parçekan li GConfê veguherî dê bête "
+#~ "sepandin"
+
+#~ msgid "UI Control"
+#~ msgstr "Kontrola Dirûvê Navîn"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Bireserea ku vê taybetmendiyê kontrol dike (piranî tenê perçeyek)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Daneya bireserên sererastkerê taybetmendiyan"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Daneyên vebijêrkî yên ji bo pergalkerên taybetiyan ên belî"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Paşdevegerandina valakirina daneyan a pergalkerê taybetiyan"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Paşdevegerandin ku piştî daneya bireseran a pergalkerê taybetiyan hate "
+#~ "valakirin dê bête bikaranîn"
+
 #, c-format
-msgid "Speaker Testing for %s"
-msgstr ""
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Pelê '%s' nehate dîtin.\n"
+#~ "\n"
+#~ "Ji kerema xwe re bawer bî ku ka pel heye yan na û dîsa biceribîne yan jî "
+#~ "wêneyekî cuda yê rûerd bikar bîne."
 
-#: ../panels/sound/gvc-mixer-dialog.c:1622
-msgid "_Test Speakers"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1753
-msgid "_Output volume:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1772
-msgid "C_hoose a device for sound output:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-#: ../panels/sound/gvc-mixer-dialog.c:1925
-msgid "Settings for the selected device:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1814
-msgid "_Input volume:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1837
-msgid "Input level:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1865
-msgid "C_hoose a device for sound input:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1892
-msgid "Hardware"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1897
-msgid "C_hoose a device to configure:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1936
-#, fuzzy
-msgid "Sound Effects"
-msgstr "Tercîhên Deng"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1943
-msgid "_Alert volume:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1956
-#, fuzzy
-msgid "Applications"
-msgstr "<b>Bername</b>"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1960
-msgid "No application is currently playing or recording audio."
-msgstr ""
-
-#: ../panels/sound/gvc-speaker-test.c:221
-msgid "Stop"
-msgstr ""
-
-#: ../panels/sound/gvc-speaker-test.c:221
-#: ../panels/sound/gvc-speaker-test.c:333
-msgid "Test"
-msgstr "Ceribandin"
-
-#: ../panels/sound/gvc-speaker-test.c:229
-msgid "Subwoofer"
-msgstr ""
-
-#: ../panels/sound/gvc-stream-status-icon.c:235
-#, fuzzy, c-format
-msgid "Failed to start Sound Preferences: %s"
-msgstr "Tercîhên Rûerdê Sermaseyê"
-
-#: ../panels/sound/gvc-stream-status-icon.c:261
-msgid "_Mute"
-msgstr ""
-
-#: ../panels/sound/gvc-stream-status-icon.c:270
-#, fuzzy
-msgid "_Sound Preferences"
-msgstr "Tercîhên Deng"
-
-#: ../panels/sound/gvc-stream-status-icon.c:415
-msgid "Muted"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:190
-msgid "Built-in"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:456
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Sound Preferences"
-msgstr "Tercîhên Deng"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:459
-#: ../panels/sound/gvc-sound-theme-chooser.c:470
-#: ../panels/sound/gvc-sound-theme-chooser.c:482
-#, fuzzy
-msgid "Testing event sound"
-msgstr "Dengên Pergalê"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:587
-#, fuzzy
-msgid "From theme"
-msgstr "Dirbê Taybet"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:782
-#, fuzzy
-msgid "C_hoose an alert sound:"
-msgstr "Nexşeya Bişkokan Hilbijêre"
-
-#: ../panels/sound/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr "Taybet"
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
-msgid "Show desktop volume control"
-msgstr ""
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
-#, fuzzy
-msgid "Volume Control"
-msgstr "Deng kêm bike"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
-msgstr ""
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
-#, fuzzy
-msgid "Change sound volume and sound events"
-msgstr "Deng çalak bike û deng û çalakiyan bi hev re têkildar bike"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Sound"
-msgstr "Deng"
-
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr ""
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr ""
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr ""
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr ""
-
-#: ../panels/universal-access/cc-ua-panel.c:505
-#: ../panels/universal-access/cc-ua-panel.c:510
-#, fuzzy
-msgid "No shortcut set"
-msgstr "Kurterê"
-
-#: ../panels/universal-access/gconf-property-editor.c:134
-msgid "Key"
-msgstr "Mifte"
-
-#: ../panels/universal-access/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr "Bişkoka Gconf ya sererastkerê vê taybetmendiyê girêdayî wê ye"
-
-#: ../panels/universal-access/gconf-property-editor.c:141
-msgid "Callback"
-msgstr "Careke din bang bike"
-
-#: ../panels/universal-access/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Vê bangkirinê dema nirxa ku bi mifteyê re têkildar e guherî bikar bîne"
-
-#: ../panels/universal-access/gconf-property-editor.c:147
-msgid "Change set"
-msgstr "Tîma guherandinê"
-
-#: ../panels/universal-access/gconf-property-editor.c:148
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"Daneyên ku dema koma guhertinê ya GConf li daxwazkarê gconf hate sepandin dê "
-"bêne bervêvekirin dihundirîne."
-
-#: ../panels/universal-access/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr "Lêvegera paşdevegerîna parçekan"
-
-#: ../panels/universal-access/gconf-property-editor.c:154
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "Paşdevegerîna ku dema dane ji GConf vegere parçekan dê bête sepandin"
-
-#: ../panels/universal-access/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr "Paşdevegerandina veguhartina parçekan"
-
-#: ../panels/universal-access/gconf-property-editor.c:160
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"Paşdevegerandina ku dema dane ji parçekan li GConfê veguherî dê bête sepandin"
-
-#: ../panels/universal-access/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "Kontrola Dirûvê Navîn"
-
-#: ../panels/universal-access/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr "Bireserea ku vê taybetmendiyê kontrol dike (piranî tenê perçeyek)"
-
-#: ../panels/universal-access/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr "Daneya bireserên sererastkerê taybetmendiyan"
-
-#: ../panels/universal-access/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr "Daneyên vebijêrkî yên ji bo pergalkerên taybetiyan ên belî"
-
-#: ../panels/universal-access/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr "Paşdevegerandina valakirina daneyan a pergalkerê taybetiyan"
-
-#: ../panels/universal-access/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Paşdevegerandin ku piştî daneya bireseran a pergalkerê taybetiyan hate "
-"valakirin dê bête bikaranîn"
-
-#: ../panels/universal-access/gconf-property-editor.c:1474
 #, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Pelê '%s' nehate dîtin.\n"
-"\n"
-"Ji kerema xwe re bawer bî ku ka pel heye yan na û dîsa biceribîne yan jî "
-"wêneyekî cuda yê rûerd bikar bîne."
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Pelê '%s' venabe.\n"
+#~ "Dibe ku ev wêne hîna nehatiye destekirin.\n"
+#~ "\n"
+#~ "Ji kerema xwe re dêvila vêya wêneyekî din hilbijêre."
 
-#: ../panels/universal-access/gconf-property-editor.c:1482
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Pelê '%s' venabe.\n"
-"Dibe ku ev wêne hîna nehatiye destekirin.\n"
-"\n"
-"Ji kerema xwe re dêvila vêya wêneyekî din hilbijêre."
+#~ msgid "Please select an image."
+#~ msgstr "Ji kerema xwe re wêneyekî hilbijêre."
 
-#: ../panels/universal-access/gconf-property-editor.c:1604
-msgid "Please select an image."
-msgstr "Ji kerema xwe re wêneyekî hilbijêre."
-
-#: ../panels/universal-access/zoom-options.c:156
 #, fuzzy
-msgid "1/4 Screen"
-msgstr "Dîmen"
+#~ msgid "1/4 Screen"
+#~ msgstr "Dîmen"
 
-#: ../panels/universal-access/zoom-options.c:157
 #, fuzzy
-msgid "1/2 Screen"
-msgstr "Dîmen"
+#~ msgid "1/2 Screen"
+#~ msgstr "Dîmen"
 
-#: ../panels/universal-access/zoom-options.c:158
 #, fuzzy
-msgid "3/4 Screen"
-msgstr "Dîmen"
+#~ msgid "3/4 Screen"
+#~ msgstr "Dîmen"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
-"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys"
-msgstr ""
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
 #, fuzzy
-msgid "Universal Access Preferences"
-msgstr "Vebijêrkên mikşê"
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Vebijêrkên mikşê"
 
-#: ../panels/universal-access/uap.ui.h:2
-#, no-c-format
-msgid "100%"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:4
-#, no-c-format
-msgid "125%"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:6
-#, no-c-format
-msgid "150%"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:8
-#, no-c-format
-msgid "75%"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "A_cceptance delay:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "Acc_eptance delay:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:11
-msgid "Beep when Caps and Num Lock are used"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:12
 #, fuzzy
-msgid "Beep when a _modifer key is pressed"
-msgstr "Di dema pêlkirina guhestinan de bi deng hişyarî bide"
+#~ msgid "Beep when a key is"
+#~ msgstr "Heke bişkok ev be bike tûtût:"
 
-#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
-#: ../panels/universal-access/uap.ui.h:14
 #, fuzzy
-msgid "Beep when a key is"
-msgstr "Heke bişkok ev be bike tûtût:"
+#~ msgid "Change contrast:"
+#~ msgstr "Tîma guherandinê"
 
-#: ../panels/universal-access/uap.ui.h:15
 #, fuzzy
-msgid "Beep when a key is _rejected"
-msgstr "Dema bişkok nehate _qebûlkirin bike tûtût"
+#~ msgid "Flash the window title"
+#~ msgstr "Darikê sernivîsa _paceyê bike flaş"
 
-#: ../panels/universal-access/uap.ui.h:16
 #, fuzzy
-msgid "Bounce Keys"
-msgstr "Bişkokên Mişk"
+#~ msgid "Keyboard Settings"
+#~ msgstr "Bijarekên klavye"
 
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Caribou"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:18
 #, fuzzy
-msgid "Change contrast:"
-msgstr "Tîma guherandinê"
+#~ msgid "Mouse Settings"
+#~ msgstr "Mîheng"
 
-#: ../panels/universal-access/uap.ui.h:19
-msgid "Closed Captioning"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Control the pointer using the keypad"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Control the pointer using the video camera."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:23
 #, fuzzy
-msgid "D_elay:"
-msgstr "_Derengmayîn:"
+#~ msgid "On screen keyboard"
+#~ msgstr "Klavyeya _dîmenderê"
 
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Dasher"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Decrease size:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Display a textual description of speech and sounds"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:27
 #, fuzzy
-msgid "Flash the entire screen"
-msgstr "Hemû dîmenderê bike _flaş"
+#~ msgid "Options..."
+#~ msgstr "Vebijêrk"
 
-#: ../panels/universal-access/uap.ui.h:28
 #, fuzzy
-msgid "Flash the window title"
-msgstr "Darikê sernivîsa _paceyê bike flaş"
+#~ msgid "Type here to test settings"
+#~ msgstr "Ji bo kontrolkirina mîhengan _biceribîne:"
 
-#: ../panels/universal-access/uap.ui.h:29
-msgid "GOK"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "Hearing"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Hover Click"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:32
 #, fuzzy
-msgid "Ignores fast duplicate keypresses"
-msgstr "dubare pêlkirina mifteyan piştguh bike dema:"
+#~ msgid "Video Mouse"
+#~ msgstr "Mişk"
 
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Increase size:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:34
 #, fuzzy
-msgid "Keyboard Settings"
-msgstr "Bijarekên klavye"
+#~ msgid "accepted"
+#~ msgstr "_hate pejirandin"
 
-#: ../panels/universal-access/uap.ui.h:39
 #, fuzzy
-msgid "Motion _threshold:"
-msgstr "_Dergeh:"
+#~ msgid "pressed"
+#~ msgstr "_hate pêlêkirin"
 
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Mouse Keys"
-msgstr "Bişkokên Mişk"
-
-#: ../panels/universal-access/uap.ui.h:41
 #, fuzzy
-msgid "Mouse Settings"
-msgstr "Mîheng"
+#~ msgid "rejected"
+#~ msgstr "_nehate pejirandin"
 
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Nomon"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:44
 #, fuzzy
-msgid "On screen keyboard"
-msgstr "Klavyeya _dîmenderê"
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "berevajî"
 
-#: ../panels/universal-access/uap.ui.h:45
-msgid "OnBoard"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:46
 #, fuzzy
-msgid "Options..."
-msgstr "Vebijêrk"
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "asayî"
 
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Pointing and Clicking"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:48
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:49
 #, fuzzy
-msgid "Screen Reader"
-msgstr "_Xwînerê dîmenderê"
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "Mezinkirin"
 
-#: ../panels/universal-access/uap.ui.h:50
 #, fuzzy
-msgid "Screen keyboard"
-msgstr "Klavyeya _dîmenderê"
+#~ msgctxt "universal access, text size"
+#~ msgid "Large"
+#~ msgstr "Mezin"
 
-#: ../panels/universal-access/uap.ui.h:51
-msgid "Seeing"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:54
-msgid "Simulated Secondary Click"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:55
 #, fuzzy
-msgid "Slow Keys"
-msgstr "Hişyariya Hêdîkirina Bişkokan"
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "Mezin"
 
-#: ../panels/universal-access/uap.ui.h:58
 #, fuzzy
-msgid "Sound Settings"
-msgstr "%d Mîhengên Dîmender\n"
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "asayî"
 
-#: ../panels/universal-access/uap.ui.h:59
 #, fuzzy
-msgid "Sticky Keys"
-msgstr "Hişyariya Bişkokên Mezeloqî"
+#~ msgctxt "universal access, text size"
+#~ msgid "Small"
+#~ msgstr "Biçûk"
 
-#: ../panels/universal-access/uap.ui.h:60
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr ""
+#~ msgid "Centered"
+#~ msgstr "Navîn"
 
-#: ../panels/universal-access/uap.ui.h:61
-msgid "Trigger a click when the pointer hovers"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "Turn on or off:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:64
 #, fuzzy
-msgid "Type here to test settings"
-msgstr "Ji bo kontrolkirina mîhengan _biceribîne:"
+#~ msgid "Image moves with the mouse pointer"
+#~ msgstr "Guhertoya mezin a nîşankerê sipî"
 
-#: ../panels/universal-access/uap.ui.h:66
 #, fuzzy
-msgid "Typing Assistant"
-msgstr "_Alîkar:"
+#~ msgid "Authentication failed"
+#~ msgstr "Belgekirî!"
 
-#: ../panels/universal-access/uap.ui.h:67
-msgid "Use a visual indication when an alert sound occurs"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:68
-#, fuzzy
-msgid "Video Mouse"
-msgstr "Mişk"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Visual Alerts"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:70
-#, fuzzy
-msgid "Zoom in:"
-msgstr "Mezinkirin"
-
-#: ../panels/universal-access/uap.ui.h:71
-#, fuzzy
-msgid "Zoom out:"
-msgstr "Derkeve"
-
-#: ../panels/universal-access/uap.ui.h:72
-#, fuzzy
-msgid "_Contrast:"
-msgstr "Tekilî"
-
-#: ../panels/universal-access/uap.ui.h:73
-#, fuzzy
-msgid "_Disable if two keys are pressed together"
-msgstr "Heke _bi hev re pêl bişkokan were kirin bandora wê rake"
-
-#: ../panels/universal-access/uap.ui.h:74
-msgid "_Test flash"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:75
-msgid "_Text size:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:76
-#, fuzzy
-msgid "_Turn on accessibility features from the keyboard"
-msgstr "_Taybetmendiyên gihîştina klavyeyê çalak bike"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:78
-#, fuzzy
-msgid "accepted"
-msgstr "_hate pejirandin"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:80
-#, fuzzy
-msgid "pressed"
-msgstr "_hate pêlêkirin"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:82
-#, fuzzy
-msgid "rejected"
-msgstr "_nehate pejirandin"
-
-#: ../panels/universal-access/uap.ui.h:83
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:84
-#, fuzzy
-msgctxt "universal access, contrast"
-msgid "High/Inverse"
-msgstr "berevajî"
-
-#: ../panels/universal-access/uap.ui.h:85
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:86
-#, fuzzy
-msgctxt "universal access, contrast"
-msgid "Normal"
-msgstr "asayî"
-
-#. Translators: this refers to theme contrast and font size
-#: ../panels/universal-access/uap.ui.h:88
-msgctxt "universal access, seeing"
-msgid "Display"
-msgstr ""
-
-#. Translators: this refers to screen magnifier
-#: ../panels/universal-access/uap.ui.h:90
-#, fuzzy
-msgctxt "universal access, seeing"
-msgid "Zoom"
-msgstr "Mezinkirin"
-
-#: ../panels/universal-access/uap.ui.h:91
-#, fuzzy
-msgctxt "universal access, text size"
-msgid "Large"
-msgstr "Mezin"
-
-#: ../panels/universal-access/uap.ui.h:92
-#, fuzzy
-msgctxt "universal access, text size"
-msgid "Larger"
-msgstr "Mezin"
-
-#: ../panels/universal-access/uap.ui.h:93
-#, fuzzy
-msgctxt "universal access, text size"
-msgid "Normal"
-msgstr "asayî"
-
-#: ../panels/universal-access/uap.ui.h:94
-#, fuzzy
-msgctxt "universal access, text size"
-msgid "Small"
-msgstr "Biçûk"
-
-#: ../panels/universal-access/zoom-options.ui.h:1
-msgid "Always"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:2
-msgid "Bottom Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:3
-msgid "Centered"
-msgstr "Navîn"
-
-#: ../panels/universal-access/zoom-options.ui.h:4
-msgid "Color and Opacity"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:5
-msgid "Crosshairs"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:6
-#, fuzzy
-msgid "Full Screen"
-msgstr "Dîmenderê Tije Bike"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-#, fuzzy
-msgid "Image moves with the mouse pointer"
-msgstr "Guhertoya mezin a nîşankerê sipî"
-
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Image scrolls at screen edges"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Left Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Length"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-#, fuzzy
-msgid "Magnification"
-msgstr "_Girdok"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
-msgid "Moveable lens - magnified view follows mouse movements"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Position of magnified view on screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:18
-msgid "Proportional"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:19
-msgid "Push"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Right Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Show"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Show crosshairs intersection"
-msgstr ""
-
-#. long delay
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "Thick"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Thickness"
-msgstr ""
-
-#. short delay
-#: ../panels/universal-access/zoom-options.ui.h:29
-msgid "Thin"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:30
-msgid "To keep the pointer centered"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:31
-msgid "To keep the pointer visible"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:32
-msgid "Top Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:33
-#, fuzzy
-msgid "Zoom Options"
-msgstr "Vebijêrk"
-
-#: ../panels/user-accounts/run-passwd.c:426
-#, fuzzy
-msgid "Authentication failed"
-msgstr "Belgekirî!"
-
-#: ../panels/user-accounts/run-passwd.c:506
-#: ../panels/user-accounts/um-password-dialog.c:375
 #, fuzzy, c-format
-msgid "The new password is too short"
-msgstr "Şîfre pir kurte."
+#~ msgid "The new password is too short"
+#~ msgstr "Şîfre pir kurte."
 
-#: ../panels/user-accounts/run-passwd.c:512
 #, fuzzy, c-format
-msgid "The new password is too simple"
-msgstr "Şîfre pir hesane."
+#~ msgid "The new password is too simple"
+#~ msgstr "Şîfre pir hesane."
 
-#: ../panels/user-accounts/run-passwd.c:518
 #, fuzzy, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Şîfreya kevin û ya nû gelekî wek hevin."
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Şîfreya kevin û ya nû gelekî wek hevin."
 
-#: ../panels/user-accounts/run-passwd.c:521
 #, fuzzy, c-format
-msgid "The new password has already been used recently."
-msgstr "Herdû şîfre ne weke hevin."
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Herdû şîfre ne weke hevin."
 
-#: ../panels/user-accounts/run-passwd.c:524
 #, fuzzy, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Pêwiste ku di şîfreya nû de hejmar an jî karekterên taybet hebin."
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Pêwiste ku di şîfreya nû de hejmar an jî karekterên taybet hebin."
 
-#: ../panels/user-accounts/run-passwd.c:528
 #, fuzzy, c-format
-msgid "The old and new passwords are the same"
-msgstr "Şîfreya kevin û ya nû yekin."
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Şîfreya kevin û ya nû yekin."
 
-#: ../panels/user-accounts/run-passwd.c:532
 #, fuzzy, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-"Şîfreya te hatiye guhertin di dema belgekirinê de , ji kerema xwe re ji nû "
-"belgekirinê pêk bîne."
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Şîfreya te hatiye guhertin di dema belgekirinê de , ji kerema xwe re ji "
+#~ "nû belgekirinê pêk bîne."
 
-#: ../panels/user-accounts/run-passwd.c:536
 #, fuzzy, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Pêwiste ku di şîfreya nû de hejmar an jî karekterên taybet hebin."
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Pêwiste ku di şîfreya nû de hejmar an jî karekterên taybet hebin."
 
-#: ../panels/user-accounts/run-passwd.c:540
 #, fuzzy, c-format
-msgid "Unknown error"
-msgstr "Nîşankereke Nenas"
+#~ msgid "Unknown error"
+#~ msgstr "Nîşankereke Nenas"
 
-#: ../panels/user-accounts/um-account-dialog.c:73
 #, fuzzy
-msgid "Failed to create user"
-msgstr "Afirandina peldanka derbasdar bi ser neket"
+#~ msgid "Failed to create user"
+#~ msgstr "Afirandina peldanka derbasdar bi ser neket"
 
-#: ../panels/user-accounts/um-account-type.c:35
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
 #, fuzzy
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Termînala Xê ya Standart"
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Termînala Xê ya Standart"
 
-#: ../panels/user-accounts/um-account-type.c:37
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgctxt "Account type"
-msgid "Administrator"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:107
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:109
 #, fuzzy
-msgid "The device is already in use."
-msgstr "Girêdana Bişkokê (%s) jixwe niha tê bikaranîn\n"
+#~ msgid "The device is already in use."
+#~ msgstr "Girêdana Bişkokê (%s) jixwe niha tê bikaranîn\n"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:111
 #, fuzzy
-msgid "An internal error occurred."
-msgstr "Çewtiyeke pergalê rû da"
+#~ msgid "An internal error occurred."
+#~ msgstr "Çewtiyeke pergalê rû da"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:181
-#: ../panels/user-accounts/um-fingerprint-dialog.c:182
 #, fuzzy
-msgid "Enabled"
-msgstr "Neçalak"
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Dirûvê navîn yê mak nehate barkirin"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:224
-msgid "Delete registered fingerprints?"
-msgstr ""
+#~ msgid "Please choose another password."
+#~ msgstr "Ji kerema xwe re şîfreyeke din hilbijêre."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:228
-msgid "_Delete Fingerprints"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:235
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:363
-msgid "Done!"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:410
-#: ../panels/user-accounts/um-fingerprint-dialog.c:432
-#, c-format
-msgid "Could not access '%s' device"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:481
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:533
 #, fuzzy
-msgid "Could not access any fingerprint readers"
-msgstr "Dirûvê navîn yê mak nehate barkirin"
+#~ msgid "Please type your current password again."
+#~ msgstr "Ji kerema xwe re şîfreyan dîsa binivîse."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:534
-msgid "Please contact your system administrator for help."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:571
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Enable Fingerprint Login"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:605
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:612
 #, fuzzy
-msgid "Selecting finger"
-msgstr "Wêne Hilbijêre"
+#~ msgid "Password could not be changed"
+#~ msgstr "Şîfreya te hatiye guhertin."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:613
-msgid "Enrolling fingerprints"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:614
-msgid "Summary"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:179
-msgid "More choices..."
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:285
-msgid "Please choose another password."
-msgstr "Ji kerema xwe re şîfreyeke din hilbijêre."
-
-#: ../panels/user-accounts/um-password-dialog.c:294
 #, fuzzy
-msgid "Please type your current password again."
-msgstr "Ji kerema xwe re şîfreyan dîsa binivîse."
+#~ msgid "You need to enter a new password"
+#~ msgstr "Şîfreya nû dîsa _binivîse:"
 
-#: ../panels/user-accounts/um-password-dialog.c:300
 #, fuzzy
-msgid "Password could not be changed"
-msgstr "Şîfreya te hatiye guhertin."
+#~ msgid "You need to confirm the password"
+#~ msgstr "Ji bo guherandina şîfreyê pêl \"Şîfreyê Biguherîne\" bike."
 
-#: ../panels/user-accounts/um-password-dialog.c:372
 #, fuzzy
-msgid "You need to enter a new password"
-msgstr "Şîfreya nû dîsa _binivîse:"
+#~ msgid "The current password is not correct"
+#~ msgstr "Ew şîfre çewt bû."
 
-#: ../panels/user-accounts/um-password-dialog.c:381
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Lawaz"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Navîn"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Baş"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Xurt"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "Nasnav hev nagirin"
+
+#~ msgid "Wrong password"
+#~ msgstr "Nasnav şaş e"
+
 #, fuzzy
-msgid "You need to confirm the password"
-msgstr "Ji bo guherandina şîfreyê pêl \"Şîfreyê Biguherîne\" bike."
+#~ msgid "This user does not exist."
+#~ msgstr "Ji bo vê bûyerê pelê dengan nehate dîtin."
 
-#: ../panels/user-accounts/um-password-dialog.c:384
-#, fuzzy
-msgid "The passwords do not match"
-msgstr "Şîfre pir kurte."
-
-#: ../panels/user-accounts/um-password-dialog.c:390
-msgid "You need to enter your current password"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:393
-#, fuzzy
-msgid "The current password is not correct"
-msgstr "Ew şîfre çewt bû."
-
-#: ../panels/user-accounts/um-password-dialog.c:466
-#: ../panels/user-accounts/um-password-dialog.c:693
-msgctxt "Password strength"
-msgid "Too short"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:469
-#: ../panels/user-accounts/um-password-dialog.c:694
-msgctxt "Password strength"
-msgid "Weak"
-msgstr "Lawaz"
-
-#: ../panels/user-accounts/um-password-dialog.c:471
-#: ../panels/user-accounts/um-password-dialog.c:695
-msgctxt "Password strength"
-msgid "Fair"
-msgstr "Navîn"
-
-#: ../panels/user-accounts/um-password-dialog.c:473
-#: ../panels/user-accounts/um-password-dialog.c:696
-msgctxt "Password strength"
-msgid "Good"
-msgstr "Baş"
-
-#: ../panels/user-accounts/um-password-dialog.c:475
-#: ../panels/user-accounts/um-password-dialog.c:697
-msgctxt "Password strength"
-msgid "Strong"
-msgstr "Xurt"
-
-#: ../panels/user-accounts/um-password-dialog.c:514
-msgid "Passwords do not match"
-msgstr "Nasnav hev nagirin"
-
-#: ../panels/user-accounts/um-password-dialog.c:540
-msgid "Wrong password"
-msgstr "Nasnav şaş e"
-
-#: ../panels/user-accounts/um-photo-dialog.c:97
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-msgid "Select"
-msgstr "Hilbijartin"
-
-#: ../panels/user-accounts/um-photo-dialog.c:445
-#, fuzzy
-msgid "Disable image"
-msgstr "Neçalak"
-
-#: ../panels/user-accounts/um-photo-dialog.c:463
-msgid "Take a photo..."
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:481
-msgid "Browse for more pictures..."
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:706
-#, c-format
-msgid "Used by %s"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-manager.c:450
-#, c-format
-msgid "A user with name '%s' already exists."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-manager.c:546
-#, fuzzy
-msgid "This user does not exist."
-msgstr "Ji bo vê bûyerê pelê dengan nehate dîtin."
-
-#: ../panels/user-accounts/um-user-panel.c:357
-msgid "Failed to delete user"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "You cannot delete your own account."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:426
-#, c-format
-msgid "%s is still logged in"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:430
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:439
 #, fuzzy, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "Tu dixwazî van xuyakirinan tomar bikî?"
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "Tu dixwazî van xuyakirinan tomar bikî?"
 
-#: ../panels/user-accounts/um-user-panel.c:443
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
+#~ msgid "_Keep Files"
+#~ msgstr "Pelan bi_parêze"
 
-#: ../panels/user-accounts/um-user-panel.c:446
-msgid "_Delete Files"
-msgstr "Pelan _jê bibe"
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Hesab neçalakkirî ye"
 
-#: ../panels/user-accounts/um-user-panel.c:447
-msgid "_Keep Files"
-msgstr "Pelan bi_parêze"
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Tune"
 
-#: ../panels/user-accounts/um-user-panel.c:499
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Hesab neçalakkirî ye"
-
-#: ../panels/user-accounts/um-user-panel.c:507
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:510
-msgctxt "Password mode"
-msgid "None"
-msgstr "Tune"
-
-#: ../panels/user-accounts/um-user-panel.c:845
-msgid "Failed to contact the accounts service"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:847
 #, fuzzy
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Baweriya xwe pê bîne ku pêvek rast hatiye sazkirin."
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Baweriya xwe pê bîne ku pêvek rast hatiye sazkirin."
 
-#: ../panels/user-accounts/um-user-panel.c:887
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
+#~ msgid "Other Accounts"
+#~ msgstr "Hesabên din"
 
-#: ../panels/user-accounts/um-user-panel.c:925
-msgid "Create a user"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:936
-#: ../panels/user-accounts/um-user-panel.c:1225
-msgid ""
-"To create a user,\n"
-"click the * icon first"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:945
-msgid "Delete the selected user"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:957
-#: ../panels/user-accounts/um-user-panel.c:1230
-msgid ""
-"To delete the selected user,\n"
-"click the * icon first"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1134
-msgid "My Account"
-msgstr "Hesaba min"
-
-#: ../panels/user-accounts/um-user-panel.c:1144
-msgid "Other Accounts"
-msgstr "Hesabên din"
-
-#: ../panels/user-accounts/um-utils.c:512
-#, c-format
-msgid "A user with the username '%s' already exists"
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:516
 #, fuzzy, c-format
-msgid "The username is too long"
-msgstr "Şîfre pir kurte."
+#~ msgid "The username is too long"
+#~ msgstr "Şîfre pir kurte."
 
-#: ../panels/user-accounts/um-utils.c:519
-msgid "The username cannot start with a '-'"
-msgstr ""
+#~ msgid "Cr_eate"
+#~ msgstr "_Afirandin"
 
-#: ../panels/user-accounts/um-utils.c:522
-msgid ""
-"The username must only consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
-msgstr ""
+#~ msgid "Create new account"
+#~ msgstr "Hesaba nû biafirîne"
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Add or remove users"
-msgstr ""
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr ""
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "User Accounts"
-msgstr "Hesabên bikarhêner"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-msgid "Cr_eate"
-msgstr "_Afirandin"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "Create new account"
-msgstr "Hesaba nû biafirîne"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
 #, fuzzy
-msgid "_Account Type"
-msgstr "Cureyê Hişyariyê"
+#~ msgid "_Account Type"
+#~ msgstr "Cureyê Hişyariyê"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
 #, fuzzy
-msgid "_Full name"
-msgstr "Nav û Paşnav"
+#~ msgid "Changing password for"
+#~ msgstr "Şîfreyê biguhêre"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
 #, fuzzy
-msgid "_Username"
-msgstr "N_avê Bikarhêner:"
+#~ msgid "Browse"
+#~ msgstr "Geroka Torê"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
 #, fuzzy
-msgid "C_onfirm password"
-msgstr "Şîfreyê biguhêre"
+#~ msgid "Take a photograph"
+#~ msgstr "Bêhna xwe vekin!"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
 #, fuzzy
-msgid "Ch_ange"
-msgstr "Tîma guherandinê"
+#~ msgid "Login Options"
+#~ msgstr "Vebijêrkên Pergalê"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
 #, fuzzy
-msgid "Changing password for"
-msgstr "Şîfreyê biguhêre"
+#~ msgid "Scroll Up"
+#~ msgstr "Bigire"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
 #, fuzzy
-msgid "Choose a generated password"
-msgstr "Şîfreyê biguhêre"
+#~ msgid "Tablet Preferences"
+#~ msgstr "Vebijêrkên Dirban"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Choose password at next login"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
 #, fuzzy
-msgid "Current _password"
-msgstr "Şîfreya _heyî:"
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Tercîhên mişk bike"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Disable this account"
-msgstr ""
+#~ msgid "- System Settings"
+#~ msgstr "- Mîhengên pergalê"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Enable this account"
-msgstr ""
+#~ msgid "System Settings"
+#~ msgstr "Mîhengên pergalê"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-msgid "Fair"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-msgid "How to choose a strong password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-msgid "Log in without a password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-#, fuzzy
-msgid "Set a password now"
-msgstr "Şîfreya _Nû:"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid ""
-"This hint may be displayed at the login screen.  It will be visible to all "
-"users of this system.  Do <b>not</b> include the password here."
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-#, fuzzy
-msgid "_Action"
-msgstr "Çalakî"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:15
-msgid "_Hint"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:16
-#, fuzzy
-msgid "_New password"
-msgstr "Şîfreya _Nû:"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:17
-#, fuzzy
-msgid "_Show password"
-msgstr "Şîfreya _Nû:"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-#, fuzzy
-msgid "Browse"
-msgstr "Geroka Torê"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-msgid "Cancel"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-msgid "Changing photo for:"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-msgid ""
-"Choose a picture that will be shown at the login screen for this account."
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-msgid "Gallery"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-#, fuzzy
-msgid "Take a photograph"
-msgstr "Bêhna xwe vekin!"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-msgid "A_utomatic Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-msgid "Account Information"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Account _type"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-#, fuzzy
-msgid "Login Options"
-msgstr "Vebijêrkên Pergalê"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Fingerprint Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "_Language"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Password"
-msgstr "Şî_fre"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left little finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left middle finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left ring finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Left thumb"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right little finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right middle finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right ring finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-msgid "Right thumb"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "Tiliya _din:"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid "_Right index finger"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Back"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-#, fuzzy
-msgid "Bluetooth Settings"
-msgstr "Mîhengên Pêşdanasînî"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Calibrate..."
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "Eraser Pressure Feel"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Firm"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Forward"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Left Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Left-Handed Orientation:"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-#, fuzzy
-msgid "Lower Button"
-msgstr "Bişkokên Hişyariyê"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Middle Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-#, fuzzy
-msgid "No Action"
-msgstr "Çalakî"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "No tablet detected"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Right Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Scroll Down"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:16
-msgid "Scroll Left"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:17
-#, fuzzy
-msgid "Scroll Right"
-msgstr "_Sivik"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:18
-#, fuzzy
-msgid "Scroll Up"
-msgstr "Bigire"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:19
-msgid "Soft"
-msgstr "Nerm"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:20
-#, fuzzy
-msgid "Stylus"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:21
-msgid "Tablet (absolute)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:22
-#, fuzzy
-msgid "Tablet Preferences"
-msgstr "Vebijêrkên Dirban"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:23
-msgid "Tip Pressure Feel"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:24
-#, fuzzy
-msgid "Top Button"
-msgstr "Bişkok"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:25
-msgid "Touchpad (relative)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:26
-msgid "Tracking Mode"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:27
-msgid "Wacom Tablet"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#, fuzzy
-msgid "Set your Wacom tablet preferences"
-msgstr "Tercîhên mişk bike"
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Wacom Graphics Tablet"
-msgstr ""
-
-#: ../shell/control-center.c:54
-msgid "Enable verbose mode"
-msgstr ""
-
-#: ../shell/control-center.c:55
-msgid "Show the overview"
-msgstr ""
-
-#: ../shell/control-center.c:56 ../shell/control-center.c:57
-#: ../shell/control-center.c:58
-msgid "Show help options"
-msgstr ""
-
-#: ../shell/control-center.c:59
-msgid "Panel to display"
-msgstr ""
-
-#: ../shell/control-center.c:81
-msgid "- System Settings"
-msgstr "- Mîhengên pergalê"
-
-#: ../shell/control-center.c:89
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
-msgstr ""
-
-#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
-msgid "System Settings"
-msgstr "Mîhengên pergalê"
-
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Navenda kontrolê"
-
-#: ../shell/shell.ui.h:2
-msgid "_All Settings"
-msgstr "_Hemû mîheng"
+#~ msgid "Control Center"
+#~ msgstr "Navenda kontrolê"
 
 #~ msgid "Image/label border"
 #~ msgstr "Nexşeya dorê ya wêne/etîketê"
@@ -4490,9 +6245,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "About Me"
 #~ msgstr "Der Barê Min De"
-
-#~ msgid "Set your personal information"
-#~ msgstr "Agahiyên xwe yên şexsî mîheng bike"
 
 #~ msgid "No Image"
 #~ msgstr "Wêne tune"
@@ -4549,9 +6301,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "    "
 #~ msgstr "    "
-
-#~ msgid "<b>Email</b>"
-#~ msgstr "<b>Eposte</b>"
 
 #~ msgid "<b>Home</b>"
 #~ msgstr "<b>Mal</b>"
@@ -4627,9 +6376,6 @@ msgstr "_Hemû mîheng"
 #~ "Piştî belgekirinê, şîfreya xwe ya nû derbas bike, ji bo bê gumankirine "
 #~ "dîsa binvîse û li ser <b>şîfreyê biguhêre</b> bitikîne."
 
-#~ msgid "User name:"
-#~ msgstr "Nave bikarhêner:"
-
 #~ msgid "Web _log:"
 #~ msgstr "_Rojnivîska Webê:"
 
@@ -4641,12 +6387,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "Zip/_Postal code:"
 #~ msgstr "_Koda Posteyê:"
-
-#~ msgid "_Address:"
-#~ msgstr "_Navnîşan:"
-
-#~ msgid "_Authenticate"
-#~ msgstr "_Belgekirin"
 
 #~ msgid "_Groupwise:"
 #~ msgstr "_Groupwise:"
@@ -4789,9 +6529,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "Delay between keypress and pointer mo_vement:"
 #~ msgstr "Derengî di navbera pêlkirina bişkokê û tevgera nîşanker de:"
 
-#~ msgid "E_nable Toggle Keys"
-#~ msgstr "Bişkokên _Veke/Bigire Çalak Bike"
-
 #~ msgid "Filters"
 #~ msgstr "Fîltre"
 
@@ -4864,9 +6601,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "_Finish"
 #~ msgstr "_Biqedîne"
 
-#~ msgid "_Style:"
-#~ msgstr "_Teşe:Di"
-
 #~ msgid "[FILE...]"
 #~ msgstr "[PEL...]"
 
@@ -4914,13 +6648,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "Copying '%s'"
 #~ msgstr "'%s' tê jibergirtin."
 
-#~ msgid "Copying files"
-#~ msgstr "Pel tên jibergirtin"
-
-#, fuzzy
-#~ msgid "Parent Window"
-#~ msgstr "Pencere"
-
 #~ msgid "From URI"
 #~ msgstr "URIya çavkanî"
 
@@ -4932,9 +6659,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "URI currently transferring to"
 #~ msgstr "URI hîna jî vediguhezîne vir"
-
-#~ msgid "Fraction completed"
-#~ msgstr "Kar nehate temamkirin"
 
 #~ msgid "Fraction of transfer currently completed"
 #~ msgstr "Karê transferê niha xelas bû"
@@ -5005,9 +6729,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "Firefox"
 #~ msgstr "Firefox"
 
-#~ msgid "GNOME Terminal"
-#~ msgstr "Termînala GNOME"
-
 #~ msgid "Galeon"
 #~ msgstr "Galeon"
 
@@ -5058,9 +6779,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "Sylpheed-Claws"
-
-#~ msgid "Thunderbird"
-#~ msgstr "Thunderbird"
 
 #~ msgid "W3M Text Browser"
 #~ msgstr "Geroka Nivîsê ya W3M"
@@ -5116,17 +6834,11 @@ msgstr "_Hemû mîheng"
 #~ msgid "Run in t_erminal"
 #~ msgstr "Di t_ermînalekê de bixebitîne"
 
-#~ msgid "Screen Resolution"
-#~ msgstr "Xuyakirina dîmender"
-
 #~ msgid "left"
 #~ msgstr "çep"
 
 #~ msgid "%d Hz"
 #~ msgstr "%d Hz"
-
-#~ msgid "Re_fresh rate:"
-#~ msgstr "Leze _Tezekirinan:"
 
 #~ msgid "Screen Resolution Preferences"
 #~ msgstr "Bijarekên xuyakirina dîmender"
@@ -5224,9 +6936,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "VB_GR"
 #~ msgstr "VB_GR"
 
-#~ msgid "_Application font:"
-#~ msgstr "Curetîpa _Sepanê:"
-
 #~ msgid "_BGR"
 #~ msgstr "_BGR"
 
@@ -5235,9 +6944,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "_Fixed width font:"
 #~ msgstr "Curetîpê firehiya wê sabît e:"
-
-#~ msgid "_Full"
-#~ msgstr "_Tam"
 
 #~ msgid "_Medium"
 #~ msgstr "_Navîn"
@@ -5311,9 +7017,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "New accelerator..."
 #~ msgstr "Lezkera nû..."
 
-#~ msgid "Desktop"
-#~ msgstr "Sermasê"
-
 #~ msgid "Window Management"
 #~ msgstr "Gerînendeyê Paceyan"
 
@@ -5324,18 +7027,12 @@ msgstr "_Hemû mîheng"
 #~ msgid "Error unsetting accelerator in configuration database: %s\n"
 #~ msgstr "Dema lezker ji danegira veavakirinan jê dibir çewtî derket: %s\n"
 
-#~ msgid "Keyboard Shortcuts"
-#~ msgstr "Kurteriyên Klavyeyê"
-
 #~ msgid "Assign shortcut keys to commands"
 #~ msgstr "Kurteriyan li fermanan tayîn bike"
 
 #, fuzzy
 #~ msgid "There was an error launching the keyboard tool: %s"
 #~ msgstr "Dema destpêkirina amûra klavyeyê de çewtî derket: %s"
-
-#~ msgid "_Accessibility"
-#~ msgstr "_Gihîştin"
 
 #~ msgid ""
 #~ "Just apply settings and quit (compatibility only; now handled by daemon)"
@@ -5446,18 +7143,8 @@ msgstr "_Hemû mîheng"
 #~ msgid "Large White Pointer - Current"
 #~ msgstr "Nîşankerê Sipiyê mezin - Yê heyî"
 
-#, fuzzy
-#~ msgid "Large White Pointer"
-#~ msgstr "Nîşankerê Sipî yê Mezin"
-
 #~ msgid "Pointer Theme"
 #~ msgstr "Dirbê nîşanekê"
-
-#~ msgid "<b>Locate Pointer</b>"
-#~ msgstr "<b>Nîşanekê bi cih bike</b>"
-
-#~ msgid "<b>Mouse Orientation</b>"
-#~ msgstr "<b>Bicihbûna Mişk</b>"
 
 #~ msgid "<b>Speed</b>"
 #~ msgstr "<b>Lez</b>"
@@ -5483,9 +7170,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "Highlight the _pointer when you press Ctrl"
 #~ msgstr "Dema min pêl bişkoka Ctrl kir cihê nîşandêrê diyar bike"
 
-#~ msgid "Medium"
-#~ msgstr "Navîn"
-
 #~ msgid "Motion"
 #~ msgstr "Tevger"
 
@@ -5499,14 +7183,8 @@ msgstr "_Hemû mîheng"
 #~ msgid "<b>Di_rect internet connection</b>"
 #~ msgstr "<b>Girêdana Înternetê ya _Rasterast</b>"
 
-#~ msgid "<b>Ignore Host List</b>"
-#~ msgstr "<b>Guh Nede Lîsteya Makîneyan</b>"
-
 #~ msgid "<b>_Manual proxy configuration</b>"
 #~ msgstr "<b>Mîhengkirina cîgir ya bi _destan</b>"
-
-#~ msgid "<b>_Use authentication</b>"
-#~ msgstr "<b>_Pelgekirinê bikar bîne</b>"
 
 #~ msgid "Advanced Configuration"
 #~ msgstr "Veavakirina Pêşketî"
@@ -5522,9 +7200,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "Proxy Configuration"
 #~ msgstr "Veavakirina Cîgir"
-
-#~ msgid "_Details"
-#~ msgstr "_Hûragahî"
 
 #~ msgid "_Secure HTTP proxy:"
 #~ msgstr "_Cîgirê HTTPê yê ewle:"
@@ -5548,9 +7223,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
 #~ msgstr "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
 
-#~ msgid "Click OK to finish."
-#~ msgstr "Ji bo bidawîkirinê Temam Bitikîne"
-
 #, fuzzy
 #~ msgid "So_und playback:"
 #~ msgstr "Dîsa lêdana deng:"
@@ -5558,9 +7230,6 @@ msgstr "_Hemû mîheng"
 #, fuzzy
 #~ msgid "Sou_nd capture:"
 #~ msgstr "Deng jibergirtin:"
-
-#~ msgid "Sounds"
-#~ msgstr "Deng"
 
 #, fuzzy
 #~ msgid "System Beep"
@@ -5669,9 +7338,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "Specify the filename of a theme to install"
 #~ msgstr "Pelekî dirban ji bo sazkirinê nehate diyarkirin"
 
-#~ msgid "filename"
-#~ msgstr "navê pelî"
-
 #~ msgid ""
 #~ "The default theme schemas could not be found on your system.  This means "
 #~ "that you probably don't have metacity installed, or that your gconf is "
@@ -5712,9 +7378,6 @@ msgstr "_Hemû mîheng"
 #, fuzzy
 #~ msgid "C_ustomize..."
 #~ msgstr "_Taybet"
-
-#~ msgid "Controls"
-#~ msgstr "Kontrolkirin"
 
 #~ msgid "Icons"
 #~ msgstr "Dawêr"
@@ -5807,14 +7470,8 @@ msgstr "_Hemû mîheng"
 #~ msgid "Toolbar _button labels:"
 #~ msgstr "Etîketên _bişkokên darikê amûran:"
 
-#~ msgid "_Copy"
-#~ msgstr "_Ji ber bigire"
-
 #~ msgid "_Detachable toolbars"
 #~ msgstr "Darikên amûran ên dikarin bên _veqetandin"
-
-#~ msgid "_Edit"
-#~ msgstr "_Sererast bike"
 
 #, fuzzy
 #~ msgid "_Editable menu shortcut keys"
@@ -5826,20 +7483,11 @@ msgstr "_Hemû mîheng"
 #~ msgid "_New"
 #~ msgstr "_Nû"
 
-#~ msgid "_Open"
-#~ msgstr "_Veke"
-
 #~ msgid "_Paste"
 #~ msgstr "_Pê ve bike"
 
 #~ msgid "_Print"
 #~ msgstr "_Çap"
-
-#~ msgid "_Quit"
-#~ msgstr "_Derkeve"
-
-#~ msgid "_Save"
-#~ msgstr "_Tomar bike"
 
 #, fuzzy
 #~ msgid "Cannot start the preferences application for your window manager"
@@ -5896,12 +7544,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "Set your window properties"
 #~ msgstr "Taybetiyên paceyên xwe mîheng bike"
 
-#~ msgid "Windows"
-#~ msgstr "Pencere"
-
-#~ msgid "Volume"
-#~ msgstr "Deng"
-
 #~ msgid ""
 #~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
 #~ "the Slow Keys feature, which affects the way your keyboard works."
@@ -5916,14 +7558,8 @@ msgstr "_Hemû mîheng"
 #~ msgid "Do you want to deactivate Slow Keys?"
 #~ msgstr "Tu dixwazî Hêdîkirina Bişkokan bigire?"
 
-#~ msgid "_Activate"
-#~ msgstr "_Çalak bike"
-
 #~ msgid "Do_n't activate"
 #~ msgstr "Çalak _neke"
-
-#~ msgid "Do_n't deactivate"
-#~ msgstr "Ra_newestîne"
 
 #~ msgid ""
 #~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
@@ -6126,9 +7762,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "<b>Start %s</b>"
 #~ msgstr "<b>Destek</b>"
 
-#~ msgid "Help"
-#~ msgstr "Alîkarî"
-
 #~ msgid "Upgrade"
 #~ msgstr "Bilindkirin"
 
@@ -6151,18 +7784,12 @@ msgstr "_Hemû mîheng"
 #~ msgid "Send To..."
 #~ msgstr "Bişîne..."
 
-#~ msgid "Move to Trash"
-#~ msgstr "Biavêje Çopê"
-
 #, fuzzy
 #~ msgid "Find Now"
 #~ msgstr "Pencere"
 
 #~ msgid "Login"
 #~ msgstr "Teketin"
-
-#~ msgid "Logout"
-#~ msgstr "Derketin"
 
 #~ msgid "Boing"
 #~ msgstr "Boing"
@@ -6176,9 +7803,6 @@ msgstr "_Hemû mîheng"
 #, fuzzy
 #~ msgid "Beep"
 #~ msgstr "Xew"
-
-#~ msgid "No sound"
-#~ msgstr "Bêdeng"
 
 #, fuzzy
 #~ msgid "Sound not set for this event."
@@ -6246,9 +7870,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "Previous track key's shortcut."
 #~ msgstr "Kurteriya bişkoka perçeyê berî vêya."
 
-#~ msgid "Search's shortcut."
-#~ msgstr "Kurteriya lêgerînan."
-
 #~ msgid "Sleep"
 #~ msgstr "Xew"
 
@@ -6285,15 +7906,8 @@ msgstr "_Hemû mîheng"
 #~ msgstr "Dîmenderparêzê bide destpêkirin"
 
 #, fuzzy
-#~ msgid "Filter"
-#~ msgstr "Fîltre"
-
-#, fuzzy
 #~ msgid "Groups"
 #~ msgstr "_Groupwise:"
-
-#~ msgid "Common Tasks"
-#~ msgstr "Pewirên Asayî"
 
 #~ msgid "The GNOME configuration tool"
 #~ msgstr "Amûra veavakirinan ya GNOME"
@@ -6301,12 +7915,6 @@ msgstr "_Hemû mîheng"
 #, fuzzy
 #~ msgid "_Postpone Break"
 #~ msgstr "_Bêhnvedanê taloq bike"
-
-#~ msgid "/_Preferences"
-#~ msgstr "/_Vebijêrk"
-
-#~ msgid "/_About"
-#~ msgstr "/_Der barê"
 
 #~ msgid "/_Take a Break"
 #~ msgstr "/_ Bêhna Xwe Veke"
@@ -6354,9 +7962,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "usage: %s fontfile\n"
 #~ msgstr "bikaranîn: %s pelê curetîpan\n"
-
-#~ msgid "Sets the default application font"
-#~ msgstr "Curetîpa sepanê ya pêşdanasînî hilbijêre"
 
 #~ msgid "If set to true, then OpenType fonts will be thumbnailed."
 #~ msgstr ""
@@ -6446,9 +8051,6 @@ msgstr "_Hemû mîheng"
 #~ "Mijara ku te hilbijartiye curetîpeke nû pêşinyar dike. Pêşdîtina curetîpê "
 #~ "li jêr xuyadike."
 
-#~ msgid "_Apply font"
-#~ msgstr "Curetîp _bisepîne"
-
 #~ msgid "Themes"
 #~ msgstr "Dirb"
 
@@ -6529,20 +8131,11 @@ msgstr "_Hemû mîheng"
 #~ msgid "<b>Please type the passwords.</b>"
 #~ msgstr "<b>Ji kerema xwe şîfreyan binivîse.</b>"
 
-#~ msgid "Change Password"
-#~ msgstr "Şîfreyê Biguherîne"
-
 #~ msgid "Old pa_ssword:"
 #~ msgstr "Şîf_reya kevn:"
 
 #~ msgid "Assistive Technology Support"
 #~ msgstr "Desteka Teknolojiya Alîkar"
-
-#~ msgid "From:"
-#~ msgstr "Ji:"
-
-#~ msgid "To:"
-#~ msgstr "Ji kê re dişîne:"
 
 #~ msgid "Epiphany"
 #~ msgstr "Epiphany"
@@ -6586,9 +8179,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "Text Editor"
 #~ msgstr "Edîtorê Nivîsê"
 
-#~ msgid "Window Manager"
-#~ msgstr "Menajerê Paceyan"
-
 #~ msgid "_Properties..."
 #~ msgstr "_Taybetî..."
 
@@ -6609,9 +8199,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "Cursor Theme"
 #~ msgstr "Dirbê Nîşankerê"
-
-#~ msgid "Cursor Size:"
-#~ msgstr "Mezinahiya Nîşankerê:"
 
 #~ msgid ""
 #~ "Can not install themes. \n"
@@ -6659,9 +8246,6 @@ msgstr "_Hemû mîheng"
 #~ msgid "Short _description:"
 #~ msgstr "_Daxuyaniya kurt:"
 
-#~ msgid "Theme _Details"
-#~ msgstr "_Kîtekîtên Dirban"
-
 #~ msgid "_Go To Theme Folder"
 #~ msgstr "_Biçe Peldanka Dirban"
 
@@ -6690,17 +8274,8 @@ msgstr "_Hemû mîheng"
 #~ msgid "There was an error loading an image: %s"
 #~ msgstr "Dema wêne dihate barkirin çewtî çêbû:%s"
 
-#~ msgid "Event"
-#~ msgstr "Buyêr"
-
 #~ msgid "Sound File"
 #~ msgstr "Dosiyê Dengê"
-
-#~ msgid "_Sounds:"
-#~ msgstr "_Deng:"
-
-#~ msgid "Sound _file:"
-#~ msgstr "Dosiyê _Dengê"
 
 #~ msgid "_Play"
 #~ msgstr "_Bileyîze"
@@ -6733,9 +8308,6 @@ msgstr "_Hemû mîheng"
 
 #~ msgid "Keyboard Update Handlers"
 #~ msgstr "Pêkanînerê rojanenekirina klavyeyê"
-
-#~ msgid "Keyboard layout"
-#~ msgstr "Rengê klavyeyê"
 
 #~ msgid "Keyboard model"
 #~ msgstr "Modela klavyeyê"
@@ -6797,9 +8369,6 @@ msgstr "_Hemû mîheng"
 #~ msgstr ""
 #~ "<b>Xwînerê dîmender û mezinker</b> - <i>Hecedarî bi alîkariya zanistiyê "
 #~ "heye</i>"
-
-#~ msgid "Start"
-#~ msgstr "Destpêk"
 
 #~ msgid "Default sound card:"
 #~ msgstr "Karta deng ya pêşdanasînî:"

--- a/po/ku.po~
+++ b/po/ku.po~
@@ -1,0 +1,6833 @@
+# translation of gnome-control-center.HEAD.po to Kurdish
+# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) 2005 THE PACKAGE'S COPYRIGHT HOLDER.
+# Erdal Ronahi <erdal.ronahi@gmail.com>, 2005.
+# Erdal Ronahi <erdal.ronahi@gmail.com, pckurd@hotmail.com>, 2005.
+# Erdal Ronahî <erdal dot ronahi at gmail dot com>, 2011.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.HEAD\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2011-10-18 15:38+0200\n"
+"PO-Revision-Date: 2011-10-18 16:05+0200\n"
+"Last-Translator: Erdal Ronahî <erdal dot ronahi at gmail dot com>\n"
+"Language-Team: Kurdish Team http://pckurd.net\n"
+"Language: ku\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Virtaal 0.6.1\n"
+"X-Rosetta-Export-Date: 2007-03-04 16:18+0000\n"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "Rûerd"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change the background"
+msgstr "Rûerdî biguherîne"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Kaxiza dîwar;Dîmender;Sermasê;"
+
+#: ../panels/background/background.ui.h:1
+msgid "Add wallpaper"
+msgstr "Kaxiza dîwar lê zêde bike"
+
+#: ../panels/background/background.ui.h:2
+msgid "Center"
+msgstr "Navîn"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:4
+msgid "Changes throughout the day"
+msgstr ""
+
+#: ../panels/background/background.ui.h:5
+msgid "Fill"
+msgstr "Tijîkirin"
+
+#: ../panels/background/background.ui.h:6
+msgid "Remove wallpaper"
+msgstr "Kaxiza dîwar rake"
+
+#: ../panels/background/background.ui.h:7
+msgid "Scale"
+msgstr "Rêjekirî"
+
+#: ../panels/background/background.ui.h:8
+msgid "Span"
+msgstr ""
+
+#: ../panels/background/background.ui.h:9
+#, fuzzy
+msgid "Tile"
+msgstr "Raxistî"
+
+#: ../panels/background/background.ui.h:10
+msgid "Zoom"
+msgstr "Mezinkirin"
+
+#: ../panels/background/bg-colors-source.c:46
+msgid "Horizontal Gradient"
+msgstr "Derbasbûna Serpahnayê"
+
+#: ../panels/background/bg-colors-source.c:47
+msgid "Vertical Gradient"
+msgstr "Gradyana Tîkane"
+
+#: ../panels/background/bg-colors-source.c:48
+msgid "Solid Color"
+msgstr "Rengê Tampon"
+
+#: ../panels/background/cc-background-panel.c:1001
+#: ../panels/user-accounts/um-photo-dialog.c:217
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+msgid "Browse for more pictures"
+msgstr ""
+
+#: ../panels/background/cc-background-panel.c:1093
+#, fuzzy
+msgid "Current background"
+msgstr "Rûerdê Sermasê"
+
+#: ../panels/background/cc-background-panel.c:1203
+#, fuzzy
+msgid "Wallpapers"
+msgstr "Kaxiza Dîwar Tuneye"
+
+#: ../panels/background/cc-background-panel.c:1210
+msgid "Pictures Folder"
+msgstr ""
+
+#: ../panels/background/cc-background-panel.c:1217
+msgid "Colors & Gradients"
+msgstr ""
+
+#: ../panels/background/cc-background-panel.c:1225
+msgid "Flickr"
+msgstr "Flickr"
+
+#: ../panels/background/cc-background-item.c:148
+msgid "multiple sizes"
+msgstr ""
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:152
+#, c-format
+msgid "%d × %d"
+msgstr ""
+
+#: ../panels/background/cc-background-item.c:281
+msgid "No Desktop Background"
+msgstr "Rûerdê sermasê tunebe"
+
+#. Add some common languages first
+#: ../panels/common/cc-common-language.c:513
+msgid "English"
+msgstr "Îngilîzî"
+
+#: ../panels/common/cc-common-language.c:515
+msgid "British English"
+msgstr "Îngilîziya Brîtanyayê"
+
+#: ../panels/common/cc-common-language.c:517
+msgid "German"
+msgstr "Almanî"
+
+#: ../panels/common/cc-common-language.c:519
+msgid "French"
+msgstr "Fransî"
+
+#: ../panels/common/cc-common-language.c:521
+msgid "Spanish"
+msgstr "Spanî"
+
+#: ../panels/common/cc-common-language.c:523
+msgid "Chinese (simplified)"
+msgstr "Çîniya hêsankirî"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:552
+msgid "United States"
+msgstr "Dewletên Yekbuyî (yên Emerîqa)"
+
+#: ../panels/common/cc-common-language.c:553
+msgid "Germany"
+msgstr "Almanya"
+
+#: ../panels/common/cc-common-language.c:554
+msgid "France"
+msgstr "Fransa"
+
+#: ../panels/common/cc-common-language.c:555
+msgid "Spain"
+msgstr "Spanya"
+
+#: ../panels/common/cc-common-language.c:556
+msgid "China"
+msgstr "Çîn"
+
+#: ../panels/common/cc-language-chooser.c:119
+msgid "Other..."
+msgstr "Yên din..."
+
+#: ../panels/common/cc-language-chooser.c:290
+msgid "Select a region"
+msgstr "Herêm hilbijêre"
+
+#: ../panels/common/gdm-languages.c:774
+msgid "Unspecified"
+msgstr "Nediyar"
+
+#: ../panels/common/language-chooser.ui.h:1
+msgid "Select a language"
+msgstr "Zimanî hilbijêre"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/printers/new-printer-dialog.ui.h:4
+#: ../panels/user-accounts/um-user-panel.c:448
+msgid "_Cancel"
+msgstr "_Betal"
+
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/universal-access/gconf-property-editor.c:1609
+msgid "_Select"
+msgstr "_Hilbijartin"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "24-hour"
+msgstr ""
+
+#. Translator: this is the separator between hours and minutes, like in HH:MM
+#: ../panels/datetime/datetime.ui.h:3
+msgid ":"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "AM/PM"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "April"
+msgstr "nîsan"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "August"
+msgstr "tebax"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "Day"
+msgstr "roj"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "December"
+msgstr "kanûn"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "February"
+msgstr "sibat"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "January"
+msgstr "çile"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "July"
+msgstr "tîrmeh"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "June"
+msgstr "hezîran"
+
+#: ../panels/datetime/datetime.ui.h:13
+msgid "March"
+msgstr "adar"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "May"
+msgstr "gulan"
+
+#: ../panels/datetime/datetime.ui.h:15
+msgid "Month"
+msgstr "meh"
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "November"
+msgstr "mijdar"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "October"
+msgstr "cotmeh"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "September"
+msgstr "îlon"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Set the time one hour ahead."
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Set the time one hour back."
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Set the time one minute ahead."
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Set the time one minute back."
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Switch between AM and PM."
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Year"
+msgstr ""
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "_City:"
+msgstr "_Bajar:"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "_Network Time"
+msgstr "Dema _torê"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "_Region:"
+msgstr "_Herêm:"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Clock;Timezone;Location;"
+msgstr "Demjimêr;Herêma demê;Cih;"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+msgid "Date and Time"
+msgstr "Roj û dem"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Date and Time preferences panel"
+msgstr "Darikê vebijêrkên roj û demê"
+
+#: ../panels/display/display-capplet.ui.h:1
+#: ../panels/display/cc-display-panel.c:641
+msgid "Monitor"
+msgstr "Dîmender"
+
+#: ../panels/display/display-capplet.ui.h:2
+msgid "Note: may limit resolution options"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:3
+msgid "R_otation:"
+msgstr "Bi_nobedarî:"
+
+#: ../panels/display/display-capplet.ui.h:4
+msgid "_Detect Displays"
+msgstr ""
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:6
+msgid "_Mirror displays"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:7
+msgid "_Resolution:"
+msgstr "_Xuyakirin:"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Change resolution and position of monitors and projectors"
+msgstr ""
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Displays"
+msgstr "Dîmender"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:477
+msgctxt "display panel, rotation"
+msgid "Normal"
+msgstr "Asayî"
+
+#: ../panels/display/cc-display-panel.c:478
+msgctxt "display panel, rotation"
+msgid "Counterclockwise"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:479
+msgctxt "display panel, rotation"
+msgid "Clockwise"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:480
+msgctxt "display panel, rotation"
+msgid "180 Degrees"
+msgstr ""
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../panels/display/cc-display-panel.c:617
+msgid "Mirror Displays"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:747
+#, c-format
+msgid "%d x %d (%s)"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:749
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:1656
+msgid "Drag to change primary display."
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:1714
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2102
+msgid "%a %R"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2104
+msgid "%a %l:%M %p"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2350
+#, fuzzy
+msgid "Could not save the monitor configuration"
+msgstr "Dirûvê navîn yê mak nehate barkirin"
+
+#: ../panels/display/cc-display-panel.c:2375
+msgid "Could not get session bus while applying display configuration"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2420
+msgid "Could not detect displays"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2614
+#, fuzzy
+msgid "Could not get screen information"
+msgstr "Xuyakirina dîmender biguherîne"
+
+#. Translators: VESA is an techncial acronym, don't translate it.
+#: ../panels/info/cc-info-panel.c:402
+#, c-format
+msgid "VESA: %s"
+msgstr ""
+
+#. TRANSLATORS: device type
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:426 ../panels/network/panel-common.c:79
+#: ../panels/network/panel-common.c:158
+msgid "Unknown"
+msgstr "Nenas"
+
+#. translators: This is the type of architecture, for example:
+#. * "64-bit" or "32-bit"
+#: ../panels/info/cc-info-panel.c:587
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:744
+#, fuzzy
+msgid "Unknown model"
+msgstr "Nîşankereke Nenas"
+
+#: ../panels/info/cc-info-panel.c:827
+msgid "The next login will attempt to use the standard experience."
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:829
+msgid ""
+"The next login will use the fallback mode intended for unsupported graphics "
+"hardware."
+msgstr ""
+
+#. translators: The hardware is not able to run GNOME 3's
+#. * shell, so we use the GNOME "Fallback" session
+#: ../panels/info/cc-info-panel.c:871
+#, fuzzy
+msgctxt "Experience"
+msgid "Fallback"
+msgstr "Careke din bang bike"
+
+#. translators: The hardware is able to run GNOME 3's
+#. * shell, also called "Standard" experience
+#: ../panels/info/cc-info-panel.c:877
+#, fuzzy
+msgctxt "Experience"
+msgid "Standard"
+msgstr "Termînala Xê ya Standart"
+
+#: ../panels/info/cc-info-panel.c:1200
+msgid "Ask what to do"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1204
+msgid "Do nothing"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1208
+#, fuzzy
+msgid "Open folder"
+msgstr "Peldanka mal"
+
+#: ../panels/info/cc-info-panel.c:1319
+#, fuzzy
+msgid "Select an application for audio CDs"
+msgstr "Sepanên xwe yên pêşdanasînî hilbijêre"
+
+#: ../panels/info/cc-info-panel.c:1320
+#, fuzzy
+msgid "Select an application for video DVDs"
+msgstr "Sepanên xwe yên pêşdanasînî hilbijêre"
+
+#: ../panels/info/cc-info-panel.c:1321
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1322
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1323
+#, fuzzy
+msgid "Select an application for software CDs"
+msgstr "Wekî Curenivîsa Bernameyê Mîheng Bike"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1335
+msgid "audio DVD"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1336
+msgid "blank Blu-ray disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1337
+msgid "blank CD disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1338
+msgid "blank DVD disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1339
+msgid "blank HD DVD disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1340
+msgid "Blu-ray video disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1341
+msgid "e-book reader"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1342
+msgid "HD DVD video disc"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1343
+msgid "Picture CD"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1344
+msgid "Super Video CD"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1345
+msgid "Video CD"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1474
+#: ../panels/keyboard/keyboard-shortcuts.c:1772
+msgid "Section"
+msgstr "Beş"
+
+#: ../panels/info/cc-info-panel.c:1483 ../panels/info/info.ui.h:15
+#, fuzzy
+msgid "Overview"
+msgstr "Pêşdîtin:"
+
+#: ../panels/info/cc-info-panel.c:1489 ../panels/info/info.ui.h:4
+msgid "Default Applications"
+msgstr "Sepanên standard"
+
+#: ../panels/info/cc-info-panel.c:1494 ../panels/info/info.ui.h:17
+msgid "Removable Media"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1499 ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "Grafîk"
+
+#: ../panels/info/cc-info-panel.c:1700
+#, c-format
+msgid "Version %s"
+msgstr "Guhertoya %s"
+
+#: ../panels/info/cc-info-panel.c:1750
+msgid "Install Updates"
+msgstr "Rojanekirinan saz bike"
+
+#: ../panels/info/cc-info-panel.c:1754
+msgid "System Up-To-Date"
+msgstr "Pergal rojane ye"
+
+#: ../panels/info/cc-info-panel.c:1758
+msgid "Checking for Updates"
+msgstr "Rojanekirin tê kontrolkirin"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+msgid "System Info"
+msgstr "Agahiyên pergalî"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "System Information"
+msgstr "Agahiyên pergalî"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: ../panels/info/info.ui.h:1
+msgid "Acti_on:"
+msgstr "Çala_kî:"
+
+#: ../panels/info/info.ui.h:2
+msgid "CD _audio:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:3
+#, fuzzy
+msgid "Calculating..."
+msgstr "Girêdide..."
+
+#: ../panels/info/info.ui.h:5
+msgid "Device name"
+msgstr "Navê alavê"
+
+#: ../panels/info/info.ui.h:6
+msgid "Disk"
+msgstr "Dîsk"
+
+#: ../panels/info/info.ui.h:7
+msgid "Driver"
+msgstr "Ajoger"
+
+#: ../panels/info/info.ui.h:8
+msgid "Experience"
+msgstr ""
+
+#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
+#: ../panels/info/info.ui.h:10
+msgid "Forced _Fallback Mode"
+msgstr ""
+
+#: ../panels/info/info.ui.h:12
+msgid "M_usic"
+msgstr "Mûzîk"
+
+#: ../panels/info/info.ui.h:13
+msgid "Memory"
+msgstr "Bîr"
+
+#: ../panels/info/info.ui.h:14
+msgid "OS type"
+msgstr ""
+
+#: ../panels/info/info.ui.h:16
+msgid "Processor"
+msgstr ""
+
+#: ../panels/info/info.ui.h:18
+msgid "Select how media should be handled"
+msgstr ""
+
+#: ../panels/info/info.ui.h:19
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: ../panels/info/info.ui.h:20
+msgid "_Calendar"
+msgstr "Sal_name"
+
+#: ../panels/info/info.ui.h:21
+msgid "_DVD video:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:22
+msgid "_Mail"
+msgstr "_Posta"
+
+#: ../panels/info/info.ui.h:23
+msgid "_Music player:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:24
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: ../panels/info/info.ui.h:25
+msgid "_Other Media..."
+msgstr ""
+
+#: ../panels/info/info.ui.h:26
+msgid "_Photos"
+msgstr ""
+
+#: ../panels/info/info.ui.h:27
+msgid "_Photos:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:28
+msgid "_Software:"
+msgstr ""
+
+#: ../panels/info/info.ui.h:29
+msgid "_Type:"
+msgstr "_Cure:"
+
+#: ../panels/info/info.ui.h:30
+msgid "_Video"
+msgstr ""
+
+#: ../panels/info/info.ui.h:31
+msgid "_Web"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Eject"
+msgstr "Bavêje"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+#, fuzzy
+msgid "Launch media player"
+msgstr "Jimêreyê bide xebitandin"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#, fuzzy
+msgid "Next track"
+msgstr "Here parçeyê din"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#, fuzzy
+msgid "Pause playback"
+msgstr "Dîsa lêdana deng:"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Play (or play/pause)"
+msgstr "Lê bide (an jî lê bide/rawestîne)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#, fuzzy
+msgid "Previous track"
+msgstr "Vegere parçeyê berê"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Sound and Media"
+msgstr "Deng û medya"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "Rawestandina lêdanê"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Volume down"
+msgstr "Deng kêm bike"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Volume mute"
+msgstr "Deng bibire"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Volume up"
+msgstr "Deng zêde bike"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Home folder"
+msgstr "Peldanka mal"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch calculator"
+msgstr "Jimêreyê bide xebitandin"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3
+#, fuzzy
+msgid "Launch email client"
+msgstr "Jimêreyê bide xebitandin"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch help browser"
+msgstr "Gerokê alîkariyê veke"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch web browser"
+msgstr "Geroka webê veke"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+#, fuzzy
+msgid "Launchers"
+msgstr "Geroka webê veke"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Search"
+msgstr "Lê bigere"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "Lock screen"
+msgstr "Ekranê qifil bike"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Derkeve"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+#: ../panels/region/gnome-region-panel.ui.h:24
+msgid "System"
+msgstr "Pergal"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+msgid "Decrease text size"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Increase text size"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#, fuzzy
+msgid "Magnifier zoom in"
+msgstr "_Girdok"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#, fuzzy
+msgid "Magnifier zoom out"
+msgstr "_Girdok"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#, fuzzy
+msgid "Toggle contrast"
+msgstr "_Tarîbûna herî baş"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#, fuzzy
+msgid "Toggle magnifier"
+msgstr "_Girdok"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#, fuzzy
+msgid "Toggle on-screen keyboard"
+msgstr "Klavyeya _dîmenderê"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#, fuzzy
+msgid "Toggle screen reader"
+msgstr "_Xwînerê dîmenderê"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
+msgid "Universal Access"
+msgstr ""
+
+#: ../panels/keyboard/eggcellrendererkeys.c:21
+#, fuzzy
+msgid "New shortcut..."
+msgstr "Kurteriya derxe."
+
+#: ../panels/keyboard/eggcellrendererkeys.c:164
+#: ../panels/keyboard/eggcellrendererkeys.c:165
+msgid "Accelerator key"
+msgstr "Bişkoka Lezker"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:174
+#: ../panels/keyboard/eggcellrendererkeys.c:175
+msgid "Accelerator modifiers"
+msgstr "Sererastkerên lezkeran"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:183
+#: ../panels/keyboard/eggcellrendererkeys.c:184
+msgid "Accelerator keycode"
+msgstr "Koda bişkokên lezkeran"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:194
+msgid "Accel Mode"
+msgstr "Moda Lezandinê"
+
+#: ../panels/keyboard/eggcellrendererkeys.c:195
+msgid "The type of accelerator."
+msgstr "Cureyê Lezkeran"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/eggcellrendererkeys.c:243
+#: ../panels/keyboard/keyboard-shortcuts.c:1193
+#: ../panels/sound/gvc-mixer-control.c:1086
+#: ../panels/user-accounts/um-fingerprint-dialog.c:177
+#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+msgid "Disabled"
+msgstr "Neçalak"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+#, fuzzy
+msgid "Change keyboard settings"
+msgstr "Taybetmendiyên Rûerd yên Sermasê Biguherîne"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "Keyboard"
+msgstr "Klavye"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:646
+#: ../panels/keyboard/keyboard-shortcuts.c:654
+#: ../panels/keyboard/keyboard-shortcuts.c:968
+#: ../panels/keyboard/keyboard-shortcuts.c:1566
+#: ../panels/keyboard/keyboard-shortcuts.c:1570
+#, fuzzy
+msgid "Custom Shortcuts"
+msgstr "Kurterê"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:814
+msgid "<Unknown Action>"
+msgstr "<Çalakiya nenas>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1219
+msgid "Error saving the new shortcut"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1352
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1382
+#, fuzzy, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"Kurteriya \"%s\" ji bo vî karî tê bikaranîn:\n"
+"\"%s\"\n"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1387
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1393
+msgid "_Reassign"
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1505
+#, fuzzy
+msgid "Too many custom shortcuts"
+msgstr "Kurteriya deng zêde bike."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1825
+msgid "Action"
+msgstr "Çalakî"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1848
+msgid "Shortcut"
+msgstr "Kurterê"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "C_ommand:"
+msgstr "_Ferman:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>Nîşankerê vêxistin/vemirandê</b>"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#, fuzzy
+msgid "Cursor _blinks in text fields"
+msgstr "Nîşan_kerê vêxistin/vemirandê di qutiyên nivîsan û qadan de"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Cursor blinks speed"
+msgstr "Nîşanek"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+#, fuzzy
+msgid "Custom Shortcut"
+msgstr "Kurterê"
+
+#. fast acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Fast"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "Dema bişkoj _pêlêkirî be bila klavye dubare bike"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+#, fuzzy
+msgid "Layout Settings"
+msgstr "Mîhengên Pêşdanasînî"
+
+#. long delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+#: ../panels/universal-access/uap.ui.h:38
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Long"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Bişkokên Dubarekirinê</b>"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "Leza dubarekirina bişkokan"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgid "S_peed:"
+msgstr "_Lez:"
+
+#. short delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+#: ../panels/mouse/gnome-mouse-properties.ui.h:23
+#: ../panels/universal-access/uap.ui.h:53
+#: ../panels/universal-access/zoom-options.ui.h:22
+#, fuzzy
+msgid "Short"
+msgstr "Kurterê"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Kurterê"
+
+#. slow acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+#: ../panels/mouse/gnome-mouse-properties.ui.h:25
+msgid "Slow"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+#, fuzzy
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"Ji bo guherandina bişkokên kurteriyan, pêl rêzika guncav bike û pêl bişkokên "
+"kurteriya nû bike, yan jî bi backspace kurteriya heyî jê bibe."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+#: ../panels/universal-access/uap.ui.h:65
+#, fuzzy
+msgid "Typing"
+msgstr "Bêhnvedana Nivîsînê"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+msgid "_Delay:"
+msgstr "_Derengmayîn:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+msgid "_Name:"
+msgstr "_Nav:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "_Speed:"
+msgstr "_Lez:"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:305
+msgid "Error logging into the account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:351
+msgid "Expired credentials. Please log in again."
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:354
+msgid "_Log In"
+msgstr ""
+
+#. translators: This is the title of the "Add Account" dialogue.
+#. * The title is not visible when using GNOME Shell
+#: ../panels/online-accounts/cc-online-accounts-panel.c:461
+msgid "Add Account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:466
+msgid "To add a new account, first select the account type"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:469
+#, fuzzy
+msgid "Account Type:"
+msgstr "Cureyê Hişyariyê"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Add..."
+msgstr "_Têxê..."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:555
+#, fuzzy
+msgid "Error creating account"
+msgstr "Dema veavakirin dihate tomarkirin çewtî: %s"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:589
+#, fuzzy
+msgid "Error removing account"
+msgstr "Dema veavakirin dihate tomarkirin çewtî: %s"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:625
+#, fuzzy
+msgid "Are you sure you want to remove the account?"
+msgstr "Tu dixwazî van xuyakirinan tomar bikî?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:627
+msgid "This will not remove the account on the server."
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:628
+msgid "_Remove"
+msgstr "_Rakirin"
+
+#. Translators: those are keywords for the online-accounts control-center panel
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+msgstr ""
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
+msgid "Manage online accounts"
+msgstr ""
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid "Online Accounts"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "Select an account"
+msgstr "Hesabekê hilbijêre"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:520
+msgid "Low on toner"
+msgstr ""
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:522
+msgid "Out of toner"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:525
+msgid "Low on developer"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:528
+msgid "Out of developer"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:530
+msgid "Low on a marker supply"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:532
+msgid "Out of a marker supply"
+msgstr ""
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:534
+#, fuzzy
+msgid "Open cover"
+msgstr "Pelî Veke"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:536
+msgid "Open door"
+msgstr ""
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:538
+msgid "Low on paper"
+msgstr ""
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:540
+msgid "Out of paper"
+msgstr ""
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:542
+msgctxt "printer state"
+msgid "Offline"
+msgstr ""
+
+#. Translators: Someone has paused the Printer
+#: ../panels/printers/cc-printers-panel.c:544
+#, fuzzy
+msgctxt "printer state"
+msgid "Paused"
+msgstr "Navber"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:546
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:548
+msgid "Waste receptacle full"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:550
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:552
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:724
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Amade"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:728
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Tê xebitandin"
+
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Rawestandî"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:851
+msgid "Toner Level"
+msgstr ""
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:854
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:857
+#, fuzzy
+msgid "Supply Level"
+msgstr "Dirb bi kar bîne"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:872
+#: ../panels/printers/cc-printers-panel.c:1258
+#, fuzzy, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "_Neçalak bike"
+msgstr[1] "_Neçalak bike"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:977
+msgid "No printers available"
+msgstr ""
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/cc-printers-panel.c:1301
+msgctxt "print job"
+msgid "Pending"
+msgstr ""
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/cc-printers-panel.c:1305
+msgctxt "print job"
+msgid "Held"
+msgstr ""
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/cc-printers-panel.c:1309
+#, fuzzy
+msgctxt "print job"
+msgid "Processing"
+msgstr "_Pisporî:"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/cc-printers-panel.c:1313
+msgctxt "print job"
+msgid "Stopped"
+msgstr ""
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/cc-printers-panel.c:1317
+msgctxt "print job"
+msgid "Canceled"
+msgstr ""
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/cc-printers-panel.c:1321
+msgctxt "print job"
+msgid "Aborted"
+msgstr ""
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/cc-printers-panel.c:1325
+msgctxt "print job"
+msgid "Completed"
+msgstr ""
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/cc-printers-panel.c:1408
+#, fuzzy
+msgid "Job Title"
+msgstr "_Sernav:"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/cc-printers-panel.c:1417
+msgid "Job State"
+msgstr ""
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/cc-printers-panel.c:1423
+#, fuzzy
+msgid "Time"
+msgstr "-Dembûrî:"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:2019
+msgid "Failed to add new printer."
+msgstr ""
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2223
+#: ../panels/printers/cc-printers-panel.c:2237
+#, fuzzy
+msgid "Test page"
+msgstr "Ceribandin"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2484
+#, fuzzy, c-format
+msgid "Could not load ui: %s"
+msgstr "Dirûvê navîn yê mak nehate barkirin"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#, fuzzy
+msgid "Change printer settings"
+msgstr "Taybetmendiyên Rûerd yên Sermasê Biguherîne"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: ../panels/printers/pp-new-printer-dialog.c:148
+msgid "Printers"
+msgstr "Çaper"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "A_ddress:"
+msgstr "_Navnîşan:"
+
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#, fuzzy
+msgid "Add a New Printer"
+msgstr "Nîşankerê Mezin"
+
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#, fuzzy
+msgid "_Add"
+msgstr "_Têxê..."
+
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "_Search by Address"
+msgstr ""
+
+#: ../panels/printers/pp-new-printer-dialog.c:654
+msgid "Getting devices..."
+msgstr ""
+
+#. Translators: No localy connected printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1230
+msgid "No local printers found"
+msgstr ""
+
+#. Translators: No network printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1243
+msgid "No network printers found"
+msgstr ""
+
+#: ../panels/printers/pp-new-printer-dialog.c:1335
+msgid ""
+"FirewallD is not running. Network printer detection needs services mdns, "
+"ipp, ipp-client and samba-client enabled on firewall."
+msgstr ""
+
+#. Translators: Column of devices which can be installed
+#: ../panels/printers/pp-new-printer-dialog.c:1363
+#: ../panels/printers/pp-new-printer-dialog.c:1368
+msgid "Devices"
+msgstr "Alav"
+
+#. Translators: Local means local printers
+#: ../panels/printers/pp-new-printer-dialog.c:1393
+msgctxt "printer type"
+msgid "Local"
+msgstr "Herêmî"
+
+#. Translators: Network means network printers
+#: ../panels/printers/pp-new-printer-dialog.c:1395
+msgctxt "printer type"
+msgid "Network"
+msgstr "Tor"
+
+#. Translators: Device types column (network or local)
+#: ../panels/printers/pp-new-printer-dialog.c:1436
+msgid "Device types"
+msgstr "Cureyên alavan"
+
+#. Translators: Name of job which makes printer to autoconfigure itself
+#: ../panels/printers/pp-new-printer-dialog.c:1737
+msgid "Automatic configuration"
+msgstr "Mîhengên bixweber"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1818
+msgid "Opening firewall for mDNS connections"
+msgstr ""
+
+#: ../panels/printers/pp-new-printer-dialog.c:1827
+msgid "Opening firewall for Samba connections"
+msgstr ""
+
+#: ../panels/printers/pp-new-printer-dialog.c:1836
+msgid "Opening firewall for IPP connections"
+msgstr ""
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:2
+msgid "Active Print Jobs"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:4
+msgid "Add New Printer"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:5
+msgid "Allowed users"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:6
+#: ../panels/network/cc-network-panel.c:1990
+#: ../panels/network/cc-network-panel.c:1993 ../panels/network/network.ui.h:11
+msgid "IP Address"
+msgstr "Navnîşana IP"
+
+#: ../panels/printers/printers.ui.h:7
+msgid "Jobs"
+msgstr "Kar"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:9
+msgid "Location"
+msgstr "Cih"
+
+#: ../panels/printers/printers.ui.h:10
+#, fuzzy
+msgid "Model"
+msgstr "Model"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:12
+msgid "Print _Test Page"
+msgstr ""
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:14
+#, fuzzy
+msgid "Printer Options"
+msgstr "Vebijêrk"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:16
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:19
+msgid "Supply"
+msgstr ""
+
+#. Translators: Switch back to printer's info tab
+#: ../panels/printers/printers.ui.h:21
+msgid "_Back"
+msgstr ""
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:23
+#, fuzzy
+msgid "_Default"
+msgstr "Wekî heyî"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:25
+#, fuzzy
+msgid "_Options"
+msgstr "Vebijêrk"
+
+#. Tanslators: Switch to tab containing printer's jobs
+#: ../panels/printers/printers.ui.h:27
+msgid "_Show"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-formats.c:142
+msgid "Imperial"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-formats.c:144
+msgid "Metric"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
+msgid "Choose a Layout"
+msgstr "Nexşeya Bişkokan Hilbijêre"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
+#, fuzzy
+msgid "Preview"
+msgstr "Pêşdîtin:"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
+msgid "Select an input source to add"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
+#, fuzzy
+msgid "Keyboard Layout Options"
+msgstr "Bijarekên klavye"
+
+#: ../panels/region/gnome-region-panel.ui.h:1
+msgid "Allow different layouts for individual windows"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:2
+#: ../panels/region/gnome-region-panel-system.c:406
+#, fuzzy
+msgid "Copy Settings..."
+msgstr "Girêdide..."
+
+#: ../panels/region/gnome-region-panel.ui.h:3
+msgid "Currency"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:4
+msgid "Dates"
+msgstr "Roj"
+
+#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
+#: ../panels/region/gnome-region-panel.ui.h:6
+msgid "Display language:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:7
+msgid "Examples"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:8
+#, fuzzy
+msgid "Format:"
+msgstr "asayî"
+
+#: ../panels/region/gnome-region-panel.ui.h:9
+#, fuzzy
+msgid "Formats"
+msgstr "asayî"
+
+#: ../panels/region/gnome-region-panel.ui.h:10
+msgid "Input source:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:11
+#, fuzzy
+msgid "Install languages..."
+msgstr "Dirban _Saz Bike..."
+
+#: ../panels/region/gnome-region-panel.ui.h:12
+msgid "Language"
+msgstr "Ziman"
+
+#: ../panels/region/gnome-region-panel.ui.h:13
+msgid "Layouts"
+msgstr "Pergal"
+
+#: ../panels/region/gnome-region-panel.ui.h:14
+msgid "Measurement"
+msgstr "Pîvan"
+
+#: ../panels/region/gnome-region-panel.ui.h:15
+msgid "New windows use the default layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:16
+msgid "New windows use the previous window's layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:17
+msgid "Numbers"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:18
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Region and Language"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:19
+msgid ""
+"Replace the current keyboard layout settings with the\n"
+"default settings"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:21
+#, fuzzy
+msgid "Reset to De_faults"
+msgstr "Vegere S_tandardan"
+
+#: ../panels/region/gnome-region-panel.ui.h:22
+msgid "Select a display language (change will be applied next time you log in)"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:23
+msgid "Select a region (change will be applied the next time you log in)"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:25
+#, fuzzy
+msgid "System settings"
+msgstr "Mîhengên X bikar bîne"
+
+#: ../panels/region/gnome-region-panel.ui.h:26
+#: ../panels/region/gnome-region-panel-system.c:400
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings. You may change the system settings to match "
+"yours."
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:27
+msgid "Times"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:28
+msgid "Use the same layout for all windows"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:29
+msgid "View and edit keyboard layout options"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:30
+#, fuzzy
+msgid "Your settings"
+msgstr "Mîhengên X bikar bîne"
+
+#: ../panels/region/gnome-region-panel.ui.h:31
+#, fuzzy
+msgid "_Options..."
+msgstr "Vebijêrk"
+
+#: ../panels/region/gnome-region-panel-system.c:395
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings."
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-system.c:403
+#, fuzzy
+msgid "Copy Settings"
+msgstr "Mîheng"
+
+#: ../panels/region/gnome-region-panel-xkblt.c:210
+msgid "Layout"
+msgstr "Bicihkirin"
+
+#: ../panels/region/gnome-region-panel-xkbot.c:229
+#: ../panels/sound/gvc-sound-theme-chooser.c:586
+msgid "Default"
+msgstr "Wekî heyî"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#, fuzzy
+msgid "Change your region and language settings"
+msgstr "Taybetmendiyên Rûerd yên Sermasê Biguherîne"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
+msgid "Language;Layout;Keyboard;"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+#, fuzzy
+msgid "A_cceleration:"
+msgstr "_Lezkirin:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Disable _touchpad while typing"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+#, fuzzy
+msgid "Double-Click Timeout"
+msgstr "<b>Navbera Demê ya Tikandina Cot</b>"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+#, fuzzy
+msgid "Drag and Drop"
+msgstr "<b>Xwêr Bikşîne Berde</b>"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Enable _mouse clicks with touchpad"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Enable h_orizontal scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "General"
+msgstr "Giştî"
+
+#. high sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgid "High"
+msgstr ""
+
+#. large threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Large"
+msgstr "Mezin"
+
+#. low sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Low"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Mouse"
+msgstr "Mişk"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+msgid "Mouse Preferences"
+msgstr "Vebijêrkên mikşê"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+#, fuzzy
+msgid "Pointer Speed"
+msgstr "Dirbê nîşanekê"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:21
+msgid "Scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:22
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr ""
+
+#. small threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:27
+#: ../panels/universal-access/uap.ui.h:57
+msgid "Small"
+msgstr "Biçûk"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:28
+#, fuzzy
+msgid "Thr_eshold:"
+msgstr "_Dergeh:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:29
+msgid "To test your settings, try to double-click on the face."
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:30
+msgid "Touchpad"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:31
+msgid "Two-_finger scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:32
+msgid "_Disabled"
+msgstr "_Neçalak"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:33
+msgid "_Edge scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:34
+#, fuzzy
+msgid "_Left-handed"
+msgstr "_Mişkê destê çepê"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:35
+msgid "_Right-handed"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:36
+msgid "_Sensitivity:"
+msgstr "_Hestyarî:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:37
+msgid "_Timeout:"
+msgstr "-Dembûrî:"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse and Touchpad"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your mouse and touchpad preferences"
+msgstr "Tercîhên mişk bike"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr ""
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/cc-network-panel.c:269
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/cc-network-panel.c:277
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#. TRANSLATORS: this is when the access point is not listed
+#. * in the dropdown (or hidden) and the user has to select
+#. * another entry manually
+#: ../panels/network/cc-network-panel.c:949
+msgctxt "Wireless access point"
+msgid "Other..."
+msgstr "Yekê din..."
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/cc-network-panel.c:1107
+#: ../panels/network/cc-network-panel.c:1514
+msgid "WEP"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:1111
+#: ../panels/network/cc-network-panel.c:1518
+msgid "WPA"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:1115
+msgid "WPA2"
+msgstr ""
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/cc-network-panel.c:1120
+msgid "Enterprise"
+msgstr ""
+
+#. TRANSLATORS: this no (!) WiFi security
+#: ../panels/network/cc-network-panel.c:1126
+#: ../panels/network/cc-network-panel.c:1509
+#: ../panels/universal-access/uap.ui.h:43
+#: ../panels/universal-access/zoom-options.ui.h:16
+#, fuzzy
+msgid "None"
+msgstr "_Tune"
+
+#: ../panels/network/cc-network-panel.c:1577
+msgid "Hotspot"
+msgstr ""
+
+#. Translators: network device speed
+#: ../panels/network/cc-network-panel.c:1643
+#: ../panels/network/cc-network-panel.c:1731
+#, c-format
+msgid "%d Mb/s"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:1986 ../panels/network/network.ui.h:12
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Navnîşan"
+
+#: ../panels/network/cc-network-panel.c:1987 ../panels/network/network.ui.h:13
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Navnîşan"
+
+#: ../panels/network/cc-network-panel.c:2040
+#: ../panels/network/cc-network-panel.c:2413
+#, c-format
+msgid "%s VPN"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:2148
+#, fuzzy
+msgid "Proxy"
+msgstr "Cîgirê _FTPê:"
+
+#: ../panels/network/cc-network-panel.c:2222
+#, fuzzy
+msgid "Network proxy"
+msgstr "Cîgirê Toreyê"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:2480
+msgid "The system network services are not compatible with this version."
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3095
+#, fuzzy
+msgid "Not connected to the internet."
+msgstr "Nehate girêdan"
+
+#: ../panels/network/cc-network-panel.c:3096
+msgid "Create the hotspot anyway?"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3114
+#, c-format
+msgid "Disconnect from %s and create a new hotspot?"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3117
+msgid "This is your only connection to the internet."
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3135
+msgid "Create _Hotspot"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3195
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3198
+msgid "_Stop Hotspot"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#, fuzzy
+msgid "Network"
+msgstr "Cîgirê Toreyê"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+#, fuzzy
+msgid "Network settings"
+msgstr "Mîhengên X bikar bîne"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid "Network;Wireless;IP;LAN;"
+msgstr ""
+
+#: ../panels/network/network.ui.h:1
+msgid "Air_plane Mode"
+msgstr ""
+
+#: ../panels/network/network.ui.h:2
+#, fuzzy
+msgid "Create..."
+msgstr "Nav biguherîne..."
+
+#: ../panels/network/network.ui.h:3
+msgid "DNS"
+msgstr ""
+
+#: ../panels/network/network.ui.h:4
+#, fuzzy
+msgid "Default Route"
+msgstr "Nîşankerê bi Pêşdanasîn"
+
+#: ../panels/network/network.ui.h:5
+msgid "Gateway"
+msgstr ""
+
+#: ../panels/network/network.ui.h:6
+msgid "Group Name"
+msgstr "Navê komê"
+
+#: ../panels/network/network.ui.h:7
+msgid "Group Password"
+msgstr "Şî_freya komê"
+
+#: ../panels/network/network.ui.h:8
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "Cîgirê H_TTPê"
+
+#: ../panels/network/network.ui.h:9
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Navnîşan"
+
+#: ../panels/network/network.ui.h:10
+msgid "IMEI"
+msgstr ""
+
+#: ../panels/network/network.ui.h:14
+#, fuzzy
+msgid "Interface"
+msgstr "Înternet"
+
+#: ../panels/network/network.ui.h:15
+#, fuzzy
+msgid "Network Name"
+msgstr "Cîgirê Toreyê"
+
+#: ../panels/network/network.ui.h:16
+msgid "Provider"
+msgstr ""
+
+#: ../panels/network/network.ui.h:17
+msgid "Security"
+msgstr "Ewlehî"
+
+#: ../panels/network/network.ui.h:18
+msgid "Security Key"
+msgstr "Mifteya ewlehiyê"
+
+#: ../panels/network/network.ui.h:19
+msgid "Select the interface to use for the new service"
+msgstr ""
+
+#: ../panels/network/network.ui.h:20
+#, fuzzy
+msgid "Speed"
+msgstr "_Lez:"
+
+#: ../panels/network/network.ui.h:21
+msgid "Subnet Mask"
+msgstr ""
+
+#: ../panels/network/network.ui.h:22
+msgid "Unlock"
+msgstr ""
+
+#: ../panels/network/network.ui.h:23
+#, fuzzy
+msgid "Username"
+msgstr "N_avê Bikarhêner:"
+
+#: ../panels/network/network.ui.h:24
+msgid "VPN"
+msgstr ""
+
+#: ../panels/network/network.ui.h:25
+#, fuzzy
+msgid "VPN Type"
+msgstr "Cure"
+
+#: ../panels/network/network.ui.h:26
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "_URLya veavakirina bixweber:"
+
+#: ../panels/network/network.ui.h:27
+msgid "_Configure..."
+msgstr ""
+
+#: ../panels/network/network.ui.h:28
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "Cîgirê _FTPê:"
+
+#: ../panels/network/network.ui.h:29
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "Cîgirê H_TTPê"
+
+#: ../panels/network/network.ui.h:30
+#, fuzzy
+msgid "_Method"
+msgstr "Meta"
+
+#: ../panels/network/network.ui.h:31
+#, fuzzy
+msgid "_Network Name"
+msgstr "Cîgirê Toreyê"
+
+#: ../panels/network/network.ui.h:32
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Makîneya S_ocks:"
+
+#: ../panels/network/network.ui.h:33
+msgid "_Stop Hotspot..."
+msgstr ""
+
+#: ../panels/network/network.ui.h:34
+msgid "_Use as Hotspot..."
+msgstr ""
+
+#: ../panels/network/network.ui.h:35
+#, fuzzy
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "_Belgekirin"
+
+#: ../panels/network/network.ui.h:36
+msgctxt "proxy method"
+msgid "Manual"
+msgstr ""
+
+#: ../panels/network/network.ui.h:37
+#, fuzzy
+msgctxt "proxy method"
+msgid "None"
+msgstr "_Tune"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:83
+msgid "Wired"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:87
+msgid "Wireless"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:94
+msgid "Mobile broadband"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:99
+msgid "Bluetooth"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:103
+msgid "Mesh"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:162
+msgid "Ad-hoc"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:166
+msgid "Infrastructure"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:190 ../panels/network/panel-common.c:251
+msgid "Status unknown"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:194
+msgid "Unmanaged"
+msgstr ""
+
+#: ../panels/network/panel-common.c:199
+msgid "Firmware missing"
+msgstr ""
+
+#: ../panels/network/panel-common.c:202
+msgid "Cable unplugged"
+msgstr ""
+
+#: ../panels/network/panel-common.c:204
+msgid "Unavailable"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:208
+#, fuzzy
+msgid "Disconnected"
+msgstr "Nehate girêdan"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:215 ../panels/network/panel-common.c:257
+#, fuzzy
+msgid "Connecting"
+msgstr "Girêdide..."
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
+#, fuzzy
+msgid "Authentication required"
+msgstr "Belgekirî!"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
+#, fuzzy
+msgid "Connected"
+msgstr "Nehate girêdan"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:227
+#, fuzzy
+msgid "Disconnecting"
+msgstr "Girêdide..."
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:231 ../panels/network/panel-common.c:269
+#, fuzzy
+msgid "Connection failed"
+msgstr "Sazkirin Ne Serketî ye"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:277
+msgid "Status unknown (missing)"
+msgstr ""
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:273
+msgid "Not connected"
+msgstr "Nehate girêdan"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr ""
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Power management settings"
+msgstr ""
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:160
+#, fuzzy
+msgid "Unknown time"
+msgstr "Nîşankereke Nenas"
+
+#: ../panels/power/cc-power-panel.c:166
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "xulek"
+msgstr[1] "xulek"
+
+#: ../panels/power/cc-power-panel.c:178
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:186
+#, c-format
+msgid "%i %s %i %s"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:187
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/power/cc-power-panel.c:188
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "xulek"
+msgstr[1] "xulek"
+
+#: ../panels/power/cc-power-panel.c:265
+msgid "Battery charging"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:268
+msgid "Battery discharging"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:279
+msgid "UPS charging"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:282
+msgid "UPS discharging"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:300
+#, c-format
+msgid "%s until charged (%.0lf%%)"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:306
+#, c-format
+msgid "%s until empty (%.0lf%%)"
+msgstr ""
+
+#. TRANSLATORS: %1 is a percentage value. Note: this string is only
+#. * used when we don't have a time value
+#: ../panels/power/cc-power-panel.c:314
+#, c-format
+msgid "%.0lf%% charged"
+msgstr ""
+
+#: ../panels/power/power.ui.h:1 ../panels/screen/screen.ui.h:1
+msgid "1 hour"
+msgstr ""
+
+#: ../panels/power/power.ui.h:2 ../panels/screen/screen.ui.h:3
+#, fuzzy
+msgid "10 minutes"
+msgstr "xulek"
+
+#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
+#, fuzzy
+msgid "30 minutes"
+msgstr "xulek"
+
+#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:8
+#, fuzzy
+msgid "5 minutes"
+msgstr "xulek"
+
+#: ../panels/power/power.ui.h:5
+msgid "Don't suspend"
+msgstr ""
+
+#: ../panels/power/power.ui.h:6
+msgid "Hibernate"
+msgstr ""
+
+#: ../panels/power/power.ui.h:7
+msgid "On battery power"
+msgstr ""
+
+#: ../panels/power/power.ui.h:8
+msgid "Power off"
+msgstr ""
+
+#: ../panels/power/power.ui.h:9
+msgid "Suspend when inactive for:"
+msgstr ""
+
+#: ../panels/power/power.ui.h:10
+msgid "When plugged in"
+msgstr ""
+
+#: ../panels/power/power.ui.h:11
+msgid "When power is _critically low:"
+msgstr ""
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: ../panels/color/color.ui.h:8
+#, fuzzy
+msgid "Color"
+msgstr "Nîşanker"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Color management settings"
+msgstr ""
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#. TRANSLATORS: this is where the user can click and import a profile
+#: ../panels/color/cc-color-panel.c:106
+msgid "Other profile…"
+msgstr "Profîla din..."
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:119
+#, fuzzy
+msgid "Default: "
+msgstr "Wekî heyî"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:126
+#, fuzzy
+msgid "Colorspace: "
+msgstr "Nîşanker"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:132
+msgid "Test profile: "
+msgstr ""
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:185 ../panels/color/color.ui.h:19
+msgid "Set for all users"
+msgstr ""
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:192
+msgid "Create virtual device"
+msgstr ""
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:227
+#, fuzzy
+msgid "Select ICC Profile File"
+msgstr "Pelê Dengê Hilbijêre"
+
+#: ../panels/color/cc-color-panel.c:230
+msgid "_Import"
+msgstr "_Veguhezîne Hundir"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:241
+msgid "Supported ICC profiles"
+msgstr ""
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:248
+#, fuzzy
+msgid "All files"
+msgstr "Hemû Pel"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:504
+#, fuzzy
+msgid "Available Profiles for Displays"
+msgstr "Pelên _heyî:"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:508
+#, fuzzy
+msgid "Available Profiles for Scanners"
+msgstr "Pelên _heyî:"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:512
+#, fuzzy
+msgid "Available Profiles for Printers"
+msgstr "Pelên _heyî:"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:516
+#, fuzzy
+msgid "Available Profiles for Cameras"
+msgstr "Pelên _heyî:"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:520
+#, fuzzy
+msgid "Available Profiles for Webcams"
+msgstr "Pelên _heyî:"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#. * where the device type is not recognised
+#. Profiles that can be added to the device
+#: ../panels/color/cc-color-panel.c:525 ../panels/color/color.ui.h:5
+#, fuzzy
+msgid "Available Profiles"
+msgstr "Pelên _heyî:"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:795
+#: ../panels/sound/gvc-mixer-dialog.c:1515
+#, fuzzy
+msgid "Device"
+msgstr "Alav"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:830
+msgid "Calibration"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:862
+msgid "Create a color profile for the selected device"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:876 ../panels/color/cc-color-panel.c:900
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:909
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:920
+#, fuzzy
+msgid "The device type is not currently supported."
+msgstr "Ev dirb ne di celebekî tê destekkirin de ye."
+
+#. TRANSLATORS: this is when an auto-added profile cannot be removed
+#: ../panels/color/cc-color-panel.c:993
+msgid "Cannot remove automatically added profile"
+msgstr ""
+
+#. TRANSLATORS: this is when there is no profile for the device
+#: ../panels/color/cc-color-panel.c:1327
+msgid "No profile"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1358
+#, c-format
+msgid "%i year"
+msgid_plural "%i years"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/color/cc-color-panel.c:1369
+#, c-format
+msgid "%i month"
+msgid_plural "%i months"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/color/cc-color-panel.c:1380
+#, c-format
+msgid "%i week"
+msgid_plural "%i weeks"
+msgstr[0] ""
+msgstr[1] ""
+
+#. fallback
+#: ../panels/color/cc-color-panel.c:1387
+#, c-format
+msgid "Less than 1 week"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1447
+#, fuzzy
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Wekî heyî"
+
+#: ../panels/color/cc-color-panel.c:1452
+#, fuzzy
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Wekî heyî"
+
+#: ../panels/color/cc-color-panel.c:1457
+#, fuzzy
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Wekî heyî"
+
+#: ../panels/color/cc-color-panel.c:1572 ../panels/color/cc-color-panel.c:1604
+#: ../panels/color/cc-color-panel.c:1615 ../panels/color/cc-color-panel.c:1626
+msgid "Uncalibrated"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1575
+msgid "This device is not color managed."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1607
+msgid "This device is using manufacturing calibrated data."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1618
+msgid ""
+"This device does not have a profile suitable for whole-screen color "
+"correction."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1651
+msgid "This device has an old profile that may no longer be accurate."
+msgstr ""
+
+#. TRANSLATORS: this is when the calibration profile age is not
+#. * specified as it has been autogenerated from the hardware
+#: ../panels/color/cc-color-panel.c:1679
+#, fuzzy
+msgid "Not specified"
+msgstr "Nehate girêdan"
+
+#. add the 'No devices detected' entry
+#: ../panels/color/cc-color-panel.c:1864
+msgid "No devices supporting color management detected"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2093
+msgctxt "Device kind"
+msgid "Display"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2095
+msgctxt "Device kind"
+msgid "Scanner"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2097
+#, fuzzy
+msgctxt "Device kind"
+msgid "Printer"
+msgstr "Nîşanek"
+
+#: ../panels/color/cc-color-panel.c:2099
+msgctxt "Device kind"
+msgid "Camera"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2101
+msgctxt "Device kind"
+msgid "Webcam"
+msgstr ""
+
+#: ../panels/color/color.ui.h:1
+msgid "Add a virtual device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:2
+msgid "Add device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:3
+msgid "Add profile"
+msgstr ""
+
+#: ../panels/color/color.ui.h:6
+msgid "Calibrate the device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:7
+msgid "Calibrate…"
+msgstr ""
+
+#: ../panels/color/color.ui.h:9
+#, fuzzy
+msgid "Delete device"
+msgstr "Jê bibe"
+
+#: ../panels/color/color.ui.h:10
+#, fuzzy
+msgid "Device type:"
+msgstr "Alav"
+
+#: ../panels/color/color.ui.h:11
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: ../panels/color/color.ui.h:12
+msgid ""
+"Image files can be dragged on this window to auto-complete the above fields."
+msgstr ""
+
+#: ../panels/color/color.ui.h:13
+msgid "Learn more"
+msgstr ""
+
+#: ../panels/color/color.ui.h:14
+msgid "Learn more about color management"
+msgstr ""
+
+#: ../panels/color/color.ui.h:15
+msgid "Manufacturer:"
+msgstr ""
+
+#: ../panels/color/color.ui.h:16
+#, fuzzy
+msgid "Model:"
+msgstr "_Model:"
+
+#: ../panels/color/color.ui.h:17
+msgid "Remove a device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:18
+msgid "Remove profile"
+msgstr ""
+
+#: ../panels/color/color.ui.h:20
+msgid "Set this device for all users on this computer"
+msgstr ""
+
+#: ../panels/color/color.ui.h:21
+#, fuzzy
+msgid "View details"
+msgstr "Kîtekîtên Dirban"
+
+#. Translators: those are keywords for the brightness and lock control-center panel
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
+msgid "Brightness;Lock;Dim;Blank;Monitor;"
+msgstr ""
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
+msgid "Screen"
+msgstr "Dîmen"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
+msgid "Screen brightness and lock settings"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:2
+#, fuzzy
+msgid "1 minute"
+msgstr "xulek"
+
+#: ../panels/screen/screen.ui.h:4
+#, fuzzy
+msgid "2 minutes"
+msgstr "xulek"
+
+#: ../panels/screen/screen.ui.h:5
+#, fuzzy
+msgid "3 minutes"
+msgstr "xulek"
+
+#: ../panels/screen/screen.ui.h:7
+#, fuzzy
+msgid "30 seconds"
+msgstr "çirke"
+
+#: ../panels/screen/screen.ui.h:9
+#, fuzzy
+msgid "Brightness"
+msgstr "Biriqandinê zêde bike"
+
+#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
+#: ../panels/screen/screen.ui.h:11
+msgid "Don't lock when at home"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:12
+#, fuzzy
+msgid "Locations..."
+msgstr "_Cih:"
+
+#: ../panels/screen/screen.ui.h:13
+msgid "Lock"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:14
+msgid "Screen turns off"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:15
+msgid "_Dim screen to save power"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:16
+#, fuzzy
+msgid "_Lock screen after:"
+msgstr "Ekranê qifil bike"
+
+#: ../panels/screen/screen.ui.h:17
+msgid "_Turn screen off when inactive for:"
+msgstr ""
+
+#: ../panels/sound/applet-main.c:49
+msgid "Enable debugging code"
+msgstr ""
+
+#: ../panels/sound/applet-main.c:50
+#, fuzzy
+msgid "Version of this application"
+msgstr "Curetîpa sepanê ya pêşdanasînî hilbijêre"
+
+#: ../panels/sound/applet-main.c:62
+msgid " — GNOME Volume Control Applet"
+msgstr ""
+
+#: ../panels/sound/gvc-applet.c:270 ../panels/sound/gvc-mixer-dialog.c:1767
+msgid "Output"
+msgstr ""
+
+#: ../panels/sound/gvc-applet.c:272
+msgid "Sound Output Volume"
+msgstr ""
+
+#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1807
+msgid "Input"
+msgstr ""
+
+#: ../panels/sound/gvc-applet.c:278
+msgid "Microphone Volume"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:111
+msgctxt "balance"
+msgid "Left"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:112
+#, fuzzy
+msgctxt "balance"
+msgid "Right"
+msgstr "rastê"
+
+#: ../panels/sound/gvc-balance-bar.c:115
+msgctxt "balance"
+msgid "Rear"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:116
+msgctxt "balance"
+msgid "Front"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:119
+msgctxt "balance"
+msgid "Minimum"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:120
+#, fuzzy
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Mêzîn bîkê"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Balance:"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:298
+msgid "_Fade:"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:301
+msgid "_Subwoofer:"
+msgstr ""
+
+#: ../panels/sound/gvc-channel-bar.c:603 ../panels/sound/gvc-channel-bar.c:612
+msgctxt "volume"
+msgid "100%"
+msgstr ""
+
+#: ../panels/sound/gvc-channel-bar.c:607
+msgctxt "volume"
+msgid "Unamplified"
+msgstr ""
+
+#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:1621
+#, fuzzy
+msgid "_Profile:"
+msgstr "_Mobîl:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1093
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1103
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/sound/gvc-mixer-control.c:1401
+msgid "System Sounds"
+msgstr "Dengên Pergalê"
+
+#: ../panels/sound/gvc-mixer-dialog.c:323
+#: ../panels/sound/gvc-mixer-dialog.c:634
+msgid "Co_nnector:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:540
+msgid "Peak detect"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1496
+#: ../panels/sound/gvc-mixer-dialog.c:1709
+#: ../panels/sound/gvc-sound-theme-chooser.c:596
+#, fuzzy
+msgid "Name"
+msgstr "Nav:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1563
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1622
+msgid "_Test Speakers"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1753
+msgid "_Output volume:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1772
+msgid "C_hoose a device for sound output:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+#: ../panels/sound/gvc-mixer-dialog.c:1925
+msgid "Settings for the selected device:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1814
+msgid "_Input volume:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1837
+msgid "Input level:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1865
+msgid "C_hoose a device for sound input:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1892
+msgid "Hardware"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1897
+msgid "C_hoose a device to configure:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1936
+#, fuzzy
+msgid "Sound Effects"
+msgstr "Tercîhên Deng"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1943
+msgid "_Alert volume:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1956
+#, fuzzy
+msgid "Applications"
+msgstr "<b>Bername</b>"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1960
+msgid "No application is currently playing or recording audio."
+msgstr ""
+
+#: ../panels/sound/gvc-speaker-test.c:221
+msgid "Stop"
+msgstr ""
+
+#: ../panels/sound/gvc-speaker-test.c:221
+#: ../panels/sound/gvc-speaker-test.c:333
+msgid "Test"
+msgstr "Ceribandin"
+
+#: ../panels/sound/gvc-speaker-test.c:229
+msgid "Subwoofer"
+msgstr ""
+
+#: ../panels/sound/gvc-stream-status-icon.c:235
+#, fuzzy, c-format
+msgid "Failed to start Sound Preferences: %s"
+msgstr "Tercîhên Rûerdê Sermaseyê"
+
+#: ../panels/sound/gvc-stream-status-icon.c:261
+msgid "_Mute"
+msgstr ""
+
+#: ../panels/sound/gvc-stream-status-icon.c:270
+#, fuzzy
+msgid "_Sound Preferences"
+msgstr "Tercîhên Deng"
+
+#: ../panels/sound/gvc-stream-status-icon.c:415
+msgid "Muted"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:190
+msgid "Built-in"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:456
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Sound Preferences"
+msgstr "Tercîhên Deng"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:459
+#: ../panels/sound/gvc-sound-theme-chooser.c:470
+#: ../panels/sound/gvc-sound-theme-chooser.c:482
+#, fuzzy
+msgid "Testing event sound"
+msgstr "Dengên Pergalê"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:587
+#, fuzzy
+msgid "From theme"
+msgstr "Dirbê Taybet"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:782
+#, fuzzy
+msgid "C_hoose an alert sound:"
+msgstr "Nexşeya Bişkokan Hilbijêre"
+
+#: ../panels/sound/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr "Taybet"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
+msgid "Show desktop volume control"
+msgstr ""
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
+#, fuzzy
+msgid "Volume Control"
+msgstr "Deng kêm bike"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+msgstr ""
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
+#, fuzzy
+msgid "Change sound volume and sound events"
+msgstr "Deng çalak bike û deng û çalakiyan bi hev re têkildar bike"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Sound"
+msgstr "Deng"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr ""
+
+#: ../panels/universal-access/cc-ua-panel.c:505
+#: ../panels/universal-access/cc-ua-panel.c:510
+#, fuzzy
+msgid "No shortcut set"
+msgstr "Kurterê"
+
+#: ../panels/universal-access/gconf-property-editor.c:134
+msgid "Key"
+msgstr "Mifte"
+
+#: ../panels/universal-access/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr "Bişkoka Gconf ya sererastkerê vê taybetmendiyê girêdayî wê ye"
+
+#: ../panels/universal-access/gconf-property-editor.c:141
+msgid "Callback"
+msgstr "Careke din bang bike"
+
+#: ../panels/universal-access/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Vê bangkirinê dema nirxa ku bi mifteyê re têkildar e guherî bikar bîne"
+
+#: ../panels/universal-access/gconf-property-editor.c:147
+msgid "Change set"
+msgstr "Tîma guherandinê"
+
+#: ../panels/universal-access/gconf-property-editor.c:148
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"Daneyên ku dema koma guhertinê ya GConf li daxwazkarê gconf hate sepandin dê "
+"bêne bervêvekirin dihundirîne."
+
+#: ../panels/universal-access/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr "Lêvegera paşdevegerîna parçekan"
+
+#: ../panels/universal-access/gconf-property-editor.c:154
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "Paşdevegerîna ku dema dane ji GConf vegere parçekan dê bête sepandin"
+
+#: ../panels/universal-access/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr "Paşdevegerandina veguhartina parçekan"
+
+#: ../panels/universal-access/gconf-property-editor.c:160
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"Paşdevegerandina ku dema dane ji parçekan li GConfê veguherî dê bête sepandin"
+
+#: ../panels/universal-access/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "Kontrola Dirûvê Navîn"
+
+#: ../panels/universal-access/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr "Bireserea ku vê taybetmendiyê kontrol dike (piranî tenê perçeyek)"
+
+#: ../panels/universal-access/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr "Daneya bireserên sererastkerê taybetmendiyan"
+
+#: ../panels/universal-access/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr "Daneyên vebijêrkî yên ji bo pergalkerên taybetiyan ên belî"
+
+#: ../panels/universal-access/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr "Paşdevegerandina valakirina daneyan a pergalkerê taybetiyan"
+
+#: ../panels/universal-access/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Paşdevegerandin ku piştî daneya bireseran a pergalkerê taybetiyan hate "
+"valakirin dê bête bikaranîn"
+
+#: ../panels/universal-access/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Pelê '%s' nehate dîtin.\n"
+"\n"
+"Ji kerema xwe re bawer bî ku ka pel heye yan na û dîsa biceribîne yan jî "
+"wêneyekî cuda yê rûerd bikar bîne."
+
+#: ../panels/universal-access/gconf-property-editor.c:1482
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Pelê '%s' venabe.\n"
+"Dibe ku ev wêne hîna nehatiye destekirin.\n"
+"\n"
+"Ji kerema xwe re dêvila vêya wêneyekî din hilbijêre."
+
+#: ../panels/universal-access/gconf-property-editor.c:1604
+msgid "Please select an image."
+msgstr "Ji kerema xwe re wêneyekî hilbijêre."
+
+#: ../panels/universal-access/zoom-options.c:156
+#, fuzzy
+msgid "1/4 Screen"
+msgstr "Dîmen"
+
+#: ../panels/universal-access/zoom-options.c:157
+#, fuzzy
+msgid "1/2 Screen"
+msgstr "Dîmen"
+
+#: ../panels/universal-access/zoom-options.c:158
+#, fuzzy
+msgid "3/4 Screen"
+msgstr "Dîmen"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
+"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys"
+msgstr ""
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#, fuzzy
+msgid "Universal Access Preferences"
+msgstr "Vebijêrkên mikşê"
+
+#: ../panels/universal-access/uap.ui.h:2
+#, no-c-format
+msgid "100%"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:4
+#, no-c-format
+msgid "125%"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:6
+#, no-c-format
+msgid "150%"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:8
+#, no-c-format
+msgid "75%"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "Acc_eptance delay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Beep when Caps and Num Lock are used"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:12
+#, fuzzy
+msgid "Beep when a _modifer key is pressed"
+msgstr "Di dema pêlkirina guhestinan de bi deng hişyarî bide"
+
+#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
+#: ../panels/universal-access/uap.ui.h:14
+#, fuzzy
+msgid "Beep when a key is"
+msgstr "Heke bişkok ev be bike tûtût:"
+
+#: ../panels/universal-access/uap.ui.h:15
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Dema bişkok nehate _qebûlkirin bike tûtût"
+
+#: ../panels/universal-access/uap.ui.h:16
+#, fuzzy
+msgid "Bounce Keys"
+msgstr "Bişkokên Mişk"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Caribou"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:18
+#, fuzzy
+msgid "Change contrast:"
+msgstr "Tîma guherandinê"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "Closed Captioning"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Control the pointer using the keypad"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Control the pointer using the video camera."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:23
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Derengmayîn:"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Dasher"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Decrease size:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Display a textual description of speech and sounds"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:27
+#, fuzzy
+msgid "Flash the entire screen"
+msgstr "Hemû dîmenderê bike _flaş"
+
+#: ../panels/universal-access/uap.ui.h:28
+#, fuzzy
+msgid "Flash the window title"
+msgstr "Darikê sernivîsa _paceyê bike flaş"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "GOK"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "Hearing"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Hover Click"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:32
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "dubare pêlkirina mifteyan piştguh bike dema:"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Increase size:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:34
+#, fuzzy
+msgid "Keyboard Settings"
+msgstr "Bijarekên klavye"
+
+#: ../panels/universal-access/uap.ui.h:39
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Dergeh:"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Mouse Keys"
+msgstr "Bişkokên Mişk"
+
+#: ../panels/universal-access/uap.ui.h:41
+#, fuzzy
+msgid "Mouse Settings"
+msgstr "Mîheng"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Nomon"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:44
+#, fuzzy
+msgid "On screen keyboard"
+msgstr "Klavyeya _dîmenderê"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "OnBoard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:46
+#, fuzzy
+msgid "Options..."
+msgstr "Vebijêrk"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Pointing and Clicking"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:49
+#, fuzzy
+msgid "Screen Reader"
+msgstr "_Xwînerê dîmenderê"
+
+#: ../panels/universal-access/uap.ui.h:50
+#, fuzzy
+msgid "Screen keyboard"
+msgstr "Klavyeya _dîmenderê"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgid "Seeing"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "Simulated Secondary Click"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:55
+#, fuzzy
+msgid "Slow Keys"
+msgstr "Hişyariya Hêdîkirina Bişkokan"
+
+#: ../panels/universal-access/uap.ui.h:58
+#, fuzzy
+msgid "Sound Settings"
+msgstr "%d Mîhengên Dîmender\n"
+
+#: ../panels/universal-access/uap.ui.h:59
+#, fuzzy
+msgid "Sticky Keys"
+msgstr "Hişyariya Bişkokên Mezeloqî"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:61
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Turn on or off:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:64
+#, fuzzy
+msgid "Type here to test settings"
+msgstr "Ji bo kontrolkirina mîhengan _biceribîne:"
+
+#: ../panels/universal-access/uap.ui.h:66
+#, fuzzy
+msgid "Typing Assistant"
+msgstr "_Alîkar:"
+
+#: ../panels/universal-access/uap.ui.h:67
+msgid "Use a visual indication when an alert sound occurs"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:68
+#, fuzzy
+msgid "Video Mouse"
+msgstr "Mişk"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Visual Alerts"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:70
+#, fuzzy
+msgid "Zoom in:"
+msgstr "Mezinkirin"
+
+#: ../panels/universal-access/uap.ui.h:71
+#, fuzzy
+msgid "Zoom out:"
+msgstr "Derkeve"
+
+#: ../panels/universal-access/uap.ui.h:72
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Tekilî"
+
+#: ../panels/universal-access/uap.ui.h:73
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Heke _bi hev re pêl bişkokan were kirin bandora wê rake"
+
+#: ../panels/universal-access/uap.ui.h:74
+msgid "_Test flash"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:75
+msgid "_Text size:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:76
+#, fuzzy
+msgid "_Turn on accessibility features from the keyboard"
+msgstr "_Taybetmendiyên gihîştina klavyeyê çalak bike"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:78
+#, fuzzy
+msgid "accepted"
+msgstr "_hate pejirandin"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:80
+#, fuzzy
+msgid "pressed"
+msgstr "_hate pêlêkirin"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:82
+#, fuzzy
+msgid "rejected"
+msgstr "_nehate pejirandin"
+
+#: ../panels/universal-access/uap.ui.h:83
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:84
+#, fuzzy
+msgctxt "universal access, contrast"
+msgid "High/Inverse"
+msgstr "berevajî"
+
+#: ../panels/universal-access/uap.ui.h:85
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:86
+#, fuzzy
+msgctxt "universal access, contrast"
+msgid "Normal"
+msgstr "asayî"
+
+#. Translators: this refers to theme contrast and font size
+#: ../panels/universal-access/uap.ui.h:88
+msgctxt "universal access, seeing"
+msgid "Display"
+msgstr ""
+
+#. Translators: this refers to screen magnifier
+#: ../panels/universal-access/uap.ui.h:90
+#, fuzzy
+msgctxt "universal access, seeing"
+msgid "Zoom"
+msgstr "Mezinkirin"
+
+#: ../panels/universal-access/uap.ui.h:91
+#, fuzzy
+msgctxt "universal access, text size"
+msgid "Large"
+msgstr "Mezin"
+
+#: ../panels/universal-access/uap.ui.h:92
+#, fuzzy
+msgctxt "universal access, text size"
+msgid "Larger"
+msgstr "Mezin"
+
+#: ../panels/universal-access/uap.ui.h:93
+#, fuzzy
+msgctxt "universal access, text size"
+msgid "Normal"
+msgstr "asayî"
+
+#: ../panels/universal-access/uap.ui.h:94
+#, fuzzy
+msgctxt "universal access, text size"
+msgid "Small"
+msgstr "Biçûk"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Always"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Bottom Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Centered"
+msgstr "Navîn"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Color and Opacity"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Crosshairs"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+#, fuzzy
+msgid "Full Screen"
+msgstr "Dîmenderê Tije Bike"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+#, fuzzy
+msgid "Image moves with the mouse pointer"
+msgstr "Guhertoya mezin a nîşankerê sipî"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Image scrolls at screen edges"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Left Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Length"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+#, fuzzy
+msgid "Magnification"
+msgstr "_Girdok"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Moveable lens - magnified view follows mouse movements"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Position of magnified view on screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgid "Proportional"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgid "Push"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Right Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Show"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Show crosshairs intersection"
+msgstr ""
+
+#. long delay
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "Thick"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Thickness"
+msgstr ""
+
+#. short delay
+#: ../panels/universal-access/zoom-options.ui.h:29
+msgid "Thin"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgid "To keep the pointer centered"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgid "To keep the pointer visible"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgid "Top Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Vebijêrk"
+
+#: ../panels/user-accounts/run-passwd.c:426
+#, fuzzy
+msgid "Authentication failed"
+msgstr "Belgekirî!"
+
+#: ../panels/user-accounts/run-passwd.c:506
+#: ../panels/user-accounts/um-password-dialog.c:375
+#, fuzzy, c-format
+msgid "The new password is too short"
+msgstr "Şîfre pir kurte."
+
+#: ../panels/user-accounts/run-passwd.c:512
+#, fuzzy, c-format
+msgid "The new password is too simple"
+msgstr "Şîfre pir hesane."
+
+#: ../panels/user-accounts/run-passwd.c:518
+#, fuzzy, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Şîfreya kevin û ya nû gelekî wek hevin."
+
+#: ../panels/user-accounts/run-passwd.c:521
+#, fuzzy, c-format
+msgid "The new password has already been used recently."
+msgstr "Herdû şîfre ne weke hevin."
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, fuzzy, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Pêwiste ku di şîfreya nû de hejmar an jî karekterên taybet hebin."
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, fuzzy, c-format
+msgid "The old and new passwords are the same"
+msgstr "Şîfreya kevin û ya nû yekin."
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, fuzzy, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+"Şîfreya te hatiye guhertin di dema belgekirinê de , ji kerema xwe re ji nû "
+"belgekirinê pêk bîne."
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, fuzzy, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Pêwiste ku di şîfreya nû de hejmar an jî karekterên taybet hebin."
+
+#: ../panels/user-accounts/run-passwd.c:540
+#, fuzzy, c-format
+msgid "Unknown error"
+msgstr "Nîşankereke Nenas"
+
+#: ../panels/user-accounts/um-account-dialog.c:73
+#, fuzzy
+msgid "Failed to create user"
+msgstr "Afirandina peldanka derbasdar bi ser neket"
+
+#: ../panels/user-accounts/um-account-type.c:35
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+#, fuzzy
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Termînala Xê ya Standart"
+
+#: ../panels/user-accounts/um-account-type.c:37
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgctxt "Account type"
+msgid "Administrator"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:107
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:109
+#, fuzzy
+msgid "The device is already in use."
+msgstr "Girêdana Bişkokê (%s) jixwe niha tê bikaranîn\n"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:111
+#, fuzzy
+msgid "An internal error occurred."
+msgstr "Çewtiyeke pergalê rû da"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:181
+#: ../panels/user-accounts/um-fingerprint-dialog.c:182
+#, fuzzy
+msgid "Enabled"
+msgstr "Neçalak"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:224
+msgid "Delete registered fingerprints?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:228
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:235
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:363
+msgid "Done!"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:410
+#: ../panels/user-accounts/um-fingerprint-dialog.c:432
+#, c-format
+msgid "Could not access '%s' device"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:481
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:533
+#, fuzzy
+msgid "Could not access any fingerprint readers"
+msgstr "Dirûvê navîn yê mak nehate barkirin"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:534
+msgid "Please contact your system administrator for help."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:571
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Enable Fingerprint Login"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:605
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:612
+#, fuzzy
+msgid "Selecting finger"
+msgstr "Wêne Hilbijêre"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:613
+msgid "Enrolling fingerprints"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:614
+msgid "Summary"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:179
+msgid "More choices..."
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:285
+msgid "Please choose another password."
+msgstr "Ji kerema xwe re şîfreyeke din hilbijêre."
+
+#: ../panels/user-accounts/um-password-dialog.c:294
+#, fuzzy
+msgid "Please type your current password again."
+msgstr "Ji kerema xwe re şîfreyan dîsa binivîse."
+
+#: ../panels/user-accounts/um-password-dialog.c:300
+#, fuzzy
+msgid "Password could not be changed"
+msgstr "Şîfreya te hatiye guhertin."
+
+#: ../panels/user-accounts/um-password-dialog.c:372
+#, fuzzy
+msgid "You need to enter a new password"
+msgstr "Şîfreya nû dîsa _binivîse:"
+
+#: ../panels/user-accounts/um-password-dialog.c:381
+#, fuzzy
+msgid "You need to confirm the password"
+msgstr "Ji bo guherandina şîfreyê pêl \"Şîfreyê Biguherîne\" bike."
+
+#: ../panels/user-accounts/um-password-dialog.c:384
+#, fuzzy
+msgid "The passwords do not match"
+msgstr "Şîfre pir kurte."
+
+#: ../panels/user-accounts/um-password-dialog.c:390
+msgid "You need to enter your current password"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:393
+#, fuzzy
+msgid "The current password is not correct"
+msgstr "Ew şîfre çewt bû."
+
+#: ../panels/user-accounts/um-password-dialog.c:466
+#: ../panels/user-accounts/um-password-dialog.c:693
+msgctxt "Password strength"
+msgid "Too short"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:469
+#: ../panels/user-accounts/um-password-dialog.c:694
+msgctxt "Password strength"
+msgid "Weak"
+msgstr "Lawaz"
+
+#: ../panels/user-accounts/um-password-dialog.c:471
+#: ../panels/user-accounts/um-password-dialog.c:695
+msgctxt "Password strength"
+msgid "Fair"
+msgstr "Navîn"
+
+#: ../panels/user-accounts/um-password-dialog.c:473
+#: ../panels/user-accounts/um-password-dialog.c:696
+msgctxt "Password strength"
+msgid "Good"
+msgstr "Baş"
+
+#: ../panels/user-accounts/um-password-dialog.c:475
+#: ../panels/user-accounts/um-password-dialog.c:697
+msgctxt "Password strength"
+msgid "Strong"
+msgstr "Xurt"
+
+#: ../panels/user-accounts/um-password-dialog.c:514
+msgid "Passwords do not match"
+msgstr "Nasnav hev nagirin"
+
+#: ../panels/user-accounts/um-password-dialog.c:540
+msgid "Wrong password"
+msgstr "Nasnav şaş e"
+
+#: ../panels/user-accounts/um-photo-dialog.c:97
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+msgid "Select"
+msgstr "Hilbijartin"
+
+#: ../panels/user-accounts/um-photo-dialog.c:445
+#, fuzzy
+msgid "Disable image"
+msgstr "Neçalak"
+
+#: ../panels/user-accounts/um-photo-dialog.c:463
+msgid "Take a photo..."
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:481
+msgid "Browse for more pictures..."
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:706
+#, c-format
+msgid "Used by %s"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-manager.c:450
+#, c-format
+msgid "A user with name '%s' already exists."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-manager.c:546
+#, fuzzy
+msgid "This user does not exist."
+msgstr "Ji bo vê bûyerê pelê dengan nehate dîtin."
+
+#: ../panels/user-accounts/um-user-panel.c:357
+msgid "Failed to delete user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "You cannot delete your own account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:426
+#, c-format
+msgid "%s is still logged in"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:430
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:439
+#, fuzzy, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "Tu dixwazî van xuyakirinan tomar bikî?"
+
+#: ../panels/user-accounts/um-user-panel.c:443
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:446
+msgid "_Delete Files"
+msgstr "Pelan _jê bibe"
+
+#: ../panels/user-accounts/um-user-panel.c:447
+msgid "_Keep Files"
+msgstr "Pelan bi_parêze"
+
+#: ../panels/user-accounts/um-user-panel.c:499
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Hesab neçalakkirî ye"
+
+#: ../panels/user-accounts/um-user-panel.c:507
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:510
+msgctxt "Password mode"
+msgid "None"
+msgstr "Tune"
+
+#: ../panels/user-accounts/um-user-panel.c:845
+msgid "Failed to contact the accounts service"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:847
+#, fuzzy
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Baweriya xwe pê bîne ku pêvek rast hatiye sazkirin."
+
+#: ../panels/user-accounts/um-user-panel.c:887
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:925
+msgid "Create a user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:936
+#: ../panels/user-accounts/um-user-panel.c:1225
+msgid ""
+"To create a user,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:945
+msgid "Delete the selected user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:957
+#: ../panels/user-accounts/um-user-panel.c:1230
+msgid ""
+"To delete the selected user,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1134
+msgid "My Account"
+msgstr "Hesaba min"
+
+#: ../panels/user-accounts/um-user-panel.c:1144
+msgid "Other Accounts"
+msgstr "Hesabên din"
+
+#: ../panels/user-accounts/um-utils.c:512
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:516
+#, fuzzy, c-format
+msgid "The username is too long"
+msgstr "Şîfre pir kurte."
+
+#: ../panels/user-accounts/um-utils.c:519
+msgid "The username cannot start with a '-'"
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:522
+msgid ""
+"The username must only consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr ""
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Add or remove users"
+msgstr ""
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr ""
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "User Accounts"
+msgstr "Hesabên bikarhêner"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "Cr_eate"
+msgstr "_Afirandin"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "Create new account"
+msgstr "Hesaba nû biafirîne"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#, fuzzy
+msgid "_Account Type"
+msgstr "Cureyê Hişyariyê"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+#, fuzzy
+msgid "_Full name"
+msgstr "Nav û Paşnav"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#, fuzzy
+msgid "_Username"
+msgstr "N_avê Bikarhêner:"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#, fuzzy
+msgid "C_onfirm password"
+msgstr "Şîfreyê biguhêre"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Tîma guherandinê"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+#, fuzzy
+msgid "Changing password for"
+msgstr "Şîfreyê biguhêre"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+#, fuzzy
+msgid "Choose a generated password"
+msgstr "Şîfreyê biguhêre"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Choose password at next login"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+#, fuzzy
+msgid "Current _password"
+msgstr "Şîfreya _heyî:"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Disable this account"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Enable this account"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+msgid "Fair"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+msgid "How to choose a strong password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+msgid "Log in without a password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+#, fuzzy
+msgid "Set a password now"
+msgstr "Şîfreya _Nû:"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid ""
+"This hint may be displayed at the login screen.  It will be visible to all "
+"users of this system.  Do <b>not</b> include the password here."
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+#, fuzzy
+msgid "_Action"
+msgstr "Çalakî"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:15
+msgid "_Hint"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:16
+#, fuzzy
+msgid "_New password"
+msgstr "Şîfreya _Nû:"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:17
+#, fuzzy
+msgid "_Show password"
+msgstr "Şîfreya _Nû:"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+#, fuzzy
+msgid "Browse"
+msgstr "Geroka Torê"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+msgid "Cancel"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+msgid "Changing photo for:"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+msgid ""
+"Choose a picture that will be shown at the login screen for this account."
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+msgid "Gallery"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+#, fuzzy
+msgid "Take a photograph"
+msgstr "Bêhna xwe vekin!"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+msgid "A_utomatic Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+msgid "Account Information"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Account _type"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+#, fuzzy
+msgid "Login Options"
+msgstr "Vebijêrkên Pergalê"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "_Language"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Password"
+msgstr "Şî_fre"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left little finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left middle finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left ring finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Left thumb"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right little finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right middle finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right ring finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+msgid "Right thumb"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "Tiliya _din:"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid "_Right index finger"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Back"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+#, fuzzy
+msgid "Bluetooth Settings"
+msgstr "Mîhengên Pêşdanasînî"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Calibrate..."
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Firm"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Forward"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Left Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Left-Handed Orientation:"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+#, fuzzy
+msgid "Lower Button"
+msgstr "Bişkokên Hişyariyê"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+#, fuzzy
+msgid "No Action"
+msgstr "Çalakî"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "No tablet detected"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Scroll Down"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:16
+msgid "Scroll Left"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:17
+#, fuzzy
+msgid "Scroll Right"
+msgstr "_Sivik"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:18
+#, fuzzy
+msgid "Scroll Up"
+msgstr "Bigire"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:19
+msgid "Soft"
+msgstr "Nerm"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:20
+#, fuzzy
+msgid "Stylus"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:21
+msgid "Tablet (absolute)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:22
+#, fuzzy
+msgid "Tablet Preferences"
+msgstr "Vebijêrkên Dirban"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:23
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:24
+#, fuzzy
+msgid "Top Button"
+msgstr "Bişkok"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:25
+msgid "Touchpad (relative)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:26
+msgid "Tracking Mode"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:27
+msgid "Wacom Tablet"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#, fuzzy
+msgid "Set your Wacom tablet preferences"
+msgstr "Tercîhên mişk bike"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Wacom Graphics Tablet"
+msgstr ""
+
+#: ../shell/control-center.c:54
+msgid "Enable verbose mode"
+msgstr ""
+
+#: ../shell/control-center.c:55
+msgid "Show the overview"
+msgstr ""
+
+#: ../shell/control-center.c:56 ../shell/control-center.c:57
+#: ../shell/control-center.c:58
+msgid "Show help options"
+msgstr ""
+
+#: ../shell/control-center.c:59
+msgid "Panel to display"
+msgstr ""
+
+#: ../shell/control-center.c:81
+msgid "- System Settings"
+msgstr "- Mîhengên pergalê"
+
+#: ../shell/control-center.c:89
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
+msgid "System Settings"
+msgstr "Mîhengên pergalê"
+
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Navenda kontrolê"
+
+#: ../shell/shell.ui.h:2
+msgid "_All Settings"
+msgstr "_Hemû mîheng"
+
+#~ msgid "Image/label border"
+#~ msgstr "Nexşeya dorê ya wêne/etîketê"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr ""
+#~ "Firehbûna nexşeyê dora wêne û etîketa ku di paceya hişyariyan de ye."
+
+#~ msgid "The type of alert"
+#~ msgstr "Cureyê Vê Hişyariyê"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Bişkokên ku di paceya hişyariyan de xuyanî dibe"
+
+#~ msgid "Show more _details"
+#~ msgstr "Hîn zêde _kîtekîtan nîşan bide"
+
+#~ msgid "About Me"
+#~ msgstr "Der Barê Min De"
+
+#~ msgid "Set your personal information"
+#~ msgstr "Agahiyên xwe yên şexsî mîheng bike"
+
+#~ msgid "No Image"
+#~ msgstr "Wêne tune"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Dema lênûska navnîşanan dixwest agahiyan bistîne çewtiyek çêbû\n"
+#~ "Pêşkêşkerê Daneyan ya Evolution vê protokolê nikare bixwîne."
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Lênûska navnîşanan venebû"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "IDa têketinê nenas e, dibe ku danegira bikarhêner xera bûbe"
+
+#~ msgid "About %s"
+#~ msgstr "Der barê %s de"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "Gede derket bi rengekî ne texmînkirî"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "Nikare qenalê backend_stdin IO bigire: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "Nikare qenalê backend_stdout IO : %s bigire"
+
+#~ msgid "System error: %s."
+#~ msgstr "Çewtiya pergalê: %s."
+
+#, fuzzy
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "Nikare /usr/bin/passwd bixebitîne: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "Amûr nehate xebitandin"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "Li ser <b>şîfreyê biguhêre</b> bitikîne da ku tu şîfreyê biguhêrî."
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "Ji kerema xwe re şîfreya xwe di şanika <b>şîfreya nû</b>de binvîse."
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "Ji kerema xwe re şîfreya xwe careke din di şanika <b>şîfreyê careke din "
+#~ "binvîse</b> de binvîse."
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "<b>Email</b>"
+#~ msgstr "<b>Eposte</b>"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Mal</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Peyama Demdemî</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Kar</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Telefon</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Web</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Xebat</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Şîfreya xwe biguhêre</span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "Ş_îrket:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "_Şîfreyê Biguherîne..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "Şîfreyê_biguhêre"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Ba_jar:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "_Welat:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "We_lat:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "_Mal:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "_Qutiya Posteyê:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "Qutiya P_osteyê:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Agahiya Şexsî"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Eyalet/_Tax:"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "Ji bo guhertina şîfreyê, şîfreya xwe ya heyî di zeviya jêr de binvîse û "
+#~ "li ser <b>Belgekirinê</b> bitikîne.\n"
+#~ "Piştî belgekirinê, şîfreya xwe ya nû derbas bike, ji bo bê gumankirine "
+#~ "dîsa binvîse û li ser <b>şîfreyê biguhêre</b> bitikîne."
+
+#~ msgid "User name:"
+#~ msgstr "Nave bikarhêner:"
+
+#~ msgid "Web _log:"
+#~ msgstr "_Rojnivîska Webê:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_Kar:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "_Faqsa kar:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "_Koda Posteyê:"
+
+#~ msgid "_Address:"
+#~ msgstr "_Navnîşan:"
+
+#~ msgid "_Authenticate"
+#~ msgstr "_Belgekirin"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "Rûpelê _destpêkê:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Kar:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Gerînende:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_Eyalet/Herêm:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Kar:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "_Koda posteyê:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Destek</b>"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>Not:</b> Guherînên di van mîhengan de hate têketineke din wê "
+#~ "çalak nebe.</i></small>"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Tercîhên Teknolojiyên Alîkar"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Bigire û _Derkeve"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Ev teknolojiyên alîkar di her têketinê de bide destpêkirin:"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "Teknolojiyên alîkar _çalak bike"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "Teknolojiyên alîkar yên GNOMEyê di têketinê de çalak bike"
+
+#, fuzzy
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Di pergala te de Teknolojiya Alîkar ya mirov dikare wê bixebitîne "
+#~ "nehatiye barkirin. Ji bo desteka klavyeya dîmenderê hebe divê pakêta "
+#~ "'gok' hatibe barkirin, ji bo bikêrhatinên wekî girdok û xwînerê dîmenderê "
+#~ "jî hebe divê pakêta 'gnopernicus' hatibe sazkirin."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Di pergala te de hemû teknolojiyên alîkar ne barkirî ye. Ji bo desteka "
+#~ "klavyeya dîmenderê divê pakêta 'gok' hatibe barkirin."
+
+#, fuzzy
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Di pergala te de hemû teknolojiyên alîkar ne barkirî ye. Ji bo girdok û "
+#~ "xwînerê dîmenderê divê pakêta 'gnopernicus' hatibe barkirin."
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "Di destpêkirina paceya tercîhên mişk de çewtî çêbû: %s"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Mîhengên AccessX ji pelê '%s' nehate stendin"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Pelê Mîhengên Taybetiyan Bistîne"
+
+#, fuzzy
+#~ msgid "Keyboard Accessibility"
+#~ msgstr "_Gihîştin"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Tercîhên gihîştina klavyeyê mîheng bike"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Di vê pergalê de pêvekên XKB nehate dîtin. Heke ev pêvek tuneye "
+#~ "taybetiyên gihîştina klavyeyê wê nexebite."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>_Qevaztina Bişkokan Çalak Bike</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>_Hêdîkirina Bişkokan Çalak Bike</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Bişkokên _Mişk Çalak Bike</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>_Dubarekirina Bişkokan Çalak Bike</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>Bişkokên _Mezeloqî Çalak Bike</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Taybetmendî</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Bişkokên Vekirin/Girtinê</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Bingehî"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr ""
+#~ "Dema taybetmendî ji klavyeyê hate girtin an jî hate _vekirin bike tûtût"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "Dema LEDek vêket bike tûtût û dema vemirî du caran bike tûtût."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Derengî di navbera pêlkirina bişkokê û tevgera nîşanker de:"
+
+#~ msgid "E_nable Toggle Keys"
+#~ msgstr "Bişkokên _Veke/Bigire Çalak Bike"
+
+#~ msgid "Filters"
+#~ msgstr "Fîltre"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Hemû pêlkirinên li ser heman bişkokê piştguh bike, heke ku di demekê ku "
+#~ "ji alî bikarhêner de hilbijartî çêbû."
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Tercîhên Gihîştina Klavyeyê (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Leza herî xort ya nîşanker:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "_Tercîhên Mişk..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Ji bilî bişkokên pêlkirî ne pejirîne di dema ji alî bikarhêner de "
+#~ "destnîşankirî de."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Karê bi hevre pêlêkirina gelek bişkojkan, dema mirov bi dor pê li "
+#~ "bişkojkên guhartîner dike çêdibe."
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Ji bo xwe bigihîne leza herî zêde maweyên borî:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Klavyeya nûmerîk veguhezîne klavyeya kontrolkirinê ya mişk."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Piştî ew qas dem neyê bikaranîn bandora wê rake:"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "Mîhengên Taybetiyan _Bistîne..."
+
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "_Bitenê bişkokên ji bo demekê pêlkirî bipejrîne:"
+
+#~ msgid "characters/second"
+#~ msgstr "karakter/çirke"
+
+#~ msgid "milliseconds"
+#~ msgstr "mîlîçirke"
+
+#~ msgid "pixels/second"
+#~ msgstr "tipik/çirke"
+
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>Sermase _Kaxiza Dîwaran</b>"
+
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>Rengên Sermaseyê</b>"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Bo hilbijartina rengan diyalogekê veke"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "Kaxiza Dîwaran Lê Zêde Bike"
+
+#~ msgid "_Finish"
+#~ msgstr "_Biqedîne"
+
+#~ msgid "_Style:"
+#~ msgstr "_Teşe:Di"
+
+#~ msgid "[FILE...]"
+#~ msgstr "[PEL...]"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Di nîşandana alîkariyê de çewtî çêbû: %s"
+
+#~ msgid "Images"
+#~ msgstr "Wêne"
+
+#, fuzzy
+#~ msgid "- Desktop Background Preferences"
+#~ msgstr "Tercîhên Rûerdê Sermaseyê"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "pîksel"
+#~ msgstr[1] "pîksel"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Gerînendeyê mîhengan yê 'gnome-settings-daemon' nehate destpêkirin.\n"
+#~ "Heke ev bername neyê destpêkirin hin mîheng jî nayên tomarkirin. Ev rewş "
+#~ "dide xuyanî; Bonobo yan jî pergala mîhengên yên derveyî GNOME (mînak KDE) "
+#~ "çalak e û ew û gerînendeyê mîhengan li hev nake."
+
+#, fuzzy
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Îkona capplet a stokê nehate barkirin: '%s'\n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Tenê mîhengan bisepîne û derkeve"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Mîhengên kevn bistîne û veşêre"
+
+#, fuzzy
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Pel tê jibergirtin: %i ji %i"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' tê jibergirtin."
+
+#~ msgid "Copying files"
+#~ msgstr "Pel tên jibergirtin"
+
+#, fuzzy
+#~ msgid "Parent Window"
+#~ msgstr "Pencere"
+
+#~ msgid "From URI"
+#~ msgstr "URIya çavkanî"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI ji vir tê guheztin"
+
+#~ msgid "To URI"
+#~ msgstr "URIya Hedef"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI hîna jî vediguhezîne vir"
+
+#~ msgid "Fraction completed"
+#~ msgstr "Kar nehate temamkirin"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Karê transferê niha xelas bû"
+
+#~ msgid "Current URI index"
+#~ msgstr "Pêrista URI ya rojane"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Pêrista URI ya rojane- ji 1ê dest pê dike."
+
+#~ msgid "Total URIs"
+#~ msgstr "Yekûna URIyan"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Bi gişî hejmara URIyan"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "Sepanên ku Têne Tercîhkirin"
+
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Dema veavakirin dihate tomarkirin çewtî: %s"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Geroka Hestiyar ya Debian"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Emulatora Termînala Debianê"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Geroka Webê ya Epiphany"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Xwînerê E-peyaman ya Evolution"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "Xwînerê E-peyaman ya Evolution 1.4"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "Xwînerê E-peyaman ya Evolution 1.5"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "Xwînerê E-peyaman ya Evolution 1.6"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "Xwînerê E-peyaman ya Evolution 2.0"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "Xwînerê E-peyaman ya Evolution 2.2"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "Xwînerê E-peyaman ya Evolution 2.4"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "Termînala GNOME"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Geroka Nivîsê ya Links"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Gerokê Nivîsan ya Lynx"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Thunderbird"
+#~ msgstr "Thunderbird"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "Geroka Nivîsê ya W3M"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "<b>Audio Player</b>"
+#~ msgstr "<b>Audio Player</b>"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>Nîşandêrê wêne</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>Msn ya Demdemî</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>Xwînerê E-peyaman</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Emulatora Terminalê</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Sererastkerê Nivîsan</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Video Player</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Geroka Webê</b>"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Hemû %s yên xuya dê li şûna wan lînk werin bicihkirin"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "_Ferman:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "Alaya e_xec:"
+
+#~ msgid "Multimedia"
+#~ msgstr "Multîmedya"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Girêdanê di _hilfirîna nû de veke"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Girêdanê di _paceya nû de veke"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Girêdanê bi geroka webê ya _standard veke"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Di t_ermînalekê de bixebitîne"
+
+#~ msgid "Screen Resolution"
+#~ msgstr "Xuyakirina dîmender"
+
+#~ msgid "left"
+#~ msgstr "çep"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Re_fresh rate:"
+#~ msgstr "Leze _Tezekirinan:"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Bijarekên xuyakirina dîmender"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "Tenê ji bo vê kompiturê (%s)  _bike pêşdanasînî"
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Mîhengên nû têne ceribandin. Heke di hundirê %d çirkeyan de tu bersivê "
+#~ "nede wê vegere mîhenga berê."
+#~ msgstr[1] ""
+#~ "Mîhengên nû têne ceribandin. Heke di hundirê %d çirkeyan de tu bersivê "
+#~ "nede wê vegere mîhengên berê."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Vê rêjeşaneyê bi kar bîne"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "Xuyakirinên berê bikar bîne"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Xuyakirinê biparêze"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "Pêşkêşkerê X desteka pêveka XRandR'ê nake. Rûyê navberî yê grafîkê nikare "
+#~ "di demildest de guhartina rêjeşaneyê bike."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Guhartoya pêveka XRandR bi vê bernameyê re li hev nake. Rûyê navberî yê "
+#~ "grafîkê nikare di demildest de guhartina rêjeşaneyê bike."
+
+#~ msgid "Font"
+#~ msgstr "Cureyê nivîsê"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Ji bo sermaseyê curetîpekê hilbijêre"
+
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<b>Lêgerîna Curenivîsan</b>"
+
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<b>Sererastkirin</b>:"
+
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<b>Nermkirin</b>:"
+
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<b>Dora deqa jêrîn</b>:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "_Awayên herî baş"
+
+#~ msgid "D_etails..."
+#~ msgstr "_Kîtekît..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Curetîpa _sermasê:"
+
+#~ msgid "Font Preferences"
+#~ msgstr "Taybetmendiyên Curetîpan"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "Kîtekîtên Lêgerîna Curenivîsan"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "Here peldanka _cureyên nivîsê"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "_Pîvana cûn"
+
+#~ msgid "N_one"
+#~ msgstr "_Tune"
+
+#~ msgid "R_esolution:"
+#~ msgstr "_Rêjeşane:"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "_Deqên Jêr (Ji bo LCDyan)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Nermkirina _deqên jêr (Ji bo LCDyan)"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_Application font:"
+#~ msgstr "Curetîpa _Sepanê:"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Document font:"
+#~ msgstr "Curetîpa _pelgeyê:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "Curetîpê firehiya wê sabît e:"
+
+#~ msgid "_Full"
+#~ msgstr "_Tam"
+
+#~ msgid "_Medium"
+#~ msgstr "_Navîn"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Reş-spî"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "Curetîpa sernavê _paceyê:"
+
+#~ msgid "dots per inch"
+#~ msgstr "Her incekê xalek"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Dibe ku curetîp pir mezin be"
+
+#, fuzzy
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Curenivîsa ku te hilbijartiye bi qasî %d point e, wê bike ku barê "
+#~ "kompîtura te giran bibe. Em pêşniyar dikin, ji kerema xwe re bila ji %d "
+#~ "biçûktir be. Curenivîsa ku te hilbijartiye bi qasî %d point e, wê bike ku "
+#~ "barê kompîtura te giran bibe. Em pêşniyar dikin, ji kerema xwe re bila ji "
+#~ "%d biçûktir be."
+#~ msgstr[1] ""
+#~ "Curenivîsa ku te hilbijartiye bi qasî %d point e, wê bike ku barê "
+#~ "kompîtura te giran bibe. Em pêşniyar dikin, ji kerema xwe re bila ji %d "
+#~ "biçûktir be. Curenivîsa ku te hilbijartiye bi qasî %d point e, wê bike ku "
+#~ "barê kompîtura te giran bibe. Em pêşniyar dikin, ji kerema xwe re bila ji "
+#~ "%d biçûktir be."
+
+#, fuzzy
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Curenivîsa ku tu hilbijart bi qasî %d point mezin e, dibe ku ev tehdeyê "
+#~ "li kompîtura te bike. Em pêşniyar dikin ku curenivîseke ku hîn biçûk "
+#~ "hilbijêrî. Curenivîsa ku tu hilbijart bi qasî %d point mezin e, dibe ku "
+#~ "ev tehdeyê li kompîtura te bike. Em pêşniyar dikin ku curenivîseke ku hîn "
+#~ "biçûk hilbijêrî."
+#~ msgstr[1] ""
+#~ "Curenivîsa ku tu hilbijart bi qasî %d point mezin e, dibe ku ev tehdeyê "
+#~ "li kompîtura te bike. Em pêşniyar dikin ku curenivîseke ku hîn biçûk "
+#~ "hilbijêrî. Curenivîsa ku tu hilbijart bi qasî %d point mezin e, dibe ku "
+#~ "ev tehdeyê li kompîtura te bike. Em pêşniyar dikin ku curenivîseke ku hîn "
+#~ "biçûk hilbijêrî."
+
+#, fuzzy
+#~ msgid "Use previous font"
+#~ msgstr "Xuyakirinên berê bikar bîne"
+
+#~ msgid "New accelerator..."
+#~ msgstr "Lezkera nû..."
+
+#~ msgid "Desktop"
+#~ msgstr "Sermasê"
+
+#~ msgid "Window Management"
+#~ msgstr "Gerînendeyê Paceyan"
+
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Dema lezkereke nû li danegira veavakirinan mîheng dikir çewtî derket: %s\n"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "Dema lezker ji danegira veavakirinan jê dibir çewtî derket: %s\n"
+
+#~ msgid "Keyboard Shortcuts"
+#~ msgstr "Kurteriyên Klavyeyê"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Kurteriyan li fermanan tayîn bike"
+
+#, fuzzy
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "Dema destpêkirina amûra klavyeyê de çewtî derket: %s"
+
+#~ msgid "_Accessibility"
+#~ msgstr "_Gihîştin"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Tenê mîhengan bisepîne û derkeve (bo lihevkirinê, niha ji aliyê daemon tê "
+#~ "kirin)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Mîhengên bêhnvedana nivîsînê nîşan bide û rûpel bide destpêkirin"
+
+#, fuzzy
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "Tercîhên Klavyeyê"
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>Ji bo mecbûrkirina bêhnvedana nivîsînê dîmender _qufle bike</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Bilez</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Dirêj</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Kin</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Hêdî</i></small>"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "Pergalên _derbasdar:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "_Destûrê bide taloqkirina bêhnvedanan"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr ""
+#~ "Kontrol dike bê ka ji bo taloqkirina bêhnvedanan destûr hatiye dayîn yan "
+#~ "na"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Modeleke Klavyeyê Hilbijêre"
+
+#~ msgid "Choose..."
+#~ msgstr "Hilbijêre..."
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Maweya bêhnvedanê dema destûr ji nivîsînê nehate dayîn"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Maweya bêhnvedanê berî ku zorê bide bêhnvedanê"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Tercîhên Klavyeyê"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "_Modela Klavyeyê:"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Ji bo pêşî li nerihetiya ji bikaranîna berdewamî ya klavyeyê bête girtin "
+#~ "dîmenderê demekê bimiftehîne"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Klavyeya Microsoft Natural"
+
+#~ msgid "Separate _group for each window"
+#~ msgstr "Ji bo her paceyê _komeke cuda"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Gihîştin..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Bidawîkirina navberdayinê:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Dema kar:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Tercîhên klavyeyê bike"
+
+#~ msgid "%d millisecond"
+#~ msgid_plural "%d milliseconds"
+#~ msgstr[0] "%d çirke-mîl"
+#~ msgstr[1] "%d çirke-mîl"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Nîşankerê bi Pêşdanasîn -  Ya ku tê bikaraîn"
+
+#~ msgid "The default pointer that ships with X"
+#~ msgstr "Nîşankerê bi pêşdanasîn a bi X re tê"
+
+#~ msgid "White Pointer"
+#~ msgstr "Nîşankerê Sipî"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Nîşankerê Sipî - Yê heyî"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Nîşankerê Mezin - Yê heyî"
+
+#~ msgid "Large version of normal pointer"
+#~ msgstr "Guhertoya mezin a nîşankerê asayî"
+
+#, fuzzy
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Nîşankerê Sipiyê mezin - Yê heyî"
+
+#, fuzzy
+#~ msgid "Large White Pointer"
+#~ msgstr "Nîşankerê Sipî yê Mezin"
+
+#~ msgid "Pointer Theme"
+#~ msgstr "Dirbê nîşanekê"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Nîşanekê bi cih bike</b>"
+
+#~ msgid "<b>Mouse Orientation</b>"
+#~ msgstr "<b>Bicihbûna Mişk</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Lez</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Bilez</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<b>Berz</b>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Mezin</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Lawaz</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Hêdî</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Biçûk</i>"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Dema min pêl bişkoka Ctrl kir cihê nîşandêrê diyar bike"
+
+#~ msgid "Medium"
+#~ msgstr "Navîn"
+
+#~ msgid "Motion"
+#~ msgstr "Tevger"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Tercîhên cîgirê toreyê mîheng bike"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Girêdana Înternetê ya _Rasterast</b>"
+
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>Guh Nede Lîsteya Makîneyan</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Mîhengkirina cîgir ya bi _destan</b>"
+
+#~ msgid "<b>_Use authentication</b>"
+#~ msgstr "<b>_Pelgekirinê bikar bîne</b>"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Veavakirina Pêşketî"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Kîtekîtên Cîgirê HTTPê"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Tercîhên Cîgirê Toreyê"
+
+#~ msgid "Port:"
+#~ msgstr "Port:"
+
+#~ msgid "Proxy Configuration"
+#~ msgstr "Veavakirina Cîgir"
+
+#~ msgid "_Details"
+#~ msgstr "_Hûragahî"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Cîgirê HTTPê yê ewle:"
+
+#~ msgid "Silence"
+#~ msgstr "Bêdengî"
+
+#, fuzzy
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "Tercîhên Deng"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>Konferansên Audio</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Mûzîk û dîmen</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>Buyerên Deng</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "Ji bo bidawîkirinê Temam Bitikîne"
+
+#, fuzzy
+#~ msgid "So_und playback:"
+#~ msgstr "Dîsa lêdana deng:"
+
+#, fuzzy
+#~ msgid "Sou_nd capture:"
+#~ msgstr "Deng jibergirtin:"
+
+#~ msgid "Sounds"
+#~ msgstr "Deng"
+
+#, fuzzy
+#~ msgid "System Beep"
+#~ msgstr "Zengila Pergalê"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "Ceribandina Beralîkirinê"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "Zengila pergalê _çalak bike"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "Dengên pergalê _lê bide"
+
+#, fuzzy
+#~ msgid "_Sound playback:"
+#~ msgstr "Dîsa lêdana deng:"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "Zengila pergala _dîtbarî"
+
+#~ msgid "Would you like to remove this theme?"
+#~ msgstr "Tu dixwazî vî dirbî rake?"
+
+#~ msgid "Theme deleted succesfully. Please select another theme."
+#~ msgstr "Dirb jê nehate birin. Ji kerema xwe re yekî din hilbijêre."
+
+#~ msgid "Theme can not be deleted"
+#~ msgstr "Dirb jê nehate birin"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Di pergalê de qet dirb nehate dîtn. Ev tê vê mahneyê ku pakêta \"gnome-"
+#~ "themes\" nehatiye sazkirin yan jî paceya \"Vebijêrkên Dirban\" şaş hatiye "
+#~ "barkirin."
+
+#, fuzzy
+#~ msgid ""
+#~ "Can not install theme. \n"
+#~ "The %s utility is not installed."
+#~ msgstr ""
+#~ "Dirb nayê sazkirin.\n"
+#~ "Sepana bzip2 ne sazkirî ye."
+
+#, fuzzy
+#~ msgid ""
+#~ "Can not install theme. \n"
+#~ "There was a problem while extracting the theme"
+#~ msgstr ""
+#~ "Dirb nayê sazkirin.\n"
+#~ "Bernameya Tar di pergala te de ne sazkirî ye."
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "Mijara GNOME %s rast hate daxistin"
+
+#~ msgid "The theme is an engine. You need to compile the theme."
+#~ msgstr "Dirb her wekî amûrekê ye. Divê tu berhevkirina dirbê bikî."
+
+#~ msgid "The file format is invalid"
+#~ msgstr "Formata pelî ne derbasdar e."
+
+#, fuzzy
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "Dirbê Gnome yê %s bi awayekî serketî hate sazkirin"
+
+#, fuzzy
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "Tu dixwazî vî dirbî rake?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Mijara berê bihêle"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Mijareke nû bixebitîne"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Pelekî dirban ji bo sazkirinê nehate diyarkirin"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Cihê pelê dirban ji bo sazkirinê ne derbasdar e"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ji bo ku tu karibî dirb li cihê ku jêr saz bike destûr tuneye:\n"
+#~ "%s"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "Formata pel ne derbasdar e."
+
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s cihê ku wê pelê dirban lê bar bibe ye. Ev wekî cihê çavkaniyê nayê "
+#~ "hilbijartin"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "Ji bo tomarkirina vî dirbî pêl bişkoka Dirb Tomar Bike bike"
+
+#, fuzzy
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Pelekî dirban ji bo sazkirinê nehate diyarkirin"
+
+#~ msgid "filename"
+#~ msgstr "navê pelî"
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "Şemayên dirbên standard di pergala te de nehate dîtin. Tê vê mahneyê ku "
+#~ "yan metacity rast nehatiye barkirin yan jî gconf şaş hatiye veavakirin."
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Divê navekî dirban were dîtin"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Dirb jixwe heye. Tu dixwazî têxe şûna wê?"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Ji bo xalên cuda yên sermaseyê dirban hilbijêre"
+
+#~ msgid "Theme"
+#~ msgstr "Dirb"
+
+#, fuzzy
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Ji bo xalên cuda yên sermaseyê dirban hilbijêre"
+
+#, fuzzy
+#~ msgid "Theme Installer"
+#~ msgstr "Sazkirina Dirban"
+
+#~ msgid "<b>You do not have permission to change theme settings</b>"
+#~ msgstr "<b>Destûr ji te re tuneye ku tu mijara mîhengan biguherînî</b>"
+
+#~ msgid "Apply _Background"
+#~ msgstr "_Rûerd Bisepîne"
+
+#~ msgid "Apply _Font"
+#~ msgstr "_Curetîp Bisepîne"
+
+#, fuzzy
+#~ msgid "C_ustomize..."
+#~ msgstr "_Taybet"
+
+#~ msgid "Controls"
+#~ msgstr "Kontrolkirin"
+
+#~ msgid "Icons"
+#~ msgstr "Dawêr"
+
+#, fuzzy
+#~ msgid "Save Theme As..."
+#~ msgstr "Dirb _Tomar Bike..."
+
+#~ msgid "Save _Background Image"
+#~ msgstr "Dîmenê dirbê zemînê tomar bike"
+
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Ji bo sermaseyê dirbekî hilbijêre"
+
+#, fuzzy
+#~ msgid "Text"
+#~ msgstr "Ceribandin"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "Ev dirb curetîp an jî rûerdekeke belî pêşniyar nake."
+
+#~ msgid "This theme suggests a background:"
+#~ msgstr "Ev dirb rûerdekî pêşniyaz dike:"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Ev dirb curetîpan an jî rûerdan pêşniyaz dike:"
+
+#~ msgid "This theme suggests a font:"
+#~ msgstr "Ev curetîpan pêşniyaz dike:"
+
+#~ msgid "Window Border"
+#~ msgstr "Kêleka Paceyan"
+
+#~ msgid "_Description:"
+#~ msgstr "_Şîrove"
+
+#~ msgid "_Install..."
+#~ msgstr "_Daxistin"
+
+#~ msgid "_Revert"
+#~ msgstr "_Bizivirîne Paş"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "Dirb _Tomar Bike..."
+
+#, fuzzy
+#~ msgid "_Selected items:"
+#~ msgstr "Pergalên _hilbijartî:"
+
+#, fuzzy
+#~ msgid "_Windows:"
+#~ msgstr "Pencere"
+
+#~ msgid "theme selection tree"
+#~ msgstr "dara hilbijartina dirban"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "Dîtina darikê pêşek û amûrên sepanan ava bike"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Pêşek û Darikê Amûran"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Tevger û Bergeh</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Pêşdîtin</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "_Jê bike"
+
+#~ msgid "Icons only"
+#~ msgstr "Tenê îkon"
+
+#~ msgid "Save File"
+#~ msgstr "Pelî Tomar Bike"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Di pêşekan de _îkonan nîşan bide"
+
+#~ msgid "Text below icons"
+#~ msgstr "Di binê îkonan de nivîs"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Li kêleka îkonan de nivîs"
+
+#~ msgid "Text only"
+#~ msgstr "Bi tenê nivîs"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Etîketên _bişkokên darikê amûran:"
+
+#~ msgid "_Copy"
+#~ msgstr "_Ji ber bigire"
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "Darikên amûran ên dikarin bên _veqetandin"
+
+#~ msgid "_Edit"
+#~ msgstr "_Sererast bike"
+
+#, fuzzy
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "Lezgînkerê pêşekên dikarin bên _pergalkirin"
+
+#~ msgid "_File"
+#~ msgstr "_Pel"
+
+#~ msgid "_New"
+#~ msgstr "_Nû"
+
+#~ msgid "_Open"
+#~ msgstr "_Veke"
+
+#~ msgid "_Paste"
+#~ msgstr "_Pê ve bike"
+
+#~ msgid "_Print"
+#~ msgstr "_Çap"
+
+#~ msgid "_Quit"
+#~ msgstr "_Derkeve"
+
+#~ msgid "_Save"
+#~ msgstr "_Tomar bike"
+
+#, fuzzy
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr ""
+#~ "<b>Ji bo rêveberê paceya te sepana vebijêrkan nehate xebitandin</b>↵\n"
+#~ "↵\n"
+#~ "%s"
+
+#~ msgid "C_ontrol"
+#~ msgstr "K_ontrol"
+
+#, fuzzy
+#~ msgid "_Alt"
+#~ msgstr "Alt"
+
+#, fuzzy
+#~ msgid "H_yper"
+#~ msgstr "Hîper"
+
+#, fuzzy
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "Super (an jî  \"Logoya Windowsê\")"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Bişkoka Tevgerê</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Çalakiya Darikê Sernavan</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Hilbijartina Paceyan</b>"
+
+#, fuzzy
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Ji bo _guhestina paceyekê, vê bişkojkê pêlêkirî bihêle û dû re bi paceyê "
+#~ "bigire:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Tercîhên Paceyan"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "Ji bo ku tu karibî vî karî bike _du caran darikê sernav bitikîne."
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Derengmayina berî bilindkirinê:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Piştî kêlîkekê paceyên hilbijartî zêde bike"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Di dema derbaskirina mişkê di ser re, Paceyan hildibijêre"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Taybetiyên paceyên xwe mîheng bike"
+
+#~ msgid "Windows"
+#~ msgstr "Pencere"
+
+#~ msgid "Volume"
+#~ msgstr "Deng"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Bila qederê 8 çirkeyan tiliya te li ser bişkoka Shift be. Ev, kurteriya "
+#~ "ku ji bo taybetmendiya Hêdîkirina Bişkokan e da ku celebê xebitandina "
+#~ "kompîtura te bi bandor bike."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Tu dixwazî Hêdîkirina Bişkokan çalak bike?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Tu dixwazî Hêdîkirina Bişkokan bigire?"
+
+#~ msgid "_Activate"
+#~ msgstr "_Çalak bike"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "Çalak _neke"
+
+#~ msgid "Do_n't deactivate"
+#~ msgstr "Ra_newestîne"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "5 caran li ser hev pêl bişkoka Shift bike.Ev, kurteriya ku ji bo "
+#~ "taybetmendiya Bişkokên Mezeloqî ye da ku celebê xebitandina kompîtura te "
+#~ "bi bandor bike."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "Te bi carekê re pêl du heb bişkokan kir yan jî te li ser hev 5 caran pêl "
+#~ "bişkoka Shift kir. Ev, taybetmendiya Bişkokên Mezeloqî ye da ku ji bo "
+#~ "celebê xebitandina klavyeya te bandor dike digire."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Tu dixwazî taybetiya Bişkokên Mezeloqî çalak bike?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Tu dixwazî Bişkokên Mezeloqî bigire?"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "Nikare pêrista \"%s\" ava bike.\n"
+#~ "Ev pêwiste da tu bikaribî mijara nîşankerê mişkê biguherînî."
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Nikare pêrista \"%s\" ava bike.\n"
+#~ "Ev pêwiste da tu bikaribî nîşankeran biguherînî."
+
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "Bikêrhatina (%s) ya Girêdana Bişkokan gelekî hatiye diyarkirin\n"
+
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr ""
+#~ "Girêdayîna (%s) ya Girêdana Bişkokan gelekî zêde hatiye diyarkirin\n"
+
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Girêdana Bişkokê (%s) nehatiye temamkirin\n"
+
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Girêdana Bişkokê (%s) ne derbasdar e.\n"
+
+#, fuzzy
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr "Sepaneke din bişkoka '%d' bikar tîne."
+
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Dema (%s) dixebitî çewtî\n"
+#~ "bi bişkoka (%s) girêdayî"
+
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Dema veavakirina XKB dihate çalakkirin çewtî çêbû\n"
+#~ "Dibe ku ji ber hin çewtiyan çêbûbe:\n"
+#~ "- ji ber çewtiyeke libxklavier\n"
+#~ "- ji ber çewtiyeke Xê (xkbcomp, amûrên xmodmap)\n"
+#~ "- ji ber sepaneke libxfile ya bi Xê re li hev nake\n"
+#~ "\n"
+#~ "Agahiya guhertoya pêşkêşkerê Xê\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "Heke tu yê vê rewşê wekî çewtiyekê ragihîne, ji kerema xwe re van tiştan "
+#~ "jî lê zêde bike:\n"
+#~ "-encama %s\n"
+#~ "-encama %s"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "Tu XFree 4.3.0 bi kar tînî\n"
+#~ "Der barê sepana XKB ya tevlihev de pirsgirêkên tên zanîn hene.\n"
+#~ "Avakirineke hêsantir biceribîne an jî guhartoyeke nivîsyariya XFree ya "
+#~ "nûtir bi dest bixe."
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "Vê hişyariyê careke din nîşan _nede"
+
+#, fuzzy
+#~ msgid ""
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.</b>\n"
+#~ "\n"
+#~ "Expected was %s, but the the following settings were found: %s.\n"
+#~ "\n"
+#~ "Which set would you like to use?"
+#~ msgstr ""
+#~ "Mîhengên klavyeya pergala X ji mîhengên te yên heyî yên klavyeya GNOME "
+#~ "cuda ne. Tu dixwazî kîjan mîhengan bi kar bînî?"
+
+#~ msgid "Keep GNOME settings"
+#~ msgstr "Mîhengên GNOME'yê biparêze"
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Ferman nehate xebitandin:%s\n"
+#~ "Saxtî bike bê ev ferman heye an na."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Mekîne nekete moda razanê.\n"
+#~ "Saxtî bike bê mekîne rast hatiye mîhengkirin an na."
+
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Di destpêkirina dîmender parêzê de çewtî çêbûbû:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Di vê beşê de dê dîmenderparêz neyê xebitandin"
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Vê peyamê careke din nîşan nede"
+
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "Pelê dengê %s wekî mînaka %s bar nekir"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Makepêrista bikarhêner nehate diyarkirin"
+
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "Mifteya GConf %s, li cureyê %s hatiye mîhengkirin, lê cureyê pêwist %s\n"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "Vê hişyariyê careke din nîşan _nede."
+
+#~ msgid "Load modmap files"
+#~ msgstr "Pelên modmap bar bike"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "Tu dixwazî pelên modmap bar bike?"
+
+#~ msgid "_Load"
+#~ msgstr "_Bar bike"
+
+#~ msgid "_Loaded files:"
+#~ msgstr "_Pelên barkirî:"
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Cureyê bg_applier: Ji bo paceya root BG_APPLIER_ROOT an jî pêşdîtina "
+#~ "BG_APPLIER_PREVIEW"
+
+#~ msgid "Preview Width"
+#~ msgstr "Firehiya Pêşdîtinê"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Heke sepîner pêşdîtin be firehî: Weke pêşdanasînî 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Bilindahiya Pêşdîtinê"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Heke sepîner pêşdîtin be bilindahî: Weke pêşdanasîni 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Dîmendera ku wê BGApplier li ser were xêzkirin"
+
+#, fuzzy
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>Destek</b>"
+
+#~ msgid "Help"
+#~ msgstr "Alîkarî"
+
+#~ msgid "Upgrade"
+#~ msgstr "Bilindkirin"
+
+#, fuzzy
+#~ msgid "Uninstall"
+#~ msgstr "_Saz bike"
+
+#, fuzzy
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Çewtiyên Destpêkirinê Nîşan Bide"
+
+#, fuzzy
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>Bişkokên Dubarekirinê</b>"
+
+#, fuzzy
+#~ msgid "Open in File Manager"
+#~ msgstr "Pelî Veke"
+
+#~ msgid "Send To..."
+#~ msgstr "Bişîne..."
+
+#~ msgid "Move to Trash"
+#~ msgstr "Biavêje Çopê"
+
+#, fuzzy
+#~ msgid "Find Now"
+#~ msgstr "Pencere"
+
+#~ msgid "Login"
+#~ msgstr "Teketin"
+
+#~ msgid "Logout"
+#~ msgstr "Derketin"
+
+#~ msgid "Boing"
+#~ msgstr "Boing"
+
+#~ msgid "Siren"
+#~ msgstr "Sîren"
+
+#~ msgid "Clink"
+#~ msgstr "Tikandin"
+
+#, fuzzy
+#~ msgid "Beep"
+#~ msgstr "Xew"
+
+#~ msgid "No sound"
+#~ msgstr "Bêdeng"
+
+#, fuzzy
+#~ msgid "Sound not set for this event."
+#~ msgstr "_Dengên ji bo buyêran"
+
+#, fuzzy
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "Ji bo vê bûyerê deng tuneye.\n"
+#~ "Ji bo dengên pêşdanasînî\n"
+#~ "tu dikarî pakêta gnome-audio saz bikî."
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "Pelê %s ne pelekî wav ya derbasdar e"
+
+#, fuzzy
+#~ msgid "Select sound file..."
+#~ msgstr "Pelê Dengê Hilbijêre"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Gerînendeyê paceyê \"%s\" Alava mîhengkirinê tomar nekiriye\n"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "Heke hatibe hilbijartin wê xebatkerên mime yên text/plain ve text/* bi "
+#~ "hev re werine girtin"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Xebatkerên text/plain ve text/* bi awayekî hevpar bikar bîne"
+
+#~ msgid "E-mail"
+#~ msgstr "E-peyam"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Kurteriya E-peyaman."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Kurteriya peldanka destpêkê."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Kurteriya vekirina geroka alîkariyê."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Kurteriya vekirina geroka webê."
+
+#~ msgid "Lock screen's shortcut."
+#~ msgstr "Kurteriya quflekirina dîmenderê."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Kurteriya derketinê."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Kurteriya bişkoka perçeyê pişt re."
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Kurteriya bişkoka rawestîne."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Kurteriya lê bide (an jî lê bide/rawestîne)"
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Kurteriya bişkoka perçeyê berî vêya."
+
+#~ msgid "Search's shortcut."
+#~ msgstr "Kurteriya lêgerînan."
+
+#~ msgid "Sleep"
+#~ msgstr "Xew"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Kurteriya xewê."
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Kurteriya bişkoka rawestandina lêdanê."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Kurteriya kêmkirina deng."
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Kurteriya deng bibire"
+
+#~ msgid "Volume step"
+#~ msgstr "Rêjekirina deng"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Rêjekirina deng li gor rêjeya deng ya ji sedî."
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr ""
+#~ "Dema dîmenderparêz dihate xebitandin ji bo çewtiyên çêdibin paceya "
+#~ "ragihandinê nîşan bide"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "Di destpêkê de dîmenderparêzê bide xebitandin"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Çewtiyên Destpêkirinê Nîşan Bide"
+
+#~ msgid "Start screensaver"
+#~ msgstr "Dîmenderparêzê bide destpêkirin"
+
+#, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Fîltre"
+
+#, fuzzy
+#~ msgid "Groups"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "Common Tasks"
+#~ msgstr "Pewirên Asayî"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Amûra veavakirinan ya GNOME"
+
+#, fuzzy
+#~ msgid "_Postpone Break"
+#~ msgstr "_Bêhnvedanê taloq bike"
+
+#~ msgid "/_Preferences"
+#~ msgstr "/_Vebijêrk"
+
+#~ msgid "/_About"
+#~ msgstr "/_Der barê"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_ Bêhna Xwe Veke"
+
+#, fuzzy
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "Ji bo bêhnvedaneke din %d xulek ma"
+#~ msgstr[1] "Ji bo bêhnvedaneke din %d xulek ma"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Ji bo navberdayineke din ji xulekekê hindiktir dem maye"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Ji ber vê çewtiyê paceya amadekirinên navberdayina nivîsê nayên jor: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Ji alî Richard Hul ve hatiye nivisandin <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "wêneyên delal ji alî  Anders Carlsson ve hatine bicihkirin"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Bibîranîna bêhnvedana kompiturê"
+
+#~ msgid "translator-credits"
+#~ msgstr "Rizoyê Xerzî, Erdal Ronahi, Koma PCKurd"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr ""
+#~ "The quick brown fox jumps over the lazy dog. ê î û Ê Î Û ç Ç ş Ş "
+#~ "0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Mezinahî:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Mafê Kopyakirinê:"
+
+#~ msgid "Description:"
+#~ msgstr "Daxûyanî:"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "bikaranîn: %s pelê curetîpan\n"
+
+#~ msgid "Sets the default application font"
+#~ msgstr "Curetîpa sepanê ya pêşdanasînî hilbijêre"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Heke li rastiye hatibe mîhengkirin, wê curenivîsên OpenType were "
+#~ "mînakkirin."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Heke li rastiye hatibe mîhengkirin, wê curenivîsên PCF were mînakkirin."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Heke li rastiye hatibe mîhengkirin, wê curenivîsên TrueType were "
+#~ "mînakkirin."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Heke mîheng rast be, dê Type 1 wekî mînakdayînê were nîşandan."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Vê mifteyê ji bo fermana curenivîsên OpenType were mînakkirin mîheng bike"
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Vê mifteyê ji bo fermana curenivîsên PCF were mînakkirin mîheng bike"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Vê mifteyê ji bo fermana curenivîsên TrueType were mînakkirin mîheng bike"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Vê mifteyê ji bo fermana curenivîsên Type1 were mînakkirin mîheng bike"
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Ji bo curetîpên OpenType fermana mînandinê"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Ji bo curetîpên PCF fermana mînandinê"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Ji bo curetîpên TrueType fermana mînandinê"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Ji bo curetîpên Type1 fermana mînandinê"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Der barê mînakdayin û mînaknedayina curetîpên OpenType de"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Der barê mînakdayin û mînaknedayina curetîpên PCF de"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Der barê mînakdayin û mînaknedayina curetîpên TrueType de"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Der barê mînakdayin û mînaknedayina curetîpên Type1 de"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "Nîşandêrê curetîpê GNOME"
+
+#, fuzzy
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "Der barê mînakdayin û mînaknedayina curetîpên Type1 de"
+
+#~ msgid "TEXT"
+#~ msgstr "TEKST"
+
+#~ msgid "SIZE"
+#~ msgstr "MEZINAHÎ"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">Curenivîsa nû bila were sepandin?</"
+#~ "span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Curetîp _nesepîne"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Mijara ku te hilbijartiye curetîpeke nû pêşinyar dike. Pêşdîtina curetîpê "
+#~ "li jêr xuyadike."
+
+#~ msgid "_Apply font"
+#~ msgstr "Curetîp _bisepîne"
+
+#~ msgid "Themes"
+#~ msgstr "Dirb"
+
+#~ msgid "Description"
+#~ msgstr "Daxuyanî"
+
+#~ msgid "Control theme"
+#~ msgstr "Dirbê kontrolkirinê"
+
+#~ msgid "Window border theme"
+#~ msgstr "Dirbê kêleka paceyê"
+
+#~ msgid "Icon theme"
+#~ msgstr "Dirbê îkonan"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABÇÊÎŞÛ"
+
+#~ msgid "[FILE]"
+#~ msgstr "[PEL]"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Dirbê pêşdanasînî mîheng bike"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "Heke rast bexebite, dê mînakên dirbên lêbarkirî bên dayin."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "Heke rast bixebite, dê mînaka dirban nîşan bide."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Vê mifteyê ji bo mînakan ji dirbên lêbarkirî re çêke fermanekê "
+#~ "bimîhengîne."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "Vê mifteyê li fermanekê bimîhengîne ku ji bo dirban mînakan nîşan bide"
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Ji bo dirbên ku hatine barkirin fermana mînandinê"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Ji bo dirban fermana mînandinê"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Der barê mînakdayin û mînaknedayina dirbên lêbarkirî de"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Der barê mînakdayin û mînaknedayina dirban de"
+
+#~ msgid "Old password is incorrect, please retype it"
+#~ msgstr "Şîfreya kevn ne rast e, ji kerema xwe re dîsa binivîse"
+
+#~ msgid "System error has occurred"
+#~ msgstr "Çewtiya  Pergalê Çêbû"
+
+#~ msgid "Could not run /usr/bin/passwd"
+#~ msgstr "/usr/bin/passwd nehate xebitandin"
+
+#~ msgid "Unexpected error has occurred"
+#~ msgstr "Çewtiyeke nenas çêbû"
+
+#~ msgid "Password is too simple"
+#~ msgstr "Şîfre pir hêsan e"
+
+#~ msgid "Old and new passwords are too similar"
+#~ msgstr "Şîfreyên kevn û yên nû pir dişibin hev"
+
+#~ msgid "Old and new password are the same"
+#~ msgstr "Şîfreyên kevn û yên nû weke hev in"
+
+#~ msgid "Please type the password again, it is wrong."
+#~ msgstr "Ji kerema xwe re şîfreyan dîsa binivîse, şîfre şaş e."
+
+#~ msgid "<b>Please type the passwords.</b>"
+#~ msgstr "<b>Ji kerema xwe şîfreyan binivîse.</b>"
+
+#~ msgid "Change Password"
+#~ msgstr "Şîfreyê Biguherîne"
+
+#~ msgid "Old pa_ssword:"
+#~ msgstr "Şîf_reya kevn:"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "Desteka Teknolojiya Alîkar"
+
+#~ msgid "From:"
+#~ msgstr "Ji:"
+
+#~ msgid "To:"
+#~ msgstr "Ji kê re dişîne:"
+
+#~ msgid "Epiphany"
+#~ msgstr "Epiphany"
+
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "Ji kerema xwe re ji bo vê edîtorê nav û fermanekê binivîse."
+
+#~ msgid "Add..."
+#~ msgstr "Lêzêde bike..."
+
+#~ msgid "C_ustom:"
+#~ msgstr "_Taybet:"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Taybetmediyên Edîtorê yên Taybet"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "Xwînerê E-peyaman ya Pêşdanasînî"
+
+#~ msgid "Default Terminal"
+#~ msgstr "Termînala Pêşdanasînî"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "Edîtorê Nivîsê ya  Pêşdanasînî"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "Geroka Torê ya  Pêşdanasînî"
+
+#~ msgid "Default Window Manager"
+#~ msgstr "Menajerê Paceyan yê  Pêşdanasînî"
+
+#~ msgid "Edit..."
+#~ msgstr "Sererast bike..."
+
+#~ msgid "Run in a _terminal"
+#~ msgstr "Di _termînalekê de bixebitîne"
+
+#~ msgid "Terminal"
+#~ msgstr "Termînal"
+
+#~ msgid "Text Editor"
+#~ msgstr "Edîtorê Nivîsê"
+
+#~ msgid "Window Manager"
+#~ msgstr "Menajerê Paceyan"
+
+#~ msgid "_Properties..."
+#~ msgstr "_Taybetî..."
+
+#~ msgid "_Select:"
+#~ msgstr "_Hilbijêre:"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "Curetîpa _Termînalê:"
+
+#~ msgid "..."
+#~ msgstr "..."
+
+#~ msgid "White Cursor"
+#~ msgstr "Nîşankerê Sipî"
+
+#~ msgid "Large Cursor"
+#~ msgstr "Nîşankerê mezin"
+
+#~ msgid "Cursor Theme"
+#~ msgstr "Dirbê Nîşankerê"
+
+#~ msgid "Cursor Size:"
+#~ msgstr "Mezinahiya Nîşankerê:"
+
+#~ msgid ""
+#~ "Can not install themes. \n"
+#~ "The gzip utility is not installed."
+#~ msgstr ""
+#~ "Dirb nayên sazkirin.\n"
+#~ "Sepana gzip ne sazkirî ye."
+
+#~ msgid ""
+#~ "Icon Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Dirbê Îkonan ya %s bi awayekî serkeftî hate sazkirin.\n"
+#~ "Tu dikarî ji kîtekîtên dirban wê hilbijêrî"
+
+#~ msgid ""
+#~ "Windows Border Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Dirbê Kêleka Paceyan %s bi awayekî serketî hate sazkirin.\n"
+#~ "Tu dikarî ji kîtekîtên dirban wê hilbijêrî."
+
+#~ msgid ""
+#~ "Controls Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Dirbên Kontrolkirinan ya %s bi awayekî serkeftî hate sazkirin.\n"
+#~ "Tu dikarî wê ji kîtekîtên dirban hilbijêrî."
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Dirbekî saz bike</span>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+#~ msgstr ""
+#~ "<span size=\"larger\" weight=\"bold\">Vî Dirbî Li Dîskê Tomar Bike</span>"
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr ""
+#~ "Dirbên nû, bi bixwêrekişandina dosiyên dirb a ser paceyê dikare bête "
+#~ "sazkirin."
+
+#~ msgid "Save Theme"
+#~ msgstr "Vî Dirbî Tomar Bike"
+
+#~ msgid "Short _description:"
+#~ msgstr "_Daxuyaniya kurt:"
+
+#~ msgid "Theme _Details"
+#~ msgstr "_Kîtekîtên Dirban"
+
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "_Biçe Peldanka Dirban"
+
+#~ msgid "_Theme name:"
+#~ msgstr "Navê _dirb:"
+
+#~ msgid "Control"
+#~ msgstr "Kontrol"
+
+#~ msgid "Desktop Preferences"
+#~ msgstr "Tercîhên Sermaseyê"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "Bonobo nehate destpêkirin"
+
+#~ msgid "Use GNOME settings"
+#~ msgstr "Mîhengên GNOME bikar bîne"
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "Pelê Glade nehate lêbarkirin.\n"
+#~ "Baş pêbawer be ku ev daemon hatiye lêbarkirin an na."
+
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Dema wêne dihate barkirin çewtî çêbû:%s"
+
+#~ msgid "Event"
+#~ msgstr "Buyêr"
+
+#~ msgid "Sound File"
+#~ msgstr "Dosiyê Dengê"
+
+#~ msgid "_Sounds:"
+#~ msgstr "_Deng:"
+
+#~ msgid "Sound _file:"
+#~ msgstr "Dosiyê _Dengê"
+
+#~ msgid "_Play"
+#~ msgstr "_Bileyîze"
+
+#~ msgid "Brightness down"
+#~ msgstr "Biriqandinê kêm bike"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Kurteriya kêmkirina biriqandinê."
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Kurteriya zêdekirina biriqandinê."
+
+#~ msgid ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+#~ msgstr ""
+#~ "Dema rewşa klavyeyê ji nû ve hate barkirin hemû skrîptên ku wê werine "
+#~ "xebitandin. Ji bo barkirina ji nû ve ya mîhengên di bingeha xwe de "
+#~ "xmodmap e pir bikêrhatî ye"
+
+#~ msgid "A list of modmap files available in the $HOME directory."
+#~ msgstr "Lîsteya pelên modmap yên di pelrêça $HOME de ye."
+
+#~ msgid "Default group, assigned on window creation"
+#~ msgstr "Koma bi pêşdanasîn di dema çêkirina paceyê de tê xuyakirin"
+
+#~ msgid "Keep and manage separate group per window"
+#~ msgstr "Ji bo her paceyekê komeke cuda bigire û bi rê ve bibe"
+
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Pêkanînerê rojanenekirina klavyeyê"
+
+#~ msgid "Keyboard layout"
+#~ msgstr "Rengê klavyeyê"
+
+#~ msgid "Keyboard model"
+#~ msgstr "Modela klavyeyê"
+
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr ""
+#~ "Li şûna vebijêrkên di hundirê gconf de vebijêrkên pergala ASAP ku dê bête "
+#~ "bikaranîn (nayê bikaranîn)"
+
+#~ msgid "Save/restore indicators together with layout groups"
+#~ msgstr "Bi komên pergalê re diyarkeran tomar bike?paşde vegerîne"
+
+#~ msgid "Show layout names instead of group names"
+#~ msgstr "Dêvila navên koman navên pergalan nîşan bide"
+
+#~ msgid ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+#~ msgstr ""
+#~ "Li şûna navên koman navên pergalan nîşan bide (bi tenê ji bo gehartoyên "
+#~ "XFree yên gelek pergalan destek dikin)"
+
+#~ msgid "Suppress the \"X sysconfig changed\" warning message"
+#~ msgstr "peyama hişyariya \"x sysconfig guherî\" nîşan nede"
+
+#~ msgid ""
+#~ "Very soon, keyboard settings in gconf will be overridden (from the system "
+#~ "configuration) This key has been deprecated since GNOME 2.12, please "
+#~ "unset the model, layouts and options keys to get the default system "
+#~ "configuration."
+#~ msgstr ""
+#~ "Di demeke kin de dê li şûna vebijêrkên klavyeyê yên di gconf de "
+#~ "vebijêrkên nû bên (ji avakirina pergalê) Vê mifteyê piştî GNOME 2.12 "
+#~ "derbasdariya xwe winda kir, ji kerama xwe re ji bo nirxên bi pêşdanasîn "
+#~ "mîhengên modelê, pergalan û vebijêrkên bişkojkan rake."
+
+#~ msgid "keyboard layout"
+#~ msgstr "pergala klavyeyê"
+
+#~ msgid "keyboard model"
+#~ msgstr "modela klavyeyê"
+
+#~ msgid "modmap file list"
+#~ msgstr "lîsteya pelên modmap"
+
+#~ msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgstr "ji alî  Richard Hult hatiye nivisandin &lt;richard@imendio.com&gt;"
+
+#~ msgid "Break reminder"
+#~ msgstr "Bîrxistkerê Bêhnvedanê"
+
+#~ msgid "<b>On-screen keyboard</b>"
+#~ msgstr "<b>Klavyeya dîmender</b>"
+
+#~ msgid ""
+#~ "<b>Screenreader and magnifier</b> - <i>Requires assistive technologies</i>"
+#~ msgstr ""
+#~ "<b>Xwînerê dîmender û mezinker</b> - <i>Hecedarî bi alîkariya zanistiyê "
+#~ "heye</i>"
+
+#~ msgid "Start"
+#~ msgstr "Destpêk"
+
+#~ msgid "Default sound card:"
+#~ msgstr "Karta deng ya pêşdanasînî:"
+
+#~ msgid "Sound & Video Preferences"
+#~ msgstr "Deng & Mîhengên Video"
+
+#~ msgid ""
+#~ "<span weight=\"bold\" size=\"larger\">The theme \"%s\" has been installed."
+#~ "</span>\n"
+#~ "\n"
+#~ "Would you like to apply it now, or keep your current theme?"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">Mijar \"%s\" hate daxistin.</span>\n"
+#~ "\n"
+#~ "Tu dixwazî niha bixebitînî, an mijara xwe ya berê bihêlî?"
+
+#~ msgid "Launch calculator's shortcut"
+#~ msgstr "kurteriyên hesabker"
+
+#~ msgid "The Keyboard Preview, X offset"
+#~ msgstr "Pêşdîtina klavye, X offset"
+
+#~ msgid "The Keyboard Preview, Y offset"
+#~ msgstr "Pêşdîtina klavye, Y offset"
+
+#~ msgid "The Keyboard Preview, height"
+#~ msgstr "Pêşdîtina klavye, bilindahî"
+
+#~ msgid "The Keyboard Preview, width"
+#~ msgstr "Pêşdîtina klavye, firehî"

--- a/po/ky.po
+++ b/po/ky.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2012-09-25 09:33+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2012-09-26 22:26+0600\n"
 "Last-Translator: Timur Zhamakeev <ztimur@gmail.com>\n"
 "Language-Team: Kirghiz <gnome-i18n@gnome.org>\n"
@@ -19,5208 +18,6548 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Lokalize 1.4\n"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:2
-msgid "Changes throughout the day"
-msgstr "Күн ичинде алмашат"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Иштемелер"
 
-#: ../panels/background/background.ui.h:3
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Мозаика"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Иштемелер"
 
-#: ../panels/background/background.ui.h:4
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Чоңойтуу"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Оңдоолорду орнотуу"
 
-#: ../panels/background/background.ui.h:5
-msgctxt "background, style"
-msgid "Center"
-msgstr "Ортосу"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "Эшиги ачык"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Масштаб"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Маалыматын кароо"
 
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Толтуруу"
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Издөө"
 
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Span"
-msgstr "Батыруу"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
 
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:199
-msgid "Select Background"
-msgstr "Фонду тандоо"
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Токтотулган"
 
-#: ../panels/background/cc-background-chooser-dialog.c:218
-msgid "Wallpapers"
-msgstr "Тушкагаз"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "Жайгашкан жери"
 
-#: ../panels/background/cc-background-chooser-dialog.c:227
-msgid "Pictures"
-msgstr "Сүрөттөр"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Системалык маалымат"
 
-#: ../panels/background/cc-background-chooser-dialog.c:235
-msgid "Colors"
-msgstr "Түстөр"
-
-#: ../panels/background/cc-background-chooser-dialog.c:244
-msgid "Flickr"
-msgstr "Flickr"
-
-#: ../panels/background/cc-background-chooser-dialog.c:286
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-#: ../panels/user-accounts/um-photo-dialog.c:98
-msgid "Select"
-msgstr "Тандоо"
-
-#: ../panels/background/cc-background-item.c:148
-msgid "multiple sizes"
-msgstr "түрдүү өлчөмү"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:152
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:281
-msgid "No Desktop Background"
-msgstr "Фонсуз Иштакта"
-
-#: ../panels/background/cc-background-panel.c:387
-msgid "Current background"
-msgstr "Учурдагы фон"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
-msgid "Background"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "Фон"
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change the background"
-msgstr "Фонду алмаштыруу"
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Тушкагаз;Экран;Иштакта;"
-
-#. TRANSLATORS: device type
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
-#: ../panels/network/panel-common.c:102
-msgid "Bluetooth"
-msgstr "Bluetooth"
-
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
-msgid "Configure Bluetooth settings"
-msgstr "Bluetooth параметрлери"
-
-#: ../panels/bluetooth/bluetooth.ui.h:1
-msgid "Set Up New Device"
-msgstr "Жаңы түзүм орнотуу"
-
-#: ../panels/bluetooth/bluetooth.ui.h:2 ../panels/network/network.ui.h:9
-msgid "Remove Device"
-msgstr "Түзүмдү алып таштоо"
-
-#: ../panels/bluetooth/bluetooth.ui.h:3
-msgid "Connection"
-msgstr "Байланыш"
-
-#: ../panels/bluetooth/bluetooth.ui.h:4
-msgid "Paired"
-msgstr "Туташкан"
-
-#: ../panels/bluetooth/bluetooth.ui.h:5 ../panels/wacom/cc-wacom-page.c:756
-msgid "Type"
-msgstr "Түрү"
-
-#: ../panels/bluetooth/bluetooth.ui.h:6
-msgid "Address"
-msgstr "Дареги"
-
-#: ../panels/bluetooth/bluetooth.ui.h:7
-msgid "Mouse and Touchpad Settings"
-msgstr "Чычкан жана сенсордук панел параметрлери"
-
-#: ../panels/bluetooth/bluetooth.ui.h:8 ../panels/universal-access/uap.ui.h:38
-msgid "Sound Settings"
-msgstr "Үн параметрлери"
-
-#: ../panels/bluetooth/bluetooth.ui.h:9
-msgid "Keyboard Settings"
-msgstr "Алиптакта параметрлери"
-
-#: ../panels/bluetooth/bluetooth.ui.h:10
-msgid "Send Files..."
-msgstr "Файл жөнөтүү..."
-
-#: ../panels/bluetooth/bluetooth.ui.h:11
-msgid "Browse Files..."
-msgstr "Файл аралоо..."
-
-#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
-#: ../panels/bluetooth/bluetooth.ui.h:13
-msgctxt "Power"
-msgid "Bluetooth"
-msgstr "Bluetooth"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:290
-msgid "Yes"
-msgstr "Ооба"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:290
-msgid "No"
-msgstr "Жок"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:405
-msgid "Bluetooth is disabled"
-msgstr "Bluetooth өчүрүлгөн"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:410
-msgid "Bluetooth is disabled by hardware switch"
-msgstr "Bluetooth аппараттык которгучу менен өчүрүлгөн"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:414
-msgid "No Bluetooth adapters found"
-msgstr "Bluetooth адаптери табылган жок"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:547
-msgid "Visibility"
-msgstr "Көрүнүүсү"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:551
-#, c-format
-msgid "Visibility of “%s”"
-msgstr "“%s” көрүнүүсү"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:595
-#, c-format
-msgid "Remove '%s' from the list of devices?"
-msgstr "'%s' ти түзүмдөр тизмесинен алып таштайлыбы?"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:597
-msgid ""
-"If you remove the device, you will have to set it up again before next use."
-msgstr ""
-"Эгер сиз муну алып таштасаңыз, кийинки жолу колдонгондо кайрадан орнотууңуз "
-"керек."
-
-#. TRANSLATORS: this is where the user can click and import a profile
-#: ../panels/color/cc-color-panel.c:106
-msgid "Other profile…"
-msgstr "Башка профиль…"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:119
-msgid "Default: "
-msgstr "Абалкы: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:126
-msgid "Colorspace: "
-msgstr "Түс мейкиндиги: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:132
-msgid "Test profile: "
-msgstr "Текшерүү профили: "
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:185 ../panels/color/color.ui.h:11
-msgid "Set for all users"
-msgstr "Бардык колдонуучулар үчүн орнотуу"
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:192
-msgid "Create virtual device"
-msgstr "Виртуалдык түзүм түзүү"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:227
-msgid "Select ICC Profile File"
-msgstr "ICC профайлынын файлын тандоо"
-
-#: ../panels/color/cc-color-panel.c:230
-msgid "_Import"
-msgstr "_Импорт"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:241
-msgid "Supported ICC profiles"
-msgstr "Колдоого ээ ICC профайлдары"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:248
-msgid "All files"
-msgstr "Бардык файл"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:522
-msgid "Available Profiles for Displays"
-msgstr "Экрандар үчүн мүмкүн болгон профайлдар"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:526
-msgid "Available Profiles for Scanners"
-msgstr "Сканерлер үчүн мүмкүн болгон профайлдар"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:530
-msgid "Available Profiles for Printers"
-msgstr "Принтерлер үчүн мүмкүн болгон профайлдар"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:534
-msgid "Available Profiles for Cameras"
-msgstr "Камералар үчүн мүмкүн болгон профайлдар"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:538
-msgid "Available Profiles for Webcams"
-msgstr "Вебкамералар үчүн мүмкүн болгон профайлдар"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#. * where the device type is not recognised
-#. Profiles that can be added to the device
-#: ../panels/color/cc-color-panel.c:543 ../panels/color/color.ui.h:2
-msgid "Available Profiles"
-msgstr "Мүмкүн болгон профайлдар"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:824
-#: ../panels/sound/gvc-mixer-dialog.c:1525
-msgid "Device"
-msgstr "Түзүм"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:859
-msgid "Calibration"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
 
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:891
-msgid "Create a color profile for the selected device"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Экран сүрөтү"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
 msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:905 ../panels/color/cc-color-panel.c:929
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Тушкагаз"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
 msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:938
-msgid "The measuring instrument does not support printer profiling."
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Үн"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:949
-msgid "The device type is not currently supported."
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Комбинациялар"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
 msgstr ""
 
-#. TRANSLATORS: this is when an auto-added profile cannot be removed
-#: ../panels/color/cc-color-panel.c:1022
-msgid "Cannot remove automatically added profile"
-msgstr ""
-
-#. TRANSLATORS: this is when there is no profile for the device
-#: ../panels/color/cc-color-panel.c:1359
-msgid "No profile"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1390
-#, c-format
-msgid "%i year"
-msgid_plural "%i years"
-msgstr[0] "%i жыл"
-
-#: ../panels/color/cc-color-panel.c:1401
-#, c-format
-msgid "%i month"
-msgid_plural "%i months"
-msgstr[0] "%i ай"
-
-#: ../panels/color/cc-color-panel.c:1412
-#, c-format
-msgid "%i week"
-msgid_plural "%i weeks"
-msgstr[0] "%i жума"
-
-#. fallback
-#: ../panels/color/cc-color-panel.c:1419
-#, c-format
-msgid "Less than 1 week"
-msgstr "1 жумадан аз"
-
-#: ../panels/color/cc-color-panel.c:1481
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Абалкы RGB"
-
-#: ../panels/color/cc-color-panel.c:1486
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Абалкы CMYK"
-
-#: ../panels/color/cc-color-panel.c:1491
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1609 ../panels/color/cc-color-panel.c:1650
-#: ../panels/color/cc-color-panel.c:1661 ../panels/color/cc-color-panel.c:1672
-msgid "Uncalibrated"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1612
-msgid "This device is not color managed."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1653
-msgid "This device is using manufacturing calibrated data."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1664
-msgid ""
-"This device does not have a profile suitable for whole-screen color "
-"correction."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1697
-msgid "This device has an old profile that may no longer be accurate."
-msgstr ""
-
-#. TRANSLATORS: this is when the calibration profile age is not
-#. * specified as it has been autogenerated from the hardware
-#: ../panels/color/cc-color-panel.c:1725
-msgid "Not specified"
-msgstr ""
-
-#. add the 'No devices detected' entry
-#: ../panels/color/cc-color-panel.c:1910
-msgid "No devices supporting color management detected"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:2139
-msgctxt "Device kind"
-msgid "Display"
-msgstr "Экран"
-
-#: ../panels/color/cc-color-panel.c:2141
-msgctxt "Device kind"
-msgid "Scanner"
-msgstr "Сканер"
-
-#: ../panels/color/cc-color-panel.c:2143
-msgctxt "Device kind"
-msgid "Printer"
-msgstr "Принтер"
-
-#: ../panels/color/cc-color-panel.c:2145
-msgctxt "Device kind"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
 msgid "Camera"
 msgstr "Камера"
 
-#: ../panels/color/cc-color-panel.c:2147
-msgctxt "Device kind"
-msgid "Webcam"
-msgstr "Вебкамера"
-
-#: ../panels/color/color.ui.h:3
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
-msgid "Color"
-msgstr "Түс"
-
-#: ../panels/color/color.ui.h:4
-msgid "Each device needs an up to date color profile to be color managed."
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
 msgstr ""
 
-#: ../panels/color/color.ui.h:5
-msgid "Learn more"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "Микрофондун бийиктиги"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
 msgstr ""
 
-#: ../panels/color/color.ui.h:6
-msgid "Learn more about color management"
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "Жайгашкан жери"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
 msgstr ""
 
-#: ../panels/color/color.ui.h:7
-msgid "Add device"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
 msgstr ""
 
-#: ../panels/color/color.ui.h:8
-msgid "Add a virtual device"
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
 msgstr ""
 
-#: ../panels/color/color.ui.h:9
-msgid "Delete device"
-msgstr "Түзүмдү жоготуу"
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
 
-#: ../panels/color/color.ui.h:10
-msgid "Remove a device"
-msgstr "Түзүмдү алып таштоо"
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
 
-#: ../panels/color/color.ui.h:12
-msgid "Set this profile for all users on this computer"
-msgstr "Бул профайлды компьютердеги бардык колдонуучуларга орнотуу"
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Жарактуу драйвер табылган жок"
 
-#: ../panels/color/color.ui.h:13
-msgid "Add profile"
-msgstr "Профайл кошуу"
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
 
-#: ../panels/color/color.ui.h:14
-msgid "Calibrate…"
-msgstr "Калибрлөө..."
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
 
-#: ../panels/color/color.ui.h:15
-msgid "Calibrate the device"
-msgstr "Түзүмдү калибрлөө"
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Кагаз түрү"
 
-#: ../panels/color/color.ui.h:16
-msgid "Remove profile"
-msgstr "Профайлды жоготуу"
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Байланыш ылдамдыгы"
 
-#: ../panels/color/color.ui.h:17
-msgid "View details"
-msgstr "Маалыматын кароо"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
 
-#: ../panels/color/color.ui.h:18
-msgid "Device type:"
-msgstr "Түзүм түрү:"
-
-#: ../panels/color/color.ui.h:19
-msgid "Manufacturer:"
-msgstr "Өндүрүүчү:"
-
-#: ../panels/color/color.ui.h:20
-msgid "Model:"
-msgstr "Модели:"
-
-#: ../panels/color/color.ui.h:21
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
-"Image files can be dragged on this window to auto-complete the above fields."
+"How much disk space this application is occupying with app data and caches."
 msgstr ""
-"Жогорудагы талааларды автоматтык түрдө толтуруу үчүн, сүрөт файлын бул "
-"терезеге сүйрөп келүүгө болот."
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Color management settings"
-msgstr "Түс башкаруу параметрлери"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Иштемелер"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
-msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
-msgstr "Түс;ICC;Профайл;Калибрлөө;Принтер;Экран;"
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
 
-#. Add some common languages first
-#: ../panels/common/cc-common-language.c:523
-msgid "English"
-msgstr "Англисче"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:525
-msgid "British English"
-msgstr "Британ анлис тилинде"
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:528
-msgid "German"
-msgstr "Немисче"
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:531
-msgid "French"
-msgstr "Французча"
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:534
-msgid "Spanish"
-msgstr "Испанча"
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:536
-msgid "Chinese (simplified)"
-msgstr "Кытайча (жөнөкөй)"
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:539
-msgid "Russian"
-msgstr "Орусча"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Абалкы"
 
-#: ../panels/common/cc-common-language.c:542
-msgid "Arabic"
-msgstr "Арабча"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:571
-msgid "United States"
-msgstr "Кошмо Штаттары"
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Фон"
 
-#: ../panels/common/cc-common-language.c:572
-msgid "Germany"
-msgstr "Германия"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "Принтер кошуу"
 
-#: ../panels/common/cc-common-language.c:573
-msgid "France"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
 msgstr "Франция"
 
-#: ../panels/common/cc-common-language.c:574
-msgid "Spain"
-msgstr "Испания"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:575
-msgid "China"
-msgstr "Кытай"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/common/cc-language-chooser.c:122
-msgid "Other..."
-msgstr "Башка..."
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
 
-#: ../panels/common/cc-language-chooser.c:296
-msgid "Select a region"
-msgstr "Регион тандоо"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
+msgstr "Bluetooth адаптери табылган жок"
 
-#: ../panels/common/gdm-languages.c:781
-msgid "Unspecified"
-msgstr "Аныкталбаган"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
 
-#: ../panels/common/language-chooser.ui.h:1
-msgid "Select a language"
-msgstr "Тил тандоо"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/printers/new-printer-dialog.ui.h:1
-#: ../panels/user-accounts/um-user-panel.c:462
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth аппараттык которгучу менен өчүрүлгөн"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Учуруда үндү ойноткон же жазган иштеме жок."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+#, fuzzy
+msgid "Display Calibration"
+msgstr "Колдонулуучу тил:"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
 msgid "_Cancel"
 msgstr "_Айынуу"
 
-#: ../panels/common/language-chooser.ui.h:3
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+#, fuzzy
+msgid "Quality"
+msgstr "Сүрөттүн сапаттуулугу"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+#, fuzzy
+msgid "Calibration Device"
+msgstr "Түзүмдү калибрлөө"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "Экран"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Ачыктык"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "_Профайл:"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "_Профайл:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Профайл кошуу"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Профайл кошуу"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Импорт"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Кошуу"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
+msgstr "Бардык колдонуучулар үчүн орнотуу"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Бул профайлды компьютердеги бардык колдонуучуларга орнотуу"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "Профайл кошуу"
+
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
+msgstr "Калибрлөө..."
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Түзүмдү калибрлөө"
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "Профайлды жоготуу"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "Маалыматын кароо"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Жогору"
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "10 мүнөт"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 мүнөт"
+
+#: panels/color/cc-color-panel.ui:640
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Төмөн"
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "5 мүнөт"
+
+#: panels/color/cc-color-panel.ui:663
+#, fuzzy
+msgid "Native to display"
+msgstr "_Чагылдырылган дисплейлер"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+#, fuzzy
+msgid "D75"
+msgstr "75%"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Түс"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Түс;ICC;Профайл;Калибрлөө;Принтер;Экран;"
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Тил тандоо"
+
+#: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
 msgstr "_Тандоо"
 
-#: ../panels/datetime/datetime.ui.h:1
-msgid "_Region:"
-msgstr "_Регион:"
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Bluetooth адаптери табылган жок"
 
-#: ../panels/datetime/datetime.ui.h:2
-msgid "_City:"
-msgstr "_Шаар:"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:3
-msgid "_Network Time"
-msgstr "Тармак _убактысы"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translator: this is the separator between hours and minutes, like in HH:MM
-#: ../panels/datetime/datetime.ui.h:5
-msgid ":"
-msgstr ":"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:6
-msgid "Set the time one hour ahead."
-msgstr "Бир саатка алдыга."
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:7
-msgid "Set the time one hour back."
-msgstr "Бир саатка артка."
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:8
-msgid "Set the time one minute ahead."
-msgstr "Бир мүнөткө алдыга."
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Убакыт"
 
-#: ../panels/datetime/datetime.ui.h:9
-msgid "Set the time one minute back."
-msgstr "Бир мүнөткө артка."
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:10
-msgid "Switch between AM and PM."
-msgstr "ТЧ жана ТК алмашуусу."
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:11
-msgid "Month"
-msgstr "Ай"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "Day"
-msgstr "Күн"
-
-#: ../panels/datetime/datetime.ui.h:13
-msgid "Year"
-msgstr "Жыл"
-
-#: ../panels/datetime/datetime.ui.h:14
-msgid "24-hour"
-msgstr "24 саатык формат"
-
-#: ../panels/datetime/datetime.ui.h:15
-msgid "AM/PM"
-msgstr "ТЧ/ТК"
-
-#: ../panels/datetime/datetime.ui.h:16
-msgid "January"
-msgstr "Январь"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "February"
-msgstr "Февраль"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "March"
-msgstr "Март"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "April"
-msgstr "Апрель"
-
-#: ../panels/datetime/datetime.ui.h:20
-msgid "May"
-msgstr "Май"
-
-#: ../panels/datetime/datetime.ui.h:21
-msgid "June"
-msgstr "Июнь"
-
-#: ../panels/datetime/datetime.ui.h:22
-msgid "July"
-msgstr "Июль"
-
-#: ../panels/datetime/datetime.ui.h:23
-msgid "August"
-msgstr "Август"
-
-#: ../panels/datetime/datetime.ui.h:24
-msgid "September"
-msgstr "Сентябрь"
-
-#: ../panels/datetime/datetime.ui.h:25
-msgid "October"
-msgstr "Октябрь"
-
-#: ../panels/datetime/datetime.ui.h:26
-msgid "November"
-msgstr "Ноябрь"
-
-#: ../panels/datetime/datetime.ui.h:27
-msgid "December"
-msgstr "Декабрь"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Дата жана убакыт"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Date and Time preferences panel"
-msgstr "Дата жана убакыт параметрлеринин панели"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Жыл"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Ай"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Январь"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Февраль"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Март"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Апрель"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Май"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Июнь"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Июль"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Август"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Сентябрь"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Октябрь"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Ноябрь"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Декабрь"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Күн"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#, fuzzy
+msgid "Time Zone"
+msgstr "Убакыт"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Дата жана убакыт"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "Автоматтык түрдө"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Саат жэбеси боюнча"
+
+#: panels/datetime/cc-datetime-panel.ui:246
+#, fuzzy
+msgid "Time _Format"
+msgstr "Форматтар"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Дата"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "30 секундда"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Календарь"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Сан"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Саат;Убакыт зонасы;Жайгашуу;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "Системанын убакыт жана дата параметрлерин өзгөртүү"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr ""
 "Убакыт жана дата параметрлерин өзгөртүү үчүн, аутентификациядан өтүү зарыл"
 
-#: ../panels/display/cc-display-panel.c:481
-msgctxt "display panel, rotation"
-msgid "Normal"
-msgstr "Кадимкидей"
-
-#: ../panels/display/cc-display-panel.c:482
-msgctxt "display panel, rotation"
-msgid "Counterclockwise"
-msgstr "Саат жэбесине каршы"
-
-#: ../panels/display/cc-display-panel.c:483
-msgctxt "display panel, rotation"
-msgid "Clockwise"
-msgstr "Саат жэбеси боюнча"
-
-#: ../panels/display/cc-display-panel.c:484
-msgctxt "display panel, rotation"
-msgid "180 Degrees"
-msgstr "180 градуска"
-
-#. Keep this string in sync with gnome-desktop/libgnome-desktop/gnome-rr-labeler.c
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external projector.  Here, "Mirrored" is being
-#. * used as an adjective.  For example, the Spanish translation could be
-#. * "Pantallas en Espejo".
-#.
-#: ../panels/display/cc-display-panel.c:623
-msgid "Mirrored Displays"
-msgstr "Чагылдырылган экрандар"
-
-#: ../panels/display/cc-display-panel.c:647
-#: ../panels/display/display-capplet.ui.h:1
-msgid "Monitor"
-msgstr "Монитор"
-
-#: ../panels/display/cc-display-panel.c:748
-#, c-format
-msgid "%d x %d (%s)"
-msgstr "%d x %d (%s)"
-
-#: ../panels/display/cc-display-panel.c:750
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#: ../panels/display/cc-display-panel.c:1659
-msgid "Drag to change primary display."
-msgstr "Негизги дисплейди өзгөртүү үчүн - жылдырыңыз"
-
-#: ../panels/display/cc-display-panel.c:1717
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr ""
-"Монитордун касиеттерин өзгөртүү үчүн, аны тандаңыз; орунун"
-"алмаштыруу үчүн - жылдырыңыз."
-
-#: ../panels/display/cc-display-panel.c:2105
-msgid "%a %R"
-msgstr "%a %R"
-
-#: ../panels/display/cc-display-panel.c:2107
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
-
-#: ../panels/display/cc-display-panel.c:2269
-#: ../panels/display/cc-display-panel.c:2321
-#, c-format
-msgid "Failed to apply configuration: %s"
-msgstr "Конфигурацияны кабылдоо ишке ашпады: %s"
-
-#: ../panels/display/cc-display-panel.c:2349
-msgid "Could not save the monitor configuration"
-msgstr "Монитордун конфигурациясын сактоого болбоду"
-
-#: ../panels/display/cc-display-panel.c:2409
-msgid "Could not detect displays"
-msgstr "Мониторлорду аныктоого болбоду"
-
-#: ../panels/display/cc-display-panel.c:2603
-msgid "Could not get screen information"
-msgstr "Экран жөнүндө маалымат алууга болбоду"
-
-#: ../panels/display/display-capplet.ui.h:2
-msgid "_Resolution"
-msgstr "_Ажырымдуулук"
-
-#: ../panels/display/display-capplet.ui.h:3
-#, fuzzy
-msgid "R_otation"
-msgstr "_Багыты"
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:5
-msgid "_Mirror displays"
-msgstr "_Чагылдырылган дисплейлер"
-
-#: ../panels/display/display-capplet.ui.h:6
-msgid "Note: may limit resolution options"
-msgstr "Эскертүү: ажырымдуулук параметри чектелүү болушу мүмкүн"
-
-#: ../panels/display/display-capplet.ui.h:7
-msgid "_Detect Displays"
-msgstr "Дисплейлерди _аныктоо"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "Дисплейлер"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Change resolution and position of monitors and projectors"
-msgstr ""
-"Мониторлор жана проекторлордун ажыратымдуулугун жана позициясын өзгөртүү"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr "Панель;Проектор;xrandr;Экран;Ажырымдуулук;Жаңылоо;"
-
-#. Translators: VESA is an techncial acronym, don't translate it.
-#: ../panels/info/cc-info-panel.c:413
-#, c-format
-msgid "VESA: %s"
-msgstr "VESA: %s"
-
-#. TRANSLATORS: device type
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:437 ../panels/network/panel-common.c:82
-#: ../panels/network/panel-common.c:162
-msgid "Unknown"
-msgstr "Белгисиз"
-
-#. translators: This is the type of architecture, for example:
-#. * "64-bit" or "32-bit"
-#: ../panels/info/cc-info-panel.c:593
-#, c-format
-msgid "%d-bit"
-msgstr "%d бит"
-
-#: ../panels/info/cc-info-panel.c:752
-msgid "Unknown model"
-msgstr "Белгисиз модель"
-
-#: ../panels/info/cc-info-panel.c:835
-msgid "The next login will attempt to use the standard experience."
-msgstr "Кийинки жолу системага кирүү учурунда стандарттык режим колдонулат."
-
-#: ../panels/info/cc-info-panel.c:837
-msgid ""
-"The next login will use the fallback mode intended for unsupported graphics "
-"hardware."
-msgstr ""
-"Кийинки жолу системага кирүү учурунда альтернативдик режим колдонулат. "
-"Ал колдоого ээ болбогон графикалык түзүмдөр үчүн жасалган."
-
-#. translators: The hardware is not able to run GNOME 3's
-#. * shell, so we use the GNOME "Fallback" session
-#: ../panels/info/cc-info-panel.c:879
-msgctxt "Experience"
-msgid "Fallback"
-msgstr "Альтернативдик"
-
-#. translators: The hardware is able to run GNOME 3's
-#. * shell, also called "Standard" experience
-#: ../panels/info/cc-info-panel.c:885
-msgctxt "Experience"
-msgid "Standard"
-msgstr "Стандарттык"
-
-#: ../panels/info/cc-info-panel.c:1227
-msgid "Ask what to do"
-msgstr "Эмне кылышты суроо"
-
-#: ../panels/info/cc-info-panel.c:1231
-msgid "Do nothing"
-msgstr "Эч нерсе кылбоо"
-
-#: ../panels/info/cc-info-panel.c:1235
-msgid "Open folder"
-msgstr "Каталогду ачуу"
-
-#: ../panels/info/cc-info-panel.c:1326
-#, fuzzy
-msgid "Other Media"
-msgstr "Башка сактама"
-
-#: ../panels/info/cc-info-panel.c:1357
-msgid "Select an application for audio CDs"
-msgstr "Аудио CD үчүн иштеме тандоо"
-
-#: ../panels/info/cc-info-panel.c:1358
-msgid "Select an application for video DVDs"
-msgstr "Аудио DVD үчүн иштеме тандоо"
-
-#: ../panels/info/cc-info-panel.c:1359
-msgid "Select an application to run when a music player is connected"
-msgstr "Музыкалык плеер туташканда аткарылуучу иштеме тандоо"
-
-#: ../panels/info/cc-info-panel.c:1360
-msgid "Select an application to run when a camera is connected"
-msgstr "Камера туташканда аткарылуучу иштеме тандоо"
-
-#: ../panels/info/cc-info-panel.c:1361
-msgid "Select an application for software CDs"
-msgstr "Программалуу CD үчүн иштеме тандоо"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1373
-msgid "audio DVD"
-msgstr "аудио DVD"
-
-#: ../panels/info/cc-info-panel.c:1374
-msgid "blank Blu-ray disc"
-msgstr "таза Blu-ray диск"
-
-#: ../panels/info/cc-info-panel.c:1375
-msgid "blank CD disc"
-msgstr "таза CD диск"
-
-#: ../panels/info/cc-info-panel.c:1376
-msgid "blank DVD disc"
-msgstr "таза DVD диск"
-
-#: ../panels/info/cc-info-panel.c:1377
-msgid "blank HD DVD disc"
-msgstr "таза HD DVD диск"
-
-#: ../panels/info/cc-info-panel.c:1378
-msgid "Blu-ray video disc"
-msgstr "Blu-ray видео диск"
-
-#: ../panels/info/cc-info-panel.c:1379
-msgid "e-book reader"
-msgstr "электрондук китеп окуу түзүмү"
-
-#: ../panels/info/cc-info-panel.c:1380
-msgid "HD DVD video disc"
-msgstr "HD DVD видео диск"
-
-#: ../panels/info/cc-info-panel.c:1381
-msgid "Picture CD"
-msgstr "Сүрөт CD"
-
-#: ../panels/info/cc-info-panel.c:1382
-msgid "Super Video CD"
-msgstr "Супервидео CD"
-
-#: ../panels/info/cc-info-panel.c:1383
-msgid "Video CD"
-msgstr "Видео CD"
-
-#: ../panels/info/cc-info-panel.c:1384
-msgid "Windows software"
-msgstr "Windows иштемеси"
-
-#: ../panels/info/cc-info-panel.c:1385
-msgid "Software"
-msgstr "Иштеме"
-
-#: ../panels/info/cc-info-panel.c:1508
-#: ../panels/keyboard/keyboard-shortcuts.c:1667
-msgid "Section"
-msgstr "Бөлүм"
-
-#: ../panels/info/cc-info-panel.c:1517 ../panels/info/info.ui.h:11
-msgid "Overview"
-msgstr "Көрүнүшү"
-
-#: ../panels/info/cc-info-panel.c:1523 ../panels/info/info.ui.h:18
-msgid "Default Applications"
-msgstr "Абалкы иштемелер"
-
-#: ../panels/info/cc-info-panel.c:1528 ../panels/info/info.ui.h:26
-msgid "Removable Media"
-msgstr "Ажыратма сактама"
-
-#: ../panels/info/cc-info-panel.c:1533 ../panels/info/info.ui.h:10
-msgid "Graphics"
-msgstr "Графика"
-
-#: ../panels/info/cc-info-panel.c:1735
-#, c-format
-msgid "Version %s"
-msgstr "Версиясы %s"
-
-#: ../panels/info/cc-info-panel.c:1785
-msgid "Install Updates"
-msgstr "Оңдоолорду орнотуу"
-
-#: ../panels/info/cc-info-panel.c:1789
-msgid "System Up-To-Date"
-msgstr "Оңдоолор жок"
-
-#: ../panels/info/cc-info-panel.c:1793
-msgid "Checking for Updates"
-msgstr "Оңдоолорду издөө"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-msgid "Details"
-msgstr "Кеңири маалыматы"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "System Information"
-msgstr "Системалык маалымат"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-#, fuzzy
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"түзүм;система;маалымат;эс;процессор;версия;абалкы;иштеме;"
-"альтернативдик;сунушталган;cd;dvd;usb;аудио;видео;диск;ажыратма;сактама;автоиш"
-"төө;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "Башка сактама кантип иштетилүүсүн танда"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "_Аракет:"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "_Түрү:"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "Түзүм аты"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "Эс"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "Процессор"
-
-#: ../panels/info/info.ui.h:7
-msgid "OS type"
-msgstr "АС тиби"
-
-#: ../panels/info/info.ui.h:8
-msgid "Disk"
-msgstr "Диск"
-
-#: ../panels/info/info.ui.h:9
-msgid "Calculating..."
-msgstr "Эсептөө"
-
-#: ../panels/info/info.ui.h:12
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "_Веб"
 
-#: ../panels/info/info.ui.h:13
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "_Почто"
 
-#: ../panels/info/info.ui.h:14
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "_Календарь"
 
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "_Музыка"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "_Видео"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "_Фото"
 
-#: ../panels/info/info.ui.h:19
-msgid "Select how media should be handled"
-msgstr "Сактама кантип иштетилүүсүн танда"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Абалкы иштемелер"
 
-#: ../panels/info/info.ui.h:20
-msgid "CD _audio"
-msgstr "CD _аудио"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Абалкы иштемелер"
 
-#: ../panels/info/info.ui.h:21
-msgid "_DVD video"
-msgstr "DVD _видео"
-
-#: ../panels/info/info.ui.h:22
-msgid "_Music player"
-msgstr "Музыка _плеери"
-
-#: ../panels/info/info.ui.h:23
-msgid "_Software"
-msgstr "_Иштеме"
-
-#: ../panels/info/info.ui.h:24
-msgid "_Other Media..."
-msgstr "_Башка сактама..."
-
-#: ../panels/info/info.ui.h:25
-msgid "_Never prompt or start programs on media insertion"
-msgstr ""
-"_Сактама түзүмү туташканда программаны иштетүүнү сурабоо жана аны аткарбоо"
-
-#: ../panels/info/info.ui.h:27
-msgid "Driver"
-msgstr "Драйвер"
-
-#: ../panels/info/info.ui.h:28
-msgid "Experience"
-msgstr "Режим"
-
-#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
-#: ../panels/info/info.ui.h:30
-msgid "Forced _Fallback Mode"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
 msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Ресурс"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Bluetooth өчүрүлгөн"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Чагылдырылган экрандар"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Экран"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Багыты"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Ажырымдуулугу"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Масштаб"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Принтерлер табылган жок"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Убакыт"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "мүнөт"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Дисплейлер"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+#, fuzzy
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+"Мониторлор жана проекторлордун ажыратымдуулугун жана позициясын өзгөртүү"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Панель;Проектор;xrandr;Экран;Ажырымдуулук;Жаңылоо;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Коопсуздук ачкычы"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Боёктун деңгээли"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Боёктун деңгээли"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Боёктун деңгээли"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Коопсуздук"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Түзүм аты"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Аппараттык дарек"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Эс"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Процессор"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Графика"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+#, fuzzy
+msgid "Calculating…"
+msgstr "Эсептөө"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Аты"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Түрү"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Версиясы %s"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows иштемеси"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Иштеме"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Түзүмдү алып таштоо"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Түзүм аты"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Наама"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"түзүм;система;маалымат;эс;процессор;версия;абалкы;иштеме;альтернативдик;"
+"сунушталган;cd;dvd;usb;аудио;видео;диск;ажыратма;сактама;автоиштөө;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "Үн жана сактамалар"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Үндү өчүрүү"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Үндү басаңдатуу"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Үндү жогорулатуу"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "Микрофондун бийиктиги"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Медиа плеерди иштетүү"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Ойнотуу (же ойнотуу/пауза)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Ойношун убактылуу токтотуу"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Ойношун токтотуу"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Мурунку трек"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Кийинки трек"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Чыгаруу"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/universal-access/uap.ui.h:68
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Басуу"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
-#: ../panels/region/gnome-region-panel.ui.h:26
-msgid "Switch to next source"
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
 msgstr "Кийинки булакка өтүү"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
-#: ../panels/region/gnome-region-panel.ui.h:24
-msgid "Switch to previous source"
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
 msgstr "Мурунку булакка өтүү"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "Иштемелерди аткаруу"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Жардам браузерин иштетүү"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "_Параметрлер..."
+
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Калькуляторду иштетүү"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "Электрондук почто клиентин иштетүү"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "Веб-аралагычын иштетүү"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "Өзүмдүк каталог"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
 msgid "Search"
 msgstr "Издөө"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "Экран сүрөтү"
-
-#. translators: Pictures is the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to Pictures"
-msgstr "Экран сүрөттөрүн \"Сүрөттөр\" каталогуна жазуу"
-
-#. translators: Pictures is the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to Pictures"
-msgstr "Терезе сүрөттөрүн \"Сүрөттөр\" каталогуна жазуу"
-
-#. translators: Pictures is the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-#, fuzzy
-msgid "Save a screenshot of an area to Pictures"
-msgstr "Областардын сүрөттөрүн \"Сүрөттөр\" каталогуна жазуу"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "Экран сүрөтүн алмашуу буферине көчүрүү"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Терезе сүрөтүн алмашуу буферине көчүрүү"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Област сүрөтүн алмашуу буферине көчүрүү"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
-#: ../panels/region/gnome-region-panel.ui.h:39
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Система"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "Чыгуу"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "Экранды кулпулоо"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "Универсалдык жетүү"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "Көрүнүүсү"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "Чоңойтууну иштетүү же токтотуу"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "Жакындатуу"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "Алыстатуу"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "Экрандан окугучту иштетүү же токтотуу"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "Экран алиптактасын иштетүү же токтотуу"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "Текстин өлчөмүн чоңойтуу"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "Текстин өлчөмүн кичирейтүү"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "Жогору контрастуулукту иштетүү же токтотуу"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:241
-#: ../panels/keyboard/cc-keyboard-option.c:347
-#: ../panels/keyboard/keyboard-shortcuts.c:1132
-#: ../panels/sound/gvc-mixer-control.c:1834
-#: ../panels/user-accounts/um-fingerprint-dialog.c:215
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Disabled"
-msgstr "Токтотулган"
+#: panels/keyboard/cc-input-chooser.ui:5
+#, fuzzy
+msgid "Add an Input Source"
+msgstr "Киргизүү булагын кошуу"
 
-#: ../panels/keyboard/cc-keyboard-option.c:315
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+#, fuzzy
+msgid "No input source selected"
+msgstr "Принтерлер табылган жок"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Параметрлер"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "Чычкан параметрлери"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Алиптактанын жайгашуусун көрсөтүү"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "Түзүмдү алып таштоо"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Киргизүү булактары"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Киргизүү булактарынын параметрлери"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "Альтернативдик символдор баскычы"
 
-#: ../panels/keyboard/cc-keyboard-option.c:320
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "Композиция баскычы"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "Keyboard"
-msgstr "Алиптаката"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "Change keyboard settings"
-msgstr "Алиптакта параметрлерин өзгөртүү"
-
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Комбинация;Кайталоо;Өчүп-жануу;"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "Баскычтардын кошумча комбинациясы"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "_Name:"
-msgstr "_Аталышы:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "C_ommand:"
-msgstr "_Команда:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "Repeat Keys"
-msgstr "Автокайталоо"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Key presses _repeat when key is held down"
-msgstr "Басылып турган баскычты _кайталоо"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "_Delay:"
-msgstr "_Аралык:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Speed:"
-msgstr "_Ылдамдык:"
-
-#. short delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-#: ../panels/universal-access/uap.ui.h:49
-msgid "Short"
-msgstr "Кыска"
-
-#. slow acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Slow"
-msgstr "Жай"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgid "Repeat keys speed"
-msgstr "Баскычты кайталоо ылдамдыгы"
-
-#. long delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Long"
-msgstr "Узун"
-
-#. fast acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Fast"
-msgstr "Тез"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgid "Cursor Blinking"
-msgstr "Курсордун өчүп-жануусу"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor _blinks in text fields"
-msgstr "Курсор тексттик талааларда _өчүп-жанат"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "S_peed:"
-msgstr "_Ылдамдык:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "Cursor blink speed"
-msgstr "Курсордун  өчүп-жануу ылдамдыгы"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 #, fuzzy
-msgid "Layout Settings"
-msgstr "Тактанын параметрлери"
+msgid "Keyboard Shortcuts"
+msgstr "Алиптакта параметрлери"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-msgid "Add Shortcut"
-msgstr "Комбинация кошуу"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Кошумча комбинациялар"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Remove Shortcut"
-msgstr "Комбинацияны жоготуу"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-#: ../panels/wacom/button-mapping.ui.h:3
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
 msgstr ""
-"Комбинацияны оңдоо үчүн, сапты тандап жаңы баскычты басыңыз "
-"же өчүрүү үчүн Backspace баскычын колдонуңуз"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-#: ../panels/region/gnome-region-panel.ui.h:29
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Бөлүм"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "Комбинациялар"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:557
-#: ../panels/keyboard/keyboard-shortcuts.c:565
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Комбинация кошуу"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "Кошумча комбинациялар"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:776
-msgid "<Unknown Action>"
-msgstr "<Белгисиз аракет>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1273
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-"\"%s\" комбинациясын колдонууга болбойт, себеби аны колдону терүүгө "
-"мүмкүн эмес.\n"
-"Control, Alt же Shift баскычтары менен чогуу колдонуп көрүңүз."
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1305
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-"\"%s\" комбинациясы \n"
-"\"%s\" үчүн колдонулууда"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1310
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1316
-msgid "_Reassign"
-msgstr "_Кайра аныктоо"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Комбинация кошуу"
 
-#: ../panels/mouse/cc-mouse-panel.c:152
-msgid "_Test Your Settings"
-msgstr "Сиздин параметрлериңизди _текшерүү"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse & Touchpad"
-msgstr "Чычкан жана сенсордук такта"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Set your mouse and touchpad preferences"
-msgstr "Сиздин чычкан түзүмүңүздүн жана сенсордук тактаңыздын параметрлери"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "Mouse Preferences"
-msgstr "Чычкан параметрлери"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "General"
-msgstr "Жалпы"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "Double-click timeout"
-msgstr "Коштоп чертүү аралыгы"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "_Double-click"
-msgstr "_Коштоп чертүү"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Primary _button"
-msgstr "Негизги _черткич"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Left"
-msgstr "_Солдогусу"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgid "_Right"
-msgstr "_Оңдогусу"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgid "Mouse"
-msgstr "Чычкан"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "_Pointer speed"
-msgstr "_Көрсөткүчтүн  ылдамдыгы"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgid "Touchpad"
-msgstr "Сенсордук такта"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgid "Disable while _typing"
-msgstr "_Терүү учурунда өчүрүү"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Tap to _click"
-msgstr "_Тийгенде чертүү катары кароо"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Two _finger scroll"
-msgstr "_Эки манжа менен жылдыруу"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "C_ontent sticks to fingers"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:134
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:139
-msgid "Five clicks, GEGL time!"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:144
-msgid "Double click, primary button"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:144
-msgid "Single click, primary button"
-msgstr ""
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Аты"
 
-#: ../panels/mouse/gnome-mouse-test.c:147
-msgid "Double click, middle button"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-test.c:147
-msgid "Single click, middle button"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-test.c:150
-msgid "Double click, secondary button"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-test.c:150
-msgid "Single click, secondary button"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:615
-msgid "Network proxy"
-msgstr "Тармак проксиси"
-
-#: ../panels/network/cc-network-panel.c:799 ../panels/network/net-vpn.c:278
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:866
-msgid "The system network services are not compatible with this version."
-msgstr ""
-
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:1001
-msgid "Air_plane Mode"
-msgstr ""
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "Тармак"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Network settings"
-msgstr "Тармак параметрлери"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 #, fuzzy
-msgid "Network;Wireless;IP;LAN;Proxy;"
-msgstr "Тармак;Wireless;IP;LAN;Прокси;"
+msgid "Command"
+msgstr "_Команда:"
 
-#: ../panels/network/net-device-mobile.c:222
-msgid "Add new connection"
-msgstr "Жаңы туташуу кошуу"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+#, fuzzy
+msgid "Shortcut"
+msgstr "Комбинациялар"
 
-#. Translators: network device speed
-#: ../panels/network/net-device-mobile.c:261
-#: ../panels/network/net-device-wifi.c:759
-#: ../panels/network/net-device-wired.c:126
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Мб/с"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Баскычтардын кошумча комбинациясы"
 
-#. TRANSLATORS: this is when the access point is not shown
-#. * in the list and the user has to enter the SSID manually
-#.
-#: ../panels/network/net-device-wifi.c:192
-msgid "Connect to a Hidden Network"
-msgstr "Жашыруун тармакка туташуу"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/net-device-wifi.c:291
-#: ../panels/network/net-device-wifi.c:470
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/net-device-wifi.c:295
-#: ../panels/network/net-device-wifi.c:474
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/net-device-wifi.c:299
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/net-device-wifi.c:304
-msgid "Enterprise"
-msgstr "Ишкана"
-
-#: ../panels/network/net-device-wifi.c:309
-#: ../panels/network/net-device-wifi.c:465
-msgctxt "Wifi security"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Жок"
 
-#: ../panels/network/net-device-wifi.c:686
-msgid "never"
-msgstr "эч качан"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
 
-#: ../panels/network/net-device-wifi.c:696
-msgid "today"
-msgstr "бүгүн"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
 
-#: ../panels/network/net-device-wifi.c:698
-msgid "yesterday"
-msgstr "кечээ"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Алиптаката"
 
-#: ../panels/network/net-device-wifi.c:700
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Учуруда үндү ойноткон же жазган иштеме жок."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Микрофондун бийиктиги"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Учуруда үндү ойноткон же жазган иштеме жок."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Сиздин параметрлериңизди _текшерүү"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Жалпы"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "Негизги _черткич"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Сол"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Оң"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Жайгашкан жери"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Чычкан"
+
+# чычканды ушинтип атасакчы? ;)
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Чертмек баскычтары"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Бөлүм"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Сенсордук такта"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Сенсордук такта"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Ыкма"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "_Тийгенде чертүү катары кароо"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "_Тийгенде чертүү катары кароо"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_Терүү учурунда өчүрүү"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "_Ыкма"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Эки тараптуу"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Чычкан жана сенсордук такта"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Түс мейкиндиги: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Монитор"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Негизги дисплейди өзгөртүү үчүн - жылдырыңыз"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Иштемелер"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Туташкан түзүмдөр"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Жаңы туташуу кошуу"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Туташкан"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Параметрлер"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Тармактын аты"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "Топтун сырсөзү"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Топтун сырсөзү"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Bluetooth адаптери табылган жок"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Тармак"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+#, fuzzy
+msgid "802.1x _Security"
+msgstr "Коопсуздук"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i күн мурун"
 
-#. TRANSLATORS: VPN status
-#: ../panels/network/net-device-wifi.c:769
-#: ../panels/network/panel-common.c:277
-msgid "Not connected"
-msgstr "Туташкан эмес"
-
-#: ../panels/network/net-device-wifi.c:771
-#: ../panels/network/net-device-wifi.c:2075
-msgid "Out of range"
-msgstr "Жетүү зонасынан тышкары"
-
-#: ../panels/network/net-device-wifi.c:802
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Жок"
-
-#: ../panels/network/net-device-wifi.c:804
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Аз"
-
-#: ../panels/network/net-device-wifi.c:806
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Орто"
-
-#: ../panels/network/net-device-wifi.c:808
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Жакшы"
-
-#: ../panels/network/net-device-wifi.c:810
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Эң жакшы"
-
-#: ../panels/network/net-device-wifi.c:994
-#, c-format
-msgid ""
-"Network details for %s including password and any custom configuration will "
-"be lost."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1005
-msgid "Forget"
-msgstr "Унутуу"
-
-#: ../panels/network/net-device-wifi.c:1541
-msgid ""
-"If you have a connection to the Internet other than wireless, you can use it "
-"to share your internet connection with others."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1545
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1549
-msgid ""
-"It is not possible to access the internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1615
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-
-#: ../panels/network/net-device-wifi.c:1618
-msgid "_Stop Hotspot"
-msgstr ""
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr ""
-
-#: ../panels/network/net-proxy.c:367
-msgid "Proxy"
-msgstr "Прокси"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "Провайдер"
-
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:686 ../panels/network/panel-common.c:688
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP дарек"
-
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-wifi.ui.h:13
-#: ../panels/network/network-wired.ui.h:3 ../panels/network/panel-common.c:684
-msgid "IPv6 Address"
-msgstr "IPv6 дарек"
-
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-wifi.ui.h:14
-#: ../panels/network/network-wired.ui.h:4
-msgid "Default Route"
-msgstr "Алдына алынган маршрут"
-
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-wifi.ui.h:15
-#: ../panels/network/network-wired.ui.h:5
-msgid "DNS"
-msgstr "DNS"
-
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-wired.ui.h:6
-msgid "_Options..."
-msgstr "_Параметрлер..."
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:5
-msgctxt "proxy method"
-msgid "None"
-msgstr "Жок"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:6
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "Өз алдынча"
-
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:7
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "Автоматтык түрдө"
-
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
-msgstr "_Ыкма"
-
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "_Конфигурациялоочу URL"
-
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "_HTTP проксиси"
-
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "H_TTPS проксиси"
-
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "_FTP проксиси"
-
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "_Socks хосту"
-
-#: ../panels/network/network.ui.h:1
-msgid "Select the interface to use for the new service"
-msgstr ""
-
-#: ../panels/network/network.ui.h:2
-msgid "C_reate..."
-msgstr "_Түзүү..."
-
-#: ../panels/network/network.ui.h:3
-msgid "_Interface"
-msgstr "_Интерфейс"
-
-#: ../panels/network/network.ui.h:4 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/network.ui.h:8
-msgid "Add Device"
-msgstr "Түзүм кошуу"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN түрү"
-
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "Шлюз"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "Топтун аты"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "Топтун сырсөзү"
-
-#: ../panels/network/network-vpn.ui.h:6
-msgid "Username"
-msgstr "Наама"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "_Configure..."
-msgstr "_Конфигурация..."
-
-#: ../panels/network/network-wifi.ui.h:1
-msgid "Wireless Hotspot"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Turn On"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/network-wifi.ui.h:3 ../panels/network/panel-common.c:90
-msgid "Wireless"
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:4
-msgid "_Use as Hotspot..."
-msgstr ""
-
-#: ../panels/network/network-wifi.ui.h:5
-msgid "_Disconnect"
-msgstr "_Ажыратуу"
-
-#: ../panels/network/network-wifi.ui.h:6
-msgid "_Connect"
-msgstr "_Туташуу"
-
-#: ../panels/network/network-wifi.ui.h:7
-msgid "Last used"
-msgstr "Акыркы колдонулганы"
-
-#: ../panels/network/network-wifi.ui.h:8
-#: ../panels/network/network-wired.ui.h:1
-msgid "Hardware Address"
-msgstr "Аппараттык дарек"
-
-#: ../panels/network/network-wifi.ui.h:9
-msgid "Security"
-msgstr "Коопсуздук"
-
-#: ../panels/network/network-wifi.ui.h:10
-msgid "Strength"
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+#, fuzzy
+msgid "Signal Strength"
 msgstr "Кубаттуулугу"
 
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Байланыш ылдамдыгы"
 
-#: ../panels/network/network-wifi.ui.h:12
-#: ../panels/network/network-wired.ui.h:2 ../panels/network/panel-common.c:683
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Коопсуздук"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 дарек"
 
-#: ../panels/network/network-wifi.ui.h:16
-msgid "_Forget Network"
-msgstr "Тармакты _унутуу"
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 дарек"
 
-#: ../panels/network/network-wifi.ui.h:17
-msgid "_Settings..."
-msgstr "_Параметрлер..."
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr "Аппараттык дарек"
 
-#: ../panels/network/network-wifi.ui.h:18
-msgid "Switch off to connect to a wireless network"
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Колдоого ээ ICC профайлдары"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Алдына алынган маршрут"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:208
+#, fuzzy
+msgid "Last Used"
+msgstr "Акыркы колдонулганы"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
 msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:19
-msgid "Network Name"
-msgstr "Тармактын аты"
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:20
-msgid "Connected Devices"
-msgstr "Туташкан түзүмдөр"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Security type"
-msgstr "Коопсуздук түрү"
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
 
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Security key"
-msgstr "Коопсуздук ачкычы"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Аталышы:"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:86
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "Дареги"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "IP дарек"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "_Ыкма"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+#, fuzzy
+msgid "Automatic (DHCP)"
+msgstr "Автоматтык түрдө"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+#, fuzzy
+msgid "Manual"
+msgstr "Өз алдынча"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Токтотулган"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Дареги"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Дареги"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "Автоматтык түрдө"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+#, fuzzy
+msgid "Automatic DNS"
+msgstr "Автоматтык түрдө"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+#, fuzzy
+msgid "Automatic Routes"
+msgstr "Автоматтык түрдө"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Метрикалык"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "_Ыкма"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+#, fuzzy
+msgid "Automatic, DHCP only"
+msgstr "Автоматтык түрдө"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+#, fuzzy
+msgid "S_ecurity"
+msgstr "Коопсуздук"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Тармак"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Тармак;Wireless;IP;LAN;Прокси;"
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Кабелдик"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:97
+#: panels/network/network-bluetooth.ui:11
 #, fuzzy
-msgid "Mobile broadband"
-msgstr "Мобилдик жазы каналдуу"
+msgid "Turn device off"
+msgstr "Жандыруу же өчүрүү:"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:106
-msgid "Mesh"
-msgstr "Тармактык"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Активдүү тапшырмалар"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:166
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:170
-msgid "Infrastructure"
-msgstr "Инфраструктура"
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Провайдер"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:194 ../panels/network/panel-common.c:255
-msgid "Status unknown"
-msgstr "Абалы белгисиз"
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP дарек"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:198
-msgid "Unmanaged"
-msgstr "Башкарууга мүмкүн эмес"
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Тармак проксиси"
 
-#: ../panels/network/panel-common.c:203
-msgid "Firmware missing"
-msgstr "Фирмалык программасы жок"
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP проксиси"
 
-#: ../panels/network/panel-common.c:206
-msgid "Cable unplugged"
-msgstr "Кабель суурулган"
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS проксиси"
 
-#: ../panels/network/panel-common.c:208
-msgid "Unavailable"
-msgstr "Жеткиликтүү эмес"
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP проксиси"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:212
-msgid "Disconnected"
-msgstr "Ажыратылган"
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks хосту"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
-msgid "Connecting"
-msgstr "Туташуу"
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
-msgid "Authentication required"
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "_HTTP проксиси"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "H_TTPS проксиси"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP проксиси"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Конфигурациялоочу URL"
+
+#: panels/network/network-vpn.ui:11
+#, fuzzy
+msgid "Turn VPN connection off"
+msgstr "Жандыруу же өчүрүү:"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Тармактын аты"
+
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Коопсуздук түрү"
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Топтун сырсөзү"
+
+#: panels/network/network-wifi.ui:90
+#, fuzzy
+msgid "Turn Wi-Fi off"
+msgstr "Жандыруу же өчүрүү:"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:119
+#, fuzzy
+msgid "_Connect to Hidden Network…"
+msgstr "Жашыруун тармакка туташуу"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
 msgstr "Аутентификация талап кылынат"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227 ../panels/network/panel-common.c:269
-msgid "Connected"
-msgstr "Туташкан"
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:231
-msgid "Disconnecting"
-msgstr "Ажыратуу"
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:273
-msgid "Connection failed"
-msgstr "Туташуу ишке ашпады"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:239 ../panels/network/panel-common.c:281
-msgid "Status unknown (missing)"
-msgstr "Абалы белгисиз  (жок)"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:301
-msgid "Configuration failed"
-msgstr "Конфигурциялоо ишке ашпады"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:305
-msgid "IP configuration failed"
-msgstr "IP конфигурациялоо ишке ашпады"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:309
-msgid "IP configuration expired"
-msgstr "IP конфигурациясынын убакыты өтүп кеткен"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:313
-msgid "Secrets were required, but not provided"
-msgstr "Сырсөз талап кылынат, бирок берилген эмес"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:317
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x клиенти ажыратылган"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:321
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x клиентин конфигурациялоо ишке ашпады"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:325
+#: panels/network/wireless-security/eap-method-fast.ui:67
 #, fuzzy
-msgid "802.1x supplicant failed"
-msgstr "802.1x клиентинин катасы"
+msgid "PAC _file"
+msgstr "Бардык файл"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:329
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x клиенти аутентификацядан өтө узак өтүүдө"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:333
-msgid "PPP service failed to start"
-msgstr "PPP кызматы ишин баштай албады"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:337
-msgid "PPP service disconnected"
-msgstr "PPP кызматы ажыратылган"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:341
-msgid "PPP failed"
-msgstr "PPP катасы"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:345
-msgid "DHCP client failed to start"
-msgstr "DHCP клиенти ишин баштай албады"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:349
-msgid "DHCP client error"
-msgstr "DHCP клиентинин катасы"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:353
-msgid "DHCP client failed"
-msgstr "DHCP клиент катасы"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:357
-msgid "Shared connection service failed to start"
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:361
-msgid "Shared connection service failed"
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:365
-msgid "AutoIP service failed to start"
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:369
-msgid "AutoIP service error"
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:373
-msgid "AutoIP service failed"
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:377
-msgid "Line busy"
-msgstr "Канал бош эмес"
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "Топтун сырсөзү"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:381
-msgid "No dial tone"
-msgstr "Каналда сигнал жок"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:385
-msgid "No carrier could be established"
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:389
-msgid "Dialing request timed out"
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Версиясы %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Версиясы %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:393
-msgid "Dialing attempt failed"
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:397
-msgid "Modem initialization failed"
-msgstr "Модемди инициализациялоо ишке ашпады"
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Аутентификация талап кылынат"
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:401
-msgid "Failed to select the specified APN"
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:405
-msgid "Not searching for networks"
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:409
-msgid "Network registration denied"
-msgstr "Тармак каттоодон баш тартты"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:413
-msgid "Network registration timed out"
-msgstr "Тармактын каттоо убакыты бүттү"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:417
-msgid "Failed to register with the requested network"
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:421
-msgid "PIN check failed"
-msgstr "PIN текшерүү катасы"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:425
-msgid "Firmware for the device may be missing"
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:429
-msgid "Connection disappeared"
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:433
-msgid "Carrier/link changed"
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+#, fuzzy
+msgid "PAP"
+msgstr "WPA"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:437
-msgid "Existing connection was assumed"
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:441
-msgid "Modem not found"
-msgstr "Модем табылган жок"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:445
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth туташуу катасы"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:449
-msgid "SIM Card not inserted"
-msgstr "SIM картасы орнотулган эмес"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:453
-msgid "SIM Pin required"
-msgstr "SIM картанын Pin коду керек"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:457
-msgid "SIM Puk required"
-msgstr "SIM картанын Puk коду керек"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:461
-msgid "SIM wrong"
-msgstr "Туура эмес SIM карта"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:465
-msgid "InfiniBand device does not support connected mode"
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
 msgstr ""
 
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:469
-msgid "Connection dependency failed"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
 msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:249
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:371
-msgid "Error logging into the account"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:425
-msgid "Expired credentials. Please log in again."
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:428
-msgid "_Log In"
-msgstr "_Кирүү"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:664
-msgid "Error creating account"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:706
-msgid "Error removing account"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:742
-msgid "Are you sure you want to remove the account?"
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:744
-msgid "This will not remove the account on the server."
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "Аутентификация талап кылынат"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "_Түрү:"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Абалкы"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Система"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
 msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:745
-msgid "_Remove"
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
 msgstr ""
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Багыты"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Үн эффектери"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Убакыт өткөндө _бекит:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Убакыт өткөндө _бекит:"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Монитордун конфигурациясын сактоого болбоду"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+#, fuzzy
+msgid "Connect to your data in the cloud"
+msgstr "Жашыруун тармакка туташуу"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Жаңы туташуу кошуу"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr ""
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "Manage online accounts"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 
-#. Translators: those are keywords for the online-accounts control-center panel
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
-msgstr ""
-
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr ""
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr ""
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr ""
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
 
-#: ../panels/power/cc-power-panel.c:157
-msgid "Unknown time"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:163
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i  мүнөт"
 
-#: ../panels/power/cc-power-panel.c:175
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i саат"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:183
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:184
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "саат"
 
-#: ../panels/power/cc-power-panel.c:185
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "мүнөт"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:228
-#, c-format
-msgid "Charging - %s until fully charged"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:236
-#, c-format
-msgid "Caution low battery, %s remaining"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:244
-#, c-format
-msgid "Using battery power - %s remaining"
-msgstr "Батарея колдонулууда - %s калды"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:261
-msgid "Charging"
-msgstr "Заряд алуу"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Using battery power"
-msgstr "Батареяны колдонуу"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:270
-msgid "Charging - fully charged"
-msgstr "Заряд алуу - толду"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:274
-msgid "Empty"
-msgstr "Бош"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:342
-#, c-format
-msgid "Caution low UPS, %s remaining"
-msgstr ""
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:348
-#, c-format
-msgid "Using UPS power - %s remaining"
-msgstr ""
-
-#. TRANSLATORS: UPS battery
-#: ../panels/power/cc-power-panel.c:366
-msgid "Caution low UPS"
-msgstr ""
-
-#. TRANSLATORS: UPS battery
-#: ../panels/power/cc-power-panel.c:371
-msgid "Using UPS power"
-msgstr ""
-
-#. TRANSLATORS: secondary battery is normally in the media bay
-#: ../panels/power/cc-power-panel.c:423
-msgid "Your secondary battery is fully charged"
-msgstr ""
-
-#. TRANSLATORS: secondary battery is normally in the media bay
-#: ../panels/power/cc-power-panel.c:427
-msgid "Your secondary battery is empty"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:510
-msgid "Wireless mouse"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:514
-msgid "Wireless keyboard"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:518
-msgid "Uninterruptible power supply"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:522
-msgid "Personal digital assistant"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:526
-msgid "Cellphone"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:530
-msgid "Media player"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:534
-msgid "Tablet"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:538
-msgid "Computer"
-msgstr ""
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:542
-msgid "Battery"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:553
-msgctxt "Battery power"
-msgid "Charging"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:560
-msgctxt "Battery power"
-msgid "Caution"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:565
-msgctxt "Battery power"
-msgid "Low"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:570
-msgctxt "Battery power"
-msgid "Good"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:575
-msgctxt "Battery power"
-msgid "Charging - fully charged"
-msgstr ""
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:579
-msgctxt "Battery power"
-msgid "Empty"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1075
-msgid ""
-"Tip: <a href=\"screen\">screen brightness</a> affects how much power is used"
-msgstr ""
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr ""
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Power management settings"
-msgstr ""
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid "Power;Sleep;Suspend;Hibernate;Battery;"
-msgstr ""
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr ""
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr ""
-
-#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
-msgid "5 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
 msgstr "5 мүнөт"
 
-#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:7
-msgid "10 minutes"
-msgstr "10 мүнөт"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 мүнөттө"
 
-#: ../panels/power/power.ui.h:5 ../panels/screen/screen.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 мүнөт"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 мүнөт"
 
-#: ../panels/power/power.ui.h:6 ../panels/screen/screen.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "5 мүнөт"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 саат"
 
-#: ../panels/power/power.ui.h:7
-msgid "Don't suspend"
-msgstr "Күтүү режимине өткөрбөө"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "10 мүнөт"
 
-#: ../panels/power/power.ui.h:8
-msgid "On battery power"
-msgstr "Батареядан иштеп жатканда"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "10 мүнөт"
 
-#: ../panels/power/power.ui.h:9
-msgid "When plugged in"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "10 мүнөт"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "1 саат"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+#, fuzzy
+msgid "Devices"
+msgstr "Түзүм"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Параметрлер жүктөлүүдө..."
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Экрандын ачыктыгы жана экранды бекитүүнүн  параметрлери"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Экрандан окуу"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Автоматтык түрдө"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+#, fuzzy
+msgid "Automatic Suspend"
+msgstr "Автоматтык түрдө"
+
+#: panels/power/cc-power-panel.ui:267
+#, fuzzy
+msgid "_Plugged In"
 msgstr "Ток булагына туташканда"
 
-#: ../panels/power/power.ui.h:10
-msgid "Suspend when inactive for"
-msgstr "Көрсөтүлгөн убакта жөн турса"
+#: panels/power/cc-power-panel.ui:279
+#, fuzzy
+msgid "On _Battery Power"
+msgstr "Батареядан иштеп жатканда"
 
-#: ../panels/power/power.ui.h:11
-msgid "When power is _critically low"
-msgstr "Батареянын кубаттуулугу _критикалык азайганда"
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Аралык:"
 
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:589
-msgid "Low on toner"
-msgstr "Тонер аз"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:591
-msgid "Out of toner"
-msgstr "Тонер жок"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:594
-msgid "Low on developer"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
 msgstr ""
 
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:597
-msgid "Out of developer"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
 msgstr ""
 
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:599
-msgid "Low on a marker supply"
-msgstr "Маркер жакында бүтөт"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:601
-msgid "Out of a marker supply"
-msgstr "Маркер бүттү"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:603
-msgid "Open cover"
-msgstr "Капкагы ачык"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:605
-msgid "Open door"
-msgstr "Эшиги ачык"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:607
-msgid "Low on paper"
-msgstr "Кагаз аз"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:609
-msgid "Out of paper"
-msgstr "Кагаз жок"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:611
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Өчүрүлгөн"
-
-#. Translators: Someone has paused the Printer
-#: ../panels/printers/cc-printers-panel.c:613
-msgctxt "printer state"
-msgid "Paused"
-msgstr "Паузада"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:615
-msgid "Waste receptacle almost full"
-msgstr "Резервуар толгонуна жакын калды"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:617
-msgid "Waste receptacle full"
-msgstr "Резервуар толду"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:619
-msgid "The optical photo conductor is near end of life"
-msgstr "Фоторезистор жакында иштен чыгат"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:621
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Фоторезистор иштен чыкты"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:724
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "Конфигурация"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:781
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Даяр"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:785
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Иштетүү"
-
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:789
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Токтотулган"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:906
-msgid "Toner Level"
-msgstr "Тонердин деңгээли"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:909
-msgid "Ink Level"
-msgstr "Боёктун деңгээли"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:912
-msgid "Supply Level"
-msgstr "Ресурстардын деңгээли"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:930
-msgctxt "printer state"
-msgid "Installing"
-msgstr "Орнотуу"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1107
-msgid "No printers available"
-msgstr "Принтерлер табылган жок"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1411
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u активдүү"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1731
-msgid "Failed to add new printer."
-msgstr "Жаңы принтер кошуулбады"
-
-#: ../panels/printers/cc-printers-panel.c:1896
-msgid "Select PPD File"
-msgstr "PPD файлын танда"
-
-#: ../panels/printers/cc-printers-panel.c:1905
+#: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
-"PostScript Printer Description файлдары (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
 
-#: ../panels/printers/cc-printers-panel.c:2210
-msgid "No suitable driver found"
-msgstr "Жарактуу драйвер табылган жок"
-
-#: ../panels/printers/cc-printers-panel.c:2279
-msgid "Searching for preferred drivers..."
-msgstr "Жарактуу драйверлер изделип жатат..."
-
-#: ../panels/printers/cc-printers-panel.c:2294
-msgid "Select from database..."
-msgstr "Маалымат базасынан тандоо..."
-
-#: ../panels/printers/cc-printers-panel.c:2303
-msgid "Provide PPD File..."
-msgstr "PPD файлын колдонуу..."
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2454
-#: ../panels/printers/cc-printers-panel.c:2477
-msgid "Test page"
-msgstr "Текшерүү барагы"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2880
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Колдонуучу интерфейси жүктөлбөдү: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "Принтерлер"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
-msgid "Change printer settings"
-msgstr "Принтер параметрлерин өзгөртүү"
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Принтер;Кезек;Басуу;Кагаз;Боёк;Тонер;"
 
-#: ../panels/printers/jobs-dialog.ui.h:1
-#: ../panels/printers/options-dialog.ui.h:1
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/printers/jobs-dialog.ui.h:2
-#: ../panels/printers/options-dialog.ui.h:4
-msgid "Close"
-msgstr "Жабуу"
-
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Active Jobs"
-msgstr "Активдүү тапшырмалар"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Resume Printing"
-msgstr "Басууну улантуу"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Pause Printing"
-msgstr "Басууну убактылуу токтотуу"
-
-#: ../panels/printers/jobs-dialog.ui.h:7
-msgid "Cancel Print Job"
-msgstr "Басуу тапшырмасын алып таштоо"
-
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1044
-msgid "_Add"
-msgstr "_Кошуу"
-
-#: ../panels/printers/new-printer-dialog.ui.h:3
-msgid "Add a New Printer"
-msgstr "Жаңы принтер кошуу"
-
-#: ../panels/printers/new-printer-dialog.ui.h:4
-msgid "Search for network printers or filter result"
-msgstr "Тармактагы принтерлерди издөө же жыйынтыгын чыпкалоо"
-
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Options"
-msgstr "Параметрлер"
-
-#: ../panels/printers/options-dialog.ui.h:3
-msgid "Loading options..."
-msgstr "Параметрлер жүктөлүүдө..."
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-#: ../panels/user-accounts/um-account-dialog.c:1043
-msgid "Cancel"
-msgstr "Айынуу"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "Драйверлер маалымат базасынан жүктөлүүдө..."
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:5
-msgid "Select Printer Driver"
-msgstr "Принтер драйверин тандоо"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:65
-#: ../panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Бир тараптуу"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:67
-#: ../panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Узун жагы менен (Стандарт)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:69
-#, fuzzy
-#: ../panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Кыска жагы менен (терс жагын ачуу)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:71
-msgid "Portrait"
-msgstr "Портрет"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:73
-msgid "Landscape"
-msgstr "Ландшафт"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:75
-msgid "Reverse landscape"
-msgstr "Алмаштырылган ландшафт"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:77
-msgid "Reverse portrait"
-msgstr "Алмаштырылган портрет"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:143
-msgctxt "print job"
-msgid "Pending"
-msgstr "Күтүү"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:147
-msgctxt "print job"
-msgid "Held"
-msgstr ""
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:151
-msgctxt "print job"
-msgid "Processing"
-msgstr "Аткарылууда"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:155
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Токтотулган"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:159
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Баш тартылган"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:163
-msgctxt "print job"
-msgid "Aborted"
-msgstr ""
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:167
-msgctxt "print job"
-msgid "Completed"
-msgstr "Аяктаган"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:289
-msgid "Job Title"
-msgstr "Тапшырма"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:298
-msgid "Job State"
-msgstr "Абалы"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:304
-msgid "Time"
-msgstr "Убакыт"
-
-#: ../panels/printers/pp-jobs-dialog.c:484
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s активдүү тапшырма"
-
-#. Translators: No printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1291
-msgid "No printers detected."
-msgstr "Принтерлер табылган жок"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Two Sided"
-msgstr "Эки тараптуу"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Type"
-msgstr "Кагаз түрү"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Paper Source"
-msgstr "Кагаз булагы"
-
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Output Tray"
-msgstr "Чыгуу орду"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "Resolution"
-msgstr "Ажырымдуулугу"
-
-#: ../panels/printers/pp-options-dialog.c:87
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript менен алыдна ала чыпкалоо"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:533
-msgid "Pages per side"
-msgstr "Беттеги барактардын саны"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:545
-msgid "Two-sided"
-msgstr "Эки тараптуу"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:557
-msgid "Orientation"
-msgstr "Багыты"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Жалпы"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Барак параметрлери"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Орнотулуучу параметрлер"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Тапшырма"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Сүрөттүн сапаттуулугу"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Түс"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Аяктоо"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:675
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Кошумча"
-
-#. Translators: Options of given printer (e.g. "MyPrinter Options")
-#: ../panels/printers/pp-options-dialog.c:936
-#, c-format
-msgid "%s Options"
-msgstr "%s параметрлери"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:75
-#: ../panels/printers/pp-ppd-option-widget.c:77
-#: ../panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Автоматтык түрдө тандоо"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:79
-#: ../panels/printers/pp-ppd-option-widget.c:81
-#: ../panels/printers/pp-ppd-option-widget.c:83
-#: ../panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Абалкы принтерлер"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "GhostScript ариптерин гана колдонуу (embed)"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "PS level 1 ге өткөрүү"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "PS level 2 ге өткөрүү"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Алдына ала чыпкалабоо"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:230
-msgid "Manufacturers"
-msgstr "Өндүрүүчүлөр"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:242
-msgid "Drivers"
-msgstr "Драйверлер"
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Принтер кошуу"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "Принтерди алып таштоо"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "Ресурс"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Принтерлер"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Аутентификация талап кылынат"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Наама"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Жайгашкан жери"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default"
-msgstr "_Абалкы"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Драйвер"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "Тапшырмалар"
+#: panels/printers/pp-details-dialog.ui:178
+#, fuzzy
+msgid "Searching for preferred drivers…"
+msgstr "Жарактуу драйверлер изделип жатат..."
 
-#. Tanslators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "_Show"
-msgstr "_Көрсөтүү"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "Жарактуу драйверлер изделип жатат..."
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "Маалымат базасынан тандоо..."
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Принтер драйверин тандоо"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "Драйверлер маалымат базасынан жүктөлүүдө..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Айынуу"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Тандоо"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "Аутентификация талап кылынат"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Аутентификация талап кылынат"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s активдүү тапшырма"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Текшерүү барагы"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "%s параметрлери"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Абалкы принтерлер"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Абалкы принтерлер"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "Басуу тапшырмасын алып таштоо"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Принтерди алып таштоо"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Активдүү тапшырмалар"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Модели"
 
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "1-барак"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Боёктун деңгээли"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "белги"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "2-барак"
-
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver..."
-msgstr "Жаңы драйвер орнотуу..."
-
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "3-барак"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "_Текшерүү барагын басуу"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "_Параметрлер"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "Жаңы принтер кошуу"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Принтер кошуу"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Принтер параметрлерин өзгөртүү"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Принтерлер"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Кечириңиз! Системалык басуу кызматы (CUPS)\n"
 "иштебеген сыяктуу."
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
-msgid "Region & Language"
-msgstr "Регион жана тил"
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid "Change your region and language settings"
-msgstr "Сиздин регион жана тил параметрлери"
-
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-msgid "Language;Layout;Keyboard;"
-msgstr "Тил;Такта;Алиптакта;"
-
-#: ../panels/region/gnome-region-panel-formats.c:142
-msgid "Imperial"
-msgstr "Империялык"
-
-#: ../panels/region/gnome-region-panel-formats.c:144
-msgid "Metric"
-msgstr "Метрикалык"
-
-#: ../panels/region/gnome-region-panel-input-chooser.ui.h:1
-msgid "Choose an input source"
-msgstr "Киргизүү булагын тандаңыз"
-
-#: ../panels/region/gnome-region-panel-input-chooser.ui.h:2
-msgid "Select an input source to add"
-msgstr "Кошуу үчүн киргизүү булагын тандаңыз"
-
-#: ../panels/region/gnome-region-panel-system.c:470
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings."
-msgstr ""
-"Кирүү терезеси, системалык наамалар жана жаңы наамалар системанын "
-"регион жана тил параметрлерин колдонот."
-
-#: ../panels/region/gnome-region-panel-system.c:475
-#: ../panels/region/gnome-region-panel.ui.h:31
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings. You may change the system settings to match "
-"yours."
-msgstr ""
-"Кирүү терезеси, системалык наамалар жана жаңы наамалар системанын "
-"регион жана тил параметрлерин колдонот. Сиз системалык параметрлерди "
-"өзүңүзгө ылайыктап алсаңыз болот."
-
-#: ../panels/region/gnome-region-panel-system.c:478
-msgid "Copy Settings"
-msgstr "Параметрлерди көчүрүү"
-
-#: ../panels/region/gnome-region-panel-system.c:481
-#: ../panels/region/gnome-region-panel.ui.h:38
-msgid "Copy Settings..."
-msgstr "Параметрлерди көчүрүү..."
-
-#: ../panels/region/gnome-region-panel.ui.h:1
-msgid "Region and Language"
-msgstr "Регион жана тил"
-
-#: ../panels/region/gnome-region-panel.ui.h:2
-msgid "Select a display language (change will be applied next time you log in)"
-msgstr "Тил тандаңыз (системага кийинки жолу киргенде колдонула баштайт)"
-
-#: ../panels/region/gnome-region-panel.ui.h:3
-msgid "Add Language"
-msgstr "Тил кошуу"
-
-#: ../panels/region/gnome-region-panel.ui.h:4
-msgid "Remove Language"
-msgstr "Тилди алып таштоо"
-
-#: ../panels/region/gnome-region-panel.ui.h:5
-msgid "Install languages..."
-msgstr "Тилдер орнотулууда..."
-
-#: ../panels/region/gnome-region-panel.ui.h:6
-msgid "Language"
-msgstr "Тил"
-
-#: ../panels/region/gnome-region-panel.ui.h:7
-msgid "Select a region (change will be applied the next time you log in)"
-msgstr "Регион тандаңыз (системага кийинки жолу киргенде колдонула баштайт)"
-
-#: ../panels/region/gnome-region-panel.ui.h:8
-msgid "Add Region"
-msgstr "Регион кошуу"
-
-#: ../panels/region/gnome-region-panel.ui.h:9
-msgid "Remove Region"
-msgstr "Регионду алып таштоо"
-
-#: ../panels/region/gnome-region-panel.ui.h:10
-msgid "Dates"
-msgstr "Дата"
-
-#: ../panels/region/gnome-region-panel.ui.h:11
-msgid "Times"
-msgstr "Убакыт"
-
-#: ../panels/region/gnome-region-panel.ui.h:12
-msgid "Numbers"
-msgstr "Сан"
-
-#: ../panels/region/gnome-region-panel.ui.h:13
-msgid "Currency"
-msgstr "Акча"
-
-#: ../panels/region/gnome-region-panel.ui.h:14
-msgid "Measurement"
-msgstr "Чен бирдиктери"
-
-#: ../panels/region/gnome-region-panel.ui.h:15
-msgid "Examples"
-msgstr "Мисалдар"
-
-#: ../panels/region/gnome-region-panel.ui.h:16
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Форматтар"
 
-#: ../panels/region/gnome-region-panel.ui.h:17
-msgid "Select keyboards or other input sources"
-msgstr "Алиптактаны жана башка киргизүү түзүмдөрүн тандаңыз"
-
-#: ../panels/region/gnome-region-panel.ui.h:18
-msgid "Add Input Source"
-msgstr "Киргизүү булагын кошуу"
-
-#: ../panels/region/gnome-region-panel.ui.h:19
-msgid "Remove Input Source"
-msgstr "Киргизүү булагын алып таштоо"
-
-#: ../panels/region/gnome-region-panel.ui.h:20
-msgid "Move Input Source Up"
-msgstr "Киргизүү булагын жогору жылдыруу"
-
-#: ../panels/region/gnome-region-panel.ui.h:21
-msgid "Move Input Source Down"
-msgstr "Киргизүү булагын төмөн жылдыруу"
-
-#: ../panels/region/gnome-region-panel.ui.h:22
-msgid "Input Source Settings"
-msgstr "Киргизүү булактарынын параметрлери"
-
-#: ../panels/region/gnome-region-panel.ui.h:23
-msgid "Show Keyboard Layout"
-msgstr "Алиптактанын жайгашуусун көрсөтүү"
-
-#: ../panels/region/gnome-region-panel.ui.h:25
-msgid "Ctrl+Alt+Space"
-msgstr "Ctrl+Alt+Space"
-
-#: ../panels/region/gnome-region-panel.ui.h:27
-msgid "Ctrl+Alt+Shift+Space"
-msgstr "Ctrl+Alt+Shift+Аралык"
-
-#: ../panels/region/gnome-region-panel.ui.h:28
-msgid "Shortcut Settings"
-msgstr "Композициялардын параметри"
-
-#: ../panels/region/gnome-region-panel.ui.h:30
-msgid "Input Sources"
-msgstr "Киргизүү булактары"
-
-#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
-#: ../panels/region/gnome-region-panel.ui.h:33
-msgid "Display language:"
-msgstr "Колдонулуучу тил:"
-
-#: ../panels/region/gnome-region-panel.ui.h:34
-msgid "Input source:"
-msgstr "Киргизүү булагы:"
-
-#: ../panels/region/gnome-region-panel.ui.h:35
-msgid "Format:"
-msgstr "Формат:"
-
-#: ../panels/region/gnome-region-panel.ui.h:36
-msgid "Your settings"
-msgstr "Сиздин параметрлер"
-
-#: ../panels/region/gnome-region-panel.ui.h:37
-msgid "System settings"
-msgstr "Системанын параметрлери"
-
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:1
-msgid "Brightness & Lock"
-msgstr "Ачыктык жана бекитүү"
-
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
-msgid "Screen brightness and lock settings"
-msgstr "Экрандын ачыктыгы жана экранды бекитүүнүн  параметрлери"
-
-#. Translators: those are keywords for the brightness and lock control-center panel
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
-#, fuzzy
-msgid "Brightness;Lock;Dim;Blank;Monitor;"
-msgstr "Ачыктык;Бекитүү;Dim;Blank;Монитор;"
-
-#: ../panels/screen/screen.ui.h:1
-msgid "Screen turns off"
-msgstr "Экран өчүрүлөт"
-
-#: ../panels/screen/screen.ui.h:2
-msgid "30 seconds"
-msgstr "30 секундда"
-
-#: ../panels/screen/screen.ui.h:3
-msgid "1 minute"
-msgstr "1 мүнөттө"
-
-#: ../panels/screen/screen.ui.h:4
-msgid "2 minutes"
-msgstr "2 мүнөттө"
-
-#: ../panels/screen/screen.ui.h:5
-msgid "3 minutes"
-msgstr "3 мүнөттө"
-
-#: ../panels/screen/screen.ui.h:10
-msgid "_Dim screen to save power"
-msgstr "Энергияны үнөмдөө үчүн экрандын ачыктыгын азайтуу"
-
-#: ../panels/screen/screen.ui.h:11
-msgid "Brightness"
-msgstr "Ачыктык"
-
-#: ../panels/screen/screen.ui.h:12
-msgid "_Turn screen off when inactive for:"
-msgstr "Убакыт аралыгында иш жүрбөсө, экранды  _өчүрүү:"
-
-#: ../panels/screen/screen.ui.h:13
-msgid "_Lock screen after:"
-msgstr "Убакыт өткөндө _бекит:"
-
-#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
-#: ../panels/screen/screen.ui.h:15
-msgid "Don't lock when at home"
-msgstr "Үйдө болгондо бекитпөө"
-
-#: ../panels/screen/screen.ui.h:16
-msgid "Locations..."
-msgstr "Жайгашкан жерлер..."
-
-#: ../panels/screen/screen.ui.h:17
-msgid "Show _notifications when locked"
-msgstr "Экран бекитилгенде да, билдирүүлөрдү көрсөтүү"
-
-#: ../panels/screen/screen.ui.h:18
-msgid "Lock"
-msgstr "Бекитүү"
-
-#: ../panels/sound/applet-main.c:49
-msgid "Enable debugging code"
-msgstr "Ката издөөнү иштетүү"
-
-#: ../panels/sound/applet-main.c:50
-msgid "Version of this application"
-msgstr "Бул иштеменени версиясы"
-
-#: ../panels/sound/applet-main.c:62
-msgid " — GNOME Volume Control Applet"
-msgstr " — GNOME үн бийиктигин башкаруу апплети"
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
-msgid "Volume Control"
-msgstr "Үн бийиктигин башкаруу"
-
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
-msgid "Show desktop volume control"
-msgstr "Үн бийиктигин башкарууну ачуу"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "Үн"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound volume and sound events"
-msgstr "Үн бийиктигин жана кабарлардын үнүн өзгөртүү"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
 msgstr ""
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "Ит"
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Форматтар"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "Тамчы"
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Форматтар"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "Айнек"
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "Сонар"
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
 
-#: ../panels/sound/gvc-applet.c:270 ../panels/sound/gvc-mixer-dialog.c:1656
-msgid "Output"
-msgstr "Чыгуу"
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Көрүнүшү"
 
-#: ../panels/sound/gvc-applet.c:272
-msgid "Sound Output Volume"
-msgstr "Чыгуудагы үн бийиктиги"
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Дата"
 
-#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1697
-msgid "Input"
-msgstr "Кирүү"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Дата жана убакыт"
 
-#: ../panels/sound/gvc-applet.c:278
-msgid "Microphone Volume"
-msgstr "Микрофондун бийиктиги"
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Сан"
 
-#: ../panels/sound/gvc-balance-bar.c:111
-msgctxt "balance"
-msgid "Left"
-msgstr "Сол"
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Чен бирдиктери"
 
-#: ../panels/sound/gvc-balance-bar.c:112
-msgctxt "balance"
-msgid "Right"
-msgstr "Оң"
+#: panels/region/cc-format-preview.ui:107
+#, fuzzy
+msgid "Paper"
+msgstr "Кагаз түрү"
 
-#: ../panels/sound/gvc-balance-bar.c:115
-msgctxt "balance"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Тилдер орнотулууда..."
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "Форматтар"
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Экранды кулпулоо"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Регион жана тил"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+#, fuzzy
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Тил;Такта;Алиптакта;"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Сактама кантип иштетилүүсүн танда"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _аудио"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "DVD _видео"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Музыка _плеери"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Иштеме"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+#, fuzzy
+msgid "_Other Media…"
+msgstr "Башка сактама"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Сактама түзүмү туташканда программаны иштетүүнү сурабоо жана аны аткарбоо"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Башка сактама кантип иштетилүүсүн танда"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Аракет:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Түрү:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Ажыратма сактама"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Bluetooth параметрлери"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"түзүм;система;маалымат;эс;процессор;версия;абалкы;иштеме;альтернативдик;"
+"сунушталган;cd;dvd;usb;аудио;видео;диск;ажыратма;сактама;автоиштөө;"
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Экран сүрөтү"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "Экран алиптактасы"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Экран бекитилгенде да, билдирүүлөрдү көрсөтүү"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Экранды кулпулоо"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+#, fuzzy
+msgid "Screen"
+msgstr "Экран сүрөтү"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Үн параметрлери"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Жайгашкан жери"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Башка..."
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Жайгашкан жери"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Иштемелер"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Издөө"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Тармак"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+#, fuzzy
+msgid "Sharing"
+msgstr "Угуу"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Угуу"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "Регионду алып таштоо"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Угуу"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "Топтун сырсөзү"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+#, fuzzy
+msgid "Remote Login"
+msgstr "Регионду алып таштоо"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Үн бийиктигин башкаруу"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Туташкан эмес"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Аутентификация талап кылынат"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Наама"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "Угуу"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Угуу"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Баланс:"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Арткы"
 
-#: ../panels/sound/gvc-balance-bar.c:116
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Алдынкы"
 
-#: ../panels/sound/gvc-balance-bar.c:119
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Минимум"
-
-#: ../panels/sound/gvc-balance-bar.c:120
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Максимум"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Balance:"
-msgstr "_Баланс:"
-
-#: ../panels/sound/gvc-balance-bar.c:298
-msgid "_Fade:"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
 msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:301
-msgid "_Subwoofer:"
-msgstr "_Сабвуфер:"
-
-#: ../panels/sound/gvc-channel-bar.c:613 ../panels/sound/gvc-channel-bar.c:622
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:617
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Күчтөтүүсүз"
-
-#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:521
-msgid "_Profile:"
-msgstr "_Профайл:"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1841
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u чыгуу"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1851
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u кирүү"
-
-#: ../panels/sound/gvc-mixer-control.c:2375
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "Системалык үндөр"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "Динамикти _текшерүү"
-
-#: ../panels/sound/gvc-mixer-dialog.c:426
-msgid "Peak detect"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1506
-#: ../panels/sound/gvc-sound-theme-chooser.c:595
-msgid "Name"
-msgstr "Аты"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1588
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1642
-msgid "_Output volume:"
-msgstr "Үндүн _бийиктиги:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1661
-msgid "C_hoose a device for sound output:"
-msgstr "Үн үчүн чыгуу түзүмүн тандоо:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1686
-msgid "Settings for the selected device:"
-msgstr "Тандалган түзүмдүн параметрлери:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "_Input volume:"
-msgstr "Жазуу _бийиктиги:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1727
-msgid "Input level:"
-msgstr "Жазуу деңгээли:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1755
-msgid "C_hoose a device for sound input:"
-msgstr "Үн кирүүчү түзүмдү танда:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1782
-msgid "Sound Effects"
-msgstr "Үн эффектери"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "_Alert volume:"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
 msgstr "Билдирүүлөрдүн үн бийиктиги:"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1802
-msgid "Applications"
-msgstr "Иштемелер"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Үндү өчүрүү"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1806
-msgid "No application is currently playing or recording audio."
-msgstr "Учуруда үндү ойноткон же жазган иштеме жок."
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Чыгуу"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:189
-msgid "Built-in"
-msgstr ""
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Үндүн _бийиктиги:"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:455
-#: ../panels/sound/gvc-sound-theme-chooser.c:467
-#: ../panels/sound/gvc-sound-theme-chooser.c:479
-msgid "Sound Preferences"
-msgstr "Үн параметрлери"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:458
-#: ../panels/sound/gvc-sound-theme-chooser.c:469
-#: ../panels/sound/gvc-sound-theme-chooser.c:481
-msgid "Testing event sound"
-msgstr ""
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "Default"
-msgstr "Абалкы"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:586
-msgid "From theme"
-msgstr "Бул темадан"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:770
-msgid "C_hoose an alert sound:"
-msgstr "_Билдирүү үчүн үн танда:"
-
-#: ../panels/sound/gvc-speaker-test.c:220
-msgid "Stop"
-msgstr "Токтотуу"
-
-#: ../panels/sound/gvc-speaker-test.c:220
-#: ../panels/sound/gvc-speaker-test.c:332
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Текшерүү"
 
-#: ../panels/sound/gvc-speaker-test.c:228
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "_Конфигурациялоочу URL"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Сабвуфер"
 
-#: ../panels/sound/gvc-stream-status-icon.c:236
-#, c-format
-msgid "Failed to start Sound Preferences: %s"
-msgstr "Үн параметрлерин иштетүүгө болбоду: %s"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Кирүү"
 
-#: ../panels/sound/gvc-stream-status-icon.c:262
-msgid "_Mute"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Жазуу деңгээли:"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Үндү жогорулатуу"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Билдирүүлөрдүн үн бийиктиги:"
+
+#: panels/sound/cc-volume-slider.ui:22
+#, fuzzy
+msgid "Mute"
 msgstr "_Өчүрүү"
 
-#: ../panels/sound/gvc-stream-status-icon.c:271
-msgid "_Sound Preferences"
-msgstr "_Үн параметрлери"
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Үн"
 
-#: ../panels/sound/gvc-stream-status-icon.c:416
-msgid "Muted"
-msgstr "Өчүрүлгөн"
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Үн бийиктигин жана кабарлардын үнүн өзгөртүү"
 
-#: ../panels/sound/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr "Башка"
-
-#: ../panels/universal-access/cc-ua-panel.c:286
-#: ../panels/universal-access/cc-ua-panel.c:292
-msgid "No shortcut set"
-msgstr "Комбинация орнотулган эмес"
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Universal Access Preferences"
-msgstr "Универсалдык жетүү параметрлери"
-
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
-"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:1
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, fuzzy, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Түзүмдү жоготуу"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Аталышы:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Түзүмдү алып таштоо"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Универсалдык жетүү"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Түзүм кошуу"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Курсордун өчүп-жануусу"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Курсор тексттик талааларда _өчүп-жанат"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Ылдамдык:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Курсордун  өчүп-жануу ылдамдыгы"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Курсордун  өчүп-жануу ылдамдыгы"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Кыска"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Узун"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Кыска"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Узун"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Кичирейтилген"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Чоңойтулган"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Автокайталоо"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Басылып турган баскычты _кайталоо"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Баскычты кайталоо ылдамдыгы"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Баскычты кайталоо ылдамдыгы"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Басуу"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Илешме тергичтер"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+# чычканды ушинтип атасакчы? ;)
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Чертмек баскычтары"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Кыска"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Узун"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Баскычты кайталоо ылдамдыгы"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+# чычканды ушинтип атасакчы? ;)
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Чертмек баскычтары"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Кыска"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Узун"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Көрүү"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "Бийик контраст"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Чоң текст"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Экрандан окуу"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Үн эффектери"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Курсордун  өчүп-жануу ылдамдыгы"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Чоңойтуу"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Угуу"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Визуалдык билдирүүлөр"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Экран алиптактасы"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Автокайталоо"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Курсордун өчүп-жануусу"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+# чычканды ушинтип атасакчы? ;)
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Чертмек баскычтары"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Принтерди алып таштоо"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "_Коштоп чертүү"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "_Коштоп чертүү"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Визуалдык билдирүүлөр"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Экрандын күйүп-өчүүсү"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Экрандын күйүп-өчүүсү"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_Аракет:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Экрандан окуу"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
+msgstr "Кубаттуулугу"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Ачыктык"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Бийик контраст"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Жок"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Төмөн"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Жогору"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Төмөн"
 
-#: ../panels/universal-access/uap.ui.h:2
-msgctxt "universal access, contrast"
-msgid "Normal"
-msgstr "Кадимкидей"
-
-#: ../panels/universal-access/uap.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Жогору"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgctxt "universal access, contrast"
-msgid "High/Inverse"
-msgstr "Жогору/Инверсия"
-
-#: ../panels/universal-access/uap.ui.h:5
-msgid "On screen keyboard"
-msgstr "Экран алиптактасы"
-
-#: ../panels/universal-access/uap.ui.h:6
-msgid "GOK"
-msgstr "GOK"
-
-#: ../panels/universal-access/uap.ui.h:7
-msgid "OnBoard"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:8
-msgid "None"
-msgstr "Жок"
-
-#: ../panels/universal-access/uap.ui.h:10
-#, no-c-format
-msgid "75%"
-msgstr "75%"
-
-#: ../panels/universal-access/uap.ui.h:11
-msgctxt "universal access, text size"
-msgid "Small"
-msgstr "Кичирейтилген"
-
-#: ../panels/universal-access/uap.ui.h:13
-#, no-c-format
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgctxt "universal access, text size"
-msgid "Normal"
-msgstr "Кадимки"
-
-#: ../panels/universal-access/uap.ui.h:16
-#, no-c-format
-msgid "125%"
-msgstr "125%"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgctxt "universal access, text size"
-msgid "Large"
-msgstr "Чоңойтулган"
-
-#: ../panels/universal-access/uap.ui.h:19
-#, no-c-format
-msgid "150%"
-msgstr "150%"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgctxt "universal access, text size"
-msgid "Larger"
-msgstr "Чоң"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "High Contrast"
-msgstr "Бийик контраст"
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Beep on Caps and Num Lock"
-msgstr "Caps жана Num Lock басылганда үн чыгаруу"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "Options..."
-msgstr "Параметрлер..."
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Screen Reader"
-msgstr "Экрандан окуу"
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Turn on or off:"
-msgstr "Жандыруу же өчүрүү:"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgctxt "universal access, zoom"
-msgid "Zoom"
-msgstr "Чоңойтуу"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Zoom in:"
-msgstr "Жакындатуу:"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "Zoom out:"
-msgstr "Алыстатуу:"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Large Text"
-msgstr "Чоң текст"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "Seeing"
-msgstr "Көрүү"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Visual Alerts"
-msgstr "Визуалдык билдирүүлөр"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Use a visual indication when an alert sound occurs"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Flash the window title"
-msgstr "Терезенин башынын күйүп-өчүүсү"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Flash the entire screen"
-msgstr "Экрандын күйүп-өчүүсү"
-
-#: ../panels/universal-access/uap.ui.h:35
-msgid "Closed Captioning"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Display a textual description of speech and sounds"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:37
-msgid "_Test flash"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Hearing"
-msgstr "Угуу"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "On Screen Keyboard"
-msgstr "Экран алиптактасы"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "Sticky Keys"
-msgstr "Илешме тергичтер"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:43
-msgid "_Disable if two keys are pressed together"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Beep when a _modifer key is pressed"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "Slow Keys"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "A_cceptance delay:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:50
-msgid "Slow keys typing delay"
-msgstr ""
-
-#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
-#: ../panels/universal-access/uap.ui.h:54
-msgid "Beep when a key is"
-msgstr ""
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:56
-msgid "pressed"
-msgstr ""
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:58
-msgid "accepted"
-msgstr ""
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:60
-msgid "rejected"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:61
-msgid "Bounce Keys"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "Ignores fast duplicate keypresses"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "Acc_eptance delay:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:64
-msgid "Bounce keys typing delay"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "Beep when a key is _rejected"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:66
-msgid "Enable by Keyboard"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:67
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr ""
-
-# чычканды ушинтип атасакчы? ;)
-#: ../panels/universal-access/uap.ui.h:69
-#, fuzzy
-msgid "Mouse Keys"
-msgstr "Чертмек баскычтары"
-
-#: ../panels/universal-access/uap.ui.h:70
-msgid "Control the pointer using the keypad"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Video Mouse"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:72
-msgid "Control the pointer using the video camera."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:73
-msgid "Simulated Secondary Click"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:74
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:75
-msgid "Secondary click delay"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:76
-msgid "Hover Click"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:77
-msgid "Trigger a click when the pointer hovers"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:78
-msgid "D_elay:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:79
-msgid "Motion _threshold:"
-msgstr ""
-
-#. small threshold
-#: ../panels/universal-access/uap.ui.h:81
-msgid "Small"
-msgstr ""
-
-#. large threshold
-#: ../panels/universal-access/uap.ui.h:83
-msgid "Large"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:84
-msgid "Mouse Settings"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:85
-msgid "Pointing and Clicking"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.c:357
-msgctxt "Distance"
-msgid "Short"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.c:358
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.c:359
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.c:360
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.c:361
-msgctxt "Distance"
-msgid "Long"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:1
-msgid "Full Screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:2
-msgid "Top Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:3
-msgid "Bottom Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:4
-msgid "Left Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:5
-msgid "Right Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:6
-msgid "Zoom Options"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:15
-msgid "Magnifier Position:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:16
-msgid "Magnifier"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
-msgstr ""
-
-#. short delay
-#: ../panels/universal-access/zoom-options.ui.h:19
-msgid "Thin"
-msgstr ""
-
-#. long delay
-#: ../panels/universal-access/zoom-options.ui.h:21
-msgid "Thick"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Length:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Color:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Crosshairs:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:25
-msgid "Overlaps mouse cursor"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "Crosshairs"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "White on black:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Brightness:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:29
-msgid "Contrast:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:30
-msgctxt "Zoom Grayscale"
-msgid "Color"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:31
-msgctxt "Zoom Grayscale"
-msgid "None"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:32
-msgctxt "Zoom Grayscale"
-msgid "Full"
-msgstr ""
-
-#. short delay
-#: ../panels/universal-access/zoom-options.ui.h:34
-msgid "Low"
-msgstr ""
-
-#. long delay
-#: ../panels/universal-access/zoom-options.ui.h:36
-msgid "High"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:35
-msgctxt "Account type"
-msgid "Standard"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:37
-msgctxt "Account type"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+#, fuzzy
+msgid "Add User"
+msgstr "Принтер кошуу"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-msgid "Add account"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Local Account"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "_Enterprise Login"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "_Username"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "Конфигурация"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Ишкана"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-msgid "_Full name"
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Өчүрүлгөн"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Account _Type"
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PPD файлын танда"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-msgid "_Domain"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Login Name"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Жок"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "_Password"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "Tip: Enterprise domain or realm name"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Принтерлер табылган жок"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Принтерлер табылган жок"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid "C_ontinue"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:14
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Мурунку трек"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Топтун сырсөзү"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Топтун сырсөзү"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Топтун сырсөзү"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Топтун сырсөзү"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Users"
+msgstr "Наама"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Жабуу"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Принтерди алып таштоо"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Башка сактама"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here."
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:18
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr ""
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:706
-msgid "Enable Fingerprint Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "User Accounts"
-msgstr ""
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users"
-msgstr ""
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Set a password now"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-msgid "Choose password at next login"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Log in without a password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "Disable this account"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Enable this account"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "_Hint"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid ""
-"This hint may be displayed at the login screen.  It will be visible to all "
-"users of this system.  Do <b>not</b> include the password here."
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "C_onfirm password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-msgid "_New password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-msgid "Generate a password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-msgid "Fair"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-msgid "Current _password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid "_Action"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-msgid "Changing password for"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:15
-msgid "_Show password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:16
-msgid "How to choose a strong password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:17
-msgid "Ch_ange"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-msgid "Changing photo for:"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
-msgid ""
-"Choose a picture that will be shown at the login screen for this account."
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-msgid "Gallery"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "Browse for more pictures"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-msgid "Take a photograph"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-msgid "Browse"
-msgstr ""
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Account Information"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Add User Account"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Remove User Account"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "Login Options"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "A_utomatic Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "_Fingerprint Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "User Icon"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "_Language"
-msgstr ""
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr ""
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr ""
 
-#: ../panels/user-accounts/pw-utils.c:94
-#: ../panels/user-accounts/um-password-dialog.c:569
-msgctxt "Password strength"
-msgid "Too short"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password strength"
-msgid "Not good enough"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:108
-#: ../panels/user-accounts/um-password-dialog.c:570
-msgctxt "Password strength"
-msgid "Weak"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:111
-#: ../panels/user-accounts/um-password-dialog.c:571
-msgctxt "Password strength"
-msgid "Fair"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:114
-#: ../panels/user-accounts/um-password-dialog.c:572
-msgctxt "Password strength"
-msgid "Good"
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:117
-#: ../panels/user-accounts/um-password-dialog.c:573
-msgctxt "Password strength"
-msgid "Strong"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:424
-msgid "Authentication failed"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:504
-#: ../panels/user-accounts/um-password-dialog.c:239
-#, c-format
-msgid "The new password is too short"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password is too simple"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:516
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:519
-#, c-format
-msgid "The new password has already been used recently."
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:526
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:530
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:534
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:538
-#, c-format
-msgid "Unknown error"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:180
-msgid "Failed to add account"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:378
-#: ../panels/user-accounts/um-account-dialog.c:419
-msgid "Failed to register account"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:551
-msgid "No supported way to authenticate with this domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:605
-msgid "Failed to join domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-account-dialog.c:662
-msgid "Failed to log into domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:219
-#: ../panels/user-accounts/um-fingerprint-dialog.c:220
-msgid "Enabled"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:268
-msgid "Delete registered fingerprints?"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:272
-msgid "_Delete Fingerprints"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:279
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:455
-msgid "Done!"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:516
-#: ../panels/user-accounts/um-fingerprint-dialog.c:558
-#, c-format
-msgid "Could not access '%s' device"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:603
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:655
-msgid "Could not access any fingerprint readers"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:656
-msgid "Please contact your system administrator for help."
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:740
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:747
-msgid "Selecting finger"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:748
-msgid "Enrolling fingerprints"
-msgstr ""
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:749
-msgid "Summary"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:96
-msgid "_Generate a password"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:150
-msgid "Please choose another password."
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:159
-msgid "Please type your current password again."
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:165
-msgid "Password could not be changed"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:236
-msgid "You need to enter a new password"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:245
-msgid "You need to confirm the password"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:248
-msgid "The passwords do not match"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:254
-msgid "You need to enter your current password"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:257
-msgid "The current password is not correct"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:347
-msgid "Passwords do not match"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:409
-msgid "Wrong password"
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:443
-msgid "Disable image"
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:461
-msgid "Take a photo..."
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:479
-msgid "Browse for more pictures..."
-msgstr ""
-
-#: ../panels/user-accounts/um-photo-dialog.c:704
-#, c-format
-msgid "Used by %s"
-msgstr ""
-
-#: ../panels/user-accounts/um-realm-manager.c:379
-#, c-format
-msgid "No such domain or realm found"
-msgstr ""
-
-#: ../panels/user-accounts/um-realm-manager.c:780
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr ""
-
-#: ../panels/user-accounts/um-realm-manager.c:785
-msgid "Invalid password, please try again"
-msgstr ""
-
-#: ../panels/user-accounts/um-realm-manager.c:789
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-manager.c:466
-#, c-format
-msgid "A user with name '%s' already exists."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-manager.c:473
-#, c-format
-msgid "No user with the name '%s' exists."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-manager.c:631
-msgid "This user does not exist."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:371
-msgid "Failed to delete user"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:431
-msgid "You cannot delete your own account."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:440
-#, c-format
-msgid "%s is still logged in"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:444
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:453
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:457
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:460
-msgid "_Delete Files"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:461
-msgid "_Keep Files"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:513
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:521
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:524
-msgctxt "Password mode"
-msgid "None"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:871
-msgid "Failed to contact the accounts service"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:873
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:913
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:951
-msgid "Create a user account"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:962
-#: ../panels/user-accounts/um-user-panel.c:1273
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:971
-msgid "Delete the selected user account"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:983
-#: ../panels/user-accounts/um-user-panel.c:1278
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1176
-msgid "My Account"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1186
-msgid "Other Accounts"
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:512
-#, c-format
-msgid "A user with the username '%s' already exists"
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:516
-#, c-format
-msgid "The username is too long"
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:519
-msgid "The username cannot start with a '-'"
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:522
-msgid ""
-"The username must only consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr ""
 
-#: ../panels/wacom/button-mapping.ui.h:2
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr ""
 
-#. Text printed on screen
-#: ../panels/wacom/calibrator/gui_gtk.c:78
-msgid "Screen Calibration"
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
+"Комбинацияны оңдоо үчүн, сапты тандап жаңы баскычты басыңыз же өчүрүү үчүн "
+"Backspace баскычын колдонуңуз"
 
-#: ../panels/wacom/calibrator/gui_gtk.c:79
+#: panels/wacom/button-mapping.ui:66
+#, fuzzy
+msgid "_Close"
+msgstr "Жабуу"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
 
-#: ../panels/wacom/calibrator/gui_gtk.c:368
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Output:"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "Виртуалдык түзүм түзүү"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
 msgstr ""
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:287
-msgid "Keep aspect ratio (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:298
-msgid "Map to single monitor"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Багыты"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-nav-button.c:89
-#, c-format
-msgid "%d of %d"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Монитор"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-page.c:118 ../panels/wacom/cc-wacom-page.c:371
-msgctxt "Wacom action-type"
-msgid "None"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-page.c:119
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr ""
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Калибрлөө..."
 
-#: ../panels/wacom/cc-wacom-page.c:120
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-page.c:601
-msgid "Up"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-page.c:601
-msgid "Down"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-page.c:638
-msgid "Switch Modes"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-page.c:724
-#: ../panels/wacom/cc-wacom-stylus-page.c:376
-msgid "Button"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-page.c:777
-msgid "Action"
-msgstr ""
-
-#: ../panels/wacom/cc-wacom-page.c:886
-msgid "Display Mapping"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set your Wacom tablet preferences"
-msgstr ""
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Map to Monitor..."
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map Buttons..."
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate..."
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Tracking Mode"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Left-Handed Orientation"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1010
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1019
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1049
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1058
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1075
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1077
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1080
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1082
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1087
-#, c-format
-msgid "Mode Switch #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1159
-#, c-format
-msgid "Left Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1162
-#, c-format
-msgid "Right Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1165
-#, c-format
-msgid "Top Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1168
-#, c-format
-msgid "Bottom Button #%d"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr ""
 
-#: ../shell/control-center.c:58
-msgid "Enable verbose mode"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
 msgstr ""
 
-#: ../shell/control-center.c:59
-msgid "Show the overview"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
 
-#: ../shell/control-center.c:60 ../shell/control-center.c:61
-#: ../shell/control-center.c:62
-msgid "Show help options"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
 msgstr ""
 
-#: ../shell/control-center.c:63
-msgid "Panel to display"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
 msgstr ""
 
-#: ../shell/control-center.c:85
-msgid "- System Settings"
-msgstr "- Системалык параметрлер"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
 
-#: ../shell/control-center.c:93
-#, c-format
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
 msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
-msgstr ""
-"%s\n"
-"Бардык параметрлердин толук тизмесин көрүү үчүн '%s --help' аткарыңыз.\n"
-
-#: ../shell/control-center.c:211
-msgid "Help"
-msgstr "Жардам"
-
-#: ../shell/control-center.c:212
-msgid "Quit"
-msgstr "Чыгуу"
-
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Башкаруу борбору"
-
-#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
-msgid "System Settings"
-msgstr "Системалык параметрлер"
-
-#: ../shell/gnome-control-center.desktop.in.in.h:2
-msgid "Preferences;Settings;"
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
 
-#: ../shell/shell.ui.h:2
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows иштемеси"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Тонер аз"
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows иштемеси"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "_Кошуу"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Кеңири маалыматы"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Тармак _убактысы"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Тармак параметрлери"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Сан"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Маалыматын кароо"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+#, fuzzy
+msgid "Manufacturer"
+msgstr "Өндүрүүчү:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Фирмалык программасы жок"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "Мобилдик жазы каналдуу"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Тармак _убактысы"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Тармак"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Кошумча"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Бекитүү"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Кеңири маалыматы"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Тармактын аты"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Автоматтык түрдө"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Тармакты _унутуу"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Bluetooth адаптери табылган жок"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Байланыш"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM картасы орнотулган эмес"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Бекитүү"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Тармакты _унутуу"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "Жаңы драйвер орнотуу..."
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Бардык параметрлер"
 
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Негизги _черткич"
 
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Жардам"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Жалпы"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Чыгуу"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Издөө"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Мурунку булакка өтүү"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Баш тартылган"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u чыгуу"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u кирүү"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Күн ичинде алмашат"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Мозаика"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Ортосу"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Толтуруу"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Батыруу"
+
+#~ msgid "Select Background"
+#~ msgstr "Фонду тандоо"
+
+#~ msgid "Pictures"
+#~ msgstr "Сүрөттөр"
+
+#~ msgid "Colors"
+#~ msgstr "Түстөр"
+
+#~ msgid "multiple sizes"
+#~ msgstr "түрдүү өлчөмү"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Фонсуз Иштакта"
+
+#~ msgid "Current background"
+#~ msgstr "Учурдагы фон"
+
+#~ msgid "Change the background"
+#~ msgstr "Фонду алмаштыруу"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Тушкагаз;Экран;Иштакта;"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Жаңы түзүм орнотуу"
+
+#~ msgid "Paired"
+#~ msgstr "Туташкан"
+
+#~ msgid "Mouse and Touchpad Settings"
+#~ msgstr "Чычкан жана сенсордук панел параметрлери"
+
+#~ msgid "Send Files..."
+#~ msgstr "Файл жөнөтүү..."
+
+#~ msgid "Browse Files..."
+#~ msgstr "Файл аралоо..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Yes"
+#~ msgstr "Ооба"
+
+#, c-format
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” көрүнүүсү"
+
+#, c-format
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "'%s' ти түзүмдөр тизмесинен алып таштайлыбы?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Эгер сиз муну алып таштасаңыз, кийинки жолу колдонгондо кайрадан "
+#~ "орнотууңуз керек."
+
+#~ msgid "Other profile…"
+#~ msgstr "Башка профиль…"
+
+#~ msgid "Default: "
+#~ msgstr "Абалкы: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Текшерүү профили: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC профайлынын файлын тандоо"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Экрандар үчүн мүмкүн болгон профайлдар"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Сканерлер үчүн мүмкүн болгон профайлдар"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Принтерлер үчүн мүмкүн болгон профайлдар"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Камералар үчүн мүмкүн болгон профайлдар"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Вебкамералар үчүн мүмкүн болгон профайлдар"
+
+#~ msgid "Available Profiles"
+#~ msgstr "Мүмкүн болгон профайлдар"
+
+#, c-format
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i жыл"
+
+#, c-format
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i ай"
+
+#, c-format
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i жума"
+
+#, c-format
+#~ msgid "Less than 1 week"
+#~ msgstr "1 жумадан аз"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Абалкы RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Абалкы CMYK"
+
+#~ msgctxt "Device kind"
+#~ msgid "Scanner"
+#~ msgstr "Сканер"
+
+#~ msgctxt "Device kind"
+#~ msgid "Printer"
+#~ msgstr "Принтер"
+
+#~ msgctxt "Device kind"
+#~ msgid "Webcam"
+#~ msgstr "Вебкамера"
+
+#~ msgid "Remove a device"
+#~ msgstr "Түзүмдү алып таштоо"
+
+#~ msgid "Device type:"
+#~ msgstr "Түзүм түрү:"
+
+#~ msgid "Model:"
+#~ msgstr "Модели:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Жогорудагы талааларды автоматтык түрдө толтуруу үчүн, сүрөт файлын бул "
+#~ "терезеге сүйрөп келүүгө болот."
+
+#~ msgid "Color management settings"
+#~ msgstr "Түс башкаруу параметрлери"
+
+#~ msgid "English"
+#~ msgstr "Англисче"
+
+#~ msgid "British English"
+#~ msgstr "Британ анлис тилинде"
+
+#~ msgid "German"
+#~ msgstr "Немисче"
+
+#~ msgid "French"
+#~ msgstr "Французча"
+
+#~ msgid "Spanish"
+#~ msgstr "Испанча"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Кытайча (жөнөкөй)"
+
+#~ msgid "Russian"
+#~ msgstr "Орусча"
+
+#~ msgid "Arabic"
+#~ msgstr "Арабча"
+
+#~ msgid "United States"
+#~ msgstr "Кошмо Штаттары"
+
+#~ msgid "Germany"
+#~ msgstr "Германия"
+
+#~ msgid "Spain"
+#~ msgstr "Испания"
+
+#~ msgid "China"
+#~ msgstr "Кытай"
+
+#~ msgid "Select a region"
+#~ msgstr "Регион тандоо"
+
+#~ msgid "Unspecified"
+#~ msgstr "Аныкталбаган"
+
+#~ msgid "_Region:"
+#~ msgstr "_Регион:"
+
+#~ msgid "_City:"
+#~ msgstr "_Шаар:"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Бир саатка алдыга."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Бир саатка артка."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Бир мүнөткө алдыга."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Бир мүнөткө артка."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "ТЧ жана ТК алмашуусу."
+
+#~ msgid "24-hour"
+#~ msgstr "24 саатык формат"
+
+#~ msgid "AM/PM"
+#~ msgstr "ТЧ/ТК"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Дата жана убакыт параметрлеринин панели"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Кадимкидей"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "Саат жэбесине каршы"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 градуска"
+
+#, c-format
+#~ msgid "%d x %d (%s)"
+#~ msgstr "%d x %d (%s)"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Монитордун касиеттерин өзгөртүү үчүн, аны тандаңыз; орунуналмаштыруу үчүн "
+#~ "- жылдырыңыз."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#, c-format
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "Конфигурацияны кабылдоо ишке ашпады: %s"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "Мониторлорду аныктоого болбоду"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Экран жөнүндө маалымат алууга болбоду"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Ажырымдуулук"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Эскертүү: ажырымдуулук параметри чектелүү болушу мүмкүн"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "Дисплейлерди _аныктоо"
+
+#, c-format
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown"
+#~ msgstr "Белгисиз"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d бит"
+
+#~ msgid "Unknown model"
+#~ msgstr "Белгисиз модель"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "Кийинки жолу системага кирүү учурунда стандарттык режим колдонулат."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "Кийинки жолу системага кирүү учурунда альтернативдик режим колдонулат. Ал "
+#~ "колдоого ээ болбогон графикалык түзүмдөр үчүн жасалган."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Альтернативдик"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "Стандарттык"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Эмне кылышты суроо"
+
+#~ msgid "Do nothing"
+#~ msgstr "Эч нерсе кылбоо"
+
+#~ msgid "Open folder"
+#~ msgstr "Каталогду ачуу"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Аудио CD үчүн иштеме тандоо"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Аудио DVD үчүн иштеме тандоо"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Музыкалык плеер туташканда аткарылуучу иштеме тандоо"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Камера туташканда аткарылуучу иштеме тандоо"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Программалуу CD үчүн иштеме тандоо"
+
+#~ msgid "audio DVD"
+#~ msgstr "аудио DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "таза Blu-ray диск"
+
+#~ msgid "blank CD disc"
+#~ msgstr "таза CD диск"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "таза DVD диск"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "таза HD DVD диск"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray видео диск"
+
+#~ msgid "e-book reader"
+#~ msgstr "электрондук китеп окуу түзүмү"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD видео диск"
+
+#~ msgid "Picture CD"
+#~ msgstr "Сүрөт CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Супервидео CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Видео CD"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Оңдоолор жок"
+
+#~ msgid "Checking for Updates"
+#~ msgstr "Оңдоолорду издөө"
+
+#~ msgid "OS type"
+#~ msgstr "АС тиби"
+
+#~ msgid "Disk"
+#~ msgstr "Диск"
+
+#~ msgid "_Other Media..."
+#~ msgstr "_Башка сактама..."
+
+#~ msgid "Experience"
+#~ msgstr "Режим"
+
+#~ msgid "Save a screenshot to Pictures"
+#~ msgstr "Экран сүрөттөрүн \"Сүрөттөр\" каталогуна жазуу"
+
+#~ msgid "Save a screenshot of a window to Pictures"
+#~ msgstr "Терезе сүрөттөрүн \"Сүрөттөр\" каталогуна жазуу"
+
+#, fuzzy
+#~ msgid "Save a screenshot of an area to Pictures"
+#~ msgstr "Областардын сүрөттөрүн \"Сүрөттөр\" каталогуна жазуу"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Экран сүрөтүн алмашуу буферине көчүрүү"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Терезе сүрөтүн алмашуу буферине көчүрүү"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Област сүрөтүн алмашуу буферине көчүрүү"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "Алиптакта параметрлерин өзгөртүү"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Комбинация;Кайталоо;Өчүп-жануу;"
+
+#~ msgid "Slow"
+#~ msgstr "Жай"
+
+#~ msgid "Fast"
+#~ msgstr "Тез"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Ылдамдык:"
+
+#, fuzzy
+#~ msgid "Layout Settings"
+#~ msgstr "Тактанын параметрлери"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Комбинацияны жоготуу"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Белгисиз аракет>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "\"%s\" комбинациясын колдонууга болбойт, себеби аны колдону терүүгө "
+#~ "мүмкүн эмес.\n"
+#~ "Control, Alt же Shift баскычтары менен чогуу колдонуп көрүңүз."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "\"%s\" комбинациясы \n"
+#~ "\"%s\" үчүн колдонулууда"
+
+#~ msgid "_Reassign"
+#~ msgstr "_Кайра аныктоо"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Сиздин чычкан түзүмүңүздүн жана сенсордук тактаңыздын параметрлери"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Коштоп чертүү аралыгы"
+
+#~ msgid "_Left"
+#~ msgstr "_Солдогусу"
+
+#~ msgid "_Right"
+#~ msgstr "_Оңдогусу"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Көрсөткүчтүн  ылдамдыгы"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "_Эки манжа менен жылдыруу"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Мб/с"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Жок"
+
+#~ msgid "never"
+#~ msgstr "эч качан"
+
+#~ msgid "today"
+#~ msgstr "бүгүн"
+
+#~ msgid "yesterday"
+#~ msgstr "кечээ"
+
+#~ msgid "Out of range"
+#~ msgstr "Жетүү зонасынан тышкары"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Жок"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Аз"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Орто"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Жакшы"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Эң жакшы"
+
+#~ msgid "Forget"
+#~ msgstr "Унутуу"
+
+#~ msgid "Proxy"
+#~ msgstr "Прокси"
+
+#~ msgid "_Options..."
+#~ msgstr "_Параметрлер..."
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Жок"
+
+#~ msgid "C_reate..."
+#~ msgstr "_Түзүү..."
+
+#~ msgid "_Interface"
+#~ msgstr "_Интерфейс"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN түрү"
+
+#~ msgid "Group Name"
+#~ msgstr "Топтун аты"
+
+#~ msgid "_Configure..."
+#~ msgstr "_Конфигурация..."
+
+#~ msgid "_Disconnect"
+#~ msgstr "_Ажыратуу"
+
+#~ msgid "_Connect"
+#~ msgstr "_Туташуу"
+
+#~ msgid "Mesh"
+#~ msgstr "Тармактык"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Инфраструктура"
+
+#~ msgid "Status unknown"
+#~ msgstr "Абалы белгисиз"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Башкарууга мүмкүн эмес"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Кабель суурулган"
+
+#~ msgid "Unavailable"
+#~ msgstr "Жеткиликтүү эмес"
+
+#~ msgid "Disconnected"
+#~ msgstr "Ажыратылган"
+
+#~ msgid "Connecting"
+#~ msgstr "Туташуу"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Ажыратуу"
+
+#~ msgid "Connection failed"
+#~ msgstr "Туташуу ишке ашпады"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Абалы белгисиз  (жок)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Конфигурциялоо ишке ашпады"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP конфигурациялоо ишке ашпады"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP конфигурациясынын убакыты өтүп кеткен"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Сырсөз талап кылынат, бирок берилген эмес"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x клиенти ажыратылган"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x клиентин конфигурациялоо ишке ашпады"
+
+#, fuzzy
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x клиентинин катасы"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x клиенти аутентификацядан өтө узак өтүүдө"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP кызматы ишин баштай албады"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP кызматы ажыратылган"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP катасы"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP клиенти ишин баштай албады"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP клиентинин катасы"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP клиент катасы"
+
+#~ msgid "Line busy"
+#~ msgstr "Канал бош эмес"
+
+#~ msgid "No dial tone"
+#~ msgstr "Каналда сигнал жок"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Модемди инициализациялоо ишке ашпады"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Тармак каттоодон баш тартты"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Тармактын каттоо убакыты бүттү"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN текшерүү катасы"
+
+#~ msgid "Modem not found"
+#~ msgstr "Модем табылган жок"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth туташуу катасы"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM картанын Pin коду керек"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM картанын Puk коду керек"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Туура эмес SIM карта"
+
+#~ msgid "_Log In"
+#~ msgstr "_Кирүү"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "Батарея колдонулууда - %s калды"
+
+#~ msgid "Charging"
+#~ msgstr "Заряд алуу"
+
+#~ msgid "Using battery power"
+#~ msgstr "Батареяны колдонуу"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "Заряд алуу - толду"
+
+#~ msgid "Empty"
+#~ msgstr "Бош"
+
+#~ msgid "Don't suspend"
+#~ msgstr "Күтүү режимине өткөрбөө"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "Көрсөтүлгөн убакта жөн турса"
+
+#~ msgid "When power is _critically low"
+#~ msgstr "Батареянын кубаттуулугу _критикалык азайганда"
+
+#~ msgid "Out of toner"
+#~ msgstr "Тонер жок"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Маркер жакында бүтөт"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Маркер бүттү"
+
+#~ msgid "Open cover"
+#~ msgstr "Капкагы ачык"
+
+#~ msgid "Low on paper"
+#~ msgstr "Кагаз аз"
+
+#~ msgid "Out of paper"
+#~ msgstr "Кагаз жок"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "Паузада"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Резервуар толгонуна жакын калды"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Резервуар толду"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Фоторезистор жакында иштен чыгат"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Фоторезистор иштен чыкты"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Даяр"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Иштетүү"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Токтотулган"
+
+#~ msgid "Toner Level"
+#~ msgstr "Тонердин деңгээли"
+
+#~ msgid "Supply Level"
+#~ msgstr "Ресурстардын деңгээли"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Орнотуу"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u активдүү"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Жаңы принтер кошуулбады"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript Printer Description файлдары (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+#~ "gz, *.PPD.GZ)"
+
+#~ msgid "Provide PPD File..."
+#~ msgstr "PPD файлын колдонуу..."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Колдонуучу интерфейси жүктөлбөдү: %s"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Resume Printing"
+#~ msgstr "Басууну улантуу"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Басууну убактылуу токтотуу"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Жаңы принтер кошуу"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Тармактагы принтерлерди издөө же жыйынтыгын чыпкалоо"
+
+#~ msgid "One Sided"
+#~ msgstr "Бир тараптуу"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Узун жагы менен (Стандарт)"
+
+#, fuzzy
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Кыска жагы менен (терс жагын ачуу)"
+
+#~ msgid "Portrait"
+#~ msgstr "Портрет"
+
+#~ msgid "Landscape"
+#~ msgstr "Ландшафт"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Алмаштырылган ландшафт"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Алмаштырылган портрет"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Күтүү"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Аткарылууда"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Токтотулган"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Аяктаган"
+
+#~ msgid "Job Title"
+#~ msgstr "Тапшырма"
+
+#~ msgid "Job State"
+#~ msgstr "Абалы"
+
+#~ msgid "Two Sided"
+#~ msgstr "Эки тараптуу"
+
+#~ msgid "Paper Source"
+#~ msgstr "Кагаз булагы"
+
+#~ msgid "Output Tray"
+#~ msgstr "Чыгуу орду"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript менен алыдна ала чыпкалоо"
+
+#~ msgid "Pages per side"
+#~ msgstr "Беттеги барактардын саны"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Жалпы"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Барак параметрлери"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Орнотулуучу параметрлер"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Тапшырма"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Түс"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Аяктоо"
+
+#~ msgid "Auto Select"
+#~ msgstr "Автоматтык түрдө тандоо"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "GhostScript ариптерин гана колдонуу (embed)"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS level 1 ге өткөрүү"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS level 2 ге өткөрүү"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Алдына ала чыпкалабоо"
+
+#~ msgid "Manufacturers"
+#~ msgstr "Өндүрүүчүлөр"
+
+#~ msgid "Drivers"
+#~ msgstr "Драйверлер"
+
+#~ msgid "_Default"
+#~ msgstr "_Абалкы"
+
+#~ msgid "Jobs"
+#~ msgstr "Тапшырмалар"
+
+#~ msgid "_Show"
+#~ msgstr "_Көрсөтүү"
+
+#~ msgid "page 1"
+#~ msgstr "1-барак"
+
+#~ msgid "label"
+#~ msgstr "белги"
+
+#~ msgid "page 2"
+#~ msgstr "2-барак"
+
+#~ msgid "page 3"
+#~ msgstr "3-барак"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "_Текшерүү барагын басуу"
+
+#~ msgid "_Options"
+#~ msgstr "_Параметрлер"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Жаңы принтер кошуу"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "Сиздин регион жана тил параметрлери"
+
+#~ msgid "Imperial"
+#~ msgstr "Империялык"
+
+#~ msgid "Choose an input source"
+#~ msgstr "Киргизүү булагын тандаңыз"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "Кошуу үчүн киргизүү булагын тандаңыз"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "Кирүү терезеси, системалык наамалар жана жаңы наамалар системанын регион "
+#~ "жана тил параметрлерин колдонот."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "Кирүү терезеси, системалык наамалар жана жаңы наамалар системанын регион "
+#~ "жана тил параметрлерин колдонот. Сиз системалык параметрлерди өзүңүзгө "
+#~ "ылайыктап алсаңыз болот."
+
+#~ msgid "Copy Settings"
+#~ msgstr "Параметрлерди көчүрүү"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "Параметрлерди көчүрүү..."
+
+#~ msgid "Region and Language"
+#~ msgstr "Регион жана тил"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr "Тил тандаңыз (системага кийинки жолу киргенде колдонула баштайт)"
+
+#~ msgid "Add Language"
+#~ msgstr "Тил кошуу"
+
+#~ msgid "Remove Language"
+#~ msgstr "Тилди алып таштоо"
+
+#~ msgid "Language"
+#~ msgstr "Тил"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "Регион тандаңыз (системага кийинки жолу киргенде колдонула баштайт)"
+
+#~ msgid "Add Region"
+#~ msgstr "Регион кошуу"
+
+#~ msgid "Currency"
+#~ msgstr "Акча"
+
+#~ msgid "Examples"
+#~ msgstr "Мисалдар"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "Алиптактаны жана башка киргизүү түзүмдөрүн тандаңыз"
+
+#~ msgid "Remove Input Source"
+#~ msgstr "Киргизүү булагын алып таштоо"
+
+#~ msgid "Move Input Source Up"
+#~ msgstr "Киргизүү булагын жогору жылдыруу"
+
+#~ msgid "Move Input Source Down"
+#~ msgstr "Киргизүү булагын төмөн жылдыруу"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Ctrl+Alt+Shift+Space"
+#~ msgstr "Ctrl+Alt+Shift+Аралык"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "Композициялардын параметри"
+
+#~ msgid "Input source:"
+#~ msgstr "Киргизүү булагы:"
+
+#~ msgid "Format:"
+#~ msgstr "Формат:"
+
+#~ msgid "Your settings"
+#~ msgstr "Сиздин параметрлер"
+
+#~ msgid "System settings"
+#~ msgstr "Системанын параметрлери"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "Ачыктык жана бекитүү"
+
+#, fuzzy
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Ачыктык;Бекитүү;Dim;Blank;Монитор;"
+
+#~ msgid "Screen turns off"
+#~ msgstr "Экран өчүрүлөт"
+
+#~ msgid "1 minute"
+#~ msgstr "1 мүнөттө"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 мүнөттө"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "Энергияны үнөмдөө үчүн экрандын ачыктыгын азайтуу"
+
+#~ msgid "_Turn screen off when inactive for:"
+#~ msgstr "Убакыт аралыгында иш жүрбөсө, экранды  _өчүрүү:"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "Үйдө болгондо бекитпөө"
+
+#~ msgid "Locations..."
+#~ msgstr "Жайгашкан жерлер..."
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Ката издөөнү иштетүү"
+
+#~ msgid "Version of this application"
+#~ msgstr "Бул иштеменени версиясы"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME үн бийиктигин башкаруу апплети"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Үн бийиктигин башкарууну ачуу"
+
+#~ msgid "Bark"
+#~ msgstr "Ит"
+
+#~ msgid "Drip"
+#~ msgstr "Тамчы"
+
+#~ msgid "Glass"
+#~ msgstr "Айнек"
+
+#~ msgid "Sonar"
+#~ msgstr "Сонар"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Чыгуудагы үн бийиктиги"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Минимум"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Максимум"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Сабвуфер:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Күчтөтүүсүз"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "Динамикти _текшерүү"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Үн үчүн чыгуу түзүмүн тандоо:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Тандалган түзүмдүн параметрлери:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Жазуу _бийиктиги:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Үн кирүүчү түзүмдү танда:"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Үн параметрлери"
+
+#~ msgid "From theme"
+#~ msgstr "Бул темадан"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Билдирүү үчүн үн танда:"
+
+#~ msgid "Stop"
+#~ msgstr "Токтотуу"
+
+#, c-format
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "Үн параметрлерин иштетүүгө болбоду: %s"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "_Үн параметрлери"
+
+#~ msgid "Muted"
+#~ msgstr "Өчүрүлгөн"
+
+#~ msgid "Custom"
+#~ msgstr "Башка"
+
+#~ msgid "No shortcut set"
+#~ msgstr "Комбинация орнотулган эмес"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Универсалдык жетүү параметрлери"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Кадимкидей"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Жогору/Инверсия"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Экран алиптактасы"
+
+#~ msgid "GOK"
+#~ msgstr "GOK"
+
+#, no-c-format
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Кадимки"
+
+#, no-c-format
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#, no-c-format
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "Чоң"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Caps жана Num Lock басылганда үн чыгаруу"
+
+#~ msgid "Options..."
+#~ msgstr "Параметрлер..."
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Чоңойтуу"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Жакындатуу:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Алыстатуу:"
+
+#~ msgid "Flash the window title"
+#~ msgstr "Терезенин башынын күйүп-өчүүсү"
+
+#~ msgid "- System Settings"
+#~ msgstr "- Системалык параметрлер"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Бардык параметрлердин толук тизмесин көрүү үчүн '%s --help' аткарыңыз.\n"
+
+#~ msgid "Control Center"
+#~ msgstr "Башкаруу борбору"
+
+#~ msgid "System Settings"
+#~ msgstr "Системалык параметрлер"

--- a/po/ky.po~
+++ b/po/ky.po~
@@ -1,0 +1,5226 @@
+# Kyrgyz translation for gnome-control-center.
+# Copyright (C) 2012 gnome-control-center authors
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Timur Zhamakeev <ztimur@gmail.com>, 2012.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2012-09-25 09:33+0000\n"
+"PO-Revision-Date: 2012-09-26 22:26+0600\n"
+"Last-Translator: Timur Zhamakeev <ztimur@gmail.com>\n"
+"Language-Team: Kirghiz <gnome-i18n@gnome.org>\n"
+"Language: ky\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Lokalize 1.4\n"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:2
+msgid "Changes throughout the day"
+msgstr "Күн ичинде алмашат"
+
+#: ../panels/background/background.ui.h:3
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Мозаика"
+
+#: ../panels/background/background.ui.h:4
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Чоңойтуу"
+
+#: ../panels/background/background.ui.h:5
+msgctxt "background, style"
+msgid "Center"
+msgstr "Ортосу"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Масштаб"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Толтуруу"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Span"
+msgstr "Батыруу"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:199
+msgid "Select Background"
+msgstr "Фонду тандоо"
+
+#: ../panels/background/cc-background-chooser-dialog.c:218
+msgid "Wallpapers"
+msgstr "Тушкагаз"
+
+#: ../panels/background/cc-background-chooser-dialog.c:227
+msgid "Pictures"
+msgstr "Сүрөттөр"
+
+#: ../panels/background/cc-background-chooser-dialog.c:235
+msgid "Colors"
+msgstr "Түстөр"
+
+#: ../panels/background/cc-background-chooser-dialog.c:244
+msgid "Flickr"
+msgstr "Flickr"
+
+#: ../panels/background/cc-background-chooser-dialog.c:286
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+#: ../panels/user-accounts/um-photo-dialog.c:98
+msgid "Select"
+msgstr "Тандоо"
+
+#: ../panels/background/cc-background-item.c:148
+msgid "multiple sizes"
+msgstr "түрдүү өлчөмү"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:152
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:281
+msgid "No Desktop Background"
+msgstr "Фонсуз Иштакта"
+
+#: ../panels/background/cc-background-panel.c:387
+msgid "Current background"
+msgstr "Учурдагы фон"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "Фон"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change the background"
+msgstr "Фонду алмаштыруу"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Тушкагаз;Экран;Иштакта;"
+
+#. TRANSLATORS: device type
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
+#: ../panels/network/panel-common.c:102
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
+msgid "Configure Bluetooth settings"
+msgstr "Bluetooth параметрлери"
+
+#: ../panels/bluetooth/bluetooth.ui.h:1
+msgid "Set Up New Device"
+msgstr "Жаңы түзүм орнотуу"
+
+#: ../panels/bluetooth/bluetooth.ui.h:2 ../panels/network/network.ui.h:9
+msgid "Remove Device"
+msgstr "Түзүмдү алып таштоо"
+
+#: ../panels/bluetooth/bluetooth.ui.h:3
+msgid "Connection"
+msgstr "Байланыш"
+
+#: ../panels/bluetooth/bluetooth.ui.h:4
+msgid "Paired"
+msgstr "Туташкан"
+
+#: ../panels/bluetooth/bluetooth.ui.h:5 ../panels/wacom/cc-wacom-page.c:756
+msgid "Type"
+msgstr "Түрү"
+
+#: ../panels/bluetooth/bluetooth.ui.h:6
+msgid "Address"
+msgstr "Дареги"
+
+#: ../panels/bluetooth/bluetooth.ui.h:7
+msgid "Mouse and Touchpad Settings"
+msgstr "Чычкан жана сенсордук панел параметрлери"
+
+#: ../panels/bluetooth/bluetooth.ui.h:8 ../panels/universal-access/uap.ui.h:38
+msgid "Sound Settings"
+msgstr "Үн параметрлери"
+
+#: ../panels/bluetooth/bluetooth.ui.h:9
+msgid "Keyboard Settings"
+msgstr "Алиптакта параметрлери"
+
+#: ../panels/bluetooth/bluetooth.ui.h:10
+msgid "Send Files..."
+msgstr "Файл жөнөтүү..."
+
+#: ../panels/bluetooth/bluetooth.ui.h:11
+msgid "Browse Files..."
+msgstr "Файл аралоо..."
+
+#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
+#: ../panels/bluetooth/bluetooth.ui.h:13
+msgctxt "Power"
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:290
+msgid "Yes"
+msgstr "Ооба"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:290
+msgid "No"
+msgstr "Жок"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:405
+msgid "Bluetooth is disabled"
+msgstr "Bluetooth өчүрүлгөн"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:410
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "Bluetooth аппараттык которгучу менен өчүрүлгөн"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:414
+msgid "No Bluetooth adapters found"
+msgstr "Bluetooth адаптери табылган жок"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:547
+msgid "Visibility"
+msgstr "Көрүнүүсү"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:551
+#, c-format
+msgid "Visibility of “%s”"
+msgstr "“%s” көрүнүүсү"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:595
+#, c-format
+msgid "Remove '%s' from the list of devices?"
+msgstr "'%s' ти түзүмдөр тизмесинен алып таштайлыбы?"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:597
+msgid ""
+"If you remove the device, you will have to set it up again before next use."
+msgstr ""
+"Эгер сиз муну алып таштасаңыз, кийинки жолу колдонгондо кайрадан орнотууңуз "
+"керек."
+
+#. TRANSLATORS: this is where the user can click and import a profile
+#: ../panels/color/cc-color-panel.c:106
+msgid "Other profile…"
+msgstr "Башка профиль…"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:119
+msgid "Default: "
+msgstr "Абалкы: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:126
+msgid "Colorspace: "
+msgstr "Түс мейкиндиги: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:132
+msgid "Test profile: "
+msgstr "Текшерүү профили: "
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:185 ../panels/color/color.ui.h:11
+msgid "Set for all users"
+msgstr "Бардык колдонуучулар үчүн орнотуу"
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:192
+msgid "Create virtual device"
+msgstr "Виртуалдык түзүм түзүү"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:227
+msgid "Select ICC Profile File"
+msgstr "ICC профайлынын файлын тандоо"
+
+#: ../panels/color/cc-color-panel.c:230
+msgid "_Import"
+msgstr "_Импорт"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:241
+msgid "Supported ICC profiles"
+msgstr "Колдоого ээ ICC профайлдары"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:248
+msgid "All files"
+msgstr "Бардык файл"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:522
+msgid "Available Profiles for Displays"
+msgstr "Экрандар үчүн мүмкүн болгон профайлдар"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:526
+msgid "Available Profiles for Scanners"
+msgstr "Сканерлер үчүн мүмкүн болгон профайлдар"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:530
+msgid "Available Profiles for Printers"
+msgstr "Принтерлер үчүн мүмкүн болгон профайлдар"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:534
+msgid "Available Profiles for Cameras"
+msgstr "Камералар үчүн мүмкүн болгон профайлдар"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:538
+msgid "Available Profiles for Webcams"
+msgstr "Вебкамералар үчүн мүмкүн болгон профайлдар"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#. * where the device type is not recognised
+#. Profiles that can be added to the device
+#: ../panels/color/cc-color-panel.c:543 ../panels/color/color.ui.h:2
+msgid "Available Profiles"
+msgstr "Мүмкүн болгон профайлдар"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:824
+#: ../panels/sound/gvc-mixer-dialog.c:1525
+msgid "Device"
+msgstr "Түзүм"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:859
+msgid "Calibration"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:891
+msgid "Create a color profile for the selected device"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:905 ../panels/color/cc-color-panel.c:929
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:938
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:949
+msgid "The device type is not currently supported."
+msgstr ""
+
+#. TRANSLATORS: this is when an auto-added profile cannot be removed
+#: ../panels/color/cc-color-panel.c:1022
+msgid "Cannot remove automatically added profile"
+msgstr ""
+
+#. TRANSLATORS: this is when there is no profile for the device
+#: ../panels/color/cc-color-panel.c:1359
+msgid "No profile"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1390
+#, c-format
+msgid "%i year"
+msgid_plural "%i years"
+msgstr[0] "%i жыл"
+
+#: ../panels/color/cc-color-panel.c:1401
+#, c-format
+msgid "%i month"
+msgid_plural "%i months"
+msgstr[0] "%i ай"
+
+#: ../panels/color/cc-color-panel.c:1412
+#, c-format
+msgid "%i week"
+msgid_plural "%i weeks"
+msgstr[0] "%i жума"
+
+#. fallback
+#: ../panels/color/cc-color-panel.c:1419
+#, c-format
+msgid "Less than 1 week"
+msgstr "1 жумадан аз"
+
+#: ../panels/color/cc-color-panel.c:1481
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Абалкы RGB"
+
+#: ../panels/color/cc-color-panel.c:1486
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Абалкы CMYK"
+
+#: ../panels/color/cc-color-panel.c:1491
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1609 ../panels/color/cc-color-panel.c:1650
+#: ../panels/color/cc-color-panel.c:1661 ../panels/color/cc-color-panel.c:1672
+msgid "Uncalibrated"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1612
+msgid "This device is not color managed."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1653
+msgid "This device is using manufacturing calibrated data."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1664
+msgid ""
+"This device does not have a profile suitable for whole-screen color "
+"correction."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1697
+msgid "This device has an old profile that may no longer be accurate."
+msgstr ""
+
+#. TRANSLATORS: this is when the calibration profile age is not
+#. * specified as it has been autogenerated from the hardware
+#: ../panels/color/cc-color-panel.c:1725
+msgid "Not specified"
+msgstr ""
+
+#. add the 'No devices detected' entry
+#: ../panels/color/cc-color-panel.c:1910
+msgid "No devices supporting color management detected"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2139
+msgctxt "Device kind"
+msgid "Display"
+msgstr "Экран"
+
+#: ../panels/color/cc-color-panel.c:2141
+msgctxt "Device kind"
+msgid "Scanner"
+msgstr "Сканер"
+
+#: ../panels/color/cc-color-panel.c:2143
+msgctxt "Device kind"
+msgid "Printer"
+msgstr "Принтер"
+
+#: ../panels/color/cc-color-panel.c:2145
+msgctxt "Device kind"
+msgid "Camera"
+msgstr "Камера"
+
+#: ../panels/color/cc-color-panel.c:2147
+msgctxt "Device kind"
+msgid "Webcam"
+msgstr "Вебкамера"
+
+#: ../panels/color/color.ui.h:3
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "Түс"
+
+#: ../panels/color/color.ui.h:4
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: ../panels/color/color.ui.h:5
+msgid "Learn more"
+msgstr ""
+
+#: ../panels/color/color.ui.h:6
+msgid "Learn more about color management"
+msgstr ""
+
+#: ../panels/color/color.ui.h:7
+msgid "Add device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:8
+msgid "Add a virtual device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:9
+msgid "Delete device"
+msgstr "Түзүмдү жоготуу"
+
+#: ../panels/color/color.ui.h:10
+msgid "Remove a device"
+msgstr "Түзүмдү алып таштоо"
+
+#: ../panels/color/color.ui.h:12
+msgid "Set this profile for all users on this computer"
+msgstr "Бул профайлды компьютердеги бардык колдонуучуларга орнотуу"
+
+#: ../panels/color/color.ui.h:13
+msgid "Add profile"
+msgstr "Профайл кошуу"
+
+#: ../panels/color/color.ui.h:14
+msgid "Calibrate…"
+msgstr "Калибрлөө..."
+
+#: ../panels/color/color.ui.h:15
+msgid "Calibrate the device"
+msgstr "Түзүмдү калибрлөө"
+
+#: ../panels/color/color.ui.h:16
+msgid "Remove profile"
+msgstr "Профайлды жоготуу"
+
+#: ../panels/color/color.ui.h:17
+msgid "View details"
+msgstr "Маалыматын кароо"
+
+#: ../panels/color/color.ui.h:18
+msgid "Device type:"
+msgstr "Түзүм түрү:"
+
+#: ../panels/color/color.ui.h:19
+msgid "Manufacturer:"
+msgstr "Өндүрүүчү:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Model:"
+msgstr "Модели:"
+
+#: ../panels/color/color.ui.h:21
+msgid ""
+"Image files can be dragged on this window to auto-complete the above fields."
+msgstr ""
+"Жогорудагы талааларды автоматтык түрдө толтуруу үчүн, сүрөт файлын бул "
+"терезеге сүйрөп келүүгө болот."
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Color management settings"
+msgstr "Түс башкаруу параметрлери"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Түс;ICC;Профайл;Калибрлөө;Принтер;Экран;"
+
+#. Add some common languages first
+#: ../panels/common/cc-common-language.c:523
+msgid "English"
+msgstr "Англисче"
+
+#: ../panels/common/cc-common-language.c:525
+msgid "British English"
+msgstr "Британ анлис тилинде"
+
+#: ../panels/common/cc-common-language.c:528
+msgid "German"
+msgstr "Немисче"
+
+#: ../panels/common/cc-common-language.c:531
+msgid "French"
+msgstr "Французча"
+
+#: ../panels/common/cc-common-language.c:534
+msgid "Spanish"
+msgstr "Испанча"
+
+#: ../panels/common/cc-common-language.c:536
+msgid "Chinese (simplified)"
+msgstr "Кытайча (жөнөкөй)"
+
+#: ../panels/common/cc-common-language.c:539
+msgid "Russian"
+msgstr "Орусча"
+
+#: ../panels/common/cc-common-language.c:542
+msgid "Arabic"
+msgstr "Арабча"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:571
+msgid "United States"
+msgstr "Кошмо Штаттары"
+
+#: ../panels/common/cc-common-language.c:572
+msgid "Germany"
+msgstr "Германия"
+
+#: ../panels/common/cc-common-language.c:573
+msgid "France"
+msgstr "Франция"
+
+#: ../panels/common/cc-common-language.c:574
+msgid "Spain"
+msgstr "Испания"
+
+#: ../panels/common/cc-common-language.c:575
+msgid "China"
+msgstr "Кытай"
+
+#: ../panels/common/cc-language-chooser.c:122
+msgid "Other..."
+msgstr "Башка..."
+
+#: ../panels/common/cc-language-chooser.c:296
+msgid "Select a region"
+msgstr "Регион тандоо"
+
+#: ../panels/common/gdm-languages.c:781
+msgid "Unspecified"
+msgstr "Аныкталбаган"
+
+#: ../panels/common/language-chooser.ui.h:1
+msgid "Select a language"
+msgstr "Тил тандоо"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/printers/new-printer-dialog.ui.h:1
+#: ../panels/user-accounts/um-user-panel.c:462
+msgid "_Cancel"
+msgstr "_Айынуу"
+
+#: ../panels/common/language-chooser.ui.h:3
+msgid "_Select"
+msgstr "_Тандоо"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "_Region:"
+msgstr "_Регион:"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "_City:"
+msgstr "_Шаар:"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "_Network Time"
+msgstr "Тармак _убактысы"
+
+#. Translator: this is the separator between hours and minutes, like in HH:MM
+#: ../panels/datetime/datetime.ui.h:5
+msgid ":"
+msgstr ":"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "Set the time one hour ahead."
+msgstr "Бир саатка алдыга."
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "Set the time one hour back."
+msgstr "Бир саатка артка."
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "Set the time one minute ahead."
+msgstr "Бир мүнөткө алдыга."
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "Set the time one minute back."
+msgstr "Бир мүнөткө артка."
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "Switch between AM and PM."
+msgstr "ТЧ жана ТК алмашуусу."
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "Month"
+msgstr "Ай"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "Day"
+msgstr "Күн"
+
+#: ../panels/datetime/datetime.ui.h:13
+msgid "Year"
+msgstr "Жыл"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "24-hour"
+msgstr "24 саатык формат"
+
+#: ../panels/datetime/datetime.ui.h:15
+msgid "AM/PM"
+msgstr "ТЧ/ТК"
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "January"
+msgstr "Январь"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "February"
+msgstr "Февраль"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "March"
+msgstr "Март"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "April"
+msgstr "Апрель"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "May"
+msgstr "Май"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "June"
+msgstr "Июнь"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "July"
+msgstr "Июль"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "August"
+msgstr "Август"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "September"
+msgstr "Сентябрь"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "October"
+msgstr "Октябрь"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "November"
+msgstr "Ноябрь"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "December"
+msgstr "Декабрь"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "Дата жана убакыт"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Date and Time preferences panel"
+msgstr "Дата жана убакыт параметрлеринин панели"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "Саат;Убакыт зонасы;Жайгашуу;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "Системанын убакыт жана дата параметрлерин өзгөртүү"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Убакыт жана дата параметрлерин өзгөртүү үчүн, аутентификациядан өтүү зарыл"
+
+#: ../panels/display/cc-display-panel.c:481
+msgctxt "display panel, rotation"
+msgid "Normal"
+msgstr "Кадимкидей"
+
+#: ../panels/display/cc-display-panel.c:482
+msgctxt "display panel, rotation"
+msgid "Counterclockwise"
+msgstr "Саат жэбесине каршы"
+
+#: ../panels/display/cc-display-panel.c:483
+msgctxt "display panel, rotation"
+msgid "Clockwise"
+msgstr "Саат жэбеси боюнча"
+
+#: ../panels/display/cc-display-panel.c:484
+msgctxt "display panel, rotation"
+msgid "180 Degrees"
+msgstr "180 градуска"
+
+#. Keep this string in sync with gnome-desktop/libgnome-desktop/gnome-rr-labeler.c
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external projector.  Here, "Mirrored" is being
+#. * used as an adjective.  For example, the Spanish translation could be
+#. * "Pantallas en Espejo".
+#.
+#: ../panels/display/cc-display-panel.c:623
+msgid "Mirrored Displays"
+msgstr "Чагылдырылган экрандар"
+
+#: ../panels/display/cc-display-panel.c:647
+#: ../panels/display/display-capplet.ui.h:1
+msgid "Monitor"
+msgstr "Монитор"
+
+#: ../panels/display/cc-display-panel.c:748
+#, c-format
+msgid "%d x %d (%s)"
+msgstr "%d x %d (%s)"
+
+#: ../panels/display/cc-display-panel.c:750
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#: ../panels/display/cc-display-panel.c:1659
+msgid "Drag to change primary display."
+msgstr "Негизги дисплейди өзгөртүү үчүн - жылдырыңыз"
+
+#: ../panels/display/cc-display-panel.c:1717
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr ""
+"Монитордун касиеттерин өзгөртүү үчүн, аны тандаңыз; орунун"
+"алмаштыруу үчүн - жылдырыңыз."
+
+#: ../panels/display/cc-display-panel.c:2105
+msgid "%a %R"
+msgstr "%a %R"
+
+#: ../panels/display/cc-display-panel.c:2107
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../panels/display/cc-display-panel.c:2269
+#: ../panels/display/cc-display-panel.c:2321
+#, c-format
+msgid "Failed to apply configuration: %s"
+msgstr "Конфигурацияны кабылдоо ишке ашпады: %s"
+
+#: ../panels/display/cc-display-panel.c:2349
+msgid "Could not save the monitor configuration"
+msgstr "Монитордун конфигурациясын сактоого болбоду"
+
+#: ../panels/display/cc-display-panel.c:2409
+msgid "Could not detect displays"
+msgstr "Мониторлорду аныктоого болбоду"
+
+#: ../panels/display/cc-display-panel.c:2603
+msgid "Could not get screen information"
+msgstr "Экран жөнүндө маалымат алууга болбоду"
+
+#: ../panels/display/display-capplet.ui.h:2
+msgid "_Resolution"
+msgstr "_Ажырымдуулук"
+
+#: ../panels/display/display-capplet.ui.h:3
+#, fuzzy
+msgid "R_otation"
+msgstr "_Багыты"
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:5
+msgid "_Mirror displays"
+msgstr "_Чагылдырылган дисплейлер"
+
+#: ../panels/display/display-capplet.ui.h:6
+msgid "Note: may limit resolution options"
+msgstr "Эскертүү: ажырымдуулук параметри чектелүү болушу мүмкүн"
+
+#: ../panels/display/display-capplet.ui.h:7
+msgid "_Detect Displays"
+msgstr "Дисплейлерди _аныктоо"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "Дисплейлер"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Change resolution and position of monitors and projectors"
+msgstr ""
+"Мониторлор жана проекторлордун ажыратымдуулугун жана позициясын өзгөртүү"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr "Панель;Проектор;xrandr;Экран;Ажырымдуулук;Жаңылоо;"
+
+#. Translators: VESA is an techncial acronym, don't translate it.
+#: ../panels/info/cc-info-panel.c:413
+#, c-format
+msgid "VESA: %s"
+msgstr "VESA: %s"
+
+#. TRANSLATORS: device type
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:437 ../panels/network/panel-common.c:82
+#: ../panels/network/panel-common.c:162
+msgid "Unknown"
+msgstr "Белгисиз"
+
+#. translators: This is the type of architecture, for example:
+#. * "64-bit" or "32-bit"
+#: ../panels/info/cc-info-panel.c:593
+#, c-format
+msgid "%d-bit"
+msgstr "%d бит"
+
+#: ../panels/info/cc-info-panel.c:752
+msgid "Unknown model"
+msgstr "Белгисиз модель"
+
+#: ../panels/info/cc-info-panel.c:835
+msgid "The next login will attempt to use the standard experience."
+msgstr "Кийинки жолу системага кирүү учурунда стандарттык режим колдонулат."
+
+#: ../panels/info/cc-info-panel.c:837
+msgid ""
+"The next login will use the fallback mode intended for unsupported graphics "
+"hardware."
+msgstr ""
+"Кийинки жолу системага кирүү учурунда альтернативдик режим колдонулат. "
+"Ал колдоого ээ болбогон графикалык түзүмдөр үчүн жасалган."
+
+#. translators: The hardware is not able to run GNOME 3's
+#. * shell, so we use the GNOME "Fallback" session
+#: ../panels/info/cc-info-panel.c:879
+msgctxt "Experience"
+msgid "Fallback"
+msgstr "Альтернативдик"
+
+#. translators: The hardware is able to run GNOME 3's
+#. * shell, also called "Standard" experience
+#: ../panels/info/cc-info-panel.c:885
+msgctxt "Experience"
+msgid "Standard"
+msgstr "Стандарттык"
+
+#: ../panels/info/cc-info-panel.c:1227
+msgid "Ask what to do"
+msgstr "Эмне кылышты суроо"
+
+#: ../panels/info/cc-info-panel.c:1231
+msgid "Do nothing"
+msgstr "Эч нерсе кылбоо"
+
+#: ../panels/info/cc-info-panel.c:1235
+msgid "Open folder"
+msgstr "Каталогду ачуу"
+
+#: ../panels/info/cc-info-panel.c:1326
+#, fuzzy
+msgid "Other Media"
+msgstr "Башка сактама"
+
+#: ../panels/info/cc-info-panel.c:1357
+msgid "Select an application for audio CDs"
+msgstr "Аудио CD үчүн иштеме тандоо"
+
+#: ../panels/info/cc-info-panel.c:1358
+msgid "Select an application for video DVDs"
+msgstr "Аудио DVD үчүн иштеме тандоо"
+
+#: ../panels/info/cc-info-panel.c:1359
+msgid "Select an application to run when a music player is connected"
+msgstr "Музыкалык плеер туташканда аткарылуучу иштеме тандоо"
+
+#: ../panels/info/cc-info-panel.c:1360
+msgid "Select an application to run when a camera is connected"
+msgstr "Камера туташканда аткарылуучу иштеме тандоо"
+
+#: ../panels/info/cc-info-panel.c:1361
+msgid "Select an application for software CDs"
+msgstr "Программалуу CD үчүн иштеме тандоо"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1373
+msgid "audio DVD"
+msgstr "аудио DVD"
+
+#: ../panels/info/cc-info-panel.c:1374
+msgid "blank Blu-ray disc"
+msgstr "таза Blu-ray диск"
+
+#: ../panels/info/cc-info-panel.c:1375
+msgid "blank CD disc"
+msgstr "таза CD диск"
+
+#: ../panels/info/cc-info-panel.c:1376
+msgid "blank DVD disc"
+msgstr "таза DVD диск"
+
+#: ../panels/info/cc-info-panel.c:1377
+msgid "blank HD DVD disc"
+msgstr "таза HD DVD диск"
+
+#: ../panels/info/cc-info-panel.c:1378
+msgid "Blu-ray video disc"
+msgstr "Blu-ray видео диск"
+
+#: ../panels/info/cc-info-panel.c:1379
+msgid "e-book reader"
+msgstr "электрондук китеп окуу түзүмү"
+
+#: ../panels/info/cc-info-panel.c:1380
+msgid "HD DVD video disc"
+msgstr "HD DVD видео диск"
+
+#: ../panels/info/cc-info-panel.c:1381
+msgid "Picture CD"
+msgstr "Сүрөт CD"
+
+#: ../panels/info/cc-info-panel.c:1382
+msgid "Super Video CD"
+msgstr "Супервидео CD"
+
+#: ../panels/info/cc-info-panel.c:1383
+msgid "Video CD"
+msgstr "Видео CD"
+
+#: ../panels/info/cc-info-panel.c:1384
+msgid "Windows software"
+msgstr "Windows иштемеси"
+
+#: ../panels/info/cc-info-panel.c:1385
+msgid "Software"
+msgstr "Иштеме"
+
+#: ../panels/info/cc-info-panel.c:1508
+#: ../panels/keyboard/keyboard-shortcuts.c:1667
+msgid "Section"
+msgstr "Бөлүм"
+
+#: ../panels/info/cc-info-panel.c:1517 ../panels/info/info.ui.h:11
+msgid "Overview"
+msgstr "Көрүнүшү"
+
+#: ../panels/info/cc-info-panel.c:1523 ../panels/info/info.ui.h:18
+msgid "Default Applications"
+msgstr "Абалкы иштемелер"
+
+#: ../panels/info/cc-info-panel.c:1528 ../panels/info/info.ui.h:26
+msgid "Removable Media"
+msgstr "Ажыратма сактама"
+
+#: ../panels/info/cc-info-panel.c:1533 ../panels/info/info.ui.h:10
+msgid "Graphics"
+msgstr "Графика"
+
+#: ../panels/info/cc-info-panel.c:1735
+#, c-format
+msgid "Version %s"
+msgstr "Версиясы %s"
+
+#: ../panels/info/cc-info-panel.c:1785
+msgid "Install Updates"
+msgstr "Оңдоолорду орнотуу"
+
+#: ../panels/info/cc-info-panel.c:1789
+msgid "System Up-To-Date"
+msgstr "Оңдоолор жок"
+
+#: ../panels/info/cc-info-panel.c:1793
+msgid "Checking for Updates"
+msgstr "Оңдоолорду издөө"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+msgid "Details"
+msgstr "Кеңири маалыматы"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "System Information"
+msgstr "Системалык маалымат"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+#, fuzzy
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"түзүм;система;маалымат;эс;процессор;версия;абалкы;иштеме;"
+"альтернативдик;сунушталган;cd;dvd;usb;аудио;видео;диск;ажыратма;сактама;автоиш"
+"төө;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "Башка сактама кантип иштетилүүсүн танда"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "_Аракет:"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "_Түрү:"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "Түзүм аты"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "Эс"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "Процессор"
+
+#: ../panels/info/info.ui.h:7
+msgid "OS type"
+msgstr "АС тиби"
+
+#: ../panels/info/info.ui.h:8
+msgid "Disk"
+msgstr "Диск"
+
+#: ../panels/info/info.ui.h:9
+msgid "Calculating..."
+msgstr "Эсептөө"
+
+#: ../panels/info/info.ui.h:12
+msgid "_Web"
+msgstr "_Веб"
+
+#: ../panels/info/info.ui.h:13
+msgid "_Mail"
+msgstr "_Почто"
+
+#: ../panels/info/info.ui.h:14
+msgid "_Calendar"
+msgstr "_Календарь"
+
+#: ../panels/info/info.ui.h:15
+msgid "M_usic"
+msgstr "_Музыка"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Video"
+msgstr "_Видео"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Photos"
+msgstr "_Фото"
+
+#: ../panels/info/info.ui.h:19
+msgid "Select how media should be handled"
+msgstr "Сактама кантип иштетилүүсүн танда"
+
+#: ../panels/info/info.ui.h:20
+msgid "CD _audio"
+msgstr "CD _аудио"
+
+#: ../panels/info/info.ui.h:21
+msgid "_DVD video"
+msgstr "DVD _видео"
+
+#: ../panels/info/info.ui.h:22
+msgid "_Music player"
+msgstr "Музыка _плеери"
+
+#: ../panels/info/info.ui.h:23
+msgid "_Software"
+msgstr "_Иштеме"
+
+#: ../panels/info/info.ui.h:24
+msgid "_Other Media..."
+msgstr "_Башка сактама..."
+
+#: ../panels/info/info.ui.h:25
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Сактама түзүмү туташканда программаны иштетүүнү сурабоо жана аны аткарбоо"
+
+#: ../panels/info/info.ui.h:27
+msgid "Driver"
+msgstr "Драйвер"
+
+#: ../panels/info/info.ui.h:28
+msgid "Experience"
+msgstr "Режим"
+
+#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
+#: ../panels/info/info.ui.h:30
+msgid "Forced _Fallback Mode"
+msgstr ""
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "Үн жана сактамалар"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "Үндү өчүрүү"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "Үндү басаңдатуу"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "Үндү жогорулатуу"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "Медиа плеерди иштетүү"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "Ойнотуу (же ойнотуу/пауза)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "Ойношун убактылуу токтотуу"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "Ойношун токтотуу"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "Мурунку трек"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "Кийинки трек"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "Чыгаруу"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Typing"
+msgstr "Басуу"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: ../panels/region/gnome-region-panel.ui.h:26
+msgid "Switch to next source"
+msgstr "Кийинки булакка өтүү"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: ../panels/region/gnome-region-panel.ui.h:24
+msgid "Switch to previous source"
+msgstr "Мурунку булакка өтүү"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "Иштемелерди аткаруу"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "Жардам браузерин иштетүү"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3
+msgid "Launch calculator"
+msgstr "Калькуляторду иштетүү"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch email client"
+msgstr "Электрондук почто клиентин иштетүү"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch web browser"
+msgstr "Веб-аралагычын иштетүү"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Home folder"
+msgstr "Өзүмдүк каталог"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Search"
+msgstr "Издөө"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "Экран сүрөтү"
+
+#. translators: Pictures is the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to Pictures"
+msgstr "Экран сүрөттөрүн \"Сүрөттөр\" каталогуна жазуу"
+
+#. translators: Pictures is the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to Pictures"
+msgstr "Терезе сүрөттөрүн \"Сүрөттөр\" каталогуна жазуу"
+
+#. translators: Pictures is the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+#, fuzzy
+msgid "Save a screenshot of an area to Pictures"
+msgstr "Областардын сүрөттөрүн \"Сүрөттөр\" каталогуна жазуу"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "Экран сүрөтүн алмашуу буферине көчүрүү"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Терезе сүрөтүн алмашуу буферине көчүрүү"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Област сүрөтүн алмашуу буферине көчүрүү"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+#: ../panels/region/gnome-region-panel.ui.h:39
+msgid "System"
+msgstr "Система"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Чыгуу"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "Экранды кулпулоо"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "Универсалдык жетүү"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "Чоңойтууну иштетүү же токтотуу"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "Жакындатуу"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "Алыстатуу"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "Экрандан окугучту иштетүү же токтотуу"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "Экран алиптактасын иштетүү же токтотуу"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "Текстин өлчөмүн чоңойтуу"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "Текстин өлчөмүн кичирейтүү"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "Жогору контрастуулукту иштетүү же токтотуу"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:241
+#: ../panels/keyboard/cc-keyboard-option.c:347
+#: ../panels/keyboard/keyboard-shortcuts.c:1132
+#: ../panels/sound/gvc-mixer-control.c:1834
+#: ../panels/user-accounts/um-fingerprint-dialog.c:215
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Disabled"
+msgstr "Токтотулган"
+
+#: ../panels/keyboard/cc-keyboard-option.c:315
+msgid "Alternative Characters Key"
+msgstr "Альтернативдик символдор баскычы"
+
+#: ../panels/keyboard/cc-keyboard-option.c:320
+msgid "Compose Key"
+msgstr "Композиция баскычы"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "Keyboard"
+msgstr "Алиптаката"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "Change keyboard settings"
+msgstr "Алиптакта параметрлерин өзгөртүү"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Комбинация;Кайталоо;Өчүп-жануу;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "Баскычтардын кошумча комбинациясы"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "_Name:"
+msgstr "_Аталышы:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "C_ommand:"
+msgstr "_Команда:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "Repeat Keys"
+msgstr "Автокайталоо"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Key presses _repeat when key is held down"
+msgstr "Басылып турган баскычты _кайталоо"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "_Delay:"
+msgstr "_Аралык:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Speed:"
+msgstr "_Ылдамдык:"
+
+#. short delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Short"
+msgstr "Кыска"
+
+#. slow acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Slow"
+msgstr "Жай"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgid "Repeat keys speed"
+msgstr "Баскычты кайталоо ылдамдыгы"
+
+#. long delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Long"
+msgstr "Узун"
+
+#. fast acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Fast"
+msgstr "Тез"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgid "Cursor Blinking"
+msgstr "Курсордун өчүп-жануусу"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor _blinks in text fields"
+msgstr "Курсор тексттик талааларда _өчүп-жанат"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "S_peed:"
+msgstr "_Ылдамдык:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "Cursor blink speed"
+msgstr "Курсордун  өчүп-жануу ылдамдыгы"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+#, fuzzy
+msgid "Layout Settings"
+msgstr "Тактанын параметрлери"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+msgid "Add Shortcut"
+msgstr "Комбинация кошуу"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Remove Shortcut"
+msgstr "Комбинацияны жоготуу"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"Комбинацияны оңдоо үчүн, сапты тандап жаңы баскычты басыңыз "
+"же өчүрүү үчүн Backspace баскычын колдонуңуз"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+#: ../panels/region/gnome-region-panel.ui.h:29
+msgid "Shortcuts"
+msgstr "Комбинациялар"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:557
+#: ../panels/keyboard/keyboard-shortcuts.c:565
+msgid "Custom Shortcuts"
+msgstr "Кошумча комбинациялар"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:776
+msgid "<Unknown Action>"
+msgstr "<Белгисиз аракет>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1273
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"\"%s\" комбинациясын колдонууга болбойт, себеби аны колдону терүүгө "
+"мүмкүн эмес.\n"
+"Control, Alt же Shift баскычтары менен чогуу колдонуп көрүңүз."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1305
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"\"%s\" комбинациясы \n"
+"\"%s\" үчүн колдонулууда"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1310
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1316
+msgid "_Reassign"
+msgstr "_Кайра аныктоо"
+
+#: ../panels/mouse/cc-mouse-panel.c:152
+msgid "_Test Your Settings"
+msgstr "Сиздин параметрлериңизди _текшерүү"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "Чычкан жана сенсордук такта"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Set your mouse and touchpad preferences"
+msgstr "Сиздин чычкан түзүмүңүздүн жана сенсордук тактаңыздын параметрлери"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "Mouse Preferences"
+msgstr "Чычкан параметрлери"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "General"
+msgstr "Жалпы"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "Double-click timeout"
+msgstr "Коштоп чертүү аралыгы"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "_Double-click"
+msgstr "_Коштоп чертүү"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Primary _button"
+msgstr "Негизги _черткич"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Left"
+msgstr "_Солдогусу"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgid "_Right"
+msgstr "_Оңдогусу"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgid "Mouse"
+msgstr "Чычкан"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "_Pointer speed"
+msgstr "_Көрсөткүчтүн  ылдамдыгы"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgid "Touchpad"
+msgstr "Сенсордук такта"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgid "Disable while _typing"
+msgstr "_Терүү учурунда өчүрүү"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Tap to _click"
+msgstr "_Тийгенде чертүү катары кароо"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Two _finger scroll"
+msgstr "_Эки манжа менен жылдыруу"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "C_ontent sticks to fingers"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:134
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:139
+msgid "Five clicks, GEGL time!"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:144
+msgid "Double click, primary button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:144
+msgid "Single click, primary button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:147
+msgid "Double click, middle button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:147
+msgid "Single click, middle button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:150
+msgid "Double click, secondary button"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:150
+msgid "Single click, secondary button"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:615
+msgid "Network proxy"
+msgstr "Тармак проксиси"
+
+#: ../panels/network/cc-network-panel.c:799 ../panels/network/net-vpn.c:278
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:866
+msgid "The system network services are not compatible with this version."
+msgstr ""
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:1001
+msgid "Air_plane Mode"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "Тармак"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Network settings"
+msgstr "Тармак параметрлери"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#, fuzzy
+msgid "Network;Wireless;IP;LAN;Proxy;"
+msgstr "Тармак;Wireless;IP;LAN;Прокси;"
+
+#: ../panels/network/net-device-mobile.c:222
+msgid "Add new connection"
+msgstr "Жаңы туташуу кошуу"
+
+#. Translators: network device speed
+#: ../panels/network/net-device-mobile.c:261
+#: ../panels/network/net-device-wifi.c:759
+#: ../panels/network/net-device-wired.c:126
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Мб/с"
+
+#. TRANSLATORS: this is when the access point is not shown
+#. * in the list and the user has to enter the SSID manually
+#.
+#: ../panels/network/net-device-wifi.c:192
+msgid "Connect to a Hidden Network"
+msgstr "Жашыруун тармакка туташуу"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/net-device-wifi.c:291
+#: ../panels/network/net-device-wifi.c:470
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/net-device-wifi.c:295
+#: ../panels/network/net-device-wifi.c:474
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/net-device-wifi.c:299
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/net-device-wifi.c:304
+msgid "Enterprise"
+msgstr "Ишкана"
+
+#: ../panels/network/net-device-wifi.c:309
+#: ../panels/network/net-device-wifi.c:465
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Жок"
+
+#: ../panels/network/net-device-wifi.c:686
+msgid "never"
+msgstr "эч качан"
+
+#: ../panels/network/net-device-wifi.c:696
+msgid "today"
+msgstr "бүгүн"
+
+#: ../panels/network/net-device-wifi.c:698
+msgid "yesterday"
+msgstr "кечээ"
+
+#: ../panels/network/net-device-wifi.c:700
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i күн мурун"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/net-device-wifi.c:769
+#: ../panels/network/panel-common.c:277
+msgid "Not connected"
+msgstr "Туташкан эмес"
+
+#: ../panels/network/net-device-wifi.c:771
+#: ../panels/network/net-device-wifi.c:2075
+msgid "Out of range"
+msgstr "Жетүү зонасынан тышкары"
+
+#: ../panels/network/net-device-wifi.c:802
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Жок"
+
+#: ../panels/network/net-device-wifi.c:804
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Аз"
+
+#: ../panels/network/net-device-wifi.c:806
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Орто"
+
+#: ../panels/network/net-device-wifi.c:808
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Жакшы"
+
+#: ../panels/network/net-device-wifi.c:810
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Эң жакшы"
+
+#: ../panels/network/net-device-wifi.c:994
+#, c-format
+msgid ""
+"Network details for %s including password and any custom configuration will "
+"be lost."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1005
+msgid "Forget"
+msgstr "Унутуу"
+
+#: ../panels/network/net-device-wifi.c:1541
+msgid ""
+"If you have a connection to the Internet other than wireless, you can use it "
+"to share your internet connection with others."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1545
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1549
+msgid ""
+"It is not possible to access the internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1615
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+
+#: ../panels/network/net-device-wifi.c:1618
+msgid "_Stop Hotspot"
+msgstr ""
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#: ../panels/network/net-proxy.c:367
+msgid "Proxy"
+msgstr "Прокси"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "Провайдер"
+
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:686 ../panels/network/panel-common.c:688
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP дарек"
+
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-wifi.ui.h:13
+#: ../panels/network/network-wired.ui.h:3 ../panels/network/panel-common.c:684
+msgid "IPv6 Address"
+msgstr "IPv6 дарек"
+
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-wifi.ui.h:14
+#: ../panels/network/network-wired.ui.h:4
+msgid "Default Route"
+msgstr "Алдына алынган маршрут"
+
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-wifi.ui.h:15
+#: ../panels/network/network-wired.ui.h:5
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-wired.ui.h:6
+msgid "_Options..."
+msgstr "_Параметрлер..."
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:5
+msgctxt "proxy method"
+msgid "None"
+msgstr "Жок"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:6
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "Өз алдынча"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:7
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "Автоматтык түрдө"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "_Ыкма"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "_Конфигурациялоочу URL"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "_HTTP проксиси"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS проксиси"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "_FTP проксиси"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "_Socks хосту"
+
+#: ../panels/network/network.ui.h:1
+msgid "Select the interface to use for the new service"
+msgstr ""
+
+#: ../panels/network/network.ui.h:2
+msgid "C_reate..."
+msgstr "_Түзүү..."
+
+#: ../panels/network/network.ui.h:3
+msgid "_Interface"
+msgstr "_Интерфейс"
+
+#: ../panels/network/network.ui.h:4 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/network.ui.h:8
+msgid "Add Device"
+msgstr "Түзүм кошуу"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN түрү"
+
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "Топтун аты"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "Топтун сырсөзү"
+
+#: ../panels/network/network-vpn.ui.h:6
+msgid "Username"
+msgstr "Наама"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "_Configure..."
+msgstr "_Конфигурация..."
+
+#: ../panels/network/network-wifi.ui.h:1
+msgid "Wireless Hotspot"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Turn On"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/network-wifi.ui.h:3 ../panels/network/panel-common.c:90
+msgid "Wireless"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:4
+msgid "_Use as Hotspot..."
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:5
+msgid "_Disconnect"
+msgstr "_Ажыратуу"
+
+#: ../panels/network/network-wifi.ui.h:6
+msgid "_Connect"
+msgstr "_Туташуу"
+
+#: ../panels/network/network-wifi.ui.h:7
+msgid "Last used"
+msgstr "Акыркы колдонулганы"
+
+#: ../panels/network/network-wifi.ui.h:8
+#: ../panels/network/network-wired.ui.h:1
+msgid "Hardware Address"
+msgstr "Аппараттык дарек"
+
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Security"
+msgstr "Коопсуздук"
+
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Strength"
+msgstr "Кубаттуулугу"
+
+#: ../panels/network/network-wifi.ui.h:11
+msgid "Link speed"
+msgstr "Байланыш ылдамдыгы"
+
+#: ../panels/network/network-wifi.ui.h:12
+#: ../panels/network/network-wired.ui.h:2 ../panels/network/panel-common.c:683
+msgid "IPv4 Address"
+msgstr "IPv4 дарек"
+
+#: ../panels/network/network-wifi.ui.h:16
+msgid "_Forget Network"
+msgstr "Тармакты _унутуу"
+
+#: ../panels/network/network-wifi.ui.h:17
+msgid "_Settings..."
+msgstr "_Параметрлер..."
+
+#: ../panels/network/network-wifi.ui.h:18
+msgid "Switch off to connect to a wireless network"
+msgstr ""
+
+#: ../panels/network/network-wifi.ui.h:19
+msgid "Network Name"
+msgstr "Тармактын аты"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "Connected Devices"
+msgstr "Туташкан түзүмдөр"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Security type"
+msgstr "Коопсуздук түрү"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Security key"
+msgstr "Коопсуздук ачкычы"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:86
+msgid "Wired"
+msgstr "Кабелдик"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:97
+#, fuzzy
+msgid "Mobile broadband"
+msgstr "Мобилдик жазы каналдуу"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:106
+msgid "Mesh"
+msgstr "Тармактык"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:166
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:170
+msgid "Infrastructure"
+msgstr "Инфраструктура"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:194 ../panels/network/panel-common.c:255
+msgid "Status unknown"
+msgstr "Абалы белгисиз"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:198
+msgid "Unmanaged"
+msgstr "Башкарууга мүмкүн эмес"
+
+#: ../panels/network/panel-common.c:203
+msgid "Firmware missing"
+msgstr "Фирмалык программасы жок"
+
+#: ../panels/network/panel-common.c:206
+msgid "Cable unplugged"
+msgstr "Кабель суурулган"
+
+#: ../panels/network/panel-common.c:208
+msgid "Unavailable"
+msgstr "Жеткиликтүү эмес"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:212
+msgid "Disconnected"
+msgstr "Ажыратылган"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
+msgid "Connecting"
+msgstr "Туташуу"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
+msgid "Authentication required"
+msgstr "Аутентификация талап кылынат"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227 ../panels/network/panel-common.c:269
+msgid "Connected"
+msgstr "Туташкан"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:231
+msgid "Disconnecting"
+msgstr "Ажыратуу"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:273
+msgid "Connection failed"
+msgstr "Туташуу ишке ашпады"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:239 ../panels/network/panel-common.c:281
+msgid "Status unknown (missing)"
+msgstr "Абалы белгисиз  (жок)"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:301
+msgid "Configuration failed"
+msgstr "Конфигурциялоо ишке ашпады"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:305
+msgid "IP configuration failed"
+msgstr "IP конфигурациялоо ишке ашпады"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:309
+msgid "IP configuration expired"
+msgstr "IP конфигурациясынын убакыты өтүп кеткен"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:313
+msgid "Secrets were required, but not provided"
+msgstr "Сырсөз талап кылынат, бирок берилген эмес"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:317
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x клиенти ажыратылган"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:321
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x клиентин конфигурациялоо ишке ашпады"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:325
+#, fuzzy
+msgid "802.1x supplicant failed"
+msgstr "802.1x клиентинин катасы"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:329
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x клиенти аутентификацядан өтө узак өтүүдө"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:333
+msgid "PPP service failed to start"
+msgstr "PPP кызматы ишин баштай албады"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:337
+msgid "PPP service disconnected"
+msgstr "PPP кызматы ажыратылган"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:341
+msgid "PPP failed"
+msgstr "PPP катасы"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:345
+msgid "DHCP client failed to start"
+msgstr "DHCP клиенти ишин баштай албады"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:349
+msgid "DHCP client error"
+msgstr "DHCP клиентинин катасы"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:353
+msgid "DHCP client failed"
+msgstr "DHCP клиент катасы"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:357
+msgid "Shared connection service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:361
+msgid "Shared connection service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:365
+msgid "AutoIP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:369
+msgid "AutoIP service error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:373
+msgid "AutoIP service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:377
+msgid "Line busy"
+msgstr "Канал бош эмес"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:381
+msgid "No dial tone"
+msgstr "Каналда сигнал жок"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:385
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:389
+msgid "Dialing request timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:393
+msgid "Dialing attempt failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:397
+msgid "Modem initialization failed"
+msgstr "Модемди инициализациялоо ишке ашпады"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:401
+msgid "Failed to select the specified APN"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:405
+msgid "Not searching for networks"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:409
+msgid "Network registration denied"
+msgstr "Тармак каттоодон баш тартты"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:413
+msgid "Network registration timed out"
+msgstr "Тармактын каттоо убакыты бүттү"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:417
+msgid "Failed to register with the requested network"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:421
+msgid "PIN check failed"
+msgstr "PIN текшерүү катасы"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:425
+msgid "Firmware for the device may be missing"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:429
+msgid "Connection disappeared"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:433
+msgid "Carrier/link changed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:437
+msgid "Existing connection was assumed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:441
+msgid "Modem not found"
+msgstr "Модем табылган жок"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:445
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth туташуу катасы"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:449
+msgid "SIM Card not inserted"
+msgstr "SIM картасы орнотулган эмес"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:453
+msgid "SIM Pin required"
+msgstr "SIM картанын Pin коду керек"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:457
+msgid "SIM Puk required"
+msgstr "SIM картанын Puk коду керек"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:461
+msgid "SIM wrong"
+msgstr "Туура эмес SIM карта"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:465
+msgid "InfiniBand device does not support connected mode"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:469
+msgid "Connection dependency failed"
+msgstr ""
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:249
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:371
+msgid "Error logging into the account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:425
+msgid "Expired credentials. Please log in again."
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:428
+msgid "_Log In"
+msgstr "_Кирүү"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:664
+msgid "Error creating account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:706
+msgid "Error removing account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:742
+msgid "Are you sure you want to remove the account?"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:744
+msgid "This will not remove the account on the server."
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:745
+msgid "_Remove"
+msgstr ""
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr ""
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Manage online accounts"
+msgstr ""
+
+#. Translators: those are keywords for the online-accounts control-center panel
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:157
+msgid "Unknown time"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:163
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i  мүнөт"
+
+#: ../panels/power/cc-power-panel.c:175
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i саат"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:183
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:184
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "саат"
+
+#: ../panels/power/cc-power-panel.c:185
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "мүнөт"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:228
+#, c-format
+msgid "Charging - %s until fully charged"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:236
+#, c-format
+msgid "Caution low battery, %s remaining"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:244
+#, c-format
+msgid "Using battery power - %s remaining"
+msgstr "Батарея колдонулууда - %s калды"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:261
+msgid "Charging"
+msgstr "Заряд алуу"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Using battery power"
+msgstr "Батареяны колдонуу"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:270
+msgid "Charging - fully charged"
+msgstr "Заряд алуу - толду"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:274
+msgid "Empty"
+msgstr "Бош"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:342
+#, c-format
+msgid "Caution low UPS, %s remaining"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:348
+#, c-format
+msgid "Using UPS power - %s remaining"
+msgstr ""
+
+#. TRANSLATORS: UPS battery
+#: ../panels/power/cc-power-panel.c:366
+msgid "Caution low UPS"
+msgstr ""
+
+#. TRANSLATORS: UPS battery
+#: ../panels/power/cc-power-panel.c:371
+msgid "Using UPS power"
+msgstr ""
+
+#. TRANSLATORS: secondary battery is normally in the media bay
+#: ../panels/power/cc-power-panel.c:423
+msgid "Your secondary battery is fully charged"
+msgstr ""
+
+#. TRANSLATORS: secondary battery is normally in the media bay
+#: ../panels/power/cc-power-panel.c:427
+msgid "Your secondary battery is empty"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:510
+msgid "Wireless mouse"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:514
+msgid "Wireless keyboard"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:518
+msgid "Uninterruptible power supply"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:522
+msgid "Personal digital assistant"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:526
+msgid "Cellphone"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:530
+msgid "Media player"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:534
+msgid "Tablet"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:538
+msgid "Computer"
+msgstr ""
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:542
+msgid "Battery"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:553
+msgctxt "Battery power"
+msgid "Charging"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:560
+msgctxt "Battery power"
+msgid "Caution"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:565
+msgctxt "Battery power"
+msgid "Low"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:570
+msgctxt "Battery power"
+msgid "Good"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:575
+msgctxt "Battery power"
+msgid "Charging - fully charged"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:579
+msgctxt "Battery power"
+msgid "Empty"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1075
+msgid ""
+"Tip: <a href=\"screen\">screen brightness</a> affects how much power is used"
+msgstr ""
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr ""
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Power management settings"
+msgstr ""
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+msgstr ""
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr ""
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr ""
+
+#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
+msgid "5 minutes"
+msgstr "5 мүнөт"
+
+#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:7
+msgid "10 minutes"
+msgstr "10 мүнөт"
+
+#: ../panels/power/power.ui.h:5 ../panels/screen/screen.ui.h:8
+msgid "30 minutes"
+msgstr "30 мүнөт"
+
+#: ../panels/power/power.ui.h:6 ../panels/screen/screen.ui.h:9
+msgid "1 hour"
+msgstr "1 саат"
+
+#: ../panels/power/power.ui.h:7
+msgid "Don't suspend"
+msgstr "Күтүү режимине өткөрбөө"
+
+#: ../panels/power/power.ui.h:8
+msgid "On battery power"
+msgstr "Батареядан иштеп жатканда"
+
+#: ../panels/power/power.ui.h:9
+msgid "When plugged in"
+msgstr "Ток булагына туташканда"
+
+#: ../panels/power/power.ui.h:10
+msgid "Suspend when inactive for"
+msgstr "Көрсөтүлгөн убакта жөн турса"
+
+#: ../panels/power/power.ui.h:11
+msgid "When power is _critically low"
+msgstr "Батареянын кубаттуулугу _критикалык азайганда"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:589
+msgid "Low on toner"
+msgstr "Тонер аз"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:591
+msgid "Out of toner"
+msgstr "Тонер жок"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:594
+msgid "Low on developer"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:597
+msgid "Out of developer"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:599
+msgid "Low on a marker supply"
+msgstr "Маркер жакында бүтөт"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:601
+msgid "Out of a marker supply"
+msgstr "Маркер бүттү"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:603
+msgid "Open cover"
+msgstr "Капкагы ачык"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:605
+msgid "Open door"
+msgstr "Эшиги ачык"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:607
+msgid "Low on paper"
+msgstr "Кагаз аз"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:609
+msgid "Out of paper"
+msgstr "Кагаз жок"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:611
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Өчүрүлгөн"
+
+#. Translators: Someone has paused the Printer
+#: ../panels/printers/cc-printers-panel.c:613
+msgctxt "printer state"
+msgid "Paused"
+msgstr "Паузада"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:615
+msgid "Waste receptacle almost full"
+msgstr "Резервуар толгонуна жакын калды"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:617
+msgid "Waste receptacle full"
+msgstr "Резервуар толду"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:619
+msgid "The optical photo conductor is near end of life"
+msgstr "Фоторезистор жакында иштен чыгат"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:621
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Фоторезистор иштен чыкты"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:724
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "Конфигурация"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:781
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Даяр"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:785
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Иштетүү"
+
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:789
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Токтотулган"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:906
+msgid "Toner Level"
+msgstr "Тонердин деңгээли"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:909
+msgid "Ink Level"
+msgstr "Боёктун деңгээли"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:912
+msgid "Supply Level"
+msgstr "Ресурстардын деңгээли"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:930
+msgctxt "printer state"
+msgid "Installing"
+msgstr "Орнотуу"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1107
+msgid "No printers available"
+msgstr "Принтерлер табылган жок"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1411
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u активдүү"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1731
+msgid "Failed to add new printer."
+msgstr "Жаңы принтер кошуулбады"
+
+#: ../panels/printers/cc-printers-panel.c:1896
+msgid "Select PPD File"
+msgstr "PPD файлын танда"
+
+#: ../panels/printers/cc-printers-panel.c:1905
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript Printer Description файлдары (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2210
+msgid "No suitable driver found"
+msgstr "Жарактуу драйвер табылган жок"
+
+#: ../panels/printers/cc-printers-panel.c:2279
+msgid "Searching for preferred drivers..."
+msgstr "Жарактуу драйверлер изделип жатат..."
+
+#: ../panels/printers/cc-printers-panel.c:2294
+msgid "Select from database..."
+msgstr "Маалымат базасынан тандоо..."
+
+#: ../panels/printers/cc-printers-panel.c:2303
+msgid "Provide PPD File..."
+msgstr "PPD файлын колдонуу..."
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2454
+#: ../panels/printers/cc-printers-panel.c:2477
+msgid "Test page"
+msgstr "Текшерүү барагы"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2880
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Колдонуучу интерфейси жүктөлбөдү: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "Принтерлер"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Change printer settings"
+msgstr "Принтер параметрлерин өзгөртүү"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Принтер;Кезек;Басуу;Кагаз;Боёк;Тонер;"
+
+#: ../panels/printers/jobs-dialog.ui.h:1
+#: ../panels/printers/options-dialog.ui.h:1
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/printers/jobs-dialog.ui.h:2
+#: ../panels/printers/options-dialog.ui.h:4
+msgid "Close"
+msgstr "Жабуу"
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Active Jobs"
+msgstr "Активдүү тапшырмалар"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Resume Printing"
+msgstr "Басууну улантуу"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Pause Printing"
+msgstr "Басууну убактылуу токтотуу"
+
+#: ../panels/printers/jobs-dialog.ui.h:7
+msgid "Cancel Print Job"
+msgstr "Басуу тапшырмасын алып таштоо"
+
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1044
+msgid "_Add"
+msgstr "_Кошуу"
+
+#: ../panels/printers/new-printer-dialog.ui.h:3
+msgid "Add a New Printer"
+msgstr "Жаңы принтер кошуу"
+
+#: ../panels/printers/new-printer-dialog.ui.h:4
+msgid "Search for network printers or filter result"
+msgstr "Тармактагы принтерлерди издөө же жыйынтыгын чыпкалоо"
+
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Options"
+msgstr "Параметрлер"
+
+#: ../panels/printers/options-dialog.ui.h:3
+msgid "Loading options..."
+msgstr "Параметрлер жүктөлүүдө..."
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+#: ../panels/user-accounts/um-account-dialog.c:1043
+msgid "Cancel"
+msgstr "Айынуу"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "Драйверлер маалымат базасынан жүктөлүүдө..."
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:5
+msgid "Select Printer Driver"
+msgstr "Принтер драйверин тандоо"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:65
+#: ../panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Бир тараптуу"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:67
+#: ../panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Узун жагы менен (Стандарт)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:69
+#, fuzzy
+#: ../panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Кыска жагы менен (терс жагын ачуу)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:71
+msgid "Portrait"
+msgstr "Портрет"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:73
+msgid "Landscape"
+msgstr "Ландшафт"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:75
+msgid "Reverse landscape"
+msgstr "Алмаштырылган ландшафт"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:77
+msgid "Reverse portrait"
+msgstr "Алмаштырылган портрет"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:143
+msgctxt "print job"
+msgid "Pending"
+msgstr "Күтүү"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:147
+msgctxt "print job"
+msgid "Held"
+msgstr ""
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:151
+msgctxt "print job"
+msgid "Processing"
+msgstr "Аткарылууда"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:155
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Токтотулган"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:159
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Баш тартылган"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:163
+msgctxt "print job"
+msgid "Aborted"
+msgstr ""
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:167
+msgctxt "print job"
+msgid "Completed"
+msgstr "Аяктаган"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:289
+msgid "Job Title"
+msgstr "Тапшырма"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:298
+msgid "Job State"
+msgstr "Абалы"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:304
+msgid "Time"
+msgstr "Убакыт"
+
+#: ../panels/printers/pp-jobs-dialog.c:484
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s активдүү тапшырма"
+
+#. Translators: No printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1291
+msgid "No printers detected."
+msgstr "Принтерлер табылган жок"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Two Sided"
+msgstr "Эки тараптуу"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Type"
+msgstr "Кагаз түрү"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Paper Source"
+msgstr "Кагаз булагы"
+
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Output Tray"
+msgstr "Чыгуу орду"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "Resolution"
+msgstr "Ажырымдуулугу"
+
+#: ../panels/printers/pp-options-dialog.c:87
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript менен алыдна ала чыпкалоо"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:533
+msgid "Pages per side"
+msgstr "Беттеги барактардын саны"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:545
+msgid "Two-sided"
+msgstr "Эки тараптуу"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:557
+msgid "Orientation"
+msgstr "Багыты"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Жалпы"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Барак параметрлери"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Орнотулуучу параметрлер"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Тапшырма"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Сүрөттүн сапаттуулугу"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Түс"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Аяктоо"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:675
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Кошумча"
+
+#. Translators: Options of given printer (e.g. "MyPrinter Options")
+#: ../panels/printers/pp-options-dialog.c:936
+#, c-format
+msgid "%s Options"
+msgstr "%s параметрлери"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:75
+#: ../panels/printers/pp-ppd-option-widget.c:77
+#: ../panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Автоматтык түрдө тандоо"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:79
+#: ../panels/printers/pp-ppd-option-widget.c:81
+#: ../panels/printers/pp-ppd-option-widget.c:83
+#: ../panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Абалкы принтерлер"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "GhostScript ариптерин гана колдонуу (embed)"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "PS level 1 ге өткөрүү"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "PS level 2 ге өткөрүү"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Алдына ала чыпкалабоо"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:230
+msgid "Manufacturers"
+msgstr "Өндүрүүчүлөр"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:242
+msgid "Drivers"
+msgstr "Драйверлер"
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "Принтер кошуу"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "Принтерди алып таштоо"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "Ресурс"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "Жайгашкан жери"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default"
+msgstr "_Абалкы"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "Тапшырмалар"
+
+#. Tanslators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "_Show"
+msgstr "_Көрсөтүү"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "Модели"
+
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "1-барак"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "белги"
+
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "2-барак"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver..."
+msgstr "Жаңы драйвер орнотуу..."
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "3-барак"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "_Текшерүү барагын басуу"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "_Параметрлер"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "Жаңы принтер кошуу"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"Кечириңиз! Системалык басуу кызматы (CUPS)\n"
+"иштебеген сыяктуу."
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "Регион жана тил"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid "Change your region and language settings"
+msgstr "Сиздин регион жана тил параметрлери"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;"
+msgstr "Тил;Такта;Алиптакта;"
+
+#: ../panels/region/gnome-region-panel-formats.c:142
+msgid "Imperial"
+msgstr "Империялык"
+
+#: ../panels/region/gnome-region-panel-formats.c:144
+msgid "Metric"
+msgstr "Метрикалык"
+
+#: ../panels/region/gnome-region-panel-input-chooser.ui.h:1
+msgid "Choose an input source"
+msgstr "Киргизүү булагын тандаңыз"
+
+#: ../panels/region/gnome-region-panel-input-chooser.ui.h:2
+msgid "Select an input source to add"
+msgstr "Кошуу үчүн киргизүү булагын тандаңыз"
+
+#: ../panels/region/gnome-region-panel-system.c:470
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings."
+msgstr ""
+"Кирүү терезеси, системалык наамалар жана жаңы наамалар системанын "
+"регион жана тил параметрлерин колдонот."
+
+#: ../panels/region/gnome-region-panel-system.c:475
+#: ../panels/region/gnome-region-panel.ui.h:31
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings. You may change the system settings to match "
+"yours."
+msgstr ""
+"Кирүү терезеси, системалык наамалар жана жаңы наамалар системанын "
+"регион жана тил параметрлерин колдонот. Сиз системалык параметрлерди "
+"өзүңүзгө ылайыктап алсаңыз болот."
+
+#: ../panels/region/gnome-region-panel-system.c:478
+msgid "Copy Settings"
+msgstr "Параметрлерди көчүрүү"
+
+#: ../panels/region/gnome-region-panel-system.c:481
+#: ../panels/region/gnome-region-panel.ui.h:38
+msgid "Copy Settings..."
+msgstr "Параметрлерди көчүрүү..."
+
+#: ../panels/region/gnome-region-panel.ui.h:1
+msgid "Region and Language"
+msgstr "Регион жана тил"
+
+#: ../panels/region/gnome-region-panel.ui.h:2
+msgid "Select a display language (change will be applied next time you log in)"
+msgstr "Тил тандаңыз (системага кийинки жолу киргенде колдонула баштайт)"
+
+#: ../panels/region/gnome-region-panel.ui.h:3
+msgid "Add Language"
+msgstr "Тил кошуу"
+
+#: ../panels/region/gnome-region-panel.ui.h:4
+msgid "Remove Language"
+msgstr "Тилди алып таштоо"
+
+#: ../panels/region/gnome-region-panel.ui.h:5
+msgid "Install languages..."
+msgstr "Тилдер орнотулууда..."
+
+#: ../panels/region/gnome-region-panel.ui.h:6
+msgid "Language"
+msgstr "Тил"
+
+#: ../panels/region/gnome-region-panel.ui.h:7
+msgid "Select a region (change will be applied the next time you log in)"
+msgstr "Регион тандаңыз (системага кийинки жолу киргенде колдонула баштайт)"
+
+#: ../panels/region/gnome-region-panel.ui.h:8
+msgid "Add Region"
+msgstr "Регион кошуу"
+
+#: ../panels/region/gnome-region-panel.ui.h:9
+msgid "Remove Region"
+msgstr "Регионду алып таштоо"
+
+#: ../panels/region/gnome-region-panel.ui.h:10
+msgid "Dates"
+msgstr "Дата"
+
+#: ../panels/region/gnome-region-panel.ui.h:11
+msgid "Times"
+msgstr "Убакыт"
+
+#: ../panels/region/gnome-region-panel.ui.h:12
+msgid "Numbers"
+msgstr "Сан"
+
+#: ../panels/region/gnome-region-panel.ui.h:13
+msgid "Currency"
+msgstr "Акча"
+
+#: ../panels/region/gnome-region-panel.ui.h:14
+msgid "Measurement"
+msgstr "Чен бирдиктери"
+
+#: ../panels/region/gnome-region-panel.ui.h:15
+msgid "Examples"
+msgstr "Мисалдар"
+
+#: ../panels/region/gnome-region-panel.ui.h:16
+msgid "Formats"
+msgstr "Форматтар"
+
+#: ../panels/region/gnome-region-panel.ui.h:17
+msgid "Select keyboards or other input sources"
+msgstr "Алиптактаны жана башка киргизүү түзүмдөрүн тандаңыз"
+
+#: ../panels/region/gnome-region-panel.ui.h:18
+msgid "Add Input Source"
+msgstr "Киргизүү булагын кошуу"
+
+#: ../panels/region/gnome-region-panel.ui.h:19
+msgid "Remove Input Source"
+msgstr "Киргизүү булагын алып таштоо"
+
+#: ../panels/region/gnome-region-panel.ui.h:20
+msgid "Move Input Source Up"
+msgstr "Киргизүү булагын жогору жылдыруу"
+
+#: ../panels/region/gnome-region-panel.ui.h:21
+msgid "Move Input Source Down"
+msgstr "Киргизүү булагын төмөн жылдыруу"
+
+#: ../panels/region/gnome-region-panel.ui.h:22
+msgid "Input Source Settings"
+msgstr "Киргизүү булактарынын параметрлери"
+
+#: ../panels/region/gnome-region-panel.ui.h:23
+msgid "Show Keyboard Layout"
+msgstr "Алиптактанын жайгашуусун көрсөтүү"
+
+#: ../panels/region/gnome-region-panel.ui.h:25
+msgid "Ctrl+Alt+Space"
+msgstr "Ctrl+Alt+Space"
+
+#: ../panels/region/gnome-region-panel.ui.h:27
+msgid "Ctrl+Alt+Shift+Space"
+msgstr "Ctrl+Alt+Shift+Аралык"
+
+#: ../panels/region/gnome-region-panel.ui.h:28
+msgid "Shortcut Settings"
+msgstr "Композициялардын параметри"
+
+#: ../panels/region/gnome-region-panel.ui.h:30
+msgid "Input Sources"
+msgstr "Киргизүү булактары"
+
+#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
+#: ../panels/region/gnome-region-panel.ui.h:33
+msgid "Display language:"
+msgstr "Колдонулуучу тил:"
+
+#: ../panels/region/gnome-region-panel.ui.h:34
+msgid "Input source:"
+msgstr "Киргизүү булагы:"
+
+#: ../panels/region/gnome-region-panel.ui.h:35
+msgid "Format:"
+msgstr "Формат:"
+
+#: ../panels/region/gnome-region-panel.ui.h:36
+msgid "Your settings"
+msgstr "Сиздин параметрлер"
+
+#: ../panels/region/gnome-region-panel.ui.h:37
+msgid "System settings"
+msgstr "Системанын параметрлери"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:1
+msgid "Brightness & Lock"
+msgstr "Ачыктык жана бекитүү"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
+msgid "Screen brightness and lock settings"
+msgstr "Экрандын ачыктыгы жана экранды бекитүүнүн  параметрлери"
+
+#. Translators: those are keywords for the brightness and lock control-center panel
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
+#, fuzzy
+msgid "Brightness;Lock;Dim;Blank;Monitor;"
+msgstr "Ачыктык;Бекитүү;Dim;Blank;Монитор;"
+
+#: ../panels/screen/screen.ui.h:1
+msgid "Screen turns off"
+msgstr "Экран өчүрүлөт"
+
+#: ../panels/screen/screen.ui.h:2
+msgid "30 seconds"
+msgstr "30 секундда"
+
+#: ../panels/screen/screen.ui.h:3
+msgid "1 minute"
+msgstr "1 мүнөттө"
+
+#: ../panels/screen/screen.ui.h:4
+msgid "2 minutes"
+msgstr "2 мүнөттө"
+
+#: ../panels/screen/screen.ui.h:5
+msgid "3 minutes"
+msgstr "3 мүнөттө"
+
+#: ../panels/screen/screen.ui.h:10
+msgid "_Dim screen to save power"
+msgstr "Энергияны үнөмдөө үчүн экрандын ачыктыгын азайтуу"
+
+#: ../panels/screen/screen.ui.h:11
+msgid "Brightness"
+msgstr "Ачыктык"
+
+#: ../panels/screen/screen.ui.h:12
+msgid "_Turn screen off when inactive for:"
+msgstr "Убакыт аралыгында иш жүрбөсө, экранды  _өчүрүү:"
+
+#: ../panels/screen/screen.ui.h:13
+msgid "_Lock screen after:"
+msgstr "Убакыт өткөндө _бекит:"
+
+#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
+#: ../panels/screen/screen.ui.h:15
+msgid "Don't lock when at home"
+msgstr "Үйдө болгондо бекитпөө"
+
+#: ../panels/screen/screen.ui.h:16
+msgid "Locations..."
+msgstr "Жайгашкан жерлер..."
+
+#: ../panels/screen/screen.ui.h:17
+msgid "Show _notifications when locked"
+msgstr "Экран бекитилгенде да, билдирүүлөрдү көрсөтүү"
+
+#: ../panels/screen/screen.ui.h:18
+msgid "Lock"
+msgstr "Бекитүү"
+
+#: ../panels/sound/applet-main.c:49
+msgid "Enable debugging code"
+msgstr "Ката издөөнү иштетүү"
+
+#: ../panels/sound/applet-main.c:50
+msgid "Version of this application"
+msgstr "Бул иштеменени версиясы"
+
+#: ../panels/sound/applet-main.c:62
+msgid " — GNOME Volume Control Applet"
+msgstr " — GNOME үн бийиктигин башкаруу апплети"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
+msgid "Volume Control"
+msgstr "Үн бийиктигин башкаруу"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
+msgid "Show desktop volume control"
+msgstr "Үн бийиктигин башкарууну ачуу"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "Үн"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound volume and sound events"
+msgstr "Үн бийиктигин жана кабарлардын үнүн өзгөртүү"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr ""
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "Ит"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "Тамчы"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "Айнек"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "Сонар"
+
+#: ../panels/sound/gvc-applet.c:270 ../panels/sound/gvc-mixer-dialog.c:1656
+msgid "Output"
+msgstr "Чыгуу"
+
+#: ../panels/sound/gvc-applet.c:272
+msgid "Sound Output Volume"
+msgstr "Чыгуудагы үн бийиктиги"
+
+#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1697
+msgid "Input"
+msgstr "Кирүү"
+
+#: ../panels/sound/gvc-applet.c:278
+msgid "Microphone Volume"
+msgstr "Микрофондун бийиктиги"
+
+#: ../panels/sound/gvc-balance-bar.c:111
+msgctxt "balance"
+msgid "Left"
+msgstr "Сол"
+
+#: ../panels/sound/gvc-balance-bar.c:112
+msgctxt "balance"
+msgid "Right"
+msgstr "Оң"
+
+#: ../panels/sound/gvc-balance-bar.c:115
+msgctxt "balance"
+msgid "Rear"
+msgstr "Арткы"
+
+#: ../panels/sound/gvc-balance-bar.c:116
+msgctxt "balance"
+msgid "Front"
+msgstr "Алдынкы"
+
+#: ../panels/sound/gvc-balance-bar.c:119
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Минимум"
+
+#: ../panels/sound/gvc-balance-bar.c:120
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Максимум"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Balance:"
+msgstr "_Баланс:"
+
+#: ../panels/sound/gvc-balance-bar.c:298
+msgid "_Fade:"
+msgstr ""
+
+#: ../panels/sound/gvc-balance-bar.c:301
+msgid "_Subwoofer:"
+msgstr "_Сабвуфер:"
+
+#: ../panels/sound/gvc-channel-bar.c:613 ../panels/sound/gvc-channel-bar.c:622
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:617
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Күчтөтүүсүз"
+
+#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:521
+msgid "_Profile:"
+msgstr "_Профайл:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1841
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u чыгуу"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1851
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u кирүү"
+
+#: ../panels/sound/gvc-mixer-control.c:2375
+msgid "System Sounds"
+msgstr "Системалык үндөр"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "Динамикти _текшерүү"
+
+#: ../panels/sound/gvc-mixer-dialog.c:426
+msgid "Peak detect"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1506
+#: ../panels/sound/gvc-sound-theme-chooser.c:595
+msgid "Name"
+msgstr "Аты"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1588
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1642
+msgid "_Output volume:"
+msgstr "Үндүн _бийиктиги:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1661
+msgid "C_hoose a device for sound output:"
+msgstr "Үн үчүн чыгуу түзүмүн тандоо:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1686
+msgid "Settings for the selected device:"
+msgstr "Тандалган түзүмдүн параметрлери:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "_Input volume:"
+msgstr "Жазуу _бийиктиги:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1727
+msgid "Input level:"
+msgstr "Жазуу деңгээли:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1755
+msgid "C_hoose a device for sound input:"
+msgstr "Үн кирүүчү түзүмдү танда:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1782
+msgid "Sound Effects"
+msgstr "Үн эффектери"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "_Alert volume:"
+msgstr "Билдирүүлөрдүн үн бийиктиги:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1802
+msgid "Applications"
+msgstr "Иштемелер"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1806
+msgid "No application is currently playing or recording audio."
+msgstr "Учуруда үндү ойноткон же жазган иштеме жок."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:189
+msgid "Built-in"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:455
+#: ../panels/sound/gvc-sound-theme-chooser.c:467
+#: ../panels/sound/gvc-sound-theme-chooser.c:479
+msgid "Sound Preferences"
+msgstr "Үн параметрлери"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:458
+#: ../panels/sound/gvc-sound-theme-chooser.c:469
+#: ../panels/sound/gvc-sound-theme-chooser.c:481
+msgid "Testing event sound"
+msgstr ""
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "Default"
+msgstr "Абалкы"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:586
+msgid "From theme"
+msgstr "Бул темадан"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:770
+msgid "C_hoose an alert sound:"
+msgstr "_Билдирүү үчүн үн танда:"
+
+#: ../panels/sound/gvc-speaker-test.c:220
+msgid "Stop"
+msgstr "Токтотуу"
+
+#: ../panels/sound/gvc-speaker-test.c:220
+#: ../panels/sound/gvc-speaker-test.c:332
+msgid "Test"
+msgstr "Текшерүү"
+
+#: ../panels/sound/gvc-speaker-test.c:228
+msgid "Subwoofer"
+msgstr "Сабвуфер"
+
+#: ../panels/sound/gvc-stream-status-icon.c:236
+#, c-format
+msgid "Failed to start Sound Preferences: %s"
+msgstr "Үн параметрлерин иштетүүгө болбоду: %s"
+
+#: ../panels/sound/gvc-stream-status-icon.c:262
+msgid "_Mute"
+msgstr "_Өчүрүү"
+
+#: ../panels/sound/gvc-stream-status-icon.c:271
+msgid "_Sound Preferences"
+msgstr "_Үн параметрлери"
+
+#: ../panels/sound/gvc-stream-status-icon.c:416
+msgid "Muted"
+msgstr "Өчүрүлгөн"
+
+#: ../panels/sound/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr "Башка"
+
+#: ../panels/universal-access/cc-ua-panel.c:286
+#: ../panels/universal-access/cc-ua-panel.c:292
+msgid "No shortcut set"
+msgstr "Комбинация орнотулган эмес"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Universal Access Preferences"
+msgstr "Универсалдык жетүү параметрлери"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
+"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:1
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Төмөн"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgctxt "universal access, contrast"
+msgid "Normal"
+msgstr "Кадимкидей"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Жогору"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgctxt "universal access, contrast"
+msgid "High/Inverse"
+msgstr "Жогору/Инверсия"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "On screen keyboard"
+msgstr "Экран алиптактасы"
+
+#: ../panels/universal-access/uap.ui.h:6
+msgid "GOK"
+msgstr "GOK"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "OnBoard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "None"
+msgstr "Жок"
+
+#: ../panels/universal-access/uap.ui.h:10
+#, no-c-format
+msgid "75%"
+msgstr "75%"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgctxt "universal access, text size"
+msgid "Small"
+msgstr "Кичирейтилген"
+
+#: ../panels/universal-access/uap.ui.h:13
+#, no-c-format
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgctxt "universal access, text size"
+msgid "Normal"
+msgstr "Кадимки"
+
+#: ../panels/universal-access/uap.ui.h:16
+#, no-c-format
+msgid "125%"
+msgstr "125%"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgctxt "universal access, text size"
+msgid "Large"
+msgstr "Чоңойтулган"
+
+#: ../panels/universal-access/uap.ui.h:19
+#, no-c-format
+msgid "150%"
+msgstr "150%"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgctxt "universal access, text size"
+msgid "Larger"
+msgstr "Чоң"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "High Contrast"
+msgstr "Бийик контраст"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Beep on Caps and Num Lock"
+msgstr "Caps жана Num Lock басылганда үн чыгаруу"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "Options..."
+msgstr "Параметрлер..."
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Screen Reader"
+msgstr "Экрандан окуу"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Turn on or off:"
+msgstr "Жандыруу же өчүрүү:"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgctxt "universal access, zoom"
+msgid "Zoom"
+msgstr "Чоңойтуу"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Zoom in:"
+msgstr "Жакындатуу:"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Zoom out:"
+msgstr "Алыстатуу:"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Large Text"
+msgstr "Чоң текст"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "Seeing"
+msgstr "Көрүү"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Visual Alerts"
+msgstr "Визуалдык билдирүүлөр"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Use a visual indication when an alert sound occurs"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Flash the window title"
+msgstr "Терезенин башынын күйүп-өчүүсү"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Flash the entire screen"
+msgstr "Экрандын күйүп-өчүүсү"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgid "Closed Captioning"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Display a textual description of speech and sounds"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:37
+msgid "_Test flash"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Hearing"
+msgstr "Угуу"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "On Screen Keyboard"
+msgstr "Экран алиптактасы"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "Sticky Keys"
+msgstr "Илешме тергичтер"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:43
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Beep when a _modifer key is pressed"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "Slow Keys"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Slow keys typing delay"
+msgstr ""
+
+#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
+#: ../panels/universal-access/uap.ui.h:54
+msgid "Beep when a key is"
+msgstr ""
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:56
+msgid "pressed"
+msgstr ""
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:58
+msgid "accepted"
+msgstr ""
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:60
+msgid "rejected"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:61
+msgid "Bounce Keys"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Acc_eptance delay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:66
+msgid "Enable by Keyboard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:67
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+# чычканды ушинтип атасакчы? ;)
+#: ../panels/universal-access/uap.ui.h:69
+#, fuzzy
+msgid "Mouse Keys"
+msgstr "Чертмек баскычтары"
+
+#: ../panels/universal-access/uap.ui.h:70
+msgid "Control the pointer using the keypad"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Video Mouse"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "Control the pointer using the video camera."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:73
+msgid "Simulated Secondary Click"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:74
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:75
+msgid "Secondary click delay"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:76
+msgid "Hover Click"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:77
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:78
+msgid "D_elay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:79
+msgid "Motion _threshold:"
+msgstr ""
+
+#. small threshold
+#: ../panels/universal-access/uap.ui.h:81
+msgid "Small"
+msgstr ""
+
+#. large threshold
+#: ../panels/universal-access/uap.ui.h:83
+msgid "Large"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:84
+msgid "Mouse Settings"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:85
+msgid "Pointing and Clicking"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:357
+msgctxt "Distance"
+msgid "Short"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:358
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:359
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:360
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:361
+msgctxt "Distance"
+msgid "Long"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr ""
+
+#. short delay
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgid "Thin"
+msgstr ""
+
+#. long delay
+#: ../panels/universal-access/zoom-options.ui.h:21
+msgid "Thick"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Length:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Color:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Crosshairs:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Overlaps mouse cursor"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "Crosshairs"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "White on black:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Brightness:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:29
+msgid "Contrast:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "Zoom Grayscale"
+msgid "Color"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "Zoom Grayscale"
+msgid "None"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "Zoom Grayscale"
+msgid "Full"
+msgstr ""
+
+#. short delay
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgid "Low"
+msgstr ""
+
+#. long delay
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgid "High"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:35
+msgctxt "Account type"
+msgid "Standard"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:37
+msgctxt "Account type"
+msgid "Administrator"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "Add account"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Local Account"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "_Enterprise Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "_Username"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+msgid "_Full name"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Account _Type"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+msgid "_Domain"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Login Name"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "_Password"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "Tip: Enterprise domain or realm name"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid "C_ontinue"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:14
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:18
+msgid "Administrator _Name"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "Administrator Password"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:706
+msgid "Enable Fingerprint Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "User Accounts"
+msgstr ""
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users"
+msgstr ""
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Set a password now"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+msgid "Choose password at next login"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Log in without a password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "Disable this account"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Enable this account"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "_Hint"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid ""
+"This hint may be displayed at the login screen.  It will be visible to all "
+"users of this system.  Do <b>not</b> include the password here."
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "C_onfirm password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+msgid "_New password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+msgid "Generate a password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+msgid "Fair"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+msgid "Current _password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid "_Action"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+msgid "Changing password for"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:15
+msgid "_Show password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:16
+msgid "How to choose a strong password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:17
+msgid "Ch_ange"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+msgid "Changing photo for:"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+msgid ""
+"Choose a picture that will be shown at the login screen for this account."
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+msgid "Gallery"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "Browse for more pictures"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+msgid "Take a photograph"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+msgid "Browse"
+msgstr ""
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Account Information"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Add User Account"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Remove User Account"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "Login Options"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "A_utomatic Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "User Icon"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "_Language"
+msgstr ""
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr ""
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:94
+#: ../panels/user-accounts/um-password-dialog.c:569
+msgctxt "Password strength"
+msgid "Too short"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password strength"
+msgid "Not good enough"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:108
+#: ../panels/user-accounts/um-password-dialog.c:570
+msgctxt "Password strength"
+msgid "Weak"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:111
+#: ../panels/user-accounts/um-password-dialog.c:571
+msgctxt "Password strength"
+msgid "Fair"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:114
+#: ../panels/user-accounts/um-password-dialog.c:572
+msgctxt "Password strength"
+msgid "Good"
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:117
+#: ../panels/user-accounts/um-password-dialog.c:573
+msgctxt "Password strength"
+msgid "Strong"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:424
+msgid "Authentication failed"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:504
+#: ../panels/user-accounts/um-password-dialog.c:239
+#, c-format
+msgid "The new password is too short"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password is too simple"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:516
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:519
+#, c-format
+msgid "The new password has already been used recently."
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:526
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:530
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:534
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:538
+#, c-format
+msgid "Unknown error"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:180
+msgid "Failed to add account"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:378
+#: ../panels/user-accounts/um-account-dialog.c:419
+msgid "Failed to register account"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:551
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:605
+msgid "Failed to join domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-account-dialog.c:662
+msgid "Failed to log into domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:219
+#: ../panels/user-accounts/um-fingerprint-dialog.c:220
+msgid "Enabled"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:268
+msgid "Delete registered fingerprints?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:272
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:279
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:455
+msgid "Done!"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:516
+#: ../panels/user-accounts/um-fingerprint-dialog.c:558
+#, c-format
+msgid "Could not access '%s' device"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:603
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:655
+msgid "Could not access any fingerprint readers"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:656
+msgid "Please contact your system administrator for help."
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:747
+msgid "Selecting finger"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:748
+msgid "Enrolling fingerprints"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:749
+msgid "Summary"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:96
+msgid "_Generate a password"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:150
+msgid "Please choose another password."
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:159
+msgid "Please type your current password again."
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:165
+msgid "Password could not be changed"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:236
+msgid "You need to enter a new password"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:245
+msgid "You need to confirm the password"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:248
+msgid "The passwords do not match"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:254
+msgid "You need to enter your current password"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:257
+msgid "The current password is not correct"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:347
+msgid "Passwords do not match"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:409
+msgid "Wrong password"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:443
+msgid "Disable image"
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:461
+msgid "Take a photo..."
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:479
+msgid "Browse for more pictures..."
+msgstr ""
+
+#: ../panels/user-accounts/um-photo-dialog.c:704
+#, c-format
+msgid "Used by %s"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:379
+#, c-format
+msgid "No such domain or realm found"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:780
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:785
+msgid "Invalid password, please try again"
+msgstr ""
+
+#: ../panels/user-accounts/um-realm-manager.c:789
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-manager.c:466
+#, c-format
+msgid "A user with name '%s' already exists."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-manager.c:473
+#, c-format
+msgid "No user with the name '%s' exists."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-manager.c:631
+msgid "This user does not exist."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:371
+msgid "Failed to delete user"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:431
+msgid "You cannot delete your own account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:440
+#, c-format
+msgid "%s is still logged in"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:444
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:453
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:457
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:460
+msgid "_Delete Files"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:461
+msgid "_Keep Files"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:513
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:521
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:524
+msgctxt "Password mode"
+msgid "None"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:871
+msgid "Failed to contact the accounts service"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:873
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:913
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:951
+msgid "Create a user account"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:962
+#: ../panels/user-accounts/um-user-panel.c:1273
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:971
+msgid "Delete the selected user account"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:983
+#: ../panels/user-accounts/um-user-panel.c:1278
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1176
+msgid "My Account"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1186
+msgid "Other Accounts"
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:512
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:516
+#, c-format
+msgid "The username is too long"
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:519
+msgid "The username cannot start with a '-'"
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:522
+msgid ""
+"The username must only consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr ""
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr ""
+
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr ""
+
+#. Text printed on screen
+#: ../panels/wacom/calibrator/gui_gtk.c:78
+msgid "Screen Calibration"
+msgstr ""
+
+#: ../panels/wacom/calibrator/gui_gtk.c:79
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: ../panels/wacom/calibrator/gui_gtk.c:368
+msgid "Mis-click detected, restarting..."
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Output:"
+msgstr ""
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:287
+msgid "Keep aspect ratio (letterbox):"
+msgstr ""
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:298
+msgid "Map to single monitor"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-nav-button.c:89
+#, c-format
+msgid "%d of %d"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:118 ../panels/wacom/cc-wacom-page.c:371
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:119
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:120
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:601
+msgid "Up"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:601
+msgid "Down"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:638
+msgid "Switch Modes"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:724
+#: ../panels/wacom/cc-wacom-stylus-page.c:376
+msgid "Button"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:777
+msgid "Action"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:886
+msgid "Display Mapping"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set your Wacom tablet preferences"
+msgstr ""
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Map to Monitor..."
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map Buttons..."
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate..."
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Tracking Mode"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Left-Handed Orientation"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1010
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1019
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1049
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1058
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1075
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1077
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1080
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1082
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1087
+#, c-format
+msgid "Mode Switch #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1159
+#, c-format
+msgid "Left Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1162
+#, c-format
+msgid "Right Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1165
+#, c-format
+msgid "Top Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1168
+#, c-format
+msgid "Bottom Button #%d"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: ../shell/control-center.c:58
+msgid "Enable verbose mode"
+msgstr ""
+
+#: ../shell/control-center.c:59
+msgid "Show the overview"
+msgstr ""
+
+#: ../shell/control-center.c:60 ../shell/control-center.c:61
+#: ../shell/control-center.c:62
+msgid "Show help options"
+msgstr ""
+
+#: ../shell/control-center.c:63
+msgid "Panel to display"
+msgstr ""
+
+#: ../shell/control-center.c:85
+msgid "- System Settings"
+msgstr "- Системалык параметрлер"
+
+#: ../shell/control-center.c:93
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"Бардык параметрлердин толук тизмесин көрүү үчүн '%s --help' аткарыңыз.\n"
+
+#: ../shell/control-center.c:211
+msgid "Help"
+msgstr "Жардам"
+
+#: ../shell/control-center.c:212
+msgid "Quit"
+msgstr "Чыгуу"
+
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Башкаруу борбору"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
+msgid "System Settings"
+msgstr "Системалык параметрлер"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr ""
+
+#: ../shell/shell.ui.h:2
+msgid "All Settings"
+msgstr "Бардык параметрлер"
+
+

--- a/po/lt.po
+++ b/po/lt.po
@@ -14,9 +14,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-05 18:05+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-05 22:41+0300\n"
 "Last-Translator: Aurimas Černius <aurisc4@gmail.com>\n"
 "Language-Team: Lietuvių <gnome-lt@lists.akl.lt>\n"
@@ -30,100 +29,7 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Sisteminė magistralė"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Pilna prieiga"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Seanso magistralė"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Įrenginiai"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Pilna prieiga prie /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Tinklas"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Turi tinklo prieigą"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Namų aplankas"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Tik skaitymui"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Failų sistema"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Nustatymai"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Gali keisti nustatymus"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s turi šiuo integruotus leidimus. Jų negalima keisti. Jei turite abejonių "
-"dėl šių leidimų, pagalvokite apie programos pašalinimą."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u failų ir saitų tipas, kuris atveriamas programos"
-msgstr[1] "%u failų ir saitų tipai, kurie atveriamas programos"
-msgstr[2] "%u failų ir saitų tipų, kurie atveriamas programos"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> yra naudojama atverti šio tipo failus bei saitus."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "Naudojama %s disko vietos."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -139,7 +45,6 @@ msgid "Install some…"
 msgstr "Įdiegti…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Atverti"
 
@@ -163,24 +68,13 @@ msgstr "Paieška"
 msgid "Receive system searches and send results."
 msgstr "Gauti sistemos paieškas bei siųsti rezultatus."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Išjungta"
 
@@ -206,7 +100,6 @@ msgid "Screenshots"
 msgstr "Ekrano nuotraukos"
 
 #: panels/applications/cc-applications-panel.ui:141
-#| msgid "Take pictures with the camera."
 msgid "Take pictures of the screen at any time."
 msgstr "Fotografuokite ekraną bet kuriuo metu."
 
@@ -346,80 +239,20 @@ msgstr "Išvalyti podėlį…"
 msgid "Control various application permissions and settings"
 msgstr "Valdyti įvairius programos leidimus bei nustatymus"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "programa;flatpak;leidimas;nustatymas;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Pasirinkite paveikslėlį"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Atsisakyti"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Atverti"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "keli dydžiai"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Nėra darbalaukio fono"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Dabartinis fonas"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stilius"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Numatytasis"
 
@@ -443,7 +276,6 @@ msgstr "Išvaizda"
 msgid "Change your background image or the UI colors"
 msgstr "Pakeiskite fono paveikslėlį arba sąsajos spalvas"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Fonas;Ekranas;Darbastalis;Darbalaukis;Stilius;Šviesus;Tamsus;Išvaizda;"
@@ -494,9 +326,7 @@ msgstr "Aparatinė skrydžio veiksena yra įjungta"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Išjunkite skrydžio veiksenos jungiklį Bluetooth įjungimui."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -504,7 +334,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Įjunkite arba išjunkite Bluetooth ir junkitės prie savo įrenginių"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "dalinimasis;dalytis;bendrinti;bluetooth;obex;"
@@ -537,91 +366,33 @@ msgstr "Jokia programa neprašė prieigos prie kameros"
 msgid "Protect your pictures"
 msgstr "Apsaugokite savo paveikslėlius"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "kamera;fotoaparatas;vaizdo;įrašas;užrakinti;privatus;privatumas;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Pridėkite kalibravimo įrenginį prie stačiakampio ir spauskite „Pradėti“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Perkelkite kalibravimo įrenginį į kalibravimo padėtį ir spauskite „Tęsti“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Perkelkite kalibravimo įrenginį prie paviršiaus ir spauskite „Tęsti“"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Užverkite nešiojamą kompiuterį"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Įvyko vidinė klaida, kurios negalima atstatyti."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Kalibravimui reikalingi įrankiai nėra įdiegti."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Nepavyko sugeneruoti profilio."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Nepavyko gauti tikslo balto taško."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Atlikta!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibracija nepavyko!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Galite pašalinti kalibravimo įrenginį."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Nelieskite kalibravimo įrenginio kol vykdoma"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Ekrano kalibravimas"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Atsisakyti"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -638,140 +409,6 @@ msgstr "_Tęsti"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Atlikta"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Nešiojamo kompiuterio ekranas"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Vidinį kamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s monitorius"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s skaityklė"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s kamera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s spausdintuvas"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s internetinė kamera"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Įjungti %s spalvų tvarkymą"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Rodyti %s spalvų profilius"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Nekalibruotas"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Numatytasis: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Spalvų erdvė:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Bandomasis profilis: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Pasirinkite ICC profilio failą"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importuoti"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Palaikomi ICC profiliai"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Visi failai"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Ekranas"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Įrašyti profilį"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "Į_rašyti"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Sukurti spalvų profilį pasirinktam įrenginiui"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Matavimo prietaisas neaptiktas. Patikrinkite, ar jis įjungtas ir teisingai "
-"prijungtas."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Matavimo prietaisas nepalaiko spausdintuvo profiliavimo."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Įrenginio tipas šiuo metu nepalaikomas."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -913,7 +550,6 @@ msgstr "_Importuoti failą..."
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -925,9 +561,7 @@ msgstr ""
 "Spalvų derinimui reikia pakankamai naujo spalvų profilio kiekvienam "
 "įrenginiui."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Sužinoti daugiau"
 
@@ -1059,82 +693,6 @@ msgstr "D65 (fotografija ir grafika)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standartinė sritis"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Bandomasis profilis"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatinis"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Žemos kokybės"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Vidutinės kokybės"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Aukštos kokybės"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Numatytasis RŽM"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Numatytasis PRGJ"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Numatytasis pilkas"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Tiekėjo pateikti gamykliniai kalibravimo duomenys"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Su šiuo profiliu negalima viso ekrano korekcija"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Šis profilis gali nebebūti tikslus."
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Spalva"
@@ -1146,14 +704,9 @@ msgstr ""
 "Kalibruokite savo įrenginių, tokių kaip ekranai, vaizduokliai, kameros ar "
 "spausdintuvai, spalvas"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Spalva;ICC;Profilis;Kalibravimas;Spausdintuvas;Ekranas;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Kitas..."
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1168,13 +721,8 @@ msgid "No languages found"
 msgstr "Nerasta kalbų"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Daugiau…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Atrakinkite nustatymams keisti"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1203,154 +751,6 @@ msgstr "Sumažinti valandą"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Sumažinti minutę"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "šiandien"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Vakar"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%Y %B %e"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d valanda"
-msgstr[1] "%d valandos"
-msgstr[2] "%d valandų"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minutė"
-msgstr[1] "%d minutės"
-msgstr[2] "%d minučių"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekundę"
-msgstr[1] "%d sekundes"
-msgstr[2] "%d sekundžių"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekundžių"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Prieigos tašką"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 val."
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "Diena / Naktis"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%Y %B %d, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%Y %B %d, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1445,17 +845,11 @@ msgstr "Automatinė laiko _juosta"
 msgid "Requires location services enabled and internet access"
 msgstr "Reikalauja vietos tarnybų bei interneto ryšio"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Įjungta"
 
@@ -1463,15 +857,42 @@ msgstr "Įjungta"
 msgid "Time Z_one"
 msgstr "Laiko ju_osta"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Atrakinti"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Laiko _formatas"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datos"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekundžių"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Kalendorius"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Skaičiai"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Keiskite datą ir laiką, įskaitant laiko juostą"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Laikrodis;Laiko juosta;Vietovė;"
@@ -1517,20 +938,9 @@ msgstr "Numatytosios programos"
 msgid "Configure Default Applications"
 msgstr "Konfigūruoti numatytąsias programas"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "numatytoji;programa;pageidaujama;laikmena;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Pranešimų apie technines problemas siuntimas mums padeda pagerinti %s. "
-"Pranešimai yra siunčiami anonimiškai, o asmeniniai duomenys yra išdarkomi. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1548,44 +958,9 @@ msgstr "Diagnostika"
 msgid "Report your problems"
 msgstr "Pranešti apie jūsų problemas"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostika;lūžimas;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Įjungta"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Išjungta"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Pritaikyti pakeitimus?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Pakeitimų negalima pritaikyti"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Taip gali būti dėl aparatinės įrangos apribojimų."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1635,31 +1010,6 @@ msgstr "Pagrindinis ekranas"
 msgid "Night Light"
 msgstr "Naktinis apšvietimas"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Gulsčias"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Stačias į dešinę"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Stačias į kairę"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Gulsčias (apverstas)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1683,6 +1033,17 @@ msgstr "Derinti televizoriui"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Mastelis"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Natūralus slinkimas"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1778,7 +1139,6 @@ msgstr "Ekranai"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Pasirinkite, kaip naudoti prijungtus monitorius ir projektorius"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1786,79 +1146,6 @@ msgid ""
 msgstr ""
 "Skydelis;Projektorius;xrandr;Ekranas;Raiška;Atnaujinimas;Monitorius;Naktinis;"
 "Apšvietimas;rausvumas;spalva;saulėtekis;saulėlydis;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Saugus paleidimas yra aktyvus"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
-"kai įrenginys paleidžiamas. Jis yra įjungtas ir veikia tinkamai."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Yra problemų su saugiu paleidimu"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
-"kai įrenginys paleidžiamas. Jis yra įjungtas, bet neveiks dėl netinkamo "
-"rakto."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Saugau paleidimo problemas dažnai galima išspręsti jūsų kompiuterio UEFI "
-"nuostatose (BIOS), o jūsų aparatinės įrangos gamintojas gali pateikti "
-"informacijos, kaip tą padaryti."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Jei reikia pagalbos, kreipkitės į savo aparatinės įrangos gamintoją ar IT "
-"pagalbos centrą."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Saugus paleidimas yra išjungtas"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
-"kai įrenginys paleidžiamas. Jis šiuo metu išjungtas."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Saugų paleidimą galima įjungti kompiuterio UEFI nuostatose (BIOS). Jei "
-"reikia pagalbos, kreipkitės į gamintoją ar IT pagalbos centrą."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1873,128 +1160,9 @@ msgstr ""
 "Daugiau informacijos gausite susisiekę su aparatinės įrangos gamintoju ar "
 "pagalba."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Pavyko"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Nepavyko"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Įrenginys patvirtina HSI lygį %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Saugumo lygis 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Šis įrenginys neturi apsaugos nuo aparatinių saugumo problemų. Taip gali "
-"būti dėl aparatūros arba aparatinės programinės įrangos konfigūracijos "
-"problemos. Rekomenduojama susisiekti su pagalbos tarnyba."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Saugumo lygis 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Šis įrenginys turi minimalią apsaugą nuo aparatinių saugumo problemų. Tai "
-"yra žemiausias saugumo lygis ir apsaugo tik nuo paprasčiausių pavojų."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Saugumo lygis 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Šis įrenginys turi bazinę apsaugą nuo aparatinių saugumo problemų. Tai "
-"apsaugo nuo kai kurių dažnų saugumo pavojų."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Saugumo lygis 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Šis įrenginys turi išplėstinę apsaugą nuo aparatinių saugumo problemų. Tai "
-"yra aukščiausias saugumo lygis ir apsaugo nuo sudėtingų saugumo pavojų."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Saugumo lygis"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Šiam įrenginiui nėra saugumo lygių."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Susisiekite su gamintoju, jei reikia pagalbos su saugumo atnaujinimais."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Gali būti galima išspręsti šią problemą įrenginio UEFI nuostatose arba "
-"susisiekus su technine pagalba."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr "Gali būti galima išspręsti šią problemą įrenginio UEFI nuostatose."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
-"Gali būti galima išspręsti šią problemą susisiekus su technine pagalba."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2008,337 +1176,9 @@ msgstr "Lygis 2"
 msgid "Level 3"
 msgstr "Lygis 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Apsaugota nuo kenksmingos programinės įrangos paleidžiant įrenginį."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Yra problemų su saugiu paleidimu"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Dalinė apsauga kai įrenginys paleidžiamas."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Saugus paleidimas yra išjungtas"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Nėra apsaugos kai įrenginys paleidžiamas."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Šią problemą galėjo sukelti UEFI nuostatų pakeitimas, operacinės sistemos "
-"pakeitimas arba kenksminga programinė įranga šioje sistemoje."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Šią problemą galėjo sukelti UEFI nuostatų pakeitimas arba kenksminga "
-"programinė įranga šioje sistemoje."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Šią problemą galėjo sukelti operacinės sistemos pakeitimas arba kenksminga "
-"programinė įranga šioje sistemoje."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Dideli saugumo pavojai.."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Ribota apsauga nuo paprastų saugumo pavojų."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Apsaugota nuo dažnų saugumo pavojų."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Apsaugota nuo daugelio saugumo pavojų."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Sudėtinga apsauga"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Nėra įvykių"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Aparatinės programinės įrangos rašymo apsauga"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Aparatinės programinės įrangos rašymo apsaugos užraktas"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Aparatinės programinės įrangos BIOS regionas"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Aparatinės programinės įrangos BIOS deskriptorius"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "DMA apsauga prieš paleidimą"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard tikrinamas paleidimas"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM apsauga"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard klaidų politika"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard saugiklis"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET įjungta"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET aktyvi"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Šifruota atmintis"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU apsauga"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux branduolio užrakinimas"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linux branduolio tikrinimas"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux mainų sritis"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Pristabdyti atmintyje"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Pristabdyti į neveiksnumą"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI platformos raktas"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI saugus paleidimas"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TPM platformos konfigūracija"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM rekonstrukcija"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel valdymo variklio gamybinė veiksena"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Intel valdymo variklio pakeitimas"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Intel valdymo variklio versija"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Aparatinės programinės įrangos atnaujinimai"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Aparatinės programinės įrangos atestacija"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Aparatinės programinės įrangos tikrinimas"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Platformos derinimas"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Procesoriaus saugumo patikros"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD atstatymo apsauga"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD aparatinės programinės įrangos pakartojimo apsauga"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "AMD aparatinės programinės įrangos rašymo apsauga"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Saugiklio platforma"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Tinkamas"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Netinkamas"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Išjungta"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Užrakinta"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Neužrakinta"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Šifruota"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Nešifruota"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Suteptas"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Nesuteptas"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Rasta"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Nerasta"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Palaikoma"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Palaikoma"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2348,7 +1188,6 @@ msgstr "Įrenginio sauga"
 msgid "Host firmware security status"
 msgstr "Kompiuterio aparatinės programinės įrangos saugos būsena"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2356,49 +1195,6 @@ msgid ""
 msgstr ""
 "ekranas;užrakinimas;diagnostika;lūžimas;privatus;neseniai;naudoti;laikinieji;"
 "indeksas;pavadinimas;tinklas;tapatybė;privatumas;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Nežinomas"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bitų"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bitų"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Nežinoma"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Neprieinama"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Sistemos logotipas"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2436,7 +1232,6 @@ msgstr "OS pavadinimas"
 
 #. translators: this field contains the distro build ID
 #: panels/info-overview/cc-info-overview-panel.ui:107
-#| msgid "%s; Build ID: %s"
 msgid "OS Build ID"
 msgstr "OS kūrimo ID"
 
@@ -2493,11 +1288,6 @@ msgstr "Apie"
 msgid "View information about your system"
 msgstr "Rodyti informaciją apie sistemą"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2576,6 +1366,12 @@ msgstr "Leistukai"
 msgid "Launch help browser"
 msgstr "Paleisti pagalbos naršyklę"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Nustatymai"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Paleisti skaičiuotuvą"
@@ -2597,7 +1393,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Paieška"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
@@ -2646,15 +1442,6 @@ msgstr "Sumažinti teksto dydį"
 msgid "High contrast on or off"
 msgstr "Įjungti arba išjungti didelį kontrastą"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nerasta įvesties šaltinių"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Kita"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Pridėti įvesties šaltinį"
@@ -2687,105 +1474,9 @@ msgstr "Nuostatos"
 msgid "View Keyboard Layout"
 msgstr "Rodyti klaviatūros išdėstymą"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Pašalinti"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Pasirinktiniai susiejimai"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Alternatyvių simbolių klavišas"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Alternatyvių simbolių klavišą galima naudoti papildomiems simboliams įvesti. "
-"Jie kartais spausdinami kaip trečias pasirinkimas jūsų klaviatūroje."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Kairysis Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Dešinysis Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Kairysis Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Dešinysis Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Meniu klavišas"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Dešinysis Vald"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Rašymo klavišas"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Komponavimo klavišas leidžia įvesti daug įvairių klavišų. Jis naudojamas "
-"paspaudžiant ir įvedant simbolių seką.  Pvz., komponavimo klavišas ir po to "
-"<b>C</b> ir <b>o</b> įves <b>©</b>, <b>a</b> ir po to <b>'</b> įves <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Didžiosios raidės"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Slinkimo užraktas"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Ekranas spausdinimas"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Įvesties šaltinius galima keisti naudojant klaviatūros trumpinį %s.\n"
-"Galite pakeisti šiuos trumpinius klaviatūros nustatymuose."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2815,46 +1506,21 @@ msgstr "Specialiųjų simbolių įvestis"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Metodai simbolių bei raidžių variantų įvedimui naudojant klaviatūrą."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternatyvių simbolių klavišas"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Rašymo klavišas"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Klaviatūros trumpiniai"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Rodyti ir tinkinti trumpinius"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d pakeistas"
-msgstr[1] "%d pakeisti"
-msgstr[2] "%d pakeistų"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Atstatyti visus trumpinius?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Visų trumpinių atstatymas gali paveikti jūsų pasirinktinius trumpinius. Šio "
-"veiksmo negalėsite atšaukti."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Atsisakyti"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Atstatyti visus"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2894,33 +1560,6 @@ msgstr "Pridėti trumpinį"
 msgid "No keyboard shortcut found"
 msgstr "Nerasta klaviatūros trumpinių"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s jau naudojamas %s. Jei jį pakeisite, %s bus išjungtas"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Įveskite naują trumpinį"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Nustatyti pasirinktinį susiejimą"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Nustatyti trumpinį"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Įveskite naują trumpinį %s pakeisti."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Pridėti pasirinktinis trumpinį"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Pašalinti"
@@ -2932,7 +1571,6 @@ msgstr "_Pakeisti"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "Nu_statyti"
 
@@ -2969,6 +1607,11 @@ msgstr "Joks"
 msgid "Reset the shortcut to its default value"
 msgstr "Atstatyti numatytąją trumpinio vertę"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Naudoti jūsų kamerą"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Klaviatūra"
@@ -2981,7 +1624,6 @@ msgstr ""
 "Keisti klaviatūros trumpinius bei nustatyti rašymo nuostatas, klaviatūrų "
 "išdėstymus bei įvesties šaltinius"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3023,7 +1665,6 @@ msgstr "Jokia programa neprašė  prieigos prie vietos informacijos"
 msgid "Protect your location information"
 msgstr "Apsaugoti savo vietos informaciją"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "vieta;gps;privatus;privatumas;"
@@ -3057,7 +1698,6 @@ msgstr "Jokia programa neprašė prieigos prie mikrofono"
 msgid "Protect your conversations"
 msgstr "Apsaugokite savo pokalbius"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofonas,įrašymas;programa;privatumas;"
@@ -3087,81 +1727,141 @@ msgstr "Kairysis"
 msgid "Right"
 msgstr "Dešinysis"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Ieškoti vietų"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Pelė"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Pelės greitis"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Natūralus slinkimas"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Slinkimas žemyn"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Slinkimas perkelia turinį, o ne rodinį."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Slinkimas perkelia turinį, o ne rodinį."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktyvus"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Jutiklinis kilimėlis"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Jutiklinio kilimėlio greitis"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Metodas"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Bakstelėti _paspaudimui"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Pasieti paspaudimui"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Slinktis dviem pirštais"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Spausdinimo _metu išjungti"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Jutiklinis kilimėlis (santykinis)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Slinkimas kraštuose"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Slinkimas žemyn"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dvipusis"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Mėginkite spausti, dvigubą paspaudimą, slinkti"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Penki paspaudimai, GEGL laikas!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dvigubas paspaudimas, pagrindinis mygtukas"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Vienas paspaudimas, pagrindinis mygtukas"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dvigubas paspaudimas, vidurinysis mygtukas"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Vienas paspaudimas, vidurinysis klavišas"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dvigubas paspaudimas, antraeilis mygtukas"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Vienas paspaudimas, antraeilis mygtukas"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3174,7 +1874,6 @@ msgstr ""
 "Keiskite pelės ar jutiklinio kilimėlio jautrumą bei pasirinkite kairiarankio "
 "ar dešiniarankio veikseną"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3256,28 +1955,17 @@ msgstr "Daug užduočių"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Tvarkykite nuostatas produktyvumui ir daugeliui užduočių"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "Užduotys;Produktyvumas;Tinkinti;Darbastalis;Karštas kampas;Darbo sritys;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Oi, atsitiko kažkas negero. Susisiekite su savo programinės įrangos tiekėju."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager turėtų veikti."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Kiti įrenginiai"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3289,59 +1977,16 @@ msgstr "Pridėti ryšį"
 msgid "Not set up"
 msgstr "Nenustatyta"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Nesaugus tinklas (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Saugus tinklas (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Saugus tinklas (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Saugus tinklas (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Saugus tinklas"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Prisijungta"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Parametrai..."
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Įjungus prieigos tašką bus atsijungta nuo %s ir nebus galima pasiekti "
-"interneto per Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Turi turėti bent 8 simbolius"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3392,20 +2037,6 @@ msgstr "Automatiškai generuoti slaptažodį"
 msgid "_Turn On"
 msgstr "Į_jungti"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Belaidis"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Stabdyti prieigos tašką ir atjungti visus naudotojus?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Stabdyti prieigos tašką"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Skrydžio veiksena"
@@ -3450,89 +2081,14 @@ msgstr "Matomi tinklai"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager turi būti paleistas"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Oi, atsitiko kažkas negero. Susisiekite su savo programinės įrangos tiekėju."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _Sauga"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Sauga"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Išlaikyti"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Nuolatinis"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Atsitiktinis"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabilus"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Įvestas MAC adresas bus naudojamas kaip aparatinis adresas tinklui, kuriame "
-"aktyvuotas šis ryšys. Ši savybė yra žinoma kaip MAC klonavimas arba "
-"apsimetimas (spoofing). Pvz.: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profilis %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Patobulintas atvėrimas"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nėra"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Niekada"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3543,183 +2099,6 @@ msgstr[0] "Prieš %i dieną"
 msgstr[1] "Prieš %i dienas"
 msgstr[2] "Prieš %i dienų"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Joks"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Silpnas"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Gerai"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Geras"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Puikus"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 adresas"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 adresas"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP adresas"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Pamiršti ryšį"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Pašalinti ryšio profilį"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Pašalinti VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Išsamiau"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatinis"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Tapatybė"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Ištrinti adresą"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Ištrinti kelią"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Joks"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bitų raktas (šešioliktainis arba ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bitų slaptažodis"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynaminis WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 asmeninis"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 kompanijos"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 asmeninis"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3729,8 +2108,20 @@ msgstr "Signalo stiprumas"
 msgid "Link speed"
 msgstr "Saito greitis"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sauga"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 adresas"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 adresas"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Aparatinis adresas"
 
@@ -3739,12 +2130,17 @@ msgid "Supported Frequencies"
 msgstr "Palaikomi dažniai"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Numatytasis kelias"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3807,7 +2203,7 @@ msgstr "Tik vietinis susiejimas"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Rankinis"
 
@@ -3851,9 +2247,8 @@ msgstr "Tinklų sietuvas"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automatinis"
 
@@ -3906,89 +2301,9 @@ msgstr "A_utomatinis, tik DHCP"
 msgid "Prefix"
 msgstr "Priešdėlis"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Nepavyko atverti ryšių redaktoriaus"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Nauja profilis"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Netinkama nuostata %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Netinkama nuostata %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importuoti iš failo…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Pridėti VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_auga"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Nepavyko importuoti PVN ryšio"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Failo „%s“ nepavyksta perskaityti arba jis neturi atpažįstamos VPN ryšio "
-"informacijos\n"
-"\n"
-"Klaida: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Pasirinkite failą importavimui"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Failas pavadinimu „%s“ jau yra."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Pakeisti"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Ar norite pakeisti %s įrašomu VPN ryšiu?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Nepavyko eksportuoti VPN ryšio"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN ryšys „%s“ negali būti eksportuotas į %s.\n"
-"\n"
-"Klaida: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Eksportuoti VPN ryšį"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4002,99 +2317,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Tinklas"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Valdykite, kaip jungiatės prie interneto"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Tinklas;IP;LAN;Proxy;WAN;Plačiajuostis;Modemas;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Belaidis"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Valdykite, kaip jungiatės prie belaidžių tinklų"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Tinklas;Belaidis;Wi-Fi;Wifi;IP;LAN;Plačiajuostis;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "niekada"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "šiandien"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "vakar"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Paskutinį kartą naudota"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Laidinis"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Pridėti naują ryšį"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Tinklo nustatymai pasirinktiems tinklams įskaitant slaptažodžius ir bet "
-"kokius asmeninius nustatymus bus prarasti."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Pamiršti"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Žinomi belaidžiai tinklai"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Pamiršti"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Sistemos taisyklės neleidžia naudoti kaip prieigos taško"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Belaidis įrenginys nepalaiko prieigos taško veiksenos"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Žiniatinklio proxy automatinis aptikimas yra naudojamai, kai konfigūracijos "
-"URL nepateiktas."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Tai nerekomenduojama nepatikimiems viešiesiems tinklams."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4113,6 +2365,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Tiekėjas"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP adresas"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4197,291 +2453,6 @@ msgstr "Į_jungti belaidį prieigos tašką…"
 msgid "_Known Wi-Fi Networks"
 msgstr "Žinomi _belaidžiai tinklai"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Būsena nežinoma"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Netvarkomas"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Nepasiekiamas"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Jungiamasi"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Reikia patvirtinti tapatybę"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Atsijungiama"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Prisijungti nepavyko"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Būsena nežinoma (trūkstama)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Konfigūracija nepavyko"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP konfigūracija nepavyko"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP konfigūracijos laikas baigėsi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Buvo reikalingos paslaptys, bet nepateiktos"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x tiekėjas atjungtas"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x tiekėjo konfigūracija nepavyko"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x tiekėjo klaida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x per ilgai užtruko patvirtindamas tapatybę"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Nepavyko paleisti PPP tarnybos"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP tarnyba atsijungė"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP nepavyko"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Nepavyko paleisti DHCP kliento"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP kliento klaida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP klientas nebeveikia"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Nepavyko paleisti bendrų ryšių tarnybos"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Bendrų ryšių tarnyba nebeveikia"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Nepavyko paleisti AutoIP tarnybos"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP tarnybos klaida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP tarnyba nebeveikia"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linija užimta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Nėra skambinimo tono"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Nepavyko nustatyti pernešėjo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Baigėsi skambinimo užklausos laikas"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Nepavyko prisiskambinti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Modemo iniciavimas nepavyko"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Nepavyko pasirinkti nurodytų APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Neieškoma tinklų"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Neleista registruoti tinklo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Baigėsi tinklo registravimo laikas"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Nepavyko registruoti prašomo tinklo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Nepavyko patikrinti PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Gali būti, kad įrenginiui trūksta aparatinės programinės įrangos"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Ryšys dingo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Buvo panaudotas esamas ryšys"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modemas nerastas"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth ryšys nepavyko"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM kortelė neįdėta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Reikalingas SIM Pin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Reikalingas SIM Puk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Neteisinga SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Nepavyko ryšio priklausomybė"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Trūksta aparatinės programinės įrangos"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabelis neįjungtas"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "nežinoma klaida 802.1x saugume (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "nepasirinktas failas"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "nežinoma klaida tikrinant eap-metodo failą"
-
-#: panels/network/wireless-security/eap-method.c:394
-#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12 arba PGP privatūs raktai"
-
-#: panels/network/wireless-security/eap-method.c:397
-#| msgid "_User certificate"
-msgid "DER or PEM certificates"
-msgstr "DER arba PEM liudijimai"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "trūksta EAP-FAST PAC failo"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC failai (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4530,14 +2501,6 @@ msgstr "_Vidinis tapatybės patvirtinimas"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Leisti automatinius PAC _priskyrimus"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "trūksta EAP-LEAP naudotojo vardo"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "trūksta EAP-LEAP slaptažodžio"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4563,15 +2526,6 @@ msgstr "_Slaptažodis"
 msgid "Sho_w password"
 msgstr "_Rodyti slaptažodį"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "netinkamas EAP-PEAP LĮ liudijimas: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "netinkamas EAP-PEAP LĮ liudijimas: nenurodytas liudijimas"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4593,7 +2547,6 @@ msgid "C_A certificate"
 msgstr "L_Į liudijimas"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4608,63 +2561,6 @@ msgstr "Ne_reikia LĮ liudijimo"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _versija"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "trūksta EAP naudotojo vardo"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "trūksta EAP slaptažodžio"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "trūksta EAP-TLS identiteto"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "netinkamas EAP-TLS LĮ liudijimas: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "netinkamas EAP-TLS LĮ liudijimas: nenurodytas liudijimas"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "netinkamas EAP-TLS privatus raktas: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "netinkamas EAP-TLS naudotojo liudijimas: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Nešifruoti privatūs raktai yra nesaugūs"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Pasirinktas privatus raktas nėra apsaugotas slaptažodžiu.  Tai gali leisti "
-"pažeisti jūsų saugumo įgaliojimus.  Pasirinkite slaptažodžiu apsaugotą "
-"privatų raktą.\n"
-"\n"
-"(Galite slaptažodžiu apsaugoti savo privatų raktą su openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Pasirinkite asmeninį liudijimą"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Pasirinkite privatų raktą"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4681,15 +2577,6 @@ msgstr "Privatus ra_ktas"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Privataus rakto slaptažodis"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "netinkamas EAP-TTLS LĮ liudijimas: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "netinkamas EAP-TTLS LĮ liudijimas: nenurodytas liudijimas"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4712,14 +2599,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Sritis"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Nežinoma klaida tikrinant 802.1x saugumą"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4747,62 +2635,10 @@ msgstr "Apsaugotas EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Tapatybės patvirtinimas"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Pasirinkite failą"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "trūksta leap naudotojo vardo"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "trūksta leap slaptažodžio"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Trūksta Wi-Fi slaptažodžio."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipas"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "trūksta wep rakto"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"netinkamas wep raktas: %zu ilgio raktas turi susidėti tik iš šešioliktainių "
-"skaitmenų"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"netinkamas wep raktas: %zu ilgio raktas turi susidėti tik iš ascii simbolių"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"netinkamas wep raktas: netinkamas rakto ilgis %zu. Raktus turi būti 5/13 "
-"(ascii) arba 10/16 (šešioliktainis) ilgio"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "netinkamas wep raktas: slaptafrazė negali būti tuščia"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"netinkamas wep raktas: slaptafrazė turi būti trumpesnė nei 64 simboliai"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4827,20 +2663,6 @@ msgstr "_Rodyti raktą"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP _indeksas"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"netinkamas wpa-psk: netinkamas rakto ilgis %zu. Turi b8ti [8,63] baitai arba "
-"64 šešioliktainiai skaitmenys"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"netinkamas wpa-psk: negalima 64 baitų rakto interpretuoti kaip šešioliktainio"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4894,27 +2716,9 @@ msgstr "_Pranešimai ekrano užrakte"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Valdykite, kurie pranešimai yra rodomi, ir ką jie rodo"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Pranešimai;žinutė;laiškas;dėklas;iššokimai;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Kita"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s pašalinta"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Klaida šalinant paskyrą"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4940,17 +2744,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Pridėti paskyrą"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s paskyra"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Pašalinti paskyrą"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Internetinės paskyros"
@@ -4960,10 +2753,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Prisijunkite prie savo internetinių paskyrų ir nuspręskite, kam jas naudosite"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4971,10 +2760,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Žiniatinklis;Tinkle;Pokalbiai;Kalendorius;"
 "Paštas;Kontaktai;ownCloud;Kerberos;IMAP;SMTP;Paketas;SkaitytiVėliau;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Nežinomas laikas"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4992,13 +2777,6 @@ msgstr[0] "%i valanda"
 msgstr[1] "%i valandos"
 msgstr[2] "%i valandų"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5012,188 +2790,6 @@ msgid_plural "minutes"
 msgstr[0] "minutė"
 msgstr[1] "minutės"
 msgstr[2] "minučių"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s iki pilno įkrovimo"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Įspėjame: liko %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Liko %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Pilnai įkrautas"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Nekraunamas"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Tuščia"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Įkraunama"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Įšsikrauna"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Belaidė pelė"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Belaidė klaviatūra"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Nenutrūkstamos srovės šaltinis"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Asmeninis skaitmeninis pagalbininkas"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobilusis telefonas"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Daugialypės terpės grotuvas"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Planšetė"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Kompiuteris"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Žaidimų įvesties įrenginys"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Akumuliatorius"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Pagrindinė"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Papildoma"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Baterijos"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Kai la_isva"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Pristabdyti"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Išjungti"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Užmigdyti"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nieko"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Naudojant baterijos energiją"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Prijungus prie elektros tinklo"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Niekada"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automatinis pristabdymas"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "Našumo veiksena laikinai išjungta dėl didelės temperatūros."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Aptikti keliai: našumo veiksena laikinai išjungta. Perkelkite įrenginį ant "
-"stabilaus paviršiaus, jei norite atstatyti."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Našumo veiksena laikinai išjungta."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Senka baterija: našumo veiksena išjungta. Ankstesnė veiksena bus atstatyta, "
-"kai baterija bus pakankamai įkrauta."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Energijos taupymo veikseną įjungė „%s“."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Našumo veikseną įjungė „%s“."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5254,6 +2850,15 @@ msgstr "100 minučių"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 valandos"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akumuliatorius"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Įrenginiai"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5332,33 +2937,6 @@ msgstr "Naudoja _baterijos energiją"
 msgid "Delay"
 msgstr "Delsa"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Našumas"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Dideli našumas ir energijos suvartojimas."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Balansuotas"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standartinis našumas ir energijos suvartojimas."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Energijos taupymas"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Sumažinti galia ir energijos suvartojimas"
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Energija"
@@ -5367,7 +2945,6 @@ msgstr "Energija"
 msgid "View your battery status and change power saving settings"
 msgstr "Rodyti baterijos būseną ir keisti energijos taupymo nustatymus"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5375,27 +2952,6 @@ msgid ""
 msgstr ""
 "Energija;Miegoti;Pristabdyti;Užmigdyti;Akumuliatorius;šviesumas;Pritemdyti;"
 "Tuščias;Monitorius;DPMS;Laisva;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Spausdintuvas „%s“ buvo ištrintas"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Nepavyko pridėti naujo spausdintuvo."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Nepavyko įkelti sąsajos: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Atrakinkite spausdintuvų pridėjimui bei nustatymų keitimui"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5407,7 +2963,6 @@ msgstr ""
 "Pridėkite spausdintuvus, matykite spausdintuvo darbus ir nuspręskite, kaip "
 "norite spausdinti"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Spausdintuvas;Eilė;Spausdinti;Rašalas;"
@@ -5415,8 +2970,6 @@ msgstr "Spausdintuvas;Eilė;Spausdinti;Rašalas;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Pridėti spausdintuvą"
 
@@ -5457,29 +3010,6 @@ msgstr ""
 msgid "Username"
 msgstr "Naudotojo vardas"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s informacija"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Nerasta tinkama tvarkyklė"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Pasirinkite PPD failą"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript spausdintuvo aprašymo failai (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Spausdintuvų pavadinimai negali turėti tarpų, tabuliacijos, # arba /"
@@ -5488,9 +3018,7 @@ msgstr "Spausdintuvų pavadinimai negali turėti tarpų, tabuliacijos, # arba /"
 msgid "Location"
 msgstr "Vieta"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Tvarkyklė"
 
@@ -5518,121 +3046,14 @@ msgstr "Pasirinkite spausdintuvo tvarkyklę"
 msgid "Loading drivers database…"
 msgstr "Įkeliama tvarkyklių duomenų bazė…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Atsisakyti"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Pasirinkti"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect spausdintuvas"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD spausdintuvas"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Viepusis"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Ilgos kraštinės (standartinis)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Trumpos kraštinės (apverstas)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Stačias"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Gulsčias"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Apverstas gulsčias"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Apverstas stačias"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Tęsti"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pristabdyti"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Laukia"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pristabdytas"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Reikia patvirtinti tapatybę"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Apdorojamas"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Sustabdytas"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Atšauktas"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Atmestas"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Baigtas"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Perkelti šį darbą į eilės pradžią"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5640,19 +3061,6 @@ msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u darbui reikia patvirtinti tapatybę"
 msgstr[1] "%u darbams reikia patvirtinti tapatybę"
 msgstr[2] "%u darbų reikia patvirtinti tapatybę"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s – aktyvūs darbai"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Įveskite savo naudotojo vardą ir slaptažodį spausdinimui iš %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5680,208 +3088,11 @@ msgstr "_Patvirtinti tapatybę"
 msgid "No Active Printer Jobs"
 msgstr "Nėra aktyvių spausdintuvo darbų"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Atrakinti spausdintuvo serverį"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Atrakinti %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Įveskite savo naudotojo vardą ir slaptažodį %s prieinamiems spausdintuvams "
-"matyti."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Ieškoma spausdintuvų"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Serijinis prievadas"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Lygiagretus prievadas"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Vieta: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adresas: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Serveris reikalauja patvirtinti tapatybę"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dvipusis"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Popieriaus tipas"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Popieriaus šaltinis"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Išvestis dėklas"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Skiriamoji geba"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript pradinis filtravimas"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Puslapių vienoje pusėje"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dvipusis"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientacija"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Bendri"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Puslapio nustatymai"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Įdiegiami parametrai"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Darbas"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Paveikslėlio kokybė"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Spalva"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Užbaigiama"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Sudėtingesni"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Bandomasis puslapis"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Bandomasis puslapis"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Automatiškai pasirinkti"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Spausdintuvo numatytieji"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Tik integruoti GhostScript šriftai"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Konvertuoti į PS lygmenį 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Konvertuoti į PS lygmenį 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Nėra pradinio filtravimo"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Gamintojas"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Nėra aktyvių darbų"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5889,115 +3100,6 @@ msgid_plural "%u Jobs"
 msgstr[0] "%u darbas"
 msgstr[1] "%u darbai"
 msgstr[2] "%u darbų"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Išvalyti spausdinimo galvutes"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Baigiasi rašalas"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Baigiasi rašalas"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Baigiasi ryškalas"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Baigėsi ryškalas"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Baigiasi spalvos tiekimas"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Baigėsi spalvos tiekimas"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Atvertas dangtis"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Atvertos durys"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Baigiasi popierius"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Baigėsi popierius"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Išjungta"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Sustabdytas"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Atliekų konteineris beveik pilnas"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Atliekų konteineris pilnas"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Optinio fotokonduktoriaus tarnavimo laikas baigiasi"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Optinis fotokonduktorius nebeveikia"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Pasirengęs"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Nepriima darbų"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Apdorojama"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6021,6 +3123,10 @@ msgstr "Išvalyti spausdinimo galvutes"
 msgid "Remove Printer"
 msgstr "Pašalinti spausdintuvą"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nėra aktyvių darbų"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6041,16 +3147,21 @@ msgid "Restart"
 msgstr "Perleisti"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Pridėti spausdintuvą…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Pridėti spausdintuvą…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Spausdintuvų nėra"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6058,7 +3169,6 @@ msgstr ""
 "Atleiskite! Sistemos spausdinimo tarnyba\n"
 "    atrodo nėra pasiekiama."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formatai"
@@ -6086,16 +3196,6 @@ msgstr "Galima ieškoti šalių arba kalbų."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Peržiūra"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperinė"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrinė"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6133,20 +3233,24 @@ msgstr ""
 "Kalbos nuostata naudojama sąsajos tekstui bei interneto puslapiams. Formatai "
 "naudojami skaičiams, datoms ir pinigams."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Jūsų paskyra"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Kalba"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formatai"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Prisijungimo ekranas"
 
@@ -6158,99 +3262,9 @@ msgstr "Regionas ir kalba"
 msgid "Select your display language and formats"
 msgstr "Pasirinkite rodymo kalbą bei formatus"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Kalba;Išdėstymas;Klaviatūra;Įvestis;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Klausti, ką daryti"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Nieko nedaryti"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Atverti aplanką"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Kitos laikmenos"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Parinkite programą, kuria norėtumėte klausytis garso CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Parinkite programą vaizdo DVD rodymui"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Pasirinkite paleistiną programą, kai muzikos grotuvas prijungiamas"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Pasirinkite paleistiną programą, kai prijungiamas fotoaparatas"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Parinkite programą programinės įrangos CD paleidimui"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "garso DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "tuščias Blu-ray diskas"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "tuščias CD diskas"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "tuščias DVD diskas"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "tuščias HD DVD diskas"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray vaizdo diskas"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "el. knygų skaitytuvas"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD vaizdo diskas"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Paveikslėlių CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super vaizdo CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Vaizdo CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows programinė įranga"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6300,7 +3314,6 @@ msgstr "Išimamos laikmenos"
 msgid "Configure Removable Media settings"
 msgstr "Konfigūruoti išimamas laikmenas"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6308,114 +3321,6 @@ msgid ""
 msgstr ""
 "įrenginys;sistema;numatytoji;programa;pageidaujama;cd;dvd;usb;audio;video;"
 "diskas;išimama;laikmena;autopaleidimas;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Ekranas išsijungia"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekundžių"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minutė"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutės"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutės"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutės"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minučių"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 valanda"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minutė"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutės"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutės"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutės"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutės"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutės"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minučių"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minučių"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minučių"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Niekada"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6453,11 +3358,16 @@ msgstr "Po kiek laiko ekranas tampa tuščias, kai yra automatiškai užrakintas
 msgid "Show _Notifications on Lock Screen"
 msgstr "Rodyti pra_nešimus užrakintame ekrane"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Pranešimai ekrano užrakte"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Drausti naujus _USB įrenginius"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6465,30 +3375,25 @@ msgstr ""
 "Drausti naujiems USB įrenginiams susisieti su sistema, kai ekranas yra "
 "užrakintas."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Ekrano privatumas"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Riboti matymo kampą"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekranas"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Ekrano nuostatos"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "ekranas;užraktas;privatus;privatumas;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Pasirinkite vietą"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Gerai"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6519,10 +3424,6 @@ msgstr "Kiti"
 msgid "Add Location"
 msgstr "Pridėti vietą"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nerasta programų"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Programų paieška"
@@ -6548,93 +3449,13 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "Valdykite, kurios programos rodo paieškos rezultatus veiklų apžvalgoje"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Paieška;rasti;indeksas;slėpti;privatumas;rezultatai;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Nėra pasirinktų bendrinimui tinklų"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Tinklai"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Įjungta"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Išjungta"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Įjungta"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktyvūs"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Pasirinkite aplanką"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Pridėti"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Įjungti dalinimąsi daugialype terpe"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Dalinimasis asmeniniais failais leidžia bendrinti viešą aplanką su kitais "
-"esamame tinkle naudojant: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Kai leidžiama prisijungti nuotoliniu būdu, nutolę naudotojai gali "
-"prisijungti naudodami saugaus apvalkalo komandą:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Įjungti dalinimąsi asmeniniais failais"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Įrenginio pavadinimas nukopijuotas"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Įrenginio adresas nukopijuotas"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Naudotojo vardas nukopijuotas"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Slaptažodis nukopijuotas"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6767,7 +3588,6 @@ msgstr "Aplankai"
 msgid "Control what you want to share with others"
 msgstr "Valdykite, kuo norite dalintis su kitais"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6786,16 +3606,11 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Reikia patvirtinti tapatybę nuotoliniams prisijungimui įjungti ar išjungti"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Pasirinktinė"
-
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
 msgstr "Spauskite"
 
 #: panels/sound/cc-alert-chooser.ui:20
-#| msgid "Sharing"
 msgid "String"
 msgstr "Eilutė"
 
@@ -6822,11 +3637,6 @@ msgstr "Užpakalinė"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Priekinė"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Testuojamas %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6880,11 +3690,6 @@ msgstr "Garsumas"
 msgid "Alert Sound"
 msgstr "Įspėjimų garsumas"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Nutildyti"
@@ -6897,83 +3702,12 @@ msgstr "Garsas"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Keisti garso garsumą, įvedimą ir įvykių garsus"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Kortelė;Mikrofonas;Garsumas;Silpnėjimas;Balansas;Bluetooth;Ausinės;Garsas;"
 "Išvestis;Įvestis;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Atsijungta"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Jungiamasi"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Prisijungta"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Autorizacijos klaida"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autorizuojama"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Sumažintas funkcionalumas"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Prisijungta ir autorizuota"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Nežinoma"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autorizuota adresu:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Prisijungta adresu:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Įtraukta adresu:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Nepavyko autorizuoti įrenginio:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Nepavyko pamiršti įrenginio:"
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7008,55 +3742,6 @@ msgstr "Autorizuoti ir prisijungti"
 msgid "Forget Device"
 msgstr "Pamiršti įrenginį"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Klaida"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorizuota"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr "Thunderbolt posistemė (boltd) neįdiegta arba nenustatyta teisingai."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Leisti tiesioginę prieigą prie įrenginių, tokių kaip įstatymo stotys bei "
-"išoriniai GPU."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Galima prijungti tik USB ir Display Port įrenginius."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Nepavyko aptikti Thunderbolt.\n"
-"Sistemai trūksta Thunderbolt palaikymo, ji buvo BIOS sistemoje išjungta arba "
-"nustatyta į nepalaikomą saugumo lygį."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt palaikymas buvo išjungtas BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Nepavyko nustatyti Thunderbolt saugumo lygio."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Klaida persijungians į tiesioginę veikseną: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Nėra Thunderbolt palaikymo"
@@ -7068,6 +3753,12 @@ msgstr "Nepavyko prisijungti prie thunderbolt posistemės."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Tiesioginė prieiga"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Leisti tiesioginę prieigą prie įrenginių, tokių kaip įstatymo stotys bei "
+"išoriniai GPU."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7085,7 +3776,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Tvarkyti Thunderbolt įrenginius"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privatumas;"
@@ -7287,41 +3977,6 @@ msgstr "Į_jungti klaviatūra"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Įjungti pritaikymo neįgaliesiems funkcijas klaviatūra"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Numatytasis"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Vidutinis"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Didelis"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Didesnis"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Didžiausias"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pikselis"
-msgstr[1] "%d pikseliai"
-msgstr[2] "%d pikselių"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Visada rodyti prieigos meniu"
@@ -7435,31 +4090,6 @@ msgstr "Blykstelti visą _ekraną"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Blykstelti visą _langą"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Trumpas"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ekrano"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ekrano"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ekrano"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Ilgas"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7616,7 +4246,6 @@ msgstr "Spalvų efektai"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Padarykite matymą, išgirdimą, rašymą, rodymą ir spaudimą paprastesnį"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7629,114 +4258,6 @@ msgstr ""
 "Kibūs;Klavišai;Lėtieji;Pasikartojantys;Pelė; Dvigubas;paspaudimas;Delsa;"
 "Greitis;Pagalba;Pasikartojimas;Mirksėjimas;vaizdinis;klausa;garsas;rašymas;"
 "animacijos;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 valanda"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 diena"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dienos"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dienos"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dienos"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dienos"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dienos"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dienos"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dienų"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dienos"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Išvalyti visus elementus iš šiukšlinės?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Visi šiukšlinės elementai bus negrįžtamai ištrinti."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Iš_valyti šiukšlinę"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Ištrinti visus laikinuosius failus?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Visi laikinieji failai bus negrįžtamai ištrinti."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Išvalyti laikinuosius _failus"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 diena"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dienos"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dienos"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Visam laikui"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7804,64 +4325,12 @@ msgstr "Failų istorija ir šiukšlinė"
 msgid "Don't leave traces"
 msgstr "Nepalikti pėdsakų"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "naudojimas;neseni;istorija;failai;laikini;tmp;privatūs;privatumas;šiukšlinė;"
 "išvalyti;palikti;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Turi atitikti jūsų paskyros teikėjo žiniatinklio adresą."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Nepavyko pridėti Pasirinkite paskyros"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Slaptažodžiai nesutampa."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Nepavyko priregistruoti paskyros"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Nėra palaikomo būdo patvirtinti tapatybę šiame serveryje"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Nepavyko prisijungti prie srities"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Šis prisijungimo vardas nesuveikė.\n"
-"Bandykite dar kartą."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Šis prisijungimo slaptažodis nesuveikė.\n"
-"Bandykite dar kartą."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Nepavyko prisijungti prie srities"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Nepavyksta rasti domeno. Gal suklydote?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7913,10 +4382,6 @@ msgstr ""
 "Kompanijos prisijungimas leidžia šiame įrenginyje naudoti centralizuotai "
 "tvarkomą naudotojo paskyrą. Taip pat galima naudoti šią paskyrą kompanijos "
 "ištekliams internete pasiekti."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Naršyti daugiau paveikslėlių"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7987,222 +4452,6 @@ msgstr "_Ištrinti pirštų antspaudus"
 msgid "Fingerprint Enroll"
 msgstr "Piršto atspaudo įtraukimas"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "reikia užimti įrenginį, norint atlikti šį veiksmą"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "įrenginį jau užėmė kitas procesas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "neturite leidimo įvykdyti veiksmą"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "atspaudai nebuvo įvesti"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Nepavyko susisiekti su įrenginiu įvedimo metu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Nepavyko susisiekti su pirštų atspaudų skaitykle"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Nepavyko susisiekti su pirštų atspaudų tarnyba"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Nepavyko išvardinti pirštų atspaudų: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Nepavyko ištrinti įrašytų pirštų atspaudų: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Kairysis smilius"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Kairysis didysis pirštas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Kairysis smilius"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Kairysis bevardis pirštas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Kairysis mažasis pirštas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Dešinysis nykštys"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Dešinysis didysis pirštas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Dešinysis smilius"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Dešinysis bevardis pirštas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Dešinysis mažasis pirštas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Nežinomas pirštas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Atlikta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Pirštų atspaudų skaitytuvas atsijungė"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Pirštų atspaudų skaitytuvo saugykla yra pilna"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Nepavyko įtraukti naujo piršto atspaudo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Nepavyko pradėti įtraukimo: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Nepavyko įtraukti naujo piršto atspaudo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Nepavyko sustabdyti įtraukimo: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Pakartotinai atitraukite ir uždėkite savo pirštą ant skaitytuvo piršto "
-"atspaudui įtraukti"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Iš _naujo įtraukti šį pirštą…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Nuskaityti naują piršto atspaudą"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Nepavyko atlaisvinti pirštų atspaudų skaitytuvo %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problema skaitant įrenginį"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Nepavyko perimti pirštų atspaudų skaitytuvo %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Nepavyko gauti pirštų atspaudų įrenginių: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Ši savaitė"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Preitą savaitę"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%Y %B %e"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Seansas įjungtas"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Seansas paleistas"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s – paskyros aktyvumas"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Ankstesnis"
@@ -8210,18 +4459,6 @@ msgstr "Ankstesnis"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Kitas"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Pasirinkite kitą slaptažodį."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Įveskite savo slaptažodį dar kartą."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Nepavyko pakeisti slaptažodžio"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8243,6 +4480,10 @@ msgstr "Naujas slaptažodis"
 msgid "Confirm Password"
 msgstr "Patvirtinkite slaptažodį"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Slaptažodžiai nesutampa."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Leisti naudotojui pakeisti slaptažodį kito prisijungimo metu"
@@ -8250,134 +4491,6 @@ msgstr "Leisti naudotojui pakeisti slaptažodį kito prisijungimo metu"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Nustatyti slaptažodį dabar"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Nepavyksta automatiškai prisijungti prie šio tipo domeno"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Nėra tokios srities"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Nepavyko prisijungti kaip %s srityje %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Netinkamas slaptažodis, bandykite dar kartą"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Nepavyko prisijungti prie %s srities: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Nepavyko ištrinti naudotojo"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Nepavyko atimti teisių iš nutolusio naudotojo"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Jūs negalite ištrinti savo paskyros."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s vis dar prisijungęs"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Naudotojų ištrynimas, kai jie yra prisijungę, gali palikti sistemą "
-"nekorektiškoje būsenoje."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Ar norite palikti naudotojo %s failus?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Trinant naudotoją galima palikti namų katalogą, paštą ir laikinus failus."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Ištrinti failus"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Palikti failus"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Ar tikrai norite atimti teises iš nuotoliniu būdu tvarkomos paskyros %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Ištrinti"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Paskyra išjungta"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Bus nustatyta kito prisijungimo metu"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Joks"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Prisijunges prie"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Nepavyko susisiekti su paskyrų tarnyba"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Įsitikinkite, kad AccountService yra įdiegta ir įjungta."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Šis skydelis turi būti atrakintas, norint keisti šią nuostatą"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Ištrinti pasirinktą naudotoją"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Pasirinktam naudotojui ištrinti,\n"
-"pirma paspauskite * piktogramą"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Atrakinkite naudotojų pridėjimui bei nustatymų keitimui"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8405,7 +4518,6 @@ msgid "Full name"
 msgstr "Pilnas vardas"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Keisti"
 
@@ -8467,7 +4579,6 @@ msgstr "Atrakinti naujos paskyros sukūrimui."
 msgid "Add or remove users and change your password"
 msgstr "Pridėti arba šalinti naudotojus bei keiskite savo slaptažodį"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8512,177 +4623,6 @@ msgstr "Tvarkyti naudotojų paskyras"
 msgid "Authentication is required to change user data"
 msgstr "Reikia patvirtinti tapatybę naudotojų duomenims keisti"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Naujas slaptažodis turi skirtis nuo senojo."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Bandykite raides ir skaitmenis."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Mėginkite labiau pakeisti slaptažodį."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Slaptažodis be naudotojo vardą būtų saugesnis."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Venkite savo vardo slaptažodyje."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Venkite kai kurių į slaptažodį įtrauktų žodžių."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Venkite dažnų žodžių."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Venkite esamų žodžių tvarkos keitimo."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Mėginkite naudoti daugiau skaitmenų."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Mėginkite naudoti daugiau didžiųjų raidžių."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Mėginkite naudoti daugiau mažųjų raidžių."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Mėginkite naudoti daugiau specialiųjų simbolių, pvz. skyrybos ženklų."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Mėginkite naudoti raidžių, skaitmenų ir skyrybos ženklų mišinį."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Venkite to paties simbolio pasikartojimų."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Venkite to paties simbolio pasikartojimų: reikia maišyti raides, skaitmenis "
-"ir skyrybos ženklus."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Venkite sekų 1234, abcd ir pan."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Slaptažodis per trumpas. Mėginkite pridėti daugiau raidžių, skaitmenų ir "
-"skyrybos ženklų mišinį."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Maišykite didžiąsias ir mažąsias raides bei panaudokite skaitmenų."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Pridėję raidžių, skaitmenų ir skyrybos ženklų  padarytumėt jį dar stipresnį."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Tapatybė nepatvirtinta"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Naujas slaptažodis per trumpas"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Naujas slaptažodis per paprastas"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Senas ir naujas slaptažodžiai yra per daug panašūs"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Naujas slaptažodis neseniai jau buvo naudotas."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Naujas slaptažodis turi susidėti iš skaičių arba specialių simbolių"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Senas ir naujas slaptažodžiai sutampa"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Jūsų slaptažodis pakeistas nuo pradinio Jūsų tapatybės atpažinimo!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Naujas slaptažodis Nesusideda iš pakankamai skirtingų simbolių"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Nežinoma klaida"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Naudotojo vardą gali sudaryti tik raidės mažosios raidės a-z, skaitmenys ir "
-"šie simboliai: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Atleiskite, šis naudotojo vardas yra neprieinamas. Bandykite kitą."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Naudotojo vardas per ilgas."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8717,53 +4657,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Aptiktas klaidingas paspaudimas, perleidžiama…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Mygtukas %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Programos nustatytas"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Siųsti klavišų seką"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Perjungti monitorių"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Rodyti pagalbą ekrane"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Planšetė prijungta ant nešiojamojo kompiuterio skydelio"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Planšetė, prijungta prie išorinio vaizduoklio"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Išorinis planšetinis įrenginys"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
-#| msgid "External tablet device"
 msgid "External pad device"
 msgstr "Išorinis planšetinis įrenginys"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Visi vaizduokliai"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8860,22 +4757,6 @@ msgstr "Dešiniojo pelės mygtuko paspaudimas"
 msgid "Forward"
 msgstr "Pirmyn"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Orinis pieštukas yra spaudimo jėga, palenkimu ir integruotu slankikliu"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Orinis pieštukas yra spaudimo jėga, palenkimu ir posūkiu"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standartinis pieštukas su spaudimo jėga ir palenkimu"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standartinis pieštukas su spaudimo jėga"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom planšetė"
@@ -8886,54 +4767,96 @@ msgstr ""
 "Nustatykite mygtukų susiejimus ir pritaikykite pieštuko jautrumą grafinėms "
 "planšetėms"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Planšetė;Wacom;Rašiklis;Trintukas;Pelė;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Naujas trumpinys…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Imituotas antrinis spustelėjimas"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows programinė įranga"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Baigiasi rašalas"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Antrinis"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows programinė įranga"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Tvarkykite nuostatas produktyvumui ir daugeliui užduočių"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Prieigos taškai"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Pridėti"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "Į_rašyti"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Veiksmo atsisakyta"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Klaida:</b> prieiga neleista keičiant nuostatas"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Klaida:</b> mobiliosios įrangos klaida"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Neregistruota"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registruota"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Tarptinklinis"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Ieškoma"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Neleista"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8963,212 +4886,13 @@ msgstr "Savi skaičiai"
 msgid "Device Details"
 msgstr "Įrenginio informacija"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Gamintojas"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Aparatinės programinės įrangos versija"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "tik 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "tik 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "tik 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "tik 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (pageidautina), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (pageidautina), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (pageidautina), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (pageidautina), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (pageidautina), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (pageidautina), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (pageidautina), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (pageidautina), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (pageidautina), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (pageidautina), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (pageidautina), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (pageidautina), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (pageidautina), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (pageidautina), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (pageidautina), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (pageidautina), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (pageidautina)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (pageidautina), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Nežinoma"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Atrakinti SIM kortelę"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Atrakinti"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Pateikite PIN kodą SIM kortelei %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Įveskite PIN SIM kortelei atrakinti"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Pateikite PUK kodą SIM kortelei %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Įveskite PUK kodą SIM kortelei atrakinti"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9185,26 +4909,6 @@ msgid_plural "You have %u tries left"
 msgstr[0] "Liko %1$u bandymas"
 msgstr[1] "Liko %1$u bandymai"
 msgstr[2] "Liko %1$u bandymų"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Įvestas blogas slaptažodis."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK kodas turi būti 8 skaitmenų skaičius"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Įveskite naują PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN kodas turi būti 4-8 skaitmenų skaičius"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Atrakinama…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9262,94 +4966,6 @@ msgstr "Užrakinti SIM su PIN"
 msgid "M_odem Details"
 msgstr "M_odemo informacija"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Telefono klaida"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Nėra ryšio su telefonu"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Veiksmas neleidžiamas"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Veiksmas nepalaikomas"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM neįdėta"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Reikalingas SIM PIN"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Reikalingas SIM PUK"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM klaida"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM užimta"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Neteisingas slaptažodis"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Reikalingas SIM PIN2"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Reikalingas SIM PUK2"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Nerasta"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Nėra tinklo tarnybos"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Baigėsi tinklo laikas"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS tarnyba neleidžiama"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Tarptinklinis ryšys šioje vietovėje neleidžiamas"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Nenurodyta GPRS klaida"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Nėra klaidos"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Veiksmo atsisakyta"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Prieiga neleidžiama"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Nežinoma klaida"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Tinklo veiksena"
@@ -9365,11 +4981,6 @@ msgstr "Pasirinkti tinklą"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Atnaujinti tinklų tiekėjus"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9427,7 +5038,6 @@ msgstr "Mobilusis tinklas"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Konfigūruoti telefonijos ir mobiliųjų duomenų ryšius"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "mobilusis;wwan;telefonija;sim;mibilusis;"
@@ -9444,41 +5054,13 @@ msgstr "Nustatymai yra pirminė sąsaja jūsų sistemos konfigūravimui."
 msgid "The GNOME Project"
 msgstr "GNOME projektas"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Rodyti versijos numerį"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Įjungti derinimo veikseną"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Ieškoti eilutės"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Išvardinti galimus skydelių pavadinimus ir išeiti"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Rodomas skydelis"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[SKYDELIS] [ARGUMENTAS…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Nuostatų kategorijos"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privatumas"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Prieinami skydeliai:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9535,7 +5117,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Atšaukti paiešką"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Nuostatos;Nustatymai;"
@@ -9572,8 +5153,6 @@ msgid ""
 msgstr ""
 "Junginys su programos lango pradiniu pločiu, aukščiu ir išdidinimo būsena."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9582,8 +5161,6 @@ msgstr[0] "%u išvestis"
 msgstr[1] "%u išvestys"
 msgstr[2] "%u išvesčių"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9592,9 +5169,3127 @@ msgstr[0] "%u įvestis"
 msgstr[1] "%u įvestys"
 msgstr[2] "%u įvesčių"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sistemos garsai"
+#~ msgid "System Bus"
+#~ msgstr "Sisteminė magistralė"
+
+#~ msgid "Full access"
+#~ msgstr "Pilna prieiga"
+
+#~ msgid "Session Bus"
+#~ msgstr "Seanso magistralė"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Pilna prieiga prie /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Turi tinklo prieigą"
+
+#~ msgid "Home"
+#~ msgstr "Namų aplankas"
+
+#~ msgid "Read-only"
+#~ msgstr "Tik skaitymui"
+
+#~ msgid "File System"
+#~ msgstr "Failų sistema"
+
+#~ msgid "Can change settings"
+#~ msgstr "Gali keisti nustatymus"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s turi šiuo integruotus leidimus. Jų negalima keisti. Jei turite "
+#~ "abejonių dėl šių leidimų, pagalvokite apie programos pašalinimą."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u failų ir saitų tipas, kuris atveriamas programos"
+#~ msgstr[1] "%u failų ir saitų tipai, kurie atveriamas programos"
+#~ msgstr[2] "%u failų ir saitų tipų, kurie atveriamas programos"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> yra naudojama atverti šio tipo failus bei saitus."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "Naudojama %s disko vietos."
+
+#~ msgid "Select a picture"
+#~ msgstr "Pasirinkite paveikslėlį"
+
+#~ msgid "_Open"
+#~ msgstr "_Atverti"
+
+#~ msgid "multiple sizes"
+#~ msgstr "keli dydžiai"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Nėra darbalaukio fono"
+
+#~ msgid "Current background"
+#~ msgstr "Dabartinis fonas"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Pridėkite kalibravimo įrenginį prie stačiakampio ir spauskite „Pradėti“"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Perkelkite kalibravimo įrenginį į kalibravimo padėtį ir spauskite „Tęsti“"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Perkelkite kalibravimo įrenginį prie paviršiaus ir spauskite „Tęsti“"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Užverkite nešiojamą kompiuterį"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Įvyko vidinė klaida, kurios negalima atstatyti."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Kalibravimui reikalingi įrankiai nėra įdiegti."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Nepavyko sugeneruoti profilio."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Nepavyko gauti tikslo balto taško."
+
+#~ msgid "Complete!"
+#~ msgstr "Atlikta!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibracija nepavyko!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Galite pašalinti kalibravimo įrenginį."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Nelieskite kalibravimo įrenginio kol vykdoma"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Nešiojamo kompiuterio ekranas"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Vidinį kamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s monitorius"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s skaityklė"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s kamera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s spausdintuvas"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s internetinė kamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Įjungti %s spalvų tvarkymą"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Rodyti %s spalvų profilius"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nekalibruotas"
+
+#~ msgid "Default: "
+#~ msgstr "Numatytasis: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Spalvų erdvė:"
+
+#~ msgid "Test profile: "
+#~ msgstr "Bandomasis profilis: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Pasirinkite ICC profilio failą"
+
+#~ msgid "_Import"
+#~ msgstr "_Importuoti"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Palaikomi ICC profiliai"
+
+#~ msgid "All files"
+#~ msgstr "Visi failai"
+
+#~ msgid "Save Profile"
+#~ msgstr "Įrašyti profilį"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Sukurti spalvų profilį pasirinktam įrenginiui"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Matavimo prietaisas neaptiktas. Patikrinkite, ar jis įjungtas ir "
+#~ "teisingai prijungtas."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Matavimo prietaisas nepalaiko spausdintuvo profiliavimo."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Įrenginio tipas šiuo metu nepalaikomas."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standartinė sritis"
+
+#~ msgid "Test Profile"
+#~ msgstr "Bandomasis profilis"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatinis"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Žemos kokybės"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Vidutinės kokybės"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Aukštos kokybės"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Numatytasis RŽM"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Numatytasis PRGJ"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Numatytasis pilkas"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Tiekėjo pateikti gamykliniai kalibravimo duomenys"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Su šiuo profiliu negalima viso ekrano korekcija"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Šis profilis gali nebebūti tikslus."
+
+#~ msgid "Other…"
+#~ msgstr "Kitas..."
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Atrakinkite nustatymams keisti"
+
+#~ msgid "Today"
+#~ msgstr "šiandien"
+
+#~ msgid "Yesterday"
+#~ msgstr "Vakar"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y %B %e"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d valanda"
+#~ msgstr[1] "%d valandos"
+#~ msgstr[2] "%d valandų"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minutė"
+#~ msgstr[1] "%d minutės"
+#~ msgstr[2] "%d minučių"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekundę"
+#~ msgstr[1] "%d sekundes"
+#~ msgstr[2] "%d sekundžių"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Prieigos tašką"
+
+#~ msgid "24-hour"
+#~ msgstr "24 val."
+
+#~ msgid "AM / PM"
+#~ msgstr "Diena / Naktis"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%Y %B %d, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%Y %B %d, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Pranešimų apie technines problemas siuntimas mums padeda pagerinti %s. "
+#~ "Pranešimai yra siunčiami anonimiškai, o asmeniniai duomenys yra "
+#~ "išdarkomi. %s"
+
+#~ msgid "On"
+#~ msgstr "Įjungta"
+
+#~ msgid "Off"
+#~ msgstr "Išjungta"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Pritaikyti pakeitimus?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Pakeitimų negalima pritaikyti"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Taip gali būti dėl aparatinės įrangos apribojimų."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Gulsčias"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Stačias į dešinę"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Stačias į kairę"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Gulsčias (apverstas)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Saugus paleidimas yra aktyvus"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
+#~ "kai įrenginys paleidžiamas. Jis yra įjungtas ir veikia tinkamai."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Yra problemų su saugiu paleidimu"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
+#~ "kai įrenginys paleidžiamas. Jis yra įjungtas, bet neveiks dėl netinkamo "
+#~ "rakto."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Saugau paleidimo problemas dažnai galima išspręsti jūsų kompiuterio UEFI "
+#~ "nuostatose (BIOS), o jūsų aparatinės įrangos gamintojas gali pateikti "
+#~ "informacijos, kaip tą padaryti."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Jei reikia pagalbos, kreipkitės į savo aparatinės įrangos gamintoją ar IT "
+#~ "pagalbos centrą."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Saugus paleidimas yra išjungtas"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
+#~ "kai įrenginys paleidžiamas. Jis šiuo metu išjungtas."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Saugų paleidimą galima įjungti kompiuterio UEFI nuostatose (BIOS). Jei "
+#~ "reikia pagalbos, kreipkitės į gamintoją ar IT pagalbos centrą."
+
+#~ msgid "Passed"
+#~ msgstr "Pavyko"
+
+#~ msgid "Failed"
+#~ msgstr "Nepavyko"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Įrenginys patvirtina HSI lygį %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Saugumo lygis 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Šis įrenginys neturi apsaugos nuo aparatinių saugumo problemų. Taip gali "
+#~ "būti dėl aparatūros arba aparatinės programinės įrangos konfigūracijos "
+#~ "problemos. Rekomenduojama susisiekti su pagalbos tarnyba."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Saugumo lygis 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Šis įrenginys turi minimalią apsaugą nuo aparatinių saugumo problemų. Tai "
+#~ "yra žemiausias saugumo lygis ir apsaugo tik nuo paprasčiausių pavojų."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Saugumo lygis 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Šis įrenginys turi bazinę apsaugą nuo aparatinių saugumo problemų. Tai "
+#~ "apsaugo nuo kai kurių dažnų saugumo pavojų."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Saugumo lygis 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Šis įrenginys turi išplėstinę apsaugą nuo aparatinių saugumo problemų. "
+#~ "Tai yra aukščiausias saugumo lygis ir apsaugo nuo sudėtingų saugumo "
+#~ "pavojų."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Šiam įrenginiui nėra saugumo lygių."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Susisiekite su gamintoju, jei reikia pagalbos su saugumo atnaujinimais."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Gali būti galima išspręsti šią problemą įrenginio UEFI nuostatose arba "
+#~ "susisiekus su technine pagalba."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr "Gali būti galima išspręsti šią problemą įrenginio UEFI nuostatose."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Gali būti galima išspręsti šią problemą susisiekus su technine pagalba."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Apsaugota nuo kenksmingos programinės įrangos paleidžiant įrenginį."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Yra problemų su saugiu paleidimu"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Dalinė apsauga kai įrenginys paleidžiamas."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Saugus paleidimas yra išjungtas"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Nėra apsaugos kai įrenginys paleidžiamas."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Šią problemą galėjo sukelti UEFI nuostatų pakeitimas, operacinės sistemos "
+#~ "pakeitimas arba kenksminga programinė įranga šioje sistemoje."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Šią problemą galėjo sukelti UEFI nuostatų pakeitimas arba kenksminga "
+#~ "programinė įranga šioje sistemoje."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Šią problemą galėjo sukelti operacinės sistemos pakeitimas arba "
+#~ "kenksminga programinė įranga šioje sistemoje."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Dideli saugumo pavojai.."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Ribota apsauga nuo paprastų saugumo pavojų."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Apsaugota nuo dažnų saugumo pavojų."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Apsaugota nuo daugelio saugumo pavojų."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Sudėtinga apsauga"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Aparatinės programinės įrangos rašymo apsauga"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Aparatinės programinės įrangos rašymo apsaugos užraktas"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Aparatinės programinės įrangos BIOS regionas"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Aparatinės programinės įrangos BIOS deskriptorius"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "DMA apsauga prieš paleidimą"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard tikrinamas paleidimas"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM apsauga"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard klaidų politika"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard saugiklis"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET įjungta"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET aktyvi"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Šifruota atmintis"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU apsauga"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux branduolio užrakinimas"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux branduolio tikrinimas"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux mainų sritis"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Pristabdyti atmintyje"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Pristabdyti į neveiksnumą"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI platformos raktas"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI saugus paleidimas"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM platformos konfigūracija"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM rekonstrukcija"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel valdymo variklio gamybinė veiksena"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel valdymo variklio pakeitimas"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel valdymo variklio versija"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Aparatinės programinės įrangos atnaujinimai"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Aparatinės programinės įrangos atestacija"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Aparatinės programinės įrangos tikrinimas"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Platformos derinimas"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Procesoriaus saugumo patikros"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD atstatymo apsauga"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD aparatinės programinės įrangos pakartojimo apsauga"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD aparatinės programinės įrangos rašymo apsauga"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Saugiklio platforma"
+
+#~ msgid "Valid"
+#~ msgstr "Tinkamas"
+
+#~ msgid "Not Valid"
+#~ msgstr "Netinkamas"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Išjungta"
+
+#~ msgid "Locked"
+#~ msgstr "Užrakinta"
+
+#~ msgid "Not Locked"
+#~ msgstr "Neužrakinta"
+
+#~ msgid "Encrypted"
+#~ msgstr "Šifruota"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Nešifruota"
+
+#~ msgid "Tainted"
+#~ msgstr "Suteptas"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Nesuteptas"
+
+#~ msgid "Found"
+#~ msgstr "Rasta"
+
+#~ msgid "Not Found"
+#~ msgstr "Nerasta"
+
+#~ msgid "Supported"
+#~ msgstr "Palaikoma"
+
+#~ msgid "Not Supported"
+#~ msgstr "Palaikoma"
+
+#~ msgid "Unknown"
+#~ msgstr "Nežinomas"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bitų"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bitų"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Nežinoma"
+
+#~ msgid "Not Available"
+#~ msgstr "Neprieinama"
+
+#~ msgid "System Logo"
+#~ msgstr "Sistemos logotipas"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nerasta įvesties šaltinių"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Kita"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Pasirinktiniai susiejimai"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Alternatyvių simbolių klavišą galima naudoti papildomiems simboliams "
+#~ "įvesti. Jie kartais spausdinami kaip trečias pasirinkimas jūsų "
+#~ "klaviatūroje."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Kairysis Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Dešinysis Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Kairysis Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Dešinysis Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Meniu klavišas"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Dešinysis Vald"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Komponavimo klavišas leidžia įvesti daug įvairių klavišų. Jis naudojamas "
+#~ "paspaudžiant ir įvedant simbolių seką.  Pvz., komponavimo klavišas ir po "
+#~ "to <b>C</b> ir <b>o</b> įves <b>©</b>, <b>a</b> ir po to <b>'</b> įves "
+#~ "<b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Didžiosios raidės"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Slinkimo užraktas"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Ekranas spausdinimas"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Įvesties šaltinius galima keisti naudojant klaviatūros trumpinį %s.\n"
+#~ "Galite pakeisti šiuos trumpinius klaviatūros nustatymuose."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d pakeistas"
+#~ msgstr[1] "%d pakeisti"
+#~ msgstr[2] "%d pakeistų"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Atstatyti visus trumpinius?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Visų trumpinių atstatymas gali paveikti jūsų pasirinktinius trumpinius. "
+#~ "Šio veiksmo negalėsite atšaukti."
+
+#~ msgid "Reset All"
+#~ msgstr "Atstatyti visus"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s jau naudojamas %s. Jei jį pakeisite, %s bus išjungtas"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Įveskite naują trumpinį"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Nustatyti pasirinktinį susiejimą"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Nustatyti trumpinį"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Įveskite naują trumpinį %s pakeisti."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Pridėti pasirinktinis trumpinį"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Slinktis dviem pirštais"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Penki paspaudimai, GEGL laikas!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dvigubas paspaudimas, pagrindinis mygtukas"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Vienas paspaudimas, pagrindinis mygtukas"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dvigubas paspaudimas, vidurinysis mygtukas"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Vienas paspaudimas, vidurinysis klavišas"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dvigubas paspaudimas, antraeilis mygtukas"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Vienas paspaudimas, antraeilis mygtukas"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager turėtų veikti."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Nesaugus tinklas (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Saugus tinklas (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Saugus tinklas (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Saugus tinklas (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Saugus tinklas"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Įjungus prieigos tašką bus atsijungta nuo %s ir nebus galima pasiekti "
+#~ "interneto per Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Turi turėti bent 8 simbolius"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Stabdyti prieigos tašką ir atjungti visus naudotojus?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Stabdyti prieigos tašką"
+
+#~ msgid "Preserve"
+#~ msgstr "Išlaikyti"
+
+#~ msgid "Permanent"
+#~ msgstr "Nuolatinis"
+
+#~ msgid "Random"
+#~ msgstr "Atsitiktinis"
+
+#~ msgid "Stable"
+#~ msgstr "Stabilus"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Įvestas MAC adresas bus naudojamas kaip aparatinis adresas tinklui, "
+#~ "kuriame aktyvuotas šis ryšys. Ši savybė yra žinoma kaip MAC klonavimas "
+#~ "arba apsimetimas (spoofing). Pvz.: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profilis %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Patobulintas atvėrimas"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nėra"
+
+#~ msgid "Never"
+#~ msgstr "Niekada"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Joks"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Silpnas"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Gerai"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Geras"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Puikus"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Pamiršti ryšį"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Pašalinti ryšio profilį"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Pašalinti VPN"
+
+#~ msgid "Details"
+#~ msgstr "Išsamiau"
+
+#~ msgid "automatic"
+#~ msgstr "automatinis"
+
+#~ msgid "Identity"
+#~ msgstr "Tapatybė"
+
+#~ msgid "Delete Address"
+#~ msgstr "Ištrinti adresą"
+
+#~ msgid "Delete Route"
+#~ msgstr "Ištrinti kelią"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Joks"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bitų raktas (šešioliktainis arba ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bitų slaptažodis"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynaminis WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 asmeninis"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 kompanijos"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 asmeninis"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Nepavyko atverti ryšių redaktoriaus"
+
+#~ msgid "New Profile"
+#~ msgstr "Nauja profilis"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Netinkama nuostata %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Netinkama nuostata %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importuoti iš failo…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Pridėti VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Nepavyko importuoti PVN ryšio"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Failo „%s“ nepavyksta perskaityti arba jis neturi atpažįstamos VPN ryšio "
+#~ "informacijos\n"
+#~ "\n"
+#~ "Klaida: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Pasirinkite failą importavimui"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Failas pavadinimu „%s“ jau yra."
+
+#~ msgid "_Replace"
+#~ msgstr "_Pakeisti"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Ar norite pakeisti %s įrašomu VPN ryšiu?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Nepavyko eksportuoti VPN ryšio"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN ryšys „%s“ negali būti eksportuotas į %s.\n"
+#~ "\n"
+#~ "Klaida: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Eksportuoti VPN ryšį"
+
+#~ msgid "never"
+#~ msgstr "niekada"
+
+#~ msgid "today"
+#~ msgstr "šiandien"
+
+#~ msgid "yesterday"
+#~ msgstr "vakar"
+
+#~ msgid "Last used"
+#~ msgstr "Paskutinį kartą naudota"
+
+#~ msgid "Add new connection"
+#~ msgstr "Pridėti naują ryšį"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Tinklo nustatymai pasirinktiems tinklams įskaitant slaptažodžius ir bet "
+#~ "kokius asmeninius nustatymus bus prarasti."
+
+#~ msgid "_Forget"
+#~ msgstr "_Pamiršti"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Žinomi belaidžiai tinklai"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Pamiršti"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Sistemos taisyklės neleidžia naudoti kaip prieigos taško"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Belaidis įrenginys nepalaiko prieigos taško veiksenos"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Žiniatinklio proxy automatinis aptikimas yra naudojamai, kai "
+#~ "konfigūracijos URL nepateiktas."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Tai nerekomenduojama nepatikimiems viešiesiems tinklams."
+
+#~ msgid "Status unknown"
+#~ msgstr "Būsena nežinoma"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Netvarkomas"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nepasiekiamas"
+
+#~ msgid "Connecting"
+#~ msgstr "Jungiamasi"
+
+#~ msgid "Authentication required"
+#~ msgstr "Reikia patvirtinti tapatybę"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Atsijungiama"
+
+#~ msgid "Connection failed"
+#~ msgstr "Prisijungti nepavyko"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Būsena nežinoma (trūkstama)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Konfigūracija nepavyko"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP konfigūracija nepavyko"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP konfigūracijos laikas baigėsi"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Buvo reikalingos paslaptys, bet nepateiktos"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x tiekėjas atjungtas"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x tiekėjo konfigūracija nepavyko"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x tiekėjo klaida"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x per ilgai užtruko patvirtindamas tapatybę"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Nepavyko paleisti PPP tarnybos"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP tarnyba atsijungė"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP nepavyko"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Nepavyko paleisti DHCP kliento"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP kliento klaida"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP klientas nebeveikia"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Nepavyko paleisti bendrų ryšių tarnybos"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Bendrų ryšių tarnyba nebeveikia"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Nepavyko paleisti AutoIP tarnybos"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP tarnybos klaida"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP tarnyba nebeveikia"
+
+#~ msgid "Line busy"
+#~ msgstr "Linija užimta"
+
+#~ msgid "No dial tone"
+#~ msgstr "Nėra skambinimo tono"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Nepavyko nustatyti pernešėjo"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Baigėsi skambinimo užklausos laikas"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Nepavyko prisiskambinti"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Modemo iniciavimas nepavyko"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Nepavyko pasirinkti nurodytų APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Neieškoma tinklų"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Neleista registruoti tinklo"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Baigėsi tinklo registravimo laikas"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Nepavyko registruoti prašomo tinklo"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Nepavyko patikrinti PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Gali būti, kad įrenginiui trūksta aparatinės programinės įrangos"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Ryšys dingo"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Buvo panaudotas esamas ryšys"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modemas nerastas"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth ryšys nepavyko"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM kortelė neįdėta"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Reikalingas SIM Pin"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Reikalingas SIM Puk"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Neteisinga SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Nepavyko ryšio priklausomybė"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Trūksta aparatinės programinės įrangos"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabelis neįjungtas"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "nežinoma klaida 802.1x saugume (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "nepasirinktas failas"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "nežinoma klaida tikrinant eap-metodo failą"
+
+#~| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 arba PGP privatūs raktai"
+
+#~| msgid "_User certificate"
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER arba PEM liudijimai"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "trūksta EAP-FAST PAC failo"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC failai (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "trūksta EAP-LEAP naudotojo vardo"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "trūksta EAP-LEAP slaptažodžio"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "netinkamas EAP-PEAP LĮ liudijimas: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "netinkamas EAP-PEAP LĮ liudijimas: nenurodytas liudijimas"
+
+#~ msgid "missing EAP username"
+#~ msgstr "trūksta EAP naudotojo vardo"
+
+#~ msgid "missing EAP password"
+#~ msgstr "trūksta EAP slaptažodžio"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "trūksta EAP-TLS identiteto"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "netinkamas EAP-TLS LĮ liudijimas: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "netinkamas EAP-TLS LĮ liudijimas: nenurodytas liudijimas"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "netinkamas EAP-TLS privatus raktas: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "netinkamas EAP-TLS naudotojo liudijimas: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Nešifruoti privatūs raktai yra nesaugūs"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Pasirinktas privatus raktas nėra apsaugotas slaptažodžiu.  Tai gali "
+#~ "leisti pažeisti jūsų saugumo įgaliojimus.  Pasirinkite slaptažodžiu "
+#~ "apsaugotą privatų raktą.\n"
+#~ "\n"
+#~ "(Galite slaptažodžiu apsaugoti savo privatų raktą su openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Pasirinkite asmeninį liudijimą"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Pasirinkite privatų raktą"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "netinkamas EAP-TTLS LĮ liudijimas: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "netinkamas EAP-TTLS LĮ liudijimas: nenurodytas liudijimas"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Nežinoma klaida tikrinant 802.1x saugumą"
+
+#~ msgid "Select a file"
+#~ msgstr "Pasirinkite failą"
+
+#~ msgid "missing leap-username"
+#~ msgstr "trūksta leap naudotojo vardo"
+
+#~ msgid "missing leap-password"
+#~ msgstr "trūksta leap slaptažodžio"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Trūksta Wi-Fi slaptažodžio."
+
+#~ msgid "missing wep-key"
+#~ msgstr "trūksta wep rakto"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "netinkamas wep raktas: %zu ilgio raktas turi susidėti tik iš "
+#~ "šešioliktainių skaitmenų"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "netinkamas wep raktas: %zu ilgio raktas turi susidėti tik iš ascii "
+#~ "simbolių"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "netinkamas wep raktas: netinkamas rakto ilgis %zu. Raktus turi būti 5/13 "
+#~ "(ascii) arba 10/16 (šešioliktainis) ilgio"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "netinkamas wep raktas: slaptafrazė negali būti tuščia"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "netinkamas wep raktas: slaptafrazė turi būti trumpesnė nei 64 simboliai"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "netinkamas wpa-psk: netinkamas rakto ilgis %zu. Turi b8ti [8,63] baitai "
+#~ "arba 64 šešioliktainiai skaitmenys"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "netinkamas wpa-psk: negalima 64 baitų rakto interpretuoti kaip "
+#~ "šešioliktainio"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Kita"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s pašalinta"
+
+#~ msgid "Error removing account"
+#~ msgstr "Klaida šalinant paskyrą"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s paskyra"
+
+#~ msgid "Remove Account"
+#~ msgstr "Pašalinti paskyrą"
+
+#~ msgid "Unknown time"
+#~ msgstr "Nežinomas laikas"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s iki pilno įkrovimo"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Įspėjame: liko %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Liko %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Pilnai įkrautas"
+
+#~ msgid "Not charging"
+#~ msgstr "Nekraunamas"
+
+#~ msgid "Empty"
+#~ msgstr "Tuščia"
+
+#~ msgid "Charging"
+#~ msgstr "Įkraunama"
+
+#~ msgid "Discharging"
+#~ msgstr "Įšsikrauna"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Belaidė pelė"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Belaidė klaviatūra"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Nenutrūkstamos srovės šaltinis"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Asmeninis skaitmeninis pagalbininkas"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobilusis telefonas"
+
+#~ msgid "Media player"
+#~ msgstr "Daugialypės terpės grotuvas"
+
+#~ msgid "Tablet"
+#~ msgstr "Planšetė"
+
+#~ msgid "Computer"
+#~ msgstr "Kompiuteris"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Žaidimų įvesties įrenginys"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Pagrindinė"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Papildoma"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterijos"
+
+#~ msgid "When _idle"
+#~ msgstr "Kai la_isva"
+
+#~ msgid "Suspend"
+#~ msgstr "Pristabdyti"
+
+#~ msgid "Power Off"
+#~ msgstr "Išjungti"
+
+#~ msgid "Hibernate"
+#~ msgstr "Užmigdyti"
+
+#~ msgid "Nothing"
+#~ msgstr "Nieko"
+
+#~ msgid "When on battery power"
+#~ msgstr "Naudojant baterijos energiją"
+
+#~ msgid "When plugged in"
+#~ msgstr "Prijungus prie elektros tinklo"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Niekada"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatinis pristabdymas"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "Našumo veiksena laikinai išjungta dėl didelės temperatūros."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Aptikti keliai: našumo veiksena laikinai išjungta. Perkelkite įrenginį "
+#~ "ant stabilaus paviršiaus, jei norite atstatyti."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Našumo veiksena laikinai išjungta."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Senka baterija: našumo veiksena išjungta. Ankstesnė veiksena bus "
+#~ "atstatyta, kai baterija bus pakankamai įkrauta."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Energijos taupymo veikseną įjungė „%s“."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Našumo veikseną įjungė „%s“."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Našumas"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Dideli našumas ir energijos suvartojimas."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Balansuotas"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standartinis našumas ir energijos suvartojimas."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Energijos taupymas"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Sumažinti galia ir energijos suvartojimas"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Spausdintuvas „%s“ buvo ištrintas"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Nepavyko pridėti naujo spausdintuvo."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Nepavyko įkelti sąsajos: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Atrakinkite spausdintuvų pridėjimui bei nustatymų keitimui"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s informacija"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nerasta tinkama tvarkyklė"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Pasirinkite PPD failą"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript spausdintuvo aprašymo failai (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+#~ "gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect spausdintuvas"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD spausdintuvas"
+
+#~ msgid "One Sided"
+#~ msgstr "Viepusis"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Ilgos kraštinės (standartinis)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Trumpos kraštinės (apverstas)"
+
+#~ msgid "Portrait"
+#~ msgstr "Stačias"
+
+#~ msgid "Landscape"
+#~ msgstr "Gulsčias"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Apverstas gulsčias"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Apverstas stačias"
+
+#~ msgid "Resume"
+#~ msgstr "Tęsti"
+
+#~ msgid "Pause"
+#~ msgstr "Pristabdyti"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Laukia"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pristabdytas"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Reikia patvirtinti tapatybę"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Apdorojamas"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Sustabdytas"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Atšauktas"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Atmestas"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Baigtas"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Perkelti šį darbą į eilės pradžią"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s – aktyvūs darbai"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Įveskite savo naudotojo vardą ir slaptažodį spausdinimui iš %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Atrakinti spausdintuvo serverį"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Atrakinti %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Įveskite savo naudotojo vardą ir slaptažodį %s prieinamiems "
+#~ "spausdintuvams matyti."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Ieškoma spausdintuvų"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serijinis prievadas"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Lygiagretus prievadas"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Vieta: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresas: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Serveris reikalauja patvirtinti tapatybę"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dvipusis"
+
+#~ msgid "Paper Type"
+#~ msgstr "Popieriaus tipas"
+
+#~ msgid "Paper Source"
+#~ msgstr "Popieriaus šaltinis"
+
+#~ msgid "Output Tray"
+#~ msgstr "Išvestis dėklas"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Skiriamoji geba"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript pradinis filtravimas"
+
+#~ msgid "Pages per side"
+#~ msgstr "Puslapių vienoje pusėje"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientacija"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Bendri"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Puslapio nustatymai"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Įdiegiami parametrai"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Darbas"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Paveikslėlio kokybė"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Spalva"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Užbaigiama"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Sudėtingesni"
+
+#~ msgid "Test page"
+#~ msgstr "Bandomasis puslapis"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatiškai pasirinkti"
+
+#~ msgid "Printer Default"
+#~ msgstr "Spausdintuvo numatytieji"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Tik integruoti GhostScript šriftai"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Konvertuoti į PS lygmenį 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Konvertuoti į PS lygmenį 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Nėra pradinio filtravimo"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Išvalyti spausdinimo galvutes"
+
+#~ msgid "Out of toner"
+#~ msgstr "Baigiasi rašalas"
+
+#~ msgid "Low on developer"
+#~ msgstr "Baigiasi ryškalas"
+
+#~ msgid "Out of developer"
+#~ msgstr "Baigėsi ryškalas"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Baigiasi spalvos tiekimas"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Baigėsi spalvos tiekimas"
+
+#~ msgid "Open cover"
+#~ msgstr "Atvertas dangtis"
+
+#~ msgid "Open door"
+#~ msgstr "Atvertos durys"
+
+#~ msgid "Low on paper"
+#~ msgstr "Baigiasi popierius"
+
+#~ msgid "Out of paper"
+#~ msgstr "Baigėsi popierius"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Išjungta"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Sustabdytas"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Atliekų konteineris beveik pilnas"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Atliekų konteineris pilnas"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Optinio fotokonduktoriaus tarnavimo laikas baigiasi"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Optinis fotokonduktorius nebeveikia"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Pasirengęs"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Nepriima darbų"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Apdorojama"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperinė"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrinė"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Klausti, ką daryti"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nieko nedaryti"
+
+#~ msgid "Open folder"
+#~ msgstr "Atverti aplanką"
+
+#~ msgid "Other Media"
+#~ msgstr "Kitos laikmenos"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Parinkite programą, kuria norėtumėte klausytis garso CD"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Parinkite programą vaizdo DVD rodymui"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Pasirinkite paleistiną programą, kai muzikos grotuvas prijungiamas"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Pasirinkite paleistiną programą, kai prijungiamas fotoaparatas"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Parinkite programą programinės įrangos CD paleidimui"
+
+#~ msgid "audio DVD"
+#~ msgstr "garso DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "tuščias Blu-ray diskas"
+
+#~ msgid "blank CD disc"
+#~ msgstr "tuščias CD diskas"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "tuščias DVD diskas"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "tuščias HD DVD diskas"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray vaizdo diskas"
+
+#~ msgid "e-book reader"
+#~ msgstr "el. knygų skaitytuvas"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD vaizdo diskas"
+
+#~ msgid "Picture CD"
+#~ msgstr "Paveikslėlių CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super vaizdo CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Vaizdo CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Ekranas išsijungia"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekundžių"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minutė"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutės"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutės"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutės"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minučių"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 valanda"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minutė"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutės"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutės"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutės"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutės"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutės"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minučių"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minučių"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minučių"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Niekada"
+
+#~ msgid "Select Location"
+#~ msgstr "Pasirinkite vietą"
+
+#~ msgid "_OK"
+#~ msgstr "_Gerai"
+
+#~ msgid "No applications found"
+#~ msgstr "Nerasta programų"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nėra pasirinktų bendrinimui tinklų"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Įjungta"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Išjungta"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Įjungta"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktyvūs"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Pasirinkite aplanką"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Įjungti dalinimąsi daugialype terpe"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Dalinimasis asmeniniais failais leidžia bendrinti viešą aplanką su kitais "
+#~ "esamame tinkle naudojant: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kai leidžiama prisijungti nuotoliniu būdu, nutolę naudotojai gali "
+#~ "prisijungti naudodami saugaus apvalkalo komandą:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Įjungti dalinimąsi asmeniniais failais"
+
+#~ msgid "Device name copied"
+#~ msgstr "Įrenginio pavadinimas nukopijuotas"
+
+#~ msgid "Device address copied"
+#~ msgstr "Įrenginio adresas nukopijuotas"
+
+#~ msgid "Username copied"
+#~ msgstr "Naudotojo vardas nukopijuotas"
+
+#~ msgid "Password copied"
+#~ msgstr "Slaptažodis nukopijuotas"
+
+#~ msgid "Custom"
+#~ msgstr "Pasirinktinė"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Testuojamas %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Atsijungta"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Jungiamasi"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Prisijungta"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Autorizacijos klaida"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autorizuojama"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Sumažintas funkcionalumas"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Prisijungta ir autorizuota"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Nežinoma"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorizuota adresu:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Prisijungta adresu:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Įtraukta adresu:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Nepavyko autorizuoti įrenginio:"
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Nepavyko pamiršti įrenginio:"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Klaida"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorizuota"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr "Thunderbolt posistemė (boltd) neįdiegta arba nenustatyta teisingai."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Galima prijungti tik USB ir Display Port įrenginius."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Nepavyko aptikti Thunderbolt.\n"
+#~ "Sistemai trūksta Thunderbolt palaikymo, ji buvo BIOS sistemoje išjungta "
+#~ "arba nustatyta į nepalaikomą saugumo lygį."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt palaikymas buvo išjungtas BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Nepavyko nustatyti Thunderbolt saugumo lygio."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Klaida persijungians į tiesioginę veikseną: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Numatytasis"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Vidutinis"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Didelis"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Didesnis"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Didžiausias"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pikselis"
+#~ msgstr[1] "%d pikseliai"
+#~ msgstr[2] "%d pikselių"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Trumpas"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ekrano"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ekrano"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ekrano"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Ilgas"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 valanda"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 diena"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dienos"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dienos"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dienos"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dienos"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dienos"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dienos"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dienų"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dienos"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Išvalyti visus elementus iš šiukšlinės?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Visi šiukšlinės elementai bus negrįžtamai ištrinti."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Iš_valyti šiukšlinę"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Ištrinti visus laikinuosius failus?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Visi laikinieji failai bus negrįžtamai ištrinti."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Išvalyti laikinuosius _failus"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 diena"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dienos"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dienos"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Visam laikui"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Turi atitikti jūsų paskyros teikėjo žiniatinklio adresą."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Nepavyko pridėti Pasirinkite paskyros"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Nepavyko priregistruoti paskyros"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nėra palaikomo būdo patvirtinti tapatybę šiame serveryje"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Nepavyko prisijungti prie srities"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Šis prisijungimo vardas nesuveikė.\n"
+#~ "Bandykite dar kartą."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Šis prisijungimo slaptažodis nesuveikė.\n"
+#~ "Bandykite dar kartą."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Nepavyko prisijungti prie srities"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Nepavyksta rasti domeno. Gal suklydote?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Naršyti daugiau paveikslėlių"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "reikia užimti įrenginį, norint atlikti šį veiksmą"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "įrenginį jau užėmė kitas procesas"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "neturite leidimo įvykdyti veiksmą"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "atspaudai nebuvo įvesti"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Nepavyko susisiekti su įrenginiu įvedimo metu"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Nepavyko susisiekti su pirštų atspaudų skaitykle"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Nepavyko susisiekti su pirštų atspaudų tarnyba"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Nepavyko išvardinti pirštų atspaudų: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Nepavyko ištrinti įrašytų pirštų atspaudų: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Kairysis smilius"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Kairysis didysis pirštas"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Kairysis smilius"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Kairysis bevardis pirštas"
+
+#~ msgid "Left little finger"
+#~ msgstr "Kairysis mažasis pirštas"
+
+#~ msgid "Right thumb"
+#~ msgstr "Dešinysis nykštys"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Dešinysis didysis pirštas"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Dešinysis smilius"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Dešinysis bevardis pirštas"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dešinysis mažasis pirštas"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Nežinomas pirštas"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Atlikta"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Pirštų atspaudų skaitytuvas atsijungė"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Pirštų atspaudų skaitytuvo saugykla yra pilna"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Nepavyko įtraukti naujo piršto atspaudo"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Nepavyko pradėti įtraukimo: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Nepavyko įtraukti naujo piršto atspaudo"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Nepavyko sustabdyti įtraukimo: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Pakartotinai atitraukite ir uždėkite savo pirštą ant skaitytuvo piršto "
+#~ "atspaudui įtraukti"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Iš _naujo įtraukti šį pirštą…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Nuskaityti naują piršto atspaudą"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Nepavyko atlaisvinti pirštų atspaudų skaitytuvo %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problema skaitant įrenginį"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Nepavyko perimti pirštų atspaudų skaitytuvo %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Nepavyko gauti pirštų atspaudų įrenginių: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Ši savaitė"
+
+#~ msgid "Last Week"
+#~ msgstr "Preitą savaitę"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y %B %e"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Seansas įjungtas"
+
+#~ msgid "Session Started"
+#~ msgstr "Seansas paleistas"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s – paskyros aktyvumas"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Pasirinkite kitą slaptažodį."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Įveskite savo slaptažodį dar kartą."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Nepavyko pakeisti slaptažodžio"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Nepavyksta automatiškai prisijungti prie šio tipo domeno"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nėra tokios srities"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Nepavyko prisijungti kaip %s srityje %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Netinkamas slaptažodis, bandykite dar kartą"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Nepavyko prisijungti prie %s srities: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Nepavyko ištrinti naudotojo"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Nepavyko atimti teisių iš nutolusio naudotojo"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Jūs negalite ištrinti savo paskyros."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s vis dar prisijungęs"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Naudotojų ištrynimas, kai jie yra prisijungę, gali palikti sistemą "
+#~ "nekorektiškoje būsenoje."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Ar norite palikti naudotojo %s failus?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Trinant naudotoją galima palikti namų katalogą, paštą ir laikinus failus."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Ištrinti failus"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Palikti failus"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Ar tikrai norite atimti teises iš nuotoliniu būdu tvarkomos paskyros %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Ištrinti"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Paskyra išjungta"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Bus nustatyta kito prisijungimo metu"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Joks"
+
+#~ msgid "Logged in"
+#~ msgstr "Prisijunges prie"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Nepavyko susisiekti su paskyrų tarnyba"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Įsitikinkite, kad AccountService yra įdiegta ir įjungta."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Šis skydelis turi būti atrakintas, norint keisti šią nuostatą"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Ištrinti pasirinktą naudotoją"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pasirinktam naudotojui ištrinti,\n"
+#~ "pirma paspauskite * piktogramą"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Atrakinkite naudotojų pridėjimui bei nustatymų keitimui"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Naujas slaptažodis turi skirtis nuo senojo."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Bandykite raides ir skaitmenis."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Mėginkite labiau pakeisti slaptažodį."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Slaptažodis be naudotojo vardą būtų saugesnis."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Venkite savo vardo slaptažodyje."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Venkite kai kurių į slaptažodį įtrauktų žodžių."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Venkite dažnų žodžių."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Venkite esamų žodžių tvarkos keitimo."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Mėginkite naudoti daugiau skaitmenų."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Mėginkite naudoti daugiau didžiųjų raidžių."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Mėginkite naudoti daugiau mažųjų raidžių."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Mėginkite naudoti daugiau specialiųjų simbolių, pvz. skyrybos ženklų."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Mėginkite naudoti raidžių, skaitmenų ir skyrybos ženklų mišinį."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Venkite to paties simbolio pasikartojimų."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Venkite to paties simbolio pasikartojimų: reikia maišyti raides, "
+#~ "skaitmenis ir skyrybos ženklus."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Venkite sekų 1234, abcd ir pan."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Slaptažodis per trumpas. Mėginkite pridėti daugiau raidžių, skaitmenų ir "
+#~ "skyrybos ženklų mišinį."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Maišykite didžiąsias ir mažąsias raides bei panaudokite skaitmenų."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Pridėję raidžių, skaitmenų ir skyrybos ženklų  padarytumėt jį dar "
+#~ "stipresnį."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Tapatybė nepatvirtinta"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Naujas slaptažodis per trumpas"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Naujas slaptažodis per paprastas"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Senas ir naujas slaptažodžiai yra per daug panašūs"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Naujas slaptažodis neseniai jau buvo naudotas."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Naujas slaptažodis turi susidėti iš skaičių arba specialių simbolių"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Senas ir naujas slaptažodžiai sutampa"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Jūsų slaptažodis pakeistas nuo pradinio Jūsų tapatybės atpažinimo!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Naujas slaptažodis Nesusideda iš pakankamai skirtingų simbolių"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Nežinoma klaida"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Naudotojo vardą gali sudaryti tik raidės mažosios raidės a-z, skaitmenys "
+#~ "ir šie simboliai: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Atleiskite, šis naudotojo vardas yra neprieinamas. Bandykite kitą."
+
+#~ msgid "The username is too long."
+#~ msgstr "Naudotojo vardas per ilgas."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Mygtukas %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Programos nustatytas"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Siųsti klavišų seką"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Perjungti monitorių"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Rodyti pagalbą ekrane"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Planšetė prijungta ant nešiojamojo kompiuterio skydelio"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Planšetė, prijungta prie išorinio vaizduoklio"
+
+#~ msgid "External tablet device"
+#~ msgstr "Išorinis planšetinis įrenginys"
+
+#~ msgid "All Displays"
+#~ msgstr "Visi vaizduokliai"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Orinis pieštukas yra spaudimo jėga, palenkimu ir integruotu slankikliu"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Orinis pieštukas yra spaudimo jėga, palenkimu ir posūkiu"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standartinis pieštukas su spaudimo jėga ir palenkimu"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standartinis pieštukas su spaudimo jėga"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Naujas trumpinys…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Veiksmo atsisakyta"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Klaida:</b> prieiga neleista keičiant nuostatas"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Klaida:</b> mobiliosios įrangos klaida"
+
+#~ msgid "Not Registered"
+#~ msgstr "Neregistruota"
+
+#~ msgid "Registered"
+#~ msgstr "Registruota"
+
+#~ msgid "Roaming"
+#~ msgstr "Tarptinklinis"
+
+#~ msgid "Searching"
+#~ msgstr "Ieškoma"
+
+#~ msgid "Denied"
+#~ msgstr "Neleista"
+
+#~ msgid "2G Only"
+#~ msgstr "tik 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "tik 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "tik 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "tik 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (pageidautina)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (pageidautina), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (pageidautina), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (pageidautina), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (pageidautina)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (pageidautina), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (pageidautina), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (pageidautina)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (pageidautina), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (pageidautina), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (pageidautina)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (pageidautina), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (pageidautina), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (pageidautina)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (pageidautina), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (pageidautina), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (pageidautina)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (pageidautina), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (pageidautina)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (pageidautina), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (pageidautina)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (pageidautina), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (pageidautina)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (pageidautina), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (pageidautina)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (pageidautina), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (pageidautina)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (pageidautina), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Nežinoma"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Atrakinti SIM kortelę"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Pateikite PIN kodą SIM kortelei %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Įveskite PIN SIM kortelei atrakinti"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Pateikite PUK kodą SIM kortelei %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Įveskite PUK kodą SIM kortelei atrakinti"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Įvestas blogas slaptažodis."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK kodas turi būti 8 skaitmenų skaičius"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Įveskite naują PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN kodas turi būti 4-8 skaitmenų skaičius"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Atrakinama…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Telefono klaida"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Nėra ryšio su telefonu"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Veiksmas neleidžiamas"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Veiksmas nepalaikomas"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM neįdėta"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Reikalingas SIM PIN"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Reikalingas SIM PUK"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM klaida"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM užimta"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Neteisingas slaptažodis"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Reikalingas SIM PIN2"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Reikalingas SIM PUK2"
+
+#~ msgid "Not found"
+#~ msgstr "Nerasta"
+
+#~ msgid "No network service"
+#~ msgstr "Nėra tinklo tarnybos"
+
+#~ msgid "Network timeout"
+#~ msgstr "Baigėsi tinklo laikas"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS tarnyba neleidžiama"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Tarptinklinis ryšys šioje vietovėje neleidžiamas"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Nenurodyta GPRS klaida"
+
+#~ msgid "No Error"
+#~ msgstr "Nėra klaidos"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Veiksmo atsisakyta"
+
+#~ msgid "Access denied"
+#~ msgstr "Prieiga neleidžiama"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Nežinoma klaida"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Rodyti versijos numerį"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Įjungti derinimo veikseną"
+
+#~ msgid "Search for the string"
+#~ msgstr "Ieškoti eilutės"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Išvardinti galimus skydelių pavadinimus ir išeiti"
+
+#~ msgid "Panel to display"
+#~ msgstr "Rodomas skydelis"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[SKYDELIS] [ARGUMENTAS…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Prieinami skydeliai:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sistemos garsai"
 
 #~| msgid "Take a screenshot of a window"
 #~ msgid "Take screenshots of the desktop."
@@ -9608,9 +8303,6 @@ msgstr "Sistemos garsai"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER arba PEM liudijimai (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Pridėti spausdintuvą…"
 
 #~ msgid "Drip"
 #~ msgstr "Lašėjimas"
@@ -10073,9 +8765,6 @@ msgstr "Sistemos garsai"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Planšetė (absoliučioji)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Jutiklinis kilimėlis (santykinis)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Piešimo planšetės nuostatos"
 
@@ -10342,9 +9031,6 @@ msgstr "Sistemos garsai"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Tiesiogiai pasiekti bluetooth aparatūrą"
-
-#~ msgid "Use your camera"
-#~ msgstr "Naudoti jūsų kamerą"
 
 #~ msgid "Print documents"
 #~ msgstr "Spausdinti dokumentus"
@@ -11232,9 +9918,6 @@ msgstr "Sistemos garsai"
 #~ msgid "Mirrored"
 #~ msgstr "Dubliuoti"
 
-#~ msgid "Secondary"
-#~ msgstr "Antrinis"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Išdėstyti vaizduoklius"
 
@@ -11309,9 +9992,6 @@ msgstr "Sistemos garsai"
 #~ msgctxt "proxy method"
 #~ msgid "Automatic"
 #~ msgstr "Automatinis"
-
-#~ msgid "_Method"
-#~ msgstr "_Metodas"
 
 #~ msgid "Group Name"
 #~ msgstr "Grupės pavadinimas"
@@ -11424,9 +10104,6 @@ msgstr "Sistemos garsai"
 
 #~ msgid "Mail"
 #~ msgstr "Paštas"
-
-#~ msgid "Calendar"
-#~ msgstr "Kalendorius"
 
 #~ msgid "Contacts"
 #~ msgstr "Kontaktai"
@@ -11556,9 +10233,6 @@ msgstr "Sistemos garsai"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Slinkimas aukštyn"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Slinkimas žemyn"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Slinkimas dešinėn"
@@ -11860,9 +10534,6 @@ msgstr "Sistemos garsai"
 
 #~ msgid "China"
 #~ msgstr "Kinija"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Spausdinimo _metu išjungti"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "Sistemos tinklo tarnybos nesuderinamos su šia versija."

--- a/po/lt.po~
+++ b/po/lt.po~
@@ -1,0 +1,11888 @@
+# Translation of gnome-control-center.HEAD.lt.po to Lithuanian
+# Lithuanian translation of gnome-control-center
+# Copyright (C) 2000-2009 Free Software Foundation, Inc.
+# Gediminas Paulauskas <menesis@chatsubo.lt>, 2000-2002.
+# Vaidotas Zemlys <mpiktas@delfi.lt>, 2003.
+# Justina Klingaitė <justina.klingaite@gmail.com>, 2005.
+# Žygimantas Beručka <zygis@gnome.org>, 2003-2007, 2009, 2010, 2012.
+# Gintautas Miliauskas <gintas@akl.lt>, 2006, 2007.
+# Vytautas Liuolia <vytautas.liuolia@gmail.com>, 2008.
+# Mantas Kriaučiūnas <mantas@akl.lt>, 2011.
+# Algimantas Margevičius <margevicius.algimantas@gmail.com>, 2011.
+# Aurimas Černius <aurisc4@gmail.com>, 2010-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-05 18:05+0000\n"
+"PO-Revision-Date: 2022-09-05 22:41+0300\n"
+"Last-Translator: Aurimas Černius <aurisc4@gmail.com>\n"
+"Language-Team: Lietuvių <gnome-lt@lists.akl.lt>\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2)\n"
+"X-Generator: Gtranslator 40.0\n"
+"X-Poedit-SourceCharset: utf-8\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Sisteminė magistralė"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Pilna prieiga"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Seanso magistralė"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Įrenginiai"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Pilna prieiga prie /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Tinklas"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Turi tinklo prieigą"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Namų aplankas"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Tik skaitymui"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Failų sistema"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Nustatymai"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Gali keisti nustatymus"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s turi šiuo integruotus leidimus. Jų negalima keisti. Jei turite abejonių "
+"dėl šių leidimų, pagalvokite apie programos pašalinimą."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u failų ir saitų tipas, kuris atveriamas programos"
+msgstr[1] "%u failų ir saitų tipai, kurie atveriamas programos"
+msgstr[2] "%u failų ir saitų tipų, kurie atveriamas programos"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> yra naudojama atverti šio tipo failus bei saitus."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "Naudojama %s disko vietos."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Programos"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Nerasta programų"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Įdiegti…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Atverti"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Išsamiau"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Paieška"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Gauti sistemos paieškas bei siųsti rezultatus."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Išjungta"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Pranešimai"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Rodyti sistemos pranešimus."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Vykdyti fone"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Leisti veiklą, kai programa yra užverta."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Ekrano nuotraukos"
+
+#: panels/applications/cc-applications-panel.ui:141
+#| msgid "Take pictures with the camera."
+msgid "Take pictures of the screen at any time."
+msgstr "Fotografuokite ekraną bet kuriuo metu."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Keisti foną"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Keisti darbastalio foną."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Garsai"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Atkurti garsus."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Nustatyti trumpinius"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Neleisti sisteminių klaviatūros trumpinių."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Fotografuoti naudojant kamerą."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofonas"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Įrašyti garsą mikrofonu."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Vietos tarnybos"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Pasiekti jūsų buvimo vietos informaciją."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Integruoti leidimai"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Sistemos prieiga, kurios reikia šiai programai"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Failų bei saitų susiejimai"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Saugykla"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Nerasta rezultatų"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Bandykite kitą paiešką"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Failų bei saitų susiejimai"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Failų tipai"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Saitų tipai"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Atstatyti"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Kiek disko vietos užima šį programa su programos duomenimis bei podėliu."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Programa"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Duomenys"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Podėlis"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Iš viso</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Išvalyti podėlį…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Valdyti įvairius programos leidimus bei nustatymus"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "programa;flatpak;leidimas;nustatymas;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Pasirinkite paveikslėlį"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Atsisakyti"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Atverti"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "keli dydžiai"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Nėra darbalaukio fono"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Dabartinis fonas"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stilius"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Numatytasis"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Tamsus"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Fonas"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Pridėti paveikslėlį…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Išvaizda"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Pakeiskite fono paveikslėlį arba sąsajos spalvas"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Fonas;Ekranas;Darbastalis;Darbalaukis;Stilius;Šviesus;Tamsus;Išvaizda;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Įjungti"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Nėra Bluetooth adapterių"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Įkiškite Bluetooth prietaisą"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth išjungtas"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Įjunkite prisijungimui prie įrenginių ir siunčiamų failų gavimui."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Skrydžio veiksena įjungta"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth yra išjungtas skrydžio veiksenoje."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Išjungti skrydžio veikseną"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Aparatinė skrydžio veiksena yra įjungta"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Išjunkite skrydžio veiksenos jungiklį Bluetooth įjungimui."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Įjunkite arba išjunkite Bluetooth ir junkitės prie savo įrenginių"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "dalinimasis;dalytis;bendrinti;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera išjungta"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Jokia programa negali daryti nuotraukų ar įrašinėti vaizdo įrašų."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Kameros naudojimas leidžia programoms daryti nuotraukas bei vaizdo įrašus. "
+"Kameros išjungimas gali sutrukdyti kai kurioms programoms teisingai veikti.\n"
+"\n"
+"Leisti žemiau esančioms programoms naudoti kamerą."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Jokia programa neprašė prieigos prie kameros"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Apsaugokite savo paveikslėlius"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "kamera;fotoaparatas;vaizdo;įrašas;užrakinti;privatus;privatumas;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Pridėkite kalibravimo įrenginį prie stačiakampio ir spauskite „Pradėti“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Perkelkite kalibravimo įrenginį į kalibravimo padėtį ir spauskite „Tęsti“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Perkelkite kalibravimo įrenginį prie paviršiaus ir spauskite „Tęsti“"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Užverkite nešiojamą kompiuterį"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Įvyko vidinė klaida, kurios negalima atstatyti."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Kalibravimui reikalingi įrankiai nėra įdiegti."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Nepavyko sugeneruoti profilio."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Nepavyko gauti tikslo balto taško."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Atlikta!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibracija nepavyko!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Galite pašalinti kalibravimo įrenginį."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Nelieskite kalibravimo įrenginio kol vykdoma"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Ekrano kalibravimas"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Pradėti"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Tęsti"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Atlikta"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Nešiojamo kompiuterio ekranas"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Vidinį kamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s monitorius"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s skaityklė"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s kamera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s spausdintuvas"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s internetinė kamera"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Įjungti %s spalvų tvarkymą"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Rodyti %s spalvų profilius"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Nekalibruotas"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Numatytasis: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Spalvų erdvė:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Bandomasis profilis: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Pasirinkite ICC profilio failą"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importuoti"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Palaikomi ICC profiliai"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Visi failai"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekranas"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Įrašyti profilį"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "Į_rašyti"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Sukurti spalvų profilį pasirinktam įrenginiui"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Matavimo prietaisas neaptiktas. Patikrinkite, ar jis įjungtas ir teisingai "
+"prijungtas."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Matavimo prietaisas nepalaiko spausdintuvo profiliavimo."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Įrenginio tipas šiuo metu nepalaikomas."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Ekrano kalibravimas"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibravimo kokybė"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibracija sukurs profilį, kurį galėsite naudoti ekrano spalvoms tvarkyti. "
+"Kuo ilgiau kalibruosite, tuo geresnė bus profilio kokybė."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Negalėsite naudotis kompiuteriu, kol vyks kalibravimas."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kokybė"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Apytikslis laikas"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibravimo įrenginys"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Pasirinkite kalibravimui naudojamą sensorinį įrenginį."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Ekrano (vaizduoklio) tipas"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Pasirinkite prijungto ekrano tipą."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profilio baltasis taškas"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Pasirinkite vaizduoklio baltąjį tašką. Dauguma vaizduoklių turi būti "
+"kalibruoti D65 apšvietimui."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Ekrano šviesumas"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Nustatykite jums įprastą ekrano šviesumą. Spalvų tvarkymas bus tiksliausias "
+"šiam šviesumo lygiui."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Taip pat galite naudoti šviesumo lygį, naudotą su kuriuo nors kitu šio "
+"įrenginio profiliu."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profilio pavadinimas"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Galite naudoti spalvų profilį skirtinguose kompiuteriuose ar net sukurti "
+"profilius skirtingoms apšvietimo sąlygoms."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profilio pavadinimas:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Santrauka"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profilis sėkmingai sukurtas!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopijuoti profilį"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Reikalauja įrašomos laikmenos"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Gali būti naudingos instrukcijos, kaip naudoti profilį <a href=\"linux\">GNU/"
+"Linux</a>, <a href=\"osx\">Apple OS X</a> ar <a href=\"windows\">Microsoft "
+"Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Pridėti profilį"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Aptikta problemų. Profilis gali gerai neveikti. <a href=\"\">Rodyti detales."
+"</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importuoti failą..."
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Pridėti"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Spalvų derinimui reikia pakankamai naujo spalvų profilio kiekvienam "
+"įrenginiui."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Sužinoti daugiau"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Sužinokite daugiau apie spalvų derinimą"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Nu_statyti visiems naudotojams"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Nustatyti šį profilį visiems šio kompiuterio naudotojams"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "Į_jungti"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Pridėti profilį"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibruoti..."
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibruoti įrenginį"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Paša_linti profilį"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Išsamiau"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Nepavyko aptikti įrenginių spalvų tvarkymui"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektorius"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plazminis monitorius"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL apšvietimas)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED apšvietimas)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (balta LED apšvietimas)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Didelės raškos LCD (CCFL apšvietimas)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Didelės raiškos LCD (RGB LED apšvietimas)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Aukšta"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minučių"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Vidutinė"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minučių"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Žema"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minučių"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Įprastas ekranui"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (spausdinimas ir pateikimas)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografija ir grafika)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standartinė sritis"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Bandomasis profilis"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatinis"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Žemos kokybės"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Vidutinės kokybės"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Aukštos kokybės"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Numatytasis RŽM"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Numatytasis PRGJ"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Numatytasis pilkas"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Tiekėjo pateikti gamykliniai kalibravimo duomenys"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Su šiuo profiliu negalima viso ekrano korekcija"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Šis profilis gali nebebūti tikslus."
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Spalva"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Kalibruokite savo įrenginių, tokių kaip ekranai, vaizduokliai, kameros ar "
+"spausdintuvai, spalvas"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Spalva;ICC;Profilis;Kalibravimas;Spausdintuvas;Ekranas;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Kitas..."
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Pasirinkite kalbą"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "Pa_sirinkti"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nerasta kalbų"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Daugiau…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Atrakinkite nustatymams keisti"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Kai kuriuos nustatymus reikia atrakinti, tik tada galima keisti."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "_Atrakinti…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Padidinti valandą"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Padidinti minutę"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Laikas"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Sumažinti valandą"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Sumažinti minutę"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "šiandien"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Vakar"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%Y %B %e"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d valanda"
+msgstr[1] "%d valandos"
+msgstr[2] "%d valandų"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minutė"
+msgstr[1] "%d minutės"
+msgstr[2] "%d minučių"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekundę"
+msgstr[1] "%d sekundes"
+msgstr[2] "%d sekundžių"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekundžių"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Prieigos tašką"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 val."
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "Diena / Naktis"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%Y %B %d, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%Y %B %d, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data ir laikas"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Metai"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mėnuo"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Sausis"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Vasaris"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Kovas"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Balandis"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Gegužė"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Birželis"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Liepa"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Rugpjūtis"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Rugsėjis"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Spalis"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Lapkritis"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Gruodis"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Diena"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Laiko juosta"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Ieškoti miesto"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatinė _data ir laikas"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Reikalauja interneto ryšio"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Da_ta ir laikas"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automatinė laiko _juosta"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Reikalauja vietos tarnybų bei interneto ryšio"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Įjungta"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Laiko ju_osta"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Laiko _formatas"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Keiskite datą ir laiką, įskaitant laiko juostą"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Laikrodis;Laiko juosta;Vietovė;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Keiskite sistemos laiko ir datos nustatymus"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Datos ir laiko nustatymams pakeisti reikia patvirtinti tapatybę."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Žiniatinklis"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Paštas"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalendorius"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_uzika"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Vaizdas"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Nuotraukos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Numatytosios programos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Konfigūruoti numatytąsias programas"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "numatytoji;programa;pageidaujama;laikmena;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Pranešimų apie technines problemas siuntimas mums padeda pagerinti %s. "
+"Pranešimai yra siunčiami anonimiškai, o asmeniniai duomenys yra išdarkomi. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Pranešimas apie problemas"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatinis pranešimas apie problemas"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostika"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Pranešti apie jūsų problemas"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostika;lūžimas;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Įjungta"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Išjungta"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Pritaikyti pakeitimus?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Pakeitimų negalima pritaikyti"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Taip gali būti dėl aparatinės įrangos apribojimų."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Pritaikyti"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Atgal"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Vaizduoklio nuostatos išjungtos"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Daugelis vaizduoklių"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Sujungti"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Veidrodis"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Turi viršutinę juostą bei veiklas"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Pagrindinis ekranas"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Naktinis apšvietimas"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Gulsčias"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Stačias į dešinę"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Stačias į kairę"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Gulsčias (apverstas)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientacija"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Skiriamoji geba"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Atnaujinimo dažnis"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Derinti televizoriui"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Mastelis"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Naktinis apšvietimas neprieinamas"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Taip gali būti dėl naudojamos grafikos tvarkyklės arba darbalaukis "
+"naudojamas nuotoliniu būdu"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Laikinai išjungtas iki rytojaus"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Perleisti filtrą iš naujo"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Naktinis apšvietimas padaro ekrano spalvas šiltesnėmis. Tai mažiau apkrauna "
+"akis ir mažina nemigą."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Tvarkaraštis"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Nuo saulėlydžio iki saulėtekio"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Pasirinktinis tvarkaraštis"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Laikai"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Nuo"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Valanda"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minutė"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Iki"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Spalvos temperatūra"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ekranai"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Pasirinkite, kaip naudoti prijungtus monitorius ir projektorius"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Skydelis;Projektorius;xrandr;Ekranas;Raiška;Atnaujinimas;Monitorius;Naktinis;"
+"Apšvietimas;rausvumas;spalva;saulėtekis;saulėlydis;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Saugus paleidimas yra aktyvus"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
+"kai įrenginys paleidžiamas. Jis yra įjungtas ir veikia tinkamai."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Yra problemų su saugiu paleidimu"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
+"kai įrenginys paleidžiamas. Jis yra įjungtas, bet neveiks dėl netinkamo "
+"rakto."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Saugau paleidimo problemas dažnai galima išspręsti jūsų kompiuterio UEFI "
+"nuostatose (BIOS), o jūsų aparatinės įrangos gamintojas gali pateikti "
+"informacijos, kaip tą padaryti."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Jei reikia pagalbos, kreipkitės į savo aparatinės įrangos gamintoją ar IT "
+"pagalbos centrą."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Saugus paleidimas yra išjungtas"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
+"kai įrenginys paleidžiamas. Jis šiuo metu išjungtas."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Saugų paleidimą galima įjungti kompiuterio UEFI nuostatose (BIOS). Jei "
+"reikia pagalbos, kreipkitės į gamintoją ar IT pagalbos centrą."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Saugus paleidimas neleidžia kenksmingai programinei įrangai būti įkeltai, "
+"kai įrenginys paleidžiamas.\n"
+"\n"
+"Daugiau informacijos gausite susisiekę su aparatinės įrangos gamintoju ar "
+"pagalba."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Pavyko"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Nepavyko"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Įrenginys patvirtina HSI lygį %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Saugumo lygis 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Šis įrenginys neturi apsaugos nuo aparatinių saugumo problemų. Taip gali "
+"būti dėl aparatūros arba aparatinės programinės įrangos konfigūracijos "
+"problemos. Rekomenduojama susisiekti su pagalbos tarnyba."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Saugumo lygis 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Šis įrenginys turi minimalią apsaugą nuo aparatinių saugumo problemų. Tai "
+"yra žemiausias saugumo lygis ir apsaugo tik nuo paprasčiausių pavojų."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Saugumo lygis 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Šis įrenginys turi bazinę apsaugą nuo aparatinių saugumo problemų. Tai "
+"apsaugo nuo kai kurių dažnų saugumo pavojų."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Saugumo lygis 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Šis įrenginys turi išplėstinę apsaugą nuo aparatinių saugumo problemų. Tai "
+"yra aukščiausias saugumo lygis ir apsaugo nuo sudėtingų saugumo pavojų."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Saugumo lygis"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Šiam įrenginiui nėra saugumo lygių."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Susisiekite su gamintoju, jei reikia pagalbos su saugumo atnaujinimais."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Gali būti galima išspręsti šią problemą įrenginio UEFI nuostatose arba "
+"susisiekus su technine pagalba."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "Gali būti galima išspręsti šią problemą įrenginio UEFI nuostatose."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+"Gali būti galima išspręsti šią problemą susisiekus su technine pagalba."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Lygis 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Lygis 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Lygis 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Apsaugota nuo kenksmingos programinės įrangos paleidžiant įrenginį."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Yra problemų su saugiu paleidimu"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Dalinė apsauga kai įrenginys paleidžiamas."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Saugus paleidimas yra išjungtas"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Nėra apsaugos kai įrenginys paleidžiamas."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Šią problemą galėjo sukelti UEFI nuostatų pakeitimas, operacinės sistemos "
+"pakeitimas arba kenksminga programinė įranga šioje sistemoje."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Šią problemą galėjo sukelti UEFI nuostatų pakeitimas arba kenksminga "
+"programinė įranga šioje sistemoje."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Šią problemą galėjo sukelti operacinės sistemos pakeitimas arba kenksminga "
+"programinė įranga šioje sistemoje."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Dideli saugumo pavojai.."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Ribota apsauga nuo paprastų saugumo pavojų."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Apsaugota nuo dažnų saugumo pavojų."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Apsaugota nuo daugelio saugumo pavojų."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Sudėtinga apsauga"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Nėra įvykių"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Aparatinės programinės įrangos rašymo apsauga"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Aparatinės programinės įrangos rašymo apsaugos užraktas"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Aparatinės programinės įrangos BIOS regionas"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Aparatinės programinės įrangos BIOS deskriptorius"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "DMA apsauga prieš paleidimą"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard tikrinamas paleidimas"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM apsauga"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard klaidų politika"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard saugiklis"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET įjungta"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET aktyvi"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Šifruota atmintis"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU apsauga"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux branduolio užrakinimas"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux branduolio tikrinimas"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux mainų sritis"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Pristabdyti atmintyje"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Pristabdyti į neveiksnumą"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI platformos raktas"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI saugus paleidimas"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM platformos konfigūracija"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM rekonstrukcija"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel valdymo variklio gamybinė veiksena"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel valdymo variklio pakeitimas"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel valdymo variklio versija"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Aparatinės programinės įrangos atnaujinimai"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Aparatinės programinės įrangos atestacija"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Aparatinės programinės įrangos tikrinimas"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Platformos derinimas"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Procesoriaus saugumo patikros"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD atstatymo apsauga"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD aparatinės programinės įrangos pakartojimo apsauga"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD aparatinės programinės įrangos rašymo apsauga"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Saugiklio platforma"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Tinkamas"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Netinkamas"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Išjungta"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Užrakinta"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Neužrakinta"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Šifruota"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Nešifruota"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Suteptas"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Nesuteptas"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Rasta"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Nerasta"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Palaikoma"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Palaikoma"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Įrenginio sauga"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Kompiuterio aparatinės programinės įrangos saugos būsena"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ekranas;užrakinimas;diagnostika;lūžimas;privatus;neseniai;naudoti;laikinieji;"
+"indeksas;pavadinimas;tinklas;tapatybė;privatumas;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Nežinomas"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bitų"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bitų"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Nežinoma"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Neprieinama"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Sistemos logotipas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Įrenginio pavadinimas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Aparatūros modelis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Atmintis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesorius"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Disko talpa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Skaičiuojama..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "OS pavadinimas"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#| msgid "%s; Build ID: %s"
+msgid "OS Build ID"
+msgstr "OS kūrimo ID"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "OS tipas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME versija"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Įkeliama…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Langų sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualizacija"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Programinės įrangos atnaujinimai"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Pervadinti įrenginį"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Įrenginio pavadinimas yra naudojamas šiam įrenginiui identifikuoti, kai jis "
+"matomas per tinklą arba poruojant su Bluetooth įrenginiais."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Įrenginio pavadinimas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Pervadinti"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Apie"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Rodyti informaciją apie sistemą"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"įrenginys;sistema;informacija;pavadinimas;atmintis;procesorius;versija;"
+"numatyta;programa;atsarginė;pageidaujama;cd;dvd;usb;audio;video;diskas;"
+"išimama;laikmena;autopaleidimas;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Garsas ir vaizdas"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Išjungti/įjungti garsą"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Pritildyti"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Pagarsinti"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Išjungti/įjungti mikrofoną"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Paleisti multimedijos grotuvą"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Groti (arba groti/pristabdyti)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pristabdyti grojimą"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Stabdyti grojimą"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Ankstesnis takelis"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Kitas takelis"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Išstumti"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Rašymas"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Perjungti į kitą įvesties šaltinį"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Perjungti į ankstesnį įvesties šaltinį"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Leistukai"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Paleisti pagalbos naršyklę"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Paleisti skaičiuotuvą"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Paleisti pašto programą"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Paleisti interneto naršyklę"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Namų aplankas"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Paieška"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Atsijungti"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Užrakinti ekraną"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Prieiga"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Įjungti arba išjungti mastelio keitimą"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Pritraukti"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Atitraukti"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Įjungti arba išjungti ekrano skaityklę"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Įjungti arba išjungti klaviatūrą ekrane"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Padidinti teksto dydį"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Sumažinti teksto dydį"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Įjungti arba išjungti didelį kontrastą"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nerasta įvesties šaltinių"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Kita"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Pridėti įvesties šaltinį"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Įvesties metodų negalima naudoti prisijungimo ekrane"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nepasirinktas įvesties šaltinis"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Parametrai"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Pakelti"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Perkelti žemyn"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Nuostatos"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Rodyti klaviatūros išdėstymą"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Pašalinti"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Pasirinktiniai susiejimai"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternatyvių simbolių klavišas"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Alternatyvių simbolių klavišą galima naudoti papildomiems simboliams įvesti. "
+"Jie kartais spausdinami kaip trečias pasirinkimas jūsų klaviatūroje."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Kairysis Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Dešinysis Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Kairysis Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Dešinysis Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Meniu klavišas"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Dešinysis Vald"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Rašymo klavišas"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Komponavimo klavišas leidžia įvesti daug įvairių klavišų. Jis naudojamas "
+"paspaudžiant ir įvedant simbolių seką.  Pvz., komponavimo klavišas ir po to "
+"<b>C</b> ir <b>o</b> įves <b>©</b>, <b>a</b> ir po to <b>'</b> įves <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Didžiosios raidės"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Slinkimo užraktas"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Ekranas spausdinimas"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Įvesties šaltinius galima keisti naudojant klaviatūros trumpinį %s.\n"
+"Galite pakeisti šiuos trumpinius klaviatūros nustatymuose."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Įvesties šaltiniai"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Įskaitant klaviatūros išdėstymus ir įvesties metodus."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Įvesties šaltinių keitimas"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Naudoti tą patį _šaltinį visiems langams"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Keisti įvesties šaltinius _individualiai kiekvienam langui"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Specialiųjų simbolių įvestis"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Metodai simbolių bei raidžių variantų įvedimui naudojant klaviatūrą."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Klaviatūros trumpiniai"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Rodyti ir tinkinti trumpinius"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d pakeistas"
+msgstr[1] "%d pakeisti"
+msgstr[2] "%d pakeistų"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Atstatyti visus trumpinius?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Visų trumpinių atstatymas gali paveikti jūsų pasirinktinius trumpinius. Šio "
+"veiksmo negalėsite atšaukti."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Atsisakyti"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Atstatyti visus"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Atstatyti visus…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Atstatyti visus trumpinius į jų numatytąsias vertes"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Skyrius"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Trumpiniai"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Pridėti trumpinį"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Pridėti pasirinktinius trumpinius"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Nustatykite pasirinktinius trumpinius programų paleidimui, scenarijų "
+"vykdymui ir kitkam."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Pridėti trumpinį"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nerasta klaviatūros trumpinių"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s jau naudojamas %s. Jei jį pakeisite, %s bus išjungtas"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Įveskite naują trumpinį"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Nustatyti pasirinktinį susiejimą"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Nustatyti trumpinį"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Įveskite naują trumpinį %s pakeisti."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Pridėti pasirinktinis trumpinį"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Pašalinti"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Pakeisti"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "Nu_statyti"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Spauskite Esc atsisakymui arba Backspace klaviatūros trumpinio išjungimui."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Pavadinimas"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Ko_manda"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Trumpinys"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Nustatyti trumpinį…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Joks"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Atstatyti numatytąją trumpinio vertę"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klaviatūra"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Keisti klaviatūros trumpinius bei nustatyti rašymo nuostatas, klaviatūrų "
+"išdėstymus bei įvesties šaltinius"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Trumpinus;Darbo sritis;Langas;Dydžio keitimas;Mastelis;Kontrastas;Įvestis;"
+"Šaltinis;Rakinimas;Garsas;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Vietos tarnybos išjungtos"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Jokia programa negali gauti vietovės informacijos."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Vietos tarnybos leidžia programoms sužinoti jūsų būvimo vietą. Wi-Fi bei "
+"mobilaus plačiajuosčio naudojimas padidina tikslumą.\n"
+"\n"
+"Naudoja Mozilla vietovės tarnybą: <a href='https://location.services.mozilla."
+"com/privacy'>privatumo politika</a>\n"
+"\n"
+"Leisti žemiau išvardintoms programoms nustatyti jūsų buvimo vietą."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Jokia programa neprašė  prieigos prie vietos informacijos"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Apsaugoti savo vietos informaciją"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "vieta;gps;privatus;privatumas;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofonas yra išjungtas"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Jokia programa negali įrašyti garso."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Mikrofono naudojimas leidžia programoms įrašyti garsus. Mikrofono išjungimas "
+"gali sutrukdyti kai kurių programų veikimą.\n"
+"\n"
+"Leisti žemiau išvardintoms programoms naudoti mikrofoną."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Jokia programa neprašė prieigos prie mikrofono"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Apsaugokite savo pokalbius"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofonas,įrašymas;programa;privatumas;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Tikrinkite savo _nustatymus"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Bendri"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Pagrindinis mygtukas"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Nustato pelių ir jutiklinių kilimėlių mygtukų fizinę tvarką"
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Kairysis"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Dešinysis"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Pelė"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Pelės greitis"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Natūralus slinkimas"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Slinkimas perkelia turinį, o ne rodinį."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Jutiklinis kilimėlis"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Jutiklinio kilimėlio greitis"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Bakstelėti _paspaudimui"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Pasieti paspaudimui"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Slinktis dviem pirštais"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Slinkimas kraštuose"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Mėginkite spausti, dvigubą paspaudimą, slinkti"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Penki paspaudimai, GEGL laikas!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dvigubas paspaudimas, pagrindinis mygtukas"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Vienas paspaudimas, pagrindinis mygtukas"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dvigubas paspaudimas, vidurinysis mygtukas"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Vienas paspaudimas, vidurinysis klavišas"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dvigubas paspaudimas, antraeilis mygtukas"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Vienas paspaudimas, antraeilis mygtukas"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Pelė ir jutiklinis kilimėlis"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Keiskite pelės ar jutiklinio kilimėlio jautrumą bei pasirinkite kairiarankio "
+"ar dešiniarankio veikseną"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Sekantis paviršius;Žymiklis;Paspaudimas;Taukštelėjimas;Dvigubas;Mygtukas;"
+"Rutulinis manipuliatorius;Slinkiklis;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Karštas kampas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Paspauskite viršutinį kairįjį kampą veiklų apžvalgai atverti."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Aktyvūs ekrano kraštai"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Tempkite langus į viršutinį, kairį bei dešinį ekrano kraštus jų dydžiui "
+"pakeisti."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Darbo sritys"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dinaminės darbo sritys"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Automatiškai pašalina tuščias darbo sritis."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Fiksuotas darbo sričių skaičius"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Nurodykite nuolatinių darbo sričių skaičių."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Darbo sričių skaičius"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Keli monitoriai"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Darbo sritys tik _pirminiame vaizduoklyje"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Darbo sritys v_isuose vaizduokliuose"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Automatinis perjungimas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Įtraukti programas iš visų darbo _sričių"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Įtraukti programas tik iš _dabartinės darbo srities"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Daug užduočių"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Tvarkykite nuostatas produktyvumui ir daugeliui užduočių"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Užduotys;Produktyvumas;Tinkinti;Darbastalis;Karštas kampas;Darbo sritys;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Oi, atsitiko kažkas negero. Susisiekite su savo programinės įrangos tiekėju."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager turėtų veikti."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Kiti įrenginiai"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Pridėti ryšį"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nenustatyta"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Nesaugus tinklas (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Saugus tinklas (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Saugus tinklas (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Saugus tinklas (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Saugus tinklas"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Prisijungta"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Parametrai..."
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Įjungus prieigos tašką bus atsijungta nuo %s ir nebus galima pasiekti "
+"interneto per Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Turi turėti bent 8 simbolius"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Turi turėti ne daugiau kaip %d simbolį"
+msgstr[1] "Turi turėti ne daugiau kaip %d simbolius"
+msgstr[2] "Turi turėti ne daugiau kaip %d simbolių"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Įjungti belaidį prieigos tašką"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-Fi prieigos taškas leidžia kitiems dalinti jūsų interneto ryšiu sukuriant "
+"Wi-Fi tinklą, prie kurio jie gali prisijungti. Tam padaryti turite turėti "
+"interneto ryšį per kitą šaltinį nei Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Tinklo pavadinimas"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Slaptažodis"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Generuoti atsitiktinį slaptažodį"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Automatiškai generuoti slaptažodį"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "Į_jungti"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Belaidis"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Stabdyti prieigos tašką ir atjungti visus naudotojus?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Stabdyti prieigos tašką"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Skrydžio veiksena"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Išjungia belaidį tinklą, Bluetooth ir mobilų plačiajuostį ryšius"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nerasta belaidžio tinklo adapterių"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Įsitikinkite, kad belaidžio tinklo adapteris įkištas ir įjungtas"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Skrydžio veiksena įjungta"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Išjungti Wi-Fi naudojimui"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Belaidis prieigos taškas aktyvus"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobilieji įrenginiai gali prisijungti nuskenavę QR kodą."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Išjungti belaidį prieigos tašką…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Matomi tinklai"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager turi būti paleistas"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x _Sauga"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sauga"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Išlaikyti"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Nuolatinis"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Atsitiktinis"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabilus"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Įvestas MAC adresas bus naudojamas kaip aparatinis adresas tinklui, kuriame "
+"aktyvuotas šis ryšys. Ši savybė yra žinoma kaip MAC klonavimas arba "
+"apsimetimas (spoofing). Pvz.: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profilis %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Patobulintas atvėrimas"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nėra"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Niekada"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "Prieš %i dieną"
+msgstr[1] "Prieš %i dienas"
+msgstr[2] "Prieš %i dienų"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Joks"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Silpnas"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Gerai"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Geras"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Puikus"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 adresas"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 adresas"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP adresas"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Pamiršti ryšį"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Pašalinti ryšio profilį"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Pašalinti VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Išsamiau"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatinis"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Tapatybė"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Ištrinti adresą"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Ištrinti kelią"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Joks"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bitų raktas (šešioliktainis arba ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bitų slaptažodis"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynaminis WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 asmeninis"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 kompanijos"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 asmeninis"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signalo stiprumas"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Saito greitis"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Aparatinis adresas"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Palaikomi dažniai"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Numatytasis kelias"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Paskutinį kartą naudota"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Prisijungti _automatiškai"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Padaryti pasiekiamu kitiems naud_otojams"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "_Matuojamas ryšys: turi duomenų apribojimų arba gali kainuoti"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Programinės įrangos atnaujinimai bei kiti dideli atsisiuntimai nebus "
+"automatiškai paleidžiami."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Pavadinimas"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC adresas"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonuotas adresas"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "baitai"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 metodas"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatinis (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Tik vietinis susiejimas"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Rankinis"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Išjungti"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Dalinamasi su kitais kompiuteriais"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresai"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresas"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Tinklo kaukė"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Tinklų sietuvas"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatinis"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatinis DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS serveriu adresas (-ai)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Skirti IP adresus kableliais"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Keliai"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatiniai keliai"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrinė"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Naudoti šį ryšį tik _resursams šiame tinkle"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 metodas"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "A_utomatinis, tik DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Priešdėlis"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Nepavyko atverti ryšių redaktoriaus"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Nauja profilis"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Netinkama nuostata %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Netinkama nuostata %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importuoti iš failo…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Pridėti VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_auga"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Nepavyko importuoti PVN ryšio"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Failo „%s“ nepavyksta perskaityti arba jis neturi atpažįstamos VPN ryšio "
+"informacijos\n"
+"\n"
+"Klaida: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Pasirinkite failą importavimui"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Failas pavadinimu „%s“ jau yra."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Pakeisti"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Ar norite pakeisti %s įrašomu VPN ryšiu?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Nepavyko eksportuoti VPN ryšio"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN ryšys „%s“ negali būti eksportuotas į %s.\n"
+"\n"
+"Klaida: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Eksportuoti VPN ryšį"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Klaida: nepavyko įkelti VPN ryšių redaktoriaus)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Valdykite, kaip jungiatės prie interneto"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Tinklas;IP;LAN;Proxy;WAN;Plačiajuostis;Modemas;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Valdykite, kaip jungiatės prie belaidžių tinklų"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Tinklas;Belaidis;Wi-Fi;Wifi;IP;LAN;Plačiajuostis;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "niekada"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "šiandien"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "vakar"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Paskutinį kartą naudota"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Laidinis"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Pridėti naują ryšį"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Tinklo nustatymai pasirinktiems tinklams įskaitant slaptažodžius ir bet "
+"kokius asmeninius nustatymus bus prarasti."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Pamiršti"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Žinomi belaidžiai tinklai"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Pamiršti"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Sistemos taisyklės neleidžia naudoti kaip prieigos taško"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Belaidis įrenginys nepalaiko prieigos taško veiksenos"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Žiniatinklio proxy automatinis aptikimas yra naudojamai, kai konfigūracijos "
+"URL nepateiktas."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Tai nerekomenduojama nepatikimiems viešiesiems tinklams."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Išjungti įrenginį"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktyvus"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Tiekėjas"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Tarpinis tinklo serveris"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP tarpinis serveris"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTP tarpinis serveris"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP tarpinis serveris"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks serveris"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "Nepa_isyti kompiuterių"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP tarpinio serverio prievadas"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS tarpinio serverio prievadas"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP tarpinio serverio prievadas"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks tarpinio serverio prievadas"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Konfigūravimo URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Išjungti VPN ryšį"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Tinklo pavadinimas"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Saugos tipas"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Slaptažodis"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Išjungti Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Daugiau parametrų…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Prisijungti prie paslėpto tinklo..."
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Į_jungti belaidį prieigos tašką…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Žinomi _belaidžiai tinklai"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Būsena nežinoma"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Netvarkomas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Nepasiekiamas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Jungiamasi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Reikia patvirtinti tapatybę"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Atsijungiama"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Prisijungti nepavyko"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Būsena nežinoma (trūkstama)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Konfigūracija nepavyko"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP konfigūracija nepavyko"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP konfigūracijos laikas baigėsi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Buvo reikalingos paslaptys, bet nepateiktos"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x tiekėjas atjungtas"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x tiekėjo konfigūracija nepavyko"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x tiekėjo klaida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x per ilgai užtruko patvirtindamas tapatybę"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Nepavyko paleisti PPP tarnybos"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP tarnyba atsijungė"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP nepavyko"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Nepavyko paleisti DHCP kliento"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP kliento klaida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP klientas nebeveikia"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Nepavyko paleisti bendrų ryšių tarnybos"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Bendrų ryšių tarnyba nebeveikia"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Nepavyko paleisti AutoIP tarnybos"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP tarnybos klaida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP tarnyba nebeveikia"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linija užimta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Nėra skambinimo tono"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Nepavyko nustatyti pernešėjo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Baigėsi skambinimo užklausos laikas"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Nepavyko prisiskambinti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Modemo iniciavimas nepavyko"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Nepavyko pasirinkti nurodytų APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Neieškoma tinklų"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Neleista registruoti tinklo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Baigėsi tinklo registravimo laikas"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Nepavyko registruoti prašomo tinklo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Nepavyko patikrinti PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Gali būti, kad įrenginiui trūksta aparatinės programinės įrangos"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Ryšys dingo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Buvo panaudotas esamas ryšys"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modemas nerastas"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth ryšys nepavyko"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM kortelė neįdėta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Reikalingas SIM Pin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Reikalingas SIM Puk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Neteisinga SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Nepavyko ryšio priklausomybė"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Trūksta aparatinės programinės įrangos"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabelis neįjungtas"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "nežinoma klaida 802.1x saugume (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "nepasirinktas failas"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "nežinoma klaida tikrinant eap-metodo failą"
+
+#: panels/network/wireless-security/eap-method.c:394
+#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 arba PGP privatūs raktai"
+
+#: panels/network/wireless-security/eap-method.c:397
+#| msgid "_User certificate"
+msgid "DER or PEM certificates"
+msgstr "DER arba PEM liudijimai"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "trūksta EAP-FAST PAC failo"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC failai (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonimas"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Tapatybė patvirtinta"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Abu"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anoni_minė tapatybė"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _failas"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Pasirinkite PAC failą"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Vidinis tapatybės patvirtinimas"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Leisti automatinius PAC _priskyrimus"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "trūksta EAP-LEAP naudotojo vardo"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "trūksta EAP-LEAP slaptažodžio"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Naudotojo vardas"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Slaptažodis"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Rodyti slaptažodį"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "netinkamas EAP-PEAP LĮ liudijimas: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "netinkamas EAP-PEAP LĮ liudijimas: nenurodytas liudijimas"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versija 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versija 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "L_Į liudijimas"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Pasirinkite liudijimų įstaigos liudijimą"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Ne_reikia LĮ liudijimo"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP _versija"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "trūksta EAP naudotojo vardo"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "trūksta EAP slaptažodžio"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "trūksta EAP-TLS identiteto"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "netinkamas EAP-TLS LĮ liudijimas: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "netinkamas EAP-TLS LĮ liudijimas: nenurodytas liudijimas"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "netinkamas EAP-TLS privatus raktas: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "netinkamas EAP-TLS naudotojo liudijimas: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Nešifruoti privatūs raktai yra nesaugūs"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Pasirinktas privatus raktas nėra apsaugotas slaptažodžiu.  Tai gali leisti "
+"pažeisti jūsų saugumo įgaliojimus.  Pasirinkite slaptažodžiu apsaugotą "
+"privatų raktą.\n"
+"\n"
+"(Galite slaptažodžiu apsaugoti savo privatų raktą su openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Pasirinkite asmeninį liudijimą"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Pasirinkite privatų raktą"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Tapatybė"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Na_udotojo liudijimas"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Privatus ra_ktas"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Privataus rakto slaptažodis"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "netinkamas EAP-TTLS LĮ liudijimas: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "netinkamas EAP-TTLS LĮ liudijimas: nenurodytas liudijimas"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (be EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Sritis"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Nežinoma klaida tikrinant 802.1x saugumą"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunneled TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Apsaugotas EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Tapatybės patvirtinimas"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Pasirinkite failą"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "trūksta leap naudotojo vardo"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "trūksta leap slaptažodžio"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Trūksta Wi-Fi slaptažodžio."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipas"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "trūksta wep rakto"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"netinkamas wep raktas: %zu ilgio raktas turi susidėti tik iš šešioliktainių "
+"skaitmenų"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"netinkamas wep raktas: %zu ilgio raktas turi susidėti tik iš ascii simbolių"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"netinkamas wep raktas: netinkamas rakto ilgis %zu. Raktus turi būti 5/13 "
+"(ascii) arba 10/16 (šešioliktainis) ilgio"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "netinkamas wep raktas: slaptafrazė negali būti tuščia"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"netinkamas wep raktas: slaptafrazė turi būti trumpesnė nei 64 simboliai"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (numatyta)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Atvira sistema"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Bendrinami raktai"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "Ra_ktas"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Rodyti raktą"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP _indeksas"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"netinkamas wpa-psk: netinkamas rakto ilgis %zu. Turi b8ti [8,63] baitai arba "
+"64 šešioliktainiai skaitmenys"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"netinkamas wpa-psk: negalima 64 baitų rakto interpretuoti kaip šešioliktainio"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Pra_nešimai"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Garso sign_alai"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Pranešimų iššokimai"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Pranešimai ir toliau bus rodomo pranešimų sąraše, kai iššokimai yra išjungti."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Rodyti pranešimų _turinį iššokimuose"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Pranešimai ekrano užrakte"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Rodyti pranešimų turinį ekran_o užrakte"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Netrukdyti"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Pranešimai ekrano užrakte"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Valdykite, kurie pranešimai yra rodomi, ir ką jie rodo"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Pranešimai;žinutė;laiškas;dėklas;iššokimai;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Kita"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s pašalinta"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Klaida šalinant paskyrą"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Atšaukti"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Užverti pranešimą"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Prisijungti prie savo duomenų debesyje"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Nėra interneto ryšio — prisijunkite, norėdami nusistatyti naujas "
+"internetines paskyras"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Pridėti paskyrą"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s paskyra"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Pašalinti paskyrą"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Internetinės paskyros"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Prisijunkite prie savo internetinių paskyrų ir nuspręskite, kam jas naudosite"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Žiniatinklis;Tinkle;Pokalbiai;Kalendorius;"
+"Paštas;Kontaktai;ownCloud;Kerberos;IMAP;SMTP;Paketas;SkaitytiVėliau;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Nežinomas laikas"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minutė"
+msgstr[1] "%i minutės"
+msgstr[2] "%i minučių"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i valanda"
+msgstr[1] "%i valandos"
+msgstr[2] "%i valandų"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "valanda"
+msgstr[1] "valandos"
+msgstr[2] "valandų"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minutė"
+msgstr[1] "minutės"
+msgstr[2] "minučių"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s iki pilno įkrovimo"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Įspėjame: liko %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Liko %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Pilnai įkrautas"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Nekraunamas"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Tuščia"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Įkraunama"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Įšsikrauna"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Belaidė pelė"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Belaidė klaviatūra"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Nenutrūkstamos srovės šaltinis"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Asmeninis skaitmeninis pagalbininkas"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobilusis telefonas"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Daugialypės terpės grotuvas"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Planšetė"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Kompiuteris"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Žaidimų įvesties įrenginys"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akumuliatorius"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Pagrindinė"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Papildoma"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Baterijos"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Kai la_isva"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Pristabdyti"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Išjungti"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Užmigdyti"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nieko"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Naudojant baterijos energiją"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Prijungus prie elektros tinklo"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Niekada"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatinis pristabdymas"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "Našumo veiksena laikinai išjungta dėl didelės temperatūros."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Aptikti keliai: našumo veiksena laikinai išjungta. Perkelkite įrenginį ant "
+"stabilaus paviršiaus, jei norite atstatyti."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Našumo veiksena laikinai išjungta."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Senka baterija: našumo veiksena išjungta. Ankstesnė veiksena bus atstatyta, "
+"kai baterija bus pakankamai įkrauta."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Energijos taupymo veikseną įjungė „%s“."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Našumo veikseną įjungė „%s“."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minučių"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minučių"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutės"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minučių"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutės"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 valanda"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minučių"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minučių"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minučių"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 valandos"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Galinga veiksena"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Paveikia sistemos našumą ir energijos suvartojimą."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Energijos taupymo parametrai"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatinis ekrano šviesumas"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Ekrano ryškumas pritaikomas prie apšvietimo."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Pritemdyti ekraną"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Sumažina ekrano ryškumą, kai kompiuteris neaktyvus."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Ekrano _išjungimas"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Išjungia ekraną po neaktyvumo laikotarpio."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatinis energijos taupymas"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Įjungia energijos taupymą, kai senka baterija."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatiškai pristabdyti"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pristabdo kompiuterį po neaktyvumo periodo."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Į_jungimo mygtuko veiksmas"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Rodyti baterijos _procentus"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatiškai pristabdyti"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Prijungtas prie elektros tinklo"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Naudoja _baterijos energiją"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Delsa"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Našumas"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Dideli našumas ir energijos suvartojimas."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Balansuotas"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standartinis našumas ir energijos suvartojimas."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Energijos taupymas"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Sumažinti galia ir energijos suvartojimas"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energija"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Rodyti baterijos būseną ir keisti energijos taupymo nustatymus"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Energija;Miegoti;Pristabdyti;Užmigdyti;Akumuliatorius;šviesumas;Pritemdyti;"
+"Tuščias;Monitorius;DPMS;Laisva;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Spausdintuvas „%s“ buvo ištrintas"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Nepavyko pridėti naujo spausdintuvo."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Nepavyko įkelti sąsajos: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Atrakinkite spausdintuvų pridėjimui bei nustatymų keitimui"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Spausdintuvai"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Pridėkite spausdintuvus, matykite spausdintuvo darbus ir nuspręskite, kaip "
+"norite spausdinti"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Spausdintuvas;Eilė;Spausdinti;Rašalas;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Pridėti spausdintuvą"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Atrakinti"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Nerasta spausdintuvų"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Įveskite tinklo adresą arba ieškokite spausdintuvo"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Reikia patvirtinti tapatybę"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Įveskite savo naudotojo vardą ir slaptažodį prieinamiems spausdintuvams "
+"matyti."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Naudotojo vardas"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s informacija"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Nerasta tinkama tvarkyklė"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Pasirinkite PPD failą"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript spausdintuvo aprašymo failai (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Spausdintuvų pavadinimai negali turėti tarpų, tabuliacijos, # arba /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Vieta"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Tvarkyklė"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Ieškoma pageidaujamų tvarkyklių..."
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Ieškoti tvarkyklių"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Pasirinkti iš duomenų bazės…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Įdiegti PPD failą…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Pasirinkite spausdintuvo tvarkyklę"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Įkeliama tvarkyklių duomenų bazė…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Pasirinkti"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect spausdintuvas"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD spausdintuvas"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Viepusis"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Ilgos kraštinės (standartinis)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Trumpos kraštinės (apverstas)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Stačias"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Gulsčias"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Apverstas gulsčias"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Apverstas stačias"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Tęsti"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pristabdyti"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Laukia"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pristabdytas"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Reikia patvirtinti tapatybę"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Apdorojamas"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Sustabdytas"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Atšauktas"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Atmestas"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Baigtas"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Perkelti šį darbą į eilės pradžią"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u darbui reikia patvirtinti tapatybę"
+msgstr[1] "%u darbams reikia patvirtinti tapatybę"
+msgstr[2] "%u darbų reikia patvirtinti tapatybę"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s – aktyvūs darbai"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Įveskite savo naudotojo vardą ir slaptažodį spausdinimui iš %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domenas"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Patvirtinti tapatybę"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Išvalyti visus"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Patvirtinti tapatybę"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Nėra aktyvių spausdintuvo darbų"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Atrakinti spausdintuvo serverį"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Atrakinti %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Įveskite savo naudotojo vardą ir slaptažodį %s prieinamiems spausdintuvams "
+"matyti."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Ieškoma spausdintuvų"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Serijinis prievadas"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Lygiagretus prievadas"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Vieta: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adresas: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Serveris reikalauja patvirtinti tapatybę"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dvipusis"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Popieriaus tipas"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Popieriaus šaltinis"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Išvestis dėklas"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Skiriamoji geba"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript pradinis filtravimas"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Puslapių vienoje pusėje"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dvipusis"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientacija"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Bendri"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Puslapio nustatymai"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Įdiegiami parametrai"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Darbas"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Paveikslėlio kokybė"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Spalva"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Užbaigiama"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Sudėtingesni"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Bandomasis puslapis"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Bandomasis puslapis"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Automatiškai pasirinkti"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Spausdintuvo numatytieji"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Tik integruoti GhostScript šriftai"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Konvertuoti į PS lygmenį 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Konvertuoti į PS lygmenį 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Nėra pradinio filtravimo"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Gamintojas"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nėra aktyvių darbų"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u darbas"
+msgstr[1] "%u darbai"
+msgstr[2] "%u darbų"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Išvalyti spausdinimo galvutes"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Baigiasi rašalas"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Baigiasi rašalas"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Baigiasi ryškalas"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Baigėsi ryškalas"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Baigiasi spalvos tiekimas"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Baigėsi spalvos tiekimas"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Atvertas dangtis"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Atvertos durys"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Baigiasi popierius"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Baigėsi popierius"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Išjungta"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Sustabdytas"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Atliekų konteineris beveik pilnas"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Atliekų konteineris pilnas"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Optinio fotokonduktoriaus tarnavimo laikas baigiasi"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Optinis fotokonduktorius nebeveikia"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Pasirengęs"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Nepriima darbų"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Apdorojama"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Spausdinimo parametrai"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Spausdintuvo informacija"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Numatytai naudoti spausdintuvą"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Išvalyti spausdinimo galvutes"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Pašalinti spausdintuvą"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modelis"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Rašalo lygis"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Išsprendę problemą paleiskite iš naujo."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Perleisti"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Pridėti spausdintuvą…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Spausdintuvų nėra"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Atleiskite! Sistemos spausdinimo tarnyba\n"
+"    atrodo nėra pasiekiama."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formatai"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Ieškoti lokalių…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Dažni formatai"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Visi formatai"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Nerasta paieškos rezultatų"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Galima ieškoti šalių arba kalbų."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Peržiūra"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperinė"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrinė"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datos"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Data ir laikas"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Skaičiai"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Matavimas"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Popierius"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Kalba ir formatas bus pakeisti kitą kartą prisijungus"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Atsijungti…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Kalbos nuostata naudojama sąsajos tekstui bei interneto puslapiams. Formatai "
+"naudojami skaičiams, datoms ir pinigams."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Jūsų paskyra"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Kalba"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formatai"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Prisijungimo ekranas"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Regionas ir kalba"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Pasirinkite rodymo kalbą bei formatus"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Kalba;Išdėstymas;Klaviatūra;Įvestis;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Klausti, ką daryti"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Nieko nedaryti"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Atverti aplanką"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Kitos laikmenos"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Parinkite programą, kuria norėtumėte klausytis garso CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Parinkite programą vaizdo DVD rodymui"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Pasirinkite paleistiną programą, kai muzikos grotuvas prijungiamas"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Pasirinkite paleistiną programą, kai prijungiamas fotoaparatas"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Parinkite programą programinės įrangos CD paleidimui"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "garso DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "tuščias Blu-ray diskas"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "tuščias CD diskas"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "tuščias DVD diskas"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "tuščias HD DVD diskas"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray vaizdo diskas"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "el. knygų skaitytuvas"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD vaizdo diskas"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Paveikslėlių CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super vaizdo CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Vaizdo CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows programinė įranga"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Pasirinkite, kaip laikmena turi būti apdorota"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Garso CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "Vaizdo _DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Muzikos grotuvas"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Programinė įranga"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "Kit_os laikmenos"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Niekada neprašyti ir nepaleisti programų įdėjus laikmeną"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Pasirinkite, kaip kitos laikmenos turi būti apdorotos"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Veiksmas:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipas:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Išimamos laikmenos"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Konfigūruoti išimamas laikmenas"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"įrenginys;sistema;numatytoji;programa;pageidaujama;cd;dvd;usb;audio;video;"
+"diskas;išimama;laikmena;autopaleidimas;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Ekranas išsijungia"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekundžių"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minutė"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutės"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutės"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutės"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minučių"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 valanda"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minutė"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutės"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutės"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutės"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutės"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutės"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minučių"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minučių"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minučių"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Niekada"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Ekrano užrakinimas"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatinis ekrano užrakinimas neleidžia kitiems naudotis jūsų kompiuteriu, "
+"kol nesate šalia."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Tuščio ekrano delsa"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Neaktyvumo trukmė, po kurios ekranas taps tuščias."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatinis ekrano už_rakinimas"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Automatinio ekrano už_rakinimo delsa"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Po kiek laiko ekranas tampa tuščias, kai yra automatiškai užrakintas."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Rodyti pra_nešimus užrakintame ekrane"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Drausti naujus _USB įrenginius"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Drausti naujiems USB įrenginiams susisieti su sistema, kai ekranas yra "
+"užrakintas."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Ekrano privatumas"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Riboti matymo kampą"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Ekrano nuostatos"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "ekranas;užraktas;privatus;privatumas;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Pasirinkite vietą"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Gerai"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Ieškoti vietų"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Aplankai, kuriuose ieškoma sistemos programų, tokių kaip Failai, Nuotraukos "
+"ar Videoįrašai."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Vietos"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Gairės"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Kiti"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Pridėti vietą"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nerasta programų"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Programų paieška"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Įtraukti programų pateiktus paieškos rezultatus."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Aplankai, kuriuose ieško sistemos programos."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Paieškos rezultatai"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Rezultatai yra rodomi pagal sąrašo tvarką."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "Valdykite, kurios programos rodo paieškos rezultatus veiklų apžvalgoje"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Paieška;rasti;indeksas;slėpti;privatumas;rezultatai;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Nėra pasirinktų bendrinimui tinklų"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Tinklai"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Įjungta"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Išjungta"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Įjungta"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktyvūs"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Pasirinkite aplanką"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Pridėti"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Įjungti dalinimąsi daugialype terpe"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Dalinimasis asmeniniais failais leidžia bendrinti viešą aplanką su kitais "
+"esamame tinkle naudojant: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Kai leidžiama prisijungti nuotoliniu būdu, nutolę naudotojai gali "
+"prisijungti naudodami saugaus apvalkalo komandą:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Įjungti dalinimąsi asmeniniais failais"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Įrenginio pavadinimas nukopijuotas"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Įrenginio adresas nukopijuotas"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Naudotojo vardas nukopijuotas"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Slaptažodis nukopijuotas"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Dalinimasis"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Kompiuterio pavadinimas"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Dalinimasis failais"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Nuotolinis _darbalaukis"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Dalini_masis daugialype terpe"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Nuotolinis p_risijungimas"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Dalinimasis failais"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Reikalauti slaptažodžio"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Nuotolinis prisijungimas"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Nuotolinis darbalaukis"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Nuotolinis darbalaukis leidžia rodyti bei valdyti darbalaukį naudojant kitą "
+"kompiuterio."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Įjungti arba išjungti nuotolinius ryšius su šiuo kompiuteriu."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Nuotolinį valdymas"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Leidžia nuotoliniams ryšiams valdyti ekraną."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Kaip prisijungti"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Prisijunkite prie šio kompiuterio naudodami įrenginio pavadinimą arba "
+"nuotolinio darbalaukio adresą."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopijuoti"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Nuotolinio darbalaukio adresas"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Tapatybės patvirtinimas"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Norint prisijungti prie šio kompiuterio būtinas naudotojo vardas ir "
+"slaptažodis."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Naudotojo vardas"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Patikrinti šifravimą"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Šifravimo piršto atspaudas"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Šifravimo piršto atspaudas yra matomas prisijungusiuose klientuose ir turi "
+"būti identiškas."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Dalinimasis daugialype terpe"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Dalinimasis muzika, nuotraukomis ir vaizdo įrašais tinkle."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Aplankai"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Valdykite, kuo norite dalintis su kitais"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"dalinimasis;dalintis;bendrinti;ssh;kompiuteris;pavadinimas;nutolęs;"
+"darbalaukis;medija;garsas;vaizdas;paveikslėliai;fotografijos;filmai;serveris;"
+"piešėjas;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Įjungti arba išjungti nuotolinį prisijungimą"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Reikia patvirtinti tapatybę nuotoliniams prisijungimui įjungti ar išjungti"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Pasirinktinė"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Spauskite"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#| msgid "Sharing"
+msgid "String"
+msgstr "Eilutė"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Virtimas"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Ūžimas"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balansas"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Išnykti"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Užpakalinė"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Priekinė"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Testuojamas %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Paspauskite ant garsiakalbio testavimui"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Sistemos garsas"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Pagrindinis garsumas"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Garso lygiai"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Išvestis"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Išvesties įrenginys"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testas"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Konfigūracija"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Žemų garsų stiprintuvas"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Įvestis"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Įvesties įrenginys"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Garsumas"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Įspėjimų garsumas"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Nutildyti"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Garsas"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Keisti garso garsumą, įvedimą ir įvykių garsus"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kortelė;Mikrofonas;Garsumas;Silpnėjimas;Balansas;Bluetooth;Ausinės;Garsas;"
+"Išvestis;Įvestis;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Atsijungta"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Jungiamasi"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Prisijungta"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Autorizacijos klaida"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autorizuojama"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Sumažintas funkcionalumas"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Prisijungta ir autorizuota"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Nežinoma"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autorizuota adresu:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Prisijungta adresu:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Įtraukta adresu:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Nepavyko autorizuoti įrenginio:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Nepavyko pamiršti įrenginio:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Priklauso nuo %u kito įrenginio"
+msgstr[1] "Priklauso nuo %u kitų įrenginių"
+msgstr[2] "Priklauso nuo %u kitų įrenginių"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Užverti pranešimą"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Pavadinimas:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Būsena:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autorizuoti ir prisijungti"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Pamiršti įrenginį"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Klaida"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorizuota"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr "Thunderbolt posistemė (boltd) neįdiegta arba nenustatyta teisingai."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Leisti tiesioginę prieigą prie įrenginių, tokių kaip įstatymo stotys bei "
+"išoriniai GPU."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Galima prijungti tik USB ir Display Port įrenginius."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Nepavyko aptikti Thunderbolt.\n"
+"Sistemai trūksta Thunderbolt palaikymo, ji buvo BIOS sistemoje išjungta arba "
+"nustatyta į nepalaikomą saugumo lygį."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt palaikymas buvo išjungtas BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Nepavyko nustatyti Thunderbolt saugumo lygio."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Klaida persijungians į tiesioginę veikseną: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Nėra Thunderbolt palaikymo"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Nepavyko prisijungti prie thunderbolt posistemės."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Tiesioginė prieiga"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Laukiantys įrenginiai"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Nėra prijungtų įrenginių"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Tvarkyti Thunderbolt įrenginius"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privatumas;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Žymeklio mirksėjimas"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Žymeklis teksto laukeliuose mirksi."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Greitis"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Žymeklio mirksėjimo greitis"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Žymiklio dydis"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Žymiklio dydį galima sujungti su masteliu ir taip jį padaryti lengviau "
+"pastebimą."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Spaudimo pagalba"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Imituotas antrinis spustelėjimas"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Pradėti antrinį spustelėjimą laikant pagrindinį mygtuką"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Priėmimo delsa:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Trumpas"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Antrinis spustelėjimo vėlavimas"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Ilgas"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Uždelstas spustelėjimas"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Pradėti spustelėjimą sustabdžius pelės žymeklį"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "D_elsa:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Trumpas"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Ilgas"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Judesio slenkstis:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Mažas"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Didelis"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Kartojimo klavišai"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Klavišų paspaudimai kartojami, kai klavišas laikomas nuspaustu."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Kartojamų klavišų delsa"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Kartojamų klavišų greitis"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Rašymo pagalbininkas"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Kibieji klavišai"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Traktuoja modifikavimo klavišų seką kaip klavišų kombinaciją"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Iš_jungti, jei du klavišai paspaudžiami kartu"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pyptelėti, kai paspaustas _modifikatorius"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Lėtieji klavišai"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Nustato delsą tarp klavišo paspaudimo ir jo priėmimo"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Trumpas"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Rodyti klavišų rašymo delsą"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Ilgas"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Pyptelėti, kai paspaudžiamas klavišas"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Pyptelėti, kai klavišas _priimamas"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Pyptelėti, jei klavišas _atmestas"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Pasi_kartojantys klavišai"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Nepaiso greitų dvigubų klavišų paspaudimų"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Trumpas"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Pasikartojančių klavišų rašymo delsa"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Ilgas"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Į_jungti klaviatūra"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Įjungti pritaikymo neįgaliesiems funkcijas klaviatūra"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Numatytasis"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Vidutinis"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Didelis"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Didesnis"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Didžiausias"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pikselis"
+msgstr[1] "%d pikseliai"
+msgstr[2] "%d pikselių"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Visada rodyti prieigos meniu"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Matymas"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Didelis kontrastas"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Dide_lis šriftas"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Įjungti a_nimacijas"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Ekrano _skaityklė"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Ekrano skaityklė skaito rodomą tekstą jums perkeliant fokusą."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Garso klavišai"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pyptelėti, kai įjungiama skaitmenų klaviatūra arba didžiosios raidės."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Ž_ymiklio dydis"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Mastelis"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Klausa"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Vaizdo įspėjimai"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Klaviatūra ekrane"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "K_artojimo klavišai"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Žymeklio mir_ksėjimas"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Rašymo _pagalbininkas (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Rodymas ir spaudimas"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Pelės _mygtukai"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Surasti spausdintuvą"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Paspaudimo pagalba"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Dvigubas paspaudimo delsa"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Dvigubas paspaudimo delsa"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Vaizdo įspėjimai"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Testuoti blykstelėjimą"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Naudoti vizualų indikatorių, kai kyla pranešimo garsas."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Blykstelti visą _ekraną"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Blykstelti visą _langą"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Trumpas"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ekrano"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ekrano"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ekrano"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Ilgas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Visas ekranas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Viršutinė pusė"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Apatinė pusė"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Kairė pusė"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Dešinė pusė"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Mastelio parametrai"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Didinimas:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Lupos padėtis:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Sekti pelės žymeklį"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Ekrano dalis:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Lupa išsiplečia už _ekrano ribų"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Lai_kyti lupos žymeklį centruotą"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Lupos žymeklis _stumia turinį aplink"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Lupos žymeklis juda su _turiniu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Kryžmė:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Persidengia su pelės žymekliu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "S_toris:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Plonas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Storas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "I_lgis:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Spa_lva:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Taikiklis"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Spalvų efektai:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Balta ant juodo:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_šviesumas:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrastas:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Spa_lva"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Joks"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Pilnas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Žemas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Aukštas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Neryškus"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Aukštas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Spalvų efektai"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Padarykite matymą, išgirdimą, rašymą, rodymą ir spaudimą paprastesnį"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Klaviatūra;Pelė;a11y;Prieiga;Universali prieiga;Kontrastas;Žymeklis;Garsas;"
+"Mastelis;Ekranas;Skaityklė;didelis;aukštas;tekstas;šriftas;dydis;AccessX;"
+"Kibūs;Klavišai;Lėtieji;Pasikartojantys;Pelė; Dvigubas;paspaudimas;Delsa;"
+"Greitis;Pagalba;Pasikartojimas;Mirksėjimas;vaizdinis;klausa;garsas;rašymas;"
+"animacijos;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 valanda"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 diena"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dienos"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dienos"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dienos"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dienos"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dienos"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dienos"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dienų"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dienos"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Išvalyti visus elementus iš šiukšlinės?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Visi šiukšlinės elementai bus negrįžtamai ištrinti."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Iš_valyti šiukšlinę"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Ištrinti visus laikinuosius failus?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Visi laikinieji failai bus negrįžtamai ištrinti."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Išvalyti laikinuosius _failus"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 diena"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dienos"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dienos"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Visam laikui"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Failų istorija"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Failų istorija įrašo visus jūsų naudotus failus. Šia informacija dalinamasi "
+"tarp programų, todėl tampa lengviau rasti failus, kuriuos galbūt norite "
+"naudoti."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Failų _istorija"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Failų _istorijos trukmė"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Išva_lyti istoriją…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Šiukšlinė ir laikinieji failai"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Šiukšlinė ir laikinieji failai kartai gali turėti asmeninės ar jautrios "
+"informacijos. Automatinis jų ištrynimas gali padėti apsaugoti jūsų privatumą."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Automatiškai išvalyti _šiukšlinę"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automatiškai išvalyti laikinuosius _failus"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Automatinio išvalymo _periodas"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Iš_valyti šiukšlinę…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Išvalyti laikinuosius _failus…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Failų istorija ir šiukšlinė"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Nepalikti pėdsakų"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"naudojimas;neseni;istorija;failai;laikini;tmp;privatūs;privatumas;šiukšlinė;"
+"išvalyti;palikti;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Turi atitikti jūsų paskyros teikėjo žiniatinklio adresą."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Nepavyko pridėti Pasirinkite paskyros"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Slaptažodžiai nesutampa."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Nepavyko priregistruoti paskyros"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Nėra palaikomo būdo patvirtinti tapatybę šiame serveryje"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Nepavyko prisijungti prie srities"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Šis prisijungimo vardas nesuveikė.\n"
+"Bandykite dar kartą."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Šis prisijungimo slaptažodis nesuveikė.\n"
+"Bandykite dar kartą."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Nepavyko prisijungti prie srities"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Nepavyksta rasti domeno. Gal suklydote?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Pridėti naudotojo paskyrą"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administratorius"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administratoriai gali pridėti bei šalinti naudotojos ir keisti visų "
+"naudotojų nustatymus. Tėvų kontrolė negali būti pritaikyta administratoriams."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Naudotojas nustato slaptažodį pirmo prisijungimo metu"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Nustatyti slaptažodį dabar"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Patvirtinti"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Kompanijos prisijungimas"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Naudotojų paskyros, kurias tvarko kompanija ar organizacija."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Esate atsijungęs"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Kompanijos prisijungimas leidžia šiame įrenginyje naudoti centralizuotai "
+"tvarkomą naudotojo paskyrą. Taip pat galima naudoti šią paskyrą kompanijos "
+"ištekliams internete pasiekti."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Naršyti daugiau paveikslėlių"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Pasirinkite failą…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Pirštų atspaudų tvarkyklė"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "_Piršto atspaudas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Ne"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Taip"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Ar norite ištrinti įrašytus pirštų antspaudus, kad būtų išjungtas "
+"prisijungimas pirštų antspaudais?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Nėra pirštų atspaudų skaitytuvo"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Nėra _pirštų atspaudų skaitytuvo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Užtikrinkite, kad įrenginys yra tvarkingai prijungtas."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Pirštų atspaudų skaitytuvas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Pasirinkite pirštų atspaudų skaitytuvą, kurį norite sukonfigūruoti"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Prisijungimas piršto atspaudu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Prisijungimas piršto atspaudu leidžia atrakinti bei prisijungti prie "
+"kompiuterio pirštu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Ištrinti pirštų antspaudus"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Piršto atspaudo įtraukimas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "reikia užimti įrenginį, norint atlikti šį veiksmą"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "įrenginį jau užėmė kitas procesas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "neturite leidimo įvykdyti veiksmą"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "atspaudai nebuvo įvesti"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Nepavyko susisiekti su įrenginiu įvedimo metu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Nepavyko susisiekti su pirštų atspaudų skaitykle"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Nepavyko susisiekti su pirštų atspaudų tarnyba"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Nepavyko išvardinti pirštų atspaudų: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Nepavyko ištrinti įrašytų pirštų atspaudų: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Kairysis smilius"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Kairysis didysis pirštas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Kairysis smilius"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Kairysis bevardis pirštas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Kairysis mažasis pirštas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Dešinysis nykštys"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Dešinysis didysis pirštas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Dešinysis smilius"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Dešinysis bevardis pirštas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Dešinysis mažasis pirštas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Nežinomas pirštas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Atlikta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Pirštų atspaudų skaitytuvas atsijungė"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Pirštų atspaudų skaitytuvo saugykla yra pilna"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Nepavyko įtraukti naujo piršto atspaudo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Nepavyko pradėti įtraukimo: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Nepavyko įtraukti naujo piršto atspaudo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Nepavyko sustabdyti įtraukimo: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Pakartotinai atitraukite ir uždėkite savo pirštą ant skaitytuvo piršto "
+"atspaudui įtraukti"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Iš _naujo įtraukti šį pirštą…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Nuskaityti naują piršto atspaudą"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Nepavyko atlaisvinti pirštų atspaudų skaitytuvo %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problema skaitant įrenginį"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Nepavyko perimti pirštų atspaudų skaitytuvo %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Nepavyko gauti pirštų atspaudų įrenginių: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Ši savaitė"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Preitą savaitę"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%Y %B %e"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Seansas įjungtas"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Seansas paleistas"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s – paskyros aktyvumas"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Ankstesnis"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Kitas"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Pasirinkite kitą slaptažodį."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Įveskite savo slaptažodį dar kartą."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Nepavyko pakeisti slaptažodžio"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Keisti slaptažodį"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Pa_keisti"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Dabartinis slaptažodis"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Naujas slaptažodis"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Patvirtinkite slaptažodį"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Leisti naudotojui pakeisti slaptažodį kito prisijungimo metu"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Nustatyti slaptažodį dabar"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Nepavyksta automatiškai prisijungti prie šio tipo domeno"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Nėra tokios srities"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Nepavyko prisijungti kaip %s srityje %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Netinkamas slaptažodis, bandykite dar kartą"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Nepavyko prisijungti prie %s srities: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Nepavyko ištrinti naudotojo"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Nepavyko atimti teisių iš nutolusio naudotojo"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Jūs negalite ištrinti savo paskyros."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s vis dar prisijungęs"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Naudotojų ištrynimas, kai jie yra prisijungę, gali palikti sistemą "
+"nekorektiškoje būsenoje."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Ar norite palikti naudotojo %s failus?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Trinant naudotoją galima palikti namų katalogą, paštą ir laikinus failus."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Ištrinti failus"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Palikti failus"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Ar tikrai norite atimti teises iš nuotoliniu būdu tvarkomos paskyros %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Ištrinti"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Paskyra išjungta"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Bus nustatyta kito prisijungimo metu"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Joks"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Prisijunges prie"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Nepavyko susisiekti su paskyrų tarnyba"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Įsitikinkite, kad AccountService yra įdiegta ir įjungta."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Šis skydelis turi būti atrakintas, norint keisti šią nuostatą"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Ištrinti pasirinktą naudotoją"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Pasirinktam naudotojui ištrinti,\n"
+"pirma paspauskite * piktogramą"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Atrakinkite naudotojų pridėjimui bei nustatymų keitimui"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Naudotojai"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Pakeitimams pritaikyti reikia perleisti seansą"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Perleisti dabar"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Užverti"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Keisti atvaizdą"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Pilnas vardas"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Keisti"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Prisijungimas _piršto atspaudu"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatinis prisijungimas"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Paskyros veikla"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administratorius"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administratoriai gali pridėti bei šalinti naudotojos ir keisti visų "
+"naudotojų nustatymus."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Tėvų kontrolė"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Atverti tėvų kontrolės programą."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Pašalinti naudotoją…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Kiti naudotojai"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Pridėti naudotoją…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Nerasta naudotojų"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Atrakinti naujos paskyros sukūrimui."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Pridėti arba šalinti naudotojus bei keiskite savo slaptažodį"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Prisijungimas;Pavadinimas;Piršto atspaudas;Atvaizdas;Logo;Veidas;Slaptažodis;"
+"Tėvų kontrolė;Ekrano laikas;Programų ribojimai;Žiniatinklio ribojimai;"
+"Naudojimas;Naudojimo ribojimai;Vaikas;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "Į_traukti"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Srities administratoriaus prisijungimas"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Kompanijos prisijungimams naudoti, šis kompiuteris turi būti\n"
+"įtrauktas į sritį. Paprašykite tinklo administratoriaus čia\n"
+"įvesti jų srities slaptažodį."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Administratoriaus _vardas"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Administratoriaus slaptažodis"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Tvarkyti naudotojų paskyras"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Reikia patvirtinti tapatybę naudotojų duomenims keisti"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Naujas slaptažodis turi skirtis nuo senojo."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Bandykite raides ir skaitmenis."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Mėginkite labiau pakeisti slaptažodį."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Slaptažodis be naudotojo vardą būtų saugesnis."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Venkite savo vardo slaptažodyje."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Venkite kai kurių į slaptažodį įtrauktų žodžių."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Venkite dažnų žodžių."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Venkite esamų žodžių tvarkos keitimo."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Mėginkite naudoti daugiau skaitmenų."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Mėginkite naudoti daugiau didžiųjų raidžių."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Mėginkite naudoti daugiau mažųjų raidžių."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Mėginkite naudoti daugiau specialiųjų simbolių, pvz. skyrybos ženklų."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Mėginkite naudoti raidžių, skaitmenų ir skyrybos ženklų mišinį."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Venkite to paties simbolio pasikartojimų."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Venkite to paties simbolio pasikartojimų: reikia maišyti raides, skaitmenis "
+"ir skyrybos ženklus."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Venkite sekų 1234, abcd ir pan."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Slaptažodis per trumpas. Mėginkite pridėti daugiau raidžių, skaitmenų ir "
+"skyrybos ženklų mišinį."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Maišykite didžiąsias ir mažąsias raides bei panaudokite skaitmenų."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Pridėję raidžių, skaitmenų ir skyrybos ženklų  padarytumėt jį dar stipresnį."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Tapatybė nepatvirtinta"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Naujas slaptažodis per trumpas"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Naujas slaptažodis per paprastas"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Senas ir naujas slaptažodžiai yra per daug panašūs"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Naujas slaptažodis neseniai jau buvo naudotas."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Naujas slaptažodis turi susidėti iš skaičių arba specialių simbolių"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Senas ir naujas slaptažodžiai sutampa"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Jūsų slaptažodis pakeistas nuo pradinio Jūsų tapatybės atpažinimo!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Naujas slaptažodis Nesusideda iš pakankamai skirtingų simbolių"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Nežinoma klaida"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Naudotojo vardą gali sudaryti tik raidės mažosios raidės a-z, skaitmenys ir "
+"šie simboliai: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Atleiskite, šis naudotojo vardas yra neprieinamas. Bandykite kitą."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Naudotojo vardas per ilgas."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Susieti mygtukus"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Susieti mygtukus su funkcijomis"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Norėdami pakeisti spartųjį klavišą, pasirinkite „siųsti klavišų "
+"kombinaciją“, paspauskite klaviatūros trumpinio mygtuką ir laikykite naujus "
+"klavišus arba spauskite grįžtamąjį trynimą išvalymui."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Užverti"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Palieskite taikinio žymeklius jiems pasirodžius ekrane planšetės "
+"kalibravimui."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Aptiktas klaidingas paspaudimas, perleidžiama…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Mygtukas %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Programos nustatytas"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Siųsti klavišų seką"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Perjungti monitorių"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Rodyti pagalbą ekrane"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Planšetė prijungta ant nešiojamojo kompiuterio skydelio"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Planšetė, prijungta prie išorinio vaizduoklio"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Išorinis planšetinis įrenginys"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#| msgid "External tablet device"
+msgid "External pad device"
+msgstr "Išorinis planšetinis įrenginys"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Visi vaizduokliai"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Planšetės veiksena"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Naudoti absoliučias pozicijas pieštukui"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Kairiarankiams skirta orientacija"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Planšetė ir ekpress klavišai™ yra pasukti kairiarankiui"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Rodyti su monitoriuje"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Išlaikyti proporcijas"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Naudoti tik dalį planšetės paviršiaus išlaikant monitoriaus proporcijas"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibruoti"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Planšetė nerasta"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Prašau prijungti ar įjungti savo Wacom planšetę."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Pieštuko spaudimo jutimas"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Minkštas"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pieštuko galiuko spaudimo jėga"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firma"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Mygtukas 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Mygtukas 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Mygtukas 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Trintuko spaudimo jutimas"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Trintuko spaudimo jėga"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Vidurinio pelės mygtuko paspaudimas"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Dešiniojo pelės mygtuko paspaudimas"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Pirmyn"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Orinis pieštukas yra spaudimo jėga, palenkimu ir integruotu slankikliu"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Orinis pieštukas yra spaudimo jėga, palenkimu ir posūkiu"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standartinis pieštukas su spaudimo jėga ir palenkimu"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standartinis pieštukas su spaudimo jėga"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom planšetė"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Nustatykite mygtukų susiejimus ir pritaikykite pieštuko jautrumą grafinėms "
+"planšetėms"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Planšetė;Wacom;Rašiklis;Trintukas;Pelė;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Naujas trumpinys…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Prieigos taškai"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Veiksmo atsisakyta"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Klaida:</b> prieiga neleista keičiant nuostatas"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Klaida:</b> mobiliosios įrangos klaida"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Neregistruota"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registruota"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Tarptinklinis"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Ieškoma"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Neleista"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modemo detalės"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modemo būsena"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Tinklas"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tinklo tipas"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Tinklo būsena"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Savi skaičiai"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Įrenginio informacija"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Aparatinės programinės įrangos versija"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "tik 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "tik 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "tik 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "tik 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (pageidautina), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (pageidautina), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (pageidautina), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (pageidautina), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (pageidautina), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (pageidautina), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (pageidautina), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (pageidautina), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (pageidautina), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (pageidautina), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (pageidautina), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (pageidautina), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (pageidautina), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (pageidautina), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (pageidautina), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (pageidautina), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (pageidautina)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (pageidautina), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Nežinoma"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Atrakinti SIM kortelę"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Atrakinti"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Pateikite PIN kodą SIM kortelei %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Įveskite PIN SIM kortelei atrakinti"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Pateikite PUK kodą SIM kortelei %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Įveskite PUK kodą SIM kortelei atrakinti"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Įvestas blogas slaptažodis. Liko %1$u bandymas"
+msgstr[1] "Įvestas blogas slaptažodis. Liko %1$u bandymai"
+msgstr[2] "Įvestas blogas slaptažodis. Liko %1$u bandymų"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Liko %1$u bandymas"
+msgstr[1] "Liko %1$u bandymai"
+msgstr[2] "Liko %1$u bandymų"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Įvestas blogas slaptažodis."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK kodas turi būti 8 skaitmenų skaičius"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Įveskite naują PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN kodas turi būti 4-8 skaitmenų skaičius"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Atrakinama…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Nėra SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Jei norite naudoti šį modemą, įdėkite SIM kortelę"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM užrakinta"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobilieji duomenys"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Pasiekite duomenis naudodami mobilųjį tinklą"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Duomenų tarptinklinis"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Naudoti mobiliuosius duomenis tarptinkliniame ryšyje"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Ti_nklo veiksena"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Tinklas"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Sudėtingesni"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Prieigos t_aškų pavadinimai"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM užrakinimas"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Užrakinti SIM su PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "M_odemo informacija"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Telefono klaida"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Nėra ryšio su telefonu"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Veiksmas neleidžiamas"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Veiksmas nepalaikomas"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM neįdėta"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Reikalingas SIM PIN"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Reikalingas SIM PUK"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM klaida"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM užimta"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Neteisingas slaptažodis"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Reikalingas SIM PIN2"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Reikalingas SIM PUK2"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Nerasta"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Nėra tinklo tarnybos"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Baigėsi tinklo laikas"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS tarnyba neleidžiama"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Tarptinklinis ryšys šioje vietovėje neleidžiamas"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Nenurodyta GPRS klaida"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Nėra klaidos"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Veiksmo atsisakyta"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Prieiga neleidžiama"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Nežinoma klaida"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Tinklo veiksena"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatinis"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Pasirinkti tinklą"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Atnaujinti tinklų tiekėjus"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Įjungti mobilųjį tinklą"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nerasta WWAN adapterių"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Įsitikinkite, kad turite belaidį/mobilųjį įrenginį"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Belaidis ryšys yra išjungtas skrydžio veiksenoje"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Išjung_ti skrydžio veikseną"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Duomenų ryšys"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM kortelė, naudojama internetui"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM užrakinimas"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Kitas"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Užrakinti SIM su PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Keisti PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Įveskite dabartinį PIN SIM užrakto nuostatoms keisti"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobilusis tinklas"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Konfigūruoti telefonijos ir mobiliųjų duomenų ryšius"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "mobilusis;wwan;telefonija;sim;mibilusis;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Įrankis GNOME grafinės aplinkos konfigūravimui"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Nustatymai yra pirminė sąsaja jūsų sistemos konfigūravimui."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME projektas"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Rodyti versijos numerį"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Įjungti derinimo veikseną"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Ieškoti eilutės"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Išvardinti galimus skydelių pavadinimus ir išeiti"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Rodomas skydelis"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[SKYDELIS] [ARGUMENTAS…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Nuostatų kategorijos"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privatumas"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Prieinami skydeliai:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Visi nustatymai"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Pagrindinis meniu"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Įspėjimas: kuriama versija"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Ši Nustatymų versija turėtų būti naudojama tik kūrimo reikmėms. Sistema gali "
+"veikti nekorektiškai, gali būti prarasti duomenys ar kilti kitų problemų."
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Pagalba"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Bendri"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Išeiti"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Paieška"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Skydeliai"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Grįžti į ankstesnį skydelį"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Atšaukti paiešką"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Nuostatos;Nustatymai;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Paskutinio atverto Nustatymų skydelio identifikatorius"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Paskutinio atverto Nustatymų skydelio identifikatorius. Neatpažintų verčių "
+"bus nepaisoma ir bus atvertas pirmas skydelis iš sąrašo."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Rodyti įspėjimą vykdant Nustatymų kuriamą versiją"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "Ar Nustatymai turėtų rodyti įspėjimą vykdant kuriamą versiją."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Pradinė lango būsena"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Junginys su programos lango pradiniu pločiu, aukščiu ir išdidinimo būsena."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u išvestis"
+msgstr[1] "%u išvestys"
+msgstr[2] "%u išvesčių"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u įvestis"
+msgstr[1] "%u įvestys"
+msgstr[2] "%u įvesčių"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sistemos garsai"
+
+#~| msgid "Take a screenshot of a window"
+#~ msgid "Take screenshots of the desktop."
+#~ msgstr "Padaryti darbalaukio nuotrauką."
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Klaida: nepavyko nustatyti HSI lygio."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Klaida: nepavyksta nustatyti neteisingo HSI lygio."
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER arba PEM liudijimai (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Pridėti spausdintuvą…"
+
+#~ msgid "Drip"
+#~ msgstr "Lašėjimas"
+
+#~ msgid "Glass"
+#~ msgstr "Stiklas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonaras"
+
+#~ msgid "No Protection"
+#~ msgstr "Nėra apsaugos"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "Minimali apsauga"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Bazinė apsauga"
+
+#~ msgid "Extended Protection"
+#~ msgstr "Išplėstinė apsauga"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "Minimali apsauga"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Bazinė apsauga"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Išplėstinė apsauga"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Ekranų išdėstymas"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "Saugus paleidimas yra neaktyvus"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI rašymas"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI rakinimas"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "SPI BIOS regionas"
+
+#~ msgid "Pre-boot DMA protection is"
+#~ msgstr "Prieš įkėlimą DMA apsauga yra"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "Branduolys suteptas"
+
+#~| msgid "Suspend"
+#~ msgid "Suspend-to-ram"
+#~ msgstr "Pristabdyti atmintyje"
+
+#~ msgid "All TPM PCRs are"
+#~ msgstr "Visi TPM PCR yra"
+
+#~| msgid "Manufacturer"
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "MEI gamintojo veiksena"
+
+#~ msgid "MEI override"
+#~ msgstr "MEI perrašymas"
+
+#~| msgid "PEAP _version"
+#~ msgid "MEI version"
+#~ msgstr "MEI versija"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "fwupd įskiepiai"
+
+#~ msgid "Intel DCI debugger"
+#~ msgstr "Intel DCI derintuvė"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "IOMMU įrenginio apsauga įjungta"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "IOMMU įrenginio apsauga išjungta"
+
+#~ msgid "Kernel is no longer tainted"
+#~ msgstr "Branduolys daugiau nėra suteptas"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "Branduolys suteptas"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "Branduolio užrakinimas išjungtas"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "Branduolio užrakinimas įjungtas"
+
+#~ msgid "Pre-boot DMA protection is disabled"
+#~ msgstr "DMA apsauga prieš įkėlimą yra išjungta"
+
+#~ msgid "Pre-boot DMA protection is enabled"
+#~ msgstr "DMA apsauga prieš įkėlimą yra įjungta"
+
+#~| msgctxt "Password mode"
+#~| msgid "Account disabled"
+#~ msgid "Secure Boot disabled"
+#~ msgstr "Saugus įkėlimas yra išjungtas"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "Saugus įkėlimas yra įjungtas"
+
+#~ msgid "All TPM PCRs are valid"
+#~ msgstr "Visi TPM PCR yra teisingi"
+
+#~ msgid "All TPM PCRs are now valid"
+#~ msgstr "Visi TPM PCR dabar yra teisingi"
+
+#~ msgid "A TPM PCR is now an invalid value"
+#~ msgstr "TPM PCR dabar yra neteisingos vertės"
+
+#~ msgid "TPM PCR0 reconstruction is invalid"
+#~ msgstr "TPM PCR0 rekonstrukcija yra netinkama"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Užrakinti ekraną"
+
+#~ msgid "Light"
+#~ msgstr "Šviesus"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "ekranas;užrakinimas;diagnostika;lūžimas;privatus;neseniai naudoti;"
+#~ "laikinieji;indeksas;pavadinimas;tinklas;tapatybė;"
+
+#~ msgid "Set"
+#~ msgstr "Nustatyti"
+
+#~ msgid "Bark"
+#~ msgstr "Lojimas"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "GNOME nustatymų garso skydelis"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "GNOME nustatymų pelės ir jutiklinio kilimėlio skydelis"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "GNOME nustatymų fono skydelis"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "GNOME nustatymų klaviatūros skydelis"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Patvirtinti tapatybę"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Dalijimasis ekranu leidžia nutolusiems naudotojams matyti ar valdyti jūsų "
+#~ "ekraną prisijungiant prie %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Ekrano bendrinimas"
+
+#~ msgid "_Password:"
+#~ msgstr "Sla_ptažodis:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Rodyti slaptažodį"
+
+#~ msgid "Access Options"
+#~ msgstr "Prieigos parametrai"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Nauji ryšiai turi prašyti prieigos"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Reikalauti slaptažodžio"
+
+#~ msgid "More Warm"
+#~ msgstr "Šilčiau"
+
+#~ msgid "Less Warm"
+#~ msgstr "Šalčiau"
+
+#~| msgid "Screenshots"
+#~ msgid "Show the screenshot UI"
+#~ msgstr "Rodyti ekrano nuotraukos sąsają"
+
+#~| msgid "Screenshots"
+#~ msgid "Take a screenshot"
+#~ msgstr "Padaryti ekrano nuotrauką"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "Rodyti ekrano įrašymo sąsają"
+
+#~ msgid "Move up"
+#~ msgstr "Pakelti"
+
+#~ msgid "Move down"
+#~ msgstr "Nuleisti"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Leisti žemiau nurodytoms programoms naudoti jūsų mikrofoną."
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Pasirinkite skaičių, datos ir pinigų formatus. Pakeitimai įsigalios kitą "
+#~ "kartą prisijungus."
+
+#~ msgid "My Account"
+#~ msgstr "Mano paskyra"
+
+#~ msgid "Language"
+#~ msgstr "Kalba"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Kalba, naudojama tekstui languose ir interneto puslapiuose."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Pakeitimams pritaikyti reikia perleisti seansą"
+
+#~ msgid "Restart…"
+#~ msgstr "Perleisti…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Prisijungimo nustatymai yra naudojami visų naudotojų, prisijungiant prie "
+#~ "sistemos"
+
+#~ msgid "Standard"
+#~ msgstr "Standartinis"
+
+#~ msgid "Account _Type"
+#~ msgstr "Paskyros _tipas"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Leisti naudotojui nustatyti slaptažodį kito _prisijungimo metu"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_Nustatyti slaptažodį dabar"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Turite būti prisijungęs prie tinklo kompanijos naudotojams pridėti."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Nufotografuoti…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pakeitimams atlikti,\n"
+#~ "pirma paspauskite * piktogramą"
+
+#~ msgid "Create a user account"
+#~ msgstr "Sukurti naują paskyrą"
+
+#~ msgid "User Icon"
+#~ msgstr "Naudotojo piktograma"
+
+#~ msgid "Account Settings"
+#~ msgstr "Paskyros nustatymai"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Tapatybės patvirtinimas ir prisijungimas"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "Tai bus naudojama kaip jūsų namų aplankas ir negalės būti pakeista."
+
+#~ msgid "Web Links"
+#~ msgstr "Žiniatinklio saitai"
+
+#~ msgid "Git Links"
+#~ msgstr "Git saitai"
+
+#~ msgid "%s Links"
+#~ msgstr "%s saitai"
+
+#~ msgid "Unset"
+#~ msgstr "Atstatyti"
+
+#~ msgid "Links"
+#~ msgstr "Saitai"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hiperteksto failai"
+
+#~ msgid "Text Files"
+#~ msgstr "Tekstiniai failai"
+
+#~ msgid "Image Files"
+#~ msgstr "Paveikslėlių failai"
+
+#~ msgid "Font Files"
+#~ msgstr "Šriftų failai"
+
+#~ msgid "Archive Files"
+#~ msgstr "Archyvų failai"
+
+#~ msgid "Package Files"
+#~ msgstr "Paketų failai"
+
+#~ msgid "Audio Files"
+#~ msgstr "Garso failai"
+
+#~ msgid "Video Files"
+#~ msgstr "Vaizdo įrašų failai"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Leidimai ir prieiga"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Duomenys ir tarnybos, prie kurių šį programa paprašė prieigos, bei "
+#~ "leidimai, kurių jai reikia."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Negalima keisti"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Pavienius programų leidimų galima peržiūrėti <a "
+#~ "href=\"privacy\">privatumo</a> nustatymuose."
+
+#~ msgid "Integration"
+#~ msgstr "Integracija"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Nustatyti darbalaukio foną"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Numatytieji apdorotojai"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Failų tipai bei saitai, kuriuos ši programa atveria."
+
+#~ msgid "Usage"
+#~ msgstr "Naudojimas"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Kiek išteklių ši programa naudoja."
+
+#~ msgid "Open in Software"
+#~ msgstr "Atverti Programinėje įrangoje"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Leisti žemiau nurodytoms programoms naudoti kamerą."
+
+#~ msgid "Display Mode"
+#~ msgstr "Rodymo veiksena"
+
+#~ msgid "Join Displays"
+#~ msgstr "Sujungti ekranus"
+
+#~ msgid "Single Display"
+#~ msgstr "Vienas ekranas"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Tempkite ekranų paveikslėlius, kad jie atitiktų jų fizinį išdėstymą. "
+#~ "Pažymėkite ekraną jo nustatymams keisti."
+
+#~ msgid "Active Display"
+#~ msgstr "Aktyvus ekranas"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Įrašyti ekrano nuotrauką į $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Įrašyti srities nuotrauką į $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopijuoti ekrano nuotrauką į iškarpinę"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopijuoti lango nuotrauką į iškarpinę"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopijuoti srities nuotrauką į iškarpinę"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Įrašytą trumpą ekrano filmuką"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Vietos tarnybos leidžia programoms žinoti jūsų geografinę vietą. "
+#~ "Tikslumas padidinamas įjungiant WiFi bei mobilųjį plačiajuosti tinklą."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Naudoja Mozilla vietos tarnybą: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Privatumo politika</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr ""
+#~ "Leisti žemiau išvardintoms programoms gauti jūsų vietovės informaciją."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Aptikta uždanga: galinga veiksena negalima"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Aukšta aparatūros temperatūra: galinga veiksena negalima"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Galinga veiksena negalima"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Valdykite, kurie paieškos rezultatai rodomi veiklų apžvalgoje. Taip pat "
+#~ "galima nustatyti paieškos rezultatų eilės tvarką stumdant eilutes sąraše."
+
+#~ msgid "Sound Keys"
+#~ msgstr "Garso klavišai"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Ekrano skaityklė"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Ekrano _skaityklė"
+
+#~ msgid "Output:"
+#~ msgstr "Išvestis:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Išlaikyti proporcijas (laiško dėžutė):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Rodyti viename monitoriuje"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d iš %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Ekrano susiejimas"
+
+#~ msgid "Stylus"
+#~ msgstr "Pieštukas"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Planšetė (absoliučioji)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Jutiklinis kilimėlis (santykinis)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Piešimo planšetės nuostatos"
+
+#~ msgid "_Help"
+#~ msgstr "_Pagalba"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth nustatymai"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Sekimo veiksena"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Susieti mygtukus..."
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Koreguokite pelės nustatymus"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Pritaikyti ekrano raišką"
+
+#~ msgid "No stylus found"
+#~ msgstr "Nerasta pieštukų"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Norėdami tęsti perkelkite savo pieštukus arčiau planšetės konfigūravimui"
+
+#~ msgid "Top Button"
+#~ msgstr "Viršutinysis mygtukas"
+
+#~ msgid "Lower Button"
+#~ msgstr "Apatinysis mygtukas"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Apatinysis mygtukas"
+
+#~ msgid "Activities"
+#~ msgstr "Veiklos"
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopijuoti"
+
+#~ msgid "Select _All"
+#~ msgstr "Pasirinkti _viską"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Dvigubo paspaudimo laikas"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Pristabdymas ir įjungimo mygtukas"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Kai kurios tarnybos yra išjungtos, nes nėra tinklo prieigos."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Nepavyko nusiųsti failo: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profilis buvo nusiųstas į:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Užsirašyti šį URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Paleisti kompiuterį iš naujo ir įkelti normalią operacinę sistemą."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Įveskite URL naršyklėje profilio parsiuntimui ir įdiegimui."
+
+#~ msgid "Upload profile"
+#~ msgstr "Nusiųsti profilį"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Reikalauja interneto ryšio"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Atrakinama..."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Prisijungimo vardas;Vardas;Piršo atspaudas;Atvaizdas;Logotipas;Veidas;"
+#~ "Slaptažodis;"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Ekrano šviesumas"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Klaviatūros šviesumas"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Pritemdyti ekraną, kai kompiuteris nenaudojamas"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Išjungti ekraną"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wi-Fi gali būti išjungtas energijos taupymui."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Mobilųjį plačiajuostį (3G, 4G, LTE ir kt.) galima išjungti energijai "
+#~ "taupyti."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth galima išjungti energijos taupymui."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Balansuotas energijos suvartojimas"
+
+#~ msgid "Add…"
+#~ msgstr "Pridėti…"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Klaviatūros trumpinys"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Galima keisti trumpiniams tinkinti"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Laikykite nuspaudę ir spausdinkite skirtingiems simboliams įvesti"
+
+#~ msgid "Left Alt"
+#~ msgstr "Kairysis Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Dešinysis Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Kairysis Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Dešinysis Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Dešinysis Vald"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Alternatyvių simbolių klavišas"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Tik modifikatoriai perjungia į kitą šaltinį"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Meniu klavišas"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Įkraunama"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Įspėjimas"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Žemas"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Geras"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Pilnai įkrautas"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Tuščia"
+
+#~ msgid "Previous source"
+#~ msgstr "Ankstesnis šaltinis"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Lyg2+Tarpas"
+
+#~ msgid "Next source"
+#~ msgstr "Kitas šaltinis"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Tarpa"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Kairėn+dešinysis alt"
+
+#~ msgid "Universal Access"
+#~ msgstr "Universali prieiga"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Išjungti prisijungimui prie belaidžio tinklo"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Slaptažodis"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Leisti prisijungti piršto antspaudu"
+
+#~ msgid "_Other finger:"
+#~ msgstr "Kitas _pirštas:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Pirštų antspaudai sėkmingai įrašyti. Dabar galite prisijungti "
+#~ "naudodamiesi pirštų antspaudų skaitytuvu."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Jums neleidžiama naudotis šiuo įrenginiu. Susisiekite su sistemos "
+#~ "administratoriumi."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Įvyko vidinė klaida."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Ar ištrinti įrašytus pirštų antspaudus?"
+
+#~ msgid "Done!"
+#~ msgstr "Baigta!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Nepavyko pasiekti įrenginio „%s“"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Nepavyko pradėti piršto antspaudo nuskaitymo įrenginiu „%s“"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Nepavyko pasiekti pirštų antspaudų skaitytuvo"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Susisiekite su sistemos administratoriumi, jei reikia pagalbos."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Jei norite prisijungti pirštų antspaudu, turite įrašyti bent vieną iš "
+#~ "savo pirštų antspaudų įrenginiu „%s“."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Pasirinkite pirštą"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Pridėti arba šalinti naudotojus bei keisti slaptažodžius"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Groti ir įrašyti garsą"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Aptikti tinklo įrenginius naudojant mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Tiesiogiai pasiekti bluetooth aparatūrą"
+
+#~ msgid "Use your camera"
+#~ msgstr "Naudoti jūsų kamerą"
+
+#~ msgid "Print documents"
+#~ msgstr "Spausdinti dokumentus"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Naudoti bet kurį prijungtą žaidimų pultą"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Leisti prisijungti prie Docker tarnybos"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Konfigūruoti tinklo ugniasienę"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Nustatyti ir naudoti privilegijuotas FUSE failų sistemas"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Atnaujinti šio įrenginio aparatinę programinę įrangą"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Pasiekti aparatinės įrangos informaciją"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Pateikti entropiją aparatiniam atsitiktinių skaičių generatoriui"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Naudoti aparatūros sugeneruotus atsitiktinius skaičius"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Pasiekti failus jūsų namų aplanke"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Pasiekti libvirt tarnybą"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Keiskti sistemos kalbos ir regiono nustatymus"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Keisti vietos nustatymus bei tiekėjus"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Skaityti sistemos ir programų žurnalus"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "pasiekti media-hub tarnybą"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Naudoti ir konfigūruoti modemus"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Skaityti sistemos prijungimo informaciją bei diskų kvotas"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Valdyti muzikos bei vaizdo grotuvus"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Keisti žemo lygmens tinklo nustatymus"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Pasiekti NetworkManager tarnybą tinklo nustatymams skaityti bei keisti"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Skaitymo prieiga prie tinklo nustatymų"
+
+#~ msgid "Change network settings"
+#~ msgstr "Keisti tinklo nustatymus"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Prieiga prie ofono tarnybos tinklo nustatymams skaityti bei keisti "
+#~ "mobiliai telefonijai"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Valdyti Open vSwitch aparatūrą"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Skaityti iš CD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Skaityti, pridėti, keisti arba šalinti įrašytus slaptažodžius"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Pasiekti pppd ir ppp įrenginius Point-to-Point protokolo ryšiams "
+#~ "konfigūruoti"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Pristabdyti arba užbaigti procesą sistemoje"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Tiesiogiai pasiekti USB aparatūrą"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Rašyti/skaityti failus išimamose laikmenose"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Neleisti ekranui užmigti/užsirakinti"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Pasiekti serijinių prievadų aparatūrą"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Perleisti arba išjungti įrenginį"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Įdiegti, pašalinti arba konfigūruoti programinę įrangą"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Pasiekti saugyklos karkaso tarnybą"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Skaityti proceso bei sistemos informaciją"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Stebėti bei valdyti bet kurią veikiančią programą"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Keisti datą ir laiką"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Keiskite laiko serverio nustatymus"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Keiskite laiko juostą"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr "Pasiekti UDisks2 tarnybą diskų ir išimamų laikmenų konfigūravimui"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Skaityti/keisti bendrinamus kalendoriaus įvykius Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Skaityti/keisti bendrinamus kontaktus Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Pasiekti energijos naudojimo duomenis"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Skaitymo/rašymo prieiga prie U2F įrenginių"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Naudotojui sukurti,\n"
+#~ "pirma paspauskite * piktogramą"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Nustatyti foną ir užrakinimo ekraną"
+
+#~ msgid "Set Background"
+#~ msgstr "Nustatyti foną"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Nustatyti užrakinimo ekraną"
+
+#~ msgid "Remove Background"
+#~ msgstr "Pašalinti foną"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Pranešimai yra siunčiami anonimiškai, o asmeniniai duomenys yra išdarkomi."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Pranešimų apie technines problemas siuntimas mums padeda pagerinti šią "
+#~ "operacinę sistemą."
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Riboti duomenų naudojimą _fone"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Tinkama ryšiams, kur duomenys yra apmokestinami arba ribojami."
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Pranešimų iššokimai"
+
+#~ msgid "No regions found"
+#~ msgstr "Nerasta regionų"
+
+#~ msgid "Last Login"
+#~ msgstr "Paskutinis prisijungimas"
+
+#~ msgid "Version %s"
+#~ msgstr "Versija %s"
+
+#~ msgid "OS name"
+#~ msgstr "OS pavadinimas"
+
+#~ msgid "OS type"
+#~ msgstr "OS tipas"
+
+#~ msgid "Disk"
+#~ msgstr "Diskas"
+
+#~ msgid "Check for updates"
+#~ msgstr "Tikrinti, ar yra atnaujinimų"
+
+#~ msgid "Network proxy"
+#~ msgstr "Tarpinis tinklo serveris"
+
+#~ msgid "page 1"
+#~ msgstr "puslapis 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Vidinis t_apatybės patvirtinimas"
+
+#~ msgid "page 2"
+#~ msgstr "puslapis 2"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Sukta pora (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Prijungiamo modulio sąsaja (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Nuo laikmenos nepriklausanti sąsaja (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Persijungimas prie belaidžio prieigos taško atjungs jus nuo <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Neįmanoma pasiekti interneto per jūsų belaidį, kol prieigos taškas yra "
+#~ "aktyvus."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Belaidžiai prieigos taškai dažniausiai dalinasi papildomu interneto ryšių "
+#~ "per Wi-Fi."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "A_utomatinis prisijungimas"
+
+#~ msgid "details"
+#~ msgstr "išsamiau"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Rodyti sl_aptažodį"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Padaryti pasiekiamu kitiems naudotojams"
+
+#~ msgid "identity"
+#~ msgstr "tapatybė"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adresai"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Tik automatiniai (DHCP) adresai"
+
+#~ msgid "Link-local only"
+#~ msgstr "Tik vietiniai susiejimai"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Nepaisyti automatiškai gaunamų kelių"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Klonuotas MAC adresas"
+
+#~ msgid "_Reset"
+#~ msgstr "_Atstatyti"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Atstatyti numatytuosius šio ryšio nustatymus, bet atsiminti jį kaip "
+#~ "pageidaujamą."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Pašalinti visus su šiuo ryšiu susijusius duomenis ir nemėginti "
+#~ "automatiškai prie jo prisijungti."
+
+#~ msgid "Hardware"
+#~ msgstr "Aparatinė įranga"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Atstatyti"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Prisijungti įrenginiai"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastruktūra"
+
+#~ msgid "In use"
+#~ msgstr "Naudojama"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Įjungta"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Išjungta"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Išjungta"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Įjungta"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Išjungta"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Įjungta"
+
+#~ msgid "Usage & History"
+#~ msgstr "Naudojimas ir istorija"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Privatumo politika"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Istorijos įsiminimas leidžia lengviau vėl rasti dalykus. Šiais elementais "
+#~ "niekada nesidalinama tinkle."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Neseniai naudoti"
+
+#~ msgid "Retain _History"
+#~ msgstr "Išlaikyti _istoriją"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Ekrano užrakinimas apsaugo jūsų privatumą, kai esate atsitraukęs."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Užr_akinti ekraną po tuščio praėjus"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Pranešimai ekrano užrakte"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Automatiškai išvalyti šiukšlinę ir laikinuosius failus, siekiant "
+#~ "nelaikyti kompiuteryje nereikalingos ir jautrios informacijos."
+
+#~ msgid "Purge _After"
+#~ msgstr "Išv_alyti po"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Atsiųsdami mums informaciją apie naudojamą programinę įrangą padės mums "
+#~ "pateikti jums tikslesnes rekomendacija. Tai taip pat mums padeda "
+#~ "tobulinti programinę įrangą.\n"
+#~ "\n"
+#~ "Visa surinkta informacija yra anoniminė, ja niekada nebus dalinamasi su "
+#~ "trečiosiomis šalimis."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Siųsti programinės įrangos naudojimo statistiką"
+
+#~ msgid "_Camera"
+#~ msgstr "_Kamera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Mikrofonas"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Vietos tarnybos"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Apsaugokite asmeninę informaciją ir valdykite, ką kiti gali matyti"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Blykstelti _lango antraštę"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Naudotojo vardas negali prasidėti simboliu „-“."
+
+#~ msgid "_Background"
+#~ msgstr "_Fonas"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Pakeitimai per dieną"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Išdėstyti"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Keisti mastelį"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centruoti"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Ištempti"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Užpildyti"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Apgaubti"
+
+#~ msgid "Colors"
+#~ msgstr "Spalvos"
+
+#~ msgid "Pictures"
+#~ msgstr "Paveikslėliai"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Nerasta paveikslėlių"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Galite pridėti paveikslėlių į aplanką %s ir juos matysite čia"
+
+#~ msgid "_Off"
+#~ msgstr "_Išjungta"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Ryšys/SSID"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automatinis pristabdymas"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Kai nuspaudžiamas įjungimo mygtukas"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Naktinis apšvietimas"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Nepavyko gauti ekrano informacijos"
+
+#~ msgid "Add input source"
+#~ msgstr "Pridėti įvesties šaltinį"
+
+#~ msgid "Remove input source"
+#~ msgstr "Pašalinti įvesties šaltinį"
+
+#~ msgid "Move input source up"
+#~ msgstr "Pakelti įvesties šaltinį"
+
+#~ msgid "Move input source down"
+#~ msgstr "Neleisti įvesties šaltinį"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Rodyti įvesties šaltinio klaviatūros išdėstymą"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Kairė"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Dešinė"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Mažiausia"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Didžiausia"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "Žemų garsų _stiprintuvas:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profilis:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Tikrinti garsiakalbius"
+
+#~ msgid "Peak detect"
+#~ msgstr "Viršūnių aptikimas"
+
+#~ msgid "Device"
+#~ msgstr "Įrenginys"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s garsiakalbių testavimas"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Pasirinkite garso išvesties įrenginį:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Pasirinkto įrenginio nustatymai:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Į_vesties garsumas:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Pasirinkite garso įvesties įrenginį:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Garso efektai"
+
+#~ msgid "Built-in"
+#~ msgstr "Vidinis"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Garso nuostatos"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Testuojamas įvykio garsas"
+
+#~ msgid "From theme"
+#~ msgstr "Iš temos"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Pasirinkite įspėjimo garsą:"
+
+#~ msgid "Stop"
+#~ msgstr "Stabdyti"
+
+#~ msgid "hardware"
+#~ msgstr "aparatinė įranga"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Perjungti į ankstesnį šaltinį"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Perjungti į kitą šaltinį"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Alternatyvus perjungimas į kitą šaltinį"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Anglų (Jungtinė Karalystė)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Jungtinė Karalystė"
+
+#~ msgid "_Options"
+#~ msgstr "_Parametrai"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standartinis"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administratorius"
+
+#~ msgid "page 3"
+#~ msgstr "puslapis 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME valdymo centras"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Valdymo centras yra GNOME pagrindinė sąsaja įvairių darbalaukio aspektų "
+#~ "konfigūravimui."
+
+#~ msgid "Quit"
+#~ msgstr "Išeiti"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Tikrinti naują slaptažodį"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Slaptažodžiai nesutampa."
+
+#~ msgid "Show the overview"
+#~ msgstr "Rodyti apžvalgą"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "Uždėkite kairįjį nykštį ant %s"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "Perbraukite kairiuoju nykščiu per %s"
+
+#~| msgid "_Left index finger"
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "Uždėkite kairįjį smilių ant %s"
+
+#~| msgid "_Left index finger"
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "Perbraukite kairiuoju smiliumi per %s"
+
+#~| msgid "Left middle finger"
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "Uždėkite kairįjį didįjį pirštą ant %s"
+
+#~| msgid "Left middle finger"
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "Perbraukite kairiuoju didžiuoju pirštu per %s"
+
+#~| msgid "Left ring finger"
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "Uždėkite kairįjį bevardį pirštą ant %s"
+
+#~| msgid "Left ring finger"
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "Perbraukite kairiuoju bevardžių pirštu per %s"
+
+#~| msgid "Left little finger"
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "Uždėkite kairįjį mažąjį pirštą ant %s"
+
+#~| msgid "Left little finger"
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "Perbraukite kairiuoju mažuoju pirštu per %s"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "Uždėkite dešinįjį nykštį ant %s"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "Perbraukite dešiniuoju nykščiu per %s"
+
+#~| msgid "_Right index finger"
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "Uždėkite dešinįjį smilių ant %s"
+
+#~| msgid "_Right index finger"
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "Perbraukite dešiniuoju smiliumi per %s"
+
+#~| msgid "Right middle finger"
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "Uždėkite dešinįjį didįjį pirštą ant %s"
+
+#~| msgid "Right middle finger"
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "Perbraukite dešiniuoju didžiuoju pirštu per %s"
+
+#~| msgid "Right ring finger"
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "Uždėkite dešinįjį bevardį pirštą ant %s"
+
+#~| msgid "Right ring finger"
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "Perbraukite dešiniuoju bevardžiu pirštu per %s"
+
+#~| msgid "Right little finger"
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "Uždėkite dešinįjį mažąjį pirštą ant %s"
+
+#~| msgid "Right little finger"
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "Perbraukite dešiniuoju mažuoju pirštu per %s"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "Uždėkite pirštą ant skaityklės dar kartą"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "Perbraukite pirštu dar kartą"
+
+#~ msgid "Swipe was too short; try again"
+#~ msgstr "Perbraukimas per trumpas; bandykite dar kartą"
+
+#~ msgid "Your finger was not centered; try swiping your finger again"
+#~ msgstr "Jūsų pirštas nebuvo centruotas; pabandykite perbraukti dar kartą"
+
+#~ msgid "Remove your finger and try swiping it again"
+#~ msgstr "Atitraukite pirštą ir bandykite perbraukti juo dar kartą"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "Perbraukimas buvo per trumpas, bandykite dar kartą"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr ""
+#~ "Jūsų pirštas nebuvo centruotas, pabandykite juo perbraukti dar kartą"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "Atitraukite pirštą ir pabandykite juo perbraukti dar kartą"
+
+#~ msgid "Disable image"
+#~ msgstr "Išjungti paveikslėlį"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Naršyti daugiau paveikslėlių..."
+
+#~ msgid "Used by %s"
+#~ msgstr "Naudoja %s"
+
+#~ msgid "Back­ground"
+#~ msgstr "Fonas"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Spalva"
+
+#~ msgid "Overview"
+#~ msgstr "Apžvalga"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Numatytosios programos"
+
+#~ msgid "Ab­out"
+#~ msgstr "Apie"
+
+#~ msgid "De­tails"
+#~ msgstr "Išsamiau"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Išimamos laikmenos"
+
+#~ msgid "Net­work"
+#~ msgstr "Tinklas"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Pranešimai"
+
+#~ msgid "Po­wer"
+#~ msgstr "Energija"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Privatumas"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Dalinimasis"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Universali prieiga"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wacom planšetė"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Aparatinė įranga"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistema"
+
+#~| msgid "_Apply"
+#~ msgid "Apply"
+#~ msgstr "Pritaikyti"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Užvertas"
+
+#~ msgid "Mirrored"
+#~ msgstr "Dubliuoti"
+
+#~ msgid "Secondary"
+#~ msgstr "Antrinis"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Išdėstyti vaizduoklius"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Tempkite vaizduoklius jų išdėstymui"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Pasukti 90° prieš laikrodžio rodyklę "
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Pasukti 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Pasukti 90° pagal laikrodžio rodyklę"
+
+#~ msgid "Size"
+#~ msgstr "Dydis"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Rodyti viršutinę juostą ir veiklų apžvalgą šiame vaizduoklyje"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Prijungti šį vaizduoklį prie kito, papildomai darbo sričiai sukurti"
+
+#~ msgid "Presentation"
+#~ msgstr "Pateiktis"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Rodyti tik skaidres ir daugialypę terpę"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Rodyti jūsų esamą vaizdą abiejuose vaizduokliuose"
+
+#~ msgid "Turn Off"
+#~ msgstr "Išjungti"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Nenaudoti šio vaizduoklio"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "Iš_dėstyti sujungtus vaizduoklius"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "_Skrydžio veiksena"
+
+#~ msgid "Server"
+#~ msgstr "Serveris"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Ištrinti DNS serverį"
+
+#~ msgid "Proxy"
+#~ msgstr "Tarpinis serveris"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Pridėti profilį…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Joks"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Rankinis"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatinis"
+
+#~ msgid "_Method"
+#~ msgstr "_Metodas"
+
+#~ msgid "Group Name"
+#~ msgstr "Grupės pavadinimas"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "Na_udoti kaip prieigos tašką..."
+
+#~ msgid "_History"
+#~ msgstr "_Istorija"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bitų (Sukūrimo ID: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bitų"
+
+#~ msgid "Base system"
+#~ msgstr "Bazinė sistema"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Spauskite Esc atsisakymui."
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Padaryti prieinamu kitiems na_udotojams"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Atstatyti šio tinklo nustatymus, įskaitant slaptažodžius, bet atsiminti "
+#~ "jį kaip pageidaujamą tinklą"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Pašalinti visas su šiuo tinklu susijusias detales ir nebemėginti "
+#~ "automatiškai prisijungti"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Jei turite kitokį interneto ryšį nei belaidis, galite nustatyti belaidį "
+#~ "prieigos tašką ir dalintis interneto ryšiu su kitais."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Mėginkite naudoti daugiau raidžių, skaitmenų ir simbolių."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Stiprumas: silpnas"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Stiprumas: silpnokas"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Stiprumas: vidutinis"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Stiprumas: geras"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Stiprumas: labai geras"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Trumpinys;Pakartoti;Mirksėti;"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Ugniasienės _zona"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Numatyta"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Zona nustato ryšio pasitikėjimo lygį"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Jūsų paskyra</small>"
+
+#~| msgid "Set Shortcut"
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Nustatyti trumpinį"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Pranešimų išš_okimai"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Pranešimų išš_okimai"
+
+#~ msgid "Add Account"
+#~ msgstr "Pridėti paskyrą"
+
+#~ msgid "Mail"
+#~ msgstr "Paštas"
+
+#~ msgid "Calendar"
+#~ msgstr "Kalendorius"
+
+#~ msgid "Contacts"
+#~ msgstr "Kontaktai"
+
+#~ msgid "Chat"
+#~ msgstr "Pokalbiai"
+
+#~ msgid "Error creating account"
+#~ msgstr "Klaida kuriant paskyrą"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Ar tikrai norite pašalinti paskyrą?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Tai nepašalins šios paskyros serveryje."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Nėra nustatytų internetinių paskyrų"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Paskyros pridėjimas leidžia jūsų programoms ją prieiti dokumentams, "
+#~ "paštui, kontaktams, kalendoriui, pokalbiams ir kt."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Konfigūruojama"
+
+#~ msgid "Toner Level"
+#~ msgstr "Dažų lygis"
+
+#~ msgid "Supply Level"
+#~ msgstr "Tiekimo lygis"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Diegiama"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktyvus"
+#~ msgstr[1] "%u aktyvūs"
+#~ msgstr[2] "%u aktyvių"
+
+#~ msgid "Supply"
+#~ msgstr "Tiekimas"
+
+#~ msgid "Jobs"
+#~ msgstr "Darbai"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Rodyti _darbus"
+
+#~ msgid "label"
+#~ msgstr "žyma"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Spausdinti _testinį puslapį"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Kitos paskyros"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Aukštyn"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Žemyn"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Nėra"
+
+#~ msgid "Left Ring"
+#~ msgstr "Kairysis ratukas"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Skambinimo veiksena #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Dešiniojo ratuko veiksena #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Kairiosios liečiamosios juostelės"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Kairiųjų liečiamų juostelių veiksena #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Dešiniosios liečiamosios juostelės"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Dešiniųjų liečiamų juostelių veiksena #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Kairiojo liečiamojo rateliu veiksenos jungiklis"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Dešiniojo liečiamojo rateliu veiksenos jungiklis"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Kairiųjų liečiamųjų juostelių veiksenos jungiklis"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Dešiniųjų liečiamųjų juostelių veiksenos jungiklis"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Veiksenos jungiklis #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Kairysis mygtukas #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Dešinysis mygtukas #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Viršutinis mygtukas #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Apatinis mygtukas #%d"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Kairiojo pelės mygtuko paspaudimas"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Slinkimas aukštyn"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Slinkimas žemyn"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Slinkimas dešinėn"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Pridėti naują spausdintuvą"
+
+#~ msgid "No printers detected."
+#~ msgstr "Nerasta spausdintuvų."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr ""
+#~ "Klaviatūros trumpinys <b>%s</b>. Įveskite naują trumpinį pakeitimui."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Norėdami pakeisti spartųjį klavišą, spustelėkite atitinkamą eilutę ir "
+#~ "paspauskite spartųjį klavišą arba spauskite Backspace išvalymui."
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Klaida prisijungiant prie paskyros"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Baigėsi įgaliojimai"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Prisijunkite šiai paskyrai įjungti."
+
+#~ msgid "_Sign In"
+#~ msgstr "Pri_sijungti"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Pašalinti trumpinį"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Nežinomas veiksmas>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Negalima naudoti sparčiojo klavišo „%s“, kadangi nebegalėsite rašyti šiuo "
+#~ "klavišu.\n"
+#~ "Bandykite klavišą kartu su tokiais klavišai kaip Control, Alt ar Shift."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Susiejimas „%s“ jau yra naudojamas\n"
+#~ "„%s“"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "Jei priskirsite spartųjį klavišą komandai „%s“, „%s“ bus išjungtas."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Priskirti iš naujo"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Trumpinys „%s“ turi susietą trumpinį „%s“. Ar norite jį automatiškai "
+#~ "nustatyti į „%s“?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "„%s“ šiuo metu yra susietas su „%s“, jei tęsite, šis trumpinys bus "
+#~ "išjungtas."
+
+#~ msgid "_Assign"
+#~ msgstr "_Priskirti"
+
+#~ msgid "Bond"
+#~ msgstr "Bond"
+
+#~ msgid "Team"
+#~ msgstr "Team"
+
+#~ msgid "Bridge"
+#~ msgstr "Bridge"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Nepavyko įkelti VPN įskiepių"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Pridėti tinklo ryšį"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Prijungimai"
+
+#~ msgid "(none)"
+#~ msgstr "(nėra)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Sujungti antraeilius"
+
+#~ msgid "Team slaves"
+#~ msgstr "Team antraeiliai"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand įrenginys nepalaiko ryšio veiksenos"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Nepasirinktas liudijimų įstaigos liudijimas"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Nenaudojamas liudijimų įstaigos (LĮ) liudijimas gali sukurti nesaugius, "
+#~ "kenkėjiškus belaidžius tinklus.  Ar norite pasirinkti liudijimų įstaigos "
+#~ "liudijimą?"
+
+#~ msgid "Ignore"
+#~ msgstr "Nepaisyti"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Pasirinkti LĮ liudijimą"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "_Klausti šio slaptažodžiu kiekvieną kartą"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "_Daugiau neperspėti"
+
+#~ msgid "Yes"
+#~ msgstr "Taip"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Kita"
+
+#~ msgid "_Verify"
+#~ msgstr "_Tikrinti"
+
+#~ msgid "Login History"
+#~ msgstr "Prisijungimo istorija"
+
+#~ msgid "Add User Account"
+#~ msgstr "Pridėti naudotojo paskyrą"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Naudotojas vardu „%s“ jau yra."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Naudojama jūsų geografinei padėčiai nustatyti"
+
+#~ msgid "Done"
+#~ msgstr "Atlikta"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Laiko _juosta"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Pratęsti spausdinimą"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Pristabdyti spausdinimą"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Laikomas"
+
+#~ msgid "Job Title"
+#~ msgstr "Darbo pavadinimas"
+
+#~ msgid "Job State"
+#~ msgstr "Darbo būsena"
+
+#~ msgid "Password:"
+#~ msgstr "Slaptažodis:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "Ka_rtojimo klavišai"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "Ž_ymeklio mirksėjimas"
+
+#~ msgid "Zoom"
+#~ msgstr "Mastelis"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Spalva"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Delsa:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Trumpas"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Lėtas"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Ilgas"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Greitas"
+
+#~ msgid "S_peed:"
+#~ msgstr "G_reitis:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Tikrinkite savo nustatymus"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Lėtas"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Greitas"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Kairė"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Dešinė"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "Žymeklio _greitis"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lėtas"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Greitas"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lėtas"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Greitas"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Pridėti naują spausdintuvą"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Belaidžiams įrenginiams reikia papildomos energijos"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Kai baterijos įkrovos lygis _kritiškai žemas"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Dalinimasis per Bluetooth leidžia dalintis failais su kitais Bluetooth "
+#~ "gebančiais įrenginiais"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Priimti tik iš įrenginių, kuriais pasitikima"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Įrašyti gautus failus parsiuntimų aplanke"
+
+#~ msgid "Show help options"
+#~ msgstr "Rodyti pagalbos parinktis"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Paleiskite „%s --help“ visam komandų eilutės parinkčių sąrašui gauti.\n"
+
+#~ msgid "United States"
+#~ msgstr "Jungtinės Amerikos Valstijos"
+
+#~ msgid "Spain"
+#~ msgstr "Ispanija"
+
+#~ msgid "China"
+#~ msgstr "Kinija"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Spausdinimo _metu išjungti"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Sistemos tinklo tarnybos nesuderinamos su šia versija."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Rodyti iššokančios pranešimus"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Rodyti užrakinimo ekrane"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Rodyti iššokančios pranešimus"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Išjungia visus belaidžius įrenginius"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Įveskite spausdintuvo adresą arba tekstą rezultatų filtravimui"
+
+#~ msgid "Sorry"
+#~ msgstr "Atleiskite"

--- a/po/lv.po
+++ b/po/lv.po
@@ -11,9 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.HEAD.lv\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issu"
-"es\n"
-"POT-Creation-Date: 2022-08-28 14:52+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-03 15:24+0300\n"
 "Last-Translator: Rūdolfs Mazurs <rudolfs.mazurs@gmail.com>\n"
 "Language-Team: Latvian <lata-l10n@googlegroups.com>\n"
@@ -21,105 +20,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 :"
-" 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
 "X-Generator: Lokalize 21.12.3\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Sistēmas kopne"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Pilna piekļuve"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Sesijas kopne"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Ierīces"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Pilna pieeja /dev resursiem"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Tīkls"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Ir piekļuve tīklam"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Mājas"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Tikai lasāms"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Datņu sistēma"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Iestatījumi"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Var mainīt iestatījumus"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s ir šādas iebūvētās atļaujas. Tās nevar mainīt. Ja jūs šādas atļaujas "
-"neapmierina, apsveriet šīs lietotnes izņemšanu."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u datnes un saites veids, ko atver lietotne"
-msgstr[1] "%u datnes un saites veidi, ko atver lietotne"
-msgstr[2] "%u datnes un saites veidu, ko atver lietotne"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> tiek izmantots, lai atvērtu sekojošos datņu un saišu veidus."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-#| msgid "%s of disk space used"
-msgid "%s of disk space used."
-msgstr "Izmantoti %s no diska vietas."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -135,7 +40,6 @@ msgid "Install some…"
 msgstr "Instalēt…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Atvērt"
 
@@ -159,24 +63,13 @@ msgstr "Meklēt"
 msgid "Receive system searches and send results."
 msgstr "Saņemt sistēmas meklējumus un sūtīt rezultātus."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Izslēgts"
 
@@ -190,7 +83,6 @@ msgid "Show system notifications."
 msgstr "Rādīt sistēmas paziņojumus."
 
 #: panels/applications/cc-applications-panel.ui:133
-#| msgid "Run in background"
 msgid "Run in Background"
 msgstr "Palaist fonā"
 
@@ -203,7 +95,6 @@ msgid "Screenshots"
 msgstr "Ekrānattēli"
 
 #: panels/applications/cc-applications-panel.ui:141
-#| msgid "Take pictures with the camera."
 msgid "Take pictures of the screen at any time."
 msgstr "Uzņemt ekrāna attēlus jebkurā laikā."
 
@@ -344,80 +235,20 @@ msgstr "Attīrīt kešatmiņu…"
 msgid "Control various application permissions and settings"
 msgstr "Kontrolē dažādas lietotnes atļaujas un iestatījumus"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "lietotne;aplikācija;flatpak;atļaujas;iestatījumi;setingi;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Izvēlieties attēlu"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "At_celt"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Atvērt"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "vairāki izmēri"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Bez fona attēla"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Pašreizējais fons"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stils"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Noklusējuma"
 
@@ -441,7 +272,6 @@ msgstr "Izskats"
 msgid "Change your background image or the UI colors"
 msgstr "Mainiet savu fona attēlu vai saskarnes krāsas"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Fons;Tapete;Ekrāns;Darbvirsma;Stils;Tumšs;Gaišs;Izskats;"
@@ -492,9 +322,7 @@ msgstr "Lidmašīnas režīms ir ieslēgts aparatūrā"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Izslēdziet lidmašīnas režīmu, lai ieslēgtu Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -502,7 +330,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Ieslēdziet un izslēdziet Bluetooth un savienojiet savas ierīces"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "koplietot;koplietošana;šārēt;šārēšana;bluetooth;obex;"
@@ -535,93 +362,33 @@ msgstr "Neviena lietotne nav pieprasījusi piekļuvi kamerai"
 msgid "Protect your pictures"
 msgstr "Aizsargāt savus attēlus"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "kamera;fotogrāfijas;video;tīmekļa kamera;slēgt;privāts;privātums;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Novietojiet savu kalibrēšanas ierīci virs kvadrāta un spiediet “Sākt”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Pārvietojiet savu kalibrēšanas ierīci uz kalibrēšanas pozīciju un spiediet "
-"“Turpināt”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Pārvietojiet savu kalibrēšanas ierīci uz virsmas pozīciju un spiediet "
-"“Turpināt”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Aizveriet klēpjdatora vāku"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Gadījās iekšēja kļūda, no kuras nevarēja atgūties."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Radās iekšēja kļūda, kuru nevarēja izlabot."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Nevarēja izveidot profilu."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Mērķa baltais punkts nebija iegūstams."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Izpildīts!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrēšana neizdevās!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Jūs varat izņemt kalibrēšanas ierīci."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Neaiztieciet kalibrēšanas ierīci, kamēr tā darbojas"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Iespējams, šis profils vairs nav precīzs"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "At_celt"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -638,140 +405,6 @@ msgstr "Tu_rpināt"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Pabeigts"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Klēpjdatora ekrāns"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Iebūvēta tīmekļa kamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitors %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Skeneris %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Fotoaparāts %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Printeris %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Tīmekļa kamera %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Aktivēt %s krāsu pārvaldību"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Rādīt %s krāsu profilus"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Nav kalibrēts"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Noklusējuma: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Krāsu telpa: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Testa profils:"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Izvēlieties ICC profila datni"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importēt"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Atbalstītie ICC profili"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Visas datnes"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Ekrāns"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Saglabāt profilu"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Saglabāt"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Izveidot krāsu profilu izvēlētajai ierīcei"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Mērinstruments nav atrasts. Pārbaudiet, vai tas ir ieslēgts un pareizi "
-"pievienots."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Mērinstruments neatbalsta printera profilēšanu."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Ierīces veids pašlaik nav atbalstīts."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -887,9 +520,9 @@ msgstr "Vajadzīgs rakstāms datu nesējs"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Šīs instrukcijas, kā izmantot profilu uz <a href=\"linux\">GNU/Linux</a>, <a "
 "href=\"osx\">Apple OS X</a> un <a href=\"windows\">Microsoft Windows</a>, "
@@ -904,8 +537,8 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Ir atklātas problēmas. Profils varētu nedarboties kā paredzēts. <a href="
-"\"\">Rādīt sīkāku informāciju.</a>"
+"Ir atklātas problēmas. Profils varētu nedarboties kā paredzēts. <a "
+"href=\"\">Rādīt sīkāku informāciju.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -913,7 +546,6 @@ msgstr "_Importēt datni…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -925,9 +557,7 @@ msgstr ""
 "Katrai ierīcei vajadzīgs aktuāls krāsu profils, lai tās krāsas būtu "
 "pārvaldītas."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Uzziniet vairāk"
 
@@ -1059,82 +689,6 @@ msgstr "D65 (fotografēšana un grafika)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standarta telpa"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testa profils"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automātiski"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Zema kvalitāte"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Vidēja kvalitāte"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Augsta kvalitāte"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Noklusējuma RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Noklusējuma CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Noklusējuma Pelēkais"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Ražotāja sniegtie rūpnīcas kalibrācijas dati"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Ar šo profilu nav iespējama pilnekrāna displeja koriģēšana"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Šis profils varētu vairs nebūt precīzs"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Krāsas"
@@ -1146,14 +700,9 @@ msgstr ""
 "Kalibrējiet krāsas savām ierīcēm, piemēram, displejiem, kamerām vai "
 "printeriem"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Krāsas;ICC;Profils;Kalibrēt;Printeris;Ekrāns;Displejs;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Citi…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1168,13 +717,8 @@ msgid "No languages found"
 msgstr "Nav atrastas valodas"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Vairāk…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Atbloķēt, lai mainītu iestatījumus"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1203,154 +747,6 @@ msgstr "Stundu atpakaļ"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Minūti atpakaļ"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Šodien"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Vakar"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y."
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d stunda"
-msgstr[1] "%d stundas"
-msgstr[2] "%d stundas"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minūte"
-msgstr[1] "%d minūtes"
-msgstr[2] "%d minūtes"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekunde"
-msgstr[1] "%d sekunžu"
-msgstr[2] "%d sekundes"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekundes"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Tīklājs"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 stundu"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %H:%M"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%H:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1445,17 +841,11 @@ msgstr "Automātiska laika _josla"
 msgid "Requires location services enabled and internet access"
 msgstr "Jābūt pieejamam interneta un atrašanās vietas pakalpojumiem"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Aktivēts"
 
@@ -1463,15 +853,43 @@ msgstr "Aktivēts"
 msgid "Time Z_one"
 msgstr "Laika j_osla"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Atbloķēt"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Laika _formāts"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datumi"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekundes"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalendārs"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Skaitļi"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Mainīt datumu un laiku, tai skaitā laika joslas"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Pulkstenis;Laika josla;Lokācija;"
@@ -1517,20 +935,9 @@ msgstr "Noklusējuma lietotnes"
 msgid "Configure Default Applications"
 msgstr "Konfigurēt noklusējuma lietotnes"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "noklusējuma;lietotne;vēlamais;mediji;defaulta;aplikācija;mēdiji;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Tehnisku problēmu ziņojumu sūtīšana palīdz mums uzlabot %s. Ziņojumi tiek "
-"sūtīti anonīmi, un tiek iztīrīti no personīgajiem datiem. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1548,44 +955,9 @@ msgstr "Diagnostika"
 msgid "Report your problems"
 msgstr "Ziņot par problēmām"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostika;avārija;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Ieslēgts"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Izslēgts"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Pielietot izmaiņas?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Izmaiņas nevar pielietot"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Tas varētu būt aparatūras ierobežojumu dēļ."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1635,31 +1007,6 @@ msgstr "Primārais displejs"
 msgid "Night Light"
 msgstr "Nakts gaisma"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Ainava"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Portrets pa labi"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Portrets pa kreisi"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Ainava (apmesta)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1683,6 +1030,17 @@ msgstr "Pielāgot televizoram"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Mērogs"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Dabiskā ritināšana"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1778,7 +1136,6 @@ msgstr "Displeji"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Izvēlieties, kā izmantot pievienotos monitorus un projektorus"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1788,80 +1145,6 @@ msgstr ""
 "Gaisma;Zils;redshift;krāsa;saullēkts;saulriets;Panel;Projector;xrandr;Screen;"
 "Resolution;Refresh;Monitor;"
 
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Secure boot ir ieslēgts"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce sāk"
-" strādāt. Tas ir ieslēgts un funkcionē normāli."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Secure boot ir problēmas"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce sāk"
-" strādāt. Tas ir ieslēgts, bet nevar strādāt, jo tam ir nederīga atslēga."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Secure boot problēmas nereti var atrisināt no sava datora UEFI"
-" aparātprogrammatūras iestatījumie  (BIOS) un jūsu aparatūras ražotājam"
-" vajadzētu sniegt informāciju par to, kā to izdarīt."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Lai saņemtu palīdzību, sazinieties ar šīs aparatūras ražotāju vai IT atbalsta"
-" sniedzēju."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-#| msgid "Camera is Turned Off"
-msgid "Secure Boot is Turned Off"
-msgstr "Secure boot ir izslēgts"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce sāk"
-" strādāt. Tas ir izslēgts."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Secure boot var izslēgt datora UEFI aparātprogrammatūras iestatījumos (BIOS)."
-" Lai saņemtu palīdzību, sazinieties ar šīs aparatūras ražotāju vai IT"
-" atbalsta sniedzēju."
-
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
 "Secure boot prevents malicious software from being loaded when the device "
@@ -1869,521 +1152,31 @@ msgid ""
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
-"Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce sāk"
-" strādāt. Lai uzzinātu vairāk, sazinieties ar aparatūras ražotāju vai IT"
-" atbalstu."
+"Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce sāk "
+"strādāt. Lai uzzinātu vairāk, sazinieties ar aparatūras ražotāju vai IT "
+"atbalstu."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-#| msgid "Password"
-msgid "Passed"
-msgstr "Izdevās"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-#| msgid "PPP failed"
-msgid "Failed"
-msgstr "Neizdevās"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Ierīce atbilst HSI %d. pakāpei"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:485
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
-msgid "Security Level 0"
-msgstr "Drošības pakāpe 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Šī ierīce netiek aizsargāta no aparatūras drošības problēmām. Tā var notikt,"
-" ja ir problēmas aparatūras vai aparātprogrammatūras konfigurācijā. Ieteicams"
-" sazināties ar savu IT atbalsta sniedzēju."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:492
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
-msgid "Security Level 1"
-msgstr "Drošības pakāpe 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Šai ierīcei ir minimāla aizsardzība pret aparatūras drošības problēmām. Šī ir"
-" zemākā ierīču drošības pakāpe un tā sniedz aizsardzību tikai pret"
-" vienkāršākajiem drošības draudiem."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:499
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
-msgid "Security Level 2"
-msgstr "Drošības pakāpe 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Šai ierīcei ir pamata aizsardzība pret aparatūras drošības problēmām. Tā"
-" sniedz aizsardzību pret izplatītākajiem drošības draudiem."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:506
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
-msgid "Security Level 3"
-msgstr "Drošības pakāpe 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Šai ierīcei ir paplašināta aizsardzība pret aparatūras drošības problēmām. Šī"
-" ir augstākā ierīču drošības pakāpe un tā sniedz aizsardzību pret"
-" izvērstākiem drošības draudiem."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:521
-#| msgctxt "Wi-Fi Hotspot"
-#| msgid "Security type"
 msgid "Security Level"
 msgstr "Drošības pakāpe"
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:522
-msgid "Security levels are not available for this device."
-msgstr "Šai ierīcei nav pieejamas aizsardzības pakāpes."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Sazinieties ar savas aparatūras ražotājiem, lai iegūtu palīdzību ar drošības"
-" atjauninājumiem."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Šo problēmu varētu atrisināt ierīces UEFI aparātprogrammatūras iestatījumos"
-" vai ar atbalsta speciālistu."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Šo problēmu varētu atrisināt ierīces UEFI aparātprogrammatūras iestatījumos."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Šo problēmu varētu atrisināt atbalsta speciālists."
-
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
-#| msgid "Ink Level"
 msgid "Level 1"
 msgstr "Pakāpe 1"
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:124
-#| msgid "Ink Level"
 msgid "Level 2"
 msgstr "Pakāpe 2"
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:160
-#| msgid "Ink Level"
 msgid "Level 3"
 msgstr "Pakāpe 3"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Aizsargāts pret ļaundabīgu programmatūru ierīces ielādes sākumā."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Secure boot ir problēmas"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Daļēja aizsardzība ierīces ielādes sākumā."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Secure boot ir izslēgts"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Nav aizsardzības ierīces ielādes sākumā."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Šī problēma varēja rasties dēļ UEFI aparātprogrammatūras iestatījumu"
-" izmaiņām, operētājsistēmas konfigurācijas izmaiņām vai dēļ ļaundabīgas"
-" programmatūras šajā datorā."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Šī problēma varēja rasties dēļ UEFI aparātprogrammatūras iestatījumu izmaiņām"
-" vai dēļ ļaundabīgas programmatūras šajā datorā."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Šī problēma varēja rasties dēļ operētājsistēmas konfigurācijas izmaiņām vai"
-" dēļ ļaundabīgas programmatūras šajā datorā."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Exposed to serious security threats."
-msgstr "Pakļauts nopietniem drošības draudiem."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Limited protection against simple security threats."
-msgstr "Daļēja aizsardzība pret vienkāršākajiem drošības draudiem."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Protected against common security threats."
-msgstr "Aizsargāts pret izplatītākajiem drošības draudiem."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Protected against a wide range of security threats."
-msgstr "Aizsargāts pret daudziem drošības draudiem."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:514
-msgid "Comprehensive Protection"
-msgstr "Vispusīga aizsardzība"
 
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Nav notikumu"
 
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection"
-msgstr "Aparātprogrammatūras rakstīšanas aizsardzība"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection Lock"
-msgstr "Aparātprogrammatūras rakstīšanas aizsardzības slēdzene"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Region"
-msgstr "Aparātprogrammatūras BIOS reģions"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Descriptor"
-msgstr "Aparātprogrammatūras BIOS deskriptors"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Pirms-ielādes DMA aizsardzība"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard pārbaudītā ielāde"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM aizsardzība"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard kļūdu politika"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard sintēze"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET ieslēgts"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET aktīvs"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Šifrēts RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU aizsardzība"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux Kernel noslēgšana"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linux Kernel verifikācija"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux maiņvieta"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-#| msgid "Suspend"
-msgid "Suspend To RAM"
-msgstr "Iesnaudināt uz RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-#| msgid "Suspend"
-msgid "Suspend To Idle"
-msgstr "Iesnaudināt uz dīkstāvi"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI platformas atslēga"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI drošā ielāde"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-#| msgid "Display Configuration"
-msgid "TPM Platform Configuration"
-msgstr "TPM platformas konfigurācija"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM rekonstrukcija"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel Management Engine ražošanas režīms"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Intel Management Engine pārrakstīšana"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Intel Management Engine versija"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-#| msgid "Software Updates"
-msgid "Firmware Updates"
-msgstr "Aparātprogrammatūras atjauninājumi"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-#| msgid "Firmware Version"
-msgid "Firmware Attestation"
-msgstr "Aparātprogrammatūras atestācija"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-#| msgid "Firmware Version"
-msgid "Firmware Updater Verification"
-msgstr "Aparātprogrammatūras atjauninātāja versija"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Platformas atkļūdošana"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Procesora drošības pārbaudes"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD atpakaļ ritināšanas aizsardzība"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-#| msgid "Firmware Version"
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD aparātprogrammatūras atkārtošanas aizsardzība"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-#| msgid "Firmware Version"
-msgid "AMD Firmware Write Protection"
-msgstr "AMD aparātprogrammatūras rakstīšanas aizsardzība"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Sintēzes platforma"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Derīgs"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-#| msgid "Not calibrated"
-msgid "Not Valid"
-msgstr "Nederīgs"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-#| msgid "Enabled"
-msgid "Not Enabled"
-msgstr "Nav ieslēgts"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-#| msgid "SIM Locked"
-msgid "Locked"
-msgstr "Bloķēts"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-#| msgid "SIM Locked"
-msgid "Not Locked"
-msgstr "Nav bloķēts"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Šifrēts"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-#| msgid "Not calibrated"
-msgid "Not Encrypted"
-msgstr "Nav šifrēts"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Bojāts"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-#| msgid "Not calibrated"
-msgid "Not Tainted"
-msgstr "Nav bojāts"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-#| msgid "Sound"
-msgid "Found"
-msgstr "Atrasts"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-#| msgid "Not found"
-msgid "Not Found"
-msgstr "Nav atrasts"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-#| msgctxt "print job"
-#| msgid "Aborted"
-msgid "Supported"
-msgstr "Atbalstīts"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-#| msgid "No Thunderbolt Support"
-msgid "Not Supported"
-msgstr "Nav atbalstīts"
-
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
-#| msgid "Security"
 msgid "Device Security"
 msgstr "Ierīces drošība"
 
@@ -2391,7 +1184,6 @@ msgstr "Ierīces drošība"
 msgid "Host firmware security status"
 msgstr "Datora aparātprogrammatūras drošības status"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2399,49 +1191,6 @@ msgid ""
 msgstr ""
 "ekrāns;bloķēt;slēgt;diagnostika;avārija;privāts;nesens;pagaidu;indeks;"
 "rādītājs;vārds;tīkls;identitāte;privātums;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Nezināms"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bitu"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bitu"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Nezināms"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Nav pieejams"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Sistēmas logo"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2479,7 +1228,6 @@ msgstr "OS nosaukums"
 
 #. translators: this field contains the distro build ID
 #: panels/info-overview/cc-info-overview-panel.ui:107
-#| msgid "%s; Build ID: %s"
 msgid "OS Build ID"
 msgstr "OS būvējuma ID"
 
@@ -2536,11 +1284,6 @@ msgstr "Par"
 msgid "View information about your system"
 msgstr "Aplūkot informāciju par šo sistēmu"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2620,6 +1363,12 @@ msgstr "Palaidēji"
 msgid "Launch help browser"
 msgstr "Palaist palīdzības pārlūku"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Iestatījumi"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Palaist kalkulatoru"
@@ -2641,7 +1390,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Meklēt"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistēma"
 
@@ -2690,15 +1439,6 @@ msgstr "Samazināt teksta izmēru"
 msgid "High contrast on or off"
 msgstr "Ieslēgt vai izslēgt augstu kontrastu"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nav atrastu ievades avotu"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Citi"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Pievienot ievades avotu"
@@ -2731,106 +1471,9 @@ msgstr "Iestatījumi"
 msgid "View Keyboard Layout"
 msgstr "Skatīt tastatūras izkārtojumu"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Izņemt"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Pielāgotas saīsnes"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Alternatīvo rakstzīmju taustiņš"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Papildu rakstzīmju ievadīšanai var izmantot alternatīvo rakstzīmju taustiņu. "
-"Dažreiz tās tiek attēlotas kā trešā opcija uz tastatūras."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Kreisais Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Labais alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Kreisais super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Labais super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Izvēlnes taustiņš"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Labais Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Kompozīcijas taustiņš"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Komponēšanas taustiņš ļauj ievadīt plašu rakstzīmju klāstu Lai to izmantotu, "
-"spiediet komponēšanas taustiņu un tad ievadiet rakstzīmes. Piemēram, pēc "
-"kompozīcijas taustiņa spiežot <b>C</b> un <b>o</b> tiks ievadīts <b>©</b>, "
-"<b>a</b> pēc tam <b>'</b> izveidos <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Reģistra slēdzis"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Ritslēdzis"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Drukāt ekrānu"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Ievades avotus var pārslēgt, izmantojot %s tastatūras īsinājumtaustiņu.\n"
-"To var mainīt tastatūras īsinājumtaustiņu iestatījumos."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2860,46 +1503,21 @@ msgstr "Īpašas rakstzīmes ieraksts"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Metodes simbolu un burtu variantu ievadīšanai, izmantojot tastatūru."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternatīvo rakstzīmju taustiņš"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Kompozīcijas taustiņš"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Tastatūras īsinājumtaustiņi"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Skatīt un pielāgot īsinājumtaustiņus"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d izmainīts"
-msgstr[1] "%d izmainīti"
-msgstr[2] "%d izmainītu"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Atiestatīt visas saīsnes?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Saīšņu atiestatīšana var ietekmēt jūsu pielāgotās saīsnes. Šo darbību nevar "
-"atsaukt."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Atcelt"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Atiestatīt visas"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2938,33 +1556,6 @@ msgstr "Pievienot īsinājumtaustiņu"
 msgid "No keyboard shortcut found"
 msgstr "Nav atrastu tastatūras īsinājumtaustiņu"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s jau izmanto %s. Ja to aizstāsiet, %s tiks izslēgts"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Ievadiet jauno saīsni"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Iestatīt pielāgotas saīsnes"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Iestatīt saīsni"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Ievadiet jaunu saīsni, lai mainītu %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Pievienot pielāgoto saīsni"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Izņemt"
@@ -2976,7 +1567,6 @@ msgstr "_Aizstāt"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "Ie_statīt"
 
@@ -3014,6 +1604,11 @@ msgstr "Nav"
 msgid "Reset the shortcut to its default value"
 msgstr "Atiestatīt saīsni uz tās noklusējuma vērtību"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Izmantot printeri pēc noklusējuma"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Tastatūra"
@@ -3026,7 +1621,6 @@ msgstr ""
 "Mainiet tastatūras īsinājumtaustiņus un izvēlieties savus rakstīšanas "
 "iestatījumus, tastatūras izkārtojumus un ievades avotus"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3069,7 +1663,6 @@ msgstr "Neviena lietotne nav pieprasījusi piekļuvi atrašanās vietai"
 msgid "Protect your location information"
 msgstr "Aizsargājiet savu atrašanās vietu"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "vieta;lokācija;gps;privāts;privātums;"
@@ -3103,7 +1696,6 @@ msgstr "Neviena lietotne nav pieprasījusi piekļuvi mikrofonam"
 msgid "Protect your conversations"
 msgstr "Aizsargāt savas sarunas"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofons;ierakstīšana;lietotne;privātums;"
@@ -3133,81 +1725,139 @@ msgstr "Kreisā"
 msgid "Right"
 msgstr "Labā"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Meklēšanas vietas"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Pele"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Peles ātrums"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Dabiskā ritināšana"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Sadaļa"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Ritināšana pārvieto saturu, nevis skatu."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Ritināšana pārvieto saturu, nevis skatu."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktīvs"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Skārienpaliktnis"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Skārienpaliktņa ātrums"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Uzsitiens nozīmē klikšķi"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Uzsitiens nozīmē klikšķi"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Divu pirkstu ritināšana"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Skārienpaliktnis (relatīvs)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Malu ritināšana"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Ritslēdzis"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Abās pusēs"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Mēģiniet veikt klikšķi, dubultklikšķi, ritināšanu"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Pieci klikšķi, laiks GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dubultklikšķis, primārā poga"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Viens klikšķis, primārā poga"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dubultklikšķis, vidējā poga"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Viens klikšķis, vidējā poga"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dubultklikšķis, sekundārā poga"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Viens klikšķis, sekundārā poga"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3220,7 +1870,6 @@ msgstr ""
 "Mainiet savas peles vai skārienpaliktņa jutīgumu un izvēlieties, vai "
 "izmantot labroču vai kreiļu režīmu"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3303,29 +1952,17 @@ msgstr "Vairākuzdevumi"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Pārvaldiet iestatījumus produktivitātei un vairākuzdevumu darbam"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "Vairākuzdevumi;Produktivitāte;Pielāgot;Darbvirsma;Karstais Stūris;Darbvietas;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Ak vai! Kaut kas nogāja greizi. Lūdzu, sazinieties ar programmatūras "
-"piegādātāju."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager ir jābūt palaistam."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Citas ierīces"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3337,59 +1974,16 @@ msgstr "Pievienot savienojumu"
 msgid "Not set up"
 msgstr "Nav iestatīts"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Nedrošs tīkls (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Drošs tīkls (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Drošs tīkls (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Drošs tīkls (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Drošs tīkls"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Savienots"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opcijas…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Ieslēdzot tīklāju, tiks pārtraukts savienojums ar %s, un nevarēs piekļūt "
-"internetam caur Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Jābūt vismaz 8 rakstzīmēm"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3440,20 +2034,6 @@ msgstr "Automātiski ģenerēt paroli"
 msgid "_Turn On"
 msgstr "_Ieslēgt"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Apturēt tīklāju un atvienot visus lietotājus?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Apturēt tīklāju"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Lidmašīnas režīms"
@@ -3498,89 +2078,15 @@ msgstr "Redzamie tīkli"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager ir jābūt palaistam"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ak vai! Kaut kas nogāja greizi. Lūdzu, sazinieties ar programmatūras "
+"piegādātāju."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _drošība"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Drošība"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Saglabāt"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Pastāvīgi"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Nejauši"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabils"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Šeit ievadītā MAC adrese tiks izmantota kā aparatūras adrese tīkla ierīcei, "
-"kurai šis savienojums ir aktivizēts. Šī iespēja ir pazīstama kā MAC "
-"klonēšana vai izlikšanās. Piemērs: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profils %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nav"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Nekad"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3591,183 +2097,6 @@ msgstr[0] "pirms %i dienas"
 msgstr[1] "pirms %i dienām"
 msgstr[2] "pirms %i dienām"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nav"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Vājš"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Lietojams"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Labs"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Teicams"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 adrese"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 adrese"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP adrese"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Aizmirst savienojumu"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Izņemt savienojuma profilu"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Izņemt VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Sistēmas informācija"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automātiski"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitāte"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Dzēst adresi"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Dzēst maršrutu"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Nav"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128 bitu atslēga (Hex vai ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128 bitu parole"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dinamiskais WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA un WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA un WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3777,8 +2106,20 @@ msgstr "Signāla stiprums"
 msgid "Link speed"
 msgstr "Savienojuma ātrums"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Drošība"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 adrese"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 adrese"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Aparatūras adrese"
 
@@ -3787,12 +2128,17 @@ msgid "Supported Frequencies"
 msgstr "Atbalstītās frekvences"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Noklusējuma maršruts"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3855,7 +2201,7 @@ msgstr "Tikai lokālais tīkls"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Pašrocīgi"
 
@@ -3899,9 +2245,8 @@ msgstr "Vārteja"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automātiski"
 
@@ -3954,89 +2299,9 @@ msgstr "Automātiski, tikai DHCP"
 msgid "Prefix"
 msgstr "Prefikss"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Nevar atvērt savienojumu redaktoru"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Jauns profils"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Nederīgi iestatījumi %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Nederīgi iestatījumi %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importēt no datnes…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Pievienot VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "D_rošība"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Nevar importēt VPN savienojumu"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Datni “%s” nevar nolasīt vai tajā nav atpazīstama VPN savienojuma "
-"informācija\n"
-"\n"
-"Kļūda — %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Izvēlieties datni, ko importēt"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Datne ar nosaukumu “%s” jau eksistē."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Aizstāt"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Vai vēlaties aizstāt %s ar saglabājamo VPN savienojumu?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Nevar eksportēt VPN savienojumu"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Nevar eksportēt VPN savienojumu “%s” uz %s.\n"
-"\n"
-"Kļūda — %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Eksportē VPN savienojumu"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4050,99 +2315,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Tīkls"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Noteikt, kā savienoties ar internetu"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Tīkls;IP;LAN;Starpnieks;WAN;Platjosla;Modems;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Noteikt, kā savienoties ar Wi-Fi tīkliem"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Tīkls;Bezvadu;Wi-Fi;Wifi;IP;LAN;Platjosla;DNS;Tīklājs;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nekad"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "šodien"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "vakar"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Pēdējoreiz lietots"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Vadu"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Pievienot jaunu savienojumu"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Informācija par izvēlētajiem tīkliem, tai skaitā paroles un jebkāda "
-"pielāgota konfigurācija, tiks pazaudēta."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "Ai_zmirst"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Zināmie Wi-Fi tīkli"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "Ai_zmirst"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Sistēmas politika neļauj izmantot kā tīklāju"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Bezvadu ierīce ierīce neatbalsta tīklāja režīmu"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Kad nav norādīts konfigurācijas URL, tiek izmantota tīmekļa starpnieka "
-"automātiskā atklāšana."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Tas nav ieteicams neuzticamos publiskos tīklos."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4161,6 +2363,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Piegādātājs"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP adrese"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4245,291 +2451,6 @@ msgstr "Ieslēgt Wi-Fi _tīklāju…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Zināmie Wi-Fi tīkli"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Nezināms statuss"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Nepārvaldīts"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Nav pieejams"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Savienojas"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Nepieciešama autentifikācija"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Atvieno"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Savienojums neizdevās"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Nezināms statuss (trūkst)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Konfigurēšana neizdevās"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP konfigurēšana neizdevās"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP konfigurācija vairs nav derīga"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Noslēpumi tika pieprasīti, bet netika sniegti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x pieprasītājports atvienots"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x pieprasītājporta konfigurēšana neizdevās"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x pieprasītājports nestrādā"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x pieprasītājports neautentificējās atvēlētajā laikā"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP servisa palaišana neizdevās"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP serviss atvienots"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP nestrādā"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP klienta palaišana neizdevās"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP klienta kļūda"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP klients nestrādā"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Koplietojamā savienojuma serviss nepalaidās"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Koplietojamā savienojuma serviss nestrādā"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP servisa palaišana neizdevās"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP servisa kļūda"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP serviss nestrādā"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Līnija aizņemta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Nav centrāles gatavības signāla"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Neizdevās izveidot nesēju"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Iezvanīšanās pieprasījuma noildze"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Iezvanīšanās neizdevās"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Neizdevās inicializēt modemu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Neizdevās izvēlēties norādīto APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Nemeklē tīklus"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Reģistrācija tīklā liegta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Tīkla reģistrācijas noildze"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Neizdevās reģistrēties pieprasītajā tīklā"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN nav atzīts par derīgu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Iespējams, ierīcei pietrūkst aparātprogrammatūras"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Savienojums pazuda"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Tika pieņemts, ka savienojums eksistē"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modems nav atrasts"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth savienojums neizdevās"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Nav ievietota SIM karte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Vajadzīgs SIM PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Vajadzīgs SIM PUK"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Nepareiza SIM karte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Savienojuma priekšnoteikums nav izpildīts"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Trūkst aparātprogrammatūras"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Vads atvienots"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "nedefinēta kļūda 802.1X drošībā (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "nav izvēlēta neviena datne"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "nenorādīta kļūda validējot eap metodes datni"
-
-#: panels/network/wireless-security/eap-method.c:394
-#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12 vai PGP privātās atslēgas"
-
-#: panels/network/wireless-security/eap-method.c:397
-#| msgid "_User certificate"
-msgid "DER or PEM certificates"
-msgstr "DER vai PEM sertifikāti"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "trūkst EAP-FAST PAC datnes"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC datne (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4578,14 +2499,6 @@ msgstr "_Iekšējā autentifikācija"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Ļauj automātisku PAC nodrošinājumu"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "trūkst EAP-LEAP lietotājvārds"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "trūkst EAP-LEAP paroles"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4611,15 +2524,6 @@ msgstr "_Parole"
 msgid "Sho_w password"
 msgstr "_Rādīt paroli"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "nederīgs EAP-PEAP CA sertifikāts: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "nederīgs EAP-PEAP CA sertifikāts: nav norādīts sertifikāts"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4641,7 +2545,6 @@ msgid "C_A certificate"
 msgstr "C_A sertifikāts"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4656,63 +2559,6 @@ msgstr "Nav nepieciešams CA sertifikāts"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _versija"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "trūkst EAP lietotājvārda"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "trūkst EAP paroles"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "trūkst EAP-TLS identitātes"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "nederīgs EAP-TLS CA sertifikāts: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "nederīgs EAP-TLS CA sertifikāts: nav norādīts sertifikāts"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "nederīga EAP-TLS privātā atslēga: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "nederīgs EAP-TLS lietotāja sertifikāts: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Nešifrētas privātās atslēgas nav drošas"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Izskatās, ka izvēlētā privātā atslēga nav aizsargāta ar paroli. Tas var ļaut "
-"kompromitēt drošības akreditācijas datus. Lūdzu, izvēlieties ar paroli "
-"aizsargātu privāto atslēgu.\n"
-"\n"
-"(Savu privāto atslēgu varat aizsargāt ar paroli ar openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Izvelieties personīgo sertifikātu"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Izvēlieties privāto atslēgu"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4729,15 +2575,6 @@ msgstr "Privātā _atslēga"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Privātās atslēgas parole"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "nederīgs EAP-TTLS CA sertifikāts: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "nederīgs EAP-TTLS CA sertifikāts: nav norādīts sertifikāts"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4760,14 +2597,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domēns"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Nezināma kļūda validējot 802.1X drošību"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4795,62 +2633,10 @@ msgstr "Protected EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "Au_tentifikācija"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Izvēlieties datni"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "trūkst leap lietotājvārda"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "trūkst leap paroles"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Pietrūkst Wi-Fi paroles."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tips"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "trūkst wep atslēgas"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"nederīga wep atslēga: atslēga ar garumu %zu var saturēt tikai heksadecimālus "
-"skaitļus"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"nederīga wep atslēga: atslēga ar garumu %zu var saturēt tikai ascii "
-"rakstzīmes"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"nederīga wep atslēga: nepareizs atslēgas garums %zu. Atslēgas garumam ir "
-"jābūt vai nu 5/13 (ascii) vai 10/26 (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "nederīga wep atslēga: parole nevar būt tukša"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "nederīga wep atslēga: parolei ir jābūt īsākai nekā 64 rakstzīmes"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4875,20 +2661,6 @@ msgstr "_Rādīt atslēgu"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP inde_kss"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"nederīgs wpa-psk: nederīgs atslēgas garums %zu. Jābūt [8,63] baiti vai 64 "
-"heksadecimālie cipari"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"nederīgs wpa-psk: nevar interpretēt atslēgu ar 64 baitiem kā heksadecimālu"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4943,27 +2715,9 @@ msgstr "_Ekrāna vairoga paziņojumi"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Nosakiet, kuri paziņojumi tiks parādīti, un kas tajos būs redzams"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Paziņojumi;Lentas;Baneri;Ziņojums;Paplāte;Uznirstošais logs;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Citi"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s ir izņemts"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Kļūda, noņemot kontu"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4989,17 +2743,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Pievienot kontu"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s konts"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Izņemt kontu"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Tiešsaistes konti"
@@ -5009,10 +2752,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Savienojieties ar saviem tiešsaistes kontiem un izvēlieties, kam tos izmantot"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5020,10 +2759,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Tīmeklis;Tiešsaiste;Tērzēšana;Kalendārs;"
 "Pasts;kontakti;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Nezināms laiks"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5041,13 +2776,6 @@ msgstr[0] "%i stunda"
 msgstr[1] "%i stundas"
 msgstr[2] "%i stundu"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5061,188 +2789,6 @@ msgid_plural "minutes"
 msgstr[0] "minūte"
 msgstr[1] "minūtes"
 msgstr[2] "minūšu"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "Pilnībā uzlādēts pēc %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Brīdinājums — atlicis %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Atlikušais laiks — %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Pilnībā uzlādēts"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Nelādējas"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Tukša"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Uzlādējas"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Izlādējas"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Bezvadu pele"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Bezvadu tastatūra"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Nepārtrauktais barošanas avots"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Personālais ciparasistents"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobilais tālrunis"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Multimediju atskaņotājs"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Planšete"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Dators"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Spēļu ievades ierīce"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Baterija"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Galvenā"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Papildus"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Baterijas"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Kad _dīkstāvē"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Iesnaudināt"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Izslēgt"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Iemidzināt"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nedarīt neko"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Kad izmanto baterijas strāvu"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Kad pieslēgts strāvai"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nekad"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automātiski iesnaudināt"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "Jaudīgais režīms ir uz laiku izslēgts pārāk augstas temperatūras dēļ."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Detektēts klēpis — jaudīgais režīms uz laiku nav pieejams. Pārvietojiet "
-"ierīci uz stabilu virsmu, lai to atjaunotu."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Jaudīgais režīms uz brīdi ir izslēgts."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Maza baterijas jauda — ieslēgta enerģijas taupīšana. Iepriekšējais režīms "
-"tiks atjaunots, kad baterija būs pietiekami uzlādēta."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Enerģijas taupīšanas režīmu ieslēdza “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Jaudīgo režīmu ieslēdza “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5303,6 +2849,15 @@ msgstr "100 minūtes"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 stundas"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterija"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Ierīces"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5381,33 +2936,6 @@ msgstr "Kad izmanto _bateriju"
 msgid "Delay"
 msgstr "Aizture"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Veiktspēja"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Augsta veiktspēja un jaudas patēriņš."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Līdzsvarota"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standarta veiktspēja un jaudas patēriņš."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Taupīga"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Samazināta veiktspēja un jaudas patēriņš."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Barošana"
@@ -5416,7 +2944,6 @@ msgstr "Barošana"
 msgid "View your battery status and change power saving settings"
 msgstr "Skatīt baterijas statusu un mainīt enerģijas taupīšanas iestatījumus"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5424,27 +2951,6 @@ msgid ""
 msgstr ""
 "Barošana;Snaust;Snaušana;Gulēt;Gulēšana;Baterija;Strāva;Gaišums;Tumšāk;Tumšs;"
 "Monitors;DPMS;Dīkstāve;Enerģija;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Printeris “%s” tika izdzēsts"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Neizdevās pievienot jaunu printeri."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Nevar ielādēt saskarni: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Atbloķēt, lai pievienotu printerus un mainītu iestatījumus"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5454,7 +2960,6 @@ msgstr "Printeri"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Pievienot printerus, skatīt printera darbus un izlemt, kā drukāt"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printeris;Rinda;Drukāt;Papīrs;Tinte;Toneris;"
@@ -5462,8 +2967,6 @@ msgstr "Printeris;Rinda;Drukāt;Papīrs;Tinte;Toneris;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Pievienot printeri"
 
@@ -5503,29 +3006,6 @@ msgstr ""
 msgid "Username"
 msgstr "Lietotājvārds"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s informācija"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Nav atrasts piemērots draiveris"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Izvēlieties PPD datni"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript Printer Description datnes (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
@@ -5535,9 +3015,7 @@ msgstr ""
 msgid "Location"
 msgstr "Atrašanās vieta"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Draiveris"
 
@@ -5565,121 +3043,14 @@ msgstr "Izvēlieties printera draiveri"
 msgid "Loading drivers database…"
 msgstr "Ielādē draiveru datubāzi…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Atcelt"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Izvēlēties"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect printeris"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD printeris"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Vienā pusē"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Garās malas iesējums"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Īsās malas iesējums"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Portrets"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Ainava"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Apgriezta ainava"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Apgriezts portrets"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Turpināt"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pauzēt"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Gaida"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pauzēts"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Nepieciešama autentifikācija"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Apstrādā"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Apturēts"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Atcelts"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Atsaukts"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Izpildīts"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Pārvietot šo uzdevumu uz rindas augšu"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5687,19 +3058,6 @@ msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u darbs pieprasa autentifikāciju"
 msgstr[1] "%u darbi pieprasa autentifikāciju"
 msgstr[2] "%u darbu pieprasa autentifikāciju"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — aktīvie darbi"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Ievadiet akreditācijas datus lai drukātu no %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5727,206 +3085,11 @@ msgstr "_Autentificēt"
 msgid "No Active Printer Jobs"
 msgstr "Nav aktīvu printera darbu"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Atbloķēt printera serveri"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Atbloķēt %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Ievadiet lietotājvārdu un paroli, lai redzētu, kādi printeri ir uz %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Meklē printerus"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Seriālais ports"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Paralēlais ports"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Atrašanās vieta: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adrese: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Serveris pieprasa autentifikāciju"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Abās pusēs"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Papīra tips"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Papīra avots"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Izvades paplāte"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Izšķirtspēja"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript prefiltrēšana"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Lappuses loksnē"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Abās pusēs"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientācija"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Vispārēji"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Lapas iestatījumi"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Instalējamās opcijas"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Darbs"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Attēla kvalitāte"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Krāsas"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Pēcapstrāde"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Paplašināti"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testa lapa"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Testa lapa"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Autoizvēle"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Printera noklusējuma"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Iekļaut tikai GhostScript fontus"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Konvertēt uz PS level 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Konvertēt uz PS level 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Bez prefiltrēšanas"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Ražotājs"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Nav aktīvu darbu"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5934,115 +3097,6 @@ msgid_plural "%u Jobs"
 msgstr[0] "%u darbs"
 msgstr[1] "%u darbi"
 msgstr[2] "%u darbu"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Tīrīt printera galviņas"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Maz tonera"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Beidzies toneris"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Palicis maz attīstītāja"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Nav attīstītāja"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Palicis maz krāsas"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Beigusies krāsa"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Atvērts vāks"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Atvērtas durvis"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Maz papīra"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Beidzies papīrs"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Nesaistē"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Apturēts"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Atkritumu tvertne gandrīz pilna"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Atkritumu tvertne pilna"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Optiskais gaismas vadītājs drīz būs jāmaina"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Optiskais gaismas vadītājs vairs nefunkcionē"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Gatavs"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Nepieņem darbus"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Apstrādā"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6066,6 +3120,10 @@ msgstr "Tīrīt printera galviņas"
 msgid "Remove Printer"
 msgstr "Izņemt printeri"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nav aktīvu darbu"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6086,16 +3144,21 @@ msgid "Restart"
 msgstr "Pārstartēt"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Pievienot printeri…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Pievienot printeri…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Nav printeru"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6103,7 +3166,6 @@ msgstr ""
 "Diemžēl izskatās, ka sistēmas \n"
 "drukāšanas serviss nav pieejams."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formāti"
@@ -6131,16 +3193,6 @@ msgstr "Var meklēt pēc valstīm vai valodām."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Priekšskatījums"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperiālās"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metriskās"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6178,20 +3230,24 @@ msgstr ""
 "Valodas iestatījumus izmanto saskarnes tekstam un tīmekļu lapām. Formātu "
 "izmanto skaitļiem, datumiem un valūtām."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Jūsu konts"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "Va_loda"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formāti"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Ierakstīšanās ekrāns"
 
@@ -6203,99 +3259,9 @@ msgstr "Vieta un valoda"
 msgid "Select your display language and formats"
 msgstr "Izvēlieties redzamo valodu un formātus"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Valoda;Izkārtojums;Tastatūra;Ievade;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Jautāt, ko darīt"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Nedarīt neko"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Atvērt mapi"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Citi datu nesēji"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Izvēlieties lietotni audio diskiem"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Izvēlieties lietotni DVD diskiem"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Izvēlieties lietotni, ko palaist, kad pievienots mūzikas atskaņotājs"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Izvēlieties lietotni, ko palaist, kad pievienota fotokamera"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Izvēlieties lietotni programmatūras CD"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "audio DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "tukšs Blu-ray disks"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "tukšs CD disks"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "tukšs DVD disks"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "tukšs HD DVD disks"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video disks"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "e-grāmatu lasītājs"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD video disks"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Bilžu CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows programmatūra"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6345,7 +3311,6 @@ msgstr "Noņemamie datu nesēji"
 msgid "Configure Removable Media settings"
 msgstr "Konfigurēt noņemamo datu nesēju iestatījums"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6354,114 +3319,6 @@ msgstr ""
 "ierīce;sistēma;noklusējums;lietotne;cd;dvd;usb;audio;video;disks;izņemams;"
 "noņemamas;vide;nesējs;datu nesējs;automātiski palaist;device;system;default;"
 "application;preferred;disc;removable;media;autorun;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Ekrāns izslēdzas"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekundes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minūte"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minūtes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minūtes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minūtes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minūtes"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 stunda"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minūtes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minūtes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minūtes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minūtes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minūtes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minūtes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minūtes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minūtes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minūtes"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nekad"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6498,43 +3355,41 @@ msgstr "Periods pēc ekrāna aptumšošanas, kad ekrāns automātiski bloķējas
 msgid "Show _Notifications on Lock Screen"
 msgstr "Rādīt _paziņojumus uz ekrāna vairoga"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Ekrāna vairoga paziņojumi"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Aizliegt jaunas _USB ierīces"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr ""
 "Liegt jaunām USB ierīcēm mijiedarboties ar sistēmu, kamēr ekrāns ir bloķēts."
 
-#: panels/screen/cc-screen-panel.ui:108
-#| msgid "Privacy"
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Ekrāna privātums"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Ierobežot skatīšanas leņķi"
 
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekrāns"
+
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
-#| msgid "Screen Sharing"
 msgid "Screen Settings"
 msgstr "Ekrāna iestatījumi"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "ekrāns;bloķēt;privāts;privātums;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Izvēlieties vietu"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Labi"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6565,10 +3420,6 @@ msgstr "Citi"
 msgid "Add Location"
 msgstr "Pievienot vietu"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nav atrastu lietotņu"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Lietotņu meklēšana"
@@ -6595,93 +3446,13 @@ msgid ""
 msgstr ""
 "Noteikt, kuras lietotnes rāda meklēšanas rezultātus aktivitāšu pārskatā"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Meklēt;Atrast;Indekss;Rādītājs;Slēpt;Privātums;Rezultāti;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Koplietošanai nav izvēlētu tīklu"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Tīkli"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Ieslēgts"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Izslēgts"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Ieslēgts"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktīvs"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Izvēlieties mapi"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Pievienot"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Ieslēgt multimediju koplietošanu"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Datņu koplietošana ļauj jums dalīties ar savu publisko mapi ar citiem jūsu "
-"pašreizējā tīklā, izmantojot: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Kad ir ieslēgta attālinātā ierakstīšanās, datoru var lietot attālināti, "
-"izmantojot Secure Shell komandu:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Ieslēgt personīgo mediju koplietošanu"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Ierīces nosaukums ir nokopēts"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Ierīces adrese ir nokopēta"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Lietotājvārds ir nokopēts"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Parole ir nokopēta"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6812,7 +3583,6 @@ msgstr "Mapes"
 msgid "Control what you want to share with others"
 msgstr "Nosakiet, kādu informāciju kopīgosiet ar citiem lietotājiem"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6831,16 +3601,11 @@ msgstr ""
 "Lai aktivētu vai deaktivētu attālināto ierakstīšanos, nepieciešama "
 "autentifikācija"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Pielāgots"
-
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
 msgstr "Klikšķis"
 
 #: panels/sound/cc-alert-chooser.ui:20
-#| msgid "Sharing"
 msgid "String"
 msgstr "Rinda"
 
@@ -6867,11 +3632,6 @@ msgstr "Aizmugure"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Priekšpuse"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Pārbauda %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6925,11 +3685,6 @@ msgstr "Skaļums"
 msgid "Alert Sound"
 msgstr "Trauksmes skaņa"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Apklusināt"
@@ -6942,83 +3697,12 @@ msgstr "Skaņa"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Mainīt skaļumu, ievades, izvades un paziņojumu skaņas"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Karte;Mikrofons;Skaļums;Klusināt;Balanss;Bluetooth;Austiņas;Audio;Izvade;"
 "Ievade;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Atvienots"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Savienojas"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Savienots"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Pilnvarošanas kļūda"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Pilnvaro"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Samazināta funkcionalitāte"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Savienots un pilnvarots"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Nezināms"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Pilnvarots:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Savienots:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Reģistrēts:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Neizdevās pilnvarot ierīci: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Neizdevās aizmirst ierīci: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7053,54 +3737,6 @@ msgstr "Pilnvarot un savienot"
 msgid "Forget Device"
 msgstr "Aizmirst ierīci"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Kļūda"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Pilnvarots"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Thunderbolt apakšsistēma (boltd) nav instalēta vai nav pareizi iestatīta."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Atļaut tieši piekļūt ierīcēm, piemēram dokiem un ārējiem GPU."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Var pievienoties tikai USB un Display Port ierīces."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Nevarēja atklāt Thunderbolt.\n"
-"Vai nu sistēmai nav Thunderbolt atbalsta, tas ir izslēgts BIOS konfigurācijā "
-"vai arī tam ir neatbalstīts drošības līmenis BIOS konfigurācijā."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt atbalsts ir izslēgts BIOS konfigurācijā."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Nevarēja noteikt Thunderbolt drošības līmeni."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Kļūda, pārslēdzot tiešo režīmu: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Nav Thunderbolt atbalsta"
@@ -7112,6 +3748,10 @@ msgstr "Nevarēja savienoties ar thunderbolt apakšsistēmu."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Tieša piekļuve"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Atļaut tieši piekļūt ierīcēm, piemēram dokiem un ārējiem GPU."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7129,7 +3769,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Pārvaldīt Thunderbolt ierīces"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;Privātums;"
@@ -7329,41 +3968,6 @@ msgstr "_Aktivēt ar tastatūru"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Ieslēgt un izslēgt pieejamības iespējas, lietojot tastatūru"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Noklusējuma"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Vidējs"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Liels"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Lielāks"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Vislielākais"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pikselis"
-msgstr[1] "%d pikseļi"
-msgstr[2] "%d pikseļu"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Vienmēr rādīt pieejamības izvēlni"
@@ -7477,31 +4081,6 @@ msgstr "Zib_snis pa visu ekrānu"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Zibsnis pa visu _logu"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Īss"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ekrāna"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ekrāna"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ekrāna"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Garš"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7658,7 +4237,6 @@ msgstr "Krāsu efekti"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Padarīt vienkāršāku redzēšanu, dzirdēšanu, rakstīšanu un klikšķināšanu"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7670,114 +4248,6 @@ msgstr ""
 "Mērogs;Ekrāna lasītājs;liels;augsts;teksts;fonts;izmērs;AccessX;Lipīgie;"
 "Taustiņi;Lēnie;Atlecošie;Pele;Dubults;klikšķis;Aizture;Ātrums;Atkārtot;"
 "Mirkšķināt;vizuāls;dzirdes;audio;raksta;animācijas;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 stunda"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 diena"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dienas"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dienas"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dienas"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dienas"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dienas"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dienas"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dienas"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dienas"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Iztukšot visu miskasti?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Viss miskastes saturs tiks neatgriezeniski dzēsts."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Iztīrīt atkritumus"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Dzēst visas pagaidu datnes?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Visas pagaidu datnes tiks pilnībā izdzēstas."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Izmest _pagaidu datnes"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 diena"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dienas"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dienas"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Visu laiku"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7845,64 +4315,12 @@ msgstr "Datņu vēsture un miskaste"
 msgid "Don't leave traces"
 msgstr "Neatstāt pēdas"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "lietojums;nesenie;vēsture;faili;datnes;pagaidu;privātums;privāts;miskaste;"
 "atkritne;attīrīt;paturēt;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Jāatbilst ierakstīšanās pakalpojuma sniedzēja tīmekļa adresei."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Neizdevās pievienot kontu"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Paroles nesakrīt."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Neizdevās reģistrēt kontu"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Nav atbalstīta autentificēšanās veida šim domēnam"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Neizdevās pievienoties domēnam"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Šis lietotājvārds nenostrādāja.\n"
-"Lūdzu, mēģiniet vēlreiz."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Šī parole nenostrādāja.\n"
-"Lūdzu, mēģiniet vēlreiz."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Neizdevās ierakstīties domēnā"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Nevar atrast domēnu. Varbūt tas ir nepareizi uzrakstīts?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7954,10 +4372,6 @@ msgstr ""
 "Uzņēmuma ierakstīšanās ļauj uz šīs ierīces izmantot esošus, centrāli "
 "pārvaldītus lietotāju kontus. Jūs varat arī izmantot šo kontu, lai piekļūtu "
 "uzņēmuma resursiem internetā."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Pārlūkot citus attēlus"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8028,222 +4442,6 @@ msgstr "_Dzēst pirkstu nospiedumus"
 msgid "Fingerprint Enroll"
 msgstr "Pirkstu nospiedumu reģistrēšana"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "lai veiktu šo darbību, ierīce ir jābūt pieprasītai"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "šo ierīci jau ir pieprasījis cits process"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "jums nav tiesību veikt šo darbību"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "nav reģistrētu izdruku"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Neizdevās sazināties ar ierīci reģistrācijas laikā"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Neizdevās sazināties ar pirkstu nospiedumu lasītāju"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Neizdevās sazināties ar pirkstu nospiedumu dēmonu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Neizdevās uzskaitīt pirkstu nospiedumus — %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Neizdevās izdzēst saglabātos pirkstu nospiedumus — %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Kreisais īkšķis"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Kreisais vidējais pirksts"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Kreisais rādītājpirksts"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Kreisais zeltnesis"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Kreisais mazais pirkstiņš"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Labais īkšķis"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Labais vidējais pirksts"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Labais _rādītājpirksts"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Labais zeltnesis"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Labais mazais pirkstiņš"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Nezināms pirksts"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Izpildīts"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Pirkstu nospiedumu ierīce ir atvienota"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Pirkstu nospiedumu ierīces krātuve ir pilna"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Neizdevās reģistrēt jaunu pirkstu nospiedumu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Neizdevās sākt reģistrēšanu — %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Neizdevās reģistrēt jaunu pirkstu nospiedumu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Neizdevās apturēt reģistrēšanu — %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Atkārtoti paceliet un novietojiet pirkstu uz lasītāja, lai reģistrētu savu "
-"pirkstu nospiedumu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Vēlreiz _reģistrēt šo pirkstu…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Skanēt jaunu pirkstu nospiedumu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Neizdevās aizmirst pirkstu nospiedumu ierīci %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problēmas, lasot ierīci"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Neizdevās satvert pirkstu nospiedumu ierīci %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Neizdevās saņemt pirkstu nospiedumu ierīci: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Šonedēļ"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Pagājušajā nedēļā"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y."
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sesija beidzās"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sesija sākās"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — konta aktivitāte"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Iepriekšējais"
@@ -8251,18 +4449,6 @@ msgstr "Iepriekšējais"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Nākamais"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Lūdzu, izvēlieties citu paroli."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Lūdzu, ievadiet savu pašreizējo paroli atkal."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Neizdevās nomainīt paroli"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8284,6 +4470,10 @@ msgstr "Jaunā parole"
 msgid "Confirm Password"
 msgstr "Apstiprināt jauno paroli"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Paroles nesakrīt."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Ļaut lietotājam mainīt paroli nākamajā ierakstīšanās reizē"
@@ -8291,134 +4481,6 @@ msgstr "Ļaut lietotājam mainīt paroli nākamajā ierakstīšanās reizē"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Iestatīt paroli tagad"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Nevar automātiski pievienoties šī veida domēnam"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Nav atrasts tāds domēns vai nogabals"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Nevar ierakstīties kā %s domēnā %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Nederīga parole; lūdzu, mēģiniet vēlreiz"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Neizdevās savienoties ar domēnu %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Neizdevās izdzēst lietotāju"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Neizdevās atsaukt attālināti pārvaldītu lietotāju"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Nav iespējams izdzēst savu kontu."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s vēl aizvien ir ierakstījies"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Lietotāja dzēšana, kamēr tas vēl ir ierakstījies, var atstāt sistēmu "
-"nesaskanīgā stāvoklī."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Vai vēlaties paturēt lietotāja %s datnes?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Pēc lietotāja dzēšanas ir iespējams paturēt mājas mapi, pastu un pagaidu "
-"datnes."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Dzēst datnes"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Paturēt datnes"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Vai tiešām vēlaties atsaukt attālināti pārvaldītu %s kontu?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Dzēst"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Konts ir deaktivēts"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Tiks iestatīta, nākamreiz ierakstoties"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Nekāda"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Ierakstījies"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Neizdevās sazināties ar kontu servisu"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Lūdzu, pārbaudiet, vai AccountService ir instalēts un aktivēts."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Lai mainītu šo iestatījumu, jāatbloķē šis panelis"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Dzēst izvēlēto lietotāja kontu"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Lai dzēstu izvēlēto lietotāja kontu,\n"
-"vispirms klikšķiniet uz * ikonas"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Atbloķēt, lai pievienotu lietotājus un mainītu iestatījumus"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8446,7 +4508,6 @@ msgid "Full name"
 msgstr "Vārds un uzvārds"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Rediģēt"
 
@@ -8508,7 +4569,6 @@ msgstr "Atbloķēt, lai pievienotu lietotāja kontu."
 msgid "Add or remove users and change your password"
 msgstr "Pievienot vai izņemt lietotājus un mainīt savu paroli"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8553,177 +4613,6 @@ msgstr "Pārvaldīt lietotāju kontus"
 msgid "Authentication is required to change user data"
 msgstr "Lai mainītu lietotāju datus, nepieciešama autentifikācija"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Jaunajai parolei ir jāatšķiras no vecās."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Mēģiniet mainīt dažus burtus un ciparus."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Mēģiniet paroli vēl nedaudz pamainīt."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Parole būtu drošāka, ja nesaturētu jūsu lietotājvārdu."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Mēģiniet neiekļaut savu vārdu parolē."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Mēģiniet neizmantot dažus vārdus, kas ir parolē."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Mēģiniet neizmantot bieži izmantotus vārdus."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Mēģiniet izvairīties no esošo vārdu pārkārtošanas."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Mēģiniet izmantot vairāk ciparu."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Mēģiniet izmantot vairāk lieto burtu."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Mēģiniet izmantot vairāk mazo burtu."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Mēģiniet izmantot vairāk īpašās rakstzīmes, piemēram, pieturzīmes."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Mēģiniet izmantot burtus, ciparus un pieturzīmes."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Mēģiniet neatkārtot vienu un to pašu rakstzīmi."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr "Drošāk ir lietot burtus, ciparus un pieturzīmes jauktā secībā."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Mēģiniet neizmantot secīgus simbolus, piemēram, 1234 vai abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Parolei jābūt garākai. Mēģiniet pievienot vairāk burtu, ciparu un "
-"pieturzīmju."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Lietojiet mazos un lielos burtus jauktā secībā, kā arī mēģiniet izmantot "
-"kādus ciparus."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Vairāk burtu, ciparu un pieturzīmju izmantošana padarīs paroli drošāku."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Autentifikācija neizdevās"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Jaunā parole ir pārāk īsa"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Jaunā parole ir pārāk vienkārša"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Jaunā un vecā parole ir pārāk līdzīgas"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Jaunā parole jau nesen tika izmantota."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Jaunajai parolei jāsatur arī cipari vai īpašās rakstzīmes"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Jaunā un vecā parole ir vienādas"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Jūsu parole ir mainīta kopš jūsu sākotnējās autorizācijas!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Jaunā parole nesatur pietiekami dažādas rakstzīmes"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Nezināma kļūda"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Lietotājvārds parasti drīkst saturēt tikai mazos burtus no a–z, ciparus un "
-"šīs rakstzīmes: . - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Diemžēl šis lietotājvārds nav pieejams. Lūdzu, mēģiniet citu."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Lietotājvārds ir pārāk garš."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8757,53 +4646,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Konstatēts nepareizs klikšķis, pārstartē…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Poga %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Definētā lietotne"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Sūtīt taustiņsitienu"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Pārslēgt monitoru"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Rādīt palīdzību uz ekrāna"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Planšete montēta uz klēpjdatora paneļa"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Planšete montēta uz ārējā displeja"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Ārējā planšetes ierīce"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
-#| msgid "External tablet device"
 msgid "External pad device"
 msgstr "Ārējā paliktņa ierīce"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Visi displeji"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8901,22 +4747,6 @@ msgstr "Labās peles pogas klikšķis"
 msgid "Forward"
 msgstr "Uz priekšu"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Aerogrāfa irbulis ar spiedienu, slīpumu un integrētu slīdni"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Aerogrāfa irbulis ar spiedienu, slīpumu un pagriezienu"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standarta irbulis ar spiedienu un slīpumu"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standarta irbulis ar spiedienu"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom planšete"
@@ -8926,54 +4756,96 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Iestatiet pogu attēlojumus un pielāgojiet irbuļa jutīgumu grafikas planšetēm"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Planšete;Wacom;Irbulis;Dzēšgumija;Pele;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Jauna saīsne…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulēt sekundāro klikšķi"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows programmatūra"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Maz tonera"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Sekundārā klikšķa aizture"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows programmatūra"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Pārvaldiet iestatījumus produktivitātei un vairākuzdevumu darbam"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Piekļuves punkti"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Pievienot"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Saglabāt"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Darbība atcelta"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Kļūda:</b> Piekļuve liegta iestatījumu mainīšanai"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Kļūda:</b> Mobilā aprīkojuma kļūda"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Nav reģistrēts"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Reģistrēts"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Viesabonēšana"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Meklē"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Piekļuve atteikta"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9003,238 +4875,13 @@ msgstr "Paša numurs"
 msgid "Device Details"
 msgstr "Informācija par ierīci"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Ražotājs"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Aparātprogrammatūras versija"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Tikai 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Tikai 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Tikai 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-#| msgid "2G Only"
-msgid "5G Only"
-msgstr "Tikai 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (vēlamais), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-#| msgid "2G, 3G (Preferred), 4G"
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (vēlamais), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-#| msgid "2G (Preferred), 3G, 4G"
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (vēlamais), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-#| msgid "2G, 3G, 4G"
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (vēlamais), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (vēlamais), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-#| msgid "3G, 4G (Preferred)"
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G (vēlamais), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1037
-#| msgid "3G, 4G (Preferred)"
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (vēlamais), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-#| msgid "3G (Preferred), 4G"
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (vēlamais), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-#| msgid "3G, 4G"
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-#| msgid "2G, 3G (Preferred), 4G"
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (vēlamais), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-#| msgid "2G (Preferred), 3G, 4G"
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (vēlamais), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-#| msgid "2G, 3G, 4G"
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-#| msgid "2G, 3G (Preferred), 4G"
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (vēlamais), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-#| msgid "2G (Preferred), 3G, 4G"
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (vēlamais), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-#| msgid "2G, 3G, 4G"
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (vēlamais), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (vēlamais), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (vēlamais), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-#| msgid "2G, 4G (Preferred)"
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-#| msgid "2G (Preferred), 4G"
-msgid "2G (Preferred), 5G"
-msgstr "2G (vēlamais), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-#| msgid "2G, 4G"
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-#| msgid "3G, 4G (Preferred)"
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-#| msgid "3G (Preferred), 4G"
-msgid "3G (Preferred), 5G"
-msgstr "3G (vēlamais), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-#| msgid "3G, 4G"
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-#| msgid "3G, 4G (Preferred)"
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (vēlamais)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-#| msgid "3G (Preferred), 4G"
-msgid "4G (Preferred), 5G"
-msgstr "4G (vēlamais), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Nezināms"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Atbloķēt SIM karti"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Atbloķēt"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Lūdzu, norādiet PIN kodu SIM kartei %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Ievadiet PIN, lai atbloķētu SIM karti"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Lūdzu, norādiet PUK kodu SIM kartei %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Ievadiet PUK, lai atbloķētu SIM karti"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9251,26 +4898,6 @@ msgid_plural "You have %u tries left"
 msgstr[0] "Jums ir atlicis %u mēģinājums"
 msgstr[1] "Jums ir atlikuši %u mēģinājumi"
 msgstr[2] "Jums ir atlikuši %u mēģinājumi"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Ievadīta kļūdaina parole."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK kodam jābūt 8 ciparu numuram"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Ievadiet jauno PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN kodam jābūt 4 līdz 8 ciparu skaitlim"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Atbloķē…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9328,94 +4955,6 @@ msgstr "Bloķēt SIM ar PIN"
 msgid "M_odem Details"
 msgstr "M_odema informācija"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Tālruņa kļūme"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Nav savienojuma ar tālruni"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Darbība nav atļauta"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Darbība nav atbalstīta"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Nav ievietota SIM karte"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Vajadzīgs SIM PIN"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Vajadzīgs SIM PUK"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM kļūme"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM ir aizņemts"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Nepareiza parole"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Vajadzīgs SIM PIN2"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Vajadzīgs SIM PUK2"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Nav atrasts"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Nav tīkla pakalpojuma"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Tīkla noildze"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS serviss nav atļauts"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Viesabonēšana nav atļauta šajā reģionā"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Nenorādīta GPRS kļūda"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Nav kļūdas"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Darbība ir atcelta"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Piekļuve atteikta"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Nezināma kļūda"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Tīkla režīms"
@@ -9431,11 +4970,6 @@ msgstr "Izvēlieties tīklu"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Atsvaidzināt tīkla pakalpojumu sniedzējus"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9493,7 +5027,6 @@ msgstr "Mobilais tīkls"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Konfigurēt telefoniju un mobilo datu savienojumus"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "mobilais;wwan;telefonija;sim;mobilais;"
@@ -9510,41 +5043,13 @@ msgstr "“Iestatījumi” ir galvenā sistēmas konfigurēšanas saskarne."
 msgid "The GNOME Project"
 msgstr "GNOME projekts"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Rādīt versijas numuru"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Aktivēt detalizēto režīmu"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Meklēt virkni"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Uzskaitīt iespējamo paneļu nosaukumus un iziet"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panelis, ko attēlot"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANELIS] [PARAMETRI…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Iestatījumu kategorijas"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privātums"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Pieejamie paneļi:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9602,7 +5107,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Atcelt meklēšanu"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Iestatījumi;Uzstādījumi;Konfigurācija;Preferences;Settings;"
@@ -9642,8 +5146,6 @@ msgstr ""
 "Kortežs, kas satur lietotnes loga sākotnējo platumu, augstumu un "
 "maksimizācijas statusu."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9652,8 +5154,6 @@ msgstr[0] "%u izvade"
 msgstr[1] "%u izvades"
 msgstr[2] "%u izvades"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9662,9 +5162,3188 @@ msgstr[0] "%u ievade"
 msgstr[1] "%u ievades"
 msgstr[2] "%u ievades"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sistēmas skaņas"
+#~ msgid "System Bus"
+#~ msgstr "Sistēmas kopne"
+
+#~ msgid "Full access"
+#~ msgstr "Pilna piekļuve"
+
+#~ msgid "Session Bus"
+#~ msgstr "Sesijas kopne"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Pilna pieeja /dev resursiem"
+
+#~ msgid "Has network access"
+#~ msgstr "Ir piekļuve tīklam"
+
+#~ msgid "Home"
+#~ msgstr "Mājas"
+
+#~ msgid "Read-only"
+#~ msgstr "Tikai lasāms"
+
+#~ msgid "File System"
+#~ msgstr "Datņu sistēma"
+
+#~ msgid "Can change settings"
+#~ msgstr "Var mainīt iestatījumus"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s ir šādas iebūvētās atļaujas. Tās nevar mainīt. Ja jūs šādas atļaujas "
+#~ "neapmierina, apsveriet šīs lietotnes izņemšanu."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u datnes un saites veids, ko atver lietotne"
+#~ msgstr[1] "%u datnes un saites veidi, ko atver lietotne"
+#~ msgstr[2] "%u datnes un saites veidu, ko atver lietotne"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> tiek izmantots, lai atvērtu sekojošos datņu un saišu veidus."
+
+#, c-format
+#~| msgid "%s of disk space used"
+#~ msgid "%s of disk space used."
+#~ msgstr "Izmantoti %s no diska vietas."
+
+#~ msgid "Select a picture"
+#~ msgstr "Izvēlieties attēlu"
+
+#~ msgid "_Open"
+#~ msgstr "_Atvērt"
+
+#~ msgid "multiple sizes"
+#~ msgstr "vairāki izmēri"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Bez fona attēla"
+
+#~ msgid "Current background"
+#~ msgstr "Pašreizējais fons"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Novietojiet savu kalibrēšanas ierīci virs kvadrāta un spiediet “Sākt”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Pārvietojiet savu kalibrēšanas ierīci uz kalibrēšanas pozīciju un "
+#~ "spiediet “Turpināt”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Pārvietojiet savu kalibrēšanas ierīci uz virsmas pozīciju un spiediet "
+#~ "“Turpināt”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Aizveriet klēpjdatora vāku"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Gadījās iekšēja kļūda, no kuras nevarēja atgūties."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Radās iekšēja kļūda, kuru nevarēja izlabot."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Nevarēja izveidot profilu."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Mērķa baltais punkts nebija iegūstams."
+
+#~ msgid "Complete!"
+#~ msgstr "Izpildīts!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrēšana neizdevās!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Jūs varat izņemt kalibrēšanas ierīci."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Neaiztieciet kalibrēšanas ierīci, kamēr tā darbojas"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Klēpjdatora ekrāns"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Iebūvēta tīmekļa kamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitors %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Skeneris %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Fotoaparāts %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Printeris %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Tīmekļa kamera %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Aktivēt %s krāsu pārvaldību"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Rādīt %s krāsu profilus"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nav kalibrēts"
+
+#~ msgid "Default: "
+#~ msgstr "Noklusējuma: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Krāsu telpa: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testa profils:"
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Izvēlieties ICC profila datni"
+
+#~ msgid "_Import"
+#~ msgstr "_Importēt"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Atbalstītie ICC profili"
+
+#~ msgid "All files"
+#~ msgstr "Visas datnes"
+
+#~ msgid "Save Profile"
+#~ msgstr "Saglabāt profilu"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Izveidot krāsu profilu izvēlētajai ierīcei"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Mērinstruments nav atrasts. Pārbaudiet, vai tas ir ieslēgts un pareizi "
+#~ "pievienots."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Mērinstruments neatbalsta printera profilēšanu."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Ierīces veids pašlaik nav atbalstīts."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standarta telpa"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testa profils"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automātiski"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Zema kvalitāte"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Vidēja kvalitāte"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Augsta kvalitāte"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Noklusējuma RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Noklusējuma CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Noklusējuma Pelēkais"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Ražotāja sniegtie rūpnīcas kalibrācijas dati"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Ar šo profilu nav iespējama pilnekrāna displeja koriģēšana"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Šis profils varētu vairs nebūt precīzs"
+
+#~ msgid "Other…"
+#~ msgstr "Citi…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Atbloķēt, lai mainītu iestatījumus"
+
+#~ msgid "Today"
+#~ msgstr "Šodien"
+
+#~ msgid "Yesterday"
+#~ msgstr "Vakar"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y."
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d stunda"
+#~ msgstr[1] "%d stundas"
+#~ msgstr[2] "%d stundas"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minūte"
+#~ msgstr[1] "%d minūtes"
+#~ msgstr[2] "%d minūtes"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekunde"
+#~ msgstr[1] "%d sekunžu"
+#~ msgstr[2] "%d sekundes"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Tīklājs"
+
+#~ msgid "24-hour"
+#~ msgstr "24 stundu"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %H:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%H:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Tehnisku problēmu ziņojumu sūtīšana palīdz mums uzlabot %s. Ziņojumi tiek "
+#~ "sūtīti anonīmi, un tiek iztīrīti no personīgajiem datiem. %s"
+
+#~ msgid "On"
+#~ msgstr "Ieslēgts"
+
+#~ msgid "Off"
+#~ msgstr "Izslēgts"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Pielietot izmaiņas?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Izmaiņas nevar pielietot"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Tas varētu būt aparatūras ierobežojumu dēļ."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Ainava"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portrets pa labi"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portrets pa kreisi"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Ainava (apmesta)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Secure boot ir ieslēgts"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce "
+#~ "sāk strādāt. Tas ir ieslēgts un funkcionē normāli."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Secure boot ir problēmas"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce "
+#~ "sāk strādāt. Tas ir ieslēgts, bet nevar strādāt, jo tam ir nederīga "
+#~ "atslēga."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Secure boot problēmas nereti var atrisināt no sava datora UEFI "
+#~ "aparātprogrammatūras iestatījumie  (BIOS) un jūsu aparatūras ražotājam "
+#~ "vajadzētu sniegt informāciju par to, kā to izdarīt."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Lai saņemtu palīdzību, sazinieties ar šīs aparatūras ražotāju vai IT "
+#~ "atbalsta sniedzēju."
+
+#~| msgid "Camera is Turned Off"
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Secure boot ir izslēgts"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce "
+#~ "sāk strādāt. Tas ir izslēgts."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Secure boot var izslēgt datora UEFI aparātprogrammatūras iestatījumos "
+#~ "(BIOS). Lai saņemtu palīdzību, sazinieties ar šīs aparatūras ražotāju vai "
+#~ "IT atbalsta sniedzēju."
+
+#~| msgid "Password"
+#~ msgid "Passed"
+#~ msgstr "Izdevās"
+
+#~| msgid "PPP failed"
+#~ msgid "Failed"
+#~ msgstr "Neizdevās"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Ierīce atbilst HSI %d. pakāpei"
+
+#~| msgctxt "Wi-Fi Hotspot"
+#~| msgid "Security type"
+#~ msgid "Security Level 0"
+#~ msgstr "Drošības pakāpe 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Šī ierīce netiek aizsargāta no aparatūras drošības problēmām. Tā var "
+#~ "notikt, ja ir problēmas aparatūras vai aparātprogrammatūras "
+#~ "konfigurācijā. Ieteicams sazināties ar savu IT atbalsta sniedzēju."
+
+#~| msgctxt "Wi-Fi Hotspot"
+#~| msgid "Security type"
+#~ msgid "Security Level 1"
+#~ msgstr "Drošības pakāpe 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Šai ierīcei ir minimāla aizsardzība pret aparatūras drošības problēmām. "
+#~ "Šī ir zemākā ierīču drošības pakāpe un tā sniedz aizsardzību tikai pret "
+#~ "vienkāršākajiem drošības draudiem."
+
+#~| msgctxt "Wi-Fi Hotspot"
+#~| msgid "Security type"
+#~ msgid "Security Level 2"
+#~ msgstr "Drošības pakāpe 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Šai ierīcei ir pamata aizsardzība pret aparatūras drošības problēmām. Tā "
+#~ "sniedz aizsardzību pret izplatītākajiem drošības draudiem."
+
+#~| msgctxt "Wi-Fi Hotspot"
+#~| msgid "Security type"
+#~ msgid "Security Level 3"
+#~ msgstr "Drošības pakāpe 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Šai ierīcei ir paplašināta aizsardzība pret aparatūras drošības "
+#~ "problēmām. Šī ir augstākā ierīču drošības pakāpe un tā sniedz aizsardzību "
+#~ "pret izvērstākiem drošības draudiem."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Šai ierīcei nav pieejamas aizsardzības pakāpes."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Sazinieties ar savas aparatūras ražotājiem, lai iegūtu palīdzību ar "
+#~ "drošības atjauninājumiem."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Šo problēmu varētu atrisināt ierīces UEFI aparātprogrammatūras "
+#~ "iestatījumos vai ar atbalsta speciālistu."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Šo problēmu varētu atrisināt ierīces UEFI aparātprogrammatūras "
+#~ "iestatījumos."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Šo problēmu varētu atrisināt atbalsta speciālists."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Aizsargāts pret ļaundabīgu programmatūru ierīces ielādes sākumā."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Secure boot ir problēmas"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Daļēja aizsardzība ierīces ielādes sākumā."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Secure boot ir izslēgts"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Nav aizsardzības ierīces ielādes sākumā."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Šī problēma varēja rasties dēļ UEFI aparātprogrammatūras iestatījumu "
+#~ "izmaiņām, operētājsistēmas konfigurācijas izmaiņām vai dēļ ļaundabīgas "
+#~ "programmatūras šajā datorā."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Šī problēma varēja rasties dēļ UEFI aparātprogrammatūras iestatījumu "
+#~ "izmaiņām vai dēļ ļaundabīgas programmatūras šajā datorā."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Šī problēma varēja rasties dēļ operētājsistēmas konfigurācijas izmaiņām "
+#~ "vai dēļ ļaundabīgas programmatūras šajā datorā."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Pakļauts nopietniem drošības draudiem."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Daļēja aizsardzība pret vienkāršākajiem drošības draudiem."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Aizsargāts pret izplatītākajiem drošības draudiem."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Aizsargāts pret daudziem drošības draudiem."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Vispusīga aizsardzība"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Aparātprogrammatūras rakstīšanas aizsardzība"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Aparātprogrammatūras rakstīšanas aizsardzības slēdzene"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Aparātprogrammatūras BIOS reģions"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Aparātprogrammatūras BIOS deskriptors"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Pirms-ielādes DMA aizsardzība"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard pārbaudītā ielāde"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM aizsardzība"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard kļūdu politika"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard sintēze"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET ieslēgts"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET aktīvs"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Šifrēts RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU aizsardzība"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux Kernel noslēgšana"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux Kernel verifikācija"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux maiņvieta"
+
+#~| msgid "Suspend"
+#~ msgid "Suspend To RAM"
+#~ msgstr "Iesnaudināt uz RAM"
+
+#~| msgid "Suspend"
+#~ msgid "Suspend To Idle"
+#~ msgstr "Iesnaudināt uz dīkstāvi"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI platformas atslēga"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI drošā ielāde"
+
+#~| msgid "Display Configuration"
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM platformas konfigurācija"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM rekonstrukcija"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine ražošanas režīms"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine pārrakstīšana"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine versija"
+
+#~| msgid "Software Updates"
+#~ msgid "Firmware Updates"
+#~ msgstr "Aparātprogrammatūras atjauninājumi"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Attestation"
+#~ msgstr "Aparātprogrammatūras atestācija"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Aparātprogrammatūras atjauninātāja versija"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Platformas atkļūdošana"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Procesora drošības pārbaudes"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD atpakaļ ritināšanas aizsardzība"
+
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD aparātprogrammatūras atkārtošanas aizsardzība"
+
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD aparātprogrammatūras rakstīšanas aizsardzība"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Sintēzes platforma"
+
+#~ msgid "Valid"
+#~ msgstr "Derīgs"
+
+#~| msgid "Not calibrated"
+#~ msgid "Not Valid"
+#~ msgstr "Nederīgs"
+
+#~| msgid "Enabled"
+#~ msgid "Not Enabled"
+#~ msgstr "Nav ieslēgts"
+
+#~| msgid "SIM Locked"
+#~ msgid "Locked"
+#~ msgstr "Bloķēts"
+
+#~| msgid "SIM Locked"
+#~ msgid "Not Locked"
+#~ msgstr "Nav bloķēts"
+
+#~ msgid "Encrypted"
+#~ msgstr "Šifrēts"
+
+#~| msgid "Not calibrated"
+#~ msgid "Not Encrypted"
+#~ msgstr "Nav šifrēts"
+
+#~ msgid "Tainted"
+#~ msgstr "Bojāts"
+
+#~| msgid "Not calibrated"
+#~ msgid "Not Tainted"
+#~ msgstr "Nav bojāts"
+
+#~| msgid "Sound"
+#~ msgid "Found"
+#~ msgstr "Atrasts"
+
+#~| msgid "Not found"
+#~ msgid "Not Found"
+#~ msgstr "Nav atrasts"
+
+#~| msgctxt "print job"
+#~| msgid "Aborted"
+#~ msgid "Supported"
+#~ msgstr "Atbalstīts"
+
+#~| msgid "No Thunderbolt Support"
+#~ msgid "Not Supported"
+#~ msgstr "Nav atbalstīts"
+
+#~ msgid "Unknown"
+#~ msgstr "Nezināms"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bitu"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bitu"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Nezināms"
+
+#~ msgid "Not Available"
+#~ msgstr "Nav pieejams"
+
+#~ msgid "System Logo"
+#~ msgstr "Sistēmas logo"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nav atrastu ievades avotu"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Citi"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Pielāgotas saīsnes"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Papildu rakstzīmju ievadīšanai var izmantot alternatīvo rakstzīmju "
+#~ "taustiņu. Dažreiz tās tiek attēlotas kā trešā opcija uz tastatūras."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Kreisais Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Labais alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Kreisais super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Labais super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Izvēlnes taustiņš"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Labais Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Komponēšanas taustiņš ļauj ievadīt plašu rakstzīmju klāstu Lai to "
+#~ "izmantotu, spiediet komponēšanas taustiņu un tad ievadiet rakstzīmes. "
+#~ "Piemēram, pēc kompozīcijas taustiņa spiežot <b>C</b> un <b>o</b> tiks "
+#~ "ievadīts <b>©</b>, <b>a</b> pēc tam <b>'</b> izveidos <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Reģistra slēdzis"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Drukāt ekrānu"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Ievades avotus var pārslēgt, izmantojot %s tastatūras īsinājumtaustiņu.\n"
+#~ "To var mainīt tastatūras īsinājumtaustiņu iestatījumos."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d izmainīts"
+#~ msgstr[1] "%d izmainīti"
+#~ msgstr[2] "%d izmainītu"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Atiestatīt visas saīsnes?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Saīšņu atiestatīšana var ietekmēt jūsu pielāgotās saīsnes. Šo darbību "
+#~ "nevar atsaukt."
+
+#~ msgid "Reset All"
+#~ msgstr "Atiestatīt visas"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s jau izmanto %s. Ja to aizstāsiet, %s tiks izslēgts"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Ievadiet jauno saīsni"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Iestatīt pielāgotas saīsnes"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Iestatīt saīsni"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Ievadiet jaunu saīsni, lai mainītu %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Pievienot pielāgoto saīsni"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Divu pirkstu ritināšana"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Pieci klikšķi, laiks GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dubultklikšķis, primārā poga"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Viens klikšķis, primārā poga"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dubultklikšķis, vidējā poga"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Viens klikšķis, vidējā poga"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dubultklikšķis, sekundārā poga"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Viens klikšķis, sekundārā poga"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager ir jābūt palaistam."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Nedrošs tīkls (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Drošs tīkls (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Drošs tīkls (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Drošs tīkls (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Drošs tīkls"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Ieslēdzot tīklāju, tiks pārtraukts savienojums ar %s, un nevarēs piekļūt "
+#~ "internetam caur Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Jābūt vismaz 8 rakstzīmēm"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Apturēt tīklāju un atvienot visus lietotājus?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Apturēt tīklāju"
+
+#~ msgid "Preserve"
+#~ msgstr "Saglabāt"
+
+#~ msgid "Permanent"
+#~ msgstr "Pastāvīgi"
+
+#~ msgid "Random"
+#~ msgstr "Nejauši"
+
+#~ msgid "Stable"
+#~ msgstr "Stabils"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Šeit ievadītā MAC adrese tiks izmantota kā aparatūras adrese tīkla "
+#~ "ierīcei, kurai šis savienojums ir aktivizēts. Šī iespēja ir pazīstama kā "
+#~ "MAC klonēšana vai izlikšanās. Piemērs: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profils %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nav"
+
+#~ msgid "Never"
+#~ msgstr "Nekad"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nav"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Vājš"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Lietojams"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Labs"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Teicams"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Aizmirst savienojumu"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Izņemt savienojuma profilu"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Izņemt VPN"
+
+#~ msgid "Details"
+#~ msgstr "Sistēmas informācija"
+
+#~ msgid "automatic"
+#~ msgstr "automātiski"
+
+#~ msgid "Identity"
+#~ msgstr "Identitāte"
+
+#~ msgid "Delete Address"
+#~ msgstr "Dzēst adresi"
+
+#~ msgid "Delete Route"
+#~ msgstr "Dzēst maršrutu"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Nav"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128 bitu atslēga (Hex vai ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128 bitu parole"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dinamiskais WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA un WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA un WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Nevar atvērt savienojumu redaktoru"
+
+#~ msgid "New Profile"
+#~ msgstr "Jauns profils"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Nederīgi iestatījumi %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Nederīgi iestatījumi %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importēt no datnes…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Pievienot VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Nevar importēt VPN savienojumu"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Datni “%s” nevar nolasīt vai tajā nav atpazīstama VPN savienojuma "
+#~ "informācija\n"
+#~ "\n"
+#~ "Kļūda — %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Izvēlieties datni, ko importēt"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Datne ar nosaukumu “%s” jau eksistē."
+
+#~ msgid "_Replace"
+#~ msgstr "_Aizstāt"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Vai vēlaties aizstāt %s ar saglabājamo VPN savienojumu?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Nevar eksportēt VPN savienojumu"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Nevar eksportēt VPN savienojumu “%s” uz %s.\n"
+#~ "\n"
+#~ "Kļūda — %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Eksportē VPN savienojumu"
+
+#~ msgid "never"
+#~ msgstr "nekad"
+
+#~ msgid "today"
+#~ msgstr "šodien"
+
+#~ msgid "yesterday"
+#~ msgstr "vakar"
+
+#~ msgid "Last used"
+#~ msgstr "Pēdējoreiz lietots"
+
+#~ msgid "Add new connection"
+#~ msgstr "Pievienot jaunu savienojumu"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Informācija par izvēlētajiem tīkliem, tai skaitā paroles un jebkāda "
+#~ "pielāgota konfigurācija, tiks pazaudēta."
+
+#~ msgid "_Forget"
+#~ msgstr "Ai_zmirst"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Zināmie Wi-Fi tīkli"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "Ai_zmirst"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Sistēmas politika neļauj izmantot kā tīklāju"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Bezvadu ierīce ierīce neatbalsta tīklāja režīmu"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Kad nav norādīts konfigurācijas URL, tiek izmantota tīmekļa starpnieka "
+#~ "automātiskā atklāšana."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Tas nav ieteicams neuzticamos publiskos tīklos."
+
+#~ msgid "Status unknown"
+#~ msgstr "Nezināms statuss"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Nepārvaldīts"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nav pieejams"
+
+#~ msgid "Connecting"
+#~ msgstr "Savienojas"
+
+#~ msgid "Authentication required"
+#~ msgstr "Nepieciešama autentifikācija"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Atvieno"
+
+#~ msgid "Connection failed"
+#~ msgstr "Savienojums neizdevās"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Nezināms statuss (trūkst)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Konfigurēšana neizdevās"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP konfigurēšana neizdevās"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP konfigurācija vairs nav derīga"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Noslēpumi tika pieprasīti, bet netika sniegti"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x pieprasītājports atvienots"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x pieprasītājporta konfigurēšana neizdevās"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x pieprasītājports nestrādā"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x pieprasītājports neautentificējās atvēlētajā laikā"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP servisa palaišana neizdevās"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP serviss atvienots"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP nestrādā"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP klienta palaišana neizdevās"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP klienta kļūda"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP klients nestrādā"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Koplietojamā savienojuma serviss nepalaidās"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Koplietojamā savienojuma serviss nestrādā"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP servisa palaišana neizdevās"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP servisa kļūda"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP serviss nestrādā"
+
+#~ msgid "Line busy"
+#~ msgstr "Līnija aizņemta"
+
+#~ msgid "No dial tone"
+#~ msgstr "Nav centrāles gatavības signāla"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Neizdevās izveidot nesēju"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Iezvanīšanās pieprasījuma noildze"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Iezvanīšanās neizdevās"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Neizdevās inicializēt modemu"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Neizdevās izvēlēties norādīto APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Nemeklē tīklus"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Reģistrācija tīklā liegta"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Tīkla reģistrācijas noildze"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Neizdevās reģistrēties pieprasītajā tīklā"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN nav atzīts par derīgu"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Iespējams, ierīcei pietrūkst aparātprogrammatūras"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Savienojums pazuda"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Tika pieņemts, ka savienojums eksistē"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modems nav atrasts"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth savienojums neizdevās"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Nav ievietota SIM karte"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Vajadzīgs SIM PIN"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Vajadzīgs SIM PUK"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Nepareiza SIM karte"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Savienojuma priekšnoteikums nav izpildīts"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Trūkst aparātprogrammatūras"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Vads atvienots"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "nedefinēta kļūda 802.1X drošībā (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "nav izvēlēta neviena datne"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "nenorādīta kļūda validējot eap metodes datni"
+
+#~| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 vai PGP privātās atslēgas"
+
+#~| msgid "_User certificate"
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER vai PEM sertifikāti"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "trūkst EAP-FAST PAC datnes"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC datne (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "trūkst EAP-LEAP lietotājvārds"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "trūkst EAP-LEAP paroles"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "nederīgs EAP-PEAP CA sertifikāts: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "nederīgs EAP-PEAP CA sertifikāts: nav norādīts sertifikāts"
+
+#~ msgid "missing EAP username"
+#~ msgstr "trūkst EAP lietotājvārda"
+
+#~ msgid "missing EAP password"
+#~ msgstr "trūkst EAP paroles"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "trūkst EAP-TLS identitātes"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "nederīgs EAP-TLS CA sertifikāts: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "nederīgs EAP-TLS CA sertifikāts: nav norādīts sertifikāts"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "nederīga EAP-TLS privātā atslēga: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "nederīgs EAP-TLS lietotāja sertifikāts: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Nešifrētas privātās atslēgas nav drošas"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Izskatās, ka izvēlētā privātā atslēga nav aizsargāta ar paroli. Tas var "
+#~ "ļaut kompromitēt drošības akreditācijas datus. Lūdzu, izvēlieties ar "
+#~ "paroli aizsargātu privāto atslēgu.\n"
+#~ "\n"
+#~ "(Savu privāto atslēgu varat aizsargāt ar paroli ar openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Izvelieties personīgo sertifikātu"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Izvēlieties privāto atslēgu"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "nederīgs EAP-TTLS CA sertifikāts: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "nederīgs EAP-TTLS CA sertifikāts: nav norādīts sertifikāts"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Nezināma kļūda validējot 802.1X drošību"
+
+#~ msgid "Select a file"
+#~ msgstr "Izvēlieties datni"
+
+#~ msgid "missing leap-username"
+#~ msgstr "trūkst leap lietotājvārda"
+
+#~ msgid "missing leap-password"
+#~ msgstr "trūkst leap paroles"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Pietrūkst Wi-Fi paroles."
+
+#~ msgid "missing wep-key"
+#~ msgstr "trūkst wep atslēgas"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "nederīga wep atslēga: atslēga ar garumu %zu var saturēt tikai "
+#~ "heksadecimālus skaitļus"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "nederīga wep atslēga: atslēga ar garumu %zu var saturēt tikai ascii "
+#~ "rakstzīmes"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "nederīga wep atslēga: nepareizs atslēgas garums %zu. Atslēgas garumam ir "
+#~ "jābūt vai nu 5/13 (ascii) vai 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "nederīga wep atslēga: parole nevar būt tukša"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "nederīga wep atslēga: parolei ir jābūt īsākai nekā 64 rakstzīmes"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "nederīgs wpa-psk: nederīgs atslēgas garums %zu. Jābūt [8,63] baiti vai 64 "
+#~ "heksadecimālie cipari"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "nederīgs wpa-psk: nevar interpretēt atslēgu ar 64 baitiem kā heksadecimālu"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Citi"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s ir izņemts"
+
+#~ msgid "Error removing account"
+#~ msgstr "Kļūda, noņemot kontu"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s konts"
+
+#~ msgid "Remove Account"
+#~ msgstr "Izņemt kontu"
+
+#~ msgid "Unknown time"
+#~ msgstr "Nezināms laiks"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "Pilnībā uzlādēts pēc %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Brīdinājums — atlicis %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Atlikušais laiks — %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Pilnībā uzlādēts"
+
+#~ msgid "Not charging"
+#~ msgstr "Nelādējas"
+
+#~ msgid "Empty"
+#~ msgstr "Tukša"
+
+#~ msgid "Charging"
+#~ msgstr "Uzlādējas"
+
+#~ msgid "Discharging"
+#~ msgstr "Izlādējas"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Bezvadu pele"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Bezvadu tastatūra"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Nepārtrauktais barošanas avots"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Personālais ciparasistents"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobilais tālrunis"
+
+#~ msgid "Media player"
+#~ msgstr "Multimediju atskaņotājs"
+
+#~ msgid "Tablet"
+#~ msgstr "Planšete"
+
+#~ msgid "Computer"
+#~ msgstr "Dators"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Spēļu ievades ierīce"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Galvenā"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Papildus"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterijas"
+
+#~ msgid "When _idle"
+#~ msgstr "Kad _dīkstāvē"
+
+#~ msgid "Suspend"
+#~ msgstr "Iesnaudināt"
+
+#~ msgid "Power Off"
+#~ msgstr "Izslēgt"
+
+#~ msgid "Hibernate"
+#~ msgstr "Iemidzināt"
+
+#~ msgid "Nothing"
+#~ msgstr "Nedarīt neko"
+
+#~ msgid "When on battery power"
+#~ msgstr "Kad izmanto baterijas strāvu"
+
+#~ msgid "When plugged in"
+#~ msgstr "Kad pieslēgts strāvai"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nekad"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automātiski iesnaudināt"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Jaudīgais režīms ir uz laiku izslēgts pārāk augstas temperatūras dēļ."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Detektēts klēpis — jaudīgais režīms uz laiku nav pieejams. Pārvietojiet "
+#~ "ierīci uz stabilu virsmu, lai to atjaunotu."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Jaudīgais režīms uz brīdi ir izslēgts."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Maza baterijas jauda — ieslēgta enerģijas taupīšana. Iepriekšējais režīms "
+#~ "tiks atjaunots, kad baterija būs pietiekami uzlādēta."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Enerģijas taupīšanas režīmu ieslēdza “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Jaudīgo režīmu ieslēdza “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Veiktspēja"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Augsta veiktspēja un jaudas patēriņš."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Līdzsvarota"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standarta veiktspēja un jaudas patēriņš."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Taupīga"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Samazināta veiktspēja un jaudas patēriņš."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Printeris “%s” tika izdzēsts"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Neizdevās pievienot jaunu printeri."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Nevar ielādēt saskarni: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Atbloķēt, lai pievienotu printerus un mainītu iestatījumus"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s informācija"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nav atrasts piemērots draiveris"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Izvēlieties PPD datni"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript Printer Description datnes (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+#~ "*.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect printeris"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD printeris"
+
+#~ msgid "One Sided"
+#~ msgstr "Vienā pusē"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Garās malas iesējums"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Īsās malas iesējums"
+
+#~ msgid "Portrait"
+#~ msgstr "Portrets"
+
+#~ msgid "Landscape"
+#~ msgstr "Ainava"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Apgriezta ainava"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Apgriezts portrets"
+
+#~ msgid "Resume"
+#~ msgstr "Turpināt"
+
+#~ msgid "Pause"
+#~ msgstr "Pauzēt"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Gaida"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pauzēts"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Nepieciešama autentifikācija"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Apstrādā"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Apturēts"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Atcelts"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Atsaukts"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Izpildīts"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Pārvietot šo uzdevumu uz rindas augšu"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — aktīvie darbi"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Ievadiet akreditācijas datus lai drukātu no %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Atbloķēt printera serveri"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Atbloķēt %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Ievadiet lietotājvārdu un paroli, lai redzētu, kādi printeri ir uz %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Meklē printerus"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Seriālais ports"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralēlais ports"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Atrašanās vieta: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adrese: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Serveris pieprasa autentifikāciju"
+
+#~ msgid "Two Sided"
+#~ msgstr "Abās pusēs"
+
+#~ msgid "Paper Type"
+#~ msgstr "Papīra tips"
+
+#~ msgid "Paper Source"
+#~ msgstr "Papīra avots"
+
+#~ msgid "Output Tray"
+#~ msgstr "Izvades paplāte"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Izšķirtspēja"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript prefiltrēšana"
+
+#~ msgid "Pages per side"
+#~ msgstr "Lappuses loksnē"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientācija"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Vispārēji"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Lapas iestatījumi"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Instalējamās opcijas"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Darbs"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Attēla kvalitāte"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Krāsas"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Pēcapstrāde"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Paplašināti"
+
+#~ msgid "Test page"
+#~ msgstr "Testa lapa"
+
+#~ msgid "Auto Select"
+#~ msgstr "Autoizvēle"
+
+#~ msgid "Printer Default"
+#~ msgstr "Printera noklusējuma"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Iekļaut tikai GhostScript fontus"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Konvertēt uz PS level 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Konvertēt uz PS level 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Bez prefiltrēšanas"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Tīrīt printera galviņas"
+
+#~ msgid "Out of toner"
+#~ msgstr "Beidzies toneris"
+
+#~ msgid "Low on developer"
+#~ msgstr "Palicis maz attīstītāja"
+
+#~ msgid "Out of developer"
+#~ msgstr "Nav attīstītāja"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Palicis maz krāsas"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Beigusies krāsa"
+
+#~ msgid "Open cover"
+#~ msgstr "Atvērts vāks"
+
+#~ msgid "Open door"
+#~ msgstr "Atvērtas durvis"
+
+#~ msgid "Low on paper"
+#~ msgstr "Maz papīra"
+
+#~ msgid "Out of paper"
+#~ msgstr "Beidzies papīrs"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Nesaistē"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Apturēts"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Atkritumu tvertne gandrīz pilna"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Atkritumu tvertne pilna"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Optiskais gaismas vadītājs drīz būs jāmaina"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Optiskais gaismas vadītājs vairs nefunkcionē"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Gatavs"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Nepieņem darbus"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Apstrādā"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperiālās"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metriskās"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Jautāt, ko darīt"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nedarīt neko"
+
+#~ msgid "Open folder"
+#~ msgstr "Atvērt mapi"
+
+#~ msgid "Other Media"
+#~ msgstr "Citi datu nesēji"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Izvēlieties lietotni audio diskiem"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Izvēlieties lietotni DVD diskiem"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Izvēlieties lietotni, ko palaist, kad pievienots mūzikas atskaņotājs"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Izvēlieties lietotni, ko palaist, kad pievienota fotokamera"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Izvēlieties lietotni programmatūras CD"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "tukšs Blu-ray disks"
+
+#~ msgid "blank CD disc"
+#~ msgstr "tukšs CD disks"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "tukšs DVD disks"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "tukšs HD DVD disks"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video disks"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-grāmatu lasītājs"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video disks"
+
+#~ msgid "Picture CD"
+#~ msgstr "Bilžu CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Ekrāns izslēdzas"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekundes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minūte"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minūtes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minūtes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minūtes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minūtes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 stunda"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minūtes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minūtes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minūtes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minūtes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minūtes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minūtes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minūtes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minūtes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minūtes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nekad"
+
+#~ msgid "Select Location"
+#~ msgstr "Izvēlieties vietu"
+
+#~ msgid "_OK"
+#~ msgstr "_Labi"
+
+#~ msgid "No applications found"
+#~ msgstr "Nav atrastu lietotņu"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Koplietošanai nav izvēlētu tīklu"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Ieslēgts"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Izslēgts"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Ieslēgts"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktīvs"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Izvēlieties mapi"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Ieslēgt multimediju koplietošanu"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Datņu koplietošana ļauj jums dalīties ar savu publisko mapi ar citiem "
+#~ "jūsu pašreizējā tīklā, izmantojot: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kad ir ieslēgta attālinātā ierakstīšanās, datoru var lietot attālināti, "
+#~ "izmantojot Secure Shell komandu:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Ieslēgt personīgo mediju koplietošanu"
+
+#~ msgid "Device name copied"
+#~ msgstr "Ierīces nosaukums ir nokopēts"
+
+#~ msgid "Device address copied"
+#~ msgstr "Ierīces adrese ir nokopēta"
+
+#~ msgid "Username copied"
+#~ msgstr "Lietotājvārds ir nokopēts"
+
+#~ msgid "Password copied"
+#~ msgstr "Parole ir nokopēta"
+
+#~ msgid "Custom"
+#~ msgstr "Pielāgots"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Pārbauda %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Atvienots"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Savienojas"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Savienots"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Pilnvarošanas kļūda"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Pilnvaro"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Samazināta funkcionalitāte"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Savienots un pilnvarots"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Nezināms"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Pilnvarots:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Savienots:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Reģistrēts:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Neizdevās pilnvarot ierīci: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Neizdevās aizmirst ierīci: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Kļūda"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Pilnvarots"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt apakšsistēma (boltd) nav instalēta vai nav pareizi iestatīta."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Var pievienoties tikai USB un Display Port ierīces."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Nevarēja atklāt Thunderbolt.\n"
+#~ "Vai nu sistēmai nav Thunderbolt atbalsta, tas ir izslēgts BIOS "
+#~ "konfigurācijā vai arī tam ir neatbalstīts drošības līmenis BIOS "
+#~ "konfigurācijā."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt atbalsts ir izslēgts BIOS konfigurācijā."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Nevarēja noteikt Thunderbolt drošības līmeni."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Kļūda, pārslēdzot tiešo režīmu: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Noklusējuma"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Vidējs"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Liels"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Lielāks"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Vislielākais"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pikselis"
+#~ msgstr[1] "%d pikseļi"
+#~ msgstr[2] "%d pikseļu"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Īss"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ekrāna"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ekrāna"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ekrāna"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Garš"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 stunda"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 diena"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dienas"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dienas"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dienas"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dienas"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dienas"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dienas"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dienas"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dienas"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Iztukšot visu miskasti?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Viss miskastes saturs tiks neatgriezeniski dzēsts."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Iztīrīt atkritumus"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Dzēst visas pagaidu datnes?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Visas pagaidu datnes tiks pilnībā izdzēstas."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Izmest _pagaidu datnes"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 diena"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dienas"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dienas"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Visu laiku"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Jāatbilst ierakstīšanās pakalpojuma sniedzēja tīmekļa adresei."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Neizdevās pievienot kontu"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Neizdevās reģistrēt kontu"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nav atbalstīta autentificēšanās veida šim domēnam"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Neizdevās pievienoties domēnam"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Šis lietotājvārds nenostrādāja.\n"
+#~ "Lūdzu, mēģiniet vēlreiz."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Šī parole nenostrādāja.\n"
+#~ "Lūdzu, mēģiniet vēlreiz."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Neizdevās ierakstīties domēnā"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Nevar atrast domēnu. Varbūt tas ir nepareizi uzrakstīts?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Pārlūkot citus attēlus"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "lai veiktu šo darbību, ierīce ir jābūt pieprasītai"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "šo ierīci jau ir pieprasījis cits process"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "jums nav tiesību veikt šo darbību"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "nav reģistrētu izdruku"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Neizdevās sazināties ar ierīci reģistrācijas laikā"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Neizdevās sazināties ar pirkstu nospiedumu lasītāju"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Neizdevās sazināties ar pirkstu nospiedumu dēmonu"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Neizdevās uzskaitīt pirkstu nospiedumus — %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Neizdevās izdzēst saglabātos pirkstu nospiedumus — %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Kreisais īkšķis"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Kreisais vidējais pirksts"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Kreisais rādītājpirksts"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Kreisais zeltnesis"
+
+#~ msgid "Left little finger"
+#~ msgstr "Kreisais mazais pirkstiņš"
+
+#~ msgid "Right thumb"
+#~ msgstr "Labais īkšķis"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Labais vidējais pirksts"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Labais _rādītājpirksts"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Labais zeltnesis"
+
+#~ msgid "Right little finger"
+#~ msgstr "Labais mazais pirkstiņš"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Nezināms pirksts"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Izpildīts"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Pirkstu nospiedumu ierīce ir atvienota"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Pirkstu nospiedumu ierīces krātuve ir pilna"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Neizdevās reģistrēt jaunu pirkstu nospiedumu"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Neizdevās sākt reģistrēšanu — %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Neizdevās reģistrēt jaunu pirkstu nospiedumu"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Neizdevās apturēt reģistrēšanu — %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Atkārtoti paceliet un novietojiet pirkstu uz lasītāja, lai reģistrētu "
+#~ "savu pirkstu nospiedumu"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Vēlreiz _reģistrēt šo pirkstu…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Skanēt jaunu pirkstu nospiedumu"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Neizdevās aizmirst pirkstu nospiedumu ierīci %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problēmas, lasot ierīci"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Neizdevās satvert pirkstu nospiedumu ierīci %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Neizdevās saņemt pirkstu nospiedumu ierīci: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Šonedēļ"
+
+#~ msgid "Last Week"
+#~ msgstr "Pagājušajā nedēļā"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y."
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sesija beidzās"
+
+#~ msgid "Session Started"
+#~ msgstr "Sesija sākās"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — konta aktivitāte"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Lūdzu, izvēlieties citu paroli."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Lūdzu, ievadiet savu pašreizējo paroli atkal."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Neizdevās nomainīt paroli"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Nevar automātiski pievienoties šī veida domēnam"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nav atrasts tāds domēns vai nogabals"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Nevar ierakstīties kā %s domēnā %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Nederīga parole; lūdzu, mēģiniet vēlreiz"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Neizdevās savienoties ar domēnu %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Neizdevās izdzēst lietotāju"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Neizdevās atsaukt attālināti pārvaldītu lietotāju"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nav iespējams izdzēst savu kontu."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s vēl aizvien ir ierakstījies"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Lietotāja dzēšana, kamēr tas vēl ir ierakstījies, var atstāt sistēmu "
+#~ "nesaskanīgā stāvoklī."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Vai vēlaties paturēt lietotāja %s datnes?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Pēc lietotāja dzēšanas ir iespējams paturēt mājas mapi, pastu un pagaidu "
+#~ "datnes."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Dzēst datnes"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Paturēt datnes"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Vai tiešām vēlaties atsaukt attālināti pārvaldītu %s kontu?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Dzēst"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Konts ir deaktivēts"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Tiks iestatīta, nākamreiz ierakstoties"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Nekāda"
+
+#~ msgid "Logged in"
+#~ msgstr "Ierakstījies"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Neizdevās sazināties ar kontu servisu"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Lūdzu, pārbaudiet, vai AccountService ir instalēts un aktivēts."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Lai mainītu šo iestatījumu, jāatbloķē šis panelis"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Dzēst izvēlēto lietotāja kontu"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Lai dzēstu izvēlēto lietotāja kontu,\n"
+#~ "vispirms klikšķiniet uz * ikonas"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Atbloķēt, lai pievienotu lietotājus un mainītu iestatījumus"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Jaunajai parolei ir jāatšķiras no vecās."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Mēģiniet mainīt dažus burtus un ciparus."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Mēģiniet paroli vēl nedaudz pamainīt."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Parole būtu drošāka, ja nesaturētu jūsu lietotājvārdu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Mēģiniet neiekļaut savu vārdu parolē."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Mēģiniet neizmantot dažus vārdus, kas ir parolē."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Mēģiniet neizmantot bieži izmantotus vārdus."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Mēģiniet izvairīties no esošo vārdu pārkārtošanas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Mēģiniet izmantot vairāk ciparu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Mēģiniet izmantot vairāk lieto burtu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Mēģiniet izmantot vairāk mazo burtu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Mēģiniet izmantot vairāk īpašās rakstzīmes, piemēram, pieturzīmes."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Mēģiniet izmantot burtus, ciparus un pieturzīmes."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Mēģiniet neatkārtot vienu un to pašu rakstzīmi."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr "Drošāk ir lietot burtus, ciparus un pieturzīmes jauktā secībā."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Mēģiniet neizmantot secīgus simbolus, piemēram, 1234 vai abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Parolei jābūt garākai. Mēģiniet pievienot vairāk burtu, ciparu un "
+#~ "pieturzīmju."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Lietojiet mazos un lielos burtus jauktā secībā, kā arī mēģiniet izmantot "
+#~ "kādus ciparus."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Vairāk burtu, ciparu un pieturzīmju izmantošana padarīs paroli drošāku."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autentifikācija neizdevās"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Jaunā parole ir pārāk īsa"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Jaunā parole ir pārāk vienkārša"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Jaunā un vecā parole ir pārāk līdzīgas"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Jaunā parole jau nesen tika izmantota."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Jaunajai parolei jāsatur arī cipari vai īpašās rakstzīmes"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Jaunā un vecā parole ir vienādas"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Jūsu parole ir mainīta kopš jūsu sākotnējās autorizācijas!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Jaunā parole nesatur pietiekami dažādas rakstzīmes"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Nezināma kļūda"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Lietotājvārds parasti drīkst saturēt tikai mazos burtus no a–z, ciparus "
+#~ "un šīs rakstzīmes: . - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Diemžēl šis lietotājvārds nav pieejams. Lūdzu, mēģiniet citu."
+
+#~ msgid "The username is too long."
+#~ msgstr "Lietotājvārds ir pārāk garš."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Poga %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Definētā lietotne"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Sūtīt taustiņsitienu"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Pārslēgt monitoru"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Rādīt palīdzību uz ekrāna"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Planšete montēta uz klēpjdatora paneļa"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Planšete montēta uz ārējā displeja"
+
+#~ msgid "External tablet device"
+#~ msgstr "Ārējā planšetes ierīce"
+
+#~ msgid "All Displays"
+#~ msgstr "Visi displeji"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Aerogrāfa irbulis ar spiedienu, slīpumu un integrētu slīdni"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Aerogrāfa irbulis ar spiedienu, slīpumu un pagriezienu"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standarta irbulis ar spiedienu un slīpumu"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standarta irbulis ar spiedienu"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Jauna saīsne…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Darbība atcelta"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Kļūda:</b> Piekļuve liegta iestatījumu mainīšanai"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Kļūda:</b> Mobilā aprīkojuma kļūda"
+
+#~ msgid "Not Registered"
+#~ msgstr "Nav reģistrēts"
+
+#~ msgid "Registered"
+#~ msgstr "Reģistrēts"
+
+#~ msgid "Roaming"
+#~ msgstr "Viesabonēšana"
+
+#~ msgid "Searching"
+#~ msgstr "Meklē"
+
+#~ msgid "Denied"
+#~ msgstr "Piekļuve atteikta"
+
+#~ msgid "2G Only"
+#~ msgstr "Tikai 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Tikai 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Tikai 4G"
+
+#~| msgid "2G Only"
+#~ msgid "5G Only"
+#~ msgstr "Tikai 5G"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (vēlamais)"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (vēlamais), 5G"
+
+#~| msgid "2G, 3G (Preferred), 4G"
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (vēlamais), 4G, 5G"
+
+#~| msgid "2G (Preferred), 3G, 4G"
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (vēlamais), 3G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (vēlamais)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (vēlamais), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (vēlamais), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G (vēlamais), 5G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (vēlamais), 5G"
+
+#~| msgid "3G (Preferred), 4G"
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (vēlamais), 4G, 5G"
+
+#~| msgid "3G, 4G"
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (vēlamais)"
+
+#~| msgid "2G, 3G (Preferred), 4G"
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (vēlamais), 5G"
+
+#~| msgid "2G (Preferred), 3G, 4G"
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (vēlamais), 4G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (vēlamais)"
+
+#~| msgid "2G, 3G (Preferred), 4G"
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (vēlamais), 5G"
+
+#~| msgid "2G (Preferred), 3G, 4G"
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (vēlamais), 3G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (vēlamais)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (vēlamais), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (vēlamais)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (vēlamais), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (vēlamais)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (vēlamais), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~| msgid "2G, 4G (Preferred)"
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (vēlamais)"
+
+#~| msgid "2G (Preferred), 4G"
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (vēlamais), 5G"
+
+#~| msgid "2G, 4G"
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (vēlamais)"
+
+#~| msgid "3G (Preferred), 4G"
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (vēlamais), 5G"
+
+#~| msgid "3G, 4G"
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (vēlamais)"
+
+#~| msgid "3G (Preferred), 4G"
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (vēlamais), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Nezināms"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Atbloķēt SIM karti"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Lūdzu, norādiet PIN kodu SIM kartei %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Ievadiet PIN, lai atbloķētu SIM karti"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Lūdzu, norādiet PUK kodu SIM kartei %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Ievadiet PUK, lai atbloķētu SIM karti"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Ievadīta kļūdaina parole."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK kodam jābūt 8 ciparu numuram"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Ievadiet jauno PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN kodam jābūt 4 līdz 8 ciparu skaitlim"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Atbloķē…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Tālruņa kļūme"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Nav savienojuma ar tālruni"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Darbība nav atļauta"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Darbība nav atbalstīta"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Nav ievietota SIM karte"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Vajadzīgs SIM PIN"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Vajadzīgs SIM PUK"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM kļūme"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM ir aizņemts"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Nepareiza parole"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Vajadzīgs SIM PIN2"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Vajadzīgs SIM PUK2"
+
+#~ msgid "Not found"
+#~ msgstr "Nav atrasts"
+
+#~ msgid "No network service"
+#~ msgstr "Nav tīkla pakalpojuma"
+
+#~ msgid "Network timeout"
+#~ msgstr "Tīkla noildze"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS serviss nav atļauts"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Viesabonēšana nav atļauta šajā reģionā"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Nenorādīta GPRS kļūda"
+
+#~ msgid "No Error"
+#~ msgstr "Nav kļūdas"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Darbība ir atcelta"
+
+#~ msgid "Access denied"
+#~ msgstr "Piekļuve atteikta"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Nezināma kļūda"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Rādīt versijas numuru"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Aktivēt detalizēto režīmu"
+
+#~ msgid "Search for the string"
+#~ msgstr "Meklēt virkni"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Uzskaitīt iespējamo paneļu nosaukumus un iziet"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panelis, ko attēlot"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANELIS] [PARAMETRI…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Pieejamie paneļi:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sistēmas skaņas"
 
 #~ msgid "Display Arrangement"
 #~ msgstr "Displeju izkārtojums"
@@ -9674,9 +8353,6 @@ msgstr "Sistēmas skaņas"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER vai PEM sertifikāti (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Pievienot printeri…"
 
 #~ msgid "Drip"
 #~ msgstr "Piliens"
@@ -9757,11 +8433,11 @@ msgstr "Sistēmas skaņas"
 #~ msgstr "Nevar mainīt"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "Atsevišķās lietotnes atļaujas var pārskatīt <a href=\"privacy"
-#~ "\">privātuma</a> iestatījumos."
+#~ "Atsevišķās lietotnes atļaujas var pārskatīt <a "
+#~ "href=\"privacy\">privātuma</a> iestatījumos."
 
 #~ msgid "Integration"
 #~ msgstr "Integrācija"
@@ -10043,9 +8719,6 @@ msgstr "Sistēmas skaņas"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Planšete (absolūta)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Skārienpaliktnis (relatīvs)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Planšetes iestatījumi"

--- a/po/lv.po~
+++ b/po/lv.po~
@@ -1,0 +1,10206 @@
+# translation of gnome-control-center.HEAD.lv.po to Latvian
+# gnome-control-center for Latvian.
+# Copyright (C) 2001, 2006, 2007, 2009 Free Software Foundation, Inc.
+#
+# Artis Trops <hornet@navigators.lv>, 2001.
+# Raivis Dejus <orvils@gmail.com>, 2006, 2007, 2009.
+# Anita Reitere <nitalynx@gmail.com>, 2010, 2012.
+# Rudolfs <rudolfs.mazurs@gmail.com>, 2011.
+# Rūdofls Mazurs <rudolfs.mazurs@gmail.com>, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022.
+# Vika Leimane <vika.leimane@gmail.com>, 2020.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.HEAD.lv\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issu"
+"es\n"
+"POT-Creation-Date: 2022-08-28 14:52+0000\n"
+"PO-Revision-Date: 2022-09-03 15:24+0300\n"
+"Last-Translator: Rūdolfs Mazurs <rudolfs.mazurs@gmail.com>\n"
+"Language-Team: Latvian <lata-l10n@googlegroups.com>\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 :"
+" 2);\n"
+"X-Generator: Lokalize 21.12.3\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Sistēmas kopne"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Pilna piekļuve"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Sesijas kopne"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Ierīces"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Pilna pieeja /dev resursiem"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Tīkls"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Ir piekļuve tīklam"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Mājas"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Tikai lasāms"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Datņu sistēma"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Iestatījumi"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Var mainīt iestatījumus"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s ir šādas iebūvētās atļaujas. Tās nevar mainīt. Ja jūs šādas atļaujas "
+"neapmierina, apsveriet šīs lietotnes izņemšanu."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u datnes un saites veids, ko atver lietotne"
+msgstr[1] "%u datnes un saites veidi, ko atver lietotne"
+msgstr[2] "%u datnes un saites veidu, ko atver lietotne"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> tiek izmantots, lai atvērtu sekojošos datņu un saišu veidus."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+#| msgid "%s of disk space used"
+msgid "%s of disk space used."
+msgstr "Izmantoti %s no diska vietas."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Lietotnes"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Nav atrastu lietotņu"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Instalēt…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Atvērt"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Skatīt sīkāku informāciju"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Meklēt"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Saņemt sistēmas meklējumus un sūtīt rezultātus."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Izslēgts"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Paziņojumi"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Rādīt sistēmas paziņojumus."
+
+#: panels/applications/cc-applications-panel.ui:133
+#| msgid "Run in background"
+msgid "Run in Background"
+msgstr "Palaist fonā"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Atļaut aktivitāti, kad lietotne ir aizvērta."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Ekrānattēli"
+
+#: panels/applications/cc-applications-panel.ui:141
+#| msgid "Take pictures with the camera."
+msgid "Take pictures of the screen at any time."
+msgstr "Uzņemt ekrāna attēlus jebkurā laikā."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Mainīt tapetes"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Mainīt darbvirsmas tapetes."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Skaņas"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Atdarināt skaņas."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Nomākt īsinājumtaustiņus"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Bloķēt standarta īsinājumtaustiņus."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Uzņemt attēlus ar kameru."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofons"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Ierakstīt audio ar mikrofonu."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Atrašanās vietas pakalpojumi"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Piekļūt ierīces atrašanās vietas datiem."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Iebūvētās atļaujas"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Piekļuve sistēmai, kas ir nepieciešama lietotnei"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Datņu un saišu asociācijas"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Krātuve"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Nav atrastu rezultātu"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Mēģiniet citus atslēgvārdus"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Datņu un saišu asociācijas"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Datņu tipi"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Saišu tipi"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Atiestatīt"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Cik daudz vietas uz diska šī lietotne aizņem, ieskaitot lietotnes datus un "
+"kešatmiņu."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Lietotne"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Dati"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Kešatmiņa"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Kopā</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Attīrīt kešatmiņu…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Kontrolē dažādas lietotnes atļaujas un iestatījumus"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "lietotne;aplikācija;flatpak;atļaujas;iestatījumi;setingi;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Izvēlieties attēlu"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "At_celt"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Atvērt"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "vairāki izmēri"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Bez fona attēla"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Pašreizējais fons"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stils"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Noklusējuma"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Tumšs"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Fons"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Pievienot attēlu…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Izskats"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Mainiet savu fona attēlu vai saskarnes krāsas"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Fons;Tapete;Ekrāns;Darbvirsma;Stils;Tumšs;Gaišs;Izskats;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Ieslēgt"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Bluetooth nav atrasts"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Pievienojiet Bluetooth spraudni."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth ir izslēgts"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Ieslēdziet, lai varētu savienot ierīces un saņemt sūtītās datnes."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Lidmašīnas režīms ir ieslēgts"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth tiek izslēgts, kad ir ieslēgts lidmašīnas režīms."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Izslēgt lidmašīnas režīmu"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Lidmašīnas režīms ir ieslēgts aparatūrā"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Izslēdziet lidmašīnas režīmu, lai ieslēgtu Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Ieslēdziet un izslēdziet Bluetooth un savienojiet savas ierīces"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "koplietot;koplietošana;šārēt;šārēšana;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera ir izslēgta"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Neviena lietotne šobrīd nevar uzņemt attēlus vai video."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Kameras lietošana ļauj lietotnēm uzņemt fotogrāfijas un video. Kameras "
+"izslēgšana var traucēt dažām lietotnēm pilnvērtīgi strādāt.\n"
+"\n"
+"Zemāk uzskaitītajām lietotnēm atļaut izmantot kameru."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Neviena lietotne nav pieprasījusi piekļuvi kamerai"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Aizsargāt savus attēlus"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "kamera;fotogrāfijas;video;tīmekļa kamera;slēgt;privāts;privātums;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Novietojiet savu kalibrēšanas ierīci virs kvadrāta un spiediet “Sākt”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Pārvietojiet savu kalibrēšanas ierīci uz kalibrēšanas pozīciju un spiediet "
+"“Turpināt”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Pārvietojiet savu kalibrēšanas ierīci uz virsmas pozīciju un spiediet "
+"“Turpināt”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Aizveriet klēpjdatora vāku"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Gadījās iekšēja kļūda, no kuras nevarēja atgūties."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Radās iekšēja kļūda, kuru nevarēja izlabot."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Nevarēja izveidot profilu."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Mērķa baltais punkts nebija iegūstams."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Izpildīts!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrēšana neizdevās!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Jūs varat izņemt kalibrēšanas ierīci."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Neaiztieciet kalibrēšanas ierīci, kamēr tā darbojas"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Iespējams, šis profils vairs nav precīzs"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Sākt"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "Tu_rpināt"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Pabeigts"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Klēpjdatora ekrāns"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Iebūvēta tīmekļa kamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitors %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Skeneris %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Fotoaparāts %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Printeris %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Tīmekļa kamera %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Aktivēt %s krāsu pārvaldību"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Rādīt %s krāsu profilus"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Nav kalibrēts"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Noklusējuma: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Krāsu telpa: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Testa profils:"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Izvēlieties ICC profila datni"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importēt"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Atbalstītie ICC profili"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Visas datnes"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekrāns"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Saglabāt profilu"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Saglabāt"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Izveidot krāsu profilu izvēlētajai ierīcei"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Mērinstruments nav atrasts. Pārbaudiet, vai tas ir ieslēgts un pareizi "
+"pievienots."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Mērinstruments neatbalsta printera profilēšanu."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Ierīces veids pašlaik nav atbalstīts."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Ekrāna kalibrēšana"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibrēšanas kvalitāte"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrēšana izveidos profilu ekrāna krāsu pārvaldīšanai. Jo vairāk laika "
+"atvēlēsiet kalibrēšanai, jo labāka būs krāsu profila kvalitāte."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Kalibrēšanas laikā datoru nevarēsiet izmantot."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kvalitāte"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Aptuvenais laiks"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibrēšanas ierīce"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Izvēlieties sensora ierīci, ko vēlaties izmantot kalibrēšanai."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Displeja tips"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Izvēlēties pievienotā displeja tipu."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profila baltais punkts"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Izvēlieties displeja mērķa balto punktu. Vairumu displeju jākalibrē "
+"standarta gaismas avotam D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Displeja gaišums"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Lūdzu, iestatiet displeja gaišumu tādu, kādu lietojat parasti. Krāsu "
+"pārvaldība būs visprecīzākā šajā gaišuma līmenī."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Varat arī izmantot tādu gaišuma līmeni, kas tika izmantots ar citu šīs "
+"ierīces profilu."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profila nosaukums"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Jūs varat lietot krāsu profilu uz dažādiem datoriem, vai pat izveidot "
+"profilus dažādiem apgaismojuma veidiem."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profila nosaukums:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Kopsavilkums"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profils ir sekmīgi izveidots!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopēt profilu"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Vajadzīgs rakstāms datu nesējs"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Šīs instrukcijas, kā izmantot profilu uz <a href=\"linux\">GNU/Linux</a>, <a "
+"href=\"osx\">Apple OS X</a> un <a href=\"windows\">Microsoft Windows</a>, "
+"varētu būt noderīgas."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Pievienot profilu"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Ir atklātas problēmas. Profils varētu nedarboties kā paredzēts. <a href="
+"\"\">Rādīt sīkāku informāciju.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importēt datni…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Pievienot"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Katrai ierīcei vajadzīgs aktuāls krāsu profils, lai tās krāsas būtu "
+"pārvaldītas."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Uzziniet vairāk"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Uzziniet vairāk par krāsu pārvaldīšanu"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Ie_statīt visiem lietotājiem "
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Iestatīt šo profilu visiem šī datora lietotājiem"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "I_eslēgt"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Pievienot profilu"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrēt…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibrēt ierīci"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Izņemt profilu"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Skatīt sīkāku informāciju"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Nevar atklāt ierīces, kurām varētu pārvaldīt krāsas"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektors"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plazma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL aizmugures gaisma)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED aizmugures gaisma)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (balts LED aizmugures gaisma)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Plaša diapazona LCD (CCFL aizmugures gaisma)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Plaša diapazona LCD (RGB LED aizmugures gaisma)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Augsta"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minūtes"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Vidēja"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minūtes"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Zema"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minūtes"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Vietējs displejam"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (drukāšana un publicēšana)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografēšana un grafika)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standarta telpa"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testa profils"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automātiski"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Zema kvalitāte"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Vidēja kvalitāte"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Augsta kvalitāte"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Noklusējuma RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Noklusējuma CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Noklusējuma Pelēkais"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Ražotāja sniegtie rūpnīcas kalibrācijas dati"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Ar šo profilu nav iespējama pilnekrāna displeja koriģēšana"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Šis profils varētu vairs nebūt precīzs"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Krāsas"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Kalibrējiet krāsas savām ierīcēm, piemēram, displejiem, kamerām vai "
+"printeriem"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Krāsas;ICC;Profils;Kalibrēt;Printeris;Ekrāns;Displejs;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Citi…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Izvēlieties valodu"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "Izvēlētie_s"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nav atrastas valodas"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Vairāk…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Atbloķēt, lai mainītu iestatījumus"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Lai mainītu dažus no iestatījumiem, tie vispirms ir jāatbloķē."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Atbloķēt…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Stundu uz priekšu"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Minūti uz priekšu"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Laiks"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Stundu atpakaļ"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Minūti atpakaļ"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Šodien"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Vakar"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y."
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d stunda"
+msgstr[1] "%d stundas"
+msgstr[2] "%d stundas"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minūte"
+msgstr[1] "%d minūtes"
+msgstr[2] "%d minūtes"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekunde"
+msgstr[1] "%d sekunžu"
+msgstr[2] "%d sekundes"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekundes"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Tīklājs"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 stundu"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %H:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%H:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Datums un laiks"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Gads"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mēnesis"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Janvāris"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februāris"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Marts"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Aprīlis"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maijs"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Jūnijs"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Jūlijs"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Augusts"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Septembris"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktobris"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembris"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Decembris"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Diena"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Laika josla"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Meklēt pilsētu"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automātisks _datums un laiks"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Vajadzīga pieeja internetam"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Da_tums un laiks"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automātiska laika _josla"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Jābūt pieejamam interneta un atrašanās vietas pakalpojumiem"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Aktivēts"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Laika j_osla"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Laika _formāts"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Mainīt datumu un laiku, tai skaitā laika joslas"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Pulkstenis;Laika josla;Lokācija;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Mainīt sistēmas laika un datuma iestatījumus"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Lai mainītu laika un datuma iestatījumus, jāveic autentifikācija."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Tīmeklis"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Pasts"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalendārs"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "Mū_zika"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotogrāfijas"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Noklusējuma lietotnes"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Konfigurēt noklusējuma lietotnes"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "noklusējuma;lietotne;vēlamais;mediji;defaulta;aplikācija;mēdiji;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Tehnisku problēmu ziņojumu sūtīšana palīdz mums uzlabot %s. Ziņojumi tiek "
+"sūtīti anonīmi, un tiek iztīrīti no personīgajiem datiem. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Problēma ziņojot"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automātiska problēmu ziņošana"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostika"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Ziņot par problēmām"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostika;avārija;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Ieslēgts"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Izslēgts"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Pielietot izmaiņas?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Izmaiņas nevar pielietot"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Tas varētu būt aparatūras ierobežojumu dēļ."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Pielietot"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Atpakaļ"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Attēlošanas iestatījumi izslēgti"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Vairāki displeji"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Pievienoties"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Dublēt"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Satur augšējo joslu un Aktivitātes"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Primārais displejs"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Nakts gaisma"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Ainava"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portrets pa labi"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portrets pa kreisi"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Ainava (apmesta)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientācija"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Izšķirtspēja"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Atsvaidzināšanas ātrums"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Pielāgot televizoram"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Mērogs"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nakts gaisma nav pieejama"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Tam par iemeslu varētu būt izmantotie grafikas draiveri, vai tiek izmantots "
+"attālinātais darbvirsmas savienojums"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Pagaidām izslēgts līdz rītdienai"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Pārstartēt filtru"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Nakts gaismas padara ekrāna krāsas siltākas. Tas var samazināt acu nogurumu "
+"un bezmiegu."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Grafiks"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "No saulrieta līdz saullēktam"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Pašrocīgs grafiks"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Laiks"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "No"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Stunda"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minūte"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Līdz"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Krāsu temperatūra"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Displeji"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Izvēlieties, kā izmantot pievienotos monitorus un projektorus"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panelis;Projektors;xrandr;Ekrāns;Izšķirtspēja;Atsvaidzināt;Monitors;Nakts;"
+"Gaisma;Zils;redshift;krāsa;saullēkts;saulriets;Panel;Projector;xrandr;Screen;"
+"Resolution;Refresh;Monitor;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Secure boot ir ieslēgts"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce sāk"
+" strādāt. Tas ir ieslēgts un funkcionē normāli."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Secure boot ir problēmas"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce sāk"
+" strādāt. Tas ir ieslēgts, bet nevar strādāt, jo tam ir nederīga atslēga."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Secure boot problēmas nereti var atrisināt no sava datora UEFI"
+" aparātprogrammatūras iestatījumie  (BIOS) un jūsu aparatūras ražotājam"
+" vajadzētu sniegt informāciju par to, kā to izdarīt."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Lai saņemtu palīdzību, sazinieties ar šīs aparatūras ražotāju vai IT atbalsta"
+" sniedzēju."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+#| msgid "Camera is Turned Off"
+msgid "Secure Boot is Turned Off"
+msgstr "Secure boot ir izslēgts"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce sāk"
+" strādāt. Tas ir izslēgts."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Secure boot var izslēgt datora UEFI aparātprogrammatūras iestatījumos (BIOS)."
+" Lai saņemtu palīdzību, sazinieties ar šīs aparatūras ražotāju vai IT"
+" atbalsta sniedzēju."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Secure boot neļauj kaitnieciskai programmatūrai ielādēties, kad ierīce sāk"
+" strādāt. Lai uzzinātu vairāk, sazinieties ar aparatūras ražotāju vai IT"
+" atbalstu."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#| msgid "Password"
+msgid "Passed"
+msgstr "Izdevās"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#| msgid "PPP failed"
+msgid "Failed"
+msgstr "Neizdevās"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Ierīce atbilst HSI %d. pakāpei"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level 0"
+msgstr "Drošības pakāpe 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Šī ierīce netiek aizsargāta no aparatūras drošības problēmām. Tā var notikt,"
+" ja ir problēmas aparatūras vai aparātprogrammatūras konfigurācijā. Ieteicams"
+" sazināties ar savu IT atbalsta sniedzēju."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level 1"
+msgstr "Drošības pakāpe 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Šai ierīcei ir minimāla aizsardzība pret aparatūras drošības problēmām. Šī ir"
+" zemākā ierīču drošības pakāpe un tā sniedz aizsardzību tikai pret"
+" vienkāršākajiem drošības draudiem."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level 2"
+msgstr "Drošības pakāpe 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Šai ierīcei ir pamata aizsardzība pret aparatūras drošības problēmām. Tā"
+" sniedz aizsardzību pret izplatītākajiem drošības draudiem."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level 3"
+msgstr "Drošības pakāpe 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Šai ierīcei ir paplašināta aizsardzība pret aparatūras drošības problēmām. Šī"
+" ir augstākā ierīču drošības pakāpe un tā sniedz aizsardzību pret"
+" izvērstākiem drošības draudiem."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+#| msgctxt "Wi-Fi Hotspot"
+#| msgid "Security type"
+msgid "Security Level"
+msgstr "Drošības pakāpe"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Šai ierīcei nav pieejamas aizsardzības pakāpes."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Sazinieties ar savas aparatūras ražotājiem, lai iegūtu palīdzību ar drošības"
+" atjauninājumiem."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Šo problēmu varētu atrisināt ierīces UEFI aparātprogrammatūras iestatījumos"
+" vai ar atbalsta speciālistu."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Šo problēmu varētu atrisināt ierīces UEFI aparātprogrammatūras iestatījumos."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Šo problēmu varētu atrisināt atbalsta speciālists."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#| msgid "Ink Level"
+msgid "Level 1"
+msgstr "Pakāpe 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#| msgid "Ink Level"
+msgid "Level 2"
+msgstr "Pakāpe 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#| msgid "Ink Level"
+msgid "Level 3"
+msgstr "Pakāpe 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Aizsargāts pret ļaundabīgu programmatūru ierīces ielādes sākumā."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Secure boot ir problēmas"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Daļēja aizsardzība ierīces ielādes sākumā."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Secure boot ir izslēgts"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Nav aizsardzības ierīces ielādes sākumā."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Šī problēma varēja rasties dēļ UEFI aparātprogrammatūras iestatījumu"
+" izmaiņām, operētājsistēmas konfigurācijas izmaiņām vai dēļ ļaundabīgas"
+" programmatūras šajā datorā."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Šī problēma varēja rasties dēļ UEFI aparātprogrammatūras iestatījumu izmaiņām"
+" vai dēļ ļaundabīgas programmatūras šajā datorā."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Šī problēma varēja rasties dēļ operētājsistēmas konfigurācijas izmaiņām vai"
+" dēļ ļaundabīgas programmatūras šajā datorā."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Pakļauts nopietniem drošības draudiem."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Daļēja aizsardzība pret vienkāršākajiem drošības draudiem."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Aizsargāts pret izplatītākajiem drošības draudiem."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Aizsargāts pret daudziem drošības draudiem."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Vispusīga aizsardzība"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Nav notikumu"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection"
+msgstr "Aparātprogrammatūras rakstīšanas aizsardzība"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection Lock"
+msgstr "Aparātprogrammatūras rakstīšanas aizsardzības slēdzene"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Region"
+msgstr "Aparātprogrammatūras BIOS reģions"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Descriptor"
+msgstr "Aparātprogrammatūras BIOS deskriptors"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Pirms-ielādes DMA aizsardzība"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard pārbaudītā ielāde"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM aizsardzība"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard kļūdu politika"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard sintēze"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET ieslēgts"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET aktīvs"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Šifrēts RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU aizsardzība"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux Kernel noslēgšana"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux Kernel verifikācija"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux maiņvieta"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+#| msgid "Suspend"
+msgid "Suspend To RAM"
+msgstr "Iesnaudināt uz RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+#| msgid "Suspend"
+msgid "Suspend To Idle"
+msgstr "Iesnaudināt uz dīkstāvi"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI platformas atslēga"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI drošā ielāde"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+#| msgid "Display Configuration"
+msgid "TPM Platform Configuration"
+msgstr "TPM platformas konfigurācija"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM rekonstrukcija"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine ražošanas režīms"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine pārrakstīšana"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine versija"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+#| msgid "Software Updates"
+msgid "Firmware Updates"
+msgstr "Aparātprogrammatūras atjauninājumi"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+#| msgid "Firmware Version"
+msgid "Firmware Attestation"
+msgstr "Aparātprogrammatūras atestācija"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+#| msgid "Firmware Version"
+msgid "Firmware Updater Verification"
+msgstr "Aparātprogrammatūras atjauninātāja versija"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Platformas atkļūdošana"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Procesora drošības pārbaudes"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD atpakaļ ritināšanas aizsardzība"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+#| msgid "Firmware Version"
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD aparātprogrammatūras atkārtošanas aizsardzība"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+#| msgid "Firmware Version"
+msgid "AMD Firmware Write Protection"
+msgstr "AMD aparātprogrammatūras rakstīšanas aizsardzība"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Sintēzes platforma"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Derīgs"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+#| msgid "Not calibrated"
+msgid "Not Valid"
+msgstr "Nederīgs"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+#| msgid "Enabled"
+msgid "Not Enabled"
+msgstr "Nav ieslēgts"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+#| msgid "SIM Locked"
+msgid "Locked"
+msgstr "Bloķēts"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+#| msgid "SIM Locked"
+msgid "Not Locked"
+msgstr "Nav bloķēts"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Šifrēts"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+#| msgid "Not calibrated"
+msgid "Not Encrypted"
+msgstr "Nav šifrēts"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Bojāts"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+#| msgid "Not calibrated"
+msgid "Not Tainted"
+msgstr "Nav bojāts"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+#| msgid "Sound"
+msgid "Found"
+msgstr "Atrasts"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+#| msgid "Not found"
+msgid "Not Found"
+msgstr "Nav atrasts"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+#| msgctxt "print job"
+#| msgid "Aborted"
+msgid "Supported"
+msgstr "Atbalstīts"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+#| msgid "No Thunderbolt Support"
+msgid "Not Supported"
+msgstr "Nav atbalstīts"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#| msgid "Security"
+msgid "Device Security"
+msgstr "Ierīces drošība"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Datora aparātprogrammatūras drošības status"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ekrāns;bloķēt;slēgt;diagnostika;avārija;privāts;nesens;pagaidu;indeks;"
+"rādītājs;vārds;tīkls;identitāte;privātums;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Nezināms"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bitu"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bitu"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Nezināms"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Nav pieejams"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Sistēmas logo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Ierīces nosaukums"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Aparatūras modelis"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Atmiņa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesors"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Diska ietilpība"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Aprēķina…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "OS nosaukums"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#| msgid "%s; Build ID: %s"
+msgid "OS Build ID"
+msgstr "OS būvējuma ID"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "OS tips"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME versija"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Ielādē…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Logu sistēma"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualizācija"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Programmatūras atjauninājumi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Pārdēvēt ierīci"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Ierīces nosaukums tiek izmantots ierīces identificēšanai, kad ierīce tiek "
+"skatīta tīklā vai savienojoties ar Bluetooth ierīcēm."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Ierīces nosaukums"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "Pā_rdēvēt"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Par"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Aplūkot informāciju par šo sistēmu"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ierīce;sistēma;informācija;resursdatora nosaukums;atmiņa;procesors;versija;"
+"noklusējums;lietotne;cd;dvd;usb;audio;video;disks;izņemams;noņemamas;vide;"
+"nesējs;datu nesējs;automātiski palaist;device;system;information;memory;"
+"processor;version;default;application;preferred;disc;removable;media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Skaņa un multimediji"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Ieslēgt/izslēgt skaņu"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Samazināt skaļumu"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Palielināt skaļumu"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Ieslēgt/izslēgt mikrofonu"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Palaist mediju atskaņotāju"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Atskaņot (vai atskaņot/pauzēt)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pauzēt atskaņošanu"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Apturēt atskaņošanu"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Iepriekšējais ieraksts"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Nākamais ieraksts"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Izgrūst"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Rakstīšana"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Pārslēgties uz nākamo ievades avotu"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Pārslēgties uz iepriekšējo ievades avotu"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Palaidēji"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Palaist palīdzības pārlūku"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Palaist kalkulatoru"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Palaist e-pasta klientu"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Palaist tīmekļa pārlūku"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Mājas mape"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Meklēt"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistēma"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Izrakstīties"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Bloķēt ekrānu"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Pieejamība"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Ieslēgt vai izslēgt tuvinājumu"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Tuvināt"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Tālināt"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Ieslēgt vai izslēgt ekrāna lasītāju"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Ieslēgt vai izslēgt ekrāna tastatūru"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Palielināt teksta izmēru"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Samazināt teksta izmēru"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Ieslēgt vai izslēgt augstu kontrastu"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nav atrastu ievades avotu"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Citi"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Pievienot ievades avotu"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Pieteikšanās ekrānā nevar izmantot ievades metodes"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nav izvēlēts ievades avots"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opcijas"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Pārvietot augšup"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Pārvietot lejup"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Iestatījumi"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Skatīt tastatūras izkārtojumu"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Izņemt"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Pielāgotas saīsnes"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternatīvo rakstzīmju taustiņš"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Papildu rakstzīmju ievadīšanai var izmantot alternatīvo rakstzīmju taustiņu. "
+"Dažreiz tās tiek attēlotas kā trešā opcija uz tastatūras."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Kreisais Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Labais alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Kreisais super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Labais super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Izvēlnes taustiņš"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Labais Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Kompozīcijas taustiņš"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Komponēšanas taustiņš ļauj ievadīt plašu rakstzīmju klāstu Lai to izmantotu, "
+"spiediet komponēšanas taustiņu un tad ievadiet rakstzīmes. Piemēram, pēc "
+"kompozīcijas taustiņa spiežot <b>C</b> un <b>o</b> tiks ievadīts <b>©</b>, "
+"<b>a</b> pēc tam <b>'</b> izveidos <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Reģistra slēdzis"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Ritslēdzis"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Drukāt ekrānu"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Ievades avotus var pārslēgt, izmantojot %s tastatūras īsinājumtaustiņu.\n"
+"To var mainīt tastatūras īsinājumtaustiņu iestatījumos."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Ievades avoti"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Iekļauj tastatūras izkārtojumus un ievades metodes."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Ievades avotu pārslēgšana"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Vi_siem logiem izmantot vienu un to pašu avotu"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Pārslēgt ievades avotus katram logam _individuāli"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Īpašas rakstzīmes ieraksts"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Metodes simbolu un burtu variantu ievadīšanai, izmantojot tastatūru."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Tastatūras īsinājumtaustiņi"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Skatīt un pielāgot īsinājumtaustiņus"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d izmainīts"
+msgstr[1] "%d izmainīti"
+msgstr[2] "%d izmainītu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Atiestatīt visas saīsnes?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Saīšņu atiestatīšana var ietekmēt jūsu pielāgotās saīsnes. Šo darbību nevar "
+"atsaukt."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Atcelt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Atiestatīt visas"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Atiestatīt visas…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Pārstatīt visas saīsnes uz noklusējuma taustiņu sasaistēm"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sadaļa"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Īsinājumtaustiņi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Pievienot īsinājumtaustiņu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Pievienot pielāgotos īsinājumtaustiņus"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Iestatiet īsinājumtaustiņus lietotņu palaišanai, skriptu darbināšanai un vēl."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Pievienot īsinājumtaustiņu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nav atrastu tastatūras īsinājumtaustiņu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s jau izmanto %s. Ja to aizstāsiet, %s tiks izslēgts"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Ievadiet jauno saīsni"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Iestatīt pielāgotas saīsnes"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Iestatīt saīsni"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Ievadiet jaunu saīsni, lai mainītu %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Pievienot pielāgoto saīsni"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Izņemt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Aizstāt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "Ie_statīt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Spiediet “Esc”, lai atceltu, vai “Backspace”, lai izslēgtu tastatūras "
+"saīsnes."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nosaukums"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Komanda"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Saīsne"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Iestatīt saīsni…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Nav"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Atiestatīt saīsni uz tās noklusējuma vērtību"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatūra"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Mainiet tastatūras īsinājumtaustiņus un izvēlieties savus rakstīšanas "
+"iestatījumus, tastatūras izkārtojumus un ievades avotus"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Saīsne;Darbvieta;Logs;Mainīt izmēru;Tuvināt;Tālināt;Mērogs;Kontrasts;Ievade;"
+"Avots;Bloķēšana;Skaļums;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Atrašanās vietas pakalpojumi ir izslēgti"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Neviena lietotne šobrīd nevar piekļūt atrašanās vietas informācijai."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Atrašanās vietas pakalpojumi ļauj lietotnēm noteikt jūsu ģeogrāfisko "
+"atrašanās vietu. Precizitāti var palielināt, ieslēdzot WiFi un mobilo "
+"platjoslu.\n"
+"\n"
+"Izmanto Mozilla dislokācijas servisu: <a href='https://location.services."
+"mozilla.com/privacy'>privātuma politika</a>\n"
+"\n"
+"Zemāk uzskaitītajām lietotnēm atļaut noteikt jūsu atrašanās vietu."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Neviena lietotne nav pieprasījusi piekļuvi atrašanās vietai"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Aizsargājiet savu atrašanās vietu"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "vieta;lokācija;gps;privāts;privātums;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofons ir izslēgts"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Neviena lietotne nevar ierakstīt skaņu."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Mikrofonu lietošana ļauj lietotnēm ierakstīt un klausīties skaņu. Mikrofona "
+"izslēgšana var traucēt dažām lietotnēm pilnvērtīgi strādāt.\n"
+"\n"
+"Zemāk uzskaitītajām lietotnēm atļaut izmantot jūsu mikrofonu."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Neviena lietotne nav pieprasījusi piekļuvi mikrofonam"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Aizsargāt savas sarunas"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofons;ierakstīšana;lietotne;privātums;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Izmēģiniet _savus iestatījumus"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Vispārēji"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primārā poga"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Iestata fizisko pogu secību datorpelēm un skārienpaliktņiem."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Kreisā"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Labā"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Pele"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Peles ātrums"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Dabiskā ritināšana"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Ritināšana pārvieto saturu, nevis skatu."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Skārienpaliktnis"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Skārienpaliktņa ātrums"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Uzsitiens nozīmē klikšķi"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Uzsitiens nozīmē klikšķi"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Divu pirkstu ritināšana"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Malu ritināšana"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Mēģiniet veikt klikšķi, dubultklikšķi, ritināšanu"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Pieci klikšķi, laiks GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dubultklikšķis, primārā poga"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Viens klikšķis, primārā poga"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dubultklikšķis, vidējā poga"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Viens klikšķis, vidējā poga"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dubultklikšķis, sekundārā poga"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Viens klikšķis, sekundārā poga"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Pele un skārienpaliktnis"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Mainiet savas peles vai skārienpaliktņa jutīgumu un izvēlieties, vai "
+"izmantot labroču vai kreiļu režīmu"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Skārienpaliktnis;Rādītājs;Klikšķis;Uzsitiens;Dubults;Poga;Kursorbumba;"
+"Ritināt;Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Karstais stūris"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+"Pieskarieties augšējam kreisajam stūrim, lai atvērtu aktivitāšu pārskatu."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Aktivēt ekrāna malas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Velciet logus pie loga augšpuses vai kreisā/labā loga sāna, lai mainītu to "
+"izmērus."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Darbvietas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dinamiskās darbvietas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Automātiski izņemt tukšās darbvietas."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Fiksēts darbvietu skaits"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Norādiet pastāvīgo darbvietu skaitu."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Darbvietu skaits"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Daudzmonitoru"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Darbvietas tikai uz _galvenā displeja"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Darbvietas uz v_isiem displejiem"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Pārslēgšanās starp lietotnēm"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Iekļaut lietotnes no visām _darbvietām"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Iekļaut lietotnes tikai no _pašreizējās darbvietas"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Vairākuzdevumi"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Pārvaldiet iestatījumus produktivitātei un vairākuzdevumu darbam"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Vairākuzdevumi;Produktivitāte;Pielāgot;Darbvirsma;Karstais Stūris;Darbvietas;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ak vai! Kaut kas nogāja greizi. Lūdzu, sazinieties ar programmatūras "
+"piegādātāju."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager ir jābūt palaistam."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Citas ierīces"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Pievienot savienojumu"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nav iestatīts"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Nedrošs tīkls (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Drošs tīkls (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Drošs tīkls (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Drošs tīkls (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Drošs tīkls"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Savienots"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opcijas…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Ieslēdzot tīklāju, tiks pārtraukts savienojums ar %s, un nevarēs piekļūt "
+"internetam caur Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Jābūt vismaz 8 rakstzīmēm"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Jābūt vismaz %d rakstzīmei"
+msgstr[1] "Jābūt vismaz %d rakstzīmēm"
+msgstr[2] "Jābūt vismaz %d rakstzīmēm"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Ieslēgt Wi-Fi tīklāju?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-Fi tīklājs ļauj citiem koplietot jūsu interneta savienojumu, izveidojot "
+"Wi-Fi tīklu, kuram citi var pievienoties. Lai to izdarītu, nepieciešams "
+"interneta savienojums caur avotu, kas nav Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Tīkla nosaukums"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Parole"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Ģenerēt nejaušu paroli"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Automātiski ģenerēt paroli"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Ieslēgt"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Apturēt tīklāju un atvienot visus lietotājus?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Apturēt tīklāju"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Lidmašīnas režīms"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Izslēdz Wi-Fi, Bluetooth un mobilo platjoslu"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nav atrastu Wi-Fi adapteru"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Pārliecinieties, ka Wi-Fi adapteris ir pievienots un ieslēgts"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Lidmašīnas režīms ir ieslēgts"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Izslēgt, lai lietotu Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi tīklājs ir aktīvs"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobilās lietotnes var noskanēt QR kodu, lai savienotos."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Ieslēgt tīklāju…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Redzamie tīkli"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager ir jābūt palaistam"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x _drošība"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Drošība"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Saglabāt"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Pastāvīgi"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Nejauši"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabils"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Šeit ievadītā MAC adrese tiks izmantota kā aparatūras adrese tīkla ierīcei, "
+"kurai šis savienojums ir aktivizēts. Šī iespēja ir pazīstama kā MAC "
+"klonēšana vai izlikšanās. Piemērs: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profils %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nav"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nekad"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "pirms %i dienas"
+msgstr[1] "pirms %i dienām"
+msgstr[2] "pirms %i dienām"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nav"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Vājš"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Lietojams"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Labs"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Teicams"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 adrese"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 adrese"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP adrese"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Aizmirst savienojumu"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Izņemt savienojuma profilu"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Izņemt VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Sistēmas informācija"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automātiski"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitāte"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Dzēst adresi"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Dzēst maršrutu"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Nav"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128 bitu atslēga (Hex vai ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128 bitu parole"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dinamiskais WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA un WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA un WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signāla stiprums"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Savienojuma ātrums"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Aparatūras adrese"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Atbalstītās frekvences"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Noklusējuma maršruts"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Iepriekš lietotās"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Savienoties _automātiski"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Padarīt pieejamu citiem liet_otājiem"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "_Mērītais savienojums: ir datu limiti vai var prasīt papildu samaksu"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Programmatūras atjauninājumi un citas liela izmēra lejupielādes netiks "
+"sāktas automātiski."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nosaukums"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC adrese"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonēta adrese"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "baiti"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 metode"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automātiski (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Tikai lokālais tīkls"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Pašrocīgi"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Izslēgt"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Koplietots ar citiem datoriem"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adreses"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adrese"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Tīkla maska"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Vārteja"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automātiski"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automātisks DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS servera adrese(-es)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Atdalīt IP adreses ar komatiem"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Maršruti"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automātiskie maršruti"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrika"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Izmant_ot šo savienojumu tikai šī tīkla resursiem"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 metode"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automātiski, tikai DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefikss"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Nevar atvērt savienojumu redaktoru"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Jauns profils"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Nederīgi iestatījumi %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Nederīgi iestatījumi %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importēt no datnes…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Pievienot VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "D_rošība"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Nevar importēt VPN savienojumu"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Datni “%s” nevar nolasīt vai tajā nav atpazīstama VPN savienojuma "
+"informācija\n"
+"\n"
+"Kļūda — %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Izvēlieties datni, ko importēt"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Datne ar nosaukumu “%s” jau eksistē."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Aizstāt"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Vai vēlaties aizstāt %s ar saglabājamo VPN savienojumu?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Nevar eksportēt VPN savienojumu"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Nevar eksportēt VPN savienojumu “%s” uz %s.\n"
+"\n"
+"Kļūda — %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Eksportē VPN savienojumu"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Kļūda — nevar ielādēt VPN savienojumu redaktoru)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Noteikt, kā savienoties ar internetu"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Tīkls;IP;LAN;Starpnieks;WAN;Platjosla;Modems;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Noteikt, kā savienoties ar Wi-Fi tīkliem"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Tīkls;Bezvadu;Wi-Fi;Wifi;IP;LAN;Platjosla;DNS;Tīklājs;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nekad"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "šodien"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "vakar"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Pēdējoreiz lietots"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Vadu"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Pievienot jaunu savienojumu"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Informācija par izvēlētajiem tīkliem, tai skaitā paroles un jebkāda "
+"pielāgota konfigurācija, tiks pazaudēta."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "Ai_zmirst"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Zināmie Wi-Fi tīkli"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "Ai_zmirst"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Sistēmas politika neļauj izmantot kā tīklāju"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Bezvadu ierīce ierīce neatbalsta tīklāja režīmu"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Kad nav norādīts konfigurācijas URL, tiek izmantota tīmekļa starpnieka "
+"automātiskā atklāšana."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Tas nav ieteicams neuzticamos publiskos tīklos."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Izslēgt ierīci"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktīvs"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Piegādātājs"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Tīkla starpniekserveris"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP starpnieks"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS starpnieks:"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP starpnieks"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks serveris"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorēt serverus"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP starpnieka ports"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS starpnieka ports"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP starpnieka ports"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks starpnieka ports"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Konfigurācijas URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Ieslēgt VPN savienojumu"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Tīkla nosaukums"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Drošības veids"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Parole"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Izslēgt Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Vairāk opciju…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Savienoties ar slēptu tīklu…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Ieslēgt Wi-Fi _tīklāju…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Zināmie Wi-Fi tīkli"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Nezināms statuss"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Nepārvaldīts"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Nav pieejams"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Savienojas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Nepieciešama autentifikācija"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Atvieno"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Savienojums neizdevās"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Nezināms statuss (trūkst)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Konfigurēšana neizdevās"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP konfigurēšana neizdevās"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP konfigurācija vairs nav derīga"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Noslēpumi tika pieprasīti, bet netika sniegti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x pieprasītājports atvienots"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x pieprasītājporta konfigurēšana neizdevās"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x pieprasītājports nestrādā"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x pieprasītājports neautentificējās atvēlētajā laikā"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP servisa palaišana neizdevās"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP serviss atvienots"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP nestrādā"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP klienta palaišana neizdevās"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP klienta kļūda"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP klients nestrādā"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Koplietojamā savienojuma serviss nepalaidās"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Koplietojamā savienojuma serviss nestrādā"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP servisa palaišana neizdevās"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP servisa kļūda"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP serviss nestrādā"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Līnija aizņemta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Nav centrāles gatavības signāla"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Neizdevās izveidot nesēju"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Iezvanīšanās pieprasījuma noildze"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Iezvanīšanās neizdevās"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Neizdevās inicializēt modemu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Neizdevās izvēlēties norādīto APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Nemeklē tīklus"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Reģistrācija tīklā liegta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Tīkla reģistrācijas noildze"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Neizdevās reģistrēties pieprasītajā tīklā"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN nav atzīts par derīgu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Iespējams, ierīcei pietrūkst aparātprogrammatūras"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Savienojums pazuda"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Tika pieņemts, ka savienojums eksistē"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modems nav atrasts"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth savienojums neizdevās"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Nav ievietota SIM karte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Vajadzīgs SIM PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Vajadzīgs SIM PUK"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Nepareiza SIM karte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Savienojuma priekšnoteikums nav izpildīts"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Trūkst aparātprogrammatūras"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Vads atvienots"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "nedefinēta kļūda 802.1X drošībā (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "nav izvēlēta neviena datne"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "nenorādīta kļūda validējot eap metodes datni"
+
+#: panels/network/wireless-security/eap-method.c:394
+#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 vai PGP privātās atslēgas"
+
+#: panels/network/wireless-security/eap-method.c:397
+#| msgid "_User certificate"
+msgid "DER or PEM certificates"
+msgstr "DER vai PEM sertifikāti"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "trūkst EAP-FAST PAC datnes"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC datne (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonīmi"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Ar autentifikāciju"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Abi"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anonī_ma identitāte"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _datne"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Izvēlieties PAC datni"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Iekšējā autentifikācija"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Ļauj automātisku PAC nodrošinājumu"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "trūkst EAP-LEAP lietotājvārds"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "trūkst EAP-LEAP paroles"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Lietotājvārds"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Parole"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Rādīt paroli"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "nederīgs EAP-PEAP CA sertifikāts: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "nederīgs EAP-PEAP CA sertifikāts: nav norādīts sertifikāts"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versija 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versija 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A sertifikāts"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Izvēlieties sertificēšanas institūcijas sertifikātu"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Nav nepieciešams CA sertifikāts"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP _versija"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "trūkst EAP lietotājvārda"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "trūkst EAP paroles"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "trūkst EAP-TLS identitātes"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "nederīgs EAP-TLS CA sertifikāts: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "nederīgs EAP-TLS CA sertifikāts: nav norādīts sertifikāts"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "nederīga EAP-TLS privātā atslēga: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "nederīgs EAP-TLS lietotāja sertifikāts: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Nešifrētas privātās atslēgas nav drošas"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Izskatās, ka izvēlētā privātā atslēga nav aizsargāta ar paroli. Tas var ļaut "
+"kompromitēt drošības akreditācijas datus. Lūdzu, izvēlieties ar paroli "
+"aizsargātu privāto atslēgu.\n"
+"\n"
+"(Savu privāto atslēgu varat aizsargāt ar paroli ar openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Izvelieties personīgo sertifikātu"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Izvēlieties privāto atslēgu"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitāte"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Lietotāja sertifikāts"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Privātā _atslēga"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Privātās atslēgas parole"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "nederīgs EAP-TTLS CA sertifikāts: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "nederīgs EAP-TTLS CA sertifikāts: nav norādīts sertifikāts"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (bez EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domēns"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Nezināma kļūda validējot 802.1X drošību"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunelēts TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Protected EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tentifikācija"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Izvēlieties datni"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "trūkst leap lietotājvārda"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "trūkst leap paroles"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Pietrūkst Wi-Fi paroles."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tips"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "trūkst wep atslēgas"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"nederīga wep atslēga: atslēga ar garumu %zu var saturēt tikai heksadecimālus "
+"skaitļus"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"nederīga wep atslēga: atslēga ar garumu %zu var saturēt tikai ascii "
+"rakstzīmes"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"nederīga wep atslēga: nepareizs atslēgas garums %zu. Atslēgas garumam ir "
+"jābūt vai nu 5/13 (ascii) vai 10/26 (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "nederīga wep atslēga: parole nevar būt tukša"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "nederīga wep atslēga: parolei ir jābūt īsākai nekā 64 rakstzīmes"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (noklusējuma)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Atvērtā sistēma"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Koplietošanas atslēga"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Atslēga"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Rādīt atslēgu"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP inde_kss"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"nederīgs wpa-psk: nederīgs atslēgas garums %zu. Jābūt [8,63] baiti vai 64 "
+"heksadecimālie cipari"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"nederīgs wpa-psk: nevar interpretēt atslēgu ar 64 baitiem kā heksadecimālu"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Paziņojumi"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Skaņas _paziņojumi"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Paziņojumu uznirstošie lodziņi"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Paziņojumi turpinās parādīties paziņojumu sarakstā, kad ir izslēgti "
+"uznirstošie lodziņi."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Rādīt ziņojuma _saturu uznirstošajos lodziņos"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Ekrāna vairoga paziņojumi"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Ekrāna vair_ogā rādīt ziņojuma saturu"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Netraucēt"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Ekrāna vairoga paziņojumi"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Nosakiet, kuri paziņojumi tiks parādīti, un kas tajos būs redzams"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Paziņojumi;Lentas;Baneri;Ziņojums;Paplāte;Uznirstošais logs;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Citi"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s ir izņemts"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Kļūda, noņemot kontu"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Atsaukt"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Aizvērt paziņojumu"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Savienoties ar saviem datiem mākonī"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Nav savienojuma ar internetu — savienojieties, lai izveidotu jaunus "
+"tiešsaistes kontus"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Pievienot kontu"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s konts"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Izņemt kontu"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Tiešsaistes konti"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Savienojieties ar saviem tiešsaistes kontiem un izvēlieties, kam tos izmantot"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Tīmeklis;Tiešsaiste;Tērzēšana;Kalendārs;"
+"Pasts;kontakti;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Nezināms laiks"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minūte"
+msgstr[1] "%i minūtes"
+msgstr[2] "%i minūšu"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i stunda"
+msgstr[1] "%i stundas"
+msgstr[2] "%i stundu"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "stunda"
+msgstr[1] "stundas"
+msgstr[2] "stundu"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minūte"
+msgstr[1] "minūtes"
+msgstr[2] "minūšu"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "Pilnībā uzlādēts pēc %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Brīdinājums — atlicis %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Atlikušais laiks — %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Pilnībā uzlādēts"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Nelādējas"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Tukša"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Uzlādējas"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Izlādējas"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Bezvadu pele"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Bezvadu tastatūra"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Nepārtrauktais barošanas avots"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Personālais ciparasistents"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobilais tālrunis"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Multimediju atskaņotājs"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Planšete"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Dators"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Spēļu ievades ierīce"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterija"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Galvenā"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Papildus"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Baterijas"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Kad _dīkstāvē"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Iesnaudināt"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Izslēgt"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Iemidzināt"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nedarīt neko"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Kad izmanto baterijas strāvu"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Kad pieslēgts strāvai"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nekad"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automātiski iesnaudināt"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "Jaudīgais režīms ir uz laiku izslēgts pārāk augstas temperatūras dēļ."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Detektēts klēpis — jaudīgais režīms uz laiku nav pieejams. Pārvietojiet "
+"ierīci uz stabilu virsmu, lai to atjaunotu."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Jaudīgais režīms uz brīdi ir izslēgts."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Maza baterijas jauda — ieslēgta enerģijas taupīšana. Iepriekšējais režīms "
+"tiks atjaunots, kad baterija būs pietiekami uzlādēta."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Enerģijas taupīšanas režīmu ieslēdza “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Jaudīgo režīmu ieslēdza “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minūtes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minūtes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minūtes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minūtes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minūtes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 stunda"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minūtes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minūtes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minūtes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 stundas"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Jaudas režīms"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Ietekmē sistēmas veiktspēju un enerģijas patēriņu."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Enerģijas taupīšanas opcijas"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automātisks ekrāna spilgtums"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Ekrāna spilgtums pielāgojas apkārtējai gaismai."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Padarīt ekrānu tumšāku"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Samazina ekrāna gaišumu, kad dators nav aktīvs."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Izslēgt _ekrānu"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Izslēgt ekrānu pēc kāda dīkstāves laika."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automātiska enerģijas taupīšana"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Ieslēdz jaudas taupīšanas režīmu, kad baterijas līmenis ir zems."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automātiski iesnaudināt"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pauzē datoru pēc kāda dīkstāves laika."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Ieslēgšanas pogas uz_vedība"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Rādīt baterijas _procentus"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automātiski iesnaudināt"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Kad _pieslēgts strāvai"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Kad izmanto _bateriju"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Aizture"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Veiktspēja"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Augsta veiktspēja un jaudas patēriņš."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Līdzsvarota"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standarta veiktspēja un jaudas patēriņš."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Taupīga"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Samazināta veiktspēja un jaudas patēriņš."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Barošana"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Skatīt baterijas statusu un mainīt enerģijas taupīšanas iestatījumus"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Barošana;Snaust;Snaušana;Gulēt;Gulēšana;Baterija;Strāva;Gaišums;Tumšāk;Tumšs;"
+"Monitors;DPMS;Dīkstāve;Enerģija;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Printeris “%s” tika izdzēsts"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Neizdevās pievienot jaunu printeri."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Nevar ielādēt saskarni: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Atbloķēt, lai pievienotu printerus un mainītu iestatījumus"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Printeri"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Pievienot printerus, skatīt printera darbus un izlemt, kā drukāt"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printeris;Rinda;Drukāt;Papīrs;Tinte;Toneris;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Pievienot printeri"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Atbloķēt"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Nav atrastu printeru"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Ievadiet tīkla adresi, vai meklējiet printeri"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Nepieciešama autentifikācija"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Ievadiet lietotājvārdu un paroli, lai redzētu printerus uz Printera servera."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Lietotājvārds"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s informācija"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Nav atrasts piemērots draiveris"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Izvēlieties PPD datni"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript Printer Description datnes (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+"Printera nosaukums nevar saturēt atstarpes rakstzīmes, tabulācijas, # un /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Atrašanās vieta"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Draiveris"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Meklē ieteicamos draiverus…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Meklēt draiverus"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Izvēlēties no datubāzes…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instalēt PPD datni…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Izvēlieties printera draiveri"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Ielādē draiveru datubāzi…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Izvēlēties"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect printeris"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD printeris"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Vienā pusē"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Garās malas iesējums"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Īsās malas iesējums"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portrets"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Ainava"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Apgriezta ainava"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Apgriezts portrets"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Turpināt"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pauzēt"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Gaida"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pauzēts"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Nepieciešama autentifikācija"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Apstrādā"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Apturēts"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Atcelts"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Atsaukts"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Izpildīts"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Pārvietot šo uzdevumu uz rindas augšu"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u darbs pieprasa autentifikāciju"
+msgstr[1] "%u darbi pieprasa autentifikāciju"
+msgstr[2] "%u darbu pieprasa autentifikāciju"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — aktīvie darbi"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Ievadiet akreditācijas datus lai drukātu no %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domēns"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utentificēt"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Attīrīt visu"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autentificēt"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Nav aktīvu printera darbu"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Atbloķēt printera serveri"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Atbloķēt %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Ievadiet lietotājvārdu un paroli, lai redzētu, kādi printeri ir uz %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Meklē printerus"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Seriālais ports"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Paralēlais ports"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Atrašanās vieta: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adrese: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Serveris pieprasa autentifikāciju"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Abās pusēs"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Papīra tips"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Papīra avots"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Izvades paplāte"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Izšķirtspēja"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript prefiltrēšana"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Lappuses loksnē"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Abās pusēs"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientācija"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Vispārēji"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Lapas iestatījumi"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Instalējamās opcijas"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Darbs"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Attēla kvalitāte"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Krāsas"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Pēcapstrāde"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Paplašināti"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Testa lapa"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Testa lapa"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Autoizvēle"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Printera noklusējuma"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Iekļaut tikai GhostScript fontus"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Konvertēt uz PS level 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Konvertēt uz PS level 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Bez prefiltrēšanas"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Ražotājs"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nav aktīvu darbu"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u darbs"
+msgstr[1] "%u darbi"
+msgstr[2] "%u darbu"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Tīrīt printera galviņas"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Maz tonera"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Beidzies toneris"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Palicis maz attīstītāja"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Nav attīstītāja"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Palicis maz krāsas"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Beigusies krāsa"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Atvērts vāks"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Atvērtas durvis"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Maz papīra"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Beidzies papīrs"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Nesaistē"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Apturēts"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Atkritumu tvertne gandrīz pilna"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Atkritumu tvertne pilna"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Optiskais gaismas vadītājs drīz būs jāmaina"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Optiskais gaismas vadītājs vairs nefunkcionē"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Gatavs"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Nepieņem darbus"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Apstrādā"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Drukāšanas opcijas"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Informācija par printeri"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Izmantot printeri pēc noklusējuma"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Tīrīt printera galviņas"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Izņemt printeri"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modelis"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Tintes līmenis"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Lūdzu, pārstartējiet, kad problēma ir atrisināta."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Pārstartēt"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Pievienot printeri…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Nav printeru"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Diemžēl izskatās, ka sistēmas \n"
+"drukāšanas serviss nav pieejams."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formāti"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Meklēšanas lokāles…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Biežākie formāti"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Visi formāti"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Meklēšanai nav rezultātu"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Var meklēt pēc valstīm vai valodām."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Priekšskatījums"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperiālās"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metriskās"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datumi"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Datums un laiks"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Skaitļi"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mērvienības"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papīrs"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Valoda un formāti, kas mainīsies pēc šīs ierakstīšanās"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Izrakstīties…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Valodas iestatījumus izmanto saskarnes tekstam un tīmekļu lapām. Formātu "
+"izmanto skaitļiem, datumiem un valūtām."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Jūsu konts"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "Va_loda"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formāti"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Ierakstīšanās ekrāns"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Vieta un valoda"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Izvēlieties redzamo valodu un formātus"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Valoda;Izkārtojums;Tastatūra;Ievade;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Jautāt, ko darīt"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Nedarīt neko"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Atvērt mapi"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Citi datu nesēji"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Izvēlieties lietotni audio diskiem"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Izvēlieties lietotni DVD diskiem"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Izvēlieties lietotni, ko palaist, kad pievienots mūzikas atskaņotājs"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Izvēlieties lietotni, ko palaist, kad pievienota fotokamera"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Izvēlieties lietotni programmatūras CD"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "audio DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "tukšs Blu-ray disks"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "tukšs CD disks"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "tukšs DVD disks"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "tukšs HD DVD disks"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video disks"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "e-grāmatu lasītājs"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD video disks"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Bilžu CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows programmatūra"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Izvēlieties, kā apstrādāt datu nesēju"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _audio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Mūzikas atskaņotājs"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Programmatūra"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Citi datu nesēji…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nekad nevaicāt un nepalaist programmas, ievietojot datu nesēju"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Izvēlieties, kā apstrādāt citus datu nesējus"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "D_arbība:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tips:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Noņemamie datu nesēji"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Konfigurēt noņemamo datu nesēju iestatījums"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"ierīce;sistēma;noklusējums;lietotne;cd;dvd;usb;audio;video;disks;izņemams;"
+"noņemamas;vide;nesējs;datu nesējs;automātiski palaist;device;system;default;"
+"application;preferred;disc;removable;media;autorun;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Ekrāns izslēdzas"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekundes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minūte"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minūtes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minūtes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minūtes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minūtes"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 stunda"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minūtes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minūtes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minūtes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minūtes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minūtes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minūtes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minūtes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minūtes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minūtes"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nekad"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Ekrāna bloķēšana"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Ekrāna automātiskā bloķēšana neļauj citiem piekļūt datoram, kamēr esat prom."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Ekrāna aptumšošanas aizture"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Neaktivitātes periods, pēc kura ekrāns kļūs tumšs."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automātiski b_loķēt ekrānu"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Automātiskās ekrāna b_loķēšanas aizture"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Periods pēc ekrāna aptumšošanas, kad ekrāns automātiski bloķējas."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Rādīt _paziņojumus uz ekrāna vairoga"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Aizliegt jaunas _USB ierīces"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Liegt jaunām USB ierīcēm mijiedarboties ar sistēmu, kamēr ekrāns ir bloķēts."
+
+#: panels/screen/cc-screen-panel.ui:108
+#| msgid "Privacy"
+msgid "Screen Privacy"
+msgstr "Ekrāna privātums"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Ierobežot skatīšanas leņķi"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#| msgid "Screen Sharing"
+msgid "Screen Settings"
+msgstr "Ekrāna iestatījumi"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "ekrāns;bloķēt;privāts;privātums;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Izvēlieties vietu"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Labi"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Meklēšanas vietas"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Mapes, kurās meklē sistēmas lietojumprogrammas, piemēram, Datnes, Attēli un "
+"Video."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Vietas"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Grāmatzīmes"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Citi"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Pievienot vietu"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nav atrastu lietotņu"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Lietotņu meklēšana"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Iekļaut meklēšanas rezultātus no lietotnēm."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Mapes, kurās meklē sistēmas lietojumprogrammas."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Meklēšanas rezultāti"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Rezultāti tiek attēloti atbilstoši saraksta secībai."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Noteikt, kuras lietotnes rāda meklēšanas rezultātus aktivitāšu pārskatā"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Meklēt;Atrast;Indekss;Rādītājs;Slēpt;Privātums;Rezultāti;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Koplietošanai nav izvēlētu tīklu"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Tīkli"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Ieslēgts"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Izslēgts"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Ieslēgts"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktīvs"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Izvēlieties mapi"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Pievienot"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Ieslēgt multimediju koplietošanu"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Datņu koplietošana ļauj jums dalīties ar savu publisko mapi ar citiem jūsu "
+"pašreizējā tīklā, izmantojot: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Kad ir ieslēgta attālinātā ierakstīšanās, datoru var lietot attālināti, "
+"izmantojot Secure Shell komandu:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Ieslēgt personīgo mediju koplietošanu"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Ierīces nosaukums ir nokopēts"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Ierīces adrese ir nokopēta"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Lietotājvārds ir nokopēts"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Parole ir nokopēta"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Koplietošana"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Datora nosaukums"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Datņu koplietošana"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Attālinātā _darbvirsma"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Multimediju koplietošana"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Attālinātā ie_rakstīšanās"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Datņu koplietošana"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Piep_rasīt paroli"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Attālinātā ierakstīšanās"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Attālinātā darbvirsma"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Attālinātā darbvirsma ļauj no cita datora skatīties un kontrolēt jūsu "
+"darbvirsmu."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Aktivēt vai deaktivēt attālinātos savienojumus ar šo datoru."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Attālinātā vadība"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Ļauj attālinātajiem savienojumiem kontrolēt ekrānu."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Kā savienoties"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Savienojieties ar šo datoru, izmantojot ierīces nosaukumu vai attālinātās "
+"darbvirsmas adresi."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopēt"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Attālinātās darbvirsmas adrese"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autentifikācija"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "Lai savienotos ar šo datoru, ir nepieciešams lietotājvārds un parole."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Lietotājvārds"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Pārbaudīt šifrēšanu"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Šifrēšanas pirkstu nospiedums"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Šifrēšanas pirkstu nospiedumu var redzēt savienotajos klientos un tiem ir "
+"jābūt identiskiem."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Multimediju koplietošana"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Dalīties tīklā ar mūziku, fotogrāfijām un video."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Mapes"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Nosakiet, kādu informāciju kopīgosiet ar citiem lietotājiem"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"koplietot;dalīties;ssh;dators;hosts;nosaukums;attālināti;darbvirsma;datu "
+"nesējs;audio;video;attēli;bildes fotogrāfijas;filmas;serveris;renderētājs;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Aktivēt vai deaktivēt attālināto ierakstīšanos"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Lai aktivētu vai deaktivētu attālināto ierakstīšanos, nepieciešama "
+"autentifikācija"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Pielāgots"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klikšķis"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#| msgid "Sharing"
+msgid "String"
+msgstr "Rinda"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Vēziens"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Dūkoņa"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Līdzsvars"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Izgaist"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Aizmugure"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Priekšpuse"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Pārbauda %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Spiediet uz skaļruņa, lai pārbaudītu"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Sistēmas skaļums"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Galvenais skaļums"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Skaļuma līmeņi"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Izvade"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Izvades ierīce"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testēt"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Konfigurācija"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Zemfrekvences reproduktors"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Ievade"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Ievades ierīce"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Skaļums"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Trauksmes skaņa"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Apklusināt"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Skaņa"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Mainīt skaļumu, ievades, izvades un paziņojumu skaņas"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Karte;Mikrofons;Skaļums;Klusināt;Balanss;Bluetooth;Austiņas;Audio;Izvade;"
+"Ievade;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Atvienots"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Savienojas"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Savienots"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Pilnvarošanas kļūda"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Pilnvaro"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Samazināta funkcionalitāte"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Savienots un pilnvarots"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Nezināms"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Pilnvarots:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Savienots:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Reģistrēts:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Neizdevās pilnvarot ierīci: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Neizdevās aizmirst ierīci: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Atkarīgs no %u citas ierīces"
+msgstr[1] "Atkarīgs no %u citām ierīcēm"
+msgstr[2] "Atkarīgs no %u citām ierīcēm"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Aizvērt paziņojumu"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nosaukums:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Statuss:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Pilnvarot un savienot"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Aizmirst ierīci"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Kļūda"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Pilnvarots"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Thunderbolt apakšsistēma (boltd) nav instalēta vai nav pareizi iestatīta."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Atļaut tieši piekļūt ierīcēm, piemēram dokiem un ārējiem GPU."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Var pievienoties tikai USB un Display Port ierīces."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Nevarēja atklāt Thunderbolt.\n"
+"Vai nu sistēmai nav Thunderbolt atbalsta, tas ir izslēgts BIOS konfigurācijā "
+"vai arī tam ir neatbalstīts drošības līmenis BIOS konfigurācijā."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt atbalsts ir izslēgts BIOS konfigurācijā."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Nevarēja noteikt Thunderbolt drošības līmeni."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Kļūda, pārslēdzot tiešo režīmu: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Nav Thunderbolt atbalsta"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Nevarēja savienoties ar thunderbolt apakšsistēmu."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Tieša piekļuve"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Gaidošās ierīces"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Nav pievienotu ierīču"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Pārvaldīt Thunderbolt ierīces"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;Privātums;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Kursora mirgošana"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Kursors mirgo teksta laukos."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Ātrums"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Kursora mirgošanas ātrums"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Kursora izmērs"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "Kursora izmēru var apvienot ar mērogu, lai tas būtu vieglāk pamanāms."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Klikšķa asistēšana"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulēt sekundāro klikšķi"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Izraisīt sekundāro klikšķi, turot nospiesto primāro taustiņu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Pieņemšanas aizture:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Īsa"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Sekundārā klikšķa aizture"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Gara"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Uzkavēšanās klikšķis"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Veikt klikšķi, kad rādītājs uzkavējas kādā vietā"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Aiztur_e:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Īsa"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Gara"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Kus_tības slieksnis:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Mazs"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Liels"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Atkārtot taustiņus"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Kad taustiņu tur nospiestu, atkārtot taustiņa signālu"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Taustiņu atkārtošanās aizture"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Taustiņu atkārtošanās ātrums"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Rakstīšanas asistents"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "L_ipīgie taustiņi"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Taustiņu secīga piespiešana darbojas kā taustiņu kombinācija"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Deaktivēt, ja divi taustiņi nospiesti reizē"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pīkstēt, kad nospiests _modifikatora taustiņš"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Lēnie taustiņi"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Taustiņi jāpiespiež mazliet ilgāk (dators ignorē netīšus pieskārienus)"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Īsa"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Lēno taustiņu rakstīšanas aizture"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Gara"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Pīkstēt, kad ir nospiests _taustiņš"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Pīkstēt, kad taustiņš tiek _pieņemts"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Pīkstēt, kad taustiņš tiek no_raidīts"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Atlecošie taustiņi"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorē ātrus taustiņu piespiešanas atkārtojumus"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Īsa"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Atlecošo taustiņu rakstīšanas aizture"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Gara"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Aktivēt ar tastatūru"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Ieslēgt un izslēgt pieejamības iespējas, lietojot tastatūru"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Noklusējuma"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Vidējs"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Liels"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Lielāks"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Vislielākais"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pikselis"
+msgstr[1] "%d pikseļi"
+msgstr[2] "%d pikseļu"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Vienmēr rādīt pieejamības izvēlni"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Redzēšana"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Augsts kontrasts"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Liels teksts"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Ieslēgt a_nimācijas"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Ek_rāna lasītājs"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Ekrāna lasītājs lasa attēloto tekstu, kad pārvieto kursoru."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Taustiņu _skaņas"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pīkstēt, kad ir ieslēgti vai izslēgti Num Lock vai Caps Lock taustiņi."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "K_ursora izmērs"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Tuvināt"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Dzirdēšana"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Vizuālie brīdinājumi"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "E_krāna tastatūra"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Atkārtot taustiņus"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Kursora _mirgošana"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Raks_tīšanas asistents (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Norādīšana un klikšķināšana"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Peles taustiņi"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Atrast rādītāju"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Klikšķa asistēšana"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Dubultklikšķa aizture"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Dubultklikšķa aizture"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Vizuālie brīdinājumi"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Testēt zibsni"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Pievienot skaņas brīdinājumiem vizuālas norādes."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Zib_snis pa visu ekrānu"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Zibsnis pa visu _logu"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Īss"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ekrāna"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ekrāna"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ekrāna"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Garš"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Pa visu ekrānu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Augšējā puse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Apakšējā puse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Kreisā puse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Labā puse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Tuvināšanas opcijas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Palielinājums:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Palielinātāja novietojums:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Sekot peles kursoram"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Ekrāna daļa:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Palielinātājs iziet ārpus _ekrāna"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Turēt palielinātāja _kursoru vidū"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "_Palielinātāja kursors bīda skata lauku"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Palielinātāja kursors pārvietojas līdz ar _saturu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Palielinātājs"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Krustiņš:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Pārklāj peles kurs_oru"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Biezums:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Plāns"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Biezs"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Garums:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Krāsa:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Krustiņš"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Krāsu efekti:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Balts uz melna:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Gaišums:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrasts:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "K_rāsa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Nav"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Pilns"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Zema"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Augsta"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Zems"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Augsts"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Krāsu efekti"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Padarīt vienkāršāku redzēšanu, dzirdēšanu, rakstīšanu un klikšķināšanu"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Tastatūra;Pele;a11y;Pieejamība;Universālā piekļuve;Kontrasts;Kursors;Skaņa;"
+"Mērogs;Ekrāna lasītājs;liels;augsts;teksts;fonts;izmērs;AccessX;Lipīgie;"
+"Taustiņi;Lēnie;Atlecošie;Pele;Dubults;klikšķis;Aizture;Ātrums;Atkārtot;"
+"Mirkšķināt;vizuāls;dzirdes;audio;raksta;animācijas;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 stunda"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 diena"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dienas"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dienas"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dienas"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dienas"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dienas"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dienas"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dienas"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dienas"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Iztukšot visu miskasti?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Viss miskastes saturs tiks neatgriezeniski dzēsts."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Iztīrīt atkritumus"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Dzēst visas pagaidu datnes?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Visas pagaidu datnes tiks pilnībā izdzēstas."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Izmest _pagaidu datnes"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 diena"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dienas"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dienas"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Visu laiku"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Datņu vēsture"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Datņu vēsture saglabā izmantoto datņu sarakstu. Šī informācija tiek "
+"koplietota starp lietojumprogrammām un ļauj vieglāk atrast datnes, kuras "
+"varētu izmantot."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Da_tņu vēsture"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Datņu lietojuma _vēstures ilgums"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Attīrīt vēsturi…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Miskaste un pagaidu datnes"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Miskastes un pagaidu datnes dažkārt var saturēt personas datus vai sensitīvu "
+"informāciju. To automātiska dzēšana var palīdzēt aizsargāt konfidencialitāti."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Au_tomātiski dzēst miskastes saturu"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automātiski dzēst pagaidu _datnes"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Automātiskās dzēšanas _periods"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Iztīrīt miskasti…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Dzēst _pagaidu datnes…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Datņu vēsture un miskaste"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Neatstāt pēdas"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"lietojums;nesenie;vēsture;faili;datnes;pagaidu;privātums;privāts;miskaste;"
+"atkritne;attīrīt;paturēt;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Jāatbilst ierakstīšanās pakalpojuma sniedzēja tīmekļa adresei."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Neizdevās pievienot kontu"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Paroles nesakrīt."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Neizdevās reģistrēt kontu"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Nav atbalstīta autentificēšanās veida šim domēnam"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Neizdevās pievienoties domēnam"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Šis lietotājvārds nenostrādāja.\n"
+"Lūdzu, mēģiniet vēlreiz."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Šī parole nenostrādāja.\n"
+"Lūdzu, mēģiniet vēlreiz."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Neizdevās ierakstīties domēnā"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Nevar atrast domēnu. Varbūt tas ir nepareizi uzrakstīts?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Pievienot lietotāju"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administratora"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administratori var pievienot un noņemt citus lietotājus un mainīt visu "
+"lietotāju iestatījumus. Vecāku kontroli nevar attiecināt uz administratoriem."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Lietotājs iestata paroli pirmo reizi ierakstoties"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Iestatīt paroli tagad"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Apstiprināt"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Uzņēmuma ierakstīšanās"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Lietotāju konti, kurus pārvalda uzņēmums vai organizācija."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Jūs esat nesaistē"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Uzņēmuma ierakstīšanās ļauj uz šīs ierīces izmantot esošus, centrāli "
+"pārvaldītus lietotāju kontus. Jūs varat arī izmantot šo kontu, lai piekļūtu "
+"uzņēmuma resursiem internetā."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Pārlūkot citus attēlus"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Izvēlieties datni…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Pirkstu nospiedumu pārvaldnieks"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Pirkstu nospiedumi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Nē"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Jā"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Vai vēlaties dzēst reģistrētos pirkstu nospiedumus, lai ierakstīšanās ar "
+"pirkstu nospiedumiem tiktu atslēgta?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Nav pirkstu nospiedumu ierīču"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Nav pirkstu nospiedumu ierīču"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Pārliecinieties, ka ierīce ir pareizi pievienota."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Pirkstu nospiedumu ierīce"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Izvēlieties pirkstu nospiedumu ierīci, kuru vēlaties konfigurēt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Pirkstu nospiedumu ierakstīšanās"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Pirkstu nospiedumu ierakstīšanās jums ļauj atslēgt un ierakstīties datorā, "
+"izmantojot savu pirkstu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Dzēst pirkstu nospiedumus"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Pirkstu nospiedumu reģistrēšana"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "lai veiktu šo darbību, ierīce ir jābūt pieprasītai"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "šo ierīci jau ir pieprasījis cits process"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "jums nav tiesību veikt šo darbību"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "nav reģistrētu izdruku"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Neizdevās sazināties ar ierīci reģistrācijas laikā"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Neizdevās sazināties ar pirkstu nospiedumu lasītāju"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Neizdevās sazināties ar pirkstu nospiedumu dēmonu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Neizdevās uzskaitīt pirkstu nospiedumus — %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Neizdevās izdzēst saglabātos pirkstu nospiedumus — %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Kreisais īkšķis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Kreisais vidējais pirksts"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Kreisais rādītājpirksts"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Kreisais zeltnesis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Kreisais mazais pirkstiņš"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Labais īkšķis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Labais vidējais pirksts"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Labais _rādītājpirksts"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Labais zeltnesis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Labais mazais pirkstiņš"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Nezināms pirksts"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Izpildīts"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Pirkstu nospiedumu ierīce ir atvienota"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Pirkstu nospiedumu ierīces krātuve ir pilna"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Neizdevās reģistrēt jaunu pirkstu nospiedumu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Neizdevās sākt reģistrēšanu — %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Neizdevās reģistrēt jaunu pirkstu nospiedumu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Neizdevās apturēt reģistrēšanu — %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Atkārtoti paceliet un novietojiet pirkstu uz lasītāja, lai reģistrētu savu "
+"pirkstu nospiedumu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Vēlreiz _reģistrēt šo pirkstu…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Skanēt jaunu pirkstu nospiedumu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Neizdevās aizmirst pirkstu nospiedumu ierīci %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problēmas, lasot ierīci"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Neizdevās satvert pirkstu nospiedumu ierīci %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Neizdevās saņemt pirkstu nospiedumu ierīci: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Šonedēļ"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Pagājušajā nedēļā"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y."
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sesija beidzās"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sesija sākās"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — konta aktivitāte"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Iepriekšējais"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Nākamais"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Lūdzu, izvēlieties citu paroli."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Lūdzu, ievadiet savu pašreizējo paroli atkal."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Neizdevās nomainīt paroli"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Mainīt paroli"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "M_ainīt"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Pašreizējā parole"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Jaunā parole"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Apstiprināt jauno paroli"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Ļaut lietotājam mainīt paroli nākamajā ierakstīšanās reizē"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Iestatīt paroli tagad"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Nevar automātiski pievienoties šī veida domēnam"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Nav atrasts tāds domēns vai nogabals"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Nevar ierakstīties kā %s domēnā %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Nederīga parole; lūdzu, mēģiniet vēlreiz"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Neizdevās savienoties ar domēnu %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Neizdevās izdzēst lietotāju"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Neizdevās atsaukt attālināti pārvaldītu lietotāju"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Nav iespējams izdzēst savu kontu."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s vēl aizvien ir ierakstījies"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Lietotāja dzēšana, kamēr tas vēl ir ierakstījies, var atstāt sistēmu "
+"nesaskanīgā stāvoklī."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Vai vēlaties paturēt lietotāja %s datnes?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Pēc lietotāja dzēšanas ir iespējams paturēt mājas mapi, pastu un pagaidu "
+"datnes."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Dzēst datnes"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Paturēt datnes"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Vai tiešām vēlaties atsaukt attālināti pārvaldītu %s kontu?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Dzēst"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Konts ir deaktivēts"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Tiks iestatīta, nākamreiz ierakstoties"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Nekāda"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Ierakstījies"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Neizdevās sazināties ar kontu servisu"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Lūdzu, pārbaudiet, vai AccountService ir instalēts un aktivēts."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Lai mainītu šo iestatījumu, jāatbloķē šis panelis"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Dzēst izvēlēto lietotāja kontu"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Lai dzēstu izvēlēto lietotāja kontu,\n"
+"vispirms klikšķiniet uz * ikonas"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Atbloķēt, lai pievienotu lietotājus un mainītu iestatījumus"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Lietotāji"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Sesija jāpārstartē, lai izmaiņas stātos spēkā"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Pārstartēt tagad"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Aizvērt"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Rediģēt avatāru"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Vārds un uzvārds"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Rediģēt"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Ierakstīšanās ar pirkstu nospiedumu"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomātiskā ierakstīšanās"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Konta aktivitāte"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrators"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administratori var pievienot un noņemt citus lietotājus un mainīt visu "
+"lietotāju iestatījumus."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Vecāku kontrole"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Atvērt vecāku kontroles lietotni."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Izņemt lietotāju…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Citi lietotāji"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Pievienot lietotāju…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Nav atrastu lietotāju"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Atbloķēt, lai pievienotu lietotāja kontu."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Pievienot vai izņemt lietotājus un mainīt savu paroli"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Lietotājs;Vārds;Pirkstu nospiedums;Avatars;Logo;Seja;Parole;Vecāku kontrole;"
+"Ekrāna laiks;Lietotņu ierobežojumi;Tīmekļa ierobežojumi;Lietošana;Lietošanas "
+"ierobežojumi;Bērns;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "R_eģistrēt"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Domēna administratora ierakstīšanās"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Lai izmantotu uzņēmuma ierakstīšanos, datoram jābūt\n"
+"reģistrētam domēnā. Tīkla administratoram šeit jāievada\n"
+"sava domēna parole."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Administratora _vārds"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Administratora parole"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Pārvaldīt lietotāju kontus"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Lai mainītu lietotāju datus, nepieciešama autentifikācija"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Jaunajai parolei ir jāatšķiras no vecās."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Mēģiniet mainīt dažus burtus un ciparus."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Mēģiniet paroli vēl nedaudz pamainīt."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Parole būtu drošāka, ja nesaturētu jūsu lietotājvārdu."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Mēģiniet neiekļaut savu vārdu parolē."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Mēģiniet neizmantot dažus vārdus, kas ir parolē."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Mēģiniet neizmantot bieži izmantotus vārdus."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Mēģiniet izvairīties no esošo vārdu pārkārtošanas."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Mēģiniet izmantot vairāk ciparu."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Mēģiniet izmantot vairāk lieto burtu."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Mēģiniet izmantot vairāk mazo burtu."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Mēģiniet izmantot vairāk īpašās rakstzīmes, piemēram, pieturzīmes."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Mēģiniet izmantot burtus, ciparus un pieturzīmes."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Mēģiniet neatkārtot vienu un to pašu rakstzīmi."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr "Drošāk ir lietot burtus, ciparus un pieturzīmes jauktā secībā."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Mēģiniet neizmantot secīgus simbolus, piemēram, 1234 vai abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Parolei jābūt garākai. Mēģiniet pievienot vairāk burtu, ciparu un "
+"pieturzīmju."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Lietojiet mazos un lielos burtus jauktā secībā, kā arī mēģiniet izmantot "
+"kādus ciparus."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Vairāk burtu, ciparu un pieturzīmju izmantošana padarīs paroli drošāku."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Autentifikācija neizdevās"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Jaunā parole ir pārāk īsa"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Jaunā parole ir pārāk vienkārša"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Jaunā un vecā parole ir pārāk līdzīgas"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Jaunā parole jau nesen tika izmantota."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Jaunajai parolei jāsatur arī cipari vai īpašās rakstzīmes"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Jaunā un vecā parole ir vienādas"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Jūsu parole ir mainīta kopš jūsu sākotnējās autorizācijas!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Jaunā parole nesatur pietiekami dažādas rakstzīmes"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Nezināma kļūda"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Lietotājvārds parasti drīkst saturēt tikai mazos burtus no a–z, ciparus un "
+"šīs rakstzīmes: . - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Diemžēl šis lietotājvārds nav pieejams. Lūdzu, mēģiniet citu."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Lietotājvārds ir pārāk garš."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Saistīt pogas"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Saistīt pogas ar funkcijām"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Lai rediģētu saīsni, izvēlieties “Sūtīt taustiņsitienu”, tad spiediet jaunos "
+"taustiņus vai lietojiet Backspace taustiņu dzēšanai."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Aizvērt"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Lūdzu, uzsitiet uz mērķa marķieriem, kad tie parādās uz ekrāna, lai "
+"kalibrētu planšeti."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Konstatēts nepareizs klikšķis, pārstartē…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Poga %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Definētā lietotne"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Sūtīt taustiņsitienu"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Pārslēgt monitoru"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Rādīt palīdzību uz ekrāna"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Planšete montēta uz klēpjdatora paneļa"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Planšete montēta uz ārējā displeja"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Ārējā planšetes ierīce"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#| msgid "External tablet device"
+msgid "External pad device"
+msgstr "Ārējā paliktņa ierīce"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Visi displeji"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Planšetes režīms"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Pildspalvai izmantot absolūto pozicionēšanu"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientācija kreiļiem"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Planšete un Express Keys™ ir pagriezti, izmantošanai ar kreiso roku"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Attēlot uz monitora"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Paturēt izmēra attiecību"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Izmantot tikai daļu no planšetes virsmas, lai saglabātu monitora malu "
+"attiecību"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibrēt"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nav atrasta planšete"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Lūdzu, pievienojiet un ieslēdziet savu Wacom planšeti."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Gala spiediena jušana"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Viegla"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Irbuļa uzgaļa spiediens"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Stingra"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Poga 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Poga 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Poga 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Dzēšgumijas spiediena sajūta"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Dzēšgumijas spiediens"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Vidējās peles pogas klikšķis"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Labās peles pogas klikšķis"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Uz priekšu"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Aerogrāfa irbulis ar spiedienu, slīpumu un integrētu slīdni"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Aerogrāfa irbulis ar spiedienu, slīpumu un pagriezienu"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standarta irbulis ar spiedienu un slīpumu"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standarta irbulis ar spiedienu"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom planšete"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Iestatiet pogu attēlojumus un pielāgojiet irbuļa jutīgumu grafikas planšetēm"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Planšete;Wacom;Irbulis;Dzēšgumija;Pele;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Jauna saīsne…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Piekļuves punkti"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Darbība atcelta"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Kļūda:</b> Piekļuve liegta iestatījumu mainīšanai"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Kļūda:</b> Mobilā aprīkojuma kļūda"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Nav reģistrēts"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Reģistrēts"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Viesabonēšana"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Meklē"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Piekļuve atteikta"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modema informācija"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modema status"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operators"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tīkla tips"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Tīkla status"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Paša numurs"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Informācija par ierīci"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Aparātprogrammatūras versija"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Tikai 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Tikai 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Tikai 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+#| msgid "2G Only"
+msgid "5G Only"
+msgstr "Tikai 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (vēlamais), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+#| msgid "2G, 3G (Preferred), 4G"
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (vēlamais), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+#| msgid "2G (Preferred), 3G, 4G"
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (vēlamais), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+#| msgid "2G, 3G, 4G"
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (vēlamais), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (vēlamais), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+#| msgid "3G, 4G (Preferred)"
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G (vēlamais), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1037
+#| msgid "3G, 4G (Preferred)"
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (vēlamais), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+#| msgid "3G (Preferred), 4G"
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (vēlamais), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+#| msgid "3G, 4G"
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+#| msgid "2G, 3G (Preferred), 4G"
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (vēlamais), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+#| msgid "2G (Preferred), 3G, 4G"
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (vēlamais), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+#| msgid "2G, 3G, 4G"
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+#| msgid "2G, 3G (Preferred), 4G"
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (vēlamais), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+#| msgid "2G (Preferred), 3G, 4G"
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (vēlamais), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+#| msgid "2G, 3G, 4G"
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (vēlamais), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (vēlamais), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (vēlamais), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+#| msgid "2G, 4G (Preferred)"
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+#| msgid "2G (Preferred), 4G"
+msgid "2G (Preferred), 5G"
+msgstr "2G (vēlamais), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+#| msgid "2G, 4G"
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+#| msgid "3G, 4G (Preferred)"
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+#| msgid "3G (Preferred), 4G"
+msgid "3G (Preferred), 5G"
+msgstr "3G (vēlamais), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+#| msgid "3G, 4G"
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+#| msgid "3G, 4G (Preferred)"
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (vēlamais)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+#| msgid "3G (Preferred), 4G"
+msgid "4G (Preferred), 5G"
+msgstr "4G (vēlamais), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Nezināms"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Atbloķēt SIM karti"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Atbloķēt"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Lūdzu, norādiet PIN kodu SIM kartei %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Ievadiet PIN, lai atbloķētu SIM karti"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Lūdzu, norādiet PUK kodu SIM kartei %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Ievadiet PUK, lai atbloķētu SIM karti"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Ievadīta nepareiza parole. Jums ir palicis %1$u mēģinājums"
+msgstr[1] "Ievadīta nepareiza parole. Jums ir palikuši %1$u mēģinājumi"
+msgstr[2] "Ievadīta nepareiza parole. Jums ir palikuši %1$u mēģinājumi"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Jums ir atlicis %u mēģinājums"
+msgstr[1] "Jums ir atlikuši %u mēģinājumi"
+msgstr[2] "Jums ir atlikuši %u mēģinājumi"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Ievadīta kļūdaina parole."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK kodam jābūt 8 ciparu numuram"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Ievadiet jauno PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN kodam jābūt 4 līdz 8 ciparu skaitlim"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Atbloķē…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Nav SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Ievadiet SIM karti, lai izmantotu šo modemu"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM bloķēta"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobilie dati"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Piekļūstiet datiem, izmantojot mobilo tīklu"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Datu viesabonēšana"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Izmantot mobilos datus viesabonēšanas režīmā"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Tīkla režīms"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "Tī_kls"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Paplašināti"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Piekļuves punktu nosaukumi"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM bloķēšana"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Bloķēt SIM ar PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "M_odema informācija"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Tālruņa kļūme"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Nav savienojuma ar tālruni"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Darbība nav atļauta"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Darbība nav atbalstīta"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Nav ievietota SIM karte"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Vajadzīgs SIM PIN"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Vajadzīgs SIM PUK"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM kļūme"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM ir aizņemts"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Nepareiza parole"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Vajadzīgs SIM PIN2"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Vajadzīgs SIM PUK2"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Nav atrasts"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Nav tīkla pakalpojuma"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Tīkla noildze"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS serviss nav atļauts"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Viesabonēšana nav atļauta šajā reģionā"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Nenorādīta GPRS kļūda"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Nav kļūdas"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Darbība ir atcelta"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Piekļuve atteikta"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Nezināma kļūda"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Tīkla režīms"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automātiski"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Izvēlieties tīklu"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Atsvaidzināt tīkla pakalpojumu sniedzējus"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Ieslēgt mobilo tīklu"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nav atrastu WWAN adapteru"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Pārliecinieties, ka jums ir bezvadu Wan vai mobilā ierīce"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Bezvadu Wan tiek izslēgts, kad ir ieslēgts lidmašīnas režīms"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Izslēgt lidmašīnas režīmu"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Datu savienojums"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM karte, ko izmanto internetam"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM bloķēšana"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Nākamais"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "B_loķēt SIM ar PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Mainīt PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Ievadiet pašreizējo PIN, lai mainītu SIM bloķēšanas iestatījumus"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobilais tīkls"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Konfigurēt telefoniju un mobilo datu savienojumus"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "mobilais;wwan;telefonija;sim;mobilais;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilītprogramma GNOME darbvirsmas konfigurēšanai"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "“Iestatījumi” ir galvenā sistēmas konfigurēšanas saskarne."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME projekts"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Rādīt versijas numuru"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Aktivēt detalizēto režīmu"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Meklēt virkni"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Uzskaitīt iespējamo paneļu nosaukumus un iziet"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panelis, ko attēlot"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANELIS] [PARAMETRI…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Iestatījumu kategorijas"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privātums"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Pieejamie paneļi:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Visi iestatījumi"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Galvenā izvēle"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Brīdinājums: izstrādes versija"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Šo “Iestatījumu” versiju vajadzētu izmantot tikai izstādes vajadzībām. Jums "
+"var gadīties nepareiza sistēmas uzvedība, datu pazaudēšana un citas "
+"negaidītas problēmas."
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Palīdzība"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Vispārēji"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Iziet"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Meklēt"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneļi"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Iet atpakaļ uz iepriekšējo paneli"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Atcelt meklēšanu"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Iestatījumi;Uzstādījumi;Konfigurācija;Preferences;Settings;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Identifikators pēdējam iestatījumu panelim, ko atvērt"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Identifikators pēdējam iestatījumu panelim, ko atvērt. Neatpazītās vērtības "
+"tiks ignorētas un tiks izvēlēts pirmais panelis izvēlētajā sarakstā."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Rādīt brīdinājumus, kad palaiž “Iestatījumu” izstrādes būvējumu"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Vai “Iestatījumiem” vajadzētu rādīt brīdinājumu, kad palaiž izstrādes "
+"būvējumu."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Loga sākotnējais stāvoklis"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Kortežs, kas satur lietotnes loga sākotnējo platumu, augstumu un "
+"maksimizācijas statusu."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u izvade"
+msgstr[1] "%u izvades"
+msgstr[2] "%u izvades"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ievade"
+msgstr[1] "%u ievades"
+msgstr[2] "%u ievades"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sistēmas skaņas"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Displeju izkārtojums"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Bloķēt ekrānu"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER vai PEM sertifikāti (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Pievienot printeri…"
+
+#~ msgid "Drip"
+#~ msgstr "Piliens"
+
+#~ msgid "Glass"
+#~ msgstr "Stikls"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonārs"
+
+#~| msgid "Right"
+#~ msgid "Light"
+#~ msgstr "Gaišs"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "ekrāns;bloķēt;slēgt;diagnostika;avārija;privāts;nesens;pagaidu;indeks;"
+#~ "rādītājs;vārds;tīkls;identitāte;"
+
+#~ msgid "Set"
+#~ msgstr "Iestatīt"
+
+#~ msgid "Bark"
+#~ msgstr "Rējiens"
+
+#~ msgid "Web Links"
+#~ msgstr "Tīmekļa saites"
+
+#~ msgid "Git Links"
+#~ msgstr "Git saites"
+
+#~ msgid "%s Links"
+#~ msgstr "%s saites"
+
+#~ msgid "Unset"
+#~ msgstr "Atstatīt"
+
+#~ msgid "Links"
+#~ msgstr "Saites"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hiperteksta datnes"
+
+#~ msgid "Text Files"
+#~ msgstr "Teksta datnes"
+
+#~ msgid "Image Files"
+#~ msgstr "Attēlu datnes"
+
+#~ msgid "Font Files"
+#~ msgstr "Fontu datnes"
+
+#~ msgid "Archive Files"
+#~ msgstr "Arhīva datnes"
+
+#~ msgid "Package Files"
+#~ msgstr "Pakotņu datnes"
+
+#~ msgid "Audio Files"
+#~ msgstr "Audio datnes"
+
+#~ msgid "Video Files"
+#~ msgstr "Video datnes"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Atļaujas un piekļuve"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Dati un pakalpojumi, kam šī lietotne prasa piekļuvi, un atļaujas, kas "
+#~ "tiem ir nepieciešamas."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Nevar mainīt"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Atsevišķās lietotnes atļaujas var pārskatīt <a href=\"privacy"
+#~ "\">privātuma</a> iestatījumos."
+
+#~ msgid "Integration"
+#~ msgstr "Integrācija"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Iestatīt darbvirsmas fonu"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Noklusējuma apstrādātājs"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Datņu un saišu veidi, ko šī lietotne atver."
+
+#~ msgid "Usage"
+#~ msgstr "Lietojums"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Cik daudz resursus šī lietotne patērē."
+
+#~ msgid "Open in Software"
+#~ msgstr "Atvērt lietotnē “Programmatūra”"
+
+#~ msgid "Activities"
+#~ msgstr "Aktivitātes"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Atļaut lietotnēm izmantot kameru"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Neizdevās augšupielādēt datni — %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profils ir augšupielādēts uz:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Pierakstiet šo URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Pārstartējiet šo datoru un ielādējiet savu parasto operētājsistēmu."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Ierakstiet šo URL savā pārlūkā, lai lejupielādētu un instalētu profilu."
+
+#~ msgid "Upload profile"
+#~ msgstr "Augšupielādēt profilu"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Nepieciešams interneta savienojums"
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopēt"
+
+#~ msgid "Select _All"
+#~ msgstr "Izvēlēties _visu"
+
+#~ msgid "Single Display"
+#~ msgstr "Viens displejs"
+
+#~ msgid "Join Displays"
+#~ msgstr "Savienot displejus"
+
+#~ msgid "Display Mode"
+#~ msgstr "Displeja režīms"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Velciet displejus, lai tie atbilstu monitoru fiziskajam novietojumam. "
+#~ "Izvēlieties displeju, lai mainītu tā iestatījumus."
+
+#~ msgid "Active Display"
+#~ msgstr "Aktīvais displejs"
+
+#~ msgid "More Warm"
+#~ msgstr "Siltāk"
+
+#~ msgid "Less Warm"
+#~ msgstr "Mazāk silti"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Saglabāt ekrānattēlu mapē $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Saglabāt loga ekrānattēlu mapē $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Saglabāt laukuma ekrānattēlu mapē $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopēt ekrānattēlu uz starpliktuvi"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopēt loga ekrānattēlu uz starpliktuvi"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopēt laukuma ekrānattēlu uz starpliktuvi"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Ierakstīt īsu ekrānierakstu"
+
+#~| msgid "Move Up"
+#~ msgid "Move up"
+#~ msgstr "Pārvietot augšup"
+
+#~| msgid "Move Down"
+#~ msgid "Move down"
+#~ msgstr "Pārvietot lejup"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Atrašanās vietas pakalpojumi ļauj lietotnēm noteikt jūsu ģeogrāfisko "
+#~ "atrašanās vietu. Precizitāti var palielināt, ieslēdzot WiFi un mobilo "
+#~ "platjoslu."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Izmanto Mozilla atrašanās vietas pakalpojumus: <a href='https://location."
+#~ "services.mozilla.com/privacy'>privātuma politika</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Atļaut lietotnēm piekļuvi jūsu atrašanās vietai."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Atļaut šīm lietotnēm izmantot jūsu mikrofonu."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Dubultklikšķa noildze"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Iesnaudināšanas un izslēgšanas poga"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Detektēts klēpis — jaudīgais režīms nav pieejams"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Augsta aparatūras temperatūra — jaudīgais režīms nav pieejams"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Jaudīgais režīms nav pieejams"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autentificēt"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Izvēlēties skaitļu, datumu un valūtu formātu. Izmaiņas stāsies spēkā "
+#~ "nākamajā sesijas palaišanas reizē."
+
+#~| msgid "%s Account"
+#~ msgid "My Account"
+#~ msgstr "Mans konts"
+
+#~| msgid "_Language"
+#~ msgid "Language"
+#~ msgstr "Valoda"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Valoda, kuru izmantot logu un tīmekļa lapu tekstos."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Pārstartējiet sesiju, lai izmaiņas stātos spēkā"
+
+#~ msgid "Restart…"
+#~ msgstr "Pārstartēt…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Ierakstīšanās iestatījumus izmanto visi lietotāji, kas ierakstās sistēmā"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Noteikt, kuras lietotnes rāda meklēšanas rezultātus aktivitāšu pārskatā. "
+#~ "Meklēšanas rezultātu secību var mainīt, sarakstā pārvietojot rindas."
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Ekrāna koplietošana ļauj attālinātiem lietotājiem redzēt vai kontrolēt "
+#~ "jūsu ekrānu, savienojoties ar: %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Ekrāna koplietošana"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Daži pakalpojumi ir deaktivēti, jo nav pieejas tīklam."
+
+#~ msgid "_Password:"
+#~ msgstr "_Parole:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Rādīt paroli"
+
+#~ msgid "Access Options"
+#~ msgstr "Piekļuves opcijas"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Jau_najiem savienojumiem jālūdz piekļuve"
+
+#~ msgid "_Require a password"
+#~ msgstr "Piep_rasīt paroli"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Taustiņu skaņas"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Ekrāna lasītājs"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Ekrāna la_sītājs"
+
+#~ msgid "Standard"
+#~ msgstr "Standarta"
+
+#~ msgid "Account _Type"
+#~ msgstr "Konta _tips"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Ļaut _lietotājam izvēlēties paroli nākamajā ierakstīšanās reizē"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Iestatīt paroli _tagad"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Jums jābūt tiešsaistē, lai pievienotu uzņēmuma kontus."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Uzņemt bildi…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Lai veiktu izmaiņas,\n"
+#~ "vispirms klikšķiniet uz * ikonas"
+
+#~ msgid "Create a user account"
+#~ msgstr "Izveidot lietotāja kontu"
+
+#~ msgid "User Icon"
+#~ msgstr "Lietotāja ikona"
+
+#~ msgid "Account Settings"
+#~ msgstr "Konta iestatījumi"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autentifikācija un ierakstīšanās"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "To izmantos, lai nosauktu mājas mapi, un to nevarēs mainīt."
+
+#~ msgid "Output:"
+#~ msgstr "Izvade:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Attēlot uz viena monitora"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d no %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Displeja attēlošana"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Planšete (absolūta)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Skārienpaliktnis (relatīvs)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Planšetes iestatījumi"
+
+#~ msgid "_Help"
+#~ msgstr "_Palīdzība"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth iestatījumi"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Sekošanas režīms"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Saistīt pogas…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Pielāgot peles iestatījumus"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Pielāgot ekrāna izšķirtspēju"
+
+#~ msgid "No stylus found"
+#~ msgstr "Nav atrastu irbuļu"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Lūdzu, novietojiet savu irbuli netālu no planšetes, lai to konfigurētu"
+
+#~ msgid "Top Button"
+#~ msgstr "Augšējā poga"
+
+#~ msgid "Lower Button"
+#~ msgstr "Apakšējā poga"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Pati apakšējā poga"
+
+#~| msgid "Unlock %s."
+#~ msgid "Unlocking..."
+#~ msgstr "Atbloķē..."
+
+#~ msgid "GNOME Settings"
+#~ msgstr "GNOME iestatījumi"
+
+#~| msgid "Left+Right Alt"
+#~ msgid "Left Alt"
+#~ msgstr "Kreisais Alt"
+
+#~| msgid "Left+Right Alt"
+#~ msgid "Right Alt"
+#~ msgstr "Labais Alt"
+
+#~| msgid "Left thumb"
+#~ msgid "Left Super"
+#~ msgstr "Kreisais super"
+
+#~| msgid "Right thumb"
+#~ msgid "Right Super"
+#~ msgstr "Labais super"
+
+#~| msgid "Right Half"
+#~ msgid "Right Ctrl"
+#~ msgstr "Labais Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Alternatīvo rakstzīmju taustiņš"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Tikai-modifikatori pārslēdz uz nākamo avotu"
+
+#~| msgid "_Mouse Keys"
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Izvēlnes taustiņš"
+
+#~| msgid "The new password does not contain enough different characters"
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Turiet piespiestu un rakstiet, lai ievadītu dažādas rakstzīmes"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Uzlādējas"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Brīdinājums"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Zema"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Laba"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Pilnībā uzlādēta"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Tukša"
+
+#~| msgid "_Screen brightness"
+#~ msgid "_Screen Brightness"
+#~ msgstr "Ekrāna gaišum_s"
+
+#~| msgid "_Keyboard brightness"
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Tastatūras gaišums"
+
+#~| msgid "_Dim screen when inactive"
+#~ msgid "_Dim Screen When Inactive"
+#~ msgstr "Pa_darīt ekrānu tumšāku, kad nav aktīvs"
+
+#~| msgid "_Blank screen"
+#~ msgid "_Blank Screen"
+#~ msgstr "_Izslēgt ekrānu"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Var izslēgt Wi-Fi, lai taupītu enerģiju."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Mobilo platjoslu (3G, 4G, LTE, utt.) var izslēgt, lai taupītu enerģiju."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth var izslēgt, lai taupītu enerģiju."
+
+#~ msgid "Add…"
+#~ msgstr "Pievienot…"
+
+#~ msgid "Previous source"
+#~ msgstr "Iepriekšējais avots"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Atstarpe"
+
+#~ msgid "Next source"
+#~ msgstr "Nākamais avots"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Atstarpe"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Kreisais+labais Alt"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Lietotājs;Vārds;Pirkstu nospiedums;Avatars;Logo;Seja;Parole;"

--- a/po/mai.po
+++ b/po/mai.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.HEAD\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&component=general\n"
-"POT-Creation-Date: 2009-03-14 17:01+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2009-03-15 16:11+0530\n"
 "Last-Translator: Sangeeta Kumari <sangeeta09@gmail.com>\n"
 "Language-Team: Maithili <maithili.sf.net>\n"
@@ -20,3448 +19,6349 @@ msgstr ""
 "\n"
 "X-Generator: KBabel 1.11.4\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "चित्र/लेबल किनार"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
+msgstr "अनुप्रयोग फोन्ट (_A):"
 
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "चेतावनी संवादमे लेबल आ चित्रक चारि तरफ किनारक चओड़ाइ"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "चहेता अनुप्रयोग"
 
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "संस्थापित करू"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "खोलू (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "विवरण (_D)"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "खोजू"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "अक्षम"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "स्थानः"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "मद्दति विकल्प देखाबू"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "पृष्ठभूमि"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "वालपेपर जोड़ू"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "ध्वनि"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "शार्टकट"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "कुंजीपटल शार्टकट"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "स्थानः"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
 msgstr "चेतावनीक प्रकार"
 
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "चेतावनीक प्रकार"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "चेतावनीक बटन"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "चेतावनी संवादमे प्रदर्शित बटन"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "बेसी विवरण देखाबू (_d)"
-
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Place your left thumb on %s"
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Swipe your left thumb on %s"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Place your left index finger on %s"
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Swipe your left index finger on %s"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "अनुप्रयोग फोन्ट (_A):"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Place your left middle finger on %s"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Swipe your left middle finger on %s"
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>इमेल</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Place your left ring finger on %s"
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Swipe your left ring finger on %s"
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Place your left little finger on %s"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "शैली:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "मूलभूत"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Swipe your left little finger on %s"
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "पृष्ठभूमि"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Place your right thumb on %s"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "प्रकटन"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Swipe your right thumb on %s"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Place your right index finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Swipe your right index finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Place your right middle finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Swipe your right middle finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Place your right ring finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Swipe your right ring finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Place your right little finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Swipe your right little finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:72
-#: ../capplets/about-me/fingerprint-strings.h:98
-msgid "Place your finger on the reader again"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:74
-#: ../capplets/about-me/fingerprint-strings.h:100
-msgid "Swipe your finger again"
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:77
-#: ../capplets/about-me/fingerprint-strings.h:103
-msgid "Swipe was too short, try again"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:79
-#: ../capplets/about-me/fingerprint-strings.h:105
-msgid "Your finger was not centered, try swiping your finger again"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:81
-#: ../capplets/about-me/fingerprint-strings.h:107
-msgid "Remove your finger, and try swiping your finger again"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:776
-msgid "Select Image"
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "पूर्ण!"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "देखाबू"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "पैघ उज्जर संकेतक"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "फाइलनाम"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "फाइलनाम"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "फ़ाइलसभ कॉपी कए रहल अछि"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "सबहि फ़ाइल"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "जोड़ू (_A)..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "मनपसंद सँ हटाबू"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "विवरण (_D)"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "मिनट"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "मध्यम (_M)"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "मिनट"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "मिनट"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "रँग"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
 msgstr "बिंब चुनू"
 
-#: ../capplets/about-me/gnome-about-me.c:778
-msgid "No Image"
-msgstr "कोनो बिंब नहि"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "चुनू (_S)"
 
-#: ../capplets/about-me/gnome-about-me.c:806
-#: ../capplets/appearance/appearance-desktop.c:660
-msgid "Images"
-msgstr "बिंब"
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:810
-#: ../capplets/appearance/theme-installer.c:695
-msgid "All Files"
-msgstr "सबहि फ़ाइलसभ"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:956
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "टाइमआउट (_T):"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "खोजू"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "देखाबू"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "अक्षम"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "सकेण्ड"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "कैलेंडर (_n):"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "कैलेंडर (_n):"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "मूलभूत अनुप्रयोग क' सँग खोलू"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "मूलभूत अनुप्रयोग क' सँग खोलू"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "देखाबू"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<b>माउस अभिमुखन</b>"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "रेज़ोल्यूशन (_R):"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "ताज़ा करब क' दर (_f):"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "अंश पूर्ण"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
 msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-"एकटा गलती भेल पता पुस्तिका सूचनाकेँ पाबै क' कोशिशमे\n"
-"Evolution डाटा सर्वर प्रोटोकॉल नियंत्रित नहि कए सकत"
-
-#: ../capplets/about-me/gnome-about-me.c:977
-msgid "Unable to open address book"
-msgstr "पता पुस्तिका खोलबमे विफल"
-
-#: ../capplets/about-me/gnome-about-me.c:991
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr "अनजान लॉगिन ID, प्रयोक्ता डाटाबेस खराब भ' सकैत अछि"
-
-#: ../capplets/about-me/gnome-about-me.c:1021
-#: ../capplets/about-me/gnome-about-me.c:1023
-#, c-format
-msgid "About %s"
-msgstr "क' संबंधमे %s"
-
-#: ../capplets/about-me/gnome-about-me.c:1041
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Enable _Fingerprint Login..."
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:1044
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Disable _Fingerprint Login..."
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "About Me"
-msgstr "हमरा संबंधमे"
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "फिल्टर"
 
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "URI सँ"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "मिनट"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+#, fuzzy
+msgid "Displays"
+msgstr "देखाबू"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "नाम:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "प्रकार:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "गनोम टर्मिनल"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "विंडोज़"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "फाइलनाम"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "नाम बदलू..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/क' संबंधमे (_A)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "ब्रेक टाइप कए रहल अछि"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+#, fuzzy
+msgid "Launch web browser"
+msgstr "एपीफेनी वेब ब्राउसर"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "खोजू"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "सिस्टम"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "अभिगम्यता"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "क्रिया"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/ वरीयतासभ (_P)"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "कुंजीपटल शार्टकट"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "माउस कुँजीसभ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "कुंजीपटल शार्टकट"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "क्रिया"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "शार्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "शार्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "मनपसंदमे जोड़ू"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "शार्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "कुंजीपटल शार्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "नाम:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "कमांड (_o):"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "शार्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "शार्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "किछु नहि"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "कुँजीपटल"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
 msgstr "निजी सूचना सेट करू"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
-"You are not allowed to access the device. Contact your system administrator."
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
-msgid "The device is already in use."
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:103
-msgid "An internal error occured"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:220
-msgid "Delete registered fingerprints?"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:223
-msgid "_Delete Fingerprints"
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:230
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "सामान्य"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "बामाँ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "दहिन्ना"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "स्थानः"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "माउस"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "माउस कुँजीसभ"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "त्वरक (_A):"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "त्वरक (_A):"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "अनुप्रयोग फोन्ट (_A):"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "क्रिया"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "संजाल सर्वर"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "कूटशब्द (_P):"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "मोजुदा कूटशब्द (_p):"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "त्वरक मोड"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "कर्सर ब्लिंक गति"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "पता"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "पता"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "पता"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "मूलभूत संकेतक"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "नाम (_N):"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "पता (_A):"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "पता (_A):"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "अक्षम"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "पता"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "पता"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "मिनट"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "संजाल प्रॉक्सी"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "क्रिया"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "पता"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "संजाल प्रॉक्सी"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "HTTP प्रॉक्सी (_H):"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "HTTP प्रॉक्सी (_H):"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "FTP प्रॉक्सी (_F):"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "सॉक्स होस्ट (_o):"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "<b>होस्ट सूची अनदेखा करू</b>"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "HTTP प्रॉक्सी (_H):"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "HTTP प्रॉक्सी (_H):"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "FTP प्रॉक्सी (_F):"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "स्वविन्यास यूआरएल (_U) : "
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "संजाल सर्वर"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "कूटशब्द (_P):"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "मद्दति विकल्प देखाबू"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "सत्यापित!"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "सबहि फ़ाइल"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>प्रमाणीकरण प्रयोग करू (_U)</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "प्रयोक्ता नाम (_s):"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "कूटशब्द (_P):"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "नवीन कूटशब्द (_N):"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "संस्करण:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "संस्करण:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "सत्यापित कएल (_A)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "नवीन कूटशब्द फिनु टाइप करू (_R):"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "सत्यापित कएल (_A)"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "प्रकार:"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "मूलभूत"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "फाइल सिस्टम"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "घूर्णन (_o):"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>प्रमाणीकरण प्रयोग करू (_U)</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "मिनट"
+msgstr[1] "मिनट"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "मिनट"
+msgstr[1] "मिनट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "मिनट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "मिनट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "मिनट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "मिनट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "मिनट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "मिनट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "मिनट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "मिनट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "त्वरक मोड"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "विलंब (_D):"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "प्वाइंटर"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "प्वाइंटर"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "सत्यापित!"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "प्रयोक्ता नाम (_s):"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "स्थानः"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "चुनू (_S)"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "सत्यापित कएल (_A)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "सत्यापित कएल (_A)"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "फोन्ट रेंडरिंग विवरण"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
+msgstr "मनपसंद सँ हटाबू"
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "मॉडल"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "सुनिश्चित करू जे ई एप्पलेट ठीकसँ संस्थापित अछि"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "प्वाइंटर"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "सामान्य"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "सामान्य कार्य"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "सबहि फ़ाइलसभ"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "पूर्वावलोकनः"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "विभाग (_D):"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "बंशी संगीत प्लेयर"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "क्रिया"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "प्रकार:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "स्थानः"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "आन"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "स्थानः"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "अनुप्रयोग फोन्ट (_A):"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "खोजू"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "संजाल सर्वर"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "डेस्कटाप"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "कूटशब्द (_P):"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "डेस्कटाप"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "यूआइ नियंत्रण"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "कॉपी करू (_C)"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "सत्यापित कएल (_A)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "प्रयोक्ता नामः"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "सिस्टम"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "प्रॉक्सी विन्यास"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "चेतावनीक बटन"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ध्वनि"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "नाम:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "थंडरबर्ड"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>कर्सर टिमटिमओनाइ</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "कर्सर ब्लिंक गति"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "गति (_S):"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "कर्सर ब्लिंक गति"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "कर्सर ब्लिंक गति"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "शार्टकट"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "शार्टकट"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "छोट"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "पैघ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>दोहराव कुँजी</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "जखन कुँजी दाबि कए राखल जाए तँ कुँजी दोहरओनाइ (_r)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "दुहराबै बला कुँजी गति"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "दुहराबै बला कुँजी गति"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "टाइपिंग मॉनीटर"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "माउस कुँजीसभ"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "शार्टकट"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "माउस कुँजीसभ"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "शार्टकट"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "पैघ"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "माउस कुँजीसभ"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "कुँजीपटल"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>दोहराव कुँजी</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>कर्सर टिमटिमओनाइ</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "माउस कुँजीसभ"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "पैघ संकेतक"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "पूरा नाम"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "बामाँ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "दहिन्ना"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "रँग"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "संपर्क"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "किछु नहि"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "पूरा (_F)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "रँग"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "फाइल सिस्टम"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "रद्दीमे पठाबू"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "नवीन कूटशब्द (_N):"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "बिंब चुनू"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "किछु नहि (_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:343
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:583
-msgid "Done!"
-msgstr "पूर्ण!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
-#, c-format
-msgid "Could not access '%s' device"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
 msgstr ""
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:444
-#, c-format
-msgid "Could not start finger capture on '%s' device"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:491
-msgid "Could not access any fingerprint readers"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:492
-msgid "Please contact your system administrator for help."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:518
-msgid "Enable Fingerprint Login"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:534
-msgid "Select finger"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
 msgstr ""
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:555
-#, c-format
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:568
-msgid "Swipe finger on reader"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:570
-msgid "Place finger on reader"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:1
-msgid "Left index finger"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "पूर्वावलोकनः"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:2
-msgid ""
-"Left thumb\n"
-"Left middle finger\n"
-"Left ring finger\n"
-"Left little finger\n"
-"Right thumb\n"
-"Right middle finger\n"
-"Right ring finger\n"
-"Right little finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:10
-msgid "Other finger: "
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:11
-msgid "Right index finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:12
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-msgid "<b>Email</b>"
-msgstr "<b>इमेल</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-msgid "<b>Home</b>"
-msgstr "<b>घर</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>इंस्टेंट मैसेज</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Job</b>"
-msgstr "<b>कार्य</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Telephone</b>"
-msgstr "<b>टेलिफोन</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Web</b>"
-msgstr "<b>वेब</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Work</b>"
-msgstr "<b>कार्य</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
-msgstr "<span size=\"larger\" weight=\"bold\"> अपन कूटशब्द बदलू</span>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "A_ddress:"
-msgstr "पता (_d):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_ssistant:"
-msgstr "सहायक (_s):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "Address"
-msgstr "पता"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "C_ity:"
-msgstr "शहर (_i):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "C_ompany:"
-msgstr "कंपनी (_o):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "Cale_ndar:"
-msgstr "कैलेंडर (_n):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "Change Passwo_rd..."
-msgstr "कूटशब्द बदलू (_r)..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Change pa_ssword"
-msgstr "कूटशब्द बदलू (_s)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change password"
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
 msgstr "कूटशब्द बदलू"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Ci_ty:"
-msgstr "शहर (_t):"
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "सेट बदलू"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Co_untry:"
-msgstr "देश (_u):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Contact"
-msgstr "संपर्क"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Cou_ntry:"
-msgstr "देश (_n):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Current _password:"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "मोजुदा कूटशब्द (_p):"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "Full Name"
-msgstr "पूरा नाम"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "Hom_e:"
-msgstr "घर (_e):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P.O. _box:"
-msgstr "P.O. _box:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "P._O. box:"
-msgstr "P._O. box:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "Personal Info"
-msgstr "निज सूचना"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#: ../capplets/about-me/gnome-about-me-password.c:938
-msgid ""
-"Please type your password again in the <b>Retype new password</b> field."
-msgstr "<b>नवीन कूटशब्द फिनु टाइफ करू</b> क्षेत्रमे अपन कूटशब्द टाइप फिनु करू."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Select your photo"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "State/Pro_vince:"
-msgstr "राज्य/क्षेत्र (_v):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid ""
-"To change your password, enter your current password in the field below and "
-"click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for "
-"verification and click <b>Change password</b>."
-msgstr ""
-"अपन कूटशब्द बदलब क' लेल, नीच्चाँ देल क्षेत्रमे अपन मोजुदा कूटशब्द दिअ' आओर <b>सत्यापित करू</"
-"b> क्लिक करू.\n"
-"अहाँक द्वारा सत्यापित कएल जाए क' बाद, अपन नवीन कूटशब्द दिअ'. एकरा प्रमाणित करब क' "
-"लेल फिनु टाइप करू आओर <b>कूटशब्द बदलू</b> क्लिक करू."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "User name:"
-msgstr "प्रयोक्ता नामः"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "Web _log:"
-msgstr "वेब लॉग (_l):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "Wor_k:"
-msgstr "कार्य (_k):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "Work _fax:"
-msgstr "कार्य फैक्स (_f):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "Zip/_Postal code:"
-msgstr "जिप/डाक कूट (_P):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Address:"
-msgstr "पता (_A):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Authenticate"
-msgstr "सत्यापित कएल (_A)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Department:"
-msgstr "विभाग (_D):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_Groupwise:"
-msgstr "समूह रूपमे (_G):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Home page:"
-msgstr "होम पेज (_H):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Home:"
-msgstr "घर (_H):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_Jabber:"
-msgstr "जैबर (_J):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Manager:"
-msgstr "प्रबंधक (_M):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Mobile:"
-msgstr "मोबाइल (_M):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_New password:"
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
 msgstr "नवीन कूटशब्द (_N):"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Profession:"
-msgstr "व्यवसाय (_P): "
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "कूटशब्द बदलू"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:55
-msgid "_Retype new password:"
-msgstr "नवीन कूटशब्द फिनु टाइप करू (_R):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:56
-msgid "_State/Province:"
-msgstr "राज्य (_S):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:57
-msgid "_Title:"
-msgstr "शीर्षक (_T):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:58
-msgid "_Work:"
-msgstr "कार्य (_W):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:59
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:60
-msgid "_Zip/Postal code:"
-msgstr "जिप/डाक कूट (_Z):"
-
-#: ../capplets/about-me/gnome-about-me-password.c:162
-msgid "Child exited unexpectedly"
-msgstr "शिशु अप्रत्याशित रूप सँ बाहर निकलि गेल "
-
-#: ../capplets/about-me/gnome-about-me-password.c:297
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr "backend_stdin IO चैनल बन्न नहि कए सकल: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:310
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr "backend_stdout IO चैनल बन्न नहि कए सकल: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:409
-msgid "Authenticated!"
-msgstr "सत्यापित!"
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:475
-#: ../capplets/about-me/gnome-about-me-password.c:551
-msgid ""
-"Your password has been changed since you initially authenticated! Please re-"
-"authenticate."
-msgstr ""
-"अहाँक कूटशब्द बदलल गेल अछि किएक अहाँ आरंभिक रूप सँ सत्यापित कएल गेल अछि! फिनु सत्यापित "
-"करू."
-
-#: ../capplets/about-me/gnome-about-me-password.c:477
-msgid "That password was incorrect."
-msgstr "कूटशब्द गलत छल."
-
-#: ../capplets/about-me/gnome-about-me-password.c:524
-msgid "Your password has been changed."
-msgstr "अहाँक कूटशब्द बदएल देल गेल अछि."
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:534
-#, c-format
-msgid "System error: %s."
-msgstr "सिस्टम त्रुटि: %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:537
-msgid "The password is too short."
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
 msgstr "कूटशब्द काफी छोट अछि"
 
-#: ../capplets/about-me/gnome-about-me-password.c:540
-msgid "The password is too simple."
-msgstr "कूटशब्द काफी आसान अछि"
-
-#: ../capplets/about-me/gnome-about-me-password.c:543
-msgid "The old and new passwords are too similar."
-msgstr "पुरान आ नवीन कूटशब्द काफी समान अछि"
-
-#: ../capplets/about-me/gnome-about-me-password.c:545
-msgid "The new password must contain numeric or special character(s)."
-msgstr "नवीन कूटशब्दकेँ जरूर सँख्या अथवा विशेष संप्रतीक सामिल रखनाइ चाही."
-
-#: ../capplets/about-me/gnome-about-me-password.c:548
-msgid "The old and new passwords are the same."
-msgstr "पुरान आ नवीन कूटशब्द समान अछि"
-
-#. translators: Unable to launch <program>: <error message>
-#: ../capplets/about-me/gnome-about-me-password.c:820
-#, c-format
-msgid "Unable to launch %s: %s"
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-password.c:824
-msgid "Unable to launch backend"
-msgstr "बैकेंड शुरू करबमे विफल"
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "नवीन कूटशब्द (_N):"
 
-#: ../capplets/about-me/gnome-about-me-password.c:825
-msgid "A system error has occurred"
-msgstr "सिस्टम त्रुटि पैदा भेल"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:845
-msgid "Checking password..."
-msgstr "कूटशब्द जाँचि रहल अछि..."
-
-#: ../capplets/about-me/gnome-about-me-password.c:932
-msgid "Click <b>Change password</b> to change your password."
-msgstr "कूटशब्द बदलब क'लेल <b>कूटशब्द बदलू</b> पर क्लिक करू."
-
-#: ../capplets/about-me/gnome-about-me-password.c:935
-msgid "Please type your password in the <b>New password</b> field."
-msgstr "<b>नवीन कूटशब्द</b> क्षेत्रमे अपन कूटशब्द टाइप करू."
-
-#: ../capplets/about-me/gnome-about-me-password.c:941
-msgid "The two passwords are not equal."
-msgstr "दुइ कूटशब्द समान नहि अछि."
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Assistive Technologies</b>"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Preferences</b>"
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid "Accessible Lo_gin"
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technologies Preferences"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid ""
-"Changes to enable assistive technologies will not take effect until your "
-"next log in."
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Close and _Log Out"
-msgstr "बन्न कए लॉगआउट करू (_L)"
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "पूरा नाम"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "Jump to Preferred Applications dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "Jump to the Accessible Login dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "Jump to the Keyboard Accessibility dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "Jump to the Mouse Accessibility dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
-msgid "_Enable assistive technologies"
-msgstr "सहायक तकनीक सक्षम करू (_E)"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
-msgid "_Keyboard Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
-msgid "_Mouse Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
-msgid "_Preferred Applications"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Choose which accessibility features to enable when you log in"
-msgstr ""
-
-#: ../capplets/appearance/appearance-desktop.c:628
-msgid "Add Wallpaper"
-msgstr "वालपेपर जोड़ू"
-
-#: ../capplets/appearance/appearance-desktop.c:664
-msgid "All files"
-msgstr "सबहि फ़ाइल"
-
-#: ../capplets/appearance/appearance-font.c:494
-msgid "Font may be too large"
-msgstr "फोन्ट साइत बहुत पैघ अछि"
-
-#: ../capplets/appearance/appearance-font.c:498
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:511
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:534
-msgid "Use previous font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-font.c:536
-msgid "Use selected font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:124
-msgid "Specify the filename of a theme to install"
-msgstr "संस्थापित करब लेल कोनो प्रसंग क' फ़ाइलनाम निर्दिष्ट करू"
-
-#: ../capplets/appearance/appearance-main.c:125
-msgid "filename"
-msgstr "फाइलनाम"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/appearance/appearance-main.c:132
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:133
-#: ../capplets/default-applications/gnome-da-capplet.c:897
-#: ../capplets/mouse/gnome-mouse-properties.c:442
-msgid "page"
-msgstr "पृष्ठ"
-
-#: ../capplets/appearance/appearance-main.c:140
-msgid "[WALLPAPER...]"
-msgstr ""
-
-#: ../capplets/appearance/appearance-style.c:173
-#: ../capplets/common/gnome-theme-info.c:445
-#: ../capplets/common/gnome-theme-info.c:637
-msgid "Default Pointer"
-msgstr "मूलभूत संकेतक"
-
-#: ../capplets/appearance/appearance-style.c:235
-#: ../capplets/appearance/appearance-themes.c:687
-msgid "Install"
-msgstr "संस्थापित करू"
-
-#: ../capplets/appearance/appearance-style.c:255
-#: ../capplets/common/gnome-theme-info.c:1647
-#, c-format
-msgid ""
-"This theme will not look as intended because the required GTK+ theme engine "
-"'%s' is not installed."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:675
-msgid "Apply Background"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:679
-msgid "Apply Font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:683
-msgid "Revert Font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:713
-msgid ""
-"The current theme suggests a background and a font. Also, the last applied "
-"font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:715
-msgid ""
-"The current theme suggests a background. Also, the last applied font "
-"suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:717
-msgid "The current theme suggests a background and a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:719
-msgid ""
-"The current theme suggests a font. Also, the last applied font suggestion "
-"can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:721
-msgid "The current theme suggests a background."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:723
-msgid "The last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:725
-msgid "The current theme suggests a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:1046
-#: ../capplets/default-applications/gnome-da-capplet.c:648
-msgid "Custom"
-msgstr "पसंदीदा"
-
-#: ../capplets/appearance/data/appearance.glade.h:1
-msgid "<b>C_olors</b>"
-msgstr ""
-
-#. font hinting
-#: ../capplets/appearance/data/appearance.glade.h:3
-msgid "<b>Hinting</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:4
-msgid "<b>Menus and Toolbars</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:5
-msgid "<b>Preview</b>"
-msgstr "<b>पूर्वावलोकन</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:6
-msgid "<b>Rendering</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:7
-msgid "<b>Smoothing</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:8
-msgid "<b>Subpixel Order</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:9
-msgid "<b>_Desktop Background</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:10
-msgid "Appearance Preferences"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:11
-msgid "Background"
-msgstr "पृष्ठभूमि"
-
-#: ../capplets/appearance/data/appearance.glade.h:12
-msgid "Best _shapes"
-msgstr "बढ़ियाँ आकार (_s)"
-
-#: ../capplets/appearance/data/appearance.glade.h:13
-msgid "Best co_ntrast"
-msgstr "सबसँ बढ़ियाँ विरोध (_n)"
-
-#: ../capplets/appearance/data/appearance.glade.h:14
-msgid "C_ustomize..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:15
-msgid "C_ut"
-msgstr "काटू (_u)"
-
-#: ../capplets/appearance/data/appearance.glade.h:16
-msgid "Changing your cursor theme takes effect the next time you log in."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:17
-msgid "Colors"
-msgstr "रँग"
-
-#: ../capplets/appearance/data/appearance.glade.h:18
-msgid "Controls"
-msgstr "नियंत्रण"
-
-#: ../capplets/appearance/data/appearance.glade.h:19
-msgid "Customize Theme"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:20
-msgid "D_etails..."
-msgstr "विवरण... (_t)"
-
-#: ../capplets/appearance/data/appearance.glade.h:21
-msgid "Des_ktop font:"
-msgstr "डेस्कटोप फोन्ट (_k):"
-
-#: ../capplets/appearance/data/appearance.glade.h:22
+#: panels/user-accounts/cc-user-panel.ui:171
 msgid "Edit"
 msgstr "संपादन"
 
-#: ../capplets/appearance/data/appearance.glade.h:23
-msgid "Font Rendering Details"
-msgstr "फोन्ट रेंडरिंग विवरण"
-
-#: ../capplets/appearance/data/appearance.glade.h:24
-msgid "Fonts"
-msgstr "फ़ॉन्ट"
-
-#: ../capplets/appearance/data/appearance.glade.h:25
-msgid "Gra_yscale"
-msgstr "ग्रेस्केल (_r)"
-
-#: ../capplets/appearance/data/appearance.glade.h:26
-msgid "Icons"
-msgstr "प्रतीक"
-
-#: ../capplets/appearance/data/appearance.glade.h:27
-msgid "Interface"
-msgstr "अंतरफलक"
-
-#: ../capplets/appearance/data/appearance.glade.h:28
-msgid "Large"
-msgstr "पैघ"
-
-#: ../capplets/appearance/data/appearance.glade.h:29
-msgid "N_one"
-msgstr "किछु नहि (_o)"
-
-#: ../capplets/appearance/data/appearance.glade.h:30
-msgid "New File"
-msgstr "नवीन फ़ाइल"
-
-#: ../capplets/appearance/data/appearance.glade.h:31
-msgid "Open File"
-msgstr "फाइल खोलू"
-
-#: ../capplets/appearance/data/appearance.glade.h:32
-msgid "Open a dialog to specify the color"
-msgstr "रँग निर्दिष्ट करब लेल एकटा समाद खोलू"
-
-#: ../capplets/appearance/data/appearance.glade.h:33
-msgid "Pointer"
-msgstr "प्वाइंटर"
-
-#: ../capplets/appearance/data/appearance.glade.h:34
-msgid "R_esolution:"
-msgstr "रेज़ोल्यूशन (_R):"
-
-#: ../capplets/appearance/data/appearance.glade.h:35
-msgid "Save File"
-msgstr "फ़ाइल सहेजू"
-
-#: ../capplets/appearance/data/appearance.glade.h:36
-msgid "Save Theme As..."
-msgstr "प्रसंग एहन सहेजू..."
-
-#: ../capplets/appearance/data/appearance.glade.h:37
-msgid "Save _As..."
-msgstr "एहन सहेजू... (_A)"
-
-#: ../capplets/appearance/data/appearance.glade.h:38
-msgid "Save _background image"
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:39
-msgid "Show _icons in menus"
-msgstr "मेनूमे आइकन देखाबू (_i)"
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:40
-msgid "Small"
-msgstr "छोट"
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:41
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"Solid color\n"
-"Horizontal gradient\n"
-"Vertical gradient"
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:44
-msgid "Sub_pixel (LCDs)"
-msgstr "सब-पिक्सल (LCD) (_p)"
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "नियंत्रण"
 
-#: ../capplets/appearance/data/appearance.glade.h:45
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "सब-पिक्सल चिकनापन (LCD) (_p)"
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "मूलभूत अनुप्रयोग क' सँग खोलू"
 
-#: ../capplets/appearance/data/appearance.glade.h:46
-msgid "Text"
-msgstr "पाठ"
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:47
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "आन"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"Text below items\n"
-"Text beside items\n"
-"Icons only\n"
-"Text only"
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:51
-msgid "The current controls theme does not support color schemes."
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:52
-msgid "Theme"
-msgstr "प्रसंग"
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:53
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"Tiled\n"
-"Zoom\n"
-"Centered\n"
-"Scaled\n"
-"Fill screen"
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:58
-msgid "Toolbar _button labels:"
-msgstr "अओजारपट्टी बटन लेबल (_b):"
-
-#. vertical hinting, pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:60
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/appearance/data/appearance.glade.h:61
-msgid "Window Border"
-msgstr "विंडो किनार"
-
-#: ../capplets/appearance/data/appearance.glade.h:62
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
-msgid "_Add..."
-msgstr "जोड़ू (_A)..."
-
-#: ../capplets/appearance/data/appearance.glade.h:63
-msgid "_Application font:"
-msgstr "अनुप्रयोग फोन्ट (_A):"
-
-#. pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:65
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/appearance/data/appearance.glade.h:66
-msgid "_Copy"
-msgstr "कॉपी करू (_C)"
-
-#: ../capplets/appearance/data/appearance.glade.h:67
-msgid "_Description:"
-msgstr "वर्णन (_D):"
-
-#: ../capplets/appearance/data/appearance.glade.h:68
-msgid "_Document font:"
-msgstr "दस्ताबेज फोन्ट (_D):"
-
-#: ../capplets/appearance/data/appearance.glade.h:69
-msgid "_Editable menu shortcut keys"
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:70
-msgid "_File"
-msgstr "फाइल (_F)"
-
-#: ../capplets/appearance/data/appearance.glade.h:71
-msgid "_Fixed width font:"
-msgstr "सटीक चओड़ाइ फोन्ट (_F)"
-
-#: ../capplets/appearance/data/appearance.glade.h:72
-msgid "_Full"
-msgstr "पूरा (_F)"
-
-#: ../capplets/appearance/data/appearance.glade.h:73
-msgid "_Input boxes:"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:74
-msgid "_Install..."
-msgstr "संस्थापित करू (_I)"
-
-#: ../capplets/appearance/data/appearance.glade.h:75
-msgid "_Medium"
-msgstr "मध्यम (_M)"
-
-#: ../capplets/appearance/data/appearance.glade.h:76
-msgid "_Monochrome"
-msgstr "एकरँग (_M)"
-
-#: ../capplets/appearance/data/appearance.glade.h:77
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:5
-msgid "_Name:"
-msgstr "नाम (_N):"
-
-#: ../capplets/appearance/data/appearance.glade.h:78
-msgid "_New"
-msgstr "नवीन (_N)"
-
-#: ../capplets/appearance/data/appearance.glade.h:79
-msgid "_None"
-msgstr "किछु नहि (_N)"
-
-#: ../capplets/appearance/data/appearance.glade.h:80
-msgid "_Open"
-msgstr "खोलू (_O)"
-
-#: ../capplets/appearance/data/appearance.glade.h:81
-msgid "_Paste"
-msgstr "साटू (_P)"
-
-#: ../capplets/appearance/data/appearance.glade.h:82
-msgid "_Print"
-msgstr "छापू (_P)"
-
-#: ../capplets/appearance/data/appearance.glade.h:83
-msgid "_Quit"
-msgstr "बाहर (_Q)"
-
-#. pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:85
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:86
-msgid "_Reset to Defaults"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:87
-msgid "_Save"
-msgstr "सहेजू (_S)"
-
-#: ../capplets/appearance/data/appearance.glade.h:88
-msgid "_Selected items:"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:89
-msgid "_Size:"
-msgstr "आकार (_S):"
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "चेतावनीक बटन"
 
-#: ../capplets/appearance/data/appearance.glade.h:90
-msgid "_Slight"
-msgstr "कम (_S)"
-
-#: ../capplets/appearance/data/appearance.glade.h:91
-msgid "_Style:"
-msgstr "शैली (_S):"
-
-#: ../capplets/appearance/data/appearance.glade.h:92
-msgid "_Tooltips:"
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
 msgstr ""
 
-#. vertical hinting, pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:94
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:95
-msgid "_Window title font:"
-msgstr "विंडो शीर्षक फोन्ट (_W)"
-
-#: ../capplets/appearance/data/appearance.glade.h:96
-msgid "_Windows:"
-msgstr "_Windows:"
-
-#: ../capplets/appearance/data/appearance.glade.h:97
-msgid "dots per inch"
-msgstr "बिन्दु प्रति इंच"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr "प्रकटन"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-info.c:50
-msgid "No Desktop Background"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-item.c:208
-msgid "Slide Show"
-msgstr "स्लाइड शो"
-
-#. translators: <b>wallpaper name</b>
-#. * mime type, x pixel(s) by y pixel(s)
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:216
-#, c-format
+#: panels/wacom/button-mapping.ui:51
 msgid ""
-"<b>%s</b>\n"
-"%s, %d %s by %d %s\n"
-"Folder: %s"
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 
-#: ../capplets/appearance/gnome-wp-item.c:222
-#: ../capplets/appearance/gnome-wp-item.c:224
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "पिक्सेल"
-msgstr[1] "पिक्सेल"
-
-#: ../capplets/appearance/theme-installer.c:174
-#: ../capplets/appearance/theme-installer.c:224
-msgid "Cannot install theme"
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
 msgstr ""
 
-#: ../capplets/appearance/theme-installer.c:176
-#, c-format
-msgid "The %s utility is not installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:226
-msgid "There was a problem while extracting the theme."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:249
-msgid "There was an error installing the selected file"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:250
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:251
-#, c-format
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
-"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
-"you need to compile."
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
 msgstr ""
 
-#: ../capplets/appearance/theme-installer.c:354
-#, c-format
-msgid "Installation for theme \"%s\" failed."
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: ../capplets/appearance/theme-installer.c:393
-#, c-format
-msgid "The theme \"%s\" has been installed."
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
-#: ../capplets/appearance/theme-installer.c:398
-msgid "Would you like to apply it now, or keep your current theme?"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
 msgstr ""
 
-#: ../capplets/appearance/theme-installer.c:400
-msgid "Keep Current Theme"
-msgstr "मोजुदा प्रसंग राखू"
-
-#: ../capplets/appearance/theme-installer.c:402
-msgid "Apply New Theme"
-msgstr "नवीन प्रसंग लागू करू"
-
-#: ../capplets/appearance/theme-installer.c:446
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "Gnome प्रसंग %s ठीक सँ संस्थापित अछि"
-
-#: ../capplets/appearance/theme-installer.c:505
-msgid "Failed to create temporary directory"
-msgstr "अस्थायी निर्देशिका बनाबैमे विफल"
-
-#: ../capplets/appearance/theme-installer.c:568
-msgid "New themes have been successfully installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:593
-msgid "No theme file location specified to install"
-msgstr "संस्थापित करब लेल कोनो प्रसंग फ़ाइल स्थान निर्दिष्ट नहि कएल अछि"
-
-#: ../capplets/appearance/theme-installer.c:614
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"एकरामे प्रसंग दएमे अपर्याप्त अनुमति:\n"
-"%s"
-
-#: ../capplets/appearance/theme-installer.c:684
-msgid "Select Theme"
-msgstr "प्रसंग चुनू"
-
-#: ../capplets/appearance/theme-installer.c:688
-msgid "Theme Packages"
-msgstr ""
-
-#: ../capplets/appearance/theme-save.c:93
-#, c-format
-msgid "Theme name must be present"
-msgstr "प्रसंग नाम मोजुद होनाइ चाही"
-
-#: ../capplets/appearance/theme-save.c:156
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "प्रसंग पहिले सँ मोजुद अछि की अहाँ एकरा स्थानांतरित कएनाइ चाहैत अछि?"
-
-#: ../capplets/appearance/theme-save.c:157
-#: ../capplets/common/file-transfer-dialog.c:450
-msgid "_Overwrite"
-msgstr "मेटाए कए लिखू (_O)"
-
-#: ../capplets/appearance/theme-util.c:75
-msgid "Would you like to delete this theme?"
-msgstr ""
-
-#: ../capplets/appearance/theme-util.c:125
-msgid "Theme cannot be deleted"
-msgstr ""
-
-#: ../capplets/appearance/theme-util.c:252
-msgid "Could not install theme engine"
-msgstr ""
-
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"विन्यास प्रबंधक 'गनोम-विन्यास-डेमन' प्रारंभ करबमे अक्षम.\n"
-"गनोम विन्यास प्रबंधक प्रारंभ नहि रहब पर किछु वरीयतासभ परिणाम नहि देत. ई बोनोबो क' "
-"सँग समस्या क' कारण भ' सकैत अछि अथवा गैर गनोम (जहिना केडीई) विन्यास प्रबंधक पहिले सँ "
-"प्रारंभ हुए आओर गनोम विन्यास प्रबंधक परस्पर विरोध कए रहल हाएत."
-
-#: ../capplets/common/capplet-stock-icons.c:66
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "'%s' स्टॉक आइकन लोड करबमे असमर्थ\n"
-
-#: ../capplets/common/capplet-util.c:88
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "मद्दति देखाबैमे कोनो त्रुटि भेल: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:98
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "फाइल कॉपी कए रहल अछि %u %u क'"
-
-#: ../capplets/common/file-transfer-dialog.c:145
-#, c-format
-msgid "Copying '%s'"
-msgstr "'%s' कॉपी कए रहल अछि"
-
-#: ../capplets/common/file-transfer-dialog.c:185
-#: ../capplets/common/file-transfer-dialog.c:312
-msgid "Copying files"
-msgstr "फ़ाइलसभ कॉपी कए रहल अछि"
-
-#: ../capplets/common/file-transfer-dialog.c:224
-msgid "Parent Window"
-msgstr "जनक विंडो"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Parent window of the dialog"
-msgstr "संवाद क' जनक विंडो"
-
-#: ../capplets/common/file-transfer-dialog.c:231
-msgid "From URI"
-msgstr "URI सँ"
-
-#: ../capplets/common/file-transfer-dialog.c:232
-msgid "URI currently transferring from"
-msgstr "URI वर्तमानमे एतय सँ स्थानांतरित कए रहल"
-
-#: ../capplets/common/file-transfer-dialog.c:239
-msgid "To URI"
-msgstr "URI केँ"
-
-#: ../capplets/common/file-transfer-dialog.c:240
-msgid "URI currently transferring to"
-msgstr "URI वर्तमानमे एतय स्थानांतरित कए रहल"
-
-#: ../capplets/common/file-transfer-dialog.c:247
-msgid "Fraction completed"
-msgstr "अंश पूर्ण"
-
-#: ../capplets/common/file-transfer-dialog.c:248
-msgid "Fraction of transfer currently completed"
-msgstr "वर्तमानमे पूर्ण भेल स्थानांतरण क' अंश"
-
-#: ../capplets/common/file-transfer-dialog.c:255
-msgid "Current URI index"
-msgstr "वर्तमान URI सूची"
-
-#: ../capplets/common/file-transfer-dialog.c:256
-msgid "Current URI index - starts from 1"
-msgstr "वर्तमान URI सूची - 1 सँ प्रारंभ"
-
-#: ../capplets/common/file-transfer-dialog.c:263
-msgid "Total URIs"
-msgstr "कुल URI"
-
-#: ../capplets/common/file-transfer-dialog.c:264
-msgid "Total number of URIs"
-msgstr "कुल URI क्रमांक"
-
-#: ../capplets/common/file-transfer-dialog.c:444
-#, c-format
-msgid "File '%s' already exists. Do you want to overwrite it?"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:447
-msgid "_Skip"
-msgstr "छोड़ू (_S)"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Overwrite _All"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:134
-msgid "Key"
-msgstr "कुँजी"
-
-#: ../capplets/common/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr "जी-कान्फ़ कुँजी जकरामे गुण संपादक संलग्न अछि"
-
-#: ../capplets/common/gconf-property-editor.c:141
-msgid "Callback"
-msgstr "कॉलबैक"
-
-#: ../capplets/common/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "जखन एहि कुँजी क' सम्बद्ध मूल्य बदलैत अछि तँ कॉलबैक जारी करू"
-
-#: ../capplets/common/gconf-property-editor.c:147
-msgid "Change set"
-msgstr "सेट बदलू"
-
-#: ../capplets/common/gconf-property-editor.c:148
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr "लागू करब पर जी-कान्फ़ चेंज सेट जकरामे डाटा मिलल अछि जी-कान्फ़ क्लाइन्टकेँ भेजू."
-
-#: ../capplets/common/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr "विज़ेट कॉलबैकमे परिवर्तन"
-
-#: ../capplets/common/gconf-property-editor.c:154
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "जखन डाटा जी-कान्फ़ सँ विज़ेटमे बदलल जएनाइ हुए तँ कॉलबैक जारी करू"
-
-#: ../capplets/common/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr "विज़ेट कॉलबैकसँ परिवर्तन"
-
-#: ../capplets/common/gconf-property-editor.c:160
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr "जखन डाटा विज़ेट सँ जी-कान्फ़मे बदलल जएनाइ हुए तँ कॉलबैक जारी करू"
-
-#: ../capplets/common/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "यूआइ नियंत्रण"
-
-#: ../capplets/common/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr "आब्जेक्ट जे गुण नियंत्रण करैत अछि (सामान्यतः एकटा विज़ेट)"
-
-#: ../capplets/common/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr "गुण संपादक वस्तु डाटा"
-
-#: ../capplets/common/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr "निर्दिष्ट गुण संपादक द्वारा चाहल गेल अनुकूलित डाटा"
-
-#: ../capplets/common/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr "गुण संपादक डाटा मुक्त करैत छी कॉलबैक"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr "गुण संपादक वस्तु डाटा जखन मुक्त करब हुए तँ कॉलबैक जारी कएल जाए"
-
-#: ../capplets/common/gconf-property-editor.c:1404
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"फ़ाइल '%s' खोजि नहि सकल. \n"
-"कृप्या सुनिश्चित करू जे ई मोजुद अछि \n"
-"फिनु कोशिश करू अथवा आन पृष्ठ भूमि बिंब चुनू."
-
-#: ../capplets/common/gconf-property-editor.c:1412
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"हमरा मालूम नहि अछि जे फ़ाइल '%s' कहिना खोलल जाएत अछि. \n"
-"संभवतः ई ओहि प्रकार क' बिंब अछि जे अखन समर्थित नहि अछि.\n"
-"\n"
-"कृप्या बदलामे कोनो आन बिंब चुनू."
-
-#: ../capplets/common/gconf-property-editor.c:1532
-msgid "Please select an image."
-msgstr "कृप्या कोनो बिंब चुनू."
-
-#: ../capplets/common/gconf-property-editor.c:1537
-msgid "_Select"
-msgstr "चुनू (_S)"
-
-#: ../capplets/common/gnome-theme-info.c:638
-msgid "Default Pointer - Current"
-msgstr "मूलभूत संकेतक - वर्तमान"
-
-#: ../capplets/common/gnome-theme-info.c:642
-msgid "White Pointer"
-msgstr "उज्जर संकेतक"
-
-#: ../capplets/common/gnome-theme-info.c:643
-msgid "White Pointer - Current"
-msgstr "उज्जर संकेतक - वर्तमान"
-
-#: ../capplets/common/gnome-theme-info.c:647
-msgid "Large Pointer"
-msgstr "पैघ संकेतक"
-
-#: ../capplets/common/gnome-theme-info.c:648
-msgid "Large Pointer - Current"
-msgstr "पैघ संकेतक - वर्तमान"
-
-#: ../capplets/common/gnome-theme-info.c:652
-msgid "Large White Pointer - Current"
-msgstr "पैघ उज्जर संकेतक -वर्तमान"
-
-#: ../capplets/common/gnome-theme-info.c:653
-msgid "Large White Pointer"
-msgstr "पैघ उज्जर संकेतक"
-
-#: ../capplets/common/gnome-theme-info.c:1623
-#, c-format
-msgid ""
-"This theme will not look as intended because the required GTK+ theme '%s' is "
-"not installed."
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1631
-#, c-format
-msgid ""
-"This theme will not look as intended because the required window manager "
-"theme '%s' is not installed."
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1638
-#, c-format
-msgid ""
-"This theme will not look as intended because the required icon theme '%s' is "
-"not installed."
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Preferred Applications"
-msgstr "चहेता अनुप्रयोग"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "अपन मूलभूत अनुप्रयोग चुनू"
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Start the preferred visual assistive technology"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:98
-#: ../capplets/default-applications/gnome-da-capplet.c:362
-#: ../capplets/default-applications/gnome-da-capplet.c:383
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "विन्यास सहेजएमे त्रुटि: %s"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:668
-msgid "Could not load the main interface"
-msgstr "मुख्य अंतरफलक लोड नहि कए सकल"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:670
-msgid "Please make sure that the applet is properly installed"
-msgstr "सुनिश्चित करू जे ई एप्पलेट ठीकसँ संस्थापित अछि"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/default-applications/gnome-da-capplet.c:896
-msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:901
-msgid "- GNOME Default Applications"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Image Viewer</b>"
-msgstr "<b>बिंब दर्शक</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Instant Messenger</b>"
-msgstr "<b>इंस्टैंट मैसेंजर</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Mail Reader</b>"
-msgstr "<b>मेल रीडर</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mobility</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Multimedia Player</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>टर्मिनल इमेल्यूटर</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Text Editor</b>"
-msgstr "<b>पाठ संपादक</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Video Player</b>"
-msgstr "<b>पाठ संपादक</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "<b>Visual</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "<b>Web Browser</b>"
-msgstr "<b>वेब ब्राउज़र</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
-msgid "Accessibility"
-msgstr "अभिगम्यता"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "सबहि %s आवृतिकेँ वास्तविक लिंकसँ प्रतिस्थापित कएल जएताह"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-msgid "C_ommand:"
-msgstr "कमांड (_o):"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Co_mmand:"
-msgstr "कमांड (_m):"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "E_xecute flag:"
-msgstr "फ्लैग चलाबू (_x):"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Internet"
-msgstr "इंटरनेट"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Multimedia"
-msgstr "मल्टीमीडिया"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Open link in new _tab"
-msgstr "नवीन टैबमे लिंक खोलू (_t)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "Open link in new _window"
-msgstr "नवीन विंडोमे लिंक खोलू (_w)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid "Open link with web browser _default"
-msgstr "मूलभूत वेब ब्रॉउजर सँ लिंक खोलू (_d)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Run at st_art"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Run in t_erminal"
-msgstr "टर्मिनलमे चलाबू (_e)"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "System"
-msgstr "सिस्टम"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "_Run at start"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "बाल्सा"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr "बंशी संगीत प्लेयर"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr "क्लॉज मेल"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr "डैशर"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr "डेबियन संवेदनशील ब्राउज़र"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr "डेबियन टर्मिनल एमुलेटर"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr "एनकम्पास"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr "एपीफेनी वेब ब्राउसर"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr "एवॉल्यूशन मेल रीडर"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr "फ़ायरबर्ड"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Firefox"
-msgstr "फ़ायरफ़ॉक्स"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr "गनोम टर्मिनल"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Galeon"
-msgstr "गेलियन"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Gnopernicus"
-msgstr "ग्नोपरनिकस"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Gnopernicus with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Iceape"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Iceape Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Icedove"
-msgstr "Icedove"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Iceweasel"
-msgstr "Iceweasel"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr "KMail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr "कोन्करर"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Konsole"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Listen"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Midori"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Mozilla"
-msgstr "मोजिला"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Mozilla 1.6"
-msgstr "मोज़िला 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Mozilla Mail"
-msgstr "मोज़िला मेल"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Mozilla Thunderbird"
-msgstr "मोजिला थंडरबर्ड"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Muine Music Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Netscape Communicator"
-msgstr "नेटस्केप कम्यूनिकेटर"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Opera"
-msgstr "ऑपेरा"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca"
-msgstr "ओरका"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "Orca with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-msgid "Rhythmbox Music Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-msgid "SeaMonkey"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-msgid "SeaMonkey Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Standard XTerminal"
-msgstr "मानक X-टर्मिनल"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-msgid "Sylpheed"
-msgstr "सिल्फीड"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-msgid "Sylpheed-Claws"
-msgstr "सिल्फीड क्लॉ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Terminator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Thunderbird"
-msgstr "थंडरबर्ड"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "Totem Movie Player"
-msgstr "टोटेम मूवी चलाबै बला"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
-msgid "aterm"
-msgstr "एटर्म"
-
-#: ../capplets/display/display-capplet.glade.h:1
-#: ../capplets/display/xrandr-capplet.c:461
-msgid "<b>Monitor</b>"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:2
-msgid "<b>Panel icon</b>"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:3
-msgid "<i>Drag the monitors to set their place</i>"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:4
-msgid "Display Preferences"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:5
-msgid "Include _panel"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:6
-msgid ""
-"Normal\n"
-"Left\n"
-"Right\n"
-"Upside-down\n"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:11
-msgid "Off"
-msgstr "बन्न"
-
-#: ../capplets/display/display-capplet.glade.h:12
-msgid "On"
-msgstr "शुरू"
-
-#: ../capplets/display/display-capplet.glade.h:13
-msgid "R_otation:"
-msgstr "घूर्णन (_o):"
-
-#: ../capplets/display/display-capplet.glade.h:14
-msgid "Re_fresh rate:"
-msgstr "ताज़ा करब क' दर (_f):"
-
-#: ../capplets/display/display-capplet.glade.h:15
-msgid "_Detect Monitors"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:16
-msgid "_Mirror screens"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:17
-msgid "_Resolution:"
-msgstr "रेज़ोल्यूशन (_R):"
-
-#: ../capplets/display/display-capplet.glade.h:18
-msgid "_Show displays in panel"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "स्क्रीन रिज़ोल्यूशन बदलू"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Display"
-msgstr "देखाबू"
-
-#: ../capplets/display/xrandr-capplet.c:328
-#: ../capplets/display/xrandr-capplet.c:367
-msgid "Normal"
-msgstr "सामान्य"
-
-#: ../capplets/display/xrandr-capplet.c:329
-msgid "Left"
-msgstr "बामाँ"
-
-#: ../capplets/display/xrandr-capplet.c:330
-msgid "Right"
-msgstr "दहिन्ना"
-
-#: ../capplets/display/xrandr-capplet.c:331
-msgid "Upside Down"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:404
-#: ../capplets/display/xrandr-capplet.c:412
-#: ../capplets/display/xrandr-capplet.c:413
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/xrandr-capplet.c:454
-#, c-format
-msgid "<b>Monitor: %s</b>"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:546
-#: ../capplets/display/xrandr-capplet.c:556
-#: ../capplets/display/xrandr-capplet.c:564
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../capplets/display/xrandr-capplet.c:1411
-msgid "Mirror Screens"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1730
-msgid "Could not apply the selected configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1757
-msgid "Could not save the monitor configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1768
-msgid "Could not get session bus while applying display configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1778
-msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1824
-msgid "Could not detect displays"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:2017
-msgid "Could not get screen information"
-msgstr ""
-
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-msgid "Sound"
-msgstr "ध्वनि"
-
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-#: ../libslab/bookmark-agent.c:1146
-msgid "Desktop"
-msgstr "डेस्कटाप"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "त्वरक कुँजी"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "त्वरक परिवर्धक"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "त्वरक कुँजीकोड"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "त्वरक मोड"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "त्वरक प्रकार"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:103
-#: ../typing-break/drwright.c:479
-msgid "Disabled"
-msgstr "अक्षम"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:184
-msgid "<Unknown Action>"
-msgstr "<अज्ञात क्रिया>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:925
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1548
-msgid "Custom Shortcuts"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1064
-msgid "Error saving the new shortcut"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1143
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1173
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1179
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1187
-msgid "_Reassign"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1307
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1503
-msgid "Too many custom shortcuts"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1788
-msgid "Action"
-msgstr "क्रिया"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1810
-msgid "Shortcut"
-msgstr "शार्टकट"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid "Custom Shortcut"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:3
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "कुंजीपटल शार्टकट"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:4
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new key "
-"combination, or press backspace to clear."
-msgstr ""
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "कमाँड लेल शार्टकट कुँजीसभ नियत करू"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:206
-#: ../capplets/keyboard/gnome-keyboard-properties.c:211
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr "विन्यास लागू करू आओर बाहर होउ (सिर्फ सुसंगतता, आब डेमन द्वारा संभालल जएताह)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:216
-msgid "Start the page with the typing break settings showing"
-msgstr "टाइपिंग ब्रेक विन्यास देखबैत हुए पृष्ठ प्रारंभ करू"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-msgid "Start the page with the accessibility settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "- GNOME Keyboard Preferences"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-msgid "<b>Bounce Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>कर्सर टिमटिमओनाइ</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "<b>General</b>"
-msgstr "<b>सामान्य</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>दोहराव कुँजी</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Slow Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>Sticky Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<b>Visual cues for sounds</b>"
-msgstr ""
-
-#. fast acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>तेज़</i></small>"
-
-#. long delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>नमहर</i></small>"
-
-#. short delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>छोट</i></small>"
-
-#. slow acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>धीमा</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "A_cceleration:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "All_ow postponing of breaks"
-msgstr "ब्रेक स्थगित कएनाइ स्वीकारू (_o)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Audio _Feedback..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Beep when _accessibility features are turned on or off"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Beep when a _modifier key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Beep when a _toggle key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Beep when a key is pr_essed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Beep when a key is reje_cted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Beep when key is _accepted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Beep when key is _rejected"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "By _country"
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "By _language"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Check if breaks are allowed to be postponed"
-msgstr "जाँचू जे की ब्रेक स्थगित करब लेल स्वीकार्य अछि"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "टाइपिंग मॉनीटर"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Choose a Keyboard Model"
-msgstr "कुँजीपटल मॉडल चुनू"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Choose a Layout"
-msgstr "एकटा लेआउट चुनू"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Cursor _blinks in text fields"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
-msgid "Cursor blinks speed"
-msgstr "कर्सर ब्लिंक गति"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
-msgid "D_elay:"
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Disa_ble sticky keys if two keys are pressed together"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Duration of the break when typing is disallowed"
-msgstr "जखन टाइपिंग स्वीकार्य नहि अछि तँ ब्रेक क' अवधि"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-msgid "Duration of work before forcing a break"
-msgstr "ब्रेक बाध्य करब सँ पहिले कार्यावधि"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "Flash _window titlebar"
-msgstr "विंडो शीर्षक-पट्टीकेँ चमकाबू (_w)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "Flash entire _screen"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
-msgid "General"
-msgstr "सामान्य"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "Key presses _repeat when key is held down"
-msgstr "जखन कुँजी दाबि कए राखल जाए तँ कुँजी दोहरओनाइ (_r)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "Keyboard Accessibility Audio Feedback"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "Keyboard Layout Options"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "Keyboard Preferences"
-msgstr "कुँजी पटल वरीयतासभ "
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "Keyboard _model:"
-msgstr "कुँजीपटल मॉडल (_m):"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "Layout _Options..."
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "Layouts"
-msgstr "लेआउट"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
 msgstr ""
-"बारंबार कुँजीपटल उपयोग चोट सँ बचबाक लेल स्क्रीनकेँ एकटा निश्चित अवधि क' पश्चात् तालाबन्न "
-"करू"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
-msgid "Mouse Keys"
-msgstr "माउस कुँजीसभ"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
-msgid "Preview:"
-msgstr "पूर्वावलोकनः"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
-msgid "Repeat keys speed"
-msgstr "दुहराबै बला कुँजी गति"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
-msgid "Reset to De_faults"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
-msgid "S_peed:"
-msgstr "गति (_p):"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
-msgid "Separate _layout for each window"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
-msgid "Show _visual feedback for the alert sound"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
-msgid "Typing Break"
-msgstr "ब्रेक टाइप कए रहल अछि"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
-msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
-msgid "_Break interval lasts:"
-msgstr "ब्रेक अंतराल टिकैत अछि (_B)"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
-msgid "_Country:"
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
-msgid "_Delay:"
-msgstr "विलंब (_D):"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
-msgid "_Ignore fast duplicate keypresses"
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
-msgid "_Language:"
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
-msgid "_Lock screen to enforce typing break"
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
-msgid "_Models:"
-msgstr "मॉडल (_M):"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
-msgid "_Only accept long keypresses"
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
-msgid "_Pointer can be controlled using the keypad"
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
-msgid "_Selected layouts:"
-msgstr "चयनित लेआउट (_S):"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
-msgid "_Simulate simultaneous keypresses"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
-msgid "_Speed:"
-msgstr "गति (_S):"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
-msgid "_Type to test settings:"
-msgstr "जमावट जाँचबाक लेल टाइप करू (_T):"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:68
-msgid "_Variants:"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:69
-msgid "_Vendors:"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:70
-msgid "_Work interval lasts:"
-msgstr "कार्य अंतराल टिकैत अछि (_W):"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:71
-msgid "minutes"
-msgstr "मिनट"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
-msgid "Unknown"
-msgstr "अज्ञात"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:215
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:235
-#: ../capplets/network/gnome-network-properties.c:561
-msgid "Default"
-msgstr "मूलभूत"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:333
+#: panels/windows/cc-windows-panel.ui:8
 msgid "Layout"
 msgstr "लेआउट"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
-msgid "Vendors"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
-msgid "Models"
-msgstr "मॉडल"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "कुँजीपटल"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "कुँजी पटल क' वरीयतासभ नियत करू"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:90
-msgid "gesture|Move left"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:95
-msgid "gesture|Move right"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:100
-msgid "gesture|Move up"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:105
-msgid "gesture|Move down"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:110
-msgid "gesture|Disabled"
-msgstr ""
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/mouse/gnome-mouse-properties.c:441
-msgid "Specify the name of the page to show (general|accessibility)"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:446
-msgid "- GNOME Mouse Preferences"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-msgid "<b>Double-Click Timeout</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>घीँचू आओर छोड़ू</b>"
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Dwell Click</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>संकेतक स्थिति देखाबू</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>माउस अभिमुखन</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<b>Pointer Speed</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<b>Simulated Secondary Click</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+#: panels/windows/cc-windows-panel.ui:68
 msgid ""
-"<i>To test your double-click settings, try to double-click on the light bulb."
-"</i>"
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
 
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid ""
-"<i>You can also use the Dwell Click panel applet to choose the click type.</"
-"i>"
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "जनक विंडो"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
 msgstr ""
 
-#. high sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "<small><i>High</i></small>"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "विंडोज़"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
 msgstr ""
 
-#. large threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "<small><i>Large</i></small>"
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
 msgstr ""
 
-#. low sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "<small><i>Low</i></small>"
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
 msgstr ""
 
-#. small threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "<small><i>Small</i></small>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
-msgid "Choose type of click _beforehand"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
-msgid "Choose type of click with mo_use gestures"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
-msgid "D_ouble click:"
-msgstr ""
-
-#. click to initiate drag-and-drop (like normally click and hold)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
-msgid "D_rag click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
-msgid "Mouse Preferences"
-msgstr "माउस वरीयतासभ "
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
-msgid "Seco_ndary click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
-msgid "Show click type _window"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
-msgid "Thr_eshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
-msgid "_Acceleration:"
-msgstr "त्वरक (_A):"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
-msgid "_Initiate click when stopping pointer movement"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
-msgid "_Left-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
-msgid "_Motion threshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
-msgid "_Right-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
-msgid "_Sensitivity:"
-msgstr "संवेदनशीलता (_S):"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
-msgid "_Single click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
-msgid "_Timeout:"
-msgstr "टाइमआउट (_T):"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr ""
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "माउस"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "अपन माउस क' वरीयतासभ नियत करू"
-
-#: ../capplets/network/gnome-network-properties.c:677
-#: ../capplets/network/gnome-network-properties.c:816
-msgid "New Location..."
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.c:782
-msgid "Location already exists"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "संजाल प्रॉक्सी"
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "संजाल प्रॉक्सी वरीयतासभ सेट करू"
-
-#: ../capplets/network/gnome-network-properties.glade.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>सीधा इंटरनेट कनेक्शन (_r)</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:2
-msgid "<b>Ignore Host List</b>"
-msgstr "<b>होस्ट सूची अनदेखा करू</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:3
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>स्वचालित प्रॉक्सी विन्यास (_A)</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:4
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b> हस्तचालित प्रॉक्सी विन्यास (_M)</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:5
-msgid "<b>_Use authentication</b>"
-msgstr "<b>प्रमाणीकरण प्रयोग करू (_U)</b>"
-
-#: ../capplets/network/gnome-network-properties.glade.h:6
-msgid "Autoconfiguration _URL:"
-msgstr "स्वविन्यास यूआरएल (_U) : "
-
-#: ../capplets/network/gnome-network-properties.glade.h:7
-msgid "C_reate"
-msgstr "बनाबू (_r)"
-
-#: ../capplets/network/gnome-network-properties.glade.h:8
-msgid "Create New Location"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "HTTP प्रॉक्सी विवरण"
-
-#: ../capplets/network/gnome-network-properties.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "HTTP प्रॉक्सी (_H):"
-
-#: ../capplets/network/gnome-network-properties.glade.h:11
-msgid "Ignored Hosts"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.glade.h:12
-msgid "Location:"
-msgstr "स्थानः"
-
-#: ../capplets/network/gnome-network-properties.glade.h:13
-msgid "Network Proxy Preferences"
-msgstr "संजाल प्रॉक्सी वरीयतासभ "
-
-#: ../capplets/network/gnome-network-properties.glade.h:14
-msgid "Port:"
-msgstr "पोर्टः"
-
-#: ../capplets/network/gnome-network-properties.glade.h:15
-msgid "Proxy Configuration"
-msgstr "प्रॉक्सी विन्यास"
-
-#: ../capplets/network/gnome-network-properties.glade.h:16
-msgid "S_ocks host:"
-msgstr "सॉक्स होस्ट (_o):"
-
-#: ../capplets/network/gnome-network-properties.glade.h:17
-msgid "The location already exists."
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.glade.h:18
-msgid "U_sername:"
-msgstr "प्रयोक्ता नाम (_s):"
-
-#: ../capplets/network/gnome-network-properties.glade.h:19
-msgid "_Delete Location"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.glade.h:20
-msgid "_Details"
-msgstr "विवरण (_D)"
-
-#: ../capplets/network/gnome-network-properties.glade.h:21
-msgid "_FTP proxy:"
-msgstr "FTP प्रॉक्सी (_F):"
-
-#: ../capplets/network/gnome-network-properties.glade.h:22
-msgid "_Location name:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.glade.h:23
-msgid "_Password:"
-msgstr "कूटशब्द (_P):"
-
-#: ../capplets/network/gnome-network-properties.glade.h:24
-msgid "_Secure HTTP proxy:"
-msgstr "सुरक्षित HTTP प्रॉक्सी (_S):"
-
-#: ../capplets/network/gnome-network-properties.glade.h:25
-msgid "_Use the same proxy for all protocols"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:346
-msgid "Cannot start the preferences application for your window manager"
-msgstr ""
-
-#. translators: this is the Control key
-#: ../capplets/windows/gnome-window-properties.c:600
-msgid "C_ontrol"
-msgstr "नियंत्रित करू (_o)"
-
-#: ../capplets/windows/gnome-window-properties.c:605
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:611
-msgid "H_yper"
-msgstr "हाइपर (_y)"
-
-#: ../capplets/windows/gnome-window-properties.c:618
-msgid "S_uper (or \"Windows logo\")"
-msgstr "सुपर (अथवा \"विंडोज़ लोगो\") (_u)"
-
-#: ../capplets/windows/gnome-window-properties.c:625
-msgid "_Meta"
-msgstr "मेटा (_M)"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>गतिविधि कुँजीसभ</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>शीर्षकपट्टी क्रिया</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>विन्डो चयन</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr "कोनो विंडोकेँ घसकाबै लेल एहि कुँजीकेँ दाबने राखू फिनु विंडो पकड़ू"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "विंडो वरीयतासभ "
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "एहि क्रिया लेल शीर्षकपट्टीकेँ दोहरा क्लिक करू (_D):"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "उठाबैसँ पहिले अन्तराल (_I):"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "एकटा अन्तराल क' बाद चुनल गेल विंडोज़केँ उप्पर उठाबू (_R)"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "जखन माउस विंडोज़ पर घूमेताह तँ ओकरा चुनू (_S)"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "सकेण्ड"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "अपन विंडो गुण सेट करू"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
 msgid "Windows"
 msgstr "विंडोज़"
 
-#. make start action
-#: ../libslab/application-tile.c:372
-#, c-format
-msgid "<b>Start %s</b>"
-msgstr "<b>%s आरंभ करू</b>"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
 
-#: ../libslab/application-tile.c:391
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "अभिगम्यता"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "पता"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "सहेजू (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "विवरण (_D)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "संजाल प्रॉक्सी"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "संजाल सर्वर"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "विवरण (_D)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "मोबाइल (_M):"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "संजाल प्रॉक्सी"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "संजाल प्रॉक्सी"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "विवरण (_D)"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "संजाल प्रॉक्सी"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "सत्यापित कएल (_A)"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "संजाल सर्वर"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "सेट बदलू"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr ""
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "मद्दति "
 
-#: ../libslab/application-tile.c:438
-msgid "Upgrade"
-msgstr "उन्नत बनाबू "
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "सामान्य"
 
-#: ../libslab/application-tile.c:453
-msgid "Uninstall"
-msgstr "विसंस्थापित करू"
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "बाहर (_Q)"
 
-#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
-msgid "Remove from Favorites"
-msgstr "मनपसंद सँ हटाबू"
-
-#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
-msgid "Add to Favorites"
-msgstr "मनपसंदमे जोड़ू"
-
-#: ../libslab/application-tile.c:867
-msgid "Remove from Startup Programs"
-msgstr "आरंभन प्रोग्राम सँ हटाबू"
-
-#: ../libslab/application-tile.c:869
-msgid "Add to Startup Programs"
-msgstr "आरंभन प्रोग्राममे जोड़ू"
-
-#: ../libslab/app-shell.c:753
-#, c-format
-msgid ""
-"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
-"\n"
-" Your filter \"<b>%s</b>\" does not match any items.</span>"
-msgstr ""
-"<span size=\"large\"><b>कोनो मेल नहि भेटल.</b> </span><span>\n"
-"\n"
-" अहाँक फिल्टर \"<b>%s</b>\" कोनो मद सँ नहि मेल करैत अछि.</span>"
-
-#: ../libslab/app-shell.c:903
-msgid "Other"
-msgstr "आन"
-
-#: ../libslab/bookmark-agent.c:1077
-msgid "New Spreadsheet"
-msgstr ""
-
-#: ../libslab/bookmark-agent.c:1082
-msgid "New Document"
-msgstr "नवीन दस्तावेज"
-
-#: ../libslab/bookmark-agent.c:1135
-msgid "Home"
-msgstr "घर"
-
-#: ../libslab/bookmark-agent.c:1140
-msgid "Documents"
-msgstr "दस्तावेज़"
-
-#: ../libslab/bookmark-agent.c:1153
-msgid "File System"
-msgstr "फाइल सिस्टम"
-
-#: ../libslab/bookmark-agent.c:1157
-msgid "Network Servers"
-msgstr "संजाल सर्वर"
-
-#: ../libslab/bookmark-agent.c:1186
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Search"
 msgstr "खोजू"
 
-#. make open with default action
-#: ../libslab/directory-tile.c:171
-#, c-format
-msgid "<b>Open</b>"
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
 msgstr ""
 
-#. make rename action
-#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:231
-msgid "Rename..."
-msgstr "नाम बदलू..."
-
-#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
-#: ../libslab/document-tile.c:245 ../libslab/document-tile.c:254
-msgid "Send To..."
-msgstr "एकरामे भेजू..."
-
-#. make move to trash action
-#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:280
-msgid "Move to Trash"
-msgstr "रद्दीमे पठाबू"
-
-#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
-#: ../libslab/document-tile.c:290 ../libslab/document-tile.c:831
-msgid "Delete"
-msgstr "मेटाबू"
-
-#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:979
-#, c-format
-msgid "Are you sure you want to permanently delete \"%s\"?"
-msgstr "की अहाँ सुनिश्चित छी जे अहाँ \"%s\"केँ स्थायी तौर पर मेटओनाइ चाहैत अछि?"
-
-#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:980
-msgid "If you delete an item, it is permanently lost."
-msgstr "जँ अहाँ कोनो वस्तुकेँ मेटाएब, तँ ई स्थाइ रूप सँ मेट जएताह."
-
-#: ../libslab/document-tile.c:192
-#, c-format
-msgid "<b>Open with \"%s\"</b>"
-msgstr "<b>\"%s\" क' सँग खोलू</b>"
-
-#: ../libslab/document-tile.c:204
-msgid "Open with Default Application"
-msgstr "मूलभूत अनुप्रयोग क' सँग खोलू"
-
-#: ../libslab/document-tile.c:215
-msgid "Open in File Manager"
-msgstr "फाइल मैनेजरमे खोलू"
-
-#: ../libslab/document-tile.c:611
-msgid "?"
-msgstr "?"
-
-#: ../libslab/document-tile.c:618
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#: ../libslab/document-tile.c:626
-msgid "Today %l:%M %p"
-msgstr "आइ %l:%M %p"
-
-#: ../libslab/document-tile.c:636
-msgid "Yesterday %l:%M %p"
-msgstr "कालि %l:%M %p"
-
-#: ../libslab/document-tile.c:648
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
-
-#: ../libslab/document-tile.c:656
-msgid "%b %d %l:%M %p"
-msgstr "%b %d %l:%M %p"
-
-#: ../libslab/document-tile.c:658
-msgid "%b %d %Y"
-msgstr "%b %d %Y"
-
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
-msgstr "आब खोजू"
-
-#: ../libslab/system-tile.c:128
-#, c-format
-msgid "<b>Open %s</b>"
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
 msgstr ""
 
-#: ../libslab/system-tile.c:141
-#, c-format
-msgid "Remove from System Items"
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
 msgstr ""
 
-#: ../libwindow-settings/gnome-wm-manager.c:316
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "विंडो प्रबंधक \"%s\" ने विन्यास अओजार रजिस्टर नहि कएने अछि\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:404
-msgid "Maximize"
-msgstr "अधिकतम"
-
-#: ../libwindow-settings/metacity-window-manager.c:405
-msgid "Maximize Vertically"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:406
-msgid "Maximize Horizontally"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:407
-msgid "Minimize"
-msgstr "छोट करू"
-
-#: ../libwindow-settings/metacity-window-manager.c:408
-msgid "Roll up"
-msgstr "रोल अप"
-
-#: ../libwindow-settings/metacity-window-manager.c:409
-msgid "None"
-msgstr "किछु नहि"
-
-#: ../shell/control-center.c:54
-#, c-format
-msgid "key not found [%s]\n"
-msgstr "कुँजी नहि भेटल [%s]\n"
-
-#: ../shell/control-center.c:151
-msgid "Filter"
-msgstr "फिल्टर"
-
-#: ../shell/control-center.c:151
-msgid "Groups"
-msgstr "समूह"
-
-#: ../shell/control-center.c:151
-msgid "Common Tasks"
-msgstr "सामान्य कार्य"
-
-#: ../shell/control-center.c:155 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "नियंत्रण केंद्र"
-
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:5
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:8
-msgid ""
-"Indicates whether to close the shell when an add or remove action is "
-"performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:9
-msgid ""
-"Indicates whether to close the shell when an upgrade or uninstall action is "
-"performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:11
-msgid ""
-"The task name to be displayed in the control-center followed by a \";\" "
-"separator then the filename of an associated .desktop file to launch for "
-"that task."
-msgstr ""
-
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
-msgid ""
-"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
-"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:14
-msgid ""
-"if true, the control-center will close when a \"Common Task\" is activated."
-msgstr ""
-
-#: ../shell/gnomecc.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "गनोम विन्यास अओजार"
-
-#: ../typing-break/drw-break-window.c:193
-msgid "_Postpone Break"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:249
-msgid "Take a break!"
-msgstr "एकटा ब्रेक लिअ'!"
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#. translators: keep the initial "/"
-#: ../typing-break/drwright.c:129
-msgid "/_Preferences"
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
 msgstr "/ वरीयतासभ (_P)"
 
-#: ../typing-break/drwright.c:130
-msgid "/_About"
-msgstr "/क' संबंधमे (_A)"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
 
-#: ../typing-break/drwright.c:132
-msgid "/_Take a Break"
-msgstr "/एकटा ब्रेक लिअ'(_T)"
-
-#: ../typing-break/drwright.c:488
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "अगिला ब्रेक तक %d मिनट"
-msgstr[1] "अगिला ब्रेक तक %d मिनट"
-
-#: ../typing-break/drwright.c:492
-#, c-format
-msgid "Less than one minute until the next break"
-msgstr "अगिला ब्रेक क' लेल एक मिनट सँ कम समय"
-
-#: ../typing-break/drwright.c:579
-#, c-format
+#: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
-msgstr "टाइपिंग ब्रेक गुण समाद लाबैमे निम्न त्रुटि क' सँग असफल: %s"
-
-#: ../typing-break/drwright.c:598
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "रिचर्ड हुल्ट <richard@imendio.com> द्वारा लिखित"
-
-#: ../typing-break/drwright.c:599
-msgid "Eye candy added by Anders Carlsson"
-msgstr "ऑन्देर्स कार्लसन द्वारा आई कैण्डी जोड़ल गेल अछि"
-
-#: ../typing-break/drwright.c:608
-msgid "A computer break reminder."
-msgstr "कम्प्यूटर ब्रेक स्मरण."
-
-#: ../typing-break/drwright.c:610
-msgid "translator-credits"
-msgstr "संगीता कुमारी (sangeeta09@gmail.com)"
-
-#: ../typing-break/main.c:61
-msgid "Enable debugging code"
-msgstr "डिबगिंग कोड सक्रिय करू"
-
-#: ../typing-break/main.c:63
-msgid "Don't check whether the notification area exists"
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
 msgstr ""
 
-#: ../typing-break/main.c:89
-msgid "Typing Monitor"
-msgstr "टाइपिंग मॉनीटर"
-
-#: ../typing-break/main.c:105
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
 msgstr ""
-"टाइपिंग निरीक्षक सूचना देखाबै क'लेल सूचना क्षेत्र क' प्रयोग करैत अछि अहाँ अपन पटल पर सूचना "
-"क्षेत्रकेँ नहि राखैत प्रतीत हाएत अछि. अहाँ अपन पटल पर दहिन्ना क्लिक कए क' आओर 'पटलमे "
-"जोड़ू' चुनि कए, सूचना क्षेत्र आओर जोड़ू पर क्लिक कए क'."
 
-#: ../font-viewer/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "जँ सही पर नियत कएल जाएत अछि, ओपन-टाइप फोन्ट क' लघु बिंब बनाओल जाएत."
-
-#: ../font-viewer/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "जँ सही पर नियत कएल जाएत अछि, पीसीएफ़ फोन्ट क' लघु बिंब बनाओल जाएत."
-
-#: ../font-viewer/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "जँ सही पर नियत कएल जाएत अछि, ट्रू-टाइप फोन्ट क' लघु बिंब बनाओल जाएत."
-
-#: ../font-viewer/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "जँ सही पर नियत कएल जाएत अछि, टाइप1 फोन्ट क' लघु बिंब बनाओल जाएत."
-
-#: ../font-viewer/fontilus.schemas.in.h:5
+#: shell/org.gnome.Settings.gschema.xml:14
 msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
-msgstr "एहि कुँजीकेँ ओपन टाइप फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
-
-#: ../font-viewer/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr "एहि कुँजीकेँ पीसीएफ़ फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
-
-#: ../font-viewer/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr "एहि कुँजीकेँ ट्रू टाइप फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
-
-#: ../font-viewer/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr "एहि कुँजीकेँ टाइप1 फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
-
-#: ../font-viewer/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "ओपन टाइप फोन्ट लेल लघु बिंब बनाबै क' कमांड"
-
-#: ../font-viewer/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "पीसीएफ़ फोन्ट लेल लघु बिंब बनाबै क' कमांड"
-
-#: ../font-viewer/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "ट्रू टाइप फोन्ट लेल लघु बिंब बनाबै क' कमांड"
-
-#: ../font-viewer/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "टाइप1 फोन्ट लेल लघु बिंब कमांड"
-
-#: ../font-viewer/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "की ओपन टाइप फोन्ट क' लघु बिंब बनाबू "
-
-#: ../font-viewer/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "की पीसीएफ़ फोन्ट क' लघु बिंब बनाबू "
-
-#: ../font-viewer/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "की ट्रू टाइप फोन्ट क' लघु बिंब बनाबू "
-
-#: ../font-viewer/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "की टाइप 1 फोन्ट क' लघु बिंब बनाबू "
-
-#: ../font-viewer/font-view.c:113
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+"Whether Settings should show a warning when running a development build."
 msgstr ""
-"सक्कय वाणी बहुजन भाबए, पाउय रसको मम्म न पाबए। देसिल बयना सब जन मिट्ठा, तैँ तैसन जम्पओ "
-"अवहट्ठा।। ०१२३४५६७८९"
 
-#: ../font-viewer/font-view.c:275
-msgid "Name:"
-msgstr "नाम:"
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
 
-#: ../font-viewer/font-view.c:278
-msgid "Style:"
-msgstr "शैली:"
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
 
-#: ../font-viewer/font-view.c:291
-msgid "Type:"
-msgstr "प्रकार:"
-
-#: ../font-viewer/font-view.c:295
-msgid "Size:"
-msgstr "आकार:"
-
-#: ../font-viewer/font-view.c:339 ../font-viewer/font-view.c:352
-msgid "Version:"
-msgstr "संस्करण:"
-
-#: ../font-viewer/font-view.c:343 ../font-viewer/font-view.c:354
-msgid "Copyright:"
-msgstr "कॉपीराइट:"
-
-#: ../font-viewer/font-view.c:347
-msgid "Description:"
-msgstr "विवरण:"
-
-#: ../font-viewer/font-view.c:437
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
-msgid "usage: %s fontfile\n"
-msgstr "उपयोग: %s फोन्ट-फ़ाइल\n"
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
-msgid "Font Viewer"
-msgstr ""
-
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
-msgid "Preview fonts"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "Text to thumbnail (default: Aa)"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "TEXT"
-msgstr "पाठ"
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "Font size (default: 64)"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "SIZE"
-msgstr "आकार"
-
-#: ../font-viewer/font-thumbnailer.c:249
-msgid "FONT-FILE OUTPUT-FILE"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:268
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
-msgid "Error parsing arguments: %s\n"
-msgstr ""
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
 
-msgid "Show help options"
-msgstr "मद्दति विकल्प देखाबू"
+#~ msgid "Image/label border"
+#~ msgstr "चित्र/लेबल किनार"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "चेतावनी संवादमे लेबल आ चित्रक चारि तरफ किनारक चओड़ाइ"
+
+#~ msgid "The type of alert"
+#~ msgstr "चेतावनीक प्रकार"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "चेतावनी संवादमे प्रदर्शित बटन"
+
+#~ msgid "Show more _details"
+#~ msgstr "बेसी विवरण देखाबू (_d)"
+
+#~ msgid "No Image"
+#~ msgstr "कोनो बिंब नहि"
+
+#~ msgid "Images"
+#~ msgstr "बिंब"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "एकटा गलती भेल पता पुस्तिका सूचनाकेँ पाबै क' कोशिशमे\n"
+#~ "Evolution डाटा सर्वर प्रोटोकॉल नियंत्रित नहि कए सकत"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "पता पुस्तिका खोलबमे विफल"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "अनजान लॉगिन ID, प्रयोक्ता डाटाबेस खराब भ' सकैत अछि"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "क' संबंधमे %s"
+
+#~ msgid "About Me"
+#~ msgstr "हमरा संबंधमे"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>घर</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>इंस्टेंट मैसेज</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>कार्य</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>टेलिफोन</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>वेब</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>कार्य</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\"> अपन कूटशब्द बदलू</span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "पता (_d):"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "सहायक (_s):"
+
+#~ msgid "C_ity:"
+#~ msgstr "शहर (_i):"
+
+#~ msgid "C_ompany:"
+#~ msgstr "कंपनी (_o):"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "कूटशब्द बदलू (_r)..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "कूटशब्द बदलू (_s)"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "शहर (_t):"
+
+#~ msgid "Co_untry:"
+#~ msgstr "देश (_u):"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "देश (_n):"
+
+#~ msgid "Hom_e:"
+#~ msgstr "घर (_e):"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _box:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. box:"
+
+#~ msgid "Personal Info"
+#~ msgstr "निज सूचना"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "<b>नवीन कूटशब्द फिनु टाइफ करू</b> क्षेत्रमे अपन कूटशब्द टाइप फिनु करू."
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "राज्य/क्षेत्र (_v):"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "अपन कूटशब्द बदलब क' लेल, नीच्चाँ देल क्षेत्रमे अपन मोजुदा कूटशब्द दिअ' आओर <b>सत्यापित "
+#~ "करू</b> क्लिक करू.\n"
+#~ "अहाँक द्वारा सत्यापित कएल जाए क' बाद, अपन नवीन कूटशब्द दिअ'. एकरा प्रमाणित करब "
+#~ "क' लेल फिनु टाइप करू आओर <b>कूटशब्द बदलू</b> क्लिक करू."
+
+#~ msgid "Web _log:"
+#~ msgstr "वेब लॉग (_l):"
+
+#~ msgid "Wor_k:"
+#~ msgstr "कार्य (_k):"
+
+#~ msgid "Work _fax:"
+#~ msgstr "कार्य फैक्स (_f):"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "जिप/डाक कूट (_P):"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "समूह रूपमे (_G):"
+
+#~ msgid "_Home page:"
+#~ msgstr "होम पेज (_H):"
+
+#~ msgid "_Home:"
+#~ msgstr "घर (_H):"
+
+#~ msgid "_Jabber:"
+#~ msgstr "जैबर (_J):"
+
+#~ msgid "_Manager:"
+#~ msgstr "प्रबंधक (_M):"
+
+#~ msgid "_Profession:"
+#~ msgstr "व्यवसाय (_P): "
+
+#~ msgid "_State/Province:"
+#~ msgstr "राज्य (_S):"
+
+#~ msgid "_Title:"
+#~ msgstr "शीर्षक (_T):"
+
+#~ msgid "_Work:"
+#~ msgstr "कार्य (_W):"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "जिप/डाक कूट (_Z):"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "शिशु अप्रत्याशित रूप सँ बाहर निकलि गेल "
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO चैनल बन्न नहि कए सकल: %s"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO चैनल बन्न नहि कए सकल: %s"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr ""
+#~ "अहाँक कूटशब्द बदलल गेल अछि किएक अहाँ आरंभिक रूप सँ सत्यापित कएल गेल अछि! फिनु "
+#~ "सत्यापित करू."
+
+#~ msgid "That password was incorrect."
+#~ msgstr "कूटशब्द गलत छल."
+
+#~ msgid "Your password has been changed."
+#~ msgstr "अहाँक कूटशब्द बदएल देल गेल अछि."
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "सिस्टम त्रुटि: %s."
+
+#~ msgid "The password is too simple."
+#~ msgstr "कूटशब्द काफी आसान अछि"
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "पुरान आ नवीन कूटशब्द काफी समान अछि"
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "नवीन कूटशब्दकेँ जरूर सँख्या अथवा विशेष संप्रतीक सामिल रखनाइ चाही."
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "पुरान आ नवीन कूटशब्द समान अछि"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "बैकेंड शुरू करबमे विफल"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "सिस्टम त्रुटि पैदा भेल"
+
+#~ msgid "Checking password..."
+#~ msgstr "कूटशब्द जाँचि रहल अछि..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "कूटशब्द बदलब क'लेल <b>कूटशब्द बदलू</b> पर क्लिक करू."
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "<b>नवीन कूटशब्द</b> क्षेत्रमे अपन कूटशब्द टाइप करू."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "दुइ कूटशब्द समान नहि अछि."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "बन्न कए लॉगआउट करू (_L)"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "सहायक तकनीक सक्षम करू (_E)"
+
+#~ msgid "Font may be too large"
+#~ msgstr "फोन्ट साइत बहुत पैघ अछि"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "संस्थापित करब लेल कोनो प्रसंग क' फ़ाइलनाम निर्दिष्ट करू"
+
+#~ msgid "page"
+#~ msgstr "पृष्ठ"
+
+#~ msgid "Custom"
+#~ msgstr "पसंदीदा"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>पूर्वावलोकन</b>"
+
+#~ msgid "Best _shapes"
+#~ msgstr "बढ़ियाँ आकार (_s)"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "सबसँ बढ़ियाँ विरोध (_n)"
+
+#~ msgid "C_ut"
+#~ msgstr "काटू (_u)"
+
+#~ msgid "D_etails..."
+#~ msgstr "विवरण... (_t)"
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "डेस्कटोप फोन्ट (_k):"
+
+#~ msgid "Fonts"
+#~ msgstr "फ़ॉन्ट"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "ग्रेस्केल (_r)"
+
+#~ msgid "Icons"
+#~ msgstr "प्रतीक"
+
+#~ msgid "Interface"
+#~ msgstr "अंतरफलक"
+
+#~ msgid "N_one"
+#~ msgstr "किछु नहि (_o)"
+
+#~ msgid "New File"
+#~ msgstr "नवीन फ़ाइल"
+
+#~ msgid "Open File"
+#~ msgstr "फाइल खोलू"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "रँग निर्दिष्ट करब लेल एकटा समाद खोलू"
+
+#~ msgid "R_esolution:"
+#~ msgstr "रेज़ोल्यूशन (_R):"
+
+#~ msgid "Save File"
+#~ msgstr "फ़ाइल सहेजू"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "प्रसंग एहन सहेजू..."
+
+#~ msgid "Save _As..."
+#~ msgstr "एहन सहेजू... (_A)"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "मेनूमे आइकन देखाबू (_i)"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "सब-पिक्सल (LCD) (_p)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "सब-पिक्सल चिकनापन (LCD) (_p)"
+
+#~ msgid "Text"
+#~ msgstr "पाठ"
+
+#~ msgid "Theme"
+#~ msgstr "प्रसंग"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "अओजारपट्टी बटन लेबल (_b):"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "Window Border"
+#~ msgstr "विंडो किनार"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "वर्णन (_D):"
+
+#~ msgid "_Document font:"
+#~ msgstr "दस्ताबेज फोन्ट (_D):"
+
+#~ msgid "_File"
+#~ msgstr "फाइल (_F)"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "सटीक चओड़ाइ फोन्ट (_F)"
+
+#~ msgid "_Install..."
+#~ msgstr "संस्थापित करू (_I)"
+
+#~ msgid "_Monochrome"
+#~ msgstr "एकरँग (_M)"
+
+#~ msgid "_New"
+#~ msgstr "नवीन (_N)"
+
+#~ msgid "_Paste"
+#~ msgstr "साटू (_P)"
+
+#~ msgid "_Print"
+#~ msgstr "छापू (_P)"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Size:"
+#~ msgstr "आकार (_S):"
+
+#~ msgid "_Slight"
+#~ msgstr "कम (_S)"
+
+#~ msgid "_Style:"
+#~ msgstr "शैली (_S):"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "विंडो शीर्षक फोन्ट (_W)"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Windows:"
+
+#~ msgid "dots per inch"
+#~ msgstr "बिन्दु प्रति इंच"
+
+#~ msgid "Slide Show"
+#~ msgstr "स्लाइड शो"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "पिक्सेल"
+#~ msgstr[1] "पिक्सेल"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "मोजुदा प्रसंग राखू"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "नवीन प्रसंग लागू करू"
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "Gnome प्रसंग %s ठीक सँ संस्थापित अछि"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "अस्थायी निर्देशिका बनाबैमे विफल"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "संस्थापित करब लेल कोनो प्रसंग फ़ाइल स्थान निर्दिष्ट नहि कएल अछि"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "एकरामे प्रसंग दएमे अपर्याप्त अनुमति:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "प्रसंग चुनू"
+
+#, c-format
+#~ msgid "Theme name must be present"
+#~ msgstr "प्रसंग नाम मोजुद होनाइ चाही"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "प्रसंग पहिले सँ मोजुद अछि की अहाँ एकरा स्थानांतरित कएनाइ चाहैत अछि?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "मेटाए कए लिखू (_O)"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "विन्यास प्रबंधक 'गनोम-विन्यास-डेमन' प्रारंभ करबमे अक्षम.\n"
+#~ "गनोम विन्यास प्रबंधक प्रारंभ नहि रहब पर किछु वरीयतासभ परिणाम नहि देत. ई बोनोबो "
+#~ "क' सँग समस्या क' कारण भ' सकैत अछि अथवा गैर गनोम (जहिना केडीई) विन्यास प्रबंधक "
+#~ "पहिले सँ प्रारंभ हुए आओर गनोम विन्यास प्रबंधक परस्पर विरोध कए रहल हाएत."
+
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "'%s' स्टॉक आइकन लोड करबमे असमर्थ\n"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "मद्दति देखाबैमे कोनो त्रुटि भेल: %s"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "फाइल कॉपी कए रहल अछि %u %u क'"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' कॉपी कए रहल अछि"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "संवाद क' जनक विंडो"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI वर्तमानमे एतय सँ स्थानांतरित कए रहल"
+
+#~ msgid "To URI"
+#~ msgstr "URI केँ"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI वर्तमानमे एतय स्थानांतरित कए रहल"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "वर्तमानमे पूर्ण भेल स्थानांतरण क' अंश"
+
+#~ msgid "Current URI index"
+#~ msgstr "वर्तमान URI सूची"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "वर्तमान URI सूची - 1 सँ प्रारंभ"
+
+#~ msgid "Total URIs"
+#~ msgstr "कुल URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "कुल URI क्रमांक"
+
+#~ msgid "_Skip"
+#~ msgstr "छोड़ू (_S)"
+
+#~ msgid "Key"
+#~ msgstr "कुँजी"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "जी-कान्फ़ कुँजी जकरामे गुण संपादक संलग्न अछि"
+
+#~ msgid "Callback"
+#~ msgstr "कॉलबैक"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "जखन एहि कुँजी क' सम्बद्ध मूल्य बदलैत अछि तँ कॉलबैक जारी करू"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr "लागू करब पर जी-कान्फ़ चेंज सेट जकरामे डाटा मिलल अछि जी-कान्फ़ क्लाइन्टकेँ भेजू."
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "विज़ेट कॉलबैकमे परिवर्तन"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "जखन डाटा जी-कान्फ़ सँ विज़ेटमे बदलल जएनाइ हुए तँ कॉलबैक जारी करू"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "विज़ेट कॉलबैकसँ परिवर्तन"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "जखन डाटा विज़ेट सँ जी-कान्फ़मे बदलल जएनाइ हुए तँ कॉलबैक जारी करू"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "आब्जेक्ट जे गुण नियंत्रण करैत अछि (सामान्यतः एकटा विज़ेट)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "गुण संपादक वस्तु डाटा"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "निर्दिष्ट गुण संपादक द्वारा चाहल गेल अनुकूलित डाटा"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "गुण संपादक डाटा मुक्त करैत छी कॉलबैक"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "गुण संपादक वस्तु डाटा जखन मुक्त करब हुए तँ कॉलबैक जारी कएल जाए"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "फ़ाइल '%s' खोजि नहि सकल. \n"
+#~ "कृप्या सुनिश्चित करू जे ई मोजुद अछि \n"
+#~ "फिनु कोशिश करू अथवा आन पृष्ठ भूमि बिंब चुनू."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "हमरा मालूम नहि अछि जे फ़ाइल '%s' कहिना खोलल जाएत अछि. \n"
+#~ "संभवतः ई ओहि प्रकार क' बिंब अछि जे अखन समर्थित नहि अछि.\n"
+#~ "\n"
+#~ "कृप्या बदलामे कोनो आन बिंब चुनू."
+
+#~ msgid "Please select an image."
+#~ msgstr "कृप्या कोनो बिंब चुनू."
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "मूलभूत संकेतक - वर्तमान"
+
+#~ msgid "White Pointer"
+#~ msgstr "उज्जर संकेतक"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "उज्जर संकेतक - वर्तमान"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "पैघ संकेतक - वर्तमान"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "पैघ उज्जर संकेतक -वर्तमान"
+
+#~ msgid "Select your default applications"
+#~ msgstr "अपन मूलभूत अनुप्रयोग चुनू"
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "विन्यास सहेजएमे त्रुटि: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "मुख्य अंतरफलक लोड नहि कए सकल"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>बिंब दर्शक</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>इंस्टैंट मैसेंजर</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>मेल रीडर</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>टर्मिनल इमेल्यूटर</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>पाठ संपादक</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>पाठ संपादक</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>वेब ब्राउज़र</b>"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "सबहि %s आवृतिकेँ वास्तविक लिंकसँ प्रतिस्थापित कएल जएताह"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "कमांड (_m):"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "फ्लैग चलाबू (_x):"
+
+#~ msgid "Internet"
+#~ msgstr "इंटरनेट"
+
+#~ msgid "Multimedia"
+#~ msgstr "मल्टीमीडिया"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "नवीन टैबमे लिंक खोलू (_t)"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "नवीन विंडोमे लिंक खोलू (_w)"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "मूलभूत वेब ब्रॉउजर सँ लिंक खोलू (_d)"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "टर्मिनलमे चलाबू (_e)"
+
+#~ msgid "Balsa"
+#~ msgstr "बाल्सा"
+
+#~ msgid "Claws Mail"
+#~ msgstr "क्लॉज मेल"
+
+#~ msgid "Dasher"
+#~ msgstr "डैशर"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "डेबियन संवेदनशील ब्राउज़र"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "डेबियन टर्मिनल एमुलेटर"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "एनकम्पास"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "एवॉल्यूशन मेल रीडर"
+
+#~ msgid "Firebird"
+#~ msgstr "फ़ायरबर्ड"
+
+#~ msgid "Firefox"
+#~ msgstr "फ़ायरफ़ॉक्स"
+
+#~ msgid "Galeon"
+#~ msgstr "गेलियन"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "ग्नोपरनिकस"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "Konqueror"
+#~ msgstr "कोन्करर"
+
+#~ msgid "Mozilla"
+#~ msgstr "मोजिला"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "मोज़िला 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "मोज़िला मेल"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "मोजिला थंडरबर्ड"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "नेटस्केप कम्यूनिकेटर"
+
+#~ msgid "Opera"
+#~ msgstr "ऑपेरा"
+
+#~ msgid "Orca"
+#~ msgstr "ओरका"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "मानक X-टर्मिनल"
+
+#~ msgid "Sylpheed"
+#~ msgstr "सिल्फीड"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "सिल्फीड क्लॉ"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "टोटेम मूवी चलाबै बला"
+
+#~ msgid "aterm"
+#~ msgstr "एटर्म"
+
+#~ msgid "Off"
+#~ msgstr "बन्न"
+
+#~ msgid "On"
+#~ msgstr "शुरू"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "स्क्रीन रिज़ोल्यूशन बदलू"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "Accelerator key"
+#~ msgstr "त्वरक कुँजी"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "त्वरक परिवर्धक"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "त्वरक कुँजीकोड"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "त्वरक प्रकार"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<अज्ञात क्रिया>"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "कमाँड लेल शार्टकट कुँजीसभ नियत करू"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "विन्यास लागू करू आओर बाहर होउ (सिर्फ सुसंगतता, आब डेमन द्वारा संभालल जएताह)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "टाइपिंग ब्रेक विन्यास देखबैत हुए पृष्ठ प्रारंभ करू"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>सामान्य</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>तेज़</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>नमहर</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>छोट</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>धीमा</i></small>"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "ब्रेक स्थगित कएनाइ स्वीकारू (_o)"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "जाँचू जे की ब्रेक स्थगित करब लेल स्वीकार्य अछि"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "कुँजीपटल मॉडल चुनू"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "एकटा लेआउट चुनू"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "जखन टाइपिंग स्वीकार्य नहि अछि तँ ब्रेक क' अवधि"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "ब्रेक बाध्य करब सँ पहिले कार्यावधि"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "विंडो शीर्षक-पट्टीकेँ चमकाबू (_w)"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "कुँजी पटल वरीयतासभ "
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "कुँजीपटल मॉडल (_m):"
+
+#~ msgid "Layouts"
+#~ msgstr "लेआउट"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "बारंबार कुँजीपटल उपयोग चोट सँ बचबाक लेल स्क्रीनकेँ एकटा निश्चित अवधि क' पश्चात् "
+#~ "तालाबन्न करू"
+
+#~ msgid "S_peed:"
+#~ msgstr "गति (_p):"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "ब्रेक अंतराल टिकैत अछि (_B)"
+
+#~ msgid "_Models:"
+#~ msgstr "मॉडल (_M):"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "चयनित लेआउट (_S):"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "जमावट जाँचबाक लेल टाइप करू (_T):"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "कार्य अंतराल टिकैत अछि (_W):"
+
+#~ msgid "Unknown"
+#~ msgstr "अज्ञात"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "कुँजी पटल क' वरीयतासभ नियत करू"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>घीँचू आओर छोड़ू</b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>संकेतक स्थिति देखाबू</b>"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "माउस वरीयतासभ "
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "संवेदनशीलता (_S):"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "अपन माउस क' वरीयतासभ नियत करू"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "संजाल प्रॉक्सी वरीयतासभ सेट करू"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>सीधा इंटरनेट कनेक्शन (_r)</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>स्वचालित प्रॉक्सी विन्यास (_A)</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b> हस्तचालित प्रॉक्सी विन्यास (_M)</b>"
+
+#~ msgid "C_reate"
+#~ msgstr "बनाबू (_r)"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP प्रॉक्सी विवरण"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "संजाल प्रॉक्सी वरीयतासभ "
+
+#~ msgid "Port:"
+#~ msgstr "पोर्टः"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "सुरक्षित HTTP प्रॉक्सी (_S):"
+
+#~ msgid "C_ontrol"
+#~ msgstr "नियंत्रित करू (_o)"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "हाइपर (_y)"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "सुपर (अथवा \"विंडोज़ लोगो\") (_u)"
+
+#~ msgid "_Meta"
+#~ msgstr "मेटा (_M)"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>गतिविधि कुँजीसभ</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>शीर्षकपट्टी क्रिया</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>विन्डो चयन</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "कोनो विंडोकेँ घसकाबै लेल एहि कुँजीकेँ दाबने राखू फिनु विंडो पकड़ू"
+
+#~ msgid "Window Preferences"
+#~ msgstr "विंडो वरीयतासभ "
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "एहि क्रिया लेल शीर्षकपट्टीकेँ दोहरा क्लिक करू (_D):"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "उठाबैसँ पहिले अन्तराल (_I):"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "एकटा अन्तराल क' बाद चुनल गेल विंडोज़केँ उप्पर उठाबू (_R)"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "जखन माउस विंडोज़ पर घूमेताह तँ ओकरा चुनू (_S)"
+
+#~ msgid "Set your window properties"
+#~ msgstr "अपन विंडो गुण सेट करू"
+
+#, c-format
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>%s आरंभ करू</b>"
+
+#~ msgid "Upgrade"
+#~ msgstr "उन्नत बनाबू "
+
+#~ msgid "Uninstall"
+#~ msgstr "विसंस्थापित करू"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "आरंभन प्रोग्राम सँ हटाबू"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "आरंभन प्रोग्राममे जोड़ू"
+
+#, c-format
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>कोनो मेल नहि भेटल.</b> </span><span>\n"
+#~ "\n"
+#~ " अहाँक फिल्टर \"<b>%s</b>\" कोनो मद सँ नहि मेल करैत अछि.</span>"
+
+#~ msgid "New Document"
+#~ msgstr "नवीन दस्तावेज"
+
+#~ msgid "Home"
+#~ msgstr "घर"
+
+#~ msgid "Documents"
+#~ msgstr "दस्तावेज़"
+
+#~ msgid "Send To..."
+#~ msgstr "एकरामे भेजू..."
+
+#~ msgid "Delete"
+#~ msgstr "मेटाबू"
+
+#, c-format
+#~ msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgstr "की अहाँ सुनिश्चित छी जे अहाँ \"%s\"केँ स्थायी तौर पर मेटओनाइ चाहैत अछि?"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "जँ अहाँ कोनो वस्तुकेँ मेटाएब, तँ ई स्थाइ रूप सँ मेट जएताह."
+
+#, c-format
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>\"%s\" क' सँग खोलू</b>"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "फाइल मैनेजरमे खोलू"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "आइ %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "कालि %l:%M %p"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%b %d %l:%M %p"
+
+#~ msgid "%b %d %Y"
+#~ msgstr "%b %d %Y"
+
+#~ msgid "Find Now"
+#~ msgstr "आब खोजू"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "विंडो प्रबंधक \"%s\" ने विन्यास अओजार रजिस्टर नहि कएने अछि\n"
+
+#~ msgid "Maximize"
+#~ msgstr "अधिकतम"
+
+#~ msgid "Minimize"
+#~ msgstr "छोट करू"
+
+#~ msgid "Roll up"
+#~ msgstr "रोल अप"
+
+#, c-format
+#~ msgid "key not found [%s]\n"
+#~ msgstr "कुँजी नहि भेटल [%s]\n"
+
+#~ msgid "Groups"
+#~ msgstr "समूह"
+
+#~ msgid "Control Center"
+#~ msgstr "नियंत्रण केंद्र"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "गनोम विन्यास अओजार"
+
+#~ msgid "Take a break!"
+#~ msgstr "एकटा ब्रेक लिअ'!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/एकटा ब्रेक लिअ'(_T)"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "अगिला ब्रेक तक %d मिनट"
+#~ msgstr[1] "अगिला ब्रेक तक %d मिनट"
+
+#, c-format
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "अगिला ब्रेक क' लेल एक मिनट सँ कम समय"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr "टाइपिंग ब्रेक गुण समाद लाबैमे निम्न त्रुटि क' सँग असफल: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "रिचर्ड हुल्ट <richard@imendio.com> द्वारा लिखित"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "ऑन्देर्स कार्लसन द्वारा आई कैण्डी जोड़ल गेल अछि"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "कम्प्यूटर ब्रेक स्मरण."
+
+#~ msgid "translator-credits"
+#~ msgstr "संगीता कुमारी (sangeeta09@gmail.com)"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "डिबगिंग कोड सक्रिय करू"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "टाइपिंग निरीक्षक सूचना देखाबै क'लेल सूचना क्षेत्र क' प्रयोग करैत अछि अहाँ अपन पटल पर "
+#~ "सूचना क्षेत्रकेँ नहि राखैत प्रतीत हाएत अछि. अहाँ अपन पटल पर दहिन्ना क्लिक कए क' आओर "
+#~ "'पटलमे जोड़ू' चुनि कए, सूचना क्षेत्र आओर जोड़ू पर क्लिक कए क'."
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "जँ सही पर नियत कएल जाएत अछि, ओपन-टाइप फोन्ट क' लघु बिंब बनाओल जाएत."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "जँ सही पर नियत कएल जाएत अछि, पीसीएफ़ फोन्ट क' लघु बिंब बनाओल जाएत."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "जँ सही पर नियत कएल जाएत अछि, ट्रू-टाइप फोन्ट क' लघु बिंब बनाओल जाएत."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "जँ सही पर नियत कएल जाएत अछि, टाइप1 फोन्ट क' लघु बिंब बनाओल जाएत."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr "एहि कुँजीकेँ ओपन टाइप फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "एहि कुँजीकेँ पीसीएफ़ फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr "एहि कुँजीकेँ ट्रू टाइप फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "एहि कुँजीकेँ टाइप1 फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "ओपन टाइप फोन्ट लेल लघु बिंब बनाबै क' कमांड"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "पीसीएफ़ फोन्ट लेल लघु बिंब बनाबै क' कमांड"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "ट्रू टाइप फोन्ट लेल लघु बिंब बनाबै क' कमांड"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "टाइप1 फोन्ट लेल लघु बिंब कमांड"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "की ओपन टाइप फोन्ट क' लघु बिंब बनाबू "
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "की पीसीएफ़ फोन्ट क' लघु बिंब बनाबू "
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "की ट्रू टाइप फोन्ट क' लघु बिंब बनाबू "
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "की टाइप 1 फोन्ट क' लघु बिंब बनाबू "
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr ""
+#~ "सक्कय वाणी बहुजन भाबए, पाउय रसको मम्म न पाबए। देसिल बयना सब जन मिट्ठा, तैँ तैसन "
+#~ "जम्पओ अवहट्ठा।। ०१२३४५६७८९"
+
+#~ msgid "Size:"
+#~ msgstr "आकार:"
+
+#~ msgid "Copyright:"
+#~ msgstr "कॉपीराइट:"
+
+#~ msgid "Description:"
+#~ msgstr "विवरण:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "उपयोग: %s फोन्ट-फ़ाइल\n"
+
+#~ msgid "TEXT"
+#~ msgstr "पाठ"
+
+#~ msgid "SIZE"
+#~ msgstr "आकार"

--- a/po/mai.po~
+++ b/po/mai.po~
@@ -1,0 +1,3467 @@
+# translation of gnome-control-center.HEAD.po to Maithili
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Sangeeta Kumari <sangeeta09@gmail.com>, 2009.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.HEAD\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&component=general\n"
+"POT-Creation-Date: 2009-03-14 17:01+0000\n"
+"PO-Revision-Date: 2009-03-15 16:11+0530\n"
+"Last-Translator: Sangeeta Kumari <sangeeta09@gmail.com>\n"
+"Language-Team: Maithili <maithili.sf.net>\n"
+"Language: mai\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"\n"
+"X-Generator: KBabel 1.11.4\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "चित्र/लेबल किनार"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "चेतावनी संवादमे लेबल आ चित्रक चारि तरफ किनारक चओड़ाइ"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "चेतावनीक प्रकार"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "चेतावनीक प्रकार"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "चेतावनीक बटन"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "चेतावनी संवादमे प्रदर्शित बटन"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "बेसी विवरण देखाबू (_d)"
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Place your left thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Swipe your left thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Place your left index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Swipe your left index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Place your left middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Swipe your left middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Place your left ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Swipe your left ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Place your left little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Swipe your left little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Place your right thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Swipe your right thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Place your right index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Swipe your right index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Place your right middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Swipe your right middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Place your right ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Swipe your right ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Place your right little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Swipe your right little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:72
+#: ../capplets/about-me/fingerprint-strings.h:98
+msgid "Place your finger on the reader again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:74
+#: ../capplets/about-me/fingerprint-strings.h:100
+msgid "Swipe your finger again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:77
+#: ../capplets/about-me/fingerprint-strings.h:103
+msgid "Swipe was too short, try again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:79
+#: ../capplets/about-me/fingerprint-strings.h:105
+msgid "Your finger was not centered, try swiping your finger again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:81
+#: ../capplets/about-me/fingerprint-strings.h:107
+msgid "Remove your finger, and try swiping your finger again"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:776
+msgid "Select Image"
+msgstr "बिंब चुनू"
+
+#: ../capplets/about-me/gnome-about-me.c:778
+msgid "No Image"
+msgstr "कोनो बिंब नहि"
+
+#: ../capplets/about-me/gnome-about-me.c:806
+#: ../capplets/appearance/appearance-desktop.c:660
+msgid "Images"
+msgstr "बिंब"
+
+#: ../capplets/about-me/gnome-about-me.c:810
+#: ../capplets/appearance/theme-installer.c:695
+msgid "All Files"
+msgstr "सबहि फ़ाइलसभ"
+
+#: ../capplets/about-me/gnome-about-me.c:956
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"एकटा गलती भेल पता पुस्तिका सूचनाकेँ पाबै क' कोशिशमे\n"
+"Evolution डाटा सर्वर प्रोटोकॉल नियंत्रित नहि कए सकत"
+
+#: ../capplets/about-me/gnome-about-me.c:977
+msgid "Unable to open address book"
+msgstr "पता पुस्तिका खोलबमे विफल"
+
+#: ../capplets/about-me/gnome-about-me.c:991
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr "अनजान लॉगिन ID, प्रयोक्ता डाटाबेस खराब भ' सकैत अछि"
+
+#: ../capplets/about-me/gnome-about-me.c:1021
+#: ../capplets/about-me/gnome-about-me.c:1023
+#, c-format
+msgid "About %s"
+msgstr "क' संबंधमे %s"
+
+#: ../capplets/about-me/gnome-about-me.c:1041
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Enable _Fingerprint Login..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:1044
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Disable _Fingerprint Login..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "About Me"
+msgstr "हमरा संबंधमे"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "निजी सूचना सेट करू"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
+msgid "The device is already in use."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:103
+msgid "An internal error occured"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:220
+msgid "Delete registered fingerprints?"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:223
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:230
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:343
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:583
+msgid "Done!"
+msgstr "पूर्ण!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
+#, c-format
+msgid "Could not access '%s' device"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:444
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:491
+msgid "Could not access any fingerprint readers"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:492
+msgid "Please contact your system administrator for help."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:518
+msgid "Enable Fingerprint Login"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:534
+msgid "Select finger"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:555
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:568
+msgid "Swipe finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:570
+msgid "Place finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:1
+msgid "Left index finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:2
+msgid ""
+"Left thumb\n"
+"Left middle finger\n"
+"Left ring finger\n"
+"Left little finger\n"
+"Right thumb\n"
+"Right middle finger\n"
+"Right ring finger\n"
+"Right little finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:10
+msgid "Other finger: "
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:11
+msgid "Right index finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:12
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+msgid "<b>Email</b>"
+msgstr "<b>इमेल</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+msgid "<b>Home</b>"
+msgstr "<b>घर</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>इंस्टेंट मैसेज</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Job</b>"
+msgstr "<b>कार्य</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Telephone</b>"
+msgstr "<b>टेलिफोन</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Web</b>"
+msgstr "<b>वेब</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Work</b>"
+msgstr "<b>कार्य</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+msgstr "<span size=\"larger\" weight=\"bold\"> अपन कूटशब्द बदलू</span>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "A_ddress:"
+msgstr "पता (_d):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_ssistant:"
+msgstr "सहायक (_s):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "Address"
+msgstr "पता"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "C_ity:"
+msgstr "शहर (_i):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "C_ompany:"
+msgstr "कंपनी (_o):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "Cale_ndar:"
+msgstr "कैलेंडर (_n):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "Change Passwo_rd..."
+msgstr "कूटशब्द बदलू (_r)..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Change pa_ssword"
+msgstr "कूटशब्द बदलू (_s)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change password"
+msgstr "कूटशब्द बदलू"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Ci_ty:"
+msgstr "शहर (_t):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Co_untry:"
+msgstr "देश (_u):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Contact"
+msgstr "संपर्क"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Cou_ntry:"
+msgstr "देश (_n):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Current _password:"
+msgstr "मोजुदा कूटशब्द (_p):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "Full Name"
+msgstr "पूरा नाम"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "Hom_e:"
+msgstr "घर (_e):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P.O. _box:"
+msgstr "P.O. _box:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "P._O. box:"
+msgstr "P._O. box:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "Personal Info"
+msgstr "निज सूचना"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#: ../capplets/about-me/gnome-about-me-password.c:938
+msgid ""
+"Please type your password again in the <b>Retype new password</b> field."
+msgstr "<b>नवीन कूटशब्द फिनु टाइफ करू</b> क्षेत्रमे अपन कूटशब्द टाइप फिनु करू."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Select your photo"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "State/Pro_vince:"
+msgstr "राज्य/क्षेत्र (_v):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid ""
+"To change your password, enter your current password in the field below and "
+"click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for "
+"verification and click <b>Change password</b>."
+msgstr ""
+"अपन कूटशब्द बदलब क' लेल, नीच्चाँ देल क्षेत्रमे अपन मोजुदा कूटशब्द दिअ' आओर <b>सत्यापित करू</"
+"b> क्लिक करू.\n"
+"अहाँक द्वारा सत्यापित कएल जाए क' बाद, अपन नवीन कूटशब्द दिअ'. एकरा प्रमाणित करब क' "
+"लेल फिनु टाइप करू आओर <b>कूटशब्द बदलू</b> क्लिक करू."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "User name:"
+msgstr "प्रयोक्ता नामः"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "Web _log:"
+msgstr "वेब लॉग (_l):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "Wor_k:"
+msgstr "कार्य (_k):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "Work _fax:"
+msgstr "कार्य फैक्स (_f):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "Zip/_Postal code:"
+msgstr "जिप/डाक कूट (_P):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Address:"
+msgstr "पता (_A):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Authenticate"
+msgstr "सत्यापित कएल (_A)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Department:"
+msgstr "विभाग (_D):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_Groupwise:"
+msgstr "समूह रूपमे (_G):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Home page:"
+msgstr "होम पेज (_H):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Home:"
+msgstr "घर (_H):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_Jabber:"
+msgstr "जैबर (_J):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Manager:"
+msgstr "प्रबंधक (_M):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Mobile:"
+msgstr "मोबाइल (_M):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_New password:"
+msgstr "नवीन कूटशब्द (_N):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Profession:"
+msgstr "व्यवसाय (_P): "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:55
+msgid "_Retype new password:"
+msgstr "नवीन कूटशब्द फिनु टाइप करू (_R):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:56
+msgid "_State/Province:"
+msgstr "राज्य (_S):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:57
+msgid "_Title:"
+msgstr "शीर्षक (_T):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:58
+msgid "_Work:"
+msgstr "कार्य (_W):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:59
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:60
+msgid "_Zip/Postal code:"
+msgstr "जिप/डाक कूट (_Z):"
+
+#: ../capplets/about-me/gnome-about-me-password.c:162
+msgid "Child exited unexpectedly"
+msgstr "शिशु अप्रत्याशित रूप सँ बाहर निकलि गेल "
+
+#: ../capplets/about-me/gnome-about-me-password.c:297
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr "backend_stdin IO चैनल बन्न नहि कए सकल: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:310
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr "backend_stdout IO चैनल बन्न नहि कए सकल: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:409
+msgid "Authenticated!"
+msgstr "सत्यापित!"
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:475
+#: ../capplets/about-me/gnome-about-me-password.c:551
+msgid ""
+"Your password has been changed since you initially authenticated! Please re-"
+"authenticate."
+msgstr ""
+"अहाँक कूटशब्द बदलल गेल अछि किएक अहाँ आरंभिक रूप सँ सत्यापित कएल गेल अछि! फिनु सत्यापित "
+"करू."
+
+#: ../capplets/about-me/gnome-about-me-password.c:477
+msgid "That password was incorrect."
+msgstr "कूटशब्द गलत छल."
+
+#: ../capplets/about-me/gnome-about-me-password.c:524
+msgid "Your password has been changed."
+msgstr "अहाँक कूटशब्द बदएल देल गेल अछि."
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:534
+#, c-format
+msgid "System error: %s."
+msgstr "सिस्टम त्रुटि: %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:537
+msgid "The password is too short."
+msgstr "कूटशब्द काफी छोट अछि"
+
+#: ../capplets/about-me/gnome-about-me-password.c:540
+msgid "The password is too simple."
+msgstr "कूटशब्द काफी आसान अछि"
+
+#: ../capplets/about-me/gnome-about-me-password.c:543
+msgid "The old and new passwords are too similar."
+msgstr "पुरान आ नवीन कूटशब्द काफी समान अछि"
+
+#: ../capplets/about-me/gnome-about-me-password.c:545
+msgid "The new password must contain numeric or special character(s)."
+msgstr "नवीन कूटशब्दकेँ जरूर सँख्या अथवा विशेष संप्रतीक सामिल रखनाइ चाही."
+
+#: ../capplets/about-me/gnome-about-me-password.c:548
+msgid "The old and new passwords are the same."
+msgstr "पुरान आ नवीन कूटशब्द समान अछि"
+
+#. translators: Unable to launch <program>: <error message>
+#: ../capplets/about-me/gnome-about-me-password.c:820
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:824
+msgid "Unable to launch backend"
+msgstr "बैकेंड शुरू करबमे विफल"
+
+#: ../capplets/about-me/gnome-about-me-password.c:825
+msgid "A system error has occurred"
+msgstr "सिस्टम त्रुटि पैदा भेल"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:845
+msgid "Checking password..."
+msgstr "कूटशब्द जाँचि रहल अछि..."
+
+#: ../capplets/about-me/gnome-about-me-password.c:932
+msgid "Click <b>Change password</b> to change your password."
+msgstr "कूटशब्द बदलब क'लेल <b>कूटशब्द बदलू</b> पर क्लिक करू."
+
+#: ../capplets/about-me/gnome-about-me-password.c:935
+msgid "Please type your password in the <b>New password</b> field."
+msgstr "<b>नवीन कूटशब्द</b> क्षेत्रमे अपन कूटशब्द टाइप करू."
+
+#: ../capplets/about-me/gnome-about-me-password.c:941
+msgid "The two passwords are not equal."
+msgstr "दुइ कूटशब्द समान नहि अछि."
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Assistive Technologies</b>"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Preferences</b>"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid "Accessible Lo_gin"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technologies Preferences"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid ""
+"Changes to enable assistive technologies will not take effect until your "
+"next log in."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Close and _Log Out"
+msgstr "बन्न कए लॉगआउट करू (_L)"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "Jump to Preferred Applications dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "Jump to the Accessible Login dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "Jump to the Mouse Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
+msgid "_Enable assistive technologies"
+msgstr "सहायक तकनीक सक्षम करू (_E)"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
+msgid "_Keyboard Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
+msgid "_Mouse Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
+msgid "_Preferred Applications"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Choose which accessibility features to enable when you log in"
+msgstr ""
+
+#: ../capplets/appearance/appearance-desktop.c:628
+msgid "Add Wallpaper"
+msgstr "वालपेपर जोड़ू"
+
+#: ../capplets/appearance/appearance-desktop.c:664
+msgid "All files"
+msgstr "सबहि फ़ाइल"
+
+#: ../capplets/appearance/appearance-font.c:494
+msgid "Font may be too large"
+msgstr "फोन्ट साइत बहुत पैघ अछि"
+
+#: ../capplets/appearance/appearance-font.c:498
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:511
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:534
+msgid "Use previous font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-font.c:536
+msgid "Use selected font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:124
+msgid "Specify the filename of a theme to install"
+msgstr "संस्थापित करब लेल कोनो प्रसंग क' फ़ाइलनाम निर्दिष्ट करू"
+
+#: ../capplets/appearance/appearance-main.c:125
+msgid "filename"
+msgstr "फाइलनाम"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/appearance/appearance-main.c:132
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:133
+#: ../capplets/default-applications/gnome-da-capplet.c:897
+#: ../capplets/mouse/gnome-mouse-properties.c:442
+msgid "page"
+msgstr "पृष्ठ"
+
+#: ../capplets/appearance/appearance-main.c:140
+msgid "[WALLPAPER...]"
+msgstr ""
+
+#: ../capplets/appearance/appearance-style.c:173
+#: ../capplets/common/gnome-theme-info.c:445
+#: ../capplets/common/gnome-theme-info.c:637
+msgid "Default Pointer"
+msgstr "मूलभूत संकेतक"
+
+#: ../capplets/appearance/appearance-style.c:235
+#: ../capplets/appearance/appearance-themes.c:687
+msgid "Install"
+msgstr "संस्थापित करू"
+
+#: ../capplets/appearance/appearance-style.c:255
+#: ../capplets/common/gnome-theme-info.c:1647
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme engine "
+"'%s' is not installed."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:675
+msgid "Apply Background"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:679
+msgid "Apply Font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:683
+msgid "Revert Font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:713
+msgid ""
+"The current theme suggests a background and a font. Also, the last applied "
+"font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:715
+msgid ""
+"The current theme suggests a background. Also, the last applied font "
+"suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:717
+msgid "The current theme suggests a background and a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:719
+msgid ""
+"The current theme suggests a font. Also, the last applied font suggestion "
+"can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:721
+msgid "The current theme suggests a background."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:723
+msgid "The last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:725
+msgid "The current theme suggests a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:1046
+#: ../capplets/default-applications/gnome-da-capplet.c:648
+msgid "Custom"
+msgstr "पसंदीदा"
+
+#: ../capplets/appearance/data/appearance.glade.h:1
+msgid "<b>C_olors</b>"
+msgstr ""
+
+#. font hinting
+#: ../capplets/appearance/data/appearance.glade.h:3
+msgid "<b>Hinting</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:4
+msgid "<b>Menus and Toolbars</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:5
+msgid "<b>Preview</b>"
+msgstr "<b>पूर्वावलोकन</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:6
+msgid "<b>Rendering</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:7
+msgid "<b>Smoothing</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:8
+msgid "<b>Subpixel Order</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:9
+msgid "<b>_Desktop Background</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:10
+msgid "Appearance Preferences"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:11
+msgid "Background"
+msgstr "पृष्ठभूमि"
+
+#: ../capplets/appearance/data/appearance.glade.h:12
+msgid "Best _shapes"
+msgstr "बढ़ियाँ आकार (_s)"
+
+#: ../capplets/appearance/data/appearance.glade.h:13
+msgid "Best co_ntrast"
+msgstr "सबसँ बढ़ियाँ विरोध (_n)"
+
+#: ../capplets/appearance/data/appearance.glade.h:14
+msgid "C_ustomize..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:15
+msgid "C_ut"
+msgstr "काटू (_u)"
+
+#: ../capplets/appearance/data/appearance.glade.h:16
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:17
+msgid "Colors"
+msgstr "रँग"
+
+#: ../capplets/appearance/data/appearance.glade.h:18
+msgid "Controls"
+msgstr "नियंत्रण"
+
+#: ../capplets/appearance/data/appearance.glade.h:19
+msgid "Customize Theme"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:20
+msgid "D_etails..."
+msgstr "विवरण... (_t)"
+
+#: ../capplets/appearance/data/appearance.glade.h:21
+msgid "Des_ktop font:"
+msgstr "डेस्कटोप फोन्ट (_k):"
+
+#: ../capplets/appearance/data/appearance.glade.h:22
+msgid "Edit"
+msgstr "संपादन"
+
+#: ../capplets/appearance/data/appearance.glade.h:23
+msgid "Font Rendering Details"
+msgstr "फोन्ट रेंडरिंग विवरण"
+
+#: ../capplets/appearance/data/appearance.glade.h:24
+msgid "Fonts"
+msgstr "फ़ॉन्ट"
+
+#: ../capplets/appearance/data/appearance.glade.h:25
+msgid "Gra_yscale"
+msgstr "ग्रेस्केल (_r)"
+
+#: ../capplets/appearance/data/appearance.glade.h:26
+msgid "Icons"
+msgstr "प्रतीक"
+
+#: ../capplets/appearance/data/appearance.glade.h:27
+msgid "Interface"
+msgstr "अंतरफलक"
+
+#: ../capplets/appearance/data/appearance.glade.h:28
+msgid "Large"
+msgstr "पैघ"
+
+#: ../capplets/appearance/data/appearance.glade.h:29
+msgid "N_one"
+msgstr "किछु नहि (_o)"
+
+#: ../capplets/appearance/data/appearance.glade.h:30
+msgid "New File"
+msgstr "नवीन फ़ाइल"
+
+#: ../capplets/appearance/data/appearance.glade.h:31
+msgid "Open File"
+msgstr "फाइल खोलू"
+
+#: ../capplets/appearance/data/appearance.glade.h:32
+msgid "Open a dialog to specify the color"
+msgstr "रँग निर्दिष्ट करब लेल एकटा समाद खोलू"
+
+#: ../capplets/appearance/data/appearance.glade.h:33
+msgid "Pointer"
+msgstr "प्वाइंटर"
+
+#: ../capplets/appearance/data/appearance.glade.h:34
+msgid "R_esolution:"
+msgstr "रेज़ोल्यूशन (_R):"
+
+#: ../capplets/appearance/data/appearance.glade.h:35
+msgid "Save File"
+msgstr "फ़ाइल सहेजू"
+
+#: ../capplets/appearance/data/appearance.glade.h:36
+msgid "Save Theme As..."
+msgstr "प्रसंग एहन सहेजू..."
+
+#: ../capplets/appearance/data/appearance.glade.h:37
+msgid "Save _As..."
+msgstr "एहन सहेजू... (_A)"
+
+#: ../capplets/appearance/data/appearance.glade.h:38
+msgid "Save _background image"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:39
+msgid "Show _icons in menus"
+msgstr "मेनूमे आइकन देखाबू (_i)"
+
+#: ../capplets/appearance/data/appearance.glade.h:40
+msgid "Small"
+msgstr "छोट"
+
+#: ../capplets/appearance/data/appearance.glade.h:41
+msgid ""
+"Solid color\n"
+"Horizontal gradient\n"
+"Vertical gradient"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:44
+msgid "Sub_pixel (LCDs)"
+msgstr "सब-पिक्सल (LCD) (_p)"
+
+#: ../capplets/appearance/data/appearance.glade.h:45
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "सब-पिक्सल चिकनापन (LCD) (_p)"
+
+#: ../capplets/appearance/data/appearance.glade.h:46
+msgid "Text"
+msgstr "पाठ"
+
+#: ../capplets/appearance/data/appearance.glade.h:47
+msgid ""
+"Text below items\n"
+"Text beside items\n"
+"Icons only\n"
+"Text only"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:51
+msgid "The current controls theme does not support color schemes."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:52
+msgid "Theme"
+msgstr "प्रसंग"
+
+#: ../capplets/appearance/data/appearance.glade.h:53
+msgid ""
+"Tiled\n"
+"Zoom\n"
+"Centered\n"
+"Scaled\n"
+"Fill screen"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:58
+msgid "Toolbar _button labels:"
+msgstr "अओजारपट्टी बटन लेबल (_b):"
+
+#. vertical hinting, pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:60
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/appearance/data/appearance.glade.h:61
+msgid "Window Border"
+msgstr "विंडो किनार"
+
+#: ../capplets/appearance/data/appearance.glade.h:62
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
+msgid "_Add..."
+msgstr "जोड़ू (_A)..."
+
+#: ../capplets/appearance/data/appearance.glade.h:63
+msgid "_Application font:"
+msgstr "अनुप्रयोग फोन्ट (_A):"
+
+#. pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:65
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/appearance/data/appearance.glade.h:66
+msgid "_Copy"
+msgstr "कॉपी करू (_C)"
+
+#: ../capplets/appearance/data/appearance.glade.h:67
+msgid "_Description:"
+msgstr "वर्णन (_D):"
+
+#: ../capplets/appearance/data/appearance.glade.h:68
+msgid "_Document font:"
+msgstr "दस्ताबेज फोन्ट (_D):"
+
+#: ../capplets/appearance/data/appearance.glade.h:69
+msgid "_Editable menu shortcut keys"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:70
+msgid "_File"
+msgstr "फाइल (_F)"
+
+#: ../capplets/appearance/data/appearance.glade.h:71
+msgid "_Fixed width font:"
+msgstr "सटीक चओड़ाइ फोन्ट (_F)"
+
+#: ../capplets/appearance/data/appearance.glade.h:72
+msgid "_Full"
+msgstr "पूरा (_F)"
+
+#: ../capplets/appearance/data/appearance.glade.h:73
+msgid "_Input boxes:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:74
+msgid "_Install..."
+msgstr "संस्थापित करू (_I)"
+
+#: ../capplets/appearance/data/appearance.glade.h:75
+msgid "_Medium"
+msgstr "मध्यम (_M)"
+
+#: ../capplets/appearance/data/appearance.glade.h:76
+msgid "_Monochrome"
+msgstr "एकरँग (_M)"
+
+#: ../capplets/appearance/data/appearance.glade.h:77
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:5
+msgid "_Name:"
+msgstr "नाम (_N):"
+
+#: ../capplets/appearance/data/appearance.glade.h:78
+msgid "_New"
+msgstr "नवीन (_N)"
+
+#: ../capplets/appearance/data/appearance.glade.h:79
+msgid "_None"
+msgstr "किछु नहि (_N)"
+
+#: ../capplets/appearance/data/appearance.glade.h:80
+msgid "_Open"
+msgstr "खोलू (_O)"
+
+#: ../capplets/appearance/data/appearance.glade.h:81
+msgid "_Paste"
+msgstr "साटू (_P)"
+
+#: ../capplets/appearance/data/appearance.glade.h:82
+msgid "_Print"
+msgstr "छापू (_P)"
+
+#: ../capplets/appearance/data/appearance.glade.h:83
+msgid "_Quit"
+msgstr "बाहर (_Q)"
+
+#. pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:85
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:86
+msgid "_Reset to Defaults"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:87
+msgid "_Save"
+msgstr "सहेजू (_S)"
+
+#: ../capplets/appearance/data/appearance.glade.h:88
+msgid "_Selected items:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:89
+msgid "_Size:"
+msgstr "आकार (_S):"
+
+#: ../capplets/appearance/data/appearance.glade.h:90
+msgid "_Slight"
+msgstr "कम (_S)"
+
+#: ../capplets/appearance/data/appearance.glade.h:91
+msgid "_Style:"
+msgstr "शैली (_S):"
+
+#: ../capplets/appearance/data/appearance.glade.h:92
+msgid "_Tooltips:"
+msgstr ""
+
+#. vertical hinting, pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:94
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:95
+msgid "_Window title font:"
+msgstr "विंडो शीर्षक फोन्ट (_W)"
+
+#: ../capplets/appearance/data/appearance.glade.h:96
+msgid "_Windows:"
+msgstr "_Windows:"
+
+#: ../capplets/appearance/data/appearance.glade.h:97
+msgid "dots per inch"
+msgstr "बिन्दु प्रति इंच"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr "प्रकटन"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-info.c:50
+msgid "No Desktop Background"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:208
+msgid "Slide Show"
+msgstr "स्लाइड शो"
+
+#. translators: <b>wallpaper name</b>
+#. * mime type, x pixel(s) by y pixel(s)
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:216
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %d %s by %d %s\n"
+"Folder: %s"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:222
+#: ../capplets/appearance/gnome-wp-item.c:224
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "पिक्सेल"
+msgstr[1] "पिक्सेल"
+
+#: ../capplets/appearance/theme-installer.c:174
+#: ../capplets/appearance/theme-installer.c:224
+msgid "Cannot install theme"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:176
+#, c-format
+msgid "The %s utility is not installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:226
+msgid "There was a problem while extracting the theme."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:249
+msgid "There was an error installing the selected file"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:250
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:251
+#, c-format
+msgid ""
+"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
+"you need to compile."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:354
+#, c-format
+msgid "Installation for theme \"%s\" failed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:393
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:398
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:400
+msgid "Keep Current Theme"
+msgstr "मोजुदा प्रसंग राखू"
+
+#: ../capplets/appearance/theme-installer.c:402
+msgid "Apply New Theme"
+msgstr "नवीन प्रसंग लागू करू"
+
+#: ../capplets/appearance/theme-installer.c:446
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "Gnome प्रसंग %s ठीक सँ संस्थापित अछि"
+
+#: ../capplets/appearance/theme-installer.c:505
+msgid "Failed to create temporary directory"
+msgstr "अस्थायी निर्देशिका बनाबैमे विफल"
+
+#: ../capplets/appearance/theme-installer.c:568
+msgid "New themes have been successfully installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:593
+msgid "No theme file location specified to install"
+msgstr "संस्थापित करब लेल कोनो प्रसंग फ़ाइल स्थान निर्दिष्ट नहि कएल अछि"
+
+#: ../capplets/appearance/theme-installer.c:614
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"एकरामे प्रसंग दएमे अपर्याप्त अनुमति:\n"
+"%s"
+
+#: ../capplets/appearance/theme-installer.c:684
+msgid "Select Theme"
+msgstr "प्रसंग चुनू"
+
+#: ../capplets/appearance/theme-installer.c:688
+msgid "Theme Packages"
+msgstr ""
+
+#: ../capplets/appearance/theme-save.c:93
+#, c-format
+msgid "Theme name must be present"
+msgstr "प्रसंग नाम मोजुद होनाइ चाही"
+
+#: ../capplets/appearance/theme-save.c:156
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "प्रसंग पहिले सँ मोजुद अछि की अहाँ एकरा स्थानांतरित कएनाइ चाहैत अछि?"
+
+#: ../capplets/appearance/theme-save.c:157
+#: ../capplets/common/file-transfer-dialog.c:450
+msgid "_Overwrite"
+msgstr "मेटाए कए लिखू (_O)"
+
+#: ../capplets/appearance/theme-util.c:75
+msgid "Would you like to delete this theme?"
+msgstr ""
+
+#: ../capplets/appearance/theme-util.c:125
+msgid "Theme cannot be deleted"
+msgstr ""
+
+#: ../capplets/appearance/theme-util.c:252
+msgid "Could not install theme engine"
+msgstr ""
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"विन्यास प्रबंधक 'गनोम-विन्यास-डेमन' प्रारंभ करबमे अक्षम.\n"
+"गनोम विन्यास प्रबंधक प्रारंभ नहि रहब पर किछु वरीयतासभ परिणाम नहि देत. ई बोनोबो क' "
+"सँग समस्या क' कारण भ' सकैत अछि अथवा गैर गनोम (जहिना केडीई) विन्यास प्रबंधक पहिले सँ "
+"प्रारंभ हुए आओर गनोम विन्यास प्रबंधक परस्पर विरोध कए रहल हाएत."
+
+#: ../capplets/common/capplet-stock-icons.c:66
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "'%s' स्टॉक आइकन लोड करबमे असमर्थ\n"
+
+#: ../capplets/common/capplet-util.c:88
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "मद्दति देखाबैमे कोनो त्रुटि भेल: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:98
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "फाइल कॉपी कए रहल अछि %u %u क'"
+
+#: ../capplets/common/file-transfer-dialog.c:145
+#, c-format
+msgid "Copying '%s'"
+msgstr "'%s' कॉपी कए रहल अछि"
+
+#: ../capplets/common/file-transfer-dialog.c:185
+#: ../capplets/common/file-transfer-dialog.c:312
+msgid "Copying files"
+msgstr "फ़ाइलसभ कॉपी कए रहल अछि"
+
+#: ../capplets/common/file-transfer-dialog.c:224
+msgid "Parent Window"
+msgstr "जनक विंडो"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Parent window of the dialog"
+msgstr "संवाद क' जनक विंडो"
+
+#: ../capplets/common/file-transfer-dialog.c:231
+msgid "From URI"
+msgstr "URI सँ"
+
+#: ../capplets/common/file-transfer-dialog.c:232
+msgid "URI currently transferring from"
+msgstr "URI वर्तमानमे एतय सँ स्थानांतरित कए रहल"
+
+#: ../capplets/common/file-transfer-dialog.c:239
+msgid "To URI"
+msgstr "URI केँ"
+
+#: ../capplets/common/file-transfer-dialog.c:240
+msgid "URI currently transferring to"
+msgstr "URI वर्तमानमे एतय स्थानांतरित कए रहल"
+
+#: ../capplets/common/file-transfer-dialog.c:247
+msgid "Fraction completed"
+msgstr "अंश पूर्ण"
+
+#: ../capplets/common/file-transfer-dialog.c:248
+msgid "Fraction of transfer currently completed"
+msgstr "वर्तमानमे पूर्ण भेल स्थानांतरण क' अंश"
+
+#: ../capplets/common/file-transfer-dialog.c:255
+msgid "Current URI index"
+msgstr "वर्तमान URI सूची"
+
+#: ../capplets/common/file-transfer-dialog.c:256
+msgid "Current URI index - starts from 1"
+msgstr "वर्तमान URI सूची - 1 सँ प्रारंभ"
+
+#: ../capplets/common/file-transfer-dialog.c:263
+msgid "Total URIs"
+msgstr "कुल URI"
+
+#: ../capplets/common/file-transfer-dialog.c:264
+msgid "Total number of URIs"
+msgstr "कुल URI क्रमांक"
+
+#: ../capplets/common/file-transfer-dialog.c:444
+#, c-format
+msgid "File '%s' already exists. Do you want to overwrite it?"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:447
+msgid "_Skip"
+msgstr "छोड़ू (_S)"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Overwrite _All"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:134
+msgid "Key"
+msgstr "कुँजी"
+
+#: ../capplets/common/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr "जी-कान्फ़ कुँजी जकरामे गुण संपादक संलग्न अछि"
+
+#: ../capplets/common/gconf-property-editor.c:141
+msgid "Callback"
+msgstr "कॉलबैक"
+
+#: ../capplets/common/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "जखन एहि कुँजी क' सम्बद्ध मूल्य बदलैत अछि तँ कॉलबैक जारी करू"
+
+#: ../capplets/common/gconf-property-editor.c:147
+msgid "Change set"
+msgstr "सेट बदलू"
+
+#: ../capplets/common/gconf-property-editor.c:148
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr "लागू करब पर जी-कान्फ़ चेंज सेट जकरामे डाटा मिलल अछि जी-कान्फ़ क्लाइन्टकेँ भेजू."
+
+#: ../capplets/common/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr "विज़ेट कॉलबैकमे परिवर्तन"
+
+#: ../capplets/common/gconf-property-editor.c:154
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "जखन डाटा जी-कान्फ़ सँ विज़ेटमे बदलल जएनाइ हुए तँ कॉलबैक जारी करू"
+
+#: ../capplets/common/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr "विज़ेट कॉलबैकसँ परिवर्तन"
+
+#: ../capplets/common/gconf-property-editor.c:160
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr "जखन डाटा विज़ेट सँ जी-कान्फ़मे बदलल जएनाइ हुए तँ कॉलबैक जारी करू"
+
+#: ../capplets/common/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "यूआइ नियंत्रण"
+
+#: ../capplets/common/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr "आब्जेक्ट जे गुण नियंत्रण करैत अछि (सामान्यतः एकटा विज़ेट)"
+
+#: ../capplets/common/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr "गुण संपादक वस्तु डाटा"
+
+#: ../capplets/common/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr "निर्दिष्ट गुण संपादक द्वारा चाहल गेल अनुकूलित डाटा"
+
+#: ../capplets/common/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr "गुण संपादक डाटा मुक्त करैत छी कॉलबैक"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr "गुण संपादक वस्तु डाटा जखन मुक्त करब हुए तँ कॉलबैक जारी कएल जाए"
+
+#: ../capplets/common/gconf-property-editor.c:1404
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"फ़ाइल '%s' खोजि नहि सकल. \n"
+"कृप्या सुनिश्चित करू जे ई मोजुद अछि \n"
+"फिनु कोशिश करू अथवा आन पृष्ठ भूमि बिंब चुनू."
+
+#: ../capplets/common/gconf-property-editor.c:1412
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"हमरा मालूम नहि अछि जे फ़ाइल '%s' कहिना खोलल जाएत अछि. \n"
+"संभवतः ई ओहि प्रकार क' बिंब अछि जे अखन समर्थित नहि अछि.\n"
+"\n"
+"कृप्या बदलामे कोनो आन बिंब चुनू."
+
+#: ../capplets/common/gconf-property-editor.c:1532
+msgid "Please select an image."
+msgstr "कृप्या कोनो बिंब चुनू."
+
+#: ../capplets/common/gconf-property-editor.c:1537
+msgid "_Select"
+msgstr "चुनू (_S)"
+
+#: ../capplets/common/gnome-theme-info.c:638
+msgid "Default Pointer - Current"
+msgstr "मूलभूत संकेतक - वर्तमान"
+
+#: ../capplets/common/gnome-theme-info.c:642
+msgid "White Pointer"
+msgstr "उज्जर संकेतक"
+
+#: ../capplets/common/gnome-theme-info.c:643
+msgid "White Pointer - Current"
+msgstr "उज्जर संकेतक - वर्तमान"
+
+#: ../capplets/common/gnome-theme-info.c:647
+msgid "Large Pointer"
+msgstr "पैघ संकेतक"
+
+#: ../capplets/common/gnome-theme-info.c:648
+msgid "Large Pointer - Current"
+msgstr "पैघ संकेतक - वर्तमान"
+
+#: ../capplets/common/gnome-theme-info.c:652
+msgid "Large White Pointer - Current"
+msgstr "पैघ उज्जर संकेतक -वर्तमान"
+
+#: ../capplets/common/gnome-theme-info.c:653
+msgid "Large White Pointer"
+msgstr "पैघ उज्जर संकेतक"
+
+#: ../capplets/common/gnome-theme-info.c:1623
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme '%s' is "
+"not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1631
+#, c-format
+msgid ""
+"This theme will not look as intended because the required window manager "
+"theme '%s' is not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1638
+#, c-format
+msgid ""
+"This theme will not look as intended because the required icon theme '%s' is "
+"not installed."
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Preferred Applications"
+msgstr "चहेता अनुप्रयोग"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "अपन मूलभूत अनुप्रयोग चुनू"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Start the preferred visual assistive technology"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:98
+#: ../capplets/default-applications/gnome-da-capplet.c:362
+#: ../capplets/default-applications/gnome-da-capplet.c:383
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "विन्यास सहेजएमे त्रुटि: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:668
+msgid "Could not load the main interface"
+msgstr "मुख्य अंतरफलक लोड नहि कए सकल"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:670
+msgid "Please make sure that the applet is properly installed"
+msgstr "सुनिश्चित करू जे ई एप्पलेट ठीकसँ संस्थापित अछि"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/default-applications/gnome-da-capplet.c:896
+msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:901
+msgid "- GNOME Default Applications"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Image Viewer</b>"
+msgstr "<b>बिंब दर्शक</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Instant Messenger</b>"
+msgstr "<b>इंस्टैंट मैसेंजर</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Mail Reader</b>"
+msgstr "<b>मेल रीडर</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mobility</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Multimedia Player</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>टर्मिनल इमेल्यूटर</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Text Editor</b>"
+msgstr "<b>पाठ संपादक</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Video Player</b>"
+msgstr "<b>पाठ संपादक</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "<b>Visual</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "<b>Web Browser</b>"
+msgstr "<b>वेब ब्राउज़र</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
+msgid "Accessibility"
+msgstr "अभिगम्यता"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "सबहि %s आवृतिकेँ वास्तविक लिंकसँ प्रतिस्थापित कएल जएताह"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+msgid "C_ommand:"
+msgstr "कमांड (_o):"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Co_mmand:"
+msgstr "कमांड (_m):"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "E_xecute flag:"
+msgstr "फ्लैग चलाबू (_x):"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Internet"
+msgstr "इंटरनेट"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Multimedia"
+msgstr "मल्टीमीडिया"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Open link in new _tab"
+msgstr "नवीन टैबमे लिंक खोलू (_t)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "Open link in new _window"
+msgstr "नवीन विंडोमे लिंक खोलू (_w)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid "Open link with web browser _default"
+msgstr "मूलभूत वेब ब्रॉउजर सँ लिंक खोलू (_d)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Run at st_art"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Run in t_erminal"
+msgstr "टर्मिनलमे चलाबू (_e)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "System"
+msgstr "सिस्टम"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "_Run at start"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "बाल्सा"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr "बंशी संगीत प्लेयर"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr "क्लॉज मेल"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr "डैशर"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr "डेबियन संवेदनशील ब्राउज़र"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr "डेबियन टर्मिनल एमुलेटर"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr "एनकम्पास"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr "एपीफेनी वेब ब्राउसर"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr "एवॉल्यूशन मेल रीडर"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr "फ़ायरबर्ड"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Firefox"
+msgstr "फ़ायरफ़ॉक्स"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr "गनोम टर्मिनल"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Galeon"
+msgstr "गेलियन"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Gnopernicus"
+msgstr "ग्नोपरनिकस"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Gnopernicus with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Iceape"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Iceape Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Icedove"
+msgstr "Icedove"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Iceweasel"
+msgstr "Iceweasel"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr "कोन्करर"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Konsole"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Listen"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Midori"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Mozilla"
+msgstr "मोजिला"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Mozilla 1.6"
+msgstr "मोज़िला 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Mozilla Mail"
+msgstr "मोज़िला मेल"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Mozilla Thunderbird"
+msgstr "मोजिला थंडरबर्ड"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Muine Music Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Netscape Communicator"
+msgstr "नेटस्केप कम्यूनिकेटर"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Opera"
+msgstr "ऑपेरा"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca"
+msgstr "ओरका"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "Orca with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+msgid "Rhythmbox Music Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+msgid "SeaMonkey"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+msgid "SeaMonkey Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Standard XTerminal"
+msgstr "मानक X-टर्मिनल"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+msgid "Sylpheed"
+msgstr "सिल्फीड"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+msgid "Sylpheed-Claws"
+msgstr "सिल्फीड क्लॉ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Terminator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Thunderbird"
+msgstr "थंडरबर्ड"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "Totem Movie Player"
+msgstr "टोटेम मूवी चलाबै बला"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
+msgid "aterm"
+msgstr "एटर्म"
+
+#: ../capplets/display/display-capplet.glade.h:1
+#: ../capplets/display/xrandr-capplet.c:461
+msgid "<b>Monitor</b>"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:2
+msgid "<b>Panel icon</b>"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:3
+msgid "<i>Drag the monitors to set their place</i>"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:4
+msgid "Display Preferences"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:5
+msgid "Include _panel"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:6
+msgid ""
+"Normal\n"
+"Left\n"
+"Right\n"
+"Upside-down\n"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:11
+msgid "Off"
+msgstr "बन्न"
+
+#: ../capplets/display/display-capplet.glade.h:12
+msgid "On"
+msgstr "शुरू"
+
+#: ../capplets/display/display-capplet.glade.h:13
+msgid "R_otation:"
+msgstr "घूर्णन (_o):"
+
+#: ../capplets/display/display-capplet.glade.h:14
+msgid "Re_fresh rate:"
+msgstr "ताज़ा करब क' दर (_f):"
+
+#: ../capplets/display/display-capplet.glade.h:15
+msgid "_Detect Monitors"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:16
+msgid "_Mirror screens"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:17
+msgid "_Resolution:"
+msgstr "रेज़ोल्यूशन (_R):"
+
+#: ../capplets/display/display-capplet.glade.h:18
+msgid "_Show displays in panel"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "स्क्रीन रिज़ोल्यूशन बदलू"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Display"
+msgstr "देखाबू"
+
+#: ../capplets/display/xrandr-capplet.c:328
+#: ../capplets/display/xrandr-capplet.c:367
+msgid "Normal"
+msgstr "सामान्य"
+
+#: ../capplets/display/xrandr-capplet.c:329
+msgid "Left"
+msgstr "बामाँ"
+
+#: ../capplets/display/xrandr-capplet.c:330
+msgid "Right"
+msgstr "दहिन्ना"
+
+#: ../capplets/display/xrandr-capplet.c:331
+msgid "Upside Down"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:404
+#: ../capplets/display/xrandr-capplet.c:412
+#: ../capplets/display/xrandr-capplet.c:413
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/xrandr-capplet.c:454
+#, c-format
+msgid "<b>Monitor: %s</b>"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:546
+#: ../capplets/display/xrandr-capplet.c:556
+#: ../capplets/display/xrandr-capplet.c:564
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../capplets/display/xrandr-capplet.c:1411
+msgid "Mirror Screens"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1730
+msgid "Could not apply the selected configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1757
+msgid "Could not save the monitor configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1768
+msgid "Could not get session bus while applying display configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1778
+msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1824
+msgid "Could not detect displays"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:2017
+msgid "Could not get screen information"
+msgstr ""
+
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+msgid "Sound"
+msgstr "ध्वनि"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+#: ../libslab/bookmark-agent.c:1146
+msgid "Desktop"
+msgstr "डेस्कटाप"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "त्वरक कुँजी"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "त्वरक परिवर्धक"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "त्वरक कुँजीकोड"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "त्वरक मोड"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "त्वरक प्रकार"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:103
+#: ../typing-break/drwright.c:479
+msgid "Disabled"
+msgstr "अक्षम"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:184
+msgid "<Unknown Action>"
+msgstr "<अज्ञात क्रिया>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:925
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1548
+msgid "Custom Shortcuts"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1064
+msgid "Error saving the new shortcut"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1143
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1173
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1179
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1187
+msgid "_Reassign"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1307
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1503
+msgid "Too many custom shortcuts"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1788
+msgid "Action"
+msgstr "क्रिया"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1810
+msgid "Shortcut"
+msgstr "शार्टकट"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid "Custom Shortcut"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:3
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "कुंजीपटल शार्टकट"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:4
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new key "
+"combination, or press backspace to clear."
+msgstr ""
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "कमाँड लेल शार्टकट कुँजीसभ नियत करू"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:206
+#: ../capplets/keyboard/gnome-keyboard-properties.c:211
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr "विन्यास लागू करू आओर बाहर होउ (सिर्फ सुसंगतता, आब डेमन द्वारा संभालल जएताह)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:216
+msgid "Start the page with the typing break settings showing"
+msgstr "टाइपिंग ब्रेक विन्यास देखबैत हुए पृष्ठ प्रारंभ करू"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+msgid "Start the page with the accessibility settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "- GNOME Keyboard Preferences"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+msgid "<b>Bounce Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>कर्सर टिमटिमओनाइ</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "<b>General</b>"
+msgstr "<b>सामान्य</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>दोहराव कुँजी</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Slow Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>Sticky Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<b>Visual cues for sounds</b>"
+msgstr ""
+
+#. fast acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>तेज़</i></small>"
+
+#. long delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>नमहर</i></small>"
+
+#. short delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>छोट</i></small>"
+
+#. slow acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>धीमा</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "A_cceleration:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "All_ow postponing of breaks"
+msgstr "ब्रेक स्थगित कएनाइ स्वीकारू (_o)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Audio _Feedback..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Beep when _accessibility features are turned on or off"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Beep when a _toggle key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Beep when a key is reje_cted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Beep when key is _accepted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Beep when key is _rejected"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "By _country"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "By _language"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Check if breaks are allowed to be postponed"
+msgstr "जाँचू जे की ब्रेक स्थगित करब लेल स्वीकार्य अछि"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Choose a Keyboard Model"
+msgstr "कुँजीपटल मॉडल चुनू"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Choose a Layout"
+msgstr "एकटा लेआउट चुनू"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Cursor _blinks in text fields"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
+msgid "Cursor blinks speed"
+msgstr "कर्सर ब्लिंक गति"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
+msgid "D_elay:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Duration of the break when typing is disallowed"
+msgstr "जखन टाइपिंग स्वीकार्य नहि अछि तँ ब्रेक क' अवधि"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+msgid "Duration of work before forcing a break"
+msgstr "ब्रेक बाध्य करब सँ पहिले कार्यावधि"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "Flash _window titlebar"
+msgstr "विंडो शीर्षक-पट्टीकेँ चमकाबू (_w)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "Flash entire _screen"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
+msgid "General"
+msgstr "सामान्य"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "Key presses _repeat when key is held down"
+msgstr "जखन कुँजी दाबि कए राखल जाए तँ कुँजी दोहरओनाइ (_r)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "Keyboard Accessibility Audio Feedback"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "Keyboard Layout Options"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "Keyboard Preferences"
+msgstr "कुँजी पटल वरीयतासभ "
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "Keyboard _model:"
+msgstr "कुँजीपटल मॉडल (_m):"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "Layout _Options..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "Layouts"
+msgstr "लेआउट"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"बारंबार कुँजीपटल उपयोग चोट सँ बचबाक लेल स्क्रीनकेँ एकटा निश्चित अवधि क' पश्चात् तालाबन्न "
+"करू"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
+msgid "Mouse Keys"
+msgstr "माउस कुँजीसभ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
+msgid "Preview:"
+msgstr "पूर्वावलोकनः"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
+msgid "Repeat keys speed"
+msgstr "दुहराबै बला कुँजी गति"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
+msgid "Reset to De_faults"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
+msgid "S_peed:"
+msgstr "गति (_p):"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
+msgid "Separate _layout for each window"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
+msgid "Show _visual feedback for the alert sound"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
+msgid "Typing Break"
+msgstr "ब्रेक टाइप कए रहल अछि"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
+msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
+msgid "_Break interval lasts:"
+msgstr "ब्रेक अंतराल टिकैत अछि (_B)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
+msgid "_Country:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
+msgid "_Delay:"
+msgstr "विलंब (_D):"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
+msgid "_Ignore fast duplicate keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
+msgid "_Language:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
+msgid "_Lock screen to enforce typing break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
+msgid "_Models:"
+msgstr "मॉडल (_M):"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
+msgid "_Only accept long keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
+msgid "_Pointer can be controlled using the keypad"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
+msgid "_Selected layouts:"
+msgstr "चयनित लेआउट (_S):"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
+msgid "_Simulate simultaneous keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
+msgid "_Speed:"
+msgstr "गति (_S):"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
+msgid "_Type to test settings:"
+msgstr "जमावट जाँचबाक लेल टाइप करू (_T):"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:68
+msgid "_Variants:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:69
+msgid "_Vendors:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:70
+msgid "_Work interval lasts:"
+msgstr "कार्य अंतराल टिकैत अछि (_W):"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:71
+msgid "minutes"
+msgstr "मिनट"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
+msgid "Unknown"
+msgstr "अज्ञात"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:215
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:235
+#: ../capplets/network/gnome-network-properties.c:561
+msgid "Default"
+msgstr "मूलभूत"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:333
+msgid "Layout"
+msgstr "लेआउट"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
+msgid "Vendors"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
+msgid "Models"
+msgstr "मॉडल"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "कुँजीपटल"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "कुँजी पटल क' वरीयतासभ नियत करू"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:90
+msgid "gesture|Move left"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:95
+msgid "gesture|Move right"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:100
+msgid "gesture|Move up"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:105
+msgid "gesture|Move down"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:110
+msgid "gesture|Disabled"
+msgstr ""
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/mouse/gnome-mouse-properties.c:441
+msgid "Specify the name of the page to show (general|accessibility)"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:446
+msgid "- GNOME Mouse Preferences"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+msgid "<b>Double-Click Timeout</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>घीँचू आओर छोड़ू</b>"
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Dwell Click</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>संकेतक स्थिति देखाबू</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>माउस अभिमुखन</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<b>Pointer Speed</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<b>Simulated Secondary Click</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid ""
+"<i>To test your double-click settings, try to double-click on the light bulb."
+"</i>"
+msgstr ""
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid ""
+"<i>You can also use the Dwell Click panel applet to choose the click type.</"
+"i>"
+msgstr ""
+
+#. high sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "<small><i>High</i></small>"
+msgstr ""
+
+#. large threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "<small><i>Large</i></small>"
+msgstr ""
+
+#. low sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "<small><i>Low</i></small>"
+msgstr ""
+
+#. small threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "<small><i>Small</i></small>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
+msgid "Choose type of click _beforehand"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
+msgid "Choose type of click with mo_use gestures"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
+msgid "D_ouble click:"
+msgstr ""
+
+#. click to initiate drag-and-drop (like normally click and hold)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
+msgid "D_rag click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
+msgid "Mouse Preferences"
+msgstr "माउस वरीयतासभ "
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
+msgid "Seco_ndary click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
+msgid "Show click type _window"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
+msgid "Thr_eshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
+msgid "_Acceleration:"
+msgstr "त्वरक (_A):"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
+msgid "_Initiate click when stopping pointer movement"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
+msgid "_Left-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
+msgid "_Motion threshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
+msgid "_Right-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
+msgid "_Sensitivity:"
+msgstr "संवेदनशीलता (_S):"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
+msgid "_Single click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
+msgid "_Timeout:"
+msgstr "टाइमआउट (_T):"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr ""
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "माउस"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "अपन माउस क' वरीयतासभ नियत करू"
+
+#: ../capplets/network/gnome-network-properties.c:677
+#: ../capplets/network/gnome-network-properties.c:816
+msgid "New Location..."
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.c:782
+msgid "Location already exists"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "संजाल प्रॉक्सी"
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "संजाल प्रॉक्सी वरीयतासभ सेट करू"
+
+#: ../capplets/network/gnome-network-properties.glade.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>सीधा इंटरनेट कनेक्शन (_r)</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:2
+msgid "<b>Ignore Host List</b>"
+msgstr "<b>होस्ट सूची अनदेखा करू</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:3
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>स्वचालित प्रॉक्सी विन्यास (_A)</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:4
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b> हस्तचालित प्रॉक्सी विन्यास (_M)</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:5
+msgid "<b>_Use authentication</b>"
+msgstr "<b>प्रमाणीकरण प्रयोग करू (_U)</b>"
+
+#: ../capplets/network/gnome-network-properties.glade.h:6
+msgid "Autoconfiguration _URL:"
+msgstr "स्वविन्यास यूआरएल (_U) : "
+
+#: ../capplets/network/gnome-network-properties.glade.h:7
+msgid "C_reate"
+msgstr "बनाबू (_r)"
+
+#: ../capplets/network/gnome-network-properties.glade.h:8
+msgid "Create New Location"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "HTTP प्रॉक्सी विवरण"
+
+#: ../capplets/network/gnome-network-properties.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "HTTP प्रॉक्सी (_H):"
+
+#: ../capplets/network/gnome-network-properties.glade.h:11
+msgid "Ignored Hosts"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.glade.h:12
+msgid "Location:"
+msgstr "स्थानः"
+
+#: ../capplets/network/gnome-network-properties.glade.h:13
+msgid "Network Proxy Preferences"
+msgstr "संजाल प्रॉक्सी वरीयतासभ "
+
+#: ../capplets/network/gnome-network-properties.glade.h:14
+msgid "Port:"
+msgstr "पोर्टः"
+
+#: ../capplets/network/gnome-network-properties.glade.h:15
+msgid "Proxy Configuration"
+msgstr "प्रॉक्सी विन्यास"
+
+#: ../capplets/network/gnome-network-properties.glade.h:16
+msgid "S_ocks host:"
+msgstr "सॉक्स होस्ट (_o):"
+
+#: ../capplets/network/gnome-network-properties.glade.h:17
+msgid "The location already exists."
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.glade.h:18
+msgid "U_sername:"
+msgstr "प्रयोक्ता नाम (_s):"
+
+#: ../capplets/network/gnome-network-properties.glade.h:19
+msgid "_Delete Location"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.glade.h:20
+msgid "_Details"
+msgstr "विवरण (_D)"
+
+#: ../capplets/network/gnome-network-properties.glade.h:21
+msgid "_FTP proxy:"
+msgstr "FTP प्रॉक्सी (_F):"
+
+#: ../capplets/network/gnome-network-properties.glade.h:22
+msgid "_Location name:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.glade.h:23
+msgid "_Password:"
+msgstr "कूटशब्द (_P):"
+
+#: ../capplets/network/gnome-network-properties.glade.h:24
+msgid "_Secure HTTP proxy:"
+msgstr "सुरक्षित HTTP प्रॉक्सी (_S):"
+
+#: ../capplets/network/gnome-network-properties.glade.h:25
+msgid "_Use the same proxy for all protocols"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:346
+msgid "Cannot start the preferences application for your window manager"
+msgstr ""
+
+#. translators: this is the Control key
+#: ../capplets/windows/gnome-window-properties.c:600
+msgid "C_ontrol"
+msgstr "नियंत्रित करू (_o)"
+
+#: ../capplets/windows/gnome-window-properties.c:605
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:611
+msgid "H_yper"
+msgstr "हाइपर (_y)"
+
+#: ../capplets/windows/gnome-window-properties.c:618
+msgid "S_uper (or \"Windows logo\")"
+msgstr "सुपर (अथवा \"विंडोज़ लोगो\") (_u)"
+
+#: ../capplets/windows/gnome-window-properties.c:625
+msgid "_Meta"
+msgstr "मेटा (_M)"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>गतिविधि कुँजीसभ</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>शीर्षकपट्टी क्रिया</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>विन्डो चयन</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr "कोनो विंडोकेँ घसकाबै लेल एहि कुँजीकेँ दाबने राखू फिनु विंडो पकड़ू"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "विंडो वरीयतासभ "
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "एहि क्रिया लेल शीर्षकपट्टीकेँ दोहरा क्लिक करू (_D):"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "उठाबैसँ पहिले अन्तराल (_I):"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "एकटा अन्तराल क' बाद चुनल गेल विंडोज़केँ उप्पर उठाबू (_R)"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "जखन माउस विंडोज़ पर घूमेताह तँ ओकरा चुनू (_S)"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "सकेण्ड"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "अपन विंडो गुण सेट करू"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "विंडोज़"
+
+#. make start action
+#: ../libslab/application-tile.c:372
+#, c-format
+msgid "<b>Start %s</b>"
+msgstr "<b>%s आरंभ करू</b>"
+
+#: ../libslab/application-tile.c:391
+msgid "Help"
+msgstr "मद्दति "
+
+#: ../libslab/application-tile.c:438
+msgid "Upgrade"
+msgstr "उन्नत बनाबू "
+
+#: ../libslab/application-tile.c:453
+msgid "Uninstall"
+msgstr "विसंस्थापित करू"
+
+#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
+msgid "Remove from Favorites"
+msgstr "मनपसंद सँ हटाबू"
+
+#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
+msgid "Add to Favorites"
+msgstr "मनपसंदमे जोड़ू"
+
+#: ../libslab/application-tile.c:867
+msgid "Remove from Startup Programs"
+msgstr "आरंभन प्रोग्राम सँ हटाबू"
+
+#: ../libslab/application-tile.c:869
+msgid "Add to Startup Programs"
+msgstr "आरंभन प्रोग्राममे जोड़ू"
+
+#: ../libslab/app-shell.c:753
+#, c-format
+msgid ""
+"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+"\n"
+" Your filter \"<b>%s</b>\" does not match any items.</span>"
+msgstr ""
+"<span size=\"large\"><b>कोनो मेल नहि भेटल.</b> </span><span>\n"
+"\n"
+" अहाँक फिल्टर \"<b>%s</b>\" कोनो मद सँ नहि मेल करैत अछि.</span>"
+
+#: ../libslab/app-shell.c:903
+msgid "Other"
+msgstr "आन"
+
+#: ../libslab/bookmark-agent.c:1077
+msgid "New Spreadsheet"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1082
+msgid "New Document"
+msgstr "नवीन दस्तावेज"
+
+#: ../libslab/bookmark-agent.c:1135
+msgid "Home"
+msgstr "घर"
+
+#: ../libslab/bookmark-agent.c:1140
+msgid "Documents"
+msgstr "दस्तावेज़"
+
+#: ../libslab/bookmark-agent.c:1153
+msgid "File System"
+msgstr "फाइल सिस्टम"
+
+#: ../libslab/bookmark-agent.c:1157
+msgid "Network Servers"
+msgstr "संजाल सर्वर"
+
+#: ../libslab/bookmark-agent.c:1186
+msgid "Search"
+msgstr "खोजू"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:171
+#, c-format
+msgid "<b>Open</b>"
+msgstr ""
+
+#. make rename action
+#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:231
+msgid "Rename..."
+msgstr "नाम बदलू..."
+
+#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
+#: ../libslab/document-tile.c:245 ../libslab/document-tile.c:254
+msgid "Send To..."
+msgstr "एकरामे भेजू..."
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:280
+msgid "Move to Trash"
+msgstr "रद्दीमे पठाबू"
+
+#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
+#: ../libslab/document-tile.c:290 ../libslab/document-tile.c:831
+msgid "Delete"
+msgstr "मेटाबू"
+
+#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:979
+#, c-format
+msgid "Are you sure you want to permanently delete \"%s\"?"
+msgstr "की अहाँ सुनिश्चित छी जे अहाँ \"%s\"केँ स्थायी तौर पर मेटओनाइ चाहैत अछि?"
+
+#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:980
+msgid "If you delete an item, it is permanently lost."
+msgstr "जँ अहाँ कोनो वस्तुकेँ मेटाएब, तँ ई स्थाइ रूप सँ मेट जएताह."
+
+#: ../libslab/document-tile.c:192
+#, c-format
+msgid "<b>Open with \"%s\"</b>"
+msgstr "<b>\"%s\" क' सँग खोलू</b>"
+
+#: ../libslab/document-tile.c:204
+msgid "Open with Default Application"
+msgstr "मूलभूत अनुप्रयोग क' सँग खोलू"
+
+#: ../libslab/document-tile.c:215
+msgid "Open in File Manager"
+msgstr "फाइल मैनेजरमे खोलू"
+
+#: ../libslab/document-tile.c:611
+msgid "?"
+msgstr "?"
+
+#: ../libslab/document-tile.c:618
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#: ../libslab/document-tile.c:626
+msgid "Today %l:%M %p"
+msgstr "आइ %l:%M %p"
+
+#: ../libslab/document-tile.c:636
+msgid "Yesterday %l:%M %p"
+msgstr "कालि %l:%M %p"
+
+#: ../libslab/document-tile.c:648
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../libslab/document-tile.c:656
+msgid "%b %d %l:%M %p"
+msgstr "%b %d %l:%M %p"
+
+#: ../libslab/document-tile.c:658
+msgid "%b %d %Y"
+msgstr "%b %d %Y"
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr "आब खोजू"
+
+#: ../libslab/system-tile.c:128
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr ""
+
+#: ../libslab/system-tile.c:141
+#, c-format
+msgid "Remove from System Items"
+msgstr ""
+
+#: ../libwindow-settings/gnome-wm-manager.c:316
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "विंडो प्रबंधक \"%s\" ने विन्यास अओजार रजिस्टर नहि कएने अछि\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:404
+msgid "Maximize"
+msgstr "अधिकतम"
+
+#: ../libwindow-settings/metacity-window-manager.c:405
+msgid "Maximize Vertically"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:406
+msgid "Maximize Horizontally"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:407
+msgid "Minimize"
+msgstr "छोट करू"
+
+#: ../libwindow-settings/metacity-window-manager.c:408
+msgid "Roll up"
+msgstr "रोल अप"
+
+#: ../libwindow-settings/metacity-window-manager.c:409
+msgid "None"
+msgstr "किछु नहि"
+
+#: ../shell/control-center.c:54
+#, c-format
+msgid "key not found [%s]\n"
+msgstr "कुँजी नहि भेटल [%s]\n"
+
+#: ../shell/control-center.c:151
+msgid "Filter"
+msgstr "फिल्टर"
+
+#: ../shell/control-center.c:151
+msgid "Groups"
+msgstr "समूह"
+
+#: ../shell/control-center.c:151
+msgid "Common Tasks"
+msgstr "सामान्य कार्य"
+
+#: ../shell/control-center.c:155 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "नियंत्रण केंद्र"
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:5
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:8
+msgid ""
+"Indicates whether to close the shell when an add or remove action is "
+"performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:9
+msgid ""
+"Indicates whether to close the shell when an upgrade or uninstall action is "
+"performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:11
+msgid ""
+"The task name to be displayed in the control-center followed by a \";\" "
+"separator then the filename of an associated .desktop file to launch for "
+"that task."
+msgstr ""
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+msgid ""
+"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
+"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:14
+msgid ""
+"if true, the control-center will close when a \"Common Task\" is activated."
+msgstr ""
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "गनोम विन्यास अओजार"
+
+#: ../typing-break/drw-break-window.c:193
+msgid "_Postpone Break"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:249
+msgid "Take a break!"
+msgstr "एकटा ब्रेक लिअ'!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#. translators: keep the initial "/"
+#: ../typing-break/drwright.c:129
+msgid "/_Preferences"
+msgstr "/ वरीयतासभ (_P)"
+
+#: ../typing-break/drwright.c:130
+msgid "/_About"
+msgstr "/क' संबंधमे (_A)"
+
+#: ../typing-break/drwright.c:132
+msgid "/_Take a Break"
+msgstr "/एकटा ब्रेक लिअ'(_T)"
+
+#: ../typing-break/drwright.c:488
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "अगिला ब्रेक तक %d मिनट"
+msgstr[1] "अगिला ब्रेक तक %d मिनट"
+
+#: ../typing-break/drwright.c:492
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr "अगिला ब्रेक क' लेल एक मिनट सँ कम समय"
+
+#: ../typing-break/drwright.c:579
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr "टाइपिंग ब्रेक गुण समाद लाबैमे निम्न त्रुटि क' सँग असफल: %s"
+
+#: ../typing-break/drwright.c:598
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "रिचर्ड हुल्ट <richard@imendio.com> द्वारा लिखित"
+
+#: ../typing-break/drwright.c:599
+msgid "Eye candy added by Anders Carlsson"
+msgstr "ऑन्देर्स कार्लसन द्वारा आई कैण्डी जोड़ल गेल अछि"
+
+#: ../typing-break/drwright.c:608
+msgid "A computer break reminder."
+msgstr "कम्प्यूटर ब्रेक स्मरण."
+
+#: ../typing-break/drwright.c:610
+msgid "translator-credits"
+msgstr "संगीता कुमारी (sangeeta09@gmail.com)"
+
+#: ../typing-break/main.c:61
+msgid "Enable debugging code"
+msgstr "डिबगिंग कोड सक्रिय करू"
+
+#: ../typing-break/main.c:63
+msgid "Don't check whether the notification area exists"
+msgstr ""
+
+#: ../typing-break/main.c:89
+msgid "Typing Monitor"
+msgstr "टाइपिंग मॉनीटर"
+
+#: ../typing-break/main.c:105
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"टाइपिंग निरीक्षक सूचना देखाबै क'लेल सूचना क्षेत्र क' प्रयोग करैत अछि अहाँ अपन पटल पर सूचना "
+"क्षेत्रकेँ नहि राखैत प्रतीत हाएत अछि. अहाँ अपन पटल पर दहिन्ना क्लिक कए क' आओर 'पटलमे "
+"जोड़ू' चुनि कए, सूचना क्षेत्र आओर जोड़ू पर क्लिक कए क'."
+
+#: ../font-viewer/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "जँ सही पर नियत कएल जाएत अछि, ओपन-टाइप फोन्ट क' लघु बिंब बनाओल जाएत."
+
+#: ../font-viewer/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "जँ सही पर नियत कएल जाएत अछि, पीसीएफ़ फोन्ट क' लघु बिंब बनाओल जाएत."
+
+#: ../font-viewer/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "जँ सही पर नियत कएल जाएत अछि, ट्रू-टाइप फोन्ट क' लघु बिंब बनाओल जाएत."
+
+#: ../font-viewer/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "जँ सही पर नियत कएल जाएत अछि, टाइप1 फोन्ट क' लघु बिंब बनाओल जाएत."
+
+#: ../font-viewer/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr "एहि कुँजीकेँ ओपन टाइप फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
+
+#: ../font-viewer/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr "एहि कुँजीकेँ पीसीएफ़ फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
+
+#: ../font-viewer/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr "एहि कुँजीकेँ ट्रू टाइप फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
+
+#: ../font-viewer/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr "एहि कुँजीकेँ टाइप1 फोन्ट क' लघु बिंब बनाबै क' कमांड लेल नियत करू."
+
+#: ../font-viewer/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "ओपन टाइप फोन्ट लेल लघु बिंब बनाबै क' कमांड"
+
+#: ../font-viewer/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "पीसीएफ़ फोन्ट लेल लघु बिंब बनाबै क' कमांड"
+
+#: ../font-viewer/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "ट्रू टाइप फोन्ट लेल लघु बिंब बनाबै क' कमांड"
+
+#: ../font-viewer/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "टाइप1 फोन्ट लेल लघु बिंब कमांड"
+
+#: ../font-viewer/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "की ओपन टाइप फोन्ट क' लघु बिंब बनाबू "
+
+#: ../font-viewer/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "की पीसीएफ़ फोन्ट क' लघु बिंब बनाबू "
+
+#: ../font-viewer/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "की ट्रू टाइप फोन्ट क' लघु बिंब बनाबू "
+
+#: ../font-viewer/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "की टाइप 1 फोन्ट क' लघु बिंब बनाबू "
+
+#: ../font-viewer/font-view.c:113
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr ""
+"सक्कय वाणी बहुजन भाबए, पाउय रसको मम्म न पाबए। देसिल बयना सब जन मिट्ठा, तैँ तैसन जम्पओ "
+"अवहट्ठा।। ०१२३४५६७८९"
+
+#: ../font-viewer/font-view.c:275
+msgid "Name:"
+msgstr "नाम:"
+
+#: ../font-viewer/font-view.c:278
+msgid "Style:"
+msgstr "शैली:"
+
+#: ../font-viewer/font-view.c:291
+msgid "Type:"
+msgstr "प्रकार:"
+
+#: ../font-viewer/font-view.c:295
+msgid "Size:"
+msgstr "आकार:"
+
+#: ../font-viewer/font-view.c:339 ../font-viewer/font-view.c:352
+msgid "Version:"
+msgstr "संस्करण:"
+
+#: ../font-viewer/font-view.c:343 ../font-viewer/font-view.c:354
+msgid "Copyright:"
+msgstr "कॉपीराइट:"
+
+#: ../font-viewer/font-view.c:347
+msgid "Description:"
+msgstr "विवरण:"
+
+#: ../font-viewer/font-view.c:437
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "उपयोग: %s फोन्ट-फ़ाइल\n"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
+msgid "Font Viewer"
+msgstr ""
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
+msgid "Preview fonts"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "Text to thumbnail (default: Aa)"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "TEXT"
+msgstr "पाठ"
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "Font size (default: 64)"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "SIZE"
+msgstr "आकार"
+
+#: ../font-viewer/font-thumbnailer.c:249
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:268
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr ""
+
+msgid "Show help options"
+msgstr "मद्दति विकल्प देखाबू"

--- a/po/mg.po
+++ b/po/mg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center HEAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-05-10 06:42+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2009-01-16 16:42+0300\n"
 "Last-Translator: Thierry Randrianiriana <randrianiriana@gmail.com>\n"
 "Language-Team: Malagasy <i18n-malagasy-gnome@gna.org>\n"
@@ -16,3629 +16,7517 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n>1;"
-
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "Sisin'ny sary/mari-tsoratra"
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr ""
-"Ny sakan'ny sisin'ny mari-tsoratra sy ny sary anatin'ny takelakakelin'ny "
-"filazana"
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr "karazam-pilazana"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "Ny karazan'ny filazana"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "Tsindrin'ny filazana"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "Ireo tsindry miseho eo amin'ny takelakakelin'ny filazana"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "Asehoy amin'ny _antsipiriany"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "About Me"
-msgstr "Momba izaho"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "Anoratana ny mombamomba anao"
-
-#: ../capplets/about-me/gnome-about-me.c:604
-msgid "Select Image"
-msgstr "Misafidiana sary"
-
-#: ../capplets/about-me/gnome-about-me.c:606
-msgid "No Image"
-msgstr "Tsy misy sary"
-
-#: ../capplets/about-me/gnome-about-me.c:769
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-"Nnisy olana teo am-panandramana maka ny lazan'ny bokin'adiresy\n"
-"Tsy raisin'ny Evolution Data Server an-tànana io firesaka io"
-
-#: ../capplets/about-me/gnome-about-me.c:790
-msgid "Unable to open address book"
-msgstr "Tsy mety mahasokatra ny bokin'adiresy"
-
-#: ../capplets/about-me/gnome-about-me.c:802
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-"ID'ny fidirana tsy fantatra. Mety simba angamba ny soratra fototry ny "
-"mpampiasa."
-
-#: ../capplets/about-me/gnome-about-me.c:833
-#: ../capplets/about-me/gnome-about-me.c:835
-#, c-format
-msgid "About %s"
-msgstr "Momba ny %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:707
-msgid "Old password is incorrect, please retype it"
-msgstr "Tsy marina ny teny fanalahidy taloha voasoratra. Avereno soratana"
-
-#: ../capplets/about-me/gnome-about-me-password.c:127
-msgid "System error has occurred"
-msgstr "Nisy olan'ny rafitra nitranga"
-
-#: ../capplets/about-me/gnome-about-me-password.c:128
-msgid "Could not run /usr/bin/passwd"
-msgstr "Tsy nahalefa ny /usr/bin/passwd"
-
-#: ../capplets/about-me/gnome-about-me-password.c:129
-msgid "Unable to launch backend"
-msgstr "Tsy mety mahalefa ny backend"
-
-#: ../capplets/about-me/gnome-about-me-password.c:131
-#: ../capplets/about-me/gnome-about-me-password.c:132
-msgid "Unexpected error has occurred"
-msgstr "Nisy olana tsy nampoizina nitranga"
-
-#: ../capplets/about-me/gnome-about-me-password.c:331
-msgid "Password is too short"
-msgstr "Fohy loatra io teny fanalahidy io"
-
-#: ../capplets/about-me/gnome-about-me-password.c:334
-#: ../capplets/about-me/gnome-about-me-password.c:337
-msgid "Password is too simple"
-msgstr "Tsotra loatra io teny fanalahidy io"
-
-#: ../capplets/about-me/gnome-about-me-password.c:340
-msgid "Old and new passwords are too similar"
-msgstr "Tsy dia mifankaiza loatra ireo teny fanalahidy taloha sy vaovao"
-
-#: ../capplets/about-me/gnome-about-me-password.c:343
-msgid "Must contain numeric or special character(s)"
-msgstr "Tsy maintsy misy isa na marika manokana"
-
-#: ../capplets/about-me/gnome-about-me-password.c:348
-msgid "Old and new password are the same"
-msgstr "Mitovy ireo teny fanalahidy taloha sy vaovao"
-
-#: ../capplets/about-me/gnome-about-me-password.c:634
-msgid "Please type the passwords."
-msgstr "Soraty ireo teny fanalahidy."
-
-#: ../capplets/about-me/gnome-about-me-password.c:642
-msgid "Please type the password again, it is wrong."
-msgstr "Avereno soratana indray ilay teny fanalahidy. Diso io voasoratra io."
-
-#: ../capplets/about-me/gnome-about-me-password.c:645
-msgid "Click on Change Password to change the password."
-msgstr "Tsindrio ny Hanova Teny Fanalahidy raha hanova ny teny fanalahidy."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/sound/sound-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-msgid "    "
-msgstr "    "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Email</b>"
-msgstr "<b>Mailaka</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Home</b>"
-msgstr "<b>Fandraisana</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Fifandraisana eo no eo</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Job</b>"
-msgstr "<b>Asa</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
-msgstr "<b>Soraty ilay teny fanalahidy.</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<b>Telephone</b>"
-msgstr "<b>Telefaonina</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "<b>Web</b>"
-msgstr "<b>Tranonkala</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "<b>Work</b>"
-msgstr "<b>Toeram-piasana</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "A_ddress:"
-msgstr "A_diresy:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr "_Mpanampy:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "Address"
-msgstr "Adiresy"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "C_ity:"
-msgstr "_Tanàna:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "C_ompany:"
-msgstr "_Orinasa:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Cale_ndar:"
-msgstr "_Kalandrie:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change Passwo_rd..."
-msgstr "Hanova _teny fanalahidy..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Change Password"
-msgstr "Manova ny teny fanalahidy"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Ci_ty:"
-msgstr "_Tanàna:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Co_untry:"
-msgstr "_Firenena:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Contact"
-msgstr "Ny mety ahazoana anao"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Cou_ntry:"
-msgstr "_Firenena:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr "Anarana feno"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Hom_e:"
-msgstr "_Trano:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "Old pa_ssword:"
-msgstr "_Teny fanalahidy taloha:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P.O. _box:"
-msgstr "Laharan'ny _Boatin-taratasy:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P._O. box:"
-msgstr "Laharan'ny _Boatin-taratasy:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "Personal Info"
-msgstr "Momba ny tena manokana"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "State/Pro_vince:"
-msgstr "Fanjakana/Fa_ritany:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-msgid "User name:"
-msgstr "Anaran'ny mpampiasa:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Web _log:"
-msgstr "_Raki-tatitry ny tranonkala:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "Wor_k:"
-msgstr "_Toeram-piasana:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid "Work _fax:"
-msgstr "_Fax ao amin'ny toeram-piasana:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Zip/_Postal code:"
-msgstr "Mari-pamantaran'ny _paositra:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "_Address:"
-msgstr "_Adiresy:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr "_Sampandraharaha:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr "_Groupwise:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "_Home page:"
-msgstr "Pejy _fandraisana:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "_Home:"
-msgstr "_Fandraisana:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr "_Jabber:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Manager:"
-msgstr "_Mpandrindra:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Mobile:"
-msgstr "_Finday:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_New password:"
-msgstr "_Teny fanalahidy vaovao:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Profession:"
-msgstr "_Asa:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Retype new password:"
-msgstr "_Avereno soratana ilay teny fanalahidy:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr "_Faritany:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Title:"
-msgstr "_Mpialoha anarana:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Work:"
-msgstr "_Toeram-piasana:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Zip/Postal code:"
-msgstr "Mari-pamantaran'ny _paositra:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Applications</b>"
+"Plural-Forms: nplurals=2; plural=n>1;\n"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
 msgstr "<b>Rindran'asas</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Support</b>"
-msgstr "<b>Fanampiana</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-"<small><i><b>Note:</b> Tsy hihatra ireo fanovana natao tamin'ity "
-"fandrindrana ity raha tsy rehefa miditra indray ianao.</i></small>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technology Preferences"
-msgstr "Safidy manokan'ny haitao fanamorana"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr "Hidio dia _mivoaha"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr "Mandefa ireo haitao fanamorana ireo isaky ny miditra ianao:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr "_Alefaso ireo haitao fanamorana"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr "_Fitara-mamily"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr "Fafan-teny miseho _amin'ny efijery"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Screenreader"
-msgstr "_Mpamaky efijery"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr "Fanampiana mikasika ny haitao fanamorana"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr ""
-"Alefaso ny fandraisana an-tànana ireo haitao fanamorana an'ny GNOME rehefa "
-"miditra"
-
-#: ../capplets/accessibility/at-properties/main.c:60
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Tsy misy haitao fanamorana ao amin'ny solosainao. Tsy maintsy apetraka ny "
-"fehin-drindran'asa 'gok' izay vao afaka mampiasa ny fafan-teny miseho "
-"amin'ny efijery. Tsy maintsy apetraka koa ny fehin-drindran'asa "
-"'gnopernicus' izay vao afaka mampiasa mpamaky efijery sy fitara-mamily."
-
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-"Tsy voapetraka ao amin'ny solosainao avokoa ireo haitao fanamorana misy. Tsy "
-"maintsy apetraka ny fehin-drindran'asa 'gok' vao afaka mandray an-tànana "
-"fafan-teny miseho amin'ny efijery."
-
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Tsy voapetraka ao amin'ny solosainao avokoa ireo haitao fanamorana misy. Tsy "
-"maintsy apetraka ny fehin-drindran'asa 'gnopernicus' vao afaka mampiasa "
-"mpamaky efijery sy fitara-mamily."
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:242
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr ""
-"Nisy olana teo am-pandefasana ny takelaka kelin'ny safidy manokan'ny totozy: "
-"%s"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:338
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:399
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr "Tsy nahaaftra fandrindrana AccessX avy amin'ny rakitra '%s'"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:436
-msgid "Import Feature Settings File"
-msgstr "Hanafatra rakitra misy fandrindrana fahasahaza"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:440
-msgid "_Import"
-msgstr "_Afaro"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Fafan-teny"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr "Mamaritra ny safidy manokan'ny fahafahana mampiasa ny fafan-teny"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-"Toa tsy manana ny tovana XKB ity rafitra ity. Tsy mandeha ny fahasahazan'ny "
-"fahafahana mampiasa ny fafan-teny  raha tsy misy io tovana io."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "<b>Alefaso ireo kitendry _faingana</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "<b>Alefaso ireo kitendry _votsa</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "<b>Alefaso ireo kitendrin'ny _totozy</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "<b>Alefaso ireo kitendry _famerenana</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "<b>Alefaso ireo kitendry _miraikidraikitra</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-msgid "<b>Features</b>"
-msgstr "<b>Fahasahaza</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr "<b>Kitendrin'ny fiovana</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "Fototra"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr "Maneno raha _tsy ekena ilay kitendry"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
-msgstr "Maneno raha alefa na ajanona avy amin'ny fafan-teny ireo _fahasahaza"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
-msgstr "Maneno rehefa voatsindry ny kitendrin'ny -fanovana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr ""
-"Maneno in-1 rehefa mirehitra ny jiro LED ary in-2 rehefa maty io jiro io."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr "Maneno rehefa ity ny kitendry:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr "_Elanelam-potoana:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr ""
-"Ny elanelana ara-potoana misy eo amin'ny fanindriana kitendry sy ny "
-"_fihetsiky ny kitondro:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr "_Atsaharo raha toa ka kitendry roa no indray voatsindry"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr "_Alefaso ireo kitendrin'ny fiovana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Sivana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr "Aza raharahaina ny kitendry sahala voatsindry anatin'ny:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-"Tsy mandraharaha ny fanindriana mifanarakaraka kitendry IRAY raha toa ka "
-"mitranga anatin'ny fotoana azon'ny mpampiasa faritana izany.s"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr "Safidy manokan'ny fahafahana mampiasa ny fafan-teny (AccessX)"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr "Hafainganan'ny kitondro _ambony indrindra:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr "Kitendrin'ny totozy"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr "_Safidy manokan'ny totozy..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-"Aza ekena ireo kitendry raha tsy efa voatsindry mandritra ny fotoana azon'ny "
-"mpampiasa faritana."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-"Manao fanindriana kitendry miara-miseho amin'ny alalan'ny fanidriana "
-"misesisesy ireo kitendrin'ny fanovana."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "S_peed:"
-msgstr "_Hafainganana:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr "Ny fotoana ilaina _hahatratrarana ny hafainganana ambony indrindra:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+#: panels/applications/cc-applications-panel.ui:31
 #, fuzzy
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr "Manova ny kitendrin'isa ho kitendrin'ny totozy."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr "_Atsaharo raha tsy ampiasaina mandritra ny:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr "_Alefaso ireo fahasahazan'ny fahafahana mampiasa ny fafan-teny"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr "_Hanafatra fandrindrana fahasahaza..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr "_Aza manaiky afa-tsy ireo kitendry voatsindry mandritra ny:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "_Type to test settings:"
-msgstr "_Manorata hitsapana ireo fandrindrana:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr "_Ekena"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr "_voatsindry"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr "_Lavina"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr "marika/segaondra"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "milliseconds"
-msgstr "milisegaondra"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr "pixel/segaondra"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "segaondra"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-msgid "Change your Desktop Background settings"
-msgstr "Manova ireo kirakiran'ny afaran'ny sehatr'asanao"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-msgid "Desktop Background"
-msgstr "Afaran'ny sehatr'asa"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "<b>_Taratasy manaingo</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-msgid "<b>_Desktop Colors</b>"
-msgstr "<b>Lokon'ny _sehatr'asa</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-msgid "Desktop Background Preferences"
-msgstr "Safidy manokan'ny afaran'ny sehatr'asa"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr "Manokatra takelaka kely ahafahana mamaritra ny loko"
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr "_Hanampy taratasy manaingo"
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-msgid "_Finish"
-msgstr "_Vita"
-
-#: ../capplets/background/gnome-background-properties.glade.h:7
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-msgid "_Remove"
-msgstr "_Esory"
-
-#: ../capplets/background/gnome-background-properties.glade.h:8
-msgid "_Style:"
-msgstr "_Endrika:"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Nisy olana teo am-manehoana ireo toro-làlana: %s"
-
-#: ../capplets/background/gnome-wp-capplet.c:984
-msgid "Centered"
-msgstr "Mahazo afovoa"
-
-#: ../capplets/background/gnome-wp-capplet.c:988
-msgid "Fill Screen"
-msgstr "Mameno efijery"
-
-#: ../capplets/background/gnome-wp-capplet.c:992
-msgid "Scaled"
-msgstr "Novaina habe"
-
-#: ../capplets/background/gnome-wp-capplet.c:996
-msgid "Zoom"
-msgstr "Zòma"
-
-#: ../capplets/background/gnome-wp-capplet.c:1000
-msgid "Tiled"
-msgstr "Mizarazara"
-
-#: ../capplets/background/gnome-wp-capplet.c:1021
-msgid "Solid Color"
-msgstr "Loko tokana"
-
-#: ../capplets/background/gnome-wp-capplet.c:1025
-msgid "Horizontal Gradient"
-msgstr "Mandry misompirana"
-
-#: ../capplets/background/gnome-wp-capplet.c:1029
-msgid "Vertical Gradient"
-msgstr "Mitsangana misompirana"
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1075
-msgid "Add Wallpaper"
-msgstr "Hanampy taratasy manaingo"
-
-#: ../capplets/background/gnome-wp-capplet.c:1092
-msgid "Images"
-msgstr "Sary"
-
-#: ../capplets/background/gnome-wp-capplet.c:1096
-msgid "All Files"
-msgstr "Ireo akitra rehetra"
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr "Tsy misy taratasy manaingo"
-
-#: ../capplets/background/gnome-wp-item.c:343
-#: ../capplets/background/gnome-wp-item.c:345
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "pixel"
-msgstr[1] "pixel"
-
-#: ../capplets/common/activate-settings-daemon.c:18
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"Tsy nahalefa ny mpandrindra kirakira 'gnome-settings-daemon'.\n"
-"Mety tsy hihatra ny safidy manokana sasany raha tsy mandeha io mpandrindra "
-"ny kirakiran'ny GNOME io. Mety midika izany fa misy olana amin'ny Bonobo, na "
-"mety efa misy mpandrindra kirakira tsy an'ny GNOME (ohatra: KDE) mandeha ka "
-"mifanipaka amin'ny an'ny GNOME."
-
-#: ../capplets/common/capplet-stock-icons.c:92
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "Tsy afaka nangala ny kisary tahiry '%s'\n"
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr "Ampiharo fotsiny ireo fandrindrana dia ajanony"
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1016
-#: ../capplets/sound/sound-properties-capplet.c:760
-msgid "Retrieve and store legacy settings"
-msgstr "Alaivo ary raiketo ireo fandrindrana taloha"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "Mandika ilay rakitra: %u amin'ny %u"
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr "Mandika ny '%s'"
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr "Avy amin'ny URI"
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr "Ny URI dia mamindra avy amin'ny"
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr "Mankany amin'ny URI"
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr "Ny URI dia mamindra mankany amin'ny"
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr "Vita ny fizarana"
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr "Vita ny fizarana ny famindrana"
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr "Fizahan-takilan'ity URI ity"
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr "Fizahan-takilan'ity URI ity - manomboka amin'ny 1"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr "Tontalin'ireo URI"
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr "Tontalin'ny isan'ny URI"
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr "Mandika rakitra"
-
-#: ../capplets/common/file-transfer-dialog.c:345
-msgid "From:"
-msgstr "Avy amin'ny:"
-
-#: ../capplets/common/file-transfer-dialog.c:349
-msgid "To:"
-msgstr "Mankany amin'ny:"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr "Mifandray..."
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Kitendry"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr "Ny famaha GConf arahan'ity mpanova toetoetra ity"
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr "Antso"
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Mandefa ity antso rehefa miova ny sanda mifandraika amin'ilay famaha"
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr "Fitambarana fanovana"
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"Fitambarana fanovana misy data alefa mankany amin'ny mpivatsin'ny gconf "
-"rehefa atao ny fampiharana"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr "Fivadihana mankany amin'ny antso widget"
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-"Antso halefa rehefa misy data havadika avy amin'ny GConf mankany amin'ilay "
-"widget"
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr "Fivadihana avyamin'ny antso widget"
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"Antso halefa rehefa misy data havadika avy amin'ny widget mankany amin'ny "
-"GConf s"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr "Fifehezana ny UI"
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr "Zavatra iray izay mifehy ny toetoetra (tokony ho widget)"
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr "Datan'ny zavatry ny mpanova toetoetra"
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr "Data manokana ilain'ny mpanova toetoetra voafaritra"
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr "Datan'ny mpanova toetoetra mamotsotra antso"
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Antso halefa rehefa havotsotra ny datan'ny zavatry ny mpanova toetoetra"
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Tsy nahita ny rakitra '%s'.\n"
-"\n"
-"Amarino tsara hoe misy izy io dia andramo indray avy eo, na misafidiana sary "
-"afara hafa."
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Tsy haiko ny manokatra ny rakitra '%s'.\n"
-"Mety karazan-tsary tsy mbola voaray an-tànana angamba izy io.\n"
-"\n"
-"Misafidiana sary hafa asolo azy."
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr "Misafidiana sary iray."
-
-#: ../capplets/common/gconf-property-editor.c:1598
-msgid "_Select"
-msgstr "_Ekeo"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
+msgid "No applications"
 msgstr "Rindran'asa tiana kokoa"
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Safidio ireo rindran'asa ataonao fampiasa"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "_Hametraka endrika..."
 
-#: ../capplets/default-applications/gnome-da-capplet.c:77
-#: ../capplets/default-applications/gnome-da-capplet.c:101
-#: ../capplets/default-applications/gnome-da-capplet.c:146
-#: ../capplets/default-applications/gnome-da-capplet.c:191
-#: ../capplets/default-applications/gnome-da-capplet.c:245
-#: ../capplets/default-applications/gnome-da-capplet.c:294
-#: ../capplets/default-applications/gnome-da-capplet.c:576
-#: ../capplets/default-applications/gnome-da-capplet.c:597
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "Nisy olana teo am-pandraiketana ny kirakira: %s"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Sokafy"
 
-#: ../capplets/default-applications/gnome-da-capplet.c:719
-#: ../capplets/sound/sound-properties-capplet.c:318
-msgid "Custom"
-msgstr "Safidy"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Antsipirian'ny endrika"
 
-#: ../capplets/default-applications/gnome-da-capplet.c:739
-msgid "Could not load the main interface"
-msgstr "Tsy afaka naka ny mpanera fototra"
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Karohy"
 
-#: ../capplets/default-applications/gnome-da-capplet.c:741
-msgid "Please make sure that the applet is properly installed"
-msgstr "Amarino tsara hoe voapetraka araka ny tokony ho izy ilay applet"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Debian Sensible Browser"
-msgstr "Debian Sensible Browser"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Debian Terminal Emulator"
-msgstr "Debian Terminal Emulator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Encompass"
-msgstr "Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Epiphany Web Browser"
-msgstr "Mpitety tranonkalan'ny Epiphany"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "Evolution Mail Reader"
-msgstr "Evolution Mail Reader"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Evolution Mail Reader 1.4"
-msgstr "Evolution Mail Reader 1.4"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Evolution Mail Reader 1.5"
-msgstr "Evolution Mail Reader 1.5"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader 1.6"
-msgstr "Evolution Mail Reader 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Evolution Mail Reader 2.0"
-msgstr "Evolution Mail Reader 2.0"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Evolution Mail Reader 2.2"
-msgstr "Evolution Mail Reader 2.2"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "Evolution Mail Reader 2.4"
-msgstr "Evolution Mail Reader 2.4"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "Firebird"
-msgstr "Firebird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "GNOME Terminal"
-msgstr "Terminal an'ny GNOME"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "KMail"
-msgstr "KMail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Links Text Browser"
-msgstr "Mpitety Links Text"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Lynx Text Browser"
-msgstr "Mpitety Lynx Text"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "Mozilla Mail"
-msgstr "Mozilla Mail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Netscape Communicator"
-msgstr "Netscape Communicator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Opera"
-msgstr "Opera"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Standard XTerminal"
-msgstr "XTerminal tsotra"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Sylpheed"
-msgstr "Sylpheed"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "W3M Text Browser"
-msgstr "Mpitety Soratra W3M"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Audio Player</b>"
-msgstr "<b>Fiahinoana raki-peo</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Image Viewer</b>"
-msgstr "<b>Mpizaha sary</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Instant Messenger</b>"
-msgstr "<b>Mpampifandray eo no eo</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mail Reader</b>"
-msgstr "<b>Mpamaky mailaka</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>Terminal Emulator</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Text Editor</b>"
-msgstr "<b>Mpanova lahabolana</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Video Player</b>"
-msgstr "<b>Fijerena horonan-tsary</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Web Browser</b>"
-msgstr "<b>Mpitety tranonkala</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "Ho soloina ity rohy ity daholo ireo %s rehetra"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Co_mmand:"
-msgstr "Bai_ko:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "E_xecute flag:"
-msgstr "Sain'ny takila _fanatanterahana:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Internet"
-msgstr "Internet"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Multimedia"
-msgstr "Haino aman-jery"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Open link in new _tab"
-msgstr "Sokafy anaty _vakizoro vaovao ilay rohy"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Open link in new _window"
-msgstr "Sokafy anaty _fikandrana vaovao ilay rohy"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Open link with web browser _default"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
-"Sokafy amin'ny alalan'ny safidy _tsotran'ny mpitety tranonkala ilay rohy"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Run in t_erminal"
-msgstr "Alefaso amin'ny alalan'ny _Terminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "System"
-msgstr "Rafitra"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Hanova ny resolution'ny efijery"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Resolution'ny efijery"
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/main.c:448
-msgid "_Resolution:"
-msgstr "_Resolution:"
-
-#: ../capplets/display/main.c:467
-msgid "Re_fresh rate:"
-msgstr "Tahan'ny re_freshment:"
-
-#: ../capplets/display/main.c:488
-msgid "Default Settings"
-msgstr "Fandrindrana tsotra"
-
-#: ../capplets/display/main.c:490
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr "Fandrindran'ny efijery %d\n"
-
-#: ../capplets/display/main.c:516
-msgid "Screen Resolution Preferences"
-msgstr "Safidy manokana mikasikan ny resolution'ny efijery"
-
-#: ../capplets/display/main.c:553
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "_Ataovy safidy tsotra ho an'ity solosaina (%s) ity ihany"
-
-#: ../capplets/display/main.c:571
-msgid "Options"
-msgstr "Safidy"
-
-#: ../capplets/display/main.c:592
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"Mitsapa ireo fandrindrana vaovao. Raha tsy manome valin-teny anatin'ny %d "
-"segaondra ianao dia haverina ireo fandrindrana teo aloha."
-msgstr[1] ""
-"Mitsapa ireo fandrindrana vaovao. Raha tsy manome valin-teny anatin'ny %d "
-"segaondra ianao dia haverina ireo fandrindrana teo aloha."
-
-#: ../capplets/display/main.c:638
-msgid "Keep Resolution"
-msgstr "Tano io resolution io"
-
-#: ../capplets/display/main.c:642
-msgid "Do you want to keep this resolution?"
-msgstr "Tianao tanana io resolution io?"
-
-#: ../capplets/display/main.c:667
-msgid "Use _previous resolution"
-msgstr "Ny resolution _teo aloha ampiasaina"
-
-#: ../capplets/display/main.c:667
-msgid "_Keep resolution"
-msgstr "_Tano io resolution io"
-
-#: ../capplets/display/main.c:818
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"Tsy mandray an-tànana ny tovana XRandR ny mpizara X. Tsy misy fanovana "
-"resolution runtime azo ampiharina amin'ny haben'ny efijery ao."
-
-#: ../capplets/display/main.c:826
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"Tsy mifanaraka amin'ity rindran'asa ity ny kinovan'ny tovana XRandR. Tsy "
-"misy fanovana runtime azo ampiharina amin'ny haben'ny efijery ao."
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Endri-tsoratra"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr "Ahafahana misafidy endri-tsoratra ho an'ny sehatr'asa"
-
-#: ../capplets/font/font-properties.glade.h:1
-msgid "<b>Font Rendering</b>"
-msgstr "<b>Fivoakan'ny endri-tsoratra</b>"
-
-#: ../capplets/font/font-properties.glade.h:2
-msgid "<b>Hinting</b>:"
-msgstr "<b>Hinting</b>:"
-
-#: ../capplets/font/font-properties.glade.h:3
-msgid "<b>Smoothing</b>:"
-msgstr "<b>Fandamalamana</b>:"
-
-#: ../capplets/font/font-properties.glade.h:4
-msgid "<b>Subpixel order</b>:"
-msgstr "<b>Filaharan'ny subpixel</b>:"
-
-#: ../capplets/font/font-properties.glade.h:5
-msgid "Best _shapes"
-msgstr "_Bika tsara indrindra"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best co_ntrast"
-msgstr "_Fifangarihana tsara indrindra"
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "D_etails..."
-msgstr "An_tsipiriany..."
-
-#: ../capplets/font/font-properties.glade.h:8
-msgid "Des_ktop font:"
-msgstr "Endri-tsoratry ny sehatr'asa:"
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "Safidy manokan'ny endri-tsoratra"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr "Antsipirian'ny fivoakan'ilay endri-tsoratra"
-
-#: ../capplets/font/font-properties.glade.h:11
-msgid "Go _to font folder"
-msgstr "_Laha-tahirin'ny endri-tsoratra"
-
-#: ../capplets/font/font-properties.glade.h:12
-msgid "Gra_yscale"
-msgstr "Ambara_tongan-doko mivolombatolalaka"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "Tsy _misy"
-
-#: ../capplets/font/font-properties.glade.h:14
-msgid "R_esolution:"
-msgstr "R_esolution:"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr "Sub_pixel (LCD)"
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "Fandamalamana sub_pixel (LCD)"
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
-msgstr "Endri-tsoratry ny _rindran'asa:"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Document font:"
-msgstr "_Endri-tsoratry ny tahirin-kevitra:"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Fixed width font:"
-msgstr "Sakan'endri-tsoratra voafetra:"
-
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Full"
-msgstr "_Feno"
-
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Medium"
-msgstr "_Antonony"
-
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_Monochrome"
-msgstr "_Tokan-doko"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_None"
-msgstr "_Tsy misy"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Slight"
-msgstr "_Malefaka"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "Endri-tsoratra ho an'ny lohatenin'ny _fikandrana:"
-
-#: ../capplets/font/font-properties.glade.h:30
-msgid "dots per inch"
-msgstr "dpi"
-
-#: ../capplets/font/main.c:489
-msgid "Font may be too large"
-msgstr "Mety lehibe loatra ilay endri-tsoratra"
-
-#: ../capplets/font/main.c:493
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe "
-"loatra (x %d) ny endri-tsoratra nosafidianao. Tsara raha mampiasa endri-"
-"tsoratra kely noho ny %d ianao."
-msgstr[1] ""
-"Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe "
-"loatra (x %d) ny endri-tsoratra nosafidianao. Tsara raha mampiasa endri-"
-"tsoratra kely noho ny %d ianao."
-
-#: ../capplets/font/main.c:506
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe %d "
-"teboka loatra ny endri-tsoratra nosafidianao. Tsara raha misafidy endri-"
-"tsoratra kely noho io ianao."
-msgstr[1] ""
-"Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe %d "
-"teboka loatra ny endri-tsoratra nosafidianao. Tsara raha misafidy endri-"
-"tsoratra kely noho io ianao."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "Mpanfaingana vaovao..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Kitendry mpanafaingana"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Mpanova ireo mpanafaingana"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Fangon'ny kitendry mpanafaingana"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Fomban'ny mpanafaingana"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Ny karazan'ilay mpanafaingana."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:187
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:471
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Natsahatra"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:534
-msgid "<Unknown Action>"
-msgstr "<Ada tsy fantatra>"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr ""
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:555
-msgid "Desktop"
-msgstr "Sehatr'asa"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Asehoy ny safidy momba ny toro-làlana"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:556
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Ampiharo ilay _afara"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Efijery"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Tsy misy taratasy manaingo"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
 msgstr "Feo"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:560
-msgid "Window Management"
-msgstr "Fandrindrana fikandrana"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:666
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become unusable to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time.\n"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
-"Tsy mety ampiasaina ny hitsin-dàlana \"%s\" satria tsy hety hampiasaina "
-"hanoratana intsony io kitendry io.\n"
-"Andramo ampiarahana amin'ny kitendry toy ny Control, Alt na Shift ilay izy.\n"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:695
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-msgstr ""
-"Ny hitsin-dàlana \"%s\" dia efa ampiasaina amin'ny:\n"
-"\"%s\"\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:727
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr ""
-"Tsy nety ny famoronana mpanfaingana vaovao ao anatin'ny soratra fototry ny "
-"kirakira: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:777
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr ""
-"Tsy nety ny fanafoanana ilay mpanafaingana tao anatin'ny soratra fototry ny "
-"kirakira: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:884
-msgid "Action"
-msgstr "Asa"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:908
-msgid "Shortcut"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
 msgstr "Hitsin-dàlana"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
 msgstr "Hintsin-dàlan'ny kitendry"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
 msgstr ""
-"Raha hanova mpanfaingana, dia manorata mpanafaingana vaovao eo amin'ny "
-"fariana voatokana amin'izany, na tsindrio ny kitendry miverina hamafana azy."
 
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Hamorona kitendry hitsin-dàlana ho ana baiko"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:87
-msgid "Unknown"
-msgstr "Tsy fantatra"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:281
-msgid "Layout"
-msgstr "Fandaminana"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:285
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:229
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Tsy misy feo"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "karazam-pilazana"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Endri-tsoratry ny _rindran'asa:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Mailaka</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Endrika:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Tsotra"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:77
-msgid "Models"
-msgstr "Modely"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:109
-#, c-format
-msgid "There was an error launching the keyboard tool: %s"
-msgstr "Nisy olana teo am-pandefasana ny fikirakirana ny kitendry: %s"
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "Ampiharo ilay _afara"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Resolution'ny efijery"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Kitondro fotsy lehibe"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Mandika rakitra"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Afaro"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Hanampy..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "_Ireo rakitra azo:"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "_Esory"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Antsipiriany"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "minitra"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Antonony"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "minitra"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "minitra"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Loko tokana"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Misafidiana sary"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Ekeo"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Tsy misy feo"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_Elanelany:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Karohy"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "_Elanelam-potoana:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "Hitsin-dàlan'ny Karohy."
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Natsahatra"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "segaondra"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalandrie:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Manova ireo kirakiran'ny afaran'ny sehatr'asanao"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "_Kalandrie:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Rindran'asa tiana kokoa"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Safidio ireo rindran'asa ataonao fampiasa"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "_Ampiharo"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Fitodika"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Resolution:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Tahan'ny re_freshment:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Novaina habe"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Vita ny fizarana"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Avy amin'ny:"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "minitra"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "Mankany amin'ny:"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Periferika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Anarana:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Karazana"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Terminal an'ny GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Periferika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Periferika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Anaran'ny _mpampiasa:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Mombamomba"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Malefaka"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Ambany"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Ambony"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Mamaky (na mamaky/miato)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+#, fuzzy
+msgid "Pause playback"
+msgstr "Famakiana feo:"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Ajanony"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Mamaky ny hira teo aloha"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Mamaky ny hira manaraka"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Tsoahy"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "Fiatoan'ny fanoratana"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Mamaky ny hira manaraka"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Mamaky ny hira teo aloha"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Alefaso ny mpitety tranonkala"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Alefaso ny mpizaha toro-làlana"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Fandrindrana tsotra"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Alefaso ny mpitety tranonkala"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Laha-tahirin'ny fandraisana"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Karohy"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Rafitra"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Hivoaka"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Gejao ny efijery"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
 msgstr "_Fahafahana mampiasa"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:756
-#: ../capplets/sound/sound-properties-capplet.c:758
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "Zòma"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Zòma"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "Fafan-teny miseho _amin'ny efijery"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Safidy"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Safidy manokana"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Fandaminana ny fafan-teny"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Esory"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Kitendrin'ny totozy"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Hintsin-dàlan'ny kitendry"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Asa"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Hitsin-dàlana"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Hitsin-dàlana"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Hitsin-dàlana"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Hintsin-dàlan'ny kitendry"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Esory"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Anarana:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Bai_ko:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Hitsin-dàlana"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Hitsin-dàlana"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_Tsy misy"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Avereno amin'ny toetra _tsotra"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Fafan-teny"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
 msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
-"Ampiharo fotsiny ireo fandrindrana dia ajanony (fifanarahana ihany; efa "
-"raisin'ny daemon an-tànana izao)"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
-"Asehoy ireo fandrindrana ny fiatoan'ny fanoratana rehefa mandefa ilay pejy"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "..."
-msgstr "..."
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>Fipian'ny kitondro</b>"
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Kitendrin'ny famerenana</b>"
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<b>_Gejao ny efijery hanamafisana ny fiatoan'ny fanoratana</b>"
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Faingana</i></small>"
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Anoratana ny mombamomba anao"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Lava</i></small>"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Fohy</i></small>"
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Meda</i></small>"
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_vailable layouts:"
-msgstr "Ireo fandaminana _misy:"
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "All_ow postponing of breaks"
-msgstr "_Ekeo ny fanemorana ireo fiatoana"
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Jereo raha toa ka azo ahemotra ireo fiatoana"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "Choose a Keyboard Model"
-msgstr "Misafidiana modelim-pafan-teny iray"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Choose a Layout"
-msgstr "Misafidiana fandaminana iray"
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Fandrindrana tsotra"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
-msgstr "_Mipy ilay kitondro anatin'ny takila sy toeran-tsoratra"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Cursor blinks speed"
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "_Malefaka"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Haben'ny kitondro:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Totozy"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Kitendrin'ny totozy"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Fanafainganana:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Fanafainganana:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Endri-tsoratry ny _rindran'asa:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Periferika"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Asa"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Tsy mifandray"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Safidy"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Proxy'ny rezo"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Teny fanalahidy:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Manova ny teny fanalahidy"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Fomban'ny mpanafaingana"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
 msgstr "Hafainganan'ny fipian'ny kitondro"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of the break when typing is disallowed"
-msgstr "Faharetan'ny fiatoana raha rehefa voarara ny fanoratana"
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Duration of work before forcing a break"
-msgstr "Faharetan'ny asa atao alohan'ny hanisiana fiatoana"
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Adiresy"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Key presses _repeat when key is held down"
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Adiresy"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Adiresy"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Kitondro tsotra"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Anarana:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Adiresy:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Adiresy:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Natsahatra"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Adiresy"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adiresy"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "minitra"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Proxy'ny rezo"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "_Alefaso"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "Adiresy"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy'ny rezo"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "Proxy H_TTP:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTP:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Mpampiantrano S_ocks:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "<b>Lisitry ny mpampiantrano tsy raharahaina</b>"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "Proxy H_TTP:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "Proxy H_TTP:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "Proxy _FTP:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "_URL'ny fikirakirana mandeha hoazy:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Proxy'ny rezo"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Teny fanalahidy:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "tsy misy safidy"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>Mampi_asà fanamarinana</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "Anaran'ny _mpampiasa:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Teny fanalahidy:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Teny fanalahidy vaovao:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Kinova:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Kinova:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Avereno soratana ilay teny fanalahidy:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "<b>Mampi_asà fanamarinana</b>"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Karazana"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Tsotra"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Rafitra"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr ""
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Feo"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Hitsin-dàlan'ny Gejao ny efijery."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Hitsin-dàlan'ny Gejao ny efijery."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>Mampi_asà fanamarinana</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "minitra"
+msgstr[1] "minitra"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minitra"
+msgstr[1] "minitra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "minitra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "minitra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "minitra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "minitra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "minitra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "minitra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "minitra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "minitra"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Periferika"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Fomban'ny mpanafaingana"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Mameno efijery"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Efijery"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Elanelam-potoana:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "Kitondro"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "Kitondro"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Tsy misy feo"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "Anaran'ny _mpampiasa:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Asa"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Nandamoka ny fametrahana"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Ekeo"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Fitsapana"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "tsy misy safidy"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Antsipirian'ny fivoakan'ilay endri-tsoratra"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Avereno amin'ny toetra _tsotra"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Modely"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Amarino tsara hoe voapetraka araka ny tokony ho izy ilay applet"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Kitondro"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Ireo akitra rehetra"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Topy maso:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "_Sampandraharaha:"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "Fivoahana"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Mameno efijery"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Asa"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Karazana:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Efijery"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Gejao ny efijery"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Efijery"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Efijery"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Fandrindran'ny efijery %d\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Safidin'ny fafan-teny"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Hafa"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Asa"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Endri-tsoratry ny _rindran'asa:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Hitsin-dàlan'ny Karohy."
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Proxy'ny rezo"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Sehatr'asa"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Esory"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Teny fanalahidy:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Sehatr'asa"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Fifehezana ny UI"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Tsy mifandray"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Adikao"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<b>Mampi_asà fanamarinana</b>"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Anaran'ny mpampiasa:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Feon'ny rafitra"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Malefaka"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Periferika"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Fitsapana"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Kirakiran'ny proxy"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Periferika"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Fanamafisam-peo"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Tsindrin'ny filazana"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Feo"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Anarana:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Periferika"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Periferika"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>Fipian'ny kitondro</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "_Mipy ilay kitondro anatin'ny takila sy toeran-tsoratra"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Hafainganana:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Hafainganan'ny fipian'ny kitondro"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Hafainganan'ny fipian'ny kitondro"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Hitsin-dàlana"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Elanelam-potoana:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Hitsin-dàlana"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Fetra:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Kely"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Lehibe"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Kitendrin'ny famerenana</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
 msgstr ""
 "_Famerenana izay voatsindry rehefa rehefa voatsindry tsy miato ny kitendry "
 "iray"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Keyboard Preferences"
-msgstr "Safidy manokan'ny fafan-teny"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Hafainganan'ny kitendry famerenana"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Keyboard _model:"
-msgstr "_Modelim-pafan-teny:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Layout Options"
-msgstr "Safidin'ny fandaminana"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Layouts"
-msgstr "Fandaminana"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-"Gejao ny efijery aorian'ny fotoana voafaritra mba hisorohana izay aretina "
-"ateraky ny fampiasana fafan-teny matetika loatra"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Microsoft Natural Keyboard"
-msgstr "Microsoft Natural Keyboard"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Preview:"
-msgstr "Topy maso:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Hafainganan'ny kitendry famerenana"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Reset To De_faults"
-msgstr "Avereno amin'ny toetra _tsotra"
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Separate _group for each window"
-msgstr "_Vondrona tokana isaka ny fikandrana"
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Fampilazan'ny kitendry miraikidraikitra"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-msgid "Typing Break"
-msgstr "Fiatoan'ny fanoratana"
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Accessibility..."
-msgstr "_Fahafahana mampiasa..."
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "_Atsaharo raha toa ka kitendry roa no indray voatsindry"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Add..."
-msgstr "_Hanampy..."
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Maneno rehefa voatsindry ny kitendrin'ny -fanovana"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "_Break interval lasts:"
-msgstr "_Faharetan'ny elanelan'ireo fiatoana:"
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Fampilazan'ny kitendry meda"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Delay:"
-msgstr "_Elanelam-potoana:"
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Models:"
-msgstr "_Modely:"
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Hitsin-dàlana"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Selected layouts:"
-msgstr "_Fandaminana voasafidy:"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Speed:"
-msgstr "_Hafainganana:"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "_Work interval lasts:"
-msgstr "_Faharetan'ny elanelan'ny asa atao:"
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Maneno rehefa voatsindry ny kitendrin'ny -fanovana"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "minutes"
-msgstr "minitra"
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Maneno rehefa ity ny kitendry:"
 
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Mamaritra ireo safidy manokan'ny fafan-teny"
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Maneno raha _tsy ekena ilay kitendry"
 
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:880
-#, c-format
-msgid "%d milliseconds"
-msgid_plural "%d milliseconds"
-msgstr[0] "%d milisegaondra"
-msgstr[1] "%d milisegaondra"
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Kitendrin'ny totozy"
 
-#: ../capplets/mouse/gnome-mouse-properties.c:560
-msgid "Unknown Pointer"
-msgstr "Kitondro tsy fantatra"
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Aza raharahaina ny kitendry sahala voatsindry anatin'ny:"
 
-#: ../capplets/mouse/gnome-mouse-properties.c:761
-msgid "Default Pointer"
-msgstr "Kitondro tsotra"
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Hitsin-dàlana"
 
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Pointer - Current"
-msgstr "Kitondro tsotra - Ny miasa izao"
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-msgid "The default pointer that ships with X"
-msgstr "Ny kitondro tsotra nivoaka niaraka tamin'ny X"
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-msgid "White Pointer"
-msgstr "Kitondro fotsy"
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Pointer - Current"
-msgstr "Kitondro fotsy - Ny miasa izao"
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-msgid "The default pointer inverted"
-msgstr "Ny kitondro tsotra navadika"
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Fahafahana mampiasa"
 
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-msgid "Large Pointer"
-msgstr "Kitondro lehibe"
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Pointer - Current"
-msgstr "Kitondro lehibe - Ny miasa izao"
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-msgid "Large version of normal pointer"
-msgstr "Ny kitondro ara-pitsipika amin'ny endriny lehibe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-msgid "Large White Pointer - Current"
-msgstr "Kitondro fotsy lehibe - Ny miasa izao"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Pointer"
-msgstr "Kitondro fotsy lehibe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-msgid "Large version of white pointer"
-msgstr "Ny kitondro fotsy amin'ny endriny lehibe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:970
-msgid "Pointer Theme"
-msgstr "Endriky ny kitondro"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr "<b>Elanelan'ny click miverina indroa </b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Alaivo dia afindrao</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Farito ny toeran'ny kitondro</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>Fitodiky ny totozy</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Speed</b>"
-msgstr "<b>Hafaingana</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>Faingana</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>Ambony</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>Lehibe</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>Ambany</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>Meda</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>Kely</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Tsindry"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr "Manasongadina ilay _kitondro rehefa manindry ny Ctrl ianao"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Large"
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
 msgstr "Lehibe"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Medium"
-msgstr "Antonony"
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "Motion"
-msgstr "Hetsika"
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "_Mpamaky efijery"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-msgid "Mouse Preferences"
-msgstr "Safidy manokan'ny totozy"
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Pointer Size:"
-msgstr "Haben'ny kitondro:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Pointers"
-msgstr "Kitondro"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "Small"
-msgstr "Kely"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
-msgstr "_Fanafainganana:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
-msgstr "_Totozy ho an'ny tànana havia"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr "_Fahamora mandray:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr "_Fetra:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
-msgstr "_Elanelany:"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Totozy"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Mamaritra ny safidy manokan'ny totozinao"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Proxy'ny rezo"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "Mamaritra ny safidy manokan'ny proxy'ny rezonao"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>Fifandraisana Internet _mivantana</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
-msgstr "<b>Lisitry ny mpampiantrano tsy raharahaina</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>Fikirakirana proxy mandeha _hoazy</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>Fikirakirana proxy ataon-tànana</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr "<b>Mampi_asà fanamarinana</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "Advanced Configuration"
-msgstr "Fikirakirana avo lenta"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr "_URL'ny fikirakirana mandeha hoazy:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "Antsipirian'ny proxy HTTP"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "Proxy H_TTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Network Proxy Preferences"
-msgstr "Safidy manokan'ny proxy'ny rezo"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Irika:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "Proxy Configuration"
-msgstr "Kirakiran'ny proxy"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr "Mpampiantrano S_ocks:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "U_sername:"
-msgstr "Anaran'ny _mpampiasa:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_Antsipiriany"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr "Proxy _FTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "_Teny fanalahidy:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr "Proxy HTTP azo _antoka:"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Alefaso ireo feo ary ampifandraiso amin'ny zava-mitranga"
-
-#: ../capplets/sound/sound-properties-capplet.c:316
-#: ../capplets/sound/sound-properties-capplet.c:368
-msgid "Not connected"
-msgstr "Tsy mifandray"
-
-#: ../capplets/sound/sound-properties-capplet.c:790
-msgid "Sound Preferences"
-msgstr "Safidy manokan'ny feo"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "<b>Audio Conferencing</b>"
-msgstr "<b>Audio Conferencing</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "<b>Music and Movies</b>"
-msgstr "<b>Hira sy horonantsary</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "<b>Sound Events</b>"
-msgstr "<b>Zava-mitranga araham-peo</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
-msgstr "<span weight=\"bold\" size=\"x-large\">Mitsapa...</span>"
-
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Click Ok to finish."
-msgstr "Tsindrio ny Ok rehefa vita."
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "Devices"
-msgstr "Periferika"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "E_nable software sound mixing (ESD)"
-msgstr "_Alefaso ny fampifangaroana feon'ilay rindran'asa (ESD)"
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "Flash _entire screen"
-msgstr "Flasheo ny efijery _manontolo"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "Flash _window titlebar"
-msgstr "Flasheo ny anjan'ny lohaten'ny _fikandrana"
-
-#: ../capplets/sound/sound-properties.glade.h:11
-msgid "Sound & Video Preferences"
-msgstr "Safidy manokan'ny feo sy ny horonantsary"
-
-#: ../capplets/sound/sound-properties.glade.h:12
-msgid "Sound Capture:"
-msgstr "Ampaham-peo:"
-
-#: ../capplets/sound/sound-properties.glade.h:13
-msgid "Sound Playback:"
-msgstr "Famakiana feo:"
-
-#: ../capplets/sound/sound-properties.glade.h:14
-msgid "Sounds"
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
 msgstr "Feo"
 
-#: ../capplets/sound/sound-properties.glade.h:15
-msgid "System Beep"
-msgstr "Feon'ny rafitra"
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
 
-#: ../capplets/sound/sound-properties.glade.h:16
-msgid "Test"
-msgstr "Fitsapana"
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
 
-#: ../capplets/sound/sound-properties.glade.h:17
-msgid "Testing Pipeline"
-msgstr "Mitsapa ny fantsona"
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Zòma"
 
-#: ../capplets/sound/sound-properties.glade.h:18
-msgid "_Enable system beep"
-msgstr "_Alefaso ny feon'ny rafitra"
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
 
-#: ../capplets/sound/sound-properties.glade.h:19
-msgid "_Play system sounds"
-msgstr "_Vakio ireo feon'ny rafitra"
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
 
-#: ../capplets/sound/sound-properties.glade.h:20
-msgid "_Visual system beep"
-msgstr "_Feon'ny rafitry ny hita maso"
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Fafan-teny miseho _amin'ny efijery"
 
-#: ../capplets/theme-switcher/gnome-theme-details.c:368
-msgid "Would you like to remove this theme?"
-msgstr "Tianao esorina ve ity endrika ity?"
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Kitendrin'ny famerenana</b>"
 
-#: ../capplets/theme-switcher/gnome-theme-details.c:433
-msgid "Theme deleted succesfully. Please select another theme."
-msgstr "Voafafa soa aman-tsara ilay endrika. Misafidiana endrika iray hafa."
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Fipian'ny kitondro</b>"
 
-#: ../capplets/theme-switcher/gnome-theme-details.c:442
-msgid "Theme can not be deleted"
-msgstr "Tsy mety fafàna ilay endrika"
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-details.c:535
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Kitendrin'ny totozy"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Kitondro lehibe"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<b>Elanelan'ny click miverina indroa </b>"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Flasheo ny efijery _manontolo"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Flasheo ny efijery _manontolo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Mameno efijery"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Safidy"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_Fitara-mamily"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "_Fitara-mamily"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "_Mpamaky efijery"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "_Fitara-mamily"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Ny mety ahazoana anao"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Tsy misy"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Feno"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"Tsy ahitana endrika anatin'ny rafitrao. Mety mikika izany hoe tsy voapetraka "
-"araka ny tokony ho izy ny \"Theme Preferences\" na tsy napetrakao ny fehin-"
-"drindran'asa \"gnome-themes\"."
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:254
-msgid "This theme is not in a supported format."
-msgstr "Tsy raisina an-tànana ny lamin'ity endrika ity."
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:272
-msgid "Failed to create temporary directory"
-msgstr "Tsy nahaforona ny laha-tahiry vonjimaika"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:293
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"Tsy afaka mametraka ilay endrika. \n"
-"Tsy voapetraka ny rindran'asa bzip2."
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:312
-#: ../capplets/theme-switcher/gnome-theme-installer.c:351
-#: ../capplets/theme-switcher/gnome-theme-installer.c:434
-msgid "Installation Failed"
-msgstr "Nandamoka ny fametrahana"
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:333
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
 msgstr ""
-"Tsy afaka mametraka ireo endrika. \n"
-"Tsy voapetraka ny rindran'asa gzip."
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:375
-#, c-format
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "_Aza atsahatra"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Voapetraka tsara araka ny tokony ho izy ny endriky ny kisary %s. \n"
-"Azonao safidiana ao anatin'ny antsipirian'ny endrika izy io."
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:378
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr "Voapetraka araka ny tokony ho izy ny Endriky ny Gnome %s"
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:381
-#, c-format
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
 msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"Voapetra araka ny tokony ho izy ny sisim-pikandrana %s.\n"
-"Azonao safidiana ao amin'ny antsipirian'ny endrika izy io."
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:384
-#, c-format
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Teny fanalahidy vaovao:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
-"Voapetraka araka ny tokony ho izy ny endriky ny fibaikoana %s.\n"
-"Azonao safidiana ao amin'ny antsipirian'ny endrika izy io."
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:390
-msgid "The theme is an engine. You need to compile the theme."
-msgstr "Milina ilay endrika. Mila compile-nao io rakitra io."
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Hisafidy raki-peo"
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:408
-msgid "The file format is invalid"
-msgstr "Tsy ekena ny lamin'io rakitra io"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:499
-msgid "No theme file location specified to install"
-msgstr "Tsy misy toeran'endrika nolazaina ny fametrahana"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:514
-msgid "The theme file location specified to install is invalid"
-msgstr "Tsy ekena ilay toeran'endrika nolazaina ny fametrahana"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Tsy misy"
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:534
-#, c-format
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
 msgstr ""
-"Tsy ampy ny fahazoan-dàlana ahafahana mametraka ilay endrika anatin'ny:\n"
-"%s"
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:555
-msgid "The file format is invalid."
-msgstr "Tsy ekena ny lamin'io endrika io."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:582
-#, c-format
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
 msgstr ""
-"%s no sori-dàlana ametrahana ireo rakitry ny endrika. Tsy mety faritana ho "
-"toerana iaviana izy io"
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:647
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
 msgstr ""
-"Tsy afaka mametraka ilay endrika.\n"
-"Tsy voapetraka ao amin'ny solosainao ny rindran'asa tar."
 
-#: ../capplets/theme-switcher/gnome-theme-manager.c:686
-msgid "Custom theme"
-msgstr "Endrika safidy"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:686
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr "Azonao raiketina amin'ny alalan'ny tsindry Raiketo ity endrika ity."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1579
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
 msgstr ""
-"Tsy hita ao amin'ny rafitrao ny drafitry ny endrika tsotra. Midika izany fa "
-"tsy voapetraka ny metacity na tsy voakirakira araka ny tokony ho izy ny "
-"gconf."
 
-#: ../capplets/theme-switcher/gnome-theme-save.c:73
-msgid "Theme name must be present"
-msgstr "Tsy maintsy asiana anaran'endrika"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Topy maso:"
 
-#: ../capplets/theme-switcher/gnome-theme-save.c:144
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Efa misy io endrika io. Tianao tsindriana ve izy io?"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr "Misafidy endrika ampiasaina amin'ny faritra maro amin'ny sehatr'asa"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "Endrika"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "Apply _Background"
-msgstr "Ampiharo ilay _afara"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "Apply _Font"
-msgstr "Ampiharo ilay _endri-tsoratra"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Controls"
-msgstr "Fibaikoana"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Icons"
-msgstr "Kisary"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Save Theme"
-msgstr "Raiketo ilay endrika"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "Save _Background Image"
-msgstr "Raiketo ilay sarin'ny _afara"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "Select theme for the desktop"
-msgstr "Misafidiana endrika ho an'ny sehatr'asa"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-msgid "Theme Details"
-msgstr "Antsipirian'ny endrika"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-msgid "Theme Preferences"
-msgstr "Safidy manokan'ny endrika"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-msgid "Theme _Details"
-msgstr "_Antsipirian'ny endrika"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "This theme does not suggest any particular font or background."
-msgstr "Tsy milaza endri-tsoratra na afara manokana ity endrika ity."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "This theme suggests a background:"
-msgstr "Milaza afara iray ity endrika ity:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-msgid "This theme suggests a font and a background:"
-msgstr "Milaza endri-tsoratra sy afara ity endrika ity:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-msgid "This theme suggests a font:"
-msgstr "Milaza endri-tsoratra ity endrika ity:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-msgid "Window Border"
-msgstr "Sisim-pikandrana"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-msgid "_Description:"
-msgstr "_Fanoritsoritana:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-msgid "_Install Theme..."
-msgstr "_Hametraka endrika..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "_Install..."
-msgstr "_Apetrao..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-msgid "_Name:"
-msgstr "_Anarana:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-msgid "_Revert"
-msgstr "_Avereno"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-msgid "_Save Theme..."
-msgstr "_Raiketo ilay endrika..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-msgid "theme selection tree"
-msgstr "Hazon'ny fisafidianana endrika"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
 msgstr ""
-"Mamaritra ny endriky ny anjan'ny fitaovana sy tolotra amin'ny rindran'asa"
 
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "Anjan'ny tolotra & fitaovana"
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Manova ny teny fanalahidy"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
-msgstr "<b>Fiasa sy endrika</b>"
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Fitambarana fanovana"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-msgid "<b>Preview</b>"
-msgstr "<b>Topy maso</b>"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Manova ny teny fanalahidy"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "_Esory"
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Teny fanalahidy vaovao:"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-msgid "Icons only"
-msgstr "Kisary fotsiny"
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Manova ny teny fanalahidy"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "Safidy manokan'ny anjan'ny tolotra sy fitaovana"
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "Rakitra vaovao"
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Hanokatra rakitra"
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Teny fanalahidy vaovao:"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Raiketo ilay rakitra"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr "Asahoy anatin'ny tolotra ny _kisary"
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-msgid "Text below icons"
-msgstr "Ny soratra ambanin'ny kisary"
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-msgid "Text beside icons"
-msgstr "Ny soratra akaikin'ny kisary"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-msgid "Text only"
-msgstr "Soratra fotsiny"
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
-msgid "Toolbar _button labels:"
-msgstr "Mari-tsoratra amin'ny _tsindrin'ny anjan'ny fitaovana:"
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Anarana feno"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_Adikao"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
-msgstr "_Anjan'ny fitaovana azo alàna"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
 msgstr "_Ovay"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
-msgstr "Mpanafaingan'ny tolotra _azo ovaina"
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "_Rakitra"
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_Vaovao"
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
-msgstr "_Sokafy"
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "_Apetao"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "_Atontay"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "_Ajanony"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "_Raiketo"
-
-#: ../capplets/windows/gnome-window-properties.c:385
-#, c-format
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
-"<b>Tsy mahalefa ny rindran'asan'ny safidy manokan'ny mpandrindra fikandrana</"
-"b>\n"
-"\n"
-"%s"
 
-#: ../capplets/windows/gnome-window-properties.c:642
-msgid "C_ontrol"
-msgstr "Fi_baikoana"
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Fibaikoana"
 
-#: ../capplets/windows/gnome-window-properties.c:647
-msgid "_Alt"
-msgstr "_Alt"
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Mamaritra ny endri-tsoratry ny rindran'asa tsotra"
 
-#: ../capplets/windows/gnome-window-properties.c:653
-msgid "H_yper"
-msgstr "H_yper"
-
-#: ../capplets/windows/gnome-window-properties.c:660
-msgid "S_uper (or \"Windows logo\")"
-msgstr "S_uper (na \"Windows logo\")"
-
-#: ../capplets/windows/gnome-window-properties.c:667
-msgid "_Meta"
-msgstr "_Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Kitendrin'ny fihetsika</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>Asan'ny anjan'ny lohateny</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Fisafidianana fikandrana</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
 msgstr ""
-"Raha hamindra fikandrana, dia tsindrio ka tano eo ity kitendry ity ary raiso "
-"ilay fikandrana rehefa avy eo:"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Safidy manokan'ny fikandrana"
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Hafa"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
 msgstr ""
-"_Tsindrio in-2 eo amin'ny anjan'ny lohateny raha hanatanteraka ity asa "
-"manaraka ity:"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "_Elanelam-potoana alohan'ny fampakarana:"
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Tsy misy feo"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_Ampiakaro ireo fikandrana voafaritra ao anatin'ny fe-potoana iray"
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Safidio ireo fikandrana rehefa mankeo amboniny ny totozy"
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
 
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "Mamaritra ny toetoetry ny fikandranao"
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Tsindry"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Fitodika"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Tsindry"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Tsindry"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Tsindry"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Fandaminana"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Mahazo afovoa"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Tsindrio ny Ok rehefa vita."
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
 msgid "Windows"
 msgstr "Windows"
 
-#: ../control-center/control-center-categories.c:287
-msgid "Others"
-msgstr "Hafa"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
 
-#: ../control-center/control-center.c:93
-msgid "Desktop Preferences"
-msgstr "Safidy manokan'ny sehatr'asa"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr "Ivotoerana fifehezan'ny GNOME"
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
 
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "Ny fitaovana fikirakiran'ny GNOME"
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Adiresy"
 
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "Fanamafisam-peo"
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Raiketo"
 
-#: ../gnome-settings-daemon/factory.c:60
-msgid "Could not initialize Bonobo"
-msgstr "Tsy nahalefa ny Bonobo"
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
 
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:406
-msgid "Slow Keys Alert"
-msgstr "Fampilazan'ny kitendry meda"
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Antsipirian'ny endrika"
 
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:407
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Proxy'ny rezo"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Antsipirian'ny endrika"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Finday:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Proxy'ny rezo"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Proxy'ny rezo"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Antsipirian'ny endrika"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Proxy'ny rezo"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "_Alefaso ireo kitendrin'ny fiovana"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Mifandray..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Fitambarana fanovana"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Fandrindrana tsotra"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
 msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
-"Notsindrianao nandritra ny 8 segaondra ny kitendry Shift. Io no hitsin-"
-"dàlana mampadeha ny fahasahazan'ny kitendry meda izay mampiova ny fiasan'ny "
-"fafan-teninao. "
 
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:409
-msgid "Do you want to activate Slow Keys?"
-msgstr "Tianao alefa ve ny kitendry meda?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Do you want to deactivate Slow Keys?"
-msgstr "Tianao atsahatra ve ny kitendry meda?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
-msgid "_Activate"
-msgstr "_Alefaso"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
-msgid "_Deactivate"
-msgstr "_Atsaharo"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
-msgid "Do_n't activate"
-msgstr "_Aza alefa"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
-msgid "Do_n't deactivate"
-msgstr "_Aza atsahatra"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:421
-msgid "Sticky Keys Alert"
-msgstr "Fampilazan'ny kitendry miraikidraikitra"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:422
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
+#: shell/cc-window.ui:164
+msgid "Help"
 msgstr ""
-"Notsindrianao in-5 misesisesy ny kitendry Shift. Io no hitsin-dàlana "
-"mampandeha ny fahasahazan'ny kitendry miraikidraikitra izay mampiova ny "
-"fiasan'ny fafan-teninao."
 
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:424
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
 msgstr ""
-"Nanindry kitendry roa miaraka ianao, na nanindry ny kitendry Shift in-5 "
-"misesisesy. Izany dia manatsahatra ny fahasahazan'ny kitendry "
-"miraikidraikitra izay mampiova ny fiasan'ny fafan-teninao."
 
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:426
-msgid "Do you want to activate Sticky Keys?"
-msgstr "Tianao alefa ve ny kitendry miraikidraikitra?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:427
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr "Tianao atsahatra ve ny kitendry miraikidraikitra?"
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:74
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing the mouse pointer theme."
-msgstr ""
-"Tsy afaka mamorona ny laha-tahiry\"%s\".\n"
-"Ilaina izy io mba ahafahana manova ny endriky ny kitondron'ny totozy."
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:96
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-"Tsa afaka mamorona ny laha-tahiry \"%s\".\n"
-"Ilaina izy io mba ahafahana manova ny kitondro."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:208
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr "Voasoritra imbetsaka ny asan'ny Key Binding (%s)\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:221
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr "Voasoritra imbetsaka ny binding'ny Key Binding (%s)\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:227
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr "Tsy feno ny Key Binding (%s)\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:255
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr "Tsy ekena ny Key Binding (%s)\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:291
-#, c-format
-msgid "It seems that another application already has access to key '%u'."
-msgstr "Toa efa misy rindran'asa hafa mampiasa ny kitendry '%u'."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:360
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr "Key miasa ny Key Binding (%s)\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:435
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-"Nisy olana teo am-panandramana mandefa ny (%s)\n"
-"izay mifanaraka amin'ny kitendry (%s)"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:105
-#, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-"Nisy olana teo am-pandefasana ny kirakira XKB.\n"
-"Maro ireo zavatra mety mahatonga izany:\n"
-"- misy bug anatin'ny tahirin-boky libxklavier\n"
-"- misy bug anatin'ny mpizara X  (ny rindran'asa xkbcomp, xmodmap)\n"
-"- tsy mifanaraka amin'ny mpizara X fametrahana ny libxkbfile\n"
-"\n"
-"Datan'ny kinovan'ny mpizara X:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"Raha toa mitatitra ity zava-miseho ity ho toy ny bug ianao, dia lazao ao:\n"
-"- Ny valin'ny <b>%s</b>\n"
-"- Ny valin'ny <b>%s</b>"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:119
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-"Mampiasa XFree 4.3.0 ianao.\n"
-"Ahitana olana maro ny kirakira XKB maro sosona.\n"
-"Manandrama mampiasa kirakira tsotra kokoa na mametraka kinovan'ny "
-"rindran'asa XFree vaovao."
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:244
-msgid "Do _not show this warning again"
-msgstr "_Aza aseho intsony ity fampilazana ity"
-
-#. !! temporary one
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
-#, c-format
-msgid ""
-"<b>The X system keyboard settings differ from your current GNOME keyboard "
-"settings.</b>\n"
-"\n"
-"Expected was %s, but the the following settings were found: %s.\n"
-"\n"
-"Which set would you like to use?"
-msgstr ""
-"<b>Tsy mitovy amin'ny fandrindran'ny fafan-tenin'ny GNOME ny fandrindran'ny "
-"fafan-tenin'ny rafitra X.</b>\n"
-"\n"
-"%s no nampoizina, nefa ity fandrindrana manaraka ity no hita:%s.\n"
-"\n"
-"Iza amin'ireo no tianao ampiasaina?"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:275
-msgid "Use X settings"
-msgstr "Ampiasao ny fandrindran'ny X"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:277
-msgid "Keep GNOME settings"
-msgstr "Ny fandrindran'ny GNOME no ampiasao"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:118
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
-msgstr ""
-"Tsy afaka nanatanteraka ny baiko: %s\n"
-"Amarino hoe misy io baiko io."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:134
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-"Tsy afaka nampiato ny solosaina.\n"
-"Amarino hoe voakirakira araka ny tokony ho izy ilay solosaina."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:168
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-"Tsy afaka naka ny rakitra Glade.\n"
-"Amarino hoe voapetraka araka ny tokony ho izy io daemon io."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:110
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-"Nisy olana teo am-pandefasana ny sary mitsitsy:\n"
-"\n"
-"%s\n"
-"Tsy handeha amin'ity session ity fahasahazan'ny sary mitsitsy."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:120
-msgid "_Do not show this message again"
-msgstr "_Aza aseho intsony ity filazana ity"
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:131
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr "Tsy afaka naka ny raki-peo %s hatao sombiny %s"
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:212
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:260
-msgid "Cannot determine user's home directory"
-msgstr "Tsy afaka namaritra ny laha-tahiry fandraisan'ny mpampiasa"
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:212
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr ""
-"Voafarirtra manaraka ny karazana %s ny famaha GConf %s, nefa ny karazany "
-"nampoizina dia %s\n"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-msgid "A_vailable files:"
-msgstr "Ireo rakitra _misy:"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-msgid "Do _not show this warning again."
-msgstr "Aza aseho _intsony ity fampilazana ity."
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
-msgstr "Alaivo ireo rakitra modmap"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
-msgstr "Tianao alaina ilay (ireo) rakitra modmap?"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr "_Alaivo"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-msgid "_Loaded files:"
-msgstr "_Ireo rakitra azo:"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr "Nisy olana teo am-pamoronana fantson'ny fambara."
-
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "Karazana"
-
-#: ../libbackground/applier.c:256
-msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-msgstr ""
-"Karazan'ny bg_applier: BG_APPLIER_ROOT ho an'ny fikandran'ny faka na "
-"BG_APPLIER_PREVIEW ho an'ny topy maso"
-
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr "Topy maso ny sakany"
-
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr "Ny sakany raha toa ka topy maso ilay mpampihatra: 64 (sanda tsotra)."
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr "Topy maso ny haavony"
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr "Ny haavony raha toa ka topy maso ilay mpampihatra: 48 (sanda tsotra)."
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Efijery"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr "Ny efijery hivelaran'ny BGApplier"
-
-#: ../libgswitchit/gswitchit_config.c:1074
-#, c-format
-msgid "There was an error loading an image: %s"
-msgstr "Nisy olana teo am-pakana ny sary iray: %s"
-
-#: ../libgswitchit/gswitchit_config.c:1399
-#, c-format
-msgid "layout \"%s\""
-msgid_plural "layouts \"%s\""
-msgstr[0] "Fandaminana \"%s\""
-msgstr[1] "Fandaminana \"%s\""
-
-#: ../libgswitchit/gswitchit_config.c:1416
-#, c-format
-msgid "option \"%s\""
-msgid_plural "options \"%s\""
-msgstr[0] "Safidy \"%s\""
-msgstr[1] "Safidy \"%s\""
-
-#: ../libgswitchit/gswitchit_config.c:1424
-#, c-format
-msgid "model \"%s\", %s and %s"
-msgstr "modely \"%s\", %s ary %s"
-
-#: ../libgswitchit/gswitchit_config.c:1425
-msgid "no layout"
-msgstr "tsy misy fandaminana"
-
-#: ../libgswitchit/gswitchit_config.c:1426
-msgid "no options"
-msgstr "tsy misy safidy"
-
-#: ../libsounds/sound-view.c:43
-msgid "Login"
-msgstr "Fidirana"
-
-#: ../libsounds/sound-view.c:44
-msgid "Logout"
-msgstr "Fivoahana"
-
-#: ../libsounds/sound-view.c:45
-msgid "Boing"
-msgstr "Fanakorana"
-
-#: ../libsounds/sound-view.c:46
-msgid "Siren"
-msgstr "Anjombona"
-
-#: ../libsounds/sound-view.c:47
-msgid "Clink"
-msgstr "Feo mikarantsana"
-
-#: ../libsounds/sound-view.c:48
-msgid "Beep"
-msgstr "Bip"
-
-#: ../libsounds/sound-view.c:49
-msgid "No sound"
-msgstr "Tsy misy feo"
-
-#: ../libsounds/sound-view.c:131
-msgid "Sound not set for this event."
-msgstr "Tsy voafaritra ny feo ho an'ity zava-miseho ity."
-
-#: ../libsounds/sound-view.c:140
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package for a set of default sounds."
-msgstr ""
-"Tsy misy ny raki-peo ho an'ity zava-miseho ity.\n"
-"Mety mila mametraka ny fehy gnome-audio izay misy feo tsotra maromaro "
-"angamba ianao."
-
-#: ../libsounds/sound-view.c:151
-msgid "The sound file for this event does not exist."
-msgstr "Tsy misy ny raki-peo ho an'ity zava-miseho ity."
-
-#: ../libsounds/sound-view.c:182
-msgid "Select Sound File"
-msgstr "Hisafidy raki-peo"
-
-#: ../libsounds/sound-view.c:202
-#, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "Rakitra .wav tsy ekena ny rakitra %s"
-
-#: ../libsounds/sound-view.c:359
-msgid "System Sounds"
-msgstr "Feon'ny rafitra"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr ""
-"Tsy nanambara fitaovana fikirakirana ny mpandrindra fikandrana \"%s\" \n"
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Alehibiazo"
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Aforeto miakatra"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr ""
-"Raha marina izay voalaza, dia ho tazonina ao anatin'ny sync ireo mpandray an-"
-"tànana mime ho an'ny text/plain and text/*"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr "Ireo mpandray an-tànana ny text/plain and text/* an'ny sync"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "E-mail"
-msgstr "Mailaka"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "E-mail's shortcut."
-msgstr "Hitsin-dàlan'ny mailaka."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Eject"
-msgstr "Tsoahy"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Eject's shortcut."
-msgstr "Hitsin-dàlan'ny Tsoahy."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "Home folder"
-msgstr "Laha-tahirin'ny fandraisana"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "Home folder's shortcut."
-msgstr "Hitsin-dàlan'ny laha-tahirin'ny fandraisana."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Launch help browser"
-msgstr "Alefaso ny mpizaha toro-làlana"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-msgid "Launch help browser's shortcut."
-msgstr "Hitsin-dàlan'ny Alefaso ny mpizaha toro-làlana."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-msgid "Launch web browser"
-msgstr "Alefaso ny mpitety tranonkala"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-msgid "Launch web browser's shortcut."
-msgstr "Hitsin-dàlan'ny Alefaso ny mpitety tranonkala."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-msgid "Lock screen"
-msgstr "Gejao ny efijery"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-msgid "Lock screen's shortcut."
-msgstr "Hitsin-dàlan'ny Gejao ny efijery."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-msgid "Log out"
-msgstr "Hivoaka"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-msgid "Log out's shortcut."
-msgstr "Hitsin-dàlan'ny Hivoaka."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-msgid "Next track key's shortcut."
-msgstr "Hitsin-dàlan'ny tsindry Manaraka."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-msgid "Pause"
-msgstr "Miato"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-msgid "Pause key's shortcut."
-msgstr "Hitsin-dàlan'ny tsindry Miato."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-msgid "Play (or play/pause)"
-msgstr "Mamaky (na mamaky/miato)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Play (or play/pause) key's shortcut."
-msgstr "Hitsin-dàlan'ny tsindry Mamaky (na mamaky/miato)."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Previous track key's shortcut."
-msgstr "Hitsin-dàlan'ny tsindry Aloha."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Ajanony"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Search"
 msgstr "Karohy"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Search's shortcut."
-msgstr "Hitsin-dàlan'ny Karohy."
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Skip to next track"
-msgstr "Mamaky ny hira manaraka"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Skip to previous track"
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
 msgstr "Mamaky ny hira teo aloha"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
-msgid "Sleep"
-msgstr "Fiatoana"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-msgid "Sleep's shortcut."
-msgstr "Hitsin-dàlan'ny Fiatoana."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Stop playback key"
-msgstr "Ajanony"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Stop playback key's shortcut."
-msgstr "Hitsin-dàlan'ny Ajanony."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-msgid "Volume down"
-msgstr "Ambany"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-msgid "Volume down's shortcut."
-msgstr "Hitsin-dàlan'ny fanamorana feo."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Volume mute"
-msgstr "Malefaka"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Volume mute's shortcut"
-msgstr "Hitsin-dàlan'ny Fanalefahana feo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
-msgid "Volume step"
-msgstr "Dingan'ny fanamafisam-peo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume step as percentage of volume."
-msgstr "Dingana mampiseho ny hamafin'ny feo."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-msgid "Volume up"
-msgstr "Ambony"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume up's shortcut."
-msgstr "Hitsin-dàlan'ny Fanamafisana feo."
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
-msgid "Display a dialog when there are errors running the screensaver"
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
 msgstr ""
-"Mampiseho takelaka kely rehefa misy olana ny fandefasana ny sary mitsitsy"
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-msgid "Run screensaver at login"
-msgstr "Alefaso eny am-pidirana ny sary mitsitsy"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
-msgstr "Asehoy ireo tsy fetezana mitranga eny am-piandohana"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
-msgid "Start screensaver"
-msgstr "Alefaso ny sary mitsitsy"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
-msgstr ""
-"Fitambaran-teny baiko alefa isaky ny averina alaina ny toetry ny fafan-teny. "
-"Ilaina ho an'ny fampiharana indray ireo fanitsiana mifototra amin'ny xmodmap "
-"izy ireo"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
-msgstr "Lisitr'ireo rakitra modmap hita ao anatin'ny laha-tahiry $HOME."
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
-msgstr "Vondrona tsotra voafaritra mandritra ny famoronana fikandrana"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr "Tano ary arindrao isaka ny fikandrana iray ny vondrona iray"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
-msgid "Keyboard Update Handlers"
-msgstr "Mpandray an-tànana ny fanavaozana ny fafan-teny"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
-msgid "Keyboard layout"
-msgstr "Fandaminana ny fafan-teny"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
-msgid "Keyboard model"
-msgstr "Modelim-pafan-teny"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
-msgid "Keyboard options"
-msgstr "Safidin'ny fafan-teny"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
-msgstr ""
-"Ho fehezina avy amin'ny ASAP'ny rafitra ireo fandrindran'ny fafan-teny ao "
-"amin'ny gconf (tsy ampiasaina intsony)"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
-msgstr "Raiketo/avereno miaraka amin'ny vondron'ny fandaminana ireo mpilaza"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
-msgstr "Ireo anaran'ny fandaminana no asehoy fa tsy ireo anaran'ny vondrona"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
-msgstr ""
-"Ireo anaran'ny fandaminana no asehoy fa tsy ireo anaran'ny vondrona (ho "
-"an'ny kinovan'ny XFree izay mandray an-tànana fandaminana maro ihany)"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr "Fafao ny fampilazana \"X sysconfig changed\""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid "The Keyboard Preview, X offset"
-msgstr "Topy mason'ny fafan-teny, offset X"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
-msgid "The Keyboard Preview, Y offset"
-msgstr "Topy mason'ny fafan-teny, offset Y"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
-msgid "The Keyboard Preview, height"
-msgstr "Topy mason'ny fafan-teny, haavo"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "The Keyboard Preview, width"
-msgstr "Topy mason'ny fafan-teny, saka"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:18
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
-msgstr ""
-"Afaka fotoana fohy dia ho fehezina avy amin'ny kirakiran'ny rafitra ireo "
-"fandrindrana ny fafan-teny ao amin'ny gconf. Efa hatramin'ny GNOME 2.12 no "
-"tsy nampiasaina izany famaha izany, ka foano ireo famahan'ny modely, "
-"fandaminana ary safidy mba ahazoana ny kirakiran-drafitra tsotra."
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:19
-msgid "keyboard layout"
-msgstr "fandaminana ny fafan-teny"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:20
-msgid "keyboard model"
-msgstr "Modelim-pafan-teny"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:21
-msgid "modmap file list"
-msgstr "lisitry ny rakitra modmap"
-
-#: ../typing-break/drw-break-window.c:213
+#: shell/org.gnome.Settings.desktop.in.in:17
 #, fuzzy
-msgid "_Postpone break"
-msgstr "_Ahemory ny fiatoana"
-
-#: ../typing-break/drw-break-window.c:260
-msgid "Take a break!"
-msgstr "Hiato kely!"
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:135
-msgid "/_Preferences"
+msgid "Preferences;Settings;"
 msgstr "/_Safidy manokana"
 
-#: ../typing-break/drwright.c:136
-msgid "/_About"
-msgstr "/_Mombamomba"
-
-#: ../typing-break/drwright.c:138
-msgid "/_Take a Break"
-msgstr "/_Hiato kely"
-
-#: ../typing-break/drwright.c:489
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "%d minitra mandra-pahatongan'ny fiatoana manaraka"
-msgstr[1] "%d minitra mandra-pahatongan'ny fiatoana manaraka"
-
-#: ../typing-break/drwright.c:493
-msgid "Less than one minute until the next break"
-msgstr "Latsaka ny iray minitra mandra-pahatongan'ny fiatoana manaraka"
-
-#: ../typing-break/drwright.c:581
-#, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
 msgstr ""
-"Tsy afaka mampiseho ny takilan'ny toetoetry ny fiatona amin'ny fanoratana "
-"miaraka amin'ny ity tsy fetezana manaraka ity: %s"
 
-#: ../typing-break/drwright.c:629
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgid "Image/label border"
+#~ msgstr "Sisin'ny sary/mari-tsoratra"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr ""
+#~ "Ny sakan'ny sisin'ny mari-tsoratra sy ny sary anatin'ny takelakakelin'ny "
+#~ "filazana"
+
+#~ msgid "The type of alert"
+#~ msgstr "Ny karazan'ny filazana"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Ireo tsindry miseho eo amin'ny takelakakelin'ny filazana"
+
+#~ msgid "Show more _details"
+#~ msgstr "Asehoy amin'ny _antsipiriany"
+
+#~ msgid "About Me"
+#~ msgstr "Momba izaho"
+
+#~ msgid "No Image"
+#~ msgstr "Tsy misy sary"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Nnisy olana teo am-panandramana maka ny lazan'ny bokin'adiresy\n"
+#~ "Tsy raisin'ny Evolution Data Server an-tànana io firesaka io"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Tsy mety mahasokatra ny bokin'adiresy"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr ""
+#~ "ID'ny fidirana tsy fantatra. Mety simba angamba ny soratra fototry ny "
+#~ "mpampiasa."
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "Momba ny %s"
+
+#~ msgid "Old password is incorrect, please retype it"
+#~ msgstr "Tsy marina ny teny fanalahidy taloha voasoratra. Avereno soratana"
+
+#~ msgid "System error has occurred"
+#~ msgstr "Nisy olan'ny rafitra nitranga"
+
+#~ msgid "Could not run /usr/bin/passwd"
+#~ msgstr "Tsy nahalefa ny /usr/bin/passwd"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "Tsy mety mahalefa ny backend"
+
+#~ msgid "Unexpected error has occurred"
+#~ msgstr "Nisy olana tsy nampoizina nitranga"
+
+#~ msgid "Password is too short"
+#~ msgstr "Fohy loatra io teny fanalahidy io"
+
+#~ msgid "Password is too simple"
+#~ msgstr "Tsotra loatra io teny fanalahidy io"
+
+#~ msgid "Old and new passwords are too similar"
+#~ msgstr "Tsy dia mifankaiza loatra ireo teny fanalahidy taloha sy vaovao"
+
+#~ msgid "Must contain numeric or special character(s)"
+#~ msgstr "Tsy maintsy misy isa na marika manokana"
+
+#~ msgid "Old and new password are the same"
+#~ msgstr "Mitovy ireo teny fanalahidy taloha sy vaovao"
+
+#~ msgid "Please type the passwords."
+#~ msgstr "Soraty ireo teny fanalahidy."
+
+#~ msgid "Please type the password again, it is wrong."
+#~ msgstr ""
+#~ "Avereno soratana indray ilay teny fanalahidy. Diso io voasoratra io."
+
+#~ msgid "Click on Change Password to change the password."
+#~ msgstr "Tsindrio ny Hanova Teny Fanalahidy raha hanova ny teny fanalahidy."
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Fandraisana</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Fifandraisana eo no eo</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Asa</b>"
+
+#~ msgid "<b>Please type the passwords.</b>"
+#~ msgstr "<b>Soraty ilay teny fanalahidy.</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Telefaonina</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Tranonkala</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Toeram-piasana</b>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "A_diresy:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "_Mpanampy:"
+
+#~ msgid "C_ity:"
+#~ msgstr "_Tanàna:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "_Orinasa:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Hanova _teny fanalahidy..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "_Tanàna:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "_Firenena:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "_Firenena:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "_Trano:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "Old pa_ssword:"
+#~ msgstr "_Teny fanalahidy taloha:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "Laharan'ny _Boatin-taratasy:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "Laharan'ny _Boatin-taratasy:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Momba ny tena manokana"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Fanjakana/Fa_ritany:"
+
+#~ msgid "Web _log:"
+#~ msgstr "_Raki-tatitry ny tranonkala:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_Toeram-piasana:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "_Fax ao amin'ny toeram-piasana:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "Mari-pamantaran'ny _paositra:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "Pejy _fandraisana:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Fandraisana:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Mpandrindra:"
+
+#~ msgid "_Profession:"
+#~ msgstr "_Asa:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_Faritany:"
+
+#~ msgid "_Title:"
+#~ msgstr "_Mpialoha anarana:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Toeram-piasana:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "Mari-pamantaran'ny _paositra:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Fanampiana</b>"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>Note:</b> Tsy hihatra ireo fanovana natao tamin'ity "
+#~ "fandrindrana ity raha tsy rehefa miditra indray ianao.</i></small>"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Safidy manokan'ny haitao fanamorana"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Hidio dia _mivoaha"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Mandefa ireo haitao fanamorana ireo isaky ny miditra ianao:"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Alefaso ireo haitao fanamorana"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "Fanampiana mikasika ny haitao fanamorana"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr ""
+#~ "Alefaso ny fandraisana an-tànana ireo haitao fanamorana an'ny GNOME "
+#~ "rehefa miditra"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Tsy misy haitao fanamorana ao amin'ny solosainao. Tsy maintsy apetraka ny "
+#~ "fehin-drindran'asa 'gok' izay vao afaka mampiasa ny fafan-teny miseho "
+#~ "amin'ny efijery. Tsy maintsy apetraka koa ny fehin-drindran'asa "
+#~ "'gnopernicus' izay vao afaka mampiasa mpamaky efijery sy fitara-mamily."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Tsy voapetraka ao amin'ny solosainao avokoa ireo haitao fanamorana misy. "
+#~ "Tsy maintsy apetraka ny fehin-drindran'asa 'gok' vao afaka mandray an-"
+#~ "tànana fafan-teny miseho amin'ny efijery."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+#~ msgstr ""
+#~ "Tsy voapetraka ao amin'ny solosainao avokoa ireo haitao fanamorana misy. "
+#~ "Tsy maintsy apetraka ny fehin-drindran'asa 'gnopernicus' vao afaka "
+#~ "mampiasa mpamaky efijery sy fitara-mamily."
+
+#, c-format
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr ""
+#~ "Nisy olana teo am-pandefasana ny takelaka kelin'ny safidy manokan'ny "
+#~ "totozy: %s"
+
+#, c-format
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Tsy nahaaftra fandrindrana AccessX avy amin'ny rakitra '%s'"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Hanafatra rakitra misy fandrindrana fahasahaza"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Mamaritra ny safidy manokan'ny fahafahana mampiasa ny fafan-teny"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Toa tsy manana ny tovana XKB ity rafitra ity. Tsy mandeha ny "
+#~ "fahasahazan'ny fahafahana mampiasa ny fafan-teny  raha tsy misy io tovana "
+#~ "io."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>Alefaso ireo kitendry _faingana</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>Alefaso ireo kitendry _votsa</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Alefaso ireo kitendrin'ny _totozy</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>Alefaso ireo kitendry _famerenana</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>Alefaso ireo kitendry _miraikidraikitra</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Fahasahaza</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Kitendrin'ny fiovana</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Fototra"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr ""
+#~ "Maneno raha alefa na ajanona avy amin'ny fafan-teny ireo _fahasahaza"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr ""
+#~ "Maneno in-1 rehefa mirehitra ny jiro LED ary in-2 rehefa maty io jiro io."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr ""
+#~ "Ny elanelana ara-potoana misy eo amin'ny fanindriana kitendry sy ny "
+#~ "_fihetsiky ny kitondro:"
+
+#~ msgid "Filters"
+#~ msgstr "Sivana"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Tsy mandraharaha ny fanindriana mifanarakaraka kitendry IRAY raha toa ka "
+#~ "mitranga anatin'ny fotoana azon'ny mpampiasa faritana izany.s"
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Safidy manokan'ny fahafahana mampiasa ny fafan-teny (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Hafainganan'ny kitondro _ambony indrindra:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "_Safidy manokan'ny totozy..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Aza ekena ireo kitendry raha tsy efa voatsindry mandritra ny fotoana "
+#~ "azon'ny mpampiasa faritana."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Manao fanindriana kitendry miara-miseho amin'ny alalan'ny fanidriana "
+#~ "misesisesy ireo kitendrin'ny fanovana."
+
+#~ msgid "S_peed:"
+#~ msgstr "_Hafainganana:"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Ny fotoana ilaina _hahatratrarana ny hafainganana ambony indrindra:"
+
 #, fuzzy
-msgid "About GNOME Typing Monitor"
-msgstr "Mombamomba ny Mpandrindra Fanoratana an'ny GNOME"
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Manova ny kitendrin'isa ho kitendrin'ny totozy."
 
-#: ../typing-break/drwright.c:653
-msgid "A computer break reminder."
-msgstr "Feo filazana fiatoana amin'ny solosaina."
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Atsaharo raha tsy ampiasaina mandritra ny:"
 
-#: ../typing-break/drwright.c:654
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
-msgstr "Nosoratan'i Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "_Alefaso ireo fahasahazan'ny fahafahana mampiasa ny fafan-teny"
 
-#: ../typing-break/drwright.c:655
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Eye Candy nampidirin'i Anders Carlsson"
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Hanafatra fandrindrana fahasahaza..."
 
-#: ../typing-break/drwright.c:831
-msgid "Break reminder"
-msgstr "Mpampatsiahy fiatoana"
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "_Aza manaiky afa-tsy ireo kitendry voatsindry mandritra ny:"
 
-#: ../typing-break/eggtrayicon.c:127
-msgid "Orientation"
-msgstr "Fitodika"
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Manorata hitsapana ireo fandrindrana:"
 
-#: ../typing-break/eggtrayicon.c:128
-msgid "The orientation of the tray."
-msgstr "Ny fitodiky ny tray."
+#~ msgid "_accepted"
+#~ msgstr "_Ekena"
 
-#: ../typing-break/main.c:100
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
-msgstr ""
-"Ny mpandrindra fanoratana dia mampiasa ny faritra filazana hanaovana "
-"fampahalalana. Toa tsy misy faritra filazana eo amin'ny tontonanao. Raha "
-"hametraka izany eo ianao, dia tondroy ny tontonana, tsindrio ny kitendry "
-"havanan'ny totozy, tsindrio ny 'Atao eo amin'ny tontonana', safidio ny "
-"'Faritra filazana' ary tsindrio ny 'Apetrao'."
+#~ msgid "_pressed"
+#~ msgstr "_voatsindry"
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr ""
-"Mitsambikina eo amibonin'ny ilay alika kamo ilay fosa miloko manja. "
-"0123456789"
+#~ msgid "_rejected"
+#~ msgstr "_Lavina"
 
-#: ../vfs-methods/fontilus/font-view.c:276
-msgid "Name:"
-msgstr "Anarana:"
+#~ msgid "characters/second"
+#~ msgstr "marika/segaondra"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "Endrika:"
+#~ msgid "milliseconds"
+#~ msgstr "milisegaondra"
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "Karazana:"
+#~ msgid "pixels/second"
+#~ msgstr "pixel/segaondra"
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "Habe:"
+#~ msgid "Desktop Background"
+#~ msgstr "Afaran'ny sehatr'asa"
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "Kinova:"
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>_Taratasy manaingo</b>"
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "Fameran-jo:"
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>Lokon'ny _sehatr'asa</b>"
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "Fanoritsoritana:"
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Safidy manokan'ny afaran'ny sehatr'asa"
 
-#: ../vfs-methods/fontilus/font-view.c:408
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Manokatra takelaka kely ahafahana mamaritra ny loko"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Hanampy taratasy manaingo"
+
+#~ msgid "_Finish"
+#~ msgstr "_Vita"
+
+#~ msgid "_Style:"
+#~ msgstr "_Endrika:"
+
 #, c-format
-msgid "usage: %s fontfile\n"
-msgstr "fampiasa: rakitr'endri-tsoratra %s\n"
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Nisy olana teo am-manehoana ireo toro-làlana: %s"
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
-msgstr "Farito ho endri-tsoratry ny rindran'asa"
+#~ msgid "Tiled"
+#~ msgstr "Mizarazara"
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
-msgid "Sets the default application font"
-msgstr "Mamaritra ny endri-tsoratry ny rindran'asa tsotra"
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Mandry misompirana"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr ""
-"Raha voalaza ho marina, dia haseho anaty sary madinika ireo endri-tsoratra "
-"OpenType."
+#~ msgid "Vertical Gradient"
+#~ msgstr "Mitsangana misompirana"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr ""
-"Raha voalaza fa marina, dia haseho anaty sary madinika ireo endri-tsoratra "
-"PCF."
+#~ msgid "Add Wallpaper"
+#~ msgstr "Hanampy taratasy manaingo"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr ""
-"Raha voalaza fa marina, dia haseho anaty sary madinika ireo endri-tsoratra "
-"TrueType."
+#~ msgid "Images"
+#~ msgstr "Sary"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr ""
-"Raha voalaza fa marina, dia haseho anaty sary madinika ireo endri-tsoratra "
-"Type1."
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "pixel"
+#~ msgstr[1] "pixel"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
-msgstr ""
-"Ampifanarao amin'ny baiko amoronana sary madinika ho an'ny endri-tsoratra "
-"OpenType ity famaha ity."
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Tsy nahalefa ny mpandrindra kirakira 'gnome-settings-daemon'.\n"
+#~ "Mety tsy hihatra ny safidy manokana sasany raha tsy mandeha io "
+#~ "mpandrindra ny kirakiran'ny GNOME io. Mety midika izany fa misy olana "
+#~ "amin'ny Bonobo, na mety efa misy mpandrindra kirakira tsy an'ny GNOME "
+#~ "(ohatra: KDE) mandeha ka mifanipaka amin'ny an'ny GNOME."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr ""
-"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endri-tsoratra "
-"PCF ity famaha ity."
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Tsy afaka nangala ny kisary tahiry '%s'\n"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr ""
-"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endri-tsoratra "
-"TrueType ity famaha ity."
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Ampiharo fotsiny ireo fandrindrana dia ajanony"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr ""
-"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endri-tsoratra "
-"Type1 ity famaha ity."
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Alaivo ary raiketo ireo fandrindrana taloha"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra openType"
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Mandika ilay rakitra: %u amin'ny %u"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra PCF"
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "Mandika ny '%s'"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra TrueType"
+#~ msgid "From URI"
+#~ msgstr "Avy amin'ny URI"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra Type1"
+#~ msgid "URI currently transferring from"
+#~ msgstr "Ny URI dia mamindra avy amin'ny"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "(Tsy) maneho ny endri-tsoratra OpenType anaty sary madinika"
+#~ msgid "To URI"
+#~ msgstr "Mankany amin'ny URI"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "(Tsy) maneho ny endri-tsoratra PCF anaty sary madinika"
+#~ msgid "URI currently transferring to"
+#~ msgstr "Ny URI dia mamindra mankany amin'ny"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "(Tsy) maneho ny endri-tsoratra TrueType anaty sary madinika"
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Vita ny fizarana ny famindrana"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "(Tsy) maneho ny endri-tsoratra Type1 anaty sary madinika"
+#~ msgid "Current URI index"
+#~ msgstr "Fizahan-takilan'ity URI ity"
 
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
-msgid "GNOME Font Viewer"
-msgstr "Mpijery endri-tsoratra an'ny GNOME"
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Fizahan-takilan'ity URI ity - manomboka amin'ny 1"
 
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-msgstr ""
-"<span weight=\"bold\" size=\"larger\">Ampiharina ilay endri-tsoratra vaovao?"
-"</span>"
+#~ msgid "Total URIs"
+#~ msgstr "Tontalin'ireo URI"
 
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr "_Aza ampiharina"
+#~ msgid "Total number of URIs"
+#~ msgstr "Tontalin'ny isan'ny URI"
 
-#: ../vfs-methods/themus/apply-font.glade.h:4
-msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
-msgstr ""
-"Tahaka ny endri-tsoratra vaovao ilay endrika nosafidianao. Miseho etsy "
-"ambany ny sariny."
+#~ msgid "Key"
+#~ msgstr "Kitendry"
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-msgid "_Apply font"
-msgstr "_Ampiharo"
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Ny famaha GConf arahan'ity mpanova toetoetra ity"
 
-#: ../vfs-methods/themus/theme-method.c:518
-msgid "Themes"
-msgstr "Endrika"
+#~ msgid "Callback"
+#~ msgstr "Antso"
 
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "Fanoritsoritana"
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Mandefa ity antso rehefa miova ny sanda mifandraika amin'ilay famaha"
 
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
-msgstr "Endriky ny fibaikoana"
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Fitambarana fanovana misy data alefa mankany amin'ny mpivatsin'ny gconf "
+#~ "rehefa atao ny fampiharana"
 
-#: ../vfs-methods/themus/themus-properties-view.c:139
-msgid "Window border theme"
-msgstr "Endriky ny sisin'ny fikandrana"
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Fivadihana mankany amin'ny antso widget"
 
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
-msgstr "Endriky ny kisary"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Antso halefa rehefa misy data havadika avy amin'ny GConf mankany "
+#~ "amin'ilay widget"
 
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
-msgstr "ABCDEFG"
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Fivadihana avyamin'ny antso widget"
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-msgid "Apply theme"
-msgstr "Ampiharo ilay endrika"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Antso halefa rehefa misy data havadika avy amin'ny widget mankany amin'ny "
+#~ "GConf s"
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-msgid "Sets the default theme"
-msgstr "Mamaritra ny endrika tsotra"
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Zavatra iray izay mifehy ny toetoetra (tokony ho widget)"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr ""
-"Raha voalaza fa marina, dia haseho anaty sary madinika ireo endrika "
-"voapetraka."
+#~ msgid "Property editor object data"
+#~ msgstr "Datan'ny zavatry ny mpanova toetoetra"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr "Raha voalaza ho marina, dia haseho anaty sary madinika ireo endrika."
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Data manokana ilain'ny mpanova toetoetra voafaritra"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:3
-msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
-msgstr ""
-"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endrika "
-"voapetraka ity famaha ity."
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Datan'ny mpanova toetoetra mamotsotra antso"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
-msgstr ""
-"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endrika ity "
-"famaha ity."
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Antso halefa rehefa havotsotra ny datan'ny zavatry ny mpanova toetoetra"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr "Baiko amoronana sary madinika ho an'ny sary voapetraka"
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Tsy nahita ny rakitra '%s'.\n"
+#~ "\n"
+#~ "Amarino tsara hoe misy izy io dia andramo indray avy eo, na misafidiana "
+#~ "sary afara hafa."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr "Baiko amoronana sary madinika ho an'ny endrika"
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Tsy haiko ny manokatra ny rakitra '%s'.\n"
+#~ "Mety karazan-tsary tsy mbola voaray an-tànana angamba izy io.\n"
+#~ "\n"
+#~ "Misafidiana sary hafa asolo azy."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr "(Tsy) maneho ireo endrika voapetraka anaty sary madinika"
+#~ msgid "Please select an image."
+#~ msgstr "Misafidiana sary iray."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr "(Tsy) maneho ireo endrika anaty sary madinika"
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Nisy olana teo am-pandraiketana ny kirakira: %s"
 
-msgid "Show help options"
-msgstr "Asehoy ny safidy momba ny toro-làlana"
+#~ msgid "Custom"
+#~ msgstr "Safidy"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Tsy afaka naka ny mpanera fototra"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian Sensible Browser"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian Terminal Emulator"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Mpitety tranonkalan'ny Epiphany"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution Mail Reader"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "Evolution Mail Reader 1.4"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "Evolution Mail Reader 1.5"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "Evolution Mail Reader 1.6"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "Evolution Mail Reader 2.0"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "Evolution Mail Reader 2.2"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "Evolution Mail Reader 2.4"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Mpitety Links Text"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Mpitety Lynx Text"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "XTerminal tsotra"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "Mpitety Soratra W3M"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "<b>Audio Player</b>"
+#~ msgstr "<b>Fiahinoana raki-peo</b>"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>Mpizaha sary</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>Mpampifandray eo no eo</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>Mpamaky mailaka</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Terminal Emulator</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Mpanova lahabolana</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Fijerena horonan-tsary</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Mpitety tranonkala</b>"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Ho soloina ity rohy ity daholo ireo %s rehetra"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "Sain'ny takila _fanatanterahana:"
+
+#~ msgid "Internet"
+#~ msgstr "Internet"
+
+#~ msgid "Multimedia"
+#~ msgstr "Haino aman-jery"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Sokafy anaty _vakizoro vaovao ilay rohy"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Sokafy anaty _fikandrana vaovao ilay rohy"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr ""
+#~ "Sokafy amin'ny alalan'ny safidy _tsotran'ny mpitety tranonkala ilay rohy"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Alefaso amin'ny alalan'ny _Terminal"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Hanova ny resolution'ny efijery"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Safidy manokana mikasikan ny resolution'ny efijery"
+
+#, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Ataovy safidy tsotra ho an'ity solosaina (%s) ity ihany"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Mitsapa ireo fandrindrana vaovao. Raha tsy manome valin-teny anatin'ny %d "
+#~ "segaondra ianao dia haverina ireo fandrindrana teo aloha."
+#~ msgstr[1] ""
+#~ "Mitsapa ireo fandrindrana vaovao. Raha tsy manome valin-teny anatin'ny %d "
+#~ "segaondra ianao dia haverina ireo fandrindrana teo aloha."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Tano io resolution io"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Tianao tanana io resolution io?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "Ny resolution _teo aloha ampiasaina"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Tano io resolution io"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "Tsy mandray an-tànana ny tovana XRandR ny mpizara X. Tsy misy fanovana "
+#~ "resolution runtime azo ampiharina amin'ny haben'ny efijery ao."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Tsy mifanaraka amin'ity rindran'asa ity ny kinovan'ny tovana XRandR. Tsy "
+#~ "misy fanovana runtime azo ampiharina amin'ny haben'ny efijery ao."
+
+#~ msgid "Font"
+#~ msgstr "Endri-tsoratra"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Ahafahana misafidy endri-tsoratra ho an'ny sehatr'asa"
+
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<b>Fivoakan'ny endri-tsoratra</b>"
+
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<b>Hinting</b>:"
+
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<b>Fandamalamana</b>:"
+
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<b>Filaharan'ny subpixel</b>:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "_Bika tsara indrindra"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "_Fifangarihana tsara indrindra"
+
+#~ msgid "D_etails..."
+#~ msgstr "An_tsipiriany..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Endri-tsoratry ny sehatr'asa:"
+
+#~ msgid "Font Preferences"
+#~ msgstr "Safidy manokan'ny endri-tsoratra"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "_Laha-tahirin'ny endri-tsoratra"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Ambara_tongan-doko mivolombatolalaka"
+
+#~ msgid "N_one"
+#~ msgstr "Tsy _misy"
+
+#~ msgid "R_esolution:"
+#~ msgstr "R_esolution:"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sub_pixel (LCD)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Fandamalamana sub_pixel (LCD)"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Endri-tsoratry ny tahirin-kevitra:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "Sakan'endri-tsoratra voafetra:"
+
+#~ msgid "_Medium"
+#~ msgstr "_Antonony"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Tokan-doko"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "Endri-tsoratra ho an'ny lohatenin'ny _fikandrana:"
+
+#~ msgid "dots per inch"
+#~ msgstr "dpi"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Mety lehibe loatra ilay endri-tsoratra"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe "
+#~ "loatra (x %d) ny endri-tsoratra nosafidianao. Tsara raha mampiasa endri-"
+#~ "tsoratra kely noho ny %d ianao."
+#~ msgstr[1] ""
+#~ "Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe "
+#~ "loatra (x %d) ny endri-tsoratra nosafidianao. Tsara raha mampiasa endri-"
+#~ "tsoratra kely noho ny %d ianao."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe "
+#~ "%d teboka loatra ny endri-tsoratra nosafidianao. Tsara raha misafidy "
+#~ "endri-tsoratra kely noho io ianao."
+#~ msgstr[1] ""
+#~ "Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe "
+#~ "%d teboka loatra ny endri-tsoratra nosafidianao. Tsara raha misafidy "
+#~ "endri-tsoratra kely noho io ianao."
+
+#~ msgid "New accelerator..."
+#~ msgstr "Mpanfaingana vaovao..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Kitendry mpanafaingana"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Mpanova ireo mpanafaingana"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Fangon'ny kitendry mpanafaingana"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Ny karazan'ilay mpanafaingana."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Ada tsy fantatra>"
+
+#~ msgid "Window Management"
+#~ msgstr "Fandrindrana fikandrana"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become unusable to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time.\n"
+#~ msgstr ""
+#~ "Tsy mety ampiasaina ny hitsin-dàlana \"%s\" satria tsy hety hampiasaina "
+#~ "hanoratana intsony io kitendry io.\n"
+#~ "Andramo ampiarahana amin'ny kitendry toy ny Control, Alt na Shift ilay "
+#~ "izy.\n"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "Ny hitsin-dàlana \"%s\" dia efa ampiasaina amin'ny:\n"
+#~ "\"%s\"\n"
+
+#, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Tsy nety ny famoronana mpanfaingana vaovao ao anatin'ny soratra fototry "
+#~ "ny kirakira: %s\n"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Tsy nety ny fanafoanana ilay mpanafaingana tao anatin'ny soratra fototry "
+#~ "ny kirakira: %s\n"
+
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "Raha hanova mpanfaingana, dia manorata mpanafaingana vaovao eo amin'ny "
+#~ "fariana voatokana amin'izany, na tsindrio ny kitendry miverina hamafana "
+#~ "azy."
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Hamorona kitendry hitsin-dàlana ho ana baiko"
+
+#~ msgid "Unknown"
+#~ msgstr "Tsy fantatra"
+
+#, c-format
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "Nisy olana teo am-pandefasana ny fikirakirana ny kitendry: %s"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Ampiharo fotsiny ireo fandrindrana dia ajanony (fifanarahana ihany; efa "
+#~ "raisin'ny daemon an-tànana izao)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr ""
+#~ "Asehoy ireo fandrindrana ny fiatoan'ny fanoratana rehefa mandefa ilay pejy"
+
+#~ msgid "..."
+#~ msgstr "..."
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>_Gejao ny efijery hanamafisana ny fiatoan'ny fanoratana</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Faingana</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Lava</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Fohy</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Meda</i></small>"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "Ireo fandaminana _misy:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "_Ekeo ny fanemorana ireo fiatoana"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Jereo raha toa ka azo ahemotra ireo fiatoana"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Misafidiana modelim-pafan-teny iray"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Misafidiana fandaminana iray"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Faharetan'ny fiatoana raha rehefa voarara ny fanoratana"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Faharetan'ny asa atao alohan'ny hanisiana fiatoana"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Safidy manokan'ny fafan-teny"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "_Modelim-pafan-teny:"
+
+#~ msgid "Layout Options"
+#~ msgstr "Safidin'ny fandaminana"
+
+#~ msgid "Layouts"
+#~ msgstr "Fandaminana"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Gejao ny efijery aorian'ny fotoana voafaritra mba hisorohana izay aretina "
+#~ "ateraky ny fampiasana fafan-teny matetika loatra"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Microsoft Natural Keyboard"
+
+#~ msgid "Separate _group for each window"
+#~ msgstr "_Vondrona tokana isaka ny fikandrana"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Fahafahana mampiasa..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Faharetan'ny elanelan'ireo fiatoana:"
+
+#~ msgid "_Models:"
+#~ msgstr "_Modely:"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Fandaminana voasafidy:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Faharetan'ny elanelan'ny asa atao:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Mamaritra ireo safidy manokan'ny fafan-teny"
+
+#, c-format
+#~ msgid "%d milliseconds"
+#~ msgid_plural "%d milliseconds"
+#~ msgstr[0] "%d milisegaondra"
+#~ msgstr[1] "%d milisegaondra"
+
+#~ msgid "Unknown Pointer"
+#~ msgstr "Kitondro tsy fantatra"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Kitondro tsotra - Ny miasa izao"
+
+#~ msgid "The default pointer that ships with X"
+#~ msgstr "Ny kitondro tsotra nivoaka niaraka tamin'ny X"
+
+#~ msgid "White Pointer"
+#~ msgstr "Kitondro fotsy"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Kitondro fotsy - Ny miasa izao"
+
+#~ msgid "The default pointer inverted"
+#~ msgstr "Ny kitondro tsotra navadika"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Kitondro lehibe - Ny miasa izao"
+
+#~ msgid "Large version of normal pointer"
+#~ msgstr "Ny kitondro ara-pitsipika amin'ny endriny lehibe"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Kitondro fotsy lehibe - Ny miasa izao"
+
+#~ msgid "Large version of white pointer"
+#~ msgstr "Ny kitondro fotsy amin'ny endriny lehibe"
+
+#~ msgid "Pointer Theme"
+#~ msgstr "Endriky ny kitondro"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Alaivo dia afindrao</b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Farito ny toeran'ny kitondro</b>"
+
+#~ msgid "<b>Mouse Orientation</b>"
+#~ msgstr "<b>Fitodiky ny totozy</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Hafaingana</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Faingana</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Ambony</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Lehibe</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Ambany</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Meda</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Kely</i>"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Manasongadina ilay _kitondro rehefa manindry ny Ctrl ianao"
+
+#~ msgid "Motion"
+#~ msgstr "Hetsika"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Safidy manokan'ny totozy"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Totozy ho an'ny tànana havia"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Fahamora mandray:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Mamaritra ny safidy manokan'ny totozinao"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Mamaritra ny safidy manokan'ny proxy'ny rezonao"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Fifandraisana Internet _mivantana</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>Fikirakirana proxy mandeha _hoazy</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Fikirakirana proxy ataon-tànana</b>"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Fikirakirana avo lenta"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Antsipirian'ny proxy HTTP"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Safidy manokan'ny proxy'ny rezo"
+
+#~ msgid "Port:"
+#~ msgstr "Irika:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "Proxy HTTP azo _antoka:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Alefaso ireo feo ary ampifandraiso amin'ny zava-mitranga"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Safidy manokan'ny feo"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>Audio Conferencing</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Hira sy horonantsary</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>Zava-mitranga araham-peo</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">Mitsapa...</span>"
+
+#~ msgid "E_nable software sound mixing (ESD)"
+#~ msgstr "_Alefaso ny fampifangaroana feon'ilay rindran'asa (ESD)"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Flasheo ny anjan'ny lohaten'ny _fikandrana"
+
+#~ msgid "Sound & Video Preferences"
+#~ msgstr "Safidy manokan'ny feo sy ny horonantsary"
+
+#~ msgid "Sound Capture:"
+#~ msgstr "Ampaham-peo:"
+
+#~ msgid "System Beep"
+#~ msgstr "Feon'ny rafitra"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "Mitsapa ny fantsona"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "_Alefaso ny feon'ny rafitra"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "_Vakio ireo feon'ny rafitra"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "_Feon'ny rafitry ny hita maso"
+
+#~ msgid "Would you like to remove this theme?"
+#~ msgstr "Tianao esorina ve ity endrika ity?"
+
+#~ msgid "Theme deleted succesfully. Please select another theme."
+#~ msgstr "Voafafa soa aman-tsara ilay endrika. Misafidiana endrika iray hafa."
+
+#~ msgid "Theme can not be deleted"
+#~ msgstr "Tsy mety fafàna ilay endrika"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Tsy ahitana endrika anatin'ny rafitrao. Mety mikika izany hoe tsy "
+#~ "voapetraka araka ny tokony ho izy ny \"Theme Preferences\" na tsy "
+#~ "napetrakao ny fehin-drindran'asa \"gnome-themes\"."
+
+#~ msgid "This theme is not in a supported format."
+#~ msgstr "Tsy raisina an-tànana ny lamin'ity endrika ity."
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Tsy nahaforona ny laha-tahiry vonjimaika"
+
+#~ msgid ""
+#~ "Can not install theme. \n"
+#~ "The bzip2 utility is not installed."
+#~ msgstr ""
+#~ "Tsy afaka mametraka ilay endrika. \n"
+#~ "Tsy voapetraka ny rindran'asa bzip2."
+
+#~ msgid ""
+#~ "Can not install themes. \n"
+#~ "The gzip utility is not installed."
+#~ msgstr ""
+#~ "Tsy afaka mametraka ireo endrika. \n"
+#~ "Tsy voapetraka ny rindran'asa gzip."
+
+#, c-format
+#~ msgid ""
+#~ "Icon Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Voapetraka tsara araka ny tokony ho izy ny endriky ny kisary %s. \n"
+#~ "Azonao safidiana ao anatin'ny antsipirian'ny endrika izy io."
+
+#, c-format
+#~ msgid "Gnome Theme %s correctly installed"
+#~ msgstr "Voapetraka araka ny tokony ho izy ny Endriky ny Gnome %s"
+
+#, c-format
+#~ msgid ""
+#~ "Windows Border Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Voapetra araka ny tokony ho izy ny sisim-pikandrana %s.\n"
+#~ "Azonao safidiana ao amin'ny antsipirian'ny endrika izy io."
+
+#, c-format
+#~ msgid ""
+#~ "Controls Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr ""
+#~ "Voapetraka araka ny tokony ho izy ny endriky ny fibaikoana %s.\n"
+#~ "Azonao safidiana ao amin'ny antsipirian'ny endrika izy io."
+
+#~ msgid "The theme is an engine. You need to compile the theme."
+#~ msgstr "Milina ilay endrika. Mila compile-nao io rakitra io."
+
+#~ msgid "The file format is invalid"
+#~ msgstr "Tsy ekena ny lamin'io rakitra io"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Tsy misy toeran'endrika nolazaina ny fametrahana"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Tsy ekena ilay toeran'endrika nolazaina ny fametrahana"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Tsy ampy ny fahazoan-dàlana ahafahana mametraka ilay endrika anatin'ny:\n"
+#~ "%s"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "Tsy ekena ny lamin'io endrika io."
+
+#, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s no sori-dàlana ametrahana ireo rakitry ny endrika. Tsy mety faritana "
+#~ "ho toerana iaviana izy io"
+
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "The tar program is not installed on your system."
+#~ msgstr ""
+#~ "Tsy afaka mametraka ilay endrika.\n"
+#~ "Tsy voapetraka ao amin'ny solosainao ny rindran'asa tar."
+
+#~ msgid "Custom theme"
+#~ msgstr "Endrika safidy"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "Azonao raiketina amin'ny alalan'ny tsindry Raiketo ity endrika ity."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "Tsy hita ao amin'ny rafitrao ny drafitry ny endrika tsotra. Midika izany "
+#~ "fa tsy voapetraka ny metacity na tsy voakirakira araka ny tokony ho izy "
+#~ "ny gconf."
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Tsy maintsy asiana anaran'endrika"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Efa misy io endrika io. Tianao tsindriana ve izy io?"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Misafidy endrika ampiasaina amin'ny faritra maro amin'ny sehatr'asa"
+
+#~ msgid "Theme"
+#~ msgstr "Endrika"
+
+#~ msgid "Apply _Font"
+#~ msgstr "Ampiharo ilay _endri-tsoratra"
+
+#~ msgid "Icons"
+#~ msgstr "Kisary"
+
+#~ msgid "Save Theme"
+#~ msgstr "Raiketo ilay endrika"
+
+#~ msgid "Save _Background Image"
+#~ msgstr "Raiketo ilay sarin'ny _afara"
+
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Misafidiana endrika ho an'ny sehatr'asa"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "Safidy manokan'ny endrika"
+
+#~ msgid "Theme _Details"
+#~ msgstr "_Antsipirian'ny endrika"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "Tsy milaza endri-tsoratra na afara manokana ity endrika ity."
+
+#~ msgid "This theme suggests a background:"
+#~ msgstr "Milaza afara iray ity endrika ity:"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Milaza endri-tsoratra sy afara ity endrika ity:"
+
+#~ msgid "This theme suggests a font:"
+#~ msgstr "Milaza endri-tsoratra ity endrika ity:"
+
+#~ msgid "Window Border"
+#~ msgstr "Sisim-pikandrana"
+
+#~ msgid "_Description:"
+#~ msgstr "_Fanoritsoritana:"
+
+#~ msgid "_Install..."
+#~ msgstr "_Apetrao..."
+
+#~ msgid "_Revert"
+#~ msgstr "_Avereno"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "_Raiketo ilay endrika..."
+
+#~ msgid "theme selection tree"
+#~ msgstr "Hazon'ny fisafidianana endrika"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr ""
+#~ "Mamaritra ny endriky ny anjan'ny fitaovana sy tolotra amin'ny rindran'asa"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Anjan'ny tolotra & fitaovana"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Fiasa sy endrika</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Topy maso</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "_Esory"
+
+#~ msgid "Icons only"
+#~ msgstr "Kisary fotsiny"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Safidy manokan'ny anjan'ny tolotra sy fitaovana"
+
+#~ msgid "New File"
+#~ msgstr "Rakitra vaovao"
+
+#~ msgid "Open File"
+#~ msgstr "Hanokatra rakitra"
+
+#~ msgid "Save File"
+#~ msgstr "Raiketo ilay rakitra"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Asahoy anatin'ny tolotra ny _kisary"
+
+#~ msgid "Text below icons"
+#~ msgstr "Ny soratra ambanin'ny kisary"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Ny soratra akaikin'ny kisary"
+
+#~ msgid "Text only"
+#~ msgstr "Soratra fotsiny"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Mari-tsoratra amin'ny _tsindrin'ny anjan'ny fitaovana:"
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "_Anjan'ny fitaovana azo alàna"
+
+#~ msgid "_Editable menu accelerators"
+#~ msgstr "Mpanafaingan'ny tolotra _azo ovaina"
+
+#~ msgid "_File"
+#~ msgstr "_Rakitra"
+
+#~ msgid "_New"
+#~ msgstr "_Vaovao"
+
+#~ msgid "_Paste"
+#~ msgstr "_Apetao"
+
+#~ msgid "_Print"
+#~ msgstr "_Atontay"
+
+#, c-format
+#~ msgid ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "<b>Tsy mahalefa ny rindran'asan'ny safidy manokan'ny mpandrindra "
+#~ "fikandrana</b>\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "C_ontrol"
+#~ msgstr "Fi_baikoana"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "S_uper (na \"Windows logo\")"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Kitendrin'ny fihetsika</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Asan'ny anjan'ny lohateny</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Fisafidianana fikandrana</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Raha hamindra fikandrana, dia tsindrio ka tano eo ity kitendry ity ary "
+#~ "raiso ilay fikandrana rehefa avy eo:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Safidy manokan'ny fikandrana"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr ""
+#~ "_Tsindrio in-2 eo amin'ny anjan'ny lohateny raha hanatanteraka ity asa "
+#~ "manaraka ity:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Elanelam-potoana alohan'ny fampakarana:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Ampiakaro ireo fikandrana voafaritra ao anatin'ny fe-potoana iray"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Safidio ireo fikandrana rehefa mankeo amboniny ny totozy"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Mamaritra ny toetoetry ny fikandranao"
+
+#~ msgid "Desktop Preferences"
+#~ msgstr "Safidy manokan'ny sehatr'asa"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Ivotoerana fifehezan'ny GNOME"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Ny fitaovana fikirakiran'ny GNOME"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "Tsy nahalefa ny Bonobo"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Notsindrianao nandritra ny 8 segaondra ny kitendry Shift. Io no hitsin-"
+#~ "dàlana mampadeha ny fahasahazan'ny kitendry meda izay mampiova ny "
+#~ "fiasan'ny fafan-teninao. "
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Tianao alefa ve ny kitendry meda?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Tianao atsahatra ve ny kitendry meda?"
+
+#~ msgid "_Deactivate"
+#~ msgstr "_Atsaharo"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "_Aza alefa"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Notsindrianao in-5 misesisesy ny kitendry Shift. Io no hitsin-dàlana "
+#~ "mampandeha ny fahasahazan'ny kitendry miraikidraikitra izay mampiova ny "
+#~ "fiasan'ny fafan-teninao."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "Nanindry kitendry roa miaraka ianao, na nanindry ny kitendry Shift in-5 "
+#~ "misesisesy. Izany dia manatsahatra ny fahasahazan'ny kitendry "
+#~ "miraikidraikitra izay mampiova ny fiasan'ny fafan-teninao."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Tianao alefa ve ny kitendry miraikidraikitra?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Tianao atsahatra ve ny kitendry miraikidraikitra?"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "Tsy afaka mamorona ny laha-tahiry\"%s\".\n"
+#~ "Ilaina izy io mba ahafahana manova ny endriky ny kitondron'ny totozy."
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Tsa afaka mamorona ny laha-tahiry \"%s\".\n"
+#~ "Ilaina izy io mba ahafahana manova ny kitondro."
+
+#, c-format
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "Voasoritra imbetsaka ny asan'ny Key Binding (%s)\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "Voasoritra imbetsaka ny binding'ny Key Binding (%s)\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Tsy feno ny Key Binding (%s)\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Tsy ekena ny Key Binding (%s)\n"
+
+#, c-format
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr "Toa efa misy rindran'asa hafa mampiasa ny kitendry '%u'."
+
+#, c-format
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "Key miasa ny Key Binding (%s)\n"
+
+#, c-format
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Nisy olana teo am-panandramana mandefa ny (%s)\n"
+#~ "izay mifanaraka amin'ny kitendry (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Nisy olana teo am-pandefasana ny kirakira XKB.\n"
+#~ "Maro ireo zavatra mety mahatonga izany:\n"
+#~ "- misy bug anatin'ny tahirin-boky libxklavier\n"
+#~ "- misy bug anatin'ny mpizara X  (ny rindran'asa xkbcomp, xmodmap)\n"
+#~ "- tsy mifanaraka amin'ny mpizara X fametrahana ny libxkbfile\n"
+#~ "\n"
+#~ "Datan'ny kinovan'ny mpizara X:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "Raha toa mitatitra ity zava-miseho ity ho toy ny bug ianao, dia lazao "
+#~ "ao:\n"
+#~ "- Ny valin'ny <b>%s</b>\n"
+#~ "- Ny valin'ny <b>%s</b>"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "Mampiasa XFree 4.3.0 ianao.\n"
+#~ "Ahitana olana maro ny kirakira XKB maro sosona.\n"
+#~ "Manandrama mampiasa kirakira tsotra kokoa na mametraka kinovan'ny "
+#~ "rindran'asa XFree vaovao."
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "_Aza aseho intsony ity fampilazana ity"
+
+#, c-format
+#~ msgid ""
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.</b>\n"
+#~ "\n"
+#~ "Expected was %s, but the the following settings were found: %s.\n"
+#~ "\n"
+#~ "Which set would you like to use?"
+#~ msgstr ""
+#~ "<b>Tsy mitovy amin'ny fandrindran'ny fafan-tenin'ny GNOME ny "
+#~ "fandrindran'ny fafan-tenin'ny rafitra X.</b>\n"
+#~ "\n"
+#~ "%s no nampoizina, nefa ity fandrindrana manaraka ity no hita:%s.\n"
+#~ "\n"
+#~ "Iza amin'ireo no tianao ampiasaina?"
+
+#~ msgid "Use X settings"
+#~ msgstr "Ampiasao ny fandrindran'ny X"
+
+#~ msgid "Keep GNOME settings"
+#~ msgstr "Ny fandrindran'ny GNOME no ampiasao"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Tsy afaka nanatanteraka ny baiko: %s\n"
+#~ "Amarino hoe misy io baiko io."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Tsy afaka nampiato ny solosaina.\n"
+#~ "Amarino hoe voakirakira araka ny tokony ho izy ilay solosaina."
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "Tsy afaka naka ny rakitra Glade.\n"
+#~ "Amarino hoe voapetraka araka ny tokony ho izy io daemon io."
+
+#, c-format
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Nisy olana teo am-pandefasana ny sary mitsitsy:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "Tsy handeha amin'ity session ity fahasahazan'ny sary mitsitsy."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Aza aseho intsony ity filazana ity"
+
+#, c-format
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "Tsy afaka naka ny raki-peo %s hatao sombiny %s"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Tsy afaka namaritra ny laha-tahiry fandraisan'ny mpampiasa"
+
+#, c-format
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "Voafarirtra manaraka ny karazana %s ny famaha GConf %s, nefa ny karazany "
+#~ "nampoizina dia %s\n"
+
+#~ msgid "A_vailable files:"
+#~ msgstr "Ireo rakitra _misy:"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "Aza aseho _intsony ity fampilazana ity."
+
+#~ msgid "Load modmap files"
+#~ msgstr "Alaivo ireo rakitra modmap"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "Tianao alaina ilay (ireo) rakitra modmap?"
+
+#~ msgid "_Load"
+#~ msgstr "_Alaivo"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "Nisy olana teo am-pamoronana fantson'ny fambara."
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Karazan'ny bg_applier: BG_APPLIER_ROOT ho an'ny fikandran'ny faka na "
+#~ "BG_APPLIER_PREVIEW ho an'ny topy maso"
+
+#~ msgid "Preview Width"
+#~ msgstr "Topy maso ny sakany"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr ""
+#~ "Ny sakany raha toa ka topy maso ilay mpampihatra: 64 (sanda tsotra)."
+
+#~ msgid "Preview Height"
+#~ msgstr "Topy maso ny haavony"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr ""
+#~ "Ny haavony raha toa ka topy maso ilay mpampihatra: 48 (sanda tsotra)."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Ny efijery hivelaran'ny BGApplier"
+
+#, c-format
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Nisy olana teo am-pakana ny sary iray: %s"
+
+#, c-format
+#~ msgid "layout \"%s\""
+#~ msgid_plural "layouts \"%s\""
+#~ msgstr[0] "Fandaminana \"%s\""
+#~ msgstr[1] "Fandaminana \"%s\""
+
+#, c-format
+#~ msgid "option \"%s\""
+#~ msgid_plural "options \"%s\""
+#~ msgstr[0] "Safidy \"%s\""
+#~ msgstr[1] "Safidy \"%s\""
+
+#, c-format
+#~ msgid "model \"%s\", %s and %s"
+#~ msgstr "modely \"%s\", %s ary %s"
+
+#~ msgid "no layout"
+#~ msgstr "tsy misy fandaminana"
+
+#~ msgid "Login"
+#~ msgstr "Fidirana"
+
+#~ msgid "Boing"
+#~ msgstr "Fanakorana"
+
+#~ msgid "Siren"
+#~ msgstr "Anjombona"
+
+#~ msgid "Clink"
+#~ msgstr "Feo mikarantsana"
+
+#~ msgid "Beep"
+#~ msgstr "Bip"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "Tsy voafaritra ny feo ho an'ity zava-miseho ity."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "Tsy misy ny raki-peo ho an'ity zava-miseho ity.\n"
+#~ "Mety mila mametraka ny fehy gnome-audio izay misy feo tsotra maromaro "
+#~ "angamba ianao."
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Tsy misy ny raki-peo ho an'ity zava-miseho ity."
+
+#, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "Rakitra .wav tsy ekena ny rakitra %s"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "Tsy nanambara fitaovana fikirakirana ny mpandrindra fikandrana \"%s\" \n"
+
+#~ msgid "Maximize"
+#~ msgstr "Alehibiazo"
+
+#~ msgid "Roll up"
+#~ msgstr "Aforeto miakatra"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "Raha marina izay voalaza, dia ho tazonina ao anatin'ny sync ireo mpandray "
+#~ "an-tànana mime ho an'ny text/plain and text/*"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Ireo mpandray an-tànana ny text/plain and text/* an'ny sync"
+
+#~ msgid "E-mail"
+#~ msgstr "Mailaka"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Hitsin-dàlan'ny mailaka."
+
+#~ msgid "Eject's shortcut."
+#~ msgstr "Hitsin-dàlan'ny Tsoahy."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Hitsin-dàlan'ny laha-tahirin'ny fandraisana."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Hitsin-dàlan'ny Alefaso ny mpizaha toro-làlana."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Hitsin-dàlan'ny Alefaso ny mpitety tranonkala."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Hitsin-dàlan'ny Hivoaka."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Hitsin-dàlan'ny tsindry Manaraka."
+
+#~ msgid "Pause"
+#~ msgstr "Miato"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Hitsin-dàlan'ny tsindry Miato."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Hitsin-dàlan'ny tsindry Mamaky (na mamaky/miato)."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Hitsin-dàlan'ny tsindry Aloha."
+
+#~ msgid "Sleep"
+#~ msgstr "Fiatoana"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Hitsin-dàlan'ny Fiatoana."
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Hitsin-dàlan'ny Ajanony."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Hitsin-dàlan'ny fanamorana feo."
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Hitsin-dàlan'ny Fanalefahana feo"
+
+#~ msgid "Volume step"
+#~ msgstr "Dingan'ny fanamafisam-peo"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Dingana mampiseho ny hamafin'ny feo."
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Hitsin-dàlan'ny Fanamafisana feo."
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr ""
+#~ "Mampiseho takelaka kely rehefa misy olana ny fandefasana ny sary mitsitsy"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "Alefaso eny am-pidirana ny sary mitsitsy"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Asehoy ireo tsy fetezana mitranga eny am-piandohana"
+
+#~ msgid "Start screensaver"
+#~ msgstr "Alefaso ny sary mitsitsy"
+
+#~ msgid ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+#~ msgstr ""
+#~ "Fitambaran-teny baiko alefa isaky ny averina alaina ny toetry ny fafan-"
+#~ "teny. Ilaina ho an'ny fampiharana indray ireo fanitsiana mifototra "
+#~ "amin'ny xmodmap izy ireo"
+
+#~ msgid "A list of modmap files available in the $HOME directory."
+#~ msgstr "Lisitr'ireo rakitra modmap hita ao anatin'ny laha-tahiry $HOME."
+
+#~ msgid "Default group, assigned on window creation"
+#~ msgstr "Vondrona tsotra voafaritra mandritra ny famoronana fikandrana"
+
+#~ msgid "Keep and manage separate group per window"
+#~ msgstr "Tano ary arindrao isaka ny fikandrana iray ny vondrona iray"
+
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Mpandray an-tànana ny fanavaozana ny fafan-teny"
+
+#~ msgid "Keyboard model"
+#~ msgstr "Modelim-pafan-teny"
+
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr ""
+#~ "Ho fehezina avy amin'ny ASAP'ny rafitra ireo fandrindran'ny fafan-teny ao "
+#~ "amin'ny gconf (tsy ampiasaina intsony)"
+
+#~ msgid "Save/restore indicators together with layout groups"
+#~ msgstr "Raiketo/avereno miaraka amin'ny vondron'ny fandaminana ireo mpilaza"
+
+#~ msgid "Show layout names instead of group names"
+#~ msgstr "Ireo anaran'ny fandaminana no asehoy fa tsy ireo anaran'ny vondrona"
+
+#~ msgid ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+#~ msgstr ""
+#~ "Ireo anaran'ny fandaminana no asehoy fa tsy ireo anaran'ny vondrona (ho "
+#~ "an'ny kinovan'ny XFree izay mandray an-tànana fandaminana maro ihany)"
+
+#~ msgid "Suppress the \"X sysconfig changed\" warning message"
+#~ msgstr "Fafao ny fampilazana \"X sysconfig changed\""
+
+#~ msgid "The Keyboard Preview, X offset"
+#~ msgstr "Topy mason'ny fafan-teny, offset X"
+
+#~ msgid "The Keyboard Preview, Y offset"
+#~ msgstr "Topy mason'ny fafan-teny, offset Y"
+
+#~ msgid "The Keyboard Preview, height"
+#~ msgstr "Topy mason'ny fafan-teny, haavo"
+
+#~ msgid "The Keyboard Preview, width"
+#~ msgstr "Topy mason'ny fafan-teny, saka"
+
+#~ msgid ""
+#~ "Very soon, keyboard settings in gconf will be overridden (from the system "
+#~ "configuration) This key has been deprecated since GNOME 2.12, please "
+#~ "unset the model, layouts and options keys to get the default system "
+#~ "configuration."
+#~ msgstr ""
+#~ "Afaka fotoana fohy dia ho fehezina avy amin'ny kirakiran'ny rafitra ireo "
+#~ "fandrindrana ny fafan-teny ao amin'ny gconf. Efa hatramin'ny GNOME 2.12 "
+#~ "no tsy nampiasaina izany famaha izany, ka foano ireo famahan'ny modely, "
+#~ "fandaminana ary safidy mba ahazoana ny kirakiran-drafitra tsotra."
+
+#~ msgid "keyboard layout"
+#~ msgstr "fandaminana ny fafan-teny"
+
+#~ msgid "keyboard model"
+#~ msgstr "Modelim-pafan-teny"
+
+#~ msgid "modmap file list"
+#~ msgstr "lisitry ny rakitra modmap"
+
+#, fuzzy
+#~ msgid "_Postpone break"
+#~ msgstr "_Ahemory ny fiatoana"
+
+#~ msgid "Take a break!"
+#~ msgstr "Hiato kely!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Hiato kely"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d minitra mandra-pahatongan'ny fiatoana manaraka"
+#~ msgstr[1] "%d minitra mandra-pahatongan'ny fiatoana manaraka"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Latsaka ny iray minitra mandra-pahatongan'ny fiatoana manaraka"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Tsy afaka mampiseho ny takilan'ny toetoetry ny fiatona amin'ny fanoratana "
+#~ "miaraka amin'ny ity tsy fetezana manaraka ity: %s"
+
+#, fuzzy
+#~ msgid "About GNOME Typing Monitor"
+#~ msgstr "Mombamomba ny Mpandrindra Fanoratana an'ny GNOME"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Feo filazana fiatoana amin'ny solosaina."
+
+#~ msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgstr "Nosoratan'i Richard Hult &lt;richard@imendio.com&gt;"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Eye Candy nampidirin'i Anders Carlsson"
+
+#~ msgid "Break reminder"
+#~ msgstr "Mpampatsiahy fiatoana"
+
+#~ msgid "The orientation of the tray."
+#~ msgstr "Ny fitodiky ny tray."
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Ny mpandrindra fanoratana dia mampiasa ny faritra filazana hanaovana "
+#~ "fampahalalana. Toa tsy misy faritra filazana eo amin'ny tontonanao. Raha "
+#~ "hametraka izany eo ianao, dia tondroy ny tontonana, tsindrio ny kitendry "
+#~ "havanan'ny totozy, tsindrio ny 'Atao eo amin'ny tontonana', safidio ny "
+#~ "'Faritra filazana' ary tsindrio ny 'Apetrao'."
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr ""
+#~ "Mitsambikina eo amibonin'ny ilay alika kamo ilay fosa miloko manja. "
+#~ "0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Habe:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Fameran-jo:"
+
+#~ msgid "Description:"
+#~ msgstr "Fanoritsoritana:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "fampiasa: rakitr'endri-tsoratra %s\n"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Farito ho endri-tsoratry ny rindran'asa"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Raha voalaza ho marina, dia haseho anaty sary madinika ireo endri-"
+#~ "tsoratra OpenType."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Raha voalaza fa marina, dia haseho anaty sary madinika ireo endri-"
+#~ "tsoratra PCF."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Raha voalaza fa marina, dia haseho anaty sary madinika ireo endri-"
+#~ "tsoratra TrueType."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Raha voalaza fa marina, dia haseho anaty sary madinika ireo endri-"
+#~ "tsoratra Type1."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Ampifanarao amin'ny baiko amoronana sary madinika ho an'ny endri-tsoratra "
+#~ "OpenType ity famaha ity."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endri-"
+#~ "tsoratra PCF ity famaha ity."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endri-"
+#~ "tsoratra TrueType ity famaha ity."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endri-"
+#~ "tsoratra Type1 ity famaha ity."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra openType"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra PCF"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra TrueType"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra Type1"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "(Tsy) maneho ny endri-tsoratra OpenType anaty sary madinika"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "(Tsy) maneho ny endri-tsoratra PCF anaty sary madinika"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "(Tsy) maneho ny endri-tsoratra TrueType anaty sary madinika"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "(Tsy) maneho ny endri-tsoratra Type1 anaty sary madinika"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "Mpijery endri-tsoratra an'ny GNOME"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">Ampiharina ilay endri-tsoratra "
+#~ "vaovao?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "_Aza ampiharina"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Tahaka ny endri-tsoratra vaovao ilay endrika nosafidianao. Miseho etsy "
+#~ "ambany ny sariny."
+
+#~ msgid "Themes"
+#~ msgstr "Endrika"
+
+#~ msgid "Description"
+#~ msgstr "Fanoritsoritana"
+
+#~ msgid "Control theme"
+#~ msgstr "Endriky ny fibaikoana"
+
+#~ msgid "Window border theme"
+#~ msgstr "Endriky ny sisin'ny fikandrana"
+
+#~ msgid "Icon theme"
+#~ msgstr "Endriky ny kisary"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#~ msgid "Apply theme"
+#~ msgstr "Ampiharo ilay endrika"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Mamaritra ny endrika tsotra"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr ""
+#~ "Raha voalaza fa marina, dia haseho anaty sary madinika ireo endrika "
+#~ "voapetraka."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr ""
+#~ "Raha voalaza ho marina, dia haseho anaty sary madinika ireo endrika."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endrika "
+#~ "voapetraka ity famaha ity."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endrika ity "
+#~ "famaha ity."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Baiko amoronana sary madinika ho an'ny sary voapetraka"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Baiko amoronana sary madinika ho an'ny endrika"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "(Tsy) maneho ireo endrika voapetraka anaty sary madinika"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "(Tsy) maneho ireo endrika anaty sary madinika"

--- a/po/mg.po~
+++ b/po/mg.po~
@@ -1,0 +1,3644 @@
+# Malagasy translation of gnome-control-center.
+# Copyright (C) 2006-2009 THE GNOME-CONTROL-CENTER'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center package.
+# Fanomezana Rajaonarisoa <rajfanhar@yahoo.fr>, 2006.
+# Thierry Randrianiriana <randrianiriana@gmail.com>, 2006-2009.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center HEAD\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2006-05-10 06:42+0200\n"
+"PO-Revision-Date: 2009-01-16 16:42+0300\n"
+"Last-Translator: Thierry Randrianiriana <randrianiriana@gmail.com>\n"
+"Language-Team: Malagasy <i18n-malagasy-gnome@gna.org>\n"
+"Language: mg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n>1;"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "Sisin'ny sary/mari-tsoratra"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+"Ny sakan'ny sisin'ny mari-tsoratra sy ny sary anatin'ny takelakakelin'ny "
+"filazana"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "karazam-pilazana"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "Ny karazan'ny filazana"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "Tsindrin'ny filazana"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "Ireo tsindry miseho eo amin'ny takelakakelin'ny filazana"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "Asehoy amin'ny _antsipiriany"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "About Me"
+msgstr "Momba izaho"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "Anoratana ny mombamomba anao"
+
+#: ../capplets/about-me/gnome-about-me.c:604
+msgid "Select Image"
+msgstr "Misafidiana sary"
+
+#: ../capplets/about-me/gnome-about-me.c:606
+msgid "No Image"
+msgstr "Tsy misy sary"
+
+#: ../capplets/about-me/gnome-about-me.c:769
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"Nnisy olana teo am-panandramana maka ny lazan'ny bokin'adiresy\n"
+"Tsy raisin'ny Evolution Data Server an-tànana io firesaka io"
+
+#: ../capplets/about-me/gnome-about-me.c:790
+msgid "Unable to open address book"
+msgstr "Tsy mety mahasokatra ny bokin'adiresy"
+
+#: ../capplets/about-me/gnome-about-me.c:802
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+"ID'ny fidirana tsy fantatra. Mety simba angamba ny soratra fototry ny "
+"mpampiasa."
+
+#: ../capplets/about-me/gnome-about-me.c:833
+#: ../capplets/about-me/gnome-about-me.c:835
+#, c-format
+msgid "About %s"
+msgstr "Momba ny %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:707
+msgid "Old password is incorrect, please retype it"
+msgstr "Tsy marina ny teny fanalahidy taloha voasoratra. Avereno soratana"
+
+#: ../capplets/about-me/gnome-about-me-password.c:127
+msgid "System error has occurred"
+msgstr "Nisy olan'ny rafitra nitranga"
+
+#: ../capplets/about-me/gnome-about-me-password.c:128
+msgid "Could not run /usr/bin/passwd"
+msgstr "Tsy nahalefa ny /usr/bin/passwd"
+
+#: ../capplets/about-me/gnome-about-me-password.c:129
+msgid "Unable to launch backend"
+msgstr "Tsy mety mahalefa ny backend"
+
+#: ../capplets/about-me/gnome-about-me-password.c:131
+#: ../capplets/about-me/gnome-about-me-password.c:132
+msgid "Unexpected error has occurred"
+msgstr "Nisy olana tsy nampoizina nitranga"
+
+#: ../capplets/about-me/gnome-about-me-password.c:331
+msgid "Password is too short"
+msgstr "Fohy loatra io teny fanalahidy io"
+
+#: ../capplets/about-me/gnome-about-me-password.c:334
+#: ../capplets/about-me/gnome-about-me-password.c:337
+msgid "Password is too simple"
+msgstr "Tsotra loatra io teny fanalahidy io"
+
+#: ../capplets/about-me/gnome-about-me-password.c:340
+msgid "Old and new passwords are too similar"
+msgstr "Tsy dia mifankaiza loatra ireo teny fanalahidy taloha sy vaovao"
+
+#: ../capplets/about-me/gnome-about-me-password.c:343
+msgid "Must contain numeric or special character(s)"
+msgstr "Tsy maintsy misy isa na marika manokana"
+
+#: ../capplets/about-me/gnome-about-me-password.c:348
+msgid "Old and new password are the same"
+msgstr "Mitovy ireo teny fanalahidy taloha sy vaovao"
+
+#: ../capplets/about-me/gnome-about-me-password.c:634
+msgid "Please type the passwords."
+msgstr "Soraty ireo teny fanalahidy."
+
+#: ../capplets/about-me/gnome-about-me-password.c:642
+msgid "Please type the password again, it is wrong."
+msgstr "Avereno soratana indray ilay teny fanalahidy. Diso io voasoratra io."
+
+#: ../capplets/about-me/gnome-about-me-password.c:645
+msgid "Click on Change Password to change the password."
+msgstr "Tsindrio ny Hanova Teny Fanalahidy raha hanova ny teny fanalahidy."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/sound/sound-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+msgid "    "
+msgstr "    "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Email</b>"
+msgstr "<b>Mailaka</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Home</b>"
+msgstr "<b>Fandraisana</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Fifandraisana eo no eo</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Job</b>"
+msgstr "<b>Asa</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr "<b>Soraty ilay teny fanalahidy.</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<b>Telephone</b>"
+msgstr "<b>Telefaonina</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "<b>Web</b>"
+msgstr "<b>Tranonkala</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "<b>Work</b>"
+msgstr "<b>Toeram-piasana</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "A_ddress:"
+msgstr "A_diresy:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr "_Mpanampy:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "Address"
+msgstr "Adiresy"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "C_ity:"
+msgstr "_Tanàna:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "C_ompany:"
+msgstr "_Orinasa:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Cale_ndar:"
+msgstr "_Kalandrie:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change Passwo_rd..."
+msgstr "Hanova _teny fanalahidy..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Change Password"
+msgstr "Manova ny teny fanalahidy"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Ci_ty:"
+msgstr "_Tanàna:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Co_untry:"
+msgstr "_Firenena:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Contact"
+msgstr "Ny mety ahazoana anao"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Cou_ntry:"
+msgstr "_Firenena:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr "Anarana feno"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Hom_e:"
+msgstr "_Trano:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "Old pa_ssword:"
+msgstr "_Teny fanalahidy taloha:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P.O. _box:"
+msgstr "Laharan'ny _Boatin-taratasy:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P._O. box:"
+msgstr "Laharan'ny _Boatin-taratasy:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "Personal Info"
+msgstr "Momba ny tena manokana"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "State/Pro_vince:"
+msgstr "Fanjakana/Fa_ritany:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+msgid "User name:"
+msgstr "Anaran'ny mpampiasa:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Web _log:"
+msgstr "_Raki-tatitry ny tranonkala:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "Wor_k:"
+msgstr "_Toeram-piasana:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid "Work _fax:"
+msgstr "_Fax ao amin'ny toeram-piasana:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Zip/_Postal code:"
+msgstr "Mari-pamantaran'ny _paositra:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "_Address:"
+msgstr "_Adiresy:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr "_Sampandraharaha:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr "_Groupwise:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "_Home page:"
+msgstr "Pejy _fandraisana:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "_Home:"
+msgstr "_Fandraisana:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr "_Jabber:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Manager:"
+msgstr "_Mpandrindra:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Mobile:"
+msgstr "_Finday:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_New password:"
+msgstr "_Teny fanalahidy vaovao:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Profession:"
+msgstr "_Asa:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Retype new password:"
+msgstr "_Avereno soratana ilay teny fanalahidy:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr "_Faritany:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Title:"
+msgstr "_Mpialoha anarana:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Work:"
+msgstr "_Toeram-piasana:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Zip/Postal code:"
+msgstr "Mari-pamantaran'ny _paositra:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Applications</b>"
+msgstr "<b>Rindran'asas</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Support</b>"
+msgstr "<b>Fanampiana</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+"<small><i><b>Note:</b> Tsy hihatra ireo fanovana natao tamin'ity "
+"fandrindrana ity raha tsy rehefa miditra indray ianao.</i></small>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technology Preferences"
+msgstr "Safidy manokan'ny haitao fanamorana"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr "Hidio dia _mivoaha"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr "Mandefa ireo haitao fanamorana ireo isaky ny miditra ianao:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr "_Alefaso ireo haitao fanamorana"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr "_Fitara-mamily"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr "Fafan-teny miseho _amin'ny efijery"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Screenreader"
+msgstr "_Mpamaky efijery"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr "Fanampiana mikasika ny haitao fanamorana"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr ""
+"Alefaso ny fandraisana an-tànana ireo haitao fanamorana an'ny GNOME rehefa "
+"miditra"
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Tsy misy haitao fanamorana ao amin'ny solosainao. Tsy maintsy apetraka ny "
+"fehin-drindran'asa 'gok' izay vao afaka mampiasa ny fafan-teny miseho "
+"amin'ny efijery. Tsy maintsy apetraka koa ny fehin-drindran'asa "
+"'gnopernicus' izay vao afaka mampiasa mpamaky efijery sy fitara-mamily."
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+"Tsy voapetraka ao amin'ny solosainao avokoa ireo haitao fanamorana misy. Tsy "
+"maintsy apetraka ny fehin-drindran'asa 'gok' vao afaka mandray an-tànana "
+"fafan-teny miseho amin'ny efijery."
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Tsy voapetraka ao amin'ny solosainao avokoa ireo haitao fanamorana misy. Tsy "
+"maintsy apetraka ny fehin-drindran'asa 'gnopernicus' vao afaka mampiasa "
+"mpamaky efijery sy fitara-mamily."
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:242
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr ""
+"Nisy olana teo am-pandefasana ny takelaka kelin'ny safidy manokan'ny totozy: "
+"%s"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:338
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:399
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr "Tsy nahaaftra fandrindrana AccessX avy amin'ny rakitra '%s'"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:436
+msgid "Import Feature Settings File"
+msgstr "Hanafatra rakitra misy fandrindrana fahasahaza"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:440
+msgid "_Import"
+msgstr "_Afaro"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Fafan-teny"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr "Mamaritra ny safidy manokan'ny fahafahana mampiasa ny fafan-teny"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+"Toa tsy manana ny tovana XKB ity rafitra ity. Tsy mandeha ny fahasahazan'ny "
+"fahafahana mampiasa ny fafan-teny  raha tsy misy io tovana io."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "<b>Alefaso ireo kitendry _faingana</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "<b>Alefaso ireo kitendry _votsa</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "<b>Alefaso ireo kitendrin'ny _totozy</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "<b>Alefaso ireo kitendry _famerenana</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "<b>Alefaso ireo kitendry _miraikidraikitra</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+msgid "<b>Features</b>"
+msgstr "<b>Fahasahaza</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr "<b>Kitendrin'ny fiovana</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "Fototra"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr "Maneno raha _tsy ekena ilay kitendry"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr "Maneno raha alefa na ajanona avy amin'ny fafan-teny ireo _fahasahaza"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr "Maneno rehefa voatsindry ny kitendrin'ny -fanovana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr ""
+"Maneno in-1 rehefa mirehitra ny jiro LED ary in-2 rehefa maty io jiro io."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr "Maneno rehefa ity ny kitendry:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr "_Elanelam-potoana:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr ""
+"Ny elanelana ara-potoana misy eo amin'ny fanindriana kitendry sy ny "
+"_fihetsiky ny kitondro:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr "_Atsaharo raha toa ka kitendry roa no indray voatsindry"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr "_Alefaso ireo kitendrin'ny fiovana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Sivana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr "Aza raharahaina ny kitendry sahala voatsindry anatin'ny:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+"Tsy mandraharaha ny fanindriana mifanarakaraka kitendry IRAY raha toa ka "
+"mitranga anatin'ny fotoana azon'ny mpampiasa faritana izany.s"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr "Safidy manokan'ny fahafahana mampiasa ny fafan-teny (AccessX)"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr "Hafainganan'ny kitondro _ambony indrindra:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr "Kitendrin'ny totozy"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr "_Safidy manokan'ny totozy..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+"Aza ekena ireo kitendry raha tsy efa voatsindry mandritra ny fotoana azon'ny "
+"mpampiasa faritana."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+"Manao fanindriana kitendry miara-miseho amin'ny alalan'ny fanidriana "
+"misesisesy ireo kitendrin'ny fanovana."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "S_peed:"
+msgstr "_Hafainganana:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr "Ny fotoana ilaina _hahatratrarana ny hafainganana ambony indrindra:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+#, fuzzy
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr "Manova ny kitendrin'isa ho kitendrin'ny totozy."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr "_Atsaharo raha tsy ampiasaina mandritra ny:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr "_Alefaso ireo fahasahazan'ny fahafahana mampiasa ny fafan-teny"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr "_Hanafatra fandrindrana fahasahaza..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr "_Aza manaiky afa-tsy ireo kitendry voatsindry mandritra ny:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "_Type to test settings:"
+msgstr "_Manorata hitsapana ireo fandrindrana:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr "_Ekena"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr "_voatsindry"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr "_Lavina"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr "marika/segaondra"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "milliseconds"
+msgstr "milisegaondra"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr "pixel/segaondra"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "segaondra"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+msgid "Change your Desktop Background settings"
+msgstr "Manova ireo kirakiran'ny afaran'ny sehatr'asanao"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+msgid "Desktop Background"
+msgstr "Afaran'ny sehatr'asa"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "<b>_Taratasy manaingo</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+msgid "<b>_Desktop Colors</b>"
+msgstr "<b>Lokon'ny _sehatr'asa</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+msgid "Desktop Background Preferences"
+msgstr "Safidy manokan'ny afaran'ny sehatr'asa"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr "Manokatra takelaka kely ahafahana mamaritra ny loko"
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr "_Hanampy taratasy manaingo"
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+msgid "_Finish"
+msgstr "_Vita"
+
+#: ../capplets/background/gnome-background-properties.glade.h:7
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+msgid "_Remove"
+msgstr "_Esory"
+
+#: ../capplets/background/gnome-background-properties.glade.h:8
+msgid "_Style:"
+msgstr "_Endrika:"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Nisy olana teo am-manehoana ireo toro-làlana: %s"
+
+#: ../capplets/background/gnome-wp-capplet.c:984
+msgid "Centered"
+msgstr "Mahazo afovoa"
+
+#: ../capplets/background/gnome-wp-capplet.c:988
+msgid "Fill Screen"
+msgstr "Mameno efijery"
+
+#: ../capplets/background/gnome-wp-capplet.c:992
+msgid "Scaled"
+msgstr "Novaina habe"
+
+#: ../capplets/background/gnome-wp-capplet.c:996
+msgid "Zoom"
+msgstr "Zòma"
+
+#: ../capplets/background/gnome-wp-capplet.c:1000
+msgid "Tiled"
+msgstr "Mizarazara"
+
+#: ../capplets/background/gnome-wp-capplet.c:1021
+msgid "Solid Color"
+msgstr "Loko tokana"
+
+#: ../capplets/background/gnome-wp-capplet.c:1025
+msgid "Horizontal Gradient"
+msgstr "Mandry misompirana"
+
+#: ../capplets/background/gnome-wp-capplet.c:1029
+msgid "Vertical Gradient"
+msgstr "Mitsangana misompirana"
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1075
+msgid "Add Wallpaper"
+msgstr "Hanampy taratasy manaingo"
+
+#: ../capplets/background/gnome-wp-capplet.c:1092
+msgid "Images"
+msgstr "Sary"
+
+#: ../capplets/background/gnome-wp-capplet.c:1096
+msgid "All Files"
+msgstr "Ireo akitra rehetra"
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr "Tsy misy taratasy manaingo"
+
+#: ../capplets/background/gnome-wp-item.c:343
+#: ../capplets/background/gnome-wp-item.c:345
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "pixel"
+msgstr[1] "pixel"
+
+#: ../capplets/common/activate-settings-daemon.c:18
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"Tsy nahalefa ny mpandrindra kirakira 'gnome-settings-daemon'.\n"
+"Mety tsy hihatra ny safidy manokana sasany raha tsy mandeha io mpandrindra "
+"ny kirakiran'ny GNOME io. Mety midika izany fa misy olana amin'ny Bonobo, na "
+"mety efa misy mpandrindra kirakira tsy an'ny GNOME (ohatra: KDE) mandeha ka "
+"mifanipaka amin'ny an'ny GNOME."
+
+#: ../capplets/common/capplet-stock-icons.c:92
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "Tsy afaka nangala ny kisary tahiry '%s'\n"
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr "Ampiharo fotsiny ireo fandrindrana dia ajanony"
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1016
+#: ../capplets/sound/sound-properties-capplet.c:760
+msgid "Retrieve and store legacy settings"
+msgstr "Alaivo ary raiketo ireo fandrindrana taloha"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "Mandika ilay rakitra: %u amin'ny %u"
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr "Mandika ny '%s'"
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr "Avy amin'ny URI"
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr "Ny URI dia mamindra avy amin'ny"
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr "Mankany amin'ny URI"
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr "Ny URI dia mamindra mankany amin'ny"
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr "Vita ny fizarana"
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr "Vita ny fizarana ny famindrana"
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr "Fizahan-takilan'ity URI ity"
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr "Fizahan-takilan'ity URI ity - manomboka amin'ny 1"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr "Tontalin'ireo URI"
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr "Tontalin'ny isan'ny URI"
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr "Mandika rakitra"
+
+#: ../capplets/common/file-transfer-dialog.c:345
+msgid "From:"
+msgstr "Avy amin'ny:"
+
+#: ../capplets/common/file-transfer-dialog.c:349
+msgid "To:"
+msgstr "Mankany amin'ny:"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr "Mifandray..."
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Kitendry"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr "Ny famaha GConf arahan'ity mpanova toetoetra ity"
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr "Antso"
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Mandefa ity antso rehefa miova ny sanda mifandraika amin'ilay famaha"
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr "Fitambarana fanovana"
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"Fitambarana fanovana misy data alefa mankany amin'ny mpivatsin'ny gconf "
+"rehefa atao ny fampiharana"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr "Fivadihana mankany amin'ny antso widget"
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+"Antso halefa rehefa misy data havadika avy amin'ny GConf mankany amin'ilay "
+"widget"
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr "Fivadihana avyamin'ny antso widget"
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"Antso halefa rehefa misy data havadika avy amin'ny widget mankany amin'ny "
+"GConf s"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr "Fifehezana ny UI"
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr "Zavatra iray izay mifehy ny toetoetra (tokony ho widget)"
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr "Datan'ny zavatry ny mpanova toetoetra"
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr "Data manokana ilain'ny mpanova toetoetra voafaritra"
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr "Datan'ny mpanova toetoetra mamotsotra antso"
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Antso halefa rehefa havotsotra ny datan'ny zavatry ny mpanova toetoetra"
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Tsy nahita ny rakitra '%s'.\n"
+"\n"
+"Amarino tsara hoe misy izy io dia andramo indray avy eo, na misafidiana sary "
+"afara hafa."
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Tsy haiko ny manokatra ny rakitra '%s'.\n"
+"Mety karazan-tsary tsy mbola voaray an-tànana angamba izy io.\n"
+"\n"
+"Misafidiana sary hafa asolo azy."
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr "Misafidiana sary iray."
+
+#: ../capplets/common/gconf-property-editor.c:1598
+msgid "_Select"
+msgstr "_Ekeo"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr "Rindran'asa tiana kokoa"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Safidio ireo rindran'asa ataonao fampiasa"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:77
+#: ../capplets/default-applications/gnome-da-capplet.c:101
+#: ../capplets/default-applications/gnome-da-capplet.c:146
+#: ../capplets/default-applications/gnome-da-capplet.c:191
+#: ../capplets/default-applications/gnome-da-capplet.c:245
+#: ../capplets/default-applications/gnome-da-capplet.c:294
+#: ../capplets/default-applications/gnome-da-capplet.c:576
+#: ../capplets/default-applications/gnome-da-capplet.c:597
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "Nisy olana teo am-pandraiketana ny kirakira: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:719
+#: ../capplets/sound/sound-properties-capplet.c:318
+msgid "Custom"
+msgstr "Safidy"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:739
+msgid "Could not load the main interface"
+msgstr "Tsy afaka naka ny mpanera fototra"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:741
+msgid "Please make sure that the applet is properly installed"
+msgstr "Amarino tsara hoe voapetraka araka ny tokony ho izy ilay applet"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Debian Sensible Browser"
+msgstr "Debian Sensible Browser"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Debian Terminal Emulator"
+msgstr "Debian Terminal Emulator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Encompass"
+msgstr "Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Epiphany Web Browser"
+msgstr "Mpitety tranonkalan'ny Epiphany"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "Evolution Mail Reader"
+msgstr "Evolution Mail Reader"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Evolution Mail Reader 1.4"
+msgstr "Evolution Mail Reader 1.4"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Evolution Mail Reader 1.5"
+msgstr "Evolution Mail Reader 1.5"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader 1.6"
+msgstr "Evolution Mail Reader 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Evolution Mail Reader 2.0"
+msgstr "Evolution Mail Reader 2.0"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Evolution Mail Reader 2.2"
+msgstr "Evolution Mail Reader 2.2"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "Evolution Mail Reader 2.4"
+msgstr "Evolution Mail Reader 2.4"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "GNOME Terminal"
+msgstr "Terminal an'ny GNOME"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Links Text Browser"
+msgstr "Mpitety Links Text"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Lynx Text Browser"
+msgstr "Mpitety Lynx Text"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "Mozilla Mail"
+msgstr "Mozilla Mail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Netscape Communicator"
+msgstr "Netscape Communicator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Opera"
+msgstr "Opera"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Standard XTerminal"
+msgstr "XTerminal tsotra"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Sylpheed"
+msgstr "Sylpheed"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "W3M Text Browser"
+msgstr "Mpitety Soratra W3M"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Audio Player</b>"
+msgstr "<b>Fiahinoana raki-peo</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Image Viewer</b>"
+msgstr "<b>Mpizaha sary</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Instant Messenger</b>"
+msgstr "<b>Mpampifandray eo no eo</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mail Reader</b>"
+msgstr "<b>Mpamaky mailaka</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>Terminal Emulator</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Text Editor</b>"
+msgstr "<b>Mpanova lahabolana</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Video Player</b>"
+msgstr "<b>Fijerena horonan-tsary</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Web Browser</b>"
+msgstr "<b>Mpitety tranonkala</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "Ho soloina ity rohy ity daholo ireo %s rehetra"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Co_mmand:"
+msgstr "Bai_ko:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "E_xecute flag:"
+msgstr "Sain'ny takila _fanatanterahana:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Internet"
+msgstr "Internet"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Multimedia"
+msgstr "Haino aman-jery"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Open link in new _tab"
+msgstr "Sokafy anaty _vakizoro vaovao ilay rohy"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Open link in new _window"
+msgstr "Sokafy anaty _fikandrana vaovao ilay rohy"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Open link with web browser _default"
+msgstr ""
+"Sokafy amin'ny alalan'ny safidy _tsotran'ny mpitety tranonkala ilay rohy"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Run in t_erminal"
+msgstr "Alefaso amin'ny alalan'ny _Terminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "System"
+msgstr "Rafitra"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Hanova ny resolution'ny efijery"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Resolution'ny efijery"
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/main.c:448
+msgid "_Resolution:"
+msgstr "_Resolution:"
+
+#: ../capplets/display/main.c:467
+msgid "Re_fresh rate:"
+msgstr "Tahan'ny re_freshment:"
+
+#: ../capplets/display/main.c:488
+msgid "Default Settings"
+msgstr "Fandrindrana tsotra"
+
+#: ../capplets/display/main.c:490
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr "Fandrindran'ny efijery %d\n"
+
+#: ../capplets/display/main.c:516
+msgid "Screen Resolution Preferences"
+msgstr "Safidy manokana mikasikan ny resolution'ny efijery"
+
+#: ../capplets/display/main.c:553
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "_Ataovy safidy tsotra ho an'ity solosaina (%s) ity ihany"
+
+#: ../capplets/display/main.c:571
+msgid "Options"
+msgstr "Safidy"
+
+#: ../capplets/display/main.c:592
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"Mitsapa ireo fandrindrana vaovao. Raha tsy manome valin-teny anatin'ny %d "
+"segaondra ianao dia haverina ireo fandrindrana teo aloha."
+msgstr[1] ""
+"Mitsapa ireo fandrindrana vaovao. Raha tsy manome valin-teny anatin'ny %d "
+"segaondra ianao dia haverina ireo fandrindrana teo aloha."
+
+#: ../capplets/display/main.c:638
+msgid "Keep Resolution"
+msgstr "Tano io resolution io"
+
+#: ../capplets/display/main.c:642
+msgid "Do you want to keep this resolution?"
+msgstr "Tianao tanana io resolution io?"
+
+#: ../capplets/display/main.c:667
+msgid "Use _previous resolution"
+msgstr "Ny resolution _teo aloha ampiasaina"
+
+#: ../capplets/display/main.c:667
+msgid "_Keep resolution"
+msgstr "_Tano io resolution io"
+
+#: ../capplets/display/main.c:818
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"Tsy mandray an-tànana ny tovana XRandR ny mpizara X. Tsy misy fanovana "
+"resolution runtime azo ampiharina amin'ny haben'ny efijery ao."
+
+#: ../capplets/display/main.c:826
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"Tsy mifanaraka amin'ity rindran'asa ity ny kinovan'ny tovana XRandR. Tsy "
+"misy fanovana runtime azo ampiharina amin'ny haben'ny efijery ao."
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Endri-tsoratra"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr "Ahafahana misafidy endri-tsoratra ho an'ny sehatr'asa"
+
+#: ../capplets/font/font-properties.glade.h:1
+msgid "<b>Font Rendering</b>"
+msgstr "<b>Fivoakan'ny endri-tsoratra</b>"
+
+#: ../capplets/font/font-properties.glade.h:2
+msgid "<b>Hinting</b>:"
+msgstr "<b>Hinting</b>:"
+
+#: ../capplets/font/font-properties.glade.h:3
+msgid "<b>Smoothing</b>:"
+msgstr "<b>Fandamalamana</b>:"
+
+#: ../capplets/font/font-properties.glade.h:4
+msgid "<b>Subpixel order</b>:"
+msgstr "<b>Filaharan'ny subpixel</b>:"
+
+#: ../capplets/font/font-properties.glade.h:5
+msgid "Best _shapes"
+msgstr "_Bika tsara indrindra"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best co_ntrast"
+msgstr "_Fifangarihana tsara indrindra"
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "D_etails..."
+msgstr "An_tsipiriany..."
+
+#: ../capplets/font/font-properties.glade.h:8
+msgid "Des_ktop font:"
+msgstr "Endri-tsoratry ny sehatr'asa:"
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "Safidy manokan'ny endri-tsoratra"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr "Antsipirian'ny fivoakan'ilay endri-tsoratra"
+
+#: ../capplets/font/font-properties.glade.h:11
+msgid "Go _to font folder"
+msgstr "_Laha-tahirin'ny endri-tsoratra"
+
+#: ../capplets/font/font-properties.glade.h:12
+msgid "Gra_yscale"
+msgstr "Ambara_tongan-doko mivolombatolalaka"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "Tsy _misy"
+
+#: ../capplets/font/font-properties.glade.h:14
+msgid "R_esolution:"
+msgstr "R_esolution:"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr "Sub_pixel (LCD)"
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "Fandamalamana sub_pixel (LCD)"
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "Endri-tsoratry ny _rindran'asa:"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Document font:"
+msgstr "_Endri-tsoratry ny tahirin-kevitra:"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Fixed width font:"
+msgstr "Sakan'endri-tsoratra voafetra:"
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Full"
+msgstr "_Feno"
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Medium"
+msgstr "_Antonony"
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_Monochrome"
+msgstr "_Tokan-doko"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_None"
+msgstr "_Tsy misy"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Slight"
+msgstr "_Malefaka"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "Endri-tsoratra ho an'ny lohatenin'ny _fikandrana:"
+
+#: ../capplets/font/font-properties.glade.h:30
+msgid "dots per inch"
+msgstr "dpi"
+
+#: ../capplets/font/main.c:489
+msgid "Font may be too large"
+msgstr "Mety lehibe loatra ilay endri-tsoratra"
+
+#: ../capplets/font/main.c:493
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe "
+"loatra (x %d) ny endri-tsoratra nosafidianao. Tsara raha mampiasa endri-"
+"tsoratra kely noho ny %d ianao."
+msgstr[1] ""
+"Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe "
+"loatra (x %d) ny endri-tsoratra nosafidianao. Tsara raha mampiasa endri-"
+"tsoratra kely noho ny %d ianao."
+
+#: ../capplets/font/main.c:506
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe %d "
+"teboka loatra ny endri-tsoratra nosafidianao. Tsara raha misafidy endri-"
+"tsoratra kely noho io ianao."
+msgstr[1] ""
+"Mety tsy afaka miasa araka ny tokony ho izy ilay solosaina satria lehibe %d "
+"teboka loatra ny endri-tsoratra nosafidianao. Tsara raha misafidy endri-"
+"tsoratra kely noho io ianao."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "Mpanfaingana vaovao..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Kitendry mpanafaingana"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Mpanova ireo mpanafaingana"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Fangon'ny kitendry mpanafaingana"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Fomban'ny mpanafaingana"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Ny karazan'ilay mpanafaingana."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:187
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:471
+msgid "Disabled"
+msgstr "Natsahatra"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:534
+msgid "<Unknown Action>"
+msgstr "<Ada tsy fantatra>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:555
+msgid "Desktop"
+msgstr "Sehatr'asa"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:556
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Feo"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:560
+msgid "Window Management"
+msgstr "Fandrindrana fikandrana"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:666
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become unusable to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time.\n"
+msgstr ""
+"Tsy mety ampiasaina ny hitsin-dàlana \"%s\" satria tsy hety hampiasaina "
+"hanoratana intsony io kitendry io.\n"
+"Andramo ampiarahana amin'ny kitendry toy ny Control, Alt na Shift ilay izy.\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:695
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+"Ny hitsin-dàlana \"%s\" dia efa ampiasaina amin'ny:\n"
+"\"%s\"\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:727
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr ""
+"Tsy nety ny famoronana mpanfaingana vaovao ao anatin'ny soratra fototry ny "
+"kirakira: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:777
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr ""
+"Tsy nety ny fanafoanana ilay mpanafaingana tao anatin'ny soratra fototry ny "
+"kirakira: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:884
+msgid "Action"
+msgstr "Asa"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:908
+msgid "Shortcut"
+msgstr "Hitsin-dàlana"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Hintsin-dàlan'ny kitendry"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"Raha hanova mpanfaingana, dia manorata mpanafaingana vaovao eo amin'ny "
+"fariana voatokana amin'izany, na tsindrio ny kitendry miverina hamafana azy."
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Hamorona kitendry hitsin-dàlana ho ana baiko"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:87
+msgid "Unknown"
+msgstr "Tsy fantatra"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:281
+msgid "Layout"
+msgstr "Fandaminana"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:285
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:229
+msgid "Default"
+msgstr "Tsotra"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:77
+msgid "Models"
+msgstr "Modely"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:109
+#, c-format
+msgid "There was an error launching the keyboard tool: %s"
+msgstr "Nisy olana teo am-pandefasana ny fikirakirana ny kitendry: %s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr "_Fahafahana mampiasa"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:756
+#: ../capplets/sound/sound-properties-capplet.c:758
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+"Ampiharo fotsiny ireo fandrindrana dia ajanony (fifanarahana ihany; efa "
+"raisin'ny daemon an-tànana izao)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr ""
+"Asehoy ireo fandrindrana ny fiatoan'ny fanoratana rehefa mandefa ilay pejy"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "..."
+msgstr "..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Fipian'ny kitondro</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Kitendrin'ny famerenana</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<b>_Gejao ny efijery hanamafisana ny fiatoan'ny fanoratana</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Faingana</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Lava</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Fohy</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Meda</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_vailable layouts:"
+msgstr "Ireo fandaminana _misy:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "All_ow postponing of breaks"
+msgstr "_Ekeo ny fanemorana ireo fiatoana"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Jereo raha toa ka azo ahemotra ireo fiatoana"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "Choose a Keyboard Model"
+msgstr "Misafidiana modelim-pafan-teny iray"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Choose a Layout"
+msgstr "Misafidiana fandaminana iray"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr "_Mipy ilay kitondro anatin'ny takila sy toeran-tsoratra"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Cursor blinks speed"
+msgstr "Hafainganan'ny fipian'ny kitondro"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of the break when typing is disallowed"
+msgstr "Faharetan'ny fiatoana raha rehefa voarara ny fanoratana"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Duration of work before forcing a break"
+msgstr "Faharetan'ny asa atao alohan'ny hanisiana fiatoana"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Key presses _repeat when key is held down"
+msgstr ""
+"_Famerenana izay voatsindry rehefa rehefa voatsindry tsy miato ny kitendry "
+"iray"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Keyboard Preferences"
+msgstr "Safidy manokan'ny fafan-teny"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Keyboard _model:"
+msgstr "_Modelim-pafan-teny:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Layout Options"
+msgstr "Safidin'ny fandaminana"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Layouts"
+msgstr "Fandaminana"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Gejao ny efijery aorian'ny fotoana voafaritra mba hisorohana izay aretina "
+"ateraky ny fampiasana fafan-teny matetika loatra"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Microsoft Natural Keyboard"
+msgstr "Microsoft Natural Keyboard"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Preview:"
+msgstr "Topy maso:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "Repeat keys speed"
+msgstr "Hafainganan'ny kitendry famerenana"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Reset To De_faults"
+msgstr "Avereno amin'ny toetra _tsotra"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Separate _group for each window"
+msgstr "_Vondrona tokana isaka ny fikandrana"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+msgid "Typing Break"
+msgstr "Fiatoan'ny fanoratana"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Accessibility..."
+msgstr "_Fahafahana mampiasa..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Add..."
+msgstr "_Hanampy..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "_Break interval lasts:"
+msgstr "_Faharetan'ny elanelan'ireo fiatoana:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Delay:"
+msgstr "_Elanelam-potoana:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Models:"
+msgstr "_Modely:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Selected layouts:"
+msgstr "_Fandaminana voasafidy:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Speed:"
+msgstr "_Hafainganana:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "_Work interval lasts:"
+msgstr "_Faharetan'ny elanelan'ny asa atao:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "minutes"
+msgstr "minitra"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Mamaritra ireo safidy manokan'ny fafan-teny"
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:880
+#, c-format
+msgid "%d milliseconds"
+msgid_plural "%d milliseconds"
+msgstr[0] "%d milisegaondra"
+msgstr[1] "%d milisegaondra"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:560
+msgid "Unknown Pointer"
+msgstr "Kitondro tsy fantatra"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+msgid "Default Pointer"
+msgstr "Kitondro tsotra"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Pointer - Current"
+msgstr "Kitondro tsotra - Ny miasa izao"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+msgid "The default pointer that ships with X"
+msgstr "Ny kitondro tsotra nivoaka niaraka tamin'ny X"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+msgid "White Pointer"
+msgstr "Kitondro fotsy"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Pointer - Current"
+msgstr "Kitondro fotsy - Ny miasa izao"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+msgid "The default pointer inverted"
+msgstr "Ny kitondro tsotra navadika"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+msgid "Large Pointer"
+msgstr "Kitondro lehibe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Pointer - Current"
+msgstr "Kitondro lehibe - Ny miasa izao"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+msgid "Large version of normal pointer"
+msgstr "Ny kitondro ara-pitsipika amin'ny endriny lehibe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+msgid "Large White Pointer - Current"
+msgstr "Kitondro fotsy lehibe - Ny miasa izao"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Pointer"
+msgstr "Kitondro fotsy lehibe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+msgid "Large version of white pointer"
+msgstr "Ny kitondro fotsy amin'ny endriny lehibe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:970
+msgid "Pointer Theme"
+msgstr "Endriky ny kitondro"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr "<b>Elanelan'ny click miverina indroa </b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Alaivo dia afindrao</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Farito ny toeran'ny kitondro</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>Fitodiky ny totozy</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Speed</b>"
+msgstr "<b>Hafaingana</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>Faingana</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>Ambony</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>Lehibe</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>Ambany</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>Meda</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>Kely</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Tsindry"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr "Manasongadina ilay _kitondro rehefa manindry ny Ctrl ianao"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Large"
+msgstr "Lehibe"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Medium"
+msgstr "Antonony"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "Motion"
+msgstr "Hetsika"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+msgid "Mouse Preferences"
+msgstr "Safidy manokan'ny totozy"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Pointer Size:"
+msgstr "Haben'ny kitondro:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Pointers"
+msgstr "Kitondro"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "Small"
+msgstr "Kely"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr "_Fanafainganana:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr "_Totozy ho an'ny tànana havia"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr "_Fahamora mandray:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr "_Fetra:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr "_Elanelany:"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Totozy"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Mamaritra ny safidy manokan'ny totozinao"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Proxy'ny rezo"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "Mamaritra ny safidy manokan'ny proxy'ny rezonao"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>Fifandraisana Internet _mivantana</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr "<b>Lisitry ny mpampiantrano tsy raharahaina</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>Fikirakirana proxy mandeha _hoazy</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>Fikirakirana proxy ataon-tànana</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr "<b>Mampi_asà fanamarinana</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "Advanced Configuration"
+msgstr "Fikirakirana avo lenta"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr "_URL'ny fikirakirana mandeha hoazy:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "Antsipirian'ny proxy HTTP"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "Proxy H_TTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Network Proxy Preferences"
+msgstr "Safidy manokan'ny proxy'ny rezo"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Irika:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "Proxy Configuration"
+msgstr "Kirakiran'ny proxy"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr "Mpampiantrano S_ocks:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "U_sername:"
+msgstr "Anaran'ny _mpampiasa:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_Antsipiriany"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr "Proxy _FTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "_Teny fanalahidy:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr "Proxy HTTP azo _antoka:"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Alefaso ireo feo ary ampifandraiso amin'ny zava-mitranga"
+
+#: ../capplets/sound/sound-properties-capplet.c:316
+#: ../capplets/sound/sound-properties-capplet.c:368
+msgid "Not connected"
+msgstr "Tsy mifandray"
+
+#: ../capplets/sound/sound-properties-capplet.c:790
+msgid "Sound Preferences"
+msgstr "Safidy manokan'ny feo"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "<b>Audio Conferencing</b>"
+msgstr "<b>Audio Conferencing</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "<b>Music and Movies</b>"
+msgstr "<b>Hira sy horonantsary</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "<b>Sound Events</b>"
+msgstr "<b>Zava-mitranga araham-peo</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+msgstr "<span weight=\"bold\" size=\"x-large\">Mitsapa...</span>"
+
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Click Ok to finish."
+msgstr "Tsindrio ny Ok rehefa vita."
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "Devices"
+msgstr "Periferika"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "E_nable software sound mixing (ESD)"
+msgstr "_Alefaso ny fampifangaroana feon'ilay rindran'asa (ESD)"
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "Flash _entire screen"
+msgstr "Flasheo ny efijery _manontolo"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "Flash _window titlebar"
+msgstr "Flasheo ny anjan'ny lohaten'ny _fikandrana"
+
+#: ../capplets/sound/sound-properties.glade.h:11
+msgid "Sound & Video Preferences"
+msgstr "Safidy manokan'ny feo sy ny horonantsary"
+
+#: ../capplets/sound/sound-properties.glade.h:12
+msgid "Sound Capture:"
+msgstr "Ampaham-peo:"
+
+#: ../capplets/sound/sound-properties.glade.h:13
+msgid "Sound Playback:"
+msgstr "Famakiana feo:"
+
+#: ../capplets/sound/sound-properties.glade.h:14
+msgid "Sounds"
+msgstr "Feo"
+
+#: ../capplets/sound/sound-properties.glade.h:15
+msgid "System Beep"
+msgstr "Feon'ny rafitra"
+
+#: ../capplets/sound/sound-properties.glade.h:16
+msgid "Test"
+msgstr "Fitsapana"
+
+#: ../capplets/sound/sound-properties.glade.h:17
+msgid "Testing Pipeline"
+msgstr "Mitsapa ny fantsona"
+
+#: ../capplets/sound/sound-properties.glade.h:18
+msgid "_Enable system beep"
+msgstr "_Alefaso ny feon'ny rafitra"
+
+#: ../capplets/sound/sound-properties.glade.h:19
+msgid "_Play system sounds"
+msgstr "_Vakio ireo feon'ny rafitra"
+
+#: ../capplets/sound/sound-properties.glade.h:20
+msgid "_Visual system beep"
+msgstr "_Feon'ny rafitry ny hita maso"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:368
+msgid "Would you like to remove this theme?"
+msgstr "Tianao esorina ve ity endrika ity?"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:433
+msgid "Theme deleted succesfully. Please select another theme."
+msgstr "Voafafa soa aman-tsara ilay endrika. Misafidiana endrika iray hafa."
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:442
+msgid "Theme can not be deleted"
+msgstr "Tsy mety fafàna ilay endrika"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:535
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+"Tsy ahitana endrika anatin'ny rafitrao. Mety mikika izany hoe tsy voapetraka "
+"araka ny tokony ho izy ny \"Theme Preferences\" na tsy napetrakao ny fehin-"
+"drindran'asa \"gnome-themes\"."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:254
+msgid "This theme is not in a supported format."
+msgstr "Tsy raisina an-tànana ny lamin'ity endrika ity."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:272
+msgid "Failed to create temporary directory"
+msgstr "Tsy nahaforona ny laha-tahiry vonjimaika"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:293
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+"Tsy afaka mametraka ilay endrika. \n"
+"Tsy voapetraka ny rindran'asa bzip2."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:312
+#: ../capplets/theme-switcher/gnome-theme-installer.c:351
+#: ../capplets/theme-switcher/gnome-theme-installer.c:434
+msgid "Installation Failed"
+msgstr "Nandamoka ny fametrahana"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:333
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+"Tsy afaka mametraka ireo endrika. \n"
+"Tsy voapetraka ny rindran'asa gzip."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:375
+#, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+"Voapetraka tsara araka ny tokony ho izy ny endriky ny kisary %s. \n"
+"Azonao safidiana ao anatin'ny antsipirian'ny endrika izy io."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:378
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr "Voapetraka araka ny tokony ho izy ny Endriky ny Gnome %s"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:381
+#, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+"Voapetra araka ny tokony ho izy ny sisim-pikandrana %s.\n"
+"Azonao safidiana ao amin'ny antsipirian'ny endrika izy io."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:384
+#, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+"Voapetraka araka ny tokony ho izy ny endriky ny fibaikoana %s.\n"
+"Azonao safidiana ao amin'ny antsipirian'ny endrika izy io."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:390
+msgid "The theme is an engine. You need to compile the theme."
+msgstr "Milina ilay endrika. Mila compile-nao io rakitra io."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:408
+msgid "The file format is invalid"
+msgstr "Tsy ekena ny lamin'io rakitra io"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:499
+msgid "No theme file location specified to install"
+msgstr "Tsy misy toeran'endrika nolazaina ny fametrahana"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:514
+msgid "The theme file location specified to install is invalid"
+msgstr "Tsy ekena ilay toeran'endrika nolazaina ny fametrahana"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:534
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"Tsy ampy ny fahazoan-dàlana ahafahana mametraka ilay endrika anatin'ny:\n"
+"%s"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:555
+msgid "The file format is invalid."
+msgstr "Tsy ekena ny lamin'io endrika io."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:582
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+"%s no sori-dàlana ametrahana ireo rakitry ny endrika. Tsy mety faritana ho "
+"toerana iaviana izy io"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:647
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr ""
+"Tsy afaka mametraka ilay endrika.\n"
+"Tsy voapetraka ao amin'ny solosainao ny rindran'asa tar."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:686
+msgid "Custom theme"
+msgstr "Endrika safidy"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:686
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr "Azonao raiketina amin'ny alalan'ny tsindry Raiketo ity endrika ity."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1579
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+"Tsy hita ao amin'ny rafitrao ny drafitry ny endrika tsotra. Midika izany fa "
+"tsy voapetraka ny metacity na tsy voakirakira araka ny tokony ho izy ny "
+"gconf."
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:73
+msgid "Theme name must be present"
+msgstr "Tsy maintsy asiana anaran'endrika"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:144
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Efa misy io endrika io. Tianao tsindriana ve izy io?"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr "Misafidy endrika ampiasaina amin'ny faritra maro amin'ny sehatr'asa"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "Endrika"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "Apply _Background"
+msgstr "Ampiharo ilay _afara"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "Apply _Font"
+msgstr "Ampiharo ilay _endri-tsoratra"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Controls"
+msgstr "Fibaikoana"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Icons"
+msgstr "Kisary"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Save Theme"
+msgstr "Raiketo ilay endrika"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "Save _Background Image"
+msgstr "Raiketo ilay sarin'ny _afara"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "Select theme for the desktop"
+msgstr "Misafidiana endrika ho an'ny sehatr'asa"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+msgid "Theme Details"
+msgstr "Antsipirian'ny endrika"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+msgid "Theme Preferences"
+msgstr "Safidy manokan'ny endrika"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+msgid "Theme _Details"
+msgstr "_Antsipirian'ny endrika"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "This theme does not suggest any particular font or background."
+msgstr "Tsy milaza endri-tsoratra na afara manokana ity endrika ity."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "This theme suggests a background:"
+msgstr "Milaza afara iray ity endrika ity:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+msgid "This theme suggests a font and a background:"
+msgstr "Milaza endri-tsoratra sy afara ity endrika ity:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+msgid "This theme suggests a font:"
+msgstr "Milaza endri-tsoratra ity endrika ity:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+msgid "Window Border"
+msgstr "Sisim-pikandrana"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+msgid "_Description:"
+msgstr "_Fanoritsoritana:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+msgid "_Install Theme..."
+msgstr "_Hametraka endrika..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "_Install..."
+msgstr "_Apetrao..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+msgid "_Name:"
+msgstr "_Anarana:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+msgid "_Revert"
+msgstr "_Avereno"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+msgid "_Save Theme..."
+msgstr "_Raiketo ilay endrika..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+msgid "theme selection tree"
+msgstr "Hazon'ny fisafidianana endrika"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr ""
+"Mamaritra ny endriky ny anjan'ny fitaovana sy tolotra amin'ny rindran'asa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "Anjan'ny tolotra & fitaovana"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr "<b>Fiasa sy endrika</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+msgid "<b>Preview</b>"
+msgstr "<b>Topy maso</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "_Esory"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+msgid "Icons only"
+msgstr "Kisary fotsiny"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "Safidy manokan'ny anjan'ny tolotra sy fitaovana"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "Rakitra vaovao"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Hanokatra rakitra"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Raiketo ilay rakitra"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr "Asahoy anatin'ny tolotra ny _kisary"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+msgid "Text below icons"
+msgstr "Ny soratra ambanin'ny kisary"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+msgid "Text beside icons"
+msgstr "Ny soratra akaikin'ny kisary"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+msgid "Text only"
+msgstr "Soratra fotsiny"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+msgid "Toolbar _button labels:"
+msgstr "Mari-tsoratra amin'ny _tsindrin'ny anjan'ny fitaovana:"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_Adikao"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr "_Anjan'ny fitaovana azo alàna"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_Ovay"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr "Mpanafaingan'ny tolotra _azo ovaina"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "_Rakitra"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_Vaovao"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "_Sokafy"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "_Apetao"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "_Atontay"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "_Ajanony"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "_Raiketo"
+
+#: ../capplets/windows/gnome-window-properties.c:385
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+"<b>Tsy mahalefa ny rindran'asan'ny safidy manokan'ny mpandrindra fikandrana</"
+"b>\n"
+"\n"
+"%s"
+
+#: ../capplets/windows/gnome-window-properties.c:642
+msgid "C_ontrol"
+msgstr "Fi_baikoana"
+
+#: ../capplets/windows/gnome-window-properties.c:647
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:653
+msgid "H_yper"
+msgstr "H_yper"
+
+#: ../capplets/windows/gnome-window-properties.c:660
+msgid "S_uper (or \"Windows logo\")"
+msgstr "S_uper (na \"Windows logo\")"
+
+#: ../capplets/windows/gnome-window-properties.c:667
+msgid "_Meta"
+msgstr "_Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Kitendrin'ny fihetsika</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>Asan'ny anjan'ny lohateny</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Fisafidianana fikandrana</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr ""
+"Raha hamindra fikandrana, dia tsindrio ka tano eo ity kitendry ity ary raiso "
+"ilay fikandrana rehefa avy eo:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Safidy manokan'ny fikandrana"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr ""
+"_Tsindrio in-2 eo amin'ny anjan'ny lohateny raha hanatanteraka ity asa "
+"manaraka ity:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "_Elanelam-potoana alohan'ny fampakarana:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_Ampiakaro ireo fikandrana voafaritra ao anatin'ny fe-potoana iray"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Safidio ireo fikandrana rehefa mankeo amboniny ny totozy"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "Mamaritra ny toetoetry ny fikandranao"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Windows"
+
+#: ../control-center/control-center-categories.c:287
+msgid "Others"
+msgstr "Hafa"
+
+#: ../control-center/control-center.c:93
+msgid "Desktop Preferences"
+msgstr "Safidy manokan'ny sehatr'asa"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr "Ivotoerana fifehezan'ny GNOME"
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "Ny fitaovana fikirakiran'ny GNOME"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "Fanamafisam-peo"
+
+#: ../gnome-settings-daemon/factory.c:60
+msgid "Could not initialize Bonobo"
+msgstr "Tsy nahalefa ny Bonobo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:406
+msgid "Slow Keys Alert"
+msgstr "Fampilazan'ny kitendry meda"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:407
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Notsindrianao nandritra ny 8 segaondra ny kitendry Shift. Io no hitsin-"
+"dàlana mampadeha ny fahasahazan'ny kitendry meda izay mampiova ny fiasan'ny "
+"fafan-teninao. "
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:409
+msgid "Do you want to activate Slow Keys?"
+msgstr "Tianao alefa ve ny kitendry meda?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Do you want to deactivate Slow Keys?"
+msgstr "Tianao atsahatra ve ny kitendry meda?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
+msgid "_Activate"
+msgstr "_Alefaso"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
+msgid "_Deactivate"
+msgstr "_Atsaharo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
+msgid "Do_n't activate"
+msgstr "_Aza alefa"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
+msgid "Do_n't deactivate"
+msgstr "_Aza atsahatra"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:421
+msgid "Sticky Keys Alert"
+msgstr "Fampilazan'ny kitendry miraikidraikitra"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:422
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Notsindrianao in-5 misesisesy ny kitendry Shift. Io no hitsin-dàlana "
+"mampandeha ny fahasahazan'ny kitendry miraikidraikitra izay mampiova ny "
+"fiasan'ny fafan-teninao."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:424
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+"Nanindry kitendry roa miaraka ianao, na nanindry ny kitendry Shift in-5 "
+"misesisesy. Izany dia manatsahatra ny fahasahazan'ny kitendry "
+"miraikidraikitra izay mampiova ny fiasan'ny fafan-teninao."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:426
+msgid "Do you want to activate Sticky Keys?"
+msgstr "Tianao alefa ve ny kitendry miraikidraikitra?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:427
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr "Tianao atsahatra ve ny kitendry miraikidraikitra?"
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:74
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing the mouse pointer theme."
+msgstr ""
+"Tsy afaka mamorona ny laha-tahiry\"%s\".\n"
+"Ilaina izy io mba ahafahana manova ny endriky ny kitondron'ny totozy."
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:96
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+"Tsa afaka mamorona ny laha-tahiry \"%s\".\n"
+"Ilaina izy io mba ahafahana manova ny kitondro."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:208
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr "Voasoritra imbetsaka ny asan'ny Key Binding (%s)\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:221
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr "Voasoritra imbetsaka ny binding'ny Key Binding (%s)\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:227
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr "Tsy feno ny Key Binding (%s)\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:255
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr "Tsy ekena ny Key Binding (%s)\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:291
+#, c-format
+msgid "It seems that another application already has access to key '%u'."
+msgstr "Toa efa misy rindran'asa hafa mampiasa ny kitendry '%u'."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:360
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr "Key miasa ny Key Binding (%s)\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:435
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+"Nisy olana teo am-panandramana mandefa ny (%s)\n"
+"izay mifanaraka amin'ny kitendry (%s)"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:105
+#, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+"Nisy olana teo am-pandefasana ny kirakira XKB.\n"
+"Maro ireo zavatra mety mahatonga izany:\n"
+"- misy bug anatin'ny tahirin-boky libxklavier\n"
+"- misy bug anatin'ny mpizara X  (ny rindran'asa xkbcomp, xmodmap)\n"
+"- tsy mifanaraka amin'ny mpizara X fametrahana ny libxkbfile\n"
+"\n"
+"Datan'ny kinovan'ny mpizara X:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"Raha toa mitatitra ity zava-miseho ity ho toy ny bug ianao, dia lazao ao:\n"
+"- Ny valin'ny <b>%s</b>\n"
+"- Ny valin'ny <b>%s</b>"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:119
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+"Mampiasa XFree 4.3.0 ianao.\n"
+"Ahitana olana maro ny kirakira XKB maro sosona.\n"
+"Manandrama mampiasa kirakira tsotra kokoa na mametraka kinovan'ny "
+"rindran'asa XFree vaovao."
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:244
+msgid "Do _not show this warning again"
+msgstr "_Aza aseho intsony ity fampilazana ity"
+
+#. !! temporary one
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
+#, c-format
+msgid ""
+"<b>The X system keyboard settings differ from your current GNOME keyboard "
+"settings.</b>\n"
+"\n"
+"Expected was %s, but the the following settings were found: %s.\n"
+"\n"
+"Which set would you like to use?"
+msgstr ""
+"<b>Tsy mitovy amin'ny fandrindran'ny fafan-tenin'ny GNOME ny fandrindran'ny "
+"fafan-tenin'ny rafitra X.</b>\n"
+"\n"
+"%s no nampoizina, nefa ity fandrindrana manaraka ity no hita:%s.\n"
+"\n"
+"Iza amin'ireo no tianao ampiasaina?"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:275
+msgid "Use X settings"
+msgstr "Ampiasao ny fandrindran'ny X"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:277
+msgid "Keep GNOME settings"
+msgstr "Ny fandrindran'ny GNOME no ampiasao"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:118
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+"Tsy afaka nanatanteraka ny baiko: %s\n"
+"Amarino hoe misy io baiko io."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:134
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+"Tsy afaka nampiato ny solosaina.\n"
+"Amarino hoe voakirakira araka ny tokony ho izy ilay solosaina."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:168
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+"Tsy afaka naka ny rakitra Glade.\n"
+"Amarino hoe voapetraka araka ny tokony ho izy io daemon io."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:110
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+"Nisy olana teo am-pandefasana ny sary mitsitsy:\n"
+"\n"
+"%s\n"
+"Tsy handeha amin'ity session ity fahasahazan'ny sary mitsitsy."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:120
+msgid "_Do not show this message again"
+msgstr "_Aza aseho intsony ity filazana ity"
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:131
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr "Tsy afaka naka ny raki-peo %s hatao sombiny %s"
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:212
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:260
+msgid "Cannot determine user's home directory"
+msgstr "Tsy afaka namaritra ny laha-tahiry fandraisan'ny mpampiasa"
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:212
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr ""
+"Voafarirtra manaraka ny karazana %s ny famaha GConf %s, nefa ny karazany "
+"nampoizina dia %s\n"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+msgid "A_vailable files:"
+msgstr "Ireo rakitra _misy:"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+msgid "Do _not show this warning again."
+msgstr "Aza aseho _intsony ity fampilazana ity."
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr "Alaivo ireo rakitra modmap"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr "Tianao alaina ilay (ireo) rakitra modmap?"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr "_Alaivo"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+msgid "_Loaded files:"
+msgstr "_Ireo rakitra azo:"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr "Nisy olana teo am-pamoronana fantson'ny fambara."
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Karazana"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+"Karazan'ny bg_applier: BG_APPLIER_ROOT ho an'ny fikandran'ny faka na "
+"BG_APPLIER_PREVIEW ho an'ny topy maso"
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr "Topy maso ny sakany"
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr "Ny sakany raha toa ka topy maso ilay mpampihatra: 64 (sanda tsotra)."
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr "Topy maso ny haavony"
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr "Ny haavony raha toa ka topy maso ilay mpampihatra: 48 (sanda tsotra)."
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Efijery"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr "Ny efijery hivelaran'ny BGApplier"
+
+#: ../libgswitchit/gswitchit_config.c:1074
+#, c-format
+msgid "There was an error loading an image: %s"
+msgstr "Nisy olana teo am-pakana ny sary iray: %s"
+
+#: ../libgswitchit/gswitchit_config.c:1399
+#, c-format
+msgid "layout \"%s\""
+msgid_plural "layouts \"%s\""
+msgstr[0] "Fandaminana \"%s\""
+msgstr[1] "Fandaminana \"%s\""
+
+#: ../libgswitchit/gswitchit_config.c:1416
+#, c-format
+msgid "option \"%s\""
+msgid_plural "options \"%s\""
+msgstr[0] "Safidy \"%s\""
+msgstr[1] "Safidy \"%s\""
+
+#: ../libgswitchit/gswitchit_config.c:1424
+#, c-format
+msgid "model \"%s\", %s and %s"
+msgstr "modely \"%s\", %s ary %s"
+
+#: ../libgswitchit/gswitchit_config.c:1425
+msgid "no layout"
+msgstr "tsy misy fandaminana"
+
+#: ../libgswitchit/gswitchit_config.c:1426
+msgid "no options"
+msgstr "tsy misy safidy"
+
+#: ../libsounds/sound-view.c:43
+msgid "Login"
+msgstr "Fidirana"
+
+#: ../libsounds/sound-view.c:44
+msgid "Logout"
+msgstr "Fivoahana"
+
+#: ../libsounds/sound-view.c:45
+msgid "Boing"
+msgstr "Fanakorana"
+
+#: ../libsounds/sound-view.c:46
+msgid "Siren"
+msgstr "Anjombona"
+
+#: ../libsounds/sound-view.c:47
+msgid "Clink"
+msgstr "Feo mikarantsana"
+
+#: ../libsounds/sound-view.c:48
+msgid "Beep"
+msgstr "Bip"
+
+#: ../libsounds/sound-view.c:49
+msgid "No sound"
+msgstr "Tsy misy feo"
+
+#: ../libsounds/sound-view.c:131
+msgid "Sound not set for this event."
+msgstr "Tsy voafaritra ny feo ho an'ity zava-miseho ity."
+
+#: ../libsounds/sound-view.c:140
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package for a set of default sounds."
+msgstr ""
+"Tsy misy ny raki-peo ho an'ity zava-miseho ity.\n"
+"Mety mila mametraka ny fehy gnome-audio izay misy feo tsotra maromaro "
+"angamba ianao."
+
+#: ../libsounds/sound-view.c:151
+msgid "The sound file for this event does not exist."
+msgstr "Tsy misy ny raki-peo ho an'ity zava-miseho ity."
+
+#: ../libsounds/sound-view.c:182
+msgid "Select Sound File"
+msgstr "Hisafidy raki-peo"
+
+#: ../libsounds/sound-view.c:202
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "Rakitra .wav tsy ekena ny rakitra %s"
+
+#: ../libsounds/sound-view.c:359
+msgid "System Sounds"
+msgstr "Feon'ny rafitra"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+"Tsy nanambara fitaovana fikirakirana ny mpandrindra fikandrana \"%s\" \n"
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Alehibiazo"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Aforeto miakatra"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr ""
+"Raha marina izay voalaza, dia ho tazonina ao anatin'ny sync ireo mpandray an-"
+"tànana mime ho an'ny text/plain and text/*"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr "Ireo mpandray an-tànana ny text/plain and text/* an'ny sync"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "E-mail"
+msgstr "Mailaka"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "E-mail's shortcut."
+msgstr "Hitsin-dàlan'ny mailaka."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Eject"
+msgstr "Tsoahy"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Eject's shortcut."
+msgstr "Hitsin-dàlan'ny Tsoahy."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "Home folder"
+msgstr "Laha-tahirin'ny fandraisana"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "Home folder's shortcut."
+msgstr "Hitsin-dàlan'ny laha-tahirin'ny fandraisana."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Launch help browser"
+msgstr "Alefaso ny mpizaha toro-làlana"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+msgid "Launch help browser's shortcut."
+msgstr "Hitsin-dàlan'ny Alefaso ny mpizaha toro-làlana."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+msgid "Launch web browser"
+msgstr "Alefaso ny mpitety tranonkala"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+msgid "Launch web browser's shortcut."
+msgstr "Hitsin-dàlan'ny Alefaso ny mpitety tranonkala."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+msgid "Lock screen"
+msgstr "Gejao ny efijery"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+msgid "Lock screen's shortcut."
+msgstr "Hitsin-dàlan'ny Gejao ny efijery."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+msgid "Log out"
+msgstr "Hivoaka"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+msgid "Log out's shortcut."
+msgstr "Hitsin-dàlan'ny Hivoaka."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+msgid "Next track key's shortcut."
+msgstr "Hitsin-dàlan'ny tsindry Manaraka."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+msgid "Pause"
+msgstr "Miato"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+msgid "Pause key's shortcut."
+msgstr "Hitsin-dàlan'ny tsindry Miato."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+msgid "Play (or play/pause)"
+msgstr "Mamaky (na mamaky/miato)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Play (or play/pause) key's shortcut."
+msgstr "Hitsin-dàlan'ny tsindry Mamaky (na mamaky/miato)."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Previous track key's shortcut."
+msgstr "Hitsin-dàlan'ny tsindry Aloha."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Search"
+msgstr "Karohy"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Search's shortcut."
+msgstr "Hitsin-dàlan'ny Karohy."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Skip to next track"
+msgstr "Mamaky ny hira manaraka"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Skip to previous track"
+msgstr "Mamaky ny hira teo aloha"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Sleep"
+msgstr "Fiatoana"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+msgid "Sleep's shortcut."
+msgstr "Hitsin-dàlan'ny Fiatoana."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Stop playback key"
+msgstr "Ajanony"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Stop playback key's shortcut."
+msgstr "Hitsin-dàlan'ny Ajanony."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Volume down"
+msgstr "Ambany"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+msgid "Volume down's shortcut."
+msgstr "Hitsin-dàlan'ny fanamorana feo."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Volume mute"
+msgstr "Malefaka"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Volume mute's shortcut"
+msgstr "Hitsin-dàlan'ny Fanalefahana feo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume step"
+msgstr "Dingan'ny fanamafisam-peo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume step as percentage of volume."
+msgstr "Dingana mampiseho ny hamafin'ny feo."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume up"
+msgstr "Ambony"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume up's shortcut."
+msgstr "Hitsin-dàlan'ny Fanamafisana feo."
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr ""
+"Mampiseho takelaka kely rehefa misy olana ny fandefasana ny sary mitsitsy"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+msgid "Run screensaver at login"
+msgstr "Alefaso eny am-pidirana ny sary mitsitsy"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr "Asehoy ireo tsy fetezana mitranga eny am-piandohana"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+msgid "Start screensaver"
+msgstr "Alefaso ny sary mitsitsy"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+"Fitambaran-teny baiko alefa isaky ny averina alaina ny toetry ny fafan-teny. "
+"Ilaina ho an'ny fampiharana indray ireo fanitsiana mifototra amin'ny xmodmap "
+"izy ireo"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr "Lisitr'ireo rakitra modmap hita ao anatin'ny laha-tahiry $HOME."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr "Vondrona tsotra voafaritra mandritra ny famoronana fikandrana"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr "Tano ary arindrao isaka ny fikandrana iray ny vondrona iray"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+msgid "Keyboard Update Handlers"
+msgstr "Mpandray an-tànana ny fanavaozana ny fafan-teny"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+msgid "Keyboard layout"
+msgstr "Fandaminana ny fafan-teny"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+msgid "Keyboard model"
+msgstr "Modelim-pafan-teny"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+msgid "Keyboard options"
+msgstr "Safidin'ny fafan-teny"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr ""
+"Ho fehezina avy amin'ny ASAP'ny rafitra ireo fandrindran'ny fafan-teny ao "
+"amin'ny gconf (tsy ampiasaina intsony)"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr "Raiketo/avereno miaraka amin'ny vondron'ny fandaminana ireo mpilaza"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr "Ireo anaran'ny fandaminana no asehoy fa tsy ireo anaran'ny vondrona"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+"Ireo anaran'ny fandaminana no asehoy fa tsy ireo anaran'ny vondrona (ho "
+"an'ny kinovan'ny XFree izay mandray an-tànana fandaminana maro ihany)"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr "Fafao ny fampilazana \"X sysconfig changed\""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid "The Keyboard Preview, X offset"
+msgstr "Topy mason'ny fafan-teny, offset X"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+msgid "The Keyboard Preview, Y offset"
+msgstr "Topy mason'ny fafan-teny, offset Y"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+msgid "The Keyboard Preview, height"
+msgstr "Topy mason'ny fafan-teny, haavo"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "The Keyboard Preview, width"
+msgstr "Topy mason'ny fafan-teny, saka"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:18
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+"Afaka fotoana fohy dia ho fehezina avy amin'ny kirakiran'ny rafitra ireo "
+"fandrindrana ny fafan-teny ao amin'ny gconf. Efa hatramin'ny GNOME 2.12 no "
+"tsy nampiasaina izany famaha izany, ka foano ireo famahan'ny modely, "
+"fandaminana ary safidy mba ahazoana ny kirakiran-drafitra tsotra."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:19
+msgid "keyboard layout"
+msgstr "fandaminana ny fafan-teny"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:20
+msgid "keyboard model"
+msgstr "Modelim-pafan-teny"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:21
+msgid "modmap file list"
+msgstr "lisitry ny rakitra modmap"
+
+#: ../typing-break/drw-break-window.c:213
+#, fuzzy
+msgid "_Postpone break"
+msgstr "_Ahemory ny fiatoana"
+
+#: ../typing-break/drw-break-window.c:260
+msgid "Take a break!"
+msgstr "Hiato kely!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:135
+msgid "/_Preferences"
+msgstr "/_Safidy manokana"
+
+#: ../typing-break/drwright.c:136
+msgid "/_About"
+msgstr "/_Mombamomba"
+
+#: ../typing-break/drwright.c:138
+msgid "/_Take a Break"
+msgstr "/_Hiato kely"
+
+#: ../typing-break/drwright.c:489
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "%d minitra mandra-pahatongan'ny fiatoana manaraka"
+msgstr[1] "%d minitra mandra-pahatongan'ny fiatoana manaraka"
+
+#: ../typing-break/drwright.c:493
+msgid "Less than one minute until the next break"
+msgstr "Latsaka ny iray minitra mandra-pahatongan'ny fiatoana manaraka"
+
+#: ../typing-break/drwright.c:581
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Tsy afaka mampiseho ny takilan'ny toetoetry ny fiatona amin'ny fanoratana "
+"miaraka amin'ny ity tsy fetezana manaraka ity: %s"
+
+#: ../typing-break/drwright.c:629
+#, fuzzy
+msgid "About GNOME Typing Monitor"
+msgstr "Mombamomba ny Mpandrindra Fanoratana an'ny GNOME"
+
+#: ../typing-break/drwright.c:653
+msgid "A computer break reminder."
+msgstr "Feo filazana fiatoana amin'ny solosaina."
+
+#: ../typing-break/drwright.c:654
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr "Nosoratan'i Richard Hult &lt;richard@imendio.com&gt;"
+
+#: ../typing-break/drwright.c:655
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Eye Candy nampidirin'i Anders Carlsson"
+
+#: ../typing-break/drwright.c:831
+msgid "Break reminder"
+msgstr "Mpampatsiahy fiatoana"
+
+#: ../typing-break/eggtrayicon.c:127
+msgid "Orientation"
+msgstr "Fitodika"
+
+#: ../typing-break/eggtrayicon.c:128
+msgid "The orientation of the tray."
+msgstr "Ny fitodiky ny tray."
+
+#: ../typing-break/main.c:100
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Ny mpandrindra fanoratana dia mampiasa ny faritra filazana hanaovana "
+"fampahalalana. Toa tsy misy faritra filazana eo amin'ny tontonanao. Raha "
+"hametraka izany eo ianao, dia tondroy ny tontonana, tsindrio ny kitendry "
+"havanan'ny totozy, tsindrio ny 'Atao eo amin'ny tontonana', safidio ny "
+"'Faritra filazana' ary tsindrio ny 'Apetrao'."
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr ""
+"Mitsambikina eo amibonin'ny ilay alika kamo ilay fosa miloko manja. "
+"0123456789"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "Anarana:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "Endrika:"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "Karazana:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "Habe:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "Kinova:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "Fameran-jo:"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "Fanoritsoritana:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "fampiasa: rakitr'endri-tsoratra %s\n"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr "Farito ho endri-tsoratry ny rindran'asa"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+msgid "Sets the default application font"
+msgstr "Mamaritra ny endri-tsoratry ny rindran'asa tsotra"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+"Raha voalaza ho marina, dia haseho anaty sary madinika ireo endri-tsoratra "
+"OpenType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+"Raha voalaza fa marina, dia haseho anaty sary madinika ireo endri-tsoratra "
+"PCF."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+"Raha voalaza fa marina, dia haseho anaty sary madinika ireo endri-tsoratra "
+"TrueType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+"Raha voalaza fa marina, dia haseho anaty sary madinika ireo endri-tsoratra "
+"Type1."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"Ampifanarao amin'ny baiko amoronana sary madinika ho an'ny endri-tsoratra "
+"OpenType ity famaha ity."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endri-tsoratra "
+"PCF ity famaha ity."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endri-tsoratra "
+"TrueType ity famaha ity."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endri-tsoratra "
+"Type1 ity famaha ity."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra openType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra PCF"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra TrueType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Baiko famoronana sary madinika ho an'ny endri-tsoratra Type1"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "(Tsy) maneho ny endri-tsoratra OpenType anaty sary madinika"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "(Tsy) maneho ny endri-tsoratra PCF anaty sary madinika"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "(Tsy) maneho ny endri-tsoratra TrueType anaty sary madinika"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "(Tsy) maneho ny endri-tsoratra Type1 anaty sary madinika"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+msgid "GNOME Font Viewer"
+msgstr "Mpijery endri-tsoratra an'ny GNOME"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr ""
+"<span weight=\"bold\" size=\"larger\">Ampiharina ilay endri-tsoratra vaovao?"
+"</span>"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr "_Aza ampiharina"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"Tahaka ny endri-tsoratra vaovao ilay endrika nosafidianao. Miseho etsy "
+"ambany ny sariny."
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+msgid "_Apply font"
+msgstr "_Ampiharo"
+
+#: ../vfs-methods/themus/theme-method.c:518
+msgid "Themes"
+msgstr "Endrika"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "Fanoritsoritana"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr "Endriky ny fibaikoana"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+msgid "Window border theme"
+msgstr "Endriky ny sisin'ny fikandrana"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr "Endriky ny kisary"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr "ABCDEFG"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+msgid "Apply theme"
+msgstr "Ampiharo ilay endrika"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+msgid "Sets the default theme"
+msgstr "Mamaritra ny endrika tsotra"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr ""
+"Raha voalaza fa marina, dia haseho anaty sary madinika ireo endrika "
+"voapetraka."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr "Raha voalaza ho marina, dia haseho anaty sary madinika ireo endrika."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endrika "
+"voapetraka ity famaha ity."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+"Ampifanaraho amin'ny baiko amoronana sary madinika ho an'ny endrika ity "
+"famaha ity."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr "Baiko amoronana sary madinika ho an'ny sary voapetraka"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr "Baiko amoronana sary madinika ho an'ny endrika"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr "(Tsy) maneho ireo endrika voapetraka anaty sary madinika"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr "(Tsy) maneho ireo endrika anaty sary madinika"
+
+msgid "Show help options"
+msgstr "Asehoy ny safidy momba ny toro-làlana"

--- a/po/mjw.po
+++ b/po/mjw.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2020-02-22 15:18+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2020-02-22 22:20+0530\n"
 "Last-Translator: Jor Teron <jor.teron@gmail.com>\n"
 "Language-Team: Karbi <karbi.translation@gmail.com>\n"
@@ -19,657 +18,311 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!= 1);\n"
 "X-Generator: Gedit\n"
 
-#: panels/applications/cc-applications-panel.c:737
-msgid "System Bus"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:737
-#: panels/applications/cc-applications-panel.c:739
-#: panels/applications/cc-applications-panel.c:752
-#: panels/applications/cc-applications-panel.c:757
-msgid "Full access"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:739
-msgid "Session Bus"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:743
-#: panels/power/cc-power-panel.c:2472 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525
-msgid "Devices"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:743
-msgid "Full access to /dev"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:747
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:252
-msgid "Network"
-msgstr "Network"
-
-#: panels/applications/cc-applications-panel.c:747
-#: panels/applications/cc-snap-row.c:109
-msgid "Has network access"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:752
-#: panels/applications/cc-applications-panel.c:754
-#: panels/search/cc-search-locations-dialog.c:361
-msgid "Home"
-msgstr "Home"
-
-#: panels/applications/cc-applications-panel.c:754
-#: panels/applications/cc-applications-panel.c:759
-msgid "Read-only"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:757
-#: panels/applications/cc-applications-panel.c:759
-msgid "File System"
-msgstr "File System"
-
-#: panels/applications/cc-applications-panel.c:763
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:281
-#: shell/cc-window.c:964 shell/cc-window.ui:125
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:763
-#: panels/applications/cc-snap-row.c:73
-msgid "Can change settings"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:765
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:926
-msgid "Web Links"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:936
-msgid "Git Links"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:942
-#, c-format
-msgid "%s Links"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:950
-#: panels/applications/cc-applications-panel.c:986
-msgid "Unset"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1041
-msgid "Links"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1049
-msgid "Hypertext Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1063
-msgid "Text Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1077
-msgid "Image Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1093
-msgid "Font Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1154
-msgid "Archive Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1174
-msgid "Package Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1197
-msgid "Audio Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1214
-msgid "Video Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1222
-msgid "Other Files"
-msgstr ""
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1564
-#: panels/applications/cc-applications-panel.ui:418
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:167
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:45
+#: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:59
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:99
-msgid "Permissions & Access"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Open"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:111
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:126
-#: panels/applications/cc-applications-panel.ui:132
-#: panels/camera/gnome-camera-panel.desktop.in.in:3
-msgid "Camera"
-msgstr "Camera"
-
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:237
-#: panels/applications/cc-applications-panel.ui:267
-#: panels/keyboard/cc-keyboard-option.c:259
-#: panels/keyboard/cc-keyboard-option.c:378
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:96
-#: panels/keyboard/keyboard-shortcuts.c:425 panels/network/network-proxy.ui:126
-#: panels/user-accounts/um-fingerprint-dialog.c:211
-#: subprojects/gvc/gvc-mixer-control.c:1876
-msgid "Disabled"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:138
-#: panels/applications/cc-applications-panel.ui:144
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
-msgid "Microphone"
-msgstr "Microphone"
-
-#: panels/applications/cc-applications-panel.ui:150
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/location/gnome-location-panel.desktop.in.in:3
-msgid "Location Services"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:162
-#: panels/applications/cc-applications-panel.ui:501
-msgid "Built-in Permissions"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:163
-msgid "Cannot be changed"
-msgstr "Lar un eh"
-
-#: panels/applications/cc-applications-panel.ui:180
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:204
-msgid "Integration"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:216
-msgid "System features used by this application."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:230
-#: panels/applications/cc-applications-panel.ui:236
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:155
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Kiri"
 
-#: panels/applications/cc-applications-panel.ui:242
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:248
-msgid "Run in background"
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "Anung-padam"
 
-#: panels/applications/cc-applications-panel.ui:254
-msgid "Set Desktop Background"
-msgstr "Desktop Nung-arjan kibi"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:260
-#: panels/applications/cc-applications-panel.ui:266
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:148
+#, fuzzy
+msgid "Change the desktop wallpaper."
+msgstr "Arni lapen apor kelar"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Seh"
 
-#: panels/applications/cc-applications-panel.ui:299
-msgid "Default Handlers"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:311
-msgid "Types of files and links that this application opens."
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:327
-msgid "Reset"
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:363
-msgid "Usage"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Camera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:375
-msgid "How much resources this application is using."
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microphone"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:390
-#: panels/applications/cc-applications-panel.ui:537
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:425
-msgid "Open in Software"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:475 shell/cc-panel-list.ui:121
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:486
-#: panels/keyboard/cc-keyboard-panel.ui:188 shell/cc-panel-list.ui:132
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:554
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "File System"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:563
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:569
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Data"
 
-#: panels/applications/cc-applications-panel.ui:575
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Cache"
 
-#: panels/applications/cc-applications-panel.ui:581
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "Kado-kawe"
 
-#: panels/applications/cc-applications-panel.ui:598
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Cache pangthir…"
-
-#: panels/applications/cc-snap-row.c:55
-msgid "Add user accounts and change passwords"
-msgstr "Monit men kethap kethan lapen password kelar"
-
-#: panels/applications/cc-snap-row.c:57 panels/applications/cc-snap-row.c:133
-msgid "Play and record sound"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:59
-msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:61
-msgid "Access bluetooth hardware directly"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:63
-msgid "Use bluetooth devices"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:65
-msgid "Use your camera"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:67
-msgid "Print documents"
-msgstr "Loh ke Print"
-
-#: panels/applications/cc-snap-row.c:69
-msgid "Use any connected joystick"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:71
-msgid "Allow connecting to the Docker service"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:75
-msgid "Configure network firewall"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:77
-msgid "Setup and use privileged FUSE filesystems"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:79
-msgid "Update firmware on this device"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:81
-msgid "Access hardware information"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:83
-msgid "Provide entropy to hardware random number generator"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:85
-msgid "Use hardware-generated random numbers"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:87
-msgid "Access files in your home folder"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:89
-msgid "Access libvirt service"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:91
-msgid "Change system language and region settings"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:93
-msgid "Change location settings and providers"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:95
-msgid "Access your location"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:97
-msgid "Read system and application logs"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:99
-msgid "Access LXD service"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:101
-msgid "access the media-hub service"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:103
-msgid "Use and configure modems"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:105
-msgid "Read system mount information and disk quotas"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:107
-msgid "Control music and video players"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:111
-msgid "Change low-level network settings"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:113
-msgid "Access the NetworkManager service to read and change network settings"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:115
-msgid "Read access to network settings"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:117
-msgid "Change network settings"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:119
-msgid "Read network settings"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:121
-msgid ""
-"Access the ofono service to read and change network settings for mobile "
-"telephony"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:123
-msgid "Control Open vSwitch hardware"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:125
-msgid "Read from CD/DVD"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:127
-msgid "Read, add, change, or remove saved passwords"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:129
-msgid ""
-"Access pppd and ppp devices for configuring Point-to-Point Protocol "
-"connections"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:131
-msgid "Pause or end any process on the system"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:135
-msgid "Access USB hardware directly"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:137
-msgid "Read/write files on removable storage devices"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:139
-msgid "Prevent screen sleep/lock"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:141
-msgid "Access serial port hardware"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:143
-msgid "Restart or power off the device"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:145
-msgid "Install, remove and configure software"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:147
-msgid "Access Storage Framework service"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:149
-msgid "Read process and system information"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:151
-msgid "Monitor and control any running program"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:153
-msgid "Change the date and time"
-msgstr "Arni lapen apor kelar"
-
-#: panels/applications/cc-snap-row.c:155
-msgid "Change time server settings"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:157
-msgid "Change the time zone"
-msgstr "Time zone kelar"
-
-#: panels/applications/cc-snap-row.c:159
-msgid "Access the UDisks2 service for configuring disks and removable media"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:161
-msgid "Read/change shared calendar events in Ubuntu Unity 8"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:163
-msgid "Read/change shared contacts in Ubuntu Unity 8"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:165
-msgid "Access energy usage data"
-msgstr ""
-
-#: panels/applications/cc-snap-row.c:167
-msgid "Read/write access to U2F devices exposed"
-msgstr ""
 
 #: panels/applications/gnome-applications-panel.desktop.in.in:4
 msgid "Control various application permissions and settings"
 msgstr ""
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 
-#: panels/background/cc-background-chooser.c:340
-msgid "Select a picture"
-msgstr "Arjan ingvai"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Stylus"
 
-#: panels/background/cc-background-chooser.c:343
-#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:240
-#: panels/color/cc-color-panel.c:893 panels/color/cc-color-panel.ui:657
-#: panels/common/cc-language-chooser.ui:24
-#: panels/display/cc-display-panel.c:947
-#: panels/info-overview/cc-info-overview-panel.ui:235
-#: panels/network/cc-wifi-hotspot-dialog.ui:122
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:176
-#: panels/network/connection-editor/vpn-helpers.c:299
-#: panels/network/net-device-wifi.c:800 panels/network/net-device-wifi.c:908
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:252
-#: panels/region/cc-format-chooser.ui:28 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:638
-#: panels/sharing/cc-sharing-panel.c:410 panels/usage/cc-usage-panel.c:134
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:107
-#: panels/user-accounts/cc-avatar-chooser.c:235
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:636
-#: panels/user-accounts/cc-user-panel.c:654
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/user-accounts/um-fingerprint-dialog.c:260
-msgid "_Cancel"
-msgstr "_Cancel"
-
-#: panels/background/cc-background-chooser.c:344
-#: panels/network/connection-editor/vpn-helpers.c:177
-#: panels/printers/pp-details-dialog.c:253
-#: panels/sharing/cc-sharing-panel.c:411
-#: panels/user-accounts/cc-avatar-chooser.c:236
-msgid "_Open"
-msgstr "_Open"
-
-#: panels/background/cc-background-item.c:140
-msgid "multiple sizes"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
 msgstr ""
 
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:144
-#, c-format
-msgid "%d × %d"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
 
-#: panels/background/cc-background-item.c:282
-msgid "No Desktop Background"
-msgstr ""
-
-#: panels/background/cc-background-panel.c:115
-msgid "Current background"
-msgstr ""
-
-#: panels/background/cc-background-panel.ui:55
-msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Sai"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Nung-arjan"
 
-#: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
 msgstr ""
 
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Wallpaper;Screen;Desktop;"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "Tablet"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Bluetooth longle"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:69
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth bon-chek"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:80
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:107
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "Airplane Mode dobom"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:118
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Airplane mode do esek Bluetooth damde."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:124
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Airplane Mode pamep-noi"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:154
-msgid "Hardware Airplane Mode is on"
-msgstr ""
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Airplane Mode dobom"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:165
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1714
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -677,30 +330,28 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Bluetooth ingpu si nangli hormu pen pachepho noi"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;"
 
-#: panels/camera/cc-camera-panel.ui:34
-msgid "Camera is turned off"
-msgstr ""
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "Bluetooth bon-chek"
 
-#: panels/camera/cc-camera-panel.ui:43
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr ""
 
-#: panels/camera/cc-camera-panel.ui:77
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 
-#: panels/camera/cc-camera-panel.ui:87
-msgid "Allow the applications below to use your camera."
-msgstr ""
-
-#: panels/camera/cc-camera-panel.ui:107
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr ""
 
@@ -708,623 +359,315 @@ msgstr ""
 msgid "Protect your pictures"
 msgstr "Arjan kerai"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:348
-msgid "Place your calibration device over the square and press “Start”"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:354
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:360
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:366
-msgid "Shut the laptop lid"
-msgstr "Laptop adip dip noi"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:397
-msgid "An internal error occurred that could not be recovered."
-msgstr ""
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:402
-msgid "Tools required for calibration are not installed."
-msgstr ""
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:408
-msgid "The profile could not be generated."
-msgstr ""
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:414
-msgid "The target whitepoint was not obtainable."
-msgstr ""
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:453
-msgid "Complete!"
-msgstr "Tanglo!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:461
-msgid "Calibration failed!"
-msgstr ""
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:468
-msgid "You can remove the calibration device."
-msgstr ""
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:537
-msgid "Do not disturb the calibration device while in progress"
-msgstr ""
-
-#: panels/color/cc-color-calibrate.ui:7
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr ""
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancel"
+
 #. This starts the calibration process
-#: panels/color/cc-color-calibrate.ui:40
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr ""
 
 #. This resumes the calibration process
-#: panels/color/cc-color-calibrate.ui:54
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr ""
 
 #. This button returns the user back to the color control panel
-#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr ""
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Laptop Screen"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Kedun Webcam"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s Monitor"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s Scanner"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s Camera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s Printer"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s Webcam"
-
-#: panels/color/cc-color-device.c:91
-#, c-format
-msgid "Enable color management for %s"
-msgstr ""
-
-#: panels/color/cc-color-device.c:94
-#, c-format
-msgid "Show color profiles for %s"
-msgstr ""
-
-#. not calibrated
-#: panels/color/cc-color-device.c:303
-msgid "Not calibrated"
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:169
-msgid "Default: "
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:177
-msgid "Colorspace: "
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:184
-msgid "Test profile: "
-msgstr ""
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:238
-msgid "Select ICC Profile File"
-msgstr ""
-
-#: panels/color/cc-color-panel.c:241
-msgid "_Import"
-msgstr "_Import"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:252
-msgid "Supported ICC profiles"
-msgstr ""
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:259
-#: panels/network/wireless-security/eap-method-fast.c:356
-msgid "All files"
-msgstr ""
-
-#: panels/color/cc-color-panel.c:554
-msgid "Screen"
-msgstr "Screen"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:846
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Un-eh-det laso file ke upload: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:858
-msgid "The profile has been uploaded to:"
-msgstr ""
-
-#: panels/color/cc-color-panel.c:860
-msgid "Write down this URL."
-msgstr "Laso URL Lo long tok ik vek tha."
-
-#: panels/color/cc-color-panel.c:861
-msgid "Restart this computer and boot your normal operating system."
-msgstr ""
-
-#: panels/color/cc-color-panel.c:862
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:890
-msgid "Save Profile"
-msgstr ""
-
-#: panels/color/cc-color-panel.c:894
-#: panels/network/connection-editor/vpn-helpers.c:300
-msgid "_Save"
-msgstr "_Save"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1208
-msgid "Create a color profile for the selected device"
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1223 panels/color/cc-color-panel.c:1247
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1257
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1268
-msgid "The device type is not currently supported."
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr ""
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Quality"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr ""
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profile amen"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Profile amen:"
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "Profile amen"
-
-#: panels/color/cc-color-panel.ui:392
-msgid "Profile successfully created!"
-msgstr "Profile selam un chit lo!"
-
-#: panels/color/cc-color-panel.ui:443
-msgid "Copy profile"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:456
-msgid "Requires writable media"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr "Internet chepho do nangji"
-
-#: panels/color/cc-color-panel.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:607
-#: panels/user-accounts/um-fingerprint-dialog.c:719
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profile selam un chit lo!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "Profile kimi kethap"
 
-#: panels/color/cc-color-panel.ui:643
-msgid "_Import File…"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:672
-#: panels/network/connection-editor/net-connection-editor.c:513
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/region/cc-input-chooser.ui:20
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr ""
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:790
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 
-#. translators: Text used in link to privacy policy
-#: panels/color/cc-color-panel.ui:812
-#: panels/diagnostics/cc-diagnostics-panel.c:143
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:817
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:865
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
-#: panels/color/cc-color-panel.ui:885
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:880
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:911
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "_Profile kimi kethap"
 
-#: panels/color/cc-color-panel.ui:924
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:928
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:939
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:952
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:988
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1032
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/cc-color-panel.ui:1037
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/cc-color-panel.ui:1042
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: panels/color/cc-color-panel.ui:1047
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Projector"
 
-#: panels/color/cc-color-panel.ui:1052
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plasma"
 
-#: panels/color/cc-color-panel.ui:1057
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL backlight)"
 
-#: panels/color/cc-color-panel.ui:1062
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED backlight)"
 
-#: panels/color/cc-color-panel.ui:1067
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (white LED backlight)"
 
-#: panels/color/cc-color-panel.ui:1072
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Wide gamut LCD (CCFL backlight)"
 
-#: panels/color/cc-color-panel.ui:1077
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Wide gamut LCD (RGB LED backlight)"
 
-#: panels/color/cc-color-panel.ui:1094
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1095
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 minutes"
 
-#: panels/color/cc-color-panel.ui:1099
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1100
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 minutes"
 
-#: panels/color/cc-color-panel.ui:1104
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1105
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 minutes"
 
-#: panels/color/cc-color-panel.ui:1127
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr ""
 
-#: panels/color/cc-color-panel.ui:1131
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Printing and publishing)"
 
-#: panels/color/cc-color-panel.ui:1135
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/cc-color-panel.ui:1139
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Photography and graphics)"
 
-#: panels/color/cc-color-panel.ui:1143
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:100
-msgid "Standard Space"
-msgstr ""
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:106
-msgid "Test Profile"
-msgstr ""
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:114
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr ""
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:124
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr ""
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:129
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr ""
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:136
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr ""
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:153
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Default RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:160
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Default CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:167
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:190
-msgid "Vendor supplied factory calibration data"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:199
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-
-#: panels/color/cc-color-profile.c:221
-msgid "This profile may no longer be accurate"
-msgstr ""
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1335,292 +678,197 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Color;ICC;Profile;Calibrate;Printer;Display;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Kaprek…"
-
-#: panels/common/cc-language-chooser.c:127 panels/region/cc-input-chooser.c:178
-msgid "More…"
-msgstr ""
-
-#: panels/common/cc-language-chooser.c:144
-msgid "No languages found"
-msgstr ""
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
 msgstr ""
 
-#: panels/common/cc-language-chooser.ui:12
+#: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
 msgstr ""
 
-#: panels/common/cc-permission-infobar.ui:20
-msgid "Unlock…"
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
 msgstr ""
 
-#: panels/common/cc-permission-infobar.ui:45
-msgid "Unlock to Change Settings"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
 msgstr ""
 
-#: panels/common/cc-permission-infobar.ui:55
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr ""
 
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:152
-msgid "Today"
-msgstr "Pini"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:154
-msgid "Yesterday"
-msgstr "Tumi"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "Phong"
 
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "Porphai %d"
-msgstr[1] "Porphai jon %d"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: panels/common/cc-util.c:166
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] ""
-msgstr[1] ""
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] ""
-msgstr[1] ""
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:172
-#, c-format
-msgctxt "time"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:177
-#, c-format
-msgctxt "time"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:187
-msgid "0 seconds"
-msgstr "0 seconds"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
-#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
-msgid "Day"
-msgstr "Arni"
-
-#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
-#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
-msgid "Month"
-msgstr "Cheklo"
-
-#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
-#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
-msgid "Year"
-msgstr "Ningkan"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:334
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:339
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:504
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:531
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:538
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:543
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:548
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:26
-msgid "January"
-msgstr "Arkoi"
-
-#: panels/datetime/cc-datetime-panel.ui:29
-msgid "February"
-msgstr "Thangthang"
-
-#: panels/datetime/cc-datetime-panel.ui:32
-msgid "March"
-msgstr "There"
-
-#: panels/datetime/cc-datetime-panel.ui:35
-msgid "April"
-msgstr "Jangmi"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "May"
-msgstr "Aru"
-
-#: panels/datetime/cc-datetime-panel.ui:41
-msgid "June"
-msgstr "Vosik"
-
-#: panels/datetime/cc-datetime-panel.ui:44
-msgid "July"
-msgstr "Jakhong"
-
-#: panels/datetime/cc-datetime-panel.ui:47
-msgid "August"
-msgstr "Paipai"
-
-#: panels/datetime/cc-datetime-panel.ui:50
-msgid "September"
-msgstr "Chiti"
-
-#: panels/datetime/cc-datetime-panel.ui:53
-msgid "October"
-msgstr "Phere"
-
-#: panels/datetime/cc-datetime-panel.ui:56
-msgid "November"
-msgstr "Phaikuni"
-
-#: panels/datetime/cc-datetime-panel.ui:59
-msgid "December"
-msgstr "Matijong"
-
-#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Arni pen Apor"
 
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Ningkan"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Cheklo"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Arkoi"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Thangthang"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "There"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Jangmi"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Aru"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Vosik"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Jakhong"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Paipai"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Chiti"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Phere"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Phaikuni"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Matijong"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Arni"
+
 #: panels/datetime/cc-datetime-panel.ui:113
-#: panels/display/cc-night-light-page.ui:194
-#: panels/display/cc-night-light-page.ui:314
-msgid "Hour"
-msgstr "Porphai"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: panels/datetime/cc-datetime-panel.ui:128
-msgid "∶"
-msgstr "∶"
-
-#: panels/datetime/cc-datetime-panel.ui:152
-#: panels/display/cc-night-light-page.ui:222
-#: panels/display/cc-night-light-page.ui:342
-msgid "Minute"
-msgstr "Minute"
-
-#: panels/datetime/cc-datetime-panel.ui:219
 msgid "Time Zone"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:240
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:313
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:314
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:334
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Arni pen Apor"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:335
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:350
-msgid "Date & _Time"
-msgstr "Arni pen Apor"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:366
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:405
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:414
-msgid "24-hour"
-msgstr "24-Porphai"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:415
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Arni"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 seconds"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calendar"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Lakha"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Arni, apor lapen time zone kelar"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;"
@@ -1633,28 +881,28 @@ msgstr ""
 msgid "To change time or date settings, you need to authenticate."
 msgstr ""
 
-#: panels/default-apps/cc-default-apps-panel.ui:31
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "_Web"
 
-#: panels/default-apps/cc-default-apps-panel.ui:43
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "_Mail"
 
-#: panels/default-apps/cc-default-apps-panel.ui:59
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "_Calendar"
 
-#: panels/default-apps/cc-default-apps-panel.ui:75
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "L_un"
 
-#: panels/default-apps/cc-default-apps-panel.ui:91
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "Lun-Arjan"
 
-#: panels/default-apps/cc-default-apps-panel.ui:162
-#: panels/removable-media/cc-removable-media-panel.ui:162
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "Arjan"
 
@@ -1666,24 +914,15 @@ msgstr ""
 msgid "Configure Default Applications"
 msgstr ""
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "default;application;preferred;media;"
 
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:145
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:30
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
 msgstr ""
 
-#: panels/diagnostics/cc-diagnostics-panel.ui:67
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
 msgid "_Automatic Problem Reporting"
 msgstr ""
 
@@ -1695,309 +934,317 @@ msgstr ""
 msgid "Report your problems"
 msgstr ""
 
-#. FIXME
-#: panels/display/cc-display-panel.c:958
-#: panels/network/connection-editor/connection-editor.ui:27
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr ""
 
-#: panels/display/cc-display-panel.c:979
-msgid "Apply Changes?"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Aphi"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
 msgstr ""
 
-#: panels/display/cc-display-panel.c:984
-msgid "Changes Cannot be Applied"
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
 msgstr ""
 
-#: panels/display/cc-display-panel.c:985
-msgid "This could be due to hardware limitations."
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:91
-msgid "Single Display"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:110
-#: panels/display/cc-display-panel.ui:315
-msgid "Join Displays"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:128
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Mirror"
 
-#: panels/display/cc-display-panel.ui:153
-msgid "Display Mode"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:222
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:223
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:245
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:252
-msgid "Display Arrangement"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:387
-msgid "Active Display"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:434
-msgid "Display Configuration"
-msgstr ""
-
-#: panels/display/cc-display-panel.ui:453
-#: panels/display/gnome-display-panel.desktop.in.in:3
-msgid "Displays"
-msgstr ""
-
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:464
-#: panels/display/cc-night-light-page.ui:111
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Night Light"
 
-#: panels/display/cc-display-settings.c:104
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:107
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr ""
-
-#: panels/display/cc-display-settings.c:187
-#, c-format
-msgid "%.2lf Hz"
-msgstr ""
-
-#: panels/display/cc-display-settings.ui:15
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr ""
 
-#: panels/display/cc-display-settings.ui:24
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr ""
 
-#: panels/display/cc-display-settings.ui:33
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr ""
 
-#: panels/display/cc-display-settings.ui:42
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr ""
 
-#: panels/display/cc-display-settings.ui:59
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr ""
 
-#: panels/display/cc-night-light-page.c:622
-msgid "More Warm"
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
 msgstr ""
 
-#: panels/display/cc-night-light-page.c:634
-msgid "Less Warm"
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
 msgstr ""
 
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:28
-msgid "Restart Filter"
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Night Light"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
 msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:61
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:88
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:127
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:136
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:137
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/region/cc-format-chooser.ui:346
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Phong"
 
-#: panels/display/cc-night-light-page.ui:165
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Pangcheng"
 
-#: panels/display/cc-night-light-page.ui:203
-#: panels/display/cc-night-light-page.ui:323
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Porphai"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minute"
+
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:234
-#: panels/display/cc-night-light-page.ui:354
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "AM"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:250
-#: panels/display/cc-night-light-page.ui:370
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PM"
 
-#: panels/display/cc-night-light-page.ui:284
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr ""
 
-#: panels/display/cc-night-light-page.ui:408
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
 msgstr ""
 
 #: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr ""
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:406
-#: panels/info-overview/cc-info-overview-panel.c:421
-#: panels/info-overview/cc-info-overview-panel.c:433
-#: panels/info-overview/cc-info-overview-panel.c:479
-#: panels/info-overview/cc-info-overview-panel.c:509
-msgid "Unknown"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
 msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:441
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; Build ID: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:456
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:459
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:665
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:669
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:671
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Chinine"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Hormu Men"
 
-#: panels/info-overview/cc-info-overview-panel.ui:54
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Hormu Men"
 
-#: panels/info-overview/cc-info-overview-panel.ui:76
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Hardware Address"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "Memory"
 
-#: panels/info-overview/cc-info-overview-panel.ui:85
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "Processor"
 
-#: panels/info-overview/cc-info-overview-panel.ui:94
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "Graphics"
 
-#: panels/info-overview/cc-info-overview-panel.ui:103
+#: panels/info-overview/cc-info-overview-panel.ui:82
 msgid "Disk Capacity"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:104
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "Lakha bom…"
 
 #. translators: this field contains the distro name and version
-#: panels/info-overview/cc-info-overview-panel.ui:126
+#: panels/info-overview/cc-info-overview-panel.ui:98
 msgid "OS Name"
 msgstr "OS Men"
 
-#: panels/info-overview/cc-info-overview-panel.ui:135
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; Build ID: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "OS Type"
 
-#: panels/info-overview/cc-info-overview-panel.ui:144
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "GNOME Version"
 
-#: panels/info-overview/cc-info-overview-panel.ui:154
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:162
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:171
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Software Updates"
 
-#: panels/info-overview/cc-info-overview-panel.ui:192
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:209
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
 msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:226
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Hormu Men"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "_Rename"
 
@@ -2009,11 +1256,6 @@ msgstr "Aputhak"
 msgid "View information about your system"
 msgstr ""
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2071,7 +1313,7 @@ msgid "Eject"
 msgstr "Patet"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:565
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Tok-bom"
 
@@ -2089,6 +1331,12 @@ msgstr ""
 
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
 msgstr ""
 
 #: panels/keyboard/01-launchers.xml.in:8
@@ -2112,39 +1360,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Kiri"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr ""
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr ""
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr ""
 
@@ -2158,7 +1374,7 @@ msgstr ""
 
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
-msgid "Universal Access"
+msgid "Accessibility"
 msgstr ""
 
 #: panels/keyboard/50-accessibility.xml.in:4
@@ -2193,248 +1409,213 @@ msgstr "Akhor apun pabi"
 msgid "High contrast on or off"
 msgstr ""
 
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:8
-#: panels/keyboard/cc-keyboard-panel.ui:72
-msgid "Alternate Characters Key"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
 msgstr ""
 
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:28
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
 msgstr ""
 
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:45
-msgid "Left Alt"
-msgstr "Ar-vi Alt"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:61
-msgid "Right Alt"
-msgstr "Ar-eh Alt"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:77
-msgid "Left Super"
-msgstr "Ar-vi Super"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:93
-msgid "Right Super"
-msgstr "Ar-eh Super"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:109
-msgid "Menu key"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
 msgstr ""
 
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:125
-msgid "Right Ctrl"
-msgstr "Ar-eh Ctrl"
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "The-bi Options"
 
-#: panels/keyboard/cc-keyboard-manager.c:501
-#: panels/keyboard/cc-keyboard-manager.c:509
-#: panels/keyboard/cc-keyboard-manager.c:809
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Angsong parlu"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Aber pasun"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
 msgstr ""
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: panels/keyboard/cc-keyboard-option.c:337
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
 msgstr ""
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: panels/keyboard/cc-keyboard-option.c:346
-msgid "Compose Key"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-option.c:351
-msgid "Modifiers-only switch to next source"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:94
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ar-eh Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:95
-msgctxt "keyboard key"
-msgid "Menu Key"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:96
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Ar-vi Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:97
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Ar-eh Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:98
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Ar-vi Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:99
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Ar-eh Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:201
-msgid "Reset All Shortcuts?"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:204
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:208
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:346
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-msgid "Cancel"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:209
-msgid "Reset All"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:305
-msgid "Reset the shortcut to its default value"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.ui:73
-msgid "Hold down and type to enter different characters"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.ui:147
-msgid "Reset All…"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.ui:148
-msgid "Reset all shortcuts to their default keybindings"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.ui:177
-msgid "No keyboard shortcut found"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:413
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
-msgid "Set Custom Shortcut"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
-msgid "Set Shortcut"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:592
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:1016
-msgid "Add Custom Shortcut"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:68
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:318
-msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:156
-#: panels/printers/pp-details-dialog.ui:40
-msgid "Name"
-msgstr "Men"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:168
-msgid "Command"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:180
-msgid "Shortcut"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:259
-msgid "Set Shortcut…"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:272
-msgid "None"
-msgstr "Awe"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:303
-msgid "Enter the new shortcut"
-msgstr "Shortcut kimi ketok"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:357
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Pawe"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:367
-msgid "Add"
-msgstr "Kethap"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:382
-msgid "Replace"
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:395
-msgid "Set"
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
 
-#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
-#: panels/region/cc-region-panel.ui:394 shell/cc-window.ui:327
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
 msgstr ""
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Adim"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Thi-hek"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Account thap noi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "Pawe"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Men"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Awe"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
 "Shortcut;Workspace;Window;The-bi;Zoom;Contrast;Input;Source;Lock;Volume;"
 
-#: panels/location/cc-location-panel.ui:31
-msgid "Location services turned off"
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:40
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:74
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-
-#: panels/location/cc-location-panel.ui:83
-msgid ""
+"mobile broadband increases accuracy.\n"
+"\n"
 "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:95
-msgid "Allow the applications below to determine your location."
-msgstr ""
-
-#: panels/location/cc-location-panel.ui:115
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr ""
 
@@ -2442,174 +1623,29 @@ msgstr ""
 msgid "Protect your location information"
 msgstr ""
 
-#. FIXME
-#: panels/lock/cc-lock-panel.ui:29
-msgid ""
-"Automatically locking the screen prevents others from access the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
 
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Blank Screen Delay"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period of inactivity after which the screen will go blank."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:67
-msgid "Automatic Screen _Lock"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:84
-msgid "Automatic _Screen Lock Delay"
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:85
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-
-#: panels/lock/cc-lock-panel.ui:105
-msgid "Show _Notifications on Lock Screen"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:149
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr ""
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:153
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 seconds"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:157
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minute"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:161
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutes"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:165
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutes"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:169
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutes"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:173
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutes"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:177
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "Porphai 1"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:192 panels/power/cc-power-panel.ui:63
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minute"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:196 panels/power/cc-power-panel.ui:67
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutes"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:200 panels/power/cc-power-panel.ui:71
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutes"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:204 panels/power/cc-power-panel.ui:75
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutes"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:208 panels/power/cc-power-panel.ui:79
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutes"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:212 panels/power/cc-power-panel.ui:83
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutes"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:216 panels/power/cc-power-panel.ui:87
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutes"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:220 panels/power/cc-power-panel.ui:91
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12  minutes"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:224 panels/power/cc-power-panel.ui:95
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutes"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:228 panels/power/cc-power-panel.ui:99
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Mentu ta kali"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr ""
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr ""
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:34
-msgid "Microphone is turned off"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
 msgstr "Microphone ingpupe"
 
-#: panels/microphone/cc-microphone-panel.ui:43
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr ""
 
-#: panels/microphone/cc-microphone-panel.ui:77
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
-"properly."
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
 msgstr ""
 
-#: panels/microphone/cc-microphone-panel.ui:87
-msgid "Allow the applications below to use your microphone."
-msgstr ""
-
-#: panels/microphone/cc-microphone-panel.ui:107
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr ""
 
@@ -2617,103 +1653,163 @@ msgstr ""
 msgid "Protect your conversations"
 msgstr ""
 
-#. FIXME
-#: panels/mouse/cc-mouse-panel.ui:37
-msgid "General"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
 msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:75
-msgid "Primary Button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:94
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
-msgid "Left"
-msgstr "Ar-vi"
-
-#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
-msgid "Right"
-msgstr "Ar-eh"
-
-#: panels/mouse/cc-mouse-panel.ui:169
-msgid "Mouse"
-msgstr "Mouse"
-
-#: panels/mouse/cc-mouse-panel.ui:208
-msgid "Mouse Speed"
-msgstr "Mouse kechat"
-
-#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
-msgid "Double-click timeout"
-msgstr ""
-
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
-msgid "Natural Scrolling"
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
-msgid "Scrolling moves the content, not the view."
-msgstr ""
-
-#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
-msgid "Touchpad"
-msgstr "Touchpad"
-
-#: panels/mouse/cc-mouse-panel.ui:501
-msgid "Touchpad Speed"
-msgstr "Touchpad kechat"
-
-#: panels/mouse/cc-mouse-panel.ui:560
-msgid "Tap to Click"
-msgstr "Tap lote Click lo"
-
-#: panels/mouse/cc-mouse-panel.ui:612
-msgid "Two-finger Scrolling"
-msgstr "Hini-Richemun lote Scroll lo"
-
-#: panels/mouse/cc-mouse-panel.ui:665
-msgid "Edge Scrolling"
-msgstr "Angchun Scroll"
-
-#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:436
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr ""
 
-#: panels/mouse/cc-mouse-test.c:132 panels/mouse/cc-mouse-test.ui:25
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Ar-vi"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Ar-eh"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Adim"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Mouse"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "Mouse kechat"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "Touchpad kechat"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "Tap lote Click lo"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Tap lote Click lo"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad kechat"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Angchun Scroll"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Hini-hin"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:137
-msgid "Five clicks, GEGL time!"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:142
-msgid "Double click, primary button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:142
-msgid "Single click, primary button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:145
-msgid "Double click, middle button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:145
-msgid "Single click, middle button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:148
-msgid "Double click, secondary button"
-msgstr ""
-
-#: panels/mouse/cc-mouse-test.c:148
-msgid "Single click, secondary button"
 msgstr ""
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
@@ -2725,1161 +1821,579 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr ""
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 
-#: panels/network/cc-network-panel.c:648 panels/network/cc-wifi-panel.ui:306
-msgid "Oops, something has gone wrong. Please contact your software vendor."
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
 msgstr ""
 
-#: panels/network/cc-network-panel.c:654
-msgid "NetworkManager needs to be running."
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
 msgstr ""
 
-#: panels/network/cc-network-panel.ui:68
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "%s Monitor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr ""
 
-#: panels/network/cc-network-panel.ui:109
-#: panels/network/connection-editor/net-connection-editor.c:596
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr ""
 
-#: panels/network/cc-network-panel.ui:153
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Chepho bomlo"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr ""
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:198
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Chepho"
 
-#: panels/network/cc-wifi-connection-row.c:258
-msgid "Insecure network (WEP)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Secure network (WPA)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:268
-msgid "Secure network (WPA2)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:273
-msgid "Secure network (WPA3)"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.c:278
-msgid "Secure network"
-msgstr ""
-
-#: panels/network/cc-wifi-connection-row.ui:102
-#: panels/network/net-device-ethernet.c:318
-#: panels/network/network-bluetooth.ui:76
-#: panels/network/network-ethernet.ui:102 panels/network/network-mobile.ui:414
-#: panels/network/network-vpn.ui:78
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr ""
 
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:132
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#: panels/network/cc-wifi-hotspot-dialog.c:248
-msgid "Must have a minimum of 8 characters"
-msgstr ""
-
-#: panels/network/cc-wifi-hotspot-dialog.c:458
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
 msgid "Turn On Wi-Fi Hotspot?"
 msgstr "Wi-Fi Hotspot ingpu ji?"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:19
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
 "Wi-Fi hotspot allows others to share your internet connection, by creating a "
 "Wi-Fi network that they can connect to. To do this, you must have an "
 "internet connection through a source other than Wi-Fi."
 msgstr ""
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:44
-#: panels/network/network-wifi.ui:105
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
 msgstr "Network amen"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:69
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:383
-#: panels/printers/pp-jobs-dialog.ui:70
-#: panels/user-accounts/cc-add-user-dialog.ui:249
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Password"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:83
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr ""
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:84
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr ""
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:130
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Ingpu noi"
 
-#: panels/network/cc-wifi-panel.c:276
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:233
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.ui:56
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Airplane Mode"
 
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Wi-Fi, Bluetooth lapen mobile broadband pamep"
 
-#: panels/network/cc-wifi-panel.ui:141
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Wi-Fi Adapter longle"
 
-#: panels/network/cc-wifi-panel.ui:153
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Nangli Wi-Fi adapter thon pame aphi ingpu pen langthu tha"
 
-#: panels/network/cc-wifi-panel.ui:188
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Airplane Mode do-bom"
 
-#: panels/network/cc-wifi-panel.ui:200
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:227
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi Hotspot"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Wi-Fi Hotspot ingpu noi…"
+
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr ""
 
-#: panels/network/cc-wifi-panel.ui:295
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr ""
 
-#: panels/network/connection-editor/8021x-security-page.ui:20
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _Security"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:112
-#: panels/network/connection-editor/ce-page-security.c:404
-#: panels/network/connection-editor/details-page.ui:90
-msgid "Security"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr ""
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:93
-#: panels/network/net-device-wifi.c:235
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:240
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:103
-msgid "WPA3"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:109
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:115
-msgid "Enterprise"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:120
-#: panels/network/net-device-wifi.c:225
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Awe"
-
-#: panels/network/connection-editor/ce-page-details.c:141
-msgid "Never"
-msgstr "Mentu ta nangne"
-
-#: panels/network/connection-editor/ce-page-details.c:156
-#: panels/network/net-device-ethernet.c:108
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "Ni %i aphrang"
 msgstr[1] "Ni jon %i aphrang"
 
-#: panels/network/connection-editor/ce-page-details.c:281
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr ""
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:283
-#: panels/network/net-device-ethernet.c:202
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:300
-msgid "2.4 GHz / 5 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:302
-msgid "2.4 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:304
-msgid "5 GHz"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-details.c:324
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Awe"
-
-#: panels/network/connection-editor/ce-page-details.c:326
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Bi-hek"
-
-#: panels/network/connection-editor/ce-page-details.c:328
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Me-chit"
-
-#: panels/network/connection-editor/ce-page-details.c:330
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Mesen"
-
-#: panels/network/connection-editor/ce-page-details.c:332
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Me-pik"
-
-#: panels/network/connection-editor/ce-page-details.c:390
-#: panels/network/connection-editor/details-page.ui:108
-#: panels/network/net-device-ethernet.c:143
-#: panels/network/net-device-mobile.c:431
-msgid "IPv4 Address"
-msgstr "IPv4 Address"
-
-#: panels/network/connection-editor/ce-page-details.c:391
-#: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-ethernet.c:148
-#: panels/network/net-device-mobile.c:432 panels/network/network-mobile.ui:200
-msgid "IPv6 Address"
-msgstr "IPv6 Address"
-
-#: panels/network/connection-editor/ce-page-details.c:394
-#: panels/network/connection-editor/ce-page-details.c:395
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:435
-#: panels/network/net-device-mobile.c:436 panels/network/network-mobile.ui:183
-msgid "IP Address"
-msgstr "IP Address"
-
-#: panels/network/connection-editor/ce-page-details.c:429
-msgid "Forget Connection"
-msgstr "Chepho thannoi"
-
-#: panels/network/connection-editor/ce-page-details.c:431
-msgid "Remove Connection Profile"
-msgstr "Chepho profile kethan"
-
-#: panels/network/connection-editor/ce-page-details.c:433
-msgid "Remove VPN"
-msgstr "VPN kethan"
-
-#: panels/network/connection-editor/ce-page-details.c:451
-msgid "Details"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:150
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ip4.c:268
-#: panels/network/connection-editor/ce-page-ip6.c:249
-msgid "Delete Address"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ip4.c:428
-#: panels/network/connection-editor/ce-page-ip6.c:398
-msgid "Delete Route"
-msgstr ""
-
-#: panels/network/connection-editor/ce-page-ip4.c:852
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:783
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:260
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Awe"
-
-#: panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit Key (Hex or ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:293
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit Passphrase"
-
-#: panels/network/connection-editor/ce-page-security.c:306
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:319
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamic WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:333
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:347
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:361
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
-
-#: panels/network/connection-editor/details-page.ui:18
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Signal Jakong"
 
-#: panels/network/connection-editor/details-page.ui:54
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:144
-#: panels/network/net-device-ethernet.c:151
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 Address"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 Address"
+
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Hardware Address"
 
-#: panels/network/connection-editor/details-page.ui:162
+#: panels/network/connection-editor/details-page.ui:142
 msgid "Supported Frequencies"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:180
-#: panels/network/net-device-ethernet.c:155
-#: panels/network/network-mobile.ui:217
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:199
-#: panels/network/connection-editor/ip4-page.ui:211
-#: panels/network/connection-editor/ip6-page.ui:225
-#: panels/network/net-device-ethernet.c:157
-#: panels/network/network-mobile.ui:235
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: panels/network/connection-editor/details-page.ui:217
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:376
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "Meth_ang chepho phit noi"
 
-#: panels/network/connection-editor/details-page.ui:395
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Kaprek m_onit/user tum san long"
 
-#: panels/network/connection-editor/details-page.ui:428
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:439
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:25
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Amen"
 
-#: panels/network/connection-editor/ethernet-page.ui:54
-#: panels/network/connection-editor/wifi-page.ui:67
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "_MAC Address"
 
-#: panels/network/connection-editor/ethernet-page.ui:105
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: panels/network/connection-editor/ethernet-page.ui:122
-#: panels/network/connection-editor/wifi-page.ui:102
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:137
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "bytes"
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:72 panels/network/network-proxy.ui:116
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:97
-#: panels/network/connection-editor/ip6-page.ui:111
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
 msgid "Shared to other computers"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:125
-#: panels/network/connection-editor/ip6-page.ui:139
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
-#: panels/printers/pp-details-dialog.ui:95
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Netmask"
 
-#: panels/network/connection-editor/ip4-page.ui:171
-#: panels/network/connection-editor/ip4-page.ui:355
-#: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:369
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Gateway"
 
-#: panels/network/connection-editor/ip4-page.ui:223
-#: panels/network/connection-editor/ip4-page.ui:291
-#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/connection-editor/ip6-page.ui:305
-#: panels/network/net-proxy.c:74 panels/network/network-proxy.ui:106
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:234
-#: panels/network/connection-editor/ip6-page.ui:248
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "Automatic DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:258
-#: panels/network/connection-editor/ip6-page.ui:272
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:279
-#: panels/network/connection-editor/ip6-page.ui:293
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Routes"
 
-#: panels/network/connection-editor/ip4-page.ui:302
-#: panels/network/connection-editor/ip6-page.ui:316
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr ""
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:368
-#: panels/network/connection-editor/ip6-page.ui:382
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metric"
 
-#: panels/network/connection-editor/ip4-page.ui:398
-#: panels/network/connection-editor/ip6-page.ui:412
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr ""
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr ""
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr ""
 
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Prefix"
 
-#: panels/network/connection-editor/net-connection-editor.c:291
-msgid "Unable to open connection editor"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:307
-msgid "New Profile"
-msgstr "Profile kimi"
-
-#: panels/network/connection-editor/net-connection-editor.c:740
-msgid "Import from file…"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:772
-msgid "Add VPN"
-msgstr ""
-
-#: panels/network/connection-editor/security-page.ui:20
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr ""
 
-#: panels/network/connection-editor/vpn-helpers.c:139
-msgid "Cannot import VPN connection"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:141
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:173
-msgid "Select file to import"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:225
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "File amen “%s” dotang do."
-
-#: panels/network/connection-editor/vpn-helpers.c:227
-msgid "_Replace"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:229
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:264
-msgid "Cannot export VPN connection"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:266
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-
-#: panels/network/connection-editor/vpn-helpers.c:296
-msgid "Export VPN connection"
-msgstr ""
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr ""
 
-#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Network"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr ""
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr ""
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:96
-msgid "never"
-msgstr "mentu ta kali"
-
-#: panels/network/net-device-ethernet.c:104
-msgid "today"
-msgstr "pini"
-
-#: panels/network/net-device-ethernet.c:106
-msgid "yesterday"
-msgstr "atumi"
-
-#: panels/network/net-device-ethernet.c:162
-msgid "Last used"
-msgstr ""
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:252
-#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Wired"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:798
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Hotspot pasang si chepho an pen than nangji?"
-
-#: panels/network/net-device-wifi.c:801
-msgid "_Stop Hotspot"
-msgstr "_Hotspot pasang"
-
-#: panels/network/net-device-wifi.c:905
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-
-#: panels/network/net-device-wifi.c:909
-msgid "_Forget"
-msgstr "_Tene-noi"
-
-#: panels/network/net-device-wifi.c:1065 panels/network/net-device-wifi.c:1072
-msgid "Known Wi-Fi Networks"
-msgstr "Wi-Fi Networks chini-tang"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1107
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Tene-noi"
-
-#: panels/network/net-device-wifi.c:1268
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1271
-msgid "Wireless device does not support Hotspot mode"
-msgstr ""
-
-#: panels/network/net-proxy.c:70
-#: panels/notifications/cc-notifications-panel.c:267
-#: panels/power/cc-power-panel.c:2068 panels/power/cc-power-panel.c:2079
-#: panels/universal-access/cc-ua-panel.c:480
-#: panels/universal-access/cc-ua-panel.c:843
-#: panels/universal-access/cc-ua-panel.c:856
-#: panels/universal-access/cc-ua-panel.c:868
-#: panels/universal-access/cc-ua-panel.c:1033
-#: panels/universal-access/cc-ua-panel.ui:323
-#: panels/universal-access/cc-ua-panel.ui:369
-#: panels/universal-access/cc-ua-panel.ui:415
-#: panels/universal-access/cc-ua-panel.ui:521
-#: panels/universal-access/cc-ua-panel.ui:674
-#: panels/universal-access/cc-ua-panel.ui:720
-#: panels/universal-access/cc-ua-panel.ui:766
-#: panels/universal-access/cc-ua-panel.ui:950
-msgid "Off"
-msgstr ""
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:113
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:121
-msgid "This is not recommended for untrusted public networks."
-msgstr ""
-
-#. update title
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/net-vpn.c:66 panels/network/net-vpn.c:163
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#: panels/network/network-bluetooth.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr ""
 
-#: panels/network/network-mobile.ui:29
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Sai"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
-#: panels/network/network-mobile.ui:47
+#: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Provider"
 
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:95
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP Address"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Network Proxy"
 
-#: panels/network/network-proxy.ui:176
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP Proxy"
 
-#: panels/network/network-proxy.ui:195
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "H_TTPS Proxy"
 
-#: panels/network/network-proxy.ui:214
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "_FTP Proxy"
 
-#: panels/network/network-proxy.ui:233
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "_Socks Host"
 
-#: panels/network/network-proxy.ui:252
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr ""
 
-#: panels/network/network-proxy.ui:290
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "HTTP proxy port"
 
-#: panels/network/network-proxy.ui:367
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "HTTPS proxy port"
 
-#: panels/network/network-proxy.ui:388
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "FTP proxy port"
 
-#: panels/network/network-proxy.ui:409
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Socks proxy port"
 
-#: panels/network/network-proxy.ui:438
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "_Configuration URL"
 
-#: panels/network/network-vpn.ui:55
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr ""
 
-#: panels/network/network-wifi.ui:37
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi Hotspot"
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Network amen"
 
-#: panels/network/network-wifi.ui:55
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr ""
-
-#: panels/network/network-wifi.ui:123
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
-msgstr ""
+msgstr "OS type"
 
-#: panels/network/network-wifi.ui:175
-msgctxt "Wi-Fi passkey"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Password"
 
-#: panels/network/network-wifi.ui:264
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Wi-Fi pamep noi"
 
-#: panels/network/network-wifi.ui:296
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr ""
 
-#: panels/network/network-wifi.ui:307
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Wi-Fi Hotspot ingpu noi…"
 
-#: panels/network/network-wifi.ui:318
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Chini-tang Wi-Fi Networks"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Status chinine"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Chepho bomlo"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Howang nangji"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:63
-msgid "Connected"
-msgstr "Chepho"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Chepho un-eh det"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Dail tone awe"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem longle"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr ""
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM Card thon thelang"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM Pin nangji"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM Puk nangji"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252
-msgid "SIM wrong"
-msgstr "SIM chokche"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:351
-msgid "Firmware missing"
-msgstr ""
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:355
-msgid "Cable unplugged"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:195
-msgid "no file selected"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:222
-msgid "unspecified error validating eap-method file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, mate PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:400
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER mate PEM certificates (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:87
-msgid "missing EAP-FAST PAC file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:347
-msgid "Choose a PAC file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:352
-msgid "PAC files (*.pac)"
-msgstr "PAC files (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -3905,74 +2419,53 @@ msgstr ""
 msgid "Both"
 msgstr "Hini-ta"
 
-#: panels/network/wireless-security/eap-method-fast.ui:49
-#: panels/network/wireless-security/eap-method-peap.ui:52
-#: panels/network/wireless-security/eap-method-ttls.ui:51
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
 msgid "Anony_mous identity"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.ui:75
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.ui:115
-#: panels/network/wireless-security/eap-method-peap.ui:150
-#: panels/network/wireless-security/eap-method-ttls.ui:143
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-fast.ui:144
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-leap.c:64
-msgid "missing EAP-LEAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.c:73
-msgid "missing EAP-LEAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.ui:17
-#: panels/network/wireless-security/eap-method-simple.ui:17
-#: panels/network/wireless-security/ws-leap.ui:18
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_Username"
 
-#: panels/network/wireless-security/eap-method-leap.ui:31
-#: panels/network/wireless-security/eap-method-simple.ui:31
-#: panels/network/wireless-security/ws-leap.ui:32
-#: panels/network/wireless-security/ws-wpa-psk.ui:14
-#: panels/sharing/cc-sharing-panel.ui:351
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:385
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Password"
 
-#: panels/network/wireless-security/eap-method-leap.ui:55
-#: panels/network/wireless-security/eap-method-simple.ui:73
-#: panels/network/wireless-security/eap-method-tls.ui:157
-#: panels/network/wireless-security/ws-leap.ui:56
-#: panels/network/wireless-security/ws-wpa-psk.ui:64
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:87
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:96
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:328
-#: panels/network/wireless-security/eap-method-tls.c:507
-#: panels/network/wireless-security/eap-method-ttls.c:336
-msgid "Choose a Certificate Authority certificate"
 msgstr ""
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
@@ -3989,98 +2482,43 @@ msgstr "Version 0"
 msgid "Version 1"
 msgstr "Version 1"
 
-#: panels/network/wireless-security/eap-method-peap.ui:78
-#: panels/network/wireless-security/eap-method-tls.ui:68
-#: panels/network/wireless-security/eap-method-ttls.ui:102
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "C_A certificate"
 
-#: panels/network/wireless-security/eap-method-peap.ui:100
-#: panels/network/wireless-security/eap-method-tls.ui:90
-#: panels/network/wireless-security/eap-method-ttls.ui:125
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr ""
 
-#: panels/network/wireless-security/eap-method-peap.ui:118
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _version"
 
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:91
-msgid "missing EAP-TLS identity"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:101
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:111
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:125
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:135
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:266
-msgid "Unencrypted private keys are insecure"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:269
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:500
-msgid "Choose your personal certificate"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:514
-msgid "Choose your private key"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.ui:17
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "I_dentity"
 
-#: panels/network/wireless-security/eap-method-tls.ui:43
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "_User certificate"
 
-#: panels/network/wireless-security/eap-method-tls.ui:108
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "Private _key"
 
-#: panels/network/wireless-security/eap-method-tls.ui:133
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Private key password"
-
-#: panels/network/wireless-security/eap-method-ttls.c:98
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:106
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4098,20 +2536,20 @@ msgstr "MSCHAPv2 (no EAP)"
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.ui:76
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
 msgid "_Domain"
-msgstr ""
-
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
 msgstr ""
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4133,49 +2571,16 @@ msgstr "Tunneled TLS"
 msgid "Protected EAP (PEAP)"
 msgstr "Protected EAP (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:56
-#: panels/network/wireless-security/ws-wep-key.ui:102
-#: panels/network/wireless-security/ws-wpa-eap.ui:61
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Au_thentication"
 
-#: panels/network/wireless-security/ws-leap.c:65
-msgid "missing leap-username"
-msgstr ""
-
-#: panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Type"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4189,87 +2594,62 @@ msgstr ""
 msgid "Shared Key"
 msgstr "Shared Key"
 
-#: panels/network/wireless-security/ws-wep-key.ui:48
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "_Key"
 
-#: panels/network/wireless-security/ws-wep-key.ui:84
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr ""
 
-#: panels/network/wireless-security/ws-wep-key.ui:134
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr ""
 
-#: panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.ui:42
-msgid "_Type"
-msgstr "_Type"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:60
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr ""
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:112
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr ""
 
-#: panels/notifications/cc-app-notifications-dialog.ui:168
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr ""
 
-#: panels/notifications/cc-app-notifications-dialog.ui:184
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
 msgstr ""
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:249
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr ""
 
-#: panels/notifications/cc-app-notifications-dialog.ui:300
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr ""
 
-#: panels/notifications/cc-app-notifications-dialog.ui:351
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr ""
 
-#: panels/notifications/cc-notifications-panel.c:267
-#: panels/power/cc-power-panel.c:2074 panels/power/cc-power-panel.c:2081
-#: panels/universal-access/cc-ua-panel.c:480
-#: panels/universal-access/cc-ua-panel.c:843
-#: panels/universal-access/cc-ua-panel.c:856
-#: panels/universal-access/cc-ua-panel.c:868
-#: panels/universal-access/cc-ua-panel.c:1033
-msgid "On"
-msgstr ""
-
-#: panels/notifications/cc-notifications-panel.ui:70
+#: panels/notifications/cc-notifications-panel.ui:10
 msgid "_Do Not Disturb"
 msgstr ""
 
-#: panels/notifications/cc-notifications-panel.ui:121
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr ""
 
@@ -4277,34 +2657,32 @@ msgstr ""
 msgid "Control which notifications are displayed and what they show"
 msgstr ""
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifications;Banner;Message;Tray;Popup;"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:150
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Kaprek"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:627
-#, c-format
-msgid "%s Account"
-msgstr "%s Account"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:924
-msgid "Error removing account"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
 msgstr ""
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:991
-#, c-format
-msgid "%s removed"
-msgstr "%s musi-lo"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Au_thentication"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Account thap noi"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4314,10 +2692,6 @@ msgstr "Online Accounts"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4326,375 +2700,179 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:54
-msgid "Undo"
-msgstr ""
-
-#: panels/online-accounts/online-accounts.ui:96
-msgid "Connect to your data in the cloud"
-msgstr ""
-
-#: panels/online-accounts/online-accounts.ui:111
-msgid "No internet connection — connect to set up new online accounts"
-msgstr ""
-
-#: panels/online-accounts/online-accounts.ui:136
-msgid "Add an account"
-msgstr "Account thap noi"
-
-#: panels/online-accounts/online-accounts.ui:243
-msgid "Remove Account"
-msgstr "Account than noi"
-
-#: panels/power/cc-power-panel.c:331
-msgid "Unknown time"
-msgstr "Apor chinine"
-
-#: panels/power/cc-power-panel.c:337
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/power/cc-power-panel.c:349
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "porphai %i"
 msgstr[1] "Jon porphai %i"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-power-panel.c:357
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: panels/power/cc-power-panel.c:358
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "porphai"
 msgstr[1] "jon porphai"
 
-#: panels/power/cc-power-panel.c:359
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:377
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s charge plengji aphan dolang"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:384
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Caution: %s an ved-lo"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:389
-#, c-format
-msgid "%s remaining"
-msgstr "%s an ved-lo"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:394 panels/power/cc-power-panel.c:424
-msgid "Fully charged"
-msgstr "Charge plenglo"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:398 panels/power/cc-power-panel.c:428
-msgid "Not charging"
-msgstr "Che charge-che"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:402 panels/power/cc-power-panel.c:432
-msgid "Empty"
-msgstr "Angse"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:415
-msgid "Charging"
-msgstr "Charge-bom"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:420
-msgid "Discharging"
-msgstr "Charge cherui bom"
-
-#: panels/power/cc-power-panel.c:553
-msgctxt "Battery name"
-msgid "Main"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:555
-msgctxt "Battery name"
-msgid "Extra"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:630
-msgid "Wireless mouse"
-msgstr "Ari-awe mouse"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:633
-msgid "Wireless keyboard"
-msgstr "Ari-awe keyboard"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:636
-msgid "Uninterruptible power supply"
-msgstr "Uninterruptible power supply"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:639
-msgid "Personal digital assistant"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:642
-msgid "Cellphone"
-msgstr "Sepalar"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:645
-msgid "Media player"
-msgstr "Media player"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:648 panels/wacom/cc-wacom-panel.c:809
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:651
-msgid "Computer"
-msgstr "Computer"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:654
-msgid "Gaming input device"
-msgstr ""
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-power-panel.c:657 panels/power/cc-power-panel.c:939
-#: panels/power/cc-power-panel.c:2425
-msgid "Battery"
-msgstr "Battery"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:718
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Charge-bom"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:725
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Chere tha"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:730
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Bihek"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:735
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Mesen"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:740
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Charge pleng-lo"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:744
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Angse"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Batteries"
-msgstr "Batteries"
-
-#: panels/power/cc-power-panel.c:1378
-msgid "When _idle"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1829
-msgid "Power Saving"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1863
-msgid "_Screen Brightness"
-msgstr "_Screen atur"
-
-#: panels/power/cc-power-panel.c:1884
-msgid "Automatic Brightness"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1897
-msgid "_Keyboard Brightness"
-msgstr "_Keyboard atur"
-
-#: panels/power/cc-power-panel.c:1908
-msgid "_Dim Screen When Inactive"
-msgstr "_Jongsi Inactive pu lote screen atur pabi noi"
-
-#: panels/power/cc-power-panel.c:1926
-msgid "_Blank Screen"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1949
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: panels/power/cc-power-panel.c:1950
-msgid "Wi-Fi can be turned off to save power."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1966
-msgid "_Mobile Broadband"
-msgstr "_Mobile Broadband"
-
-#: panels/power/cc-power-panel.c:1967
-msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2017
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: panels/power/cc-power-panel.c:2018
-msgid "Bluetooth can be turned off to save power."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2070
-msgid "When on battery power"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2072
-msgid "When plugged in"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2166
-msgid "Suspend"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2167
-msgid "Power Off"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2168
-msgid "Hibernate"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2169
-msgid "Nothing"
-msgstr ""
-
-#. Frame header
-#: panels/power/cc-power-panel.c:2269
-msgid "Suspend & Power Button"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2310
-msgid "_Automatic Suspend"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2311
-msgid "Automatic suspend"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2369
-msgid "Po_wer Button Action"
-msgstr ""
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "15 minutes"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "20 minutes"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "25 minutes"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 minutes"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 minutes"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "Porphai 1"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 minutes"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 minutes"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 minutes"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "Porphai 2"
 
-#: panels/power/cc-power-panel.ui:147
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Battery"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "_Screen atur"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Screen"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Screen"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Automatic DNS"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:172
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:188
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:233 panels/power/cc-power-panel.ui:293
-#: panels/universal-access/cc-ua-panel.ui:1527
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr ""
 
@@ -4706,49 +2884,13 @@ msgstr ""
 msgid "View your battery status and change power saving settings"
 msgstr ""
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "Authenticate"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/new-printer-dialog.ui:362
-#: panels/printers/pp-jobs-dialog.ui:57
-msgid "Username"
-msgstr "Username"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:337
-msgid "Authentication Required"
-msgstr "Howang nangji"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:699
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Printer “%s” than ed-lo"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:922
-msgid "Failed to add new printer."
-msgstr "Printer kimi thon un-eh det."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1216
-#, c-format
-msgid "Could not load ui: %s"
-msgstr ""
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4758,917 +2900,341 @@ msgstr "Printers"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
 
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:363
-#: panels/printers/pp-new-printer-dialog.c:427
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Printer kimi kethon"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr ""
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr ""
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr ""
 
-#: panels/printers/new-printer-dialog.ui:353
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Howang nangji"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:75
-#: panels/printers/pp-details-dialog.c:370
-#, c-format
-msgid "%s Details"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Username"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
 
-#: panels/printers/pp-details-dialog.c:122
-msgid "No suitable driver found"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.c:249
-msgid "Select PPD File"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.c:258
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-
-#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Adim"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:122
-#: panels/printers/pp-ppd-selection-dialog.c:250
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Driver"
 
-#: panels/printers/pp-details-dialog.ui:162
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr ""
 
-#: panels/printers/pp-details-dialog.ui:183
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Drivers kiri"
 
-#: panels/printers/pp-details-dialog.ui:192
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr ""
 
-#: panels/printers/pp-details-dialog.ui:201
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr ""
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr ""
 
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:109
-msgid "Select"
-msgstr "Chongvai"
-
-#: panels/printers/ppd-selection-dialog.ui:73
+#: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr ""
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:479
-msgid "JetDirect Printer"
-msgstr "JetDirect Printer"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:714
-msgid "LPD Printer"
-msgstr "LPD Printer"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:65
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "I-hin anchot"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:67
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
 msgstr ""
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:69
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr ""
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Chongvai"
 
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:71
-msgid "Portrait"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:73
-msgid "Landscape"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:75
-msgid "Reverse landscape"
-msgstr ""
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:77
-msgid "Reverse portrait"
-msgstr ""
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-jobs-dialog.c:222
-msgctxt "print job"
-msgid "Pending"
-msgstr ""
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-jobs-dialog.c:228
-msgctxt "print job"
-msgid "Paused"
-msgstr ""
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-jobs-dialog.c:233
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Howang nangji"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-jobs-dialog.c:238
-msgctxt "print job"
-msgid "Processing"
-msgstr "Klem bomlo"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-jobs-dialog.c:242
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Sang-kok"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-jobs-dialog.c:246
-msgctxt "print job"
-msgid "Canceled"
-msgstr ""
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-jobs-dialog.c:250
-msgctxt "print job"
-msgid "Aborted"
-msgstr ""
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-jobs-dialog.c:254
-msgctxt "print job"
-msgid "Completed"
-msgstr "Tang ed-lo"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:363
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:520
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr ""
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:524
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr ""
-
 #. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/pp-jobs-dialog.ui:44
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
 msgid "Domain"
 msgstr "Domain"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:129
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr ""
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:169
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr ""
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:232
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr ""
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:358
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr ""
 
-#: panels/printers/pp-new-printer-dialog.c:380
-msgid "Unlock Print Server"
-msgstr ""
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:384
-#, c-format
-msgid "Unlock %s."
-msgstr ""
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:388
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-
-#: panels/printers/pp-new-printer-dialog.c:838
-msgid "Searching for Printers"
-msgstr ""
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1697
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1702
-msgid "Serial Port"
-msgstr "Serial Port"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1709
-msgid "Parallel Port"
-msgstr "Parallel Port"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1751
-#, c-format
-msgid "Location: %s"
-msgstr ""
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1756
-#, c-format
-msgid "Address: %s"
-msgstr ""
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1783
-msgid "Server requires authentication"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:91
-msgid "Two Sided"
-msgstr "Hini-hin"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "Paper Type"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:93
-msgid "Paper Source"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:94
-msgid "Output Tray"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:95
-msgctxt "printing option"
-msgid "Resolution"
-msgstr ""
-
-#: panels/printers/pp-options-dialog.c:96
-msgid "GhostScript pre-filtering"
-msgstr ""
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:534
-msgid "Pages per side"
-msgstr ""
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:546
-msgid "Two-sided"
-msgstr "Hini-hin"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:558
-msgid "Orientation"
-msgstr ""
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr ""
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr ""
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr ""
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr ""
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr ""
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Alir"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr ""
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:676
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr ""
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:869
-#: panels/printers/pp-options-dialog.ui:18
+#: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Sat-lang alo"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:882
-msgid "Test page"
-msgstr "Sat-lang alo"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr ""
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr ""
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr ""
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "Bonda-atum"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:594 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr ""
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:599
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u sai klembom"
 msgstr[1] "Son %u sai klembom"
 
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:745
-msgid "Low on toner"
-msgstr "Toner bet-so vedlo"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:747
-msgid "Out of toner"
-msgstr "TOner angse lo"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:750
-msgid "Low on developer"
-msgstr ""
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:753
-msgid "Out of developer"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:755
-msgid "Low on a marker supply"
-msgstr ""
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:757
-msgid "Out of a marker supply"
-msgstr ""
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:759
-msgid "Open cover"
-msgstr ""
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:761
-msgid "Open door"
-msgstr ""
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:763
-msgid "Low on paper"
-msgstr "Lo achet bet-so lo"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:765
-msgid "Out of paper"
-msgstr "Lo ik lo"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:767
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Offline"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:769
-#: panels/printers/pp-printer-entry.c:897
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Sang-kok"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:771
-msgid "Waste receptacle almost full"
-msgstr ""
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:773
-msgid "Waste receptacle full"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:775
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:777
-msgid "The optical photo conductor is no longer functioning"
-msgstr ""
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:883
-msgctxt "printer state"
-msgid "Ready"
-msgstr ""
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:888
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr ""
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:893
-msgctxt "printer state"
-msgid "Processing"
-msgstr ""
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:917
-msgid "Clean print heads"
-msgstr ""
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr ""
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr ""
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr ""
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr ""
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Printer ke-hek"
 
-#: panels/printers/printer-entry.ui:193
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr ""
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:312
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr ""
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:319
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr ""
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:8
-msgid "Add…"
-msgstr "Akimi kethon…"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Printer thontha…"
 
-#: panels/printers/printers.ui:174
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Printer thontha…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Printers awe"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:188
-msgid "Add a Printer…"
-msgstr "Printer thontha…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:220
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 
-#: panels/region/cc-format-chooser.c:148
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-chooser.c:150
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metric"
-
-#: panels/region/cc-format-chooser.c:255 panels/region/cc-format-chooser.c:296
-#: panels/region/cc-format-chooser.ui:6
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formats"
 
-#: panels/region/cc-format-chooser.ui:48 panels/wacom/wacom-stylus-page.ui:37
-#: shell/cc-window.ui:232
-msgid "Back"
-msgstr "Aphi"
-
-#: panels/region/cc-format-chooser.ui:103
-msgid ""
-"Choose the format for numbers, dates and currencies. Changes take effect on "
-"next login."
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:119
-msgid "Search locales..."
-msgstr ""
-
-#: panels/region/cc-format-chooser.ui:160
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Common Formats"
 
-#: panels/region/cc-format-chooser.ui:191
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Kado-kawe Formats"
 
-#: panels/region/cc-format-chooser.ui:244
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:257
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:309
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr ""
 
-#: panels/region/cc-format-chooser.ui:324
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Arni"
 
-#: panels/region/cc-format-chooser.ui:368
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "Arni pen Apor"
 
-#: panels/region/cc-format-chooser.ui:390
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Lakha"
 
-#: panels/region/cc-format-chooser.ui:412
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Pun"
 
-#: panels/region/cc-format-chooser.ui:434
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Lo"
 
-#: panels/region/cc-input-chooser.c:193
-msgid "No input sources found"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
 msgstr ""
 
-#: panels/region/cc-input-chooser.c:948
-msgctxt "Input Source"
-msgid "Other"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
 msgstr ""
 
-#: panels/region/cc-input-chooser.ui:5
-msgid "Add an Input Source"
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
 msgstr ""
 
-#: panels/region/cc-input-chooser.ui:77
-msgid "Input methods can’t be used on the login screen"
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
 msgstr ""
 
-#: panels/region/cc-region-panel.c:1507
-msgid "Login _Screen"
-msgstr ""
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Nangli account"
 
-#: panels/region/cc-region-panel.ui:64
-#: panels/user-accounts/cc-user-panel.ui:313
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Lam"
 
-#: panels/region/cc-region-panel.ui:99
-msgid "Restart the session for changes to take effect"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:114
-msgid "Restart…"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:147
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formats"
 
-#: panels/region/cc-region-panel.ui:195
-msgid "Input Sources"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:209
-msgid "Choose keyboard layouts or input methods."
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:266
-msgid "No input source selected"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:300
-msgid "Login settings are used by all users when logging into the system"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:337
-msgid "Input Source Options"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:352
-msgid "Use the _same source for all windows"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:370
-msgid "Allow _different sources for each window"
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:412
-msgid "Previous source"
-msgstr "Aphrang source"
-
-#: panels/region/cc-region-panel.ui:430
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
-
-#: panels/region/cc-region-panel.ui:445
-msgid "Next source"
-msgstr "Adun source"
-
-#: panels/region/cc-region-panel.ui:463
-msgid "Super+Space"
-msgstr "Super+Space"
-
-#: panels/region/cc-region-panel.ui:478
-msgid "Left+Right Alt"
-msgstr "Left+Right Alt"
-
-#: panels/region/cc-region-panel.ui:494
-msgid "These keyboard shortcuts can be changed in the keyboard settings"
-msgstr ""
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Laptop Screen"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Dang lapen Lam"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+msgid "Select your display language and formats"
 msgstr ""
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.c:267
-msgid "Ask what to do"
-msgstr "Arju ver noi"
-
-#: panels/removable-media/cc-removable-media-panel.c:271
-msgid "Do nothing"
-msgstr "Jat-ta klem nangne"
-
-#: panels/removable-media/cc-removable-media-panel.c:275
-msgid "Open folder"
-msgstr "Folder ingpu noi"
-
-#: panels/removable-media/cc-removable-media-panel.c:341
-msgid "Other Media"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:362
-msgid "Select an application for audio CDs"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:363
-msgid "Select an application for video DVDs"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:364
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:365
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-
-#: panels/removable-media/cc-removable-media-panel.c:366
-msgid "Select an application for software CDs"
-msgstr ""
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "audio DVD"
-msgstr "audio DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "blank Blu-ray disc"
-msgstr "blank Blu-ray disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:380
-msgid "blank CD disc"
-msgstr "blank CD disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:381
-msgid "blank DVD disc"
-msgstr "blank DVD disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:382
-msgid "blank HD DVD disc"
-msgstr "blank HD DVD disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:383
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:384
-msgid "e-book reader"
-msgstr "e-book reader"
-
-#: panels/removable-media/cc-removable-media-panel.c:385
-msgid "HD DVD video disc"
-msgstr "HD DVD video disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:386
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:387
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:388
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:389
-msgid "Windows software"
-msgstr "Windows software"
-
-#: panels/removable-media/cc-removable-media-panel.ui:44
+#: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.ui:75
+#: panels/removable-media/cc-removable-media-panel.ui:52
 msgid "CD _audio"
 msgstr "CD _audio"
 
-#: panels/removable-media/cc-removable-media-panel.ui:92
+#: panels/removable-media/cc-removable-media-panel.ui:67
 msgid "_DVD video"
 msgstr "_DVD video"
 
-#: panels/removable-media/cc-removable-media-panel.ui:133
+#: panels/removable-media/cc-removable-media-panel.ui:102
 msgid "_Music player"
 msgstr "_Music player"
 
-#: panels/removable-media/cc-removable-media-panel.ui:191
+#: panels/removable-media/cc-removable-media-panel.ui:152
 msgid "_Software"
 msgstr "_Software"
 
-#: panels/removable-media/cc-removable-media-panel.ui:229
+#: panels/removable-media/cc-removable-media-panel.ui:178
 msgid "_Other Media…"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.ui:288
+#: panels/removable-media/cc-removable-media-panel.ui:195
 msgid "_Never prompt or start programs on media insertion"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.ui:342
+#: panels/removable-media/cc-removable-media-panel.ui:225
 msgid "Select how other media should be handled"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.ui:389
+#: panels/removable-media/cc-removable-media-panel.ui:259
 msgid "_Action:"
 msgstr ""
 
-#: panels/removable-media/cc-removable-media-panel.ui:412
+#: panels/removable-media/cc-removable-media-panel.ui:278
 msgid "_Type:"
 msgstr ""
 
@@ -5680,7 +3246,6 @@ msgstr ""
 msgid "Configure Removable Media settings"
 msgstr ""
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5689,55 +3254,124 @@ msgstr ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;"
 
-#: panels/search/cc-search-locations-dialog.c:635
-msgid "Select Location"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:639
-msgid "_OK"
-msgstr "_Chok"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
 
-#: panels/search/cc-search-locations-dialog.ui:9
-#: panels/search/cc-search-panel.ui:61
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Privacy"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Screen"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Account Settings"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.ui:32
-#: panels/search/cc-search-locations-dialog.ui:69
-#: panels/search/cc-search-locations-dialog.ui:107
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.ui:52
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.ui:91
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.ui:156
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Kaprek"
 
-#: panels/search/cc-search-panel.c:152
-msgid "No applications found"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Adim"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
 msgstr ""
 
-#: panels/search/cc-search-panel-row.ui:92
-msgid "Move Up"
-msgstr "Angsong parlu"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: panels/search/cc-search-panel-row.ui:102
-msgid "Move Down"
-msgstr "Aber pasun"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: panels/search/cc-search-panel.ui:33
-msgid ""
-"Control which search results are shown in the Activities Overview. The order "
-"of search results can also be changed by moving rows in the list."
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Kiri"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
 msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
@@ -5745,155 +3379,134 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Search;Find;Index;Hide;Privacy;Results;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:307
-msgid "No networks selected for sharing"
-msgstr ""
-
-#: panels/sharing/cc-sharing-networks.ui:19
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Networks"
 
-#: panels/sharing/cc-sharing-panel.c:302
-msgctxt "service is enabled"
-msgid "On"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:304 panels/sharing/cc-sharing-panel.c:331
-msgctxt "service is disabled"
-msgid "Off"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:334
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:337
-msgctxt "service is active"
-msgid "Active"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:407
-msgid "Choose a Folder"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:711
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:717
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-
-#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:723
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to %s"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:828
-msgid "Copy"
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.c:1279
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:34
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr "_Computer Amen"
 
-#: panels/sharing/cc-sharing-panel.ui:94
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:139
-msgid "_Screen Sharing"
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:184
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:229
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:268
-msgid "Some services are disabled because of no network access."
-msgstr ""
-
-#: panels/sharing/cc-sharing-panel.ui:286
-#: panels/sharing/cc-sharing-panel.ui:413
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:333
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr "_Password nangji"
 
-#: panels/sharing/cc-sharing-panel.ui:424
-#: panels/sharing/cc-sharing-panel.ui:494
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:517
-#: panels/sharing/cc-sharing-panel.ui:763
-msgid "Screen Sharing"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:575
-msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:620
-msgid "_Password:"
-msgstr "_Password:"
-
-#: panels/sharing/cc-sharing-panel.ui:650
-msgid "_Show Password"
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:681
-msgid "Access Options"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Chepho profile kethan"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:695
-msgid "_New connections must ask for access"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Chephophe"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:713
-msgid "_Require a password"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:774
-#: panels/sharing/cc-sharing-panel.ui:868
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Au_thentication"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Username"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:807
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:822
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Folders"
 
@@ -5901,7 +3514,6 @@ msgstr "Folders"
 msgid "Control what you want to share with others"
 msgstr ""
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -5918,99 +3530,94 @@ msgstr ""
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 
-#: panels/sound/cc-alert-chooser.c:151
-msgid "Custom"
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
 msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:12 panels/sound/cc-alert-selector.ui:9
-msgid "Bark"
-msgstr "Kang-uk"
-
-#: panels/sound/cc-alert-chooser.ui:19 panels/sound/cc-alert-selector.ui:15
-msgid "Drip"
-msgstr "Charchim"
-
-#: panels/sound/cc-alert-chooser.ui:26 panels/sound/cc-alert-selector.ui:21
-msgid "Glass"
-msgstr "Bilor"
-
-#: panels/sound/cc-alert-chooser.ui:33 panels/sound/cc-alert-selector.ui:27
-msgid "Sonar"
-msgstr "Sonar"
-
-#: panels/sound/cc-fade-slider.ui:13
-msgid "Rear"
-msgstr "Aphi"
-
-#: panels/sound/cc-fade-slider.ui:15
-msgid "Front"
-msgstr "Ang-no"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
 msgstr ""
 
-#: panels/sound/cc-output-test-dialog.ui:127
-msgid "Click a speaker to test"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
 
-#: panels/sound/cc-sound-panel.ui:29
-msgid "System Volume"
-msgstr "System ase"
-
-#: panels/sound/cc-sound-panel.ui:45
-msgid "Volume Levels"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
 msgstr ""
 
-#: panels/sound/cc-sound-panel.ui:67
-msgid "Output"
-msgstr ""
-
-#: panels/sound/cc-sound-panel.ui:94
-msgid "Output Device"
-msgstr ""
-
-#: panels/sound/cc-sound-panel.ui:117
-msgid "Test"
-msgstr "Ase-kelang"
-
-#: panels/sound/cc-sound-panel.ui:148 panels/sound/cc-sound-panel.ui:325
-msgid "Configuration"
-msgstr ""
-
-#: panels/sound/cc-sound-panel.ui:181
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 msgid "Balance"
 msgstr "Balance"
 
-#: panels/sound/cc-sound-panel.ui:208
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 msgid "Fade"
 msgstr "Fade"
 
-#: panels/sound/cc-sound-panel.ui:235
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Aphi"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Ang-no"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "System ase"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "System ase"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Ase-kelang"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
-#: panels/sound/cc-sound-panel.ui:257
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr ""
 
-#: panels/sound/cc-sound-panel.ui:284
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr ""
 
-#: panels/sound/cc-sound-panel.ui:358
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Seh"
 
-#: panels/sound/cc-sound-panel.ui:380
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:115
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6020,166 +3627,67 @@ msgstr "Seh"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Chinine"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr "Hovang adim:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-msgid "Connected at:"
-msgstr "Chepho adim:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-msgid "Enrolled at:"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-msgid "Failed to authorize device: "
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-msgid "Failed to forget device: "
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Au_thentication"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Amen:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Status:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:175
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:468
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:512
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:516
-msgid "Thunderbolt security level could not be determined."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:621
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+#, fuzzy
+msgid "No Thunderbolt Support"
 msgstr "Thunderbolt support pe"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:246
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr ""
 
@@ -6191,714 +3699,539 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr ""
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
-msgid "Thunderbolt;"
+#, fuzzy
+msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:500
-msgctxt "cursor size"
-msgid "Default"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.c:503
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Achetim"
-
-#: panels/universal-access/cc-ua-panel.c:506
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Kethe"
-
-#: panels/universal-access/cc-ua-panel.c:509
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Kethe-dun"
-
-#: panels/universal-access/cc-ua-panel.c:512
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Kethe-nei"
-
-#: panels/universal-access/cc-ua-panel.c:516
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] ""
-msgstr[1] ""
-
-#: panels/universal-access/cc-ua-panel.ui:78
-msgid "_Always Show Universal Access Menu"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:120
-msgid "Seeing"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:166
-msgid "_High Contrast"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:213
-msgid "_Large Text"
-msgstr "_Amek-akhor kethe"
-
-#: panels/universal-access/cc-ua-panel.ui:258
-msgid "C_ursor Size"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:305
-#: panels/universal-access/zoom-options.ui:99
-msgid "_Zoom"
-msgstr "_Pathe-bi"
-
-#: panels/universal-access/cc-ua-panel.ui:351
-msgid "Screen _Reader"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:397
-#: panels/universal-access/cc-ua-panel.ui:1263
-msgid "_Sound Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:459
-msgid "Hearing"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:503
-#: panels/universal-access/cc-ua-panel.ui:1366
-msgid "_Visual Alerts"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:611
-msgid "Screen _Keyboard"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:656
-msgid "R_epeat Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:702
-msgid "Cursor _Blinking"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:748
-msgid "_Typing Assist (AccessX)"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:809
-msgid "Pointing & Clicking"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:855
-msgid "_Mouse Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:900
-msgid "_Locate Pointer"
-msgstr "Printer ke-ri"
-
-#: panels/universal-access/cc-ua-panel.ui:932
-msgid "_Click Assist"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:978
-msgid "_Double-Click Delay"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:998
-msgid "Double-Click Delay"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1068
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:1095
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:1131
-msgid "Screen Reader"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1148
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1181
-msgid "_Screen Reader"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1220
-msgid "Sound Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1238
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1308
-msgid "Visual Alerts"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1312
-msgid "_Test flash"
-msgstr "_Flash kelang"
-
-#: panels/universal-access/cc-ua-panel.ui:1341
-msgid "Use a visual indication when an alert sound occurs."
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1392
-msgid "Flash the entire _window"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1410
-msgid "Flash the entire _screen"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1455
-msgid "Repeat Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1485
-msgid "Key presses repeat when key is held down."
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1565
-msgid "Repeat keys delay"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1613
-#: panels/universal-access/cc-ua-panel.ui:1748
-msgid "Speed"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1652
-msgid "Repeat keys speed"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1676
-msgid "Cursor Blinking"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1706
-msgid "Cursor blinks in text fields."
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1785
-msgid "Cursor blinking speed"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1821
-msgid "Typing Assist"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1860
-msgid "_Sticky Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1877
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1901
-msgid "_Disable if two keys are pressed together"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1919
-msgid "Beep when a _modifier key is pressed"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1967
-msgid "S_low Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:1984
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2017
-#: panels/universal-access/cc-ua-panel.ui:2230
-#: panels/universal-access/cc-ua-panel.ui:2567
-msgid "A_cceptance delay:"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2039
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Thi-hek"
-
-#: panels/universal-access/cc-ua-panel.ui:2058
-msgid "Slow keys typing delay"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2073
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Ding-hoi"
-
-#: panels/universal-access/cc-ua-panel.ui:2100
-msgid "Beep when a key is pr_essed"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2117
-msgid "Beep when a key is _accepted"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2134
-#: panels/universal-access/cc-ua-panel.ui:2313
-msgid "Beep when a key is _rejected"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2180
-msgid "_Bounce Keys"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2197
-msgid "Ignores fast duplicate keypresses"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2252
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Thi-hek"
-
-#: panels/universal-access/cc-ua-panel.ui:2271
-msgid "Bounce keys typing delay"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2286
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Ding-hoi"
-
-#: panels/universal-access/cc-ua-panel.ui:2399
-msgid "_Enable by Keyboard"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2416
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr ""
-
-#: panels/universal-access/cc-ua-panel.ui:2480
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2516
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2534
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2588
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Thi-hek"
 
-#: panels/universal-access/cc-ua-panel.ui:2607
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2622
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Ding-hoi"
 
-#: panels/universal-access/cc-ua-panel.ui:2679
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2697
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2730
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2752
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Thi-hek"
 
-#: panels/universal-access/cc-ua-panel.ui:2783
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Ding-hoi"
 
-#: panels/universal-access/cc-ua-panel.ui:2819
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:2841
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Bi-hek"
 
-#: panels/universal-access/cc-ua-panel.ui:2872
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "The-dung"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Thi-hek"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Ding-hoi"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Thi-hek"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Ding-hoi"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Amek-akhor kethe"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Pathe-bi"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Printer ke-ri"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Flash kelang"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "The-bi Options"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Magnifier"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Crosshairs:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Kangtheng:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Ingteng"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "A_lir:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Alir Effects:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "A_lir"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Kom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Do-pik"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Kom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Do-pik"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Alir Effects"
 
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
 msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
 
-#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
-"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
-"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
 "Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
 "big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
 "click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
 
-#: panels/universal-access/zoom-options.c:305
-msgctxt "Distance"
-msgid "Short"
-msgstr "Thi-hek"
-
-#: panels/universal-access/zoom-options.c:306
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr ""
-
-#: panels/universal-access/zoom-options.c:307
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr ""
-
-#: panels/universal-access/zoom-options.c:308
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr ""
-
-#: panels/universal-access/zoom-options.c:309
-msgctxt "Distance"
-msgid "Long"
-msgstr "Ding-hoi"
-
-#: panels/universal-access/zoom-options.ui:48
-msgid "Full Screen"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:53
-msgid "Top Half"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:58
-msgid "Bottom Half"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:63
-msgid "Left Half"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:68
-msgid "Right Half"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:78
-msgid "Zoom Options"
-msgstr "The-bi Options"
-
-#: panels/universal-access/zoom-options.ui:185
-msgid "_Magnification:"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:249
-msgid "_Follow mouse cursor"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:269
-msgid "_Screen part:"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:331
-msgid "Magnifier _extends outside of screen"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:350
-msgid "_Keep magnifier cursor centered"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:370
-msgid "Magnifier cursor _pushes contents around"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:390
-msgid "Magnifier cursor moves with _contents"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:425
-msgid "Magnifier Position:"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:446
-msgid "Magnifier"
-msgstr "Magnifier"
-
-#: panels/universal-access/zoom-options.ui:493
-msgid "_Thickness:"
-msgstr "_Kangtheng:"
-
-#: panels/universal-access/zoom-options.ui:519
-msgctxt "universal access, thickness"
-msgid "Thin"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:551
-msgctxt "universal access, thickness"
-msgid "Thick"
-msgstr "Ingteng"
-
-#: panels/universal-access/zoom-options.ui:577
-msgid "_Length:"
-msgstr ""
-
-#. The color of the accessibility crosshair
-#: panels/universal-access/zoom-options.ui:626
-msgid "Co_lor:"
-msgstr "A_lir:"
-
-#: panels/universal-access/zoom-options.ui:690
-msgid "_Crosshairs:"
-msgstr "_Crosshairs:"
-
-#: panels/universal-access/zoom-options.ui:738
-msgid "_Overlaps mouse cursor"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:776
-msgid "Crosshairs"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:825
-msgid "_White on black:"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:845
-msgid "_Brightness:"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:866
-msgid "_Contrast:"
-msgstr "_Contrast:"
-
-#. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/zoom-options.ui:886
-msgctxt "universal access, contrast"
-msgid "Co_lor"
-msgstr "A_lir"
-
-#: panels/universal-access/zoom-options.ui:911
-msgctxt "universal access, color"
-msgid "None"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:943
-msgctxt "universal access, color"
-msgid "Full"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:1006
-msgctxt "universal access, brightness"
-msgid "Low"
-msgstr "Kom"
-
-#: panels/universal-access/zoom-options.ui:1039
-msgctxt "universal access, brightness"
-msgid "High"
-msgstr "Do-pik"
-
-#: panels/universal-access/zoom-options.ui:1070
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "Kom"
-
-#: panels/universal-access/zoom-options.ui:1103
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "Do-pik"
-
-#: panels/universal-access/zoom-options.ui:1139
-msgid "Color Effects:"
-msgstr "Alir Effects:"
-
-#: panels/universal-access/zoom-options.ui:1164
-msgid "Color Effects"
-msgstr "Alir Effects"
-
-#: panels/usage/cc-usage-panel.c:155
-msgid "Empty all items from Trash?"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:156
-msgid "All items in the Trash will be permanently deleted."
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:157
-msgid "_Empty Trash"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:178
-msgid "Delete all the temporary files?"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:179
-msgid "All the temporary files will be permanently deleted."
-msgstr ""
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "_Purge Temporary Files"
-msgstr ""
-
-#: panels/usage/cc-usage-panel.ui:31
+#: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
 msgstr "File History"
 
-#: panels/usage/cc-usage-panel.ui:43
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
 "File history keeps a record of files that you have used. This information is "
 "shared between applications, and makes it easier to find files that you "
 "might want to use."
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:58
+#: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
 msgstr "File H_istory"
 
-#: panels/usage/cc-usage-panel.ui:80
+#: panels/usage/cc-usage-panel.ui:25
 msgid "File _History Duration"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:121
+#: panels/usage/cc-usage-panel.ui:48
 msgid "_Clear History…"
 msgstr "_History Musi"
 
-#: panels/usage/cc-usage-panel.ui:137
-msgid "Trash & Temporary Files"
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:147
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:161
+#: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:176
+#: panels/usage/cc-usage-panel.ui:79
 msgid "Automatically Delete Temporary _Files"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:198
+#: panels/usage/cc-usage-panel.ui:91
 msgid "Automatically Delete _Period"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:240
+#: panels/usage/cc-usage-panel.ui:115
 msgid "_Empty Trash…"
 msgstr ""
 
-#: panels/usage/cc-usage-panel.ui:252
+#: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
 msgstr ""
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:280
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "Porphai 1"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:284
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "Ni 1"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:288
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "Ni 2"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:292
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "Ni 3"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:296
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "Ni 4"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:300
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "Ni 5"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:304
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "Ni 6"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:308
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "Ni 7"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:312
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "Ni 14"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:316
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "Ni 30"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:331
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "Ni 1"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:335
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "Ni 7"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:339
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "Ni 30"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:343
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Kaike"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
@@ -6908,512 +4241,286 @@ msgstr ""
 msgid "Don't leave traces"
 msgstr ""
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "Nangli login kipu atum web address pen homan nangji."
-
-#: panels/user-accounts/cc-add-user-dialog.c:205
-msgid "Failed to add account"
-msgstr "Account thap un-eh"
-
-#: panels/user-accounts/cc-add-user-dialog.c:676
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "Passwords homan me."
-
-#: panels/user-accounts/cc-add-user-dialog.c:898
-#: panels/user-accounts/cc-add-user-dialog.c:944
-#: panels/user-accounts/cc-add-user-dialog.c:965
-msgid "Failed to register account"
-msgstr "Account register un-eh det"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1088
-msgid "No supported way to authenticate with this domain"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1161
-msgid "Failed to join domain"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1222
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.c:1229
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1237
-msgid "Failed to log into domain"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.c:1295
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "User akimi"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr "_Men keding"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-msgid "Standard"
-msgstr "Standard"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "Administrator"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-msgid "Account _Type"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-msgid "Allow user to set a password when they next _login"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
 msgstr "_Login cheng ahut password amethang pa selam nang"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
-msgid "Set a password _now"
-msgstr "_Non password bi-noi"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Password selam ik-tha non"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "_Confirm"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_Enterprise Login"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Nangli Offline"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
 "resources on the internet."
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:732
-msgid "You are Offline"
-msgstr "Nangli Offline"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-msgid "You must be online in order to add enterprise users."
-msgstr ""
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "_Enterprise Login"
-
-#: panels/user-accounts/cc-avatar-chooser.c:232
-msgid "Browse for more pictures"
-msgstr ""
-
-#: panels/user-accounts/cc-avatar-chooser.ui:39
-msgid "Take a Picture…"
-msgstr "Arjan ke-nep…"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:46
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "File chongvai…"
 
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "Laso Rui"
-
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
-msgstr "Achu Rui"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:766
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:770
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr "Session kejut"
-
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr "Session pangcheng"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr "Choningri pen kaprek password chongvai ik-tha."
-
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "_Enterprise Login"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Aphi a track"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Password kelar"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "Kel_ar"
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr ""
-
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr "_Kimi Password"
-
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "Non dobom _Password"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Kimi Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Password kelar"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Passwords homan me."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Password selam ik-tha non"
 
-#: panels/user-accounts/cc-realm-manager.c:307
-msgid "Cannot automatically join this type of domain"
-msgstr ""
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Users"
 
-#: panels/user-accounts/cc-realm-manager.c:310
-msgid "No such domain or realm found"
-msgstr ""
-
-#: panels/user-accounts/cc-realm-manager.c:732
-#: panels/user-accounts/cc-realm-manager.c:746
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr ""
-
-#: panels/user-accounts/cc-realm-manager.c:738
-msgid "Invalid password, please try again"
-msgstr ""
-
-#: panels/user-accounts/cc-realm-manager.c:751
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:209
-msgid "Your account"
-msgstr "Nangli account"
-
-#: panels/user-accounts/cc-user-panel.c:384
-msgid "Failed to delete user"
-msgstr "User than un-eh det"
-
-#: panels/user-accounts/cc-user-panel.c:442
-#: panels/user-accounts/cc-user-panel.c:501
-#: panels/user-accounts/cc-user-panel.c:553
-msgid "Failed to revoke remotely managed user"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:605
-msgid "You cannot delete your own account."
-msgstr "Nangli methang account chethan un-eh."
-
-#: panels/user-accounts/cc-user-panel.c:614
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s login bomlang"
-
-#: panels/user-accounts/cc-user-panel.c:618
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:627
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:631
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:634
-msgid "_Delete Files"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:635
-msgid "_Keep Files"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:649
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:653
-msgid "_Delete"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:703
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:711
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:714
-msgctxt "Password mode"
-msgid "None"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:759
-msgid "Logged in"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1137
-msgid "Failed to contact the accounts service"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1139
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1171
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1244
-msgid "Create a user account"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1255
-#: panels/user-accounts/cc-user-panel.c:1383
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1276
-#: panels/user-accounts/cc-user-panel.c:1387
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:5
-msgid "_Add User…"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:52
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:146
-#: panels/user-accounts/cc-user-panel.ui:162
-msgid "User Icon"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Men keding"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
 msgstr ""
 
 #: panels/user-accounts/cc-user-panel.ui:238
-msgid "Account Settings"
-msgstr "Account Settings"
+msgid "Account Activity"
+msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:265
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Administrator"
 
-#: panels/user-accounts/cc-user-panel.ui:285
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:359
-msgid "Authentication & Login"
-msgstr "Au_thentication lapen Login"
-
-#: panels/user-accounts/cc-user-panel.ui:428
-msgid "_Fingerprint Login"
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:470
-msgid "A_utomatic Login"
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:500
-msgid "Account Activity"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.ui:541
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Amen kethan…"
 
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Kaprek Ri-chimun:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "User akimi"
+
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:580
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:590
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr ""
-
-#: panels/user-accounts/data/account-fingerprint.ui:12
-msgid "Left thumb"
-msgstr "Ar-vi Rimunpo"
-
-#: panels/user-accounts/data/account-fingerprint.ui:15
-msgid "Left middle finger"
-msgstr "Ar-vi angbong Ri-chimun"
-
-#: panels/user-accounts/data/account-fingerprint.ui:18
-msgid "Left ring finger"
-msgstr "Ar-vi arnan Ri-chimun"
-
-#: panels/user-accounts/data/account-fingerprint.ui:21
-msgid "Left little finger"
-msgstr "Ar-vi Ri-munso"
-
-#: panels/user-accounts/data/account-fingerprint.ui:24
-msgid "Right thumb"
-msgstr "Ar-eh Ri-munpo"
-
-#: panels/user-accounts/data/account-fingerprint.ui:27
-msgid "Right middle finger"
-msgstr "Ar-eh angbong Ri-munpi"
-
-#: panels/user-accounts/data/account-fingerprint.ui:30
-msgid "Right ring finger"
-msgstr "Ar-eh arnan Ri-munpi"
-
-#: panels/user-accounts/data/account-fingerprint.ui:33
-msgid "Right little finger"
-msgstr "Ar-eh Ri-munso"
-
-#: panels/user-accounts/data/account-fingerprint.ui:39
-#: panels/user-accounts/um-fingerprint-dialog.c:676
-msgid "Enable Fingerprint Login"
-msgstr ""
-
-#: panels/user-accounts/data/account-fingerprint.ui:89
-msgid "_Right index finger"
-msgstr "A_r-eh Ri-munjong"
-
-#: panels/user-accounts/data/account-fingerprint.ui:105
-msgid "_Left index finger"
-msgstr "_Ar-vi Ri-munjong"
-
-#: panels/user-accounts/data/account-fingerprint.ui:126
-msgid "_Other finger:"
-msgstr "_Kaprek Ri-chimun:"
-
-#: panels/user-accounts/data/account-fingerprint.ui:324
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
-msgid "Users"
-msgstr "Users"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "Monit men kethap kethan lapen password kelar"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Login;Amen;Fingerprint;Avatar;Logo;Arje;Password;"
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr ""
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Domain Administrator Login"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here."
 msgstr ""
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "Administrator Ame_n"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Administrator Password"
 
@@ -7425,342 +4532,137 @@ msgstr "Monit accounts kerim"
 msgid "Authentication is required to change user data"
 msgstr ""
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Akimi password aban pen prek nangji."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Amek pen lakha lar si lang tha."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Ephong password lar si langtha."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Password long user amen thap dunde lote password jakong ong chet po."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Nangli men password long thapthe det si meji."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Password amek bi dunde te mesen ji."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Hodai amek bi dunde si keme."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Bor-e pen lakha pa ong tha."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Bor-e pen amek-kethe pa-ong tha."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Bor-e pen amek-so pa-ong tha."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Bor-e pen amek cherui re det tha."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Bor-e pen ajang amek 1234 mate abcd bi be det si keme."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Password ding nanglang. Bor-e pen amek, lakha lapen punctuation pa ong-tha."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Amek-kethe kibi pangvui pen lakha isi hini thap dun se keme."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Amek, lakha lapen punctiontion thap dun lote password jakong ong po."
-
-#: panels/user-accounts/run-passwd.c:424
-msgid "Authentication failed"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The new password is too short"
-msgstr "Akimi password thi ongchet"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password is too simple"
-msgstr "Akimi password joi ong"
-
-#: panels/user-accounts/run-passwd.c:516
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Akimi pen aban password homan kei-kei"
-
-#: panels/user-accounts/run-passwd.c:519
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Akimi password achu lom het si rim tang lang."
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Akimi password long numeric or special characters do nangji"
-
-#: panels/user-accounts/run-passwd.c:526
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Akimi pen aban password homan"
-
-#: panels/user-accounts/run-passwd.c:530
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-
-#: panels/user-accounts/run-passwd.c:534
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Akimi password long kaprek-kaprek amek betso jai"
-
-#: panels/user-accounts/run-passwd.c:538
-#, c-format
-msgid "Unknown error"
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Enabled"
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:259
-msgid "Delete registered fingerprints?"
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "_Delete Fingerprints"
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:269
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:439
-msgid "Done!"
-msgstr "Chunlo!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:500
-#: panels/user-accounts/um-fingerprint-dialog.c:542
-#, c-format
-msgid "Could not access “%s” device"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:583
-#, c-format
-msgid "Could not start finger capture on “%s” device"
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:627
-msgid "Could not access any fingerprint readers"
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:628
-msgid "Please contact your system administrator for help."
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: panels/user-accounts/um-fingerprint-dialog.c:710
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the “%s” device."
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:717
-msgid "Selecting finger"
-msgstr ""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:718
-msgid "Enrolling fingerprints"
-msgstr ""
-
-#: panels/user-accounts/user-utils.c:439
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-
-#: panels/user-accounts/user-utils.c:443
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Laso user amen kaprek rim tang lo. Choningri pen kaprek chongvai thu noi."
-
-#: panels/user-accounts/user-utils.c:488
-msgid "The username is too long."
-msgstr "Laso username ding ong chet-lo."
-
-#: panels/user-accounts/user-utils.c:550
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr ""
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr ""
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr ""
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr ""
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 
-#: panels/wacom/calibrator/calibrator.ui:61
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
 
-#: panels/wacom/calibrator/calibrator.ui:78
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.c:249
-#, c-format
-msgid "Button %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tablet"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "%s Monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
 msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:249
-msgid "Output:"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:261
-msgid "Keep aspect ratio (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
 msgstr ""
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:272
-msgid "Map to single monitor"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
 msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
-msgstr "%d of %d"
-
-#: panels/wacom/cc-wacom-page.c:516
-msgid "Display Mapping"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr ""
 
-#: panels/wacom/cc-wacom-panel.c:806 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
-msgstr "Stylus"
-
-#: panels/wacom/cc-wacom-stylus-page.c:360
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
 msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Ing-duk"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Ing-tang thip"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Aphrang"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr "Wacom Tablet"
 
@@ -7768,203 +4670,338 @@ msgstr "Wacom Tablet"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:296
-#: panels/wacom/gnome-wacom-properties.ui:401
-msgid "Map to Monitor…"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows software"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Toner bet-so vedlo"
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows software"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
 msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:376
-msgid "Decouple Display"
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Kethap"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Save"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "PAP"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
 msgstr ""
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr "Shortcut kimi…"
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+msgid "Modem Status"
+msgstr "Status:"
 
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Network amen"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Networks"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Lakha"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Hormu Men"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Bonda-atum"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "Aphrang"
-
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
-msgstr "Stylus longle"
-
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
-msgid "Soft"
-msgstr "Ing-duk"
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Mobile Broadband"
 
-#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
-msgid "Firm"
-msgstr "Ing-tang thip"
-
-#: panels/wacom/wacom-stylus-page.ui:234
-msgid "Top Button"
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:263
-msgid "Lower Button"
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:292
-msgid "Lowest Button"
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
 msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:321
-msgid "Tip Pressure Feel"
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Network amen"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Network"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
 msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Settings"
-msgstr "GNOME Settings"
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Network amen"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Automatic DNS"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Network"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Wi-Fi Adapter longle"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Nangli Wi-Fi adapter thon pame aphi ingpu pen langthu tha"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Airplane mode do esek Bluetooth damde."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Airplane Mode pamep-noi"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Chepho thannoi"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM Card thon thelang"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Kel_ar"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Network"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
 msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:20
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "The GNOME Project"
 
-#: shell/cc-application.c:58
-msgid "Display version number"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
 msgstr ""
 
-#: shell/cc-application.c:59
-msgid "Enable verbose mode"
-msgstr ""
-
-#: shell/cc-application.c:60
-msgid "Search for the string"
-msgstr "Amek-akhor kiri"
-
-#: shell/cc-application.c:61
-msgid "List possible panel names and exit"
-msgstr ""
-
-#: shell/cc-application.c:62
-msgid "Panel to display"
-msgstr ""
-
-#: shell/cc-application.c:62
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: shell/cc-panel-list.ui:45 shell/cc-window.c:277
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacy"
 
-#: shell/cc-panel-loader.c:288
-msgid "Available panels:"
-msgstr ""
-
-#: shell/cc-window.ui:140
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr ""
 
-#: shell/cc-window.ui:178
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr ""
 
-#: shell/cc-window.ui:319
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr ""
 
-#: shell/cc-window.ui:320
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
 "issues. "
 msgstr ""
 
-#: shell/cc-window.ui:331
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Kerap"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr ""
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -7976,7 +5013,7 @@ msgctxt "shortcut window"
 msgid "Quit"
 msgstr ""
 
-#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "Kiri"
@@ -7986,14 +5023,18 @@ msgctxt "shortcut window"
 msgid "Panels"
 msgstr ""
 
-#: shell/help-overlay.ui:40
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
 msgstr ""
 
-#: shell/help-overlay.ui:53
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
 msgstr ""
 
 #: shell/org.gnome.Settings.gschema.xml:5
@@ -8015,27 +5056,1035 @@ msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1883
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1893
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: subprojects/gvc/gvc-mixer-control.c:2750
-msgid "System Sounds"
-msgstr ""
+#~ msgid "Home"
+#~ msgstr "Home"
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Lar un eh"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Desktop Nung-arjan kibi"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Monit men kethap kethan lapen password kelar"
+
+#~ msgid "Print documents"
+#~ msgstr "Loh ke Print"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Time zone kelar"
+
+#~ msgid "Select a picture"
+#~ msgstr "Arjan ingvai"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Wallpaper;Screen;Desktop;"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Laptop adip dip noi"
+
+#~ msgid "Complete!"
+#~ msgstr "Tanglo!"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Kedun Webcam"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s Scanner"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s Camera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s Printer"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s Webcam"
+
+#~ msgid "_Import"
+#~ msgstr "_Import"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Un-eh-det laso file ke upload: %s"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Laso URL Lo long tok ik vek tha."
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Internet chepho do nangji"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Default RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Default CMYK"
+
+#~ msgid "Other…"
+#~ msgstr "Kaprek…"
+
+#~ msgid "Today"
+#~ msgstr "Pini"
+
+#~ msgid "Yesterday"
+#~ msgstr "Tumi"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "Porphai %d"
+#~ msgstr[1] "Porphai jon %d"
+
+#, c-format
+#~ msgctxt "time"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "time"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "24-hour"
+#~ msgstr "24-Porphai"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Chinine"
+
+#~ msgid "Left Alt"
+#~ msgstr "Ar-vi Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Ar-eh Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Ar-vi Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Ar-eh Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ar-eh Ctrl"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ar-eh Ctrl"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Ar-vi Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Ar-eh Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Ar-vi Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Ar-eh Alt"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Shortcut kimi ketok"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 seconds"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutes"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "Porphai 1"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12  minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutes"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Mentu ta kali"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Hini-Richemun lote Scroll lo"
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Awe"
+
+#~ msgid "Never"
+#~ msgstr "Mentu ta nangne"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Awe"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Bi-hek"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Me-chit"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Mesen"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Me-pik"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN kethan"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Awe"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit Passphrase"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamic WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "New Profile"
+#~ msgstr "Profile kimi"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "File amen “%s” dotang do."
+
+#~ msgid "never"
+#~ msgstr "mentu ta kali"
+
+#~ msgid "today"
+#~ msgstr "pini"
+
+#~ msgid "yesterday"
+#~ msgstr "atumi"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Hotspot pasang si chepho an pen than nangji?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Hotspot pasang"
+
+#~ msgid "_Forget"
+#~ msgstr "_Tene-noi"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Wi-Fi Networks chini-tang"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Tene-noi"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Password"
+
+#~ msgid "Status unknown"
+#~ msgstr "Status chinine"
+
+#~ msgid "Authentication required"
+#~ msgstr "Howang nangji"
+
+#~ msgid "Connection failed"
+#~ msgstr "Chepho un-eh det"
+
+#~ msgid "No dial tone"
+#~ msgstr "Dail tone awe"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem longle"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM Pin nangji"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk nangji"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM chokche"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "DER, PEM, mate PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER mate PEM certificates (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC files (*.pac)"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Kaprek"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s Account"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s musi-lo"
+
+#~ msgid "Remove Account"
+#~ msgstr "Account than noi"
+
+#~ msgid "Unknown time"
+#~ msgstr "Apor chinine"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s charge plengji aphan dolang"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Caution: %s an ved-lo"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s an ved-lo"
+
+#~ msgid "Fully charged"
+#~ msgstr "Charge plenglo"
+
+#~ msgid "Not charging"
+#~ msgstr "Che charge-che"
+
+#~ msgid "Empty"
+#~ msgstr "Angse"
+
+#~ msgid "Charging"
+#~ msgstr "Charge-bom"
+
+#~ msgid "Discharging"
+#~ msgstr "Charge cherui bom"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Ari-awe mouse"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Ari-awe keyboard"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Uninterruptible power supply"
+
+#~ msgid "Cellphone"
+#~ msgstr "Sepalar"
+
+#~ msgid "Media player"
+#~ msgstr "Media player"
+
+#~ msgid "Computer"
+#~ msgstr "Computer"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Charge-bom"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Chere tha"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Bihek"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Mesen"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Charge pleng-lo"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Angse"
+
+#~ msgid "Batteries"
+#~ msgstr "Batteries"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Keyboard atur"
+
+#~ msgid "_Dim Screen When Inactive"
+#~ msgstr "_Jongsi Inactive pu lote screen atur pabi noi"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Authenticate"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Printer “%s” than ed-lo"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Printer kimi thon un-eh det."
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect Printer"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD Printer"
+
+#~ msgid "One Sided"
+#~ msgstr "I-hin anchot"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Howang nangji"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Klem bomlo"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Sang-kok"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Tang ed-lo"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serial Port"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Parallel Port"
+
+#~ msgid "Two Sided"
+#~ msgstr "Hini-hin"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Alir"
+
+#~ msgid "Test page"
+#~ msgstr "Sat-lang alo"
+
+#~ msgid "Out of toner"
+#~ msgstr "TOner angse lo"
+
+#~ msgid "Low on paper"
+#~ msgstr "Lo achet bet-so lo"
+
+#~ msgid "Out of paper"
+#~ msgstr "Lo ik lo"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Offline"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Sang-kok"
+
+#~ msgid "Add…"
+#~ msgstr "Akimi kethon…"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metric"
+
+#~ msgid "Previous source"
+#~ msgstr "Aphrang source"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "Adun source"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Left+Right Alt"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Arju ver noi"
+
+#~ msgid "Do nothing"
+#~ msgstr "Jat-ta klem nangne"
+
+#~ msgid "Open folder"
+#~ msgstr "Folder ingpu noi"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "blank Blu-ray disc"
+
+#~ msgid "blank CD disc"
+#~ msgstr "blank CD disc"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "blank DVD disc"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "blank HD DVD disc"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video disc"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-book reader"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video disc"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "_OK"
+#~ msgstr "_Chok"
+
+#~ msgid "_Password:"
+#~ msgstr "_Password:"
+
+#~ msgid "Bark"
+#~ msgstr "Kang-uk"
+
+#~ msgid "Drip"
+#~ msgstr "Charchim"
+
+#~ msgid "Glass"
+#~ msgstr "Bilor"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Chinine"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Hovang adim:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Chepho adim:"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Achetim"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Kethe"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Kethe-dun"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Kethe-nei"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Thi-hek"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Ding-hoi"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "Porphai 1"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "Ni 1"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "Ni 2"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "Ni 3"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "Ni 4"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "Ni 5"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "Ni 6"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "Ni 7"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "Ni 14"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "Ni 30"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "Ni 1"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "Ni 7"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "Ni 30"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Kaike"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Nangli login kipu atum web address pen homan nangji."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Account thap un-eh"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Account register un-eh det"
+
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_Non password bi-noi"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Arjan ke-nep…"
+
+#~ msgid "This Week"
+#~ msgstr "Laso Rui"
+
+#~ msgid "Last Week"
+#~ msgstr "Achu Rui"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Session kejut"
+
+#~ msgid "Session Started"
+#~ msgstr "Session pangcheng"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Choningri pen kaprek password chongvai ik-tha."
+
+#~ msgid "Failed to delete user"
+#~ msgstr "User than un-eh det"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nangli methang account chethan un-eh."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s login bomlang"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Au_thentication lapen Login"
+
+#~ msgid "Left thumb"
+#~ msgstr "Ar-vi Rimunpo"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Ar-vi angbong Ri-chimun"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Ar-vi arnan Ri-chimun"
+
+#~ msgid "Left little finger"
+#~ msgstr "Ar-vi Ri-munso"
+
+#~ msgid "Right thumb"
+#~ msgstr "Ar-eh Ri-munpo"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Ar-eh angbong Ri-munpi"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Ar-eh arnan Ri-munpi"
+
+#~ msgid "Right little finger"
+#~ msgstr "Ar-eh Ri-munso"
+
+#~ msgid "_Right index finger"
+#~ msgstr "A_r-eh Ri-munjong"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Ar-vi Ri-munjong"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Login;Amen;Fingerprint;Avatar;Logo;Arje;Password;"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Akimi password aban pen prek nangji."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Amek pen lakha lar si lang tha."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Ephong password lar si langtha."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr ""
+#~ "Password long user amen thap dunde lote password jakong ong chet po."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Nangli men password long thapthe det si meji."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Password amek bi dunde te mesen ji."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Hodai amek bi dunde si keme."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Bor-e pen lakha pa ong tha."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Bor-e pen amek-kethe pa-ong tha."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Bor-e pen amek-so pa-ong tha."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Bor-e pen amek cherui re det tha."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Bor-e pen ajang amek 1234 mate abcd bi be det si keme."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Password ding nanglang. Bor-e pen amek, lakha lapen punctuation pa ong-"
+#~ "tha."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Amek-kethe kibi pangvui pen lakha isi hini thap dun se keme."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Amek, lakha lapen punctiontion thap dun lote password jakong ong po."
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Akimi password thi ongchet"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Akimi password joi ong"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Akimi pen aban password homan kei-kei"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Akimi password achu lom het si rim tang lang."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Akimi password long numeric or special characters do nangji"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Akimi pen aban password homan"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Akimi password long kaprek-kaprek amek betso jai"
+
+#~ msgid "Done!"
+#~ msgstr "Chunlo!"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Laso user amen kaprek rim tang lo. Choningri pen kaprek chongvai thu noi."
+
+#~ msgid "The username is too long."
+#~ msgstr "Laso username ding ong chet-lo."
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d of %d"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Shortcut kimi…"
+
+#~ msgid "No stylus found"
+#~ msgstr "Stylus longle"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "GNOME Settings"
+
+#~ msgid "Search for the string"
+#~ msgstr "Amek-akhor kiri"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
 
 #~ msgid "Remove Background"
 #~ msgstr "Nung-arjan kethan"
@@ -8045,9 +6094,6 @@ msgstr ""
 
 #~ msgid "OS name"
 #~ msgstr "OS amen"
-
-#~ msgid "OS type"
-#~ msgstr "OS type"
 
 #~ msgid "Disk"
 #~ msgstr "Disk"
@@ -8111,9 +6157,6 @@ msgstr ""
 
 #~ msgid "Ad-hoc"
 #~ msgstr "Ad-hoc"
-
-#~ msgid "Not connected"
-#~ msgstr "Chephophe"
 
 #~ msgctxt "Microphone status"
 #~ msgid "Off"

--- a/po/mjw.po~
+++ b/po/mjw.po~
@@ -1,0 +1,8136 @@
+# Karbi translation for gnome-control-center.
+# Copyright (C) 2019 gnome-control-center's Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+# Jor Teron <jor.teron@gmail.com>, 2019-20.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2020-02-22 15:18+0000\n"
+"PO-Revision-Date: 2020-02-22 22:20+0530\n"
+"Last-Translator: Jor Teron <jor.teron@gmail.com>\n"
+"Language-Team: Karbi <karbi.translation@gmail.com>\n"
+"Language: mjw\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!= 1);\n"
+"X-Generator: Gedit\n"
+
+#: panels/applications/cc-applications-panel.c:737
+msgid "System Bus"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:737
+#: panels/applications/cc-applications-panel.c:739
+#: panels/applications/cc-applications-panel.c:752
+#: panels/applications/cc-applications-panel.c:757
+msgid "Full access"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:739
+msgid "Session Bus"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:743
+#: panels/power/cc-power-panel.c:2472 panels/thunderbolt/cc-bolt-panel.ui:466
+#: panels/thunderbolt/cc-bolt-panel.ui:525
+msgid "Devices"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:743
+msgid "Full access to /dev"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:747
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:252
+msgid "Network"
+msgstr "Network"
+
+#: panels/applications/cc-applications-panel.c:747
+#: panels/applications/cc-snap-row.c:109
+msgid "Has network access"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:752
+#: panels/applications/cc-applications-panel.c:754
+#: panels/search/cc-search-locations-dialog.c:361
+msgid "Home"
+msgstr "Home"
+
+#: panels/applications/cc-applications-panel.c:754
+#: panels/applications/cc-applications-panel.c:759
+msgid "Read-only"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:757
+#: panels/applications/cc-applications-panel.c:759
+msgid "File System"
+msgstr "File System"
+
+#: panels/applications/cc-applications-panel.c:763
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:281
+#: shell/cc-window.c:964 shell/cc-window.ui:125
+#: shell/gnome-control-center.desktop.in.in:3
+msgid "Settings"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:763
+#: panels/applications/cc-snap-row.c:73
+msgid "Can change settings"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:765
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:926
+msgid "Web Links"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:936
+msgid "Git Links"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:942
+#, c-format
+msgid "%s Links"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:950
+#: panels/applications/cc-applications-panel.c:986
+msgid "Unset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1041
+msgid "Links"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1049
+msgid "Hypertext Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1063
+msgid "Text Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1077
+msgid "Image Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1093
+msgid "Font Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1154
+msgid "Archive Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1174
+msgid "Package Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1197
+msgid "Audio Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1214
+msgid "Video Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1222
+msgid "Other Files"
+msgstr ""
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1564
+#: panels/applications/cc-applications-panel.ui:418
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:167
+msgid "Applications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:45
+msgid "No applications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:59
+msgid "Install some…"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:99
+msgid "Permissions & Access"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:111
+msgid ""
+"Data and services that this app has asked for access to and permissions that "
+"it requires."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/applications/cc-applications-panel.ui:132
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Camera"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:133
+#: panels/applications/cc-applications-panel.ui:145
+#: panels/applications/cc-applications-panel.ui:157
+#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:267
+#: panels/keyboard/cc-keyboard-option.c:259
+#: panels/keyboard/cc-keyboard-option.c:378
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:96
+#: panels/keyboard/keyboard-shortcuts.c:425 panels/network/network-proxy.ui:126
+#: panels/user-accounts/um-fingerprint-dialog.c:211
+#: subprojects/gvc/gvc-mixer-control.c:1876
+msgid "Disabled"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:138
+#: panels/applications/cc-applications-panel.ui:144
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microphone"
+
+#: panels/applications/cc-applications-panel.ui:150
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:501
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:163
+msgid "Cannot be changed"
+msgstr "Lar un eh"
+
+#: panels/applications/cc-applications-panel.ui:180
+msgid ""
+"Individual permissions for applications can be reviewed in the <a href="
+"\"privacy\">Privacy</a> Settings."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Integration"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System features used by this application."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:230
+#: panels/applications/cc-applications-panel.ui:236
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:155
+msgid "Search"
+msgstr "Kiri"
+
+#: panels/applications/cc-applications-panel.ui:242
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:248
+msgid "Run in background"
+msgstr "Anung-padam"
+
+#: panels/applications/cc-applications-panel.ui:254
+msgid "Set Desktop Background"
+msgstr "Desktop Nung-arjan kibi"
+
+#: panels/applications/cc-applications-panel.ui:260
+#: panels/applications/cc-applications-panel.ui:266
+msgid "Sounds"
+msgstr "Seh"
+
+#: panels/applications/cc-applications-panel.ui:299
+msgid "Default Handlers"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+msgid "Types of files and links that this application opens."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:327
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:363
+msgid "Usage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:375
+msgid "How much resources this application is using."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/applications/cc-applications-panel.ui:537
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:425
+msgid "Open in Software"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:475 shell/cc-panel-list.ui:121
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:486
+#: panels/keyboard/cc-keyboard-panel.ui:188 shell/cc-panel-list.ui:132
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:554
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:563
+msgid "Application"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:569
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:575
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:581
+msgid "<b>Total</b>"
+msgstr "Kado-kawe"
+
+#: panels/applications/cc-applications-panel.ui:598
+msgid "Clear Cache…"
+msgstr "Cache pangthir…"
+
+#: panels/applications/cc-snap-row.c:55
+msgid "Add user accounts and change passwords"
+msgstr "Monit men kethap kethan lapen password kelar"
+
+#: panels/applications/cc-snap-row.c:57 panels/applications/cc-snap-row.c:133
+msgid "Play and record sound"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:59
+msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:61
+msgid "Access bluetooth hardware directly"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:63
+msgid "Use bluetooth devices"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:65
+msgid "Use your camera"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:67
+msgid "Print documents"
+msgstr "Loh ke Print"
+
+#: panels/applications/cc-snap-row.c:69
+msgid "Use any connected joystick"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:71
+msgid "Allow connecting to the Docker service"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:75
+msgid "Configure network firewall"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:77
+msgid "Setup and use privileged FUSE filesystems"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:79
+msgid "Update firmware on this device"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:81
+msgid "Access hardware information"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:83
+msgid "Provide entropy to hardware random number generator"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:85
+msgid "Use hardware-generated random numbers"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:87
+msgid "Access files in your home folder"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:89
+msgid "Access libvirt service"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:91
+msgid "Change system language and region settings"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:93
+msgid "Change location settings and providers"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:95
+msgid "Access your location"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:97
+msgid "Read system and application logs"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:99
+msgid "Access LXD service"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:101
+msgid "access the media-hub service"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:103
+msgid "Use and configure modems"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:105
+msgid "Read system mount information and disk quotas"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:107
+msgid "Control music and video players"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:111
+msgid "Change low-level network settings"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:113
+msgid "Access the NetworkManager service to read and change network settings"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:115
+msgid "Read access to network settings"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:117
+msgid "Change network settings"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:119
+msgid "Read network settings"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:121
+msgid ""
+"Access the ofono service to read and change network settings for mobile "
+"telephony"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:123
+msgid "Control Open vSwitch hardware"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:125
+msgid "Read from CD/DVD"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:127
+msgid "Read, add, change, or remove saved passwords"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:129
+msgid ""
+"Access pppd and ppp devices for configuring Point-to-Point Protocol "
+"connections"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:131
+msgid "Pause or end any process on the system"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:135
+msgid "Access USB hardware directly"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:137
+msgid "Read/write files on removable storage devices"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:139
+msgid "Prevent screen sleep/lock"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:141
+msgid "Access serial port hardware"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:143
+msgid "Restart or power off the device"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:145
+msgid "Install, remove and configure software"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:147
+msgid "Access Storage Framework service"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:149
+msgid "Read process and system information"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:151
+msgid "Monitor and control any running program"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:153
+msgid "Change the date and time"
+msgstr "Arni lapen apor kelar"
+
+#: panels/applications/cc-snap-row.c:155
+msgid "Change time server settings"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:157
+msgid "Change the time zone"
+msgstr "Time zone kelar"
+
+#: panels/applications/cc-snap-row.c:159
+msgid "Access the UDisks2 service for configuring disks and removable media"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:161
+msgid "Read/change shared calendar events in Ubuntu Unity 8"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:163
+msgid "Read/change shared contacts in Ubuntu Unity 8"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:165
+msgid "Access energy usage data"
+msgstr ""
+
+#: panels/applications/cc-snap-row.c:167
+msgid "Read/write access to U2F devices exposed"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-chooser.c:340
+msgid "Select a picture"
+msgstr "Arjan ingvai"
+
+#: panels/background/cc-background-chooser.c:343
+#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:240
+#: panels/color/cc-color-panel.c:893 panels/color/cc-color-panel.ui:657
+#: panels/common/cc-language-chooser.ui:24
+#: panels/display/cc-display-panel.c:947
+#: panels/info-overview/cc-info-overview-panel.ui:235
+#: panels/network/cc-wifi-hotspot-dialog.ui:122
+#: panels/network/connection-editor/connection-editor.ui:17
+#: panels/network/connection-editor/vpn-helpers.c:176
+#: panels/network/connection-editor/vpn-helpers.c:299
+#: panels/network/net-device-wifi.c:800 panels/network/net-device-wifi.c:908
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:252
+#: panels/region/cc-format-chooser.ui:28 panels/region/cc-input-chooser.ui:11
+#: panels/search/cc-search-locations-dialog.c:638
+#: panels/sharing/cc-sharing-panel.c:410 panels/usage/cc-usage-panel.c:134
+#: panels/user-accounts/cc-add-user-dialog.ui:28
+#: panels/user-accounts/cc-avatar-chooser.c:107
+#: panels/user-accounts/cc-avatar-chooser.c:235
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:636
+#: panels/user-accounts/cc-user-panel.c:654
+#: panels/user-accounts/data/join-dialog.ui:20
+#: panels/user-accounts/um-fingerprint-dialog.c:260
+msgid "_Cancel"
+msgstr "_Cancel"
+
+#: panels/background/cc-background-chooser.c:344
+#: panels/network/connection-editor/vpn-helpers.c:177
+#: panels/printers/pp-details-dialog.c:253
+#: panels/sharing/cc-sharing-panel.c:411
+#: panels/user-accounts/cc-avatar-chooser.c:236
+msgid "_Open"
+msgstr "_Open"
+
+#: panels/background/cc-background-item.c:140
+msgid "multiple sizes"
+msgstr ""
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:144
+#, c-format
+msgid "%d × %d"
+msgstr ""
+
+#: panels/background/cc-background-item.c:282
+msgid "No Desktop Background"
+msgstr ""
+
+#: panels/background/cc-background-panel.c:115
+msgid "Current background"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:55
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/cc-background-preview.ui:55
+msgid "Activities"
+msgstr "Sai"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "Nung-arjan"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr ""
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Wallpaper;Screen;Desktop;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "No Bluetooth Found"
+msgstr "Bluetooth longle"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:69
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth bon-chek"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:80
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:107
+msgid "Airplane Mode is on"
+msgstr "Airplane Mode dobom"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:118
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Airplane mode do esek Bluetooth damde."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:124
+msgid "Turn Off Airplane Mode"
+msgstr "Airplane Mode pamep-noi"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:154
+msgid "Hardware Airplane Mode is on"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:165
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1714
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Bluetooth ingpu si nangli hormu pen pachepho noi"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:34
+msgid "Camera is turned off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:43
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:77
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:87
+msgid "Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:107
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Arjan kerai"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:348
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:354
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:360
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:366
+msgid "Shut the laptop lid"
+msgstr "Laptop adip dip noi"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:397
+msgid "An internal error occurred that could not be recovered."
+msgstr ""
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:402
+msgid "Tools required for calibration are not installed."
+msgstr ""
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:408
+msgid "The profile could not be generated."
+msgstr ""
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:414
+msgid "The target whitepoint was not obtainable."
+msgstr ""
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:453
+msgid "Complete!"
+msgstr "Tanglo!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:461
+msgid "Calibration failed!"
+msgstr ""
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:468
+msgid "You can remove the calibration device."
+msgstr ""
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:537
+msgid "Do not disturb the calibration device while in progress"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:40
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:54
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
+msgid "_Done"
+msgstr ""
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Laptop Screen"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Kedun Webcam"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s Monitor"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s Scanner"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s Camera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s Printer"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s Webcam"
+
+#: panels/color/cc-color-device.c:91
+#, c-format
+msgid "Enable color management for %s"
+msgstr ""
+
+#: panels/color/cc-color-device.c:94
+#, c-format
+msgid "Show color profiles for %s"
+msgstr ""
+
+#. not calibrated
+#: panels/color/cc-color-device.c:303
+msgid "Not calibrated"
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:169
+msgid "Default: "
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:177
+msgid "Colorspace: "
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:184
+msgid "Test profile: "
+msgstr ""
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:238
+msgid "Select ICC Profile File"
+msgstr ""
+
+#: panels/color/cc-color-panel.c:241
+msgid "_Import"
+msgstr "_Import"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:252
+msgid "Supported ICC profiles"
+msgstr ""
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:259
+#: panels/network/wireless-security/eap-method-fast.c:356
+msgid "All files"
+msgstr ""
+
+#: panels/color/cc-color-panel.c:554
+msgid "Screen"
+msgstr "Screen"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:846
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Un-eh-det laso file ke upload: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:858
+msgid "The profile has been uploaded to:"
+msgstr ""
+
+#: panels/color/cc-color-panel.c:860
+msgid "Write down this URL."
+msgstr "Laso URL Lo long tok ik vek tha."
+
+#: panels/color/cc-color-panel.c:861
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+
+#: panels/color/cc-color-panel.c:862
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:890
+msgid "Save Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.c:894
+#: panels/network/connection-editor/vpn-helpers.c:300
+msgid "_Save"
+msgstr "_Save"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1208
+msgid "Create a color profile for the selected device"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1223 panels/color/cc-color-panel.c:1247
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1257
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1268
+msgid "The device type is not currently supported."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:58
+msgid "Quality"
+msgstr "Quality"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:75
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:121
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:174
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:189
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:226
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:278
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:318
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:348
+msgid "Profile Name:"
+msgstr "Profile amen:"
+
+#: panels/color/cc-color-panel.ui:377
+msgid "Profile Name"
+msgstr "Profile amen"
+
+#: panels/color/cc-color-panel.ui:392
+msgid "Profile successfully created!"
+msgstr "Profile selam un chit lo!"
+
+#: panels/color/cc-color-panel.ui:443
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:456
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:519
+msgid "Upload profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:532
+msgid "Requires Internet connection"
+msgstr "Internet chepho do nangji"
+
+#: panels/color/cc-color-panel.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:607
+#: panels/user-accounts/um-fingerprint-dialog.c:719
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:621
+msgid "Add Profile"
+msgstr "Profile kimi kethap"
+
+#: panels/color/cc-color-panel.ui:643
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:672
+#: panels/network/connection-editor/net-connection-editor.c:513
+#: panels/printers/new-printer-dialog.ui:80
+#: panels/region/cc-input-chooser.ui:20
+#: panels/user-accounts/cc-add-user-dialog.ui:47
+msgid "_Add"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:790
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:812
+#: panels/diagnostics/cc-diagnostics-panel.c:143
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:817
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:865
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
+#: panels/color/cc-color-panel.ui:885
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:880
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:911
+msgid "_Add profile"
+msgstr "_Profile kimi kethap"
+
+#: panels/color/cc-color-panel.ui:924
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:928
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:939
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:952
+msgid "_View details"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:988
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1032
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:1037
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:1042
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:1047
+msgid "Projector"
+msgstr "Projector"
+
+#: panels/color/cc-color-panel.ui:1052
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:1057
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL backlight)"
+
+#: panels/color/cc-color-panel.ui:1062
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED backlight)"
+
+#: panels/color/cc-color-panel.ui:1067
+msgid "LCD (white LED backlight)"
+msgstr "LCD (white LED backlight)"
+
+#: panels/color/cc-color-panel.ui:1072
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Wide gamut LCD (CCFL backlight)"
+
+#: panels/color/cc-color-panel.ui:1077
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Wide gamut LCD (RGB LED backlight)"
+
+#: panels/color/cc-color-panel.ui:1094
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1095
+msgid "40 minutes"
+msgstr "40 minutes"
+
+#: panels/color/cc-color-panel.ui:1099
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1100
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#: panels/color/cc-color-panel.ui:1104
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1105
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#: panels/color/cc-color-panel.ui:1127
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:1131
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Printing and publishing)"
+
+#: panels/color/cc-color-panel.ui:1135
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:1139
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Photography and graphics)"
+
+#: panels/color/cc-color-panel.ui:1143
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:100
+msgid "Standard Space"
+msgstr ""
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:106
+msgid "Test Profile"
+msgstr ""
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:114
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr ""
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:124
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr ""
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:129
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr ""
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:136
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr ""
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:153
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Default RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:160
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Default CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:167
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:190
+msgid "Vendor supplied factory calibration data"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:199
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+
+#: panels/color/cc-color-profile.c:221
+msgid "This profile may no longer be accurate"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Alir"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Profile;Calibrate;Printer;Display;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Kaprek…"
+
+#: panels/common/cc-language-chooser.c:127 panels/region/cc-input-chooser.c:178
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-language-chooser.c:144
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:12
+msgid "_Select"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:20
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:45
+msgid "Unlock to Change Settings"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:55
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:152
+msgid "Today"
+msgstr "Pini"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:154
+msgid "Yesterday"
+msgstr "Tumi"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "Porphai %d"
+msgstr[1] "Porphai jon %d"
+
+#: panels/common/cc-util.c:166
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:172
+#, c-format
+msgctxt "time"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:177
+#, c-format
+msgctxt "time"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:187
+msgid "0 seconds"
+msgstr "0 seconds"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
+#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
+msgid "Day"
+msgstr "Arni"
+
+#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
+#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
+msgid "Month"
+msgstr "Cheklo"
+
+#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
+#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
+msgid "Year"
+msgstr "Ningkan"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:334
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:339
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:504
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:531
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:538
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:543
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:548
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:26
+msgid "January"
+msgstr "Arkoi"
+
+#: panels/datetime/cc-datetime-panel.ui:29
+msgid "February"
+msgstr "Thangthang"
+
+#: panels/datetime/cc-datetime-panel.ui:32
+msgid "March"
+msgstr "There"
+
+#: panels/datetime/cc-datetime-panel.ui:35
+msgid "April"
+msgstr "Jangmi"
+
+#: panels/datetime/cc-datetime-panel.ui:38
+msgid "May"
+msgstr "Aru"
+
+#: panels/datetime/cc-datetime-panel.ui:41
+msgid "June"
+msgstr "Vosik"
+
+#: panels/datetime/cc-datetime-panel.ui:44
+msgid "July"
+msgstr "Jakhong"
+
+#: panels/datetime/cc-datetime-panel.ui:47
+msgid "August"
+msgstr "Paipai"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "September"
+msgstr "Chiti"
+
+#: panels/datetime/cc-datetime-panel.ui:53
+msgid "October"
+msgstr "Phere"
+
+#: panels/datetime/cc-datetime-panel.ui:56
+msgid "November"
+msgstr "Phaikuni"
+
+#: panels/datetime/cc-datetime-panel.ui:59
+msgid "December"
+msgstr "Matijong"
+
+#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Arni pen Apor"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#: panels/display/cc-night-light-page.ui:194
+#: panels/display/cc-night-light-page.ui:314
+msgid "Hour"
+msgstr "Porphai"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: panels/datetime/cc-datetime-panel.ui:128
+msgid "∶"
+msgstr "∶"
+
+#: panels/datetime/cc-datetime-panel.ui:152
+#: panels/display/cc-night-light-page.ui:222
+#: panels/display/cc-night-light-page.ui:342
+msgid "Minute"
+msgstr "Minute"
+
+#: panels/datetime/cc-datetime-panel.ui:219
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:240
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:313
+msgid "Automatic _Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:314
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:334
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:335
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:350
+msgid "Date & _Time"
+msgstr "Arni pen Apor"
+
+#: panels/datetime/cc-datetime-panel.ui:366
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:405
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:414
+msgid "24-hour"
+msgstr "24-Porphai"
+
+#: panels/datetime/cc-datetime-panel.ui:415
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Arni, apor lapen time zone kelar"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:31
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:43
+msgid "_Mail"
+msgstr "_Mail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:59
+msgid "_Calendar"
+msgstr "_Calendar"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "M_usic"
+msgstr "L_un"
+
+#: panels/default-apps/cc-default-apps-panel.ui:91
+msgid "_Video"
+msgstr "Lun-Arjan"
+
+#: panels/default-apps/cc-default-apps-panel.ui:162
+#: panels/removable-media/cc-removable-media-panel.ui:162
+msgid "_Photos"
+msgstr "Arjan"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr ""
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:145
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:30
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:67
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#. FIXME
+#: panels/display/cc-display-panel.c:958
+#: panels/network/connection-editor/connection-editor.ui:27
+msgid "_Apply"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:979
+msgid "Apply Changes?"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:984
+msgid "Changes Cannot be Applied"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:985
+msgid "This could be due to hardware limitations."
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:91
+msgid "Single Display"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:110
+#: panels/display/cc-display-panel.ui:315
+msgid "Join Displays"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:128
+msgid "Mirror"
+msgstr "Mirror"
+
+#: panels/display/cc-display-panel.ui:153
+msgid "Display Mode"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:245
+msgid ""
+"Drag displays to match your physical display setup. Select a display to "
+"change its settings."
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:252
+msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:434
+msgid "Display Configuration"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:453
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:464
+#: panels/display/cc-night-light-page.ui:111
+msgid "Night Light"
+msgstr "Night Light"
+
+#: panels/display/cc-display-settings.c:104
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:107
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr ""
+
+#: panels/display/cc-display-settings.c:187
+#, c-format
+msgid "%.2lf Hz"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:15
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:24
+msgctxt "display setting"
+msgid "Resolution"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:33
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:42
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:59
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-night-light-page.c:622
+msgid "More Warm"
+msgstr ""
+
+#: panels/display/cc-night-light-page.c:634
+msgid "Less Warm"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:28
+msgid "Restart Filter"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:61
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:88
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:127
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:136
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:137
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/region/cc-format-chooser.ui:346
+msgid "Times"
+msgstr "Phong"
+
+#: panels/display/cc-night-light-page.ui:165
+msgid "From"
+msgstr "Pangcheng"
+
+#: panels/display/cc-night-light-page.ui:203
+#: panels/display/cc-night-light-page.ui:323
+msgid ":"
+msgstr ":"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:234
+#: panels/display/cc-night-light-page.ui:354
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:250
+#: panels/display/cc-night-light-page.ui:370
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:284
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:408
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.c:406
+#: panels/info-overview/cc-info-overview-panel.c:421
+#: panels/info-overview/cc-info-overview-panel.c:433
+#: panels/info-overview/cc-info-overview-panel.c:479
+#: panels/info-overview/cc-info-overview-panel.c:509
+msgid "Unknown"
+msgstr ""
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:441
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; Build ID: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:456
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:459
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:665
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:669
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:671
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Chinine"
+
+#: panels/info-overview/cc-info-overview-panel.ui:54
+msgid "Device Name"
+msgstr "Hormu Men"
+
+#: panels/info-overview/cc-info-overview-panel.ui:76
+msgid "Memory"
+msgstr "Memory"
+
+#: panels/info-overview/cc-info-overview-panel.ui:85
+msgid "Processor"
+msgstr "Processor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:94
+msgid "Graphics"
+msgstr "Graphics"
+
+#: panels/info-overview/cc-info-overview-panel.ui:103
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:104
+msgid "Calculating…"
+msgstr "Lakha bom…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:126
+msgid "OS Name"
+msgstr "OS Men"
+
+#: panels/info-overview/cc-info-overview-panel.ui:135
+msgid "OS Type"
+msgstr "OS Type"
+
+#: panels/info-overview/cc-info-overview-panel.ui:144
+msgid "GNOME Version"
+msgstr "GNOME Version"
+
+#: panels/info-overview/cc-info-overview-panel.ui:154
+msgid "Windowing System"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:162
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:171
+msgid "Software Updates"
+msgstr "Software Updates"
+
+#: panels/info-overview/cc-info-overview-panel.ui:192
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:209
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:226
+msgid "_Rename"
+msgstr "_Rename"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Aputhak"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Seh pen Media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Seh pawe/pado"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Seh pathe"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Seh pabi"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Microphone seh pawe/pado"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Padam (mate padam/pasang)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Playback pasang"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Playback pajut"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Aphi a track"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Adunthu a track"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Patet"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:565
+msgid "Typing"
+msgstr "Tok-bom"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Kiri"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr ""
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Universal Access"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Akhor apun pathe"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Akhor apun pabi"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:8
+#: panels/keyboard/cc-keyboard-panel.ui:72
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:28
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:45
+msgid "Left Alt"
+msgstr "Ar-vi Alt"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:61
+msgid "Right Alt"
+msgstr "Ar-eh Alt"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:77
+msgid "Left Super"
+msgstr "Ar-vi Super"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:93
+msgid "Right Super"
+msgstr "Ar-eh Super"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:109
+msgid "Menu key"
+msgstr ""
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:125
+msgid "Right Ctrl"
+msgstr "Ar-eh Ctrl"
+
+#: panels/keyboard/cc-keyboard-manager.c:501
+#: panels/keyboard/cc-keyboard-manager.c:509
+#: panels/keyboard/cc-keyboard-manager.c:809
+msgid "Custom Shortcuts"
+msgstr ""
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: panels/keyboard/cc-keyboard-option.c:337
+msgid "Alternative Characters Key"
+msgstr ""
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: panels/keyboard/cc-keyboard-option.c:346
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-option.c:351
+msgid "Modifiers-only switch to next source"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:94
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ar-eh Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:95
+msgctxt "keyboard key"
+msgid "Menu Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:96
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Ar-vi Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:97
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Ar-eh Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:98
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Ar-vi Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:99
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Ar-eh Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:201
+msgid "Reset All Shortcuts?"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:204
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:208
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:346
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+msgid "Cancel"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:209
+msgid "Reset All"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:305
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:73
+msgid "Hold down and type to enter different characters"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:147
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:148
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:177
+msgid "No keyboard shortcut found"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:413
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+msgid "Set Custom Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+msgid "Set Shortcut"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:592
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:1016
+msgid "Add Custom Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:68
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:318
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:156
+#: panels/printers/pp-details-dialog.ui:40
+msgid "Name"
+msgstr "Men"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:168
+msgid "Command"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:180
+msgid "Shortcut"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:259
+msgid "Set Shortcut…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:272
+msgid "None"
+msgstr "Awe"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:303
+msgid "Enter the new shortcut"
+msgstr "Shortcut kimi ketok"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:357
+msgid "Remove"
+msgstr "Pawe"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:367
+msgid "Add"
+msgstr "Kethap"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:382
+msgid "Replace"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:395
+msgid "Set"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+#: panels/region/cc-region-panel.ui:394 shell/cc-window.ui:327
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;The-bi;Zoom;Contrast;Input;Source;Lock;Volume;"
+
+#: panels/location/cc-location-panel.ui:31
+msgid "Location services turned off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:40
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:74
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:83
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:95
+msgid "Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:115
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#. FIXME
+#: panels/lock/cc-lock-panel.ui:29
+msgid ""
+"Automatically locking the screen prevents others from access the computer "
+"while you're away."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:46
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:47
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:67
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:84
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:85
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/lock/cc-lock-panel.ui:105
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:149
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr ""
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:153
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 seconds"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:157
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minute"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:161
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutes"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:165
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutes"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:169
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:173
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:177
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "Porphai 1"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:192 panels/power/cc-power-panel.ui:63
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minute"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:196 panels/power/cc-power-panel.ui:67
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutes"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:200 panels/power/cc-power-panel.ui:71
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutes"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:204 panels/power/cc-power-panel.ui:75
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutes"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:208 panels/power/cc-power-panel.ui:79
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:212 panels/power/cc-power-panel.ui:83
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutes"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:216 panels/power/cc-power-panel.ui:87
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutes"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:220 panels/power/cc-power-panel.ui:91
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12  minutes"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:224 panels/power/cc-power-panel.ui:95
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:228 panels/power/cc-power-panel.ui:99
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Mentu ta kali"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr ""
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid "Microphone is turned off"
+msgstr "Microphone ingpupe"
+
+#: panels/microphone/cc-microphone-panel.ui:43
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:77
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:87
+msgid "Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:107
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:37
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:75
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:94
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Ar-vi"
+
+#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Ar-eh"
+
+#: panels/mouse/cc-mouse-panel.ui:169
+msgid "Mouse"
+msgstr "Mouse"
+
+#: panels/mouse/cc-mouse-panel.ui:208
+msgid "Mouse Speed"
+msgstr "Mouse kechat"
+
+#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
+msgid "Double-click timeout"
+msgstr ""
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
+msgid "Natural Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
+msgid "Scrolling moves the content, not the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:501
+msgid "Touchpad Speed"
+msgstr "Touchpad kechat"
+
+#: panels/mouse/cc-mouse-panel.ui:560
+msgid "Tap to Click"
+msgstr "Tap lote Click lo"
+
+#: panels/mouse/cc-mouse-panel.ui:612
+msgid "Two-finger Scrolling"
+msgstr "Hini-Richemun lote Scroll lo"
+
+#: panels/mouse/cc-mouse-panel.ui:665
+msgid "Edge Scrolling"
+msgstr "Angchun Scroll"
+
+#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:436
+msgid "Test Your _Settings"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:132 panels/mouse/cc-mouse-test.ui:25
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:137
+msgid "Five clicks, GEGL time!"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:142
+msgid "Double click, primary button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:142
+msgid "Single click, primary button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:145
+msgid "Double click, middle button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:145
+msgid "Single click, middle button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:148
+msgid "Double click, secondary button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.c:148
+msgid "Single click, secondary button"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mouse pen Touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+
+#: panels/network/cc-network-panel.c:648 panels/network/cc-wifi-panel.ui:306
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/cc-network-panel.c:654
+msgid "NetworkManager needs to be running."
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:68
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:109
+#: panels/network/connection-editor/net-connection-editor.c:596
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:153
+msgid "Not set up"
+msgstr ""
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:198
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:258
+msgid "Insecure network (WEP)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:263
+msgid "Secure network (WPA)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:268
+msgid "Secure network (WPA2)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:273
+msgid "Secure network (WPA3)"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.c:278
+msgid "Secure network"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:102
+#: panels/network/net-device-ethernet.c:318
+#: panels/network/network-bluetooth.ui:76
+#: panels/network/network-ethernet.ui:102 panels/network/network-mobile.ui:414
+#: panels/network/network-vpn.ui:78
+msgid "Options…"
+msgstr ""
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:132
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:248
+msgid "Must have a minimum of 8 characters"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:458
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi Hotspot ingpu ji?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:19
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:44
+#: panels/network/network-wifi.ui:105
+msgid "Network Name"
+msgstr "Network amen"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:69
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:383
+#: panels/printers/pp-jobs-dialog.ui:70
+#: panels/user-accounts/cc-add-user-dialog.ui:249
+msgid "Password"
+msgstr "Password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:83
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:84
+msgid "Autogenerate Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:130
+msgid "_Turn On"
+msgstr "_Ingpu noi"
+
+#: panels/network/cc-wifi-panel.c:276
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:233
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:56
+msgid "Airplane Mode"
+msgstr "Airplane Mode"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Wi-Fi, Bluetooth lapen mobile broadband pamep"
+
+#: panels/network/cc-wifi-panel.ui:141
+msgid "No Wi-Fi Adapter Found"
+msgstr "Wi-Fi Adapter longle"
+
+#: panels/network/cc-wifi-panel.ui:153
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Nangli Wi-Fi adapter thon pame aphi ingpu pen langthu tha"
+
+#: panels/network/cc-wifi-panel.ui:188
+msgid "Airplane Mode On"
+msgstr "Airplane Mode do-bom"
+
+#: panels/network/cc-wifi-panel.ui:200
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:227
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:295
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:20
+msgid "802.1x _Security"
+msgstr "802.1x _Security"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:112
+#: panels/network/connection-editor/ce-page-security.c:404
+#: panels/network/connection-editor/details-page.ui:90
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr ""
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:93
+#: panels/network/net-device-wifi.c:235
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:240
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:103
+msgid "WPA3"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:109
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:115
+msgid "Enterprise"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:120
+#: panels/network/net-device-wifi.c:225
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Awe"
+
+#: panels/network/connection-editor/ce-page-details.c:141
+msgid "Never"
+msgstr "Mentu ta nangne"
+
+#: panels/network/connection-editor/ce-page-details.c:156
+#: panels/network/net-device-ethernet.c:108
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "Ni %i aphrang"
+msgstr[1] "Ni jon %i aphrang"
+
+#: panels/network/connection-editor/ce-page-details.c:281
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr ""
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:283
+#: panels/network/net-device-ethernet.c:202
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:300
+msgid "2.4 GHz / 5 GHz"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:302
+msgid "2.4 GHz"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:304
+msgid "5 GHz"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:324
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Awe"
+
+#: panels/network/connection-editor/ce-page-details.c:326
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Bi-hek"
+
+#: panels/network/connection-editor/ce-page-details.c:328
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Me-chit"
+
+#: panels/network/connection-editor/ce-page-details.c:330
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Mesen"
+
+#: panels/network/connection-editor/ce-page-details.c:332
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Me-pik"
+
+#: panels/network/connection-editor/ce-page-details.c:390
+#: panels/network/connection-editor/details-page.ui:108
+#: panels/network/net-device-ethernet.c:143
+#: panels/network/net-device-mobile.c:431
+msgid "IPv4 Address"
+msgstr "IPv4 Address"
+
+#: panels/network/connection-editor/ce-page-details.c:391
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-ethernet.c:148
+#: panels/network/net-device-mobile.c:432 panels/network/network-mobile.ui:200
+msgid "IPv6 Address"
+msgstr "IPv6 Address"
+
+#: panels/network/connection-editor/ce-page-details.c:394
+#: panels/network/connection-editor/ce-page-details.c:395
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:435
+#: panels/network/net-device-mobile.c:436 panels/network/network-mobile.ui:183
+msgid "IP Address"
+msgstr "IP Address"
+
+#: panels/network/connection-editor/ce-page-details.c:429
+msgid "Forget Connection"
+msgstr "Chepho thannoi"
+
+#: panels/network/connection-editor/ce-page-details.c:431
+msgid "Remove Connection Profile"
+msgstr "Chepho profile kethan"
+
+#: panels/network/connection-editor/ce-page-details.c:433
+msgid "Remove VPN"
+msgstr "VPN kethan"
+
+#: panels/network/connection-editor/ce-page-details.c:451
+msgid "Details"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:150
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ip4.c:268
+#: panels/network/connection-editor/ce-page-ip6.c:249
+msgid "Delete Address"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ip4.c:428
+#: panels/network/connection-editor/ce-page-ip6.c:398
+msgid "Delete Route"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-ip4.c:852
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:783
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:260
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Awe"
+
+#: panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:293
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit Passphrase"
+
+#: panels/network/connection-editor/ce-page-security.c:306
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:319
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamic WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:333
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:347
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:361
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:18
+msgid "Signal Strength"
+msgstr "Signal Jakong"
+
+#: panels/network/connection-editor/details-page.ui:54
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:144
+#: panels/network/net-device-ethernet.c:151
+msgid "Hardware Address"
+msgstr "Hardware Address"
+
+#: panels/network/connection-editor/details-page.ui:162
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:180
+#: panels/network/net-device-ethernet.c:155
+#: panels/network/network-mobile.ui:217
+msgid "Default Route"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:199
+#: panels/network/connection-editor/ip4-page.ui:211
+#: panels/network/connection-editor/ip6-page.ui:225
+#: panels/network/net-device-ethernet.c:157
+#: panels/network/network-mobile.ui:235
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:217
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:376
+msgid "Connect _automatically"
+msgstr "Meth_ang chepho phit noi"
+
+#: panels/network/connection-editor/details-page.ui:395
+msgid "Make available to _other users"
+msgstr "Kaprek m_onit/user tum san long"
+
+#: panels/network/connection-editor/details-page.ui:428
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:439
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "_Amen"
+
+#: panels/network/connection-editor/ethernet-page.ui:54
+#: panels/network/connection-editor/wifi-page.ui:67
+msgid "_MAC Address"
+msgstr "_MAC Address"
+
+#: panels/network/connection-editor/ethernet-page.ui:105
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:122
+#: panels/network/connection-editor/wifi-page.ui:102
+msgid "_Cloned Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:137
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:42
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:72 panels/network/network-proxy.ui:116
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:97
+#: panels/network/connection-editor/ip6-page.ui:111
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:125
+#: panels/network/connection-editor/ip6-page.ui:139
+msgid "Addresses"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/printers/pp-details-dialog.ui:95
+msgid "Address"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+msgid "Netmask"
+msgstr "Netmask"
+
+#: panels/network/connection-editor/ip4-page.ui:171
+#: panels/network/connection-editor/ip4-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:369
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:291
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/connection-editor/ip6-page.ui:305
+#: panels/network/net-proxy.c:74 panels/network/network-proxy.ui:106
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:234
+#: panels/network/connection-editor/ip6-page.ui:248
+msgid "Automatic DNS"
+msgstr "Automatic DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:293
+msgid "Routes"
+msgstr "Routes"
+
+#: panels/network/connection-editor/ip4-page.ui:302
+#: panels/network/connection-editor/ip6-page.ui:316
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:368
+#: panels/network/connection-editor/ip6-page.ui:382
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/network/connection-editor/ip4-page.ui:398
+#: panels/network/connection-editor/ip6-page.ui:412
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Prefix"
+msgstr "Prefix"
+
+#: panels/network/connection-editor/net-connection-editor.c:291
+msgid "Unable to open connection editor"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:307
+msgid "New Profile"
+msgstr "Profile kimi"
+
+#: panels/network/connection-editor/net-connection-editor.c:740
+msgid "Import from file…"
+msgstr ""
+
+#: panels/network/connection-editor/net-connection-editor.c:772
+msgid "Add VPN"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:20
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:139
+msgid "Cannot import VPN connection"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:173
+msgid "Select file to import"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:225
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "File amen “%s” dotang do."
+
+#: panels/network/connection-editor/vpn-helpers.c:227
+msgid "_Replace"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:229
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:264
+msgid "Cannot export VPN connection"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:266
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+
+#: panels/network/connection-editor/vpn-helpers.c:296
+msgid "Export VPN connection"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:20
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:36
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:96
+msgid "never"
+msgstr "mentu ta kali"
+
+#: panels/network/net-device-ethernet.c:104
+msgid "today"
+msgstr "pini"
+
+#: panels/network/net-device-ethernet.c:106
+msgid "yesterday"
+msgstr "atumi"
+
+#: panels/network/net-device-ethernet.c:162
+msgid "Last used"
+msgstr ""
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:252
+#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+msgid "Wired"
+msgstr "Wired"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:798
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Hotspot pasang si chepho an pen than nangji?"
+
+#: panels/network/net-device-wifi.c:801
+msgid "_Stop Hotspot"
+msgstr "_Hotspot pasang"
+
+#: panels/network/net-device-wifi.c:905
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+
+#: panels/network/net-device-wifi.c:909
+msgid "_Forget"
+msgstr "_Tene-noi"
+
+#: panels/network/net-device-wifi.c:1065 panels/network/net-device-wifi.c:1072
+msgid "Known Wi-Fi Networks"
+msgstr "Wi-Fi Networks chini-tang"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1107
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Tene-noi"
+
+#: panels/network/net-device-wifi.c:1268
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1271
+msgid "Wireless device does not support Hotspot mode"
+msgstr ""
+
+#: panels/network/net-proxy.c:70
+#: panels/notifications/cc-notifications-panel.c:267
+#: panels/power/cc-power-panel.c:2068 panels/power/cc-power-panel.c:2079
+#: panels/universal-access/cc-ua-panel.c:480
+#: panels/universal-access/cc-ua-panel.c:843
+#: panels/universal-access/cc-ua-panel.c:856
+#: panels/universal-access/cc-ua-panel.c:868
+#: panels/universal-access/cc-ua-panel.c:1033
+#: panels/universal-access/cc-ua-panel.ui:323
+#: panels/universal-access/cc-ua-panel.ui:369
+#: panels/universal-access/cc-ua-panel.ui:415
+#: panels/universal-access/cc-ua-panel.ui:521
+#: panels/universal-access/cc-ua-panel.ui:674
+#: panels/universal-access/cc-ua-panel.ui:720
+#: panels/universal-access/cc-ua-panel.ui:766
+#: panels/universal-access/cc-ua-panel.ui:950
+msgid "Off"
+msgstr ""
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:113
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:121
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#. update title
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/net-vpn.c:66 panels/network/net-vpn.c:163
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#: panels/network/network-bluetooth.ui:50
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-mobile.ui:29
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:47
+msgid "Provider"
+msgstr "Provider"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:95
+msgid "Network Proxy"
+msgstr "Network Proxy"
+
+#: panels/network/network-proxy.ui:176
+msgid "_HTTP Proxy"
+msgstr "_HTTP Proxy"
+
+#: panels/network/network-proxy.ui:195
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS Proxy"
+
+#: panels/network/network-proxy.ui:214
+msgid "_FTP Proxy"
+msgstr "_FTP Proxy"
+
+#: panels/network/network-proxy.ui:233
+msgid "_Socks Host"
+msgstr "_Socks Host"
+
+#: panels/network/network-proxy.ui:252
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:290
+msgid "HTTP proxy port"
+msgstr "HTTP proxy port"
+
+#: panels/network/network-proxy.ui:367
+msgid "HTTPS proxy port"
+msgstr "HTTPS proxy port"
+
+#: panels/network/network-proxy.ui:388
+msgid "FTP proxy port"
+msgstr "FTP proxy port"
+
+#: panels/network/network-proxy.ui:409
+msgid "Socks proxy port"
+msgstr "Socks proxy port"
+
+#: panels/network/network-proxy.ui:438
+msgid "_Configuration URL"
+msgstr "_Configuration URL"
+
+#: panels/network/network-vpn.ui:55
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:37
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi Hotspot"
+
+#: panels/network/network-wifi.ui:55
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr ""
+
+#: panels/network/network-wifi.ui:123
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:175
+msgctxt "Wi-Fi passkey"
+msgid "Password"
+msgstr "Password"
+
+#: panels/network/network-wifi.ui:264
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi pamep noi"
+
+#: panels/network/network-wifi.ui:296
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:307
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Wi-Fi Hotspot ingpu noi…"
+
+#: panels/network/network-wifi.ui:318
+msgid "_Known Wi-Fi Networks"
+msgstr "_Chini-tang Wi-Fi Networks"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Status chinine"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Chepho bomlo"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Howang nangji"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Chepho"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Chepho un-eh det"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Dail tone awe"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem longle"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr ""
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM Card thon thelang"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM Pin nangji"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM Puk nangji"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252
+msgid "SIM wrong"
+msgstr "SIM chokche"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:351
+msgid "Firmware missing"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:355
+msgid "Cable unplugged"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:195
+msgid "no file selected"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:222
+msgid "unspecified error validating eap-method file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "DER, PEM, mate PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:400
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER mate PEM certificates (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:87
+msgid "missing EAP-FAST PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:347
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:352
+msgid "PAC files (*.pac)"
+msgstr "PAC files (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Hini-ta"
+
+#: panels/network/wireless-security/eap-method-fast.ui:49
+#: panels/network/wireless-security/eap-method-peap.ui:52
+#: panels/network/wireless-security/eap-method-ttls.ui:51
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:75
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:115
+#: panels/network/wireless-security/eap-method-peap.ui:150
+#: panels/network/wireless-security/eap-method-ttls.ui:143
+msgid "_Inner authentication"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:144
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:64
+msgid "missing EAP-LEAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:73
+msgid "missing EAP-LEAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:17
+#: panels/network/wireless-security/eap-method-simple.ui:17
+#: panels/network/wireless-security/ws-leap.ui:18
+#: panels/user-accounts/cc-add-user-dialog.ui:146
+#: panels/user-accounts/cc-add-user-dialog.ui:527
+msgid "_Username"
+msgstr "_Username"
+
+#: panels/network/wireless-security/eap-method-leap.ui:31
+#: panels/network/wireless-security/eap-method-simple.ui:31
+#: panels/network/wireless-security/ws-leap.ui:32
+#: panels/network/wireless-security/ws-wpa-psk.ui:14
+#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/user-accounts/cc-add-user-dialog.ui:310
+#: panels/user-accounts/cc-add-user-dialog.ui:547
+#: panels/user-accounts/cc-user-panel.ui:385
+msgid "_Password"
+msgstr "_Password"
+
+#: panels/network/wireless-security/eap-method-leap.ui:55
+#: panels/network/wireless-security/eap-method-simple.ui:73
+#: panels/network/wireless-security/eap-method-tls.ui:157
+#: panels/network/wireless-security/ws-leap.ui:56
+#: panels/network/wireless-security/ws-wpa-psk.ui:64
+msgid "Sho_w password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:87
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:96
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:328
+#: panels/network/wireless-security/eap-method-tls.c:507
+#: panels/network/wireless-security/eap-method-ttls.c:336
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:78
+#: panels/network/wireless-security/eap-method-tls.ui:68
+#: panels/network/wireless-security/eap-method-ttls.ui:102
+msgid "C_A certificate"
+msgstr "C_A certificate"
+
+#: panels/network/wireless-security/eap-method-peap.ui:100
+#: panels/network/wireless-security/eap-method-tls.ui:90
+#: panels/network/wireless-security/eap-method-ttls.ui:125
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:118
+msgid "PEAP _version"
+msgstr "PEAP _version"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:91
+msgid "missing EAP-TLS identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:101
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:111
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:125
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:135
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:266
+msgid "Unencrypted private keys are insecure"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:269
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:500
+msgid "Choose your personal certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:514
+msgid "Choose your private key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:17
+msgid "I_dentity"
+msgstr "I_dentity"
+
+#: panels/network/wireless-security/eap-method-tls.ui:43
+msgid "_User certificate"
+msgstr "_User certificate"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "Private _key"
+msgstr "Private _key"
+
+#: panels/network/wireless-security/eap-method-tls.ui:133
+msgid "_Private key password"
+msgstr "_Private key password"
+
+#: panels/network/wireless-security/eap-method-ttls.c:98
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:106
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:76
+#: panels/user-accounts/cc-add-user-dialog.ui:507
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunneled TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Protected EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:102
+#: panels/network/wireless-security/ws-wpa-eap.ui:61
+msgid "Au_thentication"
+msgstr "Au_thentication"
+
+#: panels/network/wireless-security/ws-leap.c:65
+msgid "missing leap-username"
+msgstr ""
+
+#: panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Default)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Shared Key"
+
+#: panels/network/wireless-security/ws-wep-key.ui:48
+msgid "_Key"
+msgstr "_Key"
+
+#: panels/network/wireless-security/ws-wep-key.ui:84
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:134
+msgid "WEP inde_x"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.ui:42
+msgid "_Type"
+msgstr "_Type"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:60
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr ""
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:112
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:168
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:184
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:249
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:300
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:351
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.c:267
+#: panels/power/cc-power-panel.c:2074 panels/power/cc-power-panel.c:2081
+#: panels/universal-access/cc-ua-panel.c:480
+#: panels/universal-access/cc-ua-panel.c:843
+#: panels/universal-access/cc-ua-panel.c:856
+#: panels/universal-access/cc-ua-panel.c:868
+#: panels/universal-access/cc-ua-panel.c:1033
+msgid "On"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:70
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:121
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Banner;Message;Tray;Popup;"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:150
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Kaprek"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:627
+#, c-format
+msgid "%s Account"
+msgstr "%s Account"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:924
+msgid "Error removing account"
+msgstr ""
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:991
+#, c-format
+msgid "%s removed"
+msgstr "%s musi-lo"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Online Accounts"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:54
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/online-accounts.ui:96
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/online-accounts.ui:111
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/online-accounts.ui:136
+msgid "Add an account"
+msgstr "Account thap noi"
+
+#: panels/online-accounts/online-accounts.ui:243
+msgid "Remove Account"
+msgstr "Account than noi"
+
+#: panels/power/cc-power-panel.c:331
+msgid "Unknown time"
+msgstr "Apor chinine"
+
+#: panels/power/cc-power-panel.c:337
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-power-panel.c:349
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "porphai %i"
+msgstr[1] "Jon porphai %i"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-power-panel.c:357
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-power-panel.c:358
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "porphai"
+msgstr[1] "jon porphai"
+
+#: panels/power/cc-power-panel.c:359
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:377
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s charge plengji aphan dolang"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:384
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Caution: %s an ved-lo"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:389
+#, c-format
+msgid "%s remaining"
+msgstr "%s an ved-lo"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:394 panels/power/cc-power-panel.c:424
+msgid "Fully charged"
+msgstr "Charge plenglo"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:398 panels/power/cc-power-panel.c:428
+msgid "Not charging"
+msgstr "Che charge-che"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:402 panels/power/cc-power-panel.c:432
+msgid "Empty"
+msgstr "Angse"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:415
+msgid "Charging"
+msgstr "Charge-bom"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:420
+msgid "Discharging"
+msgstr "Charge cherui bom"
+
+#: panels/power/cc-power-panel.c:553
+msgctxt "Battery name"
+msgid "Main"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:555
+msgctxt "Battery name"
+msgid "Extra"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:630
+msgid "Wireless mouse"
+msgstr "Ari-awe mouse"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:633
+msgid "Wireless keyboard"
+msgstr "Ari-awe keyboard"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:636
+msgid "Uninterruptible power supply"
+msgstr "Uninterruptible power supply"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:639
+msgid "Personal digital assistant"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:642
+msgid "Cellphone"
+msgstr "Sepalar"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:645
+msgid "Media player"
+msgstr "Media player"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:648 panels/wacom/cc-wacom-panel.c:809
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:651
+msgid "Computer"
+msgstr "Computer"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:654
+msgid "Gaming input device"
+msgstr ""
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-power-panel.c:657 panels/power/cc-power-panel.c:939
+#: panels/power/cc-power-panel.c:2425
+msgid "Battery"
+msgstr "Battery"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:718
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Charge-bom"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:725
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Chere tha"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:730
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Bihek"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:735
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Mesen"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:740
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Charge pleng-lo"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:744
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Angse"
+
+#: panels/power/cc-power-panel.c:937
+msgid "Batteries"
+msgstr "Batteries"
+
+#: panels/power/cc-power-panel.c:1378
+msgid "When _idle"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1829
+msgid "Power Saving"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1863
+msgid "_Screen Brightness"
+msgstr "_Screen atur"
+
+#: panels/power/cc-power-panel.c:1884
+msgid "Automatic Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1897
+msgid "_Keyboard Brightness"
+msgstr "_Keyboard atur"
+
+#: panels/power/cc-power-panel.c:1908
+msgid "_Dim Screen When Inactive"
+msgstr "_Jongsi Inactive pu lote screen atur pabi noi"
+
+#: panels/power/cc-power-panel.c:1926
+msgid "_Blank Screen"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1949
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: panels/power/cc-power-panel.c:1950
+msgid "Wi-Fi can be turned off to save power."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1966
+msgid "_Mobile Broadband"
+msgstr "_Mobile Broadband"
+
+#: panels/power/cc-power-panel.c:1967
+msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2017
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: panels/power/cc-power-panel.c:2018
+msgid "Bluetooth can be turned off to save power."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2070
+msgid "When on battery power"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2072
+msgid "When plugged in"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2166
+msgid "Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2167
+msgid "Power Off"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2168
+msgid "Hibernate"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2169
+msgid "Nothing"
+msgstr ""
+
+#. Frame header
+#: panels/power/cc-power-panel.c:2269
+msgid "Suspend & Power Button"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2310
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2311
+msgid "Automatic suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2369
+msgid "Po_wer Button Action"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:13
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:17
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:21
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:25
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:29
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:33
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "Porphai 1"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:37
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:41
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:45
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutes"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:49
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "Porphai 2"
+
+#: panels/power/cc-power-panel.ui:147
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:172
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:188
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:233 panels/power/cc-power-panel.ui:293
+#: panels/universal-access/cc-ua-panel.ui:1527
+msgid "Delay"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "Authenticate"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/new-printer-dialog.ui:362
+#: panels/printers/pp-jobs-dialog.ui:57
+msgid "Username"
+msgstr "Username"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:337
+msgid "Authentication Required"
+msgstr "Howang nangji"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:699
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Printer “%s” than ed-lo"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:922
+msgid "Failed to add new printer."
+msgstr "Printer kimi thon un-eh det."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1216
+#, c-format
+msgid "Could not load ui: %s"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Printers"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:363
+#: panels/printers/pp-new-printer-dialog.c:427
+msgid "Add Printer"
+msgstr "Printer kimi kethon"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:211
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:284
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:353
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:75
+#: panels/printers/pp-details-dialog.c:370
+#, c-format
+msgid "%s Details"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:122
+msgid "No suitable driver found"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:249
+msgid "Select PPD File"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.c:258
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "Adim"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:122
+#: panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:162
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:183
+msgid "Search for Drivers"
+msgstr "Drivers kiri"
+
+#: panels/printers/pp-details-dialog.ui:192
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:201
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/cc-avatar-chooser.c:109
+msgid "Select"
+msgstr "Chongvai"
+
+#: panels/printers/ppd-selection-dialog.ui:73
+msgid "Loading drivers database…"
+msgstr ""
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:479
+msgid "JetDirect Printer"
+msgstr "JetDirect Printer"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:714
+msgid "LPD Printer"
+msgstr "LPD Printer"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:65
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "I-hin anchot"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:67
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr ""
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:69
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:71
+msgid "Portrait"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:73
+msgid "Landscape"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:75
+msgid "Reverse landscape"
+msgstr ""
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:77
+msgid "Reverse portrait"
+msgstr ""
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-jobs-dialog.c:222
+msgctxt "print job"
+msgid "Pending"
+msgstr ""
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-jobs-dialog.c:228
+msgctxt "print job"
+msgid "Paused"
+msgstr ""
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-jobs-dialog.c:233
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Howang nangji"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-jobs-dialog.c:238
+msgctxt "print job"
+msgid "Processing"
+msgstr "Klem bomlo"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-jobs-dialog.c:242
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Sang-kok"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-jobs-dialog.c:246
+msgctxt "print job"
+msgid "Canceled"
+msgstr ""
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-jobs-dialog.c:250
+msgctxt "print job"
+msgid "Aborted"
+msgstr ""
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-jobs-dialog.c:254
+msgctxt "print job"
+msgid "Completed"
+msgstr "Tang ed-lo"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:363
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:520
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr ""
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:524
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:44
+msgid "Domain"
+msgstr "Domain"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:129
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:169
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:232
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:358
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:380
+msgid "Unlock Print Server"
+msgstr ""
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:384
+#, c-format
+msgid "Unlock %s."
+msgstr ""
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:388
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:838
+msgid "Searching for Printers"
+msgstr ""
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1697
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1702
+msgid "Serial Port"
+msgstr "Serial Port"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1709
+msgid "Parallel Port"
+msgstr "Parallel Port"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1751
+#, c-format
+msgid "Location: %s"
+msgstr ""
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1756
+#, c-format
+msgid "Address: %s"
+msgstr ""
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1783
+msgid "Server requires authentication"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:91
+msgid "Two Sided"
+msgstr "Hini-hin"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "Paper Type"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:93
+msgid "Paper Source"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:94
+msgid "Output Tray"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:95
+msgctxt "printing option"
+msgid "Resolution"
+msgstr ""
+
+#: panels/printers/pp-options-dialog.c:96
+msgid "GhostScript pre-filtering"
+msgstr ""
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:534
+msgid "Pages per side"
+msgstr ""
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:546
+msgid "Two-sided"
+msgstr "Hini-hin"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:558
+msgid "Orientation"
+msgstr ""
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr ""
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr ""
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr ""
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr ""
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr ""
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Alir"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr ""
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:676
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr ""
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:869
+#: panels/printers/pp-options-dialog.ui:18
+msgid "Test Page"
+msgstr "Sat-lang alo"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:882
+msgid "Test page"
+msgstr "Sat-lang alo"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr ""
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr ""
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr ""
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "Bonda-atum"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:594 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr ""
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:599
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u sai klembom"
+msgstr[1] "Son %u sai klembom"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:745
+msgid "Low on toner"
+msgstr "Toner bet-so vedlo"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:747
+msgid "Out of toner"
+msgstr "TOner angse lo"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:750
+msgid "Low on developer"
+msgstr ""
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:753
+msgid "Out of developer"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:755
+msgid "Low on a marker supply"
+msgstr ""
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:757
+msgid "Out of a marker supply"
+msgstr ""
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:759
+msgid "Open cover"
+msgstr ""
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:761
+msgid "Open door"
+msgstr ""
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:763
+msgid "Low on paper"
+msgstr "Lo achet bet-so lo"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:765
+msgid "Out of paper"
+msgstr "Lo ik lo"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:767
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Offline"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:769
+#: panels/printers/pp-printer-entry.c:897
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Sang-kok"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:771
+msgid "Waste receptacle almost full"
+msgstr ""
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:773
+msgid "Waste receptacle full"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:775
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:777
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:883
+msgctxt "printer state"
+msgid "Ready"
+msgstr ""
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:888
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr ""
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:893
+msgctxt "printer state"
+msgid "Processing"
+msgstr ""
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:917
+msgid "Clean print heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr ""
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "Printer ke-hek"
+
+#: panels/printers/printer-entry.ui:193
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:312
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:319
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:8
+msgid "Add…"
+msgstr "Akimi kethon…"
+
+#: panels/printers/printers.ui:174
+msgid "No printers"
+msgstr "Printers awe"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:188
+msgid "Add a Printer…"
+msgstr "Printer thontha…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:220
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.c:148
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-chooser.c:150
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/region/cc-format-chooser.c:255 panels/region/cc-format-chooser.c:296
+#: panels/region/cc-format-chooser.ui:6
+msgid "Formats"
+msgstr "Formats"
+
+#: panels/region/cc-format-chooser.ui:48 panels/wacom/wacom-stylus-page.ui:37
+#: shell/cc-window.ui:232
+msgid "Back"
+msgstr "Aphi"
+
+#: panels/region/cc-format-chooser.ui:103
+msgid ""
+"Choose the format for numbers, dates and currencies. Changes take effect on "
+"next login."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:119
+msgid "Search locales..."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:160
+msgid "Common Formats"
+msgstr "Common Formats"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "All Formats"
+msgstr "Kado-kawe Formats"
+
+#: panels/region/cc-format-chooser.ui:244
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:257
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:309
+msgid "Preview"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:324
+msgid "Dates"
+msgstr "Arni"
+
+#: panels/region/cc-format-chooser.ui:368
+msgid "Dates & Times"
+msgstr "Arni pen Apor"
+
+#: panels/region/cc-format-chooser.ui:390
+msgid "Numbers"
+msgstr "Lakha"
+
+#: panels/region/cc-format-chooser.ui:412
+msgid "Measurement"
+msgstr "Pun"
+
+#: panels/region/cc-format-chooser.ui:434
+msgid "Paper"
+msgstr "Lo"
+
+#: panels/region/cc-input-chooser.c:193
+msgid "No input sources found"
+msgstr ""
+
+#: panels/region/cc-input-chooser.c:948
+msgctxt "Input Source"
+msgid "Other"
+msgstr ""
+
+#: panels/region/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/region/cc-input-chooser.ui:77
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/region/cc-region-panel.c:1507
+msgid "Login _Screen"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:64
+#: panels/user-accounts/cc-user-panel.ui:313
+msgid "_Language"
+msgstr "_Lam"
+
+#: panels/region/cc-region-panel.ui:99
+msgid "Restart the session for changes to take effect"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:114
+msgid "Restart…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:147
+msgid "_Formats"
+msgstr "_Formats"
+
+#: panels/region/cc-region-panel.ui:195
+msgid "Input Sources"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:209
+msgid "Choose keyboard layouts or input methods."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:266
+msgid "No input source selected"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:300
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:337
+msgid "Input Source Options"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:352
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:370
+msgid "Allow _different sources for each window"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:412
+msgid "Previous source"
+msgstr "Aphrang source"
+
+#: panels/region/cc-region-panel.ui:430
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: panels/region/cc-region-panel.ui:445
+msgid "Next source"
+msgstr "Adun source"
+
+#: panels/region/cc-region-panel.ui:463
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: panels/region/cc-region-panel.ui:478
+msgid "Left+Right Alt"
+msgstr "Left+Right Alt"
+
+#: panels/region/cc-region-panel.ui:494
+msgid "These keyboard shortcuts can be changed in the keyboard settings"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Dang lapen Lam"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:267
+msgid "Ask what to do"
+msgstr "Arju ver noi"
+
+#: panels/removable-media/cc-removable-media-panel.c:271
+msgid "Do nothing"
+msgstr "Jat-ta klem nangne"
+
+#: panels/removable-media/cc-removable-media-panel.c:275
+msgid "Open folder"
+msgstr "Folder ingpu noi"
+
+#: panels/removable-media/cc-removable-media-panel.c:341
+msgid "Other Media"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:362
+msgid "Select an application for audio CDs"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:363
+msgid "Select an application for video DVDs"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:364
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:365
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.c:366
+msgid "Select an application for software CDs"
+msgstr ""
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "audio DVD"
+msgstr "audio DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "blank Blu-ray disc"
+msgstr "blank Blu-ray disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:380
+msgid "blank CD disc"
+msgstr "blank CD disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:381
+msgid "blank DVD disc"
+msgstr "blank DVD disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:382
+msgid "blank HD DVD disc"
+msgstr "blank HD DVD disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:383
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:384
+msgid "e-book reader"
+msgstr "e-book reader"
+
+#: panels/removable-media/cc-removable-media-panel.c:385
+msgid "HD DVD video disc"
+msgstr "HD DVD video disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:386
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:387
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:388
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:389
+msgid "Windows software"
+msgstr "Windows software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:44
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:75
+msgid "CD _audio"
+msgstr "CD _audio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:92
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:133
+msgid "_Music player"
+msgstr "_Music player"
+
+#: panels/removable-media/cc-removable-media-panel.ui:191
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:229
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:288
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:342
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:389
+msgid "_Action:"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:412
+msgid "_Type:"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+
+#: panels/search/cc-search-locations-dialog.c:635
+msgid "Select Location"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.c:639
+msgid "_OK"
+msgstr "_Chok"
+
+#: panels/search/cc-search-locations-dialog.ui:9
+#: panels/search/cc-search-panel.ui:61
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:32
+#: panels/search/cc-search-locations-dialog.ui:69
+#: panels/search/cc-search-locations-dialog.ui:107
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:91
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:156
+msgid "Other"
+msgstr "Kaprek"
+
+#: panels/search/cc-search-panel.c:152
+msgid "No applications found"
+msgstr ""
+
+#: panels/search/cc-search-panel-row.ui:92
+msgid "Move Up"
+msgstr "Angsong parlu"
+
+#: panels/search/cc-search-panel-row.ui:102
+msgid "Move Down"
+msgstr "Aber pasun"
+
+#: panels/search/cc-search-panel.ui:33
+msgid ""
+"Control which search results are shown in the Activities Overview. The order "
+"of search results can also be changed by moving rows in the list."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:307
+msgid "No networks selected for sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:19
+msgid "Networks"
+msgstr "Networks"
+
+#: panels/sharing/cc-sharing-panel.c:302
+msgctxt "service is enabled"
+msgid "On"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:304 panels/sharing/cc-sharing-panel.c:331
+msgctxt "service is disabled"
+msgid "Off"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:334
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:337
+msgctxt "service is active"
+msgid "Active"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:407
+msgid "Choose a Folder"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:711
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:717
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+
+#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:723
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to %s"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:828
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.c:1279
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:34
+msgid "_Computer Name"
+msgstr "_Computer Amen"
+
+#: panels/sharing/cc-sharing-panel.ui:94
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:139
+msgid "_Screen Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:184
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:229
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:268
+msgid "Some services are disabled because of no network access."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:286
+#: panels/sharing/cc-sharing-panel.ui:413
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:333
+msgid "_Require Password"
+msgstr "_Password nangji"
+
+#: panels/sharing/cc-sharing-panel.ui:424
+#: panels/sharing/cc-sharing-panel.ui:494
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:517
+#: panels/sharing/cc-sharing-panel.ui:763
+msgid "Screen Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:575
+msgid "_Allow connections to control the screen"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:620
+msgid "_Password:"
+msgstr "_Password:"
+
+#: panels/sharing/cc-sharing-panel.ui:650
+msgid "_Show Password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:681
+msgid "Access Options"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:695
+msgid "_New connections must ask for access"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:713
+msgid "_Require a password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:774
+#: panels/sharing/cc-sharing-panel.ui:868
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:807
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:822
+msgid "Folders"
+msgstr "Folders"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.c:151
+msgid "Custom"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12 panels/sound/cc-alert-selector.ui:9
+msgid "Bark"
+msgstr "Kang-uk"
+
+#: panels/sound/cc-alert-chooser.ui:19 panels/sound/cc-alert-selector.ui:15
+msgid "Drip"
+msgstr "Charchim"
+
+#: panels/sound/cc-alert-chooser.ui:26 panels/sound/cc-alert-selector.ui:21
+msgid "Glass"
+msgstr "Bilor"
+
+#: panels/sound/cc-alert-chooser.ui:33 panels/sound/cc-alert-selector.ui:27
+msgid "Sonar"
+msgstr "Sonar"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "Aphi"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "Ang-no"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:127
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:29
+msgid "System Volume"
+msgstr "System ase"
+
+#: panels/sound/cc-sound-panel.ui:45
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:67
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:94
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:117
+msgid "Test"
+msgstr "Ase-kelang"
+
+#: panels/sound/cc-sound-panel.ui:148 panels/sound/cc-sound-panel.ui:325
+msgid "Configuration"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:181
+msgid "Balance"
+msgstr "Balance"
+
+#: panels/sound/cc-sound-panel.ui:208
+msgid "Fade"
+msgstr "Fade"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:257
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:284
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:358
+msgid "Volume"
+msgstr "Seh"
+
+#: panels/sound/cc-sound-panel.ui:380
+msgid "Alert Sound"
+msgstr ""
+
+#: panels/sound/cc-volume-slider.c:115
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Seh"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:94
+#: panels/thunderbolt/cc-bolt-device-entry.c:125
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:97
+#: panels/thunderbolt/cc-bolt-device-entry.c:128
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:100
+#: panels/thunderbolt/cc-bolt-device-entry.c:132
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:103
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:106
+#: panels/thunderbolt/cc-bolt-device-entry.c:138
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:115
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:121
+#: panels/thunderbolt/cc-bolt-device-entry.c:152
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Chinine"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:177
+msgid "Authorized at:"
+msgstr "Hovang adim:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:183
+msgid "Connected at:"
+msgstr "Chepho adim:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:190
+msgid "Enrolled at:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:264
+msgid "Failed to authorize device: "
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:333
+msgid "Failed to forget device: "
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+msgid "Name:"
+msgstr "Amen:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "Status:"
+msgstr "Status:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:135
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:146
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:175
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:468
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:512
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:516
+msgid "Thunderbolt security level could not be determined."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:621
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:143
+msgid "No Thunderbolt support"
+msgstr "Thunderbolt support pe"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:246
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:269
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:289
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:397
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:535
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;"
+msgstr "Thunderbolt;"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:500
+msgctxt "cursor size"
+msgid "Default"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.c:503
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Achetim"
+
+#: panels/universal-access/cc-ua-panel.c:506
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Kethe"
+
+#: panels/universal-access/cc-ua-panel.c:509
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Kethe-dun"
+
+#: panels/universal-access/cc-ua-panel.c:512
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Kethe-nei"
+
+#: panels/universal-access/cc-ua-panel.c:516
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/universal-access/cc-ua-panel.ui:78
+msgid "_Always Show Universal Access Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:120
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:213
+msgid "_Large Text"
+msgstr "_Amek-akhor kethe"
+
+#: panels/universal-access/cc-ua-panel.ui:258
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:305
+#: panels/universal-access/zoom-options.ui:99
+msgid "_Zoom"
+msgstr "_Pathe-bi"
+
+#: panels/universal-access/cc-ua-panel.ui:351
+msgid "Screen _Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:397
+#: panels/universal-access/cc-ua-panel.ui:1263
+msgid "_Sound Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:459
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:503
+#: panels/universal-access/cc-ua-panel.ui:1366
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:611
+msgid "Screen _Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:656
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:702
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:748
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:809
+msgid "Pointing & Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:855
+msgid "_Mouse Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:900
+msgid "_Locate Pointer"
+msgstr "Printer ke-ri"
+
+#: panels/universal-access/cc-ua-panel.ui:932
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:978
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:998
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1068
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1095
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1131
+msgid "Screen Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1148
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1181
+msgid "_Screen Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1220
+msgid "Sound Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1238
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1308
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1312
+msgid "_Test flash"
+msgstr "_Flash kelang"
+
+#: panels/universal-access/cc-ua-panel.ui:1341
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1392
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1410
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1455
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1485
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1565
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1613
+#: panels/universal-access/cc-ua-panel.ui:1748
+msgid "Speed"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1652
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1676
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1706
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1785
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1821
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1860
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1877
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1901
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1919
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1967
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1984
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2017
+#: panels/universal-access/cc-ua-panel.ui:2230
+#: panels/universal-access/cc-ua-panel.ui:2567
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2039
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Thi-hek"
+
+#: panels/universal-access/cc-ua-panel.ui:2058
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2073
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Ding-hoi"
+
+#: panels/universal-access/cc-ua-panel.ui:2100
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2117
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2134
+#: panels/universal-access/cc-ua-panel.ui:2313
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2180
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2197
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2252
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Thi-hek"
+
+#: panels/universal-access/cc-ua-panel.ui:2271
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2286
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Ding-hoi"
+
+#: panels/universal-access/cc-ua-panel.ui:2399
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2416
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2480
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2516
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2534
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2588
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Thi-hek"
+
+#: panels/universal-access/cc-ua-panel.ui:2607
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2622
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Ding-hoi"
+
+#: panels/universal-access/cc-ua-panel.ui:2679
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2697
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2730
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2752
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Thi-hek"
+
+#: panels/universal-access/cc-ua-panel.ui:2783
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Ding-hoi"
+
+#: panels/universal-access/cc-ua-panel.ui:2819
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:2841
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Bi-hek"
+
+#: panels/universal-access/cc-ua-panel.ui:2872
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "The-dung"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
+"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
+"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
+"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
+"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+
+#: panels/universal-access/zoom-options.c:305
+msgctxt "Distance"
+msgid "Short"
+msgstr "Thi-hek"
+
+#: panels/universal-access/zoom-options.c:306
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr ""
+
+#: panels/universal-access/zoom-options.c:307
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr ""
+
+#: panels/universal-access/zoom-options.c:308
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr ""
+
+#: panels/universal-access/zoom-options.c:309
+msgctxt "Distance"
+msgid "Long"
+msgstr "Ding-hoi"
+
+#: panels/universal-access/zoom-options.ui:48
+msgid "Full Screen"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:53
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:58
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:63
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:68
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:78
+msgid "Zoom Options"
+msgstr "The-bi Options"
+
+#: panels/universal-access/zoom-options.ui:185
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:249
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:269
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:331
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:350
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:370
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:390
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:425
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:446
+msgid "Magnifier"
+msgstr "Magnifier"
+
+#: panels/universal-access/zoom-options.ui:493
+msgid "_Thickness:"
+msgstr "_Kangtheng:"
+
+#: panels/universal-access/zoom-options.ui:519
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:551
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Ingteng"
+
+#: panels/universal-access/zoom-options.ui:577
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/zoom-options.ui:626
+msgid "Co_lor:"
+msgstr "A_lir:"
+
+#: panels/universal-access/zoom-options.ui:690
+msgid "_Crosshairs:"
+msgstr "_Crosshairs:"
+
+#: panels/universal-access/zoom-options.ui:738
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:776
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:825
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:845
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:866
+msgid "_Contrast:"
+msgstr "_Contrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/zoom-options.ui:886
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "A_lir"
+
+#: panels/universal-access/zoom-options.ui:911
+msgctxt "universal access, color"
+msgid "None"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:943
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:1006
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Kom"
+
+#: panels/universal-access/zoom-options.ui:1039
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Do-pik"
+
+#: panels/universal-access/zoom-options.ui:1070
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Kom"
+
+#: panels/universal-access/zoom-options.ui:1103
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Do-pik"
+
+#: panels/universal-access/zoom-options.ui:1139
+msgid "Color Effects:"
+msgstr "Alir Effects:"
+
+#: panels/universal-access/zoom-options.ui:1164
+msgid "Color Effects"
+msgstr "Alir Effects"
+
+#: panels/usage/cc-usage-panel.c:155
+msgid "Empty all items from Trash?"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:156
+msgid "All items in the Trash will be permanently deleted."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:157
+msgid "_Empty Trash"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:178
+msgid "Delete all the temporary files?"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:179
+msgid "All the temporary files will be permanently deleted."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "_Purge Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:31
+msgid "File History"
+msgstr "File History"
+
+#: panels/usage/cc-usage-panel.ui:43
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:58
+msgid "File H_istory"
+msgstr "File H_istory"
+
+#: panels/usage/cc-usage-panel.ui:80
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:121
+msgid "_Clear History…"
+msgstr "_History Musi"
+
+#: panels/usage/cc-usage-panel.ui:137
+msgid "Trash & Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:147
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:161
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:176
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:198
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:240
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:252
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:280
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "Porphai 1"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:284
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "Ni 1"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:288
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "Ni 2"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:292
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "Ni 3"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:296
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "Ni 4"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:300
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "Ni 5"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:304
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "Ni 6"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:308
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "Ni 7"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:312
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "Ni 14"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:316
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "Ni 30"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:331
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "Ni 1"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:335
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "Ni 7"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:339
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "Ni 30"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:343
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Kaike"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "Nangli login kipu atum web address pen homan nangji."
+
+#: panels/user-accounts/cc-add-user-dialog.c:205
+msgid "Failed to add account"
+msgstr "Account thap un-eh"
+
+#: panels/user-accounts/cc-add-user-dialog.c:676
+#: panels/user-accounts/cc-password-dialog.c:261
+msgid "The passwords do not match."
+msgstr "Passwords homan me."
+
+#: panels/user-accounts/cc-add-user-dialog.c:898
+#: panels/user-accounts/cc-add-user-dialog.c:944
+#: panels/user-accounts/cc-add-user-dialog.c:965
+msgid "Failed to register account"
+msgstr "Account register un-eh det"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1088
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1161
+msgid "Failed to join domain"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1222
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1229
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1237
+msgid "Failed to log into domain"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.c:1295
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "User akimi"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:180
+msgid "_Full Name"
+msgstr "_Men keding"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:206
+msgid "Standard"
+msgstr "Standard"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:216
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:232
+msgid "Account _Type"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:269
+msgid "Allow user to set a password when they next _login"
+msgstr "_Login cheng ahut password amethang pa selam nang"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:283
+msgid "Set a password _now"
+msgstr "_Non password bi-noi"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:405
+msgid "_Confirm"
+msgstr "_Confirm"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:485
+#: panels/user-accounts/cc-add-user-dialog.ui:692
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:732
+msgid "You are Offline"
+msgstr "Nangli Offline"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:751
+msgid "You must be online in order to add enterprise users."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:782
+msgid "_Enterprise Login"
+msgstr "_Enterprise Login"
+
+#: panels/user-accounts/cc-avatar-chooser.c:232
+msgid "Browse for more pictures"
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:39
+msgid "Take a Picture…"
+msgstr "Arjan ke-nep…"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:46
+msgid "Select a File…"
+msgstr "File chongvai…"
+
+#: panels/user-accounts/cc-login-history-dialog.c:69
+msgid "This Week"
+msgstr "Laso Rui"
+
+#: panels/user-accounts/cc-login-history-dialog.c:72
+msgid "Last Week"
+msgstr "Achu Rui"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:82
+#: panels/user-accounts/cc-login-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:91
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:96
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:173
+#: panels/user-accounts/cc-user-panel.c:766
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:176
+#: panels/user-accounts/cc-user-panel.c:770
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:243
+msgid "Session Ended"
+msgstr "Session kejut"
+
+#: panels/user-accounts/cc-login-history-dialog.c:249
+msgid "Session Started"
+msgstr "Session pangcheng"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:343
+#, c-format
+msgid "%s — Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.c:125
+msgid "Please choose another password."
+msgstr "Choningri pen kaprek password chongvai ik-tha."
+
+#: panels/user-accounts/cc-password-dialog.c:134
+msgid "Please type your current password again."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.c:140
+msgid "Password could not be changed"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:7
+msgid "Change Password"
+msgstr "Password kelar"
+
+#: panels/user-accounts/cc-password-dialog.ui:37
+msgid "Ch_ange"
+msgstr "Kel_ar"
+
+#: panels/user-accounts/cc-password-dialog.ui:145
+msgid "_Confirm New Password"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:162
+msgid "_New Password"
+msgstr "_Kimi Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:216
+msgid "Current _Password"
+msgstr "Non dobom _Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:254
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:267
+msgid "Set a password now"
+msgstr "Password selam ik-tha non"
+
+#: panels/user-accounts/cc-realm-manager.c:307
+msgid "Cannot automatically join this type of domain"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:310
+msgid "No such domain or realm found"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:732
+#: panels/user-accounts/cc-realm-manager.c:746
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:738
+msgid "Invalid password, please try again"
+msgstr ""
+
+#: panels/user-accounts/cc-realm-manager.c:751
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:209
+msgid "Your account"
+msgstr "Nangli account"
+
+#: panels/user-accounts/cc-user-panel.c:384
+msgid "Failed to delete user"
+msgstr "User than un-eh det"
+
+#: panels/user-accounts/cc-user-panel.c:442
+#: panels/user-accounts/cc-user-panel.c:501
+#: panels/user-accounts/cc-user-panel.c:553
+msgid "Failed to revoke remotely managed user"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:605
+msgid "You cannot delete your own account."
+msgstr "Nangli methang account chethan un-eh."
+
+#: panels/user-accounts/cc-user-panel.c:614
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s login bomlang"
+
+#: panels/user-accounts/cc-user-panel.c:618
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:627
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:631
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:634
+msgid "_Delete Files"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:635
+msgid "_Keep Files"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:649
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:653
+msgid "_Delete"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:703
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:711
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:714
+msgctxt "Password mode"
+msgid "None"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:759
+msgid "Logged in"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1137
+msgid "Failed to contact the accounts service"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1139
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/cc-user-panel.c:1171
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1244
+msgid "Create a user account"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1255
+#: panels/user-accounts/cc-user-panel.c:1383
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1264
+msgid "Delete the selected user account"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1276
+#: panels/user-accounts/cc-user-panel.c:1387
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:5
+msgid "_Add User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:52
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:60
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:146
+#: panels/user-accounts/cc-user-panel.ui:162
+msgid "User Icon"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Settings"
+msgstr "Account Settings"
+
+#: panels/user-accounts/cc-user-panel.ui:265
+msgid "_Administrator"
+msgstr "_Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:285
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:359
+msgid "Authentication & Login"
+msgstr "Au_thentication lapen Login"
+
+#: panels/user-accounts/cc-user-panel.ui:428
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:470
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:500
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:541
+msgid "Remove User…"
+msgstr "Amen kethan…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:580
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:590
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/account-fingerprint.ui:12
+msgid "Left thumb"
+msgstr "Ar-vi Rimunpo"
+
+#: panels/user-accounts/data/account-fingerprint.ui:15
+msgid "Left middle finger"
+msgstr "Ar-vi angbong Ri-chimun"
+
+#: panels/user-accounts/data/account-fingerprint.ui:18
+msgid "Left ring finger"
+msgstr "Ar-vi arnan Ri-chimun"
+
+#: panels/user-accounts/data/account-fingerprint.ui:21
+msgid "Left little finger"
+msgstr "Ar-vi Ri-munso"
+
+#: panels/user-accounts/data/account-fingerprint.ui:24
+msgid "Right thumb"
+msgstr "Ar-eh Ri-munpo"
+
+#: panels/user-accounts/data/account-fingerprint.ui:27
+msgid "Right middle finger"
+msgstr "Ar-eh angbong Ri-munpi"
+
+#: panels/user-accounts/data/account-fingerprint.ui:30
+msgid "Right ring finger"
+msgstr "Ar-eh arnan Ri-munpi"
+
+#: panels/user-accounts/data/account-fingerprint.ui:33
+msgid "Right little finger"
+msgstr "Ar-eh Ri-munso"
+
+#: panels/user-accounts/data/account-fingerprint.ui:39
+#: panels/user-accounts/um-fingerprint-dialog.c:676
+msgid "Enable Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/data/account-fingerprint.ui:89
+msgid "_Right index finger"
+msgstr "A_r-eh Ri-munjong"
+
+#: panels/user-accounts/data/account-fingerprint.ui:105
+msgid "_Left index finger"
+msgstr "_Ar-vi Ri-munjong"
+
+#: panels/user-accounts/data/account-fingerprint.ui:126
+msgid "_Other finger:"
+msgstr "_Kaprek Ri-chimun:"
+
+#: panels/user-accounts/data/account-fingerprint.ui:324
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Users"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Monit men kethap kethan lapen password kelar"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Login;Amen;Fingerprint;Avatar;Logo;Arje;Password;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "Domain Administrator Login"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "Administrator Ame_n"
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "Administrator Password"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Monit accounts kerim"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Akimi password aban pen prek nangji."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Amek pen lakha lar si lang tha."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Ephong password lar si langtha."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Password long user amen thap dunde lote password jakong ong chet po."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Nangli men password long thapthe det si meji."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Password amek bi dunde te mesen ji."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Hodai amek bi dunde si keme."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Bor-e pen lakha pa ong tha."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Bor-e pen amek-kethe pa-ong tha."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Bor-e pen amek-so pa-ong tha."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Bor-e pen amek cherui re det tha."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Bor-e pen ajang amek 1234 mate abcd bi be det si keme."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Password ding nanglang. Bor-e pen amek, lakha lapen punctuation pa ong-tha."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Amek-kethe kibi pangvui pen lakha isi hini thap dun se keme."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Amek, lakha lapen punctiontion thap dun lote password jakong ong po."
+
+#: panels/user-accounts/run-passwd.c:424
+msgid "Authentication failed"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The new password is too short"
+msgstr "Akimi password thi ongchet"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password is too simple"
+msgstr "Akimi password joi ong"
+
+#: panels/user-accounts/run-passwd.c:516
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Akimi pen aban password homan kei-kei"
+
+#: panels/user-accounts/run-passwd.c:519
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Akimi password achu lom het si rim tang lang."
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Akimi password long numeric or special characters do nangji"
+
+#: panels/user-accounts/run-passwd.c:526
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Akimi pen aban password homan"
+
+#: panels/user-accounts/run-passwd.c:530
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+
+#: panels/user-accounts/run-passwd.c:534
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Akimi password long kaprek-kaprek amek betso jai"
+
+#: panels/user-accounts/run-passwd.c:538
+#, c-format
+msgid "Unknown error"
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Enabled"
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:259
+msgid "Delete registered fingerprints?"
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:269
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:439
+msgid "Done!"
+msgstr "Chunlo!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:500
+#: panels/user-accounts/um-fingerprint-dialog.c:542
+#, c-format
+msgid "Could not access “%s” device"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:583
+#, c-format
+msgid "Could not start finger capture on “%s” device"
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:627
+msgid "Could not access any fingerprint readers"
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:628
+msgid "Please contact your system administrator for help."
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: panels/user-accounts/um-fingerprint-dialog.c:710
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the “%s” device."
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:717
+msgid "Selecting finger"
+msgstr ""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:718
+msgid "Enrolling fingerprints"
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:439
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:443
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Laso user amen kaprek rim tang lo. Choningri pen kaprek chongvai thu noi."
+
+#: panels/user-accounts/user-utils.c:488
+msgid "The username is too long."
+msgstr "Laso username ding ong chet-lo."
+
+#: panels/user-accounts/user-utils.c:550
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:61
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:78
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.c:249
+#, c-format
+msgid "Button %d"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr ""
+
+#: panels/wacom/cc-wacom-mapping-panel.c:249
+msgid "Output:"
+msgstr ""
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:261
+msgid "Keep aspect ratio (letterbox):"
+msgstr ""
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:272
+msgid "Map to single monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-nav-button.c:84
+#, c-format
+msgid "%d of %d"
+msgstr "%d of %d"
+
+#: panels/wacom/cc-wacom-page.c:516
+msgid "Display Mapping"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.c:806 panels/wacom/wacom-stylus-page.ui:119
+msgid "Stylus"
+msgstr "Stylus"
+
+#: panels/wacom/cc-wacom-stylus-page.c:360
+msgid "Button"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:200
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:125
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:141
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:161
+msgid "Bluetooth Settings"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:238
+msgid "Tracking Mode"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:266
+msgid "Left-Handed Orientation"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:296
+#: panels/wacom/gnome-wacom-properties.ui:401
+msgid "Map to Monitor…"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:309
+msgid "Map Buttons…"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:322
+msgid "Calibrate…"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:340
+msgid "Adjust mouse settings"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Adjust display resolution"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-properties.ui:376
+msgid "Decouple Display"
+msgstr ""
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
+msgid "New shortcut…"
+msgstr "Shortcut kimi…"
+
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "Aphrang"
+
+#: panels/wacom/wacom-stylus-page.ui:79
+msgid "No stylus found"
+msgstr "Stylus longle"
+
+#: panels/wacom/wacom-stylus-page.ui:93
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:159
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
+msgid "Soft"
+msgstr "Ing-duk"
+
+#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
+msgid "Firm"
+msgstr "Ing-tang thip"
+
+#: panels/wacom/wacom-stylus-page.ui:234
+msgid "Top Button"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:263
+msgid "Lower Button"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:292
+msgid "Lowest Button"
+msgstr ""
+
+#: panels/wacom/wacom-stylus-page.ui:321
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+msgid "GNOME Settings"
+msgstr "GNOME Settings"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:20
+msgid "The GNOME Project"
+msgstr "The GNOME Project"
+
+#: shell/cc-application.c:58
+msgid "Display version number"
+msgstr ""
+
+#: shell/cc-application.c:59
+msgid "Enable verbose mode"
+msgstr ""
+
+#: shell/cc-application.c:60
+msgid "Search for the string"
+msgstr "Amek-akhor kiri"
+
+#: shell/cc-application.c:61
+msgid "List possible panel names and exit"
+msgstr ""
+
+#: shell/cc-application.c:62
+msgid "Panel to display"
+msgstr ""
+
+#: shell/cc-application.c:62
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:45 shell/cc-window.c:277
+msgid "Privacy"
+msgstr "Privacy"
+
+#: shell/cc-panel-loader.c:288
+msgid "Available panels:"
+msgstr ""
+
+#: shell/cc-window.ui:140
+msgid "All Settings"
+msgstr ""
+
+#: shell/cc-window.ui:178
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:319
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:320
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:331
+msgid "Help"
+msgstr "Kerap"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Kiri"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:40
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:53
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1883
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1893
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:2750
+msgid "System Sounds"
+msgstr ""
+
+#~ msgid "Remove Background"
+#~ msgstr "Nung-arjan kethan"
+
+#~ msgid "Version %s"
+#~ msgstr "Version %s"
+
+#~ msgid "OS name"
+#~ msgstr "OS amen"
+
+#~ msgid "OS type"
+#~ msgstr "OS type"
+
+#~ msgid "Disk"
+#~ msgstr "Disk"
+
+#~ msgid "Check for updates"
+#~ msgstr "Updates langtha"
+
+#~ msgid "Network proxy"
+#~ msgstr "Network proxy"
+
+#~ msgid "page 1"
+#~ msgstr "page 1"
+
+#~ msgid "page 2"
+#~ msgstr "page 2"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "Anung pen data san pakom nangji"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Jongsi nangli data ke-en ador so dak pute la mesen lo."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Addresses"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Not connected"
+#~ msgstr "Chephophe"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Dam-de"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Dam-bom"
+
+#~ msgid "_Camera"
+#~ msgstr "_Camera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Microphone"
+
+#~ msgid "Last Login"
+#~ msgstr "Aphisi Login arni"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Username pangcheng amek “-” ke longle."

--- a/po/mk.po
+++ b/po/mk.po
@@ -15,8 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: mk\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2011-11-29 09:05+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2011-12-10 20:46+0100\n"
 "Last-Translator: Jovan N\n"
 "Language-Team: Macedonian <ossm-members@hedona.on.net.mk>\n"
@@ -27,4793 +27,7546 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural= n==1 || n%10==1 ? 0 : 1;\n"
 "X-Generator: KBabel 1.11.4\n"
 
-#: ../panels/background/background.ui.h:1
-#| msgid "Add Wallpaper"
-msgid "Add wallpaper"
-msgstr "Додај позадина"
-
-#: ../panels/background/background.ui.h:2
-#| msgid "Pointer"
-msgid "Center"
-msgstr "Центар"
-
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:4
-msgid "Changes throughout the day"
-msgstr "Да се менува во текот на денот"
-
-#: ../panels/background/background.ui.h:5
-#| msgid "_File"
-msgid "Fill"
-msgstr "Пополни"
-
-#: ../panels/background/background.ui.h:6
-msgid "Primary Color"
-msgstr "Основна боја"
-
-#: ../panels/background/background.ui.h:7
-#| msgid "No Wallpaper"
-msgid "Remove wallpaper"
-msgstr "Отстрани ја позадината"
-
-#: ../panels/background/background.ui.h:8
-#| msgid "Small"
-msgid "Scale"
-msgstr "Размер"
-
-#: ../panels/background/background.ui.h:9
-#| msgid "Seco_ndary click:"
-msgid "Secondary color"
-msgstr "Секундарна боја"
-
-#: ../panels/background/background.ui.h:10
-msgid "Span"
-msgstr "Распон"
-
-#: ../panels/background/background.ui.h:11
-msgid "Swap colors"
-msgstr "Менувај бои"
-
-#: ../panels/background/background.ui.h:12
-#| msgid "_Title:"
-msgid "Tile"
-msgstr "Наслов"
-
-#: ../panels/background/background.ui.h:13
-msgid "Zoom"
-msgstr "Зумирај"
-
-#: ../panels/background/bg-colors-source.c:46
-msgid "Horizontal Gradient"
-msgstr "Хоризонтален градиент"
-
-#: ../panels/background/bg-colors-source.c:47
-msgid "Vertical Gradient"
-msgstr "Вертикален градиент"
-
-#: ../panels/background/bg-colors-source.c:48
-msgid "Solid Color"
-msgstr "Еднобојно"
-
-#: ../panels/background/cc-background-item.c:148
-msgid "multiple sizes"
-msgstr "повеќе големини"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:152
-#, c-format
-#| msgid "%d x %d"
-msgid "%d × %d"
-msgstr "%d x %d"
-
-#: ../panels/background/cc-background-item.c:281
-#| msgid "Apply Background"
-msgid "No Desktop Background"
-msgstr "Нема позадина на работната површина"
-
-#: ../panels/background/cc-background-panel.c:1001
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
-#: ../panels/user-accounts/um-photo-dialog.c:217
-msgid "Browse for more pictures"
-msgstr "Прелистај за повеќе слики"
-
-#: ../panels/background/cc-background-panel.c:1093
-#| msgid "Background"
-msgid "Current background"
-msgstr "Тековна позадина"
-
-#: ../panels/background/cc-background-panel.c:1203
-#| msgid "No Wallpaper"
-msgid "Wallpapers"
-msgstr "Позадини"
-
-#: ../panels/background/cc-background-panel.c:1210
-msgid "Pictures Folder"
-msgstr "Папка со слики"
-
-#: ../panels/background/cc-background-panel.c:1217
-msgid "Colors & Gradients"
-msgstr "Бои и градиенти"
-
-#: ../panels/background/cc-background-panel.c:1225
-msgid "Flickr"
-msgstr "Flickr"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
-msgid "Background"
-msgstr "Позадина"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-#| msgid "Save _background image"
-msgid "Change the background"
-msgstr "Смени ја позадината"
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Позадини;Екран;Работна површина;"
-
-#. TRANSLATORS: device type
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
-#: ../panels/network/panel-common.c:99
-msgid "Bluetooth"
-msgstr "Bluetooth"
-
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
-#| msgid "Monitor Resolution Settings"
-msgid "Configure Bluetooth settings"
-msgstr "Конфигурирај ги поставувањата за Bluetooth"
-
-#: ../panels/bluetooth/bluetooth.ui.h:1
-msgid "Address"
-msgstr "Адреса"
-
-#: ../panels/bluetooth/bluetooth.ui.h:2
-msgid "Browse Files..."
-msgstr "Прегледај датотеки..."
-
-#: ../panels/bluetooth/bluetooth.ui.h:3
-#| msgid "Action"
-msgid "Connection"
-msgstr "Врска"
-
-#: ../panels/bluetooth/bluetooth.ui.h:4
-#: ../panels/universal-access/uap.ui.h:34
-#| msgid "Keyboard Shortcuts"
-msgid "Keyboard Settings"
-msgstr "Поставувања за тастатура"
-
-#: ../panels/bluetooth/bluetooth.ui.h:5
-msgid "Mouse and Touchpad Settings"
-msgstr "Поставувања за глушец и тачпад"
-
-#: ../panels/bluetooth/bluetooth.ui.h:6
-msgid "Paired"
-msgstr "Спарени"
-
-#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
-#: ../panels/bluetooth/bluetooth.ui.h:8
-msgctxt "Power"
-msgid "Bluetooth"
-msgstr "Bluetooth"
-
-#: ../panels/bluetooth/bluetooth.ui.h:9
-#: ../panels/network/network.ui.h:23
-#| msgid "Devices"
-msgid "Remove Device"
-msgstr "Отстрани уред"
-
-#: ../panels/bluetooth/bluetooth.ui.h:10
-#| msgid "Send To..."
-msgid "Send Files..."
-msgstr "Испрати датотеки..."
-
-#: ../panels/bluetooth/bluetooth.ui.h:11
-msgid "Set Up New Device"
-msgstr "Постави нов уред"
-
-#: ../panels/bluetooth/bluetooth.ui.h:12
-#: ../panels/universal-access/uap.ui.h:60
-#| msgid "Sound files"
-msgid "Sound Settings"
-msgstr "Поставувања за звук"
-
-#: ../panels/bluetooth/bluetooth.ui.h:13
-#| msgid "H_yper"
-msgid "Type"
-msgstr "Тип"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:281
-msgid "Yes"
-msgstr "Да"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:281
-#| msgid "None"
-msgid "No"
-msgstr "Не"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:393
-msgid "Bluetooth is disabled"
-msgstr "Bluetooth-от е оневозможен"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:398
-msgid "Bluetooth is disabled by hardware switch"
-msgstr "Bluetooth-от е оневозможен со харверски прекинувач"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:402
-msgid "No Bluetooth adapters found"
-msgstr "Не се пронајдени Bluetooth адаптери"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:535
-#| msgid "Accessibility"
-msgid "Visibility"
-msgstr "Видливост"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:539
-#, c-format
-msgid "Visibility of “%s”"
-msgstr "Видливост на „%s“"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:583
-#, c-format
-msgid "Remove '%s' from the list of devices?"
-msgstr "Да го отстранам „%s“ од листата на уреди?"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:585
-msgid "If you remove the device, you will have to set it up again before next use."
-msgstr "Ако го отстраните уредот, ќе мора да го поставите пак пред следна употреба."
-
-#. TRANSLATORS: this is where the user can click and import a profile
-#: ../panels/color/cc-color-panel.c:106
-msgid "Other profile…"
-msgstr "Друг профил..."
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:119
-#| msgid "Default"
-msgid "Default: "
-msgstr "Стандардно:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:126
-#| msgid "Colors"
-msgid "Colorspace: "
-msgstr "Простор на бои:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:132
-msgid "Test profile: "
-msgstr "Тест профил..."
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:185
-#: ../panels/color/color.ui.h:19
-msgid "Set for all users"
-msgstr "Поставен за сите корисници"
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:192
-msgid "Create virtual device"
-msgstr "Креирај виртуелен уред"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:227
-#| msgid "Select Sound File"
-msgid "Select ICC Profile File"
-msgstr "Изберете ICC профил"
-
-#: ../panels/color/cc-color-panel.c:230
-msgid "_Import"
-msgstr "_Увези"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:241
-msgid "Supported ICC profiles"
-msgstr "Поддржани ICC профили"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:248
-msgid "All files"
-msgstr "Сите датотеки"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:504
-msgid "Available Profiles for Displays"
-msgstr "Достапни профили за прикази"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:508
-msgid "Available Profiles for Scanners"
-msgstr "Достапни профили за скенери"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:512
-msgid "Available Profiles for Printers"
-msgstr "Достапни профили за печатачи"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:516
-msgid "Available Profiles for Cameras"
-msgstr "Достапни профили за камери"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:520
-msgid "Available Profiles for Webcams"
-msgstr "Достапни профили за веб камери"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#. * where the device type is not recognised
-#. Profiles that can be added to the device
-#: ../panels/color/cc-color-panel.c:525
-#: ../panels/color/color.ui.h:5
-#| msgid "All files"
-msgid "Available Profiles"
-msgstr "Достапни профили"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:794
-#: ../panels/sound/gvc-mixer-dialog.c:1515
-#| msgid "Devices"
-msgid "Device"
-msgstr "Уред"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:829
-msgid "Calibration"
-msgstr "Калибрација"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:861
-msgid "Create a color profile for the selected device"
-msgstr "Креирајте профил за боја за избраниот уред"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:875
-#: ../panels/color/cc-color-panel.c:899
-msgid "The measuring instrument is not detected. Please check it is turned on and correctly connected."
-msgstr "Не е детектиран уред за мерење. Проверете дали е вклучен и правилно поврзан."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:908
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Уредот за мерење не поддржува профилирање на печатачи."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:919
-msgid "The device type is not currently supported."
-msgstr "Уредот не е моментално поддржан."
-
-#. TRANSLATORS: this is when an auto-added profile cannot be removed
-#: ../panels/color/cc-color-panel.c:992
-msgid "Cannot remove automatically added profile"
-msgstr "Не можам да го отстранам автоматски додадениот профил"
-
-#. TRANSLATORS: this is when there is no profile for the device
-#: ../panels/color/cc-color-panel.c:1327
-msgid "No profile"
-msgstr "Нема профил"
-
-#: ../panels/color/cc-color-panel.c:1358
-#, c-format
-msgid "%i year"
-msgid_plural "%i years"
-msgstr[0] "%i година"
-msgstr[1] "%i години"
-
-#: ../panels/color/cc-color-panel.c:1369
-#, c-format
-msgid "%i month"
-msgid_plural "%i months"
-msgstr[0] "%i месец"
-msgstr[1] "%i месеци"
-
-#: ../panels/color/cc-color-panel.c:1380
-#, c-format
-msgid "%i week"
-msgid_plural "%i weeks"
-msgstr[0] "%i недела"
-msgstr[1] "%i недели"
-
-#. fallback
-#: ../panels/color/cc-color-panel.c:1387
-#, c-format
-msgid "Less than 1 week"
-msgstr "Помалку од 1 недела"
-
-#: ../panels/color/cc-color-panel.c:1449
-#| msgid "Default"
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Стандардно RGB"
-
-#: ../panels/color/cc-color-panel.c:1454
-#| msgid "Default"
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Стандардно CMYK"
-
-#: ../panels/color/cc-color-panel.c:1459
-#| msgid "Default"
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Стандардно сиво"
-
-#: ../panels/color/cc-color-panel.c:1577
-#: ../panels/color/cc-color-panel.c:1609
-#: ../panels/color/cc-color-panel.c:1620
-#: ../panels/color/cc-color-panel.c:1631
-msgid "Uncalibrated"
-msgstr "Некалибрирано"
-
-#: ../panels/color/cc-color-panel.c:1580
-msgid "This device is not color managed."
-msgstr "Овој уред нема менаџмент на бои"
-
-#: ../panels/color/cc-color-panel.c:1612
-msgid "This device is using manufacturing calibrated data."
-msgstr "Овој уред користи некалибрирани податоци"
-
-#: ../panels/color/cc-color-panel.c:1623
-msgid "This device does not have a profile suitable for whole-screen color correction."
-msgstr "Овој уред нема соодветен профил за корекција на боја на целиот екран."
-
-#: ../panels/color/cc-color-panel.c:1656
-msgid "This device has an old profile that may no longer be accurate."
-msgstr "Овој уред има стар профил кој можеби не е точен."
-
-#. TRANSLATORS: this is when the calibration profile age is not
-#. * specified as it has been autogenerated from the hardware
-#: ../panels/color/cc-color-panel.c:1684
-#| msgid "Not connected"
-msgid "Not specified"
-msgstr "Не е одредено"
-
-#. add the 'No devices detected' entry
-#: ../panels/color/cc-color-panel.c:1868
-msgid "No devices supporting color management detected"
-msgstr "Не се откриени уреди кои поддржуваат менаџмент на бои"
-
-#: ../panels/color/cc-color-panel.c:2097
-#| msgid "_Detect Displays"
-msgctxt "Device kind"
-msgid "Display"
-msgstr "Приказ"
-
-#: ../panels/color/cc-color-panel.c:2099
-msgctxt "Device kind"
-msgid "Scanner"
-msgstr "Скенер"
-
-#: ../panels/color/cc-color-panel.c:2101
-#| msgid "Pointer"
-msgctxt "Device kind"
-msgid "Printer"
-msgstr "Печатач"
-
-#: ../panels/color/cc-color-panel.c:2103
-msgctxt "Device kind"
-msgid "Camera"
-msgstr "Камера"
-
-#: ../panels/color/cc-color-panel.c:2105
-msgctxt "Device kind"
-msgid "Webcam"
-msgstr "Веб камера"
-
-#: ../panels/color/color.ui.h:1
-msgid "Add a virtual device"
-msgstr "Додај виртуелен уред"
-
-#: ../panels/color/color.ui.h:2
-msgid "Add device"
-msgstr "Додај уред"
-
-#: ../panels/color/color.ui.h:3
-#| msgid "All files"
-msgid "Add profile"
-msgstr "Додај профил"
-
-#: ../panels/color/color.ui.h:6
-msgid "Calibrate the device"
-msgstr "Калибрирај го уредот"
-
-#: ../panels/color/color.ui.h:7
-msgid "Calibrate…"
-msgstr "Калибрирај..."
-
-#: ../panels/color/color.ui.h:8
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
-#| msgid "Colors"
-msgid "Color"
-msgstr "Боја"
-
-#: ../panels/color/color.ui.h:9
-#| msgid "Delete"
-msgid "Delete device"
-msgstr "Избриши уред"
-
-#: ../panels/color/color.ui.h:10
-#| msgid "_Device:"
-msgid "Device type:"
-msgstr "Тип на уред:"
-
-#: ../panels/color/color.ui.h:11
-msgid "Each device needs an up to date color profile to be color managed."
-msgstr "На секој уред му треба ажуриран профил за бои за бојата да биде правилно менаџирана."
-
-#: ../panels/color/color.ui.h:12
-msgid "Image files can be dragged on this window to auto-complete the above fields."
-msgstr "Може да влечите датотеки со слики во овој прозорец за автоматско довршување на полињата погоре."
-
-#: ../panels/color/color.ui.h:13
-msgid "Learn more"
-msgstr "Дознајте повеќе"
-
-#: ../panels/color/color.ui.h:14
-msgid "Learn more about color management"
-msgstr "Дознајте повеќе за менаџментот на бои"
-
-#: ../panels/color/color.ui.h:15
-#| msgid "_Manager:"
-msgid "Manufacturer:"
-msgstr "Производител:"
-
-#: ../panels/color/color.ui.h:16
-#| msgid "_Models:"
-msgid "Model:"
-msgstr "Модел:"
-
-#: ../panels/color/color.ui.h:17
-#| msgid "Remove from Favorites"
-msgid "Remove a device"
-msgstr "Отстрани уред"
-
-#: ../panels/color/color.ui.h:18
-#| msgid "Remove from Favorites"
-msgid "Remove profile"
-msgstr "Отстрани профил"
-
-#: ../panels/color/color.ui.h:20
-msgid "Set this device for all users on this computer"
-msgstr "Постави го овој уред за сите корисници на овој компјутер"
-
-#: ../panels/color/color.ui.h:21
-#| msgctxt "Sound event"
-#| msgid "New e-mail"
-msgid "View details"
-msgstr "Прегледај ги деталите"
-
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Color management settings"
-msgstr "Поставувања за менаџмент на бои"
-
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
-msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
-msgstr "Боја;ICC;Профил;Калибрирај;Печатач;Приказ;"
-
-#. Add some common languages first
-#: ../panels/common/cc-common-language.c:513
-msgid "English"
-msgstr "Англиски"
-
-#: ../panels/common/cc-common-language.c:515
-msgid "British English"
-msgstr "Британски англиски"
-
-#: ../panels/common/cc-common-language.c:517
-#| msgid "General"
-msgid "German"
-msgstr "Германски"
-
-#: ../panels/common/cc-common-language.c:519
-msgid "French"
-msgstr "Француски"
-
-#: ../panels/common/cc-common-language.c:521
-msgid "Spanish"
-msgstr "Шпански"
-
-#: ../panels/common/cc-common-language.c:523
-msgid "Chinese (simplified)"
-msgstr "Кинески (поедонставен)"
-
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:552
-msgid "United States"
-msgstr "САД"
-
-#: ../panels/common/cc-common-language.c:553
-msgid "Germany"
-msgstr "Германија"
-
-#: ../panels/common/cc-common-language.c:554
-#| msgid "Appearance"
-msgid "France"
-msgstr "Франција"
-
-#: ../panels/common/cc-common-language.c:555
-msgid "Spain"
-msgstr "Шпанија"
-
-#: ../panels/common/cc-common-language.c:556
-msgid "China"
-msgstr "Кина"
-
-#: ../panels/common/cc-language-chooser.c:119
-#| msgid "Other"
-msgid "Other..."
-msgstr "Друго..."
-
-#: ../panels/common/cc-language-chooser.c:290
-#| msgid "Select Image"
-msgid "Select a region"
-msgstr "Изберете регион"
-
-#: ../panels/common/gdm-languages.c:774
-msgid "Unspecified"
-msgstr "Неодредено"
-
-#: ../panels/common/language-chooser.ui.h:1
-#| msgid "Select Image"
-msgid "Select a language"
-msgstr "Изберете јазик"
-
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/printers/new-printer-dialog.ui.h:4
-#: ../panels/user-accounts/um-user-panel.c:449
-msgid "_Cancel"
-msgstr "_Откажи"
-
-#: ../panels/common/language-chooser.ui.h:3
-msgid "_Select"
-msgstr "_Изберете"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "24-hour"
-msgstr "24 часа"
-
-#. Translator: this is the separator between hours and minutes, like in HH:MM
-#: ../panels/datetime/datetime.ui.h:3
-msgid ":"
-msgstr ":"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "AM/PM"
-msgstr "AM/PM"
-
-#: ../panels/datetime/datetime.ui.h:5
-#| msgid "pixel"
-#| msgid_plural "pixels"
-msgid "April"
-msgstr "Април"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "August"
-msgstr "Август"
-
-#: ../panels/datetime/datetime.ui.h:7
-#| msgid "D_elay:"
-msgid "Day"
-msgstr "Ден"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "December"
-msgstr "Декември"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "February"
-msgstr "Февруари"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "January"
-msgstr "Јануари"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "July"
-msgstr "Јули"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "June"
-msgstr "Јуни"
-
-#: ../panels/datetime/datetime.ui.h:13
-#| msgid "Search"
-msgid "March"
-msgstr "Март"
-
-#: ../panels/datetime/datetime.ui.h:14
-msgid "May"
-msgstr "Мај"
-
-#: ../panels/datetime/datetime.ui.h:15
-#| msgid "Fonts"
-msgid "Month"
-msgstr "Месец"
-
-#: ../panels/datetime/datetime.ui.h:16
-msgid "November"
-msgstr "Ноември"
-
-#: ../panels/datetime/datetime.ui.h:17
-#| msgid "Other"
-msgid "October"
-msgstr "Октомври"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "September"
-msgstr "Септември"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Set the time one hour ahead."
-msgstr "Постави го времето за еден час нанапред."
-
-#: ../panels/datetime/datetime.ui.h:20
-msgid "Set the time one hour back."
-msgstr "Постави го времето за еден час наназад."
-
-#: ../panels/datetime/datetime.ui.h:21
-msgid "Set the time one minute ahead."
-msgstr "Постави го времето за една минута нанапред."
-
-#: ../panels/datetime/datetime.ui.h:22
-msgid "Set the time one minute back."
-msgstr "Постави го времето за една минута наназад."
-
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Switch between AM and PM."
-msgstr "Промени AM/PM."
-
-#: ../panels/datetime/datetime.ui.h:24
-#| msgid "Search"
-msgid "Year"
-msgstr "Година"
-
-#: ../panels/datetime/datetime.ui.h:25
-#| msgid "C_ity:"
-msgid "_City:"
-msgstr "_Град:"
-
-#: ../panels/datetime/datetime.ui.h:26
-#| msgid "Network Servers"
-msgid "_Network Time"
-msgstr "_Мрежно време"
-
-#: ../panels/datetime/datetime.ui.h:27
-#| msgid "_Resolution"
-msgid "_Region:"
-msgstr "_Регион:"
-
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Clock;Timezone;Location;"
-msgstr "Часовник;Временска зона;Локација;"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
-msgid "Date and Time"
-msgstr "Датум и време"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
-msgid "Date and Time preferences panel"
-msgstr "Панел за преференци за датум и време"
-
-#: ../panels/display/cc-display-panel.c:477
-#| msgid "Normal"
-msgctxt "display panel, rotation"
-msgid "Normal"
-msgstr "Нормално"
-
-#: ../panels/display/cc-display-panel.c:478
-msgctxt "display panel, rotation"
-msgid "Counterclockwise"
-msgstr "Обратно од стрелките на часовникот"
-
-#: ../panels/display/cc-display-panel.c:479
-msgctxt "display panel, rotation"
-msgid "Clockwise"
-msgstr "Во насока на стрелките на часовникот"
-
-#: ../panels/display/cc-display-panel.c:480
-msgctxt "display panel, rotation"
-msgid "180 Degrees"
-msgstr "180 степени"
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../panels/display/cc-display-panel.c:617
-msgid "Mirror Displays"
-msgstr "Огледало на приказот"
-
-#: ../panels/display/cc-display-panel.c:641
-#: ../panels/display/display-capplet.ui.h:1
-#| msgid "Typing Monitor"
-msgid "Monitor"
-msgstr "Монитор"
-
-#: ../panels/display/cc-display-panel.c:747
-#, c-format
-#| msgid "%d x %d"
-msgid "%d x %d (%s)"
-msgstr "%d x %d (%s)"
-
-#: ../panels/display/cc-display-panel.c:749
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#: ../panels/display/cc-display-panel.c:1656
-msgid "Drag to change primary display."
-msgstr "Влечете за да го промените примарниот приказ."
-
-#: ../panels/display/cc-display-panel.c:1714
-msgid "Select a monitor to change its properties; drag it to rearrange its placement."
-msgstr "Изберете монитор за да ги промените неговите својства; влечете го за да ја промените неговата поставеност."
-
-#: ../panels/display/cc-display-panel.c:2102
-msgid "%a %R"
-msgstr "%a %R"
-
-#: ../panels/display/cc-display-panel.c:2104
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
-
-#: ../panels/display/cc-display-panel.c:2350
-#| msgid "Could not load the main interface"
-msgid "Could not save the monitor configuration"
-msgstr "Не можам да ја зачувам конфигурацијата за екранот"
-
-#: ../panels/display/cc-display-panel.c:2375
-msgid "Could not get session bus while applying display configuration"
-msgstr "Не можев да добијам магистрала за сесијата при применување на конфигурацијата на приказот"
-
-#: ../panels/display/cc-display-panel.c:2420
-#| msgid "_Detect Displays"
-msgid "Could not detect displays"
-msgstr "Не можев да детектирам прикази"
-
-#: ../panels/display/cc-display-panel.c:2614
-#| msgid "Change screen resolution"
-msgid "Could not get screen information"
-msgstr "Не можев да добијам информации за приказот"
-
-#: ../panels/display/display-capplet.ui.h:2
-msgid "Note: may limit resolution options"
-msgstr "Забелешка: ова може да ги ограничи опциите за резолуција"
-
-#: ../panels/display/display-capplet.ui.h:3
-msgid "R_otation"
-msgstr "Р_отација"
-
-#: ../panels/display/display-capplet.ui.h:4
-msgid "_Detect Displays"
-msgstr "_Детектирај прикази"
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:6
-msgid "_Mirror displays"
-msgstr "_Огледало на приказот"
-
-#: ../panels/display/display-capplet.ui.h:7
-msgid "_Resolution"
-msgstr "_Резолуција"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Change resolution and position of monitors and projectors"
-msgstr "Промени ја резолуцијата и позицијата на мониторите и проекторите"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-#| msgid "_Detect Displays"
-msgid "Displays"
-msgstr "Прикази"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr "Панел;Проектор;xrandr;Екран;Резолуција;Освежи;"
-
-#. Translators: VESA is an techncial acronym, don't translate it.
-#: ../panels/info/cc-info-panel.c:402
-#, c-format
-msgid "VESA: %s"
-msgstr "VESA: %s"
-
-#. TRANSLATORS: device type
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:426
-#: ../panels/network/panel-common.c:79
-#: ../panels/network/panel-common.c:158
-msgid "Unknown"
-msgstr "Непознато"
-
-#. translators: This is the type of architecture, for example:
-#. * "64-bit" or "32-bit"
-#: ../panels/info/cc-info-panel.c:587
-#, c-format
-#| msgid "Edit"
-msgid "%d-bit"
-msgstr "%d-bit"
-
-#: ../panels/info/cc-info-panel.c:744
-#| msgid "Unknown"
-msgid "Unknown model"
-msgstr "Непознат модел"
-
-#: ../panels/info/cc-info-panel.c:827
-msgid "The next login will attempt to use the standard experience."
-msgstr "Следното најавување ќе се обидам да го користам стандардното искуство."
-
-#: ../panels/info/cc-info-panel.c:829
-msgid "The next login will use the fallback mode intended for unsupported graphics hardware."
-msgstr "Следното најавување ќе се користи режимот за спас, наменет за неподдржан графички хардвер."
-
-#. translators: The hardware is not able to run GNOME 3's
-#. * shell, so we use the GNOME "Fallback" session
-#: ../panels/info/cc-info-panel.c:871
-#| msgid "Callback"
-msgctxt "Experience"
-msgid "Fallback"
-msgstr "Спасувачка"
-
-#. translators: The hardware is able to run GNOME 3's
-#. * shell, also called "Standard" experience
-#: ../panels/info/cc-info-panel.c:877
-#| msgid "Standard XTerminal"
-msgctxt "Experience"
-msgid "Standard"
-msgstr "Стандардна"
-
-#: ../panels/info/cc-info-panel.c:1200
-msgid "Ask what to do"
-msgstr "Прашај ме што да направам"
-
-#: ../panels/info/cc-info-panel.c:1204
-msgid "Do nothing"
-msgstr "Не прави ништо"
-
-#: ../panels/info/cc-info-panel.c:1208
-#| msgid "Open File"
-msgid "Open folder"
-msgstr "Отвори папка"
-
-#: ../panels/info/cc-info-panel.c:1319
-#| msgid "Select your default applications"
-msgid "Select an application for audio CDs"
-msgstr "Изберете апликација за аудио CD-ња"
-
-#: ../panels/info/cc-info-panel.c:1320
-#| msgid "Select your default applications"
-msgid "Select an application for video DVDs"
-msgstr "Изберете апликација за видео CD-ња"
-
-#: ../panels/info/cc-info-panel.c:1321
-msgid "Select an application to run when a music player is connected"
-msgstr "Одберете апликација која ќе се пушти кога ќе се поврзе пуштач на музика"
-
-#: ../panels/info/cc-info-panel.c:1322
-msgid "Select an application to run when a camera is connected"
-msgstr "Одберете апликација која ќе се пушти кога ќе се поврзе камера"
-
-#: ../panels/info/cc-info-panel.c:1323
-#| msgid "Select your default applications"
-msgid "Select an application for software CDs"
-msgstr "Изберете апликација за софтверски CD-ња"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1335
-msgid "audio DVD"
-msgstr "audio DVD"
-
-#: ../panels/info/cc-info-panel.c:1336
-msgid "blank Blu-ray disc"
-msgstr "blank Blu-ray disc"
-
-#: ../panels/info/cc-info-panel.c:1337
-msgid "blank CD disc"
-msgstr "blank CD disc"
-
-#: ../panels/info/cc-info-panel.c:1338
-msgid "blank DVD disc"
-msgstr "blank DVD disc"
-
-#: ../panels/info/cc-info-panel.c:1339
-msgid "blank HD DVD disc"
-msgstr "blank HD DVD disc"
-
-#: ../panels/info/cc-info-panel.c:1340
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video disc"
-
-#: ../panels/info/cc-info-panel.c:1341
-msgid "e-book reader"
-msgstr "e-book reader"
-
-#: ../panels/info/cc-info-panel.c:1342
-msgid "HD DVD video disc"
-msgstr "HD DVD video disc"
-
-#: ../panels/info/cc-info-panel.c:1343
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: ../panels/info/cc-info-panel.c:1344
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: ../panels/info/cc-info-panel.c:1345
-msgid "Video CD"
-msgstr "Video CD"
-
-#: ../panels/info/cc-info-panel.c:1474
-#: ../panels/keyboard/keyboard-shortcuts.c:1627
-#| msgid "Action"
-msgid "Section"
-msgstr "Оддел"
-
-#: ../panels/info/cc-info-panel.c:1483
-#: ../panels/info/info.ui.h:15
-#| msgid "_Overwrite"
-msgid "Overview"
-msgstr "Преглед"
-
-#: ../panels/info/cc-info-panel.c:1489
-#: ../panels/info/info.ui.h:4
-#| msgid "Open with Default Application"
-msgid "Default Applications"
-msgstr "Стандардни апликации"
-
-#: ../panels/info/cc-info-panel.c:1494
-#: ../panels/info/info.ui.h:17
-msgid "Removable Media"
-msgstr "Removable Media"
-
-#: ../panels/info/cc-info-panel.c:1499
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "Графика"
-
-#: ../panels/info/cc-info-panel.c:1701
-#, c-format
-msgid "Version %s"
-msgstr "Верзија %s"
-
-#: ../panels/info/cc-info-panel.c:1751
-#| msgid "Install"
-msgid "Install Updates"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Апликации"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Апликации"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
 msgstr "Инсталирај ажурирања"
 
-#: ../panels/info/cc-info-panel.c:1755
-msgid "System Up-To-Date"
-msgstr "Системот е ажуриран"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "Отворена врата"
 
-#: ../panels/info/cc-info-panel.c:1759
-#| msgid "Checking password..."
-msgid "Checking for Updates"
-msgstr "Прoверувам дали има ажурирањ"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Прегледај ги деталите"
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#| msgid "_Details"
-msgid "Details"
-msgstr "Детали"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "System Information"
-msgstr "Информации за системот"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid "device;system;information;memory;processor;version;default;application;fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr "уред;систем;информација;меморија;процесор;верзија;стандардно;апликација;спас;префереиран;cd;dvd;usb;ауди;видео;диск;преносен;медиум;атоматско пуштање;"
-
-#: ../panels/info/info.ui.h:1
-#| msgid "Action"
-msgid "Acti_on:"
-msgstr "Дејство"
-
-#: ../panels/info/info.ui.h:2
-msgid "CD _audio"
-msgstr "_Аудио CD"
-
-#: ../panels/info/info.ui.h:3
-msgid "Calculating..."
-msgstr "Пресметувам..."
-
-#: ../panels/info/info.ui.h:5
-#| msgid "Devices"
-msgid "Device name"
-msgstr "Име на уред"
-
-#: ../panels/info/info.ui.h:6
-msgid "Disk"
-msgstr "Диск"
-
-#: ../panels/info/info.ui.h:7
-msgid "Driver"
-msgstr "Драјвер"
-
-#: ../panels/info/info.ui.h:8
-#| msgid "Appearance"
-msgid "Experience"
-msgstr "Искуство"
-
-#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
-#: ../panels/info/info.ui.h:10
-msgid "Forced _Fallback Mode"
-msgstr "Присилен режим за _спас"
-
-#: ../panels/info/info.ui.h:12
-msgid "M_usic"
-msgstr "М_узика"
-
-#: ../panels/info/info.ui.h:13
-msgid "Memory"
-msgstr "Меморија"
-
-#: ../panels/info/info.ui.h:14
-msgid "OS type"
-msgstr "Тип на ОС"
-
-#: ../panels/info/info.ui.h:16
-#| msgid "_Profession:"
-msgid "Processor"
-msgstr "Процесор"
-
-#: ../panels/info/info.ui.h:18
-msgid "Select how media should be handled"
-msgstr "Изберете како ќе се справувам со медиумот"
-
-#: ../panels/info/info.ui.h:19
-msgid "Select how other media should be handled"
-msgstr "Изберте како ќе се справувам со другите медиуми"
-
-#: ../panels/info/info.ui.h:20
-#| msgid "Cale_ndar:"
-msgid "_Calendar"
-msgstr "_Календар"
-
-#: ../panels/info/info.ui.h:21
-msgid "_DVD video"
-msgstr "_DVD видео"
-
-#: ../panels/info/info.ui.h:22
-#| msgid "KMail"
-msgid "_Mail"
-msgstr "_Пошта"
-
-#: ../panels/info/info.ui.h:23
-#| msgid "Muine Music Player"
-msgid "_Music player"
-msgstr "_Пуштач на музика"
-
-#: ../panels/info/info.ui.h:24
-msgid "_Never prompt or start programs on media insertion"
-msgstr "_Не прашувај или стартувај програми при внесување на медиум"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Other Media..."
-msgstr "_Други медиуми..."
-
-#: ../panels/info/info.ui.h:26
-msgid "_Photos"
-msgstr "_Слики"
-
-#: ../panels/info/info.ui.h:27
-msgid "_Software"
-msgstr "_Софтвер"
-
-#: ../panels/info/info.ui.h:28
-#| msgid "H_yper"
-msgid "_Type:"
-msgstr "_Тип"
-
-#: ../panels/info/info.ui.h:29
-msgid "_Video"
-msgstr "_Видео"
-
-#: ../panels/info/info.ui.h:30
-msgid "_Web"
-msgstr "_Веб"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
-msgid "Eject"
-msgstr "Извади"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Launch media player"
-msgstr "Пушти пуштач на медиуми"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
-msgid "Next track"
-msgstr "Следна песна"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
-#| msgid "S_ound playback:"
-msgid "Pause playback"
-msgstr "Паузирај"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
-msgid "Play (or play/pause)"
-msgstr "Пушти (или пушти/пауза)"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
-msgid "Previous track"
-msgstr "Претходна песна"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
-msgid "Sound and Media"
-msgstr "Звук и медиуми"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
-#| msgid "S_ound playback:"
-msgid "Stop playback"
-msgstr "Стопирај"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
-msgid "Volume down"
-msgstr "Намали ја гласноста"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
-msgid "Volume mute"
-msgstr "Исклучи го гласот"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
-#| msgid "Roll up"
-msgid "Volume up"
-msgstr "Зголеми ја гласноста"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:1
-msgid "Home folder"
-msgstr "Домашна папка"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:2
-msgid "Launch calculator"
-msgstr "Пушти калкулатор"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:3
-msgid "Launch email client"
-msgstr "Пушти клиент за е-пошта"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:4
-msgid "Launch help browser"
-msgstr "Пушти прелистувач на помош"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:5
-#| msgid "Epiphany Web Browser"
-msgid "Launch web browser"
-msgstr "Пушти веб прелистувач"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:6
-msgid "Launchers"
-msgstr "Пуштачи"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Пребарувај"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-#| msgid "Screen Resolution"
-msgid "Screenshots"
-msgstr "Слики од екранот"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:2
-#| msgid "Take a break!"
-msgid "Take a screenshot"
-msgstr "Сликај го екранот"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Take a screenshot of a window"
-msgstr "Земи слика од прозорец"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
-#| msgid "Lock Screen"
-msgid "Lock screen"
-msgstr "Заклучи го екранот"
-
-#: ../panels/keyboard/01-system.xml.in.h:2
-#| msgid "Logout"
-msgid "Log out"
-msgstr "Одјави се"
-
-#: ../panels/keyboard/01-system.xml.in.h:3
-#: ../panels/region/gnome-region-panel.ui.h:33
-msgid "System"
-msgstr "Систем"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-msgid "Decrease text size"
-msgstr "Намали ја големината на текстот"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
-msgid "High contrast on or off"
-msgstr "Пушти или исклучи висок контраст"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
-msgid "Increase text size"
-msgstr "Намали ја големината на текстот"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
-msgid "Turn on-screen keyboard on or off"
-msgstr "Исклучи или приклучи ја екранската тастатура"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
-msgid "Turn screen reader on or off"
-msgstr "Исклучи или пушти го читачот на екранот"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
-msgid "Turn zoom on or off"
-msgstr "Исклучи или пушти зум"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
-msgid "Universal Access"
-msgstr "Универзален пристап"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
-msgid "Zoom in"
-msgstr "Зумирај"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
-msgid "Zoom out"
-msgstr "Одзумирај"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Change keyboard settings"
-msgstr "Промени ги поставувањата за тастатурата"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "Keyboard"
-msgstr "Тастатура"
-
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Кратенка;Повтори;Трепкај;"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-#| msgid "Shortcut"
-msgid "Add Shortcut"
-msgstr "Додај кратенка"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "C_ommand:"
-msgstr "К_оманда:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#| msgid "<b>Cursor Blinking</b>"
-msgid "Cursor Blinking"
-msgstr "Трепкање на стрелката"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "Cursor _blinks in text fields"
-msgstr "_Стрелката трепка во текстуални полиња"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-#| msgid "Cursor blinks speed"
-msgid "Cursor blink speed"
-msgstr "Брзина на трепкање на стрелката"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-#| msgid "Custom Shortcuts"
-msgid "Custom Shortcut"
-msgstr "Сопствена кратенка"
-
-#. fast acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-#| msgid "_Paste"
-msgid "Fast"
-msgstr "Брзо"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "Key presses _repeat when key is held down"
-msgstr "Притисокот на копче се повторува копчето е задржано повеќе"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-#| msgid "Layout _Options..."
-msgid "Layout Settings"
-msgstr "Поставувања за распоредот"
-
-#. long delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-#: ../panels/universal-access/uap.ui.h:38
-#: ../panels/universal-access/zoom-options.ui.h:13
-#| msgctxt "Sound event"
-#| msgid "Login"
-msgid "Long"
-msgstr "Долго"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-#| msgid "Shortcut"
-msgid "Remove Shortcut"
-msgstr "Отстрани кратенка"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-#| msgid "<b>Repeat Keys</b>"
-msgid "Repeat Keys"
-msgstr "Повтори ги копчињата"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgid "Repeat keys speed"
-msgstr "Брзина на повторување на копчињата"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "S_peed:"
-msgstr "Б_рзина:"
-
-#. short delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-#: ../panels/mouse/gnome-mouse-properties.ui.h:24
-#: ../panels/universal-access/uap.ui.h:54
-#: ../panels/universal-access/zoom-options.ui.h:22
-#| msgid "Shortcut"
-msgid "Short"
-msgstr "Кратко"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-#| msgid "Shortcut"
-msgid "Shortcuts"
-msgstr "Кратенки"
-
-#. slow acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-#: ../panels/mouse/gnome-mouse-properties.ui.h:26
-msgid "Slow"
-msgstr "Бавно"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#| msgid ""
-#| "To edit a shortcut key, click on the corresponding row and type a new key "
-#| "combination, or press backspace to clear."
-msgid "To edit a shortcut, click the row and hold down the new keys or press Backspace to clear."
-msgstr "За да ги уредите кратенките, кликнете на саканиот ред и стиснете на нова комбинација од копчиња или пак притиснете backspace за да ги исчистите."
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:67
-#| msgid "Typing Break"
-msgid "Typing"
-msgstr "Пишување"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "_Delay:"
-msgstr "_Одложување:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "_Name:"
-msgstr "_Име:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid "_Speed:"
-msgstr "Брзина:"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:555
-#: ../panels/keyboard/keyboard-shortcuts.c:563
-#: ../panels/keyboard/keyboard-shortcuts.c:882
-#: ../panels/keyboard/keyboard-shortcuts.c:1383
-#: ../panels/keyboard/keyboard-shortcuts.c:1387
-msgid "Custom Shortcuts"
-msgstr "Сопствени кратенки"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:723
-msgid "<Unknown Action>"
-msgstr "<Непознато дејство>"
-
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/keyboard-shortcuts.c:1064
-#: ../panels/sound/gvc-mixer-control.c:1087
-#: ../panels/user-accounts/um-fingerprint-dialog.c:177
-#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Оневозможено"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1205
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "Зголемување"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Информации за системот"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Позадина"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
-"Кратенката „%s“ не може да се користи бидејќи ќе стане невозможно да се пишува со ова копче.\n"
-"Ве молам пробајте со копче како Control, Alt или Shift во исто време."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1237
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Слики од екранот"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
 msgstr ""
-"Кратенката „%s“ веќе се користи за \n"
-" „%s“"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1242
-#, c-format
-msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "Ако ја смените кратенката во %s, кратенката %s ќе биде исклучена."
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Позадини"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1248
-msgid "_Reassign"
-msgstr "_Додели пак"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1676
-msgid "Action"
-msgstr "Дејствие"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Звуци"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1699
-msgid "Shortcut"
-msgstr "Кратенка"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse and Touchpad"
-msgstr "Глушец и тачпад"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Кратенки"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-#| msgid "Set your mouse preferences"
-msgid "Set your mouse and touchpad preferences"
-msgstr "Поставете ги преференците за глушецот"
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr ""
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-msgstr "Тракпад;Стрелка;Клик;Тапкање;Двоен;Копче;Тракбол;"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "Камера"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "A_cceleration:"
-msgstr "З_абрзување:"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "Disable _touchpad while typing"
-msgstr "Оневозможи го _тачпадот при пишување"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "Гласност на микрофонот"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-#| msgid "<b>Double-Click Timeout</b>"
-msgid "Double-Click Timeout"
-msgstr "Застој за двоен клик"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-#| msgid "<b>Double-Click Timeout</b>"
-msgid "Double-click timeout"
-msgstr "Застој за двоен клик"
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "Локација"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-#| msgid "Thr_eshold:"
-msgid "Drag Threshold"
-msgstr "Праг на влечење"
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-#| msgid "<b>Drag and Drop</b>"
-msgid "Drag and Drop"
-msgstr "Влечи и пушти"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Enable _mouse clicks with touchpad"
-msgstr "Овозможи ги кликањата со _глушец преку тачпад"
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "Enable h_orizontal scrolling"
-msgstr "Овозможи х_оризонтално движење"
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "General"
-msgstr "Општо"
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
 
-#. high sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-#| msgid "Right"
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Не се пронајдени локални уреди"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Датотечен систем"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Апликации"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Е-пошта</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Стило"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Стандардно"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Позадина"
+
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "Додај печатач"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "Франција"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "Овозможено"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
+msgstr "Не се пронајдени Bluetooth адаптери"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "Режим за во а_вион"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth-от е оневозможен со харверски прекинувач"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "Режим за во а_вион"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Режим за во а_вион"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Нема апликации кои моментално пуштаат или снимаат аудио."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Прелистај за повеќе слики"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+#, fuzzy
+msgid "Display Calibration"
+msgstr "Калибрација"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Откажи"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "Готово!"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Калибрација"
+
+#: panels/color/cc-color-panel.ui:12
+#, fuzzy
+msgid "Calibration Quality"
+msgstr "Калибрација"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+#, fuzzy
+msgid "Calibration Device"
+msgstr "Калибрација"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "Приказ"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Голема бела стрелка"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Светлост"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "име на датотека"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "_Профил:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Резиме"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Нема профил"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Додај профил"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Увези"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Додај"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"На секој уред му треба ажуриран профил за бои за бојата да биде правилно "
+"менаџирана."
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr "Дознајте повеќе"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Дознајте повеќе за менаџментот на бои"
+
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
+msgstr "Поставен за сите корисници"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+#, fuzzy
+msgid "Set this profile for all users on this computer"
+msgstr "Постави го овој уред за сите корисници на овој компјутер"
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "Овозможено"
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "Додај профил"
+
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
+msgstr "Калибрирај..."
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Калибрирај го уредот"
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "Отстрани профил"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "Прегледај ги деталите"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+#, fuzzy
+msgid "Projector"
+msgstr "Ко_нектор:"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+#, fuzzy
+msgctxt "Calibration quality"
 msgid "High"
 msgstr "Висок"
 
-#. large threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Large"
-msgstr "Голема"
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "10 минути"
 
-#. low sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "_Средно"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 минути"
+
+#: panels/color/cc-color-panel.ui:640
+#, fuzzy
+msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Ниско"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:19
-msgid "Mouse"
-msgstr "Глушец"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "Mouse Preferences"
-msgstr "Преференци на глушецот"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:21
-#| msgid "<b>Pointer Speed</b>"
-msgid "Pointer Speed"
-msgstr "Брзина на стрелката"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:22
-msgid "Scrolling"
-msgstr "Движење"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:23
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr "По_кажи ја позицијата на стрелката при притискање на копчето Control"
-
-#. small threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:28
-#: ../panels/universal-access/uap.ui.h:59
-msgid "Small"
-msgstr "Мала"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:29
-msgid "Thr_eshold:"
-msgstr "Пр_аг:"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:30
-#| msgid ""
-#| "<i>To test your double-click settings, try to double-click on the light "
-#| "bulb.</i>"
-msgid "To test your settings, try to double-click on the face."
-msgstr "За да ги тестирате поставувањата за двојниот клик, пробајте да кликнете на лицето."
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:31
-msgid "Touchpad"
-msgstr "Тачпад"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:32
-msgid "Two-_finger scrolling"
-msgstr "Движење со _два прста"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:33
-#| msgid "Disabled"
-msgid "_Disabled"
-msgstr "_Оневозможено"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:34
-msgid "_Edge scrolling"
-msgstr "Движење по _работ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:35
-msgid "_Left-handed"
-msgstr "_Левак"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:36
-msgid "_Right-handed"
-msgstr "_Деснак"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:37
-msgid "_Sensitivity:"
-msgstr "_Осетливост:"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:38
-msgid "_Timeout:"
-msgstr "_Застој:"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/cc-network-panel.c:269
-msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "Автоматскот откривање на веб прокси се користи кога не е даден конфигурациски URL."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/cc-network-panel.c:277
-msgid "This is not recommended for untrusted public networks."
-msgstr "Ова не е препорачано за недоверливи јавни мрежи."
-
-#. TRANSLATORS: this is when the access point is not listed
-#. * in the dropdown (or hidden) and the user has to select
-#. * another entry manually
-#: ../panels/network/cc-network-panel.c:949
-#| msgid "Other"
-msgctxt "Wireless access point"
-msgid "Other..."
-msgstr "Друго..."
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/cc-network-panel.c:1107
-#: ../panels/network/cc-network-panel.c:1514
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:1111
-#: ../panels/network/cc-network-panel.c:1518
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:1115
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/cc-network-panel.c:1120
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#. TRANSLATORS: this no (!) WiFi security
-#: ../panels/network/cc-network-panel.c:1126
-#: ../panels/network/cc-network-panel.c:1509
-#: ../panels/universal-access/uap.ui.h:43
-#: ../panels/universal-access/zoom-options.ui.h:16
-msgid "None"
-msgstr "Ништо"
-
-#: ../panels/network/cc-network-panel.c:1577
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#. Translators: network device speed
-#: ../panels/network/cc-network-panel.c:1643
-#: ../panels/network/cc-network-panel.c:1731
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/cc-network-panel.c:1986
-#: ../panels/network/network.ui.h:18
-#| msgid "Address"
-msgid "IPv4 Address"
-msgstr "IPv4 адреса"
-
-#: ../panels/network/cc-network-panel.c:1987
-#: ../panels/network/network.ui.h:19
-#| msgid "Address"
-msgid "IPv6 Address"
-msgstr "IPv6 адреса"
-
-#: ../panels/network/cc-network-panel.c:1990
-#: ../panels/network/cc-network-panel.c:1993
-#: ../panels/network/network.ui.h:17
-#: ../panels/printers/printers.ui.h:9
-#| msgid "Address"
-msgid "IP Address"
-msgstr "IP адреса"
-
-#: ../panels/network/cc-network-panel.c:2040
-#: ../panels/network/cc-network-panel.c:2413
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#: ../panels/network/cc-network-panel.c:2148
-#| msgid "_FTP proxy:"
-msgid "Proxy"
-msgstr "Прокси"
-
-#: ../panels/network/cc-network-panel.c:2222
-#| msgid "Network Proxy"
-msgid "Network proxy"
-msgstr "Мрежен прокси"
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:2480
-msgid "The system network services are not compatible with this version."
-msgstr "Мрежните сервиси на системот не се компатибилни со оваа верзија."
-
-#: ../panels/network/cc-network-panel.c:3095
-#| msgid "Not connected"
-msgid "Not connected to the internet."
-msgstr "Не сум поврзан на интернет."
-
-#: ../panels/network/cc-network-panel.c:3096
-msgid "Create the hotspot anyway?"
-msgstr "Да го креирам hotspot-от и покрај тоа?"
-
-#: ../panels/network/cc-network-panel.c:3114
-#, c-format
-msgid "Disconnect from %s and create a new hotspot?"
-msgstr "Да се исклучам од %s и да креирам нов hotspot?"
-
-#: ../panels/network/cc-network-panel.c:3117
-msgid "This is your only connection to the internet."
-msgstr "Ова е Вашата единствена врска со интернет."
-
-#: ../panels/network/cc-network-panel.c:3135
-msgid "Create _Hotspot"
-msgstr "Креирај _hotspot"
-
-#: ../panels/network/cc-network-panel.c:3195
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Да го прекинам hotspot-от и да ги исклучам неговите корисници?"
-
-#: ../panels/network/cc-network-panel.c:3198
-msgid "_Stop Hotspot"
-msgstr "_Прекини го hotspot-от"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#| msgid "Network Proxy"
-msgid "Network"
-msgstr "Мрежа"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-#| msgid "Network Servers"
-msgid "Network settings"
-msgstr "Мрежни поставувања"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid "Network;Wireless;IP;LAN;Proxy;"
-msgstr "Мрежа;Безжичен;IP;LAN;Прокси;"
-
-#: ../panels/network/network.ui.h:1
-#| msgid "Devices"
-msgid "Add Device"
-msgstr "Додај уред"
-
-#: ../panels/network/network.ui.h:2
-msgid "Air_plane Mode"
-msgstr "Режим за во а_вион"
-
-#: ../panels/network/network.ui.h:3
-#| msgid "Rename..."
-msgid "Create..."
-msgstr "Креирај..."
-
-#: ../panels/network/network.ui.h:4
-msgid "DNS"
-msgstr "DNS"
-
-#: ../panels/network/network.ui.h:5
-#| msgid "Default Pointer"
-msgid "Default Route"
-msgstr "Стандардна рута"
-
-#: ../panels/network/network.ui.h:6
-#| msgid "Devices"
-msgid "Device Off"
-msgstr "Уредот е исклучен"
-
-#: ../panels/network/network.ui.h:7
-#| msgid "Disabled"
-msgid "Disable VPN"
-msgstr "Оневозможи VPN"
-
-#: ../panels/network/network.ui.h:8
-#| msgid "Port:"
-msgid "FTP Port"
-msgstr "FTP порта"
-
-#: ../panels/network/network.ui.h:9
-msgid "Gateway"
-msgstr "Премин"
-
-#: ../panels/network/network.ui.h:10
-#| msgid "Full Name"
-msgid "Group Name"
-msgstr "Име на група"
-
-#: ../panels/network/network.ui.h:11
-#| msgid "_Password:"
-msgid "Group Password"
-msgstr "Лозинка на група"
-
-#: ../panels/network/network.ui.h:12
-msgid "HTTP Port"
-msgstr "Порта за HTTP"
-
-#: ../panels/network/network.ui.h:13
-msgid "HTTPS Port"
-msgstr "Порта за HTTPS"
-
-#: ../panels/network/network.ui.h:14
-#| msgid "H_TTP proxy:"
-msgid "H_TTPS Proxy"
-msgstr "H_TTPS прокси:"
-
-#: ../panels/network/network.ui.h:15
-#| msgid "Address"
-msgid "Hardware Address"
-msgstr "Хардверска адрееса"
-
-#: ../panels/network/network.ui.h:16
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network.ui.h:20
-msgid "Interface"
-msgstr "Интерфејс"
-
-#: ../panels/network/network.ui.h:21
-#| msgid "Network Servers"
-msgid "Network Name"
-msgstr "Мрежно име"
-
-#: ../panels/network/network.ui.h:22
-#| msgid "Pointer"
-msgid "Provider"
-msgstr "Провајдер"
-
-#: ../panels/network/network.ui.h:24
-msgid "Security"
-msgstr "Безбедност"
-
-#: ../panels/network/network.ui.h:25
-msgid "Security Key"
-msgstr "Безбедносен клуч"
-
-#: ../panels/network/network.ui.h:26
-msgid "Select the interface to use for the new service"
-msgstr "Изберете го интерфејсот за користење со новиот сервис"
-
-#: ../panels/network/network.ui.h:27
-#| msgid "S_ocks host:"
-msgid "Socks Port"
-msgstr "Socks порта"
-
-#: ../panels/network/network.ui.h:28
-#| msgid "S_peed:"
-msgid "Speed"
-msgstr "Брзина"
-
-#: ../panels/network/network.ui.h:29
-msgid "Subnet Mask"
-msgstr "Сабнет маска"
-
-#: ../panels/network/network.ui.h:30
-msgid "Unlock"
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "5 минути"
+
+#: panels/color/cc-color-panel.ui:663
+#, fuzzy
+msgid "Native to display"
+msgstr "Панел за прикажување"
+
+#: panels/color/cc-color-panel.ui:667
+#, fuzzy
+msgid "D50 (Printing and publishing)"
+msgstr "Покажување и кликање"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+#, fuzzy
+msgid "D75"
+msgstr "75%"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Боја"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Боја;ICC;Профил;Калибрирај;Печатач;Приказ;"
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Изберете јазик"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Изберете"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Не се пронајдени локални уреди"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
 msgstr "Отклучи"
 
-#: ../panels/network/network.ui.h:31
-#| msgid "User name:"
-msgid "Username"
-msgstr "Корисничко име"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: ../panels/network/network.ui.h:32
-msgid "VPN"
-msgstr "VPN"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "Зголеми:"
 
-#: ../panels/network/network.ui.h:33
-msgid "VPN Type"
-msgstr "Тип на VPN"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Време"
 
-#: ../panels/network/network.ui.h:34
-#| msgid "Autoconfiguration _URL:"
-msgid "_Configuration URL"
-msgstr "_URL за конфигурирање"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../panels/network/network.ui.h:35
-msgid "_Configure..."
-msgstr "_Конфигурирај..."
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "Намали:"
 
-#: ../panels/network/network.ui.h:36
-#| msgid "_FTP proxy:"
-msgid "_FTP Proxy"
-msgstr "_FTP прокси"
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+#, fuzzy
+msgid "Date & Time"
+msgstr "Датум и време"
 
-#: ../panels/network/network.ui.h:37
-#| msgid "H_TTP proxy:"
-msgid "_HTTP Proxy"
-msgstr "H_TTP прокси"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Година"
 
-#: ../panels/network/network.ui.h:38
-#| msgid "_Meta"
-msgid "_Method"
-msgstr "_Метод"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Месец"
 
-#: ../panels/network/network.ui.h:39
-#| msgid "Network Servers"
-msgid "_Network Name"
-msgstr "_Мрежно име"
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Јануари"
 
-#: ../panels/network/network.ui.h:40
-#| msgid "S_ocks host:"
-msgid "_Socks Host"
-msgstr "S_ocks хост"
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Февруари"
 
-#: ../panels/network/network.ui.h:41
-msgid "_Stop Hotspot..."
-msgstr "_Стопирај го hotspot-от..."
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Март"
 
-#: ../panels/network/network.ui.h:42
-msgid "_Use as Hotspot..."
-msgstr "_Користи како hotspot..."
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Април"
 
-#: ../panels/network/network.ui.h:43
-#| msgid "Autodetect"
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "Автоматски"
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Мај"
 
-#: ../panels/network/network.ui.h:44
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "Рачно"
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Јуни"
 
-#: ../panels/network/network.ui.h:45
-#| msgid "None"
-msgctxt "proxy method"
-msgid "None"
-msgstr "Ништо"
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Јули"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:83
-#| msgid "Firebird"
-msgid "Wired"
-msgstr "Жичен"
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Август"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:87
-msgid "Wireless"
-msgstr "Безжичен"
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Септември"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:94
-msgid "Mobile broadband"
-msgstr "Мобилен широкопојасен"
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Октомври"
 
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:103
-#| msgid "Models"
-msgid "Mesh"
-msgstr "Мрежа"
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Ноември"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:162
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Декември"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:166
-msgid "Infrastructure"
-msgstr "Инфраструктурен"
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Ден"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:190
-#: ../panels/network/panel-common.c:251
-msgid "Status unknown"
-msgstr "Статусот е непознат"
+#: panels/datetime/cc-datetime-panel.ui:113
+#, fuzzy
+msgid "Time Zone"
+msgstr "Време"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:194
-msgid "Unmanaged"
-msgstr "Неменаџиран"
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
 
-#: ../panels/network/panel-common.c:199
-msgid "Firmware missing"
-msgstr "Недостасува firmware"
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
 
-#: ../panels/network/panel-common.c:202
-msgid "Cable unplugged"
-msgstr "Кабелот е откачен"
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
 
-#: ../panels/network/panel-common.c:204
-msgid "Unavailable"
-msgstr "Не е достапен"
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Датум и време"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:208
-#| msgid "Not connected"
-msgid "Disconnected"
-msgstr "Неповрзан"
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "А_втоматска најава"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:215
-#: ../panels/network/panel-common.c:257
-msgid "Connecting"
-msgstr "Се поврзувам"
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:219
-#: ../panels/network/panel-common.c:261
-#| msgid "Authenticated!"
-msgid "Authentication required"
-msgstr "Потребна е автентикација"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Овозможено"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223
-#: ../panels/network/panel-common.c:265
-#| msgid "Not connected"
-msgid "Connected"
-msgstr "Поврзан"
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:227
-msgid "Disconnecting"
-msgstr "Ја прекинувам врската"
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Отклучи"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:231
-#: ../panels/network/panel-common.c:269
-#| msgid "Copying files"
-msgid "Connection failed"
-msgstr "Врската не успеа"
+#: panels/datetime/cc-datetime-panel.ui:246
+#, fuzzy
+msgid "Time _Format"
+msgstr "Формат:"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:235
-#: ../panels/network/panel-common.c:277
-msgid "Status unknown (missing)"
-msgstr "Статусот е непознат (недостасува)"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:273
-msgid "Not connected"
-msgstr "Не е поврзано"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Датуми"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:305
-msgid "Error logging into the account"
-msgstr "Грешка при најавата на сметката"
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "30 секунди"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:351
-msgid "Expired credentials. Please log in again."
-msgstr "Истечени акредитиви. Најавете се повторно."
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Календар"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:354
-#| msgctxt "Sound event"
-#| msgid "Login"
-msgid "_Log In"
-msgstr "_Најави се"
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Бројки"
 
-#. translators: This is the title of the "Add Account" dialogue.
-#. * The title is not visible when using GNOME Shell
-#: ../panels/online-accounts/cc-online-accounts-panel.c:461
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "Add Account"
-msgstr "Додај сметка"
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:466
-msgid "To add a new account, first select the account type"
-msgstr "За да додадете нова сметка прво изберете го типот на сметката"
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Часовник;Временска зона;Локација;"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:469
-#| msgid "Alert Type"
-msgid "Account Type:"
-msgstr "Тип на сметка"
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Промени ги поставувањата за регион и јазик"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Add..."
-msgstr "_Додај..."
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:555
-msgid "Error creating account"
-msgstr "Грешка при креирањето на сметка"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Веб"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:589
-msgid "Error removing account"
-msgstr "Грешка при отстранувањето на сметката"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Пошта"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:625
-#| msgid "Are you sure you want to permanently delete \"%s\"?"
-msgid "Are you sure you want to remove the account?"
-msgstr "Дали сте сигурни дека сакате да ја избришете сметката?"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Календар"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:627
-msgid "This will not remove the account on the server."
-msgstr "Ова нема да ја отстрани сметката од серверот."
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "М_узика"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:628
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Видео"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Слики"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Стандардни апликации"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Стандардни апликации"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+#, fuzzy
+msgid "Problem Reporting"
+msgstr "Пропорционално"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Залиха"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Назад"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Bluetooth-от е оневозможен"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Огледало на приказот"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+#, fuzzy
+msgid "Mirror"
+msgstr "Грешка"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Огледало на приказот"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Ориентација за левичари"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Резолуција"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Бр_зина на освежување:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Размер"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Фракција комплетна"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Нема достапни печатачи"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Времиња"
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Од URI"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "минута"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Прикази"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+#, fuzzy
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Промени ја резолуцијата и позицијата на мониторите и проекторите"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Панел;Проектор;xrandr;Екран;Резолуција;Освежи;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Безбедносен клуч"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Ниво на боја за печатење"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Ниво на боја за печатење"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Ниво на боја за печатење"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Безбедност"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Име на уред"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Хардверска адрееса"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Меморија"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Процесор"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Графика"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+#, fuzzy
+msgid "Calculating…"
+msgstr "Пресметувам..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Име"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Тип"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Терминал за GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Прозорецот е минимизиран"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+#, fuzzy
+msgid "Virtualization"
+msgstr "Калибрација"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Инсталирај ажурирања"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Отстрани уред"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Име на уред"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_Корисничко име"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_За"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"уред;систем;информација;меморија;процесор;верзија;стандардно;апликација;спас;"
+"префереиран;cd;dvd;usb;ауди;видео;диск;преносен;медиум;атоматско пуштање;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Звук и медиуми"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Исклучи го гласот"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Намали ја гласноста"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Зголеми ја гласноста"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "Гласност на микрофонот"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Пушти пуштач на медиуми"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Пушти (или пушти/пауза)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Паузирај"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Стопирај"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Претходна песна"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Следна песна"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Извади"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Пишување"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Изберете извор на влез за додавање"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Пуштачи"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Пушти прелистувач на помош"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Сите поставувања"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Пушти калкулатор"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Пушти клиент за е-пошта"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Пушти веб прелистувач"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Домашна папка"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Пребарувај"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Систем"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Одјави се"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Заклучи го екранот"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Пристапност за глушецот"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Исклучи или пушти зум"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Зумирај"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Одзумирај"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Исклучи или пушти го читачот на екранот"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Исклучи или приклучи ја екранската тастатура"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Намали ја големината на текстот"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Намали ја големината на текстот"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Пушти или исклучи висок контраст"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+#, fuzzy
+msgid "Add an Input Source"
+msgstr "Влезен извор:"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+#, fuzzy
+msgid "No input source selected"
+msgstr "Изберете извор на влез за додавање"
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "_Опции"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Помести нагоре"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Помести надолу"
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Преференци"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Опции за распоредите на тастатурата"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Отстрани"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "Влезен извор:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Влезен извор:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "Користи го истиот распоред за сите прозорци"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Копчиња на глушецот"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+#, fuzzy
+msgid "Keyboard Shortcuts"
+msgstr "Поставувања за тастатура"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Сопствени кратенки"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Оддел"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Кратенки"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Додај кратенка"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Сопствени кратенки"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Додај кратенка"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Отстрани"
 
-#. Translators: those are keywords for the online-accounts control-center panel
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
-msgstr "Google;Facebook;Twitter;Yahoo;Веб;Онлајн;Разговор;Календар;Пошта;Контакт;"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
-msgid "Manage online accounts"
-msgstr "Менаџирајте со онлајн сметките"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Име"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "К_оманда:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Кратенка"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Кратенка"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ништо"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_Ресетирај на стандардното"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Тастатура"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Нема апликации кои моментално пуштаат или снимаат аудио."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Поставете лични информации"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Гласност на микрофонот"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Нема апликации кои моментално пуштаат или снимаат аудио."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Вашите поставувања"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Општо"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "Основна боја"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Лево"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Десно"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Опции за печатачот"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Глушец"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Брзина на стрелката"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Движи се надолу"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+#, fuzzy
+msgid "Traditional"
+msgstr "Пропорционално"
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Забрзување:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Тачпад"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Тачпад"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Метод"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "Клик со застанување со стрелката врз предметите"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Кликнато е копче"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Оневозможи го _тачпадот при пишување"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Тачпад (релативен)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "Движење"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Движи се налево"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
+msgstr "Глушец и тачпад"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+#, fuzzy
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Тракпад;Стрелка;Клик;Тапкање;Двоен;Копче;Тракбол;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Простор на бои:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Монитор"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Влечете за да го промените примарниот приказ."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Апликации"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Уреди"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Врска"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Поврзан"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "_Опции"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Мрежно име"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Лозинка"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Лозинка на група"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Избери генерирана лозинка"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Режим за во а_вион"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Не се пронајдени Bluetooth адаптери"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Режим за во а_вион"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Мрежа"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+#, fuzzy
+msgid "802.1x _Security"
+msgstr "Безбедност"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Брзина на трепкање на стрелката"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Безбедност"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 адреса"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 адреса"
+
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr "Хардверска адрееса"
+
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Поддржани ICC профили"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Стандардна рута"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Име:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Адреса:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Адреса:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "_Метод"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+#, fuzzy
+msgid "Automatic (DHCP)"
+msgstr "Автоматски"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+#, fuzzy
+msgid "Manual"
+msgstr "Рачно"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Оневозможено"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Адреса"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Адреса"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Премин"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "Автоматски"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+#, fuzzy
+msgid "Automatic DNS"
+msgstr "Автоматски"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+#, fuzzy
+msgid "Automatic Routes"
+msgstr "Автоматски"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Метрички"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "_Метод"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+#, fuzzy
+msgid "Automatic, DHCP only"
+msgstr "А_втоматска најава"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+#, fuzzy
+msgid "S_ecurity"
+msgstr "Безбедност"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Мрежа"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to the Internet"
+msgstr "Не сум поврзан на интернет."
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Мрежа;Безжичен;IP;LAN;Прокси;"
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Жичен"
+
+#: panels/network/network-bluetooth.ui:11
+#, fuzzy
+msgid "Turn device off"
+msgstr "Уредот е исклучен"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "%u активно"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Провајдер"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP адреса"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Мрежен прокси"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "H_TTP прокси"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS прокси:"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP прокси"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "S_ocks хост"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "Игнорирани хостови"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "H_TTP прокси"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "H_TTPS прокси:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP прокси"
+
+#: panels/network/network-proxy.ui:339
+#, fuzzy
+msgid "Socks proxy port"
+msgstr "Socks порта"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_URL за конфигурирање"
+
+#: panels/network/network-vpn.ui:11
+#, fuzzy
+msgid "Turn VPN connection off"
+msgstr "Исклучи или приклучи:"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Мрежно име"
+
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Безбедносен клуч"
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Лозинка"
+
+#: panels/network/network-wifi.ui:90
+#, fuzzy
+msgid "Turn Wi-Fi off"
+msgstr "Исклучи или приклучи:"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Покажи ги сите опции за помош"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "_Провери автентичност"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "Сите датотеки"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Користи проверка</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Корисничко име"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Лозинка"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Покажи ја лозинката"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Верзија %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Верзија %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_Провери автентичност"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "Потребна е автентикација"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Нова лозинка"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+#, fuzzy
+msgid "PAP"
+msgstr "WPA"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_Провери автентичност"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "_Тип"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Стандардно"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Датотечен систем"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Р_отација"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Звучни ефекти"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Заклучи го екранот по:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "_Заклучи го екранот по:"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Користи проверка</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Додај сметка"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Онлајн сметки"
 
-#: ../panels/online-accounts/online-accounts.ui.h:2
-#| msgid "Revert Font"
-msgid "Remove Account"
-msgstr "Избриши ја сметката"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
 
-#: ../panels/online-accounts/online-accounts.ui.h:3
-#| msgid "_Selected layouts:"
-msgid "Select an account"
-msgstr "Избери сметка"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+#, fuzzy
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Веб;Онлајн;Разговор;Календар;Пошта;Контакт;"
 
-#: ../panels/power/cc-power-panel.c:160
-#| msgid "Unknown"
-msgid "Unknown time"
-msgstr "Непознат тип"
-
-#: ../panels/power/cc-power-panel.c:166
+#: panels/power/cc-battery-row.c:83
 #, c-format
-#| msgid "minutes"
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i минута"
 msgstr[1] "%i минути"
 
-#: ../panels/power/cc-power-panel.c:178
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i час"
 msgstr[1] "%i часа"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:186
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:187
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "час"
 msgstr[1] "часа"
 
-#: ../panels/power/cc-power-panel.c:188
-#| msgid "minutes"
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "минута"
 msgstr[1] "минути"
 
-#: ../panels/power/cc-power-panel.c:265
-#| msgctxt "Sound event"
-#| msgid "Battery warning"
-msgid "Battery charging"
-msgstr "Батеријата се полни"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "5 минути"
 
-#: ../panels/power/cc-power-panel.c:268
-#| msgctxt "Sound event"
-#| msgid "Battery warning"
-msgid "Battery discharging"
-msgstr "Батеријата се празни"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 минути"
 
-#: ../panels/power/cc-power-panel.c:279
-msgid "UPS charging"
-msgstr "UPS се полни"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 минути"
 
-#: ../panels/power/cc-power-panel.c:282
-msgid "UPS discharging"
-msgstr "UPS се празни"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:300
-#, c-format
-msgid "%s until charged (%.0lf%%)"
-msgstr "%s додека се наполни (%.0lf%%)"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:306
-#, c-format
-msgid "%s until empty (%.0lf%%)"
-msgstr "%s додека се испразне (%.0lf%%)"
-
-#. TRANSLATORS: %1 is a percentage value. Note: this string is only
-#. * used when we don't have a time value
-#: ../panels/power/cc-power-panel.c:314
-#, c-format
-msgid "%.0lf%% charged"
-msgstr "наполнет е %.0lf%%"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-#| msgid "Pointer"
-msgid "Power"
-msgstr "Енергија"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Power management settings"
-msgstr "Поставувања за менаџментот со енергија"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid "Power;Sleep;Suspend;Hibernate;Battery;"
-msgstr "Енергија;Спиј;Суспендирај;Хибернирај;Батерија;"
-
-#: ../panels/power/power.ui.h:1
-#: ../panels/screen/screen.ui.h:1
-msgid "1 hour"
-msgstr "1 час"
-
-#: ../panels/power/power.ui.h:2
-#: ../panels/screen/screen.ui.h:3
-#| msgid "minutes"
-msgid "10 minutes"
-msgstr "10 минути"
-
-#: ../panels/power/power.ui.h:3
-#: ../panels/screen/screen.ui.h:6
-#| msgid "minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 минути"
 
-#: ../panels/power/power.ui.h:4
-#: ../panels/screen/screen.ui.h:8
-#| msgid "minutes"
-msgid "5 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
 msgstr "5 минути"
 
-#: ../panels/power/power.ui.h:5
-msgid "Don't suspend"
-msgstr "Не суспендирај"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 час"
 
-#: ../panels/power/power.ui.h:6
-msgid "Hibernate"
-msgstr "Хибернирај"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "10 минути"
 
-#: ../panels/power/power.ui.h:7
-msgid "On battery power"
-msgstr "На батерија"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "10 минути"
 
-#: ../panels/power/power.ui.h:8
-msgid "Power off"
-msgstr "Исклучи се"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "10 минути"
 
-#: ../panels/power/power.ui.h:9
-msgid "Suspend when inactive for:"
-msgstr "Суспендирај се по неактивност од:"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "1 час"
 
-#: ../panels/power/power.ui.h:10
-msgid "When plugged in"
-msgstr "Кога сум приклучен"
+#: panels/power/cc-power-panel.ui:58
+#, fuzzy
+msgid "Battery"
+msgstr "Батеријата се полни"
 
-#: ../panels/power/power.ui.h:11
-msgid "When power is _critically low:"
-msgstr "Кога енергијата е _многу празна:"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:533
-msgid "Low on toner"
-msgstr "Тонерот е при крај"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:535
-msgid "Out of toner"
-msgstr "Нема тонер"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:538
-msgid "Low on developer"
-msgstr "Развивачот за фотографии е при крај"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:541
-msgid "Out of developer"
-msgstr "Нема развивач за фотографии"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:543
-msgid "Low on a marker supply"
-msgstr "Маркерот е при крај"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:545
-msgid "Out of a marker supply"
-msgstr "Нема маркер"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:547
-#| msgid "Open File"
-msgid "Open cover"
-msgstr "Отворен капак"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:549
-#| msgid "Vendors"
-msgid "Open door"
-msgstr "Отворена врата"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:551
-msgid "Low on paper"
-msgstr "Хартијата е при крај"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:553
-msgid "Out of paper"
-msgstr "Нема хартија"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:555
-#| msgid "Off"
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Исклучен"
-
-#. Translators: Someone has paused the Printer
-#: ../panels/printers/cc-printers-panel.c:557
-#| msgid "_Paste"
-msgctxt "printer state"
-msgid "Paused"
-msgstr "Паузиран"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:559
-msgid "Waste receptacle almost full"
-msgstr "Контејнерот за ѓубре е скоро полн"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:561
-msgid "Waste receptacle full"
-msgstr "Контејнерот за ѓубре е преполн"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:563
-msgid "The optical photo conductor is near end of life"
-msgstr "Оптичкиот фотоспроводник е при крајот на животниот век"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:565
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Оптичкиот фотоспроводник веќе не работи"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:737
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Подготвен"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:741
-#| msgid "_Profession:"
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Процесира"
-
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:745
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Запрен"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:864
-msgid "Toner Level"
-msgstr "Ниво на тонер"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:867
-msgid "Ink Level"
-msgstr "Ниво на боја за печатење"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:870
-msgid "Supply Level"
-msgstr "Количина во залиха"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:885
-#: ../panels/printers/cc-printers-panel.c:1271
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u активно"
-msgstr[1] "%u активни"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:990
-msgid "No printers available"
-msgstr "Нема достапни печатачи"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/cc-printers-panel.c:1314
-msgctxt "print job"
-msgid "Pending"
-msgstr "Чекам"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/cc-printers-panel.c:1318
-#| msgid "Help"
-msgctxt "print job"
-msgid "Held"
-msgstr "Задржан"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/cc-printers-panel.c:1322
-#| msgid "_Profession:"
-msgctxt "print job"
-msgid "Processing"
-msgstr "Се процесира"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/cc-printers-panel.c:1326
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Запрено"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/cc-printers-panel.c:1330
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Прекинато"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/cc-printers-panel.c:1334
-#| msgid "About Me"
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Прекинато"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/cc-printers-panel.c:1338
-msgctxt "print job"
-msgid "Completed"
-msgstr "Завршено"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/cc-printers-panel.c:1421
-#| msgid "_Title:"
-msgid "Job Title"
-msgstr "Наслов на печатењето"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/cc-printers-panel.c:1430
-msgid "Job State"
-msgstr "Состојба на печатењето"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/cc-printers-panel.c:1436
-#| msgid "Theme"
-msgid "Time"
-msgstr "Време"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:2032
-msgid "Failed to add new printer."
-msgstr "Не успеав да додадам нов печатач."
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2236
-#: ../panels/printers/cc-printers-panel.c:2250
-#| msgid "page"
-msgid "Test page"
-msgstr "Тест страница"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2498
-#, c-format
-#| msgid "Could not load the main interface"
-msgid "Could not load ui: %s"
-msgstr "Не можев да го вчитам интерфејсот: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
-#| msgid "Change set"
-msgid "Change printer settings"
-msgstr "Промени ги поставувањата за печатачот"
-
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
-msgid "Printer;Queue;Print;Paper;Ink;Toner;"
-msgstr "Печатач;Ред;Печати;Хартија;Боја за печатење;Тонер;"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
-#: ../panels/printers/pp-new-printer-dialog.c:148
-#| msgid "Pointer"
-msgid "Printers"
-msgstr "Печатачи"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "A_ddress:"
-msgstr "А_дреса:"
-
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#| msgid "Large Pointer"
-msgid "Add a New Printer"
-msgstr "Додај нов печатач"
-
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#| msgid "_Add..."
-msgid "_Add"
-msgstr "_Додај"
-
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "_Search by Address"
-msgstr "_Барај по адреса"
-
-#: ../panels/printers/pp-new-printer-dialog.c:654
-msgid "Getting devices..."
-msgstr "Ги добивам уредите..."
-
-#. Translators: No localy connected printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1230
-msgid "No local printers found"
-msgstr "Не се пронајдени локални уреди"
-
-#. Translators: No network printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1243
-#| msgid "Network Servers"
-msgid "No network printers found"
-msgstr "Не се пронајдени печатачи"
-
-#: ../panels/printers/pp-new-printer-dialog.c:1335
-msgid "FirewallD is not running. Network printer detection needs services mdns, ipp, ipp-client and samba-client enabled on firewall."
-msgstr "Не се извршува FirewallD. За детектирање на мрежните печатачи потребно е mdns, ipp, ipp-client и samba-client да бидат овозможени на firewall."
-
-#. Translators: Column of devices which can be installed
-#: ../panels/printers/pp-new-printer-dialog.c:1363
-#: ../panels/printers/pp-new-printer-dialog.c:1368
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
 msgid "Devices"
 msgstr "Уреди"
 
-#. Translators: Local means local printers
-#: ../panels/printers/pp-new-printer-dialog.c:1393
-msgctxt "printer type"
-msgid "Local"
-msgstr "Локален"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Исклучи се"
 
-#. Translators: Network means network printers
-#: ../panels/printers/pp-new-printer-dialog.c:1395
-#| msgid "Network Proxy"
-msgctxt "printer type"
-msgid "Network"
-msgstr "Мрежа"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#. Translators: Device types column (network or local)
-#: ../panels/printers/pp-new-printer-dialog.c:1436
-#| msgid "Devices"
-msgid "Device types"
-msgstr "Типови на уреди"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Опции за печатачот"
 
-#. Translators: Name of job which makes printer to autoconfigure itself
-#: ../panels/printers/pp-new-printer-dialog.c:1737
-#| msgid "<b>_Automatic proxy configuration</b>"
-msgid "Automatic configuration"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
 msgstr "Автоматска конфигурација"
 
-#: ../panels/printers/pp-new-printer-dialog.c:1818
-msgid "Opening firewall for mDNS connections"
-msgstr "Отворам заштитен ѕид за mDNS врски"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Поставувања за светлост и заклучување на екранот"
 
-#: ../panels/printers/pp-new-printer-dialog.c:1827
-msgid "Opening firewall for Samba connections"
-msgstr "Отворам заштитен ѕид за Samba врски"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Екран"
 
-#: ../panels/printers/pp-new-printer-dialog.c:1836
-msgid "Opening firewall for IPP connections"
-msgstr "Отворам заштитен ѕид за IPP врски"
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
 
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:2
-msgid "Active Print Jobs"
-msgstr "Активни печатења"
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Екран"
 
-#. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:4
-msgid "Add New Printer"
-msgstr "Додај нов печатач"
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:5
-#| msgid "Pointer"
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Автоматски"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Долно копче"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+#, fuzzy
+msgid "Automatic Suspend"
+msgstr "Автоматски"
+
+#: panels/power/cc-power-panel.ui:267
+#, fuzzy
+msgid "_Plugged In"
+msgstr "Кога сум приклучен"
+
+#: panels/power/cc-power-panel.ui:279
+#, fuzzy
+msgid "On _Battery Power"
+msgstr "На батерија"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Одложување:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Енергија"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "Енергија;Спиј;Суспендирај;Хибернирај;Батерија;"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Печатачи"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Печатач;Ред;Печати;Хартија;Боја за печатење;Тонер;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Додај печатач"
 
-#: ../panels/printers/printers.ui.h:6
-msgid "Add User"
-msgstr "Нов корисник"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "Отклучи"
 
-#: ../panels/printers/printers.ui.h:7
-msgid "Allowed users"
-msgstr "Дозволени корисници"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Не се пронајдени локални уреди"
 
-#: ../panels/printers/printers.ui.h:8
-msgid "Cancel Print Job"
-msgstr "Прекини печатење"
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:10
-msgid "Jobs"
-msgstr "Печатења"
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Потребна е автентикација"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:12
-#| msgid "Action"
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Корисничко име"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Локација"
 
-#: ../panels/printers/printers.ui.h:13
-#| msgid "Models"
-msgid "Model"
-msgstr "Модел"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Драјвер"
 
-#: ../panels/printers/printers.ui.h:14
-msgid "Pause Printing"
-msgstr "Паузирај со печатење"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
 
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:16
-msgid "Print _Test Page"
-msgstr "Испечати _тест страница"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "_Барај по адреса"
 
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:18
-msgid "Printer Options"
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "Избирам прст"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Откажи"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Избери"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_Провери автентичност"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Провери автентичност"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "Активни печатења"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Тест страница"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
 msgstr "Опции за печатачот"
 
-#: ../panels/printers/printers.ui.h:19
-#| msgid "Remove from Favorites"
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Опции за печатачот"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "_Ресетирај на стандардното"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "Прекини печатење"
+
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Отстрани печатач"
 
-#: ../panels/printers/printers.ui.h:20
-msgid "Remove User"
-msgstr "Отстрани корисник"
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Активни печатења"
 
-#: ../panels/printers/printers.ui.h:21
-msgid "Resume Printing"
-msgstr "Продолжи со печатење"
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Модел"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Ниво на боја за печатење"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "_Изврши при подигнување"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Додај печатач"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Промени ги поставувањата за печатачот"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Печатачи"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:23
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Жалам, но сервисот за печатење\n"
 "изгледа дека не е активен."
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:26
-msgid "Supply"
-msgstr "Залиха"
-
-#. Translators: Switch back to printer's info tab
-#: ../panels/printers/printers.ui.h:28
-msgid "_Back"
-msgstr "_Назад"
-
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:30
-#| msgid "Default"
-msgid "_Default"
-msgstr "_Стандарден"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:32
-#| msgid "_Open"
-msgid "_Options"
-msgstr "_Опции"
-
-#. Tanslators: Switch to tab containing printer's jobs
-#: ../panels/printers/printers.ui.h:34
-#| msgid "Shutdown"
-msgid "_Show"
-msgstr "_Покажи"
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
-msgid "Change your region and language settings"
-msgstr "Промени ги поставувањата за регион и јазик"
-
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
-msgid "Language;Layout;Keyboard;"
-msgstr "Јазик;Распоред;Тастатура;"
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-#: ../panels/region/gnome-region-panel.ui.h:24
-msgid "Region and Language"
-msgstr "Регион и јазик"
-
-#: ../panels/region/gnome-region-panel-formats.c:142
-#| msgid "Opera"
-msgid "Imperial"
-msgstr "Империјален"
-
-#: ../panels/region/gnome-region-panel-formats.c:144
-msgid "Metric"
-msgstr "Метрички"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
-msgid "Choose a Layout"
-msgstr "Изберете распоред"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
-#| msgid "Preview:"
-msgid "Preview"
-msgstr "Преглед"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
-msgid "Select an input source to add"
-msgstr "Изберете извор на влез за додавање"
-
-#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
-msgid "Keyboard Layout Options"
-msgstr "Опции за распоредите на тастатурата"
-
-#: ../panels/region/gnome-region-panel-system.c:395
-msgid "The login screen, system accounts and new user accounts use the system-wide Region and Language settings."
-msgstr "Најавниот екран, сметките на системот и новите корисници ги корсистат системските поставувања за јазик и регион."
-
-#: ../panels/region/gnome-region-panel-system.c:400
-#: ../panels/region/gnome-region-panel.ui.h:35
-msgid "The login screen, system accounts and new user accounts use the system-wide Region and Language settings. You may change the system settings to match yours."
-msgstr "Најавниот екран, сметките на системот и новите корисници ги корсистат системските поставувања за јазик и регион. Можете да ги промените системските поставувања да се совпаѓаат со Вашите."
-
-#: ../panels/region/gnome-region-panel-system.c:403
-#| msgid "Copying '%s'"
-msgid "Copy Settings"
-msgstr "Копирај ги поставувањата"
-
-#: ../panels/region/gnome-region-panel-system.c:406
-#: ../panels/region/gnome-region-panel.ui.h:5
-msgid "Copy Settings..."
-msgstr "Копирај ги поставувањата..."
-
-#: ../panels/region/gnome-region-panel.ui.h:1
-#| msgid "_Language:"
-msgid "Add Language"
-msgstr "Додај јазик"
-
-#: ../panels/region/gnome-region-panel.ui.h:2
-#| msgid "Layout"
-msgid "Add Layout"
-msgstr "Додај распоред"
-
-#: ../panels/region/gnome-region-panel.ui.h:3
-msgid "Add Region"
-msgstr "Додај регион"
-
-#: ../panels/region/gnome-region-panel.ui.h:4
-msgid "Allow different layouts for individual windows"
-msgstr "Дозволи различни распореди за посебните прозорци"
-
-#: ../panels/region/gnome-region-panel.ui.h:6
-msgid "Currency"
-msgstr "Валута"
-
-#: ../panels/region/gnome-region-panel.ui.h:7
-#| msgid "aterm"
-msgid "Dates"
-msgstr "Датуми"
-
-#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
-#: ../panels/region/gnome-region-panel.ui.h:9
-#| msgid "By _language"
-msgid "Display language:"
-msgstr "Јазик за приказ:"
-
-#: ../panels/region/gnome-region-panel.ui.h:10
-msgid "Examples"
-msgstr "Примери"
-
-#: ../panels/region/gnome-region-panel.ui.h:11
-#| msgid "Port:"
-msgid "Format:"
-msgstr "Формат:"
-
-#: ../panels/region/gnome-region-panel.ui.h:12
-#| msgid "Fonts"
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Формати"
 
-#: ../panels/region/gnome-region-panel.ui.h:13
-#| msgid "_Input boxes:"
-msgid "Input source:"
-msgstr "Влезен извор:"
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:14
-#| msgid "_Install..."
-msgid "Install languages..."
-msgstr "Инсталирај јазици..."
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Чести задачи"
 
-#: ../panels/region/gnome-region-panel.ui.h:15
-#| msgid "_Language:"
-msgid "Language"
-msgstr "Јазик"
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Формати"
 
-#: ../panels/region/gnome-region-panel.ui.h:16
-msgid "Layouts"
-msgstr "Распореди"
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:17
-#| msgid "_Department:"
-msgid "Measurement"
-msgstr "Мерење"
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:18
-#| msgid "gesture|Move down"
-msgid "Move Down"
-msgstr "Помести надолу"
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Преглед"
 
-#: ../panels/region/gnome-region-panel.ui.h:19
-msgid "Move Up"
-msgstr "Помести нагоре"
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Датуми"
 
-#: ../panels/region/gnome-region-panel.ui.h:20
-msgid "New windows use the default layout"
-msgstr "Новите прозорци ќе го користат стандардниот распоред"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Датум и време"
 
-#: ../panels/region/gnome-region-panel.ui.h:21
-msgid "New windows use the previous window's layout"
-msgstr "Новите прозорци ќе го користат распоредот од претходниот прозорец"
-
-#: ../panels/region/gnome-region-panel.ui.h:22
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Бројки"
 
-#: ../panels/region/gnome-region-panel.ui.h:23
-#| msgid "Preview:"
-msgid "Preview Layout"
-msgstr "Распоред на преглед"
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Мерење"
 
-#: ../panels/region/gnome-region-panel.ui.h:25
-#| msgid "_Language:"
-msgid "Remove Language"
-msgstr "Отстрани јазик"
-
-#: ../panels/region/gnome-region-panel.ui.h:26
-#| msgid "Choose a Layout"
-msgid "Remove Layout"
-msgstr "Отстрани распоред"
-
-#: ../panels/region/gnome-region-panel.ui.h:27
-msgid "Remove Region"
-msgstr "Отстрани го регионот"
-
-#: ../panels/region/gnome-region-panel.ui.h:28
-msgid ""
-"Replace the current keyboard layout settings with the\n"
-"default settings"
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
 msgstr ""
-"Замени го тековниот распоред на тастатурата со\n"
-"стандардните поставувања"
 
-#: ../panels/region/gnome-region-panel.ui.h:30
-msgid "Reset to De_faults"
-msgstr "Ресетирај на ста_ндардното"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:31
-msgid "Select a display language (change will be applied next time you log in)"
-msgstr "Изберете јазик (промените ќе бидат активни следниот пат кога ќе се најавите)"
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "Одјава"
 
-#: ../panels/region/gnome-region-panel.ui.h:32
-msgid "Select a region (change will be applied the next time you log in)"
-msgstr "Изберете регион (промените ќе бидат активни следниот пат кога ќе се најавите)"
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:34
-#| msgid "_Type to test settings:"
-msgid "System settings"
-msgstr "Системски поставувања"
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Инсталирај јазици..."
 
-#: ../panels/region/gnome-region-panel.ui.h:36
-#| msgid "Test"
-msgid "Times"
-msgstr "Времиња"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Мојата сметка"
 
-#: ../panels/region/gnome-region-panel.ui.h:37
-#| msgid "_Use the same proxy for all protocols"
-msgid "Use the same layout for all windows"
-msgstr "Користи го истиот распоред за сите прозорци"
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Јазик"
 
-#: ../panels/region/gnome-region-panel.ui.h:38
-#| msgid "Keyboard Layout Options"
-msgid "View and edit keyboard layout options"
-msgstr "Прегледај и уреди ги поставувањата за распоредот на тастатурата"
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "Формати"
 
-#: ../panels/region/gnome-region-panel.ui.h:39
-msgid "Your settings"
-msgstr "Вашите поставувања"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Заклучи го екранот"
 
-#: ../panels/region/gnome-region-panel.ui.h:40
-#| msgid "Layout _Options..."
-msgid "_Options..."
-msgstr "_Опции..."
+#: panels/region/gnome-region-panel.desktop.in.in:3
+#, fuzzy
+msgid "Region & Language"
+msgstr "Регион и јазик"
 
-#: ../panels/region/gnome-region-panel-xkblt.c:210
-msgid "Layout"
-msgstr "Распоред"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel-xkbot.c:229
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "Default"
-msgstr "Стандардно"
+#: panels/region/gnome-region-panel.desktop.in.in:19
+#, fuzzy
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Јазик;Распоред;Тастатура;"
 
-#. Translators: those are keywords for the brightness and lock control-center panel
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
-msgid "Brightness;Lock;Dim;Blank;Monitor;"
-msgstr "Светлост;Заклучи;Затемни;Зацрни;Монитор;"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Изберете како ќе се справувам со медиумот"
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
-#| msgid "Lock Screen"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Аудио CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD видео"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Пуштач на музика"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Софтвер"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+#, fuzzy
+msgid "_Other Media…"
+msgstr "_Други медиуми..."
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Не прашувај или стартувај програми при внесување на медиум"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Изберте како ќе се справувам со другите медиуми"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "_Дејство"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Тип"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Removable Media"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Конфигурирај ги поставувањата за Bluetooth"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"уред;систем;информација;меморија;процесор;верзија;стандардно;апликација;спас;"
+"префереиран;cd;dvd;usb;ауди;видео;диск;преносен;медиум;атоматско пуштање;"
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Екран"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+#, fuzzy
+msgid "Automatic Screen _Lock"
+msgstr "А_втоматска најава"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Заклучи го екранот"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Екран"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
 msgid "Screen"
 msgstr "Екран"
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
-msgid "Screen brightness and lock settings"
-msgstr "Поставувања за светлост и заклучување на екранот"
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Поставувања за звук"
 
-#: ../panels/screen/screen.ui.h:2
-#| msgid "minutes"
-msgid "1 minute"
-msgstr "1 минута"
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:4
-#| msgid "minutes"
-msgid "2 minutes"
-msgstr "2 минути"
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Локација"
 
-#: ../panels/screen/screen.ui.h:5
-#| msgid "minutes"
-msgid "3 minutes"
-msgstr "3 минути"
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:7
-#| msgid "seconds"
-msgid "30 seconds"
-msgstr "30 секунди"
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:9
-msgid "Brightness"
-msgstr "Светлост"
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
 
-#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
-#: ../panels/screen/screen.ui.h:11
-msgid "Don't lock when at home"
-msgstr "Не заклучувај се кога сум дома"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Друго..."
 
-#: ../panels/screen/screen.ui.h:12
-#| msgid "Layout _Options..."
-msgid "Locations..."
-msgstr "Локации..."
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Локација"
 
-#: ../panels/screen/screen.ui.h:13
-msgid "Lock"
-msgstr "Заклучи"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Апликации"
 
-#: ../panels/screen/screen.ui.h:14
-msgid "Screen turns off"
-msgstr "Екранот се исклучува"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:15
-msgid "_Dim screen to save power"
-msgstr "_Затемни го екранот за да заштедува енергија"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/screen/screen.ui.h:16
-#| msgid "Lock Screen"
-msgid "_Lock screen after:"
-msgstr "_Заклучи го екранот по:"
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "_Барај по адреса"
 
-#: ../panels/screen/screen.ui.h:17
-msgid "_Turn screen off when inactive for:"
-msgstr "_Изгасни го екранот при неактивност од:"
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
-#: ../panels/sound/applet-main.c:49
-msgid "Enable debugging code"
-msgstr "Овозможи дебагирање на код"
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
 
-#: ../panels/sound/applet-main.c:50
-#| msgid "Open with Default Application"
-msgid "Version of this application"
-msgstr "Верзија на оваа апликација"
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
 
-#: ../panels/sound/applet-main.c:62
-msgid " — GNOME Volume Control Applet"
-msgstr " — Аплетот за контрола на глас на GNOME "
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Мрежа"
 
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
-msgid "Show desktop volume control"
-msgstr "Покажи ги контролите за глас"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+#, fuzzy
+msgid "Sharing"
+msgstr "Слушање"
 
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
-#| msgid "Unknown Volume Control %d"
-msgid "Volume Control"
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Слушање"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Работна површина"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "Отстрани го регионот"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Слушање"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Лозинка"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+#, fuzzy
+msgid "Remote Login"
+msgstr "Отстрани го регионот"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Работна површина"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "Контрола на гласност"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
-msgstr "Картичка;Микрофон;Звук;Намалување;Баланс;Bluetooth;Слушалки;"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
-#| msgid "Enable sound and associate sounds with events"
-msgid "Change sound volume and sound events"
-msgstr "Промени ја гласноста на звукот и звучните настани"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Не е поврзано"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Sound"
-msgstr "Звук"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "Лаење"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Копирај"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "Капење"
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "Стакло"
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Провери автентичност"
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-#| msgid "Sound"
-msgid "Sonar"
-msgstr "Сонар"
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
 
-#: ../panels/sound/gvc-applet.c:270
-#: ../panels/sound/gvc-mixer-dialog.c:1767
-#| msgid "Mutt"
-msgid "Output"
-msgstr "Излез"
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Корисничко име"
 
-#: ../panels/sound/gvc-applet.c:272
-msgid "Sound Output Volume"
-msgstr "Гласност на звучниот излез"
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
 
-#: ../panels/sound/gvc-applet.c:276
-#: ../panels/sound/gvc-mixer-dialog.c:1808
-msgid "Input"
-msgstr "Влез"
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Запишани отпечатоци"
 
-#: ../panels/sound/gvc-applet.c:278
-msgid "Microphone Volume"
-msgstr "Гласност на микрофонот"
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:111
-#| msgid "Left"
-msgctxt "balance"
-msgid "Left"
-msgstr "Лево"
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "Слушање"
 
-#: ../panels/sound/gvc-balance-bar.c:112
-#| msgid "Right"
-msgctxt "balance"
-msgid "Right"
-msgstr "Десно"
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:115
-#| msgid "Search"
-msgctxt "balance"
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+#, fuzzy
+msgid "Enable or disable remote login"
+msgstr "Овозможи х_оризонтално движење"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Слушање"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Ниво:"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Избледни:"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Назад"
 
-#: ../panels/sound/gvc-balance-bar.c:116
-#| msgid "Fonts"
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Напред"
 
-#: ../panels/sound/gvc-balance-bar.c:119
-#| msgid "Minimize"
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Минимум"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:120
-#| msgid "Maximize"
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Максимум"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Системски звуци"
 
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Balance:"
-msgstr "_Ниво:"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Звук за из_вестување:"
 
-#: ../panels/sound/gvc-balance-bar.c:298
-#| msgid "_Name:"
-msgid "_Fade:"
-msgstr "_Избледни:"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Исклучи го гласот"
 
-#: ../panels/sound/gvc-balance-bar.c:301
-msgid "_Subwoofer:"
-msgstr "_Вуфер:"
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Излез"
 
-#: ../panels/sound/gvc-channel-bar.c:603
-#: ../panels/sound/gvc-channel-bar.c:612
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "_Излезно ниво на гласност:"
 
-#: ../panels/sound/gvc-channel-bar.c:607
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Непојачано"
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Тест"
 
-#: ../panels/sound/gvc-combo-box.c:167
-#: ../panels/sound/gvc-mixer-dialog.c:1621
-#| msgid "_Mobile:"
-msgid "_Profile:"
-msgstr "_Профил:"
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "_URL за конфигурирање"
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1094
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Субвуфер"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Влез"
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Гласност на влез"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Зголеми ја гласноста"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Звук за из_вестување:"
+
+#: panels/sound/cc-volume-slider.ui:22
+#, fuzzy
+msgid "Mute"
+msgstr "И_склучи го гласот"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Звук"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Промени ја гласноста на звукот и звучните настани"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "Картичка;Микрофон;Звук;Намалување;Баланс;Bluetooth;Слушалки;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, fuzzy, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Избриши уред"
+msgstr[1] "Избриши уред"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Зголемување"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Име:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Отстрани уред"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Универзален пристап"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Ги добивам уредите..."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Трепкање на стрелката"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "_Стрелката трепка во текстуални полиња"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Брзина"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Брзина на трепкање на стрелката"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Брзина на трепкање на стрелката"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Симулиран двоен клик"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Активирај го секундардниот клик со држење на примарното копче"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Д_оцнење за прифаќање:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Кратко"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Период за двоен клик"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Долго"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "Клик со застанување со стрелката врз предметите"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Иницирај клик при запирање на движењето на стрелката"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "З_астој:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Кратко"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Долго"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Праг на движење:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Мала"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Голема"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Повтори ги копчињата"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Притисокот на копче се повторува копчето е задржано повеќе"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Брзина на повторување на копчињата"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Брзина на повторување на копчињата"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Помошник за пишување"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Лепливи копчиња"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Третира секвенца на изменувачки копчиња како комбинација на копчиња"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Оневозможи ако две копчиња се притиснати одеднаш"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Свирни кога е притиснат _менувач"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Бавни копчиња"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Става период на доцнење кога некое копче е притиснато и тоа е прифатено"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Кратко"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Доцнење при пишување на бавните копчиња"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Долго"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Свирни кога е притиснато копче за _менување"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Свирни кога копчето е _прифатено"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Свирни кога некое копче е отфр_лено"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Одбивни копчиња"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ги игнорира брзите дупликати при притискање на копчињата"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Кратко"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Доцнење при пишување на одбивните копчиња"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Долго"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "_Приклучи ги опциите за пристапност од тастатурата"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Пристапност на _тастатура"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Гледање"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "_Контраст:"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Голема"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Читач на екранот"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Одбивни копчиња"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Свирни кога _опциите за пристапност се вклучени или исклучени од тастатура"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Брзина на трепкање на стрелката"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Зумирај"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Слушање"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Визуелни известувања"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Екранска тастатура"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Повтори ги копчињата"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Трепкање на стрелката"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
+msgstr "Помошник за пишување"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Покажување и кликање"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Копчиња на глушецот"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "<b>Лоцирај ја стрелката</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "Застој за двоен клик"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "Застој за двоен клик"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Визуелни известувања"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Тестирај го блицот"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+#, fuzzy
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Користи визуелен индикатор кога ќе се појави звучен сигнал"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Трепни го целиот екран"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Трепни го целиот екран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "На цел екран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Горна половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Долната половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Лева половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Десна половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Опции за зумирање"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "Зголемување"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "Зголемување"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Дозволени корисници"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Читач на екранот"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "Orca со зголемувач"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "Мети"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
+msgstr "Дебелина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+#, fuzzy
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Тенко"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+#, fuzzy
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Дебело"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
+msgstr "Должина"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Мети"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "Звучни ефекти"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Светлост"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Контраст:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ништо"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Полно"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Ниско"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Висок"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Низок"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Високо"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "Звучни ефекти"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Тастатура;Глушец;a11y;Пристапност;Контраст;Зум;Читач на екран;текст;фонт;"
+"големина;AccessX;Лепливи копчиња;Бавни копчиња;Одбивни копчиња;Копчиња на "
+"глушец"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Датотечен систем"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "Испразни ѓубре"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Избриши ги датотеките"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "Премести во ѓубре"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Нов корисник"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "Администратор"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Изберете лозинка на следното најавување"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Изберете лозинка сега"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "_Конфигурирај..."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Enterprise"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Исклучен"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Изберете јазик"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Најава со _отпечаток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Најава со _отпечаток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Не"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Дали сакате да ги избришите регистрираните отпечатоци за да се оневозможи "
+"најавувањето со отпечатоци?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Најава со _отпечаток"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Најава со _отпечаток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Најава со _отпечаток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "И_зберете уред за конфигурирање:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Најава со _отпечаток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Избриши ги отпечатоците"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Најава со _отпечаток"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Претходна песна"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Промени ло_зинка"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Про_мени"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Тековна _лозинка"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Нова лозинка"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "По_тврди ја лозинката"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Лозинките не се совпаѓаат"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "Изберете лозинка на следното најавување"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Изберете лозинка сега"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Users"
+msgstr "Корисничко име"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Цело име"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Најава со _отпечаток"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "А_втоматска најава"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "_Тип на сметка"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Администратор"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Контроли"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Отстрани корисник"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Друг прст:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "Нов корисник"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Корисничка икона"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "Креирај нова сметка"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+#, fuzzy
+msgid "Add or remove users and change your password"
+msgstr "Додај или отстрани корисници"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+#, fuzzy
+msgid "Domain Administrator Login"
+msgstr "Администратор"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+#, fuzzy
+msgid "Administrator _Name"
+msgstr "Администратор"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+#, fuzzy
+msgid "Administrator Password"
+msgstr "Администратор"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+#, fuzzy
+msgid "Manage user accounts"
+msgstr "Менаџирајте со онлајн сметките"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+#, fuzzy
+msgid "Authentication is required to change user data"
+msgstr "Потребна е автентикација"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Горно копче"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"За да ги уредите кратенките, кликнете на саканиот ред и стиснете на нова "
+"комбинација од копчиња или пак притиснете backspace за да ги исчистите."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "Креирај виртуелен уред"
+
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Таблет (апсолутен)"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Ориентација за левичари"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Монитор"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Калибрирај..."
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Не е откриен таблет"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Прикачете или пуштете го Вашиот Wacom таблет"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Осет на притисок на врвот"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Меко"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Цврсто"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Горно копче"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Горно копче"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Горно копче"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Осет на притисок на бришачот"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Осет на притисок на бришачот"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Клик на средното копче на глушецот"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Клик на десното копче на глушецот"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Напред"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom таблет"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Таблет;Wacom;Stylus;Бришач;Глушец;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Распоред"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Главен прозорец"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Симулиран двоен клик"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Прозорци"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Кликни на „Во ред“ за крај"
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Тонерот е при крај"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Период за двоен клик"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Прозорци"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "На_јава со пристапност"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "_Додај"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Зачувај"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Детали"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_Мрежно време"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Мрежни поставувања"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Бројки"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Типови на уреди"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+#, fuzzy
+msgid "Manufacturer"
+msgstr "Производител:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Недостасува firmware"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "Мобилен широкопојасен"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_Мрежно време"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Мрежа"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Прекинато"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Заклучи"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Детали"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Мрежно име"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Автоматски"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Мрежа"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Не се пронајдени Bluetooth адаптери"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Режим за во а_вион"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Врска"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Заклучи"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Про_мени"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Мрежа"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Сите поставувања"
+
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Основна боја"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Општо"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Излез"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Пребарувај"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Прекинато"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Преференци"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u излез"
 msgstr[1] "%u излеза"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1104
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u влез"
 msgstr[1] "%u влеза"
 
-#: ../panels/sound/gvc-mixer-control.c:1402
-#| msgid "Test Sound"
-msgid "System Sounds"
-msgstr "Системски звуци"
+#~| msgid "Add Wallpaper"
+#~ msgid "Add wallpaper"
+#~ msgstr "Додај позадина"
 
-#: ../panels/sound/gvc-mixer-dialog.c:323
-#: ../panels/sound/gvc-mixer-dialog.c:634
-#| msgid "Co_untry:"
-msgid "Co_nnector:"
-msgstr "Ко_нектор:"
+#~| msgid "Pointer"
+#~ msgid "Center"
+#~ msgstr "Центар"
 
-#: ../panels/sound/gvc-mixer-dialog.c:540
-msgid "Peak detect"
-msgstr "Детектирај врв"
+#~ msgid "Changes throughout the day"
+#~ msgstr "Да се менува во текот на денот"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1496
-#: ../panels/sound/gvc-mixer-dialog.c:1709
-#: ../panels/sound/gvc-sound-theme-chooser.c:595
-#| msgid "_Name:"
-msgid "Name"
-msgstr "Име"
+#~| msgid "_File"
+#~ msgid "Fill"
+#~ msgstr "Пополни"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1563
+#~| msgid "No Wallpaper"
+#~ msgid "Remove wallpaper"
+#~ msgstr "Отстрани ја позадината"
+
+#~| msgid "Seco_ndary click:"
+#~ msgid "Secondary color"
+#~ msgstr "Секундарна боја"
+
+#~ msgid "Span"
+#~ msgstr "Распон"
+
+#~ msgid "Swap colors"
+#~ msgstr "Менувај бои"
+
+#~| msgid "_Title:"
+#~ msgid "Tile"
+#~ msgstr "Наслов"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Хоризонтален градиент"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Вертикален градиент"
+
+#~ msgid "Solid Color"
+#~ msgstr "Еднобојно"
+
+#~ msgid "multiple sizes"
+#~ msgstr "повеќе големини"
+
 #, c-format
-msgid "Speaker Testing for %s"
-msgstr "Тестирање на звучникот за %s"
+#~| msgid "%d x %d"
+#~ msgid "%d × %d"
+#~ msgstr "%d x %d"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1622
-msgid "_Test Speakers"
-msgstr "_Тестирај ги звучниците"
+#~| msgid "Apply Background"
+#~ msgid "No Desktop Background"
+#~ msgstr "Нема позадина на работната површина"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1753
-msgid "_Output volume:"
-msgstr "_Излезно ниво на гласност:"
+#~| msgid "Background"
+#~ msgid "Current background"
+#~ msgstr "Тековна позадина"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1772
-msgid "C_hoose a device for sound output:"
-msgstr "И_зберете уред за звучен излез:"
+#~ msgid "Pictures Folder"
+#~ msgstr "Папка со слики"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1797
-#: ../panels/sound/gvc-mixer-dialog.c:1926
-msgid "Settings for the selected device:"
-msgstr "Поставувања за избраниот уред:"
+#~ msgid "Colors & Gradients"
+#~ msgstr "Бои и градиенти"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1815
-#| msgid "_Input boxes:"
-msgid "_Input volume:"
-msgstr "Гласност на _влез:"
+#~| msgid "Save _background image"
+#~ msgid "Change the background"
+#~ msgstr "Смени ја позадината"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1838
-#| msgid "_Input boxes:"
-msgid "Input level:"
-msgstr "Гласност на влез"
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Позадини;Екран;Работна површина;"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1866
-msgid "C_hoose a device for sound input:"
-msgstr "О_дберете уред за звучен влез:"
+#~ msgid "Browse Files..."
+#~ msgstr "Прегледај датотеки..."
 
-#: ../panels/sound/gvc-mixer-dialog.c:1893
-msgid "Hardware"
-msgstr "Хардвер"
+#~ msgid "Mouse and Touchpad Settings"
+#~ msgstr "Поставувања за глушец и тачпад"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1898
-msgid "C_hoose a device to configure:"
-msgstr "И_зберете уред за конфигурирање:"
+#~ msgid "Paired"
+#~ msgstr "Спарени"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1937
-#| msgid "Sound files"
-msgid "Sound Effects"
-msgstr "Звучни ефекти"
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1944
-#| msgctxt "Sound event"
-#| msgid "Alert sound"
-msgid "_Alert volume:"
-msgstr "Звук за из_вестување:"
+#~| msgid "Send To..."
+#~ msgid "Send Files..."
+#~ msgstr "Испрати датотеки..."
 
-#: ../panels/sound/gvc-mixer-dialog.c:1957
-#| msgid "_Application font:"
-msgid "Applications"
-msgstr "Апликации"
+#~ msgid "Set Up New Device"
+#~ msgstr "Постави нов уред"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1961
-msgid "No application is currently playing or recording audio."
-msgstr "Нема апликации кои моментално пуштаат или снимаат аудио."
+#~ msgid "Yes"
+#~ msgstr "Да"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:189
-msgid "Built-in"
-msgstr "Вградено"
+#~| msgid "Accessibility"
+#~ msgid "Visibility"
+#~ msgstr "Видливост"
 
-#: ../panels/sound/gvc-sound-theme-chooser.c:455
-#: ../panels/sound/gvc-sound-theme-chooser.c:467
-#: ../panels/sound/gvc-sound-theme-chooser.c:479
-msgid "Sound Preferences"
-msgstr "Преференци за звук"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:458
-#: ../panels/sound/gvc-sound-theme-chooser.c:469
-#: ../panels/sound/gvc-sound-theme-chooser.c:481
-msgid "Testing event sound"
-msgstr "Тестирам звук за настани"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:586
-msgid "From theme"
-msgstr "Од тема"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:770
-#| msgid "Play _alert sound"
-msgid "C_hoose an alert sound:"
-msgstr "Из_берете звук за известување:"
-
-#: ../panels/sound/gvc-speaker-test.c:221
-msgid "Stop"
-msgstr "Стоп"
-
-#: ../panels/sound/gvc-speaker-test.c:221
-#: ../panels/sound/gvc-speaker-test.c:333
-msgid "Test"
-msgstr "Тест"
-
-#: ../panels/sound/gvc-speaker-test.c:229
-msgid "Subwoofer"
-msgstr "Субвуфер"
-
-#: ../panels/sound/gvc-stream-status-icon.c:235
 #, c-format
-#| msgid "Sound Preferences"
-msgid "Failed to start Sound Preferences: %s"
-msgstr "Не успеав да ги стартувам преференците за звук: %s"
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Видливост на „%s“"
 
-#: ../panels/sound/gvc-stream-status-icon.c:261
-#| msgid "C_ut"
-msgid "_Mute"
-msgstr "И_склучи го гласот"
+#, c-format
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Да го отстранам „%s“ од листата на уреди?"
 
-#: ../panels/sound/gvc-stream-status-icon.c:270
-#| msgid "Sound Preferences"
-msgid "_Sound Preferences"
-msgstr "_Преференци за звук"
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Ако го отстраните уредот, ќе мора да го поставите пак пред следна "
+#~ "употреба."
 
-#: ../panels/sound/gvc-stream-status-icon.c:415
-#| msgid "Multimedia"
-msgid "Muted"
-msgstr "Гласот е исклучен"
+#~ msgid "Other profile…"
+#~ msgstr "Друг профил..."
 
-#: ../panels/sound/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr "Сопствен"
+#~| msgid "Default"
+#~ msgid "Default: "
+#~ msgstr "Стандардно:"
 
-#: ../panels/universal-access/cc-ua-panel.c:445
-#: ../panels/universal-access/cc-ua-panel.c:451
-#| msgid "New shortcut..."
-msgid "No shortcut set"
-msgstr "Нема кратенки"
+#~ msgid "Test profile: "
+#~ msgstr "Тест профил..."
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys"
-msgstr "Тастатура;Глушец;a11y;Пристапност;Контраст;Зум;Читач на екран;текст;фонт;големина;AccessX;Лепливи копчиња;Бавни копчиња;Одбивни копчиња;Копчиња на глушец"
+#~| msgid "Select Sound File"
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Изберете ICC профил"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
-#| msgid "Appearance Preferences"
-msgid "Universal Access Preferences"
-msgstr "Преференции за универзален пристап"
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Достапни профили за прикази"
 
-#: ../panels/universal-access/uap.ui.h:2
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Достапни профили за скенери"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Достапни профили за печатачи"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Достапни профили за камери"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Достапни профили за веб камери"
+
+#~| msgid "All files"
+#~ msgid "Available Profiles"
+#~ msgstr "Достапни профили"
+
+#~| msgid "Devices"
+#~ msgid "Device"
+#~ msgstr "Уред"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Креирајте профил за боја за избраниот уред"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Не е детектиран уред за мерење. Проверете дали е вклучен и правилно "
+#~ "поврзан."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Уредот за мерење не поддржува профилирање на печатачи."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Уредот не е моментално поддржан."
+
+#~ msgid "Cannot remove automatically added profile"
+#~ msgstr "Не можам да го отстранам автоматски додадениот профил"
+
+#, c-format
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i година"
+#~ msgstr[1] "%i години"
+
+#, c-format
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i месец"
+#~ msgstr[1] "%i месеци"
+
+#, c-format
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i недела"
+#~ msgstr[1] "%i недели"
+
+#, c-format
+#~ msgid "Less than 1 week"
+#~ msgstr "Помалку од 1 недела"
+
+#~| msgid "Default"
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Стандардно RGB"
+
+#~| msgid "Default"
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Стандардно CMYK"
+
+#~| msgid "Default"
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Стандардно сиво"
+
+#~ msgid "Uncalibrated"
+#~ msgstr "Некалибрирано"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "Овој уред нема менаџмент на бои"
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "Овој уред користи некалибрирани податоци"
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "Овој уред нема соодветен профил за корекција на боја на целиот екран."
+
+#~ msgid "This device has an old profile that may no longer be accurate."
+#~ msgstr "Овој уред има стар профил кој можеби не е точен."
+
+#~| msgid "Not connected"
+#~ msgid "Not specified"
+#~ msgstr "Не е одредено"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "Не се откриени уреди кои поддржуваат менаџмент на бои"
+
+#~ msgctxt "Device kind"
+#~ msgid "Scanner"
+#~ msgstr "Скенер"
+
+#~| msgid "Pointer"
+#~ msgctxt "Device kind"
+#~ msgid "Printer"
+#~ msgstr "Печатач"
+
+#~ msgctxt "Device kind"
+#~ msgid "Webcam"
+#~ msgstr "Веб камера"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "Додај виртуелен уред"
+
+#~ msgid "Add device"
+#~ msgstr "Додај уред"
+
+#~| msgid "_Device:"
+#~ msgid "Device type:"
+#~ msgstr "Тип на уред:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Може да влечите датотеки со слики во овој прозорец за автоматско "
+#~ "довршување на полињата погоре."
+
+#~| msgid "_Models:"
+#~ msgid "Model:"
+#~ msgstr "Модел:"
+
+#~| msgid "Remove from Favorites"
+#~ msgid "Remove a device"
+#~ msgstr "Отстрани уред"
+
+#~ msgid "Color management settings"
+#~ msgstr "Поставувања за менаџмент на бои"
+
+#~ msgid "English"
+#~ msgstr "Англиски"
+
+#~ msgid "British English"
+#~ msgstr "Британски англиски"
+
+#~| msgid "General"
+#~ msgid "German"
+#~ msgstr "Германски"
+
+#~ msgid "French"
+#~ msgstr "Француски"
+
+#~ msgid "Spanish"
+#~ msgstr "Шпански"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Кинески (поедонставен)"
+
+#~ msgid "United States"
+#~ msgstr "САД"
+
+#~ msgid "Germany"
+#~ msgstr "Германија"
+
+#~ msgid "Spain"
+#~ msgstr "Шпанија"
+
+#~ msgid "China"
+#~ msgstr "Кина"
+
+#~| msgid "Select Image"
+#~ msgid "Select a region"
+#~ msgstr "Изберете регион"
+
+#~ msgid "Unspecified"
+#~ msgstr "Неодредено"
+
+#~ msgid "24-hour"
+#~ msgstr "24 часа"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Постави го времето за еден час нанапред."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Постави го времето за еден час наназад."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Постави го времето за една минута нанапред."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Постави го времето за една минута наназад."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Промени AM/PM."
+
+#~| msgid "C_ity:"
+#~ msgid "_City:"
+#~ msgstr "_Град:"
+
+#~| msgid "_Resolution"
+#~ msgid "_Region:"
+#~ msgstr "_Регион:"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Панел за преференци за датум и време"
+
+#~| msgid "Normal"
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Нормално"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "Обратно од стрелките на часовникот"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Во насока на стрелките на часовникот"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 степени"
+
+#, c-format
+#~| msgid "%d x %d"
+#~ msgid "%d x %d (%s)"
+#~ msgstr "%d x %d (%s)"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Изберете монитор за да ги промените неговите својства; влечете го за да "
+#~ "ја промените неговата поставеност."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~| msgid "Could not load the main interface"
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Не можам да ја зачувам конфигурацијата за екранот"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr ""
+#~ "Не можев да добијам магистрала за сесијата при применување на "
+#~ "конфигурацијата на приказот"
+
+#~| msgid "_Detect Displays"
+#~ msgid "Could not detect displays"
+#~ msgstr "Не можев да детектирам прикази"
+
+#~| msgid "Change screen resolution"
+#~ msgid "Could not get screen information"
+#~ msgstr "Не можев да добијам информации за приказот"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Забелешка: ова може да ги ограничи опциите за резолуција"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "_Детектирај прикази"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Огледало на приказот"
+
+#, c-format
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown"
+#~ msgstr "Непознато"
+
+#, c-format
+#~| msgid "Edit"
+#~ msgid "%d-bit"
+#~ msgstr "%d-bit"
+
+#~| msgid "Unknown"
+#~ msgid "Unknown model"
+#~ msgstr "Непознат модел"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr ""
+#~ "Следното најавување ќе се обидам да го користам стандардното искуство."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "Следното најавување ќе се користи режимот за спас, наменет за неподдржан "
+#~ "графички хардвер."
+
+#~| msgid "Callback"
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Спасувачка"
+
+#~| msgid "Standard XTerminal"
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "Стандардна"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Прашај ме што да направам"
+
+#~ msgid "Do nothing"
+#~ msgstr "Не прави ништо"
+
+#~| msgid "Open File"
+#~ msgid "Open folder"
+#~ msgstr "Отвори папка"
+
+#~| msgid "Select your default applications"
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Изберете апликација за аудио CD-ња"
+
+#~| msgid "Select your default applications"
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Изберете апликација за видео CD-ња"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Одберете апликација која ќе се пушти кога ќе се поврзе пуштач на музика"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Одберете апликација која ќе се пушти кога ќе се поврзе камера"
+
+#~| msgid "Select your default applications"
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Изберете апликација за софтверски CD-ња"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "blank Blu-ray disc"
+
+#~ msgid "blank CD disc"
+#~ msgstr "blank CD disc"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "blank DVD disc"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "blank HD DVD disc"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video disc"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-book reader"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video disc"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~| msgid "_Overwrite"
+#~ msgid "Overview"
+#~ msgstr "Преглед"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Системот е ажуриран"
+
+#~| msgid "Checking password..."
+#~ msgid "Checking for Updates"
+#~ msgstr "Прoверувам дали има ажурирањ"
+
+#~| msgid "Action"
+#~ msgid "Acti_on:"
+#~ msgstr "Дејство"
+
+#~ msgid "Disk"
+#~ msgstr "Диск"
+
+#~| msgid "Appearance"
+#~ msgid "Experience"
+#~ msgstr "Искуство"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "Присилен режим за _спас"
+
+#~ msgid "OS type"
+#~ msgstr "Тип на ОС"
+
+#~| msgid "Take a break!"
+#~ msgid "Take a screenshot"
+#~ msgstr "Сликај го екранот"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "Земи слика од прозорец"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "Промени ги поставувањата за тастатурата"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Кратенка;Повтори;Трепкај;"
+
+#~| msgid "Custom Shortcuts"
+#~ msgid "Custom Shortcut"
+#~ msgstr "Сопствена кратенка"
+
+#~| msgid "_Paste"
+#~ msgid "Fast"
+#~ msgstr "Брзо"
+
+#~| msgid "Layout _Options..."
+#~ msgid "Layout Settings"
+#~ msgstr "Поставувања за распоредот"
+
+#~| msgid "Shortcut"
+#~ msgid "Remove Shortcut"
+#~ msgstr "Отстрани кратенка"
+
+#~ msgid "S_peed:"
+#~ msgstr "Б_рзина:"
+
+#~ msgid "Slow"
+#~ msgstr "Бавно"
+
+#~ msgid "_Speed:"
+#~ msgstr "Брзина:"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Непознато дејство>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Кратенката „%s“ не може да се користи бидејќи ќе стане невозможно да се "
+#~ "пишува со ова копче.\n"
+#~ "Ве молам пробајте со копче како Control, Alt или Shift во исто време."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Кратенката „%s“ веќе се користи за \n"
+#~ " „%s“"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "Ако ја смените кратенката во %s, кратенката %s ќе биде исклучена."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Додели пак"
+
+#~ msgid "Action"
+#~ msgstr "Дејствие"
+
+#~| msgid "Set your mouse preferences"
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Поставете ги преференците за глушецот"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "З_абрзување:"
+
+#~| msgid "<b>Double-Click Timeout</b>"
+#~ msgid "Double-click timeout"
+#~ msgstr "Застој за двоен клик"
+
+#~| msgid "Thr_eshold:"
+#~ msgid "Drag Threshold"
+#~ msgstr "Праг на влечење"
+
+#~| msgid "<b>Drag and Drop</b>"
+#~ msgid "Drag and Drop"
+#~ msgstr "Влечи и пушти"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "Овозможи ги кликањата со _глушец преку тачпад"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Преференци на глушецот"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr ""
+#~ "По_кажи ја позицијата на стрелката при притискање на копчето Control"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "Пр_аг:"
+
+#~| msgid ""
+#~| "<i>To test your double-click settings, try to double-click on the light "
+#~| "bulb.</i>"
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr ""
+#~ "За да ги тестирате поставувањата за двојниот клик, пробајте да кликнете "
+#~ "на лицето."
+
+#~ msgid "Two-_finger scrolling"
+#~ msgstr "Движење со _два прста"
+
+#~| msgid "Disabled"
+#~ msgid "_Disabled"
+#~ msgstr "_Оневозможено"
+
+#~ msgid "_Edge scrolling"
+#~ msgstr "Движење по _работ"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Левак"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_Деснак"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Осетливост:"
+
+#~ msgid "_Timeout:"
+#~ msgstr "_Застој:"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Автоматскот откривање на веб прокси се користи кога не е даден "
+#~ "конфигурациски URL."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Ова не е препорачано за недоверливи јавни мрежи."
+
+#~| msgid "Other"
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "Друго..."
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~| msgid "_FTP proxy:"
+#~ msgid "Proxy"
+#~ msgstr "Прокси"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Мрежните сервиси на системот не се компатибилни со оваа верзија."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "Да го креирам hotspot-от и покрај тоа?"
+
+#, c-format
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "Да се исклучам од %s и да креирам нов hotspot?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "Ова е Вашата единствена врска со интернет."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "Креирај _hotspot"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Да го прекинам hotspot-от и да ги исклучам неговите корисници?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Прекини го hotspot-от"
+
+#~| msgid "Devices"
+#~ msgid "Add Device"
+#~ msgstr "Додај уред"
+
+#~| msgid "Rename..."
+#~ msgid "Create..."
+#~ msgstr "Креирај..."
+
+#~| msgid "Disabled"
+#~ msgid "Disable VPN"
+#~ msgstr "Оневозможи VPN"
+
+#~| msgid "Port:"
+#~ msgid "FTP Port"
+#~ msgstr "FTP порта"
+
+#~| msgid "Full Name"
+#~ msgid "Group Name"
+#~ msgstr "Име на група"
+
+#~ msgid "HTTP Port"
+#~ msgstr "Порта за HTTP"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "Порта за HTTPS"
+
+#~ msgid "Interface"
+#~ msgstr "Интерфејс"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Изберете го интерфејсот за користење со новиот сервис"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "Сабнет маска"
+
+#~ msgid "VPN Type"
+#~ msgstr "Тип на VPN"
+
+#~| msgid "Network Servers"
+#~ msgid "_Network Name"
+#~ msgstr "_Мрежно име"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "_Стопирај го hotspot-от..."
+
+#~ msgid "_Use as Hotspot..."
+#~ msgstr "_Користи како hotspot..."
+
+#~| msgid "None"
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Ништо"
+
+#~ msgid "Wireless"
+#~ msgstr "Безжичен"
+
+#~| msgid "Models"
+#~ msgid "Mesh"
+#~ msgstr "Мрежа"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Инфраструктурен"
+
+#~ msgid "Status unknown"
+#~ msgstr "Статусот е непознат"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Неменаџиран"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Кабелот е откачен"
+
+#~ msgid "Unavailable"
+#~ msgstr "Не е достапен"
+
+#~| msgid "Not connected"
+#~ msgid "Disconnected"
+#~ msgstr "Неповрзан"
+
+#~ msgid "Connecting"
+#~ msgstr "Се поврзувам"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Ја прекинувам врската"
+
+#~| msgid "Copying files"
+#~ msgid "Connection failed"
+#~ msgstr "Врската не успеа"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Статусот е непознат (недостасува)"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Грешка при најавата на сметката"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "Истечени акредитиви. Најавете се повторно."
+
+#~| msgctxt "Sound event"
+#~| msgid "Login"
+#~ msgid "_Log In"
+#~ msgstr "_Најави се"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "За да додадете нова сметка прво изберете го типот на сметката"
+
+#~| msgid "Alert Type"
+#~ msgid "Account Type:"
+#~ msgstr "Тип на сметка"
+
+#~ msgid "_Add..."
+#~ msgstr "_Додај..."
+
+#~ msgid "Error creating account"
+#~ msgstr "Грешка при креирањето на сметка"
+
+#~ msgid "Error removing account"
+#~ msgstr "Грешка при отстранувањето на сметката"
+
+#~| msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Дали сте сигурни дека сакате да ја избришете сметката?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Ова нема да ја отстрани сметката од серверот."
+
+#~| msgid "Revert Font"
+#~ msgid "Remove Account"
+#~ msgstr "Избриши ја сметката"
+
+#~| msgid "_Selected layouts:"
+#~ msgid "Select an account"
+#~ msgstr "Избери сметка"
+
+#~| msgid "Unknown"
+#~ msgid "Unknown time"
+#~ msgstr "Непознат тип"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#~| msgctxt "Sound event"
+#~| msgid "Battery warning"
+#~ msgid "Battery discharging"
+#~ msgstr "Батеријата се празни"
+
+#~ msgid "UPS charging"
+#~ msgstr "UPS се полни"
+
+#~ msgid "UPS discharging"
+#~ msgstr "UPS се празни"
+
+#, c-format
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s додека се наполни (%.0lf%%)"
+
+#, c-format
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s додека се испразне (%.0lf%%)"
+
+#, c-format
+#~ msgid "%.0lf%% charged"
+#~ msgstr "наполнет е %.0lf%%"
+
+#~ msgid "Power management settings"
+#~ msgstr "Поставувања за менаџментот со енергија"
+
+#~ msgid "Don't suspend"
+#~ msgstr "Не суспендирај"
+
+#~ msgid "Hibernate"
+#~ msgstr "Хибернирај"
+
+#~ msgid "Suspend when inactive for:"
+#~ msgstr "Суспендирај се по неактивност од:"
+
+#~ msgid "When power is _critically low:"
+#~ msgstr "Кога енергијата е _многу празна:"
+
+#~ msgid "Out of toner"
+#~ msgstr "Нема тонер"
+
+#~ msgid "Low on developer"
+#~ msgstr "Развивачот за фотографии е при крај"
+
+#~ msgid "Out of developer"
+#~ msgstr "Нема развивач за фотографии"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Маркерот е при крај"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Нема маркер"
+
+#~| msgid "Open File"
+#~ msgid "Open cover"
+#~ msgstr "Отворен капак"
+
+#~ msgid "Low on paper"
+#~ msgstr "Хартијата е при крај"
+
+#~ msgid "Out of paper"
+#~ msgstr "Нема хартија"
+
+#~| msgid "_Paste"
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "Паузиран"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Контејнерот за ѓубре е скоро полн"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Контејнерот за ѓубре е преполн"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Оптичкиот фотоспроводник е при крајот на животниот век"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Оптичкиот фотоспроводник веќе не работи"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Подготвен"
+
+#~| msgid "_Profession:"
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Процесира"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Запрен"
+
+#~ msgid "Toner Level"
+#~ msgstr "Ниво на тонер"
+
+#~ msgid "Supply Level"
+#~ msgstr "Количина во залиха"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Чекам"
+
+#~| msgid "Help"
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Задржан"
+
+#~| msgid "_Profession:"
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Се процесира"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Запрено"
+
+#~| msgid "About Me"
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Прекинато"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Завршено"
+
+#~| msgid "_Title:"
+#~ msgid "Job Title"
+#~ msgstr "Наслов на печатењето"
+
+#~ msgid "Job State"
+#~ msgstr "Состојба на печатењето"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Не успеав да додадам нов печатач."
+
+#, c-format
+#~| msgid "Could not load the main interface"
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Не можев да го вчитам интерфејсот: %s"
+
+#~ msgid "A_ddress:"
+#~ msgstr "А_дреса:"
+
+#~| msgid "Large Pointer"
+#~ msgid "Add a New Printer"
+#~ msgstr "Додај нов печатач"
+
+#~| msgid "Network Servers"
+#~ msgid "No network printers found"
+#~ msgstr "Не се пронајдени печатачи"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "Не се извршува FirewallD. За детектирање на мрежните печатачи потребно е "
+#~ "mdns, ipp, ipp-client и samba-client да бидат овозможени на firewall."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "Локален"
+
+#~| msgid "Network Proxy"
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "Мрежа"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "Отворам заштитен ѕид за mDNS врски"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Отворам заштитен ѕид за Samba врски"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "Отворам заштитен ѕид за IPP врски"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Додај нов печатач"
+
+#~ msgid "Jobs"
+#~ msgstr "Печатења"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Паузирај со печатење"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Испечати _тест страница"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Продолжи со печатење"
+
+#~ msgid "_Back"
+#~ msgstr "_Назад"
+
+#~| msgid "Default"
+#~ msgid "_Default"
+#~ msgstr "_Стандарден"
+
+#~| msgid "Shutdown"
+#~ msgid "_Show"
+#~ msgstr "_Покажи"
+
+#~| msgid "Opera"
+#~ msgid "Imperial"
+#~ msgstr "Империјален"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Изберете распоред"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "Најавниот екран, сметките на системот и новите корисници ги корсистат "
+#~ "системските поставувања за јазик и регион."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "Најавниот екран, сметките на системот и новите корисници ги корсистат "
+#~ "системските поставувања за јазик и регион. Можете да ги промените "
+#~ "системските поставувања да се совпаѓаат со Вашите."
+
+#~| msgid "Copying '%s'"
+#~ msgid "Copy Settings"
+#~ msgstr "Копирај ги поставувањата"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "Копирај ги поставувањата..."
+
+#~| msgid "_Language:"
+#~ msgid "Add Language"
+#~ msgstr "Додај јазик"
+
+#~| msgid "Layout"
+#~ msgid "Add Layout"
+#~ msgstr "Додај распоред"
+
+#~ msgid "Add Region"
+#~ msgstr "Додај регион"
+
+#~ msgid "Allow different layouts for individual windows"
+#~ msgstr "Дозволи различни распореди за посебните прозорци"
+
+#~ msgid "Currency"
+#~ msgstr "Валута"
+
+#~| msgid "By _language"
+#~ msgid "Display language:"
+#~ msgstr "Јазик за приказ:"
+
+#~ msgid "Examples"
+#~ msgstr "Примери"
+
+#~| msgid "_Language:"
+#~ msgid "Language"
+#~ msgstr "Јазик"
+
+#~ msgid "Layouts"
+#~ msgstr "Распореди"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "Новите прозорци ќе го користат стандардниот распоред"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "Новите прозорци ќе го користат распоредот од претходниот прозорец"
+
+#~| msgid "Preview:"
+#~ msgid "Preview Layout"
+#~ msgstr "Распоред на преглед"
+
+#~| msgid "_Language:"
+#~ msgid "Remove Language"
+#~ msgstr "Отстрани јазик"
+
+#~| msgid "Choose a Layout"
+#~ msgid "Remove Layout"
+#~ msgstr "Отстрани распоред"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Замени го тековниот распоред на тастатурата со\n"
+#~ "стандардните поставувања"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "Ресетирај на ста_ндардното"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Изберете јазик (промените ќе бидат активни следниот пат кога ќе се "
+#~ "најавите)"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr ""
+#~ "Изберете регион (промените ќе бидат активни следниот пат кога ќе се "
+#~ "најавите)"
+
+#~| msgid "_Type to test settings:"
+#~ msgid "System settings"
+#~ msgstr "Системски поставувања"
+
+#~| msgid "Keyboard Layout Options"
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "Прегледај и уреди ги поставувањата за распоредот на тастатурата"
+
+#~| msgid "Layout _Options..."
+#~ msgid "_Options..."
+#~ msgstr "_Опции..."
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Светлост;Заклучи;Затемни;Зацрни;Монитор;"
+
+#~| msgid "minutes"
+#~ msgid "1 minute"
+#~ msgstr "1 минута"
+
+#~| msgid "minutes"
+#~ msgid "3 minutes"
+#~ msgstr "3 минути"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "Не заклучувај се кога сум дома"
+
+#~| msgid "Layout _Options..."
+#~ msgid "Locations..."
+#~ msgstr "Локации..."
+
+#~ msgid "Screen turns off"
+#~ msgstr "Екранот се исклучува"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "_Затемни го екранот за да заштедува енергија"
+
+#~ msgid "_Turn screen off when inactive for:"
+#~ msgstr "_Изгасни го екранот при неактивност од:"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Овозможи дебагирање на код"
+
+#~| msgid "Open with Default Application"
+#~ msgid "Version of this application"
+#~ msgstr "Верзија на оваа апликација"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — Аплетот за контрола на глас на GNOME "
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Покажи ги контролите за глас"
+
+#~ msgid "Bark"
+#~ msgstr "Лаење"
+
+#~ msgid "Drip"
+#~ msgstr "Капење"
+
+#~ msgid "Glass"
+#~ msgstr "Стакло"
+
+#~| msgid "Sound"
+#~ msgid "Sonar"
+#~ msgstr "Сонар"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Гласност на звучниот излез"
+
+#~| msgid "Minimize"
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Минимум"
+
+#~| msgid "Maximize"
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Максимум"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Вуфер:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Непојачано"
+
+#~ msgid "Peak detect"
+#~ msgstr "Детектирај врв"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Тестирање на звучникот за %s"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Тестирај ги звучниците"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "И_зберете уред за звучен излез:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Поставувања за избраниот уред:"
+
+#~| msgid "_Input boxes:"
+#~ msgid "_Input volume:"
+#~ msgstr "Гласност на _влез:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "О_дберете уред за звучен влез:"
+
+#~ msgid "Hardware"
+#~ msgstr "Хардвер"
+
+#~ msgid "Built-in"
+#~ msgstr "Вградено"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Преференци за звук"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Тестирам звук за настани"
+
+#~ msgid "From theme"
+#~ msgstr "Од тема"
+
+#~| msgid "Play _alert sound"
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Из_берете звук за известување:"
+
+#~ msgid "Stop"
+#~ msgstr "Стоп"
+
+#, c-format
+#~| msgid "Sound Preferences"
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "Не успеав да ги стартувам преференците за звук: %s"
+
+#~| msgid "Sound Preferences"
+#~ msgid "_Sound Preferences"
+#~ msgstr "_Преференци за звук"
+
+#~| msgid "Multimedia"
+#~ msgid "Muted"
+#~ msgstr "Гласот е исклучен"
+
+#~ msgid "Custom"
+#~ msgstr "Сопствен"
+
+#~| msgid "New shortcut..."
+#~ msgid "No shortcut set"
+#~ msgstr "Нема кратенки"
+
+#~| msgid "Appearance Preferences"
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Преференции за универзален пристап"
+
 #, no-c-format
-msgid "100%"
-msgstr "100%"
+#~ msgid "100%"
+#~ msgstr "100%"
 
-#: ../panels/universal-access/uap.ui.h:4
 #, no-c-format
-msgid "125%"
-msgstr "125%"
+#~ msgid "125%"
+#~ msgstr "125%"
 
-#: ../panels/universal-access/uap.ui.h:6
 #, no-c-format
-msgid "150%"
-msgstr "150%"
-
-#: ../panels/universal-access/uap.ui.h:8
-#, no-c-format
-msgid "75%"
-msgstr "75%"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "A_cceptance delay:"
-msgstr "Д_оцнење за прифаќање:"
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "Acc_eptance delay:"
-msgstr "До_цнење за прифаќање:"
-
-#: ../panels/universal-access/uap.ui.h:11
-#| msgid "Beep when a key is pr_essed"
-msgid "Beep when Caps and Num Lock are used"
-msgstr "Свирни кога се користат Caps и Num Lock"
-
-#: ../panels/universal-access/uap.ui.h:12
-#| msgid "Beep when a _modifier key is pressed"
-msgid "Beep when a _modifer key is pressed"
-msgstr "Свирни кога е притиснат _менувач"
-
-#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
-#: ../panels/universal-access/uap.ui.h:14
-#| msgid "Beep when a key is pr_essed"
-msgid "Beep when a key is"
-msgstr "Свирни кога некое копче е"
-
-#: ../panels/universal-access/uap.ui.h:15
-#| msgid "Beep when a key is reje_cted"
-msgid "Beep when a key is _rejected"
-msgstr "Свирни кога некое копче е отфр_лено"
-
-#: ../panels/universal-access/uap.ui.h:16
-#| msgid "Mouse Keys"
-msgid "Bounce Keys"
-msgstr "Одбивни копчиња"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Bounce keys typing delay"
-msgstr "Доцнење при пишување на одбивните копчиња"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "Caribou"
-msgstr "Caribou"
-
-#: ../panels/universal-access/uap.ui.h:19
-#| msgid "Change set"
-msgid "Change contrast:"
-msgstr "Промени го контрастот:"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Closed Captioning"
-msgstr "Затворен натпис"
-
-#: ../panels/universal-access/uap.ui.h:21
-#| msgid "_Pointer can be controlled using the keypad"
-msgid "Control the pointer using the keypad"
-msgstr "Контрола на стрелката со тастатура"
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Control the pointer using the video camera."
-msgstr "Контролирај ја стрелката со помош на видео камера."
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "D_elay:"
-msgstr "З_астој:"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Dasher"
-msgstr "Dasher"
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Decrease size:"
-msgstr "Намали:"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Display a textual description of speech and sounds"
-msgstr "Прикажи текстуален опис на звуците и говорот"
-
-#: ../panels/universal-access/uap.ui.h:27
-#| msgid "Flash screen"
-msgid "Flash the entire screen"
-msgstr "Трепни го целиот екран"
-
-#: ../panels/universal-access/uap.ui.h:28
-#| msgid "Flash window"
-msgid "Flash the window title"
-msgstr "Трепни го насловот на прозорецот"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "GOK"
-msgstr "GOK"
-
-#: ../panels/universal-access/uap.ui.h:30
-#| msgctxt "Sound event"
-#| msgid "Warning"
-msgid "Hearing"
-msgstr "Слушање"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Hover Click"
-msgstr "Клик со застанување со стрелката врз предметите"
-
-#: ../panels/universal-access/uap.ui.h:32
-#| msgid "_Ignore fast duplicate keypresses"
-msgid "Ignores fast duplicate keypresses"
-msgstr "Ги игнорира брзите дупликати при притискање на копчињата"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Increase size:"
-msgstr "Зголеми:"
-
-#: ../panels/universal-access/uap.ui.h:39
-#| msgid "_Motion threshold:"
-msgid "Motion _threshold:"
-msgstr "_Праг на движење:"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Mouse Keys"
-msgstr "Копчиња на глушецот"
-
-#: ../panels/universal-access/uap.ui.h:41
-#| msgid "Mouse Keys"
-msgid "Mouse Settings"
-msgstr "Поставувања на глушецот"
-
-#: ../panels/universal-access/uap.ui.h:42
-#| msgid "None"
-msgid "Nomon"
-msgstr "Ништо"
-
-#: ../panels/universal-access/uap.ui.h:44
-#| msgid "GNOME OnScreen Keyboard"
-msgid "On screen keyboard"
-msgstr "Екранска тастатура"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "OnBoard"
-msgstr "OnBoard"
-
-#: ../panels/universal-access/uap.ui.h:46
-#| msgid "Layout _Options..."
-msgid "Options..."
-msgstr "Опции..."
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Pointing and Clicking"
-msgstr "Покажување и кликање"
-
-#: ../panels/universal-access/uap.ui.h:48
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "Става период на доцнење кога некое копче е притиснато и тоа е прифатено"
-
-#: ../panels/universal-access/uap.ui.h:49
-#| msgid "Linux Screen Reader"
-msgid "Screen Reader"
-msgstr "Читач на екранот"
-
-#: ../panels/universal-access/uap.ui.h:50
-#| msgid "GNOME OnScreen Keyboard"
-msgid "Screen keyboard"
-msgstr "Екранска тастатура"
-
-#: ../panels/universal-access/uap.ui.h:51
-#| msgid "Seco_ndary click:"
-msgid "Secondary click delay"
-msgstr "Период за двоен клик"
-
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Seeing"
-msgstr "Гледање"
-
-#: ../panels/universal-access/uap.ui.h:55
-#| msgid "<b>Simulated Secondary Click</b>"
-msgid "Simulated Secondary Click"
-msgstr "Симулиран двоен клик"
-
-#: ../panels/universal-access/uap.ui.h:56
-#| msgid "<b>Slow Keys</b>"
-msgid "Slow Keys"
-msgstr "Бавни копчиња"
-
-#: ../panels/universal-access/uap.ui.h:57
-msgid "Slow keys typing delay"
-msgstr "Доцнење при пишување на бавните копчиња"
-
-#: ../panels/universal-access/uap.ui.h:61
-#| msgid "<b>Sticky Keys</b>"
-msgid "Sticky Keys"
-msgstr "Лепливи копчиња"
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "Третира секвенца на изменувачки копчиња како комбинација на копчиња"
-
-#: ../panels/universal-access/uap.ui.h:63
-#| msgid "_Initiate click when stopping pointer movement"
-msgid "Trigger a click when the pointer hovers"
-msgstr "Иницирај клик при запирање на движењето на стрелката"
-
-#: ../panels/universal-access/uap.ui.h:64
-#| msgid "_Trigger secondary click by holding down the primary button"
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "Активирај го секундардниот клик со држење на примарното копче"
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "Turn on or off:"
-msgstr "Исклучи или приклучи:"
-
-#: ../panels/universal-access/uap.ui.h:66
-#| msgid "_Type to test settings:"
-msgid "Type here to test settings"
-msgstr "Пишувајте овде за да ги проверите поставувањата"
-
-#: ../panels/universal-access/uap.ui.h:68
-#| msgid "A_ssistant:"
-msgid "Typing Assistant"
-msgstr "Помошник за пишување"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Use a visual indication when an alert sound occurs"
-msgstr "Користи визуелен индикатор кога ќе се појави звучен сигнал"
-
-#: ../panels/universal-access/uap.ui.h:70
-#| msgid "Mouse"
-msgid "Video Mouse"
-msgstr "Видео глушец"
-
-#: ../panels/universal-access/uap.ui.h:71
-#| msgctxt "Sound event"
-#| msgid "Visual alert"
-msgid "Visual Alerts"
-msgstr "Визуелни известувања"
-
-#: ../panels/universal-access/uap.ui.h:72
-msgid "Zoom in:"
-msgstr "Зумирај:"
-
-#: ../panels/universal-access/uap.ui.h:73
-msgid "Zoom out:"
-msgstr "Одзумирај:"
-
-#: ../panels/universal-access/uap.ui.h:74
-#| msgid "_Country:"
-msgid "_Contrast:"
-msgstr "_Контраст:"
-
-#: ../panels/universal-access/uap.ui.h:75
-#| msgid "Disa_ble sticky keys if two keys are pressed together"
-msgid "_Disable if two keys are pressed together"
-msgstr "_Оневозможи ако две копчиња се притиснати одеднаш"
-
-#: ../panels/universal-access/uap.ui.h:76
-msgid "_Test flash"
-msgstr "_Тестирај го блицот"
-
-#: ../panels/universal-access/uap.ui.h:77
-msgid "_Text size:"
-msgstr "_Големина на текст:"
-
-#: ../panels/universal-access/uap.ui.h:78
-#| msgid "_Accessibility features can be toggled with keyboard shortcuts"
-msgid "_Turn on accessibility features from the keyboard"
-msgstr "_Приклучи ги опциите за пристапност од тастатурата"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:80
-msgid "accepted"
-msgstr "прифатено"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:82
-msgid "pressed"
-msgstr "притиснато"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:84
-msgid "rejected"
-msgstr "одбиено"
-
-#: ../panels/universal-access/uap.ui.h:85
-#| msgid "Right"
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "Високо"
-
-#: ../panels/universal-access/uap.ui.h:86
-msgctxt "universal access, contrast"
-msgid "High/Inverse"
-msgstr "Висок/инверзен"
-
-#: ../panels/universal-access/uap.ui.h:87
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "Низок"
-
-#: ../panels/universal-access/uap.ui.h:88
-#| msgid "Normal"
-msgctxt "universal access, contrast"
-msgid "Normal"
-msgstr "Нормално"
-
-#. Translators: this refers to theme contrast and font size
-#: ../panels/universal-access/uap.ui.h:90
-#| msgid "_Detect Displays"
-msgctxt "universal access, seeing"
-msgid "Display"
-msgstr "Приказ"
-
-#. Translators: this refers to screen magnifier
-#: ../panels/universal-access/uap.ui.h:92
-msgctxt "universal access, seeing"
-msgid "Zoom"
-msgstr "Зумирај"
-
-#: ../panels/universal-access/uap.ui.h:93
-#| msgid "Large"
-msgctxt "universal access, text size"
-msgid "Large"
-msgstr "Голем"
-
-#: ../panels/universal-access/uap.ui.h:94
-#| msgid "Large"
-msgctxt "universal access, text size"
-msgid "Larger"
-msgstr "Поголем"
-
-#: ../panels/universal-access/uap.ui.h:95
-#| msgid "Normal"
-msgctxt "universal access, text size"
-msgid "Normal"
-msgstr "Нормален"
-
-#: ../panels/universal-access/uap.ui.h:96
-#| msgid "Small"
-msgctxt "universal access, text size"
-msgid "Small"
-msgstr "Мал"
-
-#: ../panels/universal-access/zoom-options.c:156
-#| msgid "Lock Screen"
-msgid "1/4 Screen"
-msgstr "1/4 од приказот"
-
-#: ../panels/universal-access/zoom-options.c:157
-#| msgid "Lock Screen"
-msgid "1/2 Screen"
-msgstr "1/2 од приказот"
-
-#: ../panels/universal-access/zoom-options.c:158
-#| msgid "Lock Screen"
-msgid "3/4 Screen"
-msgstr "3/4 од приказот"
-
-#: ../panels/universal-access/zoom-options.ui.h:1
-msgid "Always"
-msgstr "Секогаш"
-
-#: ../panels/universal-access/zoom-options.ui.h:2
-msgid "Bottom Half"
-msgstr "Долната половина"
-
-#: ../panels/universal-access/zoom-options.ui.h:3
-#| msgid "Internet"
-msgid "Centered"
-msgstr "Центриран"
-
-#: ../panels/universal-access/zoom-options.ui.h:4
-msgid "Color and Opacity"
-msgstr "Боја и провидност"
-
-#: ../panels/universal-access/zoom-options.ui.h:5
-msgid "Crosshairs"
-msgstr "Мети"
-
-#: ../panels/universal-access/zoom-options.ui.h:6
-#| msgid "Flash screen"
-msgid "Full Screen"
-msgstr "На цел екран"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Image moves with the mouse pointer"
-msgstr "Сликата се движи по стрелката на глувчето"
-
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Image scrolls at screen edges"
-msgstr "Сликата се движи по рабовите на екранот"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-#| msgid "Left"
-msgid "Left Half"
-msgstr "Лева половина"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-#| msgid "Left"
-msgid "Length"
-msgstr "Должина"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnification"
-msgstr "Зголемување"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
-msgid "Moveable lens - magnified view follows mouse movements"
-msgstr "Подвижни леќи - зголемен преглед кој ги следи движењата на глушецот"
-
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Position of magnified view on screen"
-msgstr "Позиција на зголемениот преглед на екранот"
-
-#: ../panels/universal-access/zoom-options.ui.h:18
-msgid "Proportional"
-msgstr "Пропорционално"
-
-#: ../panels/universal-access/zoom-options.ui.h:19
-msgid "Push"
-msgstr "Притисни"
-
-#: ../panels/universal-access/zoom-options.ui.h:20
-#| msgid "Right"
-msgid "Right Half"
-msgstr "Десна половина"
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-#| msgid "Shutdown"
-msgid "Show"
-msgstr "Покажи"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Show crosshairs intersection"
-msgstr "Прикажи го пресекот на метата"
-
-#. long delay
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "Thick"
-msgstr "Дебело"
-
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Thickness"
-msgstr "Дебелина"
-
-#. short delay
-#: ../panels/universal-access/zoom-options.ui.h:29
-msgid "Thin"
-msgstr "Тенко"
-
-#: ../panels/universal-access/zoom-options.ui.h:30
-msgid "To keep the pointer centered"
-msgstr "За зачувување на стрелката во центар"
-
-#: ../panels/universal-access/zoom-options.ui.h:31
-msgid "To keep the pointer visible"
-msgstr "За да остане стрелката видлива"
-
-#: ../panels/universal-access/zoom-options.ui.h:32
-msgid "Top Half"
-msgstr "Горна половина"
-
-#: ../panels/universal-access/zoom-options.ui.h:33
-#| msgid "Layout _Options..."
-msgid "Zoom Options"
-msgstr "Опции за зумирање"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-#: ../panels/user-accounts/um-account-type.c:37
-#| msgid "Terminator"
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "Администратор"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-#: ../panels/user-accounts/um-account-type.c:35
-#| msgid "Standard XTerminal"
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Стандардно"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-#| msgid "_Paste"
-msgid "Cr_eate"
-msgstr "К_реирај"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "Create new account"
-msgstr "Креирај нова сметка"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#| msgid "Alert Type"
-msgid "_Account Type"
-msgstr "_Тип на сметка"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-#| msgid "Full Name"
-msgid "_Full name"
-msgstr "_Цело име"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#| msgid "User name:"
-msgid "_Username"
-msgstr "_Корисничко име"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-#: ../panels/user-accounts/um-fingerprint-dialog.c:571
-msgid "Enable Fingerprint Login"
-msgstr "Овозможи најава со отпечаток од прст"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left little finger"
-msgstr "Десниот мал прст"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left middle finger"
-msgstr "Левиот мал прст"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left ring finger"
-msgstr "Левиот прст прстеноносец"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Left thumb"
-msgstr "Левиот палец"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right little finger"
-msgstr "Десниот мал прст"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right middle finger"
-msgstr "Десниот среден прст"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right ring finger"
-msgstr "Десниот прст прстеноносец"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#| msgid "Right"
-msgid "Right thumb"
-msgstr "Десен палец"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
-msgstr "Вашиот отпечаток беше успешно зачуван. Сега можете да се најавувате со користење на Вашиот читач на отпечатоци."
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "_Лев показалец"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "_Друг прст:"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid "_Right index finger"
-msgstr "_Десен показалец"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Add or remove users"
-msgstr "Додај или отстрани корисници"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Најава;Има;Отпечаток;Аватар;Лого;Лице;Лозинка;"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-#| msgid "seconds"
-msgid "User Accounts"
-msgstr "Кориснички сметки"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-#| msgid "Change password"
-msgid "C_onfirm password"
-msgstr "По_тврди ја лозинката"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#| msgid "Change set"
-msgid "Ch_ange"
-msgstr "Про_мени"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-#| msgid "Change password"
-msgid "Changing password for"
-msgstr "Ја променувам лозинката за"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-#| msgid "Change password"
-msgid "Choose a generated password"
-msgstr "Избери генерирана лозинка"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Choose password at next login"
-msgstr "Изберете лозинка на следното најавување"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-#| msgid "Current _password:"
-msgid "Current _password"
-msgstr "Тековна _лозинка"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Disable this account"
-msgstr "Оневозможи ја оваа сметка"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Enable this account"
-msgstr "Овозможи ја оваа сметка"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-#| msgid "Filter"
-msgid "Fair"
-msgstr "Во ред"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-msgid "How to choose a strong password"
-msgstr "Како да изберете добра лозинка"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-msgid "Log in without a password"
-msgstr "Најави се без лозинка"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-#| msgid "_New password:"
-msgid "Set a password now"
-msgstr "Изберете лозинка сега"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid "This hint may be displayed at the login screen.  It will be visible to all users of this system.  Do <b>not</b> include the password here."
-msgstr "Овој потсетник ќе биде прикажен на најавниот екран. Тој ќе биде достапен на сите корисници на системот. <b>Не</b> ставајте ја Вашата лозинка тука."
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-#| msgid "Action"
-msgid "_Action"
-msgstr "_Дејство"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:15
-#| msgid "_Print"
-msgid "_Hint"
-msgstr "_Помош"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:16
-#| msgid "_New password:"
-msgid "_New password"
-msgstr "_Нова лозинка"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:17
-#| msgid "_New password:"
-msgid "_Show password"
-msgstr "_Покажи ја лозинката"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-msgid "Browse"
-msgstr "Прелистај"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-msgid "Cancel"
-msgstr "Откажи"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-msgid "Changing photo for:"
-msgstr "Менување на сликата за:"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-msgid "Choose a picture that will be shown at the login screen for this account."
-msgstr "Одберете слика која ќе биде прикажана на најавниот екран за оваа сметка."
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-#| msgid "Galeon"
-msgid "Gallery"
-msgstr "Галерија"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr "Фотографија"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-#: ../panels/user-accounts/um-photo-dialog.c:97
-#| msgid "_Select"
-msgid "Select"
-msgstr "Избери"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-#| msgid "Take a break!"
-msgid "Take a photograph"
-msgstr "Сликај"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-msgid "A_utomatic Login"
-msgstr "А_втоматска најава"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-msgid "Account Information"
-msgstr "Информации за сметката"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Account _type"
-msgstr "_Тип на сметка"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Add User Account"
-msgstr "Додај корисничка сметка"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-#| msgid "Layout _Options..."
-msgid "Login Options"
-msgstr "Опции за најавување"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-#| msgid "Revert Font"
-msgid "Remove User Account"
-msgstr "Отстрани корисничка сметка"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-#| msgid "User name:"
-msgid "User Icon"
-msgstr "Корисничка икона"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "_Fingerprint Login"
-msgstr "Најава со _отпечаток"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-#| msgid "_Language:"
-msgid "_Language"
-msgstr "_Јазик"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-#| msgid "_Password:"
-msgid "_Password"
-msgstr "_Лозинка"
-
-#: ../panels/user-accounts/run-passwd.c:426
-#| msgid "Authenticated!"
-msgid "Authentication failed"
-msgstr "Автентикацијата не успеа"
-
-#: ../panels/user-accounts/run-passwd.c:506
-#: ../panels/user-accounts/um-password-dialog.c:375
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "До_цнење за прифаќање:"
+
+#~| msgid "Beep when a key is pr_essed"
+#~ msgid "Beep when Caps and Num Lock are used"
+#~ msgstr "Свирни кога се користат Caps и Num Lock"
+
+#~| msgid "Beep when a key is pr_essed"
+#~ msgid "Beep when a key is"
+#~ msgstr "Свирни кога некое копче е"
+
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~| msgid "Change set"
+#~ msgid "Change contrast:"
+#~ msgstr "Промени го контрастот:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "Затворен натпис"
+
+#~| msgid "_Pointer can be controlled using the keypad"
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Контрола на стрелката со тастатура"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Контролирај ја стрелката со помош на видео камера."
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Прикажи текстуален опис на звуците и говорот"
+
+#~| msgid "Flash window"
+#~ msgid "Flash the window title"
+#~ msgstr "Трепни го насловот на прозорецот"
+
+#~ msgid "GOK"
+#~ msgstr "GOK"
+
+#~| msgid "Mouse Keys"
+#~ msgid "Mouse Settings"
+#~ msgstr "Поставувања на глушецот"
+
+#~| msgid "None"
+#~ msgid "Nomon"
+#~ msgstr "Ништо"
+
+#~| msgid "GNOME OnScreen Keyboard"
+#~ msgid "On screen keyboard"
+#~ msgstr "Екранска тастатура"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~| msgid "Layout _Options..."
+#~ msgid "Options..."
+#~ msgstr "Опции..."
+
+#~| msgid "_Type to test settings:"
+#~ msgid "Type here to test settings"
+#~ msgstr "Пишувајте овде за да ги проверите поставувањата"
+
+#~| msgid "Mouse"
+#~ msgid "Video Mouse"
+#~ msgstr "Видео глушец"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Зумирај:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Одзумирај:"
+
+#~ msgid "_Text size:"
+#~ msgstr "_Големина на текст:"
+
+#~ msgid "accepted"
+#~ msgstr "прифатено"
+
+#~ msgid "pressed"
+#~ msgstr "притиснато"
+
+#~ msgid "rejected"
+#~ msgstr "одбиено"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Висок/инверзен"
+
+#~| msgid "Normal"
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Нормално"
+
+#~| msgid "_Detect Displays"
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "Приказ"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "Зумирај"
+
+#~| msgid "Large"
+#~ msgctxt "universal access, text size"
+#~ msgid "Large"
+#~ msgstr "Голем"
+
+#~| msgid "Large"
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "Поголем"
+
+#~| msgid "Normal"
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Нормален"
+
+#~| msgid "Small"
+#~ msgctxt "universal access, text size"
+#~ msgid "Small"
+#~ msgstr "Мал"
+
+#~| msgid "Lock Screen"
+#~ msgid "1/4 Screen"
+#~ msgstr "1/4 од приказот"
+
+#~| msgid "Lock Screen"
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 од приказот"
+
+#~| msgid "Lock Screen"
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 од приказот"
+
+#~ msgid "Always"
+#~ msgstr "Секогаш"
+
+#~| msgid "Internet"
+#~ msgid "Centered"
+#~ msgstr "Центриран"
+
+#~ msgid "Color and Opacity"
+#~ msgstr "Боја и провидност"
+
+#~ msgid "Image moves with the mouse pointer"
+#~ msgstr "Сликата се движи по стрелката на глувчето"
+
+#~ msgid "Image scrolls at screen edges"
+#~ msgstr "Сликата се движи по рабовите на екранот"
+
+#~ msgid "Moveable lens - magnified view follows mouse movements"
+#~ msgstr "Подвижни леќи - зголемен преглед кој ги следи движењата на глушецот"
+
+#~ msgid "Position of magnified view on screen"
+#~ msgstr "Позиција на зголемениот преглед на екранот"
+
+#~ msgid "Push"
+#~ msgstr "Притисни"
+
+#~| msgid "Shutdown"
+#~ msgid "Show"
+#~ msgstr "Покажи"
+
+#~ msgid "Show crosshairs intersection"
+#~ msgstr "Прикажи го пресекот на метата"
+
+#~ msgid "To keep the pointer centered"
+#~ msgstr "За зачувување на стрелката во центар"
+
+#~ msgid "To keep the pointer visible"
+#~ msgstr "За да остане стрелката видлива"
+
+#~| msgid "Standard XTerminal"
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Стандардно"
+
+#~| msgid "_Paste"
+#~ msgid "Cr_eate"
+#~ msgstr "К_реирај"
+
+#~ msgid "Create new account"
+#~ msgstr "Креирај нова сметка"
+
+#~| msgid "Alert Type"
+#~ msgid "_Account Type"
+#~ msgstr "_Тип на сметка"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Овозможи најава со отпечаток од прст"
+
+#~ msgid "Left little finger"
+#~ msgstr "Десниот мал прст"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Левиот мал прст"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Левиот прст прстеноносец"
+
+#~ msgid "Left thumb"
+#~ msgstr "Левиот палец"
+
+#~ msgid "Right little finger"
+#~ msgstr "Десниот мал прст"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Десниот среден прст"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Десниот прст прстеноносец"
+
+#~| msgid "Right"
+#~ msgid "Right thumb"
+#~ msgstr "Десен палец"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Вашиот отпечаток беше успешно зачуван. Сега можете да се најавувате со "
+#~ "користење на Вашиот читач на отпечатоци."
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Лев показалец"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Десен показалец"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Најава;Има;Отпечаток;Аватар;Лого;Лице;Лозинка;"
+
+#~| msgid "seconds"
+#~ msgid "User Accounts"
+#~ msgstr "Кориснички сметки"
+
+#~| msgid "Change password"
+#~ msgid "Changing password for"
+#~ msgstr "Ја променувам лозинката за"
+
+#~ msgid "Disable this account"
+#~ msgstr "Оневозможи ја оваа сметка"
+
+#~ msgid "Enable this account"
+#~ msgstr "Овозможи ја оваа сметка"
+
+#~| msgid "Filter"
+#~ msgid "Fair"
+#~ msgstr "Во ред"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Како да изберете добра лозинка"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Најави се без лозинка"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "Овој потсетник ќе биде прикажен на најавниот екран. Тој ќе биде достапен "
+#~ "на сите корисници на системот. <b>Не</b> ставајте ја Вашата лозинка тука."
+
+#~| msgid "_Print"
+#~ msgid "_Hint"
+#~ msgstr "_Помош"
+
+#~ msgid "Browse"
+#~ msgstr "Прелистај"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Менување на сликата за:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Одберете слика која ќе биде прикажана на најавниот екран за оваа сметка."
+
+#~| msgid "Galeon"
+#~ msgid "Gallery"
+#~ msgstr "Галерија"
+
+#~ msgid "Photograph"
+#~ msgstr "Фотографија"
+
+#~| msgid "Take a break!"
+#~ msgid "Take a photograph"
+#~ msgstr "Сликај"
+
+#~ msgid "Account Information"
+#~ msgstr "Информации за сметката"
+
+#~ msgid "Add User Account"
+#~ msgstr "Додај корисничка сметка"
+
+#~| msgid "Layout _Options..."
+#~ msgid "Login Options"
+#~ msgstr "Опции за најавување"
+
+#~| msgid "Revert Font"
+#~ msgid "Remove User Account"
+#~ msgstr "Отстрани корисничка сметка"
+
+#~| msgid "Authenticated!"
+#~ msgid "Authentication failed"
+#~ msgstr "Автентикацијата не успеа"
+
 #, c-format
-#| msgid "The password is too short."
-msgid "The new password is too short"
-msgstr "Новата лозинка е премногу кратка"
+#~| msgid "The password is too short."
+#~ msgid "The new password is too short"
+#~ msgstr "Новата лозинка е премногу кратка"
 
-#: ../panels/user-accounts/run-passwd.c:512
 #, c-format
-#| msgid "The password is too simple."
-msgid "The new password is too simple"
-msgstr "Новата лозинка е премногу едноставна"
+#~| msgid "The password is too simple."
+#~ msgid "The new password is too simple"
+#~ msgstr "Новата лозинка е премногу едноставна"
 
-#: ../panels/user-accounts/run-passwd.c:518
 #, c-format
-#| msgid "The old and new passwords are too similar."
-msgid "The old and new passwords are too similar"
-msgstr "Старата и новата лозинка се премногу слични"
+#~| msgid "The old and new passwords are too similar."
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Старата и новата лозинка се премногу слични"
 
-#: ../panels/user-accounts/run-passwd.c:521
 #, c-format
-#| msgid "The two passwords are not equal."
-msgid "The new password has already been used recently."
-msgstr "Новата лозинка веќе беше користена неодамна."
+#~| msgid "The two passwords are not equal."
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Новата лозинка веќе беше користена неодамна."
 
-#: ../panels/user-accounts/run-passwd.c:524
 #, c-format
-#| msgid "The new password must contain numeric or special character(s)."
-msgid "The new password must contain numeric or special characters"
-msgstr "Новата лозинка треба да содржи нумерички и специјални знаци"
+#~| msgid "The new password must contain numeric or special character(s)."
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Новата лозинка треба да содржи нумерички и специјални знаци"
 
-#: ../panels/user-accounts/run-passwd.c:528
 #, c-format
-#| msgid "The old and new passwords are the same."
-msgid "The old and new passwords are the same"
-msgstr "Старата и новата лозинка се исти"
+#~| msgid "The old and new passwords are the same."
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Старата и новата лозинка се исти"
 
-#: ../panels/user-accounts/run-passwd.c:532
 #, c-format
-#| msgid ""
-#| "Your password has been changed since you initially authenticated! Please "
-#| "re-authenticate."
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Вашата лозинка беше променета откако претходно се автентициравте!"
+#~| msgid ""
+#~| "Your password has been changed since you initially authenticated! Please "
+#~| "re-authenticate."
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Вашата лозинка беше променета откако претходно се автентициравте!"
 
-#: ../panels/user-accounts/run-passwd.c:536
 #, c-format
-#| msgid "The new password must contain numeric or special character(s)."
-msgid "The new password does not contain enough different characters"
-msgstr "Новата лозинка не содржи доволно различни знаци"
+#~| msgid "The new password must contain numeric or special character(s)."
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Новата лозинка не содржи доволно различни знаци"
 
-#: ../panels/user-accounts/run-passwd.c:540
 #, c-format
-#| msgid "Unknown"
-msgid "Unknown error"
-msgstr "Непозната грешка"
+#~| msgid "Unknown"
+#~ msgid "Unknown error"
+#~ msgstr "Непозната грешка"
 
-#: ../panels/user-accounts/um-account-dialog.c:73
-#| msgid "Failed to create temporary directory"
-msgid "Failed to create user"
-msgstr "Не успеав да креирам корисник"
+#~| msgid "Failed to create temporary directory"
+#~ msgid "Failed to create user"
+#~ msgstr "Не успеав да креирам корисник"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:107
-msgid "You are not allowed to access the device. Contact your system administrator."
-msgstr "Немате дозвола да пристапите на уредот. Контактирајте со Вашиот администратор на системот."
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Немате дозвола да пристапите на уредот. Контактирајте со Вашиот "
+#~ "администратор на системот."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:109
-msgid "The device is already in use."
-msgstr "Уредот е веќе во употреба."
+#~ msgid "The device is already in use."
+#~ msgstr "Уредот е веќе во употреба."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:111
-#| msgid "A system error has occurred"
-msgid "An internal error occurred."
-msgstr "Се случи внатрешна грешка."
+#~| msgid "A system error has occurred"
+#~ msgid "An internal error occurred."
+#~ msgstr "Се случи внатрешна грешка."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:181
-#: ../panels/user-accounts/um-fingerprint-dialog.c:182
-#| msgid "Disabled"
-msgid "Enabled"
-msgstr "Овозможено"
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Да ги избришам регистрираните отпечатоци?"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:224
-msgid "Delete registered fingerprints?"
-msgstr "Да ги избришам регистрираните отпечатоци?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:228
-msgid "_Delete Fingerprints"
-msgstr "_Избриши ги отпечатоците"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:235
-msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
-msgstr "Дали сакате да ги избришите регистрираните отпечатоци за да се оневозможи најавувањето со отпечатоци?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:363
-#| msgid "None"
-msgid "Done!"
-msgstr "Готово!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:410
-#: ../panels/user-accounts/um-fingerprint-dialog.c:432
 #, c-format
-msgid "Could not access '%s' device"
-msgstr "Не можев да пристапам на уредот „%s“"
+#~ msgid "Could not access '%s' device"
+#~ msgstr "Не можев да пристапам на уредот „%s“"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:481
 #, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "Не можев да започнам со снимање на отпечаток на уредот „%s“"
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "Не можев да започнам со снимање на отпечаток на уредот „%s“"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:533
-#| msgid "Could not load the main interface"
-msgid "Could not access any fingerprint readers"
-msgstr "Не можев да пристапам до ниеден читач на отпечатоци"
+#~| msgid "Could not load the main interface"
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Не можев да пристапам до ниеден читач на отпечатоци"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:534
-msgid "Please contact your system administrator for help."
-msgstr "Контактирајте со администраторот на системот за помош."
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Контактирајте со администраторот на системот за помош."
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:605
 #, c-format
-msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
-msgstr "За да овозможите најава со отпечаток, мора да снимате Ваш отпечаток со користење на уредот „%s“."
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "За да овозможите најава со отпечаток, мора да снимате Ваш отпечаток со "
+#~ "користење на уредот „%s“."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:612
-#| msgid "Select Image"
-msgid "Selecting finger"
-msgstr "Избирам прст"
+#~ msgid "More choices..."
+#~ msgstr "Повеќе избор..."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:613
-msgid "Enrolling fingerprints"
-msgstr "Запишани отпечатоци"
+#~ msgid "Please choose another password."
+#~ msgstr "Одберете друга лозинка."
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:614
-msgid "Summary"
-msgstr "Резиме"
+#~| msgid "Please type your password in the <b>New password</b> field."
+#~ msgid "Please type your current password again."
+#~ msgstr "Ве молам, внесете ја Вашата лозинка пак."
 
-#: ../panels/user-accounts/um-password-dialog.c:179
-msgid "More choices..."
-msgstr "Повеќе избор..."
+#~| msgid "Your password has been changed."
+#~ msgid "Password could not be changed"
+#~ msgstr "Лозинката не може да биде променета"
 
-#: ../panels/user-accounts/um-password-dialog.c:285
-msgid "Please choose another password."
-msgstr "Одберете друга лозинка."
+#~| msgid "_Retype new password:"
+#~ msgid "You need to enter a new password"
+#~ msgstr "Треба да внесите нова лозинка"
 
-#: ../panels/user-accounts/um-password-dialog.c:294
-#| msgid "Please type your password in the <b>New password</b> field."
-msgid "Please type your current password again."
-msgstr "Ве молам, внесете ја Вашата лозинка пак."
+#~ msgid "You need to confirm the password"
+#~ msgstr "Треба да ја потврдите лозинката"
 
-#: ../panels/user-accounts/um-password-dialog.c:300
-#| msgid "Your password has been changed."
-msgid "Password could not be changed"
-msgstr "Лозинката не може да биде променета"
+#~ msgid "You need to enter your current password"
+#~ msgstr "Треба да ја внесите Вашата тековна лозинка"
 
-#: ../panels/user-accounts/um-password-dialog.c:372
-#| msgid "_Retype new password:"
-msgid "You need to enter a new password"
-msgstr "Треба да внесите нова лозинка"
+#~| msgid "That password was incorrect."
+#~ msgid "The current password is not correct"
+#~ msgstr "Тековната лозинка не е точна"
 
-#: ../panels/user-accounts/um-password-dialog.c:381
-msgid "You need to confirm the password"
-msgstr "Треба да ја потврдите лозинката"
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Премногу кратка"
 
-#: ../panels/user-accounts/um-password-dialog.c:384
-#| msgid "The password is too short."
-msgid "The passwords do not match"
-msgstr "Лозинките не се совпаѓаат"
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Слаба"
 
-#: ../panels/user-accounts/um-password-dialog.c:390
-msgid "You need to enter your current password"
-msgstr "Треба да ја внесите Вашата тековна лозинка"
+#~| msgid "Filter"
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Добра"
 
-#: ../panels/user-accounts/um-password-dialog.c:393
-#| msgid "That password was incorrect."
-msgid "The current password is not correct"
-msgstr "Тековната лозинка не е точна"
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Добра"
 
-#: ../panels/user-accounts/um-password-dialog.c:466
-#: ../panels/user-accounts/um-password-dialog.c:693
-msgctxt "Password strength"
-msgid "Too short"
-msgstr "Премногу кратка"
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Јака"
 
-#: ../panels/user-accounts/um-password-dialog.c:469
-#: ../panels/user-accounts/um-password-dialog.c:694
-msgctxt "Password strength"
-msgid "Weak"
-msgstr "Слаба"
+#~ msgid "Passwords do not match"
+#~ msgstr "Лозинките не се совпаѓаат"
 
-#: ../panels/user-accounts/um-password-dialog.c:471
-#: ../panels/user-accounts/um-password-dialog.c:695
-#| msgid "Filter"
-msgctxt "Password strength"
-msgid "Fair"
-msgstr "Добра"
+#~| msgid "Change password"
+#~ msgid "Wrong password"
+#~ msgstr "Погрешна лозинка"
 
-#: ../panels/user-accounts/um-password-dialog.c:473
-#: ../panels/user-accounts/um-password-dialog.c:696
-msgctxt "Password strength"
-msgid "Good"
-msgstr "Добра"
+#~| msgid "Disabled"
+#~ msgid "Disable image"
+#~ msgstr "Оневозможи слика"
 
-#: ../panels/user-accounts/um-password-dialog.c:475
-#: ../panels/user-accounts/um-password-dialog.c:697
-msgctxt "Password strength"
-msgid "Strong"
-msgstr "Јака"
+#~ msgid "Take a photo..."
+#~ msgstr "Сликај..."
 
-#: ../panels/user-accounts/um-password-dialog.c:514
-msgid "Passwords do not match"
-msgstr "Лозинките не се совпаѓаат"
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Прелистај за повеќе слики..."
 
-#: ../panels/user-accounts/um-password-dialog.c:540
-#| msgid "Change password"
-msgid "Wrong password"
-msgstr "Погрешна лозинка"
-
-#: ../panels/user-accounts/um-photo-dialog.c:445
-#| msgid "Disabled"
-msgid "Disable image"
-msgstr "Оневозможи слика"
-
-#: ../panels/user-accounts/um-photo-dialog.c:463
-msgid "Take a photo..."
-msgstr "Сликај..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:481
-msgid "Browse for more pictures..."
-msgstr "Прелистај за повеќе слики..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:706
 #, c-format
-msgid "Used by %s"
-msgstr "Се користи од %s"
+#~ msgid "Used by %s"
+#~ msgstr "Се користи од %s"
 
-#: ../panels/user-accounts/um-user-manager.c:450
 #, c-format
-msgid "A user with name '%s' already exists."
-msgstr "Веќе постои корисник со име „%s“."
+#~ msgid "A user with name '%s' already exists."
+#~ msgstr "Веќе постои корисник со име „%s“."
 
-#: ../panels/user-accounts/um-user-manager.c:546
-msgid "This user does not exist."
-msgstr "Овој корисник не постои."
+#~ msgid "This user does not exist."
+#~ msgstr "Овој корисник не постои."
 
-#: ../panels/user-accounts/um-user-panel.c:358
-msgid "Failed to delete user"
-msgstr "Не успеав да го избришам корисникот"
+#~ msgid "Failed to delete user"
+#~ msgstr "Не успеав да го избришам корисникот"
 
-#: ../panels/user-accounts/um-user-panel.c:418
-msgid "You cannot delete your own account."
-msgstr "Не можете да ја избришете сопствената сметка."
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Не можете да ја избришете сопствената сметка."
 
-#: ../panels/user-accounts/um-user-panel.c:427
 #, c-format
-msgid "%s is still logged in"
-msgstr "%s е сѐ уште најавен(а)"
+#~ msgid "%s is still logged in"
+#~ msgstr "%s е сѐ уште најавен(а)"
 
-#: ../panels/user-accounts/um-user-panel.c:431
-msgid "Deleting a user while they are logged in can leave the system in an inconsistent state."
-msgstr "Бришењето на корисник додека е сѐ уште најавен може да го доведе системот во неправилна состојба."
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Бришењето на корисник додека е сѐ уште најавен може да го доведе системот "
+#~ "во неправилна состојба."
 
-#: ../panels/user-accounts/um-user-panel.c:440
 #, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "Дали сакате да ги зачувате датотеките на „%s“?"
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "Дали сакате да ги зачувате датотеките на „%s“?"
 
-#: ../panels/user-accounts/um-user-panel.c:444
-msgid "It is possible to keep the home directory, mail spool and temporary files around when deleting a user account."
-msgstr "Можно е да го зачувате домашниот директориум, поштата и привремените датотеки при бришењето на корисничка сметка."
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Можно е да го зачувате домашниот директориум, поштата и привремените "
+#~ "датотеки при бришењето на корисничка сметка."
 
-#: ../panels/user-accounts/um-user-panel.c:447
-#| msgid "_Selected items:"
-msgid "_Delete Files"
-msgstr "_Избриши ги датотеките"
+#~| msgid "New File"
+#~ msgid "_Keep Files"
+#~ msgstr "_Зачувај ги датотеките"
 
-#: ../panels/user-accounts/um-user-panel.c:448
-#| msgid "New File"
-msgid "_Keep Files"
-msgstr "_Зачувај ги датотеките"
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Сметката е оневозможена"
 
-#: ../panels/user-accounts/um-user-panel.c:500
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Сметката е оневозможена"
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Ќе биде поставена на наредното најавување"
 
-#: ../panels/user-accounts/um-user-panel.c:508
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Ќе биде поставена на наредното најавување"
+#~| msgid "None"
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ништо"
 
-#: ../panels/user-accounts/um-user-panel.c:511
-#| msgid "None"
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ништо"
+#~| msgid "Failed to construct test pipeline for '%s'"
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Не успеав да контактирам со сервисот за сметки"
 
-#: ../panels/user-accounts/um-user-panel.c:846
-#| msgid "Failed to construct test pipeline for '%s'"
-msgid "Failed to contact the accounts service"
-msgstr "Не успеав да контактирам со сервисот за сметки"
+#~| msgid "Please make sure that the applet is properly installed"
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Проверете дали AccountService е инсталиран и овозможен."
 
-#: ../panels/user-accounts/um-user-panel.c:848
-#| msgid "Please make sure that the applet is properly installed"
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Проверете дали AccountService е инсталиран и овозможен."
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "За да направите промени,\n"
+#~ "кликнете на иконата *"
 
-#: ../panels/user-accounts/um-user-panel.c:888
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"За да направите промени,\n"
-"кликнете на иконата *"
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "За да креирате нова сметка,\n"
+#~ "кликнете на иконата *"
 
-#: ../panels/user-accounts/um-user-panel.c:926
-msgid "Create a user account"
-msgstr "Креирај нова сметка"
+#~ msgid "Delete the selected user account"
+#~ msgstr "Избриши ја избраната корисничка сметка"
 
-#: ../panels/user-accounts/um-user-panel.c:937
-#: ../panels/user-accounts/um-user-panel.c:1226
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"За да креирате нова сметка,\n"
-"кликнете на иконата *"
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "За да ја избришете избраната корисничка сметка,\n"
+#~ "стиснете на иконата *"
 
-#: ../panels/user-accounts/um-user-panel.c:946
-msgid "Delete the selected user account"
-msgstr "Избриши ја избраната корисничка сметка"
+#~ msgid "Other Accounts"
+#~ msgstr "Други сметки"
 
-#: ../panels/user-accounts/um-user-panel.c:958
-#: ../panels/user-accounts/um-user-panel.c:1231
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"За да ја избришете избраната корисничка сметка,\n"
-"стиснете на иконата *"
-
-#: ../panels/user-accounts/um-user-panel.c:1135
-#| msgid "By _country"
-msgid "My Account"
-msgstr "Мојата сметка"
-
-#: ../panels/user-accounts/um-user-panel.c:1145
-msgid "Other Accounts"
-msgstr "Други сметки"
-
-#: ../panels/user-accounts/um-utils.c:512
 #, c-format
-msgid "A user with the username '%s' already exists"
-msgstr "Веќе постои корисник со корисничко име „%s“"
+#~ msgid "A user with the username '%s' already exists"
+#~ msgstr "Веќе постои корисник со корисничко име „%s“"
 
-#: ../panels/user-accounts/um-utils.c:516
 #, c-format
-#| msgid "The password is too short."
-msgid "The username is too long"
-msgstr "Корисничкото име е предолго"
+#~| msgid "The password is too short."
+#~ msgid "The username is too long"
+#~ msgstr "Корисничкото име е предолго"
 
-#: ../panels/user-accounts/um-utils.c:519
-msgid "The username cannot start with a '-'"
-msgstr "Корисничкото име не смее да започнува со „-“"
+#~ msgid "The username cannot start with a '-'"
+#~ msgstr "Корисничкото име не смее да започнува со „-“"
 
-#: ../panels/user-accounts/um-utils.c:522
-msgid ""
-"The username must only consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-"Корисничкото име смее да се состои од:\n"
-" ➣ букви од англиската абецеда\n"
-" ➣ цифри\n"
-" ➣ било кој од знаците „.“, „-“ и „_“"
+#~ msgid ""
+#~ "The username must only consist of:\n"
+#~ " ➣ letters from the English alphabet\n"
+#~ " ➣ digits\n"
+#~ " ➣ any of the characters '.', '-' and '_'"
+#~ msgstr ""
+#~ "Корисничкото име смее да се состои од:\n"
+#~ " ➣ букви од англиската абецеда\n"
+#~ " ➣ цифри\n"
+#~ " ➣ било кој од знаците „.“, „-“ и „_“"
 
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#| msgid "Set your mouse preferences"
-msgid "Set your Wacom tablet preferences"
-msgstr "Поставете ги преференците за Вашиот Wacom таблет"
+#~| msgid "Set your mouse preferences"
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Поставете ги преференците за Вашиот Wacom таблет"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "Таблет;Wacom;Stylus;Бришач;Глушец;"
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "Wacom графички таблет"
 
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Wacom Graphics Tablet"
-msgstr "Wacom графички таблет"
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Поставувања за Bluetooth"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Back"
-msgstr "Назад"
+#~ msgid "Calibrate..."
+#~ msgstr "Калибрирај..."
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Bluetooth Settings"
-msgstr "Поставувања за Bluetooth"
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Клик на левото копче на глушецот"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Calibrate..."
-msgstr "Калибрирај..."
+#~| msgid "Action"
+#~ msgid "No Action"
+#~ msgstr "Нема дејство"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "Eraser Pressure Feel"
-msgstr "Осет на притисок на бришачот"
+#~| msgid "_Slight"
+#~ msgid "Scroll Right"
+#~ msgstr "Движи се надесно"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-#| msgid "Filter"
-msgid "Firm"
-msgstr "Цврсто"
+#~| msgid "Roll up"
+#~ msgid "Scroll Up"
+#~ msgstr "Движи се нагоре"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Forward"
-msgstr "Напред"
+#~| msgid "Mouse Preferences"
+#~ msgid "Tablet Preferences"
+#~ msgstr "Преференци за таблет"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Left Mouse Button Click"
-msgstr "Клик на левото копче на глушецот"
+#~ msgid "Tracking Mode"
+#~ msgstr "Режим на следење"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Left-Handed Orientation"
-msgstr "Ориентација за левичари"
+#~| msgid "Enable debugging code"
+#~ msgid "Enable verbose mode"
+#~ msgstr "Овозможи режим за дебагирање"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-#| msgid "Alert Buttons"
-msgid "Lower Button"
-msgstr "Долно копче"
+#~ msgid "Show the overview"
+#~ msgstr "Покажи го прегледот"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Middle Mouse Button Click"
-msgstr "Клик на средното копче на глушецот"
+#~ msgid "- System Settings"
+#~ msgstr "- системски поставувања"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-#| msgid "Action"
-msgid "No Action"
-msgstr "Нема дејство"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "No tablet detected"
-msgstr "Не е откриен таблет"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Прикачете или пуштете го Вашиот Wacom таблет"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Right Mouse Button Click"
-msgstr "Клик на десното копче на глушецот"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Scroll Down"
-msgstr "Движи се надолу"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:16
-msgid "Scroll Left"
-msgstr "Движи се налево"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:17
-#| msgid "_Slight"
-msgid "Scroll Right"
-msgstr "Движи се надесно"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:18
-#| msgid "Roll up"
-msgid "Scroll Up"
-msgstr "Движи се нагоре"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:19
-msgid "Soft"
-msgstr "Меко"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:20
-#: ../panels/wacom/gsd-wacom-device.c:315
-#: ../panels/wacom/gsd-wacom-device.c:544
-#| msgid "_Style:"
-msgid "Stylus"
-msgstr "Стило"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:21
-msgid "Tablet (absolute)"
-msgstr "Таблет (апсолутен)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:22
-#| msgid "Mouse Preferences"
-msgid "Tablet Preferences"
-msgstr "Преференци за таблет"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:23
-msgid "Tip Pressure Feel"
-msgstr "Осет на притисок на врвот"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:24
-#| msgid "Alert Buttons"
-msgid "Top Button"
-msgstr "Горно копче"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:25
-msgid "Touchpad (relative)"
-msgstr "Тачпад (релативен)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:26
-msgid "Tracking Mode"
-msgstr "Режим на следење"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:27
-msgid "Wacom Tablet"
-msgstr "Wacom таблет"
-
-#: ../shell/control-center.c:54
-#| msgid "Enable debugging code"
-msgid "Enable verbose mode"
-msgstr "Овозможи режим за дебагирање"
-
-#: ../shell/control-center.c:55
-msgid "Show the overview"
-msgstr "Покажи го прегледот"
-
-#: ../shell/control-center.c:56
-#: ../shell/control-center.c:57
-#: ../shell/control-center.c:58
-msgid "Show help options"
-msgstr "Покажи ги сите опции за помош"
-
-#: ../shell/control-center.c:59
-msgid "Panel to display"
-msgstr "Панел за прикажување"
-
-#: ../shell/control-center.c:81
-msgid "- System Settings"
-msgstr "- системски поставувања"
-
-#: ../shell/control-center.c:89
 #, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
-msgstr ""
-"%s\n"
-"Извршете '%s --help' за листа на сите опции на командната линија.\n"
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Извршете '%s --help' за листа на сите опции на командната линија.\n"
 
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Контролен центар"
+#~ msgid "Control Center"
+#~ msgstr "Контролен центар"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:1
-#: ../shell/shell.ui.h:2
-msgid "System Settings"
-msgstr "Системски поставувања"
-
-#: ../shell/shell.ui.h:1
-msgid "All Settings"
-msgstr "Сите поставувања"
+#~ msgid "System Settings"
+#~ msgstr "Системски поставувања"
 
 #~ msgid "Image/label border"
 #~ msgstr "Слика/ознака на граница"
+
 #~ msgid "Width of border around the label and image in the alert dialog"
 #~ msgstr ""
 #~ "Должина на границата околу ознаката и сликата во дијалогот за известување"
+
 #~ msgid "The type of alert"
 #~ msgstr "Тип на известување"
+
 #~ msgid "The buttons shown in the alert dialog"
 #~ msgstr "Копчето прикажано во дијалогот за известување"
+
 #~ msgid "Show more _details"
 #~ msgstr "Покажи повеќе _детали"
+
 #~ msgid "No Image"
 #~ msgstr "Без слика"
+
 #~ msgid "Images"
 #~ msgstr "Слики"
+
 #~ msgid "All Files"
 #~ msgstr "Сите датотеки"
+
 #~ msgid ""
 #~ "There was an error while trying to get the addressbook information\n"
 #~ "Evolution Data Server can't handle the protocol"
 #~ msgstr ""
 #~ "Се појави грешка при обидот за добивање на информации од именикот\n"
 #~ "Серверот за податоци на Еволушн не може да се справи со овој протокол"
+
 #~ msgid "Unable to open address book"
 #~ msgstr "Не можам да го отворам адресарот"
+
 #~ msgid "Unknown login ID, the user database might be corrupted"
 #~ msgstr ""
 #~ "Непозната идентификација за најава, корисничката база на податоци може да "
 #~ "е расипана"
+
 #~ msgid "About %s"
 #~ msgstr "За %s"
-#~ msgid "Set your personal information"
-#~ msgstr "Поставете лични информации"
-#~ msgid "<b>Email</b>"
-#~ msgstr "<b>Е-пошта</b>"
+
 #~ msgid "<b>Home</b>"
 #~ msgstr "<b>Дома</b>"
+
 #~ msgid "<b>Instant Messaging</b>"
 #~ msgstr "<b>Инстант пораки</b>"
+
 #~ msgid "<b>Job</b>"
 #~ msgstr "<b>Работа</b>"
+
 #~ msgid "<b>Telephone</b>"
 #~ msgstr "<b>Телефон</b>"
+
 #~ msgid "<b>Web</b>"
 #~ msgstr "<b>Веб</b>"
+
 #~ msgid "<b>Work</b>"
 #~ msgstr "<b>Работа</b>"
+
 #~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
 #~ msgstr ""
 #~ "<span size=\"larger\" weight=\"bold\">Сменете ја Вашата лозинка</span>"
+
 #~ msgid "A_IM/iChat:"
 #~ msgstr "A_IM/iChat:"
+
 #~ msgid "C_ompany:"
 #~ msgstr "К_омпанија:"
+
 #~ msgid "Change Passwo_rd..."
 #~ msgstr "Промени лозин_ка..."
-#~ msgid "Change pa_ssword"
-#~ msgstr "Промени ло_зинка"
+
 #~ msgid "Ci_ty:"
 #~ msgstr "Гр_ад:"
+
 #~ msgid "Contact"
 #~ msgstr "Контакт"
+
 #~ msgid "Cou_ntry:"
 #~ msgstr "Зем_ја:"
+
 #~ msgid "Hom_e:"
 #~ msgstr "Дом_а:"
+
 #~ msgid "IC_Q:"
 #~ msgstr "IC_Q:"
+
 #~ msgid "M_SN:"
 #~ msgstr "M_SN:"
+
 #~ msgid "P.O. _box:"
 #~ msgstr "Поштенско _сандаче:"
+
 #~ msgid "P._O. box:"
 #~ msgstr "П_оштенско сандаче:"
+
 #~ msgid "Personal Info"
 #~ msgstr "Лични информации"
+
 #~ msgid ""
 #~ "Please type your password again in the <b>Retype new password</b> field."
 #~ msgstr ""
 #~ "Ве молам внесете ја лозинката повторно во полето <b>Внеси нова лозинка</"
 #~ "b>."
+
 #~ msgid "Select your photo"
 #~ msgstr "Одберете ја Вашата фотографија"
+
 #~ msgid "State/Pro_vince:"
 #~ msgstr "Држава/Про_винција:"
+
 #~ msgid ""
 #~ "To change your password, enter your current password in the field below "
 #~ "and click <b>Authenticate</b>.\n"
@@ -4824,87 +7577,111 @@ msgstr "Сите поставувања"
 #~ "подолу и кликнете <b>Провери автентичност</b>.\n"
 #~ "После проверката проверката, внесете ја вашата нова лозинка и повторно "
 #~ "внесете ја за проверка и кликнете на <b>Промени лозинка</b>."
+
 #~ msgid "Web _log:"
 #~ msgstr "_Блог:"
+
 #~ msgid "Wor_k:"
 #~ msgstr "Рабо_та:"
+
 #~ msgid "Work _fax:"
 #~ msgstr "Факс на _работа:"
+
 #~ msgid "Zip/_Postal code:"
 #~ msgstr "Поштенски _код:"
-#~ msgid "_Address:"
-#~ msgstr "_Адреса:"
-#~ msgid "_Authenticate"
-#~ msgstr "_Провери автентичност"
+
 #~ msgid "_Groupwise:"
 #~ msgstr "_Групвајз:"
+
 #~ msgid "_Home page:"
 #~ msgstr "_Домашна страна:"
+
 #~ msgid "_Home:"
 #~ msgstr "_Дома:"
+
 #~ msgid "_Jabber:"
 #~ msgstr "_Џабер:"
+
 #~ msgid "_State/Province:"
 #~ msgstr "_Држава/Провинција:"
+
 #~ msgid "_Work:"
 #~ msgstr "_Работа:"
+
 #~ msgid "_Yahoo:"
 #~ msgstr "_Јаху:"
+
 #~ msgid "_Zip/Postal code:"
 #~ msgstr "_Поштенски код:"
+
 #~ msgid "Child exited unexpectedly"
 #~ msgstr "Подпроцесот падна неочекувано"
+
 #~ msgid "Could not shutdown backend_stdin IO channel: %s"
 #~ msgstr "Не можам да го исклучам backend_stdin влезно-излезниот канал: %s"
+
 #~ msgid "Could not shutdown backend_stdout IO channel: %s"
 #~ msgstr "Не можам да го исклучам backend_stdout влезно-излезниот канал: %s"
+
 #~ msgid "System error: %s."
 #~ msgstr "Системска грешка: %s."
+
 #~ msgid "Unable to launch %s: %s"
 #~ msgstr "Не можам да го лансирам %s: %s"
+
 #~ msgid "Unable to launch backend"
 #~ msgstr "Не можам да го лансирам бекендот"
+
 #~ msgid "Click <b>Change password</b> to change your password."
 #~ msgstr "Кликнете на <b>Промени лозинка</b> за да ја смените лозинката."
+
 #~ msgid "<b>Assistive Technologies</b>"
 #~ msgstr "<b>Помошни технологии</b>"
+
 #~ msgid "<b>Preferences</b>"
 #~ msgstr "<b>Преференции</b>"
-#~ msgid "Accessible Lo_gin"
-#~ msgstr "На_јава со пристапност"
+
 #~ msgid "Assistive Technologies Preferences"
 #~ msgstr "Преференци за помошна технологија"
+
 #~ msgid ""
 #~ "Changes to enable assistive technologies will not take effect until your "
 #~ "next log in."
 #~ msgstr ""
 #~ "Промените на овозможувањето на помошни технологии нема да се реализираат "
 #~ "се до Вашето наредно најавување."
+
 #~ msgid "Close and _Log Out"
 #~ msgstr "Затвори и _одјави се"
+
 #~ msgid "Jump to Preferred Applications dialog"
 #~ msgstr "Скокни до дијалог прозорецот за преферирани апликации"
+
 #~ msgid "Jump to the Accessible Login dialog"
 #~ msgstr "Скокни до дијалог прозорецот за најава со пристапност"
+
 #~ msgid "Jump to the Keyboard Accessibility dialog"
 #~ msgstr "Скокни до дијалог прозорецот за пристапност на тастатурата"
+
 #~ msgid "Jump to the Mouse Accessibility dialog"
 #~ msgstr "Скокни до дијалог прозорецот за пристапност на глушецот"
+
 #~ msgid "_Enable assistive technologies"
 #~ msgstr "_Вклучи помошни технологии"
-#~ msgid "_Keyboard Accessibility"
-#~ msgstr "Пристапност на _тастатура"
-#~ msgid "_Mouse Accessibility"
-#~ msgstr "_Пристапност за глушецот"
+
 #~ msgid "_Preferred Applications"
 #~ msgstr "_Преферирани апликации"
+
 #~ msgid "Assistive Technologies"
 #~ msgstr "Помошни технологии"
+
 #~ msgid "Choose which accessibility features to enable when you log in"
 #~ msgstr ""
 #~ "Изберете која опција за пристапност да биде вклучена кога ќе се најавите"
+
 #~ msgid "Font may be too large"
 #~ msgstr "Фонтот можеби е преголем"
+
 #~ msgid ""
 #~ "The font selected is %d point large, and may make it difficult to "
 #~ "effectively use the computer.  It is recommended that you select a size "
@@ -4918,10 +7695,10 @@ msgstr "Сите поставувања"
 #~ "овој компјутер.  Препорачливо е да изберете големина помала од %d."
 #~ msgstr[1] ""
 #~ "Избраниот фонт е поголем за %d точки, и може да го отежни користењето на "
-#~ "овој компјутер.  Препорачливо е да изберете големина помала од %d."
-#~ "The font selected is %d point large, and may make it difficult to "
-#~ "effectively use the computer.  It is recommended that you select a "
-#~ "smaller sized font."
+#~ "овој компјутер.  Препорачливо е да изберете големина помала од %d.The "
+#~ "font selected is %d point large, and may make it difficult to effectively "
+#~ "use the computer.  It is recommended that you select a smaller sized font."
+
 #~ msgid ""
 #~ "The font selected is %d point large, and may make it difficult to "
 #~ "effectively use the computer.  It is recommended that you select a "
@@ -4939,109 +7716,145 @@ msgstr "Сите поставувања"
 #~ msgstr[2] ""
 #~ "Избраниот фонт е поголем за %d точки, и може да го отежни користењето на "
 #~ "овој компјутер.  Препорачливо е да изберете помала големина."
+
 #~ msgid "Use previous font"
 #~ msgstr "Користи го претходниот фонт"
+
 #~ msgid "Use selected font"
 #~ msgstr "Користи го избраниот фонт"
+
 #~ msgid "Specify the filename of a theme to install"
 #~ msgstr "Одредете го името на темата за инсталација"
-#~ msgid "filename"
-#~ msgstr "име на датотека"
+
 #~ msgid ""
 #~ "Specify the name of the page to show (theme|background|fonts|interface)"
 #~ msgstr ""
 #~ "Одредете го името на страницата за прикажување (тема|позадина|фонтови|"
 #~ "интерфејс)"
+
 #~ msgid "[WALLPAPER...]"
 #~ msgstr "[ПОЗАДИНА...]"
+
 #~ msgid ""
 #~ "This theme will not look as intended because the required GTK+ theme "
 #~ "engine '%s' is not installed."
 #~ msgstr ""
 #~ "Оваа тема нема да изгледа како што треба бидејќи бараниот GTK+ енџин %s "
 #~ "не е инсталиран."
+
 #~ msgid "Apply Font"
 #~ msgstr "Примени го фонтот"
+
 #~ msgid ""
 #~ "The current theme suggests a background and a font. Also, the last "
 #~ "applied font suggestion can be reverted."
 #~ msgstr ""
 #~ "Тековната тема предлага позадина и фонт. Последниот применет фонтможе да "
 #~ "биде повторно вратен."
+
 #~ msgid ""
 #~ "The current theme suggests a background. Also, the last applied font "
 #~ "suggestion can be reverted."
 #~ msgstr ""
 #~ "Тековната тема предлага позадина. Последниот применет фонтможе да биде "
 #~ "повторно вратен."
+
 #~ msgid "The current theme suggests a background and a font."
 #~ msgstr "Тековната тема предлага позадина и фонт."
+
 #~ msgid ""
 #~ "The current theme suggests a font. Also, the last applied font suggestion "
 #~ "can be reverted."
 #~ msgstr ""
 #~ "Тековната тема предлага фонт. Последниот применет фонтможе да биде "
 #~ "повторно вратен."
+
 #~ msgid "The current theme suggests a background."
 #~ msgstr "Тековната тема предлага позадина."
+
 #~ msgid "The last applied font suggestion can be reverted."
 #~ msgstr "Последниот применет фонт може да биде повторно вратен."
+
 #~ msgid "The current theme suggests a font."
 #~ msgstr "Тековната тема предлага фонт."
+
 #~ msgid "<b>C_olors</b>"
 #~ msgstr "<b>_Бои</b>"
+
 #~ msgid "<b>Hinting</b>"
 #~ msgstr "<b>Совети</b>"
+
 #~ msgid "<b>Menus and Toolbars</b>"
 #~ msgstr "<b>Мени и ленти со алатки</b>"
+
 #~ msgid "<b>Preview</b>"
 #~ msgstr "<b>Преглед</b>"
+
 #~ msgid "<b>Rendering</b>"
 #~ msgstr "<b>Исцртување</b>"
+
 #~ msgid "<b>Smoothing</b>"
 #~ msgstr "<b>Заматување</b>"
+
 #~ msgid "<b>Subpixel Order</b>"
 #~ msgstr "<b>Подпикселен ред</b>"
+
 #~ msgid "<b>_Wallpaper</b>"
 #~ msgstr "<b>_Позадина</b>"
+
 #~ msgid "Best _shapes"
 #~ msgstr "Најдобри _облици"
+
 #~ msgid "Best co_ntrast"
 #~ msgstr "Најдобар ко_нтраст"
+
 #~ msgid "C_ustomize..."
 #~ msgstr "С_опствено..."
+
 #~ msgid "Changing your cursor theme takes effect the next time you log in."
 #~ msgstr ""
 #~ "Промената на Вашата тема за стрелки ќе има ефект после следното "
 #~ "најавување."
-#~ msgid "Controls"
-#~ msgstr "Контроли"
+
 #~ msgid "Customize Theme"
 #~ msgstr "Прилагоди тема"
+
 #~ msgid "D_etails..."
 #~ msgstr "Д_етали..."
+
 #~ msgid "Des_ktop font:"
 #~ msgstr "Фонт за р_аботната површина:"
+
 #~ msgid "Font Rendering Details"
 #~ msgstr "Детали за вчитување на фонтови"
+
 #~ msgid "Gra_yscale"
 #~ msgstr "Нијанса на сиво"
+
 #~ msgid "Icons"
 #~ msgstr "Икони"
+
 #~ msgid "N_one"
 #~ msgstr "Ништ_о"
+
 #~ msgid "Open a dialog to specify the color"
 #~ msgstr "Отвори дијалог за одредување на боја"
+
 #~ msgid "R_esolution:"
 #~ msgstr "Р_езолуција:"
+
 #~ msgid "Save File"
 #~ msgstr "Зачувај датотека"
+
 #~ msgid "Save Theme As..."
 #~ msgstr "_Зачувај ја темата како..."
+
 #~ msgid "Save _As..."
 #~ msgstr "_Зачувај како..."
+
 #~ msgid "Show _icons in menus"
 #~ msgstr "Прикажи _икони во менијата"
+
 #~ msgid ""
 #~ "Solid color\n"
 #~ "Horizontal gradient\n"
@@ -5050,12 +7863,16 @@ msgstr "Сите поставувања"
 #~ "Полна боја\n"
 #~ "Хоризонтална градација\n"
 #~ "Вертикална градација"
+
 #~ msgid "Sub_pixel (LCDs)"
 #~ msgstr "Под_пиксел (LCD)"
+
 #~ msgid "Sub_pixel smoothing (LCDs)"
 #~ msgstr "Под_пикселно зарамнување (LCD)"
+
 #~ msgid "Text"
 #~ msgstr "Текст"
+
 #~ msgid ""
 #~ "Text below items\n"
 #~ "Text beside items\n"
@@ -5066,8 +7883,10 @@ msgstr "Сите поставувања"
 #~ "Текст покрај предметите\n"
 #~ "Само икони\n"
 #~ "Само текст"
+
 #~ msgid "The current controls theme does not support color schemes."
 #~ msgstr "Тековната тема за графички контроли не поддржува шеми на бои."
+
 #~ msgid ""
 #~ "Tiled\n"
 #~ "Zoom\n"
@@ -5080,64 +7899,76 @@ msgstr "Сите поставувања"
 #~ "Центрирано\n"
 #~ "Проширливо\n"
 #~ "Исполнет екран"
+
 #~ msgid "Toolbar _button labels:"
 #~ msgstr "Ознаки за _копчиња на лентата со алатки:"
+
 #~ msgid "VB_GR"
 #~ msgstr "VB_GR"
+
 #~ msgid "Window Border"
 #~ msgstr "Граница на прозорец"
+
 #~ msgid "_BGR"
 #~ msgstr "_BGR"
-#~ msgid "_Copy"
-#~ msgstr "_Копирај"
+
 #~ msgid "_Description:"
 #~ msgstr "_Опис:"
+
 #~ msgid "_Document font:"
 #~ msgstr "_Фонт за документи:"
+
 #~ msgid "_Editable menu shortcut keys"
 #~ msgstr "_Уредливи кратенки за менито"
+
 #~ msgid "_Fixed width font:"
 #~ msgstr "_Fixed width фонт:"
-#~ msgid "_Full"
-#~ msgstr "_Полно"
-#~ msgid "_Medium"
-#~ msgstr "_Средно"
+
 #~ msgid "_Monochrome"
 #~ msgstr "_Монохром"
+
 #~ msgid "_New"
 #~ msgstr "_Ново"
+
 #~ msgid "_None"
 #~ msgstr "_Ништо"
-#~ msgid "_Quit"
-#~ msgstr "_Излез"
+
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
-#~ msgid "_Reset to Defaults"
-#~ msgstr "_Ресетирај на стандардното"
-#~ msgid "_Save"
-#~ msgstr "_Зачувај"
+
 #~ msgid "_Size:"
 #~ msgstr "_Големина:"
+
 #~ msgid "_Tooltips:"
 #~ msgstr "_Балончиња со совет:"
+
 #~ msgid "_VRGB"
 #~ msgstr "_VRGB"
+
 #~ msgid "_Window title font:"
 #~ msgstr "_Наслов на прозор фонт:"
+
 #~ msgid "_Windows:"
 #~ msgstr "_Прозорци:"
+
 #~ msgid "dots per inch"
 #~ msgstr "точки на инч"
+
 #~ msgid "Customize the look of the desktop"
 #~ msgstr "Прилагодете го изгледот на работната околина"
+
 #~ msgid "Installs themes packages for various parts of the desktop"
 #~ msgstr "Инсталира пакети со теми за разни делови на работната околина"
+
 #~ msgid "Theme Installer"
 #~ msgstr "Инсталер на теми"
+
 #~ msgid "Gnome Theme Package"
 #~ msgstr "Пакет со теми за GNOME"
+
 #~ msgid "Slide Show"
 #~ msgstr "Слајд шоу"
+
 #~ msgid ""
 #~ "<b>%s</b>\n"
 #~ "%s, %d %s by %d %s\n"
@@ -5146,59 +7977,82 @@ msgstr "Сите поставувања"
 #~ "<b>%s</b>\n"
 #~ "%s, %d %s од %d %s\n"
 #~ "Папка: %s"
+
 #~ msgid "Cannot install theme"
 #~ msgstr "Не можам да ја инсталирам темата"
+
 #~ msgid "The %s utility is not installed."
 #~ msgstr "Алатката %s не е инсталирана."
+
 #~ msgid "There was a problem while extracting the theme."
 #~ msgstr "Се појави проблем при отпакувањето на темата."
+
 #~ msgid "There was an error installing the selected file"
 #~ msgstr "Се појави грешка при инсталација на избраната датотека"
+
 #~ msgid "\"%s\" does not appear to be a valid theme."
 #~ msgstr "\"%s\" изгледа дека не е валидна тема."
+
 #~ msgid ""
 #~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
 #~ "which you need to compile."
 #~ msgstr ""
 #~ "\"%s\" изгледа дека не е валидна тема. Можеби се работи за енџин за "
 #~ "темата што треба да го компајлирате."
+
 #~ msgid "GNOME Theme %s correctly installed"
 #~ msgstr "Темата за GNOME %s е успешно инсталирана"
+
 #~ msgid "Installation for theme \"%s\" failed."
 #~ msgstr "Инсталацијата на темата \"%s\" не успеа."
+
 #~ msgid "The theme \"%s\" has been installed."
 #~ msgstr "Темата „%s“ е инсталирана."
+
 #~ msgid "Would you like to apply it now, or keep your current theme?"
 #~ msgstr ""
 #~ "Дали сакате да ја примените сега или да ја задржите Вашата тековна тема?"
+
 #~ msgid "Keep Current Theme"
 #~ msgstr "Зачувај тековна"
+
 #~ msgid "Apply New Theme"
 #~ msgstr "Примени нова"
+
 #~ msgid "New themes have been successfully installed."
 #~ msgstr "Успешно се инсталирани нови теми."
+
 #~ msgid "No theme file location specified to install"
 #~ msgstr "Не е одредена локација за тема за датотеката да биде инсталирана"
+
 #~ msgid ""
 #~ "Insufficient permissions to install the theme in:\n"
 #~ "%s"
 #~ msgstr ""
 #~ "Немате дозвола да ја инсталирате темата во:\n"
 #~ "%s"
+
 #~ msgid "Select Theme"
 #~ msgstr "Одберете тема"
+
 #~ msgid "Theme Packages"
 #~ msgstr "Пакет со теми"
+
 #~ msgid "Theme name must be present"
 #~ msgstr "Името на темата мора да е присутно"
+
 #~ msgid "The theme already exists. Would you like to replace it?"
 #~ msgstr "Темата веќе постои. Дали сакате да ја замените?"
+
 #~ msgid "Would you like to delete this theme?"
 #~ msgstr "Дали сакате да ја отстраните оваа тема?"
+
 #~ msgid "Theme cannot be deleted"
 #~ msgstr "Темата не може да се избрише"
+
 #~ msgid "Could not install theme engine"
 #~ msgstr "Не можам да го инсталирам новиот енџин за темата"
+
 #~ msgid ""
 #~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
 #~ "Without the GNOME settings manager running, some preferences may not take "
@@ -5212,88 +8066,112 @@ msgstr "Сите поставувања"
 #~ "ефект. Ова може да покаже проблем со Bonobo, или не-GNOME (пр. KDE) "
 #~ "менаџери за поставувања веќе се активни и се во конфликт со GNOME "
 #~ "менаџерот за поставувања."
+
 #~ msgid "Unable to load stock icon '%s'\n"
 #~ msgstr "Не може да се вчита stock иконата '%s'\n"
+
 #~ msgid "There was an error displaying help: %s"
 #~ msgstr "Грешка при прикажувањето на помошта: %s"
+
 #~ msgid "Copying file: %u of %u"
 #~ msgstr "Ја копирам датотеката: %u од %u"
-#~ msgid "Parent Window"
-#~ msgstr "Главен прозорец"
+
 #~ msgid "Parent window of the dialog"
 #~ msgstr "Главен прозорец на дијалогот"
-#~ msgid "From URI"
-#~ msgstr "Од URI"
+
 #~ msgid "URI currently transferring from"
 #~ msgstr "URI моментално пренесува од"
+
 #~ msgid "To URI"
 #~ msgstr "До URI"
+
 #~ msgid "URI currently transferring to"
 #~ msgstr "URI моментално пренесува до"
-#~ msgid "Fraction completed"
-#~ msgstr "Фракција комплетна"
+
 #~ msgid "Fraction of transfer currently completed"
 #~ msgstr "Фракција на пренесување моментално е завршена"
+
 #~ msgid "Current URI index"
 #~ msgstr "Тековен URI индекс"
+
 #~ msgid "Current URI index - starts from 1"
 #~ msgstr "Тековен URI индекс - почнува од 1"
+
 #~ msgid "Total URIs"
 #~ msgstr "Вкупно URI"
+
 #~ msgid "Total number of URIs"
 #~ msgstr "Вкупен број на URI"
+
 #~ msgid "File '%s' already exists. Do you want to overwrite it?"
 #~ msgstr "Датотеката %s веќе постои. Дали сакате да ја замените?"
+
 #~ msgid "_Skip"
 #~ msgstr "_Прескокни"
+
 #~ msgid "Overwrite _All"
 #~ msgstr "_Замени сè"
+
 #~ msgid "Key"
 #~ msgstr "Копче"
+
 #~ msgid "GConf key to which this property editor is attached"
 #~ msgstr "GConf копче на кое е прикачен овој property едитор"
+
 #~ msgid "Issue this callback when the value associated with key gets changed"
 #~ msgstr ""
 #~ "Поднеси го овој callback кога вредноста асоцирана со копче ќе се промени"
+
 #~ msgid ""
 #~ "GConf change set containing data to be forwarded to the gconf client on "
 #~ "apply"
 #~ msgstr ""
 #~ "Gconf промени поставување кое содржи податоци за препраќање до gconf "
 #~ "клиент на повик"
+
 #~ msgid "Conversion to widget callback"
 #~ msgstr "Конверзија во повратна информација на уред"
+
 #~ msgid ""
 #~ "Callback to be issued when data are to be converted from GConf to the "
 #~ "widget"
 #~ msgstr ""
 #~ "Повратната информација ќе биде земена во предвид кога податоците ќе бидат "
 #~ "претворени од GConf во контролата"
+
 #~ msgid "Conversion from widget callback"
 #~ msgstr "Конверзија на повратната информација од објектот"
+
 #~ msgid ""
 #~ "Callback to be issued when data are to be converted to GConf from the "
 #~ "widget"
 #~ msgstr ""
 #~ "Callback ќе биде поднесен кога податоците ќе бидат конвертирани во GConf "
 #~ "од widget"
+
 #~ msgid "UI Control"
 #~ msgstr "UI контрола"
+
 #~ msgid "Object that controls the property (normally a widget)"
 #~ msgstr "Објект кој ја контролира сопственоста (обично објект)"
+
 #~ msgid "Property editor object data"
 #~ msgstr "Едитор за сопственост на објектните податоци"
+
 #~ msgid "Custom data required by the specific property editor"
 #~ msgstr "Вообичаени податоци потребни од специфичниот едитор за сопственост"
+
 #~ msgid "Property editor data freeing callback"
 #~ msgstr ""
 #~ "Податоци за ослободување на повратната информација на едиторот за "
 #~ "сопственост"
+
 #~ msgid ""
 #~ "Callback to be issued when property editor object data is to be freed"
 #~ msgstr ""
 #~ "Callback ќе биде поднесен кога податоците со објекти на едиторот за "
 #~ "сопственост ќе бидат ослободени"
+
 #~ msgid ""
 #~ "Couldn't find the file '%s'.\n"
 #~ "\n"
@@ -5304,6 +8182,7 @@ msgstr "Сите поставувања"
 #~ "\n"
 #~ "Осигурај се дека таа постои и пробај повторно, или избери друга "
 #~ "позадинска слика."
+
 #~ msgid ""
 #~ "I don't know how to open the file '%s'.\n"
 #~ "Perhaps it's a kind of picture that is not yet supported.\n"
@@ -5314,169 +8193,229 @@ msgstr "Сите поставувања"
 #~ "Можеби е формат на слика кој сеуште не е подржан.\n"
 #~ "\n"
 #~ "Одбери друга слика."
+
 #~ msgid "Please select an image."
 #~ msgstr "Ве молам изберете слика."
+
 #~ msgid "Default Pointer - Current"
 #~ msgstr "Стандардна стрелка - тековна"
+
 #~ msgid "White Pointer"
 #~ msgstr "Бела стрелка"
+
 #~ msgid "White Pointer - Current"
 #~ msgstr "Бела стрелка - тековна"
+
 #~ msgid "Large Pointer - Current"
 #~ msgstr "Голема стрелка- тековна"
+
 #~ msgid "Large White Pointer - Current"
 #~ msgstr "Голема верзија на белата стрелка - тековна"
-#~ msgid "Large White Pointer"
-#~ msgstr "Голема бела стрелка"
+
 #~ msgid ""
 #~ "This theme will not look as intended because the required GTK+ theme '%s' "
 #~ "is not installed."
 #~ msgstr ""
 #~ "Оваа тема нема да изгледа како што треба бидејќи потребната GTK+ тема %s "
 #~ "не е инсталирана."
+
 #~ msgid ""
 #~ "This theme will not look as intended because the required window manager "
 #~ "theme '%s' is not installed."
 #~ msgstr ""
 #~ "Оваа тема нема да изгледа како што треба бидејќи потребниот менаџер на "
 #~ "прозорци %s не е инсталиран."
+
 #~ msgid ""
 #~ "This theme will not look as intended because the required icon theme '%s' "
 #~ "is not installed."
 #~ msgstr ""
 #~ "Оваа тема нема да изгледа како што треба бидејќи потребната тема со икони "
 #~ "%s не е инсталирана."
+
 #~ msgid "Preferred Applications"
 #~ msgstr "Преферирани апликации"
+
 #~ msgid "Start the preferred visual assistive technology"
 #~ msgstr "Подигни ја преферираната визуелна помошна технологија"
+
 #~ msgid "Visual Assistance"
 #~ msgstr "Визуелно помош"
+
 #~ msgid "Error saving configuration: %s"
 #~ msgstr "Грешка при зачувување на конфигурацијата: %s"
+
 #~ msgid ""
 #~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
 #~ msgstr ""
 #~ "Одредете го името на страницата за прикажување (интернет|мултимедија|"
 #~ "систем|a11y)"
+
 #~ msgid "<b>Image Viewer</b>"
 #~ msgstr "<b>Прегледувач на слики</b>"
+
 #~ msgid "<b>Instant Messenger</b>"
 #~ msgstr "<b>Инстант пораки</b>"
+
 #~ msgid "<b>Mail Reader</b>"
 #~ msgstr "<b>Читач за е-пошта</b>"
+
 #~ msgid "<b>Mobility</b>"
 #~ msgstr "<b>Мобилност</b>"
+
 #~ msgid "<b>Multimedia Player</b>"
 #~ msgstr "<b>Пуштач на мултимедијални содржини</b>"
+
 #~ msgid "<b>Terminal Emulator</b>"
 #~ msgstr "<b>Емулатор на терминал</b>"
+
 #~ msgid "<b>Text Editor</b>"
 #~ msgstr "<b>Уредувач за текст</b>"
+
 #~ msgid "<b>Video Player</b>"
 #~ msgstr "<b>Видео пуштач</b>"
+
 #~ msgid "<b>Visual</b>"
 #~ msgstr "<b>Визуелно</b>"
+
 #~ msgid "<b>Web Browser</b>"
 #~ msgstr "<b>Веб прелистувач</b>"
+
 #~ msgid "All %s occurrences will be replaced with actual link"
 #~ msgstr "Сите совпаѓања на %s ќе бидат заменети со вистниската врска"
+
 #~ msgid "Co_mmand:"
 #~ msgstr "Ко_манда:"
+
 #~ msgid "E_xecute flag:"
 #~ msgstr "И_зврши означено:"
+
 #~ msgid "Open link in new _tab"
 #~ msgstr "Отвори ја врската во ново _јазиче"
+
 #~ msgid "Open link in new _window"
 #~ msgstr "Отвори ја врската во нов _прозорец"
+
 #~ msgid "Open link with web browser _default"
 #~ msgstr "Отвори ја врската со стандардниот веб _прелистувач"
+
 #~ msgid "Run at st_art"
 #~ msgstr "Изврши при ст_артување"
+
 #~ msgid "Run in t_erminal"
 #~ msgstr "Изврши во т_ерминал"
-#~ msgid "_Run at start"
-#~ msgstr "_Изврши при подигнување"
+
 #~ msgid "Balsa"
 #~ msgstr "Balsa"
+
 #~ msgid "Banshee Music Player"
 #~ msgstr "Banshee пуштачот на музика"
+
 #~ msgid "Claws Mail"
 #~ msgstr "Claws Mail"
+
 #~ msgid "Debian Sensible Browser"
 #~ msgstr "Debian прелистувач"
+
 #~ msgid "Debian Terminal Emulator"
 #~ msgstr "Емулатор на терминал за Debian"
+
 #~ msgid "ETerm"
 #~ msgstr "ETerm"
+
 #~ msgid "Encompass"
 #~ msgstr "Encompass"
+
 #~ msgid "Evolution Mail Reader"
 #~ msgstr "Evolution читач за е-пошта"
+
 #~ msgid "Firefox"
 #~ msgstr "Firefox"
+
 #~ msgid "GNOME Magnifier without Screen Reader"
 #~ msgstr "Зголемувачот на GNOME без читач на екранот"
-#~ msgid "GNOME Terminal"
-#~ msgstr "Терминал за GNOME"
+
 #~ msgid "Gnopernicus"
 #~ msgstr "Gnopernicus"
+
 #~ msgid "Gnopernicus with Magnifier"
 #~ msgstr "Gnopernicus со зголемувач"
+
 #~ msgid "Iceape"
 #~ msgstr "Iceape"
+
 #~ msgid "Iceape Mail"
 #~ msgstr "Iceape Mail"
+
 #~ msgid "Icedove"
 #~ msgstr "Icedove"
+
 #~ msgid "Iceweasel"
 #~ msgstr "Iceweasel"
+
 #~ msgid "KDE Magnifier without Screen Reader"
 #~ msgstr "KDE зголемувач без читач на екранот"
+
 #~ msgid "Konqueror"
 #~ msgstr "Konqueror"
+
 #~ msgid "Konsole"
 #~ msgstr "Konsole"
+
 #~ msgid "Linux Screen Reader with Magnifier"
 #~ msgstr "Linux Screen Reader со зголемувач"
+
 #~ msgid "Midori"
 #~ msgstr "Midori"
+
 #~ msgid "Mozilla"
 #~ msgstr "Mozilla"
+
 #~ msgid "Mozilla 1.6"
 #~ msgstr "Mozilla 1.6"
+
 #~ msgid "Mozilla Mail"
 #~ msgstr "Mozilla Mail"
+
 #~ msgid "Mozilla Thunderbird"
 #~ msgstr "Mozilla Thunderbird"
+
 #~ msgid "NXterm"
 #~ msgstr "NXterm"
+
 #~ msgid "Netscape Communicator"
 #~ msgstr "Netscape Communicator"
+
 #~ msgid "Orca"
 #~ msgstr "Orca"
-#~ msgid "Orca with Magnifier"
-#~ msgstr "Orca со зголемувач"
+
 #~ msgid "RXVT"
 #~ msgstr "RXVT"
+
 #~ msgid "Rhythmbox Music Player"
 #~ msgstr "Rhythmbox пуштач на музика"
+
 #~ msgid "SeaMonkey"
 #~ msgstr "SeaMonkey"
+
 #~ msgid "SeaMonkey Mail"
 #~ msgstr "SeaMonkey Mail"
+
 #~ msgid "Sylpheed"
 #~ msgstr "Sylpheed"
+
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "Sylpheed-Claws"
-#~ msgid "Thunderbird"
-#~ msgstr "Thunderbird"
+
 #~ msgid "Totem Movie Player"
 #~ msgstr "Totem пуштачот на филмови"
+
 #~ msgid "Include _Panel"
 #~ msgstr "Вклучи _панел"
+
 #~ msgid "Mirror Screens"
 #~ msgstr "Огледало од екрани"
+
 #~ msgid ""
 #~ "Normal\n"
 #~ "Left\n"
@@ -5487,314 +8426,395 @@ msgstr "Сите поставувања"
 #~ "Лево\n"
 #~ "Десно\n"
 #~ "Обратно\n"
-#~ msgid "Re_fresh Rate:"
-#~ msgstr "Бр_зина на освежување:"
+
 #~ msgid "_Show Displays in Panel"
 #~ msgstr "_Покажи ги приказите во панелот"
+
 #~ msgid "Upside Down"
 #~ msgstr "Обратно"
+
 #~ msgid "%d Hz"
 #~ msgstr "%d Hz"
-#~ msgid "Desktop"
-#~ msgstr "Работна површина"
+
 #~ msgid "Accelerator key"
 #~ msgstr "Копче за забрзување"
+
 #~ msgid "Accelerator modifiers"
 #~ msgstr "Менувачи на забрзување"
+
 #~ msgid "Accelerator keycode"
 #~ msgstr "Код за забрзување"
+
 #~ msgid "Accel Mode"
 #~ msgstr "Забрзан режим"
+
 #~ msgid "The type of accelerator."
 #~ msgstr "Тип на забрзувач."
+
 #~ msgid "Error saving the new shortcut: %s"
 #~ msgstr "Грешка при зачувување на новата кратенка: %s"
+
 #~ msgid "Error unsetting accelerator in configuration database: %s"
 #~ msgstr ""
 #~ "Грешка при поставување на забрзувачот во базата за конфигурирација: %s"
+
 #~ msgid "Assign shortcut keys to commands"
 #~ msgstr "Додели кратенки за команди"
+
 #~ msgid ""
 #~ "Just apply settings and quit (compatibility only; now handled by daemon)"
 #~ msgstr ""
 #~ "Само примени ги поставувањата и излези (само компатибилност; сега се "
 #~ "управува од демон)"
+
 #~ msgid "Retrieve and store legacy settings"
 #~ msgstr "Поврати и зачувај ненативни поставувања"
+
 #~ msgid "Start the page with the typing break settings showing"
 #~ msgstr "Почни ја страницата со прикажани поставувања за куцачката пауза"
+
 #~ msgid "Start the page with the accessibility settings showing"
 #~ msgstr "Почни ја страницата со прикажани поставувања за пристапност"
+
 #~ msgid "- GNOME Keyboard Preferences"
 #~ msgstr " Преференци за тастатура"
+
 #~ msgid "<b>Bounce Keys</b>"
 #~ msgstr "<b>Скокачки копчиња</b>"
+
 #~ msgid "<b>General</b>"
 #~ msgstr "<b>Општо</b>"
+
 #~ msgid "<small><i>Fast</i></small>"
 #~ msgstr "<small><i>Брзо</i></small>"
+
 #~ msgid "<small><i>Long</i></small>"
 #~ msgstr "<small><i>Долго</i></small>"
+
 #~ msgid "<small><i>Short</i></small>"
 #~ msgstr "<small><i>Кратко</i></small>"
+
 #~ msgid "<small><i>Slow</i></small>"
 #~ msgstr "<small><i>Бавно</i></small>"
+
 #~ msgid "All_ow postponing of breaks"
 #~ msgstr "Д_озволи одложување на паузи"
+
 #~ msgid "Audio _Feedback..."
 #~ msgstr "Аудио _фидбек"
-#~ msgid "Beep when _accessibility features are turned on or off"
-#~ msgstr ""
-#~ "Свирни кога _опциите за пристапност се вклучени или исклучени од тастатура"
-#~ msgid "Beep when a _toggle key is pressed"
-#~ msgstr "Свирни кога е притиснато копче за _менување"
-#~ msgid "Beep when key is _accepted"
-#~ msgstr "Свирни кога копчето е _прифатено"
+
 #~ msgid "Beep when key is _rejected"
 #~ msgstr "Свирни ако копчето е _отфрлено"
+
 #~ msgid "Check if breaks are allowed to be postponed"
 #~ msgstr "Провери дали на паузите им е дозволено да бидат одложени"
+
 #~ msgid "Choose a Keyboard Model"
 #~ msgstr "Изберете модел на тастатура"
+
 #~ msgid "Duration of the break when typing is disallowed"
 #~ msgstr "Недозволено е траењето на паузата додека куцате"
+
 #~ msgid "Duration of work before forcing a break"
 #~ msgstr "Траењето на работата пред форсирањето на паузата"
+
 #~ msgid "Keyboard Accessibility Audio Feedback"
 #~ msgstr "Аудио фидбек за пристапност на тастатура"
+
 #~ msgid "Keyboard Preferences"
 #~ msgstr "Преференци на тастатура"
+
 #~ msgid "Keyboard _model:"
 #~ msgstr "_Модел на тастатура:"
+
 #~ msgid ""
 #~ "Lock screen after a certain duration to help prevent repetitive keyboard "
 #~ "use injuries"
 #~ msgstr ""
 #~ "Заклучи ги екранот по одредено време за да помогнеш да се спречат повреди "
 #~ "од употреба на тастатурата"
+
 #~ msgid "Separate _layout for each window"
 #~ msgstr "Посебен _распоред за секој прозорец"
+
 #~ msgid "_Break interval lasts:"
 #~ msgstr "_Интервалот на пауза трае:"
+
 #~ msgid "_Lock screen to enforce typing break"
 #~ msgstr "_Заклучи го екранот да изнудиш куцачка пауза"
+
 #~ msgid "_Only accept long keypresses"
 #~ msgstr "_Прифаќај само долго притиснати копчиња"
+
 #~ msgid "_Simulate simultaneous keypresses"
 #~ msgstr "_Симулирај симултани притискања на копчиња"
+
 #~ msgid "_Variants:"
 #~ msgstr "_Варијанти:"
+
 #~ msgid "_Vendors:"
 #~ msgstr "_Произведувачи:"
+
 #~ msgid "_Work interval lasts:"
 #~ msgstr "Интервалот на работа трае:"
+
 #~ msgid "Set your keyboard preferences"
 #~ msgstr "Поставете ги Вашите преференци за тастатурата"
+
 #~ msgid "gesture|Move left"
 #~ msgstr "Помести лево"
+
 #~ msgid "gesture|Move right"
 #~ msgstr "Помести десно"
+
 #~ msgid "gesture|Move up"
 #~ msgstr "Помести горе"
+
 #~ msgid "gesture|Disabled"
 #~ msgstr "Исклучено"
+
 #~ msgid "Specify the name of the page to show (general|accessibility)"
 #~ msgstr "Одредете го името на страницата за прикажување (општо|пристапност)"
+
 #~ msgid "- GNOME Mouse Preferences"
 #~ msgstr "- Преференци за глушецот"
+
 #~ msgid "<b>Dwell Click</b>"
 #~ msgstr "<b>Клик со пауза</b>"
-#~ msgid "<b>Locate Pointer</b>"
-#~ msgstr "<b>Лоцирај ја стрелката</b>"
+
 #~ msgid "<b>Mouse Orientation</b>"
 #~ msgstr "<b>Ориентација на глушецот</b>"
+
 #~ msgid ""
 #~ "<i>You can also use the Dwell Click panel applet to choose the click type."
 #~ "</i>"
 #~ msgstr ""
 #~ "<i>Moжете да го користите аплетот за клик со пауза за да го изберете "
 #~ "типот на кликнување.</i>"
+
 #~ msgid "<small><i>High</i></small>"
 #~ msgstr "<small><i>Високо</i></small>"
+
 #~ msgid "<small><i>Large</i></small>"
 #~ msgstr "<small><i>Големо</i></small>"
+
 #~ msgid "<small><i>Low</i></small>"
 #~ msgstr "<small><i>Ниско</i></small>"
+
 #~ msgid "<small><i>Small</i></small>"
 #~ msgstr "<small><i>Мало</i></small>"
+
 #~ msgid "Choose type of click _beforehand"
 #~ msgstr "Изберете го типот на клик _претходно"
+
 #~ msgid "Choose type of click with mo_use gestures"
 #~ msgstr "Изберете го типот на кликот со оп_ции за глушецот"
+
 #~ msgid "D_ouble click:"
 #~ msgstr "Д_воен клик:"
+
 #~ msgid "D_rag click:"
 #~ msgstr "К_лик за влечење:"
+
 #~ msgid "Show click type _window"
 #~ msgstr "Покажи го прозорецот за типот на кликнување"
-#~ msgid "_Acceleration:"
-#~ msgstr "_Забрзување:"
+
 #~ msgid "_Single click:"
 #~ msgstr "_Еден клик:"
+
 #~ msgid "Set your network proxy preferences"
 #~ msgstr "Поставете ги вашите преференци за мрежниот proxy"
+
 #~ msgid "<b>Di_rect internet connection</b>"
 #~ msgstr "<b>Ди_ректна интернет врска</b>"
+
 #~ msgid "<b>Ignore Host List</b>"
 #~ msgstr "<b>Игнорирана листа на хостови</b>"
+
 #~ msgid "<b>_Manual proxy configuration</b>"
 #~ msgstr "<b>_Рачна конфигурација на прокси</b>"
-#~ msgid "<b>_Use authentication</b>"
-#~ msgstr "<b>_Користи проверка</b>"
+
 #~ msgid "HTTP Proxy Details"
 #~ msgstr "HTTP детали за прокси"
-#~ msgid "Ignored Hosts"
-#~ msgstr "Игнорирани хостови"
+
 #~ msgid "Network Proxy Preferences"
 #~ msgstr "Преференци на мрежен proxy"
+
 #~ msgid "Proxy Configuration"
 #~ msgstr "Конфигурација на прокси"
+
 #~ msgid "U_sername:"
 #~ msgstr "Кори_сничко име:"
+
 #~ msgid "_Secure HTTP proxy:"
 #~ msgstr "_Безбеден HTTP прокси:"
+
 #~ msgid "ALSA - Advanced Linux Sound Architecture"
 #~ msgstr "ALSA - Advanced Linux Sound Architecture"
+
 #~ msgid "Artsd - ART Sound Daemon"
 #~ msgstr "Artsd - ART Sound Daemon"
+
 #~ msgid "ESD - Enlightened Sound Daemon"
 #~ msgstr "ESD - Enlightened Sound Daemon"
+
 #~ msgid "OSS - Open Sound System"
 #~ msgstr "OSS - Open Sound System"
+
 #~ msgid "PulseAudio Sound Server"
 #~ msgstr "PulseAudio сервер за звук"
+
 #~ msgid "Silence"
 #~ msgstr "Тишина"
+
 #~ msgid "- GNOME Sound Preferences"
 #~ msgstr "- Преференци за звук"
+
 #~ msgid "<b>Alerts and Sound Effects</b>"
 #~ msgstr "Известувања и звучни ефекти"
+
 #~ msgid "<b>Audio Conferencing</b>"
 #~ msgstr "<b>Аудио конференции</b>"
+
 #~ msgid "<b>Default Mixer Tracks</b>"
 #~ msgstr "<b>Стандарден миксер</b>"
+
 #~ msgid "<b>Music and Movies</b>"
 #~ msgstr "<b>Музика и филмови</b>"
+
 #~ msgid "<b>Sound Events</b>"
 #~ msgstr "<b>Системски звуци</b>"
+
 #~ msgid "<b>Sound Theme</b>"
 #~ msgstr "<b>Звучна тема</b>"
+
 #~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
 #~ msgstr "<span weight=\"bold\" size=\"x-large\">Тестирам...</span>"
-#~ msgid "Click OK to finish."
-#~ msgstr "Кликни на „Во ред“ за крај"
+
 #~ msgid "Play _sound effects when buttons are clicked"
 #~ msgstr "Пуштај_звучни ефекти кога се кликаат копчињата"
+
 #~ msgid ""
 #~ "Select the device and tracks to control with the keyboard. Use the Shift "
 #~ "and Control keys to select multiple tracks if required."
 #~ msgstr ""
 #~ "Изберете го уредот и лизгачите за контрола со тастатура. Со помош на "
 #~ "копчињата Shift и Control можете да изберете повеќе лизгачи."
+
 #~ msgid "So_und playback:"
 #~ msgstr "Пу_штање на звук:"
+
 #~ msgid "Sou_nd capture:"
 #~ msgstr "Сни_мање на звук:"
-#~ msgid "Sounds"
-#~ msgstr "Звуци"
+
 #~ msgid "Testing Pipeline"
 #~ msgstr "Pipeline за тестирање"
+
 #~ msgid "_Play alerts and sound effects"
 #~ msgstr "_Пуштај известувања и звучни ефекти"
+
 #~ msgid "_Sound playback:"
 #~ msgstr "_Пуштање на звук:"
+
 #~ msgctxt "Sound event"
 #~ msgid "Windows and Buttons"
 #~ msgstr "Прозорци и копчиња"
-#~ msgctxt "Sound event"
-#~ msgid "Button clicked"
-#~ msgstr "Кликнато е копче"
+
 #~ msgctxt "Sound event"
 #~ msgid "Toggle button clicked"
 #~ msgstr "Кликнато е копчето за менување"
+
 #~ msgctxt "Sound event"
 #~ msgid "Window maximized"
 #~ msgstr "Прозорецот е максимизиран"
+
 #~ msgctxt "Sound event"
 #~ msgid "Window unmaximized"
 #~ msgstr "Прозорецот е вратен"
-#~ msgctxt "Sound event"
-#~ msgid "Window minimised"
-#~ msgstr "Прозорецот е минимизиран"
+
 #~ msgctxt "Sound event"
 #~ msgid "Desktop"
 #~ msgstr "Работна површина"
-#~ msgctxt "Sound event"
-#~ msgid "Logout"
-#~ msgstr "Одјава"
-#~ msgctxt "Sound event"
-#~ msgid "Empty trash"
-#~ msgstr "Испразни ѓубре"
+
 #~ msgctxt "Sound event"
 #~ msgid "Long action completed (download, CD burning, etc.)"
 #~ msgstr "Завршено е долго дејство (преземање, снимање на CD, итн.)"
+
 #~ msgctxt "Sound event"
 #~ msgid "Alerts"
 #~ msgstr "Известувања"
+
 #~ msgctxt "Sound event"
 #~ msgid "Information or question"
 #~ msgstr "Информација или прашање"
-#~ msgctxt "Sound event"
-#~ msgid "Error"
-#~ msgstr "Грешка"
+
 #~ msgid "Custom..."
 #~ msgstr "Сопствено..."
+
 #~ msgid "Cannot start the preferences application for your window manager"
 #~ msgstr ""
 #~ "Не можам да ја подигнам апликацијата за преференци за Вашиот менаџер за "
 #~ "прозорци"
+
 #~ msgid "C_ontrol"
 #~ msgstr "C_ontrol"
+
 #~ msgid "_Alt"
 #~ msgstr "_Alt"
+
 #~ msgid "S_uper (or \"Windows logo\")"
 #~ msgstr "С_упер (или \"Windows лого\")"
+
 #~ msgid "<b>Movement Key</b>"
 #~ msgstr "<b>Копче за движење</b>"
+
 #~ msgid "<b>Titlebar Action</b>"
 #~ msgstr "<b>Дејствие на лентата со наслов</b>"
+
 #~ msgid "<b>Window Selection</b>"
 #~ msgstr "<b>Избор на прозорец</b>"
+
 #~ msgid "To move a window, press-and-hold this key then grab the window:"
 #~ msgstr ""
 #~ "За преместување на прозорец, стиснете и држете го ова копче и фатете го "
 #~ "прозорецот:"
+
 #~ msgid "Window Preferences"
 #~ msgstr "Преференци за прозорец"
+
 #~ msgid "_Double-click titlebar to perform this action:"
 #~ msgstr "_Двоен клик на лентата со наслов за изведување на оваа акција:"
+
 #~ msgid "_Interval before raising:"
 #~ msgstr "_Интервал пред подигање"
+
 #~ msgid "_Raise selected windows after an interval"
 #~ msgstr "_Подигни ги избраните прозорци после некој интервал"
+
 #~ msgid "_Select windows when the mouse moves over them"
 #~ msgstr "_Избирај прозорци кога глушецот поминува преку нив"
+
 #~ msgid "Set your window properties"
 #~ msgstr "Поставете ги својствата за прозорците"
-#~ msgid "Windows"
-#~ msgstr "Прозорци"
+
 #~ msgid "<b>Start %s</b>"
 #~ msgstr "<b>Старт %s</b>"
+
 #~ msgid "Upgrade"
 #~ msgstr "Надгради"
+
 #~ msgid "Uninstall"
 #~ msgstr "Деинсталирај"
+
 #~ msgid "Add to Favorites"
 #~ msgstr "Додај во обележувачи"
+
 #~ msgid "Remove from Startup Programs"
 #~ msgstr "Отстрани од програмите кои се стартуваат при подигнување"
+
 #~ msgid "Add to Startup Programs"
 #~ msgstr "Додај во програмите кои се стартуваат при подигнување"
+
 #~ msgid ""
 #~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
 #~ "\n"
@@ -5803,93 +8823,120 @@ msgstr "Сите поставувања"
 #~ "<span size=\"large\"><b>Не беа пронајдени совпаѓања.</b> </span><span>\n"
 #~ "\n"
 #~ " Вашиот филтер \"<b>%s</b>\" не се совпадна со ниеден предмет.</span>"
+
 #~ msgid "New Spreadsheet"
 #~ msgstr "Нова табеларна пресметка"
+
 #~ msgid "New Document"
 #~ msgstr "Нов документ"
+
 #~ msgid "Home"
 #~ msgstr "Дома"
+
 #~ msgid "Documents"
 #~ msgstr "Документи"
-#~ msgid "File System"
-#~ msgstr "Датотечен систем"
+
 #~ msgid "<b>Open</b>"
 #~ msgstr "<b>Отвори</b>"
-#~ msgid "Move to Trash"
-#~ msgstr "Премести во ѓубре"
+
 #~ msgid "If you delete an item, it is permanently lost."
 #~ msgstr "Ако избришете предмет, тој ќе биде трајно изгубен."
+
 #~ msgid "<b>Open with \"%s\"</b>"
 #~ msgstr "<b>Отвори со „%s“</b>"
+
 #~ msgid "Open in File Manager"
 #~ msgstr "Отвори во менаџер на датотеки"
+
 #~ msgid "?"
 #~ msgstr "?"
+
 #~ msgid "%l:%M %p"
 #~ msgstr "%l:%M %p"
+
 #~ msgid "Today %l:%M %p"
 #~ msgstr "Денес %l:%M %p"
+
 #~ msgid "Yesterday %l:%M %p"
 #~ msgstr "Вчера %l:%M %p"
+
 #~ msgid "%b %d %l:%M %p"
 #~ msgstr "%b %d %l:%M %p"
+
 #~ msgid "%b %d %Y"
 #~ msgstr "%b %d %Y"
+
 #~ msgid "Find Now"
 #~ msgstr "Пребарај сега"
+
 #~ msgid "<b>Open %s</b>"
 #~ msgstr "<b>Отвори го „%s“</b>"
+
 #~ msgid "Remove from System Items"
 #~ msgstr "Отстрани од предметите на системот"
+
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr ""
 #~ "Менаџерот за прозорци „%s“ не е регистриран како алатка за конфигурирање\n"
+
 #~ msgid "Maximize Vertically"
 #~ msgstr "Максимизирај вертикално"
+
 #~ msgid "Maximize Horizontally"
 #~ msgstr "Максимизирај хоризонтално"
+
 #~ msgid "key not found [%s]\n"
 #~ msgstr "клучот не е пронајден [%s]\n"
+
 #~ msgid "Groups"
 #~ msgstr "Групи"
-#~ msgid "Common Tasks"
-#~ msgstr "Чести задачи"
+
 #~ msgid "Close the control-center when a task is activated"
 #~ msgstr "Затвори го контролниот центар кога е активирана задача"
+
 #~ msgid "Exit shell on add or remove action performed"
 #~ msgstr ""
 #~ "Излези од школката при извршување на дејството за додавање или извршување"
+
 #~ msgid "Exit shell on help action performed"
 #~ msgstr "Излези од школката при извршување на десјтвото за помош"
+
 #~ msgid "Exit shell on start action performed"
 #~ msgstr "Излези од школката при извршување на дејството за стартување"
+
 #~ msgid "Exit shell on upgrade or uninstall action performed"
 #~ msgstr ""
 #~ "Излези од школката при извршувањето на деството на надрадување или "
 #~ "деинсталирање"
+
 #~ msgid ""
 #~ "Indicates whether to close the shell when a help action is performed."
 #~ msgstr ""
 #~ "Одредува дали да се затвори школката кога се извршува дејството за помош."
+
 #~ msgid ""
 #~ "Indicates whether to close the shell when a start action is performed."
 #~ msgstr ""
 #~ "Одредува дали да се затвори школката кога се извршува дејството за "
 #~ "подигнување."
+
 #~ msgid ""
 #~ "Indicates whether to close the shell when an add or remove action is "
 #~ "performed."
 #~ msgstr ""
 #~ "Одредува дали да се затвори школката кога се извршува дејството за "
 #~ "додавање или отстранување."
+
 #~ msgid ""
 #~ "Indicates whether to close the shell when an upgrade or uninstall action "
 #~ "is performed."
 #~ msgstr ""
 #~ "Одредува дали да се затвори школката кога се извршува дејството за "
 #~ "надградување или деинсталирање."
+
 #~ msgid "Task names and associated .desktop files"
 #~ msgstr "Имиња на задачи поврзани со .desktop датотеките"
+
 #~ msgid ""
 #~ "The task name to be displayed in the control-center followed by a \";\" "
 #~ "separator then the filename of an associated .desktop file to launch for "
@@ -5898,6 +8945,7 @@ msgstr "Сите поставувања"
 #~ "Име на задача кое ќе биде прикажано во контролниот центар проследено со "
 #~ "одделувачот \";\"и потоа името на .desktop датотеката на кое се однесува "
 #~ "пуштањето на таа задача."
+
 #~ msgid ""
 #~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
 #~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
@@ -5905,44 +8953,53 @@ msgstr "Сите поставувања"
 #~ "[Промени ја темата;gtk-theme-selector.desktop,Постави преферирани "
 #~ "апликации;default-applications.desktop,Додај печатач;gnome-cups-manager."
 #~ "desktop]"
+
 #~ msgid ""
 #~ "if true, the control-center will close when a \"Common Task\" is "
 #~ "activated."
 #~ msgstr ""
 #~ "ако е штиклирано контролниот центар ќе се затвори кога е актвирана Честа "
 #~ "задача."
+
 #~ msgid "The GNOME configuration tool"
 #~ msgstr "Алатка за конфигурирање на GNOME"
+
 #~ msgid "_Postpone Break"
 #~ msgstr "_Одложи пауза"
-#~ msgid "/_Preferences"
-#~ msgstr "/_Преференци"
-#~ msgid "/_About"
-#~ msgstr "/_За"
+
 #~ msgid "/_Take a Break"
 #~ msgstr "/_Направи пауза"
+
 #~ msgid "%d minute until the next break"
 #~ msgid_plural "%d minutes until the next break"
 #~ msgstr[0] "%d минута до следната пауза"
 #~ msgstr[1] "%d минута до следната пауза"
+
 #~ msgid "Less than one minute until the next break"
 #~ msgstr "Помалку од една минута до следната пауза"
+
 #~ msgid ""
 #~ "Unable to bring up the typing break properties dialog with the following "
 #~ "error: %s"
 #~ msgstr ""
 #~ "Не можам да го подигнам дијалогот на својствата за куцачката пауза со "
 #~ "следниве грешки: %s"
+
 #~ msgid "Written by Richard Hult <richard@imendio.com>"
 #~ msgstr "Напишано од Richard Hult <richard@imendio.com>"
+
 #~ msgid "Eye candy added by Anders Carlsson"
 #~ msgstr "Eye candy додадено од Андерс Карлсон"
+
 #~ msgid "A computer break reminder."
 #~ msgstr "Потсетувач за компјутерски паузи"
+
 #~ msgid "translator-credits"
 #~ msgstr "Арангел Ангов <arangel@linux.net.mk>"
+
 #~ msgid "Don't check whether the notification area exists"
 #~ msgstr "Не проверувај дали постои површината за известување"
+
 #~ msgid ""
 #~ "The typing monitor uses the notification area to display information. You "
 #~ "don't seem to have a notification area on your panel. You can add it by "
@@ -5953,4 +9010,3 @@ msgstr "Сите поставувања"
 #~ "информации. Изгледа дека немате област за известување на вашиот панел. "
 #~ "Можете да ја додадете со десен клик на Вашиот панел и со избирање на "
 #~ "'Додај на панел', 'Област за известување' и кликнување на копчето 'Додај'."
-

--- a/po/mk.po~
+++ b/po/mk.po~
@@ -1,0 +1,5956 @@
+# translation of mk.po to Macedonian
+# translation of gnome-control-center.HEAD.mk.po to
+# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) 2004 THE PACKAGE'S COPYRIGHT HOLDER.
+#
+# Maratonec 4 <maraton@localhost.localdomain>, 2002.
+# Aleksandar Savic <savica@mt.net.mk>, 2003.
+# Jovan Kostovski <chombium@freemail.com.mk>, 2003.
+# Arangel Angov <ufo@linux.net.mk>, 2003, 2004, 2005, 2006, 2007, 2008.
+# Ivan Stojmirov <stojmir@linux.net.mk>, 2003.
+# Tomislav Markovski <herrera@users.sourceforge.net>, 2004.
+# Арангел Ангов <ufo@linux.net.mk>, 2005.
+# Jovan Naumovski <jovan@lugola.net>, 2006, 2007.
+# Arangel Angov <arangel@linux.net.mk>, 2007.
+msgid ""
+msgstr ""
+"Project-Id-Version: mk\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2011-11-29 09:05+0000\n"
+"PO-Revision-Date: 2011-12-10 20:46+0100\n"
+"Last-Translator: Jovan N\n"
+"Language-Team: Macedonian <ossm-members@hedona.on.net.mk>\n"
+"Language: mk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural= n==1 || n%10==1 ? 0 : 1;\n"
+"X-Generator: KBabel 1.11.4\n"
+
+#: ../panels/background/background.ui.h:1
+#| msgid "Add Wallpaper"
+msgid "Add wallpaper"
+msgstr "Додај позадина"
+
+#: ../panels/background/background.ui.h:2
+#| msgid "Pointer"
+msgid "Center"
+msgstr "Центар"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:4
+msgid "Changes throughout the day"
+msgstr "Да се менува во текот на денот"
+
+#: ../panels/background/background.ui.h:5
+#| msgid "_File"
+msgid "Fill"
+msgstr "Пополни"
+
+#: ../panels/background/background.ui.h:6
+msgid "Primary Color"
+msgstr "Основна боја"
+
+#: ../panels/background/background.ui.h:7
+#| msgid "No Wallpaper"
+msgid "Remove wallpaper"
+msgstr "Отстрани ја позадината"
+
+#: ../panels/background/background.ui.h:8
+#| msgid "Small"
+msgid "Scale"
+msgstr "Размер"
+
+#: ../panels/background/background.ui.h:9
+#| msgid "Seco_ndary click:"
+msgid "Secondary color"
+msgstr "Секундарна боја"
+
+#: ../panels/background/background.ui.h:10
+msgid "Span"
+msgstr "Распон"
+
+#: ../panels/background/background.ui.h:11
+msgid "Swap colors"
+msgstr "Менувај бои"
+
+#: ../panels/background/background.ui.h:12
+#| msgid "_Title:"
+msgid "Tile"
+msgstr "Наслов"
+
+#: ../panels/background/background.ui.h:13
+msgid "Zoom"
+msgstr "Зумирај"
+
+#: ../panels/background/bg-colors-source.c:46
+msgid "Horizontal Gradient"
+msgstr "Хоризонтален градиент"
+
+#: ../panels/background/bg-colors-source.c:47
+msgid "Vertical Gradient"
+msgstr "Вертикален градиент"
+
+#: ../panels/background/bg-colors-source.c:48
+msgid "Solid Color"
+msgstr "Еднобојно"
+
+#: ../panels/background/cc-background-item.c:148
+msgid "multiple sizes"
+msgstr "повеќе големини"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:152
+#, c-format
+#| msgid "%d x %d"
+msgid "%d × %d"
+msgstr "%d x %d"
+
+#: ../panels/background/cc-background-item.c:281
+#| msgid "Apply Background"
+msgid "No Desktop Background"
+msgstr "Нема позадина на работната површина"
+
+#: ../panels/background/cc-background-panel.c:1001
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+#: ../panels/user-accounts/um-photo-dialog.c:217
+msgid "Browse for more pictures"
+msgstr "Прелистај за повеќе слики"
+
+#: ../panels/background/cc-background-panel.c:1093
+#| msgid "Background"
+msgid "Current background"
+msgstr "Тековна позадина"
+
+#: ../panels/background/cc-background-panel.c:1203
+#| msgid "No Wallpaper"
+msgid "Wallpapers"
+msgstr "Позадини"
+
+#: ../panels/background/cc-background-panel.c:1210
+msgid "Pictures Folder"
+msgstr "Папка со слики"
+
+#: ../panels/background/cc-background-panel.c:1217
+msgid "Colors & Gradients"
+msgstr "Бои и градиенти"
+
+#: ../panels/background/cc-background-panel.c:1225
+msgid "Flickr"
+msgstr "Flickr"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "Позадина"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+#| msgid "Save _background image"
+msgid "Change the background"
+msgstr "Смени ја позадината"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Позадини;Екран;Работна површина;"
+
+#. TRANSLATORS: device type
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
+#: ../panels/network/panel-common.c:99
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
+#| msgid "Monitor Resolution Settings"
+msgid "Configure Bluetooth settings"
+msgstr "Конфигурирај ги поставувањата за Bluetooth"
+
+#: ../panels/bluetooth/bluetooth.ui.h:1
+msgid "Address"
+msgstr "Адреса"
+
+#: ../panels/bluetooth/bluetooth.ui.h:2
+msgid "Browse Files..."
+msgstr "Прегледај датотеки..."
+
+#: ../panels/bluetooth/bluetooth.ui.h:3
+#| msgid "Action"
+msgid "Connection"
+msgstr "Врска"
+
+#: ../panels/bluetooth/bluetooth.ui.h:4
+#: ../panels/universal-access/uap.ui.h:34
+#| msgid "Keyboard Shortcuts"
+msgid "Keyboard Settings"
+msgstr "Поставувања за тастатура"
+
+#: ../panels/bluetooth/bluetooth.ui.h:5
+msgid "Mouse and Touchpad Settings"
+msgstr "Поставувања за глушец и тачпад"
+
+#: ../panels/bluetooth/bluetooth.ui.h:6
+msgid "Paired"
+msgstr "Спарени"
+
+#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
+#: ../panels/bluetooth/bluetooth.ui.h:8
+msgctxt "Power"
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../panels/bluetooth/bluetooth.ui.h:9
+#: ../panels/network/network.ui.h:23
+#| msgid "Devices"
+msgid "Remove Device"
+msgstr "Отстрани уред"
+
+#: ../panels/bluetooth/bluetooth.ui.h:10
+#| msgid "Send To..."
+msgid "Send Files..."
+msgstr "Испрати датотеки..."
+
+#: ../panels/bluetooth/bluetooth.ui.h:11
+msgid "Set Up New Device"
+msgstr "Постави нов уред"
+
+#: ../panels/bluetooth/bluetooth.ui.h:12
+#: ../panels/universal-access/uap.ui.h:60
+#| msgid "Sound files"
+msgid "Sound Settings"
+msgstr "Поставувања за звук"
+
+#: ../panels/bluetooth/bluetooth.ui.h:13
+#| msgid "H_yper"
+msgid "Type"
+msgstr "Тип"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:281
+msgid "Yes"
+msgstr "Да"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:281
+#| msgid "None"
+msgid "No"
+msgstr "Не"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:393
+msgid "Bluetooth is disabled"
+msgstr "Bluetooth-от е оневозможен"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:398
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "Bluetooth-от е оневозможен со харверски прекинувач"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:402
+msgid "No Bluetooth adapters found"
+msgstr "Не се пронајдени Bluetooth адаптери"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:535
+#| msgid "Accessibility"
+msgid "Visibility"
+msgstr "Видливост"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:539
+#, c-format
+msgid "Visibility of “%s”"
+msgstr "Видливост на „%s“"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:583
+#, c-format
+msgid "Remove '%s' from the list of devices?"
+msgstr "Да го отстранам „%s“ од листата на уреди?"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:585
+msgid "If you remove the device, you will have to set it up again before next use."
+msgstr "Ако го отстраните уредот, ќе мора да го поставите пак пред следна употреба."
+
+#. TRANSLATORS: this is where the user can click and import a profile
+#: ../panels/color/cc-color-panel.c:106
+msgid "Other profile…"
+msgstr "Друг профил..."
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:119
+#| msgid "Default"
+msgid "Default: "
+msgstr "Стандардно:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:126
+#| msgid "Colors"
+msgid "Colorspace: "
+msgstr "Простор на бои:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:132
+msgid "Test profile: "
+msgstr "Тест профил..."
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:185
+#: ../panels/color/color.ui.h:19
+msgid "Set for all users"
+msgstr "Поставен за сите корисници"
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:192
+msgid "Create virtual device"
+msgstr "Креирај виртуелен уред"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:227
+#| msgid "Select Sound File"
+msgid "Select ICC Profile File"
+msgstr "Изберете ICC профил"
+
+#: ../panels/color/cc-color-panel.c:230
+msgid "_Import"
+msgstr "_Увези"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:241
+msgid "Supported ICC profiles"
+msgstr "Поддржани ICC профили"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:248
+msgid "All files"
+msgstr "Сите датотеки"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:504
+msgid "Available Profiles for Displays"
+msgstr "Достапни профили за прикази"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:508
+msgid "Available Profiles for Scanners"
+msgstr "Достапни профили за скенери"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:512
+msgid "Available Profiles for Printers"
+msgstr "Достапни профили за печатачи"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:516
+msgid "Available Profiles for Cameras"
+msgstr "Достапни профили за камери"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:520
+msgid "Available Profiles for Webcams"
+msgstr "Достапни профили за веб камери"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#. * where the device type is not recognised
+#. Profiles that can be added to the device
+#: ../panels/color/cc-color-panel.c:525
+#: ../panels/color/color.ui.h:5
+#| msgid "All files"
+msgid "Available Profiles"
+msgstr "Достапни профили"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:794
+#: ../panels/sound/gvc-mixer-dialog.c:1515
+#| msgid "Devices"
+msgid "Device"
+msgstr "Уред"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:829
+msgid "Calibration"
+msgstr "Калибрација"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:861
+msgid "Create a color profile for the selected device"
+msgstr "Креирајте профил за боја за избраниот уред"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:875
+#: ../panels/color/cc-color-panel.c:899
+msgid "The measuring instrument is not detected. Please check it is turned on and correctly connected."
+msgstr "Не е детектиран уред за мерење. Проверете дали е вклучен и правилно поврзан."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:908
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Уредот за мерење не поддржува профилирање на печатачи."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:919
+msgid "The device type is not currently supported."
+msgstr "Уредот не е моментално поддржан."
+
+#. TRANSLATORS: this is when an auto-added profile cannot be removed
+#: ../panels/color/cc-color-panel.c:992
+msgid "Cannot remove automatically added profile"
+msgstr "Не можам да го отстранам автоматски додадениот профил"
+
+#. TRANSLATORS: this is when there is no profile for the device
+#: ../panels/color/cc-color-panel.c:1327
+msgid "No profile"
+msgstr "Нема профил"
+
+#: ../panels/color/cc-color-panel.c:1358
+#, c-format
+msgid "%i year"
+msgid_plural "%i years"
+msgstr[0] "%i година"
+msgstr[1] "%i години"
+
+#: ../panels/color/cc-color-panel.c:1369
+#, c-format
+msgid "%i month"
+msgid_plural "%i months"
+msgstr[0] "%i месец"
+msgstr[1] "%i месеци"
+
+#: ../panels/color/cc-color-panel.c:1380
+#, c-format
+msgid "%i week"
+msgid_plural "%i weeks"
+msgstr[0] "%i недела"
+msgstr[1] "%i недели"
+
+#. fallback
+#: ../panels/color/cc-color-panel.c:1387
+#, c-format
+msgid "Less than 1 week"
+msgstr "Помалку од 1 недела"
+
+#: ../panels/color/cc-color-panel.c:1449
+#| msgid "Default"
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Стандардно RGB"
+
+#: ../panels/color/cc-color-panel.c:1454
+#| msgid "Default"
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Стандардно CMYK"
+
+#: ../panels/color/cc-color-panel.c:1459
+#| msgid "Default"
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Стандардно сиво"
+
+#: ../panels/color/cc-color-panel.c:1577
+#: ../panels/color/cc-color-panel.c:1609
+#: ../panels/color/cc-color-panel.c:1620
+#: ../panels/color/cc-color-panel.c:1631
+msgid "Uncalibrated"
+msgstr "Некалибрирано"
+
+#: ../panels/color/cc-color-panel.c:1580
+msgid "This device is not color managed."
+msgstr "Овој уред нема менаџмент на бои"
+
+#: ../panels/color/cc-color-panel.c:1612
+msgid "This device is using manufacturing calibrated data."
+msgstr "Овој уред користи некалибрирани податоци"
+
+#: ../panels/color/cc-color-panel.c:1623
+msgid "This device does not have a profile suitable for whole-screen color correction."
+msgstr "Овој уред нема соодветен профил за корекција на боја на целиот екран."
+
+#: ../panels/color/cc-color-panel.c:1656
+msgid "This device has an old profile that may no longer be accurate."
+msgstr "Овој уред има стар профил кој можеби не е точен."
+
+#. TRANSLATORS: this is when the calibration profile age is not
+#. * specified as it has been autogenerated from the hardware
+#: ../panels/color/cc-color-panel.c:1684
+#| msgid "Not connected"
+msgid "Not specified"
+msgstr "Не е одредено"
+
+#. add the 'No devices detected' entry
+#: ../panels/color/cc-color-panel.c:1868
+msgid "No devices supporting color management detected"
+msgstr "Не се откриени уреди кои поддржуваат менаџмент на бои"
+
+#: ../panels/color/cc-color-panel.c:2097
+#| msgid "_Detect Displays"
+msgctxt "Device kind"
+msgid "Display"
+msgstr "Приказ"
+
+#: ../panels/color/cc-color-panel.c:2099
+msgctxt "Device kind"
+msgid "Scanner"
+msgstr "Скенер"
+
+#: ../panels/color/cc-color-panel.c:2101
+#| msgid "Pointer"
+msgctxt "Device kind"
+msgid "Printer"
+msgstr "Печатач"
+
+#: ../panels/color/cc-color-panel.c:2103
+msgctxt "Device kind"
+msgid "Camera"
+msgstr "Камера"
+
+#: ../panels/color/cc-color-panel.c:2105
+msgctxt "Device kind"
+msgid "Webcam"
+msgstr "Веб камера"
+
+#: ../panels/color/color.ui.h:1
+msgid "Add a virtual device"
+msgstr "Додај виртуелен уред"
+
+#: ../panels/color/color.ui.h:2
+msgid "Add device"
+msgstr "Додај уред"
+
+#: ../panels/color/color.ui.h:3
+#| msgid "All files"
+msgid "Add profile"
+msgstr "Додај профил"
+
+#: ../panels/color/color.ui.h:6
+msgid "Calibrate the device"
+msgstr "Калибрирај го уредот"
+
+#: ../panels/color/color.ui.h:7
+msgid "Calibrate…"
+msgstr "Калибрирај..."
+
+#: ../panels/color/color.ui.h:8
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#| msgid "Colors"
+msgid "Color"
+msgstr "Боја"
+
+#: ../panels/color/color.ui.h:9
+#| msgid "Delete"
+msgid "Delete device"
+msgstr "Избриши уред"
+
+#: ../panels/color/color.ui.h:10
+#| msgid "_Device:"
+msgid "Device type:"
+msgstr "Тип на уред:"
+
+#: ../panels/color/color.ui.h:11
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "На секој уред му треба ажуриран профил за бои за бојата да биде правилно менаџирана."
+
+#: ../panels/color/color.ui.h:12
+msgid "Image files can be dragged on this window to auto-complete the above fields."
+msgstr "Може да влечите датотеки со слики во овој прозорец за автоматско довршување на полињата погоре."
+
+#: ../panels/color/color.ui.h:13
+msgid "Learn more"
+msgstr "Дознајте повеќе"
+
+#: ../panels/color/color.ui.h:14
+msgid "Learn more about color management"
+msgstr "Дознајте повеќе за менаџментот на бои"
+
+#: ../panels/color/color.ui.h:15
+#| msgid "_Manager:"
+msgid "Manufacturer:"
+msgstr "Производител:"
+
+#: ../panels/color/color.ui.h:16
+#| msgid "_Models:"
+msgid "Model:"
+msgstr "Модел:"
+
+#: ../panels/color/color.ui.h:17
+#| msgid "Remove from Favorites"
+msgid "Remove a device"
+msgstr "Отстрани уред"
+
+#: ../panels/color/color.ui.h:18
+#| msgid "Remove from Favorites"
+msgid "Remove profile"
+msgstr "Отстрани профил"
+
+#: ../panels/color/color.ui.h:20
+msgid "Set this device for all users on this computer"
+msgstr "Постави го овој уред за сите корисници на овој компјутер"
+
+#: ../panels/color/color.ui.h:21
+#| msgctxt "Sound event"
+#| msgid "New e-mail"
+msgid "View details"
+msgstr "Прегледај ги деталите"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Color management settings"
+msgstr "Поставувања за менаџмент на бои"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Боја;ICC;Профил;Калибрирај;Печатач;Приказ;"
+
+#. Add some common languages first
+#: ../panels/common/cc-common-language.c:513
+msgid "English"
+msgstr "Англиски"
+
+#: ../panels/common/cc-common-language.c:515
+msgid "British English"
+msgstr "Британски англиски"
+
+#: ../panels/common/cc-common-language.c:517
+#| msgid "General"
+msgid "German"
+msgstr "Германски"
+
+#: ../panels/common/cc-common-language.c:519
+msgid "French"
+msgstr "Француски"
+
+#: ../panels/common/cc-common-language.c:521
+msgid "Spanish"
+msgstr "Шпански"
+
+#: ../panels/common/cc-common-language.c:523
+msgid "Chinese (simplified)"
+msgstr "Кинески (поедонставен)"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:552
+msgid "United States"
+msgstr "САД"
+
+#: ../panels/common/cc-common-language.c:553
+msgid "Germany"
+msgstr "Германија"
+
+#: ../panels/common/cc-common-language.c:554
+#| msgid "Appearance"
+msgid "France"
+msgstr "Франција"
+
+#: ../panels/common/cc-common-language.c:555
+msgid "Spain"
+msgstr "Шпанија"
+
+#: ../panels/common/cc-common-language.c:556
+msgid "China"
+msgstr "Кина"
+
+#: ../panels/common/cc-language-chooser.c:119
+#| msgid "Other"
+msgid "Other..."
+msgstr "Друго..."
+
+#: ../panels/common/cc-language-chooser.c:290
+#| msgid "Select Image"
+msgid "Select a region"
+msgstr "Изберете регион"
+
+#: ../panels/common/gdm-languages.c:774
+msgid "Unspecified"
+msgstr "Неодредено"
+
+#: ../panels/common/language-chooser.ui.h:1
+#| msgid "Select Image"
+msgid "Select a language"
+msgstr "Изберете јазик"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/printers/new-printer-dialog.ui.h:4
+#: ../panels/user-accounts/um-user-panel.c:449
+msgid "_Cancel"
+msgstr "_Откажи"
+
+#: ../panels/common/language-chooser.ui.h:3
+msgid "_Select"
+msgstr "_Изберете"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "24-hour"
+msgstr "24 часа"
+
+#. Translator: this is the separator between hours and minutes, like in HH:MM
+#: ../panels/datetime/datetime.ui.h:3
+msgid ":"
+msgstr ":"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "AM/PM"
+msgstr "AM/PM"
+
+#: ../panels/datetime/datetime.ui.h:5
+#| msgid "pixel"
+#| msgid_plural "pixels"
+msgid "April"
+msgstr "Април"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "August"
+msgstr "Август"
+
+#: ../panels/datetime/datetime.ui.h:7
+#| msgid "D_elay:"
+msgid "Day"
+msgstr "Ден"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "December"
+msgstr "Декември"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "February"
+msgstr "Февруари"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "January"
+msgstr "Јануари"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "July"
+msgstr "Јули"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "June"
+msgstr "Јуни"
+
+#: ../panels/datetime/datetime.ui.h:13
+#| msgid "Search"
+msgid "March"
+msgstr "Март"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "May"
+msgstr "Мај"
+
+#: ../panels/datetime/datetime.ui.h:15
+#| msgid "Fonts"
+msgid "Month"
+msgstr "Месец"
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "November"
+msgstr "Ноември"
+
+#: ../panels/datetime/datetime.ui.h:17
+#| msgid "Other"
+msgid "October"
+msgstr "Октомври"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "September"
+msgstr "Септември"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Set the time one hour ahead."
+msgstr "Постави го времето за еден час нанапред."
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Set the time one hour back."
+msgstr "Постави го времето за еден час наназад."
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Set the time one minute ahead."
+msgstr "Постави го времето за една минута нанапред."
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Set the time one minute back."
+msgstr "Постави го времето за една минута наназад."
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Switch between AM and PM."
+msgstr "Промени AM/PM."
+
+#: ../panels/datetime/datetime.ui.h:24
+#| msgid "Search"
+msgid "Year"
+msgstr "Година"
+
+#: ../panels/datetime/datetime.ui.h:25
+#| msgid "C_ity:"
+msgid "_City:"
+msgstr "_Град:"
+
+#: ../panels/datetime/datetime.ui.h:26
+#| msgid "Network Servers"
+msgid "_Network Time"
+msgstr "_Мрежно време"
+
+#: ../panels/datetime/datetime.ui.h:27
+#| msgid "_Resolution"
+msgid "_Region:"
+msgstr "_Регион:"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Clock;Timezone;Location;"
+msgstr "Часовник;Временска зона;Локација;"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+msgid "Date and Time"
+msgstr "Датум и време"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Date and Time preferences panel"
+msgstr "Панел за преференци за датум и време"
+
+#: ../panels/display/cc-display-panel.c:477
+#| msgid "Normal"
+msgctxt "display panel, rotation"
+msgid "Normal"
+msgstr "Нормално"
+
+#: ../panels/display/cc-display-panel.c:478
+msgctxt "display panel, rotation"
+msgid "Counterclockwise"
+msgstr "Обратно од стрелките на часовникот"
+
+#: ../panels/display/cc-display-panel.c:479
+msgctxt "display panel, rotation"
+msgid "Clockwise"
+msgstr "Во насока на стрелките на часовникот"
+
+#: ../panels/display/cc-display-panel.c:480
+msgctxt "display panel, rotation"
+msgid "180 Degrees"
+msgstr "180 степени"
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../panels/display/cc-display-panel.c:617
+msgid "Mirror Displays"
+msgstr "Огледало на приказот"
+
+#: ../panels/display/cc-display-panel.c:641
+#: ../panels/display/display-capplet.ui.h:1
+#| msgid "Typing Monitor"
+msgid "Monitor"
+msgstr "Монитор"
+
+#: ../panels/display/cc-display-panel.c:747
+#, c-format
+#| msgid "%d x %d"
+msgid "%d x %d (%s)"
+msgstr "%d x %d (%s)"
+
+#: ../panels/display/cc-display-panel.c:749
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#: ../panels/display/cc-display-panel.c:1656
+msgid "Drag to change primary display."
+msgstr "Влечете за да го промените примарниот приказ."
+
+#: ../panels/display/cc-display-panel.c:1714
+msgid "Select a monitor to change its properties; drag it to rearrange its placement."
+msgstr "Изберете монитор за да ги промените неговите својства; влечете го за да ја промените неговата поставеност."
+
+#: ../panels/display/cc-display-panel.c:2102
+msgid "%a %R"
+msgstr "%a %R"
+
+#: ../panels/display/cc-display-panel.c:2104
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../panels/display/cc-display-panel.c:2350
+#| msgid "Could not load the main interface"
+msgid "Could not save the monitor configuration"
+msgstr "Не можам да ја зачувам конфигурацијата за екранот"
+
+#: ../panels/display/cc-display-panel.c:2375
+msgid "Could not get session bus while applying display configuration"
+msgstr "Не можев да добијам магистрала за сесијата при применување на конфигурацијата на приказот"
+
+#: ../panels/display/cc-display-panel.c:2420
+#| msgid "_Detect Displays"
+msgid "Could not detect displays"
+msgstr "Не можев да детектирам прикази"
+
+#: ../panels/display/cc-display-panel.c:2614
+#| msgid "Change screen resolution"
+msgid "Could not get screen information"
+msgstr "Не можев да добијам информации за приказот"
+
+#: ../panels/display/display-capplet.ui.h:2
+msgid "Note: may limit resolution options"
+msgstr "Забелешка: ова може да ги ограничи опциите за резолуција"
+
+#: ../panels/display/display-capplet.ui.h:3
+msgid "R_otation"
+msgstr "Р_отација"
+
+#: ../panels/display/display-capplet.ui.h:4
+msgid "_Detect Displays"
+msgstr "_Детектирај прикази"
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:6
+msgid "_Mirror displays"
+msgstr "_Огледало на приказот"
+
+#: ../panels/display/display-capplet.ui.h:7
+msgid "_Resolution"
+msgstr "_Резолуција"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Change resolution and position of monitors and projectors"
+msgstr "Промени ја резолуцијата и позицијата на мониторите и проекторите"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+#| msgid "_Detect Displays"
+msgid "Displays"
+msgstr "Прикази"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr "Панел;Проектор;xrandr;Екран;Резолуција;Освежи;"
+
+#. Translators: VESA is an techncial acronym, don't translate it.
+#: ../panels/info/cc-info-panel.c:402
+#, c-format
+msgid "VESA: %s"
+msgstr "VESA: %s"
+
+#. TRANSLATORS: device type
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:426
+#: ../panels/network/panel-common.c:79
+#: ../panels/network/panel-common.c:158
+msgid "Unknown"
+msgstr "Непознато"
+
+#. translators: This is the type of architecture, for example:
+#. * "64-bit" or "32-bit"
+#: ../panels/info/cc-info-panel.c:587
+#, c-format
+#| msgid "Edit"
+msgid "%d-bit"
+msgstr "%d-bit"
+
+#: ../panels/info/cc-info-panel.c:744
+#| msgid "Unknown"
+msgid "Unknown model"
+msgstr "Непознат модел"
+
+#: ../panels/info/cc-info-panel.c:827
+msgid "The next login will attempt to use the standard experience."
+msgstr "Следното најавување ќе се обидам да го користам стандардното искуство."
+
+#: ../panels/info/cc-info-panel.c:829
+msgid "The next login will use the fallback mode intended for unsupported graphics hardware."
+msgstr "Следното најавување ќе се користи режимот за спас, наменет за неподдржан графички хардвер."
+
+#. translators: The hardware is not able to run GNOME 3's
+#. * shell, so we use the GNOME "Fallback" session
+#: ../panels/info/cc-info-panel.c:871
+#| msgid "Callback"
+msgctxt "Experience"
+msgid "Fallback"
+msgstr "Спасувачка"
+
+#. translators: The hardware is able to run GNOME 3's
+#. * shell, also called "Standard" experience
+#: ../panels/info/cc-info-panel.c:877
+#| msgid "Standard XTerminal"
+msgctxt "Experience"
+msgid "Standard"
+msgstr "Стандардна"
+
+#: ../panels/info/cc-info-panel.c:1200
+msgid "Ask what to do"
+msgstr "Прашај ме што да направам"
+
+#: ../panels/info/cc-info-panel.c:1204
+msgid "Do nothing"
+msgstr "Не прави ништо"
+
+#: ../panels/info/cc-info-panel.c:1208
+#| msgid "Open File"
+msgid "Open folder"
+msgstr "Отвори папка"
+
+#: ../panels/info/cc-info-panel.c:1319
+#| msgid "Select your default applications"
+msgid "Select an application for audio CDs"
+msgstr "Изберете апликација за аудио CD-ња"
+
+#: ../panels/info/cc-info-panel.c:1320
+#| msgid "Select your default applications"
+msgid "Select an application for video DVDs"
+msgstr "Изберете апликација за видео CD-ња"
+
+#: ../panels/info/cc-info-panel.c:1321
+msgid "Select an application to run when a music player is connected"
+msgstr "Одберете апликација која ќе се пушти кога ќе се поврзе пуштач на музика"
+
+#: ../panels/info/cc-info-panel.c:1322
+msgid "Select an application to run when a camera is connected"
+msgstr "Одберете апликација која ќе се пушти кога ќе се поврзе камера"
+
+#: ../panels/info/cc-info-panel.c:1323
+#| msgid "Select your default applications"
+msgid "Select an application for software CDs"
+msgstr "Изберете апликација за софтверски CD-ња"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1335
+msgid "audio DVD"
+msgstr "audio DVD"
+
+#: ../panels/info/cc-info-panel.c:1336
+msgid "blank Blu-ray disc"
+msgstr "blank Blu-ray disc"
+
+#: ../panels/info/cc-info-panel.c:1337
+msgid "blank CD disc"
+msgstr "blank CD disc"
+
+#: ../panels/info/cc-info-panel.c:1338
+msgid "blank DVD disc"
+msgstr "blank DVD disc"
+
+#: ../panels/info/cc-info-panel.c:1339
+msgid "blank HD DVD disc"
+msgstr "blank HD DVD disc"
+
+#: ../panels/info/cc-info-panel.c:1340
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video disc"
+
+#: ../panels/info/cc-info-panel.c:1341
+msgid "e-book reader"
+msgstr "e-book reader"
+
+#: ../panels/info/cc-info-panel.c:1342
+msgid "HD DVD video disc"
+msgstr "HD DVD video disc"
+
+#: ../panels/info/cc-info-panel.c:1343
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: ../panels/info/cc-info-panel.c:1344
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: ../panels/info/cc-info-panel.c:1345
+msgid "Video CD"
+msgstr "Video CD"
+
+#: ../panels/info/cc-info-panel.c:1474
+#: ../panels/keyboard/keyboard-shortcuts.c:1627
+#| msgid "Action"
+msgid "Section"
+msgstr "Оддел"
+
+#: ../panels/info/cc-info-panel.c:1483
+#: ../panels/info/info.ui.h:15
+#| msgid "_Overwrite"
+msgid "Overview"
+msgstr "Преглед"
+
+#: ../panels/info/cc-info-panel.c:1489
+#: ../panels/info/info.ui.h:4
+#| msgid "Open with Default Application"
+msgid "Default Applications"
+msgstr "Стандардни апликации"
+
+#: ../panels/info/cc-info-panel.c:1494
+#: ../panels/info/info.ui.h:17
+msgid "Removable Media"
+msgstr "Removable Media"
+
+#: ../panels/info/cc-info-panel.c:1499
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "Графика"
+
+#: ../panels/info/cc-info-panel.c:1701
+#, c-format
+msgid "Version %s"
+msgstr "Верзија %s"
+
+#: ../panels/info/cc-info-panel.c:1751
+#| msgid "Install"
+msgid "Install Updates"
+msgstr "Инсталирај ажурирања"
+
+#: ../panels/info/cc-info-panel.c:1755
+msgid "System Up-To-Date"
+msgstr "Системот е ажуриран"
+
+#: ../panels/info/cc-info-panel.c:1759
+#| msgid "Checking password..."
+msgid "Checking for Updates"
+msgstr "Прoверувам дали има ажурирањ"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#| msgid "_Details"
+msgid "Details"
+msgstr "Детали"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "System Information"
+msgstr "Информации за системот"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid "device;system;information;memory;processor;version;default;application;fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr "уред;систем;информација;меморија;процесор;верзија;стандардно;апликација;спас;префереиран;cd;dvd;usb;ауди;видео;диск;преносен;медиум;атоматско пуштање;"
+
+#: ../panels/info/info.ui.h:1
+#| msgid "Action"
+msgid "Acti_on:"
+msgstr "Дејство"
+
+#: ../panels/info/info.ui.h:2
+msgid "CD _audio"
+msgstr "_Аудио CD"
+
+#: ../panels/info/info.ui.h:3
+msgid "Calculating..."
+msgstr "Пресметувам..."
+
+#: ../panels/info/info.ui.h:5
+#| msgid "Devices"
+msgid "Device name"
+msgstr "Име на уред"
+
+#: ../panels/info/info.ui.h:6
+msgid "Disk"
+msgstr "Диск"
+
+#: ../panels/info/info.ui.h:7
+msgid "Driver"
+msgstr "Драјвер"
+
+#: ../panels/info/info.ui.h:8
+#| msgid "Appearance"
+msgid "Experience"
+msgstr "Искуство"
+
+#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
+#: ../panels/info/info.ui.h:10
+msgid "Forced _Fallback Mode"
+msgstr "Присилен режим за _спас"
+
+#: ../panels/info/info.ui.h:12
+msgid "M_usic"
+msgstr "М_узика"
+
+#: ../panels/info/info.ui.h:13
+msgid "Memory"
+msgstr "Меморија"
+
+#: ../panels/info/info.ui.h:14
+msgid "OS type"
+msgstr "Тип на ОС"
+
+#: ../panels/info/info.ui.h:16
+#| msgid "_Profession:"
+msgid "Processor"
+msgstr "Процесор"
+
+#: ../panels/info/info.ui.h:18
+msgid "Select how media should be handled"
+msgstr "Изберете како ќе се справувам со медиумот"
+
+#: ../panels/info/info.ui.h:19
+msgid "Select how other media should be handled"
+msgstr "Изберте како ќе се справувам со другите медиуми"
+
+#: ../panels/info/info.ui.h:20
+#| msgid "Cale_ndar:"
+msgid "_Calendar"
+msgstr "_Календар"
+
+#: ../panels/info/info.ui.h:21
+msgid "_DVD video"
+msgstr "_DVD видео"
+
+#: ../panels/info/info.ui.h:22
+#| msgid "KMail"
+msgid "_Mail"
+msgstr "_Пошта"
+
+#: ../panels/info/info.ui.h:23
+#| msgid "Muine Music Player"
+msgid "_Music player"
+msgstr "_Пуштач на музика"
+
+#: ../panels/info/info.ui.h:24
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Не прашувај или стартувај програми при внесување на медиум"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Other Media..."
+msgstr "_Други медиуми..."
+
+#: ../panels/info/info.ui.h:26
+msgid "_Photos"
+msgstr "_Слики"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Software"
+msgstr "_Софтвер"
+
+#: ../panels/info/info.ui.h:28
+#| msgid "H_yper"
+msgid "_Type:"
+msgstr "_Тип"
+
+#: ../panels/info/info.ui.h:29
+msgid "_Video"
+msgstr "_Видео"
+
+#: ../panels/info/info.ui.h:30
+msgid "_Web"
+msgstr "_Веб"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Eject"
+msgstr "Извади"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Launch media player"
+msgstr "Пушти пуштач на медиуми"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Next track"
+msgstr "Следна песна"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#| msgid "S_ound playback:"
+msgid "Pause playback"
+msgstr "Паузирај"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Play (or play/pause)"
+msgstr "Пушти (или пушти/пауза)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Previous track"
+msgstr "Претходна песна"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Sound and Media"
+msgstr "Звук и медиуми"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#| msgid "S_ound playback:"
+msgid "Stop playback"
+msgstr "Стопирај"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Volume down"
+msgstr "Намали ја гласноста"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Volume mute"
+msgstr "Исклучи го гласот"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#| msgid "Roll up"
+msgid "Volume up"
+msgstr "Зголеми ја гласноста"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Home folder"
+msgstr "Домашна папка"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch calculator"
+msgstr "Пушти калкулатор"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3
+msgid "Launch email client"
+msgstr "Пушти клиент за е-пошта"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch help browser"
+msgstr "Пушти прелистувач на помош"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+#| msgid "Epiphany Web Browser"
+msgid "Launch web browser"
+msgstr "Пушти веб прелистувач"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launchers"
+msgstr "Пуштачи"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Search"
+msgstr "Пребарувај"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+#| msgid "Screen Resolution"
+msgid "Screenshots"
+msgstr "Слики од екранот"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:2
+#| msgid "Take a break!"
+msgid "Take a screenshot"
+msgstr "Сликај го екранот"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Take a screenshot of a window"
+msgstr "Земи слика од прозорец"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+#| msgid "Lock Screen"
+msgid "Lock screen"
+msgstr "Заклучи го екранот"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+#| msgid "Logout"
+msgid "Log out"
+msgstr "Одјави се"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+#: ../panels/region/gnome-region-panel.ui.h:33
+msgid "System"
+msgstr "Систем"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+msgid "Decrease text size"
+msgstr "Намали ја големината на текстот"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "High contrast on or off"
+msgstr "Пушти или исклучи висок контраст"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Increase text size"
+msgstr "Намали ја големината на текстот"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Turn on-screen keyboard on or off"
+msgstr "Исклучи или приклучи ја екранската тастатура"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "Исклучи или пушти го читачот на екранот"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn zoom on or off"
+msgstr "Исклучи или пушти зум"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
+msgid "Universal Access"
+msgstr "Универзален пристап"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Zoom in"
+msgstr "Зумирај"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "Zoom out"
+msgstr "Одзумирај"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Change keyboard settings"
+msgstr "Промени ги поставувањата за тастатурата"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "Keyboard"
+msgstr "Тастатура"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Кратенка;Повтори;Трепкај;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+#| msgid "Shortcut"
+msgid "Add Shortcut"
+msgstr "Додај кратенка"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "C_ommand:"
+msgstr "К_оманда:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#| msgid "<b>Cursor Blinking</b>"
+msgid "Cursor Blinking"
+msgstr "Трепкање на стрелката"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "Cursor _blinks in text fields"
+msgstr "_Стрелката трепка во текстуални полиња"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+#| msgid "Cursor blinks speed"
+msgid "Cursor blink speed"
+msgstr "Брзина на трепкање на стрелката"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+#| msgid "Custom Shortcuts"
+msgid "Custom Shortcut"
+msgstr "Сопствена кратенка"
+
+#. fast acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+#| msgid "_Paste"
+msgid "Fast"
+msgstr "Брзо"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "Key presses _repeat when key is held down"
+msgstr "Притисокот на копче се повторува копчето е задржано повеќе"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+#| msgid "Layout _Options..."
+msgid "Layout Settings"
+msgstr "Поставувања за распоредот"
+
+#. long delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+#: ../panels/universal-access/uap.ui.h:38
+#: ../panels/universal-access/zoom-options.ui.h:13
+#| msgctxt "Sound event"
+#| msgid "Login"
+msgid "Long"
+msgstr "Долго"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+#| msgid "Shortcut"
+msgid "Remove Shortcut"
+msgstr "Отстрани кратенка"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+#| msgid "<b>Repeat Keys</b>"
+msgid "Repeat Keys"
+msgstr "Повтори ги копчињата"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgid "Repeat keys speed"
+msgstr "Брзина на повторување на копчињата"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "S_peed:"
+msgstr "Б_рзина:"
+
+#. short delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+#: ../panels/mouse/gnome-mouse-properties.ui.h:24
+#: ../panels/universal-access/uap.ui.h:54
+#: ../panels/universal-access/zoom-options.ui.h:22
+#| msgid "Shortcut"
+msgid "Short"
+msgstr "Кратко"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+#| msgid "Shortcut"
+msgid "Shortcuts"
+msgstr "Кратенки"
+
+#. slow acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+#: ../panels/mouse/gnome-mouse-properties.ui.h:26
+msgid "Slow"
+msgstr "Бавно"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#| msgid ""
+#| "To edit a shortcut key, click on the corresponding row and type a new key "
+#| "combination, or press backspace to clear."
+msgid "To edit a shortcut, click the row and hold down the new keys or press Backspace to clear."
+msgstr "За да ги уредите кратенките, кликнете на саканиот ред и стиснете на нова комбинација од копчиња или пак притиснете backspace за да ги исчистите."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:67
+#| msgid "Typing Break"
+msgid "Typing"
+msgstr "Пишување"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "_Delay:"
+msgstr "_Одложување:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "_Name:"
+msgstr "_Име:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid "_Speed:"
+msgstr "Брзина:"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:555
+#: ../panels/keyboard/keyboard-shortcuts.c:563
+#: ../panels/keyboard/keyboard-shortcuts.c:882
+#: ../panels/keyboard/keyboard-shortcuts.c:1383
+#: ../panels/keyboard/keyboard-shortcuts.c:1387
+msgid "Custom Shortcuts"
+msgstr "Сопствени кратенки"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:723
+msgid "<Unknown Action>"
+msgstr "<Непознато дејство>"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/keyboard-shortcuts.c:1064
+#: ../panels/sound/gvc-mixer-control.c:1087
+#: ../panels/user-accounts/um-fingerprint-dialog.c:177
+#: ../panels/user-accounts/um-fingerprint-dialog.c:178
+msgid "Disabled"
+msgstr "Оневозможено"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1205
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"Кратенката „%s“ не може да се користи бидејќи ќе стане невозможно да се пишува со ова копче.\n"
+"Ве молам пробајте со копче како Control, Alt или Shift во исто време."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1237
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"Кратенката „%s“ веќе се користи за \n"
+" „%s“"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1242
+#, c-format
+msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "Ако ја смените кратенката во %s, кратенката %s ќе биде исклучена."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1248
+msgid "_Reassign"
+msgstr "_Додели пак"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1676
+msgid "Action"
+msgstr "Дејствие"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1699
+msgid "Shortcut"
+msgstr "Кратенка"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse and Touchpad"
+msgstr "Глушец и тачпад"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#| msgid "Set your mouse preferences"
+msgid "Set your mouse and touchpad preferences"
+msgstr "Поставете ги преференците за глушецот"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr "Тракпад;Стрелка;Клик;Тапкање;Двоен;Копче;Тракбол;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "A_cceleration:"
+msgstr "З_абрзување:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "Disable _touchpad while typing"
+msgstr "Оневозможи го _тачпадот при пишување"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+#| msgid "<b>Double-Click Timeout</b>"
+msgid "Double-Click Timeout"
+msgstr "Застој за двоен клик"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+#| msgid "<b>Double-Click Timeout</b>"
+msgid "Double-click timeout"
+msgstr "Застој за двоен клик"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+#| msgid "Thr_eshold:"
+msgid "Drag Threshold"
+msgstr "Праг на влечење"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+#| msgid "<b>Drag and Drop</b>"
+msgid "Drag and Drop"
+msgstr "Влечи и пушти"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Enable _mouse clicks with touchpad"
+msgstr "Овозможи ги кликањата со _глушец преку тачпад"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "Enable h_orizontal scrolling"
+msgstr "Овозможи х_оризонтално движење"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "General"
+msgstr "Општо"
+
+#. high sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+#| msgid "Right"
+msgid "High"
+msgstr "Висок"
+
+#. large threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Large"
+msgstr "Голема"
+
+#. low sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Low"
+msgstr "Ниско"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:19
+msgid "Mouse"
+msgstr "Глушец"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "Mouse Preferences"
+msgstr "Преференци на глушецот"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:21
+#| msgid "<b>Pointer Speed</b>"
+msgid "Pointer Speed"
+msgstr "Брзина на стрелката"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:22
+msgid "Scrolling"
+msgstr "Движење"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:23
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr "По_кажи ја позицијата на стрелката при притискање на копчето Control"
+
+#. small threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:28
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Small"
+msgstr "Мала"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:29
+msgid "Thr_eshold:"
+msgstr "Пр_аг:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:30
+#| msgid ""
+#| "<i>To test your double-click settings, try to double-click on the light "
+#| "bulb.</i>"
+msgid "To test your settings, try to double-click on the face."
+msgstr "За да ги тестирате поставувањата за двојниот клик, пробајте да кликнете на лицето."
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:31
+msgid "Touchpad"
+msgstr "Тачпад"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:32
+msgid "Two-_finger scrolling"
+msgstr "Движење со _два прста"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:33
+#| msgid "Disabled"
+msgid "_Disabled"
+msgstr "_Оневозможено"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:34
+msgid "_Edge scrolling"
+msgstr "Движење по _работ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:35
+msgid "_Left-handed"
+msgstr "_Левак"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:36
+msgid "_Right-handed"
+msgstr "_Деснак"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:37
+msgid "_Sensitivity:"
+msgstr "_Осетливост:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:38
+msgid "_Timeout:"
+msgstr "_Застој:"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/cc-network-panel.c:269
+msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "Автоматскот откривање на веб прокси се користи кога не е даден конфигурациски URL."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/cc-network-panel.c:277
+msgid "This is not recommended for untrusted public networks."
+msgstr "Ова не е препорачано за недоверливи јавни мрежи."
+
+#. TRANSLATORS: this is when the access point is not listed
+#. * in the dropdown (or hidden) and the user has to select
+#. * another entry manually
+#: ../panels/network/cc-network-panel.c:949
+#| msgid "Other"
+msgctxt "Wireless access point"
+msgid "Other..."
+msgstr "Друго..."
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/cc-network-panel.c:1107
+#: ../panels/network/cc-network-panel.c:1514
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:1111
+#: ../panels/network/cc-network-panel.c:1518
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:1115
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/cc-network-panel.c:1120
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#. TRANSLATORS: this no (!) WiFi security
+#: ../panels/network/cc-network-panel.c:1126
+#: ../panels/network/cc-network-panel.c:1509
+#: ../panels/universal-access/uap.ui.h:43
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "None"
+msgstr "Ништо"
+
+#: ../panels/network/cc-network-panel.c:1577
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#. Translators: network device speed
+#: ../panels/network/cc-network-panel.c:1643
+#: ../panels/network/cc-network-panel.c:1731
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/cc-network-panel.c:1986
+#: ../panels/network/network.ui.h:18
+#| msgid "Address"
+msgid "IPv4 Address"
+msgstr "IPv4 адреса"
+
+#: ../panels/network/cc-network-panel.c:1987
+#: ../panels/network/network.ui.h:19
+#| msgid "Address"
+msgid "IPv6 Address"
+msgstr "IPv6 адреса"
+
+#: ../panels/network/cc-network-panel.c:1990
+#: ../panels/network/cc-network-panel.c:1993
+#: ../panels/network/network.ui.h:17
+#: ../panels/printers/printers.ui.h:9
+#| msgid "Address"
+msgid "IP Address"
+msgstr "IP адреса"
+
+#: ../panels/network/cc-network-panel.c:2040
+#: ../panels/network/cc-network-panel.c:2413
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#: ../panels/network/cc-network-panel.c:2148
+#| msgid "_FTP proxy:"
+msgid "Proxy"
+msgstr "Прокси"
+
+#: ../panels/network/cc-network-panel.c:2222
+#| msgid "Network Proxy"
+msgid "Network proxy"
+msgstr "Мрежен прокси"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:2480
+msgid "The system network services are not compatible with this version."
+msgstr "Мрежните сервиси на системот не се компатибилни со оваа верзија."
+
+#: ../panels/network/cc-network-panel.c:3095
+#| msgid "Not connected"
+msgid "Not connected to the internet."
+msgstr "Не сум поврзан на интернет."
+
+#: ../panels/network/cc-network-panel.c:3096
+msgid "Create the hotspot anyway?"
+msgstr "Да го креирам hotspot-от и покрај тоа?"
+
+#: ../panels/network/cc-network-panel.c:3114
+#, c-format
+msgid "Disconnect from %s and create a new hotspot?"
+msgstr "Да се исклучам од %s и да креирам нов hotspot?"
+
+#: ../panels/network/cc-network-panel.c:3117
+msgid "This is your only connection to the internet."
+msgstr "Ова е Вашата единствена врска со интернет."
+
+#: ../panels/network/cc-network-panel.c:3135
+msgid "Create _Hotspot"
+msgstr "Креирај _hotspot"
+
+#: ../panels/network/cc-network-panel.c:3195
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Да го прекинам hotspot-от и да ги исклучам неговите корисници?"
+
+#: ../panels/network/cc-network-panel.c:3198
+msgid "_Stop Hotspot"
+msgstr "_Прекини го hotspot-от"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#| msgid "Network Proxy"
+msgid "Network"
+msgstr "Мрежа"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+#| msgid "Network Servers"
+msgid "Network settings"
+msgstr "Мрежни поставувања"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid "Network;Wireless;IP;LAN;Proxy;"
+msgstr "Мрежа;Безжичен;IP;LAN;Прокси;"
+
+#: ../panels/network/network.ui.h:1
+#| msgid "Devices"
+msgid "Add Device"
+msgstr "Додај уред"
+
+#: ../panels/network/network.ui.h:2
+msgid "Air_plane Mode"
+msgstr "Режим за во а_вион"
+
+#: ../panels/network/network.ui.h:3
+#| msgid "Rename..."
+msgid "Create..."
+msgstr "Креирај..."
+
+#: ../panels/network/network.ui.h:4
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/network.ui.h:5
+#| msgid "Default Pointer"
+msgid "Default Route"
+msgstr "Стандардна рута"
+
+#: ../panels/network/network.ui.h:6
+#| msgid "Devices"
+msgid "Device Off"
+msgstr "Уредот е исклучен"
+
+#: ../panels/network/network.ui.h:7
+#| msgid "Disabled"
+msgid "Disable VPN"
+msgstr "Оневозможи VPN"
+
+#: ../panels/network/network.ui.h:8
+#| msgid "Port:"
+msgid "FTP Port"
+msgstr "FTP порта"
+
+#: ../panels/network/network.ui.h:9
+msgid "Gateway"
+msgstr "Премин"
+
+#: ../panels/network/network.ui.h:10
+#| msgid "Full Name"
+msgid "Group Name"
+msgstr "Име на група"
+
+#: ../panels/network/network.ui.h:11
+#| msgid "_Password:"
+msgid "Group Password"
+msgstr "Лозинка на група"
+
+#: ../panels/network/network.ui.h:12
+msgid "HTTP Port"
+msgstr "Порта за HTTP"
+
+#: ../panels/network/network.ui.h:13
+msgid "HTTPS Port"
+msgstr "Порта за HTTPS"
+
+#: ../panels/network/network.ui.h:14
+#| msgid "H_TTP proxy:"
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS прокси:"
+
+#: ../panels/network/network.ui.h:15
+#| msgid "Address"
+msgid "Hardware Address"
+msgstr "Хардверска адрееса"
+
+#: ../panels/network/network.ui.h:16
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network.ui.h:20
+msgid "Interface"
+msgstr "Интерфејс"
+
+#: ../panels/network/network.ui.h:21
+#| msgid "Network Servers"
+msgid "Network Name"
+msgstr "Мрежно име"
+
+#: ../panels/network/network.ui.h:22
+#| msgid "Pointer"
+msgid "Provider"
+msgstr "Провајдер"
+
+#: ../panels/network/network.ui.h:24
+msgid "Security"
+msgstr "Безбедност"
+
+#: ../panels/network/network.ui.h:25
+msgid "Security Key"
+msgstr "Безбедносен клуч"
+
+#: ../panels/network/network.ui.h:26
+msgid "Select the interface to use for the new service"
+msgstr "Изберете го интерфејсот за користење со новиот сервис"
+
+#: ../panels/network/network.ui.h:27
+#| msgid "S_ocks host:"
+msgid "Socks Port"
+msgstr "Socks порта"
+
+#: ../panels/network/network.ui.h:28
+#| msgid "S_peed:"
+msgid "Speed"
+msgstr "Брзина"
+
+#: ../panels/network/network.ui.h:29
+msgid "Subnet Mask"
+msgstr "Сабнет маска"
+
+#: ../panels/network/network.ui.h:30
+msgid "Unlock"
+msgstr "Отклучи"
+
+#: ../panels/network/network.ui.h:31
+#| msgid "User name:"
+msgid "Username"
+msgstr "Корисничко име"
+
+#: ../panels/network/network.ui.h:32
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/network.ui.h:33
+msgid "VPN Type"
+msgstr "Тип на VPN"
+
+#: ../panels/network/network.ui.h:34
+#| msgid "Autoconfiguration _URL:"
+msgid "_Configuration URL"
+msgstr "_URL за конфигурирање"
+
+#: ../panels/network/network.ui.h:35
+msgid "_Configure..."
+msgstr "_Конфигурирај..."
+
+#: ../panels/network/network.ui.h:36
+#| msgid "_FTP proxy:"
+msgid "_FTP Proxy"
+msgstr "_FTP прокси"
+
+#: ../panels/network/network.ui.h:37
+#| msgid "H_TTP proxy:"
+msgid "_HTTP Proxy"
+msgstr "H_TTP прокси"
+
+#: ../panels/network/network.ui.h:38
+#| msgid "_Meta"
+msgid "_Method"
+msgstr "_Метод"
+
+#: ../panels/network/network.ui.h:39
+#| msgid "Network Servers"
+msgid "_Network Name"
+msgstr "_Мрежно име"
+
+#: ../panels/network/network.ui.h:40
+#| msgid "S_ocks host:"
+msgid "_Socks Host"
+msgstr "S_ocks хост"
+
+#: ../panels/network/network.ui.h:41
+msgid "_Stop Hotspot..."
+msgstr "_Стопирај го hotspot-от..."
+
+#: ../panels/network/network.ui.h:42
+msgid "_Use as Hotspot..."
+msgstr "_Користи како hotspot..."
+
+#: ../panels/network/network.ui.h:43
+#| msgid "Autodetect"
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "Автоматски"
+
+#: ../panels/network/network.ui.h:44
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "Рачно"
+
+#: ../panels/network/network.ui.h:45
+#| msgid "None"
+msgctxt "proxy method"
+msgid "None"
+msgstr "Ништо"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:83
+#| msgid "Firebird"
+msgid "Wired"
+msgstr "Жичен"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:87
+msgid "Wireless"
+msgstr "Безжичен"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:94
+msgid "Mobile broadband"
+msgstr "Мобилен широкопојасен"
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:103
+#| msgid "Models"
+msgid "Mesh"
+msgstr "Мрежа"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:162
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:166
+msgid "Infrastructure"
+msgstr "Инфраструктурен"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:190
+#: ../panels/network/panel-common.c:251
+msgid "Status unknown"
+msgstr "Статусот е непознат"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:194
+msgid "Unmanaged"
+msgstr "Неменаџиран"
+
+#: ../panels/network/panel-common.c:199
+msgid "Firmware missing"
+msgstr "Недостасува firmware"
+
+#: ../panels/network/panel-common.c:202
+msgid "Cable unplugged"
+msgstr "Кабелот е откачен"
+
+#: ../panels/network/panel-common.c:204
+msgid "Unavailable"
+msgstr "Не е достапен"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:208
+#| msgid "Not connected"
+msgid "Disconnected"
+msgstr "Неповрзан"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:215
+#: ../panels/network/panel-common.c:257
+msgid "Connecting"
+msgstr "Се поврзувам"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:219
+#: ../panels/network/panel-common.c:261
+#| msgid "Authenticated!"
+msgid "Authentication required"
+msgstr "Потребна е автентикација"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223
+#: ../panels/network/panel-common.c:265
+#| msgid "Not connected"
+msgid "Connected"
+msgstr "Поврзан"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:227
+msgid "Disconnecting"
+msgstr "Ја прекинувам врската"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:231
+#: ../panels/network/panel-common.c:269
+#| msgid "Copying files"
+msgid "Connection failed"
+msgstr "Врската не успеа"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:235
+#: ../panels/network/panel-common.c:277
+msgid "Status unknown (missing)"
+msgstr "Статусот е непознат (недостасува)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:273
+msgid "Not connected"
+msgstr "Не е поврзано"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:305
+msgid "Error logging into the account"
+msgstr "Грешка при најавата на сметката"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:351
+msgid "Expired credentials. Please log in again."
+msgstr "Истечени акредитиви. Најавете се повторно."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:354
+#| msgctxt "Sound event"
+#| msgid "Login"
+msgid "_Log In"
+msgstr "_Најави се"
+
+#. translators: This is the title of the "Add Account" dialogue.
+#. * The title is not visible when using GNOME Shell
+#: ../panels/online-accounts/cc-online-accounts-panel.c:461
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "Add Account"
+msgstr "Додај сметка"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:466
+msgid "To add a new account, first select the account type"
+msgstr "За да додадете нова сметка прво изберете го типот на сметката"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:469
+#| msgid "Alert Type"
+msgid "Account Type:"
+msgstr "Тип на сметка"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Add..."
+msgstr "_Додај..."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:555
+msgid "Error creating account"
+msgstr "Грешка при креирањето на сметка"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:589
+msgid "Error removing account"
+msgstr "Грешка при отстранувањето на сметката"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:625
+#| msgid "Are you sure you want to permanently delete \"%s\"?"
+msgid "Are you sure you want to remove the account?"
+msgstr "Дали сте сигурни дека сакате да ја избришете сметката?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:627
+msgid "This will not remove the account on the server."
+msgstr "Ова нема да ја отстрани сметката од серверот."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:628
+msgid "_Remove"
+msgstr "_Отстрани"
+
+#. Translators: those are keywords for the online-accounts control-center panel
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+msgstr "Google;Facebook;Twitter;Yahoo;Веб;Онлајн;Разговор;Календар;Пошта;Контакт;"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
+msgid "Manage online accounts"
+msgstr "Менаџирајте со онлајн сметките"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid "Online Accounts"
+msgstr "Онлајн сметки"
+
+#: ../panels/online-accounts/online-accounts.ui.h:2
+#| msgid "Revert Font"
+msgid "Remove Account"
+msgstr "Избриши ја сметката"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+#| msgid "_Selected layouts:"
+msgid "Select an account"
+msgstr "Избери сметка"
+
+#: ../panels/power/cc-power-panel.c:160
+#| msgid "Unknown"
+msgid "Unknown time"
+msgstr "Непознат тип"
+
+#: ../panels/power/cc-power-panel.c:166
+#, c-format
+#| msgid "minutes"
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i минута"
+msgstr[1] "%i минути"
+
+#: ../panels/power/cc-power-panel.c:178
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i час"
+msgstr[1] "%i часа"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:186
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:187
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "час"
+msgstr[1] "часа"
+
+#: ../panels/power/cc-power-panel.c:188
+#| msgid "minutes"
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "минута"
+msgstr[1] "минути"
+
+#: ../panels/power/cc-power-panel.c:265
+#| msgctxt "Sound event"
+#| msgid "Battery warning"
+msgid "Battery charging"
+msgstr "Батеријата се полни"
+
+#: ../panels/power/cc-power-panel.c:268
+#| msgctxt "Sound event"
+#| msgid "Battery warning"
+msgid "Battery discharging"
+msgstr "Батеријата се празни"
+
+#: ../panels/power/cc-power-panel.c:279
+msgid "UPS charging"
+msgstr "UPS се полни"
+
+#: ../panels/power/cc-power-panel.c:282
+msgid "UPS discharging"
+msgstr "UPS се празни"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:300
+#, c-format
+msgid "%s until charged (%.0lf%%)"
+msgstr "%s додека се наполни (%.0lf%%)"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:306
+#, c-format
+msgid "%s until empty (%.0lf%%)"
+msgstr "%s додека се испразне (%.0lf%%)"
+
+#. TRANSLATORS: %1 is a percentage value. Note: this string is only
+#. * used when we don't have a time value
+#: ../panels/power/cc-power-panel.c:314
+#, c-format
+msgid "%.0lf%% charged"
+msgstr "наполнет е %.0lf%%"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+#| msgid "Pointer"
+msgid "Power"
+msgstr "Енергија"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Power management settings"
+msgstr "Поставувања за менаџментот со енергија"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+msgstr "Енергија;Спиј;Суспендирај;Хибернирај;Батерија;"
+
+#: ../panels/power/power.ui.h:1
+#: ../panels/screen/screen.ui.h:1
+msgid "1 hour"
+msgstr "1 час"
+
+#: ../panels/power/power.ui.h:2
+#: ../panels/screen/screen.ui.h:3
+#| msgid "minutes"
+msgid "10 minutes"
+msgstr "10 минути"
+
+#: ../panels/power/power.ui.h:3
+#: ../panels/screen/screen.ui.h:6
+#| msgid "minutes"
+msgid "30 minutes"
+msgstr "30 минути"
+
+#: ../panels/power/power.ui.h:4
+#: ../panels/screen/screen.ui.h:8
+#| msgid "minutes"
+msgid "5 minutes"
+msgstr "5 минути"
+
+#: ../panels/power/power.ui.h:5
+msgid "Don't suspend"
+msgstr "Не суспендирај"
+
+#: ../panels/power/power.ui.h:6
+msgid "Hibernate"
+msgstr "Хибернирај"
+
+#: ../panels/power/power.ui.h:7
+msgid "On battery power"
+msgstr "На батерија"
+
+#: ../panels/power/power.ui.h:8
+msgid "Power off"
+msgstr "Исклучи се"
+
+#: ../panels/power/power.ui.h:9
+msgid "Suspend when inactive for:"
+msgstr "Суспендирај се по неактивност од:"
+
+#: ../panels/power/power.ui.h:10
+msgid "When plugged in"
+msgstr "Кога сум приклучен"
+
+#: ../panels/power/power.ui.h:11
+msgid "When power is _critically low:"
+msgstr "Кога енергијата е _многу празна:"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:533
+msgid "Low on toner"
+msgstr "Тонерот е при крај"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:535
+msgid "Out of toner"
+msgstr "Нема тонер"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:538
+msgid "Low on developer"
+msgstr "Развивачот за фотографии е при крај"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:541
+msgid "Out of developer"
+msgstr "Нема развивач за фотографии"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:543
+msgid "Low on a marker supply"
+msgstr "Маркерот е при крај"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:545
+msgid "Out of a marker supply"
+msgstr "Нема маркер"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:547
+#| msgid "Open File"
+msgid "Open cover"
+msgstr "Отворен капак"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:549
+#| msgid "Vendors"
+msgid "Open door"
+msgstr "Отворена врата"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:551
+msgid "Low on paper"
+msgstr "Хартијата е при крај"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:553
+msgid "Out of paper"
+msgstr "Нема хартија"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:555
+#| msgid "Off"
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Исклучен"
+
+#. Translators: Someone has paused the Printer
+#: ../panels/printers/cc-printers-panel.c:557
+#| msgid "_Paste"
+msgctxt "printer state"
+msgid "Paused"
+msgstr "Паузиран"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:559
+msgid "Waste receptacle almost full"
+msgstr "Контејнерот за ѓубре е скоро полн"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:561
+msgid "Waste receptacle full"
+msgstr "Контејнерот за ѓубре е преполн"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:563
+msgid "The optical photo conductor is near end of life"
+msgstr "Оптичкиот фотоспроводник е при крајот на животниот век"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:565
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Оптичкиот фотоспроводник веќе не работи"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:737
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Подготвен"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:741
+#| msgid "_Profession:"
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Процесира"
+
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:745
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Запрен"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:864
+msgid "Toner Level"
+msgstr "Ниво на тонер"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:867
+msgid "Ink Level"
+msgstr "Ниво на боја за печатење"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:870
+msgid "Supply Level"
+msgstr "Количина во залиха"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:885
+#: ../panels/printers/cc-printers-panel.c:1271
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u активно"
+msgstr[1] "%u активни"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:990
+msgid "No printers available"
+msgstr "Нема достапни печатачи"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/cc-printers-panel.c:1314
+msgctxt "print job"
+msgid "Pending"
+msgstr "Чекам"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/cc-printers-panel.c:1318
+#| msgid "Help"
+msgctxt "print job"
+msgid "Held"
+msgstr "Задржан"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/cc-printers-panel.c:1322
+#| msgid "_Profession:"
+msgctxt "print job"
+msgid "Processing"
+msgstr "Се процесира"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/cc-printers-panel.c:1326
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Запрено"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/cc-printers-panel.c:1330
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Прекинато"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/cc-printers-panel.c:1334
+#| msgid "About Me"
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Прекинато"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/cc-printers-panel.c:1338
+msgctxt "print job"
+msgid "Completed"
+msgstr "Завршено"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/cc-printers-panel.c:1421
+#| msgid "_Title:"
+msgid "Job Title"
+msgstr "Наслов на печатењето"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/cc-printers-panel.c:1430
+msgid "Job State"
+msgstr "Состојба на печатењето"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/cc-printers-panel.c:1436
+#| msgid "Theme"
+msgid "Time"
+msgstr "Време"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:2032
+msgid "Failed to add new printer."
+msgstr "Не успеав да додадам нов печатач."
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2236
+#: ../panels/printers/cc-printers-panel.c:2250
+#| msgid "page"
+msgid "Test page"
+msgstr "Тест страница"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2498
+#, c-format
+#| msgid "Could not load the main interface"
+msgid "Could not load ui: %s"
+msgstr "Не можев да го вчитам интерфејсот: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#| msgid "Change set"
+msgid "Change printer settings"
+msgstr "Промени ги поставувањата за печатачот"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Печатач;Ред;Печати;Хартија;Боја за печатење;Тонер;"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: ../panels/printers/pp-new-printer-dialog.c:148
+#| msgid "Pointer"
+msgid "Printers"
+msgstr "Печатачи"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "A_ddress:"
+msgstr "А_дреса:"
+
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#| msgid "Large Pointer"
+msgid "Add a New Printer"
+msgstr "Додај нов печатач"
+
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#| msgid "_Add..."
+msgid "_Add"
+msgstr "_Додај"
+
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "_Search by Address"
+msgstr "_Барај по адреса"
+
+#: ../panels/printers/pp-new-printer-dialog.c:654
+msgid "Getting devices..."
+msgstr "Ги добивам уредите..."
+
+#. Translators: No localy connected printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1230
+msgid "No local printers found"
+msgstr "Не се пронајдени локални уреди"
+
+#. Translators: No network printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1243
+#| msgid "Network Servers"
+msgid "No network printers found"
+msgstr "Не се пронајдени печатачи"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1335
+msgid "FirewallD is not running. Network printer detection needs services mdns, ipp, ipp-client and samba-client enabled on firewall."
+msgstr "Не се извршува FirewallD. За детектирање на мрежните печатачи потребно е mdns, ipp, ipp-client и samba-client да бидат овозможени на firewall."
+
+#. Translators: Column of devices which can be installed
+#: ../panels/printers/pp-new-printer-dialog.c:1363
+#: ../panels/printers/pp-new-printer-dialog.c:1368
+msgid "Devices"
+msgstr "Уреди"
+
+#. Translators: Local means local printers
+#: ../panels/printers/pp-new-printer-dialog.c:1393
+msgctxt "printer type"
+msgid "Local"
+msgstr "Локален"
+
+#. Translators: Network means network printers
+#: ../panels/printers/pp-new-printer-dialog.c:1395
+#| msgid "Network Proxy"
+msgctxt "printer type"
+msgid "Network"
+msgstr "Мрежа"
+
+#. Translators: Device types column (network or local)
+#: ../panels/printers/pp-new-printer-dialog.c:1436
+#| msgid "Devices"
+msgid "Device types"
+msgstr "Типови на уреди"
+
+#. Translators: Name of job which makes printer to autoconfigure itself
+#: ../panels/printers/pp-new-printer-dialog.c:1737
+#| msgid "<b>_Automatic proxy configuration</b>"
+msgid "Automatic configuration"
+msgstr "Автоматска конфигурација"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1818
+msgid "Opening firewall for mDNS connections"
+msgstr "Отворам заштитен ѕид за mDNS врски"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1827
+msgid "Opening firewall for Samba connections"
+msgstr "Отворам заштитен ѕид за Samba врски"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1836
+msgid "Opening firewall for IPP connections"
+msgstr "Отворам заштитен ѕид за IPP врски"
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:2
+msgid "Active Print Jobs"
+msgstr "Активни печатења"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:4
+msgid "Add New Printer"
+msgstr "Додај нов печатач"
+
+#: ../panels/printers/printers.ui.h:5
+#| msgid "Pointer"
+msgid "Add Printer"
+msgstr "Додај печатач"
+
+#: ../panels/printers/printers.ui.h:6
+msgid "Add User"
+msgstr "Нов корисник"
+
+#: ../panels/printers/printers.ui.h:7
+msgid "Allowed users"
+msgstr "Дозволени корисници"
+
+#: ../panels/printers/printers.ui.h:8
+msgid "Cancel Print Job"
+msgstr "Прекини печатење"
+
+#: ../panels/printers/printers.ui.h:10
+msgid "Jobs"
+msgstr "Печатења"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:12
+#| msgid "Action"
+msgid "Location"
+msgstr "Локација"
+
+#: ../panels/printers/printers.ui.h:13
+#| msgid "Models"
+msgid "Model"
+msgstr "Модел"
+
+#: ../panels/printers/printers.ui.h:14
+msgid "Pause Printing"
+msgstr "Паузирај со печатење"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:16
+msgid "Print _Test Page"
+msgstr "Испечати _тест страница"
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:18
+msgid "Printer Options"
+msgstr "Опции за печатачот"
+
+#: ../panels/printers/printers.ui.h:19
+#| msgid "Remove from Favorites"
+msgid "Remove Printer"
+msgstr "Отстрани печатач"
+
+#: ../panels/printers/printers.ui.h:20
+msgid "Remove User"
+msgstr "Отстрани корисник"
+
+#: ../panels/printers/printers.ui.h:21
+msgid "Resume Printing"
+msgstr "Продолжи со печатење"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:23
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"Жалам, но сервисот за печатење\n"
+"изгледа дека не е активен."
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:26
+msgid "Supply"
+msgstr "Залиха"
+
+#. Translators: Switch back to printer's info tab
+#: ../panels/printers/printers.ui.h:28
+msgid "_Back"
+msgstr "_Назад"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:30
+#| msgid "Default"
+msgid "_Default"
+msgstr "_Стандарден"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:32
+#| msgid "_Open"
+msgid "_Options"
+msgstr "_Опции"
+
+#. Tanslators: Switch to tab containing printer's jobs
+#: ../panels/printers/printers.ui.h:34
+#| msgid "Shutdown"
+msgid "_Show"
+msgstr "_Покажи"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Change your region and language settings"
+msgstr "Промени ги поставувањата за регион и јазик"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
+msgid "Language;Layout;Keyboard;"
+msgstr "Јазик;Распоред;Тастатура;"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: ../panels/region/gnome-region-panel.ui.h:24
+msgid "Region and Language"
+msgstr "Регион и јазик"
+
+#: ../panels/region/gnome-region-panel-formats.c:142
+#| msgid "Opera"
+msgid "Imperial"
+msgstr "Империјален"
+
+#: ../panels/region/gnome-region-panel-formats.c:144
+msgid "Metric"
+msgstr "Метрички"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
+msgid "Choose a Layout"
+msgstr "Изберете распоред"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
+#| msgid "Preview:"
+msgid "Preview"
+msgstr "Преглед"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
+msgid "Select an input source to add"
+msgstr "Изберете извор на влез за додавање"
+
+#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
+msgid "Keyboard Layout Options"
+msgstr "Опции за распоредите на тастатурата"
+
+#: ../panels/region/gnome-region-panel-system.c:395
+msgid "The login screen, system accounts and new user accounts use the system-wide Region and Language settings."
+msgstr "Најавниот екран, сметките на системот и новите корисници ги корсистат системските поставувања за јазик и регион."
+
+#: ../panels/region/gnome-region-panel-system.c:400
+#: ../panels/region/gnome-region-panel.ui.h:35
+msgid "The login screen, system accounts and new user accounts use the system-wide Region and Language settings. You may change the system settings to match yours."
+msgstr "Најавниот екран, сметките на системот и новите корисници ги корсистат системските поставувања за јазик и регион. Можете да ги промените системските поставувања да се совпаѓаат со Вашите."
+
+#: ../panels/region/gnome-region-panel-system.c:403
+#| msgid "Copying '%s'"
+msgid "Copy Settings"
+msgstr "Копирај ги поставувањата"
+
+#: ../panels/region/gnome-region-panel-system.c:406
+#: ../panels/region/gnome-region-panel.ui.h:5
+msgid "Copy Settings..."
+msgstr "Копирај ги поставувањата..."
+
+#: ../panels/region/gnome-region-panel.ui.h:1
+#| msgid "_Language:"
+msgid "Add Language"
+msgstr "Додај јазик"
+
+#: ../panels/region/gnome-region-panel.ui.h:2
+#| msgid "Layout"
+msgid "Add Layout"
+msgstr "Додај распоред"
+
+#: ../panels/region/gnome-region-panel.ui.h:3
+msgid "Add Region"
+msgstr "Додај регион"
+
+#: ../panels/region/gnome-region-panel.ui.h:4
+msgid "Allow different layouts for individual windows"
+msgstr "Дозволи различни распореди за посебните прозорци"
+
+#: ../panels/region/gnome-region-panel.ui.h:6
+msgid "Currency"
+msgstr "Валута"
+
+#: ../panels/region/gnome-region-panel.ui.h:7
+#| msgid "aterm"
+msgid "Dates"
+msgstr "Датуми"
+
+#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
+#: ../panels/region/gnome-region-panel.ui.h:9
+#| msgid "By _language"
+msgid "Display language:"
+msgstr "Јазик за приказ:"
+
+#: ../panels/region/gnome-region-panel.ui.h:10
+msgid "Examples"
+msgstr "Примери"
+
+#: ../panels/region/gnome-region-panel.ui.h:11
+#| msgid "Port:"
+msgid "Format:"
+msgstr "Формат:"
+
+#: ../panels/region/gnome-region-panel.ui.h:12
+#| msgid "Fonts"
+msgid "Formats"
+msgstr "Формати"
+
+#: ../panels/region/gnome-region-panel.ui.h:13
+#| msgid "_Input boxes:"
+msgid "Input source:"
+msgstr "Влезен извор:"
+
+#: ../panels/region/gnome-region-panel.ui.h:14
+#| msgid "_Install..."
+msgid "Install languages..."
+msgstr "Инсталирај јазици..."
+
+#: ../panels/region/gnome-region-panel.ui.h:15
+#| msgid "_Language:"
+msgid "Language"
+msgstr "Јазик"
+
+#: ../panels/region/gnome-region-panel.ui.h:16
+msgid "Layouts"
+msgstr "Распореди"
+
+#: ../panels/region/gnome-region-panel.ui.h:17
+#| msgid "_Department:"
+msgid "Measurement"
+msgstr "Мерење"
+
+#: ../panels/region/gnome-region-panel.ui.h:18
+#| msgid "gesture|Move down"
+msgid "Move Down"
+msgstr "Помести надолу"
+
+#: ../panels/region/gnome-region-panel.ui.h:19
+msgid "Move Up"
+msgstr "Помести нагоре"
+
+#: ../panels/region/gnome-region-panel.ui.h:20
+msgid "New windows use the default layout"
+msgstr "Новите прозорци ќе го користат стандардниот распоред"
+
+#: ../panels/region/gnome-region-panel.ui.h:21
+msgid "New windows use the previous window's layout"
+msgstr "Новите прозорци ќе го користат распоредот од претходниот прозорец"
+
+#: ../panels/region/gnome-region-panel.ui.h:22
+msgid "Numbers"
+msgstr "Бројки"
+
+#: ../panels/region/gnome-region-panel.ui.h:23
+#| msgid "Preview:"
+msgid "Preview Layout"
+msgstr "Распоред на преглед"
+
+#: ../panels/region/gnome-region-panel.ui.h:25
+#| msgid "_Language:"
+msgid "Remove Language"
+msgstr "Отстрани јазик"
+
+#: ../panels/region/gnome-region-panel.ui.h:26
+#| msgid "Choose a Layout"
+msgid "Remove Layout"
+msgstr "Отстрани распоред"
+
+#: ../panels/region/gnome-region-panel.ui.h:27
+msgid "Remove Region"
+msgstr "Отстрани го регионот"
+
+#: ../panels/region/gnome-region-panel.ui.h:28
+msgid ""
+"Replace the current keyboard layout settings with the\n"
+"default settings"
+msgstr ""
+"Замени го тековниот распоред на тастатурата со\n"
+"стандардните поставувања"
+
+#: ../panels/region/gnome-region-panel.ui.h:30
+msgid "Reset to De_faults"
+msgstr "Ресетирај на ста_ндардното"
+
+#: ../panels/region/gnome-region-panel.ui.h:31
+msgid "Select a display language (change will be applied next time you log in)"
+msgstr "Изберете јазик (промените ќе бидат активни следниот пат кога ќе се најавите)"
+
+#: ../panels/region/gnome-region-panel.ui.h:32
+msgid "Select a region (change will be applied the next time you log in)"
+msgstr "Изберете регион (промените ќе бидат активни следниот пат кога ќе се најавите)"
+
+#: ../panels/region/gnome-region-panel.ui.h:34
+#| msgid "_Type to test settings:"
+msgid "System settings"
+msgstr "Системски поставувања"
+
+#: ../panels/region/gnome-region-panel.ui.h:36
+#| msgid "Test"
+msgid "Times"
+msgstr "Времиња"
+
+#: ../panels/region/gnome-region-panel.ui.h:37
+#| msgid "_Use the same proxy for all protocols"
+msgid "Use the same layout for all windows"
+msgstr "Користи го истиот распоред за сите прозорци"
+
+#: ../panels/region/gnome-region-panel.ui.h:38
+#| msgid "Keyboard Layout Options"
+msgid "View and edit keyboard layout options"
+msgstr "Прегледај и уреди ги поставувањата за распоредот на тастатурата"
+
+#: ../panels/region/gnome-region-panel.ui.h:39
+msgid "Your settings"
+msgstr "Вашите поставувања"
+
+#: ../panels/region/gnome-region-panel.ui.h:40
+#| msgid "Layout _Options..."
+msgid "_Options..."
+msgstr "_Опции..."
+
+#: ../panels/region/gnome-region-panel-xkblt.c:210
+msgid "Layout"
+msgstr "Распоред"
+
+#: ../panels/region/gnome-region-panel-xkbot.c:229
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "Default"
+msgstr "Стандардно"
+
+#. Translators: those are keywords for the brightness and lock control-center panel
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
+msgid "Brightness;Lock;Dim;Blank;Monitor;"
+msgstr "Светлост;Заклучи;Затемни;Зацрни;Монитор;"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:3
+#| msgid "Lock Screen"
+msgid "Screen"
+msgstr "Екран"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
+msgid "Screen brightness and lock settings"
+msgstr "Поставувања за светлост и заклучување на екранот"
+
+#: ../panels/screen/screen.ui.h:2
+#| msgid "minutes"
+msgid "1 minute"
+msgstr "1 минута"
+
+#: ../panels/screen/screen.ui.h:4
+#| msgid "minutes"
+msgid "2 minutes"
+msgstr "2 минути"
+
+#: ../panels/screen/screen.ui.h:5
+#| msgid "minutes"
+msgid "3 minutes"
+msgstr "3 минути"
+
+#: ../panels/screen/screen.ui.h:7
+#| msgid "seconds"
+msgid "30 seconds"
+msgstr "30 секунди"
+
+#: ../panels/screen/screen.ui.h:9
+msgid "Brightness"
+msgstr "Светлост"
+
+#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
+#: ../panels/screen/screen.ui.h:11
+msgid "Don't lock when at home"
+msgstr "Не заклучувај се кога сум дома"
+
+#: ../panels/screen/screen.ui.h:12
+#| msgid "Layout _Options..."
+msgid "Locations..."
+msgstr "Локации..."
+
+#: ../panels/screen/screen.ui.h:13
+msgid "Lock"
+msgstr "Заклучи"
+
+#: ../panels/screen/screen.ui.h:14
+msgid "Screen turns off"
+msgstr "Екранот се исклучува"
+
+#: ../panels/screen/screen.ui.h:15
+msgid "_Dim screen to save power"
+msgstr "_Затемни го екранот за да заштедува енергија"
+
+#: ../panels/screen/screen.ui.h:16
+#| msgid "Lock Screen"
+msgid "_Lock screen after:"
+msgstr "_Заклучи го екранот по:"
+
+#: ../panels/screen/screen.ui.h:17
+msgid "_Turn screen off when inactive for:"
+msgstr "_Изгасни го екранот при неактивност од:"
+
+#: ../panels/sound/applet-main.c:49
+msgid "Enable debugging code"
+msgstr "Овозможи дебагирање на код"
+
+#: ../panels/sound/applet-main.c:50
+#| msgid "Open with Default Application"
+msgid "Version of this application"
+msgstr "Верзија на оваа апликација"
+
+#: ../panels/sound/applet-main.c:62
+msgid " — GNOME Volume Control Applet"
+msgstr " — Аплетот за контрола на глас на GNOME "
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
+msgid "Show desktop volume control"
+msgstr "Покажи ги контролите за глас"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
+#| msgid "Unknown Volume Control %d"
+msgid "Volume Control"
+msgstr "Контрола на гласност"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+msgstr "Картичка;Микрофон;Звук;Намалување;Баланс;Bluetooth;Слушалки;"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:3
+#| msgid "Enable sound and associate sounds with events"
+msgid "Change sound volume and sound events"
+msgstr "Промени ја гласноста на звукот и звучните настани"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Sound"
+msgstr "Звук"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "Лаење"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "Капење"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "Стакло"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+#| msgid "Sound"
+msgid "Sonar"
+msgstr "Сонар"
+
+#: ../panels/sound/gvc-applet.c:270
+#: ../panels/sound/gvc-mixer-dialog.c:1767
+#| msgid "Mutt"
+msgid "Output"
+msgstr "Излез"
+
+#: ../panels/sound/gvc-applet.c:272
+msgid "Sound Output Volume"
+msgstr "Гласност на звучниот излез"
+
+#: ../panels/sound/gvc-applet.c:276
+#: ../panels/sound/gvc-mixer-dialog.c:1808
+msgid "Input"
+msgstr "Влез"
+
+#: ../panels/sound/gvc-applet.c:278
+msgid "Microphone Volume"
+msgstr "Гласност на микрофонот"
+
+#: ../panels/sound/gvc-balance-bar.c:111
+#| msgid "Left"
+msgctxt "balance"
+msgid "Left"
+msgstr "Лево"
+
+#: ../panels/sound/gvc-balance-bar.c:112
+#| msgid "Right"
+msgctxt "balance"
+msgid "Right"
+msgstr "Десно"
+
+#: ../panels/sound/gvc-balance-bar.c:115
+#| msgid "Search"
+msgctxt "balance"
+msgid "Rear"
+msgstr "Назад"
+
+#: ../panels/sound/gvc-balance-bar.c:116
+#| msgid "Fonts"
+msgctxt "balance"
+msgid "Front"
+msgstr "Напред"
+
+#: ../panels/sound/gvc-balance-bar.c:119
+#| msgid "Minimize"
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Минимум"
+
+#: ../panels/sound/gvc-balance-bar.c:120
+#| msgid "Maximize"
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Максимум"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Balance:"
+msgstr "_Ниво:"
+
+#: ../panels/sound/gvc-balance-bar.c:298
+#| msgid "_Name:"
+msgid "_Fade:"
+msgstr "_Избледни:"
+
+#: ../panels/sound/gvc-balance-bar.c:301
+msgid "_Subwoofer:"
+msgstr "_Вуфер:"
+
+#: ../panels/sound/gvc-channel-bar.c:603
+#: ../panels/sound/gvc-channel-bar.c:612
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:607
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Непојачано"
+
+#: ../panels/sound/gvc-combo-box.c:167
+#: ../panels/sound/gvc-mixer-dialog.c:1621
+#| msgid "_Mobile:"
+msgid "_Profile:"
+msgstr "_Профил:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1094
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u излез"
+msgstr[1] "%u излеза"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1104
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u влез"
+msgstr[1] "%u влеза"
+
+#: ../panels/sound/gvc-mixer-control.c:1402
+#| msgid "Test Sound"
+msgid "System Sounds"
+msgstr "Системски звуци"
+
+#: ../panels/sound/gvc-mixer-dialog.c:323
+#: ../panels/sound/gvc-mixer-dialog.c:634
+#| msgid "Co_untry:"
+msgid "Co_nnector:"
+msgstr "Ко_нектор:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:540
+msgid "Peak detect"
+msgstr "Детектирај врв"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1496
+#: ../panels/sound/gvc-mixer-dialog.c:1709
+#: ../panels/sound/gvc-sound-theme-chooser.c:595
+#| msgid "_Name:"
+msgid "Name"
+msgstr "Име"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1563
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "Тестирање на звучникот за %s"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1622
+msgid "_Test Speakers"
+msgstr "_Тестирај ги звучниците"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1753
+msgid "_Output volume:"
+msgstr "_Излезно ниво на гласност:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1772
+msgid "C_hoose a device for sound output:"
+msgstr "И_зберете уред за звучен излез:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1797
+#: ../panels/sound/gvc-mixer-dialog.c:1926
+msgid "Settings for the selected device:"
+msgstr "Поставувања за избраниот уред:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1815
+#| msgid "_Input boxes:"
+msgid "_Input volume:"
+msgstr "Гласност на _влез:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1838
+#| msgid "_Input boxes:"
+msgid "Input level:"
+msgstr "Гласност на влез"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1866
+msgid "C_hoose a device for sound input:"
+msgstr "О_дберете уред за звучен влез:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1893
+msgid "Hardware"
+msgstr "Хардвер"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1898
+msgid "C_hoose a device to configure:"
+msgstr "И_зберете уред за конфигурирање:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1937
+#| msgid "Sound files"
+msgid "Sound Effects"
+msgstr "Звучни ефекти"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1944
+#| msgctxt "Sound event"
+#| msgid "Alert sound"
+msgid "_Alert volume:"
+msgstr "Звук за из_вестување:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1957
+#| msgid "_Application font:"
+msgid "Applications"
+msgstr "Апликации"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1961
+msgid "No application is currently playing or recording audio."
+msgstr "Нема апликации кои моментално пуштаат или снимаат аудио."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:189
+msgid "Built-in"
+msgstr "Вградено"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:455
+#: ../panels/sound/gvc-sound-theme-chooser.c:467
+#: ../panels/sound/gvc-sound-theme-chooser.c:479
+msgid "Sound Preferences"
+msgstr "Преференци за звук"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:458
+#: ../panels/sound/gvc-sound-theme-chooser.c:469
+#: ../panels/sound/gvc-sound-theme-chooser.c:481
+msgid "Testing event sound"
+msgstr "Тестирам звук за настани"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:586
+msgid "From theme"
+msgstr "Од тема"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:770
+#| msgid "Play _alert sound"
+msgid "C_hoose an alert sound:"
+msgstr "Из_берете звук за известување:"
+
+#: ../panels/sound/gvc-speaker-test.c:221
+msgid "Stop"
+msgstr "Стоп"
+
+#: ../panels/sound/gvc-speaker-test.c:221
+#: ../panels/sound/gvc-speaker-test.c:333
+msgid "Test"
+msgstr "Тест"
+
+#: ../panels/sound/gvc-speaker-test.c:229
+msgid "Subwoofer"
+msgstr "Субвуфер"
+
+#: ../panels/sound/gvc-stream-status-icon.c:235
+#, c-format
+#| msgid "Sound Preferences"
+msgid "Failed to start Sound Preferences: %s"
+msgstr "Не успеав да ги стартувам преференците за звук: %s"
+
+#: ../panels/sound/gvc-stream-status-icon.c:261
+#| msgid "C_ut"
+msgid "_Mute"
+msgstr "И_склучи го гласот"
+
+#: ../panels/sound/gvc-stream-status-icon.c:270
+#| msgid "Sound Preferences"
+msgid "_Sound Preferences"
+msgstr "_Преференци за звук"
+
+#: ../panels/sound/gvc-stream-status-icon.c:415
+#| msgid "Multimedia"
+msgid "Muted"
+msgstr "Гласот е исклучен"
+
+#: ../panels/sound/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr "Сопствен"
+
+#: ../panels/universal-access/cc-ua-panel.c:445
+#: ../panels/universal-access/cc-ua-panel.c:451
+#| msgid "New shortcut..."
+msgid "No shortcut set"
+msgstr "Нема кратенки"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys"
+msgstr "Тастатура;Глушец;a11y;Пристапност;Контраст;Зум;Читач на екран;текст;фонт;големина;AccessX;Лепливи копчиња;Бавни копчиња;Одбивни копчиња;Копчиња на глушец"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#| msgid "Appearance Preferences"
+msgid "Universal Access Preferences"
+msgstr "Преференции за универзален пристап"
+
+#: ../panels/universal-access/uap.ui.h:2
+#, no-c-format
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/universal-access/uap.ui.h:4
+#, no-c-format
+msgid "125%"
+msgstr "125%"
+
+#: ../panels/universal-access/uap.ui.h:6
+#, no-c-format
+msgid "150%"
+msgstr "150%"
+
+#: ../panels/universal-access/uap.ui.h:8
+#, no-c-format
+msgid "75%"
+msgstr "75%"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "A_cceptance delay:"
+msgstr "Д_оцнење за прифаќање:"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "Acc_eptance delay:"
+msgstr "До_цнење за прифаќање:"
+
+#: ../panels/universal-access/uap.ui.h:11
+#| msgid "Beep when a key is pr_essed"
+msgid "Beep when Caps and Num Lock are used"
+msgstr "Свирни кога се користат Caps и Num Lock"
+
+#: ../panels/universal-access/uap.ui.h:12
+#| msgid "Beep when a _modifier key is pressed"
+msgid "Beep when a _modifer key is pressed"
+msgstr "Свирни кога е притиснат _менувач"
+
+#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
+#: ../panels/universal-access/uap.ui.h:14
+#| msgid "Beep when a key is pr_essed"
+msgid "Beep when a key is"
+msgstr "Свирни кога некое копче е"
+
+#: ../panels/universal-access/uap.ui.h:15
+#| msgid "Beep when a key is reje_cted"
+msgid "Beep when a key is _rejected"
+msgstr "Свирни кога некое копче е отфр_лено"
+
+#: ../panels/universal-access/uap.ui.h:16
+#| msgid "Mouse Keys"
+msgid "Bounce Keys"
+msgstr "Одбивни копчиња"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Bounce keys typing delay"
+msgstr "Доцнење при пишување на одбивните копчиња"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "Caribou"
+msgstr "Caribou"
+
+#: ../panels/universal-access/uap.ui.h:19
+#| msgid "Change set"
+msgid "Change contrast:"
+msgstr "Промени го контрастот:"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Closed Captioning"
+msgstr "Затворен натпис"
+
+#: ../panels/universal-access/uap.ui.h:21
+#| msgid "_Pointer can be controlled using the keypad"
+msgid "Control the pointer using the keypad"
+msgstr "Контрола на стрелката со тастатура"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Control the pointer using the video camera."
+msgstr "Контролирај ја стрелката со помош на видео камера."
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "D_elay:"
+msgstr "З_астој:"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Dasher"
+msgstr "Dasher"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Decrease size:"
+msgstr "Намали:"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Display a textual description of speech and sounds"
+msgstr "Прикажи текстуален опис на звуците и говорот"
+
+#: ../panels/universal-access/uap.ui.h:27
+#| msgid "Flash screen"
+msgid "Flash the entire screen"
+msgstr "Трепни го целиот екран"
+
+#: ../panels/universal-access/uap.ui.h:28
+#| msgid "Flash window"
+msgid "Flash the window title"
+msgstr "Трепни го насловот на прозорецот"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "GOK"
+msgstr "GOK"
+
+#: ../panels/universal-access/uap.ui.h:30
+#| msgctxt "Sound event"
+#| msgid "Warning"
+msgid "Hearing"
+msgstr "Слушање"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Hover Click"
+msgstr "Клик со застанување со стрелката врз предметите"
+
+#: ../panels/universal-access/uap.ui.h:32
+#| msgid "_Ignore fast duplicate keypresses"
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ги игнорира брзите дупликати при притискање на копчињата"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Increase size:"
+msgstr "Зголеми:"
+
+#: ../panels/universal-access/uap.ui.h:39
+#| msgid "_Motion threshold:"
+msgid "Motion _threshold:"
+msgstr "_Праг на движење:"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Mouse Keys"
+msgstr "Копчиња на глушецот"
+
+#: ../panels/universal-access/uap.ui.h:41
+#| msgid "Mouse Keys"
+msgid "Mouse Settings"
+msgstr "Поставувања на глушецот"
+
+#: ../panels/universal-access/uap.ui.h:42
+#| msgid "None"
+msgid "Nomon"
+msgstr "Ништо"
+
+#: ../panels/universal-access/uap.ui.h:44
+#| msgid "GNOME OnScreen Keyboard"
+msgid "On screen keyboard"
+msgstr "Екранска тастатура"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "OnBoard"
+msgstr "OnBoard"
+
+#: ../panels/universal-access/uap.ui.h:46
+#| msgid "Layout _Options..."
+msgid "Options..."
+msgstr "Опции..."
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Pointing and Clicking"
+msgstr "Покажување и кликање"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Става период на доцнење кога некое копче е притиснато и тоа е прифатено"
+
+#: ../panels/universal-access/uap.ui.h:49
+#| msgid "Linux Screen Reader"
+msgid "Screen Reader"
+msgstr "Читач на екранот"
+
+#: ../panels/universal-access/uap.ui.h:50
+#| msgid "GNOME OnScreen Keyboard"
+msgid "Screen keyboard"
+msgstr "Екранска тастатура"
+
+#: ../panels/universal-access/uap.ui.h:51
+#| msgid "Seco_ndary click:"
+msgid "Secondary click delay"
+msgstr "Период за двоен клик"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Seeing"
+msgstr "Гледање"
+
+#: ../panels/universal-access/uap.ui.h:55
+#| msgid "<b>Simulated Secondary Click</b>"
+msgid "Simulated Secondary Click"
+msgstr "Симулиран двоен клик"
+
+#: ../panels/universal-access/uap.ui.h:56
+#| msgid "<b>Slow Keys</b>"
+msgid "Slow Keys"
+msgstr "Бавни копчиња"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgid "Slow keys typing delay"
+msgstr "Доцнење при пишување на бавните копчиња"
+
+#: ../panels/universal-access/uap.ui.h:61
+#| msgid "<b>Sticky Keys</b>"
+msgid "Sticky Keys"
+msgstr "Лепливи копчиња"
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Третира секвенца на изменувачки копчиња како комбинација на копчиња"
+
+#: ../panels/universal-access/uap.ui.h:63
+#| msgid "_Initiate click when stopping pointer movement"
+msgid "Trigger a click when the pointer hovers"
+msgstr "Иницирај клик при запирање на движењето на стрелката"
+
+#: ../panels/universal-access/uap.ui.h:64
+#| msgid "_Trigger secondary click by holding down the primary button"
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Активирај го секундардниот клик со држење на примарното копче"
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Turn on or off:"
+msgstr "Исклучи или приклучи:"
+
+#: ../panels/universal-access/uap.ui.h:66
+#| msgid "_Type to test settings:"
+msgid "Type here to test settings"
+msgstr "Пишувајте овде за да ги проверите поставувањата"
+
+#: ../panels/universal-access/uap.ui.h:68
+#| msgid "A_ssistant:"
+msgid "Typing Assistant"
+msgstr "Помошник за пишување"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Use a visual indication when an alert sound occurs"
+msgstr "Користи визуелен индикатор кога ќе се појави звучен сигнал"
+
+#: ../panels/universal-access/uap.ui.h:70
+#| msgid "Mouse"
+msgid "Video Mouse"
+msgstr "Видео глушец"
+
+#: ../panels/universal-access/uap.ui.h:71
+#| msgctxt "Sound event"
+#| msgid "Visual alert"
+msgid "Visual Alerts"
+msgstr "Визуелни известувања"
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "Zoom in:"
+msgstr "Зумирај:"
+
+#: ../panels/universal-access/uap.ui.h:73
+msgid "Zoom out:"
+msgstr "Одзумирај:"
+
+#: ../panels/universal-access/uap.ui.h:74
+#| msgid "_Country:"
+msgid "_Contrast:"
+msgstr "_Контраст:"
+
+#: ../panels/universal-access/uap.ui.h:75
+#| msgid "Disa_ble sticky keys if two keys are pressed together"
+msgid "_Disable if two keys are pressed together"
+msgstr "_Оневозможи ако две копчиња се притиснати одеднаш"
+
+#: ../panels/universal-access/uap.ui.h:76
+msgid "_Test flash"
+msgstr "_Тестирај го блицот"
+
+#: ../panels/universal-access/uap.ui.h:77
+msgid "_Text size:"
+msgstr "_Големина на текст:"
+
+#: ../panels/universal-access/uap.ui.h:78
+#| msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgid "_Turn on accessibility features from the keyboard"
+msgstr "_Приклучи ги опциите за пристапност од тастатурата"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:80
+msgid "accepted"
+msgstr "прифатено"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:82
+msgid "pressed"
+msgstr "притиснато"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:84
+msgid "rejected"
+msgstr "одбиено"
+
+#: ../panels/universal-access/uap.ui.h:85
+#| msgid "Right"
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Високо"
+
+#: ../panels/universal-access/uap.ui.h:86
+msgctxt "universal access, contrast"
+msgid "High/Inverse"
+msgstr "Висок/инверзен"
+
+#: ../panels/universal-access/uap.ui.h:87
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Низок"
+
+#: ../panels/universal-access/uap.ui.h:88
+#| msgid "Normal"
+msgctxt "universal access, contrast"
+msgid "Normal"
+msgstr "Нормално"
+
+#. Translators: this refers to theme contrast and font size
+#: ../panels/universal-access/uap.ui.h:90
+#| msgid "_Detect Displays"
+msgctxt "universal access, seeing"
+msgid "Display"
+msgstr "Приказ"
+
+#. Translators: this refers to screen magnifier
+#: ../panels/universal-access/uap.ui.h:92
+msgctxt "universal access, seeing"
+msgid "Zoom"
+msgstr "Зумирај"
+
+#: ../panels/universal-access/uap.ui.h:93
+#| msgid "Large"
+msgctxt "universal access, text size"
+msgid "Large"
+msgstr "Голем"
+
+#: ../panels/universal-access/uap.ui.h:94
+#| msgid "Large"
+msgctxt "universal access, text size"
+msgid "Larger"
+msgstr "Поголем"
+
+#: ../panels/universal-access/uap.ui.h:95
+#| msgid "Normal"
+msgctxt "universal access, text size"
+msgid "Normal"
+msgstr "Нормален"
+
+#: ../panels/universal-access/uap.ui.h:96
+#| msgid "Small"
+msgctxt "universal access, text size"
+msgid "Small"
+msgstr "Мал"
+
+#: ../panels/universal-access/zoom-options.c:156
+#| msgid "Lock Screen"
+msgid "1/4 Screen"
+msgstr "1/4 од приказот"
+
+#: ../panels/universal-access/zoom-options.c:157
+#| msgid "Lock Screen"
+msgid "1/2 Screen"
+msgstr "1/2 од приказот"
+
+#: ../panels/universal-access/zoom-options.c:158
+#| msgid "Lock Screen"
+msgid "3/4 Screen"
+msgstr "3/4 од приказот"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Always"
+msgstr "Секогаш"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Bottom Half"
+msgstr "Долната половина"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+#| msgid "Internet"
+msgid "Centered"
+msgstr "Центриран"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Color and Opacity"
+msgstr "Боја и провидност"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Crosshairs"
+msgstr "Мети"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+#| msgid "Flash screen"
+msgid "Full Screen"
+msgstr "На цел екран"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Image moves with the mouse pointer"
+msgstr "Сликата се движи по стрелката на глувчето"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Image scrolls at screen edges"
+msgstr "Сликата се движи по рабовите на екранот"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+#| msgid "Left"
+msgid "Left Half"
+msgstr "Лева половина"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+#| msgid "Left"
+msgid "Length"
+msgstr "Должина"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnification"
+msgstr "Зголемување"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Moveable lens - magnified view follows mouse movements"
+msgstr "Подвижни леќи - зголемен преглед кој ги следи движењата на глушецот"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Position of magnified view on screen"
+msgstr "Позиција на зголемениот преглед на екранот"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgid "Proportional"
+msgstr "Пропорционално"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgid "Push"
+msgstr "Притисни"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+#| msgid "Right"
+msgid "Right Half"
+msgstr "Десна половина"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+#| msgid "Shutdown"
+msgid "Show"
+msgstr "Покажи"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Show crosshairs intersection"
+msgstr "Прикажи го пресекот на метата"
+
+#. long delay
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "Thick"
+msgstr "Дебело"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Thickness"
+msgstr "Дебелина"
+
+#. short delay
+#: ../panels/universal-access/zoom-options.ui.h:29
+msgid "Thin"
+msgstr "Тенко"
+
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgid "To keep the pointer centered"
+msgstr "За зачувување на стрелката во центар"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgid "To keep the pointer visible"
+msgstr "За да остане стрелката видлива"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgid "Top Half"
+msgstr "Горна половина"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+#| msgid "Layout _Options..."
+msgid "Zoom Options"
+msgstr "Опции за зумирање"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+#: ../panels/user-accounts/um-account-type.c:37
+#| msgid "Terminator"
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Администратор"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+#: ../panels/user-accounts/um-account-type.c:35
+#| msgid "Standard XTerminal"
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Стандардно"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#| msgid "_Paste"
+msgid "Cr_eate"
+msgstr "К_реирај"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "Create new account"
+msgstr "Креирај нова сметка"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#| msgid "Alert Type"
+msgid "_Account Type"
+msgstr "_Тип на сметка"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+#| msgid "Full Name"
+msgid "_Full name"
+msgstr "_Цело име"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#| msgid "User name:"
+msgid "_Username"
+msgstr "_Корисничко име"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+#: ../panels/user-accounts/um-fingerprint-dialog.c:571
+msgid "Enable Fingerprint Login"
+msgstr "Овозможи најава со отпечаток од прст"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left little finger"
+msgstr "Десниот мал прст"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left middle finger"
+msgstr "Левиот мал прст"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left ring finger"
+msgstr "Левиот прст прстеноносец"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Left thumb"
+msgstr "Левиот палец"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right little finger"
+msgstr "Десниот мал прст"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right middle finger"
+msgstr "Десниот среден прст"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right ring finger"
+msgstr "Десниот прст прстеноносец"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#| msgid "Right"
+msgid "Right thumb"
+msgstr "Десен палец"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
+msgstr "Вашиот отпечаток беше успешно зачуван. Сега можете да се најавувате со користење на Вашиот читач на отпечатоци."
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "_Лев показалец"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "_Друг прст:"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid "_Right index finger"
+msgstr "_Десен показалец"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Add or remove users"
+msgstr "Додај или отстрани корисници"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:3
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Најава;Има;Отпечаток;Аватар;Лого;Лице;Лозинка;"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+#| msgid "seconds"
+msgid "User Accounts"
+msgstr "Кориснички сметки"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#| msgid "Change password"
+msgid "C_onfirm password"
+msgstr "По_тврди ја лозинката"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#| msgid "Change set"
+msgid "Ch_ange"
+msgstr "Про_мени"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+#| msgid "Change password"
+msgid "Changing password for"
+msgstr "Ја променувам лозинката за"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+#| msgid "Change password"
+msgid "Choose a generated password"
+msgstr "Избери генерирана лозинка"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Choose password at next login"
+msgstr "Изберете лозинка на следното најавување"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+#| msgid "Current _password:"
+msgid "Current _password"
+msgstr "Тековна _лозинка"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Disable this account"
+msgstr "Оневозможи ја оваа сметка"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Enable this account"
+msgstr "Овозможи ја оваа сметка"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+#| msgid "Filter"
+msgid "Fair"
+msgstr "Во ред"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+msgid "How to choose a strong password"
+msgstr "Како да изберете добра лозинка"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+msgid "Log in without a password"
+msgstr "Најави се без лозинка"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+#| msgid "_New password:"
+msgid "Set a password now"
+msgstr "Изберете лозинка сега"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid "This hint may be displayed at the login screen.  It will be visible to all users of this system.  Do <b>not</b> include the password here."
+msgstr "Овој потсетник ќе биде прикажен на најавниот екран. Тој ќе биде достапен на сите корисници на системот. <b>Не</b> ставајте ја Вашата лозинка тука."
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+#| msgid "Action"
+msgid "_Action"
+msgstr "_Дејство"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:15
+#| msgid "_Print"
+msgid "_Hint"
+msgstr "_Помош"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:16
+#| msgid "_New password:"
+msgid "_New password"
+msgstr "_Нова лозинка"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:17
+#| msgid "_New password:"
+msgid "_Show password"
+msgstr "_Покажи ја лозинката"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+msgid "Browse"
+msgstr "Прелистај"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+msgid "Cancel"
+msgstr "Откажи"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+msgid "Changing photo for:"
+msgstr "Менување на сликата за:"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+msgid "Choose a picture that will be shown at the login screen for this account."
+msgstr "Одберете слика која ќе биде прикажана на најавниот екран за оваа сметка."
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+#| msgid "Galeon"
+msgid "Gallery"
+msgstr "Галерија"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr "Фотографија"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+#: ../panels/user-accounts/um-photo-dialog.c:97
+#| msgid "_Select"
+msgid "Select"
+msgstr "Избери"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+#| msgid "Take a break!"
+msgid "Take a photograph"
+msgstr "Сликај"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+msgid "A_utomatic Login"
+msgstr "А_втоматска најава"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+msgid "Account Information"
+msgstr "Информации за сметката"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Account _type"
+msgstr "_Тип на сметка"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Add User Account"
+msgstr "Додај корисничка сметка"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+#| msgid "Layout _Options..."
+msgid "Login Options"
+msgstr "Опции за најавување"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+#| msgid "Revert Font"
+msgid "Remove User Account"
+msgstr "Отстрани корисничка сметка"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+#| msgid "User name:"
+msgid "User Icon"
+msgstr "Корисничка икона"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "_Fingerprint Login"
+msgstr "Најава со _отпечаток"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+#| msgid "_Language:"
+msgid "_Language"
+msgstr "_Јазик"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+#| msgid "_Password:"
+msgid "_Password"
+msgstr "_Лозинка"
+
+#: ../panels/user-accounts/run-passwd.c:426
+#| msgid "Authenticated!"
+msgid "Authentication failed"
+msgstr "Автентикацијата не успеа"
+
+#: ../panels/user-accounts/run-passwd.c:506
+#: ../panels/user-accounts/um-password-dialog.c:375
+#, c-format
+#| msgid "The password is too short."
+msgid "The new password is too short"
+msgstr "Новата лозинка е премногу кратка"
+
+#: ../panels/user-accounts/run-passwd.c:512
+#, c-format
+#| msgid "The password is too simple."
+msgid "The new password is too simple"
+msgstr "Новата лозинка е премногу едноставна"
+
+#: ../panels/user-accounts/run-passwd.c:518
+#, c-format
+#| msgid "The old and new passwords are too similar."
+msgid "The old and new passwords are too similar"
+msgstr "Старата и новата лозинка се премногу слични"
+
+#: ../panels/user-accounts/run-passwd.c:521
+#, c-format
+#| msgid "The two passwords are not equal."
+msgid "The new password has already been used recently."
+msgstr "Новата лозинка веќе беше користена неодамна."
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+#| msgid "The new password must contain numeric or special character(s)."
+msgid "The new password must contain numeric or special characters"
+msgstr "Новата лозинка треба да содржи нумерички и специјални знаци"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+#| msgid "The old and new passwords are the same."
+msgid "The old and new passwords are the same"
+msgstr "Старата и новата лозинка се исти"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+#| msgid ""
+#| "Your password has been changed since you initially authenticated! Please "
+#| "re-authenticate."
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Вашата лозинка беше променета откако претходно се автентициравте!"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+#| msgid "The new password must contain numeric or special character(s)."
+msgid "The new password does not contain enough different characters"
+msgstr "Новата лозинка не содржи доволно различни знаци"
+
+#: ../panels/user-accounts/run-passwd.c:540
+#, c-format
+#| msgid "Unknown"
+msgid "Unknown error"
+msgstr "Непозната грешка"
+
+#: ../panels/user-accounts/um-account-dialog.c:73
+#| msgid "Failed to create temporary directory"
+msgid "Failed to create user"
+msgstr "Не успеав да креирам корисник"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:107
+msgid "You are not allowed to access the device. Contact your system administrator."
+msgstr "Немате дозвола да пристапите на уредот. Контактирајте со Вашиот администратор на системот."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:109
+msgid "The device is already in use."
+msgstr "Уредот е веќе во употреба."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:111
+#| msgid "A system error has occurred"
+msgid "An internal error occurred."
+msgstr "Се случи внатрешна грешка."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:181
+#: ../panels/user-accounts/um-fingerprint-dialog.c:182
+#| msgid "Disabled"
+msgid "Enabled"
+msgstr "Овозможено"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:224
+msgid "Delete registered fingerprints?"
+msgstr "Да ги избришам регистрираните отпечатоци?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:228
+msgid "_Delete Fingerprints"
+msgstr "_Избриши ги отпечатоците"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:235
+msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
+msgstr "Дали сакате да ги избришите регистрираните отпечатоци за да се оневозможи најавувањето со отпечатоци?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:363
+#| msgid "None"
+msgid "Done!"
+msgstr "Готово!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:410
+#: ../panels/user-accounts/um-fingerprint-dialog.c:432
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "Не можев да пристапам на уредот „%s“"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:481
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "Не можев да започнам со снимање на отпечаток на уредот „%s“"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:533
+#| msgid "Could not load the main interface"
+msgid "Could not access any fingerprint readers"
+msgstr "Не можев да пристапам до ниеден читач на отпечатоци"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:534
+msgid "Please contact your system administrator for help."
+msgstr "Контактирајте со администраторот на системот за помош."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:605
+#, c-format
+msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
+msgstr "За да овозможите најава со отпечаток, мора да снимате Ваш отпечаток со користење на уредот „%s“."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:612
+#| msgid "Select Image"
+msgid "Selecting finger"
+msgstr "Избирам прст"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:613
+msgid "Enrolling fingerprints"
+msgstr "Запишани отпечатоци"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:614
+msgid "Summary"
+msgstr "Резиме"
+
+#: ../panels/user-accounts/um-password-dialog.c:179
+msgid "More choices..."
+msgstr "Повеќе избор..."
+
+#: ../panels/user-accounts/um-password-dialog.c:285
+msgid "Please choose another password."
+msgstr "Одберете друга лозинка."
+
+#: ../panels/user-accounts/um-password-dialog.c:294
+#| msgid "Please type your password in the <b>New password</b> field."
+msgid "Please type your current password again."
+msgstr "Ве молам, внесете ја Вашата лозинка пак."
+
+#: ../panels/user-accounts/um-password-dialog.c:300
+#| msgid "Your password has been changed."
+msgid "Password could not be changed"
+msgstr "Лозинката не може да биде променета"
+
+#: ../panels/user-accounts/um-password-dialog.c:372
+#| msgid "_Retype new password:"
+msgid "You need to enter a new password"
+msgstr "Треба да внесите нова лозинка"
+
+#: ../panels/user-accounts/um-password-dialog.c:381
+msgid "You need to confirm the password"
+msgstr "Треба да ја потврдите лозинката"
+
+#: ../panels/user-accounts/um-password-dialog.c:384
+#| msgid "The password is too short."
+msgid "The passwords do not match"
+msgstr "Лозинките не се совпаѓаат"
+
+#: ../panels/user-accounts/um-password-dialog.c:390
+msgid "You need to enter your current password"
+msgstr "Треба да ја внесите Вашата тековна лозинка"
+
+#: ../panels/user-accounts/um-password-dialog.c:393
+#| msgid "That password was incorrect."
+msgid "The current password is not correct"
+msgstr "Тековната лозинка не е точна"
+
+#: ../panels/user-accounts/um-password-dialog.c:466
+#: ../panels/user-accounts/um-password-dialog.c:693
+msgctxt "Password strength"
+msgid "Too short"
+msgstr "Премногу кратка"
+
+#: ../panels/user-accounts/um-password-dialog.c:469
+#: ../panels/user-accounts/um-password-dialog.c:694
+msgctxt "Password strength"
+msgid "Weak"
+msgstr "Слаба"
+
+#: ../panels/user-accounts/um-password-dialog.c:471
+#: ../panels/user-accounts/um-password-dialog.c:695
+#| msgid "Filter"
+msgctxt "Password strength"
+msgid "Fair"
+msgstr "Добра"
+
+#: ../panels/user-accounts/um-password-dialog.c:473
+#: ../panels/user-accounts/um-password-dialog.c:696
+msgctxt "Password strength"
+msgid "Good"
+msgstr "Добра"
+
+#: ../panels/user-accounts/um-password-dialog.c:475
+#: ../panels/user-accounts/um-password-dialog.c:697
+msgctxt "Password strength"
+msgid "Strong"
+msgstr "Јака"
+
+#: ../panels/user-accounts/um-password-dialog.c:514
+msgid "Passwords do not match"
+msgstr "Лозинките не се совпаѓаат"
+
+#: ../panels/user-accounts/um-password-dialog.c:540
+#| msgid "Change password"
+msgid "Wrong password"
+msgstr "Погрешна лозинка"
+
+#: ../panels/user-accounts/um-photo-dialog.c:445
+#| msgid "Disabled"
+msgid "Disable image"
+msgstr "Оневозможи слика"
+
+#: ../panels/user-accounts/um-photo-dialog.c:463
+msgid "Take a photo..."
+msgstr "Сликај..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:481
+msgid "Browse for more pictures..."
+msgstr "Прелистај за повеќе слики..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:706
+#, c-format
+msgid "Used by %s"
+msgstr "Се користи од %s"
+
+#: ../panels/user-accounts/um-user-manager.c:450
+#, c-format
+msgid "A user with name '%s' already exists."
+msgstr "Веќе постои корисник со име „%s“."
+
+#: ../panels/user-accounts/um-user-manager.c:546
+msgid "This user does not exist."
+msgstr "Овој корисник не постои."
+
+#: ../panels/user-accounts/um-user-panel.c:358
+msgid "Failed to delete user"
+msgstr "Не успеав да го избришам корисникот"
+
+#: ../panels/user-accounts/um-user-panel.c:418
+msgid "You cannot delete your own account."
+msgstr "Не можете да ја избришете сопствената сметка."
+
+#: ../panels/user-accounts/um-user-panel.c:427
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s е сѐ уште најавен(а)"
+
+#: ../panels/user-accounts/um-user-panel.c:431
+msgid "Deleting a user while they are logged in can leave the system in an inconsistent state."
+msgstr "Бришењето на корисник додека е сѐ уште најавен може да го доведе системот во неправилна состојба."
+
+#: ../panels/user-accounts/um-user-panel.c:440
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "Дали сакате да ги зачувате датотеките на „%s“?"
+
+#: ../panels/user-accounts/um-user-panel.c:444
+msgid "It is possible to keep the home directory, mail spool and temporary files around when deleting a user account."
+msgstr "Можно е да го зачувате домашниот директориум, поштата и привремените датотеки при бришењето на корисничка сметка."
+
+#: ../panels/user-accounts/um-user-panel.c:447
+#| msgid "_Selected items:"
+msgid "_Delete Files"
+msgstr "_Избриши ги датотеките"
+
+#: ../panels/user-accounts/um-user-panel.c:448
+#| msgid "New File"
+msgid "_Keep Files"
+msgstr "_Зачувај ги датотеките"
+
+#: ../panels/user-accounts/um-user-panel.c:500
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Сметката е оневозможена"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Ќе биде поставена на наредното најавување"
+
+#: ../panels/user-accounts/um-user-panel.c:511
+#| msgid "None"
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ништо"
+
+#: ../panels/user-accounts/um-user-panel.c:846
+#| msgid "Failed to construct test pipeline for '%s'"
+msgid "Failed to contact the accounts service"
+msgstr "Не успеав да контактирам со сервисот за сметки"
+
+#: ../panels/user-accounts/um-user-panel.c:848
+#| msgid "Please make sure that the applet is properly installed"
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Проверете дали AccountService е инсталиран и овозможен."
+
+#: ../panels/user-accounts/um-user-panel.c:888
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"За да направите промени,\n"
+"кликнете на иконата *"
+
+#: ../panels/user-accounts/um-user-panel.c:926
+msgid "Create a user account"
+msgstr "Креирај нова сметка"
+
+#: ../panels/user-accounts/um-user-panel.c:937
+#: ../panels/user-accounts/um-user-panel.c:1226
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"За да креирате нова сметка,\n"
+"кликнете на иконата *"
+
+#: ../panels/user-accounts/um-user-panel.c:946
+msgid "Delete the selected user account"
+msgstr "Избриши ја избраната корисничка сметка"
+
+#: ../panels/user-accounts/um-user-panel.c:958
+#: ../panels/user-accounts/um-user-panel.c:1231
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"За да ја избришете избраната корисничка сметка,\n"
+"стиснете на иконата *"
+
+#: ../panels/user-accounts/um-user-panel.c:1135
+#| msgid "By _country"
+msgid "My Account"
+msgstr "Мојата сметка"
+
+#: ../panels/user-accounts/um-user-panel.c:1145
+msgid "Other Accounts"
+msgstr "Други сметки"
+
+#: ../panels/user-accounts/um-utils.c:512
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr "Веќе постои корисник со корисничко име „%s“"
+
+#: ../panels/user-accounts/um-utils.c:516
+#, c-format
+#| msgid "The password is too short."
+msgid "The username is too long"
+msgstr "Корисничкото име е предолго"
+
+#: ../panels/user-accounts/um-utils.c:519
+msgid "The username cannot start with a '-'"
+msgstr "Корисничкото име не смее да започнува со „-“"
+
+#: ../panels/user-accounts/um-utils.c:522
+msgid ""
+"The username must only consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr ""
+"Корисничкото име смее да се состои од:\n"
+" ➣ букви од англиската абецеда\n"
+" ➣ цифри\n"
+" ➣ било кој од знаците „.“, „-“ и „_“"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#| msgid "Set your mouse preferences"
+msgid "Set your Wacom tablet preferences"
+msgstr "Поставете ги преференците за Вашиот Wacom таблет"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Таблет;Wacom;Stylus;Бришач;Глушец;"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Wacom Graphics Tablet"
+msgstr "Wacom графички таблет"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Back"
+msgstr "Назад"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Bluetooth Settings"
+msgstr "Поставувања за Bluetooth"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Calibrate..."
+msgstr "Калибрирај..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "Eraser Pressure Feel"
+msgstr "Осет на притисок на бришачот"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+#| msgid "Filter"
+msgid "Firm"
+msgstr "Цврсто"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Forward"
+msgstr "Напред"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Left Mouse Button Click"
+msgstr "Клик на левото копче на глушецот"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Left-Handed Orientation"
+msgstr "Ориентација за левичари"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+#| msgid "Alert Buttons"
+msgid "Lower Button"
+msgstr "Долно копче"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Middle Mouse Button Click"
+msgstr "Клик на средното копче на глушецот"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+#| msgid "Action"
+msgid "No Action"
+msgstr "Нема дејство"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "No tablet detected"
+msgstr "Не е откриен таблет"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Прикачете или пуштете го Вашиот Wacom таблет"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Right Mouse Button Click"
+msgstr "Клик на десното копче на глушецот"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Scroll Down"
+msgstr "Движи се надолу"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:16
+msgid "Scroll Left"
+msgstr "Движи се налево"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:17
+#| msgid "_Slight"
+msgid "Scroll Right"
+msgstr "Движи се надесно"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:18
+#| msgid "Roll up"
+msgid "Scroll Up"
+msgstr "Движи се нагоре"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:19
+msgid "Soft"
+msgstr "Меко"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:20
+#: ../panels/wacom/gsd-wacom-device.c:315
+#: ../panels/wacom/gsd-wacom-device.c:544
+#| msgid "_Style:"
+msgid "Stylus"
+msgstr "Стило"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:21
+msgid "Tablet (absolute)"
+msgstr "Таблет (апсолутен)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:22
+#| msgid "Mouse Preferences"
+msgid "Tablet Preferences"
+msgstr "Преференци за таблет"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:23
+msgid "Tip Pressure Feel"
+msgstr "Осет на притисок на врвот"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:24
+#| msgid "Alert Buttons"
+msgid "Top Button"
+msgstr "Горно копче"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:25
+msgid "Touchpad (relative)"
+msgstr "Тачпад (релативен)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:26
+msgid "Tracking Mode"
+msgstr "Режим на следење"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:27
+msgid "Wacom Tablet"
+msgstr "Wacom таблет"
+
+#: ../shell/control-center.c:54
+#| msgid "Enable debugging code"
+msgid "Enable verbose mode"
+msgstr "Овозможи режим за дебагирање"
+
+#: ../shell/control-center.c:55
+msgid "Show the overview"
+msgstr "Покажи го прегледот"
+
+#: ../shell/control-center.c:56
+#: ../shell/control-center.c:57
+#: ../shell/control-center.c:58
+msgid "Show help options"
+msgstr "Покажи ги сите опции за помош"
+
+#: ../shell/control-center.c:59
+msgid "Panel to display"
+msgstr "Панел за прикажување"
+
+#: ../shell/control-center.c:81
+msgid "- System Settings"
+msgstr "- системски поставувања"
+
+#: ../shell/control-center.c:89
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"Извршете '%s --help' за листа на сите опции на командната линија.\n"
+
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Контролен центар"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: ../shell/shell.ui.h:2
+msgid "System Settings"
+msgstr "Системски поставувања"
+
+#: ../shell/shell.ui.h:1
+msgid "All Settings"
+msgstr "Сите поставувања"
+
+#~ msgid "Image/label border"
+#~ msgstr "Слика/ознака на граница"
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr ""
+#~ "Должина на границата околу ознаката и сликата во дијалогот за известување"
+#~ msgid "The type of alert"
+#~ msgstr "Тип на известување"
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Копчето прикажано во дијалогот за известување"
+#~ msgid "Show more _details"
+#~ msgstr "Покажи повеќе _детали"
+#~ msgid "No Image"
+#~ msgstr "Без слика"
+#~ msgid "Images"
+#~ msgstr "Слики"
+#~ msgid "All Files"
+#~ msgstr "Сите датотеки"
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Се појави грешка при обидот за добивање на информации од именикот\n"
+#~ "Серверот за податоци на Еволушн не може да се справи со овој протокол"
+#~ msgid "Unable to open address book"
+#~ msgstr "Не можам да го отворам адресарот"
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr ""
+#~ "Непозната идентификација за најава, корисничката база на податоци може да "
+#~ "е расипана"
+#~ msgid "About %s"
+#~ msgstr "За %s"
+#~ msgid "Set your personal information"
+#~ msgstr "Поставете лични информации"
+#~ msgid "<b>Email</b>"
+#~ msgstr "<b>Е-пошта</b>"
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Дома</b>"
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Инстант пораки</b>"
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Работа</b>"
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Телефон</b>"
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Веб</b>"
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Работа</b>"
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr ""
+#~ "<span size=\"larger\" weight=\"bold\">Сменете ја Вашата лозинка</span>"
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+#~ msgid "C_ompany:"
+#~ msgstr "К_омпанија:"
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Промени лозин_ка..."
+#~ msgid "Change pa_ssword"
+#~ msgstr "Промени ло_зинка"
+#~ msgid "Ci_ty:"
+#~ msgstr "Гр_ад:"
+#~ msgid "Contact"
+#~ msgstr "Контакт"
+#~ msgid "Cou_ntry:"
+#~ msgstr "Зем_ја:"
+#~ msgid "Hom_e:"
+#~ msgstr "Дом_а:"
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+#~ msgid "P.O. _box:"
+#~ msgstr "Поштенско _сандаче:"
+#~ msgid "P._O. box:"
+#~ msgstr "П_оштенско сандаче:"
+#~ msgid "Personal Info"
+#~ msgstr "Лични информации"
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "Ве молам внесете ја лозинката повторно во полето <b>Внеси нова лозинка</"
+#~ "b>."
+#~ msgid "Select your photo"
+#~ msgstr "Одберете ја Вашата фотографија"
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Држава/Про_винција:"
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "За да ја промените Вашата лозинка, внесете ја сегашната лозинка во полето "
+#~ "подолу и кликнете <b>Провери автентичност</b>.\n"
+#~ "После проверката проверката, внесете ја вашата нова лозинка и повторно "
+#~ "внесете ја за проверка и кликнете на <b>Промени лозинка</b>."
+#~ msgid "Web _log:"
+#~ msgstr "_Блог:"
+#~ msgid "Wor_k:"
+#~ msgstr "Рабо_та:"
+#~ msgid "Work _fax:"
+#~ msgstr "Факс на _работа:"
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "Поштенски _код:"
+#~ msgid "_Address:"
+#~ msgstr "_Адреса:"
+#~ msgid "_Authenticate"
+#~ msgstr "_Провери автентичност"
+#~ msgid "_Groupwise:"
+#~ msgstr "_Групвајз:"
+#~ msgid "_Home page:"
+#~ msgstr "_Домашна страна:"
+#~ msgid "_Home:"
+#~ msgstr "_Дома:"
+#~ msgid "_Jabber:"
+#~ msgstr "_Џабер:"
+#~ msgid "_State/Province:"
+#~ msgstr "_Држава/Провинција:"
+#~ msgid "_Work:"
+#~ msgstr "_Работа:"
+#~ msgid "_Yahoo:"
+#~ msgstr "_Јаху:"
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "_Поштенски код:"
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "Подпроцесот падна неочекувано"
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "Не можам да го исклучам backend_stdin влезно-излезниот канал: %s"
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "Не можам да го исклучам backend_stdout влезно-излезниот канал: %s"
+#~ msgid "System error: %s."
+#~ msgstr "Системска грешка: %s."
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "Не можам да го лансирам %s: %s"
+#~ msgid "Unable to launch backend"
+#~ msgstr "Не можам да го лансирам бекендот"
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "Кликнете на <b>Промени лозинка</b> за да ја смените лозинката."
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>Помошни технологии</b>"
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>Преференции</b>"
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "На_јава со пристапност"
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Преференци за помошна технологија"
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "Промените на овозможувањето на помошни технологии нема да се реализираат "
+#~ "се до Вашето наредно најавување."
+#~ msgid "Close and _Log Out"
+#~ msgstr "Затвори и _одјави се"
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Скокни до дијалог прозорецот за преферирани апликации"
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "Скокни до дијалог прозорецот за најава со пристапност"
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "Скокни до дијалог прозорецот за пристапност на тастатурата"
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Скокни до дијалог прозорецот за пристапност на глушецот"
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Вклучи помошни технологии"
+#~ msgid "_Keyboard Accessibility"
+#~ msgstr "Пристапност на _тастатура"
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "_Пристапност за глушецот"
+#~ msgid "_Preferred Applications"
+#~ msgstr "_Преферирани апликации"
+#~ msgid "Assistive Technologies"
+#~ msgstr "Помошни технологии"
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr ""
+#~ "Изберете која опција за пристапност да биде вклучена кога ќе се најавите"
+#~ msgid "Font may be too large"
+#~ msgstr "Фонтот можеби е преголем"
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Избраниот фонт е поголем за %d точкa, и може да го отежни користењето на "
+#~ "овој компјутер.  Препорачливо е да изберете големина помала од %d."
+#~ msgstr[1] ""
+#~ "Избраниот фонт е поголем за %d точки, и може да го отежни користењето на "
+#~ "овој компјутер.  Препорачливо е да изберете големина помала од %d."
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Избраниот фонт е поголем за %d точкa, и може да го отежни користењето на "
+#~ "овој компјутер.  Препорачливо е да изберете помала големина."
+#~ msgstr[1] ""
+#~ "Избраниот фонт е поголем за %d точки, и може да го отежни користењето на "
+#~ "овој компјутер.  Препорачливо е да изберете помала големина."
+#~ msgstr[2] ""
+#~ "Избраниот фонт е поголем за %d точки, и може да го отежни користењето на "
+#~ "овој компјутер.  Препорачливо е да изберете помала големина."
+#~ msgid "Use previous font"
+#~ msgstr "Користи го претходниот фонт"
+#~ msgid "Use selected font"
+#~ msgstr "Користи го избраниот фонт"
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Одредете го името на темата за инсталација"
+#~ msgid "filename"
+#~ msgstr "име на датотека"
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "Одредете го името на страницата за прикажување (тема|позадина|фонтови|"
+#~ "интерфејс)"
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[ПОЗАДИНА...]"
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "Оваа тема нема да изгледа како што треба бидејќи бараниот GTK+ енџин %s "
+#~ "не е инсталиран."
+#~ msgid "Apply Font"
+#~ msgstr "Примени го фонтот"
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "Тековната тема предлага позадина и фонт. Последниот применет фонтможе да "
+#~ "биде повторно вратен."
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "Тековната тема предлага позадина. Последниот применет фонтможе да биде "
+#~ "повторно вратен."
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "Тековната тема предлага позадина и фонт."
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "Тековната тема предлага фонт. Последниот применет фонтможе да биде "
+#~ "повторно вратен."
+#~ msgid "The current theme suggests a background."
+#~ msgstr "Тековната тема предлага позадина."
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "Последниот применет фонт може да биде повторно вратен."
+#~ msgid "The current theme suggests a font."
+#~ msgstr "Тековната тема предлага фонт."
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>_Бои</b>"
+#~ msgid "<b>Hinting</b>"
+#~ msgstr "<b>Совети</b>"
+#~ msgid "<b>Menus and Toolbars</b>"
+#~ msgstr "<b>Мени и ленти со алатки</b>"
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Преглед</b>"
+#~ msgid "<b>Rendering</b>"
+#~ msgstr "<b>Исцртување</b>"
+#~ msgid "<b>Smoothing</b>"
+#~ msgstr "<b>Заматување</b>"
+#~ msgid "<b>Subpixel Order</b>"
+#~ msgstr "<b>Подпикселен ред</b>"
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>_Позадина</b>"
+#~ msgid "Best _shapes"
+#~ msgstr "Најдобри _облици"
+#~ msgid "Best co_ntrast"
+#~ msgstr "Најдобар ко_нтраст"
+#~ msgid "C_ustomize..."
+#~ msgstr "С_опствено..."
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr ""
+#~ "Промената на Вашата тема за стрелки ќе има ефект после следното "
+#~ "најавување."
+#~ msgid "Controls"
+#~ msgstr "Контроли"
+#~ msgid "Customize Theme"
+#~ msgstr "Прилагоди тема"
+#~ msgid "D_etails..."
+#~ msgstr "Д_етали..."
+#~ msgid "Des_ktop font:"
+#~ msgstr "Фонт за р_аботната површина:"
+#~ msgid "Font Rendering Details"
+#~ msgstr "Детали за вчитување на фонтови"
+#~ msgid "Gra_yscale"
+#~ msgstr "Нијанса на сиво"
+#~ msgid "Icons"
+#~ msgstr "Икони"
+#~ msgid "N_one"
+#~ msgstr "Ништ_о"
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Отвори дијалог за одредување на боја"
+#~ msgid "R_esolution:"
+#~ msgstr "Р_езолуција:"
+#~ msgid "Save File"
+#~ msgstr "Зачувај датотека"
+#~ msgid "Save Theme As..."
+#~ msgstr "_Зачувај ја темата како..."
+#~ msgid "Save _As..."
+#~ msgstr "_Зачувај како..."
+#~ msgid "Show _icons in menus"
+#~ msgstr "Прикажи _икони во менијата"
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "Полна боја\n"
+#~ "Хоризонтална градација\n"
+#~ "Вертикална градација"
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Под_пиксел (LCD)"
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Под_пикселно зарамнување (LCD)"
+#~ msgid "Text"
+#~ msgstr "Текст"
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "Текст под предметите\n"
+#~ "Текст покрај предметите\n"
+#~ "Само икони\n"
+#~ "Само текст"
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "Тековната тема за графички контроли не поддржува шеми на бои."
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "Споено\n"
+#~ "Зголемено\n"
+#~ "Центрирано\n"
+#~ "Проширливо\n"
+#~ "Исполнет екран"
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Ознаки за _копчиња на лентата со алатки:"
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+#~ msgid "Window Border"
+#~ msgstr "Граница на прозорец"
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+#~ msgid "_Copy"
+#~ msgstr "_Копирај"
+#~ msgid "_Description:"
+#~ msgstr "_Опис:"
+#~ msgid "_Document font:"
+#~ msgstr "_Фонт за документи:"
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "_Уредливи кратенки за менито"
+#~ msgid "_Fixed width font:"
+#~ msgstr "_Fixed width фонт:"
+#~ msgid "_Full"
+#~ msgstr "_Полно"
+#~ msgid "_Medium"
+#~ msgstr "_Средно"
+#~ msgid "_Monochrome"
+#~ msgstr "_Монохром"
+#~ msgid "_New"
+#~ msgstr "_Ново"
+#~ msgid "_None"
+#~ msgstr "_Ништо"
+#~ msgid "_Quit"
+#~ msgstr "_Излез"
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+#~ msgid "_Reset to Defaults"
+#~ msgstr "_Ресетирај на стандардното"
+#~ msgid "_Save"
+#~ msgstr "_Зачувај"
+#~ msgid "_Size:"
+#~ msgstr "_Големина:"
+#~ msgid "_Tooltips:"
+#~ msgstr "_Балончиња со совет:"
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+#~ msgid "_Window title font:"
+#~ msgstr "_Наслов на прозор фонт:"
+#~ msgid "_Windows:"
+#~ msgstr "_Прозорци:"
+#~ msgid "dots per inch"
+#~ msgstr "точки на инч"
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Прилагодете го изгледот на работната околина"
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Инсталира пакети со теми за разни делови на работната околина"
+#~ msgid "Theme Installer"
+#~ msgstr "Инсталер на теми"
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Пакет со теми за GNOME"
+#~ msgid "Slide Show"
+#~ msgstr "Слајд шоу"
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s by %d %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s од %d %s\n"
+#~ "Папка: %s"
+#~ msgid "Cannot install theme"
+#~ msgstr "Не можам да ја инсталирам темата"
+#~ msgid "The %s utility is not installed."
+#~ msgstr "Алатката %s не е инсталирана."
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "Се појави проблем при отпакувањето на темата."
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "Се појави грешка при инсталација на избраната датотека"
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" изгледа дека не е валидна тема."
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" изгледа дека не е валидна тема. Можеби се работи за енџин за "
+#~ "темата што треба да го компајлирате."
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "Темата за GNOME %s е успешно инсталирана"
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "Инсталацијата на темата \"%s\" не успеа."
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "Темата „%s“ е инсталирана."
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr ""
+#~ "Дали сакате да ја примените сега или да ја задржите Вашата тековна тема?"
+#~ msgid "Keep Current Theme"
+#~ msgstr "Зачувај тековна"
+#~ msgid "Apply New Theme"
+#~ msgstr "Примени нова"
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "Успешно се инсталирани нови теми."
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Не е одредена локација за тема за датотеката да биде инсталирана"
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Немате дозвола да ја инсталирате темата во:\n"
+#~ "%s"
+#~ msgid "Select Theme"
+#~ msgstr "Одберете тема"
+#~ msgid "Theme Packages"
+#~ msgstr "Пакет со теми"
+#~ msgid "Theme name must be present"
+#~ msgstr "Името на темата мора да е присутно"
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Темата веќе постои. Дали сакате да ја замените?"
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Дали сакате да ја отстраните оваа тема?"
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "Темата не може да се избрише"
+#~ msgid "Could not install theme engine"
+#~ msgstr "Не можам да го инсталирам новиот енџин за темата"
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Не е можно да ги стартувам поставувањата на менаџерот 'gnome-settings-"
+#~ "daemon'.\n"
+#~ "Без да работи GNOME менаџерот за поставувања, некои преференци немаат "
+#~ "ефект. Ова може да покаже проблем со Bonobo, или не-GNOME (пр. KDE) "
+#~ "менаџери за поставувања веќе се активни и се во конфликт со GNOME "
+#~ "менаџерот за поставувања."
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Не може да се вчита stock иконата '%s'\n"
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Грешка при прикажувањето на помошта: %s"
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Ја копирам датотеката: %u од %u"
+#~ msgid "Parent Window"
+#~ msgstr "Главен прозорец"
+#~ msgid "Parent window of the dialog"
+#~ msgstr "Главен прозорец на дијалогот"
+#~ msgid "From URI"
+#~ msgstr "Од URI"
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI моментално пренесува од"
+#~ msgid "To URI"
+#~ msgstr "До URI"
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI моментално пренесува до"
+#~ msgid "Fraction completed"
+#~ msgstr "Фракција комплетна"
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Фракција на пренесување моментално е завршена"
+#~ msgid "Current URI index"
+#~ msgstr "Тековен URI индекс"
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Тековен URI индекс - почнува од 1"
+#~ msgid "Total URIs"
+#~ msgstr "Вкупно URI"
+#~ msgid "Total number of URIs"
+#~ msgstr "Вкупен број на URI"
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "Датотеката %s веќе постои. Дали сакате да ја замените?"
+#~ msgid "_Skip"
+#~ msgstr "_Прескокни"
+#~ msgid "Overwrite _All"
+#~ msgstr "_Замени сè"
+#~ msgid "Key"
+#~ msgstr "Копче"
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf копче на кое е прикачен овој property едитор"
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Поднеси го овој callback кога вредноста асоцирана со копче ќе се промени"
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Gconf промени поставување кое содржи податоци за препраќање до gconf "
+#~ "клиент на повик"
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Конверзија во повратна информација на уред"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Повратната информација ќе биде земена во предвид кога податоците ќе бидат "
+#~ "претворени од GConf во контролата"
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Конверзија на повратната информација од објектот"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Callback ќе биде поднесен кога податоците ќе бидат конвертирани во GConf "
+#~ "од widget"
+#~ msgid "UI Control"
+#~ msgstr "UI контрола"
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Објект кој ја контролира сопственоста (обично објект)"
+#~ msgid "Property editor object data"
+#~ msgstr "Едитор за сопственост на објектните податоци"
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Вообичаени податоци потребни од специфичниот едитор за сопственост"
+#~ msgid "Property editor data freeing callback"
+#~ msgstr ""
+#~ "Податоци за ослободување на повратната информација на едиторот за "
+#~ "сопственост"
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Callback ќе биде поднесен кога податоците со објекти на едиторот за "
+#~ "сопственост ќе бидат ослободени"
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Не се наоѓа датотеката '%s'.\n"
+#~ "\n"
+#~ "Осигурај се дека таа постои и пробај повторно, или избери друга "
+#~ "позадинска слика."
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Не знам како да ја отворам датотеката '%s'.\n"
+#~ "Можеби е формат на слика кој сеуште не е подржан.\n"
+#~ "\n"
+#~ "Одбери друга слика."
+#~ msgid "Please select an image."
+#~ msgstr "Ве молам изберете слика."
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Стандардна стрелка - тековна"
+#~ msgid "White Pointer"
+#~ msgstr "Бела стрелка"
+#~ msgid "White Pointer - Current"
+#~ msgstr "Бела стрелка - тековна"
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Голема стрелка- тековна"
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Голема верзија на белата стрелка - тековна"
+#~ msgid "Large White Pointer"
+#~ msgstr "Голема бела стрелка"
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Оваа тема нема да изгледа како што треба бидејќи потребната GTK+ тема %s "
+#~ "не е инсталирана."
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "Оваа тема нема да изгледа како што треба бидејќи потребниот менаџер на "
+#~ "прозорци %s не е инсталиран."
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Оваа тема нема да изгледа како што треба бидејќи потребната тема со икони "
+#~ "%s не е инсталирана."
+#~ msgid "Preferred Applications"
+#~ msgstr "Преферирани апликации"
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "Подигни ја преферираната визуелна помошна технологија"
+#~ msgid "Visual Assistance"
+#~ msgstr "Визуелно помош"
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Грешка при зачувување на конфигурацијата: %s"
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "Одредете го името на страницата за прикажување (интернет|мултимедија|"
+#~ "систем|a11y)"
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>Прегледувач на слики</b>"
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>Инстант пораки</b>"
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>Читач за е-пошта</b>"
+#~ msgid "<b>Mobility</b>"
+#~ msgstr "<b>Мобилност</b>"
+#~ msgid "<b>Multimedia Player</b>"
+#~ msgstr "<b>Пуштач на мултимедијални содржини</b>"
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Емулатор на терминал</b>"
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Уредувач за текст</b>"
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Видео пуштач</b>"
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b>Визуелно</b>"
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Веб прелистувач</b>"
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Сите совпаѓања на %s ќе бидат заменети со вистниската врска"
+#~ msgid "Co_mmand:"
+#~ msgstr "Ко_манда:"
+#~ msgid "E_xecute flag:"
+#~ msgstr "И_зврши означено:"
+#~ msgid "Open link in new _tab"
+#~ msgstr "Отвори ја врската во ново _јазиче"
+#~ msgid "Open link in new _window"
+#~ msgstr "Отвори ја врската во нов _прозорец"
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Отвори ја врската со стандардниот веб _прелистувач"
+#~ msgid "Run at st_art"
+#~ msgstr "Изврши при ст_артување"
+#~ msgid "Run in t_erminal"
+#~ msgstr "Изврши во т_ерминал"
+#~ msgid "_Run at start"
+#~ msgstr "_Изврши при подигнување"
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee пуштачот на музика"
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian прелистувач"
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Емулатор на терминал за Debian"
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution читач за е-пошта"
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "Зголемувачот на GNOME без читач на екранот"
+#~ msgid "GNOME Terminal"
+#~ msgstr "Терминал за GNOME"
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus со зголемувач"
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape Mail"
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "KDE зголемувач без читач на екранот"
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Linux Screen Reader со зголемувач"
+#~ msgid "Midori"
+#~ msgstr "Midori"
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+#~ msgid "Orca"
+#~ msgstr "Orca"
+#~ msgid "Orca with Magnifier"
+#~ msgstr "Orca со зголемувач"
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox пуштач на музика"
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey Mail"
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+#~ msgid "Thunderbird"
+#~ msgstr "Thunderbird"
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem пуштачот на филмови"
+#~ msgid "Include _Panel"
+#~ msgstr "Вклучи _панел"
+#~ msgid "Mirror Screens"
+#~ msgstr "Огледало од екрани"
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "Нормално\n"
+#~ "Лево\n"
+#~ "Десно\n"
+#~ "Обратно\n"
+#~ msgid "Re_fresh Rate:"
+#~ msgstr "Бр_зина на освежување:"
+#~ msgid "_Show Displays in Panel"
+#~ msgstr "_Покажи ги приказите во панелот"
+#~ msgid "Upside Down"
+#~ msgstr "Обратно"
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+#~ msgid "Desktop"
+#~ msgstr "Работна површина"
+#~ msgid "Accelerator key"
+#~ msgstr "Копче за забрзување"
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Менувачи на забрзување"
+#~ msgid "Accelerator keycode"
+#~ msgstr "Код за забрзување"
+#~ msgid "Accel Mode"
+#~ msgstr "Забрзан режим"
+#~ msgid "The type of accelerator."
+#~ msgstr "Тип на забрзувач."
+#~ msgid "Error saving the new shortcut: %s"
+#~ msgstr "Грешка при зачувување на новата кратенка: %s"
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr ""
+#~ "Грешка при поставување на забрзувачот во базата за конфигурирација: %s"
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Додели кратенки за команди"
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Само примени ги поставувањата и излези (само компатибилност; сега се "
+#~ "управува од демон)"
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Поврати и зачувај ненативни поставувања"
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Почни ја страницата со прикажани поставувања за куцачката пауза"
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Почни ја страницата со прикажани поставувања за пристапност"
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr " Преференци за тастатура"
+#~ msgid "<b>Bounce Keys</b>"
+#~ msgstr "<b>Скокачки копчиња</b>"
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>Општо</b>"
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Брзо</i></small>"
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Долго</i></small>"
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Кратко</i></small>"
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Бавно</i></small>"
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Д_озволи одложување на паузи"
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Аудио _фидбек"
+#~ msgid "Beep when _accessibility features are turned on or off"
+#~ msgstr ""
+#~ "Свирни кога _опциите за пристапност се вклучени или исклучени од тастатура"
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "Свирни кога е притиснато копче за _менување"
+#~ msgid "Beep when key is _accepted"
+#~ msgstr "Свирни кога копчето е _прифатено"
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Свирни ако копчето е _отфрлено"
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Провери дали на паузите им е дозволено да бидат одложени"
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Изберете модел на тастатура"
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Недозволено е траењето на паузата додека куцате"
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Траењето на работата пред форсирањето на паузата"
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Аудио фидбек за пристапност на тастатура"
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Преференци на тастатура"
+#~ msgid "Keyboard _model:"
+#~ msgstr "_Модел на тастатура:"
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Заклучи ги екранот по одредено време за да помогнеш да се спречат повреди "
+#~ "од употреба на тастатурата"
+#~ msgid "Separate _layout for each window"
+#~ msgstr "Посебен _распоред за секој прозорец"
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Интервалот на пауза трае:"
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "_Заклучи го екранот да изнудиш куцачка пауза"
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_Прифаќај само долго притиснати копчиња"
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Симулирај симултани притискања на копчиња"
+#~ msgid "_Variants:"
+#~ msgstr "_Варијанти:"
+#~ msgid "_Vendors:"
+#~ msgstr "_Произведувачи:"
+#~ msgid "_Work interval lasts:"
+#~ msgstr "Интервалот на работа трае:"
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Поставете ги Вашите преференци за тастатурата"
+#~ msgid "gesture|Move left"
+#~ msgstr "Помести лево"
+#~ msgid "gesture|Move right"
+#~ msgstr "Помести десно"
+#~ msgid "gesture|Move up"
+#~ msgstr "Помести горе"
+#~ msgid "gesture|Disabled"
+#~ msgstr "Исклучено"
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "Одредете го името на страницата за прикажување (општо|пристапност)"
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- Преференци за глушецот"
+#~ msgid "<b>Dwell Click</b>"
+#~ msgstr "<b>Клик со пауза</b>"
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Лоцирај ја стрелката</b>"
+#~ msgid "<b>Mouse Orientation</b>"
+#~ msgstr "<b>Ориентација на глушецот</b>"
+#~ msgid ""
+#~ "<i>You can also use the Dwell Click panel applet to choose the click type."
+#~ "</i>"
+#~ msgstr ""
+#~ "<i>Moжете да го користите аплетот за клик со пауза за да го изберете "
+#~ "типот на кликнување.</i>"
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i>Високо</i></small>"
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i>Големо</i></small>"
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>Ниско</i></small>"
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i>Мало</i></small>"
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Изберете го типот на клик _претходно"
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "Изберете го типот на кликот со оп_ции за глушецот"
+#~ msgid "D_ouble click:"
+#~ msgstr "Д_воен клик:"
+#~ msgid "D_rag click:"
+#~ msgstr "К_лик за влечење:"
+#~ msgid "Show click type _window"
+#~ msgstr "Покажи го прозорецот за типот на кликнување"
+#~ msgid "_Acceleration:"
+#~ msgstr "_Забрзување:"
+#~ msgid "_Single click:"
+#~ msgstr "_Еден клик:"
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Поставете ги вашите преференци за мрежниот proxy"
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Ди_ректна интернет врска</b>"
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>Игнорирана листа на хостови</b>"
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_Рачна конфигурација на прокси</b>"
+#~ msgid "<b>_Use authentication</b>"
+#~ msgstr "<b>_Користи проверка</b>"
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP детали за прокси"
+#~ msgid "Ignored Hosts"
+#~ msgstr "Игнорирани хостови"
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Преференци на мрежен proxy"
+#~ msgid "Proxy Configuration"
+#~ msgstr "Конфигурација на прокси"
+#~ msgid "U_sername:"
+#~ msgstr "Кори_сничко име:"
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Безбеден HTTP прокси:"
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - Advanced Linux Sound Architecture"
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART Sound Daemon"
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ESD - Enlightened Sound Daemon"
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - Open Sound System"
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "PulseAudio сервер за звук"
+#~ msgid "Silence"
+#~ msgstr "Тишина"
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "- Преференци за звук"
+#~ msgid "<b>Alerts and Sound Effects</b>"
+#~ msgstr "Известувања и звучни ефекти"
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>Аудио конференции</b>"
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>Стандарден миксер</b>"
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Музика и филмови</b>"
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>Системски звуци</b>"
+#~ msgid "<b>Sound Theme</b>"
+#~ msgstr "<b>Звучна тема</b>"
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">Тестирам...</span>"
+#~ msgid "Click OK to finish."
+#~ msgstr "Кликни на „Во ред“ за крај"
+#~ msgid "Play _sound effects when buttons are clicked"
+#~ msgstr "Пуштај_звучни ефекти кога се кликаат копчињата"
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+#~ msgstr ""
+#~ "Изберете го уредот и лизгачите за контрола со тастатура. Со помош на "
+#~ "копчињата Shift и Control можете да изберете повеќе лизгачи."
+#~ msgid "So_und playback:"
+#~ msgstr "Пу_штање на звук:"
+#~ msgid "Sou_nd capture:"
+#~ msgstr "Сни_мање на звук:"
+#~ msgid "Sounds"
+#~ msgstr "Звуци"
+#~ msgid "Testing Pipeline"
+#~ msgstr "Pipeline за тестирање"
+#~ msgid "_Play alerts and sound effects"
+#~ msgstr "_Пуштај известувања и звучни ефекти"
+#~ msgid "_Sound playback:"
+#~ msgstr "_Пуштање на звук:"
+#~ msgctxt "Sound event"
+#~ msgid "Windows and Buttons"
+#~ msgstr "Прозорци и копчиња"
+#~ msgctxt "Sound event"
+#~ msgid "Button clicked"
+#~ msgstr "Кликнато е копче"
+#~ msgctxt "Sound event"
+#~ msgid "Toggle button clicked"
+#~ msgstr "Кликнато е копчето за менување"
+#~ msgctxt "Sound event"
+#~ msgid "Window maximized"
+#~ msgstr "Прозорецот е максимизиран"
+#~ msgctxt "Sound event"
+#~ msgid "Window unmaximized"
+#~ msgstr "Прозорецот е вратен"
+#~ msgctxt "Sound event"
+#~ msgid "Window minimised"
+#~ msgstr "Прозорецот е минимизиран"
+#~ msgctxt "Sound event"
+#~ msgid "Desktop"
+#~ msgstr "Работна површина"
+#~ msgctxt "Sound event"
+#~ msgid "Logout"
+#~ msgstr "Одјава"
+#~ msgctxt "Sound event"
+#~ msgid "Empty trash"
+#~ msgstr "Испразни ѓубре"
+#~ msgctxt "Sound event"
+#~ msgid "Long action completed (download, CD burning, etc.)"
+#~ msgstr "Завршено е долго дејство (преземање, снимање на CD, итн.)"
+#~ msgctxt "Sound event"
+#~ msgid "Alerts"
+#~ msgstr "Известувања"
+#~ msgctxt "Sound event"
+#~ msgid "Information or question"
+#~ msgstr "Информација или прашање"
+#~ msgctxt "Sound event"
+#~ msgid "Error"
+#~ msgstr "Грешка"
+#~ msgid "Custom..."
+#~ msgstr "Сопствено..."
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr ""
+#~ "Не можам да ја подигнам апликацијата за преференци за Вашиот менаџер за "
+#~ "прозорци"
+#~ msgid "C_ontrol"
+#~ msgstr "C_ontrol"
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "С_упер (или \"Windows лого\")"
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Копче за движење</b>"
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Дејствие на лентата со наслов</b>"
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Избор на прозорец</b>"
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "За преместување на прозорец, стиснете и држете го ова копче и фатете го "
+#~ "прозорецот:"
+#~ msgid "Window Preferences"
+#~ msgstr "Преференци за прозорец"
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Двоен клик на лентата со наслов за изведување на оваа акција:"
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Интервал пред подигање"
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Подигни ги избраните прозорци после некој интервал"
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Избирај прозорци кога глушецот поминува преку нив"
+#~ msgid "Set your window properties"
+#~ msgstr "Поставете ги својствата за прозорците"
+#~ msgid "Windows"
+#~ msgstr "Прозорци"
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>Старт %s</b>"
+#~ msgid "Upgrade"
+#~ msgstr "Надгради"
+#~ msgid "Uninstall"
+#~ msgstr "Деинсталирај"
+#~ msgid "Add to Favorites"
+#~ msgstr "Додај во обележувачи"
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Отстрани од програмите кои се стартуваат при подигнување"
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Додај во програмите кои се стартуваат при подигнување"
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>Не беа пронајдени совпаѓања.</b> </span><span>\n"
+#~ "\n"
+#~ " Вашиот филтер \"<b>%s</b>\" не се совпадна со ниеден предмет.</span>"
+#~ msgid "New Spreadsheet"
+#~ msgstr "Нова табеларна пресметка"
+#~ msgid "New Document"
+#~ msgstr "Нов документ"
+#~ msgid "Home"
+#~ msgstr "Дома"
+#~ msgid "Documents"
+#~ msgstr "Документи"
+#~ msgid "File System"
+#~ msgstr "Датотечен систем"
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Отвори</b>"
+#~ msgid "Move to Trash"
+#~ msgstr "Премести во ѓубре"
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "Ако избришете предмет, тој ќе биде трајно изгубен."
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>Отвори со „%s“</b>"
+#~ msgid "Open in File Manager"
+#~ msgstr "Отвори во менаџер на датотеки"
+#~ msgid "?"
+#~ msgstr "?"
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Денес %l:%M %p"
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "Вчера %l:%M %p"
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%b %d %l:%M %p"
+#~ msgid "%b %d %Y"
+#~ msgstr "%b %d %Y"
+#~ msgid "Find Now"
+#~ msgstr "Пребарај сега"
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Отвори го „%s“</b>"
+#~ msgid "Remove from System Items"
+#~ msgstr "Отстрани од предметите на системот"
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "Менаџерот за прозорци „%s“ не е регистриран како алатка за конфигурирање\n"
+#~ msgid "Maximize Vertically"
+#~ msgstr "Максимизирај вертикално"
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Максимизирај хоризонтално"
+#~ msgid "key not found [%s]\n"
+#~ msgstr "клучот не е пронајден [%s]\n"
+#~ msgid "Groups"
+#~ msgstr "Групи"
+#~ msgid "Common Tasks"
+#~ msgstr "Чести задачи"
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Затвори го контролниот центар кога е активирана задача"
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr ""
+#~ "Излези од школката при извршување на дејството за додавање или извршување"
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Излези од школката при извршување на десјтвото за помош"
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Излези од школката при извршување на дејството за стартување"
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr ""
+#~ "Излези од школката при извршувањето на деството на надрадување или "
+#~ "деинсталирање"
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr ""
+#~ "Одредува дали да се затвори школката кога се извршува дејството за помош."
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr ""
+#~ "Одредува дали да се затвори школката кога се извршува дејството за "
+#~ "подигнување."
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "Одредува дали да се затвори школката кога се извршува дејството за "
+#~ "додавање или отстранување."
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "Одредува дали да се затвори школката кога се извршува дејството за "
+#~ "надградување или деинсталирање."
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "Имиња на задачи поврзани со .desktop датотеките"
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "Име на задача кое ќе биде прикажано во контролниот центар проследено со "
+#~ "одделувачот \";\"и потоа името на .desktop датотеката на кое се однесува "
+#~ "пуштањето на таа задача."
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[Промени ја темата;gtk-theme-selector.desktop,Постави преферирани "
+#~ "апликации;default-applications.desktop,Додај печатач;gnome-cups-manager."
+#~ "desktop]"
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "ако е штиклирано контролниот центар ќе се затвори кога е актвирана Честа "
+#~ "задача."
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Алатка за конфигурирање на GNOME"
+#~ msgid "_Postpone Break"
+#~ msgstr "_Одложи пауза"
+#~ msgid "/_Preferences"
+#~ msgstr "/_Преференци"
+#~ msgid "/_About"
+#~ msgstr "/_За"
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Направи пауза"
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d минута до следната пауза"
+#~ msgstr[1] "%d минута до следната пауза"
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Помалку од една минута до следната пауза"
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Не можам да го подигнам дијалогот на својствата за куцачката пауза со "
+#~ "следниве грешки: %s"
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Напишано од Richard Hult <richard@imendio.com>"
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Eye candy додадено од Андерс Карлсон"
+#~ msgid "A computer break reminder."
+#~ msgstr "Потсетувач за компјутерски паузи"
+#~ msgid "translator-credits"
+#~ msgstr "Арангел Ангов <arangel@linux.net.mk>"
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Не проверувај дали постои површината за известување"
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Куцачкиот монитор ја користи областа за известување за да прикаже "
+#~ "информации. Изгледа дека немате област за известување на вашиот панел. "
+#~ "Можете да ја додадете со десен клик на Вашиот панел и со избирање на "
+#~ "'Додај на панел', 'Област за известување' и кликнување на копчето 'Додај'."
+

--- a/po/ml.po
+++ b/po/ml.po
@@ -17,9 +17,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ml\n"
-"Report-Msgid-Bugs-To: https://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N"
-"+L10N&component=general\n"
-"POT-Creation-Date: 2017-08-19 14:32+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2017-08-20 23:21+0530\n"
 "Last-Translator: Anish Sheela <aneesh.nl@gmail.com>\n"
 "Language-Team: Swatantra Malayalam Computing <discuss@lists.smc.org.in>\n"
@@ -31,7057 +30,7771 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "X-Project-Style: gnome\n"
 
-#: ../panels/background/background.ui.h:1
-msgid "_Background"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "പ്രയോഗങ്ങള്‍"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "ഒരു പ്രയോഗങ്ങളും കണ്ടില്ല"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "പിപിഡി ഫയല്‍ ഇന്‍സ്റ്റാള്‍ ചെയ്യുക…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "തുറക്കുക (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "വിശദവിവരങ്ങള്‍ കാണുക (_V)"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "തെരച്ചില്‍"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "നിര്‍ജ്ജീവമാക്കിയ"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "അറിയിപ്പുകള്‍ (_N)"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "_അറിയിപ്പുകള്‍ കാണിയ്ക്കുക"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "പശ്ചാത്തലം (_B)"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "ദിനം മുഴുവന്‍ മാറിക്കൊണ്ടിരിക്കും"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "_Lock Screen"
-msgstr "പൂട്ടിയ സ്ക്രീന്‍ (_L)"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "തിരചിത്രങ്ങള്‍"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "ടൈല്‍"
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
 
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "വലിപ്പം മാറ്റുക"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "മദ്ധ്യത്തില്‍"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "അളവു്"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "നിറക്കുക"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "സ്പാന്‍"
-
-#: ../panels/background/cc-background-chooser-dialog.c:430
-msgid "Wallpapers"
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
 msgstr "പശ്ചാത്തലചിത്രങ്ങള്‍"
 
-#: ../panels/background/cc-background-chooser-dialog.c:439
-msgid "Colors"
-msgstr "നിറങ്ങള്‍"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:476
-msgid "Select Background"
-msgstr "പശ്ചാത്തലം തെരഞ്ഞെടുക്കുക"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "ശബ്ദം"
 
-#: ../panels/background/cc-background-chooser-dialog.c:504
-msgid "Pictures"
-msgstr "ചിത്രങ്ങള്‍"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:536
-msgid "No Pictures Found"
-msgstr "ചിത്രങ്ങളൊന്നും കണ്ടില്ല"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "എളുപ്പവഴികള്‍"
 
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:554 ../panels/search/cc-search-locations-dialog.c:302
-msgid "Home"
-msgstr "തട്ടകം"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "കീബോര്‍ഡ് എളുപ്പവഴിയൊന്നും കണ്ടില്ല"
 
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:566
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "താങ്കൾക്ക് താങ്കളുടെ %s അറയിലേക്ക് ചിത്രങ്ങൾ ചേർക്കാം. അവ ഇവിടെ ദൃശ്യമാവുന്നതാണ്."
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s ക്യാമറ"
 
-#: ../panels/background/cc-background-chooser-dialog.c:573 ../panels/color/cc-color-panel.c:225
-#: ../panels/color/cc-color-panel.c:963 ../panels/color/color-calibrate.ui.h:2 ../panels/color/color.ui.h:30
-#: ../panels/common/language-chooser.ui.h:3 ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:181 ../panels/network/connection-editor/vpn-helpers.c:310
-#: ../panels/network/net-device-wifi.c:1318 ../panels/network/net-device-wifi.c:1398
-#: ../panels/network/net-device-wifi.c:1633 ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/new-printer-dialog.ui.h:3 ../panels/printers/pp-details-dialog.c:319
-#: ../panels/privacy/cc-privacy-panel.c:1049 ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2 ../panels/search/cc-search-locations-dialog.c:642
-#: ../panels/sharing/cc-sharing-panel.c:375 ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/join-dialog.ui.h:2 ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264 ../panels/user-accounts/um-photo-dialog.c:94
-#: ../panels/user-accounts/um-photo-dialog.c:221 ../panels/user-accounts/um-user-panel.c:644
-#: ../panels/user-accounts/um-user-panel.c:662
-msgid "_Cancel"
-msgstr "_റദ്ദാക്കുക"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../panels/background/cc-background-chooser-dialog.c:574
-msgid "_Select"
-msgstr "_തെരഞ്ഞെടുക്കുക"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "മൈക്രോഫോണ്‍ വോള്യം"
 
-#: ../panels/background/cc-background-item.c:203
-msgid "multiple sizes"
-msgstr "അനവധി വ്യാപ്തികള്‍"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:207
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
 
-#: ../panels/background/cc-background-item.c:333
-msgid "No Desktop Background"
-msgstr "പണിയിട പശ്ചാത്തലം ലഭ്യമല്ല"
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
 
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "നിലവിലുള്ള പശ്ചാതലം"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "അടക്കം ചെയ്ത വെബ്ക്യാം"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Back­ground"
-msgstr "പശ്ചാത്തലം"
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:3
-msgid "Change your background image to a wallpaper or photo"
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്ല"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "വേറേ തെരഞ്ഞ് നോക്കുക"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "പ്രദര്‍ശന രീതി"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "ലിങ്കിന്റെ വേഗത"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+#, fuzzy
+msgid "Reset"
+msgstr "വീണ്ടും തുടങ്ങുക"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "പ്രയോഗങ്ങള്‍"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>തുറക്കുക</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "_രീതി:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "സഹജമായ"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "പശ്ചാത്തലം (_B)"
+
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "പ്രിന്റര്‍ ചേര്‍ക്കുക…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "ഫ്രാന്‍സ്"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "നിങ്ങളുടെ പശ്ചാത്തലചിത്രത്തെ ചുമർചിത്രമോ അല്ലെങ്കിൽ ചിത്രമോ ആയി മാറ്റുക"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:5
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "ചുമര്‍ചിത്രം;സ്ക്രീന്‍;പണിയിടം;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:268
-msgid "Turn Off Airplane Mode"
-msgstr "വിമാന മോഡ് മാറ്റുക"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "സജ്ജമാക്കുക (_E)"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:334
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "ബ്ലൂടൂത്ത് കണ്ടില്ല"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:334
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "ബ്ലുടൂത്ത് ഉപയോഗിക്കാന്‍ ഒരു ഡോങ്കിള്‍ കുത്തുക."
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:335
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "ബ്ലൂടൂത് പ്രവര്‍ത്തനരഹിതമാക്കി"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:335
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:336
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "വിമാന മോഡ് സജ്ജമാണ്"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:336
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "വിമാന മോഡില്‍ ബ്ലൂടൂത്ത് പ്രവര്‍ത്തന രഹിതമാക്കും."
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:337
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "വിമാന മോഡ് മാറ്റുക"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
 msgstr "ഹാര്‍ഡ്‍വെയര്‍ വിമാന മോഡ് സജ്ജമാണ്"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:337
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "ബ്ലൂടൂത്ത് സജ്ജമാക്കാന്‍ വിമാന മോഡ് സ്വിച്ച് ഓഫ് ചെയ്യുക"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
-msgid "Blue­tooth"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
 msgstr "ബ്ലൂടൂത്ത്"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:3
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "ബ്ലുടൂത്ത് ഓണ്‍ ഓഫ് ആക്കിയതിനു ശേഷം ഉപകരണം കണക്ട് ചെയ്യുക"
 
-#. Translators: those are keywords for the bluetooth control-center panel
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:5
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "ക്രമീകരണ ഉപകരണം ചതുരത്തിന്റെ മുകളില്‍ വെച്ച് “തുടങ്ങുക” അമര്‍ത്തുക"
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "ബ്ലൂടൂത് പ്രവര്‍ത്തനരഹിതമാക്കി"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
-msgid "Move your calibration device to the calibrate position and press “Continue”"
-msgstr "നിങ്ങളുടെ ക്രമീകരണ ഉപകരണം ക്രമീകരിക്കാന്‍ സജ്ജമാക്കിയിട്ട് “തുടരുക” അമര്‍ത്തുക"
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "ഓഡിയോ റിക്കോര്‍ഡ് ചെയ്യുന്നില്ല അല്ലെങ്കില്‍ നിലവില്‍ ഒരു പ്രയോഗവും പ്രവര്‍ത്തിക്കുന്നില്ല"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid "Move your calibration device to the surface position and press “Continue”"
-msgstr "നിങ്ങളുടെ ക്രമീകരണ ഉപകരണം ഉപരിതലം ആക്കിയിട്ട് “തുടരുക” അമര്‍ത്തുക"
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "ലാപ്പ്ടോപ്പ് അടയ്ക്കു"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "വീണ്ടെടുക്കാനാകാത്ത ഒരു ആന്തരിക പിശകു് ഉണ്ടായിരിക്കുന്നു."
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "കൂടുതല്‍ ചിത്രങ്ങള്‍ക്ക് വേണ്ടി ബ്രൗസ് ചെയ്യുക"
 
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "ക്രമീകരണത്തിന് വേണ്ടിയുള്ള ഉപകരണങ്ങള്‍ സ്ഥാപിച്ചിട്ടില്ല."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "പ്രൊഫൈല്‍ ഉണ്ടാക്കാനായില്ല."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "തന്ന വെള്ളബിന്ദു ഇതില്‍ നിന്ന് കിട്ടില്ല."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "പൂർത്തിയായി!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "ക്രമീകരണം പരാജയപ്പെട്ടു!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "താങ്കള്‍ക്ക് ക്രമീകരണ ഉപകരണം മാറ്റാം."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "ചെയ്തുകൊണ്ടിരിക്കുമ്പോള്‍ ക്രമീകരണ ഉപകരണം മാറ്റരുത്"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "ലാപ്ടോപ്പ് സ്ക്രീന്‍"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "അടക്കം ചെയ്ത വെബ്ക്യാം"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s മോണിറ്റര്‍"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s സ്കാനര്‍"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s ക്യാമറ"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s അച്ചടിയന്ത്രം"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s വെബ്കാം"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s -ല്‍ നിറം കൈകാര്യം ചെയ്യുന്നത് പ്രവര്‍ത്തന സജ്ജമാക്കുക"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s -നുള്ള വര്‍ണ്ണ രൂപരേഖ കാണിക്കുക"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:323
-msgid "Not calibrated"
-msgstr "ഒത്തുനോക്കാത്തതു്"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:141
-msgid "Default: "
-msgstr "സഹജമായ: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:149
-msgid "Colorspace: "
-msgstr "കളര്‍സ്പേസ്:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:156
-msgid "Test profile: "
-msgstr "പരീക്ഷണ പ്രൊഫൈല്‍:"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:223
-msgid "Select ICC Profile File"
-msgstr "തുറക്കുന്നതിനായി ഐസിസി പ്രൊഫൈല്‍ ഫയല്‍ തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/color/cc-color-panel.c:226
-msgid "_Import"
-msgstr "ഇംപോര്‍ട്ട് ചെയ്യുക (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:237
-msgid "Supported ICC profiles"
-msgstr "പിന്തുണയുള്ള ഐസിസി പ്രൊഫൈലുകള്‍"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:244 ../panels/network/wireless-security/eap-method-fast.c:417
-msgid "All files"
-msgstr "എല്ലാ ഫയലുകളും"
-
-#: ../panels/color/cc-color-panel.c:583
-msgid "Screen"
-msgstr "സ്ക്രീന്‍"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:908
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "ഫയല്‍ കയറ്റുന്നതില്‍ പരാജയം: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:922
-msgid "The profile has been uploaded to:"
-msgstr "പ്രൊഫെൽ അപ്പ്‌ലോഡ് ചെയ്യപെട്ടു:"
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Write down this URL."
-msgstr "ഈ URL എഴുതുക."
-
-#: ../panels/color/cc-color-panel.c:925
-msgid "Restart this computer and boot your normal operating system."
-msgstr "നിങ്ങളുടെ കമ്പ്യൂട്ടർ ഒരു സാധാരണ ബൂട്ടിങ്ങിൽ വീണ്ടും തുടങ്ങുക"
-
-#: ../panels/color/cc-color-panel.c:926
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "പ്രൊഫെൽ ഇൻസ്റ്റാൾ ചെയ്യുന്നതിനായി ബ്രൊസറിൽ URL ടെപ്പ് ചെയ്യുക."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:960
-msgid "Save Profile"
-msgstr "പ്രൊഫൈല്‍ സൂക്ഷിക്കുക"
-
-#: ../panels/color/cc-color-panel.c:964 ../panels/network/connection-editor/vpn-helpers.c:311
-msgid "_Save"
-msgstr "സൂക്ഷിക്കുക (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1324
-msgid "Create a color profile for the selected device"
-msgstr "തെരഞ്ഞെടുത്ത ഡിവൈസിനു് നിറമുള്ളൊരു പ്രൊഫൈല്‍ തയ്യാറാക്കുക"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
-msgid "The measuring instrument is not detected. Please check it is turned on and correctly connected."
-msgstr "അളക്കുന്ന ഉപകരണം ലഭ്യമല്ല. ഇതു് ഓണ്‍ ആണെന്നും ശരിയായി കണക്ട് ചെയ്തിട്ടുണ്ടെന്നും ഉറപ്പാക്കുക."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1373
-msgid "The measuring instrument does not support printer profiling."
-msgstr "അളക്കുന്ന ഉപകരണം പ്രിന്റര്‍ ഡയലോഗ് പിന്തുണയ്ക്കുന്നില്ല."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1384
-msgid "The device type is not currently supported."
-msgstr "ഡിവൈസ് തരം ഇപ്പോള്‍ പിന്തുണയ്ക്കുന്നില്ല."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "മാനക സ്പേസ്"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "പരീക്ഷണ പ്രൊഫൈല്‍"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "സ്വയം"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "കുറഞ്ഞ നിലവാരം"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "സാമാന്യ നിലവാരം"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "ഉയര്‍ന്ന നിലവാരം"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "സഹജമായ RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "സഹജമായ CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "സ്വതേയുള്ള ഗ്രേ"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "കമ്പനി തന്ന ക്രമീകരണ വിവരം"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "ഈ പ്രൊഫൈല്‍ വെച്ച് മുഴുവന്‍ സ്ക്രീന്‍ ഡിസ്പ്ലേ ക്രമീകരണം പറ്റില്ല"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "ഈ പ്രൊഫൈല്‍ കൃത്യമല്ലായിരിക്കാം‌"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "ഡിസ്പ്ലേ ക്രമീകരണം"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_റദ്ദാക്കുക"
+
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "തുടങ്ങുക (_S)"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "പുനരാരംഭിക്കുക (_R)"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8 ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_കഴിഞ്ഞു"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "സ്ക്രീന്‍ കാലിബ്രേഷന്‍"
 
-#: ../panels/color/color.ui.h:2
-msgid ""
-"Calibration will produce a profile that you can use to color manage your screen. The longer you spend on "
-"calibration, the better the quality of the color profile."
-msgstr ""
-"നിങ്ങളുടെ സ്ക്രീനിന്റെ നിറം കൈകാര്യം ചെയ്യാനുള്ള ഒരു പ്രൊഫൈല്‍ ക്രമീകരണം ഉണ്ടാക്കും. എത്ര നേരം ക്രമീകരിക്കാന്‍ ചിലവാക്കുന്നോ, അത്രയും "
-"നല്ലതായിരിക്കും നിറത്തിന്റെ പ്രൊഫൈല്‍."
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "കാലിബ്രേഷന്റെ ഗുണം"
 
-#: ../panels/color/color.ui.h:3
-msgid "You will not be able to use your computer while calibration takes place."
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"നിങ്ങളുടെ സ്ക്രീനിന്റെ നിറം കൈകാര്യം ചെയ്യാനുള്ള ഒരു പ്രൊഫൈല്‍ ക്രമീകരണം ഉണ്ടാക്കും. എത്ര നേരം "
+"ക്രമീകരിക്കാന്‍ ചിലവാക്കുന്നോ, അത്രയും നല്ലതായിരിക്കും നിറത്തിന്റെ പ്രൊഫൈല്‍."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
 msgstr "ക്രമീകരണം നടക്കുന്ന സമയം കമ്പ്യൂട്ടര്‍ ഉപയോഗിക്കാന്‍ പറ്റില്ല."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "നിലവാരം"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "ഏകദേശ സമയം"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "കാലിബ്രേഷന്റെ ഗുണം"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "ക്രമീകരണത്തിനുപയോഗിക്കേണ്ട സെന്‍സര്‍ തെരഞ്ഞെടുക്കുക."
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "ക്രമീകരണ ഉപകരണം"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "ബന്ധിപ്പിച്ചിരിക്കുന്ന ഡിസ്പ്ലേയുടെ തരം തെരഞ്ഞെടുക്കുക."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ക്രമീകരണത്തിനുപയോഗിക്കേണ്ട സെന്‍സര്‍ തെരഞ്ഞെടുക്കുക."
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "പ്രദര്‍ശന രീതി"
 
-#: ../panels/color/color.ui.h:13
-msgid "Select a display target white point. Most displays should be calibrated to a D65 illuminant."
-msgstr "ഡിസ്പ്ലേയ്ക്ക് കിട്ടേണ്ട വെള്ള സൂചിക തെരഞ്ഞെടുക്കുക. മിക്ക ഡിസ്പ്ലേകളും D65 തെളിച്ചത്തിലാണ് ക്രമീകരിക്കുന്നത്."
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "ബന്ധിപ്പിച്ചിരിക്കുന്ന ഡിസ്പ്ലേയുടെ തരം തെരഞ്ഞെടുക്കുക."
 
-#: ../panels/color/color.ui.h:14
+#: panels/color/cc-color-panel.ui:152
 msgid "Profile Whitepoint"
 msgstr "പ്രൊഫൈല്‍ വെള്ള സൂചിക"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:160
 msgid ""
-"Please set the display to a brightness that is typical for you. Color management will be most accurate at "
-"this brightness level."
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
 msgstr ""
-"താങ്കള്‍ക്ക് സൌകര്യമായ രീതിയിലേക്ക് ഡിസ്പ്ലേയുടെ തെളിച്ചം ക്രമീകരിക്കുക. നിറം ക്രമീകരണം ആ തെളിച്ചത്തിലായിരിക്കും ഏറ്റവും കൃത്യം."
+"ഡിസ്പ്ലേയ്ക്ക് കിട്ടേണ്ട വെള്ള സൂചിക തെരഞ്ഞെടുക്കുക. മിക്ക ഡിസ്പ്ലേകളും D65 തെളിച്ചത്തിലാണ് "
+"ക്രമീകരിക്കുന്നത്."
 
-#: ../panels/color/color.ui.h:16
-msgid "Alternatively, you can use the brightness level used with one of the other profiles for this device."
-msgstr "അല്ലെങ്കില്‍, ഈ ഉപകരണത്തിനുവേണ്ട വേറേ ഏതെങ്കിലും പ്രൊഫൈലുകള്‍ ഉപയോഗിക്കാം."
-
-#: ../panels/color/color.ui.h:17
+#: panels/color/cc-color-panel.ui:187
 msgid "Display Brightness"
 msgstr "ഡിസ്പ്ലേയുടെ തെളിച്ചം"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:195
 msgid ""
-"You can use a color profile on different computers, or even create profiles for different lighting conditions."
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
 msgstr ""
-"താങ്കള്‍ക്ക് ഈ നിറ പ്രൊഫൈല്‍ പല കമ്പ്യൂട്ടറുകള്‍ക്ക് വേണ്ടി ഉപയോഗിക്കുകയോ, പല പ്രകാശ സാഹചര്യങ്ങള്‍ക്കുവേണ്ടി പ്രൊഫൈലുകള്‍ ഉണ്ടാക്കുകയോ ചെയ്യാം."
+"താങ്കള്‍ക്ക് സൌകര്യമായ രീതിയിലേക്ക് ഡിസ്പ്ലേയുടെ തെളിച്ചം ക്രമീകരിക്കുക. നിറം ക്രമീകരണം ആ "
+"തെളിച്ചത്തിലായിരിക്കും ഏറ്റവും കൃത്യം."
 
-#: ../panels/color/color.ui.h:19
-msgid "Profile Name:"
-msgstr "പ്രൊഫൈല്‍ നാമം:"
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr "അല്ലെങ്കില്‍, ഈ ഉപകരണത്തിനുവേണ്ട വേറേ ഏതെങ്കിലും പ്രൊഫൈലുകള്‍ ഉപയോഗിക്കാം."
 
-#: ../panels/color/color.ui.h:20
+#: panels/color/cc-color-panel.ui:214
 msgid "Profile Name"
 msgstr "പ്രൊഫൈല്‍ നാമം"
 
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "പ്രൊഫൈല്‍ വിജയകരമായി ഉണ്ടാക്കിയിരിക്കുന്നു!"
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "പ്രൊഫൈല്‍ പക്‍ത്തുക"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "എഴുതാൻ കഴിയുന്ന ഒരു മാധ്യമം ആവശ്യം"
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "പ്രൊഫൈല്‍ കയറ്റുക"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "ഇന്റര്‍നെറ്റ് ബന്ധം വേണം"
-
-#: ../panels/color/color.ui.h:26
+#: panels/color/cc-color-panel.ui:222
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux\">GNU/Linux</a>, <a href=\"osx"
-"\">Apple OS X</a> and <a href=\"windows\">Microsoft Windows</a> systems useful."
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
 msgstr ""
-"<a href=\"linux\">ഗ്നു ലിനക്സ്</a>, <a href=\"osx\">ആപ്പിള്‍ ഒഎസ് എക്സ്</a> പിന്നെ <a href=\"windows\">മൈക്രോസോഫ്റ്റ് "
-"വിന്‍ഡോസ്</a> തുടങ്ങിയവയില്‍ എങ്ങനെ പ്രൊഫൈല്‍ ഉപയോഗിക്കണം എന്ന് അറിയുന്നത് നന്നായിരിക്കും."
+"താങ്കള്‍ക്ക് ഈ നിറ പ്രൊഫൈല്‍ പല കമ്പ്യൂട്ടറുകള്‍ക്ക് വേണ്ടി ഉപയോഗിക്കുകയോ, പല പ്രകാശ "
+"സാഹചര്യങ്ങള്‍ക്കുവേണ്ടി പ്രൊഫൈലുകള്‍ ഉണ്ടാക്കുകയോ ചെയ്യാം."
 
-#: ../panels/color/color.ui.h:27 ../panels/user-accounts/um-fingerprint-dialog.c:723
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "പ്രൊഫൈല്‍ നാമം:"
+
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "രത്നച്ചുരുക്കം"
 
-#: ../panels/color/color.ui.h:28
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "പ്രൊഫൈല്‍ വിജയകരമായി ഉണ്ടാക്കിയിരിക്കുന്നു!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "പ്രൊഫൈല്‍ പക്‍ത്തുക"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "എഴുതാൻ കഴിയുന്ന ഒരു മാധ്യമം ആവശ്യം"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">ഗ്നു ലിനക്സ്</a>, <a href=\"osx\">ആപ്പിള്‍ ഒഎസ് എക്സ്</a> പിന്നെ <a "
+"href=\"windows\">മൈക്രോസോഫ്റ്റ് വിന്‍ഡോസ്</a> തുടങ്ങിയവയില്‍ എങ്ങനെ പ്രൊഫൈല്‍ ഉപയോഗിക്കണം "
+"എന്ന് അറിയുന്നത് നന്നായിരിക്കും."
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "പ്രൊഫൈല്‍ ചേര്‍ക്കുക"
 
-#: ../panels/color/color.ui.h:29
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"പിഴവ് കണ്ടുപിടിച്ചു. പ്രൊഫൈല്‍ ശരിയായ രീതിയില്‍ പ്രവര്‍ത്തിക്കണമെന്നില്ല. <a href=\"\">കൂടുതല്‍ "
+"വിവരങ്ങള്‍.</a>"
+
+#: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
 msgstr "ഫയല്‍ ഇറക്കുക… (ഃഘ)"
 
-#: ../panels/color/color.ui.h:31 ../panels/network/connection-editor/net-connection-editor.c:519
-#: ../panels/printers/new-printer-dialog.ui.h:4 ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "_ചേര്‍ക്കുക"
 
-#: ../panels/color/color.ui.h:32
-msgid "Problems detected. The profile may not work correctly. <a href=\"\">Show details.</a>"
-msgstr "പിഴവ് കണ്ടുപിടിച്ചു. പ്രൊഫൈല്‍ ശരിയായ രീതിയില്‍ പ്രവര്‍ത്തിക്കണമെന്നില്ല. <a href=\"\">കൂടുതല്‍ വിവരങ്ങള്‍.</a>"
-
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "ഓരോ ഡിവൈസിനും കൈകാര്യം ചെയ്യുന്നതിനായി ഏറ്റവും പുതിയ നിറത്തിനുള്ള പ്രൊഫൈല്‍ ആവശ്യമുണ്ടു്."
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "കൂടുതല്‍ പഠിക്കുക"
 
-#: ../panels/color/color.ui.h:35
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "നിറം കൈകാര്യം ചെയ്യന്നതിനെപ്പറ്റി കൂടുതല്‍ അറിയുക"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "എല്ലാ ഉപയോക്താക്കള്‍ക്കും സജ്ജമാക്കുക (_S)"
 
-#: ../panels/color/color.ui.h:37
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "ഈ കമ്പ്യൂട്ടറിലുള്ള എല്ലാ ഉപയോക്താക്കള്‍ക്കും ഈ പ്രൊഫൈല്‍ സജ്ജമാക്കുക"
 
-#: ../panels/color/color.ui.h:38
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "സജ്ജമാക്കുക (_E)"
 
-#: ../panels/color/color.ui.h:39
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "പ്രൊഫൈല്‍ ചേര്‍ക്കുക (_A)"
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "ഒത്തുനോക്കുക… (_C)"
 
-#: ../panels/color/color.ui.h:41
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "ഉപകരണം ഒത്തുനോക്കുക"
 
-#: ../panels/color/color.ui.h:42
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "ഈ പ്രൊഫൈല്‍ ഉപേക്ഷിക്കുക (_R)"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "വിശദവിവരങ്ങള്‍ കാണുക (_V)"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "നിറം ക്രമീകരിക്കാന്‍ പറ്റുന്ന ഉപകരണങ്ങളൊന്നും കണ്ടെത്താനായില്ല"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "പ്രൊജക്ടര്‍"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "പ്ലാസ്മാ"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL backlight)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED backlight)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (white LED backlight)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Wide gamut LCD (CCFL backlight)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Wide gamut LCD (RGB LED backlight)"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "കൂടിയ"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 മിനിട്ടുകള്‍"
 
-#: ../panels/color/color.ui.h:57
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "ഇടത്തരം"
 
-#: ../panels/color/color.ui.h:58 ../panels/power/power.ui.h:2 ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 മിനിറ്റുകള്‍"
 
-#: ../panels/color/color.ui.h:59
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "കുറഞ്ഞ"
 
-#: ../panels/color/color.ui.h:60 ../panels/power/power.ui.h:1
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 മിനിട്ടുകള്‍"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "ഡിസ്പ്ലേക്ക് സ്വതവേയുള്ള"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (അച്ചടിയും പ്രസിദ്ധീകരണങ്ങളും)"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (ഫോട്ടോയും ഗ്രാഫിക്സും)"
 
-#: ../panels/color/color.ui.h:65
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Co­lor"
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
 msgstr "നിറം"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:3
-msgid "Calibrate the color of your devices, such as displays, cameras or printers"
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "ക്യാമറ , പ്രിന്റ്റർ, ഡിസ്സ്പ്ലേ ഉപകരണങ്ങളുടെ നിറം കാലിബ്രേറ്റ് ചെയ്യുക"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:5
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Color;ICC;Profile;Calibrate;Printer;Display;"
 
-#: ../panels/common/cc-common-language.c:323
-msgid "Other…"
-msgstr "മറ്റുളളവ…"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "ഒരു ഭാഷ തെരഞ്ഞെടുക്കുക"
 
-#: ../panels/common/cc-language-chooser.c:124 ../panels/region/cc-format-chooser.c:269
-#: ../panels/region/cc-input-chooser.c:169
-msgid "More…"
-msgstr "കൂടുതൽ..."
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_തെരഞ്ഞെടുക്കുക"
 
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "ഒരു ഭാഷയും കണ്ടില്ല"
 
-#: ../panels/common/cc-util.c:127 ../panels/network/connection-editor/ce-page-details.c:106
-msgid "Today"
-msgstr "ഇന്നു്"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "കൂടുതൽ..."
 
-#: ../panels/common/cc-util.c:131 ../panels/network/connection-editor/ce-page-details.c:108
-msgid "Yesterday"
-msgstr "ഇന്നലെ"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "_അണ്‍ലോക്ക് ചെയ്യുക"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: ../panels/common/language-chooser.ui.h:1
-msgid "Language"
-msgstr "ഭാഷ"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "കാഴ്ചയുടെ വലിപ്പം കൂട്ടുക"
 
-#: ../panels/datetime/big.ui.h:1 ../panels/datetime/little.ui.h:1 ../panels/datetime/middle.ui.h:1
-#: ../panels/datetime/ydm.ui.h:1
-msgid "Day"
-msgstr "ദിവസം"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "സമയം"
 
-#: ../panels/datetime/big.ui.h:2 ../panels/datetime/little.ui.h:2 ../panels/datetime/middle.ui.h:2
-#: ../panels/datetime/ydm.ui.h:2
-msgid "Month"
-msgstr "മാസം"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../panels/datetime/big.ui.h:3 ../panels/datetime/little.ui.h:3 ../panels/datetime/middle.ui.h:3
-#: ../panels/datetime/ydm.ui.h:3
-msgid "Year"
-msgstr "വര്‍ഷം"
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "കാഴ്ചയുടെ വലിപ്പം കുറയ്ക്കുക"
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:339
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:344
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:522
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:552
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:560
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:565
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:570
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:575
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "ജനുവരി"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "ഫെബ്രുവരി"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "മാര്‍ച്ച്"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "ഏപ്രില്‍"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "മേയ്"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "ജൂണ്‍"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "ജൂലൈ"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "ഓഗസ്റ്റ്"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "സെപ്റ്റംബര്‍"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "ഒക്റ്റോബര്‍"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "നവംബര്‍"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "ഡിസംബര്‍"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/datetime/datetime.ui.h:13 ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "തീയതിയും സമയവും"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "മണിക്കൂർ"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "വര്‍ഷം"
 
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr ":"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "മാസം"
 
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "മിനിട്ട്"
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "ജനുവരി"
 
-#: ../panels/datetime/datetime.ui.h:18
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ഫെബ്രുവരി"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "മാര്‍ച്ച്"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "ഏപ്രില്‍"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "മേയ്"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "ജൂണ്‍"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "ജൂലൈ"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "ഓഗസ്റ്റ്"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "സെപ്റ്റംബര്‍"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ഒക്റ്റോബര്‍"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "നവംബര്‍"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ഡിസംബര്‍"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "ദിവസം"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "സമയ മേഘല"
 
-#: ../panels/datetime/datetime.ui.h:19
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "നഗരത്തിനായി തിരയുക"
 
-#: ../panels/datetime/datetime.ui.h:20
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "തീയതിയും സമയവും സ്വയം കണ്ടെത്തുക"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "ഇന്റര്‍നെറ്റ് ബന്ധം ആവശ്യമുണ്ട്"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "തീയതിയും സമയവും"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "സമയ മേഘല സ്വയം കണ്ടെത്തുക"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Date & _Time"
-msgstr "തീയതിയും സമയവും"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "ഇന്റര്‍നെറ്റ് ബന്ധം ആവശ്യമുണ്ട്"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "പ്രവര്‍ത്തന സജ്ജമാക്കിയിരിക്കുന്നു"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "സമയ മേഘല (_Z)"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ഘടികാരദിശയില്‍ "
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "സമയ ശൈലികള്‍"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "24-hour"
-msgstr "24-മണിക്കൂര്‍"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "AM / PM"
-msgstr "AM/PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "തിയ്യതികള്‍"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "ദ്വീതീയ"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_കലണ്ടര്‍"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "സംഖ്യകള്‍"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "സമയം, തിയ്യതി, സമയമേഖലയടക്കം മാറ്റുക"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:5
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "സിസ്റ്റത്തിന്റെ സമയം, തീയതി മാറ്റുക"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "സമയം അല്ലെങ്കില്‍ തീയതി സജ്ജീകരണങ്ങള്‍ മാറ്റുന്നതിനായി, ആധികാരികത ഉറപ്പാക്കുക."
 
-#: ../panels/display/cc-display-panel.c:752
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "ലാന്‍ഡ്സ്കെയിപ്പ്"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_വെബ്"
 
-#: ../panels/display/cc-display-panel.c:755
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "പൊട്രെയിറ്റ് വലത്"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_മെയില്‍"
 
-#: ../panels/display/cc-display-panel.c:758
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "പൊട്രെയിറ്റ് ഇടത്"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_കലണ്ടര്‍"
 
-#: ../panels/display/cc-display-panel.c:761
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "തിരിഞ്ഞ ലാന്‍ഡ്സ്കേപ്"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "സം_ഗീതം"
 
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/display/cc-display-panel.c:807 ../panels/display/cc-display-panel.c:857
-#: ../panels/printers/pp-options-dialog.c:558
-msgid "Orientation"
-msgstr "സംവേദനം"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_ചലചിത്രം"
 
-#: ../panels/display/cc-display-panel.c:904 ../panels/display/cc-display-panel.c:956
-#: ../panels/display/cc-display-panel.c:1721 ../panels/display/cc-display-panel.c:1767
-#: ../panels/printers/pp-options-dialog.c:87
-msgid "Resolution"
-msgstr "ദൃശ്യസൂക്ഷ്മത"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_ചിത്രങ്ങള്‍"
 
-#: ../panels/display/cc-display-panel.c:1001 ../panels/display/cc-display-panel.c:1072
-msgid "Refresh Rate"
-msgstr "പുതുക്കല്‍ ആവൃത്തി"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "സഹജമായ പ്രയോഗങ്ങള്‍"
 
-#: ../panels/display/cc-display-panel.c:1198
-msgid "Scale"
-msgstr "വലിപ്പം മാറ്റുക"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "സഹജമായ പ്രയോഗങ്ങള്‍ ക്രമീകരിക്കുക"
 
-#: ../panels/display/cc-display-panel.c:1237
-msgid "Adjust for TV"
-msgstr "ടി.വി. യ്ക്ക് വേണ്ടി ശരിയാക്കുക"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;"
 
-#: ../panels/display/cc-display-panel.c:1432 ../panels/display/cc-display-panel.c:1478
-msgid "Primary Display"
-msgstr "പ്രധാന ഡിസ്പ്ലേ"
-
-#: ../panels/display/cc-display-panel.c:1516
-msgid "Display Arrangement"
-msgstr "പ്രദര്‍ശന സജ്ജികരണം"
-
-#: ../panels/display/cc-display-panel.c:1517
-msgid "Drag displays to match your setup. The top bar is placed on the primary display."
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
 msgstr ""
 
-#: ../panels/display/cc-display-panel.c:1927
-msgid "Display Mode"
-msgstr "പ്രദര്‍ശന രീതി"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/display/cc-display-panel.c:1939
-msgid "Join Displays"
-msgstr "പ്രദര്‍ശനങ്ങള്‍ ഒരുമിപ്പിക്കുക"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/display/cc-display-panel.c:1942
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_കംപ്യൂട്ടറില്‍ സൂക്ഷിക്കുക"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "പുറകോട്ട്"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "ബ്ലൂടൂത്ത് പ്രവര്‍ത്തന രഹിതമാക്കിയിരിക്കുന്നു"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "ഒറ്റ പ്രദര്‍ശനം"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "മിറര്‍"
 
-#: ../panels/display/cc-display-panel.c:1944
-msgid "Single Display"
-msgstr "ഒറ്റ പ്രദര്‍ശനം"
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
 
-#: ../panels/display/cc-display-panel.c:2733
-msgid "Apply Changes?"
-msgstr "മാറ്റങ്ങള്‍ സൂക്ഷിക്കട്ടെ?"
-
-#: ../panels/display/cc-display-panel.c:2737 ../panels/keyboard/cc-keyboard-panel.c:188
-#: ../panels/keyboard/shortcut-editor.ui.h:9 ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-msgid "Cancel"
-msgstr "റദ്ദാക്കുക"
-
-#: ../panels/display/cc-display-panel.c:2743
-msgid "Apply"
-msgstr "സൂക്ഷിക്കു"
-
-#: ../panels/display/cc-display-panel.c:3110
-#, c-format
-msgid "%.1lf Hz"
-msgstr "%.1lf Hz"
-
-#. TRANSLATORS: the state of the night light setting
-#: ../panels/display/cc-display-panel.c:3326 ../panels/notifications/cc-notifications-panel.c:293
-#: ../panels/power/cc-power-panel.c:1970 ../panels/power/cc-power-panel.c:1977
-#: ../panels/privacy/cc-privacy-panel.c:190 ../panels/privacy/cc-privacy-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:331 ../panels/universal-access/cc-ua-panel.c:712
-#: ../panels/universal-access/cc-ua-panel.c:725 ../panels/universal-access/cc-ua-panel.c:737
-#: ../panels/universal-access/cc-ua-panel.c:908
-msgid "On"
-msgstr "ഓണ്‍ "
-
-#: ../panels/display/cc-display-panel.c:3326 ../panels/network/net-proxy.c:54
-#: ../panels/notifications/cc-notifications-panel.c:293 ../panels/power/cc-power-panel.c:1964
-#: ../panels/power/cc-power-panel.c:1975 ../panels/privacy/cc-privacy-panel.c:190
-#: ../panels/privacy/cc-privacy-panel.c:257 ../panels/universal-access/cc-ua-panel.c:331
-#: ../panels/universal-access/cc-ua-panel.c:712 ../panels/universal-access/cc-ua-panel.c:725
-#: ../panels/universal-access/cc-ua-panel.c:737 ../panels/universal-access/cc-ua-panel.c:908
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Off"
-msgstr "ഓഫ്"
-
-#: ../panels/display/cc-display-panel.c:3347
-msgid "_Night Light"
-msgstr "രാത്രി വെളിച്ചം (_N)"
-
-#: ../panels/display/cc-display-panel.c:3454
-msgid "Could not get screen information"
-msgstr "സ്ക്രീന്‍ വിവരങ്ങള്‍ ലഭ്യമായില്ല"
-
-#. This cancels the redshift inhibit.
-#: ../panels/display/display.ui.h:2
-msgid "Restart Filter"
-msgstr "ഫില്‍റ്റര്‍ പുനരാരംഭിക്കുക"
-
-#. Inhibit the redshift functionality until the next day starts
-#: ../panels/display/display.ui.h:4
-msgid "Temporarily Disabled Until Tomorrow"
-msgstr "നാളെ വരെ തല്‍കാലം നിര്‍ത്തി"
-
-#: ../panels/display/display.ui.h:5
-msgid "Night light makes the screen color warmer. This can help to prevent eye strain and sleeplessness."
-msgstr "രാത്രി വെളിച്ചം സ്ക്രീന്‍ നിറത്തെ ചൂടാക്കി വെയ്കുന്നു. ഇത് കണ്ണിന്റെ ആയാസവും ഉറക്കമില്ലായ്മയും തടയാന്‍ സഹായിക്കുന്നു."
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "പ്രധാന ഡിസ്പ്ലേ"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: ../panels/display/display.ui.h:7
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "രാത്രി വെളിച്ചം"
 
-#: ../panels/display/display.ui.h:8
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "സംവേദനം"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "ദൃശ്യസൂക്ഷ്മത"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "പുതുക്കല്‍ ആവൃത്തി"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "ടി.വി. യ്ക്ക് വേണ്ടി ശരിയാക്കുക"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "വലിപ്പം മാറ്റുക"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "സ്വാഭാവികമായ സ്ക്രോളിങ്"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "രാത്രി വെളിച്ചം"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "നാളെ വരെ തല്‍കാലം നിര്‍ത്തി"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "ഫില്‍റ്റര്‍ പുനരാരംഭിക്കുക"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"രാത്രി വെളിച്ചം സ്ക്രീന്‍ നിറത്തെ ചൂടാക്കി വെയ്കുന്നു. ഇത് കണ്ണിന്റെ ആയാസവും ഉറക്കമില്ലായ്മയും "
+"തടയാന്‍ സഹായിക്കുന്നു."
+
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "ആസൂത്രണം"
 
-#: ../panels/display/display.ui.h:9
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "സൂര്യാസ്തമയം മുതല്‍ ഉദയം വരെ"
 
-#: ../panels/display/display.ui.h:10 ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:5 ../panels/network/net-proxy.c:56
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network-wifi.ui.h:26
-#: ../panels/privacy/cc-privacy-panel.c:217
-msgid "Manual"
-msgstr "മാനുവല്‍"
+#: panels/display/cc-night-light-page.ui:141
+#, fuzzy
+msgid "Manual Schedule"
+msgstr "ആസൂത്രണം"
 
-#: ../panels/display/display.ui.h:11
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "തവണ"
+
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "നിന്നും"
 
-#: ../panels/display/display.ui.h:12
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "മണിക്കൂർ"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "മിനിട്ട്"
+
 #. This is the short form for the time period in the morning
-#: ../panels/display/display.ui.h:14
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "AM"
 
 #. This is the short form for the time period in the afternoon
-#: ../panels/display/display.ui.h:16
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PM"
 
-#: ../panels/display/display.ui.h:17
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "വരെ"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Dis­plays"
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+#, fuzzy
+msgid "Displays"
 msgstr "പ്രദര്‍ശനങ്ങള്‍"
 
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:3
+#: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr "മോണിറ്ററുകളും പ്രൊജക്ടറുകളും എങ്ങനെ ഉപയോഗിക്കണമെന്ന് തെരഞ്ഞെടുക്കുക"
 
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:5
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;color;sunset;sunrise;"
-msgstr ""
-"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;color;sunset;sunrise;"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-overview-panel.c:381 ../panels/info/cc-info-overview-panel.c:468
-#: ../panels/network/panel-common.c:123
-msgid "Unknown"
-msgstr "അപരിചിതം"
-
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: ../panels/info/cc-info-overview-panel.c:476
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; Build ID: %s"
-
-#. translators: This is the type of architecture for the OS
-#: ../panels/info/cc-info-overview-panel.c:493
-#, c-format
-msgid "64-bit"
-msgstr "64-ബിറ്റ്"
-
-#. translators: This is the type of architecture for the OS
-#: ../panels/info/cc-info-overview-panel.c:496
-#, c-format
-msgid "32-bit"
-msgstr "32-ബീറ്റ്"
-
-#: ../panels/info/cc-info-overview-panel.c:800
-#, c-format
-msgid "Version %s"
-msgstr "പതിപ്പ് %s"
-
-#: ../panels/info/cc-info-panel.c:138
-msgid "Section"
-msgstr "വിഭാഗം"
-
-#: ../panels/info/cc-info-panel.c:147 ../panels/info/info.ui.h:1
-msgid "Overview"
-msgstr "അവലോകനം"
-
-#: ../panels/info/cc-info-panel.c:153 ../panels/info/info.ui.h:2
-msgid "Default Applications"
-msgstr "സഹജമായ പ്രയോഗങ്ങള്‍"
-
-#: ../panels/info/cc-info-panel.c:158 ../panels/info/info.ui.h:3
-msgid "Removable Media"
-msgstr "മാറ്റുവാന്‍ സാധ്യമാകുന്ന മീഡിയ"
-
-#: ../panels/info/cc-info-removable-media-panel.c:312
-msgid "Ask what to do"
-msgstr "എന്തു്  ചെയ്യണമെന്നു് ചോദിക്കുക"
-
-#: ../panels/info/cc-info-removable-media-panel.c:316
-msgid "Do nothing"
-msgstr "ഒരു പ്രവര്‍ത്തിയും ചെയ്യാതിരിക്കുക"
-
-#: ../panels/info/cc-info-removable-media-panel.c:320
-msgid "Open folder"
-msgstr "ഫോള്‍ഡര്‍ തുറക്കുക"
-
-#: ../panels/info/cc-info-removable-media-panel.c:411
-msgid "Other Media"
-msgstr "മറ്റു് മാധ്യമം"
-
-#: ../panels/info/cc-info-removable-media-panel.c:444
-msgid "Select an application for audio CDs"
-msgstr "പാട്ടു സി.ഡികള്‍ കേള്‍ക്കുന്നതിനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/info/cc-info-removable-media-panel.c:445
-msgid "Select an application for video DVDs"
-msgstr "വീഡിയോ സി.ഡികള്‍ കേള്‍ക്കുന്നതിനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/info/cc-info-removable-media-panel.c:446
-msgid "Select an application to run when a music player is connected"
-msgstr "ഒരു മ്യൂസിക് പ്ലേയര്‍ ഘടിപ്പിക്കുമ്പോള്‍ പ്രവര്‍ത്തിപ്പിയ്ക്കുവാനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/info/cc-info-removable-media-panel.c:447
-msgid "Select an application to run when a camera is connected"
-msgstr "ഒരു ക്യാമറാ ഘടിപ്പിക്കുമ്പോള്‍ പ്രവര്‍ത്തിപ്പിയ്ക്കുവാനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/info/cc-info-removable-media-panel.c:448
-msgid "Select an application for software CDs"
-msgstr "സോഫ്റ്റ്‌വെയര്‍ സിഡികള്‍ക്കുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-removable-media-panel.c:460
-msgid "audio DVD"
-msgstr "ശബ്ദ ഡിവിഡി"
-
-#: ../panels/info/cc-info-removable-media-panel.c:461
-msgid "blank Blu-ray disc"
-msgstr "കാലിയായ ബ്ലൂ-റേ ഡിസ്ക്"
-
-#: ../panels/info/cc-info-removable-media-panel.c:462
-msgid "blank CD disc"
-msgstr "കാലിയായ സിഡി ഡിസ്ക്"
-
-#: ../panels/info/cc-info-removable-media-panel.c:463
-msgid "blank DVD disc"
-msgstr "കാലിയായ ഡിവിഡി ഡിസ്ക്"
-
-#: ../panels/info/cc-info-removable-media-panel.c:464
-msgid "blank HD DVD disc"
-msgstr "കാലിയായ എച്ച്ഡി ഡിവിഡി ഡിസ്ക്"
-
-#: ../panels/info/cc-info-removable-media-panel.c:465
-msgid "Blu-ray video disc"
-msgstr "ബ്ലൂ-റേ വിഡിയോ ഡിസ്ക്"
-
-#: ../panels/info/cc-info-removable-media-panel.c:466
-msgid "e-book reader"
-msgstr "ഇ-പുസ്തക റീഡര്‍"
-
-#: ../panels/info/cc-info-removable-media-panel.c:467
-msgid "HD DVD video disc"
-msgstr "എച്ച്ഡി ഡിവിഡി വീഡിയോ ഡിസ്ക്"
-
-#: ../panels/info/cc-info-removable-media-panel.c:468
-msgid "Picture CD"
-msgstr "ചിത്രങ്ങളുള്ള സിഡി"
-
-#: ../panels/info/cc-info-removable-media-panel.c:469
-msgid "Super Video CD"
-msgstr "സൂപ്പര്‍ വീഡിയോ സിഡി"
-
-#: ../panels/info/cc-info-removable-media-panel.c:470
-msgid "Video CD"
-msgstr "വീഡിയോ സിഡി"
-
-#: ../panels/info/cc-info-removable-media-panel.c:471
-msgid "Windows software"
-msgstr "വിന്‍ഡോസ് സോഫ്റ്റ്‌വെയര്‍"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:2
-msgid "Defa­ult Applications"
-msgstr "സഹജമായ പ്രയോഗങ്ങള്‍"
-
-#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:3
-msgid "Configure Default Applications"
-msgstr "സഹജമായ പ്രയോഗങ്ങള്‍ ക്രമീകരിക്കുക"
-
-#. Translators: those are keywords for the System Information panel
-#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:5
-msgid "default;application;preferred;media;"
-msgstr "default;application;preferred;media;"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:2
-msgid "Ab­out"
-msgstr "ഗ്നോം കണ്ട്രോള്‍ സെന്ററിനെ കുറിച്ച്"
-
-#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:3 ../panels/info/gnome-info-panel.desktop.in.in.h:3
-msgid "View information about your system"
-msgstr "നിങ്ങളുടെ സിസ്റ്റത്തിനെ കുറിച്ചുള്ള വിവരങ്ങൾ കാണുക."
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:5 ../panels/info/gnome-info-panel.desktop.in.in.h:5
+#: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
-"device;system;information;memory;processor;version;default;application;preferred;cd;dvd;usb;audio;video;disc;"
-"removable;media;autorun;"
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
 msgstr ""
-"device;system;information;memory;processor;version;default;application;preferred;cd;dvd;usb;audio;video;disc;"
-"removable;media;autorun;"
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "De­tails"
-msgstr "വിശദവിവരങ്ങള്‍"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:2
-msgid "Remo­vable Media"
-msgstr "മാറ്റുവാന്‍ സാധ്യമാകുന്ന മീഡിയ"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "സുരക്ഷ കീ"
 
-#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:3
-msgid "Configure Removable Media settings"
-msgstr "മാറ്റാന്‍ സാധിക്കുന്ന മീഡിയയുടെ സജ്ജീകരണങ്ങള്‍ ക്രമീകരിക്കുക"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "ഇങ്കിന്റെ അവസ്ഥ"
 
-#. Translators: those are keywords for the System Information panel
-#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:5
-msgid "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "ഇങ്കിന്റെ അവസ്ഥ"
 
-#: ../panels/info/info-default-apps.ui.h:1
-msgid "_Web"
-msgstr "_വെബ്"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "ഇങ്കിന്റെ അവസ്ഥ"
 
-#: ../panels/info/info-default-apps.ui.h:2
-msgid "_Mail"
-msgstr "_മെയില്‍"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#: ../panels/info/info-default-apps.ui.h:3
-msgid "_Calendar"
-msgstr "_കലണ്ടര്‍"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "സുരക്ഷ"
 
-#: ../panels/info/info-default-apps.ui.h:4
-msgid "M_usic"
-msgstr "സം_ഗീതം"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
 
-#: ../panels/info/info-default-apps.ui.h:5
-msgid "_Video"
-msgstr "_ചലചിത്രം"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
 
-#: ../panels/info/info-default-apps.ui.h:6 ../panels/info/info-removable-media.ui.h:5
-msgid "_Photos"
-msgstr "_ചിത്രങ്ങള്‍"
-
-#: ../panels/info/info-overview.ui.h:1
-msgid "Device name"
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
 msgstr "ഉപകരണത്തിന്റെ പേരു്"
 
-#: ../panels/info/info-overview.ui.h:2
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "ഹാഡ്​വെയര്‍ വിലാസം"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "മെമ്മറി"
 
-#: ../panels/info/info-overview.ui.h:3
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "പ്രൊസസ്സര്‍"
 
-#: ../panels/info/info-overview.ui.h:4
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "ഗ്രാഫിക്സ്"
 
-#. To translators: this field contains the distro name and version
-#: ../panels/info/info-overview.ui.h:6
-msgid "OS name"
-msgstr "ഒ.എസിന്റെ പേര്"
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
 
-#. To translators: this field contains the distro type
-#: ../panels/info/info-overview.ui.h:8
-msgid "OS type"
-msgstr "ഏത് തരം ഒഎസ്"
-
-#: ../panels/info/info-overview.ui.h:9
-msgid "Virtualization"
-msgstr "വിര്‍ച്ച്വലൈസേഷന്‍"
-
-#: ../panels/info/info-overview.ui.h:10
-msgid "Disk"
-msgstr "ഡിസ്ക്ക്"
-
-#: ../panels/info/info-overview.ui.h:11
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "കണക്കു കൂട്ടുന്നു…"
 
-#: ../panels/info/info-overview.ui.h:12
-msgid "Check for updates"
-msgstr "പരിഷ്കരണങ്ങള്‍ക്കായി നോക്കുന്നു"
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "പേര‍്"
 
-#: ../panels/info/info-removable-media.ui.h:1
-msgid "Select how media should be handled"
-msgstr "മീഡിയ എങ്ങനെ കൈകാര്യം ചെയ്യണമെന്നു് തെരഞ്ഞെടുക്കുക"
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; Build ID: %s"
 
-#: ../panels/info/info-removable-media.ui.h:2
-msgid "CD _audio"
-msgstr "ശ്ര_വണ സിഡി"
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "തരം"
 
-#: ../panels/info/info-removable-media.ui.h:3
-msgid "_DVD video"
-msgstr "_ഡിവിഡി വീഡിയോ"
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "ഗ്നോം ടെര്‍മിനല്‍"
 
-#: ../panels/info/info-removable-media.ui.h:4
-msgid "_Music player"
-msgstr "_പാട്ടുപെട്ടി"
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "ഐച്ഛികങ്ങള്‍ ലഭ്യമാക്കുന്നു…"
 
-#: ../panels/info/info-removable-media.ui.h:6
-msgid "_Software"
-msgstr "_സോഫ്റ്റവെയര്‍"
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "വിന്‍ഡോസ് സോഫ്റ്റ്‌വെയര്‍"
 
-#: ../panels/info/info-removable-media.ui.h:7
-msgid "_Other Media…"
-msgstr "_മറ്റു് മാധ്യമം…"
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "വിര്‍ച്ച്വലൈസേഷന്‍"
 
-#: ../panels/info/info-removable-media.ui.h:8
-msgid "_Never prompt or start programs on media insertion"
-msgstr "മാധ്യമം വയ്ക്കുമ്പോള്‍ _ഒരിയ്ക്കലും പ്രോഗ്രാമുകള്‍ തുടങ്ങുകയോ ഓര്‍മ്മപ്പെടുത്തുകയോ വേണ്ട"
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "സോഫ്റ്റ്‌വെയര്‍ ഉപയോഗം"
 
-#: ../panels/info/info-removable-media.ui.h:9
-msgid "Select how other media should be handled"
-msgstr "മറ്റു് മീഡിയ എങ്ങനെ കൈകാര്യം ചെയ്യണമെന്നു് തെരഞ്ഞെടുക്കുക"
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "ഡിവൈസ് നീക്കം ചെയ്യുക"
 
-#: ../panels/info/info-removable-media.ui.h:10
-msgid "_Action:"
-msgstr "പ്ര_വര്‍ത്തി:"
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
 
-#: ../panels/info/info-removable-media.ui.h:11
-msgid "_Type:"
-msgstr "_തരം:"
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ഉപകരണത്തിന്റെ പേരു്"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "പേരു മാറ്റുക."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "%s-നെ പറ്റി"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "നിങ്ങളുടെ സിസ്റ്റത്തിനെ കുറിച്ചുള്ള വിവരങ്ങൾ കാണുക."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "ശബ്ദവും മീഡിയയും"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "നിശ്ശബ്ദമാക്കുക"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "ശബ്ദം കുറയ്ക്കുക"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "ശബ്ദം കൂട്ടുക"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "മൈക്രോഫോണ്‍ വോള്യം"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "ചലച്ചിത്രദര്‍ശിനി തുടങ്ങുക"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "പാടുക (പാടുക അല്ലെങ്കില്‍ തല്‍ക്കാലത്തേക്ക് നിര്‍ത്തുക)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "പ്ലേബാക്ക് താല്‍കാലികമായി നിര്‍ത്തുക"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "പ്ലേബാക്ക് നിര്‍ത്തുക"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "മുമ്പുളള ട്രാക്ക്"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "അടുത്ത ട്രാക്ക്"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "പുറന്തള്ളുക"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1 ../panels/universal-access/uap.ui.h:12
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "ടൈപ്പിങ്ങ്"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുക"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "മുമ്പുള്ള ശ്രോതസ്സിലേക്കു് മാറുക"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "ലഭ്യമാക്കുന്ന സംവിധാനങ്ങള്‍"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "സഹായകബ്രൌസര്‍ തുറക്കുക"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/alt/cc-window.c:1590 ../shell/cc-window.c:251
-#: ../shell/cc-window.c:794 ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/window.ui.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "സജ്ജീകരണങ്ങള്‍"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "കാല്‍ക്കുലേറ്റര്‍ തുടങ്ങുക"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "ഇ-മെയില്‍ ക്ലയന്റ് തുടങ്ങുക"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "വെബ് ബ്രൌസര്‍ തുറക്കുക"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "തട്ടകം"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "തെരച്ചില്‍"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "തിരചിത്രങ്ങള്‍"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "$PICTURES ലേക്ക് ഒരു സ്ക്രീന്‍ഷോട്ട് സൂക്ഷിയ്ക്കുക"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "$PICTURES ലേക്കു് ജാലകത്തിന്റെ ഒരു സ്ക്രീന്‍ഷോട്ട് സൂക്ഷിയ്ക്കുക"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "$PICTURES ലേക്കു് ഒരു സ്ഥലത്തിന്റെ സ്ക്രീന്‍ഷോട്ട് സൂക്ഷിയ്ക്കുക"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "ക്ലിപ്പ്ബോര്‍ഡിലേക്കു് ഒരു സ്ക്രീന്‍ഷോട്ട് പകര്‍ത്തുക"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "ക്ലിപ്പ്ബോര്‍ഡിലേക്കു് ജാലകത്തിന്റെ ഒരു സ്ക്രീന്‍ഷോട്ട് പകര്‍ത്തുക"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "ക്ലിപ്പ്ബോര്‍ഡിലേക്കു് ഒരു സ്ഥലത്തിന്റെ സ്ക്രീന്‍ഷോട്ട് പകര്‍ത്തുക"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "ഒരു ചെറിയ സ്ക്രീന്‍കാസ്റ്റ് രേഖപ്പെടുത്തുക"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "സിസ്റ്റം"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "പുറത്തു കടക്കുക"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "സ്ക്രീന്‍ പൂട്ടുക"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-msgid "Universal Access"
-msgstr "സാര്‍വ്വജനികലഭ്യത"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "മൗസ്  _സാമീപ്യത"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "വലിപ്പം കൂട്ടുക അല്ലെങ്കില്‍ കുറയ്ക്കുക"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "വലിപ്പം കൂട്ടുക"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "വലിപ്പം കുറക്കുക"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "സ്ക്രീന്‍ റീഡര്‍ ഓണ്‍ അല്ലെങ്കില്‍ ഓഫ് ചെയ്യുക"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "ഓണ്‍ സ്ക്രീന്‍ റീഡര്‍ ഓണ്‍ അല്ലെങ്കില്‍ ഓഫ് ചെയ്യുക"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "വാചകത്തിന്റെ വ്യാപ്തി കൂട്ടുക"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "വാചകത്തിന്റെ വ്യാപ്തി കുറയ്ക്കുക"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "ഹൈ കോണ്ട്രോസ്റ്റ് ഓണ്‍ അല്ലെങ്കില്‍ ഓഫ് ചെയ്യുക"
 
-#: ../panels/keyboard/cc-keyboard-manager.c:506 ../panels/keyboard/cc-keyboard-manager.c:514
-#: ../panels/keyboard/cc-keyboard-manager.c:822
-msgid "Custom Shortcuts"
-msgstr "നമ്മുടെ ഇഷ്ടത്തിനനുസരിച്ച് ഉണ്ടാക്കുന്ന എളുപ്പവഴികള്‍"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "ഇന്‍പുട്ട് ഉറവിടം ചേര്‍ക്കുക"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276 ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:435 ../panels/keyboard/shortcut-editor.ui.h:2
-#: ../panels/network/network-proxy.ui.h:4 ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1866 ../panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Disabled"
-msgstr "നിര്‍ജ്ജീവമാക്കിയ"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "പ്രവേശിക്കുമ്പോള്‍ ഇന്‍പുട്ട് മെത്തേഡുകള്‍ ഉപയോഗിക്കാനാവില്ല"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "മറ്റും ക്യാരക്ടര്‍ കീകള്‍"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "ഇന്‍പുട്ട് ഉറവിടങ്ങളൊന്നും എടുത്തില്ല"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "കംപോസ് കീ"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "ഐച്ഛികങ്ങള്‍"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുവാനുള്ള മോഡിഫയര്‍ മാത്രമുള്ള സ്വിച്ച്"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "മുകളിലേയ്ക്കു് മാറ്റുക"
 
-#: ../panels/keyboard/cc-keyboard-panel.c:181
-msgid "Reset All Shortcuts?"
-msgstr "എല്ലാ എളുപ്പവഴിയും പഴയപോലെ ആക്കട്ടെ?"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "താഴേയ്ക്കു് മാറ്റുക"
 
-#: ../panels/keyboard/cc-keyboard-panel.c:184
-msgid "Resetting the shortcuts may affect your custom shortcuts. This cannot be undone."
-msgstr "എല്ലാ എളുപ്പവഴിയും പഴയപോലെ ആക്കിയാല്‍ നിങ്ങള്‍ ക്രമീകരിച്ചതിനും മാറ്റം വരാം. ഇത് തിരിച്ച് ആക്കാന്‍ പറ്റില്ല."
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "മുന്‍ഗണനകള്‍"
 
-#: ../panels/keyboard/cc-keyboard-panel.c:189
-msgid "Reset All"
-msgstr "എല്ലാം പഴയപടി ആക്കുക"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "കീബോര്‍ഡ് വിന്യാസ ഐച്ഛികങ്ങള്‍"
 
-#: ../panels/keyboard/cc-keyboard-panel.c:281
-msgid "Reset the shortcut to its default value"
-msgstr "എളുപ്പവഴികളെ പഴയ പരുവത്തിലോട്ട് ആക്കുക"
-
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:427
-#, c-format
-msgid "%s is already being used for <b>%s</b>. If you replace it, %s will be disabled"
-msgstr ""
-
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:597
-msgid "Set Custom Shortcut"
-msgstr "സ്വന്തം എളുപ്പവഴി ഉണ്ടാക്കുക"
-
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:597
-msgid "Set Shortcut"
-msgstr "എളുപ്പവഴി ഉണ്ടാക്കുക"
-
-#. Setup the top label
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:606
-#, c-format
-msgid "Enter new shortcut to change <b>%s</b>."
-msgstr ""
-
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:1033
-msgid "Add Custom Shortcut"
-msgstr "ഒരു ഇഷ്ടാനുസൃത എളുപ്പവഴി ഉണ്ടാക്കുക"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "Key­board"
-msgstr "കീബോര്‍ഡ്"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:3
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr "കീബോഡ് കുറുക്കുവഴികള്‍ കണ്ട് മാറുറുക; ടൈപ്പിങ്ങ് മുന്‍ഗണനകള്‍ മാറ്റുക"
-
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:5
-msgid "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
-msgstr "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1 ../panels/region/input-options.ui.h:4
-#: ../shell/cc-application.c:251
-msgid "Keyboard Shortcuts"
-msgstr "കീബോര്‍ഡ് കുറക്കുവഴികള്‍"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "Reset All…"
-msgstr "എല്ലാം പഴയപോലെ ആക്കുക…"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "Reset all shortcuts to their default keybindings"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "No keyboard shortcut found"
-msgstr "കീബോര്‍ഡ് എളുപ്പവഴിയൊന്നും കണ്ടില്ല"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5 ../shell/panel-list.ui.h:4
-msgid "Try a different search"
-msgstr "വേറേ തെരഞ്ഞ് നോക്കുക"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:1
-msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr ""
-
-#: ../panels/keyboard/shortcut-editor.ui.h:3 ../panels/printers/details-dialog.ui.h:1
-#: ../panels/sound/gvc-mixer-dialog.c:1493 ../panels/sound/gvc-sound-theme-chooser.c:564
-msgid "Name"
-msgstr "പേര‍്"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:4
-msgid "Command"
-msgstr "ആജ്ഞ"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:5
-msgid "Shortcut"
-msgstr "എളുപ്പവഴി"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:6
-msgid "Set Shortcut…"
-msgstr "പുതിയ എളുപ്പവഴി…"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:7 ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "ഒന്നുമില്ല"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:8
-msgid "Enter the new shortcut"
-msgstr "പുതിയ എളുപ്പവഴി കൊടുക്കുക"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:10
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "നീക്കം ചെയ്യുക"
 
-#: ../panels/keyboard/shortcut-editor.ui.h:11
-msgid "Add"
-msgstr "ചേര്‍ക്കുക"
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "ഇന്‍പുട്ട് ഉറവിടങ്ങള്‍"
 
-#: ../panels/keyboard/shortcut-editor.ui.h:12
-msgid "Replace"
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "ഇന്‍പുട്ട് ഉറവിട സജ്ജീകരണങ്ങള്‍"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "എല്ലാ വിന്‍ഡോയ്ക്കും _ഒരേ സ്ത്രോതസ്സ് ഉപയോഗിക്കുക"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "ഓരോ ജാലകത്തിനും _വെവ്വേറെ സ്ത്രോതസ്സുകള്‍ അനുവദിക്കുക"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "മറ്റും ക്യാരക്ടര്‍ കീകള്‍"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "കംപോസ് കീ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "കീബോര്‍ഡ് കുറക്കുവഴികള്‍"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "നമ്മുടെ ഇഷ്ടത്തിനനുസരിച്ച് ഉണ്ടാക്കുന്ന എളുപ്പവഴികള്‍"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "എല്ലാം പഴയപോലെ ആക്കുക…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "വിഭാഗം"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "എളുപ്പവഴികള്‍"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "എളുപ്പവഴി ചേര്‍ക്കുക"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "ഒരു ഇഷ്ടാനുസൃത എളുപ്പവഴി ഉണ്ടാക്കുക"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "എളുപ്പവഴി ചേര്‍ക്കുക"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "കീബോര്‍ഡ് എളുപ്പവഴിയൊന്നും കണ്ടില്ല"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "നീക്കം ചെയ്യുക"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
 msgstr "പകരംവെക്കുക"
 
-#: ../panels/keyboard/shortcut-editor.ui.h:13
-msgid "Set"
-msgstr "തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/mouse/cc-mouse-panel.c:82 ../panels/wacom/cc-wacom-panel.c:402
-msgid "Test Your _Settings"
-msgstr "നിങ്ങളുടെ _സജ്ജീകരണങ്ങള്‍ പരീക്ഷിയ്ക്കുക"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Mouse & Touch­pad"
-msgstr "മൗസും ടച്ച്പാഡും"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:3
-msgid "Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr "മൌസ് അല്ലെങ്കില്‍ ടച്ച്പാഡ് കൃത്യത മാറ്റുക പിന്നെ വലംകൈ/ഇടംകൈ തെരഞ്ഞെടുക്കുക"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:5
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "സാധാരണ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "Primary Button"
-msgstr "പ്രധാന ബട്ടണ്‍"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Sets the order of physical buttons on mice and touchpads."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Left"
-msgstr "ഇടത്"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "Right"
-msgstr "വലത്"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Mouse"
-msgstr "മൌസ്"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Mouse Speed"
-msgstr "മൌസ് വേഗത"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "Double-click timeout"
-msgstr "ഇരട്ട ക്ലിക്കുകള്‍ക്കിടയില്‍ അനുവദനീയമായ സമയം"
-
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "Natural Scrolling"
-msgstr "സ്വാഭാവികമായ സ്ക്രോളിങ്"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgid "Scrolling moves the content, not the view."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgid "Touchpad"
-msgstr "ടച്ച്പാഡ്"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "പേര‍്"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad Speed"
-msgstr "ടച്ച്പാഡ് വേഗത"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "ആജ്ഞ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgid "Tap to Click"
-msgstr "ക്ലിക്ക് ചെയ്യുന്നതിനായി റ്റാപ്പ് ചെയ്യുക"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "എളുപ്പവഴി"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgid "Two-finger Scrolling"
-msgstr "രണ്ട് വിരല്‍ സ്ക്രോള്‍"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "പുതിയ എളുപ്പവഴി…"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Edge Scrolling"
-msgstr "അരിക് സ്ക്രോളിങ്"
-
-#: ../panels/mouse/gnome-mouse-test.c:130 ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "ക്ലിക്ക്, രണ്ടു് ക്ലിക്ക്, സ്ക്രോളിങ് എന്നിവ ശ്രമിയ്ക്കുക"
-
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "അഞ്ച് ക്ലിക്കുകള്‍, ജിഇജിഎല്‍ സമയം!"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "രണ്ടു് ക്ലിക്ക്, പ്രൈമറി ബട്ടണ്‍"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "ഒറ്റ ക്ലിക്ക്, പ്രൈമറി ബട്ടണ്‍"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "രണ്ടു് ക്ലിക്ക്, മദ്ധ്യ ബട്ടണ്‍"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "ഒറ്റ ക്ലിക്ക്, മദ്ധ്യ ബട്ടണ്‍"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "രണ്ടു് ക്ലിക്ക്, സെക്കന്‍ഡറി ബട്ടണ്‍"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "ഒറ്റ ക്ലിക്ക്, സെക്കന്‍ഡറി ബട്ടണ്‍"
-
-#. add proxy to device list
-#: ../panels/network/cc-network-panel.c:548
-msgid "Network proxy"
-msgstr "ശൃംഖലയിലെ പ്രോക്സി"
-
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:684 ../panels/network/net-vpn.c:192 ../panels/network/net-vpn.c:321
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#: ../panels/network/cc-network-panel.c:748 ../panels/network/wifi.ui.h:7
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "ശോ, എന്തോ പറ്റി. നിങ്ങളുടെ സോഫ്റ്റ്‍വെയര്‍ വില്പനക്കാരുമായി ബന്ധപ്പെടുക."
-
-#: ../panels/network/cc-network-panel.c:754
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager പ്രവര്‍ത്തിക്കണം."
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/network/cc-wifi-panel.c:209 ../panels/network/gnome-wifi-panel.desktop.in.in.h:2
-#: ../panels/network/network-wifi.ui.h:58
-msgid "Wi-Fi"
-msgstr "വയര്‍ലസ്സ്"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
-msgid "802.1x _Security"
-msgstr "802.1X _സുരക്ഷ"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2 ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "page 1"
-msgstr "താള്‍ 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-msgid "Anony_mous identity"
-msgstr "_അജ്ഞാത തിരിച്ചറിയല്‍"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "_ആന്തരിക ആധികാരികത ഉറപ്പാക്കല്‍"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5 ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "page 2"
-msgstr "താള്‍ 2 "
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:101
-#: ../panels/network/connection-editor/ce-page-security.c:445
-#: ../panels/network/connection-editor/details-page.ui.h:3 ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "സുരക്ഷ"
-
-#: ../panels/network/connection-editor/ce-page.c:481
-msgid "automatic"
-msgstr "തനിയെയുള്ള"
-
-#: ../panels/network/connection-editor/ce-page.c:521
-#, c-format
-msgid "Profile %d"
-msgstr "പ്രൊഫൈല്‍ %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56 ../panels/network/net-device-wifi.c:231
-#: ../panels/network/net-device-wifi.c:407
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60 ../panels/network/net-device-wifi.c:235
-#: ../panels/network/net-device-wifi.c:412 ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:64 ../panels/network/net-device-wifi.c:239
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:69 ../panels/network/net-device-wifi.c:244
-msgid "Enterprise"
-msgstr "എന്റര്‍പ്രൈസ്"
-
-#: ../panels/network/connection-editor/ce-page-details.c:74 ../panels/network/net-device-wifi.c:249
-#: ../panels/network/net-device-wifi.c:397
-msgctxt "Wifi security"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "ഒന്നുമില്ല"
 
-#: ../panels/network/connection-editor/ce-page-details.c:95 ../panels/power/power.ui.h:17
-msgid "Never"
-msgstr "ഒരിക്കലുമില്ല"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "എളുപ്പവഴികളെ പഴയ പരുവത്തിലോട്ട് ആക്കുക"
 
-#: ../panels/network/connection-editor/ce-page-details.c:110 ../panels/network/net-device-ethernet.c:120
-#: ../panels/network/net-device-wifi.c:505
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "സഹജമായ രീതിയിലേക്ക് _തിരികെ വയ്ക്കുക"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+#, fuzzy
+msgid "Keyboard"
+msgstr "കീബോര്‍ഡ്"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "കീബോഡ് കുറുക്കുവഴികള്‍ കണ്ട് മാറുറുക; ടൈപ്പിങ്ങ് മുന്‍ഗണനകള്‍ മാറ്റുക"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "ഓഡിയോ റിക്കോര്‍ഡ് ചെയ്യുന്നില്ല അല്ലെങ്കില്‍ നിലവില്‍ ഒരു പ്രയോഗവും പ്രവര്‍ത്തിക്കുന്നില്ല"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "മൈക്രോഫോണ്‍ വോള്യം"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "ഒരു പ്രയോഗങ്ങളും കണ്ടില്ല"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "നിങ്ങളുടെ _സജ്ജീകരണങ്ങള്‍ പരീക്ഷിയ്ക്കുക"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "സാധാരണ"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "പ്രധാന ബട്ടണ്‍"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "ഇടത്"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "വലത്"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "സ്ഥലം തെരയുക"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "മൌസ്"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "മൌസ് വേഗത"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "താഴേക്ക് സ്ക്രോള്‍ ചെയ്യുക"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "ഉള്ളടക്കവുമായി മാഗ്നിഫയര്‍ കര്‍സര്‍ നീങ്ങുന്നു"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_വേഗവര്‍ദ്ധനവ്:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "സജ്ജമാണ്"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "ടച്ച്പാഡ്"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "ടച്ച്പാഡ് വേഗത"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_സംവിധാനം"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "ക്ലിക്ക് ചെയ്യുന്നതിനായി റ്റാപ്പ് ചെയ്യുക"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "ക്ലിക്ക് ചെയ്യുന്നതിനായി റ്റാപ്പ് ചെയ്യുക"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "ടൈപ്പ് ചെയ്യുമ്പോള്‍ _പ്രവര്‍ത്തന രഹിതമാക്കുക"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "ടച്ച്പാഡ് (റിലേറ്റിവ്)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "അരിക് സ്ക്രോളിങ്"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "ഇടത്തേക്ക് സ്ക്രോള്‍ ചെയ്യുക"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "രണ്ടു് വശത്തും"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ക്ലിക്ക്, രണ്ടു് ക്ലിക്ക്, സ്ക്രോളിങ് എന്നിവ ശ്രമിയ്ക്കുക"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
+msgstr "മൗസും ടച്ച്പാഡും"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "മൌസ് അല്ലെങ്കില്‍ ടച്ച്പാഡ് കൃത്യത മാറ്റുക പിന്നെ വലംകൈ/ഇടംകൈ തെരഞ്ഞെടുക്കുക"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "കളര്‍സ്പേസ്:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "തനിയെ _ചവറ്റുകുട്ട ഒഴിപ്പിക്കുക"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "മോണിറ്റര്‍"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "പ്രധാന പ്രദര്‍ശനം മാറ്റുവാന്‍ വലിച്ചിടുക."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "പ്രയോഗങ്ങള്‍"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ഉപകരണങ്ങള്‍"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "പുതിയൊരു കണക്ഷന്‍ ചേര്‍ക്കുക"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "ക്രമീകരിച്ചിട്ടില്ല"
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "ബന്ധിച്ചു"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "ഐച്ഛികങ്ങള്‍…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട് സജ്ജമാക്കട്ടെ?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "നെറ്റ്‌വര്‍ക്കിന്റെ പേരു്"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "രഹസ്യവാക്ക്"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "ഒരു രഹസ്യവാക്ക് ലഭ്യമാക്കുക"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "ഒരു രഹസ്യവാക്ക് ലഭ്യമാക്കുക"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_ഓണ്‍ ചെയ്യുക"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "വിമാന മോഡ്"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "വൈ-ഫൈ, ബ്ലുടൂത്, മൊബൈല്‍ ഇന്റെര്‍നെറ്റ് നിര്‍ത്തുന്നു"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "വൈ-ഫൈ അഡാപ്റ്റര്‍ ഒന്നും കണ്ടില്ല"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "വൈ-ഫൈ അഡാപ്റ്റര്‍ കുത്തിയിട്ടുണ്ടെന്നും ഓണ്‍ ചെയ്തിട്ടുണ്ടെന്നും ഉറപ്പ് വരുത്തുക"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "വിമാന മോഡ്"
+
+#: panels/network/cc-wifi-panel.ui:165
+#, fuzzy
+msgid "Turn off to use Wi-Fi"
+msgstr "കറണ്ട് ലാഭിക്കാന്‍ വൈ-ഫൈ ഓഫാക്കുക."
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട്"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട് സജ്ജമാക്കുക (_T)…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "കാണാവുന്ന ശൃംഖല"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager പ്രവര്‍ത്തിക്കണം"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "ശോ, എന്തോ പറ്റി. നിങ്ങളുടെ സോഫ്റ്റ്‍വെയര്‍ വില്പനക്കാരുമായി ബന്ധപ്പെടുക."
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1X _സുരക്ഷ"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i ദിവസം മുമ്പു്"
 msgstr[1] "%i ദിവസങ്ങള്‍ മുമ്പു്"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:176 ../panels/network/net-device-ethernet.c:50
-#: ../panels/network/net-device-wifi.c:561
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:202 ../panels/network/net-device-wifi.c:590
-msgctxt "Signal strength"
-msgid "None"
-msgstr "ഒന്നുമില്ല"
-
-#: ../panels/network/connection-editor/ce-page-details.c:204 ../panels/network/net-device-wifi.c:592
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "പോര"
-
-#: ../panels/network/connection-editor/ce-page-details.c:206 ../panels/network/net-device-wifi.c:594
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ശരി"
-
-#: ../panels/network/connection-editor/ce-page-details.c:208 ../panels/network/net-device-wifi.c:596
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "നല്ലത്"
-
-#: ../panels/network/connection-editor/ce-page-details.c:210 ../panels/network/net-device-wifi.c:598
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "അത്യുത്തമം"
-
-#: ../panels/network/connection-editor/ce-page-details.c:248
-msgid "Forget Connection"
-msgstr "കണക്ഷന്‍ മറക്കു"
-
-#: ../panels/network/connection-editor/ce-page-details.c:250
-msgid "Remove Connection Profile"
-msgstr "കണക്ഷന്‍ പ്രൊഫൈല്‍ കളയു"
-
-#: ../panels/network/connection-editor/ce-page-details.c:252
-msgid "Remove VPN"
-msgstr "VPN നീക്കം ചെയ്യുക"
-
-#: ../panels/network/connection-editor/ce-page-details.c:280 ../panels/network/network-wifi.ui.h:46
-#: ../shell/cc-window.c:243 ../shell/panel-list.ui.h:2
-msgid "Details"
-msgstr "വിശദവിവരങ്ങള്‍"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:173
-#: ../panels/network/connection-editor/ce-page-vpn.c:188 ../panels/network/connection-editor/ce-page-wifi.c:194
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "തിരിച്ചറിയല്‍"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:251 ../panels/network/connection-editor/ce-page-ip6.c:230
-msgid "Delete Address"
-msgstr "വിലാസം നീക്കം ചെയ്യുക"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:422 ../panels/network/connection-editor/ce-page-ip6.c:390
-msgid "Delete Route"
-msgstr "റൂട്ട് നീക്കം ചെയ്യുക"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:896 ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:827 ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-security.c:245
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "ഒന്നുമില്ല"
-
-#: ../panels/network/connection-editor/ce-page-security.c:268
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "ഡബ്ലിയുഇപി 40/128-bit കീ (ഹെക്സോ ആസ്കിയോ)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:278
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit പാസ്‌ഫ്രെയിസ്"
-
-#: ../panels/network/connection-editor/ce-page-security.c:291
-#: ../panels/network/wireless-security/wireless-security.c:465
-msgid "LEAP"
-msgstr "എല്‍ഇഎപി"
-
-#: ../panels/network/connection-editor/ce-page-security.c:304
-msgid "Dynamic WEP (802.1x)"
-msgstr "ഡൈനമിക് WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:318
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 പേഴ്സണല്‍"
-
-#: ../panels/network/connection-editor/ce-page-security.c:332
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 എന്റര്‍പ്രൈസ്"
-
-#: ../panels/network/connection-editor/connection-editor.ui.h:2 ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr "_കംപ്യൂട്ടറില്‍ സൂക്ഷിക്കുക"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1 ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "സിഗ്നലിന്‍റെ കരുത്ത്"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2 ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "ലിങ്കിന്റെ വേഗത"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4 ../panels/network/net-device-ethernet.c:153
-#: ../panels/network/network-simple.ui.h:3 ../panels/network/network-wifi.ui.h:7
-#: ../panels/network/panel-common.c:644
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "സുരക്ഷ"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 വിലാസം"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5 ../panels/network/net-device-ethernet.c:154
-#: ../panels/network/net-device-ethernet.c:158 ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4 ../panels/network/network-wifi.ui.h:8
-#: ../panels/network/panel-common.c:645
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 വിലാസം"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6 ../panels/network/net-device-ethernet.c:161
-#: ../panels/network/network-simple.ui.h:2 ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "ഹാഡ്​വെയര്‍ വിലാസം"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7 ../panels/network/net-device-ethernet.c:165
-#: ../panels/network/network-mobile.ui.h:5 ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "പിന്തുണയുള്ള ഐസിസി പ്രൊഫൈലുകള്‍"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "സ്വതവേയുള്ള റൂട്ട്"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8 ../panels/network/connection-editor/ip4-page.ui.h:10
-#: ../panels/network/connection-editor/ip6-page.ui.h:11 ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-mobile.ui.h:6 ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "അവസാനം ഉപയോഗിച്ചതു്"
 
-#: ../panels/network/connection-editor/details-page.ui.h:10
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "_സ്വയം ബന്ധിപ്പിക്കുക"
 
-#: ../panels/network/connection-editor/details-page.ui.h:11
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "മറ്റുള്ള _ഉപയോക്താക്കള്‍ക്ക് ലഭ്യമാക്കുക"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1 ../panels/network/connection-editor/ip4-page.ui.h:11
-#: ../panels/network/connection-editor/ip6-page.ui.h:2 ../panels/network/net-proxy.c:58
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/privacy/cc-privacy-panel.c:217
-msgid "Automatic"
-msgstr "തനിയെയുള്ള"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "ട്വിസ്റ്റഡ് പെയര്‍ (ടിപി)"
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "അറ്റാച്ച്മെന്റ് യൂണിറ്റ് ഇന്റര്‍ഫേസ് (എയുഐ)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "ബിഎന്‍സി"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "മീഡിയ ഇന്‍ഡിപെന്‍ഡന്റ് ഇന്റര്‍ഫേസ് (എംഐഐ)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10 ../panels/network/connection-editor/vpn-page.ui.h:1
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_പേര്"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4 ../panels/network/network-wifi.ui.h:38
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "_MAC വിലാസം"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "_പകര്‍ത്തിയ വിലാസം"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "ബൈറ്റുകള്‍"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "IPv_4 സംവിധാനം"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:2 ../panels/network/network-wifi.ui.h:27
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "ഓട്ടോമാറ്റിക് (DHCP)"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:3 ../panels/network/connection-editor/ip6-page.ui.h:4
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "ലിങ്ക്-ലോക്കല്‍ മാത്രം"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:5 ../panels/network/connection-editor/ip6-page.ui.h:6
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "മാനുവല്‍"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "നിര്‍ജ്ജീവമാക്കിയ"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:6 ../panels/network/connection-editor/ip6-page.ui.h:7
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "മറ്റു് കമ്പ്യൂട്ടറുകളുമായി പങ്കിടുന്നു"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "വിലാസങ്ങള്‍"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:7 ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/printers/details-dialog.ui.h:3
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "വിലാസം"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "നെറ്റ്മാസ്ക്"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:9 ../panels/network/connection-editor/ip6-page.ui.h:10
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "ഗേറ്റ്‌വേ"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:12 ../panels/network/connection-editor/ip6-page.ui.h:12
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "തനിയെയുള്ള"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "സ്വതവേയുള്ള ഡിഎന്‍എസ്"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:13 ../panels/network/connection-editor/ip6-page.ui.h:13
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "ഐപി വിലാസങ്ങള്‍ കോമ കൊണ്ട് തിരിക്കുക"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:14 ../panels/network/connection-editor/ip6-page.ui.h:14
-#: ../panels/network/network-wifi.ui.h:32
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "റൂട്ടുകള്‍"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:15 ../panels/network/connection-editor/ip6-page.ui.h:15
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "സ്വതവേയുള്ള റൂട്ട്"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ip4-page.ui.h:17 ../panels/network/connection-editor/ip6-page.ui.h:17
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "മെട്രിക്"
 
-#: ../panels/network/connection-editor/ip4-page.ui.h:18 ../panels/network/connection-editor/ip6-page.ui.h:18
-#: ../panels/network/network-wifi.ui.h:34
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "ഈ _ബന്ധത്തിന്റെ ശൃംഖലയിലുള്ള വസ്തുക്കള്‍ക്കു് മാത്രം ഉപയോഗിയ്ക്കുക"
 
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "IPv_6 സംവിധാനം"
 
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "ഓട്ടോമാറ്റിക്, DHCP മാത്രം"
 
-#: ../panels/network/connection-editor/ip6-page.ui.h:9
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "പ്രിഫിക്സ്"
 
-#: ../panels/network/connection-editor/net-connection-editor.c:273
-msgid "Unable to open connection editor"
-msgstr "ബന്ധ എഡിറ്റര്‍ തുറക്കാനാകുന്നില്ല"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:291
-msgid "New Profile"
-msgstr "പുതിയ പ്രൊഫൈല്‍"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:603 ../panels/network/network.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:751
-msgid "Import from file…"
-msgstr "ഫയലില്‍ നിന്നും ഇംപോര്‍ട്ട് ചെയ്യുക…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:785
-msgid "Add VPN"
-msgstr "VPN ചേര്‍ക്കു"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1 ../panels/network/network-wifi.ui.h:16
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_സുരക്ഷ"
 
-#: ../panels/network/connection-editor/vpn-helpers.c:141
-msgid "Cannot import VPN connection"
-msgstr "വിപിഎന്‍ ബന്ധം ഇംപോര്‍ട്ട് ചെയ്യുവാന്‍ സാധ്യമല്ല"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:143
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"ഫയല്‍ “%s” വായിക്കാന്‍ പറ്റുന്നില്ല, അല്ലെങ്കില്‍ അതില്‍ തിരിച്ചറിയാനാകുന്ന VPN ബന്ധങ്ങളുടെ വിവരം ഇല്ല\n"
-"\n"
-"പിഴവ്: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:178
-msgid "Select file to import"
-msgstr "ഇംപോര്‍ട്ട് ചെയ്യുന്നതിനുള്ള ഫയല്‍ തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:182 ../panels/printers/pp-details-dialog.c:320
-#: ../panels/sharing/cc-sharing-panel.c:376 ../panels/user-accounts/um-photo-dialog.c:222
-msgid "_Open"
-msgstr "തുറക്കുക (_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:230
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "“%s” എന്ന പേരില്‍ ഒരു ഫയല്‍ നിലവിലുണ്ടു്."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:232
-msgid "_Replace"
-msgstr "_പകരംവെക്കുക"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:234
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "നിങ്ങള്‍ സൂക്ഷിച്ചുകൊണ്ടിരിക്കുന്ന വിപിഎന്‍ ബന്ധംഉപയോഗിച്ചു് %s മാറ്റണമോ?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:270
-msgid "Cannot export VPN connection"
-msgstr "വിപിഎന്‍ ബന്ധം എക്സ്പോര്‍ട്ട് ചെയ്യുവാന്‍ സാധിച്ചില്ല"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:272
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN ബന്ധം “%s” %s ലേക്ക് കയറ്റുമതി ചെയ്യാനാകുന്നില്ല.\n"
-"\n"
-"പിഴവ്: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:307
-msgid "Export VPN connection"
-msgstr "വിപിഎന്‍ ബന്ധം എക്സ്പോര്‍ട്ട് ചെയ്യുക"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(പിഴവ്: VPN ബന്ധം എഡിറ്റര്‍ ലഭ്യമാക്കാനയില്ല)"
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:1 ../panels/network/network-wifi.ui.h:14
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:2 ../panels/network/network-wifi.ui.h:15
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
 
-#: ../panels/network/connection-editor/wifi-page.ui.h:3 ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "എന്റെ ഹോം ശൃംഖല"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Net­work"
-msgstr "ശൃംഖല"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:3
-msgid "Control how you connect to the Internet"
-msgstr "ഇന്റെര്‍നെറ്റില്‍ ബന്ധിപ്പിക്കുന്നതെങ്ങനെയെന്ന് തീരുമാനിക്കുന്നു"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:5
-msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
-msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
-
-#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:3
-msgid "Control how you connect to Wi-Fi networks"
-msgstr "വൈഫൈ ശ്രംഖലകളില്‍ ബന്ധിപ്പിക്കുന്നതെങ്ങനെയെന്ന് തീരുമാനിക്കുന്നു"
-
-#. Translators: those are keywords for the wi-fi control-center panel
-#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:5
-msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
-msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
-
-#: ../panels/network/net-device-ethernet.c:106 ../panels/network/net-device-wifi.c:491
-msgid "never"
-msgstr "ഒരിക്കലുമില്ല"
-
-#: ../panels/network/net-device-ethernet.c:116 ../panels/network/net-device-wifi.c:501
-msgid "today"
-msgstr "ഇന്നു്"
-
-#: ../panels/network/net-device-ethernet.c:118 ../panels/network/net-device-wifi.c:503
-msgid "yesterday"
-msgstr "ഇന്നലെ"
-
-#: ../panels/network/net-device-ethernet.c:156 ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:647 ../panels/network/panel-common.c:649
-msgid "IP Address"
-msgstr "IP വിലാസം"
-
-#: ../panels/network/net-device-ethernet.c:172 ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "അവസാനം ഉപയോഗിച്ചതു്"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:275 ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "വയര്‍ഡ്"
-
-#: ../panels/network/net-device-ethernet.c:343 ../panels/network/net-device-wifi.c:1792
-#: ../panels/network/network-ethernet.ui.h:2 ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8 ../panels/network/network-vpn.ui.h:2
-msgid "Options…"
-msgstr "ഐച്ഛികങ്ങള്‍…"
-
-#: ../panels/network/net-device-mobile.c:238
-msgid "Add new connection"
-msgstr "പുതിയൊരു കണക്ഷന്‍ ചേര്‍ക്കുക"
-
-#: ../panels/network/net-device-wifi.c:1275
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട് സ്വിച്ച് ഓണ്‍ ചെയ്യുന്നതു്,  <b>%s</b>-ല്‍ നിന്നും നിങ്ങളെ വിഛേദിയ്ക്കുന്നു."
-
-#: ../panels/network/net-device-wifi.c:1279
-msgid "It is not possible to access the Internet through your wireless while the hotspot is active."
-msgstr "ഹോട്ട്സ്പോട്ട് സജീവമാകുമ്പോള്‍ വയര്‍ലെസ്സ് മുഖേനയുള്ള ഇന്റര്‍നെറ്റ് നിങ്ങള്‍ക്കു്ലഭ്യമാകുന്നതല്ല."
-
-#: ../panels/network/net-device-wifi.c:1286
-msgid "Turn On Wi-Fi Hotspot?"
-msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട് സജ്ജമാക്കട്ടെ?"
-
-#: ../panels/network/net-device-wifi.c:1308
-msgid "Wi-Fi hotspots are usually used to share an additional Internet connection over Wi-Fi."
-msgstr "വൈ-ഫൈ വഴി ഇന്റെര്‍നെറ്റ് ബന്ധം പങ്കിടാന്‍ ആണ് സാധാരണ വൈ-ഫൈ ഹോട്ട്സ്പോട്ട് ഉപയോഗിക്കുന്നത്."
-
-#: ../panels/network/net-device-wifi.c:1319
-msgid "_Turn On"
-msgstr "_ഓണ്‍ ചെയ്യുക"
-
-#: ../panels/network/net-device-wifi.c:1396
-msgid "Stop hotspot and disconnect any users?"
-msgstr "ഹോട്ട്സ്പോട്ട് നിര്‍ത്തി ഏതെങ്കിലും ഉപയോക്താക്കള്‍ വിഛേദിയ്ക്കണമോ?"
-
-#: ../panels/network/net-device-wifi.c:1399
-msgid "_Stop Hotspot"
-msgstr "ഹോട്ട്സ്പോട്ട്  _നിര്‍ത്തുക"
-
-#: ../panels/network/net-device-wifi.c:1496
-msgid "System policy prohibits use as a Hotspot"
-msgstr "ഹോട്ട്സ്പോട്ടായി ഉപയോഗിക്കാന്‍ സിസ്റ്റത്തിന്റെ നയം അനുവദിക്കുന്നില്ല"
-
-#: ../panels/network/net-device-wifi.c:1499
-msgid "Wireless device does not support Hotspot mode"
-msgstr "വയര്‍ലെസ്സ് ഡിവൈസ് ഹോട്ട്സ്പോട്ട് മോഡ് പിന്തുണയ്ക്കുന്നില്ല"
-
-#: ../panels/network/net-device-wifi.c:1630
-msgid ""
-"Network details for the selected networks, including passwords and any custom configuration will be lost."
-msgstr "രഹസ്യവാക്ക്, തയ്യാറാക്കിയ ക്രമീകരണം, എന്നിങ്ങനെയുള്ള %s-ന്റെ നെറ്റ്‌വര്‍ക്ക് വിവരങ്ങള്‍ നഷ്ടമാകുന്നു."
-
-#: ../panels/network/net-device-wifi.c:1634 ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "മറക്കുക (_F)"
-
-#: ../panels/network/net-device-wifi.c:1943 ../panels/network/net-device-wifi.c:1950
-msgid "Known Wi-Fi Networks"
-msgstr "അറിയാവുന്ന വൈ-ഫൈ ശ്രംഖലകള്‍"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1983
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "മറക്കുക (_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:102
-msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "ക്രമീകരണത്തിനുള്ളൊരു യുആര്‍എല്‍ ലഭ്യമാക്കത്തപ്പോള്‍, വെബ് പ്രോക്സി ഓട്ടോഡിസ്ക്കവറി ഉപയോഗിയ്ക്കുന്നു."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:110
-msgid "This is not recommended for untrusted public networks."
-msgstr "അവിശ്വസനീയമായ പബ്ലിക് നെറ്റ്‌വര്‍ക്കുകള്‍ക്കു് ഇതു് ഉചിതമല്ല."
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "സേവന ദാതാവു്"
-
-#: ../panels/network/network-mobile.ui.h:7
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "ശൃംഖല"
 
-#: ../panels/network/network-proxy.ui.h:1
-msgid "Network Proxy"
-msgstr "ശൃംഖലാ പ്രോക്സി"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "ഇന്റെര്‍നെറ്റില്‍ ബന്ധിപ്പിക്കുന്നതെങ്ങനെയെന്ന് തീരുമാനിക്കുന്നു"
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_HTTP Proxy"
-msgstr "_എച്ച്ടിടിപി പ്രോക്സി"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;"
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "H_TTPS Proxy"
-msgstr "എ_ച്ച്ടിടിപിഎസ് പ്രോക്സി"
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "വയര്‍ലസ്സ്"
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "_FTP Proxy"
-msgstr "എ_ഫ്‌ടിപി പ്രോക്സി"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "വൈഫൈ ശ്രംഖലകളില്‍ ബന്ധിപ്പിക്കുന്നതെങ്ങനെയെന്ന് തീരുമാനിക്കുന്നു"
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_Socks Host"
-msgstr "_Socks ഹോസ്റ്റ്"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Ignore Hosts"
-msgstr "ഹോസ്റ്റുകള്‍ _അവഗണിക്കുക"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "വയര്‍ഡ്"
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "HTTP proxy port"
-msgstr "എച്ച്ടിടിപി പ്രോക്സി പോര്‍ട്ട്"
-
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTPS proxy port"
-msgstr "എച്ച്ടിടിപിഎസ് പ്രോക്സി പോര്‍ട്ട്"
-
-#: ../panels/network/network-proxy.ui.h:12
-msgid "FTP proxy port"
-msgstr "എഫ്‌ടിപി പ്രോക്സി പോര്‍ട്ട്"
-
-#: ../panels/network/network-proxy.ui.h:13
-msgid "Socks proxy port"
-msgstr "Socks പ്രോക്സി പോര്‍ട്ട്"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "_Configuration URL"
-msgstr "ക്രമീക_രണത്തിനുള്ള യുആര്‍എല്‍"
-
-#: ../panels/network/network-simple.ui.h:7
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "ഉപകരണം ഓഫ് ചെയ്യുക"
 
-#: ../panels/network/network.ui.h:2
-msgid "Not set up"
-msgstr "ക്രമീകരിച്ചിട്ടില്ല"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "സജ്ജമാണ്"
 
-#: ../panels/network/network-vpn.ui.h:1
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "സേവന ദാതാവു്"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP വിലാസം"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "ശൃംഖലാ പ്രോക്സി"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_എച്ച്ടിടിപി പ്രോക്സി"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "എ_ച്ച്ടിടിപിഎസ് പ്രോക്സി"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "എ_ഫ്‌ടിപി പ്രോക്സി"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks ഹോസ്റ്റ്"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "ഹോസ്റ്റുകള്‍ _അവഗണിക്കുക"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "എച്ച്ടിടിപി പ്രോക്സി പോര്‍ട്ട്"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "എച്ച്ടിടിപിഎസ് പ്രോക്സി പോര്‍ട്ട്"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "എഫ്‌ടിപി പ്രോക്സി പോര്‍ട്ട്"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks പ്രോക്സി പോര്‍ട്ട്"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "ക്രമീക_രണത്തിനുള്ള യുആര്‍എല്‍"
+
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "വിപിഎന്‍ ബന്ധം ഓഫ് ചെയ്യുക"
 
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "സ്വയം _ബന്ധിപ്പിക്കുക"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "വിശദവിവരങ്ങള്‍"
-
-#: ../panels/network/network-wifi.ui.h:17 ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2 ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/sharing/sharing.ui.h:9 ../panels/user-accounts/data/account-dialog.ui.h:12
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "_രഹസ്യവാക്ക്"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "അടയാളവാക്കു് _കാണിക്കുക"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr "മറ്റുള്ള ഉപയോക്താക്കള്‍ക്ക് ലഭ്യമാക്കുക"
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "തിരിച്ചറിയല്‍"
-
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
-msgstr "_വിലാസങ്ങള്‍"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr "ഓട്ടോമാറ്റിക് (DHCP) വിലാസങ്ങള്‍ മാത്രം"
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr "ലിങ്ക്-ലോക്കല്‍ മാത്രം"
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr "മറ്റു് കമ്പ്യൂട്ടറുകളുമായി പങ്കിടുന്നു"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr "സ്വയം ലഭിച്ച റൂട്ടുകള്‍ അവ_ഗണിക്കുക"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr "_പകര്‍ത്തിയ MAC വിലാസം"
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr "ഹാര്‍ഡ്‌വെയര്‍"
-
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "_ആദ്യം മുതല്‍ തുടങ്ങുക"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid "Reset the settings for this connection to their defaults, but remember as a preferred connection."
-msgstr "ഈ ബന്ധത്തിന്റെ ഡജ്ജീകരണങ്ങള്‍ സ്വതവേയുള്ളതിലേക്ക് മാറ്റുക, പക്ഷേ, മുന്‍ഗണനയുള്ള ബന്ധമായി കരുതുക."
-
-#: ../panels/network/network-wifi.ui.h:44
-msgid "Remove all details relating to this network and do not try to automatically connect to it."
-msgstr "ഈ ശൃംഖലയുമായുള്ള എല്ലാ വിവരങ്ങളും നീക്കി തനിയെ ബന്ധിപ്പിക്കാതിരിക്കുക."
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "വീണ്ടും തുടങ്ങുക"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "ഹാര്‍ഡ്‌വെയര്‍"
-
-#: ../panels/network/network-wifi.ui.h:51
-msgctxt "tab"
-msgid "Reset"
-msgstr "വീണ്ടും തുടങ്ങുക"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട്"
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "ഒരു വയര്‍ലെസ്സ് നെറ്റ്‌വര്‍ക്കിലേക്കു് കണക്ട് ചെയ്യുന്നതിനായി സ്വിച്ച് ഓഫ് ചെയ്യുക"
-
-#: ../panels/network/network-wifi.ui.h:54
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "നെറ്റ്‌വര്‍ക്കിന്റെ പേരു്"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Connected Devices"
-msgstr "കണക്ട് ചെയ്ത ഡിവൈസുകള്‍"
-
-#: ../panels/network/network-wifi.ui.h:56
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "സുരക്ഷാ രീതി"
 
-#: ../panels/network/network-wifi.ui.h:57 ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/printers/new-printer-dialog.ui.h:14 ../panels/user-accounts/data/account-dialog.ui.h:9
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "രഹസ്യവാക്ക്"
 
-#: ../panels/network/network-wifi.ui.h:59
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "ഓണ്‍ അല്ലെങ്കില്‍ ഓഫ് ചെയ്യുക"
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "ഐച്ഛികങ്ങള്‍ ലഭ്യമാക്കുന്നു…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "അദൃശ്യമായൊരു നെറ്റ്‌വര്‍ക്കിലേക്കു് ബന്ധിപ്പിക്കുക…"
 
-#: ../panels/network/network-wifi.ui.h:61
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട് സജ്ജമാക്കുക (_T)…"
 
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "അറിയാവുന്ന വൈ-ഫൈ ശൃംഖലകള്‍"
 
-#: ../panels/network/wifi.ui.h:1
-msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
-msgstr "വൈ-ഫൈ അഡാപ്റ്റര്‍ കുത്തിയിട്ടുണ്ടെന്നും ഓണ്‍ ചെയ്തിട്ടുണ്ടെന്നും ഉറപ്പ് വരുത്തുക"
-
-#: ../panels/network/wifi.ui.h:2
-msgid "No Wi-Fi Adapter Found"
-msgstr "വൈ-ഫൈ അഡാപ്റ്റര്‍ ഒന്നും കണ്ടില്ല"
-
-#: ../panels/network/wifi.ui.h:3
-msgid "Airplane Mode"
-msgstr "വിമാന മോഡ്"
-
-#: ../panels/network/wifi.ui.h:4
-msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
-msgstr "വൈ-ഫൈ, ബ്ലുടൂത്, മൊബൈല്‍ ഇന്റെര്‍നെറ്റ് നിര്‍ത്തുന്നു"
-
-#: ../panels/network/wifi.ui.h:5
-msgid "Visible Networks"
-msgstr "കാണാവുന്ന ശൃംഖല"
-
-#: ../panels/network/wifi.ui.h:6
-msgid "NetworkManager needs to be running"
-msgstr "NetworkManager പ്രവര്‍ത്തിക്കണം"
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:127
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Infrastructure"
-msgstr "Infrastructure"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:147 ../panels/network/panel-common.c:201
-msgid "Status unknown"
-msgstr "അവസ്ഥ അറിയില്ല"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:151
-msgid "Unmanaged"
-msgstr "കൈകാര്യം ചെയ്യാത്ത"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unavailable"
-msgstr "ലഭ്യമല്ല"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:165 ../panels/network/panel-common.c:207
-msgid "Connecting"
-msgstr "ബന്ധം സ്ഥാപിക്കുന്നു"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Authentication required"
-msgstr "ആധികാരികത ഉറപ്പ് വരുത്തല്‍ ആവശ്യമുണ്ട്"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Connected"
-msgstr "ബന്ധിച്ചു"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:177
-msgid "Disconnecting"
-msgstr "വിഛേദിക്കുന്നു"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:181 ../panels/network/panel-common.c:219
-msgid "Connection failed"
-msgstr "കണക്ഷന്‍ പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:227
-msgid "Status unknown (missing)"
-msgstr "അവസ്ഥ അറിയില്ല (കാണുന്നില്ല)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223
-msgid "Not connected"
-msgstr "ബന്ധിപ്പിച്ചിട്ടില്ല"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:248
-msgid "Configuration failed"
-msgstr "ക്രമീകരണം പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "IP configuration failed"
-msgstr "ഐപി ക്രമീകരണം പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration expired"
-msgstr "ഐപി ക്രമീകരണത്തിന്റെ കാലാവധി കഴിഞ്ഞിരിയ്ക്കുന്നു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "Secrets were required, but not provided"
-msgstr "രഹസ്യങ്ങള്‍ ആവശ്യമുണ്ടു്, പക്ഷേ ലഭ്യമാക്കിയിട്ടില്ല"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x സപ്പ്ലിക്കന്റ് വിഛേദിച്ചിരിയ്ക്കുന്നു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x സപ്പ്ലിക്കന്റ് ക്രീകരണം പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant failed"
-msgstr "802.1x സപ്പ്ലിക്കന്റ് പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x സപ്പ്ലിക്കന്റ് ആധികാരികത ഉറപ്പാക്കുന്നതിനു് അധികം സമയമെടുക്കുന്നു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "PPP service failed to start"
-msgstr "പിപിപി സര്‍വീസ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service disconnected"
-msgstr "പിപിപി സര്‍വീസ് വിഛേദിച്ചിരിയ്ക്കുന്നു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP failed"
-msgstr "പിപിപി പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "DHCP client failed to start"
-msgstr "ഡിഎച്സിപി ക്ലയന്റ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client error"
-msgstr "ഡിഎച്സിപി ക്ലയന്റ് പിശക്"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client failed"
-msgstr "ഡിഎച്സിപി ക്ലയന്റ് പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "Shared connection service failed to start"
-msgstr "പങ്കിടുന്ന കണക്ഷന്‍ സര്‍വീസ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed"
-msgstr "പങ്കിടുന്ന കണക്ഷന്‍ സര്‍വീസ് പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "AutoIP service failed to start"
-msgstr "AutoIP സര്‍വീസ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service error"
-msgstr "AutoIP സര്‍വീസ് പിശക്"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service failed"
-msgstr "AutoIP സര്‍വീസ് പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "Line busy"
-msgstr "ലൈന്‍ തിരക്കിലാണു്"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "No dial tone"
-msgstr "ഡയല്‍ ടോണില്ല"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No carrier could be established"
-msgstr "ക്യാരിയര്‍ സ്ഥാപിച്ചിട്ടില്ല"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "Dialing request timed out"
-msgstr "ഡയലിങ് ആവശ്യം സമയപരിധി കഴിഞ്ഞിരിയ്ക്കുന്നു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing attempt failed"
-msgstr "ഡയലിങ് ശ്രമം പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Modem initialization failed"
-msgstr "മോഡം പ്രാരംഭം പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Failed to select the specified APN"
-msgstr "വ്യക്തമാക്കിയ എപിഎല്‍ തെരഞ്ഞെടുത്തതില്‍ പരാജയം"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Not searching for networks"
-msgstr "നെറ്റ്‌വര്‍ക്കുകള്‍ തെരയുന്നില്ല"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Network registration denied"
-msgstr "നെറ്റ്‌വര്‍ക്ക് രജിസ്ട്രേഷന്‍ നിഷേധിച്ചിരിയ്ക്കുന്നു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration timed out"
-msgstr "നെറ്റ്‌വര്‍ക്ക് രജിസ്ട്രേഷന്‍ സമയപരിധി കഴിഞ്ഞിരിയ്ക്കുന്നു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Failed to register with the requested network"
-msgstr "ആവശ്യപ്പെട്ട നെറ്റ്‌വര്‍ക്കിലേക്ക് രഡിസ്ടര്‍ ചെയ്യുന്നതില്‍ പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "PIN check failed"
-msgstr "പിന്‍ പരിശോധന പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "Firmware for the device may be missing"
-msgstr "ഡിവൈസിനുള്ള ഫേംവെയര്‍ ലഭ്യമല്ല"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Connection disappeared"
-msgstr "കണക്ഷന്‍ കാണുവാനില്ല"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Existing connection was assumed"
-msgstr "നിലവിലുള്ള കണക്ഷന്‍ കരുതപ്പെടുന്നു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Modem not found"
-msgstr "മോഡം ലഭ്യമായില്ല"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Bluetooth connection failed"
-msgstr "ബ്ലൂടൂത് കണക്ഷന്‍ പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "SIM Card not inserted"
-msgstr "സിം കാര്‍ഡ് ഇട്ടിട്ടില്ല"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Pin required"
-msgstr "സിം പിന്‍ ആവശ്യമുണ്ടു്"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Puk required"
-msgstr "സിം പൂക്ക് ആവശ്യമുണ്ടു്"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM wrong"
-msgstr "സിം തെറ്റാണു്"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "Connection dependency failed"
-msgstr "കണക്ഷന്‍ ഡിപന്‍ഡന്‍സി പരാജയപ്പെട്ടു"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:433
-msgid "Firmware missing"
-msgstr "ഫേംവെയര്‍ ലഭ്യമല്ല"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:437
-msgid "Cable unplugged"
-msgstr "കേബിള്‍ ഊരി"
-
-#: ../panels/network/wireless-security/eap-method.c:57
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:233
-msgid "no file selected"
-msgstr "ഫയല്‍ ഒന്നും എടുത്തില്ല"
-
-#: ../panels/network/wireless-security/eap-method.c:264
-msgid "unspecified error validating eap-method file"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method.c:439
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, അല്ലെങ്കില്‍ PKCS#12 സ്വകാര്യ കീകള്‍ (*.der, *.pem, *.p12, *.key)"
-
-#: ../panels/network/wireless-security/eap-method.c:442
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER അല്ലെങ്കില്‍ PEM സര്‍ട്ടിഫീക്കേറ്റുകള്‍ (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:72
-msgid "missing EAP-FAST PAC file"
-msgstr "EAP-FAST PAC ഫയല്‍ കാണുന്നില്ല"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:268
-#: ../panels/network/wireless-security/eap-method-peap.c:302
-#: ../panels/network/wireless-security/eap-method-ttls.c:351
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:283
-#: ../panels/network/wireless-security/eap-method-peap.c:272
-#: ../panels/network/wireless-security/eap-method-ttls.c:289
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:406
-msgid "Choose a PAC file"
-msgstr "ഒരു PAC ഫയല്‍ തിരഞ്ഞെടുക്കുക"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:413
-msgid "PAC files (*.pac)"
-msgstr "പിഎസി ഫയലുകള്‍ (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "അജ്ഞാതം"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "തിരിച്ചറിഞ്ഞിരിയ്ക്കുന്നു"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "രണ്ടും"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_അജ്ഞാത തിരിച്ചറിയല്‍"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "പിഎസി _ഫയല്‍"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "ഒരു PAC ഫയല്‍ തിരഞ്ഞെടുക്കുക"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "_ആന്തരിക ആധികാരികത ഉറപ്പാക്കല്‍"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-leap.c:74
-msgid "missing EAP-LEAP password"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1 ../panels/user-accounts/data/account-dialog.ui.h:4
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_ഉപയോക്താവ്"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:7 ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_രഹസ്യവാക്ക്"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "രഹസ്യവാക്ക് കാണിയ്ക്കു_ക"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:63
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-peap.c:68
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-peap.c:287
-#: ../panels/network/wireless-security/eap-method-ttls.c:336
-#: ../panels/network/wireless-security/wireless-security.c:441
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:381
-#: ../panels/network/wireless-security/eap-method-tls.c:501
-#: ../panels/network/wireless-security/eap-method-ttls.c:430
-msgid "Choose a Certificate Authority certificate"
-msgstr "ഒരു സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി സര്‍ട്ടിഫീക്കേറ്റ് തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "പതിപ്പ് 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "പതിപ്പ് 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "C_A സാക്ഷ്യപത്രം"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "ഒരു സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി സര്‍ട്ടിഫീക്കേറ്റ് തെരഞ്ഞെടുക്കുക"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr ""
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "പിഇഎപി _പതിപ്പ്"
 
-#: ../panels/network/wireless-security/eap-method-simple.c:74
-msgid "missing EAP username"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-simple.c:87
-msgid "missing EAP password"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:68
-msgid "missing EAP-TLS identity"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:77
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:84
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:95
-msgid "invalid EAP-TLS password: missing"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:109
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:119
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-tls.c:316
-msgid "Unencrypted private keys are insecure"
-msgstr "എന്‍ക്രിപ്റ്റ് ചെയ്യാത്ത സ്വകാര്യ കീകള്‍ അസുരക്ഷിതമാണു്"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:319
-msgid ""
-"The selected private key does not appear to be protected by a password. This could allow your security "
-"credentials to be compromised. Please select a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"ഈ സ്വകാര്യ ചാവി രഹസ്യവാക്ക് വെച്ച് സുരക്ഷിതമാക്കിയതായി കാണുന്നില്ല. ഇത് സുരക്ഷയെ ബാധിക്കുന്ന കാര്യമാണ്. ദയവായി രഹസ്യവാക്ക് കൊണ്ട് "
-"സുരക്ഷിതമാക്കിയ സ്വകാര്യ ചാവി തെരഞ്ഞെടുക്കുക.\n"
-"\n"
-"(ഓപ്പണ്‍ എസ്എസ്എല്‍ വെച്ച് സ്വകാര്യ കീക്ക് രഹസ്യവാക്ക് കൊടുക്കാം)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:495
-msgid "Choose your personal certificate"
-msgstr "നിങ്ങളുടെ സ്വകാര്യ സാക്ഷ്യപത്രം തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:507
-msgid "Choose your private key"
-msgstr "നിങ്ങളുടെ സ്വകാര്യ കീ തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "_തിരിച്ചറിയല്‍"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "_ഉപയോക്താവിന്റെ സാക്ഷ്യപത്രം"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "സ്വകാര്യ _ചാവി‌"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_സ്വകാര്യ കീ അടയാളവാക്ക്"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:63
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-ttls.c:68
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-ttls.c:259
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:274
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:305
+#: panels/network/wireless-security/eap-method-ttls.ui:25
 msgid "MSCHAPv2 (no EAP)"
 msgstr "MSCHAPv2 (no EAP)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:321
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/wireless-security.c:87
-msgid "Unknown error validating 802.1X security"
-msgstr ""
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "ഡൊ_മെയിന്‍"
 
-#: ../panels/network/wireless-security/wireless-security.c:453
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:477
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "എല്‍ഇഎപി"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
 msgid "PWD"
 msgstr "PWD"
 
-#: ../panels/network/wireless-security/wireless-security.c:488
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "എഫ്എഎസ്‌ടി"
 
-#: ../panels/network/wireless-security/wireless-security.c:499
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "ടണ്‍ല്ഡ് TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:510
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "സുരക്ഷിതമായ EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6 ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "_തിരിച്ചറിയല്‍"
 
-#: ../panels/network/wireless-security/ws-leap.c:63
-msgid "missing leap-username"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid "invalid wep-key: wrong key length %zu. A key must be either of length 5/13 (ascii) or 10/26 (hex)"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (സഹജം)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "Open System"
-msgstr "തുറന്ന സിസ്റ്റം"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "Shared Key"
-msgstr "പങ്കുവച്ച കീ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "_Key"
-msgstr "_കീ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Sho_w key"
-msgstr "കീ കാ_ണിക്കുക"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "WEP inde_x"
-msgstr "WEP _സൂചിക"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex digits"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_തരം"
 
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (സഹജം)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "തുറന്ന സിസ്റ്റം"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "പങ്കുവച്ച കീ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_കീ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "കീ കാ_ണിക്കുക"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP _സൂചിക"
+
 #. This is the per application switch for message tray usage.
-#: ../panels/notifications/edit-dialog.ui.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "അറിയിപ്പുകള്‍ (_N)"
 
 #. This is the setting to configure sounds associated with notifications.
-#: ../panels/notifications/edit-dialog.ui.h:4
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "ശബ്ദ അറിയിപ്പുകള്‍ (_A)"
 
-#: ../panels/notifications/edit-dialog.ui.h:5
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "പോപ്പപ്പ് അറിയിപ്പുകള്‍ (_P)"
 
-#: ../panels/notifications/edit-dialog.ui.h:6
-msgid "Notifications will continue to appear in the notification list when popups are disabled."
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
 msgstr ""
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: ../panels/notifications/edit-dialog.ui.h:8
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr ""
 
-#: ../panels/notifications/edit-dialog.ui.h:9
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr ""
 
-#: ../panels/notifications/edit-dialog.ui.h:10
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "സ്ക്രീന്‍ പൂട്ടിയിരിക്കുമ്പോള്‍ സന്ദേശങ്ങള്‍ കാണിക്കുക (_o)"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
-msgid "No­ti­fi­ca­tions"
-msgstr "അറിയിപ്പുകള്‍"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:3
-msgid "Control which notifications are displayed and what they show"
-msgstr "ഏതോക്കെ അറിയിപ്പുകളാണ് കാണിക്കുന്നതെന്നും എന്താണ് കാണിക്കുന്നതെന്നും നിയന്ത്രിക്കുക."
-
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:5
-msgid "Notifications;Banner;Message;Tray;Popup;"
-msgstr "Notifications;Banner;Message;Tray;Popup;"
-
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Notification _Popups"
-msgstr "പോപ്പപ് അറിയിപ്പുകള്‍ (_P)"
-
-#: ../panels/notifications/notifications.ui.h:2
+#: panels/notifications/cc-notifications-panel.ui:17
 #, fuzzy
-#| msgid "Notifications"
 msgid "_Lock Screen Notifications"
 msgstr "അറിയിപ്പുകള്‍"
 
-#. List of applications.
-#: ../panels/notifications/notifications.ui.h:4 ../panels/privacy/privacy.ui.h:45
-#: ../panels/sound/gvc-mixer-dialog.c:1781
-msgid "Applications"
-msgstr "പ്രയോഗങ്ങള്‍"
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "ഏതോക്കെ അറിയിപ്പുകളാണ് കാണിക്കുന്നതെന്നും എന്താണ് കാണിക്കുന്നതെന്നും നിയന്ത്രിക്കുക."
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:148
-msgctxt "Online Account"
-msgid "Other"
-msgstr "മറ്റുളളവ"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: ../panels/online-accounts/cc-online-accounts-panel.c:603
-#, c-format
-msgid "%s Account"
-msgstr "%s അക്കൌണ്ട്"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:895
-msgid "Error removing account"
-msgstr "അക്കൌണ്ട് നീക്കം ചെയ്യുന്നതില്‍ പിശക്"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: ../panels/online-accounts/cc-online-accounts-panel.c:960
-#, c-format
-msgid "<b>%s</b> removed"
-msgstr "<b>%s</b> യെ മാറ്റി"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "On­line Accounts"
-msgstr "ഓണ്‍ലൈന്‍ അക്കൌണ്ടുകള്‍"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
-msgid "Connect to your online accounts and decide what to use them for"
-msgstr "ഓണ്‍ലൈന്‍ അകൌണ്ടുകള്‍ ബന്ധിപ്പിച്ച് അവ എന്തിന് വേണ്ടി ഉപയോഗിക്കണം എന്ന് തീരുമാനിക്കുക"
-
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:5
-msgid ""
-"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
-"ReadItLater;"
-msgstr ""
-"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
-"ReadItLater;"
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Banner;Message;Tray;Popup;"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
-#: ../panels/online-accounts/online-accounts.ui.h:1 ../panels/printers/printers.ui.h:4
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "പൂർവാവസ്ഥയിലാക്കുക"
 
-#: ../panels/online-accounts/online-accounts.ui.h:2
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "അറിയിപ്പുകള്‍ കൈകാര്യം ചെയ്യുക"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr ""
 
-#: ../panels/online-accounts/online-accounts.ui.h:3
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 
-#: ../panels/online-accounts/online-accounts.ui.h:4
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "അക്കൗണ്ട് ചേര്‍ക്കുക"
 
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid "Remove Account"
-msgstr "എക്കൗണ്ട് നീക്കം ചെയ്യുക"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Online Accounts"
+msgstr "ഓണ്‍ലൈന്‍ അക്കൌണ്ടുകള്‍"
 
-#: ../panels/power/cc-power-panel.c:253
-msgid "Unknown time"
-msgstr "അജ്ഞാതസമയം"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "ഓണ്‍ലൈന്‍ അകൌണ്ടുകള്‍ ബന്ധിപ്പിച്ച് അവ എന്തിന് വേണ്ടി ഉപയോഗിക്കണം എന്ന് തീരുമാനിക്കുക"
 
-#: ../panels/power/cc-power-panel.c:259
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i മിനിട്ട്"
 msgstr[1] "%i മിനിട്ടുകള്‍"
 
-#: ../panels/power/cc-power-panel.c:271
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i മണിക്കൂര്‍"
 msgstr[1] "%i മണിക്കൂറുകള്‍"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:279
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:280
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "മണിക്കൂര്‍"
 msgstr[1] "എളുപ്പവഴി"
 
-#: ../panels/power/cc-power-panel.c:281
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "മിനിട്ട്"
 msgstr[1] "മിനിട്ടുകള്‍"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:300
-#, c-format
-msgid "%s until fully charged"
-msgstr "പൂര്‍ണ്ണമായി ചാര്‍ജ് ചെയ്യുന്നതു് വരെ %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 മിനിട്ടുകള്‍"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:307
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "സൂക്ഷിക്കുക: %s സമയം ബാക്കി"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 മിനിട്ടുകള്‍"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:312
-#, c-format
-msgid "%s remaining"
-msgstr "%s ബാക്കി"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 മിനിറ്റുകള്‍"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:317 ../panels/power/cc-power-panel.c:345
-msgid "Fully charged"
-msgstr "മുഴുവനും ചാര്‍ജ്ജ് ചെയ്തിരിയ്ക്കുന്നു"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 മിനിറ്റുകള്‍"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:321 ../panels/power/cc-power-panel.c:349
-msgid "Empty"
-msgstr "കാലി"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:336
-msgid "Charging"
-msgstr "ചാര്‍ജ് ചെയ്തുകൊണ്ടിരിയ്ക്കുന്നു"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:341
-msgid "Discharging"
-msgstr "ചാര്‍ജ് ഉപയോഗിച്ചുകൊണ്ടിരിയ്ക്കുന്നു"
-
-#: ../panels/power/cc-power-panel.c:464
-msgctxt "Battery name"
-msgid "Main"
-msgstr "പ്രധാന"
-
-#: ../panels/power/cc-power-panel.c:466
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "അധികമായ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:537
-msgid "Wireless mouse"
-msgstr "വയര്‍ലെസ്സ് മൌസ്"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgid "Wireless keyboard"
-msgstr "വയര്‍ലെസ്സ് കീബോര്‍ഡ്"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:543
-msgid "Uninterruptible power supply"
-msgstr "തടസ്സമില്ലാത്ത പവര്‍ "
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:546
-msgid "Personal digital assistant"
-msgstr "സ്വകാര്യ ഡിജിറ്റല്‍ അസിസ്റ്റന്റ്"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:549
-msgid "Cellphone"
-msgstr "സെല്‍ഫോണ്‍"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgid "Media player"
-msgstr "മീഡിയ പ്ലേയര്‍"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:555 ../panels/wacom/cc-wacom-panel.c:793
-msgid "Tablet"
-msgstr "ടാബ്ലെറ്റ്‌"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:558
-msgid "Computer"
-msgstr "കമ്പ്യൂട്ടര്‍"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:561 ../panels/power/cc-power-panel.c:801
-#: ../panels/power/cc-power-panel.c:2356
-msgid "Battery"
-msgstr "ബാറ്ററി"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:615
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "ചാര്‍ജ് ചെയ്തുകൊണ്ടിരിയ്ക്കുന്നു"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:622
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "ശ്രദ്ധിക്കുക"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:627
-msgctxt "Battery power"
-msgid "Low"
-msgstr "കുറഞ്ഞ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:632
-msgctxt "Battery power"
-msgid "Good"
-msgstr "നല്ലത്"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:637
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "മുഴുവനും ചാര്‍ജ്ജ് ചെയ്തിരിയ്ക്കുന്നു"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:641
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "കാലി"
-
-#: ../panels/power/cc-power-panel.c:799
-msgid "Batteries"
-msgstr "ബാറ്ററികള്‍"
-
-#: ../panels/power/cc-power-panel.c:1227
-msgid "When _idle"
-msgstr "_വെറുതെ ഇരിക്കുമ്പോള്‍"
-
-#: ../panels/power/cc-power-panel.c:1681
-msgid "Power Saving"
-msgstr "ഊര്‍ജ്ജ സംരക്ഷണം"
-
-#: ../panels/power/cc-power-panel.c:1712
-msgid "_Screen brightness"
-msgstr "_തിരശ്ശീല വെളിച്ചം"
-
-#: ../panels/power/cc-power-panel.c:1731
-msgid "Automatic brightness"
-msgstr "സ്വതവേയുള്ള തെളിച്ചം"
-
-#: ../panels/power/cc-power-panel.c:1751
-msgid "_Keyboard brightness"
-msgstr "കീബോര്‍ഡിന്റെ ശോഭ"
-
-#: ../panels/power/cc-power-panel.c:1761
-msgid "_Dim screen when inactive"
-msgstr "വെറുതെ ഇരിക്കുമ്പോള്‍ സ്ക്രീന്‍ _മങ്ങിക്കുക"
-
-#: ../panels/power/cc-power-panel.c:1786
-msgid "_Blank screen"
-msgstr "_ശൂന്യമായ സ്ക്രീന്‍"
-
-#: ../panels/power/cc-power-panel.c:1823
-msgid "_Wi-Fi"
-msgstr "_വയര്‍ലസ്സ്"
-
-#: ../panels/power/cc-power-panel.c:1828
-msgid "Turn off Wi-Fi to save power."
-msgstr "കറണ്ട് ലാഭിക്കാന്‍ വൈ-ഫൈ ഓഫാക്കുക."
-
-#: ../panels/power/cc-power-panel.c:1853
-msgid "_Mobile broadband"
-msgstr "മൊബൈല്‍ ബ്രോഡ്ബാന്‍ഡ്"
-
-#: ../panels/power/cc-power-panel.c:1858
-msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
-msgstr "മൊബൈല്‍ ബ്രോഡ്ബാന്‍ഡ് ഉപകരണങ്ങള്‍ (3G, 4G, LTE, etc.) ഓഫ് ചെയ്യുക."
-
-#: ../panels/power/cc-power-panel.c:1903
-msgid "_Bluetooth"
-msgstr "_ബ്ളുടൂത്ത്"
-
-#: ../panels/power/cc-power-panel.c:1966
-msgid "When on battery power"
-msgstr "ബാറ്ററിയില്‍ പ്രവര്‍ത്തിയ്ക്കുമ്പോള്‍"
-
-#: ../panels/power/cc-power-panel.c:1968
-msgid "When plugged in"
-msgstr "പ്ലഗ്ഗിന്‍ ചെയ്തപ്പോള്‍"
-
-#: ../panels/power/cc-power-panel.c:2063
-msgid "Suspend"
-msgstr "സസ്പെന്‍ഡ്"
-
-#: ../panels/power/cc-power-panel.c:2064
-msgid "Power Off"
-msgstr "നിര്‍ത്തി വെയ്ക്കുക"
-
-#: ../panels/power/cc-power-panel.c:2065
-msgid "Hibernate"
-msgstr "ശിശിരനിദ്രയിലാക്കുക"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Nothing"
-msgstr "ഒരു പ്രവര്‍ത്തിയും ചെയ്യാതിരിക്കുക"
-
-#. Frame header
-#: ../panels/power/cc-power-panel.c:2180
-msgid "Suspend & Power Button"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:2219
-msgid "_Automatic suspend"
-msgstr "_തനിയെ ഉറങ്ങുക"
-
-#: ../panels/power/cc-power-panel.c:2220
-msgid "Automatic suspend"
-msgstr "തനിയെ ഉറങ്ങുക"
-
-#: ../panels/power/cc-power-panel.c:2287
-msgid "_When the Power Button is pressed"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:2406 ../shell/cc-window.c:247 ../shell/panel-list.ui.h:1
-msgid "Devices"
-msgstr "ഉപകരണങ്ങള്‍"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Po­wer"
-msgstr ""
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:3
-msgid "View your battery status and change power saving settings"
-msgstr "ബാറ്ററിയുടെ സ്ഥിതി നോക്കി വൈദ്യുതി ലഭിക്കുക"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:5
-msgid "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-
-#: ../panels/power/power.ui.h:3
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 മിനിറ്റുകള്‍"
 
-#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 മണിക്കൂര്‍"
 
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 മിനിറ്റുകള്‍"
 
-#: ../panels/power/power.ui.h:6
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 മിനിറ്റുകള്‍"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 മിനിറ്റുകള്‍"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 മണിക്കൂര്‍"
 
-#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 മിനിട്ട്"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "ബാറ്ററി"
 
-#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 മിനിട്ടുകള്‍"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ഉപകരണങ്ങള്‍"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 മിനിട്ടുകള്‍"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "നിര്‍ത്തുക"
 
-#: ../panels/power/power.ui.h:12
-msgid "4 minutes"
-msgstr "40 മിനിറ്റുകള്‍"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 മിനിറ്റുകള്‍"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "ഊര്‍ജ്ജ സംരക്ഷണം"
 
-#: ../panels/power/power.ui.h:14
-msgid "8 minutes"
-msgstr "8 മിനിറ്റുകള്‍"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "സ്വതവേയുള്ള തെളിച്ചം"
 
-#: ../panels/power/power.ui.h:15
-msgid "10 minutes"
-msgstr "10 മിനിട്ടുകള്‍"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "സ്ക്രീന്‍ തെളിച്ചവും പൂട്ടിനുള്ള സജ്ജീകരണങ്ങള്‍"
 
-#: ../panels/power/power.ui.h:16
-msgid "12 minutes"
-msgstr "12 മിനിറ്റുകള്‍"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "സ്ക്രീന്‍"
 
-#: ../panels/power/power.ui.h:18
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "സ്വതവേയുള്ള റൂട്ട്"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "തനിയെ ഉറങ്ങുക"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "താഴെയുള്ള ബട്ടണ്‍"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "തനിയെ ഉറങ്ങുക"
 
-#: ../panels/power/power.ui.h:19
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_പ്ലഗ്ഗിന്‍ ചെയ്തിരിക്കുമ്പോള്‍"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "_ബാറ്ററിയില്‍ പ്രവര്‍ത്തിയ്ക്കുമ്പോള്‍"
 
-#: ../panels/power/power.ui.h:21 ../panels/universal-access/uap.ui.h:36
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "കാലതാമസം"
 
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "വൈദ്യുതി"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "തിരിച്ചറിയുക"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "ബാറ്ററിയുടെ സ്ഥിതി നോക്കി വൈദ്യുതി ലഭിക്കുക"
 
-#: ../panels/printers/authentication-dialog.ui.h:4 ../panels/printers/new-printer-dialog.ui.h:13
-msgid "Username"
-msgstr "ഉപയോക്താവിന്റെ പേര്"
-
-#: ../panels/printers/authentication-dialog.ui.h:6 ../panels/printers/new-printer-dialog.ui.h:11
-msgid "Authentication Required"
-msgstr "ആധികാരികത ഉറപ്പ് വരുത്തേണ്ടതുണ്ട്"
-
-#. Translators: %s is the printer name
-#: ../panels/printers/cc-printers-panel.c:717
-#, c-format
-msgid "Printer “%s” has been deleted"
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:908
-msgid "Failed to add new printer."
-msgstr "പുതിയ പ്രിന്റര്‍ ചേര്‍ക്കുന്നതില്‍ പരാജയം."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:1220
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui ലഭ്യമാക്കുവാന്‍ സാധ്യമല്ല: %s"
-
-#: ../panels/printers/details-dialog.ui.h:2 ../panels/printers/printer-entry.ui.h:8
-msgid "Location"
-msgstr "സ്ഥലം"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/details-dialog.ui.h:4 ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "ഡ്രൈവര്‍"
-
-#: ../panels/printers/details-dialog.ui.h:5
-msgid "Searching for preferred drivers…"
-msgstr "ഇഷ്ടമുള്ള ഡ്രൈവറുകള്‍ക്കായി തെരയുന്നു…"
-
-#: ../panels/printers/details-dialog.ui.h:6
-msgid "Search for Drivers"
-msgstr "ഡ്രൈവറുകള്‍ക്കായി തെരയു"
-
-#: ../panels/printers/details-dialog.ui.h:7
-msgid "Select from Database…"
-msgstr "ഡേറ്റാബെയിസില്‍ നിന്നും തെരഞ്ഞെടുക്കുക…"
-
-#: ../panels/printers/details-dialog.ui.h:8
-msgid "Install PPD File…"
-msgstr "പിപിഡി ഫയല്‍ ഇന്‍സ്റ്റാള്‍ ചെയ്യുക…"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
-msgid "Prin­ters"
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
 msgstr "പ്രിന്ററുകള്‍"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "പ്രിന്റെര്‍ ചേര്‍ക്കുക, ജോലികള്‍ കാണുക പിന്നെ എങ്ങനെ പ്രിന്റ് എടുക്കണമെന്ന് തീരുമാനിക്കുക"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:5
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
 
-#. Translators: this action removes (purges) all the listed jobs from the list.
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Clear All"
-msgstr "എല്ലാം വെടിപ്പാക്കുക"
-
-#. Translators: this label describes the dialog empty state, with no jobs listed.
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "No Active Printer Jobs"
-msgstr "സജീവമായ പ്രിന്‍റര്‍ ജോലികളില്ല"
-
 #. Translators: This is the title presented at top of the dialog.
-#: ../panels/printers/new-printer-dialog.ui.h:2 ../panels/printers/pp-new-printer-dialog.c:384
-#: ../panels/printers/pp-new-printer-dialog.c:456
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "പ്രിന്റര്‍ ചേര്‍ക്കുക"
 
+#. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:6
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_അണ്‍ലോക്ക് ചെയ്യുക"
 
 #. Translators: No printers were detected
-#: ../panels/printers/new-printer-dialog.ui.h:8
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "പ്രിന്റെറുകളൊന്നും കണ്ടില്ല"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:10
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr ""
 
-#: ../panels/printers/new-printer-dialog.ui.h:12
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "ആധികാരികത ഉറപ്പ് വരുത്തേണ്ടതുണ്ട്"
+
+#: panels/printers/new-printer-dialog.ui:308
 #, fuzzy
-#| msgid "Enter your username and password to view printers available on %s."
 msgid "Enter username and password to view printers on Print Server."
 msgstr "%s ഉള്ള പ്രിന്റ്ററുകൾ കാണുവാൻ യുസർ നെയിമും പാസ്സ് വേഡും കൊടുക്കുക"
 
-#. Translators: This button triggers the printing of a test page.
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/options-dialog.ui.h:2 ../panels/printers/pp-options-dialog.c:893
-msgid "Test Page"
-msgstr "പരീക്ഷണ താള്‍"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ഉപയോക്താവിന്റെ പേര്"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: ../panels/printers/pp-details-dialog.c:123 ../panels/printers/pp-details-dialog.c:415
-#, c-format
-msgid "%s Details"
-msgstr "%s വിശദാംശങ്ങൾ"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
 
-#: ../panels/printers/pp-details-dialog.c:172
-msgid "No suitable driver found"
-msgstr "ഉചിതമായ ഡ്രൈവര്‍ ലഭ്യമായില്ല"
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "സ്ഥലം"
 
-#: ../panels/printers/pp-details-dialog.c:316
-msgid "Select PPD File"
-msgstr "പിപിഡി ഫയല്‍ തെരഞ്ഞെടുക്കുക"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "ഡ്രൈവര്‍"
 
-#: ../panels/printers/pp-details-dialog.c:325
-msgid "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-msgstr "പോസ്റ്റ്സ്ക്രിപ്റ്റ് പ്രിന്റര്‍ വിവരണ ഫയലുകള് (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "ഇഷ്ടമുള്ള ഡ്രൈവറുകള്‍ക്കായി തെരയുന്നു…"
 
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "ഡ്രൈവറുകള്‍ക്കായി തെരയു"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "ഡേറ്റാബെയിസില്‍ നിന്നും തെരഞ്ഞെടുക്കുക…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "പിപിഡി ഫയല്‍ ഇന്‍സ്റ്റാള്‍ ചെയ്യുക…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "പ്രിന്റര്‍ ഡ്രൈവര്‍ തെരഞ്ഞെടുക്കുക"
 
-#: ../panels/printers/ppd-selection-dialog.ui.h:3 ../panels/user-accounts/um-photo-dialog.c:96
-msgid "Select"
-msgstr "തെരഞ്ഞെടുക്കുക"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
+#: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "ഡ്രൈവറുകളുടെ ഡേറ്റാബെയിസ് ലഭ്യമാക്കുന്നു…"
 
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:539
-msgid "JetDirect Printer"
-msgstr "ജെറ്റ്ഡയറക്റ്റ് പ്രിന്റര്‍"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "റദ്ദാക്കുക"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:795
-msgid "LPD Printer"
-msgstr "LPD പ്രിന്‍റര്‍"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "തെരഞ്ഞെടുക്കുക"
 
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66 ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "ഒരു വശത്തു്"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68 ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "ലോങ് എഡ്ജ് (സാധാരണ)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70 ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "ഷോര്‍ട്ട് എഡ്ജ് (ഫ്ലിപ്പ്)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "പൊട്രെയിറ്റ്"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "ലാന്‍ഡ്സ്കെയിപ്പ്"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "റിവേഴ്സ് ലാന്‍ഡ്സ്കെയിപ്പ്"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "റിവേഴ്സ് പൊട്രെയിറ്റ്"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:104
-msgctxt "print job"
-msgid "Pending"
-msgstr "ബാക്കിയുളള"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:108
-msgctxt "print job"
-msgid "Paused"
-msgstr "താല്‍ക്കാലികമായി നിര്‍ത്തിയിരിക്കുന്നു"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:112
-msgctxt "print job"
-msgid "Processing"
-msgstr "പ്രവര്‍ത്തനത്തില്‍"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:116
-msgctxt "print job"
-msgid "Stopped"
-msgstr "നിര്‍ത്തിയിരിയ്ക്കുന്നു"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:120
-msgctxt "print job"
-msgid "Canceled"
-msgstr "റദ്ദാക്കിയിരിക്കുന്നു"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:124
-msgctxt "print job"
-msgid "Aborted"
-msgstr "പാതിവഴിയില്‍ നിര്‍ത്തിയിരിക്കുന്നു"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:128
-msgctxt "print job"
-msgid "Completed"
-msgstr "പൂര്‍ത്തിയാക്കിയിരിക്കുന്നു"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: ../panels/printers/pp-jobs-dialog.c:310
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — സജീവമായ ജോലികള്‍"
-
-#: ../panels/printers/pp-new-printer-dialog.c:402
-msgid "Unlock Print Server"
-msgstr "പ്രിന്റ് സെര്‍വ്വര്‍ തുറക്കുക"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-new-printer-dialog.c:406
-#, c-format
-msgid "Unlock %s."
-msgstr "തുറക്കുക %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-new-printer-dialog.c:411
+#: panels/printers/pp-jobs-dialog.c:318
 #, fuzzy, c-format
-#| msgid "Enter your username and password to view printers available on %s."
-msgid "Enter username and password to view printers on %s."
-msgstr "%s ഉള്ള പ്രിന്റ്ററുകൾ കാണുവാൻ യുസർ നെയിമും പാസ്സ് വേഡും കൊടുക്കുക"
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "സെര്‍വറിന് പ്രാമാണ്യം ആവശ്യമുണ്ട്"
+msgstr[1] "സെര്‍വറിന് പ്രാമാണ്യം ആവശ്യമുണ്ട്"
 
-#: ../panels/printers/pp-new-printer-dialog.c:876
-msgid "Searching for Printers"
-msgstr "പ്രിന്റെറുകള്‍ക്കായി തെരയുന്നു"
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "ഡൊ_മെയിന്‍"
 
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1799
-msgid "USB"
-msgstr "USB"
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "തിരിച്ചറിയുക"
 
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1804
-msgid "Serial Port"
-msgstr "തുടര്‍ച്ചയായ പോര്‍ട്ട്"
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "എല്ലാം വെടിപ്പാക്കുക"
 
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1811
-msgid "Parallel Port"
-msgstr "സമാന്തരമായ പോര്‍ട്ട്"
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "തിരിച്ചറിയുക"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/printers/pp-new-printer-dialog.c:1816
-msgid "Bluetooth"
-msgstr "ബ്ലൂടൂത്ത്"
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "സജീവമായ പ്രിന്‍റര്‍ ജോലികളില്ല"
 
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1853
-#, c-format
-msgid "Location: %s"
-msgstr "സ്ഥലം: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1858
-#, c-format
-msgid "Address: %s"
-msgstr "_വിലാസം: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1887
-msgid "Server requires authentication"
-msgstr "സെര്‍വറിന് പ്രാമാണ്യം ആവശ്യമുണ്ട്"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Two Sided"
-msgstr "രണ്ടു് വശത്തും"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Paper Type"
-msgstr "പേപ്പര്‍ തരം"
-
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Paper Source"
-msgstr "പേപ്പര്‍ ശ്രോതസ്സ്"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "Output Tray"
-msgstr "ഔട്ട്പുട്ട് ട്രേ"
-
-#: ../panels/printers/pp-options-dialog.c:88
-msgid "GhostScript pre-filtering"
-msgstr "ഗോസ്റ്റ്സ്ക്രിപ്റ്റ് പ്രീ-ഫില്‍റ്ററിങ്"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:534
-msgid "Pages per side"
-msgstr "ഒരു വശത്തുള്ള താളുകള്‍"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:546
-msgid "Two-sided"
-msgstr "രണ്ടു് വശത്തും"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "സാധാരണ"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "താള്‍ സജ്ജീകരണം"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "ഇന്‍സ്റ്റോള്‍ ചെയ്യുവാന്‍ സാധ്യമാകുന്ന ഐച്ഛികങ്ങള്‍"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "ജോലി"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "ഇമേജിന്റെ ഗുണം"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "നിറം"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "പൂര്‍ത്തിയാകുന്നു"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:676
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "അധികമായതു്"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/pp-options-dialog.c:908
-msgid "Test page"
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
 msgstr "പരീക്ഷണ താള്‍"
 
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76 ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "സ്വയം തെരഞ്ഞെടുക്കല്‍"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80 ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84 ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "സഹജമായ പ്രിന്റര്‍"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "ഗോസ്റ്റ്സ്ക്രിപ്റ്റ് അക്ഷരസഞ്ചയങ്ങള്‍ മാത്രം എംബഡ് ചെയ്യുക"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "പിഎസ് ലവല്‍ 1 വേര്‍തിരിയ്ക്കുക"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "പിഎസ് ലവല്‍ 2 വേര്‍തിരിയ്ക്കുക"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "പ്രീ-ഫില്‍റ്ററിങ് ലഭ്യമല്ല"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "ഉല്‍പാദകന്‍"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: ../panels/printers/pp-printer-entry.c:577
-msgid "No Active Jobs"
-msgstr "സജീവമായ ജോലികള്‍ ഇല്ല"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: ../panels/printers/pp-printer-entry.c:582
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u ജോലി"
 msgstr[1] "%u ജോലികള്‍"
 
-#. Translators: The printer is low on toner
-#: ../panels/printers/pp-printer-entry.c:730
-msgid "Low on toner"
-msgstr "ടോണര്‍ കുറവാണു്"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/pp-printer-entry.c:732
-msgid "Out of toner"
-msgstr "ടോണര്‍ കാലിയാണു്"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/pp-printer-entry.c:735
-msgid "Low on developer"
-msgstr "ഡെവെലപ്പര്‍ കുറവാണു്‌"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/pp-printer-entry.c:738
-msgid "Out of developer"
-msgstr "ഡെവെലപ്പര്‍ ഇല്ല"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/pp-printer-entry.c:740
-msgid "Low on a marker supply"
-msgstr "മഷി കുറവു്"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/pp-printer-entry.c:742
-msgid "Out of a marker supply"
-msgstr "മഷി തീര്‍ത്തിരിയ്ക്കുന്നു"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/pp-printer-entry.c:744
-msgid "Open cover"
-msgstr "കവര്‍ തുറക്കുക"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/pp-printer-entry.c:746
-msgid "Open door"
-msgstr "വാതില്‍ തുറക്കുക"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/pp-printer-entry.c:748
-msgid "Low on paper"
-msgstr "പേപ്പര്‍ കുറവു്"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/pp-printer-entry.c:750
-msgid "Out of paper"
-msgstr "പേപ്പര്‍ തീര്‍ന്നു"
-
-#. Translators: The printer is offline
-#: ../panels/printers/pp-printer-entry.c:752
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ഓഫ്‌ലൈന്‍"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/pp-printer-entry.c:754 ../panels/printers/pp-printer-entry.c:884
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "നിര്‍ത്തിയിരിയ്ക്കുന്നു"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/pp-printer-entry.c:756
-msgid "Waste receptacle almost full"
-msgstr "വെയിസ്റ്റ് റിസപ്ടബിള്‍ ഏകദേശം പൂര്‍ണ്ണം"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/pp-printer-entry.c:758
-msgid "Waste receptacle full"
-msgstr "വെയിസ്റ്റ് റിസപ്ടബിള്‍ പൂര്‍ണ്ണം"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/pp-printer-entry.c:760
-msgid "The optical photo conductor is near end of life"
-msgstr "ഒപ്ടിക്കല്‍ ഫോട്ടോ കണ്ടക്ടര്‍ അവസാനിയ്ക്കുന്നു"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/pp-printer-entry.c:762
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ഒപ്ടിക്കല്‍ ഫോട്ടോ കണ്ടക്ടര്‍ പ്രവര്‍ത്തനത്തിലില്ല"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/pp-printer-entry.c:870
-msgctxt "printer state"
-msgid "Ready"
-msgstr "തയ്യാര്‍"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/pp-printer-entry.c:875
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "ജോലി ഒന്നും എടുക്കുന്നില്ല"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/pp-printer-entry.c:880
-msgctxt "printer state"
-msgid "Processing"
-msgstr "പ്രവര്‍ത്തനത്തില്‍"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: ../panels/printers/pp-printer-entry.c:904
-msgid "Clean print heads"
-msgstr "പ്രിന്റര്‍ ഹെഡ്ഡ് വൃത്തിയാക്കുക"
-
-#: ../panels/printers/printer-entry.ui.h:1
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "പ്രിന്റ് ഐച്ഛികങ്ങള്‍"
 
-#: ../panels/printers/printer-entry.ui.h:2
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "പ്രിന്റര്‍ വിശദാംശങ്ങള്‍"
 
-#: ../panels/printers/printer-entry.ui.h:3
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
 #, fuzzy
-#| msgid "Printer Default"
 msgid "Use Printer by Default"
 msgstr "സഹജമായ പ്രിന്റര്‍"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: ../panels/printers/printer-entry.ui.h:5
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "പ്രിന്റ് ഹെഡ്ഡ് വൃത്തിയാക്കുക"
 
-#: ../panels/printers/printer-entry.ui.h:6
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "പ്രിന്റര്‍ നീക്കം ചെയ്യുക"
 
-#: ../panels/printers/printer-entry.ui.h:7
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "സജീവമായ ജോലികള്‍ ഇല്ല"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "മോഡല്‍"
 
-#: ../panels/printers/printer-entry.ui.h:9
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "ഇങ്കിന്റെ അവസ്ഥ"
 
 #. Translators: This is the message which follows the printer error.
-#: ../panels/printers/printer-entry.ui.h:11
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "പ്രശ്നം പരിഹരിക്കുമ്പോള്‍ ദയവായി പുനരാരംഭിക്കുക"
 
 #. Translators: This is the button which restarts the printer.
-#: ../panels/printers/printer-entry.ui.h:13
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "പുനരാരംഭിക്കൂ"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:2
-msgid "Add…"
-msgstr "ചേര്‍ക്കുക..."
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "പ്രിന്റര്‍ ചേര്‍ക്കുക…"
 
-#: ../panels/printers/printers.ui.h:5
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "പ്രിന്റര്‍ ചേര്‍ക്കുക…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "പ്രിന്റെറുകളൊന്നും ഇല്ല"
 
-#. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:7
-msgid "Add a Printer…"
-msgstr "പ്രിന്റര്‍ ചേര്‍ക്കുക…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:9
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "ക്ഷമിയ്ക്കണം, സിസ്റ്റത്തിനുള്ള പ്രിന്റിങ് സര്‍വീസ്\n"
 "ലഭ്യമല്ല."
 
-#: ../panels/privacy/cc-privacy-panel.c:387 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "സ്ക്രീന്‍ പൂട്ട്"
-
-#: ../panels/privacy/cc-privacy-panel.c:438
-msgid "In use"
-msgstr "ഉപയോഗത്തല്‍ ഇരിക്കുന്നു"
-
-#: ../panels/privacy/cc-privacy-panel.c:443
-msgctxt "Location services status"
-msgid "On"
-msgstr "ഓണ്‍"
-
-#: ../panels/privacy/cc-privacy-panel.c:444
-msgctxt "Location services status"
-msgid "Off"
-msgstr "ഓഫ്"
-
-#: ../panels/privacy/cc-privacy-panel.c:823 ../panels/privacy/privacy.ui.h:42
-msgid "Location Services"
-msgstr ""
-
-#: ../panels/privacy/cc-privacy-panel.c:942 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "ഉപയോഗവും ചരിത്രവും"
-
-#: ../panels/privacy/cc-privacy-panel.c:1071
-msgid "Empty all items from Trash?"
-msgstr "ചവറ്റുകൊട്ട വൃത്തിയാക്കുക?"
-
-#: ../panels/privacy/cc-privacy-panel.c:1072
-msgid "All items in the Trash will be permanently deleted."
-msgstr "ചവറ്റുകുട്ടയിലെ വസ്തുകൾ ശാശ്വതമായി ഉപേക്ഷിക്കപ്പെടും"
-
-#: ../panels/privacy/cc-privacy-panel.c:1073
-msgid "_Empty Trash"
-msgstr "ചവറ്റുകുട്ട _ഒഴിപ്പിക്കുക"
-
-#: ../panels/privacy/cc-privacy-panel.c:1096
-msgid "Delete all the temporary files?"
-msgstr "ചവറ്റുകുട്ടയും താല്‍ക്കാലിക ഫയലുകളും ശൂന്യമാക്കുകയല്ലേ ?"
-
-#: ../panels/privacy/cc-privacy-panel.c:1097
-msgid "All the temporary files will be permanently deleted."
-msgstr "എല്ലാ താൽകാലിക രേഖകളും ശാശ്വതമായി ഉപേക്ഷിക്കപ്പെടും"
-
-#: ../panels/privacy/cc-privacy-panel.c:1098
-msgid "_Purge Temporary Files"
-msgstr "താല്‍ക്കാലിക ഫയലുകള്‍ _മായ്ക്കുക"
-
-#: ../panels/privacy/cc-privacy-panel.c:1120 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "ചവറ്റുകുട്ടയും താല്‍ക്കാലിക ഫയലുകളും ശൂന്യമാക്കുക"
-
-#: ../panels/privacy/cc-privacy-panel.c:1160 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr "സോഫ്റ്റ്‌വെയര്‍ ഉപയോഗം"
-
-#: ../panels/privacy/cc-privacy-panel.c:1201 ../panels/privacy/privacy.ui.h:46
-msgid "Problem Reporting"
-msgstr ""
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: ../panels/privacy/cc-privacy-panel.c:1215
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent anonymously and are scrubbed of "
-"personal data."
-msgstr ""
-
-#: ../panels/privacy/cc-privacy-panel.c:1227 ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "സ്വകാര്യത നയം"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Pri­va­cy"
-msgstr "സ്വകാര്യത"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:3
-msgid "Protect your personal information and control what others might see"
-msgstr "സ്വകാര്യ വിവരങ്ങള്‍ സംരക്ഷിക്കുക; മറ്റുള്ളവര്‍ എന്തു കാണണമെന്ന് തീരുമാനിക്കുക"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:5
-msgid "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;"
-msgstr "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "സ്ക്രീന്‍ ഓഫ് ആകുന്നു"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 സെക്കന്‍ഡുകള്‍"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 ദിവസം"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 ദിവസം"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 ദിവസം"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 ദിവസം"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 ദിവസം"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 ദിവസം"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 ദിവസം"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 ദിവസം"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 ദിവസം"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "എന്നന്നേക്കും"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are never shared over the network."
-msgstr "ചരിത്രം ഓര്‍മിച്ചുവെയ്ക്കുന്നത് കാര്യങ്ങള്‍ വിണ്ടും കണ്ടുപിടിക്കുന്നത് എളുപ്പമാക്കും. ഇത് ശ്രംഖല വഴി ഒരിക്കലും പങ്കിടില്ല."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "ഏറ്റവും _ഒടുവില്‍ ഉപയോഗിച്ച"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "ചരിത്രം _നിലനിര്‍ത്തുക"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "അടുത്തിടെയുള്ള ചരിത്രം _മായ്ക്കുക"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "നിങ്ങള്‍ ദൂരെയായിരിക്കുമ്പോള്‍ നിങ്ങളുടെ സ്വകാര്യത സ്ക്രീന്‍ പൂട്ട് സംരക്ഷിക്കുന്നു."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "തനിയെ സ്ക്രീന്‍ _പൂട്ടുക"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "സ്ക്രീന്‍ പൂട്ടുന്നതിനു മുന്പ് _ശൂന്യമായി"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "_അറിയിപ്പുകള്‍ കാണിയ്ക്കുക"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer free of unnecessary sensitive "
-"information."
-msgstr ""
-"ആവശ്യമില്ലാത്ത സ്വകാര്യ വിവരങ്ങള്‍ താങ്കളുടെ കമ്പ്യൂട്ടറില്‍ നിന്നും ഒഴിവാക്കാന്‍ തനിയെ ചവറ്റുകുട്ടയും താല്‍ക്കാലിക ഫയലുകളും നശിപ്പിക്കുക."
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "തനിയെ _ചവറ്റുകുട്ട ഒഴിപ്പിക്കുക"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "തനിയെ താല്‍ക്കാലിക _ഫയലുകള്‍ ഒഴിപ്പിക്കുക"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "_ശേഷം ഒഴിപ്പിക്കുക"
-
-#: ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash…"
-msgstr "ചവറ്റുകുട്ട ഒഴിപ്പിക്കുക (_E)"
-
-#: ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files…"
-msgstr "താല്‍ക്കാലിക ഫയലുകള്‍ മായ്ക്കുക (_P)…"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you with more accurate recommendations. "
-"It also helps us to improve our software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share your data with third parties."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "സോഫ്റ്റ്‌വെയര്‍ ഉപയോഗത്തിന്റെ വിവരം അയയ്ക്കുക"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and mobile broadband increases "
-"accuracy."
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:44
-msgid "_Location Services"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:47
-msgid "_Automatic Problem Reporting"
-msgstr ""
-
-#: ../panels/region/cc-format-chooser.c:118
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ഇംപീരിയല്‍"
-
-#: ../panels/region/cc-format-chooser.c:120
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "മെട്രിക്"
-
-#: ../panels/region/cc-format-chooser.c:285
-msgid "No regions found"
-msgstr "ഒരു മേഖലയും കണ്ടില്ല"
-
-#: ../panels/region/cc-input-chooser.c:182
-msgid "No input sources found"
-msgstr "ഇന്‍പുട്ട് ഉറവിടങ്ങളൊന്നും കണ്ടില്ല"
-
-#: ../panels/region/cc-input-chooser.c:1012
-msgctxt "Input Source"
-msgid "Other"
-msgstr "മറ്റുളളവ"
-
-#: ../panels/region/cc-region-panel.c:881
-msgid "No input source selected"
-msgstr "ഇന്‍പുട്ട് ഉറവിടങ്ങളൊന്നും എടുത്തില്ല"
-
-#: ../panels/region/cc-region-panel.c:1773
-msgid "Login _Screen"
-msgstr "പ്രവേശന സ്ക്രീന്‍ (_S)"
-
-#: ../panels/region/format-chooser.ui.h:1
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ശൈലികള്‍"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "സ്ഥലം തെരയുക"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "സാധാരണയായുള്ള പ്രവര്‍ത്തികള്‍ "
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "ശൈലികള്‍"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "തെരയല്‍ സജ്ജീകരണങ്ങള്‍"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "തിരനോട്ടം"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "തിയ്യതികള്‍"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "തവണ"
-
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "തീയതിയും സമയവും"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "സംഖ്യകള്‍"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "അളവു്"
 
-#: ../panels/region/format-chooser.ui.h:10
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "കടലാസ്"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid "Re­gion & Lan­guage"
-msgstr "സ്ഥലവും ഭാഷയും"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
-msgid "Select your display language, formats, keyboard layouts and input sources"
-msgstr "നിങ്ങളുടെ ഭാഷ, ഘടന, കീബോർഡ് മാതൃക, ഇൻപുട്ട് സോർസ് എന്നിവ തിരഞ്ഞെടുക്കുക"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:5
-msgid "Language;Layout;Keyboard;Input;"
-msgstr "Language;Layout;Keyboard;Input;"
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "ഇന്‍പുട്ട് ഉറവിടം ചേര്‍ക്കുക"
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "ഭാഷകള്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യുക..."
 
-#: ../panels/region/input-chooser.ui.h:4
-msgid "Input methods can’t be used on the login screen"
-msgstr "പ്രവേശിക്കുമ്പോള്‍ ഇന്‍പുട്ട് മെത്തേഡുകള്‍ ഉപയോഗിക്കാനാവില്ല"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "നിങ്ങളുടെ അക്കൌണ്ട്‌"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "ഇന്‍പുട്ട് ഉറവിട സജ്ജീകരണങ്ങള്‍"
-
-#: ../panels/region/input-options.ui.h:2
-msgid "Use the _same source for all windows"
-msgstr "എല്ലാ വിന്‍ഡോയ്ക്കും _ഒരേ സ്ത്രോതസ്സ് ഉപയോഗിക്കുക"
-
-#: ../panels/region/input-options.ui.h:3
-msgid "Allow _different sources for each window"
-msgstr "ഓരോ ജാലകത്തിനും _വെവ്വേറെ സ്ത്രോതസ്സുകള്‍ അനുവദിക്കുക"
-
-#: ../panels/region/input-options.ui.h:5
-msgid "Switch to previous source"
-msgstr "മുമ്പുള്ള ശ്രോതസ്സിലേക്കു് മാറുക"
-
-#: ../panels/region/input-options.ui.h:6
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
-
-#: ../panels/region/input-options.ui.h:7
-msgid "Switch to next source"
-msgstr "അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുക"
-
-#: ../panels/region/input-options.ui.h:8
-msgid "Super+Space"
-msgstr "നല്ലത്+സ്ഥലം"
-
-#: ../panels/region/input-options.ui.h:9
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr " കീ ക്രമം മാറ്റികൊണ്ട് ഈ ഷോർട്ട്കട്ട് മാറ്റാവുന്നതാണ്"
-
-#: ../panels/region/input-options.ui.h:10
-msgid "Alternative switch to next source"
-msgstr "പകരം അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുക"
-
-#: ../panels/region/input-options.ui.h:11
-msgid "Left+Right Alt"
-msgstr "വലത്+ഇടത് ആള്‍ട്ട്"
-
-#: ../panels/region/region.ui.h:1 ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "ഭാ_ഷ"
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "ഇംഗ്ലീഷ് (യുണിറ്റഡ് കിങ്ഡം)"
-
-#: ../panels/region/region.ui.h:3
-msgid "Restart the session for changes to take effect"
-msgstr "മാറ്റങ്ങള്‍ കാണാന്‍ പുറത്തിറങ്ങുക"
-
-#: ../panels/region/region.ui.h:4
-msgid "Restart…"
-msgstr "പുനരാരംഭിക്കുക…"
-
-#: ../panels/region/region.ui.h:5
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "ശൈലികള്‍ (_F)"
 
-#: ../panels/region/region.ui.h:6
-msgid "United Kingdom"
-msgstr "യുണിറ്റഡ് കിങ്ഡം"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "പ്രവേശന സ്ക്രീന്‍ (_S)"
 
-#: ../panels/region/region.ui.h:7
-msgid "Input Sources"
-msgstr "ഇന്‍പുട്ട് ഉറവിടങ്ങള്‍"
+#: panels/region/gnome-region-panel.desktop.in.in:3
+#, fuzzy
+msgid "Region & Language"
+msgstr "സ്ഥലവും ഭാഷയും"
 
-#: ../panels/region/region.ui.h:8
-msgid "_Options"
-msgstr "_ഐച്ഛികങ്ങള്‍"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "കാണിക്കാനുള്ള ഒരു ഭാഷ തെരഞ്ഞെടുക്കുക"
 
-#: ../panels/region/region.ui.h:9
-msgid "Add input source"
-msgstr "ഇന്‍പുട്ട് ഉറവിടം ചേര്‍ക്കുക"
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;"
 
-#: ../panels/region/region.ui.h:10
-msgid "Remove input source"
-msgstr "ഇന്‍പുട്ട് ഉറവിടം വെട്ടി നീക്കുക"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "മീഡിയ എങ്ങനെ കൈകാര്യം ചെയ്യണമെന്നു് തെരഞ്ഞെടുക്കുക"
 
-#: ../panels/region/region.ui.h:11
-msgid "Move input source up"
-msgstr "ഇന്‍പുട്ട് ഉറവിടം മുകളിലേക്കു് നീക്കുക"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "ശ്ര_വണ സിഡി"
 
-#: ../panels/region/region.ui.h:12
-msgid "Move input source down"
-msgstr "ഇന്‍പുട്ട് ഉറവിടം താഴേയ്ക്ക് നീക്കുക"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_ഡിവിഡി വീഡിയോ"
 
-#: ../panels/region/region.ui.h:13
-msgid "Configure input source"
-msgstr "ഇന്‍പുട്ട് ശ്രോതസ്സ് സജ്ജീകരിക്കുക"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_പാട്ടുപെട്ടി"
 
-#: ../panels/region/region.ui.h:14
-msgid "Show input source keyboard layout"
-msgstr "കീബോര്‍ഡ് വിന്യാസം കാണിയ്ക്കുക"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_സോഫ്റ്റവെയര്‍"
 
-#: ../panels/region/region.ui.h:15
-msgid "Login settings are used by all users when logging into the system"
-msgstr "സിസ്റ്റത്തിലേക്ക് പ്രവേശിക്കുമ്പോള്‍ എല്ലാ ഉപയോക്താകളും പ്രവേശന കൃമീകരണങ്ങള്‍ ഉപയോഗിക്കും"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_മറ്റു് മാധ്യമം…"
 
-#: ../panels/search/cc-search-locations-dialog.c:639
-msgid "Select Location"
-msgstr "സ്ഥലം തെരഞ്ഞെടുക്കുക"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "മാധ്യമം വയ്ക്കുമ്പോള്‍ _ഒരിയ്ക്കലും പ്രോഗ്രാമുകള്‍ തുടങ്ങുകയോ ഓര്‍മ്മപ്പെടുത്തുകയോ വേണ്ട"
 
-#: ../panels/search/cc-search-locations-dialog.c:643
-msgid "_OK"
-msgstr "ശരി"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "മറ്റു് മീഡിയ എങ്ങനെ കൈകാര്യം ചെയ്യണമെന്നു് തെരഞ്ഞെടുക്കുക"
 
-#: ../panels/search/cc-search-panel.c:178
-msgid "No applications found"
-msgstr "ഒരു പ്രയോഗങ്ങളും കണ്ടില്ല"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "പ്ര_വര്‍ത്തി:"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
-msgid "Search"
-msgstr "തെരച്ചില്‍"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_തരം:"
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:3
-msgid "Control which applications show search results in the Activities Overview"
-msgstr "പ്രവര്‍ത്തനങ്ങളില്‍ ഏതൊക്കെ പ്രയോഗങ്ങള്‍ തെരയല്‍ ഫലങ്ങള്‍ കാണുമെന്ന് തീരുമാനിക്കുക"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "മാറ്റുവാന്‍ സാധ്യമാകുന്ന മീഡിയ"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:5
-msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "Search;Find;Index;Hide;Privacy;Results;"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "മാറ്റാന്‍ സാധിക്കുന്ന മീഡിയയുടെ സജ്ജീകരണങ്ങള്‍ ക്രമീകരിക്കുക"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "സ്ക്രീന്‍ പൂട്ട്"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "_ശൂന്യമായ സ്ക്രീന്‍"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "തനിയെ സ്ക്രീന്‍ _പൂട്ടുക"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "തനിയെ സ്ക്രീന്‍ _പൂട്ടുക"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "_അറിയിപ്പുകള്‍ കാണിയ്ക്കുക"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "പൂട്ടിയ സ്ക്രീന്‍ (_L)"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "സ്വകാര്യത"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "സ്ക്രീന്‍"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "ശബ്ദ ക്രമീകരണങ്ങള്‍"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "സ്ഥലം തെരയുക"
 
-#: ../panels/search/search-locations-dialog.ui.h:2
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr "സ്ഥലങ്ങള്‍"
 
-#: ../panels/search/search-locations-dialog.ui.h:3
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "ഓര്‍മ്മക്കുറിപ്പുകള്‍"
 
-#: ../panels/search/search-locations-dialog.ui.h:4
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "മറ്റുളളവ"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "മുകളിലേയ്ക്കു് മാറ്റുക"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "സ്ഥലം"
 
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "താഴേയ്ക്കു് മാറ്റുക"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "പ്രയോഗങ്ങള്‍"
 
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "മുന്‍ഗണനകള്‍"
-
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:303
-msgid "No networks selected for sharing"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
 msgstr ""
 
-#: ../panels/sharing/cc-sharing-panel.c:266
-msgctxt "service is enabled"
-msgid "On"
-msgstr "ഓണ്‍ "
-
-#: ../panels/sharing/cc-sharing-panel.c:268 ../panels/sharing/cc-sharing-panel.c:295
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "ഓഫ്"
-
-#: ../panels/sharing/cc-sharing-panel.c:298
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "പ്രവര്‍ത്തന സജ്ജം"
-
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is active"
-msgid "Active"
-msgstr "സജ്ജമാണ്"
-
-#: ../panels/sharing/cc-sharing-panel.c:372
-msgid "Choose a Folder"
-msgstr "ഒരു ഫോള്‍ഡര്‍ തിരയുക"
-
-#: ../panels/sharing/cc-sharing-panel.c:683
-#, c-format
-msgid ""
-"Personal File Sharing allows you to share your Public folder with others on your current network using: <a "
-"href=\"dav://%s\">dav://%s</a>"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
 msgstr ""
-"<a href=\"dav://%s\">dav://%s</a> ഉപയോഗിച്ച് ഇപ്പോഴത്തെ ശ്രംഖലയില്‍ പൊതുവായ ഫോള്‍ഡറുകള്‍ പങ്കിടാന്‍ സ്വകാര്യ ഫയല്‍ പങ്കിടല്‍ "
-"അനുവദിക്കുന്നു"
 
-#: ../panels/sharing/cc-sharing-panel.c:685
-#, fuzzy, c-format
-#| msgid ""
-#| "Allow remote users to connect using the Secure Shell command:\n"
-#| "<a href=\"ssh %s\">ssh %s</a>"
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "തെരയല്‍ സജ്ജീകരണങ്ങള്‍"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
 msgstr ""
-"വിദൂര ഉപയോക്താക്കളെ സുരക്ഷിത ഷെല്‍ ഉപയോഗിച്ച് ബന്ധിപ്പിക്കാന്‍ അനുവദിക്കുന്നു:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
 
-#: ../panels/sharing/cc-sharing-panel.c:687
-#, fuzzy, c-format
-#| msgid "Allow remote users to view or control your screen by connecting to: <a href=\"vnc://%s\">vnc://%s</a>"
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
-"Screen sharing allows remote users to view or control your screen by connecting to <a href=\"vnc://%s\">vnc://"
-"%s</a>"
-msgstr "വിദൂര ഉപയോക്താക്കളെ താങ്കളുടെ സ്ക്രീന്‍ കാണുവാനോ നിയന്ത്രിക്കുവാനോ അനുവദിക്കുന്നു: <a href=\"vnc://%s\">vnc://%s</a>"
+"Control which applications show search results in the Activities Overview"
+msgstr "പ്രവര്‍ത്തനങ്ങളില്‍ ഏതൊക്കെ പ്രയോഗങ്ങള്‍ തെരയല്‍ ഫലങ്ങള്‍ കാണുമെന്ന് തീരുമാനിക്കുക"
 
-#: ../panels/sharing/cc-sharing-panel.c:799
-msgid "Copy"
-msgstr "പകര്‍ത്തുക"
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;"
 
-#: ../panels/sharing/cc-sharing-panel.c:1125
-msgid "Sharing"
-msgstr "പങ്കിടല്‍"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Sha­ring"
-msgstr "പങ്കിടല്‍"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:3
-msgid "Control what you want to share with others"
-msgstr "മറ്റുളളവരുമായി പങ്കിടുന്നത് നിയന്തിക്കുക"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:5
-msgid "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;movies;server;renderer;"
-msgstr "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;movies;server;renderer;"
-
-#: ../panels/sharing/networks.ui.h:1
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "ശൃംഖല"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "വിദൂര പ്രവേശിക്കല്‍ പ്രവര്‍ത്തനസജ്ജം/രഹിതം ആക്കുക"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "പങ്കിടല്‍"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "വിദൂര പ്രവേശനം പ്രവര്‍ത്തനസജ്ജമാക്കാന്‍/രഹിതമാക്കാന്‍ ആധികാരികത ഉറപ്പ് വരുത്തേണ്ടതുണ്ട്"
-
-#: ../panels/sharing/sharing.ui.h:1
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr "കമ്പ്യൂട്ടറിന്റെ പേരു് (_C)"
 
-#: ../panels/sharing/sharing.ui.h:2
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr "ഫയല്‍ പങ്കിടല്‍ (_F)"
 
-#: ../panels/sharing/sharing.ui.h:3
-msgid "_Screen Sharing"
-msgstr "സ്ക്രീന്‍ പങ്കിടല്‍ (_S)"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "പണിയിടം"
 
-#: ../panels/sharing/sharing.ui.h:4
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr "മീഡിയ പങ്കിടല്‍ (_M)"
 
-#: ../panels/sharing/sharing.ui.h:5
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr "വിദൂര പ്രവേശനം (_R)"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Some services are disabled because of no network access."
-msgstr "ശ്രംഖല ബന്ധമില്ലാത്തത് കൊണ്ട് ചില സേവനങ്ങള്‍ നിര്‍ത്തി വെച്ചിരിക്കുന്നു."
-
-#: ../panels/sharing/sharing.ui.h:7
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr "ഫയല്‍ പങ്കിടല്‍"
 
-#: ../panels/sharing/sharing.ui.h:8
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr "രഹസ്യവാക്ക് ആവശ്യമുണ്ടു് (_R)"
 
-#: ../panels/sharing/sharing.ui.h:10
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "വിദൂര പ്രവേശനം"
 
-#: ../panels/sharing/sharing.ui.h:11
-msgid "Screen Sharing"
-msgstr "സ്ക്രീന്‍ പങ്കിടല്‍"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "പണിയിടം"
 
-#: ../panels/sharing/sharing.ui.h:12
-msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "_Password:"
-msgstr "രഹസ്യവാക്ക് (_P):"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "വിദൂര പ്രവേശിക്കല്‍ പ്രവര്‍ത്തനസജ്ജം/രഹിതം ആക്കുക"
 
-#: ../panels/sharing/sharing.ui.h:14
-msgid "_Show Password"
-msgstr "രഹസ്യവാക്ക് കാണിയ്ക്കുക (_S)"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "വിദൂര നിയന്ത്രണം അനുവദിക്കുക"
 
-#: ../panels/sharing/sharing.ui.h:15
-msgid "Access Options"
-msgstr "ഐച്ഛികങ്ങള്‍"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:16
-msgid "_New connections must ask for access"
-msgstr "പുതിയ ബന്ധങ്ങള്‍ പ്രവേശനത്തിനായി ചോദിക്കണം (_S)"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "ബന്ധിപ്പിച്ചിട്ടില്ല"
 
-#: ../panels/sharing/sharing.ui.h:17
-msgid "_Require a password"
-msgstr "രഹസ്യവാക്ക് ആവശ്യമുണ്ടു് (_R)"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:18
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "പകര്‍ത്തുക"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "വിലാസം നീക്കം ചെയ്യുക"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_തിരിച്ചറിയല്‍"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ഉപയോക്താവിന്റെ പേര്"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "ഫിംഗര്‍പ്രിന്റുകള്‍ എന്‍റോള്‍ ചെയ്യുന്നു"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "മീഡിയ പങ്കിടല്‍"
 
-#: ../panels/sharing/sharing.ui.h:19
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "ശൃംഖലയിലുള്ള ആളുകളുമായി പാട്ടുകള്‍, ചിത്രങ്ങള്‍, ചലചിത്രങ്ങള്‍ തുടങ്ങിയവ പങ്കുവെയ്ക്കു."
 
-#: ../panels/sharing/sharing.ui.h:20
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "ഫോള്‍ഡറുകള്‍"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "ശബ്ദം"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "മറ്റുളളവരുമായി പങ്കിടുന്നത് നിയന്തിക്കുക"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "ശബ്ദത്തിന്റെ നിലയും, ഇന്‍പുട്ടുകളും, ഔട്ട്പുട്ടുകളും, അലെര്‍ട്ട് ശബ്ദങ്ങളും മാറ്റുക"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "വിദൂര പ്രവേശിക്കല്‍ പ്രവര്‍ത്തനസജ്ജം/രഹിതം ആക്കുക"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "ബാര്‍ക്ക്"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "വിദൂര പ്രവേശനം പ്രവര്‍ത്തനസജ്ജമാക്കാന്‍/രഹിതമാക്കാന്‍ ആധികാരികത ഉറപ്പ് വരുത്തേണ്ടതുണ്ട്"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "ഡ്രിപ്"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "ഫ്ലിക്കര്‍"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "ഗ്ലാസ്"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "പങ്കിടല്‍"
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "സോണാര്‍"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "ഇടത്"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "വലത്"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_ബാലന്‍സ്:"
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_മങ്ങുക:"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "പിന്നില്‍"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "മുന്നില്‍"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "ഏറ്റവും കുറഞ്ഞ"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "ഏറ്റവും കൂടിയ"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "സിസ്റ്റത്തിന്റെ ശബ്ദങ്ങള്‍"
 
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "_ബാലന്‍സ്:"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "_മുന്നറിയിപ്പിനുള്ള ശബ്ദം: "
 
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "_മങ്ങുക:"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "നിശ്ശബ്ദമാക്കുക"
 
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "_സബ്‌വൂഫര്‍:"
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "ഔട്ട്പുട്ട്"
 
-#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "_ഔട്ട്പുട്ട് വോള്യം: "
 
-#: ../panels/sound/gvc-channel-bar.c:615
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "അണ്‍ആംപ്ലിഫൈഡ്"
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "പരീക്ഷിക്കുക"
 
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
-#: ../panels/sound/gvc-mixer-dialog.c:515
-msgid "_Profile:"
-msgstr "പ്രൊ_ഫൈല്‍:"
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "ക്രമീക_രണത്തിനുള്ള യുആര്‍എല്‍"
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1873
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "സബ്‌വൂഫര്‍"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "നിവേശകം"
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "ഇന്‍പുട്ട് ലെവല്‍:"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "ശബ്ദം കൂട്ടുക"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "_മുന്നറിയിപ്പിനുള്ള ശബ്ദം: "
+
+#: panels/sound/cc-volume-slider.ui:22
+#, fuzzy
+msgid "Mute"
+msgstr "_നിശബ്ദമാക്കുക"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ശബ്ദം"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ശബ്ദത്തിന്റെ നിലയും, ഇന്‍പുട്ടുകളും, ഔട്ട്പുട്ടുകളും, അലെര്‍ട്ട് ശബ്ദങ്ങളും മാറ്റുക"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "അറിയിപ്പുകള്‍ കൈകാര്യം ചെയ്യുക"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_പേര്:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "സ്വയം _ബന്ധിപ്പിക്കുക"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "ഡിവൈസ് നീക്കം ചെയ്യുക"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s ഡൊമെയിനിലേക്കു് കണക്ട് ചെയ്യുവാന്‍ സാധ്യമല്ല: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "സാര്‍വ്വജനികലഭ്യത"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "ഡിവൈസ് ചേര്‍ക്കുക"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "തണ്ടര്‍ബേര്‍ഡ് "
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "സൂചികയുടെ മിന്നല്‍"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "ടെക്സ്റ്റ് ബോക്സുകളിലും ഫീല്‍ഡുകളിലും സൂചകം _മിന്നട്ടെ"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "വേഗത"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "സൂചകം മിന്നുന്നതിന്റെ വേഗത"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "കഴ്സര്‍ വലിപ്പം"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "ക്ലിക്ക് അസിസ്റ്റ്"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "സിമുലേറ്റ് ചെയ്ത രണ്ടാമത്തെ ക്ലിക്ക്"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "പ്രൈമറി ബട്ടണ്‍ അമര്‍ത്തിക്കൊണ്ടു് സെക്കണ്ടറി ക്ലിക്ക് നടപ്പിലാക്കുക"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_ആക്സെപ്റ്റെന്‍സ് ഡിലേ:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "കുറഞ്ഞ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "രണ്ടാമത്  ഞെക്കു് പ്രാവര്‍ത്തികമാക്കുക"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "കൂടിയ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "ചുറ്റിപ്പറ്റിയുള്ള ക്ലിക്ക്"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "പോയിന്റര്‍ നീക്കം നിര്‍ത്തുമ്പോള്‍ ക്ലിക്ക് ആരംഭിക്കുക"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "ഇ_ടവേള:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "കുറഞ്ഞ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "കൂടിയ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "നീക്കത്തിന്റെ ത്രെഷോ_ള്‍ഡ്:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "ചെറിയ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "വലിയ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "കീ ആവര്‍ത്തിക്കുക"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "കീ അമര്‍ത്തിപ്പിടിച്ചാല്‍ കീകള്‍ _ആവര്‍ത്തിക്കുക"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "കീയുടെ വേഗത ഇരട്ടിപ്പിക്കുക"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "കീയുടെ വേഗത ഇരട്ടിപ്പിക്കുക"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "_ടെപ്പിങ് അസ്സിസ്റ്റ്"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "സ്റ്റിക്കി കീകള്‍"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "തുടരെയുള്ള മോഡിഫയര്‍ കീകള്‍ കീക്കൂട്ടമായി കരുതപ്പെടുന്നു"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "രണ്ട് കീ ഒരുമിച്ച് അമര്‍ത്തിയാല്‍ പ്രവര്‍ത്തന _രഹിതമാക്കുക"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "_മോഡിഫയര്‍ അമര്‍ത്തുമ്പോള്‍ ശബ്ദമുണ്ടാക്കുക"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "സ്ലോ കീകള്‍"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "ഒരു കീ അമര്‍ത്തുന്നതിനും സ്വീകരിയ്ക്കുന്നതിനും ഇടയില്‍ ഒരു ഇടവേള നല്‍കുക"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "കുറഞ്ഞ"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "കീകള്‍ ടൈപ്പ് ചെയ്യുന്നതിനുള്ള താമസം"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "കൂടിയ"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "_ടോഗിള്‍ കീ അമര്‍ത്തുമ്പോള്‍ ശബ്ദമുണ്ടാക്കുക"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "കീ _സ്വീകരിച്ചുവെങ്കില്‍ ശബ്ദമുണ്ടാക്കാം"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "കീ _നിരസിച്ചുവെങ്കില്‍ ശബ്ദമുണ്ടാക്കുക"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "ബൌണ്‍സ് കീകള്‍"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "പെട്ടെന്നുള്ള ഇരട്ട കീ അമര്‍ത്തലുകളെ അവഗണിക്കുക"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "കുറഞ്ഞ"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "ബൌണ്‍സ് കീകള്‍ ടൈപ്പ് ചെയ്യുന്ന താമസം"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "കൂടിയ"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "കീബോര്‍ഡ് ഉപയോഗിച്ചു് സജ്ജമാക്കുക"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "കീബോര്‍ഡ് എളുപ്പവഴികള്‍ ഉപയോഗിച്ചു് ആക്സസിബിളിറ്റി വിശേഷതകള്‍ ടൊഗിള്‍ ചെയ്യുവാന്‍ സാധിക്കുന്നു"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "എപ്പോഴും സര്‍വ്വവ്യാപിയായ പ്രവേശനത്തിനുള്ള മെനു കാണിക്കാം"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "കാണുക"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "കൂടിയ കോണ്ട്രാസ്റ്റ്"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "വലിയ പദാവലി"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+#, fuzzy
+msgid "Enable A_nimations"
+msgstr "അറിയിപ്പുകള്‍ കൈകാര്യം ചെയ്യുക"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "സൗണ്ട് കീകള്‍"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "കീ ബോര്‍ഡില്‍ സ_വിശേഷതകള്‍ ഓണ്‍ ചെയ്യുമ്പോഴോ ഓഫ് ചെയ്യുമ്പോഴോ ശബ്ദമുണ്ടാക്കുക"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "കഴ്സര്‍ വലിപ്പം (_u)"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "വലിപ്പം മാറ്റുക"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "കേള്‍വി"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "ദൃശ്യമാകുന്ന അറിയിപ്പുകള്‍"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "സ്ക്രീന്‍ കീബോര്‍ഡ്"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "കീ ആവര്‍ത്തിക്കുക (_e)"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "കഴ്സര്‍ മിന്നല്‍"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_ക്രമീകരണ അസ്സിസ്റ്റന്റ് (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "ചൂണ്ടുകയും ക്ലിക്ക് ചെയ്യുകയും"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "മൌസ് കീകള്‍"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "വെള്ള സൂചിക"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "ക്ലിക്ക് അസിസ്റ്റ്"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "ഇരട്ട ക്ലിക്ക് ഡിലേ (_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "ഇരട്ട ക്ലിക്ക് ഡിലേ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "കാണുന്ന അറിയിപ്പുകള്‍"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "ഫ്ളാഷ് _പരീക്ഷിയ്ക്കുക"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ഒരു അറിയിപ്പു് ശബ്ദമുണ്ടാകുമ്പോള്‍ ഒരു ദൃശ്യ സൂചന ഉപയോഗിയ്ക്കുക"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "സ്ക്രീന്‍ മൊത്തം മിന്നിക്കുക"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "സ്ക്രീന്‍ മൊത്തം മിന്നിക്കുക"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "സ്ക്രീന്‍ പൂര്‍ണ്ണവലിപ്പത്തില്‍"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "മുകള്‍ പകുതി"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "താഴെയുള്ള പകുതി"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "ഇടതു് പകുതി"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "വലതു് പകുതി"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "വലിപ്പത്തിനുള്ള ഐച്ഛികങ്ങള്‍"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "വിപുലീകരണം:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "മാഗ്നിഫയര്‍ സ്ഥാനം:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "മൌസ് കര്‍സര്‍ തുടരുക"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "സ്ക്രീനിന്റെ ഭാഗം:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "സ്ക്രീനിന്റെ പുറത്തു് മാഗ്നിഫൈ ചെയ്യുക"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "മാഗ്നഫയര്‍ കര്‍സര്‍ മദ്ധ്യത്തിലാക്കുക"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "ഉള്ളടക്കവുമായി മാഗ്നിഫയര്‍ കര്‍സര്‍ തുടരുന്നു"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "ഉള്ളടക്കവുമായി മാഗ്നിഫയര്‍ കര്‍സര്‍ നീങ്ങുന്നു"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "മാഗ്നിഫയര്‍"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "ക്രോസ്സ്ഹെയര്‍സ്:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "മൗസ് കര്‍സര്‍ തിരുത്തുന്നു"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
+msgstr "കട്ടിയുള്ള:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "കട്ടികുറഞ്ഞ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "കട്ടിയുള്ള"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "നീളം (_L):"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "നിറം (_l):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "ക്രോസ്സ്ഹെയര്‍സ്"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "നിറ പ്രവാഹങ്ങള്‍:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "കറുപ്പില്‍ വെളുപ്പു് (_W):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "തെളിച്ചം (_B):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "കോണ്ട്രാസ്റ്റ് (_C):"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "നിറം (_l)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "ഒന്നുമില്ല"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "മുഴുവന്‍"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "കുറഞ്ഞ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "കൂടിയ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "കുറഞ്ഞ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "കൂടിയ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "നിറ പ്രവാഹങ്ങള്‍"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "കാഴ്ച്ച, കേൾവി, മുദ്രണം, പോയിന്റ്, ക്ലിക്ക് എന്നിവ മെച്ചപെടുത്തുക"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ചരിത്രം"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "ചരിത്രം"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "അടുത്തിടെയുള്ള ചരിത്രം _മായ്ക്കുക"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "ചവറ്റുകുട്ടയും താല്‍ക്കാലിക ഫയലുകളും ശൂന്യമാക്കുക"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "തനിയെ _ചവറ്റുകുട്ട ഒഴിപ്പിക്കുക"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "തനിയെ താല്‍ക്കാലിക _ഫയലുകള്‍ ഒഴിപ്പിക്കുക"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "തനിയെ _ചവറ്റുകുട്ട ഒഴിപ്പിക്കുക"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "ചവറ്റുകുട്ട ഒഴിപ്പിക്കുക (_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "താല്‍ക്കാലിക ഫയലുകള്‍ മായ്ക്കുക (_P)…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "ചവറ്റുകുട്ടയിലേക്ക് മാറ്റുക"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "ഉപയോക്താവിനെ ചേര്‍ക്കുക"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "അഡ്മിനിസ്ട്രേറ്റര്‍"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "ഉപയോക്താവ് അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കാന്‍ അനുവദിക്കുക"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "ഉടന്‍ ഒരു രഹസ്യവാക്ക് സജ്ജമാക്കുക"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "ഉറപ്പാക്കുക (_C)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_എന്റര്‍പ്രൈസ് ലോഗിന്‍"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "നിങ്ങള്‍ ഓഫ്‌ലൈന്‍ ആണ്"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "പിപിഡി ഫയല്‍ തെരഞ്ഞെടുക്കുക"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "ഫിം_ ഗര്‍പിന്റ് ലോഗിന്‍"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "ഫിം_ ഗര്‍പിന്റ് ലോഗിന്‍"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "അല്ല"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"രജിസ്ടര്‍ ചെയ്ത ഫിംഗര്‍പ്രിന്റുകള്‍ വെട്ടിമാറ്റി നിങ്ങള്‍ക്കു് ഫിംഗര്‍പ്രിന്റ് ലോഗിന്‍ പ്രവര്‍ത്തന "
+"രഹിതമാക്കണമോ?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "ഒരു പ്രിന്ററുകളും ലഭ്യമായിട്ടില്ല."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "ഫിം_ ഗര്‍പിന്റ് ലോഗിന്‍"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "ഫിം_ ഗര്‍പിന്റ് ലോഗിന്‍"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "ക്രമീകരിക്കുവാനുള്ളൊരു ഡിവൈസ് _തെരഞ്ഞെടുക്കുക:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "ഫിം_ ഗര്‍പിന്റ് ലോഗിന്‍"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "ഫിംഗര്‍പ്രിന്റുകള്‍ _വെട്ടിമാറ്റണമോ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "ഫിം_ ഗര്‍പിന്റ് ലോഗിന്‍"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "കഴിഞ്ഞ ആഴ്ച"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "അടുത്ത ആഴ്ച"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "അടയാളവാക്ക് _മാറ്റുക"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "മാറ്റു_ക"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "നിലവിലുളള _രഹസ്യവാക്ക്"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "പുതി_യ രഹസ്യവാക്ക്"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "രഹസ്യവാക്ക് ഉറപ്പാക്കുക"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "രഹസ്യവാക്കുകള്‍ തമ്മില്‍ പൊരുത്തക്കേടുണ്ട്."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "ഉപയോക്താവ് അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കാന്‍ അനുവദിക്കുക"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "ഉടന്‍ ഒരു രഹസ്യവാക്ക് സജ്ജമാക്കുക"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "ഉപയോക്താക്കള്‍"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "മാറ്റങ്ങള്‍ കാണാന്‍ പുറത്തിറങ്ങുക"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "റിസ്റ്റാർട്ട് ചെയ്യുക"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "അടയ്ക്കുക"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "മുഴു_വന്‍ പേരു്"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "ഫിം_ ഗര്‍പിന്റ് ലോഗിന്‍"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "ഓട്ടോമാറ്റിക് പ്രവേശനം"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "ഗുമ്പല് (തരം 1)"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "അഡ്മിനിസ്ട്രേറ്റര്‍"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "നിയന്ത്രണങ്ങള്‍"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "ഉപയോക്താവിനെ കളയുക…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_മറ്റ് വിരല്‍:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "ഉപയോക്താവിനെ ചേര്‍ക്കുക (_A)…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "പ്രിന്റെറുകളൊന്നും കണ്ടില്ല"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "ഉപയോക്താവിനുള്ളൊരു അക്കൌണ്ട് തയ്യാറാക്കുക"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "ഉപയോക്താക്കള്‍ ചേര്‍ക്കുക അല്ലെങ്കില്‍ വെട്ടി നീക്കുക; രഹസ്യവാക്ക് മാറ്റുക"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "ചേർക്കുക (_E)"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "ഡൊമെയിന്‍ അഡ്മിനിസ്ട്രേറ്ററിനുള്ള പ്രവേശനം"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"എന്റര്‍പ്രൈസ് പ്രവേശനങ്ങള്‍ ഉപയോഗിയ്ക്കുന്നതിനു്, ഈ കമ്പ്യൂട്ടര്‍ ഒരു ഡൊമെയിനില്‍ എന്‍റോള്‍ ചെയ്യേണ്ടതുണ്ടു്. "
+"ഇവിടെ ഡൊമെയിനുള്ള രഹസ്യവാക്ക് ടൈപ്പ് ചെയ്യുന്നതിനായി നിങ്ങളുടെ നെറ്റ്‌വര്‍ക്ക് അഡ്മിസിട്രേറ്ററോടു് "
+"ആവശ്യപ്പെടുക."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "അഡ്മിനിസ്ട്രേറ്ററിന്റെ _പേരു്"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "അഡ്മിനിസ്ട്രേറ്ററിനുള്ള രഹസ്യവാക്ക്"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "ഉപയോക്തൃ അക്കൗണ്ടുകള്‍ കൈകാര്യം ചെയ്യുക"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "ഉപയോക്താവിനുള്ള ഡേറ്റാ മാറ്റുന്നതിനായി ആധികാരികത ഉറപ്പ് വരുത്തല്‍ ആവശ്യമുണ്ട്"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "ഫംഗ്ഷനുകളിലേക്കു് ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക"
+
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"കുറുക്കുവഴി തിരുത്തുന്നതിനായി \"കീസ്ട്രോക്ക് അയയ്ക്കുക\" പ്രവൃത്തി ചെയ്ത ശേഷം പുതിയ കുറുക്കുവഴിയ്ക്കുള്ള "
+"കീ ടൈപ്പ് ചെയ്യുക. കീ നീക്കം ചെയ്യാന്‍ backspace ടൈപ്പ് ചെയ്യുക."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_അടയ്ക്കുക"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"ടാബ്ലറ്റ് കാലിബ്രേറ്റ് ചെയ്യന്നതിനായി അവ സ്ക്രീനില്‍ കാണിയ്ക്കുമ്പോള്‍ ലക്ഷ്യ അടയാളങ്ങളില്‍ ദയവായി "
+"ടാപ്പ് ചെയ്യുക."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
+msgstr "മിസ്-ക്ലിക്ക് ലഭ്യമാക്കിയിരിയ്ക്കുന്നു, വീണ്ടും ആരംഭിയ്ക്കുന്നു..."
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "ഒരു പുതിയ വിര്‍ച്ച്വല്‍ ഉപകരണം ഉണ്ടാക്കുക"
+
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "ടാബ്ലെറ്റ്‌"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "ഇടതു് വശത്തുള്ള സംവേദനം"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "മോണിറ്ററിലേക്കു് മാപ്പ് ചെയ്യുക…"
+
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "പ്രത്യേക അനുപാതം"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "ഒത്തുനോക്കുക..."
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "ടാബ്ലറ്റ് ലഭ്യമല്ല"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "ദയവായി പ്ലഗിന്‍ ചെയ്യുക അല്ലെങ്കില്‍ നിങ്ങളുടെ വാക്കോ ടാബ്ലറ്റ് ഓണ്‍ ചെയ്യുക"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "ടിപ്പ് പ്രഷര്‍ ഫീല്‍"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "സോഫ്റ്റ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "ഉറപ്പാക്കുക"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "ബട്ടണ്‍"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ബട്ടണ്‍"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ബട്ടണ്‍"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "ഇറേസര്‍ പ്രഷര്‍ ഫീല്‍"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "ഇറേസര്‍ പ്രഷര്‍ ഫീല്‍"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "മദ്ധ്യത്തിലുള്ള മൌസ് ബട്ടണ്‍ ക്ലിക്ക്"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "വലത്തുള്ള മൌസ് ബട്ടണ്‍ ക്ലിക്ക്"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "മുന്നോട്ട്"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "വാക്കൊം ടാബ്ലെറ്റ് "
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "ബട്ടണ്‍ മാപ്പിങ്ങും ഗ്രാഫിക്സ് റ്റാബ്ലറ്റിലെ സ്റ്റൈലസ് ക്രമീകരണങ്ങളും മാറ്റുക"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "വിന്യാസം"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "മാതൃജാലകം "
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "സിമുലേറ്റ് ചെയ്ത രണ്ടാമത്തെ ക്ലിക്ക്"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "ജാലകങ്ങള്"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "ടോണര്‍ കുറവാണു്"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "ദ്വീതീയ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "ജാലകങ്ങള്"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "ഐച്ഛികങ്ങള്‍"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "ചേര്‍ക്കുക"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "സൂക്ഷിക്കുക (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "വിശദവിവരങ്ങള്‍"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_ശൃംഖലയിലെ സമയം"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "ശൃംഖലയുടെ ക്രമീകരണങ്ങള്‍"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "സംഖ്യകള്‍"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "ഉപകരണ തരങ്ങള്‍"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "ഉല്‍പാദകന്‍"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "ഫേംവെയര്‍ ലഭ്യമല്ല"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "മൊബൈല്‍ ബ്രോഡ്ബാന്‍ഡ്"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_ശൃംഖലയിലെ സമയം"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "ശൃംഖല"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "അധികമായതു്"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "ഐച്ഛികങ്ങള്‍"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "പൂട്ട്"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "%s വിശദാംശങ്ങൾ"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "നെറ്റ്‌വര്‍ക്കിന്റെ പേരു്"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "തനിയെയുള്ള"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "എന്റെ ഹോം ശൃംഖല"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "എന്റെ ഹോം ശൃംഖല"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "വൈ-ഫൈ അഡാപ്റ്റര്‍ ഒന്നും കണ്ടില്ല"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "വൈ-ഫൈ അഡാപ്റ്റര്‍ കുത്തിയിട്ടുണ്ടെന്നും ഓണ്‍ ചെയ്തിട്ടുണ്ടെന്നും ഉറപ്പ് വരുത്തുക"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "വിമാന മോഡില്‍ ബ്ലൂടൂത്ത് പ്രവര്‍ത്തന രഹിതമാക്കും."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "വിമാന മോഡ് മാറ്റുക"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "കണക്ഷന്‍ മറക്കു"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "സിം കാര്‍ഡ് ഇട്ടിട്ടില്ല"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "പൂട്ട്"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "മാറ്റു_ക"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "എന്റെ ഹോം ശൃംഖല"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "മാറ്റാന്‍ സാധിക്കുന്ന മീഡിയയുടെ സജ്ജീകരണങ്ങള്‍ ക്രമീകരിക്കുക"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "പുതിയ ഡ്രൈവര്‍ സജ്ജമാക്കുന്നു…"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "സ്വകാര്യത"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "എല്ലാ സജ്ജീകരണങ്ങള്‍"
+
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "പ്രഥമ"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "സഹായം"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "സാധാരണ"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "നിര്‍ത്തുക"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "തിരയുക"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "പാനലുകള്‍"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "അവലോകനത്തിലോട്ട് തിരിച്ച് പോവുക"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "തെരയല്‍ റദ്ദാക്കുക"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u ഔട്ട്പുട്ട്"
 msgstr[1] "%u ഔട്ട്പുട്ടുകള്‍"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1883
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u ഇന്‍പുട്ട്"
 msgstr[1] "%u ഇന്‍പുട്ടുകള്‍"
 
-#: ../panels/sound/gvc/gvc-mixer-control.c:2738
-msgid "System Sounds"
-msgstr "സിസ്റ്റത്തിന്റെ ശബ്ദങ്ങള്‍"
+#~ msgid "Changes throughout the day"
+#~ msgstr "ദിനം മുഴുവന്‍ മാറിക്കൊണ്ടിരിക്കും"
 
-#: ../panels/sound/gvc-mixer-dialog.c:251
-msgid "_Test Speakers"
-msgstr "സ്പീക്കറുകള്‍ _പരിശോധിയ്ക്കുക"
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "ടൈല്‍"
 
-#: ../panels/sound/gvc-mixer-dialog.c:420
-msgid "Peak detect"
-msgstr "പീക്ക് കണ്ടുപിടിക്കല്‍"
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "വലിപ്പം മാറ്റുക"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1512
-msgid "Device"
-msgstr "ഡിവൈസ്"
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "മദ്ധ്യത്തില്‍"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1575
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "അളവു്"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "നിറക്കുക"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "സ്പാന്‍"
+
+#~ msgid "Colors"
+#~ msgstr "നിറങ്ങള്‍"
+
+#~ msgid "Select Background"
+#~ msgstr "പശ്ചാത്തലം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Pictures"
+#~ msgstr "ചിത്രങ്ങള്‍"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "ചിത്രങ്ങളൊന്നും കണ്ടില്ല"
+
+#~ msgid "Home"
+#~ msgstr "തട്ടകം"
+
 #, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s-നുള്ള സ്പീക്കര്‍ പരീക്ഷണം"
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "താങ്കൾക്ക് താങ്കളുടെ %s അറയിലേക്ക് ചിത്രങ്ങൾ ചേർക്കാം. അവ ഇവിടെ ദൃശ്യമാവുന്നതാണ്."
 
-#: ../panels/sound/gvc-mixer-dialog.c:1631
-msgid "_Output volume:"
-msgstr "_ഔട്ട്പുട്ട് വോള്യം: "
+#~ msgid "multiple sizes"
+#~ msgstr "അനവധി വ്യാപ്തികള്‍"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1645
-msgid "Output"
-msgstr "ഔട്ട്പുട്ട്"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1650
-msgid "C_hoose a device for sound output:"
-msgstr "ശബ്ദ ഔട്ട്പുട്ടിനുള്ള ഒരു ഡിവൈസ് _തെരഞ്ഞെടുക്കുക:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1672
-msgid "Settings for the selected device:"
-msgstr "തെരഞ്ഞെടുത്ത ഉപകരണത്തിന്റെ ക്രമീകരണങ്ങള്‍:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1683
-msgid "Input"
-msgstr "നിവേശകം"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1690
-msgid "_Input volume:"
-msgstr "_ഇന്‍പുട്ട് വോള്യം: "
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "Input level:"
-msgstr "ഇന്‍പുട്ട് ലെവല്‍:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1737
-msgid "C_hoose a device for sound input:"
-msgstr "ശബ്ദ ഇന്‍പുട്ടിനുള്ള ഒരു ഡിവൈസ് _തെരഞ്ഞെടുക്കുക:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1761
-msgid "Sound Effects"
-msgstr "ശബ്ദ പ്രവാഹങ്ങള്‍"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1768
-msgid "_Alert volume:"
-msgstr "_മുന്നറിയിപ്പിനുള്ള ശബ്ദം: "
-
-#: ../panels/sound/gvc-mixer-dialog.c:1785
-msgid "No application is currently playing or recording audio."
-msgstr "ഓഡിയോ റിക്കോര്‍ഡ് ചെയ്യുന്നില്ല അല്ലെങ്കില്‍ നിലവില്‍ ഒരു പ്രയോഗവും പ്രവര്‍ത്തിക്കുന്നില്ല"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "ബിള്‍ട്ടിന്‍"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454 ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "ശബ്ദ മുന്‍ഗണനകള്‍"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457 ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "ഇവന്റ് ശബ്ദം പരീക്ഷിക്കുന്നു"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:554 ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "Default"
-msgstr "സഹജമായ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:555
-msgid "From theme"
-msgstr "പ്രമേയത്തില്‍ നിന്നും"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:740
-msgid "C_hoose an alert sound:"
-msgstr "മുന്നറിയിപ്പ് ശബ്ദം _തെരഞ്ഞെടുക്കുക:"
-
-#: ../panels/sound/gvc-speaker-test.c:231
-msgid "Stop"
-msgstr "നിര്‍ത്തുക"
-
-#: ../panels/sound/gvc-speaker-test.c:231 ../panels/sound/gvc-speaker-test.c:343
-msgid "Test"
-msgstr "പരീക്ഷിക്കുക"
-
-#: ../panels/sound/gvc-speaker-test.c:239
-msgid "Subwoofer"
-msgstr "സബ്‌വൂഫര്‍"
-
-#: ../panels/sound/sound-theme-file-utils.c:304
-msgid "Custom"
-msgstr "യഥേഷ്ടം"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: ../panels/universal-access/cc-ua-panel.c:351
-msgctxt "cursor size"
-msgid "Default"
-msgstr "സാധാരണ"
-
-#: ../panels/universal-access/cc-ua-panel.c:354
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "ഇടത്തരം"
-
-#: ../panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Large"
-msgstr "വലിയ"
-
-#: ../panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "വലിയതു്"
-
-#: ../panels/universal-access/cc-ua-panel.c:363
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "ഏറ്റവും വലിയ"
-
-#: ../panels/universal-access/cc-ua-panel.c:367
 #, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d പിക്സല്‍"
-msgstr[1] "%d പിക്സലുകള്‍"
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Uni­ver­sal Access"
-msgstr "സാര്‍വ്വജനികലഭ്യത"
+#~ msgid "No Desktop Background"
+#~ msgstr "പണിയിട പശ്ചാത്തലം ലഭ്യമല്ല"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "കാഴ്ച്ച, കേൾവി, മുദ്രണം, പോയിന്റ്, ക്ലിക്ക് എന്നിവ മെച്ചപെടുത്തുക"
+#~ msgid "Current background"
+#~ msgstr "നിലവിലുള്ള പശ്ചാതലം"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:5
-msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;"
-"Mouse;Double;click;Delay;Assist;Repeat;Blink;"
-msgstr ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;"
-"Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+#~ msgid "Back­ground"
+#~ msgstr "പശ്ചാത്തലം"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "എപ്പോഴും സര്‍വ്വവ്യാപിയായ പ്രവേശനത്തിനുള്ള മെനു കാണിക്കാം"
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "ചുമര്‍ചിത്രം;സ്ക്രീന്‍;പണിയിടം;"
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "കാണുക"
+#~ msgid "Blue­tooth"
+#~ msgstr "ബ്ലൂടൂത്ത്"
 
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "കൂടിയ കോണ്ട്രാസ്റ്റ്"
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "ക്രമീകരണ ഉപകരണം ചതുരത്തിന്റെ മുകളില്‍ വെച്ച് “തുടങ്ങുക” അമര്‍ത്തുക"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "വലിയ പദാവലി"
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "നിങ്ങളുടെ ക്രമീകരണ ഉപകരണം ക്രമീകരിക്കാന്‍ സജ്ജമാക്കിയിട്ട് “തുടരുക” അമര്‍ത്തുക"
 
-#: ../panels/universal-access/uap.ui.h:5
-msgid "C_ursor Size"
-msgstr "കഴ്സര്‍ വലിപ്പം (_u)"
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "നിങ്ങളുടെ ക്രമീകരണ ഉപകരണം ഉപരിതലം ആക്കിയിട്ട് “തുടരുക” അമര്‍ത്തുക"
 
-#: ../panels/universal-access/uap.ui.h:6 ../panels/universal-access/zoom-options.ui.h:7
-msgid "_Zoom"
-msgstr "വലിപ്പം മാറ്റുക"
+#~ msgid "Shut the laptop lid"
+#~ msgstr "ലാപ്പ്ടോപ്പ് അടയ്ക്കു"
 
-#: ../panels/universal-access/uap.ui.h:8
-msgid "Screen _Reader"
-msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "വീണ്ടെടുക്കാനാകാത്ത ഒരു ആന്തരിക പിശകു് ഉണ്ടായിരിക്കുന്നു."
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "_Sound Keys"
-msgstr "സൗണ്ട് കീകള്‍"
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "ക്രമീകരണത്തിന് വേണ്ടിയുള്ള ഉപകരണങ്ങള്‍ സ്ഥാപിച്ചിട്ടില്ല."
 
-#: ../panels/universal-access/uap.ui.h:10
-msgid "Hearing"
-msgstr "കേള്‍വി"
+#~ msgid "The profile could not be generated."
+#~ msgstr "പ്രൊഫൈല്‍ ഉണ്ടാക്കാനായില്ല."
 
-#: ../panels/universal-access/uap.ui.h:11
-msgid "_Visual Alerts"
-msgstr "ദൃശ്യമാകുന്ന അറിയിപ്പുകള്‍"
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "തന്ന വെള്ളബിന്ദു ഇതില്‍ നിന്ന് കിട്ടില്ല."
 
-#: ../panels/universal-access/uap.ui.h:13
-msgid "Screen _Keyboard"
-msgstr "സ്ക്രീന്‍ കീബോര്‍ഡ്"
+#~ msgid "Complete!"
+#~ msgstr "പൂർത്തിയായി!"
 
-#: ../panels/universal-access/uap.ui.h:14
-msgid "R_epeat Keys"
-msgstr "കീ ആവര്‍ത്തിക്കുക (_e)"
+#~ msgid "Calibration failed!"
+#~ msgstr "ക്രമീകരണം പരാജയപ്പെട്ടു!"
 
-#: ../panels/universal-access/uap.ui.h:15
-msgid "Cursor _Blinking"
-msgstr "കഴ്സര്‍ മിന്നല്‍"
+#~ msgid "You can remove the calibration device."
+#~ msgstr "താങ്കള്‍ക്ക് ക്രമീകരണ ഉപകരണം മാറ്റാം."
 
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Typing Assist (AccessX)"
-msgstr "_ക്രമീകരണ അസ്സിസ്റ്റന്റ് (AccessX)"
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "ചെയ്തുകൊണ്ടിരിക്കുമ്പോള്‍ ക്രമീകരണ ഉപകരണം മാറ്റരുത്"
 
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Pointing & Clicking"
-msgstr "ചൂണ്ടുകയും ക്ലിക്ക് ചെയ്യുകയും"
+#~ msgid "Laptop Screen"
+#~ msgstr "ലാപ്ടോപ്പ് സ്ക്രീന്‍"
 
-#: ../panels/universal-access/uap.ui.h:18
-msgid "_Mouse Keys"
-msgstr "മൌസ് കീകള്‍"
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Click Assist"
-msgstr "ക്ലിക്ക് അസിസ്റ്റ്"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "_Double-Click Delay"
-msgstr "ഇരട്ട ക്ലിക്ക് ഡിലേ (_D)"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Double-Click Delay"
-msgstr "ഇരട്ട ക്ലിക്ക് ഡിലേ"
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Cursor Size"
-msgstr "കഴ്സര്‍ വലിപ്പം"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "Cursor size can be combined with zoom to make it easier to see the cursor."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Screen Reader"
-msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "_Screen Reader"
-msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Sound Keys"
-msgstr "സൗണ്ട് കീകള്‍"
-
-#: ../panels/universal-access/uap.ui.h:28
-#, fuzzy
-#| msgid "Beep when _accessibility features are turned on or off"
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "കീ ബോര്‍ഡില്‍ സ_വിശേഷതകള്‍ ഓണ്‍ ചെയ്യുമ്പോഴോ ഓഫ് ചെയ്യുമ്പോഴോ ശബ്ദമുണ്ടാക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Visual Alerts"
-msgstr "കാണുന്ന അറിയിപ്പുകള്‍"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Test flash"
-msgstr "ഫ്ളാഷ് _പരീക്ഷിയ്ക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "ഒരു അറിയിപ്പു് ശബ്ദമുണ്ടാകുമ്പോള്‍ ഒരു ദൃശ്യ സൂചന ഉപയോഗിയ്ക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Flash the _window title"
-msgstr "ജാലക തലക്കെട്ട് മിന്നിമറയുക"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Flash the entire _screen"
-msgstr "സ്ക്രീന്‍ മൊത്തം മിന്നിക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Repeat Keys"
-msgstr "കീ ആവര്‍ത്തിക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:35
-#, fuzzy
-#| msgid "Key presses _repeat when key is held down"
-msgid "Key presses repeat when key is held down."
-msgstr "കീ അമര്‍ത്തിപ്പിടിച്ചാല്‍ കീകള്‍ _ആവര്‍ത്തിക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:37
-#, fuzzy
-#| msgid "Repeat keys speed"
-msgid "Repeat keys delay"
-msgstr "കീയുടെ വേഗത ഇരട്ടിപ്പിക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Speed"
-msgstr "വേഗത"
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Repeat keys speed"
-msgstr "കീയുടെ വേഗത ഇരട്ടിപ്പിക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Cursor Blinking"
-msgstr "സൂചികയുടെ മിന്നല്‍"
-
-#: ../panels/universal-access/uap.ui.h:41
-#, fuzzy
-#| msgid "Cursor _blinks in text fields"
-msgid "Cursor blinks in text fields."
-msgstr "ടെക്സ്റ്റ് ബോക്സുകളിലും ഫീല്‍ഡുകളിലും സൂചകം _മിന്നട്ടെ"
-
-#: ../panels/universal-access/uap.ui.h:42
-#, fuzzy
-#| msgid "Cursor blink speed"
-msgid "Cursor blinking speed"
-msgstr "സൂചകം മിന്നുന്നതിന്റെ വേഗത"
-
-#: ../panels/universal-access/uap.ui.h:43
-msgid "Typing Assist"
-msgstr "_ടെപ്പിങ് അസ്സിസ്റ്റ്"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "_Sticky Keys"
-msgstr "സ്റ്റിക്കി കീകള്‍"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "തുടരെയുള്ള മോഡിഫയര്‍ കീകള്‍ കീക്കൂട്ടമായി കരുതപ്പെടുന്നു"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Disable if two keys are pressed together"
-msgstr "രണ്ട് കീ ഒരുമിച്ച് അമര്‍ത്തിയാല്‍ പ്രവര്‍ത്തന _രഹിതമാക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:47
-#, fuzzy
-#| msgid "Beep when a _modifer key is pressed"
-msgid "Beep when a _modifier key is pressed"
-msgstr "_മോഡിഫയര്‍ അമര്‍ത്തുമ്പോള്‍ ശബ്ദമുണ്ടാക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:48
-msgid "S_low Keys"
-msgstr "സ്ലോ കീകള്‍"
-
-#: ../panels/universal-access/uap.ui.h:49
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "ഒരു കീ അമര്‍ത്തുന്നതിനും സ്വീകരിയ്ക്കുന്നതിനും ഇടയില്‍ ഒരു ഇടവേള നല്‍കുക"
-
-#: ../panels/universal-access/uap.ui.h:50
-msgid "A_cceptance delay:"
-msgstr "_ആക്സെപ്റ്റെന്‍സ് ഡിലേ:"
-
-#: ../panels/universal-access/uap.ui.h:51
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "കുറഞ്ഞ"
-
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Slow keys typing delay"
-msgstr "കീകള്‍ ടൈപ്പ് ചെയ്യുന്നതിനുള്ള താമസം"
-
-#: ../panels/universal-access/uap.ui.h:53
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "കൂടിയ"
-
-#: ../panels/universal-access/uap.ui.h:54
-msgid "Beep when a key is pr_essed"
-msgstr "_ടോഗിള്‍ കീ അമര്‍ത്തുമ്പോള്‍ ശബ്ദമുണ്ടാക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:55
-msgid "Beep when a key is _accepted"
-msgstr "കീ _സ്വീകരിച്ചുവെങ്കില്‍ ശബ്ദമുണ്ടാക്കാം"
-
-#: ../panels/universal-access/uap.ui.h:56
-msgid "Beep when a key is _rejected"
-msgstr "കീ _നിരസിച്ചുവെങ്കില്‍ ശബ്ദമുണ്ടാക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:57
-msgid "_Bounce Keys"
-msgstr "ബൌണ്‍സ് കീകള്‍"
-
-#: ../panels/universal-access/uap.ui.h:58
-msgid "Ignores fast duplicate keypresses"
-msgstr "പെട്ടെന്നുള്ള ഇരട്ട കീ അമര്‍ത്തലുകളെ അവഗണിക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:59
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "കുറഞ്ഞ"
-
-#: ../panels/universal-access/uap.ui.h:60
-msgid "Bounce keys typing delay"
-msgstr "ബൌണ്‍സ് കീകള്‍ ടൈപ്പ് ചെയ്യുന്ന താമസം"
-
-#: ../panels/universal-access/uap.ui.h:61
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "കൂടിയ"
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "_Enable by Keyboard"
-msgstr "കീബോര്‍ഡ് ഉപയോഗിച്ചു് സജ്ജമാക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "കീബോര്‍ഡ് എളുപ്പവഴികള്‍ ഉപയോഗിച്ചു് ആക്സസിബിളിറ്റി വിശേഷതകള്‍ ടൊഗിള്‍ ചെയ്യുവാന്‍ സാധിക്കുന്നു"
-
-#: ../panels/universal-access/uap.ui.h:64
-msgid "Click Assist"
-msgstr "ക്ലിക്ക് അസിസ്റ്റ്"
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "_Simulated Secondary Click"
-msgstr "സിമുലേറ്റ് ചെയ്ത രണ്ടാമത്തെ ക്ലിക്ക്"
-
-#: ../panels/universal-access/uap.ui.h:66
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "പ്രൈമറി ബട്ടണ്‍ അമര്‍ത്തിക്കൊണ്ടു് സെക്കണ്ടറി ക്ലിക്ക് നടപ്പിലാക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:67
-msgctxt "secondary click"
-msgid "Short"
-msgstr "കുറഞ്ഞ"
-
-#: ../panels/universal-access/uap.ui.h:68
-msgid "Secondary click delay"
-msgstr "രണ്ടാമത്  ഞെക്കു് പ്രാവര്‍ത്തികമാക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgctxt "secondary click delay"
-msgid "Long"
-msgstr "കൂടിയ"
-
-#: ../panels/universal-access/uap.ui.h:70
-msgid "_Hover Click"
-msgstr "ചുറ്റിപ്പറ്റിയുള്ള ക്ലിക്ക്"
-
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Trigger a click when the pointer hovers"
-msgstr "പോയിന്റര്‍ നീക്കം നിര്‍ത്തുമ്പോള്‍ ക്ലിക്ക് ആരംഭിക്കുക"
-
-#: ../panels/universal-access/uap.ui.h:72
-msgid "D_elay:"
-msgstr "ഇ_ടവേള:"
-
-#: ../panels/universal-access/uap.ui.h:73
-msgctxt "dwell click delay"
-msgid "Short"
-msgstr "കുറഞ്ഞ"
-
-#: ../panels/universal-access/uap.ui.h:74
-msgctxt "dwell click delay"
-msgid "Long"
-msgstr "കൂടിയ"
-
-#: ../panels/universal-access/uap.ui.h:75
-msgid "Motion _threshold:"
-msgstr "നീക്കത്തിന്റെ ത്രെഷോ_ള്‍ഡ്:"
-
-#: ../panels/universal-access/uap.ui.h:76
-msgctxt "dwell click threshold"
-msgid "Small"
-msgstr "ചെറിയ"
-
-#: ../panels/universal-access/uap.ui.h:77
-msgctxt "dwell click threshold"
-msgid "Large"
-msgstr "വലിയ"
-
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
-msgid "Short"
-msgstr "ലഘു"
-
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ സ്ക്രീന്‍"
-
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ സ്ക്രീന്‍"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ സ്ക്രീന്‍"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
-msgid "Long"
-msgstr "നീളമുള്ള"
-
-#: ../panels/universal-access/zoom-options.ui.h:1
-msgid "Full Screen"
-msgstr "സ്ക്രീന്‍ പൂര്‍ണ്ണവലിപ്പത്തില്‍"
-
-#: ../panels/universal-access/zoom-options.ui.h:2
-msgid "Top Half"
-msgstr "മുകള്‍ പകുതി"
-
-#: ../panels/universal-access/zoom-options.ui.h:3
-msgid "Bottom Half"
-msgstr "താഴെയുള്ള പകുതി"
-
-#: ../panels/universal-access/zoom-options.ui.h:4
-msgid "Left Half"
-msgstr "ഇടതു് പകുതി"
-
-#: ../panels/universal-access/zoom-options.ui.h:5
-msgid "Right Half"
-msgstr "വലതു് പകുതി"
-
-#: ../panels/universal-access/zoom-options.ui.h:6
-msgid "Zoom Options"
-msgstr "വലിപ്പത്തിനുള്ള ഐച്ഛികങ്ങള്‍"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-#, fuzzy
-#| msgid "Magnification:"
-msgid "_Magnification:"
-msgstr "വിപുലീകരണം:"
-
-#: ../panels/universal-access/zoom-options.ui.h:9
-#, fuzzy
-#| msgid "Follow mouse cursor"
-msgid "_Follow mouse cursor"
-msgstr "മൌസ് കര്‍സര്‍ തുടരുക"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-#, fuzzy
-#| msgid "Screen part:"
-msgid "_Screen part:"
-msgstr "സ്ക്രീനിന്റെ ഭാഗം:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-#, fuzzy
-#| msgid "Magnifier extends outside of screen"
-msgid "Magnifier _extends outside of screen"
-msgstr "സ്ക്രീനിന്റെ പുറത്തു് മാഗ്നിഫൈ ചെയ്യുക"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-#, fuzzy
-#| msgid "Keep magnifier cursor centered"
-msgid "_Keep magnifier cursor centered"
-msgstr "മാഗ്നഫയര്‍ കര്‍സര്‍ മദ്ധ്യത്തിലാക്കുക"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-#, fuzzy
-#| msgid "Magnifier cursor pushes contents around"
-msgid "Magnifier cursor _pushes contents around"
-msgstr "ഉള്ളടക്കവുമായി മാഗ്നിഫയര്‍ കര്‍സര്‍ തുടരുന്നു"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-#, fuzzy
-#| msgid "Magnifier cursor moves with contents"
-msgid "Magnifier cursor moves with _contents"
-msgstr "ഉള്ളടക്കവുമായി മാഗ്നിഫയര്‍ കര്‍സര്‍ നീങ്ങുന്നു"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
-msgid "Magnifier Position:"
-msgstr "മാഗ്നിഫയര്‍ സ്ഥാനം:"
-
-#: ../panels/universal-access/zoom-options.ui.h:16
-msgid "Magnifier"
-msgstr "മാഗ്നിഫയര്‍"
-
-#: ../panels/universal-access/zoom-options.ui.h:17
-#, fuzzy
-#| msgid "Thickness:"
-msgid "_Thickness:"
-msgstr "കട്ടിയുള്ള:"
-
-#: ../panels/universal-access/zoom-options.ui.h:18
-msgctxt "universal access, thickness"
-msgid "Thin"
-msgstr "കട്ടികുറഞ്ഞ"
-
-#: ../panels/universal-access/zoom-options.ui.h:19
-msgctxt "universal access, thickness"
-msgid "Thick"
-msgstr "കട്ടിയുള്ള"
-
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "_Length:"
-msgstr "നീളം (_L):"
-
-#. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Co_lor:"
-msgstr "നിറം (_l):"
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-#, fuzzy
-#| msgid "Crosshairs:"
-msgid "_Crosshairs:"
-msgstr "ക്രോസ്സ്ഹെയര്‍സ്:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-#, fuzzy
-#| msgid "Overlaps mouse cursor"
-msgid "_Overlaps mouse cursor"
-msgstr "മൗസ് കര്‍സര്‍ തിരുത്തുന്നു"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
-msgid "Crosshairs"
-msgstr "ക്രോസ്സ്ഹെയര്‍സ്"
-
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "_White on black:"
-msgstr "കറുപ്പില്‍ വെളുപ്പു് (_W):"
-
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "_Brightness:"
-msgstr "തെളിച്ചം (_B):"
-
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "_Contrast:"
-msgstr "കോണ്ട്രാസ്റ്റ് (_C):"
-
-#. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
-msgctxt "universal access, contrast"
-msgid "Co_lor"
-msgstr "നിറം (_l)"
-
-#: ../panels/universal-access/zoom-options.ui.h:31
-msgctxt "universal access, color"
-msgid "None"
-msgstr "ഒന്നുമില്ല"
-
-#: ../panels/universal-access/zoom-options.ui.h:32
-msgctxt "universal access, color"
-msgid "Full"
-msgstr "മുഴുവന്‍"
-
-#: ../panels/universal-access/zoom-options.ui.h:33
-msgctxt "universal access, brightness"
-msgid "Low"
-msgstr "കുറഞ്ഞ"
-
-#: ../panels/universal-access/zoom-options.ui.h:34
-msgctxt "universal access, brightness"
-msgid "High"
-msgstr "കൂടിയ"
-
-#: ../panels/universal-access/zoom-options.ui.h:35
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "കുറഞ്ഞ"
-
-#: ../panels/universal-access/zoom-options.ui.h:36
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "കൂടിയ"
-
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "നിറ പ്രവാഹങ്ങള്‍:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
-msgid "Color Effects"
-msgstr "നിറ പ്രവാഹങ്ങള്‍"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:1 ../panels/user-accounts/data/join-dialog.ui.h:1
-msgid "Add User"
-msgstr "ഉപയോക്താവിനെ ചേര്‍ക്കുക"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "_Full Name"
-msgstr "മുഴു_വന്‍ പേരു്"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:6 ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Standard"
-msgstr "സാധാരണ"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7 ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Administrator"
-msgstr "അഡ്മിനിസ്ട്രേറ്റര്‍"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8 ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Account _Type"
-msgstr "അക്കൌണ്ട് _തരം"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "Allow user to set a password when they next _login"
-msgstr "ഉപയോക്താവ് അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കാന്‍ അനുവദിക്കുക (_l)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-msgid "Set a password _now"
-msgstr "ഉടന്‍ ഒരു രഹസ്യവാക്ക് സജ്ജമാക്കുക (_n)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid "_Confirm"
-msgstr "ഉറപ്പാക്കുക (_C)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:14
-msgid ""
-"Enterprise login allows an existing centrally managed user account to be used on this device. You can also "
-"use this account to access company resources on the internet."
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:15 ../panels/user-accounts/data/join-dialog.ui.h:9
-msgid "_Domain"
-msgstr "ഡൊ_മെയിന്‍"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-msgid "You are Offline"
-msgstr "നിങ്ങള്‍ ഓഫ്‌ലൈന്‍ ആണ്"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-msgid "You must be online in order to add enterprise users."
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:18
-msgid "_Enterprise Login"
-msgstr "_എന്റര്‍പ്രൈസ് ലോഗിന്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "ഇടത്ത് തള്ളവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "ഇടത്തു് നടുവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "ഇടത്തു് മോതിരവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "ഇടത്തു് ചെറുവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "വലത്ത് തള്ളവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "വലത്തു് നടുവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "വലത്തു് മോതിരവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "വലത്തു് ചെറുവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9 ../panels/user-accounts/um-fingerprint-dialog.c:680
-msgid "Enable Fingerprint Login"
-msgstr "ഫിംഗര്‍പ്രിന്റ് ലോഗിന്‍ സജ്ജമാക്കുക"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "_വലത്തു് ചൂണ്ടുവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "_ഇടത്തു് ചൂണ്ടുവിരല്‍"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "_മറ്റ് വിരല്‍:"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
-msgstr ""
-"നിങ്ങളുടെ വിരലടയാളം വിജയകരമായി സൂക്ഷിച്ചിരിക്കുന്നു. നിങ്ങള്‍ക്കിനി ഫിംഗര്‍പ്രിന്റ് റീഡര്‍ ഉപയോഗിച്ചു് ലോഗിന്‍ ചെയ്യുവാന്‍ സാധിക്കുന്നതാണു്."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "ഉപയോക്താക്കള്‍"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr "ഉപയോക്താക്കള്‍ ചേര്‍ക്കുക അല്ലെങ്കില്‍ വെട്ടി നീക്കുക; രഹസ്യവാക്ക് മാറ്റുക"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-
-#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/join-dialog.ui.h:4
-msgid "_Enroll"
-msgstr "ചേർക്കുക (_E)"
-
-#: ../panels/user-accounts/data/join-dialog.ui.h:5
-msgid "Domain Administrator Login"
-msgstr "ഡൊമെയിന്‍ അഡ്മിനിസ്ട്രേറ്ററിനുള്ള പ്രവേശനം"
-
-#: ../panels/user-accounts/data/join-dialog.ui.h:6
-msgid ""
-"In order to use enterprise logins, this computer needs to be\n"
-"enrolled in the domain. Please have your network administrator\n"
-"type their domain password here."
-msgstr ""
-"എന്റര്‍പ്രൈസ് പ്രവേശനങ്ങള്‍ ഉപയോഗിയ്ക്കുന്നതിനു്, ഈ കമ്പ്യൂട്ടര്‍ ഒരു ഡൊമെയിനില്‍ എന്‍റോള്‍ ചെയ്യേണ്ടതുണ്ടു്. ഇവിടെ ഡൊമെയിനുള്ള രഹസ്യവാക്ക് ടൈപ്പ് "
-"ചെയ്യുന്നതിനായി നിങ്ങളുടെ നെറ്റ്‌വര്‍ക്ക് അഡ്മിസിട്രേറ്ററോടു് ആവശ്യപ്പെടുക."
-
-#: ../panels/user-accounts/data/join-dialog.ui.h:10
-msgid "Administrator _Name"
-msgstr "അഡ്മിനിസ്ട്രേറ്ററിന്റെ _പേരു്"
-
-#: ../panels/user-accounts/data/join-dialog.ui.h:11
-msgid "Administrator Password"
-msgstr "അഡ്മിനിസ്ട്രേറ്ററിനുള്ള രഹസ്യവാക്ക്"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr "അടയാളവാക്ക് _മാറ്റുക"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "മാറ്റു_ക"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "പുതിയ രഹസ്യവാക്ക് ഉറപ്പുവരുത്തുക"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "പുതി_യ രഹസ്യവാക്ക്"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "നിലവിലുളള _രഹസ്യവാക്ക്"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to change their password on next login"
-msgstr "ഉപയോക്താവ് അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കാന്‍ അനുവദിക്കുക"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "ഉടന്‍ ഒരു രഹസ്യവാക്ക് സജ്ജമാക്കുക"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-msgid "_Add User…"
-msgstr "ഉപയോക്താവിനെ ചേര്‍ക്കുക (_A)…"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "മാറ്റങ്ങള്‍ കാണാന്‍ പുറത്തിറങ്ങുക"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Restart Now"
-msgstr "റിസ്റ്റാർട്ട് ചെയ്യുക"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "ഓട്ടോമാറ്റിക് പ്രവേശനം"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "ഫിം_ ഗര്‍പിന്റ് ലോഗിന്‍"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "ഉപയോക്തൃ ചിഹ്നം"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "അവസാന പ്രവേശനം"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "Remove User…"
-msgstr "ഉപയോക്താവിനെ കളയുക…"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
-msgid "Manage user accounts"
-msgstr "ഉപയോക്തൃ അക്കൗണ്ടുകള്‍ കൈകാര്യം ചെയ്യുക"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
-msgid "Authentication is required to change user data"
-msgstr "ഉപയോക്താവിനുള്ള ഡേറ്റാ മാറ്റുന്നതിനായി ആധികാരികത ഉറപ്പ് വരുത്തല്‍ ആവശ്യമുണ്ട്"
-
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "പുതിയ രഹസ്യവാക്ക് പഴയ രഹസ്യവാക്കില്‍ നിന്നും വ്യത്യസ്തമായിരിക്കണം."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "കുറച്ച് അക്കങ്ങളും അക്ഷരങ്ങളും മാറ്റി നോക്കുക"
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "രഹസ്യവാക്ക് ഒന്നുകൂടി മാറ്റാന്‍ ശ്രമിക്കുക."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "താങ്കളുടെ ഉപയോക്തൃനാമം ഇല്ലാത്ത ഒരു അടയാളവാക്ക് ആയിരിക്കും കൂടുതൽ ബലിഷ്ഠം."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "താങ്കളുടെ പേര് അടയാളവാക്കിൽ ഉപയോഗിക്കാതിരിക്കാൻ ശ്രമിക്കുക"
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "അടയാളവാക്കിൽ ഉൾക്കൊള്ളിച്ചിരിക്കുന്ന ചില വാക്കുകൾ അവഗണിക്കാൻ ശ്രമിക്കുക"
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "പൊതുവായിട്ടുള്ള വാക്കുകൾ അവഗണിക്കാൻ ശ്രമിക്കുക"
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "നിലനിൽക്കുന്ന വാക്കുകൾ പുനഃക്രമീകരിക്കാതിരിക്കാൻ ശ്രമിക്കുക"
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "കൂടുതൽ അക്കങ്ങൾ ഉപയോഗിക്കാൻ ശ്രമിക്കുക"
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "കൂടുതൽ വലിയ അക്ഷരങ്ങള്‍ ഉപയോഗിക്കാൻ ശ്രമിക്കുക"
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "കൂടുതൽ ചെറിയ അക്ഷരങ്ങള്‍ ഉപയോഗിക്കാൻ ശ്രമിക്കുക"
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "ഒരേ അക്ഷരം ആവര്‍ത്തിക്കുന്നത് ഒഴിവാക്കാന്‍ ശ്രമിക്കുക."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same type of character: you need to mix up letters, numbers and punctuation."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234, abcd, മുതലായ ശ്രേണികള്‍ ഒഴിവാക്കാന്‍ ശ്രമിക്കുക."
-
-#: ../panels/user-accounts/pw-utils.c:115
-#, fuzzy
-#| msgctxt "Password hint"
-#| msgid "Try to add more letters, numbers and symbols."
-msgctxt "Password hint"
-msgid "Password needs to be longer. Try to add more letters, numbers and punctuation."
-msgstr "കൂടുതല്‍ അക്ഷരങ്ങളും, സംഖ്യകളും, പ്രതീകങ്ങളും ഉള്‍പ്പെടുത്താന്‍ ശ്രമിക്കുക."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-
-#: ../panels/user-accounts/pw-utils.c:119
-#, fuzzy
-#| msgctxt "Password hint"
-#| msgid "Good password! Adding more letters, numbers and punctuation will make it stronger."
-msgctxt "Password hint"
-msgid "Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "നല്ല രഹസ്യവാക്ക്! കൂടുതല്‍ അക്ഷരങ്ങളും, അക്കങ്ങളും, മറ്റും അതിനെ കൂടുതല്‍ ശക്തമാക്കും."
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "തിരിച്ചറിയല്‍ പ്രക്രിയ പരാജയപ്പെട്ടു"
-
-#: ../panels/user-accounts/run-passwd.c:502
 #, c-format
-msgid "The new password is too short"
-msgstr "പുതിയ രഹസ്യവാക്ക് വളരെ ചെറുതാണു്"
+#~ msgid "%s Monitor"
+#~ msgstr "%s മോണിറ്റര്‍"
 
-#: ../panels/user-accounts/run-passwd.c:508
 #, c-format
-msgid "The new password is too simple"
-msgstr "പുതിയ രഹസ്യവാക്ക് വളരെ ലളിതമാണ്."
+#~ msgid "%s Scanner"
+#~ msgstr "%s സ്കാനര്‍"
 
-#: ../panels/user-accounts/run-passwd.c:514
 #, c-format
-msgid "The old and new passwords are too similar"
-msgstr "പഴയതും പുതിയതും ആയ രഹസ്യവാക്കുകള്‍ തമ്മില്‍ വളരെ സാമ്യമുണ്ട്."
+#~ msgid "%s Printer"
+#~ msgstr "%s അച്ചടിയന്ത്രം"
 
-#: ../panels/user-accounts/run-passwd.c:517
 #, c-format
-msgid "The new password has already been used recently."
-msgstr "പുതിയ രഹസ്യവാക്ക് അടുത്തിടയ്ക്കു് ഉപയോഗിച്ചിരിയ്ക്കുന്നു."
+#~ msgid "%s Webcam"
+#~ msgstr "%s വെബ്കാം"
 
-#: ../panels/user-accounts/run-passwd.c:520
 #, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "പുതിയ രഹസ്യവാക്കില്‍ ന്യൂമറിക് അല്ലെങ്കില്‍ പ്രത്യേക അക്ഷരങ്ങള്‍ ഉണ്ടായിരിയ്ക്കണം"
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s -ല്‍ നിറം കൈകാര്യം ചെയ്യുന്നത് പ്രവര്‍ത്തന സജ്ജമാക്കുക"
 
-#: ../panels/user-accounts/run-passwd.c:524
 #, c-format
-msgid "The old and new passwords are the same"
-msgstr "പഴയതും പുതിയതും രഹസ്യവാക്കുകള്‍ ഒന്നു തന്നെയാണ്."
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s -നുള്ള വര്‍ണ്ണ രൂപരേഖ കാണിക്കുക"
 
-#: ../panels/user-accounts/run-passwd.c:528
+#~ msgid "Not calibrated"
+#~ msgstr "ഒത്തുനോക്കാത്തതു്"
+
+#~ msgid "Default: "
+#~ msgstr "സഹജമായ: "
+
+#~ msgid "Test profile: "
+#~ msgstr "പരീക്ഷണ പ്രൊഫൈല്‍:"
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "തുറക്കുന്നതിനായി ഐസിസി പ്രൊഫൈല്‍ ഫയല്‍ തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "_Import"
+#~ msgstr "ഇംപോര്‍ട്ട് ചെയ്യുക (_I)"
+
+#~ msgid "All files"
+#~ msgstr "എല്ലാ ഫയലുകളും"
+
 #, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "നിങ്ങളുടെ ആധികാരികത ഉറപ്പുവരുത്തിയിരിക്കുന്നതിനു ശേഷം അടയാളവാക്ക് മാറിയിരിക്കുന്നു!"
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "ഫയല്‍ കയറ്റുന്നതില്‍ പരാജയം: %s"
 
-#: ../panels/user-accounts/run-passwd.c:532
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "പ്രൊഫെൽ അപ്പ്‌ലോഡ് ചെയ്യപെട്ടു:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "ഈ URL എഴുതുക."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "നിങ്ങളുടെ കമ്പ്യൂട്ടർ ഒരു സാധാരണ ബൂട്ടിങ്ങിൽ വീണ്ടും തുടങ്ങുക"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "പ്രൊഫെൽ ഇൻസ്റ്റാൾ ചെയ്യുന്നതിനായി ബ്രൊസറിൽ URL ടെപ്പ് ചെയ്യുക."
+
+#~ msgid "Save Profile"
+#~ msgstr "പ്രൊഫൈല്‍ സൂക്ഷിക്കുക"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "തെരഞ്ഞെടുത്ത ഡിവൈസിനു് നിറമുള്ളൊരു പ്രൊഫൈല്‍ തയ്യാറാക്കുക"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "അളക്കുന്ന ഉപകരണം ലഭ്യമല്ല. ഇതു് ഓണ്‍ ആണെന്നും ശരിയായി കണക്ട് ചെയ്തിട്ടുണ്ടെന്നും ഉറപ്പാക്കുക."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "അളക്കുന്ന ഉപകരണം പ്രിന്റര്‍ ഡയലോഗ് പിന്തുണയ്ക്കുന്നില്ല."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "ഡിവൈസ് തരം ഇപ്പോള്‍ പിന്തുണയ്ക്കുന്നില്ല."
+
+#~ msgid "Standard Space"
+#~ msgstr "മാനക സ്പേസ്"
+
+#~ msgid "Test Profile"
+#~ msgstr "പരീക്ഷണ പ്രൊഫൈല്‍"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "സ്വയം"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "കുറഞ്ഞ നിലവാരം"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "സാമാന്യ നിലവാരം"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "ഉയര്‍ന്ന നിലവാരം"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "സഹജമായ RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "സഹജമായ CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "സ്വതേയുള്ള ഗ്രേ"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "കമ്പനി തന്ന ക്രമീകരണ വിവരം"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "ഈ പ്രൊഫൈല്‍ വെച്ച് മുഴുവന്‍ സ്ക്രീന്‍ ഡിസ്പ്ലേ ക്രമീകരണം പറ്റില്ല"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "ഈ പ്രൊഫൈല്‍ കൃത്യമല്ലായിരിക്കാം‌"
+
+#~ msgid "Upload profile"
+#~ msgstr "പ്രൊഫൈല്‍ കയറ്റുക"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "ഇന്റര്‍നെറ്റ് ബന്ധം വേണം"
+
+#~ msgid "Co­lor"
+#~ msgstr "നിറം"
+
+#~ msgid "Other…"
+#~ msgstr "മറ്റുളളവ…"
+
+#~ msgid "Today"
+#~ msgstr "ഇന്നു്"
+
+#~ msgid "Yesterday"
+#~ msgstr "ഇന്നലെ"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgid "Language"
+#~ msgstr "ഭാഷ"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
 #, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "പുതിയ രഹസ്യവാക്കില്‍ അക്കങ്ങളോ പ്രത്യേക അക്ഷരങ്ങളോ ലഭ്യമല്ല."
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
 
-#: ../panels/user-accounts/run-passwd.c:536
 #, c-format
-msgid "Unknown error"
-msgstr "അറിയാത്ത ഏതോ പ്രശ്നം"
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
 
-#: ../panels/user-accounts/um-account-dialog.c:34
-#, fuzzy
-#| msgid "Should match the web address of your account provider."
-msgid "Should match the web address of your login provider."
-msgstr "അക്കൗണ്ട് നല്‍കിയ ആളിന്റെ വെബ്ബ് അഡ്രസുമായി സാമ്യം വേണം."
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
 
-#: ../panels/user-accounts/um-account-dialog.c:229
-msgid "Failed to add account"
-msgstr "അക്കൌണ്ട് ചേര്‍ക്കുന്നതില്‍ പരാജയം"
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
 
-#: ../panels/user-accounts/um-account-dialog.c:462
-msgid "Passwords do not match."
-msgstr "രഹസ്യവാക്കുകള്‍ തമ്മില്‍ പൊരുത്തക്കേടുണ്ട്."
+#~ msgid "%R"
+#~ msgstr "%R"
 
-#: ../panels/user-accounts/um-account-dialog.c:717 ../panels/user-accounts/um-account-dialog.c:763
-#: ../panels/user-accounts/um-account-dialog.c:784
-msgid "Failed to register account"
-msgstr "അക്കൌണ്ട് രജിസ്ടര്‍ ചെയ്യുന്നതില്‍ പരാജയം"
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
 
-#: ../panels/user-accounts/um-account-dialog.c:907
-msgid "No supported way to authenticate with this domain"
-msgstr "ഈ ഡൊമെയിനിലേക്കു് ആധികാരികത ഉറപ്പാക്കുവാന്‍ പിന്തുണയ്ക്കുന്നില്ല"
+#~ msgid "∶"
+#~ msgstr ":"
 
-#: ../panels/user-accounts/um-account-dialog.c:980
-msgid "Failed to join domain"
-msgstr "ഡൊമെയിനിലേക്കു് ചേരുന്നതില്‍ പരാജയം"
+#~ msgid "24-hour"
+#~ msgstr "24-മണിക്കൂര്‍"
 
-#: ../panels/user-accounts/um-account-dialog.c:1041
-#, fuzzy
-#| msgid ""
-#| "That login name didn't work.\n"
-#| "Please try again."
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"ആ ഉപയോക്തൃനാമം പ്രവര്‍ത്തിക്കുന്നില്ല. \n"
-"ദയവായി വീണ്ടും ശ്രമിക്കുക."
+#~ msgid "AM / PM"
+#~ msgstr "AM/PM"
 
-#: ../panels/user-accounts/um-account-dialog.c:1048
-#, fuzzy
-#| msgid ""
-#| "That login password didn't work.\n"
-#| "Please try again."
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"ആ രഹസ്യവാക്ക് പ്രവര്‍ത്തിക്കുന്നില്ല. \n"
-"ദയവായി വീണ്ടും ശ്രമിയ്ക്കുക."
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "ലാന്‍ഡ്സ്കെയിപ്പ്"
 
-#: ../panels/user-accounts/um-account-dialog.c:1056
-msgid "Failed to log into domain"
-msgstr "ഡൊമെയിനിലേക്കു് പ്രവേശിയ്ക്കുന്നതില്‍ പരാജയം"
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "പൊട്രെയിറ്റ് വലത്"
 
-#: ../panels/user-accounts/um-account-dialog.c:1114
-#, fuzzy
-#| msgid "Unable find the domain. Maybe you misspelled it?"
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "ഡൊമൈന്‍ കണ്ടുപിടിക്കാന്‍ സാധിച്ചില്ല. അതോ നിങ്ങള്‍ക്ക് തെറ്റിയോ ?"
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "പൊട്രെയിറ്റ് ഇടത്"
 
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "നിലവാരമുള്ള"
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "തിരിഞ്ഞ ലാന്‍ഡ്സ്കേപ്"
 
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "അഡ്മിനിസ്ട്രേറ്റര്‍"
+#~ msgid "Display Arrangement"
+#~ msgstr "പ്രദര്‍ശന സജ്ജികരണം"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid "You are not allowed to access the device. Contact your system administrator."
-msgstr "നിങ്ങള്‍ക്കു് ഡിവൈസിലേക്കു് പ്രവേശനമില്ല. ദയവായി സിസ്റ്റം അഡ്മിനിസ്ട്രേറ്ററുമായി ബന്ധപ്പെടുക."
+#~ msgid "Display Mode"
+#~ msgstr "പ്രദര്‍ശന രീതി"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:144
-msgid "The device is already in use."
-msgstr "ഡിവൈസ് നിലവില്‍ ഉപയോഗത്തിലാണു്."
+#~ msgid "Join Displays"
+#~ msgstr "പ്രദര്‍ശനങ്ങള്‍ ഒരുമിപ്പിക്കുക"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:146
-msgid "An internal error occurred."
-msgstr "ആന്തരിക പിശകു് ഉണ്ടായിരിക്കുന്നു."
+#~ msgid "Apply Changes?"
+#~ msgstr "മാറ്റങ്ങള്‍ സൂക്ഷിക്കട്ടെ?"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:217
-msgid "Enabled"
-msgstr "പ്രവര്‍ത്തന സജ്ജമാക്കിയിരിക്കുന്നു"
+#~ msgid "Apply"
+#~ msgstr "സൂക്ഷിക്കു"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr "രജിസ്ടര്‍ ചെയ്ത ഫിംഗര്‍പ്രിന്റുകള്‍ വെട്ടിമാറ്റണമോ?"
+#, c-format
+#~ msgid "%.1lf Hz"
+#~ msgstr "%.1lf Hz"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
-msgstr "ഫിംഗര്‍പ്രിന്റുകള്‍ _വെട്ടിമാറ്റണമോ"
+#~ msgid "On"
+#~ msgstr "ഓണ്‍ "
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
-msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
-msgstr "രജിസ്ടര്‍ ചെയ്ത ഫിംഗര്‍പ്രിന്റുകള്‍ വെട്ടിമാറ്റി നിങ്ങള്‍ക്കു് ഫിംഗര്‍പ്രിന്റ് ലോഗിന്‍ പ്രവര്‍ത്തന രഹിതമാക്കണമോ?"
+#~ msgid "Off"
+#~ msgstr "ഓഫ്"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:443
-msgid "Done!"
-msgstr "പൂര്‍ത്തിയായി!"
+#~ msgid "_Night Light"
+#~ msgstr "രാത്രി വെളിച്ചം (_N)"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:504 ../panels/user-accounts/um-fingerprint-dialog.c:546
+#~ msgid "Could not get screen information"
+#~ msgstr "സ്ക്രീന്‍ വിവരങ്ങള്‍ ലഭ്യമായില്ല"
+
+#~ msgid "Unknown"
+#~ msgstr "അപരിചിതം"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-ബിറ്റ്"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-ബീറ്റ്"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "പതിപ്പ് %s"
+
+#~ msgid "Overview"
+#~ msgstr "അവലോകനം"
+
+#~ msgid "Ask what to do"
+#~ msgstr "എന്തു്  ചെയ്യണമെന്നു് ചോദിക്കുക"
+
+#~ msgid "Do nothing"
+#~ msgstr "ഒരു പ്രവര്‍ത്തിയും ചെയ്യാതിരിക്കുക"
+
+#~ msgid "Open folder"
+#~ msgstr "ഫോള്‍ഡര്‍ തുറക്കുക"
+
+#~ msgid "Other Media"
+#~ msgstr "മറ്റു് മാധ്യമം"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "പാട്ടു സി.ഡികള്‍ കേള്‍ക്കുന്നതിനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "വീഡിയോ സി.ഡികള്‍ കേള്‍ക്കുന്നതിനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "ഒരു മ്യൂസിക് പ്ലേയര്‍ ഘടിപ്പിക്കുമ്പോള്‍ പ്രവര്‍ത്തിപ്പിയ്ക്കുവാനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "ഒരു ക്യാമറാ ഘടിപ്പിക്കുമ്പോള്‍ പ്രവര്‍ത്തിപ്പിയ്ക്കുവാനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "സോഫ്റ്റ്‌വെയര്‍ സിഡികള്‍ക്കുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "audio DVD"
+#~ msgstr "ശബ്ദ ഡിവിഡി"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "കാലിയായ ബ്ലൂ-റേ ഡിസ്ക്"
+
+#~ msgid "blank CD disc"
+#~ msgstr "കാലിയായ സിഡി ഡിസ്ക്"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "കാലിയായ ഡിവിഡി ഡിസ്ക്"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "കാലിയായ എച്ച്ഡി ഡിവിഡി ഡിസ്ക്"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "ബ്ലൂ-റേ വിഡിയോ ഡിസ്ക്"
+
+#~ msgid "e-book reader"
+#~ msgstr "ഇ-പുസ്തക റീഡര്‍"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "എച്ച്ഡി ഡിവിഡി വീഡിയോ ഡിസ്ക്"
+
+#~ msgid "Picture CD"
+#~ msgstr "ചിത്രങ്ങളുള്ള സിഡി"
+
+#~ msgid "Super Video CD"
+#~ msgstr "സൂപ്പര്‍ വീഡിയോ സിഡി"
+
+#~ msgid "Video CD"
+#~ msgstr "വീഡിയോ സിഡി"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "സഹജമായ പ്രയോഗങ്ങള്‍"
+
+#~ msgid "Ab­out"
+#~ msgstr "ഗ്നോം കണ്ട്രോള്‍ സെന്ററിനെ കുറിച്ച്"
+
+#~ msgid "De­tails"
+#~ msgstr "വിശദവിവരങ്ങള്‍"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "മാറ്റുവാന്‍ സാധ്യമാകുന്ന മീഡിയ"
+
+#~ msgid "OS name"
+#~ msgstr "ഒ.എസിന്റെ പേര്"
+
+#~ msgid "OS type"
+#~ msgstr "ഏത് തരം ഒഎസ്"
+
+#~ msgid "Disk"
+#~ msgstr "ഡിസ്ക്ക്"
+
+#~ msgid "Check for updates"
+#~ msgstr "പരിഷ്കരണങ്ങള്‍ക്കായി നോക്കുന്നു"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "$PICTURES ലേക്ക് ഒരു സ്ക്രീന്‍ഷോട്ട് സൂക്ഷിയ്ക്കുക"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "$PICTURES ലേക്കു് ജാലകത്തിന്റെ ഒരു സ്ക്രീന്‍ഷോട്ട് സൂക്ഷിയ്ക്കുക"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "$PICTURES ലേക്കു് ഒരു സ്ഥലത്തിന്റെ സ്ക്രീന്‍ഷോട്ട് സൂക്ഷിയ്ക്കുക"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "ക്ലിപ്പ്ബോര്‍ഡിലേക്കു് ഒരു സ്ക്രീന്‍ഷോട്ട് പകര്‍ത്തുക"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "ക്ലിപ്പ്ബോര്‍ഡിലേക്കു് ജാലകത്തിന്റെ ഒരു സ്ക്രീന്‍ഷോട്ട് പകര്‍ത്തുക"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "ക്ലിപ്പ്ബോര്‍ഡിലേക്കു് ഒരു സ്ഥലത്തിന്റെ സ്ക്രീന്‍ഷോട്ട് പകര്‍ത്തുക"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "ഒരു ചെറിയ സ്ക്രീന്‍കാസ്റ്റ് രേഖപ്പെടുത്തുക"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുവാനുള്ള മോഡിഫയര്‍ മാത്രമുള്ള സ്വിച്ച്"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "എല്ലാ എളുപ്പവഴിയും പഴയപോലെ ആക്കട്ടെ?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "എല്ലാ എളുപ്പവഴിയും പഴയപോലെ ആക്കിയാല്‍ നിങ്ങള്‍ ക്രമീകരിച്ചതിനും മാറ്റം വരാം. ഇത് തിരിച്ച് "
+#~ "ആക്കാന്‍ പറ്റില്ല."
+
+#~ msgid "Reset All"
+#~ msgstr "എല്ലാം പഴയപടി ആക്കുക"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "സ്വന്തം എളുപ്പവഴി ഉണ്ടാക്കുക"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "എളുപ്പവഴി ഉണ്ടാക്കുക"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "പുതിയ എളുപ്പവഴി കൊടുക്കുക"
+
+#~ msgid "Set"
+#~ msgstr "തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "ഇരട്ട ക്ലിക്കുകള്‍ക്കിടയില്‍ അനുവദനീയമായ സമയം"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "രണ്ട് വിരല്‍ സ്ക്രോള്‍"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "അഞ്ച് ക്ലിക്കുകള്‍, ജിഇജിഎല്‍ സമയം!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "രണ്ടു് ക്ലിക്ക്, പ്രൈമറി ബട്ടണ്‍"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "ഒറ്റ ക്ലിക്ക്, പ്രൈമറി ബട്ടണ്‍"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "രണ്ടു് ക്ലിക്ക്, മദ്ധ്യ ബട്ടണ്‍"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "ഒറ്റ ക്ലിക്ക്, മദ്ധ്യ ബട്ടണ്‍"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "രണ്ടു് ക്ലിക്ക്, സെക്കന്‍ഡറി ബട്ടണ്‍"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "ഒറ്റ ക്ലിക്ക്, സെക്കന്‍ഡറി ബട്ടണ്‍"
+
+#~ msgid "Network proxy"
+#~ msgstr "ശൃംഖലയിലെ പ്രോക്സി"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager പ്രവര്‍ത്തിക്കണം."
+
+#~ msgid "page 1"
+#~ msgstr "താള്‍ 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "_ആന്തരിക ആധികാരികത ഉറപ്പാക്കല്‍"
+
+#~ msgid "page 2"
+#~ msgstr "താള്‍ 2 "
+
+#~ msgid "automatic"
+#~ msgstr "തനിയെയുള്ള"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "പ്രൊഫൈല്‍ %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "എന്റര്‍പ്രൈസ്"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "ഒന്നുമില്ല"
+
+#~ msgid "Never"
+#~ msgstr "ഒരിക്കലുമില്ല"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "ഒന്നുമില്ല"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "പോര"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ശരി"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "നല്ലത്"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "അത്യുത്തമം"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "കണക്ഷന്‍ പ്രൊഫൈല്‍ കളയു"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN നീക്കം ചെയ്യുക"
+
+#~ msgid "Identity"
+#~ msgstr "തിരിച്ചറിയല്‍"
+
+#~ msgid "Delete Route"
+#~ msgstr "റൂട്ട് നീക്കം ചെയ്യുക"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "ഒന്നുമില്ല"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "ഡബ്ലിയുഇപി 40/128-bit കീ (ഹെക്സോ ആസ്കിയോ)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit പാസ്‌ഫ്രെയിസ്"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "ഡൈനമിക് WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 പേഴ്സണല്‍"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 എന്റര്‍പ്രൈസ്"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "ട്വിസ്റ്റഡ് പെയര്‍ (ടിപി)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "അറ്റാച്ച്മെന്റ് യൂണിറ്റ് ഇന്റര്‍ഫേസ് (എയുഐ)"
+
+#~ msgid "BNC"
+#~ msgstr "ബിഎന്‍സി"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "മീഡിയ ഇന്‍ഡിപെന്‍ഡന്റ് ഇന്റര്‍ഫേസ് (എംഐഐ)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "ബന്ധ എഡിറ്റര്‍ തുറക്കാനാകുന്നില്ല"
+
+#~ msgid "New Profile"
+#~ msgstr "പുതിയ പ്രൊഫൈല്‍"
+
+#~ msgid "Import from file…"
+#~ msgstr "ഫയലില്‍ നിന്നും ഇംപോര്‍ട്ട് ചെയ്യുക…"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN ചേര്‍ക്കു"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "വിപിഎന്‍ ബന്ധം ഇംപോര്‍ട്ട് ചെയ്യുവാന്‍ സാധ്യമല്ല"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "ഫയല്‍ “%s” വായിക്കാന്‍ പറ്റുന്നില്ല, അല്ലെങ്കില്‍ അതില്‍ തിരിച്ചറിയാനാകുന്ന VPN ബന്ധങ്ങളുടെ "
+#~ "വിവരം ഇല്ല\n"
+#~ "\n"
+#~ "പിഴവ്: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "ഇംപോര്‍ട്ട് ചെയ്യുന്നതിനുള്ള ഫയല്‍ തെരഞ്ഞെടുക്കുക"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "“%s” എന്ന പേരില്‍ ഒരു ഫയല്‍ നിലവിലുണ്ടു്."
+
+#~ msgid "_Replace"
+#~ msgstr "_പകരംവെക്കുക"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "നിങ്ങള്‍ സൂക്ഷിച്ചുകൊണ്ടിരിക്കുന്ന വിപിഎന്‍ ബന്ധംഉപയോഗിച്ചു് %s മാറ്റണമോ?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "വിപിഎന്‍ ബന്ധം എക്സ്പോര്‍ട്ട് ചെയ്യുവാന്‍ സാധിച്ചില്ല"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN ബന്ധം “%s” %s ലേക്ക് കയറ്റുമതി ചെയ്യാനാകുന്നില്ല.\n"
+#~ "\n"
+#~ "പിഴവ്: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "വിപിഎന്‍ ബന്ധം എക്സ്പോര്‍ട്ട് ചെയ്യുക"
+
+#~ msgid "Net­work"
+#~ msgstr "ശൃംഖല"
+
+#~ msgid "never"
+#~ msgstr "ഒരിക്കലുമില്ല"
+
+#~ msgid "today"
+#~ msgstr "ഇന്നു്"
+
+#~ msgid "yesterday"
+#~ msgstr "ഇന്നലെ"
+
+#~ msgid "Last used"
+#~ msgstr "അവസാനം ഉപയോഗിച്ചതു്"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട് സ്വിച്ച് ഓണ്‍ ചെയ്യുന്നതു്,  <b>%s</b>-ല്‍ നിന്നും നിങ്ങളെ വിഛേദിയ്ക്കുന്നു."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "ഹോട്ട്സ്പോട്ട് സജീവമാകുമ്പോള്‍ വയര്‍ലെസ്സ് മുഖേനയുള്ള ഇന്റര്‍നെറ്റ് നിങ്ങള്‍ക്കു്ലഭ്യമാകുന്നതല്ല."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "വൈ-ഫൈ വഴി ഇന്റെര്‍നെറ്റ് ബന്ധം പങ്കിടാന്‍ ആണ് സാധാരണ വൈ-ഫൈ ഹോട്ട്സ്പോട്ട് ഉപയോഗിക്കുന്നത്."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "ഹോട്ട്സ്പോട്ട് നിര്‍ത്തി ഏതെങ്കിലും ഉപയോക്താക്കള്‍ വിഛേദിയ്ക്കണമോ?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "ഹോട്ട്സ്പോട്ട്  _നിര്‍ത്തുക"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "ഹോട്ട്സ്പോട്ടായി ഉപയോഗിക്കാന്‍ സിസ്റ്റത്തിന്റെ നയം അനുവദിക്കുന്നില്ല"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "വയര്‍ലെസ്സ് ഡിവൈസ് ഹോട്ട്സ്പോട്ട് മോഡ് പിന്തുണയ്ക്കുന്നില്ല"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "രഹസ്യവാക്ക്, തയ്യാറാക്കിയ ക്രമീകരണം, എന്നിങ്ങനെയുള്ള %s-ന്റെ നെറ്റ്‌വര്‍ക്ക് വിവരങ്ങള്‍ "
+#~ "നഷ്ടമാകുന്നു."
+
+#~ msgid "_Forget"
+#~ msgstr "മറക്കുക (_F)"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "അറിയാവുന്ന വൈ-ഫൈ ശ്രംഖലകള്‍"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "മറക്കുക (_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "ക്രമീകരണത്തിനുള്ളൊരു യുആര്‍എല്‍ ലഭ്യമാക്കത്തപ്പോള്‍, വെബ് പ്രോക്സി ഓട്ടോഡിസ്ക്കവറി ഉപയോഗിയ്ക്കുന്നു."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "അവിശ്വസനീയമായ പബ്ലിക് നെറ്റ്‌വര്‍ക്കുകള്‍ക്കു് ഇതു് ഉചിതമല്ല."
+
+#~ msgid "details"
+#~ msgstr "വിശദവിവരങ്ങള്‍"
+
+#~ msgid "Show P_assword"
+#~ msgstr "അടയാളവാക്കു് _കാണിക്കുക"
+
+#~ msgid "Make available to other users"
+#~ msgstr "മറ്റുള്ള ഉപയോക്താക്കള്‍ക്ക് ലഭ്യമാക്കുക"
+
+#~ msgid "identity"
+#~ msgstr "തിരിച്ചറിയല്‍"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_വിലാസങ്ങള്‍"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "ഓട്ടോമാറ്റിക് (DHCP) വിലാസങ്ങള്‍ മാത്രം"
+
+#~ msgid "Link-local only"
+#~ msgstr "ലിങ്ക്-ലോക്കല്‍ മാത്രം"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "സ്വയം ലഭിച്ച റൂട്ടുകള്‍ അവ_ഗണിക്കുക"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_പകര്‍ത്തിയ MAC വിലാസം"
+
+#~ msgid "hardware"
+#~ msgstr "ഹാര്‍ഡ്‌വെയര്‍"
+
+#~ msgid "_Reset"
+#~ msgstr "_ആദ്യം മുതല്‍ തുടങ്ങുക"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "ഈ ബന്ധത്തിന്റെ ഡജ്ജീകരണങ്ങള്‍ സ്വതവേയുള്ളതിലേക്ക് മാറ്റുക, പക്ഷേ, മുന്‍ഗണനയുള്ള ബന്ധമായി കരുതുക."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr "ഈ ശൃംഖലയുമായുള്ള എല്ലാ വിവരങ്ങളും നീക്കി തനിയെ ബന്ധിപ്പിക്കാതിരിക്കുക."
+
+#~ msgid "reset"
+#~ msgstr "വീണ്ടും തുടങ്ങുക"
+
+#~ msgid "Hardware"
+#~ msgstr "ഹാര്‍ഡ്‌വെയര്‍"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "ഒരു വയര്‍ലെസ്സ് നെറ്റ്‌വര്‍ക്കിലേക്കു് കണക്ട് ചെയ്യുന്നതിനായി സ്വിച്ച് ഓഫ് ചെയ്യുക"
+
+#~ msgid "Connected Devices"
+#~ msgstr "കണക്ട് ചെയ്ത ഡിവൈസുകള്‍"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastructure"
+
+#~ msgid "Status unknown"
+#~ msgstr "അവസ്ഥ അറിയില്ല"
+
+#~ msgid "Unmanaged"
+#~ msgstr "കൈകാര്യം ചെയ്യാത്ത"
+
+#~ msgid "Unavailable"
+#~ msgstr "ലഭ്യമല്ല"
+
+#~ msgid "Connecting"
+#~ msgstr "ബന്ധം സ്ഥാപിക്കുന്നു"
+
+#~ msgid "Authentication required"
+#~ msgstr "ആധികാരികത ഉറപ്പ് വരുത്തല്‍ ആവശ്യമുണ്ട്"
+
+#~ msgid "Disconnecting"
+#~ msgstr "വിഛേദിക്കുന്നു"
+
+#~ msgid "Connection failed"
+#~ msgstr "കണക്ഷന്‍ പരാജയപ്പെട്ടു"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "അവസ്ഥ അറിയില്ല (കാണുന്നില്ല)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "ക്രമീകരണം പരാജയപ്പെട്ടു"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "ഐപി ക്രമീകരണം പരാജയപ്പെട്ടു"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "ഐപി ക്രമീകരണത്തിന്റെ കാലാവധി കഴിഞ്ഞിരിയ്ക്കുന്നു"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "രഹസ്യങ്ങള്‍ ആവശ്യമുണ്ടു്, പക്ഷേ ലഭ്യമാക്കിയിട്ടില്ല"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x സപ്പ്ലിക്കന്റ് വിഛേദിച്ചിരിയ്ക്കുന്നു"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x സപ്പ്ലിക്കന്റ് ക്രീകരണം പരാജയപ്പെട്ടു"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x സപ്പ്ലിക്കന്റ് പരാജയപ്പെട്ടു"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x സപ്പ്ലിക്കന്റ് ആധികാരികത ഉറപ്പാക്കുന്നതിനു് അധികം സമയമെടുക്കുന്നു"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "പിപിപി സര്‍വീസ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "പിപിപി സര്‍വീസ് വിഛേദിച്ചിരിയ്ക്കുന്നു"
+
+#~ msgid "PPP failed"
+#~ msgstr "പിപിപി പരാജയപ്പെട്ടു"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "ഡിഎച്സിപി ക്ലയന്റ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#~ msgid "DHCP client error"
+#~ msgstr "ഡിഎച്സിപി ക്ലയന്റ് പിശക്"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "ഡിഎച്സിപി ക്ലയന്റ് പരാജയപ്പെട്ടു"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "പങ്കിടുന്ന കണക്ഷന്‍ സര്‍വീസ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "പങ്കിടുന്ന കണക്ഷന്‍ സര്‍വീസ് പരാജയപ്പെട്ടു"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP സര്‍വീസ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP സര്‍വീസ് പിശക്"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP സര്‍വീസ് പരാജയപ്പെട്ടു"
+
+#~ msgid "Line busy"
+#~ msgstr "ലൈന്‍ തിരക്കിലാണു്"
+
+#~ msgid "No dial tone"
+#~ msgstr "ഡയല്‍ ടോണില്ല"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "ക്യാരിയര്‍ സ്ഥാപിച്ചിട്ടില്ല"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "ഡയലിങ് ആവശ്യം സമയപരിധി കഴിഞ്ഞിരിയ്ക്കുന്നു"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "ഡയലിങ് ശ്രമം പരാജയപ്പെട്ടു"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "മോഡം പ്രാരംഭം പരാജയപ്പെട്ടു"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "വ്യക്തമാക്കിയ എപിഎല്‍ തെരഞ്ഞെടുത്തതില്‍ പരാജയം"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "നെറ്റ്‌വര്‍ക്കുകള്‍ തെരയുന്നില്ല"
+
+#~ msgid "Network registration denied"
+#~ msgstr "നെറ്റ്‌വര്‍ക്ക് രജിസ്ട്രേഷന്‍ നിഷേധിച്ചിരിയ്ക്കുന്നു"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "നെറ്റ്‌വര്‍ക്ക് രജിസ്ട്രേഷന്‍ സമയപരിധി കഴിഞ്ഞിരിയ്ക്കുന്നു"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "ആവശ്യപ്പെട്ട നെറ്റ്‌വര്‍ക്കിലേക്ക് രഡിസ്ടര്‍ ചെയ്യുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#~ msgid "PIN check failed"
+#~ msgstr "പിന്‍ പരിശോധന പരാജയപ്പെട്ടു"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "ഡിവൈസിനുള്ള ഫേംവെയര്‍ ലഭ്യമല്ല"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "കണക്ഷന്‍ കാണുവാനില്ല"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "നിലവിലുള്ള കണക്ഷന്‍ കരുതപ്പെടുന്നു"
+
+#~ msgid "Modem not found"
+#~ msgstr "മോഡം ലഭ്യമായില്ല"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ബ്ലൂടൂത് കണക്ഷന്‍ പരാജയപ്പെട്ടു"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "സിം പിന്‍ ആവശ്യമുണ്ടു്"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "സിം പൂക്ക് ആവശ്യമുണ്ടു്"
+
+#~ msgid "SIM wrong"
+#~ msgstr "സിം തെറ്റാണു്"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "കണക്ഷന്‍ ഡിപന്‍ഡന്‍സി പരാജയപ്പെട്ടു"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "കേബിള്‍ ഊരി"
+
+#~ msgid "no file selected"
+#~ msgstr "ഫയല്‍ ഒന്നും എടുത്തില്ല"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "DER, PEM, അല്ലെങ്കില്‍ PKCS#12 സ്വകാര്യ കീകള്‍ (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER അല്ലെങ്കില്‍ PEM സര്‍ട്ടിഫീക്കേറ്റുകള്‍ (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "EAP-FAST PAC ഫയല്‍ കാണുന്നില്ല"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "പിഎസി ഫയലുകള്‍ (*.pac)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "എന്‍ക്രിപ്റ്റ് ചെയ്യാത്ത സ്വകാര്യ കീകള്‍ അസുരക്ഷിതമാണു്"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "ഈ സ്വകാര്യ ചാവി രഹസ്യവാക്ക് വെച്ച് സുരക്ഷിതമാക്കിയതായി കാണുന്നില്ല. ഇത് സുരക്ഷയെ ബാധിക്കുന്ന "
+#~ "കാര്യമാണ്. ദയവായി രഹസ്യവാക്ക് കൊണ്ട് സുരക്ഷിതമാക്കിയ സ്വകാര്യ ചാവി തെരഞ്ഞെടുക്കുക.\n"
+#~ "\n"
+#~ "(ഓപ്പണ്‍ എസ്എസ്എല്‍ വെച്ച് സ്വകാര്യ കീക്ക് രഹസ്യവാക്ക് കൊടുക്കാം)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "നിങ്ങളുടെ സ്വകാര്യ സാക്ഷ്യപത്രം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Choose your private key"
+#~ msgstr "നിങ്ങളുടെ സ്വകാര്യ കീ തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "അറിയിപ്പുകള്‍"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "പോപ്പപ് അറിയിപ്പുകള്‍ (_P)"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "മറ്റുളളവ"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s അക്കൌണ്ട്"
+
+#~ msgid "Error removing account"
+#~ msgstr "അക്കൌണ്ട് നീക്കം ചെയ്യുന്നതില്‍ പിശക്"
+
+#, c-format
+#~ msgid "<b>%s</b> removed"
+#~ msgstr "<b>%s</b> യെ മാറ്റി"
+
+#~ msgid "Remove Account"
+#~ msgstr "എക്കൗണ്ട് നീക്കം ചെയ്യുക"
+
+#~ msgid "Unknown time"
+#~ msgstr "അജ്ഞാതസമയം"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "പൂര്‍ണ്ണമായി ചാര്‍ജ് ചെയ്യുന്നതു് വരെ %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "സൂക്ഷിക്കുക: %s സമയം ബാക്കി"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s ബാക്കി"
+
+#~ msgid "Fully charged"
+#~ msgstr "മുഴുവനും ചാര്‍ജ്ജ് ചെയ്തിരിയ്ക്കുന്നു"
+
+#~ msgid "Empty"
+#~ msgstr "കാലി"
+
+#~ msgid "Charging"
+#~ msgstr "ചാര്‍ജ് ചെയ്തുകൊണ്ടിരിയ്ക്കുന്നു"
+
+#~ msgid "Discharging"
+#~ msgstr "ചാര്‍ജ് ഉപയോഗിച്ചുകൊണ്ടിരിയ്ക്കുന്നു"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "പ്രധാന"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "അധികമായ"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "വയര്‍ലെസ്സ് മൌസ്"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "വയര്‍ലെസ്സ് കീബോര്‍ഡ്"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "തടസ്സമില്ലാത്ത പവര്‍ "
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "സ്വകാര്യ ഡിജിറ്റല്‍ അസിസ്റ്റന്റ്"
+
+#~ msgid "Cellphone"
+#~ msgstr "സെല്‍ഫോണ്‍"
+
+#~ msgid "Media player"
+#~ msgstr "മീഡിയ പ്ലേയര്‍"
+
+#~ msgid "Computer"
+#~ msgstr "കമ്പ്യൂട്ടര്‍"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "ചാര്‍ജ് ചെയ്തുകൊണ്ടിരിയ്ക്കുന്നു"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "ശ്രദ്ധിക്കുക"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "കുറഞ്ഞ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "നല്ലത്"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "മുഴുവനും ചാര്‍ജ്ജ് ചെയ്തിരിയ്ക്കുന്നു"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "കാലി"
+
+#~ msgid "Batteries"
+#~ msgstr "ബാറ്ററികള്‍"
+
+#~ msgid "When _idle"
+#~ msgstr "_വെറുതെ ഇരിക്കുമ്പോള്‍"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "_തിരശ്ശീല വെളിച്ചം"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "കീബോര്‍ഡിന്റെ ശോഭ"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "വെറുതെ ഇരിക്കുമ്പോള്‍ സ്ക്രീന്‍ _മങ്ങിക്കുക"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_വയര്‍ലസ്സ്"
+
+#~ msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+#~ msgstr "മൊബൈല്‍ ബ്രോഡ്ബാന്‍ഡ് ഉപകരണങ്ങള്‍ (3G, 4G, LTE, etc.) ഓഫ് ചെയ്യുക."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_ബ്ളുടൂത്ത്"
+
+#~ msgid "When on battery power"
+#~ msgstr "ബാറ്ററിയില്‍ പ്രവര്‍ത്തിയ്ക്കുമ്പോള്‍"
+
+#~ msgid "When plugged in"
+#~ msgstr "പ്ലഗ്ഗിന്‍ ചെയ്തപ്പോള്‍"
+
+#~ msgid "Suspend"
+#~ msgstr "സസ്പെന്‍ഡ്"
+
+#~ msgid "Power Off"
+#~ msgstr "നിര്‍ത്തി വെയ്ക്കുക"
+
+#~ msgid "Hibernate"
+#~ msgstr "ശിശിരനിദ്രയിലാക്കുക"
+
+#~ msgid "Nothing"
+#~ msgstr "ഒരു പ്രവര്‍ത്തിയും ചെയ്യാതിരിക്കുക"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_തനിയെ ഉറങ്ങുക"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "തനിയെ ഉറങ്ങുക"
+
+#~ msgid "1 minute"
+#~ msgstr "1 മിനിട്ട്"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 മിനിട്ടുകള്‍"
+
+#~ msgid "4 minutes"
+#~ msgstr "40 മിനിറ്റുകള്‍"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 മിനിറ്റുകള്‍"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 മിനിട്ടുകള്‍"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 മിനിറ്റുകള്‍"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "പുതിയ പ്രിന്റര്‍ ചേര്‍ക്കുന്നതില്‍ പരാജയം."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui ലഭ്യമാക്കുവാന്‍ സാധ്യമല്ല: %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "ഉചിതമായ ഡ്രൈവര്‍ ലഭ്യമായില്ല"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "പോസ്റ്റ്സ്ക്രിപ്റ്റ് പ്രിന്റര്‍ വിവരണ ഫയലുകള് (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+#~ "GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "ജെറ്റ്ഡയറക്റ്റ് പ്രിന്റര്‍"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD പ്രിന്‍റര്‍"
+
+#~ msgid "One Sided"
+#~ msgstr "ഒരു വശത്തു്"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "ലോങ് എഡ്ജ് (സാധാരണ)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "ഷോര്‍ട്ട് എഡ്ജ് (ഫ്ലിപ്പ്)"
+
+#~ msgid "Portrait"
+#~ msgstr "പൊട്രെയിറ്റ്"
+
+#~ msgid "Landscape"
+#~ msgstr "ലാന്‍ഡ്സ്കെയിപ്പ്"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "റിവേഴ്സ് ലാന്‍ഡ്സ്കെയിപ്പ്"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "റിവേഴ്സ് പൊട്രെയിറ്റ്"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "ബാക്കിയുളള"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "താല്‍ക്കാലികമായി നിര്‍ത്തിയിരിക്കുന്നു"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "പ്രവര്‍ത്തനത്തില്‍"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "നിര്‍ത്തിയിരിയ്ക്കുന്നു"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "റദ്ദാക്കിയിരിക്കുന്നു"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "പാതിവഴിയില്‍ നിര്‍ത്തിയിരിക്കുന്നു"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "പൂര്‍ത്തിയാക്കിയിരിക്കുന്നു"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — സജീവമായ ജോലികള്‍"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "പ്രിന്റ് സെര്‍വ്വര്‍ തുറക്കുക"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "തുറക്കുക %s."
+
 #, fuzzy, c-format
-#| msgid "Could not access '%s' device"
-msgid "Could not access “%s” device"
-msgstr "'%s' ഡിവൈസിലേക്കു് പ്രവേശിക്കുവാനായില്ല"
+#~| msgid "Enter your username and password to view printers available on %s."
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "%s ഉള്ള പ്രിന്റ്ററുകൾ കാണുവാൻ യുസർ നെയിമും പാസ്സ് വേഡും കൊടുക്കുക"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:587
+#~ msgid "Searching for Printers"
+#~ msgstr "പ്രിന്റെറുകള്‍ക്കായി തെരയുന്നു"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "തുടര്‍ച്ചയായ പോര്‍ട്ട്"
+
+#~ msgid "Parallel Port"
+#~ msgstr "സമാന്തരമായ പോര്‍ട്ട്"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "സ്ഥലം: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "_വിലാസം: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "രണ്ടു് വശത്തും"
+
+#~ msgid "Paper Type"
+#~ msgstr "പേപ്പര്‍ തരം"
+
+#~ msgid "Paper Source"
+#~ msgstr "പേപ്പര്‍ ശ്രോതസ്സ്"
+
+#~ msgid "Output Tray"
+#~ msgstr "ഔട്ട്പുട്ട് ട്രേ"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "ഗോസ്റ്റ്സ്ക്രിപ്റ്റ് പ്രീ-ഫില്‍റ്ററിങ്"
+
+#~ msgid "Pages per side"
+#~ msgstr "ഒരു വശത്തുള്ള താളുകള്‍"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "സാധാരണ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "താള്‍ സജ്ജീകരണം"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "ഇന്‍സ്റ്റോള്‍ ചെയ്യുവാന്‍ സാധ്യമാകുന്ന ഐച്ഛികങ്ങള്‍"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "ജോലി"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "ഇമേജിന്റെ ഗുണം"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "നിറം"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "പൂര്‍ത്തിയാകുന്നു"
+
+#~ msgid "Test page"
+#~ msgstr "പരീക്ഷണ താള്‍"
+
+#~ msgid "Auto Select"
+#~ msgstr "സ്വയം തെരഞ്ഞെടുക്കല്‍"
+
+#~ msgid "Printer Default"
+#~ msgstr "സഹജമായ പ്രിന്റര്‍"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "ഗോസ്റ്റ്സ്ക്രിപ്റ്റ് അക്ഷരസഞ്ചയങ്ങള്‍ മാത്രം എംബഡ് ചെയ്യുക"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "പിഎസ് ലവല്‍ 1 വേര്‍തിരിയ്ക്കുക"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "പിഎസ് ലവല്‍ 2 വേര്‍തിരിയ്ക്കുക"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "പ്രീ-ഫില്‍റ്ററിങ് ലഭ്യമല്ല"
+
+#~ msgid "Out of toner"
+#~ msgstr "ടോണര്‍ കാലിയാണു്"
+
+#~ msgid "Low on developer"
+#~ msgstr "ഡെവെലപ്പര്‍ കുറവാണു്‌"
+
+#~ msgid "Out of developer"
+#~ msgstr "ഡെവെലപ്പര്‍ ഇല്ല"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "മഷി കുറവു്"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "മഷി തീര്‍ത്തിരിയ്ക്കുന്നു"
+
+#~ msgid "Open cover"
+#~ msgstr "കവര്‍ തുറക്കുക"
+
+#~ msgid "Open door"
+#~ msgstr "വാതില്‍ തുറക്കുക"
+
+#~ msgid "Low on paper"
+#~ msgstr "പേപ്പര്‍ കുറവു്"
+
+#~ msgid "Out of paper"
+#~ msgstr "പേപ്പര്‍ തീര്‍ന്നു"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "ഓഫ്‌ലൈന്‍"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "നിര്‍ത്തിയിരിയ്ക്കുന്നു"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "വെയിസ്റ്റ് റിസപ്ടബിള്‍ ഏകദേശം പൂര്‍ണ്ണം"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "വെയിസ്റ്റ് റിസപ്ടബിള്‍ പൂര്‍ണ്ണം"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ഒപ്ടിക്കല്‍ ഫോട്ടോ കണ്ടക്ടര്‍ അവസാനിയ്ക്കുന്നു"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ഒപ്ടിക്കല്‍ ഫോട്ടോ കണ്ടക്ടര്‍ പ്രവര്‍ത്തനത്തിലില്ല"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "തയ്യാര്‍"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "ജോലി ഒന്നും എടുക്കുന്നില്ല"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "പ്രവര്‍ത്തനത്തില്‍"
+
+#~ msgid "Clean print heads"
+#~ msgstr "പ്രിന്റര്‍ ഹെഡ്ഡ് വൃത്തിയാക്കുക"
+
+#~ msgid "Add…"
+#~ msgstr "ചേര്‍ക്കുക..."
+
+#~ msgid "In use"
+#~ msgstr "ഉപയോഗത്തല്‍ ഇരിക്കുന്നു"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "ഓണ്‍"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "ഓഫ്"
+
+#~ msgid "Usage & History"
+#~ msgstr "ഉപയോഗവും ചരിത്രവും"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "ചവറ്റുകൊട്ട വൃത്തിയാക്കുക?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "ചവറ്റുകുട്ടയിലെ വസ്തുകൾ ശാശ്വതമായി ഉപേക്ഷിക്കപ്പെടും"
+
+#~ msgid "_Empty Trash"
+#~ msgstr "ചവറ്റുകുട്ട _ഒഴിപ്പിക്കുക"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "ചവറ്റുകുട്ടയും താല്‍ക്കാലിക ഫയലുകളും ശൂന്യമാക്കുകയല്ലേ ?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "എല്ലാ താൽകാലിക രേഖകളും ശാശ്വതമായി ഉപേക്ഷിക്കപ്പെടും"
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "താല്‍ക്കാലിക ഫയലുകള്‍ _മായ്ക്കുക"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "സ്വകാര്യത നയം"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "സ്വകാര്യത"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "സ്വകാര്യ വിവരങ്ങള്‍ സംരക്ഷിക്കുക; മറ്റുള്ളവര്‍ എന്തു കാണണമെന്ന് തീരുമാനിക്കുക"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "സ്ക്രീന്‍ ഓഫ് ആകുന്നു"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 സെക്കന്‍ഡുകള്‍"
+
+#~ msgid "1 day"
+#~ msgstr "1 ദിവസം"
+
+#~ msgid "2 days"
+#~ msgstr "2 ദിവസം"
+
+#~ msgid "3 days"
+#~ msgstr "3 ദിവസം"
+
+#~ msgid "4 days"
+#~ msgstr "4 ദിവസം"
+
+#~ msgid "5 days"
+#~ msgstr "5 ദിവസം"
+
+#~ msgid "6 days"
+#~ msgstr "6 ദിവസം"
+
+#~ msgid "7 days"
+#~ msgstr "7 ദിവസം"
+
+#~ msgid "14 days"
+#~ msgstr "14 ദിവസം"
+
+#~ msgid "30 days"
+#~ msgstr "30 ദിവസം"
+
+#~ msgid "Forever"
+#~ msgstr "എന്നന്നേക്കും"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "ചരിത്രം ഓര്‍മിച്ചുവെയ്ക്കുന്നത് കാര്യങ്ങള്‍ വിണ്ടും കണ്ടുപിടിക്കുന്നത് എളുപ്പമാക്കും. ഇത് ശ്രംഖല വഴി "
+#~ "ഒരിക്കലും പങ്കിടില്ല."
+
+#~ msgid "_Recently Used"
+#~ msgstr "ഏറ്റവും _ഒടുവില്‍ ഉപയോഗിച്ച"
+
+#~ msgid "Retain _History"
+#~ msgstr "ചരിത്രം _നിലനിര്‍ത്തുക"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "നിങ്ങള്‍ ദൂരെയായിരിക്കുമ്പോള്‍ നിങ്ങളുടെ സ്വകാര്യത സ്ക്രീന്‍ പൂട്ട് സംരക്ഷിക്കുന്നു."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "സ്ക്രീന്‍ പൂട്ടുന്നതിനു മുന്പ് _ശൂന്യമായി"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "ആവശ്യമില്ലാത്ത സ്വകാര്യ വിവരങ്ങള്‍ താങ്കളുടെ കമ്പ്യൂട്ടറില്‍ നിന്നും ഒഴിവാക്കാന്‍ തനിയെ "
+#~ "ചവറ്റുകുട്ടയും താല്‍ക്കാലിക ഫയലുകളും നശിപ്പിക്കുക."
+
+#~ msgid "Purge _After"
+#~ msgstr "_ശേഷം ഒഴിപ്പിക്കുക"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "സോഫ്റ്റ്‌വെയര്‍ ഉപയോഗത്തിന്റെ വിവരം അയയ്ക്കുക"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ഇംപീരിയല്‍"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "മെട്രിക്"
+
+#~ msgid "No regions found"
+#~ msgstr "ഒരു മേഖലയും കണ്ടില്ല"
+
+#~ msgid "No input sources found"
+#~ msgstr "ഇന്‍പുട്ട് ഉറവിടങ്ങളൊന്നും കണ്ടില്ല"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "മറ്റുളളവ"
+
+#~ msgid ""
+#~ "Select your display language, formats, keyboard layouts and input sources"
+#~ msgstr "നിങ്ങളുടെ ഭാഷ, ഘടന, കീബോർഡ് മാതൃക, ഇൻപുട്ട് സോർസ് എന്നിവ തിരഞ്ഞെടുക്കുക"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "മുമ്പുള്ള ശ്രോതസ്സിലേക്കു് മാറുക"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുക"
+
+#~ msgid "Super+Space"
+#~ msgstr "നല്ലത്+സ്ഥലം"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr " കീ ക്രമം മാറ്റികൊണ്ട് ഈ ഷോർട്ട്കട്ട് മാറ്റാവുന്നതാണ്"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "പകരം അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുക"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "വലത്+ഇടത് ആള്‍ട്ട്"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "ഇംഗ്ലീഷ് (യുണിറ്റഡ് കിങ്ഡം)"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "മാറ്റങ്ങള്‍ കാണാന്‍ പുറത്തിറങ്ങുക"
+
+#~ msgid "Restart…"
+#~ msgstr "പുനരാരംഭിക്കുക…"
+
+#~ msgid "United Kingdom"
+#~ msgstr "യുണിറ്റഡ് കിങ്ഡം"
+
+#~ msgid "_Options"
+#~ msgstr "_ഐച്ഛികങ്ങള്‍"
+
+#~ msgid "Add input source"
+#~ msgstr "ഇന്‍പുട്ട് ഉറവിടം ചേര്‍ക്കുക"
+
+#~ msgid "Remove input source"
+#~ msgstr "ഇന്‍പുട്ട് ഉറവിടം വെട്ടി നീക്കുക"
+
+#~ msgid "Move input source up"
+#~ msgstr "ഇന്‍പുട്ട് ഉറവിടം മുകളിലേക്കു് നീക്കുക"
+
+#~ msgid "Move input source down"
+#~ msgstr "ഇന്‍പുട്ട് ഉറവിടം താഴേയ്ക്ക് നീക്കുക"
+
+#~ msgid "Configure input source"
+#~ msgstr "ഇന്‍പുട്ട് ശ്രോതസ്സ് സജ്ജീകരിക്കുക"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "കീബോര്‍ഡ് വിന്യാസം കാണിയ്ക്കുക"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "സിസ്റ്റത്തിലേക്ക് പ്രവേശിക്കുമ്പോള്‍ എല്ലാ ഉപയോക്താകളും പ്രവേശന കൃമീകരണങ്ങള്‍ ഉപയോഗിക്കും"
+
+#~ msgid "Select Location"
+#~ msgstr "സ്ഥലം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "_OK"
+#~ msgstr "ശരി"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "ഓണ്‍ "
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "ഓഫ്"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "പ്രവര്‍ത്തന സജ്ജം"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "ഒരു ഫോള്‍ഡര്‍ തിരയുക"
+
+#, c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "<a href=\"dav://%s\">dav://%s</a> ഉപയോഗിച്ച് ഇപ്പോഴത്തെ ശ്രംഖലയില്‍ പൊതുവായ "
+#~ "ഫോള്‍ഡറുകള്‍ പങ്കിടാന്‍ സ്വകാര്യ ഫയല്‍ പങ്കിടല്‍ അനുവദിക്കുന്നു"
+
 #, fuzzy, c-format
-#| msgid "Could not start finger capture on '%s' device"
-msgid "Could not start finger capture on “%s” device"
-msgstr "'%s' ഡിവൈസില്‍ വിരലടയാളങ്ങള്‍ ലഭ്യമാക്കുവാന്‍ സാധ്യമായില്ല"
+#~| msgid ""
+#~| "Allow remote users to connect using the Secure Shell command:\n"
+#~| "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "വിദൂര ഉപയോക്താക്കളെ സുരക്ഷിത ഷെല്‍ ഉപയോഗിച്ച് ബന്ധിപ്പിക്കാന്‍ അനുവദിക്കുന്നു:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:631
-msgid "Could not access any fingerprint readers"
-msgstr "ഫിംഗര്‍പ്രിന്റ് റീഡറുകളിലേക്കുള്ള പ്രവേശനം സാധ്യമായില്ല"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:632
-msgid "Please contact your system administrator for help."
-msgstr "ദയവായി സഹായത്തിനു് നിങ്ങളുടെ സിസ്റ്റം അഡ്മിനിസ്ട്രേറ്ററുമായി ബന്ധപ്പെടുക."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:714
 #, fuzzy, c-format
-#| msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
-msgid "To enable fingerprint login, you need to save one of your fingerprints, using the “%s” device."
-msgstr "ഫിംഗര്‍പ്രിന്റ് ലോഗിന്‍ സജ്ജമാക്കുന്നതിനായി, നിങ്ങളുടെ വിരലടയാളം '%s' ഡിവൈസ് ഉപയോഗിച്ചു് സൂക്ഷിക്കേണ്ടതാണു്."
+#~| msgid ""
+#~| "Allow remote users to view or control your screen by connecting to: <a "
+#~| "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "വിദൂര ഉപയോക്താക്കളെ താങ്കളുടെ സ്ക്രീന്‍ കാണുവാനോ നിയന്ത്രിക്കുവാനോ അനുവദിക്കുന്നു: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:721
-msgid "Selecting finger"
-msgstr "വിരല്‍ തെരഞ്ഞെടുക്കുന്നു"
+#~ msgid "Sha­ring"
+#~ msgstr "പങ്കിടല്‍"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:722
-msgid "Enrolling fingerprints"
-msgstr "ഫിംഗര്‍പ്രിന്റുകള്‍ എന്‍റോള്‍ ചെയ്യുന്നു"
+#~ msgid "_Screen Sharing"
+#~ msgstr "സ്ക്രീന്‍ പങ്കിടല്‍ (_S)"
 
-#: ../panels/user-accounts/um-history-dialog.c:70
-msgid "This Week"
-msgstr "ഈ ആഴ്ച"
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "ശ്രംഖല ബന്ധമില്ലാത്തത് കൊണ്ട് ചില സേവനങ്ങള്‍ നിര്‍ത്തി വെച്ചിരിക്കുന്നു."
 
-#: ../panels/user-accounts/um-history-dialog.c:73
-msgid "Last Week"
-msgstr "അവസാന ആഴ്ച"
+#~ msgid "Screen Sharing"
+#~ msgstr "സ്ക്രീന്‍ പങ്കിടല്‍"
 
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:79 ../panels/user-accounts/um-history-dialog.c:83
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
+#~ msgid "_Password:"
+#~ msgstr "രഹസ്യവാക്ക് (_P):"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
+#~ msgid "_Show Password"
+#~ msgstr "രഹസ്യവാക്ക് കാണിയ്ക്കുക (_S)"
 
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:93
+#~ msgid "_New connections must ask for access"
+#~ msgstr "പുതിയ ബന്ധങ്ങള്‍ പ്രവേശനത്തിനായി ചോദിക്കണം (_S)"
+
+#~ msgid "_Require a password"
+#~ msgstr "രഹസ്യവാക്ക് ആവശ്യമുണ്ടു് (_R)"
+
+#~ msgid "Bark"
+#~ msgstr "ബാര്‍ക്ക്"
+
+#~ msgid "Drip"
+#~ msgstr "ഡ്രിപ്"
+
+#~ msgid "Glass"
+#~ msgstr "ഗ്ലാസ്"
+
+#~ msgid "Sonar"
+#~ msgstr "സോണാര്‍"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "ഇടത്"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "വലത്"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "ഏറ്റവും കുറഞ്ഞ"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "ഏറ്റവും കൂടിയ"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_സബ്‌വൂഫര്‍:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "അണ്‍ആംപ്ലിഫൈഡ്"
+
+#~ msgid "_Profile:"
+#~ msgstr "പ്രൊ_ഫൈല്‍:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "സ്പീക്കറുകള്‍ _പരിശോധിയ്ക്കുക"
+
+#~ msgid "Peak detect"
+#~ msgstr "പീക്ക് കണ്ടുപിടിക്കല്‍"
+
+#~ msgid "Device"
+#~ msgstr "ഡിവൈസ്"
+
 #, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr ""
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s-നുള്ള സ്പീക്കര്‍ പരീക്ഷണം"
 
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:177 ../panels/user-accounts/um-user-panel.c:776
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "ശബ്ദ ഔട്ട്പുട്ടിനുള്ള ഒരു ഡിവൈസ് _തെരഞ്ഞെടുക്കുക:"
 
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:180 ../panels/user-accounts/um-user-panel.c:780
+#~ msgid "Settings for the selected device:"
+#~ msgstr "തെരഞ്ഞെടുത്ത ഉപകരണത്തിന്റെ ക്രമീകരണങ്ങള്‍:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_ഇന്‍പുട്ട് വോള്യം: "
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "ശബ്ദ ഇന്‍പുട്ടിനുള്ള ഒരു ഡിവൈസ് _തെരഞ്ഞെടുക്കുക:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "ശബ്ദ പ്രവാഹങ്ങള്‍"
+
+#~ msgid "Built-in"
+#~ msgstr "ബിള്‍ട്ടിന്‍"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ശബ്ദ മുന്‍ഗണനകള്‍"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ഇവന്റ് ശബ്ദം പരീക്ഷിക്കുന്നു"
+
+#~ msgid "From theme"
+#~ msgstr "പ്രമേയത്തില്‍ നിന്നും"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "മുന്നറിയിപ്പ് ശബ്ദം _തെരഞ്ഞെടുക്കുക:"
+
+#~ msgid "Stop"
+#~ msgstr "നിര്‍ത്തുക"
+
+#~ msgid "Custom"
+#~ msgstr "യഥേഷ്ടം"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "സാധാരണ"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "ഇടത്തരം"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "വലിയ"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "വലിയതു്"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "ഏറ്റവും വലിയ"
+
 #, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d പിക്സല്‍"
+#~ msgstr[1] "%d പിക്സലുകള്‍"
 
-#: ../panels/user-accounts/um-history-dialog.c:250
-msgid "Session Ended"
-msgstr "സെഷന്‍ അവസാനിച്ചു"
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "സാര്‍വ്വജനികലഭ്യത"
 
-#: ../panels/user-accounts/um-history-dialog.c:256
-msgid "Session Started"
-msgstr "സെഷന്‍ ആരംഭിച്ചു"
+#~ msgid "Screen Reader"
+#~ msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
 
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: ../panels/user-accounts/um-history-dialog.c:299
+#~ msgid "_Screen Reader"
+#~ msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
+
+#~ msgid "Sound Keys"
+#~ msgstr "സൗണ്ട് കീകള്‍"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "ജാലക തലക്കെട്ട് മിന്നിമറയുക"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "ലഘു"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ സ്ക്രീന്‍"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ സ്ക്രീന്‍"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ സ്ക്രീന്‍"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "നീളമുള്ള"
+
+#~ msgid "Standard"
+#~ msgstr "സാധാരണ"
+
+#~ msgid "Account _Type"
+#~ msgstr "അക്കൌണ്ട് _തരം"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "ഉപയോക്താവ് അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കാന്‍ അനുവദിക്കുക (_l)"
+
+#~ msgid "Set a password _now"
+#~ msgstr "ഉടന്‍ ഒരു രഹസ്യവാക്ക് സജ്ജമാക്കുക (_n)"
+
+#~ msgid "Left thumb"
+#~ msgstr "ഇടത്ത് തള്ളവിരല്‍"
+
+#~ msgid "Left middle finger"
+#~ msgstr "ഇടത്തു് നടുവിരല്‍"
+
+#~ msgid "Left ring finger"
+#~ msgstr "ഇടത്തു് മോതിരവിരല്‍"
+
+#~ msgid "Left little finger"
+#~ msgstr "ഇടത്തു് ചെറുവിരല്‍"
+
+#~ msgid "Right thumb"
+#~ msgstr "വലത്ത് തള്ളവിരല്‍"
+
+#~ msgid "Right middle finger"
+#~ msgstr "വലത്തു് നടുവിരല്‍"
+
+#~ msgid "Right ring finger"
+#~ msgstr "വലത്തു് മോതിരവിരല്‍"
+
+#~ msgid "Right little finger"
+#~ msgstr "വലത്തു് ചെറുവിരല്‍"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "ഫിംഗര്‍പ്രിന്റ് ലോഗിന്‍ സജ്ജമാക്കുക"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_വലത്തു് ചൂണ്ടുവിരല്‍"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_ഇടത്തു് ചൂണ്ടുവിരല്‍"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "നിങ്ങളുടെ വിരലടയാളം വിജയകരമായി സൂക്ഷിച്ചിരിക്കുന്നു. നിങ്ങള്‍ക്കിനി ഫിംഗര്‍പ്രിന്റ് റീഡര്‍ "
+#~ "ഉപയോഗിച്ചു് ലോഗിന്‍ ചെയ്യുവാന്‍ സാധിക്കുന്നതാണു്."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "പുതിയ രഹസ്യവാക്ക് ഉറപ്പുവരുത്തുക"
+
+#~ msgid "User Icon"
+#~ msgstr "ഉപയോക്തൃ ചിഹ്നം"
+
+#~ msgid "Last Login"
+#~ msgstr "അവസാന പ്രവേശനം"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "പുതിയ രഹസ്യവാക്ക് പഴയ രഹസ്യവാക്കില്‍ നിന്നും വ്യത്യസ്തമായിരിക്കണം."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "കുറച്ച് അക്കങ്ങളും അക്ഷരങ്ങളും മാറ്റി നോക്കുക"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "രഹസ്യവാക്ക് ഒന്നുകൂടി മാറ്റാന്‍ ശ്രമിക്കുക."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "താങ്കളുടെ ഉപയോക്തൃനാമം ഇല്ലാത്ത ഒരു അടയാളവാക്ക് ആയിരിക്കും കൂടുതൽ ബലിഷ്ഠം."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "താങ്കളുടെ പേര് അടയാളവാക്കിൽ ഉപയോഗിക്കാതിരിക്കാൻ ശ്രമിക്കുക"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "അടയാളവാക്കിൽ ഉൾക്കൊള്ളിച്ചിരിക്കുന്ന ചില വാക്കുകൾ അവഗണിക്കാൻ ശ്രമിക്കുക"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "പൊതുവായിട്ടുള്ള വാക്കുകൾ അവഗണിക്കാൻ ശ്രമിക്കുക"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "നിലനിൽക്കുന്ന വാക്കുകൾ പുനഃക്രമീകരിക്കാതിരിക്കാൻ ശ്രമിക്കുക"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "കൂടുതൽ അക്കങ്ങൾ ഉപയോഗിക്കാൻ ശ്രമിക്കുക"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "കൂടുതൽ വലിയ അക്ഷരങ്ങള്‍ ഉപയോഗിക്കാൻ ശ്രമിക്കുക"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "കൂടുതൽ ചെറിയ അക്ഷരങ്ങള്‍ ഉപയോഗിക്കാൻ ശ്രമിക്കുക"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "ഒരേ അക്ഷരം ആവര്‍ത്തിക്കുന്നത് ഒഴിവാക്കാന്‍ ശ്രമിക്കുക."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234, abcd, മുതലായ ശ്രേണികള്‍ ഒഴിവാക്കാന്‍ ശ്രമിക്കുക."
+
+#, fuzzy
+#~| msgctxt "Password hint"
+#~| msgid "Try to add more letters, numbers and symbols."
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr "കൂടുതല്‍ അക്ഷരങ്ങളും, സംഖ്യകളും, പ്രതീകങ്ങളും ഉള്‍പ്പെടുത്താന്‍ ശ്രമിക്കുക."
+
+#, fuzzy
+#~| msgctxt "Password hint"
+#~| msgid ""
+#~| "Good password! Adding more letters, numbers and punctuation will make it "
+#~| "stronger."
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "നല്ല രഹസ്യവാക്ക്! കൂടുതല്‍ അക്ഷരങ്ങളും, അക്കങ്ങളും, മറ്റും അതിനെ കൂടുതല്‍ ശക്തമാക്കും."
+
+#~ msgid "Authentication failed"
+#~ msgstr "തിരിച്ചറിയല്‍ പ്രക്രിയ പരാജയപ്പെട്ടു"
+
 #, c-format
-msgid "%s — Account Activity"
-msgstr ""
+#~ msgid "The new password is too short"
+#~ msgstr "പുതിയ രഹസ്യവാക്ക് വളരെ ചെറുതാണു്"
 
-#: ../panels/user-accounts/um-password-dialog.c:144
-msgid "Please choose another password."
-msgstr "ദയവായി മറ്റൊരു രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കുക."
-
-#: ../panels/user-accounts/um-password-dialog.c:153
-msgid "Please type your current password again."
-msgstr "ദയവായി പുതിയ രഹസ്യവാക്ക് വീണ്ടും ടൈപ്പ് ചെയ്യുക."
-
-#: ../panels/user-accounts/um-password-dialog.c:159
-msgid "Password could not be changed"
-msgstr "രഹസ്യവാക്ക് മാറ്റുവാന്‍ സാധ്യമാകുന്നില്ല"
-
-#: ../panels/user-accounts/um-password-dialog.c:285
-msgid "The passwords do not match."
-msgstr "രഹസ്യവാക്കുകള്‍ തമ്മില്‍ പൊരുത്തക്കേടുണ്ട്."
-
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "Browse for more pictures"
-msgstr "കൂടുതല്‍ ചിത്രങ്ങള്‍ക്ക് വേണ്ടി ബ്രൗസ് ചെയ്യുക"
-
-#: ../panels/user-accounts/um-photo-dialog.c:452
-msgid "Disable image"
-msgstr "ചിത്രം പ്രവര്‍ത്തന രഹിതമാക്കുക"
-
-#: ../panels/user-accounts/um-photo-dialog.c:470
-msgid "Take a photo…"
-msgstr "ഒരു ഫോട്ടോ എടുക്കുക…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:488
-msgid "Browse for more pictures…"
-msgstr "കൂടുതല്‍ ചിത്രങ്ങള്‍ക്ക് വേണ്ടി ബ്രൗസ് ചെയ്യുക…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:714
 #, c-format
-msgid "Used by %s"
-msgstr "%s ഉപയോഗിക്കുന്നതു്"
+#~ msgid "The new password is too simple"
+#~ msgstr "പുതിയ രഹസ്യവാക്ക് വളരെ ലളിതമാണ്."
 
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "ഈ തരത്തിലുള്ള ഡൊമൈന്‍ തനിയെ ചേര്‍ക്കാന്‍ പറ്റില്ല"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
 #, c-format
-msgid "No such domain or realm found"
-msgstr "അത്തരം ഒരു ഡൊമെയിന്‍ ലഭ്യമല്ല"
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "പഴയതും പുതിയതും ആയ രഹസ്യവാക്കുകള്‍ തമ്മില്‍ വളരെ സാമ്യമുണ്ട്."
 
-#: ../panels/user-accounts/um-realm-manager.c:815 ../panels/user-accounts/um-realm-manager.c:829
 #, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s ആയി %s ഡൊമെയിനിലേക്കു് പ്രവേശിയ്ക്കുവാന്‍ സാധ്യമല്ല"
+#~ msgid "The new password has already been used recently."
+#~ msgstr "പുതിയ രഹസ്യവാക്ക് അടുത്തിടയ്ക്കു് ഉപയോഗിച്ചിരിയ്ക്കുന്നു."
 
-#: ../panels/user-accounts/um-realm-manager.c:821
-msgid "Invalid password, please try again"
-msgstr "തെറ്റായ രഹസ്യവാക്ക്, ദയവായി വീണ്ടും ശ്രമിയ്ക്കുക"
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "പുതിയ രഹസ്യവാക്കില്‍ ന്യൂമറിക് അല്ലെങ്കില്‍ പ്രത്യേക അക്ഷരങ്ങള്‍ ഉണ്ടായിരിയ്ക്കണം"
 
-#: ../panels/user-accounts/um-realm-manager.c:834
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "പഴയതും പുതിയതും രഹസ്യവാക്കുകള്‍ ഒന്നു തന്നെയാണ്."
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "നിങ്ങളുടെ ആധികാരികത ഉറപ്പുവരുത്തിയിരിക്കുന്നതിനു ശേഷം അടയാളവാക്ക് മാറിയിരിക്കുന്നു!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "പുതിയ രഹസ്യവാക്കില്‍ അക്കങ്ങളോ പ്രത്യേക അക്ഷരങ്ങളോ ലഭ്യമല്ല."
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "അറിയാത്ത ഏതോ പ്രശ്നം"
+
+#, fuzzy
+#~| msgid "Should match the web address of your account provider."
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "അക്കൗണ്ട് നല്‍കിയ ആളിന്റെ വെബ്ബ് അഡ്രസുമായി സാമ്യം വേണം."
+
+#~ msgid "Failed to add account"
+#~ msgstr "അക്കൌണ്ട് ചേര്‍ക്കുന്നതില്‍ പരാജയം"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "രഹസ്യവാക്കുകള്‍ തമ്മില്‍ പൊരുത്തക്കേടുണ്ട്."
+
+#~ msgid "Failed to register account"
+#~ msgstr "അക്കൌണ്ട് രജിസ്ടര്‍ ചെയ്യുന്നതില്‍ പരാജയം"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "ഈ ഡൊമെയിനിലേക്കു് ആധികാരികത ഉറപ്പാക്കുവാന്‍ പിന്തുണയ്ക്കുന്നില്ല"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "ഡൊമെയിനിലേക്കു് ചേരുന്നതില്‍ പരാജയം"
+
+#, fuzzy
+#~| msgid ""
+#~| "That login name didn't work.\n"
+#~| "Please try again."
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ആ ഉപയോക്തൃനാമം പ്രവര്‍ത്തിക്കുന്നില്ല. \n"
+#~ "ദയവായി വീണ്ടും ശ്രമിക്കുക."
+
+#, fuzzy
+#~| msgid ""
+#~| "That login password didn't work.\n"
+#~| "Please try again."
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ആ രഹസ്യവാക്ക് പ്രവര്‍ത്തിക്കുന്നില്ല. \n"
+#~ "ദയവായി വീണ്ടും ശ്രമിയ്ക്കുക."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "ഡൊമെയിനിലേക്കു് പ്രവേശിയ്ക്കുന്നതില്‍ പരാജയം"
+
+#, fuzzy
+#~| msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "ഡൊമൈന്‍ കണ്ടുപിടിക്കാന്‍ സാധിച്ചില്ല. അതോ നിങ്ങള്‍ക്ക് തെറ്റിയോ ?"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "നിലവാരമുള്ള"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "അഡ്മിനിസ്ട്രേറ്റര്‍"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "നിങ്ങള്‍ക്കു് ഡിവൈസിലേക്കു് പ്രവേശനമില്ല. ദയവായി സിസ്റ്റം അഡ്മിനിസ്ട്രേറ്ററുമായി ബന്ധപ്പെടുക."
+
+#~ msgid "The device is already in use."
+#~ msgstr "ഡിവൈസ് നിലവില്‍ ഉപയോഗത്തിലാണു്."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "ആന്തരിക പിശകു് ഉണ്ടായിരിക്കുന്നു."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "രജിസ്ടര്‍ ചെയ്ത ഫിംഗര്‍പ്രിന്റുകള്‍ വെട്ടിമാറ്റണമോ?"
+
+#~ msgid "Done!"
+#~ msgstr "പൂര്‍ത്തിയായി!"
+
 #, fuzzy, c-format
-#| msgid "Couldn't connect to the %s domain: %s"
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "%s ഡൊമെയിനിലേക്കു് കണക്ട് ചെയ്യുവാന്‍ സാധ്യമല്ല: %s"
+#~| msgid "Could not access '%s' device"
+#~ msgid "Could not access “%s” device"
+#~ msgstr "'%s' ഡിവൈസിലേക്കു് പ്രവേശിക്കുവാനായില്ല"
 
-#: ../panels/user-accounts/um-user-panel.c:195
-msgid "Your account"
-msgstr "നിങ്ങളുടെ അക്കൌണ്ട്‌"
-
-#: ../panels/user-accounts/um-user-panel.c:390
-msgid "Failed to delete user"
-msgstr "ഉപയോക്താവു് വെട്ടി നീക്കുന്നതില്‍ പരാജയം"
-
-#: ../panels/user-accounts/um-user-panel.c:448 ../panels/user-accounts/um-user-panel.c:507
-#: ../panels/user-accounts/um-user-panel.c:559
-#, fuzzy
-#| msgid "Failed to delete user"
-msgid "Failed to revoke remotely managed user"
-msgstr "ഉപയോക്താവു് വെട്ടി നീക്കുന്നതില്‍ പരാജയം"
-
-#: ../panels/user-accounts/um-user-panel.c:613
-msgid "You cannot delete your own account."
-msgstr "നിങ്ങളുടെ സ്വന്തം അക്കൌണ്ട് വെട്ടിനീക്കുവാന്‍ സാധ്യമല്ല."
-
-#: ../panels/user-accounts/um-user-panel.c:622
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s ഇപ്പോഴും ലോഗിന്‍ ചെയ്തിരിയ്ക്കുന്നു"
-
-#: ../panels/user-accounts/um-user-panel.c:626
-msgid "Deleting a user while they are logged in can leave the system in an inconsistent state."
-msgstr "പ്രവേശിച്ചിരിയ്ക്കുമ്പോള്‍ ഒരു ഉപയോക്താവിനെ വെട്ടി നീക്കിയാല്‍, സിസ്റ്റത്തിനെ അസ്ഥിമായൊരു അവസ്ഥയിലാക്കുന്നു."
-
-#: ../panels/user-accounts/um-user-panel.c:635
 #, fuzzy, c-format
-#| msgid "Do you want to keep %s's files?"
-msgid "Do you want to keep %s’s files?"
-msgstr "%s's ഫയലുകള്‍ സൂക്ഷിയ്ക്കണമോ?"
+#~| msgid "Could not start finger capture on '%s' device"
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "'%s' ഡിവൈസില്‍ വിരലടയാളങ്ങള്‍ ലഭ്യമാക്കുവാന്‍ സാധ്യമായില്ല"
 
-#: ../panels/user-accounts/um-user-panel.c:639
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files around when deleting a user account."
-msgstr "ഉപയോക്താവിന്റെ അക്കൌണ്ട് നീക്കം ചെയ്താലും, അതിനുള്ള ആസ്ഥാന ഡയറക്ടറി, മെയില്‍ സ്പൂള്‍, താല്‍ക്കാലിക ഫയലുകള്‍ എന്നിവ സൂക്ഷിയ്ക്കാം."
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "ഫിംഗര്‍പ്രിന്റ് റീഡറുകളിലേക്കുള്ള പ്രവേശനം സാധ്യമായില്ല"
 
-#: ../panels/user-accounts/um-user-panel.c:642
-msgid "_Delete Files"
-msgstr "ഫയലുകള്‍ വെട്ടി നീക്കു_ക"
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "ദയവായി സഹായത്തിനു് നിങ്ങളുടെ സിസ്റ്റം അഡ്മിനിസ്ട്രേറ്ററുമായി ബന്ധപ്പെടുക."
 
-#: ../panels/user-accounts/um-user-panel.c:643
-msgid "_Keep Files"
-msgstr "ഫയലുകള്‍ _സൂക്ഷിയ്ക്കുക"
-
-#: ../panels/user-accounts/um-user-panel.c:657
 #, fuzzy, c-format
-#| msgid "Are you sure you want to remove the account?"
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "നിങ്ങള്‍ക്കു് അക്കൌണ്ട് നീക്കം ചെയ്യണമെന്നുറപ്പാണോ?"
+#~| msgid ""
+#~| "To enable fingerprint login, you need to save one of your fingerprints, "
+#~| "using the '%s' device."
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "ഫിംഗര്‍പ്രിന്റ് ലോഗിന്‍ സജ്ജമാക്കുന്നതിനായി, നിങ്ങളുടെ വിരലടയാളം '%s' ഡിവൈസ് ഉപയോഗിച്ചു് "
+#~ "സൂക്ഷിക്കേണ്ടതാണു്."
 
-#: ../panels/user-accounts/um-user-panel.c:661
-msgid "_Delete"
-msgstr "_നീക്കം ചെയ്യുക"
+#~ msgid "Selecting finger"
+#~ msgstr "വിരല്‍ തെരഞ്ഞെടുക്കുന്നു"
 
-#: ../panels/user-accounts/um-user-panel.c:711
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "അക്കൌണ്ട് നിര്‍ജ്ജീവം"
+#~ msgid "This Week"
+#~ msgstr "ഈ ആഴ്ച"
 
-#: ../panels/user-accounts/um-user-panel.c:719
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ സജ്ജമാക്കേണ്ടതു്"
+#~ msgid "Last Week"
+#~ msgstr "അവസാന ആഴ്ച"
 
-#: ../panels/user-accounts/um-user-panel.c:722
-msgctxt "Password mode"
-msgid "None"
-msgstr "ഒന്നുമില്ല"
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
 
-#: ../panels/user-accounts/um-user-panel.c:769
-msgid "Logged in"
-msgstr "പ്രവേശിച്ചു"
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
 
-#: ../panels/user-accounts/um-user-panel.c:1117
-msgid "Failed to contact the accounts service"
-msgstr "അക്കൌണ്ടുകളുടെ സര്‍വീസുമായി ബന്ധപ്പെടുന്നതില്‍ പരാജയം"
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
 
-#: ../panels/user-accounts/um-user-panel.c:1119
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "ദയവായി AccountService ഇന്‍സ്റ്റോള്‍ ചെയ്തു് പ്രവര്‍ത്തന സജ്ജമെന്നുറപ്പാക്കുക."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: ../panels/user-accounts/um-user-panel.c:1155
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"മാറ്റങ്ങള്‍ വരുത്തുന്നതിനായി,\n"
-"ആദ്യം * ചിഹ്നം ക്ലിക്ക് ചെയ്യുക"
-
-#: ../panels/user-accounts/um-user-panel.c:1195
-msgid "Create a user account"
-msgstr "ഉപയോക്താവിനുള്ളൊരു അക്കൌണ്ട് തയ്യാറാക്കുക"
-
-#: ../panels/user-accounts/um-user-panel.c:1206 ../panels/user-accounts/um-user-panel.c:1385
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"ഉപയോക്താവിനുള്ളൊരു അക്കൌണ്ട് തയ്യാറാക്കുന്നതിനായി,\n"
-"ആദ്യം * ചിഹ്നം ക്ലിക്ക് ചെയ്യുക"
-
-#: ../panels/user-accounts/um-user-panel.c:1216
-msgid "Delete the selected user account"
-msgstr "തെരഞ്ഞെടുത്ത ഉപയോക്താവിന്റെ അക്കൌണ്ട് വെട്ടി നീക്കുക"
-
-#: ../panels/user-accounts/um-user-panel.c:1228 ../panels/user-accounts/um-user-panel.c:1390
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"തെരഞ്ഞെടുത്ത ഉപയോക്തൃ അക്കൌണ്ട് വെട്ടി നീക്കുന്നതിനായി\n"
-"ആദ്യം * ചിഹ്നത്തില്‍ ക്ലിക്ക് ചെയ്യുക"
-
-#: ../panels/user-accounts/um-utils.c:507
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-
-#: ../panels/user-accounts/um-utils.c:510
 #, c-format
-msgid "The username is too long."
-msgstr "ഉപയോക്തൃനാമം വളരെ വലുതാണു്."
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
 
-#: ../panels/user-accounts/um-utils.c:513
+#~ msgid "Session Ended"
+#~ msgstr "സെഷന്‍ അവസാനിച്ചു"
+
+#~ msgid "Session Started"
+#~ msgstr "സെഷന്‍ ആരംഭിച്ചു"
+
+#~ msgid "Please choose another password."
+#~ msgstr "ദയവായി മറ്റൊരു രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കുക."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "ദയവായി പുതിയ രഹസ്യവാക്ക് വീണ്ടും ടൈപ്പ് ചെയ്യുക."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "രഹസ്യവാക്ക് മാറ്റുവാന്‍ സാധ്യമാകുന്നില്ല"
+
+#~ msgid "Disable image"
+#~ msgstr "ചിത്രം പ്രവര്‍ത്തന രഹിതമാക്കുക"
+
+#~ msgid "Take a photo…"
+#~ msgstr "ഒരു ഫോട്ടോ എടുക്കുക…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "കൂടുതല്‍ ചിത്രങ്ങള്‍ക്ക് വേണ്ടി ബ്രൗസ് ചെയ്യുക…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s ഉപയോഗിക്കുന്നതു്"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "ഈ തരത്തിലുള്ള ഡൊമൈന്‍ തനിയെ ചേര്‍ക്കാന്‍ പറ്റില്ല"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "അത്തരം ഒരു ഡൊമെയിന്‍ ലഭ്യമല്ല"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s ആയി %s ഡൊമെയിനിലേക്കു് പ്രവേശിയ്ക്കുവാന്‍ സാധ്യമല്ല"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "തെറ്റായ രഹസ്യവാക്ക്, ദയവായി വീണ്ടും ശ്രമിയ്ക്കുക"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ഉപയോക്താവു് വെട്ടി നീക്കുന്നതില്‍ പരാജയം"
+
 #, fuzzy
-#| msgid "The username cannot start with a '-'."
-msgid "The username cannot start with a “-”."
-msgstr "'-' ഉപയോഗിച്ചു് ഉപയോക്തൃനാമം ആരംഭിയ്ക്കുവാന്‍ പാടില്ല."
+#~| msgid "Failed to delete user"
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "ഉപയോക്താവു് വെട്ടി നീക്കുന്നതില്‍ പരാജയം"
 
-#: ../panels/user-accounts/um-utils.c:516
-#, fuzzy
-#| msgid ""
-#| "The username should only consist of lower and upper case letters from a-z, digits and any of characters "
-#| "'.', '-' and '_'."
-msgid ""
-"The username should only consist of upper and lower case letters from a-z, digits and the following "
-"characters: . - _"
-msgstr "ഉപയോക്തൃനാമത്തില്‍ ഇംഗ്ലീഷ് അക്ഷരങ്ങള്‍, അക്കങ്ങള്‍, '.', '-', '_' - ഇവയിലൊന്നു് മാത്രമേ പാടുള്ളൂ."
+#~ msgid "You cannot delete your own account."
+#~ msgstr "നിങ്ങളുടെ സ്വന്തം അക്കൌണ്ട് വെട്ടിനീക്കുവാന്‍ സാധ്യമല്ല."
 
-#: ../panels/user-accounts/um-utils.c:520
-#, fuzzy
-#| msgid "This will be used to name your home folder and can't be changed."
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr "ഇത് നിങ്ങളുടെ ഹോം ഫോള്‍ഡറിന്റെ പേര് നല്‍കാനായി ഉപയോഗിച്ചതിനാല്‍ മാറ്റാന്‍ സാധ്യമല്ല."
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ഇപ്പോഴും ലോഗിന്‍ ചെയ്തിരിയ്ക്കുന്നു"
 
-#: ../panels/wacom/button-mapping.ui.h:1
-msgid "Map Buttons"
-msgstr "ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക"
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "പ്രവേശിച്ചിരിയ്ക്കുമ്പോള്‍ ഒരു ഉപയോക്താവിനെ വെട്ടി നീക്കിയാല്‍, സിസ്റ്റത്തിനെ അസ്ഥിമായൊരു "
+#~ "അവസ്ഥയിലാക്കുന്നു."
 
-#: ../panels/wacom/button-mapping.ui.h:2 ../panels/wacom/cc-wacom-page.c:547
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "_Close"
-msgstr "_അടയ്ക്കുക"
-
-#: ../panels/wacom/button-mapping.ui.h:3
-msgid "Map buttons to functions"
-msgstr "ഫംഗ്ഷനുകളിലേക്കു് ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക"
-
-#: ../panels/wacom/button-mapping.ui.h:4
-#, fuzzy
-#| msgid ""
-#| "To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard shortcut button and hold down "
-#| "the new keys or press Backspace to clear."
-msgid ""
-"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard shortcut button and hold down the "
-"new keys or press Backspace to clear."
-msgstr ""
-"കുറുക്കുവഴി തിരുത്തുന്നതിനായി \"കീസ്ട്രോക്ക് അയയ്ക്കുക\" പ്രവൃത്തി ചെയ്ത ശേഷം പുതിയ കുറുക്കുവഴിയ്ക്കുള്ള കീ ടൈപ്പ് ചെയ്യുക. കീ നീക്കം ചെയ്യാന്‍ "
-"backspace ടൈപ്പ് ചെയ്യുക."
-
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
-msgid "Please tap the target markers as they appear on screen to calibrate the tablet."
-msgstr "ടാബ്ലറ്റ് കാലിബ്രേറ്റ് ചെയ്യന്നതിനായി അവ സ്ക്രീനില്‍ കാണിയ്ക്കുമ്പോള്‍ ലക്ഷ്യ അടയാളങ്ങളില്‍ ദയവായി ടാപ്പ് ചെയ്യുക."
-
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-#, fuzzy
-#| msgid "Mis-click detected, restarting..."
-msgid "Mis-click detected, restarting…"
-msgstr "മിസ്-ക്ലിക്ക് ലഭ്യമാക്കിയിരിയ്ക്കുന്നു, വീണ്ടും ആരംഭിയ്ക്കുന്നു..."
-
-#: ../panels/wacom/cc-wacom-button-row.c:266
 #, fuzzy, c-format
-#| msgid "Button"
-msgid "Button %d"
-msgstr "ബട്ടണ്‍"
+#~| msgid "Do you want to keep %s's files?"
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "%s's ഫയലുകള്‍ സൂക്ഷിയ്ക്കണമോ?"
 
-#: ../panels/wacom/cc-wacom-button-row.h:53
-#, fuzzy
-#| msgid "Applications"
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "പ്രയോഗങ്ങള്‍"
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ഉപയോക്താവിന്റെ അക്കൌണ്ട് നീക്കം ചെയ്താലും, അതിനുള്ള ആസ്ഥാന ഡയറക്ടറി, മെയില്‍ സ്പൂള്‍, "
+#~ "താല്‍ക്കാലിക ഫയലുകള്‍ എന്നിവ സൂക്ഷിയ്ക്കാം."
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "കീസ്ട്രോക്ക് അയയ്ക്കുക"
+#~ msgid "_Delete Files"
+#~ msgstr "ഫയലുകള്‍ വെട്ടി നീക്കു_ക"
 
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "മോണിറ്റര്‍ സ്വിച്ച് ചെയ്യുക"
+#~ msgid "_Keep Files"
+#~ msgstr "ഫയലുകള്‍ _സൂക്ഷിയ്ക്കുക"
 
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "സ്ക്രീനില്‍ സഹായം കാണിക്കുക"
+#, fuzzy, c-format
+#~| msgid "Are you sure you want to remove the account?"
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "നിങ്ങള്‍ക്കു് അക്കൌണ്ട് നീക്കം ചെയ്യണമെന്നുറപ്പാണോ?"
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:260
-msgid "Output:"
-msgstr "ഔട്ട്പുട്ട്:"
+#~ msgid "_Delete"
+#~ msgstr "_നീക്കം ചെയ്യുക"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:272
-msgid "Keep aspect ratio (letterbox):"
-msgstr "ആസ്പെക്ട് റേഷ്യോ സൂക്ഷിയ്ക്കുക (എഴുത്തുപെട്ടി):"
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "അക്കൌണ്ട് നിര്‍ജ്ജീവം"
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:283
-msgid "Map to single monitor"
-msgstr "ഒറ്റ മോണിറ്ററിലേക്കു് മാപ്പ് ചെയ്യുക"
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ സജ്ജമാക്കേണ്ടതു്"
 
-#: ../panels/wacom/cc-wacom-nav-button.c:86
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "ഒന്നുമില്ല"
+
+#~ msgid "Logged in"
+#~ msgstr "പ്രവേശിച്ചു"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "അക്കൌണ്ടുകളുടെ സര്‍വീസുമായി ബന്ധപ്പെടുന്നതില്‍ പരാജയം"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "ദയവായി AccountService ഇന്‍സ്റ്റോള്‍ ചെയ്തു് പ്രവര്‍ത്തന സജ്ജമെന്നുറപ്പാക്കുക."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "മാറ്റങ്ങള്‍ വരുത്തുന്നതിനായി,\n"
+#~ "ആദ്യം * ചിഹ്നം ക്ലിക്ക് ചെയ്യുക"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ഉപയോക്താവിനുള്ളൊരു അക്കൌണ്ട് തയ്യാറാക്കുന്നതിനായി,\n"
+#~ "ആദ്യം * ചിഹ്നം ക്ലിക്ക് ചെയ്യുക"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "തെരഞ്ഞെടുത്ത ഉപയോക്താവിന്റെ അക്കൌണ്ട് വെട്ടി നീക്കുക"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "തെരഞ്ഞെടുത്ത ഉപയോക്തൃ അക്കൌണ്ട് വെട്ടി നീക്കുന്നതിനായി\n"
+#~ "ആദ്യം * ചിഹ്നത്തില്‍ ക്ലിക്ക് ചെയ്യുക"
+
 #, c-format
-msgid "%d of %d"
-msgstr "%d x %d"
+#~ msgid "The username is too long."
+#~ msgstr "ഉപയോക്തൃനാമം വളരെ വലുതാണു്."
 
-#: ../panels/wacom/cc-wacom-page.c:544
-msgid "Display Mapping"
-msgstr "മാപ്പിങ് കാണിയ്ക്കുക"
-
-#: ../panels/wacom/cc-wacom-panel.c:790 ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Stylus"
-msgstr "സ്റ്റൈലസ് "
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:347
-msgid "Button"
-msgstr "ബട്ടണ്‍"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Wa­com Tab­let"
-msgstr "വാക്കൊം ടാബ്ലെറ്റ്"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr "ബട്ടണ്‍ മാപ്പിങ്ങും ഗ്രാഫിക്സ് റ്റാബ്ലറ്റിലെ സ്റ്റൈലസ് ക്രമീകരണങ്ങളും മാറ്റുക"
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:5
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "ടാബ്ലറ്റ് (ആബ്സല്യൂട്ട്)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "ടച്ച്പാഡ് (റിലേറ്റിവ്)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "ടാബ്ലറ്റ് മുന്‍ഗണനകള്‍"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Help"
-msgstr "സഹായം (_H)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "No tablet detected"
-msgstr "ടാബ്ലറ്റ് ലഭ്യമല്ല"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "ദയവായി പ്ലഗിന്‍ ചെയ്യുക അല്ലെങ്കില്‍ നിങ്ങളുടെ വാക്കോ ടാബ്ലറ്റ് ഓണ്‍ ചെയ്യുക"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Bluetooth Settings"
-msgstr "ബ്ലൂടൂത് സജ്ജീകരണങ്ങള്‍"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Wacom Tablet"
-msgstr "വാക്കൊം ടാബ്ലെറ്റ് "
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map to Monitor…"
-msgstr "മോണിറ്ററിലേക്കു് മാപ്പ് ചെയ്യുക…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Map Buttons…"
-msgstr "ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Calibrate…"
-msgstr "ഒത്തുനോക്കുക..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust display resolution"
-msgstr "ഡിസ്‌പ്ലെ റിസല്യൂഷന്‍ ശരിയാക്കുക"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Adjust mouse settings"
-msgstr "മൌസ് സജ്ജീകരണങ്ങള്‍ മാറ്റുക"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Tracking Mode"
-msgstr "ട്രാക്കിങ് മോഡ്"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:16
-msgid "Left-Handed Orientation"
-msgstr "ഇടതു് വശത്തുള്ള സംവേദനം"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "പുതിയ കുറുക്കുവഴി..."
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Middle Mouse Button Click"
-msgstr "മദ്ധ്യത്തിലുള്ള മൌസ് ബട്ടണ്‍ ക്ലിക്ക്"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Right Mouse Button Click"
-msgstr "വലത്തുള്ള മൌസ് ബട്ടണ്‍ ക്ലിക്ക്"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Back"
-msgstr "പുറകോട്ട്"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Forward"
-msgstr "മുന്നോട്ട്"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "No stylus found"
-msgstr "സ്റ്റൈലസ് കണ്ടില്ല"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Eraser Pressure Feel"
-msgstr "ഇറേസര്‍ പ്രഷര്‍ ഫീല്‍"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Soft"
-msgstr "സോഫ്റ്റ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Firm"
-msgstr "ഉറപ്പാക്കുക"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Top Button"
-msgstr "മുകളിലുള്ള ബട്ടണ്‍"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Lower Button"
-msgstr "താഴെയുള്ള ബട്ടണ്‍"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Tip Pressure Feel"
-msgstr "ടിപ്പ് പ്രഷര്‍ ഫീല്‍"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
-msgid "page 3"
-msgstr "താള്‍ 3 "
-
-#: ../shell/alt/cc-window.c:53 ../shell/alt/cc-window.c:1484 ../shell/cc-window.c:730
-msgid "All Settings"
-msgstr "എല്ലാ സജ്ജീകരണങ്ങള്‍"
-
-#. Add categories
-#: ../shell/alt/cc-window.c:875
-msgctxt "category"
-msgid "Personal"
-msgstr "സ്വകാര്യം"
-
-#: ../shell/alt/cc-window.c:876
-msgctxt "category"
-msgid "Hardware"
-msgstr "ഹാര്‍ഡ്‌വെയര്‍"
-
-#: ../shell/alt/cc-window.c:877
-msgctxt "category"
-msgid "System"
-msgstr "സിസ്റ്റം"
-
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
 #, fuzzy
-#| msgid "Control Center"
-msgid "GNOME Control Center"
-msgstr "നിയന്ത്രണകേന്ദ്രം"
+#~| msgid "The username cannot start with a '-'."
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "'-' ഉപയോഗിച്ചു് ഉപയോക്തൃനാമം ആരംഭിയ്ക്കുവാന്‍ പാടില്ല."
 
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
-msgid "Utilities to configure the GNOME desktop"
-msgstr ""
-
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
-msgid "The control center is GNOME’s main interface for configuration of various aspects of your desktop."
-msgstr ""
-
-#: ../shell/cc-application.c:45
 #, fuzzy
-#| msgid "Display Brightness"
-msgid "Display version number"
-msgstr "ഡിസ്പ്ലേയുടെ തെളിച്ചം"
+#~| msgid ""
+#~| "The username should only consist of lower and upper case letters from a-"
+#~| "z, digits and any of characters '.', '-' and '_'."
+#~ msgid ""
+#~ "The username should only consist of upper and lower case letters from a-"
+#~ "z, digits and the following characters: . - _"
+#~ msgstr ""
+#~ "ഉപയോക്തൃനാമത്തില്‍ ഇംഗ്ലീഷ് അക്ഷരങ്ങള്‍, അക്കങ്ങള്‍, '.', '-', '_' - ഇവയിലൊന്നു് മാത്രമേ "
+#~ "പാടുള്ളൂ."
 
-#: ../shell/cc-application.c:46
-msgid "Enable verbose mode"
-msgstr "വര്‍ബറോസ് മോഡ് പ്രവര്‍ത്തന സജ്ജമാക്കുക"
+#, fuzzy
+#~| msgid "This will be used to name your home folder and can't be changed."
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "ഇത് നിങ്ങളുടെ ഹോം ഫോള്‍ഡറിന്റെ പേര് നല്‍കാനായി ഉപയോഗിച്ചതിനാല്‍ മാറ്റാന്‍ സാധ്യമല്ല."
 
-#: ../shell/cc-application.c:47
-msgid "Show the overview"
-msgstr "അവലോകനം കാണിക്കുക"
+#, fuzzy, c-format
+#~| msgid "Button"
+#~ msgid "Button %d"
+#~ msgstr "ബട്ടണ്‍"
 
-#: ../shell/cc-application.c:48
-msgid "Search for the string"
-msgstr "വാചകത്തിനായി തിരയുക"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "കീസ്ട്രോക്ക് അയയ്ക്കുക"
 
-#: ../shell/cc-application.c:49
-msgid "List possible panel names and exit"
-msgstr "സാധ്യമായ പട്ടയുടെ നാമങ്ങള്‍ കാണിച്ച് പുറത്തിറങ്ങുക"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "മോണിറ്റര്‍ സ്വിച്ച് ചെയ്യുക"
 
-#: ../shell/cc-application.c:50
-msgid "Panel to display"
-msgstr "പ്രദര്‍ശിപ്പിക്കുന്നതിനുള്ള പാനല്‍"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "സ്ക്രീനില്‍ സഹായം കാണിക്കുക"
 
-#: ../shell/cc-application.c:50
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
+#~ msgid "Output:"
+#~ msgstr "ഔട്ട്പുട്ട്:"
 
-#: ../shell/cc-application.c:113
-msgid "Available panels:"
-msgstr "ലഭ്യമായ പാനലുകള്‍:"
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "ആസ്പെക്ട് റേഷ്യോ സൂക്ഷിയ്ക്കുക (എഴുത്തുപെട്ടി):"
 
-#: ../shell/cc-application.c:252
-msgid "Help"
-msgstr "സഹായം"
+#~ msgid "Map to single monitor"
+#~ msgstr "ഒറ്റ മോണിറ്ററിലേക്കു് മാപ്പ് ചെയ്യുക"
 
-#: ../shell/cc-application.c:253
-msgid "Quit"
-msgstr "പുറത്തു് കടക്കുക"
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d x %d"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
-msgid "Preferences;Settings;"
-msgstr "Preferences;Settings;"
+#~ msgid "Display Mapping"
+#~ msgstr "മാപ്പിങ് കാണിയ്ക്കുക"
 
-#: ../shell/help-overlay.ui.h:1
-msgctxt "shortcut window"
-msgid "General"
-msgstr "സാധാരണ"
+#~ msgid "Stylus"
+#~ msgstr "സ്റ്റൈലസ് "
 
-#: ../shell/help-overlay.ui.h:2
-msgctxt "shortcut window"
-msgid "Quit"
-msgstr "നിര്‍ത്തുക"
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "വാക്കൊം ടാബ്ലെറ്റ്"
 
-#: ../shell/help-overlay.ui.h:3
-msgctxt "shortcut window"
-msgid "Search"
-msgstr "തിരയുക"
+#~ msgid "Tablet (absolute)"
+#~ msgstr "ടാബ്ലറ്റ് (ആബ്സല്യൂട്ട്)"
 
-#: ../shell/help-overlay.ui.h:4
-msgctxt "shortcut window"
-msgid "Panels"
-msgstr "പാനലുകള്‍"
+#~ msgid "Tablet Preferences"
+#~ msgstr "ടാബ്ലറ്റ് മുന്‍ഗണനകള്‍"
 
-#: ../shell/help-overlay.ui.h:5
-msgctxt "shortcut window"
-msgid "Go back to the overview"
-msgstr "അവലോകനത്തിലോട്ട് തിരിച്ച് പോവുക"
+#~ msgid "_Help"
+#~ msgstr "സഹായം (_H)"
 
-#: ../shell/help-overlay.ui.h:6
-msgctxt "shortcut window"
-msgid "Cancel search"
-msgstr "തെരയല്‍ റദ്ദാക്കുക"
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ബ്ലൂടൂത് സജ്ജീകരണങ്ങള്‍"
 
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: ../shell/hostname-helper.c:189
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "ഹോട്ട്സ്പോട്ട്"
+#~ msgid "Map Buttons…"
+#~ msgstr "ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക…"
 
-#: ../shell/panel-list.ui.h:3
-msgid "No results found"
-msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്ല"
+#~ msgid "Adjust display resolution"
+#~ msgstr "ഡിസ്‌പ്ലെ റിസല്യൂഷന്‍ ശരിയാക്കുക"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "മൌസ് സജ്ജീകരണങ്ങള്‍ മാറ്റുക"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ട്രാക്കിങ് മോഡ്"
+
+#~ msgid "New shortcut…"
+#~ msgstr "പുതിയ കുറുക്കുവഴി..."
+
+#~ msgid "No stylus found"
+#~ msgstr "സ്റ്റൈലസ് കണ്ടില്ല"
+
+#~ msgid "Top Button"
+#~ msgstr "മുകളിലുള്ള ബട്ടണ്‍"
+
+#~ msgid "page 3"
+#~ msgstr "താള്‍ 3 "
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "സ്വകാര്യം"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "ഹാര്‍ഡ്‌വെയര്‍"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "സിസ്റ്റം"
+
+#, fuzzy
+#~| msgid "Control Center"
+#~ msgid "GNOME Control Center"
+#~ msgstr "നിയന്ത്രണകേന്ദ്രം"
+
+#, fuzzy
+#~| msgid "Display Brightness"
+#~ msgid "Display version number"
+#~ msgstr "ഡിസ്പ്ലേയുടെ തെളിച്ചം"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "വര്‍ബറോസ് മോഡ് പ്രവര്‍ത്തന സജ്ജമാക്കുക"
+
+#~ msgid "Show the overview"
+#~ msgstr "അവലോകനം കാണിക്കുക"
+
+#~ msgid "Search for the string"
+#~ msgstr "വാചകത്തിനായി തിരയുക"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "സാധ്യമായ പട്ടയുടെ നാമങ്ങള്‍ കാണിച്ച് പുറത്തിറങ്ങുക"
+
+#~ msgid "Panel to display"
+#~ msgstr "പ്രദര്‍ശിപ്പിക്കുന്നതിനുള്ള പാനല്‍"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "ലഭ്യമായ പാനലുകള്‍:"
+
+#~ msgid "Quit"
+#~ msgstr "പുറത്തു് കടക്കുക"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "ഹോട്ട്സ്പോട്ട്"
 
 #~ msgid "Lid Closed"
 #~ msgstr "അടച്ചു"
 
 #~ msgid "Mirrored"
 #~ msgstr "മിറര്‍ ചെയ്തു"
-
-#~ msgid "Primary"
-#~ msgstr "പ്രഥമ"
-
-#~ msgid "Secondary"
-#~ msgstr "ദ്വീതീയ"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "കൂട്ടിയോജിപ്പിച്ച പ്രദര്‍ശനങ്ങള്‍ ക്രമീകരിക്കുക"
@@ -7108,9 +7821,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Size"
 #~ msgstr "വലിപ്പം"
-
-#~ msgid "Aspect Ratio"
-#~ msgstr "പ്രത്യേക അനുപാതം"
 
 #~ msgid "Show the top bar and Activities Overview on this display"
 #~ msgstr "പശ്ചാത്തലത്തില്‍ മുകളിലത്തെ ബാറും പ്രവര്‍ത്തന വിവരങ്ങളും കാണിക്കുക"
@@ -7161,15 +7871,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Automatic"
 #~ msgstr "തനിയെയുള്ള"
 
-#~ msgid "_Method"
-#~ msgstr "_സംവിധാനം"
-
-#~ msgid "Add Device"
-#~ msgstr "ഡിവൈസ് ചേര്‍ക്കുക"
-
-#~ msgid "Remove Device"
-#~ msgstr "ഡിവൈസ് നീക്കം ചെയ്യുക"
-
 #~ msgid "VPN Type"
 #~ msgstr "VPN തരം"
 
@@ -7179,23 +7880,14 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Group Password"
 #~ msgstr "ഗ്രൂപ്പ് രഹസ്യവാക്ക്"
 
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "ബ്ലൂടൂത്ത് പ്രവര്‍ത്തന രഹിതമാക്കിയിരിക്കുന്നു"
-
 #~ msgid "Done"
 #~ msgstr "ചെയ്ത് കഴിഞ്ഞിരിക്കുന്നു"
-
-#~ msgid "Color"
-#~ msgstr "നിറം"
 
 #~ msgid "United States"
 #~ msgstr "യുണൈറ്റഡ് സ്റ്റേറ്റ്സ്"
 
 #~ msgid "Germany"
 #~ msgstr "ജര്‍മനി"
-
-#~ msgid "France"
-#~ msgstr "ഫ്രാന്‍സ്"
 
 #~ msgid "Spain"
 #~ msgstr "സ്പൈന്‍"
@@ -7215,9 +7907,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Shortcut;Repeat;Blink;"
 #~ msgstr "Shortcut;Repeat;Blink;"
-
-#~ msgid "_Name:"
-#~ msgstr "_പേര്:"
 
 #~ msgid "_Delay:"
 #~ msgstr "_താമസം:"
@@ -7241,26 +7930,25 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "S_peed:"
 #~ msgstr "വേ_ഗത:"
 
-#~ msgid "Add Shortcut"
-#~ msgstr "എളുപ്പവഴി ചേര്‍ക്കുക"
-
-#~ msgid "To edit a shortcut, click the row and hold down the new keys or press Backspace to clear."
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
 #~ msgstr ""
-#~ "കുറുക്കുവഴി ചേര്‍ക്കുന്നതിനായി വരിയില്‍ ക്ലിക്ക് ചെയ്ത ശേഷം പുതിയ കുറുക്കുവഴിയ്ക്കുള്ള കീ ടൈപ്പ് ചെയ്യുക. കീ നീക്കം ചെയ്യാന്‍ backspace "
-#~ "ടൈപ്പ് ചെയ്യുക."
-
-#~ msgid "Shortcuts"
-#~ msgstr "എളുപ്പവഴികള്‍"
+#~ "കുറുക്കുവഴി ചേര്‍ക്കുന്നതിനായി വരിയില്‍ ക്ലിക്ക് ചെയ്ത ശേഷം പുതിയ കുറുക്കുവഴിയ്ക്കുള്ള കീ ടൈപ്പ് "
+#~ "ചെയ്യുക. കീ നീക്കം ചെയ്യാന്‍ backspace ടൈപ്പ് ചെയ്യുക."
 
 #~ msgid "<Unknown Action>"
 #~ msgstr "<അറിയാത്ത പ്ര‌വൃത്തി‌>"
 
 #~ msgid ""
-#~ "The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
 #~ "Please try with a key such as Control, Alt or Shift at the same time."
 #~ msgstr ""
-#~ " \"%s\" എന്ന എളുപ്പവഴി ഉപയോഗിക്കാന്‍ പറ്റില്ല. കാരണം പിന്നീട് ഈ കീ ഉപയോഗിച്ചു് ടൈപ്പ് ചെയ്യാന്‍ സാധ്യമല്ലാതെയാകും.\n"
-#~ "Control, Alt അല്ലെങ്കില്‍ Shift എന്നിവയില്‍ ഒന്നിനോടൊപ്പം ഉപയോഗിക്കുന്ന ഒരു കീ പരീക്ഷിക്കുക."
+#~ " \"%s\" എന്ന എളുപ്പവഴി ഉപയോഗിക്കാന്‍ പറ്റില്ല. കാരണം പിന്നീട് ഈ കീ ഉപയോഗിച്ചു് ടൈപ്പ് "
+#~ "ചെയ്യാന്‍ സാധ്യമല്ലാതെയാകും.\n"
+#~ "Control, Alt അല്ലെങ്കില്‍ Shift എന്നിവയില്‍ ഒന്നിനോടൊപ്പം ഉപയോഗിക്കുന്ന ഒരു കീ "
+#~ "പരീക്ഷിക്കുക."
 
 #~ msgid ""
 #~ "The shortcut \"%s\" is already used for\n"
@@ -7269,7 +7957,9 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ "\"%s\" എന്ന എളുപ്പവഴി ഇപ്പോള്‍ തന്നെ  \n"
 #~ " \"%s\"നു വേണ്ടി ഉപയോഗിച്ചിട്ടുണ്ട്"
 
-#~ msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
 #~ msgstr "എളുപ്പവഴി \"%s\"-നു് വീണ്ടും നല്‍കിയാല്‍, \"%s\" എളുപ്പവഴി പ്രവര്‍ത്തന രഹിതമാക്കുന്നു."
 
 #~ msgid "_Reassign"
@@ -7314,9 +8004,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Fast"
 #~ msgstr "വേഗത്തില്‍"
 
-#~ msgid "Disable while _typing"
-#~ msgstr "ടൈപ്പ് ചെയ്യുമ്പോള്‍ _പ്രവര്‍ത്തന രഹിതമാക്കുക"
-
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "സിസ്റ്റത്തിന്റെ നെറ്റ്‌വര്‍ക്ക് സര്‍വീസുകള്‍ ഈ പതിപ്പുമായി പൊരുത്തപ്പെടുന്നില്ല."
 
@@ -7351,10 +8038,16 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Add Network Connection"
 #~ msgstr "പുതിയൊരു ശ്രംഖല കണക്ഷന്‍ ചേര്‍ക്കുക"
 
-#~ msgid "Reset the settings for this network, including passwords, but remember it as a preferred network"
-#~ msgstr "ഈ ശ്രംഖലയ്ക്ക് വേണ്ടിയുള്ള ക്രമീകരണങ്ങള്‍, രഹസ്യവാക്കുകള്‍ ഉള്‍പ്പെടെ, പഴയപോലെ ആക്കുക. പക്ഷേ, മുന്‍ഗണാനാശ്രംഖലയായി ഇതിനെ ഓര്‍ക്കുക"
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "ഈ ശ്രംഖലയ്ക്ക് വേണ്ടിയുള്ള ക്രമീകരണങ്ങള്‍, രഹസ്യവാക്കുകള്‍ ഉള്‍പ്പെടെ, പഴയപോലെ ആക്കുക. പക്ഷേ, "
+#~ "മുന്‍ഗണാനാശ്രംഖലയായി ഇതിനെ ഓര്‍ക്കുക"
 
-#~ msgid "Remove all details relating to this network and do not try to automatically connect"
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
 #~ msgstr "ഈ ശ്രംഖലയുമായുള്ള എല്ലാ വിവരങ്ങളും നീക്കി തനിയെ ബന്ധിപ്പിക്കാതിരിക്കുക"
 
 #~ msgid "Bond slaves"
@@ -7371,23 +8064,17 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "സംഘത്തിലെ അടിമകള്‍"
 
 #~ msgid ""
-#~ "If you have a connection to the Internet other than wireless, you can set up a wireless hotspot to share "
-#~ "the connection with others."
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
 #~ msgstr ""
-#~ "വയര്‍ലെസ്സിനു് പകരം ഇന്റര്‍നെറ്റിലേക്കു് നിങ്ങള്‍ക്കൊരു കണക്ഷനുണ്ടെങ്കില്‍, മറ്റുള്ളവരുമായി നിങ്ങള്‍ക്കു് ഇന്റര്‍നെറ്റു് പങ്കിടുവാന്‍ ഒരു വയര്‍ലസ്സ് ഹോട്ട് "
-#~ "സ്പോട്ട് ഉണ്ടാക്കാം."
-
-#~ msgid "History"
-#~ msgstr "ചരിത്രം"
+#~ "വയര്‍ലെസ്സിനു് പകരം ഇന്റര്‍നെറ്റിലേക്കു് നിങ്ങള്‍ക്കൊരു കണക്ഷനുണ്ടെങ്കില്‍, മറ്റുള്ളവരുമായി നിങ്ങള്‍ക്കു് "
+#~ "ഇന്റര്‍നെറ്റു് പങ്കിടുവാന്‍ ഒരു വയര്‍ലസ്സ് ഹോട്ട് സ്പോട്ട് ഉണ്ടാക്കാം."
 
 #~ msgid "_Use as Hotspot…"
 #~ msgstr "ഹോട്ട്സ്പോട്ടായി _ഉപയോഗിക്കുക…"
 
 #~ msgid "_History"
 #~ msgstr "_ചരിത്രം"
-
-#~ msgid "Security key"
-#~ msgstr "സുരക്ഷ കീ"
 
 #~ msgid "InfiniBand device does not support connected mode"
 #~ msgstr "InfiniBand ഡിവൈസ് കണക്ട് ചെയ്ത മോഡ് പിന്തുണയ്ക്കുന്നില്ല"
@@ -7396,11 +8083,13 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി (CA) സര്‍ട്ടിഫീക്കേറ്റ് തെരഞ്ഞെടുത്തിട്ടില്ല"
 
 #~ msgid ""
-#~ "Not using a Certificate Authority (CA) certificate can result in connections to insecure, rogue Wi-Fi "
-#~ "networks.  Would you like to choose a Certificate Authority certificate?"
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
 #~ msgstr ""
-#~ "ഒരു സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി (CA) സര്‍ട്ടിഫീക്കേറ്റ് ഉപയോഗിച്ചില്ല എങ്കില്‍, സുരക്ഷിതമല്ലാത്ത വയര്‍ലെസ് ശൃംഖലകളിലേയ്ക്കു് കടക്കുവാന്‍ "
-#~ "സാധ്യതയുണ്ടു്. നിങ്ങള്‍ക്കു് ഒരു സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി സര്‍ട്ടിഫീക്കേറ്റ് തെരഞ്ഞെടുക്കണമോ?"
+#~ "ഒരു സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി (CA) സര്‍ട്ടിഫീക്കേറ്റ് ഉപയോഗിച്ചില്ല എങ്കില്‍, "
+#~ "സുരക്ഷിതമല്ലാത്ത വയര്‍ലെസ് ശൃംഖലകളിലേയ്ക്കു് കടക്കുവാന്‍ സാധ്യതയുണ്ടു്. നിങ്ങള്‍ക്കു് ഒരു "
+#~ "സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി സര്‍ട്ടിഫീക്കേറ്റ് തെരഞ്ഞെടുക്കണമോ?"
 
 #~ msgid "Ignore"
 #~ msgstr "അവഗണിക്കുക"
@@ -7413,9 +8102,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Don't _warn me again"
 #~ msgstr "ഇനി _മുന്നറിയിപ്പ് നല്‍കേണ്ടതില്ല"
-
-#~ msgid "No"
-#~ msgstr "അല്ല"
 
 #~ msgid "Yes"
 #~ msgstr "അതെ"
@@ -7484,10 +8170,11 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "ഒരു ഓണ്‍ലൈന്‍ അക്കൌണ്ട് ചേര്‍ക്കുക"
 
 #~ msgid ""
-#~ "Adding an account allows your applications to access it for documents, mail, contacts, calendar, chat and "
-#~ "more."
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
 #~ msgstr ""
-#~ "ഒരു അക്കൌണ്ട് ചേര്‍ത്താല്‍, രേഖകള്‍, മെയില്‍, വിലാസങ്ങള്‍, കലണ്ടര്‍, ചാറ്റ് എന്നിങ്ങനെയുള്ളവയിലേക്കു് നിങ്ങളുടെ പ്രയോഗങ്ങളെ അനുവദിയ്ക്കുന്നു."
+#~ "ഒരു അക്കൌണ്ട് ചേര്‍ത്താല്‍, രേഖകള്‍, മെയില്‍, വിലാസങ്ങള്‍, കലണ്ടര്‍, ചാറ്റ് എന്നിങ്ങനെയുള്ളവയിലേക്കു് "
+#~ "നിങ്ങളുടെ പ്രയോഗങ്ങളെ അനുവദിയ്ക്കുന്നു."
 
 #~ msgid "Turns off wireless devices"
 #~ msgstr "വയർലെസ്സ് ഉപകരണങ്ങൾ ഓഫ് ചെയ്യുക"
@@ -7495,12 +8182,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~| msgid "When Battery Power is _Critical"
 #~ msgid "When battery power is _critical"
 #~ msgstr "ബാറ്ററി _വളരെ കുറവാകുമ്പോള്‍"
-
-#~ msgid "Power"
-#~ msgstr "വൈദ്യുതി"
-
-#~ msgid "Power off"
-#~ msgstr "നിര്‍ത്തുക"
 
 #~ msgctxt "printer state"
 #~ msgid "Configuring"
@@ -7524,9 +8205,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr[0] "%u സജീവം"
 #~ msgstr[1] "%u സജീവം"
 
-#~ msgid "Close"
-#~ msgstr "അടയ്ക്കുക"
-
 #~ msgid "Resume Printing"
 #~ msgstr "പ്രിന്റ് ചെയ്യുന്നതു് തുടരുക"
 
@@ -7536,19 +8214,9 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Add a New Printer"
 #~ msgstr "പുതിയ പ്രിന്റര്‍ ചേര്‍ക്കുക"
 
-#~| msgid "Authenticate"
-#~ msgid "A_uthenticate"
-#~ msgstr "തിരിച്ചറിയുക"
-
-#~ msgid "No printers detected."
-#~ msgstr "ഒരു പ്രിന്ററുകളും ലഭ്യമായിട്ടില്ല."
-
 #~| msgid "Search for network printers or filter result"
 #~ msgid "Enter address of a printer or a text to filter results"
 #~ msgstr "തിരയാന്‍ വേണ്ടി പ്രിന്ററിന്റെയോ ടെക്സ്റ്റിന്റെയോ അഡ്രസ് നല്‍കുക"
-
-#~ msgid "Loading options…"
-#~ msgstr "ഐച്ഛികങ്ങള്‍ ലഭ്യമാക്കുന്നു…"
 
 #~ msgctxt "print job"
 #~ msgid "Held"
@@ -7559,9 +8227,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Job State"
 #~ msgstr "ജോലിയുടെ അവസ്ഥ"
-
-#~ msgid "Time"
-#~ msgstr "സമയം"
 
 #~ msgid "Supply"
 #~ msgstr "ലഭ്യമാക്കുക"
@@ -7579,31 +8244,25 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "label"
 #~ msgstr "ലേബല്‍"
 
-#~ msgid "Setting new driver…"
-#~ msgstr "പുതിയ ഡ്രൈവര്‍ സജ്ജമാക്കുന്നു…"
-
 #~ msgid "Print _Test Page"
 #~ msgstr "_പരീക്ഷണത്തിനുള്ള താള്‍ പ്രിന്റ് ചെയ്യുക"
 
 #~ msgid "Add New Printer"
 #~ msgstr "പുതിയ പ്രിന്റര്‍ ചേര്‍ക്കുക"
 
-#~ msgid "Privacy"
-#~ msgstr "സ്വകാര്യത"
-
 #~ msgid "Sorry"
 #~ msgstr "ക്ഷമിക്കുക"
-
-#~ msgid "Options"
-#~ msgstr "ഐച്ഛികങ്ങള്‍"
 
 #~| msgid "Other"
 #~ msgctxt "Search Location"
 #~ msgid "Other"
 #~ msgstr "മറ്റുളളവ"
 
-#~ msgid "Bluetooth Sharing allows you to share files with other Bluetooth enabled devices"
-#~ msgstr "ബ്ലൂട്ടുത്ത് പങ്കിടല്‍ മറ്റുള്ള ബ്ലൂട്ടുത്ത് ഉപകരണങ്ങളുമായി ഫയലുകള്‍ പങ്കിടാന്‍ നിങ്ങളെ അനുവദിക്കുന്നു"
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "ബ്ലൂട്ടുത്ത് പങ്കിടല്‍ മറ്റുള്ള ബ്ലൂട്ടുത്ത് ഉപകരണങ്ങളുമായി ഫയലുകള്‍ പങ്കിടാന്‍ നിങ്ങളെ അനുവദിക്കുന്നു"
 
 #~ msgid "Only Receive From Trusted Devices"
 #~ msgstr "വിശ്വസ്ഥമായ ഉപകരണങ്ങളില്‍ നിന്ന് മാത്രം സ്വീകരിക്കുക"
@@ -7625,10 +8284,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Share Public Folder On This Network"
 #~ msgstr "ഈ ശ്രംഖലയില്‍ പൊതു അറ പങ്കിടുക"
-
-#~| msgid "Remote Control"
-#~ msgid "Allow Remote Control"
-#~ msgstr "വിദൂര നിയന്ത്രണം അനുവദിക്കുക"
 
 #~| msgid "Password"
 #~ msgid "Password:"
@@ -7751,12 +8406,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Scroll Up"
 #~ msgstr "മുകളിലേക്കു് സ്ക്രോള്‍ ചെയ്യുക"
 
-#~ msgid "Scroll Down"
-#~ msgstr "താഴേക്ക് സ്ക്രോള്‍ ചെയ്യുക"
-
-#~ msgid "Scroll Left"
-#~ msgstr "ഇടത്തേക്ക് സ്ക്രോള്‍ ചെയ്യുക"
-
 #~ msgid "Scroll Right"
 #~ msgstr "വലത്തേക്ക് സ്ക്രോള്‍ ചെയ്യുക"
 
@@ -7773,23 +8422,14 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ "%s\n"
 #~ " '%s --help' രണ്‍ ചെയ്യുക ലഭ്യമായ ആജ്ഞ-വരി ഐച്ഛികങ്ങളുടെ പട്ടിക കാണാന്‍..\n"
 
-#~ msgid "Flickr"
-#~ msgstr "ഫ്ലിക്കര്‍"
-
 #~ msgid "Set Up New Device"
 #~ msgstr "പുതിയ ഡിവൈസ് സജ്ജീകരിക്കുക"
 
 #~ msgid "Paired"
 #~ msgstr "ജോടികള്‍"
 
-#~ msgid "Type"
-#~ msgstr "തരം"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "മൌസിന്റേയും ടച്ച്പാടിന്റേയും സജ്ജീകരണങ്ങള്‍"
-
-#~ msgid "Sound Settings"
-#~ msgstr "ശബ്ദ ക്രമീകരണങ്ങള്‍"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "കീബോര്‍ഡ് ക്രമീകരണങ്ങള്‍"
@@ -7806,8 +8446,12 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Remove '%s' from the list of devices?"
 #~ msgstr "ഡിവൈസുകളുടെ പട്ടികയില്‍ നിന്നും '%s' നീക്കം ചെയ്യേണമോ?"
 
-#~ msgid "If you remove the device, you will have to set it up again before next use."
-#~ msgstr "ഈ ഡിവൈസ് നിങ്ങള്‍ നീക്കം ചെയ്താല്‍ അടുത്ത പ്രാവിശ്യം ഉപയോഗിക്കുന്നതിന്നു മുമ്പ് വീണ്ടും സജ്ജീകരിക്കേണ്ടി വരും."
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "ഈ ഡിവൈസ് നിങ്ങള്‍ നീക്കം ചെയ്താല്‍ അടുത്ത പ്രാവിശ്യം ഉപയോഗിക്കുന്നതിന്നു മുമ്പ് വീണ്ടും "
+#~ "സജ്ജീകരിക്കേണ്ടി വരും."
 
 #~ msgid "Install Updates"
 #~ msgstr "പരിഷ്കരണങ്ങള്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യുക"
@@ -7845,8 +8489,11 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Model:"
 #~ msgstr "മോഡല്‍:"
 
-#~ msgid "Image files can be dragged on this window to auto-complete the above fields."
-#~ msgstr "മുകളിലുള്ള ഫീള്‍ഡുകള്‍ സ്വയമായി പൂര്‍ത്തിയാക്കുന്നതിനു് ഈ ജാലകത്തിലേക്കു് ഇമേജ് ഫയലുകള്‍ വലിച്ചിടാം."
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "മുകളിലുള്ള ഫീള്‍ഡുകള്‍ സ്വയമായി പൂര്‍ത്തിയാക്കുന്നതിനു് ഈ ജാലകത്തിലേക്കു് ഇമേജ് ഫയലുകള്‍ വലിച്ചിടാം."
 
 #~ msgid "Left Shift"
 #~ msgstr "ഇടത് ഷിഫ്ട്"
@@ -7911,9 +8558,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "_City:"
 #~ msgstr "_നഗരം:"
 
-#~ msgid "_Network Time"
-#~ msgstr "_ശൃംഖലയിലെ സമയം"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "ഒരു മണിക്കൂര്‍ കൂട്ടി സമയം സജ്ജീകരിക്കുക."
 
@@ -7937,21 +8581,15 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "സാധാരണ"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "ഘടികാരദിശയില്‍ "
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 ഡിഗ്രീകള്‍"
 
-#~ msgid "Monitor"
-#~ msgstr "മോണിറ്റര്‍"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "പ്രധാന പ്രദര്‍ശനം മാറ്റുവാന്‍ വലിച്ചിടുക."
-
-#~ msgid "Select a monitor to change its properties; drag it to rearrange its placement."
-#~ msgstr "വിശേഷതകള്‍ മാറ്റുന്നതിനായി ഒരു മോണിറ്റര്‍ തെരഞ്ഞെടുക്കുക; സ്ഥാനം മാറ്റുന്നതിനായി അവിടേക്കു് വലിച്ചിടുക."
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "വിശേഷതകള്‍ മാറ്റുന്നതിനായി ഒരു മോണിറ്റര്‍ തെരഞ്ഞെടുക്കുക; സ്ഥാനം മാറ്റുന്നതിനായി അവിടേക്കു് "
+#~ "വലിച്ചിടുക."
 
 #~ msgid "%a %R"
 #~ msgstr "%a %R"
@@ -8136,12 +8774,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "C_ontinue"
 #~ msgstr "തു_ടരുക"
 
-#~ msgid "Previous Week"
-#~ msgstr "കഴിഞ്ഞ ആഴ്ച"
-
-#~ msgid "Next Week"
-#~ msgstr "അടുത്ത ആഴ്ച"
-
 #~ msgid "Next week"
 #~ msgstr "അടുത്ത ആഴ്ച"
 
@@ -8153,12 +8785,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Enable this account"
 #~ msgstr "ഈ അക്കൌണ്ട് പ്രവര്‍ത്തന സജ്ജമാക്കുക"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "രഹസ്യവാക്ക് ഉറപ്പാക്കുക"
-
-#~ msgid "Generate a password"
-#~ msgstr "ഒരു രഹസ്യവാക്ക് ലഭ്യമാക്കുക"
 
 #~ msgid "_Action"
 #~ msgstr "പ്ര_വര്‍ത്തി"
@@ -8172,7 +8798,8 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Changing photo for:"
 #~ msgstr "ഫോട്ടോ മാറ്റുന്നു:"
 
-#~ msgid "Choose a picture that will be shown at the login screen for this account."
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
 #~ msgstr "ഈ അക്കൌണ്ടിനു് പ്രവേശന സ്ക്രീനിനൊപ്പം കാണിയ്ക്കേണ്ട ചിത്രം തെരഞ്ഞെടുക്കുക."
 
 #~ msgid "Gallery"
@@ -8263,9 +8890,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Select a region"
 #~ msgstr "ഒരു സ്ഥലം തെരഞ്ഞെടുക്കുക"
 
-#~ msgid "Select a language"
-#~ msgstr "ഒരു ഭാഷ തെരഞ്ഞെടുക്കുക"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "തീയതിയും സമയവും മുന്‍ഗണനാ പാനല്‍"
 
@@ -8288,9 +8912,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgctxt "mouse, speed"
 #~ msgid "Fast"
 #~ msgstr "വേഗം"
-
-#~ msgid "Network settings"
-#~ msgstr "ശൃംഖലയുടെ ക്രമീകരണങ്ങള്‍"
 
 #~ msgid "_Options…"
 #~ msgstr "_ഐച്ഛികങ്ങള്‍…"
@@ -8334,9 +8955,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "00:24:16:31:8G:7A"
 #~ msgstr "00:24:16:31:8G:7A"
 
-#~ msgid "Manage notifications"
-#~ msgstr "അറിയിപ്പുകള്‍ കൈകാര്യം ചെയ്യുക"
-
 #~ msgid "Expired credentials. Please log in again."
 #~ msgstr "അനുമതികളുടെ കാലാവധി കഴിഞ്ഞിരിയ്ക്കുന്നു. ദയവായി വീണ്ടും പ്രവേശിയ്ക്കുക."
 
@@ -8365,17 +8983,20 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "ഇന്‍പുട്ട് ശ്രോതസ്സ് തെരഞ്ഞെടുക്കുക"
 
 #~ msgid ""
-#~ "The login screen, system accounts and new user accounts use the system-wide Region and Language settings."
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
 #~ msgstr ""
-#~ "പ്രവേശന സ്ക്രീന്‍, സിസ്റ്റം അക്കൌണ്ടുകള്‍, പുതിയ ഉപയോക്താവിനുള്ള അക്കൌണ്ടുകള്‍ എന്നിവ സിസ്റ്റത്തില്‍ പൂര്‍ണ്ണമായുള്ള സ്ഥലവും ഭാഷയും സജ്ജീകരണങ്ങള്‍ "
-#~ "ഉപയോഗിയ്ക്കുന്നു."
+#~ "പ്രവേശന സ്ക്രീന്‍, സിസ്റ്റം അക്കൌണ്ടുകള്‍, പുതിയ ഉപയോക്താവിനുള്ള അക്കൌണ്ടുകള്‍ എന്നിവ സിസ്റ്റത്തില്‍ "
+#~ "പൂര്‍ണ്ണമായുള്ള സ്ഥലവും ഭാഷയും സജ്ജീകരണങ്ങള്‍ ഉപയോഗിയ്ക്കുന്നു."
 
 #~ msgid ""
-#~ "The login screen, system accounts and new user accounts use the system-wide Region and Language settings. "
-#~ "You may change the system settings to match yours."
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
 #~ msgstr ""
-#~ "പ്രവേശന സ്ക്രീന്‍, സിസ്റ്റം അക്കൌണ്ടുകള്‍, പുതിയ ഉപയോക്താവിനുള്ള അക്കൌണ്ടുകള്‍ എന്നിവ സിസ്റ്റത്തില്‍ പൂര്‍ണ്ണമായുള്ള സ്ഥലവും ഭാഷയും സജ്ജീകരണങ്ങള്‍ "
-#~ "ഉപയോഗിയ്ക്കുന്നു. നിങ്ങളുടേതുമായി പൊരുത്തപ്പെടുന്നതിനു് സിസ്റ്റം സജ്ജീകരണങ്ങളില്‍ മാറ്റം വരുത്താം."
+#~ "പ്രവേശന സ്ക്രീന്‍, സിസ്റ്റം അക്കൌണ്ടുകള്‍, പുതിയ ഉപയോക്താവിനുള്ള അക്കൌണ്ടുകള്‍ എന്നിവ സിസ്റ്റത്തില്‍ "
+#~ "പൂര്‍ണ്ണമായുള്ള സ്ഥലവും ഭാഷയും സജ്ജീകരണങ്ങള്‍ ഉപയോഗിയ്ക്കുന്നു. നിങ്ങളുടേതുമായി പൊരുത്തപ്പെടുന്നതിനു് "
+#~ "സിസ്റ്റം സജ്ജീകരണങ്ങളില്‍ മാറ്റം വരുത്താം."
 
 #~ msgid "Copy Settings"
 #~ msgstr "സജ്ജീകരണങ്ങള്‍ പകര്‍ത്തുക"
@@ -8385,9 +9006,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Region and Language"
 #~ msgstr "സ്ഥലവും ഭാഷയും"
-
-#~ msgid "Select a display language"
-#~ msgstr "കാണിക്കാനുള്ള ഒരു ഭാഷ തെരഞ്ഞെടുക്കുക"
 
 #~ msgid "Add Language"
 #~ msgstr "ഭാഷ ചേര്‍ക്കുക"
@@ -8428,9 +9046,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "System settings"
 #~ msgstr "സിസ്റ്റത്തിന്റെ സജ്ജീകരണങ്ങള്‍"
 
-#~ msgid "Search settings"
-#~ msgstr "തെരയല്‍ സജ്ജീകരണങ്ങള്‍"
-
 #~ msgid "Universal Access Preferences"
 #~ msgstr "ആഗോള സമീപന മുന്‍ഗണനകള്‍"
 
@@ -8438,11 +9053,11 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "സൂച_ന"
 
 #~ msgid ""
-#~ "This hint may be displayed at the login screen.  It will be visible to all users of this system.  Do "
-#~ "<b>not</b> include the password here."
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
 #~ msgstr ""
-#~ "പ്രവേശന സ്ക്രീനില്‍ ഈ സൂചന കാണിയ്ക്കുന്നു. ഈ സിസ്റ്റം ഉപയോഗിയ്ക്കുന്ന എല്ലാ ഉപയോക്താക്കള്‍ക്കും ഇതു് കാണുവാന്‍ സാധിയ്ക്കുന്നു. ഇവിടെ "
-#~ "രഹസ്യവാക്ക് <b>നല്‍കരുതു്</b>."
+#~ "പ്രവേശന സ്ക്രീനില്‍ ഈ സൂചന കാണിയ്ക്കുന്നു. ഈ സിസ്റ്റം ഉപയോഗിയ്ക്കുന്ന എല്ലാ ഉപയോക്താക്കള്‍ക്കും "
+#~ "ഇതു് കാണുവാന്‍ സാധിയ്ക്കുന്നു. ഇവിടെ രഹസ്യവാക്ക് <b>നല്‍കരുതു്</b>."
 
 #~ msgid "Fair"
 #~ msgstr "സാമാന്യം നല്ലത്"
@@ -8464,9 +9079,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Browse Files..."
 #~ msgstr "ഫൈലുകള്‍ ബ്രൗസ് ചെയ്യുക..."
-
-#~ msgid "Create virtual device"
-#~ msgstr "ഒരു പുതിയ വിര്‍ച്ച്വല്‍ ഉപകരണം ഉണ്ടാക്കുക"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "പ്രദര്‍ശനത്തിനു് ലഭ്യമായ പ്രൊഫൈലുകള്‍"
@@ -8507,7 +9119,9 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "This device is using manufacturing calibrated data."
 #~ msgstr "ഈ ഡിവൈസ് കാലിബ്രേറ്റ് ഡേറ്റാ ഉപയോഗിയ്ക്കുന്നു."
 
-#~ msgid "This device does not have a profile suitable for whole-screen color correction."
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
 #~ msgstr "പൂര്‍ണ്ണ സ്ക്രീനിനുചിതമായൊരു പ്രൊഫൈല്‍ ഈ ഡിവൈസിനു് ലഭ്യമല്ല."
 
 #~ msgid "Not specified"
@@ -8555,8 +9169,12 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "The next login will attempt to use the standard experience."
 #~ msgstr "അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ സാധാണ രീതി ഉപയോഗിയ്ക്കുന്നു."
 
-#~ msgid "The next login will use the fallback mode intended for unsupported graphics hardware."
-#~ msgstr "അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ പിന്തുണയ്ക്കാത്ത ഗ്രാഫിക്സ് ഹാര്‍ഡ്‌വെയറിനുള്ള ഫോള്‍ബാക്ക് മോഡ്  ഉപയോഗിയ്ക്കുന്നു."
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ പിന്തുണയ്ക്കാത്ത ഗ്രാഫിക്സ് ഹാര്‍ഡ്‌വെയറിനുള്ള ഫോള്‍ബാക്ക് മോഡ്  "
+#~ "ഉപയോഗിയ്ക്കുന്നു."
 
 #~ msgctxt "Experience"
 #~ msgid "Fallback"
@@ -8623,8 +9241,11 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Charging - fully charged"
 #~ msgstr "ചാര്‍ജ് ചെയ്യുന്നു - പൂര്‍ണ്ണമായി ചാര്‍ജായി"
 
-#~ msgid "Tip: <a href=\"screen\">screen brightness</a> affects how much power is used"
-#~ msgstr "സൂചന: <a href=\"screen\">സ്ക്രീന്റെ തെളിച്ചം</a> സിസ്റ്റത്തിന്റെ പവറിനെ ബാധിയ്ക്കുന്നു"
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "സൂചന: <a href=\"screen\">സ്ക്രീന്റെ തെളിച്ചം</a> സിസ്റ്റത്തിന്റെ പവറിനെ ബാധിയ്ക്കുന്നു"
 
 #~ msgid "Suspend when inactive for"
 #~ msgstr "നിര്‍ജ്ജീവമാകുമ്പോള്‍ സസ്പെന്‍ഡ് ചെയ്യുക"
@@ -8635,20 +9256,15 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Copy Settings..."
 #~ msgstr "സജ്ജീകരണങ്ങള്‍ പകര്‍ത്തുക..."
 
-#~ msgid "Select a display language (change will be applied next time you log in)"
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
 #~ msgstr "ഒരു പ്രദര്‍ശന ഭാഷ തെരഞ്ഞെടുക്കുക (അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ മാറ്റം ലഭ്യമാകുന്നു)"
 
 #~ msgid "Remove Language"
 #~ msgstr "ഭാഷ നീക്കം ചെയ്യുക"
 
-#~ msgid "Install languages..."
-#~ msgstr "ഭാഷകള്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യുക..."
-
 #~ msgid "Brightness & Lock"
 #~ msgstr "തെളിച്ചവും പൂട്ടും"
-
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "സ്ക്രീന്‍ തെളിച്ചവും പൂട്ടിനുള്ള സജ്ജീകരണങ്ങള്‍"
 
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "Brightness;Lock;Dim;Blank;Monitor;"
@@ -8661,9 +9277,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Locations..."
 #~ msgstr "സ്ഥലങ്ങള്‍..."
-
-#~ msgid "Lock"
-#~ msgstr "പൂട്ട്"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "പ്രശ്നനിര്‍ദ്ധാരണകോഡ് പ്രാവര്‍ത്തികമാക്കുക. "
@@ -8680,14 +9293,8 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Sound Output Volume"
 #~ msgstr "ശബ്ദം ഔട്ട്പുട്ട് വോള്യം"
 
-#~ msgid "Microphone Volume"
-#~ msgstr "മൈക്രോഫോണ്‍ വോള്യം"
-
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "ശബ്ദ മുന്‍ഗണനകള്‍ പ്രവര്‍ത്തിപ്പിക്കുന്നതില്‍ പരാജയപ്പെട്ടു: %s"
-
-#~ msgid "_Mute"
-#~ msgstr "_നിശബ്ദമാക്കുക"
 
 #~ msgid "_Sound Preferences"
 #~ msgstr "_ശബ്ദ മുന്‍ഗണനകള്‍"
@@ -8759,9 +9366,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Take a screenshot"
 #~ msgstr "ഒരു സ്ക്രീന്‍ ഷോട്ട് എടുക്കുക"
 
-#~ msgid "A_cceleration:"
-#~ msgstr "_വേഗവര്‍ദ്ധനവ്:"
-
 #, fuzzy
 #~ msgid "Drag Threshold"
 #~ msgstr "വലിച്ചിഴയ്ക്കുന്നതിനുള്ള കുറഞ്ഞവില"
@@ -8781,7 +9385,8 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #, fuzzy
 #~ msgid "To test your settings, try to double-click on the face."
 #~ msgstr ""
-#~ "<i>നിങ്ങളുടെ രണ്ടു്-തവണ ക്ലിക്ക് ചെയ്യുന്നതിനുള്ള സജ്ജീകരണങ്ങള്‍ പരീക്ഷിക്കുന്നതിനായി, ലൈറ്റ് ബള്‍ബില്‍ രണ്ടു് തവണ ക്ലിക്ക് ചെയ്യുക.</i>"
+#~ "<i>നിങ്ങളുടെ രണ്ടു്-തവണ ക്ലിക്ക് ചെയ്യുന്നതിനുള്ള സജ്ജീകരണങ്ങള്‍ പരീക്ഷിക്കുന്നതിനായി, ലൈറ്റ് "
+#~ "ബള്‍ബില്‍ രണ്ടു് തവണ ക്ലിക്ക് ചെയ്യുക.</i>"
 
 #~ msgid "_Disabled"
 #~ msgstr "_നിര്‍ജ്ജീവമാക്കിയ"
@@ -8858,9 +9463,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Network"
 #~ msgstr "ശൃംഖല"
 
-#~ msgid "Device types"
-#~ msgstr "ഉപകരണ തരങ്ങള്‍"
-
 #~ msgid "Automatic configuration"
 #~ msgstr "സ്വയം ക്രമീകരണം"
 
@@ -8899,17 +9501,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "_സഹജമായതിലേയ്ക്ക് വീണ്ടും സജ്ജീകരിയ്ക്കുക"
 
 #, fuzzy
-#~ msgid "View and edit keyboard layout options"
-#~ msgstr "കീബോര്‍ഡ് വിന്യാസ ഐച്ഛികങ്ങള്‍"
-
-#~ msgid "Layout"
-#~ msgstr "വിന്യാസം"
-
-#, fuzzy
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "ക്രമീകരിക്കുവാനുള്ളൊരു ഡിവൈസ് _തെരഞ്ഞെടുക്കുക:"
-
-#, fuzzy
 #~ msgid "Caribou"
 #~ msgstr "കാരിബു"
 
@@ -8919,14 +9510,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Dasher"
 #~ msgstr "ഡാഷര്‍"
-
-#, fuzzy
-#~ msgid "Decrease size:"
-#~ msgstr "കാഴ്ചയുടെ വലിപ്പം കുറയ്ക്കുക"
-
-#, fuzzy
-#~ msgid "Increase size:"
-#~ msgstr "കാഴ്ചയുടെ വലിപ്പം കൂട്ടുക"
 
 #, fuzzy
 #~ msgid "Nomon"
@@ -8969,10 +9552,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "ഇതിലും വലിയ പാസ്‌വേറ്‍ഡ് തിരഞ്ഞെടുക്കുക"
 
 #, fuzzy
-#~ msgid "Account _type"
-#~ msgstr "ഗുമ്പല് (തരം 1)"
-
-#, fuzzy
 #~ msgid "More choices..."
 #~ msgstr "അനവധി തെരഞ്ഞെടുത്തിരിക്കുന്നു"
 
@@ -8987,16 +9566,25 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "കൂടുതല്‍ രംഗവിതാനങ്ങള്‍ക്കുള്ള യുആര്‍എല്‍"
 
 #~ msgid ""
-#~ "Set this to your current location name. This is used to determine the appropriate network proxy "
-#~ "configuration."
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
 #~ msgstr ""
-#~ "ഇതു് നിങ്ങളുടെ നിലവിലുള്ള സ്ഥാന പേരിലേക്ക് സജ്ജമാക്കുക. ശരിയായ നെറ്റ്‌വര്‍ക്ക് പ്രോക്സി ക്രമീകരണം കണ്ടുപിടിക്കന്നതിനായി ഇതുപയോഗിക്കുന്നു."
+#~ "ഇതു് നിങ്ങളുടെ നിലവിലുള്ള സ്ഥാന പേരിലേക്ക് സജ്ജമാക്കുക. ശരിയായ നെറ്റ്‌വര്‍ക്ക് പ്രോക്സി "
+#~ "ക്രമീകരണം കണ്ടുപിടിക്കന്നതിനായി ഇതുപയോഗിക്കുന്നു."
 
-#~ msgid "URL for where to get more desktop backgrounds. If set to an empty string the link will not appear."
-#~ msgstr "കൂടതല്‍ പണിയിട പശ്ചാതലങ്ങള്‍ ലഭ്യമാകുന്ന യുആര്‍എല്‍. ശൂന്യമായ സ്ട്രിങായി സജ്ജമാക്കിയാല്‍ ലിങ്ക് കാണുവാന്‍ സാധ്യമല്ല."
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "കൂടതല്‍ പണിയിട പശ്ചാതലങ്ങള്‍ ലഭ്യമാകുന്ന യുആര്‍എല്‍. ശൂന്യമായ സ്ട്രിങായി സജ്ജമാക്കിയാല്‍ ലിങ്ക് "
+#~ "കാണുവാന്‍ സാധ്യമല്ല."
 
-#~ msgid "URL for where to get more desktop themes. If set to an empty string the link will not appear."
-#~ msgstr "കൂടതല്‍ പണിയിട രംഗവിതാനങ്ങള്‍ ലഭ്യമാകുന്ന യുആര്‍എല്‍. ശൂന്യമായ സ്ട്രിങായി സജ്ജമാക്കിയാല്‍ ലിങ്ക് കാണുവാന്‍ സാധ്യമല്ല."
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "കൂടതല്‍ പണിയിട രംഗവിതാനങ്ങള്‍ ലഭ്യമാകുന്ന യുആര്‍എല്‍. ശൂന്യമായ സ്ട്രിങായി സജ്ജമാക്കിയാല്‍ ലിങ്ക് "
+#~ "കാണുവാന്‍ സാധ്യമല്ല."
 
 #~ msgid "Image/label border"
 #~ msgstr "ചിത്രത്തിന്റെ/കുറിപ്പിന്റെ അതിരു്"
@@ -9100,9 +9688,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Unable to open address book"
 #~ msgstr "മേല്‍വിലാസപുസ്തകം തുറക്കാനാവുന്നില്ല. "
-
-#~ msgid "About %s"
-#~ msgstr "%s-നെ പറ്റി"
 
 #~ msgid "A_IM/iChat:"
 #~ msgstr "എഐഎം/ഐചാറ്റ്:"
@@ -9218,21 +9803,25 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Click <b>Change password</b> to change your password."
 #~ msgstr "അടയാളവാക്ക് മാറ്റുന്നതിനായി <b>അടയാളവാക്ക് മാറ്റുക</b> എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
-#~ msgid "Please type your password again in the <b>Retype new password</b> field."
-#~ msgstr "ദയവായി <b>പുതിയ അടയാളവാക്ക് വീണ്ടും ടൈപ്പ് ചെയ്യുക</b> എന്ന കളത്തില്‍ നിങ്ങളുടെ അടയാളവാക്ക് വീണ്ടും നല്‍കുക."
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "ദയവായി <b>പുതിയ അടയാളവാക്ക് വീണ്ടും ടൈപ്പ് ചെയ്യുക</b> എന്ന കളത്തില്‍ നിങ്ങളുടെ "
+#~ "അടയാളവാക്ക് വീണ്ടും നല്‍കുക."
 
 #~ msgid "Change your password"
 #~ msgstr "നിങ്ങളുടെ അടയാളവാക്ക് മാറ്റുക"
 
 #~ msgid ""
-#~ "To change your password, enter your current password in the field below and click <b>Authenticate</b>.\n"
-#~ "After you have authenticated, enter your new password, retype it for verification and click <b>Change "
-#~ "password</b>."
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
 #~ msgstr ""
-#~ "നിങ്ങളുടെ അടയാളവാക്ക് മാറ്റുന്നതിനായി, താഴെയുളള കളത്തില്‍ നിലവിലുളള അടയാളവാക്ക് നല്‍കിയ ശേഷം, <b>ആധികാരികത ഉറപ്പ് വരുത്തല്‍</b> "
-#~ "ക്ലിക്ക് ചെയ്യുക.\n"
-#~ "നിങ്ങളുടെ ആധികാരികത ഉറപ്പു വരുത്തിയ ശേഷം, പുതിയ അടയാളവാക്ക് നല്‍കി, അത് വീണ്ടും ടൈപ്പ് ചെയ്ത് ഉറപ്പ് വരുത്തി <b>അടയാളവാക്ക് മാറ്റുക</"
-#~ "b> ക്ലിക്ക് ചെയ്യുക."
+#~ "നിങ്ങളുടെ അടയാളവാക്ക് മാറ്റുന്നതിനായി, താഴെയുളള കളത്തില്‍ നിലവിലുളള അടയാളവാക്ക് നല്‍കിയ "
+#~ "ശേഷം, <b>ആധികാരികത ഉറപ്പ് വരുത്തല്‍</b> ക്ലിക്ക് ചെയ്യുക.\n"
+#~ "നിങ്ങളുടെ ആധികാരികത ഉറപ്പു വരുത്തിയ ശേഷം, പുതിയ അടയാളവാക്ക് നല്‍കി, അത് വീണ്ടും ടൈപ്പ് "
+#~ "ചെയ്ത് ഉറപ്പ് വരുത്തി <b>അടയാളവാക്ക് മാറ്റുക</b> ക്ലിക്ക് ചെയ്യുക."
 
 #~ msgid "Accessible Lo_gin"
 #~ msgstr "സമീപിയ്ക്കാവുന്ന _കയറല്‍"
@@ -9243,7 +9832,9 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Assistive Technologies Preferences"
 #~ msgstr "സഹായകമായ സാങ്കേതികവിദ്യയുടെ മുന്‍ഗണനകള്‍"
 
-#~ msgid "Changes to enable assistive technologies will not take effect until your next log in."
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
 #~ msgstr "അടുത്ത ലോഗിനില്‍ മാത്രമേ ഈ ക്രമീകരണത്തില്‍ വരുത്തിയ മാറ്റങ്ങള്‍ പ്രവര്‍ത്തനസജ്ജമാകുകയുള്ളൂ."
 
 #~ msgid "Close and _Log Out"
@@ -9267,9 +9858,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "_Keyboard Accessibility"
 #~ msgstr "_കീബോര്‍ഡിന്റെ സാമീപ്യത"
 
-#~ msgid "_Mouse Accessibility"
-#~ msgstr "മൗസ്  _സാമീപ്യത"
-
 #~ msgid "_Preferred Applications"
 #~ msgstr "_മുന്‍ഗണനയുള്ള പ്രയോഗങ്ങള്‍"
 
@@ -9280,30 +9868,36 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "അക്ഷരസഞ്ചയം വളരെ വലുതായിരിയ്ക്കാം"
 
 #~ msgid ""
-#~ "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is "
-#~ "recommended that you select a size smaller than %d."
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
 #~ msgid_plural ""
-#~ "The font selected is %d points large, and may make it difficult to effectively use the computer. It is "
-#~ "recommended that you select a size smaller than %d."
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
 #~ msgstr[0] ""
-#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റ് വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. %d "
-#~ "നെക്കാള്‍ ചെറിയത് ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
+#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റ് വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി "
+#~ "ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. %d നെക്കാള്‍ ചെറിയത് ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
 #~ msgstr[1] ""
-#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റുകള്‍ വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. %d "
-#~ "നെക്കാളും ചെറിയത് ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
+#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റുകള്‍ വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ "
+#~ "കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. %d നെക്കാളും ചെറിയത് ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ "
+#~ "ചെയ്യുന്നു."
 
 #~ msgid ""
-#~ "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is "
-#~ "recommended that you select a smaller sized font."
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
 #~ msgid_plural ""
-#~ "The font selected is %d points large, and may make it difficult to effectively use the computer. It is "
-#~ "recommended that you select a smaller sized font."
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
 #~ msgstr[0] ""
-#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റ് വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. ചെറിയ "
-#~ "അക്ഷരസഞ്ചയം ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
+#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റ് വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി "
+#~ "ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. ചെറിയ അക്ഷരസഞ്ചയം ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
 #~ msgstr[1] ""
-#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റുകള്‍ വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. ചെറിയ "
-#~ "അക്ഷരസഞ്ചയം ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
+#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റുകള്‍ വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ "
+#~ "കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. ചെറിയ അക്ഷരസഞ്ചയം ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ "
+#~ "ചെയ്യുന്നു."
 
 #~ msgid "Use previous font"
 #~ msgstr "മുമ്പുളള അക്ഷരസഞ്ചയം ഉപയോഗിക്കുക"
@@ -9314,14 +9908,20 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Specify the filename of a theme to install"
 #~ msgstr "ഇന്‍സ്റ്റോള്‍ ചെയ്യുന്നതിന് രംഗവിതാന ഫയല്‍ തെരഞ്ഞെടുക്കുക"
 
-#~ msgid "Specify the name of the page to show (theme|background|fonts|interface)"
-#~ msgstr "കാണിക്കേണ്ട പേജിന്റെ പേര് നിശ്ചയിക്കുക(രംഗവിതാനം|പശ്ചാത്തലം|അക്ഷരസഞ്ചയങ്ങള്‍|വിനിമയതലം)"
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "കാണിക്കേണ്ട പേജിന്റെ പേര് നിശ്ചയിക്കുക(രംഗവിതാനം|പശ്ചാത്തലം|അക്ഷരസഞ്ചയങ്ങള്‍|വിനിമയതലം)"
 
 #~ msgid "[WALLPAPER...]"
 #~ msgstr "[പശ്ചാത്തലചിത്രം...]"
 
-#~ msgid "This theme will not look as intended because the required GTK+ theme engine '%s' is not installed."
-#~ msgstr "ആവശ്യമുല്ള GTK+ ഥീം എഞ്ചിന്‍ '%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "ആവശ്യമുല്ള GTK+ ഥീം എഞ്ചിന്‍ '%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ "
+#~ "ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
 
 #~ msgid "Apply Background"
 #~ msgstr "പശ്ചാത്തലം പ്രയോഗത്തില്‍വരുത്തുക"
@@ -9330,21 +9930,28 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "അക്ഷരസഞ്ചയം പ്രയോഗത്തില്‍വരുത്തുക"
 
 #~ msgid ""
-#~ "The current theme suggests a background and a font. Also, the last applied font suggestion can be reverted."
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
 #~ msgstr ""
-#~ "ഈ രംഗവിതാനം  ഒരു പശ്ചാത്തലവും അക്ഷരരൂപവും നിര്‍‌ദ്ദേശിയ്ക്കുന്നു. അവസാനം ഉപയോഗിക്കപ്പെട്ട അക്ഷരരൂപത്തിനെ കുറിച്ചുള്ള അഭിപ്രായം തിരിച്ച് "
-#~ "പഴയതു പോലെ ആക്കാവുന്നതാണ് "
+#~ "ഈ രംഗവിതാനം  ഒരു പശ്ചാത്തലവും അക്ഷരരൂപവും നിര്‍‌ദ്ദേശിയ്ക്കുന്നു. അവസാനം ഉപയോഗിക്കപ്പെട്ട "
+#~ "അക്ഷരരൂപത്തിനെ കുറിച്ചുള്ള അഭിപ്രായം തിരിച്ച് പഴയതു പോലെ ആക്കാവുന്നതാണ് "
 
-#~ msgid "The current theme suggests a background. Also, the last applied font suggestion can be reverted."
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
 #~ msgstr ""
-#~ "ഈ രംഗവിതാനം  ഒരു പശ്ചാത്തലവും അക്ഷരരൂപവും നിര്‍‌ദ്ദേശിയ്ക്കുന്നുഅവസാനം ഉപയോഗിക്കപ്പെട്ട അക്ഷരരൂപത്തിനെ കുറിച്ചുള്ള അഭിപ്രായം തിരിച്ച് "
-#~ "പഴയതു പോലെ ആക്കാവുന്നതാണ് "
+#~ "ഈ രംഗവിതാനം  ഒരു പശ്ചാത്തലവും അക്ഷരരൂപവും നിര്‍‌ദ്ദേശിയ്ക്കുന്നുഅവസാനം ഉപയോഗിക്കപ്പെട്ട "
+#~ "അക്ഷരരൂപത്തിനെ കുറിച്ചുള്ള അഭിപ്രായം തിരിച്ച് പഴയതു പോലെ ആക്കാവുന്നതാണ് "
 
 #~ msgid "The current theme suggests a background and a font."
 #~ msgstr "ഈ രംഗവിതാനം  ഒരു പശ്ചാത്തലവും അക്ഷരരൂപവും നിര്‍‌ദ്ദേശിയ്ക്കുന്നു:"
 
-#~ msgid "The current theme suggests a font. Also, the last applied font suggestion can be reverted."
-#~ msgstr "നിലവിലുള്ള പ്രമേയത്തിനു് ഒരു അക്ഷരസഞ്ചയം ആവശ്യമുണ്ടു്. കൂടാതെ, അക്ഷരസഞ്ചയത്തിനു് ഒടുവില്‍ നല്‍കിയ മാറ്റം മാറ്റുകയും ചെയ്യാം."
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "നിലവിലുള്ള പ്രമേയത്തിനു് ഒരു അക്ഷരസഞ്ചയം ആവശ്യമുണ്ടു്. കൂടാതെ, അക്ഷരസഞ്ചയത്തിനു് ഒടുവില്‍ നല്‍കിയ "
+#~ "മാറ്റം മാറ്റുകയും ചെയ്യാം."
 
 #~ msgid "The current theme suggests a background."
 #~ msgstr "ഈ രംഗവിതാനം ഒരു പശ്ചാത്തലം നിര്‍‌ദ്ദേശിയ്ക്കുന്നു:"
@@ -9366,9 +9973,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Changing your cursor theme takes effect the next time you log in."
 #~ msgstr "സൂചികയുടെ രംഗവിതാനം മാറ്റിയാല്‍ അടുത്ത തവണ അകത്ത് കയറുമ്പോഴേ അത് പ്രാവര്‍ത്തികമാവൂ."
-
-#~ msgid "Controls"
-#~ msgstr "നിയന്ത്രണങ്ങള്‍"
 
 #~ msgid "Customize Theme"
 #~ msgstr "രംഗവിതാനം ഇഷ്ടപ്പെട്ട രീതിയിലാക്കുക"
@@ -9460,9 +10064,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "സഹജമായ രീതിയിലേക്ക് _തിരികെ വയ്ക്കുക"
-
 #~ msgid "_Selected items:"
 #~ msgstr "_തെരഞ്ഞെടുത്തവ:"
 
@@ -9471,9 +10072,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "_Slight"
 #~ msgstr "_നേര്‍ത്ത"
-
-#~ msgid "_Style:"
-#~ msgstr "_രീതി:"
 
 #~ msgid "_Tooltips:"
 #~ msgstr "_സഹായസൂചികകള്‍:"
@@ -9541,8 +10139,12 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "\"%s\" does not appear to be a valid theme."
 #~ msgstr "\"%s\" ഒരു ശരിയായ പ്രമേയം അല്ല."
 
-#~ msgid "\"%s\" does not appear to be a valid theme. It may be a theme engine which you need to compile."
-#~ msgstr "\"%s\" ഒരു ശരിയായ പ്രമേയം അല്ല. ഇതു് ഒരു പക്ഷേ, കംപൈല്‍ ചെയ്യുവാനുള്ള ഒരു ഥീം എഞ്ചിന്‍ ആവാം."
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" ഒരു ശരിയായ പ്രമേയം അല്ല. ഇതു് ഒരു പക്ഷേ, കംപൈല്‍ ചെയ്യുവാനുള്ള ഒരു ഥീം എഞ്ചിന്‍ "
+#~ "ആവാം."
 
 #~ msgid "Installation for theme \"%s\" failed."
 #~ msgstr "\"%s\" എന്ന രംഗവിതാനം ഇന്‍സ്റ്റോള്‍ ചെയ്യാന്‍ സാധിച്ചില്ല"
@@ -9595,13 +10197,15 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid ""
 #~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
-#~ "Without the GNOME settings manager running, some preferences may not take effect. This could indicate a "
-#~ "problem with DBus, or a non-GNOME (e.g. KDE) settings manager may already be active and conflicting with "
-#~ "the GNOME settings manager."
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
 #~ msgstr ""
 #~ "'gnome-settings-daemon' ക്രമീകരണ മാനേജര്‍ തുടങ്ങാന്‍ കഴിഞ്ഞില്ല.\n"
-#~ "ഗ്നോം ക്രമീകരണ മാനേജര്‍ പ്രവര്‍ത്തിക്കാതെ ചില മുന്‍ഗണനകള്‍ പ്രാവര്‍ത്തികമാക്കാനാവില്ല. ഇത്  DBus അല്ലെങ്കില്‍ ഗ്നോമല്ലാത്ത (ഉദാഃ "
-#~ "കെഡിഇ)  ക്രമീകരണ മാനേജറോ ഇപ്പോള്‍ സജീവമാണെന്നോ ഗ്നോം ക്രമീകരണ മാനേജറുമായി ഇടഞ്ഞുനില്‍ക്കുകയാണെന്നോ കാണിക്കുന്നു."
+#~ "ഗ്നോം ക്രമീകരണ മാനേജര്‍ പ്രവര്‍ത്തിക്കാതെ ചില മുന്‍ഗണനകള്‍ പ്രാവര്‍ത്തികമാക്കാനാവില്ല. ഇത്  "
+#~ "DBus അല്ലെങ്കില്‍ ഗ്നോമല്ലാത്ത (ഉദാഃ കെഡിഇ)  ക്രമീകരണ മാനേജറോ ഇപ്പോള്‍ സജീവമാണെന്നോ "
+#~ "ഗ്നോം ക്രമീകരണ മാനേജറുമായി ഇടഞ്ഞുനില്‍ക്കുകയാണെന്നോ കാണിക്കുന്നു."
 
 #~ msgid "Unable to load stock icon '%s'\n"
 #~ msgstr "'%s' ശേഖരത്തിന്റെ പ്രതിരൂപം ലോഡ് ചെയ്യുവാന്‍ സാധ്യമായില്ല\n"
@@ -9611,9 +10215,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Copying file: %u of %u"
 #~ msgstr "ഫയല്‍ പകര്‍ത്തുന്നു: %2$u ലെ %1$u"
-
-#~ msgid "Parent Window"
-#~ msgstr "മാതൃജാലകം "
 
 #~ msgid "Parent window of the dialog"
 #~ msgstr "ജാലകത്തിന്റെ മാതൃജാലകം"
@@ -9646,7 +10247,8 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "ആകെ യുആര്‍ഐകളുടെ എണ്ണം"
 
 #~ msgid "File '%s' already exists. Do you want to overwrite it?"
-#~ msgstr "'%s' എന്ന ഫയല്‍ നേരത്തെ തന്നെ ഉണ്ട് . നിങ്ങള്‍ക്ക് അത് മാറ്റി ഇപ്പോള്‍ ഉള്ള ഫയല്‍ ആക്കണമോ ?"
+#~ msgstr ""
+#~ "'%s' എന്ന ഫയല്‍ നേരത്തെ തന്നെ ഉണ്ട് . നിങ്ങള്‍ക്ക് അത് മാറ്റി ഇപ്പോള്‍ ഉള്ള ഫയല്‍ ആക്കണമോ ?"
 
 #~ msgid "_Skip"
 #~ msgstr "_വേണ്ടെന്നുവയ്ക്കുക"
@@ -9663,20 +10265,32 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Issue this callback when the value associated with key gets changed"
 #~ msgstr "Issue this callback when the value associated with key gets changed"
 
-#~ msgid "GConf change set containing data to be forwarded to the gconf client on apply"
-#~ msgstr "GConf change set containing data to be forwarded to the gconf client on apply"
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
 
 #~ msgid "Conversion to widget callback"
 #~ msgstr "Conversion to widget callback"
 
-#~ msgid "Callback to be issued when data are to be converted from GConf to the widget"
-#~ msgstr "Callback to be issued when data are to be converted from GConf to the widget"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
 
 #~ msgid "Conversion from widget callback"
 #~ msgstr "Conversion from widget callback"
 
-#~ msgid "Callback to be issued when data are to be converted to GConf from the widget"
-#~ msgstr "Callback to be issued when data are to be converted to GConf from the widget"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
 
 #~ msgid "Object that controls the property (normally a widget)"
 #~ msgstr "Object that controls the property (normally a widget)"
@@ -9690,17 +10304,21 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Property editor data freeing callback"
 #~ msgstr "Property editor data freeing callback"
 
-#~ msgid "Callback to be issued when property editor object data is to be freed"
-#~ msgstr "Callback to be issued when property editor object data is to be freed"
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Callback to be issued when property editor object data is to be freed"
 
 #~ msgid ""
 #~ "Couldn't find the file '%s'.\n"
 #~ "\n"
-#~ "Please make sure it exists and try again, or choose a different background picture."
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
 #~ msgstr ""
 #~ "ഫയല്‍ '%s' ലഭ്യമല്ല.\n"
 #~ "\n"
-#~ "ദയവായി ഇതുണ്ടെന്ന് ഉറപ്പു വരുത്തിയ ശേഷം വീണ്ടും ശ്രമിയ്ക്കുക, അല്ലെങ്കില്‍ മറ്റൊരു ചിത്രം തെരഞ്ഞെടുക്കുക."
+#~ "ദയവായി ഇതുണ്ടെന്ന് ഉറപ്പു വരുത്തിയ ശേഷം വീണ്ടും ശ്രമിയ്ക്കുക, അല്ലെങ്കില്‍ മറ്റൊരു ചിത്രം "
+#~ "തെരഞ്ഞെടുക്കുക."
 
 #~ msgid ""
 #~ "I don't know how to open the file '%s'.\n"
@@ -9719,9 +10337,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Default Pointer - Current"
 #~ msgstr "സഹജമായ സൂചിക - നിലവിലുളള"
 
-#~ msgid "White Pointer"
-#~ msgstr "വെള്ള സൂചിക"
-
 #~ msgid "White Pointer - Current"
 #~ msgstr "വെള്ള സൂചിക - നിലവിലുളള"
 
@@ -9731,14 +10346,26 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Large White Pointer - Current"
 #~ msgstr "വലിയ വെള്ള സൂചിക - നിലവിലുളള"
 
-#~ msgid "This theme will not look as intended because the required GTK+ theme '%s' is not installed."
-#~ msgstr "ആവശ്യമുല്ള GTK+ ഥീം'%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "ആവശ്യമുല്ള GTK+ ഥീം'%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച "
+#~ "രീതിയില്‍ ലഭ്യമാകില്ല."
 
-#~ msgid "This theme will not look as intended because the required window manager theme '%s' is not installed."
-#~ msgstr "ആവശ്യമുല്ള വിന്‍ഡോ മാനേജര്‍ ഥീം'%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "ആവശ്യമുല്ള വിന്‍ഡോ മാനേജര്‍ ഥീം'%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ "
+#~ "ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
 
-#~ msgid "This theme will not look as intended because the required icon theme '%s' is not installed."
-#~ msgstr "ആവശ്യമുല്ള ഐക്കണ്‍ ഥീം'%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "ആവശ്യമുല്ള ഐക്കണ്‍ ഥീം'%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച "
+#~ "രീതിയില്‍ ലഭ്യമാകില്ല."
 
 #~ msgid "Preferred Applications"
 #~ msgstr "മുന്‍ഗണനാ പ്രയോഗങ്ങള്‍"
@@ -9752,7 +10379,8 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Could not load the main interface"
 #~ msgstr "പ്രധാനമായ വിനിമയതലം ലോഡ് ചെയ്യുവാന്‍ സാധ്യമായില്ല"
 
-#~ msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
 #~ msgstr "കാണിക്കേണ്ട പേജിന്റെ പേര് നിശ്ചയിക്കുക(internet|multimedia|system|a11y)"
 
 #~ msgid "All %s occurrences will be replaced with actual link"
@@ -9829,9 +10457,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "GNOME Magnifier without Screen Reader"
 #~ msgstr "സ്ക്രീന്‍ വായനക്കാരനില്ലാത്ത ഗ്നോം ഭൂതക്കണ്ണാടി"
-
-#~ msgid "GNOME Terminal"
-#~ msgstr "ഗ്നോം ടെര്‍മിനല്‍"
 
 #~ msgid "Gnopernicus"
 #~ msgstr "ഗ്നോപ്പര്‍നിക്കസ്"
@@ -9911,9 +10536,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "സില്‍ഫീഡ്-ക്ലോവ്സ്"
 
-#~ msgid "Thunderbird"
-#~ msgstr "തണ്ടര്‍ബേര്‍ഡ് "
-
 #~ msgid "Totem Movie Player"
 #~ msgstr "ടോട്ടം ചലച്ചിത്രദര്‍ശിനി"
 
@@ -9944,9 +10566,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Could not get session bus while applying display configuration"
 #~ msgstr "ഡിസ്പ്ലെ ക്രമീകരണം പ്രാഭല്യത്തിലാക്കുമ്പോള്‍ സെഷന്‍ ബസ് ലഭ്യമായില്ല"
 
-#~ msgid "Desktop"
-#~ msgstr "പണിയിടം"
-
 #~ msgid "Accelerator key"
 #~ msgstr "വേഗവ‌ര്‍ദ്ധിനി കീ"
 
@@ -9968,8 +10587,10 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Assign shortcut keys to commands"
 #~ msgstr "ആജ്ഞകള്‍ക്ക്  എളുപ്പകീകള്‍ നല്‍കുക"
 
-#~ msgid "Just apply settings and quit (compatibility only; now handled by daemon)"
-#~ msgstr "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
 
 #~ msgid "Start the page with the typing break settings showing"
 #~ msgstr "ടൈപ്പിങ്ങ് വിശ്രമവേള ക്രമീകരണം കാണിച്ച് കൊണ്ട് പേജ് തുടങ്ങുക."
@@ -10010,8 +10631,12 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Keyboard _model:"
 #~ msgstr "കീബോര്‍ഡിന്റെ _മാതൃക:"
 
-#~ msgid "Lock screen after a certain duration to help prevent repetitive keyboard use injuries"
-#~ msgstr "നിരന്തരമായ കീബോര്‍ഡ് ഉപയോഗം മൂലമുണ്ടാവുന്ന പരിക്കൊഴിവാക്കാന്‍ കുറച്ചു സമയത്തിനു ശേഷം സ്ക്രീന്‍ പൂട്ടുക "
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "നിരന്തരമായ കീബോര്‍ഡ് ഉപയോഗം മൂലമുണ്ടാവുന്ന പരിക്കൊഴിവാക്കാന്‍ കുറച്ചു സമയത്തിനു ശേഷം സ്ക്രീന്‍ "
+#~ "പൂട്ടുക "
 
 #~ msgid "_Break interval lasts:"
 #~ msgstr "വിശ്രമവേളയുടെ സമയ_പരിധി:"
@@ -10073,8 +10698,10 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Show click type _window"
 #~ msgstr "ക്ലിക്ക് തരത്തിലുള്ള _ജാലകം കാണിക്കുക"
 
-#~ msgid "You can also use the Dwell Click panel applet to choose the click type."
-#~ msgstr "ഏതു് തരത്തിലുള്ള ക്ലിക്ക് തെരഞ്ഞെടുക്കുന്നതിനായി നിങ്ങള്‍ക്കു് ഡ്വല്‍ ക്ലിക്ക് പാനല്‍ ഉപയോഗിക്കാം."
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr ""
+#~ "ഏതു് തരത്തിലുള്ള ക്ലിക്ക് തെരഞ്ഞെടുക്കുന്നതിനായി നിങ്ങള്‍ക്കു് ഡ്വല്‍ ക്ലിക്ക് പാനല്‍ ഉപയോഗിക്കാം."
 
 #~ msgid "_Single click:"
 #~ msgstr "ഒറ്റ ക്ളിക്ക്"
@@ -10142,9 +10769,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Set your window properties"
 #~ msgstr "നിങ്ങളുടെ ജാലകത്തിന്റെ വിശേഷതകള്‍ സജ്ജീകരിയ്ക്കുക"
 
-#~ msgid "Windows"
-#~ msgstr "ജാലകങ്ങള്"
-
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr "ജാലകത്തിന്റെ മാനേജര്‍ \"%s\" ക്രമീകരണത്തിനുളള പ്രയോഗം രജിസ്ടര്‍ ചെയ്തിട്ടില്ല\n"
 
@@ -10159,9 +10783,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Groups"
 #~ msgstr "കൂട്ടങ്ങള്‍:"
-
-#~ msgid "Common Tasks"
-#~ msgstr "സാധാരണയായുള്ള പ്രവര്‍ത്തികള്‍ "
 
 #~ msgid "Close the control-center when a task is activated"
 #~ msgstr "ഒരു കൃത്യം ആരംഭിച്ചാല്‍ നിയന്ത്രണകേന്ദ്രം അടക്കുക"
@@ -10178,37 +10799,48 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Exit shell on upgrade or uninstall action performed"
 #~ msgstr "നീക്കംചെയ്യലോ പുതുക്കലോ നടത്തുമ്പോള്‍ ഷെല്‍ അടയ്ക്കുക"
 
-#~ msgid "Indicates whether to close the shell when a help action is performed."
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
 #~ msgstr "സഹായകൃത്യം നടക്കുമ്പോള്‍ ഷെല്‍ അടയ്ക്കേണ്ടതുണ്ടോ എന്ന് കാണിക്കുന്നു."
 
-#~ msgid "Indicates whether to close the shell when a start action is performed."
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
 #~ msgstr "ആരംഭകൃത്യം നടക്കുമ്പോള്‍ ഷെല്‍ അടയ്ക്കേണ്ടതുണ്ടോ എന്ന് കാണിക്കുന്നു."
 
-#~ msgid "Indicates whether to close the shell when an add or remove action is performed."
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
 #~ msgstr "ചേര്‍ക്കലോ നീക്കം ചെയ്യലോ നടക്കുമ്പോള്‍ ഷെല്‍ അടയ്ക്കേണ്ടതുണ്ടോ എന്ന് കാണിക്കുന്നു."
 
-#~ msgid "Indicates whether to close the shell when an upgrade or uninstall action is performed."
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
 #~ msgstr "പുതുക്കുമ്പോളോ നീക്കം ചെയ്യുമ്പോളോ ഷെല്‍ അടയ്ക്കേണ്ടതുണ്ടോ എന്ന് കാണിക്കുന്നു."
 
 #~ msgid "Task names and associated .desktop files"
 #~ msgstr "കൃത്യനാമങ്ങളും ബന്ധപ്പെട്ട .desktop ഫയലുകളും"
 
 #~ msgid ""
-#~ "The task name to be displayed in the control-center followed by a \";\" separator then the filename of an "
-#~ "associated .desktop file to launch for that task."
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
 #~ msgstr ""
-#~ "നിയന്ത്രണകേന്ദ്രത്തില്‍ കാണിക്കേണ്ട പ്രവര്‍ത്തിയുടെ പേരു് , അതിനു ശേഷം വേര്‍തിരിക്കുന്ന ചിഹ്നമായ  \";\"  പിന്നെ ആ പ്രവര്‍ത്തിക്കു വേണ്ടി "
-#~ "തുടങ്ങേണ്ടുന്ന  .desktop ഫയലിന്റെ പേരു്."
+#~ "നിയന്ത്രണകേന്ദ്രത്തില്‍ കാണിക്കേണ്ട പ്രവര്‍ത്തിയുടെ പേരു് , അതിനു ശേഷം വേര്‍തിരിക്കുന്ന "
+#~ "ചിഹ്നമായ  \";\"  പിന്നെ ആ പ്രവര്‍ത്തിക്കു വേണ്ടി തുടങ്ങേണ്ടുന്ന  .desktop ഫയലിന്റെ പേരു്."
 
 #~ msgid ""
-#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-applications.desktop,Add "
-#~ "Printer;gnome-cups-manager.desktop]"
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
 #~ msgstr ""
-#~ "[രംഗവിതാനം മാറ്റുക;gnome-appearance-properties.desktop,മുന്‍ഗണനാ പ്രയോഗങ്ങള്‍ സജ്ജമാക്കുക;gnome-default-applications."
-#~ "desktop,പ്രിന്റര്‍ ചേര്‍ക്കുക;system-config-printer.desktop]"
+#~ "[രംഗവിതാനം മാറ്റുക;gnome-appearance-properties.desktop,മുന്‍ഗണനാ പ്രയോഗങ്ങള്‍ "
+#~ "സജ്ജമാക്കുക;gnome-default-applications.desktop,പ്രിന്റര്‍ ചേര്‍ക്കുക;system-config-"
+#~ "printer.desktop]"
 
-#~ msgid "if true, the control-center will close when a \"Common Task\" is activated."
-#~ msgstr "ശരി എന്നാണെങ്കില്‍ ഒരു \"സാധാരണ പ്രവര്‍ത്തി\" സജീവമായാല്‍ നിയന്ത്രണകേന്ദ്രം അടയ്ക്കും."
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "ശരി എന്നാണെങ്കില്‍ ഒരു \"സാധാരണ പ്രവര്‍ത്തി\" സജീവമായാല്‍ നിയന്ത്രണകേന്ദ്രം അടയ്ക്കും."
 
 #~ msgid "The GNOME configuration tool"
 #~ msgstr "ഗ്നോമിലെ ക്രമീകരണത്തിനുള്ള പണിയായുധം"
@@ -10227,7 +10859,9 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "Less than one minute until the next break"
 #~ msgstr "അടുത്ത വിശ്രമവേളയ്ക്ക് ഒരു മിനിട്ട് പോലുമില്ല"
 
-#~ msgid "Unable to bring up the typing break properties dialog with the following error: %s"
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
 #~ msgstr "ടൈപ്പിങ്ങ് വിശ്രമവേളാ ക്രമീകരണ ജാലകം തുറക്കുമ്പോള്‍ ഈ പിശക് പറ്റി: %s  "
 
 #~ msgid "Written by Richard Hult <richard@imendio.com>"
@@ -10253,12 +10887,14 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgstr "ടൈപ്പിങ് മോണിറ്റര്‍"
 
 #~ msgid ""
-#~ "The typing monitor uses the notification area to display information. You don't seem to have a "
-#~ "notification area on your panel. You can add it by right-clicking on your panel and choosing 'Add to "
-#~ "panel', selecting 'Notification area' and clicking 'Add'."
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
 #~ msgstr ""
-#~ "ടൈപ്പിങ്ങ് മേല്‍നോട്ടക്കാരന്‍ വിവരങ്ങള്‍ കാണിക്കാന്‍ അറിയിപ്പ് മേഖല ഉപയോഗിക്കുന്നു. നിങ്ങളുടെ പാനലില്‍ അറിയിപ്പ് മേഖല ഇല്ല. പാനലില്‍ "
-#~ "റൈറ്റ് ക്ലിക്ക് ചെയ്ത് അറിയിപ്പ് മേഖല പാനലിലേക്ക് ചേര്‍ക്കുക"
+#~ "ടൈപ്പിങ്ങ് മേല്‍നോട്ടക്കാരന്‍ വിവരങ്ങള്‍ കാണിക്കാന്‍ അറിയിപ്പ് മേഖല ഉപയോഗിക്കുന്നു. നിങ്ങളുടെ "
+#~ "പാനലില്‍ അറിയിപ്പ് മേഖല ഇല്ല. പാനലില്‍ റൈറ്റ് ക്ലിക്ക് ചെയ്ത് അറിയിപ്പ് മേഖല പാനലിലേക്ക് "
+#~ "ചേര്‍ക്കുക"
 
 #~ msgid "If set to true, then OpenType fonts will be thumbnailed."
 #~ msgstr "ഇതു് true ആണെങ്കില്‍, OpenType അക്ഷരസഞ്ചയങ്ങള്‍ക്കു് നഖചിത്ര ലഭ്യമാകുന്നു."
@@ -10272,16 +10908,21 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 #~ msgid "If set to true, then Type1 fonts will be thumbnailed."
 #~ msgstr "ഇതു് true ആണെങ്കില്‍, Type1 അക്ഷരസഞ്ചയങ്ങള്‍ക്കു് നഖചിത്ര ലഭ്യമാകുന്നു."
 
-#~ msgid "Set this key to the command used to create thumbnails for OpenType fonts."
-#~ msgstr "OpenType അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "OpenType അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
 
 #~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
 #~ msgstr "PCF അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
 
-#~ msgid "Set this key to the command used to create thumbnails for TrueType fonts."
-#~ msgstr "TrueType അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "TrueType അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
 
-#~ msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
 #~ msgstr "Type1 അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
 
 #~ msgid "Thumbnail command for OpenType fonts"
@@ -10367,15 +11008,6 @@ msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്�
 
 #~ msgid "Documents"
 #~ msgstr "രചനകള്‍"
-
-#~ msgid "<b>Open</b>"
-#~ msgstr "<b>തുറക്കുക</b>"
-
-#~ msgid "Rename..."
-#~ msgstr "പേരു മാറ്റുക."
-
-#~ msgid "Move to Trash"
-#~ msgstr "ചവറ്റുകുട്ടയിലേക്ക് മാറ്റുക"
 
 #~ msgid "If you delete an item, it is permanently lost."
 #~ msgstr "ഒരു വസ്തു വെട്ടിമാറ്റിയാല്‍, അതു് എന്നേക്കുമായി നഷ്ടമാകുന്നു."

--- a/po/ml.po~
+++ b/po/ml.po~
@@ -1,0 +1,10405 @@
+# translation of ml.po to
+# translation of gnome-control-center.master.ml.po to
+# translation of gnome-control-center.HEAD.ml.po to
+# This file is distributed under the same license as the gnome-control-center package.
+# Copyright (C) 2007-2008 gnome-control-center'S COPYRIGHT HOLDER.
+# FSF-India <locale@gnu.org.in>, 2003.
+# Santhosh|സന്തോഷ് Thottingal|തോട്ടിങ്ങല്‍ <santhosh00@gmail.com>, 2007.
+# Ani Peter <apeter@redhat.com>, 2007, 2009, 2012.
+# Anivar Aravind|അനിവര്‍ അരവിന്ദ് <anivar@movingrepublic.org>, 2007.
+# Ashik Salahudeen|ആഷിക് സലാഹുദ്ദീന്‍ <aashiks@gmail.com>, 2008.
+# Praveen|പ്രവീണ്‍ A|എ <pravi.a@gmail.com>, 2007, 2012.
+# Anish A <aneesh.nl@gmail.com>, 2013.
+# Jishnu Mohan <jishnu7@gmail.com>, 2013.
+# Balasankar C <c.balasankar@gmail.com>, 2013.
+# Navaneeth|നവനീത് <navaneeth@gnu.org>, 2014
+# Anish Sheela <aneesh.nl@gmail.com>, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: ml\n"
+"Report-Msgid-Bugs-To: https://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N"
+"+L10N&component=general\n"
+"POT-Creation-Date: 2017-08-19 14:32+0000\n"
+"PO-Revision-Date: 2017-08-20 23:21+0530\n"
+"Last-Translator: Anish Sheela <aneesh.nl@gmail.com>\n"
+"Language-Team: Swatantra Malayalam Computing <discuss@lists.smc.org.in>\n"
+"Language: ml\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.1\n"
+"X-Project-Style: gnome\n"
+
+#: ../panels/background/background.ui.h:1
+msgid "_Background"
+msgstr "പശ്ചാത്തലം (_B)"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "ദിനം മുഴുവന്‍ മാറിക്കൊണ്ടിരിക്കും"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "_Lock Screen"
+msgstr "പൂട്ടിയ സ്ക്രീന്‍ (_L)"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "ടൈല്‍"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "വലിപ്പം മാറ്റുക"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "മദ്ധ്യത്തില്‍"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "അളവു്"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "നിറക്കുക"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "സ്പാന്‍"
+
+#: ../panels/background/cc-background-chooser-dialog.c:430
+msgid "Wallpapers"
+msgstr "പശ്ചാത്തലചിത്രങ്ങള്‍"
+
+#: ../panels/background/cc-background-chooser-dialog.c:439
+msgid "Colors"
+msgstr "നിറങ്ങള്‍"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:476
+msgid "Select Background"
+msgstr "പശ്ചാത്തലം തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/background/cc-background-chooser-dialog.c:504
+msgid "Pictures"
+msgstr "ചിത്രങ്ങള്‍"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:536
+msgid "No Pictures Found"
+msgstr "ചിത്രങ്ങളൊന്നും കണ്ടില്ല"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:554 ../panels/search/cc-search-locations-dialog.c:302
+msgid "Home"
+msgstr "തട്ടകം"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:566
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "താങ്കൾക്ക് താങ്കളുടെ %s അറയിലേക്ക് ചിത്രങ്ങൾ ചേർക്കാം. അവ ഇവിടെ ദൃശ്യമാവുന്നതാണ്."
+
+#: ../panels/background/cc-background-chooser-dialog.c:573 ../panels/color/cc-color-panel.c:225
+#: ../panels/color/cc-color-panel.c:963 ../panels/color/color-calibrate.ui.h:2 ../panels/color/color.ui.h:30
+#: ../panels/common/language-chooser.ui.h:3 ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:181 ../panels/network/connection-editor/vpn-helpers.c:310
+#: ../panels/network/net-device-wifi.c:1318 ../panels/network/net-device-wifi.c:1398
+#: ../panels/network/net-device-wifi.c:1633 ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/new-printer-dialog.ui.h:3 ../panels/printers/pp-details-dialog.c:319
+#: ../panels/privacy/cc-privacy-panel.c:1049 ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2 ../panels/search/cc-search-locations-dialog.c:642
+#: ../panels/sharing/cc-sharing-panel.c:375 ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/join-dialog.ui.h:2 ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264 ../panels/user-accounts/um-photo-dialog.c:94
+#: ../panels/user-accounts/um-photo-dialog.c:221 ../panels/user-accounts/um-user-panel.c:644
+#: ../panels/user-accounts/um-user-panel.c:662
+msgid "_Cancel"
+msgstr "_റദ്ദാക്കുക"
+
+#: ../panels/background/cc-background-chooser-dialog.c:574
+msgid "_Select"
+msgstr "_തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/background/cc-background-item.c:203
+msgid "multiple sizes"
+msgstr "അനവധി വ്യാപ്തികള്‍"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:207
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:333
+msgid "No Desktop Background"
+msgstr "പണിയിട പശ്ചാത്തലം ലഭ്യമല്ല"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "നിലവിലുള്ള പശ്ചാതലം"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Back­ground"
+msgstr "പശ്ചാത്തലം"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:3
+msgid "Change your background image to a wallpaper or photo"
+msgstr "നിങ്ങളുടെ പശ്ചാത്തലചിത്രത്തെ ചുമർചിത്രമോ അല്ലെങ്കിൽ ചിത്രമോ ആയി മാറ്റുക"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:5
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "ചുമര്‍ചിത്രം;സ്ക്രീന്‍;പണിയിടം;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:268
+msgid "Turn Off Airplane Mode"
+msgstr "വിമാന മോഡ് മാറ്റുക"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:334
+msgid "No Bluetooth Found"
+msgstr "ബ്ലൂടൂത്ത് കണ്ടില്ല"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:334
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "ബ്ലുടൂത്ത് ഉപയോഗിക്കാന്‍ ഒരു ഡോങ്കിള്‍ കുത്തുക."
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:335
+msgid "Bluetooth Turned Off"
+msgstr "ബ്ലൂടൂത് പ്രവര്‍ത്തനരഹിതമാക്കി"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:335
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:336
+msgid "Airplane Mode is on"
+msgstr "വിമാന മോഡ് സജ്ജമാണ്"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:336
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "വിമാന മോഡില്‍ ബ്ലൂടൂത്ത് പ്രവര്‍ത്തന രഹിതമാക്കും."
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:337
+msgid "Hardware Airplane Mode is on"
+msgstr "ഹാര്‍ഡ്‍വെയര്‍ വിമാന മോഡ് സജ്ജമാണ്"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:337
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "ബ്ലൂടൂത്ത് സജ്ജമാക്കാന്‍ വിമാന മോഡ് സ്വിച്ച് ഓഫ് ചെയ്യുക"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Blue­tooth"
+msgstr "ബ്ലൂടൂത്ത്"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:3
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "ബ്ലുടൂത്ത് ഓണ്‍ ഓഫ് ആക്കിയതിനു ശേഷം ഉപകരണം കണക്ട് ചെയ്യുക"
+
+#. Translators: those are keywords for the bluetooth control-center panel
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:5
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "ക്രമീകരണ ഉപകരണം ചതുരത്തിന്റെ മുകളില്‍ വെച്ച് “തുടങ്ങുക” അമര്‍ത്തുക"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid "Move your calibration device to the calibrate position and press “Continue”"
+msgstr "നിങ്ങളുടെ ക്രമീകരണ ഉപകരണം ക്രമീകരിക്കാന്‍ സജ്ജമാക്കിയിട്ട് “തുടരുക” അമര്‍ത്തുക"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid "Move your calibration device to the surface position and press “Continue”"
+msgstr "നിങ്ങളുടെ ക്രമീകരണ ഉപകരണം ഉപരിതലം ആക്കിയിട്ട് “തുടരുക” അമര്‍ത്തുക"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "ലാപ്പ്ടോപ്പ് അടയ്ക്കു"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "വീണ്ടെടുക്കാനാകാത്ത ഒരു ആന്തരിക പിശകു് ഉണ്ടായിരിക്കുന്നു."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "ക്രമീകരണത്തിന് വേണ്ടിയുള്ള ഉപകരണങ്ങള്‍ സ്ഥാപിച്ചിട്ടില്ല."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "പ്രൊഫൈല്‍ ഉണ്ടാക്കാനായില്ല."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "തന്ന വെള്ളബിന്ദു ഇതില്‍ നിന്ന് കിട്ടില്ല."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "പൂർത്തിയായി!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "ക്രമീകരണം പരാജയപ്പെട്ടു!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "താങ്കള്‍ക്ക് ക്രമീകരണ ഉപകരണം മാറ്റാം."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "ചെയ്തുകൊണ്ടിരിക്കുമ്പോള്‍ ക്രമീകരണ ഉപകരണം മാറ്റരുത്"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "ലാപ്ടോപ്പ് സ്ക്രീന്‍"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "അടക്കം ചെയ്ത വെബ്ക്യാം"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s മോണിറ്റര്‍"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s സ്കാനര്‍"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s ക്യാമറ"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s അച്ചടിയന്ത്രം"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s വെബ്കാം"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s -ല്‍ നിറം കൈകാര്യം ചെയ്യുന്നത് പ്രവര്‍ത്തന സജ്ജമാക്കുക"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s -നുള്ള വര്‍ണ്ണ രൂപരേഖ കാണിക്കുക"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:323
+msgid "Not calibrated"
+msgstr "ഒത്തുനോക്കാത്തതു്"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:141
+msgid "Default: "
+msgstr "സഹജമായ: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:149
+msgid "Colorspace: "
+msgstr "കളര്‍സ്പേസ്:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:156
+msgid "Test profile: "
+msgstr "പരീക്ഷണ പ്രൊഫൈല്‍:"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:223
+msgid "Select ICC Profile File"
+msgstr "തുറക്കുന്നതിനായി ഐസിസി പ്രൊഫൈല്‍ ഫയല്‍ തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/color/cc-color-panel.c:226
+msgid "_Import"
+msgstr "ഇംപോര്‍ട്ട് ചെയ്യുക (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:237
+msgid "Supported ICC profiles"
+msgstr "പിന്തുണയുള്ള ഐസിസി പ്രൊഫൈലുകള്‍"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:244 ../panels/network/wireless-security/eap-method-fast.c:417
+msgid "All files"
+msgstr "എല്ലാ ഫയലുകളും"
+
+#: ../panels/color/cc-color-panel.c:583
+msgid "Screen"
+msgstr "സ്ക്രീന്‍"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:908
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "ഫയല്‍ കയറ്റുന്നതില്‍ പരാജയം: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:922
+msgid "The profile has been uploaded to:"
+msgstr "പ്രൊഫെൽ അപ്പ്‌ലോഡ് ചെയ്യപെട്ടു:"
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Write down this URL."
+msgstr "ഈ URL എഴുതുക."
+
+#: ../panels/color/cc-color-panel.c:925
+msgid "Restart this computer and boot your normal operating system."
+msgstr "നിങ്ങളുടെ കമ്പ്യൂട്ടർ ഒരു സാധാരണ ബൂട്ടിങ്ങിൽ വീണ്ടും തുടങ്ങുക"
+
+#: ../panels/color/cc-color-panel.c:926
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "പ്രൊഫെൽ ഇൻസ്റ്റാൾ ചെയ്യുന്നതിനായി ബ്രൊസറിൽ URL ടെപ്പ് ചെയ്യുക."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:960
+msgid "Save Profile"
+msgstr "പ്രൊഫൈല്‍ സൂക്ഷിക്കുക"
+
+#: ../panels/color/cc-color-panel.c:964 ../panels/network/connection-editor/vpn-helpers.c:311
+msgid "_Save"
+msgstr "സൂക്ഷിക്കുക (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1324
+msgid "Create a color profile for the selected device"
+msgstr "തെരഞ്ഞെടുത്ത ഡിവൈസിനു് നിറമുള്ളൊരു പ്രൊഫൈല്‍ തയ്യാറാക്കുക"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
+msgid "The measuring instrument is not detected. Please check it is turned on and correctly connected."
+msgstr "അളക്കുന്ന ഉപകരണം ലഭ്യമല്ല. ഇതു് ഓണ്‍ ആണെന്നും ശരിയായി കണക്ട് ചെയ്തിട്ടുണ്ടെന്നും ഉറപ്പാക്കുക."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1373
+msgid "The measuring instrument does not support printer profiling."
+msgstr "അളക്കുന്ന ഉപകരണം പ്രിന്റര്‍ ഡയലോഗ് പിന്തുണയ്ക്കുന്നില്ല."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1384
+msgid "The device type is not currently supported."
+msgstr "ഡിവൈസ് തരം ഇപ്പോള്‍ പിന്തുണയ്ക്കുന്നില്ല."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "മാനക സ്പേസ്"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "പരീക്ഷണ പ്രൊഫൈല്‍"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "സ്വയം"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "കുറഞ്ഞ നിലവാരം"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "സാമാന്യ നിലവാരം"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "ഉയര്‍ന്ന നിലവാരം"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "സഹജമായ RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "സഹജമായ CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "സ്വതേയുള്ള ഗ്രേ"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "കമ്പനി തന്ന ക്രമീകരണ വിവരം"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "ഈ പ്രൊഫൈല്‍ വെച്ച് മുഴുവന്‍ സ്ക്രീന്‍ ഡിസ്പ്ലേ ക്രമീകരണം പറ്റില്ല"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "ഈ പ്രൊഫൈല്‍ കൃത്യമല്ലായിരിക്കാം‌"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "ഡിസ്പ്ലേ ക്രമീകരണം"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "_Start"
+msgstr "തുടങ്ങുക (_S)"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "_Resume"
+msgstr "പുനരാരംഭിക്കുക (_R)"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8 ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "_കഴിഞ്ഞു"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "സ്ക്രീന്‍ കാലിബ്രേഷന്‍"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your screen. The longer you spend on "
+"calibration, the better the quality of the color profile."
+msgstr ""
+"നിങ്ങളുടെ സ്ക്രീനിന്റെ നിറം കൈകാര്യം ചെയ്യാനുള്ള ഒരു പ്രൊഫൈല്‍ ക്രമീകരണം ഉണ്ടാക്കും. എത്ര നേരം ക്രമീകരിക്കാന്‍ ചിലവാക്കുന്നോ, അത്രയും "
+"നല്ലതായിരിക്കും നിറത്തിന്റെ പ്രൊഫൈല്‍."
+
+#: ../panels/color/color.ui.h:3
+msgid "You will not be able to use your computer while calibration takes place."
+msgstr "ക്രമീകരണം നടക്കുന്ന സമയം കമ്പ്യൂട്ടര്‍ ഉപയോഗിക്കാന്‍ പറ്റില്ല."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "നിലവാരം"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "ഏകദേശ സമയം"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "കാലിബ്രേഷന്റെ ഗുണം"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ക്രമീകരണത്തിനുപയോഗിക്കേണ്ട സെന്‍സര്‍ തെരഞ്ഞെടുക്കുക."
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "ക്രമീകരണ ഉപകരണം"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "ബന്ധിപ്പിച്ചിരിക്കുന്ന ഡിസ്പ്ലേയുടെ തരം തെരഞ്ഞെടുക്കുക."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "പ്രദര്‍ശന രീതി"
+
+#: ../panels/color/color.ui.h:13
+msgid "Select a display target white point. Most displays should be calibrated to a D65 illuminant."
+msgstr "ഡിസ്പ്ലേയ്ക്ക് കിട്ടേണ്ട വെള്ള സൂചിക തെരഞ്ഞെടുക്കുക. മിക്ക ഡിസ്പ്ലേകളും D65 തെളിച്ചത്തിലാണ് ക്രമീകരിക്കുന്നത്."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "പ്രൊഫൈല്‍ വെള്ള സൂചിക"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color management will be most accurate at "
+"this brightness level."
+msgstr ""
+"താങ്കള്‍ക്ക് സൌകര്യമായ രീതിയിലേക്ക് ഡിസ്പ്ലേയുടെ തെളിച്ചം ക്രമീകരിക്കുക. നിറം ക്രമീകരണം ആ തെളിച്ചത്തിലായിരിക്കും ഏറ്റവും കൃത്യം."
+
+#: ../panels/color/color.ui.h:16
+msgid "Alternatively, you can use the brightness level used with one of the other profiles for this device."
+msgstr "അല്ലെങ്കില്‍, ഈ ഉപകരണത്തിനുവേണ്ട വേറേ ഏതെങ്കിലും പ്രൊഫൈലുകള്‍ ഉപയോഗിക്കാം."
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "ഡിസ്പ്ലേയുടെ തെളിച്ചം"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles for different lighting conditions."
+msgstr ""
+"താങ്കള്‍ക്ക് ഈ നിറ പ്രൊഫൈല്‍ പല കമ്പ്യൂട്ടറുകള്‍ക്ക് വേണ്ടി ഉപയോഗിക്കുകയോ, പല പ്രകാശ സാഹചര്യങ്ങള്‍ക്കുവേണ്ടി പ്രൊഫൈലുകള്‍ ഉണ്ടാക്കുകയോ ചെയ്യാം."
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "പ്രൊഫൈല്‍ നാമം:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "പ്രൊഫൈല്‍ നാമം"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "പ്രൊഫൈല്‍ വിജയകരമായി ഉണ്ടാക്കിയിരിക്കുന്നു!"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "പ്രൊഫൈല്‍ പക്‍ത്തുക"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "എഴുതാൻ കഴിയുന്ന ഒരു മാധ്യമം ആവശ്യം"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "പ്രൊഫൈല്‍ കയറ്റുക"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "ഇന്റര്‍നെറ്റ് ബന്ധം വേണം"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux\">GNU/Linux</a>, <a href=\"osx"
+"\">Apple OS X</a> and <a href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">ഗ്നു ലിനക്സ്</a>, <a href=\"osx\">ആപ്പിള്‍ ഒഎസ് എക്സ്</a> പിന്നെ <a href=\"windows\">മൈക്രോസോഫ്റ്റ് "
+"വിന്‍ഡോസ്</a> തുടങ്ങിയവയില്‍ എങ്ങനെ പ്രൊഫൈല്‍ ഉപയോഗിക്കണം എന്ന് അറിയുന്നത് നന്നായിരിക്കും."
+
+#: ../panels/color/color.ui.h:27 ../panels/user-accounts/um-fingerprint-dialog.c:723
+msgid "Summary"
+msgstr "രത്നച്ചുരുക്കം"
+
+#: ../panels/color/color.ui.h:28
+msgid "Add Profile"
+msgstr "പ്രൊഫൈല്‍ ചേര്‍ക്കുക"
+
+#: ../panels/color/color.ui.h:29
+msgid "_Import File…"
+msgstr "ഫയല്‍ ഇറക്കുക… (ഃഘ)"
+
+#: ../panels/color/color.ui.h:31 ../panels/network/connection-editor/net-connection-editor.c:519
+#: ../panels/printers/new-printer-dialog.ui.h:4 ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Add"
+msgstr "_ചേര്‍ക്കുക"
+
+#: ../panels/color/color.ui.h:32
+msgid "Problems detected. The profile may not work correctly. <a href=\"\">Show details.</a>"
+msgstr "പിഴവ് കണ്ടുപിടിച്ചു. പ്രൊഫൈല്‍ ശരിയായ രീതിയില്‍ പ്രവര്‍ത്തിക്കണമെന്നില്ല. <a href=\"\">കൂടുതല്‍ വിവരങ്ങള്‍.</a>"
+
+#: ../panels/color/color.ui.h:33
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "ഓരോ ഡിവൈസിനും കൈകാര്യം ചെയ്യുന്നതിനായി ഏറ്റവും പുതിയ നിറത്തിനുള്ള പ്രൊഫൈല്‍ ആവശ്യമുണ്ടു്."
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more"
+msgstr "കൂടുതല്‍ പഠിക്കുക"
+
+#: ../panels/color/color.ui.h:35
+msgid "Learn more about color management"
+msgstr "നിറം കൈകാര്യം ചെയ്യന്നതിനെപ്പറ്റി കൂടുതല്‍ അറിയുക"
+
+#: ../panels/color/color.ui.h:36
+msgid "_Set for all users"
+msgstr "എല്ലാ ഉപയോക്താക്കള്‍ക്കും സജ്ജമാക്കുക (_S)"
+
+#: ../panels/color/color.ui.h:37
+msgid "Set this profile for all users on this computer"
+msgstr "ഈ കമ്പ്യൂട്ടറിലുള്ള എല്ലാ ഉപയോക്താക്കള്‍ക്കും ഈ പ്രൊഫൈല്‍ സജ്ജമാക്കുക"
+
+#: ../panels/color/color.ui.h:38
+msgid "_Enable"
+msgstr "സജ്ജമാക്കുക (_E)"
+
+#: ../panels/color/color.ui.h:39
+msgid "_Add profile"
+msgstr "പ്രൊഫൈല്‍ ചേര്‍ക്കുക (_A)"
+
+#: ../panels/color/color.ui.h:40
+msgid "_Calibrate…"
+msgstr "ഒത്തുനോക്കുക… (_C)"
+
+#: ../panels/color/color.ui.h:41
+msgid "Calibrate the device"
+msgstr "ഉപകരണം ഒത്തുനോക്കുക"
+
+#: ../panels/color/color.ui.h:42
+msgid "_Remove profile"
+msgstr "ഈ പ്രൊഫൈല്‍ ഉപേക്ഷിക്കുക (_R)"
+
+#: ../panels/color/color.ui.h:43
+msgid "_View details"
+msgstr "വിശദവിവരങ്ങള്‍ കാണുക (_V)"
+
+#: ../panels/color/color.ui.h:44
+msgid "Unable to detect any devices that can be color managed"
+msgstr "നിറം ക്രമീകരിക്കാന്‍ പറ്റുന്ന ഉപകരണങ്ങളൊന്നും കണ്ടെത്താനായില്ല"
+
+#: ../panels/color/color.ui.h:45
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:46
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:47
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:48
+msgid "Projector"
+msgstr "പ്രൊജക്ടര്‍"
+
+#: ../panels/color/color.ui.h:49
+msgid "Plasma"
+msgstr "പ്ലാസ്മാ"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL backlight)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED backlight)"
+
+#: ../panels/color/color.ui.h:52
+msgid "LCD (white LED backlight)"
+msgstr "LCD (white LED backlight)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Wide gamut LCD (CCFL backlight)"
+
+#: ../panels/color/color.ui.h:54
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Wide gamut LCD (RGB LED backlight)"
+
+#: ../panels/color/color.ui.h:55
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "കൂടിയ"
+
+#: ../panels/color/color.ui.h:56
+msgid "40 minutes"
+msgstr "40 മിനിട്ടുകള്‍"
+
+#: ../panels/color/color.ui.h:57
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "ഇടത്തരം"
+
+#: ../panels/color/color.ui.h:58 ../panels/power/power.ui.h:2 ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 മിനിറ്റുകള്‍"
+
+#: ../panels/color/color.ui.h:59
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "കുറഞ്ഞ"
+
+#: ../panels/color/color.ui.h:60 ../panels/power/power.ui.h:1
+msgid "15 minutes"
+msgstr "15 മിനിട്ടുകള്‍"
+
+#: ../panels/color/color.ui.h:61
+msgid "Native to display"
+msgstr "ഡിസ്പ്ലേക്ക് സ്വതവേയുള്ള"
+
+#: ../panels/color/color.ui.h:62
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (അച്ചടിയും പ്രസിദ്ധീകരണങ്ങളും)"
+
+#: ../panels/color/color.ui.h:63
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:64
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (ഫോട്ടോയും ഗ്രാഫിക്സും)"
+
+#: ../panels/color/color.ui.h:65
+msgid "D75"
+msgstr "D75"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Co­lor"
+msgstr "നിറം"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:3
+msgid "Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "ക്യാമറ , പ്രിന്റ്റർ, ഡിസ്സ്പ്ലേ ഉപകരണങ്ങളുടെ നിറം കാലിബ്രേറ്റ് ചെയ്യുക"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:5
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Profile;Calibrate;Printer;Display;"
+
+#: ../panels/common/cc-common-language.c:323
+msgid "Other…"
+msgstr "മറ്റുളളവ…"
+
+#: ../panels/common/cc-language-chooser.c:124 ../panels/region/cc-format-chooser.c:269
+#: ../panels/region/cc-input-chooser.c:169
+msgid "More…"
+msgstr "കൂടുതൽ..."
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "ഒരു ഭാഷയും കണ്ടില്ല"
+
+#: ../panels/common/cc-util.c:127 ../panels/network/connection-editor/ce-page-details.c:106
+msgid "Today"
+msgstr "ഇന്നു്"
+
+#: ../panels/common/cc-util.c:131 ../panels/network/connection-editor/ce-page-details.c:108
+msgid "Yesterday"
+msgstr "ഇന്നലെ"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/common/language-chooser.ui.h:1
+msgid "Language"
+msgstr "ഭാഷ"
+
+#: ../panels/datetime/big.ui.h:1 ../panels/datetime/little.ui.h:1 ../panels/datetime/middle.ui.h:1
+#: ../panels/datetime/ydm.ui.h:1
+msgid "Day"
+msgstr "ദിവസം"
+
+#: ../panels/datetime/big.ui.h:2 ../panels/datetime/little.ui.h:2 ../panels/datetime/middle.ui.h:2
+#: ../panels/datetime/ydm.ui.h:2
+msgid "Month"
+msgstr "മാസം"
+
+#: ../panels/datetime/big.ui.h:3 ../panels/datetime/little.ui.h:3 ../panels/datetime/middle.ui.h:3
+#: ../panels/datetime/ydm.ui.h:3
+msgid "Year"
+msgstr "വര്‍ഷം"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:339
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:344
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:522
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:552
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:560
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:565
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:570
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:575
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "ജനുവരി"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "ഫെബ്രുവരി"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "മാര്‍ച്ച്"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "ഏപ്രില്‍"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "മേയ്"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "ജൂണ്‍"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "ജൂലൈ"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "ഓഗസ്റ്റ്"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "സെപ്റ്റംബര്‍"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "ഒക്റ്റോബര്‍"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "നവംബര്‍"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "ഡിസംബര്‍"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/datetime/datetime.ui.h:13 ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Date & Time"
+msgstr "തീയതിയും സമയവും"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "മണിക്കൂർ"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr ":"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "മിനിട്ട്"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Time Zone"
+msgstr "സമയ മേഘല"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Search for a city"
+msgstr "നഗരത്തിനായി തിരയുക"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Automatic _Date & Time"
+msgstr "തീയതിയും സമയവും സ്വയം കണ്ടെത്തുക"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Requires internet access"
+msgstr "ഇന്റര്‍നെറ്റ് ബന്ധം ആവശ്യമുണ്ട്"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Automatic Time _Zone"
+msgstr "സമയ മേഘല സ്വയം കണ്ടെത്തുക"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Date & _Time"
+msgstr "തീയതിയും സമയവും"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Time Z_one"
+msgstr "സമയ മേഘല (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Time _Format"
+msgstr "സമയ ശൈലികള്‍"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "24-hour"
+msgstr "24-മണിക്കൂര്‍"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "AM / PM"
+msgstr "AM/PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+msgid "Change the date and time, including time zone"
+msgstr "സമയം, തിയ്യതി, സമയമേഖലയടക്കം മാറ്റുക"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:5
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "സിസ്റ്റത്തിന്റെ സമയം, തീയതി മാറ്റുക"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "സമയം അല്ലെങ്കില്‍ തീയതി സജ്ജീകരണങ്ങള്‍ മാറ്റുന്നതിനായി, ആധികാരികത ഉറപ്പാക്കുക."
+
+#: ../panels/display/cc-display-panel.c:752
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "ലാന്‍ഡ്സ്കെയിപ്പ്"
+
+#: ../panels/display/cc-display-panel.c:755
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "പൊട്രെയിറ്റ് വലത്"
+
+#: ../panels/display/cc-display-panel.c:758
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "പൊട്രെയിറ്റ് ഇടത്"
+
+#: ../panels/display/cc-display-panel.c:761
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "തിരിഞ്ഞ ലാന്‍ഡ്സ്കേപ്"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/display/cc-display-panel.c:807 ../panels/display/cc-display-panel.c:857
+#: ../panels/printers/pp-options-dialog.c:558
+msgid "Orientation"
+msgstr "സംവേദനം"
+
+#: ../panels/display/cc-display-panel.c:904 ../panels/display/cc-display-panel.c:956
+#: ../panels/display/cc-display-panel.c:1721 ../panels/display/cc-display-panel.c:1767
+#: ../panels/printers/pp-options-dialog.c:87
+msgid "Resolution"
+msgstr "ദൃശ്യസൂക്ഷ്മത"
+
+#: ../panels/display/cc-display-panel.c:1001 ../panels/display/cc-display-panel.c:1072
+msgid "Refresh Rate"
+msgstr "പുതുക്കല്‍ ആവൃത്തി"
+
+#: ../panels/display/cc-display-panel.c:1198
+msgid "Scale"
+msgstr "വലിപ്പം മാറ്റുക"
+
+#: ../panels/display/cc-display-panel.c:1237
+msgid "Adjust for TV"
+msgstr "ടി.വി. യ്ക്ക് വേണ്ടി ശരിയാക്കുക"
+
+#: ../panels/display/cc-display-panel.c:1432 ../panels/display/cc-display-panel.c:1478
+msgid "Primary Display"
+msgstr "പ്രധാന ഡിസ്പ്ലേ"
+
+#: ../panels/display/cc-display-panel.c:1516
+msgid "Display Arrangement"
+msgstr "പ്രദര്‍ശന സജ്ജികരണം"
+
+#: ../panels/display/cc-display-panel.c:1517
+msgid "Drag displays to match your setup. The top bar is placed on the primary display."
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:1927
+msgid "Display Mode"
+msgstr "പ്രദര്‍ശന രീതി"
+
+#: ../panels/display/cc-display-panel.c:1939
+msgid "Join Displays"
+msgstr "പ്രദര്‍ശനങ്ങള്‍ ഒരുമിപ്പിക്കുക"
+
+#: ../panels/display/cc-display-panel.c:1942
+msgid "Mirror"
+msgstr "മിറര്‍"
+
+#: ../panels/display/cc-display-panel.c:1944
+msgid "Single Display"
+msgstr "ഒറ്റ പ്രദര്‍ശനം"
+
+#: ../panels/display/cc-display-panel.c:2733
+msgid "Apply Changes?"
+msgstr "മാറ്റങ്ങള്‍ സൂക്ഷിക്കട്ടെ?"
+
+#: ../panels/display/cc-display-panel.c:2737 ../panels/keyboard/cc-keyboard-panel.c:188
+#: ../panels/keyboard/shortcut-editor.ui.h:9 ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+msgid "Cancel"
+msgstr "റദ്ദാക്കുക"
+
+#: ../panels/display/cc-display-panel.c:2743
+msgid "Apply"
+msgstr "സൂക്ഷിക്കു"
+
+#: ../panels/display/cc-display-panel.c:3110
+#, c-format
+msgid "%.1lf Hz"
+msgstr "%.1lf Hz"
+
+#. TRANSLATORS: the state of the night light setting
+#: ../panels/display/cc-display-panel.c:3326 ../panels/notifications/cc-notifications-panel.c:293
+#: ../panels/power/cc-power-panel.c:1970 ../panels/power/cc-power-panel.c:1977
+#: ../panels/privacy/cc-privacy-panel.c:190 ../panels/privacy/cc-privacy-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:331 ../panels/universal-access/cc-ua-panel.c:712
+#: ../panels/universal-access/cc-ua-panel.c:725 ../panels/universal-access/cc-ua-panel.c:737
+#: ../panels/universal-access/cc-ua-panel.c:908
+msgid "On"
+msgstr "ഓണ്‍ "
+
+#: ../panels/display/cc-display-panel.c:3326 ../panels/network/net-proxy.c:54
+#: ../panels/notifications/cc-notifications-panel.c:293 ../panels/power/cc-power-panel.c:1964
+#: ../panels/power/cc-power-panel.c:1975 ../panels/privacy/cc-privacy-panel.c:190
+#: ../panels/privacy/cc-privacy-panel.c:257 ../panels/universal-access/cc-ua-panel.c:331
+#: ../panels/universal-access/cc-ua-panel.c:712 ../panels/universal-access/cc-ua-panel.c:725
+#: ../panels/universal-access/cc-ua-panel.c:737 ../panels/universal-access/cc-ua-panel.c:908
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Off"
+msgstr "ഓഫ്"
+
+#: ../panels/display/cc-display-panel.c:3347
+msgid "_Night Light"
+msgstr "രാത്രി വെളിച്ചം (_N)"
+
+#: ../panels/display/cc-display-panel.c:3454
+msgid "Could not get screen information"
+msgstr "സ്ക്രീന്‍ വിവരങ്ങള്‍ ലഭ്യമായില്ല"
+
+#. This cancels the redshift inhibit.
+#: ../panels/display/display.ui.h:2
+msgid "Restart Filter"
+msgstr "ഫില്‍റ്റര്‍ പുനരാരംഭിക്കുക"
+
+#. Inhibit the redshift functionality until the next day starts
+#: ../panels/display/display.ui.h:4
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "നാളെ വരെ തല്‍കാലം നിര്‍ത്തി"
+
+#: ../panels/display/display.ui.h:5
+msgid "Night light makes the screen color warmer. This can help to prevent eye strain and sleeplessness."
+msgstr "രാത്രി വെളിച്ചം സ്ക്രീന്‍ നിറത്തെ ചൂടാക്കി വെയ്കുന്നു. ഇത് കണ്ണിന്റെ ആയാസവും ഉറക്കമില്ലായ്മയും തടയാന്‍ സഹായിക്കുന്നു."
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: ../panels/display/display.ui.h:7
+msgid "Night Light"
+msgstr "രാത്രി വെളിച്ചം"
+
+#: ../panels/display/display.ui.h:8
+msgid "Schedule"
+msgstr "ആസൂത്രണം"
+
+#: ../panels/display/display.ui.h:9
+msgid "Sunset to Sunrise"
+msgstr "സൂര്യാസ്തമയം മുതല്‍ ഉദയം വരെ"
+
+#: ../panels/display/display.ui.h:10 ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:5 ../panels/network/net-proxy.c:56
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network-wifi.ui.h:26
+#: ../panels/privacy/cc-privacy-panel.c:217
+msgid "Manual"
+msgstr "മാനുവല്‍"
+
+#: ../panels/display/display.ui.h:11
+msgid "From"
+msgstr "നിന്നും"
+
+#: ../panels/display/display.ui.h:12
+msgid ":"
+msgstr ":"
+
+#. This is the short form for the time period in the morning
+#: ../panels/display/display.ui.h:14
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: ../panels/display/display.ui.h:16
+msgid "PM"
+msgstr "PM"
+
+#: ../panels/display/display.ui.h:17
+msgid "To"
+msgstr "വരെ"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Dis­plays"
+msgstr "പ്രദര്‍ശനങ്ങള്‍"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:3
+msgid "Choose how to use connected monitors and projectors"
+msgstr "മോണിറ്ററുകളും പ്രൊജക്ടറുകളും എങ്ങനെ ഉപയോഗിക്കണമെന്ന് തെരഞ്ഞെടുക്കുക"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:5
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;color;sunset;sunrise;"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-overview-panel.c:381 ../panels/info/cc-info-overview-panel.c:468
+#: ../panels/network/panel-common.c:123
+msgid "Unknown"
+msgstr "അപരിചിതം"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: ../panels/info/cc-info-overview-panel.c:476
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; Build ID: %s"
+
+#. translators: This is the type of architecture for the OS
+#: ../panels/info/cc-info-overview-panel.c:493
+#, c-format
+msgid "64-bit"
+msgstr "64-ബിറ്റ്"
+
+#. translators: This is the type of architecture for the OS
+#: ../panels/info/cc-info-overview-panel.c:496
+#, c-format
+msgid "32-bit"
+msgstr "32-ബീറ്റ്"
+
+#: ../panels/info/cc-info-overview-panel.c:800
+#, c-format
+msgid "Version %s"
+msgstr "പതിപ്പ് %s"
+
+#: ../panels/info/cc-info-panel.c:138
+msgid "Section"
+msgstr "വിഭാഗം"
+
+#: ../panels/info/cc-info-panel.c:147 ../panels/info/info.ui.h:1
+msgid "Overview"
+msgstr "അവലോകനം"
+
+#: ../panels/info/cc-info-panel.c:153 ../panels/info/info.ui.h:2
+msgid "Default Applications"
+msgstr "സഹജമായ പ്രയോഗങ്ങള്‍"
+
+#: ../panels/info/cc-info-panel.c:158 ../panels/info/info.ui.h:3
+msgid "Removable Media"
+msgstr "മാറ്റുവാന്‍ സാധ്യമാകുന്ന മീഡിയ"
+
+#: ../panels/info/cc-info-removable-media-panel.c:312
+msgid "Ask what to do"
+msgstr "എന്തു്  ചെയ്യണമെന്നു് ചോദിക്കുക"
+
+#: ../panels/info/cc-info-removable-media-panel.c:316
+msgid "Do nothing"
+msgstr "ഒരു പ്രവര്‍ത്തിയും ചെയ്യാതിരിക്കുക"
+
+#: ../panels/info/cc-info-removable-media-panel.c:320
+msgid "Open folder"
+msgstr "ഫോള്‍ഡര്‍ തുറക്കുക"
+
+#: ../panels/info/cc-info-removable-media-panel.c:411
+msgid "Other Media"
+msgstr "മറ്റു് മാധ്യമം"
+
+#: ../panels/info/cc-info-removable-media-panel.c:444
+msgid "Select an application for audio CDs"
+msgstr "പാട്ടു സി.ഡികള്‍ കേള്‍ക്കുന്നതിനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/info/cc-info-removable-media-panel.c:445
+msgid "Select an application for video DVDs"
+msgstr "വീഡിയോ സി.ഡികള്‍ കേള്‍ക്കുന്നതിനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/info/cc-info-removable-media-panel.c:446
+msgid "Select an application to run when a music player is connected"
+msgstr "ഒരു മ്യൂസിക് പ്ലേയര്‍ ഘടിപ്പിക്കുമ്പോള്‍ പ്രവര്‍ത്തിപ്പിയ്ക്കുവാനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/info/cc-info-removable-media-panel.c:447
+msgid "Select an application to run when a camera is connected"
+msgstr "ഒരു ക്യാമറാ ഘടിപ്പിക്കുമ്പോള്‍ പ്രവര്‍ത്തിപ്പിയ്ക്കുവാനുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/info/cc-info-removable-media-panel.c:448
+msgid "Select an application for software CDs"
+msgstr "സോഫ്റ്റ്‌വെയര്‍ സിഡികള്‍ക്കുള്ളൊരു പ്രയോഗം തെരഞ്ഞെടുക്കുക"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-removable-media-panel.c:460
+msgid "audio DVD"
+msgstr "ശബ്ദ ഡിവിഡി"
+
+#: ../panels/info/cc-info-removable-media-panel.c:461
+msgid "blank Blu-ray disc"
+msgstr "കാലിയായ ബ്ലൂ-റേ ഡിസ്ക്"
+
+#: ../panels/info/cc-info-removable-media-panel.c:462
+msgid "blank CD disc"
+msgstr "കാലിയായ സിഡി ഡിസ്ക്"
+
+#: ../panels/info/cc-info-removable-media-panel.c:463
+msgid "blank DVD disc"
+msgstr "കാലിയായ ഡിവിഡി ഡിസ്ക്"
+
+#: ../panels/info/cc-info-removable-media-panel.c:464
+msgid "blank HD DVD disc"
+msgstr "കാലിയായ എച്ച്ഡി ഡിവിഡി ഡിസ്ക്"
+
+#: ../panels/info/cc-info-removable-media-panel.c:465
+msgid "Blu-ray video disc"
+msgstr "ബ്ലൂ-റേ വിഡിയോ ഡിസ്ക്"
+
+#: ../panels/info/cc-info-removable-media-panel.c:466
+msgid "e-book reader"
+msgstr "ഇ-പുസ്തക റീഡര്‍"
+
+#: ../panels/info/cc-info-removable-media-panel.c:467
+msgid "HD DVD video disc"
+msgstr "എച്ച്ഡി ഡിവിഡി വീഡിയോ ഡിസ്ക്"
+
+#: ../panels/info/cc-info-removable-media-panel.c:468
+msgid "Picture CD"
+msgstr "ചിത്രങ്ങളുള്ള സിഡി"
+
+#: ../panels/info/cc-info-removable-media-panel.c:469
+msgid "Super Video CD"
+msgstr "സൂപ്പര്‍ വീഡിയോ സിഡി"
+
+#: ../panels/info/cc-info-removable-media-panel.c:470
+msgid "Video CD"
+msgstr "വീഡിയോ സിഡി"
+
+#: ../panels/info/cc-info-removable-media-panel.c:471
+msgid "Windows software"
+msgstr "വിന്‍ഡോസ് സോഫ്റ്റ്‌വെയര്‍"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:2
+msgid "Defa­ult Applications"
+msgstr "സഹജമായ പ്രയോഗങ്ങള്‍"
+
+#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:3
+msgid "Configure Default Applications"
+msgstr "സഹജമായ പ്രയോഗങ്ങള്‍ ക്രമീകരിക്കുക"
+
+#. Translators: those are keywords for the System Information panel
+#: ../panels/info/gnome-default-apps-panel.desktop.in.in.h:5
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:2
+msgid "Ab­out"
+msgstr "ഗ്നോം കണ്ട്രോള്‍ സെന്ററിനെ കുറിച്ച്"
+
+#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:3 ../panels/info/gnome-info-panel.desktop.in.in.h:3
+msgid "View information about your system"
+msgstr "നിങ്ങളുടെ സിസ്റ്റത്തിനെ കുറിച്ചുള്ള വിവരങ്ങൾ കാണുക."
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-overview-panel.desktop.in.in.h:5 ../panels/info/gnome-info-panel.desktop.in.in.h:5
+msgid ""
+"device;system;information;memory;processor;version;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "De­tails"
+msgstr "വിശദവിവരങ്ങള്‍"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:2
+msgid "Remo­vable Media"
+msgstr "മാറ്റുവാന്‍ സാധ്യമാകുന്ന മീഡിയ"
+
+#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:3
+msgid "Configure Removable Media settings"
+msgstr "മാറ്റാന്‍ സാധിക്കുന്ന മീഡിയയുടെ സജ്ജീകരണങ്ങള്‍ ക്രമീകരിക്കുക"
+
+#. Translators: those are keywords for the System Information panel
+#: ../panels/info/gnome-removable-media-panel.desktop.in.in.h:5
+msgid "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+
+#: ../panels/info/info-default-apps.ui.h:1
+msgid "_Web"
+msgstr "_വെബ്"
+
+#: ../panels/info/info-default-apps.ui.h:2
+msgid "_Mail"
+msgstr "_മെയില്‍"
+
+#: ../panels/info/info-default-apps.ui.h:3
+msgid "_Calendar"
+msgstr "_കലണ്ടര്‍"
+
+#: ../panels/info/info-default-apps.ui.h:4
+msgid "M_usic"
+msgstr "സം_ഗീതം"
+
+#: ../panels/info/info-default-apps.ui.h:5
+msgid "_Video"
+msgstr "_ചലചിത്രം"
+
+#: ../panels/info/info-default-apps.ui.h:6 ../panels/info/info-removable-media.ui.h:5
+msgid "_Photos"
+msgstr "_ചിത്രങ്ങള്‍"
+
+#: ../panels/info/info-overview.ui.h:1
+msgid "Device name"
+msgstr "ഉപകരണത്തിന്റെ പേരു്"
+
+#: ../panels/info/info-overview.ui.h:2
+msgid "Memory"
+msgstr "മെമ്മറി"
+
+#: ../panels/info/info-overview.ui.h:3
+msgid "Processor"
+msgstr "പ്രൊസസ്സര്‍"
+
+#: ../panels/info/info-overview.ui.h:4
+msgid "Graphics"
+msgstr "ഗ്രാഫിക്സ്"
+
+#. To translators: this field contains the distro name and version
+#: ../panels/info/info-overview.ui.h:6
+msgid "OS name"
+msgstr "ഒ.എസിന്റെ പേര്"
+
+#. To translators: this field contains the distro type
+#: ../panels/info/info-overview.ui.h:8
+msgid "OS type"
+msgstr "ഏത് തരം ഒഎസ്"
+
+#: ../panels/info/info-overview.ui.h:9
+msgid "Virtualization"
+msgstr "വിര്‍ച്ച്വലൈസേഷന്‍"
+
+#: ../panels/info/info-overview.ui.h:10
+msgid "Disk"
+msgstr "ഡിസ്ക്ക്"
+
+#: ../panels/info/info-overview.ui.h:11
+msgid "Calculating…"
+msgstr "കണക്കു കൂട്ടുന്നു…"
+
+#: ../panels/info/info-overview.ui.h:12
+msgid "Check for updates"
+msgstr "പരിഷ്കരണങ്ങള്‍ക്കായി നോക്കുന്നു"
+
+#: ../panels/info/info-removable-media.ui.h:1
+msgid "Select how media should be handled"
+msgstr "മീഡിയ എങ്ങനെ കൈകാര്യം ചെയ്യണമെന്നു് തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/info/info-removable-media.ui.h:2
+msgid "CD _audio"
+msgstr "ശ്ര_വണ സിഡി"
+
+#: ../panels/info/info-removable-media.ui.h:3
+msgid "_DVD video"
+msgstr "_ഡിവിഡി വീഡിയോ"
+
+#: ../panels/info/info-removable-media.ui.h:4
+msgid "_Music player"
+msgstr "_പാട്ടുപെട്ടി"
+
+#: ../panels/info/info-removable-media.ui.h:6
+msgid "_Software"
+msgstr "_സോഫ്റ്റവെയര്‍"
+
+#: ../panels/info/info-removable-media.ui.h:7
+msgid "_Other Media…"
+msgstr "_മറ്റു് മാധ്യമം…"
+
+#: ../panels/info/info-removable-media.ui.h:8
+msgid "_Never prompt or start programs on media insertion"
+msgstr "മാധ്യമം വയ്ക്കുമ്പോള്‍ _ഒരിയ്ക്കലും പ്രോഗ്രാമുകള്‍ തുടങ്ങുകയോ ഓര്‍മ്മപ്പെടുത്തുകയോ വേണ്ട"
+
+#: ../panels/info/info-removable-media.ui.h:9
+msgid "Select how other media should be handled"
+msgstr "മറ്റു് മീഡിയ എങ്ങനെ കൈകാര്യം ചെയ്യണമെന്നു് തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/info/info-removable-media.ui.h:10
+msgid "_Action:"
+msgstr "പ്ര_വര്‍ത്തി:"
+
+#: ../panels/info/info-removable-media.ui.h:11
+msgid "_Type:"
+msgstr "_തരം:"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "ശബ്ദവും മീഡിയയും"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "നിശ്ശബ്ദമാക്കുക"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "ശബ്ദം കുറയ്ക്കുക"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "ശബ്ദം കൂട്ടുക"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "ചലച്ചിത്രദര്‍ശിനി തുടങ്ങുക"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "പാടുക (പാടുക അല്ലെങ്കില്‍ തല്‍ക്കാലത്തേക്ക് നിര്‍ത്തുക)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "പ്ലേബാക്ക് താല്‍കാലികമായി നിര്‍ത്തുക"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "പ്ലേബാക്ക് നിര്‍ത്തുക"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "മുമ്പുളള ട്രാക്ക്"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "അടുത്ത ട്രാക്ക്"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "പുറന്തള്ളുക"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1 ../panels/universal-access/uap.ui.h:12
+msgid "Typing"
+msgstr "ടൈപ്പിങ്ങ്"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുക"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "മുമ്പുള്ള ശ്രോതസ്സിലേക്കു് മാറുക"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "ലഭ്യമാക്കുന്ന സംവിധാനങ്ങള്‍"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "സഹായകബ്രൌസര്‍ തുറക്കുക"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/alt/cc-window.c:1590 ../shell/cc-window.c:251
+#: ../shell/cc-window.c:794 ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/window.ui.h:1
+msgid "Settings"
+msgstr "സജ്ജീകരണങ്ങള്‍"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "കാല്‍ക്കുലേറ്റര്‍ തുടങ്ങുക"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "ഇ-മെയില്‍ ക്ലയന്റ് തുടങ്ങുക"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "വെബ് ബ്രൌസര്‍ തുറക്കുക"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "തട്ടകം"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "തെരച്ചില്‍"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "തിരചിത്രങ്ങള്‍"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "$PICTURES ലേക്ക് ഒരു സ്ക്രീന്‍ഷോട്ട് സൂക്ഷിയ്ക്കുക"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "$PICTURES ലേക്കു് ജാലകത്തിന്റെ ഒരു സ്ക്രീന്‍ഷോട്ട് സൂക്ഷിയ്ക്കുക"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "$PICTURES ലേക്കു് ഒരു സ്ഥലത്തിന്റെ സ്ക്രീന്‍ഷോട്ട് സൂക്ഷിയ്ക്കുക"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "ക്ലിപ്പ്ബോര്‍ഡിലേക്കു് ഒരു സ്ക്രീന്‍ഷോട്ട് പകര്‍ത്തുക"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "ക്ലിപ്പ്ബോര്‍ഡിലേക്കു് ജാലകത്തിന്റെ ഒരു സ്ക്രീന്‍ഷോട്ട് പകര്‍ത്തുക"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "ക്ലിപ്പ്ബോര്‍ഡിലേക്കു് ഒരു സ്ഥലത്തിന്റെ സ്ക്രീന്‍ഷോട്ട് പകര്‍ത്തുക"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "ഒരു ചെറിയ സ്ക്രീന്‍കാസ്റ്റ് രേഖപ്പെടുത്തുക"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "സിസ്റ്റം"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "പുറത്തു കടക്കുക"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "സ്ക്രീന്‍ പൂട്ടുക"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+msgid "Universal Access"
+msgstr "സാര്‍വ്വജനികലഭ്യത"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "വലിപ്പം കൂട്ടുക അല്ലെങ്കില്‍ കുറയ്ക്കുക"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "വലിപ്പം കൂട്ടുക"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "വലിപ്പം കുറക്കുക"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "സ്ക്രീന്‍ റീഡര്‍ ഓണ്‍ അല്ലെങ്കില്‍ ഓഫ് ചെയ്യുക"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "ഓണ്‍ സ്ക്രീന്‍ റീഡര്‍ ഓണ്‍ അല്ലെങ്കില്‍ ഓഫ് ചെയ്യുക"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "വാചകത്തിന്റെ വ്യാപ്തി കൂട്ടുക"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "വാചകത്തിന്റെ വ്യാപ്തി കുറയ്ക്കുക"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "ഹൈ കോണ്ട്രോസ്റ്റ് ഓണ്‍ അല്ലെങ്കില്‍ ഓഫ് ചെയ്യുക"
+
+#: ../panels/keyboard/cc-keyboard-manager.c:506 ../panels/keyboard/cc-keyboard-manager.c:514
+#: ../panels/keyboard/cc-keyboard-manager.c:822
+msgid "Custom Shortcuts"
+msgstr "നമ്മുടെ ഇഷ്ടത്തിനനുസരിച്ച് ഉണ്ടാക്കുന്ന എളുപ്പവഴികള്‍"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276 ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:435 ../panels/keyboard/shortcut-editor.ui.h:2
+#: ../panels/network/network-proxy.ui.h:4 ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1866 ../panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Disabled"
+msgstr "നിര്‍ജ്ജീവമാക്കിയ"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "മറ്റും ക്യാരക്ടര്‍ കീകള്‍"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "കംപോസ് കീ"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുവാനുള്ള മോഡിഫയര്‍ മാത്രമുള്ള സ്വിച്ച്"
+
+#: ../panels/keyboard/cc-keyboard-panel.c:181
+msgid "Reset All Shortcuts?"
+msgstr "എല്ലാ എളുപ്പവഴിയും പഴയപോലെ ആക്കട്ടെ?"
+
+#: ../panels/keyboard/cc-keyboard-panel.c:184
+msgid "Resetting the shortcuts may affect your custom shortcuts. This cannot be undone."
+msgstr "എല്ലാ എളുപ്പവഴിയും പഴയപോലെ ആക്കിയാല്‍ നിങ്ങള്‍ ക്രമീകരിച്ചതിനും മാറ്റം വരാം. ഇത് തിരിച്ച് ആക്കാന്‍ പറ്റില്ല."
+
+#: ../panels/keyboard/cc-keyboard-panel.c:189
+msgid "Reset All"
+msgstr "എല്ലാം പഴയപടി ആക്കുക"
+
+#: ../panels/keyboard/cc-keyboard-panel.c:281
+msgid "Reset the shortcut to its default value"
+msgstr "എളുപ്പവഴികളെ പഴയ പരുവത്തിലോട്ട് ആക്കുക"
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:427
+#, c-format
+msgid "%s is already being used for <b>%s</b>. If you replace it, %s will be disabled"
+msgstr ""
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:597
+msgid "Set Custom Shortcut"
+msgstr "സ്വന്തം എളുപ്പവഴി ഉണ്ടാക്കുക"
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:597
+msgid "Set Shortcut"
+msgstr "എളുപ്പവഴി ഉണ്ടാക്കുക"
+
+#. Setup the top label
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:606
+#, c-format
+msgid "Enter new shortcut to change <b>%s</b>."
+msgstr ""
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:1033
+msgid "Add Custom Shortcut"
+msgstr "ഒരു ഇഷ്ടാനുസൃത എളുപ്പവഴി ഉണ്ടാക്കുക"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "Key­board"
+msgstr "കീബോര്‍ഡ്"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:3
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "കീബോഡ് കുറുക്കുവഴികള്‍ കണ്ട് മാറുറുക; ടൈപ്പിങ്ങ് മുന്‍ഗണനകള്‍ മാറ്റുക"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:5
+msgid "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1 ../panels/region/input-options.ui.h:4
+#: ../shell/cc-application.c:251
+msgid "Keyboard Shortcuts"
+msgstr "കീബോര്‍ഡ് കുറക്കുവഴികള്‍"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "Reset All…"
+msgstr "എല്ലാം പഴയപോലെ ആക്കുക…"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "No keyboard shortcut found"
+msgstr "കീബോര്‍ഡ് എളുപ്പവഴിയൊന്നും കണ്ടില്ല"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5 ../shell/panel-list.ui.h:4
+msgid "Try a different search"
+msgstr "വേറേ തെരഞ്ഞ് നോക്കുക"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:1
+msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
+msgstr ""
+
+#: ../panels/keyboard/shortcut-editor.ui.h:3 ../panels/printers/details-dialog.ui.h:1
+#: ../panels/sound/gvc-mixer-dialog.c:1493 ../panels/sound/gvc-sound-theme-chooser.c:564
+msgid "Name"
+msgstr "പേര‍്"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:4
+msgid "Command"
+msgstr "ആജ്ഞ"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:5
+msgid "Shortcut"
+msgstr "എളുപ്പവഴി"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:6
+msgid "Set Shortcut…"
+msgstr "പുതിയ എളുപ്പവഴി…"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:7 ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "ഒന്നുമില്ല"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:8
+msgid "Enter the new shortcut"
+msgstr "പുതിയ എളുപ്പവഴി കൊടുക്കുക"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:10
+msgid "Remove"
+msgstr "നീക്കം ചെയ്യുക"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:11
+msgid "Add"
+msgstr "ചേര്‍ക്കുക"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:12
+msgid "Replace"
+msgstr "പകരംവെക്കുക"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:13
+msgid "Set"
+msgstr "തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/mouse/cc-mouse-panel.c:82 ../panels/wacom/cc-wacom-panel.c:402
+msgid "Test Your _Settings"
+msgstr "നിങ്ങളുടെ _സജ്ജീകരണങ്ങള്‍ പരീക്ഷിയ്ക്കുക"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Mouse & Touch­pad"
+msgstr "മൗസും ടച്ച്പാഡും"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:3
+msgid "Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "മൌസ് അല്ലെങ്കില്‍ ടച്ച്പാഡ് കൃത്യത മാറ്റുക പിന്നെ വലംകൈ/ഇടംകൈ തെരഞ്ഞെടുക്കുക"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:5
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "സാധാരണ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "Primary Button"
+msgstr "പ്രധാന ബട്ടണ്‍"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Left"
+msgstr "ഇടത്"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "Right"
+msgstr "വലത്"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Mouse"
+msgstr "മൌസ്"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Mouse Speed"
+msgstr "മൌസ് വേഗത"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "Double-click timeout"
+msgstr "ഇരട്ട ക്ലിക്കുകള്‍ക്കിടയില്‍ അനുവദനീയമായ സമയം"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "Natural Scrolling"
+msgstr "സ്വാഭാവികമായ സ്ക്രോളിങ്"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgid "Scrolling moves the content, not the view."
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgid "Touchpad"
+msgstr "ടച്ച്പാഡ്"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad Speed"
+msgstr "ടച്ച്പാഡ് വേഗത"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgid "Tap to Click"
+msgstr "ക്ലിക്ക് ചെയ്യുന്നതിനായി റ്റാപ്പ് ചെയ്യുക"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgid "Two-finger Scrolling"
+msgstr "രണ്ട് വിരല്‍ സ്ക്രോള്‍"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Edge Scrolling"
+msgstr "അരിക് സ്ക്രോളിങ്"
+
+#: ../panels/mouse/gnome-mouse-test.c:130 ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ക്ലിക്ക്, രണ്ടു് ക്ലിക്ക്, സ്ക്രോളിങ് എന്നിവ ശ്രമിയ്ക്കുക"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "അഞ്ച് ക്ലിക്കുകള്‍, ജിഇജിഎല്‍ സമയം!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "രണ്ടു് ക്ലിക്ക്, പ്രൈമറി ബട്ടണ്‍"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "ഒറ്റ ക്ലിക്ക്, പ്രൈമറി ബട്ടണ്‍"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "രണ്ടു് ക്ലിക്ക്, മദ്ധ്യ ബട്ടണ്‍"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "ഒറ്റ ക്ലിക്ക്, മദ്ധ്യ ബട്ടണ്‍"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "രണ്ടു് ക്ലിക്ക്, സെക്കന്‍ഡറി ബട്ടണ്‍"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "ഒറ്റ ക്ലിക്ക്, സെക്കന്‍ഡറി ബട്ടണ്‍"
+
+#. add proxy to device list
+#: ../panels/network/cc-network-panel.c:548
+msgid "Network proxy"
+msgstr "ശൃംഖലയിലെ പ്രോക്സി"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:684 ../panels/network/net-vpn.c:192 ../panels/network/net-vpn.c:321
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#: ../panels/network/cc-network-panel.c:748 ../panels/network/wifi.ui.h:7
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "ശോ, എന്തോ പറ്റി. നിങ്ങളുടെ സോഫ്റ്റ്‍വെയര്‍ വില്പനക്കാരുമായി ബന്ധപ്പെടുക."
+
+#: ../panels/network/cc-network-panel.c:754
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager പ്രവര്‍ത്തിക്കണം."
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/network/cc-wifi-panel.c:209 ../panels/network/gnome-wifi-panel.desktop.in.in.h:2
+#: ../panels/network/network-wifi.ui.h:58
+msgid "Wi-Fi"
+msgstr "വയര്‍ലസ്സ്"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1X _സുരക്ഷ"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2 ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "page 1"
+msgstr "താള്‍ 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+msgid "Anony_mous identity"
+msgstr "_അജ്ഞാത തിരിച്ചറിയല്‍"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "_ആന്തരിക ആധികാരികത ഉറപ്പാക്കല്‍"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5 ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "page 2"
+msgstr "താള്‍ 2 "
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:101
+#: ../panels/network/connection-editor/ce-page-security.c:445
+#: ../panels/network/connection-editor/details-page.ui.h:3 ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "സുരക്ഷ"
+
+#: ../panels/network/connection-editor/ce-page.c:481
+msgid "automatic"
+msgstr "തനിയെയുള്ള"
+
+#: ../panels/network/connection-editor/ce-page.c:521
+#, c-format
+msgid "Profile %d"
+msgstr "പ്രൊഫൈല്‍ %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56 ../panels/network/net-device-wifi.c:231
+#: ../panels/network/net-device-wifi.c:407
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60 ../panels/network/net-device-wifi.c:235
+#: ../panels/network/net-device-wifi.c:412 ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:64 ../panels/network/net-device-wifi.c:239
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:69 ../panels/network/net-device-wifi.c:244
+msgid "Enterprise"
+msgstr "എന്റര്‍പ്രൈസ്"
+
+#: ../panels/network/connection-editor/ce-page-details.c:74 ../panels/network/net-device-wifi.c:249
+#: ../panels/network/net-device-wifi.c:397
+msgctxt "Wifi security"
+msgid "None"
+msgstr "ഒന്നുമില്ല"
+
+#: ../panels/network/connection-editor/ce-page-details.c:95 ../panels/power/power.ui.h:17
+msgid "Never"
+msgstr "ഒരിക്കലുമില്ല"
+
+#: ../panels/network/connection-editor/ce-page-details.c:110 ../panels/network/net-device-ethernet.c:120
+#: ../panels/network/net-device-wifi.c:505
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i ദിവസം മുമ്പു്"
+msgstr[1] "%i ദിവസങ്ങള്‍ മുമ്പു്"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:176 ../panels/network/net-device-ethernet.c:50
+#: ../panels/network/net-device-wifi.c:561
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:202 ../panels/network/net-device-wifi.c:590
+msgctxt "Signal strength"
+msgid "None"
+msgstr "ഒന്നുമില്ല"
+
+#: ../panels/network/connection-editor/ce-page-details.c:204 ../panels/network/net-device-wifi.c:592
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "പോര"
+
+#: ../panels/network/connection-editor/ce-page-details.c:206 ../panels/network/net-device-wifi.c:594
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ശരി"
+
+#: ../panels/network/connection-editor/ce-page-details.c:208 ../panels/network/net-device-wifi.c:596
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "നല്ലത്"
+
+#: ../panels/network/connection-editor/ce-page-details.c:210 ../panels/network/net-device-wifi.c:598
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "അത്യുത്തമം"
+
+#: ../panels/network/connection-editor/ce-page-details.c:248
+msgid "Forget Connection"
+msgstr "കണക്ഷന്‍ മറക്കു"
+
+#: ../panels/network/connection-editor/ce-page-details.c:250
+msgid "Remove Connection Profile"
+msgstr "കണക്ഷന്‍ പ്രൊഫൈല്‍ കളയു"
+
+#: ../panels/network/connection-editor/ce-page-details.c:252
+msgid "Remove VPN"
+msgstr "VPN നീക്കം ചെയ്യുക"
+
+#: ../panels/network/connection-editor/ce-page-details.c:280 ../panels/network/network-wifi.ui.h:46
+#: ../shell/cc-window.c:243 ../shell/panel-list.ui.h:2
+msgid "Details"
+msgstr "വിശദവിവരങ്ങള്‍"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:173
+#: ../panels/network/connection-editor/ce-page-vpn.c:188 ../panels/network/connection-editor/ce-page-wifi.c:194
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "തിരിച്ചറിയല്‍"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:251 ../panels/network/connection-editor/ce-page-ip6.c:230
+msgid "Delete Address"
+msgstr "വിലാസം നീക്കം ചെയ്യുക"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:422 ../panels/network/connection-editor/ce-page-ip6.c:390
+msgid "Delete Route"
+msgstr "റൂട്ട് നീക്കം ചെയ്യുക"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:896 ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:827 ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-security.c:245
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "ഒന്നുമില്ല"
+
+#: ../panels/network/connection-editor/ce-page-security.c:268
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "ഡബ്ലിയുഇപി 40/128-bit കീ (ഹെക്സോ ആസ്കിയോ)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:278
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit പാസ്‌ഫ്രെയിസ്"
+
+#: ../panels/network/connection-editor/ce-page-security.c:291
+#: ../panels/network/wireless-security/wireless-security.c:465
+msgid "LEAP"
+msgstr "എല്‍ഇഎപി"
+
+#: ../panels/network/connection-editor/ce-page-security.c:304
+msgid "Dynamic WEP (802.1x)"
+msgstr "ഡൈനമിക് WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:318
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 പേഴ്സണല്‍"
+
+#: ../panels/network/connection-editor/ce-page-security.c:332
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 എന്റര്‍പ്രൈസ്"
+
+#: ../panels/network/connection-editor/connection-editor.ui.h:2 ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "_കംപ്യൂട്ടറില്‍ സൂക്ഷിക്കുക"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1 ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr "സിഗ്നലിന്‍റെ കരുത്ത്"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2 ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "ലിങ്കിന്റെ വേഗത"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4 ../panels/network/net-device-ethernet.c:153
+#: ../panels/network/network-simple.ui.h:3 ../panels/network/network-wifi.ui.h:7
+#: ../panels/network/panel-common.c:644
+msgid "IPv4 Address"
+msgstr "IPv4 വിലാസം"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5 ../panels/network/net-device-ethernet.c:154
+#: ../panels/network/net-device-ethernet.c:158 ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4 ../panels/network/network-wifi.ui.h:8
+#: ../panels/network/panel-common.c:645
+msgid "IPv6 Address"
+msgstr "IPv6 വിലാസം"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6 ../panels/network/net-device-ethernet.c:161
+#: ../panels/network/network-simple.ui.h:2 ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "ഹാഡ്​വെയര്‍ വിലാസം"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7 ../panels/network/net-device-ethernet.c:165
+#: ../panels/network/network-mobile.ui.h:5 ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "സ്വതവേയുള്ള റൂട്ട്"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8 ../panels/network/connection-editor/ip4-page.ui.h:10
+#: ../panels/network/connection-editor/ip6-page.ui.h:11 ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-mobile.ui.h:6 ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "അവസാനം ഉപയോഗിച്ചതു്"
+
+#: ../panels/network/connection-editor/details-page.ui.h:10
+msgid "Connect _automatically"
+msgstr "_സ്വയം ബന്ധിപ്പിക്കുക"
+
+#: ../panels/network/connection-editor/details-page.ui.h:11
+msgid "Make available to _other users"
+msgstr "മറ്റുള്ള _ഉപയോക്താക്കള്‍ക്ക് ലഭ്യമാക്കുക"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1 ../panels/network/connection-editor/ip4-page.ui.h:11
+#: ../panels/network/connection-editor/ip6-page.ui.h:2 ../panels/network/net-proxy.c:58
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/privacy/cc-privacy-panel.c:217
+msgid "Automatic"
+msgstr "തനിയെയുള്ള"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "ട്വിസ്റ്റഡ് പെയര്‍ (ടിപി)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "അറ്റാച്ച്മെന്റ് യൂണിറ്റ് ഇന്റര്‍ഫേസ് (എയുഐ)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "ബിഎന്‍സി"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "മീഡിയ ഇന്‍ഡിപെന്‍ഡന്റ് ഇന്റര്‍ഫേസ് (എംഐഐ)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10 ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "_പേര്"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4 ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "_MAC വിലാസം"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "_പകര്‍ത്തിയ വിലാസം"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "ബൈറ്റുകള്‍"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+msgid "IPv_4 Method"
+msgstr "IPv_4 സംവിധാനം"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2 ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "ഓട്ടോമാറ്റിക് (DHCP)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:3 ../panels/network/connection-editor/ip6-page.ui.h:4
+msgid "Link-Local Only"
+msgstr "ലിങ്ക്-ലോക്കല്‍ മാത്രം"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5 ../panels/network/connection-editor/ip6-page.ui.h:6
+msgid "Disable"
+msgstr "നിര്‍ജ്ജീവമാക്കിയ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6 ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Addresses"
+msgstr "വിലാസങ്ങള്‍"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7 ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/printers/details-dialog.ui.h:3
+msgid "Address"
+msgstr "വിലാസം"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+msgid "Netmask"
+msgstr "നെറ്റ്മാസ്ക്"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:9 ../panels/network/connection-editor/ip6-page.ui.h:10
+msgid "Gateway"
+msgstr "ഗേറ്റ്‌വേ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:12 ../panels/network/connection-editor/ip6-page.ui.h:12
+msgid "Automatic DNS"
+msgstr "സ്വതവേയുള്ള ഡിഎന്‍എസ്"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:13 ../panels/network/connection-editor/ip6-page.ui.h:13
+msgid "Separate IP addresses with commas"
+msgstr "ഐപി വിലാസങ്ങള്‍ കോമ കൊണ്ട് തിരിക്കുക"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:14 ../panels/network/connection-editor/ip6-page.ui.h:14
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "റൂട്ടുകള്‍"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:15 ../panels/network/connection-editor/ip6-page.ui.h:15
+msgid "Automatic Routes"
+msgstr "സ്വതവേയുള്ള റൂട്ട്"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ip4-page.ui.h:17 ../panels/network/connection-editor/ip6-page.ui.h:17
+msgid "Metric"
+msgstr "മെട്രിക്"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:18 ../panels/network/connection-editor/ip6-page.ui.h:18
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr "ഈ _ബന്ധത്തിന്റെ ശൃംഖലയിലുള്ള വസ്തുക്കള്‍ക്കു് മാത്രം ഉപയോഗിയ്ക്കുക"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+msgid "IPv_6 Method"
+msgstr "IPv_6 സംവിധാനം"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+msgid "Automatic, DHCP only"
+msgstr "ഓട്ടോമാറ്റിക്, DHCP മാത്രം"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:9
+msgid "Prefix"
+msgstr "പ്രിഫിക്സ്"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:273
+msgid "Unable to open connection editor"
+msgstr "ബന്ധ എഡിറ്റര്‍ തുറക്കാനാകുന്നില്ല"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:291
+msgid "New Profile"
+msgstr "പുതിയ പ്രൊഫൈല്‍"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:603 ../panels/network/network.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:751
+msgid "Import from file…"
+msgstr "ഫയലില്‍ നിന്നും ഇംപോര്‍ട്ട് ചെയ്യുക…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:785
+msgid "Add VPN"
+msgstr "VPN ചേര്‍ക്കു"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1 ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "_സുരക്ഷ"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:141
+msgid "Cannot import VPN connection"
+msgstr "വിപിഎന്‍ ബന്ധം ഇംപോര്‍ട്ട് ചെയ്യുവാന്‍ സാധ്യമല്ല"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:143
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"ഫയല്‍ “%s” വായിക്കാന്‍ പറ്റുന്നില്ല, അല്ലെങ്കില്‍ അതില്‍ തിരിച്ചറിയാനാകുന്ന VPN ബന്ധങ്ങളുടെ വിവരം ഇല്ല\n"
+"\n"
+"പിഴവ്: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:178
+msgid "Select file to import"
+msgstr "ഇംപോര്‍ട്ട് ചെയ്യുന്നതിനുള്ള ഫയല്‍ തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:182 ../panels/printers/pp-details-dialog.c:320
+#: ../panels/sharing/cc-sharing-panel.c:376 ../panels/user-accounts/um-photo-dialog.c:222
+msgid "_Open"
+msgstr "തുറക്കുക (_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:230
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "“%s” എന്ന പേരില്‍ ഒരു ഫയല്‍ നിലവിലുണ്ടു്."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:232
+msgid "_Replace"
+msgstr "_പകരംവെക്കുക"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:234
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "നിങ്ങള്‍ സൂക്ഷിച്ചുകൊണ്ടിരിക്കുന്ന വിപിഎന്‍ ബന്ധംഉപയോഗിച്ചു് %s മാറ്റണമോ?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:270
+msgid "Cannot export VPN connection"
+msgstr "വിപിഎന്‍ ബന്ധം എക്സ്പോര്‍ട്ട് ചെയ്യുവാന്‍ സാധിച്ചില്ല"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:272
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN ബന്ധം “%s” %s ലേക്ക് കയറ്റുമതി ചെയ്യാനാകുന്നില്ല.\n"
+"\n"
+"പിഴവ്: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:307
+msgid "Export VPN connection"
+msgstr "വിപിഎന്‍ ബന്ധം എക്സ്പോര്‍ട്ട് ചെയ്യുക"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(പിഴവ്: VPN ബന്ധം എഡിറ്റര്‍ ലഭ്യമാക്കാനയില്ല)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1 ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2 ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3 ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "എന്റെ ഹോം ശൃംഖല"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Net­work"
+msgstr "ശൃംഖല"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:3
+msgid "Control how you connect to the Internet"
+msgstr "ഇന്റെര്‍നെറ്റില്‍ ബന്ധിപ്പിക്കുന്നതെങ്ങനെയെന്ന് തീരുമാനിക്കുന്നു"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:5
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+
+#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:3
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "വൈഫൈ ശ്രംഖലകളില്‍ ബന്ധിപ്പിക്കുന്നതെങ്ങനെയെന്ന് തീരുമാനിക്കുന്നു"
+
+#. Translators: those are keywords for the wi-fi control-center panel
+#: ../panels/network/gnome-wifi-panel.desktop.in.in.h:5
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+
+#: ../panels/network/net-device-ethernet.c:106 ../panels/network/net-device-wifi.c:491
+msgid "never"
+msgstr "ഒരിക്കലുമില്ല"
+
+#: ../panels/network/net-device-ethernet.c:116 ../panels/network/net-device-wifi.c:501
+msgid "today"
+msgstr "ഇന്നു്"
+
+#: ../panels/network/net-device-ethernet.c:118 ../panels/network/net-device-wifi.c:503
+msgid "yesterday"
+msgstr "ഇന്നലെ"
+
+#: ../panels/network/net-device-ethernet.c:156 ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:647 ../panels/network/panel-common.c:649
+msgid "IP Address"
+msgstr "IP വിലാസം"
+
+#: ../panels/network/net-device-ethernet.c:172 ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "അവസാനം ഉപയോഗിച്ചതു്"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:275 ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "വയര്‍ഡ്"
+
+#: ../panels/network/net-device-ethernet.c:343 ../panels/network/net-device-wifi.c:1792
+#: ../panels/network/network-ethernet.ui.h:2 ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8 ../panels/network/network-vpn.ui.h:2
+msgid "Options…"
+msgstr "ഐച്ഛികങ്ങള്‍…"
+
+#: ../panels/network/net-device-mobile.c:238
+msgid "Add new connection"
+msgstr "പുതിയൊരു കണക്ഷന്‍ ചേര്‍ക്കുക"
+
+#: ../panels/network/net-device-wifi.c:1275
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട് സ്വിച്ച് ഓണ്‍ ചെയ്യുന്നതു്,  <b>%s</b>-ല്‍ നിന്നും നിങ്ങളെ വിഛേദിയ്ക്കുന്നു."
+
+#: ../panels/network/net-device-wifi.c:1279
+msgid "It is not possible to access the Internet through your wireless while the hotspot is active."
+msgstr "ഹോട്ട്സ്പോട്ട് സജീവമാകുമ്പോള്‍ വയര്‍ലെസ്സ് മുഖേനയുള്ള ഇന്റര്‍നെറ്റ് നിങ്ങള്‍ക്കു്ലഭ്യമാകുന്നതല്ല."
+
+#: ../panels/network/net-device-wifi.c:1286
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട് സജ്ജമാക്കട്ടെ?"
+
+#: ../panels/network/net-device-wifi.c:1308
+msgid "Wi-Fi hotspots are usually used to share an additional Internet connection over Wi-Fi."
+msgstr "വൈ-ഫൈ വഴി ഇന്റെര്‍നെറ്റ് ബന്ധം പങ്കിടാന്‍ ആണ് സാധാരണ വൈ-ഫൈ ഹോട്ട്സ്പോട്ട് ഉപയോഗിക്കുന്നത്."
+
+#: ../panels/network/net-device-wifi.c:1319
+msgid "_Turn On"
+msgstr "_ഓണ്‍ ചെയ്യുക"
+
+#: ../panels/network/net-device-wifi.c:1396
+msgid "Stop hotspot and disconnect any users?"
+msgstr "ഹോട്ട്സ്പോട്ട് നിര്‍ത്തി ഏതെങ്കിലും ഉപയോക്താക്കള്‍ വിഛേദിയ്ക്കണമോ?"
+
+#: ../panels/network/net-device-wifi.c:1399
+msgid "_Stop Hotspot"
+msgstr "ഹോട്ട്സ്പോട്ട്  _നിര്‍ത്തുക"
+
+#: ../panels/network/net-device-wifi.c:1496
+msgid "System policy prohibits use as a Hotspot"
+msgstr "ഹോട്ട്സ്പോട്ടായി ഉപയോഗിക്കാന്‍ സിസ്റ്റത്തിന്റെ നയം അനുവദിക്കുന്നില്ല"
+
+#: ../panels/network/net-device-wifi.c:1499
+msgid "Wireless device does not support Hotspot mode"
+msgstr "വയര്‍ലെസ്സ് ഡിവൈസ് ഹോട്ട്സ്പോട്ട് മോഡ് പിന്തുണയ്ക്കുന്നില്ല"
+
+#: ../panels/network/net-device-wifi.c:1630
+msgid ""
+"Network details for the selected networks, including passwords and any custom configuration will be lost."
+msgstr "രഹസ്യവാക്ക്, തയ്യാറാക്കിയ ക്രമീകരണം, എന്നിങ്ങനെയുള്ള %s-ന്റെ നെറ്റ്‌വര്‍ക്ക് വിവരങ്ങള്‍ നഷ്ടമാകുന്നു."
+
+#: ../panels/network/net-device-wifi.c:1634 ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "മറക്കുക (_F)"
+
+#: ../panels/network/net-device-wifi.c:1943 ../panels/network/net-device-wifi.c:1950
+msgid "Known Wi-Fi Networks"
+msgstr "അറിയാവുന്ന വൈ-ഫൈ ശ്രംഖലകള്‍"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1983
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "മറക്കുക (_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:102
+msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "ക്രമീകരണത്തിനുള്ളൊരു യുആര്‍എല്‍ ലഭ്യമാക്കത്തപ്പോള്‍, വെബ് പ്രോക്സി ഓട്ടോഡിസ്ക്കവറി ഉപയോഗിയ്ക്കുന്നു."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:110
+msgid "This is not recommended for untrusted public networks."
+msgstr "അവിശ്വസനീയമായ പബ്ലിക് നെറ്റ്‌വര്‍ക്കുകള്‍ക്കു് ഇതു് ഉചിതമല്ല."
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "സേവന ദാതാവു്"
+
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "ശൃംഖല"
+
+#: ../panels/network/network-proxy.ui.h:1
+msgid "Network Proxy"
+msgstr "ശൃംഖലാ പ്രോക്സി"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_HTTP Proxy"
+msgstr "_എച്ച്ടിടിപി പ്രോക്സി"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "H_TTPS Proxy"
+msgstr "എ_ച്ച്ടിടിപിഎസ് പ്രോക്സി"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "_FTP Proxy"
+msgstr "എ_ഫ്‌ടിപി പ്രോക്സി"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_Socks Host"
+msgstr "_Socks ഹോസ്റ്റ്"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Ignore Hosts"
+msgstr "ഹോസ്റ്റുകള്‍ _അവഗണിക്കുക"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "HTTP proxy port"
+msgstr "എച്ച്ടിടിപി പ്രോക്സി പോര്‍ട്ട്"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTPS proxy port"
+msgstr "എച്ച്ടിടിപിഎസ് പ്രോക്സി പോര്‍ട്ട്"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "FTP proxy port"
+msgstr "എഫ്‌ടിപി പ്രോക്സി പോര്‍ട്ട്"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "Socks proxy port"
+msgstr "Socks പ്രോക്സി പോര്‍ട്ട്"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "_Configuration URL"
+msgstr "ക്രമീക_രണത്തിനുള്ള യുആര്‍എല്‍"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "ഉപകരണം ഓഫ് ചെയ്യുക"
+
+#: ../panels/network/network.ui.h:2
+msgid "Not set up"
+msgstr "ക്രമീകരിച്ചിട്ടില്ല"
+
+#: ../panels/network/network-vpn.ui.h:1
+msgid "Turn VPN connection off"
+msgstr "വിപിഎന്‍ ബന്ധം ഓഫ് ചെയ്യുക"
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "സ്വയം _ബന്ധിപ്പിക്കുക"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "വിശദവിവരങ്ങള്‍"
+
+#: ../panels/network/network-wifi.ui.h:17 ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2 ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/sharing/sharing.ui.h:9 ../panels/user-accounts/data/account-dialog.ui.h:12
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "_രഹസ്യവാക്ക്"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "അടയാളവാക്കു് _കാണിക്കുക"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr "മറ്റുള്ള ഉപയോക്താക്കള്‍ക്ക് ലഭ്യമാക്കുക"
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "തിരിച്ചറിയല്‍"
+
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "_വിലാസങ്ങള്‍"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr "ഓട്ടോമാറ്റിക് (DHCP) വിലാസങ്ങള്‍ മാത്രം"
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr "ലിങ്ക്-ലോക്കല്‍ മാത്രം"
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr "മറ്റു് കമ്പ്യൂട്ടറുകളുമായി പങ്കിടുന്നു"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr "സ്വയം ലഭിച്ച റൂട്ടുകള്‍ അവ_ഗണിക്കുക"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr "_പകര്‍ത്തിയ MAC വിലാസം"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr "ഹാര്‍ഡ്‌വെയര്‍"
+
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "_ആദ്യം മുതല്‍ തുടങ്ങുക"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid "Reset the settings for this connection to their defaults, but remember as a preferred connection."
+msgstr "ഈ ബന്ധത്തിന്റെ ഡജ്ജീകരണങ്ങള്‍ സ്വതവേയുള്ളതിലേക്ക് മാറ്റുക, പക്ഷേ, മുന്‍ഗണനയുള്ള ബന്ധമായി കരുതുക."
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid "Remove all details relating to this network and do not try to automatically connect to it."
+msgstr "ഈ ശൃംഖലയുമായുള്ള എല്ലാ വിവരങ്ങളും നീക്കി തനിയെ ബന്ധിപ്പിക്കാതിരിക്കുക."
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "വീണ്ടും തുടങ്ങുക"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "ഹാര്‍ഡ്‌വെയര്‍"
+
+#: ../panels/network/network-wifi.ui.h:51
+msgctxt "tab"
+msgid "Reset"
+msgstr "വീണ്ടും തുടങ്ങുക"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട്"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "ഒരു വയര്‍ലെസ്സ് നെറ്റ്‌വര്‍ക്കിലേക്കു് കണക്ട് ചെയ്യുന്നതിനായി സ്വിച്ച് ഓഫ് ചെയ്യുക"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Network Name"
+msgstr "നെറ്റ്‌വര്‍ക്കിന്റെ പേരു്"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Connected Devices"
+msgstr "കണക്ട് ചെയ്ത ഡിവൈസുകള്‍"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "Security type"
+msgstr "സുരക്ഷാ രീതി"
+
+#: ../panels/network/network-wifi.ui.h:57 ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/printers/new-printer-dialog.ui.h:14 ../panels/user-accounts/data/account-dialog.ui.h:9
+msgid "Password"
+msgstr "രഹസ്യവാക്ക്"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Turn Wi-Fi off"
+msgstr "ഓണ്‍ അല്ലെങ്കില്‍ ഓഫ് ചെയ്യുക"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "_Connect to Hidden Network…"
+msgstr "അദൃശ്യമായൊരു നെറ്റ്‌വര്‍ക്കിലേക്കു് ബന്ധിപ്പിക്കുക…"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "വയര്‍ലെസ്സ് ഹോട്ട്സ്പോട്ട് സജ്ജമാക്കുക (_T)…"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "_Known Wi-Fi Networks"
+msgstr "അറിയാവുന്ന വൈ-ഫൈ ശൃംഖലകള്‍"
+
+#: ../panels/network/wifi.ui.h:1
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "വൈ-ഫൈ അഡാപ്റ്റര്‍ കുത്തിയിട്ടുണ്ടെന്നും ഓണ്‍ ചെയ്തിട്ടുണ്ടെന്നും ഉറപ്പ് വരുത്തുക"
+
+#: ../panels/network/wifi.ui.h:2
+msgid "No Wi-Fi Adapter Found"
+msgstr "വൈ-ഫൈ അഡാപ്റ്റര്‍ ഒന്നും കണ്ടില്ല"
+
+#: ../panels/network/wifi.ui.h:3
+msgid "Airplane Mode"
+msgstr "വിമാന മോഡ്"
+
+#: ../panels/network/wifi.ui.h:4
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "വൈ-ഫൈ, ബ്ലുടൂത്, മൊബൈല്‍ ഇന്റെര്‍നെറ്റ് നിര്‍ത്തുന്നു"
+
+#: ../panels/network/wifi.ui.h:5
+msgid "Visible Networks"
+msgstr "കാണാവുന്ന ശൃംഖല"
+
+#: ../panels/network/wifi.ui.h:6
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager പ്രവര്‍ത്തിക്കണം"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:127
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Infrastructure"
+msgstr "Infrastructure"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:147 ../panels/network/panel-common.c:201
+msgid "Status unknown"
+msgstr "അവസ്ഥ അറിയില്ല"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:151
+msgid "Unmanaged"
+msgstr "കൈകാര്യം ചെയ്യാത്ത"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unavailable"
+msgstr "ലഭ്യമല്ല"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:165 ../panels/network/panel-common.c:207
+msgid "Connecting"
+msgstr "ബന്ധം സ്ഥാപിക്കുന്നു"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Authentication required"
+msgstr "ആധികാരികത ഉറപ്പ് വരുത്തല്‍ ആവശ്യമുണ്ട്"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Connected"
+msgstr "ബന്ധിച്ചു"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:177
+msgid "Disconnecting"
+msgstr "വിഛേദിക്കുന്നു"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:181 ../panels/network/panel-common.c:219
+msgid "Connection failed"
+msgstr "കണക്ഷന്‍ പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:227
+msgid "Status unknown (missing)"
+msgstr "അവസ്ഥ അറിയില്ല (കാണുന്നില്ല)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223
+msgid "Not connected"
+msgstr "ബന്ധിപ്പിച്ചിട്ടില്ല"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:248
+msgid "Configuration failed"
+msgstr "ക്രമീകരണം പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "IP configuration failed"
+msgstr "ഐപി ക്രമീകരണം പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration expired"
+msgstr "ഐപി ക്രമീകരണത്തിന്റെ കാലാവധി കഴിഞ്ഞിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "Secrets were required, but not provided"
+msgstr "രഹസ്യങ്ങള്‍ ആവശ്യമുണ്ടു്, പക്ഷേ ലഭ്യമാക്കിയിട്ടില്ല"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x സപ്പ്ലിക്കന്റ് വിഛേദിച്ചിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x സപ്പ്ലിക്കന്റ് ക്രീകരണം പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant failed"
+msgstr "802.1x സപ്പ്ലിക്കന്റ് പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x സപ്പ്ലിക്കന്റ് ആധികാരികത ഉറപ്പാക്കുന്നതിനു് അധികം സമയമെടുക്കുന്നു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "PPP service failed to start"
+msgstr "പിപിപി സര്‍വീസ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service disconnected"
+msgstr "പിപിപി സര്‍വീസ് വിഛേദിച്ചിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP failed"
+msgstr "പിപിപി പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "DHCP client failed to start"
+msgstr "ഡിഎച്സിപി ക്ലയന്റ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client error"
+msgstr "ഡിഎച്സിപി ക്ലയന്റ് പിശക്"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client failed"
+msgstr "ഡിഎച്സിപി ക്ലയന്റ് പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "Shared connection service failed to start"
+msgstr "പങ്കിടുന്ന കണക്ഷന്‍ സര്‍വീസ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed"
+msgstr "പങ്കിടുന്ന കണക്ഷന്‍ സര്‍വീസ് പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "AutoIP service failed to start"
+msgstr "AutoIP സര്‍വീസ് ആരംഭിയ്ക്കുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service error"
+msgstr "AutoIP സര്‍വീസ് പിശക്"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service failed"
+msgstr "AutoIP സര്‍വീസ് പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "Line busy"
+msgstr "ലൈന്‍ തിരക്കിലാണു്"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "No dial tone"
+msgstr "ഡയല്‍ ടോണില്ല"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No carrier could be established"
+msgstr "ക്യാരിയര്‍ സ്ഥാപിച്ചിട്ടില്ല"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "Dialing request timed out"
+msgstr "ഡയലിങ് ആവശ്യം സമയപരിധി കഴിഞ്ഞിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing attempt failed"
+msgstr "ഡയലിങ് ശ്രമം പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Modem initialization failed"
+msgstr "മോഡം പ്രാരംഭം പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Failed to select the specified APN"
+msgstr "വ്യക്തമാക്കിയ എപിഎല്‍ തെരഞ്ഞെടുത്തതില്‍ പരാജയം"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Not searching for networks"
+msgstr "നെറ്റ്‌വര്‍ക്കുകള്‍ തെരയുന്നില്ല"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Network registration denied"
+msgstr "നെറ്റ്‌വര്‍ക്ക് രജിസ്ട്രേഷന്‍ നിഷേധിച്ചിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration timed out"
+msgstr "നെറ്റ്‌വര്‍ക്ക് രജിസ്ട്രേഷന്‍ സമയപരിധി കഴിഞ്ഞിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Failed to register with the requested network"
+msgstr "ആവശ്യപ്പെട്ട നെറ്റ്‌വര്‍ക്കിലേക്ക് രഡിസ്ടര്‍ ചെയ്യുന്നതില്‍ പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "PIN check failed"
+msgstr "പിന്‍ പരിശോധന പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "Firmware for the device may be missing"
+msgstr "ഡിവൈസിനുള്ള ഫേംവെയര്‍ ലഭ്യമല്ല"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Connection disappeared"
+msgstr "കണക്ഷന്‍ കാണുവാനില്ല"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Existing connection was assumed"
+msgstr "നിലവിലുള്ള കണക്ഷന്‍ കരുതപ്പെടുന്നു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Modem not found"
+msgstr "മോഡം ലഭ്യമായില്ല"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Bluetooth connection failed"
+msgstr "ബ്ലൂടൂത് കണക്ഷന്‍ പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "SIM Card not inserted"
+msgstr "സിം കാര്‍ഡ് ഇട്ടിട്ടില്ല"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Pin required"
+msgstr "സിം പിന്‍ ആവശ്യമുണ്ടു്"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Puk required"
+msgstr "സിം പൂക്ക് ആവശ്യമുണ്ടു്"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM wrong"
+msgstr "സിം തെറ്റാണു്"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "Connection dependency failed"
+msgstr "കണക്ഷന്‍ ഡിപന്‍ഡന്‍സി പരാജയപ്പെട്ടു"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:433
+msgid "Firmware missing"
+msgstr "ഫേംവെയര്‍ ലഭ്യമല്ല"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:437
+msgid "Cable unplugged"
+msgstr "കേബിള്‍ ഊരി"
+
+#: ../panels/network/wireless-security/eap-method.c:57
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:233
+msgid "no file selected"
+msgstr "ഫയല്‍ ഒന്നും എടുത്തില്ല"
+
+#: ../panels/network/wireless-security/eap-method.c:264
+msgid "unspecified error validating eap-method file"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method.c:439
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "DER, PEM, അല്ലെങ്കില്‍ PKCS#12 സ്വകാര്യ കീകള്‍ (*.der, *.pem, *.p12, *.key)"
+
+#: ../panels/network/wireless-security/eap-method.c:442
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER അല്ലെങ്കില്‍ PEM സര്‍ട്ടിഫീക്കേറ്റുകള്‍ (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:72
+msgid "missing EAP-FAST PAC file"
+msgstr "EAP-FAST PAC ഫയല്‍ കാണുന്നില്ല"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:268
+#: ../panels/network/wireless-security/eap-method-peap.c:302
+#: ../panels/network/wireless-security/eap-method-ttls.c:351
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:283
+#: ../panels/network/wireless-security/eap-method-peap.c:272
+#: ../panels/network/wireless-security/eap-method-ttls.c:289
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:406
+msgid "Choose a PAC file"
+msgstr "ഒരു PAC ഫയല്‍ തിരഞ്ഞെടുക്കുക"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:413
+msgid "PAC files (*.pac)"
+msgstr "പിഎസി ഫയലുകള്‍ (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+msgid "Anonymous"
+msgstr "അജ്ഞാതം"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "Authenticated"
+msgstr "തിരിച്ചറിഞ്ഞിരിയ്ക്കുന്നു"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+msgid "Both"
+msgstr "രണ്ടും"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+msgid "PAC _file"
+msgstr "പിഎസി _ഫയല്‍"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "_ആന്തരിക ആധികാരികത ഉറപ്പാക്കല്‍"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-leap.c:74
+msgid "missing EAP-LEAP password"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1 ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Username"
+msgstr "_ഉപയോക്താവ്"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:7 ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "രഹസ്യവാക്ക് കാണിയ്ക്കു_ക"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:63
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.c:68
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.c:287
+#: ../panels/network/wireless-security/eap-method-ttls.c:336
+#: ../panels/network/wireless-security/wireless-security.c:441
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:381
+#: ../panels/network/wireless-security/eap-method-tls.c:501
+#: ../panels/network/wireless-security/eap-method-ttls.c:430
+msgid "Choose a Certificate Authority certificate"
+msgstr "ഒരു സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി സര്‍ട്ടിഫീക്കേറ്റ് തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Version 0"
+msgstr "പതിപ്പ് 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 1"
+msgstr "പതിപ്പ് 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "C_A certificate"
+msgstr "C_A സാക്ഷ്യപത്രം"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "പിഇഎപി _പതിപ്പ്"
+
+#: ../panels/network/wireless-security/eap-method-simple.c:74
+msgid "missing EAP username"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-simple.c:87
+msgid "missing EAP password"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:68
+msgid "missing EAP-TLS identity"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:77
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:84
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:95
+msgid "invalid EAP-TLS password: missing"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:109
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:119
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-tls.c:316
+msgid "Unencrypted private keys are insecure"
+msgstr "എന്‍ക്രിപ്റ്റ് ചെയ്യാത്ത സ്വകാര്യ കീകള്‍ അസുരക്ഷിതമാണു്"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:319
+msgid ""
+"The selected private key does not appear to be protected by a password. This could allow your security "
+"credentials to be compromised. Please select a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"ഈ സ്വകാര്യ ചാവി രഹസ്യവാക്ക് വെച്ച് സുരക്ഷിതമാക്കിയതായി കാണുന്നില്ല. ഇത് സുരക്ഷയെ ബാധിക്കുന്ന കാര്യമാണ്. ദയവായി രഹസ്യവാക്ക് കൊണ്ട് "
+"സുരക്ഷിതമാക്കിയ സ്വകാര്യ ചാവി തെരഞ്ഞെടുക്കുക.\n"
+"\n"
+"(ഓപ്പണ്‍ എസ്എസ്എല്‍ വെച്ച് സ്വകാര്യ കീക്ക് രഹസ്യവാക്ക് കൊടുക്കാം)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:495
+msgid "Choose your personal certificate"
+msgstr "നിങ്ങളുടെ സ്വകാര്യ സാക്ഷ്യപത്രം തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:507
+msgid "Choose your private key"
+msgstr "നിങ്ങളുടെ സ്വകാര്യ കീ തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "_തിരിച്ചറിയല്‍"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "_ഉപയോക്താവിന്റെ സാക്ഷ്യപത്രം"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "Private _key"
+msgstr "സ്വകാര്യ _ചാവി‌"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+msgid "_Private key password"
+msgstr "_സ്വകാര്യ കീ അടയാളവാക്ക്"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:63
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:68
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:259
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:274
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:305
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:321
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/wireless-security.c:87
+msgid "Unknown error validating 802.1X security"
+msgstr ""
+
+#: ../panels/network/wireless-security/wireless-security.c:453
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:477
+msgid "PWD"
+msgstr "PWD"
+
+#: ../panels/network/wireless-security/wireless-security.c:488
+msgid "FAST"
+msgstr "എഫ്എഎസ്‌ടി"
+
+#: ../panels/network/wireless-security/wireless-security.c:499
+msgid "Tunneled TLS"
+msgstr "ടണ്‍ല്ഡ് TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:510
+msgid "Protected EAP (PEAP)"
+msgstr "സുരക്ഷിതമായ EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6 ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+msgid "Au_thentication"
+msgstr "_തിരിച്ചറിയല്‍"
+
+#: ../panels/network/wireless-security/ws-leap.c:63
+msgid "missing leap-username"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid "invalid wep-key: wrong key length %zu. A key must be either of length 5/13 (ascii) or 10/26 (hex)"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (സഹജം)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "Open System"
+msgstr "തുറന്ന സിസ്റ്റം"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "Shared Key"
+msgstr "പങ്കുവച്ച കീ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "_Key"
+msgstr "_കീ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Sho_w key"
+msgstr "കീ കാ_ണിക്കുക"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "WEP inde_x"
+msgstr "WEP _സൂചിക"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex digits"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "_തരം"
+
+#. This is the per application switch for message tray usage.
+#: ../panels/notifications/edit-dialog.ui.h:2
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "അറിയിപ്പുകള്‍ (_N)"
+
+#. This is the setting to configure sounds associated with notifications.
+#: ../panels/notifications/edit-dialog.ui.h:4
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "ശബ്ദ അറിയിപ്പുകള്‍ (_A)"
+
+#: ../panels/notifications/edit-dialog.ui.h:5
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "പോപ്പപ്പ് അറിയിപ്പുകള്‍ (_P)"
+
+#: ../panels/notifications/edit-dialog.ui.h:6
+msgid "Notifications will continue to appear in the notification list when popups are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: ../panels/notifications/edit-dialog.ui.h:8
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: ../panels/notifications/edit-dialog.ui.h:9
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: ../panels/notifications/edit-dialog.ui.h:10
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "സ്ക്രീന്‍ പൂട്ടിയിരിക്കുമ്പോള്‍ സന്ദേശങ്ങള്‍ കാണിക്കുക (_o)"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "No­ti­fi­ca­tions"
+msgstr "അറിയിപ്പുകള്‍"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:3
+msgid "Control which notifications are displayed and what they show"
+msgstr "ഏതോക്കെ അറിയിപ്പുകളാണ് കാണിക്കുന്നതെന്നും എന്താണ് കാണിക്കുന്നതെന്നും നിയന്ത്രിക്കുക."
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:5
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Banner;Message;Tray;Popup;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Notification _Popups"
+msgstr "പോപ്പപ് അറിയിപ്പുകള്‍ (_P)"
+
+#: ../panels/notifications/notifications.ui.h:2
+#, fuzzy
+#| msgid "Notifications"
+msgid "_Lock Screen Notifications"
+msgstr "അറിയിപ്പുകള്‍"
+
+#. List of applications.
+#: ../panels/notifications/notifications.ui.h:4 ../panels/privacy/privacy.ui.h:45
+#: ../panels/sound/gvc-mixer-dialog.c:1781
+msgid "Applications"
+msgstr "പ്രയോഗങ്ങള്‍"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:148
+msgctxt "Online Account"
+msgid "Other"
+msgstr "മറ്റുളളവ"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: ../panels/online-accounts/cc-online-accounts-panel.c:603
+#, c-format
+msgid "%s Account"
+msgstr "%s അക്കൌണ്ട്"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:895
+msgid "Error removing account"
+msgstr "അക്കൌണ്ട് നീക്കം ചെയ്യുന്നതില്‍ പിശക്"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: ../panels/online-accounts/cc-online-accounts-panel.c:960
+#, c-format
+msgid "<b>%s</b> removed"
+msgstr "<b>%s</b> യെ മാറ്റി"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "On­line Accounts"
+msgstr "ഓണ്‍ലൈന്‍ അക്കൌണ്ടുകള്‍"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "ഓണ്‍ലൈന്‍ അകൌണ്ടുകള്‍ ബന്ധിപ്പിച്ച് അവ എന്തിന് വേണ്ടി ഉപയോഗിക്കണം എന്ന് തീരുമാനിക്കുക"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:5
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
+"ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
+"ReadItLater;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: ../panels/online-accounts/online-accounts.ui.h:1 ../panels/printers/printers.ui.h:4
+msgid "Undo"
+msgstr "പൂർവാവസ്ഥയിലാക്കുക"
+
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an account"
+msgstr "അക്കൗണ്ട് ചേര്‍ക്കുക"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid "Remove Account"
+msgstr "എക്കൗണ്ട് നീക്കം ചെയ്യുക"
+
+#: ../panels/power/cc-power-panel.c:253
+msgid "Unknown time"
+msgstr "അജ്ഞാതസമയം"
+
+#: ../panels/power/cc-power-panel.c:259
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i മിനിട്ട്"
+msgstr[1] "%i മിനിട്ടുകള്‍"
+
+#: ../panels/power/cc-power-panel.c:271
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i മണിക്കൂര്‍"
+msgstr[1] "%i മണിക്കൂറുകള്‍"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:279
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:280
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "മണിക്കൂര്‍"
+msgstr[1] "എളുപ്പവഴി"
+
+#: ../panels/power/cc-power-panel.c:281
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "മിനിട്ട്"
+msgstr[1] "മിനിട്ടുകള്‍"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:300
+#, c-format
+msgid "%s until fully charged"
+msgstr "പൂര്‍ണ്ണമായി ചാര്‍ജ് ചെയ്യുന്നതു് വരെ %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:307
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "സൂക്ഷിക്കുക: %s സമയം ബാക്കി"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:312
+#, c-format
+msgid "%s remaining"
+msgstr "%s ബാക്കി"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:317 ../panels/power/cc-power-panel.c:345
+msgid "Fully charged"
+msgstr "മുഴുവനും ചാര്‍ജ്ജ് ചെയ്തിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:321 ../panels/power/cc-power-panel.c:349
+msgid "Empty"
+msgstr "കാലി"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:336
+msgid "Charging"
+msgstr "ചാര്‍ജ് ചെയ്തുകൊണ്ടിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:341
+msgid "Discharging"
+msgstr "ചാര്‍ജ് ഉപയോഗിച്ചുകൊണ്ടിരിയ്ക്കുന്നു"
+
+#: ../panels/power/cc-power-panel.c:464
+msgctxt "Battery name"
+msgid "Main"
+msgstr "പ്രധാന"
+
+#: ../panels/power/cc-power-panel.c:466
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "അധികമായ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:537
+msgid "Wireless mouse"
+msgstr "വയര്‍ലെസ്സ് മൌസ്"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgid "Wireless keyboard"
+msgstr "വയര്‍ലെസ്സ് കീബോര്‍ഡ്"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:543
+msgid "Uninterruptible power supply"
+msgstr "തടസ്സമില്ലാത്ത പവര്‍ "
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:546
+msgid "Personal digital assistant"
+msgstr "സ്വകാര്യ ഡിജിറ്റല്‍ അസിസ്റ്റന്റ്"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:549
+msgid "Cellphone"
+msgstr "സെല്‍ഫോണ്‍"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgid "Media player"
+msgstr "മീഡിയ പ്ലേയര്‍"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:555 ../panels/wacom/cc-wacom-panel.c:793
+msgid "Tablet"
+msgstr "ടാബ്ലെറ്റ്‌"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:558
+msgid "Computer"
+msgstr "കമ്പ്യൂട്ടര്‍"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:561 ../panels/power/cc-power-panel.c:801
+#: ../panels/power/cc-power-panel.c:2356
+msgid "Battery"
+msgstr "ബാറ്ററി"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:615
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "ചാര്‍ജ് ചെയ്തുകൊണ്ടിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:622
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "ശ്രദ്ധിക്കുക"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:627
+msgctxt "Battery power"
+msgid "Low"
+msgstr "കുറഞ്ഞ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:632
+msgctxt "Battery power"
+msgid "Good"
+msgstr "നല്ലത്"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:637
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "മുഴുവനും ചാര്‍ജ്ജ് ചെയ്തിരിയ്ക്കുന്നു"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:641
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "കാലി"
+
+#: ../panels/power/cc-power-panel.c:799
+msgid "Batteries"
+msgstr "ബാറ്ററികള്‍"
+
+#: ../panels/power/cc-power-panel.c:1227
+msgid "When _idle"
+msgstr "_വെറുതെ ഇരിക്കുമ്പോള്‍"
+
+#: ../panels/power/cc-power-panel.c:1681
+msgid "Power Saving"
+msgstr "ഊര്‍ജ്ജ സംരക്ഷണം"
+
+#: ../panels/power/cc-power-panel.c:1712
+msgid "_Screen brightness"
+msgstr "_തിരശ്ശീല വെളിച്ചം"
+
+#: ../panels/power/cc-power-panel.c:1731
+msgid "Automatic brightness"
+msgstr "സ്വതവേയുള്ള തെളിച്ചം"
+
+#: ../panels/power/cc-power-panel.c:1751
+msgid "_Keyboard brightness"
+msgstr "കീബോര്‍ഡിന്റെ ശോഭ"
+
+#: ../panels/power/cc-power-panel.c:1761
+msgid "_Dim screen when inactive"
+msgstr "വെറുതെ ഇരിക്കുമ്പോള്‍ സ്ക്രീന്‍ _മങ്ങിക്കുക"
+
+#: ../panels/power/cc-power-panel.c:1786
+msgid "_Blank screen"
+msgstr "_ശൂന്യമായ സ്ക്രീന്‍"
+
+#: ../panels/power/cc-power-panel.c:1823
+msgid "_Wi-Fi"
+msgstr "_വയര്‍ലസ്സ്"
+
+#: ../panels/power/cc-power-panel.c:1828
+msgid "Turn off Wi-Fi to save power."
+msgstr "കറണ്ട് ലാഭിക്കാന്‍ വൈ-ഫൈ ഓഫാക്കുക."
+
+#: ../panels/power/cc-power-panel.c:1853
+msgid "_Mobile broadband"
+msgstr "മൊബൈല്‍ ബ്രോഡ്ബാന്‍ഡ്"
+
+#: ../panels/power/cc-power-panel.c:1858
+msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+msgstr "മൊബൈല്‍ ബ്രോഡ്ബാന്‍ഡ് ഉപകരണങ്ങള്‍ (3G, 4G, LTE, etc.) ഓഫ് ചെയ്യുക."
+
+#: ../panels/power/cc-power-panel.c:1903
+msgid "_Bluetooth"
+msgstr "_ബ്ളുടൂത്ത്"
+
+#: ../panels/power/cc-power-panel.c:1966
+msgid "When on battery power"
+msgstr "ബാറ്ററിയില്‍ പ്രവര്‍ത്തിയ്ക്കുമ്പോള്‍"
+
+#: ../panels/power/cc-power-panel.c:1968
+msgid "When plugged in"
+msgstr "പ്ലഗ്ഗിന്‍ ചെയ്തപ്പോള്‍"
+
+#: ../panels/power/cc-power-panel.c:2063
+msgid "Suspend"
+msgstr "സസ്പെന്‍ഡ്"
+
+#: ../panels/power/cc-power-panel.c:2064
+msgid "Power Off"
+msgstr "നിര്‍ത്തി വെയ്ക്കുക"
+
+#: ../panels/power/cc-power-panel.c:2065
+msgid "Hibernate"
+msgstr "ശിശിരനിദ്രയിലാക്കുക"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Nothing"
+msgstr "ഒരു പ്രവര്‍ത്തിയും ചെയ്യാതിരിക്കുക"
+
+#. Frame header
+#: ../panels/power/cc-power-panel.c:2180
+msgid "Suspend & Power Button"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:2219
+msgid "_Automatic suspend"
+msgstr "_തനിയെ ഉറങ്ങുക"
+
+#: ../panels/power/cc-power-panel.c:2220
+msgid "Automatic suspend"
+msgstr "തനിയെ ഉറങ്ങുക"
+
+#: ../panels/power/cc-power-panel.c:2287
+msgid "_When the Power Button is pressed"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:2406 ../shell/cc-window.c:247 ../shell/panel-list.ui.h:1
+msgid "Devices"
+msgstr "ഉപകരണങ്ങള്‍"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Po­wer"
+msgstr ""
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:3
+msgid "View your battery status and change power saving settings"
+msgstr "ബാറ്ററിയുടെ സ്ഥിതി നോക്കി വൈദ്യുതി ലഭിക്കുക"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:5
+msgid "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+
+#: ../panels/power/power.ui.h:3
+msgid "45 minutes"
+msgstr "45 മിനിറ്റുകള്‍"
+
+#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 മണിക്കൂര്‍"
+
+#: ../panels/power/power.ui.h:5
+msgid "80 minutes"
+msgstr "80 മിനിറ്റുകള്‍"
+
+#: ../panels/power/power.ui.h:6
+msgid "90 minutes"
+msgstr "90 മിനിറ്റുകള്‍"
+
+#: ../panels/power/power.ui.h:7
+msgid "100 minutes"
+msgstr "100 മിനിറ്റുകള്‍"
+
+#: ../panels/power/power.ui.h:8
+msgid "2 hours"
+msgstr "2 മണിക്കൂര്‍"
+
+#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 മിനിട്ട്"
+
+#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 മിനിട്ടുകള്‍"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 മിനിട്ടുകള്‍"
+
+#: ../panels/power/power.ui.h:12
+msgid "4 minutes"
+msgstr "40 മിനിറ്റുകള്‍"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 മിനിറ്റുകള്‍"
+
+#: ../panels/power/power.ui.h:14
+msgid "8 minutes"
+msgstr "8 മിനിറ്റുകള്‍"
+
+#: ../panels/power/power.ui.h:15
+msgid "10 minutes"
+msgstr "10 മിനിട്ടുകള്‍"
+
+#: ../panels/power/power.ui.h:16
+msgid "12 minutes"
+msgstr "12 മിനിറ്റുകള്‍"
+
+#: ../panels/power/power.ui.h:18
+msgid "Automatic Suspend"
+msgstr "തനിയെ ഉറങ്ങുക"
+
+#: ../panels/power/power.ui.h:19
+msgid "_Plugged In"
+msgstr "_പ്ലഗ്ഗിന്‍ ചെയ്തിരിക്കുമ്പോള്‍"
+
+#: ../panels/power/power.ui.h:20
+msgid "On _Battery Power"
+msgstr "_ബാറ്ററിയില്‍ പ്രവര്‍ത്തിയ്ക്കുമ്പോള്‍"
+
+#: ../panels/power/power.ui.h:21 ../panels/universal-access/uap.ui.h:36
+msgid "Delay"
+msgstr "കാലതാമസം"
+
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "തിരിച്ചറിയുക"
+
+#: ../panels/printers/authentication-dialog.ui.h:4 ../panels/printers/new-printer-dialog.ui.h:13
+msgid "Username"
+msgstr "ഉപയോക്താവിന്റെ പേര്"
+
+#: ../panels/printers/authentication-dialog.ui.h:6 ../panels/printers/new-printer-dialog.ui.h:11
+msgid "Authentication Required"
+msgstr "ആധികാരികത ഉറപ്പ് വരുത്തേണ്ടതുണ്ട്"
+
+#. Translators: %s is the printer name
+#: ../panels/printers/cc-printers-panel.c:717
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr ""
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:908
+msgid "Failed to add new printer."
+msgstr "പുതിയ പ്രിന്റര്‍ ചേര്‍ക്കുന്നതില്‍ പരാജയം."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:1220
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui ലഭ്യമാക്കുവാന്‍ സാധ്യമല്ല: %s"
+
+#: ../panels/printers/details-dialog.ui.h:2 ../panels/printers/printer-entry.ui.h:8
+msgid "Location"
+msgstr "സ്ഥലം"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/details-dialog.ui.h:4 ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "ഡ്രൈവര്‍"
+
+#: ../panels/printers/details-dialog.ui.h:5
+msgid "Searching for preferred drivers…"
+msgstr "ഇഷ്ടമുള്ള ഡ്രൈവറുകള്‍ക്കായി തെരയുന്നു…"
+
+#: ../panels/printers/details-dialog.ui.h:6
+msgid "Search for Drivers"
+msgstr "ഡ്രൈവറുകള്‍ക്കായി തെരയു"
+
+#: ../panels/printers/details-dialog.ui.h:7
+msgid "Select from Database…"
+msgstr "ഡേറ്റാബെയിസില്‍ നിന്നും തെരഞ്ഞെടുക്കുക…"
+
+#: ../panels/printers/details-dialog.ui.h:8
+msgid "Install PPD File…"
+msgstr "പിപിഡി ഫയല്‍ ഇന്‍സ്റ്റാള്‍ ചെയ്യുക…"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Prin­ters"
+msgstr "പ്രിന്ററുകള്‍"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "പ്രിന്റെര്‍ ചേര്‍ക്കുക, ജോലികള്‍ കാണുക പിന്നെ എങ്ങനെ പ്രിന്റ് എടുക്കണമെന്ന് തീരുമാനിക്കുക"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:5
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Clear All"
+msgstr "എല്ലാം വെടിപ്പാക്കുക"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "No Active Printer Jobs"
+msgstr "സജീവമായ പ്രിന്‍റര്‍ ജോലികളില്ല"
+
+#. Translators: This is the title presented at top of the dialog.
+#: ../panels/printers/new-printer-dialog.ui.h:2 ../panels/printers/pp-new-printer-dialog.c:384
+#: ../panels/printers/pp-new-printer-dialog.c:456
+msgid "Add Printer"
+msgstr "പ്രിന്റര്‍ ചേര്‍ക്കുക"
+
+#. Translators: This buttons submits the credentials for the selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:6
+msgid "_Unlock"
+msgstr "_അണ്‍ലോക്ക് ചെയ്യുക"
+
+#. Translators: No printers were detected
+#: ../panels/printers/new-printer-dialog.ui.h:8
+msgid "No Printers Found"
+msgstr "പ്രിന്റെറുകളൊന്നും കണ്ടില്ല"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:10
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: ../panels/printers/new-printer-dialog.ui.h:12
+#, fuzzy
+#| msgid "Enter your username and password to view printers available on %s."
+msgid "Enter username and password to view printers on Print Server."
+msgstr "%s ഉള്ള പ്രിന്റ്ററുകൾ കാണുവാൻ യുസർ നെയിമും പാസ്സ് വേഡും കൊടുക്കുക"
+
+#. Translators: This button triggers the printing of a test page.
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/options-dialog.ui.h:2 ../panels/printers/pp-options-dialog.c:893
+msgid "Test Page"
+msgstr "പരീക്ഷണ താള്‍"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: ../panels/printers/pp-details-dialog.c:123 ../panels/printers/pp-details-dialog.c:415
+#, c-format
+msgid "%s Details"
+msgstr "%s വിശദാംശങ്ങൾ"
+
+#: ../panels/printers/pp-details-dialog.c:172
+msgid "No suitable driver found"
+msgstr "ഉചിതമായ ഡ്രൈവര്‍ ലഭ്യമായില്ല"
+
+#: ../panels/printers/pp-details-dialog.c:316
+msgid "Select PPD File"
+msgstr "പിപിഡി ഫയല്‍ തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/printers/pp-details-dialog.c:325
+msgid "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+msgstr "പോസ്റ്റ്സ്ക്രിപ്റ്റ് പ്രിന്റര്‍ വിവരണ ഫയലുകള് (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "പ്രിന്റര്‍ ഡ്രൈവര്‍ തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:3 ../panels/user-accounts/um-photo-dialog.c:96
+msgid "Select"
+msgstr "തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database…"
+msgstr "ഡ്രൈവറുകളുടെ ഡേറ്റാബെയിസ് ലഭ്യമാക്കുന്നു…"
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:539
+msgid "JetDirect Printer"
+msgstr "ജെറ്റ്ഡയറക്റ്റ് പ്രിന്റര്‍"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:795
+msgid "LPD Printer"
+msgstr "LPD പ്രിന്‍റര്‍"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66 ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "ഒരു വശത്തു്"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68 ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "ലോങ് എഡ്ജ് (സാധാരണ)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70 ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "ഷോര്‍ട്ട് എഡ്ജ് (ഫ്ലിപ്പ്)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "പൊട്രെയിറ്റ്"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "ലാന്‍ഡ്സ്കെയിപ്പ്"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "റിവേഴ്സ് ലാന്‍ഡ്സ്കെയിപ്പ്"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "റിവേഴ്സ് പൊട്രെയിറ്റ്"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:104
+msgctxt "print job"
+msgid "Pending"
+msgstr "ബാക്കിയുളള"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:108
+msgctxt "print job"
+msgid "Paused"
+msgstr "താല്‍ക്കാലികമായി നിര്‍ത്തിയിരിക്കുന്നു"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:112
+msgctxt "print job"
+msgid "Processing"
+msgstr "പ്രവര്‍ത്തനത്തില്‍"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:116
+msgctxt "print job"
+msgid "Stopped"
+msgstr "നിര്‍ത്തിയിരിയ്ക്കുന്നു"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:120
+msgctxt "print job"
+msgid "Canceled"
+msgstr "റദ്ദാക്കിയിരിക്കുന്നു"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:124
+msgctxt "print job"
+msgid "Aborted"
+msgstr "പാതിവഴിയില്‍ നിര്‍ത്തിയിരിക്കുന്നു"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:128
+msgctxt "print job"
+msgid "Completed"
+msgstr "പൂര്‍ത്തിയാക്കിയിരിക്കുന്നു"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: ../panels/printers/pp-jobs-dialog.c:310
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — സജീവമായ ജോലികള്‍"
+
+#: ../panels/printers/pp-new-printer-dialog.c:402
+msgid "Unlock Print Server"
+msgstr "പ്രിന്റ് സെര്‍വ്വര്‍ തുറക്കുക"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-new-printer-dialog.c:406
+#, c-format
+msgid "Unlock %s."
+msgstr "തുറക്കുക %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-new-printer-dialog.c:411
+#, fuzzy, c-format
+#| msgid "Enter your username and password to view printers available on %s."
+msgid "Enter username and password to view printers on %s."
+msgstr "%s ഉള്ള പ്രിന്റ്ററുകൾ കാണുവാൻ യുസർ നെയിമും പാസ്സ് വേഡും കൊടുക്കുക"
+
+#: ../panels/printers/pp-new-printer-dialog.c:876
+msgid "Searching for Printers"
+msgstr "പ്രിന്റെറുകള്‍ക്കായി തെരയുന്നു"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1799
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1804
+msgid "Serial Port"
+msgstr "തുടര്‍ച്ചയായ പോര്‍ട്ട്"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1811
+msgid "Parallel Port"
+msgstr "സമാന്തരമായ പോര്‍ട്ട്"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/printers/pp-new-printer-dialog.c:1816
+msgid "Bluetooth"
+msgstr "ബ്ലൂടൂത്ത്"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1853
+#, c-format
+msgid "Location: %s"
+msgstr "സ്ഥലം: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1858
+#, c-format
+msgid "Address: %s"
+msgstr "_വിലാസം: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1887
+msgid "Server requires authentication"
+msgstr "സെര്‍വറിന് പ്രാമാണ്യം ആവശ്യമുണ്ട്"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Two Sided"
+msgstr "രണ്ടു് വശത്തും"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Paper Type"
+msgstr "പേപ്പര്‍ തരം"
+
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Paper Source"
+msgstr "പേപ്പര്‍ ശ്രോതസ്സ്"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "Output Tray"
+msgstr "ഔട്ട്പുട്ട് ട്രേ"
+
+#: ../panels/printers/pp-options-dialog.c:88
+msgid "GhostScript pre-filtering"
+msgstr "ഗോസ്റ്റ്സ്ക്രിപ്റ്റ് പ്രീ-ഫില്‍റ്ററിങ്"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:534
+msgid "Pages per side"
+msgstr "ഒരു വശത്തുള്ള താളുകള്‍"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:546
+msgid "Two-sided"
+msgstr "രണ്ടു് വശത്തും"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "സാധാരണ"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "താള്‍ സജ്ജീകരണം"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "ഇന്‍സ്റ്റോള്‍ ചെയ്യുവാന്‍ സാധ്യമാകുന്ന ഐച്ഛികങ്ങള്‍"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "ജോലി"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "ഇമേജിന്റെ ഗുണം"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "നിറം"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "പൂര്‍ത്തിയാകുന്നു"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:676
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "അധികമായതു്"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/pp-options-dialog.c:908
+msgid "Test page"
+msgstr "പരീക്ഷണ താള്‍"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76 ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "സ്വയം തെരഞ്ഞെടുക്കല്‍"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80 ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84 ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "സഹജമായ പ്രിന്റര്‍"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "ഗോസ്റ്റ്സ്ക്രിപ്റ്റ് അക്ഷരസഞ്ചയങ്ങള്‍ മാത്രം എംബഡ് ചെയ്യുക"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "പിഎസ് ലവല്‍ 1 വേര്‍തിരിയ്ക്കുക"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "പിഎസ് ലവല്‍ 2 വേര്‍തിരിയ്ക്കുക"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "പ്രീ-ഫില്‍റ്ററിങ് ലഭ്യമല്ല"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "ഉല്‍പാദകന്‍"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: ../panels/printers/pp-printer-entry.c:577
+msgid "No Active Jobs"
+msgstr "സജീവമായ ജോലികള്‍ ഇല്ല"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: ../panels/printers/pp-printer-entry.c:582
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u ജോലി"
+msgstr[1] "%u ജോലികള്‍"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/pp-printer-entry.c:730
+msgid "Low on toner"
+msgstr "ടോണര്‍ കുറവാണു്"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/pp-printer-entry.c:732
+msgid "Out of toner"
+msgstr "ടോണര്‍ കാലിയാണു്"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/pp-printer-entry.c:735
+msgid "Low on developer"
+msgstr "ഡെവെലപ്പര്‍ കുറവാണു്‌"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/pp-printer-entry.c:738
+msgid "Out of developer"
+msgstr "ഡെവെലപ്പര്‍ ഇല്ല"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/pp-printer-entry.c:740
+msgid "Low on a marker supply"
+msgstr "മഷി കുറവു്"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/pp-printer-entry.c:742
+msgid "Out of a marker supply"
+msgstr "മഷി തീര്‍ത്തിരിയ്ക്കുന്നു"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/pp-printer-entry.c:744
+msgid "Open cover"
+msgstr "കവര്‍ തുറക്കുക"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/pp-printer-entry.c:746
+msgid "Open door"
+msgstr "വാതില്‍ തുറക്കുക"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/pp-printer-entry.c:748
+msgid "Low on paper"
+msgstr "പേപ്പര്‍ കുറവു്"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/pp-printer-entry.c:750
+msgid "Out of paper"
+msgstr "പേപ്പര്‍ തീര്‍ന്നു"
+
+#. Translators: The printer is offline
+#: ../panels/printers/pp-printer-entry.c:752
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ഓഫ്‌ലൈന്‍"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/pp-printer-entry.c:754 ../panels/printers/pp-printer-entry.c:884
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "നിര്‍ത്തിയിരിയ്ക്കുന്നു"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/pp-printer-entry.c:756
+msgid "Waste receptacle almost full"
+msgstr "വെയിസ്റ്റ് റിസപ്ടബിള്‍ ഏകദേശം പൂര്‍ണ്ണം"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/pp-printer-entry.c:758
+msgid "Waste receptacle full"
+msgstr "വെയിസ്റ്റ് റിസപ്ടബിള്‍ പൂര്‍ണ്ണം"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/pp-printer-entry.c:760
+msgid "The optical photo conductor is near end of life"
+msgstr "ഒപ്ടിക്കല്‍ ഫോട്ടോ കണ്ടക്ടര്‍ അവസാനിയ്ക്കുന്നു"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/pp-printer-entry.c:762
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ഒപ്ടിക്കല്‍ ഫോട്ടോ കണ്ടക്ടര്‍ പ്രവര്‍ത്തനത്തിലില്ല"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/pp-printer-entry.c:870
+msgctxt "printer state"
+msgid "Ready"
+msgstr "തയ്യാര്‍"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/pp-printer-entry.c:875
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "ജോലി ഒന്നും എടുക്കുന്നില്ല"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/pp-printer-entry.c:880
+msgctxt "printer state"
+msgid "Processing"
+msgstr "പ്രവര്‍ത്തനത്തില്‍"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: ../panels/printers/pp-printer-entry.c:904
+msgid "Clean print heads"
+msgstr "പ്രിന്റര്‍ ഹെഡ്ഡ് വൃത്തിയാക്കുക"
+
+#: ../panels/printers/printer-entry.ui.h:1
+msgid "Printing Options"
+msgstr "പ്രിന്റ് ഐച്ഛികങ്ങള്‍"
+
+#: ../panels/printers/printer-entry.ui.h:2
+msgid "Printer Details"
+msgstr "പ്രിന്റര്‍ വിശദാംശങ്ങള്‍"
+
+#: ../panels/printers/printer-entry.ui.h:3
+#, fuzzy
+#| msgid "Printer Default"
+msgid "Use Printer by Default"
+msgstr "സഹജമായ പ്രിന്റര്‍"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: ../panels/printers/printer-entry.ui.h:5
+msgid "Clean Print Heads"
+msgstr "പ്രിന്റ് ഹെഡ്ഡ് വൃത്തിയാക്കുക"
+
+#: ../panels/printers/printer-entry.ui.h:6
+msgid "Remove Printer"
+msgstr "പ്രിന്റര്‍ നീക്കം ചെയ്യുക"
+
+#: ../panels/printers/printer-entry.ui.h:7
+msgid "Model"
+msgstr "മോഡല്‍"
+
+#: ../panels/printers/printer-entry.ui.h:9
+msgid "Ink Level"
+msgstr "ഇങ്കിന്റെ അവസ്ഥ"
+
+#. Translators: This is the message which follows the printer error.
+#: ../panels/printers/printer-entry.ui.h:11
+msgid "Please restart when the problem is resolved."
+msgstr "പ്രശ്നം പരിഹരിക്കുമ്പോള്‍ ദയവായി പുനരാരംഭിക്കുക"
+
+#. Translators: This is the button which restarts the printer.
+#: ../panels/printers/printer-entry.ui.h:13
+msgid "Restart"
+msgstr "പുനരാരംഭിക്കൂ"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:2
+msgid "Add…"
+msgstr "ചേര്‍ക്കുക..."
+
+#: ../panels/printers/printers.ui.h:5
+msgid "No printers"
+msgstr "പ്രിന്റെറുകളൊന്നും ഇല്ല"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:7
+msgid "Add a Printer…"
+msgstr "പ്രിന്റര്‍ ചേര്‍ക്കുക…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:9
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"ക്ഷമിയ്ക്കണം, സിസ്റ്റത്തിനുള്ള പ്രിന്റിങ് സര്‍വീസ്\n"
+"ലഭ്യമല്ല."
+
+#: ../panels/privacy/cc-privacy-panel.c:387 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "സ്ക്രീന്‍ പൂട്ട്"
+
+#: ../panels/privacy/cc-privacy-panel.c:438
+msgid "In use"
+msgstr "ഉപയോഗത്തല്‍ ഇരിക്കുന്നു"
+
+#: ../panels/privacy/cc-privacy-panel.c:443
+msgctxt "Location services status"
+msgid "On"
+msgstr "ഓണ്‍"
+
+#: ../panels/privacy/cc-privacy-panel.c:444
+msgctxt "Location services status"
+msgid "Off"
+msgstr "ഓഫ്"
+
+#: ../panels/privacy/cc-privacy-panel.c:823 ../panels/privacy/privacy.ui.h:42
+msgid "Location Services"
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:942 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "ഉപയോഗവും ചരിത്രവും"
+
+#: ../panels/privacy/cc-privacy-panel.c:1071
+msgid "Empty all items from Trash?"
+msgstr "ചവറ്റുകൊട്ട വൃത്തിയാക്കുക?"
+
+#: ../panels/privacy/cc-privacy-panel.c:1072
+msgid "All items in the Trash will be permanently deleted."
+msgstr "ചവറ്റുകുട്ടയിലെ വസ്തുകൾ ശാശ്വതമായി ഉപേക്ഷിക്കപ്പെടും"
+
+#: ../panels/privacy/cc-privacy-panel.c:1073
+msgid "_Empty Trash"
+msgstr "ചവറ്റുകുട്ട _ഒഴിപ്പിക്കുക"
+
+#: ../panels/privacy/cc-privacy-panel.c:1096
+msgid "Delete all the temporary files?"
+msgstr "ചവറ്റുകുട്ടയും താല്‍ക്കാലിക ഫയലുകളും ശൂന്യമാക്കുകയല്ലേ ?"
+
+#: ../panels/privacy/cc-privacy-panel.c:1097
+msgid "All the temporary files will be permanently deleted."
+msgstr "എല്ലാ താൽകാലിക രേഖകളും ശാശ്വതമായി ഉപേക്ഷിക്കപ്പെടും"
+
+#: ../panels/privacy/cc-privacy-panel.c:1098
+msgid "_Purge Temporary Files"
+msgstr "താല്‍ക്കാലിക ഫയലുകള്‍ _മായ്ക്കുക"
+
+#: ../panels/privacy/cc-privacy-panel.c:1120 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "ചവറ്റുകുട്ടയും താല്‍ക്കാലിക ഫയലുകളും ശൂന്യമാക്കുക"
+
+#: ../panels/privacy/cc-privacy-panel.c:1160 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr "സോഫ്റ്റ്‌വെയര്‍ ഉപയോഗം"
+
+#: ../panels/privacy/cc-privacy-panel.c:1201 ../panels/privacy/privacy.ui.h:46
+msgid "Problem Reporting"
+msgstr ""
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: ../panels/privacy/cc-privacy-panel.c:1215
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent anonymously and are scrubbed of "
+"personal data."
+msgstr ""
+
+#: ../panels/privacy/cc-privacy-panel.c:1227 ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "സ്വകാര്യത നയം"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Pri­va­cy"
+msgstr "സ്വകാര്യത"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:3
+msgid "Protect your personal information and control what others might see"
+msgstr "സ്വകാര്യ വിവരങ്ങള്‍ സംരക്ഷിക്കുക; മറ്റുള്ളവര്‍ എന്തു കാണണമെന്ന് തീരുമാനിക്കുക"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:5
+msgid "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;"
+msgstr "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "സ്ക്രീന്‍ ഓഫ് ആകുന്നു"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 സെക്കന്‍ഡുകള്‍"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 ദിവസം"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 ദിവസം"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 ദിവസം"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 ദിവസം"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 ദിവസം"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 ദിവസം"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 ദിവസം"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 ദിവസം"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 ദിവസം"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "എന്നന്നേക്കും"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are never shared over the network."
+msgstr "ചരിത്രം ഓര്‍മിച്ചുവെയ്ക്കുന്നത് കാര്യങ്ങള്‍ വിണ്ടും കണ്ടുപിടിക്കുന്നത് എളുപ്പമാക്കും. ഇത് ശ്രംഖല വഴി ഒരിക്കലും പങ്കിടില്ല."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "ഏറ്റവും _ഒടുവില്‍ ഉപയോഗിച്ച"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "ചരിത്രം _നിലനിര്‍ത്തുക"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "അടുത്തിടെയുള്ള ചരിത്രം _മായ്ക്കുക"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "നിങ്ങള്‍ ദൂരെയായിരിക്കുമ്പോള്‍ നിങ്ങളുടെ സ്വകാര്യത സ്ക്രീന്‍ പൂട്ട് സംരക്ഷിക്കുന്നു."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "തനിയെ സ്ക്രീന്‍ _പൂട്ടുക"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "സ്ക്രീന്‍ പൂട്ടുന്നതിനു മുന്പ് _ശൂന്യമായി"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "_അറിയിപ്പുകള്‍ കാണിയ്ക്കുക"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer free of unnecessary sensitive "
+"information."
+msgstr ""
+"ആവശ്യമില്ലാത്ത സ്വകാര്യ വിവരങ്ങള്‍ താങ്കളുടെ കമ്പ്യൂട്ടറില്‍ നിന്നും ഒഴിവാക്കാന്‍ തനിയെ ചവറ്റുകുട്ടയും താല്‍ക്കാലിക ഫയലുകളും നശിപ്പിക്കുക."
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "തനിയെ _ചവറ്റുകുട്ട ഒഴിപ്പിക്കുക"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "തനിയെ താല്‍ക്കാലിക _ഫയലുകള്‍ ഒഴിപ്പിക്കുക"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "_ശേഷം ഒഴിപ്പിക്കുക"
+
+#: ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash…"
+msgstr "ചവറ്റുകുട്ട ഒഴിപ്പിക്കുക (_E)"
+
+#: ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files…"
+msgstr "താല്‍ക്കാലിക ഫയലുകള്‍ മായ്ക്കുക (_P)…"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you with more accurate recommendations. "
+"It also helps us to improve our software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share your data with third parties."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "സോഫ്റ്റ്‌വെയര്‍ ഉപയോഗത്തിന്റെ വിവരം അയയ്ക്കുക"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and mobile broadband increases "
+"accuracy."
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:44
+msgid "_Location Services"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:47
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: ../panels/region/cc-format-chooser.c:118
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ഇംപീരിയല്‍"
+
+#: ../panels/region/cc-format-chooser.c:120
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "മെട്രിക്"
+
+#: ../panels/region/cc-format-chooser.c:285
+msgid "No regions found"
+msgstr "ഒരു മേഖലയും കണ്ടില്ല"
+
+#: ../panels/region/cc-input-chooser.c:182
+msgid "No input sources found"
+msgstr "ഇന്‍പുട്ട് ഉറവിടങ്ങളൊന്നും കണ്ടില്ല"
+
+#: ../panels/region/cc-input-chooser.c:1012
+msgctxt "Input Source"
+msgid "Other"
+msgstr "മറ്റുളളവ"
+
+#: ../panels/region/cc-region-panel.c:881
+msgid "No input source selected"
+msgstr "ഇന്‍പുട്ട് ഉറവിടങ്ങളൊന്നും എടുത്തില്ല"
+
+#: ../panels/region/cc-region-panel.c:1773
+msgid "Login _Screen"
+msgstr "പ്രവേശന സ്ക്രീന്‍ (_S)"
+
+#: ../panels/region/format-chooser.ui.h:1
+msgid "Formats"
+msgstr "ശൈലികള്‍"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "തിരനോട്ടം"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "തിയ്യതികള്‍"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "തവണ"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Dates & Times"
+msgstr "തീയതിയും സമയവും"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Numbers"
+msgstr "സംഖ്യകള്‍"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Measurement"
+msgstr "അളവു്"
+
+#: ../panels/region/format-chooser.ui.h:10
+msgid "Paper"
+msgstr "കടലാസ്"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid "Re­gion & Lan­guage"
+msgstr "സ്ഥലവും ഭാഷയും"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
+msgid "Select your display language, formats, keyboard layouts and input sources"
+msgstr "നിങ്ങളുടെ ഭാഷ, ഘടന, കീബോർഡ് മാതൃക, ഇൻപുട്ട് സോർസ് എന്നിവ തിരഞ്ഞെടുക്കുക"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:5
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "ഇന്‍പുട്ട് ഉറവിടം ചേര്‍ക്കുക"
+
+#: ../panels/region/input-chooser.ui.h:4
+msgid "Input methods can’t be used on the login screen"
+msgstr "പ്രവേശിക്കുമ്പോള്‍ ഇന്‍പുട്ട് മെത്തേഡുകള്‍ ഉപയോഗിക്കാനാവില്ല"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "ഇന്‍പുട്ട് ഉറവിട സജ്ജീകരണങ്ങള്‍"
+
+#: ../panels/region/input-options.ui.h:2
+msgid "Use the _same source for all windows"
+msgstr "എല്ലാ വിന്‍ഡോയ്ക്കും _ഒരേ സ്ത്രോതസ്സ് ഉപയോഗിക്കുക"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Allow _different sources for each window"
+msgstr "ഓരോ ജാലകത്തിനും _വെവ്വേറെ സ്ത്രോതസ്സുകള്‍ അനുവദിക്കുക"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Switch to previous source"
+msgstr "മുമ്പുള്ള ശ്രോതസ്സിലേക്കു് മാറുക"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Switch to next source"
+msgstr "അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുക"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Super+Space"
+msgstr "നല്ലത്+സ്ഥലം"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr " കീ ക്രമം മാറ്റികൊണ്ട് ഈ ഷോർട്ട്കട്ട് മാറ്റാവുന്നതാണ്"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "Alternative switch to next source"
+msgstr "പകരം അടുത്ത ശ്രോതസ്സിലേക്കു് മാറുക"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Left+Right Alt"
+msgstr "വലത്+ഇടത് ആള്‍ട്ട്"
+
+#: ../panels/region/region.ui.h:1 ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "ഭാ_ഷ"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "ഇംഗ്ലീഷ് (യുണിറ്റഡ് കിങ്ഡം)"
+
+#: ../panels/region/region.ui.h:3
+msgid "Restart the session for changes to take effect"
+msgstr "മാറ്റങ്ങള്‍ കാണാന്‍ പുറത്തിറങ്ങുക"
+
+#: ../panels/region/region.ui.h:4
+msgid "Restart…"
+msgstr "പുനരാരംഭിക്കുക…"
+
+#: ../panels/region/region.ui.h:5
+msgid "_Formats"
+msgstr "ശൈലികള്‍ (_F)"
+
+#: ../panels/region/region.ui.h:6
+msgid "United Kingdom"
+msgstr "യുണിറ്റഡ് കിങ്ഡം"
+
+#: ../panels/region/region.ui.h:7
+msgid "Input Sources"
+msgstr "ഇന്‍പുട്ട് ഉറവിടങ്ങള്‍"
+
+#: ../panels/region/region.ui.h:8
+msgid "_Options"
+msgstr "_ഐച്ഛികങ്ങള്‍"
+
+#: ../panels/region/region.ui.h:9
+msgid "Add input source"
+msgstr "ഇന്‍പുട്ട് ഉറവിടം ചേര്‍ക്കുക"
+
+#: ../panels/region/region.ui.h:10
+msgid "Remove input source"
+msgstr "ഇന്‍പുട്ട് ഉറവിടം വെട്ടി നീക്കുക"
+
+#: ../panels/region/region.ui.h:11
+msgid "Move input source up"
+msgstr "ഇന്‍പുട്ട് ഉറവിടം മുകളിലേക്കു് നീക്കുക"
+
+#: ../panels/region/region.ui.h:12
+msgid "Move input source down"
+msgstr "ഇന്‍പുട്ട് ഉറവിടം താഴേയ്ക്ക് നീക്കുക"
+
+#: ../panels/region/region.ui.h:13
+msgid "Configure input source"
+msgstr "ഇന്‍പുട്ട് ശ്രോതസ്സ് സജ്ജീകരിക്കുക"
+
+#: ../panels/region/region.ui.h:14
+msgid "Show input source keyboard layout"
+msgstr "കീബോര്‍ഡ് വിന്യാസം കാണിയ്ക്കുക"
+
+#: ../panels/region/region.ui.h:15
+msgid "Login settings are used by all users when logging into the system"
+msgstr "സിസ്റ്റത്തിലേക്ക് പ്രവേശിക്കുമ്പോള്‍ എല്ലാ ഉപയോക്താകളും പ്രവേശന കൃമീകരണങ്ങള്‍ ഉപയോഗിക്കും"
+
+#: ../panels/search/cc-search-locations-dialog.c:639
+msgid "Select Location"
+msgstr "സ്ഥലം തെരഞ്ഞെടുക്കുക"
+
+#: ../panels/search/cc-search-locations-dialog.c:643
+msgid "_OK"
+msgstr "ശരി"
+
+#: ../panels/search/cc-search-panel.c:178
+msgid "No applications found"
+msgstr "ഒരു പ്രയോഗങ്ങളും കണ്ടില്ല"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid "Search"
+msgstr "തെരച്ചില്‍"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:3
+msgid "Control which applications show search results in the Activities Overview"
+msgstr "പ്രവര്‍ത്തനങ്ങളില്‍ ഏതൊക്കെ പ്രയോഗങ്ങള്‍ തെരയല്‍ ഫലങ്ങള്‍ കാണുമെന്ന് തീരുമാനിക്കുക"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:5
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "സ്ഥലം തെരയുക"
+
+#: ../panels/search/search-locations-dialog.ui.h:2
+msgid "Places"
+msgstr "സ്ഥലങ്ങള്‍"
+
+#: ../panels/search/search-locations-dialog.ui.h:3
+msgid "Bookmarks"
+msgstr "ഓര്‍മ്മക്കുറിപ്പുകള്‍"
+
+#: ../panels/search/search-locations-dialog.ui.h:4
+msgid "Other"
+msgstr "മറ്റുളളവ"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "മുകളിലേയ്ക്കു് മാറ്റുക"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "താഴേയ്ക്കു് മാറ്റുക"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "മുന്‍ഗണനകള്‍"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:303
+msgid "No networks selected for sharing"
+msgstr ""
+
+#: ../panels/sharing/cc-sharing-panel.c:266
+msgctxt "service is enabled"
+msgid "On"
+msgstr "ഓണ്‍ "
+
+#: ../panels/sharing/cc-sharing-panel.c:268 ../panels/sharing/cc-sharing-panel.c:295
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "ഓഫ്"
+
+#: ../panels/sharing/cc-sharing-panel.c:298
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "പ്രവര്‍ത്തന സജ്ജം"
+
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is active"
+msgid "Active"
+msgstr "സജ്ജമാണ്"
+
+#: ../panels/sharing/cc-sharing-panel.c:372
+msgid "Choose a Folder"
+msgstr "ഒരു ഫോള്‍ഡര്‍ തിരയുക"
+
+#: ../panels/sharing/cc-sharing-panel.c:683
+#, c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on your current network using: <a "
+"href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"<a href=\"dav://%s\">dav://%s</a> ഉപയോഗിച്ച് ഇപ്പോഴത്തെ ശ്രംഖലയില്‍ പൊതുവായ ഫോള്‍ഡറുകള്‍ പങ്കിടാന്‍ സ്വകാര്യ ഫയല്‍ പങ്കിടല്‍ "
+"അനുവദിക്കുന്നു"
+
+#: ../panels/sharing/cc-sharing-panel.c:685
+#, fuzzy, c-format
+#| msgid ""
+#| "Allow remote users to connect using the Secure Shell command:\n"
+#| "<a href=\"ssh %s\">ssh %s</a>"
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"വിദൂര ഉപയോക്താക്കളെ സുരക്ഷിത ഷെല്‍ ഉപയോഗിച്ച് ബന്ധിപ്പിക്കാന്‍ അനുവദിക്കുന്നു:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/cc-sharing-panel.c:687
+#, fuzzy, c-format
+#| msgid "Allow remote users to view or control your screen by connecting to: <a href=\"vnc://%s\">vnc://%s</a>"
+msgid ""
+"Screen sharing allows remote users to view or control your screen by connecting to <a href=\"vnc://%s\">vnc://"
+"%s</a>"
+msgstr "വിദൂര ഉപയോക്താക്കളെ താങ്കളുടെ സ്ക്രീന്‍ കാണുവാനോ നിയന്ത്രിക്കുവാനോ അനുവദിക്കുന്നു: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/cc-sharing-panel.c:799
+msgid "Copy"
+msgstr "പകര്‍ത്തുക"
+
+#: ../panels/sharing/cc-sharing-panel.c:1125
+msgid "Sharing"
+msgstr "പങ്കിടല്‍"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Sha­ring"
+msgstr "പങ്കിടല്‍"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:3
+msgid "Control what you want to share with others"
+msgstr "മറ്റുളളവരുമായി പങ്കിടുന്നത് നിയന്തിക്കുക"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:5
+msgid "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;movies;server;renderer;"
+msgstr "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;movies;server;renderer;"
+
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "ശൃംഖല"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "വിദൂര പ്രവേശിക്കല്‍ പ്രവര്‍ത്തനസജ്ജം/രഹിതം ആക്കുക"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "വിദൂര പ്രവേശനം പ്രവര്‍ത്തനസജ്ജമാക്കാന്‍/രഹിതമാക്കാന്‍ ആധികാരികത ഉറപ്പ് വരുത്തേണ്ടതുണ്ട്"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "_Computer Name"
+msgstr "കമ്പ്യൂട്ടറിന്റെ പേരു് (_C)"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid "_File Sharing"
+msgstr "ഫയല്‍ പങ്കിടല്‍ (_F)"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "_Screen Sharing"
+msgstr "സ്ക്രീന്‍ പങ്കിടല്‍ (_S)"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "_Media Sharing"
+msgstr "മീഡിയ പങ്കിടല്‍ (_M)"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "_Remote Login"
+msgstr "വിദൂര പ്രവേശനം (_R)"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Some services are disabled because of no network access."
+msgstr "ശ്രംഖല ബന്ധമില്ലാത്തത് കൊണ്ട് ചില സേവനങ്ങള്‍ നിര്‍ത്തി വെച്ചിരിക്കുന്നു."
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "File Sharing"
+msgstr "ഫയല്‍ പങ്കിടല്‍"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "_Require Password"
+msgstr "രഹസ്യവാക്ക് ആവശ്യമുണ്ടു് (_R)"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Remote Login"
+msgstr "വിദൂര പ്രവേശനം"
+
+#: ../panels/sharing/sharing.ui.h:11
+msgid "Screen Sharing"
+msgstr "സ്ക്രീന്‍ പങ്കിടല്‍"
+
+#: ../panels/sharing/sharing.ui.h:12
+msgid "_Allow connections to control the screen"
+msgstr ""
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "_Password:"
+msgstr "രഹസ്യവാക്ക് (_P):"
+
+#: ../panels/sharing/sharing.ui.h:14
+msgid "_Show Password"
+msgstr "രഹസ്യവാക്ക് കാണിയ്ക്കുക (_S)"
+
+#: ../panels/sharing/sharing.ui.h:15
+msgid "Access Options"
+msgstr "ഐച്ഛികങ്ങള്‍"
+
+#: ../panels/sharing/sharing.ui.h:16
+msgid "_New connections must ask for access"
+msgstr "പുതിയ ബന്ധങ്ങള്‍ പ്രവേശനത്തിനായി ചോദിക്കണം (_S)"
+
+#: ../panels/sharing/sharing.ui.h:17
+msgid "_Require a password"
+msgstr "രഹസ്യവാക്ക് ആവശ്യമുണ്ടു് (_R)"
+
+#: ../panels/sharing/sharing.ui.h:18
+msgid "Media Sharing"
+msgstr "മീഡിയ പങ്കിടല്‍"
+
+#: ../panels/sharing/sharing.ui.h:19
+msgid "Share music, photos and videos over the network."
+msgstr "ശൃംഖലയിലുള്ള ആളുകളുമായി പാട്ടുകള്‍, ചിത്രങ്ങള്‍, ചലചിത്രങ്ങള്‍ തുടങ്ങിയവ പങ്കുവെയ്ക്കു."
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Folders"
+msgstr "ഫോള്‍ഡറുകള്‍"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "ശബ്ദം"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ശബ്ദത്തിന്റെ നിലയും, ഇന്‍പുട്ടുകളും, ഔട്ട്പുട്ടുകളും, അലെര്‍ട്ട് ശബ്ദങ്ങളും മാറ്റുക"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "ബാര്‍ക്ക്"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "ഡ്രിപ്"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "ഗ്ലാസ്"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "സോണാര്‍"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "ഇടത്"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "വലത്"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "പിന്നില്‍"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "മുന്നില്‍"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "ഏറ്റവും കുറഞ്ഞ"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "ഏറ്റവും കൂടിയ"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "_ബാലന്‍സ്:"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "_മങ്ങുക:"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "_സബ്‌വൂഫര്‍:"
+
+#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:615
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "അണ്‍ആംപ്ലിഫൈഡ്"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
+#: ../panels/sound/gvc-mixer-dialog.c:515
+msgid "_Profile:"
+msgstr "പ്രൊ_ഫൈല്‍:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1873
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u ഔട്ട്പുട്ട്"
+msgstr[1] "%u ഔട്ട്പുട്ടുകള്‍"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1883
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ഇന്‍പുട്ട്"
+msgstr[1] "%u ഇന്‍പുട്ടുകള്‍"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2738
+msgid "System Sounds"
+msgstr "സിസ്റ്റത്തിന്റെ ശബ്ദങ്ങള്‍"
+
+#: ../panels/sound/gvc-mixer-dialog.c:251
+msgid "_Test Speakers"
+msgstr "സ്പീക്കറുകള്‍ _പരിശോധിയ്ക്കുക"
+
+#: ../panels/sound/gvc-mixer-dialog.c:420
+msgid "Peak detect"
+msgstr "പീക്ക് കണ്ടുപിടിക്കല്‍"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1512
+msgid "Device"
+msgstr "ഡിവൈസ്"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1575
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s-നുള്ള സ്പീക്കര്‍ പരീക്ഷണം"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1631
+msgid "_Output volume:"
+msgstr "_ഔട്ട്പുട്ട് വോള്യം: "
+
+#: ../panels/sound/gvc-mixer-dialog.c:1645
+msgid "Output"
+msgstr "ഔട്ട്പുട്ട്"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1650
+msgid "C_hoose a device for sound output:"
+msgstr "ശബ്ദ ഔട്ട്പുട്ടിനുള്ള ഒരു ഡിവൈസ് _തെരഞ്ഞെടുക്കുക:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1672
+msgid "Settings for the selected device:"
+msgstr "തെരഞ്ഞെടുത്ത ഉപകരണത്തിന്റെ ക്രമീകരണങ്ങള്‍:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1683
+msgid "Input"
+msgstr "നിവേശകം"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1690
+msgid "_Input volume:"
+msgstr "_ഇന്‍പുട്ട് വോള്യം: "
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "Input level:"
+msgstr "ഇന്‍പുട്ട് ലെവല്‍:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1737
+msgid "C_hoose a device for sound input:"
+msgstr "ശബ്ദ ഇന്‍പുട്ടിനുള്ള ഒരു ഡിവൈസ് _തെരഞ്ഞെടുക്കുക:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1761
+msgid "Sound Effects"
+msgstr "ശബ്ദ പ്രവാഹങ്ങള്‍"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1768
+msgid "_Alert volume:"
+msgstr "_മുന്നറിയിപ്പിനുള്ള ശബ്ദം: "
+
+#: ../panels/sound/gvc-mixer-dialog.c:1785
+msgid "No application is currently playing or recording audio."
+msgstr "ഓഡിയോ റിക്കോര്‍ഡ് ചെയ്യുന്നില്ല അല്ലെങ്കില്‍ നിലവില്‍ ഒരു പ്രയോഗവും പ്രവര്‍ത്തിക്കുന്നില്ല"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "ബിള്‍ട്ടിന്‍"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454 ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "ശബ്ദ മുന്‍ഗണനകള്‍"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457 ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "ഇവന്റ് ശബ്ദം പരീക്ഷിക്കുന്നു"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:554 ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "Default"
+msgstr "സഹജമായ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:555
+msgid "From theme"
+msgstr "പ്രമേയത്തില്‍ നിന്നും"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:740
+msgid "C_hoose an alert sound:"
+msgstr "മുന്നറിയിപ്പ് ശബ്ദം _തെരഞ്ഞെടുക്കുക:"
+
+#: ../panels/sound/gvc-speaker-test.c:231
+msgid "Stop"
+msgstr "നിര്‍ത്തുക"
+
+#: ../panels/sound/gvc-speaker-test.c:231 ../panels/sound/gvc-speaker-test.c:343
+msgid "Test"
+msgstr "പരീക്ഷിക്കുക"
+
+#: ../panels/sound/gvc-speaker-test.c:239
+msgid "Subwoofer"
+msgstr "സബ്‌വൂഫര്‍"
+
+#: ../panels/sound/sound-theme-file-utils.c:304
+msgid "Custom"
+msgstr "യഥേഷ്ടം"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: ../panels/universal-access/cc-ua-panel.c:351
+msgctxt "cursor size"
+msgid "Default"
+msgstr "സാധാരണ"
+
+#: ../panels/universal-access/cc-ua-panel.c:354
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "ഇടത്തരം"
+
+#: ../panels/universal-access/cc-ua-panel.c:357
+msgctxt "cursor size"
+msgid "Large"
+msgstr "വലിയ"
+
+#: ../panels/universal-access/cc-ua-panel.c:360
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "വലിയതു്"
+
+#: ../panels/universal-access/cc-ua-panel.c:363
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "ഏറ്റവും വലിയ"
+
+#: ../panels/universal-access/cc-ua-panel.c:367
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d പിക്സല്‍"
+msgstr[1] "%d പിക്സലുകള്‍"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Uni­ver­sal Access"
+msgstr "സാര്‍വ്വജനികലഭ്യത"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "കാഴ്ച്ച, കേൾവി, മുദ്രണം, പോയിന്റ്, ക്ലിക്ക് എന്നിവ മെച്ചപെടുത്തുക"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:5
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;"
+"Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;"
+"Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "എപ്പോഴും സര്‍വ്വവ്യാപിയായ പ്രവേശനത്തിനുള്ള മെനു കാണിക്കാം"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "കാണുക"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "കൂടിയ കോണ്ട്രാസ്റ്റ്"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "വലിയ പദാവലി"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "C_ursor Size"
+msgstr "കഴ്സര്‍ വലിപ്പം (_u)"
+
+#: ../panels/universal-access/uap.ui.h:6 ../panels/universal-access/zoom-options.ui.h:7
+msgid "_Zoom"
+msgstr "വലിപ്പം മാറ്റുക"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "Screen _Reader"
+msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "_Sound Keys"
+msgstr "സൗണ്ട് കീകള്‍"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "Hearing"
+msgstr "കേള്‍വി"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgid "_Visual Alerts"
+msgstr "ദൃശ്യമാകുന്ന അറിയിപ്പുകള്‍"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "Screen _Keyboard"
+msgstr "സ്ക്രീന്‍ കീബോര്‍ഡ്"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "R_epeat Keys"
+msgstr "കീ ആവര്‍ത്തിക്കുക (_e)"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "Cursor _Blinking"
+msgstr "കഴ്സര്‍ മിന്നല്‍"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Typing Assist (AccessX)"
+msgstr "_ക്രമീകരണ അസ്സിസ്റ്റന്റ് (AccessX)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Pointing & Clicking"
+msgstr "ചൂണ്ടുകയും ക്ലിക്ക് ചെയ്യുകയും"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "_Mouse Keys"
+msgstr "മൌസ് കീകള്‍"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Click Assist"
+msgstr "ക്ലിക്ക് അസിസ്റ്റ്"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "_Double-Click Delay"
+msgstr "ഇരട്ട ക്ലിക്ക് ഡിലേ (_D)"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Double-Click Delay"
+msgstr "ഇരട്ട ക്ലിക്ക് ഡിലേ"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Cursor Size"
+msgstr "കഴ്സര്‍ വലിപ്പം"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Screen Reader"
+msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "_Screen Reader"
+msgstr "സ്ക്രീന്‍ വായനക്കാരന്‍"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Sound Keys"
+msgstr "സൗണ്ട് കീകള്‍"
+
+#: ../panels/universal-access/uap.ui.h:28
+#, fuzzy
+#| msgid "Beep when _accessibility features are turned on or off"
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "കീ ബോര്‍ഡില്‍ സ_വിശേഷതകള്‍ ഓണ്‍ ചെയ്യുമ്പോഴോ ഓഫ് ചെയ്യുമ്പോഴോ ശബ്ദമുണ്ടാക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Visual Alerts"
+msgstr "കാണുന്ന അറിയിപ്പുകള്‍"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Test flash"
+msgstr "ഫ്ളാഷ് _പരീക്ഷിയ്ക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ഒരു അറിയിപ്പു് ശബ്ദമുണ്ടാകുമ്പോള്‍ ഒരു ദൃശ്യ സൂചന ഉപയോഗിയ്ക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Flash the _window title"
+msgstr "ജാലക തലക്കെട്ട് മിന്നിമറയുക"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Flash the entire _screen"
+msgstr "സ്ക്രീന്‍ മൊത്തം മിന്നിക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Repeat Keys"
+msgstr "കീ ആവര്‍ത്തിക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:35
+#, fuzzy
+#| msgid "Key presses _repeat when key is held down"
+msgid "Key presses repeat when key is held down."
+msgstr "കീ അമര്‍ത്തിപ്പിടിച്ചാല്‍ കീകള്‍ _ആവര്‍ത്തിക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:37
+#, fuzzy
+#| msgid "Repeat keys speed"
+msgid "Repeat keys delay"
+msgstr "കീയുടെ വേഗത ഇരട്ടിപ്പിക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Speed"
+msgstr "വേഗത"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Repeat keys speed"
+msgstr "കീയുടെ വേഗത ഇരട്ടിപ്പിക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Cursor Blinking"
+msgstr "സൂചികയുടെ മിന്നല്‍"
+
+#: ../panels/universal-access/uap.ui.h:41
+#, fuzzy
+#| msgid "Cursor _blinks in text fields"
+msgid "Cursor blinks in text fields."
+msgstr "ടെക്സ്റ്റ് ബോക്സുകളിലും ഫീല്‍ഡുകളിലും സൂചകം _മിന്നട്ടെ"
+
+#: ../panels/universal-access/uap.ui.h:42
+#, fuzzy
+#| msgid "Cursor blink speed"
+msgid "Cursor blinking speed"
+msgstr "സൂചകം മിന്നുന്നതിന്റെ വേഗത"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgid "Typing Assist"
+msgstr "_ടെപ്പിങ് അസ്സിസ്റ്റ്"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "_Sticky Keys"
+msgstr "സ്റ്റിക്കി കീകള്‍"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "തുടരെയുള്ള മോഡിഫയര്‍ കീകള്‍ കീക്കൂട്ടമായി കരുതപ്പെടുന്നു"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Disable if two keys are pressed together"
+msgstr "രണ്ട് കീ ഒരുമിച്ച് അമര്‍ത്തിയാല്‍ പ്രവര്‍ത്തന _രഹിതമാക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:47
+#, fuzzy
+#| msgid "Beep when a _modifer key is pressed"
+msgid "Beep when a _modifier key is pressed"
+msgstr "_മോഡിഫയര്‍ അമര്‍ത്തുമ്പോള്‍ ശബ്ദമുണ്ടാക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "S_low Keys"
+msgstr "സ്ലോ കീകള്‍"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "ഒരു കീ അമര്‍ത്തുന്നതിനും സ്വീകരിയ്ക്കുന്നതിനും ഇടയില്‍ ഒരു ഇടവേള നല്‍കുക"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "A_cceptance delay:"
+msgstr "_ആക്സെപ്റ്റെന്‍സ് ഡിലേ:"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "കുറഞ്ഞ"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Slow keys typing delay"
+msgstr "കീകള്‍ ടൈപ്പ് ചെയ്യുന്നതിനുള്ള താമസം"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "കൂടിയ"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "Beep when a key is pr_essed"
+msgstr "_ടോഗിള്‍ കീ അമര്‍ത്തുമ്പോള്‍ ശബ്ദമുണ്ടാക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Beep when a key is _accepted"
+msgstr "കീ _സ്വീകരിച്ചുവെങ്കില്‍ ശബ്ദമുണ്ടാക്കാം"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "Beep when a key is _rejected"
+msgstr "കീ _നിരസിച്ചുവെങ്കില്‍ ശബ്ദമുണ്ടാക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgid "_Bounce Keys"
+msgstr "ബൌണ്‍സ് കീകള്‍"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgid "Ignores fast duplicate keypresses"
+msgstr "പെട്ടെന്നുള്ള ഇരട്ട കീ അമര്‍ത്തലുകളെ അവഗണിക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "കുറഞ്ഞ"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgid "Bounce keys typing delay"
+msgstr "ബൌണ്‍സ് കീകള്‍ ടൈപ്പ് ചെയ്യുന്ന താമസം"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "കൂടിയ"
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "_Enable by Keyboard"
+msgstr "കീബോര്‍ഡ് ഉപയോഗിച്ചു് സജ്ജമാക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "കീബോര്‍ഡ് എളുപ്പവഴികള്‍ ഉപയോഗിച്ചു് ആക്സസിബിളിറ്റി വിശേഷതകള്‍ ടൊഗിള്‍ ചെയ്യുവാന്‍ സാധിക്കുന്നു"
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "Click Assist"
+msgstr "ക്ലിക്ക് അസിസ്റ്റ്"
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "_Simulated Secondary Click"
+msgstr "സിമുലേറ്റ് ചെയ്ത രണ്ടാമത്തെ ക്ലിക്ക്"
+
+#: ../panels/universal-access/uap.ui.h:66
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "പ്രൈമറി ബട്ടണ്‍ അമര്‍ത്തിക്കൊണ്ടു് സെക്കണ്ടറി ക്ലിക്ക് നടപ്പിലാക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:67
+msgctxt "secondary click"
+msgid "Short"
+msgstr "കുറഞ്ഞ"
+
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Secondary click delay"
+msgstr "രണ്ടാമത്  ഞെക്കു് പ്രാവര്‍ത്തികമാക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "കൂടിയ"
+
+#: ../panels/universal-access/uap.ui.h:70
+msgid "_Hover Click"
+msgstr "ചുറ്റിപ്പറ്റിയുള്ള ക്ലിക്ക്"
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Trigger a click when the pointer hovers"
+msgstr "പോയിന്റര്‍ നീക്കം നിര്‍ത്തുമ്പോള്‍ ക്ലിക്ക് ആരംഭിക്കുക"
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "D_elay:"
+msgstr "ഇ_ടവേള:"
+
+#: ../panels/universal-access/uap.ui.h:73
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "കുറഞ്ഞ"
+
+#: ../panels/universal-access/uap.ui.h:74
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "കൂടിയ"
+
+#: ../panels/universal-access/uap.ui.h:75
+msgid "Motion _threshold:"
+msgstr "നീക്കത്തിന്റെ ത്രെഷോ_ള്‍ഡ്:"
+
+#: ../panels/universal-access/uap.ui.h:76
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "ചെറിയ"
+
+#: ../panels/universal-access/uap.ui.h:77
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "വലിയ"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "ലഘു"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ സ്ക്രീന്‍"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ സ്ക്രീന്‍"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ സ്ക്രീന്‍"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "നീളമുള്ള"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "സ്ക്രീന്‍ പൂര്‍ണ്ണവലിപ്പത്തില്‍"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "മുകള്‍ പകുതി"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "താഴെയുള്ള പകുതി"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "ഇടതു് പകുതി"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "വലതു് പകുതി"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "വലിപ്പത്തിനുള്ള ഐച്ഛികങ്ങള്‍"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+#, fuzzy
+#| msgid "Magnification:"
+msgid "_Magnification:"
+msgstr "വിപുലീകരണം:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+#, fuzzy
+#| msgid "Follow mouse cursor"
+msgid "_Follow mouse cursor"
+msgstr "മൌസ് കര്‍സര്‍ തുടരുക"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+#, fuzzy
+#| msgid "Screen part:"
+msgid "_Screen part:"
+msgstr "സ്ക്രീനിന്റെ ഭാഗം:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+#, fuzzy
+#| msgid "Magnifier extends outside of screen"
+msgid "Magnifier _extends outside of screen"
+msgstr "സ്ക്രീനിന്റെ പുറത്തു് മാഗ്നിഫൈ ചെയ്യുക"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+#, fuzzy
+#| msgid "Keep magnifier cursor centered"
+msgid "_Keep magnifier cursor centered"
+msgstr "മാഗ്നഫയര്‍ കര്‍സര്‍ മദ്ധ്യത്തിലാക്കുക"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+#, fuzzy
+#| msgid "Magnifier cursor pushes contents around"
+msgid "Magnifier cursor _pushes contents around"
+msgstr "ഉള്ളടക്കവുമായി മാഗ്നിഫയര്‍ കര്‍സര്‍ തുടരുന്നു"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+#, fuzzy
+#| msgid "Magnifier cursor moves with contents"
+msgid "Magnifier cursor moves with _contents"
+msgstr "ഉള്ളടക്കവുമായി മാഗ്നിഫയര്‍ കര്‍സര്‍ നീങ്ങുന്നു"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "മാഗ്നിഫയര്‍ സ്ഥാനം:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "മാഗ്നിഫയര്‍"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+#, fuzzy
+#| msgid "Thickness:"
+msgid "_Thickness:"
+msgstr "കട്ടിയുള്ള:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "കട്ടികുറഞ്ഞ"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "കട്ടിയുള്ള"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "_Length:"
+msgstr "നീളം (_L):"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Co_lor:"
+msgstr "നിറം (_l):"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+#, fuzzy
+#| msgid "Crosshairs:"
+msgid "_Crosshairs:"
+msgstr "ക്രോസ്സ്ഹെയര്‍സ്:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+#, fuzzy
+#| msgid "Overlaps mouse cursor"
+msgid "_Overlaps mouse cursor"
+msgstr "മൗസ് കര്‍സര്‍ തിരുത്തുന്നു"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "ക്രോസ്സ്ഹെയര്‍സ്"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "_White on black:"
+msgstr "കറുപ്പില്‍ വെളുപ്പു് (_W):"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "_Brightness:"
+msgstr "തെളിച്ചം (_B):"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "_Contrast:"
+msgstr "കോണ്ട്രാസ്റ്റ് (_C):"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "നിറം (_l)"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "ഒന്നുമില്ല"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "മുഴുവന്‍"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "കുറഞ്ഞ"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "കൂടിയ"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "കുറഞ്ഞ"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "കൂടിയ"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "നിറ പ്രവാഹങ്ങള്‍:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "നിറ പ്രവാഹങ്ങള്‍"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1 ../panels/user-accounts/data/join-dialog.ui.h:1
+msgid "Add User"
+msgstr "ഉപയോക്താവിനെ ചേര്‍ക്കുക"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "_Full Name"
+msgstr "മുഴു_വന്‍ പേരു്"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6 ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Standard"
+msgstr "സാധാരണ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7 ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Administrator"
+msgstr "അഡ്മിനിസ്ട്രേറ്റര്‍"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8 ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Account _Type"
+msgstr "അക്കൌണ്ട് _തരം"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "Allow user to set a password when they next _login"
+msgstr "ഉപയോക്താവ് അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കാന്‍ അനുവദിക്കുക (_l)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid "Set a password _now"
+msgstr "ഉടന്‍ ഒരു രഹസ്യവാക്ക് സജ്ജമാക്കുക (_n)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid "_Confirm"
+msgstr "ഉറപ്പാക്കുക (_C)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:14
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be used on this device. You can also "
+"use this account to access company resources on the internet."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15 ../panels/user-accounts/data/join-dialog.ui.h:9
+msgid "_Domain"
+msgstr "ഡൊ_മെയിന്‍"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+msgid "You are Offline"
+msgstr "നിങ്ങള്‍ ഓഫ്‌ലൈന്‍ ആണ്"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+msgid "You must be online in order to add enterprise users."
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:18
+msgid "_Enterprise Login"
+msgstr "_എന്റര്‍പ്രൈസ് ലോഗിന്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "ഇടത്ത് തള്ളവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "ഇടത്തു് നടുവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "ഇടത്തു് മോതിരവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "ഇടത്തു് ചെറുവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "വലത്ത് തള്ളവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "വലത്തു് നടുവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "വലത്തു് മോതിരവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "വലത്തു് ചെറുവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9 ../panels/user-accounts/um-fingerprint-dialog.c:680
+msgid "Enable Fingerprint Login"
+msgstr "ഫിംഗര്‍പ്രിന്റ് ലോഗിന്‍ സജ്ജമാക്കുക"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "_വലത്തു് ചൂണ്ടുവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "_ഇടത്തു് ചൂണ്ടുവിരല്‍"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "_മറ്റ് വിരല്‍:"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
+msgstr ""
+"നിങ്ങളുടെ വിരലടയാളം വിജയകരമായി സൂക്ഷിച്ചിരിക്കുന്നു. നിങ്ങള്‍ക്കിനി ഫിംഗര്‍പ്രിന്റ് റീഡര്‍ ഉപയോഗിച്ചു് ലോഗിന്‍ ചെയ്യുവാന്‍ സാധിക്കുന്നതാണു്."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "ഉപയോക്താക്കള്‍"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "ഉപയോക്താക്കള്‍ ചേര്‍ക്കുക അല്ലെങ്കില്‍ വെട്ടി നീക്കുക; രഹസ്യവാക്ക് മാറ്റുക"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/join-dialog.ui.h:4
+msgid "_Enroll"
+msgstr "ചേർക്കുക (_E)"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:5
+msgid "Domain Administrator Login"
+msgstr "ഡൊമെയിന്‍ അഡ്മിനിസ്ട്രേറ്ററിനുള്ള പ്രവേശനം"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:6
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"എന്റര്‍പ്രൈസ് പ്രവേശനങ്ങള്‍ ഉപയോഗിയ്ക്കുന്നതിനു്, ഈ കമ്പ്യൂട്ടര്‍ ഒരു ഡൊമെയിനില്‍ എന്‍റോള്‍ ചെയ്യേണ്ടതുണ്ടു്. ഇവിടെ ഡൊമെയിനുള്ള രഹസ്യവാക്ക് ടൈപ്പ് "
+"ചെയ്യുന്നതിനായി നിങ്ങളുടെ നെറ്റ്‌വര്‍ക്ക് അഡ്മിസിട്രേറ്ററോടു് ആവശ്യപ്പെടുക."
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:10
+msgid "Administrator _Name"
+msgstr "അഡ്മിനിസ്ട്രേറ്ററിന്റെ _പേരു്"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:11
+msgid "Administrator Password"
+msgstr "അഡ്മിനിസ്ട്രേറ്ററിനുള്ള രഹസ്യവാക്ക്"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr "അടയാളവാക്ക് _മാറ്റുക"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "മാറ്റു_ക"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "പുതിയ രഹസ്യവാക്ക് ഉറപ്പുവരുത്തുക"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "പുതി_യ രഹസ്യവാക്ക്"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "നിലവിലുളള _രഹസ്യവാക്ക്"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to change their password on next login"
+msgstr "ഉപയോക്താവ് അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കാന്‍ അനുവദിക്കുക"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "ഉടന്‍ ഒരു രഹസ്യവാക്ക് സജ്ജമാക്കുക"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+msgid "_Add User…"
+msgstr "ഉപയോക്താവിനെ ചേര്‍ക്കുക (_A)…"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "മാറ്റങ്ങള്‍ കാണാന്‍ പുറത്തിറങ്ങുക"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Restart Now"
+msgstr "റിസ്റ്റാർട്ട് ചെയ്യുക"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "ഓട്ടോമാറ്റിക് പ്രവേശനം"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "ഫിം_ ഗര്‍പിന്റ് ലോഗിന്‍"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "ഉപയോക്തൃ ചിഹ്നം"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "അവസാന പ്രവേശനം"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "Remove User…"
+msgstr "ഉപയോക്താവിനെ കളയുക…"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "ഉപയോക്തൃ അക്കൗണ്ടുകള്‍ കൈകാര്യം ചെയ്യുക"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "ഉപയോക്താവിനുള്ള ഡേറ്റാ മാറ്റുന്നതിനായി ആധികാരികത ഉറപ്പ് വരുത്തല്‍ ആവശ്യമുണ്ട്"
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "പുതിയ രഹസ്യവാക്ക് പഴയ രഹസ്യവാക്കില്‍ നിന്നും വ്യത്യസ്തമായിരിക്കണം."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "കുറച്ച് അക്കങ്ങളും അക്ഷരങ്ങളും മാറ്റി നോക്കുക"
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "രഹസ്യവാക്ക് ഒന്നുകൂടി മാറ്റാന്‍ ശ്രമിക്കുക."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "താങ്കളുടെ ഉപയോക്തൃനാമം ഇല്ലാത്ത ഒരു അടയാളവാക്ക് ആയിരിക്കും കൂടുതൽ ബലിഷ്ഠം."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "താങ്കളുടെ പേര് അടയാളവാക്കിൽ ഉപയോഗിക്കാതിരിക്കാൻ ശ്രമിക്കുക"
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "അടയാളവാക്കിൽ ഉൾക്കൊള്ളിച്ചിരിക്കുന്ന ചില വാക്കുകൾ അവഗണിക്കാൻ ശ്രമിക്കുക"
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "പൊതുവായിട്ടുള്ള വാക്കുകൾ അവഗണിക്കാൻ ശ്രമിക്കുക"
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "നിലനിൽക്കുന്ന വാക്കുകൾ പുനഃക്രമീകരിക്കാതിരിക്കാൻ ശ്രമിക്കുക"
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "കൂടുതൽ അക്കങ്ങൾ ഉപയോഗിക്കാൻ ശ്രമിക്കുക"
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "കൂടുതൽ വലിയ അക്ഷരങ്ങള്‍ ഉപയോഗിക്കാൻ ശ്രമിക്കുക"
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "കൂടുതൽ ചെറിയ അക്ഷരങ്ങള്‍ ഉപയോഗിക്കാൻ ശ്രമിക്കുക"
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "ഒരേ അക്ഷരം ആവര്‍ത്തിക്കുന്നത് ഒഴിവാക്കാന്‍ ശ്രമിക്കുക."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same type of character: you need to mix up letters, numbers and punctuation."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234, abcd, മുതലായ ശ്രേണികള്‍ ഒഴിവാക്കാന്‍ ശ്രമിക്കുക."
+
+#: ../panels/user-accounts/pw-utils.c:115
+#, fuzzy
+#| msgctxt "Password hint"
+#| msgid "Try to add more letters, numbers and symbols."
+msgctxt "Password hint"
+msgid "Password needs to be longer. Try to add more letters, numbers and punctuation."
+msgstr "കൂടുതല്‍ അക്ഷരങ്ങളും, സംഖ്യകളും, പ്രതീകങ്ങളും ഉള്‍പ്പെടുത്താന്‍ ശ്രമിക്കുക."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+
+#: ../panels/user-accounts/pw-utils.c:119
+#, fuzzy
+#| msgctxt "Password hint"
+#| msgid "Good password! Adding more letters, numbers and punctuation will make it stronger."
+msgctxt "Password hint"
+msgid "Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "നല്ല രഹസ്യവാക്ക്! കൂടുതല്‍ അക്ഷരങ്ങളും, അക്കങ്ങളും, മറ്റും അതിനെ കൂടുതല്‍ ശക്തമാക്കും."
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "തിരിച്ചറിയല്‍ പ്രക്രിയ പരാജയപ്പെട്ടു"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "പുതിയ രഹസ്യവാക്ക് വളരെ ചെറുതാണു്"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "പുതിയ രഹസ്യവാക്ക് വളരെ ലളിതമാണ്."
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "പഴയതും പുതിയതും ആയ രഹസ്യവാക്കുകള്‍ തമ്മില്‍ വളരെ സാമ്യമുണ്ട്."
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "പുതിയ രഹസ്യവാക്ക് അടുത്തിടയ്ക്കു് ഉപയോഗിച്ചിരിയ്ക്കുന്നു."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "പുതിയ രഹസ്യവാക്കില്‍ ന്യൂമറിക് അല്ലെങ്കില്‍ പ്രത്യേക അക്ഷരങ്ങള്‍ ഉണ്ടായിരിയ്ക്കണം"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "പഴയതും പുതിയതും രഹസ്യവാക്കുകള്‍ ഒന്നു തന്നെയാണ്."
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "നിങ്ങളുടെ ആധികാരികത ഉറപ്പുവരുത്തിയിരിക്കുന്നതിനു ശേഷം അടയാളവാക്ക് മാറിയിരിക്കുന്നു!"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "പുതിയ രഹസ്യവാക്കില്‍ അക്കങ്ങളോ പ്രത്യേക അക്ഷരങ്ങളോ ലഭ്യമല്ല."
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "അറിയാത്ത ഏതോ പ്രശ്നം"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+#, fuzzy
+#| msgid "Should match the web address of your account provider."
+msgid "Should match the web address of your login provider."
+msgstr "അക്കൗണ്ട് നല്‍കിയ ആളിന്റെ വെബ്ബ് അഡ്രസുമായി സാമ്യം വേണം."
+
+#: ../panels/user-accounts/um-account-dialog.c:229
+msgid "Failed to add account"
+msgstr "അക്കൌണ്ട് ചേര്‍ക്കുന്നതില്‍ പരാജയം"
+
+#: ../panels/user-accounts/um-account-dialog.c:462
+msgid "Passwords do not match."
+msgstr "രഹസ്യവാക്കുകള്‍ തമ്മില്‍ പൊരുത്തക്കേടുണ്ട്."
+
+#: ../panels/user-accounts/um-account-dialog.c:717 ../panels/user-accounts/um-account-dialog.c:763
+#: ../panels/user-accounts/um-account-dialog.c:784
+msgid "Failed to register account"
+msgstr "അക്കൌണ്ട് രജിസ്ടര്‍ ചെയ്യുന്നതില്‍ പരാജയം"
+
+#: ../panels/user-accounts/um-account-dialog.c:907
+msgid "No supported way to authenticate with this domain"
+msgstr "ഈ ഡൊമെയിനിലേക്കു് ആധികാരികത ഉറപ്പാക്കുവാന്‍ പിന്തുണയ്ക്കുന്നില്ല"
+
+#: ../panels/user-accounts/um-account-dialog.c:980
+msgid "Failed to join domain"
+msgstr "ഡൊമെയിനിലേക്കു് ചേരുന്നതില്‍ പരാജയം"
+
+#: ../panels/user-accounts/um-account-dialog.c:1041
+#, fuzzy
+#| msgid ""
+#| "That login name didn't work.\n"
+#| "Please try again."
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"ആ ഉപയോക്തൃനാമം പ്രവര്‍ത്തിക്കുന്നില്ല. \n"
+"ദയവായി വീണ്ടും ശ്രമിക്കുക."
+
+#: ../panels/user-accounts/um-account-dialog.c:1048
+#, fuzzy
+#| msgid ""
+#| "That login password didn't work.\n"
+#| "Please try again."
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"ആ രഹസ്യവാക്ക് പ്രവര്‍ത്തിക്കുന്നില്ല. \n"
+"ദയവായി വീണ്ടും ശ്രമിയ്ക്കുക."
+
+#: ../panels/user-accounts/um-account-dialog.c:1056
+msgid "Failed to log into domain"
+msgstr "ഡൊമെയിനിലേക്കു് പ്രവേശിയ്ക്കുന്നതില്‍ പരാജയം"
+
+#: ../panels/user-accounts/um-account-dialog.c:1114
+#, fuzzy
+#| msgid "Unable find the domain. Maybe you misspelled it?"
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "ഡൊമൈന്‍ കണ്ടുപിടിക്കാന്‍ സാധിച്ചില്ല. അതോ നിങ്ങള്‍ക്ക് തെറ്റിയോ ?"
+
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "നിലവാരമുള്ള"
+
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "അഡ്മിനിസ്ട്രേറ്റര്‍"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid "You are not allowed to access the device. Contact your system administrator."
+msgstr "നിങ്ങള്‍ക്കു് ഡിവൈസിലേക്കു് പ്രവേശനമില്ല. ദയവായി സിസ്റ്റം അഡ്മിനിസ്ട്രേറ്ററുമായി ബന്ധപ്പെടുക."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:144
+msgid "The device is already in use."
+msgstr "ഡിവൈസ് നിലവില്‍ ഉപയോഗത്തിലാണു്."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:146
+msgid "An internal error occurred."
+msgstr "ആന്തരിക പിശകു് ഉണ്ടായിരിക്കുന്നു."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:217
+msgid "Enabled"
+msgstr "പ്രവര്‍ത്തന സജ്ജമാക്കിയിരിക്കുന്നു"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr "രജിസ്ടര്‍ ചെയ്ത ഫിംഗര്‍പ്രിന്റുകള്‍ വെട്ടിമാറ്റണമോ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr "ഫിംഗര്‍പ്രിന്റുകള്‍ _വെട്ടിമാറ്റണമോ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
+msgstr "രജിസ്ടര്‍ ചെയ്ത ഫിംഗര്‍പ്രിന്റുകള്‍ വെട്ടിമാറ്റി നിങ്ങള്‍ക്കു് ഫിംഗര്‍പ്രിന്റ് ലോഗിന്‍ പ്രവര്‍ത്തന രഹിതമാക്കണമോ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:443
+msgid "Done!"
+msgstr "പൂര്‍ത്തിയായി!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:504 ../panels/user-accounts/um-fingerprint-dialog.c:546
+#, fuzzy, c-format
+#| msgid "Could not access '%s' device"
+msgid "Could not access “%s” device"
+msgstr "'%s' ഡിവൈസിലേക്കു് പ്രവേശിക്കുവാനായില്ല"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:587
+#, fuzzy, c-format
+#| msgid "Could not start finger capture on '%s' device"
+msgid "Could not start finger capture on “%s” device"
+msgstr "'%s' ഡിവൈസില്‍ വിരലടയാളങ്ങള്‍ ലഭ്യമാക്കുവാന്‍ സാധ്യമായില്ല"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:631
+msgid "Could not access any fingerprint readers"
+msgstr "ഫിംഗര്‍പ്രിന്റ് റീഡറുകളിലേക്കുള്ള പ്രവേശനം സാധ്യമായില്ല"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:632
+msgid "Please contact your system administrator for help."
+msgstr "ദയവായി സഹായത്തിനു് നിങ്ങളുടെ സിസ്റ്റം അഡ്മിനിസ്ട്രേറ്ററുമായി ബന്ധപ്പെടുക."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:714
+#, fuzzy, c-format
+#| msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
+msgid "To enable fingerprint login, you need to save one of your fingerprints, using the “%s” device."
+msgstr "ഫിംഗര്‍പ്രിന്റ് ലോഗിന്‍ സജ്ജമാക്കുന്നതിനായി, നിങ്ങളുടെ വിരലടയാളം '%s' ഡിവൈസ് ഉപയോഗിച്ചു് സൂക്ഷിക്കേണ്ടതാണു്."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:721
+msgid "Selecting finger"
+msgstr "വിരല്‍ തെരഞ്ഞെടുക്കുന്നു"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:722
+msgid "Enrolling fingerprints"
+msgstr "ഫിംഗര്‍പ്രിന്റുകള്‍ എന്‍റോള്‍ ചെയ്യുന്നു"
+
+#: ../panels/user-accounts/um-history-dialog.c:70
+msgid "This Week"
+msgstr "ഈ ആഴ്ച"
+
+#: ../panels/user-accounts/um-history-dialog.c:73
+msgid "Last Week"
+msgstr "അവസാന ആഴ്ച"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:79 ../panels/user-accounts/um-history-dialog.c:83
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:93
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr ""
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:177 ../panels/user-accounts/um-user-panel.c:776
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:180 ../panels/user-accounts/um-user-panel.c:780
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:250
+msgid "Session Ended"
+msgstr "സെഷന്‍ അവസാനിച്ചു"
+
+#: ../panels/user-accounts/um-history-dialog.c:256
+msgid "Session Started"
+msgstr "സെഷന്‍ ആരംഭിച്ചു"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: ../panels/user-accounts/um-history-dialog.c:299
+#, c-format
+msgid "%s — Account Activity"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:144
+msgid "Please choose another password."
+msgstr "ദയവായി മറ്റൊരു രഹസ്യവാക്ക് തെരഞ്ഞെടുക്കുക."
+
+#: ../panels/user-accounts/um-password-dialog.c:153
+msgid "Please type your current password again."
+msgstr "ദയവായി പുതിയ രഹസ്യവാക്ക് വീണ്ടും ടൈപ്പ് ചെയ്യുക."
+
+#: ../panels/user-accounts/um-password-dialog.c:159
+msgid "Password could not be changed"
+msgstr "രഹസ്യവാക്ക് മാറ്റുവാന്‍ സാധ്യമാകുന്നില്ല"
+
+#: ../panels/user-accounts/um-password-dialog.c:285
+msgid "The passwords do not match."
+msgstr "രഹസ്യവാക്കുകള്‍ തമ്മില്‍ പൊരുത്തക്കേടുണ്ട്."
+
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "Browse for more pictures"
+msgstr "കൂടുതല്‍ ചിത്രങ്ങള്‍ക്ക് വേണ്ടി ബ്രൗസ് ചെയ്യുക"
+
+#: ../panels/user-accounts/um-photo-dialog.c:452
+msgid "Disable image"
+msgstr "ചിത്രം പ്രവര്‍ത്തന രഹിതമാക്കുക"
+
+#: ../panels/user-accounts/um-photo-dialog.c:470
+msgid "Take a photo…"
+msgstr "ഒരു ഫോട്ടോ എടുക്കുക…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:488
+msgid "Browse for more pictures…"
+msgstr "കൂടുതല്‍ ചിത്രങ്ങള്‍ക്ക് വേണ്ടി ബ്രൗസ് ചെയ്യുക…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:714
+#, c-format
+msgid "Used by %s"
+msgstr "%s ഉപയോഗിക്കുന്നതു്"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "ഈ തരത്തിലുള്ള ഡൊമൈന്‍ തനിയെ ചേര്‍ക്കാന്‍ പറ്റില്ല"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "അത്തരം ഒരു ഡൊമെയിന്‍ ലഭ്യമല്ല"
+
+#: ../panels/user-accounts/um-realm-manager.c:815 ../panels/user-accounts/um-realm-manager.c:829
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s ആയി %s ഡൊമെയിനിലേക്കു് പ്രവേശിയ്ക്കുവാന്‍ സാധ്യമല്ല"
+
+#: ../panels/user-accounts/um-realm-manager.c:821
+msgid "Invalid password, please try again"
+msgstr "തെറ്റായ രഹസ്യവാക്ക്, ദയവായി വീണ്ടും ശ്രമിയ്ക്കുക"
+
+#: ../panels/user-accounts/um-realm-manager.c:834
+#, fuzzy, c-format
+#| msgid "Couldn't connect to the %s domain: %s"
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "%s ഡൊമെയിനിലേക്കു് കണക്ട് ചെയ്യുവാന്‍ സാധ്യമല്ല: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:195
+msgid "Your account"
+msgstr "നിങ്ങളുടെ അക്കൌണ്ട്‌"
+
+#: ../panels/user-accounts/um-user-panel.c:390
+msgid "Failed to delete user"
+msgstr "ഉപയോക്താവു് വെട്ടി നീക്കുന്നതില്‍ പരാജയം"
+
+#: ../panels/user-accounts/um-user-panel.c:448 ../panels/user-accounts/um-user-panel.c:507
+#: ../panels/user-accounts/um-user-panel.c:559
+#, fuzzy
+#| msgid "Failed to delete user"
+msgid "Failed to revoke remotely managed user"
+msgstr "ഉപയോക്താവു് വെട്ടി നീക്കുന്നതില്‍ പരാജയം"
+
+#: ../panels/user-accounts/um-user-panel.c:613
+msgid "You cannot delete your own account."
+msgstr "നിങ്ങളുടെ സ്വന്തം അക്കൌണ്ട് വെട്ടിനീക്കുവാന്‍ സാധ്യമല്ല."
+
+#: ../panels/user-accounts/um-user-panel.c:622
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ഇപ്പോഴും ലോഗിന്‍ ചെയ്തിരിയ്ക്കുന്നു"
+
+#: ../panels/user-accounts/um-user-panel.c:626
+msgid "Deleting a user while they are logged in can leave the system in an inconsistent state."
+msgstr "പ്രവേശിച്ചിരിയ്ക്കുമ്പോള്‍ ഒരു ഉപയോക്താവിനെ വെട്ടി നീക്കിയാല്‍, സിസ്റ്റത്തിനെ അസ്ഥിമായൊരു അവസ്ഥയിലാക്കുന്നു."
+
+#: ../panels/user-accounts/um-user-panel.c:635
+#, fuzzy, c-format
+#| msgid "Do you want to keep %s's files?"
+msgid "Do you want to keep %s’s files?"
+msgstr "%s's ഫയലുകള്‍ സൂക്ഷിയ്ക്കണമോ?"
+
+#: ../panels/user-accounts/um-user-panel.c:639
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files around when deleting a user account."
+msgstr "ഉപയോക്താവിന്റെ അക്കൌണ്ട് നീക്കം ചെയ്താലും, അതിനുള്ള ആസ്ഥാന ഡയറക്ടറി, മെയില്‍ സ്പൂള്‍, താല്‍ക്കാലിക ഫയലുകള്‍ എന്നിവ സൂക്ഷിയ്ക്കാം."
+
+#: ../panels/user-accounts/um-user-panel.c:642
+msgid "_Delete Files"
+msgstr "ഫയലുകള്‍ വെട്ടി നീക്കു_ക"
+
+#: ../panels/user-accounts/um-user-panel.c:643
+msgid "_Keep Files"
+msgstr "ഫയലുകള്‍ _സൂക്ഷിയ്ക്കുക"
+
+#: ../panels/user-accounts/um-user-panel.c:657
+#, fuzzy, c-format
+#| msgid "Are you sure you want to remove the account?"
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "നിങ്ങള്‍ക്കു് അക്കൌണ്ട് നീക്കം ചെയ്യണമെന്നുറപ്പാണോ?"
+
+#: ../panels/user-accounts/um-user-panel.c:661
+msgid "_Delete"
+msgstr "_നീക്കം ചെയ്യുക"
+
+#: ../panels/user-accounts/um-user-panel.c:711
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "അക്കൌണ്ട് നിര്‍ജ്ജീവം"
+
+#: ../panels/user-accounts/um-user-panel.c:719
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ സജ്ജമാക്കേണ്ടതു്"
+
+#: ../panels/user-accounts/um-user-panel.c:722
+msgctxt "Password mode"
+msgid "None"
+msgstr "ഒന്നുമില്ല"
+
+#: ../panels/user-accounts/um-user-panel.c:769
+msgid "Logged in"
+msgstr "പ്രവേശിച്ചു"
+
+#: ../panels/user-accounts/um-user-panel.c:1117
+msgid "Failed to contact the accounts service"
+msgstr "അക്കൌണ്ടുകളുടെ സര്‍വീസുമായി ബന്ധപ്പെടുന്നതില്‍ പരാജയം"
+
+#: ../panels/user-accounts/um-user-panel.c:1119
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "ദയവായി AccountService ഇന്‍സ്റ്റോള്‍ ചെയ്തു് പ്രവര്‍ത്തന സജ്ജമെന്നുറപ്പാക്കുക."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: ../panels/user-accounts/um-user-panel.c:1155
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"മാറ്റങ്ങള്‍ വരുത്തുന്നതിനായി,\n"
+"ആദ്യം * ചിഹ്നം ക്ലിക്ക് ചെയ്യുക"
+
+#: ../panels/user-accounts/um-user-panel.c:1195
+msgid "Create a user account"
+msgstr "ഉപയോക്താവിനുള്ളൊരു അക്കൌണ്ട് തയ്യാറാക്കുക"
+
+#: ../panels/user-accounts/um-user-panel.c:1206 ../panels/user-accounts/um-user-panel.c:1385
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"ഉപയോക്താവിനുള്ളൊരു അക്കൌണ്ട് തയ്യാറാക്കുന്നതിനായി,\n"
+"ആദ്യം * ചിഹ്നം ക്ലിക്ക് ചെയ്യുക"
+
+#: ../panels/user-accounts/um-user-panel.c:1216
+msgid "Delete the selected user account"
+msgstr "തെരഞ്ഞെടുത്ത ഉപയോക്താവിന്റെ അക്കൌണ്ട് വെട്ടി നീക്കുക"
+
+#: ../panels/user-accounts/um-user-panel.c:1228 ../panels/user-accounts/um-user-panel.c:1390
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"തെരഞ്ഞെടുത്ത ഉപയോക്തൃ അക്കൌണ്ട് വെട്ടി നീക്കുന്നതിനായി\n"
+"ആദ്യം * ചിഹ്നത്തില്‍ ക്ലിക്ക് ചെയ്യുക"
+
+#: ../panels/user-accounts/um-utils.c:507
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+
+#: ../panels/user-accounts/um-utils.c:510
+#, c-format
+msgid "The username is too long."
+msgstr "ഉപയോക്തൃനാമം വളരെ വലുതാണു്."
+
+#: ../panels/user-accounts/um-utils.c:513
+#, fuzzy
+#| msgid "The username cannot start with a '-'."
+msgid "The username cannot start with a “-”."
+msgstr "'-' ഉപയോഗിച്ചു് ഉപയോക്തൃനാമം ആരംഭിയ്ക്കുവാന്‍ പാടില്ല."
+
+#: ../panels/user-accounts/um-utils.c:516
+#, fuzzy
+#| msgid ""
+#| "The username should only consist of lower and upper case letters from a-z, digits and any of characters "
+#| "'.', '-' and '_'."
+msgid ""
+"The username should only consist of upper and lower case letters from a-z, digits and the following "
+"characters: . - _"
+msgstr "ഉപയോക്തൃനാമത്തില്‍ ഇംഗ്ലീഷ് അക്ഷരങ്ങള്‍, അക്കങ്ങള്‍, '.', '-', '_' - ഇവയിലൊന്നു് മാത്രമേ പാടുള്ളൂ."
+
+#: ../panels/user-accounts/um-utils.c:520
+#, fuzzy
+#| msgid "This will be used to name your home folder and can't be changed."
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr "ഇത് നിങ്ങളുടെ ഹോം ഫോള്‍ഡറിന്റെ പേര് നല്‍കാനായി ഉപയോഗിച്ചതിനാല്‍ മാറ്റാന്‍ സാധ്യമല്ല."
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക"
+
+#: ../panels/wacom/button-mapping.ui.h:2 ../panels/wacom/cc-wacom-page.c:547
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "_Close"
+msgstr "_അടയ്ക്കുക"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr "ഫംഗ്ഷനുകളിലേക്കു് ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക"
+
+#: ../panels/wacom/button-mapping.ui.h:4
+#, fuzzy
+#| msgid ""
+#| "To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard shortcut button and hold down "
+#| "the new keys or press Backspace to clear."
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard shortcut button and hold down the "
+"new keys or press Backspace to clear."
+msgstr ""
+"കുറുക്കുവഴി തിരുത്തുന്നതിനായി \"കീസ്ട്രോക്ക് അയയ്ക്കുക\" പ്രവൃത്തി ചെയ്ത ശേഷം പുതിയ കുറുക്കുവഴിയ്ക്കുള്ള കീ ടൈപ്പ് ചെയ്യുക. കീ നീക്കം ചെയ്യാന്‍ "
+"backspace ടൈപ്പ് ചെയ്യുക."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid "Please tap the target markers as they appear on screen to calibrate the tablet."
+msgstr "ടാബ്ലറ്റ് കാലിബ്രേറ്റ് ചെയ്യന്നതിനായി അവ സ്ക്രീനില്‍ കാണിയ്ക്കുമ്പോള്‍ ലക്ഷ്യ അടയാളങ്ങളില്‍ ദയവായി ടാപ്പ് ചെയ്യുക."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+#, fuzzy
+#| msgid "Mis-click detected, restarting..."
+msgid "Mis-click detected, restarting…"
+msgstr "മിസ്-ക്ലിക്ക് ലഭ്യമാക്കിയിരിയ്ക്കുന്നു, വീണ്ടും ആരംഭിയ്ക്കുന്നു..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:266
+#, fuzzy, c-format
+#| msgid "Button"
+msgid "Button %d"
+msgstr "ബട്ടണ്‍"
+
+#: ../panels/wacom/cc-wacom-button-row.h:53
+#, fuzzy
+#| msgid "Applications"
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "പ്രയോഗങ്ങള്‍"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "കീസ്ട്രോക്ക് അയയ്ക്കുക"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "മോണിറ്റര്‍ സ്വിച്ച് ചെയ്യുക"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "സ്ക്രീനില്‍ സഹായം കാണിക്കുക"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:260
+msgid "Output:"
+msgstr "ഔട്ട്പുട്ട്:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:272
+msgid "Keep aspect ratio (letterbox):"
+msgstr "ആസ്പെക്ട് റേഷ്യോ സൂക്ഷിയ്ക്കുക (എഴുത്തുപെട്ടി):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:283
+msgid "Map to single monitor"
+msgstr "ഒറ്റ മോണിറ്ററിലേക്കു് മാപ്പ് ചെയ്യുക"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:86
+#, c-format
+msgid "%d of %d"
+msgstr "%d x %d"
+
+#: ../panels/wacom/cc-wacom-page.c:544
+msgid "Display Mapping"
+msgstr "മാപ്പിങ് കാണിയ്ക്കുക"
+
+#: ../panels/wacom/cc-wacom-panel.c:790 ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Stylus"
+msgstr "സ്റ്റൈലസ് "
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:347
+msgid "Button"
+msgstr "ബട്ടണ്‍"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Wa­com Tab­let"
+msgstr "വാക്കൊം ടാബ്ലെറ്റ്"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "ബട്ടണ്‍ മാപ്പിങ്ങും ഗ്രാഫിക്സ് റ്റാബ്ലറ്റിലെ സ്റ്റൈലസ് ക്രമീകരണങ്ങളും മാറ്റുക"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:5
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "ടാബ്ലറ്റ് (ആബ്സല്യൂട്ട്)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "ടച്ച്പാഡ് (റിലേറ്റിവ്)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "ടാബ്ലറ്റ് മുന്‍ഗണനകള്‍"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Help"
+msgstr "സഹായം (_H)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "No tablet detected"
+msgstr "ടാബ്ലറ്റ് ലഭ്യമല്ല"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "ദയവായി പ്ലഗിന്‍ ചെയ്യുക അല്ലെങ്കില്‍ നിങ്ങളുടെ വാക്കോ ടാബ്ലറ്റ് ഓണ്‍ ചെയ്യുക"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Bluetooth Settings"
+msgstr "ബ്ലൂടൂത് സജ്ജീകരണങ്ങള്‍"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Wacom Tablet"
+msgstr "വാക്കൊം ടാബ്ലെറ്റ് "
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map to Monitor…"
+msgstr "മോണിറ്ററിലേക്കു് മാപ്പ് ചെയ്യുക…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Map Buttons…"
+msgstr "ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Calibrate…"
+msgstr "ഒത്തുനോക്കുക..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust display resolution"
+msgstr "ഡിസ്‌പ്ലെ റിസല്യൂഷന്‍ ശരിയാക്കുക"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Adjust mouse settings"
+msgstr "മൌസ് സജ്ജീകരണങ്ങള്‍ മാറ്റുക"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Tracking Mode"
+msgstr "ട്രാക്കിങ് മോഡ്"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:16
+msgid "Left-Handed Orientation"
+msgstr "ഇടതു് വശത്തുള്ള സംവേദനം"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "പുതിയ കുറുക്കുവഴി..."
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Middle Mouse Button Click"
+msgstr "മദ്ധ്യത്തിലുള്ള മൌസ് ബട്ടണ്‍ ക്ലിക്ക്"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Right Mouse Button Click"
+msgstr "വലത്തുള്ള മൌസ് ബട്ടണ്‍ ക്ലിക്ക്"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Back"
+msgstr "പുറകോട്ട്"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Forward"
+msgstr "മുന്നോട്ട്"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "No stylus found"
+msgstr "സ്റ്റൈലസ് കണ്ടില്ല"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Eraser Pressure Feel"
+msgstr "ഇറേസര്‍ പ്രഷര്‍ ഫീല്‍"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Soft"
+msgstr "സോഫ്റ്റ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Firm"
+msgstr "ഉറപ്പാക്കുക"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Top Button"
+msgstr "മുകളിലുള്ള ബട്ടണ്‍"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Lower Button"
+msgstr "താഴെയുള്ള ബട്ടണ്‍"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Tip Pressure Feel"
+msgstr "ടിപ്പ് പ്രഷര്‍ ഫീല്‍"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "page 3"
+msgstr "താള്‍ 3 "
+
+#: ../shell/alt/cc-window.c:53 ../shell/alt/cc-window.c:1484 ../shell/cc-window.c:730
+msgid "All Settings"
+msgstr "എല്ലാ സജ്ജീകരണങ്ങള്‍"
+
+#. Add categories
+#: ../shell/alt/cc-window.c:875
+msgctxt "category"
+msgid "Personal"
+msgstr "സ്വകാര്യം"
+
+#: ../shell/alt/cc-window.c:876
+msgctxt "category"
+msgid "Hardware"
+msgstr "ഹാര്‍ഡ്‌വെയര്‍"
+
+#: ../shell/alt/cc-window.c:877
+msgctxt "category"
+msgid "System"
+msgstr "സിസ്റ്റം"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
+#, fuzzy
+#| msgid "Control Center"
+msgid "GNOME Control Center"
+msgstr "നിയന്ത്രണകേന്ദ്രം"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
+msgid "Utilities to configure the GNOME desktop"
+msgstr ""
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
+msgid "The control center is GNOME’s main interface for configuration of various aspects of your desktop."
+msgstr ""
+
+#: ../shell/cc-application.c:45
+#, fuzzy
+#| msgid "Display Brightness"
+msgid "Display version number"
+msgstr "ഡിസ്പ്ലേയുടെ തെളിച്ചം"
+
+#: ../shell/cc-application.c:46
+msgid "Enable verbose mode"
+msgstr "വര്‍ബറോസ് മോഡ് പ്രവര്‍ത്തന സജ്ജമാക്കുക"
+
+#: ../shell/cc-application.c:47
+msgid "Show the overview"
+msgstr "അവലോകനം കാണിക്കുക"
+
+#: ../shell/cc-application.c:48
+msgid "Search for the string"
+msgstr "വാചകത്തിനായി തിരയുക"
+
+#: ../shell/cc-application.c:49
+msgid "List possible panel names and exit"
+msgstr "സാധ്യമായ പട്ടയുടെ നാമങ്ങള്‍ കാണിച്ച് പുറത്തിറങ്ങുക"
+
+#: ../shell/cc-application.c:50
+msgid "Panel to display"
+msgstr "പ്രദര്‍ശിപ്പിക്കുന്നതിനുള്ള പാനല്‍"
+
+#: ../shell/cc-application.c:50
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:113
+msgid "Available panels:"
+msgstr "ലഭ്യമായ പാനലുകള്‍:"
+
+#: ../shell/cc-application.c:252
+msgid "Help"
+msgstr "സഹായം"
+
+#: ../shell/cc-application.c:253
+msgid "Quit"
+msgstr "പുറത്തു് കടക്കുക"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;"
+
+#: ../shell/help-overlay.ui.h:1
+msgctxt "shortcut window"
+msgid "General"
+msgstr "സാധാരണ"
+
+#: ../shell/help-overlay.ui.h:2
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "നിര്‍ത്തുക"
+
+#: ../shell/help-overlay.ui.h:3
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "തിരയുക"
+
+#: ../shell/help-overlay.ui.h:4
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "പാനലുകള്‍"
+
+#: ../shell/help-overlay.ui.h:5
+msgctxt "shortcut window"
+msgid "Go back to the overview"
+msgstr "അവലോകനത്തിലോട്ട് തിരിച്ച് പോവുക"
+
+#: ../shell/help-overlay.ui.h:6
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "തെരയല്‍ റദ്ദാക്കുക"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: ../shell/hostname-helper.c:189
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "ഹോട്ട്സ്പോട്ട്"
+
+#: ../shell/panel-list.ui.h:3
+msgid "No results found"
+msgstr "ഫലങ്ങള്‍ ഒന്നും ലഭിച്ചില്ല"
+
+#~ msgid "Lid Closed"
+#~ msgstr "അടച്ചു"
+
+#~ msgid "Mirrored"
+#~ msgstr "മിറര്‍ ചെയ്തു"
+
+#~ msgid "Primary"
+#~ msgstr "പ്രഥമ"
+
+#~ msgid "Secondary"
+#~ msgstr "ദ്വീതീയ"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "കൂട്ടിയോജിപ്പിച്ച പ്രദര്‍ശനങ്ങള്‍ ക്രമീകരിക്കുക"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "ദൃശ്യങ്ങൾ പുനഃക്രമീകരിക്കുന്നതിനായി അവയെ വലിച്ചിടുക"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~| msgctxt "display panel, rotation"
+#~| msgid "Counterclockwise"
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "ഇടത്തേക്ക് 90° കറക്കുക"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "180° കറക്കുക"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "90° വലത്തോട്ട് കറക്കുക"
+
+#~ msgid "Size"
+#~ msgstr "വലിപ്പം"
+
+#~ msgid "Aspect Ratio"
+#~ msgstr "പ്രത്യേക അനുപാതം"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "പശ്ചാത്തലത്തില്‍ മുകളിലത്തെ ബാറും പ്രവര്‍ത്തന വിവരങ്ങളും കാണിക്കുക"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "പുതിയ പണിസ്ഥലം നിര്‍മ്മിക്കാന്‍ ഈ പശ്ചാത്തലവുമായി മറ്റൊന്ന് കൂട്ടിച്ചേര്‍ക്കുക"
+
+#~ msgid "Presentation"
+#~ msgstr "സംവേദനം"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "ചിത്രപ്രദര്‍ശനങ്ങളും ദൃശ്യങ്ങളും മാത്രം കാണിക്കുക"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "രണ്ട് പശ്ചാത്തലങ്ങളിലും നിങ്ങളുടെ നിലവിലുള്ള കാഴ്ചപ്പാട് കാണിക്കുക."
+
+#~ msgid "Turn Off"
+#~ msgstr "_ഓഫ് ചെയ്യുക"
+
+#~| msgid "Don't use this display"
+#~ msgid "Don’t use this display"
+#~ msgstr "ഈ ഡിസ്പ്ലേ ഉപയോഗിക്കരുത്"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "കൂട്ടിയോജിപ്പിച്ച പ്രദര്‍ശനങ്ങള്‍ ക്രമീകരിക്കുക"
+
+#~ msgid "Server"
+#~ msgstr "സര്‍വര്‍"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "ഡിഎന്‍എസ് നീക്കം ചെയ്യുക"
+
+#~ msgid "Proxy"
+#~ msgstr "പ്രോക്സി"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "പ്രൊഫൈല്‍ ചേര്‍ക്കുക (_A)"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "ഒന്നുമില്ല"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "മാനുവല്‍"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "തനിയെയുള്ള"
+
+#~ msgid "_Method"
+#~ msgstr "_സംവിധാനം"
+
+#~ msgid "Add Device"
+#~ msgstr "ഡിവൈസ് ചേര്‍ക്കുക"
+
+#~ msgid "Remove Device"
+#~ msgstr "ഡിവൈസ് നീക്കം ചെയ്യുക"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN തരം"
+
+#~ msgid "Group Name"
+#~ msgstr "ഗ്രൂപ്പ് നാമം"
+
+#~ msgid "Group Password"
+#~ msgstr "ഗ്രൂപ്പ് രഹസ്യവാക്ക്"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "ബ്ലൂടൂത്ത് പ്രവര്‍ത്തന രഹിതമാക്കിയിരിക്കുന്നു"
+
+#~ msgid "Done"
+#~ msgstr "ചെയ്ത് കഴിഞ്ഞിരിക്കുന്നു"
+
+#~ msgid "Color"
+#~ msgstr "നിറം"
+
+#~ msgid "United States"
+#~ msgstr "യുണൈറ്റഡ് സ്റ്റേറ്റ്സ്"
+
+#~ msgid "Germany"
+#~ msgstr "ജര്‍മനി"
+
+#~ msgid "France"
+#~ msgstr "ഫ്രാന്‍സ്"
+
+#~ msgid "Spain"
+#~ msgstr "സ്പൈന്‍"
+
+#~ msgid "China"
+#~ msgstr "ചൈന"
+
+#~| msgid "Firewall _Zone"
+#~ msgid "Time _Zone"
+#~ msgstr "സമയ മേഘല"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-ബിറ്റ്"
+
+#~ msgid "Base system"
+#~ msgstr "ബെയിസ് സിസ്റ്റം"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;"
+
+#~ msgid "_Name:"
+#~ msgstr "_പേര്:"
+
+#~ msgid "_Delay:"
+#~ msgstr "_താമസം:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "കുറഞ്ഞ"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "പതുക്കെ"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "കൂടിയ"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "വേഗത്തില്‍"
+
+#~ msgid "S_peed:"
+#~ msgstr "വേ_ഗത:"
+
+#~ msgid "Add Shortcut"
+#~ msgstr "എളുപ്പവഴി ചേര്‍ക്കുക"
+
+#~ msgid "To edit a shortcut, click the row and hold down the new keys or press Backspace to clear."
+#~ msgstr ""
+#~ "കുറുക്കുവഴി ചേര്‍ക്കുന്നതിനായി വരിയില്‍ ക്ലിക്ക് ചെയ്ത ശേഷം പുതിയ കുറുക്കുവഴിയ്ക്കുള്ള കീ ടൈപ്പ് ചെയ്യുക. കീ നീക്കം ചെയ്യാന്‍ backspace "
+#~ "ടൈപ്പ് ചെയ്യുക."
+
+#~ msgid "Shortcuts"
+#~ msgstr "എളുപ്പവഴികള്‍"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<അറിയാത്ത പ്ര‌വൃത്തി‌>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ " \"%s\" എന്ന എളുപ്പവഴി ഉപയോഗിക്കാന്‍ പറ്റില്ല. കാരണം പിന്നീട് ഈ കീ ഉപയോഗിച്ചു് ടൈപ്പ് ചെയ്യാന്‍ സാധ്യമല്ലാതെയാകും.\n"
+#~ "Control, Alt അല്ലെങ്കില്‍ Shift എന്നിവയില്‍ ഒന്നിനോടൊപ്പം ഉപയോഗിക്കുന്ന ഒരു കീ പരീക്ഷിക്കുക."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "\"%s\" എന്ന എളുപ്പവഴി ഇപ്പോള്‍ തന്നെ  \n"
+#~ " \"%s\"നു വേണ്ടി ഉപയോഗിച്ചിട്ടുണ്ട്"
+
+#~ msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#~ msgstr "എളുപ്പവഴി \"%s\"-നു് വീണ്ടും നല്‍കിയാല്‍, \"%s\" എളുപ്പവഴി പ്രവര്‍ത്തന രഹിതമാക്കുന്നു."
+
+#~ msgid "_Reassign"
+#~ msgstr "_വീണ്ടും ലഭ്യമാക്കുക"
+
+#~| msgid "Test Your _Settings"
+#~ msgid "Test Your Settings"
+#~ msgstr "നിങ്ങളുടെ _സജ്ജീകരണങ്ങള്‍ പരീക്ഷിയ്ക്കുക"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "പതുക്കെ"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "വേഗത്തില്‍"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_ഇടത്"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_വലത്"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_പോയിന്ററിന്റെ വേഗത"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "പതുക്കെ"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "വേഗത്തില്‍"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "പതുക്കെ"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "വേഗത്തില്‍"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "ടൈപ്പ് ചെയ്യുമ്പോള്‍ _പ്രവര്‍ത്തന രഹിതമാക്കുക"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "സിസ്റ്റത്തിന്റെ നെറ്റ്‌വര്‍ക്ക് സര്‍വീസുകള്‍ ഈ പതിപ്പുമായി പൊരുത്തപ്പെടുന്നില്ല."
+
+#~ msgid "Make available to other _users"
+#~ msgstr "മറ്റുള്ള _ഉപയോക്താക്കള്‍ക്ക് ലഭ്യമാക്കുക"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "തീമതിൽഅപായ-മേഖല"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "സഹജമായ"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "കണക്ഷന്റെ വിശ്വസനീയത ഈ മേഖല നിഷ്കര്‍ഷിക്കുന്നതാണ്"
+
+#~ msgid "Bond"
+#~ msgstr "ബോണ്ട്"
+
+#~ msgid "Team"
+#~ msgstr "സംഘം"
+
+#~ msgid "Bridge"
+#~ msgstr "ബ്രിഡ്ജ്"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN പ്ലഗ്ഗിനുകള്‍ ലഭ്യമാക്കാനായില്ല"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "പുതിയൊരു ശ്രംഖല കണക്ഷന്‍ ചേര്‍ക്കുക"
+
+#~ msgid "Reset the settings for this network, including passwords, but remember it as a preferred network"
+#~ msgstr "ഈ ശ്രംഖലയ്ക്ക് വേണ്ടിയുള്ള ക്രമീകരണങ്ങള്‍, രഹസ്യവാക്കുകള്‍ ഉള്‍പ്പെടെ, പഴയപോലെ ആക്കുക. പക്ഷേ, മുന്‍ഗണാനാശ്രംഖലയായി ഇതിനെ ഓര്‍ക്കുക"
+
+#~ msgid "Remove all details relating to this network and do not try to automatically connect"
+#~ msgstr "ഈ ശ്രംഖലയുമായുള്ള എല്ലാ വിവരങ്ങളും നീക്കി തനിയെ ബന്ധിപ്പിക്കാതിരിക്കുക"
+
+#~ msgid "Bond slaves"
+#~ msgstr "ബോണ്ട് അടിമകള്‍"
+
+#~ msgid "(none)"
+#~ msgstr "(ഒന്നുമില്ല)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "ബ്രിഡ്ജ് അടിമകള്‍"
+
+#~| msgid "Bridge slaves"
+#~ msgid "Team slaves"
+#~ msgstr "സംഘത്തിലെ അടിമകള്‍"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set up a wireless hotspot to share "
+#~ "the connection with others."
+#~ msgstr ""
+#~ "വയര്‍ലെസ്സിനു് പകരം ഇന്റര്‍നെറ്റിലേക്കു് നിങ്ങള്‍ക്കൊരു കണക്ഷനുണ്ടെങ്കില്‍, മറ്റുള്ളവരുമായി നിങ്ങള്‍ക്കു് ഇന്റര്‍നെറ്റു് പങ്കിടുവാന്‍ ഒരു വയര്‍ലസ്സ് ഹോട്ട് "
+#~ "സ്പോട്ട് ഉണ്ടാക്കാം."
+
+#~ msgid "History"
+#~ msgstr "ചരിത്രം"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "ഹോട്ട്സ്പോട്ടായി _ഉപയോഗിക്കുക…"
+
+#~ msgid "_History"
+#~ msgstr "_ചരിത്രം"
+
+#~ msgid "Security key"
+#~ msgstr "സുരക്ഷ കീ"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand ഡിവൈസ് കണക്ട് ചെയ്ത മോഡ് പിന്തുണയ്ക്കുന്നില്ല"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി (CA) സര്‍ട്ടിഫീക്കേറ്റ് തെരഞ്ഞെടുത്തിട്ടില്ല"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in connections to insecure, rogue Wi-Fi "
+#~ "networks.  Would you like to choose a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "ഒരു സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി (CA) സര്‍ട്ടിഫീക്കേറ്റ് ഉപയോഗിച്ചില്ല എങ്കില്‍, സുരക്ഷിതമല്ലാത്ത വയര്‍ലെസ് ശൃംഖലകളിലേയ്ക്കു് കടക്കുവാന്‍ "
+#~ "സാധ്യതയുണ്ടു്. നിങ്ങള്‍ക്കു് ഒരു സര്‍ട്ടിഫീക്കേറ്റ് അഥോറിറ്റി സര്‍ട്ടിഫീക്കേറ്റ് തെരഞ്ഞെടുക്കണമോ?"
+
+#~ msgid "Ignore"
+#~ msgstr "അവഗണിക്കുക"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA സര്‍ട്ടിഫീക്കേറ്റ് തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "അടയാളവാക്ക് എപ്പോഴും ചോ_ദിക്കുക"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "ഇനി _മുന്നറിയിപ്പ് നല്‍കേണ്ടതില്ല"
+
+#~ msgid "No"
+#~ msgstr "അല്ല"
+
+#~ msgid "Yes"
+#~ msgstr "അതെ"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "പൊങ്ങിവരുന്ന ബാനറുകള്‍ കാണിക്കുക"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "വിശദാംശങ്ങള്‍ ബാനറില്‍ കാണിക്കുക"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "സ്ക്രീന്‍ പൂട്ടുന്നതില്‍ കാണിക്കുക"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "പൊങ്ങിവരുന്ന ബാനറുകള്‍ കാണിക്കുക"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "സ്ക്രീന്‍ പൂട്ടുന്നതില്‍ കാണിക്കുക"
+
+#~ msgid "Add Account"
+#~ msgstr "എക്കൗണ്ട് ചേര്‍ക്കുക"
+
+#~ msgid "Mail"
+#~ msgstr "മെയില്‍"
+
+#~ msgid "Contacts"
+#~ msgstr "വിലാസങ്ങള്‍"
+
+#~ msgid "Chat"
+#~ msgstr "സംവദിക്കുക"
+
+#~ msgid "Resources"
+#~ msgstr "വിഭവങ്ങള്‍"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "അക്കൌണ്ടിലേക്കു് പ്രവേശിയ്ക്കുന്നതില്‍ പിശക്"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "യോഗ്യതകൾ കാലവധി കഴിഞ്ഞു"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "ഈ അക്കൌണ്ട് പ്രവര്‍ത്തന സജ്ജമാക്കാന്‍ പ്രവേശിക്കുക."
+
+#~ msgid "_Sign In"
+#~ msgstr "‌‌പ്രവേശിക"
+
+#~ msgid "Error creating account"
+#~ msgstr "അക്കൌണ്ട് തയ്യാറാക്കുന്നതില്‍ പിശക്"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "ഓണ്‍ലൈന്‍ അക്കൌണ്ടുകള്‍ ക്രമീകരിച്ചിട്ടില്ല"
+
+#~ msgid "Add an online account"
+#~ msgstr "ഒരു ഓണ്‍ലൈന്‍ അക്കൌണ്ട് ചേര്‍ക്കുക"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, mail, contacts, calendar, chat and "
+#~ "more."
+#~ msgstr ""
+#~ "ഒരു അക്കൌണ്ട് ചേര്‍ത്താല്‍, രേഖകള്‍, മെയില്‍, വിലാസങ്ങള്‍, കലണ്ടര്‍, ചാറ്റ് എന്നിങ്ങനെയുള്ളവയിലേക്കു് നിങ്ങളുടെ പ്രയോഗങ്ങളെ അനുവദിയ്ക്കുന്നു."
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "വയർലെസ്സ് ഉപകരണങ്ങൾ ഓഫ് ചെയ്യുക"
+
+#~| msgid "When Battery Power is _Critical"
+#~ msgid "When battery power is _critical"
+#~ msgstr "ബാറ്ററി _വളരെ കുറവാകുമ്പോള്‍"
+
+#~ msgid "Power"
+#~ msgstr "വൈദ്യുതി"
+
+#~ msgid "Power off"
+#~ msgstr "നിര്‍ത്തുക"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "ക്രമീകരിയ്ക്കുന്നു"
+
+#~ msgid "Toner Level"
+#~ msgstr "ടോണര്‍ അവസ്ഥ"
+
+#~ msgid "Supply Level"
+#~ msgstr "ലഭ്യമാക്കുന്ന അവസ്ഥ"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "ഇന്‍സ്റ്റോള്‍ ചെയ്യുന്നു"
+
+#~ msgid "No printers available"
+#~ msgstr "പ്രിന്ററുകള്‍ ലഭ്യമല്ല"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u സജീവം"
+#~ msgstr[1] "%u സജീവം"
+
+#~ msgid "Close"
+#~ msgstr "അടയ്ക്കുക"
+
+#~ msgid "Resume Printing"
+#~ msgstr "പ്രിന്റ് ചെയ്യുന്നതു് തുടരുക"
+
+#~ msgid "Pause Printing"
+#~ msgstr "പ്രിന്റ് ചെയ്യുന്നതു് തല്‍ക്കാലത്തേക്കു് നിര്‍ത്തുക"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "പുതിയ പ്രിന്റര്‍ ചേര്‍ക്കുക"
+
+#~| msgid "Authenticate"
+#~ msgid "A_uthenticate"
+#~ msgstr "തിരിച്ചറിയുക"
+
+#~ msgid "No printers detected."
+#~ msgstr "ഒരു പ്രിന്ററുകളും ലഭ്യമായിട്ടില്ല."
+
+#~| msgid "Search for network printers or filter result"
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "തിരയാന്‍ വേണ്ടി പ്രിന്ററിന്റെയോ ടെക്സ്റ്റിന്റെയോ അഡ്രസ് നല്‍കുക"
+
+#~ msgid "Loading options…"
+#~ msgstr "ഐച്ഛികങ്ങള്‍ ലഭ്യമാക്കുന്നു…"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "തടഞ്ഞിരിയ്ക്കുന്നു"
+
+#~ msgid "Job Title"
+#~ msgstr "ജോലിയുടെ പേര്"
+
+#~ msgid "Job State"
+#~ msgstr "ജോലിയുടെ അവസ്ഥ"
+
+#~ msgid "Time"
+#~ msgstr "സമയം"
+
+#~ msgid "Supply"
+#~ msgstr "ലഭ്യമാക്കുക"
+
+#~| msgid "Default Route"
+#~ msgid "_Default printer"
+#~ msgstr "സ്വതവേയുള്ള പ്രിന്റര്‍"
+
+#~ msgid "Jobs"
+#~ msgstr "ജോലികള്‍"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "_ജോലികള്‍ കാണിക്കുക"
+
+#~ msgid "label"
+#~ msgstr "ലേബല്‍"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "പുതിയ ഡ്രൈവര്‍ സജ്ജമാക്കുന്നു…"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "_പരീക്ഷണത്തിനുള്ള താള്‍ പ്രിന്റ് ചെയ്യുക"
+
+#~ msgid "Add New Printer"
+#~ msgstr "പുതിയ പ്രിന്റര്‍ ചേര്‍ക്കുക"
+
+#~ msgid "Privacy"
+#~ msgstr "സ്വകാര്യത"
+
+#~ msgid "Sorry"
+#~ msgstr "ക്ഷമിക്കുക"
+
+#~ msgid "Options"
+#~ msgstr "ഐച്ഛികങ്ങള്‍"
+
+#~| msgid "Other"
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "മറ്റുളളവ"
+
+#~ msgid "Bluetooth Sharing allows you to share files with other Bluetooth enabled devices"
+#~ msgstr "ബ്ലൂട്ടുത്ത് പങ്കിടല്‍ മറ്റുള്ള ബ്ലൂട്ടുത്ത് ഉപകരണങ്ങളുമായി ഫയലുകള്‍ പങ്കിടാന്‍ നിങ്ങളെ അനുവദിക്കുന്നു"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "വിശ്വസ്ഥമായ ഉപകരണങ്ങളില്‍ നിന്ന് മാത്രം സ്വീകരിക്കുക"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "ഡൌണ്‍ലോഡ് ഫോള്‍ഡറിലേക്ക് കിട്ടിയ ഫയലുകളെ സൂക്ഷിക്കുക"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "ഈ ശ്രംഖലയില്‍ മീഡിയ പങ്കിടുക"
+
+#~ msgid "Shared Folders"
+#~ msgstr "പങ്കിട്ട അറകള്‍"
+
+#~ msgid "column"
+#~ msgstr "വരി"
+
+#~ msgid "Remove Folder"
+#~ msgstr "അറ നീക്കം ചെയ്യുക"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "ഈ ശ്രംഖലയില്‍ പൊതു അറ പങ്കിടുക"
+
+#~| msgid "Remote Control"
+#~ msgid "Allow Remote Control"
+#~ msgstr "വിദൂര നിയന്ത്രണം അനുവദിക്കുക"
+
+#~| msgid "Password"
+#~ msgid "Password:"
+#~ msgstr "രഹസ്യവാക്ക്:"
+
+#~ msgid "Zoom"
+#~ msgstr "വലിപ്പം മാറ്റുക"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "വര്‍ണങ്ങള്‍"
+
+#~ msgid "_Verify"
+#~ msgstr "ഉറപ്പിക്കുക (_V)"
+
+#~ msgid "Login History"
+#~ msgstr "പ്രവവേശന ചരിത്രം"
+
+#~ msgid "Add User Account"
+#~ msgstr "ഉപയോക്താവിന്റെ അക്കൌണ്ട് ചേര്‍ക്കുക"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "ബലം: ദുര്‍ബ്ബലം"
+
+#~| msgid "Length:"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "ബലം: കുറവ്"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "ബലം: തരക്കേടില്ല"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "ബലം: നല്ലത്"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "ബലം: മികച്ചത്"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "മറ്റു് അക്കൌണ്ടുകള്‍"
+
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "'%s' എന്ന പേരില്‍ ഉപയോക്തൃനാമം നിലവിലുണ്ടു്."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "മുകളിലോട്ട്"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "താഴോട്ട്"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "ഒന്നുമില്ല"
+
+#~ msgid "Left Ring"
+#~ msgstr "ഇടത്തുള്ള റിങ്"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "ഇടത്തുള്ള റിങ് മോഡ് #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "വലത്തുള്ള റിങ് മോഡ് #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "ഇടത്തുള്ള ടച്ച്സ്ട്രിപ്പ്"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "ഇടത്തുള്ള ടച്ച്സ്ട്രിപ്പ് മോഡ് #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "വലത്തുള്ള ടച്ച്സ്ട്രിപ്പ്"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "വലത്തുള്ള ടച്ച്സ്ട്രിപ്പ് മോഡ് #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "ഇടത്തുള്ള ടച്ച്സ്ട്രിപ്പ് മോഡ് സ്വിച്ചു്"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "വലത്തുള്ള ടച്ച്സ്ട്രിപ്പ് മോഡ് സ്വിച്ചു്"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "ഇടത്തുള്ള  ടച്ച്സ്ട്രിപ്പ് മോഡ് സ്വിച്ചു്"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "വലത്തുള്ള ടച്ച്സ്ട്രിപ്പ് മോഡ് സ്വിച്ചു്"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "മോഡ് സ്വിച്ച് #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "ഇടത്തുള്ള ബട്ടണ്‍ #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "വലത്തുള്ള ബട്ടണ്‍ #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "മുകളിലുള്ള ബട്ടണ്‍ #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "താഴെയുള്ള ബട്ടണ്‍ #%d"
+
+#~ msgid "No Action"
+#~ msgstr "ഒരു പ്രവര്‍ത്തിയും സാധ്യമല്ല"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "ഇടത്തുള്ള മൌസ് ബട്ടണ്‍ ക്ലിക്ക്"
+
+#~ msgid "Scroll Up"
+#~ msgstr "മുകളിലേക്കു് സ്ക്രോള്‍ ചെയ്യുക"
+
+#~ msgid "Scroll Down"
+#~ msgstr "താഴേക്ക് സ്ക്രോള്‍ ചെയ്യുക"
+
+#~ msgid "Scroll Left"
+#~ msgstr "ഇടത്തേക്ക് സ്ക്രോള്‍ ചെയ്യുക"
+
+#~ msgid "Scroll Right"
+#~ msgstr "വലത്തേക്ക് സ്ക്രോള്‍ ചെയ്യുക"
+
+#~ msgid "Show help options"
+#~ msgstr "സഹായ ഉപാധികള്‍ കാണിക്കുക"
+
+#~ msgid "- Settings"
+#~ msgstr "- സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ " '%s --help' രണ്‍ ചെയ്യുക ലഭ്യമായ ആജ്ഞ-വരി ഐച്ഛികങ്ങളുടെ പട്ടിക കാണാന്‍..\n"
+
+#~ msgid "Flickr"
+#~ msgstr "ഫ്ലിക്കര്‍"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "പുതിയ ഡിവൈസ് സജ്ജീകരിക്കുക"
+
+#~ msgid "Paired"
+#~ msgstr "ജോടികള്‍"
+
+#~ msgid "Type"
+#~ msgstr "തരം"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "മൌസിന്റേയും ടച്ച്പാടിന്റേയും സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "Sound Settings"
+#~ msgstr "ശബ്ദ ക്രമീകരണങ്ങള്‍"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "കീബോര്‍ഡ് ക്രമീകരണങ്ങള്‍"
+
+#~ msgid "Send Files…"
+#~ msgstr "ഫയല്‍ അയയ്ക്കുക…"
+
+#~ msgid "Visibility"
+#~ msgstr "കാഴ്ച"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s”ഇന്റെ കാഴ്ച"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "ഡിവൈസുകളുടെ പട്ടികയില്‍ നിന്നും '%s' നീക്കം ചെയ്യേണമോ?"
+
+#~ msgid "If you remove the device, you will have to set it up again before next use."
+#~ msgstr "ഈ ഡിവൈസ് നിങ്ങള്‍ നീക്കം ചെയ്താല്‍ അടുത്ത പ്രാവിശ്യം ഉപയോഗിക്കുന്നതിന്നു മുമ്പ് വീണ്ടും സജ്ജീകരിക്കേണ്ടി വരും."
+
+#~ msgid "Install Updates"
+#~ msgstr "പരിഷ്കരണങ്ങള്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യുക"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "എല്ലാ സോഫ്റ്റ്‌വെയറുകളും പുതിയതാണു്"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "നെറ്റ്‌വര്‍ക്ക് പ്രിന്ററുകള്‍ അല്ലെങ്കില്‍ തെരച്ചില്‍ ഫലങ്ങള്‍ക്കായി തെരയുക"
+
+#~ msgid "_Default"
+#~ msgstr "സ്വ_തവേ"
+
+#~ msgid "Immediately"
+#~ msgstr "ഉടനടി"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "പൊതു ഫോള്‍ഡര്‍ പങ്കിടുക"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "വിശ്വസ്ഥമായ ഡിവൈസുകളുമായി മാത്രം പങ്കിടുക"
+
+#~ msgid "Remote View"
+#~ msgstr "വിദൂര കാഴ്ച്ച"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "എല്ലാ ബന്ധങ്ങളും അനുവദിക്കുക"
+
+#~ msgid "Device type:"
+#~ msgstr "ഏതു തരം ഉപകരണം:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "നടത്തിപ്പുകാരന്‍:"
+
+#~ msgid "Model:"
+#~ msgstr "മോഡല്‍:"
+
+#~ msgid "Image files can be dragged on this window to auto-complete the above fields."
+#~ msgstr "മുകളിലുള്ള ഫീള്‍ഡുകള്‍ സ്വയമായി പൂര്‍ത്തിയാക്കുന്നതിനു് ഈ ജാലകത്തിലേക്കു് ഇമേജ് ഫയലുകള്‍ വലിച്ചിടാം."
+
+#~ msgid "Left Shift"
+#~ msgstr "ഇടത് ഷിഫ്ട്"
+
+#~ msgid "Left Alt"
+#~ msgstr "ഇടത് ആള്‍ട്ട്"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "ഇടത് കണ്‍ട്രോള്‍"
+
+#~ msgid "Right Shift"
+#~ msgstr "വലത് ഷിഫ്ട്"
+
+#~ msgid "Right Alt"
+#~ msgstr "വലത് ആള്‍ട്ട്"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "വലത് കണ്ട്രോള്‍"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "ഇടത് ആള്‍ട്ട്+ഷിഫ്ട്"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "വലത് ആള്‍ട്ട്+ഷിഫ്ട്"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "ഇടത് കണ്ട്രോള്‍+ഷിഫ്ട്"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "വലത് കണ്ട്രോള്‍+ഷിഫ്ട്"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "വലത്+ഇടത് ഷിഫ്റ്റ്"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "വലത്+ഇടത് കണ്ട്രോള്‍"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "ആള്‍ട്ട്+ഷിഫ്റ്റ്"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "കണ്ട്രോള്‍+ഷിഫ്റ്റ്"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "ആള്‍ട്ട്+കണ്ട്രോള്‍"
+
+#~ msgid "Caps"
+#~ msgstr "കാപ്പ്സ്"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "ഷിഫ്റ്റ്+ക്യാപ്പ്സ്"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "ആള്‍ട്ട്+ക്യാപ്പ്സ്"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "കണ്ട്രോള്‍+ക്യാപ്പ്സ്"
+
+#~ msgid "_Region:"
+#~ msgstr "_സ്ഥലം:"
+
+#~ msgid "_City:"
+#~ msgstr "_നഗരം:"
+
+#~ msgid "_Network Time"
+#~ msgstr "_ശൃംഖലയിലെ സമയം"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "ഒരു മണിക്കൂര്‍ കൂട്ടി സമയം സജ്ജീകരിക്കുക."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "ഒരു മണിക്കൂര്‍ കുറച്ചു സമയം സജ്ജീകരിക്കുക."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "ഒരു മിനിട്ട് കൂട്ടി സമയം സജ്ജീകരിക്കുക."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "ഒരു മിനിട്ട് കുറച്ചു സമയം സജ്ജീകരിക്കുക."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM PM എന്നിവ തമ്മില്‍ മാറ്റുക"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "സാധാരണ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "ഘടികാരദിശയില്‍ "
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 ഡിഗ്രീകള്‍"
+
+#~ msgid "Monitor"
+#~ msgstr "മോണിറ്റര്‍"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "പ്രധാന പ്രദര്‍ശനം മാറ്റുവാന്‍ വലിച്ചിടുക."
+
+#~ msgid "Select a monitor to change its properties; drag it to rearrange its placement."
+#~ msgstr "വിശേഷതകള്‍ മാറ്റുന്നതിനായി ഒരു മോണിറ്റര്‍ തെരഞ്ഞെടുക്കുക; സ്ഥാനം മാറ്റുന്നതിനായി അവിടേക്കു് വലിച്ചിടുക."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "ക്രമീകരണം ലഭ്യമാക്കുന്നതില്‍ പരാജയം: %s"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "മോണിറ്റര്‍ ക്രമീകരണം സൂക്ഷിക്കുവാന്‍ സാധ്യമായില്ല"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "ഡിസ്പ്ലെ ലഭ്യമായില്ല"
+
+#~ msgid "_Resolution"
+#~ msgstr "_ദൃശ്യസൂക്ഷ്മത"
+
+#~ msgid "R_otation"
+#~ msgstr "_കറക്കം"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "മി_റര്‍ പ്രദര്‍ശനങ്ങള്‍"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "കുറിപ്പു്: റിസല്യൂഷന്‍ ഐച്ഛികങ്ങള്‍ക്കു് പരിമിധി"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "ഡിസ്പ്ലെ _ലഭ്യമായില്ല"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "മൌസ് മുന്‍‌ഗണനകള്‍"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "C_ontent sticks to fingers"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "പുതിയ സര്‍വീസിനു് ഉപയോഗിയ്ക്കുവാനുള്ള ഇന്റര്‍ഫെയിസ് തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "C_reate…"
+#~ msgstr "_തയ്യാറാക്കുക…"
+
+#~ msgid "_Interface"
+#~ msgstr "മു_ഖരൂപം"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "ബാറ്ററിയുടെ ഏകദേശ ശേഷി: %s"
+
+#~ msgid "_Mobile Broadband"
+#~ msgstr "_മൊബൈല്‍ ബ്രോഡ്ബാന്‍ഡ്"
+
+#~ msgid "Hidden"
+#~ msgstr "അദൃശ്യമായവ"
+
+#~ msgid "Visible"
+#~ msgstr "ദൃശ്യമായ"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "പേരും കാഴ്ചയും"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "സ്ക്രീനിലും ശ്രംഖലയിലും നിങ്ങള്‍ എങ്ങനെ വരണമെന്ന് തീരുമാനിക്കുക."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "മുകളിലെ ബാറില്‍ _മുഴുവന്‍ പേരും കാണിക്കുക"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "_പൂട്ട് സ്ക്രീനില്‍ മുഴുവന്‍ പേരും കാണിക്കുക"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "_കരുതല്‍ മോഡ്"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "ഒന്നുമില്ല"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "സാധാരണ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "ഹൈ/ഇന്‍വേഴ്സ്"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "ഓണ്‍ സ്ക്രീന്‍ കീബോര്‍ഡ്"
+
+#~ msgid "OnBoard"
+#~ msgstr "ഓണ്‍ബോര്‍ഡ്"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "സാധാരണ"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Caps, Num Lock അമര്‍ത്തുമ്പോള്‍ ശബ്ദമുണ്ടാക്കുക"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "ഓണ്‍ അല്ലെങ്കില്‍ ഓഫ് ചെയ്യുക:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "വലിപ്പം മാറ്റുക"
+
+#~ msgid "Zoom in:"
+#~ msgstr "വലുതാക്കുക:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "ചെറുതാക്കുക:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "പേരിടല്‍ അടച്ചിരിക്കുന്നു"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "സംഭാഷണത്തിനും ശബ്ദങ്ങള്‍ക്കുമുള്ള വിവരണം കാണിയ്ക്കുക"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "ഓണ്‍ സ്ക്രീന്‍ കീബോര്‍ഡ്"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "ചെറുതു്"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "കൂടിയ"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "ശബ്ദമുണ്ടാക്കേണ്ടതു് എപ്പോള്‍:"
+
+#~ msgid "pressed"
+#~ msgstr "അമര്‍ത്തുമ്പോള്‍"
+
+#~ msgid "accepted"
+#~ msgstr "അംഗീകരിയ്ക്കുമ്പോള്‍"
+
+#~ msgid "rejected"
+#~ msgstr "നിഷേധിച്ചിരിയ്ക്കുമ്പോള്‍"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "_ആക്സപ്റ്റെന്‍സ് ഡിലേ:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "കീപാഡ് ഉപയോഗിച്ചു്  പോയിന്റര്‍ നിയന്ത്രിക്കാം"
+
+#~ msgid "Video Mouse"
+#~ msgstr "വീഡിയോ മൌസ്"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "വീഡിയോ ക്യാമറ ഉപയോഗിച്ചു് പോയിന്റര്‍ നിയന്ത്രിയ്ക്കുക"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "ചെറിയ"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "വലിയ"
+
+#~ msgid "_Local Account"
+#~ msgstr "ലോ_ക്കല്‍ അക്കൌണ്ട്"
+
+#~ msgid "_Login Name"
+#~ msgstr "പ്രവേശ_ന നാമം"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "സൂചന: എന്റര്‍പ്രൈസ് ഡൊമെയിന്‍ അല്ലെങ്കില്‍ സാമ്രാജ്യത്തിന്റെ പേരു്"
+
+#~ msgid "C_ontinue"
+#~ msgstr "തു_ടരുക"
+
+#~ msgid "Previous Week"
+#~ msgstr "കഴിഞ്ഞ ആഴ്ച"
+
+#~ msgid "Next Week"
+#~ msgstr "അടുത്ത ആഴ്ച"
+
+#~ msgid "Next week"
+#~ msgstr "അടുത്ത ആഴ്ച"
+
+#~ msgid "Log in without a password"
+#~ msgstr "ഒരു രഹസ്യവാക്കില്ലാതെ പ്രവേശിയ്ക്കുക"
+
+#~ msgid "Disable this account"
+#~ msgstr "ഈ അക്കൌണ്ട് പ്രവര്‍ത്തന രഹിതമാക്കുക"
+
+#~ msgid "Enable this account"
+#~ msgstr "ഈ അക്കൌണ്ട് പ്രവര്‍ത്തന സജ്ജമാക്കുക"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "രഹസ്യവാക്ക് ഉറപ്പാക്കുക"
+
+#~ msgid "Generate a password"
+#~ msgstr "ഒരു രഹസ്യവാക്ക് ലഭ്യമാക്കുക"
+
+#~ msgid "_Action"
+#~ msgstr "പ്ര_വര്‍ത്തി"
+
+#~ msgid "_Show password"
+#~ msgstr "രഹസ്യവാക്ക് കാണിയ്ക്കു_ക"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "ശക്തമായൊരു രഹസ്യവാക്ക് എങ്ങനെ തെരഞ്ഞെടുക്കണം"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "ഫോട്ടോ മാറ്റുന്നു:"
+
+#~ msgid "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "ഈ അക്കൌണ്ടിനു് പ്രവേശന സ്ക്രീനിനൊപ്പം കാണിയ്ക്കേണ്ട ചിത്രം തെരഞ്ഞെടുക്കുക."
+
+#~ msgid "Gallery"
+#~ msgstr "ഗ്യാലറി"
+
+#~ msgid "Take a photograph"
+#~ msgstr "ഒരു ഫോട്ടോ എടുക്കുക"
+
+#~ msgid "Browse"
+#~ msgstr "പരതുക"
+
+#~ msgid "Photograph"
+#~ msgstr "ഫോട്ടോ"
+
+#~ msgid "Account Information"
+#~ msgstr "അക്കൗണ്ട് വിവരം"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "വളരെ ചെറുതു്"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "അത്ര നല്ലതല്ല"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "പോര"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "സാമാന്യം നല്ലത്"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "നല്ലതു്"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "ശക്തം"
+
+#~ msgid "_Generate a password"
+#~ msgstr "ഒരു രഹസ്യവാക്ക് തയ്യാറാക്കുക"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "ഒരു പുതിയ രഹസ്യവാക്ക് നല്‍കേണ്ടതുണ്ടു്"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "പുതിയ രഹസ്യവാക്ക് ശക്തമല്ല"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "രഹസ്യവാക്ക് ഉറപ്പാക്കേണ്ടതുണ്ടു്"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "നിങ്ങളുടെ ഇപ്പോഴുള്ള രഹസ്യവാക്ക് നല്‍കുക"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "നിലവിലുള്ള രഹസ്യവാക്ക് തെറ്റാണു് "
+
+#~ msgid "Switch Modes"
+#~ msgstr "മോഡുകള്‍ മാറുക"
+
+#~ msgid "Action"
+#~ msgstr "പ്രവര്‍ത്തനം"
+
+#~ msgid "Change the background"
+#~ msgstr "പശ്ചാത്തലം മാറ്റുക"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "ബ്ലൂടൂത്ത്"
+
+#~ msgid "Export"
+#~ msgstr "കയറ്റുമതി"
+
+#~ msgid "Color management settings"
+#~ msgstr "നിറം കൈകാര്യം ചെയ്യല്‍ സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "British English"
+#~ msgstr "ബ്രിട്ടിഷ് ഇംഗ്ലിഷ്"
+
+#~ msgid "Spanish"
+#~ msgstr "സ്പാനിഷ്"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "ചൈനീസ് (ചുരുക്കിയത്)"
+
+#~ msgid "Select a region"
+#~ msgstr "ഒരു സ്ഥലം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Select a language"
+#~ msgstr "ഒരു ഭാഷ തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "തീയതിയും സമയവും മുന്‍ഗണനാ പാനല്‍"
+
+#~ msgid "System Information"
+#~ msgstr "സിസ്റ്റത്തെക്കുറിച്ചുള്ള വിവരം"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "കീബോര്‍ഡ് ക്രമീകരണങ്ങള്‍ മാറ്റുക"
+
+#~ msgid "Layout Settings"
+#~ msgstr "വിന്യാസത്തിന്റെ ക്രമീകരണങ്ങള്‍"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "നിങ്ങളുടെ മൌസ്, ടച്ച്പാഡ് മുന്‍ഗണനകള്‍ സജ്ജമാക്കുന്നു"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "പതിയെ"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "വേഗം"
+
+#~ msgid "Network settings"
+#~ msgstr "ശൃംഖലയുടെ ക്രമീകരണങ്ങള്‍"
+
+#~ msgid "_Options…"
+#~ msgstr "_ഐച്ഛികങ്ങള്‍…"
+
+#~ msgid "blablabla"
+#~ msgstr "ബ്ലാബ്ലാബ്ലാ"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "വിലാസ\n"
+#~ "വിഭാഗം\n"
+#~ "ഇവിടെ\n"
+#~ "വരുന്നു"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "വിഭാഗം\n"
+#~ "ഇവിടെ\n"
+#~ "വരുന്നു"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "റൂട്ടുകളുടെ\n"
+#~ "വിഭാഗം\n"
+#~ "ഇവിടെ\n"
+#~ "വരുന്നു"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "Manage notifications"
+#~ msgstr "അറിയിപ്പുകള്‍ കൈകാര്യം ചെയ്യുക"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "അനുമതികളുടെ കാലാവധി കഴിഞ്ഞിരിയ്ക്കുന്നു. ദയവായി വീണ്ടും പ്രവേശിയ്ക്കുക."
+
+#~ msgid "_Log In"
+#~ msgstr "_അകത്തുകയറുക"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "ഓണ്‍ലൈന്‍ അക്കൗണ്ടുകള്‍ കൈകാര്യം ചെയ്യുക"
+
+#~ msgid "Power management settings"
+#~ msgstr "പവര്‍ മാനേജ്മെന്റ് സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "Manufacturers"
+#~ msgstr "നടത്തിപ്പുകാര്‍"
+
+#~ msgid "Drivers"
+#~ msgstr "ഡ്രൈവറുകള്‍"
+
+#~ msgid "Privacy settings"
+#~ msgstr "സ്വകാര്യത സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "നിങ്ങളുടെ സ്ഥലം, ഭാഷ സജ്ജീകരണങ്ങള്‍ മാറ്റുക"
+
+#~ msgid "Select an input source"
+#~ msgstr "ഇന്‍പുട്ട് ശ്രോതസ്സ് തെരഞ്ഞെടുക്കുക"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-wide Region and Language settings."
+#~ msgstr ""
+#~ "പ്രവേശന സ്ക്രീന്‍, സിസ്റ്റം അക്കൌണ്ടുകള്‍, പുതിയ ഉപയോക്താവിനുള്ള അക്കൌണ്ടുകള്‍ എന്നിവ സിസ്റ്റത്തില്‍ പൂര്‍ണ്ണമായുള്ള സ്ഥലവും ഭാഷയും സജ്ജീകരണങ്ങള്‍ "
+#~ "ഉപയോഗിയ്ക്കുന്നു."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-wide Region and Language settings. "
+#~ "You may change the system settings to match yours."
+#~ msgstr ""
+#~ "പ്രവേശന സ്ക്രീന്‍, സിസ്റ്റം അക്കൌണ്ടുകള്‍, പുതിയ ഉപയോക്താവിനുള്ള അക്കൌണ്ടുകള്‍ എന്നിവ സിസ്റ്റത്തില്‍ പൂര്‍ണ്ണമായുള്ള സ്ഥലവും ഭാഷയും സജ്ജീകരണങ്ങള്‍ "
+#~ "ഉപയോഗിയ്ക്കുന്നു. നിങ്ങളുടേതുമായി പൊരുത്തപ്പെടുന്നതിനു് സിസ്റ്റം സജ്ജീകരണങ്ങളില്‍ മാറ്റം വരുത്താം."
+
+#~ msgid "Copy Settings"
+#~ msgstr "സജ്ജീകരണങ്ങള്‍ പകര്‍ത്തുക"
+
+#~ msgid "Copy Settings…"
+#~ msgstr "സജ്ജീകരണങ്ങള്‍ പകര്‍ത്തുക…"
+
+#~ msgid "Region and Language"
+#~ msgstr "സ്ഥലവും ഭാഷയും"
+
+#~ msgid "Select a display language"
+#~ msgstr "കാണിക്കാനുള്ള ഒരു ഭാഷ തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Add Language"
+#~ msgstr "ഭാഷ ചേര്‍ക്കുക"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "ഒരു സ്ഥലം തെരഞ്ഞെടുക്കുക (അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ മാറ്റം ലഭ്യമാകുന്നു)"
+
+#~ msgid "Add Region"
+#~ msgstr "സ്ഥലം ചേര്‍ക്കുക"
+
+#~ msgid "Remove Region"
+#~ msgstr "സ്ഥലം നീക്കം ചെയ്യുക"
+
+#~ msgid "Currency"
+#~ msgstr "നാണയം"
+
+#~ msgid "Examples"
+#~ msgstr "ഉദാഹരണങ്ങള്‍"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "കീബോര്‍ഡുകള്‍ അല്ലെങ്കില്‍ മറ്റു് ഇന്‍പുട്ട് ശ്രോതസ്സുകള്‍ തെഗഞ്ഞെടുക്കുക"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "എളുപ്പവഴി സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "Input source:"
+#~ msgstr "ഇന്‍പുട്ട് ഉറവിടം:"
+
+#~ msgid "Format:"
+#~ msgstr "ശൈലി:"
+
+#~ msgid "Your settings"
+#~ msgstr "നിങ്ങളുടെ സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "System settings"
+#~ msgstr "സിസ്റ്റത്തിന്റെ സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "Search settings"
+#~ msgstr "തെരയല്‍ സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "ആഗോള സമീപന മുന്‍ഗണനകള്‍"
+
+#~ msgid "_Hint"
+#~ msgstr "സൂച_ന"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to all users of this system.  Do "
+#~ "<b>not</b> include the password here."
+#~ msgstr ""
+#~ "പ്രവേശന സ്ക്രീനില്‍ ഈ സൂചന കാണിയ്ക്കുന്നു. ഈ സിസ്റ്റം ഉപയോഗിയ്ക്കുന്ന എല്ലാ ഉപയോക്താക്കള്‍ക്കും ഇതു് കാണുവാന്‍ സാധിയ്ക്കുന്നു. ഇവിടെ "
+#~ "രഹസ്യവാക്ക് <b>നല്‍കരുതു്</b>."
+
+#~ msgid "Fair"
+#~ msgstr "സാമാന്യം നല്ലത്"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "നിങ്ങളുടെ വാക്കോം ടാബ്ലറ്റ് മുന്‍ഗണനകള്‍ സജ്ജമാക്കുക"
+
+#~ msgid "Mesh"
+#~ msgstr "മെഷ്"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "ക്യാരിയര്‍/കണ്ണി മാറിയിരിയ്ക്കുന്നു"
+
+#~ msgid "_Mark As Inactive After"
+#~ msgstr "ശേഷം വെറുതെ ഇരിക്കുന്നതായി _കണക്കാകുക"
+
+#~ msgid "Don't retain history"
+#~ msgstr "ചരിത്രം വെച്ചേക്കണ്ട"
+
+#~ msgid "Browse Files..."
+#~ msgstr "ഫൈലുകള്‍ ബ്രൗസ് ചെയ്യുക..."
+
+#~ msgid "Create virtual device"
+#~ msgstr "ഒരു പുതിയ വിര്‍ച്ച്വല്‍ ഉപകരണം ഉണ്ടാക്കുക"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "പ്രദര്‍ശനത്തിനു് ലഭ്യമായ പ്രൊഫൈലുകള്‍"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "സ്കാനറുകള്‍ക്കു് ലഭ്യമായ പ്രൊഫൈലുകള്‍"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "പ്രിന്ററുകള്‍ക്കു് ലഭ്യമായ പ്രൊഫൈലുകള്‍"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "ക്യാമറകള്‍ക്കു് ലഭ്യമായ പ്രൊഫൈലുകള്‍"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "വെബ്ക്യാമറകള്‍ക്കു് ലഭ്യമായ പ്രൊഫൈലുകള്‍"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i വര്‍ഷം"
+#~ msgstr[1] "%i വര്‍ഷങ്ങള്‍"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i മാസം"
+#~ msgstr[1] "%i മാസങ്ങള്‍"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i ആഴ്ച"
+#~ msgstr[1] "%i ആഴ്ചകള്‍"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "1 ആഴ്ചയില്‍ കുറവു്"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "ഈ ഡിവൈസിനു് നിറം കൈകാര്യം ചെയ്യുന്നില്ല."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "ഈ ഡിവൈസ് കാലിബ്രേറ്റ് ഡേറ്റാ ഉപയോഗിയ്ക്കുന്നു."
+
+#~ msgid "This device does not have a profile suitable for whole-screen color correction."
+#~ msgstr "പൂര്‍ണ്ണ സ്ക്രീനിനുചിതമായൊരു പ്രൊഫൈല്‍ ഈ ഡിവൈസിനു് ലഭ്യമല്ല."
+
+#~ msgid "Not specified"
+#~ msgstr "വ്യക്തമാക്കിയിട്ടില്ല"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "നിറം കൈകാര്യം ചെയ്യുന്ന ഡിവൈസുകള്‍ ലഭ്യമല്ല"
+
+#~ msgid "Add device"
+#~ msgstr "ഡിവൈസ് ചേര്‍ക്കുക"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "ഒരു മായാ ഉപകരണം ചേര്‍ക്കുക"
+
+#~ msgid "Remove a device"
+#~ msgstr "ഒരു ഡിവൈസ് നീക്കം ചെയ്യുക"
+
+#~ msgid "English"
+#~ msgstr "ഇംഗ്ലിഷ്"
+
+#~ msgid "German"
+#~ msgstr "ജര്‍മന്‍"
+
+#~ msgid "French"
+#~ msgstr "ഫ്രഞ്ച്"
+
+#~ msgid "Russian"
+#~ msgstr "റഷ്യന്‍"
+
+#~ msgid "Arabic"
+#~ msgstr "അറബിക്"
+
+#~ msgid "Unspecified"
+#~ msgstr "വ്യക്തമാക്കിയിട്ടില്ലാത്ത"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "അജ്ഞാത മോഡല്‍"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ സാധാണ രീതി ഉപയോഗിയ്ക്കുന്നു."
+
+#~ msgid "The next login will use the fallback mode intended for unsupported graphics hardware."
+#~ msgstr "അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ പിന്തുണയ്ക്കാത്ത ഗ്രാഫിക്സ് ഹാര്‍ഡ്‌വെയറിനുള്ള ഫോള്‍ബാക്ക് മോഡ്  ഉപയോഗിയ്ക്കുന്നു."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "ഫോള്‍ബാക്ക്"
+
+#~ msgid "_Other Media..."
+#~ msgstr "_മറ്റു് മാധ്യമം..."
+
+#~ msgid "Experience"
+#~ msgstr "പ്രവൃത്തിപരിചയം"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "നിര്‍ബന്ധമായി _ഫോള്‍ബാക്ക് മോഡ്"
+
+#~ msgid "Out of range"
+#~ msgstr "പരിധിയ്ക്കു് പുറത്തു്"
+
+#~ msgid "_Options..."
+#~ msgstr "_ഐച്ഛികങ്ങള്‍..."
+
+#~ msgid "C_reate..."
+#~ msgstr "_ഉണ്ടാക്കുക..."
+
+#~ msgid "Wireless"
+#~ msgstr "വയര്‍ലസ്സ്"
+
+#~ msgid "_Disconnect"
+#~ msgstr "_വിഛേദിയ്ക്കുക"
+
+#~ msgid "_Connect"
+#~ msgstr "_കണക്ട് ചെയ്യുക"
+
+#~ msgid "Disconnected"
+#~ msgstr "ബന്ധം വേര്‍പെടുത്തിയിരിക്കുന്നു"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "ബാറ്ററിയുടെ ചാര്‍ജ് കുറവാണു്, %s ബാക്കി"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "ബാറ്ററി പവര്‍ ഉപയോഗിയ്ക്കുന്നു - %s ബാക്കി"
+
+#~ msgid "Using battery power"
+#~ msgstr "ബാറ്ററി പവര്‍ ഉപയോഗിയ്ക്കുന്നു"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "ചാര്‍ജ് ചെയ്യുന്നു - പൂര്‍ണ്ണമായി ചാര്‍ജ് ചെയ്തു"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "യുപിഎസ് പവര്‍ ഉപയോഗിയ്ക്കുന്നു - %s സമയം ബാക്കി"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "യുപിഎസ് കുറവു്"
+
+#~ msgid "Using UPS power"
+#~ msgstr "യുപിഎസ് വൈദ്യുതിയില്‍"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "നിങ്ങളുടെ കണ്ടാമത്തെ ബാറ്ററി പൂര്‍ണ്ണമായി ചാര്‍ജ് ചെയ്തിരിയ്ക്കുന്നു"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "നിങ്ങളുടെ രണ്ടാമത്തെ ബാറ്ററി കാലിയാണു്"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "ചാര്‍ജ് ചെയ്യുന്നു - പൂര്‍ണ്ണമായി ചാര്‍ജായി"
+
+#~ msgid "Tip: <a href=\"screen\">screen brightness</a> affects how much power is used"
+#~ msgstr "സൂചന: <a href=\"screen\">സ്ക്രീന്റെ തെളിച്ചം</a> സിസ്റ്റത്തിന്റെ പവറിനെ ബാധിയ്ക്കുന്നു"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "നിര്‍ജ്ജീവമാകുമ്പോള്‍ സസ്പെന്‍ഡ് ചെയ്യുക"
+
+#~ msgid "_Show"
+#~ msgstr "_കാണിക്കുക"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "സജ്ജീകരണങ്ങള്‍ പകര്‍ത്തുക..."
+
+#~ msgid "Select a display language (change will be applied next time you log in)"
+#~ msgstr "ഒരു പ്രദര്‍ശന ഭാഷ തെരഞ്ഞെടുക്കുക (അടുത്ത തവണ പ്രവേശിയ്ക്കുമ്പോള്‍ മാറ്റം ലഭ്യമാകുന്നു)"
+
+#~ msgid "Remove Language"
+#~ msgstr "ഭാഷ നീക്കം ചെയ്യുക"
+
+#~ msgid "Install languages..."
+#~ msgstr "ഭാഷകള്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യുക..."
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "തെളിച്ചവും പൂട്ടും"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "സ്ക്രീന്‍ തെളിച്ചവും പൂട്ടിനുള്ള സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Brightness;Lock;Dim;Blank;Monitor;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "പവര്‍ ലാഭിയ്ക്കുന്നതിനായി സ്ക്രീനിന്റെ തെളിച്ചം കു_റയ്ക്കുക"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "ആസ്ഥാനത്തിലുള്ളപ്പോള്‍ പൂട്ടരുതു്"
+
+#~ msgid "Locations..."
+#~ msgstr "സ്ഥലങ്ങള്‍..."
+
+#~ msgid "Lock"
+#~ msgstr "പൂട്ട്"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "പ്രശ്നനിര്‍ദ്ധാരണകോഡ് പ്രാവര്‍ത്തികമാക്കുക. "
+
+#~ msgid "Version of this application"
+#~ msgstr "ഈ പ്രയോഗത്തിന്റെ പതിപ്പു്"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — ഗ്നോം വോള്യം നിയന്ത്രണ ആപ്ലറ്റ്"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "പണിയിട ശബ്ദ ക്രമീകാരി കാണിക്കുക"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "ശബ്ദം ഔട്ട്പുട്ട് വോള്യം"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "മൈക്രോഫോണ്‍ വോള്യം"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "ശബ്ദ മുന്‍ഗണനകള്‍ പ്രവര്‍ത്തിപ്പിക്കുന്നതില്‍ പരാജയപ്പെട്ടു: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "_നിശബ്ദമാക്കുക"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "_ശബ്ദ മുന്‍ഗണനകള്‍"
+
+#~ msgid "Muted"
+#~ msgstr "നിശബ്ദമാക്കി"
+
+#~ msgid "Options..."
+#~ msgstr "ഐച്ഛികങ്ങള്‍..."
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "നിറം"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "ഒന്നുമില്ല"
+
+#~ msgid "User Accounts"
+#~ msgstr "ഉപയോക്താവിനുള്ള അക്കൌണ്ടുകള്‍"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "കൂടുതല്‍ ചിത്രങ്ങള്‍ക്ക് വേണ്ടി ബ്രൗസ് ചെയ്യുക..."
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "'%s' എന്ന പേരില്‍ ഉപയോക്താവില്ല."
+
+#~ msgid "This user does not exist."
+#~ msgstr "ഈ ഉപയോക്താവു് നിലവിലില്ല."
+
+#~ msgid "Map Buttons..."
+#~ msgstr "ബട്ടണുകള്‍ മാപ്പ് ചെയ്യുക..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "കാലിബറേറ്റ്..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- സിസ്റ്റത്തിന്റെ സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "System Settings"
+#~ msgstr "സിസ്റ്റത്തിന്റെ സജ്ജീകരണങ്ങള്‍"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "പശ്ചാത്തലചിത്രം ചേര്‍ക്കുക"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "പശ്ചാത്തലചിത്രം നീക്കം ചെയ്യുക"
+
+#~ msgid "Swap colors"
+#~ msgstr "നിറങ്ങള്‍ തമ്മില്‍ മാറ്റുക"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "ഹോറിസോണ്ടല്‍ ഗ്രേഡിയന്റെ"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "വെര്‍ട്ടിക്കല്‍ ഗ്രേഡിയന്റെ"
+
+#~ msgid "Solid Color"
+#~ msgstr "കട്ടി നിറം"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "നിറങ്ങളും ഗ്രേഡിയന്റുകളും"
+
+#, fuzzy
+#~ msgid "Acti_on:"
+#~ msgstr "പ്രവര്‍ത്തി:"
+
+#, fuzzy
+#~ msgid "Take a screenshot"
+#~ msgstr "ഒരു സ്ക്രീന്‍ ഷോട്ട് എടുക്കുക"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "_വേഗവര്‍ദ്ധനവ്:"
+
+#, fuzzy
+#~ msgid "Drag Threshold"
+#~ msgstr "വലിച്ചിഴയ്ക്കുന്നതിനുള്ള കുറഞ്ഞവില"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "വലിച്ചിടുക"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "ടച്ച്പാഡില്‍ മൌസ് _ക്ലിക്കുകള്‍ പ്രവര്‍ത്ത സജ്ജമാക്കുക"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Control കീ അമര്‍ത്തുമ്പോള്‍ പോയിന്ററിനുള്ള സ്ഥാനം _കാണിക്കുക."
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "_ത്രെഷോള്‍ഡ്:"
+
+#, fuzzy
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr ""
+#~ "<i>നിങ്ങളുടെ രണ്ടു്-തവണ ക്ലിക്ക് ചെയ്യുന്നതിനുള്ള സജ്ജീകരണങ്ങള്‍ പരീക്ഷിക്കുന്നതിനായി, ലൈറ്റ് ബള്‍ബില്‍ രണ്ടു് തവണ ക്ലിക്ക് ചെയ്യുക.</i>"
+
+#~ msgid "_Disabled"
+#~ msgstr "_നിര്‍ജ്ജീവമാക്കിയ"
+
+#~ msgid "_Left-handed"
+#~ msgstr "ഇടങ്കയ്യന്‍ മൌസ്"
+
+#~ msgid "_Right-handed"
+#~ msgstr "വലങ്കയ്യന്‍"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_സംവേദനക്ഷമത:"
+
+#~ msgid "_Timeout:"
+#~ msgstr "_സമയപരിധി:"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "മറ്റുളളവ..."
+
+#, fuzzy
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "ഏതായാലും അകത്തുകയറുക"
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "_ഹോട്ട്സ്പോട്ട് തുടങ്ങുക"
+
+#, fuzzy
+#~ msgid "Disable VPN"
+#~ msgstr "_VPN കണക്ഷനുകള്‍"
+
+#, fuzzy
+#~ msgid "FTP Port"
+#~ msgstr "FTP പ്രോക്സി പോര്‍ട്ട്"
+
+#, fuzzy
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP പ്രോക്സി പോര്‍ട്ട്"
+
+#, fuzzy
+#~ msgid "HTTPS Port"
+#~ msgstr "പോറ്‍ട്ട് ശ്റദ്ധിക്കുക"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "സബ്‌നെറ്റ് മാസ്ക്"
+
+#, fuzzy
+#~ msgid "_Network Name"
+#~ msgstr "_നെറ്റ്‌വര്‍ക്കിന്റെ പേരു്:"
+
+#, fuzzy
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "പ്രക്രിയ നിര്‍ത്തുക"
+
+#~ msgid "_Add..."
+#~ msgstr "കൂട്ടിച്ചേര്‍ക്കുക..."
+
+#~ msgid "Tip:"
+#~ msgstr "സൂചന:"
+
+#, fuzzy
+#~ msgid "Brightness Settings"
+#~ msgstr "<b>ഡിസ്‌പ്ലെ ക്രമീകരണങ്ങള്‍</b>"
+
+#, fuzzy
+#~ msgid "_Search by Address"
+#~ msgstr "നിരനിരയായി തെരയുക"
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "പ്രാദേശികം"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "ശൃംഖല"
+
+#~ msgid "Device types"
+#~ msgstr "ഉപകരണ തരങ്ങള്‍"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "സ്വയം ക്രമീകരണം"
+
+#, fuzzy
+#~ msgid "Allowed users"
+#~ msgstr "ഉപയോക്താക്കളുടെ സജ്ജീകരണം"
+
+#, fuzzy
+#~ msgid "_Back"
+#~ msgstr "പുറകോട്ട് (_B)"
+
+#, fuzzy
+#~ msgid "Add Layout"
+#~ msgstr "കീബോര്‍ഡ് വിന്യാസം"
+
+#~ msgid "Layouts"
+#~ msgstr "വിന്യാസങ്ങള്‍"
+
+#, fuzzy
+#~ msgid "New windows use the default layout"
+#~ msgstr "പുതിയ ജാലകത്തില്‍ മാനുവല്‍ ലേയൌട്ടു് ഉപയോഗിക്കുക"
+
+#, fuzzy
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "പുതിയ ജാലകങ്ങള്‍ സജീവമായ ജാലകത്തിന്റെ ശൈലി _ഉപയോഗിക്കുന്നു"
+
+#, fuzzy
+#~ msgid "Preview Layout"
+#~ msgstr "കീബോര്‍ഡ് വിന്യാസം"
+
+#, fuzzy
+#~ msgid "Remove Layout"
+#~ msgstr "കീബോര്‍ഡ് വിന്യാസം"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "_സഹജമായതിലേയ്ക്ക് വീണ്ടും സജ്ജീകരിയ്ക്കുക"
+
+#, fuzzy
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "കീബോര്‍ഡ് വിന്യാസ ഐച്ഛികങ്ങള്‍"
+
+#~ msgid "Layout"
+#~ msgstr "വിന്യാസം"
+
+#, fuzzy
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "ക്രമീകരിക്കുവാനുള്ളൊരു ഡിവൈസ് _തെരഞ്ഞെടുക്കുക:"
+
+#, fuzzy
+#~ msgid "Caribou"
+#~ msgstr "കാരിബു"
+
+#, fuzzy
+#~ msgid "Change contrast:"
+#~ msgstr "ചലച്ചിത്രത്തിന്റെ തെളിച്ചം"
+
+#~ msgid "Dasher"
+#~ msgstr "ഡാഷര്‍"
+
+#, fuzzy
+#~ msgid "Decrease size:"
+#~ msgstr "കാഴ്ചയുടെ വലിപ്പം കുറയ്ക്കുക"
+
+#, fuzzy
+#~ msgid "Increase size:"
+#~ msgstr "കാഴ്ചയുടെ വലിപ്പം കൂട്ടുക"
+
+#, fuzzy
+#~ msgid "Nomon"
+#~ msgstr "ഒന്നുമില്ല"
+
+#, fuzzy
+#~ msgid "Type here to test settings"
+#~ msgstr "തെരച്ചില്‍ രീതി മാറ്റുന്നതിനായി ഇവിടെ ക്ലിക്ക് ചെയ്യുക"
+
+#, fuzzy
+#~ msgid "_Text size:"
+#~ msgstr "വലിയ ടെക്സ്റ്റ് വ്യാപ്തി"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "വലുതാക്കുക"
+
+#, fuzzy
+#~ msgid "1/2 Screen"
+#~ msgstr "തിരച്ചിത്രം"
+
+#, fuzzy
+#~ msgid "3/4 Screen"
+#~ msgstr "തിരച്ചിത്രം"
+
+#, fuzzy
+#~ msgid "Cr_eate"
+#~ msgstr "സൃ_ഷ്ടിയ്ക്കുക"
+
+#, fuzzy
+#~ msgid "Create new account"
+#~ msgstr "പുതിയ ഉപയോക്താവിന്റെ അക്കൌണ്ട്"
+
+#, fuzzy
+#~ msgid "_Account Type"
+#~ msgstr "ഗുമ്പല് (തരം 1)"
+
+#, fuzzy
+#~ msgid "Choose a generated password"
+#~ msgstr "ഇതിലും വലിയ പാസ്‌വേറ്‍ഡ് തിരഞ്ഞെടുക്കുക"
+
+#, fuzzy
+#~ msgid "Account _type"
+#~ msgstr "ഗുമ്പല് (തരം 1)"
+
+#, fuzzy
+#~ msgid "More choices..."
+#~ msgstr "അനവധി തെരഞ്ഞെടുത്തിരിക്കുന്നു"
+
+#, fuzzy
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "വാക്കൊം ടാബ്ലെറ്റ് റൊട്ടേഷന്‍"
+
+#~ msgid "Current network location"
+#~ msgstr "നിലവിലുള്ള നെറ്റ്‌വര്‍ക്ക് സ്ഥാനം"
+
+#~ msgid "More themes URL"
+#~ msgstr "കൂടുതല്‍ രംഗവിതാനങ്ങള്‍ക്കുള്ള യുആര്‍എല്‍"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the appropriate network proxy "
+#~ "configuration."
+#~ msgstr ""
+#~ "ഇതു് നിങ്ങളുടെ നിലവിലുള്ള സ്ഥാന പേരിലേക്ക് സജ്ജമാക്കുക. ശരിയായ നെറ്റ്‌വര്‍ക്ക് പ്രോക്സി ക്രമീകരണം കണ്ടുപിടിക്കന്നതിനായി ഇതുപയോഗിക്കുന്നു."
+
+#~ msgid "URL for where to get more desktop backgrounds. If set to an empty string the link will not appear."
+#~ msgstr "കൂടതല്‍ പണിയിട പശ്ചാതലങ്ങള്‍ ലഭ്യമാകുന്ന യുആര്‍എല്‍. ശൂന്യമായ സ്ട്രിങായി സജ്ജമാക്കിയാല്‍ ലിങ്ക് കാണുവാന്‍ സാധ്യമല്ല."
+
+#~ msgid "URL for where to get more desktop themes. If set to an empty string the link will not appear."
+#~ msgstr "കൂടതല്‍ പണിയിട രംഗവിതാനങ്ങള്‍ ലഭ്യമാകുന്ന യുആര്‍എല്‍. ശൂന്യമായ സ്ട്രിങായി സജ്ജമാക്കിയാല്‍ ലിങ്ക് കാണുവാന്‍ സാധ്യമല്ല."
+
+#~ msgid "Image/label border"
+#~ msgstr "ചിത്രത്തിന്റെ/കുറിപ്പിന്റെ അതിരു്"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "അറിയിപ്പ് ജാലകത്തില്‍ കുറിപ്പിനും ചിത്രത്തിനും ചുറ്റുമുള്ള അതിരിന്റെ വീതി"
+
+#~ msgid "The type of alert"
+#~ msgstr "അറിയിപ്പിന്റെ രീതി"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "അറിയിപ്പ്  ജാലകത്തില്‍ കാണിക്കുന്ന ബട്ടണുകള്‍"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്ത് തള്ളവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്ത് തള്ളവിരല്‍ %s-ല്‍ സ്വൈപ് ചെയ്യുക"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്ത് ചൂണ്ടുവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്ത് ചൂണ്ടുവിരല്‍ %s-ല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്തു് നടുവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്തു് നടുവിരല്‍ %s-ല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്തു് മോതിരവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്തു് മോതിരവിരല്‍ %s-ല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്തു് ചെറുവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "നിങ്ങളുടെ ഇടത്തു് ചെറുവിരല്‍ %s-ല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് തള്ളവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് തള്ളവിരല്‍ %s-ല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് ചൂണ്ടുവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് ചൂണ്ടുവിരല്‍ %s-ല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് നടുവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് നടുവിരല്‍ %s-ല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് മോതിരവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് മോതിരവിരല്‍ %s-ല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് ചെറുവിരല്‍ %s-ല്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "നിങ്ങളുടെ വലത്തു് ചെറുവിരല്‍ %s-ല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "നിങ്ങളുടെ വിരല്‍ വീണ്ടും റീഡറില്‍ വയ്ക്കുക"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "നിങ്ങളുടെ വിരല്‍ വീണ്ടും സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "പെട്ടെന്നു് സ്വൈപ്പ് ചെയ്തു, ഒരിക്കല്‍ കൂടി ശ്രമിക്കുക"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "നിങ്ങളുടെ വിരല്‍ മദ്ധ്യത്തിലായിരുന്നില്ല, ഒരിക്കല്‍ കൂടി ശ്രമിക്കുക"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "നിങ്ങളുടെ വിരല്‍ മാറ്റി, ശേഷം വീണ്ടും ശ്രമിക്കുക"
+
+#~ msgid "No Image"
+#~ msgstr "ചിത്രമില്ല"
+
+#~ msgid "Images"
+#~ msgstr "ചിത്രങ്ങള്‍"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "മേല്‍വിലാസപുസ്തകത്തിന്റെ വിവരം ലഭ്യമാക്കുവാനുളള ശ്രമത്തിനിടയില്‍ ഒരു തെറ്റുണ്ടായി\n"
+#~ "എവല്യൂഷന്‍ ഡാറ്റാ സേവകന്  കീഴ്​വഴക്കം കൈകാര്യം ചെയ്യുവാന്‍ സാധ്യമല്ല"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "മേല്‍വിലാസപുസ്തകം തുറക്കാനാവുന്നില്ല. "
+
+#~ msgid "About %s"
+#~ msgstr "%s-നെ പറ്റി"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "എഐഎം/ഐചാറ്റ്:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "സ്ഥാ_പനം:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "അടയാളവാക്ക് _മാറ്റുക..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "_നഗരം:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "_രാജ്യം:"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "ഫിംഗര്‍പിന്റ് ലോഗിന്‍ _പ്രവര്‍ത്തന രഹിതമാക്കുക..."
+
+#~ msgid "Email"
+#~ msgstr "ഈമെയില്‍"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "ഫിംഗര്‍പിന്റ് ലോഗിന്‍ _സജ്ജമാക്കുക..."
+
+#~ msgid "Hom_e:"
+#~ msgstr "_തട്ടകം:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "ഐസി_ക്യു:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "ഇന്‍സ്റ്റന്റ് മെസ്സേജിങ്ങ്"
+
+#~ msgid "M_SN:"
+#~ msgstr "എം_എസ്എന്‍:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "പി. ഒ. _ബോക്സ്:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "പി. _ഒ. ബോക്സ്:"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "_സംസ്ഥാനം:"
+
+#~ msgid "Web _log:"
+#~ msgstr "വെബ് _ലോഗ്:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_ജോലി:"
+
+#~ msgid "Work"
+#~ msgstr "ജോലി"
+
+#~ msgid "Work _fax:"
+#~ msgstr "ഓഫീസ് _ഫാക്സ്:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "പിന്‍കോഡ്"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_ഗ്രൂപ്പ്‌വൈസ്:"
+
+#~ msgid "_Home page:"
+#~ msgstr "പൂ_മുഖം:"
+
+#~ msgid "_Home:"
+#~ msgstr "തട്ടകം:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_ജാബര്‍:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_സംസ്ഥാനം:"
+
+#~ msgid "_Work:"
+#~ msgstr "_ജോലി:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_യാഹൂ:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "_പിന്‍കോഡ്"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "റീഡറില്‍ വിരല്‍ സ്വൈപ്പ് ചെയ്യുക"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "റീഡറില്‍ വിരല്‍ വയ്ക്കുക"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "അപ്രതീക്ഷിതമായി ചൈല്‍ഡിന്റെ പ്രവര്‍ത്തനം നിന്നിരിക്കുന്നു"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO ചാനല്‍ നിര്‍ത്തുവാന്‍ സാധ്യമായില്ല: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO ചാനല്‍ നിര്‍ത്തുവാന്‍ സാധ്യമായില്ല: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "സിസ്റ്റത്തില്‍ തെറ്റ്: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%1$s: %2$s തുടങ്ങാന്‍ കഴിയുന്നില്ല"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "ബാക്കെന്‍ഡ് തുടങ്ങുവാന്‍ സാധ്യമായില്ല"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "സിസ്റ്റത്തില്‍ ഒരു പിശക് പറ്റിയിരിക്കുന്നു"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "അടയാളവാക്ക് മാറ്റുന്നതിനായി <b>അടയാളവാക്ക് മാറ്റുക</b> എന്നത് ക്ലിക്ക് ചെയ്യുക."
+
+#~ msgid "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "ദയവായി <b>പുതിയ അടയാളവാക്ക് വീണ്ടും ടൈപ്പ് ചെയ്യുക</b> എന്ന കളത്തില്‍ നിങ്ങളുടെ അടയാളവാക്ക് വീണ്ടും നല്‍കുക."
+
+#~ msgid "Change your password"
+#~ msgstr "നിങ്ങളുടെ അടയാളവാക്ക് മാറ്റുക"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for verification and click <b>Change "
+#~ "password</b>."
+#~ msgstr ""
+#~ "നിങ്ങളുടെ അടയാളവാക്ക് മാറ്റുന്നതിനായി, താഴെയുളള കളത്തില്‍ നിലവിലുളള അടയാളവാക്ക് നല്‍കിയ ശേഷം, <b>ആധികാരികത ഉറപ്പ് വരുത്തല്‍</b> "
+#~ "ക്ലിക്ക് ചെയ്യുക.\n"
+#~ "നിങ്ങളുടെ ആധികാരികത ഉറപ്പു വരുത്തിയ ശേഷം, പുതിയ അടയാളവാക്ക് നല്‍കി, അത് വീണ്ടും ടൈപ്പ് ചെയ്ത് ഉറപ്പ് വരുത്തി <b>അടയാളവാക്ക് മാറ്റുക</"
+#~ "b> ക്ലിക്ക് ചെയ്യുക."
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "സമീപിയ്ക്കാവുന്ന _കയറല്‍"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "സഹായകമായ സാങ്കേതികവിദ്യകള്‍"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "സഹായകമായ സാങ്കേതികവിദ്യയുടെ മുന്‍ഗണനകള്‍"
+
+#~ msgid "Changes to enable assistive technologies will not take effect until your next log in."
+#~ msgstr "അടുത്ത ലോഗിനില്‍ മാത്രമേ ഈ ക്രമീകരണത്തില്‍ വരുത്തിയ മാറ്റങ്ങള്‍ പ്രവര്‍ത്തനസജ്ജമാകുകയുള്ളൂ."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "അടച്ചു _പുറത്തിറങ്ങുക"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "മുന്‍ഗണനാ പ്രയോഗ ജാലകത്തിലേക്ക് പോവുക."
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "സമീപിയ്ക്കാവുന്ന കയറല്‍ ജാലകത്തിലേക്ക് മാറുക"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "കീബോര്‍ഡ് സാമീപ്യതാജാലകത്തിലേക്ക് പോവുക"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "കീബോര്‍ഡ് ആക്സസിബിളിറ്റി ജാലകത്തിലേക്ക് പോവുക"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "സഹായകമായ സാങ്കേതികവിദ്യകള്‍ _സജ്ജമാക്കുക"
+
+#~ msgid "_Keyboard Accessibility"
+#~ msgstr "_കീബോര്‍ഡിന്റെ സാമീപ്യത"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "മൗസ്  _സാമീപ്യത"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "_മുന്‍ഗണനയുള്ള പ്രയോഗങ്ങള്‍"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "ലോഗിന്‍ ചെയ്യമ്പോള്‍ ഏതു് ആക്സസിബിളിറ്റി വിശേഷതയാണു് തെരഞ്ഞെടുക്കേണ്ടതു്"
+
+#~ msgid "Font may be too large"
+#~ msgstr "അക്ഷരസഞ്ചയം വളരെ വലുതായിരിയ്ക്കാം"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is "
+#~ "recommended that you select a size smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to effectively use the computer. It is "
+#~ "recommended that you select a size smaller than %d."
+#~ msgstr[0] ""
+#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റ് വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. %d "
+#~ "നെക്കാള്‍ ചെറിയത് ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
+#~ msgstr[1] ""
+#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റുകള്‍ വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. %d "
+#~ "നെക്കാളും ചെറിയത് ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is "
+#~ "recommended that you select a smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to effectively use the computer. It is "
+#~ "recommended that you select a smaller sized font."
+#~ msgstr[0] ""
+#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റ് വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. ചെറിയ "
+#~ "അക്ഷരസഞ്ചയം ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
+#~ msgstr[1] ""
+#~ "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം %d പോയിന്റുകള്‍ വലിപ്പമുള്ളതാണ്. ഇതുപയോഗിച്ച് കമ്പ്യൂട്ടര്‍ കാര്യക്ഷമമായി ഉപയോഗിക്കാന്‍ വിഷമമായിരിക്കും. ചെറിയ "
+#~ "അക്ഷരസഞ്ചയം ഉപയോഗിക്കാന്‍ ശുപാര്‍ശ ചെയ്യുന്നു."
+
+#~ msgid "Use previous font"
+#~ msgstr "മുമ്പുളള അക്ഷരസഞ്ചയം ഉപയോഗിക്കുക"
+
+#~ msgid "Use selected font"
+#~ msgstr "തെരഞ്ഞെടുത്ത അക്ഷരസഞ്ചയം ഉപയോഗിക്കുക"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "ഇന്‍സ്റ്റോള്‍ ചെയ്യുന്നതിന് രംഗവിതാന ഫയല്‍ തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr "കാണിക്കേണ്ട പേജിന്റെ പേര് നിശ്ചയിക്കുക(രംഗവിതാനം|പശ്ചാത്തലം|അക്ഷരസഞ്ചയങ്ങള്‍|വിനിമയതലം)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[പശ്ചാത്തലചിത്രം...]"
+
+#~ msgid "This theme will not look as intended because the required GTK+ theme engine '%s' is not installed."
+#~ msgstr "ആവശ്യമുല്ള GTK+ ഥീം എഞ്ചിന്‍ '%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
+
+#~ msgid "Apply Background"
+#~ msgstr "പശ്ചാത്തലം പ്രയോഗത്തില്‍വരുത്തുക"
+
+#~ msgid "Apply Font"
+#~ msgstr "അക്ഷരസഞ്ചയം പ്രയോഗത്തില്‍വരുത്തുക"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "ഈ രംഗവിതാനം  ഒരു പശ്ചാത്തലവും അക്ഷരരൂപവും നിര്‍‌ദ്ദേശിയ്ക്കുന്നു. അവസാനം ഉപയോഗിക്കപ്പെട്ട അക്ഷരരൂപത്തിനെ കുറിച്ചുള്ള അഭിപ്രായം തിരിച്ച് "
+#~ "പഴയതു പോലെ ആക്കാവുന്നതാണ് "
+
+#~ msgid "The current theme suggests a background. Also, the last applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "ഈ രംഗവിതാനം  ഒരു പശ്ചാത്തലവും അക്ഷരരൂപവും നിര്‍‌ദ്ദേശിയ്ക്കുന്നുഅവസാനം ഉപയോഗിക്കപ്പെട്ട അക്ഷരരൂപത്തിനെ കുറിച്ചുള്ള അഭിപ്രായം തിരിച്ച് "
+#~ "പഴയതു പോലെ ആക്കാവുന്നതാണ് "
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "ഈ രംഗവിതാനം  ഒരു പശ്ചാത്തലവും അക്ഷരരൂപവും നിര്‍‌ദ്ദേശിയ്ക്കുന്നു:"
+
+#~ msgid "The current theme suggests a font. Also, the last applied font suggestion can be reverted."
+#~ msgstr "നിലവിലുള്ള പ്രമേയത്തിനു് ഒരു അക്ഷരസഞ്ചയം ആവശ്യമുണ്ടു്. കൂടാതെ, അക്ഷരസഞ്ചയത്തിനു് ഒടുവില്‍ നല്‍കിയ മാറ്റം മാറ്റുകയും ചെയ്യാം."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "ഈ രംഗവിതാനം ഒരു പശ്ചാത്തലം നിര്‍‌ദ്ദേശിയ്ക്കുന്നു:"
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "അക്ഷരസഞ്ചയത്തിനു് ഒടുവില്‍ നല്‍കിയ മാറ്റം മാറ്റുകയും ചെയ്യാം."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "ഈ രംഗവിതാനം ഒരു അക്ഷരസഞ്ചയം നിര്‍‌ദ്ദേശിയ്ക്കുന്നു:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "ഏറ്റവും ഉചിതമായ _രൂപങ്ങള്‍"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "ഏറ്റവും നല്ല _തെളിച്ചം"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "_ഇഷ്ടപ്പെട്ട രീതിയിലാക്കുക..."
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "സൂചികയുടെ രംഗവിതാനം മാറ്റിയാല്‍ അടുത്ത തവണ അകത്ത് കയറുമ്പോഴേ അത് പ്രാവര്‍ത്തികമാവൂ."
+
+#~ msgid "Controls"
+#~ msgstr "നിയന്ത്രണങ്ങള്‍"
+
+#~ msgid "Customize Theme"
+#~ msgstr "രംഗവിതാനം ഇഷ്ടപ്പെട്ട രീതിയിലാക്കുക"
+
+#~ msgid "D_etails..."
+#~ msgstr "_വിശദാംശങ്ങള്‍..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "_പണിയിടത്തിലെ അക്ഷരസഞ്ചയം:"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "അക്ഷരസഞ്ചയം ചിട്ടപ്പെടുത്തുന്നതിന്റെ വിശദവിവരങ്ങള്‍"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "കൂടുതല്‍ പശ്ചാത്തലങ്ങള്‍ ഓണ്‍ലൈനായി ലഭ്യമാക്കുക"
+
+#~ msgid "Get more themes online"
+#~ msgstr "കൂടുതല്‍ രംഗവിതാനങ്ങള്‍ ഓണ്‍ലൈന്‍ ലഭ്യമാക്കുക"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "_ഗ്രേസ്കെയില്‍"
+
+#~ msgid "Icons"
+#~ msgstr "ചിഹ്നങ്ങള്‍"
+
+#~ msgid "Icons only"
+#~ msgstr "ചിഹ്നങ്ങള്‍ മാത്രം"
+
+#~ msgid "N_one"
+#~ msgstr "_ഒന്നുമില്ല"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "നിറം വ്യക്തമാക്കുന്നതിനായി ഒരു ജാലകം തുറക്കുക"
+
+#~ msgid "R_esolution:"
+#~ msgstr "_ദൃശ്യസൂക്ഷ്മത:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "രംഗവിതാനം മറ്റൊരു പേരില്‍ സൂക്ഷിയ്ക്കുക..."
+
+#~ msgid "Save _As..."
+#~ msgstr "രംഗവിതാനം മറ്റൊരു പേരില്‍ സൂക്ഷിയ്ക്കുക..."
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "സബ് _പിക്സല്‍ (എല്‍സിഡികള്‍)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "സബ് _പിക്സല്‍ മിനുക്കല്‍ (എല്‍സിഡികള്‍)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "സബ്പിക്സലിന്റെ ക്രമം"
+
+#~ msgid "Text below items"
+#~ msgstr "വസ്തുക്കളുടെ താഴെയുള്ള പദാവലി"
+
+#~ msgid "Text beside items"
+#~ msgstr "വസ്തുക്കളുടെ അടുത്തുള്ള പദാവലി"
+
+#~ msgid "Text only"
+#~ msgstr "പദാവലി മാത്രം"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "നിലവിലുള്ള നിയന്ത്രണ രംഗവിതാനം വര്‍ണ്ണങ്ങളെ പിന്തുണയ്ക്കുന്നില്ല"
+
+#~ msgid "Theme"
+#~ msgstr "രംഗവിതാനം"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "വി_വരണം:"
+
+#~ msgid "_Document font:"
+#~ msgstr "രചനയിലുള്ള അക്ഷരസഞ്ചയം:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_സ്ഥിരമായ വീതിയുളള അക്ഷരസഞ്ചയം:"
+
+#~ msgid "_Monochrome"
+#~ msgstr "ഏ_കവ‌ര്‍ണ്ണം"
+
+#~ msgid "_None"
+#~ msgstr "ഒ_ന്നുമില്ല"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "സഹജമായ രീതിയിലേക്ക് _തിരികെ വയ്ക്കുക"
+
+#~ msgid "_Selected items:"
+#~ msgstr "_തെരഞ്ഞെടുത്തവ:"
+
+#~ msgid "_Size:"
+#~ msgstr "_വലിപ്പം:"
+
+#~ msgid "_Slight"
+#~ msgstr "_നേര്‍ത്ത"
+
+#~ msgid "_Style:"
+#~ msgstr "_രീതി:"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "_സഹായസൂചികകള്‍:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_ജാലക തലക്കെട്ടിന്റെ അക്ഷരസഞ്ചയം:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_ജാലകങ്ങള്‍:"
+
+#~ msgid "dots per inch"
+#~ msgstr "ഒരു ഇഞ്ചിലുള്ള കുത്തുകള്‍ "
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "പണിയിടത്തിനെ ഇഷ്ടപ്പെട്ട രീതിയിലാക്കുക"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "പണിയിടത്തിന്റെ വിവിധ ഭാഗങ്ങള്‍ക്കുള്ള രംഗവിതാന പാക്കേജുകള്‍ തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Theme Installer"
+#~ msgstr "രംഗവിതാനത്തിന്റെ ഇന്‍സ്റ്റാളര്‍"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "ഗ്നോമിലെ രംഗവിതാനത്തിനുള്ള പാക്കേജ്"
+
+#~ msgid "Slide Show"
+#~ msgstr "സ്ലൈഡ് ഷോ"
+
+#~ msgid "Image"
+#~ msgstr "ചിത്രം"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "ഫോള്‍ഡര്‍: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "ഫോള്‍ഡര്‍: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "ഈ രംഗവിതാനം ഇന്സ്റ്റാള്‍ ചെയ്യാന്‍ പറ്റില്ല "
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s ഉപാധി ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ല."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "രംഗവിതാനം പുറത്തെടുക്കുമ്പോള്‍ എന്തോ പ്രശ്നമുണ്ടായി."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "തെരഞ്ഞെടുത്ത ഫയല്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യതപ്പോള്‍ എന്തോ കുഴപ്പമുണ്ടായി"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" ഒരു ശരിയായ പ്രമേയം അല്ല."
+
+#~ msgid "\"%s\" does not appear to be a valid theme. It may be a theme engine which you need to compile."
+#~ msgstr "\"%s\" ഒരു ശരിയായ പ്രമേയം അല്ല. ഇതു് ഒരു പക്ഷേ, കംപൈല്‍ ചെയ്യുവാനുള്ള ഒരു ഥീം എഞ്ചിന്‍ ആവാം."
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "\"%s\" എന്ന രംഗവിതാനം ഇന്‍സ്റ്റോള്‍ ചെയ്യാന്‍ സാധിച്ചില്ല"
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "രംഗവിതാനം  \"%s\"  ഇന്‍സ്റ്റോള്‍ ചെയ്തു."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "നിങ്ങള്‍ക്ക് ഈ രംഗവിതാനം പ്രാവര്‍ത്തികമാക്കണോ അതോ ഇപ്പോഴുള്ളത് നിലനിര്‍ത്തണോ?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "നിലവിലുളള രംഗവിതാനം നിലനിര്‍ത്തുക"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "പുതിയ രംഗവിതാനം പ്രായോഗത്തില്‍ വരുത്തുക"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "ഗ്നോമിലെ രംഗവിതാനമായ %s ശരിയായി ഇന്‍സ്റ്റോള്‍ ചെയ്തിരിക്കുന്നു"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "പുതിയ രംഗവിതാനങ്ങള്‍ വിജയകരമായി ഇന്‍സ്റ്റോള്‍ ചെയ്തിരിക്കുന്നു."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "ഇന്‍സ്റ്റോള്‍ ചെയ്യുന്നതിന് രംഗവിതാന ഫയലിന്റെ സ്ഥാനം വ്യക്തമാക്കിയിട്ടില്ല"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "രംഗവിതാനം ഇന്‍സ്റ്റോള്‍ ചെയ്യുന്നതിനായി വേണ്ടത്ര അനുവാദങ്ങള്‍ ഇല്ല:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "രംഗവിതാനം തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Theme Packages"
+#~ msgstr "രംഗവിതാനത്തിന്റെ പാക്കേജുകള്‍"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "രംഗവിതാനത്തിന് പേര്‌ ഉണ്ടായിരിയ്ക്കണം"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "രംഗവിതാനം നിലവിലുണ്ട്. നിങ്ങള്‍ക്ക് അവ മാറ്റണമോ?"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "നിങ്ങള്‍ക്ക് ഈ രംഗവിതാനം നീക്കം ചെയ്യണമോ?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "രംഗവിതാനത്തിന്റെ യന്ത്രത്തെ ഇന്‍സ്റ്റോള്‍ ചെയ്യാന്‍ കഴിഞ്ഞില്ല"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take effect. This could indicate a "
+#~ "problem with DBus, or a non-GNOME (e.g. KDE) settings manager may already be active and conflicting with "
+#~ "the GNOME settings manager."
+#~ msgstr ""
+#~ "'gnome-settings-daemon' ക്രമീകരണ മാനേജര്‍ തുടങ്ങാന്‍ കഴിഞ്ഞില്ല.\n"
+#~ "ഗ്നോം ക്രമീകരണ മാനേജര്‍ പ്രവര്‍ത്തിക്കാതെ ചില മുന്‍ഗണനകള്‍ പ്രാവര്‍ത്തികമാക്കാനാവില്ല. ഇത്  DBus അല്ലെങ്കില്‍ ഗ്നോമല്ലാത്ത (ഉദാഃ "
+#~ "കെഡിഇ)  ക്രമീകരണ മാനേജറോ ഇപ്പോള്‍ സജീവമാണെന്നോ ഗ്നോം ക്രമീകരണ മാനേജറുമായി ഇടഞ്ഞുനില്‍ക്കുകയാണെന്നോ കാണിക്കുന്നു."
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "'%s' ശേഖരത്തിന്റെ പ്രതിരൂപം ലോഡ് ചെയ്യുവാന്‍ സാധ്യമായില്ല\n"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "സഹായം കാണിയ്ക്കുന്നതില്‍ തെറ്റുണ്ടായി: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "ഫയല്‍ പകര്‍ത്തുന്നു: %2$u ലെ %1$u"
+
+#~ msgid "Parent Window"
+#~ msgstr "മാതൃജാലകം "
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "ജാലകത്തിന്റെ മാതൃജാലകം"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "ഇപ്പോള്‍ എടുത്ത് കൊണ്ടിരിയ്ക്കുന്ന യുആര്‍ഐ"
+
+#~ msgid "To URI"
+#~ msgstr "യുആര്‍ഐയിലേയ്ക്ക്"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "ഇപ്പോള്‍ വച്ചു കൊണ്ടിരിയ്ക്കുന്ന യുആര്‍ഐ"
+
+#~ msgid "Fraction completed"
+#~ msgstr "ഒരു ഭാഗം പൂര്‍ത്തിയായി"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "നിലവില്‍ പൂര്‍ത്തിയാക്കിയ ഭാഗം"
+
+#~ msgid "Current URI index"
+#~ msgstr "നിലവിലുളള യുആര്‍ഐ സൂചിക"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "നിലവിലുളള യുആര്‍ഐ സൂചിക - 1 മുതല്‍ ആരംഭിക്കുന്നു"
+
+#~ msgid "Total URIs"
+#~ msgstr "ആകെ യുആര്‍ഐകള്‍"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "ആകെ യുആര്‍ഐകളുടെ എണ്ണം"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "'%s' എന്ന ഫയല്‍ നേരത്തെ തന്നെ ഉണ്ട് . നിങ്ങള്‍ക്ക് അത് മാറ്റി ഇപ്പോള്‍ ഉള്ള ഫയല്‍ ആക്കണമോ ?"
+
+#~ msgid "_Skip"
+#~ msgstr "_വേണ്ടെന്നുവയ്ക്കുക"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "എല്ലാം _മാറ്റിയെഴുതുക"
+
+#~ msgid "Key"
+#~ msgstr "കീ"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf key to which this property editor is attached"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Issue this callback when the value associated with key gets changed"
+
+#~ msgid "GConf change set containing data to be forwarded to the gconf client on apply"
+#~ msgstr "GConf change set containing data to be forwarded to the gconf client on apply"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Conversion to widget callback"
+
+#~ msgid "Callback to be issued when data are to be converted from GConf to the widget"
+#~ msgstr "Callback to be issued when data are to be converted from GConf to the widget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Conversion from widget callback"
+
+#~ msgid "Callback to be issued when data are to be converted to GConf from the widget"
+#~ msgstr "Callback to be issued when data are to be converted to GConf from the widget"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Object that controls the property (normally a widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Property editor object data"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Custom data required by the specific property editor"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Property editor data freeing callback"
+
+#~ msgid "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "Callback to be issued when property editor object data is to be freed"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different background picture."
+#~ msgstr ""
+#~ "ഫയല്‍ '%s' ലഭ്യമല്ല.\n"
+#~ "\n"
+#~ "ദയവായി ഇതുണ്ടെന്ന് ഉറപ്പു വരുത്തിയ ശേഷം വീണ്ടും ശ്രമിയ്ക്കുക, അല്ലെങ്കില്‍ മറ്റൊരു ചിത്രം തെരഞ്ഞെടുക്കുക."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "ഫയല്‍ '%s' തുറക്കുവാന്‍ അറിയില്ല.\n"
+#~ "ഇപ്പോഴും പിന്തുണയില്ലാത്ത ഒരു ചിത്രമാകാം ഇത് \n"
+#~ "\n"
+#~ "ദയവായി മറ്റൊരു ചിത്രം തെരഞ്ഞടുക്കുക."
+
+#~ msgid "Please select an image."
+#~ msgstr "ദയവായി ഒരു ചിത്രം തെരഞ്ഞെടുക്കുക."
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "സഹജമായ സൂചിക - നിലവിലുളള"
+
+#~ msgid "White Pointer"
+#~ msgstr "വെള്ള സൂചിക"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "വെള്ള സൂചിക - നിലവിലുളള"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "വലിയ സൂചിക - നിലവിലുളള"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "വലിയ വെള്ള സൂചിക - നിലവിലുളള"
+
+#~ msgid "This theme will not look as intended because the required GTK+ theme '%s' is not installed."
+#~ msgstr "ആവശ്യമുല്ള GTK+ ഥീം'%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
+
+#~ msgid "This theme will not look as intended because the required window manager theme '%s' is not installed."
+#~ msgstr "ആവശ്യമുല്ള വിന്‍ഡോ മാനേജര്‍ ഥീം'%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
+
+#~ msgid "This theme will not look as intended because the required icon theme '%s' is not installed."
+#~ msgstr "ആവശ്യമുല്ള ഐക്കണ്‍ ഥീം'%s' ഇന്‍സ്റ്റോള്‍ ചെയ്തിട്ടില്ലാത്തതിനാല്‍, ഈ പ്രമേയം നിങ്ങള്‍ ആഗ്രഹിച്ച രീതിയില്‍ ലഭ്യമാകില്ല."
+
+#~ msgid "Preferred Applications"
+#~ msgstr "മുന്‍ഗണനാ പ്രയോഗങ്ങള്‍"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "ആവശ്യമുള്ള വിഷ്വല്‍ അസിസ്റ്റീവ് ടെക്നോളജി ആരംഭിക്കുക"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "_ദൃശ്യമായ സഹായം"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "പ്രധാനമായ വിനിമയതലം ലോഡ് ചെയ്യുവാന്‍ സാധ്യമായില്ല"
+
+#~ msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr "കാണിക്കേണ്ട പേജിന്റെ പേര് നിശ്ചയിക്കുക(internet|multimedia|system|a11y)"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "%s ആവൃത്തികളും ശരിയായ ലിങ്ക് ഉപയോഗിച്ച് മാറ്റപ്പെടുന്നു"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "ആ_ജ്ഞ:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "_നടപ്പിലാക്കുക എന്ന കൊടി:"
+
+#~ msgid "Image Viewer"
+#~ msgstr "ചിത്രദര്‍ശിനി"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "ഇന്‍സ്റ്റന്റ് മെസഞ്ചര്‍"
+
+#~ msgid "Mail Reader"
+#~ msgstr "മെയില്‍ റീഡര്‍"
+
+#~ msgid "Mobility"
+#~ msgstr "ചലനാത്മകത"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "പുതിയ _കിളിവാതിലില്‍ കണ്ണി തുറക്കുക"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "പുതിയ _ജാലകത്തില്‍ കണ്ണി തുറക്കുക"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "_സഹജമായ വെബ് ബ്രൌസറില്‍ കണ്ണി തുറക്കുക"
+
+#~ msgid "Run at st_art"
+#~ msgstr "_തുടക്കത്തില്‍ പ്രാവര്‍ത്തിപ്പിയ്ക്കുക"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "_ടെര്‍മിനലില്‍ പ്രവര്‍ത്തിപ്പിയ്ക്കുക"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "ടെര്‍മിനല്‍ എമുലേറ്റര്‍"
+
+#~ msgid "Text Editor"
+#~ msgstr "എഴുത്തിടം"
+
+#~ msgid "_Run at start"
+#~ msgstr "_തുടക്കത്തില്‍ തന്നെ പ്രവര്‍ത്തിപ്പിയ്ക്കുക"
+
+#~ msgid "Balsa"
+#~ msgstr "ബല്‍സ"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "ബാന്‍ഷീ പാട്ടുപെട്ടി"
+
+#~ msgid "Claws Mail"
+#~ msgstr "ക്ലാവ്സ് മെയില്‍"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "ഡെബിയന്‍ സെന്‍സിബിള്‍ ബ്രൌസര്‍"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "ഡെബിയന്‍ ടെര്‍മിനര്‍ എമ്യുലേറ്റര്‍"
+
+#~ msgid "ETerm"
+#~ msgstr "ഇടേം"
+
+#~ msgid "Encompass"
+#~ msgstr "എന്‍കമ്പോസ്"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "എവല്യൂഷന്‍ മെയില്‍ റീഡര്‍"
+
+#~ msgid "Firefox"
+#~ msgstr "ഫയര്‍ഫോക്സ്"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "സ്ക്രീന്‍ വായനക്കാരനില്ലാത്ത ഗ്നോം ഭൂതക്കണ്ണാടി"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "ഗ്നോം ടെര്‍മിനല്‍"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "ഗ്നോപ്പര്‍നിക്കസ്"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "ഭൂതക്കണ്ണാടിയോടു കൂടിയ  ഗ്നോപ്പര്‍നിക്കസ് "
+
+#~ msgid "Iceape"
+#~ msgstr "ഐസെയിപ്"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "ഐസെയിപ് മെയില്‍"
+
+#~ msgid "Icedove"
+#~ msgstr "ഐസ്ഡവ്"
+
+#~ msgid "Iceweasel"
+#~ msgstr "ഐസ്‌വെസല്‍"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "സ്ക്രീന്‍ വായനക്കാരനില്ലാത്ത കെഡിഇ ഭൂതക്കണ്ണാടി"
+
+#~ msgid "Konqueror"
+#~ msgstr "കോണ്‍ക്വറര്‍"
+
+#~ msgid "Konsole"
+#~ msgstr "കണ്‍സോള്‍ (Konsole)"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "ഭൂതക്കണ്ണാടിയുള്ള ലിനക്സ് സ്ക്രീന്‍ വായനക്കാരന്‍"
+
+#~ msgid "Listen"
+#~ msgstr "ലിസന്‍"
+
+#~ msgid "Midori"
+#~ msgstr "മിഡോരി"
+
+#~ msgid "Mozilla"
+#~ msgstr "മോസില്ല"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "മോസില്ല 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "മോസില്ല മെയില്‍"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "മോസില്ലാ തണ്ടര്‍ബേര്‍ഡ് "
+
+#~ msgid "NXterm"
+#~ msgstr "എന്‍എക്സ്ടേം"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "നെറ്റ്സ്കെയിപ് കമ്മ്യൂണിക്കേറ്റര്‍"
+
+#~ msgid "Orca"
+#~ msgstr "ഓര്‍ക്ക"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "ഭൂതക്കണ്ണാടിയോടു കൂടിയ ഓര്‍ക്ക"
+
+#~ msgid "RXVT"
+#~ msgstr "ആര്‍എക്സ്‌വീടി"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "റിഥംബോക്സ് പാട്ടുപെട്ടി"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "സീമങ്കി"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "സീമങ്കി മെയില്‍"
+
+#~ msgid "Sylpheed"
+#~ msgstr "സില്‍ഫീഡ്"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "സില്‍ഫീഡ്-ക്ലോവ്സ്"
+
+#~ msgid "Thunderbird"
+#~ msgstr "തണ്ടര്‍ബേര്‍ഡ് "
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "ടോട്ടം ചലച്ചിത്രദര്‍ശിനി"
+
+#~ msgid "Include _panel"
+#~ msgstr "_പാനല്‍ ഉള്‍പ്പെടുത്തുക"
+
+#~ msgid "Monitor Preferences"
+#~ msgstr "മോണിറ്റര്‍ മുന്‍‌ഗണനകള്‍"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "എല്ലാ മോണിറ്ററുകളിലും _ഒരേ ചിത്രം"
+
+#~ msgid "Upside-down"
+#~ msgstr "മുകളില്‍ നിന്നും താഴേക്കു്"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "മോണിറ്ററുകള്‍ _ലഭ്യമാക്കുക"
+
+#~ msgid "Monitors"
+#~ msgstr "മോണിറ്ററുകള്‍"
+
+#~ msgid "Upside Down"
+#~ msgstr "മുകളില്‍ നിന്നും താഴേക്കു്"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "മോണിറ്റര്‍: %s"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "ഡിസ്പ്ലെ ക്രമീകരണം പ്രാഭല്യത്തിലാക്കുമ്പോള്‍ സെഷന്‍ ബസ് ലഭ്യമായില്ല"
+
+#~ msgid "Desktop"
+#~ msgstr "പണിയിടം"
+
+#~ msgid "Accelerator key"
+#~ msgstr "വേഗവ‌ര്‍ദ്ധിനി കീ"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "വേഗവ‌ര്‍ദ്ധിനി രൂപാന്തരകങ്ങള്‍"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "വേഗവ‌ര്‍ദ്ധിനി കീ കോഡ്"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "വേഗവ‌ര്‍ദ്ധിനി തരം"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "വേഗവ‌ര്‍ദ്ധിനി സജ്ജീകരണവിവരശേഖരത്തില്‍ ക്രമീകരിക്കുന്നതില്‍ പിശക്: %s"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "ഇഷ്ടത്തിനനുസരിച്ചു് ഉണ്ടാക്കിയ അനേകം എളുപ്പവഴികള്‍"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "ആജ്ഞകള്‍ക്ക്  എളുപ്പകീകള്‍ നല്‍കുക"
+
+#~ msgid "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "Just apply settings and quit (compatibility only; now handled by daemon)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "ടൈപ്പിങ്ങ് വിശ്രമവേള ക്രമീകരണം കാണിച്ച് കൊണ്ട് പേജ് തുടങ്ങുക."
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "സാമീപ്യതാ ക്രമീകരണം കാണിച്ച് കൊണ്ട് പേജ് തുടങ്ങുക."
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "ഗ്നോം കീബോര്‍ഡ് മുന്‍‌ഗണനകള്‍"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "കീ _നിരസിച്ചുവെങ്കില്‍ ശബ്ദമുണ്ടാക്കുക"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "കീബോര്‍ഡ് ആക്സസിബിളിറ്റി ഓഡിയോ ഫീഡ്ബാക്ക്"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "ശബ്ദമുന്നറിയിപ്പു് നല്‍കുമ്പോള്‍ _വിഷ്വല്‍ അഭിപ്രായവും കാണിക്കുക"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "ശബ്ദമനുസരിച്ചുള്ള ദൃശ്യം"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "വിശ്രമവേളകളുടെ സമയം മാറ്റാന്‍ അനുവദിക്കുക (_o)"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "ഓഡിയോ _അഭിപ്രായം..."
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "വിശ്രമവേളകള്‍ നീട്ടിവക്കാന്‍ സാധിക്കുമോ എന്ന് പരിശോധിക്കുക"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "ടൈപ്പിങ്ങ് അനുവദനീയമല്ലാത്ത വിശ്രമവേളയുടെ സമയം"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "ഒരു വിശ്രമവേളയ്ക്ക് നിര്‍ബന്ധിക്കുന്നതിന് മുമ്പുള്ള ജോലിയുടെ സമയം"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "കീബോര്‍ഡിന്റെ _മാതൃക:"
+
+#~ msgid "Lock screen after a certain duration to help prevent repetitive keyboard use injuries"
+#~ msgstr "നിരന്തരമായ കീബോര്‍ഡ് ഉപയോഗം മൂലമുണ്ടാവുന്ന പരിക്കൊഴിവാക്കാന്‍ കുറച്ചു സമയത്തിനു ശേഷം സ്ക്രീന്‍ പൂട്ടുക "
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "വിശ്രമവേളയുടെ സമയ_പരിധി:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "<b>ടൈപ്പിങ്ങ് വിശ്രമവേള നിര്‍ബന്ധമാക്കാന്‍ സ്ക്രീന്‍ _പൂട്ടുക,</b>"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "ഒരുപാടു നേരത്തേയ്ക്ക് അമര്‍ന്നിരുന്നാല്‍ _മാത്രം കീ സ്വീകരിക്കുക:"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "ഒരേപോലെ കീപ്രസ്സുകള്‍ _സിമുലേറ്റ് ചെയ്യുക"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_ജോലി സമയത്തിന്റെ സമയപരിധി:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variants:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "ഒരു കീ ബോര്‍ഡ് മോഡല്‍ തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_വില്പനക്കാര്‍"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "കീബോര്‍ഡ് മുന്‍ണനകള്‍ സജ്ജീകരിയ്ക്കുക"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "ഇടത്തേക്കു് നീക്കുക"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "വലത്തേക്കു് നീക്കുക"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "മുകളിലേക്കു് നീക്കുക"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "താഴേക്ക് നീക്കുക"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "നിര്‍ജ്ജീവമാക്കിയ"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "കാണിക്കേണ്ട പേജിന്റെ പേര് നിശ്ചയിക്കുക(general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "ഗ്നോമിലെ മൗസിന്റെ മുന്‍‌ഗണനകള്‍"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "ക്ളിക്കിന്റെ തരം _നേരത്തെ തന്നെ തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "_മൌസ് ഉപയോഗിച്ചു് ഏതു് തരത്തിലുള്ള ക്ലിക്കു് ആണെന്നു് തെരഞ്ഞെടുക്കുക."
+
+#~ msgid "D_rag click:"
+#~ msgstr "ക്ലിക്ക് _വലിച്ചിടുക:"
+
+#~ msgid "Show click type _window"
+#~ msgstr "ക്ലിക്ക് തരത്തിലുള്ള _ജാലകം കാണിക്കുക"
+
+#~ msgid "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr "ഏതു് തരത്തിലുള്ള ക്ലിക്ക് തെരഞ്ഞെടുക്കുന്നതിനായി നിങ്ങള്‍ക്കു് ഡ്വല്‍ ക്ലിക്ക് പാനല്‍ ഉപയോഗിക്കാം."
+
+#~ msgid "_Single click:"
+#~ msgstr "ഒറ്റ ക്ളിക്ക്"
+
+#~ msgid "Location already exists"
+#~ msgstr "സ്ഥലം നിലവിലുണ്ടു്."
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "നിങ്ങളുടെ ശൃംഖലയിലെ പ്രോക്സി മുന്‍ഗണനകള്‍ സജ്ജീകരിയ്ക്കുക"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>ശൃംഖലയിലെ പ്രോക്സിയുടെ _തന്നത്താനുള്ള സജ്ജീകരണം</b> (_M)"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "എച്ച്ടിടിപി പ്രോക്സിയുടെ വിശദാംശങ്ങള്‍"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "ഹോസ്റ്റ് പട്ടിക അവഗണിക്കുക"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "ശൃംഖലയിലെ പ്രോക്സിയുടെ മുന്‍ഗണനകള്‍"
+
+#~ msgid "U_sername:"
+#~ msgstr "_ഉപയോക്താവിന്റെ പേര്:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "സുരക്ഷിതമായ എച്ച്ടിടിപി പ്രോക്സി:"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "നിങ്ങളുടെ ജാലക മാനേജര്‍ക്കു വേണ്ടി മുന്‍ഗണനാപ്രയോഗം തുടങ്ങാന്‍ പറ്റിയില്ല"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "S_uper (or \"Windows logo\")"
+
+#~ msgid "Movement Key"
+#~ msgstr "ചലനങ്ങള്‍ക്കുളള കീ"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "ജാലകം നീക്കുവാന്‍ ഈ കീ അമര്‍ത്തിപ്പിടിച്ച് ജാലകം വലിക്കുക."
+
+#~ msgid "Window Preferences"
+#~ msgstr "ജാലക മുന്‍ഗണനകള്‍"
+
+#~ msgid "Window Selection"
+#~ msgstr "ജാലകം തെരഞ്ഞെടുക്കല്‍"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "ഈ പ്രവര്‍ത്തി ചെയ്യുന്നതിനായി ടൈറ്റില്‍ ബാറില്‍ _രണ്ടു തവണ ക്ലിക്ക് ചെയ്യുക:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "ഉയര്‍ത്തുന്നതിന് മുമ്പുള്ള _ഇടവേള:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "തെരഞ്ഞെടുത്ത ജാലകങ്ങള്‍ ഒരിടവേളക്ക് ശേഷം _ഉയര്‍ത്തുക"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "മൌസ് ജാലകത്തിന്റെ മുകളിലൂടെ നീങ്ങുമ്പോള്‍ അത് _തെരഞ്ഞെടുക്കുക"
+
+#~ msgid "Set your window properties"
+#~ msgstr "നിങ്ങളുടെ ജാലകത്തിന്റെ വിശേഷതകള്‍ സജ്ജീകരിയ്ക്കുക"
+
+#~ msgid "Windows"
+#~ msgstr "ജാലകങ്ങള്"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "ജാലകത്തിന്റെ മാനേജര്‍ \"%s\" ക്രമീകരണത്തിനുളള പ്രയോഗം രജിസ്ടര്‍ ചെയ്തിട്ടില്ല\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "നേരെ വലുതാക്കുക"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "കുറുകേ വലുതാക്കുക"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "ആരംഭിക്കുമ്പോള്‍ അദൃശ്യമാകുക (ഷെല്‍ പ്രീലോഡ് ചെയ്യുന്നു)"
+
+#~ msgid "Groups"
+#~ msgstr "കൂട്ടങ്ങള്‍:"
+
+#~ msgid "Common Tasks"
+#~ msgstr "സാധാരണയായുള്ള പ്രവര്‍ത്തികള്‍ "
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "ഒരു കൃത്യം ആരംഭിച്ചാല്‍ നിയന്ത്രണകേന്ദ്രം അടക്കുക"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "Exit shell on add or remove action performed"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "സഹായകൃത്യം നടപ്പിലാക്കുമ്പോള്‍ ഷെല്‍ അടയ്ക്കുക"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "ആരംഭകൃത്യം നടപ്പിലാക്കുമ്പോള്‍ ഷെല്‍ അടയ്ക്കുക"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "നീക്കംചെയ്യലോ പുതുക്കലോ നടത്തുമ്പോള്‍ ഷെല്‍ അടയ്ക്കുക"
+
+#~ msgid "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "സഹായകൃത്യം നടക്കുമ്പോള്‍ ഷെല്‍ അടയ്ക്കേണ്ടതുണ്ടോ എന്ന് കാണിക്കുന്നു."
+
+#~ msgid "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "ആരംഭകൃത്യം നടക്കുമ്പോള്‍ ഷെല്‍ അടയ്ക്കേണ്ടതുണ്ടോ എന്ന് കാണിക്കുന്നു."
+
+#~ msgid "Indicates whether to close the shell when an add or remove action is performed."
+#~ msgstr "ചേര്‍ക്കലോ നീക്കം ചെയ്യലോ നടക്കുമ്പോള്‍ ഷെല്‍ അടയ്ക്കേണ്ടതുണ്ടോ എന്ന് കാണിക്കുന്നു."
+
+#~ msgid "Indicates whether to close the shell when an upgrade or uninstall action is performed."
+#~ msgstr "പുതുക്കുമ്പോളോ നീക്കം ചെയ്യുമ്പോളോ ഷെല്‍ അടയ്ക്കേണ്ടതുണ്ടോ എന്ന് കാണിക്കുന്നു."
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "കൃത്യനാമങ്ങളും ബന്ധപ്പെട്ട .desktop ഫയലുകളും"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" separator then the filename of an "
+#~ "associated .desktop file to launch for that task."
+#~ msgstr ""
+#~ "നിയന്ത്രണകേന്ദ്രത്തില്‍ കാണിക്കേണ്ട പ്രവര്‍ത്തിയുടെ പേരു് , അതിനു ശേഷം വേര്‍തിരിക്കുന്ന ചിഹ്നമായ  \";\"  പിന്നെ ആ പ്രവര്‍ത്തിക്കു വേണ്ടി "
+#~ "തുടങ്ങേണ്ടുന്ന  .desktop ഫയലിന്റെ പേരു്."
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-applications.desktop,Add "
+#~ "Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[രംഗവിതാനം മാറ്റുക;gnome-appearance-properties.desktop,മുന്‍ഗണനാ പ്രയോഗങ്ങള്‍ സജ്ജമാക്കുക;gnome-default-applications."
+#~ "desktop,പ്രിന്റര്‍ ചേര്‍ക്കുക;system-config-printer.desktop]"
+
+#~ msgid "if true, the control-center will close when a \"Common Task\" is activated."
+#~ msgstr "ശരി എന്നാണെങ്കില്‍ ഒരു \"സാധാരണ പ്രവര്‍ത്തി\" സജീവമായാല്‍ നിയന്ത്രണകേന്ദ്രം അടയ്ക്കും."
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "ഗ്നോമിലെ ക്രമീകരണത്തിനുള്ള പണിയായുധം"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "ഇടവേള _പിന്നത്തേക്കു നീട്ടിവെയ്ക്കുക"
+
+#~ msgid "_Take a Break"
+#~ msgstr "_വിശ്രമവേള"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "അടുത്ത വിശ്രമവേളയ്ക്ക് മുമ്പ് %d മിനിട്ട്"
+#~ msgstr[1] "അടുത്ത വിശ്രമവേളയ്ക്ക് മുമ്പ് %d മിനിട്ടുകള്‍"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "അടുത്ത വിശ്രമവേളയ്ക്ക് ഒരു മിനിട്ട് പോലുമില്ല"
+
+#~ msgid "Unable to bring up the typing break properties dialog with the following error: %s"
+#~ msgstr "ടൈപ്പിങ്ങ് വിശ്രമവേളാ ക്രമീകരണ ജാലകം തുറക്കുമ്പോള്‍ ഈ പിശക് പറ്റി: %s  "
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "എഴുതിയത് റിച്ചാര്‍ഡ് ഹട്ട് <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "കണ്ണിന് കുളിര്‍മ്മ ചേര്‍ത്തത് ആന്‍ഡേര്‍സ് കാള്‍സണ്‍ "
+
+#~ msgid "A computer break reminder."
+#~ msgstr "കമ്പ്യൂട്ടറിന്റെ വിശ്രമവേള ഒന്നോര്‍മ്മപ്പെടുത്തുന്നു."
+
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "സന്തോഷ് തോട്ടിങ്ങല്‍ <santhosh00@gmail.com>\n"
+#~ "അനി പീറ്റര്‍ <peter.ani@gmail.com>\n"
+#~ "പ്രവീണ്‍ എ <pravi.a@gmail.com>\n"
+#~ "അനിവര്‍ അരവിന്ദ് <anivar@movingrepublic.org>."
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "അറിയിപ്പ് മേഖല ഉണ്ടോ എന്നു നോക്കേണ്ട"
+
+#~ msgid "Typing Monitor"
+#~ msgstr "ടൈപ്പിങ് മോണിറ്റര്‍"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You don't seem to have a "
+#~ "notification area on your panel. You can add it by right-clicking on your panel and choosing 'Add to "
+#~ "panel', selecting 'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "ടൈപ്പിങ്ങ് മേല്‍നോട്ടക്കാരന്‍ വിവരങ്ങള്‍ കാണിക്കാന്‍ അറിയിപ്പ് മേഖല ഉപയോഗിക്കുന്നു. നിങ്ങളുടെ പാനലില്‍ അറിയിപ്പ് മേഖല ഇല്ല. പാനലില്‍ "
+#~ "റൈറ്റ് ക്ലിക്ക് ചെയ്ത് അറിയിപ്പ് മേഖല പാനലിലേക്ക് ചേര്‍ക്കുക"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "ഇതു് true ആണെങ്കില്‍, OpenType അക്ഷരസഞ്ചയങ്ങള്‍ക്കു് നഖചിത്ര ലഭ്യമാകുന്നു."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "ഇതു് true ആണെങ്കില്‍, PCF അക്ഷരസഞ്ചയങ്ങള്‍ക്കു് നഖചിത്ര ലഭ്യമാകുന്നു."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "ഇതു് true ആണെങ്കില്‍, TrueType അക്ഷരസഞ്ചയങ്ങള്‍ക്കു് നഖചിത്ര ലഭ്യമാകുന്നു."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "ഇതു് true ആണെങ്കില്‍, Type1 അക്ഷരസഞ്ചയങ്ങള്‍ക്കു് നഖചിത്ര ലഭ്യമാകുന്നു."
+
+#~ msgid "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr "OpenType അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "PCF അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
+
+#~ msgid "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr "TrueType അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
+
+#~ msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "Type1 അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര ഉണ്ടാക്കുന്നതിനുള്ള കമാന്‍ഡിനു് ഈ കീ സജ്ജമാക്കുക."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "OpenType അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര കമാന്‍ഡ്"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "PCF അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര കമാന്‍ഡ്"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "TrueType അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര കമാന്‍ഡ്"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Type1 അക്ഷരസഞ്ചയങ്ങള്‍ക്കുള്ള നഖചിത്ര കമാന്‍ഡ്"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "OpenType അക്ഷരസഞ്ചയങ്ങള്‍ നഖചിത്രമാക്കണമോ എന്നു്"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCF അക്ഷരസഞ്ചയങ്ങള്‍ നഖചിത്രമാക്കണമോ എന്നു്"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "TrueType അക്ഷരസഞ്ചയങ്ങള്‍ നഖചിത്രമാക്കണമോ എന്നു്"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Type1 അക്ഷരസഞ്ചയങ്ങള്‍ നഖചിത്രമാക്കണമോ എന്നു്"
+
+#~ msgid "Copyright:"
+#~ msgstr "പകര്‍പ്പവകാശം:"
+
+#~ msgid "Description:"
+#~ msgstr "വിവരണം:"
+
+#~ msgid "Installed"
+#~ msgstr "ഇന്‍സ്റ്റോള്‍ ചെയ്തു"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "ഉപയോഗിക്കേണ്ട വിധം: %s fontfile\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "അക്ഷരസഞ്ചയം _ഇന്‍സ്റ്റോള്‍ ചെയ്യുക"
+
+#~ msgid "Font Viewer"
+#~ msgstr "അക്ഷരസഞ്ചയം കാണുന്നതിനുള്ള സംവിധാനം"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "നഖചിത്രത്തിനുള്ള വാചകം (സ്വതവേയുള്ളതു്: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "അക്ഷരസഞ്ചയത്തിന്റെ വ്യാപ്തി (സ്വതവേയുള്ളതു്: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "നിങ്ങളുടെ ഫില്‍‌റ്റര്‍ \"%s\" ഒരു വസ്തുവുമായി ചേരുന്നില്ല."
+
+#~ msgid "Upgrade"
+#~ msgstr "പുതുക്കുക"
+
+#~ msgid "Uninstall"
+#~ msgstr "നീക്കം ചെയ്യുക"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "ഇഷ്ടപ്പെട്ടവയിലേക്ക് ചേര്‍ക്കുക"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "തുടക്കത്തില്‍ പ്രവര്‍ത്തിപ്പിക്കേണ്ട പ്രോഗ്രാമുകളില്‍ നിന്ന് മാറ്റുക."
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "തുടക്കത്തില്‍ പ്രവര്‍ത്തിപ്പിക്കേണ്ട പ്രോഗ്രാമുകളിലേക്ക് ചേര്‍ക്കുക "
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "പുതിയ സ്പ്രെഡ്ഷീറ്റ്"
+
+#~ msgid "New Document"
+#~ msgstr "പുതിയ രചന"
+
+#~ msgid "Documents"
+#~ msgstr "രചനകള്‍"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>തുറക്കുക</b>"
+
+#~ msgid "Rename..."
+#~ msgstr "പേരു മാറ്റുക."
+
+#~ msgid "Move to Trash"
+#~ msgstr "ചവറ്റുകുട്ടയിലേക്ക് മാറ്റുക"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "ഒരു വസ്തു വെട്ടിമാറ്റിയാല്‍, അതു് എന്നേക്കുമായി നഷ്ടമാകുന്നു."
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "\"%s\" കൊണ്ട് തുറക്കുക"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "ഫയല്‍ മാനേജറില്‍ തുറക്കുക."
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "ഇന്നു് %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "ഇന്നലെ %l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "ഇപ്പോള്‍തന്നെ തെരയുക "
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s തുറക്കുക</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "സിസ്റ്റം ഇനങ്ങളില്‍ നിന്ന് മാറ്റുക"

--- a/po/mn.po
+++ b/po/mn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-08-15 23:55+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2006-08-16 00:49+0200\n"
 "Last-Translator: Badral <badral@openmn.org>\n"
 "Language-Team: Mongolian <openmn-translation@lists.sourceforge.net>\n"
@@ -21,3582 +21,7451 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);X-Generator: KBabel 1.10.2\n"
 "X-Generator: KBabel 1.10.2\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "Зураг/Бичээсийн хүрээ"
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "Сануулгын цонхонд зураг болон хаягийн хүрээний өргөн"
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr "Сануулгын төрөл"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "Сануулгын төрөл"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "Сануулгын товчнууд"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "Сануулгын цонхонд товчлууруудыг харуулж байна"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "Илүү _нарийвчилж харуулах"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "About Me"
-msgstr "Миний тухай"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "MIME-төрлийн мэдээлэл"
-
-#: ../capplets/about-me/gnome-about-me.c:605
-msgid "Select Image"
-msgstr "Зургийг сонгох"
-
-#: ../capplets/about-me/gnome-about-me.c:607
-msgid "No Image"
-msgstr "Зураг байхгүй байна"
-
-#: ../capplets/about-me/gnome-about-me.c:770
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-"Хаягийн номны мэдээлэлд орох үед алдаа гарлаа\n"
-"Протоколд Эволюшн Өгөгдөл Сервер орж чадахгүй байна"
-
-#: ../capplets/about-me/gnome-about-me.c:791
-msgid "Unable to open address book"
-msgstr "Хаягийн дэвтэр нээгдэх боломжгүй"
-
-#: ../capplets/about-me/gnome-about-me.c:803
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr "Үл мэдэгдэх логин ID, хэрэглэгчийн өгөгдөл магадгүй гэмтсэн байна"
-
-#: ../capplets/about-me/gnome-about-me.c:834
-#: ../capplets/about-me/gnome-about-me.c:836
-#, c-format
-msgid "About %s"
-msgstr "%s-ны тухай"
-
-#: ../capplets/about-me/gnome-about-me-password.c:172
-msgid "Child exited unexpectedly"
-msgstr "Хүү санамсаргүй гацлаа"
-
-#: ../capplets/about-me/gnome-about-me-password.c:295
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr "backend_stdin IO суваг унтраах боломжгүй : %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:308
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr "backend_stdout IO суваг унтраах боломжгүй : %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:449
-msgid "Authenticated!"
-msgstr "Батлагдлаа!"
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:466
-#: ../capplets/about-me/gnome-about-me-password.c:539
-msgid ""
-"Your password has been changed since you initially authenticated! Please re-"
-"authenticate."
-msgstr "Нууц үг таныг шинээр зөв нэвтрэхэд өөрчлөгдөнө! Дахин нэвтэрнэ үү."
-
-#: ../capplets/about-me/gnome-about-me-password.c:468
-msgid "That password was incorrect."
-msgstr "Нууц үг буруу."
-
-#: ../capplets/about-me/gnome-about-me-password.c:514
-msgid "Your password has been changed."
-msgstr "Таны нууц үг өөрчилөгдлөө."
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:524
-#, c-format
-msgid "System error: %s."
-msgstr "Системийн алдаа: %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:526
-msgid "The password is too short."
-msgstr "Нууц үг хэтэрхий богино байна."
-
-#: ../capplets/about-me/gnome-about-me-password.c:528
-#: ../capplets/about-me/gnome-about-me-password.c:530
-msgid "The password is too simple."
-msgstr "Нууц үг хэтэрхий энгийн байна."
-
-#: ../capplets/about-me/gnome-about-me-password.c:532
-msgid "The old and new passwords are too similar."
-msgstr "Хуучин болон шинэ нууц үг хэтэрхий төстэй байна."
-
-#: ../capplets/about-me/gnome-about-me-password.c:534
-msgid "The new password must contain numeric or special character(s)."
-msgstr "Тоо юмуу эсвэл тусгай тэмдэгтийг агуулах ёстой."
-
-#: ../capplets/about-me/gnome-about-me-password.c:536
-msgid "The old and new passwords are the same."
-msgstr "Хуучин болон шинэ нууц үг ижил байна."
-
-#: ../capplets/about-me/gnome-about-me-password.c:787
-#, c-format
-msgid "Unable to launch /usr/bin/passwd: %s"
-msgstr "/usr/bin/passwd ажиллахгүй байна: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:789
-msgid "Unable to launch backend"
-msgstr "Холбоог эхлүүлэх боломжгүй"
-
-#: ../capplets/about-me/gnome-about-me-password.c:790
-msgid "A system error has occurred"
-msgstr "Системд алдаа гарсан байна"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:810
-msgid "Checking password..."
-msgstr "Нууц үгийг шалгаж байна..."
-
-#: ../capplets/about-me/gnome-about-me-password.c:897
-msgid "Click <b>Change password</b> to change your password."
-msgstr ""
-"Нууц үгээ өөрчлөхийн тулд <b>Нууц үгээ өөрчлөх</b> гэсэн товчин дээр дарна."
-
-#: ../capplets/about-me/gnome-about-me-password.c:900
-msgid "Please type your password in the <b>New password</b> field."
-msgstr "<b>Шинэ нууц үг талбарт</b> нууц үгээ оруулна уу."
-
-#: ../capplets/about-me/gnome-about-me-password.c:903
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-msgid ""
-"Please type your password again in the <b>Retype new password</b> field."
-msgstr "Нууц үгээ дахин <b>Шинэ нууц үгээ давт</b> талбарт оруулна уу."
-
-#: ../capplets/about-me/gnome-about-me-password.c:906
-msgid "The two passwords are not equal."
-msgstr "Хоёр нууц үг тохирохгүй байна."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/sound/sound-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-msgid "    "
-msgstr "    "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Email</b>"
-msgstr "<i>Э-Шуудан</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Home</b>"
-msgstr "<b>Home</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Яаралтай мэдээлэл</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Job</b>"
-msgstr "<b>Ажил</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Telephone</b>"
-msgstr "<b>Утас</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<b>Web</b>"
-msgstr "<b>Вэб</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "<b>Work</b>"
-msgstr "<b>Ажил</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Нууц үгээ өөрчилөх</span>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "A_ddress:"
-msgstr "Х_аяг:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr "_Туслагч:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "Address"
-msgstr "Хаяг"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "C_ity:"
-msgstr "Х_от:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "C_ompany:"
-msgstr "К_омпани:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Cale_ndar:"
-msgstr "Хуа_нли:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change Passwo_rd..."
-msgstr "Нэвт_рэх үгээ өөрчлөх..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Change pa_ssword"
-msgstr "Нууц үгээ өө_рчлөх"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Change password"
-msgstr "Нууц үгээ өөрчлөх"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Ci_ty:"
-msgstr "Х_от:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Co_untry:"
-msgstr "У_лс:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Contact"
-msgstr "Холбоо"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Cou_ntry:"
-msgstr "У_лс:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Current _password:"
-msgstr "_Одоогийн нууц үг:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "Full Name"
-msgstr "Бүтэн нэр"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "Hom_e:"
-msgstr "Гэр:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P.O. _box:"
-msgstr "P.O. _хайрцаг:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "P._O. box:"
-msgstr "P._O. хайрцаг:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "Personal Info"
-msgstr "Хувийн мэдээлэл"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "State/Pro_vince:"
-msgstr "Улс/Орон н_утаг:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid ""
-"To change your password, enter your current password in the field below and "
-"click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for "
-"verification and click <b>Change password</b>."
-msgstr ""
-"Та нууц үгээ солих бол доор одоогийн нууц үгээ оруулаад <b>Баталгаажуулалт</"
-"b> дээр дарна уу.\n"
-"Ахин нэвтэрсэний дараа шинэ нууц үгээ оруулж, бататгахын тулд дахин оруулаад "
-"<b>Нууц үг солих</b> дээр дарна уу."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "User name:"
-msgstr "Хэрэглэгчийн нэр:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "Web _log:"
-msgstr "Веб _лог:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "Wor_k:"
-msgstr "_Ажил:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "Work _fax:"
-msgstr "Aжлын _факс:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "Zip/_Postal code:"
-msgstr "Zip/_Шуудангийн код:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "_Address:"
-msgstr "_Хаяг:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Authenticate"
-msgstr "_Баталгаажуулах"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Department:"
-msgstr "_Хэлтэс:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Groupwise:"
-msgstr "_Бүлэглэл:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_Home page:"
-msgstr "_Гэрийн хуудас:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Home:"
-msgstr "_Гэр:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Jabber:"
-msgstr "_Гэмтэл:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_Manager:"
-msgstr "_Удирдлага:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Mobile:"
-msgstr "_Гар утас:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_New password:"
-msgstr "_Шинэ нэвтрэх үг:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Profession:"
-msgstr "_Мэргэжил:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Retype new password:"
-msgstr "_Шинэ нэвтрэх үгийг дахин бичнэ үү:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:55
-msgid "_State/Province:"
-msgstr "_Улс/Орон нутаг:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:56
-msgid "_Title:"
-msgstr "_Гарчиг:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:57
-msgid "_Work:"
-msgstr "_Ажил:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:58
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:59
-msgid "_Zip/Postal code:"
-msgstr "_Zip/Шуудангийн код:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Applications</b>"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
 msgstr "<b>Програмууд</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Support</b>"
-msgstr "<b>Дэмжлэг</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-"<small><i><b>Санамж:</b> Энэ тохируулгын өөрчлөлтүүд таны дараагийн нэвтрэлт "
-"хүртэл нөлөөлөхгүй.</i></small>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Preferences"
-msgstr "Туслах Технологийн тохируулга"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr "Хаагаад _Гарах"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr "Эдгээр туслах технологуудыг нэврэлт бүрд эхлүүл:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr "Туслах технологуудыг _нээх"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr "_Өсгөгч"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr "_Дэлгэц дээрхи гар"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Screenreader"
-msgstr "_Дэлгэц уншигч"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr "Нэвтрэлтэд ГНОМЕ-н туслах технологуудын дэмжилт боломжтой."
-
-#: ../capplets/accessibility/at-properties/main.c:60
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the 'orca' "
-"package must be installed for screenreading and magnifying capabilities."
-msgstr ""
-"Таны системд ямар ч тусламж технологи байхгүй байна. Та дэлгэц гар "
-"хэрэглэхийг хүсвэл »gok« багцыг мөн дэлгэц уншилт ба томруулалтын функц "
-"хэрэглэх бол »orca« багцыг тус тус суулгана уу."
-
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-"Таны системд бүх боломжтой тусламж технологийг суулгаагүй байна. Та дэлгэц "
-"гар хэрэглэхийг хүсвэл »gok« багцыг суулгана уу."
-
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'orca' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Таны системд бүх боломжийн тусламж технологийг суулгаагүй байна. Та дэлгэц "
-"уншилт ба томруулалтын функц хэрэглэх бол »orca« багцыг тус тус суулгана уу."
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:242
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr "Хулгана тохируулах цонхыг эхлүүлэхэд алдаа гарлаа: %s"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:338
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:399
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr "AccessX-тохируулга '%s' файлаас импортлогдох боломжгүй байна"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:436
-msgid "Import Feature Settings File"
-msgstr "Тохиргооны файлын шинжийг оруулах"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:440
-msgid "_Import"
-msgstr "_Оруулж ирэх"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Гар"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr "Гарт хялбар хандалтын тохируулга хийх"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-"Энэ систем XKB-өргөтгөлгүй юм шиг байна. Гарын хялбар хандалт нь үүнгүйгээр "
-"баталгаажиж чадахгүй."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "<b>_Хязгаар товчлуурууд боломжтой</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "<b>_Удаан товчлуурууд боломжтой</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "<b>_Хулгана түлхүүр боломжтой</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "<b>_Давталт түлхүүрүүд боломжтой</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "<b>_Наалттай түлхүүрүүд боломжтой</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-msgid "<b>Features</b>"
-msgstr "<b>Шинжүүд</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr "<b>Сэлгэгч түлхүүрүүд</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "Үндсэн"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr "Түлхүүрүүдийг _хүлээж аваагүй бол чимээ өгөх"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
-msgstr "Гарын а_жиллагааны хэрэгслүүд идэвхижих эсвэл хаагдах үед чимээ өгөх"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
-msgstr "Өөрчлөгчийг албадах үед _чимээ өгөх"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr "LED асахад нэг чимээ, унтрахад хоёр чимээ өгөх."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr "Хэрвээ түлхүүр ...бол чимээ өгөх:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr "_Хоцролт:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr "Товчлуур даралт ба түүчээний _хөдөлгөөний хоорондын хүлээлт"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr "Хоёр товчлуур _зэрэг дарагдвал хаалттай"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr "Холбогч түлхүүрүүд нээлттэй"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Шүүлтүүр"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr "Товчлуурын давхар тогшилтыг дараах дотор х_эрэгсэхгүй байх:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-"Нэг товчлуурын үргэлжилсэн даралтыг хэрэглэгчийн тогтоосон хугацаан дотор "
-"хэрэгсэхгүй байх."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr "Гарын хялбар хандалтын Тохиргоо (AccessX)"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr "Хулганы заагчийн ма_ксимал хурд:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr "Хулгана товчлуур"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr "Хулгана _Тохируулгууд..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-"Хэрэглэгчийн тодорхойлсон хугацаанд түлхүүрүүдийг дарсны дараа хүлээн "
-"зөвшөөрнө."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-"Дараалсан товчлууруудын хослол дарснаар зэрэг товчилуур дарах үйлдлийг "
-"гүйцэтгэнэ."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "S_peed:"
-msgstr "Х_урд:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr "Максимум хурд хүртэл хур_дасгах хугацаа:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr "Хулганы удирдлагад гарын тооны машины хэсгийг хэрэглэх."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr "Хэрвээ дараахад хэрэглэгдээгүй бол _хаах:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr "_Гарын хялбар тусламжийн ажиллагаа боломжтой"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr "_Ажиллагааны тохируулгыг _импортлох..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr "Товчлуурын даралтыг _зөвхөн дараахын хувьд зөвшөөрөх:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "_Type to test settings:"
-msgstr "Тохируулга шалгалтын төрлүүд:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr "_зөвшөөрөгдсөн"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr "_дарагдсан"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr "бу_цаагдсан"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr "Тэмдэгт/Секунд"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "milliseconds"
-msgstr "Миллисекунд"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr "Цэгүүд/Секунд"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "Секундүүд"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-msgid "Change your Desktop Background settings"
-msgstr "Ажлын талбары дэвсгэрийн тохиргоог өөрчилөх"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-msgid "Desktop Background"
-msgstr "Ажлын талбарын дэвсгэр"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "<b>Ажлын талбарын _Туурга цаас</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-msgid "<b>_Desktop Colors</b>"
-msgstr "<b>_Ажлын талбарын өнгө</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-msgid "Desktop Background Preferences"
-msgstr "Ажлын талбарын дэвсгэрийн тохируулгууд"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr "Өнгө тодорхойлох цонхыг нээх"
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr "_Туурга цаас нэмэх"
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-msgid "_Finish"
-msgstr "_Дуусгах"
-
-#: ../capplets/background/gnome-background-properties.glade.h:7
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-msgid "_Remove"
-msgstr "_Устгах"
-
-#: ../capplets/background/gnome-background-properties.glade.h:8
-msgid "_Style:"
-msgstr "_Загвар:"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Тусламж үзүүлэхэд алдаа гарлаа: %s"
-
-#: ../capplets/background/gnome-wp-capplet.c:984
-msgid "Centered"
-msgstr "Голлосон"
-
-#: ../capplets/background/gnome-wp-capplet.c:988
-msgid "Fill Screen"
-msgstr "Дэлгэц дүүрэн"
-
-#: ../capplets/background/gnome-wp-capplet.c:992
-msgid "Scaled"
-msgstr "Хуваарилсан"
-
-#: ../capplets/background/gnome-wp-capplet.c:996
-msgid "Zoom"
-msgstr "Хэмжээг өөрчлөх"
-
-#: ../capplets/background/gnome-wp-capplet.c:1000
-msgid "Tiled"
-msgstr "Дүүргэн"
-
-#: ../capplets/background/gnome-wp-capplet.c:1021
-msgid "Solid Color"
-msgstr "Нэг өнгөт"
-
-#: ../capplets/background/gnome-wp-capplet.c:1025
-msgid "Horizontal Gradient"
-msgstr "Босоо шугамдсан"
-
-#: ../capplets/background/gnome-wp-capplet.c:1029
-msgid "Vertical Gradient"
-msgstr "Хэвтээ шугамдсан"
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1075
-msgid "Add Wallpaper"
-msgstr "Aрын фон нэмэх"
-
-#: ../capplets/background/gnome-wp-capplet.c:1092
-msgid "Images"
-msgstr "Зургууд"
-
-#: ../capplets/background/gnome-wp-capplet.c:1096
-msgid "All Files"
-msgstr "Бүх файлууд"
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr "Туурга цаасгүй"
-
-#: ../capplets/background/gnome-wp-item.c:343
-#: ../capplets/background/gnome-wp-item.c:345
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "цэг"
-msgstr[1] "цэгүүд"
-
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"Тохируулгын менежер »gnome-settings-daemon« эхлүүлэх боломжгүй байна.\n"
-"GNOME-менежергүйгээр хэд хэдэн тохируулга гүйцэлдэхгүй байх боломжтой. Энэ "
-"нь Bonobo -той эсвэл  GNOME бус (ж.нь. KDE-) тохируулгын менежер хэдийнэ "
-"идэвхижих ба GNOME тохируулгын менежертэй зөрчилдөнө."
-
-#: ../capplets/common/capplet-stock-icons.c:92
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "'%s' stock эмблемийг ачаалах боломжгүй \n"
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr "Тохируулгыг хэрэглээд гарах"
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1027
-#: ../capplets/sound/sound-properties-capplet.c:762
-msgid "Retrieve and store legacy settings"
-msgstr "Хүлээн авсан тохируулгыг олоод хадгалах"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "Файл хуулж байна: %u-ийн %u"
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr "'%s'-г хуулж байна"
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr "URI хаягаас"
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr "URI яг одоо дамжуулагдаж байна"
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr "URI руу"
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr "URI одоогоор дамжуулагдаж байна"
-
-# CHECK
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr "Хэсэгчилэл бэлэн"
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr "Дуусч буй дамжууллын хэсэгчилэл"
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr "Идэвхитэй URI-жигсаалт"
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr "Идэвхитэй URI-жигсаалт - 1-р эхэлж байна"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr "Нийт URI"
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr "URI -н нийт тоо"
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr "Файлыг хуулж байна"
-
-#: ../capplets/common/file-transfer-dialog.c:345
-msgid "From:"
-msgstr "Хэнээс"
-
-#: ../capplets/common/file-transfer-dialog.c:349
-msgid "To:"
-msgstr "Хэнд:"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr "Холболт хийгдэж байна..."
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Түлхүүр"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr "Энэ онцлог засварлагч хавсаргагдсан GConf-түлхүүр"
-
-# CHECK upto line 505
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr "Эргэх хүсэлт"
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Хэрвээ түлхүүрийн утга өөрчлөгдвөл эргэх хүсэлт гүйцэтгэх"
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr "Өөрчлөлтүүд"
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"GConf-өөрчлөлтүүд GConf-Client цааш дамжуулахад хэрэглэх өгөгдлийг агуулж "
-"байна"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr "Widget рүү эргэх хүсэлт хөрвүүлэлт"
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-" GConf -оос Widget рүү хийгдэх өгөгдөлийн хөрвүүлэлтийн үед хийгдэх эргэх "
-"хүсэлт"
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr "Widget ээс эргэх хүсэлт хөрвүүлэлт"
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"Widget-ээс GConf-рүү хийгдэх өгөгдөлийн хөрвүүлэлтийн үед хийгдэх эргэх "
-"хүсэлт"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr "Хэрэглэгчийн гадаргуу жолоодогч"
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr "Онцлогийг (энгийн Widget) шалгах объект"
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr "Онцлог боловсруулагчийн объект өгөгдөл"
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr "Тухайн онцлог боловсруулагчид шаардлагатай боломжит өгөгдөл"
-
-# CHECK
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr "Онцлог боловсруулагчийн өгөгдөл чөлөөлөх эргэх хүсэлт"
-
-# CHECK
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr "Онцлог боловсруулагчийн өгөгдөл чөлөөлөх үед хийгдэх эргэх хүсэлт"
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"»%s« файл олдсонгүй.\n"
-"\n"
-"Та энэ файл байгаа эсэхийг шалгах эсвэл та өөр дэвсгэр зураг сонгоно уу."
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"'%s' файлыг хэрхэн нээхийг мэдэхгүй байна.\n"
-"Энэ нь дэмжигдээгүй төрлийн зураг байх боломжтой.\n"
-"\n"
-"Та өөр зураг сонгоно уу."
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr "Та нэг зураг сонгоно уу."
-
-#: ../capplets/common/gconf-property-editor.c:1598
-msgid "_Select"
-msgstr "_Сонгох"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
 msgstr "Эрхэмлэсэн х.программууд"
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Та өөрийн стандарт х.программыг сонгоно уу"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:77
-#: ../capplets/default-applications/gnome-da-capplet.c:101
-#: ../capplets/default-applications/gnome-da-capplet.c:146
-#: ../capplets/default-applications/gnome-da-capplet.c:191
-#: ../capplets/default-applications/gnome-da-capplet.c:245
-#: ../capplets/default-applications/gnome-da-capplet.c:294
-#: ../capplets/default-applications/gnome-da-capplet.c:576
-#: ../capplets/default-applications/gnome-da-capplet.c:597
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "Тохиргоог хадгалахад алдаа гарлаа: %s"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:719
-#: ../capplets/sound/sound-properties-capplet.c:319
-msgid "Custom"
-msgstr "Хэвшмэл"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:739
-msgid "Could not load the main interface"
-msgstr "Гол интерфейсийг ачаалж чадсангүй"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:741
-msgid "Please make sure that the applet is properly installed"
-msgstr "Энэ апплет зөв суусан эсэхийг нягтлана уу"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Балса"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Debian Sensible Browser"
-msgstr "Дебиан тохиромжтой хөтлөгч"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Debian Terminal Emulator"
-msgstr "Дебиан терминал эмулатор"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "ETerm"
-msgstr "ЭТерм"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Encompass"
-msgstr "Энкомпасс"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Epiphany Web Browser"
-msgstr "Epiphany вэб хөтөч"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "Evolution Mail Reader"
-msgstr "Эволюшн Мэйл Уншигч"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Evolution Mail Reader 1.4"
-msgstr "Эволюшн Мэйл Уншигч 1.4"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Evolution Mail Reader 1.5"
-msgstr "Эволюшн Мэйл Уншигч 1.5"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader 1.6"
-msgstr "Эволюшн Мэйл Уншигч 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Evolution Mail Reader 2.0"
-msgstr "Эволюшн Мэйл Уншигч 2.0"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Evolution Mail Reader 2.2"
-msgstr "Эволюшн Мэйл Уншигч 2.2"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "Evolution Mail Reader 2.4"
-msgstr "Эволюшн Мэйл Уншигч 2.4"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "Firebird"
-msgstr "Firebird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "GNOME Terminal"
-msgstr "ГНОМЕ Терминал"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Galeon"
-msgstr "Галеон"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "KMail"
-msgstr "КМэйл"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Konqueror"
-msgstr "Конкюрор"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Links Text Browser"
-msgstr "Зүүн текст хөтөч"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Lynx Text Browser"
-msgstr "Люнкс Текст хөтөч"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Mozilla"
-msgstr "Моцилла"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "Mozilla 1.6"
-msgstr "Моцилла 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "Mozilla Mail"
-msgstr "Моцилла Мэйл"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Mutt"
-msgstr "Мутт"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "NXterm"
-msgstr "НКСтерм"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Netscape Communicator"
-msgstr "Netscape Холбогч"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Opera"
-msgstr "Опера"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "RXVT"
-msgstr "РКСВТ"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Standard XTerminal"
-msgstr "Стандарт КСТерминал"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Sylpheed"
-msgstr "Sylpheed"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "W3M Text Browser"
-msgstr "W3M текст хөтөч"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Audio Player</b>"
-msgstr "<b>Дуу тоглуулагч</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Image Viewer</b>"
-msgstr "<b>Зураг харагч</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Instant Messenger</b>"
-msgstr "<b>Мессэнжир</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mail Reader</b>"
-msgstr "<b>Майл уншигч</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>Терминал эмулатор</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Text Editor</b>"
-msgstr "<b>Текст боловсруулагч</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Video Player</b>"
-msgstr "<b>Видео тоглуулагч</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Web Browser</b>"
-msgstr "<b>Вэб хөтөч</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "Бүх %s тохиолдолууд нь одоогийн холбоосоор солигдсон байна"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Co_mmand:"
-msgstr "Т_ушаал:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "E_xecute flag:"
-msgstr "Дарцаг _ачаалах:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Internet"
-msgstr "Интернет"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Multimedia"
-msgstr "Multimedia"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Open link in new _tab"
-msgstr "Шинэ _табд холбоос нээх"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Open link in new _window"
-msgstr "Шинэ _цонхонд холбоос нээх"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Open link with web browser _default"
-msgstr "_Стандарт вэб хөтчөөр холбоосыг нээх"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Run in t_erminal"
-msgstr "_Терминалд ажиллуулах"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "System"
-msgstr "Систем"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Дэлгэцийн нарийвчлал өөрчлөх"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Дэлгэцийн нарийвчлал"
-
-#: ../capplets/display/main.c:25
-msgid "normal"
-msgstr "энгийн"
-
-#: ../capplets/display/main.c:26
-msgid "left"
-msgstr "зүүн"
-
-#: ../capplets/display/main.c:27
-msgid "inverted"
-msgstr "Урвуу"
-
-#: ../capplets/display/main.c:28
-msgid "right"
-msgstr "баруун"
-
-#: ../capplets/display/main.c:389
-#, c-format
-msgid "%d Hz"
-msgstr "%d Гц"
-
-#: ../capplets/display/main.c:535
-msgid "_Resolution:"
-msgstr "_Нарийвчлал:"
-
-#: ../capplets/display/main.c:554
-msgid "Re_fresh rate:"
-msgstr "Хурд _шинэчилэх:"
-
-#: ../capplets/display/main.c:574
-msgid "R_otation:"
-msgstr "_Эргүүлэлт:"
-
-#: ../capplets/display/main.c:594
-msgid "Default Settings"
-msgstr "Стандарт тохиргоо"
-
-#: ../capplets/display/main.c:596
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr "%d дэлгэцийн тохиргоо\n"
-
-#: ../capplets/display/main.c:622
-msgid "Screen Resolution Preferences"
-msgstr "Дэлгэцийн нарийвчлалын тохируулга"
-
-#: ../capplets/display/main.c:659
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "_Зөвхөн энэ компьютерийг (%s) стандарт болгох"
-
-#: ../capplets/display/main.c:677
-msgid "Options"
-msgstr "Сонголтууд"
-
-#: ../capplets/display/main.c:698
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"Шинэ тохиргоог шалгаж үзэж байна. Хэрвээ та %d секундэд хариу авахгүй бол "
-"өмнөх тохиргоо сэргээгдэнэ."
-msgstr[1] ""
-"Шинэ тохиргоог шалгаж үзэж байна. Хэрвээ та %d секундэд хариу авахгүй бол "
-"өмнөх тохиргоо сэргээгдэнэ."
-
-#: ../capplets/display/main.c:744
-msgid "Keep Resolution"
-msgstr "Нарийвчлалыг хадгал"
-
-#: ../capplets/display/main.c:748
-msgid "Do you want to keep this resolution?"
-msgstr "Та энэ тохиргоог хадгалахыг хүсэж байна уу?"
-
-#: ../capplets/display/main.c:773
-msgid "Use _previous resolution"
-msgstr "Ө_мнөх тохиргоог хэрэглэнэ"
-
-#: ../capplets/display/main.c:773
-msgid "_Keep resolution"
-msgstr "Нарийвчлалыг _авах"
-
-#: ../capplets/display/main.c:923
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"XServer нь XRandR өргөтгөлийг дэмжээгүй байна.  Нарийвчлалын өөрчлөлтүүдийг "
-"ажиллагааны үед авах боломжгүй."
-
-#: ../capplets/display/main.c:931
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"Энэ програмтай XRandR өргөтгөлийн хувилбар тохирохгүй байна. Нарийвчлалын "
-"өөрчлөлтүүдийг ажиллагааны үед авах боломжгүй."
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Фонтны хэлбэр"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr "Ажлын талбарын фонтыг сонгох"
-
-#: ../capplets/font/font-properties.glade.h:1
-msgid "<b>Font Rendering</b>"
-msgstr "<b>Фонтны дүрслэл</b>"
-
-#: ../capplets/font/font-properties.glade.h:2
-msgid "<b>Hinting</b>:"
-msgstr "<b>Дохио өгөх</b>:"
-
-#: ../capplets/font/font-properties.glade.h:3
-msgid "<b>Smoothing</b>:"
-msgstr "<b>Толийлголт</b>:"
-
-#: ../capplets/font/font-properties.glade.h:4
-msgid "<b>Subpixel order</b>:"
-msgstr "<b>Subpixel дараалал</b>:"
-
-#: ../capplets/font/font-properties.glade.h:5
-msgid "Best _shapes"
-msgstr "Хамгийн сайн хэ_лбэр"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best co_ntrast"
-msgstr "Хамгийн сайн _эрчимжилт"
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "D_etails..."
-msgstr "Дэлгэ_рэнгүй..."
-
-#: ../capplets/font/font-properties.glade.h:8
-msgid "Des_ktop font:"
-msgstr "_Ажлын талбарын фонт:"
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "Фонтын тохиргоо"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr "Фонтны дүрслэлийн тодруулга"
-
-#: ../capplets/font/font-properties.glade.h:11
-msgid "Go _to font folder"
-msgstr "Фонтны лавлах руу _оч"
-
-#: ../capplets/font/font-properties.glade.h:12
-msgid "Gra_yscale"
-msgstr "Сааралж_уулалт"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "_Хаах"
-
-#: ../capplets/font/font-properties.glade.h:14
-msgid "R_esolution:"
-msgstr "_Нарийвчлал:"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr "_Subpixel (LCDs)"
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "Sub_pixel (LCDs) толийлгож байна"
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
-msgstr "Х._программуудын фонт:"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Document font:"
-msgstr "_Баримтын фонт:"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Fixed width font:"
-msgstr "_Фонтны өргөнийг тодорхойллоо:"
-
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Full"
-msgstr "_Дүүрэн"
-
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Medium"
-msgstr "_Дунд"
-
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_Monochrome"
-msgstr "_Хар-цагаан"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_None"
-msgstr "_Хаах"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Slight"
-msgstr "Бага_втар"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "_Цонхны толгойн фонт:"
-
-#: ../capplets/font/font-properties.glade.h:30
-msgid "dots per inch"
-msgstr "Ямх тус бүрийн цэг"
-
-#: ../capplets/font/main.c:489
-msgid "Font may be too large"
-msgstr "Фонтны хэв хэт том байх"
-
-#: ../capplets/font/main.c:493
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Сонгогдсон фонтын хэв %d цэгтэй том ба энэ нь компютер үр ашигтай ажиллахад "
-"бэрхшээлтэй.  Таныг фонтын хэвийн хэмжээг %d-ээс бага болгохыг зөвлөж байна."
-msgstr[1] ""
-"Сонгогдсон фонтын хэв %d цэгтэй том ба энэ нь компютер үр ашигтай ажиллахад "
-"бэрхшээлтэй.  Таныг фонтын хэвийн хэмжээг %d-ээс бага болгохыг зөвлөж байна."
-
-#: ../capplets/font/main.c:506
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Сонгогдсон фонтын хэв %d том ба энэ магад компютер үр ашигтай ажиллахад "
-"бэрхшээлтэй. Таныг фонтын бага хэмжээг сонгохыг зөвлөж байна."
-msgstr[1] ""
-"Сонгогдсон фонтын хэв %d том ба энэ магад компютер үр ашигтай ажиллахад "
-"бэрхшээлтэй.  Таныг фонтын бага хэмжээг сонгохыг зөвлөж байна."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "Шинэ хослол товчлуур..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Хослол түлхүүр"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Хослол товчлуурыг өөрчлөгч"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Хослол товчлуурын код"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Хослолын горим"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Шорткатын төрөл"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:187
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:470
-msgid "Disabled"
-msgstr "Хаагдсан"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:534
-msgid "<Unknown Action>"
-msgstr "<Тодорхойгүй үйлдэл>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:555
-msgid "Desktop"
-msgstr "Ажлын талбар"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:556
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
-msgstr "Аудио"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:560
-msgid "Window Management"
-msgstr "Цонхны зохион байгуулалт"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:668
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become unusable to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time.\n"
-msgstr ""
-"Энэ түлхүүрийг ашиглахад хэрэглэгдэхгүй тул \"%s\" шорткатыг хэрэглэхгүй.\n"
-"Энэ түлхүүртэй Control, Alt эсвэл Shift-ийг нэгэн зэрэг дарна уу.\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:697
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-msgstr ""
-"\"%s\" Шорткат хэдийнэ хэрэглэгдсэн:\n"
-" \"%s\"\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:729
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr ""
-"Тохируулгын өгөгдлийн баазад шинэ шорткатыг оруулахад гарсан алдаа: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:779
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr "Тохируулгын өгөгдлийн баазаас шорткатыг устгах үед алдаа гарлаа: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:886
-msgid "Action"
-msgstr "Үйлдэл"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:910
-msgid "Shortcut"
-msgstr "Шорткат"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Гарын шорткат"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
-msgstr ""
-"Та шинэ шорткатыг нэмэхийн тулд зохих мөр ба шинэ товчлуурын хослол дээр "
-"дарна эсвэл арилгахын тулд Backspace-товчлуурыг дарна"
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Тушаалуудад шорткат оноох"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:87
-msgid "Unknown"
-msgstr "Үл мэдэгдэх"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:282
-msgid "Layout"
-msgstr "Үзэмж"
-
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:286
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:231
-msgid "Default"
-msgstr "Стандарт"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:77
-msgid "Models"
-msgstr "Модел"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:109
-#, c-format
-msgid "There was an error launching the keyboard tool: %s"
-msgstr "Гарны хэрэгслэлийг ачаалахад алдаа гарлаа: %s"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
-msgstr "_Хялбарчилал"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:758
-#: ../capplets/sound/sound-properties-capplet.c:760
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-"Зөвхөн тохируулга хэрэглээд гарах (Зөвхөн зүй зохицолд; одоо daemon-оор "
-"боловсруулагдана)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
-msgstr "Завсарлага тохируулгыг агуулах хуудасны эхлэлийг харуулах"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>Анивчдаг түүчээ</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Товчлуурын давталт</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<b>Дэлгэц _түгжээд завсарлага шаардах</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Хурдан</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Урт</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Богино</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Удаан</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "A_vailable layouts:"
-msgstr "Байгаа ү_зэмжүүд:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "All_ow postponing of breaks"
-msgstr "Завсарлага зөөлт _зөвшөөрөх"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Завсарлага зөөлт зөвшөөрөх эсэхийг тогтоо"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Choose a Keyboard Model"
-msgstr "Гарын загвараа сонгоно уу"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "Choose a Layout"
-msgstr "Гарын засвар сонгох"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Choose..."
-msgstr "Сонгох..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
-msgstr "Түүчээг текст талбар болон текст дотор а_нивчуулах"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Cursor blinks speed"
-msgstr "Түүчээ анивчих хурд"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of the break when typing is disallowed"
-msgstr "Бичих үед гарсан завсарлагын үргэлжлэх хугацаа"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Duration of work before forcing a break"
-msgstr "Завсарлага шаардагдахаас өмнөх ажлын хугацаа"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Key presses _repeat when key is held down"
-msgstr "Хэрвээ товчлуур доош дарагдсан бол түүнийг _давтах"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Keyboard Preferences"
-msgstr "Гарын тохируулга"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Keyboard _model:"
-msgstr "Гарын _загвар:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Layout Options"
-msgstr "Үзэмж сонголт"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Layouts"
-msgstr "Үзэмж"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr "Санамсаргүй эсвэл гажуудал товч дарагдахаас хамгаалж дэлгэц түгжих"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Microsoft Natural Keyboard"
-msgstr "Microsoft Natural Гар"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Preview:"
-msgstr "Тольдох:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "Repeat keys speed"
-msgstr "Түлхүүр давтагдах хурд"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Reset To De_faults"
-msgstr "_Стандартыг сэргээх"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Separate _group for each window"
-msgstr "Цонх бүрийн тусгай бүлгүүд"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-msgid "Typing Break"
-msgstr "Бичих үеийн завсарлага"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Accessibility..."
-msgstr "_Хялбарчилал..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Add..."
-msgstr "_Нэмэх..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "_Break interval lasts:"
-msgstr "_Сүүлийн завсарлагын интервал:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Delay:"
-msgstr "_Хүлээлт:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Models:"
-msgstr "_Модел:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Selected layouts:"
-msgstr "_Сонгогдсон үзэмжүүд:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Speed:"
-msgstr "Х_урд:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "_Work interval lasts:"
-msgstr "_Сүүлийн ажлын интервал:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "minutes"
-msgstr "Минут"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Өөрийн гарын тохируулгыг тогтоох"
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:891
-#, c-format
-msgid "%d millisecond"
-msgid_plural "%d milliseconds"
-msgstr[0] "%d миллисекунд"
-msgstr[1] "%d миллисекунд"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:567
-msgid "Unknown Pointer"
-msgstr "Тодорхойгүй түүчээ"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "Default Pointer"
-msgstr "Стандарт түүчээ"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-msgid "Default Pointer - Current"
-msgstr "Стандарт түүчээ- Идэвхитэй"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:770
-msgid "The default pointer that ships with X"
-msgstr "X -н стандарт түүчээ"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "White Pointer"
-msgstr "Цагаан түүчээ"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-msgid "White Pointer - Current"
-msgstr "Цагаан түүчээ - Идэвхитэй"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:776
-msgid "The default pointer inverted"
-msgstr "Урвуулсан стандарт түүчээ"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large Pointer"
-msgstr "Том түүчээ"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-msgid "Large Pointer - Current"
-msgstr "Том түүчээ - Идэвхитэй"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:782
-msgid "Large version of normal pointer"
-msgstr "Энгийн түүчээний том хувилбар"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:786
-msgid "Large White Pointer - Current"
-msgstr "Том цагаан түүчээ - Идэвхитэй"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:787
-msgid "Large White Pointer"
-msgstr "Том цагаан түүчээ"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:788
-msgid "Large version of white pointer"
-msgstr "Цагаан түүчээний том хувилбар"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:981
-msgid "Pointer Theme"
-msgstr "Түүчээний сэдэв"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr "<b>Давхар товшилтын Х/И завсар</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Татаад тавих</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Түүчээний байрлал</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>Хулганы чиглэл</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Speed</b>"
-msgstr "<b>Хурд</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>Хурдан</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>Өндөр</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>Том</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>Бага</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>Удаан</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>Жижиг</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Товчнууд"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr "Таныг Ctrl дарахад _түүчээг онцгойлох"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Large"
-msgstr "Том"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Medium"
-msgstr "Дунд"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "Motion"
-msgstr "Хөдөлгөөн"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-msgid "Mouse Preferences"
-msgstr "Хулганы тохируулга"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Pointer Size:"
-msgstr "Түүчээний хэмжээ:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Pointers"
-msgstr "Түүчээнүүд"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "Small"
-msgstr "Жижиг"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
-msgstr "Ху_рдасгалт:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
-msgstr "_Зүүн гарын хулгана"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr "_Мэдрэмж:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr "_Хязгаар:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
-msgstr "_Завсар:"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Хулгана"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Хулганы тохируулга хийх"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Сүлжээ-итгэмжлэгч"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "Сүлжээ-итгэмжлэгчийн тохируулгыг хийх"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>Интернэтийн _шууд холболт</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
-msgstr "<b>Хостын жагсаалтаас татгалзах</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>Итгэмжлэгчийн _автомат тохируулга</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>Итгэмжлэгчийн _гар тохируулга</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Гэрчилгээ хэрэглэнэ</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "Advanced Configuration"
-msgstr "Нарийвчилсан тохируулга"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr "Автомат тохируулгын _URL:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "HTTP-итгэмжлэгч дэлгэрэнгүй"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "_HTTP-итгэмжлэгч:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Network Proxy Preferences"
-msgstr "Сүлжээ-итгэмжлэгчийн тохируулга"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Порт:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "Proxy Configuration"
-msgstr "Итгэмжлэгчийн тохируулга"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr "S_ocks-хост:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "U_sername:"
-msgstr "_Хэрэглэгчийн нэр:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_Дэлгэрэнгүй"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr "_FTP-итгэмжлэгч:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "_Нэвтрэх үг:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr "_HTTP-итгэмжлэгчийг баталгаажуулах:"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Чимээг идэвхижүүлж үйлдлүүдтэй холбох"
-
-#: ../capplets/sound/sound-properties-capplet.c:317
-#: ../capplets/sound/sound-properties-capplet.c:369
-msgid "Not connected"
-msgstr "Холбогдсонгүй"
-
-#: ../capplets/sound/sound-properties-capplet.c:792
-msgid "Sound Preferences"
-msgstr "Чимээний тохируулга"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "<b>Audio Conferencing</b>"
-msgstr "<b>Дуут чуулган</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "<b>Music and Movies</b>"
-msgstr "<b>Хөгжим ба кино</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "<b>Sound Events</b>"
-msgstr "<b>Дууны үйлдлүүд</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
-msgstr "<span weight=\"bold\" size=\"larger\">Шалгаж байна...</span>"
-
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Click OK to finish."
-msgstr "Дуусгахдаа OK дээр дарна уу."
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "Devices"
-msgstr "Төхөөрөмжүүд"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "E_nable software sound mixing (ESD)"
-msgstr "Програм хангамжийг чимээтэй хослуулах боломжтой"
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "Flash _entire screen"
-msgstr "_Бүх дэлгэцийг гэрэлтүүлэх"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "Flash _window titlebar"
-msgstr "_Цонхны гарчиг самбарыг гэрэлтүүлэх"
-
-#: ../capplets/sound/sound-properties.glade.h:11
-msgid "Sound & Video Preferences"
-msgstr "Чимээ ба видеоны тохируулга"
-
-#: ../capplets/sound/sound-properties.glade.h:12
-msgid "Sound Capture:"
-msgstr "Дууны хүч:"
-
-#: ../capplets/sound/sound-properties.glade.h:13
-msgid "Sound Playback:"
-msgstr "Дуу тоглуулах:"
-
-#: ../capplets/sound/sound-properties.glade.h:14
-msgid "Sounds"
-msgstr "Чимээнүүд"
-
-#: ../capplets/sound/sound-properties.glade.h:15
-msgid "System Beep"
-msgstr "Системийн дохио"
-
-#: ../capplets/sound/sound-properties.glade.h:16
-msgid "Test"
-msgstr "Тест"
-
-#: ../capplets/sound/sound-properties.glade.h:17
-msgid "Testing Pipeline"
-msgstr "Pipeline шалгаж байна"
-
-#: ../capplets/sound/sound-properties.glade.h:18
-msgid "_Enable system beep"
-msgstr "Системийн дохио _идэвхжүүлэх"
-
-#: ../capplets/sound/sound-properties.glade.h:19
-msgid "_Play system sounds"
-msgstr "_Системд дуу тоглуулах"
-
-#: ../capplets/sound/sound-properties.glade.h:20
-msgid "_Visual system beep"
-msgstr "_Системийн дохиог харуулах"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:368
-msgid "Would you like to remove this theme?"
-msgstr "Та энэ загварыг устгахыг хүсч байна уу?"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:433
-msgid "Theme deleted succesfully. Please select another theme."
-msgstr "Загвар амжилттай устгагдлаа. Өөр сэдэв сонгоно уу."
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:442
-msgid "Theme can not be deleted"
-msgstr "Загвар устгагдсангүй"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:535
-msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
-msgstr ""
-"Таны системд загвар олдсонгүй. Энэ нь магад таны »Загвар тохируулга« эсвэл "
-"»gnome-themes« пакет зөв суугаагүй гэсэн үг."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:255
-msgid "This theme is not in a supported format."
-msgstr "Энэ загвар нь дэмжигдээгүй формат байна."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:273
-msgid "Failed to create temporary directory"
-msgstr "Түр зуурын директор үүсэх боломжгүй байна"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:294
-msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
-msgstr ""
-"Загвар суухгүй байна. \n"
-" bzip2 хэрэглээ суусангүй. "
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:313
-#: ../capplets/theme-switcher/gnome-theme-installer.c:352
-#: ../capplets/theme-switcher/gnome-theme-installer.c:432
-msgid "Installation Failed"
-msgstr "Суулгалт нурлаа"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:334
-msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
-msgstr ""
-"Загвар суухгүй байна. \n"
-"gzip хэрэглээ суусангүй. "
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:378
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "%s ГНОМЕ Загвар амжилттай суулаа"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:388
-msgid "The theme is an engine. You need to compile the theme."
-msgstr "Загвар бол үйл ажиллагааны нэгж юм. Та загварыг эмхтгэх хэрэгтэй."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:406
-msgid "The file format is invalid"
-msgstr "Файлын формат хүчингүй байна"
-
-#. TODO: currently cannot apply "gnome themes"
-#: ../capplets/theme-switcher/gnome-theme-installer.c:452
-#, c-format
-msgid ""
-"<span weight=\"bold\" size=\"larger\">The theme \"%s\" has been installed.</"
-"span>\n"
-"\n"
-"Would you like to apply it now, or keep your current theme?"
-msgstr ""
-"<span weight=\"bold\" size=\"larger\">Загвар \"%s\" суусан байна.</span>\n"
-"\n"
-"Та үүнийг хэрэглэхийг хүсэж байна уу одоогийнхыгоо авч үлдэх үү?"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:455
-msgid "Keep Current Theme"
-msgstr "Одоогийн загварыг авч үлдэх"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:457
-msgid "Apply New Theme"
-msgstr "Шинэ загварыг хэрэглэх"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:531
-msgid "No theme file location specified to install"
-msgstr "Файлын загвар суулгах байрлалыг тодорхойлоогүй байна"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:546
-msgid "The theme file location specified to install is invalid"
-msgstr "Файлын загвар суулгах байрлал хүчингүй"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:566
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"Загварыг суулгахад орох боломжгүй зөвшөөрөл:\n"
-"%s"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:587
-msgid "The file format is invalid."
-msgstr "Файлын формат хүчингүй байна."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:614
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-"%s бол загварын файлууд суулгах зам. Тиймээс тэр эх байрлалаар хэрэглэгдэх "
-"боломжгүй"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:686
-msgid "Custom theme"
-msgstr "Хэвшмэл загвар"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:686
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr "Та »Загвар хадгалах«-товчийг товшиж энэ загварыг хадгалаж болно."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1604
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr ""
-"Таны системд стандарт загварын схем олдсонгүй. Энэ нь таныг Metacity "
-"суулгаагүй эсвэл таны GConf алдаатай тохируулагдсаныг зааж байна."
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:73
-msgid "Theme name must be present"
-msgstr "Загварийн нэр үзүүлэгдэх ёстой"
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:144
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Завар байна. Та үүнийг солих уу?"
-
-# CHECK
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr "Ажлын талбарын янз бүрийн хэсгүүдийн хувьд загвар тогтоох"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "Загвар"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "<b>You do not have permission to change theme settings</b>"
-msgstr "<b>Танд загварын тохиргоо өөрчилөх эрх алга</b>"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "Apply _Background"
-msgstr "_Дэвсгэрийг хэрэглэх"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Apply _Font"
-msgstr "_Бичгийг хэрэглэх"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Controls"
-msgstr "Хяналтууд"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Icons"
-msgstr "Эмблемүүд"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "Save Theme"
-msgstr "Загвар хадгалах"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "Save _Background Image"
-msgstr "_Дэвсгэр зургийг хадгалах"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-msgid "Select theme for the desktop"
-msgstr "Ажлын талбары загварыг сонгох"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-msgid "Theme Details"
-msgstr "Загварын тодруулга"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-msgid "Theme Preferences"
-msgstr "Загвар тохируулгууд"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "Theme _Details"
-msgstr "Загвар _тодруулга"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "This theme does not suggest any particular font or background."
-msgstr "Энэ загвар тодорхой дэвсгэр болон фонтыг санал болгохгүй байна."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-msgid "This theme suggests a background:"
-msgstr "Энэ загвар тохирох дэвсгэрийг санал болгож байна:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-msgid "This theme suggests a font and a background:"
-msgstr "Энэ загвар тохирох дэвсгэр болон фонтыг санал болгож байна:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-msgid "This theme suggests a font:"
-msgstr "Энэ загвар тохирох фонтыг санал болгож байна:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-msgid "Window Border"
-msgstr "Цонхны хүрээ"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-msgid "_Description:"
-msgstr "_Тодорхойлолт:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "_Install Theme..."
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
 msgstr "Загвар _суулгах..."
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-msgid "_Install..."
-msgstr "_Суулгаж байна..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-msgid "_Name:"
-msgstr "_Нэр:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-msgid "_Revert"
-msgstr "_Урвуулах"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-msgid "_Save Theme..."
-msgstr "Загвар _хадгалах..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:24
-msgid "theme selection tree"
-msgstr "Загвар сонголтын мод"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
-msgstr "Х.програмийн багажны ба цэсний самбарын харагдалтыг тохируулах"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "Цэс ба багажны самбар"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
-msgstr "<b>Харьцаа ба харагдац</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-msgid "<b>Preview</b>"
-msgstr "<b>Урьд. харах</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "_Тасдах"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-msgid "Icons only"
-msgstr "Зөвхөн эмблем"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "Цэс ба багажны самбарын тохируулга"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "Шинэ файл"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Файл нээх"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Файл хадгалах"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr "Цэсэнд _тэмдэгүүдийг харуулах"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-msgid "Text below icons"
-msgstr "Эмблемийн доор текст"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-msgid "Text beside icons"
-msgstr "Эмблемийн дэргэд текст"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-msgid "Text only"
-msgstr "Зөвхөн текст"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
-msgid "Toolbar _button labels:"
-msgstr "Түүлбар _товчны бичээс:"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_Хуулах"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
-msgstr "Салгах _боломжит багажны самбар"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
-msgstr "_Боловсруулах"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
-msgstr "_Боловсруулах боломжтой цэсний хурдасгуур"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "_Файл"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_Шинэ"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
 msgstr "Нэ_эх"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "_Буулгах"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "Хэ_влэх"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "_Дуусгах"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "Ха_дгалах"
-
-#: ../capplets/windows/gnome-window-properties.c:385
-#, c-format
-msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
-msgstr ""
-"<b>Таны цонхны менежерийн тохируулга х.программыг эхлүүлж чадахгүй байна</"
-"b>\n"
-"\n"
-"%s"
-
-#: ../capplets/windows/gnome-window-properties.c:642
-msgid "C_ontrol"
-msgstr "_Хяналт"
-
-#: ../capplets/windows/gnome-window-properties.c:647
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:653
-msgid "H_yper"
-msgstr "H_yper"
-
-#: ../capplets/windows/gnome-window-properties.c:660
-msgid "S_uper (or \"Windows logo\")"
-msgstr "_Супер (эсвэл \"Цонхны тэмдэг\")"
-
-#: ../capplets/windows/gnome-window-properties.c:667
-msgid "_Meta"
-msgstr "_Мета"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Шилжүүлэгч товч</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>Толгой самбарны үйлдлүүд</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Цонхны сонголт</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr "Цонх зөөхдөө дараах товчийг дараад барьж цонхонд хүрнэ:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Цонхны тохируулга"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "Энэ үйлдлийг гүйцэтгэхдээ толгой самбарыг _давхар товшино:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "_Өргөлтийн өмнөх хүлээлт:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "Идэвхижсэн цонх тодорхой хугацааны дараа ө_ргөгдөх"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Хулганыг дээгүүр нь хөдөлгөхөд цонхнуудыг сонгоно"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "Цонхны тохируулгыг хийх"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "Цонх"
-
-#: ../control-center/control-center-categories.c:287
-msgid "Others"
-msgstr "Бусад"
-
-#: ../control-center/control-center.c:93
-msgid "Desktop Preferences"
-msgstr "Ажлын талбарын тохируулгууд"
-
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr "GNOME-Хянах төв"
-
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "GNOME-тохируулгын хэрэгсэл"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "Дуу"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:406
-msgid "Slow Keys Alert"
-msgstr "Удаашруулах товчлуурын дохио"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:407
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-msgstr ""
-"Та Shift товчлуурыг 8 секунт даржээ. Энэ нь гарын ажиллагаанд нөлөөлдөг "
-"удаашруулах товчлуурын үйл ажиллагааны хослол юм."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:409
-msgid "Do you want to activate Slow Keys?"
-msgstr "Та удаашруулах товчлуурыг идэвхижүүлэхийг хүсч байна уу?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Do you want to deactivate Slow Keys?"
-msgstr "Та удаашруулах товчлуурыг идэвхигүйжүүлэхийг хүсч байна уу?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
-msgid "_Activate"
-msgstr "_Идэвхижүлэх"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
-msgid "_Deactivate"
-msgstr "_Идэвхгүй болгох"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
-msgid "Do_n't activate"
-msgstr "_Бүү идэвхижүүл"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
-msgid "Do_n't deactivate"
-msgstr "_Бүү идэвхигүйжүүл"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:421
-msgid "Sticky Keys Alert"
-msgstr "Наалт товчлуурын дохио"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:422
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-"Та Shift товчлуурыг 5 удаа дараалуулан даржээ. Энэ нь таны гарын ажиллагаанд "
-"нөлөөлдөг наалт товчлуурын үйл ажиллагааны хослол юм."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:424
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-"Та хоёр товчлуурыг нэг удаа эсвэл Shift товчлуур 5 удаа дараалуулан даржээ. "
-"Энэ нь таны гарын ажиллагаанд нөлөөлдөг наалт шорткатын үйл ажиллагааг "
-"унтраана."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:426
-msgid "Do you want to activate Sticky Keys?"
-msgstr "Та наалт товчлуурыг идэвхижүүлэхийг хүсч байна уу?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:427
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr "Та наалт товчлуурыг идэвхгүйжүүлэхийг хүсч байна уу?"
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:74
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing the mouse pointer theme."
-msgstr ""
-"\"%s\" лавлах үүсгэж чадсангүй.\n"
-"Энэ нь түүчээний загварыг өөрчилөхөд шаардлагатай."
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:96
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-"\"%s\" лавлах үүсгэж чадсангүй.\n"
-"Энэ нь түүчээ өөрчилөхөд шаардлагатай."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:208
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr "Шорткатын (%s) хувьд олон дахин үйлдэл тогтоох\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:221
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr "Шорткат (%s) нь олон удаагаар тогтоогддог\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:227
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr "Шорткат (%s) бүрэн бус\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:255
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr "Шорткат (%s) хүчингүй\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:291
-#, c-format
-msgid "It seems that another application already has access to key '%u'."
-msgstr "Өөр програм хэдийнээ '%u' түлхүүрт олгогдсон бололтой байна."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:360
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr "Шорткат (%s) хэдийнээ хэрэглээнд байна\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:435
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr "(%2$s) товчлуурт холбогдсон (%1$s)-г ажиллуулах үед алдаа гарлаа"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:105
-#, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-"XKB-тохиргоо идэвхжих үед алдаа гарлаа.\n"
-"Энэ нь олон төрлийн нөхцөл байдлаас болно.\n"
-"-libxklavier номын сангийн програмын алдаа\n"
-"-Х Серверийн алдаа (xkbcomp, xmodmap utilities)\n"
-"-Х Сервер libxkbfile- тэй ажиллахад тохирохгүй\n"
-"\n"
-"Х Серверийн хувилбарын өгөгдөл:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"Хэрвээ та энэ байдлыг алдаагаар тайлагнахыг хүсвэл дараахыг хавсаргана уу:\n"
-"- <b>%s</b>-н үр дүн\n"
-"- <b>%s</b>-н үр дүн"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:119
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-"Та XFree 4.3.0 хэрэглэж байна.\n"
-"Нийлмэл XKB тохиргооны хувьд тодорхой бэрхшээлүүд байдаг.\n"
-"Энгийн тохиргоо хэрэглэх эсвэл XFree-н илүү шинэ хувилбар хэрэглэхийг "
-"оролдоно уу."
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:249
-msgid "Do _not show this warning again"
-msgstr "_Энэ сануулгыг дахин бүү харуул"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:263
-#, c-format
-msgid ""
-"<b>The X system keyboard settings differ from your current GNOME keyboard "
-"settings.</b>\n"
-"\n"
-"Expected was %s, but the the following settings were found: %s.\n"
-"\n"
-"Which set would you like to use?"
-msgstr ""
-"<b>Х систем гарын тохируулга нь таны одоогийн  ГНОМЕ гарын тохируулгаас "
-"ялгаатай.</b>\n"
-"\n"
-"%s тохирох байсан боловч дараах тохиргоотой байна: %s.\n"
-"\n"
-"Та алийг нь хэрэглэхийг хүсч байна вэ?"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:286
-msgid "Use X settings"
-msgstr "Х тохиргоог хэрэглэх"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:288
-msgid "Keep GNOME settings"
-msgstr "GNOME тохиргоог хэрэглэх"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:118
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
-msgstr ""
-"Тушаал биелсэнгүй: %s\n"
-"Энэ тушаал байгаа эсэхийг нягтал."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:134
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-"Тооцоолуурыг унтуулах горимд оруулж чадсангүй.\n"
-"Тооцоолуураа зөв тохируулсан эсэхээ нягтлана уу."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:168
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-"Glade файл ачаалагдсангүй.\n"
-"Энэ хэвтүүл зөв суусан эсэхийг нягтлана уу."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:110
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-"Дэлгэцийг эхлүүлэхэд алдаа гарлаа:\n"
-"\n"
-"%s\n"
-"\n"
-"Дэлгэцийн энэ хугацаанд ажиллахгүй."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:120
-msgid "_Do not show this message again"
-msgstr "_Энэ мэдээг дахин бүү харуул"
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:127
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr " %s дууны файл %s жишээгээр ачаалагдсангүй"
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:212
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:260
-msgid "Cannot determine user's home directory"
-msgstr "Хэрэглэгчийн гэр лавлахыг илрүүлж чадсангүй"
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:212
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr ""
-"GConf түлхүүр %s нь %s төрөлтэй боловч түүний тохирох төрөл нь %s байлаа\n"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-msgid "A_vailable files:"
-msgstr "_Боломжит файлууд:"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-msgid "Do _not show this warning again."
-msgstr "_Энэ сануулгыг дахин бүү харуул"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
-msgstr "modmap файлыг ачаалж байна"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
-msgstr "modmap файлыг ачаалахыг хүсч байна уу?"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr "_Ачаалах"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-msgid "_Loaded files:"
-msgstr "_Ачаалагдсан файлууд:"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr "Сигналын шугам үүсгэх үеийн алдаа."
-
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "Төрөл"
-
-#: ../libbackground/applier.c:256
-msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-msgstr ""
-"Дэвсгэр хэрэглэгчийн төрөл (bg_applier): »root« цонхны хувьд BG_APPLIER_ROOT "
-"эсвэл урьдчилан харахад BG_APPLIER_PREVIEW"
-
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr "Урьд.харах өргөн"
-
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr "Хэрэглэгч урьдчилан харах үеийн өргөн : Стандартаар 64."
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr "Урьд.харах өндөр"
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr "Хэрэглэгч урьдчилан харах үеийн өндөр : Стандартаар 48."
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Дэлгэц"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr "BGApplier зурагдах ёстой дэлгэц"
-
-#: ../libsounds/sound-view.c:43
-msgid "Login"
-msgstr "Логин"
-
-#: ../libsounds/sound-view.c:44
-msgid "Logout"
-msgstr "Гарах"
-
-#: ../libsounds/sound-view.c:45
-msgid "Boing"
-msgstr "Boing"
-
-#: ../libsounds/sound-view.c:46
-msgid "Siren"
-msgstr "Siren"
-
-#: ../libsounds/sound-view.c:47
-msgid "Clink"
-msgstr "Жингэнэх"
-
-#: ../libsounds/sound-view.c:48
-msgid "Beep"
-msgstr "Дохио"
-
-#: ../libsounds/sound-view.c:49
-msgid "No sound"
-msgstr "Дуугүй"
-
-#: ../libsounds/sound-view.c:131
-msgid "Sound not set for this event."
-msgstr "Энэ үйлдэлд чимээ байхгүй"
-
-#: ../libsounds/sound-view.c:140
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package for a set of default sounds."
-msgstr ""
-"Энэ үйлдийн хувьд тогтоосон дууны файл алга.\n"
-"Та стандарт дуугаар авахыг хүсэж байвал »gnome-audio« пакетыг суулгана уу."
-
-#: ../libsounds/sound-view.c:151
-msgid "The sound file for this event does not exist."
-msgstr "Энэ үйлдийн хувьд дууны файл байхгүй."
-
-#: ../libsounds/sound-view.c:182
-msgid "Select Sound File"
-msgstr "Дууны файл сонгоно уу"
-
-#: ../libsounds/sound-view.c:202
-#, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "%s файл хүчингүй wav файл байна"
-
-#: ../libsounds/sound-view.c:359
-msgid "System Sounds"
-msgstr "Системийн чимээ"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "»%s« цонхны менежер тохируулгын хэрэгслээр бүртгүүлээгүй байна\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Томсгох"
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Эвхэх"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr "»text/plain« ба »text/*« -н хувьд MIME-тодорхойлогчийг хадгалах"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr "»text/plain« ба »text/*«-тодорхойлогчуудын зэрэгцүүлэх (Sync)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "E-mail"
-msgstr "Э-Шуудан"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "E-mail's shortcut."
-msgstr "Э-шуудангийн шорткат."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Eject"
-msgstr "Түлхэх"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Eject's shortcut."
-msgstr "Түлхэлтийн шорткат."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "Home folder"
-msgstr "Гэр хавтас"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "Home folder's shortcut."
-msgstr "Хувийн гэрийн хавтасны шорткат."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Launch help browser"
-msgstr "Тусламж хөтчийг эхлүүлэх"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-msgid "Launch help browser's shortcut."
-msgstr "Тусламж хөтөчийн шорткот эхлүүлэх."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-msgid "Launch web browser"
-msgstr "Вэб хөтөч эхлүүлэх"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-msgid "Launch web browser's shortcut."
-msgstr "Вэб хөтөч шорткат эхлүүлэх"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-msgid "Lock screen"
-msgstr "Дэлгэц түгжих"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-msgid "Lock screen's shortcut."
-msgstr "Дэлгэц түгжих шорткат"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-msgid "Log out"
-msgstr "Гарах"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-msgid "Log out's shortcut."
-msgstr "Гарах шорткат."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-msgid "Next track key's shortcut."
-msgstr "Дараагийн гарчиг шорткат"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-msgid "Pause"
-msgstr "Зогсоолт"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-msgid "Pause key's shortcut."
-msgstr "Зогсоолтын шорткат."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-msgid "Play (or play/pause)"
-msgstr "Тоглуулах (Тоглуулах/Зогсоох)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Play (or play/pause) key's shortcut."
-msgstr "Тоглуулах (Тоглуулах/Зогсоох) шорткат."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Previous track key's shortcut."
-msgstr "Өмнөх гарчиг шорткат."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Загварын тодруулга"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Хайх"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Search's shortcut."
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Хаагдсан"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_Эргүүлэлт:"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Тусламж харуулах"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "_Дэвсгэрийг хэрэглэх"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Дэлгэц"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Туурга цаасгүй"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Чимээнүүд"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Шорткат"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Гарын шорткат"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Дуугүй"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Сануулгын төрөл"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Х._программуудын фонт:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<i>Э-Шуудан</i>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Загвар:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Стандарт"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "_Дэвсгэрийг хэрэглэх"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Дэлгэцийн нарийвчлал"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Том цагаан түүчээ"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Файлыг хуулж байна"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Оруулж ирэх"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Нэмэх..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "_Ачаалагдсан файлууд:"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "_Устгах"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Дэлгэрэнгүй"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "Минут"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Дунд"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "Минут"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "Минут"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Нэг өнгөт"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Зургийг сонгох"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Сонгох"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Дуугүй"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_Завсар:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Хайх"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "_Хоцролт:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
 msgstr "Хайлтын шорткат."
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Skip to next track"
-msgstr "Дараагийн дуу алгасах"
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Skip to previous track"
-msgstr "Өмнөх дуу алгасах"
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
-msgid "Sleep"
-msgstr "Унтуулах"
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-msgid "Sleep's shortcut."
-msgstr "Унтуулах шорткат"
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Stop playback key"
-msgstr "Тоглуулалт таслах товчлуур"
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Stop playback key's shortcut."
-msgstr "Тоглуулалт таслах шорткат."
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Хаагдсан"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "Секундүүд"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Хуа_нли:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Ажлын талбары дэвсгэрийн тохиргоог өөрчилөх"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "КМэйл"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Хуа_нли:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Эрхэмлэсэн х.программууд"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Та өөрийн стандарт х.программыг сонгоно уу"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "_Бичгийг хэрэглэх"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<b>Хулганы чиглэл</b>"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Нарийвчлал:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Хурд _шинэчилэх:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Хуваарилсан"
+
+# CHECK
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Хэсэгчилэл бэлэн"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Хэнээс"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "Минут"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "Хэнд:"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Төхөөрөмжүүд"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Нэр:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Төрөл"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "ГНОМЕ Терминал"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Цонх"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Төхөөрөмжүүд"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Төхөөрөмжүүд"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_Хэрэглэгчийн нэр:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "_Тухай"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Дуу хаах"
+
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Дуу сулруулах"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-msgid "Volume down's shortcut."
-msgstr "Дуу сулруулах шорткат."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Volume mute"
-msgstr "Дуу хаах"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Volume mute's shortcut"
-msgstr "Дуу хаах шорткат"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
-msgid "Volume step"
-msgstr "Дуу чангаруулалтын алхам"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume step as percentage of volume."
-msgstr "Дуу чангаруулалтын алхамын чимээний хувь"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Дуу чангаруулах"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume up's shortcut."
-msgstr "Дуу чангаруулах шорткат."
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
-msgid "Display a dialog when there are errors running the screensaver"
-msgstr "XScreenSaver ажиллаж байх үед алдаа гарвал диалог харуулах"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-msgid "Run screensaver at login"
-msgstr "Бүртгүүлэхэд дэлгэц гамнагч ажиллуулах"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
-msgstr "Эхлэлийн алдааг харуулах"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
-msgid "Start screensaver"
-msgstr "Дэлгэц гамнагч эхлүүлэх"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
-msgstr "Үсгийн цуглуулгыг ажиллуулах бүрд гар дахин ачаалагдана."
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
-msgstr "modmap-ийн файлын жагсаалт $HOME лавлахад байна."
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
-msgstr "Цонхны үүсэлтэд стандарт бүлэг шаардлагатай"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr "Цонх тус бүрийн бүлгийг хадгалан удирдана"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
-msgid "Keyboard Update Handlers"
-msgstr "Гарын шинэчлэлийг удирдах програм"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
-msgid "Keyboard layout"
-msgstr "Гарын байрлал"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
-msgid "Keyboard model"
-msgstr "Гарын загвар"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
-msgid "Keyboard options"
-msgstr "Гарын сонголтууд"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
-msgstr "Системээс gconf дахь XKB тохиргоог аль болох түргэн хасах уу (илүүдэл)"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
-msgstr "Тодорхойлогчыг байрлалын бүлгүүдтэй хадгалах/сэргээх"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
-msgstr "Бүлэг нэрийн оронд байрлалын нэрийг харуулах"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
 msgstr ""
-"Групп нэрийн оронд layout нэрийг харуулах (олон байрлалуудыг зөвхөн XFree "
-"хувилбарт дэмждэг)"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr "\"X sysconfig changed\" анхааруулах мэдээг үгүйсгэх"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid "The Keyboard Preview, X offset"
-msgstr "Гарын тольдолт, X офсет"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
-msgid "The Keyboard Preview, Y offset"
-msgstr "Гарын тольдолт, Y офсет"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
-msgid "The Keyboard Preview, height"
-msgstr "Гар тольдолт, өндөр"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "The Keyboard Preview, width"
-msgstr "Гар тольдолт, өргөн"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:18
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
 msgstr ""
-"Удахгүй gconf дахь гарын тохиргоо дарагдана (систем тохиргооноос) Энэ "
-"түлхүүр нь GNOME 2.12-оос хойш буруушаагдах болсон, стандарт системийн "
-"тохиргоог хадгалах загвар, байрлал ба сонголтуудыг үлдээнэ үү."
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:19
-msgid "keyboard layout"
-msgstr "Гарын засвар"
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Тоглуулах (Тоглуулах/Зогсоох)"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:20
-msgid "keyboard model"
-msgstr "Гарын загвар"
+#: panels/keyboard/00-multimedia.xml.in:16
+#, fuzzy
+msgid "Pause playback"
+msgstr "Дуу тоглуулах:"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:21
-msgid "modmap file list"
-msgstr "modmap файлын жагсаалт"
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Тоглуулалт таслах товчлуур"
 
-#: ../typing-break/drw-break-window.c:213
-msgid "_Postpone break"
-msgstr "Завсарлага _зөөх"
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Өмнөх дуу алгасах"
 
-#: ../typing-break/drw-break-window.c:260
-msgid "Take a break!"
-msgstr "Завсарла!"
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Дараагийн дуу алгасах"
 
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:128
-msgid "/_Preferences"
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Түлхэх"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "Бичих үеийн завсарлага"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Дараагийн дуу алгасах"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Өмнөх дуу алгасах"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Вэб хөтөч эхлүүлэх"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Тусламж хөтчийг эхлүүлэх"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Стандарт тохиргоо"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Вэб хөтөч эхлүүлэх"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Гэр хавтас"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Хайх"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Систем"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Гарах"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Дэлгэц түгжих"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Хялбарчилал"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "Хэмжээг өөрчлөх"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Хэмжээг өөрчлөх"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "_Дэлгэц дээрхи гар"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Сонголтууд"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
 msgstr "/_Тохируулга"
 
-#: ../typing-break/drwright.c:129
-msgid "/_About"
-msgstr "_Тухай"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Гарын байрлал"
 
-#: ../typing-break/drwright.c:131
-msgid "/_Take a Break"
-msgstr "/_Засарла"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Устгах"
 
-#: ../typing-break/drwright.c:488
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "Дараагийн завсарлага хүртэл %d минут"
-msgstr[1] "Дараагийн завсарлага хүртэл %d минут"
-
-#: ../typing-break/drwright.c:492
-msgid "Less than one minute until the next break"
-msgstr "Дараагийн завсарлага хүртэл нэг хүрэхгүй минут"
-
-#: ../typing-break/drwright.c:579
-#, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
 msgstr ""
-"Цохилт-тодруулга диалог дараах алдааны шалтгааны улмаас нээгдэх боломжгүй: %s"
 
-#: ../typing-break/drwright.c:599
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "Richard Hult &lt;richard@imendio.com&gt; бичив."
-
-#: ../typing-break/drwright.c:600
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Anders Carlsson Eye candy -г нэмсэн."
-
-#: ../typing-break/drwright.c:623
-msgid "Typing Monitor"
-msgstr "Шивэлт шалгагч"
-
-#: ../typing-break/drwright.c:625
-msgid "A computer break reminder."
-msgstr "Компьютерийн хуьд завсарлага сануулагч."
-
-#: ../typing-break/main.c:100
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"Мэдээлэл харуулахаар дэлгэцэнд бичихэд сонордуулга муж хэрэглэдэг. Таны "
-"удирдах самбарт сонордуулгын муж байхгүй шиг байна. Та удирдах самбарынхаа "
-"дээр очиж хулганы баруун товшуураар 'Самбарт нэмэх' дараа нь 'Сонордуулга "
-"муж'-г сонгож 'Нэмэх'-ийг товшино."
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "Чихний чимэг болсон аялгуу сайхан монгол хэл. 0123456789"
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:276
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Хулгана товчлуур"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Гарын шорткат"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Үйлдэл"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Шорткат"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Шорткат"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Шорткат"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Гарын шорткат"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Устгах"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Нэр:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Т_ушаал:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Шорткат"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Шорткат"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_Хаах"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_Стандартыг сэргээх"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Гар"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "MIME-төрлийн мэдээлэл"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Стандарт тохиргоо"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "баруун"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Түүчээний хэмжээ:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Хулгана"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Хулгана товчлуур"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "Ху_рдасгалт:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Ху_рдасгалт:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Х._программуудын фонт:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Төхөөрөмжүүд"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Үйлдэл"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Холбогдсонгүй"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Сонголтууд"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Нэвтрэх үг:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "_Одоогийн нууц үг:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Хослолын горим"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Түүчээ анивчих хурд"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Хаяг"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Хаяг"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Хаяг"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Стандарт түүчээ"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Нэр:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Хаяг:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Хаяг:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Хаагдсан"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Хаяг"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Хаяг"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "Минут"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "_Идэвхижүлэх"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "Хаяг"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "_HTTP-итгэмжлэгч:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "_HTTP-итгэмжлэгч:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP-итгэмжлэгч:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "S_ocks-хост:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "<b>Хостын жагсаалтаас татгалзах</b>"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "_HTTP-итгэмжлэгч:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "_HTTP-итгэмжлэгч:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP-итгэмжлэгч:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Автомат тохируулгын _URL:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Нэвтрэх үг:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Гарын сонголтууд"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "Батлагдлаа!"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Гэрчилгээ хэрэглэнэ</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "_Хэрэглэгчийн нэр:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Нэвтрэх үг:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Шинэ нэвтрэх үг:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Хувилбар:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Хувилбар:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_Баталгаажуулах"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Шинэ нэвтрэх үгийг дахин бичнэ үү:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_Баталгаажуулах"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Төрөл"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Стандарт"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Систем"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Эргүүлэлт:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Чимээнүүд"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Дэлгэц түгжих шорткат"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Дэлгэц түгжих шорткат"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Гэрчилгээ хэрэглэнэ</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "Минут"
+msgstr[1] "Минут"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "Минут"
+msgstr[1] "Минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "Минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "Минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "Минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "Минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "Минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "Минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "Минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "Минут"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Төхөөрөмжүүд"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Хослолын горим"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Дэлгэц дүүрэн"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Дэлгэц"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Хүлээлт:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "Түүчээнүүд"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "Түүчээнүүд"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Дуугүй"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Батлагдлаа!"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "_Хэрэглэгчийн нэр:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Үйлдэл"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Суулгалт нурлаа"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Сонгох"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_Баталгаажуулах"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Баталгаажуулах"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Тест"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Сонголтууд"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Фонтны дүрслэлийн тодруулга"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "_Стандартыг сэргээх"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Модел"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Энэ апплет зөв суусан эсэхийг нягтлана уу"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Түүчээнүүд"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "энгийн"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Бүх файлууд"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Тольдох:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "_Хэлтэс:"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "Гарах"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Дэлгэц дүүрэн"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Үйлдэл"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Төрөл:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Дэлгэц"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Дэлгэц түгжих"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Дэлгэц"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Дэлгэц"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "%d дэлгэцийн тохиргоо\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Гарын сонголтууд"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Бусад"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Үйлдэл"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Х._программуудын фонт:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Хайлтын шорткат."
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Ажлын талбар"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Устгах"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Нэвтрэх үг:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Ажлын талбар"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Хэрэглэгчийн гадаргуу жолоодогч"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Холбогдсонгүй"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Хуулах"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Баталгаажуулах"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Хэрэглэгчийн нэр:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Системийн чимээ"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Дуу хаах"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Төхөөрөмжүүд"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Тест"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Итгэмжлэгчийн тохируулга"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Төхөөрөмжүүд"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Дуу"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Сануулгын товчнууд"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Аудио"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Нэр:"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "Загвар:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "Төрөл:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "Хэмжээ:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "Хувилбар:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Төхөөрөмжүүд"
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "Зохиогчийн эрх:"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "Тодорхойлолт:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:408
-#, c-format
-msgid "usage: %s fontfile\n"
-msgstr "Хэрэглээ: %s фонт файл\n"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
-msgstr "Програмны бичгээр хэрэглэх"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
-msgid "Sets the default application font"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Төхөөрөмжүүд"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>Анивчдаг түүчээ</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Түүчээг текст талбар болон текст дотор а_нивчуулах"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "Х_урд:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Түүчээ анивчих хурд"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Түүчээ анивчих хурд"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Шорткат"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Хүлээлт:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Шорткат"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Хязгаар:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Жижиг"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Том"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Товчлуурын давталт</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Хэрвээ товчлуур доош дарагдсан бол түүнийг _давтах"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Түлхүүр давтагдах хурд"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Түлхүүр давтагдах хурд"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Шивэлт шалгагч"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Наалт товчлуурын дохио"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Хоёр товчлуур _зэрэг дарагдвал хаалттай"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Өөрчлөгчийг албадах үед _чимээ өгөх"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Удаашруулах товчлуурын дохио"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Шорткат"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Өөрчлөгчийг албадах үед _чимээ өгөх"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Хэрвээ түлхүүр ...бол чимээ өгөх:"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Түлхүүрүүдийг _хүлээж аваагүй бол чимээ өгөх"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Хулгана товчлуур"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Товчлуурын давхар тогшилтыг дараах дотор х_эрэгсэхгүй байх:"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Шорткат"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Хялбарчилал"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Том"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "_Дэлгэц уншигч"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Чимээнүүд"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Хэмжээг өөрчлөх"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "_Дэлгэц дээрхи гар"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Товчлуурын давталт</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Анивчдаг түүчээ</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Хулгана товчлуур"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Том түүчээ"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<b>Давхар товшилтын Х/И завсар</b>"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "_Бүх дэлгэцийг гэрэлтүүлэх"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "_Бүх дэлгэцийг гэрэлтүүлэх"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Дэлгэц дүүрэн"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Сонголтууд"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_Өсгөгч"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "_Өсгөгч"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "_Дэлгэц уншигч"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "_Өсгөгч"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Холбоо"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Хаах"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Дүүрэн"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "_Бүү идэвхигүйжүүл"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Шинэ нэвтрэх үг:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Дууны файл сонгоно уу"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Хаах"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Тольдох:"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Нууц үгээ өөрчлөх"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Өөрчлөлтүүд"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "_Одоогийн нууц үг:"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Шинэ нэвтрэх үг:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Нууц үгээ өөрчлөх"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Нууц үг хэтэрхий богино байна."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Шинэ нэвтрэх үг:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Бүтэн нэр"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_Боловсруулах"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Хяналтууд"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
 msgstr "Программын стандарт фонтыг сонгоно уу"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "OpenType бичгүүдээр бяцхан зураг загварт харуулах уу?"
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "PCF бичгүүдээр бяцхан зураг загварт харуулах уу?"
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Бусад"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "TrueType бичгүүдээр бяцхан зураг загварт харуулах уу?"
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "Type1-бичгүүдээр бяцхан зураг загварт харуулах уу?"
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Дуугүй"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"OpenType бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
-"тогтоо."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
 msgstr ""
-"PCF бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг тогтоо."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
-"TrueType бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
-"тогтоо."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
 msgstr ""
-"Type1 бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
-"тогтоо."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "OpenType-бичгүүдийг урьдчилан харах тушаал"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "PCF-бичгүүдийг урьдчилан харах тушаал"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "TrueType-бичгүүдийг урьдчилан харах тушаал"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Type1-бичгүүдийг урьдчилан харах тушаал"
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Товчнууд"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "OpenType-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "PCF-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "TrueType-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "Type1-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
-
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
-msgid "GNOME Font Viewer"
-msgstr "GNOME Фонт харагч"
-
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-msgstr "<span weight=\"bold\" size=\"larger\">Шинэ фонт хэрэглэхүү?</span>"
-
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr "Бичгийг хэрэглэх_гүй"
-
-#: ../vfs-methods/themus/apply-font.glade.h:4
+#: panels/wacom/button-mapping.ui:51
 msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"Энэ загвар нэгэн шинэ фонтын хэв суулгахыг санал болгож байна. Фонтны хэвийн "
-"хэлбэр доор харагдаж байна."
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-msgid "_Apply font"
-msgstr "_Бичгийг хэрэглэх"
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
 
-#: ../vfs-methods/themus/theme-method.c:518
-msgid "Themes"
-msgstr "Загвар"
-
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "Тодорхойлолт"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
-msgstr "Цонхны агуулгын загвар"
-
-#: ../vfs-methods/themus/themus-properties-view.c:139
-msgid "Window border theme"
-msgstr "Цонхны хүрээний загвар"
-
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
-msgstr "Эмблемийн загвар"
-
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
-msgstr "СБЖЭӨҮЯ"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-msgid "Apply theme"
-msgstr "Загварыг хэрэглэх"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-msgid "Sets the default theme"
-msgstr "Стандарт загварыг сэргээх"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr "Хэрвээ утга үнэн бол суулгасан загварууд мини харагдана."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr "Хэрвээ утга үнэн бол загварууд мини харагдана."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:3
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
 msgstr ""
-"Суулгасан загваруудын мини харагдац үүсгэхийн тулд энэ тушаал гүйцэтгэгдэнэ."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
-msgstr "Загваруудын мини харагдац үүсгэхийн тулд энэ тушаал гүйцэтгэгдэнэ."
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr "Суулгасан загваруудыг мини харах тушаал"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr "Загваруудыг мини харах тушаал"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr "Суулгасан загваруудыг мини харах эсэх"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr "Загваруудыг мини харах эсэх"
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
 
-msgid "Show help options"
-msgstr "Тусламж харуулах"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Шивэлт шалгагч"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Товчнууд"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Товчнууд"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Товчнууд"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Үзэмж"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Голлосон"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Цонх"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Дуусгахдаа OK дээр дарна уу."
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Цонх"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Хаяг"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "Ха_дгалах"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Загварын тодруулга"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Загварын тодруулга"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Гар утас:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Загварын тодруулга"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_Баталгаажуулах"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Холбогч түлхүүрүүд нээлттэй"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Холболт хийгдэж байна..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Өөрчлөлтүүд"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Стандарт тохиргоо"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Дуусгах"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Хайх"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Өмнөх дуу алгасах"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Тохируулга"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgid "Image/label border"
+#~ msgstr "Зураг/Бичээсийн хүрээ"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "Сануулгын цонхонд зураг болон хаягийн хүрээний өргөн"
+
+#~ msgid "The type of alert"
+#~ msgstr "Сануулгын төрөл"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Сануулгын цонхонд товчлууруудыг харуулж байна"
+
+#~ msgid "Show more _details"
+#~ msgstr "Илүү _нарийвчилж харуулах"
+
+#~ msgid "About Me"
+#~ msgstr "Миний тухай"
+
+#~ msgid "No Image"
+#~ msgstr "Зураг байхгүй байна"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Хаягийн номны мэдээлэлд орох үед алдаа гарлаа\n"
+#~ "Протоколд Эволюшн Өгөгдөл Сервер орж чадахгүй байна"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Хаягийн дэвтэр нээгдэх боломжгүй"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "Үл мэдэгдэх логин ID, хэрэглэгчийн өгөгдөл магадгүй гэмтсэн байна"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "%s-ны тухай"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "Хүү санамсаргүй гацлаа"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO суваг унтраах боломжгүй : %s"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO суваг унтраах боломжгүй : %s"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr "Нууц үг таныг шинээр зөв нэвтрэхэд өөрчлөгдөнө! Дахин нэвтэрнэ үү."
+
+#~ msgid "That password was incorrect."
+#~ msgstr "Нууц үг буруу."
+
+#~ msgid "Your password has been changed."
+#~ msgstr "Таны нууц үг өөрчилөгдлөө."
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "Системийн алдаа: %s."
+
+#~ msgid "The password is too simple."
+#~ msgstr "Нууц үг хэтэрхий энгийн байна."
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "Хуучин болон шинэ нууц үг хэтэрхий төстэй байна."
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "Тоо юмуу эсвэл тусгай тэмдэгтийг агуулах ёстой."
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "Хуучин болон шинэ нууц үг ижил байна."
+
+#, c-format
+#~ msgid "Unable to launch /usr/bin/passwd: %s"
+#~ msgstr "/usr/bin/passwd ажиллахгүй байна: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "Холбоог эхлүүлэх боломжгүй"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "Системд алдаа гарсан байна"
+
+#~ msgid "Checking password..."
+#~ msgstr "Нууц үгийг шалгаж байна..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr ""
+#~ "Нууц үгээ өөрчлөхийн тулд <b>Нууц үгээ өөрчлөх</b> гэсэн товчин дээр "
+#~ "дарна."
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "<b>Шинэ нууц үг талбарт</b> нууц үгээ оруулна уу."
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "Нууц үгээ дахин <b>Шинэ нууц үгээ давт</b> талбарт оруулна уу."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "Хоёр нууц үг тохирохгүй байна."
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Home</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Яаралтай мэдээлэл</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Ажил</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Утас</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Вэб</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Ажил</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Нууц үгээ өөрчилөх</span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "Х_аяг:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "_Туслагч:"
+
+#~ msgid "C_ity:"
+#~ msgstr "Х_от:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "К_омпани:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Нэвт_рэх үгээ өөрчлөх..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "Нууц үгээ өө_рчлөх"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Х_от:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "У_лс:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "У_лс:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "Гэр:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _хайрцаг:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. хайрцаг:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Хувийн мэдээлэл"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Улс/Орон н_утаг:"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "Та нууц үгээ солих бол доор одоогийн нууц үгээ оруулаад "
+#~ "<b>Баталгаажуулалт</b> дээр дарна уу.\n"
+#~ "Ахин нэвтэрсэний дараа шинэ нууц үгээ оруулж, бататгахын тулд дахин "
+#~ "оруулаад <b>Нууц үг солих</b> дээр дарна уу."
+
+#~ msgid "Web _log:"
+#~ msgstr "Веб _лог:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_Ажил:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "Aжлын _факс:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "Zip/_Шуудангийн код:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Бүлэглэл:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Гэрийн хуудас:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Гэр:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Гэмтэл:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Удирдлага:"
+
+#~ msgid "_Profession:"
+#~ msgstr "_Мэргэжил:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_Улс/Орон нутаг:"
+
+#~ msgid "_Title:"
+#~ msgstr "_Гарчиг:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Ажил:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "_Zip/Шуудангийн код:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Дэмжлэг</b>"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>Санамж:</b> Энэ тохируулгын өөрчлөлтүүд таны дараагийн "
+#~ "нэвтрэлт хүртэл нөлөөлөхгүй.</i></small>"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Туслах Технологийн тохируулга"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Хаагаад _Гарах"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Эдгээр туслах технологуудыг нэврэлт бүрд эхлүүл:"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "Туслах технологуудыг _нээх"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "Нэвтрэлтэд ГНОМЕ-н туслах технологуудын дэмжилт боломжтой."
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Таны системд ямар ч тусламж технологи байхгүй байна. Та дэлгэц гар "
+#~ "хэрэглэхийг хүсвэл »gok« багцыг мөн дэлгэц уншилт ба томруулалтын функц "
+#~ "хэрэглэх бол »orca« багцыг тус тус суулгана уу."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Таны системд бүх боломжтой тусламж технологийг суулгаагүй байна. Та "
+#~ "дэлгэц гар хэрэглэхийг хүсвэл »gok« багцыг суулгана уу."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'orca' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Таны системд бүх боломжийн тусламж технологийг суулгаагүй байна. Та "
+#~ "дэлгэц уншилт ба томруулалтын функц хэрэглэх бол »orca« багцыг тус тус "
+#~ "суулгана уу."
+
+#, c-format
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "Хулгана тохируулах цонхыг эхлүүлэхэд алдаа гарлаа: %s"
+
+#, c-format
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "AccessX-тохируулга '%s' файлаас импортлогдох боломжгүй байна"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Тохиргооны файлын шинжийг оруулах"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Гарт хялбар хандалтын тохируулга хийх"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Энэ систем XKB-өргөтгөлгүй юм шиг байна. Гарын хялбар хандалт нь "
+#~ "үүнгүйгээр баталгаажиж чадахгүй."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>_Хязгаар товчлуурууд боломжтой</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>_Удаан товчлуурууд боломжтой</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>_Хулгана түлхүүр боломжтой</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>_Давталт түлхүүрүүд боломжтой</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>_Наалттай түлхүүрүүд боломжтой</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Шинжүүд</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Сэлгэгч түлхүүрүүд</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Үндсэн"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr ""
+#~ "Гарын а_жиллагааны хэрэгслүүд идэвхижих эсвэл хаагдах үед чимээ өгөх"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "LED асахад нэг чимээ, унтрахад хоёр чимээ өгөх."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Товчлуур даралт ба түүчээний _хөдөлгөөний хоорондын хүлээлт"
+
+#~ msgid "Filters"
+#~ msgstr "Шүүлтүүр"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Нэг товчлуурын үргэлжилсэн даралтыг хэрэглэгчийн тогтоосон хугацаан дотор "
+#~ "хэрэгсэхгүй байх."
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Гарын хялбар хандалтын Тохиргоо (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Хулганы заагчийн ма_ксимал хурд:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Хулгана _Тохируулгууд..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Хэрэглэгчийн тодорхойлсон хугацаанд түлхүүрүүдийг дарсны дараа хүлээн "
+#~ "зөвшөөрнө."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Дараалсан товчлууруудын хослол дарснаар зэрэг товчилуур дарах үйлдлийг "
+#~ "гүйцэтгэнэ."
+
+#~ msgid "S_peed:"
+#~ msgstr "Х_урд:"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Максимум хурд хүртэл хур_дасгах хугацаа:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Хулганы удирдлагад гарын тооны машины хэсгийг хэрэглэх."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "Хэрвээ дараахад хэрэглэгдээгүй бол _хаах:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "_Гарын хялбар тусламжийн ажиллагаа боломжтой"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Ажиллагааны тохируулгыг _импортлох..."
+
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "Товчлуурын даралтыг _зөвхөн дараахын хувьд зөвшөөрөх:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "Тохируулга шалгалтын төрлүүд:"
+
+#~ msgid "_accepted"
+#~ msgstr "_зөвшөөрөгдсөн"
+
+#~ msgid "_pressed"
+#~ msgstr "_дарагдсан"
+
+#~ msgid "_rejected"
+#~ msgstr "бу_цаагдсан"
+
+#~ msgid "characters/second"
+#~ msgstr "Тэмдэгт/Секунд"
+
+#~ msgid "milliseconds"
+#~ msgstr "Миллисекунд"
+
+#~ msgid "pixels/second"
+#~ msgstr "Цэгүүд/Секунд"
+
+#~ msgid "Desktop Background"
+#~ msgstr "Ажлын талбарын дэвсгэр"
+
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>Ажлын талбарын _Туурга цаас</b>"
+
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>_Ажлын талбарын өнгө</b>"
+
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Ажлын талбарын дэвсгэрийн тохируулгууд"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Өнгө тодорхойлох цонхыг нээх"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Туурга цаас нэмэх"
+
+#~ msgid "_Finish"
+#~ msgstr "_Дуусгах"
+
+#~ msgid "_Style:"
+#~ msgstr "_Загвар:"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Тусламж үзүүлэхэд алдаа гарлаа: %s"
+
+#~ msgid "Tiled"
+#~ msgstr "Дүүргэн"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Босоо шугамдсан"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Хэвтээ шугамдсан"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Aрын фон нэмэх"
+
+#~ msgid "Images"
+#~ msgstr "Зургууд"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "цэг"
+#~ msgstr[1] "цэгүүд"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Тохируулгын менежер »gnome-settings-daemon« эхлүүлэх боломжгүй байна.\n"
+#~ "GNOME-менежергүйгээр хэд хэдэн тохируулга гүйцэлдэхгүй байх боломжтой. "
+#~ "Энэ нь Bonobo -той эсвэл  GNOME бус (ж.нь. KDE-) тохируулгын менежер "
+#~ "хэдийнэ идэвхижих ба GNOME тохируулгын менежертэй зөрчилдөнө."
+
+#, c-format
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "'%s' stock эмблемийг ачаалах боломжгүй \n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Тохируулгыг хэрэглээд гарах"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Хүлээн авсан тохируулгыг олоод хадгалах"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Файл хуулж байна: %u-ийн %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s'-г хуулж байна"
+
+#~ msgid "From URI"
+#~ msgstr "URI хаягаас"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI яг одоо дамжуулагдаж байна"
+
+#~ msgid "To URI"
+#~ msgstr "URI руу"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI одоогоор дамжуулагдаж байна"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Дуусч буй дамжууллын хэсэгчилэл"
+
+#~ msgid "Current URI index"
+#~ msgstr "Идэвхитэй URI-жигсаалт"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Идэвхитэй URI-жигсаалт - 1-р эхэлж байна"
+
+#~ msgid "Total URIs"
+#~ msgstr "Нийт URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "URI -н нийт тоо"
+
+#~ msgid "Key"
+#~ msgstr "Түлхүүр"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Энэ онцлог засварлагч хавсаргагдсан GConf-түлхүүр"
+
+# CHECK upto line 505
+#~ msgid "Callback"
+#~ msgstr "Эргэх хүсэлт"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Хэрвээ түлхүүрийн утга өөрчлөгдвөл эргэх хүсэлт гүйцэтгэх"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf-өөрчлөлтүүд GConf-Client цааш дамжуулахад хэрэглэх өгөгдлийг агуулж "
+#~ "байна"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Widget рүү эргэх хүсэлт хөрвүүлэлт"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ " GConf -оос Widget рүү хийгдэх өгөгдөлийн хөрвүүлэлтийн үед хийгдэх эргэх "
+#~ "хүсэлт"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Widget ээс эргэх хүсэлт хөрвүүлэлт"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Widget-ээс GConf-рүү хийгдэх өгөгдөлийн хөрвүүлэлтийн үед хийгдэх эргэх "
+#~ "хүсэлт"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Онцлогийг (энгийн Widget) шалгах объект"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Онцлог боловсруулагчийн объект өгөгдөл"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Тухайн онцлог боловсруулагчид шаардлагатай боломжит өгөгдөл"
+
+# CHECK
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Онцлог боловсруулагчийн өгөгдөл чөлөөлөх эргэх хүсэлт"
+
+# CHECK
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "Онцлог боловсруулагчийн өгөгдөл чөлөөлөх үед хийгдэх эргэх хүсэлт"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "»%s« файл олдсонгүй.\n"
+#~ "\n"
+#~ "Та энэ файл байгаа эсэхийг шалгах эсвэл та өөр дэвсгэр зураг сонгоно уу."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' файлыг хэрхэн нээхийг мэдэхгүй байна.\n"
+#~ "Энэ нь дэмжигдээгүй төрлийн зураг байх боломжтой.\n"
+#~ "\n"
+#~ "Та өөр зураг сонгоно уу."
+
+#~ msgid "Please select an image."
+#~ msgstr "Та нэг зураг сонгоно уу."
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Тохиргоог хадгалахад алдаа гарлаа: %s"
+
+#~ msgid "Custom"
+#~ msgstr "Хэвшмэл"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Гол интерфейсийг ачаалж чадсангүй"
+
+#~ msgid "Balsa"
+#~ msgstr "Балса"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Дебиан тохиромжтой хөтлөгч"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Дебиан терминал эмулатор"
+
+#~ msgid "ETerm"
+#~ msgstr "ЭТерм"
+
+#~ msgid "Encompass"
+#~ msgstr "Энкомпасс"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Epiphany вэб хөтөч"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Эволюшн Мэйл Уншигч"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "Эволюшн Мэйл Уншигч 1.4"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "Эволюшн Мэйл Уншигч 1.5"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "Эволюшн Мэйл Уншигч 1.6"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "Эволюшн Мэйл Уншигч 2.0"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "Эволюшн Мэйл Уншигч 2.2"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "Эволюшн Мэйл Уншигч 2.4"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Галеон"
+
+#~ msgid "Konqueror"
+#~ msgstr "Конкюрор"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Зүүн текст хөтөч"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Люнкс Текст хөтөч"
+
+#~ msgid "Mozilla"
+#~ msgstr "Моцилла"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Моцилла 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Моцилла Мэйл"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Мутт"
+
+#~ msgid "NXterm"
+#~ msgstr "НКСтерм"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Холбогч"
+
+#~ msgid "Opera"
+#~ msgstr "Опера"
+
+#~ msgid "RXVT"
+#~ msgstr "РКСВТ"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Стандарт КСТерминал"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M текст хөтөч"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "<b>Audio Player</b>"
+#~ msgstr "<b>Дуу тоглуулагч</b>"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>Зураг харагч</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>Мессэнжир</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>Майл уншигч</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Терминал эмулатор</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Текст боловсруулагч</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Видео тоглуулагч</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Вэб хөтөч</b>"
+
+#, no-c-format
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Бүх %s тохиолдолууд нь одоогийн холбоосоор солигдсон байна"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "Дарцаг _ачаалах:"
+
+#~ msgid "Internet"
+#~ msgstr "Интернет"
+
+#~ msgid "Multimedia"
+#~ msgstr "Multimedia"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Шинэ _табд холбоос нээх"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Шинэ _цонхонд холбоос нээх"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "_Стандарт вэб хөтчөөр холбоосыг нээх"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "_Терминалд ажиллуулах"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Дэлгэцийн нарийвчлал өөрчлөх"
+
+#~ msgid "left"
+#~ msgstr "зүүн"
+
+#~ msgid "inverted"
+#~ msgstr "Урвуу"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Гц"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Дэлгэцийн нарийвчлалын тохируулга"
+
+#, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Зөвхөн энэ компьютерийг (%s) стандарт болгох"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Шинэ тохиргоог шалгаж үзэж байна. Хэрвээ та %d секундэд хариу авахгүй бол "
+#~ "өмнөх тохиргоо сэргээгдэнэ."
+#~ msgstr[1] ""
+#~ "Шинэ тохиргоог шалгаж үзэж байна. Хэрвээ та %d секундэд хариу авахгүй бол "
+#~ "өмнөх тохиргоо сэргээгдэнэ."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Нарийвчлалыг хадгал"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Та энэ тохиргоог хадгалахыг хүсэж байна уу?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "Ө_мнөх тохиргоог хэрэглэнэ"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "Нарийвчлалыг _авах"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "XServer нь XRandR өргөтгөлийг дэмжээгүй байна.  Нарийвчлалын "
+#~ "өөрчлөлтүүдийг ажиллагааны үед авах боломжгүй."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Энэ програмтай XRandR өргөтгөлийн хувилбар тохирохгүй байна. Нарийвчлалын "
+#~ "өөрчлөлтүүдийг ажиллагааны үед авах боломжгүй."
+
+#~ msgid "Font"
+#~ msgstr "Фонтны хэлбэр"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Ажлын талбарын фонтыг сонгох"
+
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<b>Фонтны дүрслэл</b>"
+
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<b>Дохио өгөх</b>:"
+
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<b>Толийлголт</b>:"
+
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<b>Subpixel дараалал</b>:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Хамгийн сайн хэ_лбэр"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Хамгийн сайн _эрчимжилт"
+
+#~ msgid "D_etails..."
+#~ msgstr "Дэлгэ_рэнгүй..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "_Ажлын талбарын фонт:"
+
+#~ msgid "Font Preferences"
+#~ msgstr "Фонтын тохиргоо"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "Фонтны лавлах руу _оч"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Сааралж_уулалт"
+
+#~ msgid "N_one"
+#~ msgstr "_Хаах"
+
+#~ msgid "R_esolution:"
+#~ msgstr "_Нарийвчлал:"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "_Subpixel (LCDs)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Sub_pixel (LCDs) толийлгож байна"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Баримтын фонт:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_Фонтны өргөнийг тодорхойллоо:"
+
+#~ msgid "_Medium"
+#~ msgstr "_Дунд"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Хар-цагаан"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Slight"
+#~ msgstr "Бага_втар"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Цонхны толгойн фонт:"
+
+#~ msgid "dots per inch"
+#~ msgstr "Ямх тус бүрийн цэг"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Фонтны хэв хэт том байх"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Сонгогдсон фонтын хэв %d цэгтэй том ба энэ нь компютер үр ашигтай "
+#~ "ажиллахад бэрхшээлтэй.  Таныг фонтын хэвийн хэмжээг %d-ээс бага болгохыг "
+#~ "зөвлөж байна."
+#~ msgstr[1] ""
+#~ "Сонгогдсон фонтын хэв %d цэгтэй том ба энэ нь компютер үр ашигтай "
+#~ "ажиллахад бэрхшээлтэй.  Таныг фонтын хэвийн хэмжээг %d-ээс бага болгохыг "
+#~ "зөвлөж байна."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Сонгогдсон фонтын хэв %d том ба энэ магад компютер үр ашигтай ажиллахад "
+#~ "бэрхшээлтэй. Таныг фонтын бага хэмжээг сонгохыг зөвлөж байна."
+#~ msgstr[1] ""
+#~ "Сонгогдсон фонтын хэв %d том ба энэ магад компютер үр ашигтай ажиллахад "
+#~ "бэрхшээлтэй.  Таныг фонтын бага хэмжээг сонгохыг зөвлөж байна."
+
+#~ msgid "New accelerator..."
+#~ msgstr "Шинэ хослол товчлуур..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Хослол түлхүүр"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Хослол товчлуурыг өөрчлөгч"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Хослол товчлуурын код"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Шорткатын төрөл"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Тодорхойгүй үйлдэл>"
+
+#~ msgid "Window Management"
+#~ msgstr "Цонхны зохион байгуулалт"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become unusable to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time.\n"
+#~ msgstr ""
+#~ "Энэ түлхүүрийг ашиглахад хэрэглэгдэхгүй тул \"%s\" шорткатыг "
+#~ "хэрэглэхгүй.\n"
+#~ "Энэ түлхүүртэй Control, Alt эсвэл Shift-ийг нэгэн зэрэг дарна уу.\n"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "\"%s\" Шорткат хэдийнэ хэрэглэгдсэн:\n"
+#~ " \"%s\"\n"
+
+#, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Тохируулгын өгөгдлийн баазад шинэ шорткатыг оруулахад гарсан алдаа: %s\n"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Тохируулгын өгөгдлийн баазаас шорткатыг устгах үед алдаа гарлаа: %s\n"
+
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "Та шинэ шорткатыг нэмэхийн тулд зохих мөр ба шинэ товчлуурын хослол дээр "
+#~ "дарна эсвэл арилгахын тулд Backspace-товчлуурыг дарна"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Тушаалуудад шорткат оноох"
+
+#~ msgid "Unknown"
+#~ msgstr "Үл мэдэгдэх"
+
+#, c-format
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "Гарны хэрэгслэлийг ачаалахад алдаа гарлаа: %s"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Зөвхөн тохируулга хэрэглээд гарах (Зөвхөн зүй зохицолд; одоо daemon-оор "
+#~ "боловсруулагдана)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Завсарлага тохируулгыг агуулах хуудасны эхлэлийг харуулах"
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>Дэлгэц _түгжээд завсарлага шаардах</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Хурдан</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Урт</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Богино</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Удаан</i></small>"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "Байгаа ү_зэмжүүд:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Завсарлага зөөлт _зөвшөөрөх"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Завсарлага зөөлт зөвшөөрөх эсэхийг тогтоо"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Гарын загвараа сонгоно уу"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Гарын засвар сонгох"
+
+#~ msgid "Choose..."
+#~ msgstr "Сонгох..."
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Бичих үед гарсан завсарлагын үргэлжлэх хугацаа"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Завсарлага шаардагдахаас өмнөх ажлын хугацаа"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Гарын тохируулга"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Гарын _загвар:"
+
+#~ msgid "Layout Options"
+#~ msgstr "Үзэмж сонголт"
+
+#~ msgid "Layouts"
+#~ msgstr "Үзэмж"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr "Санамсаргүй эсвэл гажуудал товч дарагдахаас хамгаалж дэлгэц түгжих"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Microsoft Natural Гар"
+
+#~ msgid "Separate _group for each window"
+#~ msgstr "Цонх бүрийн тусгай бүлгүүд"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Хялбарчилал..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Сүүлийн завсарлагын интервал:"
+
+#~ msgid "_Models:"
+#~ msgstr "_Модел:"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Сонгогдсон үзэмжүүд:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Сүүлийн ажлын интервал:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Өөрийн гарын тохируулгыг тогтоох"
+
+#, c-format
+#~ msgid "%d millisecond"
+#~ msgid_plural "%d milliseconds"
+#~ msgstr[0] "%d миллисекунд"
+#~ msgstr[1] "%d миллисекунд"
+
+#~ msgid "Unknown Pointer"
+#~ msgstr "Тодорхойгүй түүчээ"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Стандарт түүчээ- Идэвхитэй"
+
+#~ msgid "The default pointer that ships with X"
+#~ msgstr "X -н стандарт түүчээ"
+
+#~ msgid "White Pointer"
+#~ msgstr "Цагаан түүчээ"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Цагаан түүчээ - Идэвхитэй"
+
+#~ msgid "The default pointer inverted"
+#~ msgstr "Урвуулсан стандарт түүчээ"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Том түүчээ - Идэвхитэй"
+
+#~ msgid "Large version of normal pointer"
+#~ msgstr "Энгийн түүчээний том хувилбар"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Том цагаан түүчээ - Идэвхитэй"
+
+#~ msgid "Large version of white pointer"
+#~ msgstr "Цагаан түүчээний том хувилбар"
+
+#~ msgid "Pointer Theme"
+#~ msgstr "Түүчээний сэдэв"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Татаад тавих</b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Түүчээний байрлал</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Хурд</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Хурдан</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Өндөр</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Том</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Бага</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Удаан</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Жижиг</i>"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Таныг Ctrl дарахад _түүчээг онцгойлох"
+
+#~ msgid "Motion"
+#~ msgstr "Хөдөлгөөн"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Хулганы тохируулга"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Зүүн гарын хулгана"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Мэдрэмж:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Хулганы тохируулга хийх"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Сүлжээ-итгэмжлэгчийн тохируулгыг хийх"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Интернэтийн _шууд холболт</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>Итгэмжлэгчийн _автомат тохируулга</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Итгэмжлэгчийн _гар тохируулга</b>"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Нарийвчилсан тохируулга"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP-итгэмжлэгч дэлгэрэнгүй"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Сүлжээ-итгэмжлэгчийн тохируулга"
+
+#~ msgid "Port:"
+#~ msgstr "Порт:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_HTTP-итгэмжлэгчийг баталгаажуулах:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Чимээг идэвхижүүлж үйлдлүүдтэй холбох"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Чимээний тохируулга"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>Дуут чуулган</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Хөгжим ба кино</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>Дууны үйлдлүүд</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Шалгаж байна...</span>"
+
+#~ msgid "E_nable software sound mixing (ESD)"
+#~ msgstr "Програм хангамжийг чимээтэй хослуулах боломжтой"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "_Цонхны гарчиг самбарыг гэрэлтүүлэх"
+
+#~ msgid "Sound & Video Preferences"
+#~ msgstr "Чимээ ба видеоны тохируулга"
+
+#~ msgid "Sound Capture:"
+#~ msgstr "Дууны хүч:"
+
+#~ msgid "System Beep"
+#~ msgstr "Системийн дохио"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "Pipeline шалгаж байна"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "Системийн дохио _идэвхжүүлэх"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "_Системд дуу тоглуулах"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "_Системийн дохиог харуулах"
+
+#~ msgid "Would you like to remove this theme?"
+#~ msgstr "Та энэ загварыг устгахыг хүсч байна уу?"
+
+#~ msgid "Theme deleted succesfully. Please select another theme."
+#~ msgstr "Загвар амжилттай устгагдлаа. Өөр сэдэв сонгоно уу."
+
+#~ msgid "Theme can not be deleted"
+#~ msgstr "Загвар устгагдсангүй"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Таны системд загвар олдсонгүй. Энэ нь магад таны »Загвар тохируулга« "
+#~ "эсвэл »gnome-themes« пакет зөв суугаагүй гэсэн үг."
+
+#~ msgid "This theme is not in a supported format."
+#~ msgstr "Энэ загвар нь дэмжигдээгүй формат байна."
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Түр зуурын директор үүсэх боломжгүй байна"
+
+#~ msgid ""
+#~ "Can not install theme. \n"
+#~ "The bzip2 utility is not installed."
+#~ msgstr ""
+#~ "Загвар суухгүй байна. \n"
+#~ " bzip2 хэрэглээ суусангүй. "
+
+#~ msgid ""
+#~ "Can not install themes. \n"
+#~ "The gzip utility is not installed."
+#~ msgstr ""
+#~ "Загвар суухгүй байна. \n"
+#~ "gzip хэрэглээ суусангүй. "
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "%s ГНОМЕ Загвар амжилттай суулаа"
+
+#~ msgid "The theme is an engine. You need to compile the theme."
+#~ msgstr "Загвар бол үйл ажиллагааны нэгж юм. Та загварыг эмхтгэх хэрэгтэй."
+
+#~ msgid "The file format is invalid"
+#~ msgstr "Файлын формат хүчингүй байна"
+
+#, c-format
+#~ msgid ""
+#~ "<span weight=\"bold\" size=\"larger\">The theme \"%s\" has been installed."
+#~ "</span>\n"
+#~ "\n"
+#~ "Would you like to apply it now, or keep your current theme?"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">Загвар \"%s\" суусан байна.</span>\n"
+#~ "\n"
+#~ "Та үүнийг хэрэглэхийг хүсэж байна уу одоогийнхыгоо авч үлдэх үү?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Одоогийн загварыг авч үлдэх"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Шинэ загварыг хэрэглэх"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Файлын загвар суулгах байрлалыг тодорхойлоогүй байна"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Файлын загвар суулгах байрлал хүчингүй"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Загварыг суулгахад орох боломжгүй зөвшөөрөл:\n"
+#~ "%s"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "Файлын формат хүчингүй байна."
+
+#, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s бол загварын файлууд суулгах зам. Тиймээс тэр эх байрлалаар "
+#~ "хэрэглэгдэх боломжгүй"
+
+#~ msgid "Custom theme"
+#~ msgstr "Хэвшмэл загвар"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "Та »Загвар хадгалах«-товчийг товшиж энэ загварыг хадгалаж болно."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "Таны системд стандарт загварын схем олдсонгүй. Энэ нь таныг Metacity "
+#~ "суулгаагүй эсвэл таны GConf алдаатай тохируулагдсаныг зааж байна."
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Загварийн нэр үзүүлэгдэх ёстой"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Завар байна. Та үүнийг солих уу?"
+
+# CHECK
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Ажлын талбарын янз бүрийн хэсгүүдийн хувьд загвар тогтоох"
+
+#~ msgid "Theme"
+#~ msgstr "Загвар"
+
+#~ msgid "<b>You do not have permission to change theme settings</b>"
+#~ msgstr "<b>Танд загварын тохиргоо өөрчилөх эрх алга</b>"
+
+#~ msgid "Apply _Font"
+#~ msgstr "_Бичгийг хэрэглэх"
+
+#~ msgid "Icons"
+#~ msgstr "Эмблемүүд"
+
+#~ msgid "Save Theme"
+#~ msgstr "Загвар хадгалах"
+
+#~ msgid "Save _Background Image"
+#~ msgstr "_Дэвсгэр зургийг хадгалах"
+
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Ажлын талбары загварыг сонгох"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "Загвар тохируулгууд"
+
+#~ msgid "Theme _Details"
+#~ msgstr "Загвар _тодруулга"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "Энэ загвар тодорхой дэвсгэр болон фонтыг санал болгохгүй байна."
+
+#~ msgid "This theme suggests a background:"
+#~ msgstr "Энэ загвар тохирох дэвсгэрийг санал болгож байна:"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Энэ загвар тохирох дэвсгэр болон фонтыг санал болгож байна:"
+
+#~ msgid "This theme suggests a font:"
+#~ msgstr "Энэ загвар тохирох фонтыг санал болгож байна:"
+
+#~ msgid "Window Border"
+#~ msgstr "Цонхны хүрээ"
+
+#~ msgid "_Description:"
+#~ msgstr "_Тодорхойлолт:"
+
+#~ msgid "_Install..."
+#~ msgstr "_Суулгаж байна..."
+
+#~ msgid "_Revert"
+#~ msgstr "_Урвуулах"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "Загвар _хадгалах..."
+
+#~ msgid "theme selection tree"
+#~ msgstr "Загвар сонголтын мод"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "Х.програмийн багажны ба цэсний самбарын харагдалтыг тохируулах"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Цэс ба багажны самбар"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Харьцаа ба харагдац</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Урьд. харах</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "_Тасдах"
+
+#~ msgid "Icons only"
+#~ msgstr "Зөвхөн эмблем"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Цэс ба багажны самбарын тохируулга"
+
+#~ msgid "New File"
+#~ msgstr "Шинэ файл"
+
+#~ msgid "Open File"
+#~ msgstr "Файл нээх"
+
+#~ msgid "Save File"
+#~ msgstr "Файл хадгалах"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Цэсэнд _тэмдэгүүдийг харуулах"
+
+#~ msgid "Text below icons"
+#~ msgstr "Эмблемийн доор текст"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Эмблемийн дэргэд текст"
+
+#~ msgid "Text only"
+#~ msgstr "Зөвхөн текст"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Түүлбар _товчны бичээс:"
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "Салгах _боломжит багажны самбар"
+
+#~ msgid "_Editable menu accelerators"
+#~ msgstr "_Боловсруулах боломжтой цэсний хурдасгуур"
+
+#~ msgid "_File"
+#~ msgstr "_Файл"
+
+#~ msgid "_New"
+#~ msgstr "_Шинэ"
+
+#~ msgid "_Paste"
+#~ msgstr "_Буулгах"
+
+#~ msgid "_Print"
+#~ msgstr "Хэ_влэх"
+
+#, c-format
+#~ msgid ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "<b>Таны цонхны менежерийн тохируулга х.программыг эхлүүлж чадахгүй байна</"
+#~ "b>\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "C_ontrol"
+#~ msgstr "_Хяналт"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "_Супер (эсвэл \"Цонхны тэмдэг\")"
+
+#~ msgid "_Meta"
+#~ msgstr "_Мета"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Шилжүүлэгч товч</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Толгой самбарны үйлдлүүд</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Цонхны сонголт</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "Цонх зөөхдөө дараах товчийг дараад барьж цонхонд хүрнэ:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Цонхны тохируулга"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "Энэ үйлдлийг гүйцэтгэхдээ толгой самбарыг _давхар товшино:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Өргөлтийн өмнөх хүлээлт:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "Идэвхижсэн цонх тодорхой хугацааны дараа ө_ргөгдөх"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Хулганыг дээгүүр нь хөдөлгөхөд цонхнуудыг сонгоно"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Цонхны тохируулгыг хийх"
+
+#~ msgid "Desktop Preferences"
+#~ msgstr "Ажлын талбарын тохируулгууд"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME-Хянах төв"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME-тохируулгын хэрэгсэл"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Та Shift товчлуурыг 8 секунт даржээ. Энэ нь гарын ажиллагаанд нөлөөлдөг "
+#~ "удаашруулах товчлуурын үйл ажиллагааны хослол юм."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Та удаашруулах товчлуурыг идэвхижүүлэхийг хүсч байна уу?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Та удаашруулах товчлуурыг идэвхигүйжүүлэхийг хүсч байна уу?"
+
+#~ msgid "_Deactivate"
+#~ msgstr "_Идэвхгүй болгох"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "_Бүү идэвхижүүл"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Та Shift товчлуурыг 5 удаа дараалуулан даржээ. Энэ нь таны гарын "
+#~ "ажиллагаанд нөлөөлдөг наалт товчлуурын үйл ажиллагааны хослол юм."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "Та хоёр товчлуурыг нэг удаа эсвэл Shift товчлуур 5 удаа дараалуулан "
+#~ "даржээ. Энэ нь таны гарын ажиллагаанд нөлөөлдөг наалт шорткатын үйл "
+#~ "ажиллагааг унтраана."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Та наалт товчлуурыг идэвхижүүлэхийг хүсч байна уу?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Та наалт товчлуурыг идэвхгүйжүүлэхийг хүсч байна уу?"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "\"%s\" лавлах үүсгэж чадсангүй.\n"
+#~ "Энэ нь түүчээний загварыг өөрчилөхөд шаардлагатай."
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "\"%s\" лавлах үүсгэж чадсангүй.\n"
+#~ "Энэ нь түүчээ өөрчилөхөд шаардлагатай."
+
+#, c-format
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "Шорткатын (%s) хувьд олон дахин үйлдэл тогтоох\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "Шорткат (%s) нь олон удаагаар тогтоогддог\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Шорткат (%s) бүрэн бус\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Шорткат (%s) хүчингүй\n"
+
+#, c-format
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr "Өөр програм хэдийнээ '%u' түлхүүрт олгогдсон бололтой байна."
+
+#, c-format
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "Шорткат (%s) хэдийнээ хэрэглээнд байна\n"
+
+#, c-format
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr "(%2$s) товчлуурт холбогдсон (%1$s)-г ажиллуулах үед алдаа гарлаа"
+
+#, c-format
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "XKB-тохиргоо идэвхжих үед алдаа гарлаа.\n"
+#~ "Энэ нь олон төрлийн нөхцөл байдлаас болно.\n"
+#~ "-libxklavier номын сангийн програмын алдаа\n"
+#~ "-Х Серверийн алдаа (xkbcomp, xmodmap utilities)\n"
+#~ "-Х Сервер libxkbfile- тэй ажиллахад тохирохгүй\n"
+#~ "\n"
+#~ "Х Серверийн хувилбарын өгөгдөл:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "Хэрвээ та энэ байдлыг алдаагаар тайлагнахыг хүсвэл дараахыг хавсаргана "
+#~ "уу:\n"
+#~ "- <b>%s</b>-н үр дүн\n"
+#~ "- <b>%s</b>-н үр дүн"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "Та XFree 4.3.0 хэрэглэж байна.\n"
+#~ "Нийлмэл XKB тохиргооны хувьд тодорхой бэрхшээлүүд байдаг.\n"
+#~ "Энгийн тохиргоо хэрэглэх эсвэл XFree-н илүү шинэ хувилбар хэрэглэхийг "
+#~ "оролдоно уу."
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "_Энэ сануулгыг дахин бүү харуул"
+
+#, c-format
+#~ msgid ""
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.</b>\n"
+#~ "\n"
+#~ "Expected was %s, but the the following settings were found: %s.\n"
+#~ "\n"
+#~ "Which set would you like to use?"
+#~ msgstr ""
+#~ "<b>Х систем гарын тохируулга нь таны одоогийн  ГНОМЕ гарын тохируулгаас "
+#~ "ялгаатай.</b>\n"
+#~ "\n"
+#~ "%s тохирох байсан боловч дараах тохиргоотой байна: %s.\n"
+#~ "\n"
+#~ "Та алийг нь хэрэглэхийг хүсч байна вэ?"
+
+#~ msgid "Use X settings"
+#~ msgstr "Х тохиргоог хэрэглэх"
+
+#~ msgid "Keep GNOME settings"
+#~ msgstr "GNOME тохиргоог хэрэглэх"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Тушаал биелсэнгүй: %s\n"
+#~ "Энэ тушаал байгаа эсэхийг нягтал."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Тооцоолуурыг унтуулах горимд оруулж чадсангүй.\n"
+#~ "Тооцоолуураа зөв тохируулсан эсэхээ нягтлана уу."
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "Glade файл ачаалагдсангүй.\n"
+#~ "Энэ хэвтүүл зөв суусан эсэхийг нягтлана уу."
+
+#, c-format
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Дэлгэцийг эхлүүлэхэд алдаа гарлаа:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Дэлгэцийн энэ хугацаанд ажиллахгүй."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Энэ мэдээг дахин бүү харуул"
+
+#, c-format
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr " %s дууны файл %s жишээгээр ачаалагдсангүй"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Хэрэглэгчийн гэр лавлахыг илрүүлж чадсангүй"
+
+#, c-format
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "GConf түлхүүр %s нь %s төрөлтэй боловч түүний тохирох төрөл нь %s байлаа\n"
+
+#~ msgid "A_vailable files:"
+#~ msgstr "_Боломжит файлууд:"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "_Энэ сануулгыг дахин бүү харуул"
+
+#~ msgid "Load modmap files"
+#~ msgstr "modmap файлыг ачаалж байна"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "modmap файлыг ачаалахыг хүсч байна уу?"
+
+#~ msgid "_Load"
+#~ msgstr "_Ачаалах"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "Сигналын шугам үүсгэх үеийн алдаа."
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Дэвсгэр хэрэглэгчийн төрөл (bg_applier): »root« цонхны хувьд "
+#~ "BG_APPLIER_ROOT эсвэл урьдчилан харахад BG_APPLIER_PREVIEW"
+
+#~ msgid "Preview Width"
+#~ msgstr "Урьд.харах өргөн"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Хэрэглэгч урьдчилан харах үеийн өргөн : Стандартаар 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Урьд.харах өндөр"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Хэрэглэгч урьдчилан харах үеийн өндөр : Стандартаар 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "BGApplier зурагдах ёстой дэлгэц"
+
+#~ msgid "Login"
+#~ msgstr "Логин"
+
+#~ msgid "Boing"
+#~ msgstr "Boing"
+
+#~ msgid "Siren"
+#~ msgstr "Siren"
+
+#~ msgid "Clink"
+#~ msgstr "Жингэнэх"
+
+#~ msgid "Beep"
+#~ msgstr "Дохио"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "Энэ үйлдэлд чимээ байхгүй"
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "Энэ үйлдийн хувьд тогтоосон дууны файл алга.\n"
+#~ "Та стандарт дуугаар авахыг хүсэж байвал »gnome-audio« пакетыг суулгана уу."
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Энэ үйлдийн хувьд дууны файл байхгүй."
+
+#, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "%s файл хүчингүй wav файл байна"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "»%s« цонхны менежер тохируулгын хэрэгслээр бүртгүүлээгүй байна\n"
+
+#~ msgid "Maximize"
+#~ msgstr "Томсгох"
+
+#~ msgid "Roll up"
+#~ msgstr "Эвхэх"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr "»text/plain« ба »text/*« -н хувьд MIME-тодорхойлогчийг хадгалах"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "»text/plain« ба »text/*«-тодорхойлогчуудын зэрэгцүүлэх (Sync)"
+
+#~ msgid "E-mail"
+#~ msgstr "Э-Шуудан"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Э-шуудангийн шорткат."
+
+#~ msgid "Eject's shortcut."
+#~ msgstr "Түлхэлтийн шорткат."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Хувийн гэрийн хавтасны шорткат."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Тусламж хөтөчийн шорткот эхлүүлэх."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Вэб хөтөч шорткат эхлүүлэх"
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Гарах шорткат."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Дараагийн гарчиг шорткат"
+
+#~ msgid "Pause"
+#~ msgstr "Зогсоолт"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Зогсоолтын шорткат."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Тоглуулах (Тоглуулах/Зогсоох) шорткат."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Өмнөх гарчиг шорткат."
+
+#~ msgid "Sleep"
+#~ msgstr "Унтуулах"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Унтуулах шорткат"
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Тоглуулалт таслах шорткат."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Дуу сулруулах шорткат."
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Дуу хаах шорткат"
+
+#~ msgid "Volume step"
+#~ msgstr "Дуу чангаруулалтын алхам"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Дуу чангаруулалтын алхамын чимээний хувь"
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Дуу чангаруулах шорткат."
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "XScreenSaver ажиллаж байх үед алдаа гарвал диалог харуулах"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "Бүртгүүлэхэд дэлгэц гамнагч ажиллуулах"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Эхлэлийн алдааг харуулах"
+
+#~ msgid "Start screensaver"
+#~ msgstr "Дэлгэц гамнагч эхлүүлэх"
+
+#~ msgid ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+#~ msgstr "Үсгийн цуглуулгыг ажиллуулах бүрд гар дахин ачаалагдана."
+
+#~ msgid "A list of modmap files available in the $HOME directory."
+#~ msgstr "modmap-ийн файлын жагсаалт $HOME лавлахад байна."
+
+#~ msgid "Default group, assigned on window creation"
+#~ msgstr "Цонхны үүсэлтэд стандарт бүлэг шаардлагатай"
+
+#~ msgid "Keep and manage separate group per window"
+#~ msgstr "Цонх тус бүрийн бүлгийг хадгалан удирдана"
+
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Гарын шинэчлэлийг удирдах програм"
+
+#~ msgid "Keyboard model"
+#~ msgstr "Гарын загвар"
+
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr ""
+#~ "Системээс gconf дахь XKB тохиргоог аль болох түргэн хасах уу (илүүдэл)"
+
+#~ msgid "Save/restore indicators together with layout groups"
+#~ msgstr "Тодорхойлогчыг байрлалын бүлгүүдтэй хадгалах/сэргээх"
+
+#~ msgid "Show layout names instead of group names"
+#~ msgstr "Бүлэг нэрийн оронд байрлалын нэрийг харуулах"
+
+#~ msgid ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+#~ msgstr ""
+#~ "Групп нэрийн оронд layout нэрийг харуулах (олон байрлалуудыг зөвхөн XFree "
+#~ "хувилбарт дэмждэг)"
+
+#~ msgid "Suppress the \"X sysconfig changed\" warning message"
+#~ msgstr "\"X sysconfig changed\" анхааруулах мэдээг үгүйсгэх"
+
+#~ msgid "The Keyboard Preview, X offset"
+#~ msgstr "Гарын тольдолт, X офсет"
+
+#~ msgid "The Keyboard Preview, Y offset"
+#~ msgstr "Гарын тольдолт, Y офсет"
+
+#~ msgid "The Keyboard Preview, height"
+#~ msgstr "Гар тольдолт, өндөр"
+
+#~ msgid "The Keyboard Preview, width"
+#~ msgstr "Гар тольдолт, өргөн"
+
+#~ msgid ""
+#~ "Very soon, keyboard settings in gconf will be overridden (from the system "
+#~ "configuration) This key has been deprecated since GNOME 2.12, please "
+#~ "unset the model, layouts and options keys to get the default system "
+#~ "configuration."
+#~ msgstr ""
+#~ "Удахгүй gconf дахь гарын тохиргоо дарагдана (систем тохиргооноос) Энэ "
+#~ "түлхүүр нь GNOME 2.12-оос хойш буруушаагдах болсон, стандарт системийн "
+#~ "тохиргоог хадгалах загвар, байрлал ба сонголтуудыг үлдээнэ үү."
+
+#~ msgid "keyboard layout"
+#~ msgstr "Гарын засвар"
+
+#~ msgid "keyboard model"
+#~ msgstr "Гарын загвар"
+
+#~ msgid "modmap file list"
+#~ msgstr "modmap файлын жагсаалт"
+
+#~ msgid "_Postpone break"
+#~ msgstr "Завсарлага _зөөх"
+
+#~ msgid "Take a break!"
+#~ msgstr "Завсарла!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Засарла"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "Дараагийн завсарлага хүртэл %d минут"
+#~ msgstr[1] "Дараагийн завсарлага хүртэл %d минут"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Дараагийн завсарлага хүртэл нэг хүрэхгүй минут"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Цохилт-тодруулга диалог дараах алдааны шалтгааны улмаас нээгдэх "
+#~ "боломжгүй: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Richard Hult &lt;richard@imendio.com&gt; бичив."
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Anders Carlsson Eye candy -г нэмсэн."
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Компьютерийн хуьд завсарлага сануулагч."
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Мэдээлэл харуулахаар дэлгэцэнд бичихэд сонордуулга муж хэрэглэдэг. Таны "
+#~ "удирдах самбарт сонордуулгын муж байхгүй шиг байна. Та удирдах "
+#~ "самбарынхаа дээр очиж хулганы баруун товшуураар 'Самбарт нэмэх' дараа нь "
+#~ "'Сонордуулга муж'-г сонгож 'Нэмэх'-ийг товшино."
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Чихний чимэг болсон аялгуу сайхан монгол хэл. 0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Хэмжээ:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Зохиогчийн эрх:"
+
+#~ msgid "Description:"
+#~ msgstr "Тодорхойлолт:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "Хэрэглээ: %s фонт файл\n"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Програмны бичгээр хэрэглэх"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "OpenType бичгүүдээр бяцхан зураг загварт харуулах уу?"
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "PCF бичгүүдээр бяцхан зураг загварт харуулах уу?"
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "TrueType бичгүүдээр бяцхан зураг загварт харуулах уу?"
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Type1-бичгүүдээр бяцхан зураг загварт харуулах уу?"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "OpenType бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
+#~ "тогтоо."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "PCF бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
+#~ "тогтоо."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "TrueType бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
+#~ "тогтоо."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Type1 бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
+#~ "тогтоо."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "OpenType-бичгүүдийг урьдчилан харах тушаал"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "PCF-бичгүүдийг урьдчилан харах тушаал"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "TrueType-бичгүүдийг урьдчилан харах тушаал"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Type1-бичгүүдийг урьдчилан харах тушаал"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "OpenType-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCF-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "TrueType-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Type1-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "GNOME Фонт харагч"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Шинэ фонт хэрэглэхүү?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Бичгийг хэрэглэх_гүй"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Энэ загвар нэгэн шинэ фонтын хэв суулгахыг санал болгож байна. Фонтны "
+#~ "хэвийн хэлбэр доор харагдаж байна."
+
+#~ msgid "Themes"
+#~ msgstr "Загвар"
+
+#~ msgid "Description"
+#~ msgstr "Тодорхойлолт"
+
+#~ msgid "Control theme"
+#~ msgstr "Цонхны агуулгын загвар"
+
+#~ msgid "Window border theme"
+#~ msgstr "Цонхны хүрээний загвар"
+
+#~ msgid "Icon theme"
+#~ msgstr "Эмблемийн загвар"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "СБЖЭӨҮЯ"
+
+#~ msgid "Apply theme"
+#~ msgstr "Загварыг хэрэглэх"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Стандарт загварыг сэргээх"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "Хэрвээ утга үнэн бол суулгасан загварууд мини харагдана."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "Хэрвээ утга үнэн бол загварууд мини харагдана."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Суулгасан загваруудын мини харагдац үүсгэхийн тулд энэ тушаал "
+#~ "гүйцэтгэгдэнэ."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr "Загваруудын мини харагдац үүсгэхийн тулд энэ тушаал гүйцэтгэгдэнэ."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Суулгасан загваруудыг мини харах тушаал"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Загваруудыг мини харах тушаал"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Суулгасан загваруудыг мини харах эсэх"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Загваруудыг мини харах эсэх"

--- a/po/mn.po~
+++ b/po/mn.po~
@@ -1,0 +1,3602 @@
+# translation of mn.po to Mongolian
+# translation of gnome-control-center.HEAD.po to Mongolian
+# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) 2004 THE PACKAGE'S COPYRIGHT HOLDER.
+# Sanlig Badral <badral@chinggis.com>, 2003.
+# Sanlig Badral <badral@users.sf.net>, 2003.
+# Sanlig Badral <badral@openmn.org>, 2003, 2004, 2006.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: mn\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2006-08-15 23:55+0200\n"
+"PO-Revision-Date: 2006-08-16 00:49+0200\n"
+"Last-Translator: Badral <badral@openmn.org>\n"
+"Language-Team: Mongolian <openmn-translation@lists.sourceforge.net>\n"
+"Language: mn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);X-Generator: KBabel 1.10.2\n"
+"X-Generator: KBabel 1.10.2\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "Зураг/Бичээсийн хүрээ"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "Сануулгын цонхонд зураг болон хаягийн хүрээний өргөн"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "Сануулгын төрөл"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "Сануулгын төрөл"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "Сануулгын товчнууд"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "Сануулгын цонхонд товчлууруудыг харуулж байна"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "Илүү _нарийвчилж харуулах"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "About Me"
+msgstr "Миний тухай"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "MIME-төрлийн мэдээлэл"
+
+#: ../capplets/about-me/gnome-about-me.c:605
+msgid "Select Image"
+msgstr "Зургийг сонгох"
+
+#: ../capplets/about-me/gnome-about-me.c:607
+msgid "No Image"
+msgstr "Зураг байхгүй байна"
+
+#: ../capplets/about-me/gnome-about-me.c:770
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"Хаягийн номны мэдээлэлд орох үед алдаа гарлаа\n"
+"Протоколд Эволюшн Өгөгдөл Сервер орж чадахгүй байна"
+
+#: ../capplets/about-me/gnome-about-me.c:791
+msgid "Unable to open address book"
+msgstr "Хаягийн дэвтэр нээгдэх боломжгүй"
+
+#: ../capplets/about-me/gnome-about-me.c:803
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr "Үл мэдэгдэх логин ID, хэрэглэгчийн өгөгдөл магадгүй гэмтсэн байна"
+
+#: ../capplets/about-me/gnome-about-me.c:834
+#: ../capplets/about-me/gnome-about-me.c:836
+#, c-format
+msgid "About %s"
+msgstr "%s-ны тухай"
+
+#: ../capplets/about-me/gnome-about-me-password.c:172
+msgid "Child exited unexpectedly"
+msgstr "Хүү санамсаргүй гацлаа"
+
+#: ../capplets/about-me/gnome-about-me-password.c:295
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr "backend_stdin IO суваг унтраах боломжгүй : %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:308
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr "backend_stdout IO суваг унтраах боломжгүй : %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:449
+msgid "Authenticated!"
+msgstr "Батлагдлаа!"
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:466
+#: ../capplets/about-me/gnome-about-me-password.c:539
+msgid ""
+"Your password has been changed since you initially authenticated! Please re-"
+"authenticate."
+msgstr "Нууц үг таныг шинээр зөв нэвтрэхэд өөрчлөгдөнө! Дахин нэвтэрнэ үү."
+
+#: ../capplets/about-me/gnome-about-me-password.c:468
+msgid "That password was incorrect."
+msgstr "Нууц үг буруу."
+
+#: ../capplets/about-me/gnome-about-me-password.c:514
+msgid "Your password has been changed."
+msgstr "Таны нууц үг өөрчилөгдлөө."
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:524
+#, c-format
+msgid "System error: %s."
+msgstr "Системийн алдаа: %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:526
+msgid "The password is too short."
+msgstr "Нууц үг хэтэрхий богино байна."
+
+#: ../capplets/about-me/gnome-about-me-password.c:528
+#: ../capplets/about-me/gnome-about-me-password.c:530
+msgid "The password is too simple."
+msgstr "Нууц үг хэтэрхий энгийн байна."
+
+#: ../capplets/about-me/gnome-about-me-password.c:532
+msgid "The old and new passwords are too similar."
+msgstr "Хуучин болон шинэ нууц үг хэтэрхий төстэй байна."
+
+#: ../capplets/about-me/gnome-about-me-password.c:534
+msgid "The new password must contain numeric or special character(s)."
+msgstr "Тоо юмуу эсвэл тусгай тэмдэгтийг агуулах ёстой."
+
+#: ../capplets/about-me/gnome-about-me-password.c:536
+msgid "The old and new passwords are the same."
+msgstr "Хуучин болон шинэ нууц үг ижил байна."
+
+#: ../capplets/about-me/gnome-about-me-password.c:787
+#, c-format
+msgid "Unable to launch /usr/bin/passwd: %s"
+msgstr "/usr/bin/passwd ажиллахгүй байна: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:789
+msgid "Unable to launch backend"
+msgstr "Холбоог эхлүүлэх боломжгүй"
+
+#: ../capplets/about-me/gnome-about-me-password.c:790
+msgid "A system error has occurred"
+msgstr "Системд алдаа гарсан байна"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:810
+msgid "Checking password..."
+msgstr "Нууц үгийг шалгаж байна..."
+
+#: ../capplets/about-me/gnome-about-me-password.c:897
+msgid "Click <b>Change password</b> to change your password."
+msgstr ""
+"Нууц үгээ өөрчлөхийн тулд <b>Нууц үгээ өөрчлөх</b> гэсэн товчин дээр дарна."
+
+#: ../capplets/about-me/gnome-about-me-password.c:900
+msgid "Please type your password in the <b>New password</b> field."
+msgstr "<b>Шинэ нууц үг талбарт</b> нууц үгээ оруулна уу."
+
+#: ../capplets/about-me/gnome-about-me-password.c:903
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+msgid ""
+"Please type your password again in the <b>Retype new password</b> field."
+msgstr "Нууц үгээ дахин <b>Шинэ нууц үгээ давт</b> талбарт оруулна уу."
+
+#: ../capplets/about-me/gnome-about-me-password.c:906
+msgid "The two passwords are not equal."
+msgstr "Хоёр нууц үг тохирохгүй байна."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/sound/sound-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+msgid "    "
+msgstr "    "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Email</b>"
+msgstr "<i>Э-Шуудан</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Home</b>"
+msgstr "<b>Home</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Яаралтай мэдээлэл</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Job</b>"
+msgstr "<b>Ажил</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Telephone</b>"
+msgstr "<b>Утас</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<b>Web</b>"
+msgstr "<b>Вэб</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "<b>Work</b>"
+msgstr "<b>Ажил</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Нууц үгээ өөрчилөх</span>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "A_ddress:"
+msgstr "Х_аяг:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr "_Туслагч:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "Address"
+msgstr "Хаяг"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "C_ity:"
+msgstr "Х_от:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "C_ompany:"
+msgstr "К_омпани:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Cale_ndar:"
+msgstr "Хуа_нли:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change Passwo_rd..."
+msgstr "Нэвт_рэх үгээ өөрчлөх..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Change pa_ssword"
+msgstr "Нууц үгээ өө_рчлөх"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Change password"
+msgstr "Нууц үгээ өөрчлөх"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Ci_ty:"
+msgstr "Х_от:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Co_untry:"
+msgstr "У_лс:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Contact"
+msgstr "Холбоо"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Cou_ntry:"
+msgstr "У_лс:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Current _password:"
+msgstr "_Одоогийн нууц үг:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "Full Name"
+msgstr "Бүтэн нэр"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "Hom_e:"
+msgstr "Гэр:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P.O. _box:"
+msgstr "P.O. _хайрцаг:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "P._O. box:"
+msgstr "P._O. хайрцаг:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "Personal Info"
+msgstr "Хувийн мэдээлэл"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "State/Pro_vince:"
+msgstr "Улс/Орон н_утаг:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid ""
+"To change your password, enter your current password in the field below and "
+"click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for "
+"verification and click <b>Change password</b>."
+msgstr ""
+"Та нууц үгээ солих бол доор одоогийн нууц үгээ оруулаад <b>Баталгаажуулалт</"
+"b> дээр дарна уу.\n"
+"Ахин нэвтэрсэний дараа шинэ нууц үгээ оруулж, бататгахын тулд дахин оруулаад "
+"<b>Нууц үг солих</b> дээр дарна уу."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "User name:"
+msgstr "Хэрэглэгчийн нэр:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "Web _log:"
+msgstr "Веб _лог:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "Wor_k:"
+msgstr "_Ажил:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "Work _fax:"
+msgstr "Aжлын _факс:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "Zip/_Postal code:"
+msgstr "Zip/_Шуудангийн код:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "_Address:"
+msgstr "_Хаяг:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Authenticate"
+msgstr "_Баталгаажуулах"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Department:"
+msgstr "_Хэлтэс:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Groupwise:"
+msgstr "_Бүлэглэл:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_Home page:"
+msgstr "_Гэрийн хуудас:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Home:"
+msgstr "_Гэр:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Jabber:"
+msgstr "_Гэмтэл:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_Manager:"
+msgstr "_Удирдлага:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Mobile:"
+msgstr "_Гар утас:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_New password:"
+msgstr "_Шинэ нэвтрэх үг:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Profession:"
+msgstr "_Мэргэжил:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Retype new password:"
+msgstr "_Шинэ нэвтрэх үгийг дахин бичнэ үү:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:55
+msgid "_State/Province:"
+msgstr "_Улс/Орон нутаг:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:56
+msgid "_Title:"
+msgstr "_Гарчиг:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:57
+msgid "_Work:"
+msgstr "_Ажил:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:58
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:59
+msgid "_Zip/Postal code:"
+msgstr "_Zip/Шуудангийн код:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Applications</b>"
+msgstr "<b>Програмууд</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Support</b>"
+msgstr "<b>Дэмжлэг</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+"<small><i><b>Санамж:</b> Энэ тохируулгын өөрчлөлтүүд таны дараагийн нэвтрэлт "
+"хүртэл нөлөөлөхгүй.</i></small>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Preferences"
+msgstr "Туслах Технологийн тохируулга"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr "Хаагаад _Гарах"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr "Эдгээр туслах технологуудыг нэврэлт бүрд эхлүүл:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr "Туслах технологуудыг _нээх"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr "_Өсгөгч"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr "_Дэлгэц дээрхи гар"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Screenreader"
+msgstr "_Дэлгэц уншигч"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr "Нэвтрэлтэд ГНОМЕ-н туслах технологуудын дэмжилт боломжтой."
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the 'orca' "
+"package must be installed for screenreading and magnifying capabilities."
+msgstr ""
+"Таны системд ямар ч тусламж технологи байхгүй байна. Та дэлгэц гар "
+"хэрэглэхийг хүсвэл »gok« багцыг мөн дэлгэц уншилт ба томруулалтын функц "
+"хэрэглэх бол »orca« багцыг тус тус суулгана уу."
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+"Таны системд бүх боломжтой тусламж технологийг суулгаагүй байна. Та дэлгэц "
+"гар хэрэглэхийг хүсвэл »gok« багцыг суулгана уу."
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'orca' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Таны системд бүх боломжийн тусламж технологийг суулгаагүй байна. Та дэлгэц "
+"уншилт ба томруулалтын функц хэрэглэх бол »orca« багцыг тус тус суулгана уу."
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:242
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr "Хулгана тохируулах цонхыг эхлүүлэхэд алдаа гарлаа: %s"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:338
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:399
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr "AccessX-тохируулга '%s' файлаас импортлогдох боломжгүй байна"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:436
+msgid "Import Feature Settings File"
+msgstr "Тохиргооны файлын шинжийг оруулах"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:440
+msgid "_Import"
+msgstr "_Оруулж ирэх"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Гар"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr "Гарт хялбар хандалтын тохируулга хийх"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+"Энэ систем XKB-өргөтгөлгүй юм шиг байна. Гарын хялбар хандалт нь үүнгүйгээр "
+"баталгаажиж чадахгүй."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "<b>_Хязгаар товчлуурууд боломжтой</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "<b>_Удаан товчлуурууд боломжтой</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "<b>_Хулгана түлхүүр боломжтой</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "<b>_Давталт түлхүүрүүд боломжтой</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "<b>_Наалттай түлхүүрүүд боломжтой</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+msgid "<b>Features</b>"
+msgstr "<b>Шинжүүд</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr "<b>Сэлгэгч түлхүүрүүд</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "Үндсэн"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr "Түлхүүрүүдийг _хүлээж аваагүй бол чимээ өгөх"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr "Гарын а_жиллагааны хэрэгслүүд идэвхижих эсвэл хаагдах үед чимээ өгөх"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr "Өөрчлөгчийг албадах үед _чимээ өгөх"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr "LED асахад нэг чимээ, унтрахад хоёр чимээ өгөх."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr "Хэрвээ түлхүүр ...бол чимээ өгөх:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr "_Хоцролт:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr "Товчлуур даралт ба түүчээний _хөдөлгөөний хоорондын хүлээлт"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr "Хоёр товчлуур _зэрэг дарагдвал хаалттай"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr "Холбогч түлхүүрүүд нээлттэй"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Шүүлтүүр"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr "Товчлуурын давхар тогшилтыг дараах дотор х_эрэгсэхгүй байх:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+"Нэг товчлуурын үргэлжилсэн даралтыг хэрэглэгчийн тогтоосон хугацаан дотор "
+"хэрэгсэхгүй байх."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr "Гарын хялбар хандалтын Тохиргоо (AccessX)"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr "Хулганы заагчийн ма_ксимал хурд:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr "Хулгана товчлуур"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr "Хулгана _Тохируулгууд..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+"Хэрэглэгчийн тодорхойлсон хугацаанд түлхүүрүүдийг дарсны дараа хүлээн "
+"зөвшөөрнө."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+"Дараалсан товчлууруудын хослол дарснаар зэрэг товчилуур дарах үйлдлийг "
+"гүйцэтгэнэ."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "S_peed:"
+msgstr "Х_урд:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr "Максимум хурд хүртэл хур_дасгах хугацаа:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr "Хулганы удирдлагад гарын тооны машины хэсгийг хэрэглэх."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr "Хэрвээ дараахад хэрэглэгдээгүй бол _хаах:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr "_Гарын хялбар тусламжийн ажиллагаа боломжтой"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr "_Ажиллагааны тохируулгыг _импортлох..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr "Товчлуурын даралтыг _зөвхөн дараахын хувьд зөвшөөрөх:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "_Type to test settings:"
+msgstr "Тохируулга шалгалтын төрлүүд:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr "_зөвшөөрөгдсөн"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr "_дарагдсан"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr "бу_цаагдсан"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr "Тэмдэгт/Секунд"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "milliseconds"
+msgstr "Миллисекунд"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr "Цэгүүд/Секунд"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "Секундүүд"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+msgid "Change your Desktop Background settings"
+msgstr "Ажлын талбары дэвсгэрийн тохиргоог өөрчилөх"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+msgid "Desktop Background"
+msgstr "Ажлын талбарын дэвсгэр"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "<b>Ажлын талбарын _Туурга цаас</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+msgid "<b>_Desktop Colors</b>"
+msgstr "<b>_Ажлын талбарын өнгө</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+msgid "Desktop Background Preferences"
+msgstr "Ажлын талбарын дэвсгэрийн тохируулгууд"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr "Өнгө тодорхойлох цонхыг нээх"
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr "_Туурга цаас нэмэх"
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+msgid "_Finish"
+msgstr "_Дуусгах"
+
+#: ../capplets/background/gnome-background-properties.glade.h:7
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+msgid "_Remove"
+msgstr "_Устгах"
+
+#: ../capplets/background/gnome-background-properties.glade.h:8
+msgid "_Style:"
+msgstr "_Загвар:"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Тусламж үзүүлэхэд алдаа гарлаа: %s"
+
+#: ../capplets/background/gnome-wp-capplet.c:984
+msgid "Centered"
+msgstr "Голлосон"
+
+#: ../capplets/background/gnome-wp-capplet.c:988
+msgid "Fill Screen"
+msgstr "Дэлгэц дүүрэн"
+
+#: ../capplets/background/gnome-wp-capplet.c:992
+msgid "Scaled"
+msgstr "Хуваарилсан"
+
+#: ../capplets/background/gnome-wp-capplet.c:996
+msgid "Zoom"
+msgstr "Хэмжээг өөрчлөх"
+
+#: ../capplets/background/gnome-wp-capplet.c:1000
+msgid "Tiled"
+msgstr "Дүүргэн"
+
+#: ../capplets/background/gnome-wp-capplet.c:1021
+msgid "Solid Color"
+msgstr "Нэг өнгөт"
+
+#: ../capplets/background/gnome-wp-capplet.c:1025
+msgid "Horizontal Gradient"
+msgstr "Босоо шугамдсан"
+
+#: ../capplets/background/gnome-wp-capplet.c:1029
+msgid "Vertical Gradient"
+msgstr "Хэвтээ шугамдсан"
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1075
+msgid "Add Wallpaper"
+msgstr "Aрын фон нэмэх"
+
+#: ../capplets/background/gnome-wp-capplet.c:1092
+msgid "Images"
+msgstr "Зургууд"
+
+#: ../capplets/background/gnome-wp-capplet.c:1096
+msgid "All Files"
+msgstr "Бүх файлууд"
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr "Туурга цаасгүй"
+
+#: ../capplets/background/gnome-wp-item.c:343
+#: ../capplets/background/gnome-wp-item.c:345
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "цэг"
+msgstr[1] "цэгүүд"
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"Тохируулгын менежер »gnome-settings-daemon« эхлүүлэх боломжгүй байна.\n"
+"GNOME-менежергүйгээр хэд хэдэн тохируулга гүйцэлдэхгүй байх боломжтой. Энэ "
+"нь Bonobo -той эсвэл  GNOME бус (ж.нь. KDE-) тохируулгын менежер хэдийнэ "
+"идэвхижих ба GNOME тохируулгын менежертэй зөрчилдөнө."
+
+#: ../capplets/common/capplet-stock-icons.c:92
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "'%s' stock эмблемийг ачаалах боломжгүй \n"
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr "Тохируулгыг хэрэглээд гарах"
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1027
+#: ../capplets/sound/sound-properties-capplet.c:762
+msgid "Retrieve and store legacy settings"
+msgstr "Хүлээн авсан тохируулгыг олоод хадгалах"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "Файл хуулж байна: %u-ийн %u"
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr "'%s'-г хуулж байна"
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr "URI хаягаас"
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr "URI яг одоо дамжуулагдаж байна"
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr "URI руу"
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr "URI одоогоор дамжуулагдаж байна"
+
+# CHECK
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr "Хэсэгчилэл бэлэн"
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr "Дуусч буй дамжууллын хэсэгчилэл"
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr "Идэвхитэй URI-жигсаалт"
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr "Идэвхитэй URI-жигсаалт - 1-р эхэлж байна"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr "Нийт URI"
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr "URI -н нийт тоо"
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr "Файлыг хуулж байна"
+
+#: ../capplets/common/file-transfer-dialog.c:345
+msgid "From:"
+msgstr "Хэнээс"
+
+#: ../capplets/common/file-transfer-dialog.c:349
+msgid "To:"
+msgstr "Хэнд:"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr "Холболт хийгдэж байна..."
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Түлхүүр"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr "Энэ онцлог засварлагч хавсаргагдсан GConf-түлхүүр"
+
+# CHECK upto line 505
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr "Эргэх хүсэлт"
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Хэрвээ түлхүүрийн утга өөрчлөгдвөл эргэх хүсэлт гүйцэтгэх"
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr "Өөрчлөлтүүд"
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"GConf-өөрчлөлтүүд GConf-Client цааш дамжуулахад хэрэглэх өгөгдлийг агуулж "
+"байна"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr "Widget рүү эргэх хүсэлт хөрвүүлэлт"
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+" GConf -оос Widget рүү хийгдэх өгөгдөлийн хөрвүүлэлтийн үед хийгдэх эргэх "
+"хүсэлт"
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr "Widget ээс эргэх хүсэлт хөрвүүлэлт"
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"Widget-ээс GConf-рүү хийгдэх өгөгдөлийн хөрвүүлэлтийн үед хийгдэх эргэх "
+"хүсэлт"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr "Хэрэглэгчийн гадаргуу жолоодогч"
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr "Онцлогийг (энгийн Widget) шалгах объект"
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr "Онцлог боловсруулагчийн объект өгөгдөл"
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr "Тухайн онцлог боловсруулагчид шаардлагатай боломжит өгөгдөл"
+
+# CHECK
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr "Онцлог боловсруулагчийн өгөгдөл чөлөөлөх эргэх хүсэлт"
+
+# CHECK
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr "Онцлог боловсруулагчийн өгөгдөл чөлөөлөх үед хийгдэх эргэх хүсэлт"
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"»%s« файл олдсонгүй.\n"
+"\n"
+"Та энэ файл байгаа эсэхийг шалгах эсвэл та өөр дэвсгэр зураг сонгоно уу."
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"'%s' файлыг хэрхэн нээхийг мэдэхгүй байна.\n"
+"Энэ нь дэмжигдээгүй төрлийн зураг байх боломжтой.\n"
+"\n"
+"Та өөр зураг сонгоно уу."
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr "Та нэг зураг сонгоно уу."
+
+#: ../capplets/common/gconf-property-editor.c:1598
+msgid "_Select"
+msgstr "_Сонгох"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr "Эрхэмлэсэн х.программууд"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Та өөрийн стандарт х.программыг сонгоно уу"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:77
+#: ../capplets/default-applications/gnome-da-capplet.c:101
+#: ../capplets/default-applications/gnome-da-capplet.c:146
+#: ../capplets/default-applications/gnome-da-capplet.c:191
+#: ../capplets/default-applications/gnome-da-capplet.c:245
+#: ../capplets/default-applications/gnome-da-capplet.c:294
+#: ../capplets/default-applications/gnome-da-capplet.c:576
+#: ../capplets/default-applications/gnome-da-capplet.c:597
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "Тохиргоог хадгалахад алдаа гарлаа: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:719
+#: ../capplets/sound/sound-properties-capplet.c:319
+msgid "Custom"
+msgstr "Хэвшмэл"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:739
+msgid "Could not load the main interface"
+msgstr "Гол интерфейсийг ачаалж чадсангүй"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:741
+msgid "Please make sure that the applet is properly installed"
+msgstr "Энэ апплет зөв суусан эсэхийг нягтлана уу"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Балса"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Debian Sensible Browser"
+msgstr "Дебиан тохиромжтой хөтлөгч"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Debian Terminal Emulator"
+msgstr "Дебиан терминал эмулатор"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "ETerm"
+msgstr "ЭТерм"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Encompass"
+msgstr "Энкомпасс"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Epiphany Web Browser"
+msgstr "Epiphany вэб хөтөч"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "Evolution Mail Reader"
+msgstr "Эволюшн Мэйл Уншигч"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Evolution Mail Reader 1.4"
+msgstr "Эволюшн Мэйл Уншигч 1.4"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Evolution Mail Reader 1.5"
+msgstr "Эволюшн Мэйл Уншигч 1.5"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader 1.6"
+msgstr "Эволюшн Мэйл Уншигч 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Evolution Mail Reader 2.0"
+msgstr "Эволюшн Мэйл Уншигч 2.0"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Evolution Mail Reader 2.2"
+msgstr "Эволюшн Мэйл Уншигч 2.2"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "Evolution Mail Reader 2.4"
+msgstr "Эволюшн Мэйл Уншигч 2.4"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "GNOME Terminal"
+msgstr "ГНОМЕ Терминал"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Galeon"
+msgstr "Галеон"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "KMail"
+msgstr "КМэйл"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Konqueror"
+msgstr "Конкюрор"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Links Text Browser"
+msgstr "Зүүн текст хөтөч"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Lynx Text Browser"
+msgstr "Люнкс Текст хөтөч"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Mozilla"
+msgstr "Моцилла"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "Mozilla 1.6"
+msgstr "Моцилла 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "Mozilla Mail"
+msgstr "Моцилла Мэйл"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Mutt"
+msgstr "Мутт"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "NXterm"
+msgstr "НКСтерм"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Netscape Communicator"
+msgstr "Netscape Холбогч"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Opera"
+msgstr "Опера"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "RXVT"
+msgstr "РКСВТ"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Standard XTerminal"
+msgstr "Стандарт КСТерминал"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Sylpheed"
+msgstr "Sylpheed"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "W3M Text Browser"
+msgstr "W3M текст хөтөч"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Audio Player</b>"
+msgstr "<b>Дуу тоглуулагч</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Image Viewer</b>"
+msgstr "<b>Зураг харагч</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Instant Messenger</b>"
+msgstr "<b>Мессэнжир</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mail Reader</b>"
+msgstr "<b>Майл уншигч</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>Терминал эмулатор</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Text Editor</b>"
+msgstr "<b>Текст боловсруулагч</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Video Player</b>"
+msgstr "<b>Видео тоглуулагч</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Web Browser</b>"
+msgstr "<b>Вэб хөтөч</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "Бүх %s тохиолдолууд нь одоогийн холбоосоор солигдсон байна"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Co_mmand:"
+msgstr "Т_ушаал:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "E_xecute flag:"
+msgstr "Дарцаг _ачаалах:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Internet"
+msgstr "Интернет"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Multimedia"
+msgstr "Multimedia"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Open link in new _tab"
+msgstr "Шинэ _табд холбоос нээх"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Open link in new _window"
+msgstr "Шинэ _цонхонд холбоос нээх"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Open link with web browser _default"
+msgstr "_Стандарт вэб хөтчөөр холбоосыг нээх"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Run in t_erminal"
+msgstr "_Терминалд ажиллуулах"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "System"
+msgstr "Систем"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Дэлгэцийн нарийвчлал өөрчлөх"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Дэлгэцийн нарийвчлал"
+
+#: ../capplets/display/main.c:25
+msgid "normal"
+msgstr "энгийн"
+
+#: ../capplets/display/main.c:26
+msgid "left"
+msgstr "зүүн"
+
+#: ../capplets/display/main.c:27
+msgid "inverted"
+msgstr "Урвуу"
+
+#: ../capplets/display/main.c:28
+msgid "right"
+msgstr "баруун"
+
+#: ../capplets/display/main.c:389
+#, c-format
+msgid "%d Hz"
+msgstr "%d Гц"
+
+#: ../capplets/display/main.c:535
+msgid "_Resolution:"
+msgstr "_Нарийвчлал:"
+
+#: ../capplets/display/main.c:554
+msgid "Re_fresh rate:"
+msgstr "Хурд _шинэчилэх:"
+
+#: ../capplets/display/main.c:574
+msgid "R_otation:"
+msgstr "_Эргүүлэлт:"
+
+#: ../capplets/display/main.c:594
+msgid "Default Settings"
+msgstr "Стандарт тохиргоо"
+
+#: ../capplets/display/main.c:596
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr "%d дэлгэцийн тохиргоо\n"
+
+#: ../capplets/display/main.c:622
+msgid "Screen Resolution Preferences"
+msgstr "Дэлгэцийн нарийвчлалын тохируулга"
+
+#: ../capplets/display/main.c:659
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "_Зөвхөн энэ компьютерийг (%s) стандарт болгох"
+
+#: ../capplets/display/main.c:677
+msgid "Options"
+msgstr "Сонголтууд"
+
+#: ../capplets/display/main.c:698
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"Шинэ тохиргоог шалгаж үзэж байна. Хэрвээ та %d секундэд хариу авахгүй бол "
+"өмнөх тохиргоо сэргээгдэнэ."
+msgstr[1] ""
+"Шинэ тохиргоог шалгаж үзэж байна. Хэрвээ та %d секундэд хариу авахгүй бол "
+"өмнөх тохиргоо сэргээгдэнэ."
+
+#: ../capplets/display/main.c:744
+msgid "Keep Resolution"
+msgstr "Нарийвчлалыг хадгал"
+
+#: ../capplets/display/main.c:748
+msgid "Do you want to keep this resolution?"
+msgstr "Та энэ тохиргоог хадгалахыг хүсэж байна уу?"
+
+#: ../capplets/display/main.c:773
+msgid "Use _previous resolution"
+msgstr "Ө_мнөх тохиргоог хэрэглэнэ"
+
+#: ../capplets/display/main.c:773
+msgid "_Keep resolution"
+msgstr "Нарийвчлалыг _авах"
+
+#: ../capplets/display/main.c:923
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"XServer нь XRandR өргөтгөлийг дэмжээгүй байна.  Нарийвчлалын өөрчлөлтүүдийг "
+"ажиллагааны үед авах боломжгүй."
+
+#: ../capplets/display/main.c:931
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"Энэ програмтай XRandR өргөтгөлийн хувилбар тохирохгүй байна. Нарийвчлалын "
+"өөрчлөлтүүдийг ажиллагааны үед авах боломжгүй."
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Фонтны хэлбэр"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr "Ажлын талбарын фонтыг сонгох"
+
+#: ../capplets/font/font-properties.glade.h:1
+msgid "<b>Font Rendering</b>"
+msgstr "<b>Фонтны дүрслэл</b>"
+
+#: ../capplets/font/font-properties.glade.h:2
+msgid "<b>Hinting</b>:"
+msgstr "<b>Дохио өгөх</b>:"
+
+#: ../capplets/font/font-properties.glade.h:3
+msgid "<b>Smoothing</b>:"
+msgstr "<b>Толийлголт</b>:"
+
+#: ../capplets/font/font-properties.glade.h:4
+msgid "<b>Subpixel order</b>:"
+msgstr "<b>Subpixel дараалал</b>:"
+
+#: ../capplets/font/font-properties.glade.h:5
+msgid "Best _shapes"
+msgstr "Хамгийн сайн хэ_лбэр"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best co_ntrast"
+msgstr "Хамгийн сайн _эрчимжилт"
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "D_etails..."
+msgstr "Дэлгэ_рэнгүй..."
+
+#: ../capplets/font/font-properties.glade.h:8
+msgid "Des_ktop font:"
+msgstr "_Ажлын талбарын фонт:"
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "Фонтын тохиргоо"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr "Фонтны дүрслэлийн тодруулга"
+
+#: ../capplets/font/font-properties.glade.h:11
+msgid "Go _to font folder"
+msgstr "Фонтны лавлах руу _оч"
+
+#: ../capplets/font/font-properties.glade.h:12
+msgid "Gra_yscale"
+msgstr "Сааралж_уулалт"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "_Хаах"
+
+#: ../capplets/font/font-properties.glade.h:14
+msgid "R_esolution:"
+msgstr "_Нарийвчлал:"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr "_Subpixel (LCDs)"
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "Sub_pixel (LCDs) толийлгож байна"
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "Х._программуудын фонт:"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Document font:"
+msgstr "_Баримтын фонт:"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Fixed width font:"
+msgstr "_Фонтны өргөнийг тодорхойллоо:"
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Full"
+msgstr "_Дүүрэн"
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Medium"
+msgstr "_Дунд"
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_Monochrome"
+msgstr "_Хар-цагаан"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_None"
+msgstr "_Хаах"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Slight"
+msgstr "Бага_втар"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "_Цонхны толгойн фонт:"
+
+#: ../capplets/font/font-properties.glade.h:30
+msgid "dots per inch"
+msgstr "Ямх тус бүрийн цэг"
+
+#: ../capplets/font/main.c:489
+msgid "Font may be too large"
+msgstr "Фонтны хэв хэт том байх"
+
+#: ../capplets/font/main.c:493
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Сонгогдсон фонтын хэв %d цэгтэй том ба энэ нь компютер үр ашигтай ажиллахад "
+"бэрхшээлтэй.  Таныг фонтын хэвийн хэмжээг %d-ээс бага болгохыг зөвлөж байна."
+msgstr[1] ""
+"Сонгогдсон фонтын хэв %d цэгтэй том ба энэ нь компютер үр ашигтай ажиллахад "
+"бэрхшээлтэй.  Таныг фонтын хэвийн хэмжээг %d-ээс бага болгохыг зөвлөж байна."
+
+#: ../capplets/font/main.c:506
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Сонгогдсон фонтын хэв %d том ба энэ магад компютер үр ашигтай ажиллахад "
+"бэрхшээлтэй. Таныг фонтын бага хэмжээг сонгохыг зөвлөж байна."
+msgstr[1] ""
+"Сонгогдсон фонтын хэв %d том ба энэ магад компютер үр ашигтай ажиллахад "
+"бэрхшээлтэй.  Таныг фонтын бага хэмжээг сонгохыг зөвлөж байна."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "Шинэ хослол товчлуур..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Хослол түлхүүр"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Хослол товчлуурыг өөрчлөгч"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Хослол товчлуурын код"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Хослолын горим"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Шорткатын төрөл"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:187
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:470
+msgid "Disabled"
+msgstr "Хаагдсан"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:534
+msgid "<Unknown Action>"
+msgstr "<Тодорхойгүй үйлдэл>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:555
+msgid "Desktop"
+msgstr "Ажлын талбар"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:556
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Аудио"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:560
+msgid "Window Management"
+msgstr "Цонхны зохион байгуулалт"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:668
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become unusable to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time.\n"
+msgstr ""
+"Энэ түлхүүрийг ашиглахад хэрэглэгдэхгүй тул \"%s\" шорткатыг хэрэглэхгүй.\n"
+"Энэ түлхүүртэй Control, Alt эсвэл Shift-ийг нэгэн зэрэг дарна уу.\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:697
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+"\"%s\" Шорткат хэдийнэ хэрэглэгдсэн:\n"
+" \"%s\"\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:729
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr ""
+"Тохируулгын өгөгдлийн баазад шинэ шорткатыг оруулахад гарсан алдаа: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:779
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr "Тохируулгын өгөгдлийн баазаас шорткатыг устгах үед алдаа гарлаа: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:886
+msgid "Action"
+msgstr "Үйлдэл"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:910
+msgid "Shortcut"
+msgstr "Шорткат"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Гарын шорткат"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"Та шинэ шорткатыг нэмэхийн тулд зохих мөр ба шинэ товчлуурын хослол дээр "
+"дарна эсвэл арилгахын тулд Backspace-товчлуурыг дарна"
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Тушаалуудад шорткат оноох"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:87
+msgid "Unknown"
+msgstr "Үл мэдэгдэх"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:282
+msgid "Layout"
+msgstr "Үзэмж"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:286
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:231
+msgid "Default"
+msgstr "Стандарт"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:77
+msgid "Models"
+msgstr "Модел"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:109
+#, c-format
+msgid "There was an error launching the keyboard tool: %s"
+msgstr "Гарны хэрэгслэлийг ачаалахад алдаа гарлаа: %s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr "_Хялбарчилал"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:758
+#: ../capplets/sound/sound-properties-capplet.c:760
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+"Зөвхөн тохируулга хэрэглээд гарах (Зөвхөн зүй зохицолд; одоо daemon-оор "
+"боловсруулагдана)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr "Завсарлага тохируулгыг агуулах хуудасны эхлэлийг харуулах"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Анивчдаг түүчээ</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Товчлуурын давталт</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<b>Дэлгэц _түгжээд завсарлага шаардах</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Хурдан</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Урт</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Богино</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Удаан</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "A_vailable layouts:"
+msgstr "Байгаа ү_зэмжүүд:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "All_ow postponing of breaks"
+msgstr "Завсарлага зөөлт _зөвшөөрөх"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Завсарлага зөөлт зөвшөөрөх эсэхийг тогтоо"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Choose a Keyboard Model"
+msgstr "Гарын загвараа сонгоно уу"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "Choose a Layout"
+msgstr "Гарын засвар сонгох"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Choose..."
+msgstr "Сонгох..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr "Түүчээг текст талбар болон текст дотор а_нивчуулах"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Cursor blinks speed"
+msgstr "Түүчээ анивчих хурд"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of the break when typing is disallowed"
+msgstr "Бичих үед гарсан завсарлагын үргэлжлэх хугацаа"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Duration of work before forcing a break"
+msgstr "Завсарлага шаардагдахаас өмнөх ажлын хугацаа"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Key presses _repeat when key is held down"
+msgstr "Хэрвээ товчлуур доош дарагдсан бол түүнийг _давтах"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Keyboard Preferences"
+msgstr "Гарын тохируулга"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Keyboard _model:"
+msgstr "Гарын _загвар:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Layout Options"
+msgstr "Үзэмж сонголт"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Layouts"
+msgstr "Үзэмж"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr "Санамсаргүй эсвэл гажуудал товч дарагдахаас хамгаалж дэлгэц түгжих"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Microsoft Natural Keyboard"
+msgstr "Microsoft Natural Гар"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Preview:"
+msgstr "Тольдох:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "Repeat keys speed"
+msgstr "Түлхүүр давтагдах хурд"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Reset To De_faults"
+msgstr "_Стандартыг сэргээх"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Separate _group for each window"
+msgstr "Цонх бүрийн тусгай бүлгүүд"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+msgid "Typing Break"
+msgstr "Бичих үеийн завсарлага"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Accessibility..."
+msgstr "_Хялбарчилал..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Add..."
+msgstr "_Нэмэх..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "_Break interval lasts:"
+msgstr "_Сүүлийн завсарлагын интервал:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Delay:"
+msgstr "_Хүлээлт:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Models:"
+msgstr "_Модел:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Selected layouts:"
+msgstr "_Сонгогдсон үзэмжүүд:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Speed:"
+msgstr "Х_урд:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "_Work interval lasts:"
+msgstr "_Сүүлийн ажлын интервал:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "minutes"
+msgstr "Минут"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Өөрийн гарын тохируулгыг тогтоох"
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:891
+#, c-format
+msgid "%d millisecond"
+msgid_plural "%d milliseconds"
+msgstr[0] "%d миллисекунд"
+msgstr[1] "%d миллисекунд"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:567
+msgid "Unknown Pointer"
+msgstr "Тодорхойгүй түүчээ"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "Default Pointer"
+msgstr "Стандарт түүчээ"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+msgid "Default Pointer - Current"
+msgstr "Стандарт түүчээ- Идэвхитэй"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:770
+msgid "The default pointer that ships with X"
+msgstr "X -н стандарт түүчээ"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "White Pointer"
+msgstr "Цагаан түүчээ"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+msgid "White Pointer - Current"
+msgstr "Цагаан түүчээ - Идэвхитэй"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:776
+msgid "The default pointer inverted"
+msgstr "Урвуулсан стандарт түүчээ"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large Pointer"
+msgstr "Том түүчээ"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+msgid "Large Pointer - Current"
+msgstr "Том түүчээ - Идэвхитэй"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:782
+msgid "Large version of normal pointer"
+msgstr "Энгийн түүчээний том хувилбар"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:786
+msgid "Large White Pointer - Current"
+msgstr "Том цагаан түүчээ - Идэвхитэй"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:787
+msgid "Large White Pointer"
+msgstr "Том цагаан түүчээ"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:788
+msgid "Large version of white pointer"
+msgstr "Цагаан түүчээний том хувилбар"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:981
+msgid "Pointer Theme"
+msgstr "Түүчээний сэдэв"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr "<b>Давхар товшилтын Х/И завсар</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Татаад тавих</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Түүчээний байрлал</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>Хулганы чиглэл</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Speed</b>"
+msgstr "<b>Хурд</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>Хурдан</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>Өндөр</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>Том</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>Бага</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>Удаан</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>Жижиг</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Товчнууд"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr "Таныг Ctrl дарахад _түүчээг онцгойлох"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Large"
+msgstr "Том"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Medium"
+msgstr "Дунд"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "Motion"
+msgstr "Хөдөлгөөн"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+msgid "Mouse Preferences"
+msgstr "Хулганы тохируулга"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Pointer Size:"
+msgstr "Түүчээний хэмжээ:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Pointers"
+msgstr "Түүчээнүүд"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "Small"
+msgstr "Жижиг"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr "Ху_рдасгалт:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr "_Зүүн гарын хулгана"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr "_Мэдрэмж:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr "_Хязгаар:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr "_Завсар:"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Хулгана"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Хулганы тохируулга хийх"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Сүлжээ-итгэмжлэгч"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "Сүлжээ-итгэмжлэгчийн тохируулгыг хийх"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>Интернэтийн _шууд холболт</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr "<b>Хостын жагсаалтаас татгалзах</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>Итгэмжлэгчийн _автомат тохируулга</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>Итгэмжлэгчийн _гар тохируулга</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Гэрчилгээ хэрэглэнэ</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "Advanced Configuration"
+msgstr "Нарийвчилсан тохируулга"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr "Автомат тохируулгын _URL:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "HTTP-итгэмжлэгч дэлгэрэнгүй"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "_HTTP-итгэмжлэгч:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Network Proxy Preferences"
+msgstr "Сүлжээ-итгэмжлэгчийн тохируулга"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Порт:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "Proxy Configuration"
+msgstr "Итгэмжлэгчийн тохируулга"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr "S_ocks-хост:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "U_sername:"
+msgstr "_Хэрэглэгчийн нэр:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_Дэлгэрэнгүй"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr "_FTP-итгэмжлэгч:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "_Нэвтрэх үг:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr "_HTTP-итгэмжлэгчийг баталгаажуулах:"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Чимээг идэвхижүүлж үйлдлүүдтэй холбох"
+
+#: ../capplets/sound/sound-properties-capplet.c:317
+#: ../capplets/sound/sound-properties-capplet.c:369
+msgid "Not connected"
+msgstr "Холбогдсонгүй"
+
+#: ../capplets/sound/sound-properties-capplet.c:792
+msgid "Sound Preferences"
+msgstr "Чимээний тохируулга"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "<b>Audio Conferencing</b>"
+msgstr "<b>Дуут чуулган</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "<b>Music and Movies</b>"
+msgstr "<b>Хөгжим ба кино</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "<b>Sound Events</b>"
+msgstr "<b>Дууны үйлдлүүд</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+msgstr "<span weight=\"bold\" size=\"larger\">Шалгаж байна...</span>"
+
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Click OK to finish."
+msgstr "Дуусгахдаа OK дээр дарна уу."
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "Devices"
+msgstr "Төхөөрөмжүүд"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "E_nable software sound mixing (ESD)"
+msgstr "Програм хангамжийг чимээтэй хослуулах боломжтой"
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "Flash _entire screen"
+msgstr "_Бүх дэлгэцийг гэрэлтүүлэх"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "Flash _window titlebar"
+msgstr "_Цонхны гарчиг самбарыг гэрэлтүүлэх"
+
+#: ../capplets/sound/sound-properties.glade.h:11
+msgid "Sound & Video Preferences"
+msgstr "Чимээ ба видеоны тохируулга"
+
+#: ../capplets/sound/sound-properties.glade.h:12
+msgid "Sound Capture:"
+msgstr "Дууны хүч:"
+
+#: ../capplets/sound/sound-properties.glade.h:13
+msgid "Sound Playback:"
+msgstr "Дуу тоглуулах:"
+
+#: ../capplets/sound/sound-properties.glade.h:14
+msgid "Sounds"
+msgstr "Чимээнүүд"
+
+#: ../capplets/sound/sound-properties.glade.h:15
+msgid "System Beep"
+msgstr "Системийн дохио"
+
+#: ../capplets/sound/sound-properties.glade.h:16
+msgid "Test"
+msgstr "Тест"
+
+#: ../capplets/sound/sound-properties.glade.h:17
+msgid "Testing Pipeline"
+msgstr "Pipeline шалгаж байна"
+
+#: ../capplets/sound/sound-properties.glade.h:18
+msgid "_Enable system beep"
+msgstr "Системийн дохио _идэвхжүүлэх"
+
+#: ../capplets/sound/sound-properties.glade.h:19
+msgid "_Play system sounds"
+msgstr "_Системд дуу тоглуулах"
+
+#: ../capplets/sound/sound-properties.glade.h:20
+msgid "_Visual system beep"
+msgstr "_Системийн дохиог харуулах"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:368
+msgid "Would you like to remove this theme?"
+msgstr "Та энэ загварыг устгахыг хүсч байна уу?"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:433
+msgid "Theme deleted succesfully. Please select another theme."
+msgstr "Загвар амжилттай устгагдлаа. Өөр сэдэв сонгоно уу."
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:442
+msgid "Theme can not be deleted"
+msgstr "Загвар устгагдсангүй"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:535
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+"Таны системд загвар олдсонгүй. Энэ нь магад таны »Загвар тохируулга« эсвэл "
+"»gnome-themes« пакет зөв суугаагүй гэсэн үг."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:255
+msgid "This theme is not in a supported format."
+msgstr "Энэ загвар нь дэмжигдээгүй формат байна."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:273
+msgid "Failed to create temporary directory"
+msgstr "Түр зуурын директор үүсэх боломжгүй байна"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:294
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+"Загвар суухгүй байна. \n"
+" bzip2 хэрэглээ суусангүй. "
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:313
+#: ../capplets/theme-switcher/gnome-theme-installer.c:352
+#: ../capplets/theme-switcher/gnome-theme-installer.c:432
+msgid "Installation Failed"
+msgstr "Суулгалт нурлаа"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:334
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+"Загвар суухгүй байна. \n"
+"gzip хэрэглээ суусангүй. "
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:378
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "%s ГНОМЕ Загвар амжилттай суулаа"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:388
+msgid "The theme is an engine. You need to compile the theme."
+msgstr "Загвар бол үйл ажиллагааны нэгж юм. Та загварыг эмхтгэх хэрэгтэй."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:406
+msgid "The file format is invalid"
+msgstr "Файлын формат хүчингүй байна"
+
+#. TODO: currently cannot apply "gnome themes"
+#: ../capplets/theme-switcher/gnome-theme-installer.c:452
+#, c-format
+msgid ""
+"<span weight=\"bold\" size=\"larger\">The theme \"%s\" has been installed.</"
+"span>\n"
+"\n"
+"Would you like to apply it now, or keep your current theme?"
+msgstr ""
+"<span weight=\"bold\" size=\"larger\">Загвар \"%s\" суусан байна.</span>\n"
+"\n"
+"Та үүнийг хэрэглэхийг хүсэж байна уу одоогийнхыгоо авч үлдэх үү?"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:455
+msgid "Keep Current Theme"
+msgstr "Одоогийн загварыг авч үлдэх"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:457
+msgid "Apply New Theme"
+msgstr "Шинэ загварыг хэрэглэх"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:531
+msgid "No theme file location specified to install"
+msgstr "Файлын загвар суулгах байрлалыг тодорхойлоогүй байна"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:546
+msgid "The theme file location specified to install is invalid"
+msgstr "Файлын загвар суулгах байрлал хүчингүй"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:566
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"Загварыг суулгахад орох боломжгүй зөвшөөрөл:\n"
+"%s"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:587
+msgid "The file format is invalid."
+msgstr "Файлын формат хүчингүй байна."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:614
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+"%s бол загварын файлууд суулгах зам. Тиймээс тэр эх байрлалаар хэрэглэгдэх "
+"боломжгүй"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:686
+msgid "Custom theme"
+msgstr "Хэвшмэл загвар"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:686
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr "Та »Загвар хадгалах«-товчийг товшиж энэ загварыг хадгалаж болно."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1604
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+"Таны системд стандарт загварын схем олдсонгүй. Энэ нь таныг Metacity "
+"суулгаагүй эсвэл таны GConf алдаатай тохируулагдсаныг зааж байна."
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:73
+msgid "Theme name must be present"
+msgstr "Загварийн нэр үзүүлэгдэх ёстой"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:144
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Завар байна. Та үүнийг солих уу?"
+
+# CHECK
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr "Ажлын талбарын янз бүрийн хэсгүүдийн хувьд загвар тогтоох"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "Загвар"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "<b>You do not have permission to change theme settings</b>"
+msgstr "<b>Танд загварын тохиргоо өөрчилөх эрх алга</b>"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "Apply _Background"
+msgstr "_Дэвсгэрийг хэрэглэх"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Apply _Font"
+msgstr "_Бичгийг хэрэглэх"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Controls"
+msgstr "Хяналтууд"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Icons"
+msgstr "Эмблемүүд"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "Save Theme"
+msgstr "Загвар хадгалах"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "Save _Background Image"
+msgstr "_Дэвсгэр зургийг хадгалах"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+msgid "Select theme for the desktop"
+msgstr "Ажлын талбары загварыг сонгох"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+msgid "Theme Details"
+msgstr "Загварын тодруулга"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+msgid "Theme Preferences"
+msgstr "Загвар тохируулгууд"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "Theme _Details"
+msgstr "Загвар _тодруулга"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "This theme does not suggest any particular font or background."
+msgstr "Энэ загвар тодорхой дэвсгэр болон фонтыг санал болгохгүй байна."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+msgid "This theme suggests a background:"
+msgstr "Энэ загвар тохирох дэвсгэрийг санал болгож байна:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+msgid "This theme suggests a font and a background:"
+msgstr "Энэ загвар тохирох дэвсгэр болон фонтыг санал болгож байна:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+msgid "This theme suggests a font:"
+msgstr "Энэ загвар тохирох фонтыг санал болгож байна:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+msgid "Window Border"
+msgstr "Цонхны хүрээ"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+msgid "_Description:"
+msgstr "_Тодорхойлолт:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "_Install Theme..."
+msgstr "Загвар _суулгах..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+msgid "_Install..."
+msgstr "_Суулгаж байна..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+msgid "_Name:"
+msgstr "_Нэр:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+msgid "_Revert"
+msgstr "_Урвуулах"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+msgid "_Save Theme..."
+msgstr "Загвар _хадгалах..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:24
+msgid "theme selection tree"
+msgstr "Загвар сонголтын мод"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr "Х.програмийн багажны ба цэсний самбарын харагдалтыг тохируулах"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "Цэс ба багажны самбар"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr "<b>Харьцаа ба харагдац</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+msgid "<b>Preview</b>"
+msgstr "<b>Урьд. харах</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "_Тасдах"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+msgid "Icons only"
+msgstr "Зөвхөн эмблем"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "Цэс ба багажны самбарын тохируулга"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "Шинэ файл"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Файл нээх"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Файл хадгалах"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr "Цэсэнд _тэмдэгүүдийг харуулах"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+msgid "Text below icons"
+msgstr "Эмблемийн доор текст"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+msgid "Text beside icons"
+msgstr "Эмблемийн дэргэд текст"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+msgid "Text only"
+msgstr "Зөвхөн текст"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+msgid "Toolbar _button labels:"
+msgstr "Түүлбар _товчны бичээс:"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_Хуулах"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr "Салгах _боломжит багажны самбар"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_Боловсруулах"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr "_Боловсруулах боломжтой цэсний хурдасгуур"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "_Файл"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_Шинэ"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "Нэ_эх"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "_Буулгах"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "Хэ_влэх"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "_Дуусгах"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "Ха_дгалах"
+
+#: ../capplets/windows/gnome-window-properties.c:385
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+"<b>Таны цонхны менежерийн тохируулга х.программыг эхлүүлж чадахгүй байна</"
+"b>\n"
+"\n"
+"%s"
+
+#: ../capplets/windows/gnome-window-properties.c:642
+msgid "C_ontrol"
+msgstr "_Хяналт"
+
+#: ../capplets/windows/gnome-window-properties.c:647
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:653
+msgid "H_yper"
+msgstr "H_yper"
+
+#: ../capplets/windows/gnome-window-properties.c:660
+msgid "S_uper (or \"Windows logo\")"
+msgstr "_Супер (эсвэл \"Цонхны тэмдэг\")"
+
+#: ../capplets/windows/gnome-window-properties.c:667
+msgid "_Meta"
+msgstr "_Мета"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Шилжүүлэгч товч</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>Толгой самбарны үйлдлүүд</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Цонхны сонголт</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr "Цонх зөөхдөө дараах товчийг дараад барьж цонхонд хүрнэ:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Цонхны тохируулга"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "Энэ үйлдлийг гүйцэтгэхдээ толгой самбарыг _давхар товшино:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "_Өргөлтийн өмнөх хүлээлт:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "Идэвхижсэн цонх тодорхой хугацааны дараа ө_ргөгдөх"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Хулганыг дээгүүр нь хөдөлгөхөд цонхнуудыг сонгоно"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "Цонхны тохируулгыг хийх"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Цонх"
+
+#: ../control-center/control-center-categories.c:287
+msgid "Others"
+msgstr "Бусад"
+
+#: ../control-center/control-center.c:93
+msgid "Desktop Preferences"
+msgstr "Ажлын талбарын тохируулгууд"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr "GNOME-Хянах төв"
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "GNOME-тохируулгын хэрэгсэл"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "Дуу"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:406
+msgid "Slow Keys Alert"
+msgstr "Удаашруулах товчлуурын дохио"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:407
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Та Shift товчлуурыг 8 секунт даржээ. Энэ нь гарын ажиллагаанд нөлөөлдөг "
+"удаашруулах товчлуурын үйл ажиллагааны хослол юм."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:409
+msgid "Do you want to activate Slow Keys?"
+msgstr "Та удаашруулах товчлуурыг идэвхижүүлэхийг хүсч байна уу?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Do you want to deactivate Slow Keys?"
+msgstr "Та удаашруулах товчлуурыг идэвхигүйжүүлэхийг хүсч байна уу?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
+msgid "_Activate"
+msgstr "_Идэвхижүлэх"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:428
+msgid "_Deactivate"
+msgstr "_Идэвхгүй болгох"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
+msgid "Do_n't activate"
+msgstr "_Бүү идэвхижүүл"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:412
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:429
+msgid "Do_n't deactivate"
+msgstr "_Бүү идэвхигүйжүүл"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:421
+msgid "Sticky Keys Alert"
+msgstr "Наалт товчлуурын дохио"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:422
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Та Shift товчлуурыг 5 удаа дараалуулан даржээ. Энэ нь таны гарын ажиллагаанд "
+"нөлөөлдөг наалт товчлуурын үйл ажиллагааны хослол юм."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:424
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+"Та хоёр товчлуурыг нэг удаа эсвэл Shift товчлуур 5 удаа дараалуулан даржээ. "
+"Энэ нь таны гарын ажиллагаанд нөлөөлдөг наалт шорткатын үйл ажиллагааг "
+"унтраана."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:426
+msgid "Do you want to activate Sticky Keys?"
+msgstr "Та наалт товчлуурыг идэвхижүүлэхийг хүсч байна уу?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:427
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr "Та наалт товчлуурыг идэвхгүйжүүлэхийг хүсч байна уу?"
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:74
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing the mouse pointer theme."
+msgstr ""
+"\"%s\" лавлах үүсгэж чадсангүй.\n"
+"Энэ нь түүчээний загварыг өөрчилөхөд шаардлагатай."
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:96
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+"\"%s\" лавлах үүсгэж чадсангүй.\n"
+"Энэ нь түүчээ өөрчилөхөд шаардлагатай."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:208
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr "Шорткатын (%s) хувьд олон дахин үйлдэл тогтоох\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:221
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr "Шорткат (%s) нь олон удаагаар тогтоогддог\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:227
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr "Шорткат (%s) бүрэн бус\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:255
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr "Шорткат (%s) хүчингүй\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:291
+#, c-format
+msgid "It seems that another application already has access to key '%u'."
+msgstr "Өөр програм хэдийнээ '%u' түлхүүрт олгогдсон бололтой байна."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:360
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr "Шорткат (%s) хэдийнээ хэрэглээнд байна\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:435
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr "(%2$s) товчлуурт холбогдсон (%1$s)-г ажиллуулах үед алдаа гарлаа"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:105
+#, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+"XKB-тохиргоо идэвхжих үед алдаа гарлаа.\n"
+"Энэ нь олон төрлийн нөхцөл байдлаас болно.\n"
+"-libxklavier номын сангийн програмын алдаа\n"
+"-Х Серверийн алдаа (xkbcomp, xmodmap utilities)\n"
+"-Х Сервер libxkbfile- тэй ажиллахад тохирохгүй\n"
+"\n"
+"Х Серверийн хувилбарын өгөгдөл:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"Хэрвээ та энэ байдлыг алдаагаар тайлагнахыг хүсвэл дараахыг хавсаргана уу:\n"
+"- <b>%s</b>-н үр дүн\n"
+"- <b>%s</b>-н үр дүн"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:119
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+"Та XFree 4.3.0 хэрэглэж байна.\n"
+"Нийлмэл XKB тохиргооны хувьд тодорхой бэрхшээлүүд байдаг.\n"
+"Энгийн тохиргоо хэрэглэх эсвэл XFree-н илүү шинэ хувилбар хэрэглэхийг "
+"оролдоно уу."
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:249
+msgid "Do _not show this warning again"
+msgstr "_Энэ сануулгыг дахин бүү харуул"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:263
+#, c-format
+msgid ""
+"<b>The X system keyboard settings differ from your current GNOME keyboard "
+"settings.</b>\n"
+"\n"
+"Expected was %s, but the the following settings were found: %s.\n"
+"\n"
+"Which set would you like to use?"
+msgstr ""
+"<b>Х систем гарын тохируулга нь таны одоогийн  ГНОМЕ гарын тохируулгаас "
+"ялгаатай.</b>\n"
+"\n"
+"%s тохирох байсан боловч дараах тохиргоотой байна: %s.\n"
+"\n"
+"Та алийг нь хэрэглэхийг хүсч байна вэ?"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:286
+msgid "Use X settings"
+msgstr "Х тохиргоог хэрэглэх"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:288
+msgid "Keep GNOME settings"
+msgstr "GNOME тохиргоог хэрэглэх"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:118
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+"Тушаал биелсэнгүй: %s\n"
+"Энэ тушаал байгаа эсэхийг нягтал."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:134
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+"Тооцоолуурыг унтуулах горимд оруулж чадсангүй.\n"
+"Тооцоолуураа зөв тохируулсан эсэхээ нягтлана уу."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:168
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+"Glade файл ачаалагдсангүй.\n"
+"Энэ хэвтүүл зөв суусан эсэхийг нягтлана уу."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:110
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+"Дэлгэцийг эхлүүлэхэд алдаа гарлаа:\n"
+"\n"
+"%s\n"
+"\n"
+"Дэлгэцийн энэ хугацаанд ажиллахгүй."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:120
+msgid "_Do not show this message again"
+msgstr "_Энэ мэдээг дахин бүү харуул"
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:127
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr " %s дууны файл %s жишээгээр ачаалагдсангүй"
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:212
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:260
+msgid "Cannot determine user's home directory"
+msgstr "Хэрэглэгчийн гэр лавлахыг илрүүлж чадсангүй"
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:212
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr ""
+"GConf түлхүүр %s нь %s төрөлтэй боловч түүний тохирох төрөл нь %s байлаа\n"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+msgid "A_vailable files:"
+msgstr "_Боломжит файлууд:"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+msgid "Do _not show this warning again."
+msgstr "_Энэ сануулгыг дахин бүү харуул"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr "modmap файлыг ачаалж байна"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr "modmap файлыг ачаалахыг хүсч байна уу?"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr "_Ачаалах"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+msgid "_Loaded files:"
+msgstr "_Ачаалагдсан файлууд:"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr "Сигналын шугам үүсгэх үеийн алдаа."
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Төрөл"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+"Дэвсгэр хэрэглэгчийн төрөл (bg_applier): »root« цонхны хувьд BG_APPLIER_ROOT "
+"эсвэл урьдчилан харахад BG_APPLIER_PREVIEW"
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr "Урьд.харах өргөн"
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr "Хэрэглэгч урьдчилан харах үеийн өргөн : Стандартаар 64."
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr "Урьд.харах өндөр"
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr "Хэрэглэгч урьдчилан харах үеийн өндөр : Стандартаар 48."
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Дэлгэц"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr "BGApplier зурагдах ёстой дэлгэц"
+
+#: ../libsounds/sound-view.c:43
+msgid "Login"
+msgstr "Логин"
+
+#: ../libsounds/sound-view.c:44
+msgid "Logout"
+msgstr "Гарах"
+
+#: ../libsounds/sound-view.c:45
+msgid "Boing"
+msgstr "Boing"
+
+#: ../libsounds/sound-view.c:46
+msgid "Siren"
+msgstr "Siren"
+
+#: ../libsounds/sound-view.c:47
+msgid "Clink"
+msgstr "Жингэнэх"
+
+#: ../libsounds/sound-view.c:48
+msgid "Beep"
+msgstr "Дохио"
+
+#: ../libsounds/sound-view.c:49
+msgid "No sound"
+msgstr "Дуугүй"
+
+#: ../libsounds/sound-view.c:131
+msgid "Sound not set for this event."
+msgstr "Энэ үйлдэлд чимээ байхгүй"
+
+#: ../libsounds/sound-view.c:140
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package for a set of default sounds."
+msgstr ""
+"Энэ үйлдийн хувьд тогтоосон дууны файл алга.\n"
+"Та стандарт дуугаар авахыг хүсэж байвал »gnome-audio« пакетыг суулгана уу."
+
+#: ../libsounds/sound-view.c:151
+msgid "The sound file for this event does not exist."
+msgstr "Энэ үйлдийн хувьд дууны файл байхгүй."
+
+#: ../libsounds/sound-view.c:182
+msgid "Select Sound File"
+msgstr "Дууны файл сонгоно уу"
+
+#: ../libsounds/sound-view.c:202
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "%s файл хүчингүй wav файл байна"
+
+#: ../libsounds/sound-view.c:359
+msgid "System Sounds"
+msgstr "Системийн чимээ"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "»%s« цонхны менежер тохируулгын хэрэгслээр бүртгүүлээгүй байна\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Томсгох"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Эвхэх"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr "»text/plain« ба »text/*« -н хувьд MIME-тодорхойлогчийг хадгалах"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr "»text/plain« ба »text/*«-тодорхойлогчуудын зэрэгцүүлэх (Sync)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "E-mail"
+msgstr "Э-Шуудан"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "E-mail's shortcut."
+msgstr "Э-шуудангийн шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Eject"
+msgstr "Түлхэх"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Eject's shortcut."
+msgstr "Түлхэлтийн шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "Home folder"
+msgstr "Гэр хавтас"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "Home folder's shortcut."
+msgstr "Хувийн гэрийн хавтасны шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Launch help browser"
+msgstr "Тусламж хөтчийг эхлүүлэх"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+msgid "Launch help browser's shortcut."
+msgstr "Тусламж хөтөчийн шорткот эхлүүлэх."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+msgid "Launch web browser"
+msgstr "Вэб хөтөч эхлүүлэх"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+msgid "Launch web browser's shortcut."
+msgstr "Вэб хөтөч шорткат эхлүүлэх"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+msgid "Lock screen"
+msgstr "Дэлгэц түгжих"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+msgid "Lock screen's shortcut."
+msgstr "Дэлгэц түгжих шорткат"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+msgid "Log out"
+msgstr "Гарах"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+msgid "Log out's shortcut."
+msgstr "Гарах шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+msgid "Next track key's shortcut."
+msgstr "Дараагийн гарчиг шорткат"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+msgid "Pause"
+msgstr "Зогсоолт"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+msgid "Pause key's shortcut."
+msgstr "Зогсоолтын шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+msgid "Play (or play/pause)"
+msgstr "Тоглуулах (Тоглуулах/Зогсоох)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Play (or play/pause) key's shortcut."
+msgstr "Тоглуулах (Тоглуулах/Зогсоох) шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Previous track key's shortcut."
+msgstr "Өмнөх гарчиг шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Search"
+msgstr "Хайх"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Search's shortcut."
+msgstr "Хайлтын шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Skip to next track"
+msgstr "Дараагийн дуу алгасах"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Skip to previous track"
+msgstr "Өмнөх дуу алгасах"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Sleep"
+msgstr "Унтуулах"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+msgid "Sleep's shortcut."
+msgstr "Унтуулах шорткат"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Stop playback key"
+msgstr "Тоглуулалт таслах товчлуур"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Stop playback key's shortcut."
+msgstr "Тоглуулалт таслах шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Volume down"
+msgstr "Дуу сулруулах"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+msgid "Volume down's shortcut."
+msgstr "Дуу сулруулах шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Volume mute"
+msgstr "Дуу хаах"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Volume mute's shortcut"
+msgstr "Дуу хаах шорткат"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume step"
+msgstr "Дуу чангаруулалтын алхам"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume step as percentage of volume."
+msgstr "Дуу чангаруулалтын алхамын чимээний хувь"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume up"
+msgstr "Дуу чангаруулах"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume up's shortcut."
+msgstr "Дуу чангаруулах шорткат."
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr "XScreenSaver ажиллаж байх үед алдаа гарвал диалог харуулах"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+msgid "Run screensaver at login"
+msgstr "Бүртгүүлэхэд дэлгэц гамнагч ажиллуулах"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr "Эхлэлийн алдааг харуулах"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+msgid "Start screensaver"
+msgstr "Дэлгэц гамнагч эхлүүлэх"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr "Үсгийн цуглуулгыг ажиллуулах бүрд гар дахин ачаалагдана."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr "modmap-ийн файлын жагсаалт $HOME лавлахад байна."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr "Цонхны үүсэлтэд стандарт бүлэг шаардлагатай"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr "Цонх тус бүрийн бүлгийг хадгалан удирдана"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+msgid "Keyboard Update Handlers"
+msgstr "Гарын шинэчлэлийг удирдах програм"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+msgid "Keyboard layout"
+msgstr "Гарын байрлал"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+msgid "Keyboard model"
+msgstr "Гарын загвар"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+msgid "Keyboard options"
+msgstr "Гарын сонголтууд"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr "Системээс gconf дахь XKB тохиргоог аль болох түргэн хасах уу (илүүдэл)"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr "Тодорхойлогчыг байрлалын бүлгүүдтэй хадгалах/сэргээх"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr "Бүлэг нэрийн оронд байрлалын нэрийг харуулах"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+"Групп нэрийн оронд layout нэрийг харуулах (олон байрлалуудыг зөвхөн XFree "
+"хувилбарт дэмждэг)"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr "\"X sysconfig changed\" анхааруулах мэдээг үгүйсгэх"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid "The Keyboard Preview, X offset"
+msgstr "Гарын тольдолт, X офсет"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+msgid "The Keyboard Preview, Y offset"
+msgstr "Гарын тольдолт, Y офсет"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+msgid "The Keyboard Preview, height"
+msgstr "Гар тольдолт, өндөр"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "The Keyboard Preview, width"
+msgstr "Гар тольдолт, өргөн"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:18
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+"Удахгүй gconf дахь гарын тохиргоо дарагдана (систем тохиргооноос) Энэ "
+"түлхүүр нь GNOME 2.12-оос хойш буруушаагдах болсон, стандарт системийн "
+"тохиргоог хадгалах загвар, байрлал ба сонголтуудыг үлдээнэ үү."
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:19
+msgid "keyboard layout"
+msgstr "Гарын засвар"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:20
+msgid "keyboard model"
+msgstr "Гарын загвар"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:21
+msgid "modmap file list"
+msgstr "modmap файлын жагсаалт"
+
+#: ../typing-break/drw-break-window.c:213
+msgid "_Postpone break"
+msgstr "Завсарлага _зөөх"
+
+#: ../typing-break/drw-break-window.c:260
+msgid "Take a break!"
+msgstr "Завсарла!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:128
+msgid "/_Preferences"
+msgstr "/_Тохируулга"
+
+#: ../typing-break/drwright.c:129
+msgid "/_About"
+msgstr "_Тухай"
+
+#: ../typing-break/drwright.c:131
+msgid "/_Take a Break"
+msgstr "/_Засарла"
+
+#: ../typing-break/drwright.c:488
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "Дараагийн завсарлага хүртэл %d минут"
+msgstr[1] "Дараагийн завсарлага хүртэл %d минут"
+
+#: ../typing-break/drwright.c:492
+msgid "Less than one minute until the next break"
+msgstr "Дараагийн завсарлага хүртэл нэг хүрэхгүй минут"
+
+#: ../typing-break/drwright.c:579
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Цохилт-тодруулга диалог дараах алдааны шалтгааны улмаас нээгдэх боломжгүй: %s"
+
+#: ../typing-break/drwright.c:599
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "Richard Hult &lt;richard@imendio.com&gt; бичив."
+
+#: ../typing-break/drwright.c:600
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Anders Carlsson Eye candy -г нэмсэн."
+
+#: ../typing-break/drwright.c:623
+msgid "Typing Monitor"
+msgstr "Шивэлт шалгагч"
+
+#: ../typing-break/drwright.c:625
+msgid "A computer break reminder."
+msgstr "Компьютерийн хуьд завсарлага сануулагч."
+
+#: ../typing-break/main.c:100
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Мэдээлэл харуулахаар дэлгэцэнд бичихэд сонордуулга муж хэрэглэдэг. Таны "
+"удирдах самбарт сонордуулгын муж байхгүй шиг байна. Та удирдах самбарынхаа "
+"дээр очиж хулганы баруун товшуураар 'Самбарт нэмэх' дараа нь 'Сонордуулга "
+"муж'-г сонгож 'Нэмэх'-ийг товшино."
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "Чихний чимэг болсон аялгуу сайхан монгол хэл. 0123456789"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "Нэр:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "Загвар:"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "Төрөл:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "Хэмжээ:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "Хувилбар:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "Зохиогчийн эрх:"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "Тодорхойлолт:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "Хэрэглээ: %s фонт файл\n"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr "Програмны бичгээр хэрэглэх"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+msgid "Sets the default application font"
+msgstr "Программын стандарт фонтыг сонгоно уу"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "OpenType бичгүүдээр бяцхан зураг загварт харуулах уу?"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "PCF бичгүүдээр бяцхан зураг загварт харуулах уу?"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "TrueType бичгүүдээр бяцхан зураг загварт харуулах уу?"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "Type1-бичгүүдээр бяцхан зураг загварт харуулах уу?"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"OpenType бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
+"тогтоо."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+"PCF бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг тогтоо."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"TrueType бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
+"тогтоо."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"Type1 бичгүүдийн хувьд бяцхан зураг үүсгэх тушаалдаа та энэ түлхүүрийг "
+"тогтоо."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "OpenType-бичгүүдийг урьдчилан харах тушаал"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "PCF-бичгүүдийг урьдчилан харах тушаал"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "TrueType-бичгүүдийг урьдчилан харах тушаал"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Type1-бичгүүдийг урьдчилан харах тушаал"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "OpenType-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "PCF-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "TrueType-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "Type1-бичгүүдийг бяцхан зураг загварээр харуулах эсэх?"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+msgid "GNOME Font Viewer"
+msgstr "GNOME Фонт харагч"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr "<span weight=\"bold\" size=\"larger\">Шинэ фонт хэрэглэхүү?</span>"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr "Бичгийг хэрэглэх_гүй"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"Энэ загвар нэгэн шинэ фонтын хэв суулгахыг санал болгож байна. Фонтны хэвийн "
+"хэлбэр доор харагдаж байна."
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+msgid "_Apply font"
+msgstr "_Бичгийг хэрэглэх"
+
+#: ../vfs-methods/themus/theme-method.c:518
+msgid "Themes"
+msgstr "Загвар"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "Тодорхойлолт"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr "Цонхны агуулгын загвар"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+msgid "Window border theme"
+msgstr "Цонхны хүрээний загвар"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr "Эмблемийн загвар"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr "СБЖЭӨҮЯ"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+msgid "Apply theme"
+msgstr "Загварыг хэрэглэх"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+msgid "Sets the default theme"
+msgstr "Стандарт загварыг сэргээх"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr "Хэрвээ утга үнэн бол суулгасан загварууд мини харагдана."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr "Хэрвээ утга үнэн бол загварууд мини харагдана."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+"Суулгасан загваруудын мини харагдац үүсгэхийн тулд энэ тушаал гүйцэтгэгдэнэ."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr "Загваруудын мини харагдац үүсгэхийн тулд энэ тушаал гүйцэтгэгдэнэ."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr "Суулгасан загваруудыг мини харах тушаал"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr "Загваруудыг мини харах тушаал"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr "Суулгасан загваруудыг мини харах эсэх"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr "Загваруудыг мини харах эсэх"
+
+msgid "Show help options"
+msgstr "Тусламж харуулах"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,9 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: mr\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-09-21 04:32+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-09-21 16:16+0530\n"
 "Last-Translator: Sandeep Shedmake <sshedmak@redhat.com>\n"
 "Language-Team: Marathi <maajhe-sanganak@freelists.org>\n"
@@ -20,5980 +19,4780 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "ॲप्लिकेशन्स्"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "ॲप्लिकेशन्स आढळले नाही"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "प्रतिष्ठापीत झाले"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "उघडा (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "तपशीलचे दृष्य"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "शोधा"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "अकार्यान्वित"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "सूचना"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "सूचना दाखवा (_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "पार्श्वभूमी"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "स्क्रीनशॉटस्"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "वॉलपेपर्स्"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "आवाज"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "शॉर्टकटस्"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "कळफलक शार्टकट्स"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s कॅमेरा"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "माइक्रोफोन वॉल्युम"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "लोकेशन सर्व्हिसेस (_L)"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "बिल्टइन वेबकॅम"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "क्षेत्र आढळले नाही"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "डिस्पले प्रकार"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "लिंकचा वेग"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "मूळस्थिती"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "ॲप्लिकेशन्स्"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>उघडा</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "शैली(_S):"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "पूर्वनिर्धारीत"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "पार्श्वभूमी"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "दिवसभरातील बदल"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "प्रोफाइल समाविष्ट करा (_A)…"
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "Lock Screen"
-msgstr "पडदा कुलूपबंद करा"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "फ्रांस"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "टाइल"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "मोठे करा"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "सेंटर"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "स्केल"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "भरा"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "स्पॅन"
-
-#: ../panels/background/cc-background-chooser-dialog.c:438
-msgid "Wallpapers"
-msgstr "वॉलपेपर्स्"
-
-#: ../panels/background/cc-background-chooser-dialog.c:447
-msgid "Colors"
-msgstr "रंग"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:485
-msgid "Select Background"
-msgstr "पार्श्वभूमी नीवडा"
-
-#: ../panels/background/cc-background-chooser-dialog.c:514
-msgid "Pictures"
-msgstr "चित्र"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:546
-msgid "No Pictures Found"
-msgstr "चित्र आढळले नाही"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:564
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "गृह"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:576
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "प्रतिमांना %s फोल्डरमध्ये समाविष्ट करणे शक्य आहे आणि ते येथे आढळतील"
-
-#: ../panels/background/cc-background-chooser-dialog.c:583
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1537
-#: ../panels/display/cc-display-panel.c:1976
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1247
-#: ../panels/network/net-device-wifi.c:1440
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/cc-printers-panel.c:1947
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-#: ../panels/user-accounts/um-photo-dialog.c:95
-#: ../panels/user-accounts/um-photo-dialog.c:222
-#: ../panels/user-accounts/um-user-panel.c:513
-msgid "_Cancel"
-msgstr "रद्द करा (_C)"
-
-#: ../panels/background/cc-background-chooser-dialog.c:584
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:97
-msgid "Select"
-msgstr "नीवडा"
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "अनेक आकार"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "डेस्कटॉप पार्श्वभूमी नाही"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "सध्याची पार्श्वभूमी"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "पार्श्वभूमी प्रतिमांना वॉलपेपर किंवा छायाचित्रकरिता बदलवा"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "वॉलपेपर;स्क्रीन;डेस्कटॉप;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "ब्य्लुटूथ बंद आहे"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "सुरू करा"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "ब्ल्युटूथ अडॅप्टर्स् आढळले नाही"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "ब्ल्युटूथ शेअरिंग"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "अयरप्लैन मोड (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "हार्डवेअर स्विचतर्फे ब्ल्युटूथ बंद केले आहे"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1688
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "अयरप्लैन मोड (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "अयरप्लैन मोड (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "ब्ल्युटूथ"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "ब्ल्युटूथ सुरू करा आणि बंद करा आणि साधनांची जोडणी करा"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "चौकोनावर कॅलिब्रेशन साधन स्थित करा आणि 'सुरू करा' दाबा"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
-msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
-"कॅलिब्रेट ठिकाणावर कॅलिब्रेशन साधन स्थानांतरित करा आणि 'सुरू ठेवा' दाबा"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr "सर्फेस ठिकाणावर कॅलिब्रेशन साधन स्थानांतरित करा आणि 'सुरू ठेवा' दाबा"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "लॅपटॉप लिड बंद करा"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "निवारण अशक्य आंतरिक त्रुटी आढळली."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "कॅलिब्रेशनकरिता आवश्यक साधने इंस्टॉल केले नाही."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "प्रोफाइल निर्माण अशक्य."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "लक्ष्य वाइटपॉइंट प्राप्यजोगी नाही."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "पूर्ण झाले!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "कॅलिब्रेशन अपयशी!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "कॅलिब्रेशन साधन काढून टाकणे शक्य आहे."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "प्रगतिमध्ये असतेवेळी कॅलिब्रेशन साधनात व्यत्यय आणू नका"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "लॅपटॉप पडदा"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "बिल्टइन वेबकॅम"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s मॉनिटर"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s स्कॅनर"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s कॅमेरा"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s छपाईयंत्र"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s वेबकॅम"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s करिता रंग व्यवस्थापन सुरू करा"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s करिता रंग प्रोफाइल्स दाखवा"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-msgid "Not calibrated"
-msgstr "कॅलिब्रेट केले नाही"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "पूर्वनिर्धारीत:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "कलरस्पेस्: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "चाचणी प्रोफाइल: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "ICC प्रोफाइल फाइल निवडा"
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "आयात करा (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "समर्थीत ICC प्रोफाइल्स्"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "सर्व फाइली"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "पडदा"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "फाइल: %s अपलोड करण्यास अपयशी"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "प्रोफाइल याकरिता अपलोड केले:"
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "हे URL लिहा."
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
-msgstr "या संगणकाला पुन्हा सुरू करा आणि सर्वसाधारण कार्य प्रणालीला बूट करा."
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "प्रोफाइल डाउनलोड आणि इंस्टॉल करण्यासाठी ब्राउजरमध्ये URL टाइप करा."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "प्रोफाइल साठवा"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "साठवा (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "निवडलेल्या साधनकरीता रंग प्रोफाइल निर्माण करा"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
 msgstr ""
-"मोजमाप यंत्र आढळले नाही. ते सुरू आहे व योग्यरित्या जोडले आहे कृपया याची "
-"खात्री करा."
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "मोजमप यंत्र प्रिंटर प्रोफाइलिंगकरीता समर्थन पुरवत नाही."
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "ॲप्लिकेशन सध्या ऑडिओ चालवत किंवा रेकॉर्ड करत आहे."
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "डिव्हास प्रकार सध्या समर्थीत नाही."
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "मानक जागा"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "चाचणी प्रोफाइल"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "आणखी चित्रांकरीता तपासणी करा"
 
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "स्व"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "कमी दर्जा"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "मध्यम दर्जा"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "उच्च दर्जा"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "पूर्वनिर्धारीत RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "पूर्वनिर्धारीत CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "पूर्वनिर्धारीत भुरे"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "विक्रेतातर्फे पुरवलेले कॅलिब्रेशन डाटा"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "पडदाभर डिस्पले सुधार या प्रोफाइलसह शक्य नाही"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "हे प्रोफाइल यापुढे अचूक नसेल"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "कॅलिब्रेशन दाखवा"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr "रद्द करा"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "रद्द करा (_C)"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "सुरू करा"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "पुन्हा सुरू करा"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "पूर्ण झाले"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "झाले (_D)"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "स्क्रीन कॅलिब्रेशन"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "कॅलिब्रेशन दर्जा"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"कॅलिब्रेशन प्रोफाइल निर्माण करेल ज्याचा वापर तुम्ही पडद्यावरील रंग "
-"व्यवस्थापीत करण्यासाठी करू शकता. जेवढा जास्तवेळ कॅलिब्रेशनवर द्याल, तेवढेच "
-"उत्तम रंग प्रोफाइलचा दर्जा होईल."
+"कॅलिब्रेशन प्रोफाइल निर्माण करेल ज्याचा वापर तुम्ही पडद्यावरील रंग व्यवस्थापीत करण्यासाठी "
+"करू शकता. जेवढा जास्तवेळ कॅलिब्रेशनवर द्याल, तेवढेच उत्तम रंग प्रोफाइलचा दर्जा होईल."
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "कॅलिब्रेशन सुरू होईपर्यंत तुम्ही संगणकाचा वापर करू शकणार नाही."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "दर्जा"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "अंदाजे वेळ"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "कॅलिब्रेशन दर्जा"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "कॅलिब्रेशनकरिता वापरण्याजोगी सेंसर साधन पसंत करा."
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "कॅलिब्रेशन साधन"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "जोडणीजोगी डिस्पले प्रकार पसंत करा."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "कॅलिब्रेशनकरिता वापरण्याजोगी सेंसर साधन पसंत करा."
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "डिस्पले प्रकार"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "जोडणीजोगी डिस्पले प्रकार पसंत करा."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "प्रोफाइल व्हाइटपॉइंट"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
-"डिस्पले लक्ष्य व्हाइट पॉइंट पसंत करा. बरेच डिस्पलेजना D65 इल्युमिनंटकरिता "
-"कॅलिब्रेट केले पाहिजे."
+"डिस्पले लक्ष्य व्हाइट पॉइंट पसंत करा. बरेच डिस्पलेजना D65 इल्युमिनंटकरिता कॅलिब्रेट केले पाहिजे."
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "प्रोफाइल व्हाइटपॉइंट"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "उजळपणा दाखवा"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"कृपया डिस्पलेला तेजपणाकरिता निश्चित करा. रंग व्यवस्थापन बऱ्यापैकी या तेचपणा "
-"स्तरकरिता अचूक असते."
+"कृपया डिस्पलेला तेजपणाकरिता निश्चित करा. रंग व्यवस्थापन बऱ्यापैकी या तेचपणा स्तरकरिता "
+"अचूक असते."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
-"वैकल्पिकरित्या, तुम्ही वापरलेल्या तेजपणा स्तराचा वापर या साधनावरील इतर "
-"प्रोफाइल्ससह करू शकता."
+"वैकल्पिकरित्या, तुम्ही वापरलेल्या तेजपणा स्तराचा वापर या साधनावरील इतर प्रोफाइल्ससह करू "
+"शकता."
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "उजळपणा दाखवा"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "प्रोफाइल नाव"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
-"तुम्ही विविध संगणकांवर या रंग प्रोफाइलचा वापर करू शकता, किंवा वेगळ्या रोशानाइ "
-"अटिंकरिता प्रोफाइल्स निर्माण करू शकता."
+"तुम्ही विविध संगणकांवर या रंग प्रोफाइलचा वापर करू शकता, किंवा वेगळ्या रोशानाइ अटिंकरिता "
+"प्रोफाइल्स निर्माण करू शकता."
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "प्रोफाइल नाव:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "प्रोफाइल नाव"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "प्रोफाइल यशस्वीरित्या निर्मीत केले!"
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "प्रोफाइलचे प्रत बनवा"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "लेखनजोगी मिडीया आवश्यक"
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "प्रोफाइल अपलोड करा"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "इंटरनेट जोडणी आवश्यक आहे"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> आणि <a "
-"href=\"windows"
-"\">Microsoft Windows</a> प्रणालींवर प्रोफाइलचा वापर कसे करायचे याकरिता उपयोगी "
-"सूचना आढळतील."
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "सारांश "
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "फाइल आयात करा…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "प्रोफाइल यशस्वीरित्या निर्मीत केले!"
 
-#: ../panels/color/color.ui.h:30
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
-msgstr "समाविष्टीत करा (_A)"
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "प्रोफाइलचे प्रत बनवा"
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "लेखनजोगी मिडीया आवश्यक"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> आणि <a "
+"href=\"windows\">Microsoft Windows</a> प्रणालींवर प्रोफाइलचा वापर कसे करायचे "
+"याकरिता उपयोगी सूचना आढळतील."
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "प्रोफाइल समाविष्ट करा"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"अडचणी आढळले. प्रोफाइल योग्यरित्या कार्य करणार नाही. <a href=\"\">तपशील "
-"दाखवा.</a>"
+"अडचणी आढळले. प्रोफाइल योग्यरित्या कार्य करणार नाही. <a href=\"\">तपशील दाखवा.</a>"
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "फाइल आयात करा…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "समाविष्टीत करा (_A)"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "प्रत्येक साधनाला रंग व्यवस्थापीत अप्टूडेट रंग प्रोफाइल आवश्यक आहे."
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "आणखी शिका"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "रंग व्यवस्थापनविषयी आणखी शिका"
 
-#: ../panels/color/color.ui.h:35
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "सर्व वापरकर्त्यांसाठी ठरवा"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "या संगणकावर सर्व वापरकर्त्यांसाठी हा प्रोफाइल ठरवा"
 
-#: ../panels/color/color.ui.h:37
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "सुरू करा"
 
-#: ../panels/color/color.ui.h:38
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "प्रोफाइल समाविष्ट करा"
 
-#: ../panels/color/color.ui.h:39
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "कॅलिब्रेट…"
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "या साधनाला कॅलिब्रेट करा"
 
-#: ../panels/color/color.ui.h:41
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "प्रोफाइल काढून टाका"
 
-#: ../panels/color/color.ui.h:42
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "तपशीलचे दृष्य"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "रंग व्यवस्थापन शक्य कोणत्याही साधनांना ओळखणे अशक्य"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "प्रोजेक्टर"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "प्लाजमा"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL बॅकलाइट)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED बॅकलाइट)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (व्हाइट LED बॅकलाइट)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "वाइड गॅमट LCD (CCFL बॅकलाइट)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "वाइड गॅमट LCD (RGB LED बॅकलाइट)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "जास्त"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 मिनिटे"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "मध्यम"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 मिनिटे"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "कमी"
 
-#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 मिनिटे"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "डिस्पलेकरिता मूळ"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (छपाई आणि प्रकाशन)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (छायाचित्रण आणि ग्राफिक्स)"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "रंग"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "साधनांचे रंग कॅलिब्रेट करा, जसे कि डिस्पलेज, कॅमेराज किंवा छापईयंत्र"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "रंग;ICC;प्रोफाइल;कॅलिब्रेट;प्रिंटर;डिस्पले;"
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:684
-msgid "United States"
-msgstr "युनाइटेड स्टेट्स्"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "भाषा निवडा"
 
-#: ../panels/common/cc-common-language.c:685
-msgid "Germany"
-msgstr "जर्मनी"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "निवडा(_S)"
 
-#: ../panels/common/cc-common-language.c:686
-msgid "France"
-msgstr "फ्रांस"
-
-#: ../panels/common/cc-common-language.c:687
-msgid "Spain"
-msgstr "स्पेन"
-
-#: ../panels/common/cc-common-language.c:688
-msgid "China"
-msgstr "चायना"
-
-#: ../panels/common/cc-common-language.c:758
-msgid "Other…"
-msgstr "इतर प्रोफाइल..."
-
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr "आणखी…"
-
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "इतर भाषा आढळले नाही"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "भाषा"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "आणखी…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "झाले (_D)"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "वेळ"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "जानेवारी"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "फेब्रुवारी"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "मार्च"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "एप्रिल"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "मे"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "जुन"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "जुलै"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "ऑगस्ट"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "सप्टेंबर"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "ऑक्टोबर"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "नोव्हेंबर"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "डिसेंबर"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "दिनांक व वेळ"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "तास"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "मिनिट"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "नेटवर्क वेळ (_N)"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "महिना"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "वर्ष"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "महिना"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "जानेवारी"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "फेब्रुवारी"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "मार्च"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "एप्रिल"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "मे"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "जुन"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "जुलै"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "ऑगस्ट"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "सप्टेंबर"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ऑक्टोबर"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "नोव्हेंबर"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "डिसेंबर"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "नेटवर्क वेळ (_N)"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "वेळ क्षेत्र"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "शहर शोधा"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "स्वय दिनांक आणि वेळ (_D)"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "इंटरनेट प्रवेश आवश्यक"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "दिनांक आणि वेळ (_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "स्व वेळ क्षेत्र (_Z)"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "Date & _Time"
-msgstr "दिनांक आणि वेळ (_T)"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "इंटरनेट प्रवेश आवश्यक"
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
-msgstr "वेळ क्षेत्र (_Z)"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "सुरू केले"
 
-#: ../panels/datetime/datetime.ui.h:28
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "वेळ क्षेत्र"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "घड्याळीच्या दिशेने"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "वेळ रूपण (_F)"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24 तास"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "दिनांक"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "दुय्यम"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "दिनदर्शिका (_C):"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "अंक"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "दिनांक आणि वेळ बदलवा, वेळक्षेत्र समाविष्टीत"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "क्लॉक;टाइमझोन;ठिकाण;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "प्रणालीची वेळ व दिनांक सेटिंग्स् बदला"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "वेळ किंवा दिनांक सेटिंग्स् बदलण्यासाठी, ओळख पटवणे आवश्यक आहे."
 
-#: ../panels/display/cc-display-panel.c:487
-msgid "Lid Closed"
-msgstr "झाकन बंद केले"
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-msgid "Mirrored"
-msgstr "मिरर्ड"
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2145
-msgid "Primary"
-msgstr "प्राथमिक"
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "बंद करा"
-
-#: ../panels/display/cc-display-panel.c:497
-msgid "Secondary"
-msgstr "दुय्यम"
-
-#: ../panels/display/cc-display-panel.c:1533
-msgid "Arrange Combined Displays"
-msgstr "एकत्रीत डिस्पलेज आयोजीत करा"
-
-#: ../panels/display/cc-display-panel.c:1539
-#: ../panels/display/cc-display-panel.c:1979
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr "लागू करा (_A)"
-
-#: ../panels/display/cc-display-panel.c:1560
-msgid "Drag displays to rearrange them"
-msgstr "डिस्पेजना ओढा आणि पुन्हा आयोजीत करा"
-
-#: ../panels/display/cc-display-panel.c:2081
-msgid "Size"
-msgstr "आकार"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2094
-msgid "Aspect Ratio"
-msgstr "ॲस्पेक्ट रेशो"
-
-#: ../panels/display/cc-display-panel.c:2115
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "रेजोल्युशन"
-
-#: ../panels/display/cc-display-panel.c:2146
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "या डिस्पलेवर शीर्ष पट्टी आणि क्रिया पूर्वावलोकन दाखवा"
-
-#: ../panels/display/cc-display-panel.c:2152
-msgid "Secondary Display"
-msgstr "दुसरा डिस्पले"
-
-#: ../panels/display/cc-display-panel.c:2153
-msgid "Join this display with another to create an extra workspace"
-msgstr "अगाऊ कार्यक्षेत्र निर्माणकरिता या डिस्पलेला दुसऱ्याशी जुळवा"
-
-#: ../panels/display/cc-display-panel.c:2160
-msgid "Presentation"
-msgstr "प्रस्तुतीकरण"
-
-#: ../panels/display/cc-display-panel.c:2161
-msgid "Show slideshows and media only"
-msgstr "स्लाइजशोज आणि फक्त मिडीया दाखवा"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2166
-msgid "Mirror"
-msgstr "मिरर"
-
-#: ../panels/display/cc-display-panel.c:2167
-msgid "Show your existing view on both displays"
-msgstr "दोन्ही डिस्पलेजवरील अस्तित्वातील अवलोकन दाखवा"
-
-#: ../panels/display/cc-display-panel.c:2173
-msgid "Turn Off"
-msgstr "बंद करा"
-
-#: ../panels/display/cc-display-panel.c:2174
-msgid "Don't use this display"
-msgstr "हे डिस्पले दाखवू नका"
-
-#: ../panels/display/cc-display-panel.c:2383
-msgid "Could not get screen information"
-msgstr "पडदा विषयी माहिती प्राप्त करणे शक्य नाही"
-
-#: ../panels/display/cc-display-panel.c:2414
-msgid "_Arrange Combined Displays"
-msgstr "एकत्रीत डिस्पलेज आयोजीत करा (_A)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "डिस्पलेज्"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr "जुळलेले मॉनिटर्स आणि प्रोजेक्टर्सचा वापर कसा करायचा ते पसंत करा"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "पॅनल;प्रोजेक्टर;xrandr;स्क्रीन;रेजोल्युशन;रिफ्रेश;मॉनिटर;"
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr "वेलँड"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "अपरिचित"
-
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-बिट"
-
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr "%d-बिट"
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr "काय करायचे ते विचारा"
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr "काहिच करू नका"
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr "फोल्डर उघडा"
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr "इतर मिडीया"
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr "ऑडिओ CDs करीता ॲप्लिकेशन निवडा"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr "ऑडिओ CDs करीता ॲप्लिकेशन निवडा"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr "संगीत वादक जोडल्यावर चालवण्याजोगी ॲप्लिकेशन निवडा"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr "कॅमेरा जोडल्यावर चालवण्याजोगी ॲप्लिकेशन निवडा"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr "सॉफ्टवेअर CDs करीता ॲप्लिकेशन निवडा"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr "ऑडिओ DVD"
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr "रिकामी ब्लुयरे डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr "रिकामी CD डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr "रिकामी DVD डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr "रिकामी HD DVD डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr "ब्ल्यु-रे व्हिडीओ डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr "इ-बूक रिडर"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr "HD DVD व्हिडीओ डिस्क"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr "चित्र CD"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr "सुपर व्हिडीओ CD"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr "व्हिडिओ CD"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr "विंडोज् सॉफ्टवेअर"
-
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1932
-msgid "Section"
-msgstr "विभाग"
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "पूर्वावलोकन"
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr "पूर्वनिर्धारीत ॲप्लिकेशन्स्"
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "काढून टाकण्याजोगी मिडीया"
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr "आवृत्ती %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:46
-msgid "Details"
-msgstr "तपशील"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr "प्रणाली विषयी माहिती दाखवा"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"डिव्हाइस;सिस्टम;इंफॉरमेशन;मेमरि;प्रोसेसर;वर्जन;डिफॉल्ट;ॲप्लिकेशन;फॉलबॅक;प्रेफर"
-"्ड;सीडी;"
-"डीवीडी;युएसबी;ऑडिओ;व्हिडीओ;डिस्क;रिमोवेबल;मिडीया;ऑटोरन;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "इतर मिडीयाला कसे हाताळायचे ते निवडा"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "तपशील"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "प्रकार (_T):"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "डिव्हाइस नाव"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "मेमरि"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "प्रोसेसर"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "बेस प्रणाली"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "डिस्क"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "गणना करत आहे..."
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "ग्राफिक्स्"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "वर्च्युअलाइजेशन"
-
-#: ../panels/info/info.ui.h:13
-msgid "Check for updates"
-msgstr "सुधारणांकरिता तपासणी करा"
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "वेब (_W)"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "मेल (_M)"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "दिनदर्शिका (_C):"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "संगीत (_u)"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "व्हिडीओ (_V)"
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "छायाचित्र (_P)"
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "मिडीया कसे हाताळायचे ते निवडा"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "पूर्वनिर्धारीत ॲप्लिकेशन्स्"
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "CD ऑडिओ (_a)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "पूर्वनिर्धारीत ॲप्लिकेशन्स्"
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "DVD व्हिडीओ (_D)"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "संगीत वादक (_M)"
-
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "सॉफ्टवेअर"
-
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "इतर मिडीया (_O)..."
-
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
 msgstr ""
-"मिडीया अंतर्भुतकरतेवेळी कधिही प्रोग्राम्स् करीता विनंती किंवा सुरू करू नका "
-"(_N)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "लागू करा (_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "मागे"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "ब्य्लुटूथ बंद आहे"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "डिस्पलेज् ओळखा (_D)"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "मिरर"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "दुसरा डिस्पले"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "उजवे रिंग"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "निर्देशन"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "रेजोल्युशन"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "पुन्हदाखल दर (_f):"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "स्केल"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "भाग पूर्ण"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "छपाईयंत्रे उपलब्ध नाही"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "आत्ता सुरू करा"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "वेळ"
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "URI पासून"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "तास"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "मिनिट"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "डिस्पलेज्"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "जुळलेले मॉनिटर्स आणि प्रोजेक्टर्सचा वापर कसा करायचा ते पसंत करा"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "पॅनल;प्रोजेक्टर;xrandr;स्क्रीन;रेजोल्युशन;रिफ्रेश;मॉनिटर;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "सुरक्षा कि"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "शाई स्तर"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "शाई स्तर"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "शाई स्तर"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "सुरक्षा"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr "स्क्रीन;लॉक;विश्लेषण;क्रॅश;वैयक्तिक;नुकतेच;तात्पुर्ते;tmp;इंडेक्स;नाव;नेटवर्क;ओळख;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "डिव्हाइस नाव"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "हार्डवेअर पत्ता"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "मेमरि"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "प्रोसेसर"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "ग्राफिक्स्"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "गणना करत आहे..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "नाव"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "प्रकार"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME टर्मिनल"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "पर्याय लोड करत आहे..."
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "विंडोज् सॉफ्टवेअर"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "वर्च्युअलाइजेशन"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "सॉफ्टवेअर वापर"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "साधन काढून टाका"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "डिव्हाइस नाव"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "नाव बदला..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "%s च्या विषयी"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "प्रणाली विषयी माहिती दाखवा"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"डिव्हाइस;सिस्टम;इंफॉरमेशन;मेमरि;प्रोसेसर;वर्जन;डिफॉल्ट;ॲप्लिकेशन;फॉलबॅक;प्रेफर्ड;सीडी;"
+"डीवीडी;युएसबी;ऑडिओ;व्हिडीओ;डिस्क;रिमोवेबल;मिडीया;ऑटोरन;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "साऊंड व मिडीया"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "वॉल्युम मंद करा"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "वॉल्युम कमी करा"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "वॉल्युम वाढवा"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "माइक्रोफोन वॉल्युम"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "मिडीया वादक सुरू करा"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "चालवा (किंवा चालवा/थांबा)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "चालवणे थांबवा"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "चालवणे थांबवा"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "पूर्वीचे ट्रॅक"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "पुढील ट्रॅक"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "बाहेर काढा"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "टाइपिंग"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "पुढील इंपुट स्रोतचा वापर करा"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "मागील इंपुट स्रोतचा वापर करा"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "लाँचर्स्"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "मदत ब्राऊजर सुरू करा"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "सेटिंग्ज"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "कॅलक्युलेटर सुरू करा"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "इमेल क्लाएंट सुरू करा"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "वेब ब्राउजर सुरू करा"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "होम फोल्डर"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "शोधा"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "स्क्रीनशॉटस्"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "स्क्रीनशॉटला $PICTURES मध्ये साठवा"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "पटलाच्या स्क्रीनशॉटला $PICTURES मध्ये साठवा"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "क्षेत्राचे स्क्रीनशॉट $PICTURES मध्ये साठवा"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "स्क्रीनशॉटचे क्लिपबोर्डवर प्रत बनवा"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "पटलाचे स्क्रीनशॉट क्लिपबोर्डवर प्रत बनवा"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "क्षेत्राचे स्क्रीनशॉट क्लिपबोर्डवर प्रत बनवा"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "छोटे स्क्रीनकास्ट रेकॉर्ड करा"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "प्रणाली"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "बाहेर पडा"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "पडदा कुलूपबंद करा"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "युनिवर्सल ॲकसेस"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "माऊस प्रवेशीयता (_M)"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "झूम सुरू किंवा बंद करा"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "मोठे करा"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "लहान करा"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "स्क्रीन रिडर सुरू किंवा बंद करा"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "ऑनस्क्रीन कळफलक सुरू किंवा बंद करा"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "मजकूर आकार वाढवा"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "मजकूर आकार कमी करा"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "जास्त काँट्रास्ट सुरू किंवा बंद करा"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1218
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-msgid "Disabled"
-msgstr "अकार्यान्वित"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "इंपुट स्रोत समाविष्ट करा"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "वैकल्पिक अक्षरांची कि"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "प्रवेश पडद्यावर इंपुट पद्धतींचा वापर शक्य नाही"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "कंपोज् कि"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "इंपुट स्रोत नीवडले नाही"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "पुढील स्रोतकरिता मॉडिफार्यस-ओन्लि स्विच"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "पर्याय"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "कळफलक"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "वर जा"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr "कळफलक शार्टक्टसचे अवलोकन आणि बदल करा आणि टाइपिंग पसंती ठरवा"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "खाली जा"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "शार्टकट;रिपिट;ब्लिंक;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "पसंती"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "स्वपसंत शॉर्टकट"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "किबोर्ड लेआऊट दाखवा"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "नाव(_N) :"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "काढून टाका (_R)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "आदेश (_o):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "पुनःवृत्ती किज्"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "कळ दाबून ठेवल्यास कळ पुनः दाबली जाते (_r)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "विलंब (_D):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "वेग(_S):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "छोटे"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "हळू"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "रिपीट किजचा वेग"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "लांब"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "वेग"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "कर्सर लुकलुकणे"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "पाठ्य गुणविशेष मधील कर्सर लुकलुकते (_b)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "वेग (_p):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "कर्सर लुकलुकण्याचा वेग"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "इनपुट स्रोत"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "शॉर्टकट समाविष्ट करा"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "शॉर्टकट काढून टाका"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"शार्टकट संपादित करण्याकरीता, परस्पर ओळवर क्लिक करा व नविन किज् दाबून ठेवा "
-"किंवा नष्ट "
-"करण्यासाठी बॅकस्पेस् दाबा."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "इंपुट स्रोत पर्याय"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "सर्व पटलांकरिता समान स्रोतचा वापर करा (_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "प्रत्येक पटलकरीता वेगळे स्रोत स्वीकारा (_d)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "वैकल्पिक अक्षरांची कि"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "कंपोज् कि"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "कळफलक शार्टकट्स"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "स्वपसंत शॉर्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "विभाग"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "शॉर्टकटस्"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:635
-#: ../panels/keyboard/keyboard-shortcuts.c:643
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "शॉर्टकट समाविष्ट करा"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "स्वपसंत शॉर्टकट"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:860
-msgid "<Unknown Action>"
-msgstr "<अज्ञात क्रिया>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1357
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"शार्टकट \"%s\" वापरले जाऊ शकत नाही कारण ही कळ वापरल्यास टाईप करणे शक्य राहणार "
-"नाही.\n"
-"कृपया Control, Alt किंवा Shift कि परस्परित्या वापरुन पहा."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1387
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "शॉर्टकट समाविष्ट करा"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "कळफलक शार्टकट्स"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "काढून टाका (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "अदलाबदल करा (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"शॉर्टकट \"%s\" आधीपासूनच\n"
-"\"%s\" करीता वापरले जाते"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1392
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"शार्टकटला \"%s\" पुन्ह निश्चित केल्यास, \"%s\" शार्टकट अकार्यान्वीत केले जाईल."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1398
-msgid "_Reassign"
-msgstr "पुन्ह निश्चित करा (_R)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "नाव"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1439
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "आदेश (_o):"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "शॉर्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "नवीन शार्टकट…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "काहीच नाही"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
 msgstr ""
-"\"%s\" शॉर्टकटला \"%s\" शॉर्टकटसह संलग्न केले आहे. तुम्हाला ते स्व \"%s\" "
-"करिता सेट करायचे?"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1449
-#, c-format
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "पूर्वनिर्धारीत पुनःस्थापीत करा (_R)"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "कळफलक"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
 msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "कळफलक शार्टक्टसचे अवलोकन आणि बदल करा आणि टाइपिंग पसंती ठरवा"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
-"\"%s\" आत्ता \"%s\" सह संबंधीत आहे, पुढे जात असल्यास हे शार्टकट बंद केले जाईल."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1456
-msgid "_Assign"
-msgstr "लागू करा (_A)"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "लोकेशन सर्व्हिसेस (_L)"
 
-#: ../panels/mouse/cc-mouse-panel.c:94
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "ॲप्लिकेशन सध्या ऑडिओ चालवत किंवा रेकॉर्ड करत आहे."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "माइक्रोफोन वॉल्युम"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "ॲप्लिकेशन्स आढळले नाही"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "सेटिंग्जची चाचणी करा (_S)"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-msgid "Test Your Settings"
-msgstr "सेटिंग्जची चाचणी करा"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "सर्वसाधारण"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "प्राथमिक बटन (_b)"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "डावे"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "उजवे"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "ठिकाण शोधा"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "माऊस"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "माऊस किज (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "खाली सरकवा"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "मॅनिफायर कर्सर अंतर्भुत माहितीसह हलतो"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "प्रवेग(_A):"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "सक्रीय"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "टचपॅड्"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "टचपॅड्"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "मेथड (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "क्लिक करण्यासाठी टॅप करा (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "क्लिक करण्यासाठी टॅप करा (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "टाइप करतेवेळी बंद करा (_t)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "टचपॅड (रिलेटिव्ह)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "स्क्रोल करत आहे"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "डावीकडे सरकवा"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "दोंही बाजूने"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "क्लिक, दोनवेळा क्लिक, स्क्रोल करण्याचा प्रयत्न करा"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "माऊस व टचपॅड्"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "माऊस किंवा टचपॅड संवेदनशिलता बदलवा आणि उजवे किंवा डावखुरा पसंत करा"
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "ट्रॅकपॅड;पॉइंटर;क्लिक;टॅप;डबल;बटन;ट्रॅकबॉल;स्क्रोल;"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "सर्वसाधारण"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "हळू"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "वेळ समाप्तीवर दोनवेळा क्लिक करा"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "वेग"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "दोनवेळा क्लिक करा (_D)"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "कलरस्पेस्: "
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "प्राथमिक बटन (_b)"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "डावे (_L)"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "कचरापेटी स्व रिक्त करा (_T)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "उजवे (_R)"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "माऊस"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "पॉइंटर वेग (_P)"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "हळू"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "%s मॉनिटर"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "वेग"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "प्राथमिक डिस्पले बदलण्यासाठी ओढा."
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "टचपॅड्"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "हळू"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "ॲप्लिकेशन्स्"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "वेग"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
-msgstr "टाइप करतेवेळी बंद करा (_t)"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
-msgstr "क्लिक करण्यासाठी टॅप करा (_c)"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
-msgstr "दोन बोटांचे सक्रोल (_f)"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "_Natural scrolling"
-msgstr "स्वाभाविक स्क्रोलिंग (_N)"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "क्लिक, दोनवेळा क्लिक, स्क्रोल करण्याचा प्रयत्न करा"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "साधने"
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "पाच क्लिक्स्, GEGL वेळ!"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "दोनवेळा क्लिक करा, प्राथमिक बटन"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "नवीन जोडणी समाविष्ट करा"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "एकदाच क्लिक क्लिक, पहिली बटन"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "दोनवेळा क्लिक करा, मधली बटन"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "जुळले"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "एकवेळा क्लिक करा, मधली बटन"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "पर्याय…"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "दोनवेळा क्लिक करा, दुसरी बटन"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "एकदाच क्लिक करा, दुसरी बटन"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "वाय-फाय हॉटस्पॉट"
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:366
-msgid "Air_plane Mode"
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "नेटवर्क नाव"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "पासवर्ड"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "गट पासवर्ड"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "सध्याचे पासवर्ड (_P)"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "सुरू करा (_T)"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
 msgstr "अयरप्लैन मोड (_p)"
 
-#: ../panels/network/cc-network-panel.c:974
-msgid "Network proxy"
-msgstr "नेटवर्क प्रॉक्सी"
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1153 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "चित्र आढळले नाही"
 
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1298
-msgid "The system network services are not compatible with this version."
-msgstr "सिस्टम नेटवर्क सर्व्हिसेस् या आवृत्तीसह सहत्व नाही."
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "अयरप्लैन मोड (_p)"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "वाय-फाय हॉटस्पॉट"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "हॉटस्पॉट म्हणून वापर करा (_U)..."
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "नेटवर्क्स"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x सुरक्षा (_S)"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "पृष्ठ 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "निनावी ओळख (_m)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "आंतरिक ओळख पटवणे (_a)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "पृष्ठ 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "सुरक्षा"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "स्व"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:218
-#: ../panels/network/net-device-wifi.c:382
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:222
-#: ../panels/network/net-device-wifi.c:387
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:226
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:231
-msgid "Enterprise"
-msgstr "एंटरप्राइज"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:236
-#: ../panels/network/net-device-wifi.c:372
-msgctxt "Wifi security"
-msgid "None"
-msgstr "काहिच नाही"
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "कधिही नाही"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:819
-msgid "Today"
-msgstr "आज"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:822
-msgid "Yesterday"
-msgstr "काल"
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:476
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%d दिवस अगोदर"
 msgstr[1] "%d दिवस अगोदर"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:533
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "None"
-msgstr "काहिच नाही"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "कमजोर"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ठिक आहे"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:568
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "चांगले"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:570
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "उत्कृष्ट"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "ओळख"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "पत्ता"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "नेटमास्क"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "गेटवे"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "पत्ता नष्ट करा"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "समाविष्ट करा"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "सर्व्हर"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "DNS सर्व्हर नष्ट करा"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "मेट्रिक"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "राउट नष्ट करा"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP)"
-msgstr "स्व (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Manual"
-msgstr "स्वहस्ते"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "फक्त स्थानीय जुळवा"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "प्रिफिक्स"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "स्व"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "स्व, फक्त DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:51
-msgid "Reset"
-msgstr "मूळस्थिती"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "काहिही नाही"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-बिट कि (Hex किंवा ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-बिट पासफ्रेज"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "डायनॅमिक WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA आणि WPA2 पर्सनल"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA आणि WPA2 एंटरप्राइज"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "सिग्नल मजबूती"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "लिंकचा वेग"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "सुरक्षा"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 पत्ता"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 पत्ता"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "हार्डवेअर पत्ता"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "समर्थीत ICC प्रोफाइल्स्"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "पूर्वनिर्धारीत राऊट"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "शेवटच्यावेळी वापरले"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "ट्विस्टेड पैर (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "अटॅचमेंट युनिट इंटरफेस (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "मिडीया इंडिपेंडंट इंटरफेस (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "नाव (_N)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
-msgid "_MAC Address"
-msgstr "MAC पत्ता (_M)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "MTU (_T)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "क्लोन केलेला पत्ता (_C)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "बाइट्स"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "इतर वापरकर्त्यांना उपलब्ध करा (_u)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "स्व जोडणी करा (_a)"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "फायरवॉल क्षेत्र (_Z)"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "पूर्वनिर्धारित"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "झोन जोडणीचे विश्वासर्हता स्तर ठरवते"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv4 (_4)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
-msgstr "पत्ते (_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "स्व DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Routes"
-msgstr "राउट्स"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "स्व राउट्स"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:34
-msgid "Use this connection _only for resources on its network"
-msgstr "नेटवर्कवरील स्रोतकरिता फक्त या जोडणीचाच वापर (_o)"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv6 (_6)"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "जोडणी संपादक उघडण्यास अशक्य"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "नवीन प्रोफाइल"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "बाँड"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "टिम"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "ब्रिज"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "VPN प्लगइन्स लोड करणे अशक्य"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "फाइलपासून आयात करा…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "नेटवर्क जोडणी समाविष्ट करा"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "मूळस्थितीत आणा (_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1441
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "विसरून जा (_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"या नेटवर्ककरिता सेटिंग्ज मूळस्थित आणा, पासवर्ड्ज समाविष्टीत, परंतु त्यास "
-"पसंतीचे नेटवर्क म्हणून लक्षात ठेवा "
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"या नेटवर्कशी संबंधीत सर्व तपशीलवार काढून टाका आणि स्व जोडणी करायचा प्रयत्न "
-"करू नका"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
-msgid "S_ecurity"
-msgstr "सुरक्षा (_e)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "VPN जोडणी आयात करणे अशक्य"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"फाइल '%s' ला वाचणे अशक्य किंवा परिचीत VPN "
-"जोडणी माहिती समाविष्टीत नाही\n"
-"\n"
-"त्रुटी: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "आयातकरिता फाइल पसंत करा"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1948
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:223
-msgid "_Open"
-msgstr "उघडा (_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "\"%s\" नावाची फाइल आधिपासूनच अस्तित्वात आहे."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "अदलाबदल करा (_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "तुम्हाला %s ला साठवण्याजोगी VPN जोडणीसह करायचे?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "VPN जोडणी एक्सपोर्ट करणे अशक्य"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN जोडणी '%s' यास %s करिता एक्सपोर्ट करणे अशक्य.\n"
-"\n"
-"त्रुटी: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-msgid "Export VPN connection"
-msgstr "VPN जोडणी एक्सपोर्ट करा"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(त्रुटी: VPN जोडणी संपादक लोड करणे अशक्य)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "_SSID"
-msgstr "SSID (_S)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
-msgid "_BSSID"
-msgstr "BSSID (_B)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "माझे होम नेटवर्क"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "इतर वापरकर्त्यांकरिता उपलब्ध करा (_o)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "नाव (_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC पत्ता (_M)"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "MTU (_T)"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "क्लोन केलेला पत्ता (_C)"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "बाइट्स"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "मेथड (_M)"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "स्व (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "फक्त स्थानीय जुळवा"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "स्वहस्ते"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "अकार्यान्वित"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "इतर संगणकांशी शेअर केले"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "पत्ते (_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "पत्ता"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "नेटमास्क"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "गेटवे"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "स्व"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "स्व DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "राउट्स"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "स्व राउट्स"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "मेट्रिक"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "नेटवर्कवरील स्रोतकरिता फक्त या जोडणीचाच वापर (_o)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "मेथड (_M)"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "स्व, फक्त DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "प्रिफिक्स"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "सुरक्षा (_e)"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(त्रुटी: VPN जोडणी संपादक लोड करणे अशक्य)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "SSID (_S)"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "BSSID (_B)"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "नेटवर्क"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+#: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "इंटरनेटशी कशी जोडणी करायची ते नियंत्रीत करा"
 
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
-"नेटवर्क;वायरलेस;वाय-फाय;वायफाय;आयपि;लॅन;प्रॉक्सी;वॅन;ब्रॉडबँड;मोडेम;ब्लुटूथ;व्"
-"हिपिएन;"
-"व्हिलॅन;ब्रिज;बाँड;डिएनएस;"
-
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "बाँड स्लेव्ज"
-
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(काहिही नाही)"
-
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "स्लेव्ज ब्रिज करा"
-
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:462
-msgid "never"
-msgstr "कधिच नाही"
-
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:472
-msgid "today"
-msgstr "आज"
-
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:474
-msgid "yesterday"
-msgstr "काल"
-
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP पत्ता"
-
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "शेवटच्यावेळी वापरले"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "वायर्ड"
-
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1596
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "पर्याय…"
-
-#: ../panels/network/net-device-ethernet.c:474
-#, c-format
-msgid "Profile %d"
-msgstr "प्रोफाइल %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "नवीन जोडणी समाविष्ट करा"
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr "टिम स्लेव्हज"
-
-#: ../panels/network/net-device-wifi.c:1154
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-"वायरलेस व्यतिरिक्त इंटरनेटसह जोडणी असल्यास, इतरांशी इंटरनेट जोडणीचा "
-"एकत्रीतपणे "
-"वापरकरिता वायरलेस हॉटस्पॉट सेट करणे शक्य आहे."
-
-#: ../panels/network/net-device-wifi.c:1158
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "वायरलेस हॉटस्पॉटचा वापर केल्यास <b>%s</b> पासून जोडणी खंडीत होईल."
-
-#: ../panels/network/net-device-wifi.c:1162
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"हॉटस्पॉट सुरू असल्यास वायरलेसच्या मदतीने इंटरनेटकरिता प्रवेश शक्य नाही."
-
-#: ../panels/network/net-device-wifi.c:1245
-msgid "Stop hotspot and disconnect any users?"
-msgstr "हॉटस्पॉट थांबवा व कोणत्याहि वापरकर्त्यांना खंडीत करायचे?"
-
-#: ../panels/network/net-device-wifi.c:1248
-msgid "_Stop Hotspot"
-msgstr "हॉटस्पॉट थांबवा (_S)"
-
-#: ../panels/network/net-device-wifi.c:1305
-msgid "System policy prohibits use as a Hotspot"
-msgstr "प्रणाली करार हॉटस्पॉटचा वापर प्रतिबंधीत करते"
-
-#: ../panels/network/net-device-wifi.c:1308
-msgid "Wireless device does not support Hotspot mode"
-msgstr "वायरलेस साधन हॉटस्पॉट मोडकरिता समर्थन पुरवत नाही"
-
-#: ../panels/network/net-device-wifi.c:1437
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"नीवडलेल्या नेटवर्क्सकरिता नेटवर्क तपशील, पासवर्ड व इतर कोणतिही पसंतीची संरचना "
-"गमवाल."
-
-#: ../panels/network/net-device-wifi.c:1745
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "इतिहास"
-
-#: ../panels/network/net-device-wifi.c:1749
-#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
-#: ../panels/wacom/cc-wacom-page.c:533
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Close"
-msgstr "बंद करा (_C)"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1757
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "विसरून जा (_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"वेब प्रॉक्सी ऑटोडिस्कवरिचा वापर जेव्हा संरचना URL पुरवले जात नाही तेव्हा होतो."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "अविश्वासर्ह पब्लिक नेटवर्कस् करिता शिफारसीय नाही."
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "प्रॉक्सी"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "प्रोफाइल समाविष्ट करा (_A)…"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "प्रोव्हाइडर"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "काहिच नाही"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "मॅन्युअल"
-
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "स्वयं"
-
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
-msgstr "मेथड (_M)"
-
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "संरचना URL (_C):"
-
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "HTTP प्रॉक्सी (_H):"
-
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "HTTPS प्रॉक्सी (_T):"
-
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "FTP प्रॉक्सी (_F): "
-
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "FTP प्रॉक्सी (_F): "
-
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "यजमानांकडे दुर्लक्ष करा (_I)"
-
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "HTTP प्रॉक्सी पोर्ट"
-
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "HTTPS प्रॉक्सी पोर्ट"
-
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "FTP प्रॉक्सी पोर्ट"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "सॉक्स प्रॉक्सी पोर्ट"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "साधन बंद करा"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "साधन समाविष्ट करा"
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "साधन काढून टाका"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN प्रकार"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "गट नाव"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "गट पासवर्ड"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "वापरकर्तानाव"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr "VPN जोडणी बंद करा"
-
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "स्व जोडणी करा (_C)"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "तपशील"
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "पासवर्ड (_P)"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "काहीच नाही"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "पासवर्ड दाखवा (_a)"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr "इतर वापरकर्त्यांकरिता उपलब्ध करा"
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "ओळख"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr "फक्त स्व (DHCP) पत्ते"
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr "फक्त स्थानीय जुळवा"
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr "इतर संगणकांशी शेअर केले"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr "स्व प्राप्य राउट्सकडे दुर्लक्ष करा (_I)"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr "क्लोन केलेले MAC पत्ता (_C)"
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr "हार्डवेअर"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"या जोडणीकरिता सेटिंग्जना त्यांच्या पूर्वनिर्धारितकरिता मूळस्थितीत आणा, परंतु "
-"त्यास पसंतीची जोडणी म्हणून लक्षात ठेवा."
-
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"या नेटवर्कशी संबंधीत सर्व तपशीलवार काढून टाका आणि स्व जोडणी करायचा प्रयत्न "
-"करू नका."
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "मूळस्थिती"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "हार्डवेअर"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr "वाय-फाय हॉटस्पॉट"
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Turn On"
-msgstr "सुरू करा (_T)"
-
-#: ../panels/network/network-wifi.ui.h:54
+"नेटवर्क;वायरलेस;वाय-फाय;वायफाय;आयपि;लॅन;प्रॉक्सी;वॅन;ब्रॉडबँड;मोडेम;ब्लुटूथ;व्हिपिएन;व्हिलॅन;"
+"ब्रिज;बाँड;डिएनएस;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "वाय-फाय"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Turn Wi-Fi off"
-msgstr "वाय-फाय बंद करा"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "इंटरनेटशी कशी जोडणी करायची ते नियंत्रीत करा"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_Use as Hotspot…"
-msgstr "हॉटस्पॉट म्हणून वापर करा (_U)..."
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"नेटवर्क;वायरलेस;वाय-फाय;वायफाय;आयपि;लॅन;प्रॉक्सी;वॅन;ब्रॉडबँड;मोडेम;ब्लुटूथ;व्हिपिएन;व्हिलॅन;"
+"ब्रिज;बाँड;डिएनएस;"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "_Connect to Hidden Network…"
-msgstr "छुप्या नेटवर्कशी जोडणी करा (_C)..."
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "वायर्ड"
 
-#: ../panels/network/network-wifi.ui.h:58
-msgid "_History"
-msgstr "इतिहास (_H)"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "साधन बंद करा"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "वाय-फाय नेटवर्कशी जोडणीकरिता बंद करा"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "सक्रीय"
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "प्रोव्हाइडर"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP पत्ता"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "नेटवर्क प्रॉक्सी"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "HTTP प्रॉक्सी (_H):"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTPS प्रॉक्सी (_T):"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "FTP प्रॉक्सी (_F): "
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "FTP प्रॉक्सी (_F): "
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "यजमानांकडे दुर्लक्ष करा (_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP प्रॉक्सी पोर्ट"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS प्रॉक्सी पोर्ट"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP प्रॉक्सी पोर्ट"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "सॉक्स प्रॉक्सी पोर्ट"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "संरचना URL (_C):"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN जोडणी बंद करा"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "नेटवर्क नाव"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Connected Devices"
-msgstr "जुळलेले साधन"
-
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "सुरक्षा प्रकार"
 
-#: ../panels/network/network-wifi.ui.h:63
-msgid "Security key"
-msgstr "सुरक्षा कि"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "पासवर्ड"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "ॲडहॉक"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "वाय-फाय बंद करा"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "इंफ्रास्टक्चर"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "पर्याय लोड करत आहे..."
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "स्थिती अपरिचीत"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "छुप्या नेटवर्कशी जोडणी करा (_C)..."
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "अव्यवस्थापीत"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "वाय-फाय हॉटस्पॉट"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "अनुपलब्ध"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "जोडत आहे"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "ओळख पटवणे आवश्यक"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "जुळले"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "खंडीत करत आहे"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "जोडणी अपयशी"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "स्थिती अपरिचीत (आढळली नाही)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "जुडले नाही"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "संरचना अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "IP संरचना अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "IP संरचना वेळसमाप्ति"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "गोपनीयता आवश्यक, परंतु पुरवले नाही"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x सप्पिकंट खंडीत केले"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x सप्लिकंट संरचना अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1x सप्लिकंट अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x सप्लिकंटला ओळख पटवण्याकरीता जास्त वेळ लागला"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "PPP सर्व्हिस सुरू होण्यास अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "PPP सर्व्हिस खंडीत"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "DHCP क्लाएंट सुरू होण्यास अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP क्लाएंट त्रुटी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP क्लाएंट अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "शेअर्ड जोडणी सर्व्हिस सुरू होण्यास अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "शेअर्ड जोडणी सर्व्हिस अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "ऑटोIP सर्व्हिस सुरू होण्यास अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "ऑटोIP सर्व्हिस सुरू होण्यास अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "ऑटोIP सर्व्हिस अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "लाइन व्यस्थ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "डायल सूर आढळले नाही"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "कॅरिअर स्थापित करणे अशक्य"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "डायलिंग विनंती वेळसमाप्ति"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "डायलिंग प्रयत्न अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "मोडेम प्रारंभिकरण अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "निर्देशीत APN नीवडण्यास अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "नेटवर्ककरीता शोधणे अशक्य"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "नेटवर्क नोंदणी नकारले"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "नेटवर्क नोंदणीची वेळसमाप्ति"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "विनंती केलेल्या नेटवर्कसह नोंदणी अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "PIN तपासणी अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "साधनकरीता फर्मवेअर कदाचित आढळले नाही"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "जोडणी पूर्णपणे खंडीत"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "अस्तित्वातील जोडणी गृहीत धरले"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "मोडेम आढळले नाही"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "ब्ल्युटूथ जोडणी अपयशी"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "SIM कार्ड अंतर्भुत केले नाही"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "SIM पिन आवश्यक"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "SIM पक आवश्यक"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "SIM चुकिचे"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "इंफिनिबँड साधन जोडणी मोडकरीता समर्थन पुरवत नाही"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "जोडणी अवलंबन अपयशी"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "फर्मवेअर आढळले नाही"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "केबल प्लग अशक्य"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "सर्टिफेकट अथॉरिटि प्रमाणपत्र पसंत केले नाही"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"सर्टिफिकेट अथॉरिटि (CA) प्रमाणपत्रचा वापर न केल्यामुळे जोडणी असुरक्षित, "
-"धोकादायक वाय-फाय नेटवर्क्सकरिता कारणीभूत ठरू शकते.  तुम्हाला सर्टिफिकेट "
-"अथॉरिटि प्रमाणपत्र पसंत करायला आवडेल?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "दुर्लक्ष करा"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "CA प्रमाणपत्र पसंत करा"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, किंवा PKCS#12 प्राइव्हेट किज (*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER किंवा PEM प्रमाणपत्र (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-msgid "Choose a PAC file"
-msgstr "PAC फाइल पसंत करा"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC फाइल्स (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC फाइल (_f)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "आंतरिक ओळख पटवा (_I)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "PAC प्रोव्हिजनिंग (_v)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "निनावी"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "ओळख पटवली"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "दोन्ही"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "निनावी ओळख (_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC फाइल (_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PAC फाइल पसंत करा"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "आंतरिक ओळख पटवा (_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC प्रोव्हिजनिंग (_v)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "वापरकर्तानाव (_U)"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "पासवर्ड (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "पासवर्ड दाखवा (_w)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate"
-msgstr "सर्टिफेकट अथॉरिटि प्रमाणपत्र पसंत करा"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "आवृत्ती 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "आवृत्ती 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "CA प्रमाणपत्र (_A)"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "सर्टिफेकट अथॉरिटि प्रमाणपत्र पसंत करा"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "ओळख पटवणे आवश्यक"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP आवृत्ती (_v)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "या पासवर्डकरिता नेहमी विचारा (_k)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "विना एंक्रिप्ट केलेले प्राइव्हेट किज असुरक्षित आहे"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"नीवडलेले प्राइवेट कि पासवर्डतर्फे सुरक्षित असल्याचे दिसून येत नाही.  "
-"यामुळे आपले सुरक्षा श्रेयशी तजजोड होऊ शकते.  कृपया पासवर्ड-सुरक्षित प्राइवेट "
-"किचा वापर करा.\n"
-"\n"
-"(openssl सह प्राइवेट किला पासवर्ड-सुरक्षित करणे शक्य आहे)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-msgid "Choose your personal certificate"
-msgstr "वैयक्तिक प्रमाणपत्र पंसत करा"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-msgid "Choose your private key"
-msgstr "प्राइवेट कि पसंत करा"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "ओळख (_d)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "वापरकर्ता प्रमाणपत्र (_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "प्राइव्हेट कि (_k)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "प्राइवेट कि पासवर्ड (_P)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "मला पुन्हा सावध करू नका (_w)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "डोमैन (_D)"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "नाही"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "होय"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "टनल्ड TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "प्रोटेक्टेड EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "ओळख (_t)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (पूर्वनिर्धारित)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "ओपन प्रणाली"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "शेअर्ड कि"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "कि (_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "कि दाखवा (_w)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP इंडेक्स (_x)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "प्रकार (_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (पूर्वनिर्धारित)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "ओपन प्रणाली"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "शेअर्ड कि"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "कि (_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "कि दाखवा (_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP इंडेक्स (_x)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "सूचना"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "आवाज सतर्कता"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "पॉपअप बॅनर्स दाखवा"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "बॅनर्समध्ये तपशील दाखवा"
-
-#: ../panels/notifications/cc-edit-dialog.c:43
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "पडदा कुलूपबंदमधील अवलोकन"
-
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "पडदा कुलूपबंद करामधील तपशील दाखवा"
-
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "सुरू करा"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "सूचना"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "सूचना"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "पडदा कुलूपबंद करामधील तपशील दाखवा"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "सूचना"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "कोणत्या सूचना दाखवायचे आणि ते काय दाखवते, ते नियंत्रीत करा "
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "सूचना;बॅनर;संदेश;ट्रे;पॉपअप;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "पॉपअप बॅनर्स दाखवा"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "पडदा कुलूपबंदमध्ये दाखवा"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "आंतरिक ओळख पटवणे (_a)"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-msgctxt "Online Account"
-msgid "Other"
-msgstr "इतर"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "खाते समाविष्ट करा"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
-msgstr "ईमेल"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr "संपर्क"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "गप्पा"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "स्रोत"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "खात्यामध्ये प्रवेश करतेवेळी त्रुटी"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "श्रेयची वेळसमाप्ति आढळली."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr "हे खाते सुरू करण्यासाठी प्रवेश करा."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr "प्रवेश करा (_S)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "खाते निर्माण करतेवेळी त्रुटी"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "खते काढून टाकतेवेळी त्रुटी"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "तुम्हला नक्की खाते काढूण टाकायचे?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "यामुळे सर्व्हरवरील खाते काढून टाकले जात नाही."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "काढून टाका (_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "ऑनलाइन खाते"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "ऑनलाइन खातींसह जोडणी करा आणि त्याचे कशासाठी वापर करायचे ते ठरवा"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-"गूगल;फेसबूक;ट्विटर;याहू;वेब;ऑनलाइन;चॅट;कॅलेंडर;मेल;काँट्रॅक्ट;ओनक्लाउड;कर्बेरो"
-"स,आईमॅप;एसएमटिपि;"
+"गूगल;फेसबूक;ट्विटर;याहू;वेब;ऑनलाइन;चॅट;कॅलेंडर;मेल;काँट्रॅक्ट;ओनक्लाउड;कर्बेरोस,आईमॅप;एसएमटिपि;"
 "पॉकेट;रिडइटलेटर;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "ऑनलाइन खाते संरचीत केले नाही"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "खाते काढून टाका"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "ऑनलाइन खाते समाविष्ट करा"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"खाते समाविष्ट केल्याने ॲप्लिकेशन्स् दस्तऐवज, मेल, संपर्क, दिनदर्शिका, गप्पा, "
-"व आणखी करीता "
-"प्रवेश प्राप्त करू शकतात."
-
-#: ../panels/power/cc-power-panel.c:183
-msgid "Unknown time"
-msgstr "अपरिचीत वेळ"
-
-#: ../panels/power/cc-power-panel.c:189
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i मिनिट"
 msgstr[1] "%i मिनिटे"
 
-#: ../panels/power/cc-power-panel.c:201
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i तास"
 msgstr[1] "%i तास"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:209
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "तास"
 msgstr[1] "तास"
 
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "मिनिट"
 msgstr[1] "मिनिटे"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:230
-#, c-format
-msgid "%s until fully charged"
-msgstr "संपूर्णतया चार्ज होईपर्यंत %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 मिनिटे"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:237
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "खबरदारी: %s उर्वरित"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 मिनिटे"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:242
-#, c-format
-msgid "%s remaining"
-msgstr "%s उर्वरित"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 मिनिटे"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
-msgid "Fully charged"
-msgstr "संपूर्णतया चार्ज करा"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 मिनिटे"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
-msgid "Empty"
-msgstr "रिकामे"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Charging"
-msgstr "चार्ज करत आहे"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:271
-msgid "Discharging"
-msgstr "डिसचार्ज करत आहे"
-
-#: ../panels/power/cc-power-panel.c:396
-msgctxt "Battery name"
-msgid "Main"
-msgstr "मुख्य"
-
-#: ../panels/power/cc-power-panel.c:398
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "अगाऊ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:470
-msgid "Wireless mouse"
-msgstr "वायरलेस माऊस"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:473
-msgid "Wireless keyboard"
-msgstr "वायरलेस किबोर्ड"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:476
-msgid "Uninterruptible power supply"
-msgstr "अव्यतय पावर पुरवठा"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Personal digital assistant"
-msgstr "वैयक्तिक डिजिटल सहाय्यक"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Cellphone"
-msgstr "सेलफोन"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Media player"
-msgstr "मिडीया वादक"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Tablet"
-msgstr "टॅबलेट"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Computer"
-msgstr "संगणक"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
-#: ../panels/power/cc-power-panel.c:2019
-msgid "Battery"
-msgstr "बॅटरि"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "चार्ज करत आहे"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "सावधानता"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Low"
-msgstr "कमी"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Good"
-msgstr "चांगले"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "संपूर्णतया चार्ज केले"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "रिकामे"
-
-#: ../panels/power/cc-power-panel.c:715
-msgid "Batteries"
-msgstr "बॅटरिज"
-
-#: ../panels/power/cc-power-panel.c:1117
-msgid "When _idle"
-msgstr "निष्क्रिय असतेवेळी (_i)"
-
-#: ../panels/power/cc-power-panel.c:1445
-msgid "Power Saving"
-msgstr "उर्जा बचत"
-
-#: ../panels/power/cc-power-panel.c:1473
-msgid "_Screen brightness"
-msgstr "पडद्याचा उजळपणा (_S)"
-
-#: ../panels/power/cc-power-panel.c:1479
-msgid "_Keyboard brightness"
-msgstr "कळफलक उजळपणा (_K)"
-
-#: ../panels/power/cc-power-panel.c:1489
-msgid "_Dim screen when inactive"
-msgstr "निष्क्रीय असताना पडदा मंद करा (_D)"
-
-#: ../panels/power/cc-power-panel.c:1514
-msgid "_Blank screen"
-msgstr "रिक्त पडदा (_B)"
-
-#: ../panels/power/cc-power-panel.c:1551
-msgid "_Wi-Fi"
-msgstr "वायफाय (_W)"
-
-#: ../panels/power/cc-power-panel.c:1556
-msgid "Turns off wireless devices"
-msgstr "वायरलेश साधनांना बंद करते"
-
-#: ../panels/power/cc-power-panel.c:1581
-msgid "_Mobile broadband"
-msgstr "मोबाइल ब्रॉडबँड (_M)"
-
-#: ../panels/power/cc-power-panel.c:1586
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "मोबाइल ब्रॉडबँड (3G, 4G, WiMax, इत्यादि) साधने बंद करते"
-
-#: ../panels/power/cc-power-panel.c:1635
-msgid "_Bluetooth"
-msgstr "ब्ल्युटूथ (_B)"
-
-#: ../panels/power/cc-power-panel.c:1686
-msgid "When on battery power"
-msgstr "बॅटरि पावरवर असताना"
-
-#: ../panels/power/cc-power-panel.c:1688
-msgid "When plugged in"
-msgstr "प्लग केल्यानंतर"
-
-#: ../panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Off"
-msgstr "स्थगित करा आणि बंद करा"
-
-#: ../panels/power/cc-power-panel.c:1851
-msgid "_Automatic suspend"
-msgstr "स्व सस्पेंड (_A)"
-
-#: ../panels/power/cc-power-panel.c:1875
-msgid "When battery power is _critical"
-msgstr "बॅटरि पावर गंभीर असताना (_c)"
-
-#: ../panels/power/cc-power-panel.c:1930
-msgid "Power Off"
-msgstr "बंद करा"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Devices"
-msgstr "साधने"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "पावर"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr "बॅटरि स्थितीचे अवलोकन करा आणि पावर साठवण्याच्या सेटिंग्ज बदलवा"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-"पावर;स्लीप;सस्पेंड;हायबरनेट;बटरि;उजळपणा;मंद;रिक्त;मॉनिटर;डीपीएमएस;आइडल;"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "हायबरनेट"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "बंद करा"
-
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 मिनिटे"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 तास"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 मिनिटे"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 मिनिटे"
 
-#: ../panels/power/power.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 मिनिटे"
 
-#: ../panels/power/power.ui.h:10
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 तास"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 मिनिट"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "बॅटरि"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 मिनिटे"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "साधने"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 मिनिटे"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "बंद करा"
 
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "4 मिनिटे"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 मिनिटे"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "उर्जा बचत"
 
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "8 मिनिटे"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "पडद्याचा उजळपणा (_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 मिनिटे"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "पडद्याचा उजळपणा व कुलूपबंद सेटिंग्स्"
 
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "12 मिनिटे"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "पडदा"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "स्क्रीन रिडर (_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "स्व राउट्स"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "स्व स्थगित करा"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "खालचे बटन"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "स्व स्थगित करा"
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "प्लग केले (_P)"
 
-#: ../panels/power/power.ui.h:22
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "बॅटरि पावरवरील (_B)"
 
-#: ../panels/power/power.ui.h:23
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "विलंब"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "ओळख पटवा"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "पावर"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "पासवर्ड"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "बॅटरि स्थितीचे अवलोकन करा आणि पावर साठवण्याच्या सेटिंग्ज बदलवा"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "ओळख पटवणे आवश्यक"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr "टोनर निग्न आहे"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr "टोनर नाही"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr "डेव्हलपर निग्न आहे"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr "डेव्हलपर नाही"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr "मार्कर पुरवठा निग्न आहे"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr "मार्कर पुरवठा कमी आहे"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr "कवर उघडा"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr "दार उघडा"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr "पेपर निग्न आहे"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr "पेपर कमी आहे"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ऑफलाइन"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "थांबवले"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr "वेस्ट बऱ्यापैकी भरले आहे"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr "वेस्ट जवळपास भरले आहे"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr "ऑप्टिकल फोटो कंडक्टरची वेळसमाप्ति आढळली"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ऑप्टिकल फोटो कंडक्टर यापुढे कार्यशील नाही"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "संरचीत करत आहे"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr "सज्ज"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "जॉब्ज स्वीकरत नाही"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr "विश्लेषण करत आहे"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Toner Level"
-msgstr "टोनरचे स्तर"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Ink Level"
-msgstr "शाई स्तर"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:928
-msgid "Supply Level"
-msgstr "पुरवठा स्तर"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:946
-msgctxt "printer state"
-msgid "Installing"
-msgstr "प्रतिष्ठापीत करत आहे"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1123
-msgid "No printers available"
-msgstr "छपाईयंत्रे उपलब्ध नाही"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1433
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u सक्रिय"
-msgstr[1] "%u सक्रिय"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1777
-msgid "Failed to add new printer."
-msgstr "नविन छपाईयंत्र समाविष्ट करण्यास अपयशी."
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid "Select PPD File"
-msgstr "PPD फाइल नीवडा"
-
-#: ../panels/printers/cc-printers-panel.c:1953
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"पोस्टस्क्रिप्ट प्रिंटर डिस्क्रिप्शन फाइल्स् (*.ppd, *.PPD, *.ppd.gz, "
-"*.PPD.gz, *.PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "पावर;स्लीप;सस्पेंड;हायबरनेट;बटरि;उजळपणा;मंद;रिक्त;मॉनिटर;डीपीएमएस;आइडल;"
 
-#: ../panels/printers/cc-printers-panel.c:2258
-msgid "No suitable driver found"
-msgstr "योग्य ड्राइव्हर आढळले नाही"
-
-#: ../panels/printers/cc-printers-panel.c:2327
-msgid "Searching for preferred drivers…"
-msgstr "पसंतीचे ड्राइव्हर्स शोधत आहे..."
-
-#: ../panels/printers/cc-printers-panel.c:2342
-msgid "Select from database…"
-msgstr "डाटाबेसपासून नीवडा..."
-
-#: ../panels/printers/cc-printers-panel.c:2351
-msgid "Provide PPD File…"
-msgstr "PPD फाइल द्या..."
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2502
-#: ../panels/printers/cc-printers-panel.c:2525
-msgid "Test page"
-msgstr "चाचणी पान"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2933
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui लोड करणे अशक्य: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "छपाईयंत्रे"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
-msgstr ""
-"छपाईयंत्र समाविष्ट करा, छपाईयंत्र जॉब्सचे अवलोकन करा आणि छपाई कसे पाहिजे ते "
-"ठरवा"
+msgstr "छपाईयंत्र समाविष्ट करा, छपाईयंत्र जॉब्सचे अवलोकन करा आणि छपाई कसे पाहिजे ते ठरवा"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "प्रिंटर;क्युउ;प्रिंट;पेपर;इंक;टोनर;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "सक्रिय जॉब्स्"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "बंद करा"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "प्रिंटिंग पुनः आरंभ करा"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "छपाई थांबवा"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "छपाई जॉब रद्द करा"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "नविन छपाईयंत्र समाविष्टीत करा"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "A_uthenticate"
-msgstr "ओळख पटवा (_u)"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "छपाईयंत्र आढळले नाही."
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-msgid "Enter address of a printer or a text to filter results"
-msgstr "परिणा फिल्टर करण्यासाठी छपाईयंत्र किंवा मजकूरचा पत्ता द्या"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "पर्याय लोड करत आहे..."
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "छपाईयंत्र ड्राइव्हर नीवडा"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "ड्राइव्हर्स् डाटाबेस् लोड करत आहे..."
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-msgid "JetDirect Printer"
-msgstr "JetDirect छपाईयंत्र"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-msgid "LPD Printer"
-msgstr "LPD छपाईयंत्र"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "एका बाजूने"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "दोंही बाजूने (मानक)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "दोंही बाजूने (पलटवून)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "उभे"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "आडवे"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "उलट आडवे"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "उलट उभे"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "उर्वरित आहे"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "रोखून ठेवले"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "विश्लेषण करत आहे"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "थांबवले"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "रद्द केले"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "रद्द केले"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "पूर्ण झाले"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "जॉब शीर्षक"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "जॉबचे स्तर"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "वेळ"
-
-#: ../panels/printers/pp-jobs-dialog.c:495
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s सक्रिय जॉब्स्"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Serial Port"
-msgstr "सिरिअल पोर्ट"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1683
-msgid "Parallel Port"
-msgstr "पॅरलल पोर्ट"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-msgid "Location: %s"
-msgstr "ठिकाण: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1744
-#, c-format
-msgid "Address: %s"
-msgstr "पत्ता: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1768
-msgid "Server requires authentication"
-msgstr "सर्व्हरला ओळख पटवून द्या"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "दोंही बाजूने"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "पेपर प्रकार"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "पेपर स्रोत"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "आऊटपुट ट्रे"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "घोस्टस्क्रिप्ट प्रिफिल्टरिंग"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:531
-msgid "Pages per side"
-msgstr "प्रत्येक बाजूवरील पृष्ठे"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:543
-msgid "Two-sided"
-msgstr "दोंही बाजूने"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:555
-msgid "Orientation"
-msgstr "निर्देशन"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:652
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "सर्वसाधारण"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "पृष्ठ मांडणी"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "प्रतिष्ठापनजोगी पर्याय"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "कार्य"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "प्रतिमा दर्जा"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "रंग"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "पूर्णत्व"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "प्रगत"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "स्वयं नीवडा"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "छपाईयंत्र पूर्वनिर्धारीत"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "फक्त घोस्टस्क्रिप्ट फाँटस् अंतर्भुत करा"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "PS स्तर 1 करीता रूपांतरीत करा"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "PS स्तर 2 करीता रूपांतरीत करा"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "प्रिफिल्टरिंग आढळले नाही"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "उत्पादक"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "ड्राइव्हर"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-"%s वरील उपलब्ध छपाईयंत्रांच्या अवलोकनकरिता तुमचे वापरकर्तानाव आणि पासवर्ड "
-"द्या."
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "छपाईयंत्र समाविष्ट करा"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "छपाईयंत्र काढून टाका"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "पुरवठा"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "चित्र आढळले नाही"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "ओळख पटवणे आवश्यक"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr "%s वरील उपलब्ध छपाईयंत्रांच्या अवलोकनकरिता तुमचे वापरकर्तानाव आणि पासवर्ड द्या."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "वापरकर्तानाव"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "ठिकाण"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default printer"
-msgstr "पूर्वनिर्धारीत छपाईयंत्र (_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "ड्राइव्हर"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "जॉब्स्"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "पसंतीचे ड्राइव्हर्स शोधत आहे..."
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "जॉब्स दाखवा (_J)"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "शहर शोधा"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "डाटाबेसपासून नीवडा..."
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "PPD फाइल द्या..."
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "छपाईयंत्र ड्राइव्हर नीवडा"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "ड्राइव्हर्स् डाटाबेस् लोड करत आहे..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "रद्द करा"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "नीवडा"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "सर्व्हरला ओळख पटवून द्या"
+msgstr[1] "सर्व्हरला ओळख पटवून द्या"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "डोमैन (_D)"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "ओळख पटवा (_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "ओळख पटवा"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s सक्रिय जॉब्स्"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "चाचणी पान"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "लॉगिन पर्याय"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "छपाईयंत्र पूर्वनिर्धारीत"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "छपाईयंत्र पूर्वनिर्धारीत"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "छपाई जॉब रद्द करा"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "छपाईयंत्र काढून टाका"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "सक्रिय जॉब्स्"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "मॉडल"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "लेबल"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "शाई स्तर"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "नवीन ड्राइव्हर ठरवत आहे..."
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "पृष्ठ 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "चाचणी पानची छपाई करा (_T)"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "पर्याय (_O)"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "आत्ता सुरू करा"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "नविन छपाईयंत्र समाविष्ट करा"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "छपाईयंत्र समाविष्ट करा"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "छपाईयंत्रच्या सेटिंग्स् बदला"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "छपाईयंत्रे"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "माफ करा! सिस्टम प्रिंटिंग सर्व्हिस्\n"
 "उपलब्ध नाही असे आढळलते."
 
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "पडदा कुलूपबंद"
-
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "वापर आणि इतिहास"
-
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
-msgstr "कचरापेटीतून सर्व घटकांना रिक्त करायचे?"
-
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
-msgstr "कचरापेटीतील सर्व घटकांना नेहमीकरिता नष्ट केले जाईल."
-
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "कचरापेटी रिकामे करा (_E)"
-
-#: ../panels/privacy/cc-privacy-panel.c:512
-msgid "Delete all the temporary files?"
-msgstr "सर्व तात्पुते फाइल्स नष्ट करायचे?"
-
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
-msgstr "सर्व तात्पुर्त्या फाइल्स नेहमीकरिता नष्ट केले जातील."
-
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "तात्पुर्त्या फाइल्स काढून टाका (_P)"
-
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "ट्रॅश आणि तात्पुर्त्या फाइल्स काढून टाका"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr "सॉफ्टवेअर वापर"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "गोपणीयता"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-"वैयक्ति माहिती सुरक्षित ठेवा आणि इतरांना ते कसे दृष्यास्पद असे ते नियंत्रीत "
-"करा"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"स्क्रीन;लॉक;विश्लेषण;क्रॅश;वैयक्तिक;नुकतेच;तात्पुर्ते;tmp;इंडेक्स;नाव;"
-"नेटवर्क;ओळख;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "पडदा बंद होते"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 सेकंद"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 दिवस"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 दिवस"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 दिवस"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 दिवस"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 दिवस"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 दिवस"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 दिवस"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 दिवस"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 दिवस"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "नेहमीकरिता"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"इतिहास लक्षात ठेवल्याने बाबी ओळखायला सोयीस्कर ठरते. या घटकांना कधिही "
-"नेटवर्कवरील शेअर केले जात नाही."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "नुकतेच वापरलेले (_R)"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "इतिहास जपवा (_H)"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "नुकतेच इतिहास नष्ट करा (_e)"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "पडदा कुलूपबंद, तुम्ही दूर असताना गोपणीयता सुरक्षित करते."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "स्व पडदा कुलूपबंद (_L)"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "रिक्त असल्यास पडदा कुलूपबंद करा (_a)"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "सूचना दाखवा (_N)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"कचरापेटी आणि तात्पुर्त्या फाइल्स स्व काढून टाका जेणेकरून संगणक अनावश्यक "
-"संवेदनशील माहितीरहीत राहील."
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "कचरापेटी स्व रिक्त करा (_T)"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "स्व तात्पुर्ते फाइल्स काढून टाका (_F)"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "नंतर काढून टाका (_A)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"वापरण्याजोगी सॉफ्टवेअरविषयी माहिती पाठवल्याने आम्ही तुम्हाला अचूक शिफारस देऊ "
-"शकू. सॉफ्टवेअर सुधारणामध्ये मदत होते.\n"
-"\n"
-"गोळा केलेली सर्व माहिती निनावी राहते, आणि आम्ही तुमचा डाटा तीसऱ्या पक्षांसह "
-"कधिही शेअर करणार नाही."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "सॉफ्टवेअर वापर आकडेवारि पाठवा (_S)"
-
-#: ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "गोपणीयता करार"
-
-#: ../panels/privacy/privacy.ui.h:42
-msgid "_Location Services"
-msgstr "लोकेशन सर्व्हिसेस (_L)"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "जिओग्राफिकल ठिकाण ओळखण्यासाठी वापरले जाते"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "इम्पिरिअल"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "मेट्रिक"
-
-#: ../panels/region/cc-format-chooser.c:284
-msgid "No regions found"
-msgstr "क्षेत्र आढळले नाही"
-
-#: ../panels/region/cc-input-chooser.c:179
-msgid "No input sources found"
-msgstr "इंपुट स्रोत आढळले नाही"
-
-#: ../panels/region/cc-input-chooser.c:1076
-msgctxt "Input Source"
-msgid "Other"
-msgstr "इतर"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:892
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "प्रभावी बदलकरिता सत्रला पुन्हा सुरू करणे आवश्यक आहे"
-
-#: ../panels/region/cc-region-panel.c:243
-#: ../panels/user-accounts/um-user-panel.c:896
-msgid "Restart Now"
-msgstr "आत्ता सुरू करा"
-
-#: ../panels/region/cc-region-panel.c:862
-msgid "No input source selected"
-msgstr "इंपुट स्रोत नीवडले नाही"
-
-#: ../panels/region/cc-region-panel.c:1092
-msgid "Sorry"
-msgstr "माफ करा"
-
-#: ../panels/region/cc-region-panel.c:1094
-msgid "Input methods can't be used on the login screen"
-msgstr "प्रवेश पडद्यावर इंपुट पद्धतींचा वापर शक्य नाही"
-
-#: ../panels/region/cc-region-panel.c:1731
-msgid "Login Screen"
-msgstr "प्रवेश पटल"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "रूपण"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "ठिकाण शोधा"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "सर्वसाधारण कार्य"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "रूपण"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "पूर्वावलोकन"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "दिनांक"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "वेळ"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "दिनांक व वेळ"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "अंक"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "मोजमाप"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "पेपर"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "भाषा प्रतिष्ठापीत करा..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "माझे खाते"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "भाषा (_L)"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "रूपण"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "प्रवेश पटल"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "क्षेत्र व भाषा"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr "डिस्पले भाषा, रूपण, कळफलक मांडणी आणि इंपुट स्रोत नीवडा"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "भाषा;मांडणी;कळफलक;इंपुट;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "इंपुट स्रोत समाविष्ट करा"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "मिडीया कसे हाताळायचे ते निवडा"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "इंपुट स्रोत पर्याय"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD ऑडिओ (_a)"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Use the _same source for all windows"
-msgstr "सर्व पटलांकरिता समान स्रोतचा वापर करा (_s)"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "DVD व्हिडीओ (_D)"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Allow _different sources for each window"
-msgstr "प्रत्येक पटलकरीता वेगळे स्रोत स्वीकारा (_d)"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "संगीत वादक (_M)"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Keyboard Shortcuts"
-msgstr "कळफलक शार्टकट्स"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "सॉफ्टवेअर"
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Switch to previous source"
-msgstr "मागील स्रोतचा वापर करा"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "इतर मिडीया (_O)..."
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "मिडीया अंतर्भुतकरतेवेळी कधिही प्रोग्राम्स् करीता विनंती किंवा सुरू करू नका (_N)"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Switch to next source"
-msgstr "पुढच्या स्रोतचा वापर करा"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "इतर मिडीयाला कसे हाताळायचे ते निवडा"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "Super+Space"
-msgstr "Super+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "तपशील"
 
-#: ../panels/region/input-options.ui.h:10
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "कळफलक सेटिंग्जमध्ये या शॉर्टकट्सना बदलणे शक्य आहे"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "प्रकार (_T):"
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Alternative switch to next source"
-msgstr "पुढील स्रोतकरिता वैकल्पिक स्वीच"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "काढून टाकण्याजोगी मिडीया"
 
-#: ../panels/region/input-options.ui.h:12
-msgid "Left+Right Alt"
-msgstr "Left+Right Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "ब्ल्युटूथ सेटिंग्स् संरचीत करा"
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "इंग्रजि (युनाइटेड किंगडम)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "युनाइटेड किंगडम"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "पर्याय"
-
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
-msgstr ""
-"प्रणालीमध्ये प्रवेश करताना प्रवेश सेटिंग्ज सर्व वापरकर्त्यांसह वापरले जाते"
-
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
-msgid "Places"
-msgstr "ठिकाण"
-
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
-msgid "Bookmarks"
-msgstr "वाचनखुणा"
-
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
-msgstr "इतर"
-
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "ठिकाण पसंत करा"
-
-#: ../panels/search/cc-search-locations-dialog.c:682
-msgid "_OK"
-msgstr "ठीक आहे (_O)"
-
-#: ../panels/search/cc-search-panel.c:176
-msgid "No applications found"
-msgstr "ॲप्लिकेशन्स आढळले नाही"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "शोधा"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Control which applications show search results in the Activities Overview"
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"क्रिया पूर्ववलोकनमध्ये कोणते ॲप्लिकेशन्स शोध परिणाम दाखवतात ते नियंत्रीत करा"
+"डिव्हाइस;सिस्टम;इंफॉरमेशन;मेमरि;प्रोसेसर;वर्जन;डिफॉल्ट;ॲप्लिकेशन;फॉलबॅक;प्रेफर्ड;सीडी;"
+"डीवीडी;युएसबी;ऑडिओ;व्हिडीओ;डिस्क;रिमोवेबल;मिडीया;ऑटोरन;"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
-msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "सर्च;फाइंड;इंडेक्स;छुपे करा;गोपणीयता;परिणाम;"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "पडदा कुलूपबंद"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "रिक्त पडदा (_B)"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "स्व पडदा कुलूपबंद (_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "स्व पडदा कुलूपबंद (_L)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "पडदा कुलूपबंद करामधील तपशील दाखवा"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "पडदा कुलूपबंद करा"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "गोपणीयता"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "पडदा"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "साऊंड सेटिंग्स्"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "ठिकाण शोधा"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "वर जा"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "खाली जा"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "पसंती"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "सुरू करा"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "बंद करा"
-
-#: ../panels/sharing/cc-sharing-panel.c:304
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "सुरू केले"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-msgctxt "service is active"
-msgid "Active"
-msgstr "सक्रीय"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "फोल्डर पसंत करा"
-
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "प्रत करा"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-msgid "Sharing"
-msgstr "शेअरिंग"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr "इतरांशी काय शेअर करायचे ते नियंत्रीत करा"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
 msgstr ""
-"शेअर;शेअरिंग;एसएसएच;यजमान;नाव;दूरस्त;डेस्कटॉप;ब्ल्युटूथ;ओबेक्स;मिडीया;ऑडिओ;व्ह"
-"िडीओ;"
-"प्रतिमा;छायाचित्र;चित्रपट;सर्व्हर;रेंडरर;"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "दूरस्त प्रवेश सुरू किंवा बंद करा"
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
+msgid "Places"
+msgstr "ठिकाण"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "दूरस्त प्रवेश सुरू किंवा बंद करण्यासाठी ओळख पटवणे आवश्यक"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
+msgid "Bookmarks"
+msgstr "वाचनखुणा"
 
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:299
-msgid "No networks selected for sharing"
-msgstr "शेअरिंगकरिता नेटवर्क्स पसंत केले नाही"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "इतर"
 
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "ठिकाण"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "ॲप्लिकेशन्स्"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "पत्तातर्फे शोधा (_S)"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "क्रिया पूर्ववलोकनमध्ये कोणते ॲप्लिकेशन्स शोध परिणाम दाखवतात ते नियंत्रीत करा"
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "सर्च;फाइंड;इंडेक्स;छुपे करा;गोपणीयता;परिणाम;"
+
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "नेटवर्क्स"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "ब्ल्युटूथ शेअरिंग"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "शेअरिंग"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-"ब्ल्युटूथ शेअरिंग तुम्हाला इतर ब्ल्युटूथ समर्थीत साधनांसह फाइल्स शेअर "
-"करण्यासाठी परवानगी देते"
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "फक्त विश्वासर्ह साधनांपासून प्राप्त करा"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "प्राप्य फाइल्सना डाउनलोड्ज फोल्डरमध्ये साठवा"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "संगणकाचे नाव"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "वैयक्तिक फाइल शेअरिंग"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "पडदा शेअरिंग"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "कार्यस्थळ"
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
 msgstr "मिडीया शेअरिंग"
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "दूरस्त प्रवेश"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "शेअरिंग"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "आवश्यक पासवर्ड"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "दूरस्त प्रवेश"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "नेटवर्क प्रवेश नसल्यामुळे काही सर्व्हिसेस बंद केले जातात."
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "कार्यस्थळ"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
-"वैयक्तिक फाइल शेअरिंग तुम्हाला पब्लिक फोल्डरला आत्ताच्या नेटवर्कवरील: <a "
-"href=\"dav://%s\">dav://%s</a> याचा वापर करून इतरांशी शेअर करण्यासाठी परवानगी "
-"देते"
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr "आवश्यक पासवर्ड"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "दूरस्त प्रवेश सुरू किंवा बंद करा"
 
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"सेक्युर शेल आदेश:\n"
-"<a href=\"ssh %s\">ssh %s</a> याचा वापर करून रिमोट वापरकर्त्यांना जोडणीकरिता "
-"परवानगी द्या"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"अवलोकन किंवा पडदा नियंत्रीत करण्यासाठी दूरस्त वापरकर्त्यांना परवानगी द्या: <a "
-"href="
-"\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "दूरस्त नियंत्रण स्वीकारा"
 
-#: ../panels/sharing/sharing.ui.h:21
-msgid "Password:"
-msgstr "पासवर्ड:"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "पासवर्ड दाखवा"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "जुडले नाही"
 
-#: ../panels/sharing/sharing.ui.h:23
-msgid "Access Options"
-msgstr "प्रवेश पर्याय"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "नवीन जोडण्यांनी प्रवेशकरिता विनंती केली पाहिजे"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "प्रत करा"
 
-#: ../panels/sharing/sharing.ui.h:25
-msgid "Require a password"
-msgstr "पासवर्ड आवश्यक"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "पत्ता नष्ट करा"
 
-#: ../panels/sharing/sharing.ui.h:26
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "ओळख (_t)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "वापरकर्तानाव"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "फिंगरप्रिंटस् एंरोल करत आहे"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "मिडीया शेअरिंग"
+
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "नेटवर्कवरील संगीत, छायाचित्र आणि व्हिडीओज शेअर करा."
 
-#: ../panels/sharing/sharing.ui.h:27
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "फोल्डर्स"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "आवाज"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "इतरांशी काय शेअर करायचे ते नियंत्रीत करा"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "आवाज स्तर, इंपुट्स, आउटपुट्स, आणि गजर आवाज बदलवा"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"शेअर;शेअरिंग;एसएसएच;यजमान;नाव;दूरस्त;डेस्कटॉप;ब्ल्युटूथ;ओबेक्स;मिडीया;ऑडिओ;व्हिडीओ;प्रतिमा;"
+"छायाचित्र;चित्रपट;सर्व्हर;रेंडरर;"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "कार्ड;माइक्रोफोन;वॉल्युम;फेड;बॅलेंस्;ब्ल्युटूथ;हेडसेट;ऑडिओ;"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "दूरस्त प्रवेश सुरू किंवा बंद करा"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "बार्क"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "दूरस्त प्रवेश सुरू किंवा बंद करण्यासाठी ओळख पटवणे आवश्यक"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "ड्रिप"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "फ्लिकर"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "ग्लास"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "शेअरिंग"
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "सोनार"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "डावे"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "उजवे"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "बॅलेंस (_B):"
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "फेड (_F):"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "पाठचे"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "पुढचे"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "किमान"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "कमाल"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "बॅलेंस (_B):"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "फेड (_F):"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "सबवूफर (_S):"
-
-#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:616
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "ॲम्प्लिफाय केले"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "प्रोफाइल (_P):"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u आउटपुट"
-msgstr[1] "%u आउटपुट"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u इंपुट"
-msgstr[1] "%u इंपुट"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "सिस्टम साऊंडस्"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "चाचणी स्पिकर्स (_T)"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "सतर्कता वॉल्युम (_A):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "पिक ओळखणे"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "वॉल्युम मंद करा"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1509
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "नाव"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1528
-msgid "Device"
-msgstr "s साधन"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1591
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s करीता स्पिकरची ऊंची"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1649
-msgid "_Output volume:"
-msgstr "आऊटपुट वॉल्युम (_O):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1663
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "आऊटपुट"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1668
-msgid "C_hoose a device for sound output:"
-msgstr "साऊंड आऊटपुटकरीता साधन निवडा (_h):"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "आऊटपुट वॉल्युम (_O):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1693
-msgid "Settings for the selected device:"
-msgstr "निवडलेल्या साधनकरीता सेटिंग्स्:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "Input"
-msgstr "इंपुट"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "_Input volume:"
-msgstr "इंपुट वॉल्यूम (_I):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1734
-msgid "Input level:"
-msgstr "इंपुट स्तर:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1762
-msgid "C_hoose a device for sound input:"
-msgstr "साऊंड इंपुटकरीता साधन पसंत करा (_h):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "Sound Effects"
-msgstr "साऊंड प्रभाव"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-msgid "_Alert volume:"
-msgstr "सतर्कता वॉल्युम (_A):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1809
-msgid "Applications"
-msgstr "ॲप्लिकेशन्स्"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1813
-msgid "No application is currently playing or recording audio."
-msgstr "ॲप्लिकेशन सध्या ऑडिओ चालवत किंवा रेकॉर्ड करत आहे."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "ब्लिटइन"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "साऊंड पसंती"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "इव्हेंट साऊंड चाचणी"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "पूर्वनिर्धारीत"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "थिम पासून"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:769
-msgid "C_hoose an alert sound:"
-msgstr "सावधानता आवाज पसंत करा (_h):"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "थांबवा"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "चाचणी"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "संरचना URL (_C):"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "सबवूफर"
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "मनपसंद"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "इंपुट"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "अवलोकन, ऐकणे, टाइप, पॉइंट आणि क्लिककरिता सोपे करा"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "इंपुट स्तर:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "वॉल्युम वाढवा"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "सतर्कता वॉल्युम (_A):"
+
+#: panels/sound/cc-volume-slider.ui:22
+#, fuzzy
+msgid "Mute"
+msgstr "मंद करा (_M)"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "आवाज"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "आवाज स्तर, इंपुट्स, आउटपुट्स, आणि गजर आवाज बदलवा"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "कार्ड;माइक्रोफोन;वॉल्युम;फेड;बॅलेंस्;ब्ल्युटूथ;हेडसेट;ऑडिओ;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "सूचना"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "नाव(_N) :"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"किबोर्ड;माऊस;ॲलि;ॲक्सेसिबिलिटि;काँट्रास्ट;झूम;स्क्रीन;रिडर;टेक्स्ट;फाँट;आकार;ॲ"
-"क्सेसएक्स;"
-"स्किकि;किज;स्लो किज्;बाउंस;माऊस;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "नेहमी युनिवर्सल ॲक्सेस मेन्यु दाखवा (_A)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "सिइंग"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "स्व जोडणी करा (_C)"
 
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "जास्त काँट्रास्ट (_H)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "साधन काढून टाका"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "मोठे मजकूर (_L)"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:5
-msgid "_Zoom"
-msgstr "मोठे करा (_Z)"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s डोमैन: %s सह जोडणी अशक्य"
 
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr "स्क्रीन रिडर (_R)"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "युनिवर्सल ॲकसेस"
 
-#: ../panels/universal-access/uap.ui.h:8
-msgid "_Sound Keys"
-msgstr "आवाज किज (_S)"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "ऐकणे"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "साधने प्राप्त करत आहे..."
 
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
-msgstr "दृष्यास्पद गजर (_V)"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Screen _Keyboard"
-msgstr "स्क्रीन किबोर्ड (_K)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "थंडरबर्ड्"
 
-#: ../panels/universal-access/uap.ui.h:13
-msgid "_Typing Assist (AccessX)"
-msgstr "टायपिंग असिस्ट (ॲक्सेसएक्स) (_T)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Pointing & Clicking"
-msgstr "पॉईंटिंग आणि क्लिकिंग"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:15
-msgid "_Mouse Keys"
-msgstr "माऊस किज (_M)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "कर्सर लुकलुकणे"
 
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "क्लिक असिस्ट (_C)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "पाठ्य गुणविशेष मधील कर्सर लुकलुकते (_b)"
 
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "स्क्रीन रिडर"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "वेग(_S):"
 
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "फोकस स्थानांतरित करत असताना स्क्रीन रिडर दाखविलेले मजकूर वाचते."
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "कर्सर लुकलुकण्याचा वेग"
 
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Screen Reader"
-msgstr "स्क्रीन रिडर (_S)"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "कर्सर लुकलुकण्याचा वेग"
 
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Sound Keys"
-msgstr "साउंड किज"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "Num लॉक किंवा Caps लॉक सुरू केल्यानंतर बीप द्या."
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "दृष्यास्पद सावधानता"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "फ्लॅशची चाचणी करा (_T)"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "गजर आवाज आढळल्यानंतर दृष्यास्पद निर्देशनचा वापर करा."
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Flash the _window title"
-msgstr "पटलाचे शीर्षक फ्लॅश करा (_w)"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Flash the entire _screen"
-msgstr "पडदाभर फ्लॅश करा (_s)"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Typing Assist"
-msgstr "टाइपिंग सहाय्यक"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "_Sticky Keys"
-msgstr "स्टीकी किज (_S)"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "मॉडिफायर किज्ची श्रृंखला यास कि जोडणी म्हणून वागवतो"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "दोन किज् एकाचवेळी दाबल्यास बंद करा (_D)"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifer key is pressed"
-msgstr "संपादकीय किल्ली दाबल्यावर बीप द्या (_m)"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "S_low Keys"
-msgstr "स्लो किज (_l)"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "कि दाबल्यावर व स्वीकारल्यावर विलंब प्रस्तुत करतो"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "स्वीकार विलंब (_c):"
-
-#: ../panels/universal-access/uap.ui.h:35
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "छोटे"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "स्लो किज् टाइपिंग विलंब"
-
-#: ../panels/universal-access/uap.ui.h:37
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "लांब"
-
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Beep when a key is pr_essed"
-msgstr "कि दाबून ठेवल्यास बीप द्या (_e)"
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Beep when a key is _accepted"
-msgstr "कि स्वीकारल्यास बीप द्या (_a)"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "कि नकारल्यास बीप द्या (_r)"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "_Bounce Keys"
-msgstr "बाऊंस किज (_B)"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "फास्ट ड्युप्लिकेट किप्रेसेस्कडे दुर्लक्ष करते"
-
-#: ../panels/universal-access/uap.ui.h:43
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "छोटे"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "बाऊंस किज् टाइपिंग विलंब"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "लांब"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Enable by Keyboard"
-msgstr "कळफलकनुरूप सुरू करा (_E)"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "किबोर्डपासून ॲसेसिबिलिटि गुणधर्म बंद किंवा सुरू करा"
-
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "क्लिक असिस्ट"
 
-#: ../panels/universal-access/uap.ui.h:49
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "दुसरी क्लिक सिम्युलेट केली (_S)"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "प्राथमीक बटन दाबून दुसरि क्लिक सुरू करा"
 
-#: ../panels/universal-access/uap.ui.h:51
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "स्वीकार विलंब (_c):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "छोटे"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "सेकंड्रि क्लिक विलंब"
 
-#: ../panels/universal-access/uap.ui.h:53
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "लांब"
 
-#: ../panels/universal-access/uap.ui.h:54
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "होवर क्लिक (_H)"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "पॉईंटर एका जागेवर असल्यास क्लिक सुरू करा"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "उशीर (_e):"
 
-#: ../panels/universal-access/uap.ui.h:57
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "छोटे"
 
-#: ../panels/universal-access/uap.ui.h:58
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "लांब"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "मोशन थ्रेशोल्ड (_t):"
 
-#: ../panels/universal-access/uap.ui.h:60
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "छोटे"
 
-#: ../panels/universal-access/uap.ui.h:61
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "मोठे"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "पुनःवृत्ती किज्"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "कळ दाबून ठेवल्यास कळ पुनः दाबली जाते (_r)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "रिपीट किजचा वेग"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "रिपीट किजचा वेग"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "टाइपिंग सहाय्यक"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "स्टीकी किज (_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "मॉडिफायर किज्ची श्रृंखला यास कि जोडणी म्हणून वागवतो"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "दोन किज् एकाचवेळी दाबल्यास बंद करा (_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "संपादकीय किल्ली दाबल्यावर बीप द्या (_m)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "स्लो किज (_l)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "कि दाबल्यावर व स्वीकारल्यावर विलंब प्रस्तुत करतो"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "छोटे"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ स्क्रीन"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "स्लो किज् टाइपिंग विलंब"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ स्क्रीन"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ स्क्रीन"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "लांब"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "कि दाबून ठेवल्यास बीप द्या (_e)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "कि स्वीकारल्यास बीप द्या (_a)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "कि नकारल्यास बीप द्या (_r)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "बाऊंस किज (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "फास्ट ड्युप्लिकेट किप्रेसेस्कडे दुर्लक्ष करते"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "छोटे"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "बाऊंस किज् टाइपिंग विलंब"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "लांब"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "कळफलकनुरूप सुरू करा (_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "किबोर्डपासून ॲसेसिबिलिटि गुणधर्म बंद किंवा सुरू करा"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "नेहमी युनिवर्सल ॲक्सेस मेन्यु दाखवा (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "सिइंग"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "जास्त काँट्रास्ट (_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "मोठे मजकूर (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "स्क्रीन रिडर (_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "फोकस स्थानांतरित करत असताना स्क्रीन रिडर दाखविलेले मजकूर वाचते."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "आवाज किज (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num लॉक किंवा Caps लॉक सुरू केल्यानंतर बीप द्या."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "कर्सर लुकलुकण्याचा वेग"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "मोठे करा (_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "ऐकणे"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "दृष्यास्पद गजर (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "स्क्रीन किबोर्ड (_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "पुनःवृत्ती किज्"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "कर्सर लुकलुकणे"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "टायपिंग असिस्ट (ॲक्सेसएक्स) (_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "पॉईंटिंग आणि क्लिकिंग"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "माऊस किज (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "पांढरा पॉईंटर"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "क्लिक असिस्ट (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "दोनवेळा क्लिक करा (_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "डबल-क्लिक् वेळ समाप्ती"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "दृष्यास्पद सावधानता"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "फ्लॅशची चाचणी करा (_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "गजर आवाज आढळल्यानंतर दृष्यास्पद निर्देशनचा वापर करा."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "पडदाभर फ्लॅश करा (_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "पडदाभर फ्लॅश करा (_s)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "पडदाभर"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "शीर्ष भाग"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "तळ भाग"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "डावे भाग"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "उजवे भाग"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "झूम पर्याय"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "मोठे करा"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "मोठे करणे:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "माऊस कर्सर लागू करा"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "स्क्रीन भाग:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "मॅगनिफायर पडद्याच्या बाहेर जाते"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "मॅगनिफायर कर्सर केंद्रित ठेवा"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "मॅगनिफायर कर्सर अंतर्भुत माहिती पुश करतो"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "मॅनिफायर कर्सर अंतर्भुत माहितीसह हलतो"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "मॅगनिफायर ठिकाण:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "माऊस कर्सर लागू करा"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "स्क्रीन भाग:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "मॅगनिफायर पडद्याच्या बाहेर जाते"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "मॅगनिफायर कर्सर केंद्रित ठेवा"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "मॅगनिफायर कर्सर अंतर्भुत माहिती पुश करतो"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "मॅनिफायर कर्सर अंतर्भुत माहितीसह हलतो"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "वर्धक"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "क्रॉसहेर्स्:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "माऊस कर्सरला अतिव्याप्ति करते"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "जाडी:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "बारीक"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "जाड"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "लांबी:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "रंग:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "क्रॉसहेर्स्:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "माऊस कर्सरला अतिव्याप्ति करते"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "क्रॉसहेर्स्"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "रंग प्रभाव:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "काळ्यावर पांढरे:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "उजळपणा:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "भिन्नता:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "रंग"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "काहिही नाही"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "पूर्ण"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "कमी"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "जास्त"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "कमी"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "जास्त"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "रंग प्रभाव:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "रंग प्रभाव"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "मानक"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "अवलोकन, ऐकणे, टाइप, पॉइंट आणि क्लिककरिता सोपे करा"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "प्रशासक"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Full Name"
-msgstr "संपूर्ण नाव (_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "खाते प्रकार (_T)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to set a password when they next login"
-msgstr "पुढील प्रवेशवेळी वापरकर्त्याला पासवर्ड सेट करण्यास परवानगी द्या"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "पासवर्ड आत्ता ठरवा"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "वैध करा (_V)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"या साधनावर वापरकरिता एंटरप्राइज प्रवेश अस्तित्वातील केंद्रीय व्यवस्थापीत "
-"वापरकर्ता खात्यांकरिता परवानगी देते"
+"किबोर्ड;माऊस;ॲलि;ॲक्सेसिबिलिटि;काँट्रास्ट;झूम;स्क्रीन;रिडर;टेक्स्ट;फाँट;आकार;ॲक्सेसएक्स;"
+"स्किकि;किज;स्लो किज्;बाउंस;माऊस;"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "डोमैन (_D)"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "इतिहास"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"एंटरप्राइज प्रवेश खाती समाविष्ट करण्यासाठी\n"
-"ऑनलाइन जा."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "एंटरप्राइज प्रवेश (_E)"
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "इतिहास"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "नुकतेच इतिहास नष्ट करा (_e)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "ट्रॅश आणि तात्पुर्त्या फाइल्स काढून टाका"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "कचरापेटी स्व रिक्त करा (_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "स्व तात्पुर्ते फाइल्स काढून टाका (_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "कचरापेटी स्व रिक्त करा (_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "कचरापेटी रिकामे करा (_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "तात्पुर्त्या फाइल्स काढून टाका (_P)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "कचरापेटीकडे हलवा"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "वापरकर्ता समाविष्ट करा"
 
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "प्रशासक"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "पुढील प्रवेशवेळी वापरकर्त्याला पासवर्ड सेट करण्यास परवानगी द्या"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "पासवर्ड आत्ता ठरवा"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "संरचीत करत आहे"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "एंटरप्राइज प्रवेश (_E)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "ऑफलाइन"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"या साधनावर वापरकरिता एंटरप्राइज प्रवेश अस्तित्वातील केंद्रीय व्यवस्थापीत वापरकर्ता "
+"खात्यांकरिता परवानगी देते"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PPD फाइल नीवडा"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "फिंगरप्रिन्ट प्रवेश (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "फिंगरप्रिन्ट प्रवेश (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "नाही"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"तुम्हाला पंजीकृत फिंगरप्रिन्ट नष्ट करायचे, तसे केल्यास फिंगरप्रिन्ट प्रवेश अकार्यान्वीत होईल?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "छपाईयंत्र आढळले नाही."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "फिंगरप्रिन्ट प्रवेश (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "फिंगरप्रिन्ट प्रवेश (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "संरचनाकरीता साधन पसंत करा (_h):"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "फिंगरप्रिन्ट प्रवेश (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "फिंगरप्रिन्ट नष्ट करा (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "फिंगरप्रिन्ट प्रवेश (_F)"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "पूर्वीचे ट्रॅक"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "पासवर्ड बदलवा"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "बदल करा (_a)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "सध्याचे पासवर्ड (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "नवीन पासवर्ड (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "पासवर्डची खात्री करा (_o)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "पासवर्ड्ज जुळत नाही."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "पुढील प्रवेशवेळी वापरकर्त्याला पासवर्ड सेट करण्यास परवानगी द्या"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "पासवर्ड आत्ता ठरवा"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "वापरकर्ते"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "प्रभावी बदलकरिता सत्रला पुन्हा सुरू करणे आवश्यक आहे"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "आत्ता सुरू करा"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "बंद करा"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "संपूर्ण नाव (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "संपादीत करा"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "फिंगरप्रिन्ट प्रवेश (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "स्वयं प्रवेश (_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "खाते प्रकार (_t)"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "प्रशासक"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "नियंत्रणे"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "वापरकर्ता खाते काढून टाका"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "इतर बोट (_O):"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "वापरकर्ता समाविष्ट करा"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "चित्र आढळले नाही"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "वापरकर्ता खाते निर्माण करा"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "वापरकर्ते समाविष्ट करा किंवा काढून टाका आणि पासवर्ड बदलवा"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "नाव नोंदणी (_E)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "डोमैन प्रशासक प्रवेश"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6003,1142 +4802,3318 @@ msgstr ""
 "ह्या डोमैन अंतर्गत असणे आवश्यक आहे. कृपया नेटवर्क प्रशासकाने\n"
 "येथे डोमैन पासवर्ड द्या."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "प्रशासक नाव (_N)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "प्रशासक पासवर्ड"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "डावा अंगठा"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "डावे मधले बोट"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "डावे अंगठी बोट"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "डावे छोटे बोट"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "उजवा अंगठा"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "उजवे मधले बोट"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "उजवे अंगठी बोट"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "उजवे छोटे बोट"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:687
-msgid "Enable Fingerprint Login"
-msgstr "फिंगरप्रिन्ट प्रवेश कार्यान्वीत करा"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "उजवे तर्जनी बोट (_R)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "डावे तर्जनी बोट (_L)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "इतर बोट (_O):"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"तुमचा फिंगरप्रिन्ट यशस्वीरित्या साठविले गेले. फिंगरप्रिन्ट रिडीरचा वापर करून "
-"तुम्ही आता "
-"दाखल करू शकता."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "वापरकर्ते"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr "वापरकर्ते समाविष्ट करा किंवा काढून टाका आणि पासवर्ड बदलवा"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "लॉगिन;नाव;फिंगरप्रिंट;अवतार;चिन्ह;फेस;पासवर्ड;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "प्रवेश इतिहास"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr "पासवर्ड बदलवा"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "बदल करा (_a)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "नवीन पासवर्ड वैध करा (_V)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "नवीन पासवर्ड (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "सध्याचे पासवर्ड (_P)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "वापरकर्ता खाते समाविष्ट करा"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "वापरकर्ता खाते काढून टाका"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "लॉगिन पर्याय"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "स्वयं प्रवेश (_u)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "फिंगरप्रिन्ट प्रवेश (_F)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "वापरकर्ता चिन्ह"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "भाषा (_L)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "मागील प्रवेश"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "वापरकर्ता खाते व्यवस्थापीत करा"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "वापरकर्ता डाटा बदलण्यासाठी ओळख पटवणे आवश्यक"
 
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "नवीन पासवर्ड जुण्यापेक्षा वेगळे पाहिजे."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "काही अक्षरे आणि संख्या बदलण्याचा प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "पासवर्डला बदलण्याचा थोडा आणखी प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "वापरकर्ता नाव विना, पासवर्ड जास्त मजबूत असू शकते."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "पासवर्डमध्ये नावाचा वापर करणे टाळा."
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "पासवर्डमध्ये समाविष्टीत काही शब्दांचा वापर टाळा."
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "काही वारंवार शब्दांचा वापर टाळा."
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "अस्तित्वातील शब्दांचे पुन्ह क्रमवारि टाळण्याचा प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "एकापेक्षा जास्त क्रमांकांच्या वापरकरिता प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "एकापेक्षा जास्त अप्परकेस अक्षरांच्या वापरकरिता प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "एकापेक्षा जास्त लोवरकेस अक्षरांच्या वापरकरिता प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "विशेष अक्षरे, जसे कि उच्चारण यांच्या वापरकरिता प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "अक्षरे, संख्या आणि उच्चारण उच्चारण यांच्या वापरकरिता प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "समान अक्षरांचा पुन्हा वापर टाळण्याचा प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"समान प्रकारचे अक्षर वारंवार टाळण्याचा प्रयत्न करा: तुम्हाला अक्षरे, क्रमांक "
-"आणि उच्चारण यांचा एकत्रीतपणे वापर करायची आवश्यकता आहे."
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 किंवा abcd सारखे क्रम टाळा."
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "जास्त अक्षरे, क्रमांक आणि चिन्ह समाविष्ट करण्याचा प्रयत्न करा."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr "अप्पर व लोअर केसचे मिश्रण करा आणि एक किंवा दोन संख्या वापरून पहा."
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-"चांगला पासवर्ड! जास्त अक्षरे, क्रमांक आणि उच्चारण समाविष्ट करून जास्त मजबूत "
-"करेल."
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "मजबूती: कमजोर"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "मजबूती: कमी"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "मजबूती: मध्यम"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "मजबूती: चांगली"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "मजबूती: जास्त"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "ओळख पटवणे अपयशी"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "नविन पासवर्ड खूप छोटे आहे"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "नविन पासवर्ड खूप सोपे आहे"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "जुणे व नविन पासवर्डस् एक समान आहे"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "नविन पासवर्ड आधिपासून नुकतेच वापरले आहे."
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "नविन पासवर्डमध्ये संख्यीक किंवा विशेष अक्षरे पाहिजेत"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "जुणे आणि नविन पासवर्ड समान आहेत"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "सुरवातीला ओळखपटल्यामुळे पासवर्ड बदलले आहे!"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "नविन पासवर्डमध्ये एकापेक्षा जास्त अक्षरे समाविष्टीत नाही"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "अपरिचीत त्रुटी"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "खाते पुरवठाकर्ताच्या वेब पत्त्याशी जुळायला पाहिजे."
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "खाते समाविष्ट करण्यास अपयशी"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-msgid "Passwords do not match."
-msgstr "पासवर्ड जुळत नाही."
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr "खातेची नोंदणी करण्यास अपयशी"
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr "ह्या डोमैनसह ओळख पटवण्यासाठी समर्थीत मार्ग नाही"
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr "डोमैनशी जोडणी करण्यास अपयशी"
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"प्रवेश नाव अकार्यक्षम.\n"
-"कृपया पुनः प्रयत्न करा"
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"प्रवेश पासवर्ड अकार्यक्षम.\n"
-"कृपया पुनः प्रयत्न करा"
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr "डोमैनमध्ये प्रवेश करण्यास अपयशी"
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "डोमेन शोधणे अशक्य. कदाचीत शुद्धलेखन चुकिचे असेल?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:138
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"तुम्हाला साधन करीता प्रवेश नाही. तुमच्या प्रणाली प्रशासकाशी संपर्क करा."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:140
-msgid "The device is already in use."
-msgstr "साधन आधिपासूनच अस्तित्वात आहे."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid "An internal error occurred."
-msgstr "आंतरिक त्रुटी आढळली."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Enabled"
-msgstr "सुरू केले"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr "पंजीकृत फिंगरप्रिन्ट नष्ट करा?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
-msgstr "फिंगरप्रिन्ट नष्ट करा (_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"तुम्हाला पंजीकृत फिंगरप्रिन्ट नष्ट करायचे, तसे केल्यास फिंगरप्रिन्ट प्रवेश "
-"अकार्यान्वीत होईल?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:444
-msgid "Done!"
-msgstr "पूर्ण झाले!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:505
-#: ../panels/user-accounts/um-fingerprint-dialog.c:547
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' साधन करीता प्रवेश प्राप्त करणे अशक्य"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:588
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "'%s' साधन वर बोट द्वारे संकेत प्राप्य सुरू करणे अशक्य"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:638
-msgid "Could not access any fingerprint readers"
-msgstr "कुठलेही फिंगरप्रिन्ट रिडर करीता प्रवेश प्राप्त करण्यास अशक्य"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:639
-msgid "Please contact your system administrator for help."
-msgstr "कृपया मदत करीता तुमच्या प्रणली प्रशासकाशी संपर्क करा."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:721
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"फिंगरप्रिन्ट प्रवेश कार्यान्वीत करण्याकरीता, तुम्हाला '%s' साधनचा वापर करून "
-"एक "
-"फिंगरप्रिन्ट साठवावे लागेल."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:728
-msgid "Selecting finger"
-msgstr "बोट निवडले"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:729
-msgid "Enrolling fingerprints"
-msgstr "फिंगरप्रिंटस् एंरोल करत आहे"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "आजचा सपताह"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "मागील सपताह"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:631
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:635
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "सत्र समाप्त झाले"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "सत्र सुरू केले"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "कृपया इतर पासवर्ड निवडा."
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "कृपया सध्याचे पासवर्ड पुनः टाइप करा."
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "पासवर्ड बदलणे अशक्य"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-msgid "The passwords do not match."
-msgstr "पासवर्ड्ज जुळत नाही."
-
-#: ../panels/user-accounts/um-photo-dialog.c:219
-msgid "Browse for more pictures"
-msgstr "आणखी चित्रांकरीता तपासणी करा"
-
-#: ../panels/user-accounts/um-photo-dialog.c:453
-msgid "Disable image"
-msgstr "प्रतिमा बंद करा"
-
-#: ../panels/user-accounts/um-photo-dialog.c:471
-msgid "Take a photo…"
-msgstr "छायाचित्र घ्या..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:489
-msgid "Browse for more pictures…"
-msgstr "अधिक प्रतिमांकरिता संचारन करा..."
-
-#: ../panels/user-accounts/um-photo-dialog.c:713
-#, c-format
-msgid "Used by %s"
-msgstr "%s तर्फे वापरले"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "या प्रकारच्या डोमेनशी स्व जुळणी अशक्य"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "या प्रकारचे डोमैन किंवा रिअल्म आढळले नाही"
-
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%2$s डोमैनकरीता %1$s प्रमाणे प्रवेश करणे अशक्य"
-
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
-msgstr "अवैध पासवर्ड, कृपया पुनः प्रयत्न करा"
-
-#: ../panels/user-accounts/um-realm-manager.c:832
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "%s डोमैन: %s सह जोडणी अशक्य"
-
-#: ../panels/user-accounts/um-user-panel.c:198
-msgid "Other Accounts"
-msgstr "इतर खाते"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "Failed to delete user"
-msgstr "वापरकर्ता नष्ट करण्यास अपयशी"
-
-#: ../panels/user-accounts/um-user-panel.c:482
-msgid "You cannot delete your own account."
-msgstr "स्वतःचे खाते नष्ट करणे शक्य नाही."
-
-#: ../panels/user-accounts/um-user-panel.c:491
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s ने अजूनही प्रवेश केले आहे"
-
-#: ../panels/user-accounts/um-user-panel.c:495
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"प्रवेश केले असताना वापरकर्त्याला नष्ट केल्याने प्रणालीला अस्थीर स्तरात जाऊ "
-"शकते."
-
-#: ../panels/user-accounts/um-user-panel.c:504
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "तुम्हाला %s's च्या फाइल्स् ठेवायचे?"
-
-#: ../panels/user-accounts/um-user-panel.c:508
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"वापरकर्ता खात्याला नष्ट करतेवेळी होम डिरेक्ट्री, मेल स्पूल व तात्पुर्ते "
-"फाइल्स् जपून ठेवणे शक्य "
-"आहे."
-
-#: ../panels/user-accounts/um-user-panel.c:511
-msgid "_Delete Files"
-msgstr "फाइल्स् नष्ट करा (_D)"
-
-#: ../panels/user-accounts/um-user-panel.c:512
-msgid "_Keep Files"
-msgstr "फाइल्स् जपवून ठेवा (_K)"
-
-#: ../panels/user-accounts/um-user-panel.c:564
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "खाते बंद केले"
-
-#: ../panels/user-accounts/um-user-panel.c:572
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "पुढच्या प्रवेशवेळी सेट करा"
-
-#: ../panels/user-accounts/um-user-panel.c:575
-msgctxt "Password mode"
-msgid "None"
-msgstr "काहिच नाही"
-
-#: ../panels/user-accounts/um-user-panel.c:624
-msgid "Logged in"
-msgstr "प्रवेश केले"
-
-#: ../panels/user-accounts/um-user-panel.c:1071
-msgid "Failed to contact the accounts service"
-msgstr "खाते सर्व्हिससह संपर्क करणे अपयशी"
-
-#: ../panels/user-accounts/um-user-panel.c:1073
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "कृपया AccountService प्रतिष्ठापीत नाही व सुरू नाही याची खात्री करा."
-
-#: ../panels/user-accounts/um-user-panel.c:1114
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"बदल करण्यासाठी,\n"
-"पहिले * चिन्ह क्लिक करा"
-
-#: ../panels/user-accounts/um-user-panel.c:1152
-msgid "Create a user account"
-msgstr "वापरकर्ता खाते निर्माण करा"
-
-#: ../panels/user-accounts/um-user-panel.c:1163
-#: ../panels/user-accounts/um-user-panel.c:1475
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"वापरकर्ता खाते निर्माण करण्यासाठी,\n"
-"पहिले * क्लिक करा"
-
-#: ../panels/user-accounts/um-user-panel.c:1173
-msgid "Delete the selected user account"
-msgstr "निवडलेल्या वापरकर्त्याचे खाते नष्ट करा"
-
-#: ../panels/user-accounts/um-user-panel.c:1185
-#: ../panels/user-accounts/um-user-panel.c:1480
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"निवडलेले वापरकर्ता खाते नष्ट करण्यासाठी,\n"
-"पहिले * चिन्हावर क्लिक करा"
-
-#: ../panels/user-accounts/um-user-panel.c:1389
-msgid "My Account"
-msgstr "माझे खाते"
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-msgid "A user with the username '%s' already exists."
-msgstr "वापरकर्तानाव '%s' असलेले वापरकर्ता आधीपासूनच अस्तित्वात आहे."
-
-#: ../panels/user-accounts/um-utils.c:571
-#, c-format
-msgid "The username is too long."
-msgstr "वापरकर्तानाव खूप मोठे आहे."
-
-#: ../panels/user-accounts/um-utils.c:574
-msgid "The username cannot start with a '-'."
-msgstr "वापरकर्तानाव '-' सह सुरू होत नाही."
-
-#: ../panels/user-accounts/um-utils.c:577
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"वापरकर्तानावमध्ये फक्त खालील लोवर आणि अप्परकेस अक्षरे a-z, अकं आणि '.', '-' व "
-"'_' पैकी "
-"कुठलेही अक्षरे समाविष्टीत असू शकतात."
-
-#: ../panels/user-accounts/um-utils.c:581
-msgid "This will be used to name your home folder and can't be changed."
-msgstr "याचा वापर होम फोल्डरला नाव देण्याकरिता केले जाईल आणि बदलणे शक्य नाही."
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:831
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "मॅप बटने"
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "बटन्सला फंक्शन्स् करीता मॅप करा"
 
-#: ../panels/wacom/button-mapping.ui.h:4
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"शार्टकट संपादित करण्यासाठी, \"किस्ट्रोक पाठवा\" कृती पसंत करा, कळफल शार्टकट "
-"बटन दाबा "
+"शार्टकट संपादित करण्यासाठी, \"किस्ट्रोक पाठवा\" कृती पसंत करा, कळफल शार्टकट बटन दाबा "
 "आणि नवीन किज दाबून ठेवा किंवा नष्ट करण्यासाठी बॅकस्पेस दाबा."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "बंद करा (_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr "टॅबलेट कॅलिब्रेट करण्यासाठी कृपया लक्ष्य मार्कर्स् टॅप करा."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "अयोग्यक्लिक आढळले, पुनः सुरू करत आहे..."
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "वर"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "वर्च्युअल साधन निर्माण करा"
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "खाली"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "टॅबलेट"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "काहिच नाही"
-
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "सेंड किस्ट्रोक्"
-
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "मॉनिटर बदला"
-
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "ऑन-स्क्रीन मदत दाखवा"
-
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "आऊटपुट:"
-
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "ॲस्पेक्ट प्रमाण जपवा (लेटरबॉक्स्):"
-
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "एकमेव मॉनिटरकरीता मॅप करा"
-
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d, %d पैकी"
-
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "मॅपिंग दाखवा"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
-msgstr "बटन"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Wacom Tablet"
-msgstr "वॅकॉम टॅबलेट"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
-"ग्राफिक्स टॅबलेट्सकरिता बटन मॅपिंग्ज ठरवा आणि स्टाइलस संवेदनशीलता आयोजीत करा"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "टॅबलेट;वॅकॉम;स्टायलस;इरेजर;माऊस;"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "डाव्या-हाताचे निर्देशन"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "टॅबलेट (ॲबसोल्युट)"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "टचपॅड (रिलेटिव्ह)"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "मॉनिटरकरिता मॅप करा..."
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "टॅबलेट पसंती"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "ॲस्पेक्ट रेशो"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "कॅलिब्रेट…"
+
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "टॅबलेट आढळले नाही"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "कृपया वॅकॉम टॅबलेट प्लग इन करा किंवा सुरू करा"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Bluetooth Settings"
-msgstr "ब्ल्युटूथ सेटिंग्स्"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map to Monitor…"
-msgstr "मॉनिटरकरिता मॅप करा..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map Buttons…"
-msgstr "मॅप बटन्स…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust display resolution"
-msgstr "डिस्पले रेजॉल्युशन सुस्थित करा"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust mouse settings"
-msgstr "माऊस सेटिंग्ज समायोजित करा"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Tracking Mode"
-msgstr "ट्रॅकिंग मोड"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Left-Handed Orientation"
-msgstr "डाव्या-हाताचे निर्देशन"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-msgid "Left Ring"
-msgstr "डावे रिंग"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "डावे रिंग मोड #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-msgid "Right Ring"
-msgstr "उजवे रिंग"
-
-#: ../panels/wacom/gsd-wacom-device.c:1104
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "उजवे रिंग मोड #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-msgid "Left Touchstrip"
-msgstr "डावे टचस्ट्रिप"
-
-#: ../panels/wacom/gsd-wacom-device.c:1157
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "डावे टचस्ट्रिप मोड #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-msgid "Right Touchstrip"
-msgstr "ऊजवे टचस्ट्रिप"
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "ऊजवे टचस्ट्रिप मोड #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1214
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "डावे टचरिंग मोड स्विच्"
-
-#: ../panels/wacom/gsd-wacom-device.c:1216
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "ऊजवे टचरिंग मोड स्विच्"
-
-#: ../panels/wacom/gsd-wacom-device.c:1219
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "डावे टचस्ट्रिप मोड स्विच्"
-
-#: ../panels/wacom/gsd-wacom-device.c:1221
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "ऊजवे टचस्ट्रिप मोड स्विच्"
-
-#: ../panels/wacom/gsd-wacom-device.c:1226
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "मोड स्विच् #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1334
-#, c-format
-msgid "Left Button #%d"
-msgstr "डावे बटन #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1337
-#, c-format
-msgid "Right Button #%d"
-msgstr "ऊजवे बटन #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1340
-#, c-format
-msgid "Top Button #%d"
-msgstr "शीर्ष बटन #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1343
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "तळ बटन #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "नवीन शार्टकट…"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "कृती नाही"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "डावे माऊस बटन क्लिक"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "मध्यम माउस बटन क्लिक"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "उजवे माऊस बटन क्लिक"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "वर सरकवा"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "खाली सरकवा"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "डावीकडे सरकवा"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "उजवीकडे सरकवा"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "मागे"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "पुढे"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "स्टायलस्"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "इरेजर प्रेशर फिल"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "मऊ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "घट्ट"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "शीर्ष बटन"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "खालचे बटन"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "टिप प्रेशर फिल"
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "बर्बोस् मोड सुरू करा"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "मऊ"
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "पूर्वावलोकन दाखवा"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "स्ट्रिंगकरिता शोधा"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "संभाव्य पटलांचे नावे दाखवा आणि बाहेर पडा"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "मदत पर्याय दार्शवा"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "दाखवण्याजोगी पटल"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[पटल] [बाब…]"
-
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- सेटिंग्ज"
-
-#: ../shell/cc-application.c:163
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-"%s\n"
-"उपलब्ध आदेश ओळ पर्यायांची संपूर्ण सूची पहाण्यासाठी '%s --help' चालवा.\n"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "उपलब्ध पटल:"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "घट्ट"
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "मदत"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "बटन"
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "बाहेर पडा"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "बटन"
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "बटन"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "इरेजर प्रेशर फिल"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "इरेजर प्रेशर फिल"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "मध्यम माउस बटन क्लिक"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "उजवे माऊस बटन क्लिक"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "पुढे"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "वॅकॉम टॅबलेट"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "ग्राफिक्स टॅबलेट्सकरिता बटन मॅपिंग्ज ठरवा आणि स्टाइलस संवेदनशीलता आयोजीत करा"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "टॅबलेट;वॅकॉम;स्टायलस;इरेजर;माऊस;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "मांडणी"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "मुख्य पटल"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "दुसरी क्लिक सिम्युलेट केली (_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "विंडोज"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "टोनर निग्न आहे"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "दुय्यम"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "विंडोज"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "प्रवेश पर्याय"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "समाविष्ट करा"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "साठवा (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "तपशील"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "नेटवर्क वेळ (_N)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "नेटवर्क सेटिंग्स्"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "अंक"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "डिव्हाइस प्रकार"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "उत्पादक"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "फर्मवेअर आढळले नाही"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "मोबाइल ब्रॉडबँड (_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "नेटवर्क वेळ (_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "नेटवर्क"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "प्रगत"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "प्रवेश पर्याय"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "कुलूपबंद"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "तपशील"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "नेटवर्क नाव"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "स्व"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "माझे होम नेटवर्क"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "माझे होम नेटवर्क"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "ब्ल्युटूथ अडॅप्टर्स् आढळले नाही"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "अयरप्लैन मोड (_p)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "जोडणी"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM कार्ड अंतर्भुत केले नाही"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "कुलूपबंद"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "बदल करा (_a)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "माझे होम नेटवर्क"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "नवीन ड्राइव्हर ठरवत आहे..."
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "गोपणीयता"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "सर्व सेटिंग्स्"
 
-#. Add categories
-#: ../shell/cc-window.c:876
-msgctxt "category"
-msgid "Personal"
-msgstr "वैयक्तिक"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "प्राथमिक"
 
-#: ../shell/cc-window.c:877
-msgctxt "category"
-msgid "Hardware"
-msgstr "हार्डवेअर"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:878
-msgctxt "category"
-msgid "System"
-msgstr "प्रणाली"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "मदत"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "सर्वसाधारण"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "बाहेर पडा"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "शोधा"
+
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "पटल चिन्ह"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "मागील स्रोतचा वापर करा"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "रद्द केले"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "पसंती;सेटिंग्स्;"
 
-#~ msgid "Flickr"
-#~ msgstr "फ्लिकर"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u आउटपुट"
+msgstr[1] "%u आउटपुट"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u इंपुट"
+msgstr[1] "%u इंपुट"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "दिवसभरातील बदल"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "टाइल"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "मोठे करा"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "सेंटर"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "भरा"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "स्पॅन"
+
+#~ msgid "Colors"
+#~ msgstr "रंग"
+
+#~ msgid "Select Background"
+#~ msgstr "पार्श्वभूमी नीवडा"
+
+#~ msgid "Pictures"
+#~ msgstr "चित्र"
+
+#~ msgid "Home"
+#~ msgstr "गृह"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "प्रतिमांना %s फोल्डरमध्ये समाविष्ट करणे शक्य आहे आणि ते येथे आढळतील"
+
+#~ msgid "multiple sizes"
+#~ msgstr "अनेक आकार"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "डेस्कटॉप पार्श्वभूमी नाही"
+
+#~ msgid "Current background"
+#~ msgstr "सध्याची पार्श्वभूमी"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "वॉलपेपर;स्क्रीन;डेस्कटॉप;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "चौकोनावर कॅलिब्रेशन साधन स्थित करा आणि 'सुरू करा' दाबा"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "कॅलिब्रेट ठिकाणावर कॅलिब्रेशन साधन स्थानांतरित करा आणि 'सुरू ठेवा' दाबा"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "सर्फेस ठिकाणावर कॅलिब्रेशन साधन स्थानांतरित करा आणि 'सुरू ठेवा' दाबा"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "लॅपटॉप लिड बंद करा"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "निवारण अशक्य आंतरिक त्रुटी आढळली."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "कॅलिब्रेशनकरिता आवश्यक साधने इंस्टॉल केले नाही."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "प्रोफाइल निर्माण अशक्य."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "लक्ष्य वाइटपॉइंट प्राप्यजोगी नाही."
+
+#~ msgid "Complete!"
+#~ msgstr "पूर्ण झाले!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "कॅलिब्रेशन अपयशी!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "कॅलिब्रेशन साधन काढून टाकणे शक्य आहे."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "प्रगतिमध्ये असतेवेळी कॅलिब्रेशन साधनात व्यत्यय आणू नका"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "लॅपटॉप पडदा"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s स्कॅनर"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s छपाईयंत्र"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s वेबकॅम"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s करिता रंग व्यवस्थापन सुरू करा"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s करिता रंग प्रोफाइल्स दाखवा"
+
+#~ msgid "Not calibrated"
+#~ msgstr "कॅलिब्रेट केले नाही"
+
+#~ msgid "Default: "
+#~ msgstr "पूर्वनिर्धारीत:"
+
+#~ msgid "Test profile: "
+#~ msgstr "चाचणी प्रोफाइल: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC प्रोफाइल फाइल निवडा"
+
+#~ msgid "_Import"
+#~ msgstr "आयात करा (_I)"
+
+#~ msgid "All files"
+#~ msgstr "सर्व फाइली"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "फाइल: %s अपलोड करण्यास अपयशी"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "प्रोफाइल याकरिता अपलोड केले:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "हे URL लिहा."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "या संगणकाला पुन्हा सुरू करा आणि सर्वसाधारण कार्य प्रणालीला बूट करा."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "प्रोफाइल डाउनलोड आणि इंस्टॉल करण्यासाठी ब्राउजरमध्ये URL टाइप करा."
+
+#~ msgid "Save Profile"
+#~ msgstr "प्रोफाइल साठवा"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "निवडलेल्या साधनकरीता रंग प्रोफाइल निर्माण करा"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "मोजमाप यंत्र आढळले नाही. ते सुरू आहे व योग्यरित्या जोडले आहे कृपया याची खात्री करा."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "मोजमप यंत्र प्रिंटर प्रोफाइलिंगकरीता समर्थन पुरवत नाही."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "डिव्हास प्रकार सध्या समर्थीत नाही."
+
+#~ msgid "Standard Space"
+#~ msgstr "मानक जागा"
+
+#~ msgid "Test Profile"
+#~ msgstr "चाचणी प्रोफाइल"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "स्व"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "कमी दर्जा"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "मध्यम दर्जा"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "उच्च दर्जा"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "पूर्वनिर्धारीत RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "पूर्वनिर्धारीत CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "पूर्वनिर्धारीत भुरे"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "विक्रेतातर्फे पुरवलेले कॅलिब्रेशन डाटा"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "पडदाभर डिस्पले सुधार या प्रोफाइलसह शक्य नाही"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "हे प्रोफाइल यापुढे अचूक नसेल"
+
+#~ msgid "Done"
+#~ msgstr "पूर्ण झाले"
+
+#~ msgid "Upload profile"
+#~ msgstr "प्रोफाइल अपलोड करा"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "इंटरनेट जोडणी आवश्यक आहे"
+
+#~ msgid "United States"
+#~ msgstr "युनाइटेड स्टेट्स्"
+
+#~ msgid "Germany"
+#~ msgstr "जर्मनी"
+
+#~ msgid "Spain"
+#~ msgstr "स्पेन"
+
+#~ msgid "China"
+#~ msgstr "चायना"
+
+#~ msgid "Other…"
+#~ msgstr "इतर प्रोफाइल..."
+
+#~ msgid "Language"
+#~ msgstr "भाषा"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "वेळ क्षेत्र (_Z)"
+
+#~ msgid "24-hour"
+#~ msgstr "24 तास"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "Lid Closed"
+#~ msgstr "झाकन बंद केले"
+
+#~ msgid "Mirrored"
+#~ msgstr "मिरर्ड"
+
+#~ msgid "Off"
+#~ msgstr "बंद करा"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "एकत्रीत डिस्पलेज आयोजीत करा"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "डिस्पेजना ओढा आणि पुन्हा आयोजीत करा"
+
+#~ msgid "Size"
+#~ msgstr "आकार"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "या डिस्पलेवर शीर्ष पट्टी आणि क्रिया पूर्वावलोकन दाखवा"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "अगाऊ कार्यक्षेत्र निर्माणकरिता या डिस्पलेला दुसऱ्याशी जुळवा"
+
+#~ msgid "Presentation"
+#~ msgstr "प्रस्तुतीकरण"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "स्लाइजशोज आणि फक्त मिडीया दाखवा"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "दोन्ही डिस्पलेजवरील अस्तित्वातील अवलोकन दाखवा"
+
+#~ msgid "Turn Off"
+#~ msgstr "बंद करा"
+
+#~ msgid "Don't use this display"
+#~ msgstr "हे डिस्पले दाखवू नका"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "पडदा विषयी माहिती प्राप्त करणे शक्य नाही"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "एकत्रीत डिस्पलेज आयोजीत करा (_A)"
+
+#~ msgid "Wayland"
+#~ msgstr "वेलँड"
+
+#~ msgid "Unknown"
+#~ msgstr "अपरिचित"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-बिट"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-बिट"
+
+#~ msgid "Ask what to do"
+#~ msgstr "काय करायचे ते विचारा"
+
+#~ msgid "Do nothing"
+#~ msgstr "काहिच करू नका"
+
+#~ msgid "Open folder"
+#~ msgstr "फोल्डर उघडा"
+
+#~ msgid "Other Media"
+#~ msgstr "इतर मिडीया"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ऑडिओ CDs करीता ॲप्लिकेशन निवडा"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "ऑडिओ CDs करीता ॲप्लिकेशन निवडा"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "संगीत वादक जोडल्यावर चालवण्याजोगी ॲप्लिकेशन निवडा"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "कॅमेरा जोडल्यावर चालवण्याजोगी ॲप्लिकेशन निवडा"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "सॉफ्टवेअर CDs करीता ॲप्लिकेशन निवडा"
+
+#~ msgid "audio DVD"
+#~ msgstr "ऑडिओ DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "रिकामी ब्लुयरे डिस्क"
+
+#~ msgid "blank CD disc"
+#~ msgstr "रिकामी CD डिस्क"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "रिकामी DVD डिस्क"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "रिकामी HD DVD डिस्क"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "ब्ल्यु-रे व्हिडीओ डिस्क"
+
+#~ msgid "e-book reader"
+#~ msgstr "इ-बूक रिडर"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD व्हिडीओ डिस्क"
+
+#~ msgid "Picture CD"
+#~ msgstr "चित्र CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "सुपर व्हिडीओ CD"
+
+#~ msgid "Video CD"
+#~ msgstr "व्हिडिओ CD"
+
+#~ msgid "Overview"
+#~ msgstr "पूर्वावलोकन"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "आवृत्ती %s"
+
+#~ msgid "Base system"
+#~ msgstr "बेस प्रणाली"
+
+#~ msgid "Disk"
+#~ msgstr "डिस्क"
+
+#~ msgid "Check for updates"
+#~ msgstr "सुधारणांकरिता तपासणी करा"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "स्क्रीनशॉटला $PICTURES मध्ये साठवा"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "पटलाच्या स्क्रीनशॉटला $PICTURES मध्ये साठवा"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "क्षेत्राचे स्क्रीनशॉट $PICTURES मध्ये साठवा"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "स्क्रीनशॉटचे क्लिपबोर्डवर प्रत बनवा"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "पटलाचे स्क्रीनशॉट क्लिपबोर्डवर प्रत बनवा"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "क्षेत्राचे स्क्रीनशॉट क्लिपबोर्डवर प्रत बनवा"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "छोटे स्क्रीनकास्ट रेकॉर्ड करा"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "पुढील स्रोतकरिता मॉडिफार्यस-ओन्लि स्विच"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "शार्टकट;रिपिट;ब्लिंक;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "स्वपसंत शॉर्टकट"
+
+#~ msgid "_Delay:"
+#~ msgstr "विलंब (_D):"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "छोटे"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "हळू"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "लांब"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "वेग"
+
+#~ msgid "S_peed:"
+#~ msgstr "वेग (_p):"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "शॉर्टकट काढून टाका"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "शार्टकट संपादित करण्याकरीता, परस्पर ओळवर क्लिक करा व नविन किज् दाबून ठेवा किंवा "
+#~ "नष्ट करण्यासाठी बॅकस्पेस् दाबा."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<अज्ञात क्रिया>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "शार्टकट \"%s\" वापरले जाऊ शकत नाही कारण ही कळ वापरल्यास टाईप करणे शक्य राहणार "
+#~ "नाही.\n"
+#~ "कृपया Control, Alt किंवा Shift कि परस्परित्या वापरुन पहा."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "शॉर्टकट \"%s\" आधीपासूनच\n"
+#~ "\"%s\" करीता वापरले जाते"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "शार्टकटला \"%s\" पुन्ह निश्चित केल्यास, \"%s\" शार्टकट अकार्यान्वीत केले जाईल."
+
+#~ msgid "_Reassign"
+#~ msgstr "पुन्ह निश्चित करा (_R)"
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" शॉर्टकटला \"%s\" शॉर्टकटसह संलग्न केले आहे. तुम्हाला ते स्व \"%s\" करिता सेट "
+#~ "करायचे?"
+
+#, c-format
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr "\"%s\" आत्ता \"%s\" सह संबंधीत आहे, पुढे जात असल्यास हे शार्टकट बंद केले जाईल."
+
+#~ msgid "_Assign"
+#~ msgstr "लागू करा (_A)"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "सेटिंग्जची चाचणी करा"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "हळू"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "वेळ समाप्तीवर दोनवेळा क्लिक करा"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "वेग"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "डावे (_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "उजवे (_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "पॉइंटर वेग (_P)"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "हळू"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "वेग"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "हळू"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "वेग"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "दोन बोटांचे सक्रोल (_f)"
+
+#~ msgid "_Natural scrolling"
+#~ msgstr "स्वाभाविक स्क्रोलिंग (_N)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "पाच क्लिक्स्, GEGL वेळ!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "दोनवेळा क्लिक करा, प्राथमिक बटन"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "एकदाच क्लिक क्लिक, पहिली बटन"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "दोनवेळा क्लिक करा, मधली बटन"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "एकवेळा क्लिक करा, मधली बटन"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "दोनवेळा क्लिक करा, दुसरी बटन"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "एकदाच क्लिक करा, दुसरी बटन"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "सिस्टम नेटवर्क सर्व्हिसेस् या आवृत्तीसह सहत्व नाही."
+
+#~ msgid "page 1"
+#~ msgstr "पृष्ठ 1"
+
+#~ msgid "page 2"
+#~ msgstr "पृष्ठ 2"
+
+#~ msgid "automatic"
+#~ msgstr "स्व"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "एंटरप्राइज"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "काहिच नाही"
+
+#~ msgid "Never"
+#~ msgstr "कधिही नाही"
+
+#~ msgid "Today"
+#~ msgstr "आज"
+
+#~ msgid "Yesterday"
+#~ msgstr "काल"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "काहिच नाही"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "कमजोर"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ठिक आहे"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "चांगले"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "उत्कृष्ट"
+
+#~ msgid "Identity"
+#~ msgstr "ओळख"
+
+#~ msgid "Server"
+#~ msgstr "सर्व्हर"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS सर्व्हर नष्ट करा"
+
+#~ msgid "Delete Route"
+#~ msgstr "राउट नष्ट करा"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "काहिही नाही"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-बिट कि (Hex किंवा ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-बिट पासफ्रेज"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "डायनॅमिक WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA आणि WPA2 पर्सनल"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA आणि WPA2 एंटरप्राइज"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "ट्विस्टेड पैर (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "अटॅचमेंट युनिट इंटरफेस (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "मिडीया इंडिपेंडंट इंटरफेस (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "इतर वापरकर्त्यांना उपलब्ध करा (_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "फायरवॉल क्षेत्र (_Z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "पूर्वनिर्धारित"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "झोन जोडणीचे विश्वासर्हता स्तर ठरवते"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv4 (_4)"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv6 (_6)"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "जोडणी संपादक उघडण्यास अशक्य"
+
+#~ msgid "New Profile"
+#~ msgstr "नवीन प्रोफाइल"
+
+#~ msgid "Bond"
+#~ msgstr "बाँड"
+
+#~ msgid "Team"
+#~ msgstr "टिम"
+
+#~ msgid "Bridge"
+#~ msgstr "ब्रिज"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN प्लगइन्स लोड करणे अशक्य"
+
+#~ msgid "Import from file…"
+#~ msgstr "फाइलपासून आयात करा…"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "नेटवर्क जोडणी समाविष्ट करा"
+
+#~ msgid "_Reset"
+#~ msgstr "मूळस्थितीत आणा (_R)"
+
+#~ msgid "_Forget"
+#~ msgstr "विसरून जा (_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "या नेटवर्ककरिता सेटिंग्ज मूळस्थित आणा, पासवर्ड्ज समाविष्टीत, परंतु त्यास पसंतीचे नेटवर्क "
+#~ "म्हणून लक्षात ठेवा "
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "या नेटवर्कशी संबंधीत सर्व तपशीलवार काढून टाका आणि स्व जोडणी करायचा प्रयत्न करू नका"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN जोडणी आयात करणे अशक्य"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "फाइल '%s' ला वाचणे अशक्य किंवा परिचीत VPN जोडणी माहिती समाविष्टीत नाही\n"
+#~ "\n"
+#~ "त्रुटी: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "आयातकरिता फाइल पसंत करा"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "\"%s\" नावाची फाइल आधिपासूनच अस्तित्वात आहे."
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "तुम्हाला %s ला साठवण्याजोगी VPN जोडणीसह करायचे?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN जोडणी एक्सपोर्ट करणे अशक्य"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN जोडणी '%s' यास %s करिता एक्सपोर्ट करणे अशक्य.\n"
+#~ "\n"
+#~ "त्रुटी: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN जोडणी एक्सपोर्ट करा"
+
+#~ msgid "Bond slaves"
+#~ msgstr "बाँड स्लेव्ज"
+
+#~ msgid "(none)"
+#~ msgstr "(काहिही नाही)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "स्लेव्ज ब्रिज करा"
+
+#~ msgid "never"
+#~ msgstr "कधिच नाही"
+
+#~ msgid "today"
+#~ msgstr "आज"
+
+#~ msgid "yesterday"
+#~ msgstr "काल"
+
+#~ msgid "Last used"
+#~ msgstr "शेवटच्यावेळी वापरले"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "प्रोफाइल %d"
+
+#~ msgid "Team slaves"
+#~ msgstr "टिम स्लेव्हज"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "वायरलेस व्यतिरिक्त इंटरनेटसह जोडणी असल्यास, इतरांशी इंटरनेट जोडणीचा एकत्रीतपणे "
+#~ "वापरकरिता वायरलेस हॉटस्पॉट सेट करणे शक्य आहे."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "वायरलेस हॉटस्पॉटचा वापर केल्यास <b>%s</b> पासून जोडणी खंडीत होईल."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "हॉटस्पॉट सुरू असल्यास वायरलेसच्या मदतीने इंटरनेटकरिता प्रवेश शक्य नाही."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "हॉटस्पॉट थांबवा व कोणत्याहि वापरकर्त्यांना खंडीत करायचे?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "हॉटस्पॉट थांबवा (_S)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "प्रणाली करार हॉटस्पॉटचा वापर प्रतिबंधीत करते"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "वायरलेस साधन हॉटस्पॉट मोडकरिता समर्थन पुरवत नाही"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "नीवडलेल्या नेटवर्क्सकरिता नेटवर्क तपशील, पासवर्ड व इतर कोणतिही पसंतीची संरचना गमवाल."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "विसरून जा (_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "वेब प्रॉक्सी ऑटोडिस्कवरिचा वापर जेव्हा संरचना URL पुरवले जात नाही तेव्हा होतो."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "अविश्वासर्ह पब्लिक नेटवर्कस् करिता शिफारसीय नाही."
+
+#~ msgid "Proxy"
+#~ msgstr "प्रॉक्सी"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "काहिच नाही"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "मॅन्युअल"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "स्वयं"
+
+#~ msgid "Add Device"
+#~ msgstr "साधन समाविष्ट करा"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN प्रकार"
+
+#~ msgid "Group Name"
+#~ msgstr "गट नाव"
+
+#~ msgid "details"
+#~ msgstr "तपशील"
+
+#~ msgid "Show P_assword"
+#~ msgstr "पासवर्ड दाखवा (_a)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "इतर वापरकर्त्यांकरिता उपलब्ध करा"
+
+#~ msgid "identity"
+#~ msgstr "ओळख"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "फक्त स्व (DHCP) पत्ते"
+
+#~ msgid "Link-local only"
+#~ msgstr "फक्त स्थानीय जुळवा"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "स्व प्राप्य राउट्सकडे दुर्लक्ष करा (_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "क्लोन केलेले MAC पत्ता (_C)"
+
+#~ msgid "hardware"
+#~ msgstr "हार्डवेअर"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "या जोडणीकरिता सेटिंग्जना त्यांच्या पूर्वनिर्धारितकरिता मूळस्थितीत आणा, परंतु त्यास "
+#~ "पसंतीची जोडणी म्हणून लक्षात ठेवा."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "या नेटवर्कशी संबंधीत सर्व तपशीलवार काढून टाका आणि स्व जोडणी करायचा प्रयत्न करू नका."
+
+#~ msgid "reset"
+#~ msgstr "मूळस्थिती"
+
+#~ msgid "Hardware"
+#~ msgstr "हार्डवेअर"
+
+#~ msgid "_History"
+#~ msgstr "इतिहास (_H)"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "वाय-फाय नेटवर्कशी जोडणीकरिता बंद करा"
+
+#~ msgid "Connected Devices"
+#~ msgstr "जुळलेले साधन"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "ॲडहॉक"
+
+#~ msgid "Infrastructure"
+#~ msgstr "इंफ्रास्टक्चर"
+
+#~ msgid "Status unknown"
+#~ msgstr "स्थिती अपरिचीत"
+
+#~ msgid "Unmanaged"
+#~ msgstr "अव्यवस्थापीत"
+
+#~ msgid "Unavailable"
+#~ msgstr "अनुपलब्ध"
+
+#~ msgid "Connecting"
+#~ msgstr "जोडत आहे"
+
+#~ msgid "Disconnecting"
+#~ msgstr "खंडीत करत आहे"
+
+#~ msgid "Connection failed"
+#~ msgstr "जोडणी अपयशी"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "स्थिती अपरिचीत (आढळली नाही)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "संरचना अपयशी"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP संरचना अपयशी"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP संरचना वेळसमाप्ति"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "गोपनीयता आवश्यक, परंतु पुरवले नाही"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x सप्पिकंट खंडीत केले"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x सप्लिकंट संरचना अपयशी"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x सप्लिकंट अपयशी"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x सप्लिकंटला ओळख पटवण्याकरीता जास्त वेळ लागला"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP सर्व्हिस सुरू होण्यास अपयशी"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP सर्व्हिस खंडीत"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP अपयशी"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP क्लाएंट सुरू होण्यास अपयशी"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP क्लाएंट त्रुटी"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP क्लाएंट अपयशी"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "शेअर्ड जोडणी सर्व्हिस सुरू होण्यास अपयशी"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "शेअर्ड जोडणी सर्व्हिस अपयशी"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "ऑटोIP सर्व्हिस सुरू होण्यास अपयशी"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "ऑटोIP सर्व्हिस सुरू होण्यास अपयशी"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "ऑटोIP सर्व्हिस अपयशी"
+
+#~ msgid "Line busy"
+#~ msgstr "लाइन व्यस्थ"
+
+#~ msgid "No dial tone"
+#~ msgstr "डायल सूर आढळले नाही"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "कॅरिअर स्थापित करणे अशक्य"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "डायलिंग विनंती वेळसमाप्ति"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "डायलिंग प्रयत्न अपयशी"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "मोडेम प्रारंभिकरण अपयशी"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "निर्देशीत APN नीवडण्यास अपयशी"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "नेटवर्ककरीता शोधणे अशक्य"
+
+#~ msgid "Network registration denied"
+#~ msgstr "नेटवर्क नोंदणी नकारले"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "नेटवर्क नोंदणीची वेळसमाप्ति"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "विनंती केलेल्या नेटवर्कसह नोंदणी अपयशी"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN तपासणी अपयशी"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "साधनकरीता फर्मवेअर कदाचित आढळले नाही"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "जोडणी पूर्णपणे खंडीत"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "अस्तित्वातील जोडणी गृहीत धरले"
+
+#~ msgid "Modem not found"
+#~ msgstr "मोडेम आढळले नाही"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ब्ल्युटूथ जोडणी अपयशी"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM पिन आवश्यक"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM पक आवश्यक"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM चुकिचे"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "इंफिनिबँड साधन जोडणी मोडकरीता समर्थन पुरवत नाही"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "जोडणी अवलंबन अपयशी"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "केबल प्लग अशक्य"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "सर्टिफेकट अथॉरिटि प्रमाणपत्र पसंत केले नाही"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "सर्टिफिकेट अथॉरिटि (CA) प्रमाणपत्रचा वापर न केल्यामुळे जोडणी असुरक्षित, धोकादायक "
+#~ "वाय-फाय नेटवर्क्सकरिता कारणीभूत ठरू शकते.  तुम्हाला सर्टिफिकेट अथॉरिटि प्रमाणपत्र पसंत "
+#~ "करायला आवडेल?"
+
+#~ msgid "Ignore"
+#~ msgstr "दुर्लक्ष करा"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA प्रमाणपत्र पसंत करा"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, किंवा PKCS#12 प्राइव्हेट किज (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER किंवा PEM प्रमाणपत्र (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC फाइल्स (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "या पासवर्डकरिता नेहमी विचारा (_k)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "विना एंक्रिप्ट केलेले प्राइव्हेट किज असुरक्षित आहे"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "नीवडलेले प्राइवेट कि पासवर्डतर्फे सुरक्षित असल्याचे दिसून येत नाही.  यामुळे आपले सुरक्षा "
+#~ "श्रेयशी तजजोड होऊ शकते.  कृपया पासवर्ड-सुरक्षित प्राइवेट किचा वापर करा.\n"
+#~ "\n"
+#~ "(openssl सह प्राइवेट किला पासवर्ड-सुरक्षित करणे शक्य आहे)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "वैयक्तिक प्रमाणपत्र पंसत करा"
+
+#~ msgid "Choose your private key"
+#~ msgstr "प्राइवेट कि पसंत करा"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "मला पुन्हा सावध करू नका (_w)"
+
+#~ msgid "Yes"
+#~ msgstr "होय"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "पॉपअप बॅनर्स दाखवा"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "बॅनर्समध्ये तपशील दाखवा"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "पडदा कुलूपबंदमधील अवलोकन"
+
+#~ msgid "On"
+#~ msgstr "सुरू करा"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "पॉपअप बॅनर्स दाखवा"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "पडदा कुलूपबंदमध्ये दाखवा"
+
+#~ msgid "Add Account"
+#~ msgstr "खाते समाविष्ट करा"
+
+#~ msgid "Mail"
+#~ msgstr "ईमेल"
+
+#~ msgid "Contacts"
+#~ msgstr "संपर्क"
+
+#~ msgid "Chat"
+#~ msgstr "गप्पा"
+
+#~ msgid "Resources"
+#~ msgstr "स्रोत"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "खात्यामध्ये प्रवेश करतेवेळी त्रुटी"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "श्रेयची वेळसमाप्ति आढळली."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "हे खाते सुरू करण्यासाठी प्रवेश करा."
+
+#~ msgid "_Sign In"
+#~ msgstr "प्रवेश करा (_S)"
+
+#~ msgid "Error creating account"
+#~ msgstr "खाते निर्माण करतेवेळी त्रुटी"
+
+#~ msgid "Error removing account"
+#~ msgstr "खते काढून टाकतेवेळी त्रुटी"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "तुम्हला नक्की खाते काढूण टाकायचे?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "यामुळे सर्व्हरवरील खाते काढून टाकले जात नाही."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "ऑनलाइन खाते संरचीत केले नाही"
+
+#~ msgid "Remove Account"
+#~ msgstr "खाते काढून टाका"
+
+#~ msgid "Add an online account"
+#~ msgstr "ऑनलाइन खाते समाविष्ट करा"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "खाते समाविष्ट केल्याने ॲप्लिकेशन्स् दस्तऐवज, मेल, संपर्क, दिनदर्शिका, गप्पा, व आणखी "
+#~ "करीता प्रवेश प्राप्त करू शकतात."
+
+#~ msgid "Unknown time"
+#~ msgstr "अपरिचीत वेळ"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "संपूर्णतया चार्ज होईपर्यंत %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "खबरदारी: %s उर्वरित"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s उर्वरित"
+
+#~ msgid "Fully charged"
+#~ msgstr "संपूर्णतया चार्ज करा"
+
+#~ msgid "Empty"
+#~ msgstr "रिकामे"
+
+#~ msgid "Charging"
+#~ msgstr "चार्ज करत आहे"
+
+#~ msgid "Discharging"
+#~ msgstr "डिसचार्ज करत आहे"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "मुख्य"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "अगाऊ"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "वायरलेस माऊस"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "वायरलेस किबोर्ड"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "अव्यतय पावर पुरवठा"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "वैयक्तिक डिजिटल सहाय्यक"
+
+#~ msgid "Cellphone"
+#~ msgstr "सेलफोन"
+
+#~ msgid "Media player"
+#~ msgstr "मिडीया वादक"
+
+#~ msgid "Computer"
+#~ msgstr "संगणक"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "चार्ज करत आहे"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "सावधानता"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "कमी"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "चांगले"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "संपूर्णतया चार्ज केले"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "रिकामे"
+
+#~ msgid "Batteries"
+#~ msgstr "बॅटरिज"
+
+#~ msgid "When _idle"
+#~ msgstr "निष्क्रिय असतेवेळी (_i)"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "कळफलक उजळपणा (_K)"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "निष्क्रीय असताना पडदा मंद करा (_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "वायफाय (_W)"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "वायरलेश साधनांना बंद करते"
+
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "मोबाइल ब्रॉडबँड (3G, 4G, WiMax, इत्यादि) साधने बंद करते"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "ब्ल्युटूथ (_B)"
+
+#~ msgid "When on battery power"
+#~ msgstr "बॅटरि पावरवर असताना"
+
+#~ msgid "When plugged in"
+#~ msgstr "प्लग केल्यानंतर"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "स्थगित करा आणि बंद करा"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "स्व सस्पेंड (_A)"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "बॅटरि पावर गंभीर असताना (_c)"
+
+#~ msgid "Power Off"
+#~ msgstr "बंद करा"
+
+#~ msgid "Hibernate"
+#~ msgstr "हायबरनेट"
+
+#~ msgid "1 minute"
+#~ msgstr "1 मिनिट"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 मिनिटे"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 मिनिटे"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 मिनिटे"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 मिनिटे"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 मिनिटे"
+
+#~ msgid "Out of toner"
+#~ msgstr "टोनर नाही"
+
+#~ msgid "Low on developer"
+#~ msgstr "डेव्हलपर निग्न आहे"
+
+#~ msgid "Out of developer"
+#~ msgstr "डेव्हलपर नाही"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "मार्कर पुरवठा निग्न आहे"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "मार्कर पुरवठा कमी आहे"
+
+#~ msgid "Open cover"
+#~ msgstr "कवर उघडा"
+
+#~ msgid "Open door"
+#~ msgstr "दार उघडा"
+
+#~ msgid "Low on paper"
+#~ msgstr "पेपर निग्न आहे"
+
+#~ msgid "Out of paper"
+#~ msgstr "पेपर कमी आहे"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "थांबवले"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "वेस्ट बऱ्यापैकी भरले आहे"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "वेस्ट जवळपास भरले आहे"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ऑप्टिकल फोटो कंडक्टरची वेळसमाप्ति आढळली"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ऑप्टिकल फोटो कंडक्टर यापुढे कार्यशील नाही"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "सज्ज"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "जॉब्ज स्वीकरत नाही"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "विश्लेषण करत आहे"
+
+#~ msgid "Toner Level"
+#~ msgstr "टोनरचे स्तर"
+
+#~ msgid "Supply Level"
+#~ msgstr "पुरवठा स्तर"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "प्रतिष्ठापीत करत आहे"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u सक्रिय"
+#~ msgstr[1] "%u सक्रिय"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "नविन छपाईयंत्र समाविष्ट करण्यास अपयशी."
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "पोस्टस्क्रिप्ट प्रिंटर डिस्क्रिप्शन फाइल्स् (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+#~ "GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "योग्य ड्राइव्हर आढळले नाही"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui लोड करणे अशक्य: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "प्रिंटिंग पुनः आरंभ करा"
+
+#~ msgid "Pause Printing"
+#~ msgstr "छपाई थांबवा"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "नविन छपाईयंत्र समाविष्टीत करा"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "परिणा फिल्टर करण्यासाठी छपाईयंत्र किंवा मजकूरचा पत्ता द्या"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect छपाईयंत्र"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD छपाईयंत्र"
+
+#~ msgid "One Sided"
+#~ msgstr "एका बाजूने"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "दोंही बाजूने (मानक)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "दोंही बाजूने (पलटवून)"
+
+#~ msgid "Portrait"
+#~ msgstr "उभे"
+
+#~ msgid "Landscape"
+#~ msgstr "आडवे"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "उलट आडवे"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "उलट उभे"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "उर्वरित आहे"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "रोखून ठेवले"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "विश्लेषण करत आहे"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "थांबवले"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "रद्द केले"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "पूर्ण झाले"
+
+#~ msgid "Job Title"
+#~ msgstr "जॉब शीर्षक"
+
+#~ msgid "Job State"
+#~ msgstr "जॉबचे स्तर"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "सिरिअल पोर्ट"
+
+#~ msgid "Parallel Port"
+#~ msgstr "पॅरलल पोर्ट"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "ठिकाण: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "पत्ता: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "दोंही बाजूने"
+
+#~ msgid "Paper Type"
+#~ msgstr "पेपर प्रकार"
+
+#~ msgid "Paper Source"
+#~ msgstr "पेपर स्रोत"
+
+#~ msgid "Output Tray"
+#~ msgstr "आऊटपुट ट्रे"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "घोस्टस्क्रिप्ट प्रिफिल्टरिंग"
+
+#~ msgid "Pages per side"
+#~ msgstr "प्रत्येक बाजूवरील पृष्ठे"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "सर्वसाधारण"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "पृष्ठ मांडणी"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "प्रतिष्ठापनजोगी पर्याय"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "कार्य"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "प्रतिमा दर्जा"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "रंग"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "पूर्णत्व"
+
+#~ msgid "Auto Select"
+#~ msgstr "स्वयं नीवडा"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "फक्त घोस्टस्क्रिप्ट फाँटस् अंतर्भुत करा"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS स्तर 1 करीता रूपांतरीत करा"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS स्तर 2 करीता रूपांतरीत करा"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "प्रिफिल्टरिंग आढळले नाही"
+
+#~ msgid "Supply"
+#~ msgstr "पुरवठा"
+
+#~ msgid "_Default printer"
+#~ msgstr "पूर्वनिर्धारीत छपाईयंत्र (_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "जॉब्स्"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "जॉब्स दाखवा (_J)"
+
+#~ msgid "label"
+#~ msgstr "लेबल"
+
+#~ msgid "page 3"
+#~ msgstr "पृष्ठ 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "चाचणी पानची छपाई करा (_T)"
+
+#~ msgid "_Options"
+#~ msgstr "पर्याय (_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "नविन छपाईयंत्र समाविष्ट करा"
+
+#~ msgid "Usage & History"
+#~ msgstr "वापर आणि इतिहास"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "कचरापेटीतून सर्व घटकांना रिक्त करायचे?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "कचरापेटीतील सर्व घटकांना नेहमीकरिता नष्ट केले जाईल."
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "सर्व तात्पुते फाइल्स नष्ट करायचे?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "सर्व तात्पुर्त्या फाइल्स नेहमीकरिता नष्ट केले जातील."
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "वैयक्ति माहिती सुरक्षित ठेवा आणि इतरांना ते कसे दृष्यास्पद असे ते नियंत्रीत करा"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "पडदा बंद होते"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 सेकंद"
+
+#~ msgid "1 day"
+#~ msgstr "1 दिवस"
+
+#~ msgid "2 days"
+#~ msgstr "2 दिवस"
+
+#~ msgid "3 days"
+#~ msgstr "3 दिवस"
+
+#~ msgid "4 days"
+#~ msgstr "4 दिवस"
+
+#~ msgid "5 days"
+#~ msgstr "5 दिवस"
+
+#~ msgid "6 days"
+#~ msgstr "6 दिवस"
+
+#~ msgid "7 days"
+#~ msgstr "7 दिवस"
+
+#~ msgid "14 days"
+#~ msgstr "14 दिवस"
+
+#~ msgid "30 days"
+#~ msgstr "30 दिवस"
+
+#~ msgid "Forever"
+#~ msgstr "नेहमीकरिता"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "इतिहास लक्षात ठेवल्याने बाबी ओळखायला सोयीस्कर ठरते. या घटकांना कधिही नेटवर्कवरील "
+#~ "शेअर केले जात नाही."
+
+#~ msgid "_Recently Used"
+#~ msgstr "नुकतेच वापरलेले (_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "इतिहास जपवा (_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "पडदा कुलूपबंद, तुम्ही दूर असताना गोपणीयता सुरक्षित करते."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "रिक्त असल्यास पडदा कुलूपबंद करा (_a)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "कचरापेटी आणि तात्पुर्त्या फाइल्स स्व काढून टाका जेणेकरून संगणक अनावश्यक संवेदनशील "
+#~ "माहितीरहीत राहील."
+
+#~ msgid "Purge _After"
+#~ msgstr "नंतर काढून टाका (_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "वापरण्याजोगी सॉफ्टवेअरविषयी माहिती पाठवल्याने आम्ही तुम्हाला अचूक शिफारस देऊ शकू. "
+#~ "सॉफ्टवेअर सुधारणामध्ये मदत होते.\n"
+#~ "\n"
+#~ "गोळा केलेली सर्व माहिती निनावी राहते, आणि आम्ही तुमचा डाटा तीसऱ्या पक्षांसह कधिही "
+#~ "शेअर करणार नाही."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "सॉफ्टवेअर वापर आकडेवारि पाठवा (_S)"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "गोपणीयता करार"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "जिओग्राफिकल ठिकाण ओळखण्यासाठी वापरले जाते"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "इम्पिरिअल"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "मेट्रिक"
+
+#~ msgid "No input sources found"
+#~ msgstr "इंपुट स्रोत आढळले नाही"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "इतर"
+
+#~ msgid "Sorry"
+#~ msgstr "माफ करा"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "पुढच्या स्रोतचा वापर करा"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "कळफलक सेटिंग्जमध्ये या शॉर्टकट्सना बदलणे शक्य आहे"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "पुढील स्रोतकरिता वैकल्पिक स्वीच"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Left+Right Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "इंग्रजि (युनाइटेड किंगडम)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "युनाइटेड किंगडम"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "प्रणालीमध्ये प्रवेश करताना प्रवेश सेटिंग्ज सर्व वापरकर्त्यांसह वापरले जाते"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "इतर"
+
+#~ msgid "Select Location"
+#~ msgstr "ठिकाण पसंत करा"
+
+#~ msgid "_OK"
+#~ msgstr "ठीक आहे (_O)"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "सुरू करा"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "बंद करा"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "सुरू केले"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "फोल्डर पसंत करा"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "शेअरिंगकरिता नेटवर्क्स पसंत केले नाही"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "ब्ल्युटूथ शेअरिंग तुम्हाला इतर ब्ल्युटूथ समर्थीत साधनांसह फाइल्स शेअर करण्यासाठी परवानगी देते"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "फक्त विश्वासर्ह साधनांपासून प्राप्त करा"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "प्राप्य फाइल्सना डाउनलोड्ज फोल्डरमध्ये साठवा"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "पडदा शेअरिंग"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "नेटवर्क प्रवेश नसल्यामुळे काही सर्व्हिसेस बंद केले जातात."
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "वैयक्तिक फाइल शेअरिंग तुम्हाला पब्लिक फोल्डरला आत्ताच्या नेटवर्कवरील: <a href=\"dav://"
+#~ "%s\">dav://%s</a> याचा वापर करून इतरांशी शेअर करण्यासाठी परवानगी देते"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "सेक्युर शेल आदेश:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a> याचा वापर करून रिमोट वापरकर्त्यांना जोडणीकरिता "
+#~ "परवानगी द्या"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "अवलोकन किंवा पडदा नियंत्रीत करण्यासाठी दूरस्त वापरकर्त्यांना परवानगी द्या: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "Password:"
+#~ msgstr "पासवर्ड:"
+
+#~ msgid "Show Password"
+#~ msgstr "पासवर्ड दाखवा"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "नवीन जोडण्यांनी प्रवेशकरिता विनंती केली पाहिजे"
+
+#~ msgid "Require a password"
+#~ msgstr "पासवर्ड आवश्यक"
+
+#~ msgid "Bark"
+#~ msgstr "बार्क"
+
+#~ msgid "Drip"
+#~ msgstr "ड्रिप"
+
+#~ msgid "Glass"
+#~ msgstr "ग्लास"
+
+#~ msgid "Sonar"
+#~ msgstr "सोनार"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "किमान"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "कमाल"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "सबवूफर (_S):"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "ॲम्प्लिफाय केले"
+
+#~ msgid "_Profile:"
+#~ msgstr "प्रोफाइल (_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "चाचणी स्पिकर्स (_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "पिक ओळखणे"
+
+#~ msgid "Device"
+#~ msgstr "s साधन"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s करीता स्पिकरची ऊंची"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "साऊंड आऊटपुटकरीता साधन निवडा (_h):"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "निवडलेल्या साधनकरीता सेटिंग्स्:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "इंपुट वॉल्यूम (_I):"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "साऊंड इंपुटकरीता साधन पसंत करा (_h):"
+
+#~ msgid "Sound Effects"
+#~ msgstr "साऊंड प्रभाव"
+
+#~ msgid "Built-in"
+#~ msgstr "ब्लिटइन"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "साऊंड पसंती"
+
+#~ msgid "Testing event sound"
+#~ msgstr "इव्हेंट साऊंड चाचणी"
+
+#~ msgid "From theme"
+#~ msgstr "थिम पासून"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "सावधानता आवाज पसंत करा (_h):"
+
+#~ msgid "Stop"
+#~ msgstr "थांबवा"
+
+#~ msgid "Custom"
+#~ msgstr "मनपसंद"
+
+#~ msgid "Screen Reader"
+#~ msgstr "स्क्रीन रिडर"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "स्क्रीन रिडर (_S)"
+
+#~ msgid "Sound Keys"
+#~ msgstr "साउंड किज"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "पटलाचे शीर्षक फ्लॅश करा (_w)"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "छोटे"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ स्क्रीन"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ स्क्रीन"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ स्क्रीन"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "लांब"
+
+#~ msgid "Zoom"
+#~ msgstr "मोठे करा"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "रंग"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "मानक"
+
+#~ msgid "Account _Type"
+#~ msgstr "खाते प्रकार (_T)"
+
+#~ msgid "_Verify"
+#~ msgstr "वैध करा (_V)"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "एंटरप्राइज प्रवेश खाती समाविष्ट करण्यासाठी\n"
+#~ "ऑनलाइन जा."
+
+#~ msgid "Left thumb"
+#~ msgstr "डावा अंगठा"
+
+#~ msgid "Left middle finger"
+#~ msgstr "डावे मधले बोट"
+
+#~ msgid "Left ring finger"
+#~ msgstr "डावे अंगठी बोट"
+
+#~ msgid "Left little finger"
+#~ msgstr "डावे छोटे बोट"
+
+#~ msgid "Right thumb"
+#~ msgstr "उजवा अंगठा"
+
+#~ msgid "Right middle finger"
+#~ msgstr "उजवे मधले बोट"
+
+#~ msgid "Right ring finger"
+#~ msgstr "उजवे अंगठी बोट"
+
+#~ msgid "Right little finger"
+#~ msgstr "उजवे छोटे बोट"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "फिंगरप्रिन्ट प्रवेश कार्यान्वीत करा"
+
+#~ msgid "_Right index finger"
+#~ msgstr "उजवे तर्जनी बोट (_R)"
+
+#~ msgid "_Left index finger"
+#~ msgstr "डावे तर्जनी बोट (_L)"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "तुमचा फिंगरप्रिन्ट यशस्वीरित्या साठविले गेले. फिंगरप्रिन्ट रिडीरचा वापर करून तुम्ही आता "
+#~ "दाखल करू शकता."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "लॉगिन;नाव;फिंगरप्रिंट;अवतार;चिन्ह;फेस;पासवर्ड;"
+
+#~ msgid "Login History"
+#~ msgstr "प्रवेश इतिहास"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "नवीन पासवर्ड वैध करा (_V)"
+
+#~ msgid "Add User Account"
+#~ msgstr "वापरकर्ता खाते समाविष्ट करा"
+
+#~ msgid "User Icon"
+#~ msgstr "वापरकर्ता चिन्ह"
+
+#~ msgid "Last Login"
+#~ msgstr "मागील प्रवेश"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "नवीन पासवर्ड जुण्यापेक्षा वेगळे पाहिजे."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "काही अक्षरे आणि संख्या बदलण्याचा प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "पासवर्डला बदलण्याचा थोडा आणखी प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "वापरकर्ता नाव विना, पासवर्ड जास्त मजबूत असू शकते."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "पासवर्डमध्ये नावाचा वापर करणे टाळा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "पासवर्डमध्ये समाविष्टीत काही शब्दांचा वापर टाळा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "काही वारंवार शब्दांचा वापर टाळा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "अस्तित्वातील शब्दांचे पुन्ह क्रमवारि टाळण्याचा प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "एकापेक्षा जास्त क्रमांकांच्या वापरकरिता प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "एकापेक्षा जास्त अप्परकेस अक्षरांच्या वापरकरिता प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "एकापेक्षा जास्त लोवरकेस अक्षरांच्या वापरकरिता प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "विशेष अक्षरे, जसे कि उच्चारण यांच्या वापरकरिता प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "अक्षरे, संख्या आणि उच्चारण उच्चारण यांच्या वापरकरिता प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "समान अक्षरांचा पुन्हा वापर टाळण्याचा प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "समान प्रकारचे अक्षर वारंवार टाळण्याचा प्रयत्न करा: तुम्हाला अक्षरे, क्रमांक आणि उच्चारण "
+#~ "यांचा एकत्रीतपणे वापर करायची आवश्यकता आहे."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 किंवा abcd सारखे क्रम टाळा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "जास्त अक्षरे, क्रमांक आणि चिन्ह समाविष्ट करण्याचा प्रयत्न करा."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr "अप्पर व लोअर केसचे मिश्रण करा आणि एक किंवा दोन संख्या वापरून पहा."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr ""
+#~ "चांगला पासवर्ड! जास्त अक्षरे, क्रमांक आणि उच्चारण समाविष्ट करून जास्त मजबूत करेल."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "मजबूती: कमजोर"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "मजबूती: कमी"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "मजबूती: मध्यम"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "मजबूती: चांगली"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "मजबूती: जास्त"
+
+#~ msgid "Authentication failed"
+#~ msgstr "ओळख पटवणे अपयशी"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "नविन पासवर्ड खूप छोटे आहे"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "नविन पासवर्ड खूप सोपे आहे"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "जुणे व नविन पासवर्डस् एक समान आहे"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "नविन पासवर्ड आधिपासून नुकतेच वापरले आहे."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "नविन पासवर्डमध्ये संख्यीक किंवा विशेष अक्षरे पाहिजेत"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "जुणे आणि नविन पासवर्ड समान आहेत"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "सुरवातीला ओळखपटल्यामुळे पासवर्ड बदलले आहे!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "नविन पासवर्डमध्ये एकापेक्षा जास्त अक्षरे समाविष्टीत नाही"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "अपरिचीत त्रुटी"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "खाते पुरवठाकर्ताच्या वेब पत्त्याशी जुळायला पाहिजे."
+
+#~ msgid "Failed to add account"
+#~ msgstr "खाते समाविष्ट करण्यास अपयशी"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "पासवर्ड जुळत नाही."
+
+#~ msgid "Failed to register account"
+#~ msgstr "खातेची नोंदणी करण्यास अपयशी"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "ह्या डोमैनसह ओळख पटवण्यासाठी समर्थीत मार्ग नाही"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "डोमैनशी जोडणी करण्यास अपयशी"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "प्रवेश नाव अकार्यक्षम.\n"
+#~ "कृपया पुनः प्रयत्न करा"
+
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "प्रवेश पासवर्ड अकार्यक्षम.\n"
+#~ "कृपया पुनः प्रयत्न करा"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "डोमैनमध्ये प्रवेश करण्यास अपयशी"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "डोमेन शोधणे अशक्य. कदाचीत शुद्धलेखन चुकिचे असेल?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "तुम्हाला साधन करीता प्रवेश नाही. तुमच्या प्रणाली प्रशासकाशी संपर्क करा."
+
+#~ msgid "The device is already in use."
+#~ msgstr "साधन आधिपासूनच अस्तित्वात आहे."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "आंतरिक त्रुटी आढळली."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "पंजीकृत फिंगरप्रिन्ट नष्ट करा?"
+
+#~ msgid "Done!"
+#~ msgstr "पूर्ण झाले!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' साधन करीता प्रवेश प्राप्त करणे अशक्य"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' साधन वर बोट द्वारे संकेत प्राप्य सुरू करणे अशक्य"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "कुठलेही फिंगरप्रिन्ट रिडर करीता प्रवेश प्राप्त करण्यास अशक्य"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "कृपया मदत करीता तुमच्या प्रणली प्रशासकाशी संपर्क करा."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "फिंगरप्रिन्ट प्रवेश कार्यान्वीत करण्याकरीता, तुम्हाला '%s' साधनचा वापर करून एक "
+#~ "फिंगरप्रिन्ट साठवावे लागेल."
+
+#~ msgid "Selecting finger"
+#~ msgstr "बोट निवडले"
+
+#~ msgid "This Week"
+#~ msgstr "आजचा सपताह"
+
+#~ msgid "Last Week"
+#~ msgstr "मागील सपताह"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "सत्र समाप्त झाले"
+
+#~ msgid "Session Started"
+#~ msgstr "सत्र सुरू केले"
+
+#~ msgid "Please choose another password."
+#~ msgstr "कृपया इतर पासवर्ड निवडा."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "कृपया सध्याचे पासवर्ड पुनः टाइप करा."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "पासवर्ड बदलणे अशक्य"
+
+#~ msgid "Disable image"
+#~ msgstr "प्रतिमा बंद करा"
+
+#~ msgid "Take a photo…"
+#~ msgstr "छायाचित्र घ्या..."
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "अधिक प्रतिमांकरिता संचारन करा..."
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s तर्फे वापरले"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "या प्रकारच्या डोमेनशी स्व जुळणी अशक्य"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "या प्रकारचे डोमैन किंवा रिअल्म आढळले नाही"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%2$s डोमैनकरीता %1$s प्रमाणे प्रवेश करणे अशक्य"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "अवैध पासवर्ड, कृपया पुनः प्रयत्न करा"
+
+#~ msgid "Other Accounts"
+#~ msgstr "इतर खाते"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "वापरकर्ता नष्ट करण्यास अपयशी"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "स्वतःचे खाते नष्ट करणे शक्य नाही."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ने अजूनही प्रवेश केले आहे"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "प्रवेश केले असताना वापरकर्त्याला नष्ट केल्याने प्रणालीला अस्थीर स्तरात जाऊ शकते."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "तुम्हाला %s's च्या फाइल्स् ठेवायचे?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "वापरकर्ता खात्याला नष्ट करतेवेळी होम डिरेक्ट्री, मेल स्पूल व तात्पुर्ते फाइल्स् जपून ठेवणे "
+#~ "शक्य आहे."
+
+#~ msgid "_Delete Files"
+#~ msgstr "फाइल्स् नष्ट करा (_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "फाइल्स् जपवून ठेवा (_K)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "खाते बंद केले"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "पुढच्या प्रवेशवेळी सेट करा"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "काहिच नाही"
+
+#~ msgid "Logged in"
+#~ msgstr "प्रवेश केले"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "खाते सर्व्हिससह संपर्क करणे अपयशी"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "कृपया AccountService प्रतिष्ठापीत नाही व सुरू नाही याची खात्री करा."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "बदल करण्यासाठी,\n"
+#~ "पहिले * चिन्ह क्लिक करा"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "वापरकर्ता खाते निर्माण करण्यासाठी,\n"
+#~ "पहिले * क्लिक करा"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "निवडलेल्या वापरकर्त्याचे खाते नष्ट करा"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "निवडलेले वापरकर्ता खाते नष्ट करण्यासाठी,\n"
+#~ "पहिले * चिन्हावर क्लिक करा"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "वापरकर्तानाव '%s' असलेले वापरकर्ता आधीपासूनच अस्तित्वात आहे."
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "वापरकर्तानाव खूप मोठे आहे."
+
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "वापरकर्तानाव '-' सह सुरू होत नाही."
+
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "वापरकर्तानावमध्ये फक्त खालील लोवर आणि अप्परकेस अक्षरे a-z, अकं आणि '.', '-' व '_' "
+#~ "पैकी कुठलेही अक्षरे समाविष्टीत असू शकतात."
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr "याचा वापर होम फोल्डरला नाव देण्याकरिता केले जाईल आणि बदलणे शक्य नाही."
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "वर"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "खाली"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "काहिच नाही"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "सेंड किस्ट्रोक्"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "मॉनिटर बदला"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "ऑन-स्क्रीन मदत दाखवा"
+
+#~ msgid "Output:"
+#~ msgstr "आऊटपुट:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "ॲस्पेक्ट प्रमाण जपवा (लेटरबॉक्स्):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "एकमेव मॉनिटरकरीता मॅप करा"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d, %d पैकी"
+
+#~ msgid "Display Mapping"
+#~ msgstr "मॅपिंग दाखवा"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "टॅबलेट (ॲबसोल्युट)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "टॅबलेट पसंती"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ब्ल्युटूथ सेटिंग्स्"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "मॅप बटन्स…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "डिस्पले रेजॉल्युशन सुस्थित करा"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "माऊस सेटिंग्ज समायोजित करा"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ट्रॅकिंग मोड"
+
+#~ msgid "Left Ring"
+#~ msgstr "डावे रिंग"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "डावे रिंग मोड #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "उजवे रिंग मोड #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "डावे टचस्ट्रिप"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "डावे टचस्ट्रिप मोड #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "ऊजवे टचस्ट्रिप"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "ऊजवे टचस्ट्रिप मोड #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "डावे टचरिंग मोड स्विच्"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "ऊजवे टचरिंग मोड स्विच्"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "डावे टचस्ट्रिप मोड स्विच्"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "ऊजवे टचस्ट्रिप मोड स्विच्"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "मोड स्विच् #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "डावे बटन #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "ऊजवे बटन #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "शीर्ष बटन #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "तळ बटन #%d"
+
+#~ msgid "No Action"
+#~ msgstr "कृती नाही"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "डावे माऊस बटन क्लिक"
+
+#~ msgid "Scroll Up"
+#~ msgstr "वर सरकवा"
+
+#~ msgid "Scroll Right"
+#~ msgstr "उजवीकडे सरकवा"
+
+#~ msgid "Stylus"
+#~ msgstr "स्टायलस्"
+
+#~ msgid "Top Button"
+#~ msgstr "शीर्ष बटन"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "बर्बोस् मोड सुरू करा"
+
+#~ msgid "Show the overview"
+#~ msgstr "पूर्वावलोकन दाखवा"
+
+#~ msgid "Search for the string"
+#~ msgstr "स्ट्रिंगकरिता शोधा"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "संभाव्य पटलांचे नावे दाखवा आणि बाहेर पडा"
+
+#~ msgid "Show help options"
+#~ msgstr "मदत पर्याय दार्शवा"
+
+#~ msgid "Panel to display"
+#~ msgstr "दाखवण्याजोगी पटल"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[पटल] [बाब…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- सेटिंग्ज"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "उपलब्ध आदेश ओळ पर्यायांची संपूर्ण सूची पहाण्यासाठी '%s --help' चालवा.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "उपलब्ध पटल:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "वैयक्तिक"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "हार्डवेअर"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "प्रणाली"
 
 #~ msgid "Change the background"
 #~ msgstr "पार्श्वभूमी बदला"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "ब्ल्युटूथ सेटिंग्स् संरचीत करा"
-
 #~ msgid "Set Up New Device"
 #~ msgstr "नविन साधनची मांडणी करा"
-
-#~ msgid "Connection"
-#~ msgstr "जोडणी"
 
 #~ msgid "Paired"
 #~ msgstr "जोड"
 
-#~ msgid "Type"
-#~ msgstr "प्रकार"
-
 #~ msgid "Mouse and Touchpad Settings"
 #~ msgstr "माऊस व टचपॅड सेटिंग्स्"
-
-#~ msgid "Sound Settings"
-#~ msgstr "साऊंड सेटिंग्स्"
 
 #~ msgid "Send Files..."
 #~ msgstr "फाइल्स् पाठवा..."
@@ -7163,9 +8138,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ "If you remove the device, you will have to set it up again before next "
 #~ "use."
 #~ msgstr "साधन काढून टाकल्यास, पुढील वापरपूर्वी तुम्हाला पुनः सेटअप करावे लागेल."
-
-#~ msgid "Create virtual device"
-#~ msgstr "वर्च्युअल साधन निर्माण करा"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "डिस्पलेकरीता उपलब्ध प्रोफाइल्स्"
@@ -7270,23 +8242,11 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Unspecified"
 #~ msgstr "विनानिर्देशीत"
 
-#~ msgid "Select a language"
-#~ msgstr "भाषा निवडा"
-
-#~ msgid "_Select"
-#~ msgstr "निवडा(_S)"
-
 #~ msgid "_Region:"
 #~ msgstr "क्षेत्र (_R):"
 
 #~ msgid "_City:"
 #~ msgstr "शहर (_i):"
-
-#~ msgid "_Network Time"
-#~ msgstr "नेटवर्क वेळ (_N)"
-
-#~ msgid ":"
-#~ msgstr ":"
 
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "वेळ एक तास पुढे ठरवा."
@@ -7318,18 +8278,11 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgstr "घड्याळीच्या उलट दिशेने"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "घड्याळीच्या दिशेने"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 डिग्रिज्"
 
 #~ msgid "%d x %d"
 #~ msgstr "%d x %d"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "प्राथमिक डिस्पले बदलण्यासाठी ओढा."
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -7359,9 +8312,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "टिप: रेजोल्युशन पर्याय मर्यादित करेल"
-
-#~ msgid "_Detect Displays"
-#~ msgstr "डिस्पलेज् ओळखा (_D)"
 
 #~ msgid "VESA: %s"
 #~ msgstr "VESA: %s"
@@ -7413,9 +8363,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "C_ontent sticks to fingers"
 #~ msgstr "अंतर्भुत माहिती बोटांना चिटकते (_o)"
-
-#~ msgid "Network settings"
-#~ msgstr "नेटवर्क सेटिंग्स्"
 
 #~ msgid "Network;Wireless;IP;LAN;Proxy;"
 #~ msgstr "नेटवर्क;वायरलेस;IP;LAN;प्रॉक्सी;"
@@ -7516,9 +8463,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Paused"
 #~ msgstr "थांबले"
 
-#~ msgid "Change printer settings"
-#~ msgstr "छपाईयंत्रच्या सेटिंग्स् बदला"
-
 #~ msgid "Manufacturers"
 #~ msgstr "उत्पादक"
 
@@ -7574,9 +8518,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Remove Language"
 #~ msgstr "भाषा काढून टाका"
 
-#~ msgid "Install languages..."
-#~ msgstr "भाषा प्रतिष्ठापीत करा..."
-
 #~ msgid "Select a region (change will be applied the next time you log in)"
 #~ msgstr "क्षेत्र निवडा (पुढच्यावेळी प्रवेश केल्यावर बदल लागू होतील)"
 
@@ -7597,9 +8538,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Move Input Source Up"
 #~ msgstr "इंपुट स्रोत स्थानांतरीत करा"
-
-#~ msgid "Show Keyboard Layout"
-#~ msgstr "किबोर्ड लेआऊट दाखवा"
 
 #~ msgid "Ctrl+Alt+Space"
 #~ msgstr "Ctrl+Alt+Space"
@@ -7625,9 +8563,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Brightness & Lock"
 #~ msgstr "उजळपणा व कुलूपबंद"
 
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "पडद्याचा उजळपणा व कुलूपबंद सेटिंग्स्"
-
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "उजळपणा;लॉक;डिम;रिकामे;मॉनिटर;"
 
@@ -7639,9 +8574,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Locations..."
 #~ msgstr "ठिकाणे..."
-
-#~ msgid "Lock"
-#~ msgstr "कुलूपबंद"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "डीबगींग कोड कार्यान्वीत करा"
@@ -7658,14 +8590,8 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Sound Output Volume"
 #~ msgstr "साऊंड आऊटपुट वॉल्युम"
 
-#~ msgid "Microphone Volume"
-#~ msgstr "माइक्रोफोन वॉल्युम"
-
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "साऊंड पसंती: %s सुरू करण्यास अपयशी"
-
-#~ msgid "_Mute"
-#~ msgstr "मंद करा (_M)"
 
 #~ msgid "_Sound Preferences"
 #~ msgstr "साऊंड पसंती (_S)"
@@ -7769,9 +8695,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "None"
 #~ msgstr "काहिच नाही"
 
-#~ msgid "Add account"
-#~ msgstr "खाते समाविष्ट करा"
-
 #~ msgid "_Local Account"
 #~ msgstr "माझे खाते"
 
@@ -7802,9 +8725,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgstr ""
 #~ "हि हिंट लॉगिन स्क्रीनवर दाखवणे शक्य आहे.  हे प्रणालीतील प्रत्येक वापरकर्त्यांना दृष्यास्पद "
 #~ "होईल.  येथे पासवर्ड समाविष्ट करू <b>नका</b>."
-
-#~ msgid "C_onfirm password"
-#~ msgstr "पासवर्डची खात्री करा (_o)"
 
 #~ msgid "Fair"
 #~ msgstr "सुरेख"
@@ -7946,9 +8866,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Take a screenshot"
 #~ msgstr "स्क्रीनशॉट घ्या"
 
-#~ msgid "Shortcut"
-#~ msgstr "शॉर्टकट"
-
 #~ msgid "_Right-handed"
 #~ msgstr "उजवी हाताळणी (_R)"
 
@@ -7974,9 +8891,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Drag Threshold"
 #~ msgstr "ड्रॅग थ्रेशहोल्ड"
 
-#~ msgid "Double-Click Timeout"
-#~ msgstr "डबल-क्लिक् वेळ समाप्ती"
-
 #~ msgid "_Timeout:"
 #~ msgstr "कालबाद(_T):"
 
@@ -7990,20 +8904,11 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "टचपॅडसह माऊस क्लिक्स् सुरू करा (_m)"
 
-#~ msgid "Scrolling"
-#~ msgstr "स्क्रोल करत आहे"
-
 #~ msgid "_Disabled"
 #~ msgstr "अकार्यक्षम केले (_D)"
 
 #~ msgid "A_ddress:"
 #~ msgstr "पत्ता(_d):"
-
-#~ msgid "_Search by Address"
-#~ msgstr "पत्तातर्फे शोधा (_S)"
-
-#~ msgid "Getting devices..."
-#~ msgstr "साधने प्राप्त करत आहे..."
 
 #~ msgid ""
 #~ "FirewallD is not running. Network printer detection needs services mdns, "
@@ -8021,9 +8926,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Network"
 #~ msgstr "नेटवर्क"
 
-#~ msgid "Device types"
-#~ msgstr "डिव्हाइस प्रकार"
-
 #~| msgid "<b>_Automatic proxy configuration</b>"
 #~ msgid "Automatic configuration"
 #~ msgstr "स्वयं संरचना"
@@ -8037,9 +8939,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Opening firewall for IPP connections"
 #~ msgstr "IPP जोडणींकरीता फायरवॉल उघडत आहे"
 
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "संरचनाकरीता साधन पसंत करा (_h):"
-
 #~ msgid "Dasher"
 #~ msgstr "डॅशर"
 
@@ -8048,9 +8947,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Caribou"
 #~ msgstr "कारिबौ"
-
-#~ msgid "Account _type"
-#~ msgstr "खाते प्रकार (_t)"
 
 #~ msgid "Current network location"
 #~ msgstr "सध्याचे नेटवर्क ठिकाण"
@@ -8184,9 +9080,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Unable to open address book"
 #~ msgstr "पत्ता वही उघडण्यास असमर्थ"
-
-#~ msgid "About %s"
-#~ msgstr "%s च्या विषयी"
 
 #~ msgid "A_IM/iChat:"
 #~ msgstr "AIM/iChat (_I):"
@@ -8371,9 +9264,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "_Keyboard Accessibility"
 #~ msgstr "कळफलक प्रवेश (_K)"
 
-#~ msgid "_Mouse Accessibility"
-#~ msgstr "माऊस प्रवेशीयता (_M)"
-
 #~ msgid "_Preferred Applications"
 #~ msgstr "पसंतीचे अनुप्रयोग (_P)"
 
@@ -8489,17 +9379,11 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Changing your cursor theme takes effect the next time you log in."
 #~ msgstr "कर्सर सुत्रयोजना मधिल बदल पुढच्यावेळी जेव्हा तुम्ही दाखलन कराल त्यावेळी होईल."
 
-#~ msgid "Controls"
-#~ msgstr "नियंत्रणे"
-
 #~ msgid "Customize Theme"
 #~ msgstr "योजना मनपसंत करा"
 
 #~ msgid "Des_ktop font:"
 #~ msgstr "डेस्कटॉप फॉन्ट (_k):"
-
-#~ msgid "Edit"
-#~ msgstr "संपादीत करा"
 
 #~ msgid "Font Rendering Details"
 #~ msgstr "फॉन्ट रेंडरींग तपशील"
@@ -8600,9 +9484,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "_RGB"
 #~ msgstr "RGB (_R)"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "पूर्वनिर्धारीत पुनःस्थापीत करा (_R)"
-
 #~ msgid "_Selected items:"
 #~ msgstr "निवडलेले घटक (_S):"
 
@@ -8611,9 +9492,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "_Slight"
 #~ msgstr "स्लाइट(_S)"
-
-#~ msgid "_Style:"
-#~ msgstr "शैली(_S):"
 
 #~ msgid "_Tooltips:"
 #~ msgstr "साधनटीप (_T):"
@@ -8763,14 +9641,8 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Copying files"
 #~ msgstr "फाइली प्रतिलिपी करत आहे"
 
-#~ msgid "Parent Window"
-#~ msgstr "मुख्य पटल"
-
 #~ msgid "Parent window of the dialog"
 #~ msgstr "संवादचे मुख्य पटल"
-
-#~ msgid "From URI"
-#~ msgstr "URI पासून"
 
 #~ msgid "URI currently transferring from"
 #~ msgstr "URI सध्या येथून स्थानांतरीत करत आहे"
@@ -8780,9 +9652,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "URI currently transferring to"
 #~ msgstr "URI सध्या येथे स्थानांतरीत करत आहे"
-
-#~ msgid "Fraction completed"
-#~ msgstr "भाग पूर्ण"
 
 #~ msgid "Fraction of transfer currently completed"
 #~ msgstr "स्थानांतराचा सध्या पूर्ण झालेला भाग"
@@ -8881,9 +9750,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Default Pointer - Current"
 #~ msgstr "पूर्वनिर्धारीत पॉईंटर - सद्य"
-
-#~ msgid "White Pointer"
-#~ msgstr "पांढरा पॉईंटर"
 
 #~ msgid "White Pointer - Current"
 #~ msgstr "पांढरा पॉईंटर - सद्य"
@@ -9015,9 +9881,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "GNOME Magnifier without Screen Reader"
 #~ msgstr "पडदा वाचक विना GNOME वर्धक"
 
-#~ msgid "GNOME Terminal"
-#~ msgstr "GNOME टर्मिनल"
-
 #~ msgid "Galeon"
 #~ msgstr "गॅलिऑन"
 
@@ -9105,9 +9968,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "सिल्फीड-क्लॉज्"
 
-#~ msgid "Thunderbird"
-#~ msgstr "थंडरबर्ड्"
-
 #~ msgid "Totem Movie Player"
 #~ msgstr "टोटेम चित्रपट कार्यक्रम"
 
@@ -9122,12 +9982,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Include _panel"
 #~ msgstr "पटल अंतर्भूत करा (_p)"
-
-#~ msgid "Panel icon"
-#~ msgstr "पटल चिन्ह"
-
-#~ msgid "Re_fresh rate:"
-#~ msgstr "पुन्हदाखल दर (_f):"
 
 #~ msgid "Upside-down"
 #~ msgstr "वर-खाली"
@@ -9149,9 +10003,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Could not get session bus while applying display configuration"
 #~ msgstr "दृष्य संयोजना लागू करतेवेळी सत्र बस प्राप्त करणे शक्य नाही"
-
-#~ msgid "Desktop"
-#~ msgstr "कार्यस्थळ"
 
 #~ msgid "Accelerator key"
 #~ msgstr "प्रवेग कळ"
@@ -9265,9 +10116,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "_Vendors:"
 #~ msgstr "विक्रेता (_V):"
 
-#~ msgid "Layout"
-#~ msgstr "मांडणी"
-
 #~ msgid "Vendors"
 #~ msgstr "विक्रेता"
 
@@ -9307,9 +10155,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid ""
 #~ "You can also use the Dwell Click panel applet to choose the click type."
 #~ msgstr "क्लिक प्रकार नीवडण्यासाठी तुम्ही ड्वेल किल्क पटल ऍपलेटचा वापर करू शकता."
-
-#~ msgid "_Acceleration:"
-#~ msgstr "प्रवेग(_A):"
 
 #~ msgid "_Single click:"
 #~ msgstr "ऐकेरी क्लिक (_S):"
@@ -9380,9 +10225,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Set your window properties"
 #~ msgstr "पटल"
 
-#~ msgid "Windows"
-#~ msgstr "विंडोज"
-
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr "\"%s\" पटल व्यवस्थापकाने संरचना साधानाची नोंद केली नाही\n"
 
@@ -9403,9 +10245,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Groups"
 #~ msgstr "गट"
-
-#~ msgid "Common Tasks"
-#~ msgstr "सर्वसाधारण कार्य"
 
 #~ msgid "Close the control-center when a task is activated"
 #~ msgstr "कार्य सक्रीय केल्यास control-center बंद करा"
@@ -9577,9 +10416,6 @@ msgstr "पसंती;सेटिंग्स्;"
 #~ msgid "Description:"
 #~ msgstr "वर्णन:"
 
-#~ msgid "Installed"
-#~ msgstr "प्रतिष्ठापीत झाले"
-
 #~ msgid "usage: %s fontfile\n"
 #~ msgstr "वापरणी: %s फॉन्टफाइल\n"
 
@@ -9630,15 +10466,6 @@ msgstr "पसंती;सेटिंग्स्;"
 
 #~ msgid "Documents"
 #~ msgstr "दस्तऐवज"
-
-#~ msgid "<b>Open</b>"
-#~ msgstr "<b>उघडा</b>"
-
-#~ msgid "Rename..."
-#~ msgstr "नाव बदला..."
-
-#~ msgid "Move to Trash"
-#~ msgstr "कचरापेटीकडे हलवा"
 
 #~ msgid "If you delete an item, it is permanently lost."
 #~ msgstr "हे घटक काढूण टाकल्यास, हे कायमस्वरूपी काढूण टाकले जातील."

--- a/po/mr.po~
+++ b/po/mr.po~
@@ -1,0 +1,9668 @@
+# translation of mr.po to Marathi
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Sandeep Shedmake <sshedmak@redhat.com>, 2008, 2009.
+# Sandeep Shedmake <sshedmak@redhat.com>, 2009, 2010, 2012, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: mr\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-09-21 04:32+0000\n"
+"PO-Revision-Date: 2014-09-21 16:16+0530\n"
+"Last-Translator: Sandeep Shedmake <sshedmak@redhat.com>\n"
+"Language-Team: Marathi <maajhe-sanganak@freelists.org>\n"
+"Language: mr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Generator: Lokalize 1.5\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "पार्श्वभूमी"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "दिवसभरातील बदल"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "Lock Screen"
+msgstr "पडदा कुलूपबंद करा"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "टाइल"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "मोठे करा"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "सेंटर"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "स्केल"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "भरा"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "स्पॅन"
+
+#: ../panels/background/cc-background-chooser-dialog.c:438
+msgid "Wallpapers"
+msgstr "वॉलपेपर्स्"
+
+#: ../panels/background/cc-background-chooser-dialog.c:447
+msgid "Colors"
+msgstr "रंग"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:485
+msgid "Select Background"
+msgstr "पार्श्वभूमी नीवडा"
+
+#: ../panels/background/cc-background-chooser-dialog.c:514
+msgid "Pictures"
+msgstr "चित्र"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:546
+msgid "No Pictures Found"
+msgstr "चित्र आढळले नाही"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:564
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "गृह"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:576
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "प्रतिमांना %s फोल्डरमध्ये समाविष्ट करणे शक्य आहे आणि ते येथे आढळतील"
+
+#: ../panels/background/cc-background-chooser-dialog.c:583
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1537
+#: ../panels/display/cc-display-panel.c:1976
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1247
+#: ../panels/network/net-device-wifi.c:1440
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/cc-printers-panel.c:1947
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+#: ../panels/user-accounts/um-photo-dialog.c:95
+#: ../panels/user-accounts/um-photo-dialog.c:222
+#: ../panels/user-accounts/um-user-panel.c:513
+msgid "_Cancel"
+msgstr "रद्द करा (_C)"
+
+#: ../panels/background/cc-background-chooser-dialog.c:584
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:97
+msgid "Select"
+msgstr "नीवडा"
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "अनेक आकार"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "डेस्कटॉप पार्श्वभूमी नाही"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "सध्याची पार्श्वभूमी"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "पार्श्वभूमी प्रतिमांना वॉलपेपर किंवा छायाचित्रकरिता बदलवा"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "वॉलपेपर;स्क्रीन;डेस्कटॉप;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "ब्य्लुटूथ बंद आहे"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "ब्ल्युटूथ अडॅप्टर्स् आढळले नाही"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "हार्डवेअर स्विचतर्फे ब्ल्युटूथ बंद केले आहे"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+msgid "Bluetooth"
+msgstr "ब्ल्युटूथ"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "ब्ल्युटूथ सुरू करा आणि बंद करा आणि साधनांची जोडणी करा"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "चौकोनावर कॅलिब्रेशन साधन स्थित करा आणि 'सुरू करा' दाबा"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+"कॅलिब्रेट ठिकाणावर कॅलिब्रेशन साधन स्थानांतरित करा आणि 'सुरू ठेवा' दाबा"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr "सर्फेस ठिकाणावर कॅलिब्रेशन साधन स्थानांतरित करा आणि 'सुरू ठेवा' दाबा"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "लॅपटॉप लिड बंद करा"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "निवारण अशक्य आंतरिक त्रुटी आढळली."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "कॅलिब्रेशनकरिता आवश्यक साधने इंस्टॉल केले नाही."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "प्रोफाइल निर्माण अशक्य."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "लक्ष्य वाइटपॉइंट प्राप्यजोगी नाही."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "पूर्ण झाले!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "कॅलिब्रेशन अपयशी!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "कॅलिब्रेशन साधन काढून टाकणे शक्य आहे."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "प्रगतिमध्ये असतेवेळी कॅलिब्रेशन साधनात व्यत्यय आणू नका"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "लॅपटॉप पडदा"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "बिल्टइन वेबकॅम"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s मॉनिटर"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s स्कॅनर"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s कॅमेरा"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s छपाईयंत्र"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s वेबकॅम"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s करिता रंग व्यवस्थापन सुरू करा"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s करिता रंग प्रोफाइल्स दाखवा"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+msgid "Not calibrated"
+msgstr "कॅलिब्रेट केले नाही"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "पूर्वनिर्धारीत:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "कलरस्पेस्: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "चाचणी प्रोफाइल: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "ICC प्रोफाइल फाइल निवडा"
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "आयात करा (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "समर्थीत ICC प्रोफाइल्स्"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "सर्व फाइली"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "पडदा"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "फाइल: %s अपलोड करण्यास अपयशी"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "प्रोफाइल याकरिता अपलोड केले:"
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "हे URL लिहा."
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr "या संगणकाला पुन्हा सुरू करा आणि सर्वसाधारण कार्य प्रणालीला बूट करा."
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "प्रोफाइल डाउनलोड आणि इंस्टॉल करण्यासाठी ब्राउजरमध्ये URL टाइप करा."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "प्रोफाइल साठवा"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "साठवा (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "निवडलेल्या साधनकरीता रंग प्रोफाइल निर्माण करा"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"मोजमाप यंत्र आढळले नाही. ते सुरू आहे व योग्यरित्या जोडले आहे कृपया याची "
+"खात्री करा."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "मोजमप यंत्र प्रिंटर प्रोफाइलिंगकरीता समर्थन पुरवत नाही."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "डिव्हास प्रकार सध्या समर्थीत नाही."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "मानक जागा"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "चाचणी प्रोफाइल"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "स्व"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "कमी दर्जा"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "मध्यम दर्जा"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "उच्च दर्जा"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "पूर्वनिर्धारीत RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "पूर्वनिर्धारीत CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "पूर्वनिर्धारीत भुरे"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "विक्रेतातर्फे पुरवलेले कॅलिब्रेशन डाटा"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "पडदाभर डिस्पले सुधार या प्रोफाइलसह शक्य नाही"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "हे प्रोफाइल यापुढे अचूक नसेल"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "कॅलिब्रेशन दाखवा"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr "रद्द करा"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "सुरू करा"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "पुन्हा सुरू करा"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "पूर्ण झाले"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "स्क्रीन कॅलिब्रेशन"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"कॅलिब्रेशन प्रोफाइल निर्माण करेल ज्याचा वापर तुम्ही पडद्यावरील रंग "
+"व्यवस्थापीत करण्यासाठी करू शकता. जेवढा जास्तवेळ कॅलिब्रेशनवर द्याल, तेवढेच "
+"उत्तम रंग प्रोफाइलचा दर्जा होईल."
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "कॅलिब्रेशन सुरू होईपर्यंत तुम्ही संगणकाचा वापर करू शकणार नाही."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "दर्जा"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "अंदाजे वेळ"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "कॅलिब्रेशन दर्जा"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "कॅलिब्रेशनकरिता वापरण्याजोगी सेंसर साधन पसंत करा."
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "कॅलिब्रेशन साधन"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "जोडणीजोगी डिस्पले प्रकार पसंत करा."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "डिस्पले प्रकार"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"डिस्पले लक्ष्य व्हाइट पॉइंट पसंत करा. बरेच डिस्पलेजना D65 इल्युमिनंटकरिता "
+"कॅलिब्रेट केले पाहिजे."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "प्रोफाइल व्हाइटपॉइंट"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"कृपया डिस्पलेला तेजपणाकरिता निश्चित करा. रंग व्यवस्थापन बऱ्यापैकी या तेचपणा "
+"स्तरकरिता अचूक असते."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"वैकल्पिकरित्या, तुम्ही वापरलेल्या तेजपणा स्तराचा वापर या साधनावरील इतर "
+"प्रोफाइल्ससह करू शकता."
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "उजळपणा दाखवा"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"तुम्ही विविध संगणकांवर या रंग प्रोफाइलचा वापर करू शकता, किंवा वेगळ्या रोशानाइ "
+"अटिंकरिता प्रोफाइल्स निर्माण करू शकता."
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "प्रोफाइल नाव:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "प्रोफाइल नाव"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "प्रोफाइल यशस्वीरित्या निर्मीत केले!"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "प्रोफाइलचे प्रत बनवा"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "लेखनजोगी मिडीया आवश्यक"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "प्रोफाइल अपलोड करा"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "इंटरनेट जोडणी आवश्यक आहे"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> आणि <a "
+"href=\"windows"
+"\">Microsoft Windows</a> प्रणालींवर प्रोफाइलचा वापर कसे करायचे याकरिता उपयोगी "
+"सूचना आढळतील."
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+msgid "Summary"
+msgstr "सारांश "
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "फाइल आयात करा…"
+
+#: ../panels/color/color.ui.h:30
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr "समाविष्टीत करा (_A)"
+
+#: ../panels/color/color.ui.h:31
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"अडचणी आढळले. प्रोफाइल योग्यरित्या कार्य करणार नाही. <a href=\"\">तपशील "
+"दाखवा.</a>"
+
+#: ../panels/color/color.ui.h:32
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "प्रत्येक साधनाला रंग व्यवस्थापीत अप्टूडेट रंग प्रोफाइल आवश्यक आहे."
+
+#: ../panels/color/color.ui.h:33
+msgid "Learn more"
+msgstr "आणखी शिका"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more about color management"
+msgstr "रंग व्यवस्थापनविषयी आणखी शिका"
+
+#: ../panels/color/color.ui.h:35
+msgid "Set for all users"
+msgstr "सर्व वापरकर्त्यांसाठी ठरवा"
+
+#: ../panels/color/color.ui.h:36
+msgid "Set this profile for all users on this computer"
+msgstr "या संगणकावर सर्व वापरकर्त्यांसाठी हा प्रोफाइल ठरवा"
+
+#: ../panels/color/color.ui.h:37
+msgid "Enable"
+msgstr "सुरू करा"
+
+#: ../panels/color/color.ui.h:38
+msgid "Add profile"
+msgstr "प्रोफाइल समाविष्ट करा"
+
+#: ../panels/color/color.ui.h:39
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Calibrate…"
+msgstr "कॅलिब्रेट…"
+
+#: ../panels/color/color.ui.h:40
+msgid "Calibrate the device"
+msgstr "या साधनाला कॅलिब्रेट करा"
+
+#: ../panels/color/color.ui.h:41
+msgid "Remove profile"
+msgstr "प्रोफाइल काढून टाका"
+
+#: ../panels/color/color.ui.h:42
+msgid "View details"
+msgstr "तपशीलचे दृष्य"
+
+#: ../panels/color/color.ui.h:43
+msgid "Unable to detect any devices that can be color managed"
+msgstr "रंग व्यवस्थापन शक्य कोणत्याही साधनांना ओळखणे अशक्य"
+
+#: ../panels/color/color.ui.h:44
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:45
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:46
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:47
+msgid "Projector"
+msgstr "प्रोजेक्टर"
+
+#: ../panels/color/color.ui.h:48
+msgid "Plasma"
+msgstr "प्लाजमा"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL बॅकलाइट)"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED बॅकलाइट)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (white LED backlight)"
+msgstr "LCD (व्हाइट LED बॅकलाइट)"
+
+#: ../panels/color/color.ui.h:52
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "वाइड गॅमट LCD (CCFL बॅकलाइट)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "वाइड गॅमट LCD (RGB LED बॅकलाइट)"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "जास्त"
+
+#: ../panels/color/color.ui.h:55
+msgid "40 minutes"
+msgstr "40 मिनिटे"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 मिनिटे"
+
+#: ../panels/color/color.ui.h:58
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "कमी"
+
+#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 मिनिटे"
+
+#: ../panels/color/color.ui.h:60
+msgid "Native to display"
+msgstr "डिस्पलेकरिता मूळ"
+
+#: ../panels/color/color.ui.h:61
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (छपाई आणि प्रकाशन)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:63
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (छायाचित्रण आणि ग्राफिक्स)"
+
+#: ../panels/color/color.ui.h:64
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "रंग"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "साधनांचे रंग कॅलिब्रेट करा, जसे कि डिस्पलेज, कॅमेराज किंवा छापईयंत्र"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "रंग;ICC;प्रोफाइल;कॅलिब्रेट;प्रिंटर;डिस्पले;"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:684
+msgid "United States"
+msgstr "युनाइटेड स्टेट्स्"
+
+#: ../panels/common/cc-common-language.c:685
+msgid "Germany"
+msgstr "जर्मनी"
+
+#: ../panels/common/cc-common-language.c:686
+msgid "France"
+msgstr "फ्रांस"
+
+#: ../panels/common/cc-common-language.c:687
+msgid "Spain"
+msgstr "स्पेन"
+
+#: ../panels/common/cc-common-language.c:688
+msgid "China"
+msgstr "चायना"
+
+#: ../panels/common/cc-common-language.c:758
+msgid "Other…"
+msgstr "इतर प्रोफाइल..."
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr "आणखी…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "इतर भाषा आढळले नाही"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "भाषा"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "झाले (_D)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "जानेवारी"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "फेब्रुवारी"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "मार्च"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "एप्रिल"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "मे"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "जुन"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "जुलै"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "ऑगस्ट"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "सप्टेंबर"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "ऑक्टोबर"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "नोव्हेंबर"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "डिसेंबर"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "दिनांक व वेळ"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "तास"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "मिनिट"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "नेटवर्क वेळ (_N)"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "महिना"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "वर्ष"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Time Zone"
+msgstr "वेळ क्षेत्र"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Search for a city"
+msgstr "शहर शोधा"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Automatic _Date & Time"
+msgstr "स्वय दिनांक आणि वेळ (_D)"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr "इंटरनेट प्रवेश आवश्यक"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Automatic Time _Zone"
+msgstr "स्व वेळ क्षेत्र (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "Date & _Time"
+msgstr "दिनांक आणि वेळ (_T)"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr "वेळ क्षेत्र (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:28
+msgid "Time _Format"
+msgstr "वेळ रूपण (_F)"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24 तास"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "दिनांक आणि वेळ बदलवा, वेळक्षेत्र समाविष्टीत"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "क्लॉक;टाइमझोन;ठिकाण;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "प्रणालीची वेळ व दिनांक सेटिंग्स् बदला"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "वेळ किंवा दिनांक सेटिंग्स् बदलण्यासाठी, ओळख पटवणे आवश्यक आहे."
+
+#: ../panels/display/cc-display-panel.c:487
+msgid "Lid Closed"
+msgstr "झाकन बंद केले"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+msgid "Mirrored"
+msgstr "मिरर्ड"
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2145
+msgid "Primary"
+msgstr "प्राथमिक"
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "बंद करा"
+
+#: ../panels/display/cc-display-panel.c:497
+msgid "Secondary"
+msgstr "दुय्यम"
+
+#: ../panels/display/cc-display-panel.c:1533
+msgid "Arrange Combined Displays"
+msgstr "एकत्रीत डिस्पलेज आयोजीत करा"
+
+#: ../panels/display/cc-display-panel.c:1539
+#: ../panels/display/cc-display-panel.c:1979
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "लागू करा (_A)"
+
+#: ../panels/display/cc-display-panel.c:1560
+msgid "Drag displays to rearrange them"
+msgstr "डिस्पेजना ओढा आणि पुन्हा आयोजीत करा"
+
+#: ../panels/display/cc-display-panel.c:2081
+msgid "Size"
+msgstr "आकार"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2094
+msgid "Aspect Ratio"
+msgstr "ॲस्पेक्ट रेशो"
+
+#: ../panels/display/cc-display-panel.c:2115
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "रेजोल्युशन"
+
+#: ../panels/display/cc-display-panel.c:2146
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "या डिस्पलेवर शीर्ष पट्टी आणि क्रिया पूर्वावलोकन दाखवा"
+
+#: ../panels/display/cc-display-panel.c:2152
+msgid "Secondary Display"
+msgstr "दुसरा डिस्पले"
+
+#: ../panels/display/cc-display-panel.c:2153
+msgid "Join this display with another to create an extra workspace"
+msgstr "अगाऊ कार्यक्षेत्र निर्माणकरिता या डिस्पलेला दुसऱ्याशी जुळवा"
+
+#: ../panels/display/cc-display-panel.c:2160
+msgid "Presentation"
+msgstr "प्रस्तुतीकरण"
+
+#: ../panels/display/cc-display-panel.c:2161
+msgid "Show slideshows and media only"
+msgstr "स्लाइजशोज आणि फक्त मिडीया दाखवा"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2166
+msgid "Mirror"
+msgstr "मिरर"
+
+#: ../panels/display/cc-display-panel.c:2167
+msgid "Show your existing view on both displays"
+msgstr "दोन्ही डिस्पलेजवरील अस्तित्वातील अवलोकन दाखवा"
+
+#: ../panels/display/cc-display-panel.c:2173
+msgid "Turn Off"
+msgstr "बंद करा"
+
+#: ../panels/display/cc-display-panel.c:2174
+msgid "Don't use this display"
+msgstr "हे डिस्पले दाखवू नका"
+
+#: ../panels/display/cc-display-panel.c:2383
+msgid "Could not get screen information"
+msgstr "पडदा विषयी माहिती प्राप्त करणे शक्य नाही"
+
+#: ../panels/display/cc-display-panel.c:2414
+msgid "_Arrange Combined Displays"
+msgstr "एकत्रीत डिस्पलेज आयोजीत करा (_A)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "डिस्पलेज्"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr "जुळलेले मॉनिटर्स आणि प्रोजेक्टर्सचा वापर कसा करायचा ते पसंत करा"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "पॅनल;प्रोजेक्टर;xrandr;स्क्रीन;रेजोल्युशन;रिफ्रेश;मॉनिटर;"
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr "वेलँड"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "अपरिचित"
+
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-बिट"
+
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr "%d-बिट"
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr "काय करायचे ते विचारा"
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr "काहिच करू नका"
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr "फोल्डर उघडा"
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr "इतर मिडीया"
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr "ऑडिओ CDs करीता ॲप्लिकेशन निवडा"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr "ऑडिओ CDs करीता ॲप्लिकेशन निवडा"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr "संगीत वादक जोडल्यावर चालवण्याजोगी ॲप्लिकेशन निवडा"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr "कॅमेरा जोडल्यावर चालवण्याजोगी ॲप्लिकेशन निवडा"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr "सॉफ्टवेअर CDs करीता ॲप्लिकेशन निवडा"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr "ऑडिओ DVD"
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr "रिकामी ब्लुयरे डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr "रिकामी CD डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr "रिकामी DVD डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr "रिकामी HD DVD डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr "ब्ल्यु-रे व्हिडीओ डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr "इ-बूक रिडर"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr "HD DVD व्हिडीओ डिस्क"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr "चित्र CD"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr "सुपर व्हिडीओ CD"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr "व्हिडिओ CD"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr "विंडोज् सॉफ्टवेअर"
+
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1932
+msgid "Section"
+msgstr "विभाग"
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "पूर्वावलोकन"
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "पूर्वनिर्धारीत ॲप्लिकेशन्स्"
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "काढून टाकण्याजोगी मिडीया"
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr "आवृत्ती %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:46
+msgid "Details"
+msgstr "तपशील"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "प्रणाली विषयी माहिती दाखवा"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"डिव्हाइस;सिस्टम;इंफॉरमेशन;मेमरि;प्रोसेसर;वर्जन;डिफॉल्ट;ॲप्लिकेशन;फॉलबॅक;प्रेफर"
+"्ड;सीडी;"
+"डीवीडी;युएसबी;ऑडिओ;व्हिडीओ;डिस्क;रिमोवेबल;मिडीया;ऑटोरन;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "इतर मिडीयाला कसे हाताळायचे ते निवडा"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "तपशील"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "प्रकार (_T):"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "डिव्हाइस नाव"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "मेमरि"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "प्रोसेसर"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "बेस प्रणाली"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "डिस्क"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "गणना करत आहे..."
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "ग्राफिक्स्"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "वर्च्युअलाइजेशन"
+
+#: ../panels/info/info.ui.h:13
+msgid "Check for updates"
+msgstr "सुधारणांकरिता तपासणी करा"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "वेब (_W)"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "मेल (_M)"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "दिनदर्शिका (_C):"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "संगीत (_u)"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "व्हिडीओ (_V)"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "छायाचित्र (_P)"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "मिडीया कसे हाताळायचे ते निवडा"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "CD ऑडिओ (_a)"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "DVD व्हिडीओ (_D)"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "संगीत वादक (_M)"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "सॉफ्टवेअर"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "इतर मिडीया (_O)..."
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"मिडीया अंतर्भुतकरतेवेळी कधिही प्रोग्राम्स् करीता विनंती किंवा सुरू करू नका "
+"(_N)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "साऊंड व मिडीया"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "वॉल्युम मंद करा"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "वॉल्युम कमी करा"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "वॉल्युम वाढवा"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "मिडीया वादक सुरू करा"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "चालवा (किंवा चालवा/थांबा)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "चालवणे थांबवा"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "चालवणे थांबवा"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "पूर्वीचे ट्रॅक"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "पुढील ट्रॅक"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "बाहेर काढा"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "टाइपिंग"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "पुढील इंपुट स्रोतचा वापर करा"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "मागील इंपुट स्रोतचा वापर करा"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "लाँचर्स्"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "मदत ब्राऊजर सुरू करा"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "सेटिंग्ज"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "कॅलक्युलेटर सुरू करा"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "इमेल क्लाएंट सुरू करा"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "वेब ब्राउजर सुरू करा"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "होम फोल्डर"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "शोधा"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "स्क्रीनशॉटस्"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "स्क्रीनशॉटला $PICTURES मध्ये साठवा"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "पटलाच्या स्क्रीनशॉटला $PICTURES मध्ये साठवा"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "क्षेत्राचे स्क्रीनशॉट $PICTURES मध्ये साठवा"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "स्क्रीनशॉटचे क्लिपबोर्डवर प्रत बनवा"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "पटलाचे स्क्रीनशॉट क्लिपबोर्डवर प्रत बनवा"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "क्षेत्राचे स्क्रीनशॉट क्लिपबोर्डवर प्रत बनवा"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "छोटे स्क्रीनकास्ट रेकॉर्ड करा"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "प्रणाली"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "बाहेर पडा"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "पडदा कुलूपबंद करा"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "युनिवर्सल ॲकसेस"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "झूम सुरू किंवा बंद करा"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "मोठे करा"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "लहान करा"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "स्क्रीन रिडर सुरू किंवा बंद करा"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "ऑनस्क्रीन कळफलक सुरू किंवा बंद करा"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "मजकूर आकार वाढवा"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "मजकूर आकार कमी करा"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "जास्त काँट्रास्ट सुरू किंवा बंद करा"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1218
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+msgid "Disabled"
+msgstr "अकार्यान्वित"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "वैकल्पिक अक्षरांची कि"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "कंपोज् कि"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "पुढील स्रोतकरिता मॉडिफार्यस-ओन्लि स्विच"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "कळफलक"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "कळफलक शार्टक्टसचे अवलोकन आणि बदल करा आणि टाइपिंग पसंती ठरवा"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "शार्टकट;रिपिट;ब्लिंक;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "स्वपसंत शॉर्टकट"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "नाव(_N) :"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "आदेश (_o):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "पुनःवृत्ती किज्"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "कळ दाबून ठेवल्यास कळ पुनः दाबली जाते (_r)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "विलंब (_D):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "वेग(_S):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "छोटे"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "हळू"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "रिपीट किजचा वेग"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "लांब"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "वेग"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "कर्सर लुकलुकणे"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "पाठ्य गुणविशेष मधील कर्सर लुकलुकते (_b)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "वेग (_p):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "कर्सर लुकलुकण्याचा वेग"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "इनपुट स्रोत"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "शॉर्टकट समाविष्ट करा"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "शॉर्टकट काढून टाका"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"शार्टकट संपादित करण्याकरीता, परस्पर ओळवर क्लिक करा व नविन किज् दाबून ठेवा "
+"किंवा नष्ट "
+"करण्यासाठी बॅकस्पेस् दाबा."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "शॉर्टकटस्"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:635
+#: ../panels/keyboard/keyboard-shortcuts.c:643
+msgid "Custom Shortcuts"
+msgstr "स्वपसंत शॉर्टकट"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:860
+msgid "<Unknown Action>"
+msgstr "<अज्ञात क्रिया>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1357
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"शार्टकट \"%s\" वापरले जाऊ शकत नाही कारण ही कळ वापरल्यास टाईप करणे शक्य राहणार "
+"नाही.\n"
+"कृपया Control, Alt किंवा Shift कि परस्परित्या वापरुन पहा."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1387
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"शॉर्टकट \"%s\" आधीपासूनच\n"
+"\"%s\" करीता वापरले जाते"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1392
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"शार्टकटला \"%s\" पुन्ह निश्चित केल्यास, \"%s\" शार्टकट अकार्यान्वीत केले जाईल."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1398
+msgid "_Reassign"
+msgstr "पुन्ह निश्चित करा (_R)"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1439
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"\"%s\" शॉर्टकटला \"%s\" शॉर्टकटसह संलग्न केले आहे. तुम्हाला ते स्व \"%s\" "
+"करिता सेट करायचे?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1449
+#, c-format
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"\"%s\" आत्ता \"%s\" सह संबंधीत आहे, पुढे जात असल्यास हे शार्टकट बंद केले जाईल."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1456
+msgid "_Assign"
+msgstr "लागू करा (_A)"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "सेटिंग्जची चाचणी करा (_S)"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+msgid "Test Your Settings"
+msgstr "सेटिंग्जची चाचणी करा"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "माऊस व टचपॅड्"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "माऊस किंवा टचपॅड संवेदनशिलता बदलवा आणि उजवे किंवा डावखुरा पसंत करा"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ट्रॅकपॅड;पॉइंटर;क्लिक;टॅप;डबल;बटन;ट्रॅकबॉल;स्क्रोल;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "सर्वसाधारण"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "हळू"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "वेळ समाप्तीवर दोनवेळा क्लिक करा"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "वेग"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "दोनवेळा क्लिक करा (_D)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "प्राथमिक बटन (_b)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "डावे (_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "उजवे (_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "माऊस"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "पॉइंटर वेग (_P)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "हळू"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "वेग"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "टचपॅड्"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "हळू"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "वेग"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr "टाइप करतेवेळी बंद करा (_t)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr "क्लिक करण्यासाठी टॅप करा (_c)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr "दोन बोटांचे सक्रोल (_f)"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "_Natural scrolling"
+msgstr "स्वाभाविक स्क्रोलिंग (_N)"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "क्लिक, दोनवेळा क्लिक, स्क्रोल करण्याचा प्रयत्न करा"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "पाच क्लिक्स्, GEGL वेळ!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "दोनवेळा क्लिक करा, प्राथमिक बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "एकदाच क्लिक क्लिक, पहिली बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "दोनवेळा क्लिक करा, मधली बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "एकवेळा क्लिक करा, मधली बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "दोनवेळा क्लिक करा, दुसरी बटन"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "एकदाच क्लिक करा, दुसरी बटन"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:366
+msgid "Air_plane Mode"
+msgstr "अयरप्लैन मोड (_p)"
+
+#: ../panels/network/cc-network-panel.c:974
+msgid "Network proxy"
+msgstr "नेटवर्क प्रॉक्सी"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1153 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1298
+msgid "The system network services are not compatible with this version."
+msgstr "सिस्टम नेटवर्क सर्व्हिसेस् या आवृत्तीसह सहत्व नाही."
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x सुरक्षा (_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "पृष्ठ 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "निनावी ओळख (_m)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "आंतरिक ओळख पटवणे (_a)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "पृष्ठ 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "सुरक्षा"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "स्व"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:218
+#: ../panels/network/net-device-wifi.c:382
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:222
+#: ../panels/network/net-device-wifi.c:387
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:226
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:231
+msgid "Enterprise"
+msgstr "एंटरप्राइज"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:236
+#: ../panels/network/net-device-wifi.c:372
+msgctxt "Wifi security"
+msgid "None"
+msgstr "काहिच नाही"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "कधिही नाही"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:819
+msgid "Today"
+msgstr "आज"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:822
+msgid "Yesterday"
+msgstr "काल"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:476
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%d दिवस अगोदर"
+msgstr[1] "%d दिवस अगोदर"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:533
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "None"
+msgstr "काहिच नाही"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "कमजोर"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ठिक आहे"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:568
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "चांगले"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:570
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "उत्कृष्ट"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "ओळख"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "पत्ता"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "नेटमास्क"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "गेटवे"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "पत्ता नष्ट करा"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "समाविष्ट करा"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "सर्व्हर"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "DNS सर्व्हर नष्ट करा"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "मेट्रिक"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "राउट नष्ट करा"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "स्व (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Manual"
+msgstr "स्वहस्ते"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "फक्त स्थानीय जुळवा"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "प्रिफिक्स"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "स्व"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "स्व, फक्त DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:51
+msgid "Reset"
+msgstr "मूळस्थिती"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "काहिही नाही"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-बिट कि (Hex किंवा ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-बिट पासफ्रेज"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "डायनॅमिक WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA आणि WPA2 पर्सनल"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA आणि WPA2 एंटरप्राइज"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr "सिग्नल मजबूती"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "लिंकचा वेग"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 पत्ता"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 पत्ता"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "हार्डवेअर पत्ता"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "पूर्वनिर्धारीत राऊट"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "शेवटच्यावेळी वापरले"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "ट्विस्टेड पैर (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "अटॅचमेंट युनिट इंटरफेस (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "मिडीया इंडिपेंडंट इंटरफेस (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "नाव (_N)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "MAC पत्ता (_M)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "MTU (_T)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "क्लोन केलेला पत्ता (_C)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "बाइट्स"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "इतर वापरकर्त्यांना उपलब्ध करा (_u)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "स्व जोडणी करा (_a)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "फायरवॉल क्षेत्र (_Z)"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "पूर्वनिर्धारित"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "झोन जोडणीचे विश्वासर्हता स्तर ठरवते"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv4 (_4)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "पत्ते (_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "स्व DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "राउट्स"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "स्व राउट्स"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr "नेटवर्कवरील स्रोतकरिता फक्त या जोडणीचाच वापर (_o)"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv6 (_6)"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "जोडणी संपादक उघडण्यास अशक्य"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "नवीन प्रोफाइल"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "बाँड"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "टिम"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "ब्रिज"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "VPN प्लगइन्स लोड करणे अशक्य"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "फाइलपासून आयात करा…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "नेटवर्क जोडणी समाविष्ट करा"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "मूळस्थितीत आणा (_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1441
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "विसरून जा (_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"या नेटवर्ककरिता सेटिंग्ज मूळस्थित आणा, पासवर्ड्ज समाविष्टीत, परंतु त्यास "
+"पसंतीचे नेटवर्क म्हणून लक्षात ठेवा "
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"या नेटवर्कशी संबंधीत सर्व तपशीलवार काढून टाका आणि स्व जोडणी करायचा प्रयत्न "
+"करू नका"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "सुरक्षा (_e)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "VPN जोडणी आयात करणे अशक्य"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"फाइल '%s' ला वाचणे अशक्य किंवा परिचीत VPN "
+"जोडणी माहिती समाविष्टीत नाही\n"
+"\n"
+"त्रुटी: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "आयातकरिता फाइल पसंत करा"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1948
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:223
+msgid "_Open"
+msgstr "उघडा (_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "\"%s\" नावाची फाइल आधिपासूनच अस्तित्वात आहे."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "अदलाबदल करा (_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "तुम्हाला %s ला साठवण्याजोगी VPN जोडणीसह करायचे?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "VPN जोडणी एक्सपोर्ट करणे अशक्य"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN जोडणी '%s' यास %s करिता एक्सपोर्ट करणे अशक्य.\n"
+"\n"
+"त्रुटी: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+msgid "Export VPN connection"
+msgstr "VPN जोडणी एक्सपोर्ट करा"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(त्रुटी: VPN जोडणी संपादक लोड करणे अशक्य)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "SSID (_S)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "BSSID (_B)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "माझे होम नेटवर्क"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "इतर वापरकर्त्यांकरिता उपलब्ध करा (_o)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "नेटवर्क"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "इंटरनेटशी कशी जोडणी करायची ते नियंत्रीत करा"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"नेटवर्क;वायरलेस;वाय-फाय;वायफाय;आयपि;लॅन;प्रॉक्सी;वॅन;ब्रॉडबँड;मोडेम;ब्लुटूथ;व्"
+"हिपिएन;"
+"व्हिलॅन;ब्रिज;बाँड;डिएनएस;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "बाँड स्लेव्ज"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(काहिही नाही)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "स्लेव्ज ब्रिज करा"
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:462
+msgid "never"
+msgstr "कधिच नाही"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:472
+msgid "today"
+msgstr "आज"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:474
+msgid "yesterday"
+msgstr "काल"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP पत्ता"
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "शेवटच्यावेळी वापरले"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "वायर्ड"
+
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1596
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "पर्याय…"
+
+#: ../panels/network/net-device-ethernet.c:474
+#, c-format
+msgid "Profile %d"
+msgstr "प्रोफाइल %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "नवीन जोडणी समाविष्ट करा"
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr "टिम स्लेव्हज"
+
+#: ../panels/network/net-device-wifi.c:1154
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"वायरलेस व्यतिरिक्त इंटरनेटसह जोडणी असल्यास, इतरांशी इंटरनेट जोडणीचा "
+"एकत्रीतपणे "
+"वापरकरिता वायरलेस हॉटस्पॉट सेट करणे शक्य आहे."
+
+#: ../panels/network/net-device-wifi.c:1158
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "वायरलेस हॉटस्पॉटचा वापर केल्यास <b>%s</b> पासून जोडणी खंडीत होईल."
+
+#: ../panels/network/net-device-wifi.c:1162
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"हॉटस्पॉट सुरू असल्यास वायरलेसच्या मदतीने इंटरनेटकरिता प्रवेश शक्य नाही."
+
+#: ../panels/network/net-device-wifi.c:1245
+msgid "Stop hotspot and disconnect any users?"
+msgstr "हॉटस्पॉट थांबवा व कोणत्याहि वापरकर्त्यांना खंडीत करायचे?"
+
+#: ../panels/network/net-device-wifi.c:1248
+msgid "_Stop Hotspot"
+msgstr "हॉटस्पॉट थांबवा (_S)"
+
+#: ../panels/network/net-device-wifi.c:1305
+msgid "System policy prohibits use as a Hotspot"
+msgstr "प्रणाली करार हॉटस्पॉटचा वापर प्रतिबंधीत करते"
+
+#: ../panels/network/net-device-wifi.c:1308
+msgid "Wireless device does not support Hotspot mode"
+msgstr "वायरलेस साधन हॉटस्पॉट मोडकरिता समर्थन पुरवत नाही"
+
+#: ../panels/network/net-device-wifi.c:1437
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"नीवडलेल्या नेटवर्क्सकरिता नेटवर्क तपशील, पासवर्ड व इतर कोणतिही पसंतीची संरचना "
+"गमवाल."
+
+#: ../panels/network/net-device-wifi.c:1745
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "इतिहास"
+
+#: ../panels/network/net-device-wifi.c:1749
+#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
+#: ../panels/wacom/cc-wacom-page.c:533
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Close"
+msgstr "बंद करा (_C)"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1757
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "विसरून जा (_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"वेब प्रॉक्सी ऑटोडिस्कवरिचा वापर जेव्हा संरचना URL पुरवले जात नाही तेव्हा होतो."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "अविश्वासर्ह पब्लिक नेटवर्कस् करिता शिफारसीय नाही."
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "प्रॉक्सी"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "प्रोफाइल समाविष्ट करा (_A)…"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "प्रोव्हाइडर"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "काहिच नाही"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "मॅन्युअल"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "स्वयं"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "मेथड (_M)"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "संरचना URL (_C):"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "HTTP प्रॉक्सी (_H):"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "HTTPS प्रॉक्सी (_T):"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "FTP प्रॉक्सी (_F): "
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "FTP प्रॉक्सी (_F): "
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "यजमानांकडे दुर्लक्ष करा (_I)"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "HTTP प्रॉक्सी पोर्ट"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "HTTPS प्रॉक्सी पोर्ट"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "FTP प्रॉक्सी पोर्ट"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "सॉक्स प्रॉक्सी पोर्ट"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "साधन बंद करा"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "साधन समाविष्ट करा"
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "साधन काढून टाका"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN प्रकार"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "गट नाव"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "गट पासवर्ड"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "वापरकर्तानाव"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "VPN जोडणी बंद करा"
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "स्व जोडणी करा (_C)"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "तपशील"
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "पासवर्ड (_P)"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "काहीच नाही"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "पासवर्ड दाखवा (_a)"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr "इतर वापरकर्त्यांकरिता उपलब्ध करा"
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "ओळख"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr "फक्त स्व (DHCP) पत्ते"
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr "फक्त स्थानीय जुळवा"
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr "इतर संगणकांशी शेअर केले"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr "स्व प्राप्य राउट्सकडे दुर्लक्ष करा (_I)"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr "क्लोन केलेले MAC पत्ता (_C)"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr "हार्डवेअर"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"या जोडणीकरिता सेटिंग्जना त्यांच्या पूर्वनिर्धारितकरिता मूळस्थितीत आणा, परंतु "
+"त्यास पसंतीची जोडणी म्हणून लक्षात ठेवा."
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"या नेटवर्कशी संबंधीत सर्व तपशीलवार काढून टाका आणि स्व जोडणी करायचा प्रयत्न "
+"करू नका."
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "मूळस्थिती"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "हार्डवेअर"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr "वाय-फाय हॉटस्पॉट"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Turn On"
+msgstr "सुरू करा (_T)"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Wi-Fi"
+msgstr "वाय-फाय"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Turn Wi-Fi off"
+msgstr "वाय-फाय बंद करा"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_Use as Hotspot…"
+msgstr "हॉटस्पॉट म्हणून वापर करा (_U)..."
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "_Connect to Hidden Network…"
+msgstr "छुप्या नेटवर्कशी जोडणी करा (_C)..."
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "_History"
+msgstr "इतिहास (_H)"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "वाय-फाय नेटवर्कशी जोडणीकरिता बंद करा"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Network Name"
+msgstr "नेटवर्क नाव"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Connected Devices"
+msgstr "जुळलेले साधन"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "Security type"
+msgstr "सुरक्षा प्रकार"
+
+#: ../panels/network/network-wifi.ui.h:63
+msgid "Security key"
+msgstr "सुरक्षा कि"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "ॲडहॉक"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "इंफ्रास्टक्चर"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "स्थिती अपरिचीत"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "अव्यवस्थापीत"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "अनुपलब्ध"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "जोडत आहे"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "ओळख पटवणे आवश्यक"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "जुळले"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "खंडीत करत आहे"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "जोडणी अपयशी"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "स्थिती अपरिचीत (आढळली नाही)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "जुडले नाही"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "संरचना अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "IP संरचना अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "IP संरचना वेळसमाप्ति"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "गोपनीयता आवश्यक, परंतु पुरवले नाही"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x सप्पिकंट खंडीत केले"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x सप्लिकंट संरचना अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1x सप्लिकंट अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x सप्लिकंटला ओळख पटवण्याकरीता जास्त वेळ लागला"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "PPP सर्व्हिस सुरू होण्यास अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "PPP सर्व्हिस खंडीत"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "DHCP क्लाएंट सुरू होण्यास अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP क्लाएंट त्रुटी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP क्लाएंट अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "शेअर्ड जोडणी सर्व्हिस सुरू होण्यास अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "शेअर्ड जोडणी सर्व्हिस अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "ऑटोIP सर्व्हिस सुरू होण्यास अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "ऑटोIP सर्व्हिस सुरू होण्यास अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "ऑटोIP सर्व्हिस अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "लाइन व्यस्थ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "डायल सूर आढळले नाही"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "कॅरिअर स्थापित करणे अशक्य"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "डायलिंग विनंती वेळसमाप्ति"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "डायलिंग प्रयत्न अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "मोडेम प्रारंभिकरण अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "निर्देशीत APN नीवडण्यास अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "नेटवर्ककरीता शोधणे अशक्य"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "नेटवर्क नोंदणी नकारले"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "नेटवर्क नोंदणीची वेळसमाप्ति"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "विनंती केलेल्या नेटवर्कसह नोंदणी अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "PIN तपासणी अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "साधनकरीता फर्मवेअर कदाचित आढळले नाही"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "जोडणी पूर्णपणे खंडीत"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "अस्तित्वातील जोडणी गृहीत धरले"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "मोडेम आढळले नाही"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "ब्ल्युटूथ जोडणी अपयशी"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "SIM कार्ड अंतर्भुत केले नाही"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "SIM पिन आवश्यक"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "SIM पक आवश्यक"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "SIM चुकिचे"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "इंफिनिबँड साधन जोडणी मोडकरीता समर्थन पुरवत नाही"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "जोडणी अवलंबन अपयशी"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "फर्मवेअर आढळले नाही"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "केबल प्लग अशक्य"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "सर्टिफेकट अथॉरिटि प्रमाणपत्र पसंत केले नाही"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"सर्टिफिकेट अथॉरिटि (CA) प्रमाणपत्रचा वापर न केल्यामुळे जोडणी असुरक्षित, "
+"धोकादायक वाय-फाय नेटवर्क्सकरिता कारणीभूत ठरू शकते.  तुम्हाला सर्टिफिकेट "
+"अथॉरिटि प्रमाणपत्र पसंत करायला आवडेल?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "दुर्लक्ष करा"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "CA प्रमाणपत्र पसंत करा"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, किंवा PKCS#12 प्राइव्हेट किज (*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER किंवा PEM प्रमाणपत्र (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+msgid "Choose a PAC file"
+msgstr "PAC फाइल पसंत करा"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC फाइल्स (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC फाइल (_f)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "आंतरिक ओळख पटवा (_I)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "PAC प्रोव्हिजनिंग (_v)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "निनावी"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "ओळख पटवली"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "दोन्ही"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "वापरकर्तानाव (_U)"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "पासवर्ड दाखवा (_w)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate"
+msgstr "सर्टिफेकट अथॉरिटि प्रमाणपत्र पसंत करा"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "आवृत्ती 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "आवृत्ती 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "CA प्रमाणपत्र (_A)"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP आवृत्ती (_v)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "या पासवर्डकरिता नेहमी विचारा (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "विना एंक्रिप्ट केलेले प्राइव्हेट किज असुरक्षित आहे"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"नीवडलेले प्राइवेट कि पासवर्डतर्फे सुरक्षित असल्याचे दिसून येत नाही.  "
+"यामुळे आपले सुरक्षा श्रेयशी तजजोड होऊ शकते.  कृपया पासवर्ड-सुरक्षित प्राइवेट "
+"किचा वापर करा.\n"
+"\n"
+"(openssl सह प्राइवेट किला पासवर्ड-सुरक्षित करणे शक्य आहे)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+msgid "Choose your personal certificate"
+msgstr "वैयक्तिक प्रमाणपत्र पंसत करा"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+msgid "Choose your private key"
+msgstr "प्राइवेट कि पसंत करा"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "ओळख (_d)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "वापरकर्ता प्रमाणपत्र (_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "प्राइव्हेट कि (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "प्राइवेट कि पासवर्ड (_P)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "मला पुन्हा सावध करू नका (_w)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "नाही"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "होय"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "टनल्ड TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "प्रोटेक्टेड EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "ओळख (_t)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (पूर्वनिर्धारित)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "ओपन प्रणाली"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "शेअर्ड कि"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "कि (_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "कि दाखवा (_w)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP इंडेक्स (_x)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "प्रकार (_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "सूचना"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "आवाज सतर्कता"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "पॉपअप बॅनर्स दाखवा"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "बॅनर्समध्ये तपशील दाखवा"
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "पडदा कुलूपबंदमधील अवलोकन"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "पडदा कुलूपबंद करामधील तपशील दाखवा"
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "सुरू करा"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "सूचना"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr "कोणत्या सूचना दाखवायचे आणि ते काय दाखवते, ते नियंत्रीत करा "
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "सूचना;बॅनर;संदेश;ट्रे;पॉपअप;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "पॉपअप बॅनर्स दाखवा"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "पडदा कुलूपबंदमध्ये दाखवा"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+msgctxt "Online Account"
+msgid "Other"
+msgstr "इतर"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "खाते समाविष्ट करा"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr "ईमेल"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr "संपर्क"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "गप्पा"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "स्रोत"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "खात्यामध्ये प्रवेश करतेवेळी त्रुटी"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "श्रेयची वेळसमाप्ति आढळली."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr "हे खाते सुरू करण्यासाठी प्रवेश करा."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr "प्रवेश करा (_S)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "खाते निर्माण करतेवेळी त्रुटी"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "खते काढून टाकतेवेळी त्रुटी"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "तुम्हला नक्की खाते काढूण टाकायचे?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "यामुळे सर्व्हरवरील खाते काढून टाकले जात नाही."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "काढून टाका (_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "ऑनलाइन खाते"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "ऑनलाइन खातींसह जोडणी करा आणि त्याचे कशासाठी वापर करायचे ते ठरवा"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"गूगल;फेसबूक;ट्विटर;याहू;वेब;ऑनलाइन;चॅट;कॅलेंडर;मेल;काँट्रॅक्ट;ओनक्लाउड;कर्बेरो"
+"स,आईमॅप;एसएमटिपि;"
+"पॉकेट;रिडइटलेटर;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "ऑनलाइन खाते संरचीत केले नाही"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "खाते काढून टाका"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "ऑनलाइन खाते समाविष्ट करा"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"खाते समाविष्ट केल्याने ॲप्लिकेशन्स् दस्तऐवज, मेल, संपर्क, दिनदर्शिका, गप्पा, "
+"व आणखी करीता "
+"प्रवेश प्राप्त करू शकतात."
+
+#: ../panels/power/cc-power-panel.c:183
+msgid "Unknown time"
+msgstr "अपरिचीत वेळ"
+
+#: ../panels/power/cc-power-panel.c:189
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i मिनिट"
+msgstr[1] "%i मिनिटे"
+
+#: ../panels/power/cc-power-panel.c:201
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i तास"
+msgstr[1] "%i तास"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:209
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:210
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "तास"
+msgstr[1] "तास"
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "मिनिट"
+msgstr[1] "मिनिटे"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:230
+#, c-format
+msgid "%s until fully charged"
+msgstr "संपूर्णतया चार्ज होईपर्यंत %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:237
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "खबरदारी: %s उर्वरित"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:242
+#, c-format
+msgid "%s remaining"
+msgstr "%s उर्वरित"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
+msgid "Fully charged"
+msgstr "संपूर्णतया चार्ज करा"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
+msgid "Empty"
+msgstr "रिकामे"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Charging"
+msgstr "चार्ज करत आहे"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:271
+msgid "Discharging"
+msgstr "डिसचार्ज करत आहे"
+
+#: ../panels/power/cc-power-panel.c:396
+msgctxt "Battery name"
+msgid "Main"
+msgstr "मुख्य"
+
+#: ../panels/power/cc-power-panel.c:398
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "अगाऊ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:470
+msgid "Wireless mouse"
+msgstr "वायरलेस माऊस"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:473
+msgid "Wireless keyboard"
+msgstr "वायरलेस किबोर्ड"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:476
+msgid "Uninterruptible power supply"
+msgstr "अव्यतय पावर पुरवठा"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Personal digital assistant"
+msgstr "वैयक्तिक डिजिटल सहाय्यक"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Cellphone"
+msgstr "सेलफोन"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Media player"
+msgstr "मिडीया वादक"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Tablet"
+msgstr "टॅबलेट"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Computer"
+msgstr "संगणक"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
+#: ../panels/power/cc-power-panel.c:2019
+msgid "Battery"
+msgstr "बॅटरि"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "चार्ज करत आहे"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "सावधानता"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Low"
+msgstr "कमी"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Good"
+msgstr "चांगले"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "संपूर्णतया चार्ज केले"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "रिकामे"
+
+#: ../panels/power/cc-power-panel.c:715
+msgid "Batteries"
+msgstr "बॅटरिज"
+
+#: ../panels/power/cc-power-panel.c:1117
+msgid "When _idle"
+msgstr "निष्क्रिय असतेवेळी (_i)"
+
+#: ../panels/power/cc-power-panel.c:1445
+msgid "Power Saving"
+msgstr "उर्जा बचत"
+
+#: ../panels/power/cc-power-panel.c:1473
+msgid "_Screen brightness"
+msgstr "पडद्याचा उजळपणा (_S)"
+
+#: ../panels/power/cc-power-panel.c:1479
+msgid "_Keyboard brightness"
+msgstr "कळफलक उजळपणा (_K)"
+
+#: ../panels/power/cc-power-panel.c:1489
+msgid "_Dim screen when inactive"
+msgstr "निष्क्रीय असताना पडदा मंद करा (_D)"
+
+#: ../panels/power/cc-power-panel.c:1514
+msgid "_Blank screen"
+msgstr "रिक्त पडदा (_B)"
+
+#: ../panels/power/cc-power-panel.c:1551
+msgid "_Wi-Fi"
+msgstr "वायफाय (_W)"
+
+#: ../panels/power/cc-power-panel.c:1556
+msgid "Turns off wireless devices"
+msgstr "वायरलेश साधनांना बंद करते"
+
+#: ../panels/power/cc-power-panel.c:1581
+msgid "_Mobile broadband"
+msgstr "मोबाइल ब्रॉडबँड (_M)"
+
+#: ../panels/power/cc-power-panel.c:1586
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "मोबाइल ब्रॉडबँड (3G, 4G, WiMax, इत्यादि) साधने बंद करते"
+
+#: ../panels/power/cc-power-panel.c:1635
+msgid "_Bluetooth"
+msgstr "ब्ल्युटूथ (_B)"
+
+#: ../panels/power/cc-power-panel.c:1686
+msgid "When on battery power"
+msgstr "बॅटरि पावरवर असताना"
+
+#: ../panels/power/cc-power-panel.c:1688
+msgid "When plugged in"
+msgstr "प्लग केल्यानंतर"
+
+#: ../panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Off"
+msgstr "स्थगित करा आणि बंद करा"
+
+#: ../panels/power/cc-power-panel.c:1851
+msgid "_Automatic suspend"
+msgstr "स्व सस्पेंड (_A)"
+
+#: ../panels/power/cc-power-panel.c:1875
+msgid "When battery power is _critical"
+msgstr "बॅटरि पावर गंभीर असताना (_c)"
+
+#: ../panels/power/cc-power-panel.c:1930
+msgid "Power Off"
+msgstr "बंद करा"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Devices"
+msgstr "साधने"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "पावर"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr "बॅटरि स्थितीचे अवलोकन करा आणि पावर साठवण्याच्या सेटिंग्ज बदलवा"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"पावर;स्लीप;सस्पेंड;हायबरनेट;बटरि;उजळपणा;मंद;रिक्त;मॉनिटर;डीपीएमएस;आइडल;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "हायबरनेट"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "बंद करा"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "45 मिनिटे"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 तास"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "80 मिनिटे"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "90 मिनिटे"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "100 मिनिटे"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "2 तास"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 मिनिट"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 मिनिटे"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 मिनिटे"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "4 मिनिटे"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 मिनिटे"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "8 मिनिटे"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 मिनिटे"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "12 मिनिटे"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "स्व स्थगित करा"
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr "प्लग केले (_P)"
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr "बॅटरि पावरवरील (_B)"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "विलंब"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "ओळख पटवा"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "पासवर्ड"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "ओळख पटवणे आवश्यक"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr "टोनर निग्न आहे"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr "टोनर नाही"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr "डेव्हलपर निग्न आहे"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr "डेव्हलपर नाही"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr "मार्कर पुरवठा निग्न आहे"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr "मार्कर पुरवठा कमी आहे"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr "कवर उघडा"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr "दार उघडा"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr "पेपर निग्न आहे"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr "पेपर कमी आहे"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ऑफलाइन"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "थांबवले"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr "वेस्ट बऱ्यापैकी भरले आहे"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr "वेस्ट जवळपास भरले आहे"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr "ऑप्टिकल फोटो कंडक्टरची वेळसमाप्ति आढळली"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ऑप्टिकल फोटो कंडक्टर यापुढे कार्यशील नाही"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "संरचीत करत आहे"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr "सज्ज"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "जॉब्ज स्वीकरत नाही"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr "विश्लेषण करत आहे"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Toner Level"
+msgstr "टोनरचे स्तर"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Ink Level"
+msgstr "शाई स्तर"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:928
+msgid "Supply Level"
+msgstr "पुरवठा स्तर"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:946
+msgctxt "printer state"
+msgid "Installing"
+msgstr "प्रतिष्ठापीत करत आहे"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1123
+msgid "No printers available"
+msgstr "छपाईयंत्रे उपलब्ध नाही"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1433
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u सक्रिय"
+msgstr[1] "%u सक्रिय"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1777
+msgid "Failed to add new printer."
+msgstr "नविन छपाईयंत्र समाविष्ट करण्यास अपयशी."
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid "Select PPD File"
+msgstr "PPD फाइल नीवडा"
+
+#: ../panels/printers/cc-printers-panel.c:1953
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"पोस्टस्क्रिप्ट प्रिंटर डिस्क्रिप्शन फाइल्स् (*.ppd, *.PPD, *.ppd.gz, "
+"*.PPD.gz, *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2258
+msgid "No suitable driver found"
+msgstr "योग्य ड्राइव्हर आढळले नाही"
+
+#: ../panels/printers/cc-printers-panel.c:2327
+msgid "Searching for preferred drivers…"
+msgstr "पसंतीचे ड्राइव्हर्स शोधत आहे..."
+
+#: ../panels/printers/cc-printers-panel.c:2342
+msgid "Select from database…"
+msgstr "डाटाबेसपासून नीवडा..."
+
+#: ../panels/printers/cc-printers-panel.c:2351
+msgid "Provide PPD File…"
+msgstr "PPD फाइल द्या..."
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2502
+#: ../panels/printers/cc-printers-panel.c:2525
+msgid "Test page"
+msgstr "चाचणी पान"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2933
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui लोड करणे अशक्य: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "छपाईयंत्रे"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"छपाईयंत्र समाविष्ट करा, छपाईयंत्र जॉब्सचे अवलोकन करा आणि छपाई कसे पाहिजे ते "
+"ठरवा"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "प्रिंटर;क्युउ;प्रिंट;पेपर;इंक;टोनर;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "सक्रिय जॉब्स्"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "बंद करा"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "प्रिंटिंग पुनः आरंभ करा"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "छपाई थांबवा"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "छपाई जॉब रद्द करा"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "नविन छपाईयंत्र समाविष्टीत करा"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "A_uthenticate"
+msgstr "ओळख पटवा (_u)"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "छपाईयंत्र आढळले नाही."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter address of a printer or a text to filter results"
+msgstr "परिणा फिल्टर करण्यासाठी छपाईयंत्र किंवा मजकूरचा पत्ता द्या"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "पर्याय लोड करत आहे..."
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "छपाईयंत्र ड्राइव्हर नीवडा"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "ड्राइव्हर्स् डाटाबेस् लोड करत आहे..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+msgid "JetDirect Printer"
+msgstr "JetDirect छपाईयंत्र"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+msgid "LPD Printer"
+msgstr "LPD छपाईयंत्र"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "एका बाजूने"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "दोंही बाजूने (मानक)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "दोंही बाजूने (पलटवून)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "उभे"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "आडवे"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "उलट आडवे"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "उलट उभे"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "उर्वरित आहे"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "रोखून ठेवले"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "विश्लेषण करत आहे"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "थांबवले"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "रद्द केले"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "रद्द केले"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "पूर्ण झाले"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "जॉब शीर्षक"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "जॉबचे स्तर"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "वेळ"
+
+#: ../panels/printers/pp-jobs-dialog.c:495
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s सक्रिय जॉब्स्"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Serial Port"
+msgstr "सिरिअल पोर्ट"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1683
+msgid "Parallel Port"
+msgstr "पॅरलल पोर्ट"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+msgid "Location: %s"
+msgstr "ठिकाण: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1744
+#, c-format
+msgid "Address: %s"
+msgstr "पत्ता: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1768
+msgid "Server requires authentication"
+msgstr "सर्व्हरला ओळख पटवून द्या"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "दोंही बाजूने"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "पेपर प्रकार"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "पेपर स्रोत"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "आऊटपुट ट्रे"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "घोस्टस्क्रिप्ट प्रिफिल्टरिंग"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:531
+msgid "Pages per side"
+msgstr "प्रत्येक बाजूवरील पृष्ठे"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:543
+msgid "Two-sided"
+msgstr "दोंही बाजूने"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:555
+msgid "Orientation"
+msgstr "निर्देशन"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:652
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "सर्वसाधारण"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "पृष्ठ मांडणी"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "प्रतिष्ठापनजोगी पर्याय"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "कार्य"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "प्रतिमा दर्जा"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "रंग"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "पूर्णत्व"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "प्रगत"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "स्वयं नीवडा"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "छपाईयंत्र पूर्वनिर्धारीत"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "फक्त घोस्टस्क्रिप्ट फाँटस् अंतर्भुत करा"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "PS स्तर 1 करीता रूपांतरीत करा"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "PS स्तर 2 करीता रूपांतरीत करा"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "प्रिफिल्टरिंग आढळले नाही"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "उत्पादक"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "ड्राइव्हर"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"%s वरील उपलब्ध छपाईयंत्रांच्या अवलोकनकरिता तुमचे वापरकर्तानाव आणि पासवर्ड "
+"द्या."
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "छपाईयंत्र समाविष्ट करा"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "छपाईयंत्र काढून टाका"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "पुरवठा"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "ठिकाण"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default printer"
+msgstr "पूर्वनिर्धारीत छपाईयंत्र (_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "जॉब्स्"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "जॉब्स दाखवा (_J)"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "मॉडल"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "लेबल"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "नवीन ड्राइव्हर ठरवत आहे..."
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "पृष्ठ 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "चाचणी पानची छपाई करा (_T)"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "पर्याय (_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "नविन छपाईयंत्र समाविष्ट करा"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"माफ करा! सिस्टम प्रिंटिंग सर्व्हिस्\n"
+"उपलब्ध नाही असे आढळलते."
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "पडदा कुलूपबंद"
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "वापर आणि इतिहास"
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr "कचरापेटीतून सर्व घटकांना रिक्त करायचे?"
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr "कचरापेटीतील सर्व घटकांना नेहमीकरिता नष्ट केले जाईल."
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "कचरापेटी रिकामे करा (_E)"
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+msgid "Delete all the temporary files?"
+msgstr "सर्व तात्पुते फाइल्स नष्ट करायचे?"
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr "सर्व तात्पुर्त्या फाइल्स नेहमीकरिता नष्ट केले जातील."
+
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "तात्पुर्त्या फाइल्स काढून टाका (_P)"
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "ट्रॅश आणि तात्पुर्त्या फाइल्स काढून टाका"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr "सॉफ्टवेअर वापर"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "गोपणीयता"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+"वैयक्ति माहिती सुरक्षित ठेवा आणि इतरांना ते कसे दृष्यास्पद असे ते नियंत्रीत "
+"करा"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"स्क्रीन;लॉक;विश्लेषण;क्रॅश;वैयक्तिक;नुकतेच;तात्पुर्ते;tmp;इंडेक्स;नाव;"
+"नेटवर्क;ओळख;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "पडदा बंद होते"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 सेकंद"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 दिवस"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 दिवस"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 दिवस"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 दिवस"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 दिवस"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 दिवस"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 दिवस"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 दिवस"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 दिवस"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "नेहमीकरिता"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"इतिहास लक्षात ठेवल्याने बाबी ओळखायला सोयीस्कर ठरते. या घटकांना कधिही "
+"नेटवर्कवरील शेअर केले जात नाही."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "नुकतेच वापरलेले (_R)"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "इतिहास जपवा (_H)"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "नुकतेच इतिहास नष्ट करा (_e)"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "पडदा कुलूपबंद, तुम्ही दूर असताना गोपणीयता सुरक्षित करते."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "स्व पडदा कुलूपबंद (_L)"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "रिक्त असल्यास पडदा कुलूपबंद करा (_a)"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "सूचना दाखवा (_N)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"कचरापेटी आणि तात्पुर्त्या फाइल्स स्व काढून टाका जेणेकरून संगणक अनावश्यक "
+"संवेदनशील माहितीरहीत राहील."
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "कचरापेटी स्व रिक्त करा (_T)"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "स्व तात्पुर्ते फाइल्स काढून टाका (_F)"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "नंतर काढून टाका (_A)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"वापरण्याजोगी सॉफ्टवेअरविषयी माहिती पाठवल्याने आम्ही तुम्हाला अचूक शिफारस देऊ "
+"शकू. सॉफ्टवेअर सुधारणामध्ये मदत होते.\n"
+"\n"
+"गोळा केलेली सर्व माहिती निनावी राहते, आणि आम्ही तुमचा डाटा तीसऱ्या पक्षांसह "
+"कधिही शेअर करणार नाही."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "सॉफ्टवेअर वापर आकडेवारि पाठवा (_S)"
+
+#: ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "गोपणीयता करार"
+
+#: ../panels/privacy/privacy.ui.h:42
+msgid "_Location Services"
+msgstr "लोकेशन सर्व्हिसेस (_L)"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "जिओग्राफिकल ठिकाण ओळखण्यासाठी वापरले जाते"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "इम्पिरिअल"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "मेट्रिक"
+
+#: ../panels/region/cc-format-chooser.c:284
+msgid "No regions found"
+msgstr "क्षेत्र आढळले नाही"
+
+#: ../panels/region/cc-input-chooser.c:179
+msgid "No input sources found"
+msgstr "इंपुट स्रोत आढळले नाही"
+
+#: ../panels/region/cc-input-chooser.c:1076
+msgctxt "Input Source"
+msgid "Other"
+msgstr "इतर"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:892
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "प्रभावी बदलकरिता सत्रला पुन्हा सुरू करणे आवश्यक आहे"
+
+#: ../panels/region/cc-region-panel.c:243
+#: ../panels/user-accounts/um-user-panel.c:896
+msgid "Restart Now"
+msgstr "आत्ता सुरू करा"
+
+#: ../panels/region/cc-region-panel.c:862
+msgid "No input source selected"
+msgstr "इंपुट स्रोत नीवडले नाही"
+
+#: ../panels/region/cc-region-panel.c:1092
+msgid "Sorry"
+msgstr "माफ करा"
+
+#: ../panels/region/cc-region-panel.c:1094
+msgid "Input methods can't be used on the login screen"
+msgstr "प्रवेश पडद्यावर इंपुट पद्धतींचा वापर शक्य नाही"
+
+#: ../panels/region/cc-region-panel.c:1731
+msgid "Login Screen"
+msgstr "प्रवेश पटल"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "रूपण"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "पूर्वावलोकन"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "दिनांक"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "वेळ"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "अंक"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "मोजमाप"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "पेपर"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "क्षेत्र व भाषा"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr "डिस्पले भाषा, रूपण, कळफलक मांडणी आणि इंपुट स्रोत नीवडा"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "भाषा;मांडणी;कळफलक;इंपुट;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "इंपुट स्रोत समाविष्ट करा"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "इंपुट स्रोत पर्याय"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Use the _same source for all windows"
+msgstr "सर्व पटलांकरिता समान स्रोतचा वापर करा (_s)"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Allow _different sources for each window"
+msgstr "प्रत्येक पटलकरीता वेगळे स्रोत स्वीकारा (_d)"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Keyboard Shortcuts"
+msgstr "कळफलक शार्टकट्स"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Switch to previous source"
+msgstr "मागील स्रोतचा वापर करा"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Switch to next source"
+msgstr "पुढच्या स्रोतचा वापर करा"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "कळफलक सेटिंग्जमध्ये या शॉर्टकट्सना बदलणे शक्य आहे"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Alternative switch to next source"
+msgstr "पुढील स्रोतकरिता वैकल्पिक स्वीच"
+
+#: ../panels/region/input-options.ui.h:12
+msgid "Left+Right Alt"
+msgstr "Left+Right Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "इंग्रजि (युनाइटेड किंगडम)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "युनाइटेड किंगडम"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "पर्याय"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"प्रणालीमध्ये प्रवेश करताना प्रवेश सेटिंग्ज सर्व वापरकर्त्यांसह वापरले जाते"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr "ठिकाण"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "वाचनखुणा"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr "इतर"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "ठिकाण पसंत करा"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+msgid "_OK"
+msgstr "ठीक आहे (_O)"
+
+#: ../panels/search/cc-search-panel.c:176
+msgid "No applications found"
+msgstr "ॲप्लिकेशन्स आढळले नाही"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "शोधा"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"क्रिया पूर्ववलोकनमध्ये कोणते ॲप्लिकेशन्स शोध परिणाम दाखवतात ते नियंत्रीत करा"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "सर्च;फाइंड;इंडेक्स;छुपे करा;गोपणीयता;परिणाम;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "ठिकाण शोधा"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "वर जा"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "खाली जा"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "पसंती"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "सुरू करा"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "बंद करा"
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "सुरू केले"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+msgctxt "service is active"
+msgid "Active"
+msgstr "सक्रीय"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "फोल्डर पसंत करा"
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "प्रत करा"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "शेअरिंग"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "इतरांशी काय शेअर करायचे ते नियंत्रीत करा"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"शेअर;शेअरिंग;एसएसएच;यजमान;नाव;दूरस्त;डेस्कटॉप;ब्ल्युटूथ;ओबेक्स;मिडीया;ऑडिओ;व्ह"
+"िडीओ;"
+"प्रतिमा;छायाचित्र;चित्रपट;सर्व्हर;रेंडरर;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "दूरस्त प्रवेश सुरू किंवा बंद करा"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "दूरस्त प्रवेश सुरू किंवा बंद करण्यासाठी ओळख पटवणे आवश्यक"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:299
+msgid "No networks selected for sharing"
+msgstr "शेअरिंगकरिता नेटवर्क्स पसंत केले नाही"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "नेटवर्क्स"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "ब्ल्युटूथ शेअरिंग"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"ब्ल्युटूथ शेअरिंग तुम्हाला इतर ब्ल्युटूथ समर्थीत साधनांसह फाइल्स शेअर "
+"करण्यासाठी परवानगी देते"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "फक्त विश्वासर्ह साधनांपासून प्राप्त करा"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "प्राप्य फाइल्सना डाउनलोड्ज फोल्डरमध्ये साठवा"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "संगणकाचे नाव"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "वैयक्तिक फाइल शेअरिंग"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "पडदा शेअरिंग"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "मिडीया शेअरिंग"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "दूरस्त प्रवेश"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "नेटवर्क प्रवेश नसल्यामुळे काही सर्व्हिसेस बंद केले जातात."
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"वैयक्तिक फाइल शेअरिंग तुम्हाला पब्लिक फोल्डरला आत्ताच्या नेटवर्कवरील: <a "
+"href=\"dav://%s\">dav://%s</a> याचा वापर करून इतरांशी शेअर करण्यासाठी परवानगी "
+"देते"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr "आवश्यक पासवर्ड"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"सेक्युर शेल आदेश:\n"
+"<a href=\"ssh %s\">ssh %s</a> याचा वापर करून रिमोट वापरकर्त्यांना जोडणीकरिता "
+"परवानगी द्या"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"अवलोकन किंवा पडदा नियंत्रीत करण्यासाठी दूरस्त वापरकर्त्यांना परवानगी द्या: <a "
+"href="
+"\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Allow Remote Control"
+msgstr "दूरस्त नियंत्रण स्वीकारा"
+
+#: ../panels/sharing/sharing.ui.h:21
+msgid "Password:"
+msgstr "पासवर्ड:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "पासवर्ड दाखवा"
+
+#: ../panels/sharing/sharing.ui.h:23
+msgid "Access Options"
+msgstr "प्रवेश पर्याय"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "नवीन जोडण्यांनी प्रवेशकरिता विनंती केली पाहिजे"
+
+#: ../panels/sharing/sharing.ui.h:25
+msgid "Require a password"
+msgstr "पासवर्ड आवश्यक"
+
+#: ../panels/sharing/sharing.ui.h:26
+msgid "Share music, photos and videos over the network."
+msgstr "नेटवर्कवरील संगीत, छायाचित्र आणि व्हिडीओज शेअर करा."
+
+#: ../panels/sharing/sharing.ui.h:27
+msgid "Folders"
+msgstr "फोल्डर्स"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "आवाज"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "आवाज स्तर, इंपुट्स, आउटपुट्स, आणि गजर आवाज बदलवा"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "कार्ड;माइक्रोफोन;वॉल्युम;फेड;बॅलेंस्;ब्ल्युटूथ;हेडसेट;ऑडिओ;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "बार्क"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "ड्रिप"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "ग्लास"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "सोनार"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "डावे"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "उजवे"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "पाठचे"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "पुढचे"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "किमान"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "कमाल"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "बॅलेंस (_B):"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "फेड (_F):"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "सबवूफर (_S):"
+
+#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:616
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "ॲम्प्लिफाय केले"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "प्रोफाइल (_P):"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u आउटपुट"
+msgstr[1] "%u आउटपुट"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u इंपुट"
+msgstr[1] "%u इंपुट"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "सिस्टम साऊंडस्"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "चाचणी स्पिकर्स (_T)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "पिक ओळखणे"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1509
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "नाव"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1528
+msgid "Device"
+msgstr "s साधन"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1591
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s करीता स्पिकरची ऊंची"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1649
+msgid "_Output volume:"
+msgstr "आऊटपुट वॉल्युम (_O):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "Output"
+msgstr "आऊटपुट"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1668
+msgid "C_hoose a device for sound output:"
+msgstr "साऊंड आऊटपुटकरीता साधन निवडा (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1693
+msgid "Settings for the selected device:"
+msgstr "निवडलेल्या साधनकरीता सेटिंग्स्:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "Input"
+msgstr "इंपुट"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "_Input volume:"
+msgstr "इंपुट वॉल्यूम (_I):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1734
+msgid "Input level:"
+msgstr "इंपुट स्तर:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1762
+msgid "C_hoose a device for sound input:"
+msgstr "साऊंड इंपुटकरीता साधन पसंत करा (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "Sound Effects"
+msgstr "साऊंड प्रभाव"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+msgid "_Alert volume:"
+msgstr "सतर्कता वॉल्युम (_A):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1809
+msgid "Applications"
+msgstr "ॲप्लिकेशन्स्"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1813
+msgid "No application is currently playing or recording audio."
+msgstr "ॲप्लिकेशन सध्या ऑडिओ चालवत किंवा रेकॉर्ड करत आहे."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "ब्लिटइन"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "साऊंड पसंती"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "इव्हेंट साऊंड चाचणी"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "पूर्वनिर्धारीत"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "थिम पासून"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:769
+msgid "C_hoose an alert sound:"
+msgstr "सावधानता आवाज पसंत करा (_h):"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "थांबवा"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "चाचणी"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "सबवूफर"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "मनपसंद"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "अवलोकन, ऐकणे, टाइप, पॉइंट आणि क्लिककरिता सोपे करा"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"किबोर्ड;माऊस;ॲलि;ॲक्सेसिबिलिटि;काँट्रास्ट;झूम;स्क्रीन;रिडर;टेक्स्ट;फाँट;आकार;ॲ"
+"क्सेसएक्स;"
+"स्किकि;किज;स्लो किज्;बाउंस;माऊस;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "नेहमी युनिवर्सल ॲक्सेस मेन्यु दाखवा (_A)"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "सिइंग"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "जास्त काँट्रास्ट (_H)"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "मोठे मजकूर (_L)"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "_Zoom"
+msgstr "मोठे करा (_Z)"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr "स्क्रीन रिडर (_R)"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "_Sound Keys"
+msgstr "आवाज किज (_S)"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "ऐकणे"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr "दृष्यास्पद गजर (_V)"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Screen _Keyboard"
+msgstr "स्क्रीन किबोर्ड (_K)"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "_Typing Assist (AccessX)"
+msgstr "टायपिंग असिस्ट (ॲक्सेसएक्स) (_T)"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Pointing & Clicking"
+msgstr "पॉईंटिंग आणि क्लिकिंग"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "_Mouse Keys"
+msgstr "माऊस किज (_M)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "क्लिक असिस्ट (_C)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "स्क्रीन रिडर"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "फोकस स्थानांतरित करत असताना स्क्रीन रिडर दाखविलेले मजकूर वाचते."
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Screen Reader"
+msgstr "स्क्रीन रिडर (_S)"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Sound Keys"
+msgstr "साउंड किज"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "Num लॉक किंवा Caps लॉक सुरू केल्यानंतर बीप द्या."
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "दृष्यास्पद सावधानता"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "फ्लॅशची चाचणी करा (_T)"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "गजर आवाज आढळल्यानंतर दृष्यास्पद निर्देशनचा वापर करा."
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Flash the _window title"
+msgstr "पटलाचे शीर्षक फ्लॅश करा (_w)"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Flash the entire _screen"
+msgstr "पडदाभर फ्लॅश करा (_s)"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Typing Assist"
+msgstr "टाइपिंग सहाय्यक"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "_Sticky Keys"
+msgstr "स्टीकी किज (_S)"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "मॉडिफायर किज्ची श्रृंखला यास कि जोडणी म्हणून वागवतो"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "दोन किज् एकाचवेळी दाबल्यास बंद करा (_D)"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifer key is pressed"
+msgstr "संपादकीय किल्ली दाबल्यावर बीप द्या (_m)"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "S_low Keys"
+msgstr "स्लो किज (_l)"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "कि दाबल्यावर व स्वीकारल्यावर विलंब प्रस्तुत करतो"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "स्वीकार विलंब (_c):"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "छोटे"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "स्लो किज् टाइपिंग विलंब"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "लांब"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Beep when a key is pr_essed"
+msgstr "कि दाबून ठेवल्यास बीप द्या (_e)"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Beep when a key is _accepted"
+msgstr "कि स्वीकारल्यास बीप द्या (_a)"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "कि नकारल्यास बीप द्या (_r)"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "_Bounce Keys"
+msgstr "बाऊंस किज (_B)"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "फास्ट ड्युप्लिकेट किप्रेसेस्कडे दुर्लक्ष करते"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "छोटे"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "बाऊंस किज् टाइपिंग विलंब"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "लांब"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Enable by Keyboard"
+msgstr "कळफलकनुरूप सुरू करा (_E)"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "किबोर्डपासून ॲसेसिबिलिटि गुणधर्म बंद किंवा सुरू करा"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "क्लिक असिस्ट"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "_Simulated Secondary Click"
+msgstr "दुसरी क्लिक सिम्युलेट केली (_S)"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "प्राथमीक बटन दाबून दुसरि क्लिक सुरू करा"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "secondary click"
+msgid "Short"
+msgstr "छोटे"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "सेकंड्रि क्लिक विलंब"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "लांब"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "_Hover Click"
+msgstr "होवर क्लिक (_H)"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "पॉईंटर एका जागेवर असल्यास क्लिक सुरू करा"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "उशीर (_e):"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "छोटे"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "लांब"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "मोशन थ्रेशोल्ड (_t):"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "छोटे"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "मोठे"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "छोटे"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ स्क्रीन"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ स्क्रीन"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ स्क्रीन"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "लांब"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "पडदाभर"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "शीर्ष भाग"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "तळ भाग"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "डावे भाग"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "उजवे भाग"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "झूम पर्याय"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "मोठे करा"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "मोठे करणे:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "माऊस कर्सर लागू करा"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "स्क्रीन भाग:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "मॅगनिफायर पडद्याच्या बाहेर जाते"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "मॅगनिफायर कर्सर केंद्रित ठेवा"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "मॅगनिफायर कर्सर अंतर्भुत माहिती पुश करतो"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "मॅनिफायर कर्सर अंतर्भुत माहितीसह हलतो"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "मॅगनिफायर ठिकाण:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "वर्धक"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "जाडी:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "बारीक"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "जाड"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "लांबी:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "रंग:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "क्रॉसहेर्स्:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "माऊस कर्सरला अतिव्याप्ति करते"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "क्रॉसहेर्स्"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "काळ्यावर पांढरे:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "उजळपणा:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "भिन्नता:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "रंग"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "काहिही नाही"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "पूर्ण"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "कमी"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "जास्त"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "कमी"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "जास्त"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "रंग प्रभाव:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "रंग प्रभाव"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "मानक"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "प्रशासक"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Full Name"
+msgstr "संपूर्ण नाव (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "खाते प्रकार (_T)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to set a password when they next login"
+msgstr "पुढील प्रवेशवेळी वापरकर्त्याला पासवर्ड सेट करण्यास परवानगी द्या"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "पासवर्ड आत्ता ठरवा"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "वैध करा (_V)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"या साधनावर वापरकरिता एंटरप्राइज प्रवेश अस्तित्वातील केंद्रीय व्यवस्थापीत "
+"वापरकर्ता खात्यांकरिता परवानगी देते"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "डोमैन (_D)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"एंटरप्राइज प्रवेश खाती समाविष्ट करण्यासाठी\n"
+"ऑनलाइन जा."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "एंटरप्राइज प्रवेश (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "वापरकर्ता समाविष्ट करा"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "नाव नोंदणी (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "डोमैन प्रशासक प्रवेश"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"एंटरप्राइज प्रवेशचा वापर करण्यासाठी, ह्या संगणकाला\n"
+"ह्या डोमैन अंतर्गत असणे आवश्यक आहे. कृपया नेटवर्क प्रशासकाने\n"
+"येथे डोमैन पासवर्ड द्या."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "प्रशासक नाव (_N)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "प्रशासक पासवर्ड"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "डावा अंगठा"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "डावे मधले बोट"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "डावे अंगठी बोट"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "डावे छोटे बोट"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "उजवा अंगठा"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "उजवे मधले बोट"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "उजवे अंगठी बोट"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "उजवे छोटे बोट"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:687
+msgid "Enable Fingerprint Login"
+msgstr "फिंगरप्रिन्ट प्रवेश कार्यान्वीत करा"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "उजवे तर्जनी बोट (_R)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "डावे तर्जनी बोट (_L)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "इतर बोट (_O):"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"तुमचा फिंगरप्रिन्ट यशस्वीरित्या साठविले गेले. फिंगरप्रिन्ट रिडीरचा वापर करून "
+"तुम्ही आता "
+"दाखल करू शकता."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "वापरकर्ते"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "वापरकर्ते समाविष्ट करा किंवा काढून टाका आणि पासवर्ड बदलवा"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "लॉगिन;नाव;फिंगरप्रिंट;अवतार;चिन्ह;फेस;पासवर्ड;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "प्रवेश इतिहास"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr "पासवर्ड बदलवा"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "बदल करा (_a)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "नवीन पासवर्ड वैध करा (_V)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "नवीन पासवर्ड (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "सध्याचे पासवर्ड (_P)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "वापरकर्ता खाते समाविष्ट करा"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "वापरकर्ता खाते काढून टाका"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "लॉगिन पर्याय"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "स्वयं प्रवेश (_u)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "फिंगरप्रिन्ट प्रवेश (_F)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "वापरकर्ता चिन्ह"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "भाषा (_L)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "मागील प्रवेश"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "वापरकर्ता खाते व्यवस्थापीत करा"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "वापरकर्ता डाटा बदलण्यासाठी ओळख पटवणे आवश्यक"
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "नवीन पासवर्ड जुण्यापेक्षा वेगळे पाहिजे."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "काही अक्षरे आणि संख्या बदलण्याचा प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "पासवर्डला बदलण्याचा थोडा आणखी प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "वापरकर्ता नाव विना, पासवर्ड जास्त मजबूत असू शकते."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "पासवर्डमध्ये नावाचा वापर करणे टाळा."
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "पासवर्डमध्ये समाविष्टीत काही शब्दांचा वापर टाळा."
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "काही वारंवार शब्दांचा वापर टाळा."
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "अस्तित्वातील शब्दांचे पुन्ह क्रमवारि टाळण्याचा प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "एकापेक्षा जास्त क्रमांकांच्या वापरकरिता प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "एकापेक्षा जास्त अप्परकेस अक्षरांच्या वापरकरिता प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "एकापेक्षा जास्त लोवरकेस अक्षरांच्या वापरकरिता प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "विशेष अक्षरे, जसे कि उच्चारण यांच्या वापरकरिता प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "अक्षरे, संख्या आणि उच्चारण उच्चारण यांच्या वापरकरिता प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "समान अक्षरांचा पुन्हा वापर टाळण्याचा प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"समान प्रकारचे अक्षर वारंवार टाळण्याचा प्रयत्न करा: तुम्हाला अक्षरे, क्रमांक "
+"आणि उच्चारण यांचा एकत्रीतपणे वापर करायची आवश्यकता आहे."
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 किंवा abcd सारखे क्रम टाळा."
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "जास्त अक्षरे, क्रमांक आणि चिन्ह समाविष्ट करण्याचा प्रयत्न करा."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr "अप्पर व लोअर केसचे मिश्रण करा आणि एक किंवा दोन संख्या वापरून पहा."
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+"चांगला पासवर्ड! जास्त अक्षरे, क्रमांक आणि उच्चारण समाविष्ट करून जास्त मजबूत "
+"करेल."
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "मजबूती: कमजोर"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "मजबूती: कमी"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "मजबूती: मध्यम"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "मजबूती: चांगली"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "मजबूती: जास्त"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "ओळख पटवणे अपयशी"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "नविन पासवर्ड खूप छोटे आहे"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "नविन पासवर्ड खूप सोपे आहे"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "जुणे व नविन पासवर्डस् एक समान आहे"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "नविन पासवर्ड आधिपासून नुकतेच वापरले आहे."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "नविन पासवर्डमध्ये संख्यीक किंवा विशेष अक्षरे पाहिजेत"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "जुणे आणि नविन पासवर्ड समान आहेत"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "सुरवातीला ओळखपटल्यामुळे पासवर्ड बदलले आहे!"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "नविन पासवर्डमध्ये एकापेक्षा जास्त अक्षरे समाविष्टीत नाही"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "अपरिचीत त्रुटी"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "खाते पुरवठाकर्ताच्या वेब पत्त्याशी जुळायला पाहिजे."
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "खाते समाविष्ट करण्यास अपयशी"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+msgid "Passwords do not match."
+msgstr "पासवर्ड जुळत नाही."
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr "खातेची नोंदणी करण्यास अपयशी"
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr "ह्या डोमैनसह ओळख पटवण्यासाठी समर्थीत मार्ग नाही"
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr "डोमैनशी जोडणी करण्यास अपयशी"
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"प्रवेश नाव अकार्यक्षम.\n"
+"कृपया पुनः प्रयत्न करा"
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"प्रवेश पासवर्ड अकार्यक्षम.\n"
+"कृपया पुनः प्रयत्न करा"
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr "डोमैनमध्ये प्रवेश करण्यास अपयशी"
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "डोमेन शोधणे अशक्य. कदाचीत शुद्धलेखन चुकिचे असेल?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:138
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"तुम्हाला साधन करीता प्रवेश नाही. तुमच्या प्रणाली प्रशासकाशी संपर्क करा."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:140
+msgid "The device is already in use."
+msgstr "साधन आधिपासूनच अस्तित्वात आहे."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid "An internal error occurred."
+msgstr "आंतरिक त्रुटी आढळली."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Enabled"
+msgstr "सुरू केले"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr "पंजीकृत फिंगरप्रिन्ट नष्ट करा?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr "फिंगरप्रिन्ट नष्ट करा (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"तुम्हाला पंजीकृत फिंगरप्रिन्ट नष्ट करायचे, तसे केल्यास फिंगरप्रिन्ट प्रवेश "
+"अकार्यान्वीत होईल?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:444
+msgid "Done!"
+msgstr "पूर्ण झाले!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:505
+#: ../panels/user-accounts/um-fingerprint-dialog.c:547
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' साधन करीता प्रवेश प्राप्त करणे अशक्य"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:588
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "'%s' साधन वर बोट द्वारे संकेत प्राप्य सुरू करणे अशक्य"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:638
+msgid "Could not access any fingerprint readers"
+msgstr "कुठलेही फिंगरप्रिन्ट रिडर करीता प्रवेश प्राप्त करण्यास अशक्य"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:639
+msgid "Please contact your system administrator for help."
+msgstr "कृपया मदत करीता तुमच्या प्रणली प्रशासकाशी संपर्क करा."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:721
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"फिंगरप्रिन्ट प्रवेश कार्यान्वीत करण्याकरीता, तुम्हाला '%s' साधनचा वापर करून "
+"एक "
+"फिंगरप्रिन्ट साठवावे लागेल."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:728
+msgid "Selecting finger"
+msgstr "बोट निवडले"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:729
+msgid "Enrolling fingerprints"
+msgstr "फिंगरप्रिंटस् एंरोल करत आहे"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "आजचा सपताह"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "मागील सपताह"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:631
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "सत्र समाप्त झाले"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "सत्र सुरू केले"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "कृपया इतर पासवर्ड निवडा."
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "कृपया सध्याचे पासवर्ड पुनः टाइप करा."
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "पासवर्ड बदलणे अशक्य"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "The passwords do not match."
+msgstr "पासवर्ड्ज जुळत नाही."
+
+#: ../panels/user-accounts/um-photo-dialog.c:219
+msgid "Browse for more pictures"
+msgstr "आणखी चित्रांकरीता तपासणी करा"
+
+#: ../panels/user-accounts/um-photo-dialog.c:453
+msgid "Disable image"
+msgstr "प्रतिमा बंद करा"
+
+#: ../panels/user-accounts/um-photo-dialog.c:471
+msgid "Take a photo…"
+msgstr "छायाचित्र घ्या..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:489
+msgid "Browse for more pictures…"
+msgstr "अधिक प्रतिमांकरिता संचारन करा..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:713
+#, c-format
+msgid "Used by %s"
+msgstr "%s तर्फे वापरले"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "या प्रकारच्या डोमेनशी स्व जुळणी अशक्य"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "या प्रकारचे डोमैन किंवा रिअल्म आढळले नाही"
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%2$s डोमैनकरीता %1$s प्रमाणे प्रवेश करणे अशक्य"
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr "अवैध पासवर्ड, कृपया पुनः प्रयत्न करा"
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "%s डोमैन: %s सह जोडणी अशक्य"
+
+#: ../panels/user-accounts/um-user-panel.c:198
+msgid "Other Accounts"
+msgstr "इतर खाते"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "Failed to delete user"
+msgstr "वापरकर्ता नष्ट करण्यास अपयशी"
+
+#: ../panels/user-accounts/um-user-panel.c:482
+msgid "You cannot delete your own account."
+msgstr "स्वतःचे खाते नष्ट करणे शक्य नाही."
+
+#: ../panels/user-accounts/um-user-panel.c:491
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ने अजूनही प्रवेश केले आहे"
+
+#: ../panels/user-accounts/um-user-panel.c:495
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"प्रवेश केले असताना वापरकर्त्याला नष्ट केल्याने प्रणालीला अस्थीर स्तरात जाऊ "
+"शकते."
+
+#: ../panels/user-accounts/um-user-panel.c:504
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "तुम्हाला %s's च्या फाइल्स् ठेवायचे?"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"वापरकर्ता खात्याला नष्ट करतेवेळी होम डिरेक्ट्री, मेल स्पूल व तात्पुर्ते "
+"फाइल्स् जपून ठेवणे शक्य "
+"आहे."
+
+#: ../panels/user-accounts/um-user-panel.c:511
+msgid "_Delete Files"
+msgstr "फाइल्स् नष्ट करा (_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:512
+msgid "_Keep Files"
+msgstr "फाइल्स् जपवून ठेवा (_K)"
+
+#: ../panels/user-accounts/um-user-panel.c:564
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "खाते बंद केले"
+
+#: ../panels/user-accounts/um-user-panel.c:572
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "पुढच्या प्रवेशवेळी सेट करा"
+
+#: ../panels/user-accounts/um-user-panel.c:575
+msgctxt "Password mode"
+msgid "None"
+msgstr "काहिच नाही"
+
+#: ../panels/user-accounts/um-user-panel.c:624
+msgid "Logged in"
+msgstr "प्रवेश केले"
+
+#: ../panels/user-accounts/um-user-panel.c:1071
+msgid "Failed to contact the accounts service"
+msgstr "खाते सर्व्हिससह संपर्क करणे अपयशी"
+
+#: ../panels/user-accounts/um-user-panel.c:1073
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "कृपया AccountService प्रतिष्ठापीत नाही व सुरू नाही याची खात्री करा."
+
+#: ../panels/user-accounts/um-user-panel.c:1114
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"बदल करण्यासाठी,\n"
+"पहिले * चिन्ह क्लिक करा"
+
+#: ../panels/user-accounts/um-user-panel.c:1152
+msgid "Create a user account"
+msgstr "वापरकर्ता खाते निर्माण करा"
+
+#: ../panels/user-accounts/um-user-panel.c:1163
+#: ../panels/user-accounts/um-user-panel.c:1475
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"वापरकर्ता खाते निर्माण करण्यासाठी,\n"
+"पहिले * क्लिक करा"
+
+#: ../panels/user-accounts/um-user-panel.c:1173
+msgid "Delete the selected user account"
+msgstr "निवडलेल्या वापरकर्त्याचे खाते नष्ट करा"
+
+#: ../panels/user-accounts/um-user-panel.c:1185
+#: ../panels/user-accounts/um-user-panel.c:1480
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"निवडलेले वापरकर्ता खाते नष्ट करण्यासाठी,\n"
+"पहिले * चिन्हावर क्लिक करा"
+
+#: ../panels/user-accounts/um-user-panel.c:1389
+msgid "My Account"
+msgstr "माझे खाते"
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+msgid "A user with the username '%s' already exists."
+msgstr "वापरकर्तानाव '%s' असलेले वापरकर्ता आधीपासूनच अस्तित्वात आहे."
+
+#: ../panels/user-accounts/um-utils.c:571
+#, c-format
+msgid "The username is too long."
+msgstr "वापरकर्तानाव खूप मोठे आहे."
+
+#: ../panels/user-accounts/um-utils.c:574
+msgid "The username cannot start with a '-'."
+msgstr "वापरकर्तानाव '-' सह सुरू होत नाही."
+
+#: ../panels/user-accounts/um-utils.c:577
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"वापरकर्तानावमध्ये फक्त खालील लोवर आणि अप्परकेस अक्षरे a-z, अकं आणि '.', '-' व "
+"'_' पैकी "
+"कुठलेही अक्षरे समाविष्टीत असू शकतात."
+
+#: ../panels/user-accounts/um-utils.c:581
+msgid "This will be used to name your home folder and can't be changed."
+msgstr "याचा वापर होम फोल्डरला नाव देण्याकरिता केले जाईल आणि बदलणे शक्य नाही."
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:831
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "मॅप बटने"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr "बटन्सला फंक्शन्स् करीता मॅप करा"
+
+#: ../panels/wacom/button-mapping.ui.h:4
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"शार्टकट संपादित करण्यासाठी, \"किस्ट्रोक पाठवा\" कृती पसंत करा, कळफल शार्टकट "
+"बटन दाबा "
+"आणि नवीन किज दाबून ठेवा किंवा नष्ट करण्यासाठी बॅकस्पेस दाबा."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "टॅबलेट कॅलिब्रेट करण्यासाठी कृपया लक्ष्य मार्कर्स् टॅप करा."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "अयोग्यक्लिक आढळले, पुनः सुरू करत आहे..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "वर"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "खाली"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "काहिच नाही"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "सेंड किस्ट्रोक्"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "मॉनिटर बदला"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "ऑन-स्क्रीन मदत दाखवा"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "आऊटपुट:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "ॲस्पेक्ट प्रमाण जपवा (लेटरबॉक्स्):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "एकमेव मॉनिटरकरीता मॅप करा"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d, %d पैकी"
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "मॅपिंग दाखवा"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "बटन"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Wacom Tablet"
+msgstr "वॅकॉम टॅबलेट"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"ग्राफिक्स टॅबलेट्सकरिता बटन मॅपिंग्ज ठरवा आणि स्टाइलस संवेदनशीलता आयोजीत करा"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "टॅबलेट;वॅकॉम;स्टायलस;इरेजर;माऊस;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "टॅबलेट (ॲबसोल्युट)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "टचपॅड (रिलेटिव्ह)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "टॅबलेट पसंती"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "No tablet detected"
+msgstr "टॅबलेट आढळले नाही"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "कृपया वॅकॉम टॅबलेट प्लग इन करा किंवा सुरू करा"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Bluetooth Settings"
+msgstr "ब्ल्युटूथ सेटिंग्स्"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map to Monitor…"
+msgstr "मॉनिटरकरिता मॅप करा..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map Buttons…"
+msgstr "मॅप बटन्स…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust display resolution"
+msgstr "डिस्पले रेजॉल्युशन सुस्थित करा"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust mouse settings"
+msgstr "माऊस सेटिंग्ज समायोजित करा"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Tracking Mode"
+msgstr "ट्रॅकिंग मोड"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Left-Handed Orientation"
+msgstr "डाव्या-हाताचे निर्देशन"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+msgid "Left Ring"
+msgstr "डावे रिंग"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "डावे रिंग मोड #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+msgid "Right Ring"
+msgstr "उजवे रिंग"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "उजवे रिंग मोड #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+msgid "Left Touchstrip"
+msgstr "डावे टचस्ट्रिप"
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "डावे टचस्ट्रिप मोड #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+msgid "Right Touchstrip"
+msgstr "ऊजवे टचस्ट्रिप"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "ऊजवे टचस्ट्रिप मोड #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "डावे टचरिंग मोड स्विच्"
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "ऊजवे टचरिंग मोड स्विच्"
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "डावे टचस्ट्रिप मोड स्विच्"
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "ऊजवे टचस्ट्रिप मोड स्विच्"
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "मोड स्विच् #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr "डावे बटन #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr "ऊजवे बटन #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr "शीर्ष बटन #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "तळ बटन #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "नवीन शार्टकट…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "कृती नाही"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "डावे माऊस बटन क्लिक"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "मध्यम माउस बटन क्लिक"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "उजवे माऊस बटन क्लिक"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "वर सरकवा"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "खाली सरकवा"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "डावीकडे सरकवा"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "उजवीकडे सरकवा"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "मागे"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "पुढे"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "स्टायलस्"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "इरेजर प्रेशर फिल"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "मऊ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "घट्ट"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "शीर्ष बटन"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "खालचे बटन"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "टिप प्रेशर फिल"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "बर्बोस् मोड सुरू करा"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "पूर्वावलोकन दाखवा"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "स्ट्रिंगकरिता शोधा"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "संभाव्य पटलांचे नावे दाखवा आणि बाहेर पडा"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "मदत पर्याय दार्शवा"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "दाखवण्याजोगी पटल"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[पटल] [बाब…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- सेटिंग्ज"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"उपलब्ध आदेश ओळ पर्यायांची संपूर्ण सूची पहाण्यासाठी '%s --help' चालवा.\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "उपलब्ध पटल:"
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "मदत"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "बाहेर पडा"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+msgid "All Settings"
+msgstr "सर्व सेटिंग्स्"
+
+#. Add categories
+#: ../shell/cc-window.c:876
+msgctxt "category"
+msgid "Personal"
+msgstr "वैयक्तिक"
+
+#: ../shell/cc-window.c:877
+msgctxt "category"
+msgid "Hardware"
+msgstr "हार्डवेअर"
+
+#: ../shell/cc-window.c:878
+msgctxt "category"
+msgid "System"
+msgstr "प्रणाली"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "पसंती;सेटिंग्स्;"
+
+#~ msgid "Flickr"
+#~ msgstr "फ्लिकर"
+
+#~ msgid "Change the background"
+#~ msgstr "पार्श्वभूमी बदला"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "ब्ल्युटूथ सेटिंग्स् संरचीत करा"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "नविन साधनची मांडणी करा"
+
+#~ msgid "Connection"
+#~ msgstr "जोडणी"
+
+#~ msgid "Paired"
+#~ msgstr "जोड"
+
+#~ msgid "Type"
+#~ msgstr "प्रकार"
+
+#~ msgid "Mouse and Touchpad Settings"
+#~ msgstr "माऊस व टचपॅड सेटिंग्स्"
+
+#~ msgid "Sound Settings"
+#~ msgstr "साऊंड सेटिंग्स्"
+
+#~ msgid "Send Files..."
+#~ msgstr "फाइल्स् पाठवा..."
+
+#~ msgid "Browse Files..."
+#~ msgstr "फाइल्स् तपासणी करा..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "ब्ल्युटूथ"
+
+#~ msgid "Visibility"
+#~ msgstr "दर्शनक्षमता"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” ची दर्शनक्षमता"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "साधनाच्या सूचीतून '%s' काढून टाकायचे?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr "साधन काढून टाकल्यास, पुढील वापरपूर्वी तुम्हाला पुनः सेटअप करावे लागेल."
+
+#~ msgid "Create virtual device"
+#~ msgstr "वर्च्युअल साधन निर्माण करा"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "डिस्पलेकरीता उपलब्ध प्रोफाइल्स्"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "स्कॅनर्सकरीता उपलब्ध प्रोफाइल्स्"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "छापाईयंत्रकरीता उपलब्ध प्रोफाइल्स्"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "कॅमेराजकरीता उपलब्ध प्रोफाइल्स्"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "वेबकॅम्सकरीता उपलब्ध प्रोफाइल्स्"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i वर्ष"
+#~ msgstr[1] "%i वर्ष"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i महिना"
+#~ msgstr[1] "%i महिने"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i सप्ताह"
+#~ msgstr[1] "%i सप्ताह"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "1 सप्ताहपेक्षा कमी"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "साधन रंग व्यवस्थापीत नाही."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "हे साधन मॅनिफॅक्चरिंग कॅलिब्रेटेड डाटाचा वापर करत आहे."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "पूर्णपडदाभर रंग सुधारणाकरीता या साधनकडे योग्य प्रोफाइल नाही."
+
+#~ msgid "Not specified"
+#~ msgstr "निर्देशीत नाही"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "रंग व्यवस्थापनकरीता समर्थन पुरवणारे साधने आढळले नाही"
+
+#~ msgid "Add device"
+#~ msgstr "डिव्हाइस समाविष्ट करा"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "वर्च्युअल डिव्हाइस समाविष्ट करा "
+
+#~ msgid "Remove a device"
+#~ msgstr "डिव्हाइस काढून टाका"
+
+#~ msgid "Device type:"
+#~ msgstr "डिव्हाइस प्रकार:"
+
+#~ msgid "Model:"
+#~ msgstr "मॉडल:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "वरील क्षेत्रांना स्वयं-पूर्ण करण्यासाठी प्रतिमा फाइल्स्ला या पटलावर ओढणे शक्य आहे."
+
+#~ msgid "Color management settings"
+#~ msgstr "रंग व्यवस्थापन सेटिंग्स्"
+
+#~ msgid "English"
+#~ msgstr "इंग्रजी"
+
+#~ msgid "British English"
+#~ msgstr "ब्रिटिश इंग्लिश"
+
+#~ msgid "German"
+#~ msgstr "जर्मन "
+
+#~ msgid "French"
+#~ msgstr "फ्रेंच"
+
+#~ msgid "Spanish"
+#~ msgstr "स्पॅनिश"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "चायनिज (सिम्प्लिफाइड)"
+
+#~ msgid "Russian"
+#~ msgstr "रशिअन"
+
+#~ msgid "Arabic"
+#~ msgstr "अरेबिक"
+
+#~ msgid "Select a region"
+#~ msgstr "क्षेत्र निवडा"
+
+#~ msgid "Unspecified"
+#~ msgstr "विनानिर्देशीत"
+
+#~ msgid "Select a language"
+#~ msgstr "भाषा निवडा"
+
+#~ msgid "_Select"
+#~ msgstr "निवडा(_S)"
+
+#~ msgid "_Region:"
+#~ msgstr "क्षेत्र (_R):"
+
+#~ msgid "_City:"
+#~ msgstr "शहर (_i):"
+
+#~ msgid "_Network Time"
+#~ msgstr "नेटवर्क वेळ (_N)"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "वेळ एक तास पुढे ठरवा."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "वेळ एक तास मागे निश्चित करा."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "वेळ एक मिनिट पुढे ठरवा."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "वेळ एक मिनिट मागे ठरवा."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM व PM चा वापर करा."
+
+#~ msgid "AM/PM"
+#~ msgstr "AM किंवा PM"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "दिनांक व वेळ पसंती पटल"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "सामान्य"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "घड्याळीच्या उलट दिशेने"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "घड्याळीच्या दिशेने"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 डिग्रिज्"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "प्राथमिक डिस्पले बदलण्यासाठी ओढा."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "गुणधर्म बदलण्यासाठी मॉनिटर निवडा; प्लेसमेंट पुनःसुस्थित करण्यासाठी ओढा."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "मॉनीटर संयोजना साठवू शकणे शक्य नाही"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "दृष्य ओळखू शकण्यास अशक्य"
+
+#~ msgid "_Resolution"
+#~ msgstr "रेजोल्यूशन (_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "चक्राकार (_o)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "मिरर डिस्पलेज् (_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "टिप: रेजोल्युशन पर्याय मर्यादित करेल"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "डिस्पलेज् ओळखा (_D)"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "अपरिचीत मॉडल"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "पुढील लॉगिन मानक अनुभव वापर करण्यासाचा प्रयत्न करेल."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr "असमर्थीत ग्राफिक्स् हार्डवेअरकरीता पुढील प्रवेश फॉलबॅक मोडचा वापर करेल."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "फॉलबॅक"
+
+#~ msgid "Install Updates"
+#~ msgstr "सुधारणा प्रतिष्ठापीत करा"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "सिस्टम अप्टूडेट"
+
+#~ msgid "System Information"
+#~ msgstr "प्रणाली माहिती"
+
+#~ msgid "OS type"
+#~ msgstr "OS प्रकार"
+
+#~ msgid "_Other Media..."
+#~ msgstr "इतर मिडीया (_O)..."
+
+#~ msgid "Experience"
+#~ msgstr "अनुभव"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "फॉलबॅक मोड जबरनपणे लागू केले (_F)"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "कळफलक सेटिंग्स् बदला"
+
+#~ msgid "Layout Settings"
+#~ msgstr "मांडणी सेटिंग्स्"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "माऊस व टचपॅड पसंती ठरवा"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "अंतर्भुत माहिती बोटांना चिटकते (_o)"
+
+#~ msgid "Network settings"
+#~ msgstr "नेटवर्क सेटिंग्स्"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "नेटवर्क;वायरलेस;IP;LAN;प्रॉक्सी;"
+
+#~ msgid "Out of range"
+#~ msgstr "व्याप्तिच्या बाहेर"
+
+#~ msgid "_Options..."
+#~ msgstr "पर्याय (_O)..."
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "नविन सर्व्हिसकरीता वापरण्याजोगी इंटरफेस निवडा"
+
+#~ msgid "C_reate..."
+#~ msgstr "निर्माण करा (_r)..."
+
+#~ msgid "_Interface"
+#~ msgstr "दुवा (_I)"
+
+#~ msgid "_Configure..."
+#~ msgstr "संरचीत करा (_C)..."
+
+#~ msgid "Wireless"
+#~ msgstr "वायरलेस"
+
+#~| msgid "Disconnected"
+#~ msgid "_Disconnect"
+#~ msgstr "खंडीत करा (_D)"
+
+#~ msgid "_Connect"
+#~ msgstr "जोडणी करा (_C)"
+
+#~ msgid "Mesh"
+#~ msgstr "मेश"
+
+#~ msgid "Disconnected"
+#~ msgstr "खंडीत"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "कॅरिअर किंवा दुवा बदलले"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "श्रेय वेळसमाप्ति. कृपया पुनः प्रवेश करा."
+
+#~ msgid "_Log In"
+#~ msgstr "प्रवेश करा (_L)"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "ऑनलाइन खाते व्यवस्थापीत करा"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "सावधानता कमी बॅटरि, %s उर्वरित"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "बॅटरि पावरचा वापर करत आहे - %s उर्वरित"
+
+#~ msgid "Using battery power"
+#~ msgstr "बॅटरि पावरचा वापर करत आहे"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "चार्ज करत आहे - पूर्णतया चार्ज केले"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "UPS पावरचा वापर करत आहे - %s उर्वरित"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "सावधानता कमी UPS"
+
+#~ msgid "Using UPS power"
+#~ msgstr "UPS पावरचा वापर करत आहे"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "दुसरी बॅटरि पूर्णपणे चार्ज झाली आहे"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "दुसरि बॅटरि रिकामी आहे"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "चार्ज करत आहे - पूर्णतया चार्ज केले"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "टिप: <a href=\"screen\">स्क्रीन तेजपणा</a> प्रभाव किती पावर वापरली ते दाखवतो"
+
+#~ msgid "Power management settings"
+#~ msgstr "पावर व्यवस्थापन सेटिंग्स्"
+
+#~ msgid "Don't suspend"
+#~ msgstr "सस्पेंड करू नका"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "ठराविक वेळकरीता निष्क्रीय असल्यास सस्पेंड करा"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "थांबले"
+
+#~ msgid "Change printer settings"
+#~ msgstr "छपाईयंत्रच्या सेटिंग्स् बदला"
+
+#~ msgid "Manufacturers"
+#~ msgstr "उत्पादक"
+
+#~ msgid "Drivers"
+#~ msgstr "ड्राइव्हर्स्"
+
+#~ msgid "_Default"
+#~ msgstr "पूर्वनिर्धारीत (_D)"
+
+#~ msgid "_Show"
+#~ msgstr "दाखवा (_S)"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "क्षेत्र व भाषा सेटिंग्स् बदला"
+
+#~ msgid "Choose an input source"
+#~ msgstr "इंपुट स्रोत नीवडा"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "समाविष्ट करण्यासाठी इंपुट स्रोत निवडा"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "प्रवेश पडदा, प्रणाली खाते व नविन वापरकर्ता खाते प्रणालीभर क्षेत्र व भाषा सेटिंग्स्चा "
+#~ "वापर करतात."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "प्रवेश पडदा, प्रणाली खाते व नविन वापरकर्ता खाते प्रणालीभर क्षेत्र व भाषा सेटिंग्स्चा "
+#~ "वापर करतात. जोडणीकरीता प्रणाली सेटिंग्स् बदलणे शक्य आहे."
+
+#~ msgid "Copy Settings"
+#~ msgstr "सेटिंग्स्चे प्रत बनवा"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "सेटिंग्स्चे प्रत बनवा..."
+
+#~ msgid "Region and Language"
+#~ msgstr "क्षेत्र व भाषा"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr "डिस्पले भाषा निवडा (पुढच्यावेळी प्रवेश करताना बदल लागू होतिल)"
+
+#~ msgid "Add Language"
+#~ msgstr "भाषा समाविष्ट करा"
+
+#~ msgid "Remove Language"
+#~ msgstr "भाषा काढून टाका"
+
+#~ msgid "Install languages..."
+#~ msgstr "भाषा प्रतिष्ठापीत करा..."
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "क्षेत्र निवडा (पुढच्यावेळी प्रवेश केल्यावर बदल लागू होतील)"
+
+#~ msgid "Add Region"
+#~ msgstr "क्षेत्र समाविष्ट करा"
+
+#~ msgid "Currency"
+#~ msgstr "चलन"
+
+#~ msgid "Examples"
+#~ msgstr "उदाहरण"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "किबोर्ड किंवा इतर इनपुट स्रोत नीवडा"
+
+#~ msgid "Remove Input Source"
+#~ msgstr "इंपुट स्रोत काढून टाका"
+
+#~ msgid "Move Input Source Up"
+#~ msgstr "इंपुट स्रोत स्थानांतरीत करा"
+
+#~ msgid "Show Keyboard Layout"
+#~ msgstr "किबोर्ड लेआऊट दाखवा"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "शॉर्टकट सेटिंग्स्"
+
+#~ msgid "Display language:"
+#~ msgstr "भाषा दाखवा:"
+
+#~ msgid "Input source:"
+#~ msgstr "इंपुट स्रोत:"
+
+#~ msgid "Format:"
+#~ msgstr "रूपण:"
+
+#~ msgid "Your settings"
+#~ msgstr "तुमच्या सेटिंग्स्"
+
+#~ msgid "System settings"
+#~ msgstr "सिस्टम सेटिंग्स्"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "उजळपणा व कुलूपबंद"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "पडद्याचा उजळपणा व कुलूपबंद सेटिंग्स्"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "उजळपणा;लॉक;डिम;रिकामे;मॉनिटर;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "पावर साठवण्याकरीता पडदा डिम करा (_D)"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "घरी असल्यास कुलूपबंद करू नका"
+
+#~ msgid "Locations..."
+#~ msgstr "ठिकाणे..."
+
+#~ msgid "Lock"
+#~ msgstr "कुलूपबंद"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "डीबगींग कोड कार्यान्वीत करा"
+
+#~ msgid "Version of this application"
+#~ msgstr "या ॲप्लिकेशनची आवृत्ती"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME वॉल्युम कंट्रोल ॲप्लेट"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "डेस्कटॉप वॉल्युम कंट्रोल दाखवा"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "साऊंड आऊटपुट वॉल्युम"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "माइक्रोफोन वॉल्युम"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "साऊंड पसंती: %s सुरू करण्यास अपयशी"
+
+#~ msgid "_Mute"
+#~ msgstr "मंद करा (_M)"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "साऊंड पसंती (_S)"
+
+#~ msgid "Muted"
+#~ msgstr "मंद केले"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "युनिवर्सल ॲक्सेस पसंती"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "सामान्य"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "हाय/इंवर्स"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "ऑनस्क्रीन किबोर्ड"
+
+#~ msgid "OnBoard"
+#~ msgstr "ऑबोर्ड"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Small"
+#~ msgstr "लहान"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "सामान्य"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Large"
+#~ msgstr "मोठे"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "इतरांपेक्षा मोठे"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "कॅप्स् व नम लॉक वापरतेवेळी बिप द्या"
+
+#~ msgid "Options..."
+#~ msgstr "पर्याय..."
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "मोठे करा"
+
+#~ msgid "Zoom in:"
+#~ msgstr "मोठे करा:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "लहान करा:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "क्लोस्ड् कॅप्शनिंग"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "स्पीच व साऊंडस्चे मजकूर वर्णन दाखवा"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "कि दाबल्यावर बीप द्या"
+
+#~ msgid "pressed"
+#~ msgstr "दाबले"
+
+#~ msgid "accepted"
+#~ msgstr "स्वीकारले"
+
+#~ msgid "rejected"
+#~ msgstr "नकारले"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "स्वीकार विलंब (_e):"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "किपॅडचा वापर करून पॉईंटर नियंत्रीत करा"
+
+#~ msgid "Video Mouse"
+#~ msgstr "व्हिडीओ माऊस"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "व्हिडीओ कॅमेराचा वापर करून पॉईंटर नियंत्रीत करा."
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "रंग"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "काहिच नाही"
+
+#~ msgid "Add account"
+#~ msgstr "खाते समाविष्ट करा"
+
+#~ msgid "_Local Account"
+#~ msgstr "माझे खाते"
+
+#~ msgid "_Login Name"
+#~ msgstr "प्रवेश नाव (_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "टिप: एंटरप्राइज डोमैन किंवा रिअल्म नाव"
+
+#~ msgid "C_ontinue"
+#~ msgstr "सुरू ठेवा (_o)"
+
+#~ msgid "User Accounts"
+#~ msgstr "वापरकर्ता खाते"
+
+#~ msgid "Log in without a password"
+#~ msgstr "पासवर्डविना प्रवेश करा"
+
+#~ msgid "Disable this account"
+#~ msgstr "हे खाते बंद करा"
+
+#~ msgid "_Hint"
+#~ msgstr "हिंट (_H)"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "हि हिंट लॉगिन स्क्रीनवर दाखवणे शक्य आहे.  हे प्रणालीतील प्रत्येक वापरकर्त्यांना दृष्यास्पद "
+#~ "होईल.  येथे पासवर्ड समाविष्ट करू <b>नका</b>."
+
+#~ msgid "C_onfirm password"
+#~ msgstr "पासवर्डची खात्री करा (_o)"
+
+#~ msgid "Fair"
+#~ msgstr "सुरेख"
+
+#~ msgid "_Action"
+#~ msgstr "कृती (_A)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "मजबूत पासवर्ड कसे निवडायचे"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "याकरीता फोटो बदलत आहे:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "या खात्याकरीता लॉगीन पडद्यावर दाखवण्याजोगी चित्र निवडा."
+
+#~ msgid "Gallery"
+#~ msgstr "दालन"
+
+#~ msgid "Take a photograph"
+#~ msgstr "छायाचित्र घेत आहे"
+
+#~ msgid "Browse"
+#~ msgstr "तपासणी करा"
+
+#~ msgid "Photograph"
+#~ msgstr "छायाचित्र"
+
+#~ msgid "Account Information"
+#~ msgstr "माहिती नाही"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "खूप छोटे आहे"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "ठिक आहे"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "कमजोर"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "सुरेख"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "चांगले"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "मजबूत"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "पुन्हा नविन पासवर्ड द्या"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "पासवर्डची खात्री करा"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "सध्याचे पासवर्ड देणे आवश्यक आहे"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "सध्याचे पासवर्ड अयोग्य आहे"
+
+#~ msgid "Wrong password"
+#~ msgstr "चुकिचे पासवर्ड"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "आणखी चित्रांकरीता तपासणी करा..."
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "नाव '%s' सह वापरकर्तानाव अस्तित्वात नाही"
+
+#~ msgid "This user does not exist."
+#~ msgstr "हा वापरकर्ता अस्तित्वात नाही."
+
+#~ msgid "Switch Modes"
+#~ msgstr "मोडस् बदला"
+
+#~ msgid "Action"
+#~ msgstr "क्रिया"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "वॅकॉम टॅबलेट पसंती"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "मॅप बटन्स्..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "कॅलिब्रेट..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- सिस्टम सेटिंग्स्"
+
+#~ msgid "Control Center"
+#~ msgstr "नियंत्रण केंद्र"
+
+#~ msgid "System Settings"
+#~ msgstr "सिस्टम सेटिंग्स्"
+
+#~ msgid "Security Key"
+#~ msgstr "सुरक्षा किज्"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "सबनेट मास्क"
+
+#~| msgid "Add Wallpaper"
+#~ msgid "Add wallpaper"
+#~ msgstr "वॉलपेपर समाविष्ट करा"
+
+#~| msgid "Add Wallpaper"
+#~ msgid "Remove wallpaper"
+#~ msgstr "वॉलपेपर काढून टाका"
+
+#~| msgid "Solid color"
+#~ msgid "Swap colors"
+#~ msgstr "रंग बदला"
+
+#~| msgid "Horizontal gradient"
+#~ msgid "Horizontal Gradient"
+#~ msgstr "आडवे ग्रेडीएंट"
+
+#~| msgid "Vertical gradient"
+#~ msgid "Vertical Gradient"
+#~ msgstr "उभे ग्रेडीएंट"
+
+#~| msgid "Solid color"
+#~ msgid "Solid Color"
+#~ msgstr "गडद रंग"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "रंग व ग्रेडिएंट"
+
+#~| msgid "Take a break!"
+#~ msgid "Take a screenshot"
+#~ msgstr "स्क्रीनशॉट घ्या"
+
+#~ msgid "Shortcut"
+#~ msgstr "शॉर्टकट"
+
+#~ msgid "_Right-handed"
+#~ msgstr "उजवी हाताळणी (_R)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "डावी-हाताळणी (_L)"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Control कळ दाबल्यास पॉईंटरची स्थिती दाखवा (_o)"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "गतिकता (_c):"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "संवेदनशीलता(_S):"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "ओढा व टाका"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "मर्यादीत मूल्य (_e):"
+
+#~| msgid "Thr_eshold:"
+#~ msgid "Drag Threshold"
+#~ msgstr "ड्रॅग थ्रेशहोल्ड"
+
+#~ msgid "Double-Click Timeout"
+#~ msgstr "डबल-क्लिक् वेळ समाप्ती"
+
+#~ msgid "_Timeout:"
+#~ msgstr "कालबाद(_T):"
+
+#~| msgid ""
+#~| "To test your double-click settings, try to double-click on the light "
+#~| "bulb."
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "सेटिंग्स्च्या तपासणीकरीता, फेसवर दोनवेळा क्लिक करा."
+
+#~| msgid "Enable mouse _clicks with touchpad"
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "टचपॅडसह माऊस क्लिक्स् सुरू करा (_m)"
+
+#~ msgid "Scrolling"
+#~ msgstr "स्क्रोल करत आहे"
+
+#~ msgid "_Disabled"
+#~ msgstr "अकार्यक्षम केले (_D)"
+
+#~ msgid "A_ddress:"
+#~ msgstr "पत्ता(_d):"
+
+#~ msgid "_Search by Address"
+#~ msgstr "पत्तातर्फे शोधा (_S)"
+
+#~ msgid "Getting devices..."
+#~ msgstr "साधने प्राप्त करत आहे..."
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD सुरू नाही. नेटवर्क छपाईयंत्र ओळखण्यासाठी फायरवॉलवरील mdns, ipp, ipp-"
+#~ "client व samba-client सर्व्हिसेस् सुरू करणे आवश्यक आहे."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "स्थानीय"
+
+#~| msgid "Network Proxy"
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "नेटवर्क"
+
+#~ msgid "Device types"
+#~ msgstr "डिव्हाइस प्रकार"
+
+#~| msgid "<b>_Automatic proxy configuration</b>"
+#~ msgid "Automatic configuration"
+#~ msgstr "स्वयं संरचना"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "mDNS जोडणींकरीता फायरवॉल उघडत आहे"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "साम्बा जोडणींकरीता फायरवॉल उघडत आहे"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "IPP जोडणींकरीता फायरवॉल उघडत आहे"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "संरचनाकरीता साधन पसंत करा (_h):"
+
+#~ msgid "Dasher"
+#~ msgstr "डॅशर"
+
+#~ msgid "Nomon"
+#~ msgstr "नोमोन"
+
+#~ msgid "Caribou"
+#~ msgstr "कारिबौ"
+
+#~ msgid "Account _type"
+#~ msgstr "खाते प्रकार (_t)"
+
+#~ msgid "Current network location"
+#~ msgstr "सध्याचे नेटवर्क ठिकाण"
+
+#~ msgid "More themes URL"
+#~ msgstr "एकापेक्षाजास्त योजनाचे URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "यांस सध्याच्या ठिकाण नावाशी सेट करा. याचा वापर योग्य नेटवर्क प्रॉक्सी संयोजना "
+#~ "ओळखण्यासाठी केला जातो."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "आणखी डेस्कटॉप पार्श्वभूमी प्राप्त करण्यासाठी URL. रिकामे अक्षरसंच करीता सेट केल्यास दुवा "
+#~ "आढळणार नाही."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "आणखी डेस्कटॉप योजना प्राप्त करण्यासाठी URL. रिकामे अक्षरसंच करीता सेट केल्यास दुवा "
+#~ "आढळणार नाही."
+
+#~ msgid "Image/label border"
+#~ msgstr "प्रतिमा/लेबल सीमा"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "रुंदी चा लेबल आणि प्रतिमा सतर्क संवाद"
+
+#~ msgid "The type of alert"
+#~ msgstr "सतर्कतेचा प्रकार"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "सतर्क संवादात दाखवलेली बटने"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "तुमचा डावीकडील आंगठा %s वर ठेवा"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "तुमचा डावीकडील आंगठा %s वर फटकारा"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "तुमची डावीकडील तर्जनी %s वर ठेवा"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "तुमची डावीकडील तर्जनी %s वर फटकारा"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "तुमचे डावीकडील मधले बोट %s वर ठेवा"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "तुमचे डावीकडील मधले बोट %s वर फटकारा"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "तुमचे डावीकडील अंगठी बोट %s वर ठेवा"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "तुमचे डावीकडील अंगठी बोट %s वर फटकारा"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "तुमचे डावीकडील लहान बोट %s वर ठेवा"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "तुमचे डावीकडील लहान बोट %s वर फटकारा"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "तुमचा उजवीकडील आंगठा %s वर ठेवा"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "तुमचा उजवीकडील आंगठा %s वर फटकारा"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "तुमची उजवीकडील तर्जनी %s वर ठेवा"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "तुमची उजवीकडील तर्जनी %s वर फटकारा"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "तुमचे उजवीकडील मधले बोट %s वर ठेवा"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "तुमचे उजवीकडील मधले बोट %s वर फटकारा"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "तुमचे उजवीकडील अंगठी बोट %s वर ठेवा"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "तुमचे उजवीकडील अंगठी बोट %s वर फटकारा"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "तुमचे उजवीकडील लहान बोट %s वर ठेवा"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "तुमचे उजवीकडील लहान बोट %s वर फटकारा"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "तुमचा बोट रिडर पुन्हा ठेवा"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "बोट पुन्हा फटकारा"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "फटकारणे कालावधी लहान होते, पुन्हा प्रयत्न करा"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "तुमचे बोट मध्य भागी नव्हते, बोट पुन्हा फटकरण्याचा प्रयत्न करा"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "बोट हटवा, व बोट पुन्हा फटकरण्याचा प्रयत्न करा"
+
+#~ msgid "No Image"
+#~ msgstr "प्रतिमा नाही"
+
+#~ msgid "Images"
+#~ msgstr "प्रतिमा"
+
+#~ msgid "All Files"
+#~ msgstr "सर्व फाइली"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "पुस्तिका माहिती प्राप्त करतेवेळी त्रुटी आढळली\n"
+#~ "Evolution माहिती सर्वर शिष्टाचार हाताळू शकत नाही"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "पत्ता वही उघडण्यास असमर्थ"
+
+#~ msgid "About %s"
+#~ msgstr "%s च्या विषयी"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "AIM/iChat (_I):"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "सहाय्यक (_s):"
+
+#~ msgid "About Me"
+#~ msgstr "माझ्या विषयी"
+
+#~ msgid "C_ompany:"
+#~ msgstr "कंपनी (_o):"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "पासवर्ड बदला(_r)..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "शहर(_t):"
+
+#~ msgid "Co_untry:"
+#~ msgstr "देश (_u):"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "देश (_n):"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "फिंगरप्रिन्ट प्रवेश अकार्यान्वीत करा (_F)..."
+
+#~ msgid "Email"
+#~ msgstr "ईमेल"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "फिंगरप्रिन्ट प्रवेश कार्यान्वीत करा (_F)..."
+
+#~ msgid "Hom_e:"
+#~ msgstr "मुख्य (_e):"
+
+#~ msgid "IC_Q:"
+#~ msgstr "ICQ (_Q):"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "तात्काळ संदेशवाहन"
+
+#~ msgid "M_SN:"
+#~ msgstr "MSN (_S):"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. बॉक्स (_b):"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P.O. बॉक्स (_O):"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "राज्य/प्रांत (_v):"
+
+#~ msgid "Web"
+#~ msgstr "वेब"
+
+#~ msgid "Web _log:"
+#~ msgstr "वेब लॉग (_l):"
+
+#~ msgid "Wor_k:"
+#~ msgstr "काम (_k):"
+
+#~ msgid "Work"
+#~ msgstr "कार्य"
+
+#~ msgid "Work _fax:"
+#~ msgstr "कार्य फॅक्स् (_f):"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "Zip/पोस्टल कोड (_P):"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "Groupwise (_G):"
+
+#~ msgid "_Home page:"
+#~ msgstr "मुख्य पान (_H):"
+
+#~ msgid "_Home:"
+#~ msgstr "मुख्य (_H):"
+
+#~ msgid "_Jabber:"
+#~ msgstr "जॅबर (_J):"
+
+#~ msgid "_Manager:"
+#~ msgstr "व्यवस्थापक (_M):"
+
+#~ msgid "_State/Province:"
+#~ msgstr "राज्य/प्रांत (_S):"
+
+#~ msgid "_Work:"
+#~ msgstr "कार्य (_W):"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "Yahoo (_Y):"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "झीप/पोस्टल कोड (_Z):"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "रिडरवर बोट फटकारा"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "रिडरवर बोट ठेवा"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "अपत्य अनपिक्षितरित्या उत्तेजित झाले"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr " backend_stdin IO वाहिनी बंद करता आली नाही: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr " backend_stdout IO वाहिनी बंद करता आली नाही:%s"
+
+#~ msgid "System error: %s."
+#~ msgstr "प्रणाली चूक: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%1$s दाखल करण्यास अपयशी: %2$s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "बॅकएंड प्रक्षेपित करण्यास असमर्थ"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "प्रणाली चूक उद्भवली आहे"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "तुमचा पासवर्ड बदलण्यासाठी <b> पासवर्ड बदला</b> वर क्लिक् करा."
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "कृपया तुमचे पासवर्ड पुन्हा <b>पासवर्ड पुन्हा टाइप का</b> गुणविशेष प्रविष्ट करा."
+
+#~ msgid "Change your password"
+#~ msgstr "तुमचा पासवर्ड बदला"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "तुमचे पासवर्ड बदलविण्याकरीता, तुमचे सद्याचे पासवर्ड गुणविशेष मध्ये प्रविष्ट करा  व "
+#~ "<b>अधिप्रणीत करा</b> वर क्लिक करा.\n"
+#~ "अधिप्रमाणीत केल्यावर, तुमचे पासवर्ड प्रविष्ट करा, तपासणी करीता पुन्हा टाइप करा व "
+#~ "<b>पासवर्ड बदलवा</b> वर क्लिक करा."
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "प्रवेशकीय दाखलन (_g)"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "सहाय्यक तंत्रज्ञाण"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "सहाय्यक तंत्रज्ञाण पसंती"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "सहाय्यक तंत्रज्ञाण मध्ये केलेले बदल तुम्ही पुढच्या वेळी दाखलन करेपर्यंत प्रभावीत ठरणार नाही."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "बंद करा आणि लॉग आउट व्हा (_L)"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "सूचनीय अनुप्रयोग संवाद कडे जा"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "प्रवेश दाखलन संवादकडे जा"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "कळफलक प्रवेश संवादकडे जा"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "माऊस प्रवेशीय संवादकडे जा"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "सहाय्यक तंत्रज्ञान कार्यान्वित करा(_E)"
+
+#~ msgid "_Keyboard Accessibility"
+#~ msgstr "कळफलक प्रवेश (_K)"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "माऊस प्रवेशीयता (_M)"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "पसंतीचे अनुप्रयोग (_P)"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "दाखलनवेळी कोणते प्रवेशीय गुणविशेष कार्यान्वीत करायचे ते निवडा"
+
+#~ msgid "Font may be too large"
+#~ msgstr "फॉन्ट खूप मोठा असू शकतो"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "निवडलेला फॉन्ट %d प्रमाणाने मोठा आहे, व संगणक योग्यरित्या वापरण्यास अडचण निर्माण "
+#~ "करीत आहे.  असे सूचविले जाते की तुम्ही %d पेक्षा कमी आकाराचे फॉन्ट निवडा."
+#~ msgstr[1] ""
+#~ "निवडलेला फॉन्ट %d प्रमाणाने मोठा आहे, व संगणक योग्यरित्या वापरण्यास अडचण निर्माण "
+#~ "करीत आहे.  असे सूचविले जाते की तुम्ही %d पेक्षा कमी आकाराचे फॉन्ट निवडा."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "निवडलेला फॉन्ट %d प्रमाणाने मोठा आहे, व संगणक योग्यरित्या वापरण्यास अडचण निर्माण "
+#~ "करीत आहे.  असे सूचविले जाते की तुम्ही कमी आकाराचे फॉन्ट निवडा."
+#~ msgstr[1] ""
+#~ "निवडलेला फॉन्ट %d प्रमाणाने मोठा आहे, व संगणक योग्यरित्या वापरण्यास अडचण निर्माण "
+#~ "करीत आहे.  असे सूचविले जाते की तुम्ही कमी आकाराचे फॉन्ट निवडा."
+
+#~ msgid "Use previous font"
+#~ msgstr "पूर्वीचे फॉन्ट वापरा"
+
+#~ msgid "Use selected font"
+#~ msgstr "निवडलेले फॉन्ट वापरा"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "प्रतिष्ठापन करण्याजोगी सुत्रयोजनाचे फाइलनाव निर्धारीत करा"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "दर्शविण्याकरीताचे निर्धारीत पानाचे नाव प्रविष्ट करा (सुत्रयोजना|पार्श्वभूमी|फॉन्ट|संवाद)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[वॉलपेपर...]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ " आवश्यक GTK+ सुत्रयोजना इंजीन '%s' प्रतिष्ठापीत नसल्यामुळे ही सुत्रोयजना ठराविले नुरूप "
+#~ "दिसेल."
+
+#~ msgid "Apply Background"
+#~ msgstr "पार्श्वभूमी लागू करा"
+
+#~ msgid "Apply Font"
+#~ msgstr "फॉन्ट लागू करा"
+
+#~ msgid "Revert Font"
+#~ msgstr "फॉन्ट उलटवा"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "वर्तमान सुत्रयोजना पार्श्वभूमी व फॉन्ट सूचविते. व, शेवटचे लागू केलेले सूचीत फॉन्ट बदलविले "
+#~ "जाऊ शकते."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "सद्याचे सुत्रयोजना पार्श्वभूमी सूचविते. व, शेवटचे लागू केलेले सूचविलेले फॉन्ट बदलविले जाऊ शकते."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "सद्याचे सुत्रयोजना पार्श्वभूमी व फॉन्ट सूचविते."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "वर्तमान सुत्रयोजना फॉन्ट सूचविते. व, शेवटचे लागू केलेले सूचविलेले फॉन्ट बदलविले जाऊ शकते."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "सद्याचे सुत्रयोजना पार्श्वभूमी सूचविते."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "शेवटचे लागू केलेले सूचीत फॉन्ट बदलविता येते."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "सद्याचे सुत्रयोजना फॉन्ट सूचविते."
+
+#~ msgid "Best _shapes"
+#~ msgstr "सर्वोत्तम आकार (_s)"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "सर्वोत्तम विरोधाभास (_n)"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "स्वपसंत करा (_u)..."
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "कर्सर सुत्रयोजना मधिल बदल पुढच्यावेळी जेव्हा तुम्ही दाखलन कराल त्यावेळी होईल."
+
+#~ msgid "Controls"
+#~ msgstr "नियंत्रणे"
+
+#~ msgid "Customize Theme"
+#~ msgstr "योजना मनपसंत करा"
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "डेस्कटॉप फॉन्ट (_k):"
+
+#~ msgid "Edit"
+#~ msgstr "संपादीत करा"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "फॉन्ट रेंडरींग तपशील"
+
+#~ msgid "Fonts"
+#~ msgstr "फॉन्टस्"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "आणखी पार्श्वभूमी ऑनलाइन स्वरूपात प्राप्त करा"
+
+#~ msgid "Get more themes online"
+#~ msgstr "आणखी योजना ऑनलाइन आणा"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "करड्याछटा(_y)"
+
+#~ msgid "Icons"
+#~ msgstr "चिन्हे"
+
+#~ msgid "Icons only"
+#~ msgstr "फक्त चिन्हे"
+
+#~ msgid "Menus and Toolbars"
+#~ msgstr "मेन्यूज व उपकरनपट्टी"
+
+#~ msgid "N_one"
+#~ msgstr "काहीच नाही(_o)"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "रंग दर्शवण्यासाठी संवाद उघडा "
+
+#~ msgid "R_esolution:"
+#~ msgstr "दृश्यप्रमाण(_e):"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "सुत्रयोजना यानुरूप संचयीत करा..."
+
+#~ msgid "Save _As..."
+#~ msgstr "असे संग्रहा(_A)..."
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "मेन्यूमध्ये चिन्ह दाखवा (_i)"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "उपपिक्सेल (LCDs) (_p)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "उपपिक्सेल गुळगुळीत करणे (LCDs) (_p)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "उपपिक्सेलची क्रमवारी"
+
+#~ msgid "Text"
+#~ msgstr "मजकूर"
+
+#~ msgid "Text below items"
+#~ msgstr "घटकांच्या खालचे मजकूर"
+
+#~ msgid "Text beside items"
+#~ msgstr "घटकांच्या बाजूचे मजकूर"
+
+#~ msgid "Text only"
+#~ msgstr "फक्त मजकूर"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "सद्याचे नियंत्रण सुत्रयोजना रंग सुत्रयोजना यास समर्थन देत नाही."
+
+#~ msgid "Theme"
+#~ msgstr "योजना"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "उपकरणपट्टी बटन लेबले(_b):"
+
+#~ msgid "VB_GR"
+#~ msgstr "VBGR (_G)"
+
+#~ msgid "_BGR"
+#~ msgstr "BGR (_B)"
+
+#~ msgid "_Description:"
+#~ msgstr "वर्णन (_D):"
+
+#~ msgid "_Document font:"
+#~ msgstr "दस्तऐवज फॉन्ट(_D):"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "संपादनजोगी मेन्यु करीताचे शॉर्टकट कळ (_E)"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "निश्चित रुंदी फॉन्ट(_F):"
+
+#~ msgid "_Monochrome"
+#~ msgstr "मोनोक्रोम(_M)"
+
+#~ msgid "_None"
+#~ msgstr "काहीच नाही(_N)"
+
+#~ msgid "_RGB"
+#~ msgstr "RGB (_R)"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "पूर्वनिर्धारीत पुनःस्थापीत करा (_R)"
+
+#~ msgid "_Selected items:"
+#~ msgstr "निवडलेले घटक (_S):"
+
+#~ msgid "_Size:"
+#~ msgstr "आकार (_S):"
+
+#~ msgid "_Slight"
+#~ msgstr "स्लाइट(_S)"
+
+#~ msgid "_Style:"
+#~ msgstr "शैली(_S):"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "साधनटीप (_T):"
+
+#~ msgid "_VRGB"
+#~ msgstr "VRGB (_V)"
+
+#~ msgid "_Window title font:"
+#~ msgstr "पटल शिर्षक फॉन्ट(_W):"
+
+#~ msgid "_Windows:"
+#~ msgstr "Windows (_W):"
+
+#~ msgid "dots per inch"
+#~ msgstr "बिंदू प्रती इंच"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "डेस्कटॉपचा दृश्य स्वपसंत करा"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "डेस्कटॉपच्या विविध भाग करीता सुत्रयोजना संकुल प्रतिष्ठापीत करा"
+
+#~ msgid "Theme Installer"
+#~ msgstr "सुत्रयोजना प्रतिष्ठापक"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Gnome सुत्रोयजना संकुल"
+
+#~ msgid "Slide Show"
+#~ msgstr "स्लाईड दाखवा "
+
+#~ msgid "Image"
+#~ msgstr "प्रतिमा"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "बिंदू"
+#~ msgstr[1] "बिंदू"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "फोल्डर: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "सुत्रयोजना प्रतिष्ठापीत करू शकत नाही"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s उपकार्यपध्दती प्रतिष्ठापीत नाही."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "सुत्रयोजना प्राप्त करतेवेळी त्रुटी आढळली."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "निवडलेल्या फाइल मध्ये त्रुटी आढळली"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" वैध सुत्रयोजना नाही असे दिसून येते."
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" वैध सुत्रयोजना म्हणून दिसून पडत नाही. ते कंपाईल करण्याजोगी सुत्रयोजना इंजीन असू "
+#~ "शकते."
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "सुत्रयोजना \"%s\" करीता प्रतिष्ठापन अपयशी."
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "सुत्रयोजना \"%s\" प्रतिष्ठापीत नाही."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "तुम्हाला आता वापरायचे का, किंवा सद्याची सुत्रयोजनाच वापरायची?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "चालू थीम राहू द्या"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "नवीन थीम लागू करा"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME थीम %s योग्यरित्या प्रतिष्ठापित"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "तात्पुरती निर्देशिका निर्माण करण्यास असफल"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "नवीन सुत्रयोजना यशस्वीरित्या प्रतिष्ठापीत केले गेले."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "प्रतिष्ठापित करण्यासाठी थीम फाइल स्थळ दर्शविले नाही"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "सुत्रयोजना प्रतिष्ठापन करीता अपुरे परवानगी:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "सुत्रयोजना निवडा"
+
+#~ msgid "Theme Packages"
+#~ msgstr "सुत्रयोजना संकुल"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "सुत्रयोजना नाव उपलब्ध असायला हवे"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "अस्तित्वात आहे?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_पुनर्लेखित"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "तुम्हाला ही सुत्रयोजना काढून टाकायची?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "सुत्रयोजना इंजीन प्रतिष्ठापीत करू शकत नाही"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "सत्र व्यवस्थापक 'gnome-settings-daemon' सुरू करण्यास अशक्य.\n"
+#~ "GNOME संयोजना व्यवस्थापक कार्यरत नसल्यास, काहिक पसंतीचा प्रभाव लागू होऊ शकत नाही. "
+#~ "हे DBus सह अडचण असू शकते, किंवा विना-GNOME (उ.दा. KDE) संयोजना व्यवस्थापक "
+#~ "आधिपासूनच स्क्रीय असू शकतो व GNOME संयोजना व्यवस्थापकाशी मतभेद आढळू शकते."
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "स्टॉक चिन्ह %s भारित करण्यास असमर्थ\n"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "मदत दर्शवण्यात चूक झाली: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "फाइल प्रतिलिपी होतेय: %u %u ची"
+
+#~ msgid "Copying files"
+#~ msgstr "फाइली प्रतिलिपी करत आहे"
+
+#~ msgid "Parent Window"
+#~ msgstr "मुख्य पटल"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "संवादचे मुख्य पटल"
+
+#~ msgid "From URI"
+#~ msgstr "URI पासून"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI सध्या येथून स्थानांतरीत करत आहे"
+
+#~ msgid "To URI"
+#~ msgstr "प्रति URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI सध्या येथे स्थानांतरीत करत आहे"
+
+#~ msgid "Fraction completed"
+#~ msgstr "भाग पूर्ण"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "स्थानांतराचा सध्या पूर्ण झालेला भाग"
+
+#~ msgid "Current URI index"
+#~ msgstr "सद्य URI इंडेक्स"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "सद्य URI इंडेक्स - 1 पासून सुरू"
+
+#~ msgid "Total URIs"
+#~ msgstr "एकूण URIs"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "URIs ची एकूण संख्या"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "फाइल '%s' आधिपासूनच अस्तित्वात आहे. तुम्हाला खोडून पुन्हा लिहायचे?"
+
+#~ msgid "_Skip"
+#~ msgstr "वगळा (_S)"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "सर्व पुन्हा खोडून लिहा (_A)"
+
+#~ msgid "Key"
+#~ msgstr "किल्ली"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf कळ जी ला हा गुणधर्म संपादक जोडला आहे"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "जेव्हा कळशी संबंधित मूल्य बदलते हा कॉलबॅक लागू करा"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr "लागू केल्यावर gconf अग्रेषित करावयाचा डेटा सामावलेला GConf बदल संच"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "विजेट कॉलबॅकमध्ये परीवर्तन"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "GConf मधून विजेटमध्ये डेटा रुपांतरित करतेवेळी लागू करावयाचा कॉलबॅक"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "विजेट कॉलबॅक पासून रुपांतर"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "GConf मध्ये विजेटमधून डेटा रुपांतरित करतेवेळी लागू करावयाचा कॉलबॅक"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "गुणधर्म नियंत्रित करणारा ऑब्जेक्ट(सहसा विजेट)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "गुणधर्म संपादक ऑब्जेक्ट डेटा"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "विशिष्ट गुणधर्म संपादकास आवश्यक स्वेच्छा डेटा"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "गुणधर्म संपादक डेटा मुक्त करण्याचा कॉलबॅक"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "गुणधर्म संपादक ऑब्जेक्ट डेटा मुक्त करावयाचा असल्यास लागू करण्याचा कॉलबॅक"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "फाइल '%s' सापडली नाही.\n"
+#~ "\n"
+#~ "ती अस्तित्वात असल्याची खात्री करून घ्या आणि पुन्हा प्रयत्न करा, किंवा दुसरे एखादे "
+#~ "पार्शभूमी चित्र निवडा."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' फाइल कशी उघडावी हे मला माहित नाही.\n"
+#~ "हे अशा प्रकारचे चित्र असू शकते जे अजून समर्थनीय नाही.\n"
+#~ "\n"
+#~ "कृपया वेगळे चित्र निवडा."
+
+#~ msgid "Please select an image."
+#~ msgstr "कृपया प्रतिमा निवडा."
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "पूर्वनिर्धारीत पॉईंटर - सद्य"
+
+#~ msgid "White Pointer"
+#~ msgstr "पांढरा पॉईंटर"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "पांढरा पॉईंटर - सद्य"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "मोठा पॉईंटर - सद्य"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "मोठा पांढरा पॉईंटर - सद्य"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "आवश्यक GTK+ सुत्रयोजना '%s' प्रतिष्ठापीत नसल्यामुळे ही सुत्रयोजना ठरविल्यानुरूप दिसणार "
+#~ "नाही."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "आवश्यक पटल व्यवस्थपाक सुत्रयोजना '%s' प्रतिष्ठापीत नसल्यामुळे ही सुत्रयोजना "
+#~ "ठरविल्यानुरूप दिसणार नाही."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "आवश्यक चिन्ह सुत्रयोजना '%s' प्रतिष्ठापीत नसल्यामुळे ही सुत्रयोजना ठरविल्यानुरूप दिसणार "
+#~ "नाही."
+
+#~ msgid "Preferred Applications"
+#~ msgstr "प्राधान्य अनुप्रयोग"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "सूचविलेले दृश्यास्पद सहाय्यक तंत्रज्ञाण सुरू करा"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "दृश्यमान सहायता"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "मुख्य इंटरफेस भारित करता आला नाही"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr "दर्शविण्याकरीता निर्धारीत पानाचे नाव प्रविष्ट करा"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "सर्व %s उद्भव प्रत्यक्ष दुव्याद्वारे बदली केले जातील"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "आदेश(_m):"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "एक्झिक्यूट ध्वज(_x):"
+
+#~ msgid "Image Viewer"
+#~ msgstr "प्रतिमा दर्शक"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "तात्काळ संदेशवाहक"
+
+#~ msgid "Internet"
+#~ msgstr "आंतरजाल"
+
+#~ msgid "Mail Reader"
+#~ msgstr "मेल वाचक"
+
+#~ msgid "Mobility"
+#~ msgstr "भ्रह्मण"
+
+#~ msgid "Multimedia"
+#~ msgstr "मल्टीमीडिया"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "दुवा नवीन टॅबमध्ये उघडा(_t)"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "दुवा नवीन पटलत उघडा(_w)"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "दुवा वेब ब्राउजर पूर्वनिर्धारीतसह उघडा(_d)"
+
+#~ msgid "Run at st_art"
+#~ msgstr "प्रारंभवेळी चालवा (_a)"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "टर्मिनल मध्ये चालवा(_e)"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "टर्मिनल इम्युलेटर"
+
+#~ msgid "Text Editor"
+#~ msgstr "मजकूर संपादक"
+
+#~ msgid "_Run at start"
+#~ msgstr "प्रारंभवेळी चालवा (_R)"
+
+#~ msgid "Balsa"
+#~ msgstr "बाल्सा"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee संगीत वादक"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws मेल"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian संवेदनशील ब्राउजर"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian टर्मिनल इम्यूलेटर"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "एनकंपास्स्"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution मेल वाचक"
+
+#~ msgid "Firebird"
+#~ msgstr "फायरबर्ड"
+
+#~ msgid "Firefox"
+#~ msgstr "फायरफॉक्स"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "पडदा वाचक विना GNOME वर्धक"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "GNOME टर्मिनल"
+
+#~ msgid "Galeon"
+#~ msgstr "गॅलिऑन"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "ग्नोपेरनीकस्"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "वर्धक रहीत Gnopernicus"
+
+#~ msgid "Iceape"
+#~ msgstr "आइसएप"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape मेल"
+
+#~ msgid "Icedove"
+#~ msgstr "आइसडोव्"
+
+#~ msgid "Iceweasel"
+#~ msgstr "आइसविसेल्"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "पडदा वाचक विना KDE वर्धक"
+
+#~ msgid "Konqueror"
+#~ msgstr "कॉन्करर"
+
+#~ msgid "Konsole"
+#~ msgstr "कंसोल"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "वर्धक रहीत Linux पडदा वाचक"
+
+#~ msgid "Listen"
+#~ msgstr "एका"
+
+#~ msgid "Midori"
+#~ msgstr "मीडोरी"
+
+#~ msgid "Mozilla"
+#~ msgstr "मोझीला"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "मोझीला 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla मेल"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "मोझीला थंडरबर्ड"
+
+#~ msgid "Mutt"
+#~ msgstr "मट्ट"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "नेटस्केप् कम्युनीकेटर"
+
+#~ msgid "Opera"
+#~ msgstr "ओपेरा"
+
+#~ msgid "Orca"
+#~ msgstr "ओर्का"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "वर्धक रहीत Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox संगीत वादक"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey मेल"
+
+#~ msgid "Sylpheed"
+#~ msgstr "सिल्फीड"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "सिल्फीड-क्लॉज्"
+
+#~ msgid "Thunderbird"
+#~ msgstr "थंडरबर्ड्"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "टोटेम चित्रपट कार्यक्रम"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Display Preferences"
+#~ msgstr "प्रदर्शन आवड निवड"
+
+#~ msgid "Drag the monitors to set their place"
+#~ msgstr "ठिकाण सेट करण्यासाठी मॉनीटर्स् ओढा"
+
+#~ msgid "Include _panel"
+#~ msgstr "पटल अंतर्भूत करा (_p)"
+
+#~ msgid "Panel icon"
+#~ msgstr "पटल चिन्ह"
+
+#~ msgid "Re_fresh rate:"
+#~ msgstr "पुन्हदाखल दर (_f):"
+
+#~ msgid "Upside-down"
+#~ msgstr "वर-खाली"
+
+#~ msgid "_Detect Monitors"
+#~ msgstr "मॉनीटर ओळखा (_D)"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "स्क्रीन दृश्यप्रमाण बदला"
+
+#~ msgid "Upside Down"
+#~ msgstr "वर खाली"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "मॉनीटर: %s"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "दृष्य संयोजना लागू करतेवेळी सत्र बस प्राप्त करणे शक्य नाही"
+
+#~ msgid "Desktop"
+#~ msgstr "कार्यस्थळ"
+
+#~ msgid "Accelerator key"
+#~ msgstr "प्रवेग कळ"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "प्रवेग बदलकार"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "प्रवेग कळकोड"
+
+#~ msgid "Accel Mode"
+#~ msgstr "प्रवेग रीत"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "प्रवेगाचा प्रकार."
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "नवीन शार्टकट साठवतेवेळी त्रुटी आढळली"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "व्यूहरचना डेटाबेस मध्ये नवीन प्रवेगक अनिश्चित करतेवेळी त्रुटी: %s"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "खूप जास्त शार्टकट आढळले"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "शॉर्टकट किज् आदेशांस लागू "
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "फक्त रचनी लागू करा आणि बाहेर पडा (फक्त सुसंगता; आता डीमॉनद्वारे हाताळलेले)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "पान टाइपिंग ब्रेक रचना दाखवण्यासह सुरू करा"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "प्रवेशकीय संयोजना प्रदर्शन सह पान सुरू करा"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- GNOME कळफलक पसंती"
+
+#~ msgid "Beep when _accessibility features are turned on or off"
+#~ msgstr "प्रवेशकीय गुणविशेष कार्यन्वीत किंवा अकार्यान्वीत करतेवेळी बीप द्या (_a)"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "कळ नकारल्यास बीप द्या (_r)"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "कळफलक प्रवेशीय ऑडिओ प्रतिसाद"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "सावध संगीत करीता दृष्यास्पद प्रतिसाद दाखवा (_v)"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "आवाज करीता दृष्यास्पद cues"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "ब्रेक लांबणीवर टाकण्यासाठी परवानगी द्या(_o)"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "ऑडिओ प्रतिसाद (_F)..."
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "ब्रेक लांबणीवर टाकता येण्यास परवानगी आहे का हे तपासा"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "टाइपींग न स्वीकारल्यास ब्रेकचा कालावधी"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "ब्रेकची जबरनरित्या देण्यापूर्वी कामाचा कालावधी"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "कळफलक नमूना (_m):"
+
+#~ msgid "Layouts"
+#~ msgstr "मांडणी"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "वारंवार कळफलक वापराच्या जेरबंदी टाळण्यासाठी स्क्रीनवर विशिष्ट कालावधीनंतर ताळा लावा"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "पूर्वनिर्धारीत करीता पुन्हस्थापीत करा (_f)"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "ब्रेक अंतराळ राहतो(_B):"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "ब्रेक जबरनरित्या टाईप करण्याकरीता पडदा कुलूपबंद करा (_L)"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "फक्त लांब कळदाब स्वीकारा (_O)"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "निवडलेले मांडणी(_S):"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "समवेळी दाबलेली कि दाखवा (_S)"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "कामाचा अंतराळ राहतो (_W):"
+
+#~ msgid "_Country:"
+#~ msgstr "देश (_C):"
+
+#~ msgid "_Variants:"
+#~ msgstr "प्रकार (_V):"
+
+#~ msgid "_Vendors:"
+#~ msgstr "विक्रेता (_V):"
+
+#~ msgid "Layout"
+#~ msgstr "मांडणी"
+
+#~ msgid "Vendors"
+#~ msgstr "विक्रेता"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "तुमच्या कळफलक पसंती निर्धारित करा"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "डावीकडे हलवा"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "उजवीकडे हलवा"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "वर हलवा"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "अकार्यान्वीत"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "दर्शविण्याकरीताचे निर्धारीत पानाचे नाव प्रविष्ट करा"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- GNOME माऊस पसंती"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "पहिलेच क्लिक प्रकार निवडा (_b)"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "माऊस रचना रहीत क्लिक प्रकार निवडा (_u)"
+
+#~ msgid "D_rag click:"
+#~ msgstr "क्लिक् ओढा (_r):"
+
+#~ msgid "Show click type _window"
+#~ msgstr "क्लिक प्रकार पटल दाखवा (_w)"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr "क्लिक प्रकार नीवडण्यासाठी तुम्ही ड्वेल किल्क पटल ऍपलेटचा वापर करू शकता."
+
+#~ msgid "_Acceleration:"
+#~ msgstr "प्रवेग(_A):"
+
+#~ msgid "_Single click:"
+#~ msgstr "ऐकेरी क्लिक (_S):"
+
+#~ msgid "Location already exists"
+#~ msgstr "ठिकाण आधिपासून अस्तित्वात आहे"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "तुमच्या संजाळ प्रॉक्सी पसंती निर्धारित करा"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>हाताने प्रॉक्सी व्यूहरचना(_M)</b>"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP प्रॉक्सी तपशील"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "यजमान सूचीकडे दुर्लक्ष करा"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "संजाळ प्रॉक्सी पसंती"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "सुरक्षित HTTP प्रॉक्सी(_S):"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "तुमच्या पटल व्यवस्थापक करीता पसंती अनुप्रयोग सुरू करू शकत नाही"
+
+#~ msgid "C_ontrol"
+#~ msgstr "Ctrl (_o)"
+
+#~ msgid "_Alt"
+#~ msgstr "Alt (_A)"
+
+#~ msgid "H_yper"
+#~ msgstr "हायपर (_y)"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "सर्वोच्च (किंवा \"Windows प्रतिमा\") (_u)"
+
+#~ msgid "Movement Key"
+#~ msgstr "हालचाल कि"
+
+#~ msgid "Titlebar Action"
+#~ msgstr "शिर्षकपट्टी कृती"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "पटल हलविण्याकरीता, ही कळ दाबा-व-पकडून ठेवा व त्यानंतर पटल ओढा:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "पटल पसंती"
+
+#~ msgid "Window Selection"
+#~ msgstr "पटल निवड"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "कार्य लागू करण्याकरीता शिर्षकपट्टीवर दोनवेळा क्लिक करा (_D):"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "वाढविण्यापूर्वीचे अवधी (_I):"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "ठराविक अवधी नंतर निवडलेले पटल वाढवा (_R)"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_माऊस जेव्हा त्यावर जाईल तेव्हा विंडो निवडा"
+
+#~ msgid "Set your window properties"
+#~ msgstr "पटल"
+
+#~ msgid "Windows"
+#~ msgstr "विंडोज"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "\"%s\" पटल व्यवस्थापकाने संरचना साधानाची नोंद केली नाही\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "उभ्यारित्या मोठे करा"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "आडवेरित्या मोठे करा"
+
+#~ msgid "Roll up"
+#~ msgstr "वर गुंडाळणे"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "सुरू झाल्यावर लपवा (शेल प्रीलोड करण्यास उपयोगी)"
+
+#~ msgid "Filter"
+#~ msgstr "फिल्टर"
+
+#~ msgid "Groups"
+#~ msgstr "गट"
+
+#~ msgid "Common Tasks"
+#~ msgstr "सर्वसाधारण कार्य"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "कार्य सक्रीय केल्यास control-center बंद करा"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "कार्यसंपन्न कृती जोडल्यास किंवा काढूण टाकल्यास शेल पासून बाहेर पडा"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "मदत कार्य संपन्न झाल्यावर शेल पासून बाहेर पडा"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "प्रारंभ कृती संपन्न झाल्यावर शेल पासून बाहेर पडा"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "प्रारंभ कृती सुधारीत किंवा अप्रतिष्ठापीत केल्यावर शेल पासून बाहेर पडा"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "मदत कार्य संपन्न झाल्यावर शेल बंद करायचे का."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "प्रारंभ कृती कार्यान्वीत केल्यावर शेल बंद करायचे की नाही ते दर्शवितो."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr "जोडा किंवा काढूण टाका कृती कार्यान्वीत केल्यास शेल बंद करायचे का ते दर्शवितो."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "सुधारीत किंवा अप्रतिष्ठापन कृती कार्यान्वीत केल्यास शेल बंद करायचे का ते दर्शवितो."
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "कार्य नाव व संबंधीत .desktop फाइल"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "control-center मध्ये दर्शविण्याकरीता कार्याचे नाव त्यापाठोपाठ \";\" विभाजक व "
+#~ "अखेरीस त्या कार्य करीता दाखलन करण्याजोगी संबंधीत .desktop फाइलचे नाव."
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[सुत्रयोजना बदलवा;gtk-theme-selector.desktop, प्राधान्यकृत अनुप्रयोग निश्चित करा;"
+#~ "default-applications.desktop,छपाईयंत्र जोडा;gnome-cups-manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr "खरे असल्यास, \"सर्वसाधारण कार्य\" सक्रीय असल्यास control-center बंद होते."
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "Break पुढे ढकला (_P)"
+
+#~ msgid "_Take a Break"
+#~ msgstr "विराम घ्या (_T)"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "पुढच्या ब्रेक पर्यंत %d मिनिट"
+#~ msgstr[1] "पुढच्या ब्रेक पर्यंत %d मिनिटं"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "मिनिटे पर्यंत"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr "खालील त्रुटी सह टायपींग ब्रेक गुणधर्म संवाद कार्यान्वीत करू शकले नाही: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Richard Hult <richard@imendio.com> द्वारे लिखीत"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Anders Carlsson ने Eye candy जोडले"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "संगणक ब्रेक स्मरणपत्र."
+
+#~ msgid "translator-credits"
+#~ msgstr "अनुवादाचे श्रेय "
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "सूचना कक्ष अस्तित्वात आहे का याचा तपास घेऊ नका"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "माहिती प्रदर्शित करण्याकरीता टायपींग मॉनीटर सूचना कक्षचा वापर करते. तुमच्या पटलावर "
+#~ "सूचना कक्ष आढळला नाही. पटलावर उजवी क्लिक देऊन व 'पटलात समावेष करा' पसंत केल्यास, "
+#~ "'सूचना कक्ष' निवडल्यास व 'समावेष करा' क्लिक केल्यावर समावेष शक्य आहे."
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "true निश्चित केल्यास, OpenType फॉन्ट थंबनेल केले जातिल."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "true निश्चित केल्यास, PCF फॉन्ट थंबनेल केले जातिल."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "true निश्चित केल्यास, TrueType फॉन्ट थंबनेल केले जातिल."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "true निश्चित केल्यास, Type1 फॉन्ट थंबनेल केले जातिल."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "OpenType फॉन्ट करीता थंबनेल बनविण्यासाठी वापरण्याजोगी आदेशकरीता ही कि निश्चित "
+#~ "करा."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "PCF फॉन्ट करीता थंबनेल बनविण्यासाठी वापरण्याजोगी आदेशकरीता ही कि निश्चित करा."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "TrueType फॉन्ट करीता थंबनेल बनविण्यासाठी वापरण्याजोगी आदेशकरीता ही कि निश्चित "
+#~ "करा."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Type1 फॉन्ट करीता थंबनेल बनविण्यासाठी वापरण्याजोगी आदेशकरीता ही कि निश्चित करा."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "OpenType फॉन्ट करीता thumbnail आदेश"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "PCF फॉन्ट करीता thumbnail आदेश"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "TrueType फॉन्ट करीता thumbnail आदेश"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Type1 फॉन्ट करीता thumbnail आदेश"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "OpenType फॉन्ट thumbnail नुरूप करायचे"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCF फॉन्ट thumbnail नुरूप करायचे"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "TrueType फॉन्ट thumbnail नुरूप करायचे"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Type1 फॉन्ट thumbnail नुरूप करायचे"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "The quick brown fox jumps over the lazy dog. 0123456789"
+
+#~ msgid "Copyright:"
+#~ msgstr "सर्वहाक्काधिकार:"
+
+#~ msgid "Description:"
+#~ msgstr "वर्णन:"
+
+#~ msgid "Installed"
+#~ msgstr "प्रतिष्ठापीत झाले"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "वापरणी: %s फॉन्टफाइल\n"
+
+#~ msgid "Font Viewer"
+#~ msgstr "फॉन्ट प्रदर्शक"
+
+#~ msgid "Preview fonts"
+#~ msgstr "फॉन्टं पूर्वदृष्य"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "thumbnail करण्याजोगी पाठ्य (पूर्वनिर्धारीत: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "फॉन्ट आकार (पूर्वनिर्धारीत: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "तुमचे फिल्टर \"%s\" कुठल्याही घटकांशी जुळत नाही."
+
+#~ msgid "Upgrade"
+#~ msgstr "अद्ययावत करा"
+
+#~ msgid "Uninstall"
+#~ msgstr "अप्रतिष्ठापन"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "आवड मध्ये जोडा"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "प्रारंभीक कार्यक्रमातून काढूण टाका"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "प्रारंभीक कार्यक्रम मध्ये जोडा"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "नवीन स्प्रेडशीट"
+
+#~ msgid "New Document"
+#~ msgstr "नवीन दस्तऐवज"
+
+#~ msgid "Documents"
+#~ msgstr "दस्तऐवज"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>उघडा</b>"
+
+#~ msgid "Rename..."
+#~ msgstr "नाव बदला..."
+
+#~ msgid "Move to Trash"
+#~ msgstr "कचरापेटीकडे हलवा"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "हे घटक काढूण टाकल्यास, हे कायमस्वरूपी काढूण टाकले जातील."
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "\"%s\" सह उघडा"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "फाइल व्यवस्थापक मध्ये उघडा"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "आज %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "उद्या %l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "आता शोधा"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s उघडा</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "प्रणाली घटक पासून काढूण टाका"

--- a/po/ms.po
+++ b/po/ms.po
@@ -4,9 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center HEAD\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2020-01-16 12:38+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2020-01-26 09:16+0800\n"
 "Last-Translator: abuyop <abuyop@gmail.com>\n"
 "Language-Team: Pasukan Terjemahan GNOME Malaysia\n"
@@ -17,684 +16,323 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-# msgstr[1] ""
-#: panels/applications/cc-applications-panel.c:708
-msgid "System Bus"
-msgstr "Bas Sistem"
-
-#: panels/applications/cc-applications-panel.c:708
-#: panels/applications/cc-applications-panel.c:710
-#: panels/applications/cc-applications-panel.c:723
-#: panels/applications/cc-applications-panel.c:728
-msgid "Full access"
-msgstr "Capaian penuh"
-
-#: panels/applications/cc-applications-panel.c:710
-msgid "Session Bus"
-msgstr "Bas Sesi"
-
-#: panels/applications/cc-applications-panel.c:714
-#: panels/power/cc-power-panel.c:2469 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525
-msgid "Devices"
-msgstr "Peranti-Peranti"
-
-#: panels/applications/cc-applications-panel.c:714
-msgid "Full access to /dev"
-msgstr "Capaian penuh ke /dev"
-
-#: panels/applications/cc-applications-panel.c:718
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:252
-msgid "Network"
-msgstr "Rangkaian"
-
-#: panels/applications/cc-applications-panel.c:718
-#: panels/applications/cc-snap-row.c:109
-msgid "Has network access"
-msgstr "Mempunyai capaian rangkaian"
-
-#: panels/applications/cc-applications-panel.c:723
-#: panels/applications/cc-applications-panel.c:725
-#: panels/search/cc-search-locations-dialog.c:361
-msgid "Home"
-msgstr "Rumah"
-
-#: panels/applications/cc-applications-panel.c:725
-#: panels/applications/cc-applications-panel.c:730
-msgid "Read-only"
-msgstr "Baca-sahaja"
-
-#: panels/applications/cc-applications-panel.c:728
-#: panels/applications/cc-applications-panel.c:730
-msgid "File System"
-msgstr "Sistem Fail"
-
-#: panels/applications/cc-applications-panel.c:734
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:281
-#: shell/cc-window.c:964 shell/cc-window.ui:125
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr "Tetapan"
-
-#: panels/applications/cc-applications-panel.c:734
-#: panels/applications/cc-snap-row.c:73
-msgid "Can change settings"
-msgstr "Boleh mengubah tetapan"
-
-#: panels/applications/cc-applications-panel.c:736
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s mempunyai keizinan terbina-dalam berikut. Ia tidak dapat diubah. Jika "
-"anda ambil kisah berkenaan keizinan ini, buang aplikasi ini."
-
-#: panels/applications/cc-applications-panel.c:891
-msgid "Web Links"
-msgstr "Pautan Sesawang"
-
-#: panels/applications/cc-applications-panel.c:901
-msgid "Git Links"
-msgstr "Pautan Git"
-
-#: panels/applications/cc-applications-panel.c:907
-#, c-format
-msgid "%s Links"
-msgstr "Pautan %s"
-
-#: panels/applications/cc-applications-panel.c:915
-#: panels/applications/cc-applications-panel.c:951
-msgid "Unset"
-msgstr "Nyahtetap"
-
-#: panels/applications/cc-applications-panel.c:1006
-msgid "Links"
-msgstr "Pautan"
-
-#: panels/applications/cc-applications-panel.c:1014
-msgid "Hypertext Files"
-msgstr "Fail Hiperteks"
-
-#: panels/applications/cc-applications-panel.c:1028
-msgid "Text Files"
-msgstr "Fail Teks"
-
-#: panels/applications/cc-applications-panel.c:1042
-msgid "Image Files"
-msgstr "Fail Imej"
-
-#: panels/applications/cc-applications-panel.c:1058
-msgid "Font Files"
-msgstr "Fail Fon"
-
-#: panels/applications/cc-applications-panel.c:1119
-msgid "Archive Files"
-msgstr "Fail Arkib"
-
-#: panels/applications/cc-applications-panel.c:1139
-msgid "Package Files"
-msgstr "Fail Pakej"
-
-#: panels/applications/cc-applications-panel.c:1162
-msgid "Audio Files"
-msgstr "Fail Audio"
-
-#: panels/applications/cc-applications-panel.c:1179
-msgid "Video Files"
-msgstr "Fail Video"
-
-#: panels/applications/cc-applications-panel.c:1187
-msgid "Other Files"
-msgstr "Lain-lain Fail"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1529
-#: panels/applications/cc-applications-panel.ui:412
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:167
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr "Aplikasi"
 
-#: panels/applications/cc-applications-panel.ui:45
+#: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
 msgstr "Tiada aplikasi"
 
-#: panels/applications/cc-applications-panel.ui:59
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr "Pasang lagi…"
 
-#: panels/applications/cc-applications-panel.ui:99
-msgid "Permissions & Access"
-msgstr "Keizinan & Capaian"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Buka"
 
-#: panels/applications/cc-applications-panel.ui:111
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-"Data dan perkhidmatan yang dipinta oleh aplikasi ini untuk capaian dan "
-"keizinan yang diperlukannya."
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_Lihat perincian"
 
-#: panels/applications/cc-applications-panel.ui:126
-#: panels/applications/cc-applications-panel.ui:132
-#: panels/camera/gnome-camera-panel.desktop.in.in:3
-msgid "Camera"
-msgstr "Kamera"
-
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:237
-#: panels/applications/cc-applications-panel.ui:261
-#: panels/keyboard/cc-keyboard-option.c:259
-#: panels/keyboard/cc-keyboard-option.c:378
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:96
-#: panels/keyboard/keyboard-shortcuts.c:425 panels/network/network-proxy.ui:126
-#: panels/user-accounts/um-fingerprint-dialog.c:211
-#: subprojects/gvc/gvc-mixer-control.c:1876
-msgid "Disabled"
-msgstr "Dilumpuhkan"
-
-#: panels/applications/cc-applications-panel.ui:138
-#: panels/applications/cc-applications-panel.ui:144
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
-msgid "Microphone"
-msgstr "Mikrofon"
-
-#: panels/applications/cc-applications-panel.ui:150
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/location/gnome-location-panel.desktop.in.in:3
-msgid "Location Services"
-msgstr "Perkhidmatan Lokasi"
-
-#: panels/applications/cc-applications-panel.ui:162
-#: panels/applications/cc-applications-panel.ui:495
-msgid "Built-in Permissions"
-msgstr "Keizinan Terbina-dalam"
-
-#: panels/applications/cc-applications-panel.ui:163
-msgid "Cannot be changed"
-msgstr "Tidak dapat diubah"
-
-#: panels/applications/cc-applications-panel.ui:180
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-"Keizinan individu untuk aplikasi boleh ditinjau dalam Tetapan <a href="
-"\"privacy\">Kerahsiaan</a>."
-
-#: panels/applications/cc-applications-panel.ui:204
-msgid "Integration"
-msgstr "Penyepaduan"
-
-#: panels/applications/cc-applications-panel.ui:216
-msgid "System features used by this application."
-msgstr "Fitur-fitur sistem yang digunakan oleh aplikasi ini."
-
-#: panels/applications/cc-applications-panel.ui:230
-#: panels/applications/cc-applications-panel.ui:236
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:155
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Gelintar"
 
-#: panels/applications/cc-applications-panel.ui:242
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Dilumpuhkan"
+
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr "Pemberitahuan"
 
-#: panels/applications/cc-applications-panel.ui:248
-msgid "Run in background"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Pemberitahuan"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "Jalan di balik tabir"
 
-#: panels/applications/cc-applications-panel.ui:254
-#: panels/applications/cc-applications-panel.ui:260
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Tangkap Layar"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Tiada Kertas Dinding"
+
+#: panels/applications/cc-applications-panel.ui:148
+#, fuzzy
+msgid "Change the desktop wallpaper."
+msgstr "Ubah tarikh dan waktu"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Bunyi"
 
-#: panels/applications/cc-applications-panel.ui:293
-msgid "Default Handlers"
-msgstr "Pengendali Lalai"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:305
-msgid "Types of files and links that this application opens."
-msgstr "Jenis fail dan pautan yang dibuka oleh aplikasi ini."
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Tetapkan Pintasan"
 
-#: panels/applications/cc-applications-panel.ui:321
-msgid "Reset"
-msgstr "Tetap Semula"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Tiada pintasan papan kekunci ditemui"
 
-#: panels/applications/cc-applications-panel.ui:357
-msgid "Usage"
-msgstr "Penggunaan"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
 
-#: panels/applications/cc-applications-panel.ui:369
-msgid "How much resources this application is using."
-msgstr "Berapa banyak sumber-sumber dalam aplikasi ini gunakan."
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:384
-#: panels/applications/cc-applications-panel.ui:531
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Perkhidmatan Lokasi"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+#, fuzzy
+msgid "Access device location data."
+msgstr "Capai lokasi anda"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Keizinan Terbina-dalam"
+
+#: panels/applications/cc-applications-panel.ui:223
+#, fuzzy
+msgid "System access that is required by the app"
+msgstr "Fitur-fitur sistem yang digunakan oleh aplikasi ini."
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Storan"
 
-#: panels/applications/cc-applications-panel.ui:419
-msgid "Open in Software"
-msgstr "Buka dalam Perisian"
-
-#: panels/applications/cc-applications-panel.ui:469 shell/cc-panel-list.ui:121
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Tiad keputusan ditemui"
 
-#: panels/applications/cc-applications-panel.ui:480
-#: panels/keyboard/cc-keyboard-panel.ui:188 shell/cc-panel-list.ui:132
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Cuba gelintar yang lain"
 
-#: panels/applications/cc-applications-panel.ui:548
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Sistem Fail"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Kelajuan sambungan"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Tetap Semula"
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Berapa banyak ruang cakera yang diperlukan oleh aplikasi ini untuk mengisi "
 "data dan cache apl."
 
-#: panels/applications/cc-applications-panel.ui:557
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Aplikasi"
 
-#: panels/applications/cc-applications-panel.ui:563
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Data"
 
-#: panels/applications/cc-applications-panel.ui:569
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Cache"
 
-#: panels/applications/cc-applications-panel.ui:575
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Jumlah</b>"
 
-#: panels/applications/cc-applications-panel.ui:592
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Kosongkan Cache…"
-
-#: panels/applications/cc-snap-row.c:55
-msgid "Add user accounts and change passwords"
-msgstr "Tambah akaun pengguna dan ubah kata laluan"
-
-#: panels/applications/cc-snap-row.c:57 panels/applications/cc-snap-row.c:133
-msgid "Play and record sound"
-msgstr "Main dan rakam bunyi"
-
-#: panels/applications/cc-snap-row.c:59
-msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
-msgstr "Kesan peranti rangkaian menggunakan mDNS/DNS-SD (Bonjour/zeroconf)"
-
-#: panels/applications/cc-snap-row.c:61
-msgid "Access bluetooth hardware directly"
-msgstr "Capai perkakasan bluetooth secara terus"
-
-#: panels/applications/cc-snap-row.c:63
-msgid "Use bluetooth devices"
-msgstr "Guna peranti bluetooth"
-
-#: panels/applications/cc-snap-row.c:65
-msgid "Use your camera"
-msgstr "Guna kamera anda"
-
-#: panels/applications/cc-snap-row.c:67
-msgid "Print documents"
-msgstr "Cetak dokumen"
-
-#: panels/applications/cc-snap-row.c:69
-msgid "Use any connected joystick"
-msgstr "Guna mana-mana kayu ria bersambung"
-
-#: panels/applications/cc-snap-row.c:71
-msgid "Allow connecting to the Docker service"
-msgstr "Benarkan bersambung dengan perkhidmatan Docker"
-
-#: panels/applications/cc-snap-row.c:75
-msgid "Configure network firewall"
-msgstr "Konfigur dinding api rangkaian"
-
-#: panels/applications/cc-snap-row.c:77
-msgid "Setup and use privileged FUSE filesystems"
-msgstr "Pasang dan guna sistem fail FUSE yang layak"
-
-#: panels/applications/cc-snap-row.c:79
-msgid "Update firmware on this device"
-msgstr "Kemas kini perisian tegar dalam peranti ini"
-
-#: panels/applications/cc-snap-row.c:81
-msgid "Access hardware information"
-msgstr "Capai maklumat perkakasan"
-
-#: panels/applications/cc-snap-row.c:83
-msgid "Provide entropy to hardware random number generator"
-msgstr "Menyediakan entropi untuk penjana nombor rawak perkakasan"
-
-#: panels/applications/cc-snap-row.c:85
-msgid "Use hardware-generated random numbers"
-msgstr "Guna nombor rawak terjana-perkakasan"
-
-#: panels/applications/cc-snap-row.c:87
-msgid "Access files in your home folder"
-msgstr "Capai fail dalam folder rumah anda"
-
-#: panels/applications/cc-snap-row.c:89
-msgid "Access libvirt service"
-msgstr "Capai perkhidmatan libvirt"
-
-#: panels/applications/cc-snap-row.c:91
-msgid "Change system language and region settings"
-msgstr "Ubah tetapan bahasa dan wilayah sistem"
-
-#: panels/applications/cc-snap-row.c:93
-msgid "Change location settings and providers"
-msgstr "Ubah tetapan dan penyedia lokasi"
-
-#: panels/applications/cc-snap-row.c:95
-msgid "Access your location"
-msgstr "Capai lokasi anda"
-
-#: panels/applications/cc-snap-row.c:97
-msgid "Read system and application logs"
-msgstr "Baca sistem dan log aplikasi"
-
-#: panels/applications/cc-snap-row.c:99
-msgid "Access LXD service"
-msgstr "Capai perkhidmatan LXD"
-
-#: panels/applications/cc-snap-row.c:101
-msgid "access the media-hub service"
-msgstr "capai perkhidmatan media-hub"
-
-#: panels/applications/cc-snap-row.c:103
-msgid "Use and configure modems"
-msgstr "Guna dan konfigur modem"
-
-#: panels/applications/cc-snap-row.c:105
-msgid "Read system mount information and disk quotas"
-msgstr "Baca maklumat lekap sistem dan kuota cakera"
-
-#: panels/applications/cc-snap-row.c:107
-msgid "Control music and video players"
-msgstr "Kawal pemain muzik dan video"
-
-#: panels/applications/cc-snap-row.c:111
-msgid "Change low-level network settings"
-msgstr "Ubah tetapan rangkaian aras-rendah"
-
-#: panels/applications/cc-snap-row.c:113
-msgid "Access the NetworkManager service to read and change network settings"
-msgstr ""
-"Capai perkhidmatan Pengurus Rangkaian untuk baca dan ubah tetapan rangkaian"
-
-#: panels/applications/cc-snap-row.c:115
-msgid "Read access to network settings"
-msgstr "Baca capaian ke tetapan rangkaian"
-
-#: panels/applications/cc-snap-row.c:117
-msgid "Change network settings"
-msgstr "Ubah tetapan rangkaian"
-
-#: panels/applications/cc-snap-row.c:119
-msgid "Read network settings"
-msgstr "Baca tetapan rangkaian"
-
-#: panels/applications/cc-snap-row.c:121
-msgid ""
-"Access the ofono service to read and change network settings for mobile "
-"telephony"
-msgstr ""
-"Capai perkhidmatan ofono untuk baca dan ubah tetapan rangkaian telefoni "
-"mudah alih"
-
-#: panels/applications/cc-snap-row.c:123
-msgid "Control Open vSwitch hardware"
-msgstr "Kawal perkakasan Open vSwitch"
-
-#: panels/applications/cc-snap-row.c:125
-msgid "Read from CD/DVD"
-msgstr "Baca dari CD/DVD"
-
-#: panels/applications/cc-snap-row.c:127
-msgid "Read, add, change, or remove saved passwords"
-msgstr "Baca, tambah, ubah, atau buang kata laluan tersimpan"
-
-#: panels/applications/cc-snap-row.c:129
-msgid ""
-"Access pppd and ppp devices for configuring Point-to-Point Protocol "
-"connections"
-msgstr ""
-"Capai peranti pppd dan ppp untuk mengkonfigur sambungan Protokol Titik-ke-"
-"Titik"
-
-#: panels/applications/cc-snap-row.c:131
-msgid "Pause or end any process on the system"
-msgstr "Jeda atau tamatkan apa-apa proses dalam sistem"
-
-#: panels/applications/cc-snap-row.c:135
-msgid "Access USB hardware directly"
-msgstr "Capai perkakasan USB secara terus"
-
-#: panels/applications/cc-snap-row.c:137
-msgid "Read/write files on removable storage devices"
-msgstr "Baca/tulis fail dalam peranti storan mudah alih"
-
-#: panels/applications/cc-snap-row.c:139
-msgid "Prevent screen sleep/lock"
-msgstr "Halang skrin dari tidur/terkunci"
-
-#: panels/applications/cc-snap-row.c:141
-msgid "Access serial port hardware"
-msgstr "Capai perkakasan port serial"
-
-#: panels/applications/cc-snap-row.c:143
-msgid "Restart or power off the device"
-msgstr "Mula semula atau matikan peranti"
-
-#: panels/applications/cc-snap-row.c:145
-msgid "Install, remove and configure software"
-msgstr "Pasang, buang dan konfigur perisian"
-
-#: panels/applications/cc-snap-row.c:147
-msgid "Access Storage Framework service"
-msgstr "Capai perkhidmatan Bingkai Kerja Storan"
-
-#: panels/applications/cc-snap-row.c:149
-msgid "Read process and system information"
-msgstr "Baca proses dan maklumat sistem"
-
-#: panels/applications/cc-snap-row.c:151
-msgid "Monitor and control any running program"
-msgstr "Pantau dan kawal apa-apa program yang berjalan"
-
-#: panels/applications/cc-snap-row.c:153
-msgid "Change the date and time"
-msgstr "Ubah tarikh dan waktu"
-
-#: panels/applications/cc-snap-row.c:155
-msgid "Change time server settings"
-msgstr "Ubah tetapan pelayan waktu"
-
-#: panels/applications/cc-snap-row.c:157
-msgid "Change the time zone"
-msgstr "Ubah zon waktu"
-
-#: panels/applications/cc-snap-row.c:159
-msgid "Access the UDisks2 service for configuring disks and removable media"
-msgstr ""
-"Capai perkhidmatan UDisks2 untuk mengkonfigur cakera dan media mudah alih"
-
-#: panels/applications/cc-snap-row.c:161
-msgid "Read/change shared calendar events in Ubuntu Unity 8"
-msgstr "Baca/ubah peristiwa kalendar terkongsi dalam Unity 8 Ubuntu"
-
-#: panels/applications/cc-snap-row.c:163
-msgid "Read/change shared contacts in Ubuntu Unity 8"
-msgstr "Baca/ubah hubungan terkongsi dalam Unity 8 Ubuntu"
-
-#: panels/applications/cc-snap-row.c:165
-msgid "Access energy usage data"
-msgstr "Capai data penggunaan tenaga"
-
-#: panels/applications/cc-snap-row.c:167
-msgid "Read/write access to U2F devices exposed"
-msgstr "Baca/tulis capaian ke peranti U2F terdedah"
 
 #: panels/applications/gnome-applications-panel.desktop.in.in:4
 msgid "Control various application permissions and settings"
 msgstr "Kawal pelbagai keizinan dan tetapan aplikasi"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplikasi;flatpak;keizinan;tetapan;"
 
-#: panels/background/cc-background-chooser.c:349
-msgid "Select a picture"
-msgstr "Pilih satu gambar"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "_Gaya:"
 
-#: panels/background/cc-background-chooser.c:352
-#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:241
-#: panels/color/cc-color-panel.c:894 panels/color/cc-color-panel.ui:657
-#: panels/common/cc-language-chooser.ui:24
-#: panels/display/cc-display-panel.c:950
-#: panels/info-overview/cc-info-overview-panel.ui:235
-#: panels/network/cc-wifi-hotspot-dialog.ui:122
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:176
-#: panels/network/connection-editor/vpn-helpers.c:299
-#: panels/network/net-device-wifi.c:800 panels/network/net-device-wifi.c:908
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:252
-#: panels/region/cc-format-chooser.ui:28 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:638
-#: panels/sharing/cc-sharing-panel.c:428 panels/usage/cc-usage-panel.c:134
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:107
-#: panels/user-accounts/cc-avatar-chooser.c:235
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:635
-#: panels/user-accounts/cc-user-panel.c:653
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/user-accounts/um-fingerprint-dialog.c:261
-msgid "_Cancel"
-msgstr "Ba_tal"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Lalai"
 
-#: panels/background/cc-background-chooser.c:353
-#: panels/network/connection-editor/vpn-helpers.c:177
-#: panels/printers/pp-details-dialog.c:253
-#: panels/sharing/cc-sharing-panel.c:429
-#: panels/user-accounts/cc-avatar-chooser.c:236
-msgid "_Open"
-msgstr "_Buka"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#: panels/background/cc-background-chooser.ui:104
-msgid "Set Background and Lock Screen"
-msgstr "Tetapkan Latar Belakang dan Skrin Kunci"
-
-#: panels/background/cc-background-chooser.ui:114
-msgid "Set Background"
-msgstr "Tetapkan Latar Belakang"
-
-#: panels/background/cc-background-chooser.ui:121
-msgid "Set Lock Screen"
-msgstr "Tetapkan Kunci skrin"
-
-#: panels/background/cc-background-chooser.ui:143
-msgid "Remove Background"
-msgstr "Buang Latar Belakang"
-
-#: panels/background/cc-background-item.c:140
-msgid "multiple sizes"
-msgstr "saiz berbilang"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:144
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:278
-msgid "No Desktop Background"
-msgstr "Tiada Latar Belakang Atas Meja"
-
-#: panels/background/cc-background-panel.c:145
-msgid "Current background"
-msgstr "Latar belakang semasa"
-
-#: panels/background/cc-background-panel.ui:63
-msgid "Add Picture…"
-msgstr "Tambah Gambar…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktiviti-Aktiviti"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Latar Belakang"
 
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Tambah Gambar…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "Keutamaan Tema"
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Ubah imej latar belakang anda dengan kertas dinding atau foto"
 
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Kertas Dinding;Skrin;Atas Meja;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "_Benarkan"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Tiada Bluetooth Ditemui"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Palamkan dongle untuk menggunakan Bluetooth."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:69
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth Dimatikan"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:80
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Hidupkan untuk sambungkan peranti dan terima pemindahan fail."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:107
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "Mod Kapat Terbang hidup"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:118
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth dilumpuhkan ketika mod kapal terbang hidup."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:124
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Matikan Mod Kapal Terbang"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:154
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
 msgstr "Mod Kapal Terbang Perkakasan hidup"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:165
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Matikan mod Kapal Terbang untuk benarkan Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1714
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -702,33 +340,32 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Hidupkan Bluetooth dan matikan, kemudian sambung peranti anda"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "kongsi;perkongsian;bluetooth;obex;"
 
-#: panels/camera/cc-camera-panel.ui:34
-msgid "Camera is turned off"
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
 msgstr "Kamera dimatikan"
 
-#: panels/camera/cc-camera-panel.ui:43
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Tiada aplikasi boleh menangkap foto atau video."
 
-#: panels/camera/cc-camera-panel.ui:77
+#: panels/camera/cc-camera-panel.ui:39
+#, fuzzy
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 "Penggunaan kamera membolehkan aplikasi-aplikasi menangkap foto-foto dan "
 "video. Melumpuhkan kamera boleh menyebabkan sesetengah aplikasi tidak "
 "berfungsi dengan baik."
 
-#: panels/camera/cc-camera-panel.ui:87
-msgid "Allow the applications below to use your camera."
-msgstr "Benarkan aplikasi di bawah menggunakan kamera anda."
-
-#: panels/camera/cc-camera-panel.ui:107
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Tiada Aplikasi Menanya untuk Capaian Kamera"
 
@@ -736,279 +373,59 @@ msgstr "Tiada Aplikasi Menanya untuk Capaian Kamera"
 msgid "Protect your pictures"
 msgstr "Lindungi gambar anda"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"skrin;kunci;diagnostik;kerosakan;persendirian;baru-baru ini;sementara;tmp;"
-"indeks;nama;rangkaian;identiti;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:348
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Letak peranti penentukuran anda atas petak dan tekan 'Mula'"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:354
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Alih peranti penentukuran anda pada kedudukan tentukur dan tekan 'Teruskan'"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:360
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Alih peranti penentukuran anda atas kedudukan permukaan dan tekan 'Teruskan'"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:366
-msgid "Shut the laptop lid"
-msgstr "Tutup penutup komputer riba"
-
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:397
-msgid "An internal error occurred that could not be recovered."
-msgstr "Satu ralat dalaman berlaku yang tidak dapat dipulihkan."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:402
-msgid "Tools required for calibration are not installed."
-msgstr "Alatan diperlukan untuk penentukuran tidak dipasang."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:408
-msgid "The profile could not be generated."
-msgstr "Profil tidak dapat dijana."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:414
-msgid "The target whitepoint was not obtainable."
-msgstr "Titik putih sasaran tidak boleh diperolehi."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:453
-msgid "Complete!"
-msgstr "Selesai!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:461
-msgid "Calibration failed!"
-msgstr "Penentukuran gagal!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:468
-msgid "You can remove the calibration device."
-msgstr "Anda boleh buang peranti penentukuran."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:537
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Jangan ganggu peranti semasa penentukuran berlansung"
-
-#: panels/color/cc-color-calibrate.ui:7
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Tentukur Paparan"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "Ba_tal"
+
 #. This starts the calibration process
-#: panels/color/cc-color-calibrate.ui:40
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "_Mula"
 
 #. This resumes the calibration process
-#: panels/color/cc-color-calibrate.ui:54
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "_Sambung Semula"
 
 #. This button returns the user back to the color control panel
-#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Selesai"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Skrin Komputer Riba"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Kamera Sesawang terbina-dalam"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Pengimbas %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Kamera %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Pencetak %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Kamera Sesawang %s"
-
-#: panels/color/cc-color-device.c:91
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Benarkan pengurusan warna untuk %s"
-
-#: panels/color/cc-color-device.c:94
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Tunjuk profil warna untuk %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:303
-msgid "Not calibrated"
-msgstr "Tidak ditentukur"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:170
-msgid "Default: "
-msgstr "Lalai: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:178
-msgid "Colorspace: "
-msgstr "Ruang warna: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:185
-msgid "Test profile: "
-msgstr "Profil ujian: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:239
-msgid "Select ICC Profile File"
-msgstr "Pilih Fail Profil ICC"
-
-#: panels/color/cc-color-panel.c:242
-msgid "_Import"
-msgstr "_Import"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:253
-msgid "Supported ICC profiles"
-msgstr "Profil ICC Tersokong"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:260
-#: panels/network/wireless-security/eap-method-fast.c:309
-msgid "All files"
-msgstr "Semua fail"
-
-#: panels/color/cc-color-panel.c:555
-msgid "Screen"
-msgstr "Skrin"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:847
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Gagal memuat naik fail: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:859
-msgid "The profile has been uploaded to:"
-msgstr "Profail telah dimuat naik ke:"
-
-#: panels/color/cc-color-panel.c:861
-msgid "Write down this URL."
-msgstr "Catatkan URL ini."
-
-#: panels/color/cc-color-panel.c:862
-msgid "Restart this computer and boot your normal operating system."
-msgstr "Mulakan semula komputer dan but sistem pengoperasian biasa anda."
-
-#: panels/color/cc-color-panel.c:863
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "Taip URL pada pelayar anda untuk memuat turun dan memasang profil."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:891
-msgid "Save Profile"
-msgstr "Simpan Profil"
-
-#: panels/color/cc-color-panel.c:895
-#: panels/network/connection-editor/vpn-helpers.c:300
-msgid "_Save"
-msgstr "_Simpan"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1209
-msgid "Create a color profile for the selected device"
-msgstr "Cipta satu profil warna untuk peranti terpilih"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1224 panels/color/cc-color-panel.c:1248
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Alat pengukuran tidak dikesan. Periksa sama ada ia telah dihidupkan dan "
-"bersambung dengan baik."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1258
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Alat pengukur tidak menyokong pemprofilan pencetak."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1269
-msgid "The device type is not currently supported."
-msgstr "Jenis peranti ini tidak disokong buat masa ini."
-
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Penentukuran Skrin"
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kualiti Penentukuran"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -1018,42 +435,42 @@ msgstr ""
 "anda. Lebih lama penentukuran dijalankan, lebih baik kualiti profil warna "
 "yang dihasilkan."
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "Anda tidak dapat menggunakan komputer ketika penentukuran berlangsung."
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Kualiti"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Masa Anggaran"
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr "Kualiti Penentukuran"
-
-#: panels/color/cc-color-panel.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Pilih peranti pengesan yang anda hendak guna untuk penentukuran."
-
-#: panels/color/cc-color-panel.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Peranti Penentukuran"
 
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
-msgstr "Pilih jenis paparan yang bersambung."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Pilih peranti pengesan yang anda hendak guna untuk penentukuran."
 
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Jenis Paparan"
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Pilih jenis paparan yang bersambung."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Titik Putih Profil"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -1061,11 +478,11 @@ msgstr ""
 "Pilih titik putih sasaran paparan. Kebanyakan paparan seharusnya ditentukur "
 "pada illuminant D65."
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
-msgstr "Titik Putih Profil"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Paparan Kecerahan"
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -1073,7 +490,7 @@ msgstr ""
 "Sila tetapkan paparan pada kecerahan yang anda biasa. Pengurusan warna akan "
 "menjadi lebih tepat pada kecerahan ini."
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -1081,11 +498,11 @@ msgstr ""
 "Sebaliknya, anda boleh guna aras kecerahan yang digunakan dengan salah satu "
 "profil lain untuk peranti ini."
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr "Paparan Kecerahan"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nama Profil"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -1093,286 +510,196 @@ msgstr ""
 "Anda boleh guna satu profil warna pada komputer lain, atau cipta profil "
 "untuk keadaan pencahayaan yang berlainan."
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Nama Profil:"
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "Nama Profil"
-
-#: panels/color/cc-color-panel.ui:392
-msgid "Profile successfully created!"
-msgstr "Berjaya mencipta profil!"
-
-#: panels/color/cc-color-panel.ui:443
-msgid "Copy profile"
-msgstr "Salin profil"
-
-#: panels/color/cc-color-panel.ui:456
-msgid "Requires writable media"
-msgstr "Perlu media boleh tulis"
-
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr "Muat naik profil"
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr "Memerlukan sambungan Internet"
-
-#: panels/color/cc-color-panel.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"Anda mungkin dapati arahan bagaimana menggunakan profil dalam sistem <a href="
-"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> dan <a href=\"windows"
-"\">Microsoft Windows</a> yang berguna."
-
-#: panels/color/cc-color-panel.ui:607
-#: panels/user-accounts/um-fingerprint-dialog.c:720
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Ringkasan"
 
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Berjaya mencipta profil!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Salin profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Perlu media boleh tulis"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Anda mungkin dapati arahan bagaimana menggunakan profil dalam sistem <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> dan <a "
+"href=\"windows\">Microsoft Windows</a> yang berguna."
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "Tambah Profil"
 
-#: panels/color/cc-color-panel.ui:643
-msgid "_Import File…"
-msgstr "_Import Fail…"
-
-#: panels/color/cc-color-panel.ui:672
-#: panels/network/connection-editor/net-connection-editor.c:513
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/region/cc-input-chooser.ui:20
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr "_Tambah"
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Masalah dikesan. Profil mungkin tidak berfungsi dengan baik. <a href="
-"\"\">Tunjuk perincian.</a>"
+"Masalah dikesan. Profil mungkin tidak berfungsi dengan baik. <a "
+"href=\"\">Tunjuk perincian.</a>"
 
-#: panels/color/cc-color-panel.ui:790
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Import Fail…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Tambah"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Setiap peranti memerlukan pengemaskinian profil warna untuk mengurus "
 "warnanya."
 
-#: panels/color/cc-color-panel.ui:812
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Ketahui lagi"
 
-#: panels/color/cc-color-panel.ui:817
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Ketahui lagi mengenai pengurusan warna"
 
-#: panels/color/cc-color-panel.ui:865
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "Tetapkan untuk semua pengguna"
 
-#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
-#: panels/color/cc-color-panel.ui:885
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Tetapkan profil ini semua pengguna pada komputer ini"
 
-#: panels/color/cc-color-panel.ui:880
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "_Benarkan"
 
-#: panels/color/cc-color-panel.ui:911
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "T_ambah profil"
 
-#: panels/color/cc-color-panel.ui:924
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "T_entukur…"
 
-#: panels/color/cc-color-panel.ui:928
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Tentukur peranti"
 
-#: panels/color/cc-color-panel.ui:939
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "_Buang profil"
 
-#: panels/color/cc-color-panel.ui:952
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "_Lihat perincian"
 
-#: panels/color/cc-color-panel.ui:988
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "Tidak dapat mengesan mana-mana peranti yang boleh diurus warnanya"
 
-#: panels/color/cc-color-panel.ui:1032
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/cc-color-panel.ui:1037
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/cc-color-panel.ui:1042
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: panels/color/cc-color-panel.ui:1047
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Projektor"
 
-#: panels/color/cc-color-panel.ui:1052
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plasma"
 
-#: panels/color/cc-color-panel.ui:1057
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (Cahaya belakang CCFL)"
 
-#: panels/color/cc-color-panel.ui:1062
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (Cahaya belakang LED RGB)"
 
-#: panels/color/cc-color-panel.ui:1067
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (cahaya belakang LED putih)"
 
-#: panels/color/cc-color-panel.ui:1072
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "LCD gamut lebar (Cahaya belakang CCFL)"
 
-#: panels/color/cc-color-panel.ui:1077
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "LCD gamut lebar (Cahaya belakang LED merah)"
 
-#: panels/color/cc-color-panel.ui:1094
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Tinggi"
 
-#: panels/color/cc-color-panel.ui:1095
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 minit"
 
-#: panels/color/cc-color-panel.ui:1099
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Sederhana"
 
-#: panels/color/cc-color-panel.ui:1100
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 minit"
 
-#: panels/color/cc-color-panel.ui:1104
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Rendah"
 
-#: panels/color/cc-color-panel.ui:1105
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 minit"
 
-#: panels/color/cc-color-panel.ui:1127
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Tabii pada paparan"
 
-#: panels/color/cc-color-panel.ui:1131
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Percetakan dan penerbitan)"
 
-#: panels/color/cc-color-panel.ui:1135
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/cc-color-panel.ui:1139
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Fotografi dan grafik)"
 
-#: panels/color/cc-color-panel.ui:1143
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:100
-msgid "Standard Space"
-msgstr "Ruang Piawai"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:106
-msgid "Test Profile"
-msgstr "Uji Profail"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:114
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatik"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:124
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Kualiti Rendah"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:129
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Kualiti Sederhana"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:136
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Kualiti Tinggi"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:153
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB lalai"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:160
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK lalai"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:167
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Kelabu lalai"
-
-#: panels/color/cc-color-profile.c:190
-msgid "Vendor supplied factory calibration data"
-msgstr "Data penentukuran kilang yang disediakan pembekal"
-
-#: panels/color/cc-color-profile.c:199
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Pembetulan paparan skrin-penuh mustahil dibuat dengan profil ini"
-
-#: panels/color/cc-color-profile.c:221
-msgid "This profile may no longer be accurate"
-msgstr "Profil ini mungkin tidak lagi tepat"
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1383,297 +710,199 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Tentukur warna peranti anda, seperti paparan, kamera atau pencetak"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Warna;ICC;Profil;Tentukur;Pencetak;Paparan;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Lain-lain…"
-
-#: panels/common/cc-language-chooser.c:127 panels/region/cc-input-chooser.c:178
-msgid "More…"
-msgstr "Lagi…"
-
-#: panels/common/cc-language-chooser.c:144
-msgid "No languages found"
-msgstr "Tiada bahasa ditemui"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
 msgstr "Pilih Bahasa"
 
-#: panels/common/cc-language-chooser.ui:12
+#: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
 msgstr "_Pilih"
 
-#: panels/common/cc-permission-infobar.ui:20
-#| msgid "_Unlock"
-msgid "Unlock…"
-msgstr "Nyahkunci…"
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Tiada bahasa ditemui"
 
-#: panels/common/cc-permission-infobar.ui:45
-#| msgid "Can change settings"
-msgid "Unlock to Change Settings"
-msgstr "Nyahkunci untuk Mengubah Tetapan"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Lagi…"
 
-#: panels/common/cc-permission-infobar.ui:55
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "Beberapa tetapan mesti dinyahkunci sebelum ia boleh diubah."
 
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:143
-msgid "Today"
-msgstr "Hari ini"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Nyahkunci…"
 
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:145
-msgid "Yesterday"
-msgstr "Semalam"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "Masa berbaki: %s"
 
-# msgstr[1] "minit"
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d jam"
-msgstr[1] "%d jam"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: panels/common/cc-util.c:166
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minit"
-msgstr[1] "%d minit"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d saat"
-msgstr[1] "%d saat"
-
-# msgstr[1] "%i jam"
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:172
-#, c-format
-msgctxt "time"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-# msgstr[1] "%i jam"
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:177
-#, c-format
-msgctxt "time"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:187
-msgid "0 seconds"
-msgstr "0 saat"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Kawasan Khas"
-
-#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
-#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
-msgid "Day"
-msgstr "Hari"
-
-#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
-#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
-msgid "Month"
-msgstr "Bulan"
-
-#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
-#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
-msgid "Year"
-msgstr "Tahun"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:334
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:339
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:504
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:531
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:538
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:543
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:548
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:26
-msgid "January"
-msgstr "Januari"
-
-#: panels/datetime/cc-datetime-panel.ui:29
-msgid "February"
-msgstr "Februari"
-
-#: panels/datetime/cc-datetime-panel.ui:32
-msgid "March"
-msgstr "Mac"
-
-#: panels/datetime/cc-datetime-panel.ui:35
-msgid "April"
-msgstr "April"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "May"
-msgstr "Mei"
-
-#: panels/datetime/cc-datetime-panel.ui:41
-msgid "June"
-msgstr "Jun"
-
-#: panels/datetime/cc-datetime-panel.ui:44
-msgid "July"
-msgstr "Julai"
-
-#: panels/datetime/cc-datetime-panel.ui:47
-msgid "August"
-msgstr "Ogos"
-
-#: panels/datetime/cc-datetime-panel.ui:50
-msgid "September"
-msgstr "September"
-
-#: panels/datetime/cc-datetime-panel.ui:53
-msgid "October"
-msgstr "Oktober"
-
-#: panels/datetime/cc-datetime-panel.ui:56
-msgid "November"
-msgstr "November"
-
-#: panels/datetime/cc-datetime-panel.ui:59
-msgid "December"
-msgstr "Disember"
-
-#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Tarikh & Waktu"
 
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Tahun"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Bulan"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januari"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februari"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Mac"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mei"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Jun"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Julai"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Ogos"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Disember"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Hari"
+
 #: panels/datetime/cc-datetime-panel.ui:113
-#: panels/display/cc-night-light-page.ui:194
-#: panels/display/cc-night-light-page.ui:314
-msgid "Hour"
-msgstr "Jam"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: panels/datetime/cc-datetime-panel.ui:128
-msgid "∶"
-msgstr "∶"
-
-#: panels/datetime/cc-datetime-panel.ui:152
-#: panels/display/cc-night-light-page.ui:222
-#: panels/display/cc-night-light-page.ui:342
-msgid "Minute"
-msgstr "Minit"
-
-#: panels/datetime/cc-datetime-panel.ui:219
 msgid "Time Zone"
 msgstr "Zon Waktu"
 
-#: panels/datetime/cc-datetime-panel.ui:240
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Gelintar satu bandar"
 
-#: panels/datetime/cc-datetime-panel.ui:313
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "_Tarikh & Wktu Automatik"
 
-#: panels/datetime/cc-datetime-panel.ui:314
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Memerlukan capaian internet"
 
-#: panels/datetime/cc-datetime-panel.ui:334
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Tarikh & _Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "_Zon Waktu Automatik"
 
-#: panels/datetime/cc-datetime-panel.ui:335
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "Memerlukan perkhidmatan lokasi dibenarkan dan capaian internet"
 
-#: panels/datetime/cc-datetime-panel.ui:350
-msgid "Date & _Time"
-msgstr "Tarikh & _Waktu"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Dibenarkan"
 
-#: panels/datetime/cc-datetime-panel.ui:366
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Z_on Waktu"
 
-#: panels/datetime/cc-datetime-panel.ui:405
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "_Buka"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format Waktu"
 
-#: panels/datetime/cc-datetime-panel.ui:414
-msgid "24-hour"
-msgstr "24-jam"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:415
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Tarikh"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 saat"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalendar"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Bilangan"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Ubah tarikh dan waktu, termasuklah zon waktu"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Jam;Zon Waktu;Lokasi;"
@@ -1686,28 +915,28 @@ msgstr "Ubah tetapan waktu dan tarikh sistem"
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Untuk mengubah tetapan waktu dan tarikh, anda perlukan sahihkan."
 
-#: panels/default-apps/cc-default-apps-panel.ui:31
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "Sesa_wang"
 
-#: panels/default-apps/cc-default-apps-panel.ui:43
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "_Mel"
 
-#: panels/default-apps/cc-default-apps-panel.ui:59
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "_Kalendar"
 
-#: panels/default-apps/cc-default-apps-panel.ui:75
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "M_uzik"
 
-#: panels/default-apps/cc-default-apps-panel.ui:91
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "_Video"
 
-#: panels/default-apps/cc-default-apps-panel.ui:162
-#: panels/removable-media/cc-removable-media-panel.ui:162
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "_Foto"
 
@@ -1719,39 +948,15 @@ msgstr "Aplikasi Lalai"
 msgid "Configure Default Applications"
 msgstr "Konfigur Aplikasi Lalai"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "lalai;aplikasi;dikehendaki;media;"
 
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: panels/diagnostics/cc-diagnostics-panel.c:141
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-"Penghantaran laporan masalah teknikal dapat membantu kami menambah baik %s. "
-"Laporan yang dihantar adalah secara awanama dan tidak melibatkan data "
-"peribadi."
-
-#: panels/diagnostics/cc-diagnostics-panel.c:151
-#: panels/diagnostics/cc-diagnostics-panel.ui:53
-msgid "Reports are sent anonymously and are scrubbed of personal data."
-msgstr "Laporan dihantar secara awanama dan data peribadi disingkirkan."
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:30
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
 msgstr "Pelaporan Masalah"
 
-#: panels/diagnostics/cc-diagnostics-panel.ui:43
-msgid ""
-"Sending reports of technical problems help us improve this operating system."
-msgstr ""
-"Menghantar laporan masalah teknikal dapat bantu kami menambah baik sistem "
-"pengoperasian ini."
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:78
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
 msgid "_Automatic Problem Reporting"
 msgstr "Pelaporan Masalah _Automatik"
 
@@ -1763,147 +968,118 @@ msgstr "Diagnostik"
 msgid "Report your problems"
 msgstr "Lapor masalah anda"
 
-#. FIXME
-#: panels/display/cc-display-panel.c:961
-#: panels/network/connection-editor/connection-editor.ui:27
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "Diagnostik"
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Laksana"
 
-#: panels/display/cc-display-panel.c:982
-msgid "Apply Changes?"
-msgstr "_Laksana Perubahan?"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Undur"
 
-#: panels/display/cc-display-panel.c:987
-msgid "Changes Cannot be Applied"
-msgstr "Perubahan Tidak Dapat Dilaksanakan"
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Nama pengguna telalu panjang."
 
-#: panels/display/cc-display-panel.c:988
-msgid "This could be due to hardware limitations."
-msgstr "Ia disebabkan oleh batasan perkakasan."
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Nyahpasang Paparan"
 
-#: panels/display/cc-display-panel.ui:91
-msgid "Single Display"
-msgstr "Paparan Tunggal"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
 
-#: panels/display/cc-display-panel.ui:110
-#: panels/display/cc-display-panel.ui:315
-msgid "Join Displays"
-msgstr "Paparan Terlibat"
-
-#: panels/display/cc-display-panel.ui:128
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Cermin"
 
-#: panels/display/cc-display-panel.ui:153
-msgid "Display Mode"
-msgstr "Mod Paparan"
-
-#: panels/display/cc-display-panel.ui:222
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Mengandungi palang alat dan Aktiviti"
 
-#: panels/display/cc-display-panel.ui:223
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Paparan Utama"
 
-#: panels/display/cc-display-panel.ui:245
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
-msgstr ""
-"Seret paparan untuk sepadankan persediaan paparan fizikal anda. Pilih satu "
-"paparan untuk mengubah tetapannya."
-
-#: panels/display/cc-display-panel.ui:252
-msgid "Display Arrangement"
-msgstr "Susunan Paparan"
-
-#: panels/display/cc-display-panel.ui:387
-msgid "Active Display"
-msgstr "Paparan Aktif"
-
-#: panels/display/cc-display-panel.ui:434
-msgid "Display Configuration"
-msgstr "Konfigurasi Paparan"
-
-#: panels/display/cc-display-panel.ui:453
-#: panels/display/gnome-display-panel.desktop.in.in:3
-msgid "Displays"
-msgstr "Paparan"
-
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:464
-#: panels/display/cc-night-light-page.ui:111
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Cahaya Malam"
 
-#: panels/display/cc-display-settings.c:104
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Lanskap"
-
-#: panels/display/cc-display-settings.c:107
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Kanan Potret"
-
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Kiri Potret"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Lanskap (dikalih)"
-
-#: panels/display/cc-display-settings.c:187
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:15
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Orientasi"
 
-#: panels/display/cc-display-settings.ui:24
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Resolusi"
 
-#: panels/display/cc-display-settings.ui:33
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Kadar Segar Semula"
 
-#: panels/display/cc-display-settings.ui:42
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Laras untuk TV"
 
-#: panels/display/cc-display-settings.ui:59
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Skala"
 
-#: panels/display/cc-night-light-page.c:622
-msgid "More Warm"
-msgstr "Lebih Hangat"
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Penatalan Tabii"
 
-#: panels/display/cc-night-light-page.c:634
-msgid "Less Warm"
-msgstr "Kurang Hangat"
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:28
-msgid "Restart Filter"
-msgstr "Mula Semula Penapis"
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Cahaya Malam"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:61
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Dilumpuhkan Buat Sementara Sehingga Esok Hari"
 
-#: panels/display/cc-night-light-page.ui:88
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Mula Semula Penapis"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1911,57 +1087,70 @@ msgstr ""
 "Cahaya malam menjadikan warna skrin lebih hangat. Ia dapat menghindari "
 "keletihan mata dan gangguan tidur."
 
-#: panels/display/cc-night-light-page.ui:127
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Jadual"
 
-#: panels/display/cc-night-light-page.ui:136
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Matahari Terbenam hingga Matahari Terbit"
 
-#: panels/display/cc-night-light-page.ui:137
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Jadual Manual"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/region/cc-format-chooser.ui:346
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Waktu"
 
-#: panels/display/cc-night-light-page.ui:165
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Daripada"
 
-#: panels/display/cc-night-light-page.ui:203
-#: panels/display/cc-night-light-page.ui:323
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Jam"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minit"
+
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:234
-#: panels/display/cc-night-light-page.ui:354
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "AM"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:250
-#: panels/display/cc-night-light-page.ui:370
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PM"
 
-#: panels/display/cc-night-light-page.ui:284
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Pada"
 
-#: panels/display/cc-night-light-page.ui:408
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Suhu Warna"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Paparan"
 
 #: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Pilih bagaimana hendak guna monitor dan projektor bersambung"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1970,102 +1159,128 @@ msgstr ""
 "Panel;Projektor;xrandr;Skrin;Resolusi;Segar Semula;Monitor;Malam;Cahaya;Biru;"
 "anjak merah;warna;matahari terbenam;matahari terbit;"
 
-#: panels/info-overview/cc-info-overview-panel.c:406
-#: panels/info-overview/cc-info-overview-panel.c:421
-#: panels/info-overview/cc-info-overview-panel.c:433
-#: panels/info-overview/cc-info-overview-panel.c:479
-#: panels/info-overview/cc-info-overview-panel.c:509
-msgid "Unknown"
-msgstr "Tidak diketahui"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:441
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s: ID Binaan: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Jenis keselamatan"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:456
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Aras Dakwat"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:459
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Aras Dakwat"
 
-#: panels/info-overview/cc-info-overview-panel.c:665
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Aras Dakwat"
 
-#: panels/info-overview/cc-info-overview-panel.c:669
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+#, fuzzy
+msgid "No Events"
+msgstr "Acara"
 
-#: panels/info-overview/cc-info-overview-panel.c:671
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Tidak diketahui"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Keselamatan"
 
-#: panels/info-overview/cc-info-overview-panel.ui:54
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"skrin;kunci;diagnostik;kerosakan;persendirian;baru-baru ini;sementara;tmp;"
+"indeks;nama;rangkaian;identiti;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Nama Peranti"
 
-#: panels/info-overview/cc-info-overview-panel.ui:76
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Alamat Perkakasan"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "Ingatan"
 
-#: panels/info-overview/cc-info-overview-panel.ui:85
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "Pemproses"
 
-#: panels/info-overview/cc-info-overview-panel.ui:94
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "Grafik"
 
-#: panels/info-overview/cc-info-overview-panel.ui:103
+#: panels/info-overview/cc-info-overview-panel.ui:82
 msgid "Disk Capacity"
 msgstr "Kapasiti Cakera"
 
-#: panels/info-overview/cc-info-overview-panel.ui:104
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "Mengira…"
 
 #. translators: this field contains the distro name and version
-#: panels/info-overview/cc-info-overview-panel.ui:126
+#: panels/info-overview/cc-info-overview-panel.ui:98
 msgid "OS Name"
 msgstr "Nama OS"
 
-#: panels/info-overview/cc-info-overview-panel.ui:135
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s: ID Binaan: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Jenis OS"
 
-#: panels/info-overview/cc-info-overview-panel.ui:144
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Versi GNOME"
 
-#: panels/info-overview/cc-info-overview-panel.ui:154
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Sistem Bertetingkap"
 
-#: panels/info-overview/cc-info-overview-panel.ui:162
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Pemayaan"
 
-#: panels/info-overview/cc-info-overview-panel.ui:171
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Kemas Kini Perisian"
 
-#: panels/info-overview/cc-info-overview-panel.ui:192
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Nama Semula Peranti"
 
-#: panels/info-overview/cc-info-overview-panel.ui:209
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -2073,7 +1288,12 @@ msgstr ""
 "Nama peranti yang digunakan untuk kenal pasti peranti ini ketika ia dilihat "
 "melalui rangkaian, atau ketika berpasangan peranti Bluetooth."
 
-#: panels/info-overview/cc-info-overview-panel.ui:226
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Nama Peranti"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "_Nama Semula"
 
@@ -2085,11 +1305,6 @@ msgstr "Perihal"
 msgid "View information about your system"
 msgstr "Lihat maklumat berkenaan sistem anda"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2147,7 +1362,7 @@ msgid "Eject"
 msgstr "Lenting"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:565
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Menaip"
 
@@ -2166,6 +1381,12 @@ msgstr "Pelancar"
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Lancar pelayar bantuan"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Tetapan"
 
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -2188,39 +1409,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Gelintar"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "Tangkap Layar"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "Simpan satu tangkap layar ke dalam $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Simpan satu tangkap layar tetingkap ke dalam $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Simpan satu tangkap layar kawasan ke dalam $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "Salin satu tangkap layar ke dalam papan keratan"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Salin satu tangkap layar tetingkap ke dalam papan keratan"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Salin satu tangkap layar kawasan ke dalam papan keratan"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "Rakam kas skrin pendek"
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistem"
 
@@ -2234,8 +1423,8 @@ msgstr "Kunci skrin"
 
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
-msgid "Universal Access"
-msgstr "Capaian Universal"
+msgid "Accessibility"
+msgstr "Kebolehcapaikan"
 
 #: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
@@ -2269,227 +1458,198 @@ msgstr "Kecilkan saiz teks"
 msgid "High contrast on or off"
 msgstr "Hidup atau matikan beza jelas tinggi"
 
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:8
-#: panels/keyboard/cc-keyboard-panel.ui:72
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Tambah Sumber Input"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Kaedah input tidak dapat digunakan pada skrin daftar masuk"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Tiada sumber input terpilih"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Pilihan"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Bergerak ke Atas"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Bergerak ke Bawah"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Keutamaan"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Susunatur papan kekunci XKB"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr "Buang"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Sumber Input"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+#, fuzzy
+msgid "Includes keyboard layouts and input methods."
+msgstr "Pilih bentangan papan kekunci atau kaedah input."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Pilihan Sumber Input"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Guna sumber yang _sama untuk semua tetingkap"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "Benarkan sumber be_rlainan untuk setiap tetingkap"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
 msgid "Alternate Characters Key"
 msgstr "Kekunci Aksara Pengganti"
 
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:28
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Kekunci aksara pengganti boleh digunakan untuk memasukkan aksara tambahan. "
-"Ia kadang kala dicetak sebagai pilih-ketiga pada papan kekunci anda."
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:45
-msgid "Left Alt"
-msgstr "Alt Kiri"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:61
-msgid "Right Alt"
-msgstr "Alt Kanan"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:77
-msgid "Left Super"
-msgstr "Super Kiri"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:93
-msgid "Right Super"
-msgstr "Super Kanan"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:109
-msgid "Menu key"
-msgstr "Kekunci Menu"
-
-#: panels/keyboard/cc-alt-chars-key-dialog.ui:125
-msgid "Right Ctrl"
-msgstr "Ctrl Kanan"
-
-#: panels/keyboard/cc-keyboard-manager.c:501
-#: panels/keyboard/cc-keyboard-manager.c:509
-#: panels/keyboard/cc-keyboard-manager.c:809
-msgid "Custom Shortcuts"
-msgstr "Pintasan Suai"
-
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: panels/keyboard/cc-keyboard-option.c:337
-msgid "Alternative Characters Key"
-msgstr "Kekunci Aksara Alternatif"
-
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: panels/keyboard/cc-keyboard-option.c:346
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "Kekunci Gubah"
 
-#: panels/keyboard/cc-keyboard-option.c:351
-msgid "Modifiers-only switch to next source"
-msgstr "Suis pengubah suai-sahaja ke sumber berikutnya"
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Pintasan Papan Kekunci"
 
-#: panels/keyboard/cc-keyboard-panel.c:94
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl Kanan"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Pintasan Suai"
 
-#: panels/keyboard/cc-keyboard-panel.c:95
-msgctxt "keyboard key"
-msgid "Menu Key"
-msgstr "Kekunci Menu"
-
-#: panels/keyboard/cc-keyboard-panel.c:96
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Super Kiri"
-
-#: panels/keyboard/cc-keyboard-panel.c:97
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Super Kanan"
-
-#: panels/keyboard/cc-keyboard-panel.c:98
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt Kiri"
-
-#: panels/keyboard/cc-keyboard-panel.c:99
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt Kanan"
-
-#: panels/keyboard/cc-keyboard-panel.c:201
-msgid "Reset All Shortcuts?"
-msgstr "Tetap Semula Semua Pintasan?"
-
-#: panels/keyboard/cc-keyboard-panel.c:204
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Penetapan semula kekunci boleh memberi kesan terhadap pintasan suai anda. "
-"Tindakan ini tidak boleh diundur kembali."
-
-#: panels/keyboard/cc-keyboard-panel.c:208
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:346
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-msgid "Cancel"
-msgstr "Batal"
-
-#: panels/keyboard/cc-keyboard-panel.c:209
-msgid "Reset All"
-msgstr "Teta_p Semula Semua"
-
-#: panels/keyboard/cc-keyboard-panel.c:305
-msgid "Reset the shortcut to its default value"
-msgstr "Tetap semula pintasan ke nilai lalainya"
-
-#: panels/keyboard/cc-keyboard-panel.ui:73
-msgid "Hold down and type to enter different characters"
-msgstr "Tahan dan taip untuk masukkan aksara yang berbeza"
-
-#: panels/keyboard/cc-keyboard-panel.ui:147
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
 msgstr "Tetap Semula Semua…"
 
-#: panels/keyboard/cc-keyboard-panel.ui:148
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Tetap semula semua pintasan ke pengikatan kekunci lalainya"
 
-#: panels/keyboard/cc-keyboard-panel.ui:177
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Aksi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Pintasan"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Pintasan Penyesuaian"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Tambah Pintasan Suai"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Pintasan Penyesuaian"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Tiada pintasan papan kekunci ditemui"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:413
-#, c-format
-#| msgid ""
-#| "%s is already being used for <b>%s</b>. If you replace it, %s will be "
-#| "disabled"
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s sudah digunakan untuk %s. Jika anda ganti ia, %s akan dilumpuhkan"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "Buang"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
-msgid "Set Custom Shortcut"
-msgstr "Tetapkan Pintasan Suai"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "Ganti"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
-msgid "Set Shortcut"
-msgstr "Tetapkan Pintasan"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
 
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:592
-#, c-format
-#| msgid "Enter new shortcut to change <b>%s</b>."
-msgid "Enter new shortcut to change %s."
-msgstr "Masukkan pintasan baharu untuk mengubah %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:1016
-msgid "Add Custom Shortcut"
-msgstr "Tambah Pintasan Suai"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:68
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:318
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Tekan Esc untuk batal atau Backspace untuk lumpuhkan pintasan papan kekunci."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:156
-#: panels/printers/pp-details-dialog.ui:40
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Nama"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:168
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Perintah"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:180
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Pintasan"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:259
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Tetapkan Pintasan…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:272
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Tiada"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:303
-msgid "Enter the new shortcut"
-msgstr "Masukkan pintasan baharu"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Tetap semula pintasan ke nilai lalainya"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:357
-msgid "Remove"
-msgstr "Buang"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:367
-msgid "Add"
-msgstr "Tambah"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:382
-msgid "Replace"
-msgstr "Ganti"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:395
-msgid "Set"
-msgstr "Tetapkan"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Ulangtetap ke de_fault"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
-#: panels/region/cc-region-panel.ui:394 shell/cc-window.ui:327
-msgid "Keyboard Shortcuts"
-msgstr "Pintasan Papan Kekunci"
+msgid "Keyboard"
+msgstr "Papan Kekunci"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
 "Lihat dan ubah pintasan papan kekunci dan tetapkan keutamaan menaip anda"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2497,36 +1657,27 @@ msgstr ""
 "Pintasan;Ruang Kerja;Tetingkap;Saiz Semula;Zum;Beza Jelas;Input;Sumber;Kunci;"
 "Volum;"
 
-#: panels/location/cc-location-panel.ui:31
-msgid "Location services turned off"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
 msgstr "Perkhidmatan lokasi dimatikan"
 
-#: panels/location/cc-location-panel.ui:40
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Tiada aplikasi boleh mendapatkan maklumat lokasi."
 
-#: panels/location/cc-location-panel.ui:74
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"Perkhidmatan lokasi membolehkan aplikasi-aplikasi dapat mengetahui lokasi "
-"anda. Penggunaan Wi-Fi dan jalur lebar mudah alih dapat meningkatkan "
-"ketepatannya."
-
-#: panels/location/cc-location-panel.ui:83
-msgid ""
+"mobile broadband increases accuracy.\n"
+"\n"
 "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
-"Penggunaan Perkhidmatan Lokasi Mozilla: <a href='https://location.services."
-"mozilla.com/privacy'>Dasar Kerahsiaan</a>"
 
-#: panels/location/cc-location-panel.ui:95
-msgid "Allow the applications below to determine your location."
-msgstr "Benarkan aplikasi di bawah menentukan lokasi anda."
-
-#: panels/location/cc-location-panel.ui:115
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Tiada Aplikasi Perlu Tanya Capaian Lokasi"
 
@@ -2534,178 +1685,32 @@ msgstr "Tiada Aplikasi Perlu Tanya Capaian Lokasi"
 msgid "Protect your location information"
 msgstr "Lindungi maklumat lokasi anda"
 
-#. FIXME
-#: panels/lock/cc-lock-panel.ui:29
-msgid ""
-"Automatically locking the screen prevents others from access the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"Kunci skrin secara automatik dapat menghalang orang lain daripada mencapai "
-"komputer ketika anda tiada."
 
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Blank Screen Delay"
-msgstr "Lengah Skrin Gelap"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Tempoh ketidakaktifan selepas skrin menjadi gelap."
-
-#: panels/lock/cc-lock-panel.ui:67
-msgid "Automatic Screen _Lock"
-msgstr "Kun_ci Skrin Automatik"
-
-#: panels/lock/cc-lock-panel.ui:84
-msgid "Automatic _Screen Lock Delay"
-msgstr "Lengah Kunci _Skrin Automatik"
-
-#: panels/lock/cc-lock-panel.ui:85
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "Tempoh selepas skrin gelap ketika skrin terkunci secara automatik."
-
-#: panels/lock/cc-lock-panel.ui:105
-msgid "Show _Notifications on Lock Screen"
-msgstr "Tunjuk _Pemberitahuan bila Skrin Kunci"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:149
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Skrin Dimatikan"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:153
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 saat"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:157
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minit"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:161
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minit"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:165
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minit"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:169
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minit"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:173
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minit"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:177
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 jam"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:192 panels/power/cc-power-panel.ui:63
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minit"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:196 panels/power/cc-power-panel.ui:67
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minit"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:200 panels/power/cc-power-panel.ui:71
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minit"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:204 panels/power/cc-power-panel.ui:75
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minit"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:208 panels/power/cc-power-panel.ui:79
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minit"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:212 panels/power/cc-power-panel.ui:83
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minit"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:216 panels/power/cc-power-panel.ui:87
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minit"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:220 panels/power/cc-power-panel.ui:91
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minit"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:224 panels/power/cc-power-panel.ui:95
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minit"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:228 panels/power/cc-power-panel.ui:99
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Tidak sesekali"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Kunci Skrin"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Kunci skrin anda"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:34
-msgid "Microphone is turned off"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
 msgstr "Mikrofon dimatikan"
 
-#: panels/microphone/cc-microphone-panel.ui:43
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Tiada aplikasi boleh merakam bunyi."
 
-#: panels/microphone/cc-microphone-panel.ui:77
+#: panels/microphone/cc-microphone-panel.ui:37
+#, fuzzy
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
-"properly."
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
 msgstr ""
 "Penggunaan mikrofon membolehkan aplikasi rakam dan dengar audio. Melumpuhkan "
 "mikrofon boleh menyebabkan beberapa aplikasi tidak berfungsi dengan baik."
 
-#: panels/microphone/cc-microphone-panel.ui:87
-msgid "Allow the applications below to use your microphone."
-msgstr "Benarkan aplikasi di bawah menggunakan mikrofon anda."
-
-#: panels/microphone/cc-microphone-panel.ui:107
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Tiada Aplikasi Perlu Tanya Capaian Mikrofon"
 
@@ -2713,104 +1718,171 @@ msgstr "Tiada Aplikasi Perlu Tanya Capaian Mikrofon"
 msgid "Protect your conversations"
 msgstr "Lindungi perbualan anda"
 
-#. FIXME
-#: panels/mouse/cc-mouse-panel.ui:37
-msgid "General"
-msgstr "Am"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:75
-msgid "Primary Button"
-msgstr "Butang Utama"
-
-#: panels/mouse/cc-mouse-panel.ui:94
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "Tetapkan tertib butang fizikal pada tetikus dan pad sentuh."
-
-#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
-msgid "Left"
-msgstr "Kiri"
-
-#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
-msgid "Right"
-msgstr "Kanan"
-
-#: panels/mouse/cc-mouse-panel.ui:169
-msgid "Mouse"
-msgstr "Tetikus"
-
-#: panels/mouse/cc-mouse-panel.ui:208
-msgid "Mouse Speed"
-msgstr "Kelajuan Tetikus"
-
-#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
-msgid "Double-click timeout"
-msgstr "Had masa tamat dwi-lik"
-
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
-msgid "Natural Scrolling"
-msgstr "Penatalan Tabii"
-
-#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
-msgid "Scrolling moves the content, not the view."
-msgstr "Penatalan menggerakkan kandungan, bukan pandangan."
-
-#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
-msgid "Touchpad"
-msgstr "Pad Sentuh"
-
-#: panels/mouse/cc-mouse-panel.ui:501
-msgid "Touchpad Speed"
-msgstr "Kelajuan Pad Sentuh"
-
-#: panels/mouse/cc-mouse-panel.ui:560
-msgid "Tap to Click"
-msgstr "Ketik untuk Klik"
-
-#: panels/mouse/cc-mouse-panel.ui:612
-msgid "Two-finger Scrolling"
-msgstr "Penatalan Dua-jari"
-
-#: panels/mouse/cc-mouse-panel.ui:665
-msgid "Edge Scrolling"
-msgstr "Penatalan Pinggir"
-
-#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:438
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Uji _Tetapan Anda"
 
-#: panels/mouse/cc-mouse-test.c:132 panels/mouse/cc-mouse-test.ui:25
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Am"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Butang Utama"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Tetapkan tertib butang fizikal pada tetikus dan pad sentuh."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Kiri"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Kanan"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Gelintar Lokasi"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Tetikus"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "Kelajuan Tetikus"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Skrol Ke Bawah"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "Penatalan menggerakkan kandungan, bukan pandangan."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Penatalan menggerakkan kandungan, bukan pandangan."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Pemecutan:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktif"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Pad Sentuh"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "Kelajuan Pad Sentuh"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "Ketik untuk Klik"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Ketik untuk Klik"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Memboleh atau melumpuhkan log masuk dari jauh"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Pad Sesentuh (relatif)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Penatalan Pinggir"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Skrol Ke Kiri"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dua-sisi"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Cuba mengklik, dwi-klik, menatal"
-
-#: panels/mouse/cc-mouse-test.c:137
-msgid "Five clicks, GEGL time!"
-msgstr "Lima klik, GEGL time!"
-
-#: panels/mouse/cc-mouse-test.c:142
-msgid "Double click, primary button"
-msgstr "Dwi klik, butang utama"
-
-#: panels/mouse/cc-mouse-test.c:142
-msgid "Single click, primary button"
-msgstr "Klik tunggal, butang utama"
-
-#: panels/mouse/cc-mouse-test.c:145
-msgid "Double click, middle button"
-msgstr "Dwi-klik, butang tengah"
-
-#: panels/mouse/cc-mouse-test.c:145
-msgid "Single click, middle button"
-msgstr "Klik tunggal, butang tengah"
-
-#: panels/mouse/cc-mouse-test.c:148
-msgid "Double click, secondary button"
-msgstr "Dwi-klik, butang sekunder"
-
-#: panels/mouse/cc-mouse-test.c:148
-msgid "Single click, secondary button"
-msgstr "Klik tunggal, butang sekunder"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2823,85 +1895,132 @@ msgstr ""
 "Ubah kepekaan tetikus atau pad sentuh anda dan pilih sama ada kanan atau "
 "kidal"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Pad Jejak;Penuding;Klik;Ketik;Dubel;Butang;Bebola Jejak;Tatal;"
 
-#: panels/network/cc-network-panel.c:648 panels/network/cc-wifi-panel.ui:306
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Alamak, ada masalah berlaku. Sila hubungi pembekal perisian anda."
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: panels/network/cc-network-panel.c:654
-msgid "NetworkManager needs to be running."
-msgstr "Pengurus Rangkaian perlu dijalankan."
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: panels/network/cc-network-panel.ui:68
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Ruang warna: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "Padam _Fail Sementara secara Automatik"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Kawalan"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Aplikasi ditakrif"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Lain-lain Peranti"
 
-#: panels/network/cc-network-panel.ui:109
-#: panels/network/connection-editor/net-connection-editor.c:596
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:153
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Tambah sambungan baharu"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Belum dipasang"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:189
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Bersambung"
 
-#: panels/network/cc-wifi-connection-row.c:249
-msgid "Insecure network (WEP)"
-msgstr "Rangkaian tidak selamat (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:254
-msgid "Secure network (WPA)"
-msgstr "Rangkaian selamat (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:259
-msgid "Secure network (WPA2)"
-msgstr "Rangkaian selamat (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:264
-msgid "Secure network"
-msgstr "Rangkaian selamat"
-
-#: panels/network/cc-wifi-connection-row.ui:102
-#: panels/network/net-device-ethernet.c:318
-#: panels/network/network-bluetooth.ui:76
-#: panels/network/network-ethernet.ui:102 panels/network/network-mobile.ui:414
-#: panels/network/network-vpn.ui:78
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Pilihan…"
 
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:132
-#, c-format
-#| msgid ""
-#| "Turning on the hotspot will disconnect from <b>%s</b>, and it will not be "
-#| "possible to access the internet through Wi-Fi."
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Menghidupkan kawasan khas akan menyebabkan %s terputus, dan tidak boleh "
-"mencapai internet melalui Wi-Fi."
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, fuzzy, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Mesti minimum 8 aksara"
+msgstr[1] "Mesti minimum 8 aksara"
 
-#: panels/network/cc-wifi-hotspot-dialog.c:248
-msgid "Must have a minimum of 8 characters"
-msgstr "Mesti minimum 8 aksara"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:458
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
 msgid "Turn On Wi-Fi Hotspot?"
 msgstr "Hidupkan Kawasan Khas Wi-Fi?"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:19
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
 "Wi-Fi hotspot allows others to share your internet connection, by creating a "
 "Wi-Fi network that they can connect to. To do this, you must have an "
@@ -2912,1088 +2031,455 @@ msgstr ""
 "Untuk membuatnya, anda mesti ada satu sambungan internet bersumber selain "
 "dari Wi-Fi."
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:44
-#: panels/network/network-wifi.ui:105
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
 msgstr "Nama Rangkaian"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:69
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:383
-#: panels/user-accounts/cc-add-user-dialog.ui:249
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Kata laluan"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:83
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Jana Kata Laluan Rawak"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:84
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Auto-jana Kata Laluan"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:130
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "D_ihidupkan"
 
-#: panels/network/cc-wifi-panel.c:277
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:233
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.ui:56
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Mod Kapal Terbang"
 
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Lumpuhkan Wi-Fi, Bluetooth dan jalur lebar bimbit"
 
-#: panels/network/cc-wifi-panel.ui:141
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Tiada Penyesuai Wi-Fi Ditemui"
 
-#: panels/network/cc-wifi-panel.ui:153
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Pastikan anda telah memalam dan menghidupkan penyesuai Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:188
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Mod Kapal Terbang hidup"
 
-#: panels/network/cc-wifi-panel.ui:200
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Matikan untuk guna Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:227
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Kawasan Khas Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Hidupkan Kawasan Khas Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Rangkaian Kelihatan"
 
-#: panels/network/cc-wifi-panel.ui:295
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "Pengurus Rangkaian perlu dijalankan"
 
-#: panels/network/connection-editor/8021x-security-page.ui:20
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Alamak, ada masalah berlaku. Sila hubungi pembekal perisian anda."
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "Ke_selamatan 802.1x"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:114
-#: panels/network/connection-editor/ce-page-security.c:386
-#: panels/network/connection-editor/details-page.ui:90
-msgid "Security"
-msgstr "Keselamatan"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Kekalkan"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Kekal"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Rawak"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabil"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Alamat MAC yang dimasukkan di sini akan digunakan sebagai alamat perkakasan "
-"untuk peranti rangkaian yang mana sambungannya aktif. Fitur ini dikenali "
-"sebagai pengklonan MAC atau perdayaan. Contohnya: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:93
-#: panels/network/net-device-wifi.c:235
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:240
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:106
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:111
-#: panels/network/net-device-wifi.c:225
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Tiada"
-
-#: panels/network/connection-editor/ce-page-details.c:132
-msgid "Never"
-msgstr "Tidak sesekali"
-
-#: panels/network/connection-editor/ce-page-details.c:147
-#: panels/network/net-device-ethernet.c:108
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i hari yang lalu"
 msgstr[1] "%i hari yang lalu"
 
-#: panels/network/connection-editor/ce-page-details.c:272
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-# msgstr[1] ""
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:274
-#: panels/network/net-device-ethernet.c:202
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:291
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:295
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:315
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Tiada"
-
-#: panels/network/connection-editor/ce-page-details.c:317
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Lemah"
-
-#: panels/network/connection-editor/ce-page-details.c:319
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:321
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Baik"
-
-#: panels/network/connection-editor/ce-page-details.c:323
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Bagus"
-
-#: panels/network/connection-editor/ce-page-details.c:381
-#: panels/network/connection-editor/details-page.ui:108
-#: panels/network/net-device-ethernet.c:143
-#: panels/network/net-device-mobile.c:431
-msgid "IPv4 Address"
-msgstr "Alamat IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:382
-#: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-ethernet.c:148
-#: panels/network/net-device-mobile.c:432 panels/network/network-mobile.ui:200
-msgid "IPv6 Address"
-msgstr "Alamat IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:385
-#: panels/network/connection-editor/ce-page-details.c:386
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:435
-#: panels/network/net-device-mobile.c:436 panels/network/network-mobile.ui:183
-msgid "IP Address"
-msgstr "Alamat IP"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-msgid "Forget Connection"
-msgstr "Lupakan Sambungan"
-
-#: panels/network/connection-editor/ce-page-details.c:422
-msgid "Remove Connection Profile"
-msgstr "Buang Profil Sambungan"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-msgid "Remove VPN"
-msgstr "Buang VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:442
-msgid "Details"
-msgstr "Perincian"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatik"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:150
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identiti"
-
-#: panels/network/connection-editor/ce-page-ip4.c:268
-#: panels/network/connection-editor/ce-page-ip6.c:249
-msgid "Delete Address"
-msgstr "Padam Alamat"
-
-#: panels/network/connection-editor/ce-page-ip4.c:428
-#: panels/network/connection-editor/ce-page-ip6.c:398
-msgid "Delete Route"
-msgstr "Padam Hala"
-
-#: panels/network/connection-editor/ce-page-ip4.c:852
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:783
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:257
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Tiada"
-
-#: panels/network/connection-editor/ce-page-security.c:280
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Kunci WEP 40/128-bit (Hex atau ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:290
-msgid "WEP 128-bit Passphrase"
-msgstr "Frasa Laluan WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:303
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:316
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP Dinamik (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:330
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Persendirian"
-
-#: panels/network/connection-editor/ce-page-security.c:344
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/details-page.ui:18
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Kekuatan Isyarat"
 
-#: panels/network/connection-editor/details-page.ui:54
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Kelajuan sambungan"
 
-#: panels/network/connection-editor/details-page.ui:144
-#: panels/network/net-device-ethernet.c:151
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Keselamatan"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Alamat IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Alamat IPv6"
+
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Alamat Perkakasan"
 
-#: panels/network/connection-editor/details-page.ui:162
+#: panels/network/connection-editor/details-page.ui:142
 msgid "Supported Frequencies"
 msgstr "Frekuensi Disokong"
 
-#: panels/network/connection-editor/details-page.ui:180
-#: panels/network/net-device-ethernet.c:155
-#: panels/network/network-mobile.ui:217
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Hala lalai"
 
-#: panels/network/connection-editor/details-page.ui:199
-#: panels/network/connection-editor/ip4-page.ui:211
-#: panels/network/connection-editor/ip6-page.ui:225
-#: panels/network/net-device-ethernet.c:157
-#: panels/network/network-mobile.ui:235
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: panels/network/connection-editor/details-page.ui:217
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Terakhir Digunakan"
 
-#: panels/network/connection-editor/details-page.ui:376
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "Sambung secara _automatik"
 
-#: panels/network/connection-editor/details-page.ui:395
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Jadikan tersedia kepada pengguna _lain"
 
-#: panels/network/connection-editor/details-page.ui:428
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 "Sambungan ber_meter: mempunyai had data atau boleh mengakibatkan cas "
 "dikenakan"
 
-#: panels/network/connection-editor/details-page.ui:439
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
 "Tatar perisian dan lain-lain muat turun bersaiz besar tidak dimulakan secara "
 "automatik."
 
-#: panels/network/connection-editor/ethernet-page.ui:25
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Nama"
 
-#: panels/network/connection-editor/ethernet-page.ui:54
-#: panels/network/connection-editor/wifi-page.ui:67
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "Alamat _MAC"
 
-#: panels/network/connection-editor/ethernet-page.ui:105
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: panels/network/connection-editor/ethernet-page.ui:122
-#: panels/network/connection-editor/wifi-page.ui:102
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "Alamat Ter_klon"
 
-#: panels/network/connection-editor/ethernet-page.ui:137
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "bait"
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "Kaedah IPv_4"
 
-#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "Automatik (DHCP)"
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "Pautan-Setempat Sahaja"
 
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:72 panels/network/network-proxy.ui:116
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "Lumpuhkan"
 
-#: panels/network/connection-editor/ip4-page.ui:97
-#: panels/network/connection-editor/ip6-page.ui:111
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
 msgid "Shared to other computers"
 msgstr "Berkongsi dengan komputer lain"
 
-#: panels/network/connection-editor/ip4-page.ui:125
-#: panels/network/connection-editor/ip6-page.ui:139
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "Alamat-Alamat"
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
-#: panels/printers/pp-details-dialog.ui:95
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Alamat"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Topeng Internet"
 
-#: panels/network/connection-editor/ip4-page.ui:171
-#: panels/network/connection-editor/ip4-page.ui:355
-#: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:369
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Get Laluan"
 
-#: panels/network/connection-editor/ip4-page.ui:223
-#: panels/network/connection-editor/ip4-page.ui:291
-#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/connection-editor/ip6-page.ui:305
-#: panels/network/net-proxy.c:74 panels/network/network-proxy.ui:106
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "Automatik"
 
-#: panels/network/connection-editor/ip4-page.ui:234
-#: panels/network/connection-editor/ip6-page.ui:248
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "DNS Automatik"
 
-#: panels/network/connection-editor/ip4-page.ui:258
-#: panels/network/connection-editor/ip6-page.ui:272
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Asingkan alamat-alamat IP dengan tanda koma"
 
-#: panels/network/connection-editor/ip4-page.ui:279
-#: panels/network/connection-editor/ip6-page.ui:293
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Hala"
 
-#: panels/network/connection-editor/ip4-page.ui:302
-#: panels/network/connection-editor/ip6-page.ui:316
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Hala Automatik"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:368
-#: panels/network/connection-editor/ip6-page.ui:382
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metrik"
 
-#: panels/network/connection-editor/ip4-page.ui:398
-#: panels/network/connection-editor/ip6-page.ui:412
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Guna sambungan ini sa_haja untuk sumber dalam rangkaiannya"
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "Kaedah IPv_6"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "Automatik, DHCP sahaja"
 
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Awalan"
 
-#: panels/network/connection-editor/net-connection-editor.c:291
-msgid "Unable to open connection editor"
-msgstr "Tidak boleh buka penyunting sambungan"
-
-#: panels/network/connection-editor/net-connection-editor.c:307
-msgid "New Profile"
-msgstr "Profil Baru"
-
-#: panels/network/connection-editor/net-connection-editor.c:740
-msgid "Import from file…"
-msgstr "Import daripada fail…"
-
-#: panels/network/connection-editor/net-connection-editor.c:772
-msgid "Add VPN"
-msgstr "Tambah VPN"
-
-#: panels/network/connection-editor/security-page.ui:20
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "K_eselamatan"
 
-#: panels/network/connection-editor/vpn-helpers.c:139
-msgid "Cannot import VPN connection"
-msgstr "Tidak dapat mengimport sambungan VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:141
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Fail \"%s\" tidak dapat baca atau tidak mengandungi maklumat sambungan VPN "
-"yang dikenali\n"
-"\n"
-"Ralat: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:173
-msgid "Select file to import"
-msgstr "Pilih fail untuk diimport"
-
-#: panels/network/connection-editor/vpn-helpers.c:225
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Satu fail bernama \"%s\" sudah wujud."
-
-#: panels/network/connection-editor/vpn-helpers.c:227
-msgid "_Replace"
-msgstr "_Ganti"
-
-#: panels/network/connection-editor/vpn-helpers.c:229
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-"Anda ingin menggantikan %s dengan sambungan VPN yang anda hendak simpan?"
-
-#: panels/network/connection-editor/vpn-helpers.c:264
-msgid "Cannot export VPN connection"
-msgstr "Tidak dapat mengeksport sambungan VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:266
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Sambungan VPN \"%s\" tidak dapat dieksport ke %s.\n"
-"\n"
-"Ralat: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:296
-msgid "Export VPN connection"
-msgstr "Eksport sambungan VPN"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(Ralat: tidak dapat muat penyunting sambungan VPN)"
 
-#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rangkaian"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Kawal bagaimana anda sambung ke Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Rangkaian;IP;LAN;Proksi;WAN;Jalur Lebar;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Kawal bagaimana hendak bersambung dengan rangkaian Wi-Wi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Rangkaian;Tanpa Wayar;Wi-Fi;Wifi;IP;LAN;Jalur Lebar;DNS;Kawasan Khas;"
 
-#: panels/network/net-device-ethernet.c:96
-msgid "never"
-msgstr "tidak sesekali"
-
-#: panels/network/net-device-ethernet.c:104
-msgid "today"
-msgstr "hari ini"
-
-#: panels/network/net-device-ethernet.c:106
-msgid "yesterday"
-msgstr "semalam"
-
-#: panels/network/net-device-ethernet.c:162
-msgid "Last used"
-msgstr "Terakhir digunakan"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:252
-#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Berwayar"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Tambah sambungan baharu"
-
-#: panels/network/net-device-wifi.c:798
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Henti kawasan khas dan putuskan mana-mana pengguna?"
-
-#: panels/network/net-device-wifi.c:801
-msgid "_Stop Hotspot"
-msgstr "_Henti Kawasan Khas"
-
-#: panels/network/net-device-wifi.c:905
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Perincian rangkaian untuk rangkaian terpilih, termasuklah kata laluan dan "
-"lain-lain konfigurasi suai akan hilang."
-
-#: panels/network/net-device-wifi.c:909
-msgid "_Forget"
-msgstr "_Lupakan"
-
-#: panels/network/net-device-wifi.c:1065 panels/network/net-device-wifi.c:1072
-msgid "Known Wi-Fi Networks"
-msgstr "Rangkaian Wi-Fi Diketahui"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1107
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Lupakan"
-
-#: panels/network/net-device-wifi.c:1268
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Dasar sistem menghalang penggunaan sebagai Kawasan Khas"
-
-#: panels/network/net-device-wifi.c:1271
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Peranti tanpa wayar tidak menyokong mod Kawasan Khas"
-
-#: panels/network/net-proxy.c:70
-#: panels/notifications/cc-notifications-panel.c:270
-#: panels/power/cc-power-panel.c:2066 panels/power/cc-power-panel.c:2077
-#: panels/universal-access/cc-ua-panel.c:480
-#: panels/universal-access/cc-ua-panel.c:843
-#: panels/universal-access/cc-ua-panel.c:856
-#: panels/universal-access/cc-ua-panel.c:868
-#: panels/universal-access/cc-ua-panel.c:1033
-#: panels/universal-access/cc-ua-panel.ui:323
-#: panels/universal-access/cc-ua-panel.ui:369
-#: panels/universal-access/cc-ua-panel.ui:415
-#: panels/universal-access/cc-ua-panel.ui:521
-#: panels/universal-access/cc-ua-panel.ui:674
-#: panels/universal-access/cc-ua-panel.ui:720
-#: panels/universal-access/cc-ua-panel.ui:766
-#: panels/universal-access/cc-ua-panel.ui:950
-msgid "Off"
-msgstr "Tutup"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:113
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Auto-penemuan Proksi Sesawang digunakan bila URL Konfigurasi tidak "
-"disediakan."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:121
-msgid "This is not recommended for untrusted public networks."
-msgstr "Tidak disarankan untuk rangkaian-rangkaian awam yang tidak dipercayai."
-
-#. update title
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/net-vpn.c:66 panels/network/net-vpn.c:163
-#, c-format
-msgid "%s VPN"
-msgstr "VPN %s"
-
-#: panels/network/network-bluetooth.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Matikan peranti"
 
-#: panels/network/network-mobile.ui:29
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Aktif"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
-#: panels/network/network-mobile.ui:47
+#: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Penyedia"
 
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:95
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Alamat IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Proksi Rangkaian"
 
-#: panels/network/network-proxy.ui:176
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "Proksi _HTTP"
 
-#: panels/network/network-proxy.ui:195
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "Proksi H_TTPS"
 
-#: panels/network/network-proxy.ui:214
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "Proksi _FTP"
 
-#: panels/network/network-proxy.ui:233
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Hos _Socks"
 
-#: panels/network/network-proxy.ui:252
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "Aba_i Hos"
 
-#: panels/network/network-proxy.ui:290
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Port proksi HTTP"
 
-#: panels/network/network-proxy.ui:367
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Port proksi HTTPS"
 
-#: panels/network/network-proxy.ui:388
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Port proksi FTP"
 
-#: panels/network/network-proxy.ui:409
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Port proksi Socks"
 
-#: panels/network/network-proxy.ui:438
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "URL _Konfigurasi"
 
-#: panels/network/network-vpn.ui:55
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "Putuskan sambungan VPN"
 
-#: panels/network/network-wifi.ui:37
-msgid "Wi-Fi Hotspot"
-msgstr "Kawasan Khas Wi-Fi"
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nama Rangkaian"
 
-#: panels/network/network-wifi.ui:55
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Matikan untuk bersambung dengan rangkaian Wi-Fi"
-
-#: panels/network/network-wifi.ui:123
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Jenis keselamatan"
 
-#: panels/network/network-wifi.ui:175
-msgctxt "Wi-Fi passkey"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Kata laluan"
 
-#: panels/network/network-wifi.ui:264
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Matikan Wi-Fi"
 
-#: panels/network/network-wifi.ui:296
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Pilihan…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Sambung ke Rangkaian Tersembunyi…"
 
-#: panels/network/network-wifi.ui:307
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Hidupkan Kawasan Khas Wi-Fi…"
 
-#: panels/network/network-wifi.ui:318
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Rangkaian Wi-Fi Diketahui"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Status tidak diketahui"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Tidak Diurus"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Tiada"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Menyambung"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Pengesahihan diperlukan"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:63
-msgid "Connected"
-msgstr "Bersambung"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Diputuskan"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Sambungan gagal"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Status tidak diketahui (hilang)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Konfigurasi gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Konfigurasi IP gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Konfigurasi IP telah luput"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Rahsia diperlukan, tetapi tidak disediakan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Perayu 802.1 telah terputus"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Konfigurasi perayu 802.1 telah gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Perayu 802.1 telah gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Perayu 802.1 mengambil masa yang lama untuk disahihkan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Perkhidmatan PPP gagal dimulakan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Perkhidmatan PPP terputus"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Klien DHCP gagal dimulakan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Ralat klien DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Klien DHCP gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Perkhidmatan sambungan berkongsi gagal dimulakan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Perkhidmatan sambungan terkongsi gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Perkhidmatan AutoIP gagal dimulakan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Ralat perkhidmatan AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Perkhidmatan AutoIP gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Talian sibuk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Tiada nada dail"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Tiada pembawa ditubuhkan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Permintaan dailan telah tamat masa"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Percubaan dailan telah gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Pengawalan modem gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Gagal memilih APN dinyatakan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Tidak menggelintar rangkaian"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Pendaftaran rangkaian dinafikan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Pendaftaran rangkaian tamat masa"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Gagal daftar dengan rangkaian yang dipinta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Semakan PIN gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Perisian tegar untuk peranti mungkin hilang"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Sambungan hilang"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Sambungan sedia ada telah dianggap"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem tidak ditemui"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Sambungan Bluetooth telah gagal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Kad SIM tidak disisip"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Pin SIM diperlukan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Puk SIM diperlukan"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252
-msgid "SIM wrong"
-msgstr "SIM salah"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Dependensi sambungan telah gagal"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:351
-msgid "Firmware missing"
-msgstr "Perisian tegar hilang"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:355
-msgid "Cable unplugged"
-msgstr "Kabel ditanggalkan"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "ralat tidak ditakrif dalam keselamatan 802.X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:153
-msgid "no file selected"
-msgstr "tiada fail terpilih"
-
-#: panels/network/wireless-security/eap-method.c:180
-msgid "unspecified error validating eap-method file"
-msgstr "ralat tidak dinyatakan ketika mengesahkan fail eap-method"
-
-#: panels/network/wireless-security/eap-method.c:355
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr ""
-"Kunci-kunci persendirian DER, PEM, atau PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:358
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Sijil-sijil DER atau PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:90
-msgid "missing EAP-FAST PAC file"
-msgstr "fail PAC EAP-FAST hilang"
-
-#: panels/network/wireless-security/eap-method-fast.c:300
-msgid "Choose a PAC file"
-msgstr "Pilih satu fail PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:305
-msgid "PAC files (*.pac)"
-msgstr "Fail PAC (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4019,75 +2505,54 @@ msgstr "Disahihkan"
 msgid "Both"
 msgstr "Kedua-duanya"
 
-#: panels/network/wireless-security/eap-method-fast.ui:49
-#: panels/network/wireless-security/eap-method-peap.ui:52
-#: panels/network/wireless-security/eap-method-ttls.ui:51
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
 msgid "Anony_mous identity"
 msgstr "Identiti a_wanama"
 
-#: panels/network/wireless-security/eap-method-fast.ui:75
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "_Fail PAC"
 
-#: panels/network/wireless-security/eap-method-fast.ui:115
-#: panels/network/wireless-security/eap-method-peap.ui:150
-#: panels/network/wireless-security/eap-method-ttls.ui:143
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Pilih satu fail PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "Pengesahihan da_laman"
 
-#: panels/network/wireless-security/eap-method-fast.ui:144
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Benarkan pembe_kalan PAC automatik"
 
-#: panels/network/wireless-security/eap-method-leap.c:69
-msgid "missing EAP-LEAP username"
-msgstr "nama pengguna EAP-LEAP hilang"
-
-#: panels/network/wireless-security/eap-method-leap.c:78
-msgid "missing EAP-LEAP password"
-msgstr "kata laluan EAP-LEAP hilang"
-
-#: panels/network/wireless-security/eap-method-leap.ui:17
-#: panels/network/wireless-security/eap-method-simple.ui:17
-#: panels/network/wireless-security/ws-leap.ui:18
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "Nama P_engguna"
 
-#: panels/network/wireless-security/eap-method-leap.ui:31
-#: panels/network/wireless-security/eap-method-simple.ui:31
-#: panels/network/wireless-security/ws-leap.ui:32
-#: panels/network/wireless-security/ws-wpa-psk.ui:14
-#: panels/sharing/cc-sharing-panel.ui:351
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:204
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Kata Laluan"
 
-#: panels/network/wireless-security/eap-method-leap.ui:55
-#: panels/network/wireless-security/eap-method-simple.ui:73
-#: panels/network/wireless-security/eap-method-tls.ui:157
-#: panels/network/wireless-security/ws-leap.ui:56
-#: panels/network/wireless-security/ws-wpa-psk.ui:64
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Tunjuk kata laluan"
-
-#: panels/network/wireless-security/eap-method-peap.c:90
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "sijil CA EAP-PEAP tidak sah: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:99
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "sijil CA EAP-PEAP tidak sah: tiada sijil dinyatakan"
-
-#: panels/network/wireless-security/eap-method-peap.c:281
-#: panels/network/wireless-security/eap-method-tls.c:496
-#: panels/network/wireless-security/eap-method-ttls.c:289
-msgid "Choose a Certificate Authority certificate"
-msgstr "Pilih satu sijil Certificate Authority"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4103,103 +2568,43 @@ msgstr "Versi 0"
 msgid "Version 1"
 msgstr "Versi 1"
 
-#: panels/network/wireless-security/eap-method-peap.ui:78
-#: panels/network/wireless-security/eap-method-tls.ui:68
-#: panels/network/wireless-security/eap-method-ttls.ui:102
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "Sijil C_A"
 
-#: panels/network/wireless-security/eap-method-peap.ui:100
-#: panels/network/wireless-security/eap-method-tls.ui:90
-#: panels/network/wireless-security/eap-method-ttls.ui:125
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Pilih satu sijil Certificate Authority"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "Tiada sijil CA _diperlukan"
 
-#: panels/network/wireless-security/eap-method-peap.ui:118
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versi PEAP"
 
-#: panels/network/wireless-security/eap-method-simple.c:80
-msgid "missing EAP username"
-msgstr "nama pengguna EAP hilang"
-
-#: panels/network/wireless-security/eap-method-simple.c:93
-msgid "missing EAP password"
-msgstr "kata laluan EAP hilang"
-
-#: panels/network/wireless-security/eap-method-tls.c:81
-msgid "missing EAP-TLS identity"
-msgstr "identiti EAP-TLS hilang"
-
-#: panels/network/wireless-security/eap-method-tls.c:91
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "sijil CA EAP-TLS tidak sah: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:100
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "sijil CA EAP-TLS tidak sah: tiada sijil dinyatakan"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "kunci-persendirian EAP-TLS tidak sah: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:123
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "sijil-pengguna EAP-TLS tidak sah: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Kunci persendirian tidak disulitkan adalah tidak selamat"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Kunci persendirian terpilih nampaknya tidak dilindungi oleh satu kata "
-"laluan. Ia mungkin membolehkan kelayakan keselamatan anda tergugat. Sila "
-"pilih satu kunci persendirian dilindungi-kata-laluan.\n"
-"\n"
-"(Anda boleh lindungi berkata laluan kunci persendirian anda dengan openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:489
-msgid "Choose your personal certificate"
-msgstr "Pilih sijil peribadi anda"
-
-#: panels/network/wireless-security/eap-method-tls.c:503
-msgid "Choose your private key"
-msgstr "Pilih kunci persendirian anda"
-
-#: panels/network/wireless-security/eap-method-tls.ui:17
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "I_dentiti"
 
-#: panels/network/wireless-security/eap-method-tls.ui:43
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "Sijil pengg_una"
 
-#: panels/network/wireless-security/eap-method-tls.ui:108
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "_Kunci persendirian"
 
-#: panels/network/wireless-security/eap-method-tls.ui:133
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Kata laluan kunci _persendirian"
-
-#: panels/network/wireless-security/eap-method-ttls.c:101
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "sijil CA EAP-TTLS tidak sah: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:109
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "sijil CA EAP-TTLS tidak sah: tiada sijil dinyatakan"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4217,20 +2622,20 @@ msgstr "MSCHAPv2 (tanpa EAP)"
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.ui:76
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
 msgid "_Domain"
 msgstr "_Domain"
-
-#: panels/network/wireless-security/wireless-security.c:107
-msgid "Unknown error validating 802.1X security"
-msgstr "Ralat tidak diketahui ketika mengesahkan keselamatan 802.1X"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4252,56 +2657,16 @@ msgstr "TLS berterowong"
 msgid "Protected EAP (PEAP)"
 msgstr "EAP Terlindung (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:56
-#: panels/network/wireless-security/ws-wep-key.ui:102
-#: panels/network/wireless-security/ws-wpa-eap.ui:61
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Pen_gesahihan"
 
-#: panels/network/wireless-security/ws-leap.c:84
-msgid "missing leap-username"
-msgstr "nama-pengguna-leap hilang"
-
-#: panels/network/wireless-security/ws-leap.c:93
-msgid "missing leap-password"
-msgstr "kata-laluan-leap hilang"
-
-#: panels/network/wireless-security/ws-wep-key.c:117
-msgid "missing wep-key"
-msgstr "kunci-WEP hilang"
-
-#: panels/network/wireless-security/ws-wep-key.c:126
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"kunci-wep tidak sah: kunci dengan panjang %zu mesti mengandungi digit-heks "
-"sahaja"
-
-#: panels/network/wireless-security/ws-wep-key.c:134
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"kunci-wep tidak sah: kunci dengan panjang %zu mesti mengandungi aksara ascii "
-"sahaja"
-
-#: panels/network/wireless-security/ws-wep-key.c:140
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"kunci-wep tidak sah: panjang kunci %zu adalah salah. Sebuah kunci mesti "
-"panjangnya 5/13 (acsii) atau 10/26 (heks)"
-
-#: panels/network/wireless-security/ws-wep-key.c:147
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "kunci-wep tidak sah: kunci frasa laluan mesti tidak-kosong"
-
-#: panels/network/wireless-security/ws-wep-key.c:149
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"kunci-wep tidak sah: frasa laluan mesti lebih pendek daripada 64 aksara"
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Jenis"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4315,54 +2680,36 @@ msgstr "Sistem Terbuka"
 msgid "Shared Key"
 msgstr "Kunci Dikongsi"
 
-#: panels/network/wireless-security/ws-wep-key.ui:48
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "_Kunci"
 
-#: panels/network/wireless-security/ws-wep-key.ui:84
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "T_unjuk kunci"
 
-#: panels/network/wireless-security/ws-wep-key.ui:134
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Indek_s WEP"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:89
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk tidak sah: panjang kunci %zu tidak sah. Mesti [8.63] bait atau 64 "
-"digit heks"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:98
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk tidak sah: tidak dapat mentafsir kunci dengan 64 bait sebagai heks"
-
-#: panels/network/wireless-security/ws-wpa-psk.ui:42
-msgid "_Type"
-msgstr "_Jenis"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:60
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "Pem_beritahuan"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:112
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "_Amaran Bunyi"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:168
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "Pemberitahuan _Timbul"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:184
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
@@ -4371,36 +2718,26 @@ msgstr ""
 "timbul dilumpuhkan."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:249
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "Tunjuk _Kandungan Mesej dalam Dialog Timbul"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:300
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "Pemberitahuan Skrin _Kunci"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:351
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "Tunjuk Ka_ndungan Mesej pada Skrin Kunci"
 
-#: panels/notifications/cc-notifications-panel.c:270
-#: panels/power/cc-power-panel.c:2072 panels/power/cc-power-panel.c:2079
-#: panels/universal-access/cc-ua-panel.c:480
-#: panels/universal-access/cc-ua-panel.c:843
-#: panels/universal-access/cc-ua-panel.c:856
-#: panels/universal-access/cc-ua-panel.c:868
-#: panels/universal-access/cc-ua-panel.c:1033
-msgid "On"
-msgstr "Hidup"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
 
-#: panels/notifications/cc-notifications-panel.ui:70
-msgid "Notification _Popups"
-msgstr "Pemberitahuan _Timbul"
-
-#: panels/notifications/cc-notifications-panel.ui:121
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr "Pemberitahuan Skrin _Kunci"
 
@@ -4408,35 +2745,33 @@ msgstr "Pemberitahuan Skrin _Kunci"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Kawal pemberitahuan yang manakah dipapar dan apakah yang ditunjukkan"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Pemberitahuan;Sepanduk;Mesej;Talam;Timbul;"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:150
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Lain-lain"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Buat Asal"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:627
-#, c-format
-msgid "%s Account"
-msgstr "Akaun %s"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Pengesahihan da_laman"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:924
-msgid "Error removing account"
-msgstr "Ralat membuang akaun"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Bersambung dengan data anda dalam awam"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:991
-#, c-format
-#| msgid "<b>%s</b> removed"
-msgid "%s removed"
-msgstr "%s dibuang"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Tiada sambungan internet — sambung untuk sediakan akaun dalam talian baharu"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Tambah satu akaun"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4446,10 +2781,6 @@ msgstr "Akaun Dalam Talian"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Sambung ke akaun atas-talian anda dan tentukan apa kegunaannya"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4458,33 +2789,7 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Sesawang;Atas-Talian;Sembang;Kalendar;Mel;"
 "Kenalan;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
-msgid "Undo"
-msgstr "Buat Asal"
-
-#: panels/online-accounts/online-accounts.ui:96
-msgid "Connect to your data in the cloud"
-msgstr "Bersambung dengan data anda dalam awam"
-
-#: panels/online-accounts/online-accounts.ui:111
-msgid "No internet connection — connect to set up new online accounts"
-msgstr ""
-"Tiada sambungan internet — sambung untuk sediakan akaun dalam talian baharu"
-
-#: panels/online-accounts/online-accounts.ui:136
-msgid "Add an account"
-msgstr "Tambah satu akaun"
-
-#: panels/online-accounts/online-accounts.ui:243
-msgid "Remove Account"
-msgstr "Buang Akaun"
-
-#: panels/power/cc-power-panel.c:334
-msgid "Unknown time"
-msgstr "Masa tidak diketahui"
-
-#: panels/power/cc-power-panel.c:340
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
@@ -4492,348 +2797,176 @@ msgstr[0] "%i minit"
 msgstr[1] "%i minit"
 
 # msgstr[1] "minit"
-#: panels/power/cc-power-panel.c:352
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i jam"
 msgstr[1] "%i jam"
 
-# msgstr[1] "%i jam"
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-power-panel.c:360
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: panels/power/cc-power-panel.c:361
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "jam"
 msgstr[1] "jam"
 
 # msgstr[1] "jam"
-#: panels/power/cc-power-panel.c:362
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minit"
 msgstr[1] "minit"
 
-# msgstr[1] "minit"
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:380
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s sehingga sepenuhnya dicas"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:387
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Amaran: %s berbaki"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:392
-#, c-format
-msgid "%s remaining"
-msgstr "%s berbaki"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:397 panels/power/cc-power-panel.c:427
-msgid "Fully charged"
-msgstr "Sepenuhnya dicas"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:401 panels/power/cc-power-panel.c:431
-msgid "Not charging"
-msgstr "Tidak dicas"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:405 panels/power/cc-power-panel.c:435
-msgid "Empty"
-msgstr "Habis"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:418
-msgid "Charging"
-msgstr "Mengecas"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:423
-msgid "Discharging"
-msgstr "Menyahcas"
-
-#: panels/power/cc-power-panel.c:556
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Utama"
-
-#: panels/power/cc-power-panel.c:558
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Tambahan"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:633
-msgid "Wireless mouse"
-msgstr "Tetikus tanpa wayar"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:636
-msgid "Wireless keyboard"
-msgstr "Papan kekunci tanpa wayar"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:639
-msgid "Uninterruptible power supply"
-msgstr "Bekalan kuasa tanpa gangguan"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:642
-msgid "Personal digital assistant"
-msgstr "Pembantu digital peribadi"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:645
-msgid "Cellphone"
-msgstr "Telefon bimbit"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:648
-msgid "Media player"
-msgstr "Pemain media"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:651 panels/wacom/cc-wacom-panel.c:815
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:654
-msgid "Computer"
-msgstr "Komputer"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:657
-msgid "Gaming input device"
-msgstr "Peranti input permainan"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-power-panel.c:660 panels/power/cc-power-panel.c:942
-#: panels/power/cc-power-panel.c:2422
-msgid "Battery"
-msgstr "Bateri"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:721
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Mengecas"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:728
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Amaran"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:733
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Rendah"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:738
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Baik"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:743
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Sepenuhnya dicas"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:747
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Habis"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Batteries"
-msgstr "Bateri-Bateri"
-
-#: panels/power/cc-power-panel.c:1381
-msgid "When _idle"
-msgstr "Bila me_lahu"
-
-#: panels/power/cc-power-panel.c:1827
-msgid "Power Saving"
-msgstr "Penjimatan Kuasa"
-
-#: panels/power/cc-power-panel.c:1861
-msgid "_Screen Brightness"
-msgstr "_Kecerahan Skrin"
-
-#: panels/power/cc-power-panel.c:1882
-msgid "Automatic Brightness"
-msgstr "Kecerahan Automatik"
-
-#: panels/power/cc-power-panel.c:1895
-msgid "_Keyboard Brightness"
-msgstr "_Kecerahan Papan Kekunci"
-
-#: panels/power/cc-power-panel.c:1906
-msgid "_Dim Screen When Inactive"
-msgstr "_Malap Skrin Bila Tidak Aktif"
-
-#: panels/power/cc-power-panel.c:1924
-msgid "_Blank Screen"
-msgstr "Skrin _Gelap"
-
-#: panels/power/cc-power-panel.c:1947
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: panels/power/cc-power-panel.c:1948
-msgid "Wi-Fi can be turned off to save power."
-msgstr "Wi-Fi boleh dimatikan untuk menjimatkan kuasa."
-
-#: panels/power/cc-power-panel.c:1964
-msgid "_Mobile Broadband"
-msgstr "_Jalur Lebar Mudah Alih"
-
-#: panels/power/cc-power-panel.c:1965
-msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
-msgstr ""
-"Jalur lebar mudah alih (LTE, 4G, 3G, dll.) boleh dimatikan untuk menjimatkan "
-"kuasa."
-
-#: panels/power/cc-power-panel.c:2015
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: panels/power/cc-power-panel.c:2016
-msgid "Bluetooth can be turned off to save power."
-msgstr "Bluetooth boleh dimatikan untuk menjimatkan kuasa."
-
-#: panels/power/cc-power-panel.c:2068
-msgid "When on battery power"
-msgstr "Bila guna kuasa bateri"
-
-#: panels/power/cc-power-panel.c:2070
-msgid "When plugged in"
-msgstr "Bila dipalam masuk"
-
-#: panels/power/cc-power-panel.c:2164
-msgid "Suspend"
-msgstr "Tangguh"
-
-#: panels/power/cc-power-panel.c:2165
-msgid "Power Off"
-msgstr "Matikan"
-
-#: panels/power/cc-power-panel.c:2166
-msgid "Hibernate"
-msgstr "Hibernasi"
-
-#: panels/power/cc-power-panel.c:2167
-msgid "Nothing"
-msgstr "Tiada apa"
-
-#. Frame header
-#: panels/power/cc-power-panel.c:2267
-msgid "Suspend & Power Button"
-msgstr "Butang Tangguh & Kuasa"
-
-#: panels/power/cc-power-panel.c:2308
-msgid "_Automatic Suspend"
-msgstr "Tangguh _Automatik"
-
-#: panels/power/cc-power-panel.c:2309
-msgid "Automatic suspend"
-msgstr "Tangguh automatik"
-
-#: panels/power/cc-power-panel.c:2366
-msgid "Po_wer Button Action"
-msgstr "Tindakan Butang K_uasa"
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "15 minit"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "20 minit"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "25 minit"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 minit"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 minit"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 jam"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 minit"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 minit"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 minit"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 jam"
 
-#: panels/power/cc-power-panel.ui:147
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bateri"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Peranti-Peranti"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Pengurusan kuasa"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Penjimatan Kuasa"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Kecerahan Automatik"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Skrin"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Pemba_ca Skrin"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "Pelaporan Masalah _Automatik"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "Tangguh _Automatik"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Tindakan Butang K_uasa"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Tangguh Automatik"
 
-#: panels/power/cc-power-panel.ui:172
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "D_ipalamkan"
 
-#: panels/power/cc-power-panel.ui:188
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Guna Kuasa _Bateri"
 
-#: panels/power/cc-power-panel.ui:233 panels/power/cc-power-panel.ui:293
-#: panels/universal-access/cc-ua-panel.ui:1527
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Lengah"
 
@@ -4845,50 +2978,14 @@ msgstr "Kuasa"
 msgid "View your battery status and change power saving settings"
 msgstr "Lihat status bateri anda dan ubah tetapan penjimatan kuasa"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "Kuasa;Tidur;Tangguh;Hibernasi;Bateri;Kecerahan;Malap;Gelap;Monitor;DPMS;"
 "Melahu;"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "Sahihkan"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:362
-msgid "Username"
-msgstr "Namapengguna"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:337
-msgid "Authentication Required"
-msgstr "Pengesahihan Diperlukan"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:715
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Pencetak \"%s\" telah dipadamkan"
-
-# msgstr[1] ""
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:938
-msgid "Failed to add new printer."
-msgstr "Gagal menambah pencetak baharu."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1242
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Tidak dapat memuatkan ui: %s"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4899,932 +2996,348 @@ msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Tambah pencetak, lihat kerja cetak dan tentukan bagaimana anda hendak cetak"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Pencetak;Baris Gilir;Cetak;Kertas;Dakwat;Toner;"
 
-#. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/jobs-dialog.ui:44
-msgid "Domain"
-msgstr "Domain"
-
-#. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/jobs-dialog.ui:123
-msgid "A_uthenticate"
-msgstr "Sa_hihkan"
-
-#. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/jobs-dialog.ui:163
-msgid "Clear All"
-msgstr "Kosongkan Semua"
-
-#. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/jobs-dialog.ui:225
-msgid "_Authenticate"
-msgstr "_Sahkan"
-
-#. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/jobs-dialog.ui:354
-msgid "No Active Printer Jobs"
-msgstr "Tiada Kerja Pencetak Aktif"
-
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:363
-#: panels/printers/pp-new-printer-dialog.c:427
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Tambah Pencetak"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Buka"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Tiada Pencetak Ditemui"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Masukkan satu alamat rangkaian atau gelintar satu pencetak"
 
-#: panels/printers/new-printer-dialog.ui:353
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Pengesahihan Diperlukan"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Masukkan nama pengguna dan kata laluan untuk melihat pencetak dalam Pelayan "
 "Cetak."
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:75
-#: panels/printers/pp-details-dialog.c:370
-#, c-format
-msgid "%s Details"
-msgstr "Perincian %s"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Namapengguna"
 
-#: panels/printers/pp-details-dialog.c:122
-msgid "No suitable driver found"
-msgstr "Tiada pemacu yang sesuai ditemui"
-
-#: panels/printers/pp-details-dialog.c:249
-msgid "Select PPD File"
-msgstr "Pilih Fail PPD"
-
-#: panels/printers/pp-details-dialog.c:258
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"Fail Keterangan Pencetak Pos Skrip (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
 
-#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Lokasi"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:122
-#: panels/printers/pp-ppd-selection-dialog.c:250
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Pemacu"
 
-#: panels/printers/pp-details-dialog.ui:162
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Menggelintar pemacu yang dikehendaki…"
 
-#: panels/printers/pp-details-dialog.ui:183
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Gelintar Pemacu"
 
-#: panels/printers/pp-details-dialog.ui:192
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Pilih dari Pangkalan Data…"
 
-#: panels/printers/pp-details-dialog.ui:201
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Pasang Fail PPD…"
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "Pilih Pemacu Pencetak"
 
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:109
-msgid "Select"
-msgstr "Pilih"
-
-#: panels/printers/ppd-selection-dialog.ui:73
+#: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "Memuatkan pangkalan data pemacu…"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:479
-msgid "JetDirect Printer"
-msgstr "Pencetak JetDirect"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Batal"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:714
-msgid "LPD Printer"
-msgstr "Pencetak LPD"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Pilih"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:65
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Satu Sisi"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:67
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Pinggir Panjang (Piawai)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:69
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Pinggir Pendek (Kalih)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:71
-msgid "Portrait"
-msgstr "Potret"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:73
-msgid "Landscape"
-msgstr "Lanskap"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:75
-msgid "Reverse landscape"
-msgstr "Lanskap terbalik"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:77
-msgid "Reverse portrait"
-msgstr "Potret terbalik"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-jobs-dialog.c:234
-msgctxt "print job"
-msgid "Pending"
-msgstr "Tertangguh"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-jobs-dialog.c:240
-msgctxt "print job"
-msgid "Paused"
-msgstr "Dijedakan"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-jobs-dialog.c:245
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Pengesahihan diperlukan"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-jobs-dialog.c:250
-msgctxt "print job"
-msgid "Processing"
-msgstr "Memproses"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-jobs-dialog.c:254
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Dihentikan"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-jobs-dialog.c:258
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Dibatalkan"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-jobs-dialog.c:262
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Dihenti Paksa"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-jobs-dialog.c:266
-msgctxt "print job"
-msgid "Completed"
-msgstr "Selesai"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:390
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u Kerja Memerlukan Pengesahihan"
 msgstr[1] "%u Kerja Memerlukan Pengesahihan"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:613
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Kerja-Kerja Aktif"
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domain"
 
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:617
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Masukkan kelayakan untuk mencetak daripada %s."
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "Sa_hihkan"
 
-#: panels/printers/pp-new-printer-dialog.c:380
-msgid "Unlock Print Server"
-msgstr "Buka Pelayan Cetak"
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Kosongkan Semua"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:384
-#, c-format
-msgid "Unlock %s."
-msgstr "Buka %s."
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Sahkan"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:388
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Masukkan nama pengguna dan kata laluan untuk melihat pencetak dalam %s."
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Tiada Kerja Pencetak Aktif"
 
-#: panels/printers/pp-new-printer-dialog.c:838
-msgid "Searching for Printers"
-msgstr "Menggelintar Pencetak"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1697
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1702
-msgid "Serial Port"
-msgstr "Port Serial"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1709
-msgid "Parallel Port"
-msgstr "Port Parallel"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1751
-#, c-format
-msgid "Location: %s"
-msgstr "Lokasi: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1756
-#, c-format
-msgid "Address: %s"
-msgstr "Alamat: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1783
-msgid "Server requires authentication"
-msgstr "Pelayan memerlukan pengesahihan"
-
-#: panels/printers/pp-options-dialog.c:91
-msgid "Two Sided"
-msgstr "Dua Sisi"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "Paper Type"
-msgstr "Jenis Kertas"
-
-#: panels/printers/pp-options-dialog.c:93
-msgid "Paper Source"
-msgstr "Sumber Kertas"
-
-#: panels/printers/pp-options-dialog.c:94
-msgid "Output Tray"
-msgstr "Talam Output"
-
-#: panels/printers/pp-options-dialog.c:95
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolusi"
-
-#: panels/printers/pp-options-dialog.c:96
-msgid "GhostScript pre-filtering"
-msgstr "Pra-penapisan GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:534
-msgid "Pages per side"
-msgstr "Halaman per muka"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:546
-msgid "Two-sided"
-msgstr "Dua-sisi"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:558
-msgid "Orientation"
-msgstr "Orientasi"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Am"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Persediaan Halaman"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Pilihan Boleh Pasang"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Kerja"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Kualiti Imej"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Warna"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Menyelesaikan"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:676
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Lanjutan"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:869
-#: panels/printers/pp-options-dialog.ui:18
+#: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Halaman Uji"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:882
-msgid "Test page"
-msgstr "Halaman uji"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Pilih Sendiri"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Lalai Pencetak"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Fon Ghostscript Terbenam sahaja"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Tukar ke PS aras 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Tukar ke PS aras 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Tiada Pra-penapisan"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "Pengeluar"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:597 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr "Tiada Kerja-Kerja Aktif"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:602
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u Kerja"
 msgstr[1] "%u Kerja"
 
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:757
-msgid "Low on toner"
-msgstr "Kekurangan toner"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:759
-msgid "Out of toner"
-msgstr "Kehabisan toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:762
-msgid "Low on developer"
-msgstr "Kekurangan penjadi"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:765
-msgid "Out of developer"
-msgstr "Kehabisan penjadi"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:767
-msgid "Low on a marker supply"
-msgstr "Kekurangan bekalan penanda"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:769
-msgid "Out of a marker supply"
-msgstr "Kehabisan bekalan penanda"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:771
-msgid "Open cover"
-msgstr "Buka penutup"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:773
-msgid "Open door"
-msgstr "Buka pintu"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:775
-msgid "Low on paper"
-msgstr "Kekurangan kertas"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:777
-msgid "Out of paper"
-msgstr "Kehabisan kertas"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:779
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Luar Talian"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:781
-#: panels/printers/pp-printer-entry.c:909
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Dihentikan"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:783
-msgid "Waste receptacle almost full"
-msgstr "Bekas sisa hampir penuh"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:785
-msgid "Waste receptacle full"
-msgstr "Bekas sisa penuh"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:787
-msgid "The optical photo conductor is near end of life"
-msgstr "Konduktor foto optik sudah menghampiri jangka hayatnya"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:789
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Konduktor foto optik sudah tidak berfunngsi"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:895
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Sedia"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:900
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Jangan terima kerja"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:905
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Memproses"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:929
-msgid "Clean print heads"
-msgstr "Bersihkan kepala cetak"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "Pilihan Percetakan"
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "Perincian Pencetak"
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "Guna Pencetak secara Lalai"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "Bersihkan Kepala Cetak"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Buang Pencetak"
 
-#: panels/printers/printer-entry.ui:193
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Tiada Kerja-Kerja Aktif"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Aras Dakwat"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:312
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Sila mula semula bila masalah telah diselesaikan."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:319
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Mula Semula"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:20
-msgid "Add…"
-msgstr "Tambah…"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Tambah satu Pencetak…"
 
-#: panels/printers/printers.ui:186
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Tambah satu Pencetak…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Tiada Pencetak"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:200
-msgid "Add a Printer…"
-msgstr "Tambah satu Pencetak…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:232
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Maaf! Perkhidmatan percetakan sistem\n"
 "nampaknya tidak tersedia."
 
-#: panels/region/cc-format-chooser.c:148
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-chooser.c:150
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrik"
-
-#: panels/region/cc-format-chooser.c:255 panels/region/cc-format-chooser.c:296
-#: panels/region/cc-format-chooser.ui:6
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Format"
 
-#: panels/region/cc-format-chooser.ui:48 panels/wacom/wacom-stylus-page.ui:37
-#: shell/cc-window.ui:232
-msgid "Back"
-msgstr "Undur"
-
-#: panels/region/cc-format-chooser.ui:103
-msgid ""
-"Choose the format for numbers, dates and currencies. Changes take effect on "
-"next login."
-msgstr ""
-"Pilih format untuk angka, tarikh dan mata wang. Perubahan hanya berkesan "
-"pada daftar masuk berikutnya."
-
-#: panels/region/cc-format-chooser.ui:119
-#| msgid "Search Locations"
-msgid "Search locales..."
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
 msgstr "Gelintar lokal..."
 
-#: panels/region/cc-format-chooser.ui:160
-#| msgid "Common Tasks"
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Format Umum"
 
-#: panels/region/cc-format-chooser.ui:191
-#| msgid "Formats"
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Semua Format"
 
-#: panels/region/cc-format-chooser.ui:244
-#| msgid "No results found"
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Tiada Keputusan Gelintar"
 
-#: panels/region/cc-format-chooser.ui:257
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Gelintar negara atau bahasa."
 
-#: panels/region/cc-format-chooser.ui:309
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Pratonton"
 
-#: panels/region/cc-format-chooser.ui:324
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Tarikh"
 
-#: panels/region/cc-format-chooser.ui:368
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "Tarikh & Waktu"
 
-#: panels/region/cc-format-chooser.ui:390
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Bilangan"
 
-#: panels/region/cc-format-chooser.ui:412
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Ukuran"
 
-#: panels/region/cc-format-chooser.ui:434
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Kertas"
 
-#: panels/region/cc-input-chooser.c:193
-msgid "No input sources found"
-msgstr "Tiada sumber input dijumpai"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#: panels/region/cc-input-chooser.c:948
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Lain-lain"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-#: panels/region/cc-input-chooser.ui:5
-msgid "Add an Input Source"
-msgstr "Tambah Sumber Input"
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#: panels/region/cc-input-chooser.ui:77
-msgid "Input methods can’t be used on the login screen"
-msgstr "Kaedah input tidak dapat digunakan pada skrin daftar masuk"
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
 
-#: panels/region/cc-region-panel.c:1511
-msgid "Login _Screen"
-msgstr "_Skrin Daftar Masuk"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Akaun anda"
 
-#: panels/region/cc-region-panel.ui:64
-#: panels/user-accounts/cc-user-panel.ui:352
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Bahasa"
 
-#: panels/region/cc-region-panel.ui:99
-msgid "Restart the session for changes to take effect"
-msgstr "Mula semula sesi supaya perubahan yang dibuat berkesan"
-
-#: panels/region/cc-region-panel.ui:114
-msgid "Restart…"
-msgstr "Mula Semula…"
-
-#: panels/region/cc-region-panel.ui:147
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Format"
 
-#: panels/region/cc-region-panel.ui:195
-msgid "Input Sources"
-msgstr "Sumber Input"
-
-#: panels/region/cc-region-panel.ui:209
-msgid "Choose keyboard layouts or input methods."
-msgstr "Pilih bentangan papan kekunci atau kaedah input."
-
-#: panels/region/cc-region-panel.ui:266
-msgid "No input source selected"
-msgstr "Tiada sumber input terpilih"
-
-#: panels/region/cc-region-panel.ui:300
-msgid "Login settings are used by all users when logging into the system"
-msgstr ""
-"Tetapan daftar masuk digunakan oleh semua pengguna bila mendaftar masuk ke "
-"dalam sistem"
-
-#: panels/region/cc-region-panel.ui:337
-msgid "Input Source Options"
-msgstr "Pilihan Sumber Input"
-
-#: panels/region/cc-region-panel.ui:352
-msgid "Use the _same source for all windows"
-msgstr "Guna sumber yang _sama untuk semua tetingkap"
-
-#: panels/region/cc-region-panel.ui:370
-msgid "Allow _different sources for each window"
-msgstr "Benarkan sumber be_rlainan untuk setiap tetingkap"
-
-#: panels/region/cc-region-panel.ui:412
-msgid "Previous source"
-msgstr "Sumber terdahulu"
-
-#: panels/region/cc-region-panel.ui:430
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
-
-#: panels/region/cc-region-panel.ui:445
-msgid "Next source"
-msgstr "Sumber berikutnya"
-
-#: panels/region/cc-region-panel.ui:463
-msgid "Super+Space"
-msgstr "Super+Space"
-
-#: panels/region/cc-region-panel.ui:478
-msgid "Left+Right Alt"
-msgstr "Alt Kiri+Kanan"
-
-#: panels/region/cc-region-panel.ui:494
-msgid "These keyboard shortcuts can be changed in the keyboard settings"
-msgstr "Pintasan papan kekunci ini boleh diubah dalam tetapan papan kekunci"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "_Skrin Daftar Masuk"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Wilayah & Bahasa"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr "Pilih bahasa paparan, format, bentangan papan kekunci dan sumber input"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Bahasa;Bentangan;Papan Kekunci;Input;"
 
-#: panels/removable-media/cc-removable-media-panel.c:267
-msgid "Ask what to do"
-msgstr "Tanya apa perlu buat"
-
-#: panels/removable-media/cc-removable-media-panel.c:271
-msgid "Do nothing"
-msgstr "Jangan buat apa-apa"
-
-#: panels/removable-media/cc-removable-media-panel.c:275
-msgid "Open folder"
-msgstr "Buka folder"
-
-#: panels/removable-media/cc-removable-media-panel.c:341
-msgid "Other Media"
-msgstr "Lain-lain Media"
-
-#: panels/removable-media/cc-removable-media-panel.c:362
-msgid "Select an application for audio CDs"
-msgstr "Pilih satu aplikasi untuk CD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:363
-msgid "Select an application for video DVDs"
-msgstr "Pilih satu aplikasi untuk DVD video"
-
-#: panels/removable-media/cc-removable-media-panel.c:364
-msgid "Select an application to run when a music player is connected"
-msgstr "Pilih satu aplikasi untuk dijalankan ketika pemain muzik disambungkan"
-
-#: panels/removable-media/cc-removable-media-panel.c:365
-msgid "Select an application to run when a camera is connected"
-msgstr "Pilih satu aplikasi untuk dijalankan ketika kamera disambungkan"
-
-#: panels/removable-media/cc-removable-media-panel.c:366
-msgid "Select an application for software CDs"
-msgstr "Pilih satu aplikasi untuk CD perisian"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "audio DVD"
-msgstr "DVD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "blank Blu-ray disc"
-msgstr "cakera Blu-Ray kosong"
-
-#: panels/removable-media/cc-removable-media-panel.c:380
-msgid "blank CD disc"
-msgstr "cakera CD kosong"
-
-#: panels/removable-media/cc-removable-media-panel.c:381
-msgid "blank DVD disc"
-msgstr "cakera DVD kosong"
-
-#: panels/removable-media/cc-removable-media-panel.c:382
-msgid "blank HD DVD disc"
-msgstr "cakera DVD HD kosong"
-
-#: panels/removable-media/cc-removable-media-panel.c:383
-msgid "Blu-ray video disc"
-msgstr "Cakera video Blu-Ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:384
-msgid "e-book reader"
-msgstr "Pembaca e-buku"
-
-#: panels/removable-media/cc-removable-media-panel.c:385
-msgid "HD DVD video disc"
-msgstr "Cakera video DVD HD"
-
-#: panels/removable-media/cc-removable-media-panel.c:386
-msgid "Picture CD"
-msgstr "CD Gambar"
-
-#: panels/removable-media/cc-removable-media-panel.c:387
-msgid "Super Video CD"
-msgstr "CD Video Super"
-
-#: panels/removable-media/cc-removable-media-panel.c:388
-msgid "Video CD"
-msgstr "CD Video"
-
-#: panels/removable-media/cc-removable-media-panel.c:389
-msgid "Windows software"
-msgstr "Perisian Windows"
-
-#: panels/removable-media/cc-removable-media-panel.ui:44
+#: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
 msgstr "Pilih bagaimana media harus dikendalikan"
 
-#: panels/removable-media/cc-removable-media-panel.ui:75
+#: panels/removable-media/cc-removable-media-panel.ui:52
 msgid "CD _audio"
 msgstr "_Audio CD"
 
-#: panels/removable-media/cc-removable-media-panel.ui:92
+#: panels/removable-media/cc-removable-media-panel.ui:67
 msgid "_DVD video"
 msgstr "Video _DVD"
 
-#: panels/removable-media/cc-removable-media-panel.ui:133
+#: panels/removable-media/cc-removable-media-panel.ui:102
 msgid "_Music player"
 msgstr "Pemain _muzik"
 
-#: panels/removable-media/cc-removable-media-panel.ui:191
+#: panels/removable-media/cc-removable-media-panel.ui:152
 msgid "_Software"
 msgstr "P_erisian"
 
-#: panels/removable-media/cc-removable-media-panel.ui:229
+#: panels/removable-media/cc-removable-media-panel.ui:178
 msgid "_Other Media…"
 msgstr "_Lain-lain Media…"
 
-#: panels/removable-media/cc-removable-media-panel.ui:288
+#: panels/removable-media/cc-removable-media-panel.ui:195
 msgid "_Never prompt or start programs on media insertion"
 msgstr "_Jangan maklum atau mulakan program semasa penyisipan media"
 
-#: panels/removable-media/cc-removable-media-panel.ui:342
+#: panels/removable-media/cc-removable-media-panel.ui:225
 msgid "Select how other media should be handled"
 msgstr "Pilih bagaimana media lain harus dikendalikan"
 
-#: panels/removable-media/cc-removable-media-panel.ui:389
+#: panels/removable-media/cc-removable-media-panel.ui:259
 msgid "_Action:"
 msgstr "Tindakan:"
 
-#: panels/removable-media/cc-removable-media-panel.ui:412
+#: panels/removable-media/cc-removable-media-panel.ui:278
 msgid "_Type:"
 msgstr "_Jenis:"
 
@@ -5836,7 +3349,6 @@ msgstr "Media Boleh Alih"
 msgid "Configure Removable Media settings"
 msgstr "Konfigur Tetapan Media Boleh Alih"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5845,22 +3357,86 @@ msgstr ""
 "peranti;sistem;lalai;aplikasi;dikehendaki;cd;dvd;usb;audio;video;cakera;"
 "boleh alih;media;auto-jalan;"
 
-#: panels/search/cc-search-locations-dialog.c:635
-msgid "Select Location"
-msgstr "Pilih Lokasi"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Kunci Skrin"
 
-#: panels/search/cc-search-locations-dialog.c:639
-msgid "_OK"
-msgstr "_OK"
+#: panels/screen/cc-screen-panel.ui:9
+#, fuzzy
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Kunci skrin secara automatik dapat menghalang orang lain daripada mencapai "
+"komputer ketika anda tiada."
 
-#: panels/search/cc-search-locations-dialog.ui:9
-#: panels/search/cc-search-panel.ui:61
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Lengah Skrin Gelap"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Tempoh ketidakaktifan selepas skrin menjadi gelap."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Kun_ci Skrin Automatik"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Lengah Kunci _Skrin Automatik"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Tempoh selepas skrin gelap ketika skrin terkunci secara automatik."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Tunjuk _Pemberitahuan bila Skrin Kunci"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Pemberitahuan Skrin _Kunci"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Kerahsiaan"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skrin"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Perkongsian Skrin"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "Gelintar Lokasi"
 
-#: panels/search/cc-search-locations-dialog.ui:32
-#: panels/search/cc-search-locations-dialog.ui:69
-#: panels/search/cc-search-locations-dialog.ui:107
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
@@ -5868,38 +3444,48 @@ msgstr ""
 "Folder-folder yang digelintar oleh aplikasi-aplikasi sistem, seperti Fail, "
 "Foto dan Video."
 
-#: panels/search/cc-search-locations-dialog.ui:52
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr "Tempat"
 
-#: panels/search/cc-search-locations-dialog.ui:91
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Tanda Buku"
 
-#: panels/search/cc-search-locations-dialog.ui:156
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Lain-lain"
 
-#: panels/search/cc-search-panel.c:153
-msgid "No applications found"
-msgstr "Tiada aplikasi dijumpai"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Lokasi"
 
-#: panels/search/cc-search-panel-row.ui:92
-msgid "Move Up"
-msgstr "Bergerak ke Atas"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Aplikasi"
 
-#: panels/search/cc-search-panel-row.ui:102
-msgid "Move Down"
-msgstr "Bergerak ke Bawah"
-
-#: panels/search/cc-search-panel.ui:33
-msgid ""
-"Control which search results are shown in the Activities Overview. The order "
-"of search results can also be changed by moving rows in the list."
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
 msgstr ""
-"Kawal keputusan gelintar yang manakah perlu ditunjukkan dalam Selayang "
-"Pandang Aktiviti. Tertib keputusan gelintar boleh diubah dengan mengerakkan "
-"baris-baris di dalam senarai."
+
+#: panels/search/cc-search-panel.ui:23
+#, fuzzy
+msgid "Folders which are searched by system applications."
+msgstr ""
+"Folder-folder yang digelintar oleh aplikasi-aplikasi sistem, seperti Fail, "
+"Foto dan Video."
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Tiada Keputusan Gelintar"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
@@ -5908,172 +3494,140 @@ msgstr ""
 "Kawal aplikasi yang manakah tunjuk keputusan gelintar dalam Selayang Pandang "
 "Aktiviti"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Gelintar;Cari;Indeks;Sembunyi;Kerahsiaan;Keputusan;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:307
-msgid "No networks selected for sharing"
-msgstr "Tiada rangkaian terpilih untuk dikongsikan"
-
-#: panels/sharing/cc-sharing-networks.ui:19
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Rangkaian"
 
-#: panels/sharing/cc-sharing-panel.c:320
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Hidup"
-
-#: panels/sharing/cc-sharing-panel.c:322 panels/sharing/cc-sharing-panel.c:349
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Tutup"
-
-#: panels/sharing/cc-sharing-panel.c:352
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Dibenarkan"
-
-#: panels/sharing/cc-sharing-panel.c:355
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktif"
-
-#: panels/sharing/cc-sharing-panel.c:425
-msgid "Choose a Folder"
-msgstr "Pilih satu Folder"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:729
-#, c-format
-#| msgid ""
-#| "File Sharing allows you to share your Public folder with others on your "
-#| "current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Perkongsian Fail membolehkan anda berkongsi folder awam anda dengan orang "
-"lain pada rangkaian semasa anda melalui: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:735
-#, c-format
-#| msgid ""
-#| "When remote login is enabled, remote users can connect using the Secure "
-#| "Shell command:\n"
-#| "<a href=\"ssh %s\">ssh %s</a>"
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Bila daftar jauh dibenarkan, pengguna jauh boleh bersambung menggunakan "
-"perintah Shell Selamat:\n"
-"%s"
-
-#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:741
-#, c-format
-#| msgid ""
-#| "Screen sharing allows remote users to view or control your screen by "
-#| "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to %s"
-msgstr ""
-"Perkongsian skrin membolehkan pengguna jauh melihat atau mengawal skrin anda "
-"bila bersambung dengan %s"
-
-#: panels/sharing/cc-sharing-panel.c:846
-msgid "Copy"
-msgstr "Salin"
-
-#: panels/sharing/cc-sharing-panel.c:1299
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Perkongsian"
 
-#: panels/sharing/cc-sharing-panel.ui:34
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr "_Nama Komputer"
 
-#: panels/sharing/cc-sharing-panel.ui:94
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr "Perkongsian _Fail"
 
-#: panels/sharing/cc-sharing-panel.ui:139
-msgid "_Screen Sharing"
-msgstr "Perkongsian _Skrin"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Desktop"
 
-#: panels/sharing/cc-sharing-panel.ui:184
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr "Perkongsian _Media"
 
-#: panels/sharing/cc-sharing-panel.ui:229
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr "Daftar Masuk _Jauh"
 
-#: panels/sharing/cc-sharing-panel.ui:268
-msgid "Some services are disabled because of no network access."
-msgstr "Sesetengah perkhidmatan dilumpuhkan kerana tiada capaian rangkaian."
-
-#: panels/sharing/cc-sharing-panel.ui:286
-#: panels/sharing/cc-sharing-panel.ui:413
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr "Perkongsian Fail"
 
-#: panels/sharing/cc-sharing-panel.ui:333
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr "Pe_rlukan Kata Laluan"
 
-#: panels/sharing/cc-sharing-panel.ui:424
-#: panels/sharing/cc-sharing-panel.ui:494
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "Daftar Masuk Jauh"
 
-#: panels/sharing/cc-sharing-panel.ui:517
-#: panels/sharing/cc-sharing-panel.ui:763
-msgid "Screen Sharing"
-msgstr "Perkongsian Skrin"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Desktop"
 
-#: panels/sharing/cc-sharing-panel.ui:575
-msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Benar atau lumpuhkan daftar masuk jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Memboleh atau melumpuhkan log masuk dari jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
 msgstr "_Membolehkan sambungan supaya dapat mengawal skrin"
 
-#: panels/sharing/cc-sharing-panel.ui:620
-msgid "_Password:"
-msgstr "_Kata laluan:"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Katalaluan tidak padan."
 
-#: panels/sharing/cc-sharing-panel.ui:650
-msgid "_Show Password"
-msgstr "Tunjuk Kata Laluan"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:681
-msgid "Access Options"
-msgstr "Pilihan Capaian"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Salin"
 
-#: panels/sharing/cc-sharing-panel.ui:695
-msgid "_New connections must ask for access"
-msgstr "Sambungan _baharu mesti tanya dahulu untuk dapatkan capaian"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Padam Alamat"
 
-#: panels/sharing/cc-sharing-panel.ui:713
-msgid "_Require a password"
-msgstr "Pe_lukan satu kata laluan"
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Pen_gesahihan"
 
-#: panels/sharing/cc-sharing-panel.ui:774
-#: panels/sharing/cc-sharing-panel.ui:868
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Namapengguna"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Mendaftarkan cap jari"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Perkongsian Media"
 
-#: panels/sharing/cc-sharing-panel.ui:807
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Kongsi muzik, gambar dan video melalui rangkaian."
 
-#: panels/sharing/cc-sharing-panel.ui:822
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Folder"
 
@@ -6081,7 +3635,6 @@ msgstr "Folder"
 msgid "Control what you want to share with others"
 msgstr "Kawal apa yang anda mahu kongsikan dengan orang lain"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6098,100 +3651,97 @@ msgstr "Benar atau lumpuhkan daftar masuk jauh"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Pengesahihan diperlukan untuk benar atau lumpuhkan daftar masuk jauh"
 
-#: panels/sound/cc-alert-chooser.c:151
-msgid "Custom"
-msgstr "Suai"
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:12 panels/sound/cc-alert-selector.ui:9
-msgid "Bark"
-msgstr "Nyalak"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Perkongsian"
 
-#: panels/sound/cc-alert-chooser.ui:19 panels/sound/cc-alert-selector.ui:15
-msgid "Drip"
-msgstr "Titisan"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:26 panels/sound/cc-alert-selector.ui:21
-msgid "Glass"
-msgstr "Gelas"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:33 panels/sound/cc-alert-selector.ui:27
-msgid "Sonar"
-msgstr "Sonar"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Imbangan"
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Resap"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Belakang"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Hadapan"
 
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Menguji %s"
-
-#: panels/sound/cc-output-test-dialog.ui:127
+#: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
 msgstr "Klik satu pembesar suara untuk diuji"
 
 # msgstr[1] ""
-#: panels/sound/cc-sound-panel.ui:29
+#: panels/sound/cc-sound-panel.ui:8
 msgid "System Volume"
 msgstr "Volum Sistem"
 
-#: panels/sound/cc-sound-panel.ui:45
+# msgstr[1] ""
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Volum Sistem"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Aras Volum"
 
-#: panels/sound/cc-sound-panel.ui:67
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Output"
 
-#: panels/sound/cc-sound-panel.ui:94
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Peranti Output"
 
-#: panels/sound/cc-sound-panel.ui:117
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Uji"
 
-#: panels/sound/cc-sound-panel.ui:148 panels/sound/cc-sound-panel.ui:325
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Konfigurasi"
 
-#: panels/sound/cc-sound-panel.ui:181
-msgid "Balance"
-msgstr "Imbangan"
-
-#: panels/sound/cc-sound-panel.ui:208
-msgid "Fade"
-msgstr "Resap"
-
-#: panels/sound/cc-sound-panel.ui:235
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwufer"
 
-#: panels/sound/cc-sound-panel.ui:257
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Input"
 
-#: panels/sound/cc-sound-panel.ui:284
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Peranti Input"
 
-#: panels/sound/cc-sound-panel.ui:358
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Volum"
 
-#: panels/sound/cc-sound-panel.ui:380
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Bunyi Amaran"
 
-#: panels/sound/cc-volume-slider.c:115
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6201,170 +3751,68 @@ msgstr "Bunyi"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Ubah aras bunyi, input, output, dan bunyi amaran"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Kad;Mikrofon;Volum;Resap;Imbangan;Bluetooth;Set Kepala;Audio;Output;Input;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Terputus"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Menyambung"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Bersambung"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Ralat Keizinan"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Mengizinkan"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Kefungisan Terkurang"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Bersambung & Diizinkan"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Tidak diketahui"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr "Diizinkan pada:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-msgid "Connected at:"
-msgstr "Bersambung pada:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-msgid "Enrolled at:"
-msgstr "Berdaftar pada:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-msgid "Failed to authorize device: "
-msgstr "Gagal izinkan peranti: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-msgid "Failed to forget device: "
-msgstr "Gagal melupakan peranti: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] "Bergantung pada %u peranti lain"
 msgstr[1] "Bergantung pada %u peranti lain"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Pemberitahuan"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Nama:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Status:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Izin dan Sambung"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "_Lupakan Peranti"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Ralat"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Diizinkan"
-
-#: panels/thunderbolt/cc-bolt-panel.c:176
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Sub-sistem Thunderbolt (boltd) tidak dipasang atau disediakan dengan baik."
-
-#: panels/thunderbolt/cc-bolt-panel.c:469
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt tidak dapat dikesan.\n"
-"Sama ada sistem kekurangan sokongan Thunderbolt, ia telah dilumpuhkan dalam "
-"BIOS atau telah ditetapkan dengan aras keselamatan tidak disokong dalam BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:513
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Sokongan Thunderbolt telah dilumpuhkan dalam BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:517
-msgid "Thunderbolt security level could not be determined."
-msgstr "Aras keselamatan Thunderbolt tidak dapat ditentukan."
-
-#: panels/thunderbolt/cc-bolt-panel.c:622
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Ralat beralih ke mod terus: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+#, fuzzy
+msgid "No Thunderbolt Support"
 msgstr "Tiada sokongan Thunderbolt"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:246
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Tidak dapat bersambung dengan domain %s: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Capaian Terus"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr "Benarkan capaian terus ke peranti seperti dock dan GPU luar."
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr "Hanya peranti Port USB dan Paparan boleh dipalamkan."
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Peranti Tertangguh"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Tiada peranti dipalam"
 
@@ -6376,588 +3824,499 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Urus peranti-peranti Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
-msgid "Thunderbolt;"
+#, fuzzy
+msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:500
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Lalai"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Kerlipan Kursor"
 
-#: panels/universal-access/cc-ua-panel.c:503
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Sederhana"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Kerlipan kursor dalam medan teks."
 
-#: panels/universal-access/cc-ua-panel.c:506
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Besar"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Kelajuan"
 
-#: panels/universal-access/cc-ua-panel.c:509
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Lebih Besae"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Kelajuan kerlipan kursor"
 
-#: panels/universal-access/cc-ua-panel.c:512
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Terbesar"
-
-#: panels/universal-access/cc-ua-panel.c:516
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d piksel"
-msgstr[1] "%d piksel"
-
-#: panels/universal-access/cc-ua-panel.ui:78
-msgid "_Always Show Universal Access Menu"
-msgstr "S_entiasa Tunjuk Menu Capaian Universal"
-
-#: panels/universal-access/cc-ua-panel.ui:120
-msgid "Seeing"
-msgstr "Melihat"
-
-#: panels/universal-access/cc-ua-panel.ui:166
-msgid "_High Contrast"
-msgstr "Beza _Jelas Tinggi"
-
-#: panels/universal-access/cc-ua-panel.ui:213
-msgid "_Large Text"
-msgstr "Teks _Besar"
-
-#: panels/universal-access/cc-ua-panel.ui:258
-msgid "C_ursor Size"
-msgstr "Saiz _Suai"
-
-#: panels/universal-access/cc-ua-panel.ui:305
-#: panels/universal-access/zoom-options.ui:99
-msgid "_Zoom"
-msgstr "_Zum"
-
-#: panels/universal-access/cc-ua-panel.ui:351
-msgid "Screen _Reader"
-msgstr "Pemba_ca Skrin"
-
-#: panels/universal-access/cc-ua-panel.ui:397
-#: panels/universal-access/cc-ua-panel.ui:1263
-msgid "_Sound Keys"
-msgstr "Kekunci Bun_yi"
-
-#: panels/universal-access/cc-ua-panel.ui:459
-msgid "Hearing"
-msgstr "Pendengaran"
-
-#: panels/universal-access/cc-ua-panel.ui:503
-#: panels/universal-access/cc-ua-panel.ui:1366
-msgid "_Visual Alerts"
-msgstr "Amaran _Visual"
-
-#: panels/universal-access/cc-ua-panel.ui:611
-msgid "Screen _Keyboard"
-msgstr "Papan _Kekunci Skrin"
-
-#: panels/universal-access/cc-ua-panel.ui:656
-msgid "R_epeat Keys"
-msgstr "Kekunci _Ulang"
-
-#: panels/universal-access/cc-ua-panel.ui:702
-msgid "Cursor _Blinking"
-msgstr "Kerlipan K_ursor"
-
-#: panels/universal-access/cc-ua-panel.ui:748
-msgid "_Typing Assist (AccessX)"
-msgstr "Bantuan Me_naip (AccessX)"
-
-#: panels/universal-access/cc-ua-panel.ui:809
-msgid "Pointing & Clicking"
-msgstr "Menuju &  Mengklik"
-
-#: panels/universal-access/cc-ua-panel.ui:855
-msgid "_Mouse Keys"
-msgstr "Kekunci T_etikus"
-
-#: panels/universal-access/cc-ua-panel.ui:900
-msgid "_Locate Pointer"
-msgstr "_Cari Penuding"
-
-#: panels/universal-access/cc-ua-panel.ui:932
-msgid "_Click Assist"
-msgstr "Bantuan _Klik"
-
-#: panels/universal-access/cc-ua-panel.ui:978
-msgid "_Double-Click Delay"
-msgstr "Lengah _Dwi-Klik"
-
-#: panels/universal-access/cc-ua-panel.ui:998
-msgid "Double-Click Delay"
-msgstr "Lengah Dwi-Klik"
-
-#: panels/universal-access/cc-ua-panel.ui:1068
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr "Saiz Kursor"
 
-#: panels/universal-access/cc-ua-panel.ui:1095
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 "Saiz kursor boleh digabungkan dengan zum supaya lebih mudah melihat kursor "
 "tersebut."
 
-#: panels/universal-access/cc-ua-panel.ui:1131
-msgid "Screen Reader"
-msgstr "Pembaca Skrin"
-
-#: panels/universal-access/cc-ua-panel.ui:1148
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "Pembaca skrin membaca teks yang terpapar bila anda gerakkan fokus."
-
-#: panels/universal-access/cc-ua-panel.ui:1181
-msgid "_Screen Reader"
-msgstr "Pembaca _Skrin"
-
-#: panels/universal-access/cc-ua-panel.ui:1220
-msgid "Sound Keys"
-msgstr "Kekunci Bunyi"
-
-#: panels/universal-access/cc-ua-panel.ui:1238
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr ""
-"Bunyi bip bila kekunci Num Lock atau Caps Lock dihidupkan atau dimatikan."
-
-#: panels/universal-access/cc-ua-panel.ui:1308
-msgid "Visual Alerts"
-msgstr "Amaran Visual"
-
-#: panels/universal-access/cc-ua-panel.ui:1312
-msgid "_Test flash"
-msgstr "_Uji kerlipan"
-
-#: panels/universal-access/cc-ua-panel.ui:1341
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "Guna satu penunjuk visual bila bunyi amaran muncul."
-
-#: panels/universal-access/cc-ua-panel.ui:1392
-msgid "Flash the entire _window"
-msgstr "Denyar keseluruhan _tetingkap"
-
-#: panels/universal-access/cc-ua-panel.ui:1410
-msgid "Flash the entire _screen"
-msgstr "Denyarkan keseluruhan _skrin"
-
-#: panels/universal-access/cc-ua-panel.ui:1455
-msgid "Repeat Keys"
-msgstr "Kekunci Ulang"
-
-#: panels/universal-access/cc-ua-panel.ui:1485
-msgid "Key presses repeat when key is held down."
-msgstr "Kekunci ditekan berulang apabila kekunci ditahan."
-
-#: panels/universal-access/cc-ua-panel.ui:1565
-msgid "Repeat keys delay"
-msgstr "Lengah kekunci berulang"
-
-#: panels/universal-access/cc-ua-panel.ui:1613
-#: panels/universal-access/cc-ua-panel.ui:1748
-msgid "Speed"
-msgstr "Kelajuan"
-
-#: panels/universal-access/cc-ua-panel.ui:1652
-msgid "Repeat keys speed"
-msgstr "Ulangan kelajuan kekunci"
-
-#: panels/universal-access/cc-ua-panel.ui:1676
-msgid "Cursor Blinking"
-msgstr "Kerlipan Kursor"
-
-#: panels/universal-access/cc-ua-panel.ui:1706
-msgid "Cursor blinks in text fields."
-msgstr "Kerlipan kursor dalam medan teks."
-
-#: panels/universal-access/cc-ua-panel.ui:1785
-msgid "Cursor blinking speed"
-msgstr "Kelajuan kerlipan kursor"
-
-#: panels/universal-access/cc-ua-panel.ui:1821
-msgid "Typing Assist"
-msgstr "Bantuan Menaip"
-
-#: panels/universal-access/cc-ua-panel.ui:1860
-msgid "_Sticky Keys"
-msgstr "Kekunci _Lekat"
-
-#: panels/universal-access/cc-ua-panel.ui:1877
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "Anggap jujukan kekunci pengubah suai sebagai satu gabungan kekunci"
-
-#: panels/universal-access/cc-ua-panel.ui:1901
-msgid "_Disable if two keys are pressed together"
-msgstr "_Lumpuhkan jika dua kekunci ditekan serentak"
-
-#: panels/universal-access/cc-ua-panel.ui:1919
-msgid "Beep when a _modifier key is pressed"
-msgstr "Bunyi bip bila kekunci _pengubah suai ditekan"
-
-#: panels/universal-access/cc-ua-panel.ui:1967
-msgid "S_low Keys"
-msgstr "Kekunci La_mbat"
-
-#: panels/universal-access/cc-ua-panel.ui:1984
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
-"Letakkan lengahan diantaranya bila kekunci ditekan dan bila ia diterima"
-
-#: panels/universal-access/cc-ua-panel.ui:2017
-#: panels/universal-access/cc-ua-panel.ui:2230
-#: panels/universal-access/cc-ua-panel.ui:2567
-msgid "A_cceptance delay:"
-msgstr "Lengah p_enerimaan:"
-
-#: panels/universal-access/cc-ua-panel.ui:2039
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Pendek"
-
-#: panels/universal-access/cc-ua-panel.ui:2058
-msgid "Slow keys typing delay"
-msgstr "Lengah menaip kekunci lambat"
-
-#: panels/universal-access/cc-ua-panel.ui:2073
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Panjang"
-
-#: panels/universal-access/cc-ua-panel.ui:2100
-msgid "Beep when a key is pr_essed"
-msgstr "Bip bila kekunci dit_ekan"
-
-#: panels/universal-access/cc-ua-panel.ui:2117
-msgid "Beep when a key is _accepted"
-msgstr "Bip bila kekunci diterim_a"
-
-#: panels/universal-access/cc-ua-panel.ui:2134
-#: panels/universal-access/cc-ua-panel.ui:2313
-msgid "Beep when a key is _rejected"
-msgstr "Bip bila kekunci dit_olak"
-
-#: panels/universal-access/cc-ua-panel.ui:2180
-msgid "_Bounce Keys"
-msgstr "Kekunci La_ntun"
-
-#: panels/universal-access/cc-ua-panel.ui:2197
-msgid "Ignores fast duplicate keypresses"
-msgstr "Abaikan penekanan kekunci berganda yang pantas"
-
-#: panels/universal-access/cc-ua-panel.ui:2252
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Pendek"
-
-#: panels/universal-access/cc-ua-panel.ui:2271
-msgid "Bounce keys typing delay"
-msgstr "Lengahan menaip kekunci lantun"
-
-#: panels/universal-access/cc-ua-panel.ui:2286
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Panjang"
-
-#: panels/universal-access/cc-ua-panel.ui:2399
-msgid "_Enable by Keyboard"
-msgstr "D_ibenarkan oleh Papan Kekunci"
-
-#: panels/universal-access/cc-ua-panel.ui:2416
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "Hidupkan dan matikan fitur-fitur kebolehcapaian melalui papan kekunci"
-
-#: panels/universal-access/cc-ua-panel.ui:2480
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "Bantuan Klik"
 
-#: panels/universal-access/cc-ua-panel.ui:2516
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "Klik Sekunder Ter_simulasi"
 
-#: panels/universal-access/cc-ua-panel.ui:2534
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "Picu satu klik kedua bila butang utama ditekan tanpa lepas"
 
-#: panels/universal-access/cc-ua-panel.ui:2588
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Lengah p_enerimaan:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Pendek"
 
-#: panels/universal-access/cc-ua-panel.ui:2607
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "Lengah klik sekunder"
 
-#: panels/universal-access/cc-ua-panel.ui:2622
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Panjang"
 
-#: panels/universal-access/cc-ua-panel.ui:2679
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "Klik A_pung"
 
-#: panels/universal-access/cc-ua-panel.ui:2697
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "Picu satu klik bila penuding terapung di atasnya"
 
-#: panels/universal-access/cc-ua-panel.ui:2730
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "L_engah:"
 
-#: panels/universal-access/cc-ua-panel.ui:2752
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Pendek"
 
-#: panels/universal-access/cc-ua-panel.ui:2783
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Panjang"
 
-#: panels/universal-access/cc-ua-panel.ui:2819
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "A_mbang gerakan:"
 
-#: panels/universal-access/cc-ua-panel.ui:2841
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Kecil"
 
-#: panels/universal-access/cc-ua-panel.ui:2872
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Besar"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Kekunci Ulang"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Kekunci ditekan berulang apabila kekunci ditahan."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Lengah kekunci berulang"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Ulangan kelajuan kekunci"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Bantuan Menaip"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Kekunci _Lekat"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Anggap jujukan kekunci pengubah suai sebagai satu gabungan kekunci"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Lumpuhkan jika dua kekunci ditekan serentak"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Bunyi bip bila kekunci _pengubah suai ditekan"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Kekunci La_mbat"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Letakkan lengahan diantaranya bila kekunci ditekan dan bila ia diterima"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Pendek"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Lengah menaip kekunci lambat"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Panjang"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Bip bila kekunci dit_ekan"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Bip bila kekunci diterim_a"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Bip bila kekunci dit_olak"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Kekunci La_ntun"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Abaikan penekanan kekunci berganda yang pantas"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Pendek"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Lengahan menaip kekunci lantun"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Panjang"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "D_ibenarkan oleh Papan Kekunci"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Hidupkan dan matikan fitur-fitur kebolehcapaian melalui papan kekunci"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "S_entiasa Tunjuk Menu Capaian Universal"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Melihat"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Beza _Jelas Tinggi"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Teks _Besar"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Pemba_ca Skrin"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Pembaca skrin membaca teks yang terpapar bila anda gerakkan fokus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Kekunci Bun_yi"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Bunyi bip bila kekunci Num Lock atau Caps Lock dihidupkan atau dimatikan."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Saiz _Suai"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zum"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Pendengaran"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Amaran _Visual"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Papan _Kekunci Skrin"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Kekunci _Ulang"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Kerlipan K_ursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Bantuan Me_naip (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Menuju &  Mengklik"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Kekunci T_etikus"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Cari Penuding"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Bantuan _Klik"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Lengah _Dwi-Klik"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Lengah Dwi-Klik"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Amaran Visual"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Uji kerlipan"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Guna satu penunjuk visual bila bunyi amaran muncul."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Denyarkan keseluruhan _skrin"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Denyar keseluruhan _tetingkap"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Skrin Penuh"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Separuh Atas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Separuh Bawah"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Separuh Kiri"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Separuh Kanan"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Pilihan Zum"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "Pe_mbesaran:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Kedudukan Pembesar:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Ikuti kursor tetikus"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Bahagian _skrin:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Pembesar _melangkaui luar skrin"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Biar kursor pembesar ditengah-tengah"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Kursor pembesar me_nolak kandungan disekitarnya"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Kursor pembesar bergerak dengan _kandungan"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Pembesar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Rerambut Silang:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Tindan kursor tetikus"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "Ke_tebalan:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Nipis"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Tebal"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Jangka masa:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Warna:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Rerambut Silang"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Kesan Warna:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "Putih atas hitam:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Kecerahan:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Beza Jelas:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Warna"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Tiada"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Penuh"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Rendah"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Tinggi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Rendah"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Tinggi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Kesan Warna"
 
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Jadikannya mudah dilihat, didengar, ditaip, tuju dan diklik"
 
-#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
-"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
-"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
 "Papan Kekunci;Tetikus;a11y;Kebolehcapaian;Beza Jelas;Kursor;Bunyi;Zum;Skrin;"
 "Pembaca;besar;tinggi;lebih besar;teks;fon;saiz;AccessX;Lekat;Kekunci;Lambat;"
 "Lantun;Tetikus;Dwi;klik;Lengah;Kelajuan;Bantuan;Ulang;Kerlipan;visual;"
 "pendengaran;audio;menaip;"
 
-#: panels/universal-access/zoom-options.c:305
-msgctxt "Distance"
-msgid "Short"
-msgstr "Pendek"
-
-#: panels/universal-access/zoom-options.c:306
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼  Skrin"
-
-#: panels/universal-access/zoom-options.c:307
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ Skrin"
-
-#: panels/universal-access/zoom-options.c:308
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ Skrin"
-
-#: panels/universal-access/zoom-options.c:309
-msgctxt "Distance"
-msgid "Long"
-msgstr "Panjang"
-
-#: panels/universal-access/zoom-options.ui:48
-msgid "Full Screen"
-msgstr "Skrin Penuh"
-
-#: panels/universal-access/zoom-options.ui:53
-msgid "Top Half"
-msgstr "Separuh Atas"
-
-#: panels/universal-access/zoom-options.ui:58
-msgid "Bottom Half"
-msgstr "Separuh Bawah"
-
-#: panels/universal-access/zoom-options.ui:63
-msgid "Left Half"
-msgstr "Separuh Kiri"
-
-#: panels/universal-access/zoom-options.ui:68
-msgid "Right Half"
-msgstr "Separuh Kanan"
-
-#: panels/universal-access/zoom-options.ui:78
-msgid "Zoom Options"
-msgstr "Pilihan Zum"
-
-#: panels/universal-access/zoom-options.ui:185
-msgid "_Magnification:"
-msgstr "Pe_mbesaran:"
-
-#: panels/universal-access/zoom-options.ui:249
-msgid "_Follow mouse cursor"
-msgstr "_Ikuti kursor tetikus"
-
-#: panels/universal-access/zoom-options.ui:269
-msgid "_Screen part:"
-msgstr "Bahagian _skrin:"
-
-#: panels/universal-access/zoom-options.ui:331
-msgid "Magnifier _extends outside of screen"
-msgstr "Pembesar _melangkaui luar skrin"
-
-#: panels/universal-access/zoom-options.ui:350
-msgid "_Keep magnifier cursor centered"
-msgstr "_Biar kursor pembesar ditengah-tengah"
-
-#: panels/universal-access/zoom-options.ui:370
-msgid "Magnifier cursor _pushes contents around"
-msgstr "Kursor pembesar me_nolak kandungan disekitarnya"
-
-#: panels/universal-access/zoom-options.ui:390
-msgid "Magnifier cursor moves with _contents"
-msgstr "Kursor pembesar bergerak dengan _kandungan"
-
-#: panels/universal-access/zoom-options.ui:425
-msgid "Magnifier Position:"
-msgstr "Kedudukan Pembesar:"
-
-#: panels/universal-access/zoom-options.ui:446
-msgid "Magnifier"
-msgstr "Pembesar"
-
-#: panels/universal-access/zoom-options.ui:493
-msgid "_Thickness:"
-msgstr "Ke_tebalan:"
-
-#: panels/universal-access/zoom-options.ui:519
-msgctxt "universal access, thickness"
-msgid "Thin"
-msgstr "Nipis"
-
-#: panels/universal-access/zoom-options.ui:551
-msgctxt "universal access, thickness"
-msgid "Thick"
-msgstr "Tebal"
-
-#: panels/universal-access/zoom-options.ui:577
-msgid "_Length:"
-msgstr "_Jangka masa:"
-
-#. The color of the accessibility crosshair
-#: panels/universal-access/zoom-options.ui:626
-msgid "Co_lor:"
-msgstr "_Warna:"
-
-#: panels/universal-access/zoom-options.ui:690
-msgid "_Crosshairs:"
-msgstr "_Rerambut Silang:"
-
-#: panels/universal-access/zoom-options.ui:738
-msgid "_Overlaps mouse cursor"
-msgstr "_Tindan kursor tetikus"
-
-#: panels/universal-access/zoom-options.ui:776
-msgid "Crosshairs"
-msgstr "Rerambut Silang"
-
-#: panels/universal-access/zoom-options.ui:825
-msgid "_White on black:"
-msgstr "Putih atas hitam:"
-
-#: panels/universal-access/zoom-options.ui:845
-msgid "_Brightness:"
-msgstr "_Kecerahan:"
-
-#: panels/universal-access/zoom-options.ui:866
-msgid "_Contrast:"
-msgstr "_Beza Jelas:"
-
-#. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/zoom-options.ui:886
-msgctxt "universal access, contrast"
-msgid "Co_lor"
-msgstr "_Warna"
-
-#: panels/universal-access/zoom-options.ui:911
-msgctxt "universal access, color"
-msgid "None"
-msgstr "Tiada"
-
-#: panels/universal-access/zoom-options.ui:943
-msgctxt "universal access, color"
-msgid "Full"
-msgstr "Penuh"
-
-#: panels/universal-access/zoom-options.ui:1006
-msgctxt "universal access, brightness"
-msgid "Low"
-msgstr "Rendah"
-
-#: panels/universal-access/zoom-options.ui:1039
-msgctxt "universal access, brightness"
-msgid "High"
-msgstr "Tinggi"
-
-#: panels/universal-access/zoom-options.ui:1070
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "Rendah"
-
-#: panels/universal-access/zoom-options.ui:1103
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "Tinggi"
-
-#: panels/universal-access/zoom-options.ui:1139
-msgid "Color Effects:"
-msgstr "Kesan Warna:"
-
-#: panels/universal-access/zoom-options.ui:1164
-msgid "Color Effects"
-msgstr "Kesan Warna"
-
-#: panels/usage/cc-usage-panel.c:155
-msgid "Empty all items from Trash?"
-msgstr "Kosongkan semua item dari tong sampah?"
-
-#: panels/usage/cc-usage-panel.c:156
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Semua item di dalam Tong Sampah akan dipadam secara kekal."
-
-#: panels/usage/cc-usage-panel.c:157
-msgid "_Empty Trash"
-msgstr "Kosongkan _Tong Sampah"
-
-#: panels/usage/cc-usage-panel.c:178
-msgid "Delete all the temporary files?"
-msgstr "Padam semua fail sementara?"
-
-#: panels/usage/cc-usage-panel.c:179
-msgid "All the temporary files will be permanently deleted."
-msgstr "Semua fail sementara akan dipadam secara kekal."
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "_Purge Temporary Files"
-msgstr "S_ingkir Fail Sementara"
-
-#: panels/usage/cc-usage-panel.ui:31
+#: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
 msgstr "Sejarah Fail"
 
-#: panels/usage/cc-usage-panel.ui:43
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
 "File history keeps a record of files that you have used. This information is "
 "shared between applications, and makes it easier to find files that you "
@@ -6967,23 +4326,24 @@ msgstr ""
 "dikongsi antara aplikasi, dan ia memudahkan pencarian fail yang anda mahu "
 "guna."
 
-#: panels/usage/cc-usage-panel.ui:58
+#: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
 msgstr "Se_jarah Fail"
 
-#: panels/usage/cc-usage-panel.ui:80
+#: panels/usage/cc-usage-panel.ui:25
 msgid "File _History Duration"
 msgstr "Jangka Masa Se_jarah Fail"
 
-#: panels/usage/cc-usage-panel.ui:121
+#: panels/usage/cc-usage-panel.ui:48
 msgid "_Clear History…"
 msgstr "_Kosongkan Sejarah…"
 
-#: panels/usage/cc-usage-panel.ui:137
-msgid "Trash & Temporary Files"
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
 msgstr "Fail dalam Tong Sampah & Sementara"
 
-#: panels/usage/cc-usage-panel.ui:147
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
@@ -6992,109 +4352,25 @@ msgstr ""
 "peribadi atau sensitif. Pemadaman secara automatik dapat melindungi "
 "kerahsiaan."
 
-#: panels/usage/cc-usage-panel.ui:161
+#: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
 msgstr "Padam Kandungan _Tong Sampah secara Automatik"
 
-#: panels/usage/cc-usage-panel.ui:176
+#: panels/usage/cc-usage-panel.ui:79
 msgid "Automatically Delete Temporary _Files"
 msgstr "Padam _Fail Sementara secara Automatik"
 
-#: panels/usage/cc-usage-panel.ui:198
+#: panels/usage/cc-usage-panel.ui:91
 msgid "Automatically Delete _Period"
 msgstr "_Tempoh Pemadaman Automatik"
 
-#: panels/usage/cc-usage-panel.ui:240
+#: panels/usage/cc-usage-panel.ui:115
 msgid "_Empty Trash…"
 msgstr "Kosongkan Tong _Sampah…"
 
-#: panels/usage/cc-usage-panel.ui:252
+#: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
 msgstr "Pa_dam Fail Sementara…"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:280
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 jam"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:284
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 hari"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:288
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 hari"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:292
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 hari"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:296
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 hari"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:300
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 hari"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:304
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 hari"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:308
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 hari"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:312
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 hari"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:316
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 hari"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:331
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 hari"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:335
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 hari"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:339
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 hari"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:343
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Selamanya"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
@@ -7104,97 +4380,56 @@ msgstr "Sejarah & Tong Sampah Fail"
 msgid "Don't leave traces"
 msgstr "Jangan tinggalkan jejak"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "Patut padankan alamat sesawang bagi penyedia daftar masuk anda."
-
-#: panels/user-accounts/cc-add-user-dialog.c:205
-msgid "Failed to add account"
-msgstr "Gagal menambah akaun"
-
-#: panels/user-accounts/cc-add-user-dialog.c:676
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "Katalaluan tidak padan."
-
-#: panels/user-accounts/cc-add-user-dialog.c:898
-#: panels/user-accounts/cc-add-user-dialog.c:944
-#: panels/user-accounts/cc-add-user-dialog.c:965
-msgid "Failed to register account"
-msgstr "Gagal mendaftarkan akaun"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1088
-msgid "No supported way to authenticate with this domain"
-msgstr "Tiada cara yang disokong untuk sahihkan domain ini"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1161
-msgid "Failed to join domain"
-msgstr "Gagal menyertai domain"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1222
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Nama daftar masuk tidak berfungsi baik.\n"
-"Cuba sekali lagi."
 
-#: panels/user-accounts/cc-add-user-dialog.c:1229
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Kata laluan daftar masuk tidak berfungsi baik.\n"
-"Cuba sekali lagi."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1237
-msgid "Failed to log into domain"
-msgstr "Gagal mendaftar masuk ke dalam domain"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1295
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Tidak dapat mencari domain. Mungkin anda tersilap eja?"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Tambah Pengguna"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr "Nama _Penuh"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-#: panels/user-accounts/cc-user-panel.ui:141
-msgid "Standard"
-msgstr "Piawai"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:216
-#: panels/user-accounts/cc-user-panel.ui:151
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "Pentadbir"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-#: panels/user-accounts/cc-user-panel.ui:169
-msgid "Account _Type"
-msgstr "_Jenis Akaun"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-msgid "Allow user to set a password when they next _login"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"Benarkan pengguna menetapkan satu kata laluan ketika mereka mendaftar _masuk"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
-msgid "Set a password _now"
-msgstr "Tetapkan satu kata laluan _sekarang"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr ""
+"Benarkan pengguna mengubah kata laluan mereka pada daftar masuk berikutnya"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Tetapkan satu kata laluan sekarang"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "Sa_hkan"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Daftar Masuk _Enterprise"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Anda berada di Luar Talian"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7204,408 +4439,236 @@ msgstr ""
 "berpusat digunakan pada peranti ini. Anda juga boleh menggunakan akaun ini "
 "untuk mencapai sumber-sumber syarikat di internet."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:732
-msgid "You are Offline"
-msgstr "Anda berada di Luar Talian"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-msgid "You must be online in order to add enterprise users."
-msgstr ""
-"Anda mesti berada dalam talian supaya dapat menambah pengguna enterprise."
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "Daftar Masuk _Enterprise"
-
-#: panels/user-accounts/cc-avatar-chooser.c:232
-msgid "Browse for more pictures"
-msgstr "Layar untuk dapatkan lagi gambar"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:39
-msgid "Take a Picture…"
-msgstr "_Tangkap satu Gambar…"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:46
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "Pilih satu Fail…"
 
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "Minggu Ini"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Daftar Masuk _Cap jari"
 
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
-msgstr "Minggu Lepas"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Daftar Masuk _Cap jari"
 
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Tiada Tindakan"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
 
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Anda pasti mahu memadam cap jari berdaftar anda supaya daftar masuk cap jari "
+"boleh dilumpuhkan?"
 
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:765
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Peranti input permainan"
 
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:769
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Daftar Masuk _Cap jari"
 
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr "Sesi Tamat"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
 
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr "Sesi Bermula"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Daftar Masuk _Cap jari"
 
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Aktiviti Akaun"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr "Sila pilih kata laluan yang lain."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Daftar Masuk _Cap jari"
 
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
-msgstr "Sila taip kata laluan semasa anda sekali lagi."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
-msgstr "Kata laluan tidak dapat diubah"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Padam Cap Jari"
 
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Daftar Masuk _Cap jari"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Trek terdahulu"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Ubah Kata Laluan"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "_Ubah"
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr "_Sahkan Kata Laluan Baharu"
-
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr "Kata Laluan _Baharu"
-
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "_Kata Laluan Semasa"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Kata Laluan _Baharu"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "_Sahkan Kata Laluan Baharu"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Katalaluan tidak padan."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
 "Benarkan pengguna mengubah kata laluan mereka pada daftar masuk berikutnya"
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Tetapkan satu kata laluan sekarang"
 
-#: panels/user-accounts/cc-realm-manager.c:307
-msgid "Cannot automatically join this type of domain"
-msgstr "Tidak dapat sertai jenis domain ini secara automatik"
-
-#: panels/user-accounts/cc-realm-manager.c:310
-msgid "No such domain or realm found"
-msgstr "Tiada domain atau wilayah sebegitu ditemui"
-
-#: panels/user-accounts/cc-realm-manager.c:732
-#: panels/user-accounts/cc-realm-manager.c:746
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Tidak dapat daftar masuk sebagai %s pada domain %s"
-
-#: panels/user-accounts/cc-realm-manager.c:738
-msgid "Invalid password, please try again"
-msgstr "Kata laluan tidak sah, sila cuba lagi"
-
-#: panels/user-accounts/cc-realm-manager.c:751
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Tidak dapat bersambung dengan domain %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:208
-msgid "Your account"
-msgstr "Akaun anda"
-
-#: panels/user-accounts/cc-user-panel.c:383
-msgid "Failed to delete user"
-msgstr "Gagal memadam pengguna"
-
-#: panels/user-accounts/cc-user-panel.c:441
-#: panels/user-accounts/cc-user-panel.c:500
-#: panels/user-accounts/cc-user-panel.c:552
-msgid "Failed to revoke remotely managed user"
-msgstr "Gagal menyeru pengguna terurus secara jauh"
-
-#: panels/user-accounts/cc-user-panel.c:604
-msgid "You cannot delete your own account."
-msgstr "Anda tidak dapat memadam akaun anda."
-
-#: panels/user-accounts/cc-user-panel.c:613
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s masih mendaftar masuk"
-
-#: panels/user-accounts/cc-user-panel.c:617
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Memadam seorang pengguna ketika mereka masih mendaftar masuk boleh "
-"menyebabkan sistem dalam keadaan tidak seragam."
-
-#: panels/user-accounts/cc-user-panel.c:626
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Anda pasti mahu mengekalkan fail-fail %s?"
-
-#: panels/user-accounts/cc-user-panel.c:630
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Adalah mungkin dapat kekalkan direktori rumah, spul mel dan fail sementara "
-"ketika memadam satu kaun pengguna."
-
-#: panels/user-accounts/cc-user-panel.c:633
-msgid "_Delete Files"
-msgstr "Pa_dam Fail"
-
-#: panels/user-accounts/cc-user-panel.c:634
-msgid "_Keep Files"
-msgstr "_Kekalkan Fail"
-
-#: panels/user-accounts/cc-user-panel.c:648
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Anda pasti mahu menarik balik akaun %s yang diurus secara jauh?"
-
-#: panels/user-accounts/cc-user-panel.c:652
-msgid "_Delete"
-msgstr "Pa_dam"
-
-#: panels/user-accounts/cc-user-panel.c:702
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Akaun dilumpuhkan"
-
-#: panels/user-accounts/cc-user-panel.c:710
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Akan ditetapkan pada daftar masuk berikutnya"
-
-#: panels/user-accounts/cc-user-panel.c:713
-msgctxt "Password mode"
-msgid "None"
-msgstr "Tiada"
-
-#: panels/user-accounts/cc-user-panel.c:758
-msgid "Logged in"
-msgstr "Telah daftar masuk"
-
-#: panels/user-accounts/cc-user-panel.c:1092
-msgid "Failed to contact the accounts service"
-msgstr "Gagal menghubungi perkhidmatan akaun"
-
-#: panels/user-accounts/cc-user-panel.c:1094
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Sila pastikan AccountService dipasang dan dibenarkan."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1126
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Untuk membuat perubahan,\n"
-"klik ikon * dahuku"
-
-#: panels/user-accounts/cc-user-panel.c:1199
-msgid "Create a user account"
-msgstr "Cipta satu akaun pengguna"
-
-#: panels/user-accounts/cc-user-panel.c:1210
-#: panels/user-accounts/cc-user-panel.c:1338
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Untuk mencipta satu akaun pengguna,\n"
-"klik pada ikon * dahulu"
-
-#: panels/user-accounts/cc-user-panel.c:1219
-msgid "Delete the selected user account"
-msgstr "Padam akaun pengguna terpilih"
-
-#: panels/user-accounts/cc-user-panel.c:1231
-#: panels/user-accounts/cc-user-panel.c:1342
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Untuk memadam akaun pengguna terpilih,\n"
-"klik pada ikon * dahulu"
-
-#: panels/user-accounts/cc-user-panel.ui:5
-msgid "_Add User…"
-msgstr "T_ambah Pengguna…"
-
-#: panels/user-accounts/cc-user-panel.ui:52
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "Sesi anda perlu dimulakan semula supaya perubahan yang dibuat berkesan"
-
-#: panels/user-accounts/cc-user-panel.ui:60
-msgid "Restart Now"
-msgstr "Mula Semula Sekarang"
-
-#: panels/user-accounts/cc-user-panel.ui:244
-msgid "A_utomatic Login"
-msgstr "Daftar Masuk A_utomatik"
-
-#: panels/user-accounts/cc-user-panel.ui:286
-msgid "_Fingerprint Login"
-msgstr "Daftar Masuk _Cap jari"
-
-#: panels/user-accounts/cc-user-panel.ui:312
-#: panels/user-accounts/cc-user-panel.ui:328
-msgid "User Icon"
-msgstr "Ikon Pengguna"
-
-#: panels/user-accounts/cc-user-panel.ui:392
-msgid "Last Login"
-msgstr "Daftar Masuk Terakhir"
-
-#: panels/user-accounts/cc-user-panel.ui:441
-msgid "Remove User…"
-msgstr "Buang Pengguna…"
-
-#. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:471
-msgid "No Users Found"
-msgstr "Tidak Pengguna Ditemui"
-
-#: panels/user-accounts/cc-user-panel.ui:481
-msgid "Unlock to add a user account."
-msgstr "Buka untuk menambah satu akaun pengguna."
-
-#: panels/user-accounts/data/account-fingerprint.ui:12
-msgid "Left thumb"
-msgstr "Ibu jari kiri"
-
-#: panels/user-accounts/data/account-fingerprint.ui:15
-msgid "Left middle finger"
-msgstr "Jari tengah kiri"
-
-#: panels/user-accounts/data/account-fingerprint.ui:18
-msgid "Left ring finger"
-msgstr "Jari manis kiri"
-
-#: panels/user-accounts/data/account-fingerprint.ui:21
-msgid "Left little finger"
-msgstr "Jari anak kiri"
-
-#: panels/user-accounts/data/account-fingerprint.ui:24
-msgid "Right thumb"
-msgstr "Ibu jari kanan"
-
-#: panels/user-accounts/data/account-fingerprint.ui:27
-msgid "Right middle finger"
-msgstr "Jari tengah kanan"
-
-#: panels/user-accounts/data/account-fingerprint.ui:30
-msgid "Right ring finger"
-msgstr "Jari manis kanan"
-
-#: panels/user-accounts/data/account-fingerprint.ui:33
-msgid "Right little finger"
-msgstr "Jari anak"
-
-#: panels/user-accounts/data/account-fingerprint.ui:39
-#: panels/user-accounts/um-fingerprint-dialog.c:677
-msgid "Enable Fingerprint Login"
-msgstr "Benarkan Daftar Masuk Cap Jari"
-
-#: panels/user-accounts/data/account-fingerprint.ui:89
-msgid "_Right index finger"
-msgstr "Jari tengah _kanan"
-
-#: panels/user-accounts/data/account-fingerprint.ui:105
-msgid "_Left index finger"
-msgstr "Jari tengah k_iri"
-
-#: panels/user-accounts/data/account-fingerprint.ui:126
-msgid "_Other finger:"
-msgstr "Jari _lain:"
-
-#: panels/user-accounts/data/account-fingerprint.ui:324
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"Cap jari anda berjaya disimpan. Sekarang, anda boleh mendaftar masuk "
-"menggunakan pembaca cap jari anda."
-
+#: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Pengguna"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Sesi anda perlu dimulakan semula supaya perubahan yang dibuat berkesan"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Mula Semula Sekarang"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+#, fuzzy
+msgid "Close"
+msgstr "T_utup"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Nama _Penuh"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_Edit"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Daftar Masuk _Cap jari"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Daftar Masuk A_utomatik"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "%s — Aktiviti Akaun"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Pentadbir"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Kawalan"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Buka dengan aplikasi default anda"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Buang Pengguna…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Lain-lain Fail"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "T_ambah Pengguna…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Tidak Pengguna Ditemui"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Buka untuk menambah satu akaun pengguna."
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "Tambah atau buang pengguna dan ubah kata laluan anda"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Daftar Masuk;Nama;Cap Jari;Avatar;Logo;Wajah;Kata Laluan;"
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Daftar"
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Daftar Masuk Pentadbir Domain"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -7615,11 +4678,11 @@ msgstr ""
 "perlu didaftarkan ke dalam domain. Sila pastikan pentadbir\n"
 "rangkaian anda menaip kata laluan domain mereka di sini."
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "_Nama Pentadbir"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Kata Laluan Pentadbir"
 
@@ -7631,282 +4694,16 @@ msgstr "Urus akaun pengguna"
 msgid "Authentication is required to change user data"
 msgstr "Pengesahihan diperlukan untuk mengubah data pengguna"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Kata laluan baharu perlu berbeza dengan yang lama."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Cuba tukar beberapa abjad dan nombor."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Cuba tukar lagi kata laluan tersebut."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Kata laluan tanpa nama pengguna anda adalah lebih kuat."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Cuba hindari penggunaan  nama anda di dalam kata laluan."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Cuba hindari beberapa perkataan yang disertakan di dalam kata laluan."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Cuba hindari perkataan umum."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Cuba hindari menertib semula perkataan sedia ada."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Cuba guna lebih nombor."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Cuba guna lebih huruf besar."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Cuba guna lebih huruf kecil."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Cuba guna lebih aksara khas, seperti tanda baca."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Cuba guna gabungan abjad, nombor dan tanda baca."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Cuba hindari pengulangan aksara yang sama."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Cuba hindari pengulangan jenis aksara yang sama: anda perlu campurkan abjad, "
-"nombor dan tanda baca."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Cuba hindari jujukan seperti 1234 atau abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Kata laluan perlu lebih panjang. Cuba tambah lagi abjad, nombor atau tanda "
-"baca."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Campurkan huruf besar dan huruf kecil dan cuba masukkan beberapa angka."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Menambah lagi abjad, angka dan tanda baca dapat mengukuhkan kata laluan."
-
-#: panels/user-accounts/run-passwd.c:424
-msgid "Authentication failed"
-msgstr "Pengesahihan gagal"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The new password is too short"
-msgstr "Kata laluan baharu terlalu pendek"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password is too simple"
-msgstr "Kata laluan terlalu ringkas"
-
-#: panels/user-accounts/run-passwd.c:516
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Kata laluan lama dan baharu adalah hampir sama"
-
-#: panels/user-accounts/run-passwd.c:519
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Kata laluan sudah digunakan baru-baru ini."
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Kata laluan baharu mesti mengandungi aksara angka atau khas"
-
-#: panels/user-accounts/run-passwd.c:526
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Kata laluan lama dan baharu adalah serupa"
-
-#: panels/user-accounts/run-passwd.c:530
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Kata laluan anda telah berubah semenjak anda mula sahihkan!"
-
-#: panels/user-accounts/run-passwd.c:534
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Kata laluan baharu tidak mengandungi aksara yang mencukupi"
-
-#: panels/user-accounts/run-passwd.c:538
-#, c-format
-msgid "Unknown error"
-msgstr "Ralat tidak diketahui"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"Anda tidak tidak dibenarkan mencapai peranti. Sila hubungi pentadbir sistem "
-"anda."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "Peranti sedang digunakan."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr "Satu ralat dalaman berlaku."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Enabled"
-msgstr "Dibenarkan"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:260
-msgid "Delete registered fingerprints?"
-msgstr "Padam cap jari berdaftar?"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:264
-msgid "_Delete Fingerprints"
-msgstr "_Padam Cap Jari"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:270
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"Anda pasti mahu memadam cap jari berdaftar anda supaya daftar masuk cap jari "
-"boleh dilumpuhkan?"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:440
-msgid "Done!"
-msgstr "Selesai!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:501
-#: panels/user-accounts/um-fingerprint-dialog.c:543
-#, c-format
-msgid "Could not access “%s” device"
-msgstr "Tidak dapat mencapai peranti \"%s\""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:584
-#, c-format
-msgid "Could not start finger capture on “%s” device"
-msgstr "Tidak dapat memulakan imbasan cap jari pada peranti \"%s\""
-
-#: panels/user-accounts/um-fingerprint-dialog.c:628
-msgid "Could not access any fingerprint readers"
-msgstr "Tidak dapat mencapai mana-mana pembaca cap jari"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:629
-msgid "Please contact your system administrator for help."
-msgstr "Sila hubungi pentadbir sistem anda untuk dapatkan bantuan."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: panels/user-accounts/um-fingerprint-dialog.c:711
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the “%s” device."
-msgstr ""
-"Untuk membenarkan daftar masuk cap jari, anda perlu simpan salah satu cap "
-"jari anda, menggunakan peranti \"%s\"."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:718
-msgid "Selecting finger"
-msgstr "Memilih jari"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:719
-msgid "Enrolling fingerprints"
-msgstr "Mendaftarkan cap jari"
-
-#: panels/user-accounts/user-utils.c:439
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Nama pengguna biasanya hanya mengandungi abjad berhuruf kecil iaitu a-z, "
-"digit dan aksara-aksara berikut: - _"
-
-#: panels/user-accounts/user-utils.c:443
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Maaf, nama pengguna tidak tersedia. Sila cuba lagi."
-
-#: panels/user-accounts/user-utils.c:488
-msgid "The username is too long."
-msgstr "Nama pengguna telalu panjang."
-
-#: panels/user-accounts/user-utils.c:550
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr ""
-"Ia akan digunakan untuk menamakan folder rumah anda dan tidak boleh diubah."
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Petakan Butang"
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "T_utup"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Butang peta ke fungsi"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -7915,75 +4712,131 @@ msgstr ""
 "tekan butang pintasan papan kekunci dan tahan kekunci-kekunci baharu atau "
 "tekan Backspace untuk kosongkan."
 
-#: panels/wacom/calibrator/calibrator.ui:61
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "T_utup"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
 "Sila ketik penanda sasaran supaya ia muncul pada skrin untuk tentukur tablet."
 
-#: panels/wacom/calibrator/calibrator.ui:78
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "Tersilap-klik dikesan, memulakan semula…"
 
-#: panels/wacom/cc-wacom-button-row.c:249
-#, c-format
-msgid "Button %d"
-msgstr "Butang %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplikasi ditakrif"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tablet"
 
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Hantar Ketukan Kekunci"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Tukar Monitor"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Orientasi Kidal"
 
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Tunjuk Bantuan Atas-Skrin"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:249
-msgid "Output:"
-msgstr "Output:"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Petakan untuk Pantau…"
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:261
-msgid "Keep aspect ratio (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
 msgstr "Kekalkan nisbah bidang (peti surat):"
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:272
-msgid "Map to single monitor"
-msgstr "Petakan ke monitor tunggal"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
-msgstr "%d daripada %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Tentukur…"
 
-#: panels/wacom/cc-wacom-page.c:516
-msgid "Display Mapping"
-msgstr "Pemetaan Paparan"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Tiada tablet dikesan"
 
-#: panels/wacom/cc-wacom-panel.c:812 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
-msgstr "Stilus"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Sila palam masuk atau hidupkan tablet Wacom anda"
 
-#: panels/wacom/cc-wacom-stylus-page.c:360
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Rasa Tekanan di Hujung"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Lembut"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Kukuh"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Butang"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Butang"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Butang"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Rasa Tekanan Eraser"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Rasa Tekanan Eraser"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Klik Butang Tengah Tetikus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Klik Butang Kanan Tetikus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Maju"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr "Tablet Wacom"
 
@@ -7991,190 +4844,342 @@ msgstr "Tablet Wacom"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Tetapkan pemetaan butang dan laras kepekaan stilus untuk tablet grafik"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stilus;Pemadam;Tetikus;"
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "Tablet (mutlak)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Susunatur"
 
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
-msgstr "Pad Sesentuh (relatif)"
-
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "Keutamaan Tablet"
-
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "_Bantuan"
-
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
-msgstr "Tiada tablet dikesan"
-
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Sila palam masuk atau hidupkan tablet Wacom anda"
-
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
-msgstr "Tetapan Bluetooth"
-
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
-msgstr "Mod Menjejak"
-
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
-msgstr "Orientasi Kidal"
-
-#: panels/wacom/gnome-wacom-properties.ui:296
-#: panels/wacom/gnome-wacom-properties.ui:401
-msgid "Map to Monitor…"
-msgstr "Petakan untuk Pantau…"
-
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
-msgstr "Butang Peta…"
-
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
-msgstr "Tentukur…"
-
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
-msgstr "Laras tetapan tetikus"
-
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
-msgstr "Laras resolusi paparan"
-
-#: panels/wacom/gnome-wacom-properties.ui:376
-msgid "Decouple Display"
-msgstr "Nyahpasang Paparan"
-
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr "Pintasan baharu…"
-
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "Lalai"
-
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "Klik Butang Tengah Tetikus"
-
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "Klik Butang Kanan Tetikus"
-
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "Maju"
-
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
-msgstr "Tiada stilus ditemui"
-
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
 msgstr ""
-"Sila alih stilus anda berdekatan dengan tablet untuk mengkonfigurkannya"
 
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
-msgstr "Rasa Tekanan Eraser"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
-msgid "Soft"
-msgstr "Lembut"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
-msgid "Firm"
-msgstr "Kukuh"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:234
-msgid "Top Button"
-msgstr "Butang Atas"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:263
-msgid "Lower Button"
-msgstr "Butang Bawah"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:292
-msgid "Lowest Button"
-msgstr "Butang Paling Rendah"
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Tetingkap Utama"
 
-#: panels/wacom/wacom-stylus-page.ui:321
-msgid "Tip Pressure Feel"
-msgstr "Rasa Tekanan di Hujung"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Klik Sekunder Ter_simulasi"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Settings"
-msgstr "Tetapan GNOME"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Tetingkap"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Kekurangan toner"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "saat"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Tetingkap"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Pilihan Capaian"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Tambah"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Simpan"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Perincian Tema"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+msgid "Modem Status"
+msgstr "Status:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Nama Rangkaian"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Rangkaian"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Bilangan"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "_Perincian Tema"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Pengeluar"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Perisian tegar hilang"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Jalur Lebar Mudah Alih"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Nama Rangkaian"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Rangkaian"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Lanjutan"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Pilihan Capaian"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Kunci Skrin"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Perincian Tema"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Nama Rangkaian"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Automatik"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Rangkaian Kelihatan"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "D_ibenarkan oleh Papan Kekunci"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Tiada Penyesuai Wi-Fi Ditemui"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Pastikan anda telah memalam dan menghidupkan penyesuai Wi-Fi"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Bluetooth dilumpuhkan ketika mod kapal terbang hidup."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Matikan Mod Kapal Terbang"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Lupakan Sambungan"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "Kad SIM tidak disisip"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Kunci Skrin"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "_Ubah"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Rangkaian Kelihatan"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "Konfigur Tetapan Media Boleh Alih"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
 msgstr "Utiliti untuk mengkonfigur atas meja GNOME"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr "Tetapan ialah antara muka utama untuk Mengkonfigur sistem anda."
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:20
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "Projek GNOME"
 
-#: shell/cc-application.c:58
-msgid "Display version number"
-msgstr "Papar nombor versi"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "- Login GDM baharu"
 
-#: shell/cc-application.c:59
-msgid "Enable verbose mode"
-msgstr "Benarkan mod berjela"
-
-#: shell/cc-application.c:60
-msgid "Search for the string"
-msgstr "Gelintar rentetan"
-
-#: shell/cc-application.c:61
-msgid "List possible panel names and exit"
-msgstr "Senaraikan nama panel yang mungkin kemudian keluar"
-
-#: shell/cc-application.c:62
-msgid "Panel to display"
-msgstr "Panel untuk dipaparkan"
-
-#: shell/cc-application.c:62
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMEN…]"
-
-#: shell/cc-panel-list.ui:45 shell/cc-window.c:277
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Kerahsiaan"
 
-#: shell/cc-panel-loader.c:292
-msgid "Available panels:"
-msgstr "Panel tersedia:"
-
-#: shell/cc-window.ui:140
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Semua Tetapan"
 
-#: shell/cc-window.ui:178
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr "Menu Utama"
 
-#: shell/cc-window.ui:319
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr "Amaran Versi Pembangunan"
 
-#: shell/cc-window.ui:320
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
@@ -8184,14 +5189,9 @@ msgstr ""
 "mungkin menghadapi kelakuan sistem yang bermasalah, kehilangan data, dan "
 "lain-lain masalah tidak dijangka. "
 
-#: shell/cc-window.ui:331
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Bantuan"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "Keutamaan;Tetapan;"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -8203,7 +5203,7 @@ msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Keluar"
 
-#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "Gelintar"
@@ -8213,15 +5213,19 @@ msgctxt "shortcut window"
 msgid "Panels"
 msgstr "Panel"
 
-#: shell/help-overlay.ui:40
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
 msgstr "Undur ke panel terdahulu"
 
-#: shell/help-overlay.ui:53
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Batal gelintar"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Keutamaan;Tetapan;"
 
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
@@ -8246,9 +5250,17 @@ msgstr ""
 "Sama ada Tetapan patut menunjukkan satu amaran ketika menjalankan binaan "
 "pembangunan."
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1883
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
@@ -8256,9 +5268,7 @@ msgstr[0] "%u Output"
 msgstr[1] "%u Output"
 
 # msgstr[1] "%u Output"
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1893
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
@@ -8266,9 +5276,2952 @@ msgstr[0] "%u Input"
 msgstr[1] "%u Input"
 
 # msgstr[1] ""
-#: subprojects/gvc/gvc-mixer-control.c:2750
-msgid "System Sounds"
-msgstr "Bunyi Sistem"
+#~ msgid "System Bus"
+#~ msgstr "Bas Sistem"
+
+#~ msgid "Full access"
+#~ msgstr "Capaian penuh"
+
+#~ msgid "Session Bus"
+#~ msgstr "Bas Sesi"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Capaian penuh ke /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Mempunyai capaian rangkaian"
+
+#~ msgid "Home"
+#~ msgstr "Rumah"
+
+#~ msgid "Read-only"
+#~ msgstr "Baca-sahaja"
+
+#~ msgid "Can change settings"
+#~ msgstr "Boleh mengubah tetapan"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s mempunyai keizinan terbina-dalam berikut. Ia tidak dapat diubah. Jika "
+#~ "anda ambil kisah berkenaan keizinan ini, buang aplikasi ini."
+
+#~ msgid "Web Links"
+#~ msgstr "Pautan Sesawang"
+
+#~ msgid "Git Links"
+#~ msgstr "Pautan Git"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "Pautan %s"
+
+#~ msgid "Unset"
+#~ msgstr "Nyahtetap"
+
+#~ msgid "Links"
+#~ msgstr "Pautan"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Fail Hiperteks"
+
+#~ msgid "Text Files"
+#~ msgstr "Fail Teks"
+
+#~ msgid "Image Files"
+#~ msgstr "Fail Imej"
+
+#~ msgid "Font Files"
+#~ msgstr "Fail Fon"
+
+#~ msgid "Archive Files"
+#~ msgstr "Fail Arkib"
+
+#~ msgid "Package Files"
+#~ msgstr "Fail Pakej"
+
+#~ msgid "Audio Files"
+#~ msgstr "Fail Audio"
+
+#~ msgid "Video Files"
+#~ msgstr "Fail Video"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Keizinan & Capaian"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Data dan perkhidmatan yang dipinta oleh aplikasi ini untuk capaian dan "
+#~ "keizinan yang diperlukannya."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Tidak dapat diubah"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Keizinan individu untuk aplikasi boleh ditinjau dalam Tetapan <a "
+#~ "href=\"privacy\">Kerahsiaan</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Penyepaduan"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Pengendali Lalai"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Jenis fail dan pautan yang dibuka oleh aplikasi ini."
+
+#~ msgid "Usage"
+#~ msgstr "Penggunaan"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Berapa banyak sumber-sumber dalam aplikasi ini gunakan."
+
+#~ msgid "Open in Software"
+#~ msgstr "Buka dalam Perisian"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Tambah akaun pengguna dan ubah kata laluan"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Main dan rakam bunyi"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Kesan peranti rangkaian menggunakan mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Capai perkakasan bluetooth secara terus"
+
+#~ msgid "Use bluetooth devices"
+#~ msgstr "Guna peranti bluetooth"
+
+#~ msgid "Use your camera"
+#~ msgstr "Guna kamera anda"
+
+#~ msgid "Print documents"
+#~ msgstr "Cetak dokumen"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Guna mana-mana kayu ria bersambung"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Benarkan bersambung dengan perkhidmatan Docker"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Konfigur dinding api rangkaian"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Pasang dan guna sistem fail FUSE yang layak"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Kemas kini perisian tegar dalam peranti ini"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Capai maklumat perkakasan"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Menyediakan entropi untuk penjana nombor rawak perkakasan"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Guna nombor rawak terjana-perkakasan"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Capai fail dalam folder rumah anda"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Capai perkhidmatan libvirt"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Ubah tetapan bahasa dan wilayah sistem"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Ubah tetapan dan penyedia lokasi"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Baca sistem dan log aplikasi"
+
+#~ msgid "Access LXD service"
+#~ msgstr "Capai perkhidmatan LXD"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "capai perkhidmatan media-hub"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Guna dan konfigur modem"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Baca maklumat lekap sistem dan kuota cakera"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Kawal pemain muzik dan video"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Ubah tetapan rangkaian aras-rendah"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Capai perkhidmatan Pengurus Rangkaian untuk baca dan ubah tetapan "
+#~ "rangkaian"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Baca capaian ke tetapan rangkaian"
+
+#~ msgid "Change network settings"
+#~ msgstr "Ubah tetapan rangkaian"
+
+#~ msgid "Read network settings"
+#~ msgstr "Baca tetapan rangkaian"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Capai perkhidmatan ofono untuk baca dan ubah tetapan rangkaian telefoni "
+#~ "mudah alih"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Kawal perkakasan Open vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Baca dari CD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Baca, tambah, ubah, atau buang kata laluan tersimpan"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Capai peranti pppd dan ppp untuk mengkonfigur sambungan Protokol Titik-ke-"
+#~ "Titik"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Jeda atau tamatkan apa-apa proses dalam sistem"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Capai perkakasan USB secara terus"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Baca/tulis fail dalam peranti storan mudah alih"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Halang skrin dari tidur/terkunci"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Capai perkakasan port serial"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Mula semula atau matikan peranti"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Pasang, buang dan konfigur perisian"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Capai perkhidmatan Bingkai Kerja Storan"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Baca proses dan maklumat sistem"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Pantau dan kawal apa-apa program yang berjalan"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Ubah tetapan pelayan waktu"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Ubah zon waktu"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Capai perkhidmatan UDisks2 untuk mengkonfigur cakera dan media mudah alih"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Baca/ubah peristiwa kalendar terkongsi dalam Unity 8 Ubuntu"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Baca/ubah hubungan terkongsi dalam Unity 8 Ubuntu"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Capai data penggunaan tenaga"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Baca/tulis capaian ke peranti U2F terdedah"
+
+#~ msgid "Select a picture"
+#~ msgstr "Pilih satu gambar"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Tetapkan Latar Belakang dan Skrin Kunci"
+
+#~ msgid "Set Background"
+#~ msgstr "Tetapkan Latar Belakang"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Tetapkan Kunci skrin"
+
+#~ msgid "Remove Background"
+#~ msgstr "Buang Latar Belakang"
+
+#~ msgid "multiple sizes"
+#~ msgstr "saiz berbilang"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Tiada Latar Belakang Atas Meja"
+
+#~ msgid "Current background"
+#~ msgstr "Latar belakang semasa"
+
+#~ msgid "Activities"
+#~ msgstr "Aktiviti-Aktiviti"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Kertas Dinding;Skrin;Atas Meja;"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Benarkan aplikasi di bawah menggunakan kamera anda."
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Letak peranti penentukuran anda atas petak dan tekan 'Mula'"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Alih peranti penentukuran anda pada kedudukan tentukur dan tekan "
+#~ "'Teruskan'"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Alih peranti penentukuran anda atas kedudukan permukaan dan tekan "
+#~ "'Teruskan'"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Tutup penutup komputer riba"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Satu ralat dalaman berlaku yang tidak dapat dipulihkan."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Alatan diperlukan untuk penentukuran tidak dipasang."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profil tidak dapat dijana."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Titik putih sasaran tidak boleh diperolehi."
+
+#~ msgid "Complete!"
+#~ msgstr "Selesai!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Penentukuran gagal!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Anda boleh buang peranti penentukuran."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Jangan ganggu peranti semasa penentukuran berlansung"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Skrin Komputer Riba"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Kamera Sesawang terbina-dalam"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Pengimbas %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Kamera %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Pencetak %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Kamera Sesawang %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Benarkan pengurusan warna untuk %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Tunjuk profil warna untuk %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Tidak ditentukur"
+
+#~ msgid "Default: "
+#~ msgstr "Lalai: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Profil ujian: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Pilih Fail Profil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Import"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Profil ICC Tersokong"
+
+#~ msgid "All files"
+#~ msgstr "Semua fail"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Gagal memuat naik fail: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profail telah dimuat naik ke:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Catatkan URL ini."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Mulakan semula komputer dan but sistem pengoperasian biasa anda."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Taip URL pada pelayar anda untuk memuat turun dan memasang profil."
+
+#~ msgid "Save Profile"
+#~ msgstr "Simpan Profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Cipta satu profil warna untuk peranti terpilih"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Alat pengukuran tidak dikesan. Periksa sama ada ia telah dihidupkan dan "
+#~ "bersambung dengan baik."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Alat pengukur tidak menyokong pemprofilan pencetak."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Jenis peranti ini tidak disokong buat masa ini."
+
+#~ msgid "Upload profile"
+#~ msgstr "Muat naik profil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Memerlukan sambungan Internet"
+
+#~ msgid "Standard Space"
+#~ msgstr "Ruang Piawai"
+
+#~ msgid "Test Profile"
+#~ msgstr "Uji Profail"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatik"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Kualiti Rendah"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Kualiti Sederhana"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Kualiti Tinggi"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB lalai"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK lalai"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Kelabu lalai"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Data penentukuran kilang yang disediakan pembekal"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Pembetulan paparan skrin-penuh mustahil dibuat dengan profil ini"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Profil ini mungkin tidak lagi tepat"
+
+#~ msgid "Other…"
+#~ msgstr "Lain-lain…"
+
+#~| msgid "Can change settings"
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Nyahkunci untuk Mengubah Tetapan"
+
+#~ msgid "Today"
+#~ msgstr "Hari ini"
+
+#~ msgid "Yesterday"
+#~ msgstr "Semalam"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+# msgstr[1] "minit"
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d jam"
+#~ msgstr[1] "%d jam"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minit"
+#~ msgstr[1] "%d minit"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d saat"
+#~ msgstr[1] "%d saat"
+
+# msgstr[1] "%i jam"
+#, c-format
+#~ msgctxt "time"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+# msgstr[1] "%i jam"
+#, c-format
+#~ msgctxt "time"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Kawasan Khas"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "24-hour"
+#~ msgstr "24-jam"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Penghantaran laporan masalah teknikal dapat membantu kami menambah baik "
+#~ "%s. Laporan yang dihantar adalah secara awanama dan tidak melibatkan data "
+#~ "peribadi."
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "Laporan dihantar secara awanama dan data peribadi disingkirkan."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Menghantar laporan masalah teknikal dapat bantu kami menambah baik sistem "
+#~ "pengoperasian ini."
+
+#~ msgid "Apply Changes?"
+#~ msgstr "_Laksana Perubahan?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Perubahan Tidak Dapat Dilaksanakan"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Ia disebabkan oleh batasan perkakasan."
+
+#~ msgid "Single Display"
+#~ msgstr "Paparan Tunggal"
+
+#~ msgid "Join Displays"
+#~ msgstr "Paparan Terlibat"
+
+#~ msgid "Display Mode"
+#~ msgstr "Mod Paparan"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Seret paparan untuk sepadankan persediaan paparan fizikal anda. Pilih "
+#~ "satu paparan untuk mengubah tetapannya."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Susunan Paparan"
+
+#~ msgid "Active Display"
+#~ msgstr "Paparan Aktif"
+
+#~ msgid "Display Configuration"
+#~ msgstr "Konfigurasi Paparan"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Lanskap"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Kanan Potret"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Kiri Potret"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Lanskap (dikalih)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "More Warm"
+#~ msgstr "Lebih Hangat"
+
+#~ msgid "Less Warm"
+#~ msgstr "Kurang Hangat"
+
+#~ msgid "Unknown"
+#~ msgstr "Tidak diketahui"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Tidak diketahui"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Simpan satu tangkap layar ke dalam $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Simpan satu tangkap layar tetingkap ke dalam $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Simpan satu tangkap layar kawasan ke dalam $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Salin satu tangkap layar ke dalam papan keratan"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Salin satu tangkap layar tetingkap ke dalam papan keratan"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Salin satu tangkap layar kawasan ke dalam papan keratan"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Rakam kas skrin pendek"
+
+#~ msgid "Universal Access"
+#~ msgstr "Capaian Universal"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Kekunci aksara pengganti boleh digunakan untuk memasukkan aksara "
+#~ "tambahan. Ia kadang kala dicetak sebagai pilih-ketiga pada papan kekunci "
+#~ "anda."
+
+#~ msgid "Left Alt"
+#~ msgstr "Alt Kiri"
+
+#~ msgid "Right Alt"
+#~ msgstr "Alt Kanan"
+
+#~ msgid "Left Super"
+#~ msgstr "Super Kiri"
+
+#~ msgid "Right Super"
+#~ msgstr "Super Kanan"
+
+#~ msgid "Menu key"
+#~ msgstr "Kekunci Menu"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl Kanan"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Kekunci Aksara Alternatif"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Suis pengubah suai-sahaja ke sumber berikutnya"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl Kanan"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Kekunci Menu"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super Kiri"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super Kanan"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt Kiri"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt Kanan"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Tetap Semula Semua Pintasan?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Penetapan semula kekunci boleh memberi kesan terhadap pintasan suai anda. "
+#~ "Tindakan ini tidak boleh diundur kembali."
+
+#~ msgid "Reset All"
+#~ msgstr "Teta_p Semula Semua"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Tahan dan taip untuk masukkan aksara yang berbeza"
+
+#, c-format
+#~| msgid ""
+#~| "%s is already being used for <b>%s</b>. If you replace it, %s will be "
+#~| "disabled"
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s sudah digunakan untuk %s. Jika anda ganti ia, %s akan dilumpuhkan"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Tetapkan Pintasan Suai"
+
+#, c-format
+#~| msgid "Enter new shortcut to change <b>%s</b>."
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Masukkan pintasan baharu untuk mengubah %s."
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Masukkan pintasan baharu"
+
+#~ msgid "Set"
+#~ msgstr "Tetapkan"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Perkhidmatan lokasi membolehkan aplikasi-aplikasi dapat mengetahui lokasi "
+#~ "anda. Penggunaan Wi-Fi dan jalur lebar mudah alih dapat meningkatkan "
+#~ "ketepatannya."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Penggunaan Perkhidmatan Lokasi Mozilla: <a href='https://location."
+#~ "services.mozilla.com/privacy'>Dasar Kerahsiaan</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Benarkan aplikasi di bawah menentukan lokasi anda."
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Skrin Dimatikan"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 saat"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minit"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 jam"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minit"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Tidak sesekali"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Kunci skrin anda"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Benarkan aplikasi di bawah menggunakan mikrofon anda."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Had masa tamat dwi-lik"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Penatalan Dua-jari"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Lima klik, GEGL time!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dwi klik, butang utama"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Klik tunggal, butang utama"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dwi-klik, butang tengah"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Klik tunggal, butang tengah"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dwi-klik, butang sekunder"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Klik tunggal, butang sekunder"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Pengurus Rangkaian perlu dijalankan."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Rangkaian tidak selamat (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Rangkaian selamat (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Rangkaian selamat (WPA2)"
+
+#~ msgid "Secure network"
+#~ msgstr "Rangkaian selamat"
+
+#, c-format
+#~| msgid ""
+#~| "Turning on the hotspot will disconnect from <b>%s</b>, and it will not "
+#~| "be possible to access the internet through Wi-Fi."
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Menghidupkan kawasan khas akan menyebabkan %s terputus, dan tidak boleh "
+#~ "mencapai internet melalui Wi-Fi."
+
+#~ msgid "Preserve"
+#~ msgstr "Kekalkan"
+
+#~ msgid "Permanent"
+#~ msgstr "Kekal"
+
+#~ msgid "Random"
+#~ msgstr "Rawak"
+
+#~ msgid "Stable"
+#~ msgstr "Stabil"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Alamat MAC yang dimasukkan di sini akan digunakan sebagai alamat "
+#~ "perkakasan untuk peranti rangkaian yang mana sambungannya aktif. Fitur "
+#~ "ini dikenali sebagai pengklonan MAC atau perdayaan. Contohnya: "
+#~ "00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Tiada"
+
+#~ msgid "Never"
+#~ msgstr "Tidak sesekali"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+# msgstr[1] ""
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Tiada"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Lemah"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Baik"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Bagus"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Buang Profil Sambungan"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Buang VPN"
+
+#~ msgid "Details"
+#~ msgstr "Perincian"
+
+#~ msgid "automatic"
+#~ msgstr "automatik"
+
+#~ msgid "Identity"
+#~ msgstr "Identiti"
+
+#~ msgid "Delete Route"
+#~ msgstr "Padam Hala"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Tiada"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Kunci WEP 40/128-bit (Hex atau ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Frasa Laluan WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP Dinamik (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Persendirian"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Tidak boleh buka penyunting sambungan"
+
+#~ msgid "New Profile"
+#~ msgstr "Profil Baru"
+
+#~ msgid "Import from file…"
+#~ msgstr "Import daripada fail…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Tambah VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Tidak dapat mengimport sambungan VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Fail \"%s\" tidak dapat baca atau tidak mengandungi maklumat sambungan "
+#~ "VPN yang dikenali\n"
+#~ "\n"
+#~ "Ralat: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Pilih fail untuk diimport"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Satu fail bernama \"%s\" sudah wujud."
+
+#~ msgid "_Replace"
+#~ msgstr "_Ganti"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "Anda ingin menggantikan %s dengan sambungan VPN yang anda hendak simpan?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Tidak dapat mengeksport sambungan VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Sambungan VPN \"%s\" tidak dapat dieksport ke %s.\n"
+#~ "\n"
+#~ "Ralat: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Eksport sambungan VPN"
+
+#~ msgid "never"
+#~ msgstr "tidak sesekali"
+
+#~ msgid "today"
+#~ msgstr "hari ini"
+
+#~ msgid "yesterday"
+#~ msgstr "semalam"
+
+#~ msgid "Last used"
+#~ msgstr "Terakhir digunakan"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Henti kawasan khas dan putuskan mana-mana pengguna?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Henti Kawasan Khas"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Perincian rangkaian untuk rangkaian terpilih, termasuklah kata laluan dan "
+#~ "lain-lain konfigurasi suai akan hilang."
+
+#~ msgid "_Forget"
+#~ msgstr "_Lupakan"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Rangkaian Wi-Fi Diketahui"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Lupakan"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Dasar sistem menghalang penggunaan sebagai Kawasan Khas"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Peranti tanpa wayar tidak menyokong mod Kawasan Khas"
+
+#~ msgid "Off"
+#~ msgstr "Tutup"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Auto-penemuan Proksi Sesawang digunakan bila URL Konfigurasi tidak "
+#~ "disediakan."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr ""
+#~ "Tidak disarankan untuk rangkaian-rangkaian awam yang tidak dipercayai."
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Matikan untuk bersambung dengan rangkaian Wi-Fi"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Kata laluan"
+
+#~ msgid "Status unknown"
+#~ msgstr "Status tidak diketahui"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Tidak Diurus"
+
+#~ msgid "Unavailable"
+#~ msgstr "Tiada"
+
+#~ msgid "Connecting"
+#~ msgstr "Menyambung"
+
+#~ msgid "Authentication required"
+#~ msgstr "Pengesahihan diperlukan"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Diputuskan"
+
+#~ msgid "Connection failed"
+#~ msgstr "Sambungan gagal"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Status tidak diketahui (hilang)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Konfigurasi gagal"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Konfigurasi IP gagal"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Konfigurasi IP telah luput"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Rahsia diperlukan, tetapi tidak disediakan"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Perayu 802.1 telah terputus"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Konfigurasi perayu 802.1 telah gagal"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Perayu 802.1 telah gagal"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Perayu 802.1 mengambil masa yang lama untuk disahihkan"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Perkhidmatan PPP gagal dimulakan"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Perkhidmatan PPP terputus"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP gagal"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Klien DHCP gagal dimulakan"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Ralat klien DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Klien DHCP gagal"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Perkhidmatan sambungan berkongsi gagal dimulakan"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Perkhidmatan sambungan terkongsi gagal"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Perkhidmatan AutoIP gagal dimulakan"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Ralat perkhidmatan AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Perkhidmatan AutoIP gagal"
+
+#~ msgid "Line busy"
+#~ msgstr "Talian sibuk"
+
+#~ msgid "No dial tone"
+#~ msgstr "Tiada nada dail"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Tiada pembawa ditubuhkan"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Permintaan dailan telah tamat masa"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Percubaan dailan telah gagal"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Pengawalan modem gagal"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Gagal memilih APN dinyatakan"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Tidak menggelintar rangkaian"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Pendaftaran rangkaian dinafikan"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Pendaftaran rangkaian tamat masa"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Gagal daftar dengan rangkaian yang dipinta"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Semakan PIN gagal"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Perisian tegar untuk peranti mungkin hilang"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Sambungan hilang"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Sambungan sedia ada telah dianggap"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem tidak ditemui"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Sambungan Bluetooth telah gagal"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Pin SIM diperlukan"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Puk SIM diperlukan"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM salah"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Dependensi sambungan telah gagal"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel ditanggalkan"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "ralat tidak ditakrif dalam keselamatan 802.X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "tiada fail terpilih"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "ralat tidak dinyatakan ketika mengesahkan fail eap-method"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr ""
+#~ "Kunci-kunci persendirian DER, PEM, atau PKCS#12 (*.der, *.pem, *.p12, *."
+#~ "key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Sijil-sijil DER atau PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "fail PAC EAP-FAST hilang"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Fail PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "nama pengguna EAP-LEAP hilang"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "kata laluan EAP-LEAP hilang"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "sijil CA EAP-PEAP tidak sah: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "sijil CA EAP-PEAP tidak sah: tiada sijil dinyatakan"
+
+#~ msgid "missing EAP username"
+#~ msgstr "nama pengguna EAP hilang"
+
+#~ msgid "missing EAP password"
+#~ msgstr "kata laluan EAP hilang"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "identiti EAP-TLS hilang"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "sijil CA EAP-TLS tidak sah: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "sijil CA EAP-TLS tidak sah: tiada sijil dinyatakan"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "kunci-persendirian EAP-TLS tidak sah: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "sijil-pengguna EAP-TLS tidak sah: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Kunci persendirian tidak disulitkan adalah tidak selamat"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Kunci persendirian terpilih nampaknya tidak dilindungi oleh satu kata "
+#~ "laluan. Ia mungkin membolehkan kelayakan keselamatan anda tergugat. Sila "
+#~ "pilih satu kunci persendirian dilindungi-kata-laluan.\n"
+#~ "\n"
+#~ "(Anda boleh lindungi berkata laluan kunci persendirian anda dengan "
+#~ "openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Pilih sijil peribadi anda"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Pilih kunci persendirian anda"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "sijil CA EAP-TTLS tidak sah: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "sijil CA EAP-TTLS tidak sah: tiada sijil dinyatakan"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Ralat tidak diketahui ketika mengesahkan keselamatan 802.1X"
+
+#~ msgid "missing leap-username"
+#~ msgstr "nama-pengguna-leap hilang"
+
+#~ msgid "missing leap-password"
+#~ msgstr "kata-laluan-leap hilang"
+
+#~ msgid "missing wep-key"
+#~ msgstr "kunci-WEP hilang"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "kunci-wep tidak sah: kunci dengan panjang %zu mesti mengandungi digit-"
+#~ "heks sahaja"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "kunci-wep tidak sah: kunci dengan panjang %zu mesti mengandungi aksara "
+#~ "ascii sahaja"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "kunci-wep tidak sah: panjang kunci %zu adalah salah. Sebuah kunci mesti "
+#~ "panjangnya 5/13 (acsii) atau 10/26 (heks)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "kunci-wep tidak sah: kunci frasa laluan mesti tidak-kosong"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "kunci-wep tidak sah: frasa laluan mesti lebih pendek daripada 64 aksara"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk tidak sah: panjang kunci %zu tidak sah. Mesti [8.63] bait atau 64 "
+#~ "digit heks"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk tidak sah: tidak dapat mentafsir kunci dengan 64 bait sebagai heks"
+
+#~ msgid "On"
+#~ msgstr "Hidup"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Pemberitahuan _Timbul"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Lain-lain"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Akaun %s"
+
+#~ msgid "Error removing account"
+#~ msgstr "Ralat membuang akaun"
+
+#, c-format
+#~| msgid "<b>%s</b> removed"
+#~ msgid "%s removed"
+#~ msgstr "%s dibuang"
+
+#~ msgid "Remove Account"
+#~ msgstr "Buang Akaun"
+
+#~ msgid "Unknown time"
+#~ msgstr "Masa tidak diketahui"
+
+# msgstr[1] "%i jam"
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+# msgstr[1] "minit"
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s sehingga sepenuhnya dicas"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Amaran: %s berbaki"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s berbaki"
+
+#~ msgid "Fully charged"
+#~ msgstr "Sepenuhnya dicas"
+
+#~ msgid "Not charging"
+#~ msgstr "Tidak dicas"
+
+#~ msgid "Empty"
+#~ msgstr "Habis"
+
+#~ msgid "Charging"
+#~ msgstr "Mengecas"
+
+#~ msgid "Discharging"
+#~ msgstr "Menyahcas"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Utama"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Tambahan"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Tetikus tanpa wayar"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Papan kekunci tanpa wayar"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Bekalan kuasa tanpa gangguan"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Pembantu digital peribadi"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telefon bimbit"
+
+#~ msgid "Media player"
+#~ msgstr "Pemain media"
+
+#~ msgid "Computer"
+#~ msgstr "Komputer"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Mengecas"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Amaran"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Rendah"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Baik"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Sepenuhnya dicas"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Habis"
+
+#~ msgid "Batteries"
+#~ msgstr "Bateri-Bateri"
+
+#~ msgid "When _idle"
+#~ msgstr "Bila me_lahu"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Kecerahan Skrin"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Kecerahan Papan Kekunci"
+
+#~ msgid "_Dim Screen When Inactive"
+#~ msgstr "_Malap Skrin Bila Tidak Aktif"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "Skrin _Gelap"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wi-Fi boleh dimatikan untuk menjimatkan kuasa."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Jalur lebar mudah alih (LTE, 4G, 3G, dll.) boleh dimatikan untuk "
+#~ "menjimatkan kuasa."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth boleh dimatikan untuk menjimatkan kuasa."
+
+#~ msgid "When on battery power"
+#~ msgstr "Bila guna kuasa bateri"
+
+#~ msgid "When plugged in"
+#~ msgstr "Bila dipalam masuk"
+
+#~ msgid "Suspend"
+#~ msgstr "Tangguh"
+
+#~ msgid "Power Off"
+#~ msgstr "Matikan"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernasi"
+
+#~ msgid "Nothing"
+#~ msgstr "Tiada apa"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Butang Tangguh & Kuasa"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Tangguh automatik"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Sahihkan"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Pencetak \"%s\" telah dipadamkan"
+
+# msgstr[1] ""
+#~ msgid "Failed to add new printer."
+#~ msgstr "Gagal menambah pencetak baharu."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Tidak dapat memuatkan ui: %s"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Perincian %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Tiada pemacu yang sesuai ditemui"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Pilih Fail PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Fail Keterangan Pencetak Pos Skrip (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Pencetak JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Pencetak LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Satu Sisi"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Pinggir Panjang (Piawai)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Pinggir Pendek (Kalih)"
+
+#~ msgid "Portrait"
+#~ msgstr "Potret"
+
+#~ msgid "Landscape"
+#~ msgstr "Lanskap"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Lanskap terbalik"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Potret terbalik"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Tertangguh"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Dijedakan"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Pengesahihan diperlukan"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Memproses"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Dihentikan"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Dibatalkan"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Dihenti Paksa"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Selesai"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Kerja-Kerja Aktif"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Masukkan kelayakan untuk mencetak daripada %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Buka Pelayan Cetak"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Buka %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Masukkan nama pengguna dan kata laluan untuk melihat pencetak dalam %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Menggelintar Pencetak"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Port Serial"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Port Parallel"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Lokasi: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Alamat: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Pelayan memerlukan pengesahihan"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dua Sisi"
+
+#~ msgid "Paper Type"
+#~ msgstr "Jenis Kertas"
+
+#~ msgid "Paper Source"
+#~ msgstr "Sumber Kertas"
+
+#~ msgid "Output Tray"
+#~ msgstr "Talam Output"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolusi"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Pra-penapisan GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Halaman per muka"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientasi"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Am"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Persediaan Halaman"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Pilihan Boleh Pasang"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Kerja"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Kualiti Imej"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Warna"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Menyelesaikan"
+
+#~ msgid "Test page"
+#~ msgstr "Halaman uji"
+
+#~ msgid "Auto Select"
+#~ msgstr "Pilih Sendiri"
+
+#~ msgid "Printer Default"
+#~ msgstr "Lalai Pencetak"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Fon Ghostscript Terbenam sahaja"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Tukar ke PS aras 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Tukar ke PS aras 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Tiada Pra-penapisan"
+
+#~ msgid "Out of toner"
+#~ msgstr "Kehabisan toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Kekurangan penjadi"
+
+#~ msgid "Out of developer"
+#~ msgstr "Kehabisan penjadi"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Kekurangan bekalan penanda"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Kehabisan bekalan penanda"
+
+#~ msgid "Open cover"
+#~ msgstr "Buka penutup"
+
+#~ msgid "Open door"
+#~ msgstr "Buka pintu"
+
+#~ msgid "Low on paper"
+#~ msgstr "Kekurangan kertas"
+
+#~ msgid "Out of paper"
+#~ msgstr "Kehabisan kertas"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Luar Talian"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Dihentikan"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Bekas sisa hampir penuh"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Bekas sisa penuh"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Konduktor foto optik sudah menghampiri jangka hayatnya"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Konduktor foto optik sudah tidak berfunngsi"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Sedia"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Jangan terima kerja"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Memproses"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Bersihkan kepala cetak"
+
+#~ msgid "Add…"
+#~ msgstr "Tambah…"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrik"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Pilih format untuk angka, tarikh dan mata wang. Perubahan hanya berkesan "
+#~ "pada daftar masuk berikutnya."
+
+#~ msgid "No input sources found"
+#~ msgstr "Tiada sumber input dijumpai"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Lain-lain"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Mula semula sesi supaya perubahan yang dibuat berkesan"
+
+#~ msgid "Restart…"
+#~ msgstr "Mula Semula…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Tetapan daftar masuk digunakan oleh semua pengguna bila mendaftar masuk "
+#~ "ke dalam sistem"
+
+#~ msgid "Previous source"
+#~ msgstr "Sumber terdahulu"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "Sumber berikutnya"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt Kiri+Kanan"
+
+#~ msgid "These keyboard shortcuts can be changed in the keyboard settings"
+#~ msgstr "Pintasan papan kekunci ini boleh diubah dalam tetapan papan kekunci"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Tanya apa perlu buat"
+
+#~ msgid "Do nothing"
+#~ msgstr "Jangan buat apa-apa"
+
+#~ msgid "Open folder"
+#~ msgstr "Buka folder"
+
+#~ msgid "Other Media"
+#~ msgstr "Lain-lain Media"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Pilih satu aplikasi untuk CD audio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Pilih satu aplikasi untuk DVD video"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Pilih satu aplikasi untuk dijalankan ketika pemain muzik disambungkan"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Pilih satu aplikasi untuk dijalankan ketika kamera disambungkan"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Pilih satu aplikasi untuk CD perisian"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD audio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "cakera Blu-Ray kosong"
+
+#~ msgid "blank CD disc"
+#~ msgstr "cakera CD kosong"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "cakera DVD kosong"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "cakera DVD HD kosong"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Cakera video Blu-Ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "Pembaca e-buku"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Cakera video DVD HD"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD Gambar"
+
+#~ msgid "Super Video CD"
+#~ msgstr "CD Video Super"
+
+#~ msgid "Video CD"
+#~ msgstr "CD Video"
+
+#~ msgid "Windows software"
+#~ msgstr "Perisian Windows"
+
+#~ msgid "Select Location"
+#~ msgstr "Pilih Lokasi"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Tiada aplikasi dijumpai"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Kawal keputusan gelintar yang manakah perlu ditunjukkan dalam Selayang "
+#~ "Pandang Aktiviti. Tertib keputusan gelintar boleh diubah dengan "
+#~ "mengerakkan baris-baris di dalam senarai."
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Tiada rangkaian terpilih untuk dikongsikan"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Hidup"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Tutup"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Dibenarkan"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Pilih satu Folder"
+
+#, c-format
+#~| msgid ""
+#~| "File Sharing allows you to share your Public folder with others on your "
+#~| "current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Perkongsian Fail membolehkan anda berkongsi folder awam anda dengan orang "
+#~ "lain pada rangkaian semasa anda melalui: %s"
+
+#, c-format
+#~| msgid ""
+#~| "When remote login is enabled, remote users can connect using the Secure "
+#~| "Shell command:\n"
+#~| "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Bila daftar jauh dibenarkan, pengguna jauh boleh bersambung menggunakan "
+#~ "perintah Shell Selamat:\n"
+#~ "%s"
+
+#, c-format
+#~| msgid ""
+#~| "Screen sharing allows remote users to view or control your screen by "
+#~| "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Perkongsian skrin membolehkan pengguna jauh melihat atau mengawal skrin "
+#~ "anda bila bersambung dengan %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Perkongsian _Skrin"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Sesetengah perkhidmatan dilumpuhkan kerana tiada capaian rangkaian."
+
+#~ msgid "_Password:"
+#~ msgstr "_Kata laluan:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Tunjuk Kata Laluan"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Sambungan _baharu mesti tanya dahulu untuk dapatkan capaian"
+
+#~ msgid "_Require a password"
+#~ msgstr "Pe_lukan satu kata laluan"
+
+#~ msgid "Custom"
+#~ msgstr "Suai"
+
+#~ msgid "Bark"
+#~ msgstr "Nyalak"
+
+#~ msgid "Drip"
+#~ msgstr "Titisan"
+
+#~ msgid "Glass"
+#~ msgstr "Gelas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Menguji %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Terputus"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Menyambung"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Bersambung"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Ralat Keizinan"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Mengizinkan"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Kefungisan Terkurang"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Bersambung & Diizinkan"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Tidak diketahui"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Diizinkan pada:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Bersambung pada:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Berdaftar pada:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Gagal izinkan peranti: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Gagal melupakan peranti: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Ralat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Diizinkan"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Sub-sistem Thunderbolt (boltd) tidak dipasang atau disediakan dengan baik."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt tidak dapat dikesan.\n"
+#~ "Sama ada sistem kekurangan sokongan Thunderbolt, ia telah dilumpuhkan "
+#~ "dalam BIOS atau telah ditetapkan dengan aras keselamatan tidak disokong "
+#~ "dalam BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Sokongan Thunderbolt telah dilumpuhkan dalam BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Aras keselamatan Thunderbolt tidak dapat ditentukan."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Ralat beralih ke mod terus: %s"
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Hanya peranti Port USB dan Paparan boleh dipalamkan."
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Lalai"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Sederhana"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Besar"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Lebih Besae"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Terbesar"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d piksel"
+#~ msgstr[1] "%d piksel"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Pembaca Skrin"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Pembaca _Skrin"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Kekunci Bunyi"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Pendek"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼  Skrin"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ Skrin"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ Skrin"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Panjang"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Kosongkan semua item dari tong sampah?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Semua item di dalam Tong Sampah akan dipadam secara kekal."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Kosongkan _Tong Sampah"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Padam semua fail sementara?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Semua fail sementara akan dipadam secara kekal."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "S_ingkir Fail Sementara"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 jam"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 hari"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 hari"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 hari"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 hari"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 hari"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Selamanya"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Patut padankan alamat sesawang bagi penyedia daftar masuk anda."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Gagal menambah akaun"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Gagal mendaftarkan akaun"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Tiada cara yang disokong untuk sahihkan domain ini"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Gagal menyertai domain"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Nama daftar masuk tidak berfungsi baik.\n"
+#~ "Cuba sekali lagi."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Kata laluan daftar masuk tidak berfungsi baik.\n"
+#~ "Cuba sekali lagi."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Gagal mendaftar masuk ke dalam domain"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Tidak dapat mencari domain. Mungkin anda tersilap eja?"
+
+#~ msgid "Standard"
+#~ msgstr "Piawai"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Jenis Akaun"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Benarkan pengguna menetapkan satu kata laluan ketika mereka mendaftar "
+#~ "_masuk"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Tetapkan satu kata laluan _sekarang"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "Anda mesti berada dalam talian supaya dapat menambah pengguna enterprise."
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Layar untuk dapatkan lagi gambar"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "_Tangkap satu Gambar…"
+
+#~ msgid "This Week"
+#~ msgstr "Minggu Ini"
+
+#~ msgid "Last Week"
+#~ msgstr "Minggu Lepas"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sesi Tamat"
+
+#~ msgid "Session Started"
+#~ msgstr "Sesi Bermula"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Sila pilih kata laluan yang lain."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Sila taip kata laluan semasa anda sekali lagi."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Kata laluan tidak dapat diubah"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Tidak dapat sertai jenis domain ini secara automatik"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Tiada domain atau wilayah sebegitu ditemui"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Tidak dapat daftar masuk sebagai %s pada domain %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Kata laluan tidak sah, sila cuba lagi"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Gagal memadam pengguna"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Gagal menyeru pengguna terurus secara jauh"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Anda tidak dapat memadam akaun anda."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s masih mendaftar masuk"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Memadam seorang pengguna ketika mereka masih mendaftar masuk boleh "
+#~ "menyebabkan sistem dalam keadaan tidak seragam."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Anda pasti mahu mengekalkan fail-fail %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Adalah mungkin dapat kekalkan direktori rumah, spul mel dan fail "
+#~ "sementara ketika memadam satu kaun pengguna."
+
+#~ msgid "_Delete Files"
+#~ msgstr "Pa_dam Fail"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Kekalkan Fail"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Anda pasti mahu menarik balik akaun %s yang diurus secara jauh?"
+
+#~ msgid "_Delete"
+#~ msgstr "Pa_dam"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Akaun dilumpuhkan"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Akan ditetapkan pada daftar masuk berikutnya"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Tiada"
+
+#~ msgid "Logged in"
+#~ msgstr "Telah daftar masuk"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Gagal menghubungi perkhidmatan akaun"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Sila pastikan AccountService dipasang dan dibenarkan."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Untuk membuat perubahan,\n"
+#~ "klik ikon * dahuku"
+
+#~ msgid "Create a user account"
+#~ msgstr "Cipta satu akaun pengguna"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Untuk mencipta satu akaun pengguna,\n"
+#~ "klik pada ikon * dahulu"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Padam akaun pengguna terpilih"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Untuk memadam akaun pengguna terpilih,\n"
+#~ "klik pada ikon * dahulu"
+
+#~ msgid "User Icon"
+#~ msgstr "Ikon Pengguna"
+
+#~ msgid "Last Login"
+#~ msgstr "Daftar Masuk Terakhir"
+
+#~ msgid "Left thumb"
+#~ msgstr "Ibu jari kiri"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Jari tengah kiri"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Jari manis kiri"
+
+#~ msgid "Left little finger"
+#~ msgstr "Jari anak kiri"
+
+#~ msgid "Right thumb"
+#~ msgstr "Ibu jari kanan"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Jari tengah kanan"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Jari manis kanan"
+
+#~ msgid "Right little finger"
+#~ msgstr "Jari anak"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Benarkan Daftar Masuk Cap Jari"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Jari tengah _kanan"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Jari tengah k_iri"
+
+#~ msgid "_Other finger:"
+#~ msgstr "Jari _lain:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Cap jari anda berjaya disimpan. Sekarang, anda boleh mendaftar masuk "
+#~ "menggunakan pembaca cap jari anda."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Daftar Masuk;Nama;Cap Jari;Avatar;Logo;Wajah;Kata Laluan;"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Kata laluan baharu perlu berbeza dengan yang lama."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Cuba tukar beberapa abjad dan nombor."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Cuba tukar lagi kata laluan tersebut."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Kata laluan tanpa nama pengguna anda adalah lebih kuat."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Cuba hindari penggunaan  nama anda di dalam kata laluan."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr ""
+#~ "Cuba hindari beberapa perkataan yang disertakan di dalam kata laluan."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Cuba hindari perkataan umum."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Cuba hindari menertib semula perkataan sedia ada."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Cuba guna lebih nombor."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Cuba guna lebih huruf besar."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Cuba guna lebih huruf kecil."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Cuba guna lebih aksara khas, seperti tanda baca."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Cuba guna gabungan abjad, nombor dan tanda baca."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Cuba hindari pengulangan aksara yang sama."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Cuba hindari pengulangan jenis aksara yang sama: anda perlu campurkan "
+#~ "abjad, nombor dan tanda baca."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Cuba hindari jujukan seperti 1234 atau abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Kata laluan perlu lebih panjang. Cuba tambah lagi abjad, nombor atau "
+#~ "tanda baca."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Campurkan huruf besar dan huruf kecil dan cuba masukkan beberapa angka."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Menambah lagi abjad, angka dan tanda baca dapat mengukuhkan kata laluan."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Pengesahihan gagal"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Kata laluan baharu terlalu pendek"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Kata laluan terlalu ringkas"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Kata laluan lama dan baharu adalah hampir sama"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Kata laluan sudah digunakan baru-baru ini."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Kata laluan baharu mesti mengandungi aksara angka atau khas"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Kata laluan lama dan baharu adalah serupa"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Kata laluan anda telah berubah semenjak anda mula sahihkan!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Kata laluan baharu tidak mengandungi aksara yang mencukupi"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Ralat tidak diketahui"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Anda tidak tidak dibenarkan mencapai peranti. Sila hubungi pentadbir "
+#~ "sistem anda."
+
+#~ msgid "The device is already in use."
+#~ msgstr "Peranti sedang digunakan."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Satu ralat dalaman berlaku."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Padam cap jari berdaftar?"
+
+#~ msgid "Done!"
+#~ msgstr "Selesai!"
+
+#, c-format
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Tidak dapat mencapai peranti \"%s\""
+
+#, c-format
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Tidak dapat memulakan imbasan cap jari pada peranti \"%s\""
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Tidak dapat mencapai mana-mana pembaca cap jari"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Sila hubungi pentadbir sistem anda untuk dapatkan bantuan."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Untuk membenarkan daftar masuk cap jari, anda perlu simpan salah satu cap "
+#~ "jari anda, menggunakan peranti \"%s\"."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Memilih jari"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Nama pengguna biasanya hanya mengandungi abjad berhuruf kecil iaitu a-z, "
+#~ "digit dan aksara-aksara berikut: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Maaf, nama pengguna tidak tersedia. Sila cuba lagi."
+
+#~ msgid "The username is too long."
+#~ msgstr "Nama pengguna telalu panjang."
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Ia akan digunakan untuk menamakan folder rumah anda dan tidak boleh "
+#~ "diubah."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Butang %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Hantar Ketukan Kekunci"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Tukar Monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Tunjuk Bantuan Atas-Skrin"
+
+#~ msgid "Output:"
+#~ msgstr "Output:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Petakan ke monitor tunggal"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d daripada %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Pemetaan Paparan"
+
+#~ msgid "Stylus"
+#~ msgstr "Stilus"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (mutlak)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Keutamaan Tablet"
+
+#~ msgid "_Help"
+#~ msgstr "_Bantuan"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Tetapan Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Mod Menjejak"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Butang Peta…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Laras tetapan tetikus"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Laras resolusi paparan"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Pintasan baharu…"
+
+#~ msgid "No stylus found"
+#~ msgstr "Tiada stilus ditemui"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Sila alih stilus anda berdekatan dengan tablet untuk mengkonfigurkannya"
+
+#~ msgid "Top Button"
+#~ msgstr "Butang Atas"
+
+#~ msgid "Lower Button"
+#~ msgstr "Butang Bawah"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Butang Paling Rendah"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "Tetapan GNOME"
+
+#~ msgid "Display version number"
+#~ msgstr "Papar nombor versi"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Benarkan mod berjela"
+
+#~ msgid "Search for the string"
+#~ msgstr "Gelintar rentetan"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Senaraikan nama panel yang mungkin kemudian keluar"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel untuk dipaparkan"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMEN…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Panel tersedia:"
+
+# msgstr[1] ""
+#~ msgid "System Sounds"
+#~ msgstr "Bunyi Sistem"
 
 #~ msgid "Restrict _background data usage"
 #~ msgstr "Hadkan pengguna data _balik tabir"
@@ -8305,11 +8258,6 @@ msgstr "Bunyi Sistem"
 #~ msgid "Span"
 #~ msgstr "Jangkau"
 
-#, fuzzy
-#~| msgid "No Wallpaper"
-#~ msgid "Wallpapers"
-#~ msgstr "Tiada Kertas Dinding"
-
 #~ msgid "Colors"
 #~ msgstr "Warna"
 
@@ -8320,10 +8268,6 @@ msgstr "Bunyi Sistem"
 #~ msgstr ""
 #~ "Anda boleh tambahkan imej ke folder %s dan imej tersebut akan muncul "
 #~ "disini"
-
-#, fuzzy
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "Nama pengguna telalu panjang."
 
 #, fuzzy
 #~| msgid "Done!"
@@ -8362,11 +8306,6 @@ msgstr "Bunyi Sistem"
 #~ msgstr "Penuhkan Skrin"
 
 #, fuzzy
-#~| msgid "seconds"
-#~ msgid "Secondary"
-#~ msgstr "saat"
-
-#, fuzzy
 #~| msgid "Size:"
 #~ msgid "Size"
 #~ msgstr "Saiz"
@@ -8378,11 +8317,6 @@ msgstr "Bunyi Sistem"
 #, fuzzy
 #~ msgid "Could not get screen information"
 #~ msgstr "Tidak dapat senarai kemaskini distribusi"
-
-#, fuzzy
-#~| msgid "Action"
-#~ msgid "Section"
-#~ msgstr "Aksi"
 
 #, fuzzy
 #~| msgid "Preview:"
@@ -8402,9 +8336,6 @@ msgstr "Bunyi Sistem"
 #, fuzzy
 #~ msgid "Check for updates"
 #~ msgstr "Cari rentetan"
-
-#~ msgid "Keyboard"
-#~ msgstr "Papan Kekunci"
 
 #, fuzzy
 #~ msgid "Shortcut;Repeat;Blink;"
@@ -8442,11 +8373,6 @@ msgstr "Bunyi Sistem"
 
 #~ msgid "S_peed:"
 #~ msgstr "Ke_lajuan:"
-
-#, fuzzy
-#~| msgid "Shortcut"
-#~ msgid "Add Shortcut"
-#~ msgstr "Pintasan Penyesuaian"
 
 #, fuzzy
 #~ msgid ""
@@ -8523,10 +8449,6 @@ msgstr "Bunyi Sistem"
 #~ msgstr "Laju"
 
 #, fuzzy
-#~ msgid "Disable while _typing"
-#~ msgstr "Memboleh atau melumpuhkan log masuk dari jauh"
-
-#, fuzzy
 #~| msgid "page"
 #~ msgid "page 1"
 #~ msgstr "laman"
@@ -8595,10 +8517,6 @@ msgstr "Bunyi Sistem"
 #~ msgstr "XDMCP: Tidak dapat menghurai alamat"
 
 #, fuzzy
-#~ msgid "Not connected"
-#~ msgstr "Katalaluan tidak padan."
-
-#, fuzzy
 #~| msgid "Ignored Hosts"
 #~ msgid "Ignore"
 #~ msgstr "Abaikan kemaskini ini"
@@ -8606,11 +8524,6 @@ msgstr "Bunyi Sistem"
 #, fuzzy
 #~ msgid "Choose CA Certificate"
 #~ msgstr "Pilih katalaluan yang lain."
-
-#, fuzzy
-#~| msgid "None"
-#~ msgid "No"
-#~ msgstr "Tiada Tindakan"
 
 #, fuzzy
 #~ msgctxt "notifications"
@@ -8651,10 +8564,6 @@ msgstr "Bunyi Sistem"
 #~ msgstr "Cipta satu akaun pengguna"
 
 #, fuzzy
-#~ msgid "Power off"
-#~ msgstr "Pengurusan kuasa"
-
-#, fuzzy
 #~| msgid "Install"
 #~ msgctxt "printer state"
 #~ msgid "Installing"
@@ -8687,17 +8596,8 @@ msgstr "Bunyi Sistem"
 #~ msgstr "_Tajuk:"
 
 #, fuzzy
-#~| msgid "_Timeout:"
-#~ msgid "Time"
-#~ msgstr "Masa berbaki: %s"
-
-#, fuzzy
 #~ msgid "Show _Jobs"
 #~ msgstr "Tunjuk katalaluan"
-
-#, fuzzy
-#~ msgid "Setting new driver…"
-#~ msgstr "- Login GDM baharu"
 
 #, fuzzy
 #~| msgid "page"
@@ -8724,19 +8624,9 @@ msgstr "Bunyi Sistem"
 #~ msgid "Switch to next source"
 #~ msgstr "Tukar ke sumber seterusnya"
 
-#~ msgid "Options"
-#~ msgstr "Pilihan"
-
 #~ msgctxt "Search Location"
 #~ msgid "Other"
 #~ msgstr "Lain-lain"
-
-#~ msgid "Preferences"
-#~ msgstr "Keutamaan"
-
-#, fuzzy
-#~ msgid "Allow Remote Control"
-#~ msgstr "Memboleh atau melumpuhkan log masuk dari jauh"
 
 #~ msgid "Password:"
 #~ msgstr "Katalaluan:"
@@ -8906,12 +8796,6 @@ msgstr "Bunyi Sistem"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Skrol ke atas"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Skrol Ke Bawah"
-
-#~ msgid "Scroll Left"
-#~ msgstr "Skrol Ke Kiri"
 
 #~ msgid "Show the overview"
 #~ msgstr "Tunjuk gambaran keseluruhan"
@@ -9196,10 +9080,6 @@ msgstr "Bunyi Sistem"
 #~ msgid "The current theme suggests a font."
 #~ msgstr "Tema ini mencadangkanfont:"
 
-#, fuzzy
-#~ msgid "Appearance Preferences"
-#~ msgstr "Keutamaan Tema"
-
 #~ msgid "Best _shapes"
 #~ msgstr "_Bentuk terbaik"
 
@@ -9209,9 +9089,6 @@ msgstr "Bunyi Sistem"
 #, fuzzy
 #~ msgid "C_ustomize..."
 #~ msgstr "Tersendiri"
-
-#~ msgid "Controls"
-#~ msgstr "Kawalan"
 
 #, fuzzy
 #~ msgid "Customize Theme"
@@ -9321,18 +9198,11 @@ msgstr "Bunyi Sistem"
 #~ msgstr "_RGB"
 
 #, fuzzy
-#~ msgid "_Reset to Defaults"
-#~ msgstr "Ulangtetap ke de_fault"
-
-#, fuzzy
 #~ msgid "_Selected items:"
 #~ msgstr "_Susunatur dipilih:"
 
 #~ msgid "_Size:"
 #~ msgstr "_Saiz:"
-
-#~ msgid "_Style:"
-#~ msgstr "_Gaya:"
 
 #~ msgid "_VRGB"
 #~ msgstr "_VRGB"
@@ -9445,9 +9315,6 @@ msgstr "Bunyi Sistem"
 
 #~ msgid "Copying '%s'"
 #~ msgstr "Penyalinan '%s'"
-
-#~ msgid "Parent Window"
-#~ msgstr "Tetingkap Utama"
 
 #~ msgid "From URI"
 #~ msgstr "Dari URI"
@@ -9588,9 +9455,6 @@ msgstr "Bunyi Sistem"
 
 #~ msgid "Visual Assistance"
 #~ msgstr "Pembantu Visual"
-
-#~ msgid "Accessibility"
-#~ msgstr "Kebolehcapaikan"
 
 #~ msgid "Co_mmand:"
 #~ msgstr "_Arahan:"
@@ -9770,10 +9634,6 @@ msgstr "Bunyi Sistem"
 #~ msgid "Upside-down"
 #~ msgstr "Terbalik"
 
-#, fuzzy
-#~ msgid "Monitors"
-#~ msgstr "Kawalan"
-
 #~ msgid "Upside Down"
 #~ msgstr "Upside Down"
 
@@ -9786,9 +9646,6 @@ msgstr "Bunyi Sistem"
 #, fuzzy
 #~ msgid "Could not set the default configuration for monitors"
 #~ msgstr "Pilih aplikasi default anda"
-
-#~ msgid "Desktop"
-#~ msgstr "Desktop"
 
 #~ msgid "Accelerator key"
 #~ msgstr "Kekunci pemecut"
@@ -9878,9 +9735,6 @@ msgstr "Bunyi Sistem"
 #~ msgid "Reset to De_faults"
 #~ msgstr "Ulangtetap ke de_fault"
 
-#~ msgid "_Acceleration:"
-#~ msgstr "_Pemecutan:"
-
 #~ msgid "_Break interval lasts:"
 #~ msgstr "_Selangmasa rehat bertahan"
 
@@ -9915,9 +9769,6 @@ msgstr "Bunyi Sistem"
 
 #~ msgid "Keyboard Layout Options"
 #~ msgstr "Susunan Opsyen Papan Kekunci"
-
-#~ msgid "Layout"
-#~ msgstr "Susunatur"
 
 #~ msgid "Set your keyboard preferences"
 #~ msgstr "Tetapkan keutamaan papan kekunci"
@@ -10027,9 +9878,6 @@ msgstr "Bunyi Sistem"
 #, fuzzy
 #~ msgid "Set your window properties"
 #~ msgstr "Ciri-ciri Tetingkap"
-
-#~ msgid "Windows"
-#~ msgstr "Tetingkap"
 
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr "Pengurus tetingkap \"%s\" tak mendaftarkan radas konfigurasi\n"
@@ -10150,9 +9998,6 @@ msgstr "Bunyi Sistem"
 
 #~ msgid "Open with \"%s\""
 #~ msgstr "Buka dengan \"%s\""
-
-#~ msgid "Open with Default Application"
-#~ msgstr "Buka dengan aplikasi default anda"
 
 #~ msgid "Open in File Manager"
 #~ msgstr "Bukan dalam Pengurus Fail"
@@ -10517,9 +10362,9 @@ msgstr "Bunyi Sistem"
 #~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
 #~ "installed the \"gnome-themes\" package."
 #~ msgstr ""
-#~ "Tiada tema dijumpai pada sistem anda. Ini bermakna dialog \"Keutamaan Tema"
-#~ "\"  anda tak dipasang dengan betul. atau anda tak memasang pakej \"gnome-"
-#~ "themes\""
+#~ "Tiada tema dijumpai pada sistem anda. Ini bermakna dialog \"Keutamaan "
+#~ "Tema\"  anda tak dipasang dengan betul. atau anda tak memasang pakej "
+#~ "\"gnome-themes\""
 
 #, fuzzy
 #~ msgid "The file format is invalid"
@@ -10556,9 +10401,6 @@ msgstr "Bunyi Sistem"
 
 #~ msgid "Short _description:"
 #~ msgstr "_Huraian pendek:"
-
-#~ msgid "Theme _Details"
-#~ msgstr "_Perincian Tema"
 
 #~ msgid "This theme does not suggest any particular font or background."
 #~ msgstr "Tema ini mencadangkan font dan latarbelakang."
@@ -10602,9 +10444,6 @@ msgstr "Bunyi Sistem"
 
 #~ msgid "_Detachable toolbars"
 #~ msgstr "Toolbar boleh _lerai"
-
-#~ msgid "_Edit"
-#~ msgstr "_Edit"
 
 #~ msgid "_File"
 #~ msgstr "_Fail"
@@ -10764,9 +10603,6 @@ msgstr "Bunyi Sistem"
 #~ msgid "The file %s is not a valid wav file"
 #~ msgstr "Fail %s adalah fail wav yang tidak sah"
 
-#~ msgid "Event"
-#~ msgstr "Acara"
-
 #~ msgid "Sound _file:"
 #~ msgstr "_Fail bunyi:"
 
@@ -10863,10 +10699,6 @@ msgstr "Bunyi Sistem"
 #, fuzzy
 #~ msgid "Keyboard Update Handlers"
 #~ msgstr "_Model papan kekunci:"
-
-#, fuzzy
-#~ msgid "Keyboard layout"
-#~ msgstr "Susunatur papan kekunci XKB"
 
 #, fuzzy
 #~ msgid "Keyboard model"

--- a/po/ms.po~
+++ b/po/ms.po~
@@ -1,0 +1,10955 @@
+# Gnome-control-center v2.0 Bahasa Melayu (ms)
+# 1. Hasbullah Bin Pit (sebol) <sebol@ikhlas.com>, 2002
+# 2. Khairulanuar Abd Majid (khai) <khairul@ikhlas.com>, 2002
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center HEAD\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2020-01-16 12:38+0000\n"
+"PO-Revision-Date: 2020-01-26 09:16+0800\n"
+"Last-Translator: abuyop <abuyop@gmail.com>\n"
+"Language-Team: Pasukan Terjemahan GNOME Malaysia\n"
+"Language: ms\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.6\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+# msgstr[1] ""
+#: panels/applications/cc-applications-panel.c:708
+msgid "System Bus"
+msgstr "Bas Sistem"
+
+#: panels/applications/cc-applications-panel.c:708
+#: panels/applications/cc-applications-panel.c:710
+#: panels/applications/cc-applications-panel.c:723
+#: panels/applications/cc-applications-panel.c:728
+msgid "Full access"
+msgstr "Capaian penuh"
+
+#: panels/applications/cc-applications-panel.c:710
+msgid "Session Bus"
+msgstr "Bas Sesi"
+
+#: panels/applications/cc-applications-panel.c:714
+#: panels/power/cc-power-panel.c:2469 panels/thunderbolt/cc-bolt-panel.ui:466
+#: panels/thunderbolt/cc-bolt-panel.ui:525
+msgid "Devices"
+msgstr "Peranti-Peranti"
+
+#: panels/applications/cc-applications-panel.c:714
+msgid "Full access to /dev"
+msgstr "Capaian penuh ke /dev"
+
+#: panels/applications/cc-applications-panel.c:718
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:252
+msgid "Network"
+msgstr "Rangkaian"
+
+#: panels/applications/cc-applications-panel.c:718
+#: panels/applications/cc-snap-row.c:109
+msgid "Has network access"
+msgstr "Mempunyai capaian rangkaian"
+
+#: panels/applications/cc-applications-panel.c:723
+#: panels/applications/cc-applications-panel.c:725
+#: panels/search/cc-search-locations-dialog.c:361
+msgid "Home"
+msgstr "Rumah"
+
+#: panels/applications/cc-applications-panel.c:725
+#: panels/applications/cc-applications-panel.c:730
+msgid "Read-only"
+msgstr "Baca-sahaja"
+
+#: panels/applications/cc-applications-panel.c:728
+#: panels/applications/cc-applications-panel.c:730
+msgid "File System"
+msgstr "Sistem Fail"
+
+#: panels/applications/cc-applications-panel.c:734
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:281
+#: shell/cc-window.c:964 shell/cc-window.ui:125
+#: shell/gnome-control-center.desktop.in.in:3
+msgid "Settings"
+msgstr "Tetapan"
+
+#: panels/applications/cc-applications-panel.c:734
+#: panels/applications/cc-snap-row.c:73
+msgid "Can change settings"
+msgstr "Boleh mengubah tetapan"
+
+#: panels/applications/cc-applications-panel.c:736
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s mempunyai keizinan terbina-dalam berikut. Ia tidak dapat diubah. Jika "
+"anda ambil kisah berkenaan keizinan ini, buang aplikasi ini."
+
+#: panels/applications/cc-applications-panel.c:891
+msgid "Web Links"
+msgstr "Pautan Sesawang"
+
+#: panels/applications/cc-applications-panel.c:901
+msgid "Git Links"
+msgstr "Pautan Git"
+
+#: panels/applications/cc-applications-panel.c:907
+#, c-format
+msgid "%s Links"
+msgstr "Pautan %s"
+
+#: panels/applications/cc-applications-panel.c:915
+#: panels/applications/cc-applications-panel.c:951
+msgid "Unset"
+msgstr "Nyahtetap"
+
+#: panels/applications/cc-applications-panel.c:1006
+msgid "Links"
+msgstr "Pautan"
+
+#: panels/applications/cc-applications-panel.c:1014
+msgid "Hypertext Files"
+msgstr "Fail Hiperteks"
+
+#: panels/applications/cc-applications-panel.c:1028
+msgid "Text Files"
+msgstr "Fail Teks"
+
+#: panels/applications/cc-applications-panel.c:1042
+msgid "Image Files"
+msgstr "Fail Imej"
+
+#: panels/applications/cc-applications-panel.c:1058
+msgid "Font Files"
+msgstr "Fail Fon"
+
+#: panels/applications/cc-applications-panel.c:1119
+msgid "Archive Files"
+msgstr "Fail Arkib"
+
+#: panels/applications/cc-applications-panel.c:1139
+msgid "Package Files"
+msgstr "Fail Pakej"
+
+#: panels/applications/cc-applications-panel.c:1162
+msgid "Audio Files"
+msgstr "Fail Audio"
+
+#: panels/applications/cc-applications-panel.c:1179
+msgid "Video Files"
+msgstr "Fail Video"
+
+#: panels/applications/cc-applications-panel.c:1187
+msgid "Other Files"
+msgstr "Lain-lain Fail"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1529
+#: panels/applications/cc-applications-panel.ui:412
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:167
+msgid "Applications"
+msgstr "Aplikasi"
+
+#: panels/applications/cc-applications-panel.ui:45
+msgid "No applications"
+msgstr "Tiada aplikasi"
+
+#: panels/applications/cc-applications-panel.ui:59
+msgid "Install some…"
+msgstr "Pasang lagi…"
+
+#: panels/applications/cc-applications-panel.ui:99
+msgid "Permissions & Access"
+msgstr "Keizinan & Capaian"
+
+#: panels/applications/cc-applications-panel.ui:111
+msgid ""
+"Data and services that this app has asked for access to and permissions that "
+"it requires."
+msgstr ""
+"Data dan perkhidmatan yang dipinta oleh aplikasi ini untuk capaian dan "
+"keizinan yang diperlukannya."
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/applications/cc-applications-panel.ui:132
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:133
+#: panels/applications/cc-applications-panel.ui:145
+#: panels/applications/cc-applications-panel.ui:157
+#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:261
+#: panels/keyboard/cc-keyboard-option.c:259
+#: panels/keyboard/cc-keyboard-option.c:378
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:96
+#: panels/keyboard/keyboard-shortcuts.c:425 panels/network/network-proxy.ui:126
+#: panels/user-accounts/um-fingerprint-dialog.c:211
+#: subprojects/gvc/gvc-mixer-control.c:1876
+msgid "Disabled"
+msgstr "Dilumpuhkan"
+
+#: panels/applications/cc-applications-panel.ui:138
+#: panels/applications/cc-applications-panel.ui:144
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:150
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Perkhidmatan Lokasi"
+
+#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:495
+msgid "Built-in Permissions"
+msgstr "Keizinan Terbina-dalam"
+
+#: panels/applications/cc-applications-panel.ui:163
+msgid "Cannot be changed"
+msgstr "Tidak dapat diubah"
+
+#: panels/applications/cc-applications-panel.ui:180
+msgid ""
+"Individual permissions for applications can be reviewed in the <a href="
+"\"privacy\">Privacy</a> Settings."
+msgstr ""
+"Keizinan individu untuk aplikasi boleh ditinjau dalam Tetapan <a href="
+"\"privacy\">Kerahsiaan</a>."
+
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Integration"
+msgstr "Penyepaduan"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System features used by this application."
+msgstr "Fitur-fitur sistem yang digunakan oleh aplikasi ini."
+
+#: panels/applications/cc-applications-panel.ui:230
+#: panels/applications/cc-applications-panel.ui:236
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:155
+msgid "Search"
+msgstr "Gelintar"
+
+#: panels/applications/cc-applications-panel.ui:242
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Pemberitahuan"
+
+#: panels/applications/cc-applications-panel.ui:248
+msgid "Run in background"
+msgstr "Jalan di balik tabir"
+
+#: panels/applications/cc-applications-panel.ui:254
+#: panels/applications/cc-applications-panel.ui:260
+msgid "Sounds"
+msgstr "Bunyi"
+
+#: panels/applications/cc-applications-panel.ui:293
+msgid "Default Handlers"
+msgstr "Pengendali Lalai"
+
+#: panels/applications/cc-applications-panel.ui:305
+msgid "Types of files and links that this application opens."
+msgstr "Jenis fail dan pautan yang dibuka oleh aplikasi ini."
+
+#: panels/applications/cc-applications-panel.ui:321
+msgid "Reset"
+msgstr "Tetap Semula"
+
+#: panels/applications/cc-applications-panel.ui:357
+msgid "Usage"
+msgstr "Penggunaan"
+
+#: panels/applications/cc-applications-panel.ui:369
+msgid "How much resources this application is using."
+msgstr "Berapa banyak sumber-sumber dalam aplikasi ini gunakan."
+
+#: panels/applications/cc-applications-panel.ui:384
+#: panels/applications/cc-applications-panel.ui:531
+msgid "Storage"
+msgstr "Storan"
+
+#: panels/applications/cc-applications-panel.ui:419
+msgid "Open in Software"
+msgstr "Buka dalam Perisian"
+
+#: panels/applications/cc-applications-panel.ui:469 shell/cc-panel-list.ui:121
+msgid "No results found"
+msgstr "Tiad keputusan ditemui"
+
+#: panels/applications/cc-applications-panel.ui:480
+#: panels/keyboard/cc-keyboard-panel.ui:188 shell/cc-panel-list.ui:132
+msgid "Try a different search"
+msgstr "Cuba gelintar yang lain"
+
+#: panels/applications/cc-applications-panel.ui:548
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Berapa banyak ruang cakera yang diperlukan oleh aplikasi ini untuk mengisi "
+"data dan cache apl."
+
+#: panels/applications/cc-applications-panel.ui:557
+msgid "Application"
+msgstr "Aplikasi"
+
+#: panels/applications/cc-applications-panel.ui:563
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:569
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:575
+msgid "<b>Total</b>"
+msgstr "<b>Jumlah</b>"
+
+#: panels/applications/cc-applications-panel.ui:592
+msgid "Clear Cache…"
+msgstr "Kosongkan Cache…"
+
+#: panels/applications/cc-snap-row.c:55
+msgid "Add user accounts and change passwords"
+msgstr "Tambah akaun pengguna dan ubah kata laluan"
+
+#: panels/applications/cc-snap-row.c:57 panels/applications/cc-snap-row.c:133
+msgid "Play and record sound"
+msgstr "Main dan rakam bunyi"
+
+#: panels/applications/cc-snap-row.c:59
+msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+msgstr "Kesan peranti rangkaian menggunakan mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#: panels/applications/cc-snap-row.c:61
+msgid "Access bluetooth hardware directly"
+msgstr "Capai perkakasan bluetooth secara terus"
+
+#: panels/applications/cc-snap-row.c:63
+msgid "Use bluetooth devices"
+msgstr "Guna peranti bluetooth"
+
+#: panels/applications/cc-snap-row.c:65
+msgid "Use your camera"
+msgstr "Guna kamera anda"
+
+#: panels/applications/cc-snap-row.c:67
+msgid "Print documents"
+msgstr "Cetak dokumen"
+
+#: panels/applications/cc-snap-row.c:69
+msgid "Use any connected joystick"
+msgstr "Guna mana-mana kayu ria bersambung"
+
+#: panels/applications/cc-snap-row.c:71
+msgid "Allow connecting to the Docker service"
+msgstr "Benarkan bersambung dengan perkhidmatan Docker"
+
+#: panels/applications/cc-snap-row.c:75
+msgid "Configure network firewall"
+msgstr "Konfigur dinding api rangkaian"
+
+#: panels/applications/cc-snap-row.c:77
+msgid "Setup and use privileged FUSE filesystems"
+msgstr "Pasang dan guna sistem fail FUSE yang layak"
+
+#: panels/applications/cc-snap-row.c:79
+msgid "Update firmware on this device"
+msgstr "Kemas kini perisian tegar dalam peranti ini"
+
+#: panels/applications/cc-snap-row.c:81
+msgid "Access hardware information"
+msgstr "Capai maklumat perkakasan"
+
+#: panels/applications/cc-snap-row.c:83
+msgid "Provide entropy to hardware random number generator"
+msgstr "Menyediakan entropi untuk penjana nombor rawak perkakasan"
+
+#: panels/applications/cc-snap-row.c:85
+msgid "Use hardware-generated random numbers"
+msgstr "Guna nombor rawak terjana-perkakasan"
+
+#: panels/applications/cc-snap-row.c:87
+msgid "Access files in your home folder"
+msgstr "Capai fail dalam folder rumah anda"
+
+#: panels/applications/cc-snap-row.c:89
+msgid "Access libvirt service"
+msgstr "Capai perkhidmatan libvirt"
+
+#: panels/applications/cc-snap-row.c:91
+msgid "Change system language and region settings"
+msgstr "Ubah tetapan bahasa dan wilayah sistem"
+
+#: panels/applications/cc-snap-row.c:93
+msgid "Change location settings and providers"
+msgstr "Ubah tetapan dan penyedia lokasi"
+
+#: panels/applications/cc-snap-row.c:95
+msgid "Access your location"
+msgstr "Capai lokasi anda"
+
+#: panels/applications/cc-snap-row.c:97
+msgid "Read system and application logs"
+msgstr "Baca sistem dan log aplikasi"
+
+#: panels/applications/cc-snap-row.c:99
+msgid "Access LXD service"
+msgstr "Capai perkhidmatan LXD"
+
+#: panels/applications/cc-snap-row.c:101
+msgid "access the media-hub service"
+msgstr "capai perkhidmatan media-hub"
+
+#: panels/applications/cc-snap-row.c:103
+msgid "Use and configure modems"
+msgstr "Guna dan konfigur modem"
+
+#: panels/applications/cc-snap-row.c:105
+msgid "Read system mount information and disk quotas"
+msgstr "Baca maklumat lekap sistem dan kuota cakera"
+
+#: panels/applications/cc-snap-row.c:107
+msgid "Control music and video players"
+msgstr "Kawal pemain muzik dan video"
+
+#: panels/applications/cc-snap-row.c:111
+msgid "Change low-level network settings"
+msgstr "Ubah tetapan rangkaian aras-rendah"
+
+#: panels/applications/cc-snap-row.c:113
+msgid "Access the NetworkManager service to read and change network settings"
+msgstr ""
+"Capai perkhidmatan Pengurus Rangkaian untuk baca dan ubah tetapan rangkaian"
+
+#: panels/applications/cc-snap-row.c:115
+msgid "Read access to network settings"
+msgstr "Baca capaian ke tetapan rangkaian"
+
+#: panels/applications/cc-snap-row.c:117
+msgid "Change network settings"
+msgstr "Ubah tetapan rangkaian"
+
+#: panels/applications/cc-snap-row.c:119
+msgid "Read network settings"
+msgstr "Baca tetapan rangkaian"
+
+#: panels/applications/cc-snap-row.c:121
+msgid ""
+"Access the ofono service to read and change network settings for mobile "
+"telephony"
+msgstr ""
+"Capai perkhidmatan ofono untuk baca dan ubah tetapan rangkaian telefoni "
+"mudah alih"
+
+#: panels/applications/cc-snap-row.c:123
+msgid "Control Open vSwitch hardware"
+msgstr "Kawal perkakasan Open vSwitch"
+
+#: panels/applications/cc-snap-row.c:125
+msgid "Read from CD/DVD"
+msgstr "Baca dari CD/DVD"
+
+#: panels/applications/cc-snap-row.c:127
+msgid "Read, add, change, or remove saved passwords"
+msgstr "Baca, tambah, ubah, atau buang kata laluan tersimpan"
+
+#: panels/applications/cc-snap-row.c:129
+msgid ""
+"Access pppd and ppp devices for configuring Point-to-Point Protocol "
+"connections"
+msgstr ""
+"Capai peranti pppd dan ppp untuk mengkonfigur sambungan Protokol Titik-ke-"
+"Titik"
+
+#: panels/applications/cc-snap-row.c:131
+msgid "Pause or end any process on the system"
+msgstr "Jeda atau tamatkan apa-apa proses dalam sistem"
+
+#: panels/applications/cc-snap-row.c:135
+msgid "Access USB hardware directly"
+msgstr "Capai perkakasan USB secara terus"
+
+#: panels/applications/cc-snap-row.c:137
+msgid "Read/write files on removable storage devices"
+msgstr "Baca/tulis fail dalam peranti storan mudah alih"
+
+#: panels/applications/cc-snap-row.c:139
+msgid "Prevent screen sleep/lock"
+msgstr "Halang skrin dari tidur/terkunci"
+
+#: panels/applications/cc-snap-row.c:141
+msgid "Access serial port hardware"
+msgstr "Capai perkakasan port serial"
+
+#: panels/applications/cc-snap-row.c:143
+msgid "Restart or power off the device"
+msgstr "Mula semula atau matikan peranti"
+
+#: panels/applications/cc-snap-row.c:145
+msgid "Install, remove and configure software"
+msgstr "Pasang, buang dan konfigur perisian"
+
+#: panels/applications/cc-snap-row.c:147
+msgid "Access Storage Framework service"
+msgstr "Capai perkhidmatan Bingkai Kerja Storan"
+
+#: panels/applications/cc-snap-row.c:149
+msgid "Read process and system information"
+msgstr "Baca proses dan maklumat sistem"
+
+#: panels/applications/cc-snap-row.c:151
+msgid "Monitor and control any running program"
+msgstr "Pantau dan kawal apa-apa program yang berjalan"
+
+#: panels/applications/cc-snap-row.c:153
+msgid "Change the date and time"
+msgstr "Ubah tarikh dan waktu"
+
+#: panels/applications/cc-snap-row.c:155
+msgid "Change time server settings"
+msgstr "Ubah tetapan pelayan waktu"
+
+#: panels/applications/cc-snap-row.c:157
+msgid "Change the time zone"
+msgstr "Ubah zon waktu"
+
+#: panels/applications/cc-snap-row.c:159
+msgid "Access the UDisks2 service for configuring disks and removable media"
+msgstr ""
+"Capai perkhidmatan UDisks2 untuk mengkonfigur cakera dan media mudah alih"
+
+#: panels/applications/cc-snap-row.c:161
+msgid "Read/change shared calendar events in Ubuntu Unity 8"
+msgstr "Baca/ubah peristiwa kalendar terkongsi dalam Unity 8 Ubuntu"
+
+#: panels/applications/cc-snap-row.c:163
+msgid "Read/change shared contacts in Ubuntu Unity 8"
+msgstr "Baca/ubah hubungan terkongsi dalam Unity 8 Ubuntu"
+
+#: panels/applications/cc-snap-row.c:165
+msgid "Access energy usage data"
+msgstr "Capai data penggunaan tenaga"
+
+#: panels/applications/cc-snap-row.c:167
+msgid "Read/write access to U2F devices exposed"
+msgstr "Baca/tulis capaian ke peranti U2F terdedah"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Kawal pelbagai keizinan dan tetapan aplikasi"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplikasi;flatpak;keizinan;tetapan;"
+
+#: panels/background/cc-background-chooser.c:349
+msgid "Select a picture"
+msgstr "Pilih satu gambar"
+
+#: panels/background/cc-background-chooser.c:352
+#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:241
+#: panels/color/cc-color-panel.c:894 panels/color/cc-color-panel.ui:657
+#: panels/common/cc-language-chooser.ui:24
+#: panels/display/cc-display-panel.c:950
+#: panels/info-overview/cc-info-overview-panel.ui:235
+#: panels/network/cc-wifi-hotspot-dialog.ui:122
+#: panels/network/connection-editor/connection-editor.ui:17
+#: panels/network/connection-editor/vpn-helpers.c:176
+#: panels/network/connection-editor/vpn-helpers.c:299
+#: panels/network/net-device-wifi.c:800 panels/network/net-device-wifi.c:908
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:252
+#: panels/region/cc-format-chooser.ui:28 panels/region/cc-input-chooser.ui:11
+#: panels/search/cc-search-locations-dialog.c:638
+#: panels/sharing/cc-sharing-panel.c:428 panels/usage/cc-usage-panel.c:134
+#: panels/user-accounts/cc-add-user-dialog.ui:28
+#: panels/user-accounts/cc-avatar-chooser.c:107
+#: panels/user-accounts/cc-avatar-chooser.c:235
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:635
+#: panels/user-accounts/cc-user-panel.c:653
+#: panels/user-accounts/data/join-dialog.ui:20
+#: panels/user-accounts/um-fingerprint-dialog.c:261
+msgid "_Cancel"
+msgstr "Ba_tal"
+
+#: panels/background/cc-background-chooser.c:353
+#: panels/network/connection-editor/vpn-helpers.c:177
+#: panels/printers/pp-details-dialog.c:253
+#: panels/sharing/cc-sharing-panel.c:429
+#: panels/user-accounts/cc-avatar-chooser.c:236
+msgid "_Open"
+msgstr "_Buka"
+
+#: panels/background/cc-background-chooser.ui:104
+msgid "Set Background and Lock Screen"
+msgstr "Tetapkan Latar Belakang dan Skrin Kunci"
+
+#: panels/background/cc-background-chooser.ui:114
+msgid "Set Background"
+msgstr "Tetapkan Latar Belakang"
+
+#: panels/background/cc-background-chooser.ui:121
+msgid "Set Lock Screen"
+msgstr "Tetapkan Kunci skrin"
+
+#: panels/background/cc-background-chooser.ui:143
+msgid "Remove Background"
+msgstr "Buang Latar Belakang"
+
+#: panels/background/cc-background-item.c:140
+msgid "multiple sizes"
+msgstr "saiz berbilang"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:144
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:278
+msgid "No Desktop Background"
+msgstr "Tiada Latar Belakang Atas Meja"
+
+#: panels/background/cc-background-panel.c:145
+msgid "Current background"
+msgstr "Latar belakang semasa"
+
+#: panels/background/cc-background-panel.ui:63
+msgid "Add Picture…"
+msgstr "Tambah Gambar…"
+
+#: panels/background/cc-background-preview.ui:55
+msgid "Activities"
+msgstr "Aktiviti-Aktiviti"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "Latar Belakang"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Ubah imej latar belakang anda dengan kertas dinding atau foto"
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Kertas Dinding;Skrin;Atas Meja;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "No Bluetooth Found"
+msgstr "Tiada Bluetooth Ditemui"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Palamkan dongle untuk menggunakan Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:69
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth Dimatikan"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:80
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Hidupkan untuk sambungkan peranti dan terima pemindahan fail."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:107
+msgid "Airplane Mode is on"
+msgstr "Mod Kapat Terbang hidup"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:118
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth dilumpuhkan ketika mod kapal terbang hidup."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:124
+msgid "Turn Off Airplane Mode"
+msgstr "Matikan Mod Kapal Terbang"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:154
+msgid "Hardware Airplane Mode is on"
+msgstr "Mod Kapal Terbang Perkakasan hidup"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:165
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Matikan mod Kapal Terbang untuk benarkan Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1714
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Hidupkan Bluetooth dan matikan, kemudian sambung peranti anda"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "kongsi;perkongsian;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:34
+msgid "Camera is turned off"
+msgstr "Kamera dimatikan"
+
+#: panels/camera/cc-camera-panel.ui:43
+msgid "No applications can capture photos or video."
+msgstr "Tiada aplikasi boleh menangkap foto atau video."
+
+#: panels/camera/cc-camera-panel.ui:77
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly."
+msgstr ""
+"Penggunaan kamera membolehkan aplikasi-aplikasi menangkap foto-foto dan "
+"video. Melumpuhkan kamera boleh menyebabkan sesetengah aplikasi tidak "
+"berfungsi dengan baik."
+
+#: panels/camera/cc-camera-panel.ui:87
+msgid "Allow the applications below to use your camera."
+msgstr "Benarkan aplikasi di bawah menggunakan kamera anda."
+
+#: panels/camera/cc-camera-panel.ui:107
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Tiada Aplikasi Menanya untuk Capaian Kamera"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Lindungi gambar anda"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"skrin;kunci;diagnostik;kerosakan;persendirian;baru-baru ini;sementara;tmp;"
+"indeks;nama;rangkaian;identiti;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:348
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Letak peranti penentukuran anda atas petak dan tekan 'Mula'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:354
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Alih peranti penentukuran anda pada kedudukan tentukur dan tekan 'Teruskan'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:360
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Alih peranti penentukuran anda atas kedudukan permukaan dan tekan 'Teruskan'"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:366
+msgid "Shut the laptop lid"
+msgstr "Tutup penutup komputer riba"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:397
+msgid "An internal error occurred that could not be recovered."
+msgstr "Satu ralat dalaman berlaku yang tidak dapat dipulihkan."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:402
+msgid "Tools required for calibration are not installed."
+msgstr "Alatan diperlukan untuk penentukuran tidak dipasang."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:408
+msgid "The profile could not be generated."
+msgstr "Profil tidak dapat dijana."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:414
+msgid "The target whitepoint was not obtainable."
+msgstr "Titik putih sasaran tidak boleh diperolehi."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:453
+msgid "Complete!"
+msgstr "Selesai!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:461
+msgid "Calibration failed!"
+msgstr "Penentukuran gagal!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:468
+msgid "You can remove the calibration device."
+msgstr "Anda boleh buang peranti penentukuran."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:537
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Jangan ganggu peranti semasa penentukuran berlansung"
+
+#: panels/color/cc-color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr "Tentukur Paparan"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:40
+msgid "_Start"
+msgstr "_Mula"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:54
+msgid "_Resume"
+msgstr "_Sambung Semula"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
+msgid "_Done"
+msgstr "_Selesai"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Skrin Komputer Riba"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Kamera Sesawang terbina-dalam"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Pengimbas %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Kamera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Pencetak %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Kamera Sesawang %s"
+
+#: panels/color/cc-color-device.c:91
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Benarkan pengurusan warna untuk %s"
+
+#: panels/color/cc-color-device.c:94
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Tunjuk profil warna untuk %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:303
+msgid "Not calibrated"
+msgstr "Tidak ditentukur"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:170
+msgid "Default: "
+msgstr "Lalai: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:178
+msgid "Colorspace: "
+msgstr "Ruang warna: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:185
+msgid "Test profile: "
+msgstr "Profil ujian: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:239
+msgid "Select ICC Profile File"
+msgstr "Pilih Fail Profil ICC"
+
+#: panels/color/cc-color-panel.c:242
+msgid "_Import"
+msgstr "_Import"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:253
+msgid "Supported ICC profiles"
+msgstr "Profil ICC Tersokong"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:260
+#: panels/network/wireless-security/eap-method-fast.c:309
+msgid "All files"
+msgstr "Semua fail"
+
+#: panels/color/cc-color-panel.c:555
+msgid "Screen"
+msgstr "Skrin"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:847
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Gagal memuat naik fail: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:859
+msgid "The profile has been uploaded to:"
+msgstr "Profail telah dimuat naik ke:"
+
+#: panels/color/cc-color-panel.c:861
+msgid "Write down this URL."
+msgstr "Catatkan URL ini."
+
+#: panels/color/cc-color-panel.c:862
+msgid "Restart this computer and boot your normal operating system."
+msgstr "Mulakan semula komputer dan but sistem pengoperasian biasa anda."
+
+#: panels/color/cc-color-panel.c:863
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "Taip URL pada pelayar anda untuk memuat turun dan memasang profil."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:891
+msgid "Save Profile"
+msgstr "Simpan Profil"
+
+#: panels/color/cc-color-panel.c:895
+#: panels/network/connection-editor/vpn-helpers.c:300
+msgid "_Save"
+msgstr "_Simpan"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1209
+msgid "Create a color profile for the selected device"
+msgstr "Cipta satu profil warna untuk peranti terpilih"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1224 panels/color/cc-color-panel.c:1248
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Alat pengukuran tidak dikesan. Periksa sama ada ia telah dihidupkan dan "
+"bersambung dengan baik."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1258
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Alat pengukur tidak menyokong pemprofilan pencetak."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1269
+msgid "The device type is not currently supported."
+msgstr "Jenis peranti ini tidak disokong buat masa ini."
+
+#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+msgid "Screen Calibration"
+msgstr "Penentukuran Skrin"
+
+#: panels/color/cc-color-panel.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Penentukuran akan menghasilkan satu profil untuk pengurusan warna skrin "
+"anda. Lebih lama penentukuran dijalankan, lebih baik kualiti profil warna "
+"yang dihasilkan."
+
+#: panels/color/cc-color-panel.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Anda tidak dapat menggunakan komputer ketika penentukuran berlangsung."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:58
+msgid "Quality"
+msgstr "Kualiti"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:75
+msgid "Approximate Time"
+msgstr "Masa Anggaran"
+
+#: panels/color/cc-color-panel.ui:121
+msgid "Calibration Quality"
+msgstr "Kualiti Penentukuran"
+
+#: panels/color/cc-color-panel.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Pilih peranti pengesan yang anda hendak guna untuk penentukuran."
+
+#: panels/color/cc-color-panel.ui:174
+msgid "Calibration Device"
+msgstr "Peranti Penentukuran"
+
+#: panels/color/cc-color-panel.ui:189
+msgid "Select the type of display that is connected."
+msgstr "Pilih jenis paparan yang bersambung."
+
+#: panels/color/cc-color-panel.ui:226
+msgid "Display Type"
+msgstr "Jenis Paparan"
+
+#: panels/color/cc-color-panel.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Pilih titik putih sasaran paparan. Kebanyakan paparan seharusnya ditentukur "
+"pada illuminant D65."
+
+#: panels/color/cc-color-panel.ui:278
+msgid "Profile Whitepoint"
+msgstr "Titik Putih Profil"
+
+#: panels/color/cc-color-panel.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Sila tetapkan paparan pada kecerahan yang anda biasa. Pengurusan warna akan "
+"menjadi lebih tepat pada kecerahan ini."
+
+#: panels/color/cc-color-panel.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Sebaliknya, anda boleh guna aras kecerahan yang digunakan dengan salah satu "
+"profil lain untuk peranti ini."
+
+#: panels/color/cc-color-panel.ui:318
+msgid "Display Brightness"
+msgstr "Paparan Kecerahan"
+
+#: panels/color/cc-color-panel.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Anda boleh guna satu profil warna pada komputer lain, atau cipta profil "
+"untuk keadaan pencahayaan yang berlainan."
+
+#: panels/color/cc-color-panel.ui:348
+msgid "Profile Name:"
+msgstr "Nama Profil:"
+
+#: panels/color/cc-color-panel.ui:377
+msgid "Profile Name"
+msgstr "Nama Profil"
+
+#: panels/color/cc-color-panel.ui:392
+msgid "Profile successfully created!"
+msgstr "Berjaya mencipta profil!"
+
+#: panels/color/cc-color-panel.ui:443
+msgid "Copy profile"
+msgstr "Salin profil"
+
+#: panels/color/cc-color-panel.ui:456
+msgid "Requires writable media"
+msgstr "Perlu media boleh tulis"
+
+#: panels/color/cc-color-panel.ui:519
+msgid "Upload profile"
+msgstr "Muat naik profil"
+
+#: panels/color/cc-color-panel.ui:532
+msgid "Requires Internet connection"
+msgstr "Memerlukan sambungan Internet"
+
+#: panels/color/cc-color-panel.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Anda mungkin dapati arahan bagaimana menggunakan profil dalam sistem <a href="
+"\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> dan <a href=\"windows"
+"\">Microsoft Windows</a> yang berguna."
+
+#: panels/color/cc-color-panel.ui:607
+#: panels/user-accounts/um-fingerprint-dialog.c:720
+msgid "Summary"
+msgstr "Ringkasan"
+
+#: panels/color/cc-color-panel.ui:621
+msgid "Add Profile"
+msgstr "Tambah Profil"
+
+#: panels/color/cc-color-panel.ui:643
+msgid "_Import File…"
+msgstr "_Import Fail…"
+
+#: panels/color/cc-color-panel.ui:672
+#: panels/network/connection-editor/net-connection-editor.c:513
+#: panels/printers/new-printer-dialog.ui:80
+#: panels/region/cc-input-chooser.ui:20
+#: panels/user-accounts/cc-add-user-dialog.ui:47
+msgid "_Add"
+msgstr "_Tambah"
+
+#: panels/color/cc-color-panel.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Masalah dikesan. Profil mungkin tidak berfungsi dengan baik. <a href="
+"\"\">Tunjuk perincian.</a>"
+
+#: panels/color/cc-color-panel.ui:790
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Setiap peranti memerlukan pengemaskinian profil warna untuk mengurus "
+"warnanya."
+
+#: panels/color/cc-color-panel.ui:812
+msgid "Learn more"
+msgstr "Ketahui lagi"
+
+#: panels/color/cc-color-panel.ui:817
+msgid "Learn more about color management"
+msgstr "Ketahui lagi mengenai pengurusan warna"
+
+#: panels/color/cc-color-panel.ui:865
+msgid "_Set for all users"
+msgstr "Tetapkan untuk semua pengguna"
+
+#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
+#: panels/color/cc-color-panel.ui:885
+msgid "Set this profile for all users on this computer"
+msgstr "Tetapkan profil ini semua pengguna pada komputer ini"
+
+#: panels/color/cc-color-panel.ui:880
+msgid "_Enable"
+msgstr "_Benarkan"
+
+#: panels/color/cc-color-panel.ui:911
+msgid "_Add profile"
+msgstr "T_ambah profil"
+
+#: panels/color/cc-color-panel.ui:924
+msgid "_Calibrate…"
+msgstr "T_entukur…"
+
+#: panels/color/cc-color-panel.ui:928
+msgid "Calibrate the device"
+msgstr "Tentukur peranti"
+
+#: panels/color/cc-color-panel.ui:939
+msgid "_Remove profile"
+msgstr "_Buang profil"
+
+#: panels/color/cc-color-panel.ui:952
+msgid "_View details"
+msgstr "_Lihat perincian"
+
+#: panels/color/cc-color-panel.ui:988
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Tidak dapat mengesan mana-mana peranti yang boleh diurus warnanya"
+
+#: panels/color/cc-color-panel.ui:1032
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:1037
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:1042
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:1047
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/cc-color-panel.ui:1052
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:1057
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (Cahaya belakang CCFL)"
+
+#: panels/color/cc-color-panel.ui:1062
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (Cahaya belakang LED RGB)"
+
+#: panels/color/cc-color-panel.ui:1067
+msgid "LCD (white LED backlight)"
+msgstr "LCD (cahaya belakang LED putih)"
+
+#: panels/color/cc-color-panel.ui:1072
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD gamut lebar (Cahaya belakang CCFL)"
+
+#: panels/color/cc-color-panel.ui:1077
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD gamut lebar (Cahaya belakang LED merah)"
+
+#: panels/color/cc-color-panel.ui:1094
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Tinggi"
+
+#: panels/color/cc-color-panel.ui:1095
+msgid "40 minutes"
+msgstr "40 minit"
+
+#: panels/color/cc-color-panel.ui:1099
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Sederhana"
+
+#: panels/color/cc-color-panel.ui:1100
+msgid "30 minutes"
+msgstr "30 minit"
+
+#: panels/color/cc-color-panel.ui:1104
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Rendah"
+
+#: panels/color/cc-color-panel.ui:1105
+msgid "15 minutes"
+msgstr "15 minit"
+
+#: panels/color/cc-color-panel.ui:1127
+msgid "Native to display"
+msgstr "Tabii pada paparan"
+
+#: panels/color/cc-color-panel.ui:1131
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Percetakan dan penerbitan)"
+
+#: panels/color/cc-color-panel.ui:1135
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:1139
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografi dan grafik)"
+
+#: panels/color/cc-color-panel.ui:1143
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:100
+msgid "Standard Space"
+msgstr "Ruang Piawai"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:106
+msgid "Test Profile"
+msgstr "Uji Profail"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:114
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatik"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:124
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Kualiti Rendah"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:129
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Kualiti Sederhana"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:136
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Kualiti Tinggi"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:153
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB lalai"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:160
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK lalai"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:167
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Kelabu lalai"
+
+#: panels/color/cc-color-profile.c:190
+msgid "Vendor supplied factory calibration data"
+msgstr "Data penentukuran kilang yang disediakan pembekal"
+
+#: panels/color/cc-color-profile.c:199
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Pembetulan paparan skrin-penuh mustahil dibuat dengan profil ini"
+
+#: panels/color/cc-color-profile.c:221
+msgid "This profile may no longer be accurate"
+msgstr "Profil ini mungkin tidak lagi tepat"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Warna"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Tentukur warna peranti anda, seperti paparan, kamera atau pencetak"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Warna;ICC;Profil;Tentukur;Pencetak;Paparan;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Lain-lain…"
+
+#: panels/common/cc-language-chooser.c:127 panels/region/cc-input-chooser.c:178
+msgid "More…"
+msgstr "Lagi…"
+
+#: panels/common/cc-language-chooser.c:144
+msgid "No languages found"
+msgstr "Tiada bahasa ditemui"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Pilih Bahasa"
+
+#: panels/common/cc-language-chooser.ui:12
+msgid "_Select"
+msgstr "_Pilih"
+
+#: panels/common/cc-permission-infobar.ui:20
+#| msgid "_Unlock"
+msgid "Unlock…"
+msgstr "Nyahkunci…"
+
+#: panels/common/cc-permission-infobar.ui:45
+#| msgid "Can change settings"
+msgid "Unlock to Change Settings"
+msgstr "Nyahkunci untuk Mengubah Tetapan"
+
+#: panels/common/cc-permission-infobar.ui:55
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Beberapa tetapan mesti dinyahkunci sebelum ia boleh diubah."
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:143
+msgid "Today"
+msgstr "Hari ini"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:145
+msgid "Yesterday"
+msgstr "Semalam"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+# msgstr[1] "minit"
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d jam"
+msgstr[1] "%d jam"
+
+#: panels/common/cc-util.c:166
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minit"
+msgstr[1] "%d minit"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d saat"
+msgstr[1] "%d saat"
+
+# msgstr[1] "%i jam"
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:172
+#, c-format
+msgctxt "time"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+# msgstr[1] "%i jam"
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:177
+#, c-format
+msgctxt "time"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:187
+msgid "0 seconds"
+msgstr "0 saat"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Kawasan Khas"
+
+#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
+#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
+msgid "Day"
+msgstr "Hari"
+
+#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
+#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
+msgid "Month"
+msgstr "Bulan"
+
+#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
+#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
+msgid "Year"
+msgstr "Tahun"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:334
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:339
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:504
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:531
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:538
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:543
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:548
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:26
+msgid "January"
+msgstr "Januari"
+
+#: panels/datetime/cc-datetime-panel.ui:29
+msgid "February"
+msgstr "Februari"
+
+#: panels/datetime/cc-datetime-panel.ui:32
+msgid "March"
+msgstr "Mac"
+
+#: panels/datetime/cc-datetime-panel.ui:35
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:38
+msgid "May"
+msgstr "Mei"
+
+#: panels/datetime/cc-datetime-panel.ui:41
+msgid "June"
+msgstr "Jun"
+
+#: panels/datetime/cc-datetime-panel.ui:44
+msgid "July"
+msgstr "Julai"
+
+#: panels/datetime/cc-datetime-panel.ui:47
+msgid "August"
+msgstr "Ogos"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:53
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:56
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:59
+msgid "December"
+msgstr "Disember"
+
+#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Tarikh & Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#: panels/display/cc-night-light-page.ui:194
+#: panels/display/cc-night-light-page.ui:314
+msgid "Hour"
+msgstr "Jam"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: panels/datetime/cc-datetime-panel.ui:128
+msgid "∶"
+msgstr "∶"
+
+#: panels/datetime/cc-datetime-panel.ui:152
+#: panels/display/cc-night-light-page.ui:222
+#: panels/display/cc-night-light-page.ui:342
+msgid "Minute"
+msgstr "Minit"
+
+#: panels/datetime/cc-datetime-panel.ui:219
+msgid "Time Zone"
+msgstr "Zon Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:240
+msgid "Search for a city"
+msgstr "Gelintar satu bandar"
+
+#: panels/datetime/cc-datetime-panel.ui:313
+msgid "Automatic _Date & Time"
+msgstr "_Tarikh & Wktu Automatik"
+
+#: panels/datetime/cc-datetime-panel.ui:314
+msgid "Requires internet access"
+msgstr "Memerlukan capaian internet"
+
+#: panels/datetime/cc-datetime-panel.ui:334
+msgid "Automatic Time _Zone"
+msgstr "_Zon Waktu Automatik"
+
+#: panels/datetime/cc-datetime-panel.ui:335
+msgid "Requires location services enabled and internet access"
+msgstr "Memerlukan perkhidmatan lokasi dibenarkan dan capaian internet"
+
+#: panels/datetime/cc-datetime-panel.ui:350
+msgid "Date & _Time"
+msgstr "Tarikh & _Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:366
+msgid "Time Z_one"
+msgstr "Z_on Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:405
+msgid "Time _Format"
+msgstr "_Format Waktu"
+
+#: panels/datetime/cc-datetime-panel.ui:414
+msgid "24-hour"
+msgstr "24-jam"
+
+#: panels/datetime/cc-datetime-panel.ui:415
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Ubah tarikh dan waktu, termasuklah zon waktu"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Jam;Zon Waktu;Lokasi;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Ubah tetapan waktu dan tarikh sistem"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Untuk mengubah tetapan waktu dan tarikh, anda perlukan sahihkan."
+
+#: panels/default-apps/cc-default-apps-panel.ui:31
+msgid "_Web"
+msgstr "Sesa_wang"
+
+#: panels/default-apps/cc-default-apps-panel.ui:43
+msgid "_Mail"
+msgstr "_Mel"
+
+#: panels/default-apps/cc-default-apps-panel.ui:59
+msgid "_Calendar"
+msgstr "_Kalendar"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "M_usic"
+msgstr "M_uzik"
+
+#: panels/default-apps/cc-default-apps-panel.ui:91
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:162
+#: panels/removable-media/cc-removable-media-panel.ui:162
+msgid "_Photos"
+msgstr "_Foto"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplikasi Lalai"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Konfigur Aplikasi Lalai"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "lalai;aplikasi;dikehendaki;media;"
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: panels/diagnostics/cc-diagnostics-panel.c:141
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+"Penghantaran laporan masalah teknikal dapat membantu kami menambah baik %s. "
+"Laporan yang dihantar adalah secara awanama dan tidak melibatkan data "
+"peribadi."
+
+#: panels/diagnostics/cc-diagnostics-panel.c:151
+#: panels/diagnostics/cc-diagnostics-panel.ui:53
+msgid "Reports are sent anonymously and are scrubbed of personal data."
+msgstr "Laporan dihantar secara awanama dan data peribadi disingkirkan."
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:30
+msgid "Problem Reporting"
+msgstr "Pelaporan Masalah"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:43
+msgid ""
+"Sending reports of technical problems help us improve this operating system."
+msgstr ""
+"Menghantar laporan masalah teknikal dapat bantu kami menambah baik sistem "
+"pengoperasian ini."
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:78
+msgid "_Automatic Problem Reporting"
+msgstr "Pelaporan Masalah _Automatik"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostik"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Lapor masalah anda"
+
+#. FIXME
+#: panels/display/cc-display-panel.c:961
+#: panels/network/connection-editor/connection-editor.ui:27
+msgid "_Apply"
+msgstr "_Laksana"
+
+#: panels/display/cc-display-panel.c:982
+msgid "Apply Changes?"
+msgstr "_Laksana Perubahan?"
+
+#: panels/display/cc-display-panel.c:987
+msgid "Changes Cannot be Applied"
+msgstr "Perubahan Tidak Dapat Dilaksanakan"
+
+#: panels/display/cc-display-panel.c:988
+msgid "This could be due to hardware limitations."
+msgstr "Ia disebabkan oleh batasan perkakasan."
+
+#: panels/display/cc-display-panel.ui:91
+msgid "Single Display"
+msgstr "Paparan Tunggal"
+
+#: panels/display/cc-display-panel.ui:110
+#: panels/display/cc-display-panel.ui:315
+msgid "Join Displays"
+msgstr "Paparan Terlibat"
+
+#: panels/display/cc-display-panel.ui:128
+msgid "Mirror"
+msgstr "Cermin"
+
+#: panels/display/cc-display-panel.ui:153
+msgid "Display Mode"
+msgstr "Mod Paparan"
+
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains top bar and Activities"
+msgstr "Mengandungi palang alat dan Aktiviti"
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Paparan Utama"
+
+#: panels/display/cc-display-panel.ui:245
+msgid ""
+"Drag displays to match your physical display setup. Select a display to "
+"change its settings."
+msgstr ""
+"Seret paparan untuk sepadankan persediaan paparan fizikal anda. Pilih satu "
+"paparan untuk mengubah tetapannya."
+
+#: panels/display/cc-display-panel.ui:252
+msgid "Display Arrangement"
+msgstr "Susunan Paparan"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr "Paparan Aktif"
+
+#: panels/display/cc-display-panel.ui:434
+msgid "Display Configuration"
+msgstr "Konfigurasi Paparan"
+
+#: panels/display/cc-display-panel.ui:453
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Paparan"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:464
+#: panels/display/cc-night-light-page.ui:111
+msgid "Night Light"
+msgstr "Cahaya Malam"
+
+#: panels/display/cc-display-settings.c:104
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Lanskap"
+
+#: panels/display/cc-display-settings.c:107
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Kanan Potret"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Kiri Potret"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Lanskap (dikalih)"
+
+#: panels/display/cc-display-settings.c:187
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:15
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientasi"
+
+#: panels/display/cc-display-settings.ui:24
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolusi"
+
+#: panels/display/cc-display-settings.ui:33
+msgid "Refresh Rate"
+msgstr "Kadar Segar Semula"
+
+#: panels/display/cc-display-settings.ui:42
+msgid "Adjust for TV"
+msgstr "Laras untuk TV"
+
+#: panels/display/cc-display-settings.ui:59
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skala"
+
+#: panels/display/cc-night-light-page.c:622
+msgid "More Warm"
+msgstr "Lebih Hangat"
+
+#: panels/display/cc-night-light-page.c:634
+msgid "Less Warm"
+msgstr "Kurang Hangat"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:28
+msgid "Restart Filter"
+msgstr "Mula Semula Penapis"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:61
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Dilumpuhkan Buat Sementara Sehingga Esok Hari"
+
+#: panels/display/cc-night-light-page.ui:88
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Cahaya malam menjadikan warna skrin lebih hangat. Ia dapat menghindari "
+"keletihan mata dan gangguan tidur."
+
+#: panels/display/cc-night-light-page.ui:127
+msgid "Schedule"
+msgstr "Jadual"
+
+#: panels/display/cc-night-light-page.ui:136
+msgid "Sunset to Sunrise"
+msgstr "Matahari Terbenam hingga Matahari Terbit"
+
+#: panels/display/cc-night-light-page.ui:137
+msgid "Manual Schedule"
+msgstr "Jadual Manual"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/region/cc-format-chooser.ui:346
+msgid "Times"
+msgstr "Waktu"
+
+#: panels/display/cc-night-light-page.ui:165
+msgid "From"
+msgstr "Daripada"
+
+#: panels/display/cc-night-light-page.ui:203
+#: panels/display/cc-night-light-page.ui:323
+msgid ":"
+msgstr ":"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:234
+#: panels/display/cc-night-light-page.ui:354
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:250
+#: panels/display/cc-night-light-page.ui:370
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:284
+msgid "To"
+msgstr "Pada"
+
+#: panels/display/cc-night-light-page.ui:408
+msgid "Color Temperature"
+msgstr "Suhu Warna"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Pilih bagaimana hendak guna monitor dan projektor bersambung"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projektor;xrandr;Skrin;Resolusi;Segar Semula;Monitor;Malam;Cahaya;Biru;"
+"anjak merah;warna;matahari terbenam;matahari terbit;"
+
+#: panels/info-overview/cc-info-overview-panel.c:406
+#: panels/info-overview/cc-info-overview-panel.c:421
+#: panels/info-overview/cc-info-overview-panel.c:433
+#: panels/info-overview/cc-info-overview-panel.c:479
+#: panels/info-overview/cc-info-overview-panel.c:509
+msgid "Unknown"
+msgstr "Tidak diketahui"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:441
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s: ID Binaan: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:456
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:459
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:665
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:669
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:671
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Tidak diketahui"
+
+#: panels/info-overview/cc-info-overview-panel.ui:54
+msgid "Device Name"
+msgstr "Nama Peranti"
+
+#: panels/info-overview/cc-info-overview-panel.ui:76
+msgid "Memory"
+msgstr "Ingatan"
+
+#: panels/info-overview/cc-info-overview-panel.ui:85
+msgid "Processor"
+msgstr "Pemproses"
+
+#: panels/info-overview/cc-info-overview-panel.ui:94
+msgid "Graphics"
+msgstr "Grafik"
+
+#: panels/info-overview/cc-info-overview-panel.ui:103
+msgid "Disk Capacity"
+msgstr "Kapasiti Cakera"
+
+#: panels/info-overview/cc-info-overview-panel.ui:104
+msgid "Calculating…"
+msgstr "Mengira…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:126
+msgid "OS Name"
+msgstr "Nama OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:135
+msgid "OS Type"
+msgstr "Jenis OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:144
+msgid "GNOME Version"
+msgstr "Versi GNOME"
+
+#: panels/info-overview/cc-info-overview-panel.ui:154
+msgid "Windowing System"
+msgstr "Sistem Bertetingkap"
+
+#: panels/info-overview/cc-info-overview-panel.ui:162
+msgid "Virtualization"
+msgstr "Pemayaan"
+
+#: panels/info-overview/cc-info-overview-panel.ui:171
+msgid "Software Updates"
+msgstr "Kemas Kini Perisian"
+
+#: panels/info-overview/cc-info-overview-panel.ui:192
+msgid "Rename Device"
+msgstr "Nama Semula Peranti"
+
+#: panels/info-overview/cc-info-overview-panel.ui:209
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Nama peranti yang digunakan untuk kenal pasti peranti ini ketika ia dilihat "
+"melalui rangkaian, atau ketika berpasangan peranti Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:226
+msgid "_Rename"
+msgstr "_Nama Semula"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Perihal"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Lihat maklumat berkenaan sistem anda"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"peranti;sistem;maklumat;nama hos;ingatan;pemproses;versi;lalai;aplikasi;"
+"dikehendaki;cd;dvd;usb;audio;video;cakera;boleh alih;media;auto-jalan;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Bunyi dan Media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Senyap/suarakan Volum"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Volum turun"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Volum naik"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Senyap/suarakan Mikrofon"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Lancar pemain media"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Main (atau main/jeda)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Jeda main balik"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Henti main balik"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Trek terdahulu"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Trek berikutnya"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Lenting"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:565
+msgid "Typing"
+msgstr "Menaip"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Beralih ke sumber input berikutnya"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Beralih ke sumber input terdahulu"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Pelancar"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Lancar pelayar bantuan"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Lancar kalkulator"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Lancar klien emel"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Lancar pelayar sesawang"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Folder Rumah"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Gelintar"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "Tangkap Layar"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr "Simpan satu tangkap layar ke dalam $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Simpan satu tangkap layar tetingkap ke dalam $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Simpan satu tangkap layar kawasan ke dalam $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "Salin satu tangkap layar ke dalam papan keratan"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Salin satu tangkap layar tetingkap ke dalam papan keratan"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Salin satu tangkap layar kawasan ke dalam papan keratan"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr "Rakam kas skrin pendek"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistem"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Daftar keluar"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Kunci skrin"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Universal Access"
+msgstr "Capaian Universal"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Hidup atau matikan zum"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zum masuk"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Zum keluar"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Hidup atau matikan pembaca skrin"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Hidup atau matikan papan kekunci atas-skrin"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Besarkan saiz teks"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Kecilkan saiz teks"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Hidup atau matikan beza jelas tinggi"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:8
+#: panels/keyboard/cc-keyboard-panel.ui:72
+msgid "Alternate Characters Key"
+msgstr "Kekunci Aksara Pengganti"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:28
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Kekunci aksara pengganti boleh digunakan untuk memasukkan aksara tambahan. "
+"Ia kadang kala dicetak sebagai pilih-ketiga pada papan kekunci anda."
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:45
+msgid "Left Alt"
+msgstr "Alt Kiri"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:61
+msgid "Right Alt"
+msgstr "Alt Kanan"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:77
+msgid "Left Super"
+msgstr "Super Kiri"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:93
+msgid "Right Super"
+msgstr "Super Kanan"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:109
+msgid "Menu key"
+msgstr "Kekunci Menu"
+
+#: panels/keyboard/cc-alt-chars-key-dialog.ui:125
+msgid "Right Ctrl"
+msgstr "Ctrl Kanan"
+
+#: panels/keyboard/cc-keyboard-manager.c:501
+#: panels/keyboard/cc-keyboard-manager.c:509
+#: panels/keyboard/cc-keyboard-manager.c:809
+msgid "Custom Shortcuts"
+msgstr "Pintasan Suai"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: panels/keyboard/cc-keyboard-option.c:337
+msgid "Alternative Characters Key"
+msgstr "Kekunci Aksara Alternatif"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: panels/keyboard/cc-keyboard-option.c:346
+msgid "Compose Key"
+msgstr "Kekunci Gubah"
+
+#: panels/keyboard/cc-keyboard-option.c:351
+msgid "Modifiers-only switch to next source"
+msgstr "Suis pengubah suai-sahaja ke sumber berikutnya"
+
+#: panels/keyboard/cc-keyboard-panel.c:94
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl Kanan"
+
+#: panels/keyboard/cc-keyboard-panel.c:95
+msgctxt "keyboard key"
+msgid "Menu Key"
+msgstr "Kekunci Menu"
+
+#: panels/keyboard/cc-keyboard-panel.c:96
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super Kiri"
+
+#: panels/keyboard/cc-keyboard-panel.c:97
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super Kanan"
+
+#: panels/keyboard/cc-keyboard-panel.c:98
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt Kiri"
+
+#: panels/keyboard/cc-keyboard-panel.c:99
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt Kanan"
+
+#: panels/keyboard/cc-keyboard-panel.c:201
+msgid "Reset All Shortcuts?"
+msgstr "Tetap Semula Semua Pintasan?"
+
+#: panels/keyboard/cc-keyboard-panel.c:204
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Penetapan semula kekunci boleh memberi kesan terhadap pintasan suai anda. "
+"Tindakan ini tidak boleh diundur kembali."
+
+#: panels/keyboard/cc-keyboard-panel.c:208
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:346
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+msgid "Cancel"
+msgstr "Batal"
+
+#: panels/keyboard/cc-keyboard-panel.c:209
+msgid "Reset All"
+msgstr "Teta_p Semula Semua"
+
+#: panels/keyboard/cc-keyboard-panel.c:305
+msgid "Reset the shortcut to its default value"
+msgstr "Tetap semula pintasan ke nilai lalainya"
+
+#: panels/keyboard/cc-keyboard-panel.ui:73
+msgid "Hold down and type to enter different characters"
+msgstr "Tahan dan taip untuk masukkan aksara yang berbeza"
+
+#: panels/keyboard/cc-keyboard-panel.ui:147
+msgid "Reset All…"
+msgstr "Tetap Semula Semua…"
+
+#: panels/keyboard/cc-keyboard-panel.ui:148
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Tetap semula semua pintasan ke pengikatan kekunci lalainya"
+
+#: panels/keyboard/cc-keyboard-panel.ui:177
+msgid "No keyboard shortcut found"
+msgstr "Tiada pintasan papan kekunci ditemui"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:413
+#, c-format
+#| msgid ""
+#| "%s is already being used for <b>%s</b>. If you replace it, %s will be "
+#| "disabled"
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s sudah digunakan untuk %s. Jika anda ganti ia, %s akan dilumpuhkan"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+msgid "Set Custom Shortcut"
+msgstr "Tetapkan Pintasan Suai"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+msgid "Set Shortcut"
+msgstr "Tetapkan Pintasan"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:592
+#, c-format
+#| msgid "Enter new shortcut to change <b>%s</b>."
+msgid "Enter new shortcut to change %s."
+msgstr "Masukkan pintasan baharu untuk mengubah %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:1016
+msgid "Add Custom Shortcut"
+msgstr "Tambah Pintasan Suai"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:68
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:318
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Tekan Esc untuk batal atau Backspace untuk lumpuhkan pintasan papan kekunci."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:156
+#: panels/printers/pp-details-dialog.ui:40
+msgid "Name"
+msgstr "Nama"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:168
+msgid "Command"
+msgstr "Perintah"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:180
+msgid "Shortcut"
+msgstr "Pintasan"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:259
+msgid "Set Shortcut…"
+msgstr "Tetapkan Pintasan…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:272
+msgid "None"
+msgstr "Tiada"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:303
+msgid "Enter the new shortcut"
+msgstr "Masukkan pintasan baharu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:357
+msgid "Remove"
+msgstr "Buang"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:367
+msgid "Add"
+msgstr "Tambah"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:382
+msgid "Replace"
+msgstr "Ganti"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:395
+msgid "Set"
+msgstr "Tetapkan"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+#: panels/region/cc-region-panel.ui:394 shell/cc-window.ui:327
+msgid "Keyboard Shortcuts"
+msgstr "Pintasan Papan Kekunci"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"Lihat dan ubah pintasan papan kekunci dan tetapkan keutamaan menaip anda"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Pintasan;Ruang Kerja;Tetingkap;Saiz Semula;Zum;Beza Jelas;Input;Sumber;Kunci;"
+"Volum;"
+
+#: panels/location/cc-location-panel.ui:31
+msgid "Location services turned off"
+msgstr "Perkhidmatan lokasi dimatikan"
+
+#: panels/location/cc-location-panel.ui:40
+msgid "No applications can obtain location information."
+msgstr "Tiada aplikasi boleh mendapatkan maklumat lokasi."
+
+#: panels/location/cc-location-panel.ui:74
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"Perkhidmatan lokasi membolehkan aplikasi-aplikasi dapat mengetahui lokasi "
+"anda. Penggunaan Wi-Fi dan jalur lebar mudah alih dapat meningkatkan "
+"ketepatannya."
+
+#: panels/location/cc-location-panel.ui:83
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+"Penggunaan Perkhidmatan Lokasi Mozilla: <a href='https://location.services."
+"mozilla.com/privacy'>Dasar Kerahsiaan</a>"
+
+#: panels/location/cc-location-panel.ui:95
+msgid "Allow the applications below to determine your location."
+msgstr "Benarkan aplikasi di bawah menentukan lokasi anda."
+
+#: panels/location/cc-location-panel.ui:115
+msgid "No Applications Have Asked for Location Access"
+msgstr "Tiada Aplikasi Perlu Tanya Capaian Lokasi"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Lindungi maklumat lokasi anda"
+
+#. FIXME
+#: panels/lock/cc-lock-panel.ui:29
+msgid ""
+"Automatically locking the screen prevents others from access the computer "
+"while you're away."
+msgstr ""
+"Kunci skrin secara automatik dapat menghalang orang lain daripada mencapai "
+"komputer ketika anda tiada."
+
+#: panels/lock/cc-lock-panel.ui:46
+msgid "Blank Screen Delay"
+msgstr "Lengah Skrin Gelap"
+
+#: panels/lock/cc-lock-panel.ui:47
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Tempoh ketidakaktifan selepas skrin menjadi gelap."
+
+#: panels/lock/cc-lock-panel.ui:67
+msgid "Automatic Screen _Lock"
+msgstr "Kun_ci Skrin Automatik"
+
+#: panels/lock/cc-lock-panel.ui:84
+msgid "Automatic _Screen Lock Delay"
+msgstr "Lengah Kunci _Skrin Automatik"
+
+#: panels/lock/cc-lock-panel.ui:85
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Tempoh selepas skrin gelap ketika skrin terkunci secara automatik."
+
+#: panels/lock/cc-lock-panel.ui:105
+msgid "Show _Notifications on Lock Screen"
+msgstr "Tunjuk _Pemberitahuan bila Skrin Kunci"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:149
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Skrin Dimatikan"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:153
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 saat"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:157
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minit"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:161
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minit"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:165
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minit"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:169
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minit"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:173
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minit"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:177
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 jam"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:192 panels/power/cc-power-panel.ui:63
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minit"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:196 panels/power/cc-power-panel.ui:67
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minit"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:200 panels/power/cc-power-panel.ui:71
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minit"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:204 panels/power/cc-power-panel.ui:75
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minit"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:208 panels/power/cc-power-panel.ui:79
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minit"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:212 panels/power/cc-power-panel.ui:83
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minit"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:216 panels/power/cc-power-panel.ui:87
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minit"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:220 panels/power/cc-power-panel.ui:91
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minit"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:224 panels/power/cc-power-panel.ui:95
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minit"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:228 panels/power/cc-power-panel.ui:99
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Tidak sesekali"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "Kunci Skrin"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr "Kunci skrin anda"
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid "Microphone is turned off"
+msgstr "Mikrofon dimatikan"
+
+#: panels/microphone/cc-microphone-panel.ui:43
+msgid "No applications can record sound."
+msgstr "Tiada aplikasi boleh merakam bunyi."
+
+#: panels/microphone/cc-microphone-panel.ui:77
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly."
+msgstr ""
+"Penggunaan mikrofon membolehkan aplikasi rakam dan dengar audio. Melumpuhkan "
+"mikrofon boleh menyebabkan beberapa aplikasi tidak berfungsi dengan baik."
+
+#: panels/microphone/cc-microphone-panel.ui:87
+msgid "Allow the applications below to use your microphone."
+msgstr "Benarkan aplikasi di bawah menggunakan mikrofon anda."
+
+#: panels/microphone/cc-microphone-panel.ui:107
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Tiada Aplikasi Perlu Tanya Capaian Mikrofon"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Lindungi perbualan anda"
+
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:37
+msgid "General"
+msgstr "Am"
+
+#: panels/mouse/cc-mouse-panel.ui:75
+msgid "Primary Button"
+msgstr "Butang Utama"
+
+#: panels/mouse/cc-mouse-panel.ui:94
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Tetapkan tertib butang fizikal pada tetikus dan pad sentuh."
+
+#: panels/mouse/cc-mouse-panel.ui:123 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Kiri"
+
+#: panels/mouse/cc-mouse-panel.ui:133 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Kanan"
+
+#: panels/mouse/cc-mouse-panel.ui:169
+msgid "Mouse"
+msgstr "Tetikus"
+
+#: panels/mouse/cc-mouse-panel.ui:208
+msgid "Mouse Speed"
+msgstr "Kelajuan Tetikus"
+
+#: panels/mouse/cc-mouse-panel.ui:230 panels/mouse/cc-mouse-panel.ui:522
+msgid "Double-click timeout"
+msgstr "Had masa tamat dwi-lik"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:267 panels/mouse/cc-mouse-panel.ui:430
+msgid "Natural Scrolling"
+msgstr "Penatalan Tabii"
+
+#: panels/mouse/cc-mouse-panel.ui:283 panels/mouse/cc-mouse-panel.ui:446
+msgid "Scrolling moves the content, not the view."
+msgstr "Penatalan menggerakkan kandungan, bukan pandangan."
+
+#: panels/mouse/cc-mouse-panel.ui:333 panels/mouse/cc-mouse-panel.ui:378
+msgid "Touchpad"
+msgstr "Pad Sentuh"
+
+#: panels/mouse/cc-mouse-panel.ui:501
+msgid "Touchpad Speed"
+msgstr "Kelajuan Pad Sentuh"
+
+#: panels/mouse/cc-mouse-panel.ui:560
+msgid "Tap to Click"
+msgstr "Ketik untuk Klik"
+
+#: panels/mouse/cc-mouse-panel.ui:612
+msgid "Two-finger Scrolling"
+msgstr "Penatalan Dua-jari"
+
+#: panels/mouse/cc-mouse-panel.ui:665
+msgid "Edge Scrolling"
+msgstr "Penatalan Pinggir"
+
+#: panels/mouse/cc-mouse-panel.ui:719 panels/wacom/cc-wacom-panel.c:438
+msgid "Test Your _Settings"
+msgstr "Uji _Tetapan Anda"
+
+#: panels/mouse/cc-mouse-test.c:132 panels/mouse/cc-mouse-test.ui:25
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Cuba mengklik, dwi-klik, menatal"
+
+#: panels/mouse/cc-mouse-test.c:137
+msgid "Five clicks, GEGL time!"
+msgstr "Lima klik, GEGL time!"
+
+#: panels/mouse/cc-mouse-test.c:142
+msgid "Double click, primary button"
+msgstr "Dwi klik, butang utama"
+
+#: panels/mouse/cc-mouse-test.c:142
+msgid "Single click, primary button"
+msgstr "Klik tunggal, butang utama"
+
+#: panels/mouse/cc-mouse-test.c:145
+msgid "Double click, middle button"
+msgstr "Dwi-klik, butang tengah"
+
+#: panels/mouse/cc-mouse-test.c:145
+msgid "Single click, middle button"
+msgstr "Klik tunggal, butang tengah"
+
+#: panels/mouse/cc-mouse-test.c:148
+msgid "Double click, secondary button"
+msgstr "Dwi-klik, butang sekunder"
+
+#: panels/mouse/cc-mouse-test.c:148
+msgid "Single click, secondary button"
+msgstr "Klik tunggal, butang sekunder"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Tetikus & Pad Sentuh"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Ubah kepekaan tetikus atau pad sentuh anda dan pilih sama ada kanan atau "
+"kidal"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Pad Jejak;Penuding;Klik;Ketik;Dubel;Butang;Bebola Jejak;Tatal;"
+
+#: panels/network/cc-network-panel.c:648 panels/network/cc-wifi-panel.ui:306
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Alamak, ada masalah berlaku. Sila hubungi pembekal perisian anda."
+
+#: panels/network/cc-network-panel.c:654
+msgid "NetworkManager needs to be running."
+msgstr "Pengurus Rangkaian perlu dijalankan."
+
+#: panels/network/cc-network-panel.ui:68
+msgid "Other Devices"
+msgstr "Lain-lain Peranti"
+
+#: panels/network/cc-network-panel.ui:109
+#: panels/network/connection-editor/net-connection-editor.c:596
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:153
+msgid "Not set up"
+msgstr "Belum dipasang"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:189
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:249
+msgid "Insecure network (WEP)"
+msgstr "Rangkaian tidak selamat (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:254
+msgid "Secure network (WPA)"
+msgstr "Rangkaian selamat (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:259
+msgid "Secure network (WPA2)"
+msgstr "Rangkaian selamat (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:264
+msgid "Secure network"
+msgstr "Rangkaian selamat"
+
+#: panels/network/cc-wifi-connection-row.ui:102
+#: panels/network/net-device-ethernet.c:318
+#: panels/network/network-bluetooth.ui:76
+#: panels/network/network-ethernet.ui:102 panels/network/network-mobile.ui:414
+#: panels/network/network-vpn.ui:78
+msgid "Options…"
+msgstr "Pilihan…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:132
+#, c-format
+#| msgid ""
+#| "Turning on the hotspot will disconnect from <b>%s</b>, and it will not be "
+#| "possible to access the internet through Wi-Fi."
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Menghidupkan kawasan khas akan menyebabkan %s terputus, dan tidak boleh "
+"mencapai internet melalui Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:248
+msgid "Must have a minimum of 8 characters"
+msgstr "Mesti minimum 8 aksara"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:458
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Hidupkan Kawasan Khas Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:19
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Kawasan khas Wi-Fi membolehkan orang lain berkongsi sambungan internent "
+"anda, dengan mencipta satu rangkaian Wi-Fi yang boleh mereka sambungkan. "
+"Untuk membuatnya, anda mesti ada satu sambungan internet bersumber selain "
+"dari Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:44
+#: panels/network/network-wifi.ui:105
+msgid "Network Name"
+msgstr "Nama Rangkaian"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:69
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:383
+#: panels/user-accounts/cc-add-user-dialog.ui:249
+msgid "Password"
+msgstr "Kata laluan"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:83
+msgid "Generate Random Password"
+msgstr "Jana Kata Laluan Rawak"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:84
+msgid "Autogenerate Password"
+msgstr "Auto-jana Kata Laluan"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:130
+msgid "_Turn On"
+msgstr "D_ihidupkan"
+
+#: panels/network/cc-wifi-panel.c:277
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:233
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:56
+msgid "Airplane Mode"
+msgstr "Mod Kapal Terbang"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Lumpuhkan Wi-Fi, Bluetooth dan jalur lebar bimbit"
+
+#: panels/network/cc-wifi-panel.ui:141
+msgid "No Wi-Fi Adapter Found"
+msgstr "Tiada Penyesuai Wi-Fi Ditemui"
+
+#: panels/network/cc-wifi-panel.ui:153
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Pastikan anda telah memalam dan menghidupkan penyesuai Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:188
+msgid "Airplane Mode On"
+msgstr "Mod Kapal Terbang hidup"
+
+#: panels/network/cc-wifi-panel.ui:200
+msgid "Turn off to use Wi-Fi"
+msgstr "Matikan untuk guna Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:227
+msgid "Visible Networks"
+msgstr "Rangkaian Kelihatan"
+
+#: panels/network/cc-wifi-panel.ui:295
+msgid "NetworkManager needs to be running"
+msgstr "Pengurus Rangkaian perlu dijalankan"
+
+#: panels/network/connection-editor/8021x-security-page.ui:20
+msgid "802.1x _Security"
+msgstr "Ke_selamatan 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:114
+#: panels/network/connection-editor/ce-page-security.c:386
+#: panels/network/connection-editor/details-page.ui:90
+msgid "Security"
+msgstr "Keselamatan"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Kekalkan"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Kekal"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Rawak"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabil"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Alamat MAC yang dimasukkan di sini akan digunakan sebagai alamat perkakasan "
+"untuk peranti rangkaian yang mana sambungannya aktif. Fitur ini dikenali "
+"sebagai pengklonan MAC atau perdayaan. Contohnya: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:93
+#: panels/network/net-device-wifi.c:235
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:240
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:101
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:106
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:111
+#: panels/network/net-device-wifi.c:225
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Tiada"
+
+#: panels/network/connection-editor/ce-page-details.c:132
+msgid "Never"
+msgstr "Tidak sesekali"
+
+#: panels/network/connection-editor/ce-page-details.c:147
+#: panels/network/net-device-ethernet.c:108
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i hari yang lalu"
+msgstr[1] "%i hari yang lalu"
+
+#: panels/network/connection-editor/ce-page-details.c:272
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+# msgstr[1] ""
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:274
+#: panels/network/net-device-ethernet.c:202
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:291
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:293
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:295
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:315
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Tiada"
+
+#: panels/network/connection-editor/ce-page-details.c:317
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Lemah"
+
+#: panels/network/connection-editor/ce-page-details.c:319
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:321
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Baik"
+
+#: panels/network/connection-editor/ce-page-details.c:323
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Bagus"
+
+#: panels/network/connection-editor/ce-page-details.c:381
+#: panels/network/connection-editor/details-page.ui:108
+#: panels/network/net-device-ethernet.c:143
+#: panels/network/net-device-mobile.c:431
+msgid "IPv4 Address"
+msgstr "Alamat IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:382
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-ethernet.c:148
+#: panels/network/net-device-mobile.c:432 panels/network/network-mobile.ui:200
+msgid "IPv6 Address"
+msgstr "Alamat IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:385
+#: panels/network/connection-editor/ce-page-details.c:386
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:435
+#: panels/network/net-device-mobile.c:436 panels/network/network-mobile.ui:183
+msgid "IP Address"
+msgstr "Alamat IP"
+
+#: panels/network/connection-editor/ce-page-details.c:420
+msgid "Forget Connection"
+msgstr "Lupakan Sambungan"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+msgid "Remove Connection Profile"
+msgstr "Buang Profil Sambungan"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+msgid "Remove VPN"
+msgstr "Buang VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:442
+msgid "Details"
+msgstr "Perincian"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatik"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:150
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identiti"
+
+#: panels/network/connection-editor/ce-page-ip4.c:268
+#: panels/network/connection-editor/ce-page-ip6.c:249
+msgid "Delete Address"
+msgstr "Padam Alamat"
+
+#: panels/network/connection-editor/ce-page-ip4.c:428
+#: panels/network/connection-editor/ce-page-ip6.c:398
+msgid "Delete Route"
+msgstr "Padam Hala"
+
+#: panels/network/connection-editor/ce-page-ip4.c:852
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:783
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:257
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Tiada"
+
+#: panels/network/connection-editor/ce-page-security.c:280
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Kunci WEP 40/128-bit (Hex atau ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:290
+msgid "WEP 128-bit Passphrase"
+msgstr "Frasa Laluan WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:303
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:316
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP Dinamik (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:330
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Persendirian"
+
+#: panels/network/connection-editor/ce-page-security.c:344
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/details-page.ui:18
+msgid "Signal Strength"
+msgstr "Kekuatan Isyarat"
+
+#: panels/network/connection-editor/details-page.ui:54
+msgid "Link speed"
+msgstr "Kelajuan sambungan"
+
+#: panels/network/connection-editor/details-page.ui:144
+#: panels/network/net-device-ethernet.c:151
+msgid "Hardware Address"
+msgstr "Alamat Perkakasan"
+
+#: panels/network/connection-editor/details-page.ui:162
+msgid "Supported Frequencies"
+msgstr "Frekuensi Disokong"
+
+#: panels/network/connection-editor/details-page.ui:180
+#: panels/network/net-device-ethernet.c:155
+#: panels/network/network-mobile.ui:217
+msgid "Default Route"
+msgstr "Hala lalai"
+
+#: panels/network/connection-editor/details-page.ui:199
+#: panels/network/connection-editor/ip4-page.ui:211
+#: panels/network/connection-editor/ip6-page.ui:225
+#: panels/network/net-device-ethernet.c:157
+#: panels/network/network-mobile.ui:235
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:217
+msgid "Last Used"
+msgstr "Terakhir Digunakan"
+
+#: panels/network/connection-editor/details-page.ui:376
+msgid "Connect _automatically"
+msgstr "Sambung secara _automatik"
+
+#: panels/network/connection-editor/details-page.ui:395
+msgid "Make available to _other users"
+msgstr "Jadikan tersedia kepada pengguna _lain"
+
+#: panels/network/connection-editor/details-page.ui:428
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"Sambungan ber_meter: mempunyai had data atau boleh mengakibatkan cas "
+"dikenakan"
+
+#: panels/network/connection-editor/details-page.ui:439
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Tatar perisian dan lain-lain muat turun bersaiz besar tidak dimulakan secara "
+"automatik."
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "_Nama"
+
+#: panels/network/connection-editor/ethernet-page.ui:54
+#: panels/network/connection-editor/wifi-page.ui:67
+msgid "_MAC Address"
+msgstr "Alamat _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:105
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:122
+#: panels/network/connection-editor/wifi-page.ui:102
+msgid "_Cloned Address"
+msgstr "Alamat Ter_klon"
+
+#: panels/network/connection-editor/ethernet-page.ui:137
+msgid "bytes"
+msgstr "bait"
+
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr "Kaedah IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:42
+msgid "Automatic (DHCP)"
+msgstr "Automatik (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr "Pautan-Setempat Sahaja"
+
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:72 panels/network/network-proxy.ui:116
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr "Lumpuhkan"
+
+#: panels/network/connection-editor/ip4-page.ui:97
+#: panels/network/connection-editor/ip6-page.ui:111
+msgid "Shared to other computers"
+msgstr "Berkongsi dengan komputer lain"
+
+#: panels/network/connection-editor/ip4-page.ui:125
+#: panels/network/connection-editor/ip6-page.ui:139
+msgid "Addresses"
+msgstr "Alamat-Alamat"
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/printers/pp-details-dialog.ui:95
+msgid "Address"
+msgstr "Alamat"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+msgid "Netmask"
+msgstr "Topeng Internet"
+
+#: panels/network/connection-editor/ip4-page.ui:171
+#: panels/network/connection-editor/ip4-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:369
+msgid "Gateway"
+msgstr "Get Laluan"
+
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:291
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/connection-editor/ip6-page.ui:305
+#: panels/network/net-proxy.c:74 panels/network/network-proxy.ui:106
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Automatik"
+
+#: panels/network/connection-editor/ip4-page.ui:234
+#: panels/network/connection-editor/ip6-page.ui:248
+msgid "Automatic DNS"
+msgstr "DNS Automatik"
+
+#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Separate IP addresses with commas"
+msgstr "Asingkan alamat-alamat IP dengan tanda koma"
+
+#: panels/network/connection-editor/ip4-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:293
+msgid "Routes"
+msgstr "Hala"
+
+#: panels/network/connection-editor/ip4-page.ui:302
+#: panels/network/connection-editor/ip6-page.ui:316
+msgid "Automatic Routes"
+msgstr "Hala Automatik"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:368
+#: panels/network/connection-editor/ip6-page.ui:382
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/network/connection-editor/ip4-page.ui:398
+#: panels/network/connection-editor/ip6-page.ui:412
+msgid "Use this connection _only for resources on its network"
+msgstr "Guna sambungan ini sa_haja untuk sumber dalam rangkaiannya"
+
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr "Kaedah IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr "Automatik, DHCP sahaja"
+
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Prefix"
+msgstr "Awalan"
+
+#: panels/network/connection-editor/net-connection-editor.c:291
+msgid "Unable to open connection editor"
+msgstr "Tidak boleh buka penyunting sambungan"
+
+#: panels/network/connection-editor/net-connection-editor.c:307
+msgid "New Profile"
+msgstr "Profil Baru"
+
+#: panels/network/connection-editor/net-connection-editor.c:740
+msgid "Import from file…"
+msgstr "Import daripada fail…"
+
+#: panels/network/connection-editor/net-connection-editor.c:772
+msgid "Add VPN"
+msgstr "Tambah VPN"
+
+#: panels/network/connection-editor/security-page.ui:20
+msgid "S_ecurity"
+msgstr "K_eselamatan"
+
+#: panels/network/connection-editor/vpn-helpers.c:139
+msgid "Cannot import VPN connection"
+msgstr "Tidak dapat mengimport sambungan VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Fail \"%s\" tidak dapat baca atau tidak mengandungi maklumat sambungan VPN "
+"yang dikenali\n"
+"\n"
+"Ralat: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:173
+msgid "Select file to import"
+msgstr "Pilih fail untuk diimport"
+
+#: panels/network/connection-editor/vpn-helpers.c:225
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Satu fail bernama \"%s\" sudah wujud."
+
+#: panels/network/connection-editor/vpn-helpers.c:227
+msgid "_Replace"
+msgstr "_Ganti"
+
+#: panels/network/connection-editor/vpn-helpers.c:229
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+"Anda ingin menggantikan %s dengan sambungan VPN yang anda hendak simpan?"
+
+#: panels/network/connection-editor/vpn-helpers.c:264
+msgid "Cannot export VPN connection"
+msgstr "Tidak dapat mengeksport sambungan VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:266
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Sambungan VPN \"%s\" tidak dapat dieksport ke %s.\n"
+"\n"
+"Ralat: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:296
+msgid "Export VPN connection"
+msgstr "Eksport sambungan VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Ralat: tidak dapat muat penyunting sambungan VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:20
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:36
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Kawal bagaimana anda sambung ke Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Rangkaian;IP;LAN;Proksi;WAN;Jalur Lebar;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Kawal bagaimana hendak bersambung dengan rangkaian Wi-Wi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Rangkaian;Tanpa Wayar;Wi-Fi;Wifi;IP;LAN;Jalur Lebar;DNS;Kawasan Khas;"
+
+#: panels/network/net-device-ethernet.c:96
+msgid "never"
+msgstr "tidak sesekali"
+
+#: panels/network/net-device-ethernet.c:104
+msgid "today"
+msgstr "hari ini"
+
+#: panels/network/net-device-ethernet.c:106
+msgid "yesterday"
+msgstr "semalam"
+
+#: panels/network/net-device-ethernet.c:162
+msgid "Last used"
+msgstr "Terakhir digunakan"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:252
+#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+msgid "Wired"
+msgstr "Berwayar"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Tambah sambungan baharu"
+
+#: panels/network/net-device-wifi.c:798
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Henti kawasan khas dan putuskan mana-mana pengguna?"
+
+#: panels/network/net-device-wifi.c:801
+msgid "_Stop Hotspot"
+msgstr "_Henti Kawasan Khas"
+
+#: panels/network/net-device-wifi.c:905
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Perincian rangkaian untuk rangkaian terpilih, termasuklah kata laluan dan "
+"lain-lain konfigurasi suai akan hilang."
+
+#: panels/network/net-device-wifi.c:909
+msgid "_Forget"
+msgstr "_Lupakan"
+
+#: panels/network/net-device-wifi.c:1065 panels/network/net-device-wifi.c:1072
+msgid "Known Wi-Fi Networks"
+msgstr "Rangkaian Wi-Fi Diketahui"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1107
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Lupakan"
+
+#: panels/network/net-device-wifi.c:1268
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Dasar sistem menghalang penggunaan sebagai Kawasan Khas"
+
+#: panels/network/net-device-wifi.c:1271
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Peranti tanpa wayar tidak menyokong mod Kawasan Khas"
+
+#: panels/network/net-proxy.c:70
+#: panels/notifications/cc-notifications-panel.c:270
+#: panels/power/cc-power-panel.c:2066 panels/power/cc-power-panel.c:2077
+#: panels/universal-access/cc-ua-panel.c:480
+#: panels/universal-access/cc-ua-panel.c:843
+#: panels/universal-access/cc-ua-panel.c:856
+#: panels/universal-access/cc-ua-panel.c:868
+#: panels/universal-access/cc-ua-panel.c:1033
+#: panels/universal-access/cc-ua-panel.ui:323
+#: panels/universal-access/cc-ua-panel.ui:369
+#: panels/universal-access/cc-ua-panel.ui:415
+#: panels/universal-access/cc-ua-panel.ui:521
+#: panels/universal-access/cc-ua-panel.ui:674
+#: panels/universal-access/cc-ua-panel.ui:720
+#: panels/universal-access/cc-ua-panel.ui:766
+#: panels/universal-access/cc-ua-panel.ui:950
+msgid "Off"
+msgstr "Tutup"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:113
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Auto-penemuan Proksi Sesawang digunakan bila URL Konfigurasi tidak "
+"disediakan."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:121
+msgid "This is not recommended for untrusted public networks."
+msgstr "Tidak disarankan untuk rangkaian-rangkaian awam yang tidak dipercayai."
+
+#. update title
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/net-vpn.c:66 panels/network/net-vpn.c:163
+#, c-format
+msgid "%s VPN"
+msgstr "VPN %s"
+
+#: panels/network/network-bluetooth.ui:50
+msgid "Turn device off"
+msgstr "Matikan peranti"
+
+#: panels/network/network-mobile.ui:29
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:47
+msgid "Provider"
+msgstr "Penyedia"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:95
+msgid "Network Proxy"
+msgstr "Proksi Rangkaian"
+
+#: panels/network/network-proxy.ui:176
+msgid "_HTTP Proxy"
+msgstr "Proksi _HTTP"
+
+#: panels/network/network-proxy.ui:195
+msgid "H_TTPS Proxy"
+msgstr "Proksi H_TTPS"
+
+#: panels/network/network-proxy.ui:214
+msgid "_FTP Proxy"
+msgstr "Proksi _FTP"
+
+#: panels/network/network-proxy.ui:233
+msgid "_Socks Host"
+msgstr "Hos _Socks"
+
+#: panels/network/network-proxy.ui:252
+msgid "_Ignore Hosts"
+msgstr "Aba_i Hos"
+
+#: panels/network/network-proxy.ui:290
+msgid "HTTP proxy port"
+msgstr "Port proksi HTTP"
+
+#: panels/network/network-proxy.ui:367
+msgid "HTTPS proxy port"
+msgstr "Port proksi HTTPS"
+
+#: panels/network/network-proxy.ui:388
+msgid "FTP proxy port"
+msgstr "Port proksi FTP"
+
+#: panels/network/network-proxy.ui:409
+msgid "Socks proxy port"
+msgstr "Port proksi Socks"
+
+#: panels/network/network-proxy.ui:438
+msgid "_Configuration URL"
+msgstr "URL _Konfigurasi"
+
+#: panels/network/network-vpn.ui:55
+msgid "Turn VPN connection off"
+msgstr "Putuskan sambungan VPN"
+
+#: panels/network/network-wifi.ui:37
+msgid "Wi-Fi Hotspot"
+msgstr "Kawasan Khas Wi-Fi"
+
+#: panels/network/network-wifi.ui:55
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Matikan untuk bersambung dengan rangkaian Wi-Fi"
+
+#: panels/network/network-wifi.ui:123
+msgid "Security type"
+msgstr "Jenis keselamatan"
+
+#: panels/network/network-wifi.ui:175
+msgctxt "Wi-Fi passkey"
+msgid "Password"
+msgstr "Kata laluan"
+
+#: panels/network/network-wifi.ui:264
+msgid "Turn Wi-Fi off"
+msgstr "Matikan Wi-Fi"
+
+#: panels/network/network-wifi.ui:296
+msgid "_Connect to Hidden Network…"
+msgstr "_Sambung ke Rangkaian Tersembunyi…"
+
+#: panels/network/network-wifi.ui:307
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Hidupkan Kawasan Khas Wi-Fi…"
+
+#: panels/network/network-wifi.ui:318
+msgid "_Known Wi-Fi Networks"
+msgstr "_Rangkaian Wi-Fi Diketahui"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Status tidak diketahui"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Tidak Diurus"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Tiada"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Menyambung"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Pengesahihan diperlukan"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Bersambung"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Diputuskan"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Sambungan gagal"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Status tidak diketahui (hilang)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Konfigurasi gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Konfigurasi IP gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Konfigurasi IP telah luput"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Rahsia diperlukan, tetapi tidak disediakan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Perayu 802.1 telah terputus"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Konfigurasi perayu 802.1 telah gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Perayu 802.1 telah gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Perayu 802.1 mengambil masa yang lama untuk disahihkan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Perkhidmatan PPP gagal dimulakan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Perkhidmatan PPP terputus"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Klien DHCP gagal dimulakan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Ralat klien DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Klien DHCP gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Perkhidmatan sambungan berkongsi gagal dimulakan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Perkhidmatan sambungan terkongsi gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Perkhidmatan AutoIP gagal dimulakan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Ralat perkhidmatan AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Perkhidmatan AutoIP gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Talian sibuk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Tiada nada dail"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Tiada pembawa ditubuhkan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Permintaan dailan telah tamat masa"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Percubaan dailan telah gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Pengawalan modem gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Gagal memilih APN dinyatakan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Tidak menggelintar rangkaian"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Pendaftaran rangkaian dinafikan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Pendaftaran rangkaian tamat masa"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Gagal daftar dengan rangkaian yang dipinta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Semakan PIN gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Perisian tegar untuk peranti mungkin hilang"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Sambungan hilang"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Sambungan sedia ada telah dianggap"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem tidak ditemui"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Sambungan Bluetooth telah gagal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Kad SIM tidak disisip"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Pin SIM diperlukan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Puk SIM diperlukan"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252
+msgid "SIM wrong"
+msgstr "SIM salah"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Dependensi sambungan telah gagal"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:351
+msgid "Firmware missing"
+msgstr "Perisian tegar hilang"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:355
+msgid "Cable unplugged"
+msgstr "Kabel ditanggalkan"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "ralat tidak ditakrif dalam keselamatan 802.X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:153
+msgid "no file selected"
+msgstr "tiada fail terpilih"
+
+#: panels/network/wireless-security/eap-method.c:180
+msgid "unspecified error validating eap-method file"
+msgstr "ralat tidak dinyatakan ketika mengesahkan fail eap-method"
+
+#: panels/network/wireless-security/eap-method.c:355
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr ""
+"Kunci-kunci persendirian DER, PEM, atau PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:358
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "Sijil-sijil DER atau PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:90
+msgid "missing EAP-FAST PAC file"
+msgstr "fail PAC EAP-FAST hilang"
+
+#: panels/network/wireless-security/eap-method-fast.c:300
+msgid "Choose a PAC file"
+msgstr "Pilih satu fail PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:305
+msgid "PAC files (*.pac)"
+msgstr "Fail PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Awanama"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Disahihkan"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Kedua-duanya"
+
+#: panels/network/wireless-security/eap-method-fast.ui:49
+#: panels/network/wireless-security/eap-method-peap.ui:52
+#: panels/network/wireless-security/eap-method-ttls.ui:51
+msgid "Anony_mous identity"
+msgstr "Identiti a_wanama"
+
+#: panels/network/wireless-security/eap-method-fast.ui:75
+msgid "PAC _file"
+msgstr "_Fail PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:115
+#: panels/network/wireless-security/eap-method-peap.ui:150
+#: panels/network/wireless-security/eap-method-ttls.ui:143
+msgid "_Inner authentication"
+msgstr "Pengesahihan da_laman"
+
+#: panels/network/wireless-security/eap-method-fast.ui:144
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Benarkan pembe_kalan PAC automatik"
+
+#: panels/network/wireless-security/eap-method-leap.c:69
+msgid "missing EAP-LEAP username"
+msgstr "nama pengguna EAP-LEAP hilang"
+
+#: panels/network/wireless-security/eap-method-leap.c:78
+msgid "missing EAP-LEAP password"
+msgstr "kata laluan EAP-LEAP hilang"
+
+#: panels/network/wireless-security/eap-method-leap.ui:17
+#: panels/network/wireless-security/eap-method-simple.ui:17
+#: panels/network/wireless-security/ws-leap.ui:18
+#: panels/user-accounts/cc-add-user-dialog.ui:146
+#: panels/user-accounts/cc-add-user-dialog.ui:527
+msgid "_Username"
+msgstr "Nama P_engguna"
+
+#: panels/network/wireless-security/eap-method-leap.ui:31
+#: panels/network/wireless-security/eap-method-simple.ui:31
+#: panels/network/wireless-security/ws-leap.ui:32
+#: panels/network/wireless-security/ws-wpa-psk.ui:14
+#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/user-accounts/cc-add-user-dialog.ui:310
+#: panels/user-accounts/cc-add-user-dialog.ui:547
+#: panels/user-accounts/cc-user-panel.ui:204
+msgid "_Password"
+msgstr "_Kata Laluan"
+
+#: panels/network/wireless-security/eap-method-leap.ui:55
+#: panels/network/wireless-security/eap-method-simple.ui:73
+#: panels/network/wireless-security/eap-method-tls.ui:157
+#: panels/network/wireless-security/ws-leap.ui:56
+#: panels/network/wireless-security/ws-wpa-psk.ui:64
+msgid "Sho_w password"
+msgstr "_Tunjuk kata laluan"
+
+#: panels/network/wireless-security/eap-method-peap.c:90
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "sijil CA EAP-PEAP tidak sah: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:99
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "sijil CA EAP-PEAP tidak sah: tiada sijil dinyatakan"
+
+#: panels/network/wireless-security/eap-method-peap.c:281
+#: panels/network/wireless-security/eap-method-tls.c:496
+#: panels/network/wireless-security/eap-method-ttls.c:289
+msgid "Choose a Certificate Authority certificate"
+msgstr "Pilih satu sijil Certificate Authority"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versi 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versi 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:78
+#: panels/network/wireless-security/eap-method-tls.ui:68
+#: panels/network/wireless-security/eap-method-ttls.ui:102
+msgid "C_A certificate"
+msgstr "Sijil C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:100
+#: panels/network/wireless-security/eap-method-tls.ui:90
+#: panels/network/wireless-security/eap-method-ttls.ui:125
+msgid "No CA certificate is _required"
+msgstr "Tiada sijil CA _diperlukan"
+
+#: panels/network/wireless-security/eap-method-peap.ui:118
+msgid "PEAP _version"
+msgstr "_Versi PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:80
+msgid "missing EAP username"
+msgstr "nama pengguna EAP hilang"
+
+#: panels/network/wireless-security/eap-method-simple.c:93
+msgid "missing EAP password"
+msgstr "kata laluan EAP hilang"
+
+#: panels/network/wireless-security/eap-method-tls.c:81
+msgid "missing EAP-TLS identity"
+msgstr "identiti EAP-TLS hilang"
+
+#: panels/network/wireless-security/eap-method-tls.c:91
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "sijil CA EAP-TLS tidak sah: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:100
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "sijil CA EAP-TLS tidak sah: tiada sijil dinyatakan"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "kunci-persendirian EAP-TLS tidak sah: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:123
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "sijil-pengguna EAP-TLS tidak sah: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Kunci persendirian tidak disulitkan adalah tidak selamat"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Kunci persendirian terpilih nampaknya tidak dilindungi oleh satu kata "
+"laluan. Ia mungkin membolehkan kelayakan keselamatan anda tergugat. Sila "
+"pilih satu kunci persendirian dilindungi-kata-laluan.\n"
+"\n"
+"(Anda boleh lindungi berkata laluan kunci persendirian anda dengan openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:489
+msgid "Choose your personal certificate"
+msgstr "Pilih sijil peribadi anda"
+
+#: panels/network/wireless-security/eap-method-tls.c:503
+msgid "Choose your private key"
+msgstr "Pilih kunci persendirian anda"
+
+#: panels/network/wireless-security/eap-method-tls.ui:17
+msgid "I_dentity"
+msgstr "I_dentiti"
+
+#: panels/network/wireless-security/eap-method-tls.ui:43
+msgid "_User certificate"
+msgstr "Sijil pengg_una"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "Private _key"
+msgstr "_Kunci persendirian"
+
+#: panels/network/wireless-security/eap-method-tls.ui:133
+msgid "_Private key password"
+msgstr "Kata laluan kunci _persendirian"
+
+#: panels/network/wireless-security/eap-method-ttls.c:101
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "sijil CA EAP-TTLS tidak sah: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:109
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "sijil CA EAP-TTLS tidak sah: tiada sijil dinyatakan"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (tanpa EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:76
+#: panels/user-accounts/cc-add-user-dialog.ui:507
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "_Domain"
+
+#: panels/network/wireless-security/wireless-security.c:107
+msgid "Unknown error validating 802.1X security"
+msgstr "Ralat tidak diketahui ketika mengesahkan keselamatan 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS berterowong"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP Terlindung (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:102
+#: panels/network/wireless-security/ws-wpa-eap.ui:61
+msgid "Au_thentication"
+msgstr "Pen_gesahihan"
+
+#: panels/network/wireless-security/ws-leap.c:84
+msgid "missing leap-username"
+msgstr "nama-pengguna-leap hilang"
+
+#: panels/network/wireless-security/ws-leap.c:93
+msgid "missing leap-password"
+msgstr "kata-laluan-leap hilang"
+
+#: panels/network/wireless-security/ws-wep-key.c:117
+msgid "missing wep-key"
+msgstr "kunci-WEP hilang"
+
+#: panels/network/wireless-security/ws-wep-key.c:126
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"kunci-wep tidak sah: kunci dengan panjang %zu mesti mengandungi digit-heks "
+"sahaja"
+
+#: panels/network/wireless-security/ws-wep-key.c:134
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"kunci-wep tidak sah: kunci dengan panjang %zu mesti mengandungi aksara ascii "
+"sahaja"
+
+#: panels/network/wireless-security/ws-wep-key.c:140
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"kunci-wep tidak sah: panjang kunci %zu adalah salah. Sebuah kunci mesti "
+"panjangnya 5/13 (acsii) atau 10/26 (heks)"
+
+#: panels/network/wireless-security/ws-wep-key.c:147
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "kunci-wep tidak sah: kunci frasa laluan mesti tidak-kosong"
+
+#: panels/network/wireless-security/ws-wep-key.c:149
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"kunci-wep tidak sah: frasa laluan mesti lebih pendek daripada 64 aksara"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Lalai)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistem Terbuka"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Kunci Dikongsi"
+
+#: panels/network/wireless-security/ws-wep-key.ui:48
+msgid "_Key"
+msgstr "_Kunci"
+
+#: panels/network/wireless-security/ws-wep-key.ui:84
+msgid "Sho_w key"
+msgstr "T_unjuk kunci"
+
+#: panels/network/wireless-security/ws-wep-key.ui:134
+msgid "WEP inde_x"
+msgstr "Indek_s WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:89
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk tidak sah: panjang kunci %zu tidak sah. Mesti [8.63] bait atau 64 "
+"digit heks"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:98
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk tidak sah: tidak dapat mentafsir kunci dengan 64 bait sebagai heks"
+
+#: panels/network/wireless-security/ws-wpa-psk.ui:42
+msgid "_Type"
+msgstr "_Jenis"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:60
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Pem_beritahuan"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:112
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Amaran Bunyi"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:168
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Pemberitahuan _Timbul"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:184
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Pemberitahuan akan terus muncul dalam senarai pemberitahuan ketika dialog "
+"timbul dilumpuhkan."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:249
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Tunjuk _Kandungan Mesej dalam Dialog Timbul"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:300
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Pemberitahuan Skrin _Kunci"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:351
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Tunjuk Ka_ndungan Mesej pada Skrin Kunci"
+
+#: panels/notifications/cc-notifications-panel.c:270
+#: panels/power/cc-power-panel.c:2072 panels/power/cc-power-panel.c:2079
+#: panels/universal-access/cc-ua-panel.c:480
+#: panels/universal-access/cc-ua-panel.c:843
+#: panels/universal-access/cc-ua-panel.c:856
+#: panels/universal-access/cc-ua-panel.c:868
+#: panels/universal-access/cc-ua-panel.c:1033
+msgid "On"
+msgstr "Hidup"
+
+#: panels/notifications/cc-notifications-panel.ui:70
+msgid "Notification _Popups"
+msgstr "Pemberitahuan _Timbul"
+
+#: panels/notifications/cc-notifications-panel.ui:121
+msgid "_Lock Screen Notifications"
+msgstr "Pemberitahuan Skrin _Kunci"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Kawal pemberitahuan yang manakah dipapar dan apakah yang ditunjukkan"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Pemberitahuan;Sepanduk;Mesej;Talam;Timbul;"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:150
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Lain-lain"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:627
+#, c-format
+msgid "%s Account"
+msgstr "Akaun %s"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:924
+msgid "Error removing account"
+msgstr "Ralat membuang akaun"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:991
+#, c-format
+#| msgid "<b>%s</b> removed"
+msgid "%s removed"
+msgstr "%s dibuang"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Akaun Dalam Talian"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Sambung ke akaun atas-talian anda dan tentukan apa kegunaannya"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Sesawang;Atas-Talian;Sembang;Kalendar;Mel;"
+"Kenalan;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
+msgid "Undo"
+msgstr "Buat Asal"
+
+#: panels/online-accounts/online-accounts.ui:96
+msgid "Connect to your data in the cloud"
+msgstr "Bersambung dengan data anda dalam awam"
+
+#: panels/online-accounts/online-accounts.ui:111
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Tiada sambungan internet — sambung untuk sediakan akaun dalam talian baharu"
+
+#: panels/online-accounts/online-accounts.ui:136
+msgid "Add an account"
+msgstr "Tambah satu akaun"
+
+#: panels/online-accounts/online-accounts.ui:243
+msgid "Remove Account"
+msgstr "Buang Akaun"
+
+#: panels/power/cc-power-panel.c:334
+msgid "Unknown time"
+msgstr "Masa tidak diketahui"
+
+#: panels/power/cc-power-panel.c:340
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minit"
+msgstr[1] "%i minit"
+
+# msgstr[1] "minit"
+#: panels/power/cc-power-panel.c:352
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i jam"
+msgstr[1] "%i jam"
+
+# msgstr[1] "%i jam"
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-power-panel.c:360
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-power-panel.c:361
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "jam"
+msgstr[1] "jam"
+
+# msgstr[1] "jam"
+#: panels/power/cc-power-panel.c:362
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minit"
+msgstr[1] "minit"
+
+# msgstr[1] "minit"
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:380
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s sehingga sepenuhnya dicas"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:387
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Amaran: %s berbaki"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:392
+#, c-format
+msgid "%s remaining"
+msgstr "%s berbaki"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:397 panels/power/cc-power-panel.c:427
+msgid "Fully charged"
+msgstr "Sepenuhnya dicas"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:401 panels/power/cc-power-panel.c:431
+msgid "Not charging"
+msgstr "Tidak dicas"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:405 panels/power/cc-power-panel.c:435
+msgid "Empty"
+msgstr "Habis"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:418
+msgid "Charging"
+msgstr "Mengecas"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:423
+msgid "Discharging"
+msgstr "Menyahcas"
+
+#: panels/power/cc-power-panel.c:556
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Utama"
+
+#: panels/power/cc-power-panel.c:558
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Tambahan"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:633
+msgid "Wireless mouse"
+msgstr "Tetikus tanpa wayar"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:636
+msgid "Wireless keyboard"
+msgstr "Papan kekunci tanpa wayar"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:639
+msgid "Uninterruptible power supply"
+msgstr "Bekalan kuasa tanpa gangguan"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:642
+msgid "Personal digital assistant"
+msgstr "Pembantu digital peribadi"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:645
+msgid "Cellphone"
+msgstr "Telefon bimbit"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:648
+msgid "Media player"
+msgstr "Pemain media"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:651 panels/wacom/cc-wacom-panel.c:815
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:654
+msgid "Computer"
+msgstr "Komputer"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:657
+msgid "Gaming input device"
+msgstr "Peranti input permainan"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-power-panel.c:660 panels/power/cc-power-panel.c:942
+#: panels/power/cc-power-panel.c:2422
+msgid "Battery"
+msgstr "Bateri"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:721
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Mengecas"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:728
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Amaran"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:733
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Rendah"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:738
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Baik"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:743
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Sepenuhnya dicas"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:747
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Habis"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Batteries"
+msgstr "Bateri-Bateri"
+
+#: panels/power/cc-power-panel.c:1381
+msgid "When _idle"
+msgstr "Bila me_lahu"
+
+#: panels/power/cc-power-panel.c:1827
+msgid "Power Saving"
+msgstr "Penjimatan Kuasa"
+
+#: panels/power/cc-power-panel.c:1861
+msgid "_Screen Brightness"
+msgstr "_Kecerahan Skrin"
+
+#: panels/power/cc-power-panel.c:1882
+msgid "Automatic Brightness"
+msgstr "Kecerahan Automatik"
+
+#: panels/power/cc-power-panel.c:1895
+msgid "_Keyboard Brightness"
+msgstr "_Kecerahan Papan Kekunci"
+
+#: panels/power/cc-power-panel.c:1906
+msgid "_Dim Screen When Inactive"
+msgstr "_Malap Skrin Bila Tidak Aktif"
+
+#: panels/power/cc-power-panel.c:1924
+msgid "_Blank Screen"
+msgstr "Skrin _Gelap"
+
+#: panels/power/cc-power-panel.c:1947
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: panels/power/cc-power-panel.c:1948
+msgid "Wi-Fi can be turned off to save power."
+msgstr "Wi-Fi boleh dimatikan untuk menjimatkan kuasa."
+
+#: panels/power/cc-power-panel.c:1964
+msgid "_Mobile Broadband"
+msgstr "_Jalur Lebar Mudah Alih"
+
+#: panels/power/cc-power-panel.c:1965
+msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+msgstr ""
+"Jalur lebar mudah alih (LTE, 4G, 3G, dll.) boleh dimatikan untuk menjimatkan "
+"kuasa."
+
+#: panels/power/cc-power-panel.c:2015
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: panels/power/cc-power-panel.c:2016
+msgid "Bluetooth can be turned off to save power."
+msgstr "Bluetooth boleh dimatikan untuk menjimatkan kuasa."
+
+#: panels/power/cc-power-panel.c:2068
+msgid "When on battery power"
+msgstr "Bila guna kuasa bateri"
+
+#: panels/power/cc-power-panel.c:2070
+msgid "When plugged in"
+msgstr "Bila dipalam masuk"
+
+#: panels/power/cc-power-panel.c:2164
+msgid "Suspend"
+msgstr "Tangguh"
+
+#: panels/power/cc-power-panel.c:2165
+msgid "Power Off"
+msgstr "Matikan"
+
+#: panels/power/cc-power-panel.c:2166
+msgid "Hibernate"
+msgstr "Hibernasi"
+
+#: panels/power/cc-power-panel.c:2167
+msgid "Nothing"
+msgstr "Tiada apa"
+
+#. Frame header
+#: panels/power/cc-power-panel.c:2267
+msgid "Suspend & Power Button"
+msgstr "Butang Tangguh & Kuasa"
+
+#: panels/power/cc-power-panel.c:2308
+msgid "_Automatic Suspend"
+msgstr "Tangguh _Automatik"
+
+#: panels/power/cc-power-panel.c:2309
+msgid "Automatic suspend"
+msgstr "Tangguh automatik"
+
+#: panels/power/cc-power-panel.c:2366
+msgid "Po_wer Button Action"
+msgstr "Tindakan Butang K_uasa"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:13
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:17
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:21
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:25
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:29
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:33
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 jam"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:37
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:41
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:45
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minit"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:49
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 jam"
+
+#: panels/power/cc-power-panel.ui:147
+msgid "Automatic Suspend"
+msgstr "Tangguh Automatik"
+
+#: panels/power/cc-power-panel.ui:172
+msgid "_Plugged In"
+msgstr "D_ipalamkan"
+
+#: panels/power/cc-power-panel.ui:188
+msgid "On _Battery Power"
+msgstr "Guna Kuasa _Bateri"
+
+#: panels/power/cc-power-panel.ui:233 panels/power/cc-power-panel.ui:293
+#: panels/universal-access/cc-ua-panel.ui:1527
+msgid "Delay"
+msgstr "Lengah"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Kuasa"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Lihat status bateri anda dan ubah tetapan penjimatan kuasa"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"Kuasa;Tidur;Tangguh;Hibernasi;Bateri;Kecerahan;Malap;Gelap;Monitor;DPMS;"
+"Melahu;"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "Sahihkan"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:362
+msgid "Username"
+msgstr "Namapengguna"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:337
+msgid "Authentication Required"
+msgstr "Pengesahihan Diperlukan"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:715
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Pencetak \"%s\" telah dipadamkan"
+
+# msgstr[1] ""
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:938
+msgid "Failed to add new printer."
+msgstr "Gagal menambah pencetak baharu."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1242
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Tidak dapat memuatkan ui: %s"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Pencetak"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Tambah pencetak, lihat kerja cetak dan tentukan bagaimana anda hendak cetak"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Pencetak;Baris Gilir;Cetak;Kertas;Dakwat;Toner;"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/jobs-dialog.ui:44
+msgid "Domain"
+msgstr "Domain"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/jobs-dialog.ui:123
+msgid "A_uthenticate"
+msgstr "Sa_hihkan"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/jobs-dialog.ui:163
+msgid "Clear All"
+msgstr "Kosongkan Semua"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/jobs-dialog.ui:225
+msgid "_Authenticate"
+msgstr "_Sahkan"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/jobs-dialog.ui:354
+msgid "No Active Printer Jobs"
+msgstr "Tiada Kerja Pencetak Aktif"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:363
+#: panels/printers/pp-new-printer-dialog.c:427
+msgid "Add Printer"
+msgstr "Tambah Pencetak"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+msgid "_Unlock"
+msgstr "_Buka"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:211
+msgid "No Printers Found"
+msgstr "Tiada Pencetak Ditemui"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:284
+msgid "Enter a network address or search for a printer"
+msgstr "Masukkan satu alamat rangkaian atau gelintar satu pencetak"
+
+#: panels/printers/new-printer-dialog.ui:353
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Masukkan nama pengguna dan kata laluan untuk melihat pencetak dalam Pelayan "
+"Cetak."
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:75
+#: panels/printers/pp-details-dialog.c:370
+#, c-format
+msgid "%s Details"
+msgstr "Perincian %s"
+
+#: panels/printers/pp-details-dialog.c:122
+msgid "No suitable driver found"
+msgstr "Tiada pemacu yang sesuai ditemui"
+
+#: panels/printers/pp-details-dialog.c:249
+msgid "Select PPD File"
+msgstr "Pilih Fail PPD"
+
+#: panels/printers/pp-details-dialog.c:258
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Fail Keterangan Pencetak Pos Skrip (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "Lokasi"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:122
+#: panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Pemacu"
+
+#: panels/printers/pp-details-dialog.ui:162
+msgid "Searching for preferred drivers…"
+msgstr "Menggelintar pemacu yang dikehendaki…"
+
+#: panels/printers/pp-details-dialog.ui:183
+msgid "Search for Drivers"
+msgstr "Gelintar Pemacu"
+
+#: panels/printers/pp-details-dialog.ui:192
+msgid "Select from Database…"
+msgstr "Pilih dari Pangkalan Data…"
+
+#: panels/printers/pp-details-dialog.ui:201
+msgid "Install PPD File…"
+msgstr "Pasang Fail PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr "Pilih Pemacu Pencetak"
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/cc-avatar-chooser.c:109
+msgid "Select"
+msgstr "Pilih"
+
+#: panels/printers/ppd-selection-dialog.ui:73
+msgid "Loading drivers database…"
+msgstr "Memuatkan pangkalan data pemacu…"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:479
+msgid "JetDirect Printer"
+msgstr "Pencetak JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:714
+msgid "LPD Printer"
+msgstr "Pencetak LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:65
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Satu Sisi"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:67
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Pinggir Panjang (Piawai)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:69
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Pinggir Pendek (Kalih)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:71
+msgid "Portrait"
+msgstr "Potret"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:73
+msgid "Landscape"
+msgstr "Lanskap"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:75
+msgid "Reverse landscape"
+msgstr "Lanskap terbalik"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:77
+msgid "Reverse portrait"
+msgstr "Potret terbalik"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-jobs-dialog.c:234
+msgctxt "print job"
+msgid "Pending"
+msgstr "Tertangguh"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-jobs-dialog.c:240
+msgctxt "print job"
+msgid "Paused"
+msgstr "Dijedakan"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-jobs-dialog.c:245
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Pengesahihan diperlukan"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-jobs-dialog.c:250
+msgctxt "print job"
+msgid "Processing"
+msgstr "Memproses"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-jobs-dialog.c:254
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Dihentikan"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-jobs-dialog.c:258
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Dibatalkan"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-jobs-dialog.c:262
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Dihenti Paksa"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-jobs-dialog.c:266
+msgctxt "print job"
+msgid "Completed"
+msgstr "Selesai"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:390
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u Kerja Memerlukan Pengesahihan"
+msgstr[1] "%u Kerja Memerlukan Pengesahihan"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:613
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Kerja-Kerja Aktif"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:617
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Masukkan kelayakan untuk mencetak daripada %s."
+
+#: panels/printers/pp-new-printer-dialog.c:380
+msgid "Unlock Print Server"
+msgstr "Buka Pelayan Cetak"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:384
+#, c-format
+msgid "Unlock %s."
+msgstr "Buka %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:388
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Masukkan nama pengguna dan kata laluan untuk melihat pencetak dalam %s."
+
+#: panels/printers/pp-new-printer-dialog.c:838
+msgid "Searching for Printers"
+msgstr "Menggelintar Pencetak"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1697
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1702
+msgid "Serial Port"
+msgstr "Port Serial"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1709
+msgid "Parallel Port"
+msgstr "Port Parallel"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1751
+#, c-format
+msgid "Location: %s"
+msgstr "Lokasi: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1756
+#, c-format
+msgid "Address: %s"
+msgstr "Alamat: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1783
+msgid "Server requires authentication"
+msgstr "Pelayan memerlukan pengesahihan"
+
+#: panels/printers/pp-options-dialog.c:91
+msgid "Two Sided"
+msgstr "Dua Sisi"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "Paper Type"
+msgstr "Jenis Kertas"
+
+#: panels/printers/pp-options-dialog.c:93
+msgid "Paper Source"
+msgstr "Sumber Kertas"
+
+#: panels/printers/pp-options-dialog.c:94
+msgid "Output Tray"
+msgstr "Talam Output"
+
+#: panels/printers/pp-options-dialog.c:95
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolusi"
+
+#: panels/printers/pp-options-dialog.c:96
+msgid "GhostScript pre-filtering"
+msgstr "Pra-penapisan GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:534
+msgid "Pages per side"
+msgstr "Halaman per muka"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:546
+msgid "Two-sided"
+msgstr "Dua-sisi"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:558
+msgid "Orientation"
+msgstr "Orientasi"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Am"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Persediaan Halaman"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Pilihan Boleh Pasang"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Kerja"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Kualiti Imej"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Warna"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Menyelesaikan"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:676
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Lanjutan"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:869
+#: panels/printers/pp-options-dialog.ui:18
+msgid "Test Page"
+msgstr "Halaman Uji"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:882
+msgid "Test page"
+msgstr "Halaman uji"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Pilih Sendiri"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Lalai Pencetak"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Fon Ghostscript Terbenam sahaja"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Tukar ke PS aras 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Tukar ke PS aras 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Tiada Pra-penapisan"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "Pengeluar"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:597 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr "Tiada Kerja-Kerja Aktif"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:602
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u Kerja"
+msgstr[1] "%u Kerja"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:757
+msgid "Low on toner"
+msgstr "Kekurangan toner"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:759
+msgid "Out of toner"
+msgstr "Kehabisan toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:762
+msgid "Low on developer"
+msgstr "Kekurangan penjadi"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:765
+msgid "Out of developer"
+msgstr "Kehabisan penjadi"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:767
+msgid "Low on a marker supply"
+msgstr "Kekurangan bekalan penanda"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:769
+msgid "Out of a marker supply"
+msgstr "Kehabisan bekalan penanda"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:771
+msgid "Open cover"
+msgstr "Buka penutup"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:773
+msgid "Open door"
+msgstr "Buka pintu"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:775
+msgid "Low on paper"
+msgstr "Kekurangan kertas"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:777
+msgid "Out of paper"
+msgstr "Kehabisan kertas"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:779
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Luar Talian"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:781
+#: panels/printers/pp-printer-entry.c:909
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Dihentikan"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:783
+msgid "Waste receptacle almost full"
+msgstr "Bekas sisa hampir penuh"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:785
+msgid "Waste receptacle full"
+msgstr "Bekas sisa penuh"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:787
+msgid "The optical photo conductor is near end of life"
+msgstr "Konduktor foto optik sudah menghampiri jangka hayatnya"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:789
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Konduktor foto optik sudah tidak berfunngsi"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:895
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Sedia"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:900
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Jangan terima kerja"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:905
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Memproses"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:929
+msgid "Clean print heads"
+msgstr "Bersihkan kepala cetak"
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr "Pilihan Percetakan"
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr "Perincian Pencetak"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr "Guna Pencetak secara Lalai"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr "Bersihkan Kepala Cetak"
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "Buang Pencetak"
+
+#: panels/printers/printer-entry.ui:193
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr "Aras Dakwat"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:312
+msgid "Please restart when the problem is resolved."
+msgstr "Sila mula semula bila masalah telah diselesaikan."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:319
+msgid "Restart"
+msgstr "Mula Semula"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:20
+msgid "Add…"
+msgstr "Tambah…"
+
+#: panels/printers/printers.ui:186
+msgid "No printers"
+msgstr "Tiada Pencetak"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:200
+msgid "Add a Printer…"
+msgstr "Tambah satu Pencetak…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:232
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"Maaf! Perkhidmatan percetakan sistem\n"
+"nampaknya tidak tersedia."
+
+#: panels/region/cc-format-chooser.c:148
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-chooser.c:150
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/region/cc-format-chooser.c:255 panels/region/cc-format-chooser.c:296
+#: panels/region/cc-format-chooser.ui:6
+msgid "Formats"
+msgstr "Format"
+
+#: panels/region/cc-format-chooser.ui:48 panels/wacom/wacom-stylus-page.ui:37
+#: shell/cc-window.ui:232
+msgid "Back"
+msgstr "Undur"
+
+#: panels/region/cc-format-chooser.ui:103
+msgid ""
+"Choose the format for numbers, dates and currencies. Changes take effect on "
+"next login."
+msgstr ""
+"Pilih format untuk angka, tarikh dan mata wang. Perubahan hanya berkesan "
+"pada daftar masuk berikutnya."
+
+#: panels/region/cc-format-chooser.ui:119
+#| msgid "Search Locations"
+msgid "Search locales..."
+msgstr "Gelintar lokal..."
+
+#: panels/region/cc-format-chooser.ui:160
+#| msgid "Common Tasks"
+msgid "Common Formats"
+msgstr "Format Umum"
+
+#: panels/region/cc-format-chooser.ui:191
+#| msgid "Formats"
+msgid "All Formats"
+msgstr "Semua Format"
+
+#: panels/region/cc-format-chooser.ui:244
+#| msgid "No results found"
+msgid "No Search Results"
+msgstr "Tiada Keputusan Gelintar"
+
+#: panels/region/cc-format-chooser.ui:257
+msgid "Searches can be for countries or languages."
+msgstr "Gelintar negara atau bahasa."
+
+#: panels/region/cc-format-chooser.ui:309
+msgid "Preview"
+msgstr "Pratonton"
+
+#: panels/region/cc-format-chooser.ui:324
+msgid "Dates"
+msgstr "Tarikh"
+
+#: panels/region/cc-format-chooser.ui:368
+msgid "Dates & Times"
+msgstr "Tarikh & Waktu"
+
+#: panels/region/cc-format-chooser.ui:390
+msgid "Numbers"
+msgstr "Bilangan"
+
+#: panels/region/cc-format-chooser.ui:412
+msgid "Measurement"
+msgstr "Ukuran"
+
+#: panels/region/cc-format-chooser.ui:434
+msgid "Paper"
+msgstr "Kertas"
+
+#: panels/region/cc-input-chooser.c:193
+msgid "No input sources found"
+msgstr "Tiada sumber input dijumpai"
+
+#: panels/region/cc-input-chooser.c:948
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Lain-lain"
+
+#: panels/region/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Tambah Sumber Input"
+
+#: panels/region/cc-input-chooser.ui:77
+msgid "Input methods can’t be used on the login screen"
+msgstr "Kaedah input tidak dapat digunakan pada skrin daftar masuk"
+
+#: panels/region/cc-region-panel.c:1511
+msgid "Login _Screen"
+msgstr "_Skrin Daftar Masuk"
+
+#: panels/region/cc-region-panel.ui:64
+#: panels/user-accounts/cc-user-panel.ui:352
+msgid "_Language"
+msgstr "_Bahasa"
+
+#: panels/region/cc-region-panel.ui:99
+msgid "Restart the session for changes to take effect"
+msgstr "Mula semula sesi supaya perubahan yang dibuat berkesan"
+
+#: panels/region/cc-region-panel.ui:114
+msgid "Restart…"
+msgstr "Mula Semula…"
+
+#: panels/region/cc-region-panel.ui:147
+msgid "_Formats"
+msgstr "_Format"
+
+#: panels/region/cc-region-panel.ui:195
+msgid "Input Sources"
+msgstr "Sumber Input"
+
+#: panels/region/cc-region-panel.ui:209
+msgid "Choose keyboard layouts or input methods."
+msgstr "Pilih bentangan papan kekunci atau kaedah input."
+
+#: panels/region/cc-region-panel.ui:266
+msgid "No input source selected"
+msgstr "Tiada sumber input terpilih"
+
+#: panels/region/cc-region-panel.ui:300
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"Tetapan daftar masuk digunakan oleh semua pengguna bila mendaftar masuk ke "
+"dalam sistem"
+
+#: panels/region/cc-region-panel.ui:337
+msgid "Input Source Options"
+msgstr "Pilihan Sumber Input"
+
+#: panels/region/cc-region-panel.ui:352
+msgid "Use the _same source for all windows"
+msgstr "Guna sumber yang _sama untuk semua tetingkap"
+
+#: panels/region/cc-region-panel.ui:370
+msgid "Allow _different sources for each window"
+msgstr "Benarkan sumber be_rlainan untuk setiap tetingkap"
+
+#: panels/region/cc-region-panel.ui:412
+msgid "Previous source"
+msgstr "Sumber terdahulu"
+
+#: panels/region/cc-region-panel.ui:430
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: panels/region/cc-region-panel.ui:445
+msgid "Next source"
+msgstr "Sumber berikutnya"
+
+#: panels/region/cc-region-panel.ui:463
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: panels/region/cc-region-panel.ui:478
+msgid "Left+Right Alt"
+msgstr "Alt Kiri+Kanan"
+
+#: panels/region/cc-region-panel.ui:494
+msgid "These keyboard shortcuts can be changed in the keyboard settings"
+msgstr "Pintasan papan kekunci ini boleh diubah dalam tetapan papan kekunci"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Wilayah & Bahasa"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr "Pilih bahasa paparan, format, bentangan papan kekunci dan sumber input"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Bahasa;Bentangan;Papan Kekunci;Input;"
+
+#: panels/removable-media/cc-removable-media-panel.c:267
+msgid "Ask what to do"
+msgstr "Tanya apa perlu buat"
+
+#: panels/removable-media/cc-removable-media-panel.c:271
+msgid "Do nothing"
+msgstr "Jangan buat apa-apa"
+
+#: panels/removable-media/cc-removable-media-panel.c:275
+msgid "Open folder"
+msgstr "Buka folder"
+
+#: panels/removable-media/cc-removable-media-panel.c:341
+msgid "Other Media"
+msgstr "Lain-lain Media"
+
+#: panels/removable-media/cc-removable-media-panel.c:362
+msgid "Select an application for audio CDs"
+msgstr "Pilih satu aplikasi untuk CD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:363
+msgid "Select an application for video DVDs"
+msgstr "Pilih satu aplikasi untuk DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.c:364
+msgid "Select an application to run when a music player is connected"
+msgstr "Pilih satu aplikasi untuk dijalankan ketika pemain muzik disambungkan"
+
+#: panels/removable-media/cc-removable-media-panel.c:365
+msgid "Select an application to run when a camera is connected"
+msgstr "Pilih satu aplikasi untuk dijalankan ketika kamera disambungkan"
+
+#: panels/removable-media/cc-removable-media-panel.c:366
+msgid "Select an application for software CDs"
+msgstr "Pilih satu aplikasi untuk CD perisian"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "audio DVD"
+msgstr "DVD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "blank Blu-ray disc"
+msgstr "cakera Blu-Ray kosong"
+
+#: panels/removable-media/cc-removable-media-panel.c:380
+msgid "blank CD disc"
+msgstr "cakera CD kosong"
+
+#: panels/removable-media/cc-removable-media-panel.c:381
+msgid "blank DVD disc"
+msgstr "cakera DVD kosong"
+
+#: panels/removable-media/cc-removable-media-panel.c:382
+msgid "blank HD DVD disc"
+msgstr "cakera DVD HD kosong"
+
+#: panels/removable-media/cc-removable-media-panel.c:383
+msgid "Blu-ray video disc"
+msgstr "Cakera video Blu-Ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:384
+msgid "e-book reader"
+msgstr "Pembaca e-buku"
+
+#: panels/removable-media/cc-removable-media-panel.c:385
+msgid "HD DVD video disc"
+msgstr "Cakera video DVD HD"
+
+#: panels/removable-media/cc-removable-media-panel.c:386
+msgid "Picture CD"
+msgstr "CD Gambar"
+
+#: panels/removable-media/cc-removable-media-panel.c:387
+msgid "Super Video CD"
+msgstr "CD Video Super"
+
+#: panels/removable-media/cc-removable-media-panel.c:388
+msgid "Video CD"
+msgstr "CD Video"
+
+#: panels/removable-media/cc-removable-media-panel.c:389
+msgid "Windows software"
+msgstr "Perisian Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:44
+msgid "Select how media should be handled"
+msgstr "Pilih bagaimana media harus dikendalikan"
+
+#: panels/removable-media/cc-removable-media-panel.ui:75
+msgid "CD _audio"
+msgstr "_Audio CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:92
+msgid "_DVD video"
+msgstr "Video _DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:133
+msgid "_Music player"
+msgstr "Pemain _muzik"
+
+#: panels/removable-media/cc-removable-media-panel.ui:191
+msgid "_Software"
+msgstr "P_erisian"
+
+#: panels/removable-media/cc-removable-media-panel.ui:229
+msgid "_Other Media…"
+msgstr "_Lain-lain Media…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:288
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Jangan maklum atau mulakan program semasa penyisipan media"
+
+#: panels/removable-media/cc-removable-media-panel.ui:342
+msgid "Select how other media should be handled"
+msgstr "Pilih bagaimana media lain harus dikendalikan"
+
+#: panels/removable-media/cc-removable-media-panel.ui:389
+msgid "_Action:"
+msgstr "Tindakan:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:412
+msgid "_Type:"
+msgstr "_Jenis:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Media Boleh Alih"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Konfigur Tetapan Media Boleh Alih"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"peranti;sistem;lalai;aplikasi;dikehendaki;cd;dvd;usb;audio;video;cakera;"
+"boleh alih;media;auto-jalan;"
+
+#: panels/search/cc-search-locations-dialog.c:635
+msgid "Select Location"
+msgstr "Pilih Lokasi"
+
+#: panels/search/cc-search-locations-dialog.c:639
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:9
+#: panels/search/cc-search-panel.ui:61
+msgid "Search Locations"
+msgstr "Gelintar Lokasi"
+
+#: panels/search/cc-search-locations-dialog.ui:32
+#: panels/search/cc-search-locations-dialog.ui:69
+#: panels/search/cc-search-locations-dialog.ui:107
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Folder-folder yang digelintar oleh aplikasi-aplikasi sistem, seperti Fail, "
+"Foto dan Video."
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Places"
+msgstr "Tempat"
+
+#: panels/search/cc-search-locations-dialog.ui:91
+msgid "Bookmarks"
+msgstr "Tanda Buku"
+
+#: panels/search/cc-search-locations-dialog.ui:156
+msgid "Other"
+msgstr "Lain-lain"
+
+#: panels/search/cc-search-panel.c:153
+msgid "No applications found"
+msgstr "Tiada aplikasi dijumpai"
+
+#: panels/search/cc-search-panel-row.ui:92
+msgid "Move Up"
+msgstr "Bergerak ke Atas"
+
+#: panels/search/cc-search-panel-row.ui:102
+msgid "Move Down"
+msgstr "Bergerak ke Bawah"
+
+#: panels/search/cc-search-panel.ui:33
+msgid ""
+"Control which search results are shown in the Activities Overview. The order "
+"of search results can also be changed by moving rows in the list."
+msgstr ""
+"Kawal keputusan gelintar yang manakah perlu ditunjukkan dalam Selayang "
+"Pandang Aktiviti. Tertib keputusan gelintar boleh diubah dengan mengerakkan "
+"baris-baris di dalam senarai."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Kawal aplikasi yang manakah tunjuk keputusan gelintar dalam Selayang Pandang "
+"Aktiviti"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Gelintar;Cari;Indeks;Sembunyi;Kerahsiaan;Keputusan;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:307
+msgid "No networks selected for sharing"
+msgstr "Tiada rangkaian terpilih untuk dikongsikan"
+
+#: panels/sharing/cc-sharing-networks.ui:19
+msgid "Networks"
+msgstr "Rangkaian"
+
+#: panels/sharing/cc-sharing-panel.c:320
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Hidup"
+
+#: panels/sharing/cc-sharing-panel.c:322 panels/sharing/cc-sharing-panel.c:349
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Tutup"
+
+#: panels/sharing/cc-sharing-panel.c:352
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Dibenarkan"
+
+#: panels/sharing/cc-sharing-panel.c:355
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktif"
+
+#: panels/sharing/cc-sharing-panel.c:425
+msgid "Choose a Folder"
+msgstr "Pilih satu Folder"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:729
+#, c-format
+#| msgid ""
+#| "File Sharing allows you to share your Public folder with others on your "
+#| "current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Perkongsian Fail membolehkan anda berkongsi folder awam anda dengan orang "
+"lain pada rangkaian semasa anda melalui: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:735
+#, c-format
+#| msgid ""
+#| "When remote login is enabled, remote users can connect using the Secure "
+#| "Shell command:\n"
+#| "<a href=\"ssh %s\">ssh %s</a>"
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Bila daftar jauh dibenarkan, pengguna jauh boleh bersambung menggunakan "
+"perintah Shell Selamat:\n"
+"%s"
+
+#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:741
+#, c-format
+#| msgid ""
+#| "Screen sharing allows remote users to view or control your screen by "
+#| "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to %s"
+msgstr ""
+"Perkongsian skrin membolehkan pengguna jauh melihat atau mengawal skrin anda "
+"bila bersambung dengan %s"
+
+#: panels/sharing/cc-sharing-panel.c:846
+msgid "Copy"
+msgstr "Salin"
+
+#: panels/sharing/cc-sharing-panel.c:1299
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Perkongsian"
+
+#: panels/sharing/cc-sharing-panel.ui:34
+msgid "_Computer Name"
+msgstr "_Nama Komputer"
+
+#: panels/sharing/cc-sharing-panel.ui:94
+msgid "_File Sharing"
+msgstr "Perkongsian _Fail"
+
+#: panels/sharing/cc-sharing-panel.ui:139
+msgid "_Screen Sharing"
+msgstr "Perkongsian _Skrin"
+
+#: panels/sharing/cc-sharing-panel.ui:184
+msgid "_Media Sharing"
+msgstr "Perkongsian _Media"
+
+#: panels/sharing/cc-sharing-panel.ui:229
+msgid "_Remote Login"
+msgstr "Daftar Masuk _Jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:268
+msgid "Some services are disabled because of no network access."
+msgstr "Sesetengah perkhidmatan dilumpuhkan kerana tiada capaian rangkaian."
+
+#: panels/sharing/cc-sharing-panel.ui:286
+#: panels/sharing/cc-sharing-panel.ui:413
+msgid "File Sharing"
+msgstr "Perkongsian Fail"
+
+#: panels/sharing/cc-sharing-panel.ui:333
+msgid "_Require Password"
+msgstr "Pe_rlukan Kata Laluan"
+
+#: panels/sharing/cc-sharing-panel.ui:424
+#: panels/sharing/cc-sharing-panel.ui:494
+msgid "Remote Login"
+msgstr "Daftar Masuk Jauh"
+
+#: panels/sharing/cc-sharing-panel.ui:517
+#: panels/sharing/cc-sharing-panel.ui:763
+msgid "Screen Sharing"
+msgstr "Perkongsian Skrin"
+
+#: panels/sharing/cc-sharing-panel.ui:575
+msgid "_Allow connections to control the screen"
+msgstr "_Membolehkan sambungan supaya dapat mengawal skrin"
+
+#: panels/sharing/cc-sharing-panel.ui:620
+msgid "_Password:"
+msgstr "_Kata laluan:"
+
+#: panels/sharing/cc-sharing-panel.ui:650
+msgid "_Show Password"
+msgstr "Tunjuk Kata Laluan"
+
+#: panels/sharing/cc-sharing-panel.ui:681
+msgid "Access Options"
+msgstr "Pilihan Capaian"
+
+#: panels/sharing/cc-sharing-panel.ui:695
+msgid "_New connections must ask for access"
+msgstr "Sambungan _baharu mesti tanya dahulu untuk dapatkan capaian"
+
+#: panels/sharing/cc-sharing-panel.ui:713
+msgid "_Require a password"
+msgstr "Pe_lukan satu kata laluan"
+
+#: panels/sharing/cc-sharing-panel.ui:774
+#: panels/sharing/cc-sharing-panel.ui:868
+msgid "Media Sharing"
+msgstr "Perkongsian Media"
+
+#: panels/sharing/cc-sharing-panel.ui:807
+msgid "Share music, photos and videos over the network."
+msgstr "Kongsi muzik, gambar dan video melalui rangkaian."
+
+#: panels/sharing/cc-sharing-panel.ui:822
+msgid "Folders"
+msgstr "Folder"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Kawal apa yang anda mahu kongsikan dengan orang lain"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"kongsi;perkongsian;ssh;hos;nama;jauh;desktop;media;audio;video;gambar;foto;"
+"cereka;pelayan;penerap;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Benar atau lumpuhkan daftar masuk jauh"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Pengesahihan diperlukan untuk benar atau lumpuhkan daftar masuk jauh"
+
+#: panels/sound/cc-alert-chooser.c:151
+msgid "Custom"
+msgstr "Suai"
+
+#: panels/sound/cc-alert-chooser.ui:12 panels/sound/cc-alert-selector.ui:9
+msgid "Bark"
+msgstr "Nyalak"
+
+#: panels/sound/cc-alert-chooser.ui:19 panels/sound/cc-alert-selector.ui:15
+msgid "Drip"
+msgstr "Titisan"
+
+#: panels/sound/cc-alert-chooser.ui:26 panels/sound/cc-alert-selector.ui:21
+msgid "Glass"
+msgstr "Gelas"
+
+#: panels/sound/cc-alert-chooser.ui:33 panels/sound/cc-alert-selector.ui:27
+msgid "Sonar"
+msgstr "Sonar"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "Belakang"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "Hadapan"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Menguji %s"
+
+#: panels/sound/cc-output-test-dialog.ui:127
+msgid "Click a speaker to test"
+msgstr "Klik satu pembesar suara untuk diuji"
+
+# msgstr[1] ""
+#: panels/sound/cc-sound-panel.ui:29
+msgid "System Volume"
+msgstr "Volum Sistem"
+
+#: panels/sound/cc-sound-panel.ui:45
+msgid "Volume Levels"
+msgstr "Aras Volum"
+
+#: panels/sound/cc-sound-panel.ui:67
+msgid "Output"
+msgstr "Output"
+
+#: panels/sound/cc-sound-panel.ui:94
+msgid "Output Device"
+msgstr "Peranti Output"
+
+#: panels/sound/cc-sound-panel.ui:117
+msgid "Test"
+msgstr "Uji"
+
+#: panels/sound/cc-sound-panel.ui:148 panels/sound/cc-sound-panel.ui:325
+msgid "Configuration"
+msgstr "Konfigurasi"
+
+#: panels/sound/cc-sound-panel.ui:181
+msgid "Balance"
+msgstr "Imbangan"
+
+#: panels/sound/cc-sound-panel.ui:208
+msgid "Fade"
+msgstr "Resap"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Subwoofer"
+msgstr "Subwufer"
+
+#: panels/sound/cc-sound-panel.ui:257
+msgid "Input"
+msgstr "Input"
+
+#: panels/sound/cc-sound-panel.ui:284
+msgid "Input Device"
+msgstr "Peranti Input"
+
+#: panels/sound/cc-sound-panel.ui:358
+msgid "Volume"
+msgstr "Volum"
+
+#: panels/sound/cc-sound-panel.ui:380
+msgid "Alert Sound"
+msgstr "Bunyi Amaran"
+
+#: panels/sound/cc-volume-slider.c:115
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Bunyi"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Ubah aras bunyi, input, output, dan bunyi amaran"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kad;Mikrofon;Volum;Resap;Imbangan;Bluetooth;Set Kepala;Audio;Output;Input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:94
+#: panels/thunderbolt/cc-bolt-device-entry.c:125
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Terputus"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:97
+#: panels/thunderbolt/cc-bolt-device-entry.c:128
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Menyambung"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:100
+#: panels/thunderbolt/cc-bolt-device-entry.c:132
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Bersambung"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:103
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Ralat Keizinan"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:106
+#: panels/thunderbolt/cc-bolt-device-entry.c:138
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Mengizinkan"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Kefungisan Terkurang"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:115
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Bersambung & Diizinkan"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:121
+#: panels/thunderbolt/cc-bolt-device-entry.c:152
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Tidak diketahui"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:177
+msgid "Authorized at:"
+msgstr "Diizinkan pada:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:183
+msgid "Connected at:"
+msgstr "Bersambung pada:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:190
+msgid "Enrolled at:"
+msgstr "Berdaftar pada:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:264
+msgid "Failed to authorize device: "
+msgstr "Gagal izinkan peranti: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:333
+msgid "Failed to forget device: "
+msgstr "Gagal melupakan peranti: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Bergantung pada %u peranti lain"
+msgstr[1] "Bergantung pada %u peranti lain"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+msgid "Name:"
+msgstr "Nama:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "Status:"
+msgstr "Status:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+msgid "Authorize and Connect"
+msgstr "Izin dan Sambung"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+msgid "Forget Device"
+msgstr "_Lupakan Peranti"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:135
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Ralat"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:146
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Diizinkan"
+
+#: panels/thunderbolt/cc-bolt-panel.c:176
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Sub-sistem Thunderbolt (boltd) tidak dipasang atau disediakan dengan baik."
+
+#: panels/thunderbolt/cc-bolt-panel.c:469
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt tidak dapat dikesan.\n"
+"Sama ada sistem kekurangan sokongan Thunderbolt, ia telah dilumpuhkan dalam "
+"BIOS atau telah ditetapkan dengan aras keselamatan tidak disokong dalam BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:513
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Sokongan Thunderbolt telah dilumpuhkan dalam BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:517
+msgid "Thunderbolt security level could not be determined."
+msgstr "Aras keselamatan Thunderbolt tidak dapat ditentukan."
+
+#: panels/thunderbolt/cc-bolt-panel.c:622
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Ralat beralih ke mod terus: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:143
+msgid "No Thunderbolt support"
+msgstr "Tiada sokongan Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:246
+msgid "Direct Access"
+msgstr "Capaian Terus"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:269
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Benarkan capaian terus ke peranti seperti dock dan GPU luar."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:289
+msgid "Only USB and Display Port devices can attach."
+msgstr "Hanya peranti Port USB dan Paparan boleh dipalamkan."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:397
+msgid "Pending Devices"
+msgstr "Peranti Tertangguh"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:535
+msgid "No devices attached"
+msgstr "Tiada peranti dipalam"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Urus peranti-peranti Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;"
+msgstr "Thunderbolt;"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:500
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Lalai"
+
+#: panels/universal-access/cc-ua-panel.c:503
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Sederhana"
+
+#: panels/universal-access/cc-ua-panel.c:506
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Besar"
+
+#: panels/universal-access/cc-ua-panel.c:509
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Lebih Besae"
+
+#: panels/universal-access/cc-ua-panel.c:512
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Terbesar"
+
+#: panels/universal-access/cc-ua-panel.c:516
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d piksel"
+msgstr[1] "%d piksel"
+
+#: panels/universal-access/cc-ua-panel.ui:78
+msgid "_Always Show Universal Access Menu"
+msgstr "S_entiasa Tunjuk Menu Capaian Universal"
+
+#: panels/universal-access/cc-ua-panel.ui:120
+msgid "Seeing"
+msgstr "Melihat"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "_High Contrast"
+msgstr "Beza _Jelas Tinggi"
+
+#: panels/universal-access/cc-ua-panel.ui:213
+msgid "_Large Text"
+msgstr "Teks _Besar"
+
+#: panels/universal-access/cc-ua-panel.ui:258
+msgid "C_ursor Size"
+msgstr "Saiz _Suai"
+
+#: panels/universal-access/cc-ua-panel.ui:305
+#: panels/universal-access/zoom-options.ui:99
+msgid "_Zoom"
+msgstr "_Zum"
+
+#: panels/universal-access/cc-ua-panel.ui:351
+msgid "Screen _Reader"
+msgstr "Pemba_ca Skrin"
+
+#: panels/universal-access/cc-ua-panel.ui:397
+#: panels/universal-access/cc-ua-panel.ui:1263
+msgid "_Sound Keys"
+msgstr "Kekunci Bun_yi"
+
+#: panels/universal-access/cc-ua-panel.ui:459
+msgid "Hearing"
+msgstr "Pendengaran"
+
+#: panels/universal-access/cc-ua-panel.ui:503
+#: panels/universal-access/cc-ua-panel.ui:1366
+msgid "_Visual Alerts"
+msgstr "Amaran _Visual"
+
+#: panels/universal-access/cc-ua-panel.ui:611
+msgid "Screen _Keyboard"
+msgstr "Papan _Kekunci Skrin"
+
+#: panels/universal-access/cc-ua-panel.ui:656
+msgid "R_epeat Keys"
+msgstr "Kekunci _Ulang"
+
+#: panels/universal-access/cc-ua-panel.ui:702
+msgid "Cursor _Blinking"
+msgstr "Kerlipan K_ursor"
+
+#: panels/universal-access/cc-ua-panel.ui:748
+msgid "_Typing Assist (AccessX)"
+msgstr "Bantuan Me_naip (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:809
+msgid "Pointing & Clicking"
+msgstr "Menuju &  Mengklik"
+
+#: panels/universal-access/cc-ua-panel.ui:855
+msgid "_Mouse Keys"
+msgstr "Kekunci T_etikus"
+
+#: panels/universal-access/cc-ua-panel.ui:900
+msgid "_Locate Pointer"
+msgstr "_Cari Penuding"
+
+#: panels/universal-access/cc-ua-panel.ui:932
+msgid "_Click Assist"
+msgstr "Bantuan _Klik"
+
+#: panels/universal-access/cc-ua-panel.ui:978
+msgid "_Double-Click Delay"
+msgstr "Lengah _Dwi-Klik"
+
+#: panels/universal-access/cc-ua-panel.ui:998
+msgid "Double-Click Delay"
+msgstr "Lengah Dwi-Klik"
+
+#: panels/universal-access/cc-ua-panel.ui:1068
+msgid "Cursor Size"
+msgstr "Saiz Kursor"
+
+#: panels/universal-access/cc-ua-panel.ui:1095
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Saiz kursor boleh digabungkan dengan zum supaya lebih mudah melihat kursor "
+"tersebut."
+
+#: panels/universal-access/cc-ua-panel.ui:1131
+msgid "Screen Reader"
+msgstr "Pembaca Skrin"
+
+#: panels/universal-access/cc-ua-panel.ui:1148
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Pembaca skrin membaca teks yang terpapar bila anda gerakkan fokus."
+
+#: panels/universal-access/cc-ua-panel.ui:1181
+msgid "_Screen Reader"
+msgstr "Pembaca _Skrin"
+
+#: panels/universal-access/cc-ua-panel.ui:1220
+msgid "Sound Keys"
+msgstr "Kekunci Bunyi"
+
+#: panels/universal-access/cc-ua-panel.ui:1238
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Bunyi bip bila kekunci Num Lock atau Caps Lock dihidupkan atau dimatikan."
+
+#: panels/universal-access/cc-ua-panel.ui:1308
+msgid "Visual Alerts"
+msgstr "Amaran Visual"
+
+#: panels/universal-access/cc-ua-panel.ui:1312
+msgid "_Test flash"
+msgstr "_Uji kerlipan"
+
+#: panels/universal-access/cc-ua-panel.ui:1341
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Guna satu penunjuk visual bila bunyi amaran muncul."
+
+#: panels/universal-access/cc-ua-panel.ui:1392
+msgid "Flash the entire _window"
+msgstr "Denyar keseluruhan _tetingkap"
+
+#: panels/universal-access/cc-ua-panel.ui:1410
+msgid "Flash the entire _screen"
+msgstr "Denyarkan keseluruhan _skrin"
+
+#: panels/universal-access/cc-ua-panel.ui:1455
+msgid "Repeat Keys"
+msgstr "Kekunci Ulang"
+
+#: panels/universal-access/cc-ua-panel.ui:1485
+msgid "Key presses repeat when key is held down."
+msgstr "Kekunci ditekan berulang apabila kekunci ditahan."
+
+#: panels/universal-access/cc-ua-panel.ui:1565
+msgid "Repeat keys delay"
+msgstr "Lengah kekunci berulang"
+
+#: panels/universal-access/cc-ua-panel.ui:1613
+#: panels/universal-access/cc-ua-panel.ui:1748
+msgid "Speed"
+msgstr "Kelajuan"
+
+#: panels/universal-access/cc-ua-panel.ui:1652
+msgid "Repeat keys speed"
+msgstr "Ulangan kelajuan kekunci"
+
+#: panels/universal-access/cc-ua-panel.ui:1676
+msgid "Cursor Blinking"
+msgstr "Kerlipan Kursor"
+
+#: panels/universal-access/cc-ua-panel.ui:1706
+msgid "Cursor blinks in text fields."
+msgstr "Kerlipan kursor dalam medan teks."
+
+#: panels/universal-access/cc-ua-panel.ui:1785
+msgid "Cursor blinking speed"
+msgstr "Kelajuan kerlipan kursor"
+
+#: panels/universal-access/cc-ua-panel.ui:1821
+msgid "Typing Assist"
+msgstr "Bantuan Menaip"
+
+#: panels/universal-access/cc-ua-panel.ui:1860
+msgid "_Sticky Keys"
+msgstr "Kekunci _Lekat"
+
+#: panels/universal-access/cc-ua-panel.ui:1877
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Anggap jujukan kekunci pengubah suai sebagai satu gabungan kekunci"
+
+#: panels/universal-access/cc-ua-panel.ui:1901
+msgid "_Disable if two keys are pressed together"
+msgstr "_Lumpuhkan jika dua kekunci ditekan serentak"
+
+#: panels/universal-access/cc-ua-panel.ui:1919
+msgid "Beep when a _modifier key is pressed"
+msgstr "Bunyi bip bila kekunci _pengubah suai ditekan"
+
+#: panels/universal-access/cc-ua-panel.ui:1967
+msgid "S_low Keys"
+msgstr "Kekunci La_mbat"
+
+#: panels/universal-access/cc-ua-panel.ui:1984
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Letakkan lengahan diantaranya bila kekunci ditekan dan bila ia diterima"
+
+#: panels/universal-access/cc-ua-panel.ui:2017
+#: panels/universal-access/cc-ua-panel.ui:2230
+#: panels/universal-access/cc-ua-panel.ui:2567
+msgid "A_cceptance delay:"
+msgstr "Lengah p_enerimaan:"
+
+#: panels/universal-access/cc-ua-panel.ui:2039
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Pendek"
+
+#: panels/universal-access/cc-ua-panel.ui:2058
+msgid "Slow keys typing delay"
+msgstr "Lengah menaip kekunci lambat"
+
+#: panels/universal-access/cc-ua-panel.ui:2073
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Panjang"
+
+#: panels/universal-access/cc-ua-panel.ui:2100
+msgid "Beep when a key is pr_essed"
+msgstr "Bip bila kekunci dit_ekan"
+
+#: panels/universal-access/cc-ua-panel.ui:2117
+msgid "Beep when a key is _accepted"
+msgstr "Bip bila kekunci diterim_a"
+
+#: panels/universal-access/cc-ua-panel.ui:2134
+#: panels/universal-access/cc-ua-panel.ui:2313
+msgid "Beep when a key is _rejected"
+msgstr "Bip bila kekunci dit_olak"
+
+#: panels/universal-access/cc-ua-panel.ui:2180
+msgid "_Bounce Keys"
+msgstr "Kekunci La_ntun"
+
+#: panels/universal-access/cc-ua-panel.ui:2197
+msgid "Ignores fast duplicate keypresses"
+msgstr "Abaikan penekanan kekunci berganda yang pantas"
+
+#: panels/universal-access/cc-ua-panel.ui:2252
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Pendek"
+
+#: panels/universal-access/cc-ua-panel.ui:2271
+msgid "Bounce keys typing delay"
+msgstr "Lengahan menaip kekunci lantun"
+
+#: panels/universal-access/cc-ua-panel.ui:2286
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Panjang"
+
+#: panels/universal-access/cc-ua-panel.ui:2399
+msgid "_Enable by Keyboard"
+msgstr "D_ibenarkan oleh Papan Kekunci"
+
+#: panels/universal-access/cc-ua-panel.ui:2416
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Hidupkan dan matikan fitur-fitur kebolehcapaian melalui papan kekunci"
+
+#: panels/universal-access/cc-ua-panel.ui:2480
+msgid "Click Assist"
+msgstr "Bantuan Klik"
+
+#: panels/universal-access/cc-ua-panel.ui:2516
+msgid "_Simulated Secondary Click"
+msgstr "Klik Sekunder Ter_simulasi"
+
+#: panels/universal-access/cc-ua-panel.ui:2534
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Picu satu klik kedua bila butang utama ditekan tanpa lepas"
+
+#: panels/universal-access/cc-ua-panel.ui:2588
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Pendek"
+
+#: panels/universal-access/cc-ua-panel.ui:2607
+msgid "Secondary click delay"
+msgstr "Lengah klik sekunder"
+
+#: panels/universal-access/cc-ua-panel.ui:2622
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Panjang"
+
+#: panels/universal-access/cc-ua-panel.ui:2679
+msgid "_Hover Click"
+msgstr "Klik A_pung"
+
+#: panels/universal-access/cc-ua-panel.ui:2697
+msgid "Trigger a click when the pointer hovers"
+msgstr "Picu satu klik bila penuding terapung di atasnya"
+
+#: panels/universal-access/cc-ua-panel.ui:2730
+msgid "D_elay:"
+msgstr "L_engah:"
+
+#: panels/universal-access/cc-ua-panel.ui:2752
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Pendek"
+
+#: panels/universal-access/cc-ua-panel.ui:2783
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Panjang"
+
+#: panels/universal-access/cc-ua-panel.ui:2819
+msgid "Motion _threshold:"
+msgstr "A_mbang gerakan:"
+
+#: panels/universal-access/cc-ua-panel.ui:2841
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Kecil"
+
+#: panels/universal-access/cc-ua-panel.ui:2872
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Besar"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Jadikannya mudah dilihat, didengar, ditaip, tuju dan diklik"
+
+#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
+"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
+"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+msgstr ""
+"Papan Kekunci;Tetikus;a11y;Kebolehcapaian;Beza Jelas;Kursor;Bunyi;Zum;Skrin;"
+"Pembaca;besar;tinggi;lebih besar;teks;fon;saiz;AccessX;Lekat;Kekunci;Lambat;"
+"Lantun;Tetikus;Dwi;klik;Lengah;Kelajuan;Bantuan;Ulang;Kerlipan;visual;"
+"pendengaran;audio;menaip;"
+
+#: panels/universal-access/zoom-options.c:305
+msgctxt "Distance"
+msgid "Short"
+msgstr "Pendek"
+
+#: panels/universal-access/zoom-options.c:306
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼  Skrin"
+
+#: panels/universal-access/zoom-options.c:307
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ Skrin"
+
+#: panels/universal-access/zoom-options.c:308
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ Skrin"
+
+#: panels/universal-access/zoom-options.c:309
+msgctxt "Distance"
+msgid "Long"
+msgstr "Panjang"
+
+#: panels/universal-access/zoom-options.ui:48
+msgid "Full Screen"
+msgstr "Skrin Penuh"
+
+#: panels/universal-access/zoom-options.ui:53
+msgid "Top Half"
+msgstr "Separuh Atas"
+
+#: panels/universal-access/zoom-options.ui:58
+msgid "Bottom Half"
+msgstr "Separuh Bawah"
+
+#: panels/universal-access/zoom-options.ui:63
+msgid "Left Half"
+msgstr "Separuh Kiri"
+
+#: panels/universal-access/zoom-options.ui:68
+msgid "Right Half"
+msgstr "Separuh Kanan"
+
+#: panels/universal-access/zoom-options.ui:78
+msgid "Zoom Options"
+msgstr "Pilihan Zum"
+
+#: panels/universal-access/zoom-options.ui:185
+msgid "_Magnification:"
+msgstr "Pe_mbesaran:"
+
+#: panels/universal-access/zoom-options.ui:249
+msgid "_Follow mouse cursor"
+msgstr "_Ikuti kursor tetikus"
+
+#: panels/universal-access/zoom-options.ui:269
+msgid "_Screen part:"
+msgstr "Bahagian _skrin:"
+
+#: panels/universal-access/zoom-options.ui:331
+msgid "Magnifier _extends outside of screen"
+msgstr "Pembesar _melangkaui luar skrin"
+
+#: panels/universal-access/zoom-options.ui:350
+msgid "_Keep magnifier cursor centered"
+msgstr "_Biar kursor pembesar ditengah-tengah"
+
+#: panels/universal-access/zoom-options.ui:370
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Kursor pembesar me_nolak kandungan disekitarnya"
+
+#: panels/universal-access/zoom-options.ui:390
+msgid "Magnifier cursor moves with _contents"
+msgstr "Kursor pembesar bergerak dengan _kandungan"
+
+#: panels/universal-access/zoom-options.ui:425
+msgid "Magnifier Position:"
+msgstr "Kedudukan Pembesar:"
+
+#: panels/universal-access/zoom-options.ui:446
+msgid "Magnifier"
+msgstr "Pembesar"
+
+#: panels/universal-access/zoom-options.ui:493
+msgid "_Thickness:"
+msgstr "Ke_tebalan:"
+
+#: panels/universal-access/zoom-options.ui:519
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Nipis"
+
+#: panels/universal-access/zoom-options.ui:551
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Tebal"
+
+#: panels/universal-access/zoom-options.ui:577
+msgid "_Length:"
+msgstr "_Jangka masa:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/zoom-options.ui:626
+msgid "Co_lor:"
+msgstr "_Warna:"
+
+#: panels/universal-access/zoom-options.ui:690
+msgid "_Crosshairs:"
+msgstr "_Rerambut Silang:"
+
+#: panels/universal-access/zoom-options.ui:738
+msgid "_Overlaps mouse cursor"
+msgstr "_Tindan kursor tetikus"
+
+#: panels/universal-access/zoom-options.ui:776
+msgid "Crosshairs"
+msgstr "Rerambut Silang"
+
+#: panels/universal-access/zoom-options.ui:825
+msgid "_White on black:"
+msgstr "Putih atas hitam:"
+
+#: panels/universal-access/zoom-options.ui:845
+msgid "_Brightness:"
+msgstr "_Kecerahan:"
+
+#: panels/universal-access/zoom-options.ui:866
+msgid "_Contrast:"
+msgstr "_Beza Jelas:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/zoom-options.ui:886
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Warna"
+
+#: panels/universal-access/zoom-options.ui:911
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Tiada"
+
+#: panels/universal-access/zoom-options.ui:943
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Penuh"
+
+#: panels/universal-access/zoom-options.ui:1006
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Rendah"
+
+#: panels/universal-access/zoom-options.ui:1039
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Tinggi"
+
+#: panels/universal-access/zoom-options.ui:1070
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Rendah"
+
+#: panels/universal-access/zoom-options.ui:1103
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Tinggi"
+
+#: panels/universal-access/zoom-options.ui:1139
+msgid "Color Effects:"
+msgstr "Kesan Warna:"
+
+#: panels/universal-access/zoom-options.ui:1164
+msgid "Color Effects"
+msgstr "Kesan Warna"
+
+#: panels/usage/cc-usage-panel.c:155
+msgid "Empty all items from Trash?"
+msgstr "Kosongkan semua item dari tong sampah?"
+
+#: panels/usage/cc-usage-panel.c:156
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Semua item di dalam Tong Sampah akan dipadam secara kekal."
+
+#: panels/usage/cc-usage-panel.c:157
+msgid "_Empty Trash"
+msgstr "Kosongkan _Tong Sampah"
+
+#: panels/usage/cc-usage-panel.c:178
+msgid "Delete all the temporary files?"
+msgstr "Padam semua fail sementara?"
+
+#: panels/usage/cc-usage-panel.c:179
+msgid "All the temporary files will be permanently deleted."
+msgstr "Semua fail sementara akan dipadam secara kekal."
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "_Purge Temporary Files"
+msgstr "S_ingkir Fail Sementara"
+
+#: panels/usage/cc-usage-panel.ui:31
+msgid "File History"
+msgstr "Sejarah Fail"
+
+#: panels/usage/cc-usage-panel.ui:43
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Sejarah fail menyimpan satu rekod fail yang anda telah gunakan. Maklumat ini "
+"dikongsi antara aplikasi, dan ia memudahkan pencarian fail yang anda mahu "
+"guna."
+
+#: panels/usage/cc-usage-panel.ui:58
+msgid "File H_istory"
+msgstr "Se_jarah Fail"
+
+#: panels/usage/cc-usage-panel.ui:80
+msgid "File _History Duration"
+msgstr "Jangka Masa Se_jarah Fail"
+
+#: panels/usage/cc-usage-panel.ui:121
+msgid "_Clear History…"
+msgstr "_Kosongkan Sejarah…"
+
+#: panels/usage/cc-usage-panel.ui:137
+msgid "Trash & Temporary Files"
+msgstr "Fail dalam Tong Sampah & Sementara"
+
+#: panels/usage/cc-usage-panel.ui:147
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Fail dalam tong sampah dan sementara kadang kala mengandungi maklumat "
+"peribadi atau sensitif. Pemadaman secara automatik dapat melindungi "
+"kerahsiaan."
+
+#: panels/usage/cc-usage-panel.ui:161
+msgid "Automatically Delete _Trash Content"
+msgstr "Padam Kandungan _Tong Sampah secara Automatik"
+
+#: panels/usage/cc-usage-panel.ui:176
+msgid "Automatically Delete Temporary _Files"
+msgstr "Padam _Fail Sementara secara Automatik"
+
+#: panels/usage/cc-usage-panel.ui:198
+msgid "Automatically Delete _Period"
+msgstr "_Tempoh Pemadaman Automatik"
+
+#: panels/usage/cc-usage-panel.ui:240
+msgid "_Empty Trash…"
+msgstr "Kosongkan Tong _Sampah…"
+
+#: panels/usage/cc-usage-panel.ui:252
+msgid "_Delete Temporary Files…"
+msgstr "Pa_dam Fail Sementara…"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:280
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 jam"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:284
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 hari"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:288
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 hari"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:292
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 hari"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:296
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 hari"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:300
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 hari"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:304
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 hari"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:308
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 hari"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:312
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 hari"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:316
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 hari"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:331
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 hari"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:335
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 hari"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:339
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 hari"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:343
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Selamanya"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Sejarah & Tong Sampah Fail"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Jangan tinggalkan jejak"
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "Patut padankan alamat sesawang bagi penyedia daftar masuk anda."
+
+#: panels/user-accounts/cc-add-user-dialog.c:205
+msgid "Failed to add account"
+msgstr "Gagal menambah akaun"
+
+#: panels/user-accounts/cc-add-user-dialog.c:676
+#: panels/user-accounts/cc-password-dialog.c:261
+msgid "The passwords do not match."
+msgstr "Katalaluan tidak padan."
+
+#: panels/user-accounts/cc-add-user-dialog.c:898
+#: panels/user-accounts/cc-add-user-dialog.c:944
+#: panels/user-accounts/cc-add-user-dialog.c:965
+msgid "Failed to register account"
+msgstr "Gagal mendaftarkan akaun"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1088
+msgid "No supported way to authenticate with this domain"
+msgstr "Tiada cara yang disokong untuk sahihkan domain ini"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1161
+msgid "Failed to join domain"
+msgstr "Gagal menyertai domain"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1222
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Nama daftar masuk tidak berfungsi baik.\n"
+"Cuba sekali lagi."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1229
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Kata laluan daftar masuk tidak berfungsi baik.\n"
+"Cuba sekali lagi."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1237
+msgid "Failed to log into domain"
+msgstr "Gagal mendaftar masuk ke dalam domain"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1295
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Tidak dapat mencari domain. Mungkin anda tersilap eja?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "Tambah Pengguna"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:180
+msgid "_Full Name"
+msgstr "Nama _Penuh"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:206
+#: panels/user-accounts/cc-user-panel.ui:141
+msgid "Standard"
+msgstr "Piawai"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-user-panel.ui:151
+msgid "Administrator"
+msgstr "Pentadbir"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:232
+#: panels/user-accounts/cc-user-panel.ui:169
+msgid "Account _Type"
+msgstr "_Jenis Akaun"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:269
+msgid "Allow user to set a password when they next _login"
+msgstr ""
+"Benarkan pengguna menetapkan satu kata laluan ketika mereka mendaftar _masuk"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:283
+msgid "Set a password _now"
+msgstr "Tetapkan satu kata laluan _sekarang"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:405
+msgid "_Confirm"
+msgstr "Sa_hkan"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:485
+#: panels/user-accounts/cc-add-user-dialog.ui:692
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Daftar masuk Enterprise membolehkan satu akaun pengguna diurus secara "
+"berpusat digunakan pada peranti ini. Anda juga boleh menggunakan akaun ini "
+"untuk mencapai sumber-sumber syarikat di internet."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:732
+msgid "You are Offline"
+msgstr "Anda berada di Luar Talian"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:751
+msgid "You must be online in order to add enterprise users."
+msgstr ""
+"Anda mesti berada dalam talian supaya dapat menambah pengguna enterprise."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:782
+msgid "_Enterprise Login"
+msgstr "Daftar Masuk _Enterprise"
+
+#: panels/user-accounts/cc-avatar-chooser.c:232
+msgid "Browse for more pictures"
+msgstr "Layar untuk dapatkan lagi gambar"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:39
+msgid "Take a Picture…"
+msgstr "_Tangkap satu Gambar…"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:46
+msgid "Select a File…"
+msgstr "Pilih satu Fail…"
+
+#: panels/user-accounts/cc-login-history-dialog.c:69
+msgid "This Week"
+msgstr "Minggu Ini"
+
+#: panels/user-accounts/cc-login-history-dialog.c:72
+msgid "Last Week"
+msgstr "Minggu Lepas"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:82
+#: panels/user-accounts/cc-login-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:91
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:96
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:173
+#: panels/user-accounts/cc-user-panel.c:765
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:176
+#: panels/user-accounts/cc-user-panel.c:769
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:243
+msgid "Session Ended"
+msgstr "Sesi Tamat"
+
+#: panels/user-accounts/cc-login-history-dialog.c:249
+msgid "Session Started"
+msgstr "Sesi Bermula"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:343
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Aktiviti Akaun"
+
+#: panels/user-accounts/cc-password-dialog.c:125
+msgid "Please choose another password."
+msgstr "Sila pilih kata laluan yang lain."
+
+#: panels/user-accounts/cc-password-dialog.c:134
+msgid "Please type your current password again."
+msgstr "Sila taip kata laluan semasa anda sekali lagi."
+
+#: panels/user-accounts/cc-password-dialog.c:140
+msgid "Password could not be changed"
+msgstr "Kata laluan tidak dapat diubah"
+
+#: panels/user-accounts/cc-password-dialog.ui:7
+msgid "Change Password"
+msgstr "Ubah Kata Laluan"
+
+#: panels/user-accounts/cc-password-dialog.ui:37
+msgid "Ch_ange"
+msgstr "_Ubah"
+
+#: panels/user-accounts/cc-password-dialog.ui:145
+msgid "_Confirm New Password"
+msgstr "_Sahkan Kata Laluan Baharu"
+
+#: panels/user-accounts/cc-password-dialog.ui:162
+msgid "_New Password"
+msgstr "Kata Laluan _Baharu"
+
+#: panels/user-accounts/cc-password-dialog.ui:216
+msgid "Current _Password"
+msgstr "_Kata Laluan Semasa"
+
+#: panels/user-accounts/cc-password-dialog.ui:254
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Benarkan pengguna mengubah kata laluan mereka pada daftar masuk berikutnya"
+
+#: panels/user-accounts/cc-password-dialog.ui:267
+msgid "Set a password now"
+msgstr "Tetapkan satu kata laluan sekarang"
+
+#: panels/user-accounts/cc-realm-manager.c:307
+msgid "Cannot automatically join this type of domain"
+msgstr "Tidak dapat sertai jenis domain ini secara automatik"
+
+#: panels/user-accounts/cc-realm-manager.c:310
+msgid "No such domain or realm found"
+msgstr "Tiada domain atau wilayah sebegitu ditemui"
+
+#: panels/user-accounts/cc-realm-manager.c:732
+#: panels/user-accounts/cc-realm-manager.c:746
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Tidak dapat daftar masuk sebagai %s pada domain %s"
+
+#: panels/user-accounts/cc-realm-manager.c:738
+msgid "Invalid password, please try again"
+msgstr "Kata laluan tidak sah, sila cuba lagi"
+
+#: panels/user-accounts/cc-realm-manager.c:751
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Tidak dapat bersambung dengan domain %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:208
+msgid "Your account"
+msgstr "Akaun anda"
+
+#: panels/user-accounts/cc-user-panel.c:383
+msgid "Failed to delete user"
+msgstr "Gagal memadam pengguna"
+
+#: panels/user-accounts/cc-user-panel.c:441
+#: panels/user-accounts/cc-user-panel.c:500
+#: panels/user-accounts/cc-user-panel.c:552
+msgid "Failed to revoke remotely managed user"
+msgstr "Gagal menyeru pengguna terurus secara jauh"
+
+#: panels/user-accounts/cc-user-panel.c:604
+msgid "You cannot delete your own account."
+msgstr "Anda tidak dapat memadam akaun anda."
+
+#: panels/user-accounts/cc-user-panel.c:613
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s masih mendaftar masuk"
+
+#: panels/user-accounts/cc-user-panel.c:617
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Memadam seorang pengguna ketika mereka masih mendaftar masuk boleh "
+"menyebabkan sistem dalam keadaan tidak seragam."
+
+#: panels/user-accounts/cc-user-panel.c:626
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Anda pasti mahu mengekalkan fail-fail %s?"
+
+#: panels/user-accounts/cc-user-panel.c:630
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Adalah mungkin dapat kekalkan direktori rumah, spul mel dan fail sementara "
+"ketika memadam satu kaun pengguna."
+
+#: panels/user-accounts/cc-user-panel.c:633
+msgid "_Delete Files"
+msgstr "Pa_dam Fail"
+
+#: panels/user-accounts/cc-user-panel.c:634
+msgid "_Keep Files"
+msgstr "_Kekalkan Fail"
+
+#: panels/user-accounts/cc-user-panel.c:648
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Anda pasti mahu menarik balik akaun %s yang diurus secara jauh?"
+
+#: panels/user-accounts/cc-user-panel.c:652
+msgid "_Delete"
+msgstr "Pa_dam"
+
+#: panels/user-accounts/cc-user-panel.c:702
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Akaun dilumpuhkan"
+
+#: panels/user-accounts/cc-user-panel.c:710
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Akan ditetapkan pada daftar masuk berikutnya"
+
+#: panels/user-accounts/cc-user-panel.c:713
+msgctxt "Password mode"
+msgid "None"
+msgstr "Tiada"
+
+#: panels/user-accounts/cc-user-panel.c:758
+msgid "Logged in"
+msgstr "Telah daftar masuk"
+
+#: panels/user-accounts/cc-user-panel.c:1092
+msgid "Failed to contact the accounts service"
+msgstr "Gagal menghubungi perkhidmatan akaun"
+
+#: panels/user-accounts/cc-user-panel.c:1094
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Sila pastikan AccountService dipasang dan dibenarkan."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/cc-user-panel.c:1126
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Untuk membuat perubahan,\n"
+"klik ikon * dahuku"
+
+#: panels/user-accounts/cc-user-panel.c:1199
+msgid "Create a user account"
+msgstr "Cipta satu akaun pengguna"
+
+#: panels/user-accounts/cc-user-panel.c:1210
+#: panels/user-accounts/cc-user-panel.c:1338
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Untuk mencipta satu akaun pengguna,\n"
+"klik pada ikon * dahulu"
+
+#: panels/user-accounts/cc-user-panel.c:1219
+msgid "Delete the selected user account"
+msgstr "Padam akaun pengguna terpilih"
+
+#: panels/user-accounts/cc-user-panel.c:1231
+#: panels/user-accounts/cc-user-panel.c:1342
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Untuk memadam akaun pengguna terpilih,\n"
+"klik pada ikon * dahulu"
+
+#: panels/user-accounts/cc-user-panel.ui:5
+msgid "_Add User…"
+msgstr "T_ambah Pengguna…"
+
+#: panels/user-accounts/cc-user-panel.ui:52
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Sesi anda perlu dimulakan semula supaya perubahan yang dibuat berkesan"
+
+#: panels/user-accounts/cc-user-panel.ui:60
+msgid "Restart Now"
+msgstr "Mula Semula Sekarang"
+
+#: panels/user-accounts/cc-user-panel.ui:244
+msgid "A_utomatic Login"
+msgstr "Daftar Masuk A_utomatik"
+
+#: panels/user-accounts/cc-user-panel.ui:286
+msgid "_Fingerprint Login"
+msgstr "Daftar Masuk _Cap jari"
+
+#: panels/user-accounts/cc-user-panel.ui:312
+#: panels/user-accounts/cc-user-panel.ui:328
+msgid "User Icon"
+msgstr "Ikon Pengguna"
+
+#: panels/user-accounts/cc-user-panel.ui:392
+msgid "Last Login"
+msgstr "Daftar Masuk Terakhir"
+
+#: panels/user-accounts/cc-user-panel.ui:441
+msgid "Remove User…"
+msgstr "Buang Pengguna…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:471
+msgid "No Users Found"
+msgstr "Tidak Pengguna Ditemui"
+
+#: panels/user-accounts/cc-user-panel.ui:481
+msgid "Unlock to add a user account."
+msgstr "Buka untuk menambah satu akaun pengguna."
+
+#: panels/user-accounts/data/account-fingerprint.ui:12
+msgid "Left thumb"
+msgstr "Ibu jari kiri"
+
+#: panels/user-accounts/data/account-fingerprint.ui:15
+msgid "Left middle finger"
+msgstr "Jari tengah kiri"
+
+#: panels/user-accounts/data/account-fingerprint.ui:18
+msgid "Left ring finger"
+msgstr "Jari manis kiri"
+
+#: panels/user-accounts/data/account-fingerprint.ui:21
+msgid "Left little finger"
+msgstr "Jari anak kiri"
+
+#: panels/user-accounts/data/account-fingerprint.ui:24
+msgid "Right thumb"
+msgstr "Ibu jari kanan"
+
+#: panels/user-accounts/data/account-fingerprint.ui:27
+msgid "Right middle finger"
+msgstr "Jari tengah kanan"
+
+#: panels/user-accounts/data/account-fingerprint.ui:30
+msgid "Right ring finger"
+msgstr "Jari manis kanan"
+
+#: panels/user-accounts/data/account-fingerprint.ui:33
+msgid "Right little finger"
+msgstr "Jari anak"
+
+#: panels/user-accounts/data/account-fingerprint.ui:39
+#: panels/user-accounts/um-fingerprint-dialog.c:677
+msgid "Enable Fingerprint Login"
+msgstr "Benarkan Daftar Masuk Cap Jari"
+
+#: panels/user-accounts/data/account-fingerprint.ui:89
+msgid "_Right index finger"
+msgstr "Jari tengah _kanan"
+
+#: panels/user-accounts/data/account-fingerprint.ui:105
+msgid "_Left index finger"
+msgstr "Jari tengah k_iri"
+
+#: panels/user-accounts/data/account-fingerprint.ui:126
+msgid "_Other finger:"
+msgstr "Jari _lain:"
+
+#: panels/user-accounts/data/account-fingerprint.ui:324
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"Cap jari anda berjaya disimpan. Sekarang, anda boleh mendaftar masuk "
+"menggunakan pembaca cap jari anda."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Pengguna"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Tambah atau buang pengguna dan ubah kata laluan anda"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Daftar Masuk;Nama;Cap Jari;Avatar;Logo;Wajah;Kata Laluan;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr "_Daftar"
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "Daftar Masuk Pentadbir Domain"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Untuk menggunakan daftar masuk enterprise, komputer ini\n"
+"perlu didaftarkan ke dalam domain. Sila pastikan pentadbir\n"
+"rangkaian anda menaip kata laluan domain mereka di sini."
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "_Nama Pentadbir"
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "Kata Laluan Pentadbir"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Urus akaun pengguna"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Pengesahihan diperlukan untuk mengubah data pengguna"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Kata laluan baharu perlu berbeza dengan yang lama."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Cuba tukar beberapa abjad dan nombor."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Cuba tukar lagi kata laluan tersebut."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Kata laluan tanpa nama pengguna anda adalah lebih kuat."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Cuba hindari penggunaan  nama anda di dalam kata laluan."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Cuba hindari beberapa perkataan yang disertakan di dalam kata laluan."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Cuba hindari perkataan umum."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Cuba hindari menertib semula perkataan sedia ada."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Cuba guna lebih nombor."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Cuba guna lebih huruf besar."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Cuba guna lebih huruf kecil."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Cuba guna lebih aksara khas, seperti tanda baca."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Cuba guna gabungan abjad, nombor dan tanda baca."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Cuba hindari pengulangan aksara yang sama."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Cuba hindari pengulangan jenis aksara yang sama: anda perlu campurkan abjad, "
+"nombor dan tanda baca."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Cuba hindari jujukan seperti 1234 atau abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Kata laluan perlu lebih panjang. Cuba tambah lagi abjad, nombor atau tanda "
+"baca."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Campurkan huruf besar dan huruf kecil dan cuba masukkan beberapa angka."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Menambah lagi abjad, angka dan tanda baca dapat mengukuhkan kata laluan."
+
+#: panels/user-accounts/run-passwd.c:424
+msgid "Authentication failed"
+msgstr "Pengesahihan gagal"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The new password is too short"
+msgstr "Kata laluan baharu terlalu pendek"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password is too simple"
+msgstr "Kata laluan terlalu ringkas"
+
+#: panels/user-accounts/run-passwd.c:516
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Kata laluan lama dan baharu adalah hampir sama"
+
+#: panels/user-accounts/run-passwd.c:519
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Kata laluan sudah digunakan baru-baru ini."
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Kata laluan baharu mesti mengandungi aksara angka atau khas"
+
+#: panels/user-accounts/run-passwd.c:526
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Kata laluan lama dan baharu adalah serupa"
+
+#: panels/user-accounts/run-passwd.c:530
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Kata laluan anda telah berubah semenjak anda mula sahihkan!"
+
+#: panels/user-accounts/run-passwd.c:534
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Kata laluan baharu tidak mengandungi aksara yang mencukupi"
+
+#: panels/user-accounts/run-passwd.c:538
+#, c-format
+msgid "Unknown error"
+msgstr "Ralat tidak diketahui"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"Anda tidak tidak dibenarkan mencapai peranti. Sila hubungi pentadbir sistem "
+"anda."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "Peranti sedang digunakan."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr "Satu ralat dalaman berlaku."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Enabled"
+msgstr "Dibenarkan"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:260
+msgid "Delete registered fingerprints?"
+msgstr "Padam cap jari berdaftar?"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:264
+msgid "_Delete Fingerprints"
+msgstr "_Padam Cap Jari"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:270
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Anda pasti mahu memadam cap jari berdaftar anda supaya daftar masuk cap jari "
+"boleh dilumpuhkan?"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:440
+msgid "Done!"
+msgstr "Selesai!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:501
+#: panels/user-accounts/um-fingerprint-dialog.c:543
+#, c-format
+msgid "Could not access “%s” device"
+msgstr "Tidak dapat mencapai peranti \"%s\""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:584
+#, c-format
+msgid "Could not start finger capture on “%s” device"
+msgstr "Tidak dapat memulakan imbasan cap jari pada peranti \"%s\""
+
+#: panels/user-accounts/um-fingerprint-dialog.c:628
+msgid "Could not access any fingerprint readers"
+msgstr "Tidak dapat mencapai mana-mana pembaca cap jari"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:629
+msgid "Please contact your system administrator for help."
+msgstr "Sila hubungi pentadbir sistem anda untuk dapatkan bantuan."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: panels/user-accounts/um-fingerprint-dialog.c:711
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the “%s” device."
+msgstr ""
+"Untuk membenarkan daftar masuk cap jari, anda perlu simpan salah satu cap "
+"jari anda, menggunakan peranti \"%s\"."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:718
+msgid "Selecting finger"
+msgstr "Memilih jari"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:719
+msgid "Enrolling fingerprints"
+msgstr "Mendaftarkan cap jari"
+
+#: panels/user-accounts/user-utils.c:439
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Nama pengguna biasanya hanya mengandungi abjad berhuruf kecil iaitu a-z, "
+"digit dan aksara-aksara berikut: - _"
+
+#: panels/user-accounts/user-utils.c:443
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Maaf, nama pengguna tidak tersedia. Sila cuba lagi."
+
+#: panels/user-accounts/user-utils.c:488
+msgid "The username is too long."
+msgstr "Nama pengguna telalu panjang."
+
+#: panels/user-accounts/user-utils.c:550
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr ""
+"Ia akan digunakan untuk menamakan folder rumah anda dan tidak boleh diubah."
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr "Petakan Butang"
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "T_utup"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr "Butang peta ke fungsi"
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Untuk menyunting satu pintasan, pilih tindakan \"Hantar Ketukan Kekunci\", "
+"tekan butang pintasan papan kekunci dan tahan kekunci-kekunci baharu atau "
+"tekan Backspace untuk kosongkan."
+
+#: panels/wacom/calibrator/calibrator.ui:61
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Sila ketik penanda sasaran supaya ia muncul pada skrin untuk tentukur tablet."
+
+#: panels/wacom/calibrator/calibrator.ui:78
+msgid "Mis-click detected, restarting…"
+msgstr "Tersilap-klik dikesan, memulakan semula…"
+
+#: panels/wacom/cc-wacom-button-row.c:249
+#, c-format
+msgid "Button %d"
+msgstr "Butang %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplikasi ditakrif"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Hantar Ketukan Kekunci"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Tukar Monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Tunjuk Bantuan Atas-Skrin"
+
+#: panels/wacom/cc-wacom-mapping-panel.c:249
+msgid "Output:"
+msgstr "Output:"
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:261
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Kekalkan nisbah bidang (peti surat):"
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:272
+msgid "Map to single monitor"
+msgstr "Petakan ke monitor tunggal"
+
+#: panels/wacom/cc-wacom-nav-button.c:84
+#, c-format
+msgid "%d of %d"
+msgstr "%d daripada %d"
+
+#: panels/wacom/cc-wacom-page.c:516
+msgid "Display Mapping"
+msgstr "Pemetaan Paparan"
+
+#: panels/wacom/cc-wacom-panel.c:812 panels/wacom/wacom-stylus-page.ui:119
+msgid "Stylus"
+msgstr "Stilus"
+
+#: panels/wacom/cc-wacom-stylus-page.c:360
+msgid "Button"
+msgstr "Butang"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:200
+msgid "Wacom Tablet"
+msgstr "Tablet Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Tetapkan pemetaan butang dan laras kepekaan stilus untuk tablet grafik"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stilus;Pemadam;Tetikus;"
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr "Tablet (mutlak)"
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr "Pad Sesentuh (relatif)"
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr "Keutamaan Tablet"
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "_Bantuan"
+
+#: panels/wacom/gnome-wacom-properties.ui:125
+msgid "No tablet detected"
+msgstr "Tiada tablet dikesan"
+
+#: panels/wacom/gnome-wacom-properties.ui:141
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Sila palam masuk atau hidupkan tablet Wacom anda"
+
+#: panels/wacom/gnome-wacom-properties.ui:161
+msgid "Bluetooth Settings"
+msgstr "Tetapan Bluetooth"
+
+#: panels/wacom/gnome-wacom-properties.ui:238
+msgid "Tracking Mode"
+msgstr "Mod Menjejak"
+
+#: panels/wacom/gnome-wacom-properties.ui:266
+msgid "Left-Handed Orientation"
+msgstr "Orientasi Kidal"
+
+#: panels/wacom/gnome-wacom-properties.ui:296
+#: panels/wacom/gnome-wacom-properties.ui:401
+msgid "Map to Monitor…"
+msgstr "Petakan untuk Pantau…"
+
+#: panels/wacom/gnome-wacom-properties.ui:309
+msgid "Map Buttons…"
+msgstr "Butang Peta…"
+
+#: panels/wacom/gnome-wacom-properties.ui:322
+msgid "Calibrate…"
+msgstr "Tentukur…"
+
+#: panels/wacom/gnome-wacom-properties.ui:340
+msgid "Adjust mouse settings"
+msgstr "Laras tetapan tetikus"
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Adjust display resolution"
+msgstr "Laras resolusi paparan"
+
+#: panels/wacom/gnome-wacom-properties.ui:376
+msgid "Decouple Display"
+msgstr "Nyahpasang Paparan"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
+msgid "New shortcut…"
+msgstr "Pintasan baharu…"
+
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "Lalai"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr "Klik Butang Tengah Tetikus"
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr "Klik Butang Kanan Tetikus"
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "Maju"
+
+#: panels/wacom/wacom-stylus-page.ui:79
+msgid "No stylus found"
+msgstr "Tiada stilus ditemui"
+
+#: panels/wacom/wacom-stylus-page.ui:93
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr ""
+"Sila alih stilus anda berdekatan dengan tablet untuk mengkonfigurkannya"
+
+#: panels/wacom/wacom-stylus-page.ui:159
+msgid "Eraser Pressure Feel"
+msgstr "Rasa Tekanan Eraser"
+
+#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
+msgid "Soft"
+msgstr "Lembut"
+
+#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
+msgid "Firm"
+msgstr "Kukuh"
+
+#: panels/wacom/wacom-stylus-page.ui:234
+msgid "Top Button"
+msgstr "Butang Atas"
+
+#: panels/wacom/wacom-stylus-page.ui:263
+msgid "Lower Button"
+msgstr "Butang Bawah"
+
+#: panels/wacom/wacom-stylus-page.ui:292
+msgid "Lowest Button"
+msgstr "Butang Paling Rendah"
+
+#: panels/wacom/wacom-stylus-page.ui:321
+msgid "Tip Pressure Feel"
+msgstr "Rasa Tekanan di Hujung"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+msgid "GNOME Settings"
+msgstr "Tetapan GNOME"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utiliti untuk mengkonfigur atas meja GNOME"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Tetapan ialah antara muka utama untuk Mengkonfigur sistem anda."
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:20
+msgid "The GNOME Project"
+msgstr "Projek GNOME"
+
+#: shell/cc-application.c:58
+msgid "Display version number"
+msgstr "Papar nombor versi"
+
+#: shell/cc-application.c:59
+msgid "Enable verbose mode"
+msgstr "Benarkan mod berjela"
+
+#: shell/cc-application.c:60
+msgid "Search for the string"
+msgstr "Gelintar rentetan"
+
+#: shell/cc-application.c:61
+msgid "List possible panel names and exit"
+msgstr "Senaraikan nama panel yang mungkin kemudian keluar"
+
+#: shell/cc-application.c:62
+msgid "Panel to display"
+msgstr "Panel untuk dipaparkan"
+
+#: shell/cc-application.c:62
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMEN…]"
+
+#: shell/cc-panel-list.ui:45 shell/cc-window.c:277
+msgid "Privacy"
+msgstr "Kerahsiaan"
+
+#: shell/cc-panel-loader.c:292
+msgid "Available panels:"
+msgstr "Panel tersedia:"
+
+#: shell/cc-window.ui:140
+msgid "All Settings"
+msgstr "Semua Tetapan"
+
+#: shell/cc-window.ui:178
+msgid "Primary Menu"
+msgstr "Menu Utama"
+
+#: shell/cc-window.ui:319
+msgid "Warning: Development Version"
+msgstr "Amaran Versi Pembangunan"
+
+#: shell/cc-window.ui:320
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Versi Tetapan ini hanya patut digunakan untuk tujuan pembangunan. Anda "
+"mungkin menghadapi kelakuan sistem yang bermasalah, kehilangan data, dan "
+"lain-lain masalah tidak dijangka. "
+
+#: shell/cc-window.ui:331
+msgid "Help"
+msgstr "Bantuan"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Keutamaan;Tetapan;"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Am"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Keluar"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Gelintar"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panel"
+
+#: shell/help-overlay.ui:40
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Undur ke panel terdahulu"
+
+#: shell/help-overlay.ui:53
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Batal gelintar"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Pengecam untuk panel Tetapan terakhir yang akan dibuka"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Pengecam untuk panel Tetapan terakhir yang akan dibuka. Nilai tidak dikenal "
+"pasti akan diabaikan dan panel pertama dalam senarai dipilih."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Tunjuk amaran ketika menjalankan Tetapan versi binaan pembangunan"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Sama ada Tetapan patut menunjukkan satu amaran ketika menjalankan binaan "
+"pembangunan."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1883
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u Output"
+msgstr[1] "%u Output"
+
+# msgstr[1] "%u Output"
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1893
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u Input"
+msgstr[1] "%u Input"
+
+# msgstr[1] ""
+#: subprojects/gvc/gvc-mixer-control.c:2750
+msgid "System Sounds"
+msgstr "Bunyi Sistem"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Hadkan pengguna data _balik tabir"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Sesuai untuk sambungan dengan data terhad."
+
+#~ msgid "No regions found"
+#~ msgstr "Tiada wilayah ditemui"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Perubahan sepanjang hari"
+
+#, fuzzy
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "_Fail"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zum"
+
+#, fuzzy
+#~| msgid "Center"
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Tengah"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Penuh"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Jangkau"
+
+#, fuzzy
+#~| msgid "No Wallpaper"
+#~ msgid "Wallpapers"
+#~ msgstr "Tiada Kertas Dinding"
+
+#~ msgid "Colors"
+#~ msgstr "Warna"
+
+#~ msgid "Pictures"
+#~ msgstr "Gambar"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Anda boleh tambahkan imej ke folder %s dan imej tersebut akan muncul "
+#~ "disini"
+
+#, fuzzy
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "Nama pengguna telalu panjang."
+
+#, fuzzy
+#~| msgid "Done!"
+#~ msgid "Done"
+#~ msgstr "Selesai!"
+
+#~ msgid "United States"
+#~ msgstr "Amerika Syarikat"
+
+#, fuzzy
+#~| msgid "Appearance"
+#~ msgid "France"
+#~ msgstr "Penampilan"
+
+#~ msgid "Spain"
+#~ msgstr "Sepanyol"
+
+#~ msgid "China"
+#~ msgstr "China"
+
+#, fuzzy
+#~| msgid "_Language:"
+#~ msgid "Language"
+#~ msgstr "_Bahasa:"
+
+#, fuzzy
+#~ msgid "Time _Zone"
+#~ msgstr "Masa berbaki: %s"
+
+#, fuzzy
+#~ msgid "Lid Closed"
+#~ msgstr "Tutup monitor laptop"
+
+#, fuzzy
+#~ msgid "Mirrored"
+#~ msgstr "Penuhkan Skrin"
+
+#, fuzzy
+#~| msgid "seconds"
+#~ msgid "Secondary"
+#~ msgstr "saat"
+
+#, fuzzy
+#~| msgid "Size:"
+#~ msgid "Size"
+#~ msgstr "Saiz"
+
+#, fuzzy
+#~ msgid "Presentation"
+#~ msgstr "<b>Orientasi Tetikus</b>"
+
+#, fuzzy
+#~ msgid "Could not get screen information"
+#~ msgstr "Tidak dapat senarai kemaskini distribusi"
+
+#, fuzzy
+#~| msgid "Action"
+#~ msgid "Section"
+#~ msgstr "Aksi"
+
+#, fuzzy
+#~| msgid "Preview:"
+#~ msgid "Overview"
+#~ msgstr "Tunjuk gambaran keseluruhan"
+
+#, fuzzy
+#~| msgid "Version:"
+#~ msgid "Version %s"
+#~ msgstr "Cetak versi GDM"
+
+#, fuzzy
+#~| msgid "File System"
+#~ msgid "Base system"
+#~ msgstr "Bunyi Sistem"
+
+#, fuzzy
+#~ msgid "Check for updates"
+#~ msgstr "Cari rentetan"
+
+#~ msgid "Keyboard"
+#~ msgstr "Papan Kekunci"
+
+#, fuzzy
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Ulangan kelajuan kekunci"
+
+#~ msgid "C_ommand:"
+#~ msgstr "A_rahan:"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Lengahan:"
+
+#, fuzzy
+#~| msgid "Short"
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Pendek"
+
+#, fuzzy
+#~| msgid "Slow"
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Lambat"
+
+#, fuzzy
+#~| msgid "Long"
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Panjang"
+
+#, fuzzy
+#~| msgid "Fast"
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Laju"
+
+#~ msgid "S_peed:"
+#~ msgstr "Ke_lajuan:"
+
+#, fuzzy
+#~| msgid "Shortcut"
+#~ msgid "Add Shortcut"
+#~ msgstr "Pintasan Penyesuaian"
+
+#, fuzzy
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr "Taip pemecut baru, atau tekan Backspace untuk terangkan"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Aksi Tidak diketahui>"
+
+#, fuzzy
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Pintasan  \"%s\" telah digunakan oleh:\n"
+#~ "\"%s\"\n"
+
+#, fuzzy
+#~| msgid "Default Settings"
+#~ msgid "Test Your Settings"
+#~ msgstr "Betulkan tetapan tetikus"
+
+#, fuzzy
+#~| msgid "Slow"
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Lambat"
+
+#, fuzzy
+#~| msgid "Fast"
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Laju"
+
+#, fuzzy
+#~| msgid "Left"
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "Kiri"
+
+#, fuzzy
+#~| msgid "Right"
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "Kanan"
+
+#, fuzzy
+#~ msgid "_Pointer speed"
+#~ msgstr "Ulangan kelajuan kekunci"
+
+#, fuzzy
+#~| msgid "Slow"
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lambat"
+
+#, fuzzy
+#~| msgid "Fast"
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Laju"
+
+#, fuzzy
+#~| msgid "Slow"
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lambat"
+
+#, fuzzy
+#~| msgid "Fast"
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Laju"
+
+#, fuzzy
+#~ msgid "Disable while _typing"
+#~ msgstr "Memboleh atau melumpuhkan log masuk dari jauh"
+
+#, fuzzy
+#~| msgid "page"
+#~ msgid "page 1"
+#~ msgstr "laman"
+
+#, fuzzy
+#~| msgid "<b>_Use authentication</b>"
+#~ msgid "Inner _authentication"
+#~ msgstr "Had dibenarkan untuk kegagalan pengesahan"
+
+#, fuzzy
+#~| msgid "page"
+#~ msgid "page 2"
+#~ msgstr "laman"
+
+#, fuzzy
+#~ msgid "Delete DNS Server"
+#~ msgstr "Padam cap jari didaftarkan?"
+
+#, fuzzy
+#~| msgid "Default"
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Default"
+
+#, fuzzy
+#~ msgid "(none)"
+#~ msgstr "Tiada"
+
+#, fuzzy
+#~| msgid "_FTP proxy:"
+#~ msgid "Proxy"
+#~ msgstr "Proksi _FTP:"
+
+#, fuzzy
+#~| msgid "None"
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Tiada"
+
+#, fuzzy
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatik"
+
+#, fuzzy
+#~| msgid "Full Name"
+#~ msgid "Group Name"
+#~ msgstr "Nama Komputer"
+
+#, fuzzy
+#~| msgid "_Details"
+#~ msgid "details"
+#~ msgstr "Keterangan"
+
+#, fuzzy
+#~| msgid "_Password:"
+#~ msgid "Show P_assword"
+#~ msgstr "Tunjuk katalaluan"
+
+#, fuzzy
+#~ msgid "Link-local only"
+#~ msgstr "Hanya arahan VERSION yang disokong"
+
+#, fuzzy
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "XDMCP: Tidak dapat menghurai alamat"
+
+#, fuzzy
+#~ msgid "Not connected"
+#~ msgstr "Katalaluan tidak padan."
+
+#, fuzzy
+#~| msgid "Ignored Hosts"
+#~ msgid "Ignore"
+#~ msgstr "Abaikan kemaskini ini"
+
+#, fuzzy
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Pilih katalaluan yang lain."
+
+#, fuzzy
+#~| msgid "None"
+#~ msgid "No"
+#~ msgstr "Tiada Tindakan"
+
+#, fuzzy
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Tunjuk pilihan bantuan"
+
+#, fuzzy
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "Papar _ikon pada menu"
+
+#, fuzzy
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Kunci Skrin"
+
+#, fuzzy
+#~ msgid "Add Account"
+#~ msgstr "Gagal untuk menambah akaun"
+
+#, fuzzy
+#~| msgid "KMail"
+#~ msgid "Mail"
+#~ msgstr "KMail"
+
+#, fuzzy
+#~| msgid "Contact"
+#~ msgid "Contacts"
+#~ msgstr "Hubungi"
+
+#, fuzzy
+#~ msgid "_Sign In"
+#~ msgstr "Kamera web bina dalam"
+
+#, fuzzy
+#~| msgid "Error creating signal pipe."
+#~ msgid "Error creating account"
+#~ msgstr "Cipta satu akaun pengguna"
+
+#, fuzzy
+#~ msgid "Power off"
+#~ msgstr "Pengurusan kuasa"
+
+#, fuzzy
+#~| msgid "Install"
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Pasang"
+
+#, fuzzy
+#~ msgid "No printers available"
+#~ msgstr "Tiada Latar Belakang Desktop"
+
+#, fuzzy
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "Aktif"
+
+#, fuzzy
+#~ msgid "Pause Printing"
+#~ msgstr "<b>Orientasi Tetikus</b>"
+
+#, fuzzy
+#~ msgid "Add a New Printer"
+#~ msgstr "Gagal untuk menambah akaun"
+
+#, fuzzy
+#~ msgid "No printers detected."
+#~ msgstr "Tiada tablet dikesan"
+
+#, fuzzy
+#~| msgid "_Title:"
+#~ msgid "Job Title"
+#~ msgstr "_Tajuk:"
+
+#, fuzzy
+#~| msgid "_Timeout:"
+#~ msgid "Time"
+#~ msgstr "Masa berbaki: %s"
+
+#, fuzzy
+#~ msgid "Show _Jobs"
+#~ msgstr "Tunjuk katalaluan"
+
+#, fuzzy
+#~ msgid "Setting new driver…"
+#~ msgstr "- Login GDM baharu"
+
+#, fuzzy
+#~| msgid "page"
+#~ msgid "page 3"
+#~ msgstr "laman"
+
+#, fuzzy
+#~ msgid "Print _Test Page"
+#~ msgstr "Cetak versi GDM"
+
+#, fuzzy
+#~| msgid "_Options..."
+#~ msgid "_Options"
+#~ msgstr "Pilihan"
+
+#, fuzzy
+#~ msgid "Add New Printer"
+#~ msgstr "Gagal untuk menambah akaun"
+
+#, fuzzy
+#~ msgid "_Recently Used"
+#~ msgstr "Digunakan oleh %s "
+
+#~ msgid "Switch to next source"
+#~ msgstr "Tukar ke sumber seterusnya"
+
+#~ msgid "Options"
+#~ msgstr "Pilihan"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Lain-lain"
+
+#~ msgid "Preferences"
+#~ msgstr "Keutamaan"
+
+#, fuzzy
+#~ msgid "Allow Remote Control"
+#~ msgstr "Memboleh atau melumpuhkan log masuk dari jauh"
+
+#~ msgid "Password:"
+#~ msgstr "Katalaluan:"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Mengecilkan"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maksimum"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Bunyi biasa"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profail:"
+
+#, fuzzy
+#~ msgid "_Test Speakers"
+#~ msgstr "Profail ujian:"
+
+#~ msgid "Peak detect"
+#~ msgstr "Kesan Puncak"
+
+#~ msgid "Device"
+#~ msgstr "Peranti"
+
+#, fuzzy
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Cari rentetan"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Pilih peranti untuk output bunyi:"
+
+#, fuzzy
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Cipta profail warna untuk peranti yang dipilih."
+
+#, fuzzy
+#~ msgid "_Input volume:"
+#~ msgstr "Volume mute"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Pilih peranti untuk input bunyi:"
+
+#, fuzzy
+#~| msgid "Sound Events"
+#~ msgid "Sound Effects"
+#~ msgstr "Keutamaan Bunyi"
+
+#, fuzzy
+#~ msgid "Built-in"
+#~ msgstr "Kamera web bina dalam"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Keutamaan Bunyi"
+
+#, fuzzy
+#~| msgid "Icon theme"
+#~ msgid "From theme"
+#~ msgstr "Tema ikon"
+
+#, fuzzy
+#~| msgid "Choose a Layout"
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Pilih Susunan"
+
+#, fuzzy
+#~| msgid "Flash _window titlebar"
+#~ msgid "Flash the _window title"
+#~ msgstr "Pengurusan dan penggubahan tetingkap"
+
+#~ msgid "Zoom"
+#~ msgstr "Zum"
+
+#~| msgid "Colors"
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Warna"
+
+#, fuzzy
+#~| msgid "_New password:"
+#~ msgid "_Verify New Password"
+#~ msgstr "Pilih katalaluan yang lain."
+
+#, fuzzy
+#~ msgid "Add User Account"
+#~ msgstr "Cipta satu akaun pengguna"
+
+#, fuzzy
+#~| msgid "Stretch"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Kualiti Rendah"
+
+#, fuzzy
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Kualiti Tinggi"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Katalaluan tidak padan."
+
+#~ msgid "Disable image"
+#~ msgstr "Lumpuhkan imej"
+
+#~ msgid "Used by %s"
+#~ msgstr "Digunakan oleh %s "
+
+#~ msgid "Other Accounts"
+#~ msgstr "Lain-lain Akaun"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Keatas"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Kebawah"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Tiada"
+
+#~ msgid "Left Ring"
+#~ msgstr "Cincin Kiri"
+
+#, fuzzy
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Mod Cincin Kanan #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Mod Cincin Kanan #%d"
+
+#, fuzzy
+#~ msgid "Left Touchstrip"
+#~ msgstr "Ibu jari kiri"
+
+#, fuzzy
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Benarkan mod panjang lebar"
+
+#, fuzzy
+#~ msgid "Right Touchstrip"
+#~ msgstr "Ibu jari kanan"
+
+#, fuzzy
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Mod Cincin Kanan #%d"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Tukar Mod #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Butang Kiri  #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Butang Kanan  #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Butang Atas #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Butang Bawah  #%d"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Skrol ke atas"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Skrol Ke Bawah"
+
+#~ msgid "Scroll Left"
+#~ msgstr "Skrol Ke Kiri"
+
+#~ msgid "Show the overview"
+#~ msgstr "Tunjuk gambaran keseluruhan"
+
+#~ msgid "Show help options"
+#~ msgstr "Tunjuk pilihan bantuan"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Peribadi"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistem"
+
+#~ msgid "More themes URL"
+#~ msgstr "Lagi URL tema"
+
+#~ msgid "Image/label border"
+#~ msgstr "Imej/label batasan"
+
+#, fuzzy
+#~ msgid "The type of alert"
+#~ msgstr "Jenis pemecut ."
+
+#~ msgid "Show more _details"
+#~ msgstr "Tunjuk perincian butiran"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "Letakkan ibu jari kiri pada %s"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "Letakkan jari telunjuk kiri anda pada %s"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "Letakkan jari tengah kiri pada %s"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "Letakkan jari manis kiri anda pada %s"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "Letakkan jari anak kiri anda pada %s"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "Letakkan jari ibu kanan anda pada %s"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "Letakkan jari tengah kanan anda pada %s"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "Letakkan jari tengah kanan anda pada %s"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "Letakkan jari manis kanan anda pada %s"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "Letakkan jari anak kanan anda pada %s"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "Letakkan jari anda pada pemgimbas sekali lagi"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "Jari anda tidak ditengahkan, sila lalukan sekali lagi jari anda"
+
+#~ msgid "No Image"
+#~ msgstr "Tiada Imej"
+
+#~ msgid "About %s"
+#~ msgstr "Perihal %s"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "A_lamat:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "P_embantu"
+
+#~ msgid "About Me"
+#~ msgstr "Perihal Saya"
+
+#~ msgid "C_ity:"
+#~ msgstr "B_andar:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "S_yarikat:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Tukar Katalal_uan..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Ban_dar:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "Ne_gara:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "Neg_ara:"
+
+#~ msgid "Email"
+#~ msgstr "Emel"
+
+#~ msgid "Hom_e:"
+#~ msgstr "Rum_ah:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "Mesej Instan"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _box:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. box:"
+
+#~ msgid "Select your photo"
+#~ msgstr "Pilih gambar anda"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Negeri/Wilayah:"
+
+#~ msgid "Web"
+#~ msgstr "Laman Sesawang"
+
+#~ msgid "Web _log:"
+#~ msgstr "Log _Laman Sesawang:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "Ker_ja"
+
+#~ msgid "Work"
+#~ msgstr "Kerja"
+
+#~ msgid "Work _fax:"
+#~ msgstr "Faks _kerja:"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "ZIP/_Poskod:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Laman Sesawang Rumah"
+
+#~ msgid "_Home:"
+#~ msgstr "_Rumah:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Pengurus:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_Negeri/Wilayah:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Kerja:"
+
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "_ZIP/Poskod:"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "Letakkan jari pada pembaca"
+
+#~ msgid "System error: %s."
+#~ msgstr "Ralat sistem: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "Tidak dapat lancarkan %s: %s"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "Ralat sistem telah berlaku"
+
+#~ msgid "Checking password..."
+#~ msgstr "Menyemak katalaluan"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "Kilik <b>Tukar katalaluan</b> untuk menukar katalaluan anda"
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "Sila taip katalaluan dalam <b>Katalaluan baru</b> ruang."
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "Sila taip katalaluan sekali lagi dalam <b>Taip semula katalaluan</b> "
+#~ "ruang."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "Tukar ka_talaluan"
+
+#~ msgid "Change your password"
+#~ msgstr "Tukar katalaluan anda"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "Kebolehcapaikan Lo_g masuk"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "Aplikasi Teknologi Penolong"
+
+#, fuzzy
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Keutamaan Aplikasi Teknologi Penolong"
+
+#, fuzzy
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "<small><i><b>Nota:</b> Perubahan kepada tetapan ini tak akan "
+#~ "bertindakbalas sehingga anda log masuk kelak.</i></small>"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Tutup dan _Log Keluar"
+
+#, fuzzy
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Aplikasi Digemari"
+
+#, fuzzy
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "_Hidupkan ciri-ciri kebolehcapaian Papan Kekunci"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Lompat ke dialog Aksesibiliti Tetikus"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Hidupkan teknologi pertolongan"
+
+#~ msgid "_Keyboard Accessibility"
+#~ msgstr "_Kebolehcapaikan Papankekunci"
+
+#, fuzzy
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "Keboleh_capaikan"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "_Aplikasi Digemari"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Tambah Kertas Dinding"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Font mungkin terlalu besar"
+
+#~ msgid "Use previous font"
+#~ msgstr "Guna fon terdahulu"
+
+#~ msgid "Use selected font"
+#~ msgstr "Guna fon dipilih"
+
+#, fuzzy
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Tiada lokasi fail tema dinyatakan untuk dipasang"
+
+#~ msgid "Apply Background"
+#~ msgstr "Terapkan Latar Belakang"
+
+#~ msgid "Apply Font"
+#~ msgstr "Terapkan Fon"
+
+#~ msgid "Revert Font"
+#~ msgstr "Kembalikan Fon"
+
+#, fuzzy
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "Tema ini mencadangkan latarbelakang:"
+
+#, fuzzy
+#~ msgid "The current theme suggests a background."
+#~ msgstr "Tema ini mencadangkan latarbelakang:"
+
+#, fuzzy
+#~ msgid "The current theme suggests a font."
+#~ msgstr "Tema ini mencadangkanfont:"
+
+#, fuzzy
+#~ msgid "Appearance Preferences"
+#~ msgstr "Keutamaan Tema"
+
+#~ msgid "Best _shapes"
+#~ msgstr "_Bentuk terbaik"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "_Kontras terbaik"
+
+#, fuzzy
+#~ msgid "C_ustomize..."
+#~ msgstr "Tersendiri"
+
+#~ msgid "Controls"
+#~ msgstr "Kawalan"
+
+#, fuzzy
+#~ msgid "Customize Theme"
+#~ msgstr "Tema tersendiri"
+
+#~ msgid "D_etails..."
+#~ msgstr "P_erincian..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Fon _desktop:"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "Perincian Rendering Font"
+
+#~ msgid "Fonts"
+#~ msgstr "Fon"
+
+#~ msgid "Get more themes online"
+#~ msgstr "Dapatkan lagi tema secara online"
+
+#, fuzzy
+#~ msgid "Gra_yscale"
+#~ msgstr "Skala _kelabu"
+
+#~ msgid "Hinting"
+#~ msgstr "Bayangang"
+
+#~ msgid "Horizontal gradient"
+#~ msgstr "Gradien mengufuk"
+
+#~ msgid "Icons"
+#~ msgstr "Ikon"
+
+#~ msgid "Icons only"
+#~ msgstr "Ikon sahaja"
+
+#~ msgid "N_one"
+#~ msgstr "_Tiada"
+
+#, fuzzy
+#~ msgid "R_esolution:"
+#~ msgstr "_Resolusi:"
+
+#, fuzzy
+#~ msgid "Save Theme As..."
+#~ msgstr "_Simpan Tema..."
+
+#~ msgid "Save _As..."
+#~ msgstr "Simpan _Sebagai..."
+
+#~ msgid "Solid color"
+#~ msgstr "Warna tegar"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sub_piksel (LCD)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "Turutan subpiksel"
+
+#~ msgid "Text"
+#~ msgstr "Teks"
+
+#~ msgid "Text below items"
+#~ msgstr "Teks dibawah item"
+
+#~ msgid "Text beside items"
+#~ msgstr "Teks di sebelah item"
+
+#~ msgid "Text only"
+#~ msgstr "Teks sahaja"
+
+#~ msgid "Theme"
+#~ msgstr "Tema"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "Vertical gradient"
+#~ msgstr "Gradien menegak"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "_Keterangan:"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Fon desktop:"
+
+#, fuzzy
+#~ msgid "_Fixed width font:"
+#~ msgstr "Font tajuk _tetingkap:"
+
+#~ msgid "_Install..."
+#~ msgstr "_Pasang..."
+
+#~ msgid "_Medium"
+#~ msgstr "_Medium"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Monokrom"
+
+#~ msgid "_None"
+#~ msgstr "_Tiada"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#, fuzzy
+#~ msgid "_Reset to Defaults"
+#~ msgstr "Ulangtetap ke de_fault"
+
+#, fuzzy
+#~ msgid "_Selected items:"
+#~ msgstr "_Susunatur dipilih:"
+
+#~ msgid "_Size:"
+#~ msgstr "_Saiz:"
+
+#~ msgid "_Style:"
+#~ msgstr "_Gaya:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "Font tajuk _tetingkap:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Tetingkap:"
+
+#~ msgid "dots per inch"
+#~ msgstr "dot per inci"
+
+#, fuzzy
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Pilih tema bagi desktop"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Pilih pakej tema bagi pelbagai bahagian pada dekstop"
+
+#~ msgid "Theme Installer"
+#~ msgstr "Pemasang Tema"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Pakej Tema GNOME"
+
+#~ msgid "Image"
+#~ msgstr "Imej"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "Tidak dapat pasang tema"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "Utiliti %s tidak dipasang."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "Terdapat ralat pasang fail dipilih"
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "Pemasangan tema \"%s\" gagal."
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Kekal Tema Terkini"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Terapkan Tema Baru"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "Tema baru berjaya dipasang"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Tiada lokasi fail tema dinyatakan untuk dipasang"
+
+#~ msgid "Select Theme"
+#~ msgstr "Pilih Tema"
+
+#~ msgid "Theme Packages"
+#~ msgstr "Tema Pakej"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Nama tema mesti ada"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Adakah anda ingin memadam tema ini?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "Tidak dapat pasang enjin tema"
+
+# lom
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Gagal memulakan pengurus tetapan 'gnome-setting-daemon'.\n"
+#~ "Tanpa pengurus tetapan GNOME terlaksana, setengah keutamaan tidakk dapat "
+#~ "bertindak. Ini menunjukkan masalah dengan DBus, atau pengurus tetapan "
+#~ "bukan-GNOME (ie. KDE) sudah tersedia aktif dan konflik dengan pengurus "
+#~ "tetapan GNOME."
+
+#, fuzzy
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "Tak dapat memuatkan ikon stkl caplet '%s'\n"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Terdapat ralat memapar bantuan: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Menyalin fail: %u of %u"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "Penyalinan '%s'"
+
+#~ msgid "Parent Window"
+#~ msgstr "Tetingkap Utama"
+
+#~ msgid "From URI"
+#~ msgstr "Dari URI"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI sedang dipindahkan dari"
+
+#~ msgid "To URI"
+#~ msgstr "Ke URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI sedang dipindahkan ke"
+
+#~ msgid "Fraction completed"
+#~ msgstr "Pecahan selesai"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Pecahan pemindahan kini selesai"
+
+#~ msgid "Current URI index"
+#~ msgstr "Indeks URI semasa"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Indeks URI semasa - bermula dari 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "Jumlah URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Bilangan Jumlah URI"
+
+#~ msgid "_Skip"
+#~ msgstr "_Langkau"
+
+#~ msgid "Key"
+#~ msgstr "Kekunci"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Kekunci GConf yang ciri-ciri editor ini disisipkan"
+
+#~ msgid "Callback"
+#~ msgstr "Panggilbalik"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Panggilbalik bila nilai yang diasiosasikan dengan kekunci bertukar"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf tukar set yang mengandungi data untuk diforwardkan ke klient gconf "
+#~ "pada terapan"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Penukaran widget panggilbalik"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Panggilbalik akan disisukan bila data hendak ditukarkan daripada GConf ke "
+#~ "widget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Penukaran daripada panggilbalik wigdet"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Panggilbalik akan diisukan apabila data yang akan ditukarkan kepada GConf "
+#~ "daripada widget"
+
+#~ msgid "UI Control"
+#~ msgstr "Kawalan UI"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Objek yang mengawal ciri-ciri (biasanya widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Tetapan data objek editor"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Data custom diperlukan bagi sesetengah editor tetapan"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Data property editor melepaskan panggilbalik"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Panggilbalik yang akan diisukan apabila data property editor yang "
+#~ "dikosongkan"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Tak menjumpai fail  '%s'.\n"
+#~ "\n"
+#~ "Pastikan ianya wujud dan cuba lagi, atau pilih gambar latar belakang yang "
+#~ "lain."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Saya tidak tau bagaimana untuk membuka fail  '%s'.\n"
+#~ "Mungkin ianya jenis gambar yang belum disokong lagi.\n"
+#~ "\n"
+#~ "Sebaliknya, sila pilih gambar lain."
+
+#~ msgid "Please select an image."
+#~ msgstr "Sila pilih satu imej."
+
+#, fuzzy
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Kursor Default - Semasa"
+
+#, fuzzy
+#~ msgid "White Pointer - Current"
+#~ msgstr "Kursor Putih - Semasa"
+
+#, fuzzy
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Kursor Besar - Semasa"
+
+#, fuzzy
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Kursor Putih Besar - Semasa"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "Aplikasi Digemari"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "Pembantu Visual"
+
+#~ msgid "Accessibility"
+#~ msgstr "Kebolehcapaikan"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "_Arahan:"
+
+#, fuzzy
+#~ msgid "E_xecute flag:"
+#~ msgstr "Flag _Larian:"
+
+#~ msgid "Image Viewer"
+#~ msgstr "Penonton Imej"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "Mesej Instan"
+
+#~ msgid "Internet"
+#~ msgstr "Internet"
+
+#~ msgid "Mail Reader"
+#~ msgstr "Pembaca Mel"
+
+#~ msgid "Mobility"
+#~ msgstr "Mobiliti"
+
+#~ msgid "Multimedia"
+#~ msgstr "Multimedia"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Buka pautan pada _tab baru"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Buka pautan pada tetingkap baru"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Laksana di t_erminal"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "Terminal Emulator"
+
+#~ msgid "Text Editor"
+#~ msgstr "Editor Teks"
+
+#~ msgid "Web Browser"
+#~ msgstr "Pelayar Web"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Pemain Muzik Banshee"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Mel Claws"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#, fuzzy
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Pelayar Web Derfault"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Terminal Debian Emulator"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Pelayar Web Epiphany"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Pembaca Emel Evolution"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus dengan Kanta Pembesar"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Mail Iceape"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Listen"
+#~ msgstr "Dengar"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mel Mozilla"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Pemain Muzik Rhythmbox"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "Mail SeaMonkey"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Pemain Wayang Totem"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Include _panel"
+#~ msgstr "Termasuk _panel"
+
+#, fuzzy
+#~ msgid "Monitor Preferences"
+#~ msgstr "Keutamaan Font"
+
+#, fuzzy
+#~ msgid "R_otation:"
+#~ msgstr "_Lokasi:"
+
+#~ msgid "Upside-down"
+#~ msgstr "Terbalik"
+
+#, fuzzy
+#~ msgid "Monitors"
+#~ msgstr "Kawalan"
+
+#~ msgid "Upside Down"
+#~ msgstr "Upside Down"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#, fuzzy
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "Pilih aplikasi default anda"
+
+#~ msgid "Desktop"
+#~ msgstr "Desktop"
+
+#~ msgid "Accelerator key"
+#~ msgstr "Kekunci pemecut"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Pengubahsuai pemecut"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Kod kekunci pemecut"
+
+#~ msgid "Accel Mode"
+#~ msgstr "Mod Pemecut"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Jenis pemecut ."
+
+#, fuzzy
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr ""
+#~ "Ralat membuang tetapan pemecut  pada pangkalandata konfigurasi: %s\n"
+
+#, fuzzy
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "Pintasan bagi volum naik"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Umpuk kekunci pintasan pada arahan"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Hanya terapkan tetapan dan keluar (kompatibiliti sahaja; kini dikendali "
+#~ "oleh deamon)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Mulakan halaman dengan tetapan hentian taip dipaparkan"
+
+#, fuzzy
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "Mulakan halaman dengan tetapan hentian taip dipaparkan"
+
+#, fuzzy
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "Keutamaan Papan Kekunci"
+
+#, fuzzy
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "Beep bila _modifier ditekan"
+
+#, fuzzy
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Beep jika kekunci di_lepas"
+
+#, fuzzy
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Keutamaan Kebolehcapaian Papan Kekunci (AccessX)"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "_Izinkan tangguhan bagi hentian"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "Maklumbalas _Audio..."
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Semak jika hentian adalah diizinkan untuk ditangguh"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Tempoh bagi hentian bila menaip tak diizinkan"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Tempoh bagi kerja untuk memaksa hentian"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "_Model papan kekunci:"
+
+#~ msgid "Layouts"
+#~ msgstr "Susunatur"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Kunci skrin selepas tempoh tertentu untuk membantu mencegah kemalangan "
+#~ "papan kekunci berulang"
+
+#, fuzzy
+#~ msgid "Reset to De_faults"
+#~ msgstr "Ulangtetap ke de_fault"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "_Pemecutan:"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Selangmasa rehat bertahan"
+
+#, fuzzy
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "<b>_Kunci skrin untuk menimplementasi hentian taip</b>"
+
+#, fuzzy
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "_Hanya terima tekanan kekunci bagi:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Taip untuk uji tetapan:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Selangmasa kerja bertahan"
+
+#~ msgid "By _language"
+#~ msgstr "Mengikut _bahasa"
+
+#~ msgid "_Country:"
+#~ msgstr "_Negara:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variasi:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Pilih Model Papan Kekunci"
+
+#~ msgid "_Models:"
+#~ msgstr "_Model:"
+
+#~ msgid "Keyboard Layout Options"
+#~ msgstr "Susunan Opsyen Papan Kekunci"
+
+#~ msgid "Layout"
+#~ msgstr "Susunatur"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Tetapkan keutamaan papan kekunci"
+
+#, fuzzy
+#~ msgid "gesture|Disabled"
+#~ msgstr "Dimatikan"
+
+#, fuzzy
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "Keutamaan Tetikus"
+
+#, fuzzy
+#~ msgid "Drag and Drop"
+#~ msgstr "<b>Heret dan Jatuh</b>"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Keutamaan Tetikus"
+
+#, fuzzy
+#~ msgid "Thr_eshold:"
+#~ msgstr "_Treshold:"
+
+#~ msgid "_Disabled"
+#~ msgstr "_Dimatikan"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Tetikus-kidal"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Tahap sensitif:"
+
+#~ msgid "_Single click:"
+#~ msgstr "_Sekali klik:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Tetapkan keutamaan tetikus"
+
+#, fuzzy
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Keutamaan proksi rangkaian"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>Konfigurasi proksi _automatik</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Konfigurasi proksi _manual</b>"
+
+#~ msgid "C_reate"
+#~ msgstr "C_ipta"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Perincian Proksi HTTP"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "Senarai Hos Abaian"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Keutamaan Proksi Rangkaian"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "Proksi HTTP _Selamat:"
+
+#, fuzzy
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr ""
+#~ "<b>Tak dapat memulakan aplikasi keutamaan bagi pengurus tetingkap anda</"
+#~ "b>\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_iper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "S_uper (atau \"Logo Windows\")"
+
+#~ msgid "Titlebar Action"
+#~ msgstr "Aksi Bar Tajuk"
+
+#, fuzzy
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Untuk meng_alih tetingkap, tekan-dan-pegang kekunci dan genggam tetingkap:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Keutamaan Tetingkap"
+
+#~ msgid "Window Selection"
+#~ msgstr "Pemilihan Tertingkap"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Dwi-klik bar tajuk untuk melakukan aksi ini:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Selang masa sebelum angkat:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Angkat tetingkap dipilih selepas satu selangmasa"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Pilih tetingkap bila tetikus di atasnya"
+
+#, fuzzy
+#~ msgid "Set your window properties"
+#~ msgstr "Ciri-ciri Tetingkap"
+
+#~ msgid "Windows"
+#~ msgstr "Tetingkap"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Pengurus tetingkap \"%s\" tak mendaftarkan radas konfigurasi\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "Maksimalkan Menegak"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Maksimalkan Melintang"
+
+#~ msgid "Filter"
+#~ msgstr "Tapis"
+
+#~ msgid "Groups"
+#~ msgstr "Kumpulan"
+
+#~ msgid "Control Center"
+#~ msgstr "Pusat Kawalan"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Radas Konfigurasi GNOME"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_Tangguh Rehat"
+
+#~ msgid "Take a break!"
+#~ msgstr "Masa rehat!"
+
+#~ msgid "_Take a Break"
+#~ msgstr "_Rehat Sebentar"
+
+#, fuzzy
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d minit sampai rehat seterusnya"
+#~ msgstr[1] "%d minit sampai rehat seterusnya"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Kurang drpd satu minit sehingga hentian berikutnya"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Tak dapat membuka dialog ciri-ciri hentian menatip kerana ralat berikut: "
+#~ "%s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Ditulis oleh Richard Hult <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Eye candy ditambah oleh Anders Carlsson"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Pengingat hentian komputer."
+
+#~ msgid "translator-credits"
+#~ msgstr "kredit-penterjemah"
+
+#~ msgid "Copyright:"
+#~ msgstr "hakcipta:"
+
+#~ msgid "Description:"
+#~ msgstr "Keterangan:"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "penggunaan: %s fontfile\n"
+
+#, fuzzy
+#~ msgid "Font Viewer"
+#~ msgstr "Pusat Kawalan GNOME"
+
+#~ msgid "Preview fonts"
+#~ msgstr "Fon Prebiu"
+
+#~ msgid "TEXT"
+#~ msgstr "TEKS"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Saiz fon (default:64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SAIZ"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "Penapisan anda \"%s\" tidak sama mana-mana item."
+
+#~ msgid "Upgrade"
+#~ msgstr "Naiktaraf"
+
+#, fuzzy
+#~ msgid "Uninstall"
+#~ msgstr "_Pasang"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "Tambah ke Kegemaran"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Buang dari Aplikasi Permulaan"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Tambah pada Program Permulaan"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "Spreadsheet Baru"
+
+#~ msgid "New Document"
+#~ msgstr "Dokumen Baru"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Buka</b>"
+
+#~ msgid "Send To..."
+#~ msgstr "Hantar Kepada..."
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "Jika anda padam item, ia kekal hilang"
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "Buka dengan \"%s\""
+
+#~ msgid "Open with Default Application"
+#~ msgstr "Buka dengan aplikasi default anda"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "Bukan dalam Pengurus Fail"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Hari ini %l:%M %p"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "Cari Sekarang"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Buka %s</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "Buangkan dari Item Sistem"
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#, fuzzy
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Kelajuan</b>"
+
+#, fuzzy
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Sokongan</b>"
+
+#, fuzzy
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Kelajuan</b>"
+
+#, fuzzy
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Sokongan</b>"
+
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "_Katalaluan:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Sokongan</b>"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Mulakan teknologi pertolongan ini setiap kali anda log masuk:"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "Sokongan Teknologi Pertolongan"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "Hidupkan sokongan bagi teknologi pertolongan GNOME pasa logmasuk"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Tiada Teknologi Pertolongan pada sistem anda. Pakej 'gok' mesti dipasang "
+#~ "untuk mendapatkan sokongan papan kekunci pada skrin, dan pakej "
+#~ "'gnopernicus' mesti dipasang untuk membolehkan pembacaanskrin dan "
+#~ "pembesaran."
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "Terdapat ralat melancarkan dialog keutamaan tetikus: %s"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Tak dapat mengimport tetapan AccessX dari fail '%s'"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Import Fail Tetapan Keupayaan"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Tetapkan ciri-ciri Kebolehcapaian Papan Kekunci"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Sistem ini nampaknya tidak mempunyai sambungan XKB. Kebolehcapaian papan "
+#~ "kekunci tidak akan beroperasi dengannya."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>Hidupkan Kekunci _Bounce</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>Hidupkan Kekunci _Perlahan</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Hidupkan Kekunci _Tetikus</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>Hidupkan Kekunci _Ulangan</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>Hidupkan Kekunci _Melekat</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Keupayaan</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Togol Kekunci</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Asas"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "Beep bila LED dinyalana dan 2 beep bila salah satu dipadam."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Lengahan antara tekanan kekunci dengan per_gerakan penuding:"
+
+#~ msgid "E_nable Toggle Keys"
+#~ msgstr "Hidupkan Kekunci _Togol"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Abaikan semua turutan tekan bagi kekunci SAMA jika ianya berlaku dalam "
+#~ "tempoh yang boleh dipilih pengguna."
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Ke_utamaan Tetikus..."
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Masa untuk meme_cut ke kelajuan maksimum:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Hidupkan pad kekunci numerik pada pad kawalan tetikus."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Dimatikan jika tidak digunakan selama:"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Import Tetapak Keupayaan..."
+
+#~ msgid "_accepted"
+#~ msgstr "dite_rima"
+
+#~ msgid "_pressed"
+#~ msgstr "dite_kan"
+
+#~ msgid "characters/second"
+#~ msgstr "aksara/saat"
+
+#~ msgid "milliseconds"
+#~ msgstr "milisaat"
+
+#~ msgid "pixels/second"
+#~ msgstr "piksel/saat"
+
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>Kertas _Dinding Desktop</b>"
+
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>Warna _Desktop</b>"
+
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Keutamaan Latar Belakang"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Tambah Kertas Dinding"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Hanya terapkan tetapan dan keluar"
+
+#~ msgid "Epiphany"
+#~ msgstr "Epiphany"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "Pelungsur Teks W3M"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Pelungsur Teks Lynx"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Pelungsur Teks Links"
+
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "Sila nyatakan nama dan arahan bagi editor ini."
+
+#, fuzzy
+#~ msgid "C_ustom:"
+#~ msgstr "Tersendiri"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Ciri-ciri Editor Tersendiri"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "Pembaca Emel Default"
+
+#~ msgid "Default Terminal"
+#~ msgstr "Terminal Default"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "Editor teks default"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "Pelayar Web Derfault"
+
+#~ msgid "Edit..."
+#~ msgstr "Edit..."
+
+#, fuzzy
+#~ msgid "Run in a _terminal"
+#~ msgstr "Laksana di _Terminal"
+
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "Pilih pengurus tetingkap yang anda mahu.  Anda dikehendaki menekan apply, "
+#~ "goyangkan kayu silap mata, dan lakukan tarian silap mata untuk "
+#~ "menjayakannya"
+
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "Memahami Kawalan Remote _Netscape"
+
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr "Guna _editor ini untuk membuka fail teks pada pengurus fail"
+
+#~ msgid "Window Manager"
+#~ msgstr "Pengurus Tetingkap"
+
+#~ msgid "_Properties..."
+#~ msgstr "_Ciri-ciri..."
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Keutamaan Resolusi Skrin"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Jadikan default bagi komputer (%s) ini sahaja"
+
+#, fuzzy
+#~ msgid "Keep Resolution"
+#~ msgstr "_Kekalkan resolusi"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Kekalkan resolusi"
+
+#, fuzzy
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "Pelayan X tak menyokong sambungan XRandR. Perubahan resolusi serta merta "
+#~ "ke saiz paparan  adalah mustahil."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Versi sambungan XRandR tak serasi dengan program ini. Perubahan "
+#~ "sertamerta rke saiz paparan adalah mustahil."
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Pilih font bagi desktop"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "_Pergi ke folder font"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "Font _terminal"
+
+#~ msgid "Window Management"
+#~ msgstr "Pengurusan Tetingkap"
+
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "Ralat menetapkan pemecut baru pada pangkalandata konfigurasi: %s\n"
+
+#~ msgid "There was an error launching the keyboard capplet : %s"
+#~ msgstr "Terdapat ralat melancarkan caplet papan kekunci: %s"
+
+#, fuzzy
+#~ msgid "..."
+#~ msgstr "Tambah..."
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Laju</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Panjang</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Pendek</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Perlahan</i></small>"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "Keboleh_capaian..."
+
+#~ msgid "The default cursor that ships with X"
+#~ msgstr "Kursor default yang datang dengan X"
+
+#~ msgid "The default cursor inverted"
+#~ msgstr "Kursor default disongsangkan"
+
+#~ msgid "Large Cursor"
+#~ msgstr "Kursor Besar"
+
+#~ msgid "Large version of normal cursor"
+#~ msgstr "Versi besar bagi kursor normal"
+
+#~ msgid "Large version of white cursor"
+#~ msgstr "Versi besar bagi kursor putih"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Pantas</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Tinggi</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Besar</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Rendah</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Perlahan</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Kecil</i>"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Serlahkan _penuding bila anda menekan Ctrl"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "Advanced Configuration"
+#~ msgstr "_URL Autokonfigurasi:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Hidupkan bunyi dan bunyi dikaitkan dengan acara"
+
+#~ msgid "E_nable sound server startup"
+#~ msgstr "_Hidupkan pelayan bunyi permulaan"
+
+#~ msgid "_Sound an audible bell"
+#~ msgstr "_Bunyikan locang boleh didengar"
+
+#~ msgid "_Sounds for events"
+#~ msgstr "_Bunyi bagi acara"
+
+#~ msgid "_Visual feedback:"
+#~ msgstr "Maklumbalas _visual:"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Tiada tema dijumpai pada sistem anda. Ini bermakna dialog \"Keutamaan Tema"
+#~ "\"  anda tak dipasang dengan betul. atau anda tak memasang pakej \"gnome-"
+#~ "themes\""
+
+#, fuzzy
+#~ msgid "The file format is invalid"
+#~ msgstr "Fail %s adalah fail wav yang tidak sah"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Lokasi fail tema yg dinyatakan untuk dipasang adalah tak sah"
+
+#, fuzzy
+#~ msgid "The file format is invalid."
+#~ msgstr "Fail %s adalah fail wav yang tidak sah"
+
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s adalah laluan dimana fail tema dipasang. Ini tak boleh dipilih sebagai "
+#~ "lokasi sumber"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "Anda boleh menyimpan tema dengan menekan btang Simpan Tema."
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Pasang Tema</span>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Simpan Tema ke Cakera</span>"
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr "Tema baru boleh juga dipasang dengan mengheret tema ke tetingkap."
+
+#~ msgid "Save Theme"
+#~ msgstr "Simpan Tema"
+
+#~ msgid "Short _description:"
+#~ msgstr "_Huraian pendek:"
+
+#~ msgid "Theme _Details"
+#~ msgstr "_Perincian Tema"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "Tema ini mencadangkan font dan latarbelakang."
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Tema ini mencadangkan font dan latarbelakang:"
+
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "_Pergi ke Folder Tema"
+
+#~ msgid "_Install Theme..."
+#~ msgstr "_Pasang Tema..."
+
+#~ msgid "_Theme name:"
+#~ msgstr "Nama _Tema: "
+
+#~ msgid "theme selection tree"
+#~ msgstr "Pepohon pemilihan tema"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "Personalisasi penampilan toolbar dan bar menu pada aplikasi"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Menu & Toolbar"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Penampilan dan Kelakuan</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Prebiu</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "_Potong"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Keutamaan Menu dan Toolbar"
+
+#, fuzzy
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Label _butang toolbar: "
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "Toolbar boleh _lerai"
+
+#~ msgid "_Edit"
+#~ msgstr "_Edit"
+
+#~ msgid "_File"
+#~ msgstr "_Fail"
+
+#~ msgid "_New"
+#~ msgstr "Ba_ru"
+
+#~ msgid "Control"
+#~ msgstr "Kawalan"
+
+#, fuzzy
+#~ msgid "Desktop Preferences"
+#~ msgstr "Keutamaan Latar Belakang"
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Adakah anda ingin mengaktifkan Kekunci Perlahan?"
+
+#, fuzzy
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Adakah anda ingin mengaktifkan Kekunci Perlahan?"
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Adakah anda akan mengaktifkan Kekunci Lekat?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Adakah anda ingin mempasifkan Kekunci Lekat?"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Tak dapat mencipta direktori \"%s\".\n"
+#~ "Ini diperlukan untuk membolehkan penukaran kursor."
+
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr ""
+#~ "Ikatan Kekunci (%s) imempunyai aksi yang ditakrifkan beberapa kali\n"
+
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "Ikatan Kekunci (%s) mempunyai ikatan ditakrifkan banyak kali\n"
+
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Ikatan kekunci (%s) tidak selesai\n"
+
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Ikatan Kekunci (%s) tidak sah\n"
+
+#~ msgid "It seems that another application already has access to key '%d'."
+#~ msgstr "Nampaknya aplikasi lain sudah mempunyai akses ke kekunci'%d'."
+
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Ralat bila cuba melaksanakan (%s)\n"
+#~ "dimana ianya dipautkan ke kekunci (%s)"
+
+#, fuzzy
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "Anda menggunakan XFree 4.3.0.\n"
+#~ "Terdapat masalah dengan konfigurasi XKB yang kompleks.\n"
+#~ "Sila cuba menggunakan konfigurasi ringkas atau dapatkan versi terkini "
+#~ "perisian XFree."
+
+#, fuzzy
+#~ msgid "Do _not show this warning again"
+#~ msgstr "_Jangan papar mesej ini lagi"
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Tak dapat melaksanakan arahan: %s\n"
+#~ "Sila tentusahkan bahawa arahan ini wujud."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Tak dapat meletakkan mesin kepada tidur.\n"
+#~ "Pastikan mesin dikonfigurasikan dengan betul."
+
+#~ msgid "Permissions on the file %s are broken\n"
+#~ msgstr "Keizinan bagi fail  %s adalah rosak\n"
+
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Terdapat ralat memulakan screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Fungsi screensaver tidak akan bekerja pada sessi ini."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Jangan papar mesej ini lagi"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Tak dapat menentukan direktori rumah pengguna"
+
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "Kekunci GConf %s ditetapkan ke jenis %s tapi ia menjangkakan jenis %s\n"
+
+#, fuzzy
+#~ msgid "Do _not show this warning again."
+#~ msgstr "_Jangan papar mesej ini lagi"
+
+#, fuzzy
+#~ msgid "_Loaded files:"
+#~ msgstr "Model"
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Jenis bg_applier: BG_APPLIER_ROOT pada tetingkap root atau "
+#~ "BG_APPLIER_PREVIEW untuk prebiu"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Lebar jika penerap adalah prebiu: Default ke 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Tinggi Prebiu"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Tinggi jika penerap adalah prebiu: Default ke 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Skrin dimana BGAplier akan lukis"
+
+#, fuzzy
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Terdapat ralat memapar bantuan: %s"
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Fail bunyi untuk acara ini tidak wujud."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package\n"
+#~ "for a set of default sounds."
+#~ msgstr ""
+#~ "Fail bunyi untuk acara ini tidak wujud.\n"
+#~ "Anda juga boleh pasang pakej gnome-audio\n"
+#~ "untuk menetapkan bunyi default."
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "Fail %s adalah fail wav yang tidak sah"
+
+#~ msgid "Event"
+#~ msgstr "Acara"
+
+#~ msgid "Sound _file:"
+#~ msgstr "_Fail bunyi:"
+
+#~ msgid "_Play"
+#~ msgstr "_Main"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "Jika benar, pengendali mime bagi text/plain dan text/* akan kekal "
+#~ "disinkronisasikan"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Sinkronisasi pengendali text/plain and text/*"
+
+#~ msgid "Brightness down"
+#~ msgstr "Kecerahan turun"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Pintasan bagi kecerahan turun"
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "PIntasan bagi kecerahan naik"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Pintasan bagi emel"
+
+#, fuzzy
+#~ msgid "Home folder's shortcut."
+#~ msgstr "PIntasan bagi Rumah Daku"
+
+#, fuzzy
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Pintasan bagi Melancarkan Pelungsur Bantuan"
+
+#, fuzzy
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Pintasan bagi Melancar Pelungsur Web"
+
+#, fuzzy
+#~ msgid "Lock screen's shortcut."
+#~ msgstr "PIntasan bagi Kunci Skrin."
+
+#, fuzzy
+#~ msgid "Log out's shortcut."
+#~ msgstr "Pintasan bagi Log Keluar"
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Pintasan bagi trek berikutnya."
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "PIntasan bagi kekunci kaku."
+
+#, fuzzy
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "PIntasan bagi Main (atau Main/Kaku)"
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Pintasan bagi trek terdahulu."
+
+#~ msgid "Sleep"
+#~ msgstr "Tidur"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Pintasan tidur"
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "PIntasan bagi kekunci Henti bermain"
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Pintasan bagi volum mute"
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Pintasan bagi volum mute"
+
+#~ msgid "Volume step"
+#~ msgstr "Langkah volum"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Langkah volum sebagai peratusan volum."
+
+#, fuzzy
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "Papar dialog bila ralat melaksanakan XScreenSaver"
+
+#, fuzzy
+#~ msgid "Run screensaver at login"
+#~ msgstr "Laksana Xcreensaver pada logmasuk"
+
+#, fuzzy
+#~ msgid "Start screensaver"
+#~ msgstr "Mula Xscreensaver"
+
+#, fuzzy
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "_Model papan kekunci:"
+
+#, fuzzy
+#~ msgid "Keyboard layout"
+#~ msgstr "Susunatur papan kekunci XKB"
+
+#, fuzzy
+#~ msgid "Keyboard model"
+#~ msgstr "_Model papan kekunci:"
+
+#, fuzzy
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr "Tetapan XKB pada gconf akan ditindih drpd sistem secepat mungkin"
+
+#, fuzzy
+#~ msgid "keyboard layout"
+#~ msgstr "Susunatur papan kekunci XKB"
+
+#, fuzzy
+#~ msgid "keyboard model"
+#~ msgstr "Model papan kekunci XKB"
+
+#~ msgid "Break reminder"
+#~ msgstr "Pengingat hentian"
+
+#~ msgid "The typing monitor is already running."
+#~ msgstr "Monitor menaip sudah dilaksanakan."
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Seekor arnab memakan kangkung bersama tiong. 0123456789"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Terapkan font baru?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Ja_ngan terapkan font"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Tema yang anda pilih mencadangkan font baru. Prebiu font dipaparkan "
+#~ "dibawah."
+
+#~ msgid "Themes"
+#~ msgstr "Tema"
+
+#~ msgid "Description"
+#~ msgstr "Huraian"
+
+#~ msgid "Window border theme"
+#~ msgstr "Tema sempadan tetingkap"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#, fuzzy
+#~ msgid "Sets the default theme"
+#~ msgstr "Ulangtetap ke de_fault"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "Jika ditetapkan, tema dipasang akan di'thumbnail'kan."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "Jika ditetapkan, tema akan di'thumbnail'kan."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Tetapkan kekunci ini dengan arahan digunakan untuk mencipta thumbnail "
+#~ "bagi tema dipasang."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "tetapkan kekunci ini dengan arahan digunakan untuk imencipta thumbnail "
+#~ "bagi tema"
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "arahan thumbnail bagi tema dipasang"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Arahan thumbnail bagi tema"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Samada untuk meng'thumbnail'kan tema dipasang"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Samada untuk meng'thumbnail'kan tema"

--- a/po/my.po
+++ b/po/my.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-11-24 08:32+0100\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2011-10-14 00:28+0630\n"
 "Last-Translator: Thura Hlaing <trhura@gmail.com>\n"
 "Language-Team: Burmese <my-l10n-team@googlegroups.com>\n"
@@ -22,3499 +22,5966 @@ msgstr ""
 "X-Poedit-Country: MYANMAR\n"
 "X-Generator: Narro 0.9.4 on http://translate.libreworks.info\n"
 
-#: ../gnome-control-center.schemas.in.h:1
-msgid "Current network location"
-msgstr "လက်ရှိကွန်ရက်တည်နေရာ"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
+msgstr "_A အပ္ပလီကေးရှင်းဖောင့်"
 
-#: ../gnome-control-center.schemas.in.h:2
-msgid "More backgrounds URL"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "ပိုကြိုက်ဆော့ဝဲများ"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "သွင်းယူမှုပြီးဆုံးပြီ"
+
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:3
-msgid "More themes URL"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_D အသေးစိတ်"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "ရှာဖွေရန်"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:4
-msgid ""
-"Set this to your current location name. This is used to determine the "
-"appropriate network proxy configuration."
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:5
-msgid ""
-"URL for where to get more desktop backgrounds. If set to an empty string the "
-"link will not appear."
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "တည်နေရာ"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:6
-msgid ""
-"URL for where to get more desktop themes. If set to an empty string the link "
-"will not appear."
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "နောက်ခံပုံ"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:110
-msgid "Image/label border"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
 msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:111
-msgid "Width of border around the label and image in the alert dialog"
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
 msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:120
-msgid "Alert Type"
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "နောက်ခံပုံထည့်"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "အသံ"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "စိတ်ကြိုက အမြန်ခလုတ်"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "ကီးဘုတ် အမြန်ခလုတ်"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "_L တည်နေရာ"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "တူညီသည့်အရာမတွေ့ပါ"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
 msgstr "အချက်ပေးအမျိုးအစား"
 
-#: ../capplets/about-me/eel-alert-dialog.c:121
-msgid "The type of alert"
-msgstr "အချက်ပေးပုံစံ"
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:129
-msgid "Alert Buttons"
-msgstr "အချက်ပေးခလုတ်များ"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:130
-msgid "The buttons shown in the alert dialog"
-msgstr "အချက်ပေးဖောင်တွင်ပြမည့်ခလုတ်များ"
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:194
-msgid "Show more _details"
-msgstr "အသေးစိတ်ကြည့်ရန်"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "_A အပ္ပလီကေးရှင်းဖောင့်"
 
-#: ../capplets/about-me/gnome-about-me.c:716
-msgid "Select Image"
-msgstr "ပုံရွေးပါ"
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:718
-msgid "No Image"
-msgstr "ပုံမရှိပါ"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:746
-#: ../capplets/appearance/appearance-desktop.c:658
-msgid "Images"
-msgstr "ပုံများ"
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>ဖွင့်ရန်</b>"
 
-#: ../capplets/about-me/gnome-about-me.c:750
-#: ../capplets/appearance/theme-installer.c:766
-msgid "All Files"
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "ပုံစံ"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "မူလပုံစံ"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "နောက်ခံပုံ"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "ပြီးဆုံး"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "ဖိုင်အမည်"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "ဖိုင်အမည်"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "ဖိုင်များကိုကူးယူခြင်း"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
 msgstr "ဖိုင်အားလုံး"
 
-#: ../capplets/about-me/gnome-about-me.c:890
+#: panels/color/cc-color-panel.ui:373
 msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:911
-msgid "Unable to open address book"
-msgstr "လိပ်စာစာရင်းကိုဖွင့်၍မရပါ"
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:934
-#, c-format
-msgid "About %s"
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_A ထည့်ရန်"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "_D အသုံးမပြု"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "နှစ်သက်မှုအဖြစ်မှပယ်ဖျက်ပါ"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_D အသေးစိတ်"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "မိနစ်"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "မိနစ်"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "မိနစ်"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "အရောင်"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "ပုံရွေးပါ"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_S ရွေးချယ်ပါ"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "တူညီသည့်အရာမတွေ့ပါ"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_T ကြာချိန်"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "ရှာဖွေရန်"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "_E ကြာချိန်"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "_D အသုံးမပြု"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "စက္ကန့်"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "မူရင်းအပ္ပလီကေးရှင်းနှင့်ဖွင့်ရန်"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "မူရင်းအပ္ပလီကေးရှင်းနှင့်ဖွင့်ရန်"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "ဖောင့်ကိုသုံးပါ"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "စကေး"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "စစ်ထုတ်ရန်"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "URI မှတဆင့်"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "မိနစ်"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "အမည်"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "အမျိုးအစား"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "ဗာရှင်း"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "ဝင်းဒိုး"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "ဖိုင်အမည်"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "အမည်ပြောင်းရန်"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
 msgstr "%s အကြောင်း"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:1
-msgid "A_IM/iChat:"
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:2
-msgid "A_ddress:"
-msgstr "လိပ်စာ"
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:3
-msgid "A_ssistant:"
-msgstr "လက်ထောက်"
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:4
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-msgid "About Me"
-msgstr "ကျွန်တော့်အကြောင်း"
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:5
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ရှာဖွေရန်"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "စနစ်ဆိုင်ရာ"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "_O ရွေးချယ်စရာများ"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+#, fuzzy
+msgid "Move Up"
+msgstr "_U အပေါ်"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+#, fuzzy
+msgid "Move Down"
+msgstr "_D အောက်"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "လိုလားချက်"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "ကီးဘုတ်လက်ကွက်ရွေးချယ်ရန်"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "_U ပရိုတိုကောအားလုံးအတွက် ကြားခံ တစ်မျိုးသာသုံးမည်"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "ကီးဘုတ် အမြန်ခလုတ်"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "စိတ်ကြိုက အမြန်ခလုတ်"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "လုပ်ဆောင်ချက်"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "အမြန်ခလုတ်"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "အမြန်ခလုတ်"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "စိတ်ကြိုက အမြန်ခလုတ်"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "အမြန်ခလုတ်"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "ကီးဘုတ် အမြန်ခလုတ်"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "အမည်"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "_O ကွန်မန်း"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "အမြန်ခလုတ်"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "အမြန်ခလုတ်"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "မသတ်မှတ်ထား"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_F မူလတိုင်းပြန်သတ်မှတ်"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "ကီးဘုတ်"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "ကိုယ်ရေးအချက်အလက်များကိုသတ်မှတ်ပါ"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "အထွေထွေရေးရာ"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "ဘယ်ဘက်"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "ညာဘက်"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_D တည်နေရာကိုဖျက်"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "မောက်(စ်)"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "ပွိုင့်တာ အမြန်နှုန်း"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "မော်နီတာ"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_A အပ္ပလီကေးရှင်းဖောင့်"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "လုပ်ဆောင်ချက်"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "_O ရွေးချယ်စရာများ"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "ကွန်ရက်ဆာဗာများ"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_P စကားဝှက်"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "လက်ရှိစကားဝှက်"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "ပွိုင့်တာ အမြန်နှုန်း"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "နေရပ်လိပ်စာ"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "နေရပ်လိပ်စာ"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "နေရပ်လိပ်စာ"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "မူလပုံစံ"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_N အမည်"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_A လိပ်စာ"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_A လိပ်စာ"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "_D အသုံးမပြု"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "နေရပ်လိပ်စာ"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "နေရပ်လိပ်စာ"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:6
-msgid "C_ity:"
-msgstr "မြို့"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:7
-msgid "C_ompany:"
-msgstr "ကုမ္မဏီ"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:8
-msgid "Cale_ndar:"
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:9
-msgid "Change Passwo_rd..."
-msgstr "စကားဝှက်ပြောင်းရန်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:10
-msgid "Ci_ty:"
-msgstr "_T မြို့"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:11
-msgid "Co_untry:"
-msgstr "_U နိုင်ငံ"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:12
-msgid "Contact"
-msgstr "ဆက်သွယ်ရန်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:13
-msgid "Cou_ntry:"
-msgstr "_N  နိုင်ငံ"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:14
-msgid "Disable _Fingerprint Login..."
-msgstr "_F လက်ဗွေစနစ်ဖြင့်ဝင်ရောက်မှုကိုပယ်ဖျက်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:15
-msgid "Email"
-msgstr "အီးမေးလ်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:16
-msgid "Enable _Fingerprint Login..."
-msgstr "လက်ဗွေစနစ်ဖြင့်ဝင်ရောက်မှုကိုအသုံးပြု"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:17
-msgid "Full Name"
-msgstr "အမည်အပြည့်အစုံ"
-
-#. Home vs Work (phone)
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:19
-msgid "Hom_e:"
-msgstr "_E အိမ်ဖုန်း"
-
-#. Home vs Work (address)
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:21
-msgid "Home"
-msgstr "အိမ်လိပ်စာ"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:22
-msgid "IC_Q:"
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:23
-msgid "Instant Messaging"
-msgstr "အင်တာနက်ဆက်သွယ်မှု"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:24
-msgid "Job"
-msgstr "အလုပ်အကိုင်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:25
-msgid "M_SN:"
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:26
-msgid "P.O. _box:"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:27
-msgid "P._O. box:"
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:28
-msgid "Personal Info"
-msgstr "ကိုယ်ရေးရာဇဝင်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:29
-msgid "Select your photo"
-msgstr "ဓာတ်ပုံရွေးပါ"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:30
-msgid "State/Pro_vince:"
-msgstr "_V ပြည်နယ်/စီရင်စု"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:31
-msgid "Telephone"
-msgstr "တယ်လီဖုန်းနံပါတ်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:32
-msgid "User name:"
-msgstr "အသုံးပြုမည့်အမည်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:33
-msgid "Web"
-msgstr "ဝဘ်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:34
-msgid "Web _log:"
-msgstr "_L ဝဘ်မှတ်သားချက်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:35
-msgid "Wor_k:"
-msgstr "_K အလုပ်ဖုန်း"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:36
-msgid "Work"
-msgstr "အလုပ်အကိုင်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:37
-msgid "Work _fax:"
-msgstr "ရုံး၏ ဖက်(စ်)"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:38
-msgid "ZIP/_Postal code:"
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:39
-msgid "_Address:"
-msgstr "_A လိပ်စာ"
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "မိနစ်"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:40
-msgid "_Department:"
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "ကွန်ရက် ကြားခံ"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "လုပ်ဆောင်ချက်"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "နေရပ်လိပ်စာ"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "ကွန်ရက် ကြားခံ"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "_T HTTP ကြားခံ"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "_T HTTP ကြားခံ"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP ကြားခံ"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "_O Socks အခြေစိုက်ရာ"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "အသုံးမပြုသည့် အခြေစိုက်များ"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "_T HTTP ကြားခံ"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "_T HTTP ကြားခံ"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP ကြားခံ"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "_U အလိုအလျောက် URL သတ်မှတ်ခြင်း"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "ကွန်ရက်ဆာဗာများ"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_P စကားဝှက်"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "အသိအမှတ်ပြုသည်"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "ဖိုင်အားလုံး"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_U အသိအမှတ်ပြုခြင်း</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "_S အသုံးပြုအမည်"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_P စကားဝှက်"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_N စကားဝှက်အသစ်"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "ဗာရှင်း"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "ဗာရှင်း"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_A အသိအမှတ်ပြု"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_R စကားဝှက်ကိုပြန်ရိုက်ရန်"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_A အသိအမှတ်ပြု"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "အမျိုးအစား"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "မူလပုံစံ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "ဖိုင်စနစ်"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "တည်နေရာ"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "_D တည်နေရာကိုဖျက်"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "မိနစ်"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "မိနစ်"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "မိနစ်"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "မိနစ်"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "မိနစ်"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "မိနစ်"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "မိနစ်"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "မိနစ်"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "မိနစ်"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "မိနစ်"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_E ကြာချိန်"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "ပွိုင့်တာ"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "ပွိုင့်တာ"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "တူညီသည့်အရာမတွေ့ပါ"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "အသိအမှတ်ပြုသည်"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "_S အသုံးပြုအမည်"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "တည်နေရာ"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "သွင်းယူခြင်းမပြီးဆုံးပါ"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "လက်ချောင်းရွေးပါ"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_S ရွေးချယ်ပါ"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_A အသိအမှတ်ပြု"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_A အသိအမှတ်ပြု"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "ဖောင့် အသေးစိတ်ပုံဖော်မှု"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "_F မူလတိုင်းပြန်သတ်မှတ်"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
+msgstr "နှစ်သက်မှုအဖြစ်မှပယ်ဖျက်ပါ"
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "အမျိုးအစားများ"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "ပွိုင့်တာ"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "ပုံမှန်"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "ဖိုင်အားလုံး"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "နမူနာ"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
 msgstr "_D ဌာန"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:41
-msgid "_GroupWise:"
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:42
-msgid "_Home page:"
-msgstr "_H အင်တာနက်စာမျက်နှာ"
-
-#. Home vs Work (email)
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:44
-msgid "_Home:"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:45
-msgid "_Manager:"
-msgstr "_M မန်နေဂျာ"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:46
-msgid "_Mobile:"
-msgstr "_M မိုဘိုင်းဖုန်း"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:47
-msgid "_Profession:"
-msgstr "_P ကျွမ်းကျင်မှု/စိတ်ဝင်စားမှု"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:48
-msgid "_State/Province:"
-msgstr "_S ပြည်နယ်/စီရင်စု"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:49
-msgid "_Title:"
-msgstr "_T ခေါင်းစဉ်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:50
-msgid "_Work:"
-msgstr "_W အလုပ်"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:51
-msgid "_XMPP:"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:52
-msgid "_Yahoo:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:53
-msgid "_ZIP/Postal code:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "ကိုယ်ရေးအချက်အလက်များကိုသတ်မှတ်ပါ"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:100
+#: panels/region/cc-region-panel.ui:45
 msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr "ဒရိုက်ဗ်သို့ဝင်ရောက်ခွင့်မရှိပါ စနစ်ပိုင်းခန့်ခွဲသူကိုဆက်သွယ်ပါ"
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:102
-msgid "The device is already in use."
-msgstr "ဤဒရိုက်ဗ်ကိုအသုံးပြုထားသည်"
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:104
-msgid "An internal error occured"
-msgstr "စနစ်ပိုင်းဆိုင်ရာအမှားဖြစ်ပွားသည်"
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:221
-msgid "Delete registered fingerprints?"
-msgstr "မှတ်ပုံတင်ထားသည့်လက်ဗွေမှတ်စနစ်ကိုဖျက်သိမ်း"
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+#, fuzzy
+msgid "_Language"
+msgstr "_L ဘာသာစကား"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:224
-msgid "_Delete Fingerprints"
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr " Rhythmbox သီချင်းဖွင့်စက်"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "လုပ်ဆောင်ချက်"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "အမျိုးအစား"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "တည်နေရာအသစ်"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "အခြား"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "တည်နေရာ"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_A အပ္ပလီကေးရှင်းဖောင့်"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "ရှာဖွေရန်"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "ကွန်ရက်ဆာဗာများ"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "အလုပ်ခုံ"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_D တည်နေရာကိုဖျက်"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_P စကားဝှက်"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "အလုပ်ခုံ"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_A အသိအမှတ်ပြု"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "အသုံးပြုမည့်အမည်"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
 msgstr "_D လက်ဗွေမှတ်စနစ်ကိုဖျက်သိမ်း"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:231
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "စနစ်ဆိုင်ရာ"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "ကြားခံ သတ်မှတ်ခြင်း"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "အချက်ပေးခလုတ်များ"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "အသံ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "အမည်"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_S အမြန်နှုန်း"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "_N "
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "အမြန်ခလုတ်"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "_N "
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "_O နှစ်ချက်နှိပ်"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_E ကြာချိန်"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "အမြန်ခလုတ်"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "အမြန်ခလုတ်"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "အမြန်ခလုတ်"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "အသံ"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+#, fuzzy
+msgid "Hearing"
+msgstr "ပုံဖော်ခြင်း"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "ပုံသွင်ပြင်"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "ကီးဘုတ်"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "မောက်(စ်)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "အဖြူရောင် ညွှန်ပြသကေင်္တ"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "_O နှစ်ချက်နှိပ်"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "_O နှစ်ချက်နှိပ်"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+#, fuzzy
+msgid "Visual Alerts"
+msgstr "ပုံသွင်ပြင်"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "အမည်အပြည့်အစုံ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "ဘယ်ဘက်"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "ညာဘက်"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "_O ရွေးချယ်စရာများ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "_O အရောင်"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "ဆက်သွယ်ရန်"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "မသတ်မှတ်ထား"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "အမည်အပြည့်အစုံ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "အရောင်"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ဖိုင်စနစ်"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "အမှိုက်ပုံးထဲထည့်ပါ"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_N စကားဝှက်အသစ်"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "လက်ဗွေမှတ်စနစ်ဖြင့်ဝင်ရောက်ခြင်းကိုအသုံးပြုပါ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "ပုံရွေးပါ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "လက်ဗွေမှတ်စနစ်ဖြင့်ဝင်ရောက်ခြင်းကိုအသုံးပြုပါ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "_D လက်ဗွေမှတ်စနစ်ကိုဖျက်သိမ်း"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_N မသတ်မှတ်ထား"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
 msgstr "အသုံးပြုရန်မှတ်ပုံတင်ထားသည့် လက်ဗွေကိုဖျက်ပစ်မလား ဖျက်မယ်ဆိုရင် လက်ဗွေစနစ်ဖြင်မဝင်ရောက်နိုင်တော့ပါ"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:359
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:1
-msgid "Done!"
-msgstr "ပြီးဆုံး"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:405
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:427
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "ဒရိုက်ဗ် '%s' ကိုဝင်လို့မရပါ"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:476
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "ဒရိုက်ဗ် '%s'မှာလက်ဗွေမှတ်ခြင်းကိုမလုပ်ဆောင်နိုင်ပါ"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:523
-msgid "Could not access any fingerprint readers"
-msgstr "လက်ဗွေမှတ်ကရိယာကိုအသုံးမပြုနိုင်ပါ"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:524
-msgid "Please contact your system administrator for help."
-msgstr "အကူအညီအတွက် စနစ်ပိုင်းဆိုင်ရာခန့်ခဲ့သူနဲ့ဆက်သွယ်ပါ"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:554
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:2
-msgid "Enable Fingerprint Login"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
 msgstr "လက်ဗွေမှတ်စနစ်ဖြင့်ဝင်ရောက်ခြင်းကိုအသုံးပြုပါ"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:584
-#, c-format
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "လက်ဗွေမှတ်စနစ်ဖြင့်ဝင်ရောက်ခြင်းကိုအသုံးပြုပါ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "လက်ဗွေမှတ်စနစ်ဖြင့်ဝင်ရောက်ခြင်းကိုအသုံးပြုပါ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:593
-msgid "Swipe finger on reader"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_D လက်ဗွေမှတ်စနစ်ကိုဖျက်သိမ်း"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "လက်ဗွေမှတ်စနစ်ဖြင့်ဝင်ရောက်ခြင်းကိုအသုံးပြုပါ"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "ဖောင့်နမူနာကြည့်"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:595
-msgid "Place finger on reader"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:3
-msgid "Left index finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:5
-msgid "Left middle finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:6
-msgid "Left ring finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:7
-msgid "Left thumb"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:8
-msgid "Other finger: "
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:9
-msgid "Right index finger"
-msgstr "ညာလက်ညှိုး"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:10
-msgid "Right little finger"
-msgstr "ညာလက်သန်း"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:11
-msgid "Right middle finger"
-msgstr "ညာလက်ခလယ်"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:12
-msgid "Right ring finger"
-msgstr "ညာလက်သူကြွယ်"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:13
-msgid "Right thumb"
-msgstr "ညာလက်မ"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:14
-msgid "Select finger"
-msgstr "လက်ချောင်းရွေးပါ"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:15
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:161
-msgid "Child exited unexpectedly"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:296
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:309
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:408
-msgid "Authenticated!"
-msgstr "အသိအမှတ်ပြုသည်"
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:474
-#: ../capplets/about-me/gnome-about-me-password.c:559
-msgid ""
-"Your password has been changed since you initially authenticated! Please re-"
-"authenticate."
-msgstr "စကားဝှက်ပထမအကြီမ်အသိအမှတ်ပြုစဉ်ကတည်းကပြောင်းသွားပြီ ပြန်အသိအမှတ်ပြုခြင်းလုပ်ဆောင်ပါ"
-
-#: ../capplets/about-me/gnome-about-me-password.c:476
-msgid "That password was incorrect."
-msgstr "စကားဝှက်မှားနေသည်"
-
-#: ../capplets/about-me/gnome-about-me-password.c:527
-msgid "Your password has been changed."
-msgstr "စကားဝှက်ကိုပြောင်းပြီးပြီ"
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:537
-#, c-format
-msgid "System error: %s."
-msgstr "စနစ်ပိုင်းဆိုင်ရာအမှား : %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:540
-msgid "The password is too short."
-msgstr "စကားဝှက်တိုလွန်းသည်"
-
-#: ../capplets/about-me/gnome-about-me-password.c:544
-msgid "The password is too simple."
-msgstr "စကားဝှက်ကအရမ်းလွယ်လွန်းသည်"
-
-#: ../capplets/about-me/gnome-about-me-password.c:549
-msgid "The old and new passwords are too similar."
-msgstr "စကားဝှက်အဟောင်းနှင့်အသစ်ပေးတဲ့စကားဝှက်တူနေသည်"
-
-#: ../capplets/about-me/gnome-about-me-password.c:551
-msgid "The new password must contain numeric or special character(s)."
-msgstr "စကားဝှက်မှာ ဂဏန်းများနှင့် အထူးပြုအက္ခရာများပါဝင်ရမည်"
-
-#: ../capplets/about-me/gnome-about-me-password.c:554
-msgid "The old and new passwords are the same."
-msgstr "စကားဝှက်အဟောင်းနှင် အသစ်တူညီနေသည်"
-
-#: ../capplets/about-me/gnome-about-me-password.c:556
-msgid "The new password has already been used recently."
-msgstr "စကားဝှက်အသစ်က လက်တလောအသုံးပြုထားပြီးဖြစ်သည်"
-
-#. translators: Unable to launch <program>: <error message>
-#: ../capplets/about-me/gnome-about-me-password.c:827
-#, c-format
-msgid "Unable to launch %s: %s"
-msgstr " %s: %s ကိုဖွင့်မရဘူး"
-
-#: ../capplets/about-me/gnome-about-me-password.c:831
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:832
-msgid "A system error has occurred"
-msgstr "စနစ်ပိုင်းဆိုင်ရာအမှားဖြစ်သွားသည်"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:852
-msgid "Checking password..."
-msgstr "စကားဝှက်ကို စစ်နေသည်"
-
-#: ../capplets/about-me/gnome-about-me-password.c:939
-msgid "Click <b>Change password</b> to change your password."
-msgstr "စကားဝှက်အသစ်ပြောင်းရန်  <b>စကားဝှက်ပြောင်း</b>ကိုနှိပ်ပါ"
-
-#: ../capplets/about-me/gnome-about-me-password.c:942
-msgid "Please type your password in the <b>New password</b> field."
-msgstr "<b>စကားဝှက်အသစ်</b> ရိုက်ရန်နေရာတွင် စကားဝှက်ကိုရိုက်ထည့်ပေးပါ "
-
-#: ../capplets/about-me/gnome-about-me-password.c:945
-#: ../capplets/about-me/gnome-about-me-password.ui.h:5
-msgid ""
-"Please type your password again in the <b>Retype new password</b> field."
-msgstr "<b>စကားဝှက်ပြန်ရိုက်ရန်</b>နေရာတွင် စကားဝှက်ကိုပြန်ရိုက်ထည့်ပေးပါ"
-
-#: ../capplets/about-me/gnome-about-me-password.c:948
-msgid "The two passwords are not equal."
-msgstr "စကားဝှက်နှစ်လုံးတူညီမှုမရှိပါ"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:1
-msgid "Change pa_ssword"
-msgstr "_S စကားဝှက်ကိုပြောင်း"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:2
-msgid "Change password"
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
 msgstr "စကားဝှက်ပြောင်းပါ"
 
-#: ../capplets/about-me/gnome-about-me-password.ui.h:3
-msgid "Change your password"
-msgstr "စကားဝှက်ပြောင်းခြင်း"
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-password.ui.h:4
-msgid "Current _password:"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "လက်ရှိစကားဝှက်"
 
-#: ../capplets/about-me/gnome-about-me-password.ui.h:6
-msgid ""
-"To change your password, enter your current password in the field below and "
-"click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for "
-"verification and click <b>Change password</b>."
-msgstr ""
-"စကားဝှက်ကိုပြောင်းရန် စကားဝှက်ကို အောက်တွင်မြင်ရသည့် စကားဝှက်များရိုက်ရန် နေရာတွင်ရိုက်၍ <b>အသိအမှတ်ပြု</"
-"b>  ဆိုသည့်ခလုတ်ကိုနှိပ်ပါ"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:8
-msgid "_Authenticate"
-msgstr "_A အသိအမှတ်ပြု"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:9
-msgid "_New password:"
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
 msgstr "_N စကားဝှက်အသစ်"
 
-#: ../capplets/about-me/gnome-about-me-password.ui.h:10
-msgid "_Retype new password:"
-msgstr "_R စကားဝှက်ကိုပြန်ရိုက်ရန်"
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "စကားဝှက်ပြောင်းပါ"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:1
-msgid "Accessible Lo_gin"
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "စကားဝှက်တိုလွန်းသည်"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:2
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technologies"
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_N စကားဝှက်အသစ်"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:3
-msgid "Assistive Technologies Preferences"
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:4
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "အမည်အပြည့်အစုံ"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+#, fuzzy
+msgid "_Fingerprint Login"
+msgstr "လက်ဗွေမှတ်စနစ်ဖြင့်ဝင်ရောက်ခြင်းကိုအသုံးပြုပါ"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"Changes to enable assistive technologies will not take effect until your "
-"next log in."
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:5
-msgid "Close and _Log Out"
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:6
-msgid "Jump to Preferred Applications dialog"
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "မူရင်းအပ္ပလီကေးရှင်းနှင့်ဖွင့်ရန်"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:7
-msgid "Jump to the Accessible Login dialog"
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "အခြား"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:8
-msgid "Jump to the Keyboard Accessibility dialog"
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "တူညီသည့်အရာမတွေ့ပါ"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:9
-msgid "Jump to the Mouse Accessibility dialog"
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
 msgstr ""
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:10
-msgid "Preferences"
-msgstr "လိုလားချက်"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:11
-msgid "_Enable assistive technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:12
-msgid "_Keyboard Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:13
-msgid "_Mouse Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:14
-msgid "_Preferred Applications"
-msgstr "_P ပိုကြိုက်အပ္ပလီကေးရှင်း"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Choose which accessibility features to enable when you log in"
-msgstr ""
-
-#: ../capplets/appearance/appearance-desktop.c:627
-msgid "Add Wallpaper"
-msgstr "နောက်ခံပုံထည့်"
-
-#: ../capplets/appearance/appearance-desktop.c:662
-msgid "All files"
-msgstr "ဖိုင်အားလုံး"
-
-#: ../capplets/appearance/appearance-font.c:499
-msgid "Font may be too large"
-msgstr "ဖောင့်အရွယ်အစားကြီးလွန်းသည်"
-
-#: ../capplets/appearance/appearance-font.c:503
-#, c-format
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
-#: ../capplets/appearance/appearance-font.c:516
-#, c-format
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-
-#: ../capplets/appearance/appearance-font.c:539
-msgid "Use previous font"
-msgstr "အရင်ဖောင့်ပြန်သုံး"
-
-#: ../capplets/appearance/appearance-font.c:541
-msgid "Use selected font"
-msgstr "ရွေးထားသည့်ဖောင့်ကိုသုံးမည်"
-
-#: ../capplets/appearance/appearance-main.c:56
-#, c-format
-msgid "Could not load user interface file: %s"
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
 
-#: ../capplets/appearance/appearance-main.c:135
-msgid "Specify the filename of a theme to install"
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
 msgstr ""
 
-#: ../capplets/appearance/appearance-main.c:136
-msgid "filename"
-msgstr "ဖိုင်အမည်"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/appearance/appearance-main.c:143
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
 msgstr ""
 
-#: ../capplets/appearance/appearance-main.c:144
-#: ../capplets/default-applications/gnome-da-capplet.c:960
-#: ../capplets/mouse/gnome-mouse-properties.c:593
-msgid "page"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
 msgstr ""
 
-#: ../capplets/appearance/appearance-main.c:151
-msgid "[WALLPAPER...]"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
 msgstr ""
 
-#: ../capplets/appearance/appearance-style.c:172
-#: ../capplets/common/gnome-theme-info.c:446
-#: ../capplets/common/gnome-theme-info.c:638
-msgid "Default Pointer"
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "အချက်ပေးခလုတ်များ"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
 msgstr ""
 
-#: ../capplets/appearance/appearance-style.c:235
-#: ../capplets/appearance/appearance-themes.c:685
-msgid "Install"
-msgstr ""
-
-#: ../capplets/appearance/appearance-style.c:256
-#: ../capplets/common/gnome-theme-info.c:1646
-#, c-format
+#: panels/wacom/button-mapping.ui:51
 msgid ""
-"This theme will not look as intended because the required GTK+ theme engine "
-"'%s' is not installed."
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:673
-msgid "Apply Background"
-msgstr "နောက်ခံပုံသတ်မှတ်"
-
-#: ../capplets/appearance/appearance-themes.c:677
-msgid "Apply Font"
-msgstr "ဖောင့်ကိုသုံးပါ"
-
-#: ../capplets/appearance/appearance-themes.c:681
-msgid "Revert Font"
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
 msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:712
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
-"The current theme suggests a background and a font. Also, the last applied "
-"font suggestion can be reverted."
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
 msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:714
-msgid ""
-"The current theme suggests a background. Also, the last applied font "
-"suggestion can be reverted."
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:716
-msgid "The current theme suggests a background and a font."
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:718
-msgid ""
-"The current theme suggests a font. Also, the last applied font suggestion "
-"can be reverted."
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
 msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:720
-msgid "The current theme suggests a background."
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:722
-msgid "The last applied font suggestion can be reverted."
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
 msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:724
-msgid "The current theme suggests a font."
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:1046
-#: ../capplets/default-applications/gnome-da-capplet.c:691
-msgid "Custom"
-msgstr "စိတ်ကြိုက်"
-
-#: ../capplets/appearance/data/appearance.ui.h:1
-msgid "Appearance Preferences"
-msgstr "ပုံပန်းသွင်ပြင် လိုလားချက်"
-
-#: ../capplets/appearance/data/appearance.ui.h:2
-msgid "Background"
-msgstr "နောက်ခံပုံ"
-
-#: ../capplets/appearance/data/appearance.ui.h:3
-msgid "Best _shapes"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:4
-msgid "Best co_ntrast"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:5
-msgid "C_olors:"
-msgstr "_O အရောင်"
-
-#: ../capplets/appearance/data/appearance.ui.h:6
-msgid "C_ustomize..."
-msgstr "_U စိတ်ကြိုက်"
-
-#: ../capplets/appearance/data/appearance.ui.h:7
-msgid "Center"
-msgstr "ဗဟို"
-
-#: ../capplets/appearance/data/appearance.ui.h:8
-msgid "Changing your cursor theme takes effect the next time you log in."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:9
-msgid "Colors"
-msgstr "အရောင်"
-
-#: ../capplets/appearance/data/appearance.ui.h:10
-msgid "Controls"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:11
-msgid "Customize Theme"
-msgstr "စိတ်ကြိုက် အမြင်အဆင်"
-
-#: ../capplets/appearance/data/appearance.ui.h:12
-msgid "D_etails..."
-msgstr "_E အသေးစိတ်"
-
-#: ../capplets/appearance/data/appearance.ui.h:13
-msgid "Des_ktop font:"
-msgstr "_K အလုပ်ခုံဖောင့်"
-
-#: ../capplets/appearance/data/appearance.ui.h:14
-msgid "Font Rendering Details"
-msgstr "ဖောင့် အသေးစိတ်ပုံဖော်မှု"
-
-#: ../capplets/appearance/data/appearance.ui.h:15
-msgid "Fonts"
-msgstr "စာလုံးပုံစံများ"
-
-#: ../capplets/appearance/data/appearance.ui.h:16
-msgid "Get more backgrounds online"
-msgstr "အင်တာနက်မှ နောက်ခံများကိုဆွဲယူ"
-
-#: ../capplets/appearance/data/appearance.ui.h:17
-msgid "Get more themes online"
-msgstr "အင်တာနက်မှ အမြင်အဆင်များကိုဆွဲယူ"
-
-#: ../capplets/appearance/data/appearance.ui.h:18
-msgid "Gra_yscale"
-msgstr ""
-
-#. font hinting
-#: ../capplets/appearance/data/appearance.ui.h:20
-msgid "Hinting"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:21
-msgid "Horizontal gradient"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:22
-msgid "Icons"
-msgstr "ပုံသကင်္တများ"
-
-#: ../capplets/appearance/data/appearance.ui.h:23
-msgid "Icons only"
-msgstr "ပုံသကင်္တများသာ"
-
-#: ../capplets/appearance/data/appearance.ui.h:24
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:17
-msgid "Large"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:25
-msgid "N_one"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:26
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:27
-msgid "Pointer"
-msgstr "ပွိုင့်တာ"
-
-#: ../capplets/appearance/data/appearance.ui.h:28
-msgid "R_esolution:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:29
-msgid "Rendering"
-msgstr "ပုံဖော်ခြင်း"
-
-#: ../capplets/appearance/data/appearance.ui.h:30
-msgid "Save Theme As..."
-msgstr "အမြင်အဆင် ပြောင်းသိမ်းရန်"
-
-#: ../capplets/appearance/data/appearance.ui.h:31
-msgid "Save _As..."
-msgstr "_A ပြောင်းသိမ်းရန်..."
-
-#: ../capplets/appearance/data/appearance.ui.h:32
-msgid "Save _background image"
-msgstr "_B နောက်ခံပုံအားသိမ်းရန်"
-
-#: ../capplets/appearance/data/appearance.ui.h:33
-msgid "Scale"
-msgstr "စကေး"
-
-#: ../capplets/appearance/data/appearance.ui.h:34
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:31
-msgid "Small"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:35
-msgid "Smoothing"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:36
-msgid "Solid color"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:37
-msgid "Span"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:38
-msgid "Stretch"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:39
-msgid "Sub_pixel (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:40
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:41
-msgid "Subpixel Order"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:42
-msgid "Text"
-msgstr "စာသား"
-
-#: ../capplets/appearance/data/appearance.ui.h:43
-msgid "Text below items"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:44
-msgid "Text beside items"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:45
-msgid "Text only"
-msgstr "စာသားသာ"
-
-#: ../capplets/appearance/data/appearance.ui.h:46
-msgid "The current controls theme does not support color schemes."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:47
-msgid "Theme"
-msgstr "အမြင်အဆင်"
-
-#: ../capplets/appearance/data/appearance.ui.h:48
-msgid "Tile"
-msgstr ""
-
-#. vertical hinting, pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.ui.h:50
-msgid "VB_GR"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:51
-msgid "Vertical gradient"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:52
-msgid "Window Border"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:53
-msgid "Zoom"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:54
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:45
-msgid "_Add..."
-msgstr "_A ထည့်ရန်"
-
-#: ../capplets/appearance/data/appearance.ui.h:55
-msgid "_Application font:"
-msgstr "_A အပ္ပလီကေးရှင်းဖောင့်"
-
-#. pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.ui.h:57
-msgid "_BGR"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:58
-msgid "_Description:"
-msgstr "_D အကြောင်းအရာများ"
-
-#: ../capplets/appearance/data/appearance.ui.h:59
-msgid "_Document font:"
-msgstr "_D စာတမ်းဖောင့်"
-
-#: ../capplets/appearance/data/appearance.ui.h:60
-msgid "_Fixed width font:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:61
-msgid "_Full"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:62
-msgid "_Input boxes:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:63
-msgid "_Install..."
-msgstr "_I သွင်းရန်"
-
-#: ../capplets/appearance/data/appearance.ui.h:64
-msgid "_Medium"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:65
-msgid "_Monochrome"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:66
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:5
-msgid "_Name:"
-msgstr "_N အမည်"
-
-#: ../capplets/appearance/data/appearance.ui.h:67
-msgid "_None"
-msgstr "_N မသတ်မှတ်ထား"
-
-#. pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.ui.h:69
-msgid "_RGB"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:70
-msgid "_Reset to Defaults"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:71
-msgid "_Selected items:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:72
-msgid "_Size:"
-msgstr "_S အရွယ်အစား"
-
-#: ../capplets/appearance/data/appearance.ui.h:73
-msgid "_Slight"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:74
-msgid "_Style:"
-msgstr "_S ပုံစံ"
-
-#: ../capplets/appearance/data/appearance.ui.h:75
-msgid "_Tooltips:"
-msgstr ""
-
-#. vertical hinting, pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.ui.h:77
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/appearance/data/appearance.ui.h:78
-msgid "_Window title font:"
-msgstr "_W ဝင်ဒိုးခေါင်းစဉ်စာသား"
-
-#: ../capplets/appearance/data/appearance.ui.h:79
-msgid "_Windows:"
-msgstr "_W ဝင်ဒိုး"
-
-#: ../capplets/appearance/data/appearance.ui.h:80
-msgid "dots per inch"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr "အလုပ်ခုံမြင်ကွင်းကိုစိတ်ကြိုက်သတ်မှတ်"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr "အလုပ်ခုံ အစိတ်အပိုင်းများအတွက် အမြင်အဆင်ပက်ကေ့များကိုသွင်းပါ"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr "အမြင်အဆင်သွင်းယူရန်"
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr "Gnome အမြင်အဆင်ပက်ကေ့"
-
-#: ../capplets/appearance/gnome-wp-info.c:50
-msgid "No Desktop Background"
-msgstr "အလုပ်ခုံနောက်ခံမရှိပါ"
-
-#: ../capplets/appearance/gnome-wp-item.c:261
-msgid "Slide Show"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-item.c:263
-msgid "Image"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-item.c:269
-msgid "multiple sizes"
-msgstr ""
-
-#. translators: x pixel(s) by y pixel(s)
-#: ../capplets/appearance/gnome-wp-item.c:272
-#, c-format
-msgid "%d %s by %d %s"
-msgstr "%d %s အရ %d %s"
-
-#: ../capplets/appearance/gnome-wp-item.c:274
-#: ../capplets/appearance/gnome-wp-item.c:276
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "ပစ်ဇယ်"
-
-#. translators: <b>wallpaper name</b>
-#. * mime type, size
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:284
-#, c-format
-msgid ""
-"<b>%s</b>\n"
-"%s, %s\n"
-"Folder: %s"
-msgstr ""
-"<b>%s</b>\n"
-"%s, %s\n"
-"ဖိုင်တွဲ: %s"
-
-#. translators: <b>wallpaper name</b>
-#. * Image missing
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:296
-#, c-format
-msgid ""
-"<b>%s</b>\n"
-"%s\n"
-"Folder: %s"
-msgstr ""
-"<b>%s</b>\n"
-"%s\n"
-"ဖိုင်တွဲ: %s"
-
-#: ../capplets/appearance/gnome-wp-item.c:300
-msgid "Image missing"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:178
-#: ../capplets/appearance/theme-installer.c:234
-msgid "Cannot install theme"
-msgstr "အမြင်အဆင်ကိုသွင်းမရပါ"
-
-#: ../capplets/appearance/theme-installer.c:180
-#, c-format
-msgid "The %s utility is not installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:236
-msgid "There was a problem while extracting the theme."
-msgstr "အမြင်အဆင်ကိုဖြည်ချနေစဉ်အမှားဖြစ်သွားသည်"
-
-#: ../capplets/appearance/theme-installer.c:264
-msgid "There was an error installing the selected file"
-msgstr "ရွေးထားသည့်ဖိုင်ကိုသွင်းနေစဉ်အမှားဖြစ်သွားသည်"
-
-#: ../capplets/appearance/theme-installer.c:265
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme."
-msgstr "\"%s\" ကမှန်ကန်တဲ့အမြင်အဆင်မဟုတ်လောက်ဘူး"
-
-#: ../capplets/appearance/theme-installer.c:266
-#, c-format
-msgid ""
-"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
-"you need to compile."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:372
-#, c-format
-msgid "Installation for theme \"%s\" failed."
-msgstr "အမြင်အဆင်  \"%s\" ကိုသွင်းယူခြင်းမပြီးမြောက်ပါ"
-
-#: ../capplets/appearance/theme-installer.c:411
-#, c-format
-msgid "The theme \"%s\" has been installed."
-msgstr "အမြင်အဆင်  \"%s\" ကိုသွင်းယူခြင်းပြီးဆုံးပြီ"
-
-#: ../capplets/appearance/theme-installer.c:421
-msgid "Would you like to apply it now, or keep your current theme?"
-msgstr "အမြင်အဆင်အသစ်ကိုသုံးမလား(သို့)အခုအမြင်အဆင်ပဲဆက်သုံးမလား"
-
-#: ../capplets/appearance/theme-installer.c:424
-msgid "Keep Current Theme"
-msgstr "လက်ရှိအမြင်အဆင်ကိုသိမ်းထား"
-
-#: ../capplets/appearance/theme-installer.c:427
-msgid "Apply New Theme"
-msgstr "အမြင်အဆင်အသစ်ကို အသုံးချ"
-
-#: ../capplets/appearance/theme-installer.c:471
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "GNOME အမြင်အဆင် %s  ကို မှန်ကန်စွာသွင်းပြီးပြီ"
-
-#: ../capplets/appearance/theme-installer.c:533
-msgid "Failed to create temporary directory"
-msgstr "ယာယီဖိုင်လမ်းညွှန်တည်ဆောက်၍မရပါ"
-
-#: ../capplets/appearance/theme-installer.c:596
-msgid "New themes have been successfully installed."
-msgstr "အမြင်အဆင်အသစ်ကို မှန်ကန်စွာသွင်းပြီးပြီ "
-
-#: ../capplets/appearance/theme-installer.c:646
-msgid "No theme file location specified to install"
-msgstr "သွင်းယူရန်သတ်မှတ်ပေးသောလမ်းကြောင်းတွင် အမြင်အဆင်ဖိုင်များကိုမတွေ့ပါ"
-
-#: ../capplets/appearance/theme-installer.c:670
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:748
-msgid "Select Theme"
-msgstr "အမြင်အဆင်ကိုရွေးပါ"
-
-#: ../capplets/appearance/theme-installer.c:759
-msgid "Theme Packages"
-msgstr "အမြင်အဆင်ပက်ကေ့များ"
-
-#: ../capplets/appearance/theme-save.c:93
-#, c-format
-msgid "Theme name must be present"
-msgstr "အမြင်အဆင်အမည် ပေးရမည်"
-
-#: ../capplets/appearance/theme-save.c:156
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "အမြင်အဆင်က ရှိပြီးသားဖြစ်သည် အစားထိုးပြီးအသုံးပြုမလား"
-
-#: ../capplets/appearance/theme-save.c:157
-#: ../capplets/common/file-transfer-dialog.c:451
-msgid "_Overwrite"
-msgstr "_O ထပ်ရေးသည်"
-
-#: ../capplets/appearance/theme-util.c:75
-msgid "Would you like to delete this theme?"
-msgstr "အခုအမြင်အဆင်ကိုဖျက်ပစ်တော့မည်လား"
-
-#: ../capplets/appearance/theme-util.c:125
-msgid "Theme cannot be deleted"
-msgstr "အမြင်အဆင်ကိုဖျက်လို့မရပါ"
-
-#: ../capplets/appearance/theme-util.c:252
-msgid "Could not install theme engine"
-msgstr ""
-
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with DBus, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-
-#: ../capplets/common/capplet-stock-icons.c:66
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:88
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr " %s အကူအညီကိုဖော်ပြစဉ်အမှားဖြစ်ပွားသည်"
-
-#: ../capplets/common/file-transfer-dialog.c:98
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "ဖိုင်ကူးယူခြင်း  %u ၏ %u"
-
-#: ../capplets/common/file-transfer-dialog.c:145
-#, c-format
-msgid "Copying '%s'"
-msgstr "'%s' ကိုကူးယူခြင်း"
-
-#: ../capplets/common/file-transfer-dialog.c:185
-#: ../capplets/common/file-transfer-dialog.c:313
-msgid "Copying files"
-msgstr "ဖိုင်များကိုကူးယူခြင်း"
-
-#: ../capplets/common/file-transfer-dialog.c:224
-msgid "Parent Window"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Parent window of the dialog"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:231
-msgid "From URI"
-msgstr "URI မှတဆင့်"
-
-#: ../capplets/common/file-transfer-dialog.c:232
-msgid "URI currently transferring from"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:239
-msgid "To URI"
-msgstr "URI သို့"
-
-#: ../capplets/common/file-transfer-dialog.c:240
-msgid "URI currently transferring to"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:247
-msgid "Fraction completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:248
-msgid "Fraction of transfer currently completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:255
-msgid "Current URI index"
-msgstr "လက်ရှိ URI အမှတ်"
-
-#: ../capplets/common/file-transfer-dialog.c:256
-msgid "Current URI index - starts from 1"
-msgstr "လက်ရှိ URI အမှတ် - ၁ မှ အစပြုသည်"
-
-#: ../capplets/common/file-transfer-dialog.c:263
-msgid "Total URIs"
-msgstr "URIs စုစုပေါင်း"
-
-#: ../capplets/common/file-transfer-dialog.c:264
-msgid "Total number of URIs"
-msgstr "URIs အာလုံးပေါင်းအရေအတွက်"
-
-#: ../capplets/common/file-transfer-dialog.c:445
-#, c-format
-msgid "File '%s' already exists. Do you want to overwrite it?"
-msgstr "ဖိုင် '%s' ကရှိပြီးသားဖြစ်သည် အစားထိုးယူမလား"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "_Skip"
-msgstr "_S ကျော်ပါ"
-
-#: ../capplets/common/file-transfer-dialog.c:449
-msgid "Overwrite _All"
-msgstr "_A အားလုံးအစားထိုးပါ"
-
-#: ../capplets/common/gconf-property-editor.c:134
-msgid "Key"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:141
-msgid "Callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:147
-msgid "Change set"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:148
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:154
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:160
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1406
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1414
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1536
-msgid "Please select an image."
-msgstr "ပုံကိုရွေးချယ်ပေးပါ"
-
-#: ../capplets/common/gconf-property-editor.c:1541
-msgid "_Select"
-msgstr "_S ရွေးချယ်ပါ"
-
-#: ../capplets/common/gnome-theme-info.c:639
-msgid "Default Pointer - Current"
-msgstr "မူလညွှန်ပြသကေင်္တ - လက်ရှီ"
-
-#: ../capplets/common/gnome-theme-info.c:643
-msgid "White Pointer"
-msgstr "အဖြူရောင် ညွှန်ပြသကေင်္တ"
-
-#: ../capplets/common/gnome-theme-info.c:644
-msgid "White Pointer - Current"
-msgstr "အဖြူရောင်ညွှန်ပြသကေင်္တ - လက်ရှီ"
-
-#: ../capplets/common/gnome-theme-info.c:648
-msgid "Large Pointer"
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:649
-msgid "Large Pointer - Current"
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:653
-msgid "Large White Pointer - Current"
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:654
-msgid "Large White Pointer"
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1622
-#, c-format
-msgid ""
-"This theme will not look as intended because the required GTK+ theme '%s' is "
-"not installed."
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1630
-#, c-format
-msgid ""
-"This theme will not look as intended because the required window manager "
-"theme '%s' is not installed."
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1637
-#, c-format
-msgid ""
-"This theme will not look as intended because the required icon theme '%s' is "
-"not installed."
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:17
-msgid "Preferred Applications"
-msgstr "ပိုကြိုက်ဆော့ဝဲများ"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "ပုံသေသုံးအပ္ပလီကေးရှင်းများရွေးပါ"
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Start the preferred visual assistive technology"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:98
-#: ../capplets/default-applications/gnome-da-capplet.c:362
-#: ../capplets/default-applications/gnome-da-capplet.c:383
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:722
-msgid "Could not load the main interface"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:724
-msgid "Please make sure that the applet is properly installed"
-msgstr ""
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/default-applications/gnome-da-capplet.c:959
-msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:964
-msgid "- GNOME Default Applications"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:1
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:1
-msgid "Accessibility"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:3
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr ""
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:4
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:1
-msgid "C_ommand:"
-msgstr "_O ကွန်မန်း"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:5
-msgid "Co_mmand:"
-msgstr "_M ကွန်မန်း"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:6
-msgid "E_xecute flag:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:7
-msgid "Image Viewer"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:8
-msgid "Instant Messenger"
-msgstr "စကားပြောပရိုဂရမ်"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:9
-msgid "Internet"
-msgstr "အင်တာနက်"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:10
-msgid "Mail Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:11
-msgid "Mobility"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:12
-msgid "Multimedia"
-msgstr "မာတီမီဒီယာ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:13
-msgid "Multimedia Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:14
-msgid "Open link in new _tab"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:15
-msgid "Open link in new _window"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:16
-msgid "Open link with web browser _default"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:18
-msgid "Run at st_art"
-msgstr "_A အစပြုပြုချင်း ဖွင့်ပါ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:19
-msgid "Run in t_erminal"
-msgstr "_E တာမီနယ်တွင်ဖွင့်ပါ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:20
-msgid "System"
-msgstr "စနစ်ဆိုင်ရာ"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:21
-msgid "Terminal Emulator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:22
-msgid "Text Editor"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:23
-msgid "Video Player"
-msgstr "ရုပ်ရှင်ဖွင့်စက်"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:24
-msgid "Visual"
-msgstr "ပုံသွင်ပြင်"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:25
-msgid "Web Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:26
-msgid "_Run at start"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Firefox"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Galeon"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Gnopernicus"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Gnopernicus with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Iceape"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Iceape Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Icedove"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Iceweasel"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Konsole"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Listen"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Midori"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Mozilla"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Mozilla 1.6"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Mozilla Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Mozilla Thunderbird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Muine Music Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "Mutt"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-msgid "NXterm"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Netscape Communicator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Opera"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "Orca with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-msgid "RXVT"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-msgid "Rhythmbox Music Player"
-msgstr " Rhythmbox သီချင်းဖွင့်စက်"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-msgid "SeaMonkey Mail"
-msgstr "SeaMonkey အီးမေးလ်"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Standard XTerminal"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-msgid "Sylpheed"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-msgid "Sylpheed-Claws"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Terminator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Thunderbird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "Totem Movie Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
-msgid "aterm"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:1
-msgid "Include _panel"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:2
-#: ../capplets/display/xrandr-capplet.c:312
-msgid "Left"
-msgstr "ဘယ်ဘက်"
-
-#: ../capplets/display/display-capplet.ui.h:3
-msgid "Make Default"
-msgstr "မူလတိုင်းသတ်မှတ်"
-
-#: ../capplets/display/display-capplet.ui.h:4
-#: ../capplets/display/xrandr-capplet.c:515
-msgid "Monitor"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
 msgstr "မော်နီတာ"
 
-#: ../capplets/display/display-capplet.ui.h:5
-msgid "Monitor Preferences"
-msgstr "မော်နီတာဆိုင်ရာလိုလားချက်"
-
-#: ../capplets/display/display-capplet.ui.h:6
-#: ../capplets/display/xrandr-capplet.c:311
-#: ../capplets/display/xrandr-capplet.c:350
-msgid "Normal"
-msgstr "ပုံမှန်"
-
-#: ../capplets/display/display-capplet.ui.h:7
-msgid "Off"
-msgstr "ပိတ်"
-
-#: ../capplets/display/display-capplet.ui.h:8
-msgid "On"
-msgstr "ဖွင့်"
-
-#: ../capplets/display/display-capplet.ui.h:9
-msgid "Panel icon"
-msgstr "ဘားတန်းပုံသကင်္တ"
-
-#: ../capplets/display/display-capplet.ui.h:10
-msgid "R_otation:"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:11
-msgid "Re_fresh rate:"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:12
-#: ../capplets/display/xrandr-capplet.c:313
-msgid "Right"
-msgstr "ညာဘက်"
-
-#: ../capplets/display/display-capplet.ui.h:13
-msgid "Sa_me image in all monitors"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:14
-msgid "Upside-down"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:15
-msgid "_Detect monitors"
-msgstr "_D မော်နီတာကိုမှတ်ယူ"
-
-#: ../capplets/display/display-capplet.ui.h:16
-msgid "_Resolution:"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:17
-msgid "_Show monitors in panel"
-msgstr "_S မော်နီတာကိုဘာတန်းတွင်ဖော်ပြပါ"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change resolution and position of monitors"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Monitors"
-msgstr "မော်နီတာ"
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:44
-#, c-format
-msgid ""
-"Usage: %s SOURCE_FILE DEST_NAME\n"
-"\n"
-"This program installs a RANDR profile for multi-monitor setups into\n"
-"a systemwide location.  The resulting profile will get used when\n"
-"the RANDR plug-in gets run in gnome-settings-daemon.\n"
-"\n"
-"SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
-"xml\n"
-"\n"
-"DEST_NAME - relative name for the installed file.  This will get put in\n"
-"            the systemwide directory for RANDR configurations,\n"
-"            so the result will typically be %s/DEST_NAME\n"
-msgstr ""
-
-#. Translators: only able to install RANDR profiles as root
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:151
-msgid "This program can only be used by the root user"
-msgstr ""
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:168
-msgid "The source filename must be absolute"
-msgstr ""
-
-#. Translators: first %s is a filename; second %s is an error message
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:179
-#, c-format
-msgid "Could not open %s: %s\n"
-msgstr ""
-
-#. Translators: first %s is a filename; second %s is an error message
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:188
-#, c-format
-msgid "Could not get information for %s: %s\n"
-msgstr ""
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:195
-#, c-format
-msgid "%s must be a regular file\n"
-msgstr ""
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:204
-msgid "This program must only be run through pkexec(1)"
-msgstr ""
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:209
-msgid "PKEXEC_UID must be set to an integer value"
-msgstr ""
-
-#. Translators: we are complaining that a file must be really owned by the user who called this program
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:215
-#, c-format
-msgid "%s must be owned by you\n"
-msgstr ""
-
-#. Translators: here we are saying that a plain filename must look like "filename", not like "some_dir/filename"
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:223
-#, c-format
-msgid "%s must not have any directory components\n"
-msgstr ""
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:231
-#, c-format
-msgid "%s must be a directory\n"
-msgstr "%s  သည်ဖိုင်လမ်းညွှန်ဖြစ်နိုင်သည်\n"
-
-#. Translators: the first %s/%s is a directory/filename; the last %s is an error message
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:242
-#, c-format
-msgid "Could not open %s/%s: %s\n"
-msgstr "%s/%s: %s ကိုဖွင့်မရပါ\n"
-
-#: ../capplets/display/gnome-display-properties-install-systemwide.c:262
-#, c-format
-msgid "Could not rename %s to %s: %s\n"
-msgstr "%s to %s: %s အမည်ပြောင်းမရပါ\n"
-
-#: ../capplets/display/org.gnome.randr.policy.in.h:1
-msgid ""
-"Authentication is required to install multi-monitor settings for all users"
-msgstr ""
-
-#: ../capplets/display/org.gnome.randr.policy.in.h:2
-msgid "Install multi-monitor settings for the whole system"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:314
-msgid "Upside Down"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:356
-#, c-format
-msgid "%d Hz"
-msgstr ""
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../capplets/display/xrandr-capplet.c:504
-#: ../capplets/display/xrandr-capplet.c:1650
-msgid "Mirror Screens"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:506
-#, c-format
-msgid "Monitor: %s"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:584
-#, c-format
-msgid "%d x %d"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1506
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:2071
-msgid "Could not save the monitor configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:2093
-msgid "Could not get session bus while applying display configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:2135
-msgid "Could not detect displays"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:2327
-msgid "The monitor configuration has been saved"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:2329
-msgid "This configuration will be used the next time someone logs in."
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:2338
-msgid "Could not set the default configuration for monitors"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:2422
-msgid "Could not get screen information"
-msgstr ""
-
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-msgid "Sound"
-msgstr "အသံ"
-
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-#: ../libslab/bookmark-agent.c:1183
-msgid "Desktop"
-msgstr "အလုပ်ခုံ"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:119
-#: ../typing-break/drwright.c:498
-msgid "Disabled"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:200
-msgid "<Unknown Action>"
-msgstr "<အမည်မသိလုပ်ဆောင်ချက်>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:950
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1581
-msgid "Custom Shortcuts"
-msgstr "စိတ်ကြိုက အမြန်ခလုတ်"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1092
-msgid "Error saving the new shortcut"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1171
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1201
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1207
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1215
-msgid "_Reassign"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1335
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1536
-msgid "Too many custom shortcuts"
-msgstr "စိတ်ကြိုက်အမြန်ခလုတ်များ များလွန်းသည်"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1832
-msgid "Action"
-msgstr "လုပ်ဆောင်ချက်"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1854
-msgid "Shortcut"
-msgstr "အမြန်ခလုတ်"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:2
-msgid "Custom Shortcut"
-msgstr "စိတ်ကြိုက်အမြန်ခလုတ်"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:3
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "ကီးဘုတ် အမြန်ခလုတ်"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:4
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new key "
-"combination, or press backspace to clear."
-msgstr ""
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "ကွန်မန်းသို့အမြန်ခလုတ်များကို ထည့်သွင်းပါ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:205
-#: ../capplets/keyboard/gnome-keyboard-properties.c:210
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:215
-msgid "Start the page with the typing break settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:220
-msgid "Start the page with the accessibility settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:226
-msgid "- GNOME Keyboard Preferences"
-msgstr "GNOME ကီးဘုတ်လိုလားချက်များ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:1
-msgid "Beep when _accessibility features are turned on or off"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:2
-msgid "Beep when a _modifier key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:3
-msgid "Beep when a _toggle key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:4
-msgid "Beep when a key is pr_essed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:5
-msgid "Beep when a key is reje_cted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:6
-msgid "Beep when key is _accepted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:7
-msgid "Beep when key is _rejected"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:8
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:4
-msgid "Bounce Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:9
-msgid "Flash _window titlebar"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:10
-msgid "Flash entire _screen"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:11
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:14
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:15
-msgid "General"
-msgstr "အထွေထွေရေးရာ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:12
-msgid "Keyboard Accessibility Audio Feedback"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:13
-msgid "Show _visual feedback for the alert sound"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:14
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:39
-msgid "Slow Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:15
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:40
-msgid "Sticky Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:16
-msgid "Visual cues for sounds"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:2
-msgid "All_ow postponing of breaks"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:3
-msgid "Audio _Feedback..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:5
-msgid "Check if breaks are allowed to be postponed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:6
-msgid "Cursor Blinking"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:7
-msgid "Cursor _blinks in text fields"
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:8
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:4
-msgid "Cursor blinks speed"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:9
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:5
-msgid "D_elay:"
-msgstr "_E ကြာချိန်"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:10
-msgid "Disa_ble sticky keys if two keys are pressed together"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:11
-msgid "Duration of the break when typing is disallowed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:12
-msgid "Duration of work before forcing a break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:13
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:14
-msgid "Fast"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:15
-msgid "Key presses _repeat when key is held down"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:16
-msgid "Keyboard Preferences"
-msgstr "ကီးဘုတ်လိုလားချက်"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:17
-msgid "Keyboard _model:"
-msgstr "ကီးဘုတ်အမျိုးအစား"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:18
-msgid "Layouts"
-msgstr "လက်ကွက်"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:19
-msgid "List of keyboard layouts selected for usage"
-msgstr "အသုံးပြုရန်အတွက် ကီးဘုတ်လက်ကွက်စာရင်း"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:20
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:21
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:19
-msgid "Long"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:22
-msgid "Mouse Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:23
-msgid "Move _Down"
-msgstr "_D အောက်"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:24
-msgid "Move _Up"
-msgstr "_U အပေါ်"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:25
-msgid "Move the selected keyboard layout down in the list"
-msgstr "စာရင်းထဲမှ ကီးဘုတ်ပုံစံကို အောက်သို့ချပါ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:26
-msgid "Move the selected keyboard layout up in the list"
-msgstr "စာရင်းထဲမှ ကီးဘုတ်ပုံစံကို အပေါ်သို့တင်ပါ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:27
-msgid "New windows u_se active window's layout"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:28
-msgid "Print a diagram of the selected keyboard layout"
-msgstr "ရွေးချယ်သည့် ကီးဘုတ်လက်ကွက်ပုံစံကို ပုံနှိပ်ပါ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:29
-msgid "Remove the selected keyboard layout from the list"
-msgstr "ရွေးချယ်လိုက်သည့် ကီးဘုတ်လက်ကွက်ကိုစာရင်းမှဖယ်ထုတ်ပါ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:30
-msgid "Repeat Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:31
-msgid "Repeat keys speed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:32
-msgid ""
-"Replace the current keyboard layout settings with the\n"
-"default settings"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:34
-msgid "Reset to De_faults"
-msgstr "_F မူလတိုင်းပြန်သတ်မှတ်"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:35
-msgid "S_peed:"
-msgstr "_P အမြန်နှုန်း"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:36
-msgid "Select a keyboard layout to be added to the list"
-msgstr "စာရင်းထဲသို့ထည့်ရန် ကီးဘုတ်လက်ကွက်ကိုရွေးပါ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:37
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:27
-msgid "Short"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:38
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:30
-msgid "Slow"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:41
-msgid "Typing Break"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:42
-msgid "View and edit keyboard layout options"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:43
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:37
-msgid "_Acceleration:"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:44
-msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:46
-msgid "_Break interval lasts:"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:47
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:38
-msgid "_Delay:"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:48
-msgid "_Ignore fast duplicate keypresses"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:49
-msgid "_Lock screen to enforce typing break"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:50
-msgid "_Only accept long keypresses"
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:51
-msgid "_Options..."
-msgstr "_O ရွေးချယ်စရာများ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:52
-msgid "_Pointer can be controlled using the keypad"
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:53
-msgid "_Separate layout for each window"
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:54
-msgid "_Show..."
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:55
-msgid "_Simulate simultaneous keypresses"
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:56
-msgid "_Speed:"
-msgstr "_S အမြန်နှုန်း"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:57
-msgid "_Type to test settings:"
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:58
-msgid "_Work interval lasts:"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:59
-msgid "minutes"
-msgstr "မိနစ်"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:1
-msgid "By _country"
-msgstr "_C နိုင်ငံအရ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:2
-msgid "By _language"
-msgstr "_L ဘာသာစကားအရ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:3
-msgid "Choose a Layout"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:4
-msgid "Preview:"
-msgstr "နမူနာ"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:5
-msgid "_Country:"
-msgstr "_C နိုင်ငံ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:6
-msgid "_Language:"
-msgstr "_L ဘာသာစကား"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:7
-msgid "_Variants:"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:1
-msgid "Choose a Keyboard Model"
-msgstr "ကီးဘုတ်အမျိုးအစားရွေးပါ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:2
-msgid "_Models:"
-msgstr "_M အမျိုးအစား"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:3
-msgid "_Vendors:"
-msgstr "_V ထုတ်လုပ်သူ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-options-dialog.ui.h:1
-msgid "Keyboard Layout Options"
-msgstr "ကီးဘုတ်လက်ကွက်ရွေးချယ်ရန်"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
-msgid "Unknown"
-msgstr "အမည်မဲ့"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:242
+#: panels/windows/cc-windows-panel.ui:8
 msgid "Layout"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:168
-msgid "Vendors"
-msgstr "ထုတ်လုပ်သူ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:234
-msgid "Models"
-msgstr "အမျိုးအစားများ"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:235
-#: ../capplets/network/gnome-network-properties.c:581
-msgid "Default"
-msgstr "မူလပုံစံ"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "ကီးဘုတ်"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "ကီးဘုတ်အစီအမံများကိုသတ်မှတ်"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:89
-msgid "gesture|Move left"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:94
-msgid "gesture|Move right"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:99
-msgid "gesture|Move up"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:104
-msgid "gesture|Move down"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:109
-msgid "gesture|Disabled"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
 msgstr ""
 
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/mouse/gnome-mouse-properties.c:592
-msgid "Specify the name of the page to show (general|accessibility)"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:597
-msgid "- GNOME Mouse Preferences"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:2
-msgid "Choose type of click _beforehand"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:3
-msgid "Choose type of click with mo_use gestures"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:6
-msgid "D_ouble click:"
-msgstr "_O နှစ်ချက်နှိပ်"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:7
-msgid "D_rag click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:8
-msgid "Disable _touchpad while typing"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:9
-msgid "Double-Click Timeout"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:10
-msgid "Drag and Drop"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:11
-msgid "Dwell Click"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:12
-msgid "Enable _mouse clicks with touchpad"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:13
-msgid "Enable h_orizontal scrolling"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:16
-msgid "High"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:18
-msgid "Locate Pointer"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:20
-msgid "Low"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:21
-msgid "Mouse Orientation"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:22
-msgid "Mouse Preferences"
-msgstr "မောက်(စ်)လိုလားချက်"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:23
-msgid "Pointer Speed"
-msgstr "ပွိုင့်တာ အမြန်နှုန်း"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:24
-msgid "Scrolling"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:25
-msgid "Seco_ndary click:"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
 msgstr "_N "
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:26
-msgid "Sh_ow position of pointer when the Control key is pressed"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "ဝင်းဒိုး"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:28
-msgid "Show click type _window"
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:29
-msgid "Simulated Secondary Click"
-msgstr ""
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "_N "
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:32
-msgid "Thr_eshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:33
-msgid ""
-"To test your double-click settings, try to double-click on the light bulb."
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:34
-msgid "Touchpad"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:35
-msgid "Two-_finger scrolling"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:36
-msgid "You can also use the Dwell Click panel applet to choose the click type."
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:39
-msgid "_Disabled"
-msgstr "_D အသုံးမပြု"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:40
-msgid "_Edge scrolling"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:41
-msgid "_Initiate click when stopping pointer movement"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:42
-msgid "_Left-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:43
-msgid "_Motion threshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:44
-msgid "_Right-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:45
-msgid "_Sensitivity:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:46
-msgid "_Single click:"
-msgstr "_S တစ်ချက်နှိပ်"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:47
-msgid "_Timeout:"
-msgstr "_T ကြာချိန်"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:48
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr ""
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "မောက်(စ်)"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "မောက်(စ်)လိုလားချက်များကို သတ်မှတ်ပါ"
-
-#: ../capplets/network/gnome-network-properties.c:699
-#: ../capplets/network/gnome-network-properties.c:850
-msgid "New Location..."
-msgstr "တည်နေရာအသစ်"
-
-#: ../capplets/network/gnome-network-properties.c:816
-msgid "Location already exists"
-msgstr "တည်နေရာသတ်မှတ်ထားပြီး"
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "ကွန်ရက် ကြားခံ"
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "ကွန်ရက် ကြားခံလိုလားချက်ကိုသတ်မှတ်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>_R အင်တာနက်ကိုတိုက်ရိုက်ချိတ်ခြင်း</b>"
-
-#: ../capplets/network/gnome-network-properties.ui.h:2
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>_A ကြားခံကိုအလိုအလျောက်သတ်မှတ်ခြင်း</b>"
-
-#: ../capplets/network/gnome-network-properties.ui.h:3
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "_M စိတ်ကြိုက်ကြားခံသတ်မှတ်ခြင်း"
-
-#: ../capplets/network/gnome-network-properties.ui.h:4
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_U အသိအမှတ်ပြုခြင်း</b>"
-
-#: ../capplets/network/gnome-network-properties.ui.h:5
-msgid "Autoconfiguration _URL:"
-msgstr "_U အလိုအလျောက် URL သတ်မှတ်ခြင်း"
-
-#: ../capplets/network/gnome-network-properties.ui.h:6
-msgid "C_reate"
-msgstr "_R ထည့်သွင်း"
-
-#: ../capplets/network/gnome-network-properties.ui.h:7
-msgid "Create New Location"
-msgstr "နေရာအသစ်ထည့်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:8
-msgid "HTTP Proxy Details"
-msgstr "HTTP ကြားခံအသေးစိတ်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:9
-msgid "H_TTP proxy:"
-msgstr "_T HTTP ကြားခံ"
-
-#: ../capplets/network/gnome-network-properties.ui.h:10
-msgid "Ignore Host List"
-msgstr "အသုံးမပြုသည့် အခြေစိုက်စာရင်း"
-
-#: ../capplets/network/gnome-network-properties.ui.h:11
-msgid "Ignored Hosts"
-msgstr "အသုံးမပြုသည့် အခြေစိုက်များ"
-
-#: ../capplets/network/gnome-network-properties.ui.h:12
-msgid "Location:"
-msgstr "တည်နေရာ"
-
-#: ../capplets/network/gnome-network-properties.ui.h:13
-msgid "Network Proxy Preferences"
-msgstr "နက်ဝက် ကြားခံလိုလားချက် သတ်မှတ်ရန်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:14
-msgid "Port:"
-msgstr "ဆက်သွယ်ပေါက်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:15
-msgid "Proxy Configuration"
-msgstr "ကြားခံ သတ်မှတ်ခြင်း"
-
-#: ../capplets/network/gnome-network-properties.ui.h:16
-msgid "S_ocks host:"
-msgstr "_O Socks အခြေစိုက်ရာ"
-
-#: ../capplets/network/gnome-network-properties.ui.h:17
-msgid "The location already exists."
-msgstr "တည်နေရာကိုထည့်သွင်းပြီသားဖြစ်သည်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:18
-msgid "U_sername:"
-msgstr "_S အသုံးပြုအမည်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:19
-msgid "_Delete Location"
-msgstr "_D တည်နေရာကိုဖျက်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:20
-msgid "_Details"
-msgstr "_D အသေးစိတ်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:21
-msgid "_FTP proxy:"
-msgstr "_FTP ကြားခံ"
-
-#: ../capplets/network/gnome-network-properties.ui.h:22
-msgid "_Location name:"
-msgstr "_L တည်နေရာ"
-
-#: ../capplets/network/gnome-network-properties.ui.h:23
-msgid "_Password:"
-msgstr "_P စကားဝှက်"
-
-#: ../capplets/network/gnome-network-properties.ui.h:24
-msgid "_Secure HTTP proxy:"
-msgstr "_S HTTPs ကြားခံ"
-
-#: ../capplets/network/gnome-network-properties.ui.h:25
-msgid "_Use the same proxy for all protocols"
-msgstr "_U ပရိုတိုကောအားလုံးအတွက် ကြားခံ တစ်မျိုးသာသုံးမည်"
-
-#: ../capplets/windows/gnome-window-properties.c:344
-msgid "Cannot start the preferences application for your window manager"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:603
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:609
-msgid "H_yper"
-msgstr "H_yper"
-
-#: ../capplets/windows/gnome-window-properties.c:616
-msgid "S_uper (or \"Windows logo\")"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:623
-msgid "_Meta"
-msgstr "_Meta"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:1
-msgid "Movement Key"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:2
-msgid "Titlebar Action"
-msgstr "ခေါင်းစီးဘားတန်းလုပ်ဆောင်မှု"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:3
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:4
-msgid "Window Preferences"
-msgstr "ဝင်ဒိုးလိုလားချက်များ"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:5
-msgid "Window Selection"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_D အခုလုပ်ဆောင်မှုကိုပြုလုပ်ရန် ခေါင်းစဉ်ဘားတန်းကို နှစ်ချက်နှိပ်ပါ"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:7
-msgid "_Interval before raising:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:8
-msgid "_Raise selected windows after an interval"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:10
-msgid "seconds"
-msgstr "စက္ကန့်"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "ဝင်းဒိုးဆိုင်ရာ ဂုဏ်သတ္တိများသတ်မှတ်ပါ"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
 msgid "Windows"
 msgstr "ဝင်းဒိုး"
 
-#: ../libwindow-settings/gnome-wm-manager.c:316
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "နေရပ်လိပ်စာ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_D အသေးစိတ်"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "ကွန်ရက် ကြားခံ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "ကွန်ရက်ဆာဗာများ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "_D အသေးစိတ်"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:404
-msgid "Maximize"
-msgstr "အကျယ်ချဲ့"
-
-#: ../libwindow-settings/metacity-window-manager.c:405
-msgid "Maximize Vertically"
-msgstr "ဒေါင်လိုက်အကျယ်ချဲ့"
-
-#: ../libwindow-settings/metacity-window-manager.c:406
-msgid "Maximize Horizontally"
-msgstr "အလျားလိုက်အကျယ်ချဲ့"
-
-#: ../libwindow-settings/metacity-window-manager.c:407
-msgid "Minimize"
-msgstr "ဖျောက်ထား"
-
-#: ../libwindow-settings/metacity-window-manager.c:408
-msgid "Roll up"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:409
-msgid "None"
-msgstr "မသတ်မှတ်ထား"
-
-#: ../shell/control-center.c:49
-#, c-format
-msgid "key not found [%s]\n"
-msgstr ""
-
-#: ../shell/control-center.c:143
-msgid "Hide on start (useful to preload the shell)"
-msgstr ""
-
-#: ../shell/control-center.c:182
-msgid "Filter"
-msgstr "စစ်ထုတ်ရန်"
-
-#: ../shell/control-center.c:182
-msgid "Groups"
-msgstr ""
-
-#: ../shell/control-center.c:182
-msgid "Common Tasks"
-msgstr ""
-
-#: ../shell/control-center.c:185 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "ထိန်းချုပ်ခန်း"
-
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:5
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:8
-msgid ""
-"Indicates whether to close the shell when an add or remove action is "
-"performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:9
-msgid ""
-"Indicates whether to close the shell when an upgrade or uninstall action is "
-"performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:11
-msgid ""
-"The task name to be displayed in the control-center followed by a \";\" "
-"separator then the filename of an associated .desktop file to launch for "
-"that task."
-msgstr ""
-
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
-msgid ""
-"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
-"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:14
-msgid ""
-"if true, the control-center will close when a \"Common Task\" is activated."
-msgstr ""
-
-#: ../shell/gnomecc.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr " GNOME ခန့်ခွဲမှုကရိယာ"
-
-#: ../typing-break/drw-break-window.c:194
-msgid "_Postpone Break"
-msgstr "_P ရွှေ့ဆိုင်း"
-
-#: ../typing-break/drw-break-window.c:250
-msgid "Take a break!"
-msgstr ""
-
-#: ../typing-break/drwright.c:136
-msgid "_Take a Break"
-msgstr ""
-
-#: ../typing-break/drwright.c:507
-#, c-format
-msgid "Take a break now (next in %dm)"
-msgstr ""
-
-#: ../typing-break/drwright.c:509
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
 msgstr[0] ""
 
-#: ../typing-break/drwright.c:515
+#: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
-msgid "Take a break now (next in less than one minute)"
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
 
-#: ../typing-break/drwright.c:517
-#, c-format
-msgid "Less than one minute until the next break"
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
 msgstr ""
 
-#: ../typing-break/drwright.c:614
-#, c-format
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_M မိုဘိုင်းဖုန်း"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "ကွန်ရက် ကြားခံ"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "ကွန်ရက် ကြားခံ"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_D အသေးစိတ်"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "ကွန်ရက် ကြားခံ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_A အသိအမှတ်ပြု"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "ကွန်ရက်ဆာဗာများ"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr ""
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
 msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
 
-#: ../typing-break/drwright.c:631
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr ""
-
-#: ../typing-break/drwright.c:632
-msgid "Eye candy added by Anders Carlsson"
-msgstr ""
-
-#: ../typing-break/drwright.c:641
-msgid "A computer break reminder."
-msgstr ""
-
-#: ../typing-break/drwright.c:643
-msgid "translator-credits"
-msgstr "လိုကယ်လိုက်ဇေးရှင်း ဂုဏ်ပြုလွှာ"
-
-#: ../typing-break/main.c:63
-msgid "Enable debugging code"
-msgstr ""
-
-#: ../typing-break/main.c:65
-msgid "Don't check whether the notification area exists"
-msgstr ""
-
-#: ../typing-break/main.c:91
-msgid "Typing Monitor"
-msgstr ""
-
-#: ../typing-break/main.c:108
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:5
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr ""
-
-#: ../font-viewer/font-view.c:293
-msgid "Name:"
-msgstr "အမည်"
-
-#: ../font-viewer/font-view.c:296
-msgid "Style:"
-msgstr "ပုံစံ"
-
-#: ../font-viewer/font-view.c:309
-msgid "Type:"
-msgstr "အမျိုးအစား"
-
-#: ../font-viewer/font-view.c:313
-msgid "Size:"
-msgstr "အရွယ်အစား"
-
-#: ../font-viewer/font-view.c:357 ../font-viewer/font-view.c:370
-msgid "Version:"
-msgstr "ဗာရှင်း"
-
-#: ../font-viewer/font-view.c:361 ../font-viewer/font-view.c:372
-msgid "Copyright:"
-msgstr "မူပိုင်ခွင့်"
-
-#: ../font-viewer/font-view.c:365
-msgid "Description:"
-msgstr "အကြောင်းအရာ"
-
-#: ../font-viewer/font-view.c:445
-msgid "Installed"
-msgstr "သွင်းယူမှုပြီးဆုံးပြီ"
-
-#: ../font-viewer/font-view.c:448
-msgid "Install Failed"
-msgstr "သွင်းယူခြင်းမပြီးဆုံးပါ"
-
-#: ../font-viewer/font-view.c:519
-#, c-format
-msgid "usage: %s fontfile\n"
-msgstr ""
-
-#: ../font-viewer/font-view.c:590
-msgid "I_nstall Font"
-msgstr "_N ဖောင့်သွင်းရန်"
-
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
-msgid "Font Viewer"
-msgstr "ဖောင့်ကြည့်ရန်"
-
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
-msgid "Preview fonts"
-msgstr "ဖောင့်နမူနာကြည့်"
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "Text to thumbnail (default: Aa)"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "TEXT"
-msgstr "စာသား"
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "Font size (default: 64)"
-msgstr "ဖောင့်အရွယ်အစား (ပုံသေ ၆၄)"
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "SIZE"
-msgstr "အရွယ်အစား"
-
-#: ../font-viewer/font-thumbnailer.c:249
-msgid "FONT-FILE OUTPUT-FILE"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:268
-#, c-format
-msgid "Error parsing arguments: %s\n"
-msgstr ""
-
-#: ../libslab/app-shell.c:754
-#, c-format
-msgid "Your filter \"%s\" does not match any items."
-msgstr ""
-
-#: ../libslab/app-shell.c:756
-msgid "No matches found."
-msgstr "တူညီသည့်အရာမတွေ့ပါ"
-
-#: ../libslab/app-shell.c:909
-msgid "Other"
-msgstr "အခြား"
-
-#. make start action
-#: ../libslab/application-tile.c:374
-#, c-format
-msgid "Start %s"
-msgstr ""
-
-#: ../libslab/application-tile.c:395
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "အကူအညီ"
 
-#: ../libslab/application-tile.c:442
-msgid "Upgrade"
-msgstr "မွမ်းမံ/အဆင်မြှင့်"
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "အထွေထွေရေးရာ"
 
-#: ../libslab/application-tile.c:457
-msgid "Uninstall"
-msgstr "ဖယ်ထုတ်"
-
-#: ../libslab/application-tile.c:784 ../libslab/document-tile.c:738
-msgid "Remove from Favorites"
-msgstr "နှစ်သက်မှုအဖြစ်မှပယ်ဖျက်ပါ"
-
-#: ../libslab/application-tile.c:786 ../libslab/document-tile.c:740
-msgid "Add to Favorites"
-msgstr "နှစ်သက်မှုအဖြစ်ထည့်ပါ"
-
-#: ../libslab/application-tile.c:871
-msgid "Remove from Startup Programs"
-msgstr "ကနဉီးအပ္ပလီကေးရှင်းမှဖယ်ထုတ်ပါ"
-
-#: ../libslab/application-tile.c:873
-msgid "Add to Startup Programs"
-msgstr "ကနဉီးအပ္ပလီကေးရှင်းသို့ထည့်ပါ"
-
-#: ../libslab/bookmark-agent.c:1110
-msgid "New Spreadsheet"
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
 msgstr ""
 
-#: ../libslab/bookmark-agent.c:1115
-msgid "New Document"
-msgstr "စာတမ်းအသစ်ယူ"
-
-#: ../libslab/bookmark-agent.c:1168
-msgctxt "Home folder"
-msgid "Home"
-msgstr ""
-
-#: ../libslab/bookmark-agent.c:1175
-msgid "Documents"
-msgstr "စာတမ်းများ"
-
-#: ../libslab/bookmark-agent.c:1190
-msgid "File System"
-msgstr "ဖိုင်စနစ်"
-
-#: ../libslab/bookmark-agent.c:1194
-msgid "Network Servers"
-msgstr "ကွန်ရက်ဆာဗာများ"
-
-#: ../libslab/bookmark-agent.c:1223
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Search"
 msgstr "ရှာဖွေရန်"
 
-#. make open with default action
-#: ../libslab/directory-tile.c:171
-#, c-format
-msgid "<b>Open</b>"
-msgstr "<b>ဖွင့်ရန်</b>"
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "ဘားတန်းပုံသကင်္တ"
 
-#. make rename action
-#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:236
-msgid "Rename..."
-msgstr "အမည်ပြောင်းရန်"
-
-#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
-#: ../libslab/document-tile.c:250 ../libslab/document-tile.c:259
-msgid "Send To..."
-msgstr "ပို့ရန်"
-
-#. make move to trash action
-#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:285
-msgid "Move to Trash"
-msgstr "အမှိုက်ပုံးထဲထည့်ပါ"
-
-#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
-#: ../libslab/document-tile.c:295 ../libslab/document-tile.c:854
-msgid "Delete"
-msgstr "ဖျက်ပစ်ပါ"
-
-#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:1016
-#, c-format
-msgid "Are you sure you want to permanently delete \"%s\"?"
-msgstr "\"%s\" ကိုဖျက်ပစ်တော့မှာလား"
-
-#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:1017
-msgid "If you delete an item, it is permanently lost."
-msgstr "ဖျက်မယ်ဆိုရင် ပြန်မရနိုင်တော့ဘူးနော်"
-
-#: ../libslab/document-tile.c:195
-#, c-format
-msgid "Open with \"%s\""
-msgstr "\"%s\" နှင့်ဖွင့်ရန်"
-
-#: ../libslab/document-tile.c:209
-msgid "Open with Default Application"
-msgstr "မူရင်းအပ္ပလီကေးရှင်းနှင့်ဖွင့်ရန်"
-
-#: ../libslab/document-tile.c:220
-msgid "Open in File Manager"
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
 msgstr ""
 
-#. clean item from menu
-#: ../libslab/document-tile.c:304
-msgid "Remove from recent menu"
-msgstr "လက်တလောမီနူးမှဖယ်ထုတ်ပါ"
-
-#. clean all the items from menu
-#: ../libslab/document-tile.c:312
-msgid "Purge all the recent items"
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
 msgstr ""
 
-#: ../libslab/document-tile.c:634
-msgid "?"
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "လိုလားချက်"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
 msgstr ""
 
-#: ../libslab/document-tile.c:641
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
 
-#: ../libslab/document-tile.c:649
-msgid "Today %l:%M %p"
-msgstr "ယနေ့ %l:%M %p"
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
 
-#: ../libslab/document-tile.c:659
-msgid "Yesterday %l:%M %p"
-msgstr "မနေ့က  %l:%M %p"
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
 
-#: ../libslab/document-tile.c:671
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
 
-#: ../libslab/document-tile.c:679
-msgid "%b %d %l:%M %p"
-msgstr "%b %d %l:%M %p"
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
 
-#: ../libslab/document-tile.c:681
-msgid "%b %d %Y"
-msgstr "%b %d %Y"
-
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
-msgstr "ရှာဖွေပါ"
-
-#: ../libslab/system-tile.c:127
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
-msgid "<b>Open %s</b>"
-msgstr "<b>%s ကိုဖွင့်ရန်</b>"
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
 
-#: ../libslab/system-tile.c:140
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
-msgid "Remove from System Items"
-msgstr "စနစ်ပိုင်းဆိုင်ရာမှ ဖယ်ထုတ်ပါ"
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+
+#~ msgid "Current network location"
+#~ msgstr "လက်ရှိကွန်ရက်တည်နေရာ"
+
+#~ msgid "The type of alert"
+#~ msgstr "အချက်ပေးပုံစံ"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "အချက်ပေးဖောင်တွင်ပြမည့်ခလုတ်များ"
+
+#~ msgid "Show more _details"
+#~ msgstr "အသေးစိတ်ကြည့်ရန်"
+
+#~ msgid "No Image"
+#~ msgstr "ပုံမရှိပါ"
+
+#~ msgid "Images"
+#~ msgstr "ပုံများ"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "လိပ်စာစာရင်းကိုဖွင့်၍မရပါ"
+
+#~ msgid "A_ddress:"
+#~ msgstr "လိပ်စာ"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "လက်ထောက်"
+
+#~ msgid "About Me"
+#~ msgstr "ကျွန်တော့်အကြောင်း"
+
+#~ msgid "C_ity:"
+#~ msgstr "မြို့"
+
+#~ msgid "C_ompany:"
+#~ msgstr "ကုမ္မဏီ"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "စကားဝှက်ပြောင်းရန်"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "_T မြို့"
+
+#~ msgid "Co_untry:"
+#~ msgstr "_U နိုင်ငံ"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "_N  နိုင်ငံ"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "_F လက်ဗွေစနစ်ဖြင့်ဝင်ရောက်မှုကိုပယ်ဖျက်"
+
+#~ msgid "Email"
+#~ msgstr "အီးမေးလ်"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "လက်ဗွေစနစ်ဖြင့်ဝင်ရောက်မှုကိုအသုံးပြု"
+
+#~ msgid "Hom_e:"
+#~ msgstr "_E အိမ်ဖုန်း"
+
+#~ msgid "Home"
+#~ msgstr "အိမ်လိပ်စာ"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "အင်တာနက်ဆက်သွယ်မှု"
+
+#~ msgid "Job"
+#~ msgstr "အလုပ်အကိုင်"
+
+#~ msgid "Personal Info"
+#~ msgstr "ကိုယ်ရေးရာဇဝင်"
+
+#~ msgid "Select your photo"
+#~ msgstr "ဓာတ်ပုံရွေးပါ"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "_V ပြည်နယ်/စီရင်စု"
+
+#~ msgid "Telephone"
+#~ msgstr "တယ်လီဖုန်းနံပါတ်"
+
+#~ msgid "Web"
+#~ msgstr "ဝဘ်"
+
+#~ msgid "Web _log:"
+#~ msgstr "_L ဝဘ်မှတ်သားချက်"
+
+#~ msgid "Wor_k:"
+#~ msgstr "_K အလုပ်ဖုန်း"
+
+#~ msgid "Work"
+#~ msgstr "အလုပ်အကိုင်"
+
+#~ msgid "Work _fax:"
+#~ msgstr "ရုံး၏ ဖက်(စ်)"
+
+#~ msgid "_Home page:"
+#~ msgstr "_H အင်တာနက်စာမျက်နှာ"
+
+#~ msgid "_Manager:"
+#~ msgstr "_M မန်နေဂျာ"
+
+#~ msgid "_Profession:"
+#~ msgstr "_P ကျွမ်းကျင်မှု/စိတ်ဝင်စားမှု"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_S ပြည်နယ်/စီရင်စု"
+
+#~ msgid "_Title:"
+#~ msgstr "_T ခေါင်းစဉ်"
+
+#~ msgid "_Work:"
+#~ msgstr "_W အလုပ်"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "ဒရိုက်ဗ်သို့ဝင်ရောက်ခွင့်မရှိပါ စနစ်ပိုင်းခန့်ခွဲသူကိုဆက်သွယ်ပါ"
+
+#~ msgid "The device is already in use."
+#~ msgstr "ဤဒရိုက်ဗ်ကိုအသုံးပြုထားသည်"
+
+#~ msgid "An internal error occured"
+#~ msgstr "စနစ်ပိုင်းဆိုင်ရာအမှားဖြစ်ပွားသည်"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "မှတ်ပုံတင်ထားသည့်လက်ဗွေမှတ်စနစ်ကိုဖျက်သိမ်း"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "ဒရိုက်ဗ် '%s' ကိုဝင်လို့မရပါ"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "ဒရိုက်ဗ် '%s'မှာလက်ဗွေမှတ်ခြင်းကိုမလုပ်ဆောင်နိုင်ပါ"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "လက်ဗွေမှတ်ကရိယာကိုအသုံးမပြုနိုင်ပါ"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "အကူအညီအတွက် စနစ်ပိုင်းဆိုင်ရာခန့်ခဲ့သူနဲ့ဆက်သွယ်ပါ"
+
+#~ msgid "Right index finger"
+#~ msgstr "ညာလက်ညှိုး"
+
+#~ msgid "Right little finger"
+#~ msgstr "ညာလက်သန်း"
+
+#~ msgid "Right middle finger"
+#~ msgstr "ညာလက်ခလယ်"
+
+#~ msgid "Right ring finger"
+#~ msgstr "ညာလက်သူကြွယ်"
+
+#~ msgid "Right thumb"
+#~ msgstr "ညာလက်မ"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr "စကားဝှက်ပထမအကြီမ်အသိအမှတ်ပြုစဉ်ကတည်းကပြောင်းသွားပြီ ပြန်အသိအမှတ်ပြုခြင်းလုပ်ဆောင်ပါ"
+
+#~ msgid "That password was incorrect."
+#~ msgstr "စကားဝှက်မှားနေသည်"
+
+#~ msgid "Your password has been changed."
+#~ msgstr "စကားဝှက်ကိုပြောင်းပြီးပြီ"
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "စနစ်ပိုင်းဆိုင်ရာအမှား : %s."
+
+#~ msgid "The password is too simple."
+#~ msgstr "စကားဝှက်ကအရမ်းလွယ်လွန်းသည်"
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "စကားဝှက်အဟောင်းနှင့်အသစ်ပေးတဲ့စကားဝှက်တူနေသည်"
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "စကားဝှက်မှာ ဂဏန်းများနှင့် အထူးပြုအက္ခရာများပါဝင်ရမည်"
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "စကားဝှက်အဟောင်းနှင် အသစ်တူညီနေသည်"
+
+#~ msgid "The new password has already been used recently."
+#~ msgstr "စကားဝှက်အသစ်က လက်တလောအသုံးပြုထားပြီးဖြစ်သည်"
+
+#, c-format
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr " %s: %s ကိုဖွင့်မရဘူး"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "စနစ်ပိုင်းဆိုင်ရာအမှားဖြစ်သွားသည်"
+
+#~ msgid "Checking password..."
+#~ msgstr "စကားဝှက်ကို စစ်နေသည်"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "စကားဝှက်အသစ်ပြောင်းရန်  <b>စကားဝှက်ပြောင်း</b>ကိုနှိပ်ပါ"
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "<b>စကားဝှက်အသစ်</b> ရိုက်ရန်နေရာတွင် စကားဝှက်ကိုရိုက်ထည့်ပေးပါ "
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "<b>စကားဝှက်ပြန်ရိုက်ရန်</b>နေရာတွင် စကားဝှက်ကိုပြန်ရိုက်ထည့်ပေးပါ"
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "စကားဝှက်နှစ်လုံးတူညီမှုမရှိပါ"
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "_S စကားဝှက်ကိုပြောင်း"
+
+#~ msgid "Change your password"
+#~ msgstr "စကားဝှက်ပြောင်းခြင်း"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "စကားဝှက်ကိုပြောင်းရန် စကားဝှက်ကို အောက်တွင်မြင်ရသည့် စကားဝှက်များရိုက်ရန် နေရာတွင်ရိုက်၍ <b>အသိအမှတ်ပြု</"
+#~ "b>  ဆိုသည့်ခလုတ်ကိုနှိပ်ပါ"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "_P ပိုကြိုက်အပ္ပလီကေးရှင်း"
+
+#~ msgid "Font may be too large"
+#~ msgstr "ဖောင့်အရွယ်အစားကြီးလွန်းသည်"
+
+#~ msgid "Use previous font"
+#~ msgstr "အရင်ဖောင့်ပြန်သုံး"
+
+#~ msgid "Use selected font"
+#~ msgstr "ရွေးထားသည့်ဖောင့်ကိုသုံးမည်"
+
+#~ msgid "Apply Background"
+#~ msgstr "နောက်ခံပုံသတ်မှတ်"
+
+#~ msgid "Custom"
+#~ msgstr "စိတ်ကြိုက်"
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "ပုံပန်းသွင်ပြင် လိုလားချက်"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "_U စိတ်ကြိုက်"
+
+#~ msgid "Center"
+#~ msgstr "ဗဟို"
+
+#~ msgid "Customize Theme"
+#~ msgstr "စိတ်ကြိုက် အမြင်အဆင်"
+
+#~ msgid "D_etails..."
+#~ msgstr "_E အသေးစိတ်"
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "_K အလုပ်ခုံဖောင့်"
+
+#~ msgid "Fonts"
+#~ msgstr "စာလုံးပုံစံများ"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "အင်တာနက်မှ နောက်ခံများကိုဆွဲယူ"
+
+#~ msgid "Get more themes online"
+#~ msgstr "အင်တာနက်မှ အမြင်အဆင်များကိုဆွဲယူ"
+
+#~ msgid "Icons"
+#~ msgstr "ပုံသကင်္တများ"
+
+#~ msgid "Icons only"
+#~ msgstr "ပုံသကင်္တများသာ"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "အမြင်အဆင် ပြောင်းသိမ်းရန်"
+
+#~ msgid "Save _As..."
+#~ msgstr "_A ပြောင်းသိမ်းရန်..."
+
+#~ msgid "Save _background image"
+#~ msgstr "_B နောက်ခံပုံအားသိမ်းရန်"
+
+#~ msgid "Text"
+#~ msgstr "စာသား"
+
+#~ msgid "Text only"
+#~ msgstr "စာသားသာ"
+
+#~ msgid "Theme"
+#~ msgstr "အမြင်အဆင်"
+
+#~ msgid "_Description:"
+#~ msgstr "_D အကြောင်းအရာများ"
+
+#~ msgid "_Document font:"
+#~ msgstr "_D စာတမ်းဖောင့်"
+
+#~ msgid "_Install..."
+#~ msgstr "_I သွင်းရန်"
+
+#~ msgid "_Size:"
+#~ msgstr "_S အရွယ်အစား"
+
+#~ msgid "_Style:"
+#~ msgstr "_S ပုံစံ"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_W ဝင်ဒိုးခေါင်းစဉ်စာသား"
+
+#~ msgid "_Windows:"
+#~ msgstr "_W ဝင်ဒိုး"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "အလုပ်ခုံမြင်ကွင်းကိုစိတ်ကြိုက်သတ်မှတ်"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "အလုပ်ခုံ အစိတ်အပိုင်းများအတွက် အမြင်အဆင်ပက်ကေ့များကိုသွင်းပါ"
+
+#~ msgid "Theme Installer"
+#~ msgstr "အမြင်အဆင်သွင်းယူရန်"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Gnome အမြင်အဆင်ပက်ကေ့"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "အလုပ်ခုံနောက်ခံမရှိပါ"
+
+#, c-format
+#~ msgid "%d %s by %d %s"
+#~ msgstr "%d %s အရ %d %s"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "ပစ်ဇယ်"
+
+#, c-format
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "ဖိုင်တွဲ: %s"
+
+#, c-format
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "ဖိုင်တွဲ: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "အမြင်အဆင်ကိုသွင်းမရပါ"
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "အမြင်အဆင်ကိုဖြည်ချနေစဉ်အမှားဖြစ်သွားသည်"
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "ရွေးထားသည့်ဖိုင်ကိုသွင်းနေစဉ်အမှားဖြစ်သွားသည်"
+
+#, c-format
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" ကမှန်ကန်တဲ့အမြင်အဆင်မဟုတ်လောက်ဘူး"
+
+#, c-format
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "အမြင်အဆင်  \"%s\" ကိုသွင်းယူခြင်းမပြီးမြောက်ပါ"
+
+#, c-format
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "အမြင်အဆင်  \"%s\" ကိုသွင်းယူခြင်းပြီးဆုံးပြီ"
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "အမြင်အဆင်အသစ်ကိုသုံးမလား(သို့)အခုအမြင်အဆင်ပဲဆက်သုံးမလား"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "လက်ရှိအမြင်အဆင်ကိုသိမ်းထား"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "အမြင်အဆင်အသစ်ကို အသုံးချ"
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME အမြင်အဆင် %s  ကို မှန်ကန်စွာသွင်းပြီးပြီ"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "ယာယီဖိုင်လမ်းညွှန်တည်ဆောက်၍မရပါ"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "အမြင်အဆင်အသစ်ကို မှန်ကန်စွာသွင်းပြီးပြီ "
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "သွင်းယူရန်သတ်မှတ်ပေးသောလမ်းကြောင်းတွင် အမြင်အဆင်ဖိုင်များကိုမတွေ့ပါ"
+
+#~ msgid "Select Theme"
+#~ msgstr "အမြင်အဆင်ကိုရွေးပါ"
+
+#~ msgid "Theme Packages"
+#~ msgstr "အမြင်အဆင်ပက်ကေ့များ"
+
+#, c-format
+#~ msgid "Theme name must be present"
+#~ msgstr "အမြင်အဆင်အမည် ပေးရမည်"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "အမြင်အဆင်က ရှိပြီးသားဖြစ်သည် အစားထိုးပြီးအသုံးပြုမလား"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_O ထပ်ရေးသည်"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "အခုအမြင်အဆင်ကိုဖျက်ပစ်တော့မည်လား"
+
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "အမြင်အဆင်ကိုဖျက်လို့မရပါ"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr " %s အကူအညီကိုဖော်ပြစဉ်အမှားဖြစ်ပွားသည်"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "ဖိုင်ကူးယူခြင်း  %u ၏ %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' ကိုကူးယူခြင်း"
+
+#~ msgid "To URI"
+#~ msgstr "URI သို့"
+
+#~ msgid "Current URI index"
+#~ msgstr "လက်ရှိ URI အမှတ်"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "လက်ရှိ URI အမှတ် - ၁ မှ အစပြုသည်"
+
+#~ msgid "Total URIs"
+#~ msgstr "URIs စုစုပေါင်း"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "URIs အာလုံးပေါင်းအရေအတွက်"
+
+#, c-format
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "ဖိုင် '%s' ကရှိပြီးသားဖြစ်သည် အစားထိုးယူမလား"
+
+#~ msgid "_Skip"
+#~ msgstr "_S ကျော်ပါ"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "_A အားလုံးအစားထိုးပါ"
+
+#~ msgid "Please select an image."
+#~ msgstr "ပုံကိုရွေးချယ်ပေးပါ"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "မူလညွှန်ပြသကေင်္တ - လက်ရှီ"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "အဖြူရောင်ညွှန်ပြသကေင်္တ - လက်ရှီ"
+
+#~ msgid "Select your default applications"
+#~ msgstr "ပုံသေသုံးအပ္ပလီကေးရှင်းများရွေးပါ"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "_M ကွန်မန်း"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "စကားပြောပရိုဂရမ်"
+
+#~ msgid "Internet"
+#~ msgstr "အင်တာနက်"
+
+#~ msgid "Multimedia"
+#~ msgstr "မာတီမီဒီယာ"
+
+#~ msgid "Run at st_art"
+#~ msgstr "_A အစပြုပြုချင်း ဖွင့်ပါ"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "_E တာမီနယ်တွင်ဖွင့်ပါ"
+
+#~ msgid "Video Player"
+#~ msgstr "ရုပ်ရှင်ဖွင့်စက်"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey အီးမေးလ်"
+
+#~ msgid "Make Default"
+#~ msgstr "မူလတိုင်းသတ်မှတ်"
+
+#~ msgid "Monitor Preferences"
+#~ msgstr "မော်နီတာဆိုင်ရာလိုလားချက်"
+
+#~ msgid "Off"
+#~ msgstr "ပိတ်"
+
+#~ msgid "On"
+#~ msgstr "ဖွင့်"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "_D မော်နီတာကိုမှတ်ယူ"
+
+#~ msgid "_Show monitors in panel"
+#~ msgstr "_S မော်နီတာကိုဘာတန်းတွင်ဖော်ပြပါ"
+
+#~ msgid "Monitors"
+#~ msgstr "မော်နီတာ"
+
+#, c-format
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s  သည်ဖိုင်လမ်းညွှန်ဖြစ်နိုင်သည်\n"
+
+#, c-format
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "%s/%s: %s ကိုဖွင့်မရပါ\n"
+
+#, c-format
+#~ msgid "Could not rename %s to %s: %s\n"
+#~ msgstr "%s to %s: %s အမည်ပြောင်းမရပါ\n"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<အမည်မသိလုပ်ဆောင်ချက်>"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "စိတ်ကြိုက်အမြန်ခလုတ်များ များလွန်းသည်"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "စိတ်ကြိုက်အမြန်ခလုတ်"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "ကွန်မန်းသို့အမြန်ခလုတ်များကို ထည့်သွင်းပါ"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "GNOME ကီးဘုတ်လိုလားချက်များ"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "ကီးဘုတ်လိုလားချက်"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "ကီးဘုတ်အမျိုးအစား"
+
+#~ msgid "Layouts"
+#~ msgstr "လက်ကွက်"
+
+#~ msgid "List of keyboard layouts selected for usage"
+#~ msgstr "အသုံးပြုရန်အတွက် ကီးဘုတ်လက်ကွက်စာရင်း"
+
+#~ msgid "Move the selected keyboard layout down in the list"
+#~ msgstr "စာရင်းထဲမှ ကီးဘုတ်ပုံစံကို အောက်သို့ချပါ"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "စာရင်းထဲမှ ကီးဘုတ်ပုံစံကို အပေါ်သို့တင်ပါ"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "ရွေးချယ်သည့် ကီးဘုတ်လက်ကွက်ပုံစံကို ပုံနှိပ်ပါ"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "ရွေးချယ်လိုက်သည့် ကီးဘုတ်လက်ကွက်ကိုစာရင်းမှဖယ်ထုတ်ပါ"
+
+#~ msgid "S_peed:"
+#~ msgstr "_P အမြန်နှုန်း"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "စာရင်းထဲသို့ထည့်ရန် ကီးဘုတ်လက်ကွက်ကိုရွေးပါ"
+
+#~ msgid "By _country"
+#~ msgstr "_C နိုင်ငံအရ"
+
+#~ msgid "By _language"
+#~ msgstr "_L ဘာသာစကားအရ"
+
+#~ msgid "_Country:"
+#~ msgstr "_C နိုင်ငံ"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "ကီးဘုတ်အမျိုးအစားရွေးပါ"
+
+#~ msgid "_Models:"
+#~ msgstr "_M အမျိုးအစား"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_V ထုတ်လုပ်သူ"
+
+#~ msgid "Unknown"
+#~ msgstr "အမည်မဲ့"
+
+#~ msgid "Vendors"
+#~ msgstr "ထုတ်လုပ်သူ"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "ကီးဘုတ်အစီအမံများကိုသတ်မှတ်"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "မောက်(စ်)လိုလားချက်"
+
+#~ msgid "_Single click:"
+#~ msgstr "_S တစ်ချက်နှိပ်"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "မောက်(စ်)လိုလားချက်များကို သတ်မှတ်ပါ"
+
+#~ msgid "Location already exists"
+#~ msgstr "တည်နေရာသတ်မှတ်ထားပြီး"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "ကွန်ရက် ကြားခံလိုလားချက်ကိုသတ်မှတ်"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>_R အင်တာနက်ကိုတိုက်ရိုက်ချိတ်ခြင်း</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>_A ကြားခံကိုအလိုအလျောက်သတ်မှတ်ခြင်း</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "_M စိတ်ကြိုက်ကြားခံသတ်မှတ်ခြင်း"
+
+#~ msgid "C_reate"
+#~ msgstr "_R ထည့်သွင်း"
+
+#~ msgid "Create New Location"
+#~ msgstr "နေရာအသစ်ထည့်"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP ကြားခံအသေးစိတ်"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "အသုံးမပြုသည့် အခြေစိုက်စာရင်း"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "နက်ဝက် ကြားခံလိုလားချက် သတ်မှတ်ရန်"
+
+#~ msgid "Port:"
+#~ msgstr "ဆက်သွယ်ပေါက်"
+
+#~ msgid "The location already exists."
+#~ msgstr "တည်နေရာကိုထည့်သွင်းပြီသားဖြစ်သည်"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_S HTTPs ကြားခံ"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "Titlebar Action"
+#~ msgstr "ခေါင်းစီးဘားတန်းလုပ်ဆောင်မှု"
+
+#~ msgid "Window Preferences"
+#~ msgstr "ဝင်ဒိုးလိုလားချက်များ"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_D အခုလုပ်ဆောင်မှုကိုပြုလုပ်ရန် ခေါင်းစဉ်ဘားတန်းကို နှစ်ချက်နှိပ်ပါ"
+
+#~ msgid "Set your window properties"
+#~ msgstr "ဝင်းဒိုးဆိုင်ရာ ဂုဏ်သတ္တိများသတ်မှတ်ပါ"
+
+#~ msgid "Maximize"
+#~ msgstr "အကျယ်ချဲ့"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "ဒေါင်လိုက်အကျယ်ချဲ့"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "အလျားလိုက်အကျယ်ချဲ့"
+
+#~ msgid "Minimize"
+#~ msgstr "ဖျောက်ထား"
+
+#~ msgid "Control Center"
+#~ msgstr "ထိန်းချုပ်ခန်း"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr " GNOME ခန့်ခွဲမှုကရိယာ"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "_P ရွှေ့ဆိုင်း"
+
+#~ msgid "translator-credits"
+#~ msgstr "လိုကယ်လိုက်ဇေးရှင်း ဂုဏ်ပြုလွှာ"
+
+#~ msgid "Size:"
+#~ msgstr "အရွယ်အစား"
+
+#~ msgid "Copyright:"
+#~ msgstr "မူပိုင်ခွင့်"
+
+#~ msgid "Description:"
+#~ msgstr "အကြောင်းအရာ"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "_N ဖောင့်သွင်းရန်"
+
+#~ msgid "Font Viewer"
+#~ msgstr "ဖောင့်ကြည့်ရန်"
+
+#~ msgid "TEXT"
+#~ msgstr "စာသား"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "ဖောင့်အရွယ်အစား (ပုံသေ ၆၄)"
+
+#~ msgid "SIZE"
+#~ msgstr "အရွယ်အစား"
+
+#~ msgid "Upgrade"
+#~ msgstr "မွမ်းမံ/အဆင်မြှင့်"
+
+#~ msgid "Uninstall"
+#~ msgstr "ဖယ်ထုတ်"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "နှစ်သက်မှုအဖြစ်ထည့်ပါ"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "ကနဉီးအပ္ပလီကေးရှင်းမှဖယ်ထုတ်ပါ"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "ကနဉီးအပ္ပလီကေးရှင်းသို့ထည့်ပါ"
+
+#~ msgid "New Document"
+#~ msgstr "စာတမ်းအသစ်ယူ"
+
+#~ msgid "Documents"
+#~ msgstr "စာတမ်းများ"
+
+#~ msgid "Send To..."
+#~ msgstr "ပို့ရန်"
+
+#~ msgid "Delete"
+#~ msgstr "ဖျက်ပစ်ပါ"
+
+#, c-format
+#~ msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgstr "\"%s\" ကိုဖျက်ပစ်တော့မှာလား"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "ဖျက်မယ်ဆိုရင် ပြန်မရနိုင်တော့ဘူးနော်"
+
+#, c-format
+#~ msgid "Open with \"%s\""
+#~ msgstr "\"%s\" နှင့်ဖွင့်ရန်"
+
+#~ msgid "Remove from recent menu"
+#~ msgstr "လက်တလောမီနူးမှဖယ်ထုတ်ပါ"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "ယနေ့ %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "မနေ့က  %l:%M %p"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%b %d %l:%M %p"
+
+#~ msgid "%b %d %Y"
+#~ msgstr "%b %d %Y"
+
+#~ msgid "Find Now"
+#~ msgstr "ရှာဖွေပါ"
+
+#, c-format
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s ကိုဖွင့်ရန်</b>"
+
+#, c-format
+#~ msgid "Remove from System Items"
+#~ msgstr "စနစ်ပိုင်းဆိုင်ရာမှ ဖယ်ထုတ်ပါ"

--- a/po/my.po~
+++ b/po/my.po~
@@ -1,0 +1,3520 @@
+# Burmese Translations of gnome-control-center
+# Copyright (C) 2011 Myanmar L10n Team
+# This file is distributed under the same license as the above package.
+# ye`monkyaw <yemonkyaw007@gmail.com>, 2011.
+# Thura Hlaing <trhura@gmail.com>, 2011.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2011-11-24 08:32+0100\n"
+"PO-Revision-Date: 2011-10-14 00:28+0630\n"
+"Last-Translator: Thura Hlaing <trhura@gmail.com>\n"
+"Language-Team: Burmese <my-l10n-team@googlegroups.com>\n"
+"Language: my\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Poedit-Language: Burmese\n"
+"X-Poedit-SourceCharset: utf-8\n"
+"X-Poedit-Country: MYANMAR\n"
+"X-Generator: Narro 0.9.4 on http://translate.libreworks.info\n"
+
+#: ../gnome-control-center.schemas.in.h:1
+msgid "Current network location"
+msgstr "လက်ရှိကွန်ရက်တည်နေရာ"
+
+#: ../gnome-control-center.schemas.in.h:2
+msgid "More backgrounds URL"
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:3
+msgid "More themes URL"
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:4
+msgid ""
+"Set this to your current location name. This is used to determine the "
+"appropriate network proxy configuration."
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:5
+msgid ""
+"URL for where to get more desktop backgrounds. If set to an empty string the "
+"link will not appear."
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:6
+msgid ""
+"URL for where to get more desktop themes. If set to an empty string the link "
+"will not appear."
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:110
+msgid "Image/label border"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:111
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:120
+msgid "Alert Type"
+msgstr "အချက်ပေးအမျိုးအစား"
+
+#: ../capplets/about-me/eel-alert-dialog.c:121
+msgid "The type of alert"
+msgstr "အချက်ပေးပုံစံ"
+
+#: ../capplets/about-me/eel-alert-dialog.c:129
+msgid "Alert Buttons"
+msgstr "အချက်ပေးခလုတ်များ"
+
+#: ../capplets/about-me/eel-alert-dialog.c:130
+msgid "The buttons shown in the alert dialog"
+msgstr "အချက်ပေးဖောင်တွင်ပြမည့်ခလုတ်များ"
+
+#: ../capplets/about-me/eel-alert-dialog.c:194
+msgid "Show more _details"
+msgstr "အသေးစိတ်ကြည့်ရန်"
+
+#: ../capplets/about-me/gnome-about-me.c:716
+msgid "Select Image"
+msgstr "ပုံရွေးပါ"
+
+#: ../capplets/about-me/gnome-about-me.c:718
+msgid "No Image"
+msgstr "ပုံမရှိပါ"
+
+#: ../capplets/about-me/gnome-about-me.c:746
+#: ../capplets/appearance/appearance-desktop.c:658
+msgid "Images"
+msgstr "ပုံများ"
+
+#: ../capplets/about-me/gnome-about-me.c:750
+#: ../capplets/appearance/theme-installer.c:766
+msgid "All Files"
+msgstr "ဖိုင်အားလုံး"
+
+#: ../capplets/about-me/gnome-about-me.c:890
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:911
+msgid "Unable to open address book"
+msgstr "လိပ်စာစာရင်းကိုဖွင့်၍မရပါ"
+
+#: ../capplets/about-me/gnome-about-me.c:934
+#, c-format
+msgid "About %s"
+msgstr "%s အကြောင်း"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:1
+msgid "A_IM/iChat:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:2
+msgid "A_ddress:"
+msgstr "လိပ်စာ"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:3
+msgid "A_ssistant:"
+msgstr "လက်ထောက်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:4
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+msgid "About Me"
+msgstr "ကျွန်တော့်အကြောင်း"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:5
+msgid "Address"
+msgstr "နေရပ်လိပ်စာ"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:6
+msgid "C_ity:"
+msgstr "မြို့"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:7
+msgid "C_ompany:"
+msgstr "ကုမ္မဏီ"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:8
+msgid "Cale_ndar:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:9
+msgid "Change Passwo_rd..."
+msgstr "စကားဝှက်ပြောင်းရန်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:10
+msgid "Ci_ty:"
+msgstr "_T မြို့"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:11
+msgid "Co_untry:"
+msgstr "_U နိုင်ငံ"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:12
+msgid "Contact"
+msgstr "ဆက်သွယ်ရန်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:13
+msgid "Cou_ntry:"
+msgstr "_N  နိုင်ငံ"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:14
+msgid "Disable _Fingerprint Login..."
+msgstr "_F လက်ဗွေစနစ်ဖြင့်ဝင်ရောက်မှုကိုပယ်ဖျက်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:15
+msgid "Email"
+msgstr "အီးမေးလ်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:16
+msgid "Enable _Fingerprint Login..."
+msgstr "လက်ဗွေစနစ်ဖြင့်ဝင်ရောက်မှုကိုအသုံးပြု"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:17
+msgid "Full Name"
+msgstr "အမည်အပြည့်အစုံ"
+
+#. Home vs Work (phone)
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:19
+msgid "Hom_e:"
+msgstr "_E အိမ်ဖုန်း"
+
+#. Home vs Work (address)
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:21
+msgid "Home"
+msgstr "အိမ်လိပ်စာ"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:22
+msgid "IC_Q:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:23
+msgid "Instant Messaging"
+msgstr "အင်တာနက်ဆက်သွယ်မှု"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:24
+msgid "Job"
+msgstr "အလုပ်အကိုင်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:25
+msgid "M_SN:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:26
+msgid "P.O. _box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:27
+msgid "P._O. box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:28
+msgid "Personal Info"
+msgstr "ကိုယ်ရေးရာဇဝင်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:29
+msgid "Select your photo"
+msgstr "ဓာတ်ပုံရွေးပါ"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:30
+msgid "State/Pro_vince:"
+msgstr "_V ပြည်နယ်/စီရင်စု"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:31
+msgid "Telephone"
+msgstr "တယ်လီဖုန်းနံပါတ်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:32
+msgid "User name:"
+msgstr "အသုံးပြုမည့်အမည်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:33
+msgid "Web"
+msgstr "ဝဘ်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:34
+msgid "Web _log:"
+msgstr "_L ဝဘ်မှတ်သားချက်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:35
+msgid "Wor_k:"
+msgstr "_K အလုပ်ဖုန်း"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:36
+msgid "Work"
+msgstr "အလုပ်အကိုင်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:37
+msgid "Work _fax:"
+msgstr "ရုံး၏ ဖက်(စ်)"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:38
+msgid "ZIP/_Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:39
+msgid "_Address:"
+msgstr "_A လိပ်စာ"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:40
+msgid "_Department:"
+msgstr "_D ဌာန"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:41
+msgid "_GroupWise:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:42
+msgid "_Home page:"
+msgstr "_H အင်တာနက်စာမျက်နှာ"
+
+#. Home vs Work (email)
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:44
+msgid "_Home:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:45
+msgid "_Manager:"
+msgstr "_M မန်နေဂျာ"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:46
+msgid "_Mobile:"
+msgstr "_M မိုဘိုင်းဖုန်း"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:47
+msgid "_Profession:"
+msgstr "_P ကျွမ်းကျင်မှု/စိတ်ဝင်စားမှု"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:48
+msgid "_State/Province:"
+msgstr "_S ပြည်နယ်/စီရင်စု"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:49
+msgid "_Title:"
+msgstr "_T ခေါင်းစဉ်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:50
+msgid "_Work:"
+msgstr "_W အလုပ်"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:51
+msgid "_XMPP:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:52
+msgid "_Yahoo:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:53
+msgid "_ZIP/Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "ကိုယ်ရေးအချက်အလက်များကိုသတ်မှတ်ပါ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:100
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr "ဒရိုက်ဗ်သို့ဝင်ရောက်ခွင့်မရှိပါ စနစ်ပိုင်းခန့်ခွဲသူကိုဆက်သွယ်ပါ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:102
+msgid "The device is already in use."
+msgstr "ဤဒရိုက်ဗ်ကိုအသုံးပြုထားသည်"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:104
+msgid "An internal error occured"
+msgstr "စနစ်ပိုင်းဆိုင်ရာအမှားဖြစ်ပွားသည်"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:221
+msgid "Delete registered fingerprints?"
+msgstr "မှတ်ပုံတင်ထားသည့်လက်ဗွေမှတ်စနစ်ကိုဖျက်သိမ်း"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:224
+msgid "_Delete Fingerprints"
+msgstr "_D လက်ဗွေမှတ်စနစ်ကိုဖျက်သိမ်း"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:231
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "အသုံးပြုရန်မှတ်ပုံတင်ထားသည့် လက်ဗွေကိုဖျက်ပစ်မလား ဖျက်မယ်ဆိုရင် လက်ဗွေစနစ်ဖြင်မဝင်ရောက်နိုင်တော့ပါ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:359
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:1
+msgid "Done!"
+msgstr "ပြီးဆုံး"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:405
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:427
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "ဒရိုက်ဗ် '%s' ကိုဝင်လို့မရပါ"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:476
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "ဒရိုက်ဗ် '%s'မှာလက်ဗွေမှတ်ခြင်းကိုမလုပ်ဆောင်နိုင်ပါ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:523
+msgid "Could not access any fingerprint readers"
+msgstr "လက်ဗွေမှတ်ကရိယာကိုအသုံးမပြုနိုင်ပါ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:524
+msgid "Please contact your system administrator for help."
+msgstr "အကူအညီအတွက် စနစ်ပိုင်းဆိုင်ရာခန့်ခဲ့သူနဲ့ဆက်သွယ်ပါ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:554
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:2
+msgid "Enable Fingerprint Login"
+msgstr "လက်ဗွေမှတ်စနစ်ဖြင့်ဝင်ရောက်ခြင်းကိုအသုံးပြုပါ"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:584
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:593
+msgid "Swipe finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:595
+msgid "Place finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:3
+msgid "Left index finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:5
+msgid "Left middle finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:6
+msgid "Left ring finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:7
+msgid "Left thumb"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:8
+msgid "Other finger: "
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:9
+msgid "Right index finger"
+msgstr "ညာလက်ညှိုး"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:10
+msgid "Right little finger"
+msgstr "ညာလက်သန်း"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:11
+msgid "Right middle finger"
+msgstr "ညာလက်ခလယ်"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:12
+msgid "Right ring finger"
+msgstr "ညာလက်သူကြွယ်"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:13
+msgid "Right thumb"
+msgstr "ညာလက်မ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:14
+msgid "Select finger"
+msgstr "လက်ချောင်းရွေးပါ"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:15
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:161
+msgid "Child exited unexpectedly"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:296
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:309
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:408
+msgid "Authenticated!"
+msgstr "အသိအမှတ်ပြုသည်"
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:474
+#: ../capplets/about-me/gnome-about-me-password.c:559
+msgid ""
+"Your password has been changed since you initially authenticated! Please re-"
+"authenticate."
+msgstr "စကားဝှက်ပထမအကြီမ်အသိအမှတ်ပြုစဉ်ကတည်းကပြောင်းသွားပြီ ပြန်အသိအမှတ်ပြုခြင်းလုပ်ဆောင်ပါ"
+
+#: ../capplets/about-me/gnome-about-me-password.c:476
+msgid "That password was incorrect."
+msgstr "စကားဝှက်မှားနေသည်"
+
+#: ../capplets/about-me/gnome-about-me-password.c:527
+msgid "Your password has been changed."
+msgstr "စကားဝှက်ကိုပြောင်းပြီးပြီ"
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:537
+#, c-format
+msgid "System error: %s."
+msgstr "စနစ်ပိုင်းဆိုင်ရာအမှား : %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:540
+msgid "The password is too short."
+msgstr "စကားဝှက်တိုလွန်းသည်"
+
+#: ../capplets/about-me/gnome-about-me-password.c:544
+msgid "The password is too simple."
+msgstr "စကားဝှက်ကအရမ်းလွယ်လွန်းသည်"
+
+#: ../capplets/about-me/gnome-about-me-password.c:549
+msgid "The old and new passwords are too similar."
+msgstr "စကားဝှက်အဟောင်းနှင့်အသစ်ပေးတဲ့စကားဝှက်တူနေသည်"
+
+#: ../capplets/about-me/gnome-about-me-password.c:551
+msgid "The new password must contain numeric or special character(s)."
+msgstr "စကားဝှက်မှာ ဂဏန်းများနှင့် အထူးပြုအက္ခရာများပါဝင်ရမည်"
+
+#: ../capplets/about-me/gnome-about-me-password.c:554
+msgid "The old and new passwords are the same."
+msgstr "စကားဝှက်အဟောင်းနှင် အသစ်တူညီနေသည်"
+
+#: ../capplets/about-me/gnome-about-me-password.c:556
+msgid "The new password has already been used recently."
+msgstr "စကားဝှက်အသစ်က လက်တလောအသုံးပြုထားပြီးဖြစ်သည်"
+
+#. translators: Unable to launch <program>: <error message>
+#: ../capplets/about-me/gnome-about-me-password.c:827
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr " %s: %s ကိုဖွင့်မရဘူး"
+
+#: ../capplets/about-me/gnome-about-me-password.c:831
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:832
+msgid "A system error has occurred"
+msgstr "စနစ်ပိုင်းဆိုင်ရာအမှားဖြစ်သွားသည်"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:852
+msgid "Checking password..."
+msgstr "စကားဝှက်ကို စစ်နေသည်"
+
+#: ../capplets/about-me/gnome-about-me-password.c:939
+msgid "Click <b>Change password</b> to change your password."
+msgstr "စကားဝှက်အသစ်ပြောင်းရန်  <b>စကားဝှက်ပြောင်း</b>ကိုနှိပ်ပါ"
+
+#: ../capplets/about-me/gnome-about-me-password.c:942
+msgid "Please type your password in the <b>New password</b> field."
+msgstr "<b>စကားဝှက်အသစ်</b> ရိုက်ရန်နေရာတွင် စကားဝှက်ကိုရိုက်ထည့်ပေးပါ "
+
+#: ../capplets/about-me/gnome-about-me-password.c:945
+#: ../capplets/about-me/gnome-about-me-password.ui.h:5
+msgid ""
+"Please type your password again in the <b>Retype new password</b> field."
+msgstr "<b>စကားဝှက်ပြန်ရိုက်ရန်</b>နေရာတွင် စကားဝှက်ကိုပြန်ရိုက်ထည့်ပေးပါ"
+
+#: ../capplets/about-me/gnome-about-me-password.c:948
+msgid "The two passwords are not equal."
+msgstr "စကားဝှက်နှစ်လုံးတူညီမှုမရှိပါ"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:1
+msgid "Change pa_ssword"
+msgstr "_S စကားဝှက်ကိုပြောင်း"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:2
+msgid "Change password"
+msgstr "စကားဝှက်ပြောင်းပါ"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:3
+msgid "Change your password"
+msgstr "စကားဝှက်ပြောင်းခြင်း"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:4
+msgid "Current _password:"
+msgstr "လက်ရှိစကားဝှက်"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:6
+msgid ""
+"To change your password, enter your current password in the field below and "
+"click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for "
+"verification and click <b>Change password</b>."
+msgstr ""
+"စကားဝှက်ကိုပြောင်းရန် စကားဝှက်ကို အောက်တွင်မြင်ရသည့် စကားဝှက်များရိုက်ရန် နေရာတွင်ရိုက်၍ <b>အသိအမှတ်ပြု</"
+"b>  ဆိုသည့်ခလုတ်ကိုနှိပ်ပါ"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:8
+msgid "_Authenticate"
+msgstr "_A အသိအမှတ်ပြု"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:9
+msgid "_New password:"
+msgstr "_N စကားဝှက်အသစ်"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:10
+msgid "_Retype new password:"
+msgstr "_R စကားဝှက်ကိုပြန်ရိုက်ရန်"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:1
+msgid "Accessible Lo_gin"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:2
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:3
+msgid "Assistive Technologies Preferences"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:4
+msgid ""
+"Changes to enable assistive technologies will not take effect until your "
+"next log in."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:5
+msgid "Close and _Log Out"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:6
+msgid "Jump to Preferred Applications dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:7
+msgid "Jump to the Accessible Login dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:8
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:9
+msgid "Jump to the Mouse Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:10
+msgid "Preferences"
+msgstr "လိုလားချက်"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:11
+msgid "_Enable assistive technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:12
+msgid "_Keyboard Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:13
+msgid "_Mouse Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:14
+msgid "_Preferred Applications"
+msgstr "_P ပိုကြိုက်အပ္ပလီကေးရှင်း"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Choose which accessibility features to enable when you log in"
+msgstr ""
+
+#: ../capplets/appearance/appearance-desktop.c:627
+msgid "Add Wallpaper"
+msgstr "နောက်ခံပုံထည့်"
+
+#: ../capplets/appearance/appearance-desktop.c:662
+msgid "All files"
+msgstr "ဖိုင်အားလုံး"
+
+#: ../capplets/appearance/appearance-font.c:499
+msgid "Font may be too large"
+msgstr "ဖောင့်အရွယ်အစားကြီးလွန်းသည်"
+
+#: ../capplets/appearance/appearance-font.c:503
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+
+#: ../capplets/appearance/appearance-font.c:516
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+
+#: ../capplets/appearance/appearance-font.c:539
+msgid "Use previous font"
+msgstr "အရင်ဖောင့်ပြန်သုံး"
+
+#: ../capplets/appearance/appearance-font.c:541
+msgid "Use selected font"
+msgstr "ရွေးထားသည့်ဖောင့်ကိုသုံးမည်"
+
+#: ../capplets/appearance/appearance-main.c:56
+#, c-format
+msgid "Could not load user interface file: %s"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:135
+msgid "Specify the filename of a theme to install"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:136
+msgid "filename"
+msgstr "ဖိုင်အမည်"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/appearance/appearance-main.c:143
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:144
+#: ../capplets/default-applications/gnome-da-capplet.c:960
+#: ../capplets/mouse/gnome-mouse-properties.c:593
+msgid "page"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:151
+msgid "[WALLPAPER...]"
+msgstr ""
+
+#: ../capplets/appearance/appearance-style.c:172
+#: ../capplets/common/gnome-theme-info.c:446
+#: ../capplets/common/gnome-theme-info.c:638
+msgid "Default Pointer"
+msgstr ""
+
+#: ../capplets/appearance/appearance-style.c:235
+#: ../capplets/appearance/appearance-themes.c:685
+msgid "Install"
+msgstr ""
+
+#: ../capplets/appearance/appearance-style.c:256
+#: ../capplets/common/gnome-theme-info.c:1646
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme engine "
+"'%s' is not installed."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:673
+msgid "Apply Background"
+msgstr "နောက်ခံပုံသတ်မှတ်"
+
+#: ../capplets/appearance/appearance-themes.c:677
+msgid "Apply Font"
+msgstr "ဖောင့်ကိုသုံးပါ"
+
+#: ../capplets/appearance/appearance-themes.c:681
+msgid "Revert Font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:712
+msgid ""
+"The current theme suggests a background and a font. Also, the last applied "
+"font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:714
+msgid ""
+"The current theme suggests a background. Also, the last applied font "
+"suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:716
+msgid "The current theme suggests a background and a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:718
+msgid ""
+"The current theme suggests a font. Also, the last applied font suggestion "
+"can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:720
+msgid "The current theme suggests a background."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:722
+msgid "The last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:724
+msgid "The current theme suggests a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:1046
+#: ../capplets/default-applications/gnome-da-capplet.c:691
+msgid "Custom"
+msgstr "စိတ်ကြိုက်"
+
+#: ../capplets/appearance/data/appearance.ui.h:1
+msgid "Appearance Preferences"
+msgstr "ပုံပန်းသွင်ပြင် လိုလားချက်"
+
+#: ../capplets/appearance/data/appearance.ui.h:2
+msgid "Background"
+msgstr "နောက်ခံပုံ"
+
+#: ../capplets/appearance/data/appearance.ui.h:3
+msgid "Best _shapes"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:4
+msgid "Best co_ntrast"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:5
+msgid "C_olors:"
+msgstr "_O အရောင်"
+
+#: ../capplets/appearance/data/appearance.ui.h:6
+msgid "C_ustomize..."
+msgstr "_U စိတ်ကြိုက်"
+
+#: ../capplets/appearance/data/appearance.ui.h:7
+msgid "Center"
+msgstr "ဗဟို"
+
+#: ../capplets/appearance/data/appearance.ui.h:8
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:9
+msgid "Colors"
+msgstr "အရောင်"
+
+#: ../capplets/appearance/data/appearance.ui.h:10
+msgid "Controls"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:11
+msgid "Customize Theme"
+msgstr "စိတ်ကြိုက် အမြင်အဆင်"
+
+#: ../capplets/appearance/data/appearance.ui.h:12
+msgid "D_etails..."
+msgstr "_E အသေးစိတ်"
+
+#: ../capplets/appearance/data/appearance.ui.h:13
+msgid "Des_ktop font:"
+msgstr "_K အလုပ်ခုံဖောင့်"
+
+#: ../capplets/appearance/data/appearance.ui.h:14
+msgid "Font Rendering Details"
+msgstr "ဖောင့် အသေးစိတ်ပုံဖော်မှု"
+
+#: ../capplets/appearance/data/appearance.ui.h:15
+msgid "Fonts"
+msgstr "စာလုံးပုံစံများ"
+
+#: ../capplets/appearance/data/appearance.ui.h:16
+msgid "Get more backgrounds online"
+msgstr "အင်တာနက်မှ နောက်ခံများကိုဆွဲယူ"
+
+#: ../capplets/appearance/data/appearance.ui.h:17
+msgid "Get more themes online"
+msgstr "အင်တာနက်မှ အမြင်အဆင်များကိုဆွဲယူ"
+
+#: ../capplets/appearance/data/appearance.ui.h:18
+msgid "Gra_yscale"
+msgstr ""
+
+#. font hinting
+#: ../capplets/appearance/data/appearance.ui.h:20
+msgid "Hinting"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:21
+msgid "Horizontal gradient"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:22
+msgid "Icons"
+msgstr "ပုံသကင်္တများ"
+
+#: ../capplets/appearance/data/appearance.ui.h:23
+msgid "Icons only"
+msgstr "ပုံသကင်္တများသာ"
+
+#: ../capplets/appearance/data/appearance.ui.h:24
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:17
+msgid "Large"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:25
+msgid "N_one"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:26
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:27
+msgid "Pointer"
+msgstr "ပွိုင့်တာ"
+
+#: ../capplets/appearance/data/appearance.ui.h:28
+msgid "R_esolution:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:29
+msgid "Rendering"
+msgstr "ပုံဖော်ခြင်း"
+
+#: ../capplets/appearance/data/appearance.ui.h:30
+msgid "Save Theme As..."
+msgstr "အမြင်အဆင် ပြောင်းသိမ်းရန်"
+
+#: ../capplets/appearance/data/appearance.ui.h:31
+msgid "Save _As..."
+msgstr "_A ပြောင်းသိမ်းရန်..."
+
+#: ../capplets/appearance/data/appearance.ui.h:32
+msgid "Save _background image"
+msgstr "_B နောက်ခံပုံအားသိမ်းရန်"
+
+#: ../capplets/appearance/data/appearance.ui.h:33
+msgid "Scale"
+msgstr "စကေး"
+
+#: ../capplets/appearance/data/appearance.ui.h:34
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:31
+msgid "Small"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:35
+msgid "Smoothing"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:36
+msgid "Solid color"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:37
+msgid "Span"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:38
+msgid "Stretch"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:39
+msgid "Sub_pixel (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:40
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:41
+msgid "Subpixel Order"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:42
+msgid "Text"
+msgstr "စာသား"
+
+#: ../capplets/appearance/data/appearance.ui.h:43
+msgid "Text below items"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:44
+msgid "Text beside items"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:45
+msgid "Text only"
+msgstr "စာသားသာ"
+
+#: ../capplets/appearance/data/appearance.ui.h:46
+msgid "The current controls theme does not support color schemes."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:47
+msgid "Theme"
+msgstr "အမြင်အဆင်"
+
+#: ../capplets/appearance/data/appearance.ui.h:48
+msgid "Tile"
+msgstr ""
+
+#. vertical hinting, pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.ui.h:50
+msgid "VB_GR"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:51
+msgid "Vertical gradient"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:52
+msgid "Window Border"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:53
+msgid "Zoom"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:54
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:45
+msgid "_Add..."
+msgstr "_A ထည့်ရန်"
+
+#: ../capplets/appearance/data/appearance.ui.h:55
+msgid "_Application font:"
+msgstr "_A အပ္ပလီကေးရှင်းဖောင့်"
+
+#. pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.ui.h:57
+msgid "_BGR"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:58
+msgid "_Description:"
+msgstr "_D အကြောင်းအရာများ"
+
+#: ../capplets/appearance/data/appearance.ui.h:59
+msgid "_Document font:"
+msgstr "_D စာတမ်းဖောင့်"
+
+#: ../capplets/appearance/data/appearance.ui.h:60
+msgid "_Fixed width font:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:61
+msgid "_Full"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:62
+msgid "_Input boxes:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:63
+msgid "_Install..."
+msgstr "_I သွင်းရန်"
+
+#: ../capplets/appearance/data/appearance.ui.h:64
+msgid "_Medium"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:65
+msgid "_Monochrome"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:66
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:5
+msgid "_Name:"
+msgstr "_N အမည်"
+
+#: ../capplets/appearance/data/appearance.ui.h:67
+msgid "_None"
+msgstr "_N မသတ်မှတ်ထား"
+
+#. pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.ui.h:69
+msgid "_RGB"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:70
+msgid "_Reset to Defaults"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:71
+msgid "_Selected items:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:72
+msgid "_Size:"
+msgstr "_S အရွယ်အစား"
+
+#: ../capplets/appearance/data/appearance.ui.h:73
+msgid "_Slight"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:74
+msgid "_Style:"
+msgstr "_S ပုံစံ"
+
+#: ../capplets/appearance/data/appearance.ui.h:75
+msgid "_Tooltips:"
+msgstr ""
+
+#. vertical hinting, pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.ui.h:77
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/appearance/data/appearance.ui.h:78
+msgid "_Window title font:"
+msgstr "_W ဝင်ဒိုးခေါင်းစဉ်စာသား"
+
+#: ../capplets/appearance/data/appearance.ui.h:79
+msgid "_Windows:"
+msgstr "_W ဝင်ဒိုး"
+
+#: ../capplets/appearance/data/appearance.ui.h:80
+msgid "dots per inch"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr "အလုပ်ခုံမြင်ကွင်းကိုစိတ်ကြိုက်သတ်မှတ်"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr "အလုပ်ခုံ အစိတ်အပိုင်းများအတွက် အမြင်အဆင်ပက်ကေ့များကိုသွင်းပါ"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr "အမြင်အဆင်သွင်းယူရန်"
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr "Gnome အမြင်အဆင်ပက်ကေ့"
+
+#: ../capplets/appearance/gnome-wp-info.c:50
+msgid "No Desktop Background"
+msgstr "အလုပ်ခုံနောက်ခံမရှိပါ"
+
+#: ../capplets/appearance/gnome-wp-item.c:261
+msgid "Slide Show"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:263
+msgid "Image"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:269
+msgid "multiple sizes"
+msgstr ""
+
+#. translators: x pixel(s) by y pixel(s)
+#: ../capplets/appearance/gnome-wp-item.c:272
+#, c-format
+msgid "%d %s by %d %s"
+msgstr "%d %s အရ %d %s"
+
+#: ../capplets/appearance/gnome-wp-item.c:274
+#: ../capplets/appearance/gnome-wp-item.c:276
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "ပစ်ဇယ်"
+
+#. translators: <b>wallpaper name</b>
+#. * mime type, size
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:284
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %s\n"
+"Folder: %s"
+msgstr ""
+"<b>%s</b>\n"
+"%s, %s\n"
+"ဖိုင်တွဲ: %s"
+
+#. translators: <b>wallpaper name</b>
+#. * Image missing
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:296
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s\n"
+"Folder: %s"
+msgstr ""
+"<b>%s</b>\n"
+"%s\n"
+"ဖိုင်တွဲ: %s"
+
+#: ../capplets/appearance/gnome-wp-item.c:300
+msgid "Image missing"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:178
+#: ../capplets/appearance/theme-installer.c:234
+msgid "Cannot install theme"
+msgstr "အမြင်အဆင်ကိုသွင်းမရပါ"
+
+#: ../capplets/appearance/theme-installer.c:180
+#, c-format
+msgid "The %s utility is not installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:236
+msgid "There was a problem while extracting the theme."
+msgstr "အမြင်အဆင်ကိုဖြည်ချနေစဉ်အမှားဖြစ်သွားသည်"
+
+#: ../capplets/appearance/theme-installer.c:264
+msgid "There was an error installing the selected file"
+msgstr "ရွေးထားသည့်ဖိုင်ကိုသွင်းနေစဉ်အမှားဖြစ်သွားသည်"
+
+#: ../capplets/appearance/theme-installer.c:265
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme."
+msgstr "\"%s\" ကမှန်ကန်တဲ့အမြင်အဆင်မဟုတ်လောက်ဘူး"
+
+#: ../capplets/appearance/theme-installer.c:266
+#, c-format
+msgid ""
+"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
+"you need to compile."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:372
+#, c-format
+msgid "Installation for theme \"%s\" failed."
+msgstr "အမြင်အဆင်  \"%s\" ကိုသွင်းယူခြင်းမပြီးမြောက်ပါ"
+
+#: ../capplets/appearance/theme-installer.c:411
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr "အမြင်အဆင်  \"%s\" ကိုသွင်းယူခြင်းပြီးဆုံးပြီ"
+
+#: ../capplets/appearance/theme-installer.c:421
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr "အမြင်အဆင်အသစ်ကိုသုံးမလား(သို့)အခုအမြင်အဆင်ပဲဆက်သုံးမလား"
+
+#: ../capplets/appearance/theme-installer.c:424
+msgid "Keep Current Theme"
+msgstr "လက်ရှိအမြင်အဆင်ကိုသိမ်းထား"
+
+#: ../capplets/appearance/theme-installer.c:427
+msgid "Apply New Theme"
+msgstr "အမြင်အဆင်အသစ်ကို အသုံးချ"
+
+#: ../capplets/appearance/theme-installer.c:471
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "GNOME အမြင်အဆင် %s  ကို မှန်ကန်စွာသွင်းပြီးပြီ"
+
+#: ../capplets/appearance/theme-installer.c:533
+msgid "Failed to create temporary directory"
+msgstr "ယာယီဖိုင်လမ်းညွှန်တည်ဆောက်၍မရပါ"
+
+#: ../capplets/appearance/theme-installer.c:596
+msgid "New themes have been successfully installed."
+msgstr "အမြင်အဆင်အသစ်ကို မှန်ကန်စွာသွင်းပြီးပြီ "
+
+#: ../capplets/appearance/theme-installer.c:646
+msgid "No theme file location specified to install"
+msgstr "သွင်းယူရန်သတ်မှတ်ပေးသောလမ်းကြောင်းတွင် အမြင်အဆင်ဖိုင်များကိုမတွေ့ပါ"
+
+#: ../capplets/appearance/theme-installer.c:670
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:748
+msgid "Select Theme"
+msgstr "အမြင်အဆင်ကိုရွေးပါ"
+
+#: ../capplets/appearance/theme-installer.c:759
+msgid "Theme Packages"
+msgstr "အမြင်အဆင်ပက်ကေ့များ"
+
+#: ../capplets/appearance/theme-save.c:93
+#, c-format
+msgid "Theme name must be present"
+msgstr "အမြင်အဆင်အမည် ပေးရမည်"
+
+#: ../capplets/appearance/theme-save.c:156
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "အမြင်အဆင်က ရှိပြီးသားဖြစ်သည် အစားထိုးပြီးအသုံးပြုမလား"
+
+#: ../capplets/appearance/theme-save.c:157
+#: ../capplets/common/file-transfer-dialog.c:451
+msgid "_Overwrite"
+msgstr "_O ထပ်ရေးသည်"
+
+#: ../capplets/appearance/theme-util.c:75
+msgid "Would you like to delete this theme?"
+msgstr "အခုအမြင်အဆင်ကိုဖျက်ပစ်တော့မည်လား"
+
+#: ../capplets/appearance/theme-util.c:125
+msgid "Theme cannot be deleted"
+msgstr "အမြင်အဆင်ကိုဖျက်လို့မရပါ"
+
+#: ../capplets/appearance/theme-util.c:252
+msgid "Could not install theme engine"
+msgstr ""
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with DBus, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+
+#: ../capplets/common/capplet-stock-icons.c:66
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:88
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr " %s အကူအညီကိုဖော်ပြစဉ်အမှားဖြစ်ပွားသည်"
+
+#: ../capplets/common/file-transfer-dialog.c:98
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "ဖိုင်ကူးယူခြင်း  %u ၏ %u"
+
+#: ../capplets/common/file-transfer-dialog.c:145
+#, c-format
+msgid "Copying '%s'"
+msgstr "'%s' ကိုကူးယူခြင်း"
+
+#: ../capplets/common/file-transfer-dialog.c:185
+#: ../capplets/common/file-transfer-dialog.c:313
+msgid "Copying files"
+msgstr "ဖိုင်များကိုကူးယူခြင်း"
+
+#: ../capplets/common/file-transfer-dialog.c:224
+msgid "Parent Window"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Parent window of the dialog"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:231
+msgid "From URI"
+msgstr "URI မှတဆင့်"
+
+#: ../capplets/common/file-transfer-dialog.c:232
+msgid "URI currently transferring from"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:239
+msgid "To URI"
+msgstr "URI သို့"
+
+#: ../capplets/common/file-transfer-dialog.c:240
+msgid "URI currently transferring to"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:247
+msgid "Fraction completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:248
+msgid "Fraction of transfer currently completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:255
+msgid "Current URI index"
+msgstr "လက်ရှိ URI အမှတ်"
+
+#: ../capplets/common/file-transfer-dialog.c:256
+msgid "Current URI index - starts from 1"
+msgstr "လက်ရှိ URI အမှတ် - ၁ မှ အစပြုသည်"
+
+#: ../capplets/common/file-transfer-dialog.c:263
+msgid "Total URIs"
+msgstr "URIs စုစုပေါင်း"
+
+#: ../capplets/common/file-transfer-dialog.c:264
+msgid "Total number of URIs"
+msgstr "URIs အာလုံးပေါင်းအရေအတွက်"
+
+#: ../capplets/common/file-transfer-dialog.c:445
+#, c-format
+msgid "File '%s' already exists. Do you want to overwrite it?"
+msgstr "ဖိုင် '%s' ကရှိပြီးသားဖြစ်သည် အစားထိုးယူမလား"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "_Skip"
+msgstr "_S ကျော်ပါ"
+
+#: ../capplets/common/file-transfer-dialog.c:449
+msgid "Overwrite _All"
+msgstr "_A အားလုံးအစားထိုးပါ"
+
+#: ../capplets/common/gconf-property-editor.c:134
+msgid "Key"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:141
+msgid "Callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:147
+msgid "Change set"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:148
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:154
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:160
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1406
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1414
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1536
+msgid "Please select an image."
+msgstr "ပုံကိုရွေးချယ်ပေးပါ"
+
+#: ../capplets/common/gconf-property-editor.c:1541
+msgid "_Select"
+msgstr "_S ရွေးချယ်ပါ"
+
+#: ../capplets/common/gnome-theme-info.c:639
+msgid "Default Pointer - Current"
+msgstr "မူလညွှန်ပြသကေင်္တ - လက်ရှီ"
+
+#: ../capplets/common/gnome-theme-info.c:643
+msgid "White Pointer"
+msgstr "အဖြူရောင် ညွှန်ပြသကေင်္တ"
+
+#: ../capplets/common/gnome-theme-info.c:644
+msgid "White Pointer - Current"
+msgstr "အဖြူရောင်ညွှန်ပြသကေင်္တ - လက်ရှီ"
+
+#: ../capplets/common/gnome-theme-info.c:648
+msgid "Large Pointer"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:649
+msgid "Large Pointer - Current"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:653
+msgid "Large White Pointer - Current"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:654
+msgid "Large White Pointer"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1622
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme '%s' is "
+"not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1630
+#, c-format
+msgid ""
+"This theme will not look as intended because the required window manager "
+"theme '%s' is not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1637
+#, c-format
+msgid ""
+"This theme will not look as intended because the required icon theme '%s' is "
+"not installed."
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:17
+msgid "Preferred Applications"
+msgstr "ပိုကြိုက်ဆော့ဝဲများ"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "ပုံသေသုံးအပ္ပလီကေးရှင်းများရွေးပါ"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Start the preferred visual assistive technology"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:98
+#: ../capplets/default-applications/gnome-da-capplet.c:362
+#: ../capplets/default-applications/gnome-da-capplet.c:383
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:722
+msgid "Could not load the main interface"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:724
+msgid "Please make sure that the applet is properly installed"
+msgstr ""
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/default-applications/gnome-da-capplet.c:959
+msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:964
+msgid "- GNOME Default Applications"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:1
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:1
+msgid "Accessibility"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:3
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr ""
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:4
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:1
+msgid "C_ommand:"
+msgstr "_O ကွန်မန်း"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:5
+msgid "Co_mmand:"
+msgstr "_M ကွန်မန်း"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:6
+msgid "E_xecute flag:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:7
+msgid "Image Viewer"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:8
+msgid "Instant Messenger"
+msgstr "စကားပြောပရိုဂရမ်"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:9
+msgid "Internet"
+msgstr "အင်တာနက်"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:10
+msgid "Mail Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:11
+msgid "Mobility"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:12
+msgid "Multimedia"
+msgstr "မာတီမီဒီယာ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:13
+msgid "Multimedia Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:14
+msgid "Open link in new _tab"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:15
+msgid "Open link in new _window"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:16
+msgid "Open link with web browser _default"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:18
+msgid "Run at st_art"
+msgstr "_A အစပြုပြုချင်း ဖွင့်ပါ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:19
+msgid "Run in t_erminal"
+msgstr "_E တာမီနယ်တွင်ဖွင့်ပါ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:20
+msgid "System"
+msgstr "စနစ်ဆိုင်ရာ"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:21
+msgid "Terminal Emulator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:22
+msgid "Text Editor"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:23
+msgid "Video Player"
+msgstr "ရုပ်ရှင်ဖွင့်စက်"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:24
+msgid "Visual"
+msgstr "ပုံသွင်ပြင်"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:25
+msgid "Web Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:26
+msgid "_Run at start"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Firefox"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Galeon"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Gnopernicus"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Gnopernicus with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Iceape"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Iceape Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Icedove"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Iceweasel"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Konsole"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Listen"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Midori"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Mozilla"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Mozilla 1.6"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Mozilla Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Mozilla Thunderbird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Muine Music Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "Mutt"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+msgid "NXterm"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Netscape Communicator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Opera"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "Orca with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+msgid "RXVT"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+msgid "Rhythmbox Music Player"
+msgstr " Rhythmbox သီချင်းဖွင့်စက်"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+msgid "SeaMonkey Mail"
+msgstr "SeaMonkey အီးမေးလ်"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Standard XTerminal"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+msgid "Sylpheed"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+msgid "Sylpheed-Claws"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Terminator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Thunderbird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "Totem Movie Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
+msgid "aterm"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:1
+msgid "Include _panel"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:2
+#: ../capplets/display/xrandr-capplet.c:312
+msgid "Left"
+msgstr "ဘယ်ဘက်"
+
+#: ../capplets/display/display-capplet.ui.h:3
+msgid "Make Default"
+msgstr "မူလတိုင်းသတ်မှတ်"
+
+#: ../capplets/display/display-capplet.ui.h:4
+#: ../capplets/display/xrandr-capplet.c:515
+msgid "Monitor"
+msgstr "မော်နီတာ"
+
+#: ../capplets/display/display-capplet.ui.h:5
+msgid "Monitor Preferences"
+msgstr "မော်နီတာဆိုင်ရာလိုလားချက်"
+
+#: ../capplets/display/display-capplet.ui.h:6
+#: ../capplets/display/xrandr-capplet.c:311
+#: ../capplets/display/xrandr-capplet.c:350
+msgid "Normal"
+msgstr "ပုံမှန်"
+
+#: ../capplets/display/display-capplet.ui.h:7
+msgid "Off"
+msgstr "ပိတ်"
+
+#: ../capplets/display/display-capplet.ui.h:8
+msgid "On"
+msgstr "ဖွင့်"
+
+#: ../capplets/display/display-capplet.ui.h:9
+msgid "Panel icon"
+msgstr "ဘားတန်းပုံသကင်္တ"
+
+#: ../capplets/display/display-capplet.ui.h:10
+msgid "R_otation:"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:11
+msgid "Re_fresh rate:"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:12
+#: ../capplets/display/xrandr-capplet.c:313
+msgid "Right"
+msgstr "ညာဘက်"
+
+#: ../capplets/display/display-capplet.ui.h:13
+msgid "Sa_me image in all monitors"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:14
+msgid "Upside-down"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:15
+msgid "_Detect monitors"
+msgstr "_D မော်နီတာကိုမှတ်ယူ"
+
+#: ../capplets/display/display-capplet.ui.h:16
+msgid "_Resolution:"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:17
+msgid "_Show monitors in panel"
+msgstr "_S မော်နီတာကိုဘာတန်းတွင်ဖော်ပြပါ"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change resolution and position of monitors"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Monitors"
+msgstr "မော်နီတာ"
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:44
+#, c-format
+msgid ""
+"Usage: %s SOURCE_FILE DEST_NAME\n"
+"\n"
+"This program installs a RANDR profile for multi-monitor setups into\n"
+"a systemwide location.  The resulting profile will get used when\n"
+"the RANDR plug-in gets run in gnome-settings-daemon.\n"
+"\n"
+"SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+"xml\n"
+"\n"
+"DEST_NAME - relative name for the installed file.  This will get put in\n"
+"            the systemwide directory for RANDR configurations,\n"
+"            so the result will typically be %s/DEST_NAME\n"
+msgstr ""
+
+#. Translators: only able to install RANDR profiles as root
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:151
+msgid "This program can only be used by the root user"
+msgstr ""
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:168
+msgid "The source filename must be absolute"
+msgstr ""
+
+#. Translators: first %s is a filename; second %s is an error message
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:179
+#, c-format
+msgid "Could not open %s: %s\n"
+msgstr ""
+
+#. Translators: first %s is a filename; second %s is an error message
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:188
+#, c-format
+msgid "Could not get information for %s: %s\n"
+msgstr ""
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:195
+#, c-format
+msgid "%s must be a regular file\n"
+msgstr ""
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:204
+msgid "This program must only be run through pkexec(1)"
+msgstr ""
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:209
+msgid "PKEXEC_UID must be set to an integer value"
+msgstr ""
+
+#. Translators: we are complaining that a file must be really owned by the user who called this program
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:215
+#, c-format
+msgid "%s must be owned by you\n"
+msgstr ""
+
+#. Translators: here we are saying that a plain filename must look like "filename", not like "some_dir/filename"
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:223
+#, c-format
+msgid "%s must not have any directory components\n"
+msgstr ""
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:231
+#, c-format
+msgid "%s must be a directory\n"
+msgstr "%s  သည်ဖိုင်လမ်းညွှန်ဖြစ်နိုင်သည်\n"
+
+#. Translators: the first %s/%s is a directory/filename; the last %s is an error message
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:242
+#, c-format
+msgid "Could not open %s/%s: %s\n"
+msgstr "%s/%s: %s ကိုဖွင့်မရပါ\n"
+
+#: ../capplets/display/gnome-display-properties-install-systemwide.c:262
+#, c-format
+msgid "Could not rename %s to %s: %s\n"
+msgstr "%s to %s: %s အမည်ပြောင်းမရပါ\n"
+
+#: ../capplets/display/org.gnome.randr.policy.in.h:1
+msgid ""
+"Authentication is required to install multi-monitor settings for all users"
+msgstr ""
+
+#: ../capplets/display/org.gnome.randr.policy.in.h:2
+msgid "Install multi-monitor settings for the whole system"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:314
+msgid "Upside Down"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:356
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../capplets/display/xrandr-capplet.c:504
+#: ../capplets/display/xrandr-capplet.c:1650
+msgid "Mirror Screens"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:506
+#, c-format
+msgid "Monitor: %s"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:584
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1506
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:2071
+msgid "Could not save the monitor configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:2093
+msgid "Could not get session bus while applying display configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:2135
+msgid "Could not detect displays"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:2327
+msgid "The monitor configuration has been saved"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:2329
+msgid "This configuration will be used the next time someone logs in."
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:2338
+msgid "Could not set the default configuration for monitors"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:2422
+msgid "Could not get screen information"
+msgstr ""
+
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+msgid "Sound"
+msgstr "အသံ"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+#: ../libslab/bookmark-agent.c:1183
+msgid "Desktop"
+msgstr "အလုပ်ခုံ"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:119
+#: ../typing-break/drwright.c:498
+msgid "Disabled"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:200
+msgid "<Unknown Action>"
+msgstr "<အမည်မသိလုပ်ဆောင်ချက်>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:950
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1581
+msgid "Custom Shortcuts"
+msgstr "စိတ်ကြိုက အမြန်ခလုတ်"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1092
+msgid "Error saving the new shortcut"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1171
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1201
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1207
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1215
+msgid "_Reassign"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1335
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1536
+msgid "Too many custom shortcuts"
+msgstr "စိတ်ကြိုက်အမြန်ခလုတ်များ များလွန်းသည်"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1832
+msgid "Action"
+msgstr "လုပ်ဆောင်ချက်"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1854
+msgid "Shortcut"
+msgstr "အမြန်ခလုတ်"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:2
+msgid "Custom Shortcut"
+msgstr "စိတ်ကြိုက်အမြန်ခလုတ်"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:3
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "ကီးဘုတ် အမြန်ခလုတ်"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:4
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new key "
+"combination, or press backspace to clear."
+msgstr ""
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "ကွန်မန်းသို့အမြန်ခလုတ်များကို ထည့်သွင်းပါ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:205
+#: ../capplets/keyboard/gnome-keyboard-properties.c:210
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:215
+msgid "Start the page with the typing break settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:220
+msgid "Start the page with the accessibility settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:226
+msgid "- GNOME Keyboard Preferences"
+msgstr "GNOME ကီးဘုတ်လိုလားချက်များ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:1
+msgid "Beep when _accessibility features are turned on or off"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:2
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:3
+msgid "Beep when a _toggle key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:4
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:5
+msgid "Beep when a key is reje_cted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:6
+msgid "Beep when key is _accepted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:7
+msgid "Beep when key is _rejected"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:8
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:4
+msgid "Bounce Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:9
+msgid "Flash _window titlebar"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:10
+msgid "Flash entire _screen"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:11
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:14
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:15
+msgid "General"
+msgstr "အထွေထွေရေးရာ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:12
+msgid "Keyboard Accessibility Audio Feedback"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:13
+msgid "Show _visual feedback for the alert sound"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:14
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:39
+msgid "Slow Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:15
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:40
+msgid "Sticky Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:16
+msgid "Visual cues for sounds"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:2
+msgid "All_ow postponing of breaks"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:3
+msgid "Audio _Feedback..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:5
+msgid "Check if breaks are allowed to be postponed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:6
+msgid "Cursor Blinking"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:7
+msgid "Cursor _blinks in text fields"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:8
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:4
+msgid "Cursor blinks speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:9
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:5
+msgid "D_elay:"
+msgstr "_E ကြာချိန်"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:10
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:11
+msgid "Duration of the break when typing is disallowed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:12
+msgid "Duration of work before forcing a break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:13
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:14
+msgid "Fast"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:15
+msgid "Key presses _repeat when key is held down"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:16
+msgid "Keyboard Preferences"
+msgstr "ကီးဘုတ်လိုလားချက်"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:17
+msgid "Keyboard _model:"
+msgstr "ကီးဘုတ်အမျိုးအစား"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:18
+msgid "Layouts"
+msgstr "လက်ကွက်"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:19
+msgid "List of keyboard layouts selected for usage"
+msgstr "အသုံးပြုရန်အတွက် ကီးဘုတ်လက်ကွက်စာရင်း"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:20
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:21
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:19
+msgid "Long"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:22
+msgid "Mouse Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:23
+msgid "Move _Down"
+msgstr "_D အောက်"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:24
+msgid "Move _Up"
+msgstr "_U အပေါ်"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:25
+msgid "Move the selected keyboard layout down in the list"
+msgstr "စာရင်းထဲမှ ကီးဘုတ်ပုံစံကို အောက်သို့ချပါ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:26
+msgid "Move the selected keyboard layout up in the list"
+msgstr "စာရင်းထဲမှ ကီးဘုတ်ပုံစံကို အပေါ်သို့တင်ပါ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:27
+msgid "New windows u_se active window's layout"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:28
+msgid "Print a diagram of the selected keyboard layout"
+msgstr "ရွေးချယ်သည့် ကီးဘုတ်လက်ကွက်ပုံစံကို ပုံနှိပ်ပါ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:29
+msgid "Remove the selected keyboard layout from the list"
+msgstr "ရွေးချယ်လိုက်သည့် ကီးဘုတ်လက်ကွက်ကိုစာရင်းမှဖယ်ထုတ်ပါ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:30
+msgid "Repeat Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:31
+msgid "Repeat keys speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:32
+msgid ""
+"Replace the current keyboard layout settings with the\n"
+"default settings"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:34
+msgid "Reset to De_faults"
+msgstr "_F မူလတိုင်းပြန်သတ်မှတ်"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:35
+msgid "S_peed:"
+msgstr "_P အမြန်နှုန်း"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:36
+msgid "Select a keyboard layout to be added to the list"
+msgstr "စာရင်းထဲသို့ထည့်ရန် ကီးဘုတ်လက်ကွက်ကိုရွေးပါ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:37
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:27
+msgid "Short"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:38
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:30
+msgid "Slow"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:41
+msgid "Typing Break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:42
+msgid "View and edit keyboard layout options"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:43
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:37
+msgid "_Acceleration:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:44
+msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:46
+msgid "_Break interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:47
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:38
+msgid "_Delay:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:48
+msgid "_Ignore fast duplicate keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:49
+msgid "_Lock screen to enforce typing break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:50
+msgid "_Only accept long keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:51
+msgid "_Options..."
+msgstr "_O ရွေးချယ်စရာများ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:52
+msgid "_Pointer can be controlled using the keypad"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:53
+msgid "_Separate layout for each window"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:54
+msgid "_Show..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:55
+msgid "_Simulate simultaneous keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:56
+msgid "_Speed:"
+msgstr "_S အမြန်နှုန်း"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:57
+msgid "_Type to test settings:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:58
+msgid "_Work interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:59
+msgid "minutes"
+msgstr "မိနစ်"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:1
+msgid "By _country"
+msgstr "_C နိုင်ငံအရ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:2
+msgid "By _language"
+msgstr "_L ဘာသာစကားအရ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:3
+msgid "Choose a Layout"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:4
+msgid "Preview:"
+msgstr "နမူနာ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:5
+msgid "_Country:"
+msgstr "_C နိုင်ငံ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:6
+msgid "_Language:"
+msgstr "_L ဘာသာစကား"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:7
+msgid "_Variants:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:1
+msgid "Choose a Keyboard Model"
+msgstr "ကီးဘုတ်အမျိုးအစားရွေးပါ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:2
+msgid "_Models:"
+msgstr "_M အမျိုးအစား"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:3
+msgid "_Vendors:"
+msgstr "_V ထုတ်လုပ်သူ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-options-dialog.ui.h:1
+msgid "Keyboard Layout Options"
+msgstr "ကီးဘုတ်လက်ကွက်ရွေးချယ်ရန်"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
+msgid "Unknown"
+msgstr "အမည်မဲ့"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:242
+msgid "Layout"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:168
+msgid "Vendors"
+msgstr "ထုတ်လုပ်သူ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:234
+msgid "Models"
+msgstr "အမျိုးအစားများ"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:235
+#: ../capplets/network/gnome-network-properties.c:581
+msgid "Default"
+msgstr "မူလပုံစံ"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "ကီးဘုတ်"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "ကီးဘုတ်အစီအမံများကိုသတ်မှတ်"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:89
+msgid "gesture|Move left"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:94
+msgid "gesture|Move right"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:99
+msgid "gesture|Move up"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:104
+msgid "gesture|Move down"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:109
+msgid "gesture|Disabled"
+msgstr ""
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/mouse/gnome-mouse-properties.c:592
+msgid "Specify the name of the page to show (general|accessibility)"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:597
+msgid "- GNOME Mouse Preferences"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:2
+msgid "Choose type of click _beforehand"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:3
+msgid "Choose type of click with mo_use gestures"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:6
+msgid "D_ouble click:"
+msgstr "_O နှစ်ချက်နှိပ်"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:7
+msgid "D_rag click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:8
+msgid "Disable _touchpad while typing"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:9
+msgid "Double-Click Timeout"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:10
+msgid "Drag and Drop"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:11
+msgid "Dwell Click"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:12
+msgid "Enable _mouse clicks with touchpad"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:13
+msgid "Enable h_orizontal scrolling"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:16
+msgid "High"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:18
+msgid "Locate Pointer"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:20
+msgid "Low"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:21
+msgid "Mouse Orientation"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:22
+msgid "Mouse Preferences"
+msgstr "မောက်(စ်)လိုလားချက်"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:23
+msgid "Pointer Speed"
+msgstr "ပွိုင့်တာ အမြန်နှုန်း"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:24
+msgid "Scrolling"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:25
+msgid "Seco_ndary click:"
+msgstr "_N "
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:26
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:28
+msgid "Show click type _window"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:29
+msgid "Simulated Secondary Click"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:32
+msgid "Thr_eshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:33
+msgid ""
+"To test your double-click settings, try to double-click on the light bulb."
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:34
+msgid "Touchpad"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:35
+msgid "Two-_finger scrolling"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:36
+msgid "You can also use the Dwell Click panel applet to choose the click type."
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:39
+msgid "_Disabled"
+msgstr "_D အသုံးမပြု"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:40
+msgid "_Edge scrolling"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:41
+msgid "_Initiate click when stopping pointer movement"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:42
+msgid "_Left-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:43
+msgid "_Motion threshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:44
+msgid "_Right-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:45
+msgid "_Sensitivity:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:46
+msgid "_Single click:"
+msgstr "_S တစ်ချက်နှိပ်"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:47
+msgid "_Timeout:"
+msgstr "_T ကြာချိန်"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:48
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr ""
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "မောက်(စ်)"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "မောက်(စ်)လိုလားချက်များကို သတ်မှတ်ပါ"
+
+#: ../capplets/network/gnome-network-properties.c:699
+#: ../capplets/network/gnome-network-properties.c:850
+msgid "New Location..."
+msgstr "တည်နေရာအသစ်"
+
+#: ../capplets/network/gnome-network-properties.c:816
+msgid "Location already exists"
+msgstr "တည်နေရာသတ်မှတ်ထားပြီး"
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "ကွန်ရက် ကြားခံ"
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "ကွန်ရက် ကြားခံလိုလားချက်ကိုသတ်မှတ်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>_R အင်တာနက်ကိုတိုက်ရိုက်ချိတ်ခြင်း</b>"
+
+#: ../capplets/network/gnome-network-properties.ui.h:2
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>_A ကြားခံကိုအလိုအလျောက်သတ်မှတ်ခြင်း</b>"
+
+#: ../capplets/network/gnome-network-properties.ui.h:3
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "_M စိတ်ကြိုက်ကြားခံသတ်မှတ်ခြင်း"
+
+#: ../capplets/network/gnome-network-properties.ui.h:4
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_U အသိအမှတ်ပြုခြင်း</b>"
+
+#: ../capplets/network/gnome-network-properties.ui.h:5
+msgid "Autoconfiguration _URL:"
+msgstr "_U အလိုအလျောက် URL သတ်မှတ်ခြင်း"
+
+#: ../capplets/network/gnome-network-properties.ui.h:6
+msgid "C_reate"
+msgstr "_R ထည့်သွင်း"
+
+#: ../capplets/network/gnome-network-properties.ui.h:7
+msgid "Create New Location"
+msgstr "နေရာအသစ်ထည့်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:8
+msgid "HTTP Proxy Details"
+msgstr "HTTP ကြားခံအသေးစိတ်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:9
+msgid "H_TTP proxy:"
+msgstr "_T HTTP ကြားခံ"
+
+#: ../capplets/network/gnome-network-properties.ui.h:10
+msgid "Ignore Host List"
+msgstr "အသုံးမပြုသည့် အခြေစိုက်စာရင်း"
+
+#: ../capplets/network/gnome-network-properties.ui.h:11
+msgid "Ignored Hosts"
+msgstr "အသုံးမပြုသည့် အခြေစိုက်များ"
+
+#: ../capplets/network/gnome-network-properties.ui.h:12
+msgid "Location:"
+msgstr "တည်နေရာ"
+
+#: ../capplets/network/gnome-network-properties.ui.h:13
+msgid "Network Proxy Preferences"
+msgstr "နက်ဝက် ကြားခံလိုလားချက် သတ်မှတ်ရန်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:14
+msgid "Port:"
+msgstr "ဆက်သွယ်ပေါက်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:15
+msgid "Proxy Configuration"
+msgstr "ကြားခံ သတ်မှတ်ခြင်း"
+
+#: ../capplets/network/gnome-network-properties.ui.h:16
+msgid "S_ocks host:"
+msgstr "_O Socks အခြေစိုက်ရာ"
+
+#: ../capplets/network/gnome-network-properties.ui.h:17
+msgid "The location already exists."
+msgstr "တည်နေရာကိုထည့်သွင်းပြီသားဖြစ်သည်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:18
+msgid "U_sername:"
+msgstr "_S အသုံးပြုအမည်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:19
+msgid "_Delete Location"
+msgstr "_D တည်နေရာကိုဖျက်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:20
+msgid "_Details"
+msgstr "_D အသေးစိတ်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:21
+msgid "_FTP proxy:"
+msgstr "_FTP ကြားခံ"
+
+#: ../capplets/network/gnome-network-properties.ui.h:22
+msgid "_Location name:"
+msgstr "_L တည်နေရာ"
+
+#: ../capplets/network/gnome-network-properties.ui.h:23
+msgid "_Password:"
+msgstr "_P စကားဝှက်"
+
+#: ../capplets/network/gnome-network-properties.ui.h:24
+msgid "_Secure HTTP proxy:"
+msgstr "_S HTTPs ကြားခံ"
+
+#: ../capplets/network/gnome-network-properties.ui.h:25
+msgid "_Use the same proxy for all protocols"
+msgstr "_U ပရိုတိုကောအားလုံးအတွက် ကြားခံ တစ်မျိုးသာသုံးမည်"
+
+#: ../capplets/windows/gnome-window-properties.c:344
+msgid "Cannot start the preferences application for your window manager"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:603
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:609
+msgid "H_yper"
+msgstr "H_yper"
+
+#: ../capplets/windows/gnome-window-properties.c:616
+msgid "S_uper (or \"Windows logo\")"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:623
+msgid "_Meta"
+msgstr "_Meta"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:1
+msgid "Movement Key"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:2
+msgid "Titlebar Action"
+msgstr "ခေါင်းစီးဘားတန်းလုပ်ဆောင်မှု"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:3
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:4
+msgid "Window Preferences"
+msgstr "ဝင်ဒိုးလိုလားချက်များ"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:5
+msgid "Window Selection"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_D အခုလုပ်ဆောင်မှုကိုပြုလုပ်ရန် ခေါင်းစဉ်ဘားတန်းကို နှစ်ချက်နှိပ်ပါ"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:7
+msgid "_Interval before raising:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:8
+msgid "_Raise selected windows after an interval"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:10
+msgid "seconds"
+msgstr "စက္ကန့်"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "ဝင်းဒိုးဆိုင်ရာ ဂုဏ်သတ္တိများသတ်မှတ်ပါ"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "ဝင်းဒိုး"
+
+#: ../libwindow-settings/gnome-wm-manager.c:316
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:404
+msgid "Maximize"
+msgstr "အကျယ်ချဲ့"
+
+#: ../libwindow-settings/metacity-window-manager.c:405
+msgid "Maximize Vertically"
+msgstr "ဒေါင်လိုက်အကျယ်ချဲ့"
+
+#: ../libwindow-settings/metacity-window-manager.c:406
+msgid "Maximize Horizontally"
+msgstr "အလျားလိုက်အကျယ်ချဲ့"
+
+#: ../libwindow-settings/metacity-window-manager.c:407
+msgid "Minimize"
+msgstr "ဖျောက်ထား"
+
+#: ../libwindow-settings/metacity-window-manager.c:408
+msgid "Roll up"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:409
+msgid "None"
+msgstr "မသတ်မှတ်ထား"
+
+#: ../shell/control-center.c:49
+#, c-format
+msgid "key not found [%s]\n"
+msgstr ""
+
+#: ../shell/control-center.c:143
+msgid "Hide on start (useful to preload the shell)"
+msgstr ""
+
+#: ../shell/control-center.c:182
+msgid "Filter"
+msgstr "စစ်ထုတ်ရန်"
+
+#: ../shell/control-center.c:182
+msgid "Groups"
+msgstr ""
+
+#: ../shell/control-center.c:182
+msgid "Common Tasks"
+msgstr ""
+
+#: ../shell/control-center.c:185 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "ထိန်းချုပ်ခန်း"
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:5
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:8
+msgid ""
+"Indicates whether to close the shell when an add or remove action is "
+"performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:9
+msgid ""
+"Indicates whether to close the shell when an upgrade or uninstall action is "
+"performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:11
+msgid ""
+"The task name to be displayed in the control-center followed by a \";\" "
+"separator then the filename of an associated .desktop file to launch for "
+"that task."
+msgstr ""
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+msgid ""
+"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
+"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:14
+msgid ""
+"if true, the control-center will close when a \"Common Task\" is activated."
+msgstr ""
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr " GNOME ခန့်ခွဲမှုကရိယာ"
+
+#: ../typing-break/drw-break-window.c:194
+msgid "_Postpone Break"
+msgstr "_P ရွှေ့ဆိုင်း"
+
+#: ../typing-break/drw-break-window.c:250
+msgid "Take a break!"
+msgstr ""
+
+#: ../typing-break/drwright.c:136
+msgid "_Take a Break"
+msgstr ""
+
+#: ../typing-break/drwright.c:507
+#, c-format
+msgid "Take a break now (next in %dm)"
+msgstr ""
+
+#: ../typing-break/drwright.c:509
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] ""
+
+#: ../typing-break/drwright.c:515
+#, c-format
+msgid "Take a break now (next in less than one minute)"
+msgstr ""
+
+#: ../typing-break/drwright.c:517
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr ""
+
+#: ../typing-break/drwright.c:614
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+
+#: ../typing-break/drwright.c:631
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr ""
+
+#: ../typing-break/drwright.c:632
+msgid "Eye candy added by Anders Carlsson"
+msgstr ""
+
+#: ../typing-break/drwright.c:641
+msgid "A computer break reminder."
+msgstr ""
+
+#: ../typing-break/drwright.c:643
+msgid "translator-credits"
+msgstr "လိုကယ်လိုက်ဇေးရှင်း ဂုဏ်ပြုလွှာ"
+
+#: ../typing-break/main.c:63
+msgid "Enable debugging code"
+msgstr ""
+
+#: ../typing-break/main.c:65
+msgid "Don't check whether the notification area exists"
+msgstr ""
+
+#: ../typing-break/main.c:91
+msgid "Typing Monitor"
+msgstr ""
+
+#: ../typing-break/main.c:108
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr ""
+
+#: ../font-viewer/font-view.c:293
+msgid "Name:"
+msgstr "အမည်"
+
+#: ../font-viewer/font-view.c:296
+msgid "Style:"
+msgstr "ပုံစံ"
+
+#: ../font-viewer/font-view.c:309
+msgid "Type:"
+msgstr "အမျိုးအစား"
+
+#: ../font-viewer/font-view.c:313
+msgid "Size:"
+msgstr "အရွယ်အစား"
+
+#: ../font-viewer/font-view.c:357 ../font-viewer/font-view.c:370
+msgid "Version:"
+msgstr "ဗာရှင်း"
+
+#: ../font-viewer/font-view.c:361 ../font-viewer/font-view.c:372
+msgid "Copyright:"
+msgstr "မူပိုင်ခွင့်"
+
+#: ../font-viewer/font-view.c:365
+msgid "Description:"
+msgstr "အကြောင်းအရာ"
+
+#: ../font-viewer/font-view.c:445
+msgid "Installed"
+msgstr "သွင်းယူမှုပြီးဆုံးပြီ"
+
+#: ../font-viewer/font-view.c:448
+msgid "Install Failed"
+msgstr "သွင်းယူခြင်းမပြီးဆုံးပါ"
+
+#: ../font-viewer/font-view.c:519
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr ""
+
+#: ../font-viewer/font-view.c:590
+msgid "I_nstall Font"
+msgstr "_N ဖောင့်သွင်းရန်"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
+msgid "Font Viewer"
+msgstr "ဖောင့်ကြည့်ရန်"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
+msgid "Preview fonts"
+msgstr "ဖောင့်နမူနာကြည့်"
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "Text to thumbnail (default: Aa)"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "TEXT"
+msgstr "စာသား"
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "Font size (default: 64)"
+msgstr "ဖောင့်အရွယ်အစား (ပုံသေ ၆၄)"
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "SIZE"
+msgstr "အရွယ်အစား"
+
+#: ../font-viewer/font-thumbnailer.c:249
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:268
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr ""
+
+#: ../libslab/app-shell.c:754
+#, c-format
+msgid "Your filter \"%s\" does not match any items."
+msgstr ""
+
+#: ../libslab/app-shell.c:756
+msgid "No matches found."
+msgstr "တူညီသည့်အရာမတွေ့ပါ"
+
+#: ../libslab/app-shell.c:909
+msgid "Other"
+msgstr "အခြား"
+
+#. make start action
+#: ../libslab/application-tile.c:374
+#, c-format
+msgid "Start %s"
+msgstr ""
+
+#: ../libslab/application-tile.c:395
+msgid "Help"
+msgstr "အကူအညီ"
+
+#: ../libslab/application-tile.c:442
+msgid "Upgrade"
+msgstr "မွမ်းမံ/အဆင်မြှင့်"
+
+#: ../libslab/application-tile.c:457
+msgid "Uninstall"
+msgstr "ဖယ်ထုတ်"
+
+#: ../libslab/application-tile.c:784 ../libslab/document-tile.c:738
+msgid "Remove from Favorites"
+msgstr "နှစ်သက်မှုအဖြစ်မှပယ်ဖျက်ပါ"
+
+#: ../libslab/application-tile.c:786 ../libslab/document-tile.c:740
+msgid "Add to Favorites"
+msgstr "နှစ်သက်မှုအဖြစ်ထည့်ပါ"
+
+#: ../libslab/application-tile.c:871
+msgid "Remove from Startup Programs"
+msgstr "ကနဉီးအပ္ပလီကေးရှင်းမှဖယ်ထုတ်ပါ"
+
+#: ../libslab/application-tile.c:873
+msgid "Add to Startup Programs"
+msgstr "ကနဉီးအပ္ပလီကေးရှင်းသို့ထည့်ပါ"
+
+#: ../libslab/bookmark-agent.c:1110
+msgid "New Spreadsheet"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1115
+msgid "New Document"
+msgstr "စာတမ်းအသစ်ယူ"
+
+#: ../libslab/bookmark-agent.c:1168
+msgctxt "Home folder"
+msgid "Home"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1175
+msgid "Documents"
+msgstr "စာတမ်းများ"
+
+#: ../libslab/bookmark-agent.c:1190
+msgid "File System"
+msgstr "ဖိုင်စနစ်"
+
+#: ../libslab/bookmark-agent.c:1194
+msgid "Network Servers"
+msgstr "ကွန်ရက်ဆာဗာများ"
+
+#: ../libslab/bookmark-agent.c:1223
+msgid "Search"
+msgstr "ရှာဖွေရန်"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:171
+#, c-format
+msgid "<b>Open</b>"
+msgstr "<b>ဖွင့်ရန်</b>"
+
+#. make rename action
+#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:236
+msgid "Rename..."
+msgstr "အမည်ပြောင်းရန်"
+
+#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
+#: ../libslab/document-tile.c:250 ../libslab/document-tile.c:259
+msgid "Send To..."
+msgstr "ပို့ရန်"
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:285
+msgid "Move to Trash"
+msgstr "အမှိုက်ပုံးထဲထည့်ပါ"
+
+#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
+#: ../libslab/document-tile.c:295 ../libslab/document-tile.c:854
+msgid "Delete"
+msgstr "ဖျက်ပစ်ပါ"
+
+#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:1016
+#, c-format
+msgid "Are you sure you want to permanently delete \"%s\"?"
+msgstr "\"%s\" ကိုဖျက်ပစ်တော့မှာလား"
+
+#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:1017
+msgid "If you delete an item, it is permanently lost."
+msgstr "ဖျက်မယ်ဆိုရင် ပြန်မရနိုင်တော့ဘူးနော်"
+
+#: ../libslab/document-tile.c:195
+#, c-format
+msgid "Open with \"%s\""
+msgstr "\"%s\" နှင့်ဖွင့်ရန်"
+
+#: ../libslab/document-tile.c:209
+msgid "Open with Default Application"
+msgstr "မူရင်းအပ္ပလီကေးရှင်းနှင့်ဖွင့်ရန်"
+
+#: ../libslab/document-tile.c:220
+msgid "Open in File Manager"
+msgstr ""
+
+#. clean item from menu
+#: ../libslab/document-tile.c:304
+msgid "Remove from recent menu"
+msgstr "လက်တလောမီနူးမှဖယ်ထုတ်ပါ"
+
+#. clean all the items from menu
+#: ../libslab/document-tile.c:312
+msgid "Purge all the recent items"
+msgstr ""
+
+#: ../libslab/document-tile.c:634
+msgid "?"
+msgstr ""
+
+#: ../libslab/document-tile.c:641
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#: ../libslab/document-tile.c:649
+msgid "Today %l:%M %p"
+msgstr "ယနေ့ %l:%M %p"
+
+#: ../libslab/document-tile.c:659
+msgid "Yesterday %l:%M %p"
+msgstr "မနေ့က  %l:%M %p"
+
+#: ../libslab/document-tile.c:671
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../libslab/document-tile.c:679
+msgid "%b %d %l:%M %p"
+msgstr "%b %d %l:%M %p"
+
+#: ../libslab/document-tile.c:681
+msgid "%b %d %Y"
+msgstr "%b %d %Y"
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr "ရှာဖွေပါ"
+
+#: ../libslab/system-tile.c:127
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr "<b>%s ကိုဖွင့်ရန်</b>"
+
+#: ../libslab/system-tile.c:140
+#, c-format
+msgid "Remove from System Items"
+msgstr "စနစ်ပိုင်းဆိုင်ရာမှ ဖယ်ထုတ်ပါ"

--- a/po/nb.po
+++ b/po/nb.po
@@ -8,9 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center 3.40.x\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-03-07 17:29+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-03-10 16:23+0100\n"
 "Last-Translator: Kjartan Maraas <kmaraas@gnome.org>\n"
 "Language-Team: Norwegian bokmål <i18n-nb@lister.ping.uio.no>\n"
@@ -21,99 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: panels/applications/cc-applications-panel.c:803
-msgid "System Bus"
-msgstr "Systembuss"
-
-#: panels/applications/cc-applications-panel.c:803
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:823
-msgid "Full access"
-msgstr "Full tilgang"
-
-#: panels/applications/cc-applications-panel.c:805
-msgid "Session Bus"
-msgstr "Øktbuss"
-
-#: panels/applications/cc-applications-panel.c:809
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Enheter"
-
-#: panels/applications/cc-applications-panel.c:809
-msgid "Full access to /dev"
-msgstr "Full tilgang til /dev"
-
-#: panels/applications/cc-applications-panel.c:813
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Nettverk"
-
-#: panels/applications/cc-applications-panel.c:813
-msgid "Has network access"
-msgstr "Har tilgang til nettverk"
-
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:820
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Hjem"
-
-#: panels/applications/cc-applications-panel.c:820
-#: panels/applications/cc-applications-panel.c:825
-msgid "Read-only"
-msgstr "Skrivebeskyttet"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-msgid "File System"
-msgstr "Filsystem"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Innstillinger"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Can change settings"
-msgstr "Kan endre innstillinger"
-
-#: panels/applications/cc-applications-panel.c:831
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s har følgende rettigheter innebygget. Disse kan ikke endres. Hvis du er "
-"bekymret for disse tilgangene bør du vurdere å fjerne dette programmet."
-
-#: panels/applications/cc-applications-panel.c:1164
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] ""
-msgstr[1] ""
-
-#: panels/applications/cc-applications-panel.c:1171
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1223
-#, c-format
-msgid "%s of disk space used"
-msgstr ""
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1387
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -129,7 +36,6 @@ msgid "Install some…"
 msgstr "Installer noen …"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Åpne"
 
@@ -140,6 +46,10 @@ msgstr "Vis detaljer"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Søk"
@@ -149,24 +59,13 @@ msgstr "Søk"
 msgid "Receive system searches and send results."
 msgstr ""
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1900
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Slått av"
 
@@ -180,7 +79,8 @@ msgid "Show system notifications."
 msgstr "Vis systemvarslinger."
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+#, fuzzy
+msgid "Run in Background"
 msgstr "Kjør i bakgrunnen"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -188,131 +88,144 @@ msgid "Allow activity when the app is closed."
 msgstr ""
 
 #: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Skjerm"
+
+#: panels/applications/cc-applications-panel.ui:141
+#, fuzzy
+msgid "Take pictures of the screen at any time."
+msgstr "Ta bilder med kameraet."
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Lyder"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "Hindre snarveier"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "Hindre systemets tastatursnarveier"
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "Kamera"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "Ta bilder med kameraet."
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "Mikrofon"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "Ta opp lyd med mikrofonen."
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Stedstjenester"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "Få tilgang til stedsdata for enheten."
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "Innebygde rettigheter"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "Systemtilgang som kreves av dette programmet."
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Lagring"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Fant ingen resultater"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Prøv et annet søk"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "Filtyper"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "Lenketyper"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Nullstill"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Hvor mye diskplass programmet bruker med applikasjonsdata og mellomlager."
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Program"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Data"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Buffer"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Totalt</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Tøm buffer …"
 
@@ -320,91 +233,33 @@ msgstr "Tøm buffer …"
 msgid "Control various application permissions and settings"
 msgstr "Kontroller forskjellige rettigheter og innstillinger for programmer"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "program;flatpak;rettighet;innstilling;"
-
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "Velg et bilde"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:226
-#: panels/network/connection-editor/vpn-helpers.c:346
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "A_vbryt"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:227
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:524
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Åpne"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "flere størrelser"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Ingen skrivebordsbakgrunn"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Gjeldende bakgrunn"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stil"
 
-#: panels/background/cc-background-panel.ui:45
-msgid "Light"
-msgstr "Lys"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+#, fuzzy
+msgid "Default"
+msgstr "Forvalgt"
 
-#: panels/background/cc-background-panel.ui:72
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "Mørk"
 
-#: panels/background/cc-background-panel.ui:91
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: panels/background/cc-background-panel.ui:97
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "Legg til bilde …"
 
@@ -416,50 +271,59 @@ msgstr "Utseende"
 msgid "Change your background image or the UI colors"
 msgstr "Bytt bakgrunnsbilde eller farger på brukergrensesnittet"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+#, fuzzy
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Bakgrunn;Skjerm;Skrivebord;Skrivebord;Stil;Lys;Mørk;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "_Slå på"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Fant ikke Bluetooth"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Koble til en dongle for å bruke Bluetooth."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth er slått av"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Slå på for å koble til enheter og motta filer."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "Flymodus er på"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth er slått av når flymodus er på."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Slå av flymodus"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "Flymodus slått på med maskinvare"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Slå av flymodus-bryteren for å slå på Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -467,31 +331,31 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Slå av/på bluetooth og koble til enheter"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "del;deling;bluetooth;obex;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "Kamera er slått av"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Ingen programmer kan ta bilder eller video."
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
 "\n"
 "Allow the applications below to use your camera."
 msgstr ""
-"Bruk av kamera lar programmer ta bilder og video. Hvis du slår av kamera vil noen programmer ikke lenger fungere korrekt.\n"
+"Bruk av kamera lar programmer ta bilder og video. Hvis du slår av kamera vil "
+"noen programmer ikke lenger fungere korrekt.\n"
 "\n"
 "Tillat at programmene under kan bruke ditt kamera."
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Ingen programmer har bedt om tilgang til kamera"
 
@@ -499,95 +363,33 @@ msgstr "Ingen programmer har bedt om tilgang til kamera"
 msgid "Protect your pictures"
 msgstr "Beskytt bildene dine"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"skjerm;lås;diagnostikk;krash;privat;nylige filer;midlertidig;tmp;indeks;navn;"
-"nettverk;identitet;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Plasser kalibreringsenheten over firkanten og trykk «Start»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "Flytt kalibreringsenheten til kalibreringsposisjon og trykk «Fortsett»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Flytt kalibreringsenheten til overflateposisjon og trykk «Fortsett»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Lukk lokket på bærbar"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Det oppstod en intern feil som ikke kan rettes opp."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Verktøy som kreves for kalibrering er ikke installert."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Profilen kunne ikke genereres."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Hvitpunkt for mål kunne ikke hentes."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Fullført"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrering mislyktes!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Du kan fjerne kalibreringsenheten."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ikke forstyrr kalibreringsenheten mens kalibrering pågår"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kalibrering av skjerm"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "A_vbryt"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -601,141 +403,9 @@ msgstr "G_jenoppta"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "Fer_dig"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Skjerm på bærbar"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Innebygget webkamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s skjerm"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s skanner"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s kamera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s skriver"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s webkamera"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Slå på fargehåndtering for %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Vis fargeprofiler for %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Ikke kalibrert"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Forvalg: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Fargeområde: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Testprofil:"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Velg fil for ICC-profil"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importer"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Støttede ICC-profiler"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Alle filer"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Skjerm"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Lagre profil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:347
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Lagre"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Lag en fargeprofil for valgt enhet"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Fant ikke måleinstrument. Kontroller at det er slått på og riktig tilkoblet."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Måleinstrumentet støtter ikke profilering av skrivere."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Enhetstypen er ikke støttet."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -852,9 +522,9 @@ msgstr "Krever skrivbart medie"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Instruksjonene om hvordan profilen skal brukes på <a href=\"linux\">GNU/"
 "Linux</a>, <a href=\"osx\">Apple OS X</a> og <a href=\"windows\">Microsoft "
@@ -869,16 +539,16 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Fant problemer. Profilen vil kanskje ikke fungere som den skal. <a href="
-"\"\">Vis detaljer.</a>"
+"Fant problemer. Profilen vil kanskje ikke fungere som den skal. <a "
+"href=\"\">Vis detaljer.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
 msgstr "_Importer fil …"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "_Legg til"
@@ -887,9 +557,7 @@ msgstr "_Legg til"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "Hver enhet må ha en oppdatert fargeprofil for å bli fargestyrt."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Lær mer"
 
@@ -1021,82 +689,6 @@ msgstr "D65 (fotografi og grafikk)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standard fargeområde"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testprofil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatisk"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Lav kvalitet"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Middels kvalitet"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Høy kvalitet"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Forvalgt RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Forvalgt CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Forvalgt grå"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Kalibreringsdata fra fabrikken levert av forhandler"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Skjermkorrigering i fullskjerm er ikke mulig med denne profilen"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Denne profilen er kanskje ikke nøyaktig lenger"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Farge"
@@ -1106,14 +698,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Kalibrer farger for enheter som f.eks. skjermer, kamera eller skrivere"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Farge;ICC;Profil;Kalibrer;Skriver;Skjerm;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Annet …"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1128,19 +715,14 @@ msgid "No languages found"
 msgstr "Fant ingen språk"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Mer …"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Lås opp for å endre innstillinger"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "Noen innstillinger må låses opp før de kan endres."
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "Lås opp …"
 
@@ -1163,151 +745,6 @@ msgstr "Reduser time"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Reduser minutt"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "I dag"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "I går"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d time"
-msgstr[1] "%d timer"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minutt"
-msgstr[1] "%d minutter"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekund"
-msgstr[1] "%d sekunder"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekunder"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-timer"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%B %e %Y, %a %H.%M"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%B %e %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%H.%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1390,32 +827,68 @@ msgstr "Automatisk _dato &amp; klokkeslett"
 msgid "Requires internet access"
 msgstr "Krever tilkobling til internett"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "Da_to &amp; klokkeslett"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Automatisk tids_sone"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr ""
 "Krever tilgang til internett og at tjeneste for stedsinformasjon kjører"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Slått på"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Tidss_one"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Lås opp"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Tids_format"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datoer"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekunder"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalender"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Tall"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Endra dato og klokkeslett - inklusive tidssone"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Klokke;Tidssone;Plassering;Adresse;"
@@ -1461,20 +934,9 @@ msgstr "Forvalgte programmer"
 msgid "Configure Default Applications"
 msgstr "Konfigurer forvalgte programmer"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "forvalgt;program;foretrukket;medie;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Problemrapportering hjelper oss med å forbedre %s. Rapporter sendes anonymt, "
-"og inneholder ikke personlig data. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1492,154 +954,116 @@ msgstr "Diagnostikk"
 msgid "Report your problems"
 msgstr "Rapporter problemene dine"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"skjerm;lås;diagnostikk;krash;privat;nylige filer;midlertidig;tmp;indeks;navn;"
-"nettverk;identitet;personvern;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:337
-#: panels/universal-access/cc-ua-panel.c:469
-#: panels/universal-access/cc-ua-panel.c:479
-#: panels/universal-access/cc-ua-panel.c:491
-#: panels/universal-access/cc-ua-panel.c:527
-msgid "On"
-msgstr "På"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:337
-#: panels/universal-access/cc-ua-panel.c:469
-#: panels/universal-access/cc-ua-panel.c:479
-#: panels/universal-access/cc-ua-panel.c:491
-#: panels/universal-access/cc-ua-panel.c:527
-msgid "Off"
-msgstr "Av"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "Bruk endringer?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "Endringer kan ikke brukes"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "Dette kan være på grunn av begrensninger i maskinvaren."
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "Diagnostikk"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Bruk"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Tilbake"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "Plassering av skjerm"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "Flere skjermer"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "Slå sammen"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Speil"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Inneholder topplinje og aktiviteter"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Primær skjerm"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Nattlys"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Landskap"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Portrett høyre"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Portrett venstre"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Landskap (vendt)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Orientering"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Oppløsning"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Oppfriskingshastighet"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Juster for TV"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Skalering"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Naturlig rulling"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Nattlys"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Midlertidig deaktivert til i morgen"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "Start filter på nytt"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1647,59 +1071,59 @@ msgstr ""
 "Nattlys gjør skjermens farger varmere. Dette kan hjelpe til å motvirke "
 "belastning på øyet og søvnløshet."
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Tidsplan"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Solnedgang til soloppgang"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Manuell tidsplan"
 
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Tid"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Fra"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Time"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Minutt"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "AM"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PM"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Til"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Fargetemperatur"
 
@@ -1711,7 +1135,6 @@ msgstr "Skjermer"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Velg hvordan tilkoblede skjermer og prosjektorer skal brukes"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1720,54 +1143,57 @@ msgstr ""
 "Panel;Prosjektor;xrandr;Skjerm;Oppløsning;Oppdater;Skjerm;Natt;Lys;Blå;"
 "redshift;farge;solnedgang;soloppgang;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Ukjent"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; bygg-ID: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Type sikkerhet"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Blekknivå"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Blekknivå"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Blekknivå"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Ukjent"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Sikkerhet"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Systemlogo"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"skjerm;lås;diagnostikk;krash;privat;nylige filer;midlertidig;tmp;indeks;navn;"
+"nettverk;identitet;personvern;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Navn på enhet"
 
@@ -1800,31 +1226,43 @@ msgstr "Beregner …"
 msgid "OS Name"
 msgstr "Navn på operativsystem"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; bygg-ID: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Type operativsystem"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "GNOME versjon"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Låser opp …"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Vindussystem"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Virtualisering"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Programvareoppdateringer"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Endre navn på enhet"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1832,7 +1270,12 @@ msgstr ""
 "Enhetsnavnet brukes til å identifisere denne enheten når den vises over "
 "nettverket eller ved paring med Bluetooth-enheter."
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Navn på enhet"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "End_re navn"
 
@@ -1844,11 +1287,6 @@ msgstr "Om"
 msgid "View information about your system"
 msgstr "Vis informasjon om systemet"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1926,6 +1364,12 @@ msgstr "Oppstartere"
 msgid "Launch help browser"
 msgstr "Start hjelpleser"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Innstillinger"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Start kalkulator"
@@ -1947,7 +1391,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Søk"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "System"
 
@@ -1996,20 +1440,11 @@ msgstr "Mindre tekststørrelse"
 msgid "High contrast on or off"
 msgstr "Høy kontrast på eller av"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Fant ingen inndatakilder"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Annen"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Legg til en inndatakilde"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Inndatametoder kan ikke brukes på påloggingsskjermen"
 
@@ -2017,120 +1452,30 @@ msgstr "Inndatametoder kan ikke brukes på påloggingsskjermen"
 msgid "No input source selected"
 msgstr "Ingen inndatakilder valgt"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "Valg …"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "Flytt opp"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "Flytt ned"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Brukervalg"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Vis tastaturutforming"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Fjern"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Egendefinerte snarveier"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "Tast for alternative tegn"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Tasten for alternative taster kan brukes til å skrive flere tegn. Disse "
-"vises noen ganger som et tredje alternativ på tastaturet ditt."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Venstre Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Høyre Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Venstre super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Høyre super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menytast"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Høyre Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Komponeringstast"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Compose-tasten lar deg skrive en stor variasjon av tegn. For å bruke den "
-"trykker du Compose og så en sekvens med tegn. For eksempel Compose-tasten "
-"fulgt av <b>C</b> og <b>o</b> vil skrive <b>©</b>, <b>a</b> fulgt av <b>'</"
-"b> vil skrive <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2152,54 +1497,29 @@ msgstr "Bruk _samme kilde for alle vinduer"
 msgid "Switch input sources _individually for each window"
 msgstr "Bytt inndatakilder _individuelt for hvert vindu"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Skriv spesielle tegn"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Metoder for å skrive symboler og bokstavvarianter med tastaturet."
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tast for alternative tegn"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Komponeringstast"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Tastatursnarveier"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Vis og tilpass snarveier"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d endret"
-msgstr[1] "%d endret"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
-msgid "Reset All Shortcuts?"
-msgstr "Nullstill alle snarveier?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Hvis du nullstiller snarveiene kan dette påvirke dine egendefinerte "
-"snarveier. Dette kan ikke angres."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
-msgid "Reset All"
-msgstr "Nullstill alle"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2209,96 +1529,92 @@ msgstr "Nullstill alle …"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Nullstill alle snarveier til sine forvalgte verdier"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "H_andling:"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Snarvei"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Legg til snarvei"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Legg til egendefinerte snarveier"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "Sett opp egendefinerte snarveier for å starte programmer, kjøre skript og "
 "mer."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Legg til snarvei"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Ingen tastatursnarvei funnet"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s brukes allerede for %s. Hvis du erstatter den vil %s bli slått av"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "Fjern"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Oppgi den nye snarveien"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Sett egendefinert snarvei"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Sett snarvei"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Oppgi ny snarvei for å endre %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Legg til egendefinert snarvei"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Legg til"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
 msgstr "Erstatt"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "Sett"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Trykk Esc for å avbryte eller Slett for å nullstille tastatursnarveien."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Navn"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Kommando"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Snarvei"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Sett snarvei …"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Ingen"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Nullstill snarveien til sin forvalgte verdi"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Bruk skriver som forvalgt"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2308,9 +1624,10 @@ msgstr "Tastatur"
 msgid ""
 "Change keyboard shortcuts and set your typing preferences, keyboard layouts "
 "and input sources"
-msgstr "Endre tastatursnarveier, endre skriveoppsett, tastaturutforming og inndatakilder"
+msgstr ""
+"Endre tastatursnarveier, endre skriveoppsett, tastaturutforming og "
+"inndatakilder"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2318,15 +1635,15 @@ msgstr ""
 "snarvei;arbeidsområde;vindu;endre størrelse;zoom;kontrast;inndata;kilde;lås;"
 "volum"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "Stedstjenester er slått av"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Ingen programmer kan hente stedsinformasjon."
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2337,7 +1654,7 @@ msgid ""
 "Allow the applications below to determine your location."
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Ingen programmer har bedt om stedsinformasjon"
 
@@ -2345,171 +1662,19 @@ msgstr "Ingen programmer har bedt om stedsinformasjon"
 msgid "Protect your location information"
 msgstr "Beskytt din stedsinformasjon"
 
-#. FIXME
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Skjermen slår seg av"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekunder"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minutt"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74 panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 time"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minutt"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Aldri"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"Automatisk låsing av skjermen forhindrer andres tilgang til datamaskinen når "
-"du er borte."
 
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "Pause før skjermen slås av"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Periode med inaktivitet før skjermen slås av."
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "Automatisk _låsing av skjerm"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "Pause før automatisk _låsing av skjerm"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "Periode etter skjermen slås av før den låses automatisk."
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "Vis varsli_nger på låseskjerm"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "Forby nye _USB-enheter"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Forhindre nye USB-enheter fra å ha interaksjon med systemet når skjermen er "
-"låst."
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Lås skjerm"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Lås skjermen"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "Mikrofonen er slått av"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Ingen programmer kan ta opp lyd."
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2517,11 +1682,12 @@ msgid ""
 "\n"
 "Allow the applications below to use your microphone."
 msgstr ""
-"Bruk av mikrofonen lar programmer ta opp og lytte til lyd. Hvis du slår av mikrofonen kan dette medføre at noen programmer ikke fungerer slik de skal.\n"
+"Bruk av mikrofonen lar programmer ta opp og lytte til lyd. Hvis du slår av "
+"mikrofonen kan dette medføre at noen programmer ikke fungerer slik de skal.\n"
 "\n"
 "Tillat at programmene under kan bruke din mikrofon."
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Ingen programmer har bedt om tilgang til mikrofonen"
 
@@ -2529,7 +1695,10 @@ msgstr "Ingen programmer har bedt om tilgang til mikrofonen"
 msgid "Protect your conversations"
 msgstr "Beskytt samtalene dine"
 
-#. FIXME
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Test inn_stillinger"
@@ -2547,83 +1716,147 @@ msgstr "Primærknapp"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "Setter rekkefølge for de fysiske knappene på mus og pekeflater."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Venstre"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Høyre"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Søkelokasjoner"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mus"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Mushastighet"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "Naturlig rulling"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Rulling flytter innholdet, ikke visningen."
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Rulling flytter innholdet, ikke visningen."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktiv"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Pekeplate"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Hastighet for pekeplate"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Tapp for å klikke"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "Rulling med to fingre"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Tapp for å klikke"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Hastighet for pekeplate"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Kantrulling"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Tosidig"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Prøv klikk, dobbeltklikk og rulling"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Fem klikk. Tid for GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dobbeltklikk, primærknapp"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Enkeltklikk, primærknapp"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dobbeltklikk, midterste knapp"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Enkeltklikk, midterste knapp"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dobbeltklikk, sekundærknapp"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Enkeltklikk, sekundærknapp"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2636,7 +1869,6 @@ msgstr ""
 "Endre sensitivitet for mus eller pekeplate og velg om du er høyrehendt eller "
 "venstrehendt"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Styrepute;Peker;Klikk;Tapp;Dobbel;Knapp;Styrekule;Rull;"
@@ -2714,84 +1946,38 @@ msgstr "Multitasking"
 msgid "Manage preferences for productivity and multitasking"
 msgstr ""
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Oi! Noe gikk galt. Kontakt programvareleverandøren."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager må kjøre."
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Andre enheter"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Legg til ny tilkobling"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Ikke satt opp"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "Usikret nettverk (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "Sikret nettverk (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "Sikret nettverk (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "Sikret nettverk (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "Sikret nettverk"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Tilkoblet"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Valg …"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Hvis du slår på hotspot vil du bli koblet fra %s, og det vil ikke være mulig "
-"å aksessere internett via Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Må bestå av minst 8 tegn"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -2819,354 +2005,87 @@ msgid "Network Name"
 msgstr "Nettverksnavn"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Passord"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Generer et tilfeldig passord"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Lag passord automatisk"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Slå på"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Trådløs"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Vil du slå av trådløst aksesspunkt og koble fra brukere?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "_Stopp hotspot"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Flymodus"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Slår av Wi-Fi, blåtann og mobilt bredbånd"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Fant ingen trådløse kort"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Sjekk at du har et Wi-Fi-kort som er satt inn og slått på"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Flymodus er på"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Slå av for å bruke Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Trådløst aksesspunkt er aktivt"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Mobile enheter kan skanne QR-koden for å koble til."
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Slå av trådløst aksesspunkt …"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Synlige nettverk"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager må kjøre"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Oi! Noe gikk galt. Kontakt programvareleverandøren."
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x sikkerhet"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Sikkerhet"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Behold"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Tilfeldig"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabil"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"MAC-adressen som oppgis her vil bli brukt som maskinvareadresse for "
-"nettverksenheten denne tilkoblingen aktiveres på. Denne funksjonen er kjent "
-"som MAC-kloning eller spoofing. Eksempel: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Bedrift"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Aldri"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i dag siden"
 msgstr[1] "%i dager siden"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Svak"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "God"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Utmerket"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4-adresse"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "IPv6-adresse"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP-adresse"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "Glem tilkobling"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "Fjern tilkoblingsprofil"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "Fjern VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "Detaljer"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatisk"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitet"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Slett adresse"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "Slett rute"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit nøkkel (heksadesimal eller ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit passordfrase"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamisk WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 personlig"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 bedrift"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 personlig"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3177,8 +2096,20 @@ msgstr "Signalstyrke"
 msgid "Link speed"
 msgstr "Hastighet for tilkobling"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sikkerhet"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4-adresse"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-adresse"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Maskinvareadresse"
 
@@ -3187,12 +2118,17 @@ msgid "Supported Frequencies"
 msgstr "Støttede frekvenser"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Forvalgt rute"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3206,12 +2142,12 @@ msgstr "Koble til _automatisk"
 msgid "Make available to _other users"
 msgstr "Gjør tilgjengelig for _andre brukere"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 "_Målt tilkobling: har begrensninger på data eller kan forårsake kostnader"
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3256,7 +2192,7 @@ msgstr "Kun link-local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manuell"
 
@@ -3276,33 +2212,32 @@ msgid "Addresses"
 msgstr "Adresser"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Adresse"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Nettverksmaske"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Gateway"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automatisk"
 
@@ -3311,29 +2246,34 @@ msgstr "Automatisk"
 msgid "Automatic DNS"
 msgstr "Automatisk DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Separer IP-adresser med komma"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Ruter"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Automatiske ruter"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Måleverdi"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Bruk denne tilkoblingen _kun for ressurser på dette nettverket"
 
@@ -3346,83 +2286,13 @@ msgid "Automatic, DHCP only"
 msgstr "Automatisk. Kun DHCP"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Prefiks"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Klarte ikke å åpne tilkoblingsbehandler"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Ny profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Importer fil …"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "Legg til VPN"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Sikk_erhet"
-
-#: panels/network/connection-editor/vpn-helpers.c:191
-msgid "Cannot import VPN connection"
-msgstr "Klarte ikke å importere VPN-forbindelse"
-
-#: panels/network/connection-editor/vpn-helpers.c:193
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Filen «%s» kunne ikke leses, eller inneholder ikke gjenkjent informasjon om "
-"VPN-tilkobling\n"
-"\n"
-"Feil: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:223
-msgid "Select file to import"
-msgstr "Velg fil som skal importeres"
-
-#: panels/network/connection-editor/vpn-helpers.c:276
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "En fil med navn «%s» eksisterer allerede."
-
-#: panels/network/connection-editor/vpn-helpers.c:278
-msgid "_Replace"
-msgstr "E_rstatt"
-
-#: panels/network/connection-editor/vpn-helpers.c:280
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Vil du erstatte %s med VPN-forbindelsen du lagrer?"
-
-#: panels/network/connection-editor/vpn-helpers.c:315
-msgid "Cannot export VPN connection"
-msgstr "Klarte ikke å eksportere VPN-forbindelse"
-
-#: panels/network/connection-editor/vpn-helpers.c:317
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN-forbindelse «%s» kunne ikke eksporteres til %s.\n"
-"\n"
-"Feil: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:343
-msgid "Export VPN connection"
-msgstr "Eksporter VPN-forbindelse"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3436,103 +2306,46 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Nettverk"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Kontroller hvordan du kobler til internett"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Nettverk;IP;LAN;Mellomtjener;WAN;Bredbånd;Modem;Blåtann;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Trådløs"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Kontroller hvordan du kobler til trådløse nettverk"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Nettverk;Trådløst;Wi-Fi;Wifi;IP;LAN;Bredbånd;DNS;Aksesspunkt;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "aldri"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "i dag"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "i går"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Sist brukt"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Kablet"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Legg til ny tilkobling"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Nettverksdetaljer for valgte nettverk - inkludert passord og innstillinger - "
-"går tapt."
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "_Glem"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Kjente trådløse nettverk"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Glem"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Systemregler hindrer oppsett av aksesspunkt"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Trådløs enhet støtter ikke hotspotmodus"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Automatisk gjenkjenning av web-mellomtjener brukes når du ikke oppgir "
-"nettadresse til et oppsett."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Dette anbefales ikke for offentlige nettverk du ikke stoler på."
-
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Slå enhet av"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Aktiv"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3543,47 +2356,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Tilbyder"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adresse"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Nettverksmellomtjener"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP-mellomtjener"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "H_TTP-mellomtjener"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "_FTP-mellomtjener"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "_Socks-vert"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "_Ignorer verter"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Port for HTTP-mellomtjener"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Port for HTTPS-mellomtjener"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Port for FTP-mellomtjener"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Port for Socks-mellomtjener"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "_Nettadresse til oppsett"
 
@@ -3610,300 +2427,22 @@ msgstr "Passord"
 msgid "Turn Wi-Fi off"
 msgstr "Slå trådløs av"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Valg …"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Koble til skjult nettverk …"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Slå på _trådløst aksesspunkt …"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Kjente trådløse nettverk"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Ukjent status"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Ikke administrert"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Ikke tilgjengelig"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Kobler til"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Autentisering kreves"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Kobler fra"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Tilkobling mislyktes"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Ukjent status (mangler)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Oppsett mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP-oppsett mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP-oppsett er utgått"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Hemmeligheter kreves men ble ikke oppgitt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x-hjelper frakoblet"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Oppsett av 802.1x-hjelper mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x-hjelper mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x-hjelper brukte for lang tid på autentisering"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP-tjeneste klarte ikke å starte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP-tjeneste koblet fra"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP-klient startet ikke"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Feil i DHCP-klient"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP-klient mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Tjeneste for delt tilkobling startet ikke"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Tjeneste for delt tilkobling mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP-tjeneste startet ikke"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Feil i AutoIP-tjeneste"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP-tjeneste mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linjen er opptatt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Ingen summetone"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Klarte ikke å etablere bærekanal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Tidsavbrudd for oppringing"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Oppringingsforsøk mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Oppstart av modem mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Klarte ikke å velge angitt APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Søker ikke etter nettverk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Nettverksregistrering nektet"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Tidsavbrudd for nettverksregistrering"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Klarte ikke å registrere med forespurt nettverk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN-sjekk mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Fastvare for enheten mangler kanskje"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Tilkobling forsvant"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Eksisterende tilkobling ble antatt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Fant ikke modem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Tilkobling med Bluetooth mislyktes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM-kort er ikke satt inn"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Pin for SIM kreves"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Puk for SIM kreves"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Feil SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Tilkoblingsavhengighet mislyktes"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Fastvare mangler"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabel koblet fra"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "udefinert feil i 802.1x sikkerhet (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "ingen fil valgt"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "uspesifisert feil ved validering av fil for eap-metode"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM eller PKCS#12 private nøkler (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER- eller PEM-sertifikater (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "mangler EAP-FAST PAC-fil"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC-filer (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -3953,14 +2492,6 @@ msgstr "_Indre autentisering"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Tillat automatisk PAC-pro_visjonering"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "mangler brukernavn for EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "mangler passord for EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -3973,7 +2504,7 @@ msgstr "Br_ukernavn"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Passord"
 
@@ -3985,15 +2516,6 @@ msgstr "_Passord"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Vi_s passord"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "ugyldig EAP-PEAP CA-sertifikat: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "ugyldig EAP-PEAP CA-sertifikat: ingen sertifikat oppgitt"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4016,7 +2538,6 @@ msgid "C_A certificate"
 msgstr "C_A-sertifikat"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4031,63 +2552,6 @@ msgstr "Ingen CA-sertifikat k_reves"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP-_versjon"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "mangler brukernavn for EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "mangler passord for EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "mangler identitet for EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "ugyldig EAP-TLS CA-sertifikat: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "ugyldig EAP-TLS CA-sertifikat: ingen sertifikat oppgitt"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "ugyldig EAP-TLS privat nøkkel: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "ugyldig EAP-TLS brukersertifikat: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Ukrypterte private nøkler er usikre"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Valgt privat nøkkel ser ikke ut til å være beskyttet av et passord. Dette "
-"kan medføre at påloggingsinformasjonen kan kompromitteres. Velg en "
-"passordbeskyttet privat nøkkel.\n"
-"\n"
-"Privat nøkkel kan passordbeskyttes med openssl."
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Velg personlig sertifikat"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Velg privatnøkkel"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4104,15 +2568,6 @@ msgstr "Privat nø_kkel"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Passord for privat nøkkel"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "ugyldig EAP-TTLS CA-sertifikat: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "ugyldig EAP-TTLS CA-sertifikat: ingen sertifikat oppgitt"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4135,14 +2590,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domene"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Ukjent feil ved validering av 802.1x sikkerhet"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4170,60 +2626,10 @@ msgstr "Beskyttet EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "Au_tentisering"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Velg en fil"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "mangler leap-brukernavn"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "mangler leap-passord"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Passord for Wi-Fi mangler."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Type"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "mangler wep-nøkkel"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"ugyldig wep-nøkkel: nøkkel med lengde %zu må kun inneholde heksadesimale tall"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"ugyldig wep-nøkkel: nøkkel med en lengde på %zu må kun inneholde ASCII-tegn"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"ugyldig wep-nøkkel: feil lengde på nøkkel %zu. En nøkkel må enten være av "
-"lengde 5/13 (ascii) eller 10/26 (heksadesimal)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "ugyldig wep-nøkkel: passordfrasen kan ikke være tom"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "ugyldig wep-nøkkel: passordfrasen må være kortere enn 64 tegn"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4248,19 +2654,6 @@ msgstr "_Vis nøkkel"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP-indeks"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"ugyldig wpa-psk: ugyldig key-length %zu. Må være [8,63] bytes eller 64 hex "
-"sifre"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "ugyldig wpa-psk: kan ikke tolke nøkkel med 64 bytes som hex"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4314,58 +2707,34 @@ msgstr "Vars_linger på låseskjerm"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Kontroller hvilke varslinger som vises og hva de viser"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Varslinger;Banner;Melding;Trau;Oppsprett;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "%s fjernet"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Annen"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Feil ved fjerning av konto"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Angre"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Vis systemvarslinger."
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "Koble til dine data i skyen"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "Ingen tilkobling til internett – koble til for å sette opp nye kontoer på "
 "nettet"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Legg til konto"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:426
-#, c-format
-msgid "%s Account"
-msgstr "%s-konto"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:429
-msgid "Remove Account"
-msgstr "Fjern konto"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4375,10 +2744,6 @@ msgstr "Kontoer på nettet"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Koble til nettkontoer og bestem hva de skal brukes til"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4386,10 +2751,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Nett;Lynmeldinger;Kalender;E-post;Kontakt;"
 "ownCloud;Kerberos;IMAP;SMTP;Lomme;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Ukjent tid"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4405,13 +2766,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i time"
 msgstr[1] "%i timer"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4423,184 +2777,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minutt"
 msgstr[1] "minutter"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "fullt ladet om %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Advarsel: %s gjenstår"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s gjenstår"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Fullt ladet"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Lader ikke"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Tom"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Lader"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Lader ut"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Trådløs mus"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Trådløst tastatur"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Avbruddsfri strømforsyning"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Personlig digital assistent"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobiltelefon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Musikkavspiller"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tegnebrett"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Datamaskin"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Inndataenhet for spill"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batteri"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Hoved"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Ekstra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batterier"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "Når led_ig"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "Hvilemodus"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "Slå av"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "Dvalemodus"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "Ingenting"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "På batteristrøm"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "Når den er koblet til strøm"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Aldri"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "Automatisk hvilemodus"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr "Ytelsesmodus er midlertidig slått av."
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Strømsparingsmodus aktivert av «%s»."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Ytelsesmodus aktivert av «%s»."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4662,6 +2838,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 timer"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batteri"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Enheter"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Strømmodus"
@@ -4682,89 +2867,62 @@ msgstr "Automatisk lysstyrke"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "Lysstyrke på skjermen justeres i forhold til omgivelsene."
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Demp skjerm"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "_Blank skjerm"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Automatisk strømsparing"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "_Automatisk hvilemodus"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr ""
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Handling for str_ømknapp"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Vis batteri_prosent"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Automatisk hvilemodus"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "Når den er _koblet til strøm"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "På _batteristrøm"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Pause"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Høy ytelse"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Høy ytelse og strømbruk."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Balansert"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standard ytelse og strømbruk."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Strømsparing"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Redusert ytelse og strømbruk."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4774,7 +2932,6 @@ msgstr "Strøm"
 msgid "View your battery status and change power saving settings"
 msgstr "Vis batteristatus og endre innstillinger for strømsparing"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4782,27 +2939,6 @@ msgid ""
 msgstr ""
 "Strøm;Sove;Hvile;Dvale;Batteri;Lysstyrke;Demp;Slå av;Skjerm;DPMS;Inaktiv;"
 "Energi;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Skriver «%s» er slettet"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "Klarte ikke å legge til ny skriver."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Klarte ikke å laste brukergrensesnitt: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Lås opp for å legge til skrivere og endre innstillinger"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4814,7 +2950,6 @@ msgstr ""
 "Legg til skrivere, vis utskriftsjobber og bestem hvordan du ønsker å skrive "
 "ut"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Skriver;Kø;Utskrift;Papir;Blekk;Toner;"
@@ -4822,92 +2957,69 @@ msgstr "Skriver;Kø;Utskrift;Papir;Blekk;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Legg til skriver"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "Lås _opp"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Fant ingen skrivere"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Skriv inn en nettverksadresse, eller søk etter en skriver"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Autentisering kreves"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr "Oppgi brukernavn og passord for å se skrivere på utskriftstjener."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Brukernavn"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "Detaljer for %s"
-
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Fant ingen passende driver"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "Velg PPD-fil"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"PostScript Printer Description-filer (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
 
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Plassering"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Driver"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Søker etter foretrukne drivere …"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Søker etter drivere"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Velg fra database …"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Installer PPD-fil …"
 
@@ -4919,132 +3031,20 @@ msgstr "Velger skriverdriver"
 msgid "Loading drivers database…"
 msgstr "Laster driverdatabase …"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Avbryt"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Velg"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect-skriver"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD-skriver"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Ensidig"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Lang kant (standard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Kort kant (vend)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Portrett"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Landskap"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Omvendt landskap"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Omvendt portrett"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "Utestående"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "På pause"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Autentisering kreves"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "Prosesserer"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Stoppet"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Avbrutt"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Avbrutt med feil"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Fullført"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr ""
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u jobb krever autentisering"
 msgstr[1] "%u jobber krever autentisering"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s – Aktive jobber"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Oppgi brukernavn og passord for å skrive ut fra %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5053,340 +3053,36 @@ msgid "Domain"
 msgstr "Domene"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "A_utentiser"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Tøm alle"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Autentiser"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Ingen aktive utskriftsjobber"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Lås opp utskriftstjener"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Lås opp %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Oppgi brukernavn og passord for å vise skrivere på %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Søker etter skrivere"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Seriellport"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Parallellport"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Plassering: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adresse: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Tjener krever autentisering"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Tosidig"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Papirtype"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Papirkilde"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Skuff"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Oppløsning"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Forhåndsfiltrering med GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Sider per side"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Tosidig"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientering"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Generelt"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Sideoppsett"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Installerbare alternativer"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Jobb"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Bildekvalitet"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Farge"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Fullføring"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avansert"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testside"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Testside"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Automatisk valg"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Forvalg for skriver"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Kun innebyggede GhostScript skrifter"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Konverter til PS nivå 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Konverter til PS nivå 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Ingen forhåndsfiltrering"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Produsent"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Ingen aktive jobber"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u jobb"
 msgstr[1] "%u jobber"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Rens utskriftshodene"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Lite toner"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Tom for toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Lite fremkaller"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Tom for fremkaller"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Lite farge"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Tom for farge"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Åpent deksel"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Åpen dør"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Lite papir"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Tom for papir"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Frakoblet"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Stoppet"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Søppelbeholderen er nesten full"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Søppelbeholderen er full"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Optisk fotoleder er nær slutten på sin levetid"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Optisk fotoleder fungerer ikke lenger"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Klar"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Godtar ikke jobber"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Prosesserer"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5410,41 +3106,45 @@ msgstr "Rens utskriftshodene"
 msgid "Remove Printer"
 msgstr "Fjern skriver"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ingen aktive jobber"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Modell"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Blekknivå"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Vennligst start på nytt når problemet er løst."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Start på nytt"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Legg til en skriver …"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Legg til en skriver …"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Ingen skrivere"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Legg til en skriver …"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5452,49 +3152,34 @@ msgstr ""
 "Beklager! Systemets utskriftstjeneste\n"
 "ser ikke ut til å være tilgjengelig."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formater"
-
-#: panels/region/cc-format-chooser.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "Tilbake"
 
 #: panels/region/cc-format-chooser.ui:76
 #, fuzzy
 msgid "Search locales…"
 msgstr "Søk etter stedsbaserte formater …"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Vanlige formater"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Alle formater"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Ingen søkeresultater"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Du kan søke etter land eller språk."
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Forhåndvisning"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperisk"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrisk"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5526,26 +3211,29 @@ msgstr ""
 
 #: panels/region/cc-region-panel.ui:45
 #, fuzzy
-#| msgid "The format used for numbers, dates, and currencies."
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr "Format for tall, datoer og valutaer."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Din konto"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Språk"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formater"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Påloggingsskjerm"
 
@@ -5555,104 +3243,12 @@ msgstr "Region og språk"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
 #, fuzzy
-#| msgid ""
-#| "Select your display language, formats, keyboard layouts and input sources"
 msgid "Select your display language and formats"
 msgstr "Velg språk for visning, formater, tastaturutforminger og inndatakilder"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Språk;Utforming;Tastatur;Inndata;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Spør hva som skal gjøres"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Ikke gjør noe"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Åpne mappe"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Annet medie"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Velg et program for lyd-CDer"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Velg et program for video-DVDer"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Velg et program som skal kjøres når en musikkavspiller kobles til"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Velg et program som skal kjøres når et kamera kobles til"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Velg et program for programvare-CDer"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "Lyd-DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Tom Blu-ray-plate"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "Tom CD-plate"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "Tom DVD-plate"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "tom HD-DVD plate"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray videoplate"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "E-bokleser"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD-DVD-videoplate"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Bilde-CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video-CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows programvare"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5702,7 +3298,6 @@ msgstr "Avtagbare medier"
 msgid "Configure Removable Media settings"
 msgstr "Konfigurer innstillinger for avtagbare medier"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5711,13 +3306,80 @@ msgstr ""
 "enhet;system;forvalg;program;foretrukket;cd;dvd;usb;lyd;video;plate;avtagbar;"
 "medie;automatisk kjøring;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Velg lokasjon"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Lås skjerm"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatisk låsing av skjermen forhindrer andres tilgang til datamaskinen når "
+"du er borte."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Pause før skjermen slås av"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Periode med inaktivitet før skjermen slås av."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatisk _låsing av skjerm"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Pause før automatisk _låsing av skjerm"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Periode etter skjermen slås av før den låses automatisk."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Vis varsli_nger på låseskjerm"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Vars_linger på låseskjerm"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Forby nye _USB-enheter"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Forhindre nye USB-enheter fra å ha interaksjon med systemet når skjermen er "
+"låst."
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Personvern"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skjerm"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Innstillinger"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5735,21 +3397,17 @@ msgstr ""
 msgid "Places"
 msgstr "Steder"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Bokmerker"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "Andre"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Legg til plassering"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Fant ingen programmer"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5761,9 +3419,6 @@ msgstr ""
 
 #: panels/search/cc-search-panel.ui:23
 #, fuzzy
-#| msgid ""
-#| "Folders which are searched by system applications, such as Files, Photos "
-#| "and Videos."
 msgid "Folders which are searched by system applications."
 msgstr ""
 "Mapper som brukes av systemprogrammer, slik som filer, bilder og videoer."
@@ -5782,65 +3437,13 @@ msgid ""
 msgstr ""
 "Kontroller hvilke programmer som viser resultater i aktivitetsoversikten"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Søk;finn;Indeks;Skjul;Personvern;Resultater;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "Ingen nettverk valgt for deling"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Nettverk"
-
-#: panels/sharing/cc-sharing-panel.c:367
-msgctxt "service is enabled"
-msgid "On"
-msgstr "På"
-
-#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Av"
-
-#: panels/sharing/cc-sharing-panel.c:399
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Slått på"
-
-#: panels/sharing/cc-sharing-panel.c:402
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktiv"
-
-#: panels/sharing/cc-sharing-panel.c:520
-msgid "Choose a Folder"
-msgstr "Velg en mappe"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:748
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Fildeling lar deg dele offentlig mappe med andre på samme nettverk ved å "
-"bruke: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:754
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Når ekstern pålogging er aktivert kan eksterne brukere koble seg til med "
-"Secure Shell-kommandoen:\n"
-"%s"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -5880,85 +3483,88 @@ msgstr "K_rev passord"
 msgid "Remote Login"
 msgstr "Ekstern pålogging"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "Eksternt skrivebord"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 #, fuzzy
-#| msgid "Enable or disable remote login"
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr "Slå på eller av ekstern pålogging"
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "Ekstern kontroll"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 #, fuzzy
-#| msgid "_Allow connections to control the screen"
 msgid "Allows remote connections to control the screen."
 msgstr "Till_at tilkoblinger å kontrollere skjermen"
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 #, fuzzy
-#| msgid "Forget Connection"
 msgid "How to Connect"
 msgstr "Glem tilkobling"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
 #, fuzzy
-#| msgid "Delete Address"
 msgid "Remote Desktop Address"
 msgstr "Slett adresse"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "Autentisering"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "Brukernavn"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "Verifiser kryptering"
 
-#: panels/sharing/cc-sharing-panel.ui:430
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr "Fingeravtrykk for kryptering"
 
-#: panels/sharing/cc-sharing-panel.ui:431
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:463
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Deling av media"
 
-#: panels/sharing/cc-sharing-panel.ui:485
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Del musikk, bilder og videoer over nettverket."
 
-#: panels/sharing/cc-sharing-panel.ui:498
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Mapper"
 
@@ -5966,7 +3572,6 @@ msgstr "Mapper"
 msgid "Control what you want to share with others"
 msgstr "Kontroller hva du vil dele med andre"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -5983,38 +3588,38 @@ msgstr "Slå på eller av ekstern pålogging"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Du må autentisere deg for å slå av eller på ekstern pålogging"
 
-#: panels/sound/cc-alert-chooser.c:150
-msgid "Custom"
-msgstr "Egendefinert"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Bjeff"
+msgid "Click"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "Drypp"
+#, fuzzy
+msgid "String"
+msgstr "Deling"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "Glass"
+msgid "Swing"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "Sonar"
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balanse"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Fade"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Bak"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Foran"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Tester %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6024,58 +3629,54 @@ msgstr "Klikk på en høyttaler for å teste"
 msgid "System Volume"
 msgstr "Systemvolum"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Systemvolum"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Volumnivåer"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Utgang"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Utgangsenhet"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Test"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Konfigurasjon"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "Balanse"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "Fade"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Basselement"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Inngang"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Inngangsenhet"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Volum"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Varsellyd"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6085,82 +3686,11 @@ msgstr "Lyd"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Endre lydvolum, innganger, utganger og lyder for hendelser"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Kort;Mikrofon;Volum;Fade;Balanse;Bluetooth;Hodetelefon;Lyd;Utgang;Inngang;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Koblet fra"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Kobler til"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Tilkoblet"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Feil ved autorisering"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autoriserer"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Redusert funksjonalitet"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Tilkoblet og autorisert"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Ukjent"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autorisert hos:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Tilkoblet på:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Meldt inn hos:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Klarte ikke å autorisere enhet: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Klarte ikke å glemme enhet: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6169,92 +3699,54 @@ msgid_plural "Depends on %u other devices"
 msgstr[0] "Avhenger av %u annen enhet"
 msgstr[1] "Avhenger av %u andre enheter"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Vis systemvarslinger."
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Navn:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Status:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Autoriser og koble til"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Glem enhet"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Feil"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Ingen støtte for Thunderbolt"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorisert"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Kunne ikke koble til thunderbolt-undersystem."
 
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Thunderbolt støtte (boltd) er ikke installert eller ikke satt opp korrekt."
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Direkte tilgang"
 
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 "Tillat direkte tilgang til enheter som dokkingstasjoner og eksterne GPUer."
 
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Kun USB og Display Port enheter kan koble til."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt ble ikke funnet.\n"
-"Enten mangler systemet støtte for Thunderbolt eller så er det deaktivert "
-"eller satt til et sikkerhetsnivå i BIOS som ikke er støttet."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Støtte for Thunderbolt er slått av i BIOS"
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Kunne ikke avgjøre sikkerhetsnivå for Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Feil ved bytting av direkte modus: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
-msgid "No Thunderbolt Support"
-msgstr "Ingen støtte for Thunderbolt"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:104
-msgid "Could not connect to the thunderbolt subsystem."
-msgstr "Kunne ikke koble til thunderbolt-undersystem."
-
-#: panels/thunderbolt/cc-bolt-panel.ui:153
-msgid "Direct Access"
-msgstr "Direkte tilgang"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Utestående enheter"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Ingen enheter koblet til"
 
@@ -6266,7 +3758,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Håndter Thunderbolt-enheter"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;Personvern;"
@@ -6275,16 +3766,16 @@ msgstr "Thunderbolt;Personvern;"
 msgid "Cursor Blinking"
 msgstr "Markørblinking"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Markøren blinker i tekstfelt."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Hastighet"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Hastighet for markørblinking"
 
@@ -6371,15 +3862,15 @@ msgstr "Stor"
 msgid "Repeat Keys"
 msgstr "Repeter taster"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Tastetrykk repeteres når tasten holdes nede."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Pause for tasterepetering"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Hastighet for tasterepetering"
 
@@ -6460,47 +3951,13 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Lang"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "Slå _på via tastatur"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Slå på funksjoner for tilgjengelighet fra tastaturet"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Forvalgt"
-
-#: panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Middels"
-
-#: panels/universal-access/cc-ua-panel.c:363
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Stor"
-
-#: panels/universal-access/cc-ua-panel.c:366
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Større"
-
-#: panels/universal-access/cc-ua-panel.c:369
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Størst"
-
-#: panels/universal-access/cc-ua-panel.c:373
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d piksel"
-msgstr[1] "%d piksler"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6615,31 +4072,6 @@ msgstr "La hele _skjermen blinke"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "La hele _vinduet blinke"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Kort"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ skjerm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ skjerm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ skjerm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Lang"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6796,14 +4228,8 @@ msgstr "Fargeeffekter"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Gjør det lettere å se, høre, skrive og peke og klikke"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 #, fuzzy
-#| msgid ""
-#| "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
-#| "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
-#| "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
-#| "audio;typing;"
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
@@ -6814,114 +4240,6 @@ msgstr ""
 "Zoom;Skjerm;Leser;stor;høy;tekst;skrift;størrelse;AccessX;Klebrige;Taster;"
 "Trege;Sprett;Mus;Dobbeltklikk;Pause;Hastighet;Assister;Gjenta;Blink;visuell;"
 "hørsel;lyd;skriving;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 time"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dag"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dager"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dager"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dager"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dager"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dager"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dager"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dager"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dager"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Tøm alle oppføringer fra papirkurven?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Alle elementer i papirkurven slettes permanent."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Tøm papirkurv"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Slett alle midlertidige filer?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Alle midlertidige filer slettes permanent."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Fjern midlertidige filer"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dag"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dager"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dager"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "For alltid"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -6989,57 +4307,10 @@ msgstr "Filhistorikk og papirkurv"
 msgid "Don't leave traces"
 msgstr "Ikke etterlat spor"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Skal være lik kontotilbyders nettstedsadresse."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Klarte ikke å legge til en konto"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:258
-msgid "The passwords do not match."
-msgstr "Passordene er ikke like."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Klarte ikke å registrere konto"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Ingen støttet måte å autentisere med dette domenet"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Klarte ikke å bli med i domenet"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Brukernavnet virket ikke.\n"
-"Vennligst prøv igjen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Passordet for påloggingen virket ikke.\n"
-"Vennligst prøv igjen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Klarte ikke å logge inn i domenet"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Fant ikke domenet. Kanskje du stavet det feil?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7052,9 +4323,6 @@ msgstr "Administrator"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:132
 #, fuzzy
-#| msgid ""
-#| "Administrators can add and remove other users, and can change settings "
-#| "for all users."
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users. Parental controls cannot be applied to administrators."
@@ -7079,14 +4347,14 @@ msgid "Enterprise Login"
 msgstr "Bedriftspålogging"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+msgid "User accounts which are managed by a company or organization."
 msgstr ""
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "Du er frakoblet"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7095,10 +4363,6 @@ msgstr ""
 "Bedriftspålogging lar deg bruke en eksisterende og sentralt håndtert "
 "brukerkoknto  på denne enheten. Du kan også bruke denne kontoen til å "
 "aksessere bedriftsressurser på internett."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Se etter flere bilder"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7112,15 +4376,15 @@ msgstr "Administrasjon av fingeravtrykk"
 msgid "Fingerprint"
 msgstr "Fingeravtrykk"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_Nei"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Ja"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7128,32 +4392,32 @@ msgstr ""
 "Vil du slette dine registrerte fingeravtrykk slik at innlogging med "
 "fingeravtrykk slås av?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Ingen fingeravtrykkleser"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "Ingen fingeravtrykkleser"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "Sjekk av enheten er koblet til riktig."
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Fingeravtrykksleser"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "Velg fingeravtrykksleseren du vil konfigurere"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "Innlogging med fingeravtrykk"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7161,437 +4425,103 @@ msgstr ""
 "Fingeravtrykkspålogging lar deg låse opp og logge inn på datamaskinen med "
 "fingeren."
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "_Slett fingeravtrykk"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Innlesing av fingeravtrykk"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "enheten må gjøres krav på for å utføre denne handlingen"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Forrige spor"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "enheten er allerede gjort krav på av en annen prosess"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "du har ikke rettigheter til å utføre handlingen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "ingen fingeravtrykk er registrert"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Klarte ikke å kommunisere med enheten under registrering"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Klarte ikke å kommunisere med fingeravtrykkleseren"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Klarte ikke å kommunisere med fingeravtrykktjenesten"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Klarte ikke å vise fingeravtrykk: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Klarte ikke å slette lagrede fingeravtrykk: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Venstre tommel"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Venstre langefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Venstre pekefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Venstre ringfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Venstre lillefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Høyre tommel"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Høyre langfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Høy_re pekefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Høyre ringfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Høyre lillefinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Ukjent finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Fullført"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Fingeravtrykkleser koblet fra"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Lagring for fingeravtrykkleser er full"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Klarte ikke å lese inn nytt fingeravtrykk"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Klarte ikke å starte innlesing: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Klarte ikke å lese inn nytt fingeravtrykk"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Klarte ikke å stoppe innlesing: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
 msgstr ""
-"Legg fingeren din på leseren gjentatte ganger for å lagre fingeravtrykket "
-"ditt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Les inn denne finge_ren på nytt …"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Les inn nytt fingeravtrykk"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Klarte ikke å frigjøre finngeravtrykkleser %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problem med å lese fra enhet"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Klarte ikke å gjøre krav på fingeravtrykkleser %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Klarte ikke å hente fingeravtrykklesere: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Denne uken"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Forrige uke"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s – %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k.%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Økten ble avsluttet"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Økten startet"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s – kontoaktivitet"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Velg et annet passord."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Skriv inn gjeldende passord en gang til."
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Passordet kunne ikke endres"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Endre passord"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "_Endre"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "Gjeldende passord"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "Nytt passord"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "Bekreft passord"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Passordene er ikke like."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "La bruker endre sitt passord ved neste pålogging"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Velg passord nå"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Du kan ikke bli medlem av denne type domene automatisk"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Fant ikke dette domenet eller området"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Klarte ikke å logge inn som %s på domenet %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Ugyldig passord. Prøv igjen"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Kunne ikke koble til domenet %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "Klarte ikke å slette bruker"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "Klarte ikke å trekke tilbake eksternt håndtert bruker"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "Du kan ikke slette din egen konto."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s er fremdeles logget inn"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Hvis du sletter en innlogget bruker kan systemet ende opp i en inkonsistent "
-"tilstand."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Vil du beholde filene til %s?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Det er mulig å beholde hjemmemappe, e-postkø og midlertidige filer når du "
-"sletter en brukerkonto."
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "_Slett filer"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "_Behold filer"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Er du sikker på at du vil trekke tilbake eksternt håndtert konto for %s?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "_Slett"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Kontoen er sperret"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Velges ved neste innlogging"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Logget inn"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "Slått på"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "Klarte ikke å kontakte kontotjenesten"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Sjekk at kontotjenesten er installert og aktivert."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr ""
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "Slett valgt brukerkonto"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Klikk på *-ikonet\n"
-"for å slette valgt brukerkonto"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Lås opp for å legge til brukere og endre innstillinger"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Brukere"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "Økten må startes på nytt for at endringene skal tre i kraft"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Start på nytt nå"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Lukk"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Full tilgang"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Innlogging med _fingeravtrykk"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "A_utomatisk pålogging"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "Kontoaktivitet"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Administrator"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7599,32 +4529,32 @@ msgstr ""
 "Administratorer kan legge til og fjerne andre brukere, og kan endre "
 "innstillinger for alle brukere."
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "_Foreldrekontroll"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Åpne programmet for foreldrekontroll"
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Fjern bruker …"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "Andre brukere"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "Legg til bruker …"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Fant ingen brukere"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Lås opp for å legge til en brukerkonto."
 
@@ -7632,7 +4562,6 @@ msgstr "Lås opp for å legge til en brukerkonto."
 msgid "Add or remove users and change your password"
 msgstr "Legg til eller fjern brukere og bytt passord"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7674,179 +4603,8 @@ msgstr "Håndter brukerkontoer"
 msgid "Authentication is required to change user data"
 msgstr "Du må autentisere deg for å endre brukerdata"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Det nye passordet må være ulikt det gamle."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Prøv å endre noen bokstaver og tall."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Prøv å endre passord enda litt mer."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Passordet blir sterkere hvis det ikke inneholder brukernavnet ditt."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Prøv å unngå å bruke navnet ditt i passordet."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Prøv å unngå noen av ordene som brukes i passordet."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Prøv å unngå vanlige ord."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Prøv å unngå å endre rekkefølge på eksisterende ord."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Prøv å bruke flere tall."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Prøv å bruke flere store bokstaver."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Prøv å bruke flere små bokstaver."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Prøv å bruke flere spesialtegn, som tegnsetting."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Prøv å bruke en blanding av bokstaver, tall og tegnsetting."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Prøv å unngå å gjenta samme tegn."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Prøv å unngå å gjenta samme type tegn. Du må blande bokstaver, tall og "
-"tegnsettingstegn."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Prøv å unngå sekvenser som 1234 eller abcs."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Passordet må være lenger. Prøv å bruke en blanding av bokstaver, tall og "
-"tegnsetting."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Bland store og små bokstaver, og prøv å bruke et tall eller to."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Passordet blir sterkere hvis du legger til flere bokstaver, tall og "
-"spesialtegn."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Autentisering mislyktes"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "Det nye passordet er for kort"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "Det nye passordet er for enkelt"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Gammelt og nytt passord er for like"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Det nye passordet har allerede blitt brukt nylig."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Det nye passordet må inneholde tall eller spesielle tegn"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Gammelt og nytt passord er det samme"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Passordet ditt er endret siden første autentisering!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Det nye passordet inneholder ikke nok spesielle tegn"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Ukjent feil"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Brukernavnet inneholder vanligvis små bokstaver fra a-z, tall, samt tegnene "
-"«.», «-» og «_»."
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Beklager, det brukernavnet er ikke tilgjengelig. Prøv et annet."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Brukernavnet er for langt."
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Tilegne knapper"
 
@@ -7878,49 +4636,11 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Feil klikk oppdaget. Starter på nytt …"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Knapp %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Program definert"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Send tastetrykk"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Bytt skjerm"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Vis hjelp på skjermen"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr ""
-
-#: panels/wacom/cc-wacom-device.c:435
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
 #, fuzzy
-#| msgid "No tablet detected"
-msgid "External tablet device"
+msgid "External pad device"
 msgstr "Fant ingen tegnebrett"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Alle skjermer"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -7930,28 +4650,28 @@ msgstr "Tegnebrettmodus"
 msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "Venstrehendt orientering"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Knytt til skjerm"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "Behold høyde-/breddeforhold"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "Kalibrer"
 
@@ -7961,13 +4681,27 @@ msgstr "Fant ingen tegnebrett"
 
 #: panels/wacom/cc-wacom-panel.ui:57
 #, fuzzy
-#| msgid "Please plug in or turn on your Wacom tablet"
 msgid "Please plug in or turn on your Wacom tablet."
 msgstr "Slå på eller koble til Wacom-tegnebrett"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "Følelse av trykk på tuppen"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+#, fuzzy
+msgid "Soft"
+msgstr "_Programvare"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
 
 #: panels/wacom/cc-wacom-stylus-page.ui:54
 msgctxt "display setting"
@@ -7988,20 +4722,21 @@ msgstr "Knapp 3"
 msgid "Eraser Pressure Feel"
 msgstr "Følsomhet for sletteknapp"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Følsomhet for sletteknapp"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
 msgstr ""
 
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
 msgstr ""
 
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr ""
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
 msgstr ""
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
@@ -8012,54 +4747,95 @@ msgstr "Wacom pekeplate"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Tilordne knapper og juster følsomhet for penn for grafiske tegnebrett"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tegnebrett;Wacom;Stylus;Viskelær;Mus;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Ny snarvei …"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulert andreklikk"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows programvare"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Lite toner"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Pause for sekundært klikk"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows programvare"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Aksesspunkter"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Legg til"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Lagre"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr ""
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registrert"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr ""
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Søker"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Nektet"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8087,110 +4863,16 @@ msgstr "Eget nummer"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:151
 #, fuzzy
-#| msgid "Printer Details"
 msgid "Device Details"
 msgstr "Detaljer for skriver"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Produsent"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Fastvareversjon"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Kun 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Kun 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Kun 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device.c:1043
-#, fuzzy
-#| msgid "Unknown"
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Ukjent"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Lås opp SIM-kort"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Lås opp"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8205,26 +4887,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] ""
 msgstr[1] ""
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr ""
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Låser opp …"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -8268,13 +4930,11 @@ msgstr "Avansert"
 
 #: panels/wwan/cc-wwan-device-page.ui:146
 #, fuzzy
-#| msgid "Access Options"
 msgid "_Access Point Names"
 msgstr "Alternativer for tilgang"
 
 #: panels/wwan/cc-wwan-device-page.ui:155
 #, fuzzy
-#| msgid "Screen Lock"
 msgid "_SIM Lock"
 msgstr "Lås skjerm"
 
@@ -8284,202 +4944,63 @@ msgstr ""
 
 #: panels/wwan/cc-wwan-device-page.ui:165
 #, fuzzy
-#| msgid "%s Details"
 msgid "M_odem Details"
 msgstr "Detaljer for %s"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-#, fuzzy
-#| msgid "PIN check failed"
-msgid "Phone failure"
-msgstr "PIN-sjekk mislyktes"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-#, fuzzy
-#| msgid "Turn VPN connection off"
-msgid "No connection to phone"
-msgstr "Slå av VPN-forbindelse"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-#, fuzzy
-#| msgid "SIM Card not inserted"
-msgid "SIM not inserted"
-msgstr "SIM-kort er ikke satt inn"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PIN required"
-msgstr "Pin for SIM kreves"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PUK required"
-msgstr "Pin for SIM kreves"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-#, fuzzy
-#| msgid "Current _Password"
-msgid "Incorrect password"
-msgstr "Gjeldende _passord"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PIN2 required"
-msgstr "Pin for SIM kreves"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-#, fuzzy
-#| msgid "SIM Pin required"
-msgid "SIM PUK2 required"
-msgstr "Pin for SIM kreves"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-#, fuzzy
-#| msgid "No stylus found"
-msgid "Not found"
-msgstr "Fant ingen penn"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-#, fuzzy
-#| msgid "Networks"
-msgid "No network service"
-msgstr "Nettverk"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-#, fuzzy
-#| msgid "Network Name"
-msgid "Network timeout"
-msgstr "Nettverksnavn"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-#, fuzzy
-#| msgid "AutoIP service failed"
-msgid "GPRS services not allowed"
-msgstr "AutoIP-tjeneste mislyktes"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-#, fuzzy
-#| msgctxt "print job"
-#| msgid "Canceled"
-msgid "Action Cancelled"
-msgstr "Avbrutt"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr ""
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-#, fuzzy
-#| msgid "Unknown error"
-msgid "Unknown Error"
-msgstr "Ukjent feil"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 #, fuzzy
-#| msgid "Network Name"
 msgid "Network Mode"
 msgstr "Nettverksnavn"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr ""
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "Lukk"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Automatisk"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Velg nettverk"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
-msgstr ""
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
 msgstr ""
 
 #: panels/wwan/cc-wwan-panel.ui:10
 #, fuzzy
-#| msgid "_Enable by Keyboard"
 msgid "Enable Mobile Network"
 msgstr "Slå _på via tastatur"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 #, fuzzy
-#| msgid "No Wi-Fi Adapter Found"
 msgid "No WWAN Adapter Found"
 msgstr "Fant ingen trådløse kort"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 #, fuzzy
-#| msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "Sjekk at du har et Wi-Fi-kort som er satt inn og slått på"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 #, fuzzy
-#| msgid "Bluetooth is disabled when airplane mode is on."
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "Bluetooth er slått av når flymodus er på."
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 #, fuzzy
-#| msgid "Turn Off Airplane Mode"
 msgid "_Turn off Airplane Mode"
 msgstr "Slå av flymodus"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 #, fuzzy
-#| msgid "Forget Connection"
 msgid "Data Connection"
 msgstr "Glem tilkobling"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 #, fuzzy
-#| msgid "SIM Card not inserted"
 msgid "SIM card used for internet"
 msgstr "SIM-kort er ikke satt inn"
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
 #, fuzzy
-#| msgid "Screen Lock"
 msgid "SIM Lock"
 msgstr "Lås skjerm"
 
@@ -8487,34 +5008,29 @@ msgstr "Lås skjerm"
 msgid "_Next"
 msgstr ""
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr ""
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 #, fuzzy
-#| msgid "Ch_ange"
 msgid "Change PIN"
 msgstr "_Endre"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr ""
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:3
 #, fuzzy
-#| msgid "Visible Networks"
 msgid "Mobile Network"
 msgstr "Synlige nettverk"
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:4
 #, fuzzy
-#| msgid "Configure Removable Media settings"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Konfigurer innstillinger for avtagbare medier"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -8527,63 +5043,17 @@ msgstr "Verktøy som lar deg tilpasse GNOME-skrivebordet"
 msgid "Settings is the primary interface for configuring your system."
 msgstr "Innstillinger er primærgrensesnittet for å konfigurere systemet ditt."
 
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:17
-#, fuzzy
-#| msgid "GNOME Settings"
-msgid "GNOME Settings Sound Panel"
-msgstr "GNOME kontrollpanel"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:21
-msgid "GNOME Settings Mouse &amp; Touchpad Panel"
-msgstr ""
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:25
-#, fuzzy
-#| msgid "GNOME Settings"
-msgid "GNOME Settings Background Panel"
-msgstr "GNOME kontrollpanel"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:29
-#, fuzzy
-#| msgid "GNOME Settings"
-msgid "GNOME Settings Keyboard Panel"
-msgstr "GNOME kontrollpanel"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:38
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "GNOME prosjektet"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Vis versjonsnummer"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Vis mer informasjon"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Søk etter strengen"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Vis mulige navn på paneler og avslutt"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel som skal vises"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT …]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Personvern"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Tilgjengelige paneler:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8640,7 +5110,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Avbryt søk"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Brukervalg;Innstillinger;"
@@ -8674,24 +5143,2549 @@ msgid ""
 "application window."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u utgang"
 msgstr[1] "%u utganger"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u inngang"
 msgstr[1] "%u innganger"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "Systemlyder"
+#~ msgid "System Bus"
+#~ msgstr "Systembuss"
+
+#~ msgid "Session Bus"
+#~ msgstr "Øktbuss"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Full tilgang til /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Har tilgang til nettverk"
+
+#~ msgid "Home"
+#~ msgstr "Hjem"
+
+#~ msgid "Read-only"
+#~ msgstr "Skrivebeskyttet"
+
+#~ msgid "File System"
+#~ msgstr "Filsystem"
+
+#~ msgid "Can change settings"
+#~ msgstr "Kan endre innstillinger"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s har følgende rettigheter innebygget. Disse kan ikke endres. Hvis du er "
+#~ "bekymret for disse tilgangene bør du vurdere å fjerne dette programmet."
+
+#~ msgid "Select a picture"
+#~ msgstr "Velg et bilde"
+
+#~ msgid "_Open"
+#~ msgstr "_Åpne"
+
+#~ msgid "multiple sizes"
+#~ msgstr "flere størrelser"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Ingen skrivebordsbakgrunn"
+
+#~ msgid "Current background"
+#~ msgstr "Gjeldende bakgrunn"
+
+#~ msgid "Light"
+#~ msgstr "Lys"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "skjerm;lås;diagnostikk;krash;privat;nylige filer;midlertidig;tmp;indeks;"
+#~ "navn;nettverk;identitet;"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Plasser kalibreringsenheten over firkanten og trykk «Start»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Flytt kalibreringsenheten til kalibreringsposisjon og trykk «Fortsett»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "Flytt kalibreringsenheten til overflateposisjon og trykk «Fortsett»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Lukk lokket på bærbar"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Det oppstod en intern feil som ikke kan rettes opp."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Verktøy som kreves for kalibrering er ikke installert."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profilen kunne ikke genereres."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Hvitpunkt for mål kunne ikke hentes."
+
+#~ msgid "Complete!"
+#~ msgstr "Fullført"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrering mislyktes!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Du kan fjerne kalibreringsenheten."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ikke forstyrr kalibreringsenheten mens kalibrering pågår"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Skjerm på bærbar"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Innebygget webkamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s skjerm"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s skanner"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s kamera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s skriver"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s webkamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Slå på fargehåndtering for %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Vis fargeprofiler for %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Ikke kalibrert"
+
+#~ msgid "Default: "
+#~ msgstr "Forvalg: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Fargeområde: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testprofil:"
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Velg fil for ICC-profil"
+
+#~ msgid "_Import"
+#~ msgstr "_Importer"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Støttede ICC-profiler"
+
+#~ msgid "All files"
+#~ msgstr "Alle filer"
+
+#~ msgid "Save Profile"
+#~ msgstr "Lagre profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Lag en fargeprofil for valgt enhet"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Fant ikke måleinstrument. Kontroller at det er slått på og riktig "
+#~ "tilkoblet."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Måleinstrumentet støtter ikke profilering av skrivere."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Enhetstypen er ikke støttet."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standard fargeområde"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testprofil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatisk"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Lav kvalitet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Middels kvalitet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Høy kvalitet"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Forvalgt RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Forvalgt CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Forvalgt grå"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Kalibreringsdata fra fabrikken levert av forhandler"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Skjermkorrigering i fullskjerm er ikke mulig med denne profilen"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Denne profilen er kanskje ikke nøyaktig lenger"
+
+#~ msgid "Other…"
+#~ msgstr "Annet …"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Lås opp for å endre innstillinger"
+
+#~ msgid "Today"
+#~ msgstr "I dag"
+
+#~ msgid "Yesterday"
+#~ msgstr "I går"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d time"
+#~ msgstr[1] "%d timer"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minutt"
+#~ msgstr[1] "%d minutter"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekund"
+#~ msgstr[1] "%d sekunder"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24-timer"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%B %e %Y, %a %H.%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%B %e %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%H.%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Problemrapportering hjelper oss med å forbedre %s. Rapporter sendes "
+#~ "anonymt, og inneholder ikke personlig data. %s"
+
+#~ msgid "On"
+#~ msgstr "På"
+
+#~ msgid "Off"
+#~ msgstr "Av"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Bruk endringer?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Endringer kan ikke brukes"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Dette kan være på grunn av begrensninger i maskinvaren."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Plassering av skjerm"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Landskap"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portrett høyre"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portrett venstre"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Landskap (vendt)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Unknown"
+#~ msgstr "Ukjent"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Ukjent"
+
+#~ msgid "System Logo"
+#~ msgstr "Systemlogo"
+
+#~ msgid "No input sources found"
+#~ msgstr "Fant ingen inndatakilder"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Annen"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Egendefinerte snarveier"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Tasten for alternative taster kan brukes til å skrive flere tegn. Disse "
+#~ "vises noen ganger som et tredje alternativ på tastaturet ditt."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Venstre Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Høyre Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Venstre super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Høyre super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menytast"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Høyre Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Compose-tasten lar deg skrive en stor variasjon av tegn. For å bruke den "
+#~ "trykker du Compose og så en sekvens med tegn. For eksempel Compose-tasten "
+#~ "fulgt av <b>C</b> og <b>o</b> vil skrive <b>©</b>, <b>a</b> fulgt av "
+#~ "<b>'</b> vil skrive <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d endret"
+#~ msgstr[1] "%d endret"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Nullstill alle snarveier?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Hvis du nullstiller snarveiene kan dette påvirke dine egendefinerte "
+#~ "snarveier. Dette kan ikke angres."
+
+#~ msgid "Reset All"
+#~ msgstr "Nullstill alle"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s brukes allerede for %s. Hvis du erstatter den vil %s bli slått av"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Oppgi den nye snarveien"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Sett egendefinert snarvei"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Sett snarvei"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Oppgi ny snarvei for å endre %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Legg til egendefinert snarvei"
+
+#~ msgid "Set"
+#~ msgstr "Sett"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Skjermen slår seg av"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekunder"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minutt"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 time"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minutt"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Aldri"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Lås skjermen"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Rulling med to fingre"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Fem klikk. Tid for GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dobbeltklikk, primærknapp"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Enkeltklikk, primærknapp"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dobbeltklikk, midterste knapp"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Enkeltklikk, midterste knapp"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dobbeltklikk, sekundærknapp"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Enkeltklikk, sekundærknapp"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager må kjøre."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Usikret nettverk (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Sikret nettverk (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Sikret nettverk (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Sikret nettverk (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Sikret nettverk"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Hvis du slår på hotspot vil du bli koblet fra %s, og det vil ikke være "
+#~ "mulig å aksessere internett via Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Må bestå av minst 8 tegn"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Vil du slå av trådløst aksesspunkt og koble fra brukere?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Stopp hotspot"
+
+#~ msgid "Preserve"
+#~ msgstr "Behold"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "Tilfeldig"
+
+#~ msgid "Stable"
+#~ msgstr "Stabil"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "MAC-adressen som oppgis her vil bli brukt som maskinvareadresse for "
+#~ "nettverksenheten denne tilkoblingen aktiveres på. Denne funksjonen er "
+#~ "kjent som MAC-kloning eller spoofing. Eksempel: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Bedrift"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "Never"
+#~ msgstr "Aldri"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Svak"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "God"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Utmerket"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Glem tilkobling"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Fjern tilkoblingsprofil"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Fjern VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detaljer"
+
+#~ msgid "automatic"
+#~ msgstr "automatisk"
+
+#~ msgid "Identity"
+#~ msgstr "Identitet"
+
+#~ msgid "Delete Address"
+#~ msgstr "Slett adresse"
+
+#~ msgid "Delete Route"
+#~ msgstr "Slett rute"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit nøkkel (heksadesimal eller ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit passordfrase"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamisk WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 personlig"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 bedrift"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 personlig"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Klarte ikke å åpne tilkoblingsbehandler"
+
+#~ msgid "New Profile"
+#~ msgstr "Ny profil"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importer fil …"
+
+#~ msgid "Add VPN"
+#~ msgstr "Legg til VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Klarte ikke å importere VPN-forbindelse"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Filen «%s» kunne ikke leses, eller inneholder ikke gjenkjent informasjon "
+#~ "om VPN-tilkobling\n"
+#~ "\n"
+#~ "Feil: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Velg fil som skal importeres"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "En fil med navn «%s» eksisterer allerede."
+
+#~ msgid "_Replace"
+#~ msgstr "E_rstatt"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Vil du erstatte %s med VPN-forbindelsen du lagrer?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Klarte ikke å eksportere VPN-forbindelse"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN-forbindelse «%s» kunne ikke eksporteres til %s.\n"
+#~ "\n"
+#~ "Feil: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Eksporter VPN-forbindelse"
+
+#~ msgid "never"
+#~ msgstr "aldri"
+
+#~ msgid "today"
+#~ msgstr "i dag"
+
+#~ msgid "yesterday"
+#~ msgstr "i går"
+
+#~ msgid "Last used"
+#~ msgstr "Sist brukt"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Nettverksdetaljer for valgte nettverk - inkludert passord og "
+#~ "innstillinger - går tapt."
+
+#~ msgid "_Forget"
+#~ msgstr "_Glem"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Kjente trådløse nettverk"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Glem"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Systemregler hindrer oppsett av aksesspunkt"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Trådløs enhet støtter ikke hotspotmodus"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Automatisk gjenkjenning av web-mellomtjener brukes når du ikke oppgir "
+#~ "nettadresse til et oppsett."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Dette anbefales ikke for offentlige nettverk du ikke stoler på."
+
+#~ msgid "Status unknown"
+#~ msgstr "Ukjent status"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Ikke administrert"
+
+#~ msgid "Unavailable"
+#~ msgstr "Ikke tilgjengelig"
+
+#~ msgid "Connecting"
+#~ msgstr "Kobler til"
+
+#~ msgid "Authentication required"
+#~ msgstr "Autentisering kreves"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Kobler fra"
+
+#~ msgid "Connection failed"
+#~ msgstr "Tilkobling mislyktes"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Ukjent status (mangler)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Oppsett mislyktes"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP-oppsett mislyktes"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP-oppsett er utgått"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Hemmeligheter kreves men ble ikke oppgitt"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x-hjelper frakoblet"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Oppsett av 802.1x-hjelper mislyktes"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x-hjelper mislyktes"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x-hjelper brukte for lang tid på autentisering"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP-tjeneste klarte ikke å starte"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP-tjeneste koblet fra"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP mislyktes"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP-klient startet ikke"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Feil i DHCP-klient"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-klient mislyktes"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Tjeneste for delt tilkobling startet ikke"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Tjeneste for delt tilkobling mislyktes"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP-tjeneste startet ikke"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Feil i AutoIP-tjeneste"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP-tjeneste mislyktes"
+
+#~ msgid "Line busy"
+#~ msgstr "Linjen er opptatt"
+
+#~ msgid "No dial tone"
+#~ msgstr "Ingen summetone"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Klarte ikke å etablere bærekanal"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Tidsavbrudd for oppringing"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Oppringingsforsøk mislyktes"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Oppstart av modem mislyktes"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Klarte ikke å velge angitt APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Søker ikke etter nettverk"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Nettverksregistrering nektet"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Tidsavbrudd for nettverksregistrering"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Klarte ikke å registrere med forespurt nettverk"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN-sjekk mislyktes"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Fastvare for enheten mangler kanskje"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Tilkobling forsvant"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Eksisterende tilkobling ble antatt"
+
+#~ msgid "Modem not found"
+#~ msgstr "Fant ikke modem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Tilkobling med Bluetooth mislyktes"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM-kort er ikke satt inn"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Pin for SIM kreves"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Puk for SIM kreves"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Feil SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Tilkoblingsavhengighet mislyktes"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Fastvare mangler"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel koblet fra"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "udefinert feil i 802.1x sikkerhet (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "ingen fil valgt"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "uspesifisert feil ved validering av fil for eap-metode"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "DER, PEM eller PKCS#12 private nøkler (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER- eller PEM-sertifikater (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "mangler EAP-FAST PAC-fil"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC-filer (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "mangler brukernavn for EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "mangler passord for EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "ugyldig EAP-PEAP CA-sertifikat: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "ugyldig EAP-PEAP CA-sertifikat: ingen sertifikat oppgitt"
+
+#~ msgid "missing EAP username"
+#~ msgstr "mangler brukernavn for EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "mangler passord for EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "mangler identitet for EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "ugyldig EAP-TLS CA-sertifikat: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "ugyldig EAP-TLS CA-sertifikat: ingen sertifikat oppgitt"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "ugyldig EAP-TLS privat nøkkel: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "ugyldig EAP-TLS brukersertifikat: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Ukrypterte private nøkler er usikre"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Valgt privat nøkkel ser ikke ut til å være beskyttet av et passord. Dette "
+#~ "kan medføre at påloggingsinformasjonen kan kompromitteres. Velg en "
+#~ "passordbeskyttet privat nøkkel.\n"
+#~ "\n"
+#~ "Privat nøkkel kan passordbeskyttes med openssl."
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Velg personlig sertifikat"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Velg privatnøkkel"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "ugyldig EAP-TTLS CA-sertifikat: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "ugyldig EAP-TTLS CA-sertifikat: ingen sertifikat oppgitt"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Ukjent feil ved validering av 802.1x sikkerhet"
+
+#~ msgid "Select a file"
+#~ msgstr "Velg en fil"
+
+#~ msgid "missing leap-username"
+#~ msgstr "mangler leap-brukernavn"
+
+#~ msgid "missing leap-password"
+#~ msgstr "mangler leap-passord"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Passord for Wi-Fi mangler."
+
+#~ msgid "missing wep-key"
+#~ msgstr "mangler wep-nøkkel"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "ugyldig wep-nøkkel: nøkkel med lengde %zu må kun inneholde heksadesimale "
+#~ "tall"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "ugyldig wep-nøkkel: nøkkel med en lengde på %zu må kun inneholde ASCII-"
+#~ "tegn"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "ugyldig wep-nøkkel: feil lengde på nøkkel %zu. En nøkkel må enten være av "
+#~ "lengde 5/13 (ascii) eller 10/26 (heksadesimal)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "ugyldig wep-nøkkel: passordfrasen kan ikke være tom"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "ugyldig wep-nøkkel: passordfrasen må være kortere enn 64 tegn"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "ugyldig wpa-psk: ugyldig key-length %zu. Må være [8,63] bytes eller 64 "
+#~ "hex sifre"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "ugyldig wpa-psk: kan ikke tolke nøkkel med 64 bytes som hex"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s fjernet"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Annen"
+
+#~ msgid "Error removing account"
+#~ msgstr "Feil ved fjerning av konto"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s-konto"
+
+#~ msgid "Remove Account"
+#~ msgstr "Fjern konto"
+
+#~ msgid "Unknown time"
+#~ msgstr "Ukjent tid"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "fullt ladet om %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Advarsel: %s gjenstår"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s gjenstår"
+
+#~ msgid "Fully charged"
+#~ msgstr "Fullt ladet"
+
+#~ msgid "Not charging"
+#~ msgstr "Lader ikke"
+
+#~ msgid "Empty"
+#~ msgstr "Tom"
+
+#~ msgid "Charging"
+#~ msgstr "Lader"
+
+#~ msgid "Discharging"
+#~ msgstr "Lader ut"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Trådløs mus"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Trådløst tastatur"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Avbruddsfri strømforsyning"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Personlig digital assistent"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobiltelefon"
+
+#~ msgid "Media player"
+#~ msgstr "Musikkavspiller"
+
+#~ msgid "Tablet"
+#~ msgstr "Tegnebrett"
+
+#~ msgid "Computer"
+#~ msgstr "Datamaskin"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Inndataenhet for spill"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Hoved"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Ekstra"
+
+#~ msgid "Batteries"
+#~ msgstr "Batterier"
+
+#~ msgid "When _idle"
+#~ msgstr "Når led_ig"
+
+#~ msgid "Suspend"
+#~ msgstr "Hvilemodus"
+
+#~ msgid "Power Off"
+#~ msgstr "Slå av"
+
+#~ msgid "Hibernate"
+#~ msgstr "Dvalemodus"
+
+#~ msgid "Nothing"
+#~ msgstr "Ingenting"
+
+#~ msgid "When on battery power"
+#~ msgstr "På batteristrøm"
+
+#~ msgid "When plugged in"
+#~ msgstr "Når den er koblet til strøm"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Aldri"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatisk hvilemodus"
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Ytelsesmodus er midlertidig slått av."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Strømsparingsmodus aktivert av «%s»."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Ytelsesmodus aktivert av «%s»."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Høy ytelse"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Høy ytelse og strømbruk."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Balansert"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standard ytelse og strømbruk."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Strømsparing"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Redusert ytelse og strømbruk."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Skriver «%s» er slettet"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Klarte ikke å legge til ny skriver."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Klarte ikke å laste brukergrensesnitt: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Lås opp for å legge til skrivere og endre innstillinger"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detaljer for %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Fant ingen passende driver"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Velg PPD-fil"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript Printer Description-filer (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect-skriver"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD-skriver"
+
+#~ msgid "One Sided"
+#~ msgstr "Ensidig"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Lang kant (standard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kort kant (vend)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portrett"
+
+#~ msgid "Landscape"
+#~ msgstr "Landskap"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Omvendt landskap"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Omvendt portrett"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Utestående"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "På pause"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autentisering kreves"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Prosesserer"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Stoppet"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Avbrutt"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Avbrutt med feil"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Fullført"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s – Aktive jobber"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Oppgi brukernavn og passord for å skrive ut fra %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Lås opp utskriftstjener"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Lås opp %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Oppgi brukernavn og passord for å vise skrivere på %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Søker etter skrivere"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Seriellport"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Parallellport"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Plassering: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresse: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Tjener krever autentisering"
+
+#~ msgid "Two Sided"
+#~ msgstr "Tosidig"
+
+#~ msgid "Paper Type"
+#~ msgstr "Papirtype"
+
+#~ msgid "Paper Source"
+#~ msgstr "Papirkilde"
+
+#~ msgid "Output Tray"
+#~ msgstr "Skuff"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Oppløsning"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Forhåndsfiltrering med GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Sider per side"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientering"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Generelt"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Sideoppsett"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Installerbare alternativer"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Jobb"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Bildekvalitet"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Farge"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Fullføring"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avansert"
+
+#~ msgid "Test page"
+#~ msgstr "Testside"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatisk valg"
+
+#~ msgid "Printer Default"
+#~ msgstr "Forvalg for skriver"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Kun innebyggede GhostScript skrifter"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Konverter til PS nivå 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Konverter til PS nivå 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Ingen forhåndsfiltrering"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Rens utskriftshodene"
+
+#~ msgid "Out of toner"
+#~ msgstr "Tom for toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Lite fremkaller"
+
+#~ msgid "Out of developer"
+#~ msgstr "Tom for fremkaller"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Lite farge"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Tom for farge"
+
+#~ msgid "Open cover"
+#~ msgstr "Åpent deksel"
+
+#~ msgid "Open door"
+#~ msgstr "Åpen dør"
+
+#~ msgid "Low on paper"
+#~ msgstr "Lite papir"
+
+#~ msgid "Out of paper"
+#~ msgstr "Tom for papir"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Frakoblet"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Stoppet"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Søppelbeholderen er nesten full"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Søppelbeholderen er full"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Optisk fotoleder er nær slutten på sin levetid"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Optisk fotoleder fungerer ikke lenger"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Klar"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Godtar ikke jobber"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Prosesserer"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperisk"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrisk"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Spør hva som skal gjøres"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ikke gjør noe"
+
+#~ msgid "Open folder"
+#~ msgstr "Åpne mappe"
+
+#~ msgid "Other Media"
+#~ msgstr "Annet medie"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Velg et program for lyd-CDer"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Velg et program for video-DVDer"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Velg et program som skal kjøres når en musikkavspiller kobles til"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Velg et program som skal kjøres når et kamera kobles til"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Velg et program for programvare-CDer"
+
+#~ msgid "audio DVD"
+#~ msgstr "Lyd-DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Tom Blu-ray-plate"
+
+#~ msgid "blank CD disc"
+#~ msgstr "Tom CD-plate"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "Tom DVD-plate"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "tom HD-DVD plate"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray videoplate"
+
+#~ msgid "e-book reader"
+#~ msgstr "E-bokleser"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD-DVD-videoplate"
+
+#~ msgid "Picture CD"
+#~ msgstr "Bilde-CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video-CD"
+
+#~ msgid "Select Location"
+#~ msgstr "Velg lokasjon"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Fant ingen programmer"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Ingen nettverk valgt for deling"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "På"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Av"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Slått på"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Velg en mappe"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Fildeling lar deg dele offentlig mappe med andre på samme nettverk ved å "
+#~ "bruke: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Når ekstern pålogging er aktivert kan eksterne brukere koble seg til med "
+#~ "Secure Shell-kommandoen:\n"
+#~ "%s"
+
+#~ msgid "Custom"
+#~ msgstr "Egendefinert"
+
+#~ msgid "Bark"
+#~ msgstr "Bjeff"
+
+#~ msgid "Drip"
+#~ msgstr "Drypp"
+
+#~ msgid "Glass"
+#~ msgstr "Glass"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Tester %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Koblet fra"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Kobler til"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Tilkoblet"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Feil ved autorisering"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autoriserer"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Redusert funksjonalitet"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Tilkoblet og autorisert"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Ukjent"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorisert hos:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Tilkoblet på:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Meldt inn hos:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Klarte ikke å autorisere enhet: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Klarte ikke å glemme enhet: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Feil"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorisert"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt støtte (boltd) er ikke installert eller ikke satt opp korrekt."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Kun USB og Display Port enheter kan koble til."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt ble ikke funnet.\n"
+#~ "Enten mangler systemet støtte for Thunderbolt eller så er det deaktivert "
+#~ "eller satt til et sikkerhetsnivå i BIOS som ikke er støttet."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Støtte for Thunderbolt er slått av i BIOS"
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Kunne ikke avgjøre sikkerhetsnivå for Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Feil ved bytting av direkte modus: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Middels"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Stor"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Større"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Størst"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d piksel"
+#~ msgstr[1] "%d piksler"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kort"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ skjerm"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ skjerm"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ skjerm"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Lang"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 time"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dag"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dager"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dager"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dager"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dager"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dager"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dager"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dager"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dager"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Tøm alle oppføringer fra papirkurven?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Alle elementer i papirkurven slettes permanent."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Tøm papirkurv"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Slett alle midlertidige filer?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Alle midlertidige filer slettes permanent."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Fjern midlertidige filer"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dag"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dager"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dager"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "For alltid"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Skal være lik kontotilbyders nettstedsadresse."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Klarte ikke å legge til en konto"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Klarte ikke å registrere konto"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Ingen støttet måte å autentisere med dette domenet"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Klarte ikke å bli med i domenet"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Brukernavnet virket ikke.\n"
+#~ "Vennligst prøv igjen."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Passordet for påloggingen virket ikke.\n"
+#~ "Vennligst prøv igjen."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Klarte ikke å logge inn i domenet"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Fant ikke domenet. Kanskje du stavet det feil?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Se etter flere bilder"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "enheten må gjøres krav på for å utføre denne handlingen"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "enheten er allerede gjort krav på av en annen prosess"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "du har ikke rettigheter til å utføre handlingen"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "ingen fingeravtrykk er registrert"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Klarte ikke å kommunisere med enheten under registrering"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Klarte ikke å kommunisere med fingeravtrykkleseren"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Klarte ikke å kommunisere med fingeravtrykktjenesten"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Klarte ikke å vise fingeravtrykk: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Klarte ikke å slette lagrede fingeravtrykk: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Venstre tommel"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Venstre langefinger"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Venstre pekefinger"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Venstre ringfinger"
+
+#~ msgid "Left little finger"
+#~ msgstr "Venstre lillefinger"
+
+#~ msgid "Right thumb"
+#~ msgstr "Høyre tommel"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Høyre langfinger"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Høy_re pekefinger"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Høyre ringfinger"
+
+#~ msgid "Right little finger"
+#~ msgstr "Høyre lillefinger"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Ukjent finger"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Fullført"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Fingeravtrykkleser koblet fra"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Lagring for fingeravtrykkleser er full"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Klarte ikke å lese inn nytt fingeravtrykk"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Klarte ikke å starte innlesing: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Klarte ikke å lese inn nytt fingeravtrykk"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Klarte ikke å stoppe innlesing: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Legg fingeren din på leseren gjentatte ganger for å lagre fingeravtrykket "
+#~ "ditt"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Les inn denne finge_ren på nytt …"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Les inn nytt fingeravtrykk"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Klarte ikke å frigjøre finngeravtrykkleser %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problem med å lese fra enhet"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Klarte ikke å gjøre krav på fingeravtrykkleser %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Klarte ikke å hente fingeravtrykklesere: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Denne uken"
+
+#~ msgid "Last Week"
+#~ msgstr "Forrige uke"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s – %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k.%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Økten ble avsluttet"
+
+#~ msgid "Session Started"
+#~ msgstr "Økten startet"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s – kontoaktivitet"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Velg et annet passord."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Skriv inn gjeldende passord en gang til."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Passordet kunne ikke endres"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Du kan ikke bli medlem av denne type domene automatisk"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Fant ikke dette domenet eller området"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Klarte ikke å logge inn som %s på domenet %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Ugyldig passord. Prøv igjen"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Kunne ikke koble til domenet %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Klarte ikke å slette bruker"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Klarte ikke å trekke tilbake eksternt håndtert bruker"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Du kan ikke slette din egen konto."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s er fremdeles logget inn"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Hvis du sletter en innlogget bruker kan systemet ende opp i en "
+#~ "inkonsistent tilstand."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Vil du beholde filene til %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Det er mulig å beholde hjemmemappe, e-postkø og midlertidige filer når du "
+#~ "sletter en brukerkonto."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Slett filer"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Behold filer"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Er du sikker på at du vil trekke tilbake eksternt håndtert konto for %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Slett"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Kontoen er sperret"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Velges ved neste innlogging"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "Logged in"
+#~ msgstr "Logget inn"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Klarte ikke å kontakte kontotjenesten"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Sjekk at kontotjenesten er installert og aktivert."
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Slett valgt brukerkonto"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klikk på *-ikonet\n"
+#~ "for å slette valgt brukerkonto"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Lås opp for å legge til brukere og endre innstillinger"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Det nye passordet må være ulikt det gamle."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Prøv å endre noen bokstaver og tall."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Prøv å endre passord enda litt mer."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Passordet blir sterkere hvis det ikke inneholder brukernavnet ditt."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Prøv å unngå å bruke navnet ditt i passordet."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Prøv å unngå noen av ordene som brukes i passordet."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Prøv å unngå vanlige ord."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Prøv å unngå å endre rekkefølge på eksisterende ord."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Prøv å bruke flere tall."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Prøv å bruke flere store bokstaver."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Prøv å bruke flere små bokstaver."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Prøv å bruke flere spesialtegn, som tegnsetting."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Prøv å bruke en blanding av bokstaver, tall og tegnsetting."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Prøv å unngå å gjenta samme tegn."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Prøv å unngå å gjenta samme type tegn. Du må blande bokstaver, tall og "
+#~ "tegnsettingstegn."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Prøv å unngå sekvenser som 1234 eller abcs."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Passordet må være lenger. Prøv å bruke en blanding av bokstaver, tall og "
+#~ "tegnsetting."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Bland store og små bokstaver, og prøv å bruke et tall eller to."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Passordet blir sterkere hvis du legger til flere bokstaver, tall og "
+#~ "spesialtegn."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autentisering mislyktes"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Det nye passordet er for kort"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Det nye passordet er for enkelt"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Gammelt og nytt passord er for like"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Det nye passordet har allerede blitt brukt nylig."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Det nye passordet må inneholde tall eller spesielle tegn"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Gammelt og nytt passord er det samme"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Passordet ditt er endret siden første autentisering!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Det nye passordet inneholder ikke nok spesielle tegn"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Ukjent feil"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Brukernavnet inneholder vanligvis små bokstaver fra a-z, tall, samt "
+#~ "tegnene «.», «-» og «_»."
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Beklager, det brukernavnet er ikke tilgjengelig. Prøv et annet."
+
+#~ msgid "The username is too long."
+#~ msgstr "Brukernavnet er for langt."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Knapp %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Program definert"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Send tastetrykk"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Bytt skjerm"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Vis hjelp på skjermen"
+
+#~ msgid "All Displays"
+#~ msgstr "Alle skjermer"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Ny snarvei …"
+
+#~ msgid "Registered"
+#~ msgstr "Registrert"
+
+#~ msgid "Searching"
+#~ msgstr "Søker"
+
+#~ msgid "Denied"
+#~ msgstr "Nektet"
+
+#~ msgid "2G Only"
+#~ msgstr "Kun 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Kun 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Kun 4G"
+
+#, fuzzy
+#~| msgid "Unknown"
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Ukjent"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Lås opp SIM-kort"
+
+#, fuzzy
+#~| msgid "PIN check failed"
+#~ msgid "Phone failure"
+#~ msgstr "PIN-sjekk mislyktes"
+
+#, fuzzy
+#~| msgid "Turn VPN connection off"
+#~ msgid "No connection to phone"
+#~ msgstr "Slå av VPN-forbindelse"
+
+#, fuzzy
+#~| msgid "SIM Card not inserted"
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM-kort er ikke satt inn"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PIN required"
+#~ msgstr "Pin for SIM kreves"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PUK required"
+#~ msgstr "Pin for SIM kreves"
+
+#, fuzzy
+#~| msgid "Current _Password"
+#~ msgid "Incorrect password"
+#~ msgstr "Gjeldende _passord"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Pin for SIM kreves"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Pin for SIM kreves"
+
+#, fuzzy
+#~| msgid "No stylus found"
+#~ msgid "Not found"
+#~ msgstr "Fant ingen penn"
+
+#, fuzzy
+#~| msgid "Networks"
+#~ msgid "No network service"
+#~ msgstr "Nettverk"
+
+#, fuzzy
+#~| msgid "Network Name"
+#~ msgid "Network timeout"
+#~ msgstr "Nettverksnavn"
+
+#, fuzzy
+#~| msgid "AutoIP service failed"
+#~ msgid "GPRS services not allowed"
+#~ msgstr "AutoIP-tjeneste mislyktes"
+
+#, fuzzy
+#~| msgctxt "print job"
+#~| msgid "Canceled"
+#~ msgid "Action Cancelled"
+#~ msgstr "Avbrutt"
+
+#, fuzzy
+#~| msgid "Unknown error"
+#~ msgid "Unknown Error"
+#~ msgstr "Ukjent feil"
+
+#, fuzzy
+#~| msgid "GNOME Settings"
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "GNOME kontrollpanel"
+
+#, fuzzy
+#~| msgid "GNOME Settings"
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "GNOME kontrollpanel"
+
+#, fuzzy
+#~| msgid "GNOME Settings"
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "GNOME kontrollpanel"
+
+#~ msgid "Display version number"
+#~ msgstr "Vis versjonsnummer"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Vis mer informasjon"
+
+#~ msgid "Search for the string"
+#~ msgstr "Søk etter strengen"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Vis mulige navn på paneler og avslutt"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel som skal vises"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT …]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Tilgjengelige paneler:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Systemlyder"

--- a/po/nb.po~
+++ b/po/nb.po~
@@ -1,0 +1,8697 @@
+# Norwegian bokmål translation of gnome-control-center.
+# Copyright (C) 1999-2015 The GNOME Project.
+#
+# Kjartan Maraas <kmaraas@gnome.org>, 1999-2021.
+# Terance Edward Sola <terance@lyse.net>, 2005.
+# Torstein Adolf Winterseth <kvikende@fsfe.org>, 2010.
+# Åka Sikrom <a4NOSPAMPLEASETHANKYOU alfakrøll hush dått com>, 2014-2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center 3.40.x\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-03-07 17:29+0000\n"
+"PO-Revision-Date: 2022-03-10 16:23+0100\n"
+"Last-Translator: Kjartan Maraas <kmaraas@gnome.org>\n"
+"Language-Team: Norwegian bokmål <i18n-nb@lister.ping.uio.no>\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.5.4\n"
+
+#: panels/applications/cc-applications-panel.c:803
+msgid "System Bus"
+msgstr "Systembuss"
+
+#: panels/applications/cc-applications-panel.c:803
+#: panels/applications/cc-applications-panel.c:805
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:823
+msgid "Full access"
+msgstr "Full tilgang"
+
+#: panels/applications/cc-applications-panel.c:805
+msgid "Session Bus"
+msgstr "Øktbuss"
+
+#: panels/applications/cc-applications-panel.c:809
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
+#: panels/thunderbolt/cc-bolt-panel.ui:310
+msgid "Devices"
+msgstr "Enheter"
+
+#: panels/applications/cc-applications-panel.c:809
+msgid "Full access to /dev"
+msgstr "Full tilgang til /dev"
+
+#: panels/applications/cc-applications-panel.c:813
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Nettverk"
+
+#: panels/applications/cc-applications-panel.c:813
+msgid "Has network access"
+msgstr "Har tilgang til nettverk"
+
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:820
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Hjem"
+
+#: panels/applications/cc-applications-panel.c:820
+#: panels/applications/cc-applications-panel.c:825
+msgid "Read-only"
+msgstr "Skrivebeskyttet"
+
+#: panels/applications/cc-applications-panel.c:823
+#: panels/applications/cc-applications-panel.c:825
+msgid "File System"
+msgstr "Filsystem"
+
+#: panels/applications/cc-applications-panel.c:829
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:878 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Innstillinger"
+
+#: panels/applications/cc-applications-panel.c:829
+msgid "Can change settings"
+msgstr "Kan endre innstillinger"
+
+#: panels/applications/cc-applications-panel.c:831
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s har følgende rettigheter innebygget. Disse kan ikke endres. Hvis du er "
+"bekymret for disse tilgangene bør du vurdere å fjerne dette programmet."
+
+#: panels/applications/cc-applications-panel.c:1164
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/applications/cc-applications-panel.c:1171
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1223
+#, c-format
+msgid "%s of disk space used"
+msgstr ""
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1387
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Programmer"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Ingen programmer"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Installer noen …"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Åpne"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Vis detaljer"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Søk"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/applications/cc-applications-panel.ui:177
+#: panels/applications/cc-applications-panel.ui:191
+#: panels/applications/cc-applications-panel.ui:205
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
+#: panels/user-accounts/cc-user-panel.c:789
+#: panels/user-accounts/cc-user-panel.c:879
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1900
+msgid "Disabled"
+msgstr "Slått av"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Varslinger"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Vis systemvarslinger."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in background"
+msgstr "Kjør i bakgrunnen"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Change Wallpaper"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#: panels/applications/cc-applications-panel.ui:154
+msgid "Sounds"
+msgstr "Lyder"
+
+#: panels/applications/cc-applications-panel.ui:148
+#: panels/applications/cc-applications-panel.ui:155
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Inhibit Shortcuts"
+msgstr "Hindre snarveier"
+
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Block standard keyboard shortcuts."
+msgstr "Hindre systemets tastatursnarveier"
+
+#: panels/applications/cc-applications-panel.ui:168
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:169
+#: panels/applications/cc-applications-panel.ui:176
+msgid "Take pictures with the camera."
+msgstr "Ta bilder med kameraet."
+
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:183
+#: panels/applications/cc-applications-panel.ui:190
+msgid "Record audio with the microphone."
+msgstr "Ta opp lyd med mikrofonen."
+
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Stedstjenester"
+
+#: panels/applications/cc-applications-panel.ui:197
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Access device location data."
+msgstr "Få tilgang til stedsdata for enheten."
+
+#: panels/applications/cc-applications-panel.ui:215
+#: panels/applications/cc-applications-panel.ui:319
+msgid "Built-in Permissions"
+msgstr "Innebygde rettigheter"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System access that is required by the app"
+msgstr "Systemtilgang som kreves av dette programmet."
+
+#: panels/applications/cc-applications-panel.ui:224
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:399
+msgid "Storage"
+msgstr "Lagring"
+
+#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+msgid "No results found"
+msgstr "Fant ingen resultater"
+
+#: panels/applications/cc-applications-panel.ui:304
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
+#: shell/cc-panel-list.ui:114
+msgid "Try a different search"
+msgstr "Prøv et annet søk"
+
+#: panels/applications/cc-applications-panel.ui:344
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:367
+msgid "File Types"
+msgstr "Filtyper"
+
+#: panels/applications/cc-applications-panel.ui:373
+msgid "Link Types"
+msgstr "Lenketyper"
+
+#: panels/applications/cc-applications-panel.ui:383
+msgid "Reset"
+msgstr "Nullstill"
+
+#: panels/applications/cc-applications-panel.ui:410
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Hvor mye diskplass programmet bruker med applikasjonsdata og mellomlager."
+
+#: panels/applications/cc-applications-panel.ui:413
+msgid "Application"
+msgstr "Program"
+
+#: panels/applications/cc-applications-panel.ui:419
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:425
+msgid "Cache"
+msgstr "Buffer"
+
+#: panels/applications/cc-applications-panel.ui:431
+msgid "<b>Total</b>"
+msgstr "<b>Totalt</b>"
+
+#: panels/applications/cc-applications-panel.ui:441
+msgid "Clear Cache…"
+msgstr "Tøm buffer …"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Kontroller forskjellige rettigheter og innstillinger for programmer"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "program;flatpak;rettighet;innstilling;"
+
+#: panels/background/cc-background-chooser.c:307
+msgid "Select a picture"
+msgstr "Velg et bilde"
+
+#: panels/background/cc-background-chooser.c:310
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:198
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/network/cc-wifi-hotspot-dialog.ui:123
+#: panels/network/cc-wifi-panel.c:881
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:226
+#: panels/network/connection-editor/vpn-helpers.c:346
+#: panels/network/net-device-wifi.c:860
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:263
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:18
+#: panels/user-accounts/cc-user-panel.c:579
+#: panels/user-accounts/cc-user-panel.c:597
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:139
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
+msgid "_Cancel"
+msgstr "A_vbryt"
+
+#: panels/background/cc-background-chooser.c:311
+#: panels/network/connection-editor/vpn-helpers.c:227
+#: panels/printers/pp-details-dialog.c:264
+#: panels/sharing/cc-sharing-panel.c:524
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Åpne"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "flere størrelser"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Ingen skrivebordsbakgrunn"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Gjeldende bakgrunn"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stil"
+
+#: panels/background/cc-background-panel.ui:45
+msgid "Light"
+msgstr "Lys"
+
+#: panels/background/cc-background-panel.ui:72
+msgid "Dark"
+msgstr "Mørk"
+
+#: panels/background/cc-background-panel.ui:91
+msgid "Background"
+msgstr "Bakgrunn"
+
+#: panels/background/cc-background-panel.ui:97
+msgid "Add Picture…"
+msgstr "Legg til bilde …"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Utseende"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Bytt bakgrunnsbilde eller farger på brukergrensesnittet"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgstr "Bakgrunn;Skjerm;Skrivebord;Skrivebord;Stil;Lys;Mørk;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:21
+msgid "No Bluetooth Found"
+msgstr "Fant ikke Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:22
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Koble til en dongle for å bruke Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:28
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth er slått av"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:29
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Slå på for å koble til enheter og motta filer."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:35
+msgid "Airplane Mode is On"
+msgstr "Flymodus er på"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:36
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth er slått av når flymodus er på."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Turn Off Airplane Mode"
+msgstr "Slå av flymodus"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:53
+msgid "Hardware Airplane Mode is On"
+msgstr "Flymodus slått på med maskinvare"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:54
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Slå av flymodus-bryteren for å slå på Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Slå av/på bluetooth og koble til enheter"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "del;deling;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:21
+msgid "Camera is Turned Off"
+msgstr "Kamera er slått av"
+
+#: panels/camera/cc-camera-panel.ui:22
+msgid "No applications can capture photos or video."
+msgstr "Ingen programmer kan ta bilder eller video."
+
+#: panels/camera/cc-camera-panel.ui:36
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Bruk av kamera lar programmer ta bilder og video. Hvis du slår av kamera vil noen programmer ikke lenger fungere korrekt.\n"
+"\n"
+"Tillat at programmene under kan bruke ditt kamera."
+
+#: panels/camera/cc-camera-panel.ui:52
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Ingen programmer har bedt om tilgang til kamera"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Beskytt bildene dine"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"skjerm;lås;diagnostikk;krash;privat;nylige filer;midlertidig;tmp;indeks;navn;"
+"nettverk;identitet;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Plasser kalibreringsenheten over firkanten og trykk «Start»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "Flytt kalibreringsenheten til kalibreringsposisjon og trykk «Fortsett»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Flytt kalibreringsenheten til overflateposisjon og trykk «Fortsett»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Lukk lokket på bærbar"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Det oppstod en intern feil som ikke kan rettes opp."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Verktøy som kreves for kalibrering er ikke installert."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Profilen kunne ikke genereres."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Hvitpunkt for mål kunne ikke hentes."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Fullført"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrering mislyktes!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Du kan fjerne kalibreringsenheten."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ikke forstyrr kalibreringsenheten mens kalibrering pågår"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Kalibrering av skjerm"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Start"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "G_jenoppta"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+msgid "_Done"
+msgstr "Fer_dig"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Skjerm på bærbar"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Innebygget webkamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s skjerm"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s skanner"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s kamera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s skriver"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s webkamera"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Slå på fargehåndtering for %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Vis fargeprofiler for %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Ikke kalibrert"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Forvalg: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Fargeområde: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Testprofil:"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Velg fil for ICC-profil"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importer"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Støttede ICC-profiler"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Alle filer"
+
+#: panels/color/cc-color-panel.c:586
+msgid "Screen"
+msgstr "Skjerm"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Lagre profil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:347
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Lagre"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Lag en fargeprofil for valgt enhet"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Fant ikke måleinstrument. Kontroller at det er slått på og riktig tilkoblet."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Måleinstrumentet støtter ikke profilering av skrivere."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Enhetstypen er ikke støttet."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Kalibrering av skjerm"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kvalitet på kalibrering"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrering lager en profil som du kan bruke til å styre farger på skjermen. "
+"Kvaliteten på fargeprofilen blir bedre hvis du lar kalibreringen bruke lang "
+"tid."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Du kan ikke bruke datamaskinen mens skjermen blir kalibrert."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kvalitet"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Tilnærmet tid"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibreringsenhet"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Velg hvilken sensorenhet du vil kalibrere med."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Type skjerm"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Velg type skjerm som er koblet til."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Hvitpunkt for profil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Velg et hvitpunkt for skjermen. De fleste skjermer bør kalibreres til en D65 "
+"lyskilde."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Lysstyrke for skjerm"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Still skjermen til en lysstyrke du typisk foretrekker. Fargehåndtering "
+"tilpasses slik at farger vises mest nøyaktig ved dette lysnivået."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Du kan eventuelt bruke lysstyrkenivået som allerede er valgt av en av de "
+"andre profilene for denne enheten."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Navn på profil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Du kan bruke en fargeprofil på forskjellige datamaskiner, eller til og med "
+"lage profiler for forskjellige lysforhold."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Navn på profil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Sammendrag"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Oppretting av profil fullført!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopier profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Krever skrivbart medie"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Instruksjonene om hvordan profilen skal brukes på <a href=\"linux\">GNU/"
+"Linux</a>, <a href=\"osx\">Apple OS X</a> og <a href=\"windows\">Microsoft "
+"Windows</a> systemer kan være nyttig."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Legg til profil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Fant problemer. Profilen vil kanskje ikke fungere som den skal. <a href="
+"\"\">Vis detaljer.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importer fil …"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/network/connection-editor/net-connection-editor.c:497
+#: panels/printers/new-printer-dialog.ui:84
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Legg til"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "Hver enhet må ha en oppdatert fargeprofil for å bli fargestyrt."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Lær mer"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Lær mer om fargehåndtering"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Bruk på alle brukere"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Angi denne profilen for alle brukere på denne datamaskinen"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Slå på"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Legg til profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrer …"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibrer enheten"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Fje_rn profil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Vis detaljer"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Fant ingen enheter som støtter fargehåndtering"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Prosjektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL-baklys)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED-baklys)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (hvitt LED-baklys)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Bred gamut LCD (CCFL-baklys)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Bred gamut LCD (RGB LED-baklys)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Høy"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutter"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Middels"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutter"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Lav"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutter"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Skjermens egen"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Utskrift og trykking)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografi og grafikk)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standard fargeområde"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testprofil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatisk"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Lav kvalitet"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Middels kvalitet"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Høy kvalitet"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Forvalgt RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Forvalgt CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Forvalgt grå"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Kalibreringsdata fra fabrikken levert av forhandler"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Skjermkorrigering i fullskjerm er ikke mulig med denne profilen"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Denne profilen er kanskje ikke nøyaktig lenger"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Farge"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Kalibrer farger for enheter som f.eks. skjermer, kamera eller skrivere"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Farge;ICC;Profil;Kalibrer;Skriver;Skjerm;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Annet …"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Velg språk"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Velg"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Fant ingen språk"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Mer …"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Lås opp for å endre innstillinger"
+
+#: panels/common/cc-permission-infobar.ui:40
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Noen innstillinger må låses opp før de kan endres."
+
+#: panels/common/cc-permission-infobar.ui:57
+msgid "Unlock…"
+msgstr "Lås opp …"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Øk time"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Øk minutt"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Tid"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Reduser time"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Reduser minutt"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:162
+msgid "Today"
+msgstr "I dag"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:164
+msgid "Yesterday"
+msgstr "I går"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d time"
+msgstr[1] "%d timer"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minutt"
+msgstr[1] "%d minutter"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekund"
+msgstr[1] "%d sekunder"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekunder"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-timer"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%B %e %Y, %a %H.%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%B %e %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%H.%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Dato og klokkeslett"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "År"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Måned"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januar"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Mars"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mai"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juni"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juli"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Desember"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dag"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Tidssone"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Søk etter en by"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatisk _dato &amp; klokkeslett"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Krever tilkobling til internett"
+
+#: panels/datetime/cc-datetime-panel.ui:177
+msgid "Date &amp; _Time"
+msgstr "Da_to &amp; klokkeslett"
+
+#: panels/datetime/cc-datetime-panel.ui:201
+msgid "Automatic Time _Zone"
+msgstr "Automatisk tids_sone"
+
+#: panels/datetime/cc-datetime-panel.ui:202
+msgid "Requires location services enabled and internet access"
+msgstr ""
+"Krever tilgang til internett og at tjeneste for stedsinformasjon kjører"
+
+#: panels/datetime/cc-datetime-panel.ui:214
+msgid "Time Z_one"
+msgstr "Tidss_one"
+
+#: panels/datetime/cc-datetime-panel.ui:239
+msgid "Time _Format"
+msgstr "Tids_format"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Endra dato og klokkeslett - inklusive tidssone"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Klokke;Tidssone;Plassering;Adresse;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Endre innstillinger for systemets klokke og dato"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Du må autentisere deg for å endre innstillinger for tid og dato."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Nett"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_E-post"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalender"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usikk"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotografier"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Forvalgte programmer"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Konfigurer forvalgte programmer"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "forvalgt;program;foretrukket;medie;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Problemrapportering hjelper oss med å forbedre %s. Rapporter sendes anonymt, "
+"og inneholder ikke personlig data. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Problemrapportering"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatisk problemrapportering"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostikk"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Rapporter problemene dine"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"skjerm;lås;diagnostikk;krash;privat;nylige filer;midlertidig;tmp;indeks;navn;"
+"nettverk;identitet;personvern;"
+
+#: panels/display/cc-display-panel.c:512
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
+#: panels/universal-access/cc-ua-panel.c:337
+#: panels/universal-access/cc-ua-panel.c:469
+#: panels/universal-access/cc-ua-panel.c:479
+#: panels/universal-access/cc-ua-panel.c:491
+#: panels/universal-access/cc-ua-panel.c:527
+msgid "On"
+msgstr "På"
+
+#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:337
+#: panels/universal-access/cc-ua-panel.c:469
+#: panels/universal-access/cc-ua-panel.c:479
+#: panels/universal-access/cc-ua-panel.c:491
+#: panels/universal-access/cc-ua-panel.c:527
+msgid "Off"
+msgstr "Av"
+
+#: panels/display/cc-display-panel.c:945
+msgid "Apply Changes?"
+msgstr "Bruk endringer?"
+
+#: panels/display/cc-display-panel.c:950
+msgid "Changes Cannot be Applied"
+msgstr "Endringer kan ikke brukes"
+
+#: panels/display/cc-display-panel.c:952
+msgid "This could be due to hardware limitations."
+msgstr "Dette kan være på grunn av begrensninger i maskinvaren."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Bruk"
+
+#: panels/display/cc-display-panel.ui:97
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:113
+msgid "Display Arrangement"
+msgstr "Plassering av skjerm"
+
+#: panels/display/cc-display-panel.ui:124
+msgid "Multiple Displays"
+msgstr "Flere skjermer"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:133
+msgid "Join"
+msgstr "Slå sammen"
+
+#: panels/display/cc-display-panel.ui:140
+msgid "Mirror"
+msgstr "Speil"
+
+#: panels/display/cc-display-panel.ui:153
+msgid "Contains top bar and Activities"
+msgstr "Inneholder topplinje og aktiviteter"
+
+#: panels/display/cc-display-panel.ui:154
+msgid "Primary Display"
+msgstr "Primær skjerm"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:175
+#: panels/display/cc-display-panel.ui:223
+#: panels/display/cc-night-light-page.ui:77
+msgid "Night Light"
+msgstr "Nattlys"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Landskap"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portrett høyre"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portrett venstre"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Landskap (vendt)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:40
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientering"
+
+#: panels/display/cc-display-settings.ui:47
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Oppløsning"
+
+#: panels/display/cc-display-settings.ui:54
+msgid "Refresh Rate"
+msgstr "Oppfriskingshastighet"
+
+#: panels/display/cc-display-settings.ui:61
+msgid "Adjust for TV"
+msgstr "Juster for TV"
+
+#: panels/display/cc-display-settings.ui:75
+#: panels/display/cc-display-settings.ui:90
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skalering"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:21
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Midlertidig deaktivert til i morgen"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:35
+msgid "Restart Filter"
+msgstr "Start filter på nytt"
+
+#: panels/display/cc-night-light-page.ui:57
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Nattlys gjør skjermens farger varmere. Dette kan hjelpe til å motvirke "
+"belastning på øyet og søvnløshet."
+
+#: panels/display/cc-night-light-page.ui:91
+msgid "Schedule"
+msgstr "Tidsplan"
+
+#: panels/display/cc-night-light-page.ui:99
+msgid "Sunset to Sunrise"
+msgstr "Solnedgang til soloppgang"
+
+#: panels/display/cc-night-light-page.ui:100
+msgid "Manual Schedule"
+msgstr "Manuell tidsplan"
+
+#: panels/display/cc-night-light-page.ui:110
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Tid"
+
+#: panels/display/cc-night-light-page.ui:123
+msgid "From"
+msgstr "Fra"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/display/cc-night-light-page.ui:235
+msgid "Hour"
+msgstr "Time"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/display/cc-night-light-page.ui:241
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:171
+#: panels/display/cc-night-light-page.ui:258
+msgid "Minute"
+msgstr "Minutt"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:181
+#: panels/display/cc-night-light-page.ui:268
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:193
+#: panels/display/cc-night-light-page.ui:280
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:210
+msgid "To"
+msgstr "Til"
+
+#: panels/display/cc-night-light-page.ui:316
+msgid "Color Temperature"
+msgstr "Fargetemperatur"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Skjermer"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Velg hvordan tilkoblede skjermer og prosjektorer skal brukes"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Prosjektor;xrandr;Skjerm;Oppløsning;Oppdater;Skjerm;Natt;Lys;Blå;"
+"redshift;farge;solnedgang;soloppgang;"
+
+#: panels/info-overview/cc-info-overview-panel.c:411
+#: panels/info-overview/cc-info-overview-panel.c:435
+#: panels/info-overview/cc-info-overview-panel.c:481
+#: panels/info-overview/cc-info-overview-panel.c:511
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Ukjent"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:443
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; bygg-ID: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:458
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:461
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:720
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:724
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:726
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Ukjent"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Systemlogo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "Device Name"
+msgstr "Navn på enhet"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Maskinvaremodell"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Minne"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Prosessor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafikk"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Diskkapasitet"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Beregner …"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Navn på operativsystem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:106
+msgid "OS Type"
+msgstr "Type operativsystem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:114
+msgid "GNOME Version"
+msgstr "GNOME versjon"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "Windowing System"
+msgstr "Vindussystem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:131
+msgid "Virtualization"
+msgstr "Virtualisering"
+
+#: panels/info-overview/cc-info-overview-panel.ui:139
+msgid "Software Updates"
+msgstr "Programvareoppdateringer"
+
+#: panels/info-overview/cc-info-overview-panel.ui:158
+msgid "Rename Device"
+msgstr "Endre navn på enhet"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Enhetsnavnet brukes til å identifisere denne enheten når den vises over "
+"nettverket eller ved paring med Bluetooth-enheter."
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid "_Rename"
+msgstr "End_re navn"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Om"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Vis informasjon om systemet"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"enhet;system;informasjon;minne;vertsnavn;prosessor;versjon;forvalg;program;"
+"foretrukket;cd;dvd;usb;lyd;video;plate;avtagbar;medie;automatisk kjøring;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Lyd og media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Demp / slå på volum"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Volum ned"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Volum opp"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Demp / slå på mikrofon"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Start mediespiller"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Spill av (eller spill av/pause)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pause avspilling"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Stopp avspilling"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Forrige spor"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Neste spor"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Utløs"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Skriving"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Bytt til neste inndatakilde"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Bytt til forrige inndatakilde"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Oppstartere"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Start hjelpleser"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Start kalkulator"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Start e-postprogram"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Start nettleser"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Hjemmemappe"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Søk"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Logg ut"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Lås skjerm"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Tilgjengelighet"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Slå av/på zoom"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zoom inn"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Zoom ut"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Slå av/på skjermleser"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Slå av/på tastatur på skjermen"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Større tekststørrelse"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Mindre tekststørrelse"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Høy kontrast på eller av"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Fant ingen inndatakilder"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Annen"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Legg til en inndatakilde"
+
+#: panels/keyboard/cc-input-chooser.ui:81
+msgid "Input methods can’t be used on the login screen"
+msgstr "Inndatametoder kan ikke brukes på påloggingsskjermen"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Ingen inndatakilder valgt"
+
+#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+msgid "Move Up"
+msgstr "Flytt opp"
+
+#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+msgid "Move Down"
+msgstr "Flytt ned"
+
+#: panels/keyboard/cc-input-row.ui:38
+msgid "Preferences"
+msgstr "Brukervalg"
+
+#: panels/keyboard/cc-input-row.ui:45
+msgid "View Keyboard Layout"
+msgstr "Vis tastaturutforming"
+
+#: panels/keyboard/cc-input-row.ui:51
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+msgid "Remove"
+msgstr "Fjern"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Egendefinerte snarveier"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:62
+msgid "Alternate Characters Key"
+msgstr "Tast for alternative tegn"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Tasten for alternative taster kan brukes til å skrive flere tegn. Disse "
+"vises noen ganger som et tredje alternativ på tastaturet ditt."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Venstre Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Høyre Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Venstre super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Høyre super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menytast"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Høyre Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:79
+msgid "Compose Key"
+msgstr "Komponeringstast"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Compose-tasten lar deg skrive en stor variasjon av tegn. For å bruke den "
+"trykker du Compose og så en sekvens med tegn. For eksempel Compose-tasten "
+"fulgt av <b>C</b> og <b>o</b> vil skrive <b>©</b>, <b>a</b> fulgt av <b>'</"
+"b> vil skrive <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Inndatakilder"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Bytt inndatakilde"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Bruk _samme kilde for alle vinduer"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Bytt inndatakilder _individuelt for hvert vindu"
+
+#: panels/keyboard/cc-keyboard-panel.ui:58
+msgid "Special Character Entry"
+msgstr "Skriv spesielle tegn"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Metoder for å skrive symboler og bokstavvarianter med tastaturet."
+
+#: panels/keyboard/cc-keyboard-panel.ui:97
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Tastatursnarveier"
+
+#: panels/keyboard/cc-keyboard-panel.ui:100
+msgid "View and Customize Shortcuts"
+msgstr "Vis og tilpass snarveier"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d endret"
+msgstr[1] "%d endret"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
+msgid "Reset All Shortcuts?"
+msgstr "Nullstill alle snarveier?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Hvis du nullstiller snarveiene kan dette påvirke dine egendefinerte "
+"snarveier. Dette kan ikke angres."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
+msgid "Reset All"
+msgstr "Nullstill alle"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Nullstill alle …"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Nullstill alle snarveier til sine forvalgte verdier"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+msgid "Add Custom Shortcuts"
+msgstr "Legg til egendefinerte snarveier"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Sett opp egendefinerte snarveier for å starte programmer, kjøre skript og "
+"mer."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+msgid "Add Shortcut"
+msgstr "Legg til snarvei"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+msgid "No keyboard shortcut found"
+msgstr "Ingen tastatursnarvei funnet"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s brukes allerede for %s. Hvis du erstatter den vil %s bli slått av"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Oppgi den nye snarveien"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Sett egendefinert snarvei"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Sett snarvei"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Oppgi ny snarvei for å endre %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
+msgid "Add Custom Shortcut"
+msgstr "Legg til egendefinert snarvei"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Legg til"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
+msgid "Replace"
+msgstr "Erstatt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
+msgid "Set"
+msgstr "Sett"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Trykk Esc for å avbryte eller Slett for å nullstille tastatursnarveien."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Navn"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+msgid "Command"
+msgstr "Kommando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+msgid "Shortcut"
+msgstr "Snarvei"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+msgid "Set Shortcut…"
+msgstr "Sett snarvei …"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "Ingen"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Nullstill snarveien til sin forvalgte verdi"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatur"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "Endre tastatursnarveier, endre skriveoppsett, tastaturutforming og inndatakilder"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"snarvei;arbeidsområde;vindu;endre størrelse;zoom;kontrast;inndata;kilde;lås;"
+"volum"
+
+#: panels/location/cc-location-panel.ui:20
+msgid "Location Services Turned Off"
+msgstr "Stedstjenester er slått av"
+
+#: panels/location/cc-location-panel.ui:21
+msgid "No applications can obtain location information."
+msgstr "Ingen programmer kan hente stedsinformasjon."
+
+#: panels/location/cc-location-panel.ui:35
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:53
+msgid "No Applications Have Asked for Location Access"
+msgstr "Ingen programmer har bedt om stedsinformasjon"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Beskytt din stedsinformasjon"
+
+#. FIXME
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:62
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Skjermen slår seg av"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:65
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekunder"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:68
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minutt"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:71
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:74 panels/lock/cc-lock-panel.c:77
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:80
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:83
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 time"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:126
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minutt"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:129
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:132
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:135
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:138
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:141
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:144
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:147
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:150
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:153
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Aldri"
+
+#: panels/lock/cc-lock-panel.ui:8
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatisk låsing av skjermen forhindrer andres tilgang til datamaskinen når "
+"du er borte."
+
+#: panels/lock/cc-lock-panel.ui:13
+msgid "Blank Screen Delay"
+msgstr "Pause før skjermen slås av"
+
+#: panels/lock/cc-lock-panel.ui:14
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Periode med inaktivitet før skjermen slås av."
+
+#: panels/lock/cc-lock-panel.ui:32
+msgid "Automatic Screen _Lock"
+msgstr "Automatisk _låsing av skjerm"
+
+#: panels/lock/cc-lock-panel.ui:46
+msgid "Automatic _Screen Lock Delay"
+msgstr "Pause før automatisk _låsing av skjerm"
+
+#: panels/lock/cc-lock-panel.ui:47
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Periode etter skjermen slås av før den låses automatisk."
+
+#: panels/lock/cc-lock-panel.ui:65
+msgid "Show _Notifications on Lock Screen"
+msgstr "Vis varsli_nger på låseskjerm"
+
+#: panels/lock/cc-lock-panel.ui:80
+msgid "Forbid new _USB devices"
+msgstr "Forby nye _USB-enheter"
+
+#: panels/lock/cc-lock-panel.ui:81
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Forhindre nye USB-enheter fra å ha interaksjon med systemet når skjermen er "
+"låst."
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "Lås skjerm"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr "Lås skjermen"
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:20
+msgid "Microphone Turned Off"
+msgstr "Mikrofonen er slått av"
+
+#: panels/microphone/cc-microphone-panel.ui:21
+msgid "No applications can record sound."
+msgstr "Ingen programmer kan ta opp lyd."
+
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Bruk av mikrofonen lar programmer ta opp og lytte til lyd. Hvis du slår av mikrofonen kan dette medføre at noen programmer ikke fungerer slik de skal.\n"
+"\n"
+"Tillat at programmene under kan bruke din mikrofon."
+
+#: panels/microphone/cc-microphone-panel.ui:51
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Ingen programmer har bedt om tilgang til mikrofonen"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Beskytt samtalene dine"
+
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Test inn_stillinger"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Generelt"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primærknapp"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Setter rekkefølge for de fysiske knappene på mus og pekeflater."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Venstre"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Høyre"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mus"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Mushastighet"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
+msgid "Natural Scrolling"
+msgstr "Naturlig rulling"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
+msgid "Scrolling moves the content, not the view."
+msgstr "Rulling flytter innholdet, ikke visningen."
+
+#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+msgid "Touchpad"
+msgstr "Pekeplate"
+
+#: panels/mouse/cc-mouse-panel.ui:119
+msgid "Touchpad Speed"
+msgstr "Hastighet for pekeplate"
+
+#: panels/mouse/cc-mouse-panel.ui:136
+msgid "Tap to Click"
+msgstr "Tapp for å klikke"
+
+#: panels/mouse/cc-mouse-panel.ui:147
+msgid "Two-finger Scrolling"
+msgstr "Rulling med to fingre"
+
+#: panels/mouse/cc-mouse-panel.ui:159
+msgid "Edge Scrolling"
+msgstr "Kantrulling"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Prøv klikk, dobbeltklikk og rulling"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Fem klikk. Tid for GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dobbeltklikk, primærknapp"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Enkeltklikk, primærknapp"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dobbeltklikk, midterste knapp"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Enkeltklikk, midterste knapp"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dobbeltklikk, sekundærknapp"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Enkeltklikk, sekundærknapp"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mus og pekeplate"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Endre sensitivitet for mus eller pekeplate og velg om du er høyrehendt eller "
+"venstrehendt"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Styrepute;Peker;Klikk;Tapp;Dobbel;Knapp;Styrekule;Rull;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Aktive skjermkanter"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Arbeidsområder"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Fjerner tomme arbeidsområder automatisk."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Fast antall arbeidsområder"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "A_tall arbeidsområder"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Flerskjerm"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Bytting mellom programmer"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitasking"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgstr ""
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Oi! Noe gikk galt. Kontakt programvareleverandøren."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager må kjøre."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Andre enheter"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
+#: panels/network/connection-editor/net-connection-editor.c:580
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:70
+msgid "Not set up"
+msgstr "Ikke satt opp"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:207
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:263
+msgid "Insecure network (WEP)"
+msgstr "Usikret nettverk (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:267
+msgid "Secure network (WPA)"
+msgstr "Sikret nettverk (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:271
+msgid "Secure network (WPA2)"
+msgstr "Sikret nettverk (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Secure network (WPA3)"
+msgstr "Sikret nettverk (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network"
+msgstr "Sikret nettverk"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Tilkoblet"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
+#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Valg …"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Hvis du slår på hotspot vil du bli koblet fra %s, og det vil ikke være mulig "
+"å aksessere internett via Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Må bestå av minst 8 tegn"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Må bestå av minst %d tegn"
+msgstr[1] "Må bestå av minst %d tegn"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Slå på trådløst aksesspunkt?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-Fi hotspot tillater andre å dele din internettforbindelse ved å lage et "
+"Wi-Fi nettverk de kan koble til. For å gjøre dette må du ha en "
+"internettforbindelse gjennom noe annet enn Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nettverksnavn"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:74
+#: panels/printers/new-printer-dialog.ui:331
+#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:362
+#: panels/wwan/cc-wwan-apn-dialog.ui:172
+msgid "Password"
+msgstr "Passord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:86
+msgid "Generate Random Password"
+msgstr "Generer et tilfeldig passord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:87
+msgid "Autogenerate Password"
+msgstr "Lag passord automatisk"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:129
+msgid "_Turn On"
+msgstr "_Slå på"
+
+#: panels/network/cc-wifi-panel.c:544
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Trådløs"
+
+#: panels/network/cc-wifi-panel.c:879
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Vil du slå av trådløst aksesspunkt og koble fra brukere?"
+
+#: panels/network/cc-wifi-panel.c:882
+msgid "_Stop Hotspot"
+msgstr "_Stopp hotspot"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Airplane Mode"
+msgstr "Flymodus"
+
+#: panels/network/cc-wifi-panel.ui:73
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Slår av Wi-Fi, blåtann og mobilt bredbånd"
+
+#: panels/network/cc-wifi-panel.ui:110
+msgid "No Wi-Fi Adapter Found"
+msgstr "Fant ingen trådløse kort"
+
+#: panels/network/cc-wifi-panel.ui:120
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Sjekk at du har et Wi-Fi-kort som er satt inn og slått på"
+
+#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+msgid "Airplane Mode On"
+msgstr "Flymodus er på"
+
+#: panels/network/cc-wifi-panel.ui:162
+msgid "Turn off to use Wi-Fi"
+msgstr "Slå av for å bruke Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:199
+msgid "Wi-Fi Hotspot Active"
+msgstr "Trådløst aksesspunkt er aktivt"
+
+#: panels/network/cc-wifi-panel.ui:209
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobile enheter kan skanne QR-koden for å koble til."
+
+#: panels/network/cc-wifi-panel.ui:217
+msgid "Turn Off Hotspot…"
+msgstr "Slå av trådløst aksesspunkt …"
+
+#: panels/network/cc-wifi-panel.ui:237
+msgid "Visible Networks"
+msgstr "Synlige nettverk"
+
+#: panels/network/cc-wifi-panel.ui:294
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager må kjøre"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x sikkerhet"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Sikkerhet"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Behold"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Tilfeldig"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabil"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"MAC-adressen som oppgis her vil bli brukt som maskinvareadresse for "
+"nettverksenheten denne tilkoblingen aktiveres på. Denne funksjonen er kjent "
+"som MAC-kloning eller spoofing. Eksempel: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:101
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:107
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:112
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:119
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "Enterprise"
+msgstr "Bedrift"
+
+#: panels/network/connection-editor/ce-page-details.c:130
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/network/connection-editor/ce-page-details.c:151
+msgid "Never"
+msgstr "Aldri"
+
+#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i dag siden"
+msgstr[1] "%i dager siden"
+
+#: panels/network/connection-editor/ce-page-details.c:293
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:295
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:312
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Svak"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "God"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Utmerket"
+
+#: panels/network/connection-editor/ce-page-details.c:409
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4-adresse"
+
+#: panels/network/connection-editor/ce-page-details.c:410
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
+msgid "IPv6 Address"
+msgstr "IPv6-adresse"
+
+#: panels/network/connection-editor/ce-page-details.c:412
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adresse"
+
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:420
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
+#: panels/network/network-mobile.ui:217
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:473
+msgid "Forget Connection"
+msgstr "Glem tilkobling"
+
+#: panels/network/connection-editor/ce-page-details.c:475
+msgid "Remove Connection Profile"
+msgstr "Fjern tilkoblingsprofil"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Remove VPN"
+msgstr "Fjern VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:495
+msgid "Details"
+msgstr "Detaljer"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatisk"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitet"
+
+#: panels/network/connection-editor/ce-page-ip4.c:245
+#: panels/network/connection-editor/ce-page-ip6.c:226
+msgid "Delete Address"
+msgstr "Slett adresse"
+
+#: panels/network/connection-editor/ce-page-ip4.c:392
+#: panels/network/connection-editor/ce-page-ip6.c:361
+msgid "Delete Route"
+msgstr "Slett rute"
+
+#: panels/network/connection-editor/ce-page-ip4.c:742
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:712
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit nøkkel (heksadesimal eller ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit passordfrase"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamisk WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 personlig"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 bedrift"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 personlig"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signalstyrke"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Hastighet for tilkobling"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Maskinvareadresse"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Støttede frekvenser"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:189
+msgid "Default Route"
+msgstr "Forvalgt rute"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Sist brukt"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Koble til _automatisk"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Gjør tilgjengelig for _andre brukere"
+
+#: panels/network/connection-editor/details-page.ui:412
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Målt tilkobling: har begrensninger på data eller kan forårsake kostnader"
+
+#: panels/network/connection-editor/details-page.ui:421
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Programvareoppdateringer og andre store nedlastinger vil ikke startes "
+"automatisk."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Navn"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC-adresse"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonet adresse"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4-metode"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatisk (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Kun link-local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+msgid "Manual"
+msgstr "Manuell"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Slå av"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Delt med andre datamaskiner"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresser"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:255
+#: panels/printers/pp-details-dialog.ui:90
+msgid "Address"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:258
+msgid "Netmask"
+msgstr "Nettverksmaske"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:279
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:232
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Automatisk"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatisk DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:196
+#: panels/network/connection-editor/ip6-page.ui:205
+msgid "Separate IP addresses with commas"
+msgstr "Separer IP-adresser med komma"
+
+#: panels/network/connection-editor/ip4-page.ui:213
+#: panels/network/connection-editor/ip6-page.ui:222
+msgid "Routes"
+msgstr "Ruter"
+
+#: panels/network/connection-editor/ip4-page.ui:231
+#: panels/network/connection-editor/ip6-page.ui:240
+msgid "Automatic Routes"
+msgstr "Automatiske ruter"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:281
+#: panels/network/connection-editor/ip6-page.ui:290
+msgid "Metric"
+msgstr "Måleverdi"
+
+#: panels/network/connection-editor/ip4-page.ui:304
+#: panels/network/connection-editor/ip6-page.ui:313
+msgid "Use this connection _only for resources on its network"
+msgstr "Bruk denne tilkoblingen _kun for ressurser på dette nettverket"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6-metode"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatisk. Kun DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:267
+msgid "Prefix"
+msgstr "Prefiks"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Klarte ikke å åpne tilkoblingsbehandler"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Ny profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:715
+msgid "Import from file…"
+msgstr "Importer fil …"
+
+#: panels/network/connection-editor/net-connection-editor.c:741
+msgid "Add VPN"
+msgstr "Legg til VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Sikk_erhet"
+
+#: panels/network/connection-editor/vpn-helpers.c:191
+msgid "Cannot import VPN connection"
+msgstr "Klarte ikke å importere VPN-forbindelse"
+
+#: panels/network/connection-editor/vpn-helpers.c:193
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Filen «%s» kunne ikke leses, eller inneholder ikke gjenkjent informasjon om "
+"VPN-tilkobling\n"
+"\n"
+"Feil: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:223
+msgid "Select file to import"
+msgstr "Velg fil som skal importeres"
+
+#: panels/network/connection-editor/vpn-helpers.c:276
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "En fil med navn «%s» eksisterer allerede."
+
+#: panels/network/connection-editor/vpn-helpers.c:278
+msgid "_Replace"
+msgstr "E_rstatt"
+
+#: panels/network/connection-editor/vpn-helpers.c:280
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Vil du erstatte %s med VPN-forbindelsen du lagrer?"
+
+#: panels/network/connection-editor/vpn-helpers.c:315
+msgid "Cannot export VPN connection"
+msgstr "Klarte ikke å eksportere VPN-forbindelse"
+
+#: panels/network/connection-editor/vpn-helpers.c:317
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN-forbindelse «%s» kunne ikke eksporteres til %s.\n"
+"\n"
+"Feil: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:343
+msgid "Export VPN connection"
+msgstr "Eksporter VPN-forbindelse"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Feil: klarte ikke å laste inn VPN-tilkoblingsbehandler)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Kontroller hvordan du kobler til internett"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Nettverk;IP;LAN;Mellomtjener;WAN;Bredbånd;Modem;Blåtann;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Kontroller hvordan du kobler til trådløse nettverk"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Nettverk;Trådløst;Wi-Fi;Wifi;IP;LAN;Bredbånd;DNS;Aksesspunkt;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "aldri"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "i dag"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "i går"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Sist brukt"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Kablet"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Legg til ny tilkobling"
+
+#: panels/network/net-device-wifi.c:857
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Nettverksdetaljer for valgte nettverk - inkludert passord og innstillinger - "
+"går tapt."
+
+#: panels/network/net-device-wifi.c:861
+msgid "_Forget"
+msgstr "_Glem"
+
+#: panels/network/net-device-wifi.c:1041
+msgid "Known Wi-Fi Networks"
+msgstr "Kjente trådløse nettverk"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1073
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Glem"
+
+#: panels/network/net-device-wifi.c:1216
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Systemregler hindrer oppsett av aksesspunkt"
+
+#: panels/network/net-device-wifi.c:1219
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Trådløs enhet støtter ikke hotspotmodus"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Automatisk gjenkjenning av web-mellomtjener brukes når du ikke oppgir "
+"nettadresse til et oppsett."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Dette anbefales ikke for offentlige nettverk du ikke stoler på."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Slå enhet av"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Tilbyder"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+msgid "Network Proxy"
+msgstr "Nettverksmellomtjener"
+
+#: panels/network/network-proxy.ui:139
+msgid "_HTTP Proxy"
+msgstr "_HTTP-mellomtjener"
+
+#: panels/network/network-proxy.ui:156
+msgid "H_TTPS Proxy"
+msgstr "H_TTP-mellomtjener"
+
+#: panels/network/network-proxy.ui:173
+msgid "_FTP Proxy"
+msgstr "_FTP-mellomtjener"
+
+#: panels/network/network-proxy.ui:190
+msgid "_Socks Host"
+msgstr "_Socks-vert"
+
+#: panels/network/network-proxy.ui:207
+msgid "_Ignore Hosts"
+msgstr "_Ignorer verter"
+
+#: panels/network/network-proxy.ui:244
+msgid "HTTP proxy port"
+msgstr "Port for HTTP-mellomtjener"
+
+#: panels/network/network-proxy.ui:307
+msgid "HTTPS proxy port"
+msgstr "Port for HTTPS-mellomtjener"
+
+#: panels/network/network-proxy.ui:322
+msgid "FTP proxy port"
+msgstr "Port for FTP-mellomtjener"
+
+#: panels/network/network-proxy.ui:337
+msgid "Socks proxy port"
+msgstr "Port for Socks-mellomtjener"
+
+#: panels/network/network-proxy.ui:357
+msgid "_Configuration URL"
+msgstr "_Nettadresse til oppsett"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Slå av VPN-forbindelse"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nettverksnavn"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Type sikkerhet"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Passord"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Slå trådløs av"
+
+#: panels/network/network-wifi.ui:121
+msgid "_Connect to Hidden Network…"
+msgstr "_Koble til skjult nettverk …"
+
+#: panels/network/network-wifi.ui:128
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Slå på _trådløst aksesspunkt …"
+
+#: panels/network/network-wifi.ui:135
+msgid "_Known Wi-Fi Networks"
+msgstr "_Kjente trådløse nettverk"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Ukjent status"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Ikke administrert"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Ikke tilgjengelig"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Kobler til"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Autentisering kreves"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Kobler fra"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Tilkobling mislyktes"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Ukjent status (mangler)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Oppsett mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP-oppsett mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP-oppsett er utgått"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Hemmeligheter kreves men ble ikke oppgitt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x-hjelper frakoblet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Oppsett av 802.1x-hjelper mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x-hjelper mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x-hjelper brukte for lang tid på autentisering"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP-tjeneste klarte ikke å starte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP-tjeneste koblet fra"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP-klient startet ikke"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Feil i DHCP-klient"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP-klient mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Tjeneste for delt tilkobling startet ikke"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Tjeneste for delt tilkobling mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP-tjeneste startet ikke"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Feil i AutoIP-tjeneste"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP-tjeneste mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linjen er opptatt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Ingen summetone"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Klarte ikke å etablere bærekanal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Tidsavbrudd for oppringing"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Oppringingsforsøk mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Oppstart av modem mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Klarte ikke å velge angitt APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Søker ikke etter nettverk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Nettverksregistrering nektet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Tidsavbrudd for nettverksregistrering"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Klarte ikke å registrere med forespurt nettverk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN-sjekk mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Fastvare for enheten mangler kanskje"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Tilkobling forsvant"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Eksisterende tilkobling ble antatt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Fant ikke modem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Tilkobling med Bluetooth mislyktes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM-kort er ikke satt inn"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Pin for SIM kreves"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Puk for SIM kreves"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Feil SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Tilkoblingsavhengighet mislyktes"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Fastvare mangler"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabel koblet fra"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "udefinert feil i 802.1x sikkerhet (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "ingen fil valgt"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "uspesifisert feil ved validering av fil for eap-metode"
+
+#: panels/network/wireless-security/eap-method.c:389
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "DER, PEM eller PKCS#12 private nøkler (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:392
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER- eller PEM-sertifikater (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "mangler EAP-FAST PAC-fil"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC-filer (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonym"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autentisert"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Begge"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anony_m identitet"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC-_fil"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Velg en PAC-fil"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Indre autentisering"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Tillat automatisk PAC-pro_visjonering"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "mangler brukernavn for EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "mangler passord for EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Br_ukernavn"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:175
+msgid "_Password"
+msgstr "_Passord"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Vi_s passord"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "ugyldig EAP-PEAP CA-sertifikat: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "ugyldig EAP-PEAP CA-sertifikat: ingen sertifikat oppgitt"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versjon 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versjon 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A-sertifikat"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Velg et sertifikat fra en sertifikatutsteder"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Ingen CA-sertifikat k_reves"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP-_versjon"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "mangler brukernavn for EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "mangler passord for EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "mangler identitet for EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "ugyldig EAP-TLS CA-sertifikat: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "ugyldig EAP-TLS CA-sertifikat: ingen sertifikat oppgitt"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "ugyldig EAP-TLS privat nøkkel: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "ugyldig EAP-TLS brukersertifikat: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Ukrypterte private nøkler er usikre"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Valgt privat nøkkel ser ikke ut til å være beskyttet av et passord. Dette "
+"kan medføre at påloggingsinformasjonen kan kompromitteres. Velg en "
+"passordbeskyttet privat nøkkel.\n"
+"\n"
+"Privat nøkkel kan passordbeskyttes med openssl."
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Velg personlig sertifikat"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Velg privatnøkkel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitet"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Br_ukersertifikat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Privat nø_kkel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Passord for privat nøkkel"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "ugyldig EAP-TTLS CA-sertifikat: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "ugyldig EAP-TTLS CA-sertifikat: ingen sertifikat oppgitt"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (uten EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domene"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Ukjent feil ved validering av 802.1x sikkerhet"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunnelert TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Beskyttet EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tentisering"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Velg en fil"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "mangler leap-brukernavn"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "mangler leap-passord"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Passord for Wi-Fi mangler."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Type"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "mangler wep-nøkkel"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"ugyldig wep-nøkkel: nøkkel med lengde %zu må kun inneholde heksadesimale tall"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"ugyldig wep-nøkkel: nøkkel med en lengde på %zu må kun inneholde ASCII-tegn"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"ugyldig wep-nøkkel: feil lengde på nøkkel %zu. En nøkkel må enten være av "
+"lengde 5/13 (ascii) eller 10/26 (heksadesimal)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "ugyldig wep-nøkkel: passordfrasen kan ikke være tom"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "ugyldig wep-nøkkel: passordfrasen må være kortere enn 64 tegn"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (forvalg)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Åpent system"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Delt nøkkel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "Nø_kkel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Vis nøkkel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP-indeks"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"ugyldig wpa-psk: ugyldig key-length %zu. Må være [8,63] bytes eller 64 hex "
+"sifre"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "ugyldig wpa-psk: kan ikke tolke nøkkel med 64 bytes som hex"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Varslinger"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Lydv_arsel"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Varslinger"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Varslinger vil fortsatt vises i varslinslisten når meldingsbokser slås av."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Vis meldings_innhold i varslingsdialoger"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Vars_linger på låseskjerm"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Vis meldingsinnh_old på låseskjerm"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Ikke forstyrr"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Vars_linger på låseskjerm"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Kontroller hvilke varslinger som vises og hva de viser"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Varslinger;Banner;Melding;Trau;Oppsprett;"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:277
+#, c-format
+msgid "%s removed"
+msgstr "%s fjernet"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:406
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Annen"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "Feil ved fjerning av konto"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:51
+msgid "Undo"
+msgstr "Angre"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:55
+msgid "Connect to your data in the cloud"
+msgstr "Koble til dine data i skyen"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:66
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Ingen tilkobling til internett – koble til for å sette opp nye kontoer på "
+"nettet"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:93
+msgid "Add an account"
+msgstr "Legg til konto"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:426
+#, c-format
+msgid "%s Account"
+msgstr "%s-konto"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:429
+msgid "Remove Account"
+msgstr "Fjern konto"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Kontoer på nettet"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Koble til nettkontoer og bestem hva de skal brukes til"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Nett;Lynmeldinger;Kalender;E-post;Kontakt;"
+"ownCloud;Kerberos;IMAP;SMTP;Lomme;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Ukjent tid"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minutt"
+msgstr[1] "%i minutter"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i time"
+msgstr[1] "%i timer"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "time"
+msgstr[1] "timer"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minutt"
+msgstr[1] "minutter"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "fullt ladet om %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Advarsel: %s gjenstår"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s gjenstår"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Fullt ladet"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Lader ikke"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Tom"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Lader"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Lader ut"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Trådløs mus"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Trådløst tastatur"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Avbruddsfri strømforsyning"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Personlig digital assistent"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobiltelefon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Musikkavspiller"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tegnebrett"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Datamaskin"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Inndataenhet for spill"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batteri"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Hoved"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Ekstra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batterier"
+
+#: panels/power/cc-power-panel.c:511
+msgid "When _idle"
+msgstr "Når led_ig"
+
+#: panels/power/cc-power-panel.c:671
+msgid "Suspend"
+msgstr "Hvilemodus"
+
+#: panels/power/cc-power-panel.c:672
+msgid "Power Off"
+msgstr "Slå av"
+
+#: panels/power/cc-power-panel.c:673
+msgid "Hibernate"
+msgstr "Dvalemodus"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Nothing"
+msgstr "Ingenting"
+
+#: panels/power/cc-power-panel.c:730
+msgid "When on battery power"
+msgstr "På batteristrøm"
+
+#: panels/power/cc-power-panel.c:732
+msgid "When plugged in"
+msgstr "Når den er koblet til strøm"
+
+#: panels/power/cc-power-panel.c:853
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Aldri"
+
+#: panels/power/cc-power-panel.c:937
+msgid "Automatic suspend"
+msgstr "Automatisk hvilemodus"
+
+#: panels/power/cc-power-panel.c:1030
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1032
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1034
+msgid "Performance mode temporarily disabled."
+msgstr "Ytelsesmodus er midlertidig slått av."
+
+#: panels/power/cc-power-panel.c:1076
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1084
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Strømsparingsmodus aktivert av «%s»."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1088
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Ytelsesmodus aktivert av «%s»."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 time"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 timer"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Strømmodus"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Påvirker systemets ytelse og strømbruk."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Alternativer for strømsparing"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatisk lysstyrke"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Lysstyrke på skjermen justeres i forhold til omgivelsene."
+
+#: panels/power/cc-power-panel.ui:138
+msgid "Dim Screen"
+msgstr "Demp skjerm"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:150
+msgid "Screen _Blank"
+msgstr "_Blank skjerm"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:159
+msgid "Automatic Power Saver"
+msgstr "Automatisk strømsparing"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:173
+msgid "_Automatic Suspend"
+msgstr "_Automatisk hvilemodus"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:199
+msgid "Po_wer Button Behavior"
+msgstr "Handling for str_ømknapp"
+
+#: panels/power/cc-power-panel.ui:207
+msgid "Show Battery _Percentage"
+msgstr "Vis batteri_prosent"
+
+#: panels/power/cc-power-panel.ui:243
+msgid "Automatic Suspend"
+msgstr "Automatisk hvilemodus"
+
+#: panels/power/cc-power-panel.ui:266
+msgid "_Plugged In"
+msgstr "Når den er _koblet til strøm"
+
+#: panels/power/cc-power-panel.ui:278
+msgid "On _Battery Power"
+msgstr "På _batteristrøm"
+
+#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
+#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+msgid "Delay"
+msgstr "Pause"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Høy ytelse"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Høy ytelse og strømbruk."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Balansert"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standard ytelse og strømbruk."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Strømsparing"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Redusert ytelse og strømbruk."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Strøm"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Vis batteristatus og endre innstillinger for strømsparing"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Strøm;Sove;Hvile;Dvale;Batteri;Lysstyrke;Demp;Slå av;Skjerm;DPMS;Inaktiv;"
+"Energi;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:676
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Skriver «%s» er slettet"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:928
+msgid "Failed to add new printer."
+msgstr "Klarte ikke å legge til ny skriver."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1229
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Klarte ikke å laste brukergrensesnitt: %s"
+
+#: panels/printers/cc-printers-panel.c:1297
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Lås opp for å legge til skrivere og endre innstillinger"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Skrivere"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Legg til skrivere, vis utskriftsjobber og bestem hvordan du ønsker å skrive "
+"ut"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Skriver;Kø;Utskrift;Papir;Blekk;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Legg til skriver"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:100
+#: panels/printers/new-printer-dialog.ui:115
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "Lås _opp"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:194
+msgid "No Printers Found"
+msgstr "Fant ingen skrivere"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:244
+msgid "Enter a network address or search for a printer"
+msgstr "Skriv inn en nettverksadresse, eller søk etter en skriver"
+
+#: panels/printers/new-printer-dialog.ui:286
+msgid "Authentication Required"
+msgstr "Autentisering kreves"
+
+#: panels/printers/new-printer-dialog.ui:302
+msgid "Enter username and password to view printers on Print Server."
+msgstr "Oppgi brukernavn og passord for å se skrivere på utskriftstjener."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:311
+#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:148
+msgid "Username"
+msgstr "Brukernavn"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:365
+#, c-format
+msgid "%s Details"
+msgstr "Detaljer for %s"
+
+#: panels/printers/pp-details-dialog.c:101
+msgid "No suitable driver found"
+msgstr "Fant ingen passende driver"
+
+#: panels/printers/pp-details-dialog.c:260
+msgid "Select PPD File"
+msgstr "Velg PPD-fil"
+
+#: panels/printers/pp-details-dialog.c:269
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript Printer Description-filer (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+msgid "Location"
+msgstr "Plassering"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:115
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:154
+msgid "Searching for preferred drivers…"
+msgstr "Søker etter foretrukne drivere …"
+
+#: panels/printers/pp-details-dialog.ui:173
+msgid "Search for Drivers"
+msgstr "Søker etter drivere"
+
+#: panels/printers/pp-details-dialog.ui:181
+msgid "Select from Database…"
+msgstr "Velg fra database …"
+
+#: panels/printers/pp-details-dialog.ui:189
+msgid "Install PPD File…"
+msgstr "Installer PPD-fil …"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Velger skriverdriver"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Laster driverdatabase …"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Velg"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect-skriver"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD-skriver"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Ensidig"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Lang kant (standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Kort kant (vend)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portrett"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Landskap"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Omvendt landskap"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Omvendt portrett"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:134
+msgctxt "print job"
+msgid "Pending"
+msgstr "Utestående"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:140
+msgctxt "print job"
+msgid "Paused"
+msgstr "På pause"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:145
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autentisering kreves"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "Prosesserer"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Stoppet"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Avbrutt"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Avbrutt med feil"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "Fullført"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:176
+msgid "Move this job to the top of the queue"
+msgstr ""
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u jobb krever autentisering"
+msgstr[1] "%u jobber krever autentisering"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s – Aktive jobber"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Oppgi brukernavn og passord for å skrive ut fra %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domene"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:100
+msgid "A_uthenticate"
+msgstr "A_utentiser"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:128
+msgid "Clear All"
+msgstr "Tøm alle"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:173
+msgid "_Authenticate"
+msgstr "_Autentiser"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:214
+msgid "No Active Printer Jobs"
+msgstr "Ingen aktive utskriftsjobber"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Lås opp utskriftstjener"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Lås opp %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Oppgi brukernavn og passord for å vise skrivere på %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Søker etter skrivere"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Seriellport"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Parallellport"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Plassering: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adresse: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Tjener krever autentisering"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Tosidig"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Papirtype"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Papirkilde"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Skuff"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Oppløsning"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Forhåndsfiltrering med GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Sider per side"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Tosidig"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientering"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Generelt"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Sideoppsett"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Installerbare alternativer"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Jobb"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Bildekvalitet"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Farge"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Fullføring"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avansert"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Testside"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Testside"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Automatisk valg"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Forvalg for skriver"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Kun innebyggede GhostScript skrifter"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Konverter til PS nivå 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Konverter til PS nivå 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Ingen forhåndsfiltrering"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Produsent"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ingen aktive jobber"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u jobb"
+msgstr[1] "%u jobber"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Rens utskriftshodene"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Lite toner"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Tom for toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Lite fremkaller"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Tom for fremkaller"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Lite farge"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Tom for farge"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Åpent deksel"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Åpen dør"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Lite papir"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Tom for papir"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Frakoblet"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Stoppet"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Søppelbeholderen er nesten full"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Søppelbeholderen er full"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Optisk fotoleder er nær slutten på sin levetid"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Optisk fotoleder fungerer ikke lenger"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Klar"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Godtar ikke jobber"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Prosesserer"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Alternativer for utskrift"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Detaljer for skriver"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Bruk skriver som forvalgt"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Rens utskriftshodene"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Fjern skriver"
+
+#: panels/printers/printer-entry.ui:187
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modell"
+
+#: panels/printers/printer-entry.ui:242
+msgid "Ink Level"
+msgstr "Blekknivå"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:304
+msgid "Please restart when the problem is resolved."
+msgstr "Vennligst start på nytt når problemet er løst."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:310
+msgid "Restart"
+msgstr "Start på nytt"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10
+msgid "Add Printer…"
+msgstr "Legg til en skriver …"
+
+#: panels/printers/printers.ui:168
+msgid "No printers"
+msgstr "Ingen skrivere"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:179
+msgid "Add a Printer…"
+msgstr "Legg til en skriver …"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:204
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Beklager! Systemets utskriftstjeneste\n"
+"ser ikke ut til å være tilgjengelig."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formater"
+
+#: panels/region/cc-format-chooser.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Tilbake"
+
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Søk etter stedsbaserte formater …"
+
+#: panels/region/cc-format-chooser.ui:113
+msgid "Common Formats"
+msgstr "Vanlige formater"
+
+#: panels/region/cc-format-chooser.ui:140
+msgid "All Formats"
+msgstr "Alle formater"
+
+#: panels/region/cc-format-chooser.ui:188
+msgid "No Search Results"
+msgstr "Ingen søkeresultater"
+
+#: panels/region/cc-format-chooser.ui:200
+msgid "Searches can be for countries or languages."
+msgstr "Du kan søke etter land eller språk."
+
+#: panels/region/cc-format-chooser.ui:236
+msgid "Preview"
+msgstr "Forhåndvisning"
+
+#: panels/region/cc-format-preview.c:135
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperisk"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrisk"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datoer"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dato og klokkeslett"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Tall"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Måleenheter"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papir"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+#, fuzzy
+#| msgid "The format used for numbers, dates, and currencies."
+msgid ""
+"The language setting is used for interface text and web pages. Formats is "
+"used for numbers, dates, and currencies."
+msgstr "Format for tall, datoer og valutaer."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Din konto"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:299
+msgid "_Language"
+msgstr "_Språk"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formater"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Påloggingsskjerm"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Region og språk"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+#| msgid ""
+#| "Select your display language, formats, keyboard layouts and input sources"
+msgid "Select your display language and formats"
+msgstr "Velg språk for visning, formater, tastaturutforminger og inndatakilder"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Språk;Utforming;Tastatur;Inndata;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Spør hva som skal gjøres"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Ikke gjør noe"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Åpne mappe"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Annet medie"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Velg et program for lyd-CDer"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Velg et program for video-DVDer"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Velg et program som skal kjøres når en musikkavspiller kobles til"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Velg et program som skal kjøres når et kamera kobles til"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Velg et program for programvare-CDer"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "Lyd-DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Tom Blu-ray-plate"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "Tom CD-plate"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "Tom DVD-plate"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "tom HD-DVD plate"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray videoplate"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "E-bokleser"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD-DVD-videoplate"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Bilde-CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video-CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows programvare"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Velg hvordan medier skal håndteres"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD-_lyd"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD-video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Musikkavspiller"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Programvare"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "Annet medie …"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Aldri spør eller start programmer når et medie settes inn"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Velg hvordan andre medier skal håndteres"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "H_andling:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Type:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Avtagbare medier"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Konfigurer innstillinger for avtagbare medier"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"enhet;system;forvalg;program;foretrukket;cd;dvd;usb;lyd;video;plate;avtagbar;"
+"medie;automatisk kjøring;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Velg lokasjon"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Søkelokasjoner"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Mapper som brukes av systemprogrammer, slik som filer, bilder og videoer."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Steder"
+
+#: panels/search/cc-search-locations-dialog.ui:33
+msgid "Bookmarks"
+msgstr "Bokmerker"
+
+#: panels/search/cc-search-locations-dialog.ui:48
+msgid "Others"
+msgstr "Andre"
+
+#: panels/search/cc-search-locations-dialog.ui:55
+msgid "Add Location"
+msgstr "Legg til plassering"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Fant ingen programmer"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Programsøk"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+#, fuzzy
+#| msgid ""
+#| "Folders which are searched by system applications, such as Files, Photos "
+#| "and Videos."
+msgid "Folders which are searched by system applications."
+msgstr ""
+"Mapper som brukes av systemprogrammer, slik som filer, bilder og videoer."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Søkeresultater"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Kontroller hvilke programmer som viser resultater i aktivitetsoversikten"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Søk;finn;Indeks;Skjul;Personvern;Resultater;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:265
+msgid "No networks selected for sharing"
+msgstr "Ingen nettverk valgt for deling"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Nettverk"
+
+#: panels/sharing/cc-sharing-panel.c:367
+msgctxt "service is enabled"
+msgid "On"
+msgstr "På"
+
+#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Av"
+
+#: panels/sharing/cc-sharing-panel.c:399
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Slått på"
+
+#: panels/sharing/cc-sharing-panel.c:402
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktiv"
+
+#: panels/sharing/cc-sharing-panel.c:520
+msgid "Choose a Folder"
+msgstr "Velg en mappe"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:748
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Fildeling lar deg dele offentlig mappe med andre på samme nettverk ved å "
+"bruke: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:754
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Når ekstern pålogging er aktivert kan eksterne brukere koble seg til med "
+"Secure Shell-kommandoen:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Deling"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Navn på _datamaskin"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Fildeling"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Deling av _media"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Ekste_rn pålogging"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Fildeling"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "K_rev passord"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Ekstern pålogging"
+
+#: panels/sharing/cc-sharing-panel.ui:250
+#: panels/sharing/cc-sharing-panel.ui:267
+msgid "Remote Desktop"
+msgstr "Eksternt skrivebord"
+
+#: panels/sharing/cc-sharing-panel.ui:263
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:268
+#, fuzzy
+#| msgid "Enable or disable remote login"
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Slå på eller av ekstern pålogging"
+
+#: panels/sharing/cc-sharing-panel.ui:280
+msgid "Remote Control"
+msgstr "Ekstern kontroll"
+
+#: panels/sharing/cc-sharing-panel.ui:281
+#, fuzzy
+#| msgid "_Allow connections to control the screen"
+msgid "Allows remote connections to control the screen."
+msgstr "Till_at tilkoblinger å kontrollere skjermen"
+
+#: panels/sharing/cc-sharing-panel.ui:294
+#, fuzzy
+#| msgid "Forget Connection"
+msgid "How to Connect"
+msgstr "Glem tilkobling"
+
+#: panels/sharing/cc-sharing-panel.ui:295
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:323
+#, fuzzy
+#| msgid "Delete Address"
+msgid "Remote Desktop Address"
+msgstr "Slett adresse"
+
+#: panels/sharing/cc-sharing-panel.ui:350
+msgid "Authentication"
+msgstr "Autentisering"
+
+#: panels/sharing/cc-sharing-panel.ui:351
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:355
+msgid "User Name"
+msgstr "Brukernavn"
+
+#: panels/sharing/cc-sharing-panel.ui:401
+msgid "Verify Encryption"
+msgstr "Verifiser kryptering"
+
+#: panels/sharing/cc-sharing-panel.ui:430
+msgid "Encryption Fingerprint"
+msgstr "Fingeravtrykk for kryptering"
+
+#: panels/sharing/cc-sharing-panel.ui:431
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:463
+msgid "Media Sharing"
+msgstr "Deling av media"
+
+#: panels/sharing/cc-sharing-panel.ui:485
+msgid "Share music, photos and videos over the network."
+msgstr "Del musikk, bilder og videoer over nettverket."
+
+#: panels/sharing/cc-sharing-panel.ui:498
+msgid "Folders"
+msgstr "Mapper"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Kontroller hva du vil dele med andre"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"del;deling;ssh;vert;navn;ekstern;skrivebord;media;lyd;video;bilder;foto;"
+"filmer;tjener;visning;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Slå på eller av ekstern pålogging"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Du må autentisere deg for å slå av eller på ekstern pålogging"
+
+#: panels/sound/cc-alert-chooser.c:150
+msgid "Custom"
+msgstr "Egendefinert"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr "Bjeff"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "Drip"
+msgstr "Drypp"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Glass"
+msgstr "Glass"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Sonar"
+msgstr "Sonar"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "Bak"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "Foran"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Tester %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Klikk på en høyttaler for å teste"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Systemvolum"
+
+#: panels/sound/cc-sound-panel.ui:25
+msgid "Volume Levels"
+msgstr "Volumnivåer"
+
+#: panels/sound/cc-sound-panel.ui:35
+msgid "Output"
+msgstr "Utgang"
+
+#: panels/sound/cc-sound-panel.ui:56
+msgid "Output Device"
+msgstr "Utgangsenhet"
+
+#: panels/sound/cc-sound-panel.ui:75
+msgid "Test"
+msgstr "Test"
+
+#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+msgid "Configuration"
+msgstr "Konfigurasjon"
+
+#: panels/sound/cc-sound-panel.ui:135
+msgid "Balance"
+msgstr "Balanse"
+
+#: panels/sound/cc-sound-panel.ui:161
+msgid "Fade"
+msgstr "Fade"
+
+#: panels/sound/cc-sound-panel.ui:187
+msgid "Subwoofer"
+msgstr "Basselement"
+
+#: panels/sound/cc-sound-panel.ui:205
+msgid "Input"
+msgstr "Inngang"
+
+#: panels/sound/cc-sound-panel.ui:226
+msgid "Input Device"
+msgstr "Inngangsenhet"
+
+#: panels/sound/cc-sound-panel.ui:294
+msgid "Volume"
+msgstr "Volum"
+
+#: panels/sound/cc-sound-panel.ui:312
+msgid "Alert Sound"
+msgstr "Varsellyd"
+
+#: panels/sound/cc-volume-slider.c:117
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Lyd"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Endre lydvolum, innganger, utganger og lyder for hendelser"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kort;Mikrofon;Volum;Fade;Balanse;Bluetooth;Hodetelefon;Lyd;Utgang;Inngang;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Koblet fra"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Kobler til"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Tilkoblet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Feil ved autorisering"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autoriserer"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Redusert funksjonalitet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Tilkoblet og autorisert"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Ukjent"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autorisert hos:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Tilkoblet på:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Meldt inn hos:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Klarte ikke å autorisere enhet: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Klarte ikke å glemme enhet: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Avhenger av %u annen enhet"
+msgstr[1] "Avhenger av %u andre enheter"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+msgid "Name:"
+msgstr "Navn:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+msgid "Status:"
+msgstr "Status:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+msgid "Authorize and Connect"
+msgstr "Autoriser og koble til"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+msgid "Forget Device"
+msgstr "Glem enhet"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Feil"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorisert"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Thunderbolt støtte (boltd) er ikke installert eller ikke satt opp korrekt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:157
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Tillat direkte tilgang til enheter som dokkingstasjoner og eksterne GPUer."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Kun USB og Display Port enheter kan koble til."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt ble ikke funnet.\n"
+"Enten mangler systemet støtte for Thunderbolt eller så er det deaktivert "
+"eller satt til et sikkerhetsnivå i BIOS som ikke er støttet."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Støtte for Thunderbolt er slått av i BIOS"
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Kunne ikke avgjøre sikkerhetsnivå for Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Feil ved bytting av direkte modus: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "No Thunderbolt Support"
+msgstr "Ingen støtte for Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:104
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Kunne ikke koble til thunderbolt-undersystem."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:153
+msgid "Direct Access"
+msgstr "Direkte tilgang"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:225
+msgid "Pending Devices"
+msgstr "Utestående enheter"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:319
+msgid "No devices attached"
+msgstr "Ingen enheter koblet til"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Håndter Thunderbolt-enheter"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;Personvern;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Markørblinking"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+msgid "Cursor blinks in text fields."
+msgstr "Markøren blinker i tekstfelt."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
+#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+msgid "Speed"
+msgstr "Hastighet"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+msgid "Cursor blinking speed"
+msgstr "Hastighet for markørblinking"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Markørstørrelse"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Markørstørrelsen kan kombineres med zoom for å gjøre det lettere å se "
+"markøren."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Klikkassistent"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulert andreklikk"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Utløs sekundærklikk ved å holde nede primærknappen"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Pause før godkjenning:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Pause for sekundært klikk"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Henge-klikk"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Initier klikk når pekeren henger over et punkt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Paus_e:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Terskel for bevegelse:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Liten"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Stor"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repeter taster"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+msgid "Key presses repeat when key is held down."
+msgstr "Tastetrykk repeteres når tasten holdes nede."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+msgid "Repeat keys delay"
+msgstr "Pause for tasterepetering"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+msgid "Repeat keys speed"
+msgstr "Hastighet for tasterepetering"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Skriveassistent"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Klebrige ta_ster"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Behandler en sekvens med endringstaster som en tastekombinasjon"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Slå av hvis to taster trykkes ned samtidig"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pip når en e_ndringstast blir trykket ned"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "T_rege taster"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Setter inn en pause fra en tast trykkes ned til den godtas"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Pause for tasting med trege taster"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Pip når en tast trykkes n_ed"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Pip når en tast godt_as"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Pip nå_r en tast avvises"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "S_prettetaster"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorer raskt dupliserte tastaturtrykk"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Pause for tasting med sprettetaster"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:326
+msgid "_Enable by Keyboard"
+msgstr "Slå _på via tastatur"
+
+#: panels/universal-access/cc-typing-dialog.ui:336
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Slå på funksjoner for tilgjengelighet fra tastaturet"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:357
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Forvalgt"
+
+#: panels/universal-access/cc-ua-panel.c:360
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Middels"
+
+#: panels/universal-access/cc-ua-panel.c:363
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Stor"
+
+#: panels/universal-access/cc-ua-panel.c:366
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Større"
+
+#: panels/universal-access/cc-ua-panel.c:369
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Størst"
+
+#: panels/universal-access/cc-ua-panel.c:373
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d piksel"
+msgstr[1] "%d piksler"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Alltid vis meny for universell tilgang"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Syn"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Høy kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Stor tekst"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Skjermlese_r"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Skjermleser leser tekst som vises mens du flytter fokus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Lydtaster"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pip når Num Lock eller Caps Lock slås på eller av."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Mark_ørstørrelse"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Hørsel"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Synlige varsel"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Tastatur på s_kjermen"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "R_epeter taster"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Markør_blinking"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Skriveassistent (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Pek og klikk"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Mustaster"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Finn peker"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Klikkassistent"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Pause for _dobbeltklikk"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Pause for dobbeltklikk"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Synlige varsel"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Test blinking"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Bruk en visuell indikasjon når en varsellyd spilles av."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "La hele _skjermen blinke"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "La hele _vinduet blinke"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ skjerm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ skjerm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ skjerm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Full skjerm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Øverste halvdel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Nederste halvdel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Venstre halvdel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Høyre halvdel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Alternativer for zoom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "For_størrelse:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posisjon for forstørrelse:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Følg muspeker"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Del av _skjermen:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "_Forstørrelsesglass fortsetter utenfor skjermen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Hold forstørrelsesglasspeker sentrert"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Forstørrelsesglasspeker _dytter innholdet rundt"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Forstørrelsesglasspeker flytter seg med _innholdet"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Forstørrelsesglass"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Siktekryss:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Overlapper med muspeker"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Tykkelse:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tynn"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Tykk"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Lengde:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "F_arge:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Siktekryss"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Fargeeffekter:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Hvit på sort:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Lysstyrke:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "F_arge"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Full"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Lav"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Høy"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Lav"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Høy"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Fargeeffekter"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Gjør det lettere å se, høre, skrive og peke og klikke"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+#| "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+#| "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+#| "audio;typing;"
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Tastatur;Mus;a11y;Tilgjengelighet;Kontrast for universell tilgang;Markør;Lyd;"
+"Zoom;Skjerm;Leser;stor;høy;tekst;skrift;størrelse;AccessX;Klebrige;Taster;"
+"Trege;Sprett;Mus;Dobbeltklikk;Pause;Hastighet;Assister;Gjenta;Blink;visuell;"
+"hørsel;lyd;skriving;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 time"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dag"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dager"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dager"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dager"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dager"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dager"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dager"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dager"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dager"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Tøm alle oppføringer fra papirkurven?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Alle elementer i papirkurven slettes permanent."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Tøm papirkurv"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Slett alle midlertidige filer?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Alle midlertidige filer slettes permanent."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Fjern midlertidige filer"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dag"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dager"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dager"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "For alltid"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Filhistorikk"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Filhistorikk holder oversikt over filer du har brukt. Denne informasjonen "
+"deles mellom programmer og gjør det lettere å finne filer du kanskje vil "
+"bruke."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Filh_istorikk"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Periode for fil_historikk"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Tøm historikk …"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Papirkurv og midlertidige filer"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Papirkurv og midlertidige filer kan noen ganger inneholde personlig eller "
+"sensitiv informasjon. Automatisk sletting kan hjelpe personvernet ditt."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Tøm _papirkurven automatisk"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Tøm _midlertidige filer automatisk"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Periode for automatisk sletting"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Tøm papirkurv …"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Slett midlertidige filer …"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Filhistorikk og papirkurv"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Ikke etterlat spor"
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Skal være lik kontotilbyders nettstedsadresse."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Klarte ikke å legge til en konto"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.c:258
+msgid "The passwords do not match."
+msgstr "Passordene er ikke like."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Klarte ikke å registrere konto"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Ingen støttet måte å autentisere med dette domenet"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Klarte ikke å bli med i domenet"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Brukernavnet virket ikke.\n"
+"Vennligst prøv igjen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Passordet for påloggingen virket ikke.\n"
+"Vennligst prøv igjen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Klarte ikke å logge inn i domenet"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Fant ikke domenet. Kanskje du stavet det feil?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Legg til bruker"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+#, fuzzy
+#| msgid ""
+#| "Administrators can add and remove other users, and can change settings "
+#| "for all users."
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administratorer kan legge til og fjerne andre brukere, og kan endre "
+"innstillinger for alle brukere."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Bruker setter passordet ved første pålogging"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Sett passordet nå"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Bekreft"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Bedriftspålogging"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organisation."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:385
+msgid "You are Offline"
+msgstr "Du er frakoblet"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:386
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Bedriftspålogging lar deg bruke en eksisterende og sentralt håndtert "
+"brukerkoknto  på denne enheten. Du kan også bruke denne kontoen til å "
+"aksessere bedriftsressurser på internett."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Se etter flere bilder"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Velg en fil …"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Administrasjon av fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+msgid "_No"
+msgstr "_Nei"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+msgid "_Yes"
+msgstr "_Ja"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Vil du slette dine registrerte fingeravtrykk slik at innlogging med "
+"fingeravtrykk slås av?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+msgid "No fingerprint device"
+msgstr "Ingen fingeravtrykkleser"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+msgid "No Fingerprint device"
+msgstr "Ingen fingeravtrykkleser"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+msgid "Ensure the device is properly connected."
+msgstr "Sjekk av enheten er koblet til riktig."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+msgid "Fingerprint Device"
+msgstr "Fingeravtrykksleser"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Velg fingeravtrykksleseren du vil konfigurere"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+msgid "Fingerprint Login"
+msgstr "Innlogging med fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Fingeravtrykkspålogging lar deg låse opp og logge inn på datamaskinen med "
+"fingeren."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+msgid "_Delete Fingerprints"
+msgstr "_Slett fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+msgid "Fingerprint Enroll"
+msgstr "Innlesing av fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "enheten må gjøres krav på for å utføre denne handlingen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "enheten er allerede gjort krav på av en annen prosess"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "du har ikke rettigheter til å utføre handlingen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "ingen fingeravtrykk er registrert"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Klarte ikke å kommunisere med enheten under registrering"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Klarte ikke å kommunisere med fingeravtrykkleseren"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Klarte ikke å kommunisere med fingeravtrykktjenesten"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Klarte ikke å vise fingeravtrykk: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Klarte ikke å slette lagrede fingeravtrykk: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Venstre tommel"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Venstre langefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Venstre pekefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Venstre ringfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Venstre lillefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Høyre tommel"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Høyre langfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Høy_re pekefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Høyre ringfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Høyre lillefinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Ukjent finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Fullført"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Fingeravtrykkleser koblet fra"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Lagring for fingeravtrykkleser er full"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Klarte ikke å lese inn nytt fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Klarte ikke å starte innlesing: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Klarte ikke å lese inn nytt fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Klarte ikke å stoppe innlesing: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Legg fingeren din på leseren gjentatte ganger for å lagre fingeravtrykket "
+"ditt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Les inn denne finge_ren på nytt …"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Les inn nytt fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Klarte ikke å frigjøre finngeravtrykkleser %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problem med å lese fra enhet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Klarte ikke å gjøre krav på fingeravtrykkleser %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Klarte ikke å hente fingeravtrykklesere: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Denne uken"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Forrige uke"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s – %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:712
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k.%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:716
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Økten ble avsluttet"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Økten startet"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s – kontoaktivitet"
+
+#: panels/user-accounts/cc-password-dialog.c:133
+msgid "Please choose another password."
+msgstr "Velg et annet passord."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Please type your current password again."
+msgstr "Skriv inn gjeldende passord en gang til."
+
+#: panels/user-accounts/cc-password-dialog.c:148
+msgid "Password could not be changed"
+msgstr "Passordet kunne ikke endres"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Endre passord"
+
+#: panels/user-accounts/cc-password-dialog.ui:32
+msgid "Ch_ange"
+msgstr "_Endre"
+
+#: panels/user-accounts/cc-password-dialog.ui:51
+msgid "Current Password"
+msgstr "Gjeldende passord"
+
+#: panels/user-accounts/cc-password-dialog.ui:76
+msgid "New Password"
+msgstr "Nytt passord"
+
+#: panels/user-accounts/cc-password-dialog.ui:121
+msgid "Confirm Password"
+msgstr "Bekreft passord"
+
+#: panels/user-accounts/cc-password-dialog.ui:175
+msgid "Allow user to change their password on next login"
+msgstr "La bruker endre sitt passord ved neste pålogging"
+
+#: panels/user-accounts/cc-password-dialog.ui:186
+msgid "Set a password now"
+msgstr "Velg passord nå"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Du kan ikke bli medlem av denne type domene automatisk"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Fant ikke dette domenet eller området"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Klarte ikke å logge inn som %s på domenet %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Ugyldig passord. Prøv igjen"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Kunne ikke koble til domenet %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:341
+msgid "Failed to delete user"
+msgstr "Klarte ikke å slette bruker"
+
+#: panels/user-accounts/cc-user-panel.c:398
+#: panels/user-accounts/cc-user-panel.c:453
+#: panels/user-accounts/cc-user-panel.c:499
+msgid "Failed to revoke remotely managed user"
+msgstr "Klarte ikke å trekke tilbake eksternt håndtert bruker"
+
+#: panels/user-accounts/cc-user-panel.c:548
+msgid "You cannot delete your own account."
+msgstr "Du kan ikke slette din egen konto."
+
+#: panels/user-accounts/cc-user-panel.c:557
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s er fremdeles logget inn"
+
+#: panels/user-accounts/cc-user-panel.c:561
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Hvis du sletter en innlogget bruker kan systemet ende opp i en inkonsistent "
+"tilstand."
+
+#: panels/user-accounts/cc-user-panel.c:570
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Vil du beholde filene til %s?"
+
+#: panels/user-accounts/cc-user-panel.c:574
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Det er mulig å beholde hjemmemappe, e-postkø og midlertidige filer når du "
+"sletter en brukerkonto."
+
+#: panels/user-accounts/cc-user-panel.c:577
+msgid "_Delete Files"
+msgstr "_Slett filer"
+
+#: panels/user-accounts/cc-user-panel.c:578
+msgid "_Keep Files"
+msgstr "_Behold filer"
+
+#: panels/user-accounts/cc-user-panel.c:592
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Er du sikker på at du vil trekke tilbake eksternt håndtert konto for %s?"
+
+#: panels/user-accounts/cc-user-panel.c:596
+msgid "_Delete"
+msgstr "_Slett"
+
+#: panels/user-accounts/cc-user-panel.c:646
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Kontoen er sperret"
+
+#: panels/user-accounts/cc-user-panel.c:654
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Velges ved neste innlogging"
+
+#: panels/user-accounts/cc-user-panel.c:657
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/user-accounts/cc-user-panel.c:700
+msgid "Logged in"
+msgstr "Logget inn"
+
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:787
+#: panels/user-accounts/cc-user-panel.c:876
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Slått på"
+
+#: panels/user-accounts/cc-user-panel.c:1173
+msgid "Failed to contact the accounts service"
+msgstr "Klarte ikke å kontakte kontotjenesten"
+
+#: panels/user-accounts/cc-user-panel.c:1175
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Sjekk at kontotjenesten er installert og aktivert."
+
+#: panels/user-accounts/cc-user-panel.c:1197
+msgid "This panel must be unlocked to change this setting"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.c:1264
+msgid "Delete the selected user account"
+msgstr "Slett valgt brukerkonto"
+
+#: panels/user-accounts/cc-user-panel.c:1268
+#: panels/user-accounts/cc-user-panel.c:1377
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Klikk på *-ikonet\n"
+"for å slette valgt brukerkonto"
+
+#: panels/user-accounts/cc-user-panel.c:1423
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Lås opp for å legge til brukere og endre innstillinger"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Brukere"
+
+#: panels/user-accounts/cc-user-panel.ui:60
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Økten må startes på nytt for at endringene skal tre i kraft"
+
+#: panels/user-accounts/cc-user-panel.ui:67
+msgid "Restart Now"
+msgstr "Start på nytt nå"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:195
+msgid "_Fingerprint Login"
+msgstr "Innlogging med _fingeravtrykk"
+
+#: panels/user-accounts/cc-user-panel.ui:218
+msgid "A_utomatic Login"
+msgstr "A_utomatisk pålogging"
+
+#: panels/user-accounts/cc-user-panel.ui:231
+msgid "Account Activity"
+msgstr "Kontoaktivitet"
+
+#: panels/user-accounts/cc-user-panel.ui:259
+msgid "_Administrator"
+msgstr "_Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:260
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administratorer kan legge til og fjerne andre brukere, og kan endre "
+"innstillinger for alle brukere."
+
+#: panels/user-accounts/cc-user-panel.ui:276
+msgid "_Parental Controls"
+msgstr "_Foreldrekontroll"
+
+#: panels/user-accounts/cc-user-panel.ui:277
+msgid "Open the Parental Controls application."
+msgstr "Åpne programmet for foreldrekontroll"
+
+#: panels/user-accounts/cc-user-panel.ui:328
+msgid "Remove User…"
+msgstr "Fjern bruker …"
+
+#: panels/user-accounts/cc-user-panel.ui:340
+msgid "Other Users"
+msgstr "Andre brukere"
+
+#: panels/user-accounts/cc-user-panel.ui:353
+msgid "Add User…"
+msgstr "Legg til bruker …"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:381
+msgid "No Users Found"
+msgstr "Fant ingen brukere"
+
+#: panels/user-accounts/cc-user-panel.ui:390
+msgid "Unlock to add a user account."
+msgstr "Lås opp for å legge til en brukerkonto."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Legg til eller fjern brukere og bytt passord"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Meld inn"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Brukernavn for domeneadministrator"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"For å bruke pålogging for bedrifter må datamaskinen være medlem\n"
+"i domenet. Be domeneadministrator om å skrive inn\n"
+"domenepassord her."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Navn på administrator"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Passord for administrator"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Håndter brukerkontoer"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Du må autentisere deg for å endre brukerdata"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Det nye passordet må være ulikt det gamle."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Prøv å endre noen bokstaver og tall."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Prøv å endre passord enda litt mer."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Passordet blir sterkere hvis det ikke inneholder brukernavnet ditt."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Prøv å unngå å bruke navnet ditt i passordet."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Prøv å unngå noen av ordene som brukes i passordet."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Prøv å unngå vanlige ord."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Prøv å unngå å endre rekkefølge på eksisterende ord."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Prøv å bruke flere tall."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Prøv å bruke flere store bokstaver."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Prøv å bruke flere små bokstaver."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Prøv å bruke flere spesialtegn, som tegnsetting."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Prøv å bruke en blanding av bokstaver, tall og tegnsetting."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Prøv å unngå å gjenta samme tegn."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Prøv å unngå å gjenta samme type tegn. Du må blande bokstaver, tall og "
+"tegnsettingstegn."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Prøv å unngå sekvenser som 1234 eller abcs."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Passordet må være lenger. Prøv å bruke en blanding av bokstaver, tall og "
+"tegnsetting."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Bland store og små bokstaver, og prøv å bruke et tall eller to."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Passordet blir sterkere hvis du legger til flere bokstaver, tall og "
+"spesialtegn."
+
+#: panels/user-accounts/run-passwd.c:413
+msgid "Authentication failed"
+msgstr "Autentisering mislyktes"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The new password is too short"
+msgstr "Det nye passordet er for kort"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password is too simple"
+msgstr "Det nye passordet er for enkelt"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Gammelt og nytt passord er for like"
+
+#: panels/user-accounts/run-passwd.c:507
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Det nye passordet har allerede blitt brukt nylig."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Det nye passordet må inneholde tall eller spesielle tegn"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Gammelt og nytt passord er det samme"
+
+#: panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Passordet ditt er endret siden første autentisering!"
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Det nye passordet inneholder ikke nok spesielle tegn"
+
+#: panels/user-accounts/run-passwd.c:526
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Ukjent feil"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Brukernavnet inneholder vanligvis små bokstaver fra a-z, tall, samt tegnene "
+"«.», «-» og «_»."
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Beklager, det brukernavnet er ikke tilgjengelig. Prøv et annet."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Brukernavnet er for langt."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+msgid "Map Buttons"
+msgstr "Tilegne knapper"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Koble knapper til funksjoner"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Velg handlingen «Send tastetrykk», trykk inn tastatursnarveiknappen og hold "
+"nede en ny tastekombinasjon for å redigere en snarvei, eller trykk "
+"slettetast for å fjerne den."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Lukk"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Trykk på målmarkørene når de vises på skjermen for å kalibrere tegnebrettet."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Feil klikk oppdaget. Starter på nytt …"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Knapp %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Program definert"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Send tastetrykk"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Bytt skjerm"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Vis hjelp på skjermen"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr ""
+
+#: panels/wacom/cc-wacom-device.c:435
+#, fuzzy
+#| msgid "No tablet detected"
+msgid "External tablet device"
+msgstr "Fant ingen tegnebrett"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Alle skjermer"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Tegnebrettmodus"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:27
+msgid "Left Hand Orientation"
+msgstr "Venstrehendt orientering"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:56
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Knytt til skjerm"
+
+#: panels/wacom/cc-wacom-page.ui:62
+msgid "Keep Aspect Ratio"
+msgstr "Behold høyde-/breddeforhold"
+
+#: panels/wacom/cc-wacom-page.ui:63
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:73
+msgid "Calibrate"
+msgstr "Kalibrer"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Fant ingen tegnebrett"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+#| msgid "Please plug in or turn on your Wacom tablet"
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Slå på eller koble til Wacom-tegnebrett"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Følelse av trykk på tuppen"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Knapp 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Knapp 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Knapp 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Følsomhet for sletteknapp"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr ""
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom pekeplate"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Tilordne knapper og juster følsomhet for penn for grafiske tegnebrett"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tegnebrett;Wacom;Stylus;Viskelær;Mus;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Ny snarvei …"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Aksesspunkter"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:122
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr ""
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registrert"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Søker"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Nektet"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Detaljer om modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Status for modem:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Nettverkstype"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Nettverksstatus"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Eget nummer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+#| msgid "Printer Details"
+msgid "Device Details"
+msgstr "Detaljer for skriver"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Fastvareversjon"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Kun 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Kun 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Kun 4G"
+
+#: panels/wwan/cc-wwan-device.c:1003
+msgid "2G, 3G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1005
+msgid "2G, 3G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G (Preferred), 3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "3G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1017
+msgid "3G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1019
+msgid "3G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1025
+msgid "2G, 4G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1027
+msgid "2G (Preferred), 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1029
+msgid "2G, 4G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "2G, 3G (Preferred)"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "2G (Preferred), 3G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "2G, 3G"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device.c:1043
+#, fuzzy
+#| msgid "Unknown"
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Ukjent"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Lås opp SIM-kort"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Lås opp"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Låser opp …"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Ingen SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM låst"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobildata"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Nettverksmodus"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "N_ettverk"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avansert"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+#| msgid "Access Options"
+msgid "_Access Point Names"
+msgstr "Alternativer for tilgang"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+#| msgid "Screen Lock"
+msgid "_SIM Lock"
+msgstr "Lås skjerm"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+#| msgid "%s Details"
+msgid "M_odem Details"
+msgstr "Detaljer for %s"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+#, fuzzy
+#| msgid "PIN check failed"
+msgid "Phone failure"
+msgstr "PIN-sjekk mislyktes"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+#, fuzzy
+#| msgid "Turn VPN connection off"
+msgid "No connection to phone"
+msgstr "Slå av VPN-forbindelse"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+#, fuzzy
+#| msgid "SIM Card not inserted"
+msgid "SIM not inserted"
+msgstr "SIM-kort er ikke satt inn"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PIN required"
+msgstr "Pin for SIM kreves"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PUK required"
+msgstr "Pin for SIM kreves"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+#, fuzzy
+#| msgid "Current _Password"
+msgid "Incorrect password"
+msgstr "Gjeldende _passord"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PIN2 required"
+msgstr "Pin for SIM kreves"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+#, fuzzy
+#| msgid "SIM Pin required"
+msgid "SIM PUK2 required"
+msgstr "Pin for SIM kreves"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+#, fuzzy
+#| msgid "No stylus found"
+msgid "Not found"
+msgstr "Fant ingen penn"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+#, fuzzy
+#| msgid "Networks"
+msgid "No network service"
+msgstr "Nettverk"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+#, fuzzy
+#| msgid "Network Name"
+msgid "Network timeout"
+msgstr "Nettverksnavn"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+#, fuzzy
+#| msgid "AutoIP service failed"
+msgid "GPRS services not allowed"
+msgstr "AutoIP-tjeneste mislyktes"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+#, fuzzy
+#| msgctxt "print job"
+#| msgid "Canceled"
+msgid "Action Cancelled"
+msgstr "Avbrutt"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Access denied"
+msgstr ""
+
+#: panels/wwan/cc-wwan-errors-private.h:103
+#, fuzzy
+#| msgid "Unknown error"
+msgid "Unknown Error"
+msgstr "Ukjent feil"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+#| msgid "Network Name"
+msgid "Network Mode"
+msgstr "Nettverksnavn"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:146
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
+msgid "Close"
+msgstr "Lukk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:69
+msgid "_Automatic"
+msgstr "_Automatisk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:84
+msgid "Choose Network"
+msgstr "Velg nettverk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:99
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
+#, c-format
+msgid "SIM %d"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+#| msgid "_Enable by Keyboard"
+msgid "Enable Mobile Network"
+msgstr "Slå _på via tastatur"
+
+#: panels/wwan/cc-wwan-panel.ui:94
+#, fuzzy
+#| msgid "No Wi-Fi Adapter Found"
+msgid "No WWAN Adapter Found"
+msgstr "Fant ingen trådløse kort"
+
+#: panels/wwan/cc-wwan-panel.ui:104
+#, fuzzy
+#| msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Sjekk at du har et Wi-Fi-kort som er satt inn og slått på"
+
+#: panels/wwan/cc-wwan-panel.ui:145
+#, fuzzy
+#| msgid "Bluetooth is disabled when airplane mode is on."
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Bluetooth er slått av når flymodus er på."
+
+#: panels/wwan/cc-wwan-panel.ui:153
+#, fuzzy
+#| msgid "Turn Off Airplane Mode"
+msgid "_Turn off Airplane Mode"
+msgstr "Slå av flymodus"
+
+#: panels/wwan/cc-wwan-panel.ui:184
+#, fuzzy
+#| msgid "Forget Connection"
+msgid "Data Connection"
+msgstr "Glem tilkobling"
+
+#: panels/wwan/cc-wwan-panel.ui:185
+#, fuzzy
+#| msgid "SIM Card not inserted"
+msgid "SIM card used for internet"
+msgstr "SIM-kort er ikke satt inn"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+#| msgid "Screen Lock"
+msgid "SIM Lock"
+msgstr "Lås skjerm"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#, fuzzy
+#| msgid "Ch_ange"
+msgid "Change PIN"
+msgstr "_Endre"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+#| msgid "Visible Networks"
+msgid "Mobile Network"
+msgstr "Synlige nettverk"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Configure Removable Media settings"
+msgid "Configure Telephony and mobile data connections"
+msgstr "Konfigurer innstillinger for avtagbare medier"
+
+#. FIXME
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Verktøy som lar deg tilpasse GNOME-skrivebordet"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Innstillinger er primærgrensesnittet for å konfigurere systemet ditt."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:17
+#, fuzzy
+#| msgid "GNOME Settings"
+msgid "GNOME Settings Sound Panel"
+msgstr "GNOME kontrollpanel"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:21
+msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:25
+#, fuzzy
+#| msgid "GNOME Settings"
+msgid "GNOME Settings Background Panel"
+msgstr "GNOME kontrollpanel"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:29
+#, fuzzy
+#| msgid "GNOME Settings"
+msgid "GNOME Settings Keyboard Panel"
+msgstr "GNOME kontrollpanel"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:38
+msgid "The GNOME Project"
+msgstr "GNOME prosjektet"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Vis versjonsnummer"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Vis mer informasjon"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Søk etter strengen"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Vis mulige navn på paneler og avslutt"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel som skal vises"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT …]"
+
+#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Personvern"
+
+#: shell/cc-panel-loader.c:301
+msgid "Available panels:"
+msgstr "Tilgjengelige paneler:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Alle innstillinger"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Hovedmeny"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Advarsel: Utviklerversjon"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Denne versjonen av Innstillinger bør kun brukes for utviklingsformål. Du kan "
+"oppleve feil i systemets oppførsel, datatap og andre uventede feil."
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Hjelp"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Generelt"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Avslutt"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Søk"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneler"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Gå tilbake til forrige panel"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Avbryt søk"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Brukervalg;Innstillinger;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Identifikator for siste innstillingspanel som ble åpnet"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1907
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u utgang"
+msgstr[1] "%u utganger"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1917
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u inngang"
+msgstr[1] "%u innganger"
+
+#: subprojects/gvc/gvc-mixer-control.c:2867
+msgid "System Sounds"
+msgstr "Systemlyder"

--- a/po/nds.po
+++ b/po/nds.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center gnome-2-28\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&component=general\n"
-"POT-Creation-Date: 2009-11-22 16:05+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2009-11-23 00:53+0100\n"
 "Last-Translator: Nils-Christoph Fiedler <fiedler@medienkompanie.de>\n"
 "Language-Team: Low German <nds-lowgerman@lists.sourceforge.net>\n"
@@ -18,3435 +17,5989 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: ../gnome-control-center.schemas.in.h:1
-msgid "Current network location"
-msgstr "Aktueller Netwarkort"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
+msgstr "_Programmschriftart:"
 
-#: ../gnome-control-center.schemas.in.h:2
-msgid "More backgrounds URL"
-msgstr "Mehr Achtergründe URL"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "- GNOME-Standardprogramme"
 
-#: ../gnome-control-center.schemas.in.h:3
-msgid "More themes URL"
-msgstr "Mehr Themen URL"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Installert"
 
-#: ../gnome-control-center.schemas.in.h:4
-msgid ""
-"Set this to your current location name. This is used to determine the "
-"appropriate network proxy configuration."
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:5
-msgid ""
-"URL for where to get more desktop backgrounds. If set to an empty string the "
-"link will not appear."
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_Details"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Sök"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#: ../gnome-control-center.schemas.in.h:6
-msgid ""
-"URL for where to get more desktop themes. If set to an empty string the link "
-"will not appear."
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Deaktivert"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "Ort:"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Hölpoptschoonen opwiesen"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Achtergrund"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
 msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
 msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Achtergrund hentofögen"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Ton"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Anpasste Kortsnieds"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Knöppboord Kortsnieds"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "_Ortnaam:"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Nix funnen, wat passt."
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
 msgstr "Alarmtyp"
 
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "Alarmtyp"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "Alarmknöppe"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "Alarmknöppe im Alarmdialog"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "Mehr _Details opwiesen"
-
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Place your left thumb on %s"
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Swipe your left thumb on %s"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Place your left index finger on %s"
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Swipe your left index finger on %s"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "_Programmschriftart:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Place your left middle finger on %s"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Swipe your left middle finger on %s"
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Opmaken</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Place your left ring finger on %s"
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Swipe your left ring finger on %s"
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Place your left little finger on %s"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Stil:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Standard"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Swipe your left little finger on %s"
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Achtergrund"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Place your right thumb on %s"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "utsehn"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Swipe your right thumb on %s"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Place your right index finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Swipe your right index finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Place your right middle finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Swipe your right middle finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Place your right ring finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Swipe your right ring finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Place your right little finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Swipe your right little finger on %s"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:72
-#: ../capplets/about-me/fingerprint-strings.h:98
-msgid "Place your finger on the reader again"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:74
-#: ../capplets/about-me/fingerprint-strings.h:100
-msgid "Swipe your finger again"
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:77
-#: ../capplets/about-me/fingerprint-strings.h:103
-msgid "Swipe was too short, try again"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:79
-#: ../capplets/about-me/fingerprint-strings.h:105
-msgid "Your finger was not centered, try swiping your finger again"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
 msgstr ""
 
-#: ../capplets/about-me/fingerprint-strings.h:81
-#: ../capplets/about-me/fingerprint-strings.h:107
-msgid "Remove your finger, and try swiping your finger again"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:716
-msgid "Select Image"
-msgstr "Bill utwählen"
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:718
-msgid "No Image"
-msgstr "Keen Bill"
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:746
-#: ../capplets/appearance/appearance-desktop.c:654
-msgid "Images"
-msgstr "Billers"
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:750
-#: ../capplets/appearance/theme-installer.c:763
-msgid "All Files"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
+msgstr "Starte %s"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "Fertig!"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "Billschirm"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Billschirminstellens"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "Dateinaam"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "Dateinaam"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Kopere Dateien"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
 msgstr "All Dateien"
 
-#: ../capplets/about-me/gnome-about-me.c:890
+#: panels/color/cc-color-panel.ui:373
 msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:911
-msgid "Unable to open address book"
-msgstr "Nich möglich, Anskrivtenbook optomaken"
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:934
-#, c-format
-msgid "About %s"
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Hentofögen..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "_Deaktivert"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "Ut Leevsten löschen"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Details"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Hoch"
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "Minuuten"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "_Middig"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "Minuuten"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "Minuuten"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Klöörs"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Bill utwählen"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_utwählen"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Nix funnen, wat passt."
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Sök"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "Billschirm"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Deaktivert"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "Sekunnen"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Kale_nner:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Kale_nner:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "- GNOME-Standardprogramme"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "- GNOME-Standardprogramme"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Düsser Schriftart tostimmen"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+#, fuzzy
+msgid "Mirror"
+msgstr "Spegelbillschirms"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Billschirm"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Oplösens:"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Gröte ännern"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Filter"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Vun URI"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "Minuuten"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+#, fuzzy
+msgid "Displays"
+msgstr "Billschirm"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Naam:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Typ:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME Terminal"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Finsters"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Dateinaam"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Annern Naam geven..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
 msgstr "Över %s"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:1
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:2
-msgid "A_ddress:"
-msgstr "An_skrivt"
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:3
-msgid "A_ssistant:"
-msgstr "H_ölper:"
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:4
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-msgid "About Me"
-msgstr "Över mik"
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:5
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+#, fuzzy
+msgid "Launch media player"
+msgstr "Multimediaspeeler"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+#, fuzzy
+msgid "Launch web browser"
+msgstr "Epiphany Netkieker"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Sök"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:6
+#, fuzzy
+msgid "Lock screen"
+msgstr "Billschirm full maken"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Togangelikheit"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+#, fuzzy
+msgid "Zoom in"
+msgstr "Gröte"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Gröte"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "_Optschoonen..."
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+#, fuzzy
+msgid "Move Down"
+msgstr "Boven nah unnen"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Instellens"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Knöppboordutsehnoptschoonen"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "_De sülvigen Proxy för all Protokolls bruken"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Knöppboord Kortsnieds"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Anpasste Kortsnieds"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Aktschoon"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Kortsnied"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Kortsnied"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Anpasste Kortsnieds"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Kortsnied"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Knöppboord Kortsnieds"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Naam:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "_Order:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Kortsnied"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Kortsnied"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Keen"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_To Originale torüggsetten"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Knöppboord"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Giv dien persönliche Informatschoonen in"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Allgemeen"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Links"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Rechts"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_Ort löschen"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Muus"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Muus"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Billschirm"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_Programmschriftart:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Aktschoon"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "_Optschoonen..."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Netwark Servers"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Passwoord:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Aktuelles _Passwoord:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Anskrivt"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Anskrivt"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Anskrivt"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Standardmuuswieser"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Naam:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Anskrivt:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Anskrivt:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Deaktivert"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Anskrivt"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Anskrivt"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:6
-msgid "C_ity:"
-msgstr "St_adt:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:7
-msgid "C_ompany:"
-msgstr "F_irma:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:8
-msgid "Cale_ndar:"
-msgstr "Kale_nner:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:9
-msgid "Change Passwo_rd..."
-msgstr "Passwoo_rd ännern..."
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:10
-msgid "Ci_ty:"
-msgstr "St_adt:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:11
-msgid "Co_untry:"
-msgstr "Lan_d:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:12
-msgid "Contact"
-msgstr "Kontakt"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:13
-msgid "Cou_ntry:"
-msgstr "_Land:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:14
-msgid "Disable _Fingerprint Login..."
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:15
-msgid "Email"
-msgstr "E-Post"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:16
-msgid "Enable _Fingerprint Login..."
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:17
-msgid "Full Name"
-msgstr "Vor- un Tonaam"
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:18
-msgid "Hom_e:"
-msgstr "Heima_t:"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:19
-#: ../libslab/bookmark-agent.c:1135
-msgid "Home"
-msgstr "Heimat"
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:20
-msgid "IC_Q:"
-msgstr "IC_Q:"
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:21
-msgid "Instant Messaging"
-msgstr "Foortsnahrichtendeenst"
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "Minuuten"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:22
-msgid "Job"
-msgstr "Arbeid"
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:23
-msgid "M_SN:"
-msgstr "M_SN:"
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:24
-msgid "P.O. _box:"
-msgstr "P.O. _box:"
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:25
-msgid "P._O. box:"
-msgstr "P._O. box:"
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:26
-msgid "Personal Info"
-msgstr "Persönliche Informatschoonen"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:27
-msgid "Select your photo"
-msgstr "Wähl dien Bill ut"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:28
-msgid "State/Pro_vince:"
-msgstr "Land/Re_gion:"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:29
-msgid "Telephone"
-msgstr "Klönkassen"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:30
-msgid "User name:"
-msgstr "Brukernaam:"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:31
-msgid "Web"
-msgstr "Net"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:32
-msgid "Web _log:"
-msgstr "Dageboo_k:"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Netwark-Proxy"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:33
-msgid "Wor_k:"
-msgstr "Arbei_d:"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:34
-msgid "Work"
-msgstr "Arbeid"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:35
-msgid "Work _fax:"
-msgstr "Arbeid _FAX:"
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:36
-msgid "Zip/_Postal code:"
-msgstr "Zip/_Postleittaal:"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:37
-msgid "_Address:"
-msgstr "_Anskrivt:"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:38
-msgid "_Department:"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Aktschoon"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "Anskrivt"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Netwark-Proxy"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "_FTP Proxy:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "_FTP Proxy:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP Proxy:"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "_FTP Proxy:"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP Proxy:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Proxy-Konfiguratschoon"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Netwark Servers"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Passwoord:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Hölpoptschoonen opwiesen"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "All Dateien"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "B_rukernaam:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Passwoord:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Nejes Passwoord:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Verschoon:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Verschoon:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Nejes Passwoord ingeven:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Typ:"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Standard"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Dateisystem"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "R_otatschoon:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "_Ort löschen"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "Minuuten"
+msgstr[1] "Minuuten"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "Minuuten"
+msgstr[1] "Minuuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "Minuuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "Minuuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "Minuuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "Minuuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "Minuuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "Minuuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "Minuuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "Minuuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Spegelbillschirms"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "Muuswieser"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "Muuswieser"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Nix funnen, wat passt."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "B_rukernaam:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Ort:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Installatschoon fehlslagen"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+#, fuzzy
+msgid "Select Printer Driver"
+msgstr "Finger wählen"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_utwählen"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "_Details"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "_To Originale torüggsetten"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
+msgstr "Ut Leevsten löschen"
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Modelle"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Muuswieser"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "Normal"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "All Dateien"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Utblick"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
 msgstr "_Kontor:"
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:39
-msgid "_Groupwise:"
-msgstr "_Groupwise:"
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:40
-msgid "_Home page:"
-msgstr "_Hemsiet:"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:41
-msgid "_Home:"
-msgstr "_Heimat:"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:42
-msgid "_Jabber:"
-msgstr "_Jabber:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:43
-msgid "_Manager:"
-msgstr "_Oppasser:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:44
-msgid "_Mobile:"
-msgstr "_Unnerwegs:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:45
-msgid "_Profession:"
-msgstr "_Beroop:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:46
-msgid "_State/Province:"
-msgstr "_Land/Region:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:47
-msgid "_Title:"
-msgstr "_Titel:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:48
-msgid "_Work:"
-msgstr "_Arbeid:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:49
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me-dialog.ui.h:50
-msgid "_Zip/Postal code:"
-msgstr "_Zip/Postleittaal:"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "Giv dien persönliche Informatschoonen in"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:97
+#: panels/region/cc-region-panel.ui:45
 msgid ""
-"You are not allowed to access the device. Contact your system administrator."
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
-msgid "The device is already in use."
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
-msgid "An internal error occured"
-msgstr "Een interner Fehler is optreten"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:218
-msgid "Delete registered fingerprints?"
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:221
-msgid "_Delete Fingerprints"
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+#, fuzzy
+msgid "_Language"
+msgstr "_Sprak:"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Linux Billschirmleser"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "Muine Tonspeeler"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Aktschoon"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Typ:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+#, fuzzy
+msgid "Screen"
+msgstr "Spegelbillschirms"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Ort:"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Annere"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Ort:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_Programmschriftart:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Sök"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Netwark Servers"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Schrievdisk"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Ort löschen"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Passwoord:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Schrievdisk"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "UI Kontroll"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Brukernaam:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
 msgstr "Fingeravdrücken_s löschen"
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:228
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "System"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Proxy-Konfiguratschoon"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Alarmknöppe"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Ton"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Naam:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Twe_jter Klick:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Koort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "Twe_jter Klick:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Koort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Lüttj"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Groot"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Koort"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Koort"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Groot"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Linux Billschirmleser"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Ton"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Gröte"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Visuell"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Knöppboord"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Muus"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Groter Muuswieser"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+#, fuzzy
+msgid "Visual Alerts"
+msgstr "Visuell"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Billschirm full maken"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "Links"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "Rechts"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "_Optschoonen..."
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "Orca mit Vergröterer"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "K_löörs:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Kontakt"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Keen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Full"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Hoch"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+#, fuzzy
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Hoch"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "Klöörs"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Dateisystem"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "In'n Papierkörv verschuven"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "Terminator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Nejes Passwoord:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Bill utwählen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Fingeravdrücken_s löschen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Keen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:342
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:1
-msgid "Done!"
-msgstr "Fertig!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
-#, c-format
-msgid "Could not access '%s' device"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
 msgstr ""
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:459
-#, c-format
-msgid "Could not start finger capture on '%s' device"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:506
-msgid "Could not access any fingerprint readers"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:507
-msgid "Please contact your system administrator for help."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:537
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:2
-msgid "Enable Fingerprint Login"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
 msgstr ""
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:567
-#, c-format
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:576
-msgid "Swipe finger on reader"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "Fingeravdrücken_s löschen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:578
-msgid "Place finger on reader"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Schriftartutblick"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:3
-msgid "Left index finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:5
-msgid "Left middle finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:6
-msgid "Left ring finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:7
-msgid "Left thumb"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:8
-msgid "Other finger: "
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:9
-msgid "Right index finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:10
-msgid "Right little finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:11
-msgid "Right middle finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:12
-msgid "Right ring finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:13
-msgid "Right thumb"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:14
-msgid "Select finger"
-msgstr "Finger wählen"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:15
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:161
-msgid "Child exited unexpectedly"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:296
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:309
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:408
-msgid "Authenticated!"
-msgstr ""
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:474
-#: ../capplets/about-me/gnome-about-me-password.c:550
-msgid ""
-"Your password has been changed since you initially authenticated! Please re-"
-"authenticate."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:476
-msgid "That password was incorrect."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:523
-msgid "Your password has been changed."
-msgstr ""
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:533
-#, c-format
-msgid "System error: %s."
-msgstr "Systemfehler: %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:536
-msgid "The password is too short."
-msgstr "Dat Passwoord is to kort."
-
-#: ../capplets/about-me/gnome-about-me-password.c:539
-msgid "The password is too simple."
-msgstr "Dat Passwoord is to eenfach."
-
-#: ../capplets/about-me/gnome-about-me-password.c:542
-msgid "The old and new passwords are too similar."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:544
-msgid "The new password must contain numeric or special character(s)."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:547
-msgid "The old and new passwords are the same."
-msgstr ""
-
-#. translators: Unable to launch <program>: <error message>
-#: ../capplets/about-me/gnome-about-me-password.c:818
-#, c-format
-msgid "Unable to launch %s: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:822
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:823
-msgid "A system error has occurred"
-msgstr "Een Systemfehler is optreten"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:843
-msgid "Checking password..."
-msgstr "Kiek mi dat Passwoord an..."
-
-#: ../capplets/about-me/gnome-about-me-password.c:930
-msgid "Click <b>Change password</b> to change your password."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:933
-msgid "Please type your password in the <b>New password</b> field."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:936
-#: ../capplets/about-me/gnome-about-me-password.ui.h:5
-msgid ""
-"Please type your password again in the <b>Retype new password</b> field."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:939
-msgid "The two passwords are not equal."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:1
-msgid "Change pa_ssword"
-msgstr "Pa_sswoord ännern"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:2
-msgid "Change password"
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
 msgstr "Passwoord ännern"
 
-#: ../capplets/about-me/gnome-about-me-password.ui.h:3
-msgid "Change your password"
-msgstr "Dien Passwoord ännern"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:4
-msgid "Current _password:"
-msgstr "Aktuelles _Passwoord:"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:6
-msgid ""
-"To change your password, enter your current password in the field below and "
-"click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for "
-"verification and click <b>Change password</b>."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:8
-msgid "_Authenticate"
-msgstr "_Bewiesen, dat je du sülvst büst"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:9
-msgid "_New password:"
-msgstr "_Nejes Passwoord:"
-
-#: ../capplets/about-me/gnome-about-me-password.ui.h:10
-msgid "_Retype new password:"
-msgstr "_Nejes Passwoord ingeven:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:1
-msgid "Accessible Lo_gin"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:2
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:3
-msgid "Assistive Technologies Preferences"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:4
-msgid ""
-"Changes to enable assistive technologies will not take effect until your "
-"next log in."
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:5
-msgid "Close and _Log Out"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:6
-msgid "Jump to Preferred Applications dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:7
-msgid "Jump to the Accessible Login dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:8
-msgid "Jump to the Keyboard Accessibility dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:9
-msgid "Jump to the Mouse Accessibility dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:10
-msgid "Preferences"
-msgstr "Instellens"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:11
-msgid "_Enable assistive technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:12
-msgid "_Keyboard Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:13
-msgid "_Mouse Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:14
-msgid "_Preferred Applications"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Choose which accessibility features to enable when you log in"
-msgstr ""
-
-#: ../capplets/appearance/appearance-desktop.c:623
-msgid "Add Wallpaper"
-msgstr "Achtergrund hentofögen"
-
-#: ../capplets/appearance/appearance-desktop.c:658
-msgid "All files"
-msgstr "All Dateien"
-
-#: ../capplets/appearance/appearance-font.c:494
-msgid "Font may be too large"
-msgstr ""
-
-#: ../capplets/appearance/appearance-font.c:498
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:511
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:534
-msgid "Use previous font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-font.c:536
-msgid "Use selected font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:54
-#, c-format
-msgid "Could not load user interface file: %s"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:133
-msgid "Specify the filename of a theme to install"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:134
-msgid "filename"
-msgstr "Dateinaam"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/appearance/appearance-main.c:141
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:142
-#: ../capplets/default-applications/gnome-da-capplet.c:959
-#: ../capplets/mouse/gnome-mouse-properties.c:591
-msgid "page"
-msgstr "Siet"
-
-#: ../capplets/appearance/appearance-main.c:149
-msgid "[WALLPAPER...]"
-msgstr "[WALLPAPER...]"
-
-#: ../capplets/appearance/appearance-style.c:173
-#: ../capplets/common/gnome-theme-info.c:446
-#: ../capplets/common/gnome-theme-info.c:638
-msgid "Default Pointer"
-msgstr "Standardmuuswieser"
-
-#: ../capplets/appearance/appearance-style.c:235
-#: ../capplets/appearance/appearance-themes.c:685
-msgid "Install"
-msgstr "Installeren"
-
-#: ../capplets/appearance/appearance-style.c:255
-#: ../capplets/common/gnome-theme-info.c:1646
-#, c-format
-msgid ""
-"This theme will not look as intended because the required GTK+ theme engine "
-"'%s' is not installed."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:673
-msgid "Apply Background"
-msgstr "Düssem Achtergrund tostimmen"
-
-#: ../capplets/appearance/appearance-themes.c:677
-msgid "Apply Font"
-msgstr "Düsser Schriftart tostimmen"
-
-#: ../capplets/appearance/appearance-themes.c:681
-msgid "Revert Font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:711
-msgid ""
-"The current theme suggests a background and a font. Also, the last applied "
-"font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:713
-msgid ""
-"The current theme suggests a background. Also, the last applied font "
-"suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:715
-msgid "The current theme suggests a background and a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:717
-msgid ""
-"The current theme suggests a font. Also, the last applied font suggestion "
-"can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:719
-msgid "The current theme suggests a background."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:721
-msgid "The last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:723
-msgid "The current theme suggests a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:1045
-#: ../capplets/default-applications/gnome-da-capplet.c:690
-msgid "Custom"
-msgstr "Anpasst"
-
-#: ../capplets/appearance/data/appearance.ui.h:1
-msgid "Appearance Preferences"
-msgstr "Utsehninstellens"
-
-#: ../capplets/appearance/data/appearance.ui.h:2
-msgid "Background"
-msgstr "Achtergrund"
-
-#: ../capplets/appearance/data/appearance.ui.h:3
-msgid "Best _shapes"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:4
-msgid "Best co_ntrast"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:5
-msgid "C_olors:"
-msgstr "K_löörs:"
-
-#: ../capplets/appearance/data/appearance.ui.h:6
-msgid "C_ustomize..."
-msgstr "A_npassen..."
-
-#: ../capplets/appearance/data/appearance.ui.h:7
-msgid "Center"
-msgstr "Inne Midde"
-
-#: ../capplets/appearance/data/appearance.ui.h:8
-msgid "Changing your cursor theme takes effect the next time you log in."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:9
-msgid "Colors"
-msgstr "Klöörs"
-
-#: ../capplets/appearance/data/appearance.ui.h:10
-msgid "Controls"
-msgstr "Kontroll"
-
-#: ../capplets/appearance/data/appearance.ui.h:11
-msgid "Customize Theme"
-msgstr "Thema anpassen"
-
-#: ../capplets/appearance/data/appearance.ui.h:12
-msgid "D_etails..."
-msgstr "D_etails..."
-
-#: ../capplets/appearance/data/appearance.ui.h:13
-msgid "Des_ktop font:"
-msgstr "Schrievdis_kschriftart:"
-
-#: ../capplets/appearance/data/appearance.ui.h:14
-msgid "Font Rendering Details"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:15
-msgid "Fonts"
-msgstr "Schriftart"
-
-#: ../capplets/appearance/data/appearance.ui.h:16
-msgid "Get more backgrounds online"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:17
-msgid "Get more themes online"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:18
-msgid "Gra_yscale"
-msgstr ""
-
-#. font hinting
-#: ../capplets/appearance/data/appearance.ui.h:20
-msgid "Hinting"
-msgstr "Wiesen"
-
-#: ../capplets/appearance/data/appearance.ui.h:21
-msgid "Horizontal gradient"
-msgstr "Horizontaler Verlööp"
-
-#: ../capplets/appearance/data/appearance.ui.h:22
-msgid "Icons"
-msgstr "Symbole"
-
-#: ../capplets/appearance/data/appearance.ui.h:23
-msgid "Icons only"
-msgstr "Just Symbole"
-
-#: ../capplets/appearance/data/appearance.ui.h:24
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:16
-msgid "Large"
-msgstr "Groot"
-
-#: ../capplets/appearance/data/appearance.ui.h:25
-msgid "N_one"
-msgstr "K_eene"
-
-#: ../capplets/appearance/data/appearance.ui.h:26
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:27
-msgid "Pointer"
-msgstr "Muuswieser"
-
-#: ../capplets/appearance/data/appearance.ui.h:28
-msgid "R_esolution:"
-msgstr "_Oplösens:"
-
-#: ../capplets/appearance/data/appearance.ui.h:29
-msgid "Rendering"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:30
-msgid "Save Theme As..."
-msgstr "Thema spieker as..."
-
-#: ../capplets/appearance/data/appearance.ui.h:31
-msgid "Save _As..."
-msgstr "Spiekern _as..."
-
-#: ../capplets/appearance/data/appearance.ui.h:32
-msgid "Save _background image"
-msgstr "Achter_grundbill spiekern"
-
-#: ../capplets/appearance/data/appearance.ui.h:33
-msgid "Scale"
-msgstr "Gröte ännern"
-
-#: ../capplets/appearance/data/appearance.ui.h:34
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:30
-msgid "Small"
-msgstr "Lüttj"
-
-#: ../capplets/appearance/data/appearance.ui.h:35
-msgid "Smoothing"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:36
-msgid "Solid color"
-msgstr "Solide Klöör"
-
-#: ../capplets/appearance/data/appearance.ui.h:37
-msgid "Stretch"
-msgstr "Wieder maken"
-
-#: ../capplets/appearance/data/appearance.ui.h:38
-msgid "Sub_pixel (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:39
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:40
-msgid "Subpixel Order"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:41
-msgid "Text"
-msgstr "Text"
-
-#: ../capplets/appearance/data/appearance.ui.h:42
-msgid "Text below items"
-msgstr "Text unner Elemente"
-
-#: ../capplets/appearance/data/appearance.ui.h:43
-msgid "Text beside items"
-msgstr "Text neben de Elemente"
-
-#: ../capplets/appearance/data/appearance.ui.h:44
-msgid "Text only"
-msgstr "Just text"
-
-#: ../capplets/appearance/data/appearance.ui.h:45
-msgid "The current controls theme does not support color schemes."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:46
-msgid "Theme"
-msgstr "Thema"
-
-#: ../capplets/appearance/data/appearance.ui.h:47
-msgid "Tile"
-msgstr ""
-
-#. vertical hinting, pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.ui.h:49
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/appearance/data/appearance.ui.h:50
-msgid "Vertical gradient"
-msgstr "Vertikaler Verlööp"
-
-#: ../capplets/appearance/data/appearance.ui.h:51
-msgid "Window Border"
-msgstr "Finsterkant"
-
-#: ../capplets/appearance/data/appearance.ui.h:52
-msgid "Zoom"
-msgstr "Gröte"
-
-#: ../capplets/appearance/data/appearance.ui.h:53
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:36
-msgid "_Add..."
-msgstr "_Hentofögen..."
-
-#: ../capplets/appearance/data/appearance.ui.h:54
-msgid "_Application font:"
-msgstr "_Programmschriftart:"
-
-#. pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.ui.h:56
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/appearance/data/appearance.ui.h:57
-msgid "_Description:"
-msgstr "B_eschrieven:"
-
-#: ../capplets/appearance/data/appearance.ui.h:58
-msgid "_Document font:"
-msgstr "Dokumentschriftart:"
-
-#: ../capplets/appearance/data/appearance.ui.h:59
-msgid "_Fixed width font:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:60
-msgid "_Full"
-msgstr "_Full"
-
-#: ../capplets/appearance/data/appearance.ui.h:61
-msgid "_Input boxes:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:62
-msgid "_Install..."
-msgstr "_Installeren..."
-
-#: ../capplets/appearance/data/appearance.ui.h:63
-msgid "_Medium"
-msgstr "_Middig"
-
-#: ../capplets/appearance/data/appearance.ui.h:64
-msgid "_Monochrome"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:65
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:5
-msgid "_Name:"
-msgstr "_Naam:"
-
-#: ../capplets/appearance/data/appearance.ui.h:66
-msgid "_None"
-msgstr "_Keen"
-
-#. pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.ui.h:68
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/appearance/data/appearance.ui.h:69
-msgid "_Reset to Defaults"
-msgstr "_To Originale torüggsetten"
-
-#: ../capplets/appearance/data/appearance.ui.h:70
-msgid "_Selected items:"
-msgstr "_Utwählte Elemente:"
-
-#: ../capplets/appearance/data/appearance.ui.h:71
-msgid "_Size:"
-msgstr "_Gröte:"
-
-#: ../capplets/appearance/data/appearance.ui.h:72
-msgid "_Slight"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.ui.h:73
-msgid "_Style:"
-msgstr "_Stil:"
-
-#: ../capplets/appearance/data/appearance.ui.h:74
-msgid "_Tooltips:"
-msgstr "_Lütte Henwiese:"
-
-#. vertical hinting, pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.ui.h:76
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/appearance/data/appearance.ui.h:77
-msgid "_Window title font:"
-msgstr "_Finstertitelschriftart:"
-
-#: ../capplets/appearance/data/appearance.ui.h:78
-msgid "_Windows:"
-msgstr "_Finsters:"
-
-#: ../capplets/appearance/data/appearance.ui.h:79
-msgid "dots per inch"
-msgstr "Punkt per Inch"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr "utsehn"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr "Schrievdiskutsehn anpassen"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr "Themen installerer"
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr "GNOME-Themen Pack"
-
-#: ../capplets/appearance/gnome-wp-info.c:50
-msgid "No Desktop Background"
-msgstr "Keen Schrievdiskachtergrund"
-
-#: ../capplets/appearance/gnome-wp-item.c:258
-msgid "Slide Show"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-item.c:260
-msgid "Image"
-msgstr "Bill"
-
-#: ../capplets/appearance/gnome-wp-item.c:266
-msgid "multiple sizes"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-item.c:271
-#: ../capplets/appearance/gnome-wp-item.c:273
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "Pixel"
-msgstr[1] "Pixels"
-
-#. translators: <b>wallpaper name</b>
-#. * mime type, size
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:279
-#, c-format
-msgid ""
-"<b>%s</b>\n"
-"%s, %s\n"
-"Folder: %s"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:178
-#: ../capplets/appearance/theme-installer.c:234
-msgid "Cannot install theme"
-msgstr "Künn dat Thema nich installeren"
-
-#: ../capplets/appearance/theme-installer.c:180
-#, c-format
-msgid "The %s utility is not installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:236
-msgid "There was a problem while extracting the theme."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:264
-msgid "There was an error installing the selected file"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:265
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:266
-#, c-format
-msgid ""
-"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
-"you need to compile."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:372
-#, c-format
-msgid "Installation for theme \"%s\" failed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:411
-#, c-format
-msgid "The theme \"%s\" has been installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:421
-msgid "Would you like to apply it now, or keep your current theme?"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:424
-msgid "Keep Current Theme"
-msgstr "Aktuelles Thema behollen"
-
-#: ../capplets/appearance/theme-installer.c:427
-msgid "Apply New Theme"
-msgstr "Nejem Thema tostimmen"
-
-#: ../capplets/appearance/theme-installer.c:471
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "GNOME-Thema %s akerat installert"
-
-#: ../capplets/appearance/theme-installer.c:533
-msgid "Failed to create temporary directory"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:596
-msgid "New themes have been successfully installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:643
-msgid "No theme file location specified to install"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:667
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:745
-msgid "Select Theme"
-msgstr "Thema wählen"
-
-#: ../capplets/appearance/theme-installer.c:756
-msgid "Theme Packages"
-msgstr "Themenpacks"
-
-#: ../capplets/appearance/theme-save.c:93
-#, c-format
-msgid "Theme name must be present"
-msgstr ""
-
-#: ../capplets/appearance/theme-save.c:156
-msgid "The theme already exists. Would you like to replace it?"
-msgstr ""
-
-#: ../capplets/appearance/theme-save.c:157
-#: ../capplets/common/file-transfer-dialog.c:450
-msgid "_Overwrite"
-msgstr "_Överschrieven"
-
-#: ../capplets/appearance/theme-util.c:75
-msgid "Would you like to delete this theme?"
-msgstr ""
-
-#: ../capplets/appearance/theme-util.c:125
-msgid "Theme cannot be deleted"
-msgstr "Thema künn nich löscht werrn"
-
-#: ../capplets/appearance/theme-util.c:252
-msgid "Could not install theme engine"
-msgstr ""
-
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with DBus, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-
-#: ../capplets/common/capplet-stock-icons.c:66
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:88
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:98
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "Kopere Datei: %u of %u"
-
-#: ../capplets/common/file-transfer-dialog.c:145
-#, c-format
-msgid "Copying '%s'"
-msgstr "Kopere '%s'"
-
-#: ../capplets/common/file-transfer-dialog.c:185
-#: ../capplets/common/file-transfer-dialog.c:312
-msgid "Copying files"
-msgstr "Kopere Dateien"
-
-#: ../capplets/common/file-transfer-dialog.c:224
-msgid "Parent Window"
-msgstr "Ollenfinster"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Parent window of the dialog"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:231
-msgid "From URI"
-msgstr "Vun URI"
-
-#: ../capplets/common/file-transfer-dialog.c:232
-msgid "URI currently transferring from"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:239
-msgid "To URI"
-msgstr "To URI"
-
-#: ../capplets/common/file-transfer-dialog.c:240
-msgid "URI currently transferring to"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:247
-msgid "Fraction completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:248
-msgid "Fraction of transfer currently completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:255
-msgid "Current URI index"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:256
-msgid "Current URI index - starts from 1"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:263
-msgid "Total URIs"
-msgstr "All URIs"
-
-#: ../capplets/common/file-transfer-dialog.c:264
-msgid "Total number of URIs"
-msgstr "Totale Taal vun URIs"
-
-#: ../capplets/common/file-transfer-dialog.c:444
-#, c-format
-msgid "File '%s' already exists. Do you want to overwrite it?"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:447
-msgid "_Skip"
-msgstr "_Överhüppen"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Overwrite _All"
-msgstr "_Allens överschrieven"
-
-#: ../capplets/common/gconf-property-editor.c:134
-msgid "Key"
-msgstr "Slötel"
-
-#: ../capplets/common/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:141
-msgid "Callback"
-msgstr "Torüggröpen"
-
-#: ../capplets/common/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:147
-msgid "Change set"
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
 msgstr "Tosammenstellens ännern"
 
-#: ../capplets/common/gconf-property-editor.c:148
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Aktuelles _Passwoord:"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Nejes Passwoord:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Passwoord ännern"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Dat Passwoord is to kort."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Nejes Passwoord:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Vor- un Tonaam"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Bewarken"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+#, fuzzy
+msgid "_Fingerprint Login"
+msgstr "Fingeravdrücken_s löschen"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Kontroll"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:154
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Annere"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Nix funnen, wat passt."
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:160
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "UI Kontroll"
-
-#: ../capplets/common/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:181
-msgid "Property editor object data"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Alarmknöppe"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:1405
-#, c-format
+#: panels/wacom/button-mapping.ui:51
 msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:1413
-#, c-format
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
 msgstr ""
 
-#: ../capplets/common/gconf-property-editor.c:1533
-msgid "Please select an image."
-msgstr "Bidde een Bill utwählen."
-
-#: ../capplets/common/gconf-property-editor.c:1538
-msgid "_Select"
-msgstr "_utwählen"
-
-#: ../capplets/common/gnome-theme-info.c:639
-msgid "Default Pointer - Current"
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: ../capplets/common/gnome-theme-info.c:643
-msgid "White Pointer"
-msgstr "Witter Muuswieser"
-
-#: ../capplets/common/gnome-theme-info.c:644
-msgid "White Pointer - Current"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
-#: ../capplets/common/gnome-theme-info.c:648
-msgid "Large Pointer"
-msgstr "Groter Muuswieser"
-
-#: ../capplets/common/gnome-theme-info.c:649
-msgid "Large Pointer - Current"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
 msgstr ""
 
-#: ../capplets/common/gnome-theme-info.c:653
-msgid "Large White Pointer - Current"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: ../capplets/common/gnome-theme-info.c:654
-msgid "Large White Pointer"
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
 msgstr ""
 
-#: ../capplets/common/gnome-theme-info.c:1622
-#, c-format
-msgid ""
-"This theme will not look as intended because the required GTK+ theme '%s' is "
-"not installed."
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: ../capplets/common/gnome-theme-info.c:1630
-#, c-format
-msgid ""
-"This theme will not look as intended because the required window manager "
-"theme '%s' is not installed."
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1637
-#, c-format
-msgid ""
-"This theme will not look as intended because the required icon theme '%s' is "
-"not installed."
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:17
-msgid "Preferred Applications"
-msgstr "Leevste Programme"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Start the preferred visual assistive technology"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr "Visueller Hölper"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:98
-#: ../capplets/default-applications/gnome-da-capplet.c:362
-#: ../capplets/default-applications/gnome-da-capplet.c:383
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:721
-msgid "Could not load the main interface"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:723
-msgid "Please make sure that the applet is properly installed"
-msgstr ""
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/default-applications/gnome-da-capplet.c:958
-msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:963
-msgid "- GNOME Default Applications"
-msgstr "- GNOME-Standardprogramme"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:1
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:1
-msgid "Accessibility"
-msgstr "Togangelikheit"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:3
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr ""
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:4
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:1
-msgid "C_ommand:"
-msgstr "_Order:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:5
-msgid "Co_mmand:"
-msgstr "Or_der:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:6
-msgid "E_xecute flag:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:7
-msgid "Image Viewer"
-msgstr "Billopwieser"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:8
-msgid "Instant Messenger"
-msgstr "Foortsnahrichtenschriever"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:9
-msgid "Internet"
-msgstr "Innernet"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:10
-msgid "Mail Reader"
-msgstr "Postleser"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:11
-msgid "Mobility"
-msgstr "Unnerwegs allens dorbi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:12
-msgid "Multimedia"
-msgstr "Multimedia"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:13
-msgid "Multimedia Player"
-msgstr "Multimediaspeeler"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:14
-msgid "Open link in new _tab"
-msgstr "Verknüppen in nejer _Registerkoort opmaken"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:15
-msgid "Open link in new _window"
-msgstr "Verknüppen in nejem _Finster opmaken"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:16
-msgid "Open link with web browser _default"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:18
-msgid "Run at st_art"
-msgstr "Bi'm Start lööpen laten"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:19
-msgid "Run in t_erminal"
-msgstr "Im T_erminal lööpen laten"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:20
-msgid "System"
-msgstr "System"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:21
-msgid "Terminal Emulator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:22
-msgid "Text Editor"
-msgstr "Textbewarker"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:23
-msgid "Video Player"
-msgstr "Filmspeeler"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:24
-msgid "Visual"
-msgstr "Visuell"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:25
-msgid "Web Browser"
-msgstr "Netkieker"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:26
-msgid "_Run at start"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr "Banshee Tonspeeler"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr "Claws Mail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr "Dasher"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr "Debian Sensible Browser"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr "Debian Terminal Emulator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr "Debian Terminal Emulator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr "Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr "Epiphany Netkieker"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr "Evolution Postleser"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr "Firebird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr "GNOME Terminal"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Gnopernicus"
-msgstr "Gnopernicus"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Gnopernicus with Magnifier"
-msgstr "Gnopernicus mit Vergröterer"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Iceape"
-msgstr "Iceape"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Iceape Mail"
-msgstr "Iceape Post"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Icedove"
-msgstr "Icedove"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Iceweasel"
-msgstr "Iceweasel"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr "KMail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Konsole"
-msgstr "Konsole"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr "Linux Billschirmleser"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Listen"
-msgstr "Tohören"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Midori"
-msgstr "Midori"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Mozilla Mail"
-msgstr "Mozilla Post"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Muine Music Player"
-msgstr "Muine Tonspeeler"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Netscape Communicator"
-msgstr "Netscape Kommunikator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Opera"
-msgstr "Opera"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca"
-msgstr "Orca"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "Orca with Magnifier"
-msgstr "Orca mit Vergröterer"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-msgid "Rhythmbox Music Player"
-msgstr "Rhythmbox Tonspeeler"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-msgid "SeaMonkey Mail"
-msgstr "SeaMonkey Post"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Standard XTerminal"
-msgstr "Standard XTerminal"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-msgid "Sylpheed"
-msgstr "Sylpheed"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Terminator"
-msgstr "Terminator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "Totem Movie Player"
-msgstr "Totem Filmspeeler"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/display/display-capplet.ui.h:1
-msgid "Display Preferences"
-msgstr "Billschirminstellens"
-
-#: ../capplets/display/display-capplet.ui.h:2
-msgid "Drag the monitors to set their place"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:3
-msgid "Include _panel"
-msgstr "_Balken insluten"
-
-#: ../capplets/display/display-capplet.ui.h:4
-#: ../capplets/display/xrandr-capplet.c:302
-msgid "Left"
-msgstr "Links"
-
-#: ../capplets/display/display-capplet.ui.h:5
-#: ../capplets/display/xrandr-capplet.c:440
-msgid "Monitor"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
 msgstr "Billschirm"
 
-#: ../capplets/display/display-capplet.ui.h:6
-#: ../capplets/display/xrandr-capplet.c:301
-#: ../capplets/display/xrandr-capplet.c:340
-msgid "Normal"
-msgstr "Normal"
-
-#: ../capplets/display/display-capplet.ui.h:7
-msgid "Off"
-msgstr "Ut"
-
-#: ../capplets/display/display-capplet.ui.h:8
-msgid "On"
-msgstr "An"
-
-#: ../capplets/display/display-capplet.ui.h:9
-msgid "Panel icon"
-msgstr "Balkensymbol"
-
-#: ../capplets/display/display-capplet.ui.h:10
-msgid "R_otation:"
-msgstr "R_otatschoon:"
-
-#: ../capplets/display/display-capplet.ui.h:11
-msgid "Re_fresh rate:"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:12
-#: ../capplets/display/xrandr-capplet.c:303
-msgid "Right"
-msgstr "Rechts"
-
-#: ../capplets/display/display-capplet.ui.h:13
-msgid "Upside-down"
-msgstr "Boven nah unnen"
-
-#: ../capplets/display/display-capplet.ui.h:14
-msgid "_Detect Monitors"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:15
-msgid "_Mirror screens"
-msgstr ""
-
-#: ../capplets/display/display-capplet.ui.h:16
-msgid "_Resolution:"
-msgstr "_Oplösens:"
-
-#: ../capplets/display/display-capplet.ui.h:17
-msgid "_Show displays in panel"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Display"
-msgstr "Billschirm"
-
-#: ../capplets/display/xrandr-capplet.c:304
-msgid "Upside Down"
-msgstr "Boven nah unnen"
-
-#: ../capplets/display/xrandr-capplet.c:346
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/xrandr-capplet.c:432
-#, c-format
-msgid "Monitor: %s"
-msgstr "Billschirm: %s"
-
-#: ../capplets/display/xrandr-capplet.c:511
-#, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../capplets/display/xrandr-capplet.c:1463
-msgid "Mirror Screens"
-msgstr "Spegelbillschirms"
-
-#: ../capplets/display/xrandr-capplet.c:1883
-msgid "Could not save the monitor configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1894
-msgid "Could not get session bus while applying display configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1936
-msgid "Could not detect displays"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:2151
-msgid "Could not get screen information"
-msgstr ""
-
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-msgid "Sound"
-msgstr "Ton"
-
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-#: ../libslab/bookmark-agent.c:1146
-msgid "Desktop"
-msgstr "Schrievdisk"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr "Nejer Kortsnied..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:119
-#: ../typing-break/drwright.c:431
-msgid "Disabled"
-msgstr "Deaktivert"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:200
-msgid "<Unknown Action>"
-msgstr "<Unbekannte Aktschoon>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:950
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1581
-msgid "Custom Shortcuts"
-msgstr "Anpasste Kortsnieds"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1092
-msgid "Error saving the new shortcut"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1171
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1201
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1207
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1215
-msgid "_Reassign"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1335
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1536
-msgid "Too many custom shortcuts"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1832
-msgid "Action"
-msgstr "Aktschoon"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1854
-msgid "Shortcut"
-msgstr "Kortsnied"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:2
-msgid "Custom Shortcut"
-msgstr "Anpasster Kortsnied"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:3
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Knöppboord Kortsnieds"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:4
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new key "
-"combination, or press backspace to clear."
-msgstr ""
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:205
-#: ../capplets/keyboard/gnome-keyboard-properties.c:210
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:215
-msgid "Start the page with the typing break settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:220
-msgid "Start the page with the accessibility settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:226
-msgid "- GNOME Keyboard Preferences"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:1
-msgid "Beep when _accessibility features are turned on or off"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:2
-msgid "Beep when a _modifier key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:3
-msgid "Beep when a _toggle key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:4
-msgid "Beep when a key is pr_essed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:5
-msgid "Beep when a key is reje_cted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:6
-msgid "Beep when key is _accepted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:7
-msgid "Beep when key is _rejected"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:8
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:4
-msgid "Bounce Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:9
-msgid "Flash _window titlebar"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:10
-msgid "Flash entire _screen"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:11
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:14
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:14
-msgid "General"
-msgstr "Allgemeen"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:12
-msgid "Keyboard Accessibility Audio Feedback"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:13
-msgid "Show _visual feedback for the alert sound"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:14
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:31
-msgid "Slow Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:15
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:32
-msgid "Sticky Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:16
-msgid "Visual cues for sounds"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:2
-msgid "All_ow postponing of breaks"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:3
-msgid "Audio _Feedback..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:5
-msgid "Check if breaks are allowed to be postponed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:6
-msgid "Cursor Blinking"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:7
-msgid "Cursor _blinks in text fields"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:8
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:4
-msgid "Cursor blinks speed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:9
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:5
-msgid "D_elay:"
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:10
-msgid "Disa_ble sticky keys if two keys are pressed together"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:11
-msgid "Duration of the break when typing is disallowed"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:12
-msgid "Duration of work before forcing a break"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:13
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:13
-msgid "Fast"
-msgstr "Fix"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:15
-msgid "Key presses _repeat when key is held down"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:16
-msgid "Keyboard Preferences"
-msgstr "Knöppboordinstellens"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:17
-msgid "Keyboard _model:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:18
-msgid "Layouts"
-msgstr "Utsehn"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:19
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:20
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:18
-msgid "Long"
-msgstr "lang"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:21
-msgid "Mouse Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:22
-msgid "Move _Down"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:23
-msgid "Move _Up"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:24
-msgid "New windows u_se active window's layout"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:25
-msgid "Repeat Keys"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:26
-msgid "Repeat keys speed"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:27
-msgid "Reset to De_faults"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:28
-msgid "S_peed:"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:29
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:26
-msgid "Short"
-msgstr "Koort"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:30
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:29
-msgid "Slow"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:33
-msgid "Typing Break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:34
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:36
-msgid "_Acceleration:"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:35
-msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:37
-msgid "_Break interval lasts:"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:38
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:37
-msgid "_Delay:"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:39
-msgid "_Ignore fast duplicate keypresses"
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:40
-msgid "_Lock screen to enforce typing break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:41
-msgid "_Only accept long keypresses"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:42
-msgid "_Options..."
-msgstr "_Optschoonen..."
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:43
-msgid "_Pointer can be controlled using the keypad"
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:44
-msgid "_Separate layout for each window"
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:45
-msgid "_Simulate simultaneous keypresses"
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:46
-msgid "_Speed:"
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:47
-msgid "_Type to test settings:"
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:48
-msgid "_Work interval lasts:"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:49
-msgid "minutes"
-msgstr "Minuuten"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:1
-msgid "By _country"
-msgstr "Nah _Land"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:2
-msgid "By _language"
-msgstr "Nah _Sprak"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:3
-msgid "Choose a Layout"
-msgstr "Utsehn wählen"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:4
-msgid "Preview:"
-msgstr "Utblick:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:5
-msgid "_Country:"
-msgstr "_Land:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:6
-msgid "_Language:"
-msgstr "_Sprak:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:7
-msgid "_Variants:"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:1
-msgid "Choose a Keyboard Model"
-msgstr "Wähl een Knöppboordutsehn"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:2
-msgid "_Models:"
-msgstr "_Modelle:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:3
-msgid "_Vendors:"
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-options-dialog.ui.h:1
-msgid "Keyboard Layout Options"
-msgstr "Knöppboordutsehnoptschoonen"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
-msgid "Unknown"
-msgstr "Unbekannt"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:240
+#: panels/windows/cc-windows-panel.ui:8
 msgid "Layout"
 msgstr "Utsehn"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:168
-msgid "Vendors"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:234
-msgid "Models"
-msgstr "Modelle"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:234
-#: ../capplets/network/gnome-network-properties.c:583
-msgid "Default"
-msgstr "Standard"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Knöppboord"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Knöppboordinstellens setten"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:89
-msgid "gesture|Move left"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:94
-msgid "gesture|Move right"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:99
-msgid "gesture|Move up"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:104
-msgid "gesture|Move down"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
 msgstr ""
 
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:109
-msgid "gesture|Disabled"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
 msgstr ""
 
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/mouse/gnome-mouse-properties.c:590
-msgid "Specify the name of the page to show (general|accessibility)"
-msgstr ""
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Ollenfinster"
 
-#: ../capplets/mouse/gnome-mouse-properties.c:595
-msgid "- GNOME Mouse Preferences"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:2
-msgid "Choose type of click _beforehand"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:3
-msgid "Choose type of click with mo_use gestures"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:6
-msgid "D_ouble click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:7
-msgid "D_rag click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:8
-msgid "Double-Click Timeout"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:9
-msgid "Drag and Drop"
-msgstr "Trecken un loslaten"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:10
-msgid "Dwell Click"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:11
-msgid "Enable _horizontal scrolling"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:12
-msgid "Enable mouse _clicks with touchpad"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:15
-msgid "High"
-msgstr "Hoch"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:17
-msgid "Locate Pointer"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:19
-msgid "Low"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:20
-msgid "Mouse Orientation"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:21
-msgid "Mouse Preferences"
-msgstr "Muusinstellens"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:22
-msgid "Pointer Speed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:23
-msgid "Scrolling"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:24
-msgid "Seco_ndary click:"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
 msgstr "Twe_jter Klick:"
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:25
-msgid "Sh_ow position of pointer when the Control key is pressed"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Finsters"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:27
-msgid "Show click type _window"
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:28
-msgid "Simulated Secondary Click"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:31
-msgid "Thr_eshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:32
-msgid ""
-"To test your double-click settings, try to double-click on the light bulb."
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:33
-msgid "Touchpad"
-msgstr "Touchpad"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:34
-msgid "Two-_finger scrolling"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:35
-msgid "You can also use the Dwell Click panel applet to choose the click type."
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:38
-msgid "_Disable touchpad while typing"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:39
-msgid "_Disabled"
-msgstr "_Deaktivert"
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:40
-msgid "_Edge scrolling"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:41
-msgid "_Initiate click when stopping pointer movement"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:42
-msgid "_Left-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:43
-msgid "_Motion threshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:44
-msgid "_Right-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:45
-msgid "_Sensitivity:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:46
-msgid "_Single click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:47
-msgid "_Timeout:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.ui.h:48
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr ""
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Muus"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.c:701
-#: ../capplets/network/gnome-network-properties.c:852
-msgid "New Location..."
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.c:818
-msgid "Location already exists"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Netwark-Proxy"
-
-#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "Netwark-Proxy-Instellens setten"
-
-#: ../capplets/network/gnome-network-properties.ui.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:2
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:3
-msgid "<b>_Manual proxy configuration</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:4
-msgid "<b>_Use authentication</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:5
-msgid "Autoconfiguration _URL:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:6
-msgid "C_reate"
-msgstr "E_rstellen"
-
-#: ../capplets/network/gnome-network-properties.ui.h:7
-msgid "Create New Location"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:8
-msgid "HTTP Proxy Details"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:9
-msgid "H_TTP proxy:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:10
-msgid "Ignore Host List"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:11
-msgid "Ignored Hosts"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:12
-msgid "Location:"
-msgstr "Ort:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:13
-msgid "Network Proxy Preferences"
-msgstr "Netwark-Proxy-Instellens"
-
-#: ../capplets/network/gnome-network-properties.ui.h:14
-msgid "Port:"
-msgstr "Port:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:15
-msgid "Proxy Configuration"
-msgstr "Proxy-Konfiguratschoon"
-
-#: ../capplets/network/gnome-network-properties.ui.h:16
-msgid "S_ocks host:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:17
-msgid "The location already exists."
-msgstr ""
-
-#: ../capplets/network/gnome-network-properties.ui.h:18
-msgid "U_sername:"
-msgstr "B_rukernaam:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:19
-msgid "_Delete Location"
-msgstr "_Ort löschen"
-
-#: ../capplets/network/gnome-network-properties.ui.h:20
-msgid "_Details"
-msgstr "_Details"
-
-#: ../capplets/network/gnome-network-properties.ui.h:21
-msgid "_FTP proxy:"
-msgstr "_FTP Proxy:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:22
-msgid "_Location name:"
-msgstr "_Ortnaam:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:23
-msgid "_Password:"
-msgstr "_Passwoord:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:24
-msgid "_Secure HTTP proxy:"
-msgstr "_Seker HTTP Proxy:"
-
-#: ../capplets/network/gnome-network-properties.ui.h:25
-msgid "_Use the same proxy for all protocols"
-msgstr "_De sülvigen Proxy för all Protokolls bruken"
-
-#: ../capplets/windows/gnome-window-properties.c:344
-msgid "Cannot start the preferences application for your window manager"
-msgstr ""
-
-#. translators: this is the Control key
-#: ../capplets/windows/gnome-window-properties.c:608
-msgid "C_ontrol"
-msgstr "K_ontroll"
-
-#: ../capplets/windows/gnome-window-properties.c:613
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:619
-msgid "H_yper"
-msgstr "H_yper"
-
-#: ../capplets/windows/gnome-window-properties.c:626
-msgid "S_uper (or \"Windows logo\")"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:633
-msgid "_Meta"
-msgstr "_Meta"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:1
-msgid "Movement Key"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:2
-msgid "Titlebar Action"
-msgstr "Titelbalkenaktschoon"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:3
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:4
-msgid "Window Preferences"
-msgstr "Finsterinstellens"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:5
-msgid "Window Selection"
-msgstr "Finsterwähler"
-
-#: ../capplets/windows/gnome-window-properties.ui.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:7
-msgid "_Interval before raising:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:8
-msgid "_Raise selected windows after an interval"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.ui.h:10
-msgid "seconds"
-msgstr "Sekunnen"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr ""
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Twe_jter Klick:"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
 msgid "Windows"
 msgstr "Finsters"
 
-#: ../libwindow-settings/gnome-wm-manager.c:316
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Togangelikheit"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Anskrivt"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Details"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Netwark-Proxy"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Netwark Servers"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "_Details"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:404
-msgid "Maximize"
-msgstr "Vergrötern"
-
-#: ../libwindow-settings/metacity-window-manager.c:405
-msgid "Maximize Vertically"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:406
-msgid "Maximize Horizontally"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:407
-msgid "Minimize"
-msgstr "Lütter maken"
-
-#: ../libwindow-settings/metacity-window-manager.c:408
-msgid "Roll up"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:409
-msgid "None"
-msgstr "Keen"
-
-#: ../shell/control-center.c:49
-#, c-format
-msgid "key not found [%s]\n"
-msgstr ""
-
-#: ../shell/control-center.c:143
-msgid "Hide on start (useful to preload the shell)"
-msgstr ""
-
-#: ../shell/control-center.c:182
-msgid "Filter"
-msgstr "Filter"
-
-#: ../shell/control-center.c:182
-msgid "Groups"
-msgstr "Gruppen"
-
-#: ../shell/control-center.c:182
-msgid "Common Tasks"
-msgstr ""
-
-#: ../shell/control-center.c:185 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Kontrollzentrum"
-
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:5
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:8
-msgid ""
-"Indicates whether to close the shell when an add or remove action is "
-"performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:9
-msgid ""
-"Indicates whether to close the shell when an upgrade or uninstall action is "
-"performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:11
-msgid ""
-"The task name to be displayed in the control-center followed by a \";\" "
-"separator then the filename of an associated .desktop file to launch for "
-"that task."
-msgstr ""
-
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
-msgid ""
-"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
-"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:14
-msgid ""
-"if true, the control-center will close when a \"Common Task\" is activated."
-msgstr ""
-
-#: ../shell/gnomecc.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "GNOME-Konfiguratschoonswarktügg"
-
-#: ../typing-break/drw-break-window.c:194
-msgid "_Postpone Break"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:250
-msgid "Take a break!"
-msgstr "Tied för'n Tee?"
-
-#: ../typing-break/drwright.c:116
-msgid "_Take a Break"
-msgstr "_Tied för'n Tee?"
-
-#: ../typing-break/drwright.c:440
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../typing-break/drwright.c:444
+#: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
-msgid "Less than one minute until the next break"
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
 
-#: ../typing-break/drwright.c:526
-#, c-format
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Unnerwegs:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Netwark-Proxy"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Netwark-Proxy"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Details"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Netwark-Proxy"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "Netwark Servers"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Tosammenstellens ännern"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr ""
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
 msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
 
-#: ../typing-break/drwright.c:543
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "Schrieven vun Richard Hult <richard@imendio.com>"
-
-#: ../typing-break/drwright.c:544
-msgid "Eye candy added by Anders Carlsson"
-msgstr ""
-
-#: ../typing-break/drwright.c:553
-msgid "A computer break reminder."
-msgstr ""
-
-#: ../typing-break/drwright.c:555
-msgid "translator-credits"
-msgstr "Nils-Christoph Fiedler <fiedler@medienkompanie.de>"
-
-#: ../typing-break/main.c:61
-msgid "Enable debugging code"
-msgstr ""
-
-#: ../typing-break/main.c:63
-msgid "Don't check whether the notification area exists"
-msgstr ""
-
-#: ../typing-break/main.c:89
-msgid "Typing Monitor"
-msgstr ""
-
-#: ../typing-break/main.c:105
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:5
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr ""
-
-#: ../font-viewer/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr ""
-
-#: ../font-viewer/font-view.c:289
-msgid "Name:"
-msgstr "Naam:"
-
-#: ../font-viewer/font-view.c:292
-msgid "Style:"
-msgstr "Stil:"
-
-#: ../font-viewer/font-view.c:305
-msgid "Type:"
-msgstr "Typ:"
-
-#: ../font-viewer/font-view.c:309
-msgid "Size:"
-msgstr "Gröte:"
-
-#: ../font-viewer/font-view.c:353 ../font-viewer/font-view.c:366
-msgid "Version:"
-msgstr "Verschoon:"
-
-#: ../font-viewer/font-view.c:357 ../font-viewer/font-view.c:368
-msgid "Copyright:"
-msgstr "Koperschod:"
-
-#: ../font-viewer/font-view.c:361
-msgid "Description:"
-msgstr "Beschrievens:"
-
-#: ../font-viewer/font-view.c:441
-msgid "Installed"
-msgstr "Installert"
-
-#: ../font-viewer/font-view.c:444
-msgid "Install Failed"
-msgstr "Installatschoon fehlslagen"
-
-#: ../font-viewer/font-view.c:516
-#, c-format
-msgid "usage: %s fontfile\n"
-msgstr ""
-
-#: ../font-viewer/font-view.c:591
-msgid "I_nstall Font"
-msgstr "Schriftart _installeren"
-
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
-msgid "Font Viewer"
-msgstr "Schriftartwieser"
-
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
-msgid "Preview fonts"
-msgstr "Schriftartutblick"
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "Text to thumbnail (default: Aa)"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "TEXT"
-msgstr "TEXT"
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "Font size (default: 64)"
-msgstr "Schriftartgröte (Standard: 64)"
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "SIZE"
-msgstr "SIZE"
-
-#: ../font-viewer/font-thumbnailer.c:249
-msgid "FONT-FILE OUTPUT-FILE"
-msgstr "FONT-FILE OUTPUT-FILE"
-
-#: ../font-viewer/font-thumbnailer.c:268
-#, c-format
-msgid "Error parsing arguments: %s\n"
-msgstr ""
-
-#: ../libslab/app-shell.c:754
-#, c-format
-msgid "Your filter \"%s\" does not match any items."
-msgstr ""
-
-#: ../libslab/app-shell.c:756
-msgid "No matches found."
-msgstr "Nix funnen, wat passt."
-
-#: ../libslab/app-shell.c:905
-msgid "Other"
-msgstr "Annere"
-
-#. make start action
-#: ../libslab/application-tile.c:374
-#, c-format
-msgid "Start %s"
-msgstr "Starte %s"
-
-#: ../libslab/application-tile.c:395
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Hölp"
 
-#: ../libslab/application-tile.c:442
-msgid "Upgrade"
-msgstr "Upgrade"
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Allgemeen"
 
-#: ../libslab/application-tile.c:457
-msgid "Uninstall"
-msgstr "Deinstalleren"
-
-#: ../libslab/application-tile.c:784 ../libslab/document-tile.c:721
-msgid "Remove from Favorites"
-msgstr "Ut Leevsten löschen"
-
-#: ../libslab/application-tile.c:786 ../libslab/document-tile.c:723
-msgid "Add to Favorites"
-msgstr "To Leevsten hentofögen"
-
-#: ../libslab/application-tile.c:871
-msgid "Remove from Startup Programs"
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
 msgstr ""
 
-#: ../libslab/application-tile.c:873
-msgid "Add to Startup Programs"
-msgstr "To Startprogramme hentofögen"
-
-#: ../libslab/bookmark-agent.c:1077
-msgid "New Spreadsheet"
-msgstr ""
-
-#: ../libslab/bookmark-agent.c:1082
-msgid "New Document"
-msgstr "Nejes Dokument"
-
-#: ../libslab/bookmark-agent.c:1140
-msgid "Documents"
-msgstr "Dokumente"
-
-#: ../libslab/bookmark-agent.c:1153
-msgid "File System"
-msgstr "Dateisystem"
-
-#: ../libslab/bookmark-agent.c:1157
-msgid "Network Servers"
-msgstr "Netwark Servers"
-
-#: ../libslab/bookmark-agent.c:1186
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Search"
 msgstr "Sök"
 
-#. make open with default action
-#: ../libslab/directory-tile.c:171
-#, c-format
-msgid "<b>Open</b>"
-msgstr "<b>Opmaken</b>"
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Balkensymbol"
 
-#. make rename action
-#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:234
-msgid "Rename..."
-msgstr "Annern Naam geven..."
-
-#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
-#: ../libslab/document-tile.c:248 ../libslab/document-tile.c:257
-msgid "Send To..."
-msgstr "Sennen an..."
-
-#. make move to trash action
-#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:283
-msgid "Move to Trash"
-msgstr "In'n Papierkörv verschuven"
-
-#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
-#: ../libslab/document-tile.c:293 ../libslab/document-tile.c:837
-msgid "Delete"
-msgstr "Löschen"
-
-#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:985
-#, c-format
-msgid "Are you sure you want to permanently delete \"%s\"?"
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
 msgstr ""
 
-#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:986
-msgid "If you delete an item, it is permanently lost."
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
 msgstr ""
 
-#: ../libslab/document-tile.c:193
-#, c-format
-msgid "Open with \"%s\""
-msgstr "Opmaken mit \"%s\""
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "Instellens"
 
-#: ../libslab/document-tile.c:207
-msgid "Open with Default Application"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
 msgstr ""
 
-#: ../libslab/document-tile.c:218
-msgid "Open in File Manager"
-msgstr "In Dateioppasser opmaken"
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
 
-#: ../libslab/document-tile.c:617
-msgid "?"
-msgstr "?"
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
 
-#: ../libslab/document-tile.c:624
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
 
-#: ../libslab/document-tile.c:632
-msgid "Today %l:%M %p"
-msgstr "Vandag %l:%M %p"
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
 
-#: ../libslab/document-tile.c:642
-msgid "Yesterday %l:%M %p"
-msgstr "Güstern %l:%M %p"
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
 
-#: ../libslab/document-tile.c:654
-msgid "%a %l:%M %p"
-msgstr "%a %l:%M %p"
-
-#: ../libslab/document-tile.c:662
-msgid "%b %d %l:%M %p"
-msgstr "%b %d %l:%M %p"
-
-#: ../libslab/document-tile.c:664
-msgid "%b %d %Y"
-msgstr "%b %d %Y"
-
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
-msgstr "Nu finnen"
-
-#: ../libslab/system-tile.c:127
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
-msgid "<b>Open %s</b>"
-msgstr "<b>%s opmaken</b>"
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../libslab/system-tile.c:140
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
-msgid "Remove from System Items"
-msgstr "Ut Systemelementen löschen"
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
 
-msgid "Show help options"
-msgstr "Hölpoptschoonen opwiesen"
+#~ msgid "Current network location"
+#~ msgstr "Aktueller Netwarkort"
 
-#~ msgid "Fill screen"
-#~ msgstr "Billschirm full maken"
+#~ msgid "More backgrounds URL"
+#~ msgstr "Mehr Achtergründe URL"
 
-#~ msgid "Edit"
-#~ msgstr "Bewarken"
+#~ msgid "More themes URL"
+#~ msgstr "Mehr Themen URL"
+
+#~ msgid "The type of alert"
+#~ msgstr "Alarmtyp"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Alarmknöppe im Alarmdialog"
+
+#~ msgid "Show more _details"
+#~ msgstr "Mehr _Details opwiesen"
+
+#~ msgid "No Image"
+#~ msgstr "Keen Bill"
+
+#~ msgid "Images"
+#~ msgstr "Billers"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Nich möglich, Anskrivtenbook optomaken"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "An_skrivt"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "H_ölper:"
+
+#~ msgid "About Me"
+#~ msgstr "Över mik"
+
+#~ msgid "C_ity:"
+#~ msgstr "St_adt:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "F_irma:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Passwoo_rd ännern..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "St_adt:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "Lan_d:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "_Land:"
+
+#~ msgid "Email"
+#~ msgstr "E-Post"
+
+#~ msgid "Hom_e:"
+#~ msgstr "Heima_t:"
+
+#~ msgid "Home"
+#~ msgstr "Heimat"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "Foortsnahrichtendeenst"
+
+#~ msgid "Job"
+#~ msgstr "Arbeid"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _box:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. box:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Persönliche Informatschoonen"
+
+#~ msgid "Select your photo"
+#~ msgstr "Wähl dien Bill ut"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Land/Re_gion:"
+
+#~ msgid "Telephone"
+#~ msgstr "Klönkassen"
+
+#~ msgid "Web"
+#~ msgstr "Net"
+
+#~ msgid "Web _log:"
+#~ msgstr "Dageboo_k:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "Arbei_d:"
+
+#~ msgid "Work"
+#~ msgstr "Arbeid"
+
+#~ msgid "Work _fax:"
+#~ msgstr "Arbeid _FAX:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "Zip/_Postleittaal:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Hemsiet:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Heimat:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Oppasser:"
+
+#~ msgid "_Profession:"
+#~ msgstr "_Beroop:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_Land/Region:"
+
+#~ msgid "_Title:"
+#~ msgstr "_Titel:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Arbeid:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "_Zip/Postleittaal:"
+
+#~ msgid "An internal error occured"
+#~ msgstr "Een interner Fehler is optreten"
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "Systemfehler: %s."
+
+#~ msgid "The password is too simple."
+#~ msgstr "Dat Passwoord is to eenfach."
+
+#~ msgid "A system error has occurred"
+#~ msgstr "Een Systemfehler is optreten"
+
+#~ msgid "Checking password..."
+#~ msgstr "Kiek mi dat Passwoord an..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "Pa_sswoord ännern"
+
+#~ msgid "Change your password"
+#~ msgstr "Dien Passwoord ännern"
+
+#~ msgid "page"
+#~ msgstr "Siet"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid "Install"
+#~ msgstr "Installeren"
+
+#~ msgid "Apply Background"
+#~ msgstr "Düssem Achtergrund tostimmen"
+
+#~ msgid "Custom"
+#~ msgstr "Anpasst"
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "Utsehninstellens"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "A_npassen..."
+
+#~ msgid "Center"
+#~ msgstr "Inne Midde"
+
+#~ msgid "Customize Theme"
+#~ msgstr "Thema anpassen"
+
+#~ msgid "D_etails..."
+#~ msgstr "D_etails..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Schrievdis_kschriftart:"
+
+#~ msgid "Fonts"
+#~ msgstr "Schriftart"
+
+#~ msgid "Hinting"
+#~ msgstr "Wiesen"
+
+#~ msgid "Horizontal gradient"
+#~ msgstr "Horizontaler Verlööp"
+
+#~ msgid "Icons"
+#~ msgstr "Symbole"
+
+#~ msgid "Icons only"
+#~ msgstr "Just Symbole"
+
+#~ msgid "N_one"
+#~ msgstr "K_eene"
+
+#~ msgid "R_esolution:"
+#~ msgstr "_Oplösens:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "Thema spieker as..."
+
+#~ msgid "Save _As..."
+#~ msgstr "Spiekern _as..."
+
+#~ msgid "Save _background image"
+#~ msgstr "Achter_grundbill spiekern"
+
+#~ msgid "Solid color"
+#~ msgstr "Solide Klöör"
+
+#~ msgid "Stretch"
+#~ msgstr "Wieder maken"
+
+#~ msgid "Text"
+#~ msgstr "Text"
+
+#~ msgid "Text below items"
+#~ msgstr "Text unner Elemente"
+
+#~ msgid "Text beside items"
+#~ msgstr "Text neben de Elemente"
+
+#~ msgid "Text only"
+#~ msgstr "Just text"
+
+#~ msgid "Theme"
+#~ msgstr "Thema"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "Vertical gradient"
+#~ msgstr "Vertikaler Verlööp"
+
+#~ msgid "Window Border"
+#~ msgstr "Finsterkant"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "B_eschrieven:"
+
+#~ msgid "_Document font:"
+#~ msgstr "Dokumentschriftart:"
+
+#~ msgid "_Install..."
+#~ msgstr "_Installeren..."
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Selected items:"
+#~ msgstr "_Utwählte Elemente:"
+
+#~ msgid "_Size:"
+#~ msgstr "_Gröte:"
+
+#~ msgid "_Style:"
+#~ msgstr "_Stil:"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "_Lütte Henwiese:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Finstertitelschriftart:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Finsters:"
+
+#~ msgid "dots per inch"
+#~ msgstr "Punkt per Inch"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Schrievdiskutsehn anpassen"
+
+#~ msgid "Theme Installer"
+#~ msgstr "Themen installerer"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "GNOME-Themen Pack"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Keen Schrievdiskachtergrund"
+
+#~ msgid "Image"
+#~ msgstr "Bill"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "Pixel"
+#~ msgstr[1] "Pixels"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "Künn dat Thema nich installeren"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Aktuelles Thema behollen"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Nejem Thema tostimmen"
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME-Thema %s akerat installert"
+
+#~ msgid "Select Theme"
+#~ msgstr "Thema wählen"
+
+#~ msgid "Theme Packages"
+#~ msgstr "Themenpacks"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_Överschrieven"
+
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "Thema künn nich löscht werrn"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Kopere Datei: %u of %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "Kopere '%s'"
+
+#~ msgid "To URI"
+#~ msgstr "To URI"
+
+#~ msgid "Total URIs"
+#~ msgstr "All URIs"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Totale Taal vun URIs"
+
+#~ msgid "_Skip"
+#~ msgstr "_Överhüppen"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "_Allens överschrieven"
+
+#~ msgid "Key"
+#~ msgstr "Slötel"
+
+#~ msgid "Callback"
+#~ msgstr "Torüggröpen"
+
+#~ msgid "Please select an image."
+#~ msgstr "Bidde een Bill utwählen."
+
+#~ msgid "White Pointer"
+#~ msgstr "Witter Muuswieser"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "Leevste Programme"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "Visueller Hölper"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Or_der:"
+
+#~ msgid "Image Viewer"
+#~ msgstr "Billopwieser"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "Foortsnahrichtenschriever"
+
+#~ msgid "Internet"
+#~ msgstr "Innernet"
+
+#~ msgid "Mail Reader"
+#~ msgstr "Postleser"
+
+#~ msgid "Mobility"
+#~ msgstr "Unnerwegs allens dorbi"
+
+#~ msgid "Multimedia"
+#~ msgstr "Multimedia"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Verknüppen in nejer _Registerkoort opmaken"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Verknüppen in nejem _Finster opmaken"
+
+#~ msgid "Run at st_art"
+#~ msgstr "Bi'm Start lööpen laten"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Im T_erminal lööpen laten"
+
+#~ msgid "Text Editor"
+#~ msgstr "Textbewarker"
+
+#~ msgid "Video Player"
+#~ msgstr "Filmspeeler"
+
+#~ msgid "Web Browser"
+#~ msgstr "Netkieker"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee Tonspeeler"
+
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian Sensible Browser"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian Terminal Emulator"
+
+#~ msgid "ETerm"
+#~ msgstr "Debian Terminal Emulator"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution Postleser"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus mit Vergröterer"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape Post"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
+
+#~ msgid "Listen"
+#~ msgstr "Tohören"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Post"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Kommunikator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox Tonspeeler"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey Post"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Standard XTerminal"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem Filmspeeler"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Include _panel"
+#~ msgstr "_Balken insluten"
+
+#~ msgid "Off"
+#~ msgstr "Ut"
+
+#~ msgid "On"
+#~ msgstr "An"
+
+#~ msgid "Upside-down"
+#~ msgstr "Boven nah unnen"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#, c-format
+#~ msgid "Monitor: %s"
+#~ msgstr "Billschirm: %s"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "New shortcut..."
+#~ msgstr "Nejer Kortsnied..."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Unbekannte Aktschoon>"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "Anpasster Kortsnied"
+
+#~ msgid "Fast"
+#~ msgstr "Fix"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Knöppboordinstellens"
+
+#~ msgid "Layouts"
+#~ msgstr "Utsehn"
+
+#~ msgid "By _country"
+#~ msgstr "Nah _Land"
+
+#~ msgid "By _language"
+#~ msgstr "Nah _Sprak"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Utsehn wählen"
+
+#~ msgid "Preview:"
+#~ msgstr "Utblick:"
+
+#~ msgid "_Country:"
+#~ msgstr "_Land:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Wähl een Knöppboordutsehn"
+
+#~ msgid "_Models:"
+#~ msgstr "_Modelle:"
+
+#~ msgid "Unknown"
+#~ msgstr "Unbekannt"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Knöppboordinstellens setten"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "Trecken un loslaten"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Muusinstellens"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Netwark-Proxy-Instellens setten"
+
+#~ msgid "C_reate"
+#~ msgstr "E_rstellen"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Netwark-Proxy-Instellens"
+
+#~ msgid "Port:"
+#~ msgstr "Port:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Seker HTTP Proxy:"
+
+#~ msgid "C_ontrol"
+#~ msgstr "K_ontroll"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "Titlebar Action"
+#~ msgstr "Titelbalkenaktschoon"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Finsterinstellens"
+
+#~ msgid "Window Selection"
+#~ msgstr "Finsterwähler"
+
+#~ msgid "Maximize"
+#~ msgstr "Vergrötern"
+
+#~ msgid "Minimize"
+#~ msgstr "Lütter maken"
+
+#~ msgid "Groups"
+#~ msgstr "Gruppen"
+
+#~ msgid "Control Center"
+#~ msgstr "Kontrollzentrum"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME-Konfiguratschoonswarktügg"
+
+#~ msgid "Take a break!"
+#~ msgstr "Tied för'n Tee?"
+
+#~ msgid "_Take a Break"
+#~ msgstr "_Tied för'n Tee?"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Schrieven vun Richard Hult <richard@imendio.com>"
+
+#~ msgid "translator-credits"
+#~ msgstr "Nils-Christoph Fiedler <fiedler@medienkompanie.de>"
+
+#~ msgid "Size:"
+#~ msgstr "Gröte:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Koperschod:"
+
+#~ msgid "Description:"
+#~ msgstr "Beschrievens:"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "Schriftart _installeren"
+
+#~ msgid "Font Viewer"
+#~ msgstr "Schriftartwieser"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Schriftartgröte (Standard: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "Upgrade"
+#~ msgstr "Upgrade"
+
+#~ msgid "Uninstall"
+#~ msgstr "Deinstalleren"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "To Leevsten hentofögen"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "To Startprogramme hentofögen"
+
+#~ msgid "New Document"
+#~ msgstr "Nejes Dokument"
+
+#~ msgid "Documents"
+#~ msgstr "Dokumente"
+
+#~ msgid "Send To..."
+#~ msgstr "Sennen an..."
+
+#~ msgid "Delete"
+#~ msgstr "Löschen"
+
+#, c-format
+#~ msgid "Open with \"%s\""
+#~ msgstr "Opmaken mit \"%s\""
+
+#~ msgid "Open in File Manager"
+#~ msgstr "In Dateioppasser opmaken"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Vandag %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "Güstern %l:%M %p"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%b %d %l:%M %p"
+
+#~ msgid "%b %d %Y"
+#~ msgstr "%b %d %Y"
+
+#~ msgid "Find Now"
+#~ msgstr "Nu finnen"
+
+#, c-format
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s opmaken</b>"
+
+#, c-format
+#~ msgid "Remove from System Items"
+#~ msgstr "Ut Systemelementen löschen"
 
 #~ msgid "Interface"
 #~ msgstr "Bovensied"
@@ -3460,6 +6013,3 @@ msgstr "Hölpoptschoonen opwiesen"
 #, fuzzy
 #~ msgid "Selected _layouts:"
 #~ msgstr "_Utwählte Utsehn:"
-
-#~ msgid "Preview"
-#~ msgstr "Utblick"

--- a/po/nds.po~
+++ b/po/nds.po~
@@ -1,0 +1,3465 @@
+# Low German translation for gnome-control-center.
+# Copyright (C) 2009 gnome-control-center's COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center package.
+# Nils-Christoph Fiedler <fiedler@medienkompanie.de>, 2009.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center gnome-2-28\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&component=general\n"
+"POT-Creation-Date: 2009-11-22 16:05+0000\n"
+"PO-Revision-Date: 2009-11-23 00:53+0100\n"
+"Last-Translator: Nils-Christoph Fiedler <fiedler@medienkompanie.de>\n"
+"Language-Team: Low German <nds-lowgerman@lists.sourceforge.net>\n"
+"Language: nds\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+#: ../gnome-control-center.schemas.in.h:1
+msgid "Current network location"
+msgstr "Aktueller Netwarkort"
+
+#: ../gnome-control-center.schemas.in.h:2
+msgid "More backgrounds URL"
+msgstr "Mehr Achtergründe URL"
+
+#: ../gnome-control-center.schemas.in.h:3
+msgid "More themes URL"
+msgstr "Mehr Themen URL"
+
+#: ../gnome-control-center.schemas.in.h:4
+msgid ""
+"Set this to your current location name. This is used to determine the "
+"appropriate network proxy configuration."
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:5
+msgid ""
+"URL for where to get more desktop backgrounds. If set to an empty string the "
+"link will not appear."
+msgstr ""
+
+#: ../gnome-control-center.schemas.in.h:6
+msgid ""
+"URL for where to get more desktop themes. If set to an empty string the link "
+"will not appear."
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "Alarmtyp"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "Alarmtyp"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "Alarmknöppe"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "Alarmknöppe im Alarmdialog"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "Mehr _Details opwiesen"
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Place your left thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Swipe your left thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Place your left index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Swipe your left index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Place your left middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Swipe your left middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Place your left ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Swipe your left ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Place your left little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Swipe your left little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Place your right thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Swipe your right thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Place your right index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Swipe your right index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Place your right middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Swipe your right middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Place your right ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Swipe your right ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Place your right little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Swipe your right little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:72
+#: ../capplets/about-me/fingerprint-strings.h:98
+msgid "Place your finger on the reader again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:74
+#: ../capplets/about-me/fingerprint-strings.h:100
+msgid "Swipe your finger again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:77
+#: ../capplets/about-me/fingerprint-strings.h:103
+msgid "Swipe was too short, try again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:79
+#: ../capplets/about-me/fingerprint-strings.h:105
+msgid "Your finger was not centered, try swiping your finger again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:81
+#: ../capplets/about-me/fingerprint-strings.h:107
+msgid "Remove your finger, and try swiping your finger again"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:716
+msgid "Select Image"
+msgstr "Bill utwählen"
+
+#: ../capplets/about-me/gnome-about-me.c:718
+msgid "No Image"
+msgstr "Keen Bill"
+
+#: ../capplets/about-me/gnome-about-me.c:746
+#: ../capplets/appearance/appearance-desktop.c:654
+msgid "Images"
+msgstr "Billers"
+
+#: ../capplets/about-me/gnome-about-me.c:750
+#: ../capplets/appearance/theme-installer.c:763
+msgid "All Files"
+msgstr "All Dateien"
+
+#: ../capplets/about-me/gnome-about-me.c:890
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:911
+msgid "Unable to open address book"
+msgstr "Nich möglich, Anskrivtenbook optomaken"
+
+#: ../capplets/about-me/gnome-about-me.c:934
+#, c-format
+msgid "About %s"
+msgstr "Över %s"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:1
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:2
+msgid "A_ddress:"
+msgstr "An_skrivt"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:3
+msgid "A_ssistant:"
+msgstr "H_ölper:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:4
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+msgid "About Me"
+msgstr "Över mik"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:5
+msgid "Address"
+msgstr "Anskrivt"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:6
+msgid "C_ity:"
+msgstr "St_adt:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:7
+msgid "C_ompany:"
+msgstr "F_irma:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:8
+msgid "Cale_ndar:"
+msgstr "Kale_nner:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:9
+msgid "Change Passwo_rd..."
+msgstr "Passwoo_rd ännern..."
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:10
+msgid "Ci_ty:"
+msgstr "St_adt:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:11
+msgid "Co_untry:"
+msgstr "Lan_d:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:12
+msgid "Contact"
+msgstr "Kontakt"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:13
+msgid "Cou_ntry:"
+msgstr "_Land:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:14
+msgid "Disable _Fingerprint Login..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:15
+msgid "Email"
+msgstr "E-Post"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:16
+msgid "Enable _Fingerprint Login..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:17
+msgid "Full Name"
+msgstr "Vor- un Tonaam"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:18
+msgid "Hom_e:"
+msgstr "Heima_t:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:19
+#: ../libslab/bookmark-agent.c:1135
+msgid "Home"
+msgstr "Heimat"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:20
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:21
+msgid "Instant Messaging"
+msgstr "Foortsnahrichtendeenst"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:22
+msgid "Job"
+msgstr "Arbeid"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:23
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:24
+msgid "P.O. _box:"
+msgstr "P.O. _box:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:25
+msgid "P._O. box:"
+msgstr "P._O. box:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:26
+msgid "Personal Info"
+msgstr "Persönliche Informatschoonen"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:27
+msgid "Select your photo"
+msgstr "Wähl dien Bill ut"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:28
+msgid "State/Pro_vince:"
+msgstr "Land/Re_gion:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:29
+msgid "Telephone"
+msgstr "Klönkassen"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:30
+msgid "User name:"
+msgstr "Brukernaam:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:31
+msgid "Web"
+msgstr "Net"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:32
+msgid "Web _log:"
+msgstr "Dageboo_k:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:33
+msgid "Wor_k:"
+msgstr "Arbei_d:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:34
+msgid "Work"
+msgstr "Arbeid"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:35
+msgid "Work _fax:"
+msgstr "Arbeid _FAX:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:36
+msgid "Zip/_Postal code:"
+msgstr "Zip/_Postleittaal:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:37
+msgid "_Address:"
+msgstr "_Anskrivt:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:38
+msgid "_Department:"
+msgstr "_Kontor:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:39
+msgid "_Groupwise:"
+msgstr "_Groupwise:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:40
+msgid "_Home page:"
+msgstr "_Hemsiet:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:41
+msgid "_Home:"
+msgstr "_Heimat:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:42
+msgid "_Jabber:"
+msgstr "_Jabber:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:43
+msgid "_Manager:"
+msgstr "_Oppasser:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:44
+msgid "_Mobile:"
+msgstr "_Unnerwegs:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:45
+msgid "_Profession:"
+msgstr "_Beroop:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:46
+msgid "_State/Province:"
+msgstr "_Land/Region:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:47
+msgid "_Title:"
+msgstr "_Titel:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:48
+msgid "_Work:"
+msgstr "_Arbeid:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:49
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me-dialog.ui.h:50
+msgid "_Zip/Postal code:"
+msgstr "_Zip/Postleittaal:"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "Giv dien persönliche Informatschoonen in"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:97
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
+msgid "The device is already in use."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
+msgid "An internal error occured"
+msgstr "Een interner Fehler is optreten"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:218
+msgid "Delete registered fingerprints?"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:221
+msgid "_Delete Fingerprints"
+msgstr "Fingeravdrücken_s löschen"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:228
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:342
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:1
+msgid "Done!"
+msgstr "Fertig!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
+#, c-format
+msgid "Could not access '%s' device"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:459
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:506
+msgid "Could not access any fingerprint readers"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:507
+msgid "Please contact your system administrator for help."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:537
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:2
+msgid "Enable Fingerprint Login"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:567
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:576
+msgid "Swipe finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:578
+msgid "Place finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:3
+msgid "Left index finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:5
+msgid "Left middle finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:6
+msgid "Left ring finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:7
+msgid "Left thumb"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:8
+msgid "Other finger: "
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:9
+msgid "Right index finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:10
+msgid "Right little finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:11
+msgid "Right middle finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:12
+msgid "Right ring finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:13
+msgid "Right thumb"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:14
+msgid "Select finger"
+msgstr "Finger wählen"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.ui.h:15
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:161
+msgid "Child exited unexpectedly"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:296
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:309
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:408
+msgid "Authenticated!"
+msgstr ""
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:474
+#: ../capplets/about-me/gnome-about-me-password.c:550
+msgid ""
+"Your password has been changed since you initially authenticated! Please re-"
+"authenticate."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:476
+msgid "That password was incorrect."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:523
+msgid "Your password has been changed."
+msgstr ""
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:533
+#, c-format
+msgid "System error: %s."
+msgstr "Systemfehler: %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:536
+msgid "The password is too short."
+msgstr "Dat Passwoord is to kort."
+
+#: ../capplets/about-me/gnome-about-me-password.c:539
+msgid "The password is too simple."
+msgstr "Dat Passwoord is to eenfach."
+
+#: ../capplets/about-me/gnome-about-me-password.c:542
+msgid "The old and new passwords are too similar."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:544
+msgid "The new password must contain numeric or special character(s)."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:547
+msgid "The old and new passwords are the same."
+msgstr ""
+
+#. translators: Unable to launch <program>: <error message>
+#: ../capplets/about-me/gnome-about-me-password.c:818
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:822
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:823
+msgid "A system error has occurred"
+msgstr "Een Systemfehler is optreten"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:843
+msgid "Checking password..."
+msgstr "Kiek mi dat Passwoord an..."
+
+#: ../capplets/about-me/gnome-about-me-password.c:930
+msgid "Click <b>Change password</b> to change your password."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:933
+msgid "Please type your password in the <b>New password</b> field."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:936
+#: ../capplets/about-me/gnome-about-me-password.ui.h:5
+msgid ""
+"Please type your password again in the <b>Retype new password</b> field."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:939
+msgid "The two passwords are not equal."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:1
+msgid "Change pa_ssword"
+msgstr "Pa_sswoord ännern"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:2
+msgid "Change password"
+msgstr "Passwoord ännern"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:3
+msgid "Change your password"
+msgstr "Dien Passwoord ännern"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:4
+msgid "Current _password:"
+msgstr "Aktuelles _Passwoord:"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:6
+msgid ""
+"To change your password, enter your current password in the field below and "
+"click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for "
+"verification and click <b>Change password</b>."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:8
+msgid "_Authenticate"
+msgstr "_Bewiesen, dat je du sülvst büst"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:9
+msgid "_New password:"
+msgstr "_Nejes Passwoord:"
+
+#: ../capplets/about-me/gnome-about-me-password.ui.h:10
+msgid "_Retype new password:"
+msgstr "_Nejes Passwoord ingeven:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:1
+msgid "Accessible Lo_gin"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:2
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:3
+msgid "Assistive Technologies Preferences"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:4
+msgid ""
+"Changes to enable assistive technologies will not take effect until your "
+"next log in."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:5
+msgid "Close and _Log Out"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:6
+msgid "Jump to Preferred Applications dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:7
+msgid "Jump to the Accessible Login dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:8
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:9
+msgid "Jump to the Mouse Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:10
+msgid "Preferences"
+msgstr "Instellens"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:11
+msgid "_Enable assistive technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:12
+msgid "_Keyboard Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:13
+msgid "_Mouse Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.ui.h:14
+msgid "_Preferred Applications"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Choose which accessibility features to enable when you log in"
+msgstr ""
+
+#: ../capplets/appearance/appearance-desktop.c:623
+msgid "Add Wallpaper"
+msgstr "Achtergrund hentofögen"
+
+#: ../capplets/appearance/appearance-desktop.c:658
+msgid "All files"
+msgstr "All Dateien"
+
+#: ../capplets/appearance/appearance-font.c:494
+msgid "Font may be too large"
+msgstr ""
+
+#: ../capplets/appearance/appearance-font.c:498
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:511
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:534
+msgid "Use previous font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-font.c:536
+msgid "Use selected font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:54
+#, c-format
+msgid "Could not load user interface file: %s"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:133
+msgid "Specify the filename of a theme to install"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:134
+msgid "filename"
+msgstr "Dateinaam"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/appearance/appearance-main.c:141
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:142
+#: ../capplets/default-applications/gnome-da-capplet.c:959
+#: ../capplets/mouse/gnome-mouse-properties.c:591
+msgid "page"
+msgstr "Siet"
+
+#: ../capplets/appearance/appearance-main.c:149
+msgid "[WALLPAPER...]"
+msgstr "[WALLPAPER...]"
+
+#: ../capplets/appearance/appearance-style.c:173
+#: ../capplets/common/gnome-theme-info.c:446
+#: ../capplets/common/gnome-theme-info.c:638
+msgid "Default Pointer"
+msgstr "Standardmuuswieser"
+
+#: ../capplets/appearance/appearance-style.c:235
+#: ../capplets/appearance/appearance-themes.c:685
+msgid "Install"
+msgstr "Installeren"
+
+#: ../capplets/appearance/appearance-style.c:255
+#: ../capplets/common/gnome-theme-info.c:1646
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme engine "
+"'%s' is not installed."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:673
+msgid "Apply Background"
+msgstr "Düssem Achtergrund tostimmen"
+
+#: ../capplets/appearance/appearance-themes.c:677
+msgid "Apply Font"
+msgstr "Düsser Schriftart tostimmen"
+
+#: ../capplets/appearance/appearance-themes.c:681
+msgid "Revert Font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:711
+msgid ""
+"The current theme suggests a background and a font. Also, the last applied "
+"font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:713
+msgid ""
+"The current theme suggests a background. Also, the last applied font "
+"suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:715
+msgid "The current theme suggests a background and a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:717
+msgid ""
+"The current theme suggests a font. Also, the last applied font suggestion "
+"can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:719
+msgid "The current theme suggests a background."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:721
+msgid "The last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:723
+msgid "The current theme suggests a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:1045
+#: ../capplets/default-applications/gnome-da-capplet.c:690
+msgid "Custom"
+msgstr "Anpasst"
+
+#: ../capplets/appearance/data/appearance.ui.h:1
+msgid "Appearance Preferences"
+msgstr "Utsehninstellens"
+
+#: ../capplets/appearance/data/appearance.ui.h:2
+msgid "Background"
+msgstr "Achtergrund"
+
+#: ../capplets/appearance/data/appearance.ui.h:3
+msgid "Best _shapes"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:4
+msgid "Best co_ntrast"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:5
+msgid "C_olors:"
+msgstr "K_löörs:"
+
+#: ../capplets/appearance/data/appearance.ui.h:6
+msgid "C_ustomize..."
+msgstr "A_npassen..."
+
+#: ../capplets/appearance/data/appearance.ui.h:7
+msgid "Center"
+msgstr "Inne Midde"
+
+#: ../capplets/appearance/data/appearance.ui.h:8
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:9
+msgid "Colors"
+msgstr "Klöörs"
+
+#: ../capplets/appearance/data/appearance.ui.h:10
+msgid "Controls"
+msgstr "Kontroll"
+
+#: ../capplets/appearance/data/appearance.ui.h:11
+msgid "Customize Theme"
+msgstr "Thema anpassen"
+
+#: ../capplets/appearance/data/appearance.ui.h:12
+msgid "D_etails..."
+msgstr "D_etails..."
+
+#: ../capplets/appearance/data/appearance.ui.h:13
+msgid "Des_ktop font:"
+msgstr "Schrievdis_kschriftart:"
+
+#: ../capplets/appearance/data/appearance.ui.h:14
+msgid "Font Rendering Details"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:15
+msgid "Fonts"
+msgstr "Schriftart"
+
+#: ../capplets/appearance/data/appearance.ui.h:16
+msgid "Get more backgrounds online"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:17
+msgid "Get more themes online"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:18
+msgid "Gra_yscale"
+msgstr ""
+
+#. font hinting
+#: ../capplets/appearance/data/appearance.ui.h:20
+msgid "Hinting"
+msgstr "Wiesen"
+
+#: ../capplets/appearance/data/appearance.ui.h:21
+msgid "Horizontal gradient"
+msgstr "Horizontaler Verlööp"
+
+#: ../capplets/appearance/data/appearance.ui.h:22
+msgid "Icons"
+msgstr "Symbole"
+
+#: ../capplets/appearance/data/appearance.ui.h:23
+msgid "Icons only"
+msgstr "Just Symbole"
+
+#: ../capplets/appearance/data/appearance.ui.h:24
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:16
+msgid "Large"
+msgstr "Groot"
+
+#: ../capplets/appearance/data/appearance.ui.h:25
+msgid "N_one"
+msgstr "K_eene"
+
+#: ../capplets/appearance/data/appearance.ui.h:26
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:27
+msgid "Pointer"
+msgstr "Muuswieser"
+
+#: ../capplets/appearance/data/appearance.ui.h:28
+msgid "R_esolution:"
+msgstr "_Oplösens:"
+
+#: ../capplets/appearance/data/appearance.ui.h:29
+msgid "Rendering"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:30
+msgid "Save Theme As..."
+msgstr "Thema spieker as..."
+
+#: ../capplets/appearance/data/appearance.ui.h:31
+msgid "Save _As..."
+msgstr "Spiekern _as..."
+
+#: ../capplets/appearance/data/appearance.ui.h:32
+msgid "Save _background image"
+msgstr "Achter_grundbill spiekern"
+
+#: ../capplets/appearance/data/appearance.ui.h:33
+msgid "Scale"
+msgstr "Gröte ännern"
+
+#: ../capplets/appearance/data/appearance.ui.h:34
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:30
+msgid "Small"
+msgstr "Lüttj"
+
+#: ../capplets/appearance/data/appearance.ui.h:35
+msgid "Smoothing"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:36
+msgid "Solid color"
+msgstr "Solide Klöör"
+
+#: ../capplets/appearance/data/appearance.ui.h:37
+msgid "Stretch"
+msgstr "Wieder maken"
+
+#: ../capplets/appearance/data/appearance.ui.h:38
+msgid "Sub_pixel (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:39
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:40
+msgid "Subpixel Order"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:41
+msgid "Text"
+msgstr "Text"
+
+#: ../capplets/appearance/data/appearance.ui.h:42
+msgid "Text below items"
+msgstr "Text unner Elemente"
+
+#: ../capplets/appearance/data/appearance.ui.h:43
+msgid "Text beside items"
+msgstr "Text neben de Elemente"
+
+#: ../capplets/appearance/data/appearance.ui.h:44
+msgid "Text only"
+msgstr "Just text"
+
+#: ../capplets/appearance/data/appearance.ui.h:45
+msgid "The current controls theme does not support color schemes."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:46
+msgid "Theme"
+msgstr "Thema"
+
+#: ../capplets/appearance/data/appearance.ui.h:47
+msgid "Tile"
+msgstr ""
+
+#. vertical hinting, pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.ui.h:49
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/appearance/data/appearance.ui.h:50
+msgid "Vertical gradient"
+msgstr "Vertikaler Verlööp"
+
+#: ../capplets/appearance/data/appearance.ui.h:51
+msgid "Window Border"
+msgstr "Finsterkant"
+
+#: ../capplets/appearance/data/appearance.ui.h:52
+msgid "Zoom"
+msgstr "Gröte"
+
+#: ../capplets/appearance/data/appearance.ui.h:53
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:36
+msgid "_Add..."
+msgstr "_Hentofögen..."
+
+#: ../capplets/appearance/data/appearance.ui.h:54
+msgid "_Application font:"
+msgstr "_Programmschriftart:"
+
+#. pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.ui.h:56
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/appearance/data/appearance.ui.h:57
+msgid "_Description:"
+msgstr "B_eschrieven:"
+
+#: ../capplets/appearance/data/appearance.ui.h:58
+msgid "_Document font:"
+msgstr "Dokumentschriftart:"
+
+#: ../capplets/appearance/data/appearance.ui.h:59
+msgid "_Fixed width font:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:60
+msgid "_Full"
+msgstr "_Full"
+
+#: ../capplets/appearance/data/appearance.ui.h:61
+msgid "_Input boxes:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:62
+msgid "_Install..."
+msgstr "_Installeren..."
+
+#: ../capplets/appearance/data/appearance.ui.h:63
+msgid "_Medium"
+msgstr "_Middig"
+
+#: ../capplets/appearance/data/appearance.ui.h:64
+msgid "_Monochrome"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:65
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:5
+msgid "_Name:"
+msgstr "_Naam:"
+
+#: ../capplets/appearance/data/appearance.ui.h:66
+msgid "_None"
+msgstr "_Keen"
+
+#. pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.ui.h:68
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/appearance/data/appearance.ui.h:69
+msgid "_Reset to Defaults"
+msgstr "_To Originale torüggsetten"
+
+#: ../capplets/appearance/data/appearance.ui.h:70
+msgid "_Selected items:"
+msgstr "_Utwählte Elemente:"
+
+#: ../capplets/appearance/data/appearance.ui.h:71
+msgid "_Size:"
+msgstr "_Gröte:"
+
+#: ../capplets/appearance/data/appearance.ui.h:72
+msgid "_Slight"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.ui.h:73
+msgid "_Style:"
+msgstr "_Stil:"
+
+#: ../capplets/appearance/data/appearance.ui.h:74
+msgid "_Tooltips:"
+msgstr "_Lütte Henwiese:"
+
+#. vertical hinting, pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.ui.h:76
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/appearance/data/appearance.ui.h:77
+msgid "_Window title font:"
+msgstr "_Finstertitelschriftart:"
+
+#: ../capplets/appearance/data/appearance.ui.h:78
+msgid "_Windows:"
+msgstr "_Finsters:"
+
+#: ../capplets/appearance/data/appearance.ui.h:79
+msgid "dots per inch"
+msgstr "Punkt per Inch"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr "utsehn"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr "Schrievdiskutsehn anpassen"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr "Themen installerer"
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr "GNOME-Themen Pack"
+
+#: ../capplets/appearance/gnome-wp-info.c:50
+msgid "No Desktop Background"
+msgstr "Keen Schrievdiskachtergrund"
+
+#: ../capplets/appearance/gnome-wp-item.c:258
+msgid "Slide Show"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:260
+msgid "Image"
+msgstr "Bill"
+
+#: ../capplets/appearance/gnome-wp-item.c:266
+msgid "multiple sizes"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:271
+#: ../capplets/appearance/gnome-wp-item.c:273
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "Pixel"
+msgstr[1] "Pixels"
+
+#. translators: <b>wallpaper name</b>
+#. * mime type, size
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:279
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %s\n"
+"Folder: %s"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:178
+#: ../capplets/appearance/theme-installer.c:234
+msgid "Cannot install theme"
+msgstr "Künn dat Thema nich installeren"
+
+#: ../capplets/appearance/theme-installer.c:180
+#, c-format
+msgid "The %s utility is not installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:236
+msgid "There was a problem while extracting the theme."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:264
+msgid "There was an error installing the selected file"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:265
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:266
+#, c-format
+msgid ""
+"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
+"you need to compile."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:372
+#, c-format
+msgid "Installation for theme \"%s\" failed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:411
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:421
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:424
+msgid "Keep Current Theme"
+msgstr "Aktuelles Thema behollen"
+
+#: ../capplets/appearance/theme-installer.c:427
+msgid "Apply New Theme"
+msgstr "Nejem Thema tostimmen"
+
+#: ../capplets/appearance/theme-installer.c:471
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "GNOME-Thema %s akerat installert"
+
+#: ../capplets/appearance/theme-installer.c:533
+msgid "Failed to create temporary directory"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:596
+msgid "New themes have been successfully installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:643
+msgid "No theme file location specified to install"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:667
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:745
+msgid "Select Theme"
+msgstr "Thema wählen"
+
+#: ../capplets/appearance/theme-installer.c:756
+msgid "Theme Packages"
+msgstr "Themenpacks"
+
+#: ../capplets/appearance/theme-save.c:93
+#, c-format
+msgid "Theme name must be present"
+msgstr ""
+
+#: ../capplets/appearance/theme-save.c:156
+msgid "The theme already exists. Would you like to replace it?"
+msgstr ""
+
+#: ../capplets/appearance/theme-save.c:157
+#: ../capplets/common/file-transfer-dialog.c:450
+msgid "_Overwrite"
+msgstr "_Överschrieven"
+
+#: ../capplets/appearance/theme-util.c:75
+msgid "Would you like to delete this theme?"
+msgstr ""
+
+#: ../capplets/appearance/theme-util.c:125
+msgid "Theme cannot be deleted"
+msgstr "Thema künn nich löscht werrn"
+
+#: ../capplets/appearance/theme-util.c:252
+msgid "Could not install theme engine"
+msgstr ""
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with DBus, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+
+#: ../capplets/common/capplet-stock-icons.c:66
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:88
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:98
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "Kopere Datei: %u of %u"
+
+#: ../capplets/common/file-transfer-dialog.c:145
+#, c-format
+msgid "Copying '%s'"
+msgstr "Kopere '%s'"
+
+#: ../capplets/common/file-transfer-dialog.c:185
+#: ../capplets/common/file-transfer-dialog.c:312
+msgid "Copying files"
+msgstr "Kopere Dateien"
+
+#: ../capplets/common/file-transfer-dialog.c:224
+msgid "Parent Window"
+msgstr "Ollenfinster"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Parent window of the dialog"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:231
+msgid "From URI"
+msgstr "Vun URI"
+
+#: ../capplets/common/file-transfer-dialog.c:232
+msgid "URI currently transferring from"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:239
+msgid "To URI"
+msgstr "To URI"
+
+#: ../capplets/common/file-transfer-dialog.c:240
+msgid "URI currently transferring to"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:247
+msgid "Fraction completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:248
+msgid "Fraction of transfer currently completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:255
+msgid "Current URI index"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:256
+msgid "Current URI index - starts from 1"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:263
+msgid "Total URIs"
+msgstr "All URIs"
+
+#: ../capplets/common/file-transfer-dialog.c:264
+msgid "Total number of URIs"
+msgstr "Totale Taal vun URIs"
+
+#: ../capplets/common/file-transfer-dialog.c:444
+#, c-format
+msgid "File '%s' already exists. Do you want to overwrite it?"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:447
+msgid "_Skip"
+msgstr "_Överhüppen"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Overwrite _All"
+msgstr "_Allens överschrieven"
+
+#: ../capplets/common/gconf-property-editor.c:134
+msgid "Key"
+msgstr "Slötel"
+
+#: ../capplets/common/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:141
+msgid "Callback"
+msgstr "Torüggröpen"
+
+#: ../capplets/common/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:147
+msgid "Change set"
+msgstr "Tosammenstellens ännern"
+
+#: ../capplets/common/gconf-property-editor.c:148
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:154
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:160
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "UI Kontroll"
+
+#: ../capplets/common/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1405
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1413
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1533
+msgid "Please select an image."
+msgstr "Bidde een Bill utwählen."
+
+#: ../capplets/common/gconf-property-editor.c:1538
+msgid "_Select"
+msgstr "_utwählen"
+
+#: ../capplets/common/gnome-theme-info.c:639
+msgid "Default Pointer - Current"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:643
+msgid "White Pointer"
+msgstr "Witter Muuswieser"
+
+#: ../capplets/common/gnome-theme-info.c:644
+msgid "White Pointer - Current"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:648
+msgid "Large Pointer"
+msgstr "Groter Muuswieser"
+
+#: ../capplets/common/gnome-theme-info.c:649
+msgid "Large Pointer - Current"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:653
+msgid "Large White Pointer - Current"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:654
+msgid "Large White Pointer"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1622
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme '%s' is "
+"not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1630
+#, c-format
+msgid ""
+"This theme will not look as intended because the required window manager "
+"theme '%s' is not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1637
+#, c-format
+msgid ""
+"This theme will not look as intended because the required icon theme '%s' is "
+"not installed."
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:17
+msgid "Preferred Applications"
+msgstr "Leevste Programme"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Start the preferred visual assistive technology"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr "Visueller Hölper"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:98
+#: ../capplets/default-applications/gnome-da-capplet.c:362
+#: ../capplets/default-applications/gnome-da-capplet.c:383
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:721
+msgid "Could not load the main interface"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:723
+msgid "Please make sure that the applet is properly installed"
+msgstr ""
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/default-applications/gnome-da-capplet.c:958
+msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:963
+msgid "- GNOME Default Applications"
+msgstr "- GNOME-Standardprogramme"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:1
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:1
+msgid "Accessibility"
+msgstr "Togangelikheit"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:3
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr ""
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:4
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:1
+msgid "C_ommand:"
+msgstr "_Order:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:5
+msgid "Co_mmand:"
+msgstr "Or_der:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:6
+msgid "E_xecute flag:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:7
+msgid "Image Viewer"
+msgstr "Billopwieser"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:8
+msgid "Instant Messenger"
+msgstr "Foortsnahrichtenschriever"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:9
+msgid "Internet"
+msgstr "Innernet"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:10
+msgid "Mail Reader"
+msgstr "Postleser"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:11
+msgid "Mobility"
+msgstr "Unnerwegs allens dorbi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:12
+msgid "Multimedia"
+msgstr "Multimedia"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:13
+msgid "Multimedia Player"
+msgstr "Multimediaspeeler"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:14
+msgid "Open link in new _tab"
+msgstr "Verknüppen in nejer _Registerkoort opmaken"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:15
+msgid "Open link in new _window"
+msgstr "Verknüppen in nejem _Finster opmaken"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:16
+msgid "Open link with web browser _default"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:18
+msgid "Run at st_art"
+msgstr "Bi'm Start lööpen laten"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:19
+msgid "Run in t_erminal"
+msgstr "Im T_erminal lööpen laten"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:20
+msgid "System"
+msgstr "System"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:21
+msgid "Terminal Emulator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:22
+msgid "Text Editor"
+msgstr "Textbewarker"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:23
+msgid "Video Player"
+msgstr "Filmspeeler"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:24
+msgid "Visual"
+msgstr "Visuell"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:25
+msgid "Web Browser"
+msgstr "Netkieker"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.ui.h:26
+msgid "_Run at start"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr "Banshee Tonspeeler"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr "Claws Mail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr "Dasher"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr "Debian Sensible Browser"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr "Debian Terminal Emulator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr "Debian Terminal Emulator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr "Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr "Epiphany Netkieker"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr "Evolution Postleser"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr "GNOME Terminal"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Gnopernicus"
+msgstr "Gnopernicus"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Gnopernicus with Magnifier"
+msgstr "Gnopernicus mit Vergröterer"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Iceape"
+msgstr "Iceape"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Iceape Mail"
+msgstr "Iceape Post"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Icedove"
+msgstr "Icedove"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Iceweasel"
+msgstr "Iceweasel"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Konsole"
+msgstr "Konsole"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr "Linux Billschirmleser"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Listen"
+msgstr "Tohören"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Midori"
+msgstr "Midori"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Mozilla Mail"
+msgstr "Mozilla Post"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Muine Music Player"
+msgstr "Muine Tonspeeler"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Netscape Communicator"
+msgstr "Netscape Kommunikator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Opera"
+msgstr "Opera"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca"
+msgstr "Orca"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "Orca with Magnifier"
+msgstr "Orca mit Vergröterer"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+msgid "Rhythmbox Music Player"
+msgstr "Rhythmbox Tonspeeler"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+msgid "SeaMonkey Mail"
+msgstr "SeaMonkey Post"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Standard XTerminal"
+msgstr "Standard XTerminal"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+msgid "Sylpheed"
+msgstr "Sylpheed"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Terminator"
+msgstr "Terminator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "Totem Movie Player"
+msgstr "Totem Filmspeeler"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/display/display-capplet.ui.h:1
+msgid "Display Preferences"
+msgstr "Billschirminstellens"
+
+#: ../capplets/display/display-capplet.ui.h:2
+msgid "Drag the monitors to set their place"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:3
+msgid "Include _panel"
+msgstr "_Balken insluten"
+
+#: ../capplets/display/display-capplet.ui.h:4
+#: ../capplets/display/xrandr-capplet.c:302
+msgid "Left"
+msgstr "Links"
+
+#: ../capplets/display/display-capplet.ui.h:5
+#: ../capplets/display/xrandr-capplet.c:440
+msgid "Monitor"
+msgstr "Billschirm"
+
+#: ../capplets/display/display-capplet.ui.h:6
+#: ../capplets/display/xrandr-capplet.c:301
+#: ../capplets/display/xrandr-capplet.c:340
+msgid "Normal"
+msgstr "Normal"
+
+#: ../capplets/display/display-capplet.ui.h:7
+msgid "Off"
+msgstr "Ut"
+
+#: ../capplets/display/display-capplet.ui.h:8
+msgid "On"
+msgstr "An"
+
+#: ../capplets/display/display-capplet.ui.h:9
+msgid "Panel icon"
+msgstr "Balkensymbol"
+
+#: ../capplets/display/display-capplet.ui.h:10
+msgid "R_otation:"
+msgstr "R_otatschoon:"
+
+#: ../capplets/display/display-capplet.ui.h:11
+msgid "Re_fresh rate:"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:12
+#: ../capplets/display/xrandr-capplet.c:303
+msgid "Right"
+msgstr "Rechts"
+
+#: ../capplets/display/display-capplet.ui.h:13
+msgid "Upside-down"
+msgstr "Boven nah unnen"
+
+#: ../capplets/display/display-capplet.ui.h:14
+msgid "_Detect Monitors"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:15
+msgid "_Mirror screens"
+msgstr ""
+
+#: ../capplets/display/display-capplet.ui.h:16
+msgid "_Resolution:"
+msgstr "_Oplösens:"
+
+#: ../capplets/display/display-capplet.ui.h:17
+msgid "_Show displays in panel"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Display"
+msgstr "Billschirm"
+
+#: ../capplets/display/xrandr-capplet.c:304
+msgid "Upside Down"
+msgstr "Boven nah unnen"
+
+#: ../capplets/display/xrandr-capplet.c:346
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/xrandr-capplet.c:432
+#, c-format
+msgid "Monitor: %s"
+msgstr "Billschirm: %s"
+
+#: ../capplets/display/xrandr-capplet.c:511
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../capplets/display/xrandr-capplet.c:1463
+msgid "Mirror Screens"
+msgstr "Spegelbillschirms"
+
+#: ../capplets/display/xrandr-capplet.c:1883
+msgid "Could not save the monitor configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1894
+msgid "Could not get session bus while applying display configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1936
+msgid "Could not detect displays"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:2151
+msgid "Could not get screen information"
+msgstr ""
+
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+msgid "Sound"
+msgstr "Ton"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+#: ../libslab/bookmark-agent.c:1146
+msgid "Desktop"
+msgstr "Schrievdisk"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr "Nejer Kortsnied..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:119
+#: ../typing-break/drwright.c:431
+msgid "Disabled"
+msgstr "Deaktivert"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:200
+msgid "<Unknown Action>"
+msgstr "<Unbekannte Aktschoon>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:950
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1581
+msgid "Custom Shortcuts"
+msgstr "Anpasste Kortsnieds"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1092
+msgid "Error saving the new shortcut"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1171
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1201
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1207
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1215
+msgid "_Reassign"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1335
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1536
+msgid "Too many custom shortcuts"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1832
+msgid "Action"
+msgstr "Aktschoon"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1854
+msgid "Shortcut"
+msgstr "Kortsnied"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:2
+msgid "Custom Shortcut"
+msgstr "Anpasster Kortsnied"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:3
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Knöppboord Kortsnieds"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.ui.h:4
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new key "
+"combination, or press backspace to clear."
+msgstr ""
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:205
+#: ../capplets/keyboard/gnome-keyboard-properties.c:210
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:215
+msgid "Start the page with the typing break settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:220
+msgid "Start the page with the accessibility settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:226
+msgid "- GNOME Keyboard Preferences"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:1
+msgid "Beep when _accessibility features are turned on or off"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:2
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:3
+msgid "Beep when a _toggle key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:4
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:5
+msgid "Beep when a key is reje_cted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:6
+msgid "Beep when key is _accepted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:7
+msgid "Beep when key is _rejected"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:8
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:4
+msgid "Bounce Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:9
+msgid "Flash _window titlebar"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:10
+msgid "Flash entire _screen"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:11
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:14
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:14
+msgid "General"
+msgstr "Allgemeen"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:12
+msgid "Keyboard Accessibility Audio Feedback"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:13
+msgid "Show _visual feedback for the alert sound"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:14
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:31
+msgid "Slow Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:15
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:32
+msgid "Sticky Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-a11y-notifications.ui.h:16
+msgid "Visual cues for sounds"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:2
+msgid "All_ow postponing of breaks"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:3
+msgid "Audio _Feedback..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:5
+msgid "Check if breaks are allowed to be postponed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:6
+msgid "Cursor Blinking"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:7
+msgid "Cursor _blinks in text fields"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:8
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:4
+msgid "Cursor blinks speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:9
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:5
+msgid "D_elay:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:10
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:11
+msgid "Duration of the break when typing is disallowed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:12
+msgid "Duration of work before forcing a break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:13
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:13
+msgid "Fast"
+msgstr "Fix"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:15
+msgid "Key presses _repeat when key is held down"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:16
+msgid "Keyboard Preferences"
+msgstr "Knöppboordinstellens"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:17
+msgid "Keyboard _model:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:18
+msgid "Layouts"
+msgstr "Utsehn"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:19
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:20
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:18
+msgid "Long"
+msgstr "lang"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:21
+msgid "Mouse Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:22
+msgid "Move _Down"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:23
+msgid "Move _Up"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:24
+msgid "New windows u_se active window's layout"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:25
+msgid "Repeat Keys"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:26
+msgid "Repeat keys speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:27
+msgid "Reset to De_faults"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:28
+msgid "S_peed:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:29
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:26
+msgid "Short"
+msgstr "Koort"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:30
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:29
+msgid "Slow"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:33
+msgid "Typing Break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:34
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:36
+msgid "_Acceleration:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:35
+msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:37
+msgid "_Break interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:38
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:37
+msgid "_Delay:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:39
+msgid "_Ignore fast duplicate keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:40
+msgid "_Lock screen to enforce typing break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:41
+msgid "_Only accept long keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:42
+msgid "_Options..."
+msgstr "_Optschoonen..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:43
+msgid "_Pointer can be controlled using the keypad"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:44
+msgid "_Separate layout for each window"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:45
+msgid "_Simulate simultaneous keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:46
+msgid "_Speed:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:47
+msgid "_Type to test settings:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:48
+msgid "_Work interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-dialog.ui.h:49
+msgid "minutes"
+msgstr "Minuuten"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:1
+msgid "By _country"
+msgstr "Nah _Land"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:2
+msgid "By _language"
+msgstr "Nah _Sprak"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:3
+msgid "Choose a Layout"
+msgstr "Utsehn wählen"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:4
+msgid "Preview:"
+msgstr "Utblick:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:5
+msgid "_Country:"
+msgstr "_Land:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:6
+msgid "_Language:"
+msgstr "_Sprak:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-layout-chooser.ui.h:7
+msgid "_Variants:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:1
+msgid "Choose a Keyboard Model"
+msgstr "Wähl een Knöppboordutsehn"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:2
+msgid "_Models:"
+msgstr "_Modelle:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-model-chooser.ui.h:3
+msgid "_Vendors:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-options-dialog.ui.h:1
+msgid "Keyboard Layout Options"
+msgstr "Knöppboordutsehnoptschoonen"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:240
+msgid "Layout"
+msgstr "Utsehn"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:168
+msgid "Vendors"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:234
+msgid "Models"
+msgstr "Modelle"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:234
+#: ../capplets/network/gnome-network-properties.c:583
+msgid "Default"
+msgstr "Standard"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Knöppboord"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Knöppboordinstellens setten"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:89
+msgid "gesture|Move left"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:94
+msgid "gesture|Move right"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:99
+msgid "gesture|Move up"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:104
+msgid "gesture|Move down"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:109
+msgid "gesture|Disabled"
+msgstr ""
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/mouse/gnome-mouse-properties.c:590
+msgid "Specify the name of the page to show (general|accessibility)"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:595
+msgid "- GNOME Mouse Preferences"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:2
+msgid "Choose type of click _beforehand"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:3
+msgid "Choose type of click with mo_use gestures"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:6
+msgid "D_ouble click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:7
+msgid "D_rag click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:8
+msgid "Double-Click Timeout"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:9
+msgid "Drag and Drop"
+msgstr "Trecken un loslaten"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:10
+msgid "Dwell Click"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:11
+msgid "Enable _horizontal scrolling"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:12
+msgid "Enable mouse _clicks with touchpad"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:15
+msgid "High"
+msgstr "Hoch"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:17
+msgid "Locate Pointer"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:19
+msgid "Low"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:20
+msgid "Mouse Orientation"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:21
+msgid "Mouse Preferences"
+msgstr "Muusinstellens"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:22
+msgid "Pointer Speed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:23
+msgid "Scrolling"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:24
+msgid "Seco_ndary click:"
+msgstr "Twe_jter Klick:"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:25
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:27
+msgid "Show click type _window"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:28
+msgid "Simulated Secondary Click"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:31
+msgid "Thr_eshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:32
+msgid ""
+"To test your double-click settings, try to double-click on the light bulb."
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:33
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:34
+msgid "Two-_finger scrolling"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:35
+msgid "You can also use the Dwell Click panel applet to choose the click type."
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:38
+msgid "_Disable touchpad while typing"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:39
+msgid "_Disabled"
+msgstr "_Deaktivert"
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:40
+msgid "_Edge scrolling"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:41
+msgid "_Initiate click when stopping pointer movement"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:42
+msgid "_Left-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:43
+msgid "_Motion threshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:44
+msgid "_Right-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:45
+msgid "_Sensitivity:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:46
+msgid "_Single click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:47
+msgid "_Timeout:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.ui.h:48
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr ""
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Muus"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.c:701
+#: ../capplets/network/gnome-network-properties.c:852
+msgid "New Location..."
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.c:818
+msgid "Location already exists"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Netwark-Proxy"
+
+#: ../capplets/network/gnome-network-properties.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "Netwark-Proxy-Instellens setten"
+
+#: ../capplets/network/gnome-network-properties.ui.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:2
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:3
+msgid "<b>_Manual proxy configuration</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:4
+msgid "<b>_Use authentication</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:5
+msgid "Autoconfiguration _URL:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:6
+msgid "C_reate"
+msgstr "E_rstellen"
+
+#: ../capplets/network/gnome-network-properties.ui.h:7
+msgid "Create New Location"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:8
+msgid "HTTP Proxy Details"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:9
+msgid "H_TTP proxy:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:10
+msgid "Ignore Host List"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:11
+msgid "Ignored Hosts"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:12
+msgid "Location:"
+msgstr "Ort:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:13
+msgid "Network Proxy Preferences"
+msgstr "Netwark-Proxy-Instellens"
+
+#: ../capplets/network/gnome-network-properties.ui.h:14
+msgid "Port:"
+msgstr "Port:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:15
+msgid "Proxy Configuration"
+msgstr "Proxy-Konfiguratschoon"
+
+#: ../capplets/network/gnome-network-properties.ui.h:16
+msgid "S_ocks host:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:17
+msgid "The location already exists."
+msgstr ""
+
+#: ../capplets/network/gnome-network-properties.ui.h:18
+msgid "U_sername:"
+msgstr "B_rukernaam:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:19
+msgid "_Delete Location"
+msgstr "_Ort löschen"
+
+#: ../capplets/network/gnome-network-properties.ui.h:20
+msgid "_Details"
+msgstr "_Details"
+
+#: ../capplets/network/gnome-network-properties.ui.h:21
+msgid "_FTP proxy:"
+msgstr "_FTP Proxy:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:22
+msgid "_Location name:"
+msgstr "_Ortnaam:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:23
+msgid "_Password:"
+msgstr "_Passwoord:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:24
+msgid "_Secure HTTP proxy:"
+msgstr "_Seker HTTP Proxy:"
+
+#: ../capplets/network/gnome-network-properties.ui.h:25
+msgid "_Use the same proxy for all protocols"
+msgstr "_De sülvigen Proxy för all Protokolls bruken"
+
+#: ../capplets/windows/gnome-window-properties.c:344
+msgid "Cannot start the preferences application for your window manager"
+msgstr ""
+
+#. translators: this is the Control key
+#: ../capplets/windows/gnome-window-properties.c:608
+msgid "C_ontrol"
+msgstr "K_ontroll"
+
+#: ../capplets/windows/gnome-window-properties.c:613
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:619
+msgid "H_yper"
+msgstr "H_yper"
+
+#: ../capplets/windows/gnome-window-properties.c:626
+msgid "S_uper (or \"Windows logo\")"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:633
+msgid "_Meta"
+msgstr "_Meta"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:1
+msgid "Movement Key"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:2
+msgid "Titlebar Action"
+msgstr "Titelbalkenaktschoon"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:3
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:4
+msgid "Window Preferences"
+msgstr "Finsterinstellens"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:5
+msgid "Window Selection"
+msgstr "Finsterwähler"
+
+#: ../capplets/windows/gnome-window-properties.ui.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:7
+msgid "_Interval before raising:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:8
+msgid "_Raise selected windows after an interval"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.ui.h:10
+msgid "seconds"
+msgstr "Sekunnen"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr ""
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Finsters"
+
+#: ../libwindow-settings/gnome-wm-manager.c:316
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:404
+msgid "Maximize"
+msgstr "Vergrötern"
+
+#: ../libwindow-settings/metacity-window-manager.c:405
+msgid "Maximize Vertically"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:406
+msgid "Maximize Horizontally"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:407
+msgid "Minimize"
+msgstr "Lütter maken"
+
+#: ../libwindow-settings/metacity-window-manager.c:408
+msgid "Roll up"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:409
+msgid "None"
+msgstr "Keen"
+
+#: ../shell/control-center.c:49
+#, c-format
+msgid "key not found [%s]\n"
+msgstr ""
+
+#: ../shell/control-center.c:143
+msgid "Hide on start (useful to preload the shell)"
+msgstr ""
+
+#: ../shell/control-center.c:182
+msgid "Filter"
+msgstr "Filter"
+
+#: ../shell/control-center.c:182
+msgid "Groups"
+msgstr "Gruppen"
+
+#: ../shell/control-center.c:182
+msgid "Common Tasks"
+msgstr ""
+
+#: ../shell/control-center.c:185 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Kontrollzentrum"
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:5
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:8
+msgid ""
+"Indicates whether to close the shell when an add or remove action is "
+"performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:9
+msgid ""
+"Indicates whether to close the shell when an upgrade or uninstall action is "
+"performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:11
+msgid ""
+"The task name to be displayed in the control-center followed by a \";\" "
+"separator then the filename of an associated .desktop file to launch for "
+"that task."
+msgstr ""
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+msgid ""
+"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
+"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:14
+msgid ""
+"if true, the control-center will close when a \"Common Task\" is activated."
+msgstr ""
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "GNOME-Konfiguratschoonswarktügg"
+
+#: ../typing-break/drw-break-window.c:194
+msgid "_Postpone Break"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:250
+msgid "Take a break!"
+msgstr "Tied för'n Tee?"
+
+#: ../typing-break/drwright.c:116
+msgid "_Take a Break"
+msgstr "_Tied för'n Tee?"
+
+#: ../typing-break/drwright.c:440
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../typing-break/drwright.c:444
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr ""
+
+#: ../typing-break/drwright.c:526
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+
+#: ../typing-break/drwright.c:543
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "Schrieven vun Richard Hult <richard@imendio.com>"
+
+#: ../typing-break/drwright.c:544
+msgid "Eye candy added by Anders Carlsson"
+msgstr ""
+
+#: ../typing-break/drwright.c:553
+msgid "A computer break reminder."
+msgstr ""
+
+#: ../typing-break/drwright.c:555
+msgid "translator-credits"
+msgstr "Nils-Christoph Fiedler <fiedler@medienkompanie.de>"
+
+#: ../typing-break/main.c:61
+msgid "Enable debugging code"
+msgstr ""
+
+#: ../typing-break/main.c:63
+msgid "Don't check whether the notification area exists"
+msgstr ""
+
+#: ../typing-break/main.c:89
+msgid "Typing Monitor"
+msgstr ""
+
+#: ../typing-break/main.c:105
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr ""
+
+#: ../font-viewer/font-view.c:289
+msgid "Name:"
+msgstr "Naam:"
+
+#: ../font-viewer/font-view.c:292
+msgid "Style:"
+msgstr "Stil:"
+
+#: ../font-viewer/font-view.c:305
+msgid "Type:"
+msgstr "Typ:"
+
+#: ../font-viewer/font-view.c:309
+msgid "Size:"
+msgstr "Gröte:"
+
+#: ../font-viewer/font-view.c:353 ../font-viewer/font-view.c:366
+msgid "Version:"
+msgstr "Verschoon:"
+
+#: ../font-viewer/font-view.c:357 ../font-viewer/font-view.c:368
+msgid "Copyright:"
+msgstr "Koperschod:"
+
+#: ../font-viewer/font-view.c:361
+msgid "Description:"
+msgstr "Beschrievens:"
+
+#: ../font-viewer/font-view.c:441
+msgid "Installed"
+msgstr "Installert"
+
+#: ../font-viewer/font-view.c:444
+msgid "Install Failed"
+msgstr "Installatschoon fehlslagen"
+
+#: ../font-viewer/font-view.c:516
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr ""
+
+#: ../font-viewer/font-view.c:591
+msgid "I_nstall Font"
+msgstr "Schriftart _installeren"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
+msgid "Font Viewer"
+msgstr "Schriftartwieser"
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
+msgid "Preview fonts"
+msgstr "Schriftartutblick"
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "Text to thumbnail (default: Aa)"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "TEXT"
+msgstr "TEXT"
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "Font size (default: 64)"
+msgstr "Schriftartgröte (Standard: 64)"
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "SIZE"
+msgstr "SIZE"
+
+#: ../font-viewer/font-thumbnailer.c:249
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr "FONT-FILE OUTPUT-FILE"
+
+#: ../font-viewer/font-thumbnailer.c:268
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr ""
+
+#: ../libslab/app-shell.c:754
+#, c-format
+msgid "Your filter \"%s\" does not match any items."
+msgstr ""
+
+#: ../libslab/app-shell.c:756
+msgid "No matches found."
+msgstr "Nix funnen, wat passt."
+
+#: ../libslab/app-shell.c:905
+msgid "Other"
+msgstr "Annere"
+
+#. make start action
+#: ../libslab/application-tile.c:374
+#, c-format
+msgid "Start %s"
+msgstr "Starte %s"
+
+#: ../libslab/application-tile.c:395
+msgid "Help"
+msgstr "Hölp"
+
+#: ../libslab/application-tile.c:442
+msgid "Upgrade"
+msgstr "Upgrade"
+
+#: ../libslab/application-tile.c:457
+msgid "Uninstall"
+msgstr "Deinstalleren"
+
+#: ../libslab/application-tile.c:784 ../libslab/document-tile.c:721
+msgid "Remove from Favorites"
+msgstr "Ut Leevsten löschen"
+
+#: ../libslab/application-tile.c:786 ../libslab/document-tile.c:723
+msgid "Add to Favorites"
+msgstr "To Leevsten hentofögen"
+
+#: ../libslab/application-tile.c:871
+msgid "Remove from Startup Programs"
+msgstr ""
+
+#: ../libslab/application-tile.c:873
+msgid "Add to Startup Programs"
+msgstr "To Startprogramme hentofögen"
+
+#: ../libslab/bookmark-agent.c:1077
+msgid "New Spreadsheet"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1082
+msgid "New Document"
+msgstr "Nejes Dokument"
+
+#: ../libslab/bookmark-agent.c:1140
+msgid "Documents"
+msgstr "Dokumente"
+
+#: ../libslab/bookmark-agent.c:1153
+msgid "File System"
+msgstr "Dateisystem"
+
+#: ../libslab/bookmark-agent.c:1157
+msgid "Network Servers"
+msgstr "Netwark Servers"
+
+#: ../libslab/bookmark-agent.c:1186
+msgid "Search"
+msgstr "Sök"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:171
+#, c-format
+msgid "<b>Open</b>"
+msgstr "<b>Opmaken</b>"
+
+#. make rename action
+#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:234
+msgid "Rename..."
+msgstr "Annern Naam geven..."
+
+#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
+#: ../libslab/document-tile.c:248 ../libslab/document-tile.c:257
+msgid "Send To..."
+msgstr "Sennen an..."
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:283
+msgid "Move to Trash"
+msgstr "In'n Papierkörv verschuven"
+
+#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
+#: ../libslab/document-tile.c:293 ../libslab/document-tile.c:837
+msgid "Delete"
+msgstr "Löschen"
+
+#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:985
+#, c-format
+msgid "Are you sure you want to permanently delete \"%s\"?"
+msgstr ""
+
+#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:986
+msgid "If you delete an item, it is permanently lost."
+msgstr ""
+
+#: ../libslab/document-tile.c:193
+#, c-format
+msgid "Open with \"%s\""
+msgstr "Opmaken mit \"%s\""
+
+#: ../libslab/document-tile.c:207
+msgid "Open with Default Application"
+msgstr ""
+
+#: ../libslab/document-tile.c:218
+msgid "Open in File Manager"
+msgstr "In Dateioppasser opmaken"
+
+#: ../libslab/document-tile.c:617
+msgid "?"
+msgstr "?"
+
+#: ../libslab/document-tile.c:624
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#: ../libslab/document-tile.c:632
+msgid "Today %l:%M %p"
+msgstr "Vandag %l:%M %p"
+
+#: ../libslab/document-tile.c:642
+msgid "Yesterday %l:%M %p"
+msgstr "Güstern %l:%M %p"
+
+#: ../libslab/document-tile.c:654
+msgid "%a %l:%M %p"
+msgstr "%a %l:%M %p"
+
+#: ../libslab/document-tile.c:662
+msgid "%b %d %l:%M %p"
+msgstr "%b %d %l:%M %p"
+
+#: ../libslab/document-tile.c:664
+msgid "%b %d %Y"
+msgstr "%b %d %Y"
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr "Nu finnen"
+
+#: ../libslab/system-tile.c:127
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr "<b>%s opmaken</b>"
+
+#: ../libslab/system-tile.c:140
+#, c-format
+msgid "Remove from System Items"
+msgstr "Ut Systemelementen löschen"
+
+msgid "Show help options"
+msgstr "Hölpoptschoonen opwiesen"
+
+#~ msgid "Fill screen"
+#~ msgstr "Billschirm full maken"
+
+#~ msgid "Edit"
+#~ msgstr "Bewarken"
+
+#~ msgid "Interface"
+#~ msgstr "Bovensied"
+
+#~ msgid "Menus and Toolbars"
+#~ msgstr "Menüs un Warktüggbalkens"
+
+#~ msgid "_File"
+#~ msgstr "_Datei"
+
+#, fuzzy
+#~ msgid "Selected _layouts:"
+#~ msgstr "_Utwählte Utsehn:"
+
+#~ msgid "Preview"
+#~ msgstr "Utblick"

--- a/po/ne.po
+++ b/po/ne.po
@@ -8,9 +8,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Gnome Nepali Translation Project\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issues\n"
-"POT-Creation-Date: 2022-04-27 09:19+0000\n"
-"PO-Revision-Date: 2022-05-22 13:50+0545\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-09-19 12:00+0545\n"
 "Last-Translator: Pawan Chitrakar <chautari@gmail.com>\n"
 "Language-Team: Nepali Translation Team <chautari@gmail.com>\n"
 "Language: ne\n"
@@ -22,90 +22,8 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-Bookmarks: -1,-1,-1,-1,-1,-1,-1,-1,1617,-1\n"
 
-#: panels/applications/cc-applications-panel.c:803
-msgid "System Bus"
-msgstr "प्रणाली बस"
-
-#: panels/applications/cc-applications-panel.c:803 panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:818 panels/applications/cc-applications-panel.c:823
-msgid "Full access"
-msgstr "पूर्ण पहुँच"
-
-#: panels/applications/cc-applications-panel.c:805
-msgid "Session Bus"
-msgstr "सत्र बस"
-
-#: panels/applications/cc-applications-panel.c:809 panels/power/cc-power-panel.ui:75
-#: panels/thunderbolt/cc-bolt-panel.ui:266 panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "यन्त्रहरू"
-
-#: panels/applications/cc-applications-panel.c:809
-msgid "Full access to /dev"
-msgstr "/dev मा पूरा पहुँच"
-
-#: panels/applications/cc-applications-panel.c:813
-#: panels/network/gnome-network-panel.desktop.in.in:3 panels/network/network-mobile.ui:230
-#: panels/wwan/cc-wwan-device-page.ui:61 panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "सञ्जाल"
-
-#: panels/applications/cc-applications-panel.c:813
-msgid "Has network access"
-msgstr "सञ्जाल पहुच छ"
-
-#: panels/applications/cc-applications-panel.c:818 panels/applications/cc-applications-panel.c:820
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "गृह"
-
-#: panels/applications/cc-applications-panel.c:820 panels/applications/cc-applications-panel.c:825
-msgid "Read-only"
-msgstr "पढ्न-मात्र"
-
-#: panels/applications/cc-applications-panel.c:823 panels/applications/cc-applications-panel.c:825
-msgid "File System"
-msgstr "फाइल प्रणाली"
-
-#: panels/applications/cc-applications-panel.c:829 panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246 shell/cc-window.c:878
-#: shell/cc-window.ui:22 shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "सेटिङ"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Can change settings"
-msgstr "सेटिङ्गहरू परिवर्तन गर्न सक्छ"
-
-#: panels/applications/cc-applications-panel.c:831
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you are concerned about "
-"these permissions, consider removing this application."
-msgstr ""
-"%s सँग निम्न अनुमति अवस्थित छ । यी परिवर्तन गर्न सकिँदैन । यदि तपाईँ यी अनुमतिका बारेमा चिन्तित हुनुहुन्छ भने, यो "
-"अनुप्रयोग हटाउन विचार गर्नुहोस् ।"
-
-#: panels/applications/cc-applications-panel.c:1164
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "अनुप्रयोगद्वारा खोलिएका %u फाइल र लिङ्क प्रकार"
-msgstr[1] "अनुप्रयोगद्वारा खोलिएका %u फाइल र लिङ्क प्रकारहरू"
-
-#: panels/applications/cc-applications-panel.c:1171
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> निम्न प्रकारका फाइलहरू र लिङ्कहरू खोल्न प्रयोग गरिन्छ।"
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1223
-#, c-format
-msgid "%s of disk space used"
-msgstr "प्रयोग गरिएको डिस्क स्थानको %s"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1387 panels/applications/cc-applications-panel.ui:19
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
@@ -120,7 +38,6 @@ msgid "Install some…"
 msgstr "स्थापना गर्नुहोस्…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "खोल्नुहोस्:"
 
@@ -128,29 +45,29 @@ msgstr "खोल्नुहोस्:"
 msgid "View Details"
 msgstr "विवरण हेर्नुहोस्"
 
-#: panels/applications/cc-applications-panel.ui:112 panels/applications/cc-applications-panel.ui:119
-#: panels/keyboard/01-launchers.xml.in:16 panels/search/gnome-search-panel.desktop.in.in:3
-#: shell/cc-window.ui:41
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "खोजी गर्नुहोस्"
 
-#: panels/applications/cc-applications-panel.ui:113 panels/applications/cc-applications-panel.ui:120
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
 msgid "Receive system searches and send results."
 msgstr "प्रणाली खोजी प्राप्त गर्नुहोस् र परिणाम पठाउनुहोस् ।"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:121 panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177 panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118 panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789 panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478 subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "असक्षम पारिएको छ"
 
@@ -164,7 +81,7 @@ msgid "Show system notifications."
 msgstr "प्रणाली सूचना देखाउनुहोस् ।"
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+msgid "Run in Background"
 msgstr "पृष्ठभूमि मा चलाउनुहोस्"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -172,119 +89,142 @@ msgid "Allow activity when the app is closed."
 msgstr "अनुप्रयोग बन्द हुँदा क्रियाकलाप अनुमति दिनुहोस् ।"
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "स्क्रिनसट"
+
+#: panels/applications/cc-applications-panel.ui:141
+#, fuzzy
+msgid "Take pictures of the screen at any time."
+msgstr "क्यामेरासँग तस्वीर लिनुहोस् ।"
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "वालपेपर परिवर्तन गर्नुहोस्"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "डेस्कटप वालपेपर परिवर्तन गर्नुहोस् ।"
 
-#: panels/applications/cc-applications-panel.ui:147 panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "ध्वनिहरू"
 
-#: panels/applications/cc-applications-panel.ui:148 panels/applications/cc-applications-panel.ui:155
-#, fuzzy
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
-msgstr "ध्वनिहरू"
+msgstr "ध्वनिहरू पुनरुत्पादन गर्नुहोस्।"
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "सर्टकट निषेध गर्नुहोस्"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "मानक कुञ्जीपाटी सर्टकटहरू बन्द गर्नुहोस् ।"
 
-#: panels/applications/cc-applications-panel.ui:168 panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "क्यामेरा"
 
-#: panels/applications/cc-applications-panel.ui:169 panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "क्यामेरासँग तस्वीर लिनुहोस् ।"
 
-#: panels/applications/cc-applications-panel.ui:182 panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "माईक्रोफोन"
 
-#: panels/applications/cc-applications-panel.ui:183 panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "माइकसँग अडियो रेकर्ड गर्नुहोस्।"
 
-#: panels/applications/cc-applications-panel.ui:196 panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "स्थान सेवाहरू"
 
-#: panels/applications/cc-applications-panel.ui:197 panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "पहुँच यन्त्र स्थान डेटा ।"
 
-#: panels/applications/cc-applications-panel.ui:215 panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "सम्मिलित अनुमति"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "अनुप्रयोगद्वारा आवश्यक पर्ने प्रणाली पहुँच"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "फाइल र लिङ्क संघ"
 
-#: panels/applications/cc-applications-panel.ui:232 panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "भण्डारण"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "नतिजा भेटिएन"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198 shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "फरक खोज कोशिश गर्नुहोस्"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "फाइल र लिङ्क संघ"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "फाइल प्रकार"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "लिङ्क प्रकार"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "रिसेट गर्नुहोस्"
 
-#: panels/applications/cc-applications-panel.ui:410
-msgid "How much disk space this application is occupying with app data and caches."
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
 msgstr "अनुप्रयोग डेटा र क्याससँग यो अनुप्रयोगले कति डिस्क स्थान ओगटिरहेको छ ।"
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "अनुप्रयोग"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "डेटा"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "क्यास"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>जम्मा</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "क्यास खाली गर्नुहोस्…"
 
@@ -292,78 +232,32 @@ msgstr "क्यास खाली गर्नुहोस्…"
 msgid "Control various application permissions and settings"
 msgstr "विभिन्न अनुप्रयोग अनुमति र सेटिङ नियन्त्रण गर्नुहोस्"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "अनुप्रयोग;flatpak;अनुमति;सेटिङ;"
-
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "तस्वीर छान्नुहोस्"
-
-#: panels/background/cc-background-chooser.c:310 panels/color/cc-color-calibrate.ui:22
-#: panels/color/cc-color-panel.c:284 panels/color/cc-color-panel.c:844
-#: panels/common/cc-language-chooser.ui:21 panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198 panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123 panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341 panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50 panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24 panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:526 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25 panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167 panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18 panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597 panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32 panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "रद्द गर्नुहोस्"
-
-#: panels/background/cc-background-chooser.c:311 panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:264 panels/sharing/cc-sharing-panel.c:527
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "खोल्नुहोस्"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "बिभिन्न आकार"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "डेस्कटप पृष्ठभूमि छैन"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "हालको पृष्ठभूमि"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "शैली"
 
-#: panels/background/cc-background-panel.ui:45
-msgid "Light"
-msgstr "हल्का"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "पूर्वनिर्धारित"
 
-#: panels/background/cc-background-panel.ui:72
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "गाढा"
 
-#: panels/background/cc-background-panel.ui:91
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "पृष्ठभूमि"
 
-#: panels/background/cc-background-panel.ui:97
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "तस्वीर थप्नुहोस्…"
 
@@ -375,50 +269,58 @@ msgstr "मोहडा"
 msgid "Change your background image or the UI colors"
 msgstr "तपाईँको पृष्ठभूमि छवि वा यूआई रङ परिवर्तन गर्नुहोस्"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+#, fuzzy
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "पृष्ठभूमि; वालपेपर; पर्दा;डेस्कटप; शैली: उज्यालो;अँध्यारो;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "सक्षम पार्नुहोस्"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "ब्लुटुठ भेटिएन"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "ब्लुटुठ चलाउन डङ्गल जडान गरनुहोस् ।"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "ब्लुटुठ बन्द गरियो"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "उपकरणहरू जडान गर्न खोल्नुहोस् र फाइल स्थानान्तरण प्राप्त गर्नुहोस्।"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "एअरप्लेन मोड राख्नु"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "हवाईजहाज मोड मा हुँदा ब्लुटुथ अक्षम हुन्छ ।"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "एअरप्लेन मोड हटाऊनु"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "हार्डवेयर हवाईजहाज मोड चलिरहेको छ"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "ब्लुटुथ सक्षम गर्न हवाइजहाज मोड स्विच बन्द गर्नुहोस्।"
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "ब्लुटुठ"
 
@@ -426,34 +328,30 @@ msgstr "ब्लुटुठ"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "यन्त्र जडानकोलागि ब्लुटुठ बन्द अनि खोल्नुहोस्"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "साझा;साझेदारी;ब्लुटुथ;ओबेक्स;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "क्यामेरा बन्द गरियो"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "कुनै पनि अनुप्रयोगले फोटो वा भिडियो ग्रहण गर्न सक्दैन ।"
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 #, fuzzy
-#| msgid ""
-#| "Use of the camera allows applications to capture photos and video. Disabling the camera may "
-#| "cause some applications to not function properly."
 msgid ""
-"Use of the camera allows applications to capture photos and video. Disabling the camera may cause "
-"some applications to not function properly.\n"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
 "\n"
 "Allow the applications below to use your camera."
 msgstr ""
-"क्यामेराको प्रयोगले अनुप्रयोगहरूलाई फोटो र भिडियो ग्रहण गर्न अनुमति दिन्छ । क्यामेरा अक्षम गर्दा केही अनुप्रयोगले "
-"राम्रोसँग कार्य नगर्न सक्छ ।"
+"क्यामेराको प्रयोगले अनुप्रयोगहरूलाई फोटो र भिडियो ग्रहण गर्न अनुमति दिन्छ । क्यामेरा अक्षम "
+"गर्दा केही अनुप्रयोगले राम्रोसँग कार्य नगर्न सक्छ ।"
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "क्यामेरा पहुँचका लागि कुनै अनुप्रयोगले सोधेको छैन"
 
@@ -461,89 +359,33 @@ msgstr "क्यामेरा पहुँचका लागि कुनै
 msgid "Protect your pictures"
 msgstr "तपाईँको तस्वीर सुरक्षित राख्नुहोस्"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;"
-msgstr "पर्दा;ताल्चा;निदान;क्र्यास;निजी;हालैको;अस्थायी;tmp;index;नाम;सञ्जाल;पहिचान;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "वर्ग माथि तपाईँको क्यालिब्रेसन यन्त्र राख्नुहोस् र \"Start\" थिच्नुहोस्"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid "Move your calibration device to the calibrate position and press “Continue”"
-msgstr "क्यालिब्रसन यन्त्र क्यालिब्रट स्थानमाराखि जारि बटन थिच्नुहोस् ।"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid "Move your calibration device to the surface position and press “Continue”"
-msgstr "क्यालिब्रसन यन्त्र सटह स्थानमाराखि जारि बटन थिच्नुहोस् ।"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "कम्प्युटर बन्द गर्नुहोस्"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "एउटा आन्तरिक त्रुटि देखा पर्यो जुन पुन: प्राप्त गर्न सकिएन ।."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "अंशांकनलागि आवश्यक उपकरण स्थापित छैन।"
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "प्रोफाईल बनाउन सकिएन"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "लक्षित सेतोबिन्दु प्राप्त गर्न सकिने थिएन ।"
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "पूर्ण !"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "क्यालिब्रसन असफल!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "क्यालिब्रसन यन्त्र हटाउन सक्नुहुन्छ ।"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "अंशांकन प्रगतिमा हुँदा यन्त्रमा नचालाउनुहोस्"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "क्यामेरा;फोटो;भिडियो;वेबक्याम;लक;निजी;गोपनीयता;"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "क्यालिब्रसन प्रदर्शन गर्नुहोस्"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "रद्द गर्नुहोस्"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -557,137 +399,9 @@ msgstr "पुन: निरन्तरता दिनुहोस्"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "गरियो"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "ल्याकटप पर्दा"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "अवस्थित वेवक्याम"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s मोनिटर"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s स्क्यानर"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s क्यामेरा"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s मुद्रक"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s वेवक्याम"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s रङ व्यवस्थापनका सक्षम गर्नुहोस्"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s को रङ्ग प्रोफाईल देखाउनुहोस्"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "क्यालिब्रेट नगरिएको"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "पुर्वनिर्धारित "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "रङ्ग भर्ने स्थान "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "नमुना प्रोफाइल "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "ICC प्रोफाइल रोज्नुहोस्"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "आयात गर्नुहोस्"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "ICC प्रोफाइल "
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303 panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "सबै फाइलहरू"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "पर्दा"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "प्रोफाईल बचत गर"
-
-#: panels/color/cc-color-panel.c:845 panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "बचत गर्नुहोस्"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "चयन यन्त्र लागि एक रङ प्रोफाइल सिर्जना गर्नुहोस्"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and correctly connected."
-msgstr "मापन यन्त्र भेटिएन । सो यन्त्र जोडिएको छ र खुला छ भन्ने सुनिश्चित गर्नुहोस् ।"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "नाप्ने यन्त्रले प्रिन्टर प्रोफाइल समर्थन गर्दैन"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "यस प्रकारको यन्त्र समर्थित छैन ।"
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -699,14 +413,16 @@ msgstr "क्यालिब्रसन गुणस्तर"
 
 #: panels/color/cc-color-panel.ui:21
 msgid ""
-"Calibration will produce a profile that you can use to color manage your screen. The longer you "
-"spend on calibration, the better the quality of the color profile."
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
 msgstr ""
-"क्यालिब्रेसनले प्रोफाईल उत्पादन गर्नेछ जुन तपाइँले तपाइँको स्क्रीन प्रबन्ध गर्न सक्नुहुनेछ। लामो समयसम्म तपाईंले "
-"क्यालिब्रेसनमा खर्च गर्नुहुन्छ, रङ प्रोफाइलको गुणस्तर राम्रो।"
+"क्यालिब्रेसनले प्रोफाईल उत्पादन गर्नेछ जुन तपाइँले तपाइँको स्क्रीन प्रबन्ध गर्न सक्नुहुनेछ। लामो "
+"समयसम्म तपाईंले क्यालिब्रेसनमा खर्च गर्नुहुन्छ, रङ प्रोफाइलको गुणस्तर राम्रो।"
 
 #: panels/color/cc-color-panel.ui:28
-msgid "You will not be able to use your computer while calibration takes place."
+msgid ""
+"You will not be able to use your computer while calibration takes place."
 msgstr "अंशांकन हुन्जेल तपाईं आफ्नो कम्प्युटर प्रयोग गर्न सक्नुहुन्न।"
 
 #. This is the approximate time it takes to calibrate the display.
@@ -740,8 +456,12 @@ msgid "Profile Whitepoint"
 msgstr "प्रोफाइल सेतोविन्दु"
 
 #: panels/color/cc-color-panel.ui:160
-msgid "Select a display target white point. Most displays should be calibrated to a D65 illuminant."
-msgstr "एक प्रदर्शन लक्ष्य सेतो बिन्दु चयन गर्नुहोस्। प्रायः प्रदर्शनहरू डि-६५ प्रकाशकका लागि क्यालिब्रेट हुनु पर्छ."
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"एक प्रदर्शन लक्ष्य सेतो बिन्दु चयन गर्नुहोस्। प्रायः प्रदर्शनहरू डि-६५ प्रकाशकका लागि "
+"क्यालिब्रेट हुनु पर्छ."
 
 #: panels/color/cc-color-panel.ui:187
 msgid "Display Brightness"
@@ -749,17 +469,19 @@ msgstr "पर्दा चम्किलोपन"
 
 #: panels/color/cc-color-panel.ui:195
 msgid ""
-"Please set the display to a brightness that is typical for you. Color management will be most "
-"accurate at this brightness level."
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
 msgstr ""
-"कृपया प्रदर्शनलाई एक चमकमा सेट गर्नुहोस् जुन तपाईंको लागि ठेट हो। यस चमक स्तरमा रङ्ग व्यवस्थापन अधिक सटीक हुनेछ।"
+"कृपया प्रदर्शनलाई एक चमकमा सेट गर्नुहोस् जुन तपाईंको लागि ठेट हो। यस चमक स्तरमा रङ्ग "
+"व्यवस्थापन अधिक सटीक हुनेछ।"
 
 #: panels/color/cc-color-panel.ui:202
 msgid ""
-"Alternatively, you can use the brightness level used with one of the other profiles for this "
-"device."
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
 msgstr ""
-"वैकल्पिक रूपमा, तपाईं यस यन्त्रको लागि अन्य प्रोफाइलहरू मध्ये एक प्रयोग गरिएको चमक तह प्रयोग गर्न सक्नुहुनेछ।."
+"वैकल्पिक रूपमा, तपाईं यस यन्त्रको लागि अन्य प्रोफाइलहरू मध्ये एक प्रयोग गरिएको चमक तह "
+"प्रयोग गर्न सक्नुहुनेछ।."
 
 #: panels/color/cc-color-panel.ui:214
 msgid "Profile Name"
@@ -767,11 +489,11 @@ msgstr "प्रोफाइल नाम"
 
 #: panels/color/cc-color-panel.ui:222
 msgid ""
-"You can use a color profile on different computers, or even create profiles for different "
-"lighting conditions."
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
 msgstr ""
-"तपाईँले विभिन्न कम्प्युटरमा रङ प्रोफाइल प्रयोग गर्न सक्नुहुन्छ, वा फरक प्रकाश अवस्थाका लागि प्रोफाइलहरू सिर्जना गर्न "
-"सक्नुहुन्छ ।"
+"तपाईँले विभिन्न कम्प्युटरमा रङ प्रोफाइल प्रयोग गर्न सक्नुहुन्छ, वा फरक प्रकाश अवस्थाका लागि "
+"प्रोफाइलहरू सिर्जना गर्न सक्नुहुन्छ ।"
 
 #: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
@@ -795,27 +517,34 @@ msgstr "लेख्न मिल्ने मिडियाको आवश्
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux\">GNU/Linux</a>, <a "
-"href=\"osx\">Apple OS X</a> and <a href=\"windows\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"तपाईँले प्रोफाइल कसरी प्रयोग गर्ने भन्ने सन्दर्भमा यी निर्देशनहरू फेला पार्न सक्नुहुन्छ <a href=\"linux\">GNU/Linux</"
-"a>, <a href=\"osx\">Apple OS X</a> र <a href=\"windows\">Microsoft Windows</a> प्रणाली उपयोगी हुन्छ।"
+"तपाईँले प्रोफाइल कसरी प्रयोग गर्ने भन्ने सन्दर्भमा यी निर्देशनहरू फेला पार्न सक्नुहुन्छ <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> र <a "
+"href=\"windows\">Microsoft Windows</a> प्रणाली उपयोगी हुन्छ।"
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "प्रोफाइल थप्नुहोस्"
 
 #: panels/color/cc-color-panel.ui:373
-msgid "Problems detected. The profile may not work correctly. <a href=\"\">Show details.</a>"
-msgstr "समस्या देखा परेको छ। प्रोफाइल काम नगर्न सक्छन् । <a href=\"\">विस्तृत विवरणहरू हेर्नुहोस् ।</a>"
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"समस्या देखा परेको छ। प्रोफाइल काम नगर्न सक्छन् । <a href=\"\">विस्तृत विवरणहरू हेर्नुहोस् ।"
+"</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
 msgstr "फाईल आयात…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84 panels/user-accounts/cc-add-user-dialog.ui:39
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "थप्नुहोस्"
 
@@ -823,8 +552,7 @@ msgstr "थप्नुहोस्"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "रङ देखाउन हरेक यन्त्रको रङ प्रोफाइल अद्यावधिक हुनु आवश्यक छ।"
 
-#. translators: Text used in link to privacy policy
-#: panels/color/cc-color-panel.ui:434 panels/diagnostics/cc-diagnostics-panel.c:137
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "अरु जान्नुहोस्"
 
@@ -956,98 +684,18 @@ msgstr "डि६५ (फोटोग्राफि र ग्राफिक�
 msgid "D75"
 msgstr "डि७५"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "सेतो खालीस्थान"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "नमुना प्रोफाइल"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "स्वचालित"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "तल्लो गुणस्तर"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "मध्यम गुणस्तर"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "उच्च गुणस्तर"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "पुर्वनिर्धारित  RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "पुर्वनिर्धारित  CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "पुर्वनिर्धारित कैलो"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "विक्रेताले कारखाना अंशांकन डाटा प्रदान गर्यो"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "यो प्रोफाइलसँग पूरा-पर्दा प्रदर्शन सुधार सम्भव छैन"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "यो प्रोफाइल अब सही नहुन सक्छ"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "रङ"
 
 #: panels/color/gnome-color-panel.desktop.in.in:4
-msgid "Calibrate the color of your devices, such as displays, cameras or printers"
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "तपाईँको यन्त्र, जस्तै प्रदर्शन, क्यामेरा वा मुद्रकको रङ क्यालिब्रेट गर्नुहोस्"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "रङ;आइसिसी;प्रोफाइल;क्यालिब्रेट;मुद्रणयन्त्र;डिस्प्ले;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "अन्य…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1061,19 +709,15 @@ msgstr "चयन गर्नुहोस्"
 msgid "No languages found"
 msgstr "कुनै भाषा फेला परेन"
 
-#: panels/common/cc-language-chooser.ui:69 panels/keyboard/cc-input-chooser.c:173
+#: panels/common/cc-language-chooser.ui:69
 msgid "More…"
 msgstr "अरू…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "सेटिङ परिवर्तन गर्न ताल्चा खोल्नुहोस्"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "केही सेटिङ हरू परिवर्तन गर्नु पहिले ताल्चा खोलिएको हुनुपर्छ ।"
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "ताल्चा हटाउनुहोस्…"
 
@@ -1097,150 +741,8 @@ msgstr "घट्दो घण्टा"
 msgid "Decrement Minute"
 msgstr "मिनेट घट्डोक्रम"
 
-#: panels/common/cc-util.c:127 panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "आज"
-
-#: panels/common/cc-util.c:131 panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "हिजो"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d घन्टा"
-msgstr[1] "%d घन्टा"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d मिनेट"
-msgstr[1] "%d मिनेट"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d सेकेन्ड"
-msgstr[1] "%d सेकेन्ड"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "० सेकेण्ड"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "हटस्पट"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "२४ घण्टा"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "१२ घन्टा (AM/PM)"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:15 panels/datetime/gnome-datetime-panel.desktop.in.in:3
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "मिति र समय"
 
@@ -1320,31 +822,67 @@ msgstr "स्वतः मिति र समय"
 msgid "Requires internet access"
 msgstr "ईन्टर्नेट हुनु आवश्यक"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "मिति र समय"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "स्वत: समय क्षेत्र"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "स्थान सेवा सक्षम र इन्टरनेट पहुँच आवश्यक छ"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "सक्षम पारिएको"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "समय क्षेत्र"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ताल्चा खोल्नुहोस्"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "समय ढाँचा"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "मिति"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "० सेकेण्ड"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "पात्रो"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "सङ्ख्याहरू"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "समय क्षेत्र सहित मिति र समय परिवर्तन गर्नुहोस"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "घडी;समय क्षेत्र;स्थान;"
@@ -1390,20 +928,9 @@ msgstr "पुर्वनिर्धारित अनुप्रयोग"
 msgid "Configure Default Applications"
 msgstr "पुर्वनिर्धारित अनुप्रयोग कन्फिगर"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "पूर्वनिर्धारित;अनुप्रयोग;रुचाइएको;मिडिया;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent anonymously and are "
-"scrubbed of personal data. %s"
-msgstr ""
-"प्राविधिक समस्याहरूको प्रतिवेदन पठाउँदा %s सुधार गर्न मद्दत गर्दछ । रिपोर्टहरू गुप्त रूपमा पठाइन्छ र व्यक्तिगत "
-"जानकारी कोरिन्छ। %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1421,192 +948,175 @@ msgstr "निदान"
 msgid "Report your problems"
 msgstr "तपाईँको समस्याहरू प्रतिवेदन गर्नुहोस्"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20 panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;privacy;"
-msgstr "पर्दा;ताल्चा;निदान;क्र्यास;निजी;हालैको;अस्थायी;tmp;index;नाम;सञ्जाल;पहिचान;गोपनीयता;"
+msgid "diagnostics;crash;"
+msgstr "निदान;दुर्घटना;"
 
-#: panels/display/cc-display-panel.c:512 panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:336 panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478 panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "खुला छ"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217 panels/power/cc-power-panel.c:728
-#: panels/power/cc-power-panel.c:739 panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468 panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490 panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "बन्द"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "परिवर्तन लागू गर्नुहोस्?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "परिवर्तनहरू लागू गर्न सकिँदैन"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "यो हार्डवेयरको सीमितताले गर्दा हुन सक्छ ।"
-
-#: panels/display/cc-display-panel.ui:43 panels/network/connection-editor/connection-editor.ui:21
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "लागू गर्नुहोस्"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "पछाडि"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr "दृश्यात्मक सेटिङ असक्षम पारियो"
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "प्रदर्शन व्यवस्था"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "धेरैवटा पर्दा"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "जोड्नुहोस्"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "दर्पण"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "माथिल्लो पट्टी र क्रियाकलाप समाविष्ट गर्दछ"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "प्रमुख डिस्प्ले"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175 panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "रातको उज्यालो"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "ल्याण्डस्केप"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "पोर्ट्रेट दाँया"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "पोर्ट्रेट बाँया"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "ल्यान्डस्केप (फ्लिप गरिएको)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf हर्ज"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "अभिमूखिकरण"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "रिजोल्युसन"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "पुनसुचारु दर"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "टि भि समायोजन गर्नुहोस्"
 
-#: panels/display/cc-display-settings.ui:75 panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "मापन गर्नुहोस्"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "प्राकृतिक स्क्रोलिङ"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "रात प्रकाश उपलब्ध छैन"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"यो ग्राफिक्स ड्राइभर प्रयोग भइरहेको, वा डेस्कटप टाढाबाट प्रयोग भइरहेको परिणाम हुन सक्छ"
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "भोलि सम्म अस्थाई निस्क्रिय"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "फिल्टर पून सुरू गर्नु"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
-"Night light makes the screen color warmer. This can help to prevent eye strain and sleeplessness."
-msgstr "रातको प्रकाशले पर्दाको रङलाई तातो बनाउँदछ । यसले आँखाको तनाव र निन्द्रा नलाग्न मदत गर्न सक्छ।"
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"रातको प्रकाशले पर्दाको रङलाई तातो बनाउँदछ । यसले आँखाको तनाव र निन्द्रा नलाग्न मदत "
+"गर्न सक्छ।"
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "समय तालिका"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "सूर्यास्ट देखि सूर्योदय"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "म्यानुअल तालिका"
 
-#: panels/display/cc-night-light-page.ui:110 panels/region/cc-format-preview.ui:35
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "समय"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "बाट"
 
-#: panels/display/cc-night-light-page.ui:148 panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "घण्टा"
 
-#: panels/display/cc-night-light-page.ui:154 panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171 panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "मिनेट"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181 panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "पूर्वाह्न"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193 panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "अपराह्न"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "लाई"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "रङ्ग तापक्रम"
 
@@ -1617,64 +1127,62 @@ msgstr "प्रदर्शन"
 #: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr ""
-"तपाईँको माउस वा टचप्याड संवेदनशीलता परिवर्तन गर्नुहोस् र दायाँ वा बायाँ-हाते चयन गर्नुहोस् जडान गरिएको मोनिटर र "
-"प्रोजेक्टर कसरी प्रयोग गर्ने रोज्नुहोस्"
+"तपाईँको माउस वा टचप्याड संवेदनशीलता परिवर्तन गर्नुहोस् र दायाँ वा बायाँ-हाते चयन गर्नुहोस् "
+"जडान गरिएको मोनिटर र प्रोजेक्टर कसरी प्रयोग गर्ने रोज्नुहोस्"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
-"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;color;sunset;"
-"sunrise;"
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
 msgstr ""
-"प्यानल; प्रोजेक्टर;xrandr; पर्दा; पर्दा रिजोल्युसन; ताजा पार्नुहोस्; मोनिटर; रात; प्रकाश; नीलो;रेडसिफ्ट;रङ;"
-"सूर्यास्त;सूर्योदय;"
+"प्यानल; प्रोजेक्टर;xrandr; पर्दा; पर्दा रिजोल्युसन; ताजा पार्नुहोस्; मोनिटर; रात; "
+"प्रकाश; नीलो;रेडसिफ्ट;रङ;सूर्यास्त;सूर्योदय;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511 panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "अज्ञात"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; निर्माण :%s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr "सुरक्षाको तह"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "६४-विट"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "तह १"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "३२-विट"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "तह २"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "एक्स ११"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "३ तह"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "व्यल्यान्ड"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "घटनाहरू छैन"
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "अज्ञात"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "सुरक्षा यन्त्र"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "प्रणाली लोगो"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.ui:32 panels/sharing/cc-sharing-panel.ui:299
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"पर्दा;ताल्चा;निदान;क्र्यास;निजी;हालैको;अस्थायी;tmp;index;नाम;सञ्जाल;पहिचान;गोपनीयता;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "उपकरण नाम"
 
@@ -1707,37 +1215,53 @@ msgstr "गणना गरिदै…"
 msgid "OS Name"
 msgstr "OS नाम"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "सञ्चालन प्रणाली निर्माण आईडी"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "OS प्रकार"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "जिनोम संस्करण"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "लोड गर्दैछ…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "सञ्झ्याल प्रणाली"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "अवास्तविकरण"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "सफ्टवेयर अद्यावधिकहरू"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "उपकरण पुन: नामकरण गर्नुहोस्"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
-msgid ""
-"The device name is used to identify this device when it is viewed over the network, or when "
-"pairing Bluetooth devices."
-msgstr "यन्त्र नाम यो यन्त्र लाई सञ्जाल माथि हेरेपछि, वा ब्लुटुथ यन्त्रहरू जोडिदा पहिचान गर्न प्रयोग गरिन्छ ।"
-
 #: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"यन्त्र नाम यो यन्त्र लाई सञ्जाल माथि हेरेपछि, वा ब्लुटुथ यन्त्रहरू जोडिदा पहिचान गर्न "
+"प्रयोग गरिन्छ ।"
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "यन्त्र नाम"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "पुन: नामकरण गर्नुहोस्"
 
@@ -1749,18 +1273,13 @@ msgstr "बारेमा"
 msgid "View information about your system"
 msgstr "तपाईँको प्रणाली बारेको सूचना हेर्नुहोस्"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
-"device;system;information;hostname;memory;processor;version;default;application;preferred;cd;dvd;"
-"usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
-"उपकरण;प्रणाली;जानकारी;होस्टनाम;स्मृति;प्रोसेसर;संस्करण;पूर्वनिर्धारित;अनुप्रयोग;उपयुक्त;सीडी;डीभिडी;यूएसबी;अडियो;"
-"भिडियो;डिस्क;हटाउन सकिने;मिडिया; स्वचालित;"
+"उपकरण;प्रणाली;जानकारी;होस्टनाम;स्मृति;प्रोसेसर;संस्करण;पूर्वनिर्धारित;अनुप्रयोग;उपयुक्त;"
+"सीडी;डीभिडी;यूएसबी;अडियो;भिडियो;डिस्क;हटाउन सकिने;मिडिया; स्वचालित;"
 
 #: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
@@ -1810,7 +1329,8 @@ msgstr "पछिल्लो ट्रयाक"
 msgid "Eject"
 msgstr "निकाल्नुहोस्"
 
-#: panels/keyboard/01-input-sources.xml.in:4 panels/universal-access/cc-ua-panel.ui:163
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "टाइप गर्दै"
 
@@ -1829,6 +1349,12 @@ msgstr "सुरुआत"
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "मद्दत ब्राउजर सुरुआत गर्नुहोस्"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "सेटिङ"
 
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -1851,7 +1377,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "खोजी गर्नुहोस्"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "प्रणाली"
 
@@ -1900,20 +1426,11 @@ msgstr "पाठ साइज घटाउनुहोस्"
 msgid "High contrast on or off"
 msgstr "हाई कन्ट्रास्ट अन अथवा अफ"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "कुनै पनि निर्गत श्रोत फेला परेन ।"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "अन्य"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "निर्गत श्रोत थप्नुहोस्"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "लगइन पर्दामा आगत विधिहरू प्रयोग गर्न सकिँदैन"
 
@@ -1921,110 +1438,29 @@ msgstr "लगइन पर्दामा आगत विधिहरू प�
 msgid "No input source selected"
 msgstr "निर्गत श्रोत चयन गरिएको छैन"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "विकल्पहरू"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "माथि सार्नुहोस्"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "तल सार्नुहोस्"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "प्राथमिकता"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "कुञ्जीपाटी रूपरेखा हेर्नुहोस्"
 
-#: panels/keyboard/cc-input-row.ui:51 panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "हटाउने"
-
-#: panels/keyboard/cc-keyboard-manager.c:485 panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "अनुकुलित सर्टकट"
-
-#: panels/keyboard/cc-keyboard-panel.c:64 panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "वैकल्पिक क्यारेक्टर कुञ्जी"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. These are sometimes "
-"printed as a third-option on your keyboard."
-msgstr ""
-"वैकल्पिक क्यारेक्टर कुञ्जीलाई थप क्यारेक्टरहरू प्रविष्ट गर्न प्रयोग गर्न सकिन्छ । यी कहिलेकाहीँ तपाईँको कुञ्जीपाटीमा "
-"तेस्रो-विकल्पको रूपमा मुद्रण गरिन्छ।"
-
-#: panels/keyboard/cc-keyboard-panel.c:67 panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "देब्रे alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68 panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "दाहिने alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69 panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "देब्रे super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70 panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "दाहिने super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71 panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "मेनु कुञ्जी"
-
-#: panels/keyboard/cc-keyboard-panel.c:72 panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "दाया Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80 panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "कम्पोज​ कि"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use it, press compose then "
-"a sequence of characters.  For example, compose key followed by <b>C</b> and <b>o</b> will enter "
-"<b>©</b>, <b>a</b> followed by <b>'</b> will enter <b>á</b>."
-msgstr ""
-"कम्पोज कुञ्जीले प्रविष्ट गर्नका लागि विभिन्न क्यारेक्टरहरूलाई अनुमति दिन्छ । यसलाई प्रयोग गर्न, त्यसपछि अक्षरहरूको "
-"क्रम रचना गर्नुहोस्।  उदाहरणका लागि, <b>सी</b> र <b>ओ</b> <b>©</b> प्रवेश गर्ने कुञ्जी रचना गर्नुहोस् <b>क</b> "
-"त्यसपछि <b>'</b> <b>á</b> प्रवेश गर्नेछ।"
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "क्यप्स लक"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "scroll lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "पर्दा मुद्रण गर्नुहोस्"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"आगत स्रोतहरू %s कुञ्जीपाटी सर्टकट प्रयोग गरेर स्विच गर्न सकिन्छ।\n"
-"यो कुञ्जीपाटी सर्टकट सेटिङमा परिवर्तन गर्न सकिन्छ ।"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2046,48 +1482,29 @@ msgstr "सबै सञ्झ्यालको लागि एकै श्�
 msgid "Switch input sources _individually for each window"
 msgstr "हरेक सञ्झ्यालका लागि आगत स्रोत व्यक्तिगत रूपमा स्विच गर्नुहोस्"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "विशेष वर्ण प्रविष्टि"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "कुञ्जीपाटी प्रयोग गरेर प्रतिमा र अक्षर विविधता प्रविष्ट गर्नका लागि विधिहरू ।"
 
-#: panels/keyboard/cc-keyboard-panel.ui:97 panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "वैकल्पिक क्यारेक्टर कुञ्जी"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "कम्पोज​ कि"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "कुञ्जीपाटी सर्टकट"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "सर्टकट हेर्नुहोस् र अनुकूलन गर्नुहोस्"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d परिमार्जित"
-msgstr[1] "%d परिमार्जित"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
-msgid "Reset All Shortcuts?"
-msgstr "सबै सर्टकटहरू रिसेट गर्नुहुन्छ?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Resetting the shortcuts may affect your custom shortcuts. This cannot be undone."
-msgstr "सर्टकट रिसेट गर्दा यसले तपाईंको अनुकूल सर्टकटलाई असर गर्न सक्छ। यो पूर्वावस्थामा लाउन सकिँदैन ।"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83 panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "रद्द गर्नुहोस्"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
-msgid "Reset All"
-msgstr "सबै रिसेट गर्नुहोस्"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2097,84 +1514,74 @@ msgstr "सबै रिसेट गर्नुहोस्…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "सबै सर्टकटहरूलाई तिनीहरूको पूर्वनिर्धारित कुञ्जीबाइन्डिङमा रिसेट गर्नुहोस्"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "खण्ड"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "सर्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "सर्टकट थप्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "अनुकुलित सर्टकट थप्नुहोस्"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
-msgstr "अनुप्रयोग सुरुआत गर्न, स्क्रिप्ट चलाउन, र अरू धेरैका लागि अनुकूल सर्टकट सेटअप गर्नुहोस् ।."
+msgstr ""
+"अनुप्रयोग सुरुआत गर्न, स्क्रिप्ट चलाउन, र अरू धेरैका लागि अनुकूल सर्टकट सेटअप गर्नुहोस् ।."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "सर्टकट थप्नुहोस्"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "कुञ्जीपाटी सर्टकट भेटिएन"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s पहिले नै %s का लागि प्रयोग भैरहेको छ । यदि तपाईँले यसलाई प्रतिस्थापन गर्नुभयो भने, %s अक्षम हुनेछ"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_हटाउनुहोस्"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "नयाँ सर्टकट टाइप गर्नुहोस्"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "प्रतिस्थापन"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "अनुकूलन सर्टकट सेट गर्नुहोस्"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "सर्टकट सेट गर्नुहोस्"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "%s परिवर्तन गर्न नयाँ सर्टकट प्रविष्ट गर्नुहोस् । "
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "अनुकूलन सर्टकट थप्नुहोस्"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "थप्नुहोस्"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
-msgstr "बदलनुहोस्"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr "सेट गर्नुहोस्"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr "कुञ्जीपाटी सर्टकट अक्षम पार्न रद्द गर्न वा Backspace थिच्नुहोस् ।"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153 panels/printers/pp-details-dialog.ui:39
-#: panels/user-accounts/cc-add-user-dialog.ui:68 panels/user-accounts/cc-user-panel.ui:132
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "नाम"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "आदेश"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "सर्टकट"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "कुनै सर्टकट सेट…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "कुनै पनि होइन"
 
@@ -2182,41 +1589,50 @@ msgstr "कुनै पनि होइन"
 msgid "Reset the shortcut to its default value"
 msgstr "यसको पूर्वनिर्धारित मानमा सर्टकट रिसेट गर्नुहोस्"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "पूर्वनिर्धारितहरूमा पुन: सेट गर्नुहोस्"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "कुञ्जीपाटी"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
 msgid ""
-"Change keyboard shortcuts and set your typing preferences, keyboard layouts and input sources"
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
-"कुञ्जीपाटी सर्टकट परिवर्तन गर्नुहोस् र तपाईँको टाइपिङ प्राथमिकता, कुञ्जीपाटी सजावट र आगत स्रोत सेट गर्नुहोस्"
+"कुञ्जीपाटी सर्टकट परिवर्तन गर्नुहोस् र तपाईँको टाइपिङ प्राथमिकता, कुञ्जीपाटी सजावट र "
+"आगत स्रोत सेट गर्नुहोस्"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
-msgid "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
-msgstr "सर्टकट; कार्यस्थान; सञ्झ्याल; रिसाइज गर्नुहोस्; जुम गर्नुहोस्; व्यतिरेक;आगत; स्रोत; ताल्चा लगाउनुहोस्; भोल्युम;"
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"सर्टकट; कार्यस्थान; सञ्झ्याल; रिसाइज गर्नुहोस्; जुम गर्नुहोस्; व्यतिरेक;आगत; स्रोत; ताल्चा "
+"लगाउनुहोस्; भोल्युम;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "स्थान सेवा बन्द गरियो"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "अनुप्रयोगले स्थान सूचना प्राप्त गर्न सक्दैन ।"
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and mobile broadband "
-"increases accuracy.\n"
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
 "\n"
-"Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/privacy'>Privacy "
-"Policy</a>\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
 "\n"
 "Allow the applications below to determine your location."
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "अनुप्रयोगले स्थान पहुँचका लागि सोधेको छैन"
 
@@ -2224,184 +1640,32 @@ msgstr "अनुप्रयोगले स्थान पहुँचका 
 msgid "Protect your location information"
 msgstr "तपाईँको स्थान जानकारि सुरक्षित गर्नुहोस्"
 
-#. FIXME
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "पर्दा बन्द गर्नुहोस्"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "स्थान;जीपीएस;निजी;गोपनीयता;"
 
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "३० सेकेण्ड"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "१ मिनेट"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "२ मिनेट"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "३ मिनेट"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "५ मिनेट"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "३० मिनेट"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "१ घन्टा"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "१ मिनेट"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "२ मिनेट"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "३ मिनेट"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "४ मिनेट"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "५ मिनेट"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "८ मिनेट"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "१० मिनेट"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "१२ मिनेट"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "१५ मिनेट"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "कहिल्यै पनि"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer while you're away."
-msgstr "पर्दामा स्वचालित रूपले ताल्चा लगाउँदा तपाईँ टाढा हुँदा अरूलाई कम्प्युटर पहुँच गर्नबाट रोकिन्छ ।."
-
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "खाली पर्दा ढिलाई"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "निस्क्रियताको अवधि जस पछि पर्दा खाली हुन्छ ।"
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "स्वत: पर्दामा ताल्चा"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "स्वत: पर्दामा ताल्चा ढिलाइ"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "पर्दा स्वत: ताल्चा लगाएको बेलामा पर्दा खाली गरेपछिको अवधि ।"
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "ताल्चा लागेको पर्दामा सूचनाहरू देखाउनुहोस्"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "नयाँ युएसबि यन्त्र निषेध गर्नुहोस्"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid "Prevent new USB devices from interacting with the system when the screen is locked."
-msgstr "पर्दामा ताल्चा लगाएको बेलामा नयाँ USB यन्त्रलाई प्रणालीसँग अन्तरक्रिया गर्नबाट रोक्नुहोस् ।"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "पर्दा ताल्चा लगाउनुहोस्"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "पर्दा ताल्चा लगाउनुहोस्"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "माईक्रोफोन बन्द गरियो"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "कुनै अनुप्रयोगले ध्वनि रेकर्ड गर्न सक्दैन ।"
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 #, fuzzy
-#| msgid ""
-#| "Use of the microphone allows applications to record and listen to audio. Disabling the "
-#| "microphone may cause some applications to not function properly."
 msgid ""
-"Use of the microphone allows applications to record and listen to audio. Disabling the microphone "
-"may cause some applications to not function properly.\n"
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
 "\n"
 "Allow the applications below to use your microphone."
 msgstr ""
-"माइक्रोफोनको प्रयोगले अनुप्रयोगलाई रेकर्ड गर्न र अडियोको सञ्जाल स्रोतमा संसाधनका लागि मात्र यो जडान प्रयोग गर्न "
-"अनुमति दिन्छ । माइक्रोफोन अक्षम पार्नाले केही अनुप्रयोगहरू राम्रोसँग काम नगर्न सक्छन्।"
+"माइक्रोफोनको प्रयोगले अनुप्रयोगलाई रेकर्ड गर्न र अडियोको सञ्जाल स्रोतमा संसाधनका लागि "
+"मात्र यो जडान प्रयोग गर्न अनुमति दिन्छ । माइक्रोफोन अक्षम पार्नाले केही अनुप्रयोगहरू "
+"राम्रोसँग काम नगर्न सक्छन्।"
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "माइक पहुँचका लागि कुनै अनुप्रयोगले सोधेको छैन"
 
@@ -2409,12 +1673,16 @@ msgstr "माइक पहुँचका लागि कुनै अनु�
 msgid "Protect your conversations"
 msgstr "तपाईँको वार्तालाप सुरक्षित गर्नुहोस्"
 
-#. FIXME
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "माइक्रोफोन;रेकर्डिङ;अनुप्रयोग;गोपनीयता;"
+
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "सेटिङहरू परिक्षण गर्नुहोस्:"
 
-#: panels/mouse/cc-mouse-panel.ui:23 panels/multitasking/cc-multitasking-panel.ui:9
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
 msgid "General"
 msgstr "साधारण"
 
@@ -2426,93 +1694,161 @@ msgstr "मुख्य बटन"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "माउस र टचप्याडमा भौतिक बटनको क्रम सेट गर्दछ ।."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "देब्रे"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "दाहिने"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "स्थान (हरूमा) खोजी गर्नुहोस्"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "माउस"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "माउस गति"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "प्राकृतिक स्क्रोलिङ"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "तल स्क्रोल गर्नुहोस्"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "स्क्रोलिङ्ग ले सामग्रीलाई सार्दछ , दृश्य होइन।"
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "स्क्रोलिङ्ग ले सामग्रीलाई सार्दछ , दृश्य होइन।"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "गतिवर्धन:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "सक्रिय गर्नुहोस्"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "ट्चप्याड"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "टचप्याड गति"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "विधि"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "क्लिक गर्नुस थिच्न"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "दुई औला स्क्रोलिङ्ग"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr "क्लिक गर्नु थिच्नुहोस्"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr " टाइप गर्दा अक्षम पार्नुहोस्"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "ट्चप्याड()"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "छेउस्क्रोलिङ्ग"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "तल स्क्रोल गर्नुहोस्"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "दुबैपट्टी"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "थिच्न , दुई चोटी थिच्न ,इस्क्रोल्ल कोसिस गर्नुस"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "पाँच क्लिक, GEGL समय!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "मुख्य बटन दुई चोटी थिच्नुहोस"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "मुख्य बटन एक पटक थिच्नुहोस"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "बीच को बटन दुई चोटी थिच्नुहोस"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "बीच को बटन एक चोटी थिच्नुहोस"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "साहायक बटन दुई चोटी थिच्नुहोस"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "सहायक बटन एक चोटी थिच्नुहोस"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "माउस र टचप्याड"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:4
-msgid "Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr "तपाईँको माउस वा टचप्याड संवेदनशीलता परिवर्तन गर्नुहोस् र दायाँ वा बायाँ-हाते चयन गर्नुहोस्"
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"तपाईँको माउस वा टचप्याड संवेदनशीलता परिवर्तन गर्नुहोस् र दायाँ वा बायाँ-हाते चयन गर्नुहोस्"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "ट्रयाकप्याड; सूचक; क्लिक; ट्याप; डबल; बटन; ट्रयाक्बल;स्कोल;"
@@ -2520,7 +1856,7 @@ msgstr "ट्रयाकप्याड; सूचक; क्लिक; ट्
 #: panels/multitasking/cc-multitasking-panel.ui:15
 #, fuzzy
 msgid "_Hot Corner"
-msgstr "तातो बेसारे"
+msgstr "हट..."
 
 #: panels/multitasking/cc-multitasking-panel.ui:16
 msgid "Touch the top-left corner to open the Activities Overview."
@@ -2531,7 +1867,8 @@ msgid "_Active Screen Edges"
 msgstr "सक्रिय पर्दा किनारा"
 
 #: panels/multitasking/cc-multitasking-panel.ui:43
-msgid "Drag windows against the top, left, and right screen edges to resize them."
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
 msgstr "सञ्झ्यालहरूलाई रिसाइज गर्न माथिल्लो, बायाँ, र दायाँ पर्दा किनाराहरूमा तान्नुहोस् ।"
 
 #: panels/multitasking/cc-multitasking-panel.ui:70
@@ -2584,87 +1921,44 @@ msgstr "हालको कार्यस्थानबाट मात्र 
 
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
 msgid "Multitasking"
-msgstr ""
+msgstr "मल्टिटास्किङ"
 
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
 msgid "Manage preferences for productivity and multitasking"
 msgstr "उत्पादकत्व र मल्टिटास्किङका लागि प्राथमिकता प्रबन्ध गर्नुहोस्"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+#, fuzzy
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr "मल्टिटास्किङ; बहुँविध कार्य; उत्पादकत्व;अनुकूलन;डेस्कटप "
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "ओहो, केही गलत भएको छ। कृपया आफ्नो सफ्टवेयर विक्रेता सँग सम्पर्क गर्नुहोस् ।"
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "नेट्वोर्क म्यानेजर चलिरहन गर्न आवश्यक छ।"
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "अरु यन्त्रहरू"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "भीपीएन"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "जडान थप्नुहोस्"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "सेटअप भएको छैन"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "असुरक्षित सञ्जाल (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "सुरक्षित सञ्जाल WPA"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "सुरक्षित सञ्जाल WPA2"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "सुरक्षित सञ्जाल WPA3"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "सुरक्षित सञ्जाल"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "जडान गरियो"
 
-#: panels/network/cc-wifi-connection-row.ui:62 panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "विकल्पहरू…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible to access the "
-"internet through Wi-Fi."
-msgstr "हटस्पट खोल्दा %s बाट विच्छेदन हुनेछ, र वाई-फाई मार्फत इन्टरनेट पहुँच सम्भव हुदैन ।"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "न्यूनतम ८ क्यारेक्टर हुनुपर्दछ"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -2679,349 +1973,103 @@ msgstr "वाई-फाई हटस्पट खोल्नुहोस्?"
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
-"Wi-Fi hotspot allows others to share your internet connection, by creating a Wi-Fi network that "
-"they can connect to. To do this, you must have an internet connection through a source other than "
-"Wi-Fi."
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
 msgstr ""
-"वाई-फाई हटस्पटले अरूलाई तिनीहरूले जडान गर्न सक्ने वाई-फाई सञ्जाल सिर्जना गरेर, तपाईँको इन्टरनेट जडान साझेदारी "
-"गर्न अनुमति दिन्छ। यसो गर्न, तपाईं Wi-Fi बाहेक अन्य स्रोत मार्फत इन्टरनेट जडान हुनुपर्छ."
+"वाई-फाई हटस्पटले अरूलाई तिनीहरूले जडान गर्न सक्ने वाई-फाई सञ्जाल सिर्जना गरेर, तपाईँको "
+"इन्टरनेट जडान साझेदारी गर्न अनुमति दिन्छ। यसो गर्न, तपाईं Wi-Fi बाहेक अन्य स्रोत मार्फत "
+"इन्टरनेट जडान हुनुपर्छ."
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
 msgstr "सञ्जाल  नाम"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74 panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
-#: panels/user-accounts/cc-add-user-dialog.ui:145 panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362 panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "पासवर्ड"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "अनियमित पासवर्ड उत्पन्न गर्नुहोस्"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "स्वत: उत्पन्न पासवर्ड"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "खोल्नु"
 
-#: panels/network/cc-wifi-panel.c:544 panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "वाई-फाई"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "हटस्पट बन्द गर्ने कुनै पनि प्रयोगकर्ता छुटाउने हो?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "हटस्पट रोक्नुहोस्"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "हवाइजहाज मोड"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Wi-Fi, ब्लुटुथ र मोबाइल ब्रडब्यान्ड अक्षम पार्दछ"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "कुनै पनि वाई-फाई एडप्टर फेला परेन"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "तपाईँले एउटा वाई-फाई एडप्टर प्लगइन गरेर खुला गर्नुभएको छ भन्ने निश्चित गर्नुहोस्"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "एअरप्लेन मोड राख्नु"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "वाई-फाई प्रयोग गर्न बन्द गर्नुहोस्"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "वाई-फाई हटस्पट सक्रिय गर्नुहोस्"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "मोबाइल यन्त्रले जडान गर्न QR कोड स्क्यान गर्न सक्दछ ।"
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "हटस्पट बन्द गर्नुहोस्…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "देखिने सञ्जाल"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "सञ्जाल प्रवन्धक चलि रहन आवश्यक छ।"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "ओहो, केही गलत भएको छ। कृपया आफ्नो सफ्टवेयर विक्रेता सँग सम्पर्क गर्नुहोस् ।"
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x सुरक्षा"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "सुरक्षा"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "सरक्षण गर्नुहोस्"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "स्थायी"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "अनियमित"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "स्थिर"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the network device this "
-"connection is activated on. This feature is known as MAC cloning or spoofing. Example: "
-"00:11:22:33:44:55"
-msgstr ""
-"यहाँ प्रविष्ट गरिएको MAC ठेगाना यो जडान सक्रिय पारिएको सञ्जाल यन्त्रका लागि हार्डवेयर ठेगानाको रूपमा प्रयोग "
-"गरिनेछ । यो विशेषतालाई MAC क्लोनिङ वा स्पूफिङ भनिन्छ । उदाहरण: ००:११:२२:३३:४४:५५"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "प्रोफाइल %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97 panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101 panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "विस्तारित खुला"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "ईन्टरप्राईज"
-
-#: panels/network/connection-editor/ce-page-details.c:130 panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "कुनै पनि होइन"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "कहिले पनि होइन"
-
-#: panels/network/connection-editor/ce-page-details.c:166 panels/network/net-device-ethernet.c:105
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i दिन अघि"
 msgstr[1] "%i दिन अघि"
 
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295 panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d एम बी/से"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "कुनै पनि होइन"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "कमजोर"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ठिक छ"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "असल"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "उत्तम"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94 panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 ठेगाना"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110 panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "IPv6 ठेगाना"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413 panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151 panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "आईपी ठेगाना"
-
-#: panels/network/connection-editor/ce-page-details.c:417 panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418 panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165 panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169 panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453 panels/network/net-device-mobile.c:454
-#: panels/network/network-mobile.ui:203 panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "जडान भुल्नुहोस्"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "जडान प्रोफाईल हटाउनुहोस्"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "भीपीएन हटाउनुहोस्"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "विस्तृत विवरणहरू"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "स्वचालित"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "परिचय"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "ठेगाना पुस्तिका  मेट्नुहोस्"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "पथ मेट्नुहोस्"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "कुनै पनि होइन"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit Key (Hex or ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit पासफ्रेज"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "गतिशील WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
-
-#: panels/network/connection-editor/details-page.ui:14 panels/wwan/cc-wwan-details-dialog.ui:73
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "सङ्केत शक्ति"
 
@@ -3029,7 +2077,20 @@ msgstr "सङ्केत शक्ति"
 msgid "Link speed"
 msgstr "लिङ्क गति"
 
-#: panels/network/connection-editor/details-page.ui:126 panels/network/net-device-ethernet.c:154
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "सुरक्षा"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 ठेगाना"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 ठेगाना"
+
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "हार्डवेयर ठेगाना"
 
@@ -3037,11 +2098,18 @@ msgstr "हार्डवेयर ठेगाना"
 msgid "Supported Frequencies"
 msgstr "समर्थित पुनरावृत्तिहरू"
 
-#: panels/network/connection-editor/details-page.ui:158 panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160 panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "पूर्वनिर्धारित पथ"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3055,12 +2123,13 @@ msgstr "स्वतः जडान गर्नुहोस्"
 msgid "Make available to _other users"
 msgstr "अन्य प्रयोगकर्तालाई उपलव्ध गराउनुहोस्"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr "मिटरगरिएको जडान: डाटा सीमा छ वा शुल्क लिन सक्छ"
 
-#: panels/network/connection-editor/details-page.ui:421
-msgid "Software updates and other large downloads will not be started automatically."
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
 msgstr "सफ्टवेयर अद्यावधिक र अन्य ठूला डाउनलोडहरू स्वचालित रूपमा सुरु गरिने छैन।"
 
 #: panels/network/connection-editor/ethernet-page.ui:21
@@ -3094,72 +2163,95 @@ msgstr "IPv_4 बिधी"
 msgid "Automatic (DHCP)"
 msgstr "स्वचालित"
 
-#: panels/network/connection-editor/ip4-page.ui:45 panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "लिङ्क स्थानीय मात्र"
 
-#: panels/network/connection-editor/ip4-page.ui:55 panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "म्यानुअल"
 
-#: panels/network/connection-editor/ip4-page.ui:65 panels/network/connection-editor/ip6-page.ui:75
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "असक्षम पार्नुहोस्"
 
-#: panels/network/connection-editor/ip4-page.ui:75 panels/network/connection-editor/ip6-page.ui:85
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
 msgid "Shared to other computers"
 msgstr "अन्य कम्प्युटरमा साझेदार गरिएको"
 
-#: panels/network/connection-editor/ip4-page.ui:98 panels/network/connection-editor/ip6-page.ui:108
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "ठेगानाहरू"
 
-#: panels/network/connection-editor/ip4-page.ui:112 panels/network/connection-editor/ip4-page.ui:246
-#: panels/network/connection-editor/ip6-page.ui:122 panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "ठगाना"
 
-#: panels/network/connection-editor/ip4-page.ui:124 panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "नेटमास्क"
 
-#: panels/network/connection-editor/ip4-page.ui:136 panels/network/connection-editor/ip4-page.ui:270
-#: panels/network/connection-editor/ip6-page.ui:146 panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "गेटवे"
 
-#: panels/network/connection-editor/ip4-page.ui:175 panels/network/connection-editor/ip4-page.ui:223
-#: panels/network/connection-editor/ip6-page.ui:36 panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232 panels/network/net-proxy.c:73
-#: panels/network/network-proxy.ui:91 panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "स्वचालित"
 
-#: panels/network/connection-editor/ip4-page.ui:183 panels/network/connection-editor/ip6-page.ui:193
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "स्वचालित डिएनएस"
 
-#: panels/network/connection-editor/ip4-page.ui:196 panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "डीएनएस सर्भर ठेगाना(हरू)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "अल्पविरामद्वारा आईपी ठेगाना छुट्याउनुहोस्"
 
-#: panels/network/connection-editor/ip4-page.ui:213 panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "पथ"
 
-#: panels/network/connection-editor/ip4-page.ui:231 panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "स्वचालित पथ"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281 panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "मेट्रिक"
 
-#: panels/network/connection-editor/ip4-page.ui:304 panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "यसको सञ्जालमा संसाधनका लागि मात्र यो जडान प्रयोग गर्नुहोस् ।"
 
@@ -3171,81 +2263,14 @@ msgstr "IPv_6 बिधी"
 msgid "Automatic, DHCP only"
 msgstr "स्वचालित DHCP मात्रै"
 
-#: panels/network/connection-editor/ip6-page.ui:134 panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "PREFIX"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "जडान सम्पादक खोल्न सकिएन"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "नायाँ प्रोफाइल"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "फाईलबाट आयात गर्नुहोस्…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "भीपीएन थप्नुहोस्"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "सुरक्षा"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "भीपीएन जडान आयात गर्न सकिएन"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"फाइल \"%s\" पढ्न सकिएन वा पहिचान गरिएको भीपीएन जडान सूचना समावेश गर्दैन\n"
-"\n"
-"त्रुटि: %s ."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "आयात गर्न फाइल चयन गर्नुहोस्"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "'%s' नाम गरेको फाइल पहिले नै अवस्थित छ ।."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "बदल्नुहोस्"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "तपाईँले बचत गरिरहनु भएको भीपीएन जडानसँग %s बदल्न चाहनुहुन्छ?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "भीपीएन जडान निर्यातगर्न सकिएन"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"भीपीएन जडान \"%s\" %sमा निर्यात गर्न सकेन ।\n"
-"\n"
-"त्रुटि: %s ."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "भीपीएन जडान निर्यात गर्नुहोस्"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3259,100 +2284,48 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "सञ्जाल"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "कसरी तपाईं इन्टरनेट जडान गर्ने बारे नियन्त्रण गर्नुहोस"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "सञ्जाल;आईपी; LAN; प्रोक्सी; WAN; ब्रडब्यान्ड; मोडेम; ब्लुटुथ;भीपीएन;डीएनएस;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "वाई-फाई"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "तपाईँले ताररहित सञ्जालमा कसरी जडान गर्न नियन्त्रण गर्नुहोस्"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "सञ्जाल; ताररहित;Wi-Fi;Wifi;IP; LAN; ब्रडब्यान्ड;डीएनएस; हटस्पट;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "कहिले पनि होइन"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "आज"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "हिजो"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "अन्तिम पटक प्रयोग गरिएको"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264 panels/network/network-bluetooth.ui:5
-#: panels/network/network-ethernet.ui:5
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "तारजडिट"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "नयां जडान थप्नुहोस्"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any custom configuration will "
-"be lost."
-msgstr "चयन गरिएका सञ्जालका लागि सञ्जाल विवरणहरू, पासवर्डहरू र कुनै पनि अनुकूल कन्फिगरेसन समाविष्ट गर्दछ ।"
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "भुलनुहोस्"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "परिचित वाई-फाई सञ्जाल"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "भुलनुहोस्"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "प्रणाली नीतिले हटस्पटको रूपमा प्रयोग निषेध गर्दछ"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "ताररहित यन्त्रले हटस्पट शैलीलाई समर्थन गर्दैन"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "कन्फिगरेसन युआरएल प्रदान गरिएको छैन वेब प्रोक्सी Autodiscovery प्रयोग गरिएको छ ।"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "यो अविश्वसनीय सार्वजनिक नेटवर्कको लागि सिफारिश गरिएको छैन।"
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "यन्त्र बन्द गर्नुहोस्"
 
-#: panels/network/network-mobile.ui:27 panels/wwan/cc-wwan-details-dialog.ui:237
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "सक्रिय गर्नुहोस्"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
@@ -3360,47 +2333,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "प्रदायक"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "आईपी ठेगाना"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "सञ्जाल प्रोक्सि"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP प्रोक्सि"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "H_TTPS प्रोक्सी"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "_FTP प्रोक्सि"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "SOCKS होस्ट"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "होस्त वेवास्ता गर्नुहोस"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "HTTP प्रोक्सि पोर्ट"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "HTTPS प्रोक्सी पोर्ट"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "FTP प्रोक्सि पोर्ट"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "SOCKS प्रोक्सी पोर्ट"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "कन्फिगरेसन यूआरएल"
 
@@ -3427,300 +2404,21 @@ msgstr "पासवर्ड"
 msgid "Turn Wi-Fi off"
 msgstr "वाई-फाई बन्दगर्नुहोस"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "अरू विकल्पहरू…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "लुकेको सञ्जालमा जोड्नुहोस्…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "वाई-फाई हटस्पट खोल्नुहोस्..."
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "परिचित वाई-फाई सञ्जाल"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "वस्तुस्थिति अज्ञात"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "अव्यवस्थित"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "अनुपलब्ध"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "जडान गर्दै"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "प्रमाणीकरण आवश्यक"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "जडान हटाउदै"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "जडान असफल"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "वस्तुस्थिति अज्ञात(हराएको)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "कन्फिगुरेसन असफल"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP कन्फिगरेसन असफल भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP कन्फिगरेसन म्याद समाप्त भएको छ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "पासवर्ड आवश्यक छ, तर प्रदान गरिएन"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x supplicant विच्छेदन भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x supplicant कन्फिगरेसन विफल"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x supplicant विफल"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant प्रमाणित गर्न लामो समय लियो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "पिपिपि सेवा सुरु गर्न असफल भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "पिपिपि सेवा विच्छेद भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "पिपिपि असफल"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP client सुरु गर्न असफल भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP क्लाईन्त मा त्रुति"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP असफल भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "साझा जडान सेवा सुरु गर्न विफल"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "साझेदारि जडान सेवा असफल"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "स्वतIP सेवा सुरु गर्न असफल भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "स्वतIP सेवामा त्रुटि"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "स्वतIP सेवा असफल भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "लाईन व्यस्त छ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "डायलटोन छैन"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "कुनै क्यारियर स्थापित गर्न सकिएन"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "डायलिङ्ग समय सकियो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "डायलिङ्गगर्ने प्रयास असफल"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "मोडेम सुरुवात गर्न असफल"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "APN चयन गर्न असफल भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "सञ्जाल खोजी गर्दैन"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "सञ्जाल दर्ता गर्नदिएन"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "सञ्जालदर्ता समय सकियो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "अनुरोध सञ्जाल दर्ता गर्न असफल"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN जाच असफल भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "उपकरण लागि फर्मवेयर नरहेको हुन सक्छ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "जडान विस्थापन भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "होलको जडान पुन जडानभयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "मोडेम फेला परेन"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "ब्लुटुठ जडान असफल भयो"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "सिमकार्ड राखिएको छैन"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "सिमको पिन आवश्यक"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "सिमको PUK आवश्यक"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "गलत SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "जडान निर्भरता विफल"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "फर्मवेयर छैन"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "केबल छुटेको"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "802.1X सुरक्षामा अपरिभाषित त्रुटि (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "कुनै फाइल चयन गरिएको छैन"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "eap-method फाइल वैधता गर्दा निर्दिष्ट नगरिएको त्रुटि"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, वा PKCS#12 निजी कुञ्जीहरू (*. der, *. pem, *. p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER वा PEM प्रमाणपत्र (*. der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "EAP-FAST PAC फाइल हराइरहेको छ"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC files (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -3770,14 +2468,6 @@ msgstr "आन्तरिक प्रमाणीकरण"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "स्वचालित PAC प्रावधानलाई अनुमति दिनुहोस्"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "EAP-LEAP प्रयोगकर्ता नाम हराइरहेको छ"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "EAP-LEAP पासवर्ड हराइरहेको छ"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -3786,28 +2476,22 @@ msgstr "प्रयोगकर्ता नाम"
 
 #: panels/network/wireless-security/eap-method-leap.ui:23
 #: panels/network/wireless-security/eap-method-simple.ui:23
-#: panels/network/wireless-security/ws-leap.ui:23 panels/network/wireless-security/ws-sae.ui:10
-#: panels/network/wireless-security/ws-wpa-psk.ui:10 panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "पासवर्ड"
 
 #: panels/network/wireless-security/eap-method-leap.ui:44
 #: panels/network/wireless-security/eap-method-simple.ui:61
 #: panels/network/wireless-security/eap-method-tls.ui:129
-#: panels/network/wireless-security/ws-leap.ui:44 panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "पासवर्ड :देखाउनुहोस्"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "अवैध EAP-PEAP CA प्रमाणपत्र: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "अवैध EAP-PEAP CA प्रमाणपत्र: प्रमाणपत्र निर्दिष्ट गरिएको छैन"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -3830,7 +2514,6 @@ msgid "C_A certificate"
 msgstr "C_A प्रमाणपत्र"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -3845,61 +2528,6 @@ msgstr "CA प्रमाणपत्र आवश्यक छैन"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP संस्करण"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "EAP प्रयोगकर्ता नाम हराइरहेको छ"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "EAP पासवर्ड हराइरहेको छ"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "हराइरहेको EAP-TLS परिचय"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "अवैध EAP-TLS CA प्रमाणपत्र: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "अवैध EAP-TLS CA प्रमाणपत्र: प्रमाणपत्र निर्दिष्ट गरिएको छैन"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "अवैध EAP-TLS व्यक्तिगत कुञ्जी: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "अवैध EAP-TLS प्रयोगकर्ता-प्रमाणपत्र: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "गुप्तिकरण नगरिएको व्यक्तिगत कुञ्जी हरू असुरक्षित छन्"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This could allow your "
-"security credentials to be compromised. Please select a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"चयन गरिएको व्यक्तिगत कुञ्जीलाई पासवर्डद्वारा सुरक्षित गरेको देखिदैन । यसले तपाईँको सुरक्षा प्रमाणपत्रहरू सम्झौता गर्न "
-"अनुमति दिन सक्छ । कृपया पासवर्ड सुरक्षित व्यक्तिगत कुञ्जी चयन गर्नुहोस् ।\n"
-"\n"
-"(तपाईं आफ्नो निजी कुञ्जी openssl संग पासवर्ड-सुरक्षा गर्न सक्नुहुन्छ)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "तपाईँको व्यक्तिगत प्रमाणपत्र छान्नुहोस्"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "निजी  कुञ्जी छान्नुहोस्"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -3916,15 +2544,6 @@ msgstr "निजी कुञ्जी"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "निजी कुञ्जी"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "अवैध EAP-TTLS CA प्रमाणपत्र: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "अवैध EAP-TTLS CA प्रमाणपत्र: प्रमाणपत्र निर्दिष्ट गरिएको छैन"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -3947,14 +2566,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "डोमेन"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "802.1X सुरक्षा लाई प्रमाणित गर्दा अज्ञात त्रुटि"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -3982,53 +2602,10 @@ msgstr "सुरक्षित EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "प्रमाणीकरण"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "एउटा फाइल चयन गर्नुहोस्"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "LEAP-प्रयोगकर्ता नाम हराइरहेको छ"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "LEAP-पासवर्ड हराइरहेको छ"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "वाई-फाई पासवर्ड छैन।"
-
-#: panels/network/wireless-security/ws-sae.ui:33 panels/network/wireless-security/ws-wpa-psk.ui:33
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "प्रकार"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "wep-key हराएको छ"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "अवैध wep-key: %zu लम्बाइ भएको कुञ्जीले हेक्स-अङ्क मात्र समाविष्ट गर्नुपर्दछ"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "अवैध wep-key: %zu लम्बाइ भएको कुञ्जीले ascii क्यारेक्टर मात्र समाविष्ट गर्नुपर्दछ"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 (ascii) or 10/26 (hex)"
-msgstr "अवैध wep-key: गलत कुञ्जी लम्बाइ %zu। एउटा कुञ्जी या त लम्बाइ ५/१३ (ascii) वा १०/२६ (hex) हुनुपर्छ"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "अवैध wep-key: पासफ्रेज खाली नभएको हुनुपर्छ"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "अवैध wep-key: पासफ्रेज ६४ क्यारेक्टर भन्दा छोटो हुनुपर्छ"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4054,15 +2631,6 @@ msgstr "कुञ्जि देखाउनुहोस्"
 msgid "WEP inde_x"
 msgstr "WEP inde_x"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex digits"
-msgstr "अवैध wpa-psk: अवैध कुञ्जी-लम्बाइ %zu । [८,६३] बाइट वा ६४ हेक्स अङ्क हुनुपर्दछ"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "अवैध wpa-psk: हेक्सको रूपमा ६४ बाइटहरूसँग कुञ्जी व्याख्या गर्न सकिँदैन"
-
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
@@ -4081,7 +2649,9 @@ msgid "Notification _Popups"
 msgstr "सुचना पपअप"
 
 #: panels/notifications/cc-app-notifications-dialog.ui:43
-msgid "Notifications will continue to appear in the notification list when popups are disabled."
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
 msgstr "पपअप अक्षम पारिएको बेलामा सूचना सूचीमा सूचनाहरू देखापर्नेछन् ।"
 
 #. Popups here refers to message tray notifications in the middle of the screen.
@@ -4112,55 +2682,31 @@ msgstr "पर्दा सूचनाहरू ताल्चा लगाउ
 msgid "Control which notifications are displayed and what they show"
 msgstr "कुन सूचना प्रदर्शन गरिएको छ र तिनीहरूले के देखाउँछन् नियन्त्रण गर्नुहोस्"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "सूचनाहरू; ब्यानर; सन्देश; ट्रे; पपअप;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "%s हटाउनुहोस्"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "अन्य"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "खाता हटाउँदा त्रुटि"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/cc-online-accounts-panel.ui:23 panels/printers/printers.ui:51
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "पुर्वस्थितिमा फर्काउनुहोस्"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "सूचना बन्दगर्नुहोस्"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "क्लाउडमा तपाईँको डाटामा जडान गर्नुहोस्"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr "नया अनलाईन खाता बनाउन ईन्टरनेट जडान  गर्नुहोस् "
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "प्रयोगकर्ता खाता थप्नुहोस्"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s खाता"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "खाता हटाउनुहोस्"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4168,23 +2714,16 @@ msgstr "अनलाईन खाताहरू"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
-msgstr "तपाईँको अनलाइन खातामा जडान गर्नुहोस् र तिनीहरूलाई केका लागि प्रयोग गर्ने निर्णय गर्नुहोस्"
+msgstr ""
+"तपाईँको अनलाइन खातामा जडान गर्नुहोस् र तिनीहरूलाई केका लागि प्रयोग गर्ने निर्णय गर्नुहोस्"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
-"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;"
-"Pocket;ReadItLater;"
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;"
-"Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "अज्ञात समय"
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4200,13 +2739,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i घण्टा"
 msgstr[1] "%i घण्टा"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4218,185 +2750,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "मिनट"
 msgstr[1] "मिनट"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "पुरा चार्जको हुन %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "सावधान: %sबाँकी"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s बाकि छ"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "पुरा चार्ज"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "चार्ज छैन"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "खाली"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "चार्जहुँदै"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "चार्ज सकिदैँछ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "वायरलेस माउस"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "वायरलेस कुञ्जीपाटी"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "अटुट विद्युत आपूर्ति"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "पर्सनल डिजिटल असिस्टेन्ट"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "सेलफोन"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "मिडिया प्लेयर"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "ट्याबलेट"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "कम्प्युटर"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "खेल आगत यन्त्र"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "बेटरि"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "मुख्य"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "अतिरिक्त"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "बेटरिहरू"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "निश्क्रिय"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "निश्क्रिय गर्ने"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "पावर बन्द"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "हाइवरनेट"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "केही पनि होइन"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "जब बेटरि पावरमा"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "जडान भएको बेला"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "कहिल्यै पनि"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "स्वत निश्क्रिय"
-
-#: panels/power/cc-power-panel.c:1030
-msgid "Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a stable surface to "
-"restore."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1034
-#, fuzzy
-#| msgid "Performance mode unavailable"
-msgid "Performance mode temporarily disabled."
-msgstr "भोलि सम्म अस्थाई निस्क्रिय"
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when battery is sufficiently "
-"charged."
-msgstr "न्यून ब्याट्री: पावर सेभर सक्षम पारियो । ब्याट्री पर्याप्त चार्ज हुँदा अघिल्लो मोड पूर्वावस्थामा ल्याइनेछ ।"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "शक्ति बचतकर्ता मोड \"%s\" द्वारा सक्रिय पारियो।"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "प्रदर्शन मोड \"%s\" द्वारा सक्रिय पारियो।"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4458,6 +2811,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "२ घण्टा"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "बेटरि"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "यन्त्रहरू"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "शक्ति मोड"
@@ -4478,89 +2840,62 @@ msgstr "स्वत: पर्दा चम्किलोपन"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "पर्दा चम्किलोपन वरिपरिको प्रकाशमा समायोजन हुन्छ ।"
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "मलिन पर्दा"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "कम्प्युटर निस्क्रिय हुँदा पर्दा चम्किलोपन घटाउछ ।"
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "खाली पर्दा"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "निस्क्रियताको अवधि पछि पर्दा बन्द गर्छ ।"
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "स्वाचालित पावर बचत"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr "ब्याट्री कम हुँदा पावर बचत मोड सक्षम पार्छ ।"
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "स्वत निश्क्रिय"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "निष्क्रियअवधि पछि कम्प्युटर पज गर्दछ ।"
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "पावर बटन व्यवहार"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "ब्याटरि प्रतिशत देखाउनुहोस्"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "स्वत निश्क्रिय"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "जडान भएको बेला"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "बेटरि पावरमा"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "विलम्ब गर्नुहोस्"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "कार्यसम्पादन"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "उच्च प्रदर्शन र शक्ति प्रयोग। "
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "सन्तुलन"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "मानक प्रदर्शन र शक्ति उपयोग।"
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "पावर बचत"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "कम प्रदर्शन र शक्ति प्रयोग."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4570,32 +2905,13 @@ msgstr "पावर"
 msgid "View your battery status and change power saving settings"
 msgstr "तपाईँको ब्याट्री स्थिति हेर्नुहोस् र पावर बचत सेटिङ परिवर्तन गर्नुहोस्"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
-msgid "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;Energy;"
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
-"शक्ति; निद्रा; निलम्बन गर्नुहोस्; हाइबर्नेट; ब्याट्री; चम्किलोपन;धमिलो;खाली; मोनिटर;DPMS;निष्प्रयोजन; शक्ति;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "मुद्रणयन्त्र “%s” मेटियो"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "नयाँ मुद्रक थप्न असफल"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui जडान गर्न सकिएन : %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "मुद्रक र परिवर्तन सेटिङ थप्न ताल्चा खोल्नुहोस्"
+"शक्ति; निद्रा; निलम्बन गर्नुहोस्; हाइबर्नेट; ब्याट्री; चम्किलोपन;धमिलो;खाली; मोनिटर;"
+"DPMS;निष्प्रयोजन; शक्ति;"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4605,89 +2921,76 @@ msgstr "मुद्रणयन्त्रहरू"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "मुद्रक थप्नुहोस्, मुद्रक कार्य हेर्नुहोस् र तपाईँले कसरी मुद्रण गर्ने निर्णय गर्नुहोस् ।"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "मुद्रणयन्त्र;Queue;मुद्रण;कागज;मसी;टोनर;"
 
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:28 panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255 panels/printers/pp-new-printer-dialog.c:312
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "मुद्रक थप्नुहोस्"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100 panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "ताल्चा खोल्नुहोस्"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "मुद्रणयन्त्रहरू भेटिएन"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "कृपया मान्य सञ्जाल ठेगाना प्रविष्ट गर्नुहोस् र पुन: प्रयास गर्नुहोस् ।"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "प्रमाणीकरण आवश्यक"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr "मुद्रण सर्भरमा मुद्रणहरू हेर्न प्रयोगकर्ता नाम र पासवर्ड प्रवेश गर्नुहोस् ।"
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311 panels/printers/pp-jobs-dialog.ui:41
-#: panels/user-accounts/cc-add-user-dialog.ui:94 panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "प्रयोगकर्ता नाम"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74 panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "विस्तृत विवरण %s"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "मुद्रक नामले स्पेस, ट्याब, #, वा / समावेश गर्न सक्दैन"
 
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "उपयुक्त ड्राइभर पाइएन"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "PPD फाइल चयन गर्नुहोस्"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-msgstr "पोस्ट स्क्रिप्ट मुद्रणयन्त्र डिस्क्रिप्सन फाइलहरू  (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "स्थान"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115 panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "ड्राइभर"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "उपयुक्त ड्राइभर खोजी गरिदै…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "ड्राइभर खोज"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "डाटाबेस चयन गर्नुहोस्…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "PPD फाइल स्थापना गर्नुहोस्"
 
@@ -4699,109 +3002,14 @@ msgstr "मुद्रक चयन गर्नुहोस्"
 msgid "Loading drivers database…"
 msgstr "ड्राइभर डाटाबेस लोड गरिँदैछ…"
 
-#: panels/printers/ppd-selection-dialog.ui:91 panels/user-accounts/cc-avatar-chooser.c:98
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "रद्द गर्नुहोस्"
+
+#: panels/printers/ppd-selection-dialog.ui:91
 msgid "Select"
 msgstr "चयन गर्नुहोस्"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect  मुद्रक"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "एलपीडि मुद्रण"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64 panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "एकापट्टी"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66 panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "लामो धार भएको"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68 panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "छोटो किनारा (फ्लिप)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "पोर्ट्रेट"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "ल्याण्डस्केप"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "ल्याण्डस्केप उल्टाउनुहोस्"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "पोट्रेट उल्टाउनुहोस्"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "विचाराधिन"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "पज गरिएको"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "प्रमाणीकरण आवश्यक"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "प्रक्रिया गरिदै"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "रोकियो"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "रद्द गरियो"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "परित्याग गरियो"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "पूरा भयो"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "यो कामलाई पङ्क्ति माथि तिर सार्नुहोस्"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -4809,353 +3017,43 @@ msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u कार्य प्रमाणीकरण आवश्यक छ"
 msgstr[1] "%u कार्यहरू प्रमाणीकरण आवश्यक छ"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — सक्रिय कार्य"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "%s बाट मुद्रण गर्न कालागि प्रमाणपत्रहरू प्रविष्ट गर्नुहोस् ।"
-
 #. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/pp-jobs-dialog.ui:30 panels/user-accounts/cc-add-user-dialog.ui:300
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
 msgid "Domain"
 msgstr "डोमेन"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "प्रमाणीकरण गर्नुहोस्"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "सबै खाली गर्नुहोस्"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "प्रमाणीकरण"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "सक्रिय मुद्रण कार्य छैन"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "मुद्रण सर्भर ताल्चा खोल्नुहोस्"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s ताल्चा हटाउनुहोस्।"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "%sमा मुद्रणहरू हेर्न प्रयोगकर्ता नाम र पासवर्ड प्रवेश गर्नुहोस् ।."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "मुद्रणयन्त्रहरू खोज्दै"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "युएसबि"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "क्रम पोर्ट"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "समानान्तर पोर्ट"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "स्थान: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "ठेगाना %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "सर्भरलाई प्रमाणीकरण आवश्यक छ"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "दुबैपट्टी"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "कागजको प्रकार"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "कागज श्रोत"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "निर्गत ट्रे"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "रिजोल्युसन"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "घोस्टस्क्रिप्ट प्रि-फिल्टरिङ"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "एकापट्टि पृष्ठहरू"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "दुबैपट्टी"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "अभिमुखीकरण"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "साधारण"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "पृष्ठ सेटअप"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "स्थापना गर्ने विकल्पहरू"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "काम"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "छवि गुणस्तर"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "रङ"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "सकिदै"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "उन्नत"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844 panels/printers/pp-options-dialog.ui:14
+#: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "नमुना पृष्ठ"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "नमुना पृष्ठ"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75 panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "स्वतः छान्ने"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79 panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83 panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "पूर्वानिर्धारण मुद्रण"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "घोस्टस्क्रिप्ट फन्टहरू मात्र सम्मिलित गर्नुहोस्"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "पीएस स्तर १ रूपान्तरण"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "पीएस स्तर २ रूपान्तरण"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "पूर्व-फिल्टर छैन"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220 panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "उत्पादक"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "सक्रिय कार्यहरू छैन"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u काम"
 msgstr[1] "%u कामहरू"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "मुद्रण हेड सफा गर्नुहोस्"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "टोनर कम"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "टोनर सकियो"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "डेभेलोपर कम छ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "डेभेलोपर सकियो"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "मार्कर आपूर्ति कमि"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "मार्कर आपूर्ति सकियो"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "आवरण खोल्नुहोस्"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "ढोका खुला छ"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "कागजको कमी"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "कागज सकियो"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "अफलाइन"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743 panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "रोकियो"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "फोहोर भण्डारण लगभग पूर्ण"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "फोहोर भण्डारण भरियो"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "ओप्टिकल फोटो सञ्चालक  जीवनको अन्तमा छ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ओप्टिकल फोटो सञ्चालकले हालै काम गरेको छैन"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "तयार"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "मुद्रण कार्य स्वीकार्य छैन"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "प्रक्रिया गरिदै"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5179,40 +3077,45 @@ msgstr "मुद्रण हेड सफा गर्नुहोस्"
 msgid "Remove Printer"
 msgstr "मुद्रण हटाउनुहोस्"
 
-#: panels/printers/printer-entry.ui:187 panels/wwan/cc-wwan-details-dialog.ui:184
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "सक्रिय कार्यहरू छैन"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "शैली"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "मसि लेबल"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "समस्या समाधान गरि पुन: सुरु गर्नुहोस्"
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "पुन: सुरु गर्नुहोस्"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "मुद्रक थप्नुहोस्…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "नयाँ मुद्रक थप्नुहोस्…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "मुद्रणहरू भेटिएन"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "नयाँ मुद्रक थप्नुहोस्…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5220,49 +3123,33 @@ msgstr ""
 "माफ गर्नुहोस्! प्रणाली मुद्रण सेवा\n"
 "उपलब्ध छैन जस्तो देखिन्छ ।"
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ढाँचाहरू"
-
-#: panels/region/cc-format-chooser.ui:37 panels/wacom/cc-wacom-stylus-page.ui:136
-#: panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "पछाडि"
 
 #: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr "लोकेलहरू खोजी गर्नुहोस्…"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "साझा ढाँचाहरू"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "सबै ढाँचाहरू"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "खोजी परिणाम छैन"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "खोजी हरू देश वा भाषाहरूका लागि हुन सक्छन्।"
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "पूर्वावलोकन"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "इम्पेरियल"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "मेट्रिक"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5294,26 +3181,30 @@ msgstr "लगआउट…"
 
 #: panels/region/cc-region-panel.ui:45
 msgid ""
-"The language setting is used for interface text and web pages. Formats is used for numbers, "
-"dates, and currencies."
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
 msgstr ""
-"इन्टरफेस पाठ र वेब पृष्ठहरूका लागि भाषा सेटिङ प्रयोग गरिन्छ । ढाँचाहरू संख्या, मिति र मुद्राहरूका लागि प्रयोग "
-"गरिन्छ।"
+"भाषा सेटिङ इन्टरफेस पाठ र वेब पृष्ठहरूको लागि प्रयोग गरिन्छ। ढाँचाहरू संख्याहरू, मितिहरू र "
+"मुद्राहरूको लागि प्रयोग गरिन्छ।"
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "तपाईको खाता"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "भाषा"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "ढाँचाहरू"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "लग‍इन स्क्रिन"
 
@@ -5325,99 +3216,9 @@ msgstr "क्षेत्र र भाषा"
 msgid "Select your display language and formats"
 msgstr "तपाईँको प्रदर्शन भाषा र ढाँचा चयन गर्नुहोस्"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "भाषा;खाका;किबोर्ड;आगत;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "के गर्ने भनेर सोध्नुहोस्"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "केही पनि होइन"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "फोल्डर खोल्नुहोस्"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "अरु मिडिया"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "अडियो सिडिहरूको लागि अनुप्रयोग छान्नुहोस्"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "भिडियो डिभिडिहरूको लागि अनुप्रयोग छान्नुहो"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "संगीत बजाउने यन्त्र जॊडीएपछि संगीत बजाउनकालागि एक अनुप्रयोग छान्नुहोस्"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "फोटो खिच्ने यन्त्र (क्यामेरा) जडित भएमा कुन प्रोग्राम सुचारु हुने, रोज्नुहोस्"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "अनुप्रयोग सिडिहरूको लागि अनुप्रयोग छान्नुहो"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "ध्वनि डिभिडि॒"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "रित्तो ब्लुरे चक्का"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "रित्तो सिडि चक्का"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "रित्तो डिभिडि॒ चक्का"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "रित्तो एचडिडिभिडि चक्का"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "ब्लुरे भिडियो चक्का"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "इ- पुस्तक पाठक"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "एचडि डिभिडि भिडियो चक्का"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "तस्वीर सिडि"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "सुपर भिडियो सिडि"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "भिडिओ(दृष्य) सिडि"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "विन्डोज् सफ्टवेर"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5467,49 +3268,113 @@ msgstr "हटाउन सकिने माध्यम"
 msgid "Configure Removable Media settings"
 msgstr "हटाउन योग्य मिडिया सेटिङ्ग"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"उपकरण;प्रणाली;पूर्वनिर्धारित;मनपरेको;अनुप्रयोग;सीडी;डीभिडी;यूएसबी;अडियो;भिडियो;डिस्क;हटाउन सकिने;मिडिया;"
-"स्वचालित;"
+"उपकरण;प्रणाली;पूर्वनिर्धारित;मनपरेको;अनुप्रयोग;सीडी;डीभिडी;यूएसबी;अडियो;भिडियो;डिस्क;"
+"हटाउन सकिने;मिडिया;स्वचालित;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "_स्थान छान्नुहोस्"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "पर्दा ताल्चा लगाउनुहोस्"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "ठिक छ"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"पर्दामा स्वचालित रूपले ताल्चा लगाउँदा तपाईँ टाढा हुँदा अरूलाई कम्प्युटर पहुँच गर्नबाट रोकिन्छ "
+"।."
 
-#: panels/search/cc-search-locations-dialog.ui:8 panels/search/cc-search-panel.ui:22
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "खाली पर्दा ढिलाई"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "निस्क्रियताको अवधि जस पछि पर्दा खाली हुन्छ ।"
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "स्वत: पर्दामा ताल्चा"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "स्वत: पर्दामा ताल्चा ढिलाइ"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "पर्दा स्वत: ताल्चा लगाएको बेलामा पर्दा खाली गरेपछिको अवधि ।"
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "ताल्चा लागेको पर्दामा सूचनाहरू देखाउनुहोस्"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "पर्दा सूचनाहरू ताल्चा लगाउनुहोस्"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "नयाँ युएसबि यन्त्र निषेध गर्नुहोस्"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"पर्दामा ताल्चा लगाएको बेलामा नयाँ USB यन्त्रलाई प्रणालीसँग अन्तरक्रिया गर्नबाट रोक्नुहोस् ।"
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr "पर्दा गोपनियता"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr "दृश्य कोण सीमित गर्नुहोस्"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "पर्दा"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "दृष्टिवाचकअनुकूलता फेरी बहन गरियो ।"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "पर्दा;ताल्चा;निजी;गोपनीयता;"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "स्थान (हरूमा) खोजी गर्नुहोस्"
 
 #: panels/search/cc-search-locations-dialog.ui:13
-msgid "Folders which are searched by system applications, such as Files, Photos and Videos."
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
 msgstr "फाइल, फोटो र भिडियो जस्ता प्रणाली अनुप्रयोगद्वारा खोजी गरिने फोल्डरहरू ।"
 
 #: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr "स्थानहरू"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "पुस्तकचिनो"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "अन्य"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "स्थान थप्नुहोस्"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "अनुप्रयोग पाईएन"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5521,7 +3386,6 @@ msgstr "अनुप्रयोग-प्रदान गरिएको खो
 
 #: panels/search/cc-search-panel.ui:23
 #, fuzzy
-#| msgid "Folders which are searched by system applications, such as Files, Photos and Videos."
 msgid "Folders which are searched by system applications."
 msgstr "फाइल, फोटो र भिडियो जस्ता प्रणाली अनुप्रयोगद्वारा खोजी गरिने फोल्डरहरू ।"
 
@@ -5534,65 +3398,20 @@ msgid "Results are displayed according to the list order."
 msgstr "परिणाम सूची क्रम अनुसार प्रदर्शन गरिन्छ ।"
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
-msgid "Control which applications show search results in the Activities Overview"
+msgid ""
+"Control which applications show search results in the Activities Overview"
 msgstr "क्रियाकलाप अवलोकनमा कुन अनुप्रयोगले खोजी परिणाम देखाउँदछ नियन्त्रण गर्नुहोस्"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "खोजी गर्नुहोस्; फेला पार्नुहोस्;अनुक्रमणिका; लुकाउनुहोस्; गोपनीयता; परिणाम;"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "साझेदारि सञ्जाल छानिइको छैन"
 
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "सञ्जाल"
 
-#: panels/sharing/cc-sharing-panel.c:370
-msgctxt "service is enabled"
-msgid "On"
-msgstr "खुला छ"
-
-#: panels/sharing/cc-sharing-panel.c:372 panels/sharing/cc-sharing-panel.c:399
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "बन्द"
-
-#: panels/sharing/cc-sharing-panel.c:402
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "सक्षम पारिएको"
-
-#: panels/sharing/cc-sharing-panel.c:405
-msgctxt "service is active"
-msgid "Active"
-msgstr "सक्रिय"
-
-#: panels/sharing/cc-sharing-panel.c:523
-msgid "Choose a Folder"
-msgstr "एउटा फोल्डर रोज्नुहोस्"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:751
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your current network using: %s"
-msgstr "फाइल साझेदारीले तपाईँको हालको सञ्जालमा अन्यसँग तपाईँको सार्वजनिक फोल्डर साझेदारी गर्न अनुमति दिन्छ: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:757
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure Shell command:\n"
-"%s"
-msgstr ""
-"टाढाको लगइन सक्षम पारिएमा, सुरक्षित शेल आदेश प्रयोग गरेर टाढा प्रयोगकर्ताहरूले जडान गर्न सक्दछन्:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.ui:9 panels/sharing/gnome-sharing-panel.desktop.in.in:3
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "साझेदारी"
 
@@ -5624,55 +3443,68 @@ msgstr "फाइल साझेदारी"
 msgid "_Require Password"
 msgstr "पासवर्ड आवश्यक"
 
-#: panels/sharing/cc-sharing-panel.ui:195 panels/sharing/cc-sharing-panel.ui:231
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "टाढा लगइन"
 
-#: panels/sharing/cc-sharing-panel.ui:250 panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "टाढाको डेस्कटप"
 
-#: panels/sharing/cc-sharing-panel.ui:263
-msgid "Remote desktop allows viewing and controlling your desktop from another computer."
-msgstr "टाढाको डेस्कटपले अर्को कम्प्युटरबाट तपाईँको डेस्कटप हेर्न र नियन्त्रण गर्न अनुमति दिन्छ ।"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"टाढाको डेस्कटपले अर्को कम्प्युटरबाट तपाईँको डेस्कटप हेर्न र नियन्त्रण गर्न अनुमति दिन्छ ।"
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr "यो कम्प्युटरमा टाढाको डेस्कटप जडान सक्षम वा असक्षम पार्नुहोस् ।"
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "टाढाको नियन्त्रण"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
 msgstr "पर्दा नियन्त्रण गर्न टाढाको जडानलाई अनुमति दिन्छ ।"
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
 msgstr "कसरी जडान गर्ने"
 
-#: panels/sharing/cc-sharing-panel.ui:295
-msgid "Connect to this computer using the device name or remote desktop address."
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
 msgstr "टाढाको डेस्कटप ठेगाना वा यन्त्र नाम प्रयोग गरेर यो कम्प्युटरमा जडान गर्नुहोस् ।"
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "प्रतिलिपि बनाउनुहोस्"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "टाढाको डेस्कटप ठेगाना"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "प्रमाणीकरण"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr "यो कम्प्युटरमा जडान गर्न प्रयोगकर्ता नाम र पासवर्ड आवश्यक हुन्छ ।"
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "प्रयोगकर्ताको नाम"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "गुप्तीकरण रूजु गर्नुहोस्"
 
@@ -5681,7 +3513,10 @@ msgid "Encryption Fingerprint"
 msgstr "गुप्तिकरण औठाछाप"
 
 #: panels/sharing/cc-sharing-panel.ui:435
-msgid "The encryption fingerprint can be seen in connecting clients and should be identical"
+#, fuzzy
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
 msgstr "गुप्तिकरण औठाछाप जडान क्लाइन्टमा देख्न सकिन्छ र समान हुनुपर्दछ"
 
 #: panels/sharing/cc-sharing-panel.ui:467
@@ -5700,12 +3535,13 @@ msgstr "फोल्डरहरू"
 msgid "Control what you want to share with others"
 msgstr "अरूसँग बाँड्न चाहेको कुरा नियन्त्रण गर्नुहोस्"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;movies;server;"
-"renderer;"
-msgstr "साझेदारी;साझेदारी;ssh;होस्ट;नाम;टाढाको;डेस्कटप;मिडिया;अडियो;भिडियो;तस्विर;फोटो;चलचित्र;सर्भर;रेन्डरर;"
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"साझेदारी;साझेदारी;ssh;होस्ट;नाम;टाढाको;डेस्कटप;मिडिया;अडियो;भिडियो;तस्विर;फोटो;"
+"चलचित्र;सर्भर;रेन्डरर;"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
@@ -5715,38 +3551,37 @@ msgstr "टाढाको लगइन सक्षम वा अक्षम �
 msgid "Authentication is required to enable or disable remote login"
 msgstr "टाढाको लगइन सक्षम वा अक्षम पार्न प्रमाणीकरण आवश्यक हुन्छ"
 
-#: panels/sound/cc-alert-chooser.c:150
-msgid "Custom"
-msgstr "अनुकुलन"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Bark"
+msgid "Click"
+msgstr "क्लिक गर्नुहोस्"
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "द्रिप"
+msgid "String"
+msgstr "स्ट्रिङ"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "ग्लास"
+msgid "Swing"
+msgstr "स्विङ"
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "सोनार"
+msgid "Hum"
+msgstr "हम"
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "सन्तुलन"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "फेड"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "पछाडि"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "अगाडी ल्याउनुहोस्"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "निरिक्षण %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -5756,58 +3591,53 @@ msgstr "स्पिकर निरिक्षण गर्न क्लिक
 msgid "System Volume"
 msgstr "प्रणाली भोल्युम"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "मास्टर भोलुम"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "भोल्युम तहहरू"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "निर्गत"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "निर्गत यन्त्र"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "परिक्षण गर्नुहोस्"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "कन्फिगरेसन"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "सन्तुलन"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "फेड"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "सबउफर"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "आगत"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "आगत उपकरण"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "भोल्युम"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "सावधानि ध्वनि"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "१००%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "मौन"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -5817,75 +3647,10 @@ msgstr "ध्वनि"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "ध्वनि स्तर, आगत, निर्गत, र चेतावनी ध्वनि परिवर्तन गर्नुहोस्"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr "कार्ड; माइक्रोफोन; भोल्युम; फेड; ब्यालेन्स; ब्लुटुथ; हेडसेट;ध्वनि;आगत;निर्गत"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92 panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "जडान विच्छेदन भयो"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95 panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "जडान गर्दै"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98 panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "जडान भयो"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "प्रमाणिकरण असफल"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104 panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "प्राधिकृत गर्दै"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "घटाइएको कार्यात्मकता"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "प्रमाणीकरण र जडान भयो"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119 panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "अज्ञात"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "प्रमाणीकरण:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "जडान भएको:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "दर्ता भएको:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "यन्त्र अधिकार प्राप्त गर्न असफल भयो: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "यन्त्र बिर्सन असफल भयो: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -5894,88 +3659,52 @@ msgid_plural "Depends on %u other devices"
 msgstr[0] "%u अन्य यन्त्रमा निर्भर गर्दछ"
 msgstr[1] "%u अन्य यन्त्रहरूमा निर्भर गर्दछ"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "सूचना बन्दगर्नुहोस्"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "नाम:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "वस्तुस्थिति:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "अधिकार दिनुहोस्"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "यन्त्र भुलनुहोस्"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "त्रुटी"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "प्रमाणीकरण गरिएको"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr "थन्डरबोल्ट उपप्रणाली (boltd) स्थापना गरिएको छैन वा राम्रोसँग सेटअप गरिएको छैन ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:425 panels/thunderbolt/cc-bolt-panel.ui:157
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "डक र बाह्य GPUs जस्ता यन्त्रमा प्रत्यक्ष पहुँच अनुमति दिनुहोस् ।."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "USB र प्रदर्शन पोर्ट यन्त्र मात्र संलग्न गर्न सकिन्छ ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the BIOS or is set to an "
-"unsupported security level in the BIOS."
-msgstr ""
-"थन्डरबोल्ट पत्ता लगाउन सकेन ।\n"
-"या त प्रणालीमा थन्डरबोल्ट समर्थनको कमी छ, यो BIOS मा अक्षम पारिएको छ वा BIOS मा एउटा असमर्थित सुरक्षा "
-"स्तरमा सेट गरिएको छ ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "BIOS मा थन्डरबोल्ट समर्थन अक्षम पारिएको छ ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "थन्डरबोल्ट सुरक्षा स्तर निर्धारण गर्न सकेन ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "प्रत्यक्ष मोड स्विच गर्दा त्रुटि: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
+#: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "थन्डरबोल्ट समर्थन छैन"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:104
+#: panels/thunderbolt/cc-bolt-panel.ui:103
 msgid "Could not connect to the thunderbolt subsystem."
 msgstr "थन्डरबोल्ट उपप्रणालीमा जडान गर्न सकेन ।"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:153
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "सिधा पहुँच"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "डक र बाह्य GPUs जस्ता यन्त्रमा प्रत्यक्ष पहुँच अनुमति दिनुहोस् ।."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "विचाराधिन यन्त्रहरू"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "उपकरण जडित छैन"
 
@@ -5987,7 +3716,6 @@ msgstr "थन्डरबोल्ट"
 msgid "Manage Thunderbolt devices"
 msgstr "थन्डरबोल्ट यन्त्र प्रबन्ध गर्नुहोस्"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "थन्डरबोल्ट;गोपनीयता;"
@@ -5996,16 +3724,16 @@ msgstr "थन्डरबोल्ट;गोपनीयता;"
 msgid "Cursor Blinking"
 msgstr "झिम्किरहेको कर्सर"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "पाठ बाकसहरुमा कर्सर झिम्किन्छ ।."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "गति"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "झिम्किरहेको कर्सर गति"
 
@@ -6014,7 +3742,8 @@ msgid "Cursor Size"
 msgstr "कर्सर आकार"
 
 #: panels/universal-access/cc-cursor-size-dialog.ui:22
-msgid "Cursor size can be combined with zoom to make it easier to see the cursor."
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr "कर्सरलाई सजिलैसँग हेर्नका लागि कर्सरको साइजजूमसँग संयोजन गर्न सकिन्छ ।"
 
 #: panels/universal-access/cc-pointing-dialog.ui:5
@@ -6029,7 +3758,8 @@ msgstr "सिमुलेतेड सेकेन्डरी क्लिक 
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "प्राथमिक बटन समातेर द्वितीयक क्लिक ट्रिगर गर्नुहोस्"
 
-#: panels/universal-access/cc-pointing-dialog.ui:66 panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
 #: panels/universal-access/cc-typing-dialog.ui:230
 msgid "A_cceptance delay:"
 msgstr "A_cceptance ढिलाइ:"
@@ -6088,15 +3818,15 @@ msgstr "ठूलो"
 msgid "Repeat Keys"
 msgstr "कुञ्जीहरू दोहोर्याउनुहोस्"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "कुञ्जी तल झर्दा कुञ्जी थिचाइहरू दोहोरिन्छन् ।"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "दोहोरिने कुञ्जी ढिलाई"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "कुञ्जी गति दोहोर्याउनुहोस्"
 
@@ -6150,7 +3880,8 @@ msgstr "कुञ्जी थिचिँदा बिप गर्नुहो
 msgid "Beep when a key is _accepted"
 msgstr "कुञ्जी भएको बेला बीप गर्नुहोस्"
 
-#: panels/universal-access/cc-typing-dialog.ui:180 panels/universal-access/cc-typing-dialog.ui:273
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
 msgid "Beep when a key is _rejected"
 msgstr "यदि कुञ्जी अस्वीकृत हुन्छ भने बिप गर्नुहोस्"
 
@@ -6176,47 +3907,13 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "लामो"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "कुञ्जीपाटी सक्षम पार्नुहोस्"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "किबोर्ड प्रयोग गरेर पहुँच विकल्प बन्द र खुला गर्ने"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "पुर्वनिर्धारित"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "मध्यम"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "ठूलो"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "अझ ठूलो"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "सबै भन्दा ठूलो"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d पिक्सेल"
-msgstr[1] "%d पिक्सेलहरू"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6258,7 +3955,8 @@ msgstr "नम लक वा क्याप्स लक सुरु वा �
 msgid "C_ursor Size"
 msgstr "कर्सर साइज"
 
-#: panels/universal-access/cc-ua-panel.ui:116 panels/universal-access/cc-zoom-options-dialog.ui:82
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
 msgid "_Zoom"
 msgstr "जूम गर्नुहोस्"
 
@@ -6266,7 +3964,8 @@ msgstr "जूम गर्नुहोस्"
 msgid "Hearing"
 msgstr "सुन्दै"
 
-#: panels/universal-access/cc-ua-panel.ui:141 panels/universal-access/cc-visual-alerts-dialog.ui:54
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
 msgid "_Visual Alerts"
 msgstr "दृश्यात्मक सावधानि"
 
@@ -6287,8 +3986,6 @@ msgid "_Typing Assist (AccessX)"
 msgstr "टाइप सहयोगि(AccessX)"
 
 #: panels/universal-access/cc-ua-panel.ui:240
-#, fuzzy
-#| msgid "Pointing & Clicking"
 msgid "Pointing &amp; Clicking"
 msgstr "पोइन्टिङ्ग र क्लिकिङ्ग"
 
@@ -6331,31 +4028,6 @@ msgstr "सम्पूर्ण पर्दा फ्ल्यास गर्
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "पूरा सञ्झ्याल फ्ल्यास गर्नुहोस्"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "छोटो"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ पर्दा"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ पर्दा"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ पर्दा"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "लामो"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6512,129 +4184,17 @@ msgstr "रङ्ग प्रभाव"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "हर्न, सुन्न, टाईप, देखाउन र क्लिक गर्न सहज बनाउनुहोस्"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
-#, fuzzy
-#| msgid ""
-#| "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
-#| "big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Speed;"
-#| "Assist;Repeat;Blink;visual;hearing;audio;typing;"
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;Zoom;Screen;Reader;big;"
-"high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Speed;Assist;"
-"Repeat;Blink;visual;hearing;audio;typing;animations;"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"कुञ्जीपाटी; माउस;a11y; पहुँचयोग्य; विश्वव्यापी पहुँच; व्यतिरेक; कर्सर; ध्वनि बजाउनुहोस्; जुम गर्नुहोस्; पर्दा; पर्दा "
-"पाठक;ठूलो;उच्च;ठूलो;पाठ;फन्ट;साइज; पहुँच X; टाँसिने; कुञ्जीहरू; ढिलो; उफ्रिने; माउस;डबल;क्लिक;विलम्ब; गति; सहयोग "
-"गर्नुहोस्; दोहोर्याउनुहोस्; ब्लिङ्क;दृश्य;श्रवण;अडियो;टाइपिङ;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "१ घन्टा"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "१ दिन"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "२ दिन"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "३ दिन"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "४ दिन"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "५ दिन"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "६ दिन"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "७ दिन"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "१४ दिन"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "३० दिन"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "रद्दीटोकरीमा भएका सबै वस्तुहरू मेट्नुहोस्"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "रद्दीटोकरीमा भएका सबै वस्तुहरू मेट्नुहोस्."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "रद्दीटोकरी रित्याउनुहोस्"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "सबै अस्थाई फाइलहरू मेट्नुहोस्?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "सबै अस्थायी फाइलहरू स्थायी रूपले मेटिनेछ ।"
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "अस्थाई फाइलहरू मेट्नुहोस्"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "१ दिन"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "७ दिन"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "३० दिन"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "सधै"
+"कुञ्जीपाटी; माउस;a11y; पहुँचयोग्य; विश्वव्यापी पहुँच; व्यतिरेक; कर्सर; ध्वनि बजाउनुहोस्; जुम "
+"गर्नुहोस्; पर्दा;पाठक;ठूलो;उच्च;ठूलो;पाठ;फन्ट;साइज; पहुँच X; टाँसिने; कुञ्जीहरू; ढिलो; "
+"उफ्रिने; माउस;डबल;क्लिक;विलम्ब; गति; सहयोग गर्नुहोस्; दोहोर्याउनुहोस्; झिम्काउने;दृश्य;"
+"श्रवण;अडियो;टाइपिङ;एनिमेसन;"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -6642,11 +4202,12 @@ msgstr "फाइल इतिहास"
 
 #: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"File history keeps a record of files that you have used. This information is shared between "
-"applications, and makes it easier to find files that you might want to use."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"फाइल इतिहासले तपाईँले प्रयोग गरेको फाइलको रेकर्ड राख्दछ । यो सूचना अनुप्रयोगको बीचमा साझेदार गरिएको छ, र "
-"तपाईँले प्रयोग गर्न चाहेको फाइल फेला पार्न सजिलो बनाउँदछ ।"
+"फाइल इतिहासले तपाईँले प्रयोग गरेको फाइलको रेकर्ड राख्दछ । यो सूचना अनुप्रयोगको बीचमा "
+"साझेदार गरिएको छ, र तपाईँले प्रयोग गर्न चाहेको फाइल फेला पार्न सजिलो बनाउँदछ ।"
 
 #: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
@@ -6666,11 +4227,11 @@ msgstr "रद्दीटोकरी र अस्थायी फाइल"
 
 #: panels/usage/cc-usage-panel.ui:64
 msgid ""
-"Trash and temporary files can sometimes include personal or sensitive information. Automatically "
-"deleting them can help to protect privacy."
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
 msgstr ""
-"रद्दीटोकरी र अस्थायी फाइलले कहिलेकाहीं व्यक्तिगत वा संवेदनशील जानकारी समावेश गर्न सक्छ । तिनीहरूलाई स्वचालित "
-"रूपमा मेट्दा गोपनीयताको सुरक्षा गर्न मद्दत मिल्छ ।"
+"रद्दीटोकरी र अस्थायी फाइलले कहिलेकाहीं व्यक्तिगत वा संवेदनशील जानकारी समावेश गर्न सक्छ । "
+"तिनीहरूलाई स्वचालित रूपमा मेट्दा गोपनीयताको सुरक्षा गर्न मद्दत मिल्छ ।"
 
 #: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
@@ -6700,53 +4261,15 @@ msgstr "फाइल इतिहास र रद्दीटोकरी"
 msgid "Don't leave traces"
 msgstr "चिन्ह हरू नछोड्नुहोस्"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "तपाईँको लगइन प्रदायकको वेब ठेगानासँग मिल्नुपर्छ ।"
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "खाता थप्न असफल"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679 panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr "पासवर्ड मिलेन"
-
-#: panels/user-accounts/cc-add-user-dialog.c:883 panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "खाता दर्ता गर्न असफल"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "यो डोमेनसँग प्रमाणीकरण गर्ने कुनै समर्थित तरिका छैन"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "डोमेन जडान गर्न असफल"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr "लगईन नाम मिलेन : पुन प्रयास गर्नुस ।"
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"प्रयोग;हालैको;इतिहास;फाइलहरू;अस्थायी;tmp;निजी;गोपनीयता;रद्दी टोकरी;शुद्धिकरण;कायम "
+"राख्नुहोस्;"
 
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr "लगईन पासवर्ड मिलेन : पुन प्रयास गर्नुस।. "
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "डोमेन लगईन असफल"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "डोमेन फेला पार्न अक्षम । सायद तपाईँले गलत हिज्जे गर्नुभएको छ?"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:15 panels/user-accounts/data/join-dialog.ui:9
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "प्रयोगकर्ता थप्नुहोस्"
 
@@ -6756,11 +4279,12 @@ msgstr "प्रशासक"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:132
 #, fuzzy
-#| msgid "Administrators can add and remove other users, and can change settings for all users."
 msgid ""
-"Administrators can add and remove other users, and can change settings for all users. Parental "
-"controls cannot be applied to administrators."
-msgstr "प्रशासकले अन्य प्रयोगकर्ताहरू थप्न र हटाउन सक्दछ, र सबै प्रयोगकर्ताका लागि सेटिङहरू परिवर्तन गर्न सक्दछ ।"
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"प्रशासकले अन्य प्रयोगकर्ताहरू थप्न र हटाउन सक्दछ, र सबै प्रयोगकर्ताका लागि सेटिङहरू "
+"परिवर्तन गर्न सक्दछ ।"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:149
 msgid "User sets password on first login"
@@ -6779,24 +4303,23 @@ msgid "Enterprise Login"
 msgstr "इन्टरप्राइज लगइन"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+#, fuzzy
+msgid "User accounts which are managed by a company or organization."
 msgstr "प्रयोगकर्ता खाता जुन कुनै कम्पनी वा संस्थाद्वारा व्यवस्थापन गरिन्छ।"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "अफलाइन छ"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
-"Enterprise login allows an existing centrally managed user account to be used on this device. You "
-"can also use this account to access company resources on the internet."
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
-"उद्यम लगइनले एउटा अवस्थित केन्द्रिय रूपमा प्रबन्धित प्रयोगकर्ता खातालाई यो यन्त्रमा प्रयोग गर्न अनुमति दिन्छ । "
-"तपाईं यो खाता पनि इन्टरनेट मा कम्पनी स्रोतहरू पहुँच गर्न प्रयोग गर्न सक्नुहुन्छ।"
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "अरु छविकोलागि ब्राउज गर्नुहोस्"
+"उद्यम लगइनले एउटा अवस्थित केन्द्रिय रूपमा प्रबन्धित प्रयोगकर्ता खातालाई यो यन्त्रमा प्रयोग "
+"गर्न अनुमति दिन्छ । तपाईं यो खाता पनि इन्टरनेट मा कम्पनी स्रोतहरू पहुँच गर्न प्रयोग गर्न "
+"सक्नुहुन्छ।"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -6810,490 +4333,180 @@ msgstr "अंगुठाछाप प्रबन्धक"
 msgid "Fingerprint"
 msgstr "औठाछाप"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "होइन"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "हो"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
-msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
 msgstr "औठाछाप लगइन अक्षम पारिएको हुनाले तपाईँले दर्ता भएका औठाछापहरू मेट्न चाहनुहुन्छ?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "अंगुठाछाप उपकरण छैन"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "अंगुठाछाप उपकरण छैन"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "यन्त्र राम्रोसँग जडान गरिएको छ भन्ने निश्चित गर्नुहोस् ।"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "अंगुठाछाप उपकरण"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "तपाईँले कन्फिगर गर्न चाहनुभएको औठाछाप यन्त्र रोज्नुहोस्"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "अंगुठाछाप लगइन"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
-msgid "Fingerprint login allows you to unlock and log into your computer with your finger"
-msgstr "औठाछाप लगइनले तपाईँलाई आफ्नो औँलाले तपाईँको कम्प्युटरमा ताल्चा खोल्न र लग गर्न अनुमति दिन्छ"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"औठाछाप लगइनले तपाईँलाई आफ्नो औँलाले तपाईँको कम्प्युटरमा ताल्चा खोल्न र लग गर्न अनुमति दिन्छ"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "अंगुठाछाप मेट्नुहोस्"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "अंगुठाछाप दर्ता गर्नुहोस्"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "यन्त्रले यो कार्य सम्पादन गर्न दावी गर्नु पर्दछ"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "अघिल्लो"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "यन्त्र पहिल्यै अर्को प्रक्रियाद्वारा दावा गरिएको छ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "तपाईँलाई कार्य सम्पादन गर्न अनुमति छैन ।"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "कुनै मुद्रण दर्ता भएको छैन"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "नामाकरण गर्दा यन्त्रसँग सञ्चार गर्न असफल भयो"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "औठाछाप वाचकसँग सञ्चार गर्न असफल भयो"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "औठाछाप डेइमोनसँग सञ्चार गर्न असफल"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "औठाछापहरू सूचीबद्ध गर्न असफल भयो: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "बचत गरिएका औठाछापहरू मेट्न असफल भयो: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "बायाँ बुढीऔँला"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Left middle finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "बायाँ चोर औँला"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "बायाँ साहिँली औँला"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "बायाँ कान्छी औँला"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "दायाँ बुढी औँला"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "दायाँ माझी औँला"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "दाहिने चोर औँला"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "दायाँ साहिँली औँला"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "दायाँ कान्छी औँला"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "अज्ञात अंगुठाछाप"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "पुरा गर्नुहोस्"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "अंगुठाछाप उपकरण छुटाइएको छ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "औठाछाप यन्त्र भण्डारण भरिएको छ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "नया अंगुठाछाप दर्ता गर्न असफल"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "दर्ता सेवा शुरु असफल भयो:%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "नया अंगुठाछाप दर्ता गर्न असफल"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "दर्ता सेवा रोक्न असफल भयो:%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid "Repeatedly lift and place your finger on the reader to enroll your fingerprint"
-msgstr "बारम्बार उचालेर आफ्नो औँठाछाप भर्ना गर्न पाठकलाई आफ्नो औँला राख्नुहोस्"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "अंगुठा पुन दर्ता गर्नुहोस्…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "नया अंगुठाछाप स्क्यान गर्नुहोस्"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "%s औठाछाप यन्त्र निस्काशन गर्न असफल भयो: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "यन्त्र पढ्न समस्या"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "%s औठाछाप यन्त्र दावी गर्न असफल भयो: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "औठाछाप यन्त्र प्राप्त गर्न असफल भयो: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "यो हप्ता"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "गएको हप्ता"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179 panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182 panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "सेसन बन्द गरियो"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "सेसन सुरु गरियो"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — खाता क्रियाकलाप"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "कृपया अर्को पासवर्ड रोज्नुहोस् ।"
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "कृपया तपाईँको हालको पासवर्ड फेरि प्रविष्टि गर्नुहोस् ।"
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "पासवर्ड परिवर्तन गर्न सकिएन"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "पछिल्लो"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "पासवर्ड परिवर्तन गर्नुहोस्"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "परिवर्तन"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "हालको पासवर्ड "
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "नयाँ पासवर्ड"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "पासवर्ड यकीन गर्नुहोस्"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "पासवर्ड मिलेन"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "प्रयोगकर्तालाई अर्को लगइनमा आफ्नो पासवर्ड परिवर्तन गर्न अनुमति दिनुहोस्"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "पासवर्ड सेट गर्नुहोस्"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "यस प्रकारको डोमेन स्वचालित रूपमा जडान गर्न सकिँदैन"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "डोमेन वा रियालम नाम भेटिएन"
-
-#: panels/user-accounts/cc-realm-manager.c:712 panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "तपाईँ %s डोमेन %s पहुँच गर्न लगइन हुनुपर्दछ"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "अवैध पासवर्ड, पुन: प्रयास गर्नुहोस्"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "%s डोमेनमा जडान गर्न सकेन: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "प्रयोगकर्ता मेट्न असफल"
-
-#: panels/user-accounts/cc-user-panel.c:398 panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "टाढाबाट प्रबन्ध गरिएको प्रयोगकर्ता लाई खारेज गर्न असफल भयो"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "तपाईँले आफ्नो खाता आफैं मेट्न सक्नुहुन्न ।"
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s अझै लगईन छ"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid "Deleting a user while they are logged in can leave the system in an inconsistent state."
-msgstr "तिनीहरू लगइन भएको बेलामा प्रयोगकर्ता मेट्दा प्रणालीलाई असङ्गत अवस्थामा छोड्न सक्छ ।"
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "के तपाई %s को फाईलहरु राख्न चाहानुहुन्छ?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files around when deleting a "
-"user account."
-msgstr "प्रयोगकर्ता खाता मेट्दा गृह डाइरेक्टरी, मेल स्पूल र अस्थायी फाइलहरू वरिपरि राख्न सम्भव छ ।"
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "फाइलहरू मेट्नुहोस्"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "फाइलहरू राख्नुहोस्"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "तपाईँ टाढाबाट प्रबन्ध गरिएको %s खाता हटाउन निश्चित हुनुहुन्छ?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "मेट्नुहोस्"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "खाता अक्षम पारिएको"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "अर्को लगइनमा सेट गर्ने"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "कुनै पनि होइन"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "लगईन गरियो"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787 panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "सक्षम पारिएको"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "खाता सेवा जडान असफल"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "कृपया खाता सेवा स्थापना र सक्षम पारिएको निश्चित गर्नुहोस् ।"
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "यो सेटिङ परिवर्तन गर्न यो प्यानलको ताल्चा खोलिनुपर्छ"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "चयन गरेको प्रयोगकर्ता खाता मेट्नुहोस्"
-
-#: panels/user-accounts/cc-user-panel.c:1268 panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"चयन गरिएको प्रयोगकर्ता खाता मेट्न,\n"
-"पहिला * प्रतिमा क्लिक गर्नुहोस्"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "प्रयोगकर्ता थप्न र सेटिङ परिवर्तन गर्न ताल्चा खोल्नुहोस्"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "प्रयोगकर्ता"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "परिवर्तन प्रभाव लिनका लागि तपाईँको सत्र पुन: सुरुआत गर्नु आवश्यक छ"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "फेरि सुरु गर्नुहोस्"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "बन्द गर्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "अवतार प्रतिमा सम्पादन गर्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "पूरा नाम"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "सम्पादन गर्नुहोस्"
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "लगइन अंगुठाछाप"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "स्वतः लगईन"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "खाता क्रियाकलाप"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "प्रशासक"
 
-#: panels/user-accounts/cc-user-panel.ui:260
-msgid "Administrators can add and remove other users, and can change settings for all users."
-msgstr "प्रशासकले अन्य प्रयोगकर्ताहरू थप्न र हटाउन सक्दछ, र सबै प्रयोगकर्ताका लागि सेटिङहरू परिवर्तन गर्न सक्दछ ।"
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"प्रशासकले अन्य प्रयोगकर्ताहरू थप्न र हटाउन सक्दछ, र सबै प्रयोगकर्ताका लागि सेटिङहरू "
+"परिवर्तन गर्न सक्दछ ।"
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "प्यारेन्टल नियन्त्रण"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "प्यारेन्टल नियन्त्रण अनुप्रयोग खोल्नुहोस् ।"
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "प्रयोगकर्ता हटाउनुस्…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "अन्य प्रयोगकर्ता"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "प्रयोगकर्ता थप्नुहोस्..."
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "प्रयोगकर्ता भेटिएन"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "प्रयोगकर्ता खाता थप्नका लागि ताल्चा खोल्नुहोस् ।."
 
@@ -7301,14 +4514,13 @@ msgstr "प्रयोगकर्ता खाता थप्नका ला
 msgid "Add or remove users and change your password"
 msgstr "प्रयोगकर्ता थप्नुहोस् वा हटाउनुहोस् र तपाईँको पासवर्ड परिवर्तन गर्नुहोस्"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen Time;App Restrictions;"
-"Web Restrictions;Usage;Usage Limit;Kid;Child;"
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"लगइन;नाम:औठाछाप;अवतार;लोगो;मोहडा;पासवर्ड;आमाबाबुको नियन्त्रण;पर्दा समय;अनुप्रयोग प्रतिबन्ध;वेब प्रतिबन्ध;"
-"उपयोग;प्रयोग दायरा;बच्चा;बच्चा;"
+"लगइन;नाम:औठाछाप;अवतार;लोगो;मोहडा;पासवर्ड;आमाबाबुको नियन्त्रण;पर्दा समय;अनुप्रयोग "
+"प्रतिबन्ध;वेब प्रतिबन्ध;उपयोग;प्रयोग दायरा;बच्चा;बच्चा;"
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
 #: panels/user-accounts/data/join-dialog.ui:30
@@ -7345,169 +4557,8 @@ msgstr "प्रयोगकर्ता खाताहरू प्रवन�
 msgid "Authentication is required to change user data"
 msgstr "प्रयोगकर्ता डाटा परिवर्तन गर्न प्रमाणीकरण चाहिन्छ"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "नया पासवर्ड पुरानो भन्दा फरक हुनु पर्छ ।"
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "केहि संख्या र अक्षर परिवर्तन गरि प्रयास गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "अलि धेरै पटक पासवर्ड परिवर्तन गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "तपाईँको प्रयोगकर्ता नाम बिनाको पासवर्ड अझ बलियो हुनेछ ।"
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "पासवर्डमा तपाईँको नाम प्रयोग नगर्न प्रयास गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "पासवर्डमा समावेश गरिएका केही शब्दबाट बच्ने प्रयास गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "सामान्य शब्द नबोली बस्नुहोस्।"
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "हालको शब्द पुन: क्रमबद्ध गर्नबाट रोक्न प्रयास गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "वढि अंक प्रयोग गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "वढि अक्षर  प्रयोग गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "वढि अक्षर  प्रयोग गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "विराम चिन्ह जस्तै, धेरै विशेष वर्ण प्रयोग गर्ने प्रयास गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "अक्षर, सङ्ख्या र विराम चिन्हको मिश्रण प्रयोग गर्ने प्रयास गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "उही क्यारेक्टर दोहोर्याउनबाट रोक्न प्रयास गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up letters, numbers and "
-"punctuation."
-msgstr ""
-"उही प्रकारको क्यारेक्टर दोहोर्याउनबाट रोक्न प्रयास गर्नुहोस्: तपाईँले अक्षर, सङ्ख्या र विराम चिन्ह मिश्रण गर्नु "
-"आवश्यक छ ।"
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "१२३४ वा abcd जस्ता क्रमबाट बच्ने प्रयास गर्नुहोस् ।"
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid "Password needs to be longer. Try to add more letters, numbers and punctuation."
-msgstr "पासवर्ड लामो हुनु आवश्यक छ । धेरै अक्षर, सङ्ख्याहरू र विराम चिन्ह हरू थप्न प्रयास गर्नुहोस्।"
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "ठूलो वर्ण र सानो केस मिसाउनुहोस् र एक वा दुई नम्बर प्रयोग गर्न प्रयास गर्नुहोस्।"
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid "Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "धेरै अक्षर, सङ्ख्या र विराम चिन्ह थप्दा पासवर्ड बलियो हुन्छ ।."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "प्रमाणीकरण असफल भयो"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "नयाँ पासवर्ड अति छोटो छ"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "नयाँ पासवर्ड धेरै सहज छ"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "पुरानो र नयाँ पासवर्डहरू धेरै उस्तै छन् "
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "पासवर्ड पहिला नै प्रयोग गरिएको छ । अन्य पासवर्ड रोज्नुहोस् ।"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "नयाँ पासवर्डले सङ्ख्यात्मक वा विशेष क्यारेक्टर(हरू) समाविष्ट गर्नुपर्दछ"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "पुरानो र नयाँ पासवर्डहरू एउटै छन्"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "तपाईँले सुरुमा प्रमाणीकरण गरे पछि तपाईँको पासवर्ड परिवर्तन गरिएको छ!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "नयाँ पासवर्डले सङ्ख्यात्मक वा विशेष क्यारेक्टर(हरू) समाविष्ट गर्नु"
-
-#: panels/user-accounts/run-passwd.c:526 panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "अज्ञात त्रुटि"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, digits and the following "
-"characters: - _"
-msgstr "प्रयोगकर्ता नाममा साधारणतया a-z, अङ्क र निम्न क्यारेक्टरहरूको लोअर केस अक्षरहरू मात्र हुनुपर्दछ: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "माफ गर्नुहोस्, त्यो प्रयोगकर्ता नाम उपलब्ध छैन । कृपया अर्को प्रयास गर्नुहोस् ।"
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "प्रयोगकर्ता नाम धेरै लामो भयो ।"
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "बटनहरू म्याप गर्नुहोस्"
 
@@ -7517,65 +4568,31 @@ msgstr "बटनहरू क्रियामा मापन गर्नु
 
 #: panels/wacom/button-mapping.ui:51
 msgid ""
-"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard shortcut button and "
-"hold down the new keys or press Backspace to clear."
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"सर्टकट सम्पादन गर्न, \"कुञ्जीस्ट्रोक पठाउनुहोस्\" कार्य रोज्नुहोस्, कुञ्जीपाटी सर्टकट बटन थिच्नुहोस् र नयाँ कुञ्जीहरू "
-"होल्ड गर्नुहोस् वा खाली गर्न ब्याकस्पेस थिच्नुहोस् ।"
+"सर्टकट सम्पादन गर्न, \"कुञ्जीस्ट्रोक पठाउनुहोस्\" कार्य रोज्नुहोस्, कुञ्जीपाटी सर्टकट बटन "
+"थिच्नुहोस् र नयाँ कुञ्जीहरू होल्ड गर्नुहोस् वा खाली गर्न ब्याकस्पेस थिच्नुहोस् ।"
 
 #: panels/wacom/button-mapping.ui:66
 msgid "_Close"
 msgstr "बन्द गर्नुहोस्"
 
 #: panels/wacom/calibrator/calibrator.ui:51
-msgid "Please tap the target markers as they appear on screen to calibrate the tablet."
-msgstr "कृपया ट्याब्लेट क्यालिब्रेट गर्न तिनीहरू पर्दामा देखा परे जस्तै लक्षित मार्करहरू ट्याप गर्नुहोस् ।"
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"कृपया ट्याब्लेट क्यालिब्रेट गर्न तिनीहरू पर्दामा देखा परे जस्तै लक्षित मार्करहरू ट्याप गर्नुहोस् ।"
 
 #: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "गलत-क्लिक पत्ता लाग्यो, फेरि सुरु गर्दैछ…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "बटन %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "अनुप्रयोग परिभाषित छ"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "कुञ्जी स्ट्रोक पठाउनुस्"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "मोनिटर बदल्नुहोस् "
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "सिहर्स मद्दत देखाउनुहोस्"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "ल्यापटप प्यानलमा माउन्ट गरिएको ट्याबलेट"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "बाह्य प्रदर्शनमा माउन्ट गरिएको ट्याबलेट"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "बाह्य ट्याबलेट यन्त्र"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "सबै प्रदर्शन"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "बाहिरी प्याड यन्त्र"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -7585,30 +4602,29 @@ msgstr "ट्याबलेट शैली"
 msgid "Use absolute positioning for the pen"
 msgstr "कलमका लागि निश्चित स्थिति प्रयोग गर्नुहोस्"
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "बाया अभिमुखीकरण"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr "बायाँ हाते प्रयोगका लागि ट्याबलेट र एक्सप्रेस कुञ्जी™ घुमाइएको छ"
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 #, fuzzy
-#| msgid "Map to Monitor…"
 msgctxt "display setting"
 msgid "Map to Monitor"
-msgstr "मोनिटर म्याप गर्नुहोस् ..."
+msgstr "मोनिटर म्याप गर्नुहोस्…"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "साइज औसत राख्नुहोस्"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr "मोनिटर आकार अनुपात राख्न मात्र ट्याबलेट सतहको भाग प्रयोग गर्नुहोस्"
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "क्यालिब्रेट"
 
@@ -7624,7 +4640,8 @@ msgstr "कृपया वाक्म ट्याबलेट जोडनु
 msgid "Tip Pressure Feel"
 msgstr "टुप्पोमा  दबाव महसूस"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:21 panels/wacom/cc-wacom-stylus-page.ui:82
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
 msgid "Soft"
 msgstr "नरम"
 
@@ -7632,7 +4649,8 @@ msgstr "नरम"
 msgid "Stylus tip pressure"
 msgstr "स्टाइलस टुप्पोमा चाप"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:41 panels/wacom/cc-wacom-stylus-page.ui:102
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
 msgid "Firm"
 msgstr "Firm"
 
@@ -7657,13 +4675,8 @@ msgstr "मेट्ने दबाव महसूस"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:96
 #, fuzzy
-#| msgid "Eraser Pressure Feel"
 msgid "Eraser pressure"
 msgstr "मेट्ने दबाव महसूस"
-
-#: panels/wacom/cc-wacom-stylus-page.ui:133
-msgid "Default"
-msgstr "पूर्वनिर्धारित"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:134
 msgid "Middle Mouse Button Click"
@@ -7677,78 +4690,106 @@ msgstr "दाया बटनमा क्लिक गर्नुहोस्
 msgid "Forward"
 msgstr "अगाडि"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "चाप, झुकाव, र एकीकृत स्लाइडरसँग एयरब्रश स्टाइलस"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "चाप, झुकाव, र परिक्रमणसँग एयरब्रस स्टाइलस"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "चाप र झुकाव सहित मानक स्टायलस"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "चाप सहित मानक स्टायलस"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "वाक्म ट्याबलेट"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr "बटन मानचित्र सेट गर्नुहोस् र ग्राफिक्स ट्याबलेटका लागि स्टाइलस संवेदनशीलता समायोजन गर्नुहोस्"
+msgstr ""
+"बटन मानचित्र सेट गर्नुहोस् र ग्राफिक्स ट्याबलेटका लागि स्टाइलस संवेदनशीलता समायोजन गर्नुहोस्"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "ट्याबलेट;वाक्म;स्टाईलस्;ईरेजर;माउस;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "नयाँ शर्टकर्ट…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "सजावट"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "प्रमूल सञ्झ्याल"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "सिमुलेतेड सेकेन्डरी क्लिक सक्षम गर्नुहोस्"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "सञ्झ्यालहरू"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "समाप्त गर्न 'ठीक छ' बटन क्लिक गर्नुहोस् ।"
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "टोनर कम"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "द्धितीयक"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "सञ्झ्यालहरू"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "उत्पादकत्व र मल्टिटास्किङका लागि प्राथमिकता प्रबन्ध गर्नुहोस्"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "पहुँच बिन्दुहरु"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "थप्नुहोस्"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "बचत गर्नुहोस्"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "सञ्चालन रद्द गरियो"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>त्रुटि:</b>सेटिङ हरू परिवर्तन गर्न अस्वीकार गर्यो"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>त्रुटि:</b> मोबाइल यन्त्र त्रुटि"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "दर्ता गरिएको छैन"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "दर्ता"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "रोमिङ"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "खोजी गर्दै"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "अस्वीकार गरियो"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -7771,113 +4812,20 @@ msgid "Network Status"
 msgstr "सञ्जाल वस्तुस्थिति"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:122
-#, fuzzy
-#| msgid "Numbers"
 msgid "Own Number"
-msgstr "नम्बर"
+msgstr "आफ्नै नम्बर"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:151
 msgid "Device Details"
 msgstr "यन्त्र विवरण"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "उत्पादक"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "फर्मवेयर संस्करण"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "२जि मात्र"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "३जी मात्र"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "४जी मात्र"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "२जी, ३जी, ४जी (रुचाइएको)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "२जी, ३जी (रुचाइएको), ४जी "
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "२जी  (रुचाइएको), ३जी, ४जी "
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "२जि, ३जि, ४जी"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "३जी, ४जी (रुचाइएको)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "३जी (रुचाइएको), ४जी"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "३जि, ४जी"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "२जी, ४जी (रुचाइएको)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "२जी (रुचाइएको), ४जी "
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "२जी, ४जी"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "२जी, ३जी (रुचाइएको)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "२जी (रुचाइएको), ३जी (रुचाइएको)"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "२जि, ३जि"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "अज्ञात"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "सिम कार्डको ताल्चा खोल्नुहोस्"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "ताल्चा खोल्नुहोस्"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "%d सिमका लागि कृपया पिन कोड उपलब्ध गराउनुहोस्"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "तपाईँको सिम कार्डअनलक गर्न पिन प्रविष्ट गर्नुहोस्"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "%d सिमका लागि कृपया PUK कोड उपलब्ध गराउनुहोस्"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "तपाईँको सिम कार्ड अनलक गर्न PUK प्रविष्ट गर्नुहोस्"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -7892,26 +4840,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "तपाईँसँग %u प्रयास बाँकी छ"
 msgstr[1] "तपाईँसँग %u प्रयास बाँकी छ"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "गलत पासवर्ड प्रविष्ट भयो ।"
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK कोड ८ अङ्क नम्बर हुनुपर्दछ"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "नयाँ पिन प्रविष्ट गर्नुहोस्"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "पिन कोड ४-८ अङ्क नम्बर को हुनुपर्छ"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "ताल्चा खोलिदै…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -7969,146 +4897,47 @@ msgstr "पिनसँग सिम कार्ड ताल्चा लग�
 msgid "M_odem Details"
 msgstr "मोडेम विवरण"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "फोन असफलता"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "फोनमा जडान छैन"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "सञ्चालन अनुमति छैन"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "सञ्चालन समर्थित छैन"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "सिमकार्ड राखिएको छैन"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "सिमको पिन आवश्यक"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "सिमको PUK आवश्यक"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "सिम असफलता"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "सिमकार्ड व्यस्त"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "पासवर्ड गलत थियो"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "सिमको पिन२ आवश्यक"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "सिमको PUK२ आवश्यक"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "फेला परेन"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "सञ्जाल सेवा छैन"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "सञ्जाल समय समाप्ति"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS सेवालाई अनुमति छैन"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "यो स्थान क्षेत्रमा रोमिङ गर्न अनुमति छैन"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "निर्दिष्ट नगरिएको GPRS त्रुटि"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "कार्य रद्द गरियो"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "पहुँच अस्वीकृत भयो"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "अज्ञात त्रुटि"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "सञ्जाल शैली"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39 panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "सेट गर्नुहोस्"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "बन्द गर्नुहोस्"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "स्वचालित"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "सञ्जाल छान्नुहोस्"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "सञ्जाल प्रदायकहरू ताजा पार्नुहोस्"
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "सिमकार्ड %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "मोबाइल सञ्जाल सक्षम पार्नुहोस्"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "कुनै WWAN एडप्टर फेला परेन"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "तपाईँसँग ताररहित वान/सेलुलर यन्त्र छ भन्ने निश्चित गर्नुहोस्"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "हवाईजहाज मोडमा हुँदा ताररहित वान असक्षम हुन्छ"
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "हवाइजहाज शैली बन्द गर्नुहोस्"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "डेटा जडान"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "इन्टरनेटका लागि सिम कार्ड प्रयोग गरियो"
 
@@ -8120,15 +4949,15 @@ msgstr "सिमकार्ड ताल्चा"
 msgid "_Next"
 msgstr "पछिल्लो"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "पिनसँग सिम कार्ड ताल्चा लगाउनुहोस्"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "पिन कोड परिवर्तन गर्नुहोस्"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr "सिम ताल्चा सेटिङ परिवर्तन गर्न हालको पिन प्रविष्ट गर्नुहोस्"
 
@@ -8140,8 +4969,6 @@ msgstr "मोबाइल सञ्जाल"
 msgid "Configure Telephony and mobile data connections"
 msgstr "टेलिफोनी र मोबाइल डेटा जडान कन्फिगर गर्नुहोस्"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "सेलुलर;wwan;टेलिफोनी;सिम;मोबाइल;"
@@ -8158,37 +4985,14 @@ msgstr "तपाईँको प्रणाली कन्फिगर गर
 msgid "The GNOME Project"
 msgstr "जिनोम परियोजना"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "संस्करण प्रदर्शन गर्नुहोस्"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "वर्गहरु:"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "भर्बोज निर्गत सक्षम पार्नुहोस्"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "स्ट्रिङको खोजी गर्नुहोस्"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "सम्भावित प्यानल नामहरू सूचीबद्ध गर्नुहोस् र निस्कनुहोस्"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "प्रदर्शन गर्न प्यानल"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "गोपनीयता"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "उपलब्ध प्यानलहरू:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8204,11 +5008,12 @@ msgstr "चेतावनी: विकास संस्करण"
 
 #: shell/cc-window.ui:153
 msgid ""
-"This version of Settings should only be used for development purposes. You may experience "
-"incorrect system behavior, data loss, and other unexpected issues. "
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
-"सेटिङको यो संस्करण विकास उद्देश्यका लागि मात्र प्रयोग गरिएको हुनुपर्दछ । तपाईँले गलत प्रणाली व्यवहार, डेटा ह्रास, "
-"र अन्य अनपेक्षित समस्या अनुभव गर्न सक्नुहुन्छ । "
+"सेटिङको यो संस्करण विकास उद्देश्यका लागि मात्र प्रयोग गरिएको हुनुपर्दछ । तपाईँले गलत "
+"प्रणाली व्यवहार, डेटा ह्रास, र अन्य अनपेक्षित समस्या अनुभव गर्न सक्नुहुन्छ । "
 
 #: shell/cc-window.ui:164
 msgid "Help"
@@ -8244,7 +5049,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "खोजी रद्द गर्नुहोस्"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "प्राथमिकता;सेटिङ;"
@@ -8255,18 +5059,19 @@ msgstr "खोलिने अन्तिम सेटिङ प्यानल
 
 #: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
-"The identifier for the last Settings panel to be opened. Unrecognised values will be ignored and "
-"the first panel in the list selected."
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
 msgstr ""
-"खोलिने अन्तिम सेटिङ प्यानलका लागि पहिचायक । अज्ञात मानहरू उपेक्षा गरिनेछ र सूचीमा पहिलो प्यानल चयन गरिएको "
-"हुनेछ ।"
+"खोलिने अन्तिम सेटिङ प्यानलका लागि पहिचायक । अज्ञात मानहरू उपेक्षा गरिनेछ र सूचीमा "
+"पहिलो प्यानल चयन गरिएको हुनेछ ।"
 
 #: shell/org.gnome.Settings.gschema.xml:13
 msgid "Show warning when running a development build of Settings"
 msgstr "सेटिङको विकास निर्माण चलाउदा चेतावनी देखाउनुहोस्"
 
 #: shell/org.gnome.Settings.gschema.xml:14
-msgid "Whether Settings should show a warning when running a development build."
+msgid ""
+"Whether Settings should show a warning when running a development build."
 msgstr "विकास निर्माण चलाउदा सेटिङले चेतावनी देखाउनु पर्दछ या पर्दैन ।"
 
 #: shell/org.gnome.Settings.gschema.xml:20
@@ -8274,11 +5079,11 @@ msgid "Initial state of the window"
 msgstr "सञ्झ्यालको सुरुआत स्थिति"
 
 #: shell/org.gnome.Settings.gschema.xml:21
-msgid "A tuple containing the initial width, height and maximized state of the application window."
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
 msgstr "अनुप्रयोग सञ्झ्यालको सुरु चौडाइ, उचाइ र अधिकतम स्थिति समाविष्ट टुपल ।"
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -8286,8 +5091,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u निर्गत"
 msgstr[1] "%u निर्गत"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -8295,9 +5098,2984 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u आगत"
 msgstr[1] "%u आगत"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "प्रणाली ध्वनिहरू"
+#~ msgid "System Bus"
+#~ msgstr "प्रणाली बस"
+
+#~ msgid "Full access"
+#~ msgstr "पूर्ण पहुँच"
+
+#~ msgid "Session Bus"
+#~ msgstr "सत्र बस"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "/dev मा पूरा पहुँच"
+
+#~ msgid "Has network access"
+#~ msgstr "सञ्जाल पहुच छ"
+
+#~ msgid "Home"
+#~ msgstr "गृह"
+
+#~ msgid "Read-only"
+#~ msgstr "पढ्न-मात्र"
+
+#~ msgid "File System"
+#~ msgstr "फाइल प्रणाली"
+
+#~ msgid "Can change settings"
+#~ msgstr "सेटिङ्गहरू परिवर्तन गर्न सक्छ"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s सँग निम्न अनुमति अवस्थित छ । यी परिवर्तन गर्न सकिँदैन । यदि तपाईँ यी अनुमतिका "
+#~ "बारेमा चिन्तित हुनुहुन्छ भने, यो अनुप्रयोग हटाउन विचार गर्नुहोस् ।"
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "अनुप्रयोगद्वारा खोलिएका %u फाइल र लिङ्क प्रकार"
+#~ msgstr[1] "अनुप्रयोगद्वारा खोलिएका %u फाइल र लिङ्क प्रकारहरू"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> निम्न प्रकारका फाइलहरू र लिङ्कहरू खोल्न प्रयोग गरिन्छ।"
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s मा डिस्क स्पेस प्रयोग भएको छ ।"
+
+#~ msgid "Select a picture"
+#~ msgstr "तस्वीर छान्नुहोस्"
+
+#~ msgid "_Open"
+#~ msgstr "खोल्नुहोस्"
+
+#~ msgid "multiple sizes"
+#~ msgstr "बिभिन्न आकार"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "डेस्कटप पृष्ठभूमि छैन"
+
+#~ msgid "Current background"
+#~ msgstr "हालको पृष्ठभूमि"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "वर्ग माथि तपाईँको क्यालिब्रेसन यन्त्र राख्नुहोस् र \"Start\" थिच्नुहोस्"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "क्यालिब्रसन यन्त्र क्यालिब्रट स्थानमाराखि जारि बटन थिच्नुहोस् ।"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "क्यालिब्रसन यन्त्र सटह स्थानमाराखि जारि बटन थिच्नुहोस् ।"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "कम्प्युटर बन्द गर्नुहोस्"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "एउटा आन्तरिक त्रुटि देखा पर्यो जुन पुन: प्राप्त गर्न सकिएन ।."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "अंशांकनलागि आवश्यक उपकरण स्थापित छैन।"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "प्रोफाईल बनाउन सकिएन"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "लक्षित सेतोबिन्दु प्राप्त गर्न सकिने थिएन ।"
+
+#~ msgid "Complete!"
+#~ msgstr "पूर्ण !"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "क्यालिब्रसन असफल!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "क्यालिब्रसन यन्त्र हटाउन सक्नुहुन्छ ।"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "अंशांकन प्रगतिमा हुँदा यन्त्रमा नचालाउनुहोस्"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "ल्याकटप पर्दा"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "अवस्थित वेवक्याम"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s मोनिटर"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s स्क्यानर"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s क्यामेरा"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s मुद्रक"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s वेवक्याम"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s रङ व्यवस्थापनका सक्षम गर्नुहोस्"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s को रङ्ग प्रोफाईल देखाउनुहोस्"
+
+#~ msgid "Not calibrated"
+#~ msgstr "क्यालिब्रेट नगरिएको"
+
+#~ msgid "Default: "
+#~ msgstr "पुर्वनिर्धारित "
+
+#~ msgid "Colorspace: "
+#~ msgstr "रङ्ग भर्ने स्थान "
+
+#~ msgid "Test profile: "
+#~ msgstr "नमुना प्रोफाइल "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC प्रोफाइल रोज्नुहोस्"
+
+#~ msgid "_Import"
+#~ msgstr "आयात गर्नुहोस्"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "ICC प्रोफाइल "
+
+#~ msgid "All files"
+#~ msgstr "सबै फाइलहरू"
+
+#~ msgid "Save Profile"
+#~ msgstr "प्रोफाईल बचत गर"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "चयन यन्त्र लागि एक रङ प्रोफाइल सिर्जना गर्नुहोस्"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr "मापन यन्त्र भेटिएन । सो यन्त्र जोडिएको छ र खुला छ भन्ने सुनिश्चित गर्नुहोस् ।"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "नाप्ने यन्त्रले प्रिन्टर प्रोफाइल समर्थन गर्दैन"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "यस प्रकारको यन्त्र समर्थित छैन ।"
+
+#~ msgid "Standard Space"
+#~ msgstr "सेतो खालीस्थान"
+
+#~ msgid "Test Profile"
+#~ msgstr "नमुना प्रोफाइल"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "स्वचालित"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "तल्लो गुणस्तर"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "मध्यम गुणस्तर"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "उच्च गुणस्तर"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "पुर्वनिर्धारित  RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "पुर्वनिर्धारित  CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "पुर्वनिर्धारित कैलो"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "विक्रेताले कारखाना अंशांकन डाटा प्रदान गर्यो"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "यो प्रोफाइलसँग पूरा-पर्दा प्रदर्शन सुधार सम्भव छैन"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "यो प्रोफाइल अब सही नहुन सक्छ"
+
+#~ msgid "Other…"
+#~ msgstr "अन्य…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "सेटिङ परिवर्तन गर्न ताल्चा खोल्नुहोस्"
+
+#~ msgid "Today"
+#~ msgstr "आज"
+
+#~ msgid "Yesterday"
+#~ msgstr "हिजो"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d घन्टा"
+#~ msgstr[1] "%d घन्टा"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d मिनेट"
+#~ msgstr[1] "%d मिनेट"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d सेकेन्ड"
+#~ msgstr[1] "%d सेकेन्ड"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "हटस्पट"
+
+#~ msgid "24-hour"
+#~ msgstr "२४ घण्टा"
+
+#~ msgid "AM / PM"
+#~ msgstr "१२ घन्टा (AM/PM)"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "प्राविधिक समस्याहरूको प्रतिवेदन पठाउँदा %s सुधार गर्न मद्दत गर्दछ । रिपोर्टहरू गुप्त "
+#~ "रूपमा पठाइन्छ र व्यक्तिगत जानकारी कोरिन्छ। %s"
+
+#~ msgid "On"
+#~ msgstr "खुला छ"
+
+#~ msgid "Off"
+#~ msgstr "बन्द"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "परिवर्तन लागू गर्नुहोस्?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "परिवर्तनहरू लागू गर्न सकिँदैन"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "यो हार्डवेयरको सीमितताले गर्दा हुन सक्छ ।"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "ल्याण्डस्केप"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "पोर्ट्रेट दाँया"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "पोर्ट्रेट बाँया"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "ल्यान्डस्केप (फ्लिप गरिएको)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf हर्ज"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "सुरक्षित बुट सक्रिय छ"
+
+#, fuzzy
+#~| msgid "Camera is Turned Off"
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "माइक्रोफोन बन्द गरिएको छ"
+
+#~ msgid "Passed"
+#~ msgstr "पास भयो"
+
+#~ msgid "Failed"
+#~ msgstr "असफल"
+
+#~ msgid "Security Level 0"
+#~ msgstr "सुरक्षको तह ०"
+
+#~ msgid "Security Level 1"
+#~ msgstr "सुरक्षको तह १"
+
+#~ msgid "Security Level 2"
+#~ msgstr "सुरक्षाको तह२"
+
+#~ msgid "Security Level 3"
+#~ msgstr "सुरक्षको तह ३"
+
+#, fuzzy
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "यन्त्र उपलब्ध छैन: %s"
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "सुरक्षित बुट सक्रिय छैन"
+
+#, fuzzy
+#~ msgid "No protection when the device is started."
+#~ msgstr "यन्त्र ताला खोल्न विकल्पहरू"
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "व्यापक सुरक्षा"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection"
+#~ msgstr "फर्मवेयर"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "फर्मवेयर संस्करण"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "फर्मवेयर"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "फर्मवेयर"
+
+#, fuzzy
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "ठाडो गरी क्रमबद्ध गरिएको फ्युज"
+
+#, fuzzy
+#~ msgid "Intel CET Enabled"
+#~ msgstr "सक्षम"
+
+#, fuzzy
+#~ msgid "Intel CET Active"
+#~ msgstr "सक्रिय छैन"
+
+#, fuzzy
+#~ msgid "Encrypted RAM"
+#~ msgstr "DVD-RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU सुरक्षा"
+
+#, fuzzy
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "लकडाउन त्रुटि: अवैध तर्क"
+
+#, fuzzy
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "प्रमाणपत्र रुजु गर्नुहोस्"
+
+#~ msgid "Linux Swap"
+#~ msgstr "लिनक्स स्वाप"
+
+#, fuzzy
+#~| msgid "Suspend"
+#~ msgid "Suspend To RAM"
+#~ msgstr "DVD-RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "निष्क्रिय मा निलम्बित गर्नुहोस्"
+
+#, fuzzy
+#~ msgid "UEFI Platform Key"
+#~ msgstr "विकासकर्ताका लागि जिनोम प्लेटफर्म र लाइब्रेरीहरूका लागि मार्गदर्शन ।"
+
+#, fuzzy
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "सुरक्षित"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "टीपीएम प्लेटफर्म कन्फिगरेसन"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "टिपिएम पुनर्निर्माण"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "टिपिएम v२.०"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "फर्मवेयर अद्यावधिकहरू"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Attestation"
+#~ msgstr "फर्मवेयर"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "प्याकेज अपडेटर"
+
+#, fuzzy
+#~ msgid "Platform Debugging"
+#~ msgstr "डिबगिङ सक्षम पार्नुहोस्"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "प्रोसेसर सुरक्षा जाँच"
+
+#, fuzzy
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "सुरक्षा"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "फर्मवेयर संस्करण"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "फर्मवेयर संस्करण"
+
+#, fuzzy
+#~ msgid "Fused Platform"
+#~ msgstr "जिनोम बिकासकर्ता प्लाटफर्म"
+
+#~ msgid "Valid"
+#~ msgstr "वैध छ"
+
+#~ msgid "Not Valid"
+#~ msgstr "वैध छैन"
+
+#~ msgid "Not Enabled"
+#~ msgstr "सक्षम पारिएको छैन"
+
+#~ msgid "Locked"
+#~ msgstr "ताल्चा लगाइयो"
+
+#~ msgid "Not Locked"
+#~ msgstr "ताल्चा लगाइएको छैन"
+
+#~ msgid "Encrypted"
+#~ msgstr "गुप्तिकृत"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "गुप्तीकरण नगरिएको"
+
+#~ msgid "Tainted"
+#~ msgstr "दाग लागेको"
+
+#~ msgid "Not Tainted"
+#~ msgstr "दाग लागेको छैन"
+
+#~ msgid "Found"
+#~ msgstr "फेला पर्यो"
+
+#~ msgid "Not Found"
+#~ msgstr "फेला परेन"
+
+#~ msgid "Supported"
+#~ msgstr "समर्थित छ"
+
+#~ msgid "Not Supported"
+#~ msgstr "समर्थित छैन"
+
+#~ msgid "Unknown"
+#~ msgstr "अज्ञात"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "६४-विट"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "३२-विट"
+
+#~ msgid "X11"
+#~ msgstr "एक्स ११"
+
+#~ msgid "Wayland"
+#~ msgstr "व्यल्यान्ड"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "अज्ञात"
+
+#~ msgid "Not Available"
+#~ msgstr "उपलब्ध छैन"
+
+#~ msgid "System Logo"
+#~ msgstr "प्रणाली लोगो"
+
+#~ msgid "No input sources found"
+#~ msgstr "कुनै पनि निर्गत श्रोत फेला परेन ।"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "अन्य"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "अनुकुलित सर्टकट"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "वैकल्पिक क्यारेक्टर कुञ्जीलाई थप क्यारेक्टरहरू प्रविष्ट गर्न प्रयोग गर्न सकिन्छ । यी "
+#~ "कहिलेकाहीँ तपाईँको कुञ्जीपाटीमा तेस्रो-विकल्पको रूपमा मुद्रण गरिन्छ।"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "देब्रे alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "दाहिने alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "देब्रे super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "दाहिने super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "मेनु कुञ्जी"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "दाया Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "कम्पोज कुञ्जीले प्रविष्ट गर्नका लागि विभिन्न क्यारेक्टरहरूलाई अनुमति दिन्छ । यसलाई "
+#~ "प्रयोग गर्न, त्यसपछि अक्षरहरूको क्रम रचना गर्नुहोस्।  उदाहरणका लागि, <b>सी</b> र "
+#~ "<b>ओ</b> <b>©</b> प्रवेश गर्ने कुञ्जी रचना गर्नुहोस् <b>क</b> त्यसपछि <b>'</b> "
+#~ "<b>á</b> प्रवेश गर्नेछ।"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "क्यप्स लक"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "scroll lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "पर्दा मुद्रण गर्नुहोस्"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "आगत स्रोतहरू %s कुञ्जीपाटी सर्टकट प्रयोग गरेर स्विच गर्न सकिन्छ।\n"
+#~ "यो कुञ्जीपाटी सर्टकट सेटिङमा परिवर्तन गर्न सकिन्छ ।"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d परिमार्जित"
+#~ msgstr[1] "%d परिमार्जित"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "सबै सर्टकटहरू रिसेट गर्नुहुन्छ?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "सर्टकट रिसेट गर्दा यसले तपाईंको अनुकूल सर्टकटलाई असर गर्न सक्छ। यो पूर्वावस्थामा लाउन "
+#~ "सकिँदैन ।"
+
+#~ msgid "Reset All"
+#~ msgstr "सबै रिसेट गर्नुहोस्"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s पहिले नै %s का लागि प्रयोग भैरहेको छ । यदि तपाईँले यसलाई प्रतिस्थापन गर्नुभयो भने, "
+#~ "%s अक्षम हुनेछ"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "नयाँ सर्टकट टाइप गर्नुहोस्"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "अनुकूलन सर्टकट सेट गर्नुहोस्"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "सर्टकट सेट गर्नुहोस्"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "%s परिवर्तन गर्न नयाँ सर्टकट प्रविष्ट गर्नुहोस् । "
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "अनुकूलन सर्टकट थप्नुहोस्"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "दुई औला स्क्रोलिङ्ग"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "पाँच क्लिक, GEGL समय!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "मुख्य बटन दुई चोटी थिच्नुहोस"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "मुख्य बटन एक पटक थिच्नुहोस"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "बीच को बटन दुई चोटी थिच्नुहोस"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "बीच को बटन एक चोटी थिच्नुहोस"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "साहायक बटन दुई चोटी थिच्नुहोस"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "सहायक बटन एक चोटी थिच्नुहोस"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "नेट्वोर्क म्यानेजर चलिरहन गर्न आवश्यक छ।"
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "असुरक्षित सञ्जाल (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "सुरक्षित सञ्जाल WPA"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "सुरक्षित सञ्जाल WPA2"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "सुरक्षित सञ्जाल WPA3"
+
+#~ msgid "Secure network"
+#~ msgstr "सुरक्षित सञ्जाल"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "हटस्पट खोल्दा %s बाट विच्छेदन हुनेछ, र वाई-फाई मार्फत इन्टरनेट पहुँच सम्भव हुदैन ।"
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "न्यूनतम ८ क्यारेक्टर हुनुपर्दछ"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "हटस्पट बन्द गर्ने कुनै पनि प्रयोगकर्ता छुटाउने हो?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "हटस्पट रोक्नुहोस्"
+
+#~ msgid "Preserve"
+#~ msgstr "सरक्षण गर्नुहोस्"
+
+#~ msgid "Permanent"
+#~ msgstr "स्थायी"
+
+#~ msgid "Random"
+#~ msgstr "अनियमित"
+
+#~ msgid "Stable"
+#~ msgstr "स्थिर"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "यहाँ प्रविष्ट गरिएको MAC ठेगाना यो जडान सक्रिय पारिएको सञ्जाल यन्त्रका लागि "
+#~ "हार्डवेयर ठेगानाको रूपमा प्रयोग गरिनेछ । यो विशेषतालाई MAC क्लोनिङ वा स्पूफिङ भनिन्छ "
+#~ "। उदाहरण: ००:११:२२:३३:४४:५५"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "प्रोफाइल %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "विस्तारित खुला"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "ईन्टरप्राईज"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "कुनै पनि होइन"
+
+#~ msgid "Never"
+#~ msgstr "कहिले पनि होइन"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d एम बी/से"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "कुनै पनि होइन"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "कमजोर"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ठिक छ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "असल"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "उत्तम"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "जडान भुल्नुहोस्"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "जडान प्रोफाईल हटाउनुहोस्"
+
+#~ msgid "Remove VPN"
+#~ msgstr "भीपीएन हटाउनुहोस्"
+
+#~ msgid "Details"
+#~ msgstr "विस्तृत विवरणहरू"
+
+#~ msgid "automatic"
+#~ msgstr "स्वचालित"
+
+#~ msgid "Identity"
+#~ msgstr "परिचय"
+
+#~ msgid "Delete Address"
+#~ msgstr "ठेगाना पुस्तिका  मेट्नुहोस्"
+
+#~ msgid "Delete Route"
+#~ msgstr "पथ मेट्नुहोस्"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "कुनै पनि होइन"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit पासफ्रेज"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "गतिशील WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "जडान सम्पादक खोल्न सकिएन"
+
+#~ msgid "New Profile"
+#~ msgstr "नायाँ प्रोफाइल"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "अवैध सेटिङ %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "अवैध सेटिङ %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "फाईलबाट आयात गर्नुहोस्…"
+
+#~ msgid "Add VPN"
+#~ msgstr "भीपीएन थप्नुहोस्"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "भीपीएन जडान आयात गर्न सकिएन"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "फाइल \"%s\" पढ्न सकिएन वा पहिचान गरिएको भीपीएन जडान सूचना समावेश गर्दैन\n"
+#~ "\n"
+#~ "त्रुटि: %s ."
+
+#~ msgid "Select file to import"
+#~ msgstr "आयात गर्न फाइल चयन गर्नुहोस्"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "'%s' नाम गरेको फाइल पहिले नै अवस्थित छ ।."
+
+#~ msgid "_Replace"
+#~ msgstr "बदल्नुहोस्"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "तपाईँले बचत गरिरहनु भएको भीपीएन जडानसँग %s बदल्न चाहनुहुन्छ?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "भीपीएन जडान निर्यातगर्न सकिएन"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "भीपीएन जडान \"%s\" %sमा निर्यात गर्न सकेन ।\n"
+#~ "\n"
+#~ "त्रुटि: %s ."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "भीपीएन जडान निर्यात गर्नुहोस्"
+
+#~ msgid "never"
+#~ msgstr "कहिले पनि होइन"
+
+#~ msgid "today"
+#~ msgstr "आज"
+
+#~ msgid "yesterday"
+#~ msgstr "हिजो"
+
+#~ msgid "Last used"
+#~ msgstr "अन्तिम पटक प्रयोग गरिएको"
+
+#~ msgid "Add new connection"
+#~ msgstr "नयां जडान थप्नुहोस्"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "चयन गरिएका सञ्जालका लागि सञ्जाल विवरणहरू, पासवर्डहरू र कुनै पनि अनुकूल कन्फिगरेसन "
+#~ "समाविष्ट गर्दछ ।"
+
+#~ msgid "_Forget"
+#~ msgstr "भुलनुहोस्"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "परिचित वाई-फाई सञ्जाल"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "भुलनुहोस्"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "प्रणाली नीतिले हटस्पटको रूपमा प्रयोग निषेध गर्दछ"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "ताररहित यन्त्रले हटस्पट शैलीलाई समर्थन गर्दैन"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "कन्फिगरेसन युआरएल प्रदान गरिएको छैन वेब प्रोक्सी Autodiscovery प्रयोग गरिएको छ ।"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "यो अविश्वसनीय सार्वजनिक नेटवर्कको लागि सिफारिश गरिएको छैन।"
+
+#~ msgid "Status unknown"
+#~ msgstr "वस्तुस्थिति अज्ञात"
+
+#~ msgid "Unmanaged"
+#~ msgstr "अव्यवस्थित"
+
+#~ msgid "Unavailable"
+#~ msgstr "अनुपलब्ध"
+
+#~ msgid "Connecting"
+#~ msgstr "जडान गर्दै"
+
+#~ msgid "Authentication required"
+#~ msgstr "प्रमाणीकरण आवश्यक"
+
+#~ msgid "Disconnecting"
+#~ msgstr "जडान हटाउदै"
+
+#~ msgid "Connection failed"
+#~ msgstr "जडान असफल"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "वस्तुस्थिति अज्ञात(हराएको)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "कन्फिगुरेसन असफल"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP कन्फिगरेसन असफल भयो"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP कन्फिगरेसन म्याद समाप्त भएको छ"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "पासवर्ड आवश्यक छ, तर प्रदान गरिएन"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x supplicant विच्छेदन भयो"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x supplicant कन्फिगरेसन विफल"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x supplicant विफल"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant प्रमाणित गर्न लामो समय लियो"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "पिपिपि सेवा सुरु गर्न असफल भयो"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "पिपिपि सेवा विच्छेद भयो"
+
+#~ msgid "PPP failed"
+#~ msgstr "पिपिपि असफल"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP client सुरु गर्न असफल भयो"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP क्लाईन्त मा त्रुति"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP असफल भयो"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "साझा जडान सेवा सुरु गर्न विफल"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "साझेदारि जडान सेवा असफल"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "स्वतIP सेवा सुरु गर्न असफल भयो"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "स्वतIP सेवामा त्रुटि"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "स्वतIP सेवा असफल भयो"
+
+#~ msgid "Line busy"
+#~ msgstr "लाईन व्यस्त छ"
+
+#~ msgid "No dial tone"
+#~ msgstr "डायलटोन छैन"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "कुनै क्यारियर स्थापित गर्न सकिएन"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "डायलिङ्ग समय सकियो"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "डायलिङ्गगर्ने प्रयास असफल"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "मोडेम सुरुवात गर्न असफल"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "APN चयन गर्न असफल भयो"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "सञ्जाल खोजी गर्दैन"
+
+#~ msgid "Network registration denied"
+#~ msgstr "सञ्जाल दर्ता गर्नदिएन"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "सञ्जालदर्ता समय सकियो"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "अनुरोध सञ्जाल दर्ता गर्न असफल"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN जाच असफल भयो"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "उपकरण लागि फर्मवेयर नरहेको हुन सक्छ"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "जडान विस्थापन भयो"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "होलको जडान पुन जडानभयो"
+
+#~ msgid "Modem not found"
+#~ msgstr "मोडेम फेला परेन"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ब्लुटुठ जडान असफल भयो"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "सिमकार्ड राखिएको छैन"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "सिमको पिन आवश्यक"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "सिमको PUK आवश्यक"
+
+#~ msgid "SIM wrong"
+#~ msgstr "गलत SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "जडान निर्भरता विफल"
+
+#~ msgid "Firmware missing"
+#~ msgstr "फर्मवेयर छैन"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "केबल छुटेको"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "802.1X सुरक्षामा अपरिभाषित त्रुटि (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "कुनै फाइल चयन गरिएको छैन"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "eap-method फाइल वैधता गर्दा निर्दिष्ट नगरिएको त्रुटि"
+
+#, fuzzy
+#~| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, वा PKCS#12 निजी कुञ्जीहरू (*. der, *. pem, *. p12, *.key)"
+
+#, fuzzy
+#~| msgid "_User certificate"
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER वा PEM प्रमाणपत्र (*. der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "EAP-FAST PAC फाइल हराइरहेको छ"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC files (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "EAP-LEAP प्रयोगकर्ता नाम हराइरहेको छ"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "EAP-LEAP पासवर्ड हराइरहेको छ"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "अवैध EAP-PEAP CA प्रमाणपत्र: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "अवैध EAP-PEAP CA प्रमाणपत्र: प्रमाणपत्र निर्दिष्ट गरिएको छैन"
+
+#~ msgid "missing EAP username"
+#~ msgstr "EAP प्रयोगकर्ता नाम हराइरहेको छ"
+
+#~ msgid "missing EAP password"
+#~ msgstr "EAP पासवर्ड हराइरहेको छ"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "हराइरहेको EAP-TLS परिचय"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "अवैध EAP-TLS CA प्रमाणपत्र: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "अवैध EAP-TLS CA प्रमाणपत्र: प्रमाणपत्र निर्दिष्ट गरिएको छैन"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "अवैध EAP-TLS व्यक्तिगत कुञ्जी: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "अवैध EAP-TLS प्रयोगकर्ता-प्रमाणपत्र: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "गुप्तिकरण नगरिएको व्यक्तिगत कुञ्जी हरू असुरक्षित छन्"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "चयन गरिएको व्यक्तिगत कुञ्जीलाई पासवर्डद्वारा सुरक्षित गरेको देखिदैन । यसले तपाईँको "
+#~ "सुरक्षा प्रमाणपत्रहरू सम्झौता गर्न अनुमति दिन सक्छ । कृपया पासवर्ड सुरक्षित व्यक्तिगत "
+#~ "कुञ्जी चयन गर्नुहोस् ।\n"
+#~ "\n"
+#~ "(तपाईं आफ्नो निजी कुञ्जी openssl संग पासवर्ड-सुरक्षा गर्न सक्नुहुन्छ)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "तपाईँको व्यक्तिगत प्रमाणपत्र छान्नुहोस्"
+
+#~ msgid "Choose your private key"
+#~ msgstr "निजी  कुञ्जी छान्नुहोस्"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "अवैध EAP-TTLS CA प्रमाणपत्र: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "अवैध EAP-TTLS CA प्रमाणपत्र: प्रमाणपत्र निर्दिष्ट गरिएको छैन"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "802.1X सुरक्षा लाई प्रमाणित गर्दा अज्ञात त्रुटि"
+
+#~ msgid "Select a file"
+#~ msgstr "एउटा फाइल चयन गर्नुहोस्"
+
+#~ msgid "missing leap-username"
+#~ msgstr "LEAP-प्रयोगकर्ता नाम हराइरहेको छ"
+
+#~ msgid "missing leap-password"
+#~ msgstr "LEAP-पासवर्ड हराइरहेको छ"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "वाई-फाई पासवर्ड छैन।"
+
+#~ msgid "missing wep-key"
+#~ msgstr "wep-key हराएको छ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr "अवैध wep-key: %zu लम्बाइ भएको कुञ्जीले हेक्स-अङ्क मात्र समाविष्ट गर्नुपर्दछ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "अवैध wep-key: %zu लम्बाइ भएको कुञ्जीले ascii क्यारेक्टर मात्र समाविष्ट गर्नुपर्दछ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "अवैध wep-key: गलत कुञ्जी लम्बाइ %zu। एउटा कुञ्जी या त लम्बाइ ५/१३ (ascii) वा "
+#~ "१०/२६ (hex) हुनुपर्छ"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "अवैध wep-key: पासफ्रेज खाली नभएको हुनुपर्छ"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "अवैध wep-key: पासफ्रेज ६४ क्यारेक्टर भन्दा छोटो हुनुपर्छ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr "अवैध wpa-psk: अवैध कुञ्जी-लम्बाइ %zu । [८,६३] बाइट वा ६४ हेक्स अङ्क हुनुपर्दछ"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "अवैध wpa-psk: हेक्सको रूपमा ६४ बाइटहरूसँग कुञ्जी व्याख्या गर्न सकिँदैन"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "अन्य"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s हटाउनुहोस्"
+
+#~ msgid "Error removing account"
+#~ msgstr "खाता हटाउँदा त्रुटि"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s खाता"
+
+#~ msgid "Remove Account"
+#~ msgstr "खाता हटाउनुहोस्"
+
+#~ msgid "Unknown time"
+#~ msgstr "अज्ञात समय"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "पुरा चार्जको हुन %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "सावधान: %sबाँकी"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s बाकि छ"
+
+#~ msgid "Fully charged"
+#~ msgstr "पुरा चार्ज"
+
+#~ msgid "Not charging"
+#~ msgstr "चार्ज छैन"
+
+#~ msgid "Empty"
+#~ msgstr "खाली"
+
+#~ msgid "Charging"
+#~ msgstr "चार्जहुँदै"
+
+#~ msgid "Discharging"
+#~ msgstr "चार्ज सकिदैँछ"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "वायरलेस माउस"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "वायरलेस कुञ्जीपाटी"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "अटुट विद्युत आपूर्ति"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "पर्सनल डिजिटल असिस्टेन्ट"
+
+#~ msgid "Cellphone"
+#~ msgstr "सेलफोन"
+
+#~ msgid "Media player"
+#~ msgstr "मिडिया प्लेयर"
+
+#~ msgid "Tablet"
+#~ msgstr "ट्याबलेट"
+
+#~ msgid "Computer"
+#~ msgstr "कम्प्युटर"
+
+#~ msgid "Gaming input device"
+#~ msgstr "खेल आगत यन्त्र"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "मुख्य"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "अतिरिक्त"
+
+#~ msgid "Batteries"
+#~ msgstr "बेटरिहरू"
+
+#~ msgid "When _idle"
+#~ msgstr "निश्क्रिय"
+
+#~ msgid "Suspend"
+#~ msgstr "निश्क्रिय गर्ने"
+
+#~ msgid "Power Off"
+#~ msgstr "पावर बन्द"
+
+#~ msgid "Hibernate"
+#~ msgstr "हाइवरनेट"
+
+#~ msgid "Nothing"
+#~ msgstr "केही पनि होइन"
+
+#~ msgid "When on battery power"
+#~ msgstr "जब बेटरि पावरमा"
+
+#~ msgid "When plugged in"
+#~ msgstr "जडान भएको बेला"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "कहिल्यै पनि"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "स्वत निश्क्रिय"
+
+#, fuzzy
+#~| msgid "Performance mode unavailable"
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "भोलि सम्म अस्थाई निस्क्रिय"
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "न्यून ब्याट्री: पावर सेभर सक्षम पारियो । ब्याट्री पर्याप्त चार्ज हुँदा अघिल्लो मोड "
+#~ "पूर्वावस्थामा ल्याइनेछ ।"
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "शक्ति बचतकर्ता मोड \"%s\" द्वारा सक्रिय पारियो।"
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "प्रदर्शन मोड \"%s\" द्वारा सक्रिय पारियो।"
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "कार्यसम्पादन"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "उच्च प्रदर्शन र शक्ति प्रयोग। "
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "सन्तुलन"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "मानक प्रदर्शन र शक्ति उपयोग।"
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "पावर बचत"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "कम प्रदर्शन र शक्ति प्रयोग."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "मुद्रणयन्त्र “%s” मेटियो"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "नयाँ मुद्रक थप्न असफल"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui जडान गर्न सकिएन : %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "मुद्रक र परिवर्तन सेटिङ थप्न ताल्चा खोल्नुहोस्"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "विस्तृत विवरण %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "उपयुक्त ड्राइभर पाइएन"
+
+#~ msgid "Select PPD File"
+#~ msgstr "PPD फाइल चयन गर्नुहोस्"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "पोस्ट स्क्रिप्ट मुद्रणयन्त्र डिस्क्रिप्सन फाइलहरू  (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+#~ "*.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect  मुद्रक"
+
+#~ msgid "LPD Printer"
+#~ msgstr "एलपीडि मुद्रण"
+
+#~ msgid "One Sided"
+#~ msgstr "एकापट्टी"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "लामो धार भएको"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "छोटो किनारा (फ्लिप)"
+
+#~ msgid "Portrait"
+#~ msgstr "पोर्ट्रेट"
+
+#~ msgid "Landscape"
+#~ msgstr "ल्याण्डस्केप"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "ल्याण्डस्केप उल्टाउनुहोस्"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "पोट्रेट उल्टाउनुहोस्"
+
+#~ msgid "Resume"
+#~ msgstr "पुन: निरन्तरता दिनुहोस्"
+
+#~ msgid "Pause"
+#~ msgstr "पज गर्नुहोस्"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "विचाराधिन"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "पज गरिएको"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "प्रमाणीकरण आवश्यक"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "प्रक्रिया गरिदै"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "रोकियो"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "रद्द गरियो"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "परित्याग गरियो"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "पूरा भयो"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "यो कामलाई पङ्क्ति माथि तिर सार्नुहोस्"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — सक्रिय कार्य"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "%s बाट मुद्रण गर्न कालागि प्रमाणपत्रहरू प्रविष्ट गर्नुहोस् ।"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "मुद्रण सर्भर ताल्चा खोल्नुहोस्"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s ताल्चा हटाउनुहोस्।"
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "%sमा मुद्रणहरू हेर्न प्रयोगकर्ता नाम र पासवर्ड प्रवेश गर्नुहोस् ।."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "मुद्रणयन्त्रहरू खोज्दै"
+
+#~ msgid "USB"
+#~ msgstr "युएसबि"
+
+#~ msgid "Serial Port"
+#~ msgstr "क्रम पोर्ट"
+
+#~ msgid "Parallel Port"
+#~ msgstr "समानान्तर पोर्ट"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "स्थान: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "ठेगाना %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "सर्भरलाई प्रमाणीकरण आवश्यक छ"
+
+#~ msgid "Two Sided"
+#~ msgstr "दुबैपट्टी"
+
+#~ msgid "Paper Type"
+#~ msgstr "कागजको प्रकार"
+
+#~ msgid "Paper Source"
+#~ msgstr "कागज श्रोत"
+
+#~ msgid "Output Tray"
+#~ msgstr "निर्गत ट्रे"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "रिजोल्युसन"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "घोस्टस्क्रिप्ट प्रि-फिल्टरिङ"
+
+#~ msgid "Pages per side"
+#~ msgstr "एकापट्टि पृष्ठहरू"
+
+#~ msgid "Orientation"
+#~ msgstr "अभिमुखीकरण"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "साधारण"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "पृष्ठ सेटअप"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "स्थापना गर्ने विकल्पहरू"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "काम"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "छवि गुणस्तर"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "रङ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "सकिदै"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "उन्नत"
+
+#~ msgid "Test page"
+#~ msgstr "नमुना पृष्ठ"
+
+#~ msgid "Auto Select"
+#~ msgstr "स्वतः छान्ने"
+
+#~ msgid "Printer Default"
+#~ msgstr "पूर्वानिर्धारण मुद्रण"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "घोस्टस्क्रिप्ट फन्टहरू मात्र सम्मिलित गर्नुहोस्"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "पीएस स्तर १ रूपान्तरण"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "पीएस स्तर २ रूपान्तरण"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "पूर्व-फिल्टर छैन"
+
+#~ msgid "Clean print heads"
+#~ msgstr "मुद्रण हेड सफा गर्नुहोस्"
+
+#~ msgid "Out of toner"
+#~ msgstr "टोनर सकियो"
+
+#~ msgid "Low on developer"
+#~ msgstr "डेभेलोपर कम छ"
+
+#~ msgid "Out of developer"
+#~ msgstr "डेभेलोपर सकियो"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "मार्कर आपूर्ति कमि"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "मार्कर आपूर्ति सकियो"
+
+#~ msgid "Open cover"
+#~ msgstr "आवरण खोल्नुहोस्"
+
+#~ msgid "Open door"
+#~ msgstr "ढोका खुला छ"
+
+#~ msgid "Low on paper"
+#~ msgstr "कागजको कमी"
+
+#~ msgid "Out of paper"
+#~ msgstr "कागज सकियो"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "अफलाइन"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "रोकियो"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "फोहोर भण्डारण लगभग पूर्ण"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "फोहोर भण्डारण भरियो"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ओप्टिकल फोटो सञ्चालक  जीवनको अन्तमा छ"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ओप्टिकल फोटो सञ्चालकले हालै काम गरेको छैन"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "तयार"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "मुद्रण कार्य स्वीकार्य छैन"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "प्रक्रिया गरिदै"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "इम्पेरियल"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "मेट्रिक"
+
+#~ msgid "Ask what to do"
+#~ msgstr "के गर्ने भनेर सोध्नुहोस्"
+
+#~ msgid "Do nothing"
+#~ msgstr "केही पनि होइन"
+
+#~ msgid "Open folder"
+#~ msgstr "फोल्डर खोल्नुहोस्"
+
+#~ msgid "Other Media"
+#~ msgstr "अरु मिडिया"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "अडियो सिडिहरूको लागि अनुप्रयोग छान्नुहोस्"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "भिडियो डिभिडिहरूको लागि अनुप्रयोग छान्नुहो"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "संगीत बजाउने यन्त्र जॊडीएपछि संगीत बजाउनकालागि एक अनुप्रयोग छान्नुहोस्"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "फोटो खिच्ने यन्त्र (क्यामेरा) जडित भएमा कुन प्रोग्राम सुचारु हुने, रोज्नुहोस्"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "अनुप्रयोग सिडिहरूको लागि अनुप्रयोग छान्नुहो"
+
+#~ msgid "audio DVD"
+#~ msgstr "ध्वनि डिभिडि॒"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "रित्तो ब्लुरे चक्का"
+
+#~ msgid "blank CD disc"
+#~ msgstr "रित्तो सिडि चक्का"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "रित्तो डिभिडि॒ चक्का"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "रित्तो एचडिडिभिडि चक्का"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "ब्लुरे भिडियो चक्का"
+
+#~ msgid "e-book reader"
+#~ msgstr "इ- पुस्तक पाठक"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "एचडि डिभिडि भिडियो चक्का"
+
+#~ msgid "Picture CD"
+#~ msgstr "तस्वीर सिडि"
+
+#~ msgid "Super Video CD"
+#~ msgstr "सुपर भिडियो सिडि"
+
+#~ msgid "Video CD"
+#~ msgstr "भिडिओ(दृष्य) सिडि"
+
+#~ msgid "Windows software"
+#~ msgstr "विन्डोज् सफ्टवेर"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "पर्दा बन्द गर्नुहोस्"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "३० सेकेण्ड"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "१ मिनेट"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "२ मिनेट"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "३ मिनेट"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "५ मिनेट"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "३० मिनेट"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "१ घन्टा"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "१ मिनेट"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "२ मिनेट"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "३ मिनेट"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "४ मिनेट"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "५ मिनेट"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "८ मिनेट"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "१० मिनेट"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "१२ मिनेट"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "१५ मिनेट"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "कहिल्यै पनि"
+
+#~ msgid "Select Location"
+#~ msgstr "_स्थान छान्नुहोस्"
+
+#~ msgid "_OK"
+#~ msgstr "ठिक छ"
+
+#~ msgid "No applications found"
+#~ msgstr "अनुप्रयोग पाईएन"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "साझेदारि सञ्जाल छानिइको छैन"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "खुला छ"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "बन्द"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "सक्षम पारिएको"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "सक्रिय"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "एउटा फोल्डर रोज्नुहोस्"
+
+#, fuzzy
+#~| msgid "Media Sharing"
+#~ msgid "Enable media sharing"
+#~ msgstr "मेडिया साझेदारी"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "फाइल साझेदारीले तपाईँको हालको सञ्जालमा अन्यसँग तपाईँको सार्वजनिक फोल्डर साझेदारी "
+#~ "गर्न अनुमति दिन्छ: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "टाढाको लगइन सक्षम पारिएमा, सुरक्षित शेल आदेश प्रयोग गरेर टाढा प्रयोगकर्ताहरूले जडान "
+#~ "गर्न सक्दछन्:\n"
+#~ "%s"
+
+#, fuzzy
+#~ msgid "Enable personal media sharing"
+#~ msgstr "मेडिया साझेदारी"
+
+#~ msgid "Device name copied"
+#~ msgstr "यन्त्र नाम प्रतिलिपी गरियो"
+
+#~ msgid "Device address copied"
+#~ msgstr "यन्त्र ठेगान प्रतिलिपि गरियो"
+
+#~ msgid "Username copied"
+#~ msgstr "प्रयोगकर्ताको नाम प्रतिलिपी गरियो"
+
+#~ msgid "Password copied"
+#~ msgstr "गुप्तशब्द प्रतिलिपि गरियो"
+
+#~ msgid "Custom"
+#~ msgstr "अनुकुलन"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "निरिक्षण %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "१००%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "जडान विच्छेदन भयो"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "जडान गर्दै"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "जडान भयो"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "प्रमाणिकरण असफल"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "प्राधिकृत गर्दै"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "घटाइएको कार्यात्मकता"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "प्रमाणीकरण र जडान भयो"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "अज्ञात"
+
+#~ msgid "Authorized at:"
+#~ msgstr "प्रमाणीकरण:"
+
+#~ msgid "Connected at:"
+#~ msgstr "जडान भएको:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "दर्ता भएको:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "यन्त्र अधिकार प्राप्त गर्न असफल भयो: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "यन्त्र बिर्सन असफल भयो: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "त्रुटी"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "प्रमाणीकरण गरिएको"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "थन्डरबोल्ट उपप्रणाली (boltd) स्थापना गरिएको छैन वा राम्रोसँग सेटअप गरिएको छैन ।"
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "USB र प्रदर्शन पोर्ट यन्त्र मात्र संलग्न गर्न सकिन्छ ।"
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "थन्डरबोल्ट पत्ता लगाउन सकेन ।\n"
+#~ "या त प्रणालीमा थन्डरबोल्ट समर्थनको कमी छ, यो BIOS मा अक्षम पारिएको छ वा BIOS "
+#~ "मा एउटा असमर्थित सुरक्षा स्तरमा सेट गरिएको छ ।"
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "BIOS मा थन्डरबोल्ट समर्थन अक्षम पारिएको छ ।"
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "थन्डरबोल्ट सुरक्षा स्तर निर्धारण गर्न सकेन ।"
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "प्रत्यक्ष मोड स्विच गर्दा त्रुटि: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "पुर्वनिर्धारित"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "मध्यम"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "ठूलो"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "अझ ठूलो"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "सबै भन्दा ठूलो"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d पिक्सेल"
+#~ msgstr[1] "%d पिक्सेलहरू"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "छोटो"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ पर्दा"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ पर्दा"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ पर्दा"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "लामो"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "१ घन्टा"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "१ दिन"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "२ दिन"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "३ दिन"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "४ दिन"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "५ दिन"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "६ दिन"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "७ दिन"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "१४ दिन"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "३० दिन"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "रद्दीटोकरीमा भएका सबै वस्तुहरू मेट्नुहोस्"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "रद्दीटोकरीमा भएका सबै वस्तुहरू मेट्नुहोस्."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "रद्दीटोकरी रित्याउनुहोस्"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "सबै अस्थाई फाइलहरू मेट्नुहोस्?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "सबै अस्थायी फाइलहरू स्थायी रूपले मेटिनेछ ।"
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "अस्थाई फाइलहरू मेट्नुहोस्"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "१ दिन"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "७ दिन"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "३० दिन"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "सधै"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "तपाईँको लगइन प्रदायकको वेब ठेगानासँग मिल्नुपर्छ ।"
+
+#~ msgid "Failed to add account"
+#~ msgstr "खाता थप्न असफल"
+
+#~ msgid "Failed to register account"
+#~ msgstr "खाता दर्ता गर्न असफल"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "यो डोमेनसँग प्रमाणीकरण गर्ने कुनै समर्थित तरिका छैन"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "डोमेन जडान गर्न असफल"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr "लगईन नाम मिलेन : पुन प्रयास गर्नुस ।"
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr "लगईन पासवर्ड मिलेन : पुन प्रयास गर्नुस।. "
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "डोमेन लगईन असफल"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "डोमेन फेला पार्न अक्षम । सायद तपाईँले गलत हिज्जे गर्नुभएको छ?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "अरु छविकोलागि ब्राउज गर्नुहोस्"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "यन्त्रले यो कार्य सम्पादन गर्न दावी गर्नु पर्दछ"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "यन्त्र पहिल्यै अर्को प्रक्रियाद्वारा दावा गरिएको छ"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "तपाईँलाई कार्य सम्पादन गर्न अनुमति छैन ।"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "कुनै मुद्रण दर्ता भएको छैन"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "नामाकरण गर्दा यन्त्रसँग सञ्चार गर्न असफल भयो"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "औठाछाप वाचकसँग सञ्चार गर्न असफल भयो"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "औठाछाप डेइमोनसँग सञ्चार गर्न असफल"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "औठाछापहरू सूचीबद्ध गर्न असफल भयो: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "बचत गरिएका औठाछापहरू मेट्न असफल भयो: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "बायाँ बुढीऔँला"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Left middle finger"
+
+#~ msgid "_Left index finger"
+#~ msgstr "बायाँ चोर औँला"
+
+#~ msgid "Left ring finger"
+#~ msgstr "बायाँ साहिँली औँला"
+
+#~ msgid "Left little finger"
+#~ msgstr "बायाँ कान्छी औँला"
+
+#~ msgid "Right thumb"
+#~ msgstr "दायाँ बुढी औँला"
+
+#~ msgid "Right middle finger"
+#~ msgstr "दायाँ माझी औँला"
+
+#~ msgid "_Right index finger"
+#~ msgstr "दाहिने चोर औँला"
+
+#~ msgid "Right ring finger"
+#~ msgstr "दायाँ साहिँली औँला"
+
+#~ msgid "Right little finger"
+#~ msgstr "दायाँ कान्छी औँला"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "अज्ञात अंगुठाछाप"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "पुरा गर्नुहोस्"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "अंगुठाछाप उपकरण छुटाइएको छ"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "औठाछाप यन्त्र भण्डारण भरिएको छ"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "नया अंगुठाछाप दर्ता गर्न असफल"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "दर्ता सेवा शुरु असफल भयो:%s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "नया अंगुठाछाप दर्ता गर्न असफल"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "दर्ता सेवा रोक्न असफल भयो:%s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr "बारम्बार उचालेर आफ्नो औँठाछाप भर्ना गर्न पाठकलाई आफ्नो औँला राख्नुहोस्"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "अंगुठा पुन दर्ता गर्नुहोस्…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "नया अंगुठाछाप स्क्यान गर्नुहोस्"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "%s औठाछाप यन्त्र निस्काशन गर्न असफल भयो: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "यन्त्र पढ्न समस्या"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "%s औठाछाप यन्त्र दावी गर्न असफल भयो: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "औठाछाप यन्त्र प्राप्त गर्न असफल भयो: %s"
+
+#~ msgid "This Week"
+#~ msgstr "यो हप्ता"
+
+#~ msgid "Last Week"
+#~ msgstr "गएको हप्ता"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "सेसन बन्द गरियो"
+
+#~ msgid "Session Started"
+#~ msgstr "सेसन सुरु गरियो"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — खाता क्रियाकलाप"
+
+#~ msgid "Please choose another password."
+#~ msgstr "कृपया अर्को पासवर्ड रोज्नुहोस् ।"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "कृपया तपाईँको हालको पासवर्ड फेरि प्रविष्टि गर्नुहोस् ।"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "पासवर्ड परिवर्तन गर्न सकिएन"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "यस प्रकारको डोमेन स्वचालित रूपमा जडान गर्न सकिँदैन"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "डोमेन वा रियालम नाम भेटिएन"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "तपाईँ %s डोमेन %s पहुँच गर्न लगइन हुनुपर्दछ"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "अवैध पासवर्ड, पुन: प्रयास गर्नुहोस्"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "%s डोमेनमा जडान गर्न सकेन: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "प्रयोगकर्ता मेट्न असफल"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "टाढाबाट प्रबन्ध गरिएको प्रयोगकर्ता लाई खारेज गर्न असफल भयो"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "तपाईँले आफ्नो खाता आफैं मेट्न सक्नुहुन्न ।"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s अझै लगईन छ"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "तिनीहरू लगइन भएको बेलामा प्रयोगकर्ता मेट्दा प्रणालीलाई असङ्गत अवस्थामा छोड्न सक्छ ।"
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "के तपाई %s को फाईलहरु राख्न चाहानुहुन्छ?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "प्रयोगकर्ता खाता मेट्दा गृह डाइरेक्टरी, मेल स्पूल र अस्थायी फाइलहरू वरिपरि राख्न सम्भव "
+#~ "छ ।"
+
+#~ msgid "_Delete Files"
+#~ msgstr "फाइलहरू मेट्नुहोस्"
+
+#~ msgid "_Keep Files"
+#~ msgstr "फाइलहरू राख्नुहोस्"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "तपाईँ टाढाबाट प्रबन्ध गरिएको %s खाता हटाउन निश्चित हुनुहुन्छ?"
+
+#~ msgid "_Delete"
+#~ msgstr "मेट्नुहोस्"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "खाता अक्षम पारिएको"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "अर्को लगइनमा सेट गर्ने"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "कुनै पनि होइन"
+
+#~ msgid "Logged in"
+#~ msgstr "लगईन गरियो"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "खाता सेवा जडान असफल"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "कृपया खाता सेवा स्थापना र सक्षम पारिएको निश्चित गर्नुहोस् ।"
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "यो सेटिङ परिवर्तन गर्न यो प्यानलको ताल्चा खोलिनुपर्छ"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "चयन गरेको प्रयोगकर्ता खाता मेट्नुहोस्"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "चयन गरिएको प्रयोगकर्ता खाता मेट्न,\n"
+#~ "पहिला * प्रतिमा क्लिक गर्नुहोस्"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "प्रयोगकर्ता थप्न र सेटिङ परिवर्तन गर्न ताल्चा खोल्नुहोस्"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "नया पासवर्ड पुरानो भन्दा फरक हुनु पर्छ ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "केहि संख्या र अक्षर परिवर्तन गरि प्रयास गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "अलि धेरै पटक पासवर्ड परिवर्तन गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "तपाईँको प्रयोगकर्ता नाम बिनाको पासवर्ड अझ बलियो हुनेछ ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "पासवर्डमा तपाईँको नाम प्रयोग नगर्न प्रयास गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "पासवर्डमा समावेश गरिएका केही शब्दबाट बच्ने प्रयास गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "सामान्य शब्द नबोली बस्नुहोस्।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "हालको शब्द पुन: क्रमबद्ध गर्नबाट रोक्न प्रयास गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "वढि अंक प्रयोग गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "वढि अक्षर  प्रयोग गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "वढि अक्षर  प्रयोग गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "विराम चिन्ह जस्तै, धेरै विशेष वर्ण प्रयोग गर्ने प्रयास गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "अक्षर, सङ्ख्या र विराम चिन्हको मिश्रण प्रयोग गर्ने प्रयास गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "उही क्यारेक्टर दोहोर्याउनबाट रोक्न प्रयास गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "उही प्रकारको क्यारेक्टर दोहोर्याउनबाट रोक्न प्रयास गर्नुहोस्: तपाईँले अक्षर, सङ्ख्या र "
+#~ "विराम चिन्ह मिश्रण गर्नु आवश्यक छ ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "१२३४ वा abcd जस्ता क्रमबाट बच्ने प्रयास गर्नुहोस् ।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "पासवर्ड लामो हुनु आवश्यक छ । धेरै अक्षर, सङ्ख्याहरू र विराम चिन्ह हरू थप्न प्रयास "
+#~ "गर्नुहोस्।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "ठूलो वर्ण र सानो केस मिसाउनुहोस् र एक वा दुई नम्बर प्रयोग गर्न प्रयास गर्नुहोस्।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "धेरै अक्षर, सङ्ख्या र विराम चिन्ह थप्दा पासवर्ड बलियो हुन्छ ।."
+
+#~ msgid "Authentication failed"
+#~ msgstr "प्रमाणीकरण असफल भयो"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "नयाँ पासवर्ड अति छोटो छ"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "नयाँ पासवर्ड धेरै सहज छ"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "पुरानो र नयाँ पासवर्डहरू धेरै उस्तै छन् "
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "पासवर्ड पहिला नै प्रयोग गरिएको छ । अन्य पासवर्ड रोज्नुहोस् ।"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "नयाँ पासवर्डले सङ्ख्यात्मक वा विशेष क्यारेक्टर(हरू) समाविष्ट गर्नुपर्दछ"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "पुरानो र नयाँ पासवर्डहरू एउटै छन्"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "तपाईँले सुरुमा प्रमाणीकरण गरे पछि तपाईँको पासवर्ड परिवर्तन गरिएको छ!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "नयाँ पासवर्डले सङ्ख्यात्मक वा विशेष क्यारेक्टर(हरू) समाविष्ट गर्नु"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "अज्ञात त्रुटि"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "प्रयोगकर्ता नाममा साधारणतया a-z, अङ्क र निम्न क्यारेक्टरहरूको लोअर केस अक्षरहरू मात्र "
+#~ "हुनुपर्दछ: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "माफ गर्नुहोस्, त्यो प्रयोगकर्ता नाम उपलब्ध छैन । कृपया अर्को प्रयास गर्नुहोस् ।"
+
+#~ msgid "The username is too long."
+#~ msgstr "प्रयोगकर्ता नाम धेरै लामो भयो ।"
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "बटन %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "अनुप्रयोग परिभाषित छ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "कुञ्जी स्ट्रोक पठाउनुस्"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "मोनिटर बदल्नुहोस् "
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "सिहर्स मद्दत देखाउनुहोस्"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "ल्यापटप प्यानलमा माउन्ट गरिएको ट्याबलेट"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "बाह्य प्रदर्शनमा माउन्ट गरिएको ट्याबलेट"
+
+#~ msgid "External tablet device"
+#~ msgstr "बाह्य ट्याबलेट यन्त्र"
+
+#~ msgid "All Displays"
+#~ msgstr "सबै प्रदर्शन"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "चाप, झुकाव, र एकीकृत स्लाइडरसँग एयरब्रश स्टाइलस"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "चाप, झुकाव, र परिक्रमणसँग एयरब्रस स्टाइलस"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "चाप र झुकाव सहित मानक स्टायलस"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "चाप सहित मानक स्टायलस"
+
+#~ msgid "New shortcut…"
+#~ msgstr "नयाँ शर्टकर्ट…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "सञ्चालन रद्द गरियो"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>त्रुटि:</b>सेटिङ हरू परिवर्तन गर्न अस्वीकार गर्यो"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>त्रुटि:</b> मोबाइल यन्त्र त्रुटि"
+
+#~ msgid "Not Registered"
+#~ msgstr "दर्ता गरिएको छैन"
+
+#~ msgid "Registered"
+#~ msgstr "दर्ता"
+
+#~ msgid "Roaming"
+#~ msgstr "रोमिङ"
+
+#~ msgid "Searching"
+#~ msgstr "खोजी गर्दै"
+
+#~ msgid "Denied"
+#~ msgstr "अस्वीकार गरियो"
+
+#~ msgid "2G Only"
+#~ msgstr "२जि मात्र"
+
+#~ msgid "3G Only"
+#~ msgstr "३जी मात्र"
+
+#~ msgid "4G Only"
+#~ msgstr "४जी मात्र"
+
+#~ msgid "5G Only"
+#~ msgstr "५जी मात्र"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "२जी, ३जी, ४जी,५जी (रुचाइएको)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "२जी, ३जी, ४जी (रुचाइएको),५जी"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "२जी, ३जी (रुचाइएको), ४जी,५जी"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "२जी (रुचाइएको), ३जी, ४जी,५जी"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "२जि, ३जि, ४जी,५जी"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "२जी, ३जी, ४जी (रुचाइएको)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "२जी, ३जी (रुचाइएको), ४जी "
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "२जी  (रुचाइएको), ३जी, ४जी "
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "२जि, ३जि, ४जी"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "३जी, ४जी ,५जी(रुचाइएको)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "३जी, ४जी (रुचाइएको),५जी"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "३जी (रुचाइएको), ४जी,५जी"
+
+#~| msgid "3G, 4G"
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "३जी, ४जी, ५जी"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "२जी, ४जी, ५जी (रुचाइएको)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "२जी, ४जी (रुचाइएको), ५जी"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "२जी (रुचाइएको), ४जी,५जी"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "२जि, ४जी,५जी"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "२जी, ३जी, ५जी (रुचाइएको)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "२जी, ३जी (रुचाइएको), ५जी"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "२जी (रुचाइएको), ३जी, ५जी"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "२जी, ३जी, ५जी"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "३जी, ४जी (रुचाइएको)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "३जी (रुचाइएको), ४जी"
+
+#~ msgid "3G, 4G"
+#~ msgstr "३जि, ४जी"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "२जी, ४जी (रुचाइएको)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "२जी (रुचाइएको), ४जी "
+
+#~ msgid "2G, 4G"
+#~ msgstr "२जी, ४जी"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "२जी, ३जी (रुचाइएको)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "२जी (रुचाइएको), ३जी (रुचाइएको)"
+
+#~ msgid "2G, 3G"
+#~ msgstr "२जि, ३जि"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "२जी, ५जी (रुचाइएको)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "२जी (रुचाइएको), ५जी"
+
+#~ msgid "2G, 5G"
+#~ msgstr "२जी, ५जी"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "३जी, ५जी(प्राथमिकता)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "३जी (प्राथमिकता), ५जी"
+
+#~ msgid "3G, 5G"
+#~ msgstr "३जी, ५जी"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "४जी ,५जी(रुचाइएको)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "४जी (रुचाइएको), ५जी"
+
+#~ msgid "4G, 5G"
+#~ msgstr "४जी, ५जी"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "अज्ञात"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "सिम कार्डको ताल्चा खोल्नुहोस्"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "%d सिमका लागि कृपया पिन कोड उपलब्ध गराउनुहोस्"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "तपाईँको सिम कार्डअनलक गर्न पिन प्रविष्ट गर्नुहोस्"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "%d सिमका लागि कृपया PUK कोड उपलब्ध गराउनुहोस्"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "तपाईँको सिम कार्ड अनलक गर्न PUK प्रविष्ट गर्नुहोस्"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "गलत पासवर्ड प्रविष्ट भयो ।"
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK कोड ८ अङ्क नम्बर हुनुपर्दछ"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "नयाँ पिन प्रविष्ट गर्नुहोस्"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "पिन कोड ४-८ अङ्क नम्बर को हुनुपर्छ"
+
+#~ msgid "Unlocking…"
+#~ msgstr "ताल्चा खोलिदै…"
+
+#~ msgid "Phone failure"
+#~ msgstr "फोन असफलता"
+
+#~ msgid "No connection to phone"
+#~ msgstr "फोनमा जडान छैन"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "सञ्चालन अनुमति छैन"
+
+#~ msgid "Operation not supported"
+#~ msgstr "सञ्चालन समर्थित छैन"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "सिमकार्ड राखिएको छैन"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "सिमको पिन आवश्यक"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "सिमको PUK आवश्यक"
+
+#~ msgid "SIM failure"
+#~ msgstr "सिम असफलता"
+
+#~ msgid "SIM busy"
+#~ msgstr "सिमकार्ड व्यस्त"
+
+#~ msgid "Incorrect password"
+#~ msgstr "पासवर्ड गलत थियो"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "सिमको पिन२ आवश्यक"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "सिमको PUK२ आवश्यक"
+
+#~ msgid "Not found"
+#~ msgstr "फेला परेन"
+
+#~ msgid "No network service"
+#~ msgstr "सञ्जाल सेवा छैन"
+
+#~ msgid "Network timeout"
+#~ msgstr "सञ्जाल समय समाप्ति"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS सेवालाई अनुमति छैन"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "यो स्थान क्षेत्रमा रोमिङ गर्न अनुमति छैन"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "निर्दिष्ट नगरिएको GPRS त्रुटि"
+
+#~ msgid "No Error"
+#~ msgstr "त्रुटि छैन"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "कार्य रद्द गरियो"
+
+#~ msgid "Access denied"
+#~ msgstr "पहुँच अस्वीकृत भयो"
+
+#~ msgid "Unknown Error"
+#~ msgstr "अज्ञात त्रुटि"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "सिमकार्ड %d"
+
+#~ msgid "Display version number"
+#~ msgstr "संस्करण प्रदर्शन गर्नुहोस्"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "भर्बोज निर्गत सक्षम पार्नुहोस्"
+
+#~ msgid "Search for the string"
+#~ msgstr "स्ट्रिङको खोजी गर्नुहोस्"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "सम्भावित प्यानल नामहरू सूचीबद्ध गर्नुहोस् र निस्कनुहोस्"
+
+#~ msgid "Panel to display"
+#~ msgstr "प्रदर्शन गर्न प्यानल"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "उपलब्ध प्यानलहरू:"
+
+#~ msgid "System Sounds"
+#~ msgstr "प्रणाली ध्वनिहरू"
+
+#~ msgid "Light"
+#~ msgstr "हल्का"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "पर्दा;ताल्चा;निदान;क्र्यास;निजी;हालैको;अस्थायी;tmp;index;नाम;सञ्जाल;पहिचान;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "प्रदर्शन व्यवस्था"
+
+#~ msgid "Set"
+#~ msgstr "सेट गर्नुहोस्"
+
+#~ msgid "Lock your screen"
+#~ msgstr "पर्दा ताल्चा लगाउनुहोस्"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER वा PEM प्रमाणपत्र (*. der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Bark"
+#~ msgstr "Bark"
+
+#~ msgid "Drip"
+#~ msgstr "द्रिप"
+
+#~ msgid "Glass"
+#~ msgstr "ग्लास"
+
+#~ msgid "Sonar"
+#~ msgstr "सोनार"
 
 #~ msgid "Web Links"
 #~ msgstr "वेब लिङ्क"
@@ -8341,17 +8119,20 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Permissions & Access"
 #~ msgstr "अनुमतिहरू र पहुँचहरू"
 
-#~ msgid "Data and services that this app has asked for access to and permissions that it requires."
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
 #~ msgstr "यो अनुप्रयोगले आवश्यक पर्ने पहुँच र अनुमतिमागेको डाटा र सेवाहरू ।"
 
 #~ msgid "Cannot be changed"
 #~ msgstr "परिवर्तित हुन सक्दैनन्"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href=\"privacy\">Privacy</a> "
-#~ "Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "अनुप्रयोगहरूका लागि व्यक्तिगत अनुमतिहरू <a href=\"privacy\">गोपनीयता</a> सेटिङमा पुनरावलोकन गर्न सकिन्छ।"
+#~ "अनुप्रयोगहरूका लागि व्यक्तिगत अनुमतिहरू <a href=\"privacy\">गोपनीयता</a> सेटिङमा "
+#~ "पुनरावलोकन गर्न सकिन्छ।"
 
 #~ msgid "Integration"
 #~ msgstr "इन्टिगरेसन"
@@ -8417,24 +8198,20 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "प्रर्दशन मोड"
 
 #~ msgid ""
-#~ "Drag displays to match your physical display setup. Select a display to change its settings."
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
 #~ msgstr ""
-#~ "तपाईँको भौतिक प्रदर्शन सेटअप मिलाउन प्रदर्शन तान्नुहोस् । यसको सेटिङ परिवर्तन गर्न प्रदर्शन चयन गर्नुहोस् ।"
+#~ "तपाईँको भौतिक प्रदर्शन सेटअप मिलाउन प्रदर्शन तान्नुहोस् । यसको सेटिङ परिवर्तन गर्न "
+#~ "प्रदर्शन चयन गर्नुहोस् ।"
 
 #~ msgid "Active Display"
 #~ msgstr "सक्रिय पर्दा"
-
-#~ msgid "Display Configuration"
-#~ msgstr "कन्फिगरेसन देखाउनुहोस्"
 
 #~ msgid "More Warm"
 #~ msgstr "अझ न्यानो"
 
 #~ msgid "Less Warm"
 #~ msgstr "कम न्यानो"
-
-#~ msgid "Screenshots"
-#~ msgstr "स्क्रिनसट"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "स्क्रिनसट $PICTURESमा बचत गर्नुहोस्"
@@ -8464,18 +8241,18 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "तल सार्नुहोस्"
 
 #~ msgid ""
-#~ "Location services allow applications to know your location. Using Wi-Fi and mobile broadband "
-#~ "increases accuracy."
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
 #~ msgstr ""
-#~ "स्थान सेवाहरूले अनुप्रयोगहरूलाई तपाईँको स्थान जान्न अनुमति दिन्छ । वाई-फाई र मोबाइल ब्रडब्यान्ड प्रयोग गर्दा "
-#~ "यथार्थता बढ्छ।"
+#~ "स्थान सेवाहरूले अनुप्रयोगहरूलाई तपाईँको स्थान जान्न अनुमति दिन्छ । वाई-फाई र मोबाइल "
+#~ "ब्रडब्यान्ड प्रयोग गर्दा यथार्थता बढ्छ।"
 
 #~ msgid ""
-#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/privacy'>Privacy "
-#~ "Policy</a>"
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
 #~ msgstr ""
-#~ "मोजिला स्थान सेवा प्रयोग गर्दछ: <a href='https://location.services.mozilla.com/privacy'>गोपनीयता "
-#~ "नीति</a>"
+#~ "मोजिला स्थान सेवा प्रयोग गर्दछ: <a href='https://location.services.mozilla."
+#~ "com/privacy'>गोपनीयता नीति</a>"
 
 #~ msgid "Allow the applications below to determine your location."
 #~ msgstr "तपाईँको स्थान निर्धारण गर्न तलका अनुप्रयोगहरूलाई अनुमति दिनुहोस् ।."
@@ -8507,8 +8284,10 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Wi-Fi can be turned off to save power."
 #~ msgstr "पावर बचत गर्न वाइफाइ बन्द गर्नुहोस्।."
 
-#~ msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
-#~ msgstr "पावर बचत गर्न मोबाइल ब्रोडब्यान्ड (एलटीई, 4G, 3 जी,  आदि) बन्द गर्न सक्नुहुन्छ"
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "पावर बचत गर्न मोबाइल ब्रोडब्यान्ड (एलटीई, 4G, 3 जी,  आदि) बन्द गर्न सक्नुहुन्छ"
 
 #~ msgid "_Bluetooth"
 #~ msgstr "ब्लुटुठ"
@@ -8534,8 +8313,12 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Authenticate"
 #~ msgstr "प्रमाणीकरण"
 
-#~ msgid "Choose the format for numbers, dates and currencies. Changes take effect on next login."
-#~ msgstr "सङ्ख्या, मिति र मुद्राका लागि ढाँचा रोज्नुहोस् । परिवर्तनले पछिल्लो लगइनमा प्रभाव पार्छ ।."
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "सङ्ख्या, मिति र मुद्राका लागि ढाँचा रोज्नुहोस् । परिवर्तनले पछिल्लो लगइनमा प्रभाव "
+#~ "पार्छ ।."
 
 #~ msgid "Language"
 #~ msgstr "भाषा"
@@ -8553,27 +8336,24 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "प्रणालीमा लगइन गर्दा सबै प्रयोगकर्ताले लगइन सेटिङ प्रयोग गर्छन्"
 
 #~ msgid ""
-#~ "Control which search results are shown in the Activities Overview. The order of search results "
-#~ "can also be changed by moving rows in the list."
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
 #~ msgstr ""
-#~ "क्रियाकलाप अवलोकनमा कुन खोजी परिणाम देखाइन्छ नियन्त्रण गर्नुहोस् । सूचीमा पङ्क्तिहरू सार्दा पनि खोजी "
-#~ "परिणामको क्रम परिवर्तन गर्न सकिन्छ ।"
+#~ "क्रियाकलाप अवलोकनमा कुन खोजी परिणाम देखाइन्छ नियन्त्रण गर्नुहोस् । सूचीमा पङ्क्तिहरू "
+#~ "सार्दा पनि खोजी परिणामको क्रम परिवर्तन गर्न सकिन्छ ।"
 
-#~ msgid "Screen sharing allows remote users to view or control your screen by connecting to %s"
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
 #~ msgstr ""
-#~ "पर्दा साझेदारीले टाढाको प्रयोगकर्ताहरूलाई तपाईँको पर्दा %s मा जडान गरेर हेर्न वा नियन्त्रण गर्न अनुमति दिन्छ"
-
-#~ msgid "Copy"
-#~ msgstr "प्रतिलिपि बनाउनुहोस्"
+#~ "पर्दा साझेदारीले टाढाको प्रयोगकर्ताहरूलाई तपाईँको पर्दा %s मा जडान गरेर हेर्न वा "
+#~ "नियन्त्रण गर्न अनुमति दिन्छ"
 
 #~ msgid "_Screen Sharing"
 #~ msgstr "प्रदर्शनपर्दा साझेदारी"
 
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr "सञ्जाल पहुँच नभएकोले केही सेवाहरू अक्षम पारिएको छ ।"
-
-#~ msgid "Screen Sharing"
-#~ msgstr "प्रदर्शनपर्दा साझेदारी"
 
 #~ msgid "_Password:"
 #~ msgstr "_पासवर्ड:"
@@ -8595,9 +8375,6 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #~ msgid "_Screen Reader"
 #~ msgstr "दृष्टि वाचक"
-
-#~ msgid "_Full Name"
-#~ msgstr "पूरा नाम"
 
 #~ msgid "Standard"
 #~ msgstr "माणक"
@@ -8663,9 +8440,6 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "ट्याबलेट()"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "ट्चप्याड()"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "ट्याबलेट प्राथमिकता"
 
@@ -8687,7 +8461,8 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Adjust display resolution"
 #~ msgstr "रिजोल्युसन मिलाउने"
 
-#~ msgid "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
 #~ msgstr "कृपया यसलाई कन्फिगर गर्न ट्याबलेटको निकटतामा तपाईँको स्टाइलस सार्नुहोस्"
 
 #~ msgid "Top Button"
@@ -8788,11 +8563,13 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "10 Gb/s"
 #~ msgstr "१० Gb/s"
 
-#~ msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
 #~ msgstr "वायरलेस हटस्पटमा स्विच गर्नु भए पछि  तपाईं <b>%s</b> छुट्नु हुनेछ।"
 
 #~ msgid ""
-#~ "It is not possible to access the Internet through your wireless while the hotspot is active."
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
 #~ msgstr "यो हटस्पट सक्रिय हुँदा, वायरलेस मार्फत इन्टरनेटमा पहुँच सम्भव छैन।"
 
 #~ msgid "Automatic _Connect"
@@ -9064,9 +8841,6 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Could not get screen information"
 #~ msgstr "प्रदर्शनपर्दाको जानकारी प्राप्त गर्न सकेन"
 
-#~ msgid "Section"
-#~ msgstr "खण्ड"
-
 #~ msgid "Overview"
 #~ msgstr "अवलोकन"
 
@@ -9269,9 +9043,6 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Mirrored"
 #~ msgstr "ऐना"
 
-#~ msgid "Secondary"
-#~ msgstr "द्धितीयक"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "क्मबाईन्ड प्रदर्शनपर्दा मिलानुहोस्"
 
@@ -9338,9 +9109,6 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Automatic"
 #~ msgstr "स्वचालित"
 
-#~ msgid "_Method"
-#~ msgstr "विधि"
-
 #~ msgid "Group Name"
 #~ msgstr "कार्य समूहको लागि एउटा नाम"
 
@@ -9384,25 +9152,30 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #, fuzzy
 #~| msgid ""
-#~| "To edit a shortcut key, click on the corresponding row and type a new accelerator, or press "
-#~| "backspace to clear."
-#~ msgid "To edit a shortcut, click the row and hold down the new keys or press Backspace to clear."
+#~| "To edit a shortcut key, click on the corresponding row and type a new "
+#~| "accelerator, or press backspace to clear."
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
 #~ msgstr ""
-#~ "सर्टकट कुञ्जी सम्पादन गर्न, संगती पङ्क्तिमा क्लिक गर्नुहोस् र एउटा नयाँ गतिवर्धक टाइप गर्नुहोस्, वा खाली गर्न "
-#~ "ब्याकस्पेस थिच्नुहोस् ।"
+#~ "सर्टकट कुञ्जी सम्पादन गर्न, संगती पङ्क्तिमा क्लिक गर्नुहोस् र एउटा नयाँ गतिवर्धक टाइप "
+#~ "गर्नुहोस्, वा खाली गर्न ब्याकस्पेस थिच्नुहोस् ।"
 
 #~ msgid "<Unknown Action>"
 #~ msgstr "<Unknown Action>"
 
 #, fuzzy
 #~| msgid ""
-#~| "The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+#~| "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~| "type using this key.\n"
 #~| "Please try with a key such as Control, Alt or Shift at the same time.\n"
 #~ msgid ""
-#~ "The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
 #~ "Please try with a key such as Control, Alt or Shift at the same time."
 #~ msgstr ""
-#~ "सर्टकट \"%s\" लाई प्रयोग गर्न सकिँदैन किनकी यस कुञ्जीलाई प्रयोग गरेर टाइप गर्न असम्भव हुन्छ ।\n"
+#~ "सर्टकट \"%s\" लाई प्रयोग गर्न सकिँदैन किनकी यस कुञ्जीलाई प्रयोग गरेर टाइप गर्न "
+#~ "असम्भव हुन्छ ।\n"
 #~ "कृपया Control, Alt वा Shift जस्ता कुञ्जीबाट एकै समयमा प्रयास गर्नुहोस् ।\n"
 
 #, fuzzy
@@ -9462,9 +9235,6 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgctxt "touchpad pointer, speed"
 #~ msgid "Fast"
 #~ msgstr "छिटो"
-
-#~ msgid "Disable while _typing"
-#~ msgstr " टाइप गर्दा अक्षम पार्नुहोस्"
 
 #, fuzzy
 #~ msgid "Make available to other _users"
@@ -9615,10 +9385,6 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Installing"
 #~ msgstr "स्थापना गर्नुहोस्..."
 
-#, fuzzy
-#~ msgid "No printers available"
-#~ msgstr "मुद्रण"
-
 #~ msgid "%u active"
 #~ msgid_plural "%u active"
 #~ msgstr[0] "%u सष्क्रिय बनाउनुहोस्"
@@ -9637,9 +9403,6 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #~ msgid "No printers detected."
 #~ msgstr "मुद्रण पत्ता लागेन"
-
-#~ msgid "Loading options…"
-#~ msgstr "विकल्प लोड गर्दै"
 
 #, fuzzy
 #~ msgctxt "print job"
@@ -9664,10 +9427,6 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "label"
 #~ msgstr "लेबुल"
 
-#, fuzzy
-#~ msgid "Setting new driver…"
-#~ msgstr "ड्राइभर:"
-
 #~ msgid "Print _Test Page"
 #~ msgstr "नमुना पृष्ठ मुद्रण गर्नुहोस्"
 
@@ -9676,9 +9435,6 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #~ msgid "Sorry"
 #~ msgstr "क्षमा"
-
-#~ msgid "Options"
-#~ msgstr "विकल्पहरू"
 
 #~ msgctxt "Search Location"
 #~ msgid "Other"
@@ -9814,9 +9570,6 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Scroll Up"
 #~ msgstr "माथि स्क्रोल गर्नुहोस्"
 
-#~ msgid "Scroll Down"
-#~ msgstr "तल स्क्रोल गर्नुहोस्"
-
 #~ msgid "Show help options"
 #~ msgstr "मद्दत विकल्पहरू देखाउनुहोस्"
 
@@ -9894,7 +9647,8 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "<b>कार्य</b>"
 
 #~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
-#~ msgstr "<span size=\"larger\" weight=\"bold\">तपाईँको पासवर्ड परिवर्तन गर्नुहोस्</span>"
+#~ msgstr ""
+#~ "<span size=\"larger\" weight=\"bold\">तपाईँको पासवर्ड परिवर्तन गर्नुहोस्</span>"
 
 #~ msgid "A_IM/iChat:"
 #~ msgstr "A_IM/iChat:"
@@ -9941,22 +9695,24 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "P._O. box:"
 #~ msgstr "पो.ओ. बाकस:"
 
-#~ msgid "Please type your password again in the <b>Retype new password</b> field."
-#~ msgstr "कृपया <b>नयाँ पासवर्ड रिटाइप गर्नुहोस्</b> फाँटमा फेरि तपाईँको पासवर्ड टाइप गर्नुहोस् ।"
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "कृपया <b>नयाँ पासवर्ड रिटाइप गर्नुहोस्</b> फाँटमा फेरि तपाईँको पासवर्ड टाइप गर्नुहोस् ।"
 
 #~ msgid "State/Pro_vince:"
 #~ msgstr "राज्य/क्षेत्र:"
 
 #~ msgid ""
-#~ "To change your password, enter your current password in the field below and click "
-#~ "<b>Authenticate</b>.\n"
-#~ "After you have authenticated, enter your new password, retype it for verification and click "
-#~ "<b>Change password</b>."
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
 #~ msgstr ""
-#~ "तपाईँको पासवर्ड परिवर्तन गर्न, तलका फाँटमा हालको पसावर्ड प्रविष्टि गर्नुहोस् र <b>प्रमाणीकरण गर्नुहोस्</b> "
-#~ "क्लिक गर्नुहोस् ।\n"
-#~ "तपाईँले प्रमाणीकरण गरिसके पछि, तपाईँको नयाँ पासवर्ड प्रविष्टि गर्नुहोस्, प्रमाणीकरणका लागि यसलाई पुन: टाइप "
-#~ "गर्नुहोस् र <b>पासवर्ड परिवर्तन गर्नुहोस्</b> क्लिक गर्नुहोस् ।"
+#~ "तपाईँको पासवर्ड परिवर्तन गर्न, तलका फाँटमा हालको पसावर्ड प्रविष्टि गर्नुहोस् र "
+#~ "<b>प्रमाणीकरण गर्नुहोस्</b> क्लिक गर्नुहोस् ।\n"
+#~ "तपाईँले प्रमाणीकरण गरिसके पछि, तपाईँको नयाँ पासवर्ड प्रविष्टि गर्नुहोस्, प्रमाणीकरणका "
+#~ "लागि यसलाई पुन: टाइप गर्नुहोस् र <b>पासवर्ड परिवर्तन गर्नुहोस्</b> क्लिक गर्नुहोस् ।"
 
 #~ msgid "Web _log:"
 #~ msgstr "वेब लग:"
@@ -10019,7 +9775,8 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "पासवर्ड जाँच गर्दैछ..."
 
 #~ msgid "Click <b>Change password</b> to change your password."
-#~ msgstr "तपाईँको पासवर्ड परिवर्तन गर्न <b>पासवर्ड परिवर्तन गर्नुहोस्</b> क्लिक गर्नुहोस् ।"
+#~ msgstr ""
+#~ "तपाईँको पासवर्ड परिवर्तन गर्न <b>पासवर्ड परिवर्तन गर्नुहोस्</b> क्लिक गर्नुहोस् ।"
 
 #~ msgid "<b>Assistive Technologies</b>"
 #~ msgstr "<b>प्रलम्बित प्रविधिहरू</b>"
@@ -10033,8 +9790,12 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Assistive Technology Preferences"
 #~ msgstr "प्रलम्बित प्रविधि प्राथमिक्ताहरू"
 
-#~ msgid "Changes to enable assistive technologies will not take effect until your next log in."
-#~ msgstr "प्रलम्बित प्रविधिहरू सक्षम पार्न गरिएका परिवर्तनहरूले तपाईँको पछिल्लो लग इन नगरे सम्म प्रभाव लिने छैन ।"
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "प्रलम्बित प्रविधिहरू सक्षम पार्न गरिएका परिवर्तनहरूले तपाईँको पछिल्लो लग इन नगरे सम्म "
+#~ "प्रभाव लिने छैन ।"
 
 #~ msgid "Close and _Log Out"
 #~ msgstr "बन्द गर्नुहोस् र लग आउट गर्नुहोस्"
@@ -10076,9 +9837,11 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "तपाईँको कुञ्जीपाटी पहुँचता प्राथमिक्ताहरू सेट गर्नुहोस्"
 
 #~ msgid ""
-#~ "This system does not seem to have the XKB extension.  The keyboard accessibility features will "
-#~ "not operate without it."
-#~ msgstr "यो प्रणललीसँग XKB विस्तार भएको देखिँदैन ।  कुञ्जीपाटी पहुँचता विशेषताहरू यो बिना सञ्चालन हुने छैनन् ।"
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "यो प्रणललीसँग XKB विस्तार भएको देखिँदैन ।  कुञ्जीपाटी पहुँचता विशेषताहरू यो बिना "
+#~ "सञ्चालन हुने छैनन् ।"
 
 #~ msgid "<b>Enable Bo_unce Keys</b>"
 #~ msgstr "<b>फर्कने कुञ्जीहरू सक्षम पार्नुहोस्</b>"
@@ -10120,10 +9883,11 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "फिल्टरहरू"
 
 #~ msgid ""
-#~ "Ignore all subsequent presses of the SAME key if they happen within a user selectable period "
-#~ "of time."
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
 #~ msgstr ""
-#~ "यदि प्रयोगकर्ता चयनयोग्य समयावधिभित्र एउटै कुञ्जी थिचिएमा उक्त कुञ्जीको पछिल्ला डबै थिचाइहरू उपेक्षा गर्नुहोस् ।"
+#~ "यदि प्रयोगकर्ता चयनयोग्य समयावधिभित्र एउटै कुञ्जी थिचिएमा उक्त कुञ्जीको पछिल्ला डबै "
+#~ "थिचाइहरू उपेक्षा गर्नुहोस् ।"
 
 #~ msgid "Keyboard Accessibility Preferences (AccessX)"
 #~ msgstr "कुञ्जीपाटी पहुँचता प्राथमिक्ताहरू (AccessX)"
@@ -10132,11 +9896,18 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "माउस प्राथमिकताहरू..."
 
 #~ msgid ""
-#~ "Only accept keys after they have been pressed and held for a user adjustable amount of time."
-#~ msgstr "कुञ्जीहरू थिचिए पछि र प्रयोगकर्ता समायोजनयोग्य समयको मात्रका लागि लिए पछि मात्र स्वीकार गर्नुहोस् ।"
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "कुञ्जीहरू थिचिए पछि र प्रयोगकर्ता समायोजनयोग्य समयको मात्रका लागि लिए पछि मात्र "
+#~ "स्वीकार गर्नुहोस् ।"
 
-#~ msgid "Perform multiple simultaneous key press operations by pressing modifier keys in sequence."
-#~ msgstr "अनुक्रममा परिमार्जक कुञ्जीहरू थिचेर वहुविध समकालिन कुञ्जी थिचाइ सञ्चालनहरू कार्यसम्पादन गर्नुहोस् ।"
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "अनुक्रममा परिमार्जक कुञ्जीहरू थिचेर वहुविध समकालिन कुञ्जी थिचाइ सञ्चालनहरू कार्यसम्पादन "
+#~ "गर्नुहोस् ।"
 
 #~ msgid "Time to acce_lerate to maximum speed:"
 #~ msgstr "अधिक्तम गतिमा गतिवर्धन गर्नका लागि समय:"
@@ -10184,30 +9955,34 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "फन्ट धेरै ठूलो हुन सक्दछ"
 
 #~ msgid ""
-#~ "The font selected is %d point large, and may make it difficult to effectively use the "
-#~ "computer.  It is recommended that you select a size smaller than %d."
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
 #~ msgid_plural ""
-#~ "The font selected is %d points large, and may make it difficult to effectively use the "
-#~ "computer. It is recommended that you select a size smaller than %d."
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
 #~ msgstr[0] ""
-#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारि रूपले प्रयोग गर्न यसलाई कठिन बनाउन सक्दछ ।  "
-#~ "तपाईँलाई %d भन्दा सानो साइज चयन गर्न सिफारिस गरन्छ ।"
+#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारि रूपले प्रयोग गर्न यसलाई कठिन "
+#~ "बनाउन सक्दछ ।  तपाईँलाई %d भन्दा सानो साइज चयन गर्न सिफारिस गरन्छ ।"
 #~ msgstr[1] ""
-#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारि रूपले प्रयोग गर्न यसलाई कठिन बनाउन सक्दछ ।  "
-#~ "तपाईँलाई %d भन्दा सानो साइज चयन गर्न सिफारिस गरन्छ ।"
+#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारि रूपले प्रयोग गर्न यसलाई कठिन "
+#~ "बनाउन सक्दछ ।  तपाईँलाई %d भन्दा सानो साइज चयन गर्न सिफारिस गरन्छ ।"
 
 #~ msgid ""
-#~ "The font selected is %d point large, and may make it difficult to effectively use the "
-#~ "computer.  It is recommended that you select a smaller sized font."
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
 #~ msgid_plural ""
-#~ "The font selected is %d points large, and may make it difficult to effectively use the "
-#~ "computer. It is recommended that you select a smaller sized font."
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
 #~ msgstr[0] ""
-#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारी रूपले प्रयोग गर्न यसलाई कठिन बनाउन सक्दछ ।  "
-#~ "तपाईँलाई सानो साइजको फन्ट चयन गर्न सिफारिस गरन्छ ।"
+#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारी रूपले प्रयोग गर्न यसलाई कठिन "
+#~ "बनाउन सक्दछ ।  तपाईँलाई सानो साइजको फन्ट चयन गर्न सिफारिस गरन्छ ।"
 #~ msgstr[1] ""
-#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारी रूपले प्रयोग गर्न यसलाई कठिन बनाउन सक्दछ ।  "
-#~ "तपाईँलाई सानो साइजको फन्ट चयन गर्न सिफारिस गरन्छ ।"
+#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारी रूपले प्रयोग गर्न यसलाई कठिन "
+#~ "बनाउन सक्दछ ।  तपाईँलाई सानो साइजको फन्ट चयन गर्न सिफारिस गरन्छ ।"
 
 #~ msgid "Use previous font"
 #~ msgstr "अघिल्लो फन्ट प्रयोग गर्नुहोस्"
@@ -10218,7 +9993,8 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Specify the filename of a theme to install"
 #~ msgstr "स्थापना गर्नलाई विषयवस्तुको फाइलनाम निर्दिष्ट गर्नुहोस्"
 
-#~ msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
 #~ msgstr "theme|background|fonts|interface) देखाउन पृष्ठको नाम निर्दिष्ट गर्नुहोस्"
 
 #~ msgid "[WALLPAPER...]"
@@ -10296,9 +10072,6 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #~ msgid "Des_ktop font:"
 #~ msgstr "डेस्कटप फन्ट:"
-
-#~ msgid "Edit"
-#~ msgstr "सम्पादन गर्नुहोस्"
 
 #~ msgid "Font Rendering Details"
 #~ msgstr "फन्ट रेन्डरिङ विवरणहरू"
@@ -10404,9 +10177,6 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "_RGB"
 #~ msgstr "RGB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "पूर्वनिर्धारितहरूमा पुन: सेट गर्नुहोस्"
-
 #~ msgid "_Selected items:"
 #~ msgstr "वस्तुहरू चयन गर्नुहोस्:"
 
@@ -10498,9 +10268,11 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ "%s"
 
 #~ msgid ""
-#~ "%s is the path where the theme files will be installed. This can not be selected as the source "
-#~ "location"
-#~ msgstr "%s मार्ग हो जहाँ विषयवस्तु फाइल स्थापना गरिनेछ । यसलाई स्रोत स्थानको रूपमा चयन गर्न सकिँदैन"
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s मार्ग हो जहाँ विषयवस्तु फाइल स्थापना गरिनेछ । यसलाई स्रोत स्थानको रूपमा चयन गर्न "
+#~ "सकिँदैन"
 
 #~ msgid "The file format is invalid."
 #~ msgstr "फाइल ढाँचा अवैध छ ।"
@@ -10522,14 +10294,15 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #~ msgid ""
 #~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
-#~ "Without the GNOME settings manager running, some preferences may not take effect. This could "
-#~ "indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) settings manager may already be "
-#~ "active and conflicting with the GNOME settings manager."
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
 #~ msgstr ""
 #~ "सेटिङ प्रबन्धक 'जीनोम-सेटिङ-डेइमोन' सरुआत गर्न अस्क्षम ।\n"
-#~ "जीनोम सेटिङ प्रबन्धक चालु बिना, केही प्राथमिकताहरूले प्रभाव गर्नेछैन । यसले Bonobo सँग समस्या भएको इङ्गित गर्न "
-#~ "सक्दछ, वा एउटा जीनोमबिहिन(जस्तै केडीई) सेटिङ प्रबन्धक पहिल्यै सक्रिय पारिएको हुन सक्दछ र जीनोम सेटिङ "
-#~ "प्रबन्धकसँग द्वन्द्व भैरहेको हुन सक्दछ ।"
+#~ "जीनोम सेटिङ प्रबन्धक चालु बिना, केही प्राथमिकताहरूले प्रभाव गर्नेछैन । यसले Bonobo सँग "
+#~ "समस्या भएको इङ्गित गर्न सक्दछ, वा एउटा जीनोमबिहिन(जस्तै केडीई) सेटिङ प्रबन्धक पहिल्यै "
+#~ "सक्रिय पारिएको हुन सक्दछ र जीनोम सेटिङ प्रबन्धकसँग द्वन्द्व भैरहेको हुन सक्दछ ।"
 
 #~ msgid "Unable to load stock icon '%s'\n"
 #~ msgstr "'%s' भण्डार प्रतिमा लोड गर्न असफल भयो\n"
@@ -10548,9 +10321,6 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #~ msgid "Copying '%s'"
 #~ msgstr "'%s' प्रतिलिपि गर्दै"
-
-#~ msgid "Parent Window"
-#~ msgstr "प्रमूल सञ्झ्याल"
 
 #~ msgid "Parent window of the dialog"
 #~ msgstr "संवादको प्रमूल सञ्झ्याल"
@@ -10594,19 +10364,26 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Issue this callback when the value associated with key gets changed"
 #~ msgstr "कुञ्जीसँग सम्बन्धित मान परिवर्तन हुँदा यो कलब्याक जारी गर्नुहोस्"
 
-#~ msgid "GConf change set containing data to be forwarded to the gconf client on apply"
-#~ msgstr "लागूमा जीकन्फ क्लाइन्टलाई फरवार्ड गरिनका लागि डेटा समाविष्ट गर्ने जीकन्फ परिवर्तन सेट"
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "लागूमा जीकन्फ क्लाइन्टलाई फरवार्ड गरिनका लागि डेटा समाविष्ट गर्ने जीकन्फ परिवर्तन सेट"
 
 #~ msgid "Conversion to widget callback"
 #~ msgstr "विड्जेट कलब्याकमा रूपान्तरण"
 
-#~ msgid "Callback to be issued when data are to be converted from GConf to the widget"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
 #~ msgstr "जीकन्फबाट विजेटमा डेटा रूपान्तरण हुँदा जारी गरिनका लागि कलब्याक"
 
 #~ msgid "Conversion from widget callback"
 #~ msgstr "विजेट कलब्याकबाट रूपान्तरण"
 
-#~ msgid "Callback to be issued when data are to be converted to GConf from the widget"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
 #~ msgstr "विजेटबाट जीकन्फमा डेटा रूपान्तरण हुँदा जाी गरिनका लागि कलब्याक"
 
 #~ msgid "UI Control"
@@ -10624,17 +10401,20 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Property editor data freeing callback"
 #~ msgstr "गुण सम्पादक डेटा स्वतन्त्र कलब्याक"
 
-#~ msgid "Callback to be issued when property editor object data is to be freed"
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
 #~ msgstr "गुण सम्पादक वस्तु डेटा खाली गरिँदा जारी गरिनुपर्ने कलब्याक"
 
 #~ msgid ""
 #~ "Couldn't find the file '%s'.\n"
 #~ "\n"
-#~ "Please make sure it exists and try again, or choose a different background picture."
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
 #~ msgstr ""
 #~ "'%s' फाइल फेला पार्न सकिएन ।\n"
 #~ "\n"
-#~ "कृपया यो अवस्थित छ भनेर निश्चित गर्नुहोस् र फेरि प्रयास गर्नुहोस्, वा एउटा फरक पृष्ठभूमि तस्वीर रोज्नुहोस् ।"
+#~ "कृपया यो अवस्थित छ भनेर निश्चित गर्नुहोस् र फेरि प्रयास गर्नुहोस्, वा एउटा फरक पृष्ठभूमि "
+#~ "तस्वीर रोज्नुहोस् ।"
 
 #~ msgid ""
 #~ "I don't know how to open the file '%s'.\n"
@@ -10888,15 +10668,17 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "यस कम्प्युटर(%s)को लागि मात्र पूर्वनिर्धारित बनाउनुहोस्"
 
 #~ msgid ""
-#~ "Testing the new settings. If you don't respond in %d second the previous settings will be "
-#~ "restored."
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
 #~ msgid_plural ""
-#~ "Testing the new settings. If you don't respond in %d seconds the previous settings will be "
-#~ "restored."
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
 #~ msgstr[0] ""
-#~ "नयाँ सेटिङहरू परिक्षण गर्दै । यदि तपाईँले %d सेकेण्ड भित्र प्रतिउत्तर नगरेमा अघिल्लो सेटिङहरू पुर्वावस्थामा ल्याइनेछ ।"
+#~ "नयाँ सेटिङहरू परिक्षण गर्दै । यदि तपाईँले %d सेकेण्ड भित्र प्रतिउत्तर नगरेमा अघिल्लो "
+#~ "सेटिङहरू पुर्वावस्थामा ल्याइनेछ ।"
 #~ msgstr[1] ""
-#~ "नयाँ सेटिङहरू परिक्षण गर्दै । यदि तपाईँले %d सेकेण्ड भित्र प्रतिउत्तर नगरेमा अघिल्लो सेटिङहरू पुर्वावस्थामा ल्याइनेछ ।"
+#~ "नयाँ सेटिङहरू परिक्षण गर्दै । यदि तपाईँले %d सेकेण्ड भित्र प्रतिउत्तर नगरेमा अघिल्लो "
+#~ "सेटिङहरू पुर्वावस्थामा ल्याइनेछ ।"
 
 #~ msgid "Keep Resolution"
 #~ msgstr "रिजोल्युसन राख्नुहोस्"
@@ -10905,16 +10687,18 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "रिजोल्युसन राख्नुहोस्"
 
 #~ msgid ""
-#~ "The X Server does not support the XRandR extension.  Runtime resolution changes to the display "
-#~ "size are not available."
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
 #~ msgstr ""
-#~ "X सर्भरले XRandR विस्तारलाई समर्थन गर्दैन ।  प्रदर्शन साइजमा चालुसमय रिजोल्युसन परिवर्तनहरू उपलब्ध छैनन् ।"
+#~ "X सर्भरले XRandR विस्तारलाई समर्थन गर्दैन ।  प्रदर्शन साइजमा चालुसमय रिजोल्युसन "
+#~ "परिवर्तनहरू उपलब्ध छैनन् ।"
 
 #~ msgid ""
-#~ "The version of the XRandR extension is incompatible with this program. Runtime changes to the "
-#~ "display size are not available."
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
 #~ msgstr ""
-#~ "XRandR विस्तारको यो संस्करण यो कार्यक्रमसँग अमिल्दो छ । प्रदर्शन साइजमा चालुसमयको परिवर्तनहरू उपलब्ध छैनन् ।"
+#~ "XRandR विस्तारको यो संस्करण यो कार्यक्रमसँग अमिल्दो छ । प्रदर्शन साइजमा चालुसमयको "
+#~ "परिवर्तनहरू उपलब्ध छैनन् ।"
 
 #~ msgid "New accelerator..."
 #~ msgstr "नयाँ गतिवर्धक..."
@@ -10946,8 +10730,11 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "_Accessibility"
 #~ msgstr "पहुँचता"
 
-#~ msgid "Just apply settings and quit (compatibility only; now handled by daemon)"
-#~ msgstr "केवल सेटिङहरू लागू गर्नुहोस् र अन्त्य गर्नुहोस् (अमिल्दो मात्र; अहिले डेइमोनद्वारा ह्याण्डल गरिएको)"
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "केवल सेटिङहरू लागू गर्नुहोस् र अन्त्य गर्नुहोस् (अमिल्दो मात्र; अहिले डेइमोनद्वारा ह्याण्डल "
+#~ "गरिएको)"
 
 #~ msgid "Start the page with the typing break settings showing"
 #~ msgstr "टाइप विच्छेद सेटिङ देखाएर पृष्ठ सुरुआत गर्नुहोस्"
@@ -10994,9 +10781,12 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Layouts"
 #~ msgstr "सजावटहरू"
 
-#~ msgid "Lock screen after a certain duration to help prevent repetitive keyboard use injuries"
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
 #~ msgstr ""
-#~ "पुनरावृतिक कुञ्जीपाटी प्रयोग क्षतिलाई रोक्नलाई मद्दत गर्नका लागि निश्चित समयावधि पछि पर्दा ताल्चा लगाउनुहोस्"
+#~ "पुनरावृतिक कुञ्जीपाटी प्रयोग क्षतिलाई रोक्नलाई मद्दत गर्नका लागि निश्चित समयावधि "
+#~ "पछि पर्दा ताल्चा लगाउनुहोस्"
 
 #~ msgid "Microsoft Natural Keyboard"
 #~ msgstr "माइक्रोसफ्ट प्राकृतिक कुञ्जीपाटी"
@@ -11027,9 +10817,6 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #~ msgid "_Work interval lasts:"
 #~ msgstr "कामको अन्तराल अन्त्य हुन्छ:"
-
-#~ msgid "Layout"
-#~ msgstr "सजावट"
 
 #~ msgid "Vendors"
 #~ msgstr "विक्रेताहरू"
@@ -11063,9 +10850,6 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #~ msgid "Motion"
 #~ msgstr "चाल"
-
-#~ msgid "_Acceleration:"
-#~ msgstr "गतिवर्धन:"
 
 #~ msgid "_Left-handed mouse"
 #~ msgstr "वायाँ-हाते माउस"
@@ -11142,18 +10926,15 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
 #~ msgstr "<span weight=\"bold\" size=\"x-large\">परिक्षण गर्दैछ...</span>"
 
-#~ msgid "Click OK to finish."
-#~ msgstr "समाप्त गर्न 'ठीक छ' बटन क्लिक गर्नुहोस् ।"
-
 #~ msgid "E_nable software sound mixing (ESD)"
 #~ msgstr "सफ्टवेयर ध्वनि मिश्रण (ESD) सक्षम पार्नुहोस्"
 
 #~ msgid ""
-#~ "Select the device and tracks to control with the keyboard. Use the Shift and Control keys to "
-#~ "select multiple tracks if required."
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
 #~ msgstr ""
-#~ "कुञ्जीपाटीसँग नियन्त्रण गर्न यन्त्र र ट्रयाकहरू चयन गर्नुहोस् । यदि आवश्यक परेमा वहुविध ट्रयाकहरू चयन गर्न शिफ्ट र "
-#~ "नियन्त्रण कुञ्जीहरू प्रयोग गर्नुहोस् ।"
+#~ "कुञ्जीपाटीसँग नियन्त्रण गर्न यन्त्र र ट्रयाकहरू चयन गर्नुहोस् । यदि आवश्यक परेमा वहुविध "
+#~ "ट्रयाकहरू चयन गर्न शिफ्ट र नियन्त्रण कुञ्जीहरू प्रयोग गर्नुहोस् ।"
 
 #~ msgid "So_und playback:"
 #~ msgstr "ध्वनि प्लेब्याक:"
@@ -11221,15 +11002,12 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Set your window properties"
 #~ msgstr "तपाईँको सञ्झ्यालको गुणहरू सेट गर्नुहोस्"
 
-#~ msgid "Windows"
-#~ msgstr "सञ्झ्यालहरू"
-
 #~ msgid ""
-#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for the Slow Keys "
-#~ "feature, which affects the way your keyboard works."
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
 #~ msgstr ""
-#~ "तपाईँले शिफ्ट कुञ्जी ८ सेकेण्डका लागि लिनुभएको छ । यो सुस्त कुञ्जी विशेषताका लागि सर्टकट हो, जसले तपाईँको "
-#~ "कुञ्जीपाटीको काम गर्ने तरिकालाई प्रभाव पार्दछ ।"
+#~ "तपाईँले शिफ्ट कुञ्जी ८ सेकेण्डका लागि लिनुभएको छ । यो सुस्त कुञ्जी विशेषताका लागि सर्टकट "
+#~ "हो, जसले तपाईँको कुञ्जीपाटीको काम गर्ने तरिकालाई प्रभाव पार्दछ ।"
 
 #~ msgid "Do you want to activate Slow Keys?"
 #~ msgstr "तपाईँ सुस्त कुञ्जीहरू सक्रिय बनाउन चहानुहुन्छ?"
@@ -11241,18 +11019,20 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "सक्रिय नबनाउनुहोस्"
 
 #~ msgid ""
-#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut for the Sticky Keys "
-#~ "feature, which affects the way your keyboard works."
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
 #~ msgstr ""
-#~ "तपाईँले भर्खरै एउटा पङ्क्तिमा ५ पटक शिफ्ट कुञ्जी थिच्नुभयो ।  यो टाँसिने कुञ्जी विशेषताका लागि सर्टकट हो, जसले "
-#~ "तपाईँको कुञ्जीले काम गर्ने तरिकालाई असर गर्दछ ।"
+#~ "तपाईँले भर्खरै एउटा पङ्क्तिमा ५ पटक शिफ्ट कुञ्जी थिच्नुभयो ।  यो टाँसिने कुञ्जी विशेषताका "
+#~ "लागि सर्टकट हो, जसले तपाईँको कुञ्जीले काम गर्ने तरिकालाई असर गर्दछ ।"
 
 #~ msgid ""
-#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a row.  This turns off "
-#~ "the Sticky Keys feature, which affects the way your keyboard works."
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
 #~ msgstr ""
-#~ "तपाईँले भर्खरै एकै पटक दुईवटा कुञ्जीहरू थिच्नुभयो, वा एउटा पङ्क्तिमा शिफ्ट कुञ्जी ५ पटक थिच्नुभयो ।  यसले टाँसिने "
-#~ "कुञ्जी विशेषतालाई बन्द गर्दछ, जसले तपाईँको कुञ्जीपाटीले काम गर्ने तरिकालाई असर गर्दछ ।"
+#~ "तपाईँले भर्खरै एकै पटक दुईवटा कुञ्जीहरू थिच्नुभयो, वा एउटा पङ्क्तिमा शिफ्ट कुञ्जी ५ पटक "
+#~ "थिच्नुभयो ।  यसले टाँसिने कुञ्जी विशेषतालाई बन्द गर्दछ, जसले तपाईँको कुञ्जीपाटीले काम "
+#~ "गर्ने तरिकालाई असर गर्दछ ।"
 
 #~ msgid "Do you want to activate Sticky Keys?"
 #~ msgstr "तपाईँ टाँसिन्ने कुञ्जीहरू सक्रिय बनाउन चहानुहुन्छ?"
@@ -11328,7 +11108,8 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid ""
 #~ "You are using XFree 4.3.0.\n"
 #~ "There are known problems with complex XKB configurations.\n"
-#~ "Try using a simpler configuration or taking a fresher version of XFree software."
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
 #~ msgstr ""
 #~ "तपाईँले XFree ४.३.०. प्रयोग गरिरहनुभएको छ\n"
 #~ "त्यहाँ जटिल XKB कन्फीगरेसनसँग ज्ञात समस्याहरू छन् ।\n"
@@ -11338,24 +11119,26 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "यो चेतावनी फेरि नदेखाउनुहोस्"
 
 #~ msgid ""
-#~ "<b>The X system keyboard settings differ from your current GNOME keyboard settings.</b>\n"
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.</b>\n"
 #~ "\n"
 #~ "Expected was %s, but the the following settings were found: %s.\n"
 #~ "\n"
 #~ "Which set would you like to use?"
 #~ msgstr ""
-#~ "<b>X प्रणाली कुञ्जीपाटी सेटिङहरू तपाईँको हालको जीनोम कुञ्जीपाटी सेटिङहरूबाट भिन्न हुन्छन् ।</b>\n"
+#~ "<b>X प्रणाली कुञ्जीपाटी सेटिङहरू तपाईँको हालको जीनोम कुञ्जीपाटी सेटिङहरूबाट भिन्न "
+#~ "हुन्छन् ।</b>\n"
 #~ "\n"
 #~ "अपेक्षा गरिएको %s थियो, तर निम्न सेटिङहरू फेला परे: %s.\n"
 #~ "\n"
 #~ "जुन सेट तपाईँ प्रयोग गर्न चाहनुहुन्छ?"
 
 #~ msgid ""
-#~ "Could not get default terminal. Verify that your default terminal command is set and points to "
-#~ "a valid application."
+#~ "Could not get default terminal. Verify that your default terminal command "
+#~ "is set and points to a valid application."
 #~ msgstr ""
-#~ "पूर्वनिर्धारित टर्मिनल प्राप्त गर्न सकेन । तपाईँको पूर्वनिर्धारित आदेश सेट भएको र वैध अनुप्रयोगमा देखाउँदछ भन्ने रूजु "
-#~ "गर्नुहोस् ।"
+#~ "पूर्वनिर्धारित टर्मिनल प्राप्त गर्न सकेन । तपाईँको पूर्वनिर्धारित आदेश सेट भएको र वैध "
+#~ "अनुप्रयोगमा देखाउँदछ भन्ने रूजु गर्नुहोस् ।"
 
 #~ msgid ""
 #~ "Couldn't execute command: %s\n"
@@ -11411,9 +11194,12 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "_Loaded files:"
 #~ msgstr "लोड गरिएका फाइलहरू:"
 
-#~ msgid "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW for preview"
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
 #~ msgstr ""
-#~ "bg_applier को प्रकार: मूल सञ्झ्यालका लागि BG_APPLIER_ROOT वा पूर्वावलोकनका लागि BG_APPLIER_PREVIEW"
+#~ "bg_applier को प्रकार: मूल सञ्झ्यालका लागि BG_APPLIER_ROOT वा पूर्वावलोकनका लागि "
+#~ "BG_APPLIER_PREVIEW"
 
 #~ msgid "Preview Width"
 #~ msgstr "पूर्वावलोकन चौडाइ"
@@ -11534,7 +11320,8 @@ msgstr "प्रणाली ध्वनिहरू"
 
 #~ msgid ""
 #~ "The sound file for this event does not exist.\n"
-#~ "You may want to install the gnome-audio package for a set of default sounds."
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
 #~ msgstr ""
 #~ "यो घटनाका लागि ध्वनि पाइल अवस्थित छैन ।\n"
 #~ "तपाईँ पूर्वननिर्धारित ध्वनिहरूको सेटका लागि जीनोम-अडियो प्याकेज स्थापना गर्न सक्नुहुन्छ ।"
@@ -11551,8 +11338,10 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr "\"%s\" सञ्झ्याल प्रबन्धकले कन्फिगरेसन उपकरण दर्ता गरेको छैन\n"
 
-#~ msgid "If true, the mime handlers for text/plain and text/* will be kept in sync"
-#~ msgstr "यदि ठीक छ भने, माइम ह्याण्डलर text/plain and text/* का लागि समक्रमाणमा राखिनेछ"
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "यदि ठीक छ भने, माइम ह्याण्डलर text/plain and text/* का लागि समक्रमाणमा राखिनेछ"
 
 #~ msgid "Sync text/plain and text/* handlers"
 #~ msgstr "text/plain and text/* ह्याण्डलर समक्रमण गर्नुहोस्"
@@ -11648,40 +11437,54 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "'सुरुआत गर्नुहोस्' कार्य कार्यसम्पादन गर्दा शेल अन्त्य गर्नुहोस्"
 
 #~ msgid "Exit shell on upgrade or uninstall action performed"
-#~ msgstr "'स्तरवृधि गर्नुहोस्' वा 'स्थापना नगर्नुहोस्' कार्य कार्यसम्पादन गर्दा शेल अन्त्य गर्नुहोस्"
+#~ msgstr ""
+#~ "'स्तरवृधि गर्नुहोस्' वा 'स्थापना नगर्नुहोस्' कार्य कार्यसम्पादन गर्दा शेल अन्त्य गर्नुहोस्"
 
 #~ msgid "Indicates whether to close the shell when a help action is performed"
 #~ msgstr "'मद्दत' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन इङ्गित गर्दछ"
 
-#~ msgid "Indicates whether to close the shell when a start action is performed"
-#~ msgstr "'सुरुआत गर्नुहोस्' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन इङ्गित गर्दछ"
-
-#~ msgid "Indicates whether to close the shell when an add or remove action is performed"
-#~ msgstr "एउटा 'थप्नुहोस्' वा 'हटाउनुहोस्' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन इङ्गित गर्दछ"
-
-#~ msgid "Indicates whether to close the shell when an upgrade or uninstall action is performed"
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed"
 #~ msgstr ""
-#~ "एउटा 'स्तरवृधि' वा 'स्थापना नगर्नुहोस्' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन इङ्गित गर्दछ"
+#~ "'सुरुआत गर्नुहोस्' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन इङ्गित गर्दछ"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed"
+#~ msgstr ""
+#~ "एउटा 'थप्नुहोस्' वा 'हटाउनुहोस्' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन "
+#~ "इङ्गित गर्दछ"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed"
+#~ msgstr ""
+#~ "एउटा 'स्तरवृधि' वा 'स्थापना नगर्नुहोस्' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ "
+#~ "या पर्दैन इङ्गित गर्दछ"
 
 #~ msgid "Task names and associated .desktop files"
 #~ msgstr "कार्य नामहरू र सम्बन्धितहरू । डेस्कटप फाइलहरू"
 
 #~ msgid ""
-#~ "The task name to be displayed in the control-center (thus needing to be translated) followed "
-#~ "by a \";\" separator then the filename of an associated .desktop file to launch for that task."
+#~ "The task name to be displayed in the control-center (thus needing to be "
+#~ "translated) followed by a \";\" separator then the filename of an "
+#~ "associated .desktop file to launch for that task."
 #~ msgstr ""
-#~ "\";\" विभाजक र त्यसपछि सम्बन्धित फाइलनामद्वारा अनुशरण गरिने नियन्त्रण-केन्द्रमा प्रदर्शन गरिनुपर्ने कार्यनाम "
-#~ "(यसैले अनुवाद गर्नु आवश्यक छ) \";\" विभाजकद्वारा अनुशरण गरिने र त्यसपछि सम्बन्धित फाइलनाम । उक्त कार्यको "
-#~ "लागि सुरुआत गर्नुपर्ने डेस्कटप फाइल ।"
+#~ "\";\" विभाजक र त्यसपछि सम्बन्धित फाइलनामद्वारा अनुशरण गरिने नियन्त्रण-केन्द्रमा "
+#~ "प्रदर्शन गरिनुपर्ने कार्यनाम (यसैले अनुवाद गर्नु आवश्यक छ) \";\" विभाजकद्वारा अनुशरण "
+#~ "गरिने र त्यसपछि सम्बन्धित फाइलनाम । उक्त कार्यको लागि सुरुआत गर्नुपर्ने डेस्कटप फाइल ।"
 
 #~ msgid ""
-#~ "[Change Desktop Background;background.desktop,Change Theme;gtk-theme-selector.desktop,Set "
-#~ "Preferred Applications;default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ "[Change Desktop Background;background.desktop,Change Theme;gtk-theme-"
+#~ "selector.desktop,Set Preferred Applications;default-applications.desktop,"
+#~ "Add Printer;gnome-cups-manager.desktop]"
 #~ msgstr ""
-#~ "[डेस्कटप पृष्ठभूमि; पष्ठभूमि.डेस्कटप,विषुवस्तु परिवर्तन गर्नुहोस्;gtk-theme-चयनकर्ता.डेस्कटप,रूचाइएको अनुप्रयोगहरू सेट;"
-#~ "पूर्वनिर्धारित-अनुप्रयोगहरू.डेस्कटप,मिद्रक थप्नुहोस्;जीनोम-कप्स-प्रबन्धक.डेस्कटप परिवर्तन गर्नुहोस्]"
+#~ "[डेस्कटप पृष्ठभूमि; पष्ठभूमि.डेस्कटप,विषुवस्तु परिवर्तन गर्नुहोस्;gtk-theme-चयनकर्ता.डेस्कटप,"
+#~ "रूचाइएको अनुप्रयोगहरू सेट;पूर्वनिर्धारित-अनुप्रयोगहरू.डेस्कटप,मिद्रक थप्नुहोस्;जीनोम-कप्स-"
+#~ "प्रबन्धक.डेस्कटप परिवर्तन गर्नुहोस्]"
 
-#~ msgid "if true, the control-center will close when a \"Common Task\" is activated"
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is activated"
 #~ msgstr "यदि ठीज छ भने, \"साझा कार्य\" सक्रिय हुँदा नियन्त्रण-केन्द्र बन्द हुनेछ"
 
 #~ msgid "The GNOME configuration tool"
@@ -11704,7 +11507,9 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Less than one minute until the next break"
 #~ msgstr "पछिल्लो विश्राम नभएसम्म एक मिनेटभन्दा कम"
 
-#~ msgid "Unable to bring up the typing break properties dialog with the following error: %s"
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
 #~ msgstr "निम्न त्रुटिसँग टाइपिङ बिच्छेद गुण संवाद ल्याउन असक्षम: %s"
 
 #~ msgid "Written by Richard Hult <richard@imendio.com>"
@@ -11723,13 +11528,15 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgstr "सूचना क्षेत्र अवस्थित छ या छैन जाँच नगर्नुहोस्"
 
 #~ msgid ""
-#~ "The typing monitor uses the notification area to display information. You don't seem to have a "
-#~ "notification area on your panel. You can add it by right-clicking on your panel and choosing "
-#~ "'Add to panel', selecting 'Notification area' and clicking 'Add'."
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
 #~ msgstr ""
-#~ "यो टाइपिङ मनिटरले सूचना प्रदर्शन गर्न सूचना क्षेत्र प्रयोग गर्दछ । तपाईँसँग प्यानलमा सूचना क्षेत्र भएको देखिँदैन । "
-#~ "तपाईँले यसलाई 'सूचना क्षेत्र' चयन गरेर र 'थप्नुहोस्' क्लिक गरेर तपाईँको प्यानलमा दायाँ-क्लिक गरेर र 'प्यानलमा "
-#~ "थप्नुहोस्' रोजेर तपाईँको प्यानलमा थप्न सक्नुहुन्छ ।"
+#~ "यो टाइपिङ मनिटरले सूचना प्रदर्शन गर्न सूचना क्षेत्र प्रयोग गर्दछ । तपाईँसँग प्यानलमा "
+#~ "सूचना क्षेत्र भएको देखिँदैन । तपाईँले यसलाई 'सूचना क्षेत्र' चयन गरेर र 'थप्नुहोस्' क्लिक "
+#~ "गरेर तपाईँको प्यानलमा दायाँ-क्लिक गरेर र 'प्यानलमा थप्नुहोस्' रोजेर तपाईँको प्यानलमा "
+#~ "थप्न सक्नुहुन्छ ।"
 
 #~ msgid "If set to true, then OpenType fonts will be thumbnailed."
 #~ msgstr "यदि सेट सहि भएमा, खुला प्रकारका फन्टहरूलाई थम्बनेल गरिनेछ ।"
@@ -11743,17 +11550,28 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "If set to true, then Type1 fonts will be thumbnailed."
 #~ msgstr "यदि सेट सहि भएमा, प्रकार १ का फन्टहरूलाई थम्बनेल गरिनेछ ।"
 
-#~ msgid "Set this key to the command used to create thumbnails for OpenType fonts."
-#~ msgstr "खुला प्रकारका फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "खुला प्रकारका फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई "
+#~ "सेट गर्नुहोस् ।"
 
 #~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
-#~ msgstr "PCF फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+#~ msgstr ""
+#~ "PCF फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् "
+#~ "।"
 
-#~ msgid "Set this key to the command used to create thumbnails for TrueType fonts."
-#~ msgstr "सही प्रकारका फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "सही प्रकारका फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई "
+#~ "सेट गर्नुहोस् ।"
 
-#~ msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-#~ msgstr "प्रकार १ फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "प्रकार १ फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट "
+#~ "गर्नुहोस् ।"
 
 #~ msgid "Thumbnail command for OpenType fonts"
 #~ msgstr "खुला प्रकारका फन्टहरूका लागि थम्बनेल आदेश"
@@ -11815,8 +11633,12 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "Do _not apply font"
 #~ msgstr "फन्ट लागू नगर्नुहोस्"
 
-#~ msgid "The theme you have selected suggests a new font. A preview of the font is shown below."
-#~ msgstr "तपाईँले चयन गर्नुभएको विषयवस्तुले एउटा नयाँ फन्टको सुझाव दिन्छ । फन्टको एउटा पूर्वावलोकन तल देखाइन्छ ।"
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "तपाईँले चयन गर्नुभएको विषयवस्तुले एउटा नयाँ फन्टको सुझाव दिन्छ । फन्टको एउटा "
+#~ "पूर्वावलोकन तल देखाइन्छ ।"
 
 #~ msgid "Themes"
 #~ msgstr "विषयवस्तुहरू"
@@ -11836,11 +11658,17 @@ msgstr "प्रणाली ध्वनिहरू"
 #~ msgid "If set to true, then themes will be thumbnailed."
 #~ msgstr "यदि सेट सहि भएमा, विषयवस्तुहरूलाई थम्बनेल गरिनेछ ।"
 
-#~ msgid "Set this key to the command used to create thumbnails for installed themes."
-#~ msgstr "स्थापन गरिएको विषयवस्तुहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "स्थापन गरिएको विषयवस्तुहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो "
+#~ "कुञ्जीलाई सेट गर्नुहोस् ।"
 
 #~ msgid "Set this key to the command used to create thumbnails for themes."
-#~ msgstr "विषयवस्तुहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+#~ msgstr ""
+#~ "विषयवस्तुहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् "
+#~ "।"
 
 #~ msgid "Thumbnail command for installed themes"
 #~ msgstr "स्थापित विषयवस्तुहरूका लागि थम्बनेल आदेश"

--- a/po/ne.po~
+++ b/po/ne.po~
@@ -1,0 +1,12725 @@
+# translation of gnome-control-center.gnome-2-20.ne.po to Nepali
+# Nepali Translation projectE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Pawan Chitrakar   <pawan@nplinux.org>, 2004.
+# Narayan Kumar Magar <narayan@mpp.org.np>, 2007.
+msgid ""
+msgstr ""
+"Project-Id-Version: Gnome Nepali Translation Project\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issues\n"
+"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"PO-Revision-Date: 2022-09-19 12:00+0545\n"
+"Last-Translator: Pawan Chitrakar <chautari@gmail.com>\n"
+"Language-Team: Nepali Translation Team <chautari@gmail.com>\n"
+"Language: ne\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 3.0.1\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Bookmarks: -1,-1,-1,-1,-1,-1,-1,-1,1617,-1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "प्रणाली बस"
+
+#: panels/applications/cc-applications-panel.c:822 panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837 panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "पूर्ण पहुँच"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "सत्र बस"
+
+#: panels/applications/cc-applications-panel.c:828 panels/power/cc-power-panel.ui:75
+#: panels/thunderbolt/cc-bolt-panel.ui:265 panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "यन्त्रहरू"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "/dev मा पूरा पहुँच"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3 panels/network/network-mobile.ui:235
+#: panels/wwan/cc-wwan-device-page.ui:61 panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "सञ्जाल"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "सञ्जाल पहुच छ"
+
+#: panels/applications/cc-applications-panel.c:837 panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "गृह"
+
+#: panels/applications/cc-applications-panel.c:839 panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "पढ्न-मात्र"
+
+#: panels/applications/cc-applications-panel.c:842 panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "फाइल प्रणाली"
+
+#: panels/applications/cc-applications-panel.c:848 panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246 shell/cc-window.c:880
+#: shell/cc-window.ui:22 shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "सेटिङ"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "सेटिङ्गहरू परिवर्तन गर्न सक्छ"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you are concerned about "
+"these permissions, consider removing this application."
+msgstr ""
+"%s सँग निम्न अनुमति अवस्थित छ । यी परिवर्तन गर्न सकिँदैन । यदि तपाईँ यी अनुमतिका बारेमा चिन्तित हुनुहुन्छ भने, यो "
+"अनुप्रयोग हटाउन विचार गर्नुहोस् ।"
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "अनुप्रयोगद्वारा खोलिएका %u फाइल र लिङ्क प्रकार"
+msgstr[1] "अनुप्रयोगद्वारा खोलिएका %u फाइल र लिङ्क प्रकारहरू"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> निम्न प्रकारका फाइलहरू र लिङ्कहरू खोल्न प्रयोग गरिन्छ।"
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s मा डिस्क स्पेस प्रयोग भएको छ ।"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415 panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "अनुप्रयोग"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "अनुप्रयोग छैन"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "स्थापना गर्नुहोस्…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "खोल्नुहोस्:"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "विवरण हेर्नुहोस्"
+
+#: panels/applications/cc-applications-panel.ui:112 panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16 panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63 panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82 panels/search/gnome-search-panel.desktop.in.in:3
+#: shell/cc-window.ui:41
+msgid "Search"
+msgstr "खोजी गर्नुहोस्"
+
+#: panels/applications/cc-applications-panel.ui:113 panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "प्रणाली खोजी प्राप्त गर्नुहोस् र परिणाम पठाउनुहोस् ।"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121 panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184 panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123 panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804 panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478 subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "असक्षम पारिएको छ"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "सूचना"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "प्रणाली सूचना देखाउनुहोस् ।"
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "पृष्ठभूमि मा चलाउनुहोस्"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "अनुप्रयोग बन्द हुँदा क्रियाकलाप अनुमति दिनुहोस् ।"
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "स्क्रिनसट"
+
+#: panels/applications/cc-applications-panel.ui:141
+#, fuzzy
+#| msgid "Take pictures with the camera."
+msgid "Take pictures of the screen at any time."
+msgstr "क्यामेरासँग तस्वीर लिनुहोस् ।"
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "वालपेपर परिवर्तन गर्नुहोस्"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "डेस्कटप वालपेपर परिवर्तन गर्नुहोस् ।"
+
+#: panels/applications/cc-applications-panel.ui:154 panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "ध्वनिहरू"
+
+#: panels/applications/cc-applications-panel.ui:155 panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "ध्वनिहरू पुनरुत्पादन गर्नुहोस्।"
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "सर्टकट निषेध गर्नुहोस्"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "मानक कुञ्जीपाटी सर्टकटहरू बन्द गर्नुहोस् ।"
+
+#: panels/applications/cc-applications-panel.ui:175 panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "क्यामेरा"
+
+#: panels/applications/cc-applications-panel.ui:176 panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "क्यामेरासँग तस्वीर लिनुहोस् ।"
+
+#: panels/applications/cc-applications-panel.ui:189 panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "माईक्रोफोन"
+
+#: panels/applications/cc-applications-panel.ui:190 panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "माइकसँग अडियो रेकर्ड गर्नुहोस्।"
+
+#: panels/applications/cc-applications-panel.ui:203 panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "स्थान सेवाहरू"
+
+#: panels/applications/cc-applications-panel.ui:204 panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "पहुँच यन्त्र स्थान डेटा ।"
+
+#: panels/applications/cc-applications-panel.ui:222 panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "सम्मिलित अनुमति"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "अनुप्रयोगद्वारा आवश्यक पर्ने प्रणाली पहुँच"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "फाइल र लिङ्क संघ"
+
+#: panels/applications/cc-applications-panel.ui:239 panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "भण्डारण"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "नतिजा भेटिएन"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210 shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "फरक खोज कोशिश गर्नुहोस्"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "फाइल र लिङ्क संघ"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "फाइल प्रकार"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "लिङ्क प्रकार"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234 panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "रिसेट गर्नुहोस्"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid "How much disk space this application is occupying with app data and caches."
+msgstr "अनुप्रयोग डेटा र क्याससँग यो अनुप्रयोगले कति डिस्क स्थान ओगटिरहेको छ ।"
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "अनुप्रयोग"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "डेटा"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "क्यास"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>जम्मा</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "क्यास खाली गर्नुहोस्…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "विभिन्न अनुप्रयोग अनुमति र सेटिङ नियन्त्रण गर्नुहोस्"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "अनुप्रयोग;flatpak;अनुमति;सेटिङ;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "तस्वीर छान्नुहोस्"
+
+#: panels/background/cc-background-chooser.c:315 panels/color/cc-color-calibrate.ui:22
+#: panels/color/cc-color-panel.c:284 panels/color/cc-color-panel.c:844
+#: panels/common/cc-language-chooser.ui:21 panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218 panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23 panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886 panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341 panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50 panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24 panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25 panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167 panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20 panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612 panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32 panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "रद्द गर्नुहोस्"
+
+#: panels/background/cc-background-chooser.c:316 panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270 panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "खोल्नुहोस्"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "बिभिन्न आकार"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "डेस्कटप पृष्ठभूमि छैन"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "हालको पृष्ठभूमि"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "शैली"
+
+#: panels/background/cc-background-panel.ui:49 panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "पूर्वनिर्धारित"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "गाढा"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "पृष्ठभूमि"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "तस्वीर थप्नुहोस्…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "मोहडा"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "तपाईँको पृष्ठभूमि छवि वा यूआई रङ परिवर्तन गर्नुहोस्"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+#, fuzzy
+#| msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "पृष्ठभूमि; वालपेपर; पर्दा;डेस्कटप; शैली: उज्यालो;अँध्यारो;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172 panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122 panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "सक्षम पार्नुहोस्"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "ब्लुटुठ भेटिएन"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "ब्लुटुठ चलाउन डङ्गल जडान गरनुहोस् ।"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "ब्लुटुठ बन्द गरियो"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "उपकरणहरू जडान गर्न खोल्नुहोस् र फाइल स्थानान्तरण प्राप्त गर्नुहोस्।"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "एअरप्लेन मोड राख्नु"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "हवाईजहाज मोड मा हुँदा ब्लुटुथ अक्षम हुन्छ ।"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "एअरप्लेन मोड हटाऊनु"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "हार्डवेयर हवाईजहाज मोड चलिरहेको छ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "ब्लुटुथ सक्षम गर्न हवाइजहाज मोड स्विच बन्द गर्नुहोस्।"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "ब्लुटुठ"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "यन्त्र जडानकोलागि ब्लुटुठ बन्द अनि खोल्नुहोस्"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "साझा;साझेदारी;ब्लुटुथ;ओबेक्स;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "क्यामेरा बन्द गरियो"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "कुनै पनि अनुप्रयोगले फोटो वा भिडियो ग्रहण गर्न सक्दैन ।"
+
+#: panels/camera/cc-camera-panel.ui:39
+#, fuzzy
+#| msgid ""
+#| "Use of the camera allows applications to capture photos and video. Disabling the camera may "
+#| "cause some applications to not function properly."
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling the camera may cause "
+"some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"क्यामेराको प्रयोगले अनुप्रयोगहरूलाई फोटो र भिडियो ग्रहण गर्न अनुमति दिन्छ । क्यामेरा अक्षम गर्दा केही अनुप्रयोगले "
+"राम्रोसँग कार्य नगर्न सक्छ ।"
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "क्यामेरा पहुँचका लागि कुनै अनुप्रयोगले सोधेको छैन"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "तपाईँको तस्वीर सुरक्षित राख्नुहोस्"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "क्यामेरा;फोटो;भिडियो;वेबक्याम;लक;निजी;गोपनीयता;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "वर्ग माथि तपाईँको क्यालिब्रेसन यन्त्र राख्नुहोस् र \"Start\" थिच्नुहोस्"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid "Move your calibration device to the calibrate position and press “Continue”"
+msgstr "क्यालिब्रसन यन्त्र क्यालिब्रट स्थानमाराखि जारि बटन थिच्नुहोस् ।"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid "Move your calibration device to the surface position and press “Continue”"
+msgstr "क्यालिब्रसन यन्त्र सटह स्थानमाराखि जारि बटन थिच्नुहोस् ।"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "कम्प्युटर बन्द गर्नुहोस्"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "एउटा आन्तरिक त्रुटि देखा पर्यो जुन पुन: प्राप्त गर्न सकिएन ।."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "अंशांकनलागि आवश्यक उपकरण स्थापित छैन।"
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "प्रोफाईल बनाउन सकिएन"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "लक्षित सेतोबिन्दु प्राप्त गर्न सकिने थिएन ।"
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "पूर्ण !"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "क्यालिब्रसन असफल!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "क्यालिब्रसन यन्त्र हटाउन सक्नुहुन्छ ।"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "अंशांकन प्रगतिमा हुँदा यन्त्रमा नचालाउनुहोस्"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "क्यालिब्रसन प्रदर्शन गर्नुहोस्"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "सुरु गर्नुहोस्"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "पुन: निरन्तरता दिनुहोस्"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "गरियो"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "ल्याकटप पर्दा"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "अवस्थित वेवक्याम"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s मोनिटर"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s स्क्यानर"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s क्यामेरा"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s मुद्रक"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s वेवक्याम"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s रङ व्यवस्थापनका सक्षम गर्नुहोस्"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s को रङ्ग प्रोफाईल देखाउनुहोस्"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "क्यालिब्रेट नगरिएको"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "पुर्वनिर्धारित "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "रङ्ग भर्ने स्थान "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "नमुना प्रोफाइल "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "ICC प्रोफाइल रोज्नुहोस्"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "आयात गर्नुहोस्"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "ICC प्रोफाइल "
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303 panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "सबै फाइलहरू"
+
+#: panels/color/cc-color-panel.c:586 panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "पर्दा"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "प्रोफाईल बचत गर"
+
+#: panels/color/cc-color-panel.c:845 panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "बचत गर्नुहोस्"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "चयन यन्त्र लागि एक रङ प्रोफाइल सिर्जना गर्नुहोस्"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and correctly connected."
+msgstr "मापन यन्त्र भेटिएन । सो यन्त्र जोडिएको छ र खुला छ भन्ने सुनिश्चित गर्नुहोस् ।"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "नाप्ने यन्त्रले प्रिन्टर प्रोफाइल समर्थन गर्दैन"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "यस प्रकारको यन्त्र समर्थित छैन ।"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "पर्दा क्यालिब्रसन"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "क्यालिब्रसन गुणस्तर"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your screen. The longer you "
+"spend on calibration, the better the quality of the color profile."
+msgstr ""
+"क्यालिब्रेसनले प्रोफाईल उत्पादन गर्नेछ जुन तपाइँले तपाइँको स्क्रीन प्रबन्ध गर्न सक्नुहुनेछ। लामो समयसम्म तपाईंले "
+"क्यालिब्रेसनमा खर्च गर्नुहुन्छ, रङ प्रोफाइलको गुणस्तर राम्रो।"
+
+#: panels/color/cc-color-panel.ui:28
+msgid "You will not be able to use your computer while calibration takes place."
+msgstr "अंशांकन हुन्जेल तपाईं आफ्नो कम्प्युटर प्रयोग गर्न सक्नुहुन्न।"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "गुणस्तर"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "अनुमानित समय"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "क्यालिब्रसन यन्त्र"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "तपाईंले क्यालिब्रेसनको लागि प्रयोग गर्न चाहेको सेन्सर उपकरण चयन गर्नुहोस्।"
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "पर्दा प्रकार"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "जडान भएका प्रदर्शनपर्दा चयन गर्नुहोस् ।"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "प्रोफाइल सेतोविन्दु"
+
+#: panels/color/cc-color-panel.ui:160
+msgid "Select a display target white point. Most displays should be calibrated to a D65 illuminant."
+msgstr "एक प्रदर्शन लक्ष्य सेतो बिन्दु चयन गर्नुहोस्। प्रायः प्रदर्शनहरू डि-६५ प्रकाशकका लागि क्यालिब्रेट हुनु पर्छ."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "पर्दा चम्किलोपन"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color management will be most "
+"accurate at this brightness level."
+msgstr ""
+"कृपया प्रदर्शनलाई एक चमकमा सेट गर्नुहोस् जुन तपाईंको लागि ठेट हो। यस चमक स्तरमा रङ्ग व्यवस्थापन अधिक सटीक हुनेछ।"
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other profiles for this "
+"device."
+msgstr ""
+"वैकल्पिक रूपमा, तपाईं यस यन्त्रको लागि अन्य प्रोफाइलहरू मध्ये एक प्रयोग गरिएको चमक तह प्रयोग गर्न सक्नुहुनेछ।."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "प्रोफाइल नाम"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles for different "
+"lighting conditions."
+msgstr ""
+"तपाईँले विभिन्न कम्प्युटरमा रङ प्रोफाइल प्रयोग गर्न सक्नुहुन्छ, वा फरक प्रकाश अवस्थाका लागि प्रोफाइलहरू सिर्जना गर्न "
+"सक्नुहुन्छ ।"
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "प्रोफाइल नाम:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "सारांश"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "प्रोफाईल सिर्जना गरिए !"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "प्रोफाइल प्रतिलिपी गर्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "लेख्न मिल्ने मिडियाको आवश्यकता"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux\">GNU/Linux</a>, <a "
+"href=\"osx\">Apple OS X</a> and <a href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"तपाईँले प्रोफाइल कसरी प्रयोग गर्ने भन्ने सन्दर्भमा यी निर्देशनहरू फेला पार्न सक्नुहुन्छ <a href=\"linux\">GNU/Linux</"
+"a>, <a href=\"osx\">Apple OS X</a> र <a href=\"windows\">Microsoft Windows</a> प्रणाली उपयोगी हुन्छ।"
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "प्रोफाइल थप्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:373
+msgid "Problems detected. The profile may not work correctly. <a href=\"\">Show details.</a>"
+msgstr "समस्या देखा परेको छ। प्रोफाइल काम नगर्न सक्छन् । <a href=\"\">विस्तृत विवरणहरू हेर्नुहोस् ।</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "फाईल आयात…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87 panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "थप्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "रङ देखाउन हरेक यन्त्रको रङ प्रोफाइल अद्यावधिक हुनु आवश्यक छ।"
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434 panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "अरु जान्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "रङ्ग प्रबन्धको अधिक जानकारि"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "सबै प्रयोगकर्ताकोलागि सेट गर्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "सबै प्रयोगकर्ताकोलागि प्रोफाईल सेट गर्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "सक्षम पार्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "प्रोफाइल थप्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "क्यालिब्रेट…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "यन्त्र क्यालिब्रेट गर्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "प्रोफाईल हटाउनुहोस्"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "विवरण हेर्नुहोस्"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "रङ व्यवस्थापन गर्न सकिने कुनै पनि यन्त्रहरू पत्ता लगाउन असक्षम"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "एलसिडि"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "प्रोजेक्टर"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "प्लाज्मा"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "एलसिडि (CCFL backlight)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "एलसिडि (RGB LED backlight)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "एलसिडि(white LED backlight)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "फराकिलो गामुट LCD (सि सि एफ एल ब्याकलाइट)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "फराकिलो गामुट एलसीडी (RGB एलईडी ब्याकलाइट)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "उच्च"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "४० मिनेट"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "३० मिनेट"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "न्यून"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "१५ मिनेट"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "मौलिक प्रर्दशन गर्ने"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "डि५० (छपाई र प्रकाशन)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "डि५५"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "डि६५ (फोटोग्राफि र ग्राफिक्स)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "डि७५"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "सेतो खालीस्थान"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "नमुना प्रोफाइल"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "स्वचालित"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "तल्लो गुणस्तर"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "मध्यम गुणस्तर"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "उच्च गुणस्तर"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "पुर्वनिर्धारित  RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "पुर्वनिर्धारित  CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "पुर्वनिर्धारित कैलो"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "विक्रेताले कारखाना अंशांकन डाटा प्रदान गर्यो"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "यो प्रोफाइलसँग पूरा-पर्दा प्रदर्शन सुधार सम्भव छैन"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "यो प्रोफाइल अब सही नहुन सक्छ"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "रङ"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid "Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "तपाईँको यन्त्र, जस्तै प्रदर्शन, क्यामेरा वा मुद्रकको रङ क्यालिब्रेट गर्नुहोस्"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "रङ;आइसिसी;प्रोफाइल;क्यालिब्रेट;मुद्रणयन्त्र;डिस्प्ले;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "अन्य…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "भाषा चयन गर्नुहोस्"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "चयन गर्नुहोस्"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "कुनै भाषा फेला परेन"
+
+#: panels/common/cc-language-chooser.ui:69 panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "अरू…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "सेटिङ परिवर्तन गर्न ताल्चा खोल्नुहोस्"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "केही सेटिङ हरू परिवर्तन गर्नु पहिले ताल्चा खोलिएको हुनुपर्छ ।"
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "ताल्चा हटाउनुहोस्…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "बढोत्तरी घन्टा"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "बढोत्तरी मिनेट"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "समय:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "घट्दो घण्टा"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "मिनेट घट्डोक्रम"
+
+#: panels/common/cc-util.c:127 panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "आज"
+
+#: panels/common/cc-util.c:131 panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "हिजो"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d घन्टा"
+msgstr[1] "%d घन्टा"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d मिनेट"
+msgstr[1] "%d मिनेट"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d सेकेन्ड"
+msgstr[1] "%d सेकेन्ड"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "० सेकेण्ड"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "हटस्पट"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "२४ घण्टा"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "१२ घन्टा (AM/PM)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15 panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "मिति र समय"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "वर्ष"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "महिना"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "जनवरी"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "फ़रवरी"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "मार्च"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "अप्रेल"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "मे"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "जून"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "जुलाई"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "अगस्ट"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "सेप्टेम्बर"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "अक्टोबर"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "नोभेम्बर"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "डिसेम्बर"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "दिन"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "समय क्षेत्र"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "शहर खोज्नुहोस्"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "स्वतः मिति र समय"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "ईन्टर्नेट हुनु आवश्यक"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "मिति र समय"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "स्वत: समय क्षेत्र"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "स्थान सेवा सक्षम र इन्टरनेट पहुँच आवश्यक छ"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212 panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43 panels/location/cc-location-panel.ui:9
+#: panels/screen/cc-screen-panel.ui:40 panels/screen/cc-screen-panel.ui:76
+#: panels/screen/cc-screen-panel.ui:96 panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904 panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "सक्षम पारिएको"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "समय क्षेत्र"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "समय ढाँचा"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "समय क्षेत्र सहित मिति र समय परिवर्तन गर्नुहोस"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "घडी;समय क्षेत्र;स्थान;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "समय र मिति सेटिङहरू बदल्नुहोस्"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "समय वा मिति सेटिङहरू बदल्न, प्रमाणिकरण गर्नु आवश्यक छ ।"
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "वेब"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "पत्राचार"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "पात्रो"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "सङ्गित"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "भिडियो"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "फोटो"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "पुर्वनिर्धारित अनुप्रयोग"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "पुर्वनिर्धारित अनुप्रयोग कन्फिगर"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "पूर्वनिर्धारित;अनुप्रयोग;रुचाइएको;मिडिया;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent anonymously and are "
+"scrubbed of personal data. %s"
+msgstr ""
+"प्राविधिक समस्याहरूको प्रतिवेदन पठाउँदा %s सुधार गर्न मद्दत गर्दछ । रिपोर्टहरू गुप्त रूपमा पठाइन्छ र व्यक्तिगत "
+"जानकारी कोरिन्छ। %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "समस्या प्रतिवेदन"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "स्वत:समस्या प्रतिवेदन"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "निदान"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "तपाईँको समस्याहरू प्रतिवेदन गर्नुहोस्"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "निदान;दुर्घटना;"
+
+#: panels/display/cc-display-panel.c:492 panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336 panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478 panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "खुला छ"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217 panels/power/cc-power-panel.c:731
+#: panels/power/cc-power-panel.c:742 panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468 panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490 panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "बन्द"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "परिवर्तन लागू गर्नुहोस्?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "परिवर्तनहरू लागू गर्न सकिँदैन"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "यो हार्डवेयरको सीमितताले गर्दा हुन सक्छ ।"
+
+#: panels/display/cc-display-panel.ui:43 panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "लागू गर्नुहोस्"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64 panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44 panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136 panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "पछाडि"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "दृश्यात्मक सेटिङ असक्षम पारियो"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "धेरैवटा पर्दा"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "जोड्नुहोस्"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "दर्पण"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "माथिल्लो पट्टी र क्रियाकलाप समाविष्ट गर्दछ"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "प्रमुख डिस्प्ले"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177 panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "रातको उज्यालो"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "ल्याण्डस्केप"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "पोर्ट्रेट दाँया"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "पोर्ट्रेट बाँया"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "ल्यान्डस्केप (फ्लिप गरिएको)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf हर्ज"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "अभिमूखिकरण"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "रिजोल्युसन"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "पुनसुचारु दर"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "टि भि समायोजन गर्नुहोस्"
+
+#: panels/display/cc-display-settings.ui:78 panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "मापन गर्नुहोस्"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "रात प्रकाश उपलब्ध छैन"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop being used remotely"
+msgstr "यो ग्राफिक्स ड्राइभर प्रयोग भइरहेको, वा डेस्कटप टाढाबाट प्रयोग भइरहेको परिणाम हुन सक्छ"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "भोलि सम्म अस्थाई निस्क्रिय"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "फिल्टर पून सुरू गर्नु"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye strain and sleeplessness."
+msgstr "रातको प्रकाशले पर्दाको रङलाई तातो बनाउँदछ । यसले आँखाको तनाव र निन्द्रा नलाग्न मदत गर्न सक्छ।"
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "समय तालिका"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "सूर्यास्ट देखि सूर्योदय"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "म्यानुअल तालिका"
+
+#: panels/display/cc-night-light-page.ui:154 panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "समय"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "बाट"
+
+#: panels/display/cc-night-light-page.ui:192 panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "घण्टा"
+
+#: panels/display/cc-night-light-page.ui:198 panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215 panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "मिनेट"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225 panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "पूर्वाह्न"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237 panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "अपराह्न"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "लाई"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "रङ्ग तापक्रम"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "प्रदर्शन"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+"तपाईँको माउस वा टचप्याड संवेदनशीलता परिवर्तन गर्नुहोस् र दायाँ वा बायाँ-हाते चयन गर्नुहोस् जडान गरिएको मोनिटर र "
+"प्रोजेक्टर कसरी प्रयोग गर्ने रोज्नुहोस्"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;color;sunset;"
+"sunrise;"
+msgstr ""
+"प्यानल; प्रोजेक्टर;xrandr; पर्दा; पर्दा रिजोल्युसन; ताजा पार्नुहोस्; मोनिटर; रात; प्रकाश; नीलो;रेडसिफ्ट;रङ;"
+"सूर्यास्त;सूर्योदय;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:109
+msgid "Secure Boot is Active"
+msgstr "सुरक्षित बुट सक्रिय छ"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts. It is currently "
+"turned on and is functioning correctly."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr ""
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts. It is currently "
+"turned on, but will not work due to having an invalid key."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI firmware settings (BIOS) and "
+"your hardware manufacturer may provide information on how to do this."
+msgstr ""
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+#, fuzzy
+#| msgid "Camera is Turned Off"
+msgid "Secure Boot is Turned Off"
+msgstr "माइक्रोफोन बन्द गरिएको छ"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts. It is currently "
+"turned off."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware settings (BIOS). For help, "
+"contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "पास भयो"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "असफल"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:482
+msgid "Security Level 0"
+msgstr "सुरक्षको तह ०"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could be because of a "
+"hardware or firmware configuration issue. It is recommended to contact your IT support provider."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:489
+msgid "Security Level 1"
+msgstr "सुरक्षको तह १"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is the lowest device "
+"security level and only provides protection against simple security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:496
+msgid "Security Level 2"
+msgstr "सुरक्षाको तह२"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This provides protection "
+"against some common security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:503
+msgid "Security Level 3"
+msgstr "सुरक्षको तह ३"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This is the highest device "
+"security level and provides protection against advanced security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:518
+msgid "Security Level"
+msgstr "सुरक्षाको तह"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:519
+#, fuzzy
+msgid "Security levels are not available for this device."
+msgstr "यन्त्र उपलब्ध छैन: %s"
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware settings, or by a "
+"support technician."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid "It might be possible to resolve this issue in the device’s UEFI firmware settings."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "तह १"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "तह २"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "३ तह"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:110
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:116
+msgid "Secure Boot has Problems"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:117
+msgid "Some protection when the device is started."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:122
+msgid "Secure Boot is Off"
+msgstr "सुरक्षित बुट सक्रिय छैन"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:123
+#, fuzzy
+msgid "No protection when the device is started."
+msgstr "यन्त्र ताला खोल्न विकल्पहरू"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:142
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an operating system "
+"configuration change, or because of malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:150
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, or because of "
+"malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:157
+msgid ""
+"This issue could have been caused by an operating system configuration change, or because of "
+"malicious software on this system."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:483
+msgid "Exposed to serious security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:490
+msgid "Limited protection against simple security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:497
+msgid "Protected against common security threats."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:504
+#: panels/firmware-security/cc-firmware-security-panel.c:512
+msgid "Protected against a wide range of security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:511
+msgid "Comprehensive Protection"
+msgstr "व्यापक सुरक्षा"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "घटनाहरू छैन"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection"
+msgstr "फर्मवेयर"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection Lock"
+msgstr "फर्मवेयर संस्करण"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Region"
+msgstr "फर्मवेयर"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Descriptor"
+msgstr "फर्मवेयर"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+#, fuzzy
+msgid "Intel BootGuard Fuse"
+msgstr "ठाडो गरी क्रमबद्ध गरिएको फ्युज"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+#, fuzzy
+msgid "Intel CET Enabled"
+msgstr "सक्षम"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+#, fuzzy
+msgid "Intel CET Active"
+msgstr "सक्रिय छैन"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr ""
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+#, fuzzy
+msgid "Encrypted RAM"
+msgstr "DVD-RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU सुरक्षा"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+#, fuzzy
+msgid "Linux Kernel Lockdown"
+msgstr "लकडाउन त्रुटि: अवैध तर्क"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+#, fuzzy
+msgid "Linux Kernel Verification"
+msgstr "प्रमाणपत्र रुजु गर्नुहोस्"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "लिनक्स स्वाप"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+#, fuzzy
+#| msgid "Suspend"
+msgid "Suspend To RAM"
+msgstr "DVD-RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "निष्क्रिय मा निलम्बित गर्नुहोस्"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+#, fuzzy
+msgid "UEFI Platform Key"
+msgstr "विकासकर्ताका लागि जिनोम प्लेटफर्म र लाइब्रेरीहरूका लागि मार्गदर्शन ।"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+#, fuzzy
+msgid "UEFI Secure Boot"
+msgstr "सुरक्षित"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "टीपीएम प्लेटफर्म कन्फिगरेसन"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "टिपिएम पुनर्निर्माण"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "टिपिएम v२.०"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "फर्मवेयर अद्यावधिकहरू"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Attestation"
+msgstr "फर्मवेयर"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Updater Verification"
+msgstr "प्याकेज अपडेटर"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+#, fuzzy
+msgid "Platform Debugging"
+msgstr "डिबगिङ सक्षम पार्नुहोस्"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "प्रोसेसर सुरक्षा जाँच"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+#, fuzzy
+msgid "AMD Rollback Protection"
+msgstr "सुरक्षा"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "AMD Firmware Replay Protection"
+msgstr "फर्मवेयर संस्करण"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "AMD Firmware Write Protection"
+msgstr "फर्मवेयर संस्करण"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+#, fuzzy
+msgid "Fused Platform"
+msgstr "जिनोम बिकासकर्ता प्लाटफर्म"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "वैध छ"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "वैध छैन"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "सक्षम पारिएको छैन"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "ताल्चा लगाइयो"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "ताल्चा लगाइएको छैन"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "गुप्तिकृत"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "गुप्तीकरण नगरिएको"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "दाग लागेको"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "दाग लागेको छैन"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "फेला पर्यो"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "फेला परेन"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "समर्थित छ"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "समर्थित छैन"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "सुरक्षा यन्त्र"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;privacy;"
+msgstr "पर्दा;ताल्चा;निदान;क्र्यास;निजी;हालैको;अस्थायी;tmp;index;नाम;सञ्जाल;पहिचान;गोपनीयता;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388 panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "अज्ञात"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "६४-विट"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "३२-विट"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "एक्स ११"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "व्यल्यान्ड"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "अज्ञात"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "उपलब्ध छैन"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "प्रणाली लोगो"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32 panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "उपकरण नाम"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "हार्डवेयर नमूना"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "स्मृती"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "प्रक्रियाकर्ता"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "ग्राफिक्स"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "डिस्क क्षमता"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "गणना गरिदै…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "OS नाम"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "सञ्चालन प्रणाली निर्माण आईडी"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "OS प्रकार"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "जिनोम संस्करण"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "लोड गर्दैछ…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "सञ्झ्याल प्रणाली"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "अवास्तविकरण"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "सफ्टवेयर अद्यावधिकहरू"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "उपकरण पुन: नामकरण गर्नुहोस्"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the network, or when "
+"pairing Bluetooth devices."
+msgstr "यन्त्र नाम यो यन्त्र लाई सञ्जाल माथि हेरेपछि, वा ब्लुटुथ यन्त्रहरू जोडिदा पहिचान गर्न प्रयोग गरिन्छ ।"
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "यन्त्र नाम"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "पुन: नामकरण गर्नुहोस्"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "बारेमा"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "तपाईँको प्रणाली बारेको सूचना हेर्नुहोस्"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;application;preferred;cd;dvd;"
+"usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"उपकरण;प्रणाली;जानकारी;होस्टनाम;स्मृति;प्रोसेसर;संस्करण;पूर्वनिर्धारित;अनुप्रयोग;उपयुक्त;सीडी;डीभिडी;यूएसबी;अडियो;"
+"भिडियो;डिस्क;हटाउन सकिने;मिडिया; स्वचालित;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "ध्वनि: र मेडिया"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "ध्वनि मौन गर/ मौन नगर"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "भोल्युम घटाउनुहोस्"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "भोल्युम बढाउनुहोस्"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "माइक्रोफोन मौन गर/ मौन नगर"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "मिडिया प्लेयर सुरु"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "बजाउनुहोस् (वा बजाउनुहोस्/पज गर्नुहोस्)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "पज प्रतिश्रवण"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "प्लेब्याक रोक्नुहोस्"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "अघिल्लो ट्रयाक"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "पछिल्लो ट्रयाक"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "निकाल्नुहोस्"
+
+#: panels/keyboard/01-input-sources.xml.in:4 panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "टाइप गर्दै"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "पछिल्लो आगत श्रोतमा जानुहोस्"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "अघिल्लो निर्गत श्रोतमा स्विच गर्नुहोस्"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "सुरुआत"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "मद्दत ब्राउजर सुरुआत गर्नुहोस्"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "गणकयन्त्र सुरु"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "इमेल क्लाइन्ट सुरु"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "वेब ब्राउजर सुरुआत गर्नुहोस्"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "गृह फोल्डर"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "खोजी गर्नुहोस्"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "प्रणाली"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "लग आउट गर्नुहोस्"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "पर्दा ताल्चा लगाउनुहोस्"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "पहुँचता"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "घट बढ गर्ने नगर्ने"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "जूम गर्नुहोस्"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "जुम घटाउनुहोस्"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "स्क्रीन रिडरलाई लाई  अन अथवा अफ गराउनुहोस"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "अन-स्क्रीन किबोर्ड लाई अन अथवा अफ गराउनुहोस"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "पाठ साइज बढाउनुहोस्"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "पाठ साइज घटाउनुहोस्"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "हाई कन्ट्रास्ट अन अथवा अफ"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "कुनै पनि निर्गत श्रोत फेला परेन ।"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "अन्य"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "निर्गत श्रोत थप्नुहोस्"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "लगइन पर्दामा आगत विधिहरू प्रयोग गर्न सकिँदैन"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "निर्गत श्रोत चयन गरिएको छैन"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "विकल्पहरू"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "माथि सार्नुहोस्"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "तल सार्नुहोस्"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "प्राथमिकता"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "कुञ्जीपाटी रूपरेखा हेर्नुहोस्"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "हटाउने"
+
+#: panels/keyboard/cc-keyboard-manager.c:485 panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "अनुकुलित सर्टकट"
+
+#: panels/keyboard/cc-keyboard-panel.c:64 panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "वैकल्पिक क्यारेक्टर कुञ्जी"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. These are sometimes "
+"printed as a third-option on your keyboard."
+msgstr ""
+"वैकल्पिक क्यारेक्टर कुञ्जीलाई थप क्यारेक्टरहरू प्रविष्ट गर्न प्रयोग गर्न सकिन्छ । यी कहिलेकाहीँ तपाईँको कुञ्जीपाटीमा "
+"तेस्रो-विकल्पको रूपमा मुद्रण गरिन्छ।"
+
+#: panels/keyboard/cc-keyboard-panel.c:67 panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "देब्रे alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68 panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "दाहिने alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69 panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "देब्रे super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70 panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "दाहिने super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71 panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "मेनु कुञ्जी"
+
+#: panels/keyboard/cc-keyboard-panel.c:72 panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "दाया Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80 panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "कम्पोज​ कि"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use it, press compose then "
+"a sequence of characters.  For example, compose key followed by <b>C</b> and <b>o</b> will enter "
+"<b>©</b>, <b>a</b> followed by <b>'</b> will enter <b>á</b>."
+msgstr ""
+"कम्पोज कुञ्जीले प्रविष्ट गर्नका लागि विभिन्न क्यारेक्टरहरूलाई अनुमति दिन्छ । यसलाई प्रयोग गर्न, त्यसपछि अक्षरहरूको "
+"क्रम रचना गर्नुहोस्।  उदाहरणका लागि, <b>सी</b> र <b>ओ</b> <b>©</b> प्रवेश गर्ने कुञ्जी रचना गर्नुहोस् <b>क</b> "
+"त्यसपछि <b>'</b> <b>á</b> प्रवेश गर्नेछ।"
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "क्यप्स लक"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "scroll lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "पर्दा मुद्रण गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"आगत स्रोतहरू %s कुञ्जीपाटी सर्टकट प्रयोग गरेर स्विच गर्न सकिन्छ।\n"
+"यो कुञ्जीपाटी सर्टकट सेटिङमा परिवर्तन गर्न सकिन्छ ।"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "आगत स्रोतहरू"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "कुञ्जीपाटी सजावट र आगत विधिहरू समावेश गर्दछ ।"
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "आगत स्रोत स्विचिङ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "सबै सञ्झ्यालको लागि एकै श्रोत  प्रयोग गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "हरेक सञ्झ्यालका लागि आगत स्रोत व्यक्तिगत रूपमा स्विच गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "विशेष वर्ण प्रविष्टि"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "कुञ्जीपाटी प्रयोग गरेर प्रतिमा र अक्षर विविधता प्रविष्ट गर्नका लागि विधिहरू ।"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "कुञ्जीपाटी सर्टकट"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "सर्टकट हेर्नुहोस् र अनुकूलन गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d परिमार्जित"
+msgstr[1] "%d परिमार्जित"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "सबै सर्टकटहरू रिसेट गर्नुहुन्छ?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid "Resetting the shortcuts may affect your custom shortcuts. This cannot be undone."
+msgstr "सर्टकट रिसेट गर्दा यसले तपाईंको अनुकूल सर्टकटलाई असर गर्न सक्छ। यो पूर्वावस्थामा लाउन सकिँदैन ।"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83 panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "रद्द गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "सबै रिसेट गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "सबै रिसेट गर्नुहोस्…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "सबै सर्टकटहरूलाई तिनीहरूको पूर्वनिर्धारित कुञ्जीबाइन्डिङमा रिसेट गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "खण्ड"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "सर्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "सर्टकट थप्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "अनुकुलित सर्टकट थप्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "अनुप्रयोग सुरुआत गर्न, स्क्रिप्ट चलाउन, र अरू धेरैका लागि अनुकूल सर्टकट सेटअप गर्नुहोस् ।."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "सर्टकट थप्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "कुञ्जीपाटी सर्टकट भेटिएन"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s पहिले नै %s का लागि प्रयोग भैरहेको छ । यदि तपाईँले यसलाई प्रतिस्थापन गर्नुभयो भने, %s अक्षम हुनेछ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "नयाँ सर्टकट टाइप गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "अनुकूलन सर्टकट सेट गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "सर्टकट सेट गर्नुहोस्"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "%s परिवर्तन गर्न नयाँ सर्टकट प्रविष्ट गर्नुहोस् । "
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "अनुकूलन सर्टकट थप्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_हटाउनुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "प्रतिस्थापन"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56 panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115 panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "सेट गर्नुहोस्"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "कुञ्जीपाटी सर्टकट अक्षम पार्न रद्द गर्न वा Backspace थिच्नुहोस् ।"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161 panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68 panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "नाम"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "आदेश"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "सर्टकट"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "कुनै सर्टकट सेट…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "कुनै पनि होइन"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "यसको पूर्वनिर्धारित मानमा सर्टकट रिसेट गर्नुहोस्"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "कुञ्जीपाटी"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts and input sources"
+msgstr ""
+"कुञ्जीपाटी सर्टकट परिवर्तन गर्नुहोस् र तपाईँको टाइपिङ प्राथमिकता, कुञ्जीपाटी सजावट र आगत स्रोत सेट गर्नुहोस्"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr "सर्टकट; कार्यस्थान; सञ्झ्याल; रिसाइज गर्नुहोस्; जुम गर्नुहोस्; व्यतिरेक;आगत; स्रोत; ताल्चा लगाउनुहोस्; भोल्युम;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "स्थान सेवा बन्द गरियो"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "अनुप्रयोगले स्थान सूचना प्राप्त गर्न सक्दैन ।"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and mobile broadband "
+"increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/privacy'>Privacy "
+"Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "अनुप्रयोगले स्थान पहुँचका लागि सोधेको छैन"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "तपाईँको स्थान जानकारि सुरक्षित गर्नुहोस्"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "स्थान;जीपीएस;निजी;गोपनीयता;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "माईक्रोफोन बन्द गरियो"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "कुनै अनुप्रयोगले ध्वनि रेकर्ड गर्न सक्दैन ।"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+#, fuzzy
+#| msgid ""
+#| "Use of the microphone allows applications to record and listen to audio. Disabling the "
+#| "microphone may cause some applications to not function properly."
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. Disabling the microphone "
+"may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"माइक्रोफोनको प्रयोगले अनुप्रयोगलाई रेकर्ड गर्न र अडियोको सञ्जाल स्रोतमा संसाधनका लागि मात्र यो जडान प्रयोग गर्न "
+"अनुमति दिन्छ । माइक्रोफोन अक्षम पार्नाले केही अनुप्रयोगहरू राम्रोसँग काम नगर्न सक्छन्।"
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "माइक पहुँचका लागि कुनै अनुप्रयोगले सोधेको छैन"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "तपाईँको वार्तालाप सुरक्षित गर्नुहोस्"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "माइक्रोफोन;रेकर्डिङ;अनुप्रयोग;गोपनीयता;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "सेटिङहरू परिक्षण गर्नुहोस्:"
+
+#: panels/mouse/cc-mouse-panel.ui:23 panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "साधारण"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "मुख्य बटन"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "माउस र टचप्याडमा भौतिक बटनको क्रम सेट गर्दछ ।."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "देब्रे"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "दाहिने"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "माउस"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "माउस गति"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "प्राकृतिक स्क्रोलिङ"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "स्क्रोलिङ्ग ले सामग्रीलाई सार्दछ , दृश्य होइन।"
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "ट्चप्याड"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "टचप्याड गति"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "क्लिक गर्नुस थिच्न"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "क्लिक गर्नु थिच्नुहोस्"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "दुई औला स्क्रोलिङ्ग"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "छेउस्क्रोलिङ्ग"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "थिच्न , दुई चोटी थिच्न ,इस्क्रोल्ल कोसिस गर्नुस"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "पाँच क्लिक, GEGL समय!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "मुख्य बटन दुई चोटी थिच्नुहोस"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "मुख्य बटन एक पटक थिच्नुहोस"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "बीच को बटन दुई चोटी थिच्नुहोस"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "बीच को बटन एक चोटी थिच्नुहोस"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "साहायक बटन दुई चोटी थिच्नुहोस"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "सहायक बटन एक चोटी थिच्नुहोस"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "माउस र टचप्याड"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid "Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "तपाईँको माउस वा टचप्याड संवेदनशीलता परिवर्तन गर्नुहोस् र दायाँ वा बायाँ-हाते चयन गर्नुहोस्"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ट्रयाकप्याड; सूचक; क्लिक; ट्याप; डबल; बटन; ट्रयाक्बल;स्कोल;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+#, fuzzy
+msgid "_Hot Corner"
+msgstr "हट..."
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "क्रियाकलाप सरोवर खोल्न माथिल्लो-बायाँ कुनामा स्पर्श गर्नुहोस् ।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "सक्रिय पर्दा किनारा"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid "Drag windows against the top, left, and right screen edges to resize them."
+msgstr "सञ्झ्यालहरूलाई रिसाइज गर्न माथिल्लो, बायाँ, र दायाँ पर्दा किनाराहरूमा तान्नुहोस् ।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "कार्यस्थान"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "गतिशील कार्यस्थान"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "खाली स्थान स्वचालित रूपमा हटाइनेछ ।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "कार्यस्थानको निश्चित सङ्ख्या"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "स्थायी कार्यस्थानको सङ्ख्या निर्दिष्ट गर्नुहोस् ।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "कार्यस्थानको सङ्ख्या"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "बहुँविध मोनिटर"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "प्राथमिक प्रदर्शनमा कार्यस्थान मात्र"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "सबै प्रदर्शनमा कार्यस्थान"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "अनुप्रयोग स्विचिङ"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "सबै कार्यस्थानबाट अनुप्रयोग सम्मिलित गर्नुहोस्"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "हालको कार्यस्थानबाट मात्र अनुप्रयोग समावेश गर्नुहोस्"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "मल्टिटास्किङ"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "उत्पादकत्व र मल्टिटास्किङका लागि प्राथमिकता प्रबन्ध गर्नुहोस्"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+#, fuzzy
+#| msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr "मल्टिटास्किङ; बहुँविध कार्य; उत्पादकत्व;अनुकूलन;डेस्कटप "
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "ओहो, केही गलत भएको छ। कृपया आफ्नो सफ्टवेयर विक्रेता सँग सम्पर्क गर्नुहोस् ।"
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "नेट्वोर्क म्यानेजर चलिरहन गर्न आवश्यक छ।"
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "अरु यन्त्रहरू"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "भीपीएन"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "जडान थप्नुहोस्"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "सेटअप भएको छैन"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "असुरक्षित सञ्जाल (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "सुरक्षित सञ्जाल WPA"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "सुरक्षित सञ्जाल WPA2"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "सुरक्षित सञ्जाल WPA3"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "सुरक्षित सञ्जाल"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "जडान गरियो"
+
+#: panels/network/cc-wifi-connection-row.ui:62 panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "विकल्पहरू…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible to access the "
+"internet through Wi-Fi."
+msgstr "हटस्पट खोल्दा %s बाट विच्छेदन हुनेछ, र वाई-फाई मार्फत इन्टरनेट पहुँच सम्भव हुदैन ।"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "न्यूनतम ८ क्यारेक्टर हुनुपर्दछ"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "न्युनतम %d वर्ण हुनुपर्दछ"
+msgstr[1] "अधिकतम %d वर्णहरू हुनुपर्दछ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "वाई-फाई हटस्पट खोल्नुहोस्?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a Wi-Fi network that "
+"they can connect to. To do this, you must have an internet connection through a source other than "
+"Wi-Fi."
+msgstr ""
+"वाई-फाई हटस्पटले अरूलाई तिनीहरूले जडान गर्न सक्ने वाई-फाई सञ्जाल सिर्जना गरेर, तपाईँको इन्टरनेट जडान साझेदारी "
+"गर्न अनुमति दिन्छ। यसो गर्न, तपाईं Wi-Fi बाहेक अन्य स्रोत मार्फत इन्टरनेट जडान हुनुपर्छ."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "सञ्जाल  नाम"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75 panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145 panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364 panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "पासवर्ड"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "अनियमित पासवर्ड उत्पन्न गर्नुहोस्"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "स्वत: उत्पन्न पासवर्ड"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "खोल्नु"
+
+#: panels/network/cc-wifi-panel.c:549 panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "वाई-फाई"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "हटस्पट बन्द गर्ने कुनै पनि प्रयोगकर्ता छुटाउने हो?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "हटस्पट रोक्नुहोस्"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "हवाइजहाज मोड"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Wi-Fi, ब्लुटुथ र मोबाइल ब्रडब्यान्ड अक्षम पार्दछ"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "कुनै पनि वाई-फाई एडप्टर फेला परेन"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "तपाईँले एउटा वाई-फाई एडप्टर प्लगइन गरेर खुला गर्नुभएको छ भन्ने निश्चित गर्नुहोस्"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "एअरप्लेन मोड राख्नु"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "वाई-फाई प्रयोग गर्न बन्द गर्नुहोस्"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "वाई-फाई हटस्पट सक्रिय गर्नुहोस्"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "मोबाइल यन्त्रले जडान गर्न QR कोड स्क्यान गर्न सक्दछ ।"
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "हटस्पट बन्द गर्नुहोस्…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "देखिने सञ्जाल"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "सञ्जाल प्रवन्धक चलि रहन आवश्यक छ।"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x सुरक्षा"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "सुरक्षा"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "सरक्षण गर्नुहोस्"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "स्थायी"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "अनियमित"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "स्थिर"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the network device this "
+"connection is activated on. This feature is known as MAC cloning or spoofing. Example: "
+"00:11:22:33:44:55"
+msgstr ""
+"यहाँ प्रविष्ट गरिएको MAC ठेगाना यो जडान सक्रिय पारिएको सञ्जाल यन्त्रका लागि हार्डवेयर ठेगानाको रूपमा प्रयोग "
+"गरिनेछ । यो विशेषतालाई MAC क्लोनिङ वा स्पूफिङ भनिन्छ । उदाहरण: ००:११:२२:३३:४४:५५"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "प्रोफाइल %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98 panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102 panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "विस्तारित खुला"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "ईन्टरप्राईज"
+
+#: panels/network/connection-editor/ce-page-details.c:136 panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "कुनै पनि होइन"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "कहिले पनि होइन"
+
+#: panels/network/connection-editor/ce-page-details.c:172 panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i दिन अघि"
+msgstr[1] "%i दिन अघि"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301 panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d एम बी/से"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "कुनै पनि होइन"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "कमजोर"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ठिक छ"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "असल"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "उत्तम"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94 panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 ठेगाना"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110 panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 ठेगाना"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419 panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151 panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "आईपी ठेगाना"
+
+#: panels/network/connection-editor/ce-page-details.c:423 panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424 panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165 panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169 panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453 panels/network/net-device-mobile.c:454
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "जडान भुल्नुहोस्"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "जडान प्रोफाईल हटाउनुहोस्"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "भीपीएन हटाउनुहोस्"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "विस्तृत विवरणहरू"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "स्वचालित"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "परिचय"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "ठेगाना पुस्तिका  मेट्नुहोस्"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "पथ मेट्नुहोस्"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "कुनै पनि होइन"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit पासफ्रेज"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "गतिशील WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14 panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "सङ्केत शक्ति"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "लिङ्क गति"
+
+#: panels/network/connection-editor/details-page.ui:126 panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "हार्डवेयर ठेगाना"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "समर्थित पुनरावृत्तिहरू"
+
+#: panels/network/connection-editor/details-page.ui:158 panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160 panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "पूर्वनिर्धारित पथ"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "अन्तिम पटक प्रयोग गरिएको"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "स्वतः जडान गर्नुहोस्"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "अन्य प्रयोगकर्तालाई उपलव्ध गराउनुहोस्"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "मिटरगरिएको जडान: डाटा सीमा छ वा शुल्क लिन सक्छ"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid "Software updates and other large downloads will not be started automatically."
+msgstr "सफ्टवेयर अद्यावधिक र अन्य ठूला डाउनलोडहरू स्वचालित रूपमा सुरु गरिने छैन।"
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "नाम"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC ठेगाना"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "क्लोण्ड ठेगाना"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "बाइट"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 बिधी"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "स्वचालित"
+
+#: panels/network/connection-editor/ip4-page.ui:45 panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "लिङ्क स्थानीय मात्र"
+
+#: panels/network/connection-editor/ip4-page.ui:55 panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "म्यानुअल"
+
+#: panels/network/connection-editor/ip4-page.ui:65 panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "असक्षम पार्नुहोस्"
+
+#: panels/network/connection-editor/ip4-page.ui:75 panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "अन्य कम्प्युटरमा साझेदार गरिएको"
+
+#: panels/network/connection-editor/ip4-page.ui:98 panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "ठेगानाहरू"
+
+#: panels/network/connection-editor/ip4-page.ui:112 panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122 panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ठगाना"
+
+#: panels/network/connection-editor/ip4-page.ui:124 panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "नेटमास्क"
+
+#: panels/network/connection-editor/ip4-page.ui:136 panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146 panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "गेटवे"
+
+#: panels/network/connection-editor/ip4-page.ui:175 panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36 panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237 panels/network/net-proxy.c:73
+#: panels/network/network-proxy.ui:93 panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "स्वचालित"
+
+#: panels/network/connection-editor/ip4-page.ui:183 panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "स्वचालित डिएनएस"
+
+#: panels/network/connection-editor/ip4-page.ui:192 panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "डीएनएस सर्भर ठेगाना(हरू)"
+
+#: panels/network/connection-editor/ip4-page.ui:200 panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "अल्पविरामद्वारा आईपी ठेगाना छुट्याउनुहोस्"
+
+#: panels/network/connection-editor/ip4-page.ui:217 panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "पथ"
+
+#: panels/network/connection-editor/ip4-page.ui:235 panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "स्वचालित पथ"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285 panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "मेट्रिक"
+
+#: panels/network/connection-editor/ip4-page.ui:308 panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "यसको सञ्जालमा संसाधनका लागि मात्र यो जडान प्रयोग गर्नुहोस् ।"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 बिधी"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "स्वचालित DHCP मात्रै"
+
+#: panels/network/connection-editor/ip6-page.ui:134 panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "PREFIX"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "जडान सम्पादक खोल्न सकिएन"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "नायाँ प्रोफाइल"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "अवैध सेटिङ %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "अवैध सेटिङ %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "फाईलबाट आयात गर्नुहोस्…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "भीपीएन थप्नुहोस्"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "सुरक्षा"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "भीपीएन जडान आयात गर्न सकिएन"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"फाइल \"%s\" पढ्न सकिएन वा पहिचान गरिएको भीपीएन जडान सूचना समावेश गर्दैन\n"
+"\n"
+"त्रुटि: %s ."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "आयात गर्न फाइल चयन गर्नुहोस्"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "'%s' नाम गरेको फाइल पहिले नै अवस्थित छ ।."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "बदल्नुहोस्"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "तपाईँले बचत गरिरहनु भएको भीपीएन जडानसँग %s बदल्न चाहनुहुन्छ?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "भीपीएन जडान निर्यातगर्न सकिएन"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"भीपीएन जडान \"%s\" %sमा निर्यात गर्न सकेन ।\n"
+"\n"
+"त्रुटि: %s ."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "भीपीएन जडान निर्यात गर्नुहोस्"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(त्रुटि: भिपिएन संजाल सम्पादक लोड गर्न असमर्थ)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "कसरी तपाईं इन्टरनेट जडान गर्ने बारे नियन्त्रण गर्नुहोस"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "सञ्जाल;आईपी; LAN; प्रोक्सी; WAN; ब्रडब्यान्ड; मोडेम; ब्लुटुथ;भीपीएन;डीएनएस;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "तपाईँले ताररहित सञ्जालमा कसरी जडान गर्न नियन्त्रण गर्नुहोस्"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "सञ्जाल; ताररहित;Wi-Fi;Wifi;IP; LAN; ब्रडब्यान्ड;डीएनएस; हटस्पट;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "कहिले पनि होइन"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "आज"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "हिजो"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "अन्तिम पटक प्रयोग गरिएको"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264 panels/network/network-bluetooth.ui:5
+#: panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "तारजडिट"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "नयां जडान थप्नुहोस्"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any custom configuration will "
+"be lost."
+msgstr "चयन गरिएका सञ्जालका लागि सञ्जाल विवरणहरू, पासवर्डहरू र कुनै पनि अनुकूल कन्फिगरेसन समाविष्ट गर्दछ ।"
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "भुलनुहोस्"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "परिचित वाई-फाई सञ्जाल"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "भुलनुहोस्"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "प्रणाली नीतिले हटस्पटको रूपमा प्रयोग निषेध गर्दछ"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "ताररहित यन्त्रले हटस्पट शैलीलाई समर्थन गर्दैन"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "कन्फिगरेसन युआरएल प्रदान गरिएको छैन वेब प्रोक्सी Autodiscovery प्रयोग गरिएको छ ।"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "यो अविश्वसनीय सार्वजनिक नेटवर्कको लागि सिफारिश गरिएको छैन।"
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "यन्त्र बन्द गर्नुहोस्"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "सक्रिय गर्नुहोस्"
+
+#: panels/network/network-mobile.ui:27 panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "प्रदायक"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "सञ्जाल प्रोक्सि"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP प्रोक्सि"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS प्रोक्सी"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP प्रोक्सि"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "SOCKS होस्ट"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "होस्त वेवास्ता गर्नुहोस"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP प्रोक्सि पोर्ट"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS प्रोक्सी पोर्ट"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP प्रोक्सि पोर्ट"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "SOCKS प्रोक्सी पोर्ट"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "कन्फिगरेसन यूआरएल"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "भीपीएन जडान बन्द गर्नुहोस्"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "सञ्जाल  नाम"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "सुरक्षा प्रकार"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "पासवर्ड"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "वाई-फाई बन्दगर्नुहोस"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "अरू विकल्पहरू…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "लुकेको सञ्जालमा जोड्नुहोस्…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "वाई-फाई हटस्पट खोल्नुहोस्..."
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "परिचित वाई-फाई सञ्जाल"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "वस्तुस्थिति अज्ञात"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "अव्यवस्थित"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "अनुपलब्ध"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "जडान गर्दै"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "प्रमाणीकरण आवश्यक"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "जडान हटाउदै"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "जडान असफल"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "वस्तुस्थिति अज्ञात(हराएको)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "कन्फिगुरेसन असफल"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP कन्फिगरेसन असफल भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP कन्फिगरेसन म्याद समाप्त भएको छ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "पासवर्ड आवश्यक छ, तर प्रदान गरिएन"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x supplicant विच्छेदन भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x supplicant कन्फिगरेसन विफल"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x supplicant विफल"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant प्रमाणित गर्न लामो समय लियो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "पिपिपि सेवा सुरु गर्न असफल भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "पिपिपि सेवा विच्छेद भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "पिपिपि असफल"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP client सुरु गर्न असफल भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP क्लाईन्त मा त्रुति"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP असफल भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "साझा जडान सेवा सुरु गर्न विफल"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "साझेदारि जडान सेवा असफल"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "स्वतIP सेवा सुरु गर्न असफल भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "स्वतIP सेवामा त्रुटि"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "स्वतIP सेवा असफल भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "लाईन व्यस्त छ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "डायलटोन छैन"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "कुनै क्यारियर स्थापित गर्न सकिएन"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "डायलिङ्ग समय सकियो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "डायलिङ्गगर्ने प्रयास असफल"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "मोडेम सुरुवात गर्न असफल"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "APN चयन गर्न असफल भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "सञ्जाल खोजी गर्दैन"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "सञ्जाल दर्ता गर्नदिएन"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "सञ्जालदर्ता समय सकियो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "अनुरोध सञ्जाल दर्ता गर्न असफल"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN जाच असफल भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "उपकरण लागि फर्मवेयर नरहेको हुन सक्छ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "जडान विस्थापन भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "होलको जडान पुन जडानभयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "मोडेम फेला परेन"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "ब्लुटुठ जडान असफल भयो"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "सिमकार्ड राखिएको छैन"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "सिमको पिन आवश्यक"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "सिमको PUK आवश्यक"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "गलत SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "जडान निर्भरता विफल"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "फर्मवेयर छैन"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "केबल छुटेको"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "802.1X सुरक्षामा अपरिभाषित त्रुटि (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "कुनै फाइल चयन गरिएको छैन"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "eap-method फाइल वैधता गर्दा निर्दिष्ट नगरिएको त्रुटि"
+
+#: panels/network/wireless-security/eap-method.c:394
+#, fuzzy
+#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, वा PKCS#12 निजी कुञ्जीहरू (*. der, *. pem, *. p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:397
+#, fuzzy
+#| msgid "_User certificate"
+msgid "DER or PEM certificates"
+msgstr "DER वा PEM प्रमाणपत्र (*. der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "EAP-FAST PAC फाइल हराइरहेको छ"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC files (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "बेनामी"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "प्रमाणीकरण गरिएको"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "दुवै"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "अज्ञात पहिचान"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _file"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PACफाईल छान्नुहोस्"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "आन्तरिक प्रमाणीकरण"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "स्वचालित PAC प्रावधानलाई अनुमति दिनुहोस्"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "EAP-LEAP प्रयोगकर्ता नाम हराइरहेको छ"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "EAP-LEAP पासवर्ड हराइरहेको छ"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "प्रयोगकर्ता नाम"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23 panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10 panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "पासवर्ड"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44 panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "पासवर्ड :देखाउनुहोस्"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "अवैध EAP-PEAP CA प्रमाणपत्र: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "अवैध EAP-PEAP CA प्रमाणपत्र: प्रमाणपत्र निर्दिष्ट गरिएको छैन"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "संस्करण ०"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "संस्करण १"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A प्रमाणपत्र"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "प्रमाणपत्र अधिकार पत्र रोज्नुहोस्"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "CA प्रमाणपत्र आवश्यक छैन"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP संस्करण"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "EAP प्रयोगकर्ता नाम हराइरहेको छ"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "EAP पासवर्ड हराइरहेको छ"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "हराइरहेको EAP-TLS परिचय"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "अवैध EAP-TLS CA प्रमाणपत्र: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "अवैध EAP-TLS CA प्रमाणपत्र: प्रमाणपत्र निर्दिष्ट गरिएको छैन"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "अवैध EAP-TLS व्यक्तिगत कुञ्जी: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "अवैध EAP-TLS प्रयोगकर्ता-प्रमाणपत्र: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "गुप्तिकरण नगरिएको व्यक्तिगत कुञ्जी हरू असुरक्षित छन्"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This could allow your "
+"security credentials to be compromised. Please select a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"चयन गरिएको व्यक्तिगत कुञ्जीलाई पासवर्डद्वारा सुरक्षित गरेको देखिदैन । यसले तपाईँको सुरक्षा प्रमाणपत्रहरू सम्झौता गर्न "
+"अनुमति दिन सक्छ । कृपया पासवर्ड सुरक्षित व्यक्तिगत कुञ्जी चयन गर्नुहोस् ।\n"
+"\n"
+"(तपाईं आफ्नो निजी कुञ्जी openssl संग पासवर्ड-सुरक्षा गर्न सक्नुहुन्छ)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "तपाईँको व्यक्तिगत प्रमाणपत्र छान्नुहोस्"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "निजी  कुञ्जी छान्नुहोस्"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "परिचय"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "प्रयोगकर्ता प्रमाणपत्र"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "निजी कुञ्जी"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "निजी कुञ्जी"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "अवैध EAP-TTLS CA प्रमाणपत्र: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "अवैध EAP-TTLS CA प्रमाणपत्र: प्रमाणपत्र निर्दिष्ट गरिएको छैन"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "डोमेन"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "802.1X सुरक्षा लाई प्रमाणित गर्दा अज्ञात त्रुटि"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "चाँडो"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "टनेल गरिएको TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "सुरक्षित EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "प्रमाणीकरण"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "एउटा फाइल चयन गर्नुहोस्"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "LEAP-प्रयोगकर्ता नाम हराइरहेको छ"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "LEAP-पासवर्ड हराइरहेको छ"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "वाई-फाई पासवर्ड छैन।"
+
+#: panels/network/wireless-security/ws-sae.ui:33 panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "प्रकार"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "wep-key हराएको छ"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "अवैध wep-key: %zu लम्बाइ भएको कुञ्जीले हेक्स-अङ्क मात्र समाविष्ट गर्नुपर्दछ"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "अवैध wep-key: %zu लम्बाइ भएको कुञ्जीले ascii क्यारेक्टर मात्र समाविष्ट गर्नुपर्दछ"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 (ascii) or 10/26 (hex)"
+msgstr "अवैध wep-key: गलत कुञ्जी लम्बाइ %zu। एउटा कुञ्जी या त लम्बाइ ५/१३ (ascii) वा १०/२६ (hex) हुनुपर्छ"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "अवैध wep-key: पासफ्रेज खाली नभएको हुनुपर्छ"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "अवैध wep-key: पासफ्रेज ६४ क्यारेक्टर भन्दा छोटो हुनुपर्छ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "१(पूर्वनिर्धारीत)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "खुल्ला प्रणाली"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "साझेदार गरिएको कुञ्जी"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "कुञ्जी"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "कुञ्जि देखाउनुहोस्"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP inde_x"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex digits"
+msgstr "अवैध wpa-psk: अवैध कुञ्जी-लम्बाइ %zu । [८,६३] बाइट वा ६४ हेक्स अङ्क हुनुपर्दछ"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "अवैध wpa-psk: हेक्सको रूपमा ६४ बाइटहरूसँग कुञ्जी व्याख्या गर्न सकिँदैन"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "सूचना"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "ध्वनि सुचक"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "सुचना पपअप"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid "Notifications will continue to appear in the notification list when popups are disabled."
+msgstr "पपअप अक्षम पारिएको बेलामा सूचना सूचीमा सूचनाहरू देखापर्नेछन् ।"
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "पपअपमा सन्देश सामाग्री देखाउनुहोस्"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "पर्दा सूचनाहरू ताल्चा लगाउनुहोस्"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "ताल्चा लागेको पर्दामा सन्देश सामाग्री देखाउनुहोस्"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "डिस्टर्ब नगर्नुहोस्"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "पर्दा सूचनाहरू ताल्चा लगाउनुहोस्"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "कुन सूचना प्रदर्शन गरिएको छ र तिनीहरूले के देखाउँछन् नियन्त्रण गर्नुहोस्"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "सूचनाहरू; ब्यानर; सन्देश; ट्रे; पपअप;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "अन्य"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s हटाउनुहोस्"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "खाता हटाउँदा त्रुटि"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23 panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "पुर्वस्थितिमा फर्काउनुहोस्"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "सूचना बन्दगर्नुहोस्"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "क्लाउडमा तपाईँको डाटामा जडान गर्नुहोस्"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "नया अनलाईन खाता बनाउन ईन्टरनेट जडान  गर्नुहोस् "
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "प्रयोगकर्ता खाता थप्नुहोस्"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s खाता"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "खाता हटाउनुहोस्"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "अनलाईन खाताहरू"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "तपाईँको अनलाइन खातामा जडान गर्नुहोस् र तिनीहरूलाई केका लागि प्रयोग गर्ने निर्णय गर्नुहोस्"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;"
+"Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;"
+"Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "अज्ञात समय"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i मिनट"
+msgstr[1] "%i मिनट"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i घण्टा"
+msgstr[1] "%i घण्टा"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "घण्टा"
+msgstr[1] "घण्टा"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "मिनट"
+msgstr[1] "मिनट"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "पुरा चार्जको हुन %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "सावधान: %sबाँकी"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s बाकि छ"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "पुरा चार्ज"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "चार्ज छैन"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "खाली"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "चार्जहुँदै"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "चार्ज सकिदैँछ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "वायरलेस माउस"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "वायरलेस कुञ्जीपाटी"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "अटुट विद्युत आपूर्ति"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "पर्सनल डिजिटल असिस्टेन्ट"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "सेलफोन"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "मिडिया प्लेयर"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "ट्याबलेट"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "कम्प्युटर"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "खेल आगत यन्त्र"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "बेटरि"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "मुख्य"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "अतिरिक्त"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "बेटरिहरू"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "निश्क्रिय"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "निश्क्रिय गर्ने"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "पावर बन्द"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "हाइवरनेट"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "केही पनि होइन"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "जब बेटरि पावरमा"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "जडान भएको बेला"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "कहिल्यै पनि"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "स्वत निश्क्रिय"
+
+#: panels/power/cc-power-panel.c:1033
+msgid "Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a stable surface to "
+"restore."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1037
+#, fuzzy
+#| msgid "Performance mode unavailable"
+msgid "Performance mode temporarily disabled."
+msgstr "भोलि सम्म अस्थाई निस्क्रिय"
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when battery is sufficiently "
+"charged."
+msgstr "न्यून ब्याट्री: पावर सेभर सक्षम पारियो । ब्याट्री पर्याप्त चार्ज हुँदा अघिल्लो मोड पूर्वावस्थामा ल्याइनेछ ।"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "शक्ति बचतकर्ता मोड \"%s\" द्वारा सक्रिय पारियो।"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "प्रदर्शन मोड \"%s\" द्वारा सक्रिय पारियो।"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "१५ मिनेट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "२० मिनेट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "२५ मिनेट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "३० मिनेट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "४५ मिनेट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "१ घन्टा"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "८० मिनेट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "९० मिनेट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "१०० मिनेट"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "२ घण्टा"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "शक्ति मोड"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "प्रणाली कार्यसम्पादन र शक्ति उपयोगलाई प्रभाव पार्छ ।."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "पावर बचत विकल्प"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "स्वत: पर्दा चम्किलोपन"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "पर्दा चम्किलोपन वरिपरिको प्रकाशमा समायोजन हुन्छ ।"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "मलिन पर्दा"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "कम्प्युटर निस्क्रिय हुँदा पर्दा चम्किलोपन घटाउछ ।"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "खाली पर्दा"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "निस्क्रियताको अवधि पछि पर्दा बन्द गर्छ ।"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "स्वाचालित पावर बचत"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "ब्याट्री कम हुँदा पावर बचत मोड सक्षम पार्छ ।"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "स्वत निश्क्रिय"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "निष्क्रियअवधि पछि कम्प्युटर पज गर्दछ ।"
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "पावर बटन व्यवहार"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "ब्याटरि प्रतिशत देखाउनुहोस्"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "स्वत निश्क्रिय"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "जडान भएको बेला"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "बेटरि पावरमा"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "विलम्ब गर्नुहोस्"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "कार्यसम्पादन"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "उच्च प्रदर्शन र शक्ति प्रयोग। "
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "सन्तुलन"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "मानक प्रदर्शन र शक्ति उपयोग।"
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "पावर बचत"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "कम प्रदर्शन र शक्ति प्रयोग."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "पावर"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "तपाईँको ब्याट्री स्थिति हेर्नुहोस् र पावर बचत सेटिङ परिवर्तन गर्नुहोस्"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;Energy;"
+msgstr ""
+"शक्ति; निद्रा; निलम्बन गर्नुहोस्; हाइबर्नेट; ब्याट्री; चम्किलोपन;धमिलो;खाली; मोनिटर;DPMS;निष्प्रयोजन; शक्ति;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "मुद्रणयन्त्र “%s” मेटियो"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "नयाँ मुद्रक थप्न असफल"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui जडान गर्न सकिएन : %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "मुद्रक र परिवर्तन सेटिङ थप्न ताल्चा खोल्नुहोस्"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "मुद्रणयन्त्रहरू"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "मुद्रक थप्नुहोस्, मुद्रक कार्य हेर्नुहोस् र तपाईँले कसरी मुद्रण गर्ने निर्णय गर्नुहोस् ।"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "मुद्रणयन्त्र;Queue;मुद्रण;कागज;मसी;टोनर;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28 panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255 panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "मुद्रक थप्नुहोस्"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103 panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "ताल्चा खोल्नुहोस्"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "मुद्रणयन्त्रहरू भेटिएन"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "कृपया मान्य सञ्जाल ठेगाना प्रविष्ट गर्नुहोस् र पुन: प्रयास गर्नुहोस् ।"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "प्रमाणीकरण आवश्यक"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr "मुद्रण सर्भरमा मुद्रणहरू हेर्न प्रयोगकर्ता नाम र पासवर्ड प्रवेश गर्नुहोस् ।"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317 panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94 panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "प्रयोगकर्ता नाम"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76 panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "विस्तृत विवरण %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "उपयुक्त ड्राइभर पाइएन"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "PPD फाइल चयन गर्नुहोस्"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+msgstr "पोस्ट स्क्रिप्ट मुद्रणयन्त्र डिस्क्रिप्सन फाइलहरू  (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "मुद्रक नामले स्पेस, ट्याब, #, वा / समावेश गर्न सक्दैन"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "स्थान"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139 panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "ड्राइभर"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "उपयुक्त ड्राइभर खोजी गरिदै…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "ड्राइभर खोज"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "डाटाबेस चयन गर्नुहोस्…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "PPD फाइल स्थापना गर्नुहोस्"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "मुद्रक चयन गर्नुहोस्"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "ड्राइभर डाटाबेस लोड गरिँदैछ…"
+
+#: panels/printers/ppd-selection-dialog.ui:91 panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "चयन गर्नुहोस्"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect  मुद्रक"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "एलपीडि मुद्रण"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64 panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "एकापट्टी"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66 panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "लामो धार भएको"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68 panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "छोटो किनारा (फ्लिप)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "पोर्ट्रेट"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "ल्याण्डस्केप"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "ल्याण्डस्केप उल्टाउनुहोस्"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "पोट्रेट उल्टाउनुहोस्"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "पुन: निरन्तरता दिनुहोस्"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "पज गर्नुहोस्"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "विचाराधिन"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "पज गरिएको"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "प्रमाणीकरण आवश्यक"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "प्रक्रिया गरिदै"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "रोकियो"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "रद्द गरियो"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "परित्याग गरियो"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "पूरा भयो"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "यो कामलाई पङ्क्ति माथि तिर सार्नुहोस्"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u कार्य प्रमाणीकरण आवश्यक छ"
+msgstr[1] "%u कार्यहरू प्रमाणीकरण आवश्यक छ"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — सक्रिय कार्य"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "%s बाट मुद्रण गर्न कालागि प्रमाणपत्रहरू प्रविष्ट गर्नुहोस् ।"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30 panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "डोमेन"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "प्रमाणीकरण गर्नुहोस्"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "सबै खाली गर्नुहोस्"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "प्रमाणीकरण"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "सक्रिय मुद्रण कार्य छैन"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "मुद्रण सर्भर ताल्चा खोल्नुहोस्"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s ताल्चा हटाउनुहोस्।"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "%sमा मुद्रणहरू हेर्न प्रयोगकर्ता नाम र पासवर्ड प्रवेश गर्नुहोस् ।."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "मुद्रणयन्त्रहरू खोज्दै"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "युएसबि"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "क्रम पोर्ट"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "समानान्तर पोर्ट"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "स्थान: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "ठेगाना %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "सर्भरलाई प्रमाणीकरण आवश्यक छ"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "दुबैपट्टी"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "कागजको प्रकार"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "कागज श्रोत"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "निर्गत ट्रे"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "रिजोल्युसन"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "घोस्टस्क्रिप्ट प्रि-फिल्टरिङ"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "एकापट्टि पृष्ठहरू"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "दुबैपट्टी"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "अभिमुखीकरण"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "साधारण"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "पृष्ठ सेटअप"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "स्थापना गर्ने विकल्पहरू"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "काम"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "छवि गुणस्तर"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "रङ"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "सकिदै"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "उन्नत"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844 panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "नमुना पृष्ठ"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "नमुना पृष्ठ"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75 panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "स्वतः छान्ने"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79 panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83 panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "पूर्वानिर्धारण मुद्रण"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "घोस्टस्क्रिप्ट फन्टहरू मात्र सम्मिलित गर्नुहोस्"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "पीएस स्तर १ रूपान्तरण"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "पीएस स्तर २ रूपान्तरण"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "पूर्व-फिल्टर छैन"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220 panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "उत्पादक"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "सक्रिय कार्यहरू छैन"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u काम"
+msgstr[1] "%u कामहरू"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "मुद्रण हेड सफा गर्नुहोस्"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "टोनर कम"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "टोनर सकियो"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "डेभेलोपर कम छ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "डेभेलोपर सकियो"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "मार्कर आपूर्ति कमि"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "मार्कर आपूर्ति सकियो"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "आवरण खोल्नुहोस्"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "ढोका खुला छ"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "कागजको कमी"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "कागज सकियो"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "अफलाइन"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743 panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "रोकियो"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "फोहोर भण्डारण लगभग पूर्ण"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "फोहोर भण्डारण भरियो"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "ओप्टिकल फोटो सञ्चालक  जीवनको अन्तमा छ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ओप्टिकल फोटो सञ्चालकले हालै काम गरेको छैन"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "तयार"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "मुद्रण कार्य स्वीकार्य छैन"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "प्रक्रिया गरिदै"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "मुद्रण विक्लपहरू"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "मुद्रण विवरण"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "पूर्वानिर्धारण मुद्रण प्रयोग गर्नहोस्"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "मुद्रण हेड सफा गर्नुहोस्"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "मुद्रण हटाउनुहोस्"
+
+#: panels/printers/printer-entry.ui:183 panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "शैली"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "मसि लेबल"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "समस्या समाधान गरि पुन: सुरु गर्नुहोस्"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "पुन: सुरु गर्नुहोस्"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "मुद्रक थप्नुहोस्…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "मुद्रणहरू भेटिएन"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"माफ गर्नुहोस्! प्रणाली मुद्रण सेवा\n"
+"उपलब्ध छैन जस्तो देखिन्छ ।"
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "ढाँचाहरू"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "लोकेलहरू खोजी गर्नुहोस्…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "साझा ढाँचाहरू"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "सबै ढाँचाहरू"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "खोजी परिणाम छैन"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "खोजी हरू देश वा भाषाहरूका लागि हुन सक्छन्।"
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "पूर्वावलोकन"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "इम्पेरियल"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "मेट्रिक"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "मिति"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "मिति र समय"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "सङ्ख्याहरू"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "नाप"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "कागज"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "अर्को लगइन पछि भाषा र ढाँचा परिवर्तन हुनेछ"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "लगआउट…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are used for numbers, "
+"dates, and currencies."
+msgstr ""
+"भाषा सेटिङ इन्टरफेस पाठ र वेब पृष्ठहरूको लागि प्रयोग गरिन्छ। ढाँचाहरू संख्याहरू, मितिहरू र मुद्राहरूको लागि प्रयोग "
+"गरिन्छ।"
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "तपाईको खाता"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "भाषा"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "ढाँचाहरू"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "लग‍इन स्क्रिन"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "क्षेत्र र भाषा"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "तपाईँको प्रदर्शन भाषा र ढाँचा चयन गर्नुहोस्"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "भाषा;खाका;किबोर्ड;आगत;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "के गर्ने भनेर सोध्नुहोस्"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "केही पनि होइन"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "फोल्डर खोल्नुहोस्"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "अरु मिडिया"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "अडियो सिडिहरूको लागि अनुप्रयोग छान्नुहोस्"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "भिडियो डिभिडिहरूको लागि अनुप्रयोग छान्नुहो"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "संगीत बजाउने यन्त्र जॊडीएपछि संगीत बजाउनकालागि एक अनुप्रयोग छान्नुहोस्"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "फोटो खिच्ने यन्त्र (क्यामेरा) जडित भएमा कुन प्रोग्राम सुचारु हुने, रोज्नुहोस्"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "अनुप्रयोग सिडिहरूको लागि अनुप्रयोग छान्नुहो"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "ध्वनि डिभिडि॒"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "रित्तो ब्लुरे चक्का"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "रित्तो सिडि चक्का"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "रित्तो डिभिडि॒ चक्का"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "रित्तो एचडिडिभिडि चक्का"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "ब्लुरे भिडियो चक्का"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "इ- पुस्तक पाठक"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "एचडि डिभिडि भिडियो चक्का"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "तस्वीर सिडि"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "सुपर भिडियो सिडि"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "भिडिओ(दृष्य) सिडि"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "विन्डोज् सफ्टवेर"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "मेडिया कसरी सम्हाल्ने, छान्नुहोस्"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "ध्वनि सिडि॒"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "डिभिडि॒ भिडियो"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "सङ्गीत प्लेयर"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "सफ्टवेयर"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "अरु मिडिया…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_मेडिया हाल्दा कहिले पनि कार्यक्रमहरु सुरु नगर्ने"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "अन्य मिडिया कसरी सम्हाल्नु पर्छ, छान्नुहोस्"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "कार्य:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "प्रकार:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "हटाउन सकिने माध्यम"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "हटाउन योग्य मिडिया सेटिङ्ग"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"उपकरण;प्रणाली;पूर्वनिर्धारित;मनपरेको;अनुप्रयोग;सीडी;डीभिडी;यूएसबी;अडियो;भिडियो;डिस्क;हटाउन सकिने;मिडिया;"
+"स्वचालित;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "पर्दा बन्द गर्नुहोस्"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "३० सेकेण्ड"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "१ मिनेट"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "२ मिनेट"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "३ मिनेट"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "५ मिनेट"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "३० मिनेट"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "१ घन्टा"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "१ मिनेट"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "२ मिनेट"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "३ मिनेट"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "४ मिनेट"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "५ मिनेट"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "८ मिनेट"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "१० मिनेट"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "१२ मिनेट"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "१५ मिनेट"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "कहिल्यै पनि"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "पर्दा ताल्चा लगाउनुहोस्"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer while you're away."
+msgstr "पर्दामा स्वचालित रूपले ताल्चा लगाउँदा तपाईँ टाढा हुँदा अरूलाई कम्प्युटर पहुँच गर्नबाट रोकिन्छ ।."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "खाली पर्दा ढिलाई"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "निस्क्रियताको अवधि जस पछि पर्दा खाली हुन्छ ।"
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "स्वत: पर्दामा ताल्चा"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "स्वत: पर्दामा ताल्चा ढिलाइ"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "पर्दा स्वत: ताल्चा लगाएको बेलामा पर्दा खाली गरेपछिको अवधि ।"
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "ताल्चा लागेको पर्दामा सूचनाहरू देखाउनुहोस्"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "नयाँ युएसबि यन्त्र निषेध गर्नुहोस्"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid "Prevent new USB devices from interacting with the system when the screen is locked."
+msgstr "पर्दामा ताल्चा लगाएको बेलामा नयाँ USB यन्त्रलाई प्रणालीसँग अन्तरक्रिया गर्नबाट रोक्नुहोस् ।"
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "पर्दा गोपनियता"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "दृश्य कोण सीमित गर्नुहोस्"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Screen Sharing"
+msgid "Screen Settings"
+msgstr "दृष्टिवाचकअनुकूलता फेरी बहन गरियो ।"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "पर्दा;ताल्चा;निजी;गोपनीयता;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "_स्थान छान्नुहोस्"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "ठिक छ"
+
+#: panels/search/cc-search-locations-dialog.ui:8 panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "स्थान (हरूमा) खोजी गर्नुहोस्"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid "Folders which are searched by system applications, such as Files, Photos and Videos."
+msgstr "फाइल, फोटो र भिडियो जस्ता प्रणाली अनुप्रयोगद्वारा खोजी गरिने फोल्डरहरू ।"
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "स्थानहरू"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "पुस्तकचिनो"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "अन्य"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "स्थान थप्नुहोस्"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "अनुप्रयोग पाईएन"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "अनुप्रयोग खोजी"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "अनुप्रयोग-प्रदान गरिएको खोजी परिणाम समावेश गर्नुहोस् ।"
+
+#: panels/search/cc-search-panel.ui:23
+#, fuzzy
+#| msgid "Folders which are searched by system applications, such as Files, Photos and Videos."
+msgid "Folders which are searched by system applications."
+msgstr "फाइल, फोटो र भिडियो जस्ता प्रणाली अनुप्रयोगद्वारा खोजी गरिने फोल्डरहरू ।"
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "नतिजा खोजी गर्नुहोस्"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "परिणाम सूची क्रम अनुसार प्रदर्शन गरिन्छ ।"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid "Control which applications show search results in the Activities Overview"
+msgstr "क्रियाकलाप अवलोकनमा कुन अनुप्रयोगले खोजी परिणाम देखाउँदछ नियन्त्रण गर्नुहोस्"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "खोजी गर्नुहोस्; फेला पार्नुहोस्;अनुक्रमणिका; लुकाउनुहोस्; गोपनीयता; परिणाम;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "साझेदारि सञ्जाल छानिइको छैन"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "सञ्जाल"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "खुला छ"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "बन्द"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "सक्षम पारिएको"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "सक्रिय"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "एउटा फोल्डर रोज्नुहोस्"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "थप्नुहोस्"
+
+#: panels/sharing/cc-sharing-panel.c:736
+#, fuzzy
+#| msgid "Media Sharing"
+msgid "Enable media sharing"
+msgstr "मेडिया साझेदारी"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your current network using: %s"
+msgstr "फाइल साझेदारीले तपाईँको हालको सञ्जालमा अन्यसँग तपाईँको सार्वजनिक फोल्डर साझेदारी गर्न अनुमति दिन्छ: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure Shell command:\n"
+"%s"
+msgstr ""
+"टाढाको लगइन सक्षम पारिएमा, सुरक्षित शेल आदेश प्रयोग गरेर टाढा प्रयोगकर्ताहरूले जडान गर्न सक्दछन्:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+#, fuzzy
+msgid "Enable personal media sharing"
+msgstr "मेडिया साझेदारी"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "यन्त्र नाम प्रतिलिपी गरियो"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "यन्त्र ठेगान प्रतिलिपि गरियो"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "प्रयोगकर्ताको नाम प्रतिलिपी गरियो"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "गुप्तशब्द प्रतिलिपि गरियो"
+
+#: panels/sharing/cc-sharing-panel.ui:9 panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "साझेदारी"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "कम्प्युटर नाम"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "फाइल साझेदारी"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "टाढाको डेस्कटप"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "मेडिया साझेदारी"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "टाढा लगइन"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "फाइल साझेदारी"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "पासवर्ड आवश्यक"
+
+#: panels/sharing/cc-sharing-panel.ui:195 panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "टाढा लगइन"
+
+#: panels/sharing/cc-sharing-panel.ui:251 panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "टाढाको डेस्कटप"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid "Remote desktop allows viewing and controlling your desktop from another computer."
+msgstr "टाढाको डेस्कटपले अर्को कम्प्युटरबाट तपाईँको डेस्कटप हेर्न र नियन्त्रण गर्न अनुमति दिन्छ ।"
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "यो कम्प्युटरमा टाढाको डेस्कटप जडान सक्षम वा असक्षम पार्नुहोस् ।"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "टाढाको नियन्त्रण"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "पर्दा नियन्त्रण गर्न टाढाको जडानलाई अनुमति दिन्छ ।"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "कसरी जडान गर्ने"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid "Connect to this computer using the device name or remote desktop address."
+msgstr "टाढाको डेस्कटप ठेगाना वा यन्त्र नाम प्रयोग गरेर यो कम्प्युटरमा जडान गर्नुहोस् ।"
+
+#: panels/sharing/cc-sharing-panel.ui:318 panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372 panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "प्रतिलिपि बनाउनुहोस्"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "टाढाको डेस्कटप ठेगाना"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "प्रमाणीकरण"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "यो कम्प्युटरमा जडान गर्न प्रयोगकर्ता नाम र पासवर्ड आवश्यक हुन्छ ।"
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "प्रयोगकर्ताको नाम"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "गुप्तीकरण रूजु गर्नुहोस्"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "गुप्तिकरण औठाछाप"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+#, fuzzy
+#| msgid "The encryption fingerprint can be seen in connecting clients and should be identical"
+msgid "The encryption fingerprint can be seen in connecting clients and should be identical."
+msgstr "गुप्तिकरण औठाछाप जडान क्लाइन्टमा देख्न सकिन्छ र समान हुनुपर्दछ"
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "मेडिया साझेदारी"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "सञ्जालमा संगीत, फोटो र भिडियो सेयर गर्नुहोस् ।."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "फोल्डरहरू"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "अरूसँग बाँड्न चाहेको कुरा नियन्त्रण गर्नुहोस्"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;movies;server;"
+"renderer;"
+msgstr "साझेदारी;साझेदारी;ssh;होस्ट;नाम;टाढाको;डेस्कटप;मिडिया;अडियो;भिडियो;तस्विर;फोटो;चलचित्र;सर्भर;रेन्डरर;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "टाढाको लगइन सक्षम वा अक्षम पार्नुहोस्"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "टाढाको लगइन सक्षम वा अक्षम पार्न प्रमाणीकरण आवश्यक हुन्छ"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "अनुकुलन"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "क्लिक गर्नुहोस्"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "स्ट्रिङ"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "स्विङ"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "हम"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "सन्तुलन"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "फेड"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "पछाडि"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "अगाडी ल्याउनुहोस्"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "निरिक्षण %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "स्पिकर निरिक्षण गर्न क्लिक गर्नुहोस्"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "प्रणाली भोल्युम"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "मास्टर भोलुम"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "भोल्युम तहहरू"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "निर्गत"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "निर्गत यन्त्र"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "परिक्षण गर्नुहोस्"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "कन्फिगरेसन"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "सबउफर"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "आगत"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "आगत उपकरण"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "भोल्युम"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "सावधानि ध्वनि"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "१००%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "मौन"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ध्वनि"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ध्वनि स्तर, आगत, निर्गत, र चेतावनी ध्वनि परिवर्तन गर्नुहोस्"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "कार्ड; माइक्रोफोन; भोल्युम; फेड; ब्यालेन्स; ब्लुटुथ; हेडसेट;ध्वनि;आगत;निर्गत"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92 panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "जडान विच्छेदन भयो"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95 panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "जडान गर्दै"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98 panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "जडान भयो"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "प्रमाणिकरण असफल"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104 panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "प्राधिकृत गर्दै"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "घटाइएको कार्यात्मकता"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "प्रमाणीकरण र जडान भयो"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119 panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "अज्ञात"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "प्रमाणीकरण:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "जडान भएको:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "दर्ता भएको:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "यन्त्र अधिकार प्राप्त गर्न असफल भयो: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "यन्त्र बिर्सन असफल भयो: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "%u अन्य यन्त्रमा निर्भर गर्दछ"
+msgstr[1] "%u अन्य यन्त्रहरूमा निर्भर गर्दछ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43 panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "सूचना बन्दगर्नुहोस्"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "नाम:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "वस्तुस्थिति:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "अधिकार दिनुहोस्"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "यन्त्र भुलनुहोस्"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "त्रुटी"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "प्रमाणीकरण गरिएको"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr "थन्डरबोल्ट उपप्रणाली (boltd) स्थापना गरिएको छैन वा राम्रोसँग सेटअप गरिएको छैन ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:425 panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "डक र बाह्य GPUs जस्ता यन्त्रमा प्रत्यक्ष पहुँच अनुमति दिनुहोस् ।."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "USB र प्रदर्शन पोर्ट यन्त्र मात्र संलग्न गर्न सकिन्छ ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the BIOS or is set to an "
+"unsupported security level in the BIOS."
+msgstr ""
+"थन्डरबोल्ट पत्ता लगाउन सकेन ।\n"
+"या त प्रणालीमा थन्डरबोल्ट समर्थनको कमी छ, यो BIOS मा अक्षम पारिएको छ वा BIOS मा एउटा असमर्थित सुरक्षा "
+"स्तरमा सेट गरिएको छ ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "BIOS मा थन्डरबोल्ट समर्थन अक्षम पारिएको छ ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "थन्डरबोल्ट सुरक्षा स्तर निर्धारण गर्न सकेन ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "प्रत्यक्ष मोड स्विच गर्दा त्रुटि: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "थन्डरबोल्ट समर्थन छैन"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "थन्डरबोल्ट उपप्रणालीमा जडान गर्न सकेन ।"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "सिधा पहुँच"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "विचाराधिन यन्त्रहरू"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "उपकरण जडित छैन"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "थन्डरबोल्ट"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "थन्डरबोल्ट यन्त्र प्रबन्ध गर्नुहोस्"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "थन्डरबोल्ट;गोपनीयता;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "झिम्किरहेको कर्सर"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "पाठ बाकसहरुमा कर्सर झिम्किन्छ ।."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "गति"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "झिम्किरहेको कर्सर गति"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "कर्सर आकार"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid "Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "कर्सरलाई सजिलैसँग हेर्नका लागि कर्सरको साइजजूमसँग संयोजन गर्न सकिन्छ ।"
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "क्लिक सहयोगि"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "सिमुलेतेड सेकेन्डरी क्लिक सक्षम गर्नुहोस्"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "प्राथमिक बटन समातेर द्वितीयक क्लिक ट्रिगर गर्नुहोस्"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66 panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "A_cceptance ढिलाइ:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "छोटो"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "दोस्रो क्लिक विलम्ब गर्नुहोस्"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "लामो"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "होवर चयन"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "एउटा वस्तु माथि सूचक होभरहरू भएको बेलामा एउटा उपकरणटिप देखाउनुहोस् ।"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "विलम्ब गर्नुहोस्:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "छोटो"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "लामो"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "चाल सीमा:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "सानो"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "ठूलो"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "कुञ्जीहरू दोहोर्याउनुहोस्"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "कुञ्जी तल झर्दा कुञ्जी थिचाइहरू दोहोरिन्छन् ।"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "दोहोरिने कुञ्जी ढिलाई"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "कुञ्जी गति दोहोर्याउनुहोस्"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "टाइप सहयोगि"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "टाँसिने कुञ्जि"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "मोडिफायर किहरूलाई किकोरूपमा व्यवहार गर्छ"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "यदि दुई कुञ्जी एउटै समयमा थिचिएमा अक्षम पार्नुहोस्"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "परिमार्जक कुञ्जि थिचिएमा ध्वनि संकेत गर्ने कि ?"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "ढिला कुञ्जीहरू"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "कि थिचिनु र स्विकार गर्नुको बिचमा ढिलाई राख्छ"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "छोटो"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "ढिलो कुञ्जी टाइपिङ ढिलाइ"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "लामो"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "कुञ्जी थिचिँदा बिप गर्नुहोस्"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "कुञ्जी भएको बेला बीप गर्नुहोस्"
+
+#: panels/universal-access/cc-typing-dialog.ui:180 panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "यदि कुञ्जी अस्वीकृत हुन्छ भने बिप गर्नुहोस्"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "बाउन्स कुञ्जीहरू"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "यसभित्र नक्कल कुञ्जी थिचाइहरूलाई उपेक्षा गर्नुहोस्"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "छोटो"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "बाउन्स कुञ्जी टाइपिङ ढिलाइ"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "लामो"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "कुञ्जीपाटी सक्षम पार्नुहोस्"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "किबोर्ड प्रयोग गरेर पहुँच विकल्प बन्द र खुला गर्ने"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "पुर्वनिर्धारित"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "ठूलो"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "अझ ठूलो"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "सबै भन्दा ठूलो"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d पिक्सेल"
+msgstr[1] "%d पिक्सेलहरू"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "सधै पहुँचता मेनु देखाउनुहोस्"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "हेरिदै"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "उच्च व्यतिरेक"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "ठूलो पाठ शैली"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "एनिमेसन सक्षम पार्नुहोस्"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "दृष्टि वाचक"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "पर्दाबाचक ले देखाईएको पाठ पढ्न सक्छ"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "ध्वनि: कुञ्जि"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "नम लक वा क्याप्स लक सुरु वा बन्द हुँदा बीप गर्नुहोस् ।."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "कर्सर साइज"
+
+#: panels/universal-access/cc-ua-panel.ui:116 panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "जूम गर्नुहोस्"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "सुन्दै"
+
+#: panels/universal-access/cc-ua-panel.ui:141 panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "दृश्यात्मक सावधानि"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "कुञ्जिपाटी"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "कुञ्जीहरू दोहोर्याउनुहोस्"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "झिम्किरहेको कर्सर"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "टाइप सहयोगि(AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "पोइन्टिङ्ग र क्लिकिङ्ग"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "माउस कुञ्जीहरू"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "सूचक फेलापार्नुहोस्"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "क्लिक सहयोगि"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "दोहोरोक्लिक ढिलाई"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "दोहोरोक्लिक ढिलाई"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "दृश्यात्मक सावधानि"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "फ्ल्यास परीक्षण गर्नुहोस्"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "सावधानि ध्वनि आउँदा दृश्यात्मक सुचक प्रयोग गर्नुहोस"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "सम्पूर्ण पर्दा फ्ल्यास गर्ने"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "पूरा सञ्झ्याल फ्ल्यास गर्नुहोस्"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "छोटो"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ पर्दा"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ पर्दा"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ पर्दा"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "लामो"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "पूरा पर्दा"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "माथिल्लो आधा"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "तल्लो आधा"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "आधाबांया"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "दाहिने आधा"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "जूम वि"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "अभिवर्द्धन:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "अभिवर्धक स्थान:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "माउस कर्सर पछ्याउनुहोस्"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "पर्दा:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "अभिवर्धक पर्दा बाहिर विस्तार गर्दछ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "अभिवर्धक कर्सर केन्द्रित राख्नुहोस्"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "अभिवर्धक कर्सरले विषयवस्तु वरिपरि धकेल्छ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "सामग्रीसँग अभिवर्धक कर्सर सर्छ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "अभिवर्धक"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "प्रतिच्छेदनहरू (crosshairs):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "माउस कर्सर खप्टिन्छ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "मोटोई:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "मसिनो"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "बाक्लो"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "लम्बाइ:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "रङ्ग:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "प्रतिच्छेदनहरू (crosshairs)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "रङ्ग प्रभाव:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "कालोमा सेतोमा:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "चम्किलोपन:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "व्यतिरेक:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "रङ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "कुनै पनि होइन"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "पूरा"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "न्यून"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "उच्च"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "न्यून"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "उच्च"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "रङ्ग प्रभाव"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "हर्न, सुन्न, टाईप, देखाउन र क्लिक गर्न सहज बनाउनुहोस्"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;Zoom;Screen;Reader;big;"
+"high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Speed;Assist;"
+"Repeat;Blink;visual;hearing;audio;typing;animations;"
+msgstr ""
+"कुञ्जीपाटी; माउस;a11y; पहुँचयोग्य; विश्वव्यापी पहुँच; व्यतिरेक; कर्सर; ध्वनि बजाउनुहोस्; जुम गर्नुहोस्; पर्दा;पाठक;"
+"ठूलो;उच्च;ठूलो;पाठ;फन्ट;साइज; पहुँच X; टाँसिने; कुञ्जीहरू; ढिलो; उफ्रिने; माउस;डबल;क्लिक;विलम्ब; गति; सहयोग "
+"गर्नुहोस्; दोहोर्याउनुहोस्; झिम्काउने;दृश्य;श्रवण;अडियो;टाइपिङ;एनिमेसन;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "१ घन्टा"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "१ दिन"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "२ दिन"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "३ दिन"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "४ दिन"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "५ दिन"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "६ दिन"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "७ दिन"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "१४ दिन"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "३० दिन"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "रद्दीटोकरीमा भएका सबै वस्तुहरू मेट्नुहोस्"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "रद्दीटोकरीमा भएका सबै वस्तुहरू मेट्नुहोस्."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "रद्दीटोकरी रित्याउनुहोस्"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "सबै अस्थाई फाइलहरू मेट्नुहोस्?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "सबै अस्थायी फाइलहरू स्थायी रूपले मेटिनेछ ।"
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "अस्थाई फाइलहरू मेट्नुहोस्"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "१ दिन"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "७ दिन"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "३० दिन"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "सधै"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "फाइल इतिहास"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is shared between "
+"applications, and makes it easier to find files that you might want to use."
+msgstr ""
+"फाइल इतिहासले तपाईँले प्रयोग गरेको फाइलको रेकर्ड राख्दछ । यो सूचना अनुप्रयोगको बीचमा साझेदार गरिएको छ, र "
+"तपाईँले प्रयोग गर्न चाहेको फाइल फेला पार्न सजिलो बनाउँदछ ।"
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "फाइल इतिहास"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "फाइल इतिहास अवधी"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "इतिहास खाली गर्नुहोस्…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "रद्दीटोकरी र अस्थायी फाइल"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive information. Automatically "
+"deleting them can help to protect privacy."
+msgstr ""
+"रद्दीटोकरी र अस्थायी फाइलले कहिलेकाहीं व्यक्तिगत वा संवेदनशील जानकारी समावेश गर्न सक्छ । तिनीहरूलाई स्वचालित "
+"रूपमा मेट्दा गोपनीयताको सुरक्षा गर्न मद्दत मिल्छ ।"
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "रद्दीटोकरी सामग्री स्वत: मेट्नुहोस्"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "स्वत: अस्थाई फाइलहरू मेट्नुहोस्"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "स्वत: मेट्ने अवधि"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "रद्दीटोकरी खाली गर्नुहोस्…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "अस्थाई फाइलहरू मेट्नुहोस्…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "फाइल इतिहास र रद्दीटोकरी"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "चिन्ह हरू नछोड्नुहोस्"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr "प्रयोग;हालैको;इतिहास;फाइलहरू;अस्थायी;tmp;निजी;गोपनीयता;रद्दी टोकरी;शुद्धिकरण;कायम राख्नुहोस्;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "तपाईँको लगइन प्रदायकको वेब ठेगानासँग मिल्नुपर्छ ।"
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "खाता थप्न असफल"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679 panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "पासवर्ड मिलेन"
+
+#: panels/user-accounts/cc-add-user-dialog.c:883 panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "खाता दर्ता गर्न असफल"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "यो डोमेनसँग प्रमाणीकरण गर्ने कुनै समर्थित तरिका छैन"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "डोमेन जडान गर्न असफल"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr "लगईन नाम मिलेन : पुन प्रयास गर्नुस ।"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr "लगईन पासवर्ड मिलेन : पुन प्रयास गर्नुस।. "
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "डोमेन लगईन असफल"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "डोमेन फेला पार्न अक्षम । सायद तपाईँले गलत हिज्जे गर्नुभएको छ?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15 panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "प्रयोगकर्ता थप्नुहोस्"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "प्रशासक"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+#, fuzzy
+#| msgid "Administrators can add and remove other users, and can change settings for all users."
+msgid ""
+"Administrators can add and remove other users, and can change settings for all users. Parental "
+"controls cannot be applied to administrators."
+msgstr "प्रशासकले अन्य प्रयोगकर्ताहरू थप्न र हटाउन सक्दछ, र सबै प्रयोगकर्ताका लागि सेटिङहरू परिवर्तन गर्न सक्दछ ।"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "प्रयोगकर्तालाई अर्को लगइनमा आफ्नो पासवर्ड राख्न अनुमति दिनुहोस्"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "अहिले पासवर्ड सेट गर्नुहोस्"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "पुष्टि गर्नुहोस्"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "इन्टरप्राइज लगइन"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+#, fuzzy
+#| msgid "User accounts which are managed by a company or organisation."
+msgid "User accounts which are managed by a company or organization."
+msgstr "प्रयोगकर्ता खाता जुन कुनै कम्पनी वा संस्थाद्वारा व्यवस्थापन गरिन्छ।"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "अफलाइन छ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be used on this device. You "
+"can also use this account to access company resources on the internet."
+msgstr ""
+"उद्यम लगइनले एउटा अवस्थित केन्द्रिय रूपमा प्रबन्धित प्रयोगकर्ता खातालाई यो यन्त्रमा प्रयोग गर्न अनुमति दिन्छ । "
+"तपाईं यो खाता पनि इन्टरनेट मा कम्पनी स्रोतहरू पहुँच गर्न प्रयोग गर्न सक्नुहुन्छ।"
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "अरु छविकोलागि ब्राउज गर्नुहोस्"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "एउटा फाइल चयन गर्नुहोस्…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "अंगुठाछाप प्रबन्धक"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "औठाछाप"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "होइन"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "हो"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
+msgstr "औठाछाप लगइन अक्षम पारिएको हुनाले तपाईँले दर्ता भएका औठाछापहरू मेट्न चाहनुहुन्छ?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "अंगुठाछाप उपकरण छैन"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "अंगुठाछाप उपकरण छैन"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "यन्त्र राम्रोसँग जडान गरिएको छ भन्ने निश्चित गर्नुहोस् ।"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "अंगुठाछाप उपकरण"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "तपाईँले कन्फिगर गर्न चाहनुभएको औठाछाप यन्त्र रोज्नुहोस्"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "अंगुठाछाप लगइन"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid "Fingerprint login allows you to unlock and log into your computer with your finger"
+msgstr "औठाछाप लगइनले तपाईँलाई आफ्नो औँलाले तपाईँको कम्प्युटरमा ताल्चा खोल्न र लग गर्न अनुमति दिन्छ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "अंगुठाछाप मेट्नुहोस्"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "अंगुठाछाप दर्ता गर्नुहोस्"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "यन्त्रले यो कार्य सम्पादन गर्न दावी गर्नु पर्दछ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "यन्त्र पहिल्यै अर्को प्रक्रियाद्वारा दावा गरिएको छ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "तपाईँलाई कार्य सम्पादन गर्न अनुमति छैन ।"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "कुनै मुद्रण दर्ता भएको छैन"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "नामाकरण गर्दा यन्त्रसँग सञ्चार गर्न असफल भयो"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "औठाछाप वाचकसँग सञ्चार गर्न असफल भयो"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "औठाछाप डेइमोनसँग सञ्चार गर्न असफल"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "औठाछापहरू सूचीबद्ध गर्न असफल भयो: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "बचत गरिएका औठाछापहरू मेट्न असफल भयो: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "बायाँ बुढीऔँला"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Left middle finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "बायाँ चोर औँला"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "बायाँ साहिँली औँला"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "बायाँ कान्छी औँला"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "दायाँ बुढी औँला"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "दायाँ माझी औँला"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "दाहिने चोर औँला"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "दायाँ साहिँली औँला"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "दायाँ कान्छी औँला"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "अज्ञात अंगुठाछाप"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "पुरा गर्नुहोस्"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "अंगुठाछाप उपकरण छुटाइएको छ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "औठाछाप यन्त्र भण्डारण भरिएको छ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "नया अंगुठाछाप दर्ता गर्न असफल"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "दर्ता सेवा शुरु असफल भयो:%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "नया अंगुठाछाप दर्ता गर्न असफल"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "दर्ता सेवा रोक्न असफल भयो:%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid "Repeatedly lift and place your finger on the reader to enroll your fingerprint"
+msgstr "बारम्बार उचालेर आफ्नो औँठाछाप भर्ना गर्न पाठकलाई आफ्नो औँला राख्नुहोस्"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "अंगुठा पुन दर्ता गर्नुहोस्…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "नया अंगुठाछाप स्क्यान गर्नुहोस्"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "%s औठाछाप यन्त्र निस्काशन गर्न असफल भयो: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "यन्त्र पढ्न समस्या"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "%s औठाछाप यन्त्र दावी गर्न असफल भयो: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "औठाछाप यन्त्र प्राप्त गर्न असफल भयो: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "यो हप्ता"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "गएको हप्ता"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179 panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182 panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "सेसन बन्द गरियो"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "सेसन सुरु गरियो"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — खाता क्रियाकलाप"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "अघिल्लो"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "पछिल्लो"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "कृपया अर्को पासवर्ड रोज्नुहोस् ।"
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "कृपया तपाईँको हालको पासवर्ड फेरि प्रविष्टि गर्नुहोस् ।"
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "पासवर्ड परिवर्तन गर्न सकिएन"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "पासवर्ड परिवर्तन गर्नुहोस्"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "परिवर्तन"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "हालको पासवर्ड "
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "नयाँ पासवर्ड"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "पासवर्ड यकीन गर्नुहोस्"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "प्रयोगकर्तालाई अर्को लगइनमा आफ्नो पासवर्ड परिवर्तन गर्न अनुमति दिनुहोस्"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "पासवर्ड सेट गर्नुहोस्"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "यस प्रकारको डोमेन स्वचालित रूपमा जडान गर्न सकिँदैन"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "डोमेन वा रियालम नाम भेटिएन"
+
+#: panels/user-accounts/cc-realm-manager.c:712 panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "तपाईँ %s डोमेन %s पहुँच गर्न लगइन हुनुपर्दछ"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "अवैध पासवर्ड, पुन: प्रयास गर्नुहोस्"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "%s डोमेनमा जडान गर्न सकेन: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "प्रयोगकर्ता मेट्न असफल"
+
+#: panels/user-accounts/cc-user-panel.c:413 panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "टाढाबाट प्रबन्ध गरिएको प्रयोगकर्ता लाई खारेज गर्न असफल भयो"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "तपाईँले आफ्नो खाता आफैं मेट्न सक्नुहुन्न ।"
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s अझै लगईन छ"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid "Deleting a user while they are logged in can leave the system in an inconsistent state."
+msgstr "तिनीहरू लगइन भएको बेलामा प्रयोगकर्ता मेट्दा प्रणालीलाई असङ्गत अवस्थामा छोड्न सक्छ ।"
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "के तपाई %s को फाईलहरु राख्न चाहानुहुन्छ?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files around when deleting a "
+"user account."
+msgstr "प्रयोगकर्ता खाता मेट्दा गृह डाइरेक्टरी, मेल स्पूल र अस्थायी फाइलहरू वरिपरि राख्न सम्भव छ ।"
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "फाइलहरू मेट्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "फाइलहरू राख्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "तपाईँ टाढाबाट प्रबन्ध गरिएको %s खाता हटाउन निश्चित हुनुहुन्छ?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "मेट्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "खाता अक्षम पारिएको"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "अर्को लगइनमा सेट गर्ने"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "कुनै पनि होइन"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "लगईन गरियो"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "खाता सेवा जडान असफल"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "कृपया खाता सेवा स्थापना र सक्षम पारिएको निश्चित गर्नुहोस् ।"
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "यो सेटिङ परिवर्तन गर्न यो प्यानलको ताल्चा खोलिनुपर्छ"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "चयन गरेको प्रयोगकर्ता खाता मेट्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.c:1297 panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"चयन गरिएको प्रयोगकर्ता खाता मेट्न,\n"
+"पहिला * प्रतिमा क्लिक गर्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "प्रयोगकर्ता थप्न र सेटिङ परिवर्तन गर्न ताल्चा खोल्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "प्रयोगकर्ता"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "परिवर्तन प्रभाव लिनका लागि तपाईँको सत्र पुन: सुरुआत गर्नु आवश्यक छ"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "फेरि सुरु गर्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "बन्द गर्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "अवतार प्रतिमा सम्पादन गर्नुहोस्"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "पूरा नाम"
+
+#: panels/user-accounts/cc-user-panel.ui:171 panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "सम्पादन गर्नुहोस्"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "लगइन अंगुठाछाप"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "स्वतः लगईन"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "खाता क्रियाकलाप"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "प्रशासक"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid "Administrators can add and remove other users, and can change settings for all users."
+msgstr "प्रशासकले अन्य प्रयोगकर्ताहरू थप्न र हटाउन सक्दछ, र सबै प्रयोगकर्ताका लागि सेटिङहरू परिवर्तन गर्न सक्दछ ।"
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "प्यारेन्टल नियन्त्रण"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "प्यारेन्टल नियन्त्रण अनुप्रयोग खोल्नुहोस् ।"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "प्रयोगकर्ता हटाउनुस्…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "अन्य प्रयोगकर्ता"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "प्रयोगकर्ता थप्नुहोस्..."
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "प्रयोगकर्ता भेटिएन"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "प्रयोगकर्ता खाता थप्नका लागि ताल्चा खोल्नुहोस् ।."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "प्रयोगकर्ता थप्नुहोस् वा हटाउनुहोस् र तपाईँको पासवर्ड परिवर्तन गर्नुहोस्"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen Time;App Restrictions;"
+"Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"लगइन;नाम:औठाछाप;अवतार;लोगो;मोहडा;पासवर्ड;आमाबाबुको नियन्त्रण;पर्दा समय;अनुप्रयोग प्रतिबन्ध;वेब प्रतिबन्ध;"
+"उपयोग;प्रयोग दायरा;बच्चा;बच्चा;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "दर्ता"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "डोमेन प्रशासक लगइन"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"उद्यम लगइन प्रयोग गर्न, यो कम्प्युटर हुन आवश्यक छ\n"
+"डोमेनमा भर्ना गरिएको । कृपया तपाईँको सञ्जाल प्रशासक हुनुहोस् ।\n"
+"तिनीहरूको डोमेन पासवर्ड यहाँ टाइप गर्नुहोस् ।"
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "प्रशासक नाम"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "प्रशासक पासवर्ड"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "प्रयोगकर्ता खाताहरू प्रवन्ध गर्नुहोस्"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "प्रयोगकर्ता डाटा परिवर्तन गर्न प्रमाणीकरण चाहिन्छ"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "नया पासवर्ड पुरानो भन्दा फरक हुनु पर्छ ।"
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "केहि संख्या र अक्षर परिवर्तन गरि प्रयास गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "अलि धेरै पटक पासवर्ड परिवर्तन गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "तपाईँको प्रयोगकर्ता नाम बिनाको पासवर्ड अझ बलियो हुनेछ ।"
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "पासवर्डमा तपाईँको नाम प्रयोग नगर्न प्रयास गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "पासवर्डमा समावेश गरिएका केही शब्दबाट बच्ने प्रयास गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "सामान्य शब्द नबोली बस्नुहोस्।"
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "हालको शब्द पुन: क्रमबद्ध गर्नबाट रोक्न प्रयास गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "वढि अंक प्रयोग गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "वढि अक्षर  प्रयोग गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "वढि अक्षर  प्रयोग गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "विराम चिन्ह जस्तै, धेरै विशेष वर्ण प्रयोग गर्ने प्रयास गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "अक्षर, सङ्ख्या र विराम चिन्हको मिश्रण प्रयोग गर्ने प्रयास गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "उही क्यारेक्टर दोहोर्याउनबाट रोक्न प्रयास गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up letters, numbers and "
+"punctuation."
+msgstr ""
+"उही प्रकारको क्यारेक्टर दोहोर्याउनबाट रोक्न प्रयास गर्नुहोस्: तपाईँले अक्षर, सङ्ख्या र विराम चिन्ह मिश्रण गर्नु "
+"आवश्यक छ ।"
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "१२३४ वा abcd जस्ता क्रमबाट बच्ने प्रयास गर्नुहोस् ।"
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid "Password needs to be longer. Try to add more letters, numbers and punctuation."
+msgstr "पासवर्ड लामो हुनु आवश्यक छ । धेरै अक्षर, सङ्ख्याहरू र विराम चिन्ह हरू थप्न प्रयास गर्नुहोस्।"
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "ठूलो वर्ण र सानो केस मिसाउनुहोस् र एक वा दुई नम्बर प्रयोग गर्न प्रयास गर्नुहोस्।"
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid "Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "धेरै अक्षर, सङ्ख्या र विराम चिन्ह थप्दा पासवर्ड बलियो हुन्छ ।."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "प्रमाणीकरण असफल भयो"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "नयाँ पासवर्ड अति छोटो छ"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "नयाँ पासवर्ड धेरै सहज छ"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "पुरानो र नयाँ पासवर्डहरू धेरै उस्तै छन् "
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "पासवर्ड पहिला नै प्रयोग गरिएको छ । अन्य पासवर्ड रोज्नुहोस् ।"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "नयाँ पासवर्डले सङ्ख्यात्मक वा विशेष क्यारेक्टर(हरू) समाविष्ट गर्नुपर्दछ"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "पुरानो र नयाँ पासवर्डहरू एउटै छन्"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "तपाईँले सुरुमा प्रमाणीकरण गरे पछि तपाईँको पासवर्ड परिवर्तन गरिएको छ!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "नयाँ पासवर्डले सङ्ख्यात्मक वा विशेष क्यारेक्टर(हरू) समाविष्ट गर्नु"
+
+#: panels/user-accounts/run-passwd.c:514 panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "अज्ञात त्रुटि"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, digits and the following "
+"characters: - _"
+msgstr "प्रयोगकर्ता नाममा साधारणतया a-z, अङ्क र निम्न क्यारेक्टरहरूको लोअर केस अक्षरहरू मात्र हुनुपर्दछ: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "माफ गर्नुहोस्, त्यो प्रयोगकर्ता नाम उपलब्ध छैन । कृपया अर्को प्रयास गर्नुहोस् ।"
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "प्रयोगकर्ता नाम धेरै लामो भयो ।"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "बटनहरू म्याप गर्नुहोस्"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "बटनहरू क्रियामा मापन गर्नुहोस्"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard shortcut button and "
+"hold down the new keys or press Backspace to clear."
+msgstr ""
+"सर्टकट सम्पादन गर्न, \"कुञ्जीस्ट्रोक पठाउनुहोस्\" कार्य रोज्नुहोस्, कुञ्जीपाटी सर्टकट बटन थिच्नुहोस् र नयाँ कुञ्जीहरू "
+"होल्ड गर्नुहोस् वा खाली गर्न ब्याकस्पेस थिच्नुहोस् ।"
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "बन्द गर्नुहोस्"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid "Please tap the target markers as they appear on screen to calibrate the tablet."
+msgstr "कृपया ट्याब्लेट क्यालिब्रेट गर्न तिनीहरू पर्दामा देखा परे जस्तै लक्षित मार्करहरू ट्याप गर्नुहोस् ।"
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "गलत-क्लिक पत्ता लाग्यो, फेरि सुरु गर्दैछ…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "बटन %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "अनुप्रयोग परिभाषित छ"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "कुञ्जी स्ट्रोक पठाउनुस्"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "मोनिटर बदल्नुहोस् "
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "सिहर्स मद्दत देखाउनुहोस्"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "ल्यापटप प्यानलमा माउन्ट गरिएको ट्याबलेट"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "बाह्य प्रदर्शनमा माउन्ट गरिएको ट्याबलेट"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "बाह्य ट्याबलेट यन्त्र"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "बाहिरी प्याड यन्त्र"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "सबै प्रदर्शन"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "ट्याबलेट शैली"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "कलमका लागि निश्चित स्थिति प्रयोग गर्नुहोस्"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "बाया अभिमुखीकरण"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "बायाँ हाते प्रयोगका लागि ट्याबलेट र एक्सप्रेस कुञ्जी™ घुमाइएको छ"
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+#| msgid "Map to Monitor…"
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "मोनिटर म्याप गर्नुहोस्…"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "साइज औसत राख्नुहोस्"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "मोनिटर आकार अनुपात राख्न मात्र ट्याबलेट सतहको भाग प्रयोग गर्नुहोस्"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "क्यालिब्रेट"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "ट्याबलेट फेला परेन"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "कृपया वाक्म ट्याबलेट जोडनु या सुचारू गर्नुहोस"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "टुप्पोमा  दबाव महसूस"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21 panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "नरम"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "स्टाइलस टुप्पोमा चाप"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41 panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firm"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "बटन १"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "बटन २"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "बटन ३"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "मेट्ने दबाव महसूस"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+#| msgid "Eraser Pressure Feel"
+msgid "Eraser pressure"
+msgstr "मेट्ने दबाव महसूस"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "बिच बटनमा क्लिक गर्नुहोस्"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "दाया बटनमा क्लिक गर्नुहोस्"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "अगाडि"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "चाप, झुकाव, र एकीकृत स्लाइडरसँग एयरब्रश स्टाइलस"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "चाप, झुकाव, र परिक्रमणसँग एयरब्रस स्टाइलस"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "चाप र झुकाव सहित मानक स्टायलस"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "चाप सहित मानक स्टायलस"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "वाक्म ट्याबलेट"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "बटन मानचित्र सेट गर्नुहोस् र ग्राफिक्स ट्याबलेटका लागि स्टाइलस संवेदनशीलता समायोजन गर्नुहोस्"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "ट्याबलेट;वाक्म;स्टाईलस्;ईरेजर;माउस;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "नयाँ शर्टकर्ट…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "पहुँच बिन्दुहरु"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "सञ्चालन रद्द गरियो"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>त्रुटि:</b>सेटिङ हरू परिवर्तन गर्न अस्वीकार गर्यो"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>त्रुटि:</b> मोबाइल यन्त्र त्रुटि"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "दर्ता गरिएको छैन"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "दर्ता"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "रोमिङ"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "खोजी गर्दै"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "अस्वीकार गरियो"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "मोडेम विवरण"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "मोडेम स्थिति"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "बाहक"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "सञ्जाल प्रकार"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "सञ्जाल वस्तुस्थिति"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "आफ्नै नम्बर"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "यन्त्र विवरण"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "फर्मवेयर संस्करण"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "२जि मात्र"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "३जी मात्र"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "४जी मात्र"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "५जी मात्र"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "२जी, ३जी, ४जी,५जी (रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "२जी, ३जी, ४जी (रुचाइएको),५जी"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "२जी, ३जी (रुचाइएको), ४जी,५जी"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "२जी (रुचाइएको), ३जी, ४जी,५जी"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "२जि, ३जि, ४जी,५जी"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "२जी, ३जी, ४जी (रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "२जी, ३जी (रुचाइएको), ४जी "
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "२जी  (रुचाइएको), ३जी, ४जी "
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "२जि, ३जि, ४जी"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "३जी, ४जी ,५जी(रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "३जी, ४जी (रुचाइएको),५जी"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "३जी (रुचाइएको), ४जी,५जी"
+
+#: panels/wwan/cc-wwan-device.c:1041
+#| msgid "3G, 4G"
+msgid "3G, 4G, 5G"
+msgstr "३जी, ४जी, ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "२जी, ४जी, ५जी (रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "२जी, ४जी (रुचाइएको), ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "२जी (रुचाइएको), ४जी,५जी"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "२जि, ४जी,५जी"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "२जी, ३जी, ५जी (रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "२जी, ३जी (रुचाइएको), ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "२जी (रुचाइएको), ३जी, ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "२जी, ३जी, ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "३जी, ४जी (रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "३जी (रुचाइएको), ४जी"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "३जि, ४जी"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "२जी, ४जी (रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "२जी (रुचाइएको), ४जी "
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "२जी, ४जी"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "२जी, ३जी (रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "२जी (रुचाइएको), ३जी (रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "२जि, ३जि"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "२जी, ५जी (रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "२जी (रुचाइएको), ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "२जी, ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "३जी, ५जी(प्राथमिकता)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "३जी (प्राथमिकता), ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "३जी, ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "४जी ,५जी(रुचाइएको)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "४जी (रुचाइएको), ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "४जी, ५जी"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "अज्ञात"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "सिम कार्डको ताल्चा खोल्नुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "ताल्चा खोल्नुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "%d सिमका लागि कृपया पिन कोड उपलब्ध गराउनुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "तपाईँको सिम कार्डअनलक गर्न पिन प्रविष्ट गर्नुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "%d सिमका लागि कृपया PUK कोड उपलब्ध गराउनुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "तपाईँको सिम कार्ड अनलक गर्न PUK प्रविष्ट गर्नुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "गलत पासवर्ड प्रविष्ट भयो । तपाईँसँग %1$u प्रयास बाँकी छ"
+msgstr[1] "गलत पासवर्ड प्रविष्ट भयो । तपाईँसँग %1$u प्रयास बाँकी छ"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "तपाईँसँग %u प्रयास बाँकी छ"
+msgstr[1] "तपाईँसँग %u प्रयास बाँकी छ"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "गलत पासवर्ड प्रविष्ट भयो ।"
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK कोड ८ अङ्क नम्बर हुनुपर्दछ"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "नयाँ पिन प्रविष्ट गर्नुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "पिन कोड ४-८ अङ्क नम्बर को हुनुपर्छ"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "ताल्चा खोलिदै…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "सिमकार्ड राखिएको छैन"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "यो मोडेम प्रयोग गर्न सिम कार्ड घुसाउनुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "सिमकार्ड ताल्चा लगाइयो"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "मोबाइल डेटा"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "मोबाइल सञ्जाल प्रयोग गरेर डेटा पहुँच गर्नुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "डेटा रोमिङ"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "रोमिङ गर्दा मोबाइल डेटा प्रयोग गर्नुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "सञ्जाल शैली"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "सञ्जाल"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "उन्नत"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "पहुँच बिन्दु नामहरू"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "सिमकार्ड ताल्चा"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "पिनसँग सिम कार्ड ताल्चा लगाउनुहोस्"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "मोडेम विवरण"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "फोन असफलता"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "फोनमा जडान छैन"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "सञ्चालन अनुमति छैन"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "सञ्चालन समर्थित छैन"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "सिमकार्ड राखिएको छैन"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "सिमको पिन आवश्यक"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "सिमको PUK आवश्यक"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "सिम असफलता"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "सिमकार्ड व्यस्त"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "पासवर्ड गलत थियो"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "सिमको पिन२ आवश्यक"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "सिमको PUK२ आवश्यक"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "फेला परेन"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "सञ्जाल सेवा छैन"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "सञ्जाल समय समाप्ति"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS सेवालाई अनुमति छैन"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "यो स्थान क्षेत्रमा रोमिङ गर्न अनुमति छैन"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "निर्दिष्ट नगरिएको GPRS त्रुटि"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "त्रुटि छैन"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "कार्य रद्द गरियो"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "पहुँच अस्वीकृत भयो"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "अज्ञात त्रुटि"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "सञ्जाल शैली"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "स्वचालित"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "सञ्जाल छान्नुहोस्"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "सञ्जाल प्रदायकहरू ताजा पार्नुहोस्"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "सिमकार्ड %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "मोबाइल सञ्जाल सक्षम पार्नुहोस्"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "कुनै WWAN एडप्टर फेला परेन"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "तपाईँसँग ताररहित वान/सेलुलर यन्त्र छ भन्ने निश्चित गर्नुहोस्"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "हवाईजहाज मोडमा हुँदा ताररहित वान असक्षम हुन्छ"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "हवाइजहाज शैली बन्द गर्नुहोस्"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "डेटा जडान"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "इन्टरनेटका लागि सिम कार्ड प्रयोग गरियो"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "सिमकार्ड ताल्चा"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "पछिल्लो"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "पिनसँग सिम कार्ड ताल्चा लगाउनुहोस्"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "पिन कोड परिवर्तन गर्नुहोस्"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "सिम ताल्चा सेटिङ परिवर्तन गर्न हालको पिन प्रविष्ट गर्नुहोस्"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "मोबाइल सञ्जाल"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "टेलिफोनी र मोबाइल डेटा जडान कन्फिगर गर्नुहोस्"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "सेलुलर;wwan;टेलिफोनी;सिम;मोबाइल;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "जिनोम डेस्कटप कन्फिगर गर्ने युटिलिटी"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "तपाईँको प्रणाली कन्फिगर गर्नका लागि सेटिङ प्राथमिक इन्टरफेस हो ।"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "जिनोम परियोजना"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "संस्करण प्रदर्शन गर्नुहोस्"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "भर्बोज निर्गत सक्षम पार्नुहोस्"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "स्ट्रिङको खोजी गर्नुहोस्"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "सम्भावित प्यानल नामहरू सूचीबद्ध गर्नुहोस् र निस्कनुहोस्"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "प्रदर्शन गर्न प्यानल"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "वर्गहरु:"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "गोपनीयता"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "उपलब्ध प्यानलहरू:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "सबै सेटिङ"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "मुख्य मेनु"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "चेतावनी: विकास संस्करण"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You may experience "
+"incorrect system behavior, data loss, and other unexpected issues. "
+msgstr ""
+"सेटिङको यो संस्करण विकास उद्देश्यका लागि मात्र प्रयोग गरिएको हुनुपर्दछ । तपाईँले गलत प्रणाली व्यवहार, डेटा ह्रास, "
+"र अन्य अनपेक्षित समस्या अनुभव गर्न सक्नुहुन्छ । "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "मद्दत"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "साधारण"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "अन्त्य गर्नुहोस्"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "खोजी गर्नुहोस्"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "प्यानल"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "अघिल्लो प्यानलमा फर्कनुहोस्"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "खोजी रद्द गर्नुहोस्"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "प्राथमिकता;सेटिङ;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "खोलिने अन्तिम सेटिङ प्यानलका लागि पहिचायक"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values will be ignored and "
+"the first panel in the list selected."
+msgstr ""
+"खोलिने अन्तिम सेटिङ प्यानलका लागि पहिचायक । अज्ञात मानहरू उपेक्षा गरिनेछ र सूचीमा पहिलो प्यानल चयन गरिएको "
+"हुनेछ ।"
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "सेटिङको विकास निर्माण चलाउदा चेतावनी देखाउनुहोस्"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid "Whether Settings should show a warning when running a development build."
+msgstr "विकास निर्माण चलाउदा सेटिङले चेतावनी देखाउनु पर्दछ या पर्दैन ।"
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "सञ्झ्यालको सुरुआत स्थिति"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid "A tuple containing the initial width, height and maximized state of the application window."
+msgstr "अनुप्रयोग सञ्झ्यालको सुरु चौडाइ, उचाइ र अधिकतम स्थिति समाविष्ट टुपल ।"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u निर्गत"
+msgstr[1] "%u निर्गत"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u आगत"
+msgstr[1] "%u आगत"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "प्रणाली ध्वनिहरू"
+
+#~ msgid "Light"
+#~ msgstr "हल्का"
+
+#~ msgid "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;"
+#~ msgstr "पर्दा;ताल्चा;निदान;क्र्यास;निजी;हालैको;अस्थायी;tmp;index;नाम;सञ्जाल;पहिचान;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "प्रदर्शन व्यवस्था"
+
+#~ msgid "Set"
+#~ msgstr "सेट गर्नुहोस्"
+
+#~ msgid "Lock your screen"
+#~ msgstr "पर्दा ताल्चा लगाउनुहोस्"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER वा PEM प्रमाणपत्र (*. der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "नयाँ मुद्रक थप्नुहोस्…"
+
+#~ msgid "Bark"
+#~ msgstr "Bark"
+
+#~ msgid "Drip"
+#~ msgstr "द्रिप"
+
+#~ msgid "Glass"
+#~ msgstr "ग्लास"
+
+#~ msgid "Sonar"
+#~ msgstr "सोनार"
+
+#~ msgid "Web Links"
+#~ msgstr "वेब लिङ्क"
+
+#~ msgid "Git Links"
+#~ msgstr "GIT लिङ्कहरू"
+
+#~ msgid "%s Links"
+#~ msgstr "%s लिङ्कहरू"
+
+#~ msgid "Unset"
+#~ msgstr "सेट नगर्नुहोस्"
+
+#~ msgid "Links"
+#~ msgstr "लिङ्कहरू"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "हाइपरटेक्स्ट फाइलहरू"
+
+#~ msgid "Text Files"
+#~ msgstr "पाठ फाइलहरू"
+
+#~ msgid "Image Files"
+#~ msgstr "छवि फाइल"
+
+#~ msgid "Font Files"
+#~ msgstr "फन्ट फाइलहरू"
+
+#~ msgid "Archive Files"
+#~ msgstr "संग्रह फाइलहरू"
+
+#~ msgid "Package Files"
+#~ msgstr "प्याकेज फाइलहरू"
+
+#~ msgid "Audio Files"
+#~ msgstr "अडियो फाइलहरु"
+
+#~ msgid "Video Files"
+#~ msgstr "भिडियो फाइलहरू"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "अनुमतिहरू र पहुँचहरू"
+
+#~ msgid "Data and services that this app has asked for access to and permissions that it requires."
+#~ msgstr "यो अनुप्रयोगले आवश्यक पर्ने पहुँच र अनुमतिमागेको डाटा र सेवाहरू ।"
+
+#~ msgid "Cannot be changed"
+#~ msgstr "परिवर्तित हुन सक्दैनन्"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href=\"privacy\">Privacy</a> "
+#~ "Settings."
+#~ msgstr ""
+#~ "अनुप्रयोगहरूका लागि व्यक्तिगत अनुमतिहरू <a href=\"privacy\">गोपनीयता</a> सेटिङमा पुनरावलोकन गर्न सकिन्छ।"
+
+#~ msgid "Integration"
+#~ msgstr "इन्टिगरेसन"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "डेक्सटप पृष्ठभूमि सेट गर्नुहोस्"
+
+#~ msgid "Default Handlers"
+#~ msgstr "पूर्वनिर्धारित ह्यान्डलर"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "यो अनुप्रयोगले खोल्ने फाइलहरू र लिङ्कका प्रकारहरू ।"
+
+#~ msgid "Usage"
+#~ msgstr "प्रयोग"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "यो अनुप्रयोगले कति संसाधन प्रयोग गरिरहेको छ ।"
+
+#~ msgid "Open in Software"
+#~ msgstr "सफ्टवेयरमा खोल्नुहोस्"
+
+#~ msgid "Activities"
+#~ msgstr "गतिविधिहरू"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "तपाईँको क्यामेरा प्रयोग गर्न तलका अनुप्रयोगहरूलाई अनुमति दिनुहोस् ।."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "%s फाइलअपलोड गर्न असफल"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "प्रोफाइल अपलोड गरियो:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "यस यूआरएललाई लेख्नुहोस् ।"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "कम्प्युटर समान्य प्रणालीमा फेरि सुरु गर्नुहोस् ।"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "प्रोफाईल डाउनलोड र स्थापना गर्न यूआरएल प्रविष्ट गर्नुहोस्।"
+
+#~ msgid "Upload profile"
+#~ msgstr "अपलोड प्रोफाइल"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "इन्टरनेट जडानको आवश्यकता छ"
+
+#~ msgid "_Copy"
+#~ msgstr "प्रतिलिपि बनाउनुहोस्"
+
+#~ msgid "Select _All"
+#~ msgstr "सबै छान्नुहोस्"
+
+#~ msgid "Single Display"
+#~ msgstr "एकल प्रदर्शन"
+
+#~ msgid "Join Displays"
+#~ msgstr "प्रदर्शन जडान गर्नुहोस्"
+
+#~ msgid "Display Mode"
+#~ msgstr "प्रर्दशन मोड"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to change its settings."
+#~ msgstr ""
+#~ "तपाईँको भौतिक प्रदर्शन सेटअप मिलाउन प्रदर्शन तान्नुहोस् । यसको सेटिङ परिवर्तन गर्न प्रदर्शन चयन गर्नुहोस् ।"
+
+#~ msgid "Active Display"
+#~ msgstr "सक्रिय पर्दा"
+
+#~ msgid "More Warm"
+#~ msgstr "अझ न्यानो"
+
+#~ msgid "Less Warm"
+#~ msgstr "कम न्यानो"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "स्क्रिनसट $PICTURESमा बचत गर्नुहोस्"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "सञ्झ्यालको स्क्रिनसट $PICTURES मा बचत गर्नुहोस्"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "कुनै क्षेत्रको स्क्रिनसट $PICTURES मा बचत गर्नुहोस् ।"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "स्क्रीनको तस्बिरलाई क्लिप्बोर्डमा कपी गर्ने"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "विन्डोको तस्बिरलाई क्लिप् बोर्डमा कपी गर्ने"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "स्क्रीन्शोत लाई कपी गर्नुहोस"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "पर्दाको छोटो भिडियो रेकर्ड गर्नुहोस्"
+
+#~ msgid "Move up"
+#~ msgstr "माथि सार्नुहोस्"
+
+#~ msgid "Move down"
+#~ msgstr "तल सार्नुहोस्"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi and mobile broadband "
+#~ "increases accuracy."
+#~ msgstr ""
+#~ "स्थान सेवाहरूले अनुप्रयोगहरूलाई तपाईँको स्थान जान्न अनुमति दिन्छ । वाई-फाई र मोबाइल ब्रडब्यान्ड प्रयोग गर्दा "
+#~ "यथार्थता बढ्छ।"
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla.com/privacy'>Privacy "
+#~ "Policy</a>"
+#~ msgstr ""
+#~ "मोजिला स्थान सेवा प्रयोग गर्दछ: <a href='https://location.services.mozilla.com/privacy'>गोपनीयता "
+#~ "नीति</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "तपाईँको स्थान निर्धारण गर्न तलका अनुप्रयोगहरूलाई अनुमति दिनुहोस् ।."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "तलका अनुप्रयोगहरूलाई तपाईँको माइक्रोफोन प्रयोग गर्न अनुमति दिनुहोस् ।."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "डवल-क्लिक टायमआउट"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s भीपीएन"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "पर्दा चम्किलोपन"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "कुञ्जीपाटी चम्किलोपन"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "निस्क्रिय हुँदा धमिलो पर्दा"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "खाली पर्दा"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "वाई-फाई"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "पावर बचत गर्न वाइफाइ बन्द गर्नुहोस्।."
+
+#~ msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr "पावर बचत गर्न मोबाइल ब्रोडब्यान्ड (एलटीई, 4G, 3 जी,  आदि) बन्द गर्न सक्नुहुन्छ"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "ब्लुटुठ"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "शक्ति बचत गर्न ब्लुटुथ बन्द गर्न सकिन्छ ।"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "निलम्बन र पावर बटन"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "ल्याप पत्ता लाग्यो: कार्यसम्पादन मोड उपलब्ध छैन"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "उच्च हार्डवेयर तापक्रम: कार्यसम्पादन मोड उपलब्ध छैन"
+
+#~ msgid "Balanced Power"
+#~ msgstr "संतुलित पावर"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "प्रमाणीकरण"
+
+#~ msgid "Choose the format for numbers, dates and currencies. Changes take effect on next login."
+#~ msgstr "सङ्ख्या, मिति र मुद्राका लागि ढाँचा रोज्नुहोस् । परिवर्तनले पछिल्लो लगइनमा प्रभाव पार्छ ।."
+
+#~ msgid "Language"
+#~ msgstr "भाषा"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "सञ्झ्याल र वेब पृष्ठमा पाठका लागि प्रयोग गरिने भाषा ।"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "द्ष्व्परिवर्तनहरूले असर गर्न पुन: सुरुआत गर्नुहोस्"
+
+#~ msgid "Restart…"
+#~ msgstr "पु:न सुरु गर्ने…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "प्रणालीमा लगइन गर्दा सबै प्रयोगकर्ताले लगइन सेटिङ प्रयोग गर्छन्"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The order of search results "
+#~ "can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "क्रियाकलाप अवलोकनमा कुन खोजी परिणाम देखाइन्छ नियन्त्रण गर्नुहोस् । सूचीमा पङ्क्तिहरू सार्दा पनि खोजी "
+#~ "परिणामको क्रम परिवर्तन गर्न सकिन्छ ।"
+
+#~ msgid "Screen sharing allows remote users to view or control your screen by connecting to %s"
+#~ msgstr ""
+#~ "पर्दा साझेदारीले टाढाको प्रयोगकर्ताहरूलाई तपाईँको पर्दा %s मा जडान गरेर हेर्न वा नियन्त्रण गर्न अनुमति दिन्छ"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "प्रदर्शनपर्दा साझेदारी"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "सञ्जाल पहुँच नभएकोले केही सेवाहरू अक्षम पारिएको छ ।"
+
+#~ msgid "_Password:"
+#~ msgstr "_पासवर्ड:"
+
+#~ msgid "_Show Password"
+#~ msgstr "पासवर्ड देखाउनुहोस्"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "नयाँ जडानले पहुँच माग्नुपर्छ"
+
+#~ msgid "_Require a password"
+#~ msgstr "पासवर्ड आवश्यक"
+
+#~ msgid "Sound Keys"
+#~ msgstr "ध्वनि: कुञ्जि"
+
+#~ msgid "Screen Reader"
+#~ msgstr "दृष्टि वाचक"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "दृष्टि वाचक"
+
+#~ msgid "Standard"
+#~ msgstr "माणक"
+
+#~ msgid "Account _Type"
+#~ msgstr "खाता: प्रकार"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "प्रयोगकर्ताले पछिल्लो लगइन गर्दा पासवर्ड सेट गर्न अनुमति दिन्छ"
+
+#~ msgid "Set a password _now"
+#~ msgstr "पासवर्ड सेट गर्नुहोस्"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "उद्यम प्रयोगकर्ताहरू थप्नका लागि तपाईँ अनलाइन हुनुपर्दछ ।"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "तस्वीर लिनुहोस …"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "परिवर्तन गर्न,\n"
+#~ "पहिला * प्रतिमा क्लिक गर्नुहोस्"
+
+#~ msgid "Create a user account"
+#~ msgstr "नयाँ प्रयोगकर्ता खाता सिर्जना गर्नुहोस्"
+
+#~ msgid "User Icon"
+#~ msgstr "प्रयोगकर्ता प्रतिमा"
+
+#~ msgid "Account Settings"
+#~ msgstr "खाता सेटिङ्"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "प्रमाणीकरण र लगइन"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "लगइन गर्नुहोस्; नाम: औठाछाप; अवतार; लोगो; मोहडा; पासवर्ड;"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "यो तपाईँको गृह फोल्डर नाम दिन प्रयोग गरिन्छ र परिवर्तन गर्न सकिँदैन ।"
+
+#~ msgid "Output:"
+#~ msgstr "निर्गत:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "आकार अनुपात (पत्रमञ्जूषा) राख्नुहोस्:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "एकल मोनिटर सेट गर्नुहोस्"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d को %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "प्रदर्शन गर्नुहोस्"
+
+#~ msgid "Stylus"
+#~ msgstr "स्टाईलस्"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "ट्याबलेट()"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "ट्चप्याड()"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "ट्याबलेट प्राथमिकता"
+
+#~ msgid "_Help"
+#~ msgstr "मद्दत"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ब्लुटुठ सेटिङ"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ट्रयाकिङ्ग मोड"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "नक्शाको बटनहरु…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "माउस सेटिङ्ग मिलाउने"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "रिजोल्युसन मिलाउने"
+
+#~ msgid "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "कृपया यसलाई कन्फिगर गर्न ट्याबलेटको निकटतामा तपाईँको स्टाइलस सार्नुहोस्"
+
+#~ msgid "Top Button"
+#~ msgstr "माथिल्लो बटन"
+
+#~ msgid "Lower Button"
+#~ msgstr "तल्लो बटन"
+
+#~ msgid "Lowest Button"
+#~ msgstr "सबैभन्दा न्यून बटन"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "ग्नोम सेटिङ"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "कुञ्जीपाटी सर्टकट"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "यो अनुकूल सर्टकटमा परिवर्तन गर्न सकिन्छ"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "विभिन्न क्यारेक्टरहरू प्रविष्ट गर्न तल राख्नुहोस् र टाइप गर्नुहोस्"
+
+#~ msgid "Add…"
+#~ msgstr "थप्नुहोस्…"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "पृष्ठभूमि मिलाउ र पर्दा ताल्चा लगाउ"
+
+#~ msgid "Set Background"
+#~ msgstr "पृष्ठभूमि मिलाउ"
+
+#, fuzzy
+#~| msgid "_Lock Screen"
+#~ msgid "Set Lock Screen"
+#~ msgstr "पृष्ठभूमि मिलाउ र पर्दा ताल्चा लगाउ"
+
+#~ msgid "Remove Background"
+#~ msgstr "पृष्ठभूमि हताउ"
+
+#~ msgid "∶"
+#~ msgstr ":"
+
+#~ msgid "Version %s"
+#~ msgstr "%s संस्करण"
+
+#~ msgid "OS name"
+#~ msgstr "ओएस्(OS) नाम"
+
+#~ msgid "OS type"
+#~ msgstr "OS को किसिम"
+
+#~ msgid "Disk"
+#~ msgstr "डिस्क"
+
+#~ msgid "Check for updates"
+#~ msgstr "अपडेट जाँच गर्नुहोस्"
+
+#~ msgid "Universal Access"
+#~ msgstr "विश्वब्यापी पहुँच"
+
+#, fuzzy
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "पछिल्लो आगत श्रोतमा जानुहोस्"
+
+#~ msgid "Network proxy"
+#~ msgstr "सञ्जाल प्रोक्सि"
+
+#~ msgid "page 1"
+#~ msgstr "पृष्ठ १"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "आन्तरिक प्रमाणीकरण"
+
+#~ msgid "page 2"
+#~ msgstr "पृष्ठ २"
+
+#, fuzzy
+#~| msgid "Save _background image"
+#~ msgid "Restrict background data usage"
+#~ msgstr "ति छनौटहरूमा डेटा कडा गर्नुहोस्"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "मोडिएको जोडा (TP)"
+
+#~ msgid "BNC"
+#~ msgstr "बिएनसि"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "१० Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "१०० Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "१० Gb/s"
+
+#~ msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "वायरलेस हटस्पटमा स्विच गर्नु भए पछि  तपाईं <b>%s</b> छुट्नु हुनेछ।"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the hotspot is active."
+#~ msgstr "यो हटस्पट सक्रिय हुँदा, वायरलेस मार्फत इन्टरनेटमा पहुँच सम्भव छैन।"
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "स्वत जडान"
+
+#~ msgid "details"
+#~ msgstr "विस्तृत विवरणहरू"
+
+#~ msgid "Show P_assword"
+#~ msgstr "पासवर्ड :देखाउनुहोस्"
+
+#~ msgid "Make available to other users"
+#~ msgstr "अन्य प्रयोगकर्तालाई उपलव्ध गराउनुहोस्"
+
+#~ msgid "identity"
+#~ msgstr "परिचय"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "ठेगानाहरू"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "स्वचालित DHCP मात्रै"
+
+#~ msgid "Link-local only"
+#~ msgstr "लिङ्क स्थानीय मात्र"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "MAC ठेगाना प्रतिलिपी"
+
+#~ msgid "_Reset"
+#~ msgstr "रिसेट गर्नुहोस्"
+
+#~ msgid "Hardware"
+#~ msgstr "हार्डवेयर"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "रिसेट गर्नुहोस्"
+
+#, fuzzy
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "वायरलेस नेटवर्क जडान गर्न स्विच बन्द गर्नुहोस्"
+
+#~ msgid "Connected Devices"
+#~ msgstr "जडान भएका यन्त्रहरू"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "पासवर्ड"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "इन्फ्रास्ट्रक्चर"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "सुचना पपअप"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "चार्जहुँदै"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "सावधान"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "कम"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "असल"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "पुरा चार्ज भयो"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "खाली"
+
+#~ msgid "In use"
+#~ msgstr "प्रयोगमा रहेको"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "खुला छ"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "बन्द छ"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "बन्द छ"
+
+#, fuzzy
+#~| msgid "On"
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "खुला छ"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "बन्द छ"
+
+#, fuzzy
+#~| msgid "On"
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "खुला छ"
+
+#~ msgid "Usage & History"
+#~ msgstr "प्रयोग र ईतिहास"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "गोपनीयता नीति"
+
+#~ msgid "_Recently Used"
+#~ msgstr "हालै प्रयोग गरिएको"
+
+#~ msgid "Retain _History"
+#~ msgstr "ईतिहास जगेर्ना गर्नुहोस्"
+
+#, fuzzy
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "पर्दा ताला लगाउ"
+
+#, fuzzy
+#~| msgid "Notifications"
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "पृष्ठभूमि मिलाउ र पर्दा ताल्चा लगाउ"
+
+#, fuzzy
+#~ msgid "Purge _After"
+#~ msgstr "पछि छ"
+
+#, fuzzy
+#~ msgid "_Send software usage statistics"
+#~ msgstr "सफ्टवेयर प्रयोग"
+
+#~ msgid "_Camera"
+#~ msgstr "क्यामेरा"
+
+#~ msgid "_Microphone"
+#~ msgstr "माईक्रोफोन"
+
+#~ msgid "_Location Services"
+#~ msgstr "स्थान सेवाहरू"
+
+#~ msgid "No regions found"
+#~ msgstr "कुनै क्षेत्र फेला परेन"
+
+#~ msgid "Previous source"
+#~ msgstr "अघिल्लो श्रोतमा "
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "पछिल्लो श्रोत"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "सञ्झ्याल शीर्षक फ्ल्यास गर"
+
+#~ msgid "Last Login"
+#~ msgstr "अन्तिम लगइन"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "औँठाछाप लगइन सक्षम पार्नुहोस्"
+
+#~ msgid "_Other finger:"
+#~ msgstr "अर्को अंगुठा:"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "प्रयोगकर्ता नाम '-' बाट सुरु हुनु हुँदैन"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "त्रुटि देखापर्यो ।"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "दर्ता भएको अंगुठाछाप मेट्नुहोस् ?"
+
+#~ msgid "Done!"
+#~ msgstr "गरियो !"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr " “%s” यन्त्रको पहुँच प्राप्त गर्न सकेन"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "कृपया तपाईँको प्रणाली प्रसासकलाई सम्पर्क गर्नुहोस् ।"
+
+#~ msgid "Selecting finger"
+#~ msgstr "फिङ्गर छनोट"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "दिनभर परिवर्तन"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "टायल"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "जूम गर्नुहोस्"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "केन्द्र"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "मापन"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "भर्नुहोस्"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "विस्तार"
+
+#~ msgid "Colors"
+#~ msgstr "रङ्गहरू"
+
+#~ msgid "Pictures"
+#~ msgstr "तस्वीरहरू"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "कुनै छबि भेटिएन"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "%s फोल्डरमा थपिएका छविहरू यहा हेर्न सकिन्छ"
+
+#~ msgid "Back­ground"
+#~ msgstr "पृष्ठभुमी"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "ब्लुटुठ"
+
+#~ msgid "Co­lor"
+#~ msgstr "रङ्ग"
+
+#~ msgid "Apply"
+#~ msgstr "लागु गर्ने"
+
+#, fuzzy
+#~| msgid "Right"
+#~ msgid "_Night Light"
+#~ msgstr "रात मोड"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "प्रदर्शनपर्दाको जानकारी प्राप्त गर्न सकेन"
+
+#~ msgid "Overview"
+#~ msgstr "अवलोकन"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "पूर्वनिर्धारित अनुप्रयोगहरू"
+
+#~ msgid "Ab­out"
+#~ msgstr "बारेमा"
+
+#~ msgid "De­tails"
+#~ msgstr "विवरणहरू"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "हटाउन योग्य मिडिया"
+
+#~ msgid "Net­work"
+#~ msgstr "सञ्जाल"
+
+#~ msgid "hardware"
+#~ msgstr "हार्डवेयर "
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "सूचना"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "स्वत निश्क्रिय"
+
+#, fuzzy
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "'ताजा पार्नुहोस्' बटन थिचेको बेलामा देखाउने फ्रेम"
+
+#~ msgid "Po­wer"
+#~ msgstr "पावर"
+
+#, fuzzy
+#~ msgid "Pri­va­cy"
+#~ msgstr "CY:"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "अघिल्लो श्रोतमा जाने"
+
+#~ msgid "Switch to next source"
+#~ msgstr "अर्को श्रोतमा जाने"
+
+#, fuzzy
+#~ msgid "Alternative switch to next source"
+#~ msgstr "प्रयोगगरेर अर्को स्रोतमा  परिवर्तनग गर्नुहोस्:"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "अंग्र‍ेजि (युनाइटेड किङ्गडम)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "यनाइटेड किङ्गडम"
+
+#~ msgid "_Options"
+#~ msgstr "विकल्पहरू"
+
+#~ msgid "Add input source"
+#~ msgstr "आगत स्रोत थप्नुहोस्"
+
+#~ msgid "Remove input source"
+#~ msgstr "आगत स्रोत हटाउनुहोस्"
+
+#~ msgid "Move input source up"
+#~ msgstr "आगत स्रोतलाई माथि सार्नुहोस्"
+
+#~ msgid "Move input source down"
+#~ msgstr "आगत स्रोतलाई तल सार्नुहोस्"
+
+#~ msgid "Configure input source"
+#~ msgstr "आगत स्रोत"
+
+#, fuzzy
+#~| msgid "No input source selected"
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "भाषा;खाका;किबोर्ड;इनपुट विधि;पाठ प्रवेश;"
+
+#~ msgid "Sha­ring"
+#~ msgstr "साझेदारी"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "_बायाँ:"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "_दायाँ:"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "न्यूनतम:"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "अधिकतम"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "सबउफर"
+
+#~ msgid "_Profile:"
+#~ msgstr "प्रोफाइल"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "ध्वनी यन्त्र"
+
+#~ msgid "Peak detect"
+#~ msgstr "पिक पत्ता गलाउनुहोस्"
+
+#~ msgid "Device"
+#~ msgstr "यन्त्र"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s को लागि स्पिकर परीक्षण"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "ध्वनि निर्गतको लागि यन्त्र चयन गर्नुहोस्"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "चयन गरिएको डिभायिसको लागि सेटिङ:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "इनपुट भोल्युम:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "ध्वनि आगतको लागि यन्त्र चयन गर्नुहोस्"
+
+#~ msgid "Sound Effects"
+#~ msgstr "ध्वनि प्रभाव"
+
+#~ msgid "Built-in"
+#~ msgstr "स्वतः निर्मित"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ध्वनि प्राथमिकताहरू"
+
+#~ msgid "Testing event sound"
+#~ msgstr "घटना ध्वनि परीक्षण"
+
+#~ msgid "From theme"
+#~ msgstr "थिमबाट"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "सावधानि ध्वनि चयन गर्नुहोस्"
+
+#~ msgid "Stop"
+#~ msgstr "रोक्नुहोस्"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "विश्वब्यापी पहुँच"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "पासवर्द रूजु गर्नुहोस्"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "पासवर्ड मिलेन ।"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "मानक"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "प्रशासक"
+
+#~ msgid "Disable image"
+#~ msgstr "छवि अक्षम पार्नुहोस्"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "अरु बढि छविकोलागि ब्राउज गर्नुहोस्..."
+
+#~ msgid "Used by %s"
+#~ msgstr "%s ले प्रयोग गर्दैछ"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "वाक्म ट्याबलेट"
+
+#~ msgid "page 3"
+#~ msgstr "पृष्ठ ३"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "हार्डवेयर"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "प्रणाली"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME Control Center"
+
+#~ msgid "Show the overview"
+#~ msgstr "अधिलेखन हेर्नुहोस्"
+
+#~ msgid "Quit"
+#~ msgstr "अन्त्य गर्नुहोस्"
+
+#~ msgid "Lid Closed"
+#~ msgstr "ढकनी बन्द भयो"
+
+#~ msgid "Mirrored"
+#~ msgstr "ऐना"
+
+#~ msgid "Secondary"
+#~ msgstr "द्धितीयक"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "क्मबाईन्ड प्रदर्शनपर्दा मिलानुहोस्"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "पुन: मिलाउन तान्नुहोस्"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "९०° घडीको विपरित दिशामा घुमाउनुहोस्"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "१८० ° घुमाउनुहोस्"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "९०° घडीसरह घुमाउनुहोस्"
+
+#~ msgid "Size"
+#~ msgstr "आकार"
+
+#~ msgid "Presentation"
+#~ msgstr "प्रस्तुतिकरण"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "स्लाईडसो र मिडिया मात्रै देखाउनुहोस्"
+
+#~ msgid "Turn Off"
+#~ msgstr "बन्द गर्नुहोस्"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "यो प्रदर्शन प्रयोग नगर्नु"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "क्मबाईन्ड प्रदर्शनपर्दा मिलानुहोस्"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "हवाई मोड"
+
+#~ msgid "Server"
+#~ msgstr "सर्भर:"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "डिएनएस सर्भर मेट्नुहोस्"
+
+#~ msgid "Proxy"
+#~ msgstr "प्रोक्सि"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "प्रोफाइल थप्नुहोस्..."
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "कुनै पनि होइन"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "म्यानुअल"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "स्वचालित"
+
+#~ msgid "_Method"
+#~ msgstr "विधि"
+
+#~ msgid "Group Name"
+#~ msgstr "कार्य समूहको लागि एउटा नाम"
+
+#~ msgid "Done"
+#~ msgstr "गरियो ।"
+
+#~ msgid "Time _Zone"
+#~ msgstr "समय क्षेत्र"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "पुर्वाधार प्रणाली"
+
+#, fuzzy
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "चम्किनु"
+
+#~ msgid "_Delay:"
+#~ msgstr "विलम्ब गर्नुहोस्:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "छोटो"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "मन्द"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "लामो"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "छिटो"
+
+#~ msgid "S_peed:"
+#~ msgstr "गति:"
+
+#, fuzzy
+#~| msgid ""
+#~| "To edit a shortcut key, click on the corresponding row and type a new accelerator, or press "
+#~| "backspace to clear."
+#~ msgid "To edit a shortcut, click the row and hold down the new keys or press Backspace to clear."
+#~ msgstr ""
+#~ "सर्टकट कुञ्जी सम्पादन गर्न, संगती पङ्क्तिमा क्लिक गर्नुहोस् र एउटा नयाँ गतिवर्धक टाइप गर्नुहोस्, वा खाली गर्न "
+#~ "ब्याकस्पेस थिच्नुहोस् ।"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Unknown Action>"
+
+#, fuzzy
+#~| msgid ""
+#~| "The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+#~| "Please try with a key such as Control, Alt or Shift at the same time.\n"
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "सर्टकट \"%s\" लाई प्रयोग गर्न सकिँदैन किनकी यस कुञ्जीलाई प्रयोग गरेर टाइप गर्न असम्भव हुन्छ ।\n"
+#~ "कृपया Control, Alt वा Shift जस्ता कुञ्जीबाट एकै समयमा प्रयास गर्नुहोस् ।\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "The shortcut \"%s\" is already used for:\n"
+#~| " \"%s\"\n"
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "\"%s\" नाम गरेको एउटा फोलडर पहिल्यै अवस्थित छ ।\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "_Reassign"
+#~ msgstr "पुन: मानाङ्कन गर्नुहोस्"
+
+#~ msgid "_Assign"
+#~ msgstr "मानाङ्कन गर्नुहोस्"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "सेटिङहरू परिक्षण गर्नुहोस्:"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "मन्द"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "छिटो"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_बायाँ:"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_दायाँ:"
+
+#, fuzzy
+#~| msgid "Ma_ximum pointer speed:"
+#~ msgid "_Pointer speed"
+#~ msgstr "गति:"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "मन्द"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "छिटो"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "मन्द"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "छिटो"
+
+#~ msgid "Disable while _typing"
+#~ msgstr " टाइप गर्दा अक्षम पार्नुहोस्"
+
+#, fuzzy
+#~ msgid "Make available to other _users"
+#~ msgstr "अन्य प्रयोगकर्तालाई उपलव्ध गराउनुहोस्"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "फायरवाल"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "पुर्वनिर्धारित "
+
+#~ msgid "Team"
+#~ msgstr "समूह"
+
+#~ msgid "Bridge"
+#~ msgstr "पुल"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#, fuzzy
+#~| msgid "Could not load the main interface"
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "'%s' छवि लोड गर्न सकेन ।"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "सञ्जाल जडान थप्नुहोस्..."
+
+#~ msgid "(none)"
+#~ msgstr "कुनै पनि होइन"
+
+#, fuzzy
+#~ msgid "Bridge slaves"
+#~ msgstr "पुल"
+
+#, fuzzy
+#~ msgid "Team slaves"
+#~ msgstr "समूह"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "हटस्पटको रुपमा प्रयोग गर्नुहोस्"
+
+#~ msgid "_History"
+#~ msgstr "इतिहास"
+
+#, fuzzy
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "प्रमाणपत्र अधिकार विश्वास"
+
+#~ msgid "Ignore"
+#~ msgstr "उपेक्षा गर्नुहोस्"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "सबै सीए प्रमाणपत्र छान्नुहोस्"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "हरेकपटक पासवर्ड माग्नु"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "मलाई फेरि नसम्झाउनुहोस्"
+
+#~ msgid "Yes"
+#~ msgstr "हो"
+
+#~ msgid "2"
+#~ msgstr "२"
+
+#~ msgid "3"
+#~ msgstr "३"
+
+#~ msgid "4"
+#~ msgstr "४"
+
+#, fuzzy
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "पपअप मेनु"
+
+#, fuzzy
+#~| msgid "Show _icons in menus"
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "विवरण देखाउनुहोस्"
+
+#, fuzzy
+#~| msgid "Lock screen"
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "पर्दा ताल्चा लगाउनुहोस्"
+
+#, fuzzy
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "सावधान पपअप गर्नुहोस्"
+
+#~ msgid "Add Account"
+#~ msgstr "खाता थप्नुहोस्"
+
+#~ msgid "Mail"
+#~ msgstr "पत्राचार"
+
+#~ msgid "Contacts"
+#~ msgstr "सम्पर्कहरू"
+
+#~ msgid "Chat"
+#~ msgstr "कुराकानी"
+
+#, fuzzy
+#~ msgid "Error logging into the account"
+#~ msgstr "खाता सिर्जना गर्दा त्रुटि"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "प्रमाणपत्रहरू म्याद समाप्ति भएको छ ।"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "लगईन गरि यो खाता सक्षम पार्नुहोस्"
+
+#~ msgid "_Sign In"
+#~ msgstr "लगइन गर्दै"
+
+#~ msgid "Error creating account"
+#~ msgstr "खाता सिर्जना गर्दा त्रुटि"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "तपाईँ यो खाता मेट्न निश्चित हुनुहुन्छ ?"
+
+#, fuzzy
+#~ msgid "No online accounts configured"
+#~ msgstr "अनलाईन खाताहरू"
+
+#, fuzzy
+#~ msgid "Turns off wireless devices"
+#~ msgstr "संक्षेपित वा सग्लो ब्रेलमा साटो फेरो गर्छ ।"
+
+#, fuzzy
+#~ msgid "When battery power is _critical"
+#~ msgstr "बेटरि पावर"
+
+#~ msgid "Toner Level"
+#~ msgstr "टोनर लेबल"
+
+#, fuzzy
+#~| msgid "Apply theme"
+#~ msgid "Supply Level"
+#~ msgstr "पुर्ति"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "स्थापना गर्नुहोस्..."
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u सष्क्रिय बनाउनुहोस्"
+#~ msgstr[1] "%u सष्क्रिय बनाउनुहोस्"
+
+#, fuzzy
+#~ msgid "Resume Printing"
+#~ msgstr "पज गरिएको खेललाई पुन: निरन्तरता दिनुहोस्"
+
+#, fuzzy
+#~ msgid "Pause Printing"
+#~ msgstr "पज गर्नुहोस्"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "मुद्रक थप्नुहोस्..."
+
+#~ msgid "No printers detected."
+#~ msgstr "मुद्रण पत्ता लागेन"
+
+#, fuzzy
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "कुञ्जी तल झर्दा कुञ्जी थिचाइहरू दोहोरिन्छन्"
+
+#~ msgid "Job Title"
+#~ msgstr "काम शीर्षक"
+
+#~ msgid "Job State"
+#~ msgstr "काम स्थिति"
+
+#~ msgid "Supply"
+#~ msgstr "पुर्ति"
+
+#~ msgid "Jobs"
+#~ msgstr "कार्य"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "कार्य देखाउनुहोस्"
+
+#~ msgid "label"
+#~ msgstr "लेबुल"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "नमुना पृष्ठ मुद्रण गर्नुहोस्"
+
+#~ msgid "Add New Printer"
+#~ msgstr "नयां मुद्रक थप्नुहोस्..."
+
+#~ msgid "Sorry"
+#~ msgstr "क्षमा"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "_अन्य..."
+
+#~ msgid "Password:"
+#~ msgstr "पासवर्ड :"
+
+#~ msgid "Zoom"
+#~ msgstr "जूम गर्नुहोस्"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "रङ"
+
+#~ msgid "_Verify"
+#~ msgstr "रूजु गर्नुहोस्"
+
+#~ msgid "Login History"
+#~ msgstr "लगईन इतिहास"
+
+#~ msgid "Add User Account"
+#~ msgstr "प्रयोगकर्ता खाता थप्नुहोस्"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "शक्ति:कमजोर"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "शक्ति:न्युन"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "शक्ति:मध्यम"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "शक्ति:राम्रो"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "शक्ति:उच्च "
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "अन्य खाताहरू"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "प्रयोगकर्ता '%s' पहिले नै अवस्थित छ"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "माथि"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "तल"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "कुनै पनि होइन"
+
+#, fuzzy
+#~| msgid "Left"
+#~ msgid "Left Ring"
+#~ msgstr "A RING"
+
+#, fuzzy
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "मुद्रा परिवर्तन #%d"
+
+#, fuzzy
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "दायाँ बटन #%d"
+
+#, fuzzy
+#~ msgid "Left Touchstrip"
+#~ msgstr "बायाँ"
+
+#, fuzzy
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "मुद्रा परिवर्तन #%d"
+
+#, fuzzy
+#~ msgid "Right Touchstrip"
+#~ msgstr "दायाँ"
+
+#, fuzzy
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "दायाँ बटन #%d"
+
+#, fuzzy
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "मुद्रा चाबी"
+
+#, fuzzy
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "मुद्रा चाबी"
+
+#, fuzzy
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "मुद्रा चाबी"
+
+#, fuzzy
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "मुद्रा चाबी"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "मुद्रा परिवर्तन #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "बाया बटन #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "दायाँ बटन #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "माथिल्लो बटन #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "तल्लो बटन  #%d"
+
+#~ msgid "No Action"
+#~ msgstr "कार्य छैन"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "बाया बटनमा क्लिक गर्नुहोस्"
+
+#~ msgid "Scroll Up"
+#~ msgstr "माथि स्क्रोल गर्नुहोस्"
+
+#~ msgid "Scroll Down"
+#~ msgstr "तल स्क्रोल गर्नुहोस्"
+
+#~ msgid "Show help options"
+#~ msgstr "मद्दत विकल्पहरू देखाउनुहोस्"
+
+#~ msgid "- Settings"
+#~ msgstr "सेटिङ"
+
+#, fuzzy
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr "उपलब्ध आदेश लाइन विकल्पको पूरै सूची हेर्न  '%s --मद्दत' चलाउनुहोस्"
+
+#~ msgid "United States"
+#~ msgstr "युनाइटेड स्टेट्स"
+
+#~ msgid "France"
+#~ msgstr "फ्रान्स"
+
+#~ msgid "Spain"
+#~ msgstr "स्पेन"
+
+#~ msgid "China"
+#~ msgstr "चाइना"
+
+#~ msgid "Image/label border"
+#~ msgstr "छवि/लेबुल किनारा"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "सावधान संवादमा लेबुल र छवि वरिपरि किनाराको चौडाइ"
+
+#~ msgid "The type of alert"
+#~ msgstr "सावधानको प्रकार"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "सावधानी संवादमा देखाइएको बटनहरू"
+
+#~ msgid "No Image"
+#~ msgstr "छवि छैन"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "ठेगानपुस्तिका सूचना प्राप्त गर्ने प्रयास गर्दा त्यहाँ एउटा त्रुटि थियो\n"
+#~ "इभोल्युसन डेटा सर्भरले प्रोटोकल ह्याण्डल गर्न सक्दैन"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "अज्ञात लग इन आईडी, प्रयोगकर्ता डाटावेश दुषित गरिएको हुन सक्दछ"
+
+#~ msgid "About %s"
+#~ msgstr "%s बारेमा"
+
+#~ msgid "About Me"
+#~ msgstr "मेरो बारेमा"
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>गृह</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>शिघ्र सन्देश पठाउँदै</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>काम</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>टेलिफोन</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>वेब</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>कार्य</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">तपाईँको पासवर्ड परिवर्तन गर्नुहोस्</span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "ठेगान:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "सहायक:"
+
+#~ msgid "C_ity:"
+#~ msgstr "शहर:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "कम्पनी:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "पासवर्ड परिवर्तन गर्नुहोस्..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "पासवर्ड परिवर्तन गर्नुहोस्"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "शहर:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "देश:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "देश:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "गृह:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "ICQ:"
+
+#~ msgid "M_SN:"
+#~ msgstr "MSN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "पो.ओ. बाकस:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "पो.ओ. बाकस:"
+
+#~ msgid "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "कृपया <b>नयाँ पासवर्ड रिटाइप गर्नुहोस्</b> फाँटमा फेरि तपाईँको पासवर्ड टाइप गर्नुहोस् ।"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "राज्य/क्षेत्र:"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below and click "
+#~ "<b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for verification and click "
+#~ "<b>Change password</b>."
+#~ msgstr ""
+#~ "तपाईँको पासवर्ड परिवर्तन गर्न, तलका फाँटमा हालको पसावर्ड प्रविष्टि गर्नुहोस् र <b>प्रमाणीकरण गर्नुहोस्</b> "
+#~ "क्लिक गर्नुहोस् ।\n"
+#~ "तपाईँले प्रमाणीकरण गरिसके पछि, तपाईँको नयाँ पासवर्ड प्रविष्टि गर्नुहोस्, प्रमाणीकरणका लागि यसलाई पुन: टाइप "
+#~ "गर्नुहोस् र <b>पासवर्ड परिवर्तन गर्नुहोस्</b> क्लिक गर्नुहोस् ।"
+
+#~ msgid "Web _log:"
+#~ msgstr "वेब लग:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "कार्य:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "कार्य फ्याक्स:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "जिप/ हुलाक सङ्केत:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "समूहगत:"
+
+#~ msgid "_Home page:"
+#~ msgstr "गृह पृष्ठ:"
+
+#~ msgid "_Home:"
+#~ msgstr "गृह:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "ज्याबर:"
+
+#~ msgid "_Manager:"
+#~ msgstr "प्रबन्धक:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "राज्य/क्षेत्र:"
+
+#~ msgid "_Work:"
+#~ msgstr "कार्य:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "याहू:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "जिप/हुलाक सङ्केत:"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "शाखा अनपेक्षित रूपमा अन्त्य भयो"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO च्यानल बन्द गर्न सकेन: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO च्यानल बन्द गर्न सकेन: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "प्रणाली त्रुटि: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%s सुरुआत गर्न अक्षम: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "ब्याकइन्ड सुरुआत गर्न अक्षम"
+
+#~ msgid "Checking password..."
+#~ msgstr "पासवर्ड जाँच गर्दैछ..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "तपाईँको पासवर्ड परिवर्तन गर्न <b>पासवर्ड परिवर्तन गर्नुहोस्</b> क्लिक गर्नुहोस् ।"
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>प्रलम्बित प्रविधिहरू</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>प्राथमिकताहरू</b>"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "पहुँचयोग्य लग इन"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "प्रलम्बित प्रविधि प्राथमिक्ताहरू"
+
+#~ msgid "Changes to enable assistive technologies will not take effect until your next log in."
+#~ msgstr "प्रलम्बित प्रविधिहरू सक्षम पार्न गरिएका परिवर्तनहरूले तपाईँको पछिल्लो लग इन नगरे सम्म प्रभाव लिने छैन ।"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "बन्द गर्नुहोस् र लग आउट गर्नुहोस्"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "रूचाइएको अनुप्रयोग संवादमा जानुहोस्"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "पहुँचयोग्य लग इन संवादमा जानुहोस्"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "कुञ्जीपाटी पहुँचता संवादमा जानुहोस्"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "प्रलम्बित प्रविधिहरू सक्षम पार्नुहोस्"
+
+#~ msgid "_Keyboard Accessibility"
+#~ msgstr "कुञ्जीपाटी पहुँचता"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "रूचाइएका अनुप्रयोगहरू"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "लग इनमा जीनोम प्रलम्बित प्रविधिहरूका लागि समर्थन सक्षम पार्नुहोस्"
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "माउस प्राथमिकता संवाद सुरुआत गर्दा त्यहाँ एउटा त्रुटि थियो: %s"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "'%s' फाइलबाट AccessX सेटिङहरू आयात गर्न असक्षम"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "विशेषता सेटिङ फाइल आयात गर्नुहोस्"
+
+#~ msgid "Keyboard Accessibility"
+#~ msgstr "कुञ्जीपाटी पहुँचता"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "तपाईँको कुञ्जीपाटी पहुँचता प्राथमिक्ताहरू सेट गर्नुहोस्"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard accessibility features will "
+#~ "not operate without it."
+#~ msgstr "यो प्रणललीसँग XKB विस्तार भएको देखिँदैन ।  कुञ्जीपाटी पहुँचता विशेषताहरू यो बिना सञ्चालन हुने छैनन् ।"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>फर्कने कुञ्जीहरू सक्षम पार्नुहोस्</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>ढिला कुञ्जीहरू सक्षम पार्नुहोस्</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>माउस कुञ्जीहरू सक्षम पार्नुहोस्</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>दोहोरिने कुञ्जीहरू सक्षम पार्नुहोस्</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>टाँसिने कुञ्जीहरू सक्षम पार्नुहोस्</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>विशेषताहरू</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>टगल कुञ्जीहरू</b>"
+
+#~ msgid "Basic"
+#~ msgstr "आधारभूत"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr "कुञ्जीपाटीबाट विशेषताहरू खोल्दा वा बन्द गर्दा बीप गर्नुहोस्"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "एउटा LED खोल्दा बीप र बन्द गर्दा दुई पटक बीप गर्दछ ।"
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "कुञ्जीथिचाइ र सङ्केतक चाल बीच विलम्ब गर्नुहोस्:"
+
+#~ msgid "E_nable Toggle Keys"
+#~ msgstr "टगल कुञ्जीहरू सक्षम पार्नुहोस्"
+
+#~ msgid "Filters"
+#~ msgstr "फिल्टरहरू"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a user selectable period "
+#~ "of time."
+#~ msgstr ""
+#~ "यदि प्रयोगकर्ता चयनयोग्य समयावधिभित्र एउटै कुञ्जी थिचिएमा उक्त कुञ्जीको पछिल्ला डबै थिचाइहरू उपेक्षा गर्नुहोस् ।"
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "कुञ्जीपाटी पहुँचता प्राथमिक्ताहरू (AccessX)"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "माउस प्राथमिकताहरू..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user adjustable amount of time."
+#~ msgstr "कुञ्जीहरू थिचिए पछि र प्रयोगकर्ता समायोजनयोग्य समयको मात्रका लागि लिए पछि मात्र स्वीकार गर्नुहोस् ।"
+
+#~ msgid "Perform multiple simultaneous key press operations by pressing modifier keys in sequence."
+#~ msgstr "अनुक्रममा परिमार्जक कुञ्जीहरू थिचेर वहुविध समकालिन कुञ्जी थिचाइ सञ्चालनहरू कार्यसम्पादन गर्नुहोस् ।"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "अधिक्तम गतिमा गतिवर्धन गर्नका लागि समय:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "सङ्ख्यात्मक किप्याडलाई माउस नियन्त्रण प्याडमा परिवर्तन गर्नुहोस् ।"
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "यदि यसका लागि प्रयोग नभएमा असक्षम पार्नुहोस्:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "कुञ्जीपाटी पहुँचता विशेषताहरू सक्षम पार्नुहोस्"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "विशेषता सेटिङहरू आयात गर्नुहोस्..."
+
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "यसका लागि लिइएका कुञ्जीहरू मात्र स्वीकार गर्नुहोस्:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "सेटिङहरू परिक्षण गर्न टाइप गर्नुहोस्:"
+
+#~ msgid "_accepted"
+#~ msgstr "स्वीकार गरिएको"
+
+#~ msgid "_pressed"
+#~ msgstr "थिचिएको"
+
+#~ msgid "_rejected"
+#~ msgstr "अस्वीकार गरिएको"
+
+#~ msgid "characters/second"
+#~ msgstr "क्यारेक्टरहरू/सेकेन्ड"
+
+#~ msgid "milliseconds"
+#~ msgstr "मिलिसेकेन्ड"
+
+#~ msgid "pixels/second"
+#~ msgstr "पिक्सेल/सेकेन्ड"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "वालपेपर थप्नुहोस्"
+
+#~ msgid "Font may be too large"
+#~ msgstr "फन्ट धेरै ठूलो हुन सक्दछ"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to effectively use the "
+#~ "computer.  It is recommended that you select a size smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to effectively use the "
+#~ "computer. It is recommended that you select a size smaller than %d."
+#~ msgstr[0] ""
+#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारि रूपले प्रयोग गर्न यसलाई कठिन बनाउन सक्दछ ।  "
+#~ "तपाईँलाई %d भन्दा सानो साइज चयन गर्न सिफारिस गरन्छ ।"
+#~ msgstr[1] ""
+#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारि रूपले प्रयोग गर्न यसलाई कठिन बनाउन सक्दछ ।  "
+#~ "तपाईँलाई %d भन्दा सानो साइज चयन गर्न सिफारिस गरन्छ ।"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to effectively use the "
+#~ "computer.  It is recommended that you select a smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to effectively use the "
+#~ "computer. It is recommended that you select a smaller sized font."
+#~ msgstr[0] ""
+#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारी रूपले प्रयोग गर्न यसलाई कठिन बनाउन सक्दछ ।  "
+#~ "तपाईँलाई सानो साइजको फन्ट चयन गर्न सिफारिस गरन्छ ।"
+#~ msgstr[1] ""
+#~ "चयन गरिएको फन्ट %d बिन्दु ठूलो छ, र कम्प्युटर प्रभावकारी रूपले प्रयोग गर्न यसलाई कठिन बनाउन सक्दछ ।  "
+#~ "तपाईँलाई सानो साइजको फन्ट चयन गर्न सिफारिस गरन्छ ।"
+
+#~ msgid "Use previous font"
+#~ msgstr "अघिल्लो फन्ट प्रयोग गर्नुहोस्"
+
+#~ msgid "Use selected font"
+#~ msgstr "चयन गरिएको फन्ट प्रयोग गर्नुहोस्"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "स्थापना गर्नलाई विषयवस्तुको फाइलनाम निर्दिष्ट गर्नुहोस्"
+
+#~ msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr "theme|background|fonts|interface) देखाउन पृष्ठको नाम निर्दिष्ट गर्नुहोस्"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid "Apply Font"
+#~ msgstr "फन्ट लागू गर्नुहोस्"
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "हालको विषयवस्तुले पृष्ठभूमि र फन्ट बारेमा सुझाब दिन्छ ।"
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "हालको विषयवस्तुले एउटा पृष्ठभूमिको सुझाव दिन्छ ।"
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "हालको विषयवस्तुले एउटा फन्ट सुझाव दिन्छ ।"
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>रङ्गहरू</b>"
+
+#~ msgid "<b>Hinting</b>"
+#~ msgstr "<b>सङ्केत गर्दै</b>"
+
+#~ msgid "<b>Menus and Toolbars</b>"
+#~ msgstr "<b>मेनुहरू र उपकरणपट्टीहरू</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>पूर्वावलोकन</b>"
+
+#~ msgid "<b>Rendering</b>"
+#~ msgstr "<b>रेन्डर गर्दै</b>"
+
+#~ msgid "<b>Smoothing</b>"
+#~ msgstr "<b>नरम गर्दै</b>"
+
+#~ msgid "<b>Subpixel Order</b>"
+#~ msgstr "<b>उपपिक्सेल क्रम</b>"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>वालपेपर</b>"
+
+#~ msgid "Best _shapes"
+#~ msgstr "सर्वोत्तम आकारहरू"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "सर्वित्तम व्यतिरेक"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "अनुकुलन गर्नुहोस्..."
+
+#~ msgid "C_ut"
+#~ msgstr "काट्नुहोस्"
+
+#~ msgid ""
+#~ "Centered\n"
+#~ "Fill screen\n"
+#~ "Scaled\n"
+#~ "Zoom\n"
+#~ "Tiled"
+#~ msgstr ""
+#~ "केन्द्रिकृत\n"
+#~ "पर्दा भर्नुहोस्\n"
+#~ "मापन गरिएको\n"
+#~ "जुम\n"
+#~ "टायल गरिएको"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "तपाईँको कर्सर विषयवस्तु परिवर्तन गर्नाले तपाईँले पछि लग इन गर्दा प्रभाव गर्नेछ ।"
+
+#~ msgid "Customize Theme"
+#~ msgstr "विषयवस्तु अनुकुलन गर्नुहोस्"
+
+#~ msgid "D_etails..."
+#~ msgstr "विस्तृत विवरणहरू..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "डेस्कटप फन्ट:"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "फन्ट रेन्डरिङ विवरणहरू"
+
+#~ msgid "Go _to Fonts Folder"
+#~ msgstr "फन्ट फोल्डरमा जानुहोस्"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "ग्रेस्केल"
+
+#~ msgid "Icons"
+#~ msgstr "प्रतिमाहरू"
+
+#~ msgid "Interface"
+#~ msgstr "इन्टरफेस"
+
+#~ msgid "N_one"
+#~ msgstr "कुनै पनि होइन"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "रङ्ग निर्दिष्ट गर्न संवाद खोल्नुहोस्"
+
+#~ msgid "R_esolution:"
+#~ msgstr "रेज्योलुसन:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "यस रूपमा विषयवस्तु बचत गर्नुहोस्..."
+
+#~ msgid "Save _As..."
+#~ msgstr "यस रूपमा बचत गर्नुहोस्..."
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "ठोस रङ्ग\n"
+#~ "तेर्सो ग्रेडियन्ट\n"
+#~ "ठाडो ग्रेडियन्ट"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "उप-पिक्सेल (LCDs)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "उप-पिक्सल महिन (LCDs)"
+
+#~ msgid "Text"
+#~ msgstr "पाठ"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "वस्तुहरू तल पाठ\n"
+#~ "वस्तुहरू बाहेक कपाठ\n"
+#~ "प्रतिमाहरू मात्र\n"
+#~ "पाठ मात्र"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "हालको नियन्त्रण विषयवस्तुले रङ्ग स्किमाहरूलाई समर्थन गर्दैन ।"
+
+#~ msgid "Theme"
+#~ msgstr "विषयवस्तु"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "उपकरणपट्टी बटन लेबुलहरू:"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "वर्णन:"
+
+#~ msgid "_Document font:"
+#~ msgstr "कागजात फन्ट:"
+
+#~ msgid "_File"
+#~ msgstr "फाइल"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "स्थिर चौडाइ फन्ट:"
+
+#~ msgid "_Monochrome"
+#~ msgstr "मोनोक्रोम"
+
+#~ msgid "_New"
+#~ msgstr "नयाँ"
+
+#~ msgid "_None"
+#~ msgstr "कुनै पनि होइन"
+
+#~ msgid "_Paste"
+#~ msgstr "टाँस्नुहोस्"
+
+#~ msgid "_Print"
+#~ msgstr "मुद्रण गर्नुहोस्"
+
+#~ msgid "_RGB"
+#~ msgstr "RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "पूर्वनिर्धारितहरूमा पुन: सेट गर्नुहोस्"
+
+#~ msgid "_Selected items:"
+#~ msgstr "वस्तुहरू चयन गर्नुहोस्:"
+
+#~ msgid "_Size:"
+#~ msgstr "साइज:"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "टूलटिप:"
+
+#~ msgid "_VRGB"
+#~ msgstr "VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "सञ्झ्याल शिर्षक फन्ट:"
+
+#~ msgid "_Windows:"
+#~ msgstr "सञ्झ्यालहरू:"
+
+#~ msgid "dots per inch"
+#~ msgstr "प्रति इन्च थोप्लाहरू"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "डेक्सटपको हेराइ अनुकुलन गर्नुहोस्"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "डेक्सटपको विभिन्न भागहरुका लागि विषयवस्तु प्याकेजहरू स्थापना गर्दछ"
+
+#~ msgid "Theme Installer"
+#~ msgstr "विषयवस्तु स्थापक"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "जीनोम विषयवस्तु प्याकेज"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s by %d %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s द्वारा %d %s\n"
+#~ "फोल्डर: %s"
+
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "The %s utility is not installed."
+#~ msgstr ""
+#~ "विषयवस्तु स्थापना गर्न सकिँदैन ।\n"
+#~ "%s उपयोगिता स्थापना गरिएको छैन ।"
+
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "There was a problem while extracting the theme."
+#~ msgstr ""
+#~ "विषयवस्तु स्थापना गर्न सकिँदैन ।\n"
+#~ "विषयवस्तु ल्याउँदा त्यहाँ एउटा समस्या थियो ।"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "जीनोम विषयवस्तु %s सही रूपले स्थापना गरियो"
+
+#~ msgid "The theme is an engine. You need to compile it."
+#~ msgstr "विषयवस्तु एउटा इन्जिन हो । तपाईँले यो पूरा गर्न आवश्यक छ ।"
+
+#~ msgid "The file format is invalid"
+#~ msgstr "फाइल ढाँचा अवैध छ"
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "\"%s\" विषयवस्तु स्थापना भएको छ ।"
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "तपाईँ यसलाई अहिले लागू गर्नुहुन्छ, वा हालको विषयवस्तु नै राख्नुहुन्छ?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "हालको विषयवस्तु राख्नुहोस्"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "नयाँ विषयवस्तु लागु गर्नुहोस्"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "अस्थायी डाइरेक्टरी सिर्जना गर्न असफल भयो"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "स्थापना गर्न विषयवस्तु फाइल स्थान निर्दिष्ट गरिएको छैन"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "यसमा विषयवस्तु स्थापना गर्न अपर्याप्त अनुमतिहरू:\n"
+#~ "%s"
+
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be selected as the source "
+#~ "location"
+#~ msgstr "%s मार्ग हो जहाँ विषयवस्तु फाइल स्थापना गरिनेछ । यसलाई स्रोत स्थानको रूपमा चयन गर्न सकिँदैन"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "फाइल ढाँचा अवैध छ ।"
+
+#~ msgid "Select Theme"
+#~ msgstr "विषयवस्तु चयन गर्नुहोस्"
+
+#~ msgid "Theme Packages"
+#~ msgstr "विषयवस्तु प्याकेज"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "विषयवस्तु नाम उपस्थित हुनै पर्दछ"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "विषयवस्तु पहिल्यै अवस्थित छ । यसलाई प्रतिस्थापन गर्नुहुन्छ?"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "तपाईँ यो नाम मेट्न चाहनुहुन्छ?"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take effect. This could "
+#~ "indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) settings manager may already be "
+#~ "active and conflicting with the GNOME settings manager."
+#~ msgstr ""
+#~ "सेटिङ प्रबन्धक 'जीनोम-सेटिङ-डेइमोन' सरुआत गर्न अस्क्षम ।\n"
+#~ "जीनोम सेटिङ प्रबन्धक चालु बिना, केही प्राथमिकताहरूले प्रभाव गर्नेछैन । यसले Bonobo सँग समस्या भएको इङ्गित गर्न "
+#~ "सक्दछ, वा एउटा जीनोमबिहिन(जस्तै केडीई) सेटिङ प्रबन्धक पहिल्यै सक्रिय पारिएको हुन सक्दछ र जीनोम सेटिङ "
+#~ "प्रबन्धकसँग द्वन्द्व भैरहेको हुन सक्दछ ।"
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "'%s' भण्डार प्रतिमा लोड गर्न असफल भयो\n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "केवल सेटिङहरू लागू गर्नुहोस् र अन्त्य गर्नुहोस्"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "हस्तान्तरित सेटिङहरू पुन: प्राप्त गर्नुहोस् र भण्डारण गर्नुहोस्"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "मद्दत प्रदर्शन गर्दा त्यहाँ एउटा त्रुटि थियो: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "फाइल प्रतिलिपि गर्दै: %u को %u"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' प्रतिलिपि गर्दै"
+
+#~ msgid "Parent Window"
+#~ msgstr "प्रमूल सञ्झ्याल"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "संवादको प्रमूल सञ्झ्याल"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "यसबा URI हालै स्तानान्तरण गर्दै"
+
+#~ msgid "To URI"
+#~ msgstr "URI लाई"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "यसमा URI हालै स्थानान्तरण गर्दै"
+
+#~ msgid "Fraction completed"
+#~ msgstr "भिन्न पूरा भयो"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "स्थानातरणको भिन्न हालै पूरा भयो"
+
+#~ msgid "Current URI index"
+#~ msgstr "हालको URI अनुक्रमाणिका"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "हालको अनुक्रमाणिका सूची - १ बाट सुरु हुन्छ"
+
+#~ msgid "Total URIs"
+#~ msgstr "जम्मा URIs"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "URIs को जम्मा सङ्ख्या"
+
+#~ msgid "Key"
+#~ msgstr "कुञ्जी"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "जिकन्फ कुञ्जी जसमा यो गुण सम्पादक सम्पादन गरिएको छ"
+
+#~ msgid "Callback"
+#~ msgstr "कलब्याक गर्नुहोस्"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "कुञ्जीसँग सम्बन्धित मान परिवर्तन हुँदा यो कलब्याक जारी गर्नुहोस्"
+
+#~ msgid "GConf change set containing data to be forwarded to the gconf client on apply"
+#~ msgstr "लागूमा जीकन्फ क्लाइन्टलाई फरवार्ड गरिनका लागि डेटा समाविष्ट गर्ने जीकन्फ परिवर्तन सेट"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "विड्जेट कलब्याकमा रूपान्तरण"
+
+#~ msgid "Callback to be issued when data are to be converted from GConf to the widget"
+#~ msgstr "जीकन्फबाट विजेटमा डेटा रूपान्तरण हुँदा जारी गरिनका लागि कलब्याक"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "विजेट कलब्याकबाट रूपान्तरण"
+
+#~ msgid "Callback to be issued when data are to be converted to GConf from the widget"
+#~ msgstr "विजेटबाट जीकन्फमा डेटा रूपान्तरण हुँदा जाी गरिनका लागि कलब्याक"
+
+#~ msgid "UI Control"
+#~ msgstr "UI नियन्त्रण"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "वस्तु जसले गुण नियन्त्रण गर्दछ (सामान्यतया विजेट)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "गुण सम्पादक वस्तु डेटा"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "निर्दिष्ट गुण सम्पादकद्वारा आवश्यक अनुकुलन डेटा"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "गुण सम्पादक डेटा स्वतन्त्र कलब्याक"
+
+#~ msgid "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "गुण सम्पादक वस्तु डेटा खाली गरिँदा जारी गरिनुपर्ने कलब्याक"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different background picture."
+#~ msgstr ""
+#~ "'%s' फाइल फेला पार्न सकिएन ।\n"
+#~ "\n"
+#~ "कृपया यो अवस्थित छ भनेर निश्चित गर्नुहोस् र फेरि प्रयास गर्नुहोस्, वा एउटा फरक पृष्ठभूमि तस्वीर रोज्नुहोस् ।"
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' फाइल कसरी खोल्ने मलाई थाहा छैन ।\n"
+#~ "सायद यो एक प्रकारको तस्वीर हो जुन अझैसम्म समर्थित छैन ।\n"
+#~ "\n"
+#~ "कृपया यसको सट्टामा एउटा फरक तस्वीर चयन गर्नुहोस् ।"
+
+#~ msgid "Please select an image."
+#~ msgstr "कृपया एउटा छवि चयन गर्नुहोस् ।"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "पूर्वनिर्धारित सङ्केतक - हाल"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "सेतो सङ्केतक - हाल"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "ठूलो सङ्केतक - हाल"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "ठूलो सेतो सङ्केतक - हाल"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "रूचाइएका अनुप्रयोगहरू"
+
+#~ msgid "Autostart the preferred AT"
+#~ msgstr "यसमा रूचाइएको सवत: सुरु गर्नुहोस्"
+
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>छवि दर्शक</b>"
+
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>द्रुट मेसेन्जर</b>"
+
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>पत्र पाठक</b>"
+
+#~ msgid "<b>Mobility</b>"
+#~ msgstr "<b>गतिशीलता</b>"
+
+#~ msgid "<b>Multimedia Player</b>"
+#~ msgstr "<b>मल्टिमिडिया प्लेयर</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>टर्मिनल इमुलेटर</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>पाठ सम्पादक</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>भिडियो प्लेयर</b>"
+
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b>दृष्टिगत</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>वेब ब्राउजर</b>"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "सबै %s घटनाहरू वास्तविक लिङ्कले प्रतिस्थापित हुनेछन्"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "कार्यान्वयन झण्डा:"
+
+#~ msgid "Internet"
+#~ msgstr "इन्टरनेट"
+
+#~ msgid "Multimedia"
+#~ msgstr "मल्टिमिडिया"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "नयाँ ट्याबमा लिङ्क खोल्नुहोस्"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "नयाँ सञ्झ्यालमा लिङ्क खोल्नुहोस्"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "पूर्वनिर्धारित वेब ब्राउजरसँग लिङ्क खोल्नुहोस्"
+
+#~ msgid "Run at st_art"
+#~ msgstr "सुरुआतमा चलाउनुहोस्"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "टर्मिनलमा चलाउनुहोस्"
+
+#~ msgid "Balsa"
+#~ msgstr "बाल्सा"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "बान्शी संगित प्लेयर"
+
+#~ msgid "Claws Mail"
+#~ msgstr "क्लज् मेल"
+
+#~ msgid "Dasher"
+#~ msgstr "ड्याशर"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "डेबियन समझदार ब्राउजर"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "डेबियन टर्मिनल इमुलेटर"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "घेर्नु"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "एपिफनी वेब ब्राउजर"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "इभोल्युसन मेल पाठक"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "इभोल्युसन मेल पाठक १.४"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "इभोल्युसन मेल पाठक १.५"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "इभोल्युसन मेल पाठक १.६"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "इभोल्युसन मेल पाठक २.०"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "इभोल्युसन मेल पाठक २.२"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "इभोल्युसन मेल पाठक २.४"
+
+#~ msgid "Firebird"
+#~ msgstr "फायरबर्ड"
+
+#~ msgid "Firefox"
+#~ msgstr "फायरफक्स"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "पर्दा पाठक बिनाको जीनोम म्याग्नीफायर"
+
+#~ msgid "Galeon"
+#~ msgstr "गेलियन"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "जीनोपेर्निकस"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "म्याग्नीफायरसँग जीनोपेर्निकस"
+
+#~ msgid "Iceape"
+#~ msgstr "आइसएप"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "आइसएप मेल"
+
+#~ msgid "Icedove"
+#~ msgstr "आइसडोभ"
+
+#~ msgid "Iceweasel"
+#~ msgstr "आइसविसेल"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "पर्दा पाठकबिना केडीई म्याग्नीफायर"
+
+#~ msgid "Konqueror"
+#~ msgstr "कन्क्वेरर"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "पाठ ब्राउजरलाई लिङ्क गर्दछ"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "म्याग्नीफायरसँग लिनक्स पर्दा पाठक"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "लिनक्स पाठ ब्राउजर"
+
+#~ msgid "Mozilla"
+#~ msgstr "मोजिल्ला"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "मोजिल्ला १.६"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "मोजिल्ला मेल"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "मोजिल्ला थन्डरबर्ड"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "मुइन संगीत प्लेयर"
+
+#~ msgid "Mutt"
+#~ msgstr "मट"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "नेटस्केप सञ्चारकर्मी"
+
+#~ msgid "Opera"
+#~ msgstr "ओपेरा"
+
+#~ msgid "Orca"
+#~ msgstr "ओर्का"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "रिदमबाकस संगीत प्लेयर"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "सी मङ्की"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "सि मङ्की मेल"
+
+#~ msgid "Simple OnScreen Keyboard"
+#~ msgstr "पर्दा कुञ्जीपाटीमा सरल"
+
+#~ msgid "Sylpheed"
+#~ msgstr "सिल्फीड"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "सिल्फीड-क्लज्"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "टोटेम चलचित्र प्लेयर"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M पाठ ब्राउजर"
+
+#~ msgid "aterm"
+#~ msgstr "अटर्म"
+
+#~ msgid "Inverted"
+#~ msgstr "व्युतक्रमित"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "पर्दा रिजोल्युसन प्राथमिक्ताहरू"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "यस कम्प्युटर(%s)को लागि मात्र पूर्वनिर्धारित बनाउनुहोस्"
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous settings will be "
+#~ "restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous settings will be "
+#~ "restored."
+#~ msgstr[0] ""
+#~ "नयाँ सेटिङहरू परिक्षण गर्दै । यदि तपाईँले %d सेकेण्ड भित्र प्रतिउत्तर नगरेमा अघिल्लो सेटिङहरू पुर्वावस्थामा ल्याइनेछ ।"
+#~ msgstr[1] ""
+#~ "नयाँ सेटिङहरू परिक्षण गर्दै । यदि तपाईँले %d सेकेण्ड भित्र प्रतिउत्तर नगरेमा अघिल्लो सेटिङहरू पुर्वावस्थामा ल्याइनेछ ।"
+
+#~ msgid "Keep Resolution"
+#~ msgstr "रिजोल्युसन राख्नुहोस्"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "रिजोल्युसन राख्नुहोस्"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution changes to the display "
+#~ "size are not available."
+#~ msgstr ""
+#~ "X सर्भरले XRandR विस्तारलाई समर्थन गर्दैन ।  प्रदर्शन साइजमा चालुसमय रिजोल्युसन परिवर्तनहरू उपलब्ध छैनन् ।"
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. Runtime changes to the "
+#~ "display size are not available."
+#~ msgstr ""
+#~ "XRandR विस्तारको यो संस्करण यो कार्यक्रमसँग अमिल्दो छ । प्रदर्शन साइजमा चालुसमयको परिवर्तनहरू उपलब्ध छैनन् ।"
+
+#~ msgid "New accelerator..."
+#~ msgstr "नयाँ गतिवर्धक..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "गतिवर्धक कुञ्जी"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "गतिवर्धक परिमार्जकहरू"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "गतिवर्धक कुञ्जीसङ्केत"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "गतिवर्धकका प्रकार ।"
+
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "कन्फिगरेसन डाटाबेशमा नयाँ गतिवर्धक सेट गर्दा त्रुटि:%s\n"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "कन्फिगरेसन डाटाबेसमा गतिवर्धक सेटबाट हटाउँदा त्रुटि: %s\n"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "आदेशहरूमा सर्टकट कुञ्जीहरू मानाङ्कन गर्नुहोस्"
+
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "कुञ्जीपाटी उपकरण सुरुआत गर्दा त्यहाँ एउटा त्रुटि थियो: %s"
+
+#~ msgid "_Accessibility"
+#~ msgstr "पहुँचता"
+
+#~ msgid "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "केवल सेटिङहरू लागू गर्नुहोस् र अन्त्य गर्नुहोस् (अमिल्दो मात्र; अहिले डेइमोनद्वारा ह्याण्डल गरिएको)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "टाइप विच्छेद सेटिङ देखाएर पृष्ठ सुरुआत गर्नुहोस्"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "जीनोम कुञ्जीपाटी प्राथमिकताहरू"
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>टाइप विच्छेद लागू गर्न पर्दा ताल्चा लगाउनुहोस्</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>छिटो</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>लामो</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>छोटो</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>सुस्त</i></small>"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "विच्छेदहरूको स्थगन गर्न अनुमति दिनुहोस्"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "यदि विच्छेदहरू स्थगन गर्न अनुमति दिइन्छ भने जाँच गर्नुहोस्"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "एउटा कुञ्जीपाटी नमूना रोज्नुहोस्"
+
+#~ msgid "Choose..."
+#~ msgstr "रोज्नुहोस्..."
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "टाइप गर्न अनुमति अस्वीकार गर्दा विश्रामको अवधि"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "विच्छेदको लागि बल प्रयोग गर्नु अगाडी कामको अवधि"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "कुञ्जीपाटी नमूना:"
+
+#~ msgid "Layouts"
+#~ msgstr "सजावटहरू"
+
+#~ msgid "Lock screen after a certain duration to help prevent repetitive keyboard use injuries"
+#~ msgstr ""
+#~ "पुनरावृतिक कुञ्जीपाटी प्रयोग क्षतिलाई रोक्नलाई मद्दत गर्नका लागि निश्चित समयावधि पछि पर्दा ताल्चा लगाउनुहोस्"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "माइक्रोसफ्ट प्राकृतिक कुञ्जीपाटी"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "पूर्वनिर्धारितहरू रिसेट गर्नुहोस्"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "पहुँचता..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "विच्छेदन अन्तराल अन्त्य हुन्छ:"
+
+#~ msgid "_Layouts:"
+#~ msgstr "सजावटहरू:"
+
+#~ msgid "_Models:"
+#~ msgstr "नमूनाहरू:"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "चयन गरिएको सजावटहरू:"
+
+#~ msgid "_Variants:"
+#~ msgstr "चलहरू:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "विक्रेताहरू:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "कामको अन्तराल अन्त्य हुन्छ:"
+
+#~ msgid "Layout"
+#~ msgstr "सजावट"
+
+#~ msgid "Vendors"
+#~ msgstr "विक्रेताहरू"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "तपाईँको कुञ्जीपाटी प्राथमिक्ताहरू सेट गर्नुहोस्"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>तान्नुहोस् र छोड्नुहोस्</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>गति</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>चाँडो</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>उच्च</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>ठूलो</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>न्यून</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>सुस्त</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>सानो</i>"
+
+#~ msgid "Motion"
+#~ msgstr "चाल"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "गतिवर्धन:"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "वायाँ-हाते माउस"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "शीघ्रचेतनता:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "तपाईँको माउस प्राथमिक्ताहरू सेट गर्नुहोस्"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "तपाईँको सञ्जाल प्रोक्सी प्राथमिक्ताहरू सेट गर्नुहोस्"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>स्वाचालित प्रोक्सी कन्फिगरेसन</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>म्यानुअल प्रोक्सी कन्फिगरेसन</b>"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "उन्नत कन्फिगरेसन"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP प्रोक्सी विवरणहरू"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "सञ्जाल प्रोक्सी प्राथमिक्ताहरू"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr " HTTP प्रोक्सीलाई सुरक्षित गर्नुहोस्:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "ध्वनि र घटनाहरूसँग सम्बन्धित ध्वनिहरू सक्षम पार्नुहोस्"
+
+#~ msgid "Unknown Volume Control %d"
+#~ msgstr "अज्ञात भोल्युम नियन्त्रण %d"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - उन्नत लिनक्स ध्वनी बनावट"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART ध्वनी डेइमोन"
+
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ESD - स्पष्ट गरिएको ध्वनी डेइमोन"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - खुला ध्वनी प्रणाली"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "पल्सअडियो ध्वनी सर्भर"
+
+#~ msgid "Silence"
+#~ msgstr "मौन"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "जीनोम ध्वनि प्राथमिकताहरू"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>अडियो वार्तालाप</b>"
+
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>पूर्वनिर्धारित मिश्रित ट्रयाकहरू</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>संगीत र चलचित्र</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>ध्वनि घटनाहरू</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">परिक्षण गर्दैछ...</span>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "समाप्त गर्न 'ठीक छ' बटन क्लिक गर्नुहोस् ।"
+
+#~ msgid "E_nable software sound mixing (ESD)"
+#~ msgstr "सफ्टवेयर ध्वनि मिश्रण (ESD) सक्षम पार्नुहोस्"
+
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift and Control keys to "
+#~ "select multiple tracks if required."
+#~ msgstr ""
+#~ "कुञ्जीपाटीसँग नियन्त्रण गर्न यन्त्र र ट्रयाकहरू चयन गर्नुहोस् । यदि आवश्यक परेमा वहुविध ट्रयाकहरू चयन गर्न शिफ्ट र "
+#~ "नियन्त्रण कुञ्जीहरू प्रयोग गर्नुहोस् ।"
+
+#~ msgid "So_und playback:"
+#~ msgstr "ध्वनि प्लेब्याक:"
+
+#~ msgid "Sou_nd capture:"
+#~ msgstr "ध्वनि ग्रहण:"
+
+#~ msgid "System Beep"
+#~ msgstr "प्रणाली बिप"
+
+#~ msgid "_Device:"
+#~ msgstr "यन्त्र:"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "प्रणाली बिप सक्षम पार्नुहोस्"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "प्रणाली ध्वनि बजाउनुहोस्"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "ध्वनि प्लेब्याक:"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "दृष्टिगत प्रणाली बीप"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "तपाईँको सञ्झ्याल प्रबन्धकका लागि प्राथमिकता अनुप्रयोग सुरुआत गर्न सकिँदैन"
+
+#~ msgid "C_ontrol"
+#~ msgstr "नियन्त्रण गर्नुहोस्"
+
+#~ msgid "_Alt"
+#~ msgstr "Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "अति"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "सर्वोत्तम(वा\"सञ्झ्याल लोगो\")"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>चाल कुञ्जी</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>शीर्षकपट्टी कार्य</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>सञ्झ्याल चयन</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "सञ्झ्याल सार्न, यो कुञ्जी थिच्नुहोस्-र-राख्नुहोस् त्यसपछि सञ्झ्याल लिनुहोस्:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "सञ्झ्याल प्राथमिकताहरू"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "बढाउन अगाडिको अन्तराल:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "एउटा अन्तराल पछि चयन गरिएको सञ्झ्यालहरू बढाउनुहोस्"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "माउस सञ्झ्यालहरू माथि हुँदा तिनीहरूलाई चयन गर्नुहोस्"
+
+#~ msgid "Set your window properties"
+#~ msgstr "तपाईँको सञ्झ्यालको गुणहरू सेट गर्नुहोस्"
+
+#~ msgid "Windows"
+#~ msgstr "सञ्झ्यालहरू"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for the Slow Keys "
+#~ "feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "तपाईँले शिफ्ट कुञ्जी ८ सेकेण्डका लागि लिनुभएको छ । यो सुस्त कुञ्जी विशेषताका लागि सर्टकट हो, जसले तपाईँको "
+#~ "कुञ्जीपाटीको काम गर्ने तरिकालाई प्रभाव पार्दछ ।"
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "तपाईँ सुस्त कुञ्जीहरू सक्रिय बनाउन चहानुहुन्छ?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "तपाईँ सुस्त कुञ्जीहरू निष्क्रिय बनाउन चहानुहुन्छ?"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "सक्रिय नबनाउनुहोस्"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut for the Sticky Keys "
+#~ "feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "तपाईँले भर्खरै एउटा पङ्क्तिमा ५ पटक शिफ्ट कुञ्जी थिच्नुभयो ।  यो टाँसिने कुञ्जी विशेषताका लागि सर्टकट हो, जसले "
+#~ "तपाईँको कुञ्जीले काम गर्ने तरिकालाई असर गर्दछ ।"
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a row.  This turns off "
+#~ "the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "तपाईँले भर्खरै एकै पटक दुईवटा कुञ्जीहरू थिच्नुभयो, वा एउटा पङ्क्तिमा शिफ्ट कुञ्जी ५ पटक थिच्नुभयो ।  यसले टाँसिने "
+#~ "कुञ्जी विशेषतालाई बन्द गर्दछ, जसले तपाईँको कुञ्जीपाटीले काम गर्ने तरिकालाई असर गर्दछ ।"
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "तपाईँ टाँसिन्ने कुञ्जीहरू सक्रिय बनाउन चहानुहुन्छ?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "तपाईँ टाँसिन्ने कुञ्जीहरू निष्क्रिय बनाउन चहानुहुन्छ?"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "\"%s\" डाइरेक्टरी सिर्जना गर्न सकिँदैन ।\n"
+#~ "माउस सङ्केतक विषयवस्तुलाई परिवर्तन गर्न अनुमति दिन यो आवश्यक पर्दछ ।"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "\"%s\" डाइरेक्टरी सिर्जना गर्न सकिँदैन ।\n"
+#~ "माउस कर्सरहरूलाई परिवर्तन गर्न अनुमति दिन यो आवश्यक पर्दछ ।"
+
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "कुञ्जी बन्धन (%s) सँग धेरै पटक परिभाषित यसका कार्यहरू छन्\n"
+
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "कुञ्जी बन्धन (%s) सँग धेरै पटक परिभाषित यसका बन्धनहरू छन्\n"
+
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "कुञ्जी बन्धन (%s) अपूर्ण छ\n"
+
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "कुञ्जी बन्धन (%s) अवैध छ\n"
+
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr "अर्को अनुप्रयोग '%u' कुञ्जीमा पहिल्यै पहुँच भएको देखिन्छ ।"
+
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "(%s) चलाउन प्रयास गर्दा त्रुटि\n"
+#~ "जुन (%s) कुञ्जीमा लिङ्क गरिएको छ"
+
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "XKB कन्फिगरेसन सक्रिय पार्दा त्रुटि ।\n"
+#~ "यो बिभिन्न परिस्थितिहरूमा हुन सक्दछ:\n"
+#~ "- libxklavier लाइब्रेरीमा एउटा बग\n"
+#~ "- X सर्भरमा (xkbcomp, xmodmap utilities) एउटा बग\n"
+#~ "- अमिल्दो libxkbfile कार्यान्वयनसँग X सर्भर\n"
+#~ "\n"
+#~ "X सर्भर संस्करण डेटा:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "यदि तपाईँले यस हवस्थालाई बगको रूपमा प्रतिवेदन गर्नुभएमा, कृपया निम्ग समावेश गर्नुहोस्:\n"
+#~ "- <b>%s</b> को परिणाम\n"
+#~ "- <b>%s</b> को परिणाम"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree software."
+#~ msgstr ""
+#~ "तपाईँले XFree ४.३.०. प्रयोग गरिरहनुभएको छ\n"
+#~ "त्यहाँ जटिल XKB कन्फीगरेसनसँग ज्ञात समस्याहरू छन् ।\n"
+#~ "सरल  कन्फिगरेसन प्रयोग गरेर वा XFree को ताजा संस्करण लिएर प्रयास गर्नुहोस् ।"
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "यो चेतावनी फेरि नदेखाउनुहोस्"
+
+#~ msgid ""
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard settings.</b>\n"
+#~ "\n"
+#~ "Expected was %s, but the the following settings were found: %s.\n"
+#~ "\n"
+#~ "Which set would you like to use?"
+#~ msgstr ""
+#~ "<b>X प्रणाली कुञ्जीपाटी सेटिङहरू तपाईँको हालको जीनोम कुञ्जीपाटी सेटिङहरूबाट भिन्न हुन्छन् ।</b>\n"
+#~ "\n"
+#~ "अपेक्षा गरिएको %s थियो, तर निम्न सेटिङहरू फेला परे: %s.\n"
+#~ "\n"
+#~ "जुन सेट तपाईँ प्रयोग गर्न चाहनुहुन्छ?"
+
+#~ msgid ""
+#~ "Could not get default terminal. Verify that your default terminal command is set and points to "
+#~ "a valid application."
+#~ msgstr ""
+#~ "पूर्वनिर्धारित टर्मिनल प्राप्त गर्न सकेन । तपाईँको पूर्वनिर्धारित आदेश सेट भएको र वैध अनुप्रयोगमा देखाउँदछ भन्ने रूजु "
+#~ "गर्नुहोस् ।"
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this is a valid command."
+#~ msgstr ""
+#~ "आदेश कार्यान्वयन गर्न सकिएन: %s\n"
+#~ "यो एउटा वैध आदेश हो भन्ने रूजु गर्नुहोस् ।"
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "निष्क्रिय पार्नका लागि मेशिन राख्न सकिएन ।\n"
+#~ "मेशिन सही तरिकाले कन्फिगर गरिएको छ भन्ने रूजु गर्नुहोस् ।"
+
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "स्क्रिनसेभर सुरुआत गर्दा त्यहाँ एउटा त्रुटि थियो:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "स्क्रिनसेभर प्रकार्यत्मकताले यो सत्रमा कार्य गर्ने छैन ।"
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "यो सन्देश फेरि नदेखाउनुहोस्"
+
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "%s ध्वनि फाइललाई %s नमूनाको रूपमा लोड गर्न सकिएन"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "प्रयोगकर्ताको गृह डाइरेक्टरी निर्धारण गर्न सकिँदैन"
+
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr "जीकन्फ कुञ्जी %s सेट %s प्रकारमा तर यसको अपेक्षित प्रकार %s थियो\n"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "यो चेतावनी फेरि नदेखाउनुहोस् ।"
+
+#~ msgid "Load modmap files"
+#~ msgstr "मोडम्याप फाइलहरू लोड गर्नुहोस्"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "मोडम्याप फाइल(हरू) लोड गर्न चाहनुहुन्छ?"
+
+#~ msgid "_Load"
+#~ msgstr "लोड गर्नुहोस्"
+
+#~ msgid "_Loaded files:"
+#~ msgstr "लोड गरिएका फाइलहरू:"
+
+#~ msgid "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW for preview"
+#~ msgstr ""
+#~ "bg_applier को प्रकार: मूल सञ्झ्यालका लागि BG_APPLIER_ROOT वा पूर्वावलोकनका लागि BG_APPLIER_PREVIEW"
+
+#~ msgid "Preview Width"
+#~ msgstr "पूर्वावलोकन चौडाइ"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "यदि एप्लायर पूर्वावलोकन हुन्छ भने चौडा गर्नुहोस्: ६४ मा पूर्वनिर्धारित ।"
+
+#~ msgid "Preview Height"
+#~ msgstr "पूर्वावलोकन उच्चाइ"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "यदि पूर्वावलोकन हुन्छ भने उच्च गर्नुहोस्: ४८ मा पूर्वानिर्धारित ।"
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "पर्दा जहाँ BGApplier कोर्नुपर्दछ"
+
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>%s सुरु गर्नुहोस्</b>"
+
+#~ msgid "Upgrade"
+#~ msgstr "स्तरवृधि"
+
+#~ msgid "Uninstall"
+#~ msgstr "स्थापना नगर्नुहोस्"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "मनपर्नेहरूमा थप्नुहोस्"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "सुरुआत कार्यक्रमहरूबाट हटाउनुहोस्"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "सुरुआत कार्यक्रमहरूलाई थप्नुहोस्"
+
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>मिल्दो फेला परेन ।</b> </span><span>\n"
+#~ "\n"
+#~ " तपाईँको फिल्टरले \"<b>%s</b>\" कुनै पनि वस्तुहरूलाई मिलाउँदैन ।</span>"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "नयाँ स्प्रिडशीट"
+
+#~ msgid "New Document"
+#~ msgstr "नयाँ कागजात"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>खोल्नुहोस्</b>"
+
+#~ msgid "Send To..."
+#~ msgstr "पठाउनुहोस्..."
+
+#~ msgid "Edited %m/%d/%Y"
+#~ msgstr "सम्पादित %m/%d/%Y"
+
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>\"%s\" सँग खोल्नुहोस्</b>"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "फाइल प्रबन्धक खोल्नुहोस्"
+
+#~ msgid "Unexpected attribute '%s' for element '%s'"
+#~ msgstr "'%s' तत्वका लागि अनपेक्षित '%s' विशेषता"
+
+#~ msgid "Attribute '%s' of element '%s' not found"
+#~ msgstr "'%s' तत्वको '%s' विशेषता फेला परेन"
+
+#~ msgid "Unexpected tag '%s', tag '%s' expected"
+#~ msgstr "अनपेक्षित '%s' ट्याग, '%s' ट्याग अपेक्षा गरियो"
+
+#~ msgid "Unexpected tag '%s' inside '%s'"
+#~ msgstr "'%s' भित्र अनपेक्षित '%s' ट्याग"
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "डेटा डाइरेक्टरी भित्र वैध पुस्तकचिनो फाइल फेला परेन"
+
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "'%s' URI का लागि पुस्तकचिनो फेला परेन"
+
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "'%s' URI का लागि पुस्तकचिनो भित्र माइम प्रकार परिभाषित छैन"
+
+#~ msgid "No private flag has been defined in bookmark for URI '%s'"
+#~ msgstr "'%s' URI का लागि पुस्तकचिनो भित्र प्राइभेट झण्डा परिभाषा गरिएको छैन"
+
+#~ msgid "No groups set in bookmark for URI '%s'"
+#~ msgstr "'%s' URI का लागि पुस्तकचिनो भित्र समूहहरू सेट गरिएको छैन"
+
+#~ msgid "No application with name '%s' registered a bookmark for '%s'"
+#~ msgstr "'%s' नामको अनुप्रयोगले '%s' का लागि पुस्तकचिनो दर्ता गरेन"
+
+#~ msgid "Find Now"
+#~ msgstr "नयाँ फेला पार्नुहोस्"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s खोल्नुहोस्</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "प्रणालीबाट वस्तुहरू हटाउनुहोस्"
+
+#~ msgid "Boing"
+#~ msgstr "बोइङ"
+
+#~ msgid "Siren"
+#~ msgstr "सिरेन"
+
+#~ msgid "Clink"
+#~ msgstr "क्लिङ्क"
+
+#~ msgid "Beep"
+#~ msgstr "बीप"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "यो घटनाका ध्वनि सेट गरिएको छैन"
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default sounds."
+#~ msgstr ""
+#~ "यो घटनाका लागि ध्वनि पाइल अवस्थित छैन ।\n"
+#~ "तपाईँ पूर्वननिर्धारित ध्वनिहरूको सेटका लागि जीनोम-अडियो प्याकेज स्थापना गर्न सक्नुहुन्छ ।"
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "यो घटनाका लागि ध्वनि फाइल अवस्थित छैन ।"
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "%s फाइल एउटा वैध वेभ फाईल होइन"
+
+#~ msgid "Select sound file..."
+#~ msgstr "ध्वनि फाइल चयन गर्नुहोस्..."
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "\"%s\" सञ्झ्याल प्रबन्धकले कन्फिगरेसन उपकरण दर्ता गरेको छैन\n"
+
+#~ msgid "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr "यदि ठीक छ भने, माइम ह्याण्डलर text/plain and text/* का लागि समक्रमाणमा राखिनेछ"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "text/plain and text/* ह्याण्डलर समक्रमण गर्नुहोस्"
+
+#~ msgid "E-mail"
+#~ msgstr "इमेल"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "इमेलको सर्टकट"
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "गृह फोल्डरको सर्टकट"
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "मद्दत ब्राउजरको सर्टकट सुरुआत गर्नुहोस् ।"
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "वेब ब्राउजरको सर्टकट सुरुआत गर्नुहोस् ।"
+
+#~ msgid "Lock screen's shortcut."
+#~ msgstr "पर्दाको सर्टकट ताल्चा लगाउनुहोस् ।"
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "लगआउटको सर्टकट ।"
+
+#~ msgid "Media player key's shortcut."
+#~ msgstr "मिडिया प्लेयर कुञ्जीको सर्टकट ।"
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "पछिल्लो ट्रयाक कुञ्जीको सर्टकट ।"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "पज कुञ्जीको सर्टकट ।"
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "बजाउनुहोस् (वा बजाउनुहोस्/पज गर्नुहोस्) कुञ्जीको सर्टकट ।"
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "अघिल्लो ट्रयाक कुञ्जीको सर्टकट ।"
+
+#~ msgid "Sleep"
+#~ msgstr "निष्क्रिय पार्नुहोस्"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "निष्क्रियको सर्टकट ।"
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "प्लेब्याकको सर्टकट रोक्नुहोस् ।"
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "भोल्युम घटाइको सर्टकट ।"
+
+#~ msgid "Volume mute's shortcut."
+#~ msgstr "भोल्युम मौनको सर्टकट ।"
+
+#~ msgid "Volume step"
+#~ msgstr "भोल्युम तह"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "भोल्युमको प्रतिशतको रूपमा भोल्युम तह ।"
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "भोल्युम बढाउनुहोस्‌को सर्टकट ।"
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "स्क्रिनसेभर चलाउँदा त्रुटि हुँदा एउटा संवाद प्रदर्शन गर्नुहोस्"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "लग इनमा स्क्रिनसेभर चलाउनुहोस्"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "प्रारम्भिक त्रुटिहरू देखाउनुहोस्"
+
+#~ msgid "Start screensaver"
+#~ msgstr "स्क्रिनसेभर सुरु गर्नुहोस्"
+
+#~ msgid "Filter"
+#~ msgstr "फिल्टर"
+
+#~ msgid "Groups"
+#~ msgstr "समूहहरू"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "कार्य सक्रिय गरिएको बेला नियन्त्रण-केन्द्र बन्द गर्नुहोस्"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "'थप्नुहोस्' वा 'हटाउनुहोस्‌' कार्य कार्यसम्पादन गर्दा शेल अन्त्य गर्नुहोस्"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "'मद्दत' कार्य कार्यसम्पादन गर्दा शेल अन्त्य गर्नुहोस्"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "'सुरुआत गर्नुहोस्' कार्य कार्यसम्पादन गर्दा शेल अन्त्य गर्नुहोस्"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "'स्तरवृधि गर्नुहोस्' वा 'स्थापना नगर्नुहोस्' कार्य कार्यसम्पादन गर्दा शेल अन्त्य गर्नुहोस्"
+
+#~ msgid "Indicates whether to close the shell when a help action is performed"
+#~ msgstr "'मद्दत' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन इङ्गित गर्दछ"
+
+#~ msgid "Indicates whether to close the shell when a start action is performed"
+#~ msgstr "'सुरुआत गर्नुहोस्' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन इङ्गित गर्दछ"
+
+#~ msgid "Indicates whether to close the shell when an add or remove action is performed"
+#~ msgstr "एउटा 'थप्नुहोस्' वा 'हटाउनुहोस्' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन इङ्गित गर्दछ"
+
+#~ msgid "Indicates whether to close the shell when an upgrade or uninstall action is performed"
+#~ msgstr ""
+#~ "एउटा 'स्तरवृधि' वा 'स्थापना नगर्नुहोस्' कार्य कार्यसम्पादन गरिँदा शेल बन्द गर्नु पर्दछ या पर्दैन इङ्गित गर्दछ"
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "कार्य नामहरू र सम्बन्धितहरू । डेस्कटप फाइलहरू"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center (thus needing to be translated) followed "
+#~ "by a \";\" separator then the filename of an associated .desktop file to launch for that task."
+#~ msgstr ""
+#~ "\";\" विभाजक र त्यसपछि सम्बन्धित फाइलनामद्वारा अनुशरण गरिने नियन्त्रण-केन्द्रमा प्रदर्शन गरिनुपर्ने कार्यनाम "
+#~ "(यसैले अनुवाद गर्नु आवश्यक छ) \";\" विभाजकद्वारा अनुशरण गरिने र त्यसपछि सम्बन्धित फाइलनाम । उक्त कार्यको "
+#~ "लागि सुरुआत गर्नुपर्ने डेस्कटप फाइल ।"
+
+#~ msgid ""
+#~ "[Change Desktop Background;background.desktop,Change Theme;gtk-theme-selector.desktop,Set "
+#~ "Preferred Applications;default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[डेस्कटप पृष्ठभूमि; पष्ठभूमि.डेस्कटप,विषुवस्तु परिवर्तन गर्नुहोस्;gtk-theme-चयनकर्ता.डेस्कटप,रूचाइएको अनुप्रयोगहरू सेट;"
+#~ "पूर्वनिर्धारित-अनुप्रयोगहरू.डेस्कटप,मिद्रक थप्नुहोस्;जीनोम-कप्स-प्रबन्धक.डेस्कटप परिवर्तन गर्नुहोस्]"
+
+#~ msgid "if true, the control-center will close when a \"Common Task\" is activated"
+#~ msgstr "यदि ठीज छ भने, \"साझा कार्य\" सक्रिय हुँदा नियन्त्रण-केन्द्र बन्द हुनेछ"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "जिनोम कन्फिगरेसन उपकरण"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "विच्छेदन स्थगन गर्नुहोस्"
+
+#~ msgid "Take a break!"
+#~ msgstr "विश्राम लिनुहोस्!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "विश्राम लिनुहोस्"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "पछिल्लो विश्राम नभएसम्म %d मिनेट"
+#~ msgstr[1] "पछिल्लो विश्राम नभएसम्म %d मिनेट"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "पछिल्लो विश्राम नभएसम्म एक मिनेटभन्दा कम"
+
+#~ msgid "Unable to bring up the typing break properties dialog with the following error: %s"
+#~ msgstr "निम्न त्रुटिसँग टाइपिङ बिच्छेद गुण संवाद ल्याउन असक्षम: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "रिचार्ड हल्ट <richard@imendio.com> द्वारा लेखिएको"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "एन्डर्स कार्ल्ससनद्वारा थपिएको आई क्यान्डि"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "एउटा कमप्युटर विच्छेदन रिमाइन्डर ।"
+
+#~ msgid "translator-credits"
+#~ msgstr "Narayan Kumar Magar<narayan@mpp.org.np>"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "सूचना क्षेत्र अवस्थित छ या छैन जाँच नगर्नुहोस्"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You don't seem to have a "
+#~ "notification area on your panel. You can add it by right-clicking on your panel and choosing "
+#~ "'Add to panel', selecting 'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "यो टाइपिङ मनिटरले सूचना प्रदर्शन गर्न सूचना क्षेत्र प्रयोग गर्दछ । तपाईँसँग प्यानलमा सूचना क्षेत्र भएको देखिँदैन । "
+#~ "तपाईँले यसलाई 'सूचना क्षेत्र' चयन गरेर र 'थप्नुहोस्' क्लिक गरेर तपाईँको प्यानलमा दायाँ-क्लिक गरेर र 'प्यानलमा "
+#~ "थप्नुहोस्' रोजेर तपाईँको प्यानलमा थप्न सक्नुहुन्छ ।"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "यदि सेट सहि भएमा, खुला प्रकारका फन्टहरूलाई थम्बनेल गरिनेछ ।"
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "यदि सेट सहि भएमा, PCF फन्टहरूलाई थम्बनेल गरिनेछ ।"
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "यदि सेट सहि भएमा, सहि प्रकारका फन्टहरूलाई थम्बनेल गरिनेछ ।"
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "यदि सेट सहि भएमा, प्रकार १ का फन्टहरूलाई थम्बनेल गरिनेछ ।"
+
+#~ msgid "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr "खुला प्रकारका फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "PCF फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+
+#~ msgid "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr "सही प्रकारका फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+
+#~ msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "प्रकार १ फन्टहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "खुला प्रकारका फन्टहरूका लागि थम्बनेल आदेश"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "PCF फन्टहरूका लागि थम्बनेल आदेश"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "सहि प्रकारका फन्टहरूका लागि थम्बनेल आदेश"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "प्रकारका १ फन्टहरूका लागि थम्बनेल आदेश"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "खुला प्रकारका फन्टहरूलाई थम्बनेल गर्नु पर्दछ या पर्दैन"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCFफन्टहरूलाई थम्बनेल गर्नु पर्दछ या पर्दैन"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "सहि प्रकारका फन्टहरूलाई थम्बनेल गर्नु पर्दछ या पर्दैन"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "प्रकार १ फन्टहरूलाई थम्बनेल गर्नु पर्दछ या पर्दैन"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "फुर्तिलो खैरो फ्याउरो अल्छी कुकुरमाथि उफ्रिन्छ ।०१२३४५६७८९"
+
+#~ msgid "Copyright:"
+#~ msgstr "प्रतिलिपि अधिकार:"
+
+#~ msgid "Description:"
+#~ msgstr "वर्णन:"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "प्रयोग: %s फन्टफाइल\n"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "जिनोम फन्ट दर्शक"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "थम्बनेलमा पाठ (पूर्वनिर्धारित: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "पाठ"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "फन्ट साइज (पूर्वनिर्धारित: ६४)"
+
+#~ msgid "SIZE"
+#~ msgstr "साइज"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">नयाँ फन्ट लागू गर्नुहुन्छ?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "फन्ट लागू नगर्नुहोस्"
+
+#~ msgid "The theme you have selected suggests a new font. A preview of the font is shown below."
+#~ msgstr "तपाईँले चयन गर्नुभएको विषयवस्तुले एउटा नयाँ फन्टको सुझाव दिन्छ । फन्टको एउटा पूर्वावलोकन तल देखाइन्छ ।"
+
+#~ msgid "Themes"
+#~ msgstr "विषयवस्तुहरू"
+
+#~ msgid "Description"
+#~ msgstr "वर्णन"
+
+#~ msgid "Control theme"
+#~ msgstr "विषयवस्तु नियन्त्रण गर्नुहोस्"
+
+#~ msgid "Window border theme"
+#~ msgstr "सञ्झ्याल किनारा विषयवस्तु"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "यदि सेट सहि भएमा, स्थापित विषयवस्तुहरूलाई थम्बनेल गरिनेछ ।"
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "यदि सेट सहि भएमा, विषयवस्तुहरूलाई थम्बनेल गरिनेछ ।"
+
+#~ msgid "Set this key to the command used to create thumbnails for installed themes."
+#~ msgstr "स्थापन गरिएको विषयवस्तुहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr "विषयवस्तुहरूका लागि थम्बनेलहरू सिर्जना गर्न प्रयोग गरिने आदेशमा यो कुञ्जीलाई सेट गर्नुहोस् ।"
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "स्थापित विषयवस्तुहरूका लागि थम्बनेल आदेश"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "विषयवस्तुहरूका लागि थम्बनेल आदेश"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "स्थापित विषयवस्तुहरुलाई थम्बनेल गर्नु पर्दछ या पर्दैन"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "विषयवस्तुहरुलाई थम्बनेल गर्नु पर्दछ या पर्दैन"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#~ msgid "[FILE]"
+#~ msgstr "[FILE]"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "पूर्वनिर्धारित विषयवस्तु सेट गर्दछ"

--- a/po/nl.po
+++ b/po/nl.po
@@ -20,13 +20,13 @@
 # Nathan Follens <nfollens@gnome.org>, 2015-2022.
 # Hannie Dumoleyn <hannie@ubuntu-nl.org>, 2011, 2012, 2013, 2014, 2015, 2017, 2018, 2020, 2021.
 # Justin van Steijn <jvs@fsfe.org>, 2016, 2018.
+# Philip Goto <philip.goto@gmail.com>, 2022.
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-05-27 03:58+0000\n"
-"PO-Revision-Date: 2022-07-04 10:38+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-10-05 20:46+0200\n"
 "Last-Translator: Nathan Follens <nfollens@gnome.org>\n"
 "Language-Team: Dutch <gnome-nl-list@gnome.org>\n"
 "Language: nl\n"
@@ -34,104 +34,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.1\n"
+"X-Generator: Poedit 3.1.1\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:790
-msgid "System Bus"
-msgstr "Systeembus"
-
-#: panels/applications/cc-applications-panel.c:790
-#: panels/applications/cc-applications-panel.c:792
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:810
-msgid "Full access"
-msgstr "Volledige toegang"
-
-#: panels/applications/cc-applications-panel.c:792
-msgid "Session Bus"
-msgstr "Sessiebus"
-
-#: panels/applications/cc-applications-panel.c:796
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Apparaten"
-
-#: panels/applications/cc-applications-panel.c:796
-msgid "Full access to /dev"
-msgstr "Volledige toegang tot /dev"
-
-#: panels/applications/cc-applications-panel.c:800
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Netwerk"
-
-#: panels/applications/cc-applications-panel.c:800
-msgid "Has network access"
-msgstr "Heeft netwerktoegang"
-
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:807
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Persoonlijke map"
-
-#: panels/applications/cc-applications-panel.c:807
-#: panels/applications/cc-applications-panel.c:812
-msgid "Read-only"
-msgstr "Alleen-lezen"
-
-#: panels/applications/cc-applications-panel.c:810
-#: panels/applications/cc-applications-panel.c:812
-msgid "File System"
-msgstr "Bestandssysteem"
-
-#: panels/applications/cc-applications-panel.c:816
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Instellingen"
-
-#: panels/applications/cc-applications-panel.c:816
-msgid "Can change settings"
-msgstr "Kan instellingen wijzigen"
-
-#: panels/applications/cc-applications-panel.c:818
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s heeft volgende ingebouwde rechten. Deze kunnen niet gewijzigd worden. "
-"Indien u hier bezorgd om bent, kunt u de toepassing verwijderen."
-
-#: panels/applications/cc-applications-panel.c:1154
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u bestands- en verwijzingstype wordt geopend door de toepassing"
-msgstr[1] "%u bestands- en verwijzingstypes worden geopend door de toepassing"
-
-#: panels/applications/cc-applications-panel.c:1161
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> wordt gebruikt om de volgende types bestanden en verwijzingen te "
-"openen."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1213
-#, c-format
-msgid "%s of disk space used"
-msgstr "%s aan schijfruimte in gebruik"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1377
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -148,7 +54,6 @@ msgid "Install some…"
 msgstr "Installeer enkele…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Openen"
 
@@ -159,6 +64,10 @@ msgstr "Details bekijken"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Zoeken"
@@ -168,24 +77,13 @@ msgstr "Zoeken"
 msgid "Receive system searches and send results."
 msgstr "Ontvang systeemzoekopdrachten en stuur zoekresultaten terug."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1900
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Uitgeschakeld"
 
@@ -199,7 +97,7 @@ msgid "Show system notifications."
 msgstr "Toon systeemnotificaties."
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+msgid "Run in Background"
 msgstr "Uitvoeren op de achtergrond"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -207,132 +105,143 @@ msgid "Allow activity when the app is closed."
 msgstr "Sta activiteit toe wanneer de toepassing gesloten is."
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Schermafdrukken"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Maak op elk moment foto’s van het scherm."
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "Achtergrond wijzigen"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "Wijzig de bureaubladachtergrond."
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Geluiden"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "Maak geluid."
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "Sneltoetsen blokkeren"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "Blokkeer standaardsneltoetsen."
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "Camera"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
-msgstr "Maak foto's met de camera."
+msgstr "Maak foto’s met de camera."
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "Microfoon"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "Neem geluid op met de microfoon."
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Locatiediensten"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "Toegang tot locatiegegevens van apparaat."
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "Ingebouwde rechten"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "Systeemtoegang die door de toepassing vereist wordt"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "Bestands- &amp; verwijzingsassociaties"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Opslag"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Geen resultaat gevonden"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Probeer een andere zoekopdracht"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "Bestands- en verwijzingsassociaties"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "Bestandstypes"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "Verwijzingstypes"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Opnieuw instellen"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Hoe veel opslagruimte deze toepassing bezet met toepassingsgegevens en "
 "cachegeheugen."
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Toepassing"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Gegevens"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Cachegeheugen"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Totaal</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Cachegeheugen wissen…"
 
@@ -340,92 +249,34 @@ msgstr "Cachegeheugen wissen…"
 msgid "Control various application permissions and settings"
 msgstr "Beheer verschillende toepassingsrechten en -instellingen"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "application;flatpak;permission;setting;toepassing;rechten;machtigingen;"
 "instellingen;"
 
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "Selecteer een afbeelding"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:519 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "_Annuleren"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:520
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Openen"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "meerdere groottes"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Geen werkbladachtergrond"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Huidige achtergrond"
-
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stijl"
 
-#: panels/background/cc-background-panel.ui:46
-msgid "Light"
-msgstr "Licht"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Standaard"
 
-#: panels/background/cc-background-panel.ui:73
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "Donker"
 
-#: panels/background/cc-background-panel.ui:92
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Achtergrond"
 
-#: panels/background/cc-background-panel.ui:98
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "Afbeelding toevoegen…"
 
@@ -438,53 +289,60 @@ msgid "Change your background image or the UI colors"
 msgstr ""
 "Wijzig uw achtergrondafbeelding of de kleuren van de gebruikersinterface"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
-"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Achtergrond;"
-"Bureaubladachtergrond;Scherm;Bureaublad;Stijl;Licht;Donker;"
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;Achtergrond;"
+"Bureaubladachtergrond;Scherm;Bureaublad;Stijl;Licht;Donker;Weergave;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Inschakelen"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Bluetooth niet aangetroffen"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Sluit een dongle aan om Bluetooth te gebruiken."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth uitgeschakeld"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 "Schakel in om apparaten aan te sluiten en bestandsoverdrachten te ontvangen."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "Vliegtuigstand is aan"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth wordt uitgeschakeld als vliegtuigstand aan staat."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Vliegtuigstand uitzetten"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "Hardware-vliegtuigstand is aan"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Vliegtuigstand uitschakelen om Bluetooth mogelijk te maken."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -492,20 +350,19 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Bluetooth aan- en uitzetten en uw apparaten aansluiten"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;delen;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "Camera is uitgeschakeld"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Er zijn geen toepassingen die foto’s of video’s kunnen maken."
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
@@ -518,7 +375,7 @@ msgstr ""
 "\n"
 "Sta de onderstaande toepassingen toe uw camera te gebruiken."
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Er hebben nog geen toepassingen toegang tot de camera gevraagd"
 
@@ -526,96 +383,35 @@ msgstr "Er hebben nog geen toepassingen toegang tot de camera gevraagd"
 msgid "Protect your pictures"
 msgstr "Bescherm uw foto’s"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;scherm;vergrendelen;privé;tijdelijk;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Plaats uw kalibratieapparaat boven het vierkant en druk op ‘Starten’"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Zet uw kalibratieapparaat in de kalibratiepositie en druk op ‘Doorgaan’"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Zet uw kalibratieapparaat in de oppervlaktepositie en druk op ‘Doorgaan’"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Sluit het deksel van de laptop"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Er is een interne fout opgetreden die niet hersteld kon worden."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "De hulpmiddelen nodig voor de kalibratie zijn niet geïnstalleerd."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Het profiel kon niet gegenereerd worden."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Het ‘target whitepoint’ was niet te krijgen."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Klaar!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibratie mislukt!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "U kunt het kalibratieapparaat verwijderen."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Niet aan het kalibratieapparaat komen terwijl dit proces loopt"
+"camera;photos;video;webcam;lock;private;privacy;foto;video;vergrendel;privé;"
+"privacy;"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kalibratie weergeven"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Annuleren"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -629,144 +425,9 @@ msgstr "He_rvatten"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Klaar"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Laptopscherm"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Ingebouwde webcam"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s-beeldscherm"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s-scanner"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s-camera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s-printer"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s-webcam"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Kleurbeheer voor %s inschakelen"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Kleurprofielen voor %s tonen"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Niet gekalibreerd"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Standaard: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Kleurruimte: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Testprofiel: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "ICC-profiel selecteren"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importeren"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Ondersteunde ICC-profielen"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Alle bestanden"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Scherm"
-
-# bij een browser is dit bladwijzers, maar hier is
-# favorieten/favoriet beter (favoriete programma's) (tino)
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Profiel opslaan"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "Op_slaan"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Kleurprofiel maken voor het geselecteerde apparaat"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Het meetinstrument is niet gevonden. Controleer of het aan staat en correct "
-"verbonden is."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Het meetinstrument ondersteunt het profileren van printers niet."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Dit type apparaat wordt niet ondersteund."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -883,9 +544,9 @@ msgstr "Schrijfbaar medium vereist"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "De instructies over hoe een profiel te gebruiken op <a href=\"linux\">GNU/"
 "Linux</a>, <a href=\"osx\">Apple OS X</a>- en <a href=\"windows\">Microsoft "
@@ -900,16 +561,16 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Er zijn problemen ontdekt. Het profiel werkt mogelijk niet correct. <a href="
-"\"\">Details tonen.</a>"
+"Er zijn problemen ontdekt. Het profiel werkt mogelijk niet correct. <a "
+"href=\"\">Details tonen.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
 msgstr "Bestand _importeren…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "_Toevoegen"
@@ -920,9 +581,7 @@ msgstr ""
 "Elk apparaat heeft een actueel bijgewerkt kleurprofiel nodig om gebruik te "
 "maken van kleurbeheer."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Meer informatie"
 
@@ -1056,82 +715,6 @@ msgstr "D65 (Fotografie en afbeeldingen)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standaard kleurruimte"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testprofiel"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatisch"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Lage kwaliteit"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Gemiddelde kwaliteit"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Hoge kwaliteit"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Standaard RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Standaard CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Standaard grijs"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Fabrieksinstellingen voor kalibratie zijn door fabrikant geleverd"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Volledig scherm-correctie is niet mogelijk met dit profiel"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Dit profiel is mogelijk niet meer accuraat"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Kleur"
@@ -1143,14 +726,9 @@ msgstr ""
 "De kleur van uw apparaten, zoals beeldschermen, camera’s of printers "
 "kalibreren"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Color;ICC;Profile;Calibrate;Printer;Display;Kleur;Kalibreren;Weergave;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Ander profiel…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1165,21 +743,16 @@ msgid "No languages found"
 msgstr "Er zijn geen talen aangetroffen"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Meer…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Ontgrendel om instellingen te wijzigen"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr ""
 "Sommige instellingen moeten eerst ontgrendeld worden vooraleer ze gewijzigd "
 "kunnen worden."
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "Ontgrendelen…"
 
@@ -1204,151 +777,6 @@ msgstr "Uur verlagen"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Minuut verlagen"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Vandaag"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Gisteren"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%d %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%d %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d uur"
-msgstr[1] "%d uur"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuut"
-msgstr[1] "%d minuten"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d seconde"
-msgstr[1] "%d seconden"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 seconden"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-uurs"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%k:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1432,32 +860,67 @@ msgstr "Automatische _datum &amp; tijd"
 msgid "Requires internet access"
 msgstr "Internetverbinding vereist"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "Datum &amp; _tijd"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Automatische tijd_zone"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "Vereist locatiediensten en internettoegang"
 
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Ingeschakeld"
+
 # Is dit intervaltijd uit de dubbelklik-pref of iets anders?
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "_Tijdzone"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Ontgrendelen"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Tijd_notatie"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Data"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 seconden"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Agenda"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Getallen"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Datum en tijd, inclusief tijdzone, wijzigen"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;Klok;Tijdzone;Locatie;"
@@ -1505,21 +968,9 @@ msgstr "Standaardtoepassingen"
 msgid "Configure Default Applications"
 msgstr "Standaardtoepassingen configureren"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "default;application;preferred;media;standaard;toepassing;voorkeur;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Het sturen van rapporten over technische problemen helpt ons %s te "
-"verbeteren. Rapporten worden anoniem verstuurd en bevatten geen persoonlijke "
-"gegevens. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1538,155 +989,117 @@ msgstr "Bevindingen"
 msgid "Report your problems"
 msgstr "Meld uw problemen"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+# 'Bevindingen' stond in mijn vertaalgeheugen van andere GNOME-toepassingen, anders zou ik iets met 'Diagnostiek' gebruiken - Nathan
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;scherm;vergrendelen;privé;tijdelijk;naam;netwerk;"
-"identiteit;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Aan"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Uit"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "Wijzigingen toepassen?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "Wijzigingen kunnen niet worden toegepast"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "Dit kan het gevolg zijn van hardwarebeperkingen."
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;bevindingen;"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Toepassen"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Terug"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr "Scherminstellingen uitgeschakeld"
 
-# Select a display language (change will be applied next time you log in)
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "Schermvolgorde"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "Meerdere schermen"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "Samenvoegen"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Spiegelen"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Bevat de bovenste balk en Activiteiten"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Primair scherm"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Nachtlicht"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Liggend"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Staand rechts"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Staand links"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Liggend (omgedraaid)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Stand"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Resolutie"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Verversingsfrequentie"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Aanpassen aan tv"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Schalen"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Natuurlijk schuiven"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nachtlicht niet beschikbaar"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Dit kan het resultaat zijn van het gebruikte grafische stuurprogramma, of "
+"omdat het bureaublad op afstand wordt gebruikt"
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Tijdelijk uitgeschakeld tot morgen"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "Filter herstarten"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1694,61 +1107,61 @@ msgstr ""
 "Nachtlicht maakt de schermkleur warmer. Dit kan helpen vermoeide ogen en "
 "slapeloosheid te voorkomen."
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Planning"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Zonsondergang tot zonsopgang"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Handmatige planning"
 
 # Is dit intervaltijd uit de dubbelklik-pref of iets anders?
 # Rachid: het wordt in de code gebruikt bij datum en de opmaak voor tijd dingen dus het lijkt mij iets met TIJD te maken te hebben ;)
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Tijden"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Van"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "uur"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "minuut"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "am"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "pm"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "tot"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Kleurtemperatuur"
 
@@ -1760,7 +1173,6 @@ msgstr "Schermen"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Kiezen hoe aangesloten beeldschermen en projectoren gebruikt worden"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1770,54 +1182,58 @@ msgstr ""
 "redshift;color;sunset;sunrise;Paneel;Scherm;Resolutie;Verversen;Beeldscherm;"
 "Nacht;Licht;Blauw;kleur;zonsondergang;zonsopgang;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Onbekend"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Veilig opstarten voorkomt dat kwaadaardige software wordt geladen wanneer "
+"het apparaat wordt opgestart.\n"
+"\n"
+"Voor meer informatie kunt u contact opnemen met de hardwarefabrikant of IT-"
+"ondersteuning."
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; build-ID: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr "Beveiligingsniveau"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Niveau 1"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Niveau 2"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Niveau 3"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Geen gebeurtenissen"
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Onbekend"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Apparaatbeveiliging"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Systeemlogo"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Firmwarebeveiligingsstatus van host"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;scherm;vergrendelen;privé;tijdelijk;naam;netwerk;"
+"identiteit;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Apparaatnaam"
 
@@ -1850,31 +1266,41 @@ msgstr "Wordt berekend…"
 msgid "OS Name"
 msgstr "Naam besturingssysteem"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "build-ID van besturingssysteem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Type besturingssysteem"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Gnome-versie"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Laden…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Venstersysteem"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Virtualisatie"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Software-updates"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Apparaat hernoemen"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1882,7 +1308,11 @@ msgstr ""
 "De apparaatnaam wordt gebruikt om dit apparaat te identificeren in het "
 "netwerk, of bij het koppelen van Bluetooth-apparaten."
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Apparaatnaam"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "He_rnoemen"
 
@@ -1895,11 +1325,6 @@ msgid "View information about your system"
 msgstr "Systeeminformatie bekijken"
 
 # The user can search on this keywords. Thereby we chose to let the translation contain both English and Dutch words.
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1979,6 +1404,12 @@ msgstr "Starters"
 msgid "Launch help browser"
 msgstr "Hulptoepassing starten"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Instellingen"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Rekenmachine starten"
@@ -2000,7 +1431,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Zoeken"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Systeem"
 
@@ -2049,20 +1480,11 @@ msgstr "Kleinere tekst"
 msgid "High contrast on or off"
 msgstr "Hoog contrast aan of uit"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Er zijn geen invoerbronnen aangetroffen"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Overige"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Invoerbron toevoegen"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Invoermethoden kunnen niet gebruikt worden in het aanmeldscherm"
 
@@ -2070,122 +1492,29 @@ msgstr "Invoermethoden kunnen niet gebruikt worden in het aanmeldscherm"
 msgid "No input source selected"
 msgstr "Er zijn geen invoerbronnen geselecteerd"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opties"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "Naar boven"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "Naar beneden"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Toetsenbordindeling bekijken"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Verwijderen"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Aangepaste sneltoets"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "Toets voor alternatieve tekens"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"De alternatievetekenstoets kan gebruikt worden om extra tekens in te voeren. "
-"Deze worden soms als derde teken op uw toetsenbord gedrukt."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Linker Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Rechter Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Linker Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Rechter Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menutoets"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Rechter Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Samensteltoets"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Met de samensteltoets kan een grote verscheidenheid aan tekens worden "
-"ingevoerd. Om deze te gebruiken, drukt u op samenstellen en vervolgens op "
-"een reeks tekens. Bijvoorbeeld, samensteltoets gevolgd door <b>C</b> en "
-"<b>o</b> geeft <b>©</b>, <b>a</b> gevolgd door <b>'</b> geeft <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Schakelen tussen invoerbronnen is mogelijk met de sneltoets %s.\n"
-"Dit kan gewijzigd worden in de sneltoetsinstellingen."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2207,55 +1536,30 @@ msgstr "Dezelfde _bron gebruiken voor alle vensters"
 msgid "Switch input sources _individually for each window"
 msgstr "Wisselen van Invoerbron af_zonderlijk voor elk venster"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Invoer voor speciale tekens"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Methoden om symbolen en lettervarianten in te voeren met het toetsenbord."
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Toets voor alternatieve tekens"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Samensteltoets"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Sneltoetsen"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Sneltoetsen bekijken en aanpassen"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d aangepast"
-msgstr[1] "%d aangepast"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Alle sneltoetsen opnieuw instellen?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Het opnieuw instellen van de sneltoetsen kan invloed hebben op uw aangepaste "
-"sneltoetsen. Dit kan niet ongedaan worden gemaakt."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Annuleren"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Alles opnieuw instellen"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2265,98 +1569,87 @@ msgstr "Alles opnieuw instellen…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Alle sneltoetsen naar hun standaardwaarde terugzetten"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sectie"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Sneltoetsen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Sneltoets toevoegen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Aangepaste sneltoetsen toevoegen"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "Aangepaste sneltoetsen instellen voor het starten van toepassingen, het "
 "uitvoeren van scripts en meer."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Sneltoets toevoegen"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Geen sneltoets gevonden"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s wordt al gebruikt voor %s. Als u deze vervangt, zal %s worden "
-"uitgeschakeld"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Verwijderen"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Voer de nieuwe sneltoets in"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Ve_rvangen"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Aangepaste sneltoets instellen"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "In_stellen"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Sneltoets instellen"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Voer een nieuwe sneltoets in om %s te wijzigen."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Aangepaste sneltoets toevoegen"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Toevoegen"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
-msgstr "Vervangen"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "Instellen"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Druk op Esc om te annuleren, of Backspace om de sneltoets uit te schakelen."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Naam"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Opdracht"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Sneltoets"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Sneltoets instellen…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Geen"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Sneltoets naar standaardwaarde terugzetten"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Uw camera gebruiken"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2370,7 +1663,6 @@ msgstr ""
 "Wijzig uw sneltoetsen bekijken en stel uw typvoorkeuren, "
 "toetsenbordindelingen en invoerbronnen in"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2378,15 +1670,15 @@ msgstr ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 "Sneltoets;Werkruimte;Venster;Vergrendelen;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "Locatiediensten zijn uitgeschakeld"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Er zijn geen toepassingen die locatie-informatie kunnen verkrijgen."
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2404,7 +1696,7 @@ msgstr ""
 "\n"
 "Sta de onderstaande toepassingen toe om uw locatie te bepalen."
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Er hebben nog geen toepassingen toegang tot uw locatie gevraagd"
 
@@ -2412,177 +1704,19 @@ msgstr "Er hebben nog geen toepassingen toegang tot uw locatie gevraagd"
 msgid "Protect your location information"
 msgstr "Beveilig uw locatie-informatie"
 
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Scherm wordt uitgeschakeld"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;locatie;privé;"
 
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 seconden"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuut"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minuten"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minuten"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minuten"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minuten"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 uur"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "5 minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minuten"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nooit"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
-msgstr ""
-"Door het scherm automatisch te vergrendelen kunnen anderen uw computer niet "
-"gebruiken terwijl u weg bent."
-
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "Vertraging voor zwart scherm"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Periode van inactiviteit waarna het scherm zwart wordt."
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "Automatische s_chermvergrendeling"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "Vertraging voor automatische _schermvergrendeling"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-"Punt waarop het scherm automatisch wordt vergrendeld na op zwart gestaan te "
-"hebben."
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "_Notificaties tonen op vergrendelingsscherm"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "Nieuwe _USB-apparaten verbieden"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Voorkomen dat nieuwe USB-apparaten interactie hebben met het systeem wanneer "
-"het scherm is vergrendeld."
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Schermvergrendeling"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Vergrendel uw scherm"
-
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "Microfoon is uitgeschakeld"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Er zijn geen toepassingen die geluid kunnen opnemen."
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2596,13 +1730,18 @@ msgstr ""
 "\n"
 "Sta de onderstaande toepassingen toe uw microfoon te gebruiken."
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Er hebben nog geen toepassingen toegang tot uw microfoon gevraagd"
 
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:4
 msgid "Protect your conversations"
 msgstr "Bescherm uw gesprekken"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"microphone;recording;application;privacy;microfoon;opname;opnemen;toepassing;"
 
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
@@ -2621,84 +1760,150 @@ msgstr "Primaire knop"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "Stelt de volgorde van fysieke knoppen in op muizen en touchpads."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Links"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Rechts"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Zoeklocaties"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Muis"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Aanwijzersnelheid"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "Natuurlijk schuiven"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Omlaag schuiven"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Schuiven beweegt de inhoud, niet de weergave."
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Schuiven beweegt de inhoud, niet de weergave."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Actief"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Touchpadsnelheid"
 
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
 # op het touchpad tikken om te klikken
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Tikken om te klikken"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "Scrollen met twee vingers"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+# op het touchpad tikken om te klikken
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr "Tikken om te klikken"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Afbeelding uitschakelen"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relatief)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Aan de rand schuiven"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Omlaag schuiven"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Tweezijdig"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Probeer te klikken, dubbelklikken, of scrollen"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Vijf klikken, GEGL-tijd!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dubbelklik, primaire knop"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Enkele klik, primaire knop"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dubbelklik, middelste knop"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Enkele klik, middelste knop"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dubbelklik, secundaire knop"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Enkele klik, secundaire knop"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2711,7 +1916,6 @@ msgstr ""
 "De gevoeligheid van muis of touchpad wijzigen en rechts- of linkshandig "
 "kiezen"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -2793,86 +1997,39 @@ msgstr "Multitasken"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Beheer voorkeuren voor productiviteit en multitasken"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
-"Multitasking;Multitask;Productivity;Customize;Desktop;Multitasken;"
-"Productiviteit;Aanpassen;Bureaublad;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Oeps! Er ging iets mis. Neem contact op met uw softwareleverancier."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Netwerkbeheer moet draaien."
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"Multitasken;Productiviteit;Aanpassen;Bureaublad;Snelhoek;Werkbladen;"
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Overige apparaten"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Verbinding toevoegen"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Niet ingesteld"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "Onveilig netwerk (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "Beveiligd netwerk (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "Beveiligd netwerk (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "Beveiligd netwerk (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "Beveiligd netwerk"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Verbonden"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opties…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Door de hotspot in te schakelen verbreekt u de verbinding met %s, en zult u "
-"geen toegang tot het internet hebben via wifi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Moet minimaal 8 tekens bevatten"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -2900,355 +2057,87 @@ msgid "Network Name"
 msgstr "Netwerknaam"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Willekeurig wachtwoord genereren"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Wachtwoord automatisch genereren"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Inschakelen"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wifi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Hotspot stoppen en verbinding verbreken met gebruikers?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "Hotspot _stoppen"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Vliegtuigstand"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Schakelt wifi, bluetooth en mobiel breedband uit"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Geen wifi-adapter gevonden"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Zorg ervoor dat u een wifi-adapter heeft aangesloten en ingeschakeld"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Vliegtuigstand aan"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Schakel uit om wifi te gebruiken"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Wifi-hotspot ingeschakeld"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Mobiele apparaten kunnen de QR-code scannen om verbinding te maken."
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Wifi-hotspot uitschakelen…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Zichtbare netwerken"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "Netwerkbeheer moet draaien"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Oeps! Er ging iets mis. Neem contact op met uw softwareleverancier."
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x-_beveiliging"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Beveiliging"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Behouden"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Willekeurig"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabiel"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Het ingevoerde MAC-adres zal gebruikt worden als het hardware-adres voor het "
-"netwerkapparaat waarop deze verbinding is geactiveerd. Dit wordt ‘MAC "
-"cloning’ of ‘spoofing’ genoemd. Voorbeeld: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profiel %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-# Kan niet vertaald worden. - Nathan
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Geen"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Nooit"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i dag geleden"
 msgstr[1] "%i dagen geleden"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Geen"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Zwak"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Oké"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Goed"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Uitstekend"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4-adres"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "IPv6-adres"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP-adres"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "Verbinding vergeten"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "Verbindingsprofiel verwijderen"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "VPN verwijderen"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "Details"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatisch"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identiteit"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Adres verwijderen"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "Route verwijderen"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Geen"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bits sleutel (hex of ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bits wachtwoord"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamische WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA en WPA2 Persoonlijk"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA en WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Persoonlijk"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3259,8 +2148,20 @@ msgstr "Signaalsterkte"
 msgid "Link speed"
 msgstr "Verbindingssnelheid"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Beveiliging"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4-adres"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-adres"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hardware-adres"
 
@@ -3269,12 +2170,17 @@ msgid "Supported Frequencies"
 msgstr "Ondersteunde frequenties"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Standaardroute"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3288,11 +2194,11 @@ msgstr "_Automatisch verbinden"
 msgid "Make available to _other users"
 msgstr "Beschikbaar maken voor andere _gebruikers"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr "Verbinding _met datalimiet: houdt mogelijk kosten in"
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3337,7 +2243,7 @@ msgstr "Alleen Link-Local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Handmatig"
 
@@ -3357,33 +2263,32 @@ msgid "Addresses"
 msgstr "Adressen"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Adres"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Netmasker"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Gateway"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Automatisch"
 
@@ -3392,29 +2297,34 @@ msgstr "Automatisch"
 msgid "Automatic DNS"
 msgstr "Automatische DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS-serveradres(sen)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Scheid IP-adressen met komma’s"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Routes"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Automatische routes"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metrisch"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Deze verbinding _alleen gebruiken voor bronnen op hun netwerk"
 
@@ -3427,83 +2337,13 @@ msgid "Automatic, DHCP only"
 msgstr "Automatisch, alleen DHCP"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Voorvoegsel"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Openen van verbindingseditor mislukt"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Nieuw profiel"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Uit bestand importeren…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "VPN toevoegen"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "B_eveiliging"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Kan VPN-verbinding niet importeren"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Het bestand ‘%s’ kon niet gelezen worden, of bevat geen herkende informatie "
-"over de VPN-verbinding\n"
-"\n"
-"Fout: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Het te importeren bestand selecteren"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Er bestaat al een bestand met de naam ‘%s’."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "Ve_rvangen"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Wilt u %s vervangen door de VPN-verbinding die u op wilt slaan?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Kan VPN-verbinding niet exporteren"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"De VPN-verbinding ‘%s’ kon niet geëxporteerd worden naar %s.\n"
-"\n"
-"Fout: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "VPN-verbinding exporteren"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3517,106 +2357,48 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Netwerk"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Regelen hoe u verbinding maakt met het internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;Netwerk;IP;LAN;Proxy;WAN;Broadband;Breedband;Modem;Bluetooth;vpn;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wifi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Regelen hoe u verbinding maakt met wifi-netwerken"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;Netwerk;Wireless;Draadloos;Wi-Fi;Wifi;IP;LAN;Broadband;Breedband;DNS;"
 "Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nooit"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "vandaag"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "gisteren"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Laatst gebruikt"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Bekabeld"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Nieuwe verbinding toevoegen"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Netwerkdetails voor de geselecteerde netwerken, inclusief wachtwoord en "
-"aangepaste configuratie, zullen verloren gaan."
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "_Vergeten"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Bekende wifi-netwerken"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Vergeten"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Systeembeleid staat gebruik als hotspot niet toe"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Draadloos apparaat ondersteunt de hotspot-modus niet"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Automatisch ontdekken van de web-proxy wordt gebruikt als er geen "
-"configuratie-url is opgegeven."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Dit wordt afgeraden voor niet-vertrouwde publieke netwerken."
-
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Apparaat uitzetten"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Actief"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3627,47 +2409,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Provider"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adres"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Netwerkproxy"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP-proxy"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "H_TTPS-proxy"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "_FTP-proxy"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "S_ocks-host"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "Hostcomputers _negeren"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Poort HTTP-proxy"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Poort HTTPS-proxy"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Poort FTP-proxy"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Poort Socks-proxy"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "_Configuratie-URL"
 
@@ -3694,300 +2480,21 @@ msgstr "Wachtwoord"
 msgid "Turn Wi-Fi off"
 msgstr "Wifi uitschakelen"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Meer opties…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Verbinden met een verborgen netwerk…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Wifi-hotspot i_nschakelen…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "Be_kende wifi-netwerken"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Onbekende status"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Niet-gemanaged"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Niet beschikbaar"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Verbinden"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Authenticatie vereist"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Verbinding verbreken"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Verbinding mislukt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Onbekende status (ontbreekt)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Configuratie mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP-configuratie mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP-configuratie verlopen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Geheimen werden vereist, maar niet verstrekt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Niet verbonden met 802.1x supplicant"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Configuratie 802.1x supplicant mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x supplicant mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant authenticatie duurde te lang"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Starten van PPP-dienst mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Niet verbonden met PPP-dienst"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Starten van DHCP-client mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Fout DHCP-client"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP-client mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Starten van gedeelde verbinding-dienst mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Gedeelde verbinding-dienst mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Starten van AutoIP-dienst mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Fout AutoIP-dienst"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP-dienst mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Lijn bezet"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Geen kiestoon"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Er kon geen carrier worden vastgesteld"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Tijdslimiet belaanvraag overschreden"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Belpoging mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Initialisatie van modem mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Selecteren van opgegeven APN mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Er wordt niet naar netwerken gezocht"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Netwerkregistratie geweigerd"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Tijdslimiet netwerkregistratie verlopen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Registreren bij het gevraagde netwerk mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Controle van pincode mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Mogelijk ontbreekt de firmware voor het apparaat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Verbinding verdwenen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Er werd uitgegaan van de bestaande verbinding"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem niet gevonden"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth-verbinding mislukt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Simkaart niet ingebracht"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Pincode voor simkaart vereist"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Pukcode voor simkaart vereist"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Verkeerde simkaart"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Verbindingsafhankelijkheid mislukt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Firmware ontbreekt"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabel niet verbonden"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "ongedefinieerde fout in 802.1X-beveiliging (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "geen bestand geselecteerd"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "niet-opgegeven fout bij valideren van eap-method-bestand"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER-, PEM- of PKCS#12-privésleutels (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER- of PEM-certificaten (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "EAP-FAST PAC-bestand ontbreekt"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC-bestanden (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4043,14 +2550,6 @@ msgstr "_Interne aanmeldingscontrole"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Automatische PAC-_voorziening toestaan"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "EAP-LEAP-gebruikersnaam ontbreekt"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "EAP-LEAP-wachtwoord ontbreekt"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4063,7 +2562,7 @@ msgstr "Gebr_uikersnaam"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Wachtwoord"
 
@@ -4075,15 +2574,6 @@ msgstr "_Wachtwoord"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Wachtwoord tonen"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "ongeldig EAP-PEAP CA-certificaat: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "ongeldig EAP-PEAP CA-certificaat: geen certificaat opgegeven"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4112,7 +2602,6 @@ msgid "C_A certificate"
 msgstr "C_A-certificaat"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4127,63 +2616,6 @@ msgstr "Geen CA-certificaat vereist"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP-_versie"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "EAP-gebruikersnaam ontbreekt"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "EAP-wachtwoord ontbreekt"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "EAP-TLS-identiteit ontbreekt"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "ongeldig EAP-TLS CA-certificaat: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "ongeldig EAP-TLS CA-certificaat: geen certificaat opgegeven"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "ongeldige EAP-TLS-privésleutel: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "ongeldig EAP-TLS-gebruikerscertificaat: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Niet-versleutelde privésleutels zijn onveilig"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"De geselecteerde privésleutel lijkt niet te zijn beveiligd met een "
-"wachtwoord. Dit kan ertoe leiden dat uw beveiligingsgegevens in gevaar "
-"komen. Kies een privésleutel die met een wachtwoord is beveiligd.\n"
-"\n"
-"(U kunt uw privésleutel beveiligen met openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Kies uw persoonlijke certificaat"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Kies uw privésleutel"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4200,15 +2632,6 @@ msgstr "Privé_sleutel"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Wachtwoord _privésleutel"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "ongeldig EAP-TTLS CA-certificaat: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "ongeldig EAP-TTLS CA-certificaat: geen certificaat opgegeven"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4231,14 +2654,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domein"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Onbekende fout bij valideren van 802.1X-beveiliging"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4272,62 +2696,10 @@ msgstr "Beveiligde EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Controleren"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Selecteer een bestand"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "leap-gebruikersnaam ontbreekt"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "leap-wachtwoord ontbreekt"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Wifi-wachtwoord ontbreekt."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Type"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "wep-sleutel ontbreekt"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"ongeldige wep-sleutel: sleutel met een lengte van %zu kan enkel hex-cijfers "
-"bevatten"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"ongeldige wep-sleutel: sleutel met een lengte van %zu kan enkel ascii-tekens "
-"bevatten"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"ongeldige wep-sleutel: verkeerde sleutellengte %zu. Een sleutle moet ofwel "
-"5/13 tekens (ascii) of 10/26 tekens (hex) lang zijn"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "ongeldige wep-sleutel: wachtwoord mag niet leeg zijn"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "ongeldige wep-sleutel: wachtwoord moet korter dan 64 tekens zijn"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4352,19 +2724,6 @@ msgstr "Sleutel t_onen"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP-inde_x"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"ongeldige wpa-psk: ongeldige sleutellengte %zu. Moet [8,63] bytes of 64 hex-"
-"cijfers zijn"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "ongeldige wpa-psk: kan sleutel met 64 bytes niet interpreteren als hex"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4419,60 +2778,35 @@ msgstr "_Notificaties op vergrendelingsscherm"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Regelen welke notificaties weergegeven worden en wat ze tonen"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Notifications;Notificaties;Banners;Banieren;Bericht;Message;Tray;Systeemvak;"
 "Pop-up;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "%s verwijderd"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Overige"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Fout bij verwijderen van account"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Ongedaan maken"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Notificatie sluiten"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "Met uw data in de cloud verbinden"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "Geen internetverbinding — maak verbinding om nieuwe online-accounts in te "
 "stellen"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Een account toevoegen"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s-account"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Account verwijderen"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4482,10 +2816,6 @@ msgstr "Online accounts"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Verbind met uw online-accounts en bepaal waar u ze voor gebruikt"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4493,10 +2823,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Agenda;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Onbekende tijd"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4512,13 +2838,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i uur"
 msgstr[1] "%i uur"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4530,188 +2849,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuut"
 msgstr[1] "minuten"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s totdat deze volledig opgeladen is"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Waarschuwing: %s resterend"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s resterend"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Volledig opgeladen"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Niet aan het opladen"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Leeg"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Aan het opladen"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Aan het ontladen"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Draadloze muis"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Draadloos toetsenbord"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Onderbrekingsvrije voeding"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Personal digital assistant"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobiele telefoon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Mediaspeler"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Computer"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Gamings-invoerapparaat"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Accu"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Hoofd"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Extra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Accu’s"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "Wanneer i_nactief"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "Pauzestand"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "Uitschakelen"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "Slaapstand"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "Niets doen"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "Wanneer op accustroom"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "Als de kabel aangesloten is"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nooit"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "Automatisch in pauzestand zetten"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "Prestatiemodus tijdelijk uitgeschakeld wegens hoge temperaturen."
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Schoot gedetecteerd: prestatiemodus tijdelijk niet beschikbaar. Zet het "
-"apparaat op een stabiel oppervlak om te herstellen."
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr "Prestatiemodus tijdelijk uitgeschakeld."
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Lage accu: energiebesparing ingeschakeld. De vorige modus wordt hersteld "
-"wanneer de accu voldoende opgeladen is."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Energiebesparingsmodus geactiveerd door ‘%s’."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Prestatiemodus geactiveerd door ‘%s’."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4773,6 +2910,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 uur"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Accu"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Apparaten"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Energiemodus"
@@ -4793,89 +2939,62 @@ msgstr "Automatische schermhelderheid"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "De schermhelderheid wordt aangepast naargelang het omgevingslicht."
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Scherm dimmen"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "Verlaagt de schermhelderheid wanneer de computer niet actief is."
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "_Leeg scherm"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "Zet het scherm uit na een periode van inactiviteit."
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Automatisch energie besparen"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr "Schakelt de energiebesparingsmodus in wanneer de accu bijna leeg is."
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "_Automatisch in pauzestand zetten"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "Zet de computer in pauzestand na een periode van inactiviteit."
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Aan-/uit_knopgedrag"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Accu_percentage tonen"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Automatisch in pauzestand zetten"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_Aangesloten"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Op _accustroom"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Vertraging"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Prestaties"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Hoge prestaties en stroomverbruik."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Gebalanceerd"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standaard prestaties en stroomverbruik."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Energie besparen"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Verlaagde prestaties en stroomverbruik."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4885,7 +3004,6 @@ msgstr "Energie"
 msgid "View your battery status and change power saving settings"
 msgstr "De accustatus bekijken en instellingen voor energiebesparing wijzigen"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4893,27 +3011,6 @@ msgid ""
 msgstr ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Helderheid;Dim;Blank;"
 "Monitor;Beeldscherm;DPMS;Idle;Energie;Slaapstand;Pauzestand;Accu;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Printer ‘%s’ is verwijderd"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "Nieuwe printer toevoegen mislukt."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Kon UI niet laden: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Ontgrendel om printers toe te voegen en instellingen te wijzigen"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4924,7 +3021,6 @@ msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Printers toevoegen, afdruktaken bekijken, en bepalen hoe u wilt afdrukken"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Queue;Print;Paper;Ink;Toner;Wachtrij;Papier;Inkt;"
@@ -4932,95 +3028,71 @@ msgstr "Printer;Queue;Print;Paper;Ink;Toner;Wachtrij;Papier;Inkt;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Printer toevoegen"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Ontgrendelen"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Geen printers gevonden"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Voer een netwerkadres in of zoek naar een printer"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Authenticatie vereist"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Voer uw gebruikersnaam en wachtwoord in om printers op printserver te "
 "bekijken."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "Details van %s"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Printernamen mogen geen SPATIE, TAB, # of / bevatten"
 
-# geen/zonder
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Geen geschikt stuurprogramma aangetroffen"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "PPD-bestand selecteren"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript Printer Description-bestanden (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD.GZ)"
-
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Locatie"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Stuurprogramma"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Zoeken naar de beste stuurprogramma’s…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Naar stuurprogramma’s zoeken"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Selecteren uit de database…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "PPD-bestand installeren…"
 
@@ -5032,134 +3104,20 @@ msgstr "Printerstuurprogramma kiezen"
 msgid "Loading drivers database…"
 msgstr "Stuurprogrammadatabase wordt geladen…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Annuleren"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Selecteren"
 
-# bij een browser is dit bladwijzers, maar hier is
-# favorieten/favoriet beter (favoriete programma's) (tino)
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect-printer"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD-printer"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Eenzijdig"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Lange zijde (standaard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Korte zijde (omdraaien)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Staand"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Liggend"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Omgekeerd liggend"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Omgekeerd staand"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "Wachten"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "Gepauzeerd"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Authenticatie vereist"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "Verwerken"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Gestopt"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Geannuleerd"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Afgebroken"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Voltooid"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "Verplaats deze opdracht naar boven in de wachtrij"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u taak vereist authenticatie"
 msgstr[1] "%u taken vereisen authenticatie"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Actieve afdruktaken"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Voer uw aanmeldgegevens in om af te drukken op %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5168,344 +3126,36 @@ msgid "Domain"
 msgstr "Domein"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "A_uthenticeren"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Alles wissen"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Authenticeren"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Geen actieve afdruktaken"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Printserver ontgrendelen"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s ontgrendelen."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Voer uw gebruikersnaam en wachtwoord in om printers op %s te bekijken."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Naar printers zoeken"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Seriële poort"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Parallelle poort"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Locatie: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adres: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Server vereist authenticatie"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Tweezijdig"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Papiersoort"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Papierbron"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Uitvoerlade"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolutie"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Voorfilteren GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Pagina’s per vel"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Tweezijdig"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Stand"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Algemeen"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Pagina-instelling"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Installeerbare opties"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Taak"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Afdrukkwaliteit"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Kleur"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Afwerking"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Geavanceerd"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testpagina"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Testpagina"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Automatisch selecteren"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Standaardinstellingen van de printer"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Alleen GhostScript-lettertypen insluiten"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Converteren naar PS level 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Converteren naar PS level 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Niet vooraf filteren"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Fabrikant"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Geen actieve afdruktaken"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u taak"
 msgstr[1] "%u taken"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Printkoppen schoonmaken"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Weinig toner"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Geen toner meer"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Weinig developer (voor ontwikkelen)"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Geen developer meer (voor ontwikkelen)"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Weinig marker-voorraad"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Geen marker meer"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Klep open"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Deur open"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Weinig papier"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Geen papier meer"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Offline"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Gestopt"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Afvalbakje bijna vol"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Afvalbakje vol"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr ""
-"De optische lichtgevoelige geleider (optical photo conductor) is bijna niet "
-"meer te gebruiken"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr ""
-"De optische lichtgevoelige geleider (optical photo conductor) functioneert "
-"niet meer"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Gereed"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Taken worden niet geaccepteerd"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Verwerken"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5531,41 +3181,45 @@ msgstr "Printkoppen schoonmaken"
 msgid "Remove Printer"
 msgstr "Printer verwijderen"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Geen actieve afdruktaken"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Inkt-niveau"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Gelieve opnieuw te starten wanneer het probleem opgelost is."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Herstarten"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Printer toevoegen…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Printer toevoegen…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Geen printers"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Printer toevoegen…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5573,51 +3227,33 @@ msgstr ""
 "Helaas, de systeemdienst voor\n"
 "    afdrukken is niet beschikbaar."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formaten"
-
-#: panels/region/cc-format-chooser.ui:37
-#: panels/wacom/cc-wacom-stylus-page.ui:136
-#: panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "Terug"
 
 #: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr "Locales zoeken…"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Algemene formaten"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Alle formaten"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Geen zoekresultaten"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "U kunt zoeken naar landen of talen."
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Voorbeeld"
-
-# Maatsysteem dat in de VS wordt gebruikt met inch, foot en pound.
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperiaal (Brits-Amerikaans)"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrisch"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -5649,26 +3285,30 @@ msgstr "Afmelden…"
 
 #: panels/region/cc-region-panel.ui:45
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
 "De taalinstelling wordt gebruikt voor tekst in de interface en webpagina’s. "
-"De indeling wordt gebruikt voor getallen, datums en munteenheden."
+"De indelingen worden gebruikt voor getallen, datums en munteenheden."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Uw account"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Taal"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formaten"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Aanmeldscherm"
 
@@ -5680,100 +3320,9 @@ msgstr "Regio en taal"
 msgid "Select your display language and formats"
 msgstr "Selecteer uw taal en formaten"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Taal;Indeling;Toetsenbord;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Vragen wat te doen"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Niets doen"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Map openen"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Andere media"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Selecteer een toepassing voor audio-cd’s"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Selecteer een toepassing voor video-dvd’s"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Selecteer de te starten toepassing als een muziekspeler wordt aangesloten"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Selecteer de te starten toepassing als een camera wordt aangesloten"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Selecteer een toepassing voor software-cd’s"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "audio-dvd"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "lege Blu-ray-schijf"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "lege cd"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "lege dvd"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "lege hd-dvd"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray-videoschijf"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "e-book-lezer"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Hd-dvd-videoschijf"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Foto-cd"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super-video-cd"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video-cd"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows-software"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5825,7 +3374,6 @@ msgid "Configure Removable Media settings"
 msgstr "Instellingen voor verwijderbare media configureren"
 
 # The user can search on this keywords. Thereby we chose to let the translation contain both English and Dutch words.
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5835,13 +3383,80 @@ msgstr ""
 "removable;media;autorun;apparaat;standaard;toepassing;voorkeur;schijf;"
 "verwijderbaar;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Locatie selecteren"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Schermvergrendeling"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Oké"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Door het scherm automatisch te vergrendelen kunnen anderen uw computer niet "
+"gebruiken terwijl u weg bent."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Vertraging voor zwart scherm"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Periode van inactiviteit waarna het scherm zwart wordt."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatische s_chermvergrendeling"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Vertraging voor automatische _schermvergrendeling"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Punt waarop het scherm automatisch wordt vergrendeld na op zwart gestaan te "
+"hebben."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Notificaties tonen op vergrendelingsscherm"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Notificaties op vergrendelingsscherm"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Nieuwe _USB-apparaten verbieden"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Voorkomen dat nieuwe USB-apparaten interactie hebben met het systeem wanneer "
+"het scherm is vergrendeld."
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr "Schermprivacy"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr "Zichthoek beperken"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Scherm"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Scherminstellingen"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;scherm;vergrendel;privé;"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5860,21 +3475,17 @@ msgstr ""
 msgid "Places"
 msgstr "Locaties"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Bladwijzers"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "Overige"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Locatie toevoegen"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Geen toepassingen aangetroffen"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5902,65 +3513,13 @@ msgid ""
 msgstr ""
 "Regelen welke toepassingen zoekresultaten tonen in het activiteitenoverzicht"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Search;Find;Index;Hide;Privacy;Results;Zoeken;Verbergen;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "Geen netwerken geselecteerd om te delen"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Netwerken"
-
-#: panels/sharing/cc-sharing-panel.c:363
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Aan"
-
-#: panels/sharing/cc-sharing-panel.c:365 panels/sharing/cc-sharing-panel.c:392
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Uit"
-
-#: panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Ingeschakeld"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is active"
-msgid "Active"
-msgstr "Actief"
-
-#: panels/sharing/cc-sharing-panel.c:516
-msgid "Choose a Folder"
-msgstr "Een map kiezen"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:744
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Met ‘Delen van persoonlijke bestanden’ kunt u de map ‘Openbaar’ delen met "
-"anderen op uw huidige netwerk via: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:750
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Wanneer aanmelden op afstand is ingeschakeld kunnen gebruikers op afstand "
-"verbinding maken via de Secure Shell-opdracht:\n"
-"%s"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6000,12 +3559,12 @@ msgstr "_Wachtwoord vereisen"
 msgid "Remote Login"
 msgstr "Aanmelden op afstand"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "Bureaublad op afstand"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
@@ -6013,29 +3572,36 @@ msgstr ""
 "Bureaublad op afstand maakt het mogelijk om uw bureaublad vanop een andere "
 "computer te bekijken en te besturen."
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr "Schakel bureaubladverbindingen op afstand in of uit."
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "Externe besturing"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
 msgstr "Staat externe verbindingen toe om het scherm te besturen."
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
 msgstr "Hoe te verbinden"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
 "Verbind met deze computer met de apparaatnaam of het externbureaubladadres."
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopiëren"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "Adres van bureaublad op afstand"
 
@@ -6045,45 +3611,45 @@ msgstr "Adres van bureaublad op afstand"
 # gaan wijzigen.
 # Dus letterlijke vertaling is 'Aanmeldingscontrole' maar in dit
 # geval houden we het kort en gebruiken we alleen 'Controle' (tino)
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "Authenticatie"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr ""
 "De gebruikersnaam en het wachtwoord zijn vereist om aan te melden bij deze "
 "computer."
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "Gebruikersnaam"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "Versleuteling verifiëren"
 
-#: panels/sharing/cc-sharing-panel.ui:428
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr "Vingerafdruk voor versleuteling"
 
-#: panels/sharing/cc-sharing-panel.ui:429
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
 "De vingerafdruk voor versleuteling is zichtbaar voor verbinding makende "
-"cliënten en zou identiek moeten zijn"
+"cliënten en zou identiek moeten zijn."
 
-#: panels/sharing/cc-sharing-panel.ui:461
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Media delen"
 
-#: panels/sharing/cc-sharing-panel.ui:483
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Muziek, foto’s en video’s delen op het netwerk."
 
-#: panels/sharing/cc-sharing-panel.ui:496
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Mappen"
 
@@ -6091,7 +3657,6 @@ msgstr "Mappen"
 msgid "Control what you want to share with others"
 msgstr "Regelen wat u met anderen wilt delen"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6109,38 +3674,37 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Er is authenticatie vereist om aanmelden op afstand in of uit te schakelen"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Aangepast"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Blaffen"
+msgid "Click"
+msgstr "Klik"
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "Druppelen"
+msgid "String"
+msgstr "Snaar"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "Glas"
+msgid "Swing"
+msgstr "Zwaai"
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "Sonar"
+msgid "Hum"
+msgstr "Brom"
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balans"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Fade"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Achterzijde"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Voorzijde"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s testen"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6150,58 +3714,53 @@ msgstr "Klik op een speaker om te testen"
 msgid "System Volume"
 msgstr "Systeemvolume"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Hoofdvolume"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Volumeniveaus"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Uitvoer"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Uitvoerapparaat"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Testen"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Configuratie"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "Balans"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "Fade"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Invoer"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Invoerapparaat"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Volume"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Waarschuwingsvolume"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Dempen"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6211,83 +3770,12 @@ msgstr "Geluid"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Geluidsvolume, invoer, uitvoer en gebeurtenisgeluiden wijzigen"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Card;Kaart;Microphone;Microfoon;Volume;Fade;Balance;Balans;Bluetooth;Headset;"
 "Audio;Output;Uitvoer;Input;Invoer;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Verbinding verbroken"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Verbinden"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Verbonden"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Authenticatie-fout"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autoriseren"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Verminderde functionaliteit"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Verbonden en geautoriseerd"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Onbekend"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Geautoriseerd om:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Verbonden om:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Geregistreerd om:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Autoriseren van apparaat mislukt: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Vergeten van apparaat mislukt: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6296,101 +3784,54 @@ msgid_plural "Depends on %u other devices"
 msgstr[0] "Afhankelijk van %u ander apparaat"
 msgstr[1] "Afhankelijk van %u andere apparaten"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Notificatie sluiten"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Naam:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Status:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Autoriseren en verbinden"
 
 # bij een browser is dit bladwijzers, maar hier is
 # favorieten/favoriet beter (favoriete programma's) (tino)
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Apparaat vergeten"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Fout"
-
-# dit is de knop die naast het veld 'huidige wachtwoord' staat
-# als je je huidige wachtwoord hebt ingevuld en op 'Authenticate'
-# klikt (en het wachtwoord is juist) kun je je huidige wachtwoord
-# gaan wijzigen.
-# Dus letterlijke vertaling is 'Aanmeldingscontrole' maar in dit
-# geval houden we het kort en gebruiken we alleen 'Controle' (tino)
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Geautoriseerd"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Het Thunderbolt-subsysteem (boltd) is niet geïnstalleerd of niet correct "
-"ingesteld."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Directe toegang tot apparaten zoals docks en externe GPU's toestaan."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Alleen USB- en Display Port-apparaten kunnen worden aangesloten."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt kon niet worden gedetecteerd.\n"
-"Of het systeem ondersteunt Thunderbolt niet, of het is uitgeschakeld in de "
-"BIOS, of het is ingesteld op een niet-ondersteund beveiligingsniveau in de "
-"BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "De ondersteuning van Thunderbolt is uitgeschakeld in de BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Thunderbolt-beveiligingsniveau kon niet bepaald worden."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Fout bij omschakelen naar directe modus: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
+#: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Geen Thunderbolt-ondersteuning"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:104
+#: panels/thunderbolt/cc-bolt-panel.ui:103
 msgid "Could not connect to the thunderbolt subsystem."
 msgstr "Kon geen verbinding maken met het Thunderbolt-subsysteem."
 
-#: panels/thunderbolt/cc-bolt-panel.ui:153
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Directe toegang"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Directe toegang tot apparaten zoals docks en externe GPU's toestaan."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Apparaten in afwachting"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Geen apparaten aangesloten"
 
@@ -6402,7 +3843,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Thunderbolt-apparaten beheren"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;"
@@ -6411,16 +3851,16 @@ msgstr "Thunderbolt;privacy;"
 msgid "Cursor Blinking"
 msgstr "Knipperen van de cursor"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Cursor knippert in tekstvelden."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Snelheid"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Cursorknippersnelheid"
 
@@ -6507,15 +3947,15 @@ msgstr "Groot"
 msgid "Repeat Keys"
 msgstr "Herhaaltoetsen"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Toetsaanslagen herhalen zich wanneer de toets ingedrukt blijft."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Toetsherhaalvertraging"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Toetsherhaalsnelheid"
 
@@ -6597,47 +4037,13 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Lang"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "_Via toetsenbord inschakelen"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Toegankelijkheidsfuncties via het toetsenbord inschakelen"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Standaard"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Gemiddeld"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Groot"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Groter"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Grootst"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixels"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6754,31 +4160,6 @@ msgstr "_Hele scherm laten knipperen"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Hele _venster laten knipperen"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Kort"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ scherm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ scherm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ scherm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Lang"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6935,7 +4316,6 @@ msgstr "Kleureffecten"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Zien, horen, typen, aanwijzen en klikken vergemakkelijken"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -6949,114 +4329,6 @@ msgstr ""
 "Delay;Speed;snelheid;Assist;Repeat;Blink;Visual;visueel;hearing;horen;hoor;"
 "luisteren;audio;typing;typen;Muistoetsen;Toetsenbord;Toegankelijkheid;Tekst;"
 "Lettertype;vergroten;Dubbel;klik;geluid;groot;hoog;animations;animaties;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 uur"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dag"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dagen"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dagen"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dagen"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dagen"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dagen"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dagen"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dagen"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dagen"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Alle items uit prullenbak verwijderen?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Alle items in de prullenbak zullen definitief verwijderd worden."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Prullenbak l_egen"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Alle tijdelijke bestanden verwijderen?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Alle tijdelijke bestanden zullen definitief verwijderd worden."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Tijdelijke bestanden _definitief verwijderen"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dag"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dagen"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dagen"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Voor altijd"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7125,56 +4397,13 @@ msgstr "Bestandsgeschiedenis & prullenbak"
 msgid "Don't leave traces"
 msgstr "Geen sporen achterlaten"
 
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Dient overeen te komen met het internetadres van uw inlog-provider."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Toevoegen van account mislukt"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr "De wachtwoorden komen niet overeen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Registreren van account mislukt"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Geen ondersteunde manier om met dit domein te authenticeren"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Toetreden tot domein mislukt"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Ongeldige gebruikersnaam.\n"
-"Probeer het opnieuw."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Ongeldig wachtwoord.\n"
-"Probeer het opnieuw."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Aanmelden bij domein mislukt"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Domein niet gevonden. Heeft u het verkeerd gespeld?"
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"gebruik;onlangs gebruikt;geschiedenis;bestanden;tijdelijk;privé;prullenbak;"
+"legen;houden;"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7211,14 +4440,14 @@ msgid "Enterprise Login"
 msgstr "Bedrijfsaanmelding"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+msgid "User accounts which are managed by a company or organization."
 msgstr "Gebruikersaccounts die door een bedrijf of organisatie beheerd worden."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "U bent offline"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7227,10 +4456,6 @@ msgstr ""
 "Met enterprise-aanmelding kan een bestaande centraal beheerde "
 "gebruikersaccount op dit apparaat gebruikt worden. U kunt dit account ook "
 "gebruiken om toegang te krijgen tot bedrijfsbronnen op het internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Bladeren naar meer afbeeldingen"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7244,16 +4469,16 @@ msgstr "Vingerafdrukbeheer"
 msgid "Fingerprint"
 msgstr "Vingerafdruk"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_Nee"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Ja"
 
 # geregistreerde/opgeslagen
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7261,32 +4486,32 @@ msgstr ""
 "Wilt u uw geregistreerde vingerafdruk verwijderen zodat "
 "vingerafdrukaanmelding uitgeschakeld wordt?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Geen vingerafdrukapparaat"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "Geen vingerafdrukapparaat"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "Controleer of het apparaat correct verbonden is."
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Vingerafdrukapparaat"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "Kies het vingerafdrukapparaat dat u wilt instellen"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "Aanmelden met vingerafdruk"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7294,438 +4519,102 @@ msgstr ""
 "Aanmelden met vingerafdruk biedt u de mogelijkheid om uw computer te "
 "ontgrendelen en aan te melden met uw vinger"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "Vingerafdrukken ver_wijderen"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Vingerafdruk registreren"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "het apparaat moet worden geclaimd om deze actie uit te voeren"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Vorige"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "het apparaat is al geclaimd door een ander proces"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "u heeft niet de rechten om de actie uit te voeren"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "er zijn geen afdrukken geregistreerd"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Communicatie met het apparaat mislukt tijdens het registreren"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Communicatie met de vingerafdruklezer mislukt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Communicatie met de vingerafdrukdaemon mislukt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Oplijsten van vingerafdrukken mislukt: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Verwijderen van opgeslagen vingerafdrukken mislukt: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Linkerduim"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Linkermiddelvinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Linkerwijsvinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Linkerringvinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Linkerpink"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Rechterduim"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Rechtermiddelvinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Rechterwijsvinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Rechterringvinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Rechterpink"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Onbekende vinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Klaar"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Vingerafdrukapparaat niet verbonden"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Vingerafdrukapparaatopslag is vol"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Registreren van nieuwe vingerafdruk mislukt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Starten van registratie mislukt: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Registreren van nieuwe vingerafdruk mislukt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Stoppen van registratie mislukt: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Plaats uw vinger herhaaldelijk op de lezer om uw vingerafdruk te registreren"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Deze vinger opnieuw _registreren…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Nieuwe vingerafdruk scannen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Loslaten van vingerafdrukapparaat %s mislukt: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Probleem bij lezen van apparaat"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Toe-eigenen van vingerafdrukapparaat %s mislukt: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Opvragen van vingerafdrukapparaten mislukt: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Deze week"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Vorige week"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%d %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%d %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sessie beëindigd"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sessie gestart"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Accountactiviteit"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Kies een ander wachtwoord."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Vul uw wachtwoord opnieuw in."
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Wachtwoord kon niet gewijzigd worden"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Volgende"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Wachtwoord wijzigen"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "_Wijzigen"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "Huidig wachtwoord"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "Nieuw wachtwoord"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "Bevestig wachtwoord"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "De wachtwoorden komen niet overeen."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Gebruiker kan wachtwoord wijzigen bij de volgende keer aanmelden"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Nu een wachtwoord instellen"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Automatisch voegen bij dit type domein is niet mogelijk"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Een dergelijk domein of realm is niet aangetroffen"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Aanmelden als %s bij het domein %s kan niet"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Ongeldig wachtwoord, probeer het opnieuw"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Kon geen verbinding maken met het %s-domein: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "Kon gebruiker niet verwijderen"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "Op afstand beheerde gebruiker kon niet worden verwijderen"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "U kunt uw eigen account niet verwijderen."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s is nog aangemeld"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Het verwijderen van een gebruiker die nog aangemeld is, kan leiden tot een "
-"inconsistent systeem."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Moeten de bestanden van %s bewaard blijven?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Het is mogelijk om de persoonlijke map, de e-mailmap en de tijdelijke "
-"bestanden te bewaren als een account verwijderd wordt."
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "Bestanden _verwijderen"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "Bestanden be_waren"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Weet u zeker dat u de op afstand beheerde account van %s wilt verwijderen?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "Verwij_deren"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Account uitgeschakeld"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "In te stellen bij volgende keer aanmelden"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Geen"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Aangemeld"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "Ingeschakeld"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "Kon de accounts-service niet benaderen"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Zorg ervoor dat het de AccountService geïnstalleerd in ingeschakeld is."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "Om deze instelling te wijzigen moet dit paneel ontgrendeld worden"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "De geselecteerde gebruiker verwijderen"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Klik op het *-pictogram om de geselecteerde\n"
-"gebruiker te verwijderen"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Ontgrendel om gebruikers toe te voegen en instellingen te wijzigen"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Gebruikers"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 "Om de wijzigingen door te voeren moet de computer opnieuw gestart worden"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Nu herstarten"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Sluiten"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Gebruikersafbeelding bewerken"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Volledige naam"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Bewerken"
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Aanmelden met _vingerafdruk"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "A_utomatisch aanmelden"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "Accountactiviteit"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Beheerder"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7733,32 +4622,32 @@ msgstr ""
 "Beheerders kunnen gebruikers toevoegen en verwijderen, en de instellingen "
 "voor alle gebruikers wijzigen."
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "_Ouderlijk toezicht"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Open de toepassing Ouderlijk toezicht."
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Gebruiker verwijderen…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "Andere gebruikers"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "Gebruiker toevoegen…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Geen gebruikers gevonden"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Ontgrendel om een gebruikersaccount toe te voegen."
 
@@ -7766,7 +4655,6 @@ msgstr "Ontgrendel om een gebruikersaccount toe te voegen."
 msgid "Add or remove users and change your password"
 msgstr "Gebruikers toevoegen of verwijderen en uw wachtwoord wijzigen"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7814,183 +4702,8 @@ msgstr "Gebruikersaccounts beheren"
 msgid "Authentication is required to change user data"
 msgstr "Er is authenticatie vereist om gebruikersgegevens te wijzigen"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Het nieuwe wachtwoord moet anders zijn dan het oude."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Probeer enkele letters en cijfers te wijzigen."
-
-# venstertitel
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Probeer het wachtwoord iets meer te wijzigen."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Een wachtwoord zonder uw gebruikersnaam zal sterker zijn."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Vermijd het gebruik van uw naam in uw wachtwoord."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Probeer woorden die in het wachtwoord voorkomen te vermijden."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Probeer algemene woorden te vermijden."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Probeer het herordenen van bestaande woorden te vermijden."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Probeer meer cijfers te gebruiken."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Probeer meer hoofdletters te gebruiken."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Probeer meer kleine letters te gebruiken."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Probeer meer speciale tekens, zoals interpunctie, te gebruiken."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-"Probeer een combinatie van letters, cijfers en interpunctie te gebruiken."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Probeer herhaling van hetzelfde teken te vermijden."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Probeer herhaling van hetzelfde soort teken te vermijden: u dient letters, "
-"cijfers en interpunctie te combineren."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Probeer reeksen zoals 1234 of abcd te vermijden."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Het wachtwoord moet langer zijn. Probeer meer letters, cijfers en leestekens "
-"toe te voegen."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Gebruik zowel hoofdletters als kleine letters en probeer een paar cijfers te "
-"gebruiken."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Toevoegen van meer letters, cijfers en leestekens maakt het wachtwoord nog "
-"sterker."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Authenticatie mislukt"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "Het nieuwe wachtwoord is te kort"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "Het nieuwe wachtwoord is te eenvoudig"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Het oude en nieuwe wachtwoord lijken teveel op elkaar"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Het nieuwe wachtwoord is recentelijk al gebruikt."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Het nieuwe wachtwoord moet numerieke of speciale tekens bevatten"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Het oude en nieuwe wachtwoord zijn hetzelfde"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Uw wachtwoord is gewijzigd sinds de vorige wachtwoordcontrole!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Het nieuwe wachtwoord bevat niet genoeg verschillende tekens"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Onbekende fout"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"De gebruikersnaam bestaat doorgaans enkel uit kleine letters van a t/m z, "
-"cijfers en de volgende tekens: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Die gebruikersnaam is helaas niet beschikbaar. Probeer een andere."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "De gebruikersnaam is te lang."
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Knoppen toewijzen"
 
@@ -8023,47 +4736,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Misklik gedetecteerd, herstarten…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Knop %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Toepassingen gedefinieerd"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Toetsaanslag sturen"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Van beeldscherm wisselen"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Schermhulp tonen"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tablet gemonteerd op laptoppaneel"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tablet gemonteerd op extern beeldscherm"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Extern tabletapparaat"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Alle schermen"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Extern pad-apparaat"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8073,30 +4749,30 @@ msgstr "Tabletmodus"
 msgid "Use absolute positioning for the pen"
 msgstr "Absolute positie voor de pen gebruiken"
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "Linkshandige oriëntatie"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr "Tablet en Express Keys™ zijn gedraaid voor linkshandig gebruik"
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Naar monitor mappen"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "Beeldverhouding behouden"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 "Gebruik slechts een deel van het tabletoppervlak om de beeldverhouding van "
 "het beeldscherm te behouden"
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "Kalibreren"
 
@@ -8150,10 +4826,6 @@ msgstr "Gedrag gumdruk"
 msgid "Eraser pressure"
 msgstr "Gumdruk"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:133
-msgid "Default"
-msgstr "Standaard"
-
 #: panels/wacom/cc-wacom-stylus-page.ui:134
 msgid "Middle Mouse Button Click"
 msgstr "Middelste muisknop-klik"
@@ -8166,22 +4838,6 @@ msgstr "Rechtermuisknop-klik"
 msgid "Forward"
 msgstr "Vooruit"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Airbrushstylus met druk, tilt en geïntegreerde slider"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Airbrushstylus met druk, tilt en rotatie"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standaardstylus met druk en tilt"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standaardstylus met druk"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom-tablet"
@@ -8192,54 +4848,96 @@ msgstr ""
 "Knoptoewijzingen instellen en gevoeligheid van stylus voor  grafische "
 "tabletten aanpassen"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;Tekenen;Gum;Muis;gom;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Nieuwe sneltoets…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Ge_simuleerde secundaire klik"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows-software"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Weinig toner"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Secundair"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows-software"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Beheer voorkeuren voor productiviteit en multitasken"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Toegangspunten"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Toevoegen"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "Op_slaan"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Bewerking geannuleerd"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Fout:</b> Toegang geweigerd bij wijzigen van instellingen"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Fout:</b> Probleem met mobiele uitrusting"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Niet geregistreerd"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Geregistreerd"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Zoeken"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Geweigerd"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8269,104 +4967,13 @@ msgstr "Eigen nummer"
 msgid "Device Details"
 msgstr "Apparaatinformatie"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabrikant"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Firmwareversie"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Alleen 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Alleen 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Alleen 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (voorkeur)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (voorkeur), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (voorkeur), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (voorkeur)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (voorkeur), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (voorkeur)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (voorkeur), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (voorkeur)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (voorkeur), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Onbekend"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Simkaart ontgrendelen"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Ontgrendelen"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Voer de pincode voor simkaart %d in"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Voer de pincode in om uw simkaart te ontgrendelen"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Voer de pukcode voor simkaart %d in"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Voer de pukcode in om uw simkaart te ontgrendelen"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8381,26 +4988,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "U heeft nog %u resterende poging"
 msgstr[1] "U heeft nog %u resterende pogingen"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Onjuist wachtwoord."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "De pukcode moet een getal van 8 cijfers zijn"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Voer nieuwe pincode in"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "De pincode moet een getal van 4 à 8 cijfers zijn"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Ontgrendelen…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -8458,147 +5045,47 @@ msgstr "Simkaart vergrendelen met pincode"
 msgid "M_odem Details"
 msgstr "M_odeminformatie"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Telefoonfout"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Geen verbinding met telefoon"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Bewerking niet toegestaan"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Bewerking niet ondersteund"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Simkaart niet ingevoerd"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Pincode voor simkaart vereist"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Pukcode voor simkaart vereist"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Simkaartfout"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Simkaart bezig"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Onjuist wachtwoord"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Pin2-code voor simkaart vereist"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Puk2-code voor simkaart vereist"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Niet gevonden"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Geen netwerkdienst"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Netwerktime-out"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS-diensten niet toegestaan"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming niet toegestaan in dit locatiegebied"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Ongespecificeerde GPRS-fout"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "Actie geannuleerd"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Toegang geweigerd"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Onbekende fout"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Netwerkmodus"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "In_stellen"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "Sluiten"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Automatisch"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Netwerk kiezen"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Netwerkproviders vernieuwen"
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "Simkaart %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "Mobiel netwerk inschakelen"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "Geen WWAN-adapter gevonden"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "Zorg ervoor dat u een draadlozewan- of mobiel apparaat heeft"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "Draadloze wan wordt uitgeschakeld als vliegtuigstand aan staat"
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "Vliegtuigstand ui_tzetten"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "Dataverbinding"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "Simkaart gebruikt voor internet"
 
@@ -8610,15 +5097,15 @@ msgstr "Simkaartvergrendeling"
 msgid "_Next"
 msgstr "Volge_nde"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "Simkaart vergrende_len met pincode"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "Pincode wijzigen"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr ""
 "Voer de huidige pincode in om de simkaartvergrendelingsinstellingen te "
@@ -8632,7 +5119,6 @@ msgstr "Mobiel netwerk"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configureer telefonie en mobielegegevensverbindingen"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -8650,37 +5136,13 @@ msgstr "Instellingen is de hoofdinterface voor de configuratie van uw systeem."
 msgid "The GNOME Project"
 msgstr "Het Gnome-project"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Versienummer weergeven"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Instellingscategorieën"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Verbose-modus inschakelen"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Zoeken naar de tekenreeks"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Een lijst met mogelijke paneelnamen tonen en sluiten"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Te tonen paneel"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacy"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Beschikbare panelen:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8738,7 +5200,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Zoeken annuleren"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;Settings;Voorkeuren;Instellingen;"
@@ -8780,27 +5241,3205 @@ msgstr ""
 "Een tupel met daarin de initiële breedte, hoogte en maximalisatiestatus van "
 "het toepassingsvenster."
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u uitvoer"
 msgstr[1] "%u uitvoeren"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u invoer"
 msgstr[1] "%u invoeren"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "Systeemgeluiden"
+#~ msgid "System Bus"
+#~ msgstr "Systeembus"
+
+#~ msgid "Full access"
+#~ msgstr "Volledige toegang"
+
+#~ msgid "Session Bus"
+#~ msgstr "Sessiebus"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Volledige toegang tot /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Heeft netwerktoegang"
+
+#~ msgid "Home"
+#~ msgstr "Persoonlijke map"
+
+#~ msgid "Read-only"
+#~ msgstr "Alleen-lezen"
+
+#~ msgid "File System"
+#~ msgstr "Bestandssysteem"
+
+#~ msgid "Can change settings"
+#~ msgstr "Kan instellingen wijzigen"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s heeft volgende ingebouwde rechten. Deze kunnen niet gewijzigd worden. "
+#~ "Indien u hier bezorgd om bent, kunt u de toepassing verwijderen."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u bestands- en verwijzingstype wordt geopend door de toepassing"
+#~ msgstr[1] ""
+#~ "%u bestands- en verwijzingstypes worden geopend door de toepassing"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> wordt gebruikt om de volgende types bestanden en verwijzingen "
+#~ "te openen."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s aan schijfruimte in gebruik."
+
+#~ msgid "Select a picture"
+#~ msgstr "Selecteer een afbeelding"
+
+#~ msgid "_Open"
+#~ msgstr "_Openen"
+
+#~ msgid "multiple sizes"
+#~ msgstr "meerdere groottes"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Geen werkbladachtergrond"
+
+#~ msgid "Current background"
+#~ msgstr "Huidige achtergrond"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Plaats uw kalibratieapparaat boven het vierkant en druk op ‘Starten’"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Zet uw kalibratieapparaat in de kalibratiepositie en druk op ‘Doorgaan’"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Zet uw kalibratieapparaat in de oppervlaktepositie en druk op ‘Doorgaan’"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Sluit het deksel van de laptop"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Er is een interne fout opgetreden die niet hersteld kon worden."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "De hulpmiddelen nodig voor de kalibratie zijn niet geïnstalleerd."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Het profiel kon niet gegenereerd worden."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Het ‘target whitepoint’ was niet te krijgen."
+
+#~ msgid "Complete!"
+#~ msgstr "Klaar!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibratie mislukt!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "U kunt het kalibratieapparaat verwijderen."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Niet aan het kalibratieapparaat komen terwijl dit proces loopt"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Laptopscherm"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Ingebouwde webcam"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s-beeldscherm"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s-scanner"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s-camera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s-printer"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s-webcam"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Kleurbeheer voor %s inschakelen"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Kleurprofielen voor %s tonen"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Niet gekalibreerd"
+
+#~ msgid "Default: "
+#~ msgstr "Standaard: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Kleurruimte: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testprofiel: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC-profiel selecteren"
+
+#~ msgid "_Import"
+#~ msgstr "_Importeren"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Ondersteunde ICC-profielen"
+
+#~ msgid "All files"
+#~ msgstr "Alle bestanden"
+
+# bij een browser is dit bladwijzers, maar hier is
+# favorieten/favoriet beter (favoriete programma's) (tino)
+#~ msgid "Save Profile"
+#~ msgstr "Profiel opslaan"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Kleurprofiel maken voor het geselecteerde apparaat"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Het meetinstrument is niet gevonden. Controleer of het aan staat en "
+#~ "correct verbonden is."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Het meetinstrument ondersteunt het profileren van printers niet."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Dit type apparaat wordt niet ondersteund."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standaard kleurruimte"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testprofiel"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatisch"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Lage kwaliteit"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Gemiddelde kwaliteit"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Hoge kwaliteit"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Standaard RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Standaard CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Standaard grijs"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Fabrieksinstellingen voor kalibratie zijn door fabrikant geleverd"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Volledig scherm-correctie is niet mogelijk met dit profiel"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Dit profiel is mogelijk niet meer accuraat"
+
+#~ msgid "Other…"
+#~ msgstr "Ander profiel…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Ontgrendel om instellingen te wijzigen"
+
+#~ msgid "Today"
+#~ msgstr "Vandaag"
+
+#~ msgid "Yesterday"
+#~ msgstr "Gisteren"
+
+#~ msgid "%b %e"
+#~ msgstr "%d %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%d %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d uur"
+#~ msgstr[1] "%d uur"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuut"
+#~ msgstr[1] "%d minuten"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d seconde"
+#~ msgstr[1] "%d seconden"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24-uurs"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%k:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Het sturen van rapporten over technische problemen helpt ons %s te "
+#~ "verbeteren. Rapporten worden anoniem verstuurd en bevatten geen "
+#~ "persoonlijke gegevens. %s"
+
+#~ msgid "On"
+#~ msgstr "Aan"
+
+#~ msgid "Off"
+#~ msgstr "Uit"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Wijzigingen toepassen?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Wijzigingen kunnen niet worden toegepast"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Dit kan het gevolg zijn van hardwarebeperkingen."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Liggend"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Staand rechts"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Staand links"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Liggend (omgedraaid)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Veilig opstarten is actief"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Veilig opstarten voorkomt dat kwaadaardige software wordt geladen wanneer "
+#~ "het apparaat wordt opgestart. Het is momenteel ingeschakeld en "
+#~ "functioneert correct."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Veilig opstarten heeft problemen"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Veilig opstarten voorkomt dat kwaadaardige software wordt geladen wanneer "
+#~ "het apparaat wordt opgestart. Het is momenteel ingeschakeld, maar zal "
+#~ "niet werken vanwege een ongeldige sleutel."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Problemen met veilig opstarten kunnen vaak worden opgelost via de UEFI-"
+#~ "firmware-instellingen (BIOS) van uw computer. Uw hardwarefabrikant kan "
+#~ "informatie verstrekken over hoe u dit kunt doen."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Neem voor hulp contact op met uw hardwarefabrikant of IT-ondersteuning."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Veilig opstarten is uitgeschakeld"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Veilig opstarten voorkomt dat kwaadaardige software wordt geladen wanneer "
+#~ "het apparaat wordt opgestart. Het is momenteel uitgeschakeld."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Veilig opstarten kan vaak worden ingeschakeld via de UEFI-firmware-"
+#~ "instellingen (BIOS) van uw computer. Neem voor hulp contact op met uw "
+#~ "hardwarefabrikant of IT-ondersteuning."
+
+#~ msgid "Passed"
+#~ msgstr "Voldaan"
+
+#~ msgid "Failed"
+#~ msgstr "Niet voldaan"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Apparaat voldoet aan HSI-niveau %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Beveiligingsniveau 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Dit apparaat heeft geen bescherming tegen hardwarebeveiligingsproblemen. "
+#~ "Dit kan komen door een probleem met de hardware- of firmwareconfiguratie. "
+#~ "Het wordt aanbevolen contact op te nemen met uw IT-ondersteuning."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Beveiligingsniveau 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Dit apparaat heeft minimale bescherming tegen "
+#~ "hardwarebeveiligingsproblemen. Dit is het laagste "
+#~ "hardwarebeveiligingsniveau en biedt alleen bescherming tegen eenvoudige "
+#~ "beveiligingsrisico’s."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Beveiligingsniveau 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Dit apparaat heeft basisbescherming tegen hardwarebeveiligingsproblemen. "
+#~ "Dit biedt bescherming tegen enkele veelvoorkomende beveiligingsrisico’s."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Beveiligingsniveau 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Dit apparaat heeft uitgebreide bescherming tegen "
+#~ "hardwarebeveiligingsproblemen. Dit is het hoogste "
+#~ "hardwarebeveiligingsniveau en biedt bescherming tegen geavanceerde "
+#~ "beveiligingsrisico’s."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Beveiligingsniveaus zijn niet beschikbaar voor dit apparaat."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Neem contact op met uw hardwarefabrikant voor hulp met "
+#~ "beveiligingsupdates."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Mogelijk kan dit probleem worden opgelost in de UEFI-firmware-"
+#~ "instellingen van het apparaat, of door een ondersteuningstechnicus."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Mogelijk kan dit probleem worden opgelost in de UEFI-firmware-"
+#~ "instellingen van het apparaat."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Mogelijk kan dit probleem worden opgelost door een "
+#~ "ondersteuningstechnicus."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr ""
+#~ "Beveiligd tegen kwaadaardige software wanneer het apparaat wordt "
+#~ "opgestart."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Veilig opstarten heeft problemen"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Enige bescherming wanneer het apparaat wordt opgestart."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Veilig opstarten is uitgeschakeld"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Geen bescherming wanneer het apparaat wordt opgestart."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Dit probleem kan veroorzaakt zijn door een wijziging in de UEFI-firmware-"
+#~ "instellingen, een wijziging in de configuratie van het besturingssysteem, "
+#~ "of door kwaadaardige software op dit systeem."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Dit probleem kan veroorzaakt zijn door een wijziging in de UEFI-firmware-"
+#~ "instellingen, of door kwaadaardige software op dit systeem."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Dit probleem kan veroorzaakt zijn door een wijziging in de configuratie "
+#~ "van het besturingssysteem, of door kwaadaardige software op dit systeem."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Blootgesteld aan ernstige veiligheidsrisico’s."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Beperkte bescherming tegen eenvoudige beveiligingsrisico’s."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Beschermd tegen veelvoorkomende beveiligingsrisico’s."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Beschermd tegen een breed scala aan beveiligingsrisico’s."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Uitgebreide bescherming"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Firmware-schrijfbeveiliging"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Firmware-schrijfbeveiliginsvergrendeling"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Firmware-BIOS-regio"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Firmware-BIOS-descriptor"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Pre-boot DMA-bescherming"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard - Geverifieerd opstarten"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard - ACM-beschermd"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard - Foutbeleid"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard - Zekering"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET ingeschakeld"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET actief"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Versleuteld geheugen"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU-bescherming"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux-kernelvergrendeling"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux-kernelverificatie"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux-wisselgeheugen"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Pauzestand d.m.v. geheugen"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Pauzestand d.m.v. slapen"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI-platformsleutel"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI-veilig-starten"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM-platformconfiguratie"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM-reconstructie"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Fabrieksstand van Intel Management Engine"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Overschrijving van Intel Management Engine"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Versie van Intel Management Engine"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Firmware-updates"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Firmware-controleerbaarheid"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Firmware-updater-verificatie"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Platform-foutopsporing"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Processor-beveiligingschecks"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD-terugrolbescherming"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD-firmware-replay-bescherming"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD-firmware-schrijfbescherming"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Platform met zekering"
+
+#~ msgid "Valid"
+#~ msgstr "Geldig"
+
+#~ msgid "Not Valid"
+#~ msgstr "Niet geldig"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Niet ingeschakeld"
+
+#~ msgid "Locked"
+#~ msgstr "Vergrendeld"
+
+#~ msgid "Not Locked"
+#~ msgstr "Niet vergrendeld"
+
+#~ msgid "Encrypted"
+#~ msgstr "Versleuteld"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Niet versleuteld"
+
+#~ msgid "Tainted"
+#~ msgstr "Aangetast"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Niet aangetast"
+
+#~ msgid "Found"
+#~ msgstr "Gevonden"
+
+#~ msgid "Not Found"
+#~ msgstr "Niet gevonden"
+
+#~ msgid "Supported"
+#~ msgstr "Ondersteund"
+
+#~ msgid "Not Supported"
+#~ msgstr "Niet-ondersteund"
+
+#~ msgid "Unknown"
+#~ msgstr "Onbekend"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Onbekend"
+
+#~ msgid "Not Available"
+#~ msgstr "Niet beschikbaar"
+
+#~ msgid "System Logo"
+#~ msgstr "Systeemlogo"
+
+#~ msgid "No input sources found"
+#~ msgstr "Er zijn geen invoerbronnen aangetroffen"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Overige"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Aangepaste sneltoets"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "De alternatievetekenstoets kan gebruikt worden om extra tekens in te "
+#~ "voeren. Deze worden soms als derde teken op uw toetsenbord gedrukt."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Linker Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Rechter Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Linker Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Rechter Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menutoets"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Rechter Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Met de samensteltoets kan een grote verscheidenheid aan tekens worden "
+#~ "ingevoerd. Om deze te gebruiken, drukt u op samenstellen en vervolgens op "
+#~ "een reeks tekens. Bijvoorbeeld, samensteltoets gevolgd door <b>C</b> en "
+#~ "<b>o</b> geeft <b>©</b>, <b>a</b> gevolgd door <b>'</b> geeft <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Schakelen tussen invoerbronnen is mogelijk met de sneltoets %s.\n"
+#~ "Dit kan gewijzigd worden in de sneltoetsinstellingen."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d aangepast"
+#~ msgstr[1] "%d aangepast"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Alle sneltoetsen opnieuw instellen?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Het opnieuw instellen van de sneltoetsen kan invloed hebben op uw "
+#~ "aangepaste sneltoetsen. Dit kan niet ongedaan worden gemaakt."
+
+#~ msgid "Reset All"
+#~ msgstr "Alles opnieuw instellen"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s wordt al gebruikt voor %s. Als u deze vervangt, zal %s worden "
+#~ "uitgeschakeld"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Voer de nieuwe sneltoets in"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Aangepaste sneltoets instellen"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Sneltoets instellen"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Voer een nieuwe sneltoets in om %s te wijzigen."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Aangepaste sneltoets toevoegen"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Scrollen met twee vingers"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Vijf klikken, GEGL-tijd!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dubbelklik, primaire knop"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Enkele klik, primaire knop"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dubbelklik, middelste knop"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Enkele klik, middelste knop"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dubbelklik, secundaire knop"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Enkele klik, secundaire knop"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Netwerkbeheer moet draaien."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Onveilig netwerk (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Beveiligd netwerk (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Beveiligd netwerk (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Beveiligd netwerk (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Beveiligd netwerk"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Door de hotspot in te schakelen verbreekt u de verbinding met %s, en zult "
+#~ "u geen toegang tot het internet hebben via wifi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Moet minimaal 8 tekens bevatten"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Hotspot stoppen en verbinding verbreken met gebruikers?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "Hotspot _stoppen"
+
+#~ msgid "Preserve"
+#~ msgstr "Behouden"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "Willekeurig"
+
+#~ msgid "Stable"
+#~ msgstr "Stabiel"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Het ingevoerde MAC-adres zal gebruikt worden als het hardware-adres voor "
+#~ "het netwerkapparaat waarop deze verbinding is geactiveerd. Dit wordt ‘MAC "
+#~ "cloning’ of ‘spoofing’ genoemd. Voorbeeld: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profiel %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+# Kan niet vertaald worden. - Nathan
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgid "Never"
+#~ msgstr "Nooit"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Zwak"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Oké"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Goed"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Uitstekend"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Verbinding vergeten"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Verbindingsprofiel verwijderen"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN verwijderen"
+
+#~ msgid "Details"
+#~ msgstr "Details"
+
+#~ msgid "automatic"
+#~ msgstr "automatisch"
+
+#~ msgid "Identity"
+#~ msgstr "Identiteit"
+
+#~ msgid "Delete Address"
+#~ msgstr "Adres verwijderen"
+
+#~ msgid "Delete Route"
+#~ msgstr "Route verwijderen"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bits sleutel (hex of ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bits wachtwoord"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamische WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA en WPA2 Persoonlijk"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA en WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Persoonlijk"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Openen van verbindingseditor mislukt"
+
+#~ msgid "New Profile"
+#~ msgstr "Nieuw profiel"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Ongeldige instelling %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Ongeldige instelling %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Uit bestand importeren…"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN toevoegen"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Kan VPN-verbinding niet importeren"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Het bestand ‘%s’ kon niet gelezen worden, of bevat geen herkende "
+#~ "informatie over de VPN-verbinding\n"
+#~ "\n"
+#~ "Fout: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Het te importeren bestand selecteren"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Er bestaat al een bestand met de naam ‘%s’."
+
+#~ msgid "_Replace"
+#~ msgstr "Ve_rvangen"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Wilt u %s vervangen door de VPN-verbinding die u op wilt slaan?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Kan VPN-verbinding niet exporteren"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "De VPN-verbinding ‘%s’ kon niet geëxporteerd worden naar %s.\n"
+#~ "\n"
+#~ "Fout: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN-verbinding exporteren"
+
+#~ msgid "never"
+#~ msgstr "nooit"
+
+#~ msgid "today"
+#~ msgstr "vandaag"
+
+#~ msgid "yesterday"
+#~ msgstr "gisteren"
+
+#~ msgid "Last used"
+#~ msgstr "Laatst gebruikt"
+
+#~ msgid "Add new connection"
+#~ msgstr "Nieuwe verbinding toevoegen"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Netwerkdetails voor de geselecteerde netwerken, inclusief wachtwoord en "
+#~ "aangepaste configuratie, zullen verloren gaan."
+
+#~ msgid "_Forget"
+#~ msgstr "_Vergeten"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Bekende wifi-netwerken"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Vergeten"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Systeembeleid staat gebruik als hotspot niet toe"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Draadloos apparaat ondersteunt de hotspot-modus niet"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Automatisch ontdekken van de web-proxy wordt gebruikt als er geen "
+#~ "configuratie-url is opgegeven."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Dit wordt afgeraden voor niet-vertrouwde publieke netwerken."
+
+#~ msgid "Status unknown"
+#~ msgstr "Onbekende status"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Niet-gemanaged"
+
+#~ msgid "Unavailable"
+#~ msgstr "Niet beschikbaar"
+
+#~ msgid "Connecting"
+#~ msgstr "Verbinden"
+
+#~ msgid "Authentication required"
+#~ msgstr "Authenticatie vereist"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Verbinding verbreken"
+
+#~ msgid "Connection failed"
+#~ msgstr "Verbinding mislukt"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Onbekende status (ontbreekt)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Configuratie mislukt"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP-configuratie mislukt"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP-configuratie verlopen"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Geheimen werden vereist, maar niet verstrekt"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Niet verbonden met 802.1x supplicant"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Configuratie 802.1x supplicant mislukt"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x supplicant mislukt"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant authenticatie duurde te lang"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Starten van PPP-dienst mislukt"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Niet verbonden met PPP-dienst"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP mislukt"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Starten van DHCP-client mislukt"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Fout DHCP-client"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-client mislukt"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Starten van gedeelde verbinding-dienst mislukt"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Gedeelde verbinding-dienst mislukt"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Starten van AutoIP-dienst mislukt"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Fout AutoIP-dienst"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP-dienst mislukt"
+
+#~ msgid "Line busy"
+#~ msgstr "Lijn bezet"
+
+#~ msgid "No dial tone"
+#~ msgstr "Geen kiestoon"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Er kon geen carrier worden vastgesteld"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Tijdslimiet belaanvraag overschreden"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Belpoging mislukt"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Initialisatie van modem mislukt"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Selecteren van opgegeven APN mislukt"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Er wordt niet naar netwerken gezocht"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Netwerkregistratie geweigerd"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Tijdslimiet netwerkregistratie verlopen"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Registreren bij het gevraagde netwerk mislukt"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Controle van pincode mislukt"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Mogelijk ontbreekt de firmware voor het apparaat"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Verbinding verdwenen"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Er werd uitgegaan van de bestaande verbinding"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem niet gevonden"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth-verbinding mislukt"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Simkaart niet ingebracht"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Pincode voor simkaart vereist"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Pukcode voor simkaart vereist"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Verkeerde simkaart"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Verbindingsafhankelijkheid mislukt"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Firmware ontbreekt"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel niet verbonden"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "ongedefinieerde fout in 802.1X-beveiliging (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "geen bestand geselecteerd"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "niet-opgegeven fout bij valideren van eap-method-bestand"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER-, PEM-, PKCS#12-, of PGP-privésleutels"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER- of PEM-certificaten"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "EAP-FAST PAC-bestand ontbreekt"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC-bestanden (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "EAP-LEAP-gebruikersnaam ontbreekt"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "EAP-LEAP-wachtwoord ontbreekt"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "ongeldig EAP-PEAP CA-certificaat: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "ongeldig EAP-PEAP CA-certificaat: geen certificaat opgegeven"
+
+#~ msgid "missing EAP username"
+#~ msgstr "EAP-gebruikersnaam ontbreekt"
+
+#~ msgid "missing EAP password"
+#~ msgstr "EAP-wachtwoord ontbreekt"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "EAP-TLS-identiteit ontbreekt"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "ongeldig EAP-TLS CA-certificaat: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "ongeldig EAP-TLS CA-certificaat: geen certificaat opgegeven"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "ongeldige EAP-TLS-privésleutel: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "ongeldig EAP-TLS-gebruikerscertificaat: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Niet-versleutelde privésleutels zijn onveilig"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "De geselecteerde privésleutel lijkt niet te zijn beveiligd met een "
+#~ "wachtwoord. Dit kan ertoe leiden dat uw beveiligingsgegevens in gevaar "
+#~ "komen. Kies een privésleutel die met een wachtwoord is beveiligd.\n"
+#~ "\n"
+#~ "(U kunt uw privésleutel beveiligen met openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Kies uw persoonlijke certificaat"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Kies uw privésleutel"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "ongeldig EAP-TTLS CA-certificaat: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "ongeldig EAP-TTLS CA-certificaat: geen certificaat opgegeven"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Onbekende fout bij valideren van 802.1X-beveiliging"
+
+#~ msgid "Select a file"
+#~ msgstr "Selecteer een bestand"
+
+#~ msgid "missing leap-username"
+#~ msgstr "leap-gebruikersnaam ontbreekt"
+
+#~ msgid "missing leap-password"
+#~ msgstr "leap-wachtwoord ontbreekt"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Wifi-wachtwoord ontbreekt."
+
+#~ msgid "missing wep-key"
+#~ msgstr "wep-sleutel ontbreekt"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "ongeldige wep-sleutel: sleutel met een lengte van %zu kan enkel hex-"
+#~ "cijfers bevatten"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "ongeldige wep-sleutel: sleutel met een lengte van %zu kan enkel ascii-"
+#~ "tekens bevatten"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "ongeldige wep-sleutel: verkeerde sleutellengte %zu. Een sleutle moet "
+#~ "ofwel 5/13 tekens (ascii) of 10/26 tekens (hex) lang zijn"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "ongeldige wep-sleutel: wachtwoord mag niet leeg zijn"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "ongeldige wep-sleutel: wachtwoord moet korter dan 64 tekens zijn"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "ongeldige wpa-psk: ongeldige sleutellengte %zu. Moet [8,63] bytes of 64 "
+#~ "hex-cijfers zijn"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "ongeldige wpa-psk: kan sleutel met 64 bytes niet interpreteren als hex"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Overige"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s verwijderd"
+
+#~ msgid "Error removing account"
+#~ msgstr "Fout bij verwijderen van account"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s-account"
+
+#~ msgid "Remove Account"
+#~ msgstr "Account verwijderen"
+
+#~ msgid "Unknown time"
+#~ msgstr "Onbekende tijd"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s totdat deze volledig opgeladen is"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Waarschuwing: %s resterend"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s resterend"
+
+#~ msgid "Fully charged"
+#~ msgstr "Volledig opgeladen"
+
+#~ msgid "Not charging"
+#~ msgstr "Niet aan het opladen"
+
+#~ msgid "Empty"
+#~ msgstr "Leeg"
+
+#~ msgid "Charging"
+#~ msgstr "Aan het opladen"
+
+#~ msgid "Discharging"
+#~ msgstr "Aan het ontladen"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Draadloze muis"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Draadloos toetsenbord"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Onderbrekingsvrije voeding"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Personal digital assistant"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobiele telefoon"
+
+#~ msgid "Media player"
+#~ msgstr "Mediaspeler"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Computer"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Gamings-invoerapparaat"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Hoofd"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Extra"
+
+#~ msgid "Batteries"
+#~ msgstr "Accu’s"
+
+#~ msgid "When _idle"
+#~ msgstr "Wanneer i_nactief"
+
+#~ msgid "Suspend"
+#~ msgstr "Pauzestand"
+
+#~ msgid "Power Off"
+#~ msgstr "Uitschakelen"
+
+#~ msgid "Hibernate"
+#~ msgstr "Slaapstand"
+
+#~ msgid "Nothing"
+#~ msgstr "Niets doen"
+
+#~ msgid "When on battery power"
+#~ msgstr "Wanneer op accustroom"
+
+#~ msgid "When plugged in"
+#~ msgstr "Als de kabel aangesloten is"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nooit"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatisch in pauzestand zetten"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "Prestatiemodus tijdelijk uitgeschakeld wegens hoge temperaturen."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Schoot gedetecteerd: prestatiemodus tijdelijk niet beschikbaar. Zet het "
+#~ "apparaat op een stabiel oppervlak om te herstellen."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Prestatiemodus tijdelijk uitgeschakeld."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Lage accu: energiebesparing ingeschakeld. De vorige modus wordt hersteld "
+#~ "wanneer de accu voldoende opgeladen is."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Energiebesparingsmodus geactiveerd door ‘%s’."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Prestatiemodus geactiveerd door ‘%s’."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Prestaties"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Hoge prestaties en stroomverbruik."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Gebalanceerd"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standaard prestaties en stroomverbruik."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Energie besparen"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Verlaagde prestaties en stroomverbruik."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Printer ‘%s’ is verwijderd"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Nieuwe printer toevoegen mislukt."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Kon UI niet laden: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Ontgrendel om printers toe te voegen en instellingen te wijzigen"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Details van %s"
+
+# geen/zonder
+#~ msgid "No suitable driver found"
+#~ msgstr "Geen geschikt stuurprogramma aangetroffen"
+
+#~ msgid "Select PPD File"
+#~ msgstr "PPD-bestand selecteren"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript Printer Description-bestanden (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+#~ "gz, *.PPD.GZ)"
+
+# bij een browser is dit bladwijzers, maar hier is
+# favorieten/favoriet beter (favoriete programma's) (tino)
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect-printer"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD-printer"
+
+#~ msgid "One Sided"
+#~ msgstr "Eenzijdig"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Lange zijde (standaard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Korte zijde (omdraaien)"
+
+#~ msgid "Portrait"
+#~ msgstr "Staand"
+
+#~ msgid "Landscape"
+#~ msgstr "Liggend"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Omgekeerd liggend"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Omgekeerd staand"
+
+#~ msgid "Resume"
+#~ msgstr "Hervatten"
+
+#~ msgid "Pause"
+#~ msgstr "Pauzeren"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Wachten"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Gepauzeerd"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Authenticatie vereist"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Verwerken"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Gestopt"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Geannuleerd"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Afgebroken"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Voltooid"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Verplaats deze opdracht naar boven in de wachtrij"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Actieve afdruktaken"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Voer uw aanmeldgegevens in om af te drukken op %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Printserver ontgrendelen"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s ontgrendelen."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Voer uw gebruikersnaam en wachtwoord in om printers op %s te bekijken."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Naar printers zoeken"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Seriële poort"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Parallelle poort"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Locatie: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adres: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Server vereist authenticatie"
+
+#~ msgid "Two Sided"
+#~ msgstr "Tweezijdig"
+
+#~ msgid "Paper Type"
+#~ msgstr "Papiersoort"
+
+#~ msgid "Paper Source"
+#~ msgstr "Papierbron"
+
+#~ msgid "Output Tray"
+#~ msgstr "Uitvoerlade"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolutie"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Voorfilteren GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Pagina’s per vel"
+
+#~ msgid "Orientation"
+#~ msgstr "Stand"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Algemeen"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Pagina-instelling"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Installeerbare opties"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Taak"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Afdrukkwaliteit"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Kleur"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Afwerking"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Geavanceerd"
+
+#~ msgid "Test page"
+#~ msgstr "Testpagina"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatisch selecteren"
+
+#~ msgid "Printer Default"
+#~ msgstr "Standaardinstellingen van de printer"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Alleen GhostScript-lettertypen insluiten"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Converteren naar PS level 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Converteren naar PS level 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Niet vooraf filteren"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Printkoppen schoonmaken"
+
+#~ msgid "Out of toner"
+#~ msgstr "Geen toner meer"
+
+#~ msgid "Low on developer"
+#~ msgstr "Weinig developer (voor ontwikkelen)"
+
+#~ msgid "Out of developer"
+#~ msgstr "Geen developer meer (voor ontwikkelen)"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Weinig marker-voorraad"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Geen marker meer"
+
+#~ msgid "Open cover"
+#~ msgstr "Klep open"
+
+#~ msgid "Open door"
+#~ msgstr "Deur open"
+
+#~ msgid "Low on paper"
+#~ msgstr "Weinig papier"
+
+#~ msgid "Out of paper"
+#~ msgstr "Geen papier meer"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Offline"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Gestopt"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Afvalbakje bijna vol"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Afvalbakje vol"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr ""
+#~ "De optische lichtgevoelige geleider (optical photo conductor) is bijna "
+#~ "niet meer te gebruiken"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr ""
+#~ "De optische lichtgevoelige geleider (optical photo conductor) "
+#~ "functioneert niet meer"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Gereed"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Taken worden niet geaccepteerd"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Verwerken"
+
+# Maatsysteem dat in de VS wordt gebruikt met inch, foot en pound.
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperiaal (Brits-Amerikaans)"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrisch"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Vragen wat te doen"
+
+#~ msgid "Do nothing"
+#~ msgstr "Niets doen"
+
+#~ msgid "Open folder"
+#~ msgstr "Map openen"
+
+#~ msgid "Other Media"
+#~ msgstr "Andere media"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Selecteer een toepassing voor audio-cd’s"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Selecteer een toepassing voor video-dvd’s"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Selecteer de te starten toepassing als een muziekspeler wordt aangesloten"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Selecteer de te starten toepassing als een camera wordt aangesloten"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Selecteer een toepassing voor software-cd’s"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio-dvd"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "lege Blu-ray-schijf"
+
+#~ msgid "blank CD disc"
+#~ msgstr "lege cd"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "lege dvd"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "lege hd-dvd"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray-videoschijf"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-book-lezer"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Hd-dvd-videoschijf"
+
+#~ msgid "Picture CD"
+#~ msgstr "Foto-cd"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super-video-cd"
+
+#~ msgid "Video CD"
+#~ msgstr "Video-cd"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Scherm wordt uitgeschakeld"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 seconden"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuut"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuten"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuten"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuten"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minuten"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 uur"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "5 minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minuten"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nooit"
+
+#~ msgid "Select Location"
+#~ msgstr "Locatie selecteren"
+
+#~ msgid "_OK"
+#~ msgstr "_Oké"
+
+#~ msgid "No applications found"
+#~ msgstr "Geen toepassingen aangetroffen"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Geen netwerken geselecteerd om te delen"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Aan"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Uit"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Ingeschakeld"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Actief"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Een map kiezen"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Delen van media inschakelen"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Met ‘Delen van persoonlijke bestanden’ kunt u de map ‘Openbaar’ delen met "
+#~ "anderen op uw huidige netwerk via: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Wanneer aanmelden op afstand is ingeschakeld kunnen gebruikers op afstand "
+#~ "verbinding maken via de Secure Shell-opdracht:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Delen van persoonlijke media inschakelen"
+
+#~ msgid "Device name copied"
+#~ msgstr "Apparaatnaam gekopieerd"
+
+#~ msgid "Device address copied"
+#~ msgstr "Apparaatadres gekopieerd"
+
+#~ msgid "Username copied"
+#~ msgstr "Gebruikersnaam gekopieerd"
+
+#~ msgid "Password copied"
+#~ msgstr "Wachtwoord gekopieerd"
+
+#~ msgid "Custom"
+#~ msgstr "Aangepast"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s testen"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Verbinding verbroken"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Verbinden"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Verbonden"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Authenticatie-fout"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autoriseren"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Verminderde functionaliteit"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Verbonden en geautoriseerd"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Onbekend"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Geautoriseerd om:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Verbonden om:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Geregistreerd om:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Autoriseren van apparaat mislukt: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Vergeten van apparaat mislukt: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Fout"
+
+# dit is de knop die naast het veld 'huidige wachtwoord' staat
+# als je je huidige wachtwoord hebt ingevuld en op 'Authenticate'
+# klikt (en het wachtwoord is juist) kun je je huidige wachtwoord
+# gaan wijzigen.
+# Dus letterlijke vertaling is 'Aanmeldingscontrole' maar in dit
+# geval houden we het kort en gebruiken we alleen 'Controle' (tino)
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Geautoriseerd"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Het Thunderbolt-subsysteem (boltd) is niet geïnstalleerd of niet correct "
+#~ "ingesteld."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Alleen USB- en Display Port-apparaten kunnen worden aangesloten."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt kon niet worden gedetecteerd.\n"
+#~ "Of het systeem ondersteunt Thunderbolt niet, of het is uitgeschakeld in "
+#~ "de BIOS, of het is ingesteld op een niet-ondersteund beveiligingsniveau "
+#~ "in de BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "De ondersteuning van Thunderbolt is uitgeschakeld in de BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Thunderbolt-beveiligingsniveau kon niet bepaald worden."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Fout bij omschakelen naar directe modus: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Standaard"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Gemiddeld"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Groot"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Groter"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Grootst"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixels"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kort"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ scherm"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ scherm"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ scherm"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Lang"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 uur"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dag"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dagen"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dagen"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dagen"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dagen"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dagen"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dagen"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dagen"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dagen"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Alle items uit prullenbak verwijderen?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Alle items in de prullenbak zullen definitief verwijderd worden."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Prullenbak l_egen"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Alle tijdelijke bestanden verwijderen?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Alle tijdelijke bestanden zullen definitief verwijderd worden."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Tijdelijke bestanden _definitief verwijderen"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dag"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dagen"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dagen"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Voor altijd"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Dient overeen te komen met het internetadres van uw inlog-provider."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Toevoegen van account mislukt"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Registreren van account mislukt"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Geen ondersteunde manier om met dit domein te authenticeren"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Toetreden tot domein mislukt"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ongeldige gebruikersnaam.\n"
+#~ "Probeer het opnieuw."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ongeldig wachtwoord.\n"
+#~ "Probeer het opnieuw."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Aanmelden bij domein mislukt"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Domein niet gevonden. Heeft u het verkeerd gespeld?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Bladeren naar meer afbeeldingen"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "het apparaat moet worden geclaimd om deze actie uit te voeren"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "het apparaat is al geclaimd door een ander proces"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "u heeft niet de rechten om de actie uit te voeren"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "er zijn geen afdrukken geregistreerd"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Communicatie met het apparaat mislukt tijdens het registreren"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Communicatie met de vingerafdruklezer mislukt"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Communicatie met de vingerafdrukdaemon mislukt"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Oplijsten van vingerafdrukken mislukt: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Verwijderen van opgeslagen vingerafdrukken mislukt: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Linkerduim"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Linkermiddelvinger"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Linkerwijsvinger"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Linkerringvinger"
+
+#~ msgid "Left little finger"
+#~ msgstr "Linkerpink"
+
+#~ msgid "Right thumb"
+#~ msgstr "Rechterduim"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Rechtermiddelvinger"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Rechterwijsvinger"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Rechterringvinger"
+
+#~ msgid "Right little finger"
+#~ msgstr "Rechterpink"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Onbekende vinger"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Klaar"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Vingerafdrukapparaat niet verbonden"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Vingerafdrukapparaatopslag is vol"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Registreren van nieuwe vingerafdruk mislukt"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Starten van registratie mislukt: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Registreren van nieuwe vingerafdruk mislukt"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Stoppen van registratie mislukt: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Plaats uw vinger herhaaldelijk op de lezer om uw vingerafdruk te "
+#~ "registreren"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Deze vinger opnieuw _registreren…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Nieuwe vingerafdruk scannen"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Loslaten van vingerafdrukapparaat %s mislukt: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Probleem bij lezen van apparaat"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Toe-eigenen van vingerafdrukapparaat %s mislukt: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Opvragen van vingerafdrukapparaten mislukt: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Deze week"
+
+#~ msgid "Last Week"
+#~ msgstr "Vorige week"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%d %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%d %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sessie beëindigd"
+
+#~ msgid "Session Started"
+#~ msgstr "Sessie gestart"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Accountactiviteit"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Kies een ander wachtwoord."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Vul uw wachtwoord opnieuw in."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Wachtwoord kon niet gewijzigd worden"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Automatisch voegen bij dit type domein is niet mogelijk"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Een dergelijk domein of realm is niet aangetroffen"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Aanmelden als %s bij het domein %s kan niet"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Ongeldig wachtwoord, probeer het opnieuw"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Kon geen verbinding maken met het %s-domein: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Kon gebruiker niet verwijderen"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Op afstand beheerde gebruiker kon niet worden verwijderen"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "U kunt uw eigen account niet verwijderen."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s is nog aangemeld"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Het verwijderen van een gebruiker die nog aangemeld is, kan leiden tot "
+#~ "een inconsistent systeem."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Moeten de bestanden van %s bewaard blijven?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Het is mogelijk om de persoonlijke map, de e-mailmap en de tijdelijke "
+#~ "bestanden te bewaren als een account verwijderd wordt."
+
+#~ msgid "_Delete Files"
+#~ msgstr "Bestanden _verwijderen"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Bestanden be_waren"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Weet u zeker dat u de op afstand beheerde account van %s wilt verwijderen?"
+
+#~ msgid "_Delete"
+#~ msgstr "Verwij_deren"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Account uitgeschakeld"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "In te stellen bij volgende keer aanmelden"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgid "Logged in"
+#~ msgstr "Aangemeld"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Kon de accounts-service niet benaderen"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Zorg ervoor dat het de AccountService geïnstalleerd in ingeschakeld is."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Om deze instelling te wijzigen moet dit paneel ontgrendeld worden"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "De geselecteerde gebruiker verwijderen"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klik op het *-pictogram om de geselecteerde\n"
+#~ "gebruiker te verwijderen"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Ontgrendel om gebruikers toe te voegen en instellingen te wijzigen"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Het nieuwe wachtwoord moet anders zijn dan het oude."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Probeer enkele letters en cijfers te wijzigen."
+
+# venstertitel
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Probeer het wachtwoord iets meer te wijzigen."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Een wachtwoord zonder uw gebruikersnaam zal sterker zijn."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Vermijd het gebruik van uw naam in uw wachtwoord."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Probeer woorden die in het wachtwoord voorkomen te vermijden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Probeer algemene woorden te vermijden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Probeer het herordenen van bestaande woorden te vermijden."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Probeer meer cijfers te gebruiken."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Probeer meer hoofdletters te gebruiken."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Probeer meer kleine letters te gebruiken."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Probeer meer speciale tekens, zoals interpunctie, te gebruiken."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Probeer een combinatie van letters, cijfers en interpunctie te gebruiken."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Probeer herhaling van hetzelfde teken te vermijden."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Probeer herhaling van hetzelfde soort teken te vermijden: u dient "
+#~ "letters, cijfers en interpunctie te combineren."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Probeer reeksen zoals 1234 of abcd te vermijden."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Het wachtwoord moet langer zijn. Probeer meer letters, cijfers en "
+#~ "leestekens toe te voegen."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Gebruik zowel hoofdletters als kleine letters en probeer een paar cijfers "
+#~ "te gebruiken."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Toevoegen van meer letters, cijfers en leestekens maakt het wachtwoord "
+#~ "nog sterker."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Authenticatie mislukt"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Het nieuwe wachtwoord is te kort"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Het nieuwe wachtwoord is te eenvoudig"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Het oude en nieuwe wachtwoord lijken teveel op elkaar"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Het nieuwe wachtwoord is recentelijk al gebruikt."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Het nieuwe wachtwoord moet numerieke of speciale tekens bevatten"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Het oude en nieuwe wachtwoord zijn hetzelfde"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Uw wachtwoord is gewijzigd sinds de vorige wachtwoordcontrole!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Het nieuwe wachtwoord bevat niet genoeg verschillende tekens"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Onbekende fout"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "De gebruikersnaam bestaat doorgaans enkel uit kleine letters van a t/m z, "
+#~ "cijfers en de volgende tekens: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Die gebruikersnaam is helaas niet beschikbaar. Probeer een andere."
+
+#~ msgid "The username is too long."
+#~ msgstr "De gebruikersnaam is te lang."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Knop %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Toepassingen gedefinieerd"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Toetsaanslag sturen"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Van beeldscherm wisselen"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Schermhulp tonen"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tablet gemonteerd op laptoppaneel"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tablet gemonteerd op extern beeldscherm"
+
+#~ msgid "External tablet device"
+#~ msgstr "Extern tabletapparaat"
+
+#~ msgid "All Displays"
+#~ msgstr "Alle schermen"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Airbrushstylus met druk, tilt en geïntegreerde slider"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Airbrushstylus met druk, tilt en rotatie"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standaardstylus met druk en tilt"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standaardstylus met druk"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nieuwe sneltoets…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Bewerking geannuleerd"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Fout:</b> Toegang geweigerd bij wijzigen van instellingen"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Fout:</b> Probleem met mobiele uitrusting"
+
+#~ msgid "Not Registered"
+#~ msgstr "Niet geregistreerd"
+
+#~ msgid "Registered"
+#~ msgstr "Geregistreerd"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Zoeken"
+
+#~ msgid "Denied"
+#~ msgstr "Geweigerd"
+
+#~ msgid "2G Only"
+#~ msgstr "Alleen 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Alleen 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Alleen 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Alleen 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (voorkeur)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (voorkeur), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (voorkeur), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (voorkeur), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (voorkeur)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (voorkeur), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (voorkeur), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (voorkeur)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (voorkeur), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (voorkeur), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (voorkeur)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (voorkeur), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (voorkeur), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (voorkeur)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (voorkeur), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (voorkeur), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (voorkeur)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (voorkeur), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (voorkeur)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (voorkeur), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (voorkeur)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (voorkeur), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (voorkeur)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (voorkeur), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (voorkeur)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (voorkeur), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (voorkeur)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (voorkeur), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Onbekend"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Simkaart ontgrendelen"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Voer de pincode voor simkaart %d in"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Voer de pincode in om uw simkaart te ontgrendelen"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Voer de pukcode voor simkaart %d in"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Voer de pukcode in om uw simkaart te ontgrendelen"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Onjuist wachtwoord."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "De pukcode moet een getal van 8 cijfers zijn"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Voer nieuwe pincode in"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "De pincode moet een getal van 4 à 8 cijfers zijn"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Ontgrendelen…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Telefoonfout"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Geen verbinding met telefoon"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Bewerking niet toegestaan"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Bewerking niet ondersteund"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Simkaart niet ingevoerd"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Pincode voor simkaart vereist"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Pukcode voor simkaart vereist"
+
+#~ msgid "SIM failure"
+#~ msgstr "Simkaartfout"
+
+#~ msgid "SIM busy"
+#~ msgstr "Simkaart bezig"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Onjuist wachtwoord"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Pin2-code voor simkaart vereist"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Puk2-code voor simkaart vereist"
+
+#~ msgid "Not found"
+#~ msgstr "Niet gevonden"
+
+#~ msgid "No network service"
+#~ msgstr "Geen netwerkdienst"
+
+#~ msgid "Network timeout"
+#~ msgstr "Netwerktime-out"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS-diensten niet toegestaan"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming niet toegestaan in dit locatiegebied"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Ongespecificeerde GPRS-fout"
+
+#~ msgid "No Error"
+#~ msgstr "Geen fout"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Actie geannuleerd"
+
+#~ msgid "Access denied"
+#~ msgstr "Toegang geweigerd"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Onbekende fout"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "Simkaart %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Versienummer weergeven"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Verbose-modus inschakelen"
+
+#~ msgid "Search for the string"
+#~ msgstr "Zoeken naar de tekenreeks"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Een lijst met mogelijke paneelnamen tonen en sluiten"
+
+#~ msgid "Panel to display"
+#~ msgstr "Te tonen paneel"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Beschikbare panelen:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Systeemgeluiden"
+
+#~ msgid "Light"
+#~ msgstr "Licht"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;scherm;vergrendelen;privé;tijdelijk;"
+
+# Select a display language (change will be applied next time you log in)
+#~ msgid "Display Arrangement"
+#~ msgstr "Schermvolgorde"
+
+#~ msgid "Set"
+#~ msgstr "Instellen"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Vergrendel uw scherm"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER- of PEM-certificaten (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Bark"
+#~ msgstr "Blaffen"
+
+#~ msgid "Drip"
+#~ msgstr "Druppelen"
+
+#~ msgid "Glass"
+#~ msgstr "Glas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
 
 #~ msgid "Web Links"
 #~ msgstr "Webverwijzingen"
@@ -8855,8 +8494,8 @@ msgstr "Systeemgeluiden"
 #~ msgstr "Kunnen niet gewijzigd worden"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Individuele rechten voor toepassingen kunnen aangepast worden in de <a "
 #~ "href=\"privacy\">Privacy</a>-instellingen."
@@ -8938,17 +8577,11 @@ msgstr "Systeemgeluiden"
 #~ msgid "Active Display"
 #~ msgstr "Actief scherm"
 
-#~ msgid "Display Configuration"
-#~ msgstr "Schermconfiguratie"
-
 #~ msgid "More Warm"
 #~ msgstr "Warmer"
 
 #~ msgid "Less Warm"
 #~ msgstr "Minder warm"
-
-#~ msgid "Screenshots"
-#~ msgstr "Schermafdrukken"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "Een schermafdruk opslaan in $PICTURES"
@@ -9072,18 +8705,12 @@ msgstr "Systeemgeluiden"
 #~ "Met scherm delen kunnen gebruikers op afstand uw scherm te bekijken of "
 #~ "besturen door te verbinden met %s"
 
-#~ msgid "Copy"
-#~ msgstr "Kopiëren"
-
 #~ msgid "_Screen Sharing"
 #~ msgstr "_Scherm delen"
 
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr ""
 #~ "Sommige diensten zijn uitgeschakeld omdat er geen netwerktoegang is."
-
-#~ msgid "Screen Sharing"
-#~ msgstr "Scherm delen"
 
 #~ msgid "_Password:"
 #~ msgstr "_Wachtwoord:"
@@ -9108,9 +8735,6 @@ msgstr "Systeemgeluiden"
 
 #~ msgid "_Screen Reader"
 #~ msgstr "_Schermlezer"
-
-#~ msgid "_Full Name"
-#~ msgstr "_Volledige naam"
 
 #~ msgid "Standard"
 #~ msgstr "Standaard"
@@ -9174,9 +8798,6 @@ msgstr "Systeemgeluiden"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablet (absoluut)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Touchpad (relatief)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Tabletvoorkeuren"
@@ -9413,9 +9034,6 @@ msgstr "Systeemgeluiden"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Rechtstreekse toegang tot uw Bluetooth-hardware"
-
-#~ msgid "Use your camera"
-#~ msgstr "Uw camera gebruiken"
 
 #~ msgid "Print documents"
 #~ msgstr "Documenten afdrukken"
@@ -10001,9 +9619,6 @@ msgstr "Systeemgeluiden"
 #~ msgid "Alternative switch to next source"
 #~ msgstr "Alternatieve overschakeling naar volgende bron"
 
-#~ msgid "_Options"
-#~ msgstr "_Opties"
-
 #~ msgid "Add input source"
 #~ msgstr "Invoerbron toevoegen"
 
@@ -10140,9 +9755,6 @@ msgstr "Systeemgeluiden"
 #~ msgid "Co­lor"
 #~ msgstr "Kleur"
 
-#~ msgid "Section"
-#~ msgstr "Sectie"
-
 #~ msgid "Overview"
 #~ msgstr "Overzicht"
 
@@ -10178,9 +9790,6 @@ msgstr "Systeemgeluiden"
 #~ msgid "Uni­ver­sal Access"
 #~ msgstr "Universele toegang"
 
-#~ msgid "Disable image"
-#~ msgstr "Afbeelding uitschakelen"
-
 #~ msgid "Browse for more pictures…"
 #~ msgstr "Bladeren naar meer afbeeldingen…"
 
@@ -10203,9 +9812,6 @@ msgstr "Systeemgeluiden"
 
 #~ msgid "Mirrored"
 #~ msgstr "Gespiegeld"
-
-#~ msgid "Secondary"
-#~ msgstr "Secundair"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Gecombineerde schermen rangschikken"
@@ -10271,9 +9877,6 @@ msgstr "Systeemgeluiden"
 
 #~ msgid "Press Esc to cancel."
 #~ msgstr "Druk op Esc om te annuleren."
-
-#~ msgid "Edit"
-#~ msgstr "Bewerken"
 
 #~ msgctxt "button"
 #~ msgid "Set Shortcut"
@@ -10369,9 +9972,6 @@ msgstr "Systeemgeluiden"
 #~ msgid "Mail"
 #~ msgstr "E-mail"
 
-#~ msgid "Calendar"
-#~ msgstr "Agenda"
-
 #~ msgid "Contacts"
 #~ msgstr "Contacten"
 
@@ -10386,9 +9986,6 @@ msgstr "Systeemgeluiden"
 
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "Dit zal niet het account op de server verwijderen."
-
-#~ msgid "_Remove"
-#~ msgstr "_Verwijderen"
 
 #~ msgid "No online accounts configured"
 #~ msgstr "Geen online-accounts geconfigureerd"
@@ -10419,9 +10016,6 @@ msgstr "Systeemgeluiden"
 #~ msgstr[0] "%u actief"
 #~ msgstr[1] "%u actief"
 
-#~ msgid "Loading options…"
-#~ msgstr "Opties worden geladen…"
-
 #~ msgid "Supply"
 #~ msgstr "Voorraad"
 
@@ -10433,9 +10027,6 @@ msgstr "Systeemgeluiden"
 
 #~ msgid "label"
 #~ msgstr "label"
-
-#~ msgid "Setting new driver…"
-#~ msgstr "Een nieuw stuurprogramma instellen…"
 
 #~ msgid "Print _Test Page"
 #~ msgstr "_Testpagina afdrukken"
@@ -10535,9 +10126,6 @@ msgstr "Systeemgeluiden"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Omhoog schuiven"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Omlaag schuiven"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Naar rechts schuiven"
@@ -10657,6 +10245,3 @@ msgstr "Systeemgeluiden"
 
 #~ msgid "Yes"
 #~ msgstr "Ja"
-
-#~ msgid "Personal File Sharing"
-#~ msgstr "Delen van persoonlijke bestanden"

--- a/po/nl.po~
+++ b/po/nl.po~
@@ -1,0 +1,11570 @@
+# Dutch translation for gnome-control-center
+# This file is distributed under the same license as the gnome-control-center package.
+# Bas Wagter <B.J.Wagter@bk.tudelft.nl>
+# Hein-Jan Leliveld <h.j.leliveld@student.tn.tudelft.nl>
+# desktop                  - werkblad
+# enroll (fingerprint)     - (vingerafruk) nemen
+# modifier keys            - optietoetsen
+# wallpaper                - achtergrond
+# calibrate                - kalibreren
+# keywords		   - Engelse keywords laten staan + enkele Nederlandse woorden die Rachid had toegevoegd.
+# Dennis Smit <synap@area101.penguin.nl>, 2000.
+# Almer S. Tigelaar <almer@gnome.org>, 2001.
+# Jan-Willem Harmanny <jwharmanny@hotmail.com>, 2002.
+# Huib Kleinhout <huib@stack.nl>, 2002.
+# Ronald Hummelink <ronald@hummelink.xs4all.nl>, 2002.
+# Tino Meinen <tino.meinen@gmail.com>, 2004, 2006, 2007, 2009.
+# Wouter Bolsterlee <wbolster@gnome.org>, 2006, 2008, 2011–2012.
+# Rachid BM <rachidbm@ubuntu.com>, 2011.
+# Reinout van Schouwen <reinouts@gnome.org>, 2002–2008, 2011, 2012, 2014, 2016.
+# Nathan Follens <nfollens@gnome.org>, 2015-2022.
+# Hannie Dumoleyn <hannie@ubuntu-nl.org>, 2011, 2012, 2013, 2014, 2015, 2017, 2018, 2020, 2021.
+# Justin van Steijn <jvs@fsfe.org>, 2016, 2018.
+# Philip Goto <philip.goto@gmail.com>, 2022.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-22 15:35+0000\n"
+"PO-Revision-Date: 2022-10-05 20:46+0200\n"
+"Last-Translator: Nathan Follens <nfollens@gnome.org>\n"
+"Language-Team: Dutch <gnome-nl-list@gnome.org>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.1.1\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Systeembus"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Volledige toegang"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Sessiebus"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Apparaten"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Volledige toegang tot /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Netwerk"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Heeft netwerktoegang"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Persoonlijke map"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Alleen-lezen"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Bestandssysteem"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Instellingen"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Kan instellingen wijzigen"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s heeft volgende ingebouwde rechten. Deze kunnen niet gewijzigd worden. "
+"Indien u hier bezorgd om bent, kunt u de toepassing verwijderen."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u bestands- en verwijzingstype wordt geopend door de toepassing"
+msgstr[1] "%u bestands- en verwijzingstypes worden geopend door de toepassing"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> wordt gebruikt om de volgende types bestanden en verwijzingen te "
+"openen."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s aan schijfruimte in gebruik."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Toepassingen"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Geen toepassingen"
+
+# Geen context, dus moet misschien nog aangepast worden - Nathan
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Installeer enkele…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Openen"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Details bekijken"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Zoeken"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Ontvang systeemzoekopdrachten en stuur zoekresultaten terug."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificaties"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Toon systeemnotificaties."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Uitvoeren op de achtergrond"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Sta activiteit toe wanneer de toepassing gesloten is."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Schermafdrukken"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Maak op elk moment foto’s van het scherm."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Achtergrond wijzigen"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Wijzig de bureaubladachtergrond."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Geluiden"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Maak geluid."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Sneltoetsen blokkeren"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Blokkeer standaardsneltoetsen."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Camera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Maak foto’s met de camera."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microfoon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Neem geluid op met de microfoon."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Locatiediensten"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Toegang tot locatiegegevens van apparaat."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Ingebouwde rechten"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Systeemtoegang die door de toepassing vereist wordt"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Bestands- &amp; verwijzingsassociaties"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Opslag"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Geen resultaat gevonden"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Probeer een andere zoekopdracht"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Bestands- en verwijzingsassociaties"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Bestandstypes"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Verwijzingstypes"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Opnieuw instellen"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Hoe veel opslagruimte deze toepassing bezet met toepassingsgegevens en "
+"cachegeheugen."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Toepassing"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Gegevens"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cachegeheugen"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Totaal</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Cachegeheugen wissen…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Beheer verschillende toepassingsrechten en -instellingen"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"application;flatpak;permission;setting;toepassing;rechten;machtigingen;"
+"instellingen;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Selecteer een afbeelding"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Annuleren"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Openen"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "meerdere groottes"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Geen werkbladachtergrond"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Huidige achtergrond"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stijl"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Standaard"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Donker"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Achtergrond"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Afbeelding toevoegen…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Weergave"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+"Wijzig uw achtergrondafbeelding of de kleuren van de gebruikersinterface"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;Achtergrond;"
+"Bureaubladachtergrond;Scherm;Bureaublad;Stijl;Licht;Donker;Weergave;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Inschakelen"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Bluetooth niet aangetroffen"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Sluit een dongle aan om Bluetooth te gebruiken."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth uitgeschakeld"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Schakel in om apparaten aan te sluiten en bestandsoverdrachten te ontvangen."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Vliegtuigstand is aan"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth wordt uitgeschakeld als vliegtuigstand aan staat."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Vliegtuigstand uitzetten"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Hardware-vliegtuigstand is aan"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Vliegtuigstand uitschakelen om Bluetooth mogelijk te maken."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Bluetooth aan- en uitzetten en uw apparaten aansluiten"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;delen;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Camera is uitgeschakeld"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Er zijn geen toepassingen die foto’s of video’s kunnen maken."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Gebruik van de camera geeft toepassingen de mogelijkheid foto’s en video’s "
+"(op) te nemen. De camera uitschakelen kan ertoe leiden dat sommige "
+"toepassingen niet correct functioneren.\n"
+"\n"
+"Sta de onderstaande toepassingen toe uw camera te gebruiken."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Er hebben nog geen toepassingen toegang tot de camera gevraagd"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Bescherm uw foto’s"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;foto;video;vergrendel;privé;"
+"privacy;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Plaats uw kalibratieapparaat boven het vierkant en druk op ‘Starten’"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Zet uw kalibratieapparaat in de kalibratiepositie en druk op ‘Doorgaan’"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Zet uw kalibratieapparaat in de oppervlaktepositie en druk op ‘Doorgaan’"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Sluit het deksel van de laptop"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Er is een interne fout opgetreden die niet hersteld kon worden."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "De hulpmiddelen nodig voor de kalibratie zijn niet geïnstalleerd."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Het profiel kon niet gegenereerd worden."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Het ‘target whitepoint’ was niet te krijgen."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Klaar!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibratie mislukt!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "U kunt het kalibratieapparaat verwijderen."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Niet aan het kalibratieapparaat komen terwijl dit proces loopt"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Kalibratie weergeven"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Starten"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "He_rvatten"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Klaar"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Laptopscherm"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Ingebouwde webcam"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s-beeldscherm"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s-scanner"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s-camera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s-printer"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s-webcam"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Kleurbeheer voor %s inschakelen"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Kleurprofielen voor %s tonen"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Niet gekalibreerd"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Standaard: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Kleurruimte: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Testprofiel: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "ICC-profiel selecteren"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importeren"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Ondersteunde ICC-profielen"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Alle bestanden"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Scherm"
+
+# bij een browser is dit bladwijzers, maar hier is
+# favorieten/favoriet beter (favoriete programma's) (tino)
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Profiel opslaan"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "Op_slaan"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Kleurprofiel maken voor het geselecteerde apparaat"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Het meetinstrument is niet gevonden. Controleer of het aan staat en correct "
+"verbonden is."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Het meetinstrument ondersteunt het profileren van printers niet."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Dit type apparaat wordt niet ondersteund."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Schermkalibratie"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibratiekwaliteit"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibratie zal een profiel opleveren dat u kunt gebruiken voor kleurbeheer "
+"van uw scherm. Hoe langer u kalibreert, hoe beter de kwaliteit van het "
+"kleurprofiel."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Tijdens het kalibreren kunt u uw computer niet gebruiken."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kwaliteit"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Geschatte tijd"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibratieapparaat"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Het sensorapparaat dat u voor kalibratie wilt gebruiken selecteren."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Type beeldscherm"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Het type scherm dat aangesloten is selecteren."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Whitepoint-profiel"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Selecteer een ‘target white point’ voor het scherm. De meeste schermen "
+"moeten naar een ‘D65 illuminant’ gekalibreerd worden."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Helderheid van het scherm"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Stel de voor u juiste helderheid van het scherm in. Kleurbeheer zal het "
+"nauwkeurigst zijn bij deze helderheid."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"U kunt ook gebruik maken van het helderheidsniveau dat gebruikt wordt met "
+"een van de andere profielen voor dit apparaat."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profielnaam"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"U kunt een kleurprofiel gebruiken op verschillende computers, of zelfs een "
+"profiel aanmaken voor verschillende lichtomstandigheden."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profielnaam:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Samenvatting"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profiel met succes aangemaakt!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Profiel kopiëren"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Schrijfbaar medium vereist"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"De instructies over hoe een profiel te gebruiken op <a href=\"linux\">GNU/"
+"Linux</a>, <a href=\"osx\">Apple OS X</a>- en <a href=\"windows\">Microsoft "
+"Windows</a>-systemen kunnen nuttig zijn."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Profiel toevoegen"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Er zijn problemen ontdekt. Het profiel werkt mogelijk niet correct. <a href="
+"\"\">Details tonen.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "Bestand _importeren…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Toevoegen"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Elk apparaat heeft een actueel bijgewerkt kleurprofiel nodig om gebruik te "
+"maken van kleurbeheer."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Meer informatie"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Meer te weten komen over kleurbeheer"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Voor _alle gebruikers instellen"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Dit profiel instellen voor alle gebruikers op deze computer"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Inschakelen"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Profiel _toevoegen"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibreren…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Apparaat kalibreren"
+
+# bij een browser is dit bladwijzers, maar hier is
+# favorieten/favoriet beter (favoriete programma's) (tino)
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Profiel _verwijderen"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "Details _bekijken"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Er zijn geen apparaten met kleurbeheer aangetroffen"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projector"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL achtergrondverlichting)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED achtergrondverlichting)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (wit LED achtergrondverlichting)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Wide gamut LCD (CCFL achtergrondverlichting)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Wide gamut LCD (RGB LED achtergrondverlichting)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Hoog"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minuten"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Gemiddeld"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minuten"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Laag"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minuten"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Scherm-eigen"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Afdrukken en publiceren)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografie en afbeeldingen)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standaard kleurruimte"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testprofiel"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatisch"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Lage kwaliteit"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Gemiddelde kwaliteit"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Hoge kwaliteit"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Standaard RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Standaard CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Standaard grijs"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Fabrieksinstellingen voor kalibratie zijn door fabrikant geleverd"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Volledig scherm-correctie is niet mogelijk met dit profiel"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Dit profiel is mogelijk niet meer accuraat"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Kleur"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"De kleur van uw apparaten, zoals beeldschermen, camera’s of printers "
+"kalibreren"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Profile;Calibrate;Printer;Display;Kleur;Kalibreren;Weergave;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Ander profiel…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Selecteer een taal"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Selecteren"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Er zijn geen talen aangetroffen"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Meer…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Ontgrendel om instellingen te wijzigen"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+"Sommige instellingen moeten eerst ontgrendeld worden vooraleer ze gewijzigd "
+"kunnen worden."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Ontgrendelen…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Uur verhogen"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Minuut verhogen"
+
+# Is dit intervaltijd uit de dubbelklik-pref of iets anders?
+# Rachid: het wordt in de code gebruikt bij datum en de opmaak voor tijd dingen dus het lijkt mij iets met TIJD te maken te hebben ;)
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Tijd"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Uur verlagen"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Minuut verlagen"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Vandaag"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Gisteren"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%d %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%d %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d uur"
+msgstr[1] "%d uur"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuut"
+msgstr[1] "%d minuten"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d seconde"
+msgstr[1] "%d seconden"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 seconden"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-uurs"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%k:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Datum en tijd"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Jaar"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Maand"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januari"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februari"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Maart"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mei"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juni"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juli"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Augustus"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "December"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dag"
+
+# Is dit intervaltijd uit de dubbelklik-pref of iets anders?
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Tijdzone"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Een locatie zoeken"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatische _datum &amp; tijd"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Internetverbinding vereist"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Datum &amp; _tijd"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automatische tijd_zone"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Vereist locatiediensten en internettoegang"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Ingeschakeld"
+
+# Is dit intervaltijd uit de dubbelklik-pref of iets anders?
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "_Tijdzone"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Tijd_notatie"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Datum en tijd, inclusief tijdzone, wijzigen"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;Klok;Tijdzone;Locatie;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Datum en tijd van systeem wijzigen"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Om de datum en tijd van het systeem te wijzigen dient u zich te "
+"authenticeren."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_E-mail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Agenda"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_uziek"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Foto’s"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Standaardtoepassingen"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Standaardtoepassingen configureren"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;standaard;toepassing;voorkeur;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Het sturen van rapporten over technische problemen helpt ons %s te "
+"verbeteren. Rapporten worden anoniem verstuurd en bevatten geen persoonlijke "
+"gegevens. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Problemen melden"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Problemen _automatisch melden"
+
+# 'Bevindingen' stond in mijn vertaalgeheugen van andere GNOME-toepassingen, anders zou ik iets met 'Diagnostiek' gebruiken - Nathan
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Bevindingen"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Meld uw problemen"
+
+# 'Bevindingen' stond in mijn vertaalgeheugen van andere GNOME-toepassingen, anders zou ik iets met 'Diagnostiek' gebruiken - Nathan
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;bevindingen;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Aan"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Uit"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Wijzigingen toepassen?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Wijzigingen kunnen niet worden toegepast"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Dit kan het gevolg zijn van hardwarebeperkingen."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Toepassen"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Terug"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Scherminstellingen uitgeschakeld"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Meerdere schermen"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Samenvoegen"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Spiegelen"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Bevat de bovenste balk en Activiteiten"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Primair scherm"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Nachtlicht"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Liggend"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Staand rechts"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Staand links"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Liggend (omgedraaid)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Stand"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolutie"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Verversingsfrequentie"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Aanpassen aan tv"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Schalen"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nachtlicht niet beschikbaar"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Dit kan het resultaat zijn van het gebruikte grafische stuurprogramma, of "
+"omdat het bureaublad op afstand wordt gebruikt"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Tijdelijk uitgeschakeld tot morgen"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Filter herstarten"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Nachtlicht maakt de schermkleur warmer. Dit kan helpen vermoeide ogen en "
+"slapeloosheid te voorkomen."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Planning"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Zonsondergang tot zonsopgang"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Handmatige planning"
+
+# Is dit intervaltijd uit de dubbelklik-pref of iets anders?
+# Rachid: het wordt in de code gebruikt bij datum en de opmaak voor tijd dingen dus het lijkt mij iets met TIJD te maken te hebben ;)
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Tijden"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Van"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "uur"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "minuut"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "am"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "pm"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "tot"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Kleurtemperatuur"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Schermen"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Kiezen hoe aangesloten beeldschermen en projectoren gebruikt worden"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;Paneel;Scherm;Resolutie;Verversen;Beeldscherm;"
+"Nacht;Licht;Blauw;kleur;zonsondergang;zonsopgang;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Veilig opstarten is actief"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Veilig opstarten voorkomt dat kwaadaardige software wordt geladen wanneer "
+"het apparaat wordt opgestart. Het is momenteel ingeschakeld en functioneert "
+"correct."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Veilig opstarten heeft problemen"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Veilig opstarten voorkomt dat kwaadaardige software wordt geladen wanneer "
+"het apparaat wordt opgestart. Het is momenteel ingeschakeld, maar zal niet "
+"werken vanwege een ongeldige sleutel."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Problemen met veilig opstarten kunnen vaak worden opgelost via de UEFI-"
+"firmware-instellingen (BIOS) van uw computer. Uw hardwarefabrikant kan "
+"informatie verstrekken over hoe u dit kunt doen."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Neem voor hulp contact op met uw hardwarefabrikant of IT-ondersteuning."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Veilig opstarten is uitgeschakeld"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Veilig opstarten voorkomt dat kwaadaardige software wordt geladen wanneer "
+"het apparaat wordt opgestart. Het is momenteel uitgeschakeld."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Veilig opstarten kan vaak worden ingeschakeld via de UEFI-firmware-"
+"instellingen (BIOS) van uw computer. Neem voor hulp contact op met uw "
+"hardwarefabrikant of IT-ondersteuning."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Veilig opstarten voorkomt dat kwaadaardige software wordt geladen wanneer "
+"het apparaat wordt opgestart.\n"
+"\n"
+"Voor meer informatie kunt u contact opnemen met de hardwarefabrikant of IT-"
+"ondersteuning."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Voldaan"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Niet voldaan"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Apparaat voldoet aan HSI-niveau %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Beveiligingsniveau 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Dit apparaat heeft geen bescherming tegen hardwarebeveiligingsproblemen. Dit "
+"kan komen door een probleem met de hardware- of firmwareconfiguratie. Het "
+"wordt aanbevolen contact op te nemen met uw IT-ondersteuning."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Beveiligingsniveau 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Dit apparaat heeft minimale bescherming tegen hardwarebeveiligingsproblemen. "
+"Dit is het laagste hardwarebeveiligingsniveau en biedt alleen bescherming "
+"tegen eenvoudige beveiligingsrisico’s."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Beveiligingsniveau 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Dit apparaat heeft basisbescherming tegen hardwarebeveiligingsproblemen. Dit "
+"biedt bescherming tegen enkele veelvoorkomende beveiligingsrisico’s."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Beveiligingsniveau 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Dit apparaat heeft uitgebreide bescherming tegen "
+"hardwarebeveiligingsproblemen. Dit is het hoogste hardwarebeveiligingsniveau "
+"en biedt bescherming tegen geavanceerde beveiligingsrisico’s."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Beveiligingsniveau"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Beveiligingsniveaus zijn niet beschikbaar voor dit apparaat."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Neem contact op met uw hardwarefabrikant voor hulp met beveiligingsupdates."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Mogelijk kan dit probleem worden opgelost in de UEFI-firmware-instellingen "
+"van het apparaat, of door een ondersteuningstechnicus."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Mogelijk kan dit probleem worden opgelost in de UEFI-firmware-instellingen "
+"van het apparaat."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+"Mogelijk kan dit probleem worden opgelost door een ondersteuningstechnicus."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Niveau 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Niveau 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Niveau 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+"Beveiligd tegen kwaadaardige software wanneer het apparaat wordt opgestart."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Veilig opstarten heeft problemen"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Enige bescherming wanneer het apparaat wordt opgestart."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Veilig opstarten is uitgeschakeld"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Geen bescherming wanneer het apparaat wordt opgestart."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Dit probleem kan veroorzaakt zijn door een wijziging in de UEFI-firmware-"
+"instellingen, een wijziging in de configuratie van het besturingssysteem, of "
+"door kwaadaardige software op dit systeem."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Dit probleem kan veroorzaakt zijn door een wijziging in de UEFI-firmware-"
+"instellingen, of door kwaadaardige software op dit systeem."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Dit probleem kan veroorzaakt zijn door een wijziging in de configuratie van "
+"het besturingssysteem, of door kwaadaardige software op dit systeem."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Blootgesteld aan ernstige veiligheidsrisico’s."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Beperkte bescherming tegen eenvoudige beveiligingsrisico’s."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Beschermd tegen veelvoorkomende beveiligingsrisico’s."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Beschermd tegen een breed scala aan beveiligingsrisico’s."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Uitgebreide bescherming"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Geen gebeurtenissen"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Firmware-schrijfbeveiliging"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Firmware-schrijfbeveiliginsvergrendeling"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Firmware-BIOS-regio"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Firmware-BIOS-descriptor"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Pre-boot DMA-bescherming"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard - Geverifieerd opstarten"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard - ACM-beschermd"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard - Foutbeleid"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard - Zekering"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET ingeschakeld"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET actief"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Versleuteld geheugen"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU-bescherming"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux-kernelvergrendeling"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux-kernelverificatie"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux-wisselgeheugen"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Pauzestand d.m.v. geheugen"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Pauzestand d.m.v. slapen"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI-platformsleutel"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI-veilig-starten"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM-platformconfiguratie"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM-reconstructie"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Fabrieksstand van Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Overschrijving van Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Versie van Intel Management Engine"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Firmware-updates"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Firmware-controleerbaarheid"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Firmware-updater-verificatie"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Platform-foutopsporing"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Processor-beveiligingschecks"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD-terugrolbescherming"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD-firmware-replay-bescherming"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD-firmware-schrijfbescherming"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Platform met zekering"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Geldig"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Niet geldig"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Niet ingeschakeld"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Vergrendeld"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Niet vergrendeld"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Versleuteld"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Niet versleuteld"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Aangetast"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Niet aangetast"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Gevonden"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Niet gevonden"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Ondersteund"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Niet-ondersteund"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Apparaatbeveiliging"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Firmwarebeveiligingsstatus van host"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;scherm;vergrendelen;privé;tijdelijk;naam;netwerk;"
+"identiteit;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Onbekend"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Onbekend"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Niet beschikbaar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Systeemlogo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Apparaatnaam"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Hardwaremodel"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Geheugen"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafisch"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Schijfcapaciteit"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Wordt berekend…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Naam besturingssysteem"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "build-ID van besturingssysteem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Type besturingssysteem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Gnome-versie"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Laden…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Venstersysteem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisatie"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Software-updates"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Apparaat hernoemen"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"De apparaatnaam wordt gebruikt om dit apparaat te identificeren in het "
+"netwerk, of bij het koppelen van Bluetooth-apparaten."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Apparaatnaam"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "He_rnoemen"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Info"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Systeeminformatie bekijken"
+
+# The user can search on this keywords. Thereby we chose to let the translation contain both English and Dutch words.
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"apparaat;informatie;geheugen;versie;standaard;toepassing;voorkeur;hostnaam;"
+"automatisch;uitvoeren;verwijderbaar;verwijderbare;toestel;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Geluid en media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Geluid dempen/aanzetten"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Geluid zachter"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Geluid harder"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Microfoon dempen/aanzetten"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Mediaspeler starten"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Afspelen (of spelen/pauzeren)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Afspelen pauzeren"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Afspelen stoppen"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Vorig nummer"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Volgend nummer"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Uitwerpen"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Typen"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Overschakelen naar volgende invoerbron"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Overschakelen naar vorige invoerbron"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Starters"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Hulptoepassing starten"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Rekenmachine starten"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "E-mailtoepassing starten"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Webbrowser starten"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Persoonlijke map"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Zoeken"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Systeem"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Afmelden"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Scherm vergrendelen"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Toegankelijkheid"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Zoom in- of uitschakelen"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Inzoomen"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Uitzoomen"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Schermlezer in- of uitschakelen"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Toetsenbord op scherm in- of uitschakelen"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Grotere tekst"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Kleinere tekst"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Hoog contrast aan of uit"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Er zijn geen invoerbronnen aangetroffen"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Overige"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Invoerbron toevoegen"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Invoermethoden kunnen niet gebruikt worden in het aanmeldscherm"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Er zijn geen invoerbronnen geselecteerd"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opties"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Naar boven"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Naar beneden"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Voorkeuren"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Toetsenbordindeling bekijken"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Verwijderen"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Aangepaste sneltoets"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Toets voor alternatieve tekens"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"De alternatievetekenstoets kan gebruikt worden om extra tekens in te voeren. "
+"Deze worden soms als derde teken op uw toetsenbord gedrukt."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Linker Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Rechter Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Linker Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Rechter Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menutoets"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Rechter Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Samensteltoets"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Met de samensteltoets kan een grote verscheidenheid aan tekens worden "
+"ingevoerd. Om deze te gebruiken, drukt u op samenstellen en vervolgens op "
+"een reeks tekens. Bijvoorbeeld, samensteltoets gevolgd door <b>C</b> en "
+"<b>o</b> geeft <b>©</b>, <b>a</b> gevolgd door <b>'</b> geeft <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Schakelen tussen invoerbronnen is mogelijk met de sneltoets %s.\n"
+"Dit kan gewijzigd worden in de sneltoetsinstellingen."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Invoerbron"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Bevat toetsenbordindelingen en invoermethoden."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Wisselen van invoerbron"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Dezelfde _bron gebruiken voor alle vensters"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Wisselen van Invoerbron af_zonderlijk voor elk venster"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Invoer voor speciale tekens"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Methoden om symbolen en lettervarianten in te voeren met het toetsenbord."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Sneltoetsen"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Sneltoetsen bekijken en aanpassen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d aangepast"
+msgstr[1] "%d aangepast"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Alle sneltoetsen opnieuw instellen?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Het opnieuw instellen van de sneltoetsen kan invloed hebben op uw aangepaste "
+"sneltoetsen. Dit kan niet ongedaan worden gemaakt."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Annuleren"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Alles opnieuw instellen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Alles opnieuw instellen…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Alle sneltoetsen naar hun standaardwaarde terugzetten"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sectie"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Sneltoetsen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Sneltoets toevoegen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Aangepaste sneltoetsen toevoegen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Aangepaste sneltoetsen instellen voor het starten van toepassingen, het "
+"uitvoeren van scripts en meer."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Sneltoets toevoegen"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Geen sneltoets gevonden"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s wordt al gebruikt voor %s. Als u deze vervangt, zal %s worden "
+"uitgeschakeld"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Voer de nieuwe sneltoets in"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Aangepaste sneltoets instellen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Sneltoets instellen"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Voer een nieuwe sneltoets in om %s te wijzigen."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Aangepaste sneltoets toevoegen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Verwijderen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Ve_rvangen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "In_stellen"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Druk op Esc om te annuleren, of Backspace om de sneltoets uit te schakelen."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Naam"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Opdracht"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Sneltoets"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Sneltoets instellen…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Geen"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Sneltoets naar standaardwaarde terugzetten"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Toetsenbord"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Wijzig uw sneltoetsen bekijken en stel uw typvoorkeuren, "
+"toetsenbordindelingen en invoerbronnen in"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+"Sneltoets;Werkruimte;Venster;Vergrendelen;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Locatiediensten zijn uitgeschakeld"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Er zijn geen toepassingen die locatie-informatie kunnen verkrijgen."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Locatiediensten laten toepassingen uw locatie bepalen. Met wifi of mobiel "
+"internet verkrijgt u accuratere resultaten.\n"
+"\n"
+"Maakt gebruik van de Mozilla-locatiedienst: <a href='https://location."
+"services.mozilla.com/privacy'>privacybeleid</a>\n"
+"\n"
+"Sta de onderstaande toepassingen toe om uw locatie te bepalen."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Er hebben nog geen toepassingen toegang tot uw locatie gevraagd"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Beveilig uw locatie-informatie"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;locatie;privé;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Microfoon is uitgeschakeld"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Er zijn geen toepassingen die geluid kunnen opnemen."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Gebruik van de microfoon geeft toepassingen de mogelijkheid om geluid op te "
+"nemen en te beluisteren. De microfoon uitschakelen kan ertoe leiden dat "
+"sommige toepassingen niet correct functioneren.\n"
+"\n"
+"Sta de onderstaande toepassingen toe uw microfoon te gebruiken."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Er hebben nog geen toepassingen toegang tot uw microfoon gevraagd"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Bescherm uw gesprekken"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"microphone;recording;application;privacy;microfoon;opname;opnemen;toepassing;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Uw instellingen _testen"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Algemeen"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primaire knop"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Stelt de volgorde van fysieke knoppen in op muizen en touchpads."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Links"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Rechts"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Muis"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Aanwijzersnelheid"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Natuurlijk schuiven"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Schuiven beweegt de inhoud, niet de weergave."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Touchpadsnelheid"
+
+# op het touchpad tikken om te klikken
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Tikken om te klikken"
+
+# op het touchpad tikken om te klikken
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Tikken om te klikken"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Scrollen met twee vingers"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Aan de rand schuiven"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Probeer te klikken, dubbelklikken, of scrollen"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Vijf klikken, GEGL-tijd!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dubbelklik, primaire knop"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Enkele klik, primaire knop"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dubbelklik, middelste knop"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Enkele klik, middelste knop"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dubbelklik, secundaire knop"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Enkele klik, secundaire knop"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Muis en touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"De gevoeligheid van muis of touchpad wijzigen en rechts- of linkshandig "
+"kiezen"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;Aanwijzer;Klik;Tik;"
+"Dubbel;Knop;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Snel_hoek"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Tik op de linkerbovenhoek om het activiteitenoverzicht te openen."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Schermranden _activeren"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Versleep vensters tegen boven-, linker en rechterrand van het scherm om hun "
+"grootte aan te passen."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Werkbladen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dynamische werkbladen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Verwijdert automatisch lege werkbladen."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Vast aantal werkbladen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Geef een vast aantal werkbladen op."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "Aa_ntal werkbladen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Meerdere schermen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Werkbladen alleen op _hoofdscherm"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Werkbladen op alle _schermen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Wisselen tussen toepassingen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Toepassingen van alle _werkbladen tonen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Alleen toepassingen van het _huidige werkblad tonen"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitasken"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Beheer voorkeuren voor productiviteit en multitasken"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"Multitasken;Productiviteit;Aanpassen;Bureaublad;Snelhoek;Werkbladen;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Oeps! Er ging iets mis. Neem contact op met uw softwareleverancier."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Netwerkbeheer moet draaien."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Overige apparaten"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Verbinding toevoegen"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Niet ingesteld"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Onveilig netwerk (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Beveiligd netwerk (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Beveiligd netwerk (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Beveiligd netwerk (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Beveiligd netwerk"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Verbonden"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opties…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Door de hotspot in te schakelen verbreekt u de verbinding met %s, en zult u "
+"geen toegang tot het internet hebben via wifi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Moet minimaal 8 tekens bevatten"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Mag maximaal %d teken bevatten"
+msgstr[1] "Mag maximaal %d tekens bevatten"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wifi-hotspot inschakelen?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Een wifihotspot maakt het mogelijk om uw internetverbinding te delen met "
+"anderen, door een wifi-netwerk te maken waarmee ze kunnen verbinden. "
+"Hiervoor heeft u een internetverbinding via een andere bron dan wifi nodig."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Netwerknaam"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Wachtwoord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Willekeurig wachtwoord genereren"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Wachtwoord automatisch genereren"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Inschakelen"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wifi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Hotspot stoppen en verbinding verbreken met gebruikers?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "Hotspot _stoppen"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Vliegtuigstand"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Schakelt wifi, bluetooth en mobiel breedband uit"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Geen wifi-adapter gevonden"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Zorg ervoor dat u een wifi-adapter heeft aangesloten en ingeschakeld"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Vliegtuigstand aan"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Schakel uit om wifi te gebruiken"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wifi-hotspot ingeschakeld"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobiele apparaten kunnen de QR-code scannen om verbinding te maken."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Wifi-hotspot uitschakelen…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Zichtbare netwerken"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Netwerkbeheer moet draaien"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x-_beveiliging"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Beveiliging"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Behouden"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Willekeurig"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabiel"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Het ingevoerde MAC-adres zal gebruikt worden als het hardware-adres voor het "
+"netwerkapparaat waarop deze verbinding is geactiveerd. Dit wordt ‘MAC "
+"cloning’ of ‘spoofing’ genoemd. Voorbeeld: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profiel %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+# Kan niet vertaald worden. - Nathan
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Geen"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nooit"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i dag geleden"
+msgstr[1] "%i dagen geleden"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Geen"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Zwak"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Oké"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Goed"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Uitstekend"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4-adres"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-adres"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adres"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Verbinding vergeten"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Verbindingsprofiel verwijderen"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "VPN verwijderen"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Details"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatisch"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identiteit"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Adres verwijderen"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Route verwijderen"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Geen"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bits sleutel (hex of ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bits wachtwoord"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamische WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA en WPA2 Persoonlijk"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA en WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Persoonlijk"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signaalsterkte"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Verbindingssnelheid"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hardware-adres"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Ondersteunde frequenties"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Standaardroute"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Laatst gebruikt"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "_Automatisch verbinden"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Beschikbaar maken voor andere _gebruikers"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "Verbinding _met datalimiet: houdt mogelijk kosten in"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Software-updates en andere grote downloads zullen niet automatisch gestart "
+"worden."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Naam"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC-adres"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Ge_kloond adres"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4-methode"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatisch (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Alleen Link-Local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Handmatig"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Uitschakelen"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Gedeeld met andere computers"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adressen"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adres"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Netmasker"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatisch"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatische DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS-serveradres(sen)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Scheid IP-adressen met komma’s"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Routes"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatische routes"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrisch"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Deze verbinding _alleen gebruiken voor bronnen op hun netwerk"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6-methode"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatisch, alleen DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Voorvoegsel"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Openen van verbindingseditor mislukt"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Nieuw profiel"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Ongeldige instelling %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Ongeldige instelling %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Uit bestand importeren…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "VPN toevoegen"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "B_eveiliging"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Kan VPN-verbinding niet importeren"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Het bestand ‘%s’ kon niet gelezen worden, of bevat geen herkende informatie "
+"over de VPN-verbinding\n"
+"\n"
+"Fout: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Het te importeren bestand selecteren"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Er bestaat al een bestand met de naam ‘%s’."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "Ve_rvangen"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Wilt u %s vervangen door de VPN-verbinding die u op wilt slaan?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Kan VPN-verbinding niet exporteren"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"De VPN-verbinding ‘%s’ kon niet geëxporteerd worden naar %s.\n"
+"\n"
+"Fout: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "VPN-verbinding exporteren"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Fout: laden van VPN-verbindingseditor mislukt)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Regelen hoe u verbinding maakt met het internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;Netwerk;IP;LAN;Proxy;WAN;Broadband;Breedband;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Regelen hoe u verbinding maakt met wifi-netwerken"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Netwerk;Wireless;Draadloos;Wi-Fi;Wifi;IP;LAN;Broadband;Breedband;DNS;"
+"Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nooit"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "vandaag"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "gisteren"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Laatst gebruikt"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Bekabeld"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Nieuwe verbinding toevoegen"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Netwerkdetails voor de geselecteerde netwerken, inclusief wachtwoord en "
+"aangepaste configuratie, zullen verloren gaan."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Vergeten"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Bekende wifi-netwerken"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Vergeten"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Systeembeleid staat gebruik als hotspot niet toe"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Draadloos apparaat ondersteunt de hotspot-modus niet"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Automatisch ontdekken van de web-proxy wordt gebruikt als er geen "
+"configuratie-url is opgegeven."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Dit wordt afgeraden voor niet-vertrouwde publieke netwerken."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Apparaat uitzetten"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Actief"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Provider"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Netwerkproxy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP-proxy"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS-proxy"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP-proxy"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "S_ocks-host"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "Hostcomputers _negeren"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Poort HTTP-proxy"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Poort HTTPS-proxy"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Poort FTP-proxy"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Poort Socks-proxy"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Configuratie-URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN-verbinding uitschakelen"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Netwerknaam"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Beveiligingstype"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Wachtwoord"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wifi uitschakelen"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Meer opties…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Verbinden met een verborgen netwerk…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wifi-hotspot i_nschakelen…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Be_kende wifi-netwerken"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Onbekende status"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Niet-gemanaged"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Niet beschikbaar"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Verbinden"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Authenticatie vereist"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Verbinding verbreken"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Verbinding mislukt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Onbekende status (ontbreekt)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Configuratie mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP-configuratie mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP-configuratie verlopen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Geheimen werden vereist, maar niet verstrekt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Niet verbonden met 802.1x supplicant"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Configuratie 802.1x supplicant mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x supplicant mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant authenticatie duurde te lang"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Starten van PPP-dienst mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Niet verbonden met PPP-dienst"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Starten van DHCP-client mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Fout DHCP-client"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP-client mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Starten van gedeelde verbinding-dienst mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Gedeelde verbinding-dienst mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Starten van AutoIP-dienst mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Fout AutoIP-dienst"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP-dienst mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Lijn bezet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Geen kiestoon"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Er kon geen carrier worden vastgesteld"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Tijdslimiet belaanvraag overschreden"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Belpoging mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Initialisatie van modem mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Selecteren van opgegeven APN mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Er wordt niet naar netwerken gezocht"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Netwerkregistratie geweigerd"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Tijdslimiet netwerkregistratie verlopen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Registreren bij het gevraagde netwerk mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Controle van pincode mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Mogelijk ontbreekt de firmware voor het apparaat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Verbinding verdwenen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Er werd uitgegaan van de bestaande verbinding"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem niet gevonden"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth-verbinding mislukt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Simkaart niet ingebracht"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Pincode voor simkaart vereist"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Pukcode voor simkaart vereist"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Verkeerde simkaart"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Verbindingsafhankelijkheid mislukt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Firmware ontbreekt"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabel niet verbonden"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "ongedefinieerde fout in 802.1X-beveiliging (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "geen bestand geselecteerd"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "niet-opgegeven fout bij valideren van eap-method-bestand"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER-, PEM-, PKCS#12-, of PGP-privésleutels"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER- of PEM-certificaten"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "EAP-FAST PAC-bestand ontbreekt"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC-bestanden (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anoniem"
+
+# dit is de knop die naast het veld 'huidige wachtwoord' staat
+# als je je huidige wachtwoord hebt ingevuld en op 'Authenticate'
+# klikt (en het wachtwoord is juist) kun je je huidige wachtwoord
+# gaan wijzigen.
+# Dus letterlijke vertaling is 'Aanmeldingscontrole' maar in dit
+# geval houden we het kort en gebruiken we alleen 'Controle' (tino)
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Gecontroleerd"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Beide"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anonie_me identiteit"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC-_bestand"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Kies een PAC-bestand"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Interne aanmeldingscontrole"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Automatische PAC-_voorziening toestaan"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "EAP-LEAP-gebruikersnaam ontbreekt"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "EAP-LEAP-wachtwoord ontbreekt"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Gebr_uikersnaam"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Wachtwoord"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Wachtwoord tonen"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "ongeldig EAP-PEAP CA-certificaat: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "ongeldig EAP-PEAP CA-certificaat: geen certificaat opgegeven"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versie 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versie 1"
+
+# dit is de knop die naast het veld 'huidige wachtwoord' staat
+# als je je huidige wachtwoord hebt ingevuld en op 'Authenticate'
+# klikt (en het wachtwoord is juist) kun je je huidige wachtwoord
+# gaan wijzigen.
+# Dus letterlijke vertaling is 'Aanmeldingscontrole' maar in dit
+# geval houden we het kort en gebruiken we alleen 'Controle' (tino)
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A-certificaat"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Kies een Certificate Authority-certificaat"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Geen CA-certificaat vereist"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP-_versie"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "EAP-gebruikersnaam ontbreekt"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "EAP-wachtwoord ontbreekt"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "EAP-TLS-identiteit ontbreekt"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "ongeldig EAP-TLS CA-certificaat: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "ongeldig EAP-TLS CA-certificaat: geen certificaat opgegeven"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "ongeldige EAP-TLS-privésleutel: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "ongeldig EAP-TLS-gebruikerscertificaat: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Niet-versleutelde privésleutels zijn onveilig"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"De geselecteerde privésleutel lijkt niet te zijn beveiligd met een "
+"wachtwoord. Dit kan ertoe leiden dat uw beveiligingsgegevens in gevaar "
+"komen. Kies een privésleutel die met een wachtwoord is beveiligd.\n"
+"\n"
+"(U kunt uw privésleutel beveiligen met openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Kies uw persoonlijke certificaat"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Kies uw privésleutel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentiteit"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Gebr_uikerscertificaat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Privé_sleutel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Wachtwoord _privésleutel"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "ongeldig EAP-TTLS CA-certificaat: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "ongeldig EAP-TTLS CA-certificaat: geen certificaat opgegeven"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (geen EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domein"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Onbekende fout bij valideren van 802.1X-beveiliging"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Getunnelde TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Beveiligde EAP (PEAP)"
+
+# dit is de knop die naast het veld 'huidige wachtwoord' staat
+# als je je huidige wachtwoord hebt ingevuld en op 'Authenticate'
+# klikt (en het wachtwoord is juist) kun je je huidige wachtwoord
+# gaan wijzigen.
+# Dus letterlijke vertaling is 'Aanmeldingscontrole' maar in dit
+# geval houden we het kort en gebruiken we alleen 'Controle' (tino)
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Controleren"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Selecteer een bestand"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "leap-gebruikersnaam ontbreekt"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "leap-wachtwoord ontbreekt"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Wifi-wachtwoord ontbreekt."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Type"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "wep-sleutel ontbreekt"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"ongeldige wep-sleutel: sleutel met een lengte van %zu kan enkel hex-cijfers "
+"bevatten"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"ongeldige wep-sleutel: sleutel met een lengte van %zu kan enkel ascii-tekens "
+"bevatten"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"ongeldige wep-sleutel: verkeerde sleutellengte %zu. Een sleutle moet ofwel "
+"5/13 tekens (ascii) of 10/26 tekens (hex) lang zijn"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "ongeldige wep-sleutel: wachtwoord mag niet leeg zijn"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "ongeldige wep-sleutel: wachtwoord moet korter dan 64 tekens zijn"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Standaard)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Open systeem"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Gedeelde sleutel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Sleutel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Sleutel t_onen"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP-inde_x"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"ongeldige wpa-psk: ongeldige sleutellengte %zu. Moet [8,63] bytes of 64 hex-"
+"cijfers zijn"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "ongeldige wpa-psk: kan sleutel met 64 bytes niet interpreteren als hex"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificaties"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Geluids_waarschuwingen"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Notificaties"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Notificaties zullen nog steeds verschijnen in de lijst met notificaties "
+"wanneer pop-ups uitgeschakeld zijn."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Bericht_inhoud tonen in pop-ups"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notificaties op _vergrendelingsscherm"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "_Berichtinhoud tonen op vergrendelingsscherm"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Niet storen"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Notificaties op vergrendelingsscherm"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Regelen welke notificaties weergegeven worden en wat ze tonen"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;Notificaties;Banners;Banieren;Bericht;Message;Tray;Systeemvak;"
+"Pop-up;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Overige"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s verwijderd"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Fout bij verwijderen van account"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Ongedaan maken"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Notificatie sluiten"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Met uw data in de cloud verbinden"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Geen internetverbinding — maak verbinding om nieuwe online-accounts in te "
+"stellen"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Een account toevoegen"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s-account"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Account verwijderen"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Online accounts"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Verbind met uw online-accounts en bepaal waar u ze voor gebruikt"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Agenda;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Onbekende tijd"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuut"
+msgstr[1] "%i minuten"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i uur"
+msgstr[1] "%i uur"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "uur"
+msgstr[1] "uur"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuut"
+msgstr[1] "minuten"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s totdat deze volledig opgeladen is"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Waarschuwing: %s resterend"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s resterend"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Volledig opgeladen"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Niet aan het opladen"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Leeg"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Aan het opladen"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Aan het ontladen"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Draadloze muis"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Draadloos toetsenbord"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Onderbrekingsvrije voeding"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Personal digital assistant"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobiele telefoon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Mediaspeler"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Computer"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Gamings-invoerapparaat"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Accu"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Hoofd"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Extra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Accu’s"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Wanneer i_nactief"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Pauzestand"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Uitschakelen"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Slaapstand"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Niets doen"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Wanneer op accustroom"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Als de kabel aangesloten is"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nooit"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatisch in pauzestand zetten"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "Prestatiemodus tijdelijk uitgeschakeld wegens hoge temperaturen."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Schoot gedetecteerd: prestatiemodus tijdelijk niet beschikbaar. Zet het "
+"apparaat op een stabiel oppervlak om te herstellen."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Prestatiemodus tijdelijk uitgeschakeld."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Lage accu: energiebesparing ingeschakeld. De vorige modus wordt hersteld "
+"wanneer de accu voldoende opgeladen is."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Energiebesparingsmodus geactiveerd door ‘%s’."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Prestatiemodus geactiveerd door ‘%s’."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 uur"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minuten"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 uur"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Energiemodus"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Heeft invloed op de systeemprestaties en het stroomverbruik."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Energiebesparingsopties"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatische schermhelderheid"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "De schermhelderheid wordt aangepast naargelang het omgevingslicht."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Scherm dimmen"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Verlaagt de schermhelderheid wanneer de computer niet actief is."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Leeg scherm"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Zet het scherm uit na een periode van inactiviteit."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatisch energie besparen"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Schakelt de energiebesparingsmodus in wanneer de accu bijna leeg is."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatisch in pauzestand zetten"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Zet de computer in pauzestand na een periode van inactiviteit."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Aan-/uit_knopgedrag"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Accu_percentage tonen"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatisch in pauzestand zetten"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Aangesloten"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Op _accustroom"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Vertraging"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Prestaties"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Hoge prestaties en stroomverbruik."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Gebalanceerd"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standaard prestaties en stroomverbruik."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Energie besparen"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Verlaagde prestaties en stroomverbruik."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energie"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "De accustatus bekijken en instellingen voor energiebesparing wijzigen"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Helderheid;Dim;Blank;"
+"Monitor;Beeldscherm;DPMS;Idle;Energie;Slaapstand;Pauzestand;Accu;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Printer ‘%s’ is verwijderd"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Nieuwe printer toevoegen mislukt."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Kon UI niet laden: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Ontgrendel om printers toe te voegen en instellingen te wijzigen"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Printers"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Printers toevoegen, afdruktaken bekijken, en bepalen hoe u wilt afdrukken"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;Wachtrij;Papier;Inkt;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Printer toevoegen"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Ontgrendelen"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Geen printers gevonden"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Voer een netwerkadres in of zoek naar een printer"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Authenticatie vereist"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Voer uw gebruikersnaam en wachtwoord in om printers op printserver te "
+"bekijken."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Gebruikersnaam"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Details van %s"
+
+# geen/zonder
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Geen geschikt stuurprogramma aangetroffen"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "PPD-bestand selecteren"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript Printer Description-bestanden (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Printernamen mogen geen SPATIE, TAB, # of / bevatten"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Locatie"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Stuurprogramma"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Zoeken naar de beste stuurprogramma’s…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Naar stuurprogramma’s zoeken"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Selecteren uit de database…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "PPD-bestand installeren…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Printerstuurprogramma kiezen"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Stuurprogrammadatabase wordt geladen…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Selecteren"
+
+# bij een browser is dit bladwijzers, maar hier is
+# favorieten/favoriet beter (favoriete programma's) (tino)
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect-printer"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD-printer"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Eenzijdig"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Lange zijde (standaard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Korte zijde (omdraaien)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Staand"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Liggend"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Omgekeerd liggend"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Omgekeerd staand"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Hervatten"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pauzeren"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Wachten"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Gepauzeerd"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Authenticatie vereist"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Verwerken"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Gestopt"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Geannuleerd"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Afgebroken"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Voltooid"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Verplaats deze opdracht naar boven in de wachtrij"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u taak vereist authenticatie"
+msgstr[1] "%u taken vereisen authenticatie"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Actieve afdruktaken"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Voer uw aanmeldgegevens in om af te drukken op %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domein"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_uthenticeren"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Alles wissen"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Authenticeren"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Geen actieve afdruktaken"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Printserver ontgrendelen"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s ontgrendelen."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Voer uw gebruikersnaam en wachtwoord in om printers op %s te bekijken."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Naar printers zoeken"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Seriële poort"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Parallelle poort"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Locatie: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adres: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Server vereist authenticatie"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Tweezijdig"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Papiersoort"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Papierbron"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Uitvoerlade"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolutie"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Voorfilteren GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Pagina’s per vel"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Tweezijdig"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Stand"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Algemeen"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Pagina-instelling"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Installeerbare opties"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Taak"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Afdrukkwaliteit"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Kleur"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Afwerking"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Geavanceerd"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Testpagina"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Testpagina"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Automatisch selecteren"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Standaardinstellingen van de printer"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Alleen GhostScript-lettertypen insluiten"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Converteren naar PS level 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Converteren naar PS level 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Niet vooraf filteren"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabrikant"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Geen actieve afdruktaken"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u taak"
+msgstr[1] "%u taken"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Printkoppen schoonmaken"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Weinig toner"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Geen toner meer"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Weinig developer (voor ontwikkelen)"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Geen developer meer (voor ontwikkelen)"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Weinig marker-voorraad"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Geen marker meer"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Klep open"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Deur open"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Weinig papier"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Geen papier meer"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Offline"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Gestopt"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Afvalbakje bijna vol"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Afvalbakje vol"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr ""
+"De optische lichtgevoelige geleider (optical photo conductor) is bijna niet "
+"meer te gebruiken"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr ""
+"De optische lichtgevoelige geleider (optical photo conductor) functioneert "
+"niet meer"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Gereed"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Taken worden niet geaccepteerd"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Verwerken"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Afdrukopties"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Details van de printer"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Printer standaard gebruiken"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Printkoppen schoonmaken"
+
+# bij een browser is dit bladwijzers, maar hier is
+# favorieten/favoriet beter (favoriete programma's) (tino)
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Printer verwijderen"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Inkt-niveau"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Gelieve opnieuw te starten wanneer het probleem opgelost is."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Herstarten"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Printer toevoegen…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Geen printers"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Helaas, de systeemdienst voor\n"
+"    afdrukken is niet beschikbaar."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formaten"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Locales zoeken…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Algemene formaten"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Alle formaten"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Geen zoekresultaten"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "U kunt zoeken naar landen of talen."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Voorbeeld"
+
+# Maatsysteem dat in de VS wordt gebruikt met inch, foot en pound.
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperiaal (Brits-Amerikaans)"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrisch"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Data"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Datum en tijd"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Getallen"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Maatsysteem"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papiersoort"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Taal en indeling worden gewijzigd bij de volgende aanmelding"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Afmelden…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"De taalinstelling wordt gebruikt voor tekst in de interface en webpagina’s. "
+"De indelingen worden gebruikt voor getallen, datums en munteenheden."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Uw account"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Taal"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formaten"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Aanmeldscherm"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Regio en taal"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Selecteer uw taal en formaten"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Taal;Indeling;Toetsenbord;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Vragen wat te doen"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Niets doen"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Map openen"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Andere media"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Selecteer een toepassing voor audio-cd’s"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Selecteer een toepassing voor video-dvd’s"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Selecteer de te starten toepassing als een muziekspeler wordt aangesloten"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Selecteer de te starten toepassing als een camera wordt aangesloten"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Selecteer een toepassing voor software-cd’s"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "audio-dvd"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "lege Blu-ray-schijf"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "lege cd"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "lege dvd"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "lege hd-dvd"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray-videoschijf"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "e-book-lezer"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Hd-dvd-videoschijf"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Foto-cd"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super-video-cd"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video-cd"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows-software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Kies hoe met media omgegaan moet worden"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Audio-cd"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_Dvd-video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Muziekspeler"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Andere media…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Nooit vragen en ook geen toepassingen starten als media ingevoerd worden"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Kies hoe met andere media omgegaan moet worden"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Actie:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Type:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Verwijderbare media"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Instellingen voor verwijderbare media configureren"
+
+# The user can search on this keywords. Thereby we chose to let the translation contain both English and Dutch words.
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;apparaat;standaard;toepassing;voorkeur;schijf;"
+"verwijderbaar;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Scherm wordt uitgeschakeld"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 seconden"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuut"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minuten"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minuten"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minuten"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minuten"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 uur"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "5 minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minuten"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nooit"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Schermvergrendeling"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Door het scherm automatisch te vergrendelen kunnen anderen uw computer niet "
+"gebruiken terwijl u weg bent."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Vertraging voor zwart scherm"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Periode van inactiviteit waarna het scherm zwart wordt."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatische s_chermvergrendeling"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Vertraging voor automatische _schermvergrendeling"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Punt waarop het scherm automatisch wordt vergrendeld na op zwart gestaan te "
+"hebben."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Notificaties tonen op vergrendelingsscherm"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Nieuwe _USB-apparaten verbieden"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Voorkomen dat nieuwe USB-apparaten interactie hebben met het systeem wanneer "
+"het scherm is vergrendeld."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Schermprivacy"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Zichthoek beperken"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Scherminstellingen"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;scherm;vergrendel;privé;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Locatie selecteren"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Oké"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Zoeklocaties"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Mappen die door systeemtoepassingen doorzocht worden, zoals Bestanden, "
+"Foto’s en Video’s."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Locaties"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Bladwijzers"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Overige"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Locatie toevoegen"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Geen toepassingen aangetroffen"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Zoeken in toepassingen"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Toon zoekresultaten geleverd door toepassingen."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Mappen die door systeemtoepassingen doorzocht worden."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Zoekresultaten"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "De resultaten worden weergegeven aan de hand van de lijstvolgorde."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Regelen welke toepassingen zoekresultaten tonen in het activiteitenoverzicht"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;Zoeken;Verbergen;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Geen netwerken geselecteerd om te delen"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Netwerken"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Aan"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Uit"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Ingeschakeld"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Actief"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Een map kiezen"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Toevoegen"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Delen van media inschakelen"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Met ‘Delen van persoonlijke bestanden’ kunt u de map ‘Openbaar’ delen met "
+"anderen op uw huidige netwerk via: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Wanneer aanmelden op afstand is ingeschakeld kunnen gebruikers op afstand "
+"verbinding maken via de Secure Shell-opdracht:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Delen van persoonlijke media inschakelen"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Apparaatnaam gekopieerd"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Apparaatadres gekopieerd"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Gebruikersnaam gekopieerd"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Wachtwoord gekopieerd"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Delen"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Computernaam"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Delen van _bestanden"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Bureaubla_d op afstand"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Media delen"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Aanmelden op afstand"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Delen van bestanden"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Wachtwoord vereisen"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Aanmelden op afstand"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Bureaublad op afstand"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Bureaublad op afstand maakt het mogelijk om uw bureaublad vanop een andere "
+"computer te bekijken en te besturen."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Schakel bureaubladverbindingen op afstand in of uit."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Externe besturing"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Staat externe verbindingen toe om het scherm te besturen."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Hoe te verbinden"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Verbind met deze computer met de apparaatnaam of het externbureaubladadres."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopiëren"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Adres van bureaublad op afstand"
+
+# dit is de knop die naast het veld 'huidige wachtwoord' staat
+# als je je huidige wachtwoord hebt ingevuld en op 'Authenticate'
+# klikt (en het wachtwoord is juist) kun je je huidige wachtwoord
+# gaan wijzigen.
+# Dus letterlijke vertaling is 'Aanmeldingscontrole' maar in dit
+# geval houden we het kort en gebruiken we alleen 'Controle' (tino)
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Authenticatie"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"De gebruikersnaam en het wachtwoord zijn vereist om aan te melden bij deze "
+"computer."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Gebruikersnaam"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Versleuteling verifiëren"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Vingerafdruk voor versleuteling"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"De vingerafdruk voor versleuteling is zichtbaar voor verbinding makende "
+"cliënten en zou identiek moeten zijn."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Media delen"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Muziek, foto’s en video’s delen op het netwerk."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Mappen"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Regelen wat u met anderen wilt delen"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;delen;afbeeldingen;films;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Aanmelden op afstand in- of uitschakelen"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Er is authenticatie vereist om aanmelden op afstand in of uit te schakelen"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Aangepast"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klik"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Snaar"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Zwaai"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Brom"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balans"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Fade"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Achterzijde"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Voorzijde"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s testen"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Klik op een speaker om te testen"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Systeemvolume"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Hoofdvolume"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Volumeniveaus"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Uitvoer"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Uitvoerapparaat"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testen"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuratie"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Invoer"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Invoerapparaat"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volume"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Waarschuwingsvolume"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Dempen"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Geluid"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Geluidsvolume, invoer, uitvoer en gebeurtenisgeluiden wijzigen"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Kaart;Microphone;Microfoon;Volume;Fade;Balance;Balans;Bluetooth;Headset;"
+"Audio;Output;Uitvoer;Input;Invoer;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Verbinding verbroken"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Verbinden"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Verbonden"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Authenticatie-fout"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autoriseren"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Verminderde functionaliteit"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Verbonden en geautoriseerd"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Onbekend"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Geautoriseerd om:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Verbonden om:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Geregistreerd om:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Autoriseren van apparaat mislukt: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Vergeten van apparaat mislukt: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Afhankelijk van %u ander apparaat"
+msgstr[1] "Afhankelijk van %u andere apparaten"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Notificatie sluiten"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Naam:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Status:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autoriseren en verbinden"
+
+# bij een browser is dit bladwijzers, maar hier is
+# favorieten/favoriet beter (favoriete programma's) (tino)
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Apparaat vergeten"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Fout"
+
+# dit is de knop die naast het veld 'huidige wachtwoord' staat
+# als je je huidige wachtwoord hebt ingevuld en op 'Authenticate'
+# klikt (en het wachtwoord is juist) kun je je huidige wachtwoord
+# gaan wijzigen.
+# Dus letterlijke vertaling is 'Aanmeldingscontrole' maar in dit
+# geval houden we het kort en gebruiken we alleen 'Controle' (tino)
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Geautoriseerd"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Het Thunderbolt-subsysteem (boltd) is niet geïnstalleerd of niet correct "
+"ingesteld."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Directe toegang tot apparaten zoals docks en externe GPU's toestaan."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Alleen USB- en Display Port-apparaten kunnen worden aangesloten."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt kon niet worden gedetecteerd.\n"
+"Of het systeem ondersteunt Thunderbolt niet, of het is uitgeschakeld in de "
+"BIOS, of het is ingesteld op een niet-ondersteund beveiligingsniveau in de "
+"BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "De ondersteuning van Thunderbolt is uitgeschakeld in de BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Thunderbolt-beveiligingsniveau kon niet bepaald worden."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Fout bij omschakelen naar directe modus: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Geen Thunderbolt-ondersteuning"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Kon geen verbinding maken met het Thunderbolt-subsysteem."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Directe toegang"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Apparaten in afwachting"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Geen apparaten aangesloten"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Thunderbolt-apparaten beheren"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Knipperen van de cursor"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Cursor knippert in tekstvelden."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Snelheid"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Cursorknippersnelheid"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Cursorgrootte"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"De cursorgrootte kan gecombineerd worden met zoomen zodat de cursor beter "
+"zichtbaar wordt."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Op Typ-assistent klikken"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Ge_simuleerde secundaire klik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Tweede keer klikken als de primaire knop ingedrukt gehouden wordt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Vertraging voor a_ccepteren:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Vertraging secundaire klik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_ZweefKlik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Klikken als muisbeweging stopt"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Vertra_ging:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Be_wegingsdrempel:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Klein"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Groot"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Herhaaltoetsen"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Toetsaanslagen herhalen zich wanneer de toets ingedrukt blijft."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Toetsherhaalvertraging"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Toetsherhaalsnelheid"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Typ-assistent"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Plaktoetsen"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Een opeenvolging van optietoetsen als een toetsencombinatie behandelen"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Uitschakelen wanneer twee toetsen tegelijkertijd worden ingedrukt"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Piepen wanneer _bewerktoets wordt ingedrukt"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "T_rage toetsen"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Een vertraging inbouwen tussen het aanslaan en accepteren van een toets"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Typ-vertraging trage toetsen"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Piepen wanneer  er een toets wordt i_ngedrukt"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Piepen wanneer toets is _geaccepteerd"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Piepen wanneer toets is _geweigerd"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "S_pringende toetsen"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Snel opeenvolgende dubbele toetsaanslagen negeren"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Typ-vertraging kaatstoetsen"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Via toetsenbord inschakelen"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Toegankelijkheidsfuncties via het toetsenbord inschakelen"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Standaard"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Gemiddeld"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Groot"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Groter"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Grootst"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixels"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Toegankelijkheidsmenu _altijd tonen"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Zicht"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Hoog contrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Grote letters"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "A_nimaties inschakelen"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Schermlezer"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "De schermlezer leest getoonde tekst terwijl u de focus verplaatst."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Geluidtoetsen"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Piepen wanneer Num Lock of Caps Lock aan of uit wordt gezet."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "C_ursorgrootte"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Gehoor"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Visuele alertering"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Toetsenbord op scherm"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Herhaaltoetsen"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Knipperen van de cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Typ-assistent (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Aanwijzen &amp; klikken"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Muistoetsen"
+
+# bij een browser is dit bladwijzers, maar hier is
+# favorieten/favoriet beter (favoriete programma's) (tino)
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Locatie van muisaanwijzer weergeven"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Op Typ-assistent _klikken"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Dubbelklikvertraging"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Intervaltijd voor dubbelklik"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Visuele alertering"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Knipperen testen"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Visuele indicatie tonen als er een alerteringsgeluid klinkt."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "_Hele scherm laten knipperen"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Hele _venster laten knipperen"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ scherm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ scherm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ scherm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Volledig scherm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Bovenste helft"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Onderste helft"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Linkerhelft"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Rechterhelft"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Zoomopties"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Vergroting:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Positie vergrootglas:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Muisaanwijzer volgen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Schermdeel:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Vergrootglas komt _buiten het scherm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Vergrootglascursor _gecentreerd houden"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Vergrootglascursor _schuift inhoud rond"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Vergrootglascursor beweegt mee met de _inhoud"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Vergrootglas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Draadkruis:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Overlapt muisaanwijzer"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Dikte:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Dun"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Dik"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Lengte:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Kleur:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Draadkruis"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Kleureffecten:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Wit op zwart:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Helderheid:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Kl_eur"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Geen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Volledig"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Laag"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Hoog"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Laag"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Hoog"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Kleureffecten"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Zien, horen, typen, aanwijzen en klikken vergemakkelijken"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;"
+"Plaktoetsen;Slow;Trage toetsen;Bounce;Springende toetsen;Mouse;Double;click;"
+"Delay;Speed;snelheid;Assist;Repeat;Blink;Visual;visueel;hearing;horen;hoor;"
+"luisteren;audio;typing;typen;Muistoetsen;Toetsenbord;Toegankelijkheid;Tekst;"
+"Lettertype;vergroten;Dubbel;klik;geluid;groot;hoog;animations;animaties;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 uur"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dag"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dagen"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dagen"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dagen"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dagen"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dagen"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dagen"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dagen"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dagen"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Alle items uit prullenbak verwijderen?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Alle items in de prullenbak zullen definitief verwijderd worden."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Prullenbak l_egen"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Alle tijdelijke bestanden verwijderen?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Alle tijdelijke bestanden zullen definitief verwijderd worden."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Tijdelijke bestanden _definitief verwijderen"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dag"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dagen"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dagen"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Voor altijd"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Bestandsgeschiedenis"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Bestandsgeschiedenis bewaart een log van de bestanden die u hebt gebruikt. "
+"Deze informatie wordt gedeeld tussen apparaten, en maakt het u eenvoudiger "
+"om bestanden die u zou kunnen willen gebruiken terug te vinden."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Bestandsgesch_iedenis"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Duur van bestandsgesc_hiedenis"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Geschiedenis _wissen…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Prullenbak &amp; tijdelijke bestanden"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"In de prullenbak en tijdelijke bestanden kan er zich soms persoonlijke of "
+"gevoelige informatie bevinden. Deze bestanden automatisch laten verwijderen "
+"kan uw privacy helpen beschermen."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Inhoud van prullenbak au_tomatisch verwijderen"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Tijdelijke _bestanden automatisch verwijderen"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Periode voor automatisch verwijderen"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Prullenbak l_egen…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Tijdelijke bestanden verwij_deren…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Bestandsgeschiedenis & prullenbak"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Geen sporen achterlaten"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"gebruik;onlangs gebruikt;geschiedenis;bestanden;tijdelijk;privé;prullenbak;"
+"legen;houden;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Dient overeen te komen met het internetadres van uw inlog-provider."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Toevoegen van account mislukt"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "De wachtwoorden komen niet overeen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Registreren van account mislukt"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Geen ondersteunde manier om met dit domein te authenticeren"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Toetreden tot domein mislukt"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ongeldige gebruikersnaam.\n"
+"Probeer het opnieuw."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ongeldig wachtwoord.\n"
+"Probeer het opnieuw."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Aanmelden bij domein mislukt"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Domein niet gevonden. Heeft u het verkeerd gespeld?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Gebruiker toevoegen"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Beheerder"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Beheerders kunnen gebruikers toevoegen en verwijderen, en de instellingen "
+"voor alle gebruikers wijzigen. Ouderlijk toezicht kan niet toegepast worden "
+"op beheerders."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Gebruiker kan wachtwoord instellen bij de eerste keer aanmelden"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Stel nu een wachtwoord in"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Bevestigen"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Bedrijfsaanmelding"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Gebruikersaccounts die door een bedrijf of organisatie beheerd worden."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "U bent offline"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Met enterprise-aanmelding kan een bestaande centraal beheerde "
+"gebruikersaccount op dit apparaat gebruikt worden. U kunt dit account ook "
+"gebruiken om toegang te krijgen tot bedrijfsbronnen op het internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Bladeren naar meer afbeeldingen"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Selecteer een bestand…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Vingerafdrukbeheer"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Vingerafdruk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Nee"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Ja"
+
+# geregistreerde/opgeslagen
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Wilt u uw geregistreerde vingerafdruk verwijderen zodat "
+"vingerafdrukaanmelding uitgeschakeld wordt?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Geen vingerafdrukapparaat"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Geen vingerafdrukapparaat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Controleer of het apparaat correct verbonden is."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Vingerafdrukapparaat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Kies het vingerafdrukapparaat dat u wilt instellen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Aanmelden met vingerafdruk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Aanmelden met vingerafdruk biedt u de mogelijkheid om uw computer te "
+"ontgrendelen en aan te melden met uw vinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "Vingerafdrukken ver_wijderen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Vingerafdruk registreren"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "het apparaat moet worden geclaimd om deze actie uit te voeren"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "het apparaat is al geclaimd door een ander proces"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "u heeft niet de rechten om de actie uit te voeren"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "er zijn geen afdrukken geregistreerd"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Communicatie met het apparaat mislukt tijdens het registreren"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Communicatie met de vingerafdruklezer mislukt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Communicatie met de vingerafdrukdaemon mislukt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Oplijsten van vingerafdrukken mislukt: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Verwijderen van opgeslagen vingerafdrukken mislukt: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Linkerduim"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Linkermiddelvinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "_Linkerwijsvinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Linkerringvinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Linkerpink"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Rechterduim"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Rechtermiddelvinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "_Rechterwijsvinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Rechterringvinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Rechterpink"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Onbekende vinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Klaar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Vingerafdrukapparaat niet verbonden"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Vingerafdrukapparaatopslag is vol"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Registreren van nieuwe vingerafdruk mislukt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Starten van registratie mislukt: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Registreren van nieuwe vingerafdruk mislukt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Stoppen van registratie mislukt: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Plaats uw vinger herhaaldelijk op de lezer om uw vingerafdruk te registreren"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "Deze vinger opnieuw _registreren…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Nieuwe vingerafdruk scannen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Loslaten van vingerafdrukapparaat %s mislukt: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Probleem bij lezen van apparaat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Toe-eigenen van vingerafdrukapparaat %s mislukt: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Opvragen van vingerafdrukapparaten mislukt: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Deze week"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Vorige week"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%d %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%d %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sessie beëindigd"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sessie gestart"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Accountactiviteit"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Vorige"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Volgende"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Kies een ander wachtwoord."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Vul uw wachtwoord opnieuw in."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Wachtwoord kon niet gewijzigd worden"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Wachtwoord wijzigen"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Wijzigen"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Huidig wachtwoord"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nieuw wachtwoord"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Bevestig wachtwoord"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Gebruiker kan wachtwoord wijzigen bij de volgende keer aanmelden"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Nu een wachtwoord instellen"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Automatisch voegen bij dit type domein is niet mogelijk"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Een dergelijk domein of realm is niet aangetroffen"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Aanmelden als %s bij het domein %s kan niet"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Ongeldig wachtwoord, probeer het opnieuw"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Kon geen verbinding maken met het %s-domein: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Kon gebruiker niet verwijderen"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Op afstand beheerde gebruiker kon niet worden verwijderen"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "U kunt uw eigen account niet verwijderen."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s is nog aangemeld"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Het verwijderen van een gebruiker die nog aangemeld is, kan leiden tot een "
+"inconsistent systeem."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Moeten de bestanden van %s bewaard blijven?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Het is mogelijk om de persoonlijke map, de e-mailmap en de tijdelijke "
+"bestanden te bewaren als een account verwijderd wordt."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "Bestanden _verwijderen"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "Bestanden be_waren"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Weet u zeker dat u de op afstand beheerde account van %s wilt verwijderen?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "Verwij_deren"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Account uitgeschakeld"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "In te stellen bij volgende keer aanmelden"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Geen"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Aangemeld"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Kon de accounts-service niet benaderen"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Zorg ervoor dat het de AccountService geïnstalleerd in ingeschakeld is."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Om deze instelling te wijzigen moet dit paneel ontgrendeld worden"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "De geselecteerde gebruiker verwijderen"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Klik op het *-pictogram om de geselecteerde\n"
+"gebruiker te verwijderen"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Ontgrendel om gebruikers toe te voegen en instellingen te wijzigen"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Gebruikers"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+"Om de wijzigingen door te voeren moet de computer opnieuw gestart worden"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Nu herstarten"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Sluiten"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Gebruikersafbeelding bewerken"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Volledige naam"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Bewerken"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Aanmelden met _vingerafdruk"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatisch aanmelden"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Accountactiviteit"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Beheerder"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Beheerders kunnen gebruikers toevoegen en verwijderen, en de instellingen "
+"voor alle gebruikers wijzigen."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Ouderlijk toezicht"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Open de toepassing Ouderlijk toezicht."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Gebruiker verwijderen…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Andere gebruikers"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Gebruiker toevoegen…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Geen gebruikers gevonden"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Ontgrendel om een gebruikersaccount toe te voegen."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Gebruikers toevoegen of verwijderen en uw wachtwoord wijzigen"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;aanmelden;"
+"aanmelding;naam;vingerafdruk;gezicht;wachtwoord;paswoord;ouderlijk toezicht;"
+"schermtijd;toepassingsbeperkingen;appbeperkingen;applicatiebeperkingen;"
+"webbeperkingen;internetbeperkingen;surfbeperkingen;gebruik;gebruikslimiet;"
+"kind;kinderen;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Registreren"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Aanmelding domeinbeheerder"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Voor enterprise-aanmelding moet deze computer\n"
+"ingeschreven zijn bij het domein. Laat uw netwerkbeheerder\n"
+"hier het wachtwoord voor het domein intypen."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Beheerders_naam"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Wachtwoord beheerder"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Gebruikersaccounts beheren"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Er is authenticatie vereist om gebruikersgegevens te wijzigen"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Het nieuwe wachtwoord moet anders zijn dan het oude."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Probeer enkele letters en cijfers te wijzigen."
+
+# venstertitel
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Probeer het wachtwoord iets meer te wijzigen."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Een wachtwoord zonder uw gebruikersnaam zal sterker zijn."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Vermijd het gebruik van uw naam in uw wachtwoord."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Probeer woorden die in het wachtwoord voorkomen te vermijden."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Probeer algemene woorden te vermijden."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Probeer het herordenen van bestaande woorden te vermijden."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Probeer meer cijfers te gebruiken."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Probeer meer hoofdletters te gebruiken."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Probeer meer kleine letters te gebruiken."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Probeer meer speciale tekens, zoals interpunctie, te gebruiken."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+"Probeer een combinatie van letters, cijfers en interpunctie te gebruiken."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Probeer herhaling van hetzelfde teken te vermijden."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Probeer herhaling van hetzelfde soort teken te vermijden: u dient letters, "
+"cijfers en interpunctie te combineren."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Probeer reeksen zoals 1234 of abcd te vermijden."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Het wachtwoord moet langer zijn. Probeer meer letters, cijfers en leestekens "
+"toe te voegen."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Gebruik zowel hoofdletters als kleine letters en probeer een paar cijfers te "
+"gebruiken."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Toevoegen van meer letters, cijfers en leestekens maakt het wachtwoord nog "
+"sterker."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Authenticatie mislukt"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Het nieuwe wachtwoord is te kort"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Het nieuwe wachtwoord is te eenvoudig"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Het oude en nieuwe wachtwoord lijken teveel op elkaar"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Het nieuwe wachtwoord is recentelijk al gebruikt."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Het nieuwe wachtwoord moet numerieke of speciale tekens bevatten"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Het oude en nieuwe wachtwoord zijn hetzelfde"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Uw wachtwoord is gewijzigd sinds de vorige wachtwoordcontrole!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Het nieuwe wachtwoord bevat niet genoeg verschillende tekens"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Onbekende fout"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"De gebruikersnaam bestaat doorgaans enkel uit kleine letters van a t/m z, "
+"cijfers en de volgende tekens: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Die gebruikersnaam is helaas niet beschikbaar. Probeer een andere."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "De gebruikersnaam is te lang."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Knoppen toewijzen"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Knoppen toewijzen aan functies"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Om een sneltoets te bewerken, kies de actie ‘Send Keystroke’, druk op de "
+"sneltoetsknop en houd de nieuwe toetsen ingedrukt, of druk op Backspace om "
+"hem te wissen."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Sluiten"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Tik op de referentiepunten die op het scherm verschijnen om het tablet te "
+"kalibreren."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Misklik gedetecteerd, herstarten…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Knop %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Toepassingen gedefinieerd"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Toetsaanslag sturen"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Van beeldscherm wisselen"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Schermhulp tonen"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tablet gemonteerd op laptoppaneel"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tablet gemonteerd op extern beeldscherm"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Extern tabletapparaat"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Extern pad-apparaat"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Alle schermen"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Tabletmodus"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Absolute positie voor de pen gebruiken"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Linkshandige oriëntatie"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tablet en Express Keys™ zijn gedraaid voor linkshandig gebruik"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Naar monitor mappen"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Beeldverhouding behouden"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Gebruik slechts een deel van het tabletoppervlak om de beeldverhouding van "
+"het beeldscherm te behouden"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibreren"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Geen tablet gedetecteerd"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Sluit uw Wacom-tablet aan en zet het aan."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Gedrag puntdruk"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Zacht"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Styluspuntdruk"
+
+# ??? (Wouter Bolsterlee)
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Stevig"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Knop 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Knop 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Knop 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Gedrag gumdruk"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Gumdruk"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Middelste muisknop-klik"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Rechtermuisknop-klik"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Vooruit"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Airbrushstylus met druk, tilt en geïntegreerde slider"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Airbrushstylus met druk, tilt en rotatie"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standaardstylus met druk en tilt"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standaardstylus met druk"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom-tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Knoptoewijzingen instellen en gevoeligheid van stylus voor  grafische "
+"tabletten aanpassen"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;Tekenen;Gum;Muis;gom;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Nieuwe sneltoets…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Toegangspunten"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Bewerking geannuleerd"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Fout:</b> Toegang geweigerd bij wijzigen van instellingen"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Fout:</b> Probleem met mobiele uitrusting"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Niet geregistreerd"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Geregistreerd"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Zoeken"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Geweigerd"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modeminformatie"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modemstatus"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Carrier"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Netwerktype"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Netwerkstatus"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Eigen nummer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Apparaatinformatie"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Firmwareversie"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Alleen 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Alleen 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Alleen 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Alleen 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (voorkeur), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (voorkeur), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (voorkeur), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (voorkeur), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (voorkeur), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (voorkeur), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (voorkeur), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (voorkeur), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (voorkeur), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (voorkeur), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (voorkeur), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (voorkeur), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (voorkeur), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (voorkeur), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (voorkeur), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (voorkeur), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (voorkeur)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (voorkeur), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Simkaart ontgrendelen"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Ontgrendelen"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Voer de pincode voor simkaart %d in"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Voer de pincode in om uw simkaart te ontgrendelen"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Voer de pukcode voor simkaart %d in"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Voer de pukcode in om uw simkaart te ontgrendelen"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Onjuist wachtwoord. U heeft nog resterende %1$u poging"
+msgstr[1] "Onjuist wachtwoord. U heeft nog resterende %1$u pogingen"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "U heeft nog %u resterende poging"
+msgstr[1] "U heeft nog %u resterende pogingen"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Onjuist wachtwoord."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "De pukcode moet een getal van 8 cijfers zijn"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Voer nieuwe pincode in"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "De pincode moet een getal van 4 à 8 cijfers zijn"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Ontgrendelen…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Geen simkaart"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Voer een simkaart in om deze modem te gebruiken"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "Simkaart vergrendeld"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobiele gegevens"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Toegang tot gegevens met mobiel netwerk"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Dataroaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Mobiele gegevens gebruiken bij roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Netwerkmodus"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "N_etwerk"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Geavanceerd"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Toeg_angspuntnamen"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_Simkaartvergrendeling"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Simkaart vergrendelen met pincode"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "M_odeminformatie"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Telefoonfout"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Geen verbinding met telefoon"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Bewerking niet toegestaan"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Bewerking niet ondersteund"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Simkaart niet ingevoerd"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Pincode voor simkaart vereist"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Pukcode voor simkaart vereist"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Simkaartfout"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Simkaart bezig"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Onjuist wachtwoord"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Pin2-code voor simkaart vereist"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Puk2-code voor simkaart vereist"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Niet gevonden"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Geen netwerkdienst"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Netwerktime-out"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS-diensten niet toegestaan"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming niet toegestaan in dit locatiegebied"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Ongespecificeerde GPRS-fout"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Geen fout"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Actie geannuleerd"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Toegang geweigerd"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Onbekende fout"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Netwerkmodus"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatisch"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Netwerk kiezen"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Netwerkproviders vernieuwen"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "Simkaart %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Mobiel netwerk inschakelen"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Geen WWAN-adapter gevonden"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Zorg ervoor dat u een draadlozewan- of mobiel apparaat heeft"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Draadloze wan wordt uitgeschakeld als vliegtuigstand aan staat"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Vliegtuigstand ui_tzetten"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Dataverbinding"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Simkaart gebruikt voor internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Simkaartvergrendeling"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "Volge_nde"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "Simkaart vergrende_len met pincode"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Pincode wijzigen"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+"Voer de huidige pincode in om de simkaartvergrendelingsinstellingen te "
+"wijzigen"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobiel netwerk"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configureer telefonie en mobielegegevensverbindingen"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+"cellular;wwan;telephony;sim;mobile;mobiel;simkaart;telefonie;cellulair;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Hulpprogramma om het Gnome-bureaublad te configureren"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Instellingen is de hoofdinterface voor de configuratie van uw systeem."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Het Gnome-project"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Versienummer weergeven"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Verbose-modus inschakelen"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Zoeken naar de tekenreeks"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Een lijst met mogelijke paneelnamen tonen en sluiten"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Te tonen paneel"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Instellingscategorieën"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privacy"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Beschikbare panelen:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Alle instellingen"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Primair menu"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Waarschuwing: ontwikkelversie"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Deze versie van Instellingen moet alleen voor ontwikkelingsdoeleinden "
+"gebruikt worden. U kunt onjuist systeemgedrag, gegevensverlies en andere "
+"onverwachte problemen tegenkomen. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Hulp"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Algemeen"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Afsluiten"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Zoeken"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panelen"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Terug naar het vorige paneel"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Zoeken annuleren"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;Voorkeuren;Instellingen;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "De identificatie voor het laatst geopende paneel van Instellingen"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"De identificatie voor het laatst geopende paneel van Instellingen. Niet-"
+"herkende waarden worden genegeerd, en het eerste paneel in de lijst wordt "
+"geselecteerd."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Waarschuwing tonen wanneer er een ontwikkelversie van Instellingen draait"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Of Instellingen een waarschuwing moet tonen wanneer er een ontwikkelversie "
+"draait."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Beginstaat van het venster"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Een tupel met daarin de initiële breedte, hoogte en maximalisatiestatus van "
+"het toepassingsvenster."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u uitvoer"
+msgstr[1] "%u uitvoeren"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u invoer"
+msgstr[1] "%u invoeren"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Systeemgeluiden"
+
+#~ msgid "Light"
+#~ msgstr "Licht"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;scherm;vergrendelen;privé;tijdelijk;"
+
+# Select a display language (change will be applied next time you log in)
+#~ msgid "Display Arrangement"
+#~ msgstr "Schermvolgorde"
+
+#~ msgid "Set"
+#~ msgstr "Instellen"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Vergrendel uw scherm"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER- of PEM-certificaten (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Printer toevoegen…"
+
+#~ msgid "Bark"
+#~ msgstr "Blaffen"
+
+#~ msgid "Drip"
+#~ msgstr "Druppelen"
+
+#~ msgid "Glass"
+#~ msgstr "Glas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "Web Links"
+#~ msgstr "Webverwijzingen"
+
+#~ msgid "Git Links"
+#~ msgstr "Gitverwijzingen"
+
+#~ msgid "%s Links"
+#~ msgstr "%s-verwijzingen"
+
+#~ msgid "Unset"
+#~ msgstr "Niet instellen"
+
+#~ msgid "Links"
+#~ msgstr "Verwijzingen"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hypertextbestanden"
+
+#~ msgid "Text Files"
+#~ msgstr "Tekstbestanden"
+
+#~ msgid "Image Files"
+#~ msgstr "Afbeeldingsbestanden"
+
+#~ msgid "Font Files"
+#~ msgstr "Lettertypebestanden"
+
+#~ msgid "Archive Files"
+#~ msgstr "Archiefbestanden"
+
+#~ msgid "Package Files"
+#~ msgstr "Pakketbestanden"
+
+#~ msgid "Audio Files"
+#~ msgstr "Audiobestanden"
+
+#~ msgid "Video Files"
+#~ msgstr "Videobestanden"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Rechten & toegang"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Gegevens en diensten waartoe deze toepassing toegang heeft gevraagd, en "
+#~ "rechten die ze vereist."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Kunnen niet gewijzigd worden"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Individuele rechten voor toepassingen kunnen aangepast worden in de <a "
+#~ "href=\"privacy\">Privacy</a>-instellingen."
+
+#~ msgid "Integration"
+#~ msgstr "Integratie"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Bureaubladachtergrond instellen"
+
+# 'handler' kan misschien een andere vertaling gebruiken - Nathan
+#~ msgid "Default Handlers"
+#~ msgstr "Standaardverwerkers"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Type bestanden en verwijzingen die deze toepassing opent."
+
+#~ msgid "Usage"
+#~ msgstr "Gebruik"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Hoe veel systeembronnen deze toepassing verbruikt."
+
+#~ msgid "Open in Software"
+#~ msgstr "Openen met Software"
+
+#~ msgid "Activities"
+#~ msgstr "Activiteiten"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Verleen de onderstaande toepassingen de toegang tot uw camera."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Bestand uploaden mislukt: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Het profiel is geüpload naar:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Noteer deze URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Deze computer herstarten en opstarten met uw normale besturingssysteem."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Voer de URL in in uw browser om het profiel te downloaden en te "
+#~ "installeren."
+
+#~ msgid "Upload profile"
+#~ msgstr "Profiel uploaden"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Internetverbinding vereist"
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopiëren"
+
+#~ msgid "Select _All"
+#~ msgstr "_Alles selecteren"
+
+#~ msgid "Single Display"
+#~ msgstr "Enkel scherm"
+
+#~ msgid "Join Displays"
+#~ msgstr "Schermen bij elkaar brengen"
+
+#~ msgid "Display Mode"
+#~ msgstr "Beeldschermmodus"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Versleep schermen om overeen te komen met de fysieke opstelling van uw "
+#~ "schermen. Selecteer een scherm om de instellingen ervan te wijzigen."
+
+#~ msgid "Active Display"
+#~ msgstr "Actief scherm"
+
+#~ msgid "More Warm"
+#~ msgstr "Warmer"
+
+#~ msgid "Less Warm"
+#~ msgstr "Minder warm"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Een schermafdruk opslaan in $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Een schermafdruk van een venster opslaan in $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Een schermafdruk van een gebied opslaan in $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Een schermafdruk naar het klembord kopiëren"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Een schermafdruk van een venster naar het klembord kopiëren"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Een schermafdruk van een gebied naar het klembord kopiëren"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Korte schermopname"
+
+#~ msgid "Move up"
+#~ msgstr "Naar boven"
+
+#~ msgid "Move down"
+#~ msgstr "Naar beneden"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Met locatiediensten kunnen toepassingen uw locatie te weten komen. "
+#~ "Gebruik van wifi en mobiele breedband verhoogt de nauwkeurigheid."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Gebruikt de Mozilla-locatiedienst: <a href='https://location.services."
+#~ "mozilla.com/privacy'>privacybeleid</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Verleen de onderstaande toepassingen de toegang tot uw locatie."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Verleen de onderstaande toepassingen de toegang tot uw microfoon."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Intervaltijd voor dubbelklik"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Pauzestand en uitschakelen"
+
+# Ik weet niet wat ze hier met lap bedoelen - Hannie Niet vertaald
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "‘Lap’ gedetecteerd: prestatiemodus niet beschikbaar"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Temperatuur hardware Hoog: prestatiemodus niet beschikbaar"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Prestatiemodus niet beschikbaar"
+
+#~ msgid " "
+#~ msgstr " "
+
+# dit is de knop die naast het veld 'huidige wachtwoord' staat
+# als je je huidige wachtwoord hebt ingevuld en op 'Authenticate'
+# klikt (en het wachtwoord is juist) kun je je huidige wachtwoord
+# gaan wijzigen.
+# Dus letterlijke vertaling is 'Aanmeldingscontrole' maar in dit
+# geval houden we het kort en gebruiken we alleen 'Controle' (tino)
+#~ msgid "Authenticate"
+#~ msgstr "Controleren"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Kies de formattering voor getallen, datums en munteenheden. De "
+#~ "wijzigingen worden doorgevoerd bij uw volgende aanmelding."
+
+#~ msgid "My Account"
+#~ msgstr "Mijn account"
+
+#~ msgid "Language"
+#~ msgstr "Taal"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr ""
+#~ "De taal die gebruikt wordt voor tekst in vensters en internetpagina's."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr ""
+#~ "Om de wijzigingen door te voeren moet de sessie opnieuw gestart worden"
+
+#~ msgid "Restart…"
+#~ msgstr "Herstarten…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Aanmeldinstellingen worden gebruikt door alle gebruikers die zich "
+#~ "aanmelden bij het systeem"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Bepaal welke zoekresultaten weergegeven worden in het "
+#~ "activiteitenoverzicht. De volgorde van de zoekresultaten kan ook "
+#~ "aangepast worden door de rijen in de lijst te verplaatsen."
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Met scherm delen kunnen gebruikers op afstand uw scherm te bekijken of "
+#~ "besturen door te verbinden met %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Scherm delen"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "Sommige diensten zijn uitgeschakeld omdat er geen netwerktoegang is."
+
+#~ msgid "_Password:"
+#~ msgstr "_Wachtwoord:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Wachtwoord _tonen"
+
+#~ msgid "Access Options"
+#~ msgstr "Toegangsopties"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Nieuwe verbindingen moeten toegang vragen"
+
+#~ msgid "_Require a password"
+#~ msgstr "Een wachtwoord _vereisen"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Geluidtoetsen"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Schermlezer"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Schermlezer"
+
+#~ msgid "Standard"
+#~ msgstr "Standaard"
+
+#~ msgid "Account _Type"
+#~ msgstr "Account-_type"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Gebruiker kan wachtwoord instellen bij de volgende keer _aanmelden"
+
+#~ msgid "Set a password _now"
+#~ msgstr "_Nu een wachtwoord instellen"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "U moet online gaan om enterprise-\n"
+#~ "gebruikers toe te voegen."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Neem een foto…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klik op het het *-pictogram\n"
+#~ "om wijzigingen te maken"
+
+#~ msgid "Create a user account"
+#~ msgstr "Gebruikersaccount aanmaken"
+
+#~ msgid "User Icon"
+#~ msgstr "Gebruikerspictogram"
+
+#~ msgid "Account Settings"
+#~ msgstr "Accountinstellingen"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Authenticatie & aanmelden"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Dit zal gebruikt worden om uw persoonlijke map een naam te geven en kan "
+#~ "niet worden gewijzigd."
+
+#~ msgid "Output:"
+#~ msgstr "Uitvoer:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Beeldverhouding behouden (breedbeeld):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Toewijzen aan één monitor"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d van %d"
+
+# Select a display language (change will be applied next time you log in)
+#~ msgid "Display Mapping"
+#~ msgstr "Taal voor weergave"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (absoluut)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Touchpad (relatief)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Tabletvoorkeuren"
+
+#~ msgid "_Help"
+#~ msgstr "_Hulp"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth-instellingen"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Tracking-modus"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Knoppen toewijzen…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Muisinstellingen aanpassen"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Beeldschermresolutie aanpassen"
+
+#~ msgid "No stylus found"
+#~ msgstr "Geen pen aangetroffen"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Breng de pen in de buurt van het tablet om hem te configureren"
+
+#~ msgid "Top Button"
+#~ msgstr "Bovenste knop"
+
+#~ msgid "Lower Button"
+#~ msgstr "Onderste knop"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Onderste knop"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Bezig met ontgrendelen…"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "Gnome-instellingen"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Aanmelden;Inloggen;"
+#~ "Vingerafdruk;Gezicht;Wachtwoord;"
+
+#~| msgid "Keyboard Shortcuts"
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Sneltoets"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Dit kan worden gewijzigd in Sneltoetsen aanpassen"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Houd ingedrukt en typ om andere tekens in te voeren"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Helderheid beeld_scherm"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Helderheid toetsenbord"
+
+#~| msgid "_Dim Screen When Inactive"
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Scherm dimmen wanneer inactief"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Zwart scherm"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wifi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wifi kan worden uitgeschakeld om energie te besparen."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Mobiele breedband (LTE, 4G, 3G, etc.) kan worden uitgeschakeld om energie "
+#~ "te besparen."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth kan worden uitgeschakeld om energie te besparen."
+
+#~| msgid "Balance"
+#~ msgid "Balanced Power"
+#~ msgstr "Evenwichtig stroomverbruik"
+
+#~ msgid "Add…"
+#~ msgstr "Toevoegen…"
+
+#~ msgid "Left Alt"
+#~ msgstr "Linker Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Rechter Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Linker Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Rechter Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Rechter Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Toets voor alternatieve tekens"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "‘Modifiers-only’-schakeling naar volgende bron"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Menutoets"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Aan het opladen"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Waarschuwing"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Laag"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Goed"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Volledig opgeladen"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Leeg"
+
+#~ msgid "Previous source"
+#~ msgstr "Vorige bron"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Spatiebalk"
+
+#~ msgid "Next source"
+#~ msgstr "Volgende bron"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Spatiebalk"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Linker+rechter Alt"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Universele toegang"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Uitschakelen om te verbinden met een wifi-netwerk"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Wachtwoord"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Vingerafdrukaanmelding aanzetten"
+
+#~ msgid "_Other finger:"
+#~ msgstr "An_dere vinger:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Uw vingerafdruk is opgeslagen. U kunt nu aanmelden via uw "
+#~ "vingerafdruklezer."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "U heeft geen toegang tot het apparaat. Neem contact op met uw "
+#~ "systeembeheerder."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Er is een interne fout opgetreden."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Geregistreerde vingerafdrukken verwijderen?"
+
+#~ msgid "Done!"
+#~ msgstr "Voltooid!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Kon geen toegang krijgen tot het ‘%s’-apparaat"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Kon vingerafdruk nemen op het ‘%s’-apparaat niet starten"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Kon tot geen enkele vingerafdruklezer toegang krijgen"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Neem contact op met uw systeembeheerder voor hulp."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Om vingerafdrukaanmelding aan te zetten moet u een van uw vingerafdrukken "
+#~ "opslaan met het ‘%s’-apparaat."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Vinger selecteren"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Gebruikersaccounts toevoegen en wachtwoorden wijzigen"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Geluid afspelen en opnemen"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Netwerkapparaten detecteren met mDNS/DNS-SD (Bonjour/Zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Rechtstreekse toegang tot uw Bluetooth-hardware"
+
+#~ msgid "Use your camera"
+#~ msgstr "Uw camera gebruiken"
+
+#~ msgid "Print documents"
+#~ msgstr "Documenten afdrukken"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Verbonden joysticks gebruiken"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Verbinding met de Docker-dienst toestaan"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Netwerkfirewall configureren"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Geprivilegieerde FUSE-bestandssystemen instellen en gebruiken"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Firmware op dit apparaat bijwerken"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Toegang tot hardware-informatie"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Entropie leveren aan de willekeuriggetalgenerator van de hardware"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Willekeurige getallen gegenereerd door de hardware gebruiken"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Toegang tot bestanden in uw persoonlijke map"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Toegang tot de libvirt-dienst"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Systeemtaal en regio-instellingen wijzigen"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Locatie-instellingen en -aanbieders wijzigen"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Systeem- en toepassingslogboeken lezen"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "Toegang tot de media-hub-dienst"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Modems configureren en gebruiken"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Systeemaankoppelingsinformatie en schijfquota’s lezen"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Muziek- en videospelers besturen"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Netwerkinstellingen op laag niveau wijzigen"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Toegang tot de NetworkManager-dienst om de netwerkinstellingen te lezen "
+#~ "en te wijzigen"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Leestoegang tot de netwerkinstellingen"
+
+#~ msgid "Change network settings"
+#~ msgstr "Netwerkinstellingen wijzigen"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Toegang tot de ofono-dienst om de netwerkinstellingen voor mobiele "
+#~ "telefonie te lezen en te wijzigen"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Open vSwitch-hardware besturen"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Cd’s/dvd’s lezen"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Opgeslagen wachtwoorden lezen, toevoegen, wijzigen of verwijderen"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Toegang tot pppd- en ppp-apparaten om Point-to-Point-protocolverbindingen "
+#~ "in te stellen"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Eender welk proces op het systeem pauzeren of beëindigen"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Rechtstreekse toegang tot de USB-hardware"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Bestanden op verwijderbare opslagapparaten lezen/schrijven"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Slaapmodus(schermvergrendeling verhinderen"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Toegang tot de seriëlepoorthardware"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Het apparaat afsluiten of opnieuw opstarten"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Software installeren, verwijderen en instellen"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Toegang tot de Storage Framework-dienst"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Proces- en systeeminformatie lezen"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Draaiende programma’s monitoren en besturen"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Datum en tijd wijzigen"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Tijdsserverinstellingen wijzigen"
+
+#~ msgid "Change the time zone"
+#~ msgstr "De tijdzone wijzigen"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Toegang tot de UDisks2-dienst om schijven en verwijderbare media in te "
+#~ "stellen"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Gedeelde agenda-afspraken in Ubuntu Unity 8 lezen/wijzigen"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Gedeelde contacten in Ubuntu Unity 8 lezen/wijzigen"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Toegang tot energieverbruiksgegevens"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Lees-/schrijftoegang tot U2F-apparaten"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klik op het *-pictogram\n"
+#~ "om een gebruikersaccount aan te maken"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Bureaubladachtergrond en vergrendelingsscherm instellen"
+
+#~ msgid "Set Background"
+#~ msgstr "Bureaubladachtergrond instellen"
+
+# Dit is een zelfstandig naamwoord!
+#~ msgid "Set Lock Screen"
+#~ msgstr "Vergrendelingsscherm instellen"
+
+#~ msgid "Remove Background"
+#~ msgstr "Achtergrond verwijderen"
+
+#~ msgid "Version %s"
+#~ msgstr "Versie %s"
+
+#~ msgid "OS name"
+#~ msgstr "Naam besturingssysteem"
+
+#~ msgid "OS type"
+#~ msgstr "Type besturingssysteem"
+
+#~ msgid "Disk"
+#~ msgstr "Schijf"
+
+#~ msgid "Check for updates"
+#~ msgstr "Zoeken naar updates"
+
+#~ msgid "Network proxy"
+#~ msgstr "Netwerkproxy"
+
+#~ msgid "page 1"
+#~ msgstr "pagina 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Interne _aanmeldingscontrole"
+
+#~ msgid "page 2"
+#~ msgstr "pagina 2"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Gegevensverbruik in de achtergrond _beperken"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Geschikt voor betaalde of gelimiteerde verbindingen."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "De inschakeling van de draadloze hotspot zal uw verbinding met <b>%s</b> "
+#~ "verbreken."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "U heeft geen toegang tot het internet via uw draadloze verbinding zolang "
+#~ "de hotspot is geactiveerd."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Wifi-hotspots worden meestal gebruikt om een extra internetverbinding via "
+#~ "wifi te delen."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Automatisch ver_binden"
+
+#~ msgid "details"
+#~ msgstr "details"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Wachtwoord _tonen"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Beschikbaar maken voor andere gebruikers"
+
+#~ msgid "identity"
+#~ msgstr "identiteit"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adressen"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Alleen automatische (DHCP) adressen"
+
+#~ msgid "Link-local only"
+#~ msgstr "Alleen Link-Local"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "Automatisch verkregen routes _negeren"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Ge_kloond MAC-adres"
+
+#~ msgid "_Reset"
+#~ msgstr "_Opnieuw instellen"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Instellingen voor deze verbinding terugzetten naar standaardinstellingen, "
+#~ "maar onthouden als een voorkeursnetwerk."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Alle details met betrekking tot dit netwerk verwijderen, en niet proberen "
+#~ "automatisch verbinding te maken."
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Opnieuw instellen"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Verbonden apparaten"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastructuur"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Notificaties"
+
+#~ msgid "In use"
+#~ msgstr "In gebruik"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Aan"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Uit"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Uit"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Aan"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Uit"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Aan"
+
+#~ msgid "Usage & History"
+#~ msgstr "Gebruik en geschiedenis"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Privacybeleid"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Het onthouden van uw geschiedenis maakt terugvinden eenvoudiger. Deze "
+#~ "zaken worden nooit gedeeld over het netwerk."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Onlangs gebruikt"
+
+#~ msgid "Retain _History"
+#~ msgstr "_Geschiedenis behouden"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "De schermvergrendeling beschermt uw privacy wanneer u weg bent."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Scherm _vergrendelen na zwart scherm gedurende"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Notificaties op vergrendelingsscherm"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Automatisch de prullenbak legen en tijdelijke bestanden verwijderen om te "
+#~ "zorgen dat uw computer geen onnodige gevoelige informatie bevat."
+
+#~ msgid "Purge _After"
+#~ msgstr "Verwijderen _na"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Als u ons informatie stuurt over welke software u gebruikt dan helpt u "
+#~ "ons om u van accuratere aanbevelingen te voorzien. Het helpt ons "
+#~ "daarnaast om onze software te verbeteren.\n"
+#~ "\n"
+#~ "Alle informatie die wij verzamelen is geanonimiseerd en we zullen uw "
+#~ "gegevens nooit delen met derden."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Statistieken over softwaregebruik verzenden"
+
+#~ msgid "_Camera"
+#~ msgstr "_Camera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Microfoon"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Locatiediensten"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Uw persoonlijke gegevens beschermen en regelen wat anderen mogen zien"
+
+#~ msgid "No regions found"
+#~ msgstr "Geen regio’s gevonden"
+
+# laten knipperen/oplichten
+#~ msgid "Flash the _window title"
+#~ msgstr "_Titelbalk laten knipperen"
+
+#~ msgid "Last Login"
+#~ msgstr "Laatste keer aangemeld"
+
+#~ msgid "Delete Background"
+#~ msgstr "Bureaubladachtergrond verwijderen"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "De gebruikersnaam mag niet met een ‘-’ beginnen."
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "_Background"
+#~ msgstr "_Achtergrond"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Verandert gedurende de dag"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Tegelen"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zoomen"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centreren"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Schalen"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Vullen"
+
+# ??? (Wouter Bolsterlee)
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Omspannen"
+
+#~ msgid "Colors"
+#~ msgstr "Kleuren"
+
+# het gaat hier om de mapnaam -Justin
+#~ msgid "Pictures"
+#~ msgstr "Afbeeldingen"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Er zijn geen afbeeldingen aangetroffen"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "U kunt afbeeldingen toevoegen aan uw %s-map waarna ze hier weergegeven "
+#~ "zullen worden"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "_Off"
+#~ msgstr "_Uit"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Verbinding/SSID"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automatisch in pauzestand zetten"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "Als de _aan-/uitknop wordt ingedrukt"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Nachtlicht"
+
+# beeldscherm
+#~ msgid "Could not get screen information"
+#~ msgstr "Kon informatie over het scherm niet verkrijgen"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Overschakelen naar vorige bron"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Overschakelen naar volgende bron"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Alternatieve overschakeling naar volgende bron"
+
+#~ msgid "Add input source"
+#~ msgstr "Invoerbron toevoegen"
+
+#~ msgid "Remove input source"
+#~ msgstr "Invoerbron verwijderen"
+
+#~ msgid "Move input source up"
+#~ msgstr "Invoerbron naar boven verplaatsen"
+
+#~ msgid "Move input source down"
+#~ msgstr "Invoerbron naar beneden verplaatsen"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Invoerbron toetsenbordindeling tonen"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Links"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Rechts"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimum"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maximum"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profiel:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "Speakers _testen"
+
+#~ msgid "Peak detect"
+#~ msgstr "Piekdetectie"
+
+#~ msgid "Device"
+#~ msgstr "Apparaat"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Speakers testen voor %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Kies een apparaat voor geluids_weergave:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Instellingen voor het gekozen apparaat:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "I_nvoervolume:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Kies een a_pparaat voor geluidsopname:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Geluidseffecten"
+
+#~ msgid "Built-in"
+#~ msgstr "Ingebouwd"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Geluidsvoorkeuren"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Evenementgeluid testen"
+
+#~ msgid "From theme"
+#~ msgstr "Van thema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Kies een evenementgeluid:"
+
+#~ msgid "Stop"
+#~ msgstr "Stoppen"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standaard"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Beheerder"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Gnome-configuratiecentrum"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Het configuratiecentrum is de hoofdinterface van Gnome om verschillende "
+#~ "aspecten van uw desktop te configureren."
+
+#~ msgid "Quit"
+#~ msgstr "Afsluiten"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "hardware"
+#~ msgstr "hardware"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Engels (Verenigd Koninkrijk)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Verenigd Koninkrijk"
+
+#~ msgid "page 3"
+#~ msgstr "pagina 3"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Nieuw wachtwoord verifiëren"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Wachtwoorden komen niet overeen."
+
+#~ msgid "Show the overview"
+#~ msgstr "Overzicht tonen"
+
+#~ msgid "Back­ground"
+#~ msgstr "Achtergrond"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Kleur"
+
+#~ msgid "Overview"
+#~ msgstr "Overzicht"
+
+#~| msgid "Default Applications"
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Standaardtoepassingen"
+
+#~ msgid "Ab­out"
+#~ msgstr "Info"
+
+#~ msgid "De­tails"
+#~ msgstr "Details"
+
+#~| msgid "Removable Media"
+#~ msgid "Remo­vable Media"
+#~ msgstr "Verwijderbare media"
+
+#~ msgid "Net­work"
+#~ msgstr "Netwerk"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Notificaties"
+
+#~ msgid "Po­wer"
+#~ msgstr "Energie"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Pri­va­cy"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Delen"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Universele toegang"
+
+#~ msgid "Disable image"
+#~ msgstr "Afbeelding uitschakelen"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Bladeren naar meer afbeeldingen…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Gebruikt door %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wacom­-tablet"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Systeem"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Deksel gesloten"
+
+#~ msgid "Mirrored"
+#~ msgstr "Gespiegeld"
+
+#~ msgid "Secondary"
+#~ msgstr "Secundair"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Gecombineerde schermen rangschikken"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Schermen slepen om ze te rangschikken"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "90° linksom draaien"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "180° draaien"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "90° rechtsom draaien"
+
+#~ msgid "Size"
+#~ msgstr "Grootte"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Menubalk en activiteitenoverzicht op het scherm tonen"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Dit scherm met een ander scherm samenvoegen om extra werkruimte te krijgen"
+
+#~ msgid "Presentation"
+#~ msgstr "Presentatie"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Alleen diavoorstellingen en media tonen"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Huidige beeld op beide schermen tonen"
+
+#~ msgid "Turn Off"
+#~ msgstr "_Uitschakelen"
+
+# 'display' hier ook maar als scherm vertaald (RvS)
+#~ msgid "Don’t use this display"
+#~ msgstr "Dit scherm niet gebruiken"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Gecombineerde schermen rangschikken"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (build-ID: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "Basissysteem"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;Sneltoets;Herhalen;Knipperen;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Druk op Esc om te annuleren."
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Sneltoets instellen"
+
+#~ msgid "Server"
+#~ msgstr "Server"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS-server verwijderen"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Beschikbaar maken voor andere _gebruikers"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Firewall-_zone"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Standaard"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "De zone bepaalt het vertrouwensniveau van de verbinding"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Instellingen voor dit netwerk opnieuw instellen, inclusief wachtwoorden, "
+#~ "maar onthouden als een voorkeursnetwerk"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Alle details met betrekking tot dit netwerk verwijderen, en niet proberen "
+#~ "automatisch verbinding te maken"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Als u een andere dan een draadloze verbinding met het internet heeft, "
+#~ "kunt u een draadloze hotspot instellen om de verbinding met anderen te "
+#~ "delen."
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "Profiel toe_voegen…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Handmatig"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatisch"
+
+#~ msgid "Group Name"
+#~ msgstr "Groepsnaam"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Als hotspot gebruiken…"
+
+#~ msgid "_History"
+#~ msgstr "_Geschiedenis"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Notificatie_banieren"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Notificatie_banieren"
+
+#~ msgid "Add Account"
+#~ msgstr "Account toevoegen"
+
+#~ msgid "Mail"
+#~ msgstr "E-mail"
+
+#~ msgid "Calendar"
+#~ msgstr "Agenda"
+
+#~ msgid "Contacts"
+#~ msgstr "Contacten"
+
+#~ msgid "Chat"
+#~ msgstr "Chatten"
+
+#~ msgid "Error creating account"
+#~ msgstr "Fout tijdens aanmaken van het account"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Weet u zeker dat u dit account wilt verwijderen?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Dit zal niet het account op de server verwijderen."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Geen online-accounts geconfigureerd"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Door het toevoegen van een account kunnen uw toepassingen er toegang toe "
+#~ "krijgen voor documenten, e-mail, contacten, agenda, chatten en meer."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Bezig met configureren"
+
+#~ msgid "Toner Level"
+#~ msgstr "Toner-niveau"
+
+#~ msgid "Supply Level"
+#~ msgstr "Voorraad-niveau"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Bezig met installeren"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u actief"
+#~ msgstr[1] "%u actief"
+
+#~ msgid "Supply"
+#~ msgstr "Voorraad"
+
+#~ msgid "Jobs"
+#~ msgstr "Taken"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "_Taken tonen"
+
+#~ msgid "label"
+#~ msgstr "label"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "_Testpagina afdrukken"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Probeer meer letters, cijfers en symbolen toe te voegen."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Sterkte: zwak"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Sterkte: laag"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Sterkte: medium"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Sterkte: goed"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Sterkte: hoog"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Andere accounts"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Omhoog"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Omlaag"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgid "Left Ring"
+#~ msgstr "Linker ring"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Linker ring-modus #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Rechter ring-modus #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Linker aanraakstrook"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Linker aanraakstrookmodus #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Rechter aanraakstrook"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Rechter aanraakstrookmodus #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Schakelaar linker aanraakringmodus"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Schakelaar rechter aanraakringmodus"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Schakelaar linker aanraakstrookmodus"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Schakelaar rechter aanraakstrookmodus"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Modusschakelaar #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Linkerknop #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Rechterknop #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Bovenste knop #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Onderste knop #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Geen actie"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Linkermuisknop-klik"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Omhoog schuiven"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Omlaag schuiven"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Naar rechts schuiven"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Nieuwe printer toevoegen"
+
+#~ msgid "No printers detected."
+#~ msgstr "Geen printers gedetecteerd."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Sneltoets verwijderen"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Om een sneltoets te bewerken, klikt u op de corresponderende rij en voert "
+#~ "u een nieuwe toetscombinatie in of drukt u op Backspace om hem te wissen."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Onbekende actie>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "De sneltoets ‘%s’ kan niet gebruikt worden, omdat het dan onmogelijk "
+#~ "wordt deze toets te gebruiken om te typen.\n"
+#~ "Probeer het eens met een toets als Control, Alt of Shift tegelijkertijd."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "De sneltoets ‘%s’ is reeds in gebruik voor:\n"
+#~ "‘%s’"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Als u de aan ‘%s’ toegewezen sneltoets opnieuw instelt, zal de sneltoets "
+#~ "‘%s’ uitgeschakeld zijn."
+
+# Geen aparte vertaling voor assign/reassign
+#~ msgid "_Reassign"
+#~ msgstr "_Opnieuw toewijzen"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "De \"%s\" sneltoets heeft een geassocieerde \"%s\" sneltoets. Wilt u deze "
+#~ "automatisch veranderen naar \"%s\"?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" is op dit moment geassocieerd met \"%s\", deze sneltoets zal "
+#~ "worden uitgeschakeld indien u verder gaat."
+
+# Geen aparte vertaling voor assign/reassign
+#~ msgid "_Assign"
+#~ msgstr "_Toewijzen"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Fout tijdens het aanmelden"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Aanmeldgegevens zijn verlopen."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Aanmelden om deze account in te schakelen."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Aanmelden"
+
+#~ msgid "Login History"
+#~ msgstr "Aanmeldgeschiedenis"
+
+#~ msgid "Add User Account"
+#~ msgstr "Gebruikersaccount toevoegen"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Netwerkverbinding toevoegen"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Geen Certificate Authority-certificaat gekozen"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Het niet gebruiken van een Certificate Authority (CA) certificaat kan "
+#~ "leiden tot verbindingen met onveilige, malafide WiFi-netwerken. Wilt u "
+#~ "een Certificate Authority-certificaat kiezen?"
+
+#~ msgid "Ignore"
+#~ msgstr "Negeren"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA-certificaat kiezen"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Elke keer naar dit wachtwoord _vragen"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Mij niet meer _waarschuwen"
+
+#~ msgid "Yes"
+#~ msgstr "Ja"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,4337 +10,4560 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nn\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&component=general\n"
-"POT-Creation-Date: 2012-05-02 06:31+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2012-05-02 08:48+0000\n"
 "Last-Translator: Torstein Adolf Winterseth <kvikende@fsfe.org>\n"
 "Language-Team: Norwegian Nynorsk <i18n-nn@lister.ping.uio.no>\n"
+"Language: nn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"Language: nn\n"
 
-#: ../panels/background/background.ui.h:1
-#| msgid "_Title:"
-msgid "Tile"
-msgstr "Tittel"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Program"
 
-#: ../panels/background/background.ui.h:2
-msgid "Zoom"
-msgstr "Zoom"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Program"
 
-#: ../panels/background/background.ui.h:3
-#| msgid "Pointer"
-msgid "Center"
-msgstr "Midten"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Installer oppdateringar"
 
-#: ../panels/background/background.ui.h:4
-#| msgid "Small"
-msgid "Scale"
-msgstr "Skaler"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "Loket er ope"
 
-#: ../panels/background/background.ui.h:5
-#| msgid "_Full"
-msgid "Fill"
-msgstr "Fyll"
-
-#: ../panels/background/background.ui.h:6
-msgid "Span"
-msgstr "Spennvidd"
-
-#: ../panels/background/background.ui.h:7
-msgid "<b>Background</b>"
-msgstr "<b>Bakgrunn</b>"
-
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:9
-msgid "Changes throughout the day"
-msgstr "Vert endra heile dagen"
-
-#: ../panels/background/background.ui.h:10
-msgid "Primary Color"
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
 msgstr ""
 
-#: ../panels/background/background.ui.h:11
-msgid "Swap colors"
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Søk"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#: ../panels/background/background.ui.h:12
-msgid "Secondary color"
-msgstr ""
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Av"
 
-#: ../panels/background/background.ui.h:13
-msgid "Add wallpaper"
-msgstr "Legg til bakgrunn"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "Plassering"
 
-#: ../panels/background/background.ui.h:14
-msgid "Remove wallpaper"
-msgstr "Fjern bakgrunn"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Systeminformasjon"
 
-#: ../panels/background/background.ui.h:15
-msgid "Add dots"
-msgstr ""
-
-#: ../panels/background/background.ui.h:16
-msgid "<b>Theme</b>"
-msgstr "<b>Tema</b>"
-
-#: ../panels/background/background.ui.h:17
-msgid "<b>Launcher icon size</b>"
-msgstr ""
-
-#: ../panels/background/background.ui.h:18
-msgid "Look"
-msgstr ""
-
-#: ../panels/background/background.ui.h:19
-msgid "<b>Auto-hide the Launcher</b>"
-msgstr ""
-
-#: ../panels/background/background.ui.h:20
-msgid ""
-"<span size=\"small\">The launcher will reveal when moving the pointer to the "
-"defined hot spot.</span>"
-msgstr ""
-
-#: ../panels/background/background.ui.h:21
-msgid "Reveal location:"
-msgstr ""
-
-#: ../panels/background/background.ui.h:22
-msgid "Left side"
-msgstr ""
-
-#: ../panels/background/background.ui.h:23
-msgid "Top left corner"
-msgstr ""
-
-#: ../panels/background/background.ui.h:24
-msgid "Other reveal option"
-msgstr ""
-
-#: ../panels/background/background.ui.h:25
-msgid "Reveal sensitivity"
-msgstr ""
-
-#: ../panels/background/background.ui.h:26
-msgid "<small>Low</small>"
-msgstr ""
-
-#: ../panels/background/background.ui.h:27
-msgid "<small>High</small>"
-msgstr ""
-
-#: ../panels/background/background.ui.h:28
-msgid ""
-"Some settings have been overriden by an external program, press \"Restore "
-"Default Behaviors\"  to reset the behavior and return control to this panel."
-msgstr ""
-
-#: ../panels/background/background.ui.h:29
-msgid "Restore Default Behaviours"
-msgstr ""
-
-#: ../panels/background/background.ui.h:30
-msgid "Behavior"
-msgstr ""
-
-#: ../panels/background/bg-colors-source.c:46
-msgid "Horizontal Gradient"
-msgstr "Vassrett fargeovergang"
-
-#: ../panels/background/bg-colors-source.c:47
-msgid "Vertical Gradient"
-msgstr "Loddrett fargeovergang"
-
-#: ../panels/background/bg-colors-source.c:48
-msgid "Solid Color"
-msgstr "Einsfarga"
-
-#: ../panels/background/cc-background-item.c:148
-msgid "multiple sizes"
-msgstr "fleire storleikar"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:152
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:281
-#| msgid "Apply Background"
-msgid "No Desktop Background"
-msgstr "Ingen skrivebordsbakgrunn"
-
-#: ../panels/background/cc-background-panel.c:1068
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "Browse for more pictures"
-msgstr "Bla gjennom for fleire bilete"
-
-#: ../panels/background/cc-background-panel.c:1160
-msgid "Current background"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "Noverande bakgrunn"
 
-#: ../panels/background/cc-background-panel.c:1351
-msgid "default"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
 
-#: ../panels/background/cc-background-panel.c:1766
-#| msgid "Add Wallpaper"
-msgid "Wallpapers"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
 msgstr "Bakgrunnsbilete"
 
-#: ../panels/background/cc-background-panel.c:1773
-msgid "Pictures Folder"
-msgstr "Biletmappe"
-
-#: ../panels/background/cc-background-panel.c:1780
-msgid "Colors & Gradients"
-msgstr "Fargar og fargeovergangar"
-
-#: ../panels/background/cc-background-panel.c:1788
-msgid "Flickr"
-msgstr "Flickr"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
-msgid "Appearance"
-msgstr "Utsjånad"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change the background and theme"
-msgstr "Endra bakgrunnen og temaet"
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;Theme;Appearance;Launcher;Unity;Menus;"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
 msgstr ""
 
-#. TRANSLATORS: device type
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
-#: ../panels/network/panel-common.c:99
-msgid "Bluetooth"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Lyd"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
 
-#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
-msgid "Configure Bluetooth settings"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Snøggtastar"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
 msgstr ""
 
-#: ../panels/bluetooth/bluetooth.ui.h:1
-msgid "Set Up New Device"
-msgstr ""
-
-#: ../panels/bluetooth/bluetooth.ui.h:2 ../panels/network/network.ui.h:9
-msgid "Remove Device"
-msgstr ""
-
-#: ../panels/bluetooth/bluetooth.ui.h:3
-msgid "Connection"
-msgstr ""
-
-#: ../panels/bluetooth/bluetooth.ui.h:4
-msgid "Paired"
-msgstr ""
-
-#: ../panels/bluetooth/bluetooth.ui.h:5
-msgid "Type"
-msgstr ""
-
-#: ../panels/bluetooth/bluetooth.ui.h:6
-msgid "Address"
-msgstr "Adresse"
-
-#: ../panels/bluetooth/bluetooth.ui.h:7
-msgid "Mouse and Touchpad Settings"
-msgstr ""
-
-#: ../panels/bluetooth/bluetooth.ui.h:8 ../panels/universal-access/uap.ui.h:43
-msgid "Sound Settings"
-msgstr ""
-
-#: ../panels/bluetooth/bluetooth.ui.h:9 ../panels/universal-access/uap.ui.h:74
-msgid "Keyboard Settings"
-msgstr ""
-
-#: ../panels/bluetooth/bluetooth.ui.h:10
-msgid "Send Files..."
-msgstr ""
-
-#: ../panels/bluetooth/bluetooth.ui.h:11
-msgid "Browse Files..."
-msgstr ""
-
-#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
-#: ../panels/bluetooth/bluetooth.ui.h:13
-msgctxt "Power"
-msgid "Bluetooth"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:281
-msgid "Yes"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:281
-msgid "No"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:393
-msgid "Bluetooth is disabled"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:398
-msgid "Bluetooth is disabled by hardware switch"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:402
-msgid "No Bluetooth adapters found"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:535
-msgid "Visibility"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:539
-#, c-format
-msgid "Visibility of “%s”"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:583
-#, c-format
-msgid "Remove '%s' from the list of devices?"
-msgstr ""
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:585
-msgid ""
-"If you remove the device, you will have to set it up again before next use."
-msgstr ""
-
-#. TRANSLATORS: this is where the user can click and import a profile
-#: ../panels/color/cc-color-panel.c:107
-msgid "Other profile…"
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:120
-msgid "Default: "
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:127
-msgid "Colorspace: "
-msgstr ""
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:133
-msgid "Test profile: "
-msgstr ""
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:186 ../panels/color/color.ui.h:11
-msgid "Set for all users"
-msgstr ""
-
-#. TRANSLATORS: this is when the profile should be set for all users
-#: ../panels/color/cc-color-panel.c:193
-msgid "Create virtual device"
-msgstr ""
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:228
-msgid "Select ICC Profile File"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:231
-msgid "_Import"
-msgstr ""
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:242
-msgid "Supported ICC profiles"
-msgstr ""
-
-#
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:249
-msgid "All files"
-msgstr "Alle filer"
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:639
-msgid "Available Profiles for Displays"
-msgstr ""
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:643
-msgid "Available Profiles for Scanners"
-msgstr ""
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:647
-msgid "Available Profiles for Printers"
-msgstr ""
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:651
-msgid "Available Profiles for Cameras"
-msgstr ""
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#: ../panels/color/cc-color-panel.c:655
-msgid "Available Profiles for Webcams"
-msgstr ""
-
-#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
-#. * where the device type is not recognised
-#. Profiles that can be added to the device
-#: ../panels/color/cc-color-panel.c:660 ../panels/color/color.ui.h:2
-msgid "Available Profiles"
-msgstr ""
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:936
-#: ../panels/sound/gvc-mixer-dialog.c:1516
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1609
-msgid "Device"
-msgstr "Eining"
-
-#. TRANSLATORS: column for device list
-#: ../panels/color/cc-color-panel.c:971
-msgid "Calibration"
-msgstr ""
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1003
-msgid "Create a color profile for the selected device"
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1017 ../panels/color/cc-color-panel.c:1041
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1050
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1061
-msgid "The device type is not currently supported."
-msgstr ""
-
-#. TRANSLATORS: this is when an auto-added profile cannot be removed
-#: ../panels/color/cc-color-panel.c:1133
-msgid "Cannot remove automatically added profile"
-msgstr ""
-
-#. TRANSLATORS: this is when there is no profile for the device
-#: ../panels/color/cc-color-panel.c:1462
-msgid "No profile"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1493
-#, c-format
-msgid "%i year"
-msgid_plural "%i years"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../panels/color/cc-color-panel.c:1504
-#, c-format
-msgid "%i month"
-msgid_plural "%i months"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../panels/color/cc-color-panel.c:1515
-#, c-format
-msgid "%i week"
-msgid_plural "%i weeks"
-msgstr[0] ""
-msgstr[1] ""
-
-#. fallback
-#: ../panels/color/cc-color-panel.c:1522
-#, c-format
-msgid "Less than 1 week"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1584
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1589
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1594
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1712 ../panels/color/cc-color-panel.c:1753
-#: ../panels/color/cc-color-panel.c:1764 ../panels/color/cc-color-panel.c:1775
-msgid "Uncalibrated"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1715
-msgid "This device is not color managed."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1756
-msgid "This device is using manufacturing calibrated data."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1767
-msgid ""
-"This device does not have a profile suitable for whole-screen color "
-"correction."
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:1800
-msgid "This device has an old profile that may no longer be accurate."
-msgstr ""
-
-#. TRANSLATORS: this is when the calibration profile age is not
-#. * specified as it has been autogenerated from the hardware
-#: ../panels/color/cc-color-panel.c:1828
-msgid "Not specified"
-msgstr ""
-
-#. add the 'No devices detected' entry
-#: ../panels/color/cc-color-panel.c:2013
-msgid "No devices supporting color management detected"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:2242
-msgctxt "Device kind"
-msgid "Display"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:2244
-msgctxt "Device kind"
-msgid "Scanner"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:2246
-msgctxt "Device kind"
-msgid "Printer"
-msgstr ""
-
-#: ../panels/color/cc-color-panel.c:2248
-msgctxt "Device kind"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr ""
 
-#: ../panels/color/cc-color-panel.c:2250
-msgctxt "Device kind"
-msgid "Webcam"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
 msgstr ""
 
-#: ../panels/color/color.ui.h:3
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
-msgid "Color"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "Mikrofonvolum"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
 msgstr ""
 
-#: ../panels/color/color.ui.h:4
-msgid "Each device needs an up to date color profile to be color managed."
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "Plassering"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
 msgstr ""
 
-#: ../panels/color/color.ui.h:5
-msgid "Learn more"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
 msgstr ""
 
-#: ../panels/color/color.ui.h:6
-msgid "Learn more about color management"
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
 msgstr ""
 
-#: ../panels/color/color.ui.h:7
-msgid "Add device"
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
 msgstr ""
 
-#: ../panels/color/color.ui.h:8
-msgid "Add a virtual device"
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
 msgstr ""
 
-#: ../panels/color/color.ui.h:9
-msgid "Delete device"
+#
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Testlyd"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
 msgstr ""
 
-#: ../panels/color/color.ui.h:10
-msgid "Remove a device"
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
 msgstr ""
 
-#: ../panels/color/color.ui.h:12
-msgid "Set this device for all users on this computer"
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Einingstype"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
 msgstr ""
 
-#: ../panels/color/color.ui.h:13
-msgid "Add profile"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
 msgstr ""
 
-#: ../panels/color/color.ui.h:14
-msgid "Calibrate…"
-msgstr ""
-
-#: ../panels/color/color.ui.h:15
-msgid "Calibrate the device"
-msgstr ""
-
-#: ../panels/color/color.ui.h:16
-msgid "Remove profile"
-msgstr ""
-
-#: ../panels/color/color.ui.h:17
-msgid "View details"
-msgstr ""
-
-#: ../panels/color/color.ui.h:18
-msgid "Device type:"
-msgstr ""
-
-#: ../panels/color/color.ui.h:19
-msgid "Manufacturer:"
-msgstr ""
-
-#: ../panels/color/color.ui.h:20
-msgid "Model:"
-msgstr ""
-
-#: ../panels/color/color.ui.h:21
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
-"Image files can be dragged on this window to auto-complete the above fields."
+"How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Color management settings"
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Program"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
 msgstr ""
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
-msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
 msgstr ""
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:587
-msgid "United States"
-msgstr "USA"
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Tema</b>"
 
-#: ../panels/common/cc-common-language.c:588
-msgid "Germany"
-msgstr "Tyskland"
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:589
-msgid "France"
-msgstr "Frankrike"
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:590
-msgid "Spain"
-msgstr "Spania"
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
 
-#: ../panels/common/cc-common-language.c:591
-msgid "China"
-msgstr "Kina"
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr ""
 
-#: ../panels/common/cc-language-chooser.c:294
-msgid "Select a region"
-msgstr "Vel ein region"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Standard"
 
-#: ../panels/common/gdm-languages.c:781
-msgid "Unspecified"
-msgstr "Uspesifisert"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#: ../panels/common/language-chooser.ui.h:1
-msgid "Select a language"
-msgstr "Vel eit språk"
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "<b>Bakgrunn</b>"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/printers/new-printer-dialog.ui.h:4
-#: ../panels/user-accounts/um-user-panel.c:446
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Utsjånad"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
+msgstr "Endra bakgrunnen og temaet"
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+#, fuzzy
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Skrivebordsbakgrunn;Skjerm;Skrivebord;Tema"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "På"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Ingen program spelar eller tek opp lyd."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Bla gjennom for fleire bilete"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
 msgid "_Cancel"
 msgstr "_Avbryt"
 
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/universal-access/gconf-property-editor.c:1609
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
+msgstr "Ferdig!"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+#, fuzzy
+msgid "Display Type"
+msgstr "Skjermar"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Skjermar"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "_Profil:"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "_Profil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "_Profil:"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Legg til"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
+msgstr "På"
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "_Profil:"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "_Fjern"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Høg"
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "minutt"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:640
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Låg"
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "minutt"
+
+#: panels/color/cc-color-panel.ui:663
+#, fuzzy
+msgid "Native to display"
+msgstr "_Like skjermar"
+
+#: panels/color/cc-color-panel.ui:667
+#, fuzzy
+msgid "D50 (Printing and publishing)"
+msgstr "Peik og klikk"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Vel eit språk"
+
+#: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
 msgstr "_Vel"
 
-#: ../panels/datetime/datetime.ui.h:1
-msgid "_Region:"
-msgstr "_Region:"
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:2
-msgid "_City:"
-msgstr "_By:"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:3
-msgid "_Network Time"
-msgstr "_Nettverkstid"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translator: this is the separator between hours and minutes, like in HH:MM
-#: ../panels/datetime/datetime.ui.h:5
-msgid ":"
-msgstr "."
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "Lås opp"
 
-#: ../panels/datetime/datetime.ui.h:6
-msgid "Set the time one hour ahead."
-msgstr "Still klokka ein time fram."
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:7
-msgid "Set the time one hour back."
-msgstr "Still klokka ein time tilbake."
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "Auk storleik:"
 
-#: ../panels/datetime/datetime.ui.h:8
-msgid "Set the time one minute ahead."
-msgstr "Still klokka eitt minutt fram."
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Tidspunkt"
 
-#: ../panels/datetime/datetime.ui.h:9
-msgid "Set the time one minute back."
-msgstr "Still klokka eitt minutt tilbake."
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:10
-msgid "Switch between AM and PM."
-msgstr "Byt mellom a.m. og p.m."
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "Minsk storleik:"
 
-#: ../panels/datetime/datetime.ui.h:11
-msgid "Month"
-msgstr "Månad"
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+#, fuzzy
+msgid "Date & Time"
+msgstr "Dato og tid"
 
-#: ../panels/datetime/datetime.ui.h:12
-msgid "Day"
-msgstr "Dag"
-
-#: ../panels/datetime/datetime.ui.h:13
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "År"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "24-hour"
-msgstr "24-timar"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Månad"
 
-#: ../panels/datetime/datetime.ui.h:15
-msgid "AM/PM"
-msgstr "a.m./p.m."
-
-#: ../panels/datetime/datetime.ui.h:16
+#: panels/datetime/cc-datetime-panel.ui:71
 msgid "January"
 msgstr "Januar"
 
-#: ../panels/datetime/datetime.ui.h:17
+#: panels/datetime/cc-datetime-panel.ui:72
 msgid "February"
 msgstr "Februar"
 
-#: ../panels/datetime/datetime.ui.h:18
-#| msgid "Search"
+#: panels/datetime/cc-datetime-panel.ui:73
 msgid "March"
 msgstr "Mars"
 
-#: ../panels/datetime/datetime.ui.h:19
-#| msgid "pixel"
-#| msgid_plural "pixels"
+#: panels/datetime/cc-datetime-panel.ui:74
 msgid "April"
 msgstr "April"
 
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:75
 msgid "May"
 msgstr "Mai"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:76
 msgid "June"
 msgstr "Juni"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:77
 msgid "July"
 msgstr "Juli"
 
-#: ../panels/datetime/datetime.ui.h:23
+#: panels/datetime/cc-datetime-panel.ui:78
 msgid "August"
 msgstr "August"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:79
 msgid "September"
 msgstr "September"
 
 #
-#: ../panels/datetime/datetime.ui.h:25
-#| msgid "Other"
+#: panels/datetime/cc-datetime-panel.ui:80
 msgid "October"
 msgstr "Oktober"
 
-#: ../panels/datetime/datetime.ui.h:26
+#: panels/datetime/cc-datetime-panel.ui:81
 msgid "November"
 msgstr "November"
 
-#: ../panels/datetime/datetime.ui.h:27
+#: panels/datetime/cc-datetime-panel.ui:82
 msgid "December"
 msgstr "Desember"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
-msgid "Date and Time"
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dag"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#, fuzzy
+msgid "Time Zone"
+msgstr "Tidspunkt"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
 msgstr "Dato og tid"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Date and Time preferences panel"
-msgstr "Panel for innstillingar til dato og tid"
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "Automatisk oppsett"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "På"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Lås opp"
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datoar"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+msgid "Seconds"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalender"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Desember"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Klokke;Tidssone;Stad;"
 
-#: ../panels/display/cc-display-panel.c:509
-msgctxt "display panel, rotation"
-msgid "Normal"
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Endra region- og språkinnstillingane dine"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
 msgstr ""
 
-#: ../panels/display/cc-display-panel.c:510
-msgctxt "display panel, rotation"
-msgid "Counterclockwise"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:511
-msgctxt "display panel, rotation"
-msgid "Clockwise"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:512
-msgctxt "display panel, rotation"
-msgid "180 Degrees"
-msgstr ""
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#. 
-#: ../panels/display/cc-display-panel.c:653
-msgid "Mirror Displays"
-msgstr "Like skjermar"
-
-#: ../panels/display/cc-display-panel.c:677
-#: ../panels/display/display-capplet.ui.h:1
-#| msgid "Typing Monitor"
-msgid "Monitor"
-msgstr "Skjerm"
-
-#: ../panels/display/cc-display-panel.c:783
-#, c-format
-#| msgid "%d x %d"
-msgid "%d x %d (%s)"
-msgstr "%d × %d (%s)"
-
-#: ../panels/display/cc-display-panel.c:785
-#, c-format
-msgid "%d x %d"
-msgstr "%d × %d"
-
-#: ../panels/display/cc-display-panel.c:1693
-msgid "Drag to change primary display."
-msgstr "Dra for å endra primærskjerm"
-
-#: ../panels/display/cc-display-panel.c:1751
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr "Vel skjermen du vil endra. Drag den for å endra plasseringa."
-
-#: ../panels/display/cc-display-panel.c:2166
-msgid "%a %R"
-msgstr "%a %R"
-
-#: ../panels/display/cc-display-panel.c:2168
-msgid "%a %l:%M %p"
-msgstr "%a %H.%M"
-
-#: ../panels/display/cc-display-panel.c:2330
-#: ../panels/display/cc-display-panel.c:2382
-#, c-format
-msgid "Failed to apply configuration: %s"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2410
-#| msgid "Could not load the main interface"
-msgid "Could not save the monitor configuration"
-msgstr "Klarte ikkje lagra skjerminnstillingane"
-
-#: ../panels/display/cc-display-panel.c:2470
-msgid "Could not detect displays"
-msgstr "Klarte ikkje oppdaga skjermar"
-
-#: ../panels/display/cc-display-panel.c:2735
-msgid "All displays"
-msgstr ""
-
-#: ../panels/display/cc-display-panel.c:2886
-#| msgid "Change screen resolution"
-msgid "Could not get screen information"
-msgstr "Klarte ikkje få informasjon om skjermen"
-
-#: ../panels/display/display-capplet.ui.h:2
-msgid "_Resolution"
-msgstr "_Oppløysing"
-
-#: ../panels/display/display-capplet.ui.h:3
-msgid "R_otation"
-msgstr "R_otering"
-
-#: ../panels/display/display-capplet.ui.h:4
-msgid "L_auncher placement"
-msgstr ""
-
-#: ../panels/display/display-capplet.ui.h:5
-msgid "S_ticky edges"
-msgstr ""
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:7
-msgid "_Mirror displays"
-msgstr "_Like skjermar"
-
-#: ../panels/display/display-capplet.ui.h:8
-msgid "Note: may limit resolution options"
-msgstr "Merk: kan avgrensa innstillingane for oppløysing"
-
-#: ../panels/display/display-capplet.ui.h:9
-msgid "_Detect Displays"
-msgstr "_Finn skjermar"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "Skjermar"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-#| msgid "Change resolution and position of monitors"
-msgid "Change resolution and position of monitors and projectors"
-msgstr "Endra oppløysing og posisjonen til skjermar og prosjektørar"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr "Panel;Prosjektør;xrandr;Skjerm;Oppløysing;Oppfrisking;"
-
-#. Translators: VESA is an techncial acronym, don't translate it.
-#: ../panels/info/cc-info-panel.c:401
-#, c-format
-msgid "VESA: %s"
-msgstr "VESA: %s"
-
-#. TRANSLATORS: device type
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:425 ../panels/network/panel-common.c:79
-#: ../panels/network/panel-common.c:158
-msgid "Unknown"
-msgstr "Ukjend"
-
-#. translators: This is the type of architecture, for example:
-#. * "64-bit" or "32-bit"
-#: ../panels/info/cc-info-panel.c:586
-#, c-format
-msgid "%d-bit"
-msgstr "%d-bit"
-
-#: ../panels/info/cc-info-panel.c:743
-msgid "Unknown model"
-msgstr "Ukjend modell"
-
-#: ../panels/info/cc-info-panel.c:826
-msgid "The next login will attempt to use the standard experience."
-msgstr "Neste innlogging vil prøva å bruka standard brukaroppleving."
-
-#: ../panels/info/cc-info-panel.c:828
-msgid ""
-"The next login will use the fallback mode intended for unsupported graphics "
-"hardware."
-msgstr ""
-"Neste innlogging vil bruka reserveløysing for grafikkort som ikkje er støtta."
-
-#. translators: The hardware is not able to run GNOME 3's
-#. * shell, so we use the GNOME "Fallback" session
-#: ../panels/info/cc-info-panel.c:870
-msgctxt "Experience"
-msgid "Fallback"
-msgstr "Reserveløysing"
-
-#. translators: The hardware is able to run GNOME 3's
-#. * shell, also called "Standard" experience
-#: ../panels/info/cc-info-panel.c:876
-msgctxt "Experience"
-msgid "Standard"
-msgstr "Standard"
-
-#: ../panels/info/cc-info-panel.c:1199
-msgid "Ask what to do"
-msgstr "Spør etter kva som skal gjerast"
-
-#: ../panels/info/cc-info-panel.c:1203 ../panels/power/power.ui.h:9
-msgid "Do nothing"
-msgstr "Ikkje gjer noko"
-
-#: ../panels/info/cc-info-panel.c:1207
-msgid "Open folder"
-msgstr "Opna mappe"
-
-#: ../panels/info/cc-info-panel.c:1322
-msgid "Select an application for audio CDs"
-msgstr "Vel eit program for lyd-CD-ar"
-
-#: ../panels/info/cc-info-panel.c:1323
-msgid "Select an application for video DVDs"
-msgstr "Vel eit program for video-DVD-ar"
-
-#: ../panels/info/cc-info-panel.c:1324
-msgid "Select an application to run when a music player is connected"
-msgstr "Vel programmet som skal køyrast når ein musikkspelar vert kopla til"
-
-#: ../panels/info/cc-info-panel.c:1325
-msgid "Select an application to run when a camera is connected"
-msgstr "Vel programmet som skal køyrast når eit kamera vert kopla til"
-
-#: ../panels/info/cc-info-panel.c:1326
-msgid "Select an application for software CDs"
-msgstr "Vel eit program for CD-ar med programvare"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#. 
-#: ../panels/info/cc-info-panel.c:1338
-msgid "audio DVD"
-msgstr "lyd-DVD"
-
-#: ../panels/info/cc-info-panel.c:1339
-msgid "blank Blu-ray disc"
-msgstr "Tom Blu-ray-plate"
-
-#: ../panels/info/cc-info-panel.c:1340
-msgid "blank CD disc"
-msgstr "tom CD-plate"
-
-#: ../panels/info/cc-info-panel.c:1341
-msgid "blank DVD disc"
-msgstr "tom DVD-plate"
-
-#: ../panels/info/cc-info-panel.c:1342
-msgid "blank HD DVD disc"
-msgstr "tom HD-DVD-plate"
-
-#: ../panels/info/cc-info-panel.c:1343
-msgid "Blu-ray video disc"
-msgstr "Blu-Ray-videoplate"
-
-#: ../panels/info/cc-info-panel.c:1344
-msgid "e-book reader"
-msgstr "E-boklesar"
-
-#: ../panels/info/cc-info-panel.c:1345
-msgid "HD DVD video disc"
-msgstr "HD-DVD-videodisk"
-
-#: ../panels/info/cc-info-panel.c:1346
-msgid "Picture CD"
-msgstr "Bilet-CD"
-
-#: ../panels/info/cc-info-panel.c:1347
-msgid "Super Video CD"
-msgstr "Super Video-CD"
-
-#: ../panels/info/cc-info-panel.c:1348
-msgid "Video CD"
-msgstr "Video-CD"
-
-#: ../panels/info/cc-info-panel.c:1471
-#: ../panels/keyboard/keyboard-shortcuts.c:1647
-msgid "Section"
-msgstr ""
-
-#: ../panels/info/cc-info-panel.c:1480 ../panels/info/info.ui.h:11
-msgid "Overview"
-msgstr "Oversikt"
-
-#: ../panels/info/cc-info-panel.c:1486 ../panels/info/info.ui.h:18
-msgid "Default Applications"
-msgstr "Standardprogram"
-
-#: ../panels/info/cc-info-panel.c:1491 ../panels/info/info.ui.h:26
-msgid "Removable Media"
-msgstr "Flyttbart medium"
-
-#: ../panels/info/cc-info-panel.c:1496 ../panels/info/info.ui.h:10
-msgid "Graphics"
-msgstr "Grafikk"
-
-#: ../panels/info/cc-info-panel.c:1698
-#, c-format
-msgid "Version %s"
-msgstr "Versjon %s"
-
-#: ../panels/info/cc-info-panel.c:1750
-msgid "Install Updates"
-msgstr "Installer oppdateringar"
-
-#: ../panels/info/cc-info-panel.c:1754
-msgid "System Up-To-Date"
-msgstr "Systemet er oppdatert"
-
-#: ../panels/info/cc-info-panel.c:1758
-msgid "Checking for Updates"
-msgstr "Ser etter oppdateringar"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-msgid "Details"
-msgstr ""
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "System Information"
-msgstr "Systeminformasjon"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;fallba"
-"ck;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "Vel korleis andre medium skal handsamast"
-
-#: ../panels/info/info.ui.h:2
-#| msgid "Action"
-msgid "Acti_on:"
-msgstr "_Handling:"
-
-#: ../panels/info/info.ui.h:3
-#| msgid "Type:"
-msgid "_Type:"
-msgstr "_Type:"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "Einingsnamn"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "Minne"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "Prosessor"
-
-#: ../panels/info/info.ui.h:7
-msgid "OS type"
-msgstr "Type operativsystem"
-
-#: ../panels/info/info.ui.h:8
-msgid "Disk"
-msgstr "Lagringseining"
-
-#: ../panels/info/info.ui.h:9
-msgid "Calculating..."
-msgstr "Reknar ut …"
-
-#: ../panels/info/info.ui.h:12
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "_Nett"
 
-#: ../panels/info/info.ui.h:13
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "_E-post"
 
-#: ../panels/info/info.ui.h:14
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "_Kalender"
 
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "M_usikk"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "_Video"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "_Bilete"
 
-#: ../panels/info/info.ui.h:19
-msgid "Select how media should be handled"
-msgstr "Vel korleis medium skal handsamast"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Standardprogram"
 
-#: ../panels/info/info.ui.h:20
-msgid "CD _audio"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Standardprogram"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
 msgstr ""
 
-#: ../panels/info/info.ui.h:21
-msgid "_DVD video"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
 msgstr ""
 
-#: ../panels/info/info.ui.h:22
-msgid "_Music player"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
 msgstr ""
 
-#: ../panels/info/info.ui.h:23
-msgid "_Software"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
 msgstr ""
 
-#: ../panels/info/info.ui.h:24
-msgid "_Other Media..."
-msgstr "_Andre medium …"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Never prompt or start programs on media insertion"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
 msgstr ""
-"_Aldri start eller spør kva for program skal starta når medium vert innsete"
 
-#: ../panels/info/info.ui.h:27
-msgid "Driver"
-msgstr "Drivar"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
 
-#: ../panels/info/info.ui.h:28
-msgid "Experience"
-msgstr "Brukaroppleving"
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Tilførsle"
 
-#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
-#: ../panels/info/info.ui.h:30
-msgid "Forced _Fallback Mode"
-msgstr "Tvungen _reserveløysing"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Like skjermar"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "Like skjermar"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Skrivarinnstillingar"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Oppløysing"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skaler"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Ingen skrivar tilgjengeleg"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr "."
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "minutt"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Skjermar"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+#, fuzzy
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Endra oppløysing og posisjonen til skjermar og prosjektørar"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Panel;Prosjektør;xrandr;Skjerm;Oppløysing;Oppfrisking;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Tilførslenivå"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Blekknivå"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Blekknivå"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Blekknivå"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Einingstype"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Einingsnamn"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Maskinvare"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Minne"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Prosessor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafikk"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+#, fuzzy
+msgid "Calculating…"
+msgstr "Reknar ut …"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Namn"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "_Type:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Versjon %s"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Installer oppdateringar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Eining"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Einingsnamn"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"eining;system;informasjon;minne;prosessor;versjon;standard;program;"
+"reserveløysing;føretrekt;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "Lyd og media"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Slå av lyd"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Lågare lydstyrke"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Høgare lydstyrke"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "Mikrofonvolum"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Start mediaspelar"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Spel av (eller spel av / pause)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Set avspeling på pause"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Stopp avspeling"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Førre spor"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Neste spor"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Løys ut"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
-msgid "Launchers"
-msgstr "Oppstartarar"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:2
-msgid "Launch help browser"
-msgstr "Start hjelplesar"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:3
-msgid "Launch calculator"
-msgstr "Start kalkulator"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:4
-msgid "Launch email client"
-msgstr "Start e-postprogram"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:5
-msgid "Launch web browser"
-msgstr "Start nettlesar"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:6
-msgid "Home folder"
-msgstr "Heimemappe"
-
-#: ../panels/keyboard/01-launchers.xml.in.h:7
-msgid "Search"
-msgstr "Søk"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:2
-msgid "Take a screenshot"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Take a screenshot of a window"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:4
-msgid "Take a screenshot of an area"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Copy a screenshot to clipboard"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:6
-msgid "Copy a screenshot of a window to clipboard"
-msgstr ""
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Copy a screenshot of an area to clipboard"
-msgstr ""
-
-#: ../panels/keyboard/01-system.xml.in.h:1
-#: ../panels/region/gnome-region-panel.ui.h:40
-msgid "System"
-msgstr "System"
-
-#: ../panels/keyboard/01-system.xml.in.h:2
-msgid "Log out"
-msgstr "Logg ut"
-
-#: ../panels/keyboard/01-system.xml.in.h:3
-msgid "Lock screen"
-msgstr "Lås skjermen"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "Tilgjenge"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
-msgid "Turn zoom on or off"
-msgstr ""
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
-msgid "Zoom in"
-msgstr ""
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
-msgid "Zoom out"
-msgstr ""
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
-msgid "Turn screen reader on or off"
-msgstr ""
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
-msgid "Turn on-screen keyboard on or off"
-msgstr ""
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
-msgid "Increase text size"
-msgstr "Større tekststorleik"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
-msgid "Decrease text size"
-msgstr "Mindre tekststorleik"
-
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
-msgid "High contrast on or off"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "Keyboard"
-msgstr "Tastatur"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "Change keyboard settings"
-msgstr "Endra tastaturinnstillingar"
-
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Snøggtast;Repeter;Blink;"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-#| msgid "Shortcut"
-msgid "Custom Shortcut"
-msgstr "Eigendefinert snøggtast"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "_Name:"
-msgstr "_Namn:"
-
-#
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "C_ommand:"
-msgstr "K_ommando:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-#| msgid "<b>Repeat Keys</b>"
-msgid "Repeat Keys"
-msgstr "Repeterande tastar"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Key presses _repeat when key is held down"
-msgstr "Tastetrykk vert _repeterte når tasten vert halden nede"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "_Delay:"
-msgstr "_Pause:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Speed:"
-msgstr "_Fart:"
-
-#. short delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-#: ../panels/mouse/gnome-mouse-properties.ui.h:26
-#: ../panels/universal-access/uap.ui.h:55
-#: ../panels/universal-access/zoom-options.c:333
-#| msgid "Shortcut"
-msgid "Short"
-msgstr "Kort"
-
-#. slow acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "Slow"
-msgstr "Treg"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgid "Repeat keys speed"
-msgstr "Tasterepetisjonsrate"
-
-#. long delay
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-#: ../panels/mouse/gnome-mouse-properties.ui.h:28
-#: ../panels/universal-access/uap.ui.h:58
-#: ../panels/universal-access/zoom-options.c:337
-#| msgid "Login"
-msgid "Long"
-msgstr "Lang"
-
-#. fast acceleration
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-#| msgid "_Paste"
-msgid "Fast"
-msgstr "Snøgg"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-#| msgid "<b>Cursor Blinking</b>"
-msgid "Cursor Blinking"
-msgstr "Blinkande skrivemerke"
-
-#
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor _blinks in text fields"
-msgstr "Skrivemerket _blinkar i tekstfelt"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "S_peed:"
-msgstr "_Fart:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "Cursor blink speed"
-msgstr ""
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Layout Settings"
-msgstr "Utformingsinnstillingar"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/universal-access/uap.ui.h:75
-#| msgid "Typing Break"
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Skriving"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-msgid "Add Shortcut"
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Vel inndatakjelda som skal leggjast til"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Remove Shortcut"
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Oppstartarar"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Start hjelplesar"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "_Alle innstillingar"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Start kalkulator"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Start e-postprogram"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Start nettlesar"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Heimemappe"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Søk"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Logg ut"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Lås skjermen"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
 msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-#: ../panels/wacom/button-mapping.ui.h:3
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
-msgstr ""
-"For å endra ein snarveg, trykk på den tilhøyrande rada og hald nede "
-"tastekombinasjonen, eller trykk slettetasten for å fjerna den."
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-#| msgid "Shortcut"
-msgid "Shortcuts"
-msgstr "Snøggtastar"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:554
-#: ../panels/keyboard/keyboard-shortcuts.c:562
-#: ../panels/keyboard/keyboard-shortcuts.c:867
-#: ../panels/keyboard/keyboard-shortcuts.c:1410
-#: ../panels/keyboard/keyboard-shortcuts.c:1414
-#| msgid "Shortcut"
-msgid "Custom Shortcuts"
-msgstr "Eigendefinerte snøggtastar"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:722
-msgid "<Unknown Action>"
-msgstr "<Ukjend handling>"
-
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/keyboard-shortcuts.c:1062
-#: ../panels/sound/gvc-mixer-control.c:1087
-#: ../panels/user-accounts/um-fingerprint-dialog.c:215
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-#: ../panels/sound-nua/gvc-mixer-control.c:1906
-msgid "Disabled"
-msgstr "Av"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1088
-msgid "Error saving the new shortcut"
-msgstr "Klarte ikkje lagra den nye snøggtasten"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1219
-#, c-format
-#| msgid ""
-#| "The shortcut \"%s\" cannot be used because it will become impossible to "
-#| "type using this key.\n"
-#| "Please try with a key such as Control, Alt or Shift at the same time.\n"
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-"Snarvegen «%s» kan ikkje brukast fordi det vil verta umogleg å skriva med "
-"denne tasten.\n"
-"Prøv igjen med ein tastekombinasjon som inneheld Ctrl, Alt eller Shift."
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1251
-#, c-format
-#| msgid ""
-#| "The shortcut \"%s\" is already used for:\n"
-#| " \"%s\"\n"
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-"Snøggtasten «%s» er alt i bruk av:\n"
-" «%s»"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1256
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-"Om du endrar snøggtasten til «%s» vil snøggtasten «%s» verta avslått."
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1262
-msgid "_Reassign"
-msgstr "_Tildel på nytt"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1349
-msgid "Too many custom shortcuts"
-msgstr "For mange eigendefinerte snøggtastar"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1700
-#: ../panels/wacom/cc-wacom-page.c:582
-msgid "Action"
-msgstr "Handling"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1722
-msgid "Shortcut"
-msgstr "Snøggtast"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-#| msgid "Touchpad"
-msgid "Mouse and Touchpad"
-msgstr "Mus og styreplate"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-#| msgid "Set your mouse preferences"
-msgid "Set your mouse and touchpad preferences"
-msgstr "Set opp innstillingane for mus og styreplate"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "Mouse Preferences"
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Større tekststorleik"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Mindre tekststorleik"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+#, fuzzy
+msgid "No input source selected"
+msgstr "Vel inndatakjelda som skal leggjast til"
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "Innstillingar"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
 msgstr "Eigenskapar for mus"
 
 #
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "General"
-msgstr "Allmennt"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Alternativ for tastaturutforming"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "_Right-handed"
-msgstr "_Høgrehendt"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Fjern"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "_Left-handed"
-msgstr "_Venstrehendt"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr "Vi_s kor peikaren er når Ctrl-tasten vert trykt ned"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-#| msgid "<b>Pointer Speed</b>"
-msgid "Pointer Speed"
-msgstr "Peikarfart"
-
-#
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "A_cceleration:"
-msgstr "A_ksellerasjon:"
-
-# TRN: Finn betre ord!
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "_Sensitivity:"
-msgstr "_Sensitivitet:"
-
-#. low sensitivity
-#. TRANSLATORS: secondary battery
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-#: ../panels/power/cc-power-panel.c:576
-msgid "Low"
-msgstr "Låg"
-
-#. high sensitivity
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-#| msgid "Right"
-msgid "High"
-msgstr "Høg"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-#| msgid "<b>Drag and Drop</b>"
-msgid "Drag and Drop"
-msgstr "Dra og slepp"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Thr_eshold:"
-msgstr "_Grense:"
-
-#. small threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-#: ../panels/universal-access/uap.ui.h:87
-msgid "Small"
-msgstr "Liten"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:21
-msgid "Drag Threshold"
-msgstr ""
-
-#. large threshold
-#: ../panels/mouse/gnome-mouse-properties.ui.h:23
-#: ../panels/universal-access/uap.ui.h:89
-msgid "Large"
-msgstr "Stor"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:24
-#| msgid "<b>Double-Click Timeout</b>"
-msgid "Double-Click Timeout"
-msgstr "Tidsgrense for dobbeltklikk"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:25
-msgid "_Timeout:"
-msgstr "_Tidsgrense:"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:27
-msgid "Double-click timeout"
-msgstr ""
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:29
-#| msgid ""
-#| "To test your double-click settings, try to double-click on the light bulb."
-msgid "To test your settings, try to double-click on the face."
-msgstr "Dobbeltklikk på fjeset for å testa innstillingane dine."
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:30
-msgid "Mouse"
-msgstr "Mus"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:31
-msgid "Disable _touchpad while typing"
-msgstr "Slå av _styreplata under skriving"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:32
-msgid "Enable _mouse clicks with touchpad"
-msgstr "Slå på museklikk med styreplata"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:33
-msgid "Scrolling"
-msgstr "Rulling"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:34
-#| msgid "Disabled"
-msgid "_Disabled"
-msgstr "_Av"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:35
-msgid "_Edge scrolling"
-msgstr "_Kantrulling"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:36
-msgid "Two-_finger scrolling"
-msgstr "Rulling med to _fingrar"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:37
-msgid "Enable h_orizontal scrolling"
-msgstr "Slå på _vassrett rulling"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:38
-msgid "Touchpad"
-msgstr "Styreplate"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/cc-network-panel.c:291
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/cc-network-panel.c:299
-msgid "This is not recommended for untrusted public networks."
-msgstr ""
-
-#. TRANSLATORS: this is when the access point is not listed
-#. * in the dropdown (or hidden) and the user has to select
-#. * another entry manually
-#: ../panels/network/cc-network-panel.c:1019
-msgctxt "Wireless access point"
-msgid "Other..."
-msgstr ""
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/cc-network-panel.c:1183
-#: ../panels/network/cc-network-panel.c:1590
-msgid "WEP"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:1187
-#: ../panels/network/cc-network-panel.c:1594
-msgid "WPA"
-msgstr ""
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/cc-network-panel.c:1191
-msgid "WPA2"
-msgstr ""
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/cc-network-panel.c:1196
-msgid "Enterprise"
-msgstr ""
-
-#
-#. TRANSLATORS: this no (!) WiFi security
-#: ../panels/network/cc-network-panel.c:1202
-#: ../panels/network/cc-network-panel.c:1585
-#: ../panels/universal-access/uap.ui.h:5 ../panels/wacom/cc-wacom-page.c:297
-#: ../panels/wacom/cc-wacom-page.c:314
-msgid "None"
-msgstr "Ingen"
-
-#: ../panels/network/cc-network-panel.c:1689
-msgid "Hotspot"
-msgstr ""
-
-#. Translators: network device speed
-#: ../panels/network/cc-network-panel.c:1696
-#, c-format
-msgid "%d Mb/s"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:2042 ../panels/network/network.ui.h:11
-msgid "IPv4 Address"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:2043 ../panels/network/network.ui.h:12
-msgid "IPv6 Address"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:2046
-#: ../panels/network/cc-network-panel.c:2049 ../panels/network/network.ui.h:27
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP-adresse"
-
-#: ../panels/network/cc-network-panel.c:2096
-#: ../panels/network/cc-network-panel.c:2471
-#, c-format
-msgid "%s VPN"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:2204
-msgid "Proxy"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:2278
-msgid "Network proxy"
-msgstr ""
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:2538
-msgid "The system network services are not compatible with this version."
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:2736
-#, c-format
-msgid ""
-"Network details for %s including password and any custom configuration will "
-"be lost"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:2746
-msgid "Forget"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3245
-msgid "Not connected to the internet."
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3246
-msgid "Create the hotspot anyway?"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3264
-#, c-format
-msgid "Disconnect from %s and create a new hotspot?"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3267
-msgid "This is your only connection to the internet."
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3285
-msgid "Create _Hotspot"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3345
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-
-#: ../panels/network/cc-network-panel.c:3348
-msgid "_Stop Hotspot"
-msgstr ""
-
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:3366
-msgid "Airplane Mode"
-msgstr ""
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-msgid "Network"
-msgstr ""
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Network settings"
-msgstr ""
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid "Network;Wireless;IP;LAN;Proxy;"
-msgstr ""
-
-#: ../panels/network/network.ui.h:1
-msgid "Select the interface to use for the new service"
-msgstr ""
-
-#: ../panels/network/network.ui.h:2
-msgid "Create..."
-msgstr ""
-
-#
-#: ../panels/network/network.ui.h:3
-msgid "Interface"
-msgstr "Grensesnitt"
-
-#: ../panels/network/network.ui.h:4
-msgid "VPN"
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
 msgstr ""
 
-#: ../panels/network/network.ui.h:5
-msgctxt "proxy method"
-msgid "None"
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
 
-#: ../panels/network/network.ui.h:6
-msgctxt "proxy method"
-msgid "Manual"
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
 msgstr ""
 
-#: ../panels/network/network.ui.h:7
-msgctxt "proxy method"
-msgid "Automatic"
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
 msgstr ""
 
-#: ../panels/network/network.ui.h:8
-msgid "Add Device"
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
 msgstr ""
 
-#: ../panels/network/network.ui.h:10
-msgid "Hardware Address"
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
 msgstr ""
 
-#: ../panels/network/network.ui.h:13
-msgid "Subnet Mask"
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 
-#: ../panels/network/network.ui.h:14
-msgid "Default Route"
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
 msgstr ""
 
-#: ../panels/network/network.ui.h:15
-msgid "DNS"
-msgstr ""
-
-#: ../panels/network/network.ui.h:16
-msgid "Device Off"
-msgstr ""
-
-#: ../panels/network/network.ui.h:17
-#: ../panels/region/gnome-region-panel.ui.h:26
-#| msgid "Options"
-msgid "_Options..."
-msgstr "_Innstillingar …"
-
-#: ../panels/network/network.ui.h:18
-msgid "Security"
-msgstr ""
-
-#: ../panels/network/network.ui.h:19
-msgid "_Network Name"
-msgstr ""
-
-#: ../panels/network/network.ui.h:20
-msgid "Network Name"
-msgstr ""
-
-#: ../panels/network/network.ui.h:21
-msgid "Security Key"
-msgstr ""
-
-#: ../panels/network/network.ui.h:22
-msgid "Forget Network"
-msgstr ""
-
-#: ../panels/network/network.ui.h:23
-msgid "_Use as Hotspot..."
-msgstr ""
-
-#: ../panels/network/network.ui.h:24
-msgid "_Stop Hotspot..."
-msgstr ""
-
-#: ../panels/network/network.ui.h:25
-msgid "IMEI"
-msgstr ""
-
-#: ../panels/network/network.ui.h:26
-msgid "Provider"
-msgstr ""
-
-#: ../panels/network/network.ui.h:28
-msgid "VPN Type"
-msgstr ""
-
-#: ../panels/network/network.ui.h:29
-msgid "Gateway"
-msgstr ""
-
-#: ../panels/network/network.ui.h:30
-msgid "Group Name"
-msgstr ""
-
-#: ../panels/network/network.ui.h:31
-msgid "Group Password"
-msgstr ""
-
-#: ../panels/network/network.ui.h:32
-msgid "Username"
-msgstr ""
-
-#: ../panels/network/network.ui.h:33
-msgid "Disable VPN"
-msgstr ""
-
-#: ../panels/network/network.ui.h:34
-msgid "_Configure..."
-msgstr ""
-
-#: ../panels/network/network.ui.h:35
-msgid "_Method"
-msgstr ""
-
-#: ../panels/network/network.ui.h:36
-msgid "_Configuration URL"
-msgstr ""
-
-#: ../panels/network/network.ui.h:37
-msgid "_HTTP Proxy"
-msgstr ""
-
-#: ../panels/network/network.ui.h:38
-msgid "H_TTPS Proxy"
-msgstr ""
-
-#: ../panels/network/network.ui.h:39
-msgid "_FTP Proxy"
-msgstr ""
-
-#: ../panels/network/network.ui.h:40
-msgid "_Socks Host"
-msgstr ""
-
-#: ../panels/network/network.ui.h:41
-msgid "HTTP Port"
-msgstr ""
-
-#: ../panels/network/network.ui.h:42
-msgid "HTTPS Port"
-msgstr ""
-
-#: ../panels/network/network.ui.h:43
-msgid "FTP Port"
-msgstr ""
-
-#: ../panels/network/network.ui.h:44
-msgid "Socks Port"
-msgstr ""
-
-#: ../panels/network/network.ui.h:45
-msgid "Apply system wide"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:83
-msgid "Wired"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:87
-msgid "Wireless"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:94
-msgid "Mobile broadband"
-msgstr ""
-
-#. TRANSLATORS: device type
-#: ../panels/network/panel-common.c:103
-msgid "Mesh"
-msgstr ""
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:162
-msgid "Ad-hoc"
-msgstr ""
-
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:166
-msgid "Infrastructure"
-msgstr ""
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:190 ../panels/network/panel-common.c:251
-msgid "Status unknown"
-msgstr ""
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Musetastar"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:194
-msgid "Unmanaged"
-msgstr ""
-
-#: ../panels/network/panel-common.c:199
-msgid "Firmware missing"
-msgstr ""
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+#, fuzzy
+msgid "Keyboard Shortcuts"
+msgstr "Snøggtastar"
 
-#: ../panels/network/panel-common.c:202
-msgid "Cable unplugged"
-msgstr ""
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Eigendefinerte snøggtastar"
 
-#: ../panels/network/panel-common.c:204
-msgid "Unavailable"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
 msgstr ""
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:208
-msgid "Disconnected"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
 msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:215 ../panels/network/panel-common.c:257
-msgid "Connecting"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
 msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
-msgid "Authentication required"
-msgstr ""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Snøggtastar"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
-msgid "Connected"
-msgstr ""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Snøggtast"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:227
-msgid "Disconnecting"
-msgstr ""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Eigendefinerte snøggtastar"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:231 ../panels/network/panel-common.c:269
-msgid "Connection failed"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:277
-msgid "Status unknown (missing)"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
 msgstr ""
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:273
-msgid "Not connected"
-msgstr "Ikkje tilkopla"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:305
-msgid "Error logging into the account"
-msgstr "Klarte ikkje logga inn på kontoen"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:351
-msgid "Expired credentials. Please log in again."
-msgstr "Påloggingsinformasjonen er utgått. Prøv å logga inn på nytt."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:354
-msgid "_Log In"
-msgstr "_Logg inn"
-
-#. translators: This is the title of the "Add Account" dialogue.
-#. * The title is not visible when using GNOME Shell
-#: ../panels/online-accounts/cc-online-accounts-panel.c:461
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "Add Account"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
 msgstr ""
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:466
-msgid "To add a new account, first select the account type"
-msgstr "Vel kontotype før du legg til ny konto"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:469
-msgid "Account Type:"
-msgstr "Kontotype:"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "_Add..."
-msgstr "_Legg til …"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:550
-msgid "Error creating account"
-msgstr "Klarte ikkje laga konto"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:584
-msgid "Error removing account"
-msgstr "Klarte ikkje fjerna konto"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:620
-msgid "Are you sure you want to remove the account?"
-msgstr "Vil du fjerna denne kontoen?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:622
-msgid "This will not remove the account on the server."
-msgstr "Dette vil ikkje fjerna kontoen på tenaren."
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:623
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Fjern"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Namn"
+
+#
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "K_ommando:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Snøggtast"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Snøggtast"
+
+#
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ingen"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Set til _standard"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatur"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Ingen program spelar eller tek opp lyd."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Mikrofonvolum"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Ingen program spelar eller tek opp lyd."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Utformingsinnstillingar"
+
+#
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Allmennt"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Venstre"
+
+#
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Høgre"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Skrivarinnstillingar"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Mus"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Peikarfart"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Rulling"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "A_ksellerasjon:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Styreplate"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Styreplate"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Slå av _styreplata under skriving"
+
+#
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "A_ksellerasjon:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "Rulling"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
+msgstr "Mus og styreplate"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Skjerm"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Dra for å endra primærskjerm"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Program"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Einingar"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Handling"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Innstillingar"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr ""
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Vis passord:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Vel frambringa passord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Vel frambringa passord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Nettverk"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Kor fort skrivemerket blinkar"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Namn:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "IP-adresse"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+#, fuzzy
+msgid "Manual"
+msgstr "Januar"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Av"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresse"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+#, fuzzy
+msgid "Automatic Routes"
+msgstr "Automatisk oppsett"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrisk"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+#, fuzzy
+msgid "Turn device off"
+msgstr "Slå på eller av:"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "%u aktiv"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adresse"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Nettverk"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr ""
+
+#: panels/network/network-vpn.ui:11
+#, fuzzy
+msgid "Turn VPN connection off"
+msgstr "Slå på eller av:"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "_Nettverkstid"
+
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Type operativsystem"
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Vis passord:"
+
+#: panels/network/network-wifi.ui:90
+#, fuzzy
+msgid "Turn Wi-Fi off"
+msgstr "Slå på eller av:"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Vis hjelpeval"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "Autentisering feila"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "Alle filer"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "Autentisering feila"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Vis passord:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Versjon %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Versjon %s"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "Autentisering feila"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "_Type:"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Standard"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "System"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "R_otering"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Lydeffektar"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Klarte ikkje lagra skjerminnstillingane"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Vel ein konto"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Nettkontoar"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "Manage online accounts"
-msgstr "Administrer nettkontoar"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
 
-#. Translators: those are keywords for the online-accounts control-center panel
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+#, fuzzy
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Nett;Web;Chat;Nettprat;Kalender;E-post;Kontakt;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Remove Account"
-msgstr ""
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Select an account"
-msgstr "Vel ein konto"
-
-#: ../panels/power/cc-power-panel.c:168
-#| msgid "Unknown"
-msgid "Unknown time"
-msgstr "Ukjend tid"
-
-#: ../panels/power/cc-power-panel.c:174
+#: panels/power/cc-battery-row.c:83
 #, c-format
-#| msgid "minutes"
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i minutt"
 msgstr[1] "%i minutt"
 
-#: ../panels/power/cc-power-panel.c:186
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i time"
 msgstr[1] "%i timar"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:194
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:195
-#| msgid "Short"
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "time"
 msgstr[1] "timar"
 
-#: ../panels/power/cc-power-panel.c:196
-#| msgid "minutes"
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minutt"
 msgstr[1] "minutt"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:239
-#, c-format
-msgid "Charging - %s until fully charged"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "minutt"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:247
-#, c-format
-msgid "Caution low battery, %s remaining"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "minutt"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:255
-#, c-format
-msgid "Using battery power - %s remaining"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "minutt"
 
-#. TRANSLATORS: primary battery
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:272 ../panels/power/cc-power-panel.c:564
-msgid "Charging"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "minutt"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:277
-msgid "Using battery power"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "minutt"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:281 ../panels/power/cc-power-panel.c:586
-msgid "Charging - fully charged"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "time"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:285 ../panels/power/cc-power-panel.c:590
-msgid "Empty"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "minutt"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:353
-#, c-format
-msgid "Caution low UPS, %s remaining"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "minutt"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:359
-#, c-format
-msgid "Using UPS power - %s remaining"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "minutt"
 
-#. TRANSLATORS: UPS battery
-#: ../panels/power/cc-power-panel.c:377
-msgid "Caution low UPS"
-msgstr ""
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "time"
 
-#. TRANSLATORS: UPS battery
-#: ../panels/power/cc-power-panel.c:382
-msgid "Using UPS power"
-msgstr ""
-
-#. TRANSLATORS: secondary battery is normally in the media bay
-#: ../panels/power/cc-power-panel.c:434
-msgid "Your secondary battery is fully charged"
-msgstr ""
-
-#. TRANSLATORS: secondary battery is normally in the media bay
-#: ../panels/power/cc-power-panel.c:438
-msgid "Your secondary battery is empty"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:521
-msgid "Wireless mouse"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:525
-msgid "Wireless keyboard"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:529
-msgid "Uninterruptible power supply"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:533
-msgid "Personal digital assistant"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:537
-msgid "Cellphone"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:541
-msgid "Media player"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:545
-msgid "Tablet"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:549
-msgid "Computer"
-msgstr ""
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:553
+#: panels/power/cc-power-panel.ui:58
 msgid "Battery"
 msgstr ""
 
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:571
-msgid "Caution"
-msgstr ""
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:581
-msgid "Good"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1090
-msgid "Tip:"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1091
-msgid "Brightness Settings"
-msgstr ""
-
-#: ../panels/power/cc-power-panel.c:1092
-msgid "affect how much power is used"
-msgstr ""
-
-#
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-#| msgid "Pointer"
-msgid "Power"
-msgstr "Straum"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Power management settings"
-msgstr "Innstillingar for straumhandtering"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid "Power;Sleep;Suspend;Hibernate;Battery;"
-msgstr ""
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr ""
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr ""
-
-#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
-msgid "5 minutes"
-msgstr ""
-
-#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:7
-msgid "10 minutes"
-msgstr ""
-
-#: ../panels/power/power.ui.h:5 ../panels/screen/screen.ui.h:8
-msgid "30 minutes"
-msgstr ""
-
-#: ../panels/power/power.ui.h:6 ../panels/screen/screen.ui.h:9
-msgid "1 hour"
-msgstr ""
-
-#: ../panels/power/power.ui.h:7
-msgid "Don't suspend"
-msgstr ""
-
-#: ../panels/power/power.ui.h:8
-msgid "Suspend"
-msgstr ""
-
-#: ../panels/power/power.ui.h:10
-msgid "When battery is present"
-msgstr ""
-
-#: ../panels/power/power.ui.h:11
-msgid "When battery is charging/in use"
-msgstr ""
-
-#: ../panels/power/power.ui.h:12 ../panels/screen/screen.ui.h:10
-msgid "Never"
-msgstr "Aldri"
-
-#: ../panels/power/power.ui.h:13
-msgid "On battery power"
-msgstr ""
-
-#: ../panels/power/power.ui.h:14
-msgid "When plugged in"
-msgstr ""
-
-#: ../panels/power/power.ui.h:15
-msgid "Suspend when inactive for"
-msgstr ""
-
-#: ../panels/power/power.ui.h:16
-msgid "When power is _critically low"
-msgstr ""
-
-#: ../panels/power/power.ui.h:17
-msgid "When the lid is closed"
-msgstr ""
-
-#: ../panels/power/power.ui.h:18
-msgid "Show battery status in the _menu bar"
-msgstr ""
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:541
-msgid "Low on toner"
-msgstr "Lite tonar att"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:543
-msgid "Out of toner"
-msgstr "Tom for tonar"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:546
-msgid "Low on developer"
-msgstr "Lite framkallingsvæske"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:549
-msgid "Out of developer"
-msgstr "Tom for framkallingsvæske"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:551
-msgid "Low on a marker supply"
-msgstr "Lite farge att"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:553
-msgid "Out of a marker supply"
-msgstr "Tom for ein farge"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:555
-msgid "Open cover"
-msgstr "Loket er ope"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:557
-msgid "Open door"
-msgstr "Loket er ope"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:559
-msgid "Low on paper"
-msgstr "Lite papir att"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:561
-msgid "Out of paper"
-msgstr "Tom for papir"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:563
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Fråkopla"
-
-#. Translators: Someone has paused the Printer
-#: ../panels/printers/cc-printers-panel.c:565
-msgctxt "printer state"
-msgid "Paused"
-msgstr "Sett på pause"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:567
-msgid "Waste receptacle almost full"
-msgstr "Bosmottaket er nesten fullt"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:569
-msgid "Waste receptacle full"
-msgstr "Bosmottaket er fullt"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:571
-msgid "The optical photo conductor is near end of life"
-msgstr "Bilettrommelen er snart oppbrukt"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:573
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Bilettrommelen fungerer ikkje lengre"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:748
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Klar"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:752
-msgctxt "printer state"
-msgid "Processing"
-msgstr "I arbeid"
-
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:756
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Stoppa"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:868
-msgid "Toner Level"
-msgstr "Tonarnivå"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:871
-msgid "Ink Level"
-msgstr "Blekknivå"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:874
-msgid "Supply Level"
-msgstr "Tilførslenivå"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:889
-#: ../panels/printers/cc-printers-panel.c:1284
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u aktiv"
-msgstr[1] "%u aktive"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:996
-msgid "No printers available"
-msgstr "Ingen skrivar tilgjengeleg"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/cc-printers-panel.c:1327
-msgctxt "print job"
-msgid "Pending"
-msgstr "Ventar"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/cc-printers-panel.c:1331
-msgctxt "print job"
-msgid "Held"
-msgstr "Halden att"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/cc-printers-panel.c:1335
-msgctxt "print job"
-msgid "Processing"
-msgstr "I arbeid"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/cc-printers-panel.c:1339
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Stoppa"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/cc-printers-panel.c:1343
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Avbrote"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/cc-printers-panel.c:1347
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Avbrote av feil"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/cc-printers-panel.c:1351
-msgctxt "print job"
-msgid "Completed"
-msgstr "Fullført"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/cc-printers-panel.c:1431
-msgid "Job Title"
-msgstr "Oppgåvenamn"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/cc-printers-panel.c:1440
-msgid "Job State"
-msgstr "Oppgåvestatus"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/cc-printers-panel.c:1446
-msgid "Time"
-msgstr "Tidspunkt"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:2068
-msgid "Failed to add new printer."
-msgstr "Klarte ikkje leggja til den nye skrivaren."
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2272
-#: ../panels/printers/cc-printers-panel.c:2286
-msgid "Test page"
-msgstr "Testside"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2535
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Klarte ikkje lasta grensesnitt: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:147
-msgid "Printers"
-msgstr "Skrivarar"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
-msgid "Change printer settings"
-msgstr "Endra skrivarinnstillingar"
-
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
-msgid "Printer;Queue;Print;Paper;Ink;Toner;"
-msgstr "Skrivar;Kø;Utskrift;Papir;Blekk;Tonar;"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "Legg til ny skrivar"
-
-#: ../panels/printers/new-printer-dialog.ui.h:2
-msgid "A_ddress:"
-msgstr "A_dresse:"
-
-#: ../panels/printers/new-printer-dialog.ui.h:3
-msgid "_Search by Address"
-msgstr "_Søk etter adresse"
-
-#: ../panels/printers/new-printer-dialog.ui.h:5
-#| msgid "_Add..."
-msgid "_Add"
-msgstr "_Legg til"
-
-#: ../panels/printers/pp-new-printer-dialog.c:651
-msgid "Getting devices..."
-msgstr "Hentar einingar …"
-
-#. Translators: No localy connected printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1234
-msgid "No local printers found"
-msgstr ""
-
-#. Translators: No network printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1247
-msgid "No network printers found"
-msgstr ""
-
-#: ../panels/printers/pp-new-printer-dialog.c:1339
-msgid ""
-"FirewallD is not running. Network printer detection needs services mdns, "
-"ipp, ipp-client and samba-client enabled on firewall."
-msgstr ""
-"FirewallD køyrer ikkje. For å kunna oppdaga nettverksskrivarar må tenestene "
-"mdns, ipp, ipp-client og samba-client vere slått på i brannmuren."
-
-#. Translators: Column of devices which can be installed
-#: ../panels/printers/pp-new-printer-dialog.c:1367
-#: ../panels/printers/pp-new-printer-dialog.c:1372
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
 msgid "Devices"
 msgstr "Einingar"
 
-#. Translators: Local means local printers
-#: ../panels/printers/pp-new-printer-dialog.c:1397
-msgctxt "printer type"
-msgid "Local"
-msgstr "Lokal"
+#
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Straum"
 
-#. Translators: Network means network printers
-#: ../panels/printers/pp-new-printer-dialog.c:1399
-msgctxt "printer type"
-msgid "Network"
-msgstr "Nettverk"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#. Translators: Device types column (network or local)
-#: ../panels/printers/pp-new-printer-dialog.c:1440
-msgid "Device types"
-msgstr "Einingstype"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Skrivarinnstillingar"
 
-#. Translators: Name of job which makes printer to autoconfigure itself
-#: ../panels/printers/pp-new-printer-dialog.c:1760
-msgid "Automatic configuration"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
 msgstr "Automatisk oppsett"
 
-#: ../panels/printers/pp-new-printer-dialog.c:1783
-msgid "Opening firewall for mDNS connections"
-msgstr "Opnar brannmur for mDNS-tilkoplingar"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Innstillingar for lysstyrke på skjerm og låsing"
 
-#: ../panels/printers/pp-new-printer-dialog.c:1792
-msgid "Opening firewall for Samba connections"
-msgstr "Opnar brannmur for Samba-tilkoplingar"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Skjerm"
 
-#: ../panels/printers/pp-new-printer-dialog.c:1801
-msgid "Opening firewall for IPP connections"
-msgstr "Opnar brannmur for IPP-tilkoplingar"
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:1
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Skjerm"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+#, fuzzy
+msgid "Automatic Suspend"
+msgstr "Automatisk oppsett"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Pause:"
+
+#
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Straum"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Skrivarar"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Skrivar;Kø;Utskrift;Papir;Blekk;Tonar;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "Lås opp"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Skrivarar"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
 msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "Tilførsle"
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Autentisering feila"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Plassering"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default"
-msgstr "_Standard"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Drivar"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "Oppgåver"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
 
-#. Tanslators: Switch to tab containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "_Show"
-msgstr "_Vis"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "_Søk etter adresse"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Vel"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "Autentisering feila"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Autentisering feila"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "Aktive utskriftsoppgåver"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Testside"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Skrivarinnstillingar"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Skrivarinnstillingar"
+
+#
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Set til _standard"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Aktive utskriftsoppgåver"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Modell"
 
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:15
-msgid "Print _Test Page"
-msgstr "Skriv ut _testside"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Blekknivå"
 
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:17
-msgid "_Options"
-msgstr "Innstillingar"
-
-#. Translators: Switch back to printer's info tab
-#: ../panels/printers/printers.ui.h:19
-msgid "_Back"
-msgstr "Til_bake"
-
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:21
-msgid "Active Print Jobs"
-msgstr "Aktive utskriftsoppgåver"
-
-#: ../panels/printers/printers.ui.h:22
-msgid "Resume Printing"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
 msgstr ""
 
-#: ../panels/printers/printers.ui.h:23
-msgid "Pause Printing"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
 msgstr ""
-
-#: ../panels/printers/printers.ui.h:24
-msgid "Cancel Print Job"
-msgstr ""
-
-#. Translators: This tab contains list of active print jobs of the selected printer
-#: ../panels/printers/printers.ui.h:26
-msgid "Printer Options"
-msgstr "Skrivarinnstillingar"
-
-#: ../panels/printers/printers.ui.h:27
-msgid "Add User"
-msgstr ""
-
-#: ../panels/printers/printers.ui.h:28
-msgid "Remove User"
-msgstr ""
-
-#: ../panels/printers/printers.ui.h:29
-msgid "Allowed users"
-msgstr "Brukarar med tilgang"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:31
-msgid "Add New Printer"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
 msgstr "Legg til ny skrivar"
 
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Endra skrivarinnstillingar"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Skrivarar"
+
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:33
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Utskriftstenesta er ikkje\n"
 "tilgjengeleg."
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
-msgid "Keyboard Layout"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid "Change your region and language settings"
-msgstr "Endra region- og språkinnstillingane dine"
-
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-msgid "Language;Layout;Keyboard;"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-formats.c:142
-msgid "Imperial"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-formats.c:144
-msgid "Metric"
-msgstr "Metrisk"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
-msgid "Choose a Layout"
-msgstr "Vel utforming"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
-msgid "Preview"
-msgstr "Førehandsvis"
-
-#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
-msgid "Select an input source to add"
-msgstr "Vel inndatakjelda som skal leggjast til"
-
-#
-#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
-msgid "Keyboard Layout Options"
-msgstr "Alternativ for tastaturutforming"
-
-#: ../panels/region/gnome-region-panel-system.c:420
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings."
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-system.c:425
-#: ../panels/region/gnome-region-panel.ui.h:32
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings. You may change the system settings to match "
-"yours."
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-system.c:428
-msgid "Copy Settings"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel-system.c:431
-#: ../panels/region/gnome-region-panel.ui.h:39
-msgid "Copy Settings..."
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:1
-msgid "Region and Language"
-msgstr "Region og språk"
-
-#: ../panels/region/gnome-region-panel.ui.h:2
-msgid ""
-"Select a display language (change will be applied next time you log in)"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:3
-msgid "Install languages..."
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:4
-msgid "Add Language"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:5
-msgid "Remove Language"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:6
-msgid "Language"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:7
-msgid "Select a region (change will be applied the next time you log in)"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:8
-msgid "Add Region"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:9
-msgid "Remove Region"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:10
-msgid "Dates"
-msgstr "Datoar"
-
-#: ../panels/region/gnome-region-panel.ui.h:11
-msgid "Times"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:12
-msgid "Numbers"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:13
-msgid "Currency"
-msgstr "Valutainnstillingar"
-
-#: ../panels/region/gnome-region-panel.ui.h:14
-msgid "Measurement"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:15
-msgid "Examples"
-msgstr ""
-
-#: ../panels/region/gnome-region-panel.ui.h:16
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:17
-msgid "Add Layout"
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:18
-msgid "Remove Layout"
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:19
-msgid "Move Up"
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:20
-msgid "Move Down"
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:21
-msgid "Preview Layout"
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:22
-msgid "Use the same layout for all windows"
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Førehandsvis"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datoar"
+
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "Dato og tid"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:23
-msgid "Allow different layouts for individual windows"
-msgstr "Tillat ulike utformingar for kvart vindauge"
-
-#: ../panels/region/gnome-region-panel.ui.h:24
-msgid "New windows use the default layout"
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:25
-msgid "New windows use the previous window's layout"
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
 msgstr ""
 
-#
-#: ../panels/region/gnome-region-panel.ui.h:27
-#| msgid "Keyboard Layout Options"
-msgid "View and edit keyboard layout options"
-msgstr "Vis og endra tastaturutformingsinnstillingar"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#
-#: ../panels/region/gnome-region-panel.ui.h:28
-msgid "Reset to De_faults"
-msgstr "Set til _standard"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:29
+#: panels/region/cc-region-panel.ui:45
 msgid ""
-"Replace the current keyboard layout settings with the\n"
-"default settings"
-msgstr ""
-"Byt ut gjeldande tastaturutformingsinnstillingar med standardinnstillingane"
-
-#: ../panels/region/gnome-region-panel.ui.h:31
-msgid "Layouts"
-msgstr "Utformingar"
-
-#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
-#: ../panels/region/gnome-region-panel.ui.h:34
-msgid "Display language:"
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:35
-msgid "Input source:"
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:36
-msgid "Format:"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Min konto"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:37
-msgid "Your settings"
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel.ui.h:38
-msgid "System settings"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Lås skjermen"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+#, fuzzy
+msgid "Region & Language"
+msgstr "Region og språk"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
 msgstr ""
 
-#: ../panels/region/gnome-region-panel-xkblt.c:210
-msgid "Layout"
-msgstr "Formgjeving"
-
-#: ../panels/region/gnome-region-panel-xkbot.c:229
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:586
-msgid "Default"
-msgstr "Standard"
-
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:1
-msgid "Brightness and Lock"
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
-msgid "Screen brightness and lock settings"
-msgstr "Innstillingar for lysstyrke på skjerm og låsing"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Vel korleis medium skal handsamast"
 
-#. Translators: those are keywords for the brightness and lock control-center panel
-#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
-msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:1
-msgid "Screen turns off"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:2
-msgid "30 seconds"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:3
-msgid "1 minute"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:4
-msgid "2 minutes"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+#, fuzzy
+msgid "_Other Media…"
+msgstr "_Andre medium …"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Aldri start eller spør kva for program skal starta når medium vert innsete"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Vel korleis andre medium skal handsamast"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "_Handling:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Type:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Flyttbart medium"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Endra tastaturinnstillingar"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:5
-msgid "3 minutes"
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Skjerm"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:11
-msgid "_Dim screen to save power"
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:12
-msgid "Brightness"
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:13
-msgid "_Turn screen off when inactive for:"
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:14
-msgid "_Lock screen after:"
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:15
-msgid "Require my password when waking from suspend"
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
 msgstr ""
 
-#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
-#: ../panels/screen/screen.ui.h:17
-msgid "Don't lock when at home"
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:18
-msgid "Locations..."
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Lås skjermen"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
 msgstr ""
 
-#: ../panels/screen/screen.ui.h:19
-msgid "Lock"
-msgstr "Lås"
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
 
-#
-#: ../panels/sound/applet-main.c:49 ../panels/sound-nua/applet-main.c:49
-msgid "Enable debugging code"
-msgstr "Aktiver feilsøkingsmodus"
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Skjerm"
 
-#
-#: ../panels/sound/applet-main.c:50 ../panels/sound-nua/applet-main.c:50
-#| msgid "Open with Default Application"
-msgid "Version of this application"
-msgstr "Versjon av dette programmet"
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
 
-#: ../panels/sound/applet-main.c:62 ../panels/sound-nua/applet-main.c:62
-msgid " — GNOME Volume Control Applet"
-msgstr " – GNOME panelprogram for volumkontroll"
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skjerm"
 
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
-#| msgid "UI Control"
-msgid "Volume Control"
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Systeminnstillingar"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Plassering"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Andre kontoar"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Plassering"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Program"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "_Søk etter adresse"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Nettverk"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+#, fuzzy
+msgid "Sharing"
+msgstr "Høyrsel"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
+msgstr "Høyrsel"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Fjern"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "Høyrsel"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "Volumkontroll"
 
-#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
-msgid "Show desktop volume control"
-msgstr "Vis volumkontroll for skrivebord"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-#: ../panels/sound-nua/data/gnome-sound-nua-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "Lyd"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-#: ../panels/sound-nua/data/gnome-sound-nua-panel.desktop.in.in.h:2
-msgid "Change sound volume and sound events"
-msgstr "Endra lydvolum og -hendingar"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-#: ../panels/sound-nua/data/gnome-sound-nua-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
 msgstr ""
-"Kort;Mikrofon;Volum;Feiding;Fading;Fade;Balanse;Blåtann;Bluetooth;Headset;Hov"
-"udsett;Hovudtelefonar;"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "Bjeff"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Ikkje tilkopla"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "Drypp"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "Glass"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr ""
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-#| msgid "Sound"
-msgid "Sonar"
-msgstr "Sonar"
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
 
-#: ../panels/sound/gvc-applet.c:270 ../panels/sound/gvc-mixer-dialog.c:1768
-#: ../panels/sound-nua/gvc-applet.c:270
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1761
-#| msgid "Mutt"
-msgid "Output"
-msgstr "Utdata"
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Autentisering feila"
 
-#: ../panels/sound/gvc-applet.c:272 ../panels/sound-nua/gvc-applet.c:272
-msgid "Sound Output Volume"
-msgstr "Volum for lydutdata"
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
 
-#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1809
-#: ../panels/sound-nua/gvc-applet.c:276
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1894
-msgid "Input"
-msgstr "Inndata"
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Namn"
 
-#: ../panels/sound/gvc-applet.c:278 ../panels/sound-nua/gvc-applet.c:278
-msgid "Microphone Volume"
-msgstr "Mikrofonvolum"
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
 
-#
-#: ../panels/sound/gvc-balance-bar.c:111
-#: ../panels/sound-nua/gvc-balance-bar.c:111
-#| msgid "Left"
-msgctxt "balance"
-msgid "Left"
-msgstr "Venstre"
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "_Slett fingeravtrykk"
 
-#
-#: ../panels/sound/gvc-balance-bar.c:112
-#: ../panels/sound-nua/gvc-balance-bar.c:112
-#| msgid "Right"
-msgctxt "balance"
-msgid "Right"
-msgstr "Høgre"
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:115
-#: ../panels/sound-nua/gvc-balance-bar.c:115
-#| msgid "Search"
-msgctxt "balance"
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "Medium og autokjør"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+#, fuzzy
+msgid "Enable or disable remote login"
+msgstr "Slå på _vassrett rulling"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Høyrsel"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Balanse:"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Feiding:"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Bak"
 
 #
-#: ../panels/sound/gvc-balance-bar.c:116
-#: ../panels/sound-nua/gvc-balance-bar.c:116
-#| msgid "Fonts"
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Framme"
 
-#
-#: ../panels/sound/gvc-balance-bar.c:119
-#: ../panels/sound-nua/gvc-balance-bar.c:119
-#| msgid "Minimize"
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Minimum"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:120
-#: ../panels/sound-nua/gvc-balance-bar.c:120
-#| msgid "Maximize"
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Maksimum"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-#: ../panels/sound-nua/gvc-balance-bar.c:295
-msgid "_Balance:"
-msgstr "_Balanse:"
-
-#: ../panels/sound/gvc-balance-bar.c:298
-#: ../panels/sound-nua/gvc-balance-bar.c:298
-#| msgid "_Name:"
-msgid "_Fade:"
-msgstr "_Feiding:"
-
-#: ../panels/sound/gvc-balance-bar.c:301
-#: ../panels/sound-nua/gvc-balance-bar.c:301
-msgid "_Subwoofer:"
-msgstr "_Basselement"
-
-#: ../panels/sound/gvc-channel-bar.c:603 ../panels/sound/gvc-channel-bar.c:612
-#: ../panels/sound-nua/gvc-channel-bar.c:603
-#: ../panels/sound-nua/gvc-channel-bar.c:612
-msgctxt "volume"
-msgid "100%"
-msgstr "100 %"
-
-#: ../panels/sound/gvc-channel-bar.c:607
-#: ../panels/sound-nua/gvc-channel-bar.c:607
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Uforsterka"
-
-#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:1622
-#: ../panels/sound-nua/gvc-combo-box.c:167
-#| msgid "_Mobile:"
-msgid "_Profile:"
-msgstr "_Profil:"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1094
-#: ../panels/sound-nua/gvc-mixer-control.c:1913
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u utgang"
-msgstr[1] "%u utgangar"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc-mixer-control.c:1104
-#: ../panels/sound-nua/gvc-mixer-control.c:1923
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u inngang"
-msgstr[1] "%u inngangar"
-
-#: ../panels/sound/gvc-mixer-control.c:1402
-#: ../panels/sound-nua/gvc-mixer-control.c:2440
-#| msgid "System"
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "Systemlydar"
 
-#: ../panels/sound/gvc-mixer-dialog.c:324
-#: ../panels/sound/gvc-mixer-dialog.c:635
-msgid "Co_nnector:"
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
 msgstr ""
 
-#: ../panels/sound/gvc-mixer-dialog.c:541
-#: ../panels/sound-nua/gvc-mixer-dialog.c:343
-msgid "Peak detect"
-msgstr "Oppdag topp"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Slå av lyd"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1497
-#: ../panels/sound/gvc-mixer-dialog.c:1710
-#: ../panels/sound/gvc-sound-theme-chooser.c:595
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1591
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:596
-#| msgid "Name:"
-msgid "Name"
-msgstr "Namn"
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Utdata"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1564
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1693
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "Høgtalartesting for %s"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1623
-msgid "_Test Speakers"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1754
-#: ../panels/sound-nua/gvc-mixer-dialog.c:2034
-msgid "_Output volume:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1773
-msgid "C_hoose a device for sound output:"
-msgstr "_Vel eining som lydutgang:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1798
-#: ../panels/sound/gvc-mixer-dialog.c:1927
-msgid "Settings for the selected device:"
-msgstr "Innstillingar for den valde eininga:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1816
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1941
-msgid "_Input volume:"
-msgstr ""
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Eining"
 
 #
-#: ../panels/sound/gvc-mixer-dialog.c:1839
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1974
-#| msgid "_Input boxes:"
-msgid "Input level:"
-msgstr "Nivå for innlyd:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1867
-msgid "C_hoose a device for sound input:"
-msgstr "_Vel eining som lydinngang:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1894
-msgid "Hardware"
-msgstr "Maskinvare"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1899
-msgid "C_hoose a device to configure:"
-msgstr "_Vel eining å setja opp:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1938
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1995
-msgid "Sound Effects"
-msgstr "Lydeffektar"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1945
-#: ../panels/sound-nua/gvc-mixer-dialog.c:2002
-msgid "_Alert volume:"
-msgstr ""
-
-#: ../panels/sound/gvc-mixer-dialog.c:1958
-#: ../panels/sound-nua/gvc-mixer-dialog.c:2015
-#| msgid "_Application font:"
-msgid "Applications"
-msgstr "Program"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1962
-#: ../panels/sound-nua/gvc-mixer-dialog.c:2019
-msgid "No application is currently playing or recording audio."
-msgstr "Ingen program spelar eller tek opp lyd."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:189
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:190
-msgid "Built-in"
-msgstr "Innebygd"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:455
-#: ../panels/sound/gvc-sound-theme-chooser.c:467
-#: ../panels/sound/gvc-sound-theme-chooser.c:479
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:456
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:468
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:480
-#| msgid "Mouse Preferences"
-msgid "Sound Preferences"
-msgstr "Lydinnstillingar"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:458
-#: ../panels/sound/gvc-sound-theme-chooser.c:469
-#: ../panels/sound/gvc-sound-theme-chooser.c:481
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:459
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:470
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:482
-msgid "Testing event sound"
-msgstr "Testar hendingslyd"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:586
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:587
-msgid "From theme"
-msgstr "Frå tema"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:770
-#: ../panels/sound-nua/gvc-sound-theme-chooser.c:782
-#| msgid "Choose a Layout"
-msgid "C_hoose an alert sound:"
-msgstr "_Vel varsellyd:"
-
-#: ../panels/sound/gvc-speaker-test.c:221
-#: ../panels/sound-nua/gvc-speaker-test.c:221
-msgid "Stop"
-msgstr "Stopp"
-
-#
-#: ../panels/sound/gvc-speaker-test.c:221
-#: ../panels/sound/gvc-speaker-test.c:333
-#: ../panels/sound-nua/gvc-speaker-test.c:221
-#: ../panels/sound-nua/gvc-speaker-test.c:333
-#| msgid "Text"
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Test"
 
-#: ../panels/sound/gvc-speaker-test.c:229
-#: ../panels/sound-nua/gvc-speaker-test.c:229
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Automatisk oppsett"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr ""
 
-#: ../panels/sound/gvc-stream-status-icon.c:236
-#: ../panels/sound-nua/gvc-stream-status-icon.c:235
-#, c-format
-msgid "Failed to start Sound Preferences: %s"
-msgstr "Starting av lydval feila: %s"
-
-#: ../panels/sound/gvc-stream-status-icon.c:262
-#: ../panels/sound-nua/gvc-stream-status-icon.c:261
-#| msgid "Mutt"
-msgid "_Mute"
-msgstr "_Demp"
-
-#: ../panels/sound/gvc-stream-status-icon.c:271
-#: ../panels/sound-nua/gvc-stream-status-icon.c:270
-#| msgid "Mouse Preferences"
-msgid "_Sound Preferences"
-msgstr "_Lydinnstillingar"
-
-#: ../panels/sound/gvc-stream-status-icon.c:416
-#: ../panels/sound-nua/gvc-stream-status-icon.c:415
-#| msgid "Multimedia"
-msgid "Muted"
-msgstr "Dempa"
-
-#: ../panels/sound/sound-theme-file-utils.c:292
-#: ../panels/sound-nua/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr "Sjølvvald"
-
-#: ../panels/universal-access/cc-ua-panel.c:522
-#: ../panels/universal-access/cc-ua-panel.c:528
-msgid "No shortcut set"
-msgstr ""
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Inndata"
 
 #
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-#| msgid "Appearance Preferences"
-msgid "Universal Access Preferences"
-msgstr "Innstillingar for tilgjenge"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Nivå for innlyd:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Høgare lydstyrke"
+
+#
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Testlyd"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Demp"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Lyd"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Endra lydvolum og -hendingar"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen "
-"Reader;text;font;size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
+"Kort;Mikrofon;Volum;Feiding;Fading;Fade;Balanse;Blåtann;Bluetooth;Headset;"
+"Hovudsett;Hovudtelefonar;"
 
-#
-#: ../panels/universal-access/uap.ui.h:1
-#| msgid "GNOME OnScreen Keyboard"
-msgid "On screen keyboard"
-msgstr "Tastatur på skjermen"
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
 
-#
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Dasher"
-msgstr "Dasher"
-
-#: ../panels/universal-access/uap.ui.h:3
-msgid "Nomon"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:4
-msgid "Caribou"
-msgstr "Reinsdyr"
-
-#: ../panels/universal-access/uap.ui.h:7
-#, no-c-format
-msgid "75%"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:8
-msgctxt "universal access, text size"
-msgid "Small"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:10
-#, no-c-format
-msgid "100%"
-msgstr "100 %"
-
-#: ../panels/universal-access/uap.ui.h:11
-msgctxt "universal access, text size"
-msgid "Normal"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:13
-#, no-c-format
-msgid "125%"
-msgstr "125 %"
-
-#: ../panels/universal-access/uap.ui.h:14
-msgctxt "universal access, text size"
-msgid "Large"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:16
-#, no-c-format
-msgid "150%"
-msgstr "150 %"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgctxt "universal access, text size"
-msgid "Larger"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "GOK"
-msgstr "GOK"
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "OnBoard"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Change contrast:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "_Contrast:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "_Text size:"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "Increase size:"
-msgstr "Auk storleik:"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Decrease size:"
-msgstr "Minsk storleik:"
-
-#. Translators: this refers to theme contrast and font size
-#: ../panels/universal-access/uap.ui.h:26
-msgctxt "universal access, seeing"
-msgid "Display"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Turn on or off:"
-msgstr "Slå på eller av:"
-
-#: ../panels/universal-access/uap.ui.h:28
-#| msgid "Zoom"
-msgid "Zoom in:"
-msgstr "Forstørr:"
-
-#: ../panels/universal-access/uap.ui.h:29
-#| msgid "Zoom"
-msgid "Zoom out:"
-msgstr "Forminsk:"
-
-#: ../panels/universal-access/uap.ui.h:30
-#| msgid "_Options..."
-msgid "Options..."
-msgstr "Innstillingar …"
-
-#. Translators: this refers to screen magnifier
-#: ../panels/universal-access/uap.ui.h:32
-msgctxt "universal access, seeing"
-msgid "Zoom"
-msgstr ""
-
-#
-#: ../panels/universal-access/uap.ui.h:33
-#| msgid "Linux Screen Reader"
-msgid "Screen Reader"
-msgstr "Skjermlesar"
-
-#
-#: ../panels/universal-access/uap.ui.h:34
-#| msgid "Beep when a key is pr_essed"
-msgid "Beep when Caps and Num Lock are used"
-msgstr "Pip når Caps Lock og Num Lock vert brukt"
-
-#: ../panels/universal-access/uap.ui.h:35
-msgid "Seeing"
-msgstr "Syn"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Use a visual indication when an alert sound occurs"
-msgstr "Bruk visuell indikasjon når varsellydar vert avspela"
-
-#: ../panels/universal-access/uap.ui.h:37
-msgid "_Test flash"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:38
-#| msgid "Flash _window titlebar"
-msgid "Flash the window title"
-msgstr "Blink tittellinja på vindauget"
-
-#: ../panels/universal-access/uap.ui.h:39
-#| msgid "Flash entire _screen"
-msgid "Flash the entire screen"
-msgstr "Lat heile skjermen blinke"
-
-#: ../panels/universal-access/uap.ui.h:40
-#| msgid "Visual"
-msgid "Visual Alerts"
-msgstr "Visuelle varslar"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "Display a textual description of speech and sounds"
-msgstr "Vis tekstskildring av tale og lydar."
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Closed Captioning"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
 msgstr "Undertekst"
 
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Hearing"
-msgstr "Høyrsel"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Namn:"
 
-#: ../panels/universal-access/uap.ui.h:45
-msgid "Screen keyboard"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:46
-#| msgid "A_ssistant:"
-msgid "Typing Assistant"
-msgstr "Skriveassistent"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "_Turn on accessibility features from the keyboard"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:48
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "Ser på rekkjefølgjer av valtastar som tastekombinasjonar"
-
-#: ../panels/universal-access/uap.ui.h:49
-msgid "_Disable if two keys are pressed together"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:50
-msgid "Beep when a _modifer key is pressed"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Eining"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:51
-#| msgid "<b>Sticky Keys</b>"
-msgid "Sticky Keys"
-msgstr "Seige tastar"
-
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "Set eit opphald mellom tastetrykk og når trykket vert godteke"
-
-#: ../panels/universal-access/uap.ui.h:53
-msgid "A_cceptance delay:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:56
-msgid "Slow keys typing delay"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Tilgjenge"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Hentar einingar …"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Blinkande skrivemerke"
 
 #
-#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
-#: ../panels/universal-access/uap.ui.h:60
-#| msgid "Beep when a key is pr_essed"
-msgid "Beep when a key is"
-msgstr "Pip når tast vert"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Skrivemerket _blinkar i tekstfelt"
 
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:62
-msgid "pressed"
-msgstr "trykt"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Fart:"
 
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:64
-msgid "accepted"
-msgstr "godkjent"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Kor fort skrivemerket blinkar"
 
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:66
-msgid "rejected"
-msgstr "avvist"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Blinkande skrivemerke"
 
-#: ../panels/universal-access/uap.ui.h:67
-#| msgid "<b>Slow Keys</b>"
-msgid "Slow Keys"
-msgstr "Trege tastar"
-
-#
-#: ../panels/universal-access/uap.ui.h:68
-#| msgid "_Ignore fast duplicate keypresses"
-msgid "Ignores fast duplicate keypresses"
-msgstr "Overser snøgge duplikate tastetrykk"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Acc_eptance delay:"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:70
-msgid "Bounce keys typing delay"
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Beep when a key is _rejected"
-msgstr ""
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "Simulert høgreklikk"
 
-#: ../panels/universal-access/uap.ui.h:72
-#| msgid "Mouse Keys"
-msgid "Bounce Keys"
-msgstr "Sprettetastar"
-
-#: ../panels/universal-access/uap.ui.h:73
-#| msgid "_Type to test settings:"
-msgid "Type here to test settings"
-msgstr "Skriv for å testa innstillingane"
-
-#: ../panels/universal-access/uap.ui.h:76
-msgid "Control the pointer using the keypad"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:77
-msgid "Mouse Keys"
-msgstr "Musetastar"
-
-#: ../panels/universal-access/uap.ui.h:78
-msgid "Control the pointer using the video camera."
-msgstr "Styr musepeikaren med videokameraet."
-
-#: ../panels/universal-access/uap.ui.h:79
-#| msgid "Mouse"
-msgid "Video Mouse"
-msgstr "Videomus"
-
-#: ../panels/universal-access/uap.ui.h:80
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:81
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:82
-#| msgid "<b>Simulated Secondary Click</b>"
-msgid "Simulated Secondary Click"
-msgstr "Simulert høgreklikk"
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lang"
 
-#: ../panels/universal-access/uap.ui.h:83
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr ""
 
 #
-#: ../panels/universal-access/uap.ui.h:84
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "Paus_e:"
 
-#: ../panels/universal-access/uap.ui.h:85
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:90
-msgid "Hover Click"
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Liten"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Stor"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repeterande tastar"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Tastetrykk vert _repeterte når tasten vert halden nede"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Tasterepetisjonsrate"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Tasterepetisjonsrate"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Skriveassistent"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Seige tastar"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Ser på rekkjefølgjer av valtastar som tastekombinasjonar"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:91
-msgid "Mouse Settings"
+#
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pip når tast vert"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Trege tastar"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Set eit opphald mellom tastetrykk og når trykket vert godteke"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:92
-msgid "Pointing and Clicking"
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Pip når tast vert"
+
+#
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Pip når tast vert"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Sprettetastar"
+
+#
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Overser snøgge duplikate tastetrykk"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lang"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Syn"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "Slå av/på kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Stor"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Skjermlesar"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Sprettetastar"
+
+#
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pip når Caps Lock og Num Lock vert brukt"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Høyrsel"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Visuelle varslar"
+
+#
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Tastatur på skjermen"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Repeterande tastar"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Blinkande skrivemerke"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
+msgstr "Skriveassistent"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
 msgstr "Peik og klikk"
 
-#: ../panels/universal-access/uap.ui.h:93
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Musetastar"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Plassering"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "Tidsgrense for dobbeltklikk"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "Tidsgrense for dobbeltklikk"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Visuelle varslar"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+#, fuzzy
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Bruk visuell indikasjon når varsellydar vert avspela"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Lat heile skjermen blinke"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Lat heile skjermen blinke"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Brukarar med tilgang"
+
+#
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Skjermlesar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "Gjer større"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "Lydeffektar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr ""
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Låg"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+#, fuzzy
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Høg"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:94
-msgctxt "universal access, contrast"
-msgid "Normal"
-msgstr ""
-
-#: ../panels/universal-access/uap.ui.h:95
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:96
-msgctxt "universal access, contrast"
-msgid "High/Inverse"
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "Lydeffektar"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.c:334
-msgid "1/4 Screen"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.c:335
-msgid "1/2 Screen"
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.c:336
-msgid "3/4 Screen"
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:1
-msgid "Zoom Options"
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:2
-msgid "Magnification:"
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:3
-msgid "Follow mouse cursor"
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:4
-msgid "Screen part:"
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:5
-msgid "Magnifier extends outside of screen"
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:6
-msgid "Keep magnifier cursor centered"
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Magnifier cursor pushes contents around"
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnifier cursor moves with contents"
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Magnifier Position:"
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Thickness:"
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Slett filer"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
 msgstr ""
 
-#. short delay
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Thin"
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
 msgstr ""
 
-#. long delay
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Thick"
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:15
-msgid "Length:"
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
 msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:16
-msgid "Color:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Crosshairs:"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:18
-msgid "Overlaps mouse cursor"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:19
-msgid "Full Screen"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Top Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:21
-msgid "Bottom Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Left Half"
-msgstr ""
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Right Half"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:35
-#| msgid "Standard XTerminal"
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Standard"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:37
-#| msgid "Terminator"
-msgctxt "Account type"
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
 msgid "Administrator"
 msgstr "Administrator"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-msgid "_Username"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-#| msgid "Create New Location"
-msgid "Create new account"
-msgstr "Lag ny konto"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "_Full name"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "_Account Type"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#| msgid "C_reate"
-msgid "Cr_eate"
-msgstr "_Lag"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "Venstre tommel"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "Venstre langfinger"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "Venstre ringfinger"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "Venstre litlefinger"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-#| msgid "Right"
-msgid "Right thumb"
-msgstr "Høgre tommel"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "Høgre langfinger"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "Høgre ringfinger"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "Høgre litlefinger"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:706
-msgid "Enable Fingerprint Login"
-msgstr "Slå på innlogging via fingeravtrykk"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr ""
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+#: panels/user-accounts/cc-add-user-dialog.ui:132
 msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"Fingeravtrykket ditt vart lagra. Du skal no kunne logga inn ved hjelp av "
-"fingeravtrykklesaren din."
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-#| msgid "seconds"
-msgid "User Accounts"
-msgstr "Brukarkontoar"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users"
-msgstr "Legg til eller fjern brukarar"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Innlogging;Namn;Fingeravtrykk;Personbilete;Logo;Fjes;Passord;"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-#| msgid "_New password:"
-msgid "Set a password now"
-msgstr "Set passord no"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-msgid "Choose password at next login"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
 msgstr "Vel passord under neste innlogging"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Log in without a password"
-msgstr "Logg inn utan passord"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Set passord no"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "Disable this account"
-msgstr "Slå av denne kontoen"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Enable this account"
-msgstr "Slå på denne kontoen"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "_Hint"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
 msgstr ""
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Slå på innlogging via fingeravtrykk"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Fråkopla"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
-"This hint may be displayed at the login screen.  It will be visible to all "
-"users of this system.  Do <b>not</b> include the password here."
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
 msgstr ""
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "C_onfirm password"
-msgstr ""
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Vel eit språk"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-msgid "_New password"
-msgstr ""
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Slå på innlogging via fingeravtrykk"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-#| msgid "Change password"
-msgid "Choose a generated password"
-msgstr "Vel frambringa passord"
-
-#
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-#| msgid "Filter"
-msgid "Fair"
-msgstr "Rimeleg"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-msgid "Current _password"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid "_Action"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-msgid "Changing password for"
-msgstr ""
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:15
-#| msgid "_New password:"
-msgid "_Show password"
-msgstr "_Vis passord:"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:16
-msgid "How to choose a strong password"
-msgstr "Korleis velja eit sterkt passord"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:17
-#| msgid "Change set"
-msgid "Ch_ange"
-msgstr "_Endra"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-msgid "Changing photo for:"
-msgstr "Endrar bilete til:"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
-msgid ""
-"Choose a picture that will be shown at the login screen for this account."
-msgstr "Vel bilete som vil visast på innloggingskjermen for denne kontoen."
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-#| msgid "Galeon"
-msgid "Gallery"
-msgstr "Galleri"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-#| msgid "Take a break!"
-msgid "Take a photograph"
-msgstr "Ta fotografi"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-#| msgid "Web Browser"
-msgid "Browse"
-msgstr "Bla gjennom"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr "Fotograf"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-#: ../panels/user-accounts/um-photo-dialog.c:98
-#| msgid "_Select"
-msgid "Select"
-msgstr "Vel"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Account Information"
-msgstr "Kontoinformasjon"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Add User Account"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Remove User Account"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Account _type"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "Login Options"
-msgstr "Innloggingsinnstillingar"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "_Password"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "A_utomatic Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "_Fingerprint Login"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "User Icon"
-msgstr ""
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "_Language"
-msgstr ""
-
-#: ../panels/user-accounts/run-passwd.c:426
-#| msgid "Authenticated!"
-msgid "Authentication failed"
-msgstr "Autentisering feila"
-
-#: ../panels/user-accounts/run-passwd.c:506
-#: ../panels/user-accounts/um-password-dialog.c:376
-#, c-format
-#| msgid "The password is too short."
-msgid "The new password is too short"
-msgstr "Det nye passordet er for kort"
-
-#: ../panels/user-accounts/run-passwd.c:512
-#, c-format
-#| msgid "The password is too simple."
-msgid "The new password is too simple"
-msgstr "Det nye passordet er for enkelt"
-
-#: ../panels/user-accounts/run-passwd.c:518
-#, c-format
-#| msgid "The old and new passwords are too similar."
-msgid "The old and new passwords are too similar"
-msgstr "Gammalt og nytt passord er for like"
-
-#: ../panels/user-accounts/run-passwd.c:521
-#, c-format
-#| msgid "The two passwords are not equal."
-msgid "The new password has already been used recently."
-msgstr "Det nye passordet har nyleg vore brukt."
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-#| msgid "The new password must contain numeric or special character(s)."
-msgid "The new password must contain numeric or special characters"
-msgstr "Det nye passordet må innehalda tal eller spesialteikn."
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-#| msgid "The old and new passwords are the same."
-msgid "The old and new passwords are the same"
-msgstr "Gammalt og nytt passord er det same."
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-#| msgid ""
-#| "Your password has been changed since you initially authenticated! Please "
-#| "re-authenticate."
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-"Passordet ditt har vorte endra sidan du autentiserte første gong. Du må "
-"autentisera deg på nytt."
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-#| msgid "The new password must contain numeric or special character(s)."
-msgid "The new password does not contain enough different characters"
-msgstr "Det nye passordet inneheld ikkje mange nok forskjellege teikn."
-
-#: ../panels/user-accounts/run-passwd.c:540
-#, c-format
-#| msgid "Unknown"
-msgid "Unknown error"
-msgstr "Ukjend feil"
-
-#: ../panels/user-accounts/um-account-dialog.c:73
-#| msgid "Failed to create temporary directory"
-msgid "Failed to create user"
-msgstr "Laging av ny brukar feila"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"Du har ikkje løyve til å opna eininga. Kontakt systemadministratoren."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "Eininga er alt i bruk."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:143
-#| msgid "An internal error occured"
-msgid "An internal error occurred."
-msgstr "Ein intern feil har oppstått."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:219
-#: ../panels/user-accounts/um-fingerprint-dialog.c:220
-#| msgid "Disabled"
-msgid "Enabled"
-msgstr "På"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:268
-msgid "Delete registered fingerprints?"
-msgstr "Slett registrerte fingeravtrykk?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:272
-msgid "_Delete Fingerprints"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
 msgstr "_Slett fingeravtrykk"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:279
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -4348,763 +4571,1932 @@ msgstr ""
 "Vil du sletta registrerte fingeravtrykk slik at innlogging via fingeravtrykk "
 "vert avslått?"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:455
-#| msgid "None"
-msgid "Done!"
-msgstr "Ferdig!"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:516
-#: ../panels/user-accounts/um-fingerprint-dialog.c:558
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "Klarte ikkje opna eininga «%s»"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Slå på innlogging via fingeravtrykk"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:603
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "Klarte ikkje starta innlesing av fingeravtrykk på eining «%s»"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:655
-#| msgid "Could not load the main interface"
-msgid "Could not access any fingerprint readers"
-msgstr "Klarte ikkje opna fingeravtrykklesar"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Slå på innlogging via fingeravtrykk"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:656
-msgid "Please contact your system administrator for help."
-msgstr "Kontakt systemadministratoren for å få hjelp."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "_Vel eining å setja opp:"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#. 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:740
-#, c-format
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Slå på innlogging via fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"For å slå på innlogging via fingeravtrykk må du lagra eitt fingeravtrykk ved "
-"å bruka eininga «%s»"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:747
-msgid "Selecting finger"
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
 msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:748
-msgid "Enrolling fingerprints"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Slett fingeravtrykk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Slå på innlogging via fingeravtrykk"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Førre spor"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
 msgstr ""
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:749
-msgid "Summary"
-msgstr ""
-
-#: ../panels/user-accounts/um-password-dialog.c:180
-msgid "More choices..."
-msgstr "Fleire val …"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-msgid "Please choose another password."
-msgstr "Vel eit anna passord."
-
-#: ../panels/user-accounts/um-password-dialog.c:295
-#| msgid "Please type your password in the <b>New password</b> field."
-msgid "Please type your current password again."
-msgstr "Skriv inn gjeldande passord omatt."
-
-#: ../panels/user-accounts/um-password-dialog.c:301
-#| msgid "Your password has been changed."
-msgid "Password could not be changed"
-msgstr "Passordet kunne ikkje endrast"
-
-#: ../panels/user-accounts/um-password-dialog.c:373
-#| msgid "_Retype new password:"
-msgid "You need to enter a new password"
-msgstr "Du må skriva inn eit nytt passord"
-
-#: ../panels/user-accounts/um-password-dialog.c:382
-msgid "You need to confirm the password"
-msgstr "Du må bekrefta passordet"
-
-#: ../panels/user-accounts/um-password-dialog.c:385
-#| msgid "The password is too short."
-msgid "The passwords do not match"
-msgstr "Passorda er ikkje like"
-
-#: ../panels/user-accounts/um-password-dialog.c:391
-msgid "You need to enter your current password"
-msgstr "Du må skriva inn ditt gjeldande passord"
-
-#: ../panels/user-accounts/um-password-dialog.c:394
-#| msgid "That password was incorrect."
-msgid "The current password is not correct"
-msgstr "Det gjeldande passordet er ikkje riktig"
-
-#: ../panels/user-accounts/um-password-dialog.c:467
-#: ../panels/user-accounts/um-password-dialog.c:731
-msgctxt "Password strength"
-msgid "Too short"
-msgstr "For kort"
-
-#: ../panels/user-accounts/um-password-dialog.c:470
-#: ../panels/user-accounts/um-password-dialog.c:732
-msgctxt "Password strength"
-msgid "Weak"
-msgstr "Svakt"
-
-#
-#: ../panels/user-accounts/um-password-dialog.c:472
-#: ../panels/user-accounts/um-password-dialog.c:733
-#| msgid "Filter"
-msgctxt "Password strength"
-msgid "Fair"
-msgstr "Greitt"
-
-#: ../panels/user-accounts/um-password-dialog.c:474
-#: ../panels/user-accounts/um-password-dialog.c:734
-msgctxt "Password strength"
-msgid "Good"
-msgstr "Godt"
-
-#: ../panels/user-accounts/um-password-dialog.c:476
-#: ../panels/user-accounts/um-password-dialog.c:735
-#| msgid "Scrolling"
-msgctxt "Password strength"
-msgid "Strong"
-msgstr "Sterkt"
-
-#: ../panels/user-accounts/um-password-dialog.c:515
-msgid "Passwords do not match"
-msgstr "Passord er ikkje like"
-
-#: ../panels/user-accounts/um-password-dialog.c:541
-#| msgid "Change password"
-msgid "Wrong password"
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
 msgstr "Svakt passord"
 
-#: ../panels/user-accounts/um-photo-dialog.c:443
-#| msgid "Disabled"
-msgid "Disable image"
-msgstr "Slå av bilete"
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Endra"
 
-#: ../panels/user-accounts/um-photo-dialog.c:461
-msgid "Take a photo..."
-msgstr "Ta bilete …"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Svakt passord"
 
-#: ../panels/user-accounts/um-photo-dialog.c:479
-msgid "Browse for more pictures..."
-msgstr "Bla gjennom for fleire bilete …"
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Vis passord:"
 
-#: ../panels/user-accounts/um-photo-dialog.c:704
-#, c-format
-msgid "Used by %s"
-msgstr "Brukt av %s"
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Svakt passord"
 
-#: ../panels/user-accounts/um-user-manager.c:463
-#, c-format
-#| msgid "The location already exists."
-msgid "A user with name '%s' already exists."
-msgstr "Brukar med namnet «%s» finst alt."
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Passorda er ikkje like"
 
-#: ../panels/user-accounts/um-user-manager.c:569
-msgid "This user does not exist."
-msgstr "Denne brukaren finst ikkje."
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "Vel passord under neste innlogging"
 
-#: ../panels/user-accounts/um-user-panel.c:355
-msgid "Failed to delete user"
-msgstr "Sletting av brukar feila"
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Set passord no"
 
-#: ../panels/user-accounts/um-user-panel.c:415
-msgid "You cannot delete your own account."
-msgstr "Du kan ikkje sletta din eigen konto"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:424
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s er fortset logga inn"
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:428
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "Kontotype:"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
-"Sletting av brukar medan dei er logga inn kan etterlata systemet i ein "
-"inkonsekvent tilstand."
 
-#: ../panels/user-accounts/um-user-panel.c:437
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "Vil du behalda filene til «%s»?"
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:441
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Fjern bakgrunn"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+#, fuzzy
+msgid "Add or remove users and change your password"
+msgstr "Legg til eller fjern brukarar"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"Det er mogleg å behalda heimemappa, e-postkøa og mellombels filer etter "
-"sletting av brukarkonto."
 
-#: ../panels/user-accounts/um-user-panel.c:444
-#| msgid "_Delete Fingerprints"
-msgid "_Delete Files"
-msgstr "_Slett filer"
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:445
-#| msgid "All Files"
-msgid "_Keep Files"
-msgstr "_Behald filer"
+#: panels/user-accounts/data/join-dialog.ui:59
+#, fuzzy
+msgid "Domain Administrator Login"
+msgstr "Administrator"
 
-#: ../panels/user-accounts/um-user-panel.c:497
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Deaktivert konto"
-
-#: ../panels/user-accounts/um-user-panel.c:505
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Å verta sette under neste innlogging"
-
-#
-#: ../panels/user-accounts/um-user-panel.c:508
-#| msgid "None"
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ingen"
-
-#: ../panels/user-accounts/um-user-panel.c:860
-msgid "Failed to contact the accounts service"
-msgstr "Å få kontakt med kontotenesta feila"
-
-#: ../panels/user-accounts/um-user-panel.c:862
-#| msgid "Please make sure that the applet is properly installed"
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Kontroller at kontotenesta er installert og slått på."
-
-#: ../panels/user-accounts/um-user-panel.c:902
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"For å gjera endringar,\n"
-"trykk på *-ikonet først"
-
-#: ../panels/user-accounts/um-user-panel.c:940
-msgid "Create a user account"
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:951
-#: ../panels/user-accounts/um-user-panel.c:1241
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
+#: panels/user-accounts/data/join-dialog.ui:112
+#, fuzzy
+msgid "Administrator _Name"
+msgstr "Administrator"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+#, fuzzy
+msgid "Administrator Password"
+msgstr "Administrator"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+#, fuzzy
+msgid "Manage user accounts"
+msgstr "Administrer nettkontoar"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
 msgstr ""
 
-#: ../panels/user-accounts/um-user-panel.c:960
-msgid "Delete the selected user account"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:972
-#: ../panels/user-accounts/um-user-panel.c:1246
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-
-#: ../panels/user-accounts/um-user-panel.c:1149
-#| msgid "By _country"
-msgid "My Account"
-msgstr "Min konto"
-
-#: ../panels/user-accounts/um-user-panel.c:1159
-msgid "Other Accounts"
-msgstr "Andre kontoar"
-
-#: ../panels/user-accounts/um-utils.c:512
-#, c-format
-msgid "A user with the username '%s' already exists"
-msgstr "Brukar med brukarnamnet «%s» finst alt"
-
-#: ../panels/user-accounts/um-utils.c:516
-#, c-format
-#| msgid "The password is too short."
-msgid "The username is too long"
-msgstr "Brukarnamnet er for langt"
-
-#: ../panels/user-accounts/um-utils.c:519
-msgid "The username cannot start with a '-'"
-msgstr "Brukarnamnet kan ikkje starta med «-»"
-
-#: ../panels/user-accounts/um-utils.c:522
-msgid ""
-"The username must only consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-msgid "Wacom Graphics Tablet"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set your Wacom tablet preferences"
-msgstr ""
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "No tablet detected"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Map to Monitor..."
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map Buttons..."
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate..."
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Tracking Mode"
-msgstr ""
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Left-Handed Orientation"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr ""
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
-msgid "Tip Pressure Feel"
-msgstr ""
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr ""
 
-#: ../panels/wacom/button-mapping.ui.h:2
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr ""
 
-#: ../panels/wacom/gsd-wacom-device.c:909
-#, c-format
-msgid "Left Ring Mode #%d"
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"For å endra ein snarveg, trykk på den tilhøyrande rada og hald nede "
+"tastekombinasjonen, eller trykk slettetasten for å fjerna den."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
 msgstr ""
 
-#: ../panels/wacom/gsd-wacom-device.c:916
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:944
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:951
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:966
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:968
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:971
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:973
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:978
-#, c-format
-msgid "Mode Switch #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1050
-#, c-format
-msgid "Left Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1053
-#, c-format
-msgid "Right Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1056
-#, c-format
-msgid "Top Button #%d"
-msgstr ""
-
-#: ../panels/wacom/gsd-wacom-device.c:1059
-#, c-format
-msgid "Bottom Button #%d"
-msgstr ""
-
-#. Text printed on screen
-#: ../panels/wacom/calibrator/gui_gtk.c:70
-msgid "Screen Calibration"
-msgstr ""
-
-#: ../panels/wacom/calibrator/gui_gtk.c:71
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
 
-#: ../panels/wacom/calibrator/gui_gtk.c:271
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-nav-button.c:89
-#, c-format
-msgid "%d of %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:235
-msgid "Output:"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
 msgstr ""
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:248
-msgid "Map to single monitor"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-stylus-page.c:376
-#: ../panels/wacom/cc-wacom-page.c:561
-msgid "Button"
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-page.c:279
-msgid "Switch Modes"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-page.c:526
-msgid "Up"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Skjerm"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-page.c:526
-msgid "Down"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
-#: ../panels/wacom/cc-wacom-page.c:681
-msgid "Display Mapping"
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
 msgstr ""
 
-#: ../shell/control-center.c:58
-msgid "Enable verbose mode"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
 msgstr ""
 
-#: ../shell/control-center.c:59
-msgid "Show the overview"
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr ""
 
-#: ../shell/control-center.c:60 ../shell/control-center.c:61
-#: ../shell/control-center.c:62
-msgid "Show help options"
-msgstr "Vis hjelpeval"
-
-#: ../shell/control-center.c:63
-msgid "Panel to display"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
 msgstr ""
 
-#: ../shell/control-center.c:85
-msgid "- System Settings"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
 msgstr ""
 
-#: ../shell/control-center.c:93
-#, c-format
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Formgjeving"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
 msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Simulert høgreklikk"
+
+#: panels/windows/cc-windows-panel.ui:89
+msgid "Windows Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Lite tonar att"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Simulert høgreklikk"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "_Legg til"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_Nettverkstid"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Nettverk"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Einingstype"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_Nettverkstid"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Nettverk"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Avbrote"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Lås"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr ""
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Nettverk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Nettverk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Lås"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "_Endra"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Nettverk"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "_Alle innstillingar"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
 msgstr ""
 
 #
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Kontrollsenter"
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Allmennt"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
-msgid "System Settings"
-msgstr "Systeminnstillingar"
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Søk"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Avbrote"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr ""
 
-#: ../panels/sound-nua/gvc-channel-bar.c:901
-#| msgid "Mutt"
-msgid "Mute"
-msgstr "Demp"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
 
-#: ../panels/sound-nua/gvc-mixer-dialog.c:777
-#: ../panels/sound-nua/gvc-mixer-dialog.c:950
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
-msgid "Settings for %s"
-msgstr ""
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u utgang"
+msgstr[1] "%u utgangar"
 
-#: ../panels/sound-nua/gvc-mixer-dialog.c:806
-#: ../panels/sound-nua/gvc-mixer-dialog.c:962
-msgid "Mode:"
-msgstr ""
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u inngang"
+msgstr[1] "%u inngangar"
 
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1766
-msgid "Play sound through"
-msgstr ""
+#~| msgid "_Title:"
+#~ msgid "Tile"
+#~ msgstr "Tittel"
 
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1791
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1923
-msgid "Settings for the selected device"
-msgstr ""
+#~| msgid "Pointer"
+#~ msgid "Center"
+#~ msgstr "Midten"
 
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1864
-msgid "Test:"
-msgstr ""
+#~| msgid "_Full"
+#~ msgid "Fill"
+#~ msgstr "Fyll"
+
+#~ msgid "Span"
+#~ msgstr "Spennvidd"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Vert endra heile dagen"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "Legg til bakgrunn"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Vassrett fargeovergang"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Loddrett fargeovergang"
+
+#~ msgid "Solid Color"
+#~ msgstr "Einsfarga"
+
+#~ msgid "multiple sizes"
+#~ msgstr "fleire storleikar"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~| msgid "Apply Background"
+#~ msgid "No Desktop Background"
+#~ msgstr "Ingen skrivebordsbakgrunn"
+
+#~ msgid "Pictures Folder"
+#~ msgstr "Biletmappe"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "Fargar og fargeovergangar"
+
+#~ msgid "United States"
+#~ msgstr "USA"
+
+#~ msgid "Germany"
+#~ msgstr "Tyskland"
+
+#~ msgid "France"
+#~ msgstr "Frankrike"
+
+#~ msgid "Spain"
+#~ msgstr "Spania"
+
+#~ msgid "China"
+#~ msgstr "Kina"
+
+#~ msgid "Select a region"
+#~ msgstr "Vel ein region"
+
+#~ msgid "Unspecified"
+#~ msgstr "Uspesifisert"
+
+#~ msgid "_Region:"
+#~ msgstr "_Region:"
+
+#~ msgid "_City:"
+#~ msgstr "_By:"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Still klokka ein time fram."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Still klokka ein time tilbake."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Still klokka eitt minutt fram."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Still klokka eitt minutt tilbake."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Byt mellom a.m. og p.m."
+
+#~ msgid "24-hour"
+#~ msgstr "24-timar"
+
+#~ msgid "AM/PM"
+#~ msgstr "a.m./p.m."
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Panel for innstillingar til dato og tid"
+
+#, c-format
+#~| msgid "%d x %d"
+#~ msgid "%d x %d (%s)"
+#~ msgstr "%d × %d (%s)"
+
+#, c-format
+#~ msgid "%d x %d"
+#~ msgstr "%d × %d"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "Vel skjermen du vil endra. Drag den for å endra plasseringa."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %H.%M"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "Klarte ikkje oppdaga skjermar"
+
+#~| msgid "Change screen resolution"
+#~ msgid "Could not get screen information"
+#~ msgstr "Klarte ikkje få informasjon om skjermen"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Merk: kan avgrensa innstillingane for oppløysing"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "_Finn skjermar"
+
+#, c-format
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown"
+#~ msgstr "Ukjend"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-bit"
+
+#~ msgid "Unknown model"
+#~ msgstr "Ukjend modell"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "Neste innlogging vil prøva å bruka standard brukaroppleving."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "Neste innlogging vil bruka reserveløysing for grafikkort som ikkje er "
+#~ "støtta."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Reserveløysing"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Spør etter kva som skal gjerast"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ikkje gjer noko"
+
+#~ msgid "Open folder"
+#~ msgstr "Opna mappe"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Vel eit program for lyd-CD-ar"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Vel eit program for video-DVD-ar"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Vel programmet som skal køyrast når ein musikkspelar vert kopla til"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Vel programmet som skal køyrast når eit kamera vert kopla til"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Vel eit program for CD-ar med programvare"
+
+#~ msgid "audio DVD"
+#~ msgstr "lyd-DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Tom Blu-ray-plate"
+
+#~ msgid "blank CD disc"
+#~ msgstr "tom CD-plate"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "tom DVD-plate"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "tom HD-DVD-plate"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-Ray-videoplate"
+
+#~ msgid "e-book reader"
+#~ msgstr "E-boklesar"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD-DVD-videodisk"
+
+#~ msgid "Picture CD"
+#~ msgstr "Bilet-CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video-CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video-CD"
+
+#~ msgid "Overview"
+#~ msgstr "Oversikt"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Systemet er oppdatert"
+
+#~ msgid "Checking for Updates"
+#~ msgstr "Ser etter oppdateringar"
+
+#~ msgid "Disk"
+#~ msgstr "Lagringseining"
+
+#~ msgid "Experience"
+#~ msgstr "Brukaroppleving"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "Tvungen _reserveløysing"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Snøggtast;Repeter;Blink;"
+
+#~| msgid "Shortcut"
+#~ msgid "Custom Shortcut"
+#~ msgstr "Eigendefinert snøggtast"
+
+#~ msgid "Slow"
+#~ msgstr "Treg"
+
+#~| msgid "_Paste"
+#~ msgid "Fast"
+#~ msgstr "Snøgg"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Fart:"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Ukjend handling>"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "Klarte ikkje lagra den nye snøggtasten"
+
+#, c-format
+#~| msgid ""
+#~| "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~| "type using this key.\n"
+#~| "Please try with a key such as Control, Alt or Shift at the same time.\n"
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Snarvegen «%s» kan ikkje brukast fordi det vil verta umogleg å skriva med "
+#~ "denne tasten.\n"
+#~ "Prøv igjen med ein tastekombinasjon som inneheld Ctrl, Alt eller Shift."
+
+#, c-format
+#~| msgid ""
+#~| "The shortcut \"%s\" is already used for:\n"
+#~| " \"%s\"\n"
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Snøggtasten «%s» er alt i bruk av:\n"
+#~ " «%s»"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Om du endrar snøggtasten til «%s» vil snøggtasten «%s» verta avslått."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Tildel på nytt"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "For mange eigendefinerte snøggtastar"
+
+#~| msgid "Set your mouse preferences"
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Set opp innstillingane for mus og styreplate"
+
+#~ msgid "_Right-handed"
+#~ msgstr "_Høgrehendt"
+
+#~ msgid "_Left-handed"
+#~ msgstr "_Venstrehendt"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Vi_s kor peikaren er når Ctrl-tasten vert trykt ned"
+
+# TRN: Finn betre ord!
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Sensitivitet:"
+
+#~| msgid "<b>Drag and Drop</b>"
+#~ msgid "Drag and Drop"
+#~ msgstr "Dra og slepp"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "_Grense:"
+
+#~ msgid "_Timeout:"
+#~ msgstr "_Tidsgrense:"
+
+#~| msgid ""
+#~| "To test your double-click settings, try to double-click on the light "
+#~| "bulb."
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "Dobbeltklikk på fjeset for å testa innstillingane dine."
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "Slå på museklikk med styreplata"
+
+#~| msgid "Disabled"
+#~ msgid "_Disabled"
+#~ msgstr "_Av"
+
+#~ msgid "_Edge scrolling"
+#~ msgstr "_Kantrulling"
+
+#~ msgid "Two-_finger scrolling"
+#~ msgstr "Rulling med to _fingrar"
 
 #
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1871
-msgid "Test Sound"
-msgstr "Testlyd"
+#~ msgid "Interface"
+#~ msgstr "Grensesnitt"
 
-#: ../panels/sound-nua/gvc-mixer-dialog.c:1898
-msgid "Record sound from"
-msgstr ""
+#~| msgid "Options"
+#~ msgid "_Options..."
+#~ msgstr "_Innstillingar …"
 
-#: ../panels/universal-access/gconf-property-editor.c:134
-msgid "Key"
-msgstr "Nøkkel"
+#~ msgid "Error logging into the account"
+#~ msgstr "Klarte ikkje logga inn på kontoen"
 
-#: ../panels/universal-access/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr "GConf-nøkkel som denne eigenskapsredigeraren brukar"
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "Påloggingsinformasjonen er utgått. Prøv å logga inn på nytt."
 
-#: ../panels/universal-access/gconf-property-editor.c:141
-msgid "Callback"
-msgstr "Tilbakekall"
+#~ msgid "_Log In"
+#~ msgstr "_Logg inn"
 
-#: ../panels/universal-access/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Send dette tilbakekallet når verdien knytta til nøkkelen vert endra"
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "Vel kontotype før du legg til ny konto"
 
-#: ../panels/universal-access/gconf-property-editor.c:147
-msgid "Change set"
-msgstr "Mengd av endringar"
+#~ msgid "_Add..."
+#~ msgstr "_Legg til …"
 
-#: ../panels/universal-access/gconf-property-editor.c:148
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"Endringsmengda til GConf inneheld data som skal sendast vidare til gconf-"
-"klienten når endringane vert gjord verksame"
+#~ msgid "Error creating account"
+#~ msgstr "Klarte ikkje laga konto"
 
-#: ../panels/universal-access/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr "Konvertering til tilbakekall av skjermelement"
+#~ msgid "Error removing account"
+#~ msgstr "Klarte ikkje fjerna konto"
 
-#: ../panels/universal-access/gconf-property-editor.c:154
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-"Tilbakekall som skal sendast når data skal konverterast frå GConf til "
-"skjermelementet"
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Vil du fjerna denne kontoen?"
 
-#: ../panels/universal-access/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr "Konvertering frå tilbakekall av skjermelement"
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Dette vil ikkje fjerna kontoen på tenaren."
 
-#: ../panels/universal-access/gconf-property-editor.c:160
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"Tilbakekall som skal sendast når data skal konverterast til GConf frå "
-"skjermelementet"
+#~| msgid "Unknown"
+#~ msgid "Unknown time"
+#~ msgstr "Ukjend tid"
 
-#: ../panels/universal-access/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "UI-kontroll"
-
-#: ../panels/universal-access/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr "Objekt som kontrollerer eigenskapen (normalt eit skjermelement)"
-
-#: ../panels/universal-access/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr "Objektdata for redigering av eigenskapar"
-
-#: ../panels/universal-access/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr "Eigendefinerte data som trengst til eigenskapredigeringsprogrammet"
-
-#: ../panels/universal-access/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr "Tilbakekall som frigjer data frå eigenskapredigeringsprogrammet"
-
-#: ../panels/universal-access/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Tilbakekall som skal sendast når eigenskapsredigeringsprogrammet skal "
-"frigjera objektdata"
-
-#: ../panels/universal-access/gconf-property-editor.c:1474
 #, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Klarte ikkje finna fila «%s»\n"
-"\n"
-"Kontroller at fila finst og prøv på nytt, eller vel eit anna bakgrunnsbilete."
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
 
-#: ../panels/universal-access/gconf-property-editor.c:1482
+#~ msgid "Power management settings"
+#~ msgstr "Innstillingar for straumhandtering"
+
+#~ msgid "Never"
+#~ msgstr "Aldri"
+
+#~ msgid "Out of toner"
+#~ msgstr "Tom for tonar"
+
+#~ msgid "Low on developer"
+#~ msgstr "Lite framkallingsvæske"
+
+#~ msgid "Out of developer"
+#~ msgstr "Tom for framkallingsvæske"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Lite farge att"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Tom for ein farge"
+
+#~ msgid "Open cover"
+#~ msgstr "Loket er ope"
+
+#~ msgid "Low on paper"
+#~ msgstr "Lite papir att"
+
+#~ msgid "Out of paper"
+#~ msgstr "Tom for papir"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "Sett på pause"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Bosmottaket er nesten fullt"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Bosmottaket er fullt"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Bilettrommelen er snart oppbrukt"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Bilettrommelen fungerer ikkje lengre"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Klar"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "I arbeid"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Stoppa"
+
+#~ msgid "Toner Level"
+#~ msgstr "Tonarnivå"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Ventar"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Halden att"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "I arbeid"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Stoppa"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Avbrote av feil"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Fullført"
+
+#~ msgid "Job Title"
+#~ msgstr "Oppgåvenamn"
+
+#~ msgid "Job State"
+#~ msgstr "Oppgåvestatus"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Klarte ikkje leggja til den nye skrivaren."
+
 #, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Veit ikkje korleis fila «%s» skal opnast.\n"
-"Kanskje det er ein biletetype som ikkje er støtta.\n"
-"\n"
-"Vel eit anna bilete i staden."
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Klarte ikkje lasta grensesnitt: %s"
 
-#: ../panels/universal-access/gconf-property-editor.c:1604
-msgid "Please select an image."
-msgstr "Vel eit bilete."
+#~ msgid "Add a New Printer"
+#~ msgstr "Legg til ny skrivar"
 
-#: ../shell/cc-shell-nav-bar.c:117
-msgid "_All Settings"
-msgstr "_Alle innstillingar"
+#~ msgid "A_ddress:"
+#~ msgstr "A_dresse:"
 
-#: ../newstrings.desktop.in.h:1
-msgid "Application Menu"
-msgstr ""
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD køyrer ikkje. For å kunna oppdaga nettverksskrivarar må "
+#~ "tenestene mdns, ipp, ipp-client og samba-client vere slått på i "
+#~ "brannmuren."
 
-#: ../newstrings.desktop.in.h:2
-msgid "Integrated in menu bar and hidden"
-msgstr ""
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "Lokal"
 
-#: ../newstrings.desktop.in.h:3
-msgid "Integrated in menu bar and visible"
-msgstr ""
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "Opnar brannmur for mDNS-tilkoplingar"
 
-#~ msgid "Cursor blinks speed"
-#~ msgstr "Kor fort skrivemerket blinkar"
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Opnar brannmur for Samba-tilkoplingar"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "Opnar brannmur for IPP-tilkoplingar"
+
+#~ msgid "_Default"
+#~ msgstr "_Standard"
+
+#~ msgid "Jobs"
+#~ msgstr "Oppgåver"
+
+#~ msgid "_Show"
+#~ msgstr "_Vis"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Skriv ut _testside"
+
+#~ msgid "_Back"
+#~ msgstr "Til_bake"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Vel utforming"
+
+#~ msgid "Currency"
+#~ msgstr "Valutainnstillingar"
+
+#~ msgid "Allow different layouts for individual windows"
+#~ msgstr "Tillat ulike utformingar for kvart vindauge"
+
+#
+#~| msgid "Keyboard Layout Options"
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "Vis og endra tastaturutformingsinnstillingar"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "Byt ut gjeldande tastaturutformingsinnstillingar med "
+#~ "standardinnstillingane"
+
+#~ msgid "Layouts"
+#~ msgstr "Utformingar"
+
+#
+#~ msgid "Enable debugging code"
+#~ msgstr "Aktiver feilsøkingsmodus"
+
+#
+#~| msgid "Open with Default Application"
+#~ msgid "Version of this application"
+#~ msgstr "Versjon av dette programmet"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " – GNOME panelprogram for volumkontroll"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Vis volumkontroll for skrivebord"
+
+#~ msgid "Bark"
+#~ msgstr "Bjeff"
+
+#~ msgid "Drip"
+#~ msgstr "Drypp"
+
+#~ msgid "Glass"
+#~ msgstr "Glass"
+
+#~| msgid "Sound"
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Volum for lydutdata"
+
+#
+#~| msgid "Minimize"
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimum"
+
+#~| msgid "Maximize"
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maksimum"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Basselement"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100 %"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Uforsterka"
+
+#~ msgid "Peak detect"
+#~ msgstr "Oppdag topp"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Høgtalartesting for %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Vel eining som lydutgang:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Innstillingar for den valde eininga:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Vel eining som lydinngang:"
+
+#~ msgid "Built-in"
+#~ msgstr "Innebygd"
+
+#~| msgid "Mouse Preferences"
+#~ msgid "Sound Preferences"
+#~ msgstr "Lydinnstillingar"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Testar hendingslyd"
+
+#~ msgid "From theme"
+#~ msgstr "Frå tema"
+
+#~| msgid "Choose a Layout"
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Vel varsellyd:"
+
+#~ msgid "Stop"
+#~ msgstr "Stopp"
+
+#, c-format
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "Starting av lydval feila: %s"
+
+#~| msgid "Mutt"
+#~ msgid "_Mute"
+#~ msgstr "_Demp"
+
+#~| msgid "Mouse Preferences"
+#~ msgid "_Sound Preferences"
+#~ msgstr "_Lydinnstillingar"
+
+#~| msgid "Multimedia"
+#~ msgid "Muted"
+#~ msgstr "Dempa"
+
+#~ msgid "Custom"
+#~ msgstr "Sjølvvald"
+
+#
+#~| msgid "Appearance Preferences"
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Innstillingar for tilgjenge"
+
+#
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Caribou"
+#~ msgstr "Reinsdyr"
+
+#, no-c-format
+#~ msgid "100%"
+#~ msgstr "100 %"
+
+#, no-c-format
+#~ msgid "125%"
+#~ msgstr "125 %"
+
+#, no-c-format
+#~ msgid "150%"
+#~ msgstr "150 %"
+
+#~ msgid "GOK"
+#~ msgstr "GOK"
+
+#~| msgid "Zoom"
+#~ msgid "Zoom in:"
+#~ msgstr "Forstørr:"
+
+#~| msgid "Zoom"
+#~ msgid "Zoom out:"
+#~ msgstr "Forminsk:"
+
+#~| msgid "_Options..."
+#~ msgid "Options..."
+#~ msgstr "Innstillingar …"
+
+#~| msgid "Flash _window titlebar"
+#~ msgid "Flash the window title"
+#~ msgstr "Blink tittellinja på vindauget"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Vis tekstskildring av tale og lydar."
+
+#~ msgid "pressed"
+#~ msgstr "trykt"
+
+#~ msgid "accepted"
+#~ msgstr "godkjent"
+
+#~ msgid "rejected"
+#~ msgstr "avvist"
+
+#~| msgid "_Type to test settings:"
+#~ msgid "Type here to test settings"
+#~ msgstr "Skriv for å testa innstillingane"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Styr musepeikaren med videokameraet."
+
+#~| msgid "Mouse"
+#~ msgid "Video Mouse"
+#~ msgstr "Videomus"
+
+#~| msgid "Standard XTerminal"
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~| msgid "Create New Location"
+#~ msgid "Create new account"
+#~ msgstr "Lag ny konto"
+
+#~| msgid "C_reate"
+#~ msgid "Cr_eate"
+#~ msgstr "_Lag"
+
+#~ msgid "Left thumb"
+#~ msgstr "Venstre tommel"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Venstre langfinger"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Venstre ringfinger"
+
+#~ msgid "Left little finger"
+#~ msgstr "Venstre litlefinger"
+
+#~| msgid "Right"
+#~ msgid "Right thumb"
+#~ msgstr "Høgre tommel"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Høgre langfinger"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Høgre ringfinger"
+
+#~ msgid "Right little finger"
+#~ msgstr "Høgre litlefinger"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Fingeravtrykket ditt vart lagra. Du skal no kunne logga inn ved hjelp av "
+#~ "fingeravtrykklesaren din."
+
+#~| msgid "seconds"
+#~ msgid "User Accounts"
+#~ msgstr "Brukarkontoar"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Innlogging;Namn;Fingeravtrykk;Personbilete;Logo;Fjes;Passord;"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Logg inn utan passord"
+
+#~ msgid "Disable this account"
+#~ msgstr "Slå av denne kontoen"
+
+#~ msgid "Enable this account"
+#~ msgstr "Slå på denne kontoen"
+
+#
+#~| msgid "Filter"
+#~ msgid "Fair"
+#~ msgstr "Rimeleg"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Korleis velja eit sterkt passord"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Endrar bilete til:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "Vel bilete som vil visast på innloggingskjermen for denne kontoen."
+
+#~| msgid "Galeon"
+#~ msgid "Gallery"
+#~ msgstr "Galleri"
+
+#~| msgid "Take a break!"
+#~ msgid "Take a photograph"
+#~ msgstr "Ta fotografi"
+
+#~| msgid "Web Browser"
+#~ msgid "Browse"
+#~ msgstr "Bla gjennom"
+
+#~ msgid "Photograph"
+#~ msgstr "Fotograf"
+
+#~ msgid "Account Information"
+#~ msgstr "Kontoinformasjon"
+
+#~ msgid "Login Options"
+#~ msgstr "Innloggingsinnstillingar"
+
+#, c-format
+#~| msgid "The password is too short."
+#~ msgid "The new password is too short"
+#~ msgstr "Det nye passordet er for kort"
+
+#, c-format
+#~| msgid "The password is too simple."
+#~ msgid "The new password is too simple"
+#~ msgstr "Det nye passordet er for enkelt"
+
+#, c-format
+#~| msgid "The old and new passwords are too similar."
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Gammalt og nytt passord er for like"
+
+#, c-format
+#~| msgid "The two passwords are not equal."
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Det nye passordet har nyleg vore brukt."
+
+#, c-format
+#~| msgid "The new password must contain numeric or special character(s)."
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Det nye passordet må innehalda tal eller spesialteikn."
+
+#, c-format
+#~| msgid "The old and new passwords are the same."
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Gammalt og nytt passord er det same."
+
+#, c-format
+#~| msgid ""
+#~| "Your password has been changed since you initially authenticated! Please "
+#~| "re-authenticate."
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Passordet ditt har vorte endra sidan du autentiserte første gong. Du må "
+#~ "autentisera deg på nytt."
+
+#, c-format
+#~| msgid "The new password must contain numeric or special character(s)."
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Det nye passordet inneheld ikkje mange nok forskjellege teikn."
+
+#, c-format
+#~| msgid "Unknown"
+#~ msgid "Unknown error"
+#~ msgstr "Ukjend feil"
+
+#~| msgid "Failed to create temporary directory"
+#~ msgid "Failed to create user"
+#~ msgstr "Laging av ny brukar feila"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Du har ikkje løyve til å opna eininga. Kontakt systemadministratoren."
+
+#~ msgid "The device is already in use."
+#~ msgstr "Eininga er alt i bruk."
+
+#~| msgid "An internal error occured"
+#~ msgid "An internal error occurred."
+#~ msgstr "Ein intern feil har oppstått."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Slett registrerte fingeravtrykk?"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "Klarte ikkje opna eininga «%s»"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "Klarte ikkje starta innlesing av fingeravtrykk på eining «%s»"
+
+#~| msgid "Could not load the main interface"
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Klarte ikkje opna fingeravtrykklesar"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Kontakt systemadministratoren for å få hjelp."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "For å slå på innlogging via fingeravtrykk må du lagra eitt fingeravtrykk "
+#~ "ved å bruka eininga «%s»"
+
+#~ msgid "More choices..."
+#~ msgstr "Fleire val …"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Vel eit anna passord."
+
+#~| msgid "Please type your password in the <b>New password</b> field."
+#~ msgid "Please type your current password again."
+#~ msgstr "Skriv inn gjeldande passord omatt."
+
+#~| msgid "Your password has been changed."
+#~ msgid "Password could not be changed"
+#~ msgstr "Passordet kunne ikkje endrast"
+
+#~| msgid "_Retype new password:"
+#~ msgid "You need to enter a new password"
+#~ msgstr "Du må skriva inn eit nytt passord"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "Du må bekrefta passordet"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "Du må skriva inn ditt gjeldande passord"
+
+#~| msgid "That password was incorrect."
+#~ msgid "The current password is not correct"
+#~ msgstr "Det gjeldande passordet er ikkje riktig"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "For kort"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Svakt"
+
+#
+#~| msgid "Filter"
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Greitt"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Godt"
+
+#~| msgid "Scrolling"
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Sterkt"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "Passord er ikkje like"
+
+#~| msgid "Disabled"
+#~ msgid "Disable image"
+#~ msgstr "Slå av bilete"
+
+#~ msgid "Take a photo..."
+#~ msgstr "Ta bilete …"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Bla gjennom for fleire bilete …"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "Brukt av %s"
+
+#, c-format
+#~| msgid "The location already exists."
+#~ msgid "A user with name '%s' already exists."
+#~ msgstr "Brukar med namnet «%s» finst alt."
+
+#~ msgid "This user does not exist."
+#~ msgstr "Denne brukaren finst ikkje."
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Sletting av brukar feila"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Du kan ikkje sletta din eigen konto"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s er fortset logga inn"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Sletting av brukar medan dei er logga inn kan etterlata systemet i ein "
+#~ "inkonsekvent tilstand."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "Vil du behalda filene til «%s»?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Det er mogleg å behalda heimemappa, e-postkøa og mellombels filer etter "
+#~ "sletting av brukarkonto."
+
+#~| msgid "All Files"
+#~ msgid "_Keep Files"
+#~ msgstr "_Behald filer"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Deaktivert konto"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Å verta sette under neste innlogging"
+
+#
+#~| msgid "None"
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Å få kontakt med kontotenesta feila"
+
+#~| msgid "Please make sure that the applet is properly installed"
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Kontroller at kontotenesta er installert og slått på."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "For å gjera endringar,\n"
+#~ "trykk på *-ikonet først"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists"
+#~ msgstr "Brukar med brukarnamnet «%s» finst alt"
+
+#, c-format
+#~| msgid "The password is too short."
+#~ msgid "The username is too long"
+#~ msgstr "Brukarnamnet er for langt"
+
+#~ msgid "The username cannot start with a '-'"
+#~ msgstr "Brukarnamnet kan ikkje starta med «-»"
+
+#
+#~ msgid "Control Center"
+#~ msgstr "Kontrollsenter"
+
+#~ msgid "Key"
+#~ msgstr "Nøkkel"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf-nøkkel som denne eigenskapsredigeraren brukar"
+
+#~ msgid "Callback"
+#~ msgstr "Tilbakekall"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Send dette tilbakekallet når verdien knytta til nøkkelen vert endra"
+
+#~ msgid "Change set"
+#~ msgstr "Mengd av endringar"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Endringsmengda til GConf inneheld data som skal sendast vidare til gconf-"
+#~ "klienten når endringane vert gjord verksame"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Konvertering til tilbakekall av skjermelement"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Tilbakekall som skal sendast når data skal konverterast frå GConf til "
+#~ "skjermelementet"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Konvertering frå tilbakekall av skjermelement"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Tilbakekall som skal sendast når data skal konverterast til GConf frå "
+#~ "skjermelementet"
+
+#~ msgid "UI Control"
+#~ msgstr "UI-kontroll"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Objekt som kontrollerer eigenskapen (normalt eit skjermelement)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Objektdata for redigering av eigenskapar"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Eigendefinerte data som trengst til eigenskapredigeringsprogrammet"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Tilbakekall som frigjer data frå eigenskapredigeringsprogrammet"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Tilbakekall som skal sendast når eigenskapsredigeringsprogrammet skal "
+#~ "frigjera objektdata"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Klarte ikkje finna fila «%s»\n"
+#~ "\n"
+#~ "Kontroller at fila finst og prøv på nytt, eller vel eit anna "
+#~ "bakgrunnsbilete."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Veit ikkje korleis fila «%s» skal opnast.\n"
+#~ "Kanskje det er ein biletetype som ikkje er støtta.\n"
+#~ "\n"
+#~ "Vel eit anna bilete i staden."
+
+#~ msgid "Please select an image."
+#~ msgstr "Vel eit bilete."
 
 #~ msgid "Accel Mode"
 #~ msgstr "Snarvegtastmodus"
@@ -5120,7 +6512,8 @@ msgstr ""
 #~ msgstr "R_otering:"
 
 #~ msgid "Could not get session bus while applying display configuration"
-#~ msgstr "Klarte ikkje finna øktbussen under aktivering av skjerminnstillingar"
+#~ msgstr ""
+#~ "Klarte ikkje finna øktbussen under aktivering av skjerminnstillingar"
 
 #~| msgid "Shortcut"
 #~ msgid "New shortcut..."
@@ -5141,9 +6534,6 @@ msgstr ""
 #~ msgid "CD _audio:"
 #~ msgstr "CD-_lyd:"
 
-#~ msgid "Media and Autorun"
-#~ msgstr "Medium og autokjør"
-
 #~ msgid "_DVD video:"
 #~ msgstr "_DVD-video:"
 
@@ -5161,10 +6551,6 @@ msgstr ""
 
 #~ msgid "Configure media and autorun preferences"
 #~ msgstr "Set opp medium- og autostart-innstillingar"
-
-#~| msgid "Mirror Screens"
-#~ msgid "Screen"
-#~ msgstr "Skjerm"
 
 #~ msgid "Battery charging"
 #~ msgstr "Batteriet vert lada"
@@ -5190,9 +6576,6 @@ msgstr ""
 #~ msgid "%.0lf%% charged"
 #~ msgstr "%.0lf%% lada"
 
-#~ msgid "Unlock"
-#~ msgstr "Lås opp"
-
 #~| msgid "C_reate"
 #~ msgid "Create a user"
 #~ msgstr "Lag brukar"
@@ -5214,9 +6597,6 @@ msgstr ""
 #~ "For å sletta den valde brukaren,\n"
 #~ "trykk på *-ikonet først"
 
-#~ msgid "Wallpaper;Screen;Desktop;Theme;"
-#~ msgstr "Skrivebordsbakgrunn;Skjerm;Skrivebord;Tema"
-
 #~ msgid "Theme to be used for the UI"
 #~ msgstr "Tema brukt i grensesnittet"
 
@@ -5229,18 +6609,8 @@ msgstr ""
 #~ msgid "Counterclockwise"
 #~ msgstr "Mot klokka"
 
-#~ msgid ""
-#~ "device;system;information;memory;processor;version;default;application;fallba"
-#~ "ck;preferred;"
-#~ msgstr ""
-#~ "eining;system;informasjon;minne;prosessor;versjon;standard;program;reserveløy"
-#~ "sing;føretrekt;"
-
 #~ msgid "System Info"
 #~ msgstr "Systeminformasjon"
-
-#~ msgid "Toggle contrast"
-#~ msgstr "Slå av/på kontrast"
 
 #~ msgid "Magnifier zoom out"
 #~ msgstr "Gjer mindre"
@@ -5253,9 +6623,6 @@ msgstr ""
 
 #~ msgid "Toggle screen reader"
 #~ msgstr "Slå av/på skjermlesar"
-
-#~ msgid "Magnifier zoom in"
-#~ msgstr "Gjer større"
 
 #~ msgid "cd;dvd;usb;audio;video;disc;"
 #~ msgstr "cd;dvd;usb;lyd;video;plate;"

--- a/po/nn.po~
+++ b/po/nn.po~
@@ -1,0 +1,5261 @@
+# translation of nn.po to Norwegian Nynorsk
+# Norwegian (nynorsk) translation of gnome-control-center.
+# Copyright (C) 1999-2008 Free Software Foundation, Inc.
+# Copyright (C) Roy-Magne Mo <rmo@sunnmore.net>, 2001.
+# Eskild Hustvedt <eskildh@gnome.org> 2008
+# Roy-Magne Mo <rmo@sunnmore.net>, 2001.
+# Åsmund Skjæveland <aasmunds@ulrik.uio.no>, 2003-2008.
+# Torstein Adolf Winterseth <kvikende@fsfe.org>, 2010.
+# Andreas Nesdal <gedemiti@gmail.com>, 2011.
+msgid ""
+msgstr ""
+"Project-Id-Version: nn\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&component=general\n"
+"POT-Creation-Date: 2012-05-02 06:31+0000\n"
+"PO-Revision-Date: 2012-05-02 08:48+0000\n"
+"Last-Translator: Torstein Adolf Winterseth <kvikende@fsfe.org>\n"
+"Language-Team: Norwegian Nynorsk <i18n-nn@lister.ping.uio.no>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"Language: nn\n"
+
+#: ../panels/background/background.ui.h:1
+#| msgid "_Title:"
+msgid "Tile"
+msgstr "Tittel"
+
+#: ../panels/background/background.ui.h:2
+msgid "Zoom"
+msgstr "Zoom"
+
+#: ../panels/background/background.ui.h:3
+#| msgid "Pointer"
+msgid "Center"
+msgstr "Midten"
+
+#: ../panels/background/background.ui.h:4
+#| msgid "Small"
+msgid "Scale"
+msgstr "Skaler"
+
+#: ../panels/background/background.ui.h:5
+#| msgid "_Full"
+msgid "Fill"
+msgstr "Fyll"
+
+#: ../panels/background/background.ui.h:6
+msgid "Span"
+msgstr "Spennvidd"
+
+#: ../panels/background/background.ui.h:7
+msgid "<b>Background</b>"
+msgstr "<b>Bakgrunn</b>"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:9
+msgid "Changes throughout the day"
+msgstr "Vert endra heile dagen"
+
+#: ../panels/background/background.ui.h:10
+msgid "Primary Color"
+msgstr ""
+
+#: ../panels/background/background.ui.h:11
+msgid "Swap colors"
+msgstr ""
+
+#: ../panels/background/background.ui.h:12
+msgid "Secondary color"
+msgstr ""
+
+#: ../panels/background/background.ui.h:13
+msgid "Add wallpaper"
+msgstr "Legg til bakgrunn"
+
+#: ../panels/background/background.ui.h:14
+msgid "Remove wallpaper"
+msgstr "Fjern bakgrunn"
+
+#: ../panels/background/background.ui.h:15
+msgid "Add dots"
+msgstr ""
+
+#: ../panels/background/background.ui.h:16
+msgid "<b>Theme</b>"
+msgstr "<b>Tema</b>"
+
+#: ../panels/background/background.ui.h:17
+msgid "<b>Launcher icon size</b>"
+msgstr ""
+
+#: ../panels/background/background.ui.h:18
+msgid "Look"
+msgstr ""
+
+#: ../panels/background/background.ui.h:19
+msgid "<b>Auto-hide the Launcher</b>"
+msgstr ""
+
+#: ../panels/background/background.ui.h:20
+msgid ""
+"<span size=\"small\">The launcher will reveal when moving the pointer to the "
+"defined hot spot.</span>"
+msgstr ""
+
+#: ../panels/background/background.ui.h:21
+msgid "Reveal location:"
+msgstr ""
+
+#: ../panels/background/background.ui.h:22
+msgid "Left side"
+msgstr ""
+
+#: ../panels/background/background.ui.h:23
+msgid "Top left corner"
+msgstr ""
+
+#: ../panels/background/background.ui.h:24
+msgid "Other reveal option"
+msgstr ""
+
+#: ../panels/background/background.ui.h:25
+msgid "Reveal sensitivity"
+msgstr ""
+
+#: ../panels/background/background.ui.h:26
+msgid "<small>Low</small>"
+msgstr ""
+
+#: ../panels/background/background.ui.h:27
+msgid "<small>High</small>"
+msgstr ""
+
+#: ../panels/background/background.ui.h:28
+msgid ""
+"Some settings have been overriden by an external program, press \"Restore "
+"Default Behaviors\"  to reset the behavior and return control to this panel."
+msgstr ""
+
+#: ../panels/background/background.ui.h:29
+msgid "Restore Default Behaviours"
+msgstr ""
+
+#: ../panels/background/background.ui.h:30
+msgid "Behavior"
+msgstr ""
+
+#: ../panels/background/bg-colors-source.c:46
+msgid "Horizontal Gradient"
+msgstr "Vassrett fargeovergang"
+
+#: ../panels/background/bg-colors-source.c:47
+msgid "Vertical Gradient"
+msgstr "Loddrett fargeovergang"
+
+#: ../panels/background/bg-colors-source.c:48
+msgid "Solid Color"
+msgstr "Einsfarga"
+
+#: ../panels/background/cc-background-item.c:148
+msgid "multiple sizes"
+msgstr "fleire storleikar"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:152
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:281
+#| msgid "Apply Background"
+msgid "No Desktop Background"
+msgstr "Ingen skrivebordsbakgrunn"
+
+#: ../panels/background/cc-background-panel.c:1068
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "Browse for more pictures"
+msgstr "Bla gjennom for fleire bilete"
+
+#: ../panels/background/cc-background-panel.c:1160
+msgid "Current background"
+msgstr "Noverande bakgrunn"
+
+#: ../panels/background/cc-background-panel.c:1351
+msgid "default"
+msgstr ""
+
+#: ../panels/background/cc-background-panel.c:1766
+#| msgid "Add Wallpaper"
+msgid "Wallpapers"
+msgstr "Bakgrunnsbilete"
+
+#: ../panels/background/cc-background-panel.c:1773
+msgid "Pictures Folder"
+msgstr "Biletmappe"
+
+#: ../panels/background/cc-background-panel.c:1780
+msgid "Colors & Gradients"
+msgstr "Fargar og fargeovergangar"
+
+#: ../panels/background/cc-background-panel.c:1788
+msgid "Flickr"
+msgstr "Flickr"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Appearance"
+msgstr "Utsjånad"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change the background and theme"
+msgstr "Endra bakgrunnen og temaet"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;Theme;Appearance;Launcher;Unity;Menus;"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:1
+#: ../panels/network/panel-common.c:99
+msgid "Bluetooth"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth-properties.desktop.in.in.h:2
+msgid "Configure Bluetooth settings"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:1
+msgid "Set Up New Device"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:2 ../panels/network/network.ui.h:9
+msgid "Remove Device"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:3
+msgid "Connection"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:4
+msgid "Paired"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:5
+msgid "Type"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:6
+msgid "Address"
+msgstr "Adresse"
+
+#: ../panels/bluetooth/bluetooth.ui.h:7
+msgid "Mouse and Touchpad Settings"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:8 ../panels/universal-access/uap.ui.h:43
+msgid "Sound Settings"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:9 ../panels/universal-access/uap.ui.h:74
+msgid "Keyboard Settings"
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:10
+msgid "Send Files..."
+msgstr ""
+
+#: ../panels/bluetooth/bluetooth.ui.h:11
+msgid "Browse Files..."
+msgstr ""
+
+#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
+#: ../panels/bluetooth/bluetooth.ui.h:13
+msgctxt "Power"
+msgid "Bluetooth"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:281
+msgid "Yes"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:281
+msgid "No"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:393
+msgid "Bluetooth is disabled"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:398
+msgid "Bluetooth is disabled by hardware switch"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:402
+msgid "No Bluetooth adapters found"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:535
+msgid "Visibility"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:539
+#, c-format
+msgid "Visibility of “%s”"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:583
+#, c-format
+msgid "Remove '%s' from the list of devices?"
+msgstr ""
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:585
+msgid ""
+"If you remove the device, you will have to set it up again before next use."
+msgstr ""
+
+#. TRANSLATORS: this is where the user can click and import a profile
+#: ../panels/color/cc-color-panel.c:107
+msgid "Other profile…"
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:120
+msgid "Default: "
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:127
+msgid "Colorspace: "
+msgstr ""
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:133
+msgid "Test profile: "
+msgstr ""
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:186 ../panels/color/color.ui.h:11
+msgid "Set for all users"
+msgstr ""
+
+#. TRANSLATORS: this is when the profile should be set for all users
+#: ../panels/color/cc-color-panel.c:193
+msgid "Create virtual device"
+msgstr ""
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:228
+msgid "Select ICC Profile File"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:231
+msgid "_Import"
+msgstr ""
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:242
+msgid "Supported ICC profiles"
+msgstr ""
+
+#
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:249
+msgid "All files"
+msgstr "Alle filer"
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:639
+msgid "Available Profiles for Displays"
+msgstr ""
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:643
+msgid "Available Profiles for Scanners"
+msgstr ""
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:647
+msgid "Available Profiles for Printers"
+msgstr ""
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:651
+msgid "Available Profiles for Cameras"
+msgstr ""
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#: ../panels/color/cc-color-panel.c:655
+msgid "Available Profiles for Webcams"
+msgstr ""
+
+#. TRANSLATORS: this is the dialog title in the 'Add profile' UI
+#. * where the device type is not recognised
+#. Profiles that can be added to the device
+#: ../panels/color/cc-color-panel.c:660 ../panels/color/color.ui.h:2
+msgid "Available Profiles"
+msgstr ""
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:936
+#: ../panels/sound/gvc-mixer-dialog.c:1516
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1609
+msgid "Device"
+msgstr "Eining"
+
+#. TRANSLATORS: column for device list
+#: ../panels/color/cc-color-panel.c:971
+msgid "Calibration"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1003
+msgid "Create a color profile for the selected device"
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1017 ../panels/color/cc-color-panel.c:1041
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1050
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1061
+msgid "The device type is not currently supported."
+msgstr ""
+
+#. TRANSLATORS: this is when an auto-added profile cannot be removed
+#: ../panels/color/cc-color-panel.c:1133
+msgid "Cannot remove automatically added profile"
+msgstr ""
+
+#. TRANSLATORS: this is when there is no profile for the device
+#: ../panels/color/cc-color-panel.c:1462
+msgid "No profile"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1493
+#, c-format
+msgid "%i year"
+msgid_plural "%i years"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/color/cc-color-panel.c:1504
+#, c-format
+msgid "%i month"
+msgid_plural "%i months"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../panels/color/cc-color-panel.c:1515
+#, c-format
+msgid "%i week"
+msgid_plural "%i weeks"
+msgstr[0] ""
+msgstr[1] ""
+
+#. fallback
+#: ../panels/color/cc-color-panel.c:1522
+#, c-format
+msgid "Less than 1 week"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1584
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1589
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1594
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1712 ../panels/color/cc-color-panel.c:1753
+#: ../panels/color/cc-color-panel.c:1764 ../panels/color/cc-color-panel.c:1775
+msgid "Uncalibrated"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1715
+msgid "This device is not color managed."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1756
+msgid "This device is using manufacturing calibrated data."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1767
+msgid ""
+"This device does not have a profile suitable for whole-screen color "
+"correction."
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:1800
+msgid "This device has an old profile that may no longer be accurate."
+msgstr ""
+
+#. TRANSLATORS: this is when the calibration profile age is not
+#. * specified as it has been autogenerated from the hardware
+#: ../panels/color/cc-color-panel.c:1828
+msgid "Not specified"
+msgstr ""
+
+#. add the 'No devices detected' entry
+#: ../panels/color/cc-color-panel.c:2013
+msgid "No devices supporting color management detected"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2242
+msgctxt "Device kind"
+msgid "Display"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2244
+msgctxt "Device kind"
+msgid "Scanner"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2246
+msgctxt "Device kind"
+msgid "Printer"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2248
+msgctxt "Device kind"
+msgid "Camera"
+msgstr ""
+
+#: ../panels/color/cc-color-panel.c:2250
+msgctxt "Device kind"
+msgid "Webcam"
+msgstr ""
+
+#: ../panels/color/color.ui.h:3
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr ""
+
+#: ../panels/color/color.ui.h:4
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: ../panels/color/color.ui.h:5
+msgid "Learn more"
+msgstr ""
+
+#: ../panels/color/color.ui.h:6
+msgid "Learn more about color management"
+msgstr ""
+
+#: ../panels/color/color.ui.h:7
+msgid "Add device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:8
+msgid "Add a virtual device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:9
+msgid "Delete device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:10
+msgid "Remove a device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:12
+msgid "Set this device for all users on this computer"
+msgstr ""
+
+#: ../panels/color/color.ui.h:13
+msgid "Add profile"
+msgstr ""
+
+#: ../panels/color/color.ui.h:14
+msgid "Calibrate…"
+msgstr ""
+
+#: ../panels/color/color.ui.h:15
+msgid "Calibrate the device"
+msgstr ""
+
+#: ../panels/color/color.ui.h:16
+msgid "Remove profile"
+msgstr ""
+
+#: ../panels/color/color.ui.h:17
+msgid "View details"
+msgstr ""
+
+#: ../panels/color/color.ui.h:18
+msgid "Device type:"
+msgstr ""
+
+#: ../panels/color/color.ui.h:19
+msgid "Manufacturer:"
+msgstr ""
+
+#: ../panels/color/color.ui.h:20
+msgid "Model:"
+msgstr ""
+
+#: ../panels/color/color.ui.h:21
+msgid ""
+"Image files can be dragged on this window to auto-complete the above fields."
+msgstr ""
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Color management settings"
+msgstr ""
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:587
+msgid "United States"
+msgstr "USA"
+
+#: ../panels/common/cc-common-language.c:588
+msgid "Germany"
+msgstr "Tyskland"
+
+#: ../panels/common/cc-common-language.c:589
+msgid "France"
+msgstr "Frankrike"
+
+#: ../panels/common/cc-common-language.c:590
+msgid "Spain"
+msgstr "Spania"
+
+#: ../panels/common/cc-common-language.c:591
+msgid "China"
+msgstr "Kina"
+
+#: ../panels/common/cc-language-chooser.c:294
+msgid "Select a region"
+msgstr "Vel ein region"
+
+#: ../panels/common/gdm-languages.c:781
+msgid "Unspecified"
+msgstr "Uspesifisert"
+
+#: ../panels/common/language-chooser.ui.h:1
+msgid "Select a language"
+msgstr "Vel eit språk"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/printers/new-printer-dialog.ui.h:4
+#: ../panels/user-accounts/um-user-panel.c:446
+msgid "_Cancel"
+msgstr "_Avbryt"
+
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/universal-access/gconf-property-editor.c:1609
+msgid "_Select"
+msgstr "_Vel"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "_Region:"
+msgstr "_Region:"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "_City:"
+msgstr "_By:"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "_Network Time"
+msgstr "_Nettverkstid"
+
+#. Translator: this is the separator between hours and minutes, like in HH:MM
+#: ../panels/datetime/datetime.ui.h:5
+msgid ":"
+msgstr "."
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "Set the time one hour ahead."
+msgstr "Still klokka ein time fram."
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "Set the time one hour back."
+msgstr "Still klokka ein time tilbake."
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "Set the time one minute ahead."
+msgstr "Still klokka eitt minutt fram."
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "Set the time one minute back."
+msgstr "Still klokka eitt minutt tilbake."
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "Switch between AM and PM."
+msgstr "Byt mellom a.m. og p.m."
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "Month"
+msgstr "Månad"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "Day"
+msgstr "Dag"
+
+#: ../panels/datetime/datetime.ui.h:13
+msgid "Year"
+msgstr "År"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "24-hour"
+msgstr "24-timar"
+
+#: ../panels/datetime/datetime.ui.h:15
+msgid "AM/PM"
+msgstr "a.m./p.m."
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "January"
+msgstr "Januar"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "February"
+msgstr "Februar"
+
+#: ../panels/datetime/datetime.ui.h:18
+#| msgid "Search"
+msgid "March"
+msgstr "Mars"
+
+#: ../panels/datetime/datetime.ui.h:19
+#| msgid "pixel"
+#| msgid_plural "pixels"
+msgid "April"
+msgstr "April"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "May"
+msgstr "Mai"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "June"
+msgstr "Juni"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "July"
+msgstr "Juli"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "August"
+msgstr "August"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "September"
+msgstr "September"
+
+#
+#: ../panels/datetime/datetime.ui.h:25
+#| msgid "Other"
+msgid "October"
+msgstr "Oktober"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "November"
+msgstr "November"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "December"
+msgstr "Desember"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date and Time"
+msgstr "Dato og tid"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Date and Time preferences panel"
+msgstr "Panel for innstillingar til dato og tid"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "Klokke;Tidssone;Stad;"
+
+#: ../panels/display/cc-display-panel.c:509
+msgctxt "display panel, rotation"
+msgid "Normal"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:510
+msgctxt "display panel, rotation"
+msgid "Counterclockwise"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:511
+msgctxt "display panel, rotation"
+msgid "Clockwise"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:512
+msgctxt "display panel, rotation"
+msgid "180 Degrees"
+msgstr ""
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#. 
+#: ../panels/display/cc-display-panel.c:653
+msgid "Mirror Displays"
+msgstr "Like skjermar"
+
+#: ../panels/display/cc-display-panel.c:677
+#: ../panels/display/display-capplet.ui.h:1
+#| msgid "Typing Monitor"
+msgid "Monitor"
+msgstr "Skjerm"
+
+#: ../panels/display/cc-display-panel.c:783
+#, c-format
+#| msgid "%d x %d"
+msgid "%d x %d (%s)"
+msgstr "%d × %d (%s)"
+
+#: ../panels/display/cc-display-panel.c:785
+#, c-format
+msgid "%d x %d"
+msgstr "%d × %d"
+
+#: ../panels/display/cc-display-panel.c:1693
+msgid "Drag to change primary display."
+msgstr "Dra for å endra primærskjerm"
+
+#: ../panels/display/cc-display-panel.c:1751
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr "Vel skjermen du vil endra. Drag den for å endra plasseringa."
+
+#: ../panels/display/cc-display-panel.c:2166
+msgid "%a %R"
+msgstr "%a %R"
+
+#: ../panels/display/cc-display-panel.c:2168
+msgid "%a %l:%M %p"
+msgstr "%a %H.%M"
+
+#: ../panels/display/cc-display-panel.c:2330
+#: ../panels/display/cc-display-panel.c:2382
+#, c-format
+msgid "Failed to apply configuration: %s"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2410
+#| msgid "Could not load the main interface"
+msgid "Could not save the monitor configuration"
+msgstr "Klarte ikkje lagra skjerminnstillingane"
+
+#: ../panels/display/cc-display-panel.c:2470
+msgid "Could not detect displays"
+msgstr "Klarte ikkje oppdaga skjermar"
+
+#: ../panels/display/cc-display-panel.c:2735
+msgid "All displays"
+msgstr ""
+
+#: ../panels/display/cc-display-panel.c:2886
+#| msgid "Change screen resolution"
+msgid "Could not get screen information"
+msgstr "Klarte ikkje få informasjon om skjermen"
+
+#: ../panels/display/display-capplet.ui.h:2
+msgid "_Resolution"
+msgstr "_Oppløysing"
+
+#: ../panels/display/display-capplet.ui.h:3
+msgid "R_otation"
+msgstr "R_otering"
+
+#: ../panels/display/display-capplet.ui.h:4
+msgid "L_auncher placement"
+msgstr ""
+
+#: ../panels/display/display-capplet.ui.h:5
+msgid "S_ticky edges"
+msgstr ""
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:7
+msgid "_Mirror displays"
+msgstr "_Like skjermar"
+
+#: ../panels/display/display-capplet.ui.h:8
+msgid "Note: may limit resolution options"
+msgstr "Merk: kan avgrensa innstillingane for oppløysing"
+
+#: ../panels/display/display-capplet.ui.h:9
+msgid "_Detect Displays"
+msgstr "_Finn skjermar"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "Skjermar"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+#| msgid "Change resolution and position of monitors"
+msgid "Change resolution and position of monitors and projectors"
+msgstr "Endra oppløysing og posisjonen til skjermar og prosjektørar"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr "Panel;Prosjektør;xrandr;Skjerm;Oppløysing;Oppfrisking;"
+
+#. Translators: VESA is an techncial acronym, don't translate it.
+#: ../panels/info/cc-info-panel.c:401
+#, c-format
+msgid "VESA: %s"
+msgstr "VESA: %s"
+
+#. TRANSLATORS: device type
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:425 ../panels/network/panel-common.c:79
+#: ../panels/network/panel-common.c:158
+msgid "Unknown"
+msgstr "Ukjend"
+
+#. translators: This is the type of architecture, for example:
+#. * "64-bit" or "32-bit"
+#: ../panels/info/cc-info-panel.c:586
+#, c-format
+msgid "%d-bit"
+msgstr "%d-bit"
+
+#: ../panels/info/cc-info-panel.c:743
+msgid "Unknown model"
+msgstr "Ukjend modell"
+
+#: ../panels/info/cc-info-panel.c:826
+msgid "The next login will attempt to use the standard experience."
+msgstr "Neste innlogging vil prøva å bruka standard brukaroppleving."
+
+#: ../panels/info/cc-info-panel.c:828
+msgid ""
+"The next login will use the fallback mode intended for unsupported graphics "
+"hardware."
+msgstr ""
+"Neste innlogging vil bruka reserveløysing for grafikkort som ikkje er støtta."
+
+#. translators: The hardware is not able to run GNOME 3's
+#. * shell, so we use the GNOME "Fallback" session
+#: ../panels/info/cc-info-panel.c:870
+msgctxt "Experience"
+msgid "Fallback"
+msgstr "Reserveløysing"
+
+#. translators: The hardware is able to run GNOME 3's
+#. * shell, also called "Standard" experience
+#: ../panels/info/cc-info-panel.c:876
+msgctxt "Experience"
+msgid "Standard"
+msgstr "Standard"
+
+#: ../panels/info/cc-info-panel.c:1199
+msgid "Ask what to do"
+msgstr "Spør etter kva som skal gjerast"
+
+#: ../panels/info/cc-info-panel.c:1203 ../panels/power/power.ui.h:9
+msgid "Do nothing"
+msgstr "Ikkje gjer noko"
+
+#: ../panels/info/cc-info-panel.c:1207
+msgid "Open folder"
+msgstr "Opna mappe"
+
+#: ../panels/info/cc-info-panel.c:1322
+msgid "Select an application for audio CDs"
+msgstr "Vel eit program for lyd-CD-ar"
+
+#: ../panels/info/cc-info-panel.c:1323
+msgid "Select an application for video DVDs"
+msgstr "Vel eit program for video-DVD-ar"
+
+#: ../panels/info/cc-info-panel.c:1324
+msgid "Select an application to run when a music player is connected"
+msgstr "Vel programmet som skal køyrast når ein musikkspelar vert kopla til"
+
+#: ../panels/info/cc-info-panel.c:1325
+msgid "Select an application to run when a camera is connected"
+msgstr "Vel programmet som skal køyrast når eit kamera vert kopla til"
+
+#: ../panels/info/cc-info-panel.c:1326
+msgid "Select an application for software CDs"
+msgstr "Vel eit program for CD-ar med programvare"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#. 
+#: ../panels/info/cc-info-panel.c:1338
+msgid "audio DVD"
+msgstr "lyd-DVD"
+
+#: ../panels/info/cc-info-panel.c:1339
+msgid "blank Blu-ray disc"
+msgstr "Tom Blu-ray-plate"
+
+#: ../panels/info/cc-info-panel.c:1340
+msgid "blank CD disc"
+msgstr "tom CD-plate"
+
+#: ../panels/info/cc-info-panel.c:1341
+msgid "blank DVD disc"
+msgstr "tom DVD-plate"
+
+#: ../panels/info/cc-info-panel.c:1342
+msgid "blank HD DVD disc"
+msgstr "tom HD-DVD-plate"
+
+#: ../panels/info/cc-info-panel.c:1343
+msgid "Blu-ray video disc"
+msgstr "Blu-Ray-videoplate"
+
+#: ../panels/info/cc-info-panel.c:1344
+msgid "e-book reader"
+msgstr "E-boklesar"
+
+#: ../panels/info/cc-info-panel.c:1345
+msgid "HD DVD video disc"
+msgstr "HD-DVD-videodisk"
+
+#: ../panels/info/cc-info-panel.c:1346
+msgid "Picture CD"
+msgstr "Bilet-CD"
+
+#: ../panels/info/cc-info-panel.c:1347
+msgid "Super Video CD"
+msgstr "Super Video-CD"
+
+#: ../panels/info/cc-info-panel.c:1348
+msgid "Video CD"
+msgstr "Video-CD"
+
+#: ../panels/info/cc-info-panel.c:1471
+#: ../panels/keyboard/keyboard-shortcuts.c:1647
+msgid "Section"
+msgstr ""
+
+#: ../panels/info/cc-info-panel.c:1480 ../panels/info/info.ui.h:11
+msgid "Overview"
+msgstr "Oversikt"
+
+#: ../panels/info/cc-info-panel.c:1486 ../panels/info/info.ui.h:18
+msgid "Default Applications"
+msgstr "Standardprogram"
+
+#: ../panels/info/cc-info-panel.c:1491 ../panels/info/info.ui.h:26
+msgid "Removable Media"
+msgstr "Flyttbart medium"
+
+#: ../panels/info/cc-info-panel.c:1496 ../panels/info/info.ui.h:10
+msgid "Graphics"
+msgstr "Grafikk"
+
+#: ../panels/info/cc-info-panel.c:1698
+#, c-format
+msgid "Version %s"
+msgstr "Versjon %s"
+
+#: ../panels/info/cc-info-panel.c:1750
+msgid "Install Updates"
+msgstr "Installer oppdateringar"
+
+#: ../panels/info/cc-info-panel.c:1754
+msgid "System Up-To-Date"
+msgstr "Systemet er oppdatert"
+
+#: ../panels/info/cc-info-panel.c:1758
+msgid "Checking for Updates"
+msgstr "Ser etter oppdateringar"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+msgid "Details"
+msgstr ""
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "System Information"
+msgstr "Systeminformasjon"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;fallba"
+"ck;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "Vel korleis andre medium skal handsamast"
+
+#: ../panels/info/info.ui.h:2
+#| msgid "Action"
+msgid "Acti_on:"
+msgstr "_Handling:"
+
+#: ../panels/info/info.ui.h:3
+#| msgid "Type:"
+msgid "_Type:"
+msgstr "_Type:"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "Einingsnamn"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "Minne"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "Prosessor"
+
+#: ../panels/info/info.ui.h:7
+msgid "OS type"
+msgstr "Type operativsystem"
+
+#: ../panels/info/info.ui.h:8
+msgid "Disk"
+msgstr "Lagringseining"
+
+#: ../panels/info/info.ui.h:9
+msgid "Calculating..."
+msgstr "Reknar ut …"
+
+#: ../panels/info/info.ui.h:12
+msgid "_Web"
+msgstr "_Nett"
+
+#: ../panels/info/info.ui.h:13
+msgid "_Mail"
+msgstr "_E-post"
+
+#: ../panels/info/info.ui.h:14
+msgid "_Calendar"
+msgstr "_Kalender"
+
+#: ../panels/info/info.ui.h:15
+msgid "M_usic"
+msgstr "M_usikk"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Video"
+msgstr "_Video"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Photos"
+msgstr "_Bilete"
+
+#: ../panels/info/info.ui.h:19
+msgid "Select how media should be handled"
+msgstr "Vel korleis medium skal handsamast"
+
+#: ../panels/info/info.ui.h:20
+msgid "CD _audio"
+msgstr ""
+
+#: ../panels/info/info.ui.h:21
+msgid "_DVD video"
+msgstr ""
+
+#: ../panels/info/info.ui.h:22
+msgid "_Music player"
+msgstr ""
+
+#: ../panels/info/info.ui.h:23
+msgid "_Software"
+msgstr ""
+
+#: ../panels/info/info.ui.h:24
+msgid "_Other Media..."
+msgstr "_Andre medium …"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Aldri start eller spør kva for program skal starta når medium vert innsete"
+
+#: ../panels/info/info.ui.h:27
+msgid "Driver"
+msgstr "Drivar"
+
+#: ../panels/info/info.ui.h:28
+msgid "Experience"
+msgstr "Brukaroppleving"
+
+#. Hardware is not able to run GNOME 3's shell, so we might want to force running the 'Fallback' experience.
+#: ../panels/info/info.ui.h:30
+msgid "Forced _Fallback Mode"
+msgstr "Tvungen _reserveløysing"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "Lyd og media"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "Slå av lyd"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "Lågare lydstyrke"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "Høgare lydstyrke"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "Start mediaspelar"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "Spel av (eller spel av / pause)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "Set avspeling på pause"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "Stopp avspeling"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "Førre spor"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "Neste spor"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "Løys ut"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "Oppstartarar"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "Start hjelplesar"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3
+msgid "Launch calculator"
+msgstr "Start kalkulator"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch email client"
+msgstr "Start e-postprogram"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch web browser"
+msgstr "Start nettlesar"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Home folder"
+msgstr "Heimemappe"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Search"
+msgstr "Søk"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:2
+msgid "Take a screenshot"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Take a screenshot of a window"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:4
+msgid "Take a screenshot of an area"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Copy a screenshot to clipboard"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:6
+msgid "Copy a screenshot of a window to clipboard"
+msgstr ""
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Copy a screenshot of an area to clipboard"
+msgstr ""
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+#: ../panels/region/gnome-region-panel.ui.h:40
+msgid "System"
+msgstr "System"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "Logg ut"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "Lås skjermen"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "Tilgjenge"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "Større tekststorleik"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "Mindre tekststorleik"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "Keyboard"
+msgstr "Tastatur"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "Change keyboard settings"
+msgstr "Endra tastaturinnstillingar"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Snøggtast;Repeter;Blink;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+#| msgid "Shortcut"
+msgid "Custom Shortcut"
+msgstr "Eigendefinert snøggtast"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "_Name:"
+msgstr "_Namn:"
+
+#
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "C_ommand:"
+msgstr "K_ommando:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+#| msgid "<b>Repeat Keys</b>"
+msgid "Repeat Keys"
+msgstr "Repeterande tastar"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Key presses _repeat when key is held down"
+msgstr "Tastetrykk vert _repeterte når tasten vert halden nede"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "_Delay:"
+msgstr "_Pause:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Speed:"
+msgstr "_Fart:"
+
+#. short delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+#: ../panels/mouse/gnome-mouse-properties.ui.h:26
+#: ../panels/universal-access/uap.ui.h:55
+#: ../panels/universal-access/zoom-options.c:333
+#| msgid "Shortcut"
+msgid "Short"
+msgstr "Kort"
+
+#. slow acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "Slow"
+msgstr "Treg"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgid "Repeat keys speed"
+msgstr "Tasterepetisjonsrate"
+
+#. long delay
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+#: ../panels/mouse/gnome-mouse-properties.ui.h:28
+#: ../panels/universal-access/uap.ui.h:58
+#: ../panels/universal-access/zoom-options.c:337
+#| msgid "Login"
+msgid "Long"
+msgstr "Lang"
+
+#. fast acceleration
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+#| msgid "_Paste"
+msgid "Fast"
+msgstr "Snøgg"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+#| msgid "<b>Cursor Blinking</b>"
+msgid "Cursor Blinking"
+msgstr "Blinkande skrivemerke"
+
+#
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor _blinks in text fields"
+msgstr "Skrivemerket _blinkar i tekstfelt"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "S_peed:"
+msgstr "_Fart:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "Cursor blink speed"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Layout Settings"
+msgstr "Utformingsinnstillingar"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/universal-access/uap.ui.h:75
+#| msgid "Typing Break"
+msgid "Typing"
+msgstr "Skriving"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+msgid "Add Shortcut"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Remove Shortcut"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"For å endra ein snarveg, trykk på den tilhøyrande rada og hald nede "
+"tastekombinasjonen, eller trykk slettetasten for å fjerna den."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+#| msgid "Shortcut"
+msgid "Shortcuts"
+msgstr "Snøggtastar"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:554
+#: ../panels/keyboard/keyboard-shortcuts.c:562
+#: ../panels/keyboard/keyboard-shortcuts.c:867
+#: ../panels/keyboard/keyboard-shortcuts.c:1410
+#: ../panels/keyboard/keyboard-shortcuts.c:1414
+#| msgid "Shortcut"
+msgid "Custom Shortcuts"
+msgstr "Eigendefinerte snøggtastar"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:722
+msgid "<Unknown Action>"
+msgstr "<Ukjend handling>"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/keyboard-shortcuts.c:1062
+#: ../panels/sound/gvc-mixer-control.c:1087
+#: ../panels/user-accounts/um-fingerprint-dialog.c:215
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+#: ../panels/sound-nua/gvc-mixer-control.c:1906
+msgid "Disabled"
+msgstr "Av"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1088
+msgid "Error saving the new shortcut"
+msgstr "Klarte ikkje lagra den nye snøggtasten"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1219
+#, c-format
+#| msgid ""
+#| "The shortcut \"%s\" cannot be used because it will become impossible to "
+#| "type using this key.\n"
+#| "Please try with a key such as Control, Alt or Shift at the same time.\n"
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"Snarvegen «%s» kan ikkje brukast fordi det vil verta umogleg å skriva med "
+"denne tasten.\n"
+"Prøv igjen med ein tastekombinasjon som inneheld Ctrl, Alt eller Shift."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1251
+#, c-format
+#| msgid ""
+#| "The shortcut \"%s\" is already used for:\n"
+#| " \"%s\"\n"
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"Snøggtasten «%s» er alt i bruk av:\n"
+" «%s»"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1256
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"Om du endrar snøggtasten til «%s» vil snøggtasten «%s» verta avslått."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1262
+msgid "_Reassign"
+msgstr "_Tildel på nytt"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1349
+msgid "Too many custom shortcuts"
+msgstr "For mange eigendefinerte snøggtastar"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1700
+#: ../panels/wacom/cc-wacom-page.c:582
+msgid "Action"
+msgstr "Handling"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1722
+msgid "Shortcut"
+msgstr "Snøggtast"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#| msgid "Touchpad"
+msgid "Mouse and Touchpad"
+msgstr "Mus og styreplate"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#| msgid "Set your mouse preferences"
+msgid "Set your mouse and touchpad preferences"
+msgstr "Set opp innstillingane for mus og styreplate"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "Mouse Preferences"
+msgstr "Eigenskapar for mus"
+
+#
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "General"
+msgstr "Allmennt"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "_Right-handed"
+msgstr "_Høgrehendt"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "_Left-handed"
+msgstr "_Venstrehendt"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr "Vi_s kor peikaren er når Ctrl-tasten vert trykt ned"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+#| msgid "<b>Pointer Speed</b>"
+msgid "Pointer Speed"
+msgstr "Peikarfart"
+
+#
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "A_cceleration:"
+msgstr "A_ksellerasjon:"
+
+# TRN: Finn betre ord!
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "_Sensitivity:"
+msgstr "_Sensitivitet:"
+
+#. low sensitivity
+#. TRANSLATORS: secondary battery
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+#: ../panels/power/cc-power-panel.c:576
+msgid "Low"
+msgstr "Låg"
+
+#. high sensitivity
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+#| msgid "Right"
+msgid "High"
+msgstr "Høg"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+#| msgid "<b>Drag and Drop</b>"
+msgid "Drag and Drop"
+msgstr "Dra og slepp"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Thr_eshold:"
+msgstr "_Grense:"
+
+#. small threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+#: ../panels/universal-access/uap.ui.h:87
+msgid "Small"
+msgstr "Liten"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:21
+msgid "Drag Threshold"
+msgstr ""
+
+#. large threshold
+#: ../panels/mouse/gnome-mouse-properties.ui.h:23
+#: ../panels/universal-access/uap.ui.h:89
+msgid "Large"
+msgstr "Stor"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:24
+#| msgid "<b>Double-Click Timeout</b>"
+msgid "Double-Click Timeout"
+msgstr "Tidsgrense for dobbeltklikk"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:25
+msgid "_Timeout:"
+msgstr "_Tidsgrense:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:27
+msgid "Double-click timeout"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:29
+#| msgid ""
+#| "To test your double-click settings, try to double-click on the light bulb."
+msgid "To test your settings, try to double-click on the face."
+msgstr "Dobbeltklikk på fjeset for å testa innstillingane dine."
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:30
+msgid "Mouse"
+msgstr "Mus"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:31
+msgid "Disable _touchpad while typing"
+msgstr "Slå av _styreplata under skriving"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:32
+msgid "Enable _mouse clicks with touchpad"
+msgstr "Slå på museklikk med styreplata"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:33
+msgid "Scrolling"
+msgstr "Rulling"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:34
+#| msgid "Disabled"
+msgid "_Disabled"
+msgstr "_Av"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:35
+msgid "_Edge scrolling"
+msgstr "_Kantrulling"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:36
+msgid "Two-_finger scrolling"
+msgstr "Rulling med to _fingrar"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:37
+msgid "Enable h_orizontal scrolling"
+msgstr "Slå på _vassrett rulling"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:38
+msgid "Touchpad"
+msgstr "Styreplate"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/cc-network-panel.c:291
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/cc-network-panel.c:299
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+
+#. TRANSLATORS: this is when the access point is not listed
+#. * in the dropdown (or hidden) and the user has to select
+#. * another entry manually
+#: ../panels/network/cc-network-panel.c:1019
+msgctxt "Wireless access point"
+msgid "Other..."
+msgstr ""
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/cc-network-panel.c:1183
+#: ../panels/network/cc-network-panel.c:1590
+msgid "WEP"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:1187
+#: ../panels/network/cc-network-panel.c:1594
+msgid "WPA"
+msgstr ""
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/cc-network-panel.c:1191
+msgid "WPA2"
+msgstr ""
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/cc-network-panel.c:1196
+msgid "Enterprise"
+msgstr ""
+
+#
+#. TRANSLATORS: this no (!) WiFi security
+#: ../panels/network/cc-network-panel.c:1202
+#: ../panels/network/cc-network-panel.c:1585
+#: ../panels/universal-access/uap.ui.h:5 ../panels/wacom/cc-wacom-page.c:297
+#: ../panels/wacom/cc-wacom-page.c:314
+msgid "None"
+msgstr "Ingen"
+
+#: ../panels/network/cc-network-panel.c:1689
+msgid "Hotspot"
+msgstr ""
+
+#. Translators: network device speed
+#: ../panels/network/cc-network-panel.c:1696
+#, c-format
+msgid "%d Mb/s"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:2042 ../panels/network/network.ui.h:11
+msgid "IPv4 Address"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:2043 ../panels/network/network.ui.h:12
+msgid "IPv6 Address"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:2046
+#: ../panels/network/cc-network-panel.c:2049 ../panels/network/network.ui.h:27
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP-adresse"
+
+#: ../panels/network/cc-network-panel.c:2096
+#: ../panels/network/cc-network-panel.c:2471
+#, c-format
+msgid "%s VPN"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:2204
+msgid "Proxy"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:2278
+msgid "Network proxy"
+msgstr ""
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:2538
+msgid "The system network services are not compatible with this version."
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:2736
+#, c-format
+msgid ""
+"Network details for %s including password and any custom configuration will "
+"be lost"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:2746
+msgid "Forget"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3245
+msgid "Not connected to the internet."
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3246
+msgid "Create the hotspot anyway?"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3264
+#, c-format
+msgid "Disconnect from %s and create a new hotspot?"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3267
+msgid "This is your only connection to the internet."
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3285
+msgid "Create _Hotspot"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3345
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+
+#: ../panels/network/cc-network-panel.c:3348
+msgid "_Stop Hotspot"
+msgstr ""
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:3366
+msgid "Airplane Mode"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+msgid "Network"
+msgstr ""
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Network settings"
+msgstr ""
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid "Network;Wireless;IP;LAN;Proxy;"
+msgstr ""
+
+#: ../panels/network/network.ui.h:1
+msgid "Select the interface to use for the new service"
+msgstr ""
+
+#: ../panels/network/network.ui.h:2
+msgid "Create..."
+msgstr ""
+
+#
+#: ../panels/network/network.ui.h:3
+msgid "Interface"
+msgstr "Grensesnitt"
+
+#: ../panels/network/network.ui.h:4
+msgid "VPN"
+msgstr ""
+
+#: ../panels/network/network.ui.h:5
+msgctxt "proxy method"
+msgid "None"
+msgstr ""
+
+#: ../panels/network/network.ui.h:6
+msgctxt "proxy method"
+msgid "Manual"
+msgstr ""
+
+#: ../panels/network/network.ui.h:7
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr ""
+
+#: ../panels/network/network.ui.h:8
+msgid "Add Device"
+msgstr ""
+
+#: ../panels/network/network.ui.h:10
+msgid "Hardware Address"
+msgstr ""
+
+#: ../panels/network/network.ui.h:13
+msgid "Subnet Mask"
+msgstr ""
+
+#: ../panels/network/network.ui.h:14
+msgid "Default Route"
+msgstr ""
+
+#: ../panels/network/network.ui.h:15
+msgid "DNS"
+msgstr ""
+
+#: ../panels/network/network.ui.h:16
+msgid "Device Off"
+msgstr ""
+
+#: ../panels/network/network.ui.h:17
+#: ../panels/region/gnome-region-panel.ui.h:26
+#| msgid "Options"
+msgid "_Options..."
+msgstr "_Innstillingar …"
+
+#: ../panels/network/network.ui.h:18
+msgid "Security"
+msgstr ""
+
+#: ../panels/network/network.ui.h:19
+msgid "_Network Name"
+msgstr ""
+
+#: ../panels/network/network.ui.h:20
+msgid "Network Name"
+msgstr ""
+
+#: ../panels/network/network.ui.h:21
+msgid "Security Key"
+msgstr ""
+
+#: ../panels/network/network.ui.h:22
+msgid "Forget Network"
+msgstr ""
+
+#: ../panels/network/network.ui.h:23
+msgid "_Use as Hotspot..."
+msgstr ""
+
+#: ../panels/network/network.ui.h:24
+msgid "_Stop Hotspot..."
+msgstr ""
+
+#: ../panels/network/network.ui.h:25
+msgid "IMEI"
+msgstr ""
+
+#: ../panels/network/network.ui.h:26
+msgid "Provider"
+msgstr ""
+
+#: ../panels/network/network.ui.h:28
+msgid "VPN Type"
+msgstr ""
+
+#: ../panels/network/network.ui.h:29
+msgid "Gateway"
+msgstr ""
+
+#: ../panels/network/network.ui.h:30
+msgid "Group Name"
+msgstr ""
+
+#: ../panels/network/network.ui.h:31
+msgid "Group Password"
+msgstr ""
+
+#: ../panels/network/network.ui.h:32
+msgid "Username"
+msgstr ""
+
+#: ../panels/network/network.ui.h:33
+msgid "Disable VPN"
+msgstr ""
+
+#: ../panels/network/network.ui.h:34
+msgid "_Configure..."
+msgstr ""
+
+#: ../panels/network/network.ui.h:35
+msgid "_Method"
+msgstr ""
+
+#: ../panels/network/network.ui.h:36
+msgid "_Configuration URL"
+msgstr ""
+
+#: ../panels/network/network.ui.h:37
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: ../panels/network/network.ui.h:38
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: ../panels/network/network.ui.h:39
+msgid "_FTP Proxy"
+msgstr ""
+
+#: ../panels/network/network.ui.h:40
+msgid "_Socks Host"
+msgstr ""
+
+#: ../panels/network/network.ui.h:41
+msgid "HTTP Port"
+msgstr ""
+
+#: ../panels/network/network.ui.h:42
+msgid "HTTPS Port"
+msgstr ""
+
+#: ../panels/network/network.ui.h:43
+msgid "FTP Port"
+msgstr ""
+
+#: ../panels/network/network.ui.h:44
+msgid "Socks Port"
+msgstr ""
+
+#: ../panels/network/network.ui.h:45
+msgid "Apply system wide"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:83
+msgid "Wired"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:87
+msgid "Wireless"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:94
+msgid "Mobile broadband"
+msgstr ""
+
+#. TRANSLATORS: device type
+#: ../panels/network/panel-common.c:103
+msgid "Mesh"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:162
+msgid "Ad-hoc"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:166
+msgid "Infrastructure"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:190 ../panels/network/panel-common.c:251
+msgid "Status unknown"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:194
+msgid "Unmanaged"
+msgstr ""
+
+#: ../panels/network/panel-common.c:199
+msgid "Firmware missing"
+msgstr ""
+
+#: ../panels/network/panel-common.c:202
+msgid "Cable unplugged"
+msgstr ""
+
+#: ../panels/network/panel-common.c:204
+msgid "Unavailable"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:208
+msgid "Disconnected"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:215 ../panels/network/panel-common.c:257
+msgid "Connecting"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:219 ../panels/network/panel-common.c:261
+msgid "Authentication required"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223 ../panels/network/panel-common.c:265
+msgid "Connected"
+msgstr ""
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:227
+msgid "Disconnecting"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:231 ../panels/network/panel-common.c:269
+msgid "Connection failed"
+msgstr ""
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:235 ../panels/network/panel-common.c:277
+msgid "Status unknown (missing)"
+msgstr ""
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:273
+msgid "Not connected"
+msgstr "Ikkje tilkopla"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:305
+msgid "Error logging into the account"
+msgstr "Klarte ikkje logga inn på kontoen"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:351
+msgid "Expired credentials. Please log in again."
+msgstr "Påloggingsinformasjonen er utgått. Prøv å logga inn på nytt."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:354
+msgid "_Log In"
+msgstr "_Logg inn"
+
+#. translators: This is the title of the "Add Account" dialogue.
+#. * The title is not visible when using GNOME Shell
+#: ../panels/online-accounts/cc-online-accounts-panel.c:461
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "Add Account"
+msgstr ""
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:466
+msgid "To add a new account, first select the account type"
+msgstr "Vel kontotype før du legg til ny konto"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:469
+msgid "Account Type:"
+msgstr "Kontotype:"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "_Add..."
+msgstr "_Legg til …"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:550
+msgid "Error creating account"
+msgstr "Klarte ikkje laga konto"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:584
+msgid "Error removing account"
+msgstr "Klarte ikkje fjerna konto"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:620
+msgid "Are you sure you want to remove the account?"
+msgstr "Vil du fjerna denne kontoen?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:622
+msgid "This will not remove the account on the server."
+msgstr "Dette vil ikkje fjerna kontoen på tenaren."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:623
+msgid "_Remove"
+msgstr "_Fjern"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "Nettkontoar"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Manage online accounts"
+msgstr "Administrer nettkontoar"
+
+#. Translators: those are keywords for the online-accounts control-center panel
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Nett;Web;Chat;Nettprat;Kalender;E-post;Kontakt;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Remove Account"
+msgstr ""
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Select an account"
+msgstr "Vel ein konto"
+
+#: ../panels/power/cc-power-panel.c:168
+#| msgid "Unknown"
+msgid "Unknown time"
+msgstr "Ukjend tid"
+
+#: ../panels/power/cc-power-panel.c:174
+#, c-format
+#| msgid "minutes"
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minutt"
+msgstr[1] "%i minutt"
+
+#: ../panels/power/cc-power-panel.c:186
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i time"
+msgstr[1] "%i timar"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:194
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:195
+#| msgid "Short"
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "time"
+msgstr[1] "timar"
+
+#: ../panels/power/cc-power-panel.c:196
+#| msgid "minutes"
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minutt"
+msgstr[1] "minutt"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:239
+#, c-format
+msgid "Charging - %s until fully charged"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:247
+#, c-format
+msgid "Caution low battery, %s remaining"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:255
+#, c-format
+msgid "Using battery power - %s remaining"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:272 ../panels/power/cc-power-panel.c:564
+msgid "Charging"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:277
+msgid "Using battery power"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:281 ../panels/power/cc-power-panel.c:586
+msgid "Charging - fully charged"
+msgstr ""
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:285 ../panels/power/cc-power-panel.c:590
+msgid "Empty"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:353
+#, c-format
+msgid "Caution low UPS, %s remaining"
+msgstr ""
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:359
+#, c-format
+msgid "Using UPS power - %s remaining"
+msgstr ""
+
+#. TRANSLATORS: UPS battery
+#: ../panels/power/cc-power-panel.c:377
+msgid "Caution low UPS"
+msgstr ""
+
+#. TRANSLATORS: UPS battery
+#: ../panels/power/cc-power-panel.c:382
+msgid "Using UPS power"
+msgstr ""
+
+#. TRANSLATORS: secondary battery is normally in the media bay
+#: ../panels/power/cc-power-panel.c:434
+msgid "Your secondary battery is fully charged"
+msgstr ""
+
+#. TRANSLATORS: secondary battery is normally in the media bay
+#: ../panels/power/cc-power-panel.c:438
+msgid "Your secondary battery is empty"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:521
+msgid "Wireless mouse"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:525
+msgid "Wireless keyboard"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:529
+msgid "Uninterruptible power supply"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:533
+msgid "Personal digital assistant"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:537
+msgid "Cellphone"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:541
+msgid "Media player"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:545
+msgid "Tablet"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:549
+msgid "Computer"
+msgstr ""
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:553
+msgid "Battery"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:571
+msgid "Caution"
+msgstr ""
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:581
+msgid "Good"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1090
+msgid "Tip:"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1091
+msgid "Brightness Settings"
+msgstr ""
+
+#: ../panels/power/cc-power-panel.c:1092
+msgid "affect how much power is used"
+msgstr ""
+
+#
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+#| msgid "Pointer"
+msgid "Power"
+msgstr "Straum"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Power management settings"
+msgstr "Innstillingar for straumhandtering"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+msgstr ""
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr ""
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr ""
+
+#: ../panels/power/power.ui.h:3 ../panels/screen/screen.ui.h:6
+msgid "5 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:4 ../panels/screen/screen.ui.h:7
+msgid "10 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:5 ../panels/screen/screen.ui.h:8
+msgid "30 minutes"
+msgstr ""
+
+#: ../panels/power/power.ui.h:6 ../panels/screen/screen.ui.h:9
+msgid "1 hour"
+msgstr ""
+
+#: ../panels/power/power.ui.h:7
+msgid "Don't suspend"
+msgstr ""
+
+#: ../panels/power/power.ui.h:8
+msgid "Suspend"
+msgstr ""
+
+#: ../panels/power/power.ui.h:10
+msgid "When battery is present"
+msgstr ""
+
+#: ../panels/power/power.ui.h:11
+msgid "When battery is charging/in use"
+msgstr ""
+
+#: ../panels/power/power.ui.h:12 ../panels/screen/screen.ui.h:10
+msgid "Never"
+msgstr "Aldri"
+
+#: ../panels/power/power.ui.h:13
+msgid "On battery power"
+msgstr ""
+
+#: ../panels/power/power.ui.h:14
+msgid "When plugged in"
+msgstr ""
+
+#: ../panels/power/power.ui.h:15
+msgid "Suspend when inactive for"
+msgstr ""
+
+#: ../panels/power/power.ui.h:16
+msgid "When power is _critically low"
+msgstr ""
+
+#: ../panels/power/power.ui.h:17
+msgid "When the lid is closed"
+msgstr ""
+
+#: ../panels/power/power.ui.h:18
+msgid "Show battery status in the _menu bar"
+msgstr ""
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:541
+msgid "Low on toner"
+msgstr "Lite tonar att"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:543
+msgid "Out of toner"
+msgstr "Tom for tonar"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:546
+msgid "Low on developer"
+msgstr "Lite framkallingsvæske"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:549
+msgid "Out of developer"
+msgstr "Tom for framkallingsvæske"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:551
+msgid "Low on a marker supply"
+msgstr "Lite farge att"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:553
+msgid "Out of a marker supply"
+msgstr "Tom for ein farge"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:555
+msgid "Open cover"
+msgstr "Loket er ope"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:557
+msgid "Open door"
+msgstr "Loket er ope"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:559
+msgid "Low on paper"
+msgstr "Lite papir att"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:561
+msgid "Out of paper"
+msgstr "Tom for papir"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:563
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Fråkopla"
+
+#. Translators: Someone has paused the Printer
+#: ../panels/printers/cc-printers-panel.c:565
+msgctxt "printer state"
+msgid "Paused"
+msgstr "Sett på pause"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:567
+msgid "Waste receptacle almost full"
+msgstr "Bosmottaket er nesten fullt"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:569
+msgid "Waste receptacle full"
+msgstr "Bosmottaket er fullt"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:571
+msgid "The optical photo conductor is near end of life"
+msgstr "Bilettrommelen er snart oppbrukt"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:573
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Bilettrommelen fungerer ikkje lengre"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:748
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Klar"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:752
+msgctxt "printer state"
+msgid "Processing"
+msgstr "I arbeid"
+
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:756
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Stoppa"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:868
+msgid "Toner Level"
+msgstr "Tonarnivå"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:871
+msgid "Ink Level"
+msgstr "Blekknivå"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:874
+msgid "Supply Level"
+msgstr "Tilførslenivå"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:889
+#: ../panels/printers/cc-printers-panel.c:1284
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u aktiv"
+msgstr[1] "%u aktive"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:996
+msgid "No printers available"
+msgstr "Ingen skrivar tilgjengeleg"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/cc-printers-panel.c:1327
+msgctxt "print job"
+msgid "Pending"
+msgstr "Ventar"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/cc-printers-panel.c:1331
+msgctxt "print job"
+msgid "Held"
+msgstr "Halden att"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/cc-printers-panel.c:1335
+msgctxt "print job"
+msgid "Processing"
+msgstr "I arbeid"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/cc-printers-panel.c:1339
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Stoppa"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/cc-printers-panel.c:1343
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Avbrote"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/cc-printers-panel.c:1347
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Avbrote av feil"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/cc-printers-panel.c:1351
+msgctxt "print job"
+msgid "Completed"
+msgstr "Fullført"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/cc-printers-panel.c:1431
+msgid "Job Title"
+msgstr "Oppgåvenamn"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/cc-printers-panel.c:1440
+msgid "Job State"
+msgstr "Oppgåvestatus"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/cc-printers-panel.c:1446
+msgid "Time"
+msgstr "Tidspunkt"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:2068
+msgid "Failed to add new printer."
+msgstr "Klarte ikkje leggja til den nye skrivaren."
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2272
+#: ../panels/printers/cc-printers-panel.c:2286
+msgid "Test page"
+msgstr "Testside"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2535
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Klarte ikkje lasta grensesnitt: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:147
+msgid "Printers"
+msgstr "Skrivarar"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Change printer settings"
+msgstr "Endra skrivarinnstillingar"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Skrivar;Kø;Utskrift;Papir;Blekk;Tonar;"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "Legg til ny skrivar"
+
+#: ../panels/printers/new-printer-dialog.ui.h:2
+msgid "A_ddress:"
+msgstr "A_dresse:"
+
+#: ../panels/printers/new-printer-dialog.ui.h:3
+msgid "_Search by Address"
+msgstr "_Søk etter adresse"
+
+#: ../panels/printers/new-printer-dialog.ui.h:5
+#| msgid "_Add..."
+msgid "_Add"
+msgstr "_Legg til"
+
+#: ../panels/printers/pp-new-printer-dialog.c:651
+msgid "Getting devices..."
+msgstr "Hentar einingar …"
+
+#. Translators: No localy connected printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1234
+msgid "No local printers found"
+msgstr ""
+
+#. Translators: No network printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1247
+msgid "No network printers found"
+msgstr ""
+
+#: ../panels/printers/pp-new-printer-dialog.c:1339
+msgid ""
+"FirewallD is not running. Network printer detection needs services mdns, "
+"ipp, ipp-client and samba-client enabled on firewall."
+msgstr ""
+"FirewallD køyrer ikkje. For å kunna oppdaga nettverksskrivarar må tenestene "
+"mdns, ipp, ipp-client og samba-client vere slått på i brannmuren."
+
+#. Translators: Column of devices which can be installed
+#: ../panels/printers/pp-new-printer-dialog.c:1367
+#: ../panels/printers/pp-new-printer-dialog.c:1372
+msgid "Devices"
+msgstr "Einingar"
+
+#. Translators: Local means local printers
+#: ../panels/printers/pp-new-printer-dialog.c:1397
+msgctxt "printer type"
+msgid "Local"
+msgstr "Lokal"
+
+#. Translators: Network means network printers
+#: ../panels/printers/pp-new-printer-dialog.c:1399
+msgctxt "printer type"
+msgid "Network"
+msgstr "Nettverk"
+
+#. Translators: Device types column (network or local)
+#: ../panels/printers/pp-new-printer-dialog.c:1440
+msgid "Device types"
+msgstr "Einingstype"
+
+#. Translators: Name of job which makes printer to autoconfigure itself
+#: ../panels/printers/pp-new-printer-dialog.c:1760
+msgid "Automatic configuration"
+msgstr "Automatisk oppsett"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1783
+msgid "Opening firewall for mDNS connections"
+msgstr "Opnar brannmur for mDNS-tilkoplingar"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1792
+msgid "Opening firewall for Samba connections"
+msgstr "Opnar brannmur for Samba-tilkoplingar"
+
+#: ../panels/printers/pp-new-printer-dialog.c:1801
+msgid "Opening firewall for IPP connections"
+msgstr "Opnar brannmur for IPP-tilkoplingar"
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr ""
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "Tilførsle"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "Plassering"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default"
+msgstr "_Standard"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "Oppgåver"
+
+#. Tanslators: Switch to tab containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "_Show"
+msgstr "_Vis"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "Modell"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:15
+msgid "Print _Test Page"
+msgstr "Skriv ut _testside"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:17
+msgid "_Options"
+msgstr "Innstillingar"
+
+#. Translators: Switch back to printer's info tab
+#: ../panels/printers/printers.ui.h:19
+msgid "_Back"
+msgstr "Til_bake"
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:21
+msgid "Active Print Jobs"
+msgstr "Aktive utskriftsoppgåver"
+
+#: ../panels/printers/printers.ui.h:22
+msgid "Resume Printing"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:23
+msgid "Pause Printing"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:24
+msgid "Cancel Print Job"
+msgstr ""
+
+#. Translators: This tab contains list of active print jobs of the selected printer
+#: ../panels/printers/printers.ui.h:26
+msgid "Printer Options"
+msgstr "Skrivarinnstillingar"
+
+#: ../panels/printers/printers.ui.h:27
+msgid "Add User"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:28
+msgid "Remove User"
+msgstr ""
+
+#: ../panels/printers/printers.ui.h:29
+msgid "Allowed users"
+msgstr "Brukarar med tilgang"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:31
+msgid "Add New Printer"
+msgstr "Legg til ny skrivar"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:33
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"Utskriftstenesta er ikkje\n"
+"tilgjengeleg."
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Keyboard Layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid "Change your region and language settings"
+msgstr "Endra region- og språkinnstillingane dine"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-formats.c:142
+msgid "Imperial"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-formats.c:144
+msgid "Metric"
+msgstr "Metrisk"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:1
+msgid "Choose a Layout"
+msgstr "Vel utforming"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:2
+msgid "Preview"
+msgstr "Førehandsvis"
+
+#: ../panels/region/gnome-region-panel-layout-chooser.ui.h:3
+msgid "Select an input source to add"
+msgstr "Vel inndatakjelda som skal leggjast til"
+
+#
+#: ../panels/region/gnome-region-panel-options-dialog.ui.h:1
+msgid "Keyboard Layout Options"
+msgstr "Alternativ for tastaturutforming"
+
+#: ../panels/region/gnome-region-panel-system.c:420
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings."
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-system.c:425
+#: ../panels/region/gnome-region-panel.ui.h:32
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings. You may change the system settings to match "
+"yours."
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-system.c:428
+msgid "Copy Settings"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-system.c:431
+#: ../panels/region/gnome-region-panel.ui.h:39
+msgid "Copy Settings..."
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:1
+msgid "Region and Language"
+msgstr "Region og språk"
+
+#: ../panels/region/gnome-region-panel.ui.h:2
+msgid ""
+"Select a display language (change will be applied next time you log in)"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:3
+msgid "Install languages..."
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:4
+msgid "Add Language"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:5
+msgid "Remove Language"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:6
+msgid "Language"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:7
+msgid "Select a region (change will be applied the next time you log in)"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:8
+msgid "Add Region"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:9
+msgid "Remove Region"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:10
+msgid "Dates"
+msgstr "Datoar"
+
+#: ../panels/region/gnome-region-panel.ui.h:11
+msgid "Times"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:12
+msgid "Numbers"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:13
+msgid "Currency"
+msgstr "Valutainnstillingar"
+
+#: ../panels/region/gnome-region-panel.ui.h:14
+msgid "Measurement"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:15
+msgid "Examples"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:16
+msgid "Formats"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:17
+msgid "Add Layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:18
+msgid "Remove Layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:19
+msgid "Move Up"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:20
+msgid "Move Down"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:21
+msgid "Preview Layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:22
+msgid "Use the same layout for all windows"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:23
+msgid "Allow different layouts for individual windows"
+msgstr "Tillat ulike utformingar for kvart vindauge"
+
+#: ../panels/region/gnome-region-panel.ui.h:24
+msgid "New windows use the default layout"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:25
+msgid "New windows use the previous window's layout"
+msgstr ""
+
+#
+#: ../panels/region/gnome-region-panel.ui.h:27
+#| msgid "Keyboard Layout Options"
+msgid "View and edit keyboard layout options"
+msgstr "Vis og endra tastaturutformingsinnstillingar"
+
+#
+#: ../panels/region/gnome-region-panel.ui.h:28
+msgid "Reset to De_faults"
+msgstr "Set til _standard"
+
+#: ../panels/region/gnome-region-panel.ui.h:29
+msgid ""
+"Replace the current keyboard layout settings with the\n"
+"default settings"
+msgstr ""
+"Byt ut gjeldande tastaturutformingsinnstillingar med standardinnstillingane"
+
+#: ../panels/region/gnome-region-panel.ui.h:31
+msgid "Layouts"
+msgstr "Utformingar"
+
+#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
+#: ../panels/region/gnome-region-panel.ui.h:34
+msgid "Display language:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:35
+msgid "Input source:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:36
+msgid "Format:"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:37
+msgid "Your settings"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel.ui.h:38
+msgid "System settings"
+msgstr ""
+
+#: ../panels/region/gnome-region-panel-xkblt.c:210
+msgid "Layout"
+msgstr "Formgjeving"
+
+#: ../panels/region/gnome-region-panel-xkbot.c:229
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:586
+msgid "Default"
+msgstr "Standard"
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:1
+msgid "Brightness and Lock"
+msgstr ""
+
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:2
+msgid "Screen brightness and lock settings"
+msgstr "Innstillingar for lysstyrke på skjerm og låsing"
+
+#. Translators: those are keywords for the brightness and lock control-center panel
+#: ../panels/screen/gnome-screen-panel.desktop.in.in.h:4
+msgid "Brightness;Lock;Dim;Blank;Monitor;"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:1
+msgid "Screen turns off"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:2
+msgid "30 seconds"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:3
+msgid "1 minute"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:4
+msgid "2 minutes"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:5
+msgid "3 minutes"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:11
+msgid "_Dim screen to save power"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:12
+msgid "Brightness"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:13
+msgid "_Turn screen off when inactive for:"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:14
+msgid "_Lock screen after:"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:15
+msgid "Require my password when waking from suspend"
+msgstr ""
+
+#. To translators: This asks whether you want to lock the screen (through the screensaver) when you're detected to be physically in your home (your house, etc.)
+#: ../panels/screen/screen.ui.h:17
+msgid "Don't lock when at home"
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:18
+msgid "Locations..."
+msgstr ""
+
+#: ../panels/screen/screen.ui.h:19
+msgid "Lock"
+msgstr "Lås"
+
+#
+#: ../panels/sound/applet-main.c:49 ../panels/sound-nua/applet-main.c:49
+msgid "Enable debugging code"
+msgstr "Aktiver feilsøkingsmodus"
+
+#
+#: ../panels/sound/applet-main.c:50 ../panels/sound-nua/applet-main.c:50
+#| msgid "Open with Default Application"
+msgid "Version of this application"
+msgstr "Versjon av dette programmet"
+
+#: ../panels/sound/applet-main.c:62 ../panels/sound-nua/applet-main.c:62
+msgid " — GNOME Volume Control Applet"
+msgstr " – GNOME panelprogram for volumkontroll"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:1
+#| msgid "UI Control"
+msgid "Volume Control"
+msgstr "Volumkontroll"
+
+#: ../panels/sound/data/gnome-sound-applet.desktop.in.h:2
+msgid "Show desktop volume control"
+msgstr "Vis volumkontroll for skrivebord"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+#: ../panels/sound-nua/data/gnome-sound-nua-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "Lyd"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+#: ../panels/sound-nua/data/gnome-sound-nua-panel.desktop.in.in.h:2
+msgid "Change sound volume and sound events"
+msgstr "Endra lydvolum og -hendingar"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+#: ../panels/sound-nua/data/gnome-sound-nua-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+msgstr ""
+"Kort;Mikrofon;Volum;Feiding;Fading;Fade;Balanse;Blåtann;Bluetooth;Headset;Hov"
+"udsett;Hovudtelefonar;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "Bjeff"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "Drypp"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "Glass"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+#| msgid "Sound"
+msgid "Sonar"
+msgstr "Sonar"
+
+#: ../panels/sound/gvc-applet.c:270 ../panels/sound/gvc-mixer-dialog.c:1768
+#: ../panels/sound-nua/gvc-applet.c:270
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1761
+#| msgid "Mutt"
+msgid "Output"
+msgstr "Utdata"
+
+#: ../panels/sound/gvc-applet.c:272 ../panels/sound-nua/gvc-applet.c:272
+msgid "Sound Output Volume"
+msgstr "Volum for lydutdata"
+
+#: ../panels/sound/gvc-applet.c:276 ../panels/sound/gvc-mixer-dialog.c:1809
+#: ../panels/sound-nua/gvc-applet.c:276
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1894
+msgid "Input"
+msgstr "Inndata"
+
+#: ../panels/sound/gvc-applet.c:278 ../panels/sound-nua/gvc-applet.c:278
+msgid "Microphone Volume"
+msgstr "Mikrofonvolum"
+
+#
+#: ../panels/sound/gvc-balance-bar.c:111
+#: ../panels/sound-nua/gvc-balance-bar.c:111
+#| msgid "Left"
+msgctxt "balance"
+msgid "Left"
+msgstr "Venstre"
+
+#
+#: ../panels/sound/gvc-balance-bar.c:112
+#: ../panels/sound-nua/gvc-balance-bar.c:112
+#| msgid "Right"
+msgctxt "balance"
+msgid "Right"
+msgstr "Høgre"
+
+#: ../panels/sound/gvc-balance-bar.c:115
+#: ../panels/sound-nua/gvc-balance-bar.c:115
+#| msgid "Search"
+msgctxt "balance"
+msgid "Rear"
+msgstr "Bak"
+
+#
+#: ../panels/sound/gvc-balance-bar.c:116
+#: ../panels/sound-nua/gvc-balance-bar.c:116
+#| msgid "Fonts"
+msgctxt "balance"
+msgid "Front"
+msgstr "Framme"
+
+#
+#: ../panels/sound/gvc-balance-bar.c:119
+#: ../panels/sound-nua/gvc-balance-bar.c:119
+#| msgid "Minimize"
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Minimum"
+
+#: ../panels/sound/gvc-balance-bar.c:120
+#: ../panels/sound-nua/gvc-balance-bar.c:120
+#| msgid "Maximize"
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Maksimum"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+#: ../panels/sound-nua/gvc-balance-bar.c:295
+msgid "_Balance:"
+msgstr "_Balanse:"
+
+#: ../panels/sound/gvc-balance-bar.c:298
+#: ../panels/sound-nua/gvc-balance-bar.c:298
+#| msgid "_Name:"
+msgid "_Fade:"
+msgstr "_Feiding:"
+
+#: ../panels/sound/gvc-balance-bar.c:301
+#: ../panels/sound-nua/gvc-balance-bar.c:301
+msgid "_Subwoofer:"
+msgstr "_Basselement"
+
+#: ../panels/sound/gvc-channel-bar.c:603 ../panels/sound/gvc-channel-bar.c:612
+#: ../panels/sound-nua/gvc-channel-bar.c:603
+#: ../panels/sound-nua/gvc-channel-bar.c:612
+msgctxt "volume"
+msgid "100%"
+msgstr "100 %"
+
+#: ../panels/sound/gvc-channel-bar.c:607
+#: ../panels/sound-nua/gvc-channel-bar.c:607
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Uforsterka"
+
+#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:1622
+#: ../panels/sound-nua/gvc-combo-box.c:167
+#| msgid "_Mobile:"
+msgid "_Profile:"
+msgstr "_Profil:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1094
+#: ../panels/sound-nua/gvc-mixer-control.c:1913
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u utgang"
+msgstr[1] "%u utgangar"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc-mixer-control.c:1104
+#: ../panels/sound-nua/gvc-mixer-control.c:1923
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u inngang"
+msgstr[1] "%u inngangar"
+
+#: ../panels/sound/gvc-mixer-control.c:1402
+#: ../panels/sound-nua/gvc-mixer-control.c:2440
+#| msgid "System"
+msgid "System Sounds"
+msgstr "Systemlydar"
+
+#: ../panels/sound/gvc-mixer-dialog.c:324
+#: ../panels/sound/gvc-mixer-dialog.c:635
+msgid "Co_nnector:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:541
+#: ../panels/sound-nua/gvc-mixer-dialog.c:343
+msgid "Peak detect"
+msgstr "Oppdag topp"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1497
+#: ../panels/sound/gvc-mixer-dialog.c:1710
+#: ../panels/sound/gvc-sound-theme-chooser.c:595
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1591
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:596
+#| msgid "Name:"
+msgid "Name"
+msgstr "Namn"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1564
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1693
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "Høgtalartesting for %s"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1623
+msgid "_Test Speakers"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1754
+#: ../panels/sound-nua/gvc-mixer-dialog.c:2034
+msgid "_Output volume:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1773
+msgid "C_hoose a device for sound output:"
+msgstr "_Vel eining som lydutgang:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1798
+#: ../panels/sound/gvc-mixer-dialog.c:1927
+msgid "Settings for the selected device:"
+msgstr "Innstillingar for den valde eininga:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1816
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1941
+msgid "_Input volume:"
+msgstr ""
+
+#
+#: ../panels/sound/gvc-mixer-dialog.c:1839
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1974
+#| msgid "_Input boxes:"
+msgid "Input level:"
+msgstr "Nivå for innlyd:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1867
+msgid "C_hoose a device for sound input:"
+msgstr "_Vel eining som lydinngang:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1894
+msgid "Hardware"
+msgstr "Maskinvare"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1899
+msgid "C_hoose a device to configure:"
+msgstr "_Vel eining å setja opp:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1938
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1995
+msgid "Sound Effects"
+msgstr "Lydeffektar"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1945
+#: ../panels/sound-nua/gvc-mixer-dialog.c:2002
+msgid "_Alert volume:"
+msgstr ""
+
+#: ../panels/sound/gvc-mixer-dialog.c:1958
+#: ../panels/sound-nua/gvc-mixer-dialog.c:2015
+#| msgid "_Application font:"
+msgid "Applications"
+msgstr "Program"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1962
+#: ../panels/sound-nua/gvc-mixer-dialog.c:2019
+msgid "No application is currently playing or recording audio."
+msgstr "Ingen program spelar eller tek opp lyd."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:189
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:190
+msgid "Built-in"
+msgstr "Innebygd"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:455
+#: ../panels/sound/gvc-sound-theme-chooser.c:467
+#: ../panels/sound/gvc-sound-theme-chooser.c:479
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:456
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:468
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:480
+#| msgid "Mouse Preferences"
+msgid "Sound Preferences"
+msgstr "Lydinnstillingar"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:458
+#: ../panels/sound/gvc-sound-theme-chooser.c:469
+#: ../panels/sound/gvc-sound-theme-chooser.c:481
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:459
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:470
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:482
+msgid "Testing event sound"
+msgstr "Testar hendingslyd"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:586
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:587
+msgid "From theme"
+msgstr "Frå tema"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:770
+#: ../panels/sound-nua/gvc-sound-theme-chooser.c:782
+#| msgid "Choose a Layout"
+msgid "C_hoose an alert sound:"
+msgstr "_Vel varsellyd:"
+
+#: ../panels/sound/gvc-speaker-test.c:221
+#: ../panels/sound-nua/gvc-speaker-test.c:221
+msgid "Stop"
+msgstr "Stopp"
+
+#
+#: ../panels/sound/gvc-speaker-test.c:221
+#: ../panels/sound/gvc-speaker-test.c:333
+#: ../panels/sound-nua/gvc-speaker-test.c:221
+#: ../panels/sound-nua/gvc-speaker-test.c:333
+#| msgid "Text"
+msgid "Test"
+msgstr "Test"
+
+#: ../panels/sound/gvc-speaker-test.c:229
+#: ../panels/sound-nua/gvc-speaker-test.c:229
+msgid "Subwoofer"
+msgstr ""
+
+#: ../panels/sound/gvc-stream-status-icon.c:236
+#: ../panels/sound-nua/gvc-stream-status-icon.c:235
+#, c-format
+msgid "Failed to start Sound Preferences: %s"
+msgstr "Starting av lydval feila: %s"
+
+#: ../panels/sound/gvc-stream-status-icon.c:262
+#: ../panels/sound-nua/gvc-stream-status-icon.c:261
+#| msgid "Mutt"
+msgid "_Mute"
+msgstr "_Demp"
+
+#: ../panels/sound/gvc-stream-status-icon.c:271
+#: ../panels/sound-nua/gvc-stream-status-icon.c:270
+#| msgid "Mouse Preferences"
+msgid "_Sound Preferences"
+msgstr "_Lydinnstillingar"
+
+#: ../panels/sound/gvc-stream-status-icon.c:416
+#: ../panels/sound-nua/gvc-stream-status-icon.c:415
+#| msgid "Multimedia"
+msgid "Muted"
+msgstr "Dempa"
+
+#: ../panels/sound/sound-theme-file-utils.c:292
+#: ../panels/sound-nua/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr "Sjølvvald"
+
+#: ../panels/universal-access/cc-ua-panel.c:522
+#: ../panels/universal-access/cc-ua-panel.c:528
+msgid "No shortcut set"
+msgstr ""
+
+#
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+#| msgid "Appearance Preferences"
+msgid "Universal Access Preferences"
+msgstr "Innstillingar for tilgjenge"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen "
+"Reader;text;font;size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+msgstr ""
+
+#
+#: ../panels/universal-access/uap.ui.h:1
+#| msgid "GNOME OnScreen Keyboard"
+msgid "On screen keyboard"
+msgstr "Tastatur på skjermen"
+
+#
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Dasher"
+msgstr "Dasher"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "Nomon"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "Caribou"
+msgstr "Reinsdyr"
+
+#: ../panels/universal-access/uap.ui.h:7
+#, no-c-format
+msgid "75%"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:8
+msgctxt "universal access, text size"
+msgid "Small"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:10
+#, no-c-format
+msgid "100%"
+msgstr "100 %"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgctxt "universal access, text size"
+msgid "Normal"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:13
+#, no-c-format
+msgid "125%"
+msgstr "125 %"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgctxt "universal access, text size"
+msgid "Large"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:16
+#, no-c-format
+msgid "150%"
+msgstr "150 %"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgctxt "universal access, text size"
+msgid "Larger"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "GOK"
+msgstr "GOK"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "OnBoard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Change contrast:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "_Contrast:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "_Text size:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "Increase size:"
+msgstr "Auk storleik:"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Decrease size:"
+msgstr "Minsk storleik:"
+
+#. Translators: this refers to theme contrast and font size
+#: ../panels/universal-access/uap.ui.h:26
+msgctxt "universal access, seeing"
+msgid "Display"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Turn on or off:"
+msgstr "Slå på eller av:"
+
+#: ../panels/universal-access/uap.ui.h:28
+#| msgid "Zoom"
+msgid "Zoom in:"
+msgstr "Forstørr:"
+
+#: ../panels/universal-access/uap.ui.h:29
+#| msgid "Zoom"
+msgid "Zoom out:"
+msgstr "Forminsk:"
+
+#: ../panels/universal-access/uap.ui.h:30
+#| msgid "_Options..."
+msgid "Options..."
+msgstr "Innstillingar …"
+
+#. Translators: this refers to screen magnifier
+#: ../panels/universal-access/uap.ui.h:32
+msgctxt "universal access, seeing"
+msgid "Zoom"
+msgstr ""
+
+#
+#: ../panels/universal-access/uap.ui.h:33
+#| msgid "Linux Screen Reader"
+msgid "Screen Reader"
+msgstr "Skjermlesar"
+
+#
+#: ../panels/universal-access/uap.ui.h:34
+#| msgid "Beep when a key is pr_essed"
+msgid "Beep when Caps and Num Lock are used"
+msgstr "Pip når Caps Lock og Num Lock vert brukt"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgid "Seeing"
+msgstr "Syn"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Use a visual indication when an alert sound occurs"
+msgstr "Bruk visuell indikasjon når varsellydar vert avspela"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgid "_Test flash"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:38
+#| msgid "Flash _window titlebar"
+msgid "Flash the window title"
+msgstr "Blink tittellinja på vindauget"
+
+#: ../panels/universal-access/uap.ui.h:39
+#| msgid "Flash entire _screen"
+msgid "Flash the entire screen"
+msgstr "Lat heile skjermen blinke"
+
+#: ../panels/universal-access/uap.ui.h:40
+#| msgid "Visual"
+msgid "Visual Alerts"
+msgstr "Visuelle varslar"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "Display a textual description of speech and sounds"
+msgstr "Vis tekstskildring av tale og lydar."
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Closed Captioning"
+msgstr "Undertekst"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Hearing"
+msgstr "Høyrsel"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "Screen keyboard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:46
+#| msgid "A_ssistant:"
+msgid "Typing Assistant"
+msgstr "Skriveassistent"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "_Turn on accessibility features from the keyboard"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Ser på rekkjefølgjer av valtastar som tastekombinasjonar"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Beep when a _modifer key is pressed"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:51
+#| msgid "<b>Sticky Keys</b>"
+msgid "Sticky Keys"
+msgstr "Seige tastar"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Set eit opphald mellom tastetrykk og når trykket vert godteke"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "Slow keys typing delay"
+msgstr ""
+
+#
+#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
+#: ../panels/universal-access/uap.ui.h:60
+#| msgid "Beep when a key is pr_essed"
+msgid "Beep when a key is"
+msgstr "Pip når tast vert"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:62
+msgid "pressed"
+msgstr "trykt"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:64
+msgid "accepted"
+msgstr "godkjent"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:66
+msgid "rejected"
+msgstr "avvist"
+
+#: ../panels/universal-access/uap.ui.h:67
+#| msgid "<b>Slow Keys</b>"
+msgid "Slow Keys"
+msgstr "Trege tastar"
+
+#
+#: ../panels/universal-access/uap.ui.h:68
+#| msgid "_Ignore fast duplicate keypresses"
+msgid "Ignores fast duplicate keypresses"
+msgstr "Overser snøgge duplikate tastetrykk"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Acc_eptance delay:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:70
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:72
+#| msgid "Mouse Keys"
+msgid "Bounce Keys"
+msgstr "Sprettetastar"
+
+#: ../panels/universal-access/uap.ui.h:73
+#| msgid "_Type to test settings:"
+msgid "Type here to test settings"
+msgstr "Skriv for å testa innstillingane"
+
+#: ../panels/universal-access/uap.ui.h:76
+msgid "Control the pointer using the keypad"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:77
+msgid "Mouse Keys"
+msgstr "Musetastar"
+
+#: ../panels/universal-access/uap.ui.h:78
+msgid "Control the pointer using the video camera."
+msgstr "Styr musepeikaren med videokameraet."
+
+#: ../panels/universal-access/uap.ui.h:79
+#| msgid "Mouse"
+msgid "Video Mouse"
+msgstr "Videomus"
+
+#: ../panels/universal-access/uap.ui.h:80
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:81
+msgid "Secondary click delay"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:82
+#| msgid "<b>Simulated Secondary Click</b>"
+msgid "Simulated Secondary Click"
+msgstr "Simulert høgreklikk"
+
+#: ../panels/universal-access/uap.ui.h:83
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#
+#: ../panels/universal-access/uap.ui.h:84
+msgid "D_elay:"
+msgstr "Paus_e:"
+
+#: ../panels/universal-access/uap.ui.h:85
+msgid "Motion _threshold:"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:90
+msgid "Hover Click"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:91
+msgid "Mouse Settings"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:92
+msgid "Pointing and Clicking"
+msgstr "Peik og klikk"
+
+#: ../panels/universal-access/uap.ui.h:93
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:94
+msgctxt "universal access, contrast"
+msgid "Normal"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:95
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: ../panels/universal-access/uap.ui.h:96
+msgctxt "universal access, contrast"
+msgid "High/Inverse"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:334
+msgid "1/4 Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:335
+msgid "1/2 Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.c:336
+msgid "3/4 Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Zoom Options"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Magnification:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Follow mouse cursor"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Screen part:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Magnifier extends outside of screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Keep magnifier cursor centered"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Magnifier cursor pushes contents around"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnifier cursor moves with contents"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Magnifier Position:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Thickness:"
+msgstr ""
+
+#. short delay
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Thin"
+msgstr ""
+
+#. long delay
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Thick"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Length:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Color:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Crosshairs:"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgid "Overlaps mouse cursor"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgid "Full Screen"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Top Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:21
+msgid "Bottom Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Left Half"
+msgstr ""
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Right Half"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:35
+#| msgid "Standard XTerminal"
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Standard"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:37
+#| msgid "Terminator"
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Administrator"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+#| msgid "Create New Location"
+msgid "Create new account"
+msgstr "Lag ny konto"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "_Full name"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "_Account Type"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#| msgid "C_reate"
+msgid "Cr_eate"
+msgstr "_Lag"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "Venstre tommel"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "Venstre langfinger"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "Venstre ringfinger"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "Venstre litlefinger"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+#| msgid "Right"
+msgid "Right thumb"
+msgstr "Høgre tommel"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "Høgre langfinger"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "Høgre ringfinger"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "Høgre litlefinger"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:706
+msgid "Enable Fingerprint Login"
+msgstr "Slå på innlogging via fingeravtrykk"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr ""
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"Fingeravtrykket ditt vart lagra. Du skal no kunne logga inn ved hjelp av "
+"fingeravtrykklesaren din."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+#| msgid "seconds"
+msgid "User Accounts"
+msgstr "Brukarkontoar"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users"
+msgstr "Legg til eller fjern brukarar"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Innlogging;Namn;Fingeravtrykk;Personbilete;Logo;Fjes;Passord;"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#| msgid "_New password:"
+msgid "Set a password now"
+msgstr "Set passord no"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+msgid "Choose password at next login"
+msgstr "Vel passord under neste innlogging"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Log in without a password"
+msgstr "Logg inn utan passord"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "Disable this account"
+msgstr "Slå av denne kontoen"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Enable this account"
+msgstr "Slå på denne kontoen"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "_Hint"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid ""
+"This hint may be displayed at the login screen.  It will be visible to all "
+"users of this system.  Do <b>not</b> include the password here."
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "C_onfirm password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+msgid "_New password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+#| msgid "Change password"
+msgid "Choose a generated password"
+msgstr "Vel frambringa passord"
+
+#
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+#| msgid "Filter"
+msgid "Fair"
+msgstr "Rimeleg"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+msgid "Current _password"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid "_Action"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+msgid "Changing password for"
+msgstr ""
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:15
+#| msgid "_New password:"
+msgid "_Show password"
+msgstr "_Vis passord:"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:16
+msgid "How to choose a strong password"
+msgstr "Korleis velja eit sterkt passord"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:17
+#| msgid "Change set"
+msgid "Ch_ange"
+msgstr "_Endra"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+msgid "Changing photo for:"
+msgstr "Endrar bilete til:"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+msgid ""
+"Choose a picture that will be shown at the login screen for this account."
+msgstr "Vel bilete som vil visast på innloggingskjermen for denne kontoen."
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+#| msgid "Galeon"
+msgid "Gallery"
+msgstr "Galleri"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+#| msgid "Take a break!"
+msgid "Take a photograph"
+msgstr "Ta fotografi"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+#| msgid "Web Browser"
+msgid "Browse"
+msgstr "Bla gjennom"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr "Fotograf"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+#: ../panels/user-accounts/um-photo-dialog.c:98
+#| msgid "_Select"
+msgid "Select"
+msgstr "Vel"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Account Information"
+msgstr "Kontoinformasjon"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Add User Account"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Remove User Account"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Account _type"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "Login Options"
+msgstr "Innloggingsinnstillingar"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "_Password"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "A_utomatic Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "User Icon"
+msgstr ""
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "_Language"
+msgstr ""
+
+#: ../panels/user-accounts/run-passwd.c:426
+#| msgid "Authenticated!"
+msgid "Authentication failed"
+msgstr "Autentisering feila"
+
+#: ../panels/user-accounts/run-passwd.c:506
+#: ../panels/user-accounts/um-password-dialog.c:376
+#, c-format
+#| msgid "The password is too short."
+msgid "The new password is too short"
+msgstr "Det nye passordet er for kort"
+
+#: ../panels/user-accounts/run-passwd.c:512
+#, c-format
+#| msgid "The password is too simple."
+msgid "The new password is too simple"
+msgstr "Det nye passordet er for enkelt"
+
+#: ../panels/user-accounts/run-passwd.c:518
+#, c-format
+#| msgid "The old and new passwords are too similar."
+msgid "The old and new passwords are too similar"
+msgstr "Gammalt og nytt passord er for like"
+
+#: ../panels/user-accounts/run-passwd.c:521
+#, c-format
+#| msgid "The two passwords are not equal."
+msgid "The new password has already been used recently."
+msgstr "Det nye passordet har nyleg vore brukt."
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+#| msgid "The new password must contain numeric or special character(s)."
+msgid "The new password must contain numeric or special characters"
+msgstr "Det nye passordet må innehalda tal eller spesialteikn."
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+#| msgid "The old and new passwords are the same."
+msgid "The old and new passwords are the same"
+msgstr "Gammalt og nytt passord er det same."
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+#| msgid ""
+#| "Your password has been changed since you initially authenticated! Please "
+#| "re-authenticate."
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+"Passordet ditt har vorte endra sidan du autentiserte første gong. Du må "
+"autentisera deg på nytt."
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+#| msgid "The new password must contain numeric or special character(s)."
+msgid "The new password does not contain enough different characters"
+msgstr "Det nye passordet inneheld ikkje mange nok forskjellege teikn."
+
+#: ../panels/user-accounts/run-passwd.c:540
+#, c-format
+#| msgid "Unknown"
+msgid "Unknown error"
+msgstr "Ukjend feil"
+
+#: ../panels/user-accounts/um-account-dialog.c:73
+#| msgid "Failed to create temporary directory"
+msgid "Failed to create user"
+msgstr "Laging av ny brukar feila"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"Du har ikkje løyve til å opna eininga. Kontakt systemadministratoren."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "Eininga er alt i bruk."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:143
+#| msgid "An internal error occured"
+msgid "An internal error occurred."
+msgstr "Ein intern feil har oppstått."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:219
+#: ../panels/user-accounts/um-fingerprint-dialog.c:220
+#| msgid "Disabled"
+msgid "Enabled"
+msgstr "På"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:268
+msgid "Delete registered fingerprints?"
+msgstr "Slett registrerte fingeravtrykk?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:272
+msgid "_Delete Fingerprints"
+msgstr "_Slett fingeravtrykk"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:279
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Vil du sletta registrerte fingeravtrykk slik at innlogging via fingeravtrykk "
+"vert avslått?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:455
+#| msgid "None"
+msgid "Done!"
+msgstr "Ferdig!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:516
+#: ../panels/user-accounts/um-fingerprint-dialog.c:558
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "Klarte ikkje opna eininga «%s»"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:603
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "Klarte ikkje starta innlesing av fingeravtrykk på eining «%s»"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:655
+#| msgid "Could not load the main interface"
+msgid "Could not access any fingerprint readers"
+msgstr "Klarte ikkje opna fingeravtrykklesar"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:656
+msgid "Please contact your system administrator for help."
+msgstr "Kontakt systemadministratoren for å få hjelp."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#. 
+#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"For å slå på innlogging via fingeravtrykk må du lagra eitt fingeravtrykk ved "
+"å bruka eininga «%s»"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:747
+msgid "Selecting finger"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:748
+msgid "Enrolling fingerprints"
+msgstr ""
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:749
+msgid "Summary"
+msgstr ""
+
+#: ../panels/user-accounts/um-password-dialog.c:180
+msgid "More choices..."
+msgstr "Fleire val …"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "Please choose another password."
+msgstr "Vel eit anna passord."
+
+#: ../panels/user-accounts/um-password-dialog.c:295
+#| msgid "Please type your password in the <b>New password</b> field."
+msgid "Please type your current password again."
+msgstr "Skriv inn gjeldande passord omatt."
+
+#: ../panels/user-accounts/um-password-dialog.c:301
+#| msgid "Your password has been changed."
+msgid "Password could not be changed"
+msgstr "Passordet kunne ikkje endrast"
+
+#: ../panels/user-accounts/um-password-dialog.c:373
+#| msgid "_Retype new password:"
+msgid "You need to enter a new password"
+msgstr "Du må skriva inn eit nytt passord"
+
+#: ../panels/user-accounts/um-password-dialog.c:382
+msgid "You need to confirm the password"
+msgstr "Du må bekrefta passordet"
+
+#: ../panels/user-accounts/um-password-dialog.c:385
+#| msgid "The password is too short."
+msgid "The passwords do not match"
+msgstr "Passorda er ikkje like"
+
+#: ../panels/user-accounts/um-password-dialog.c:391
+msgid "You need to enter your current password"
+msgstr "Du må skriva inn ditt gjeldande passord"
+
+#: ../panels/user-accounts/um-password-dialog.c:394
+#| msgid "That password was incorrect."
+msgid "The current password is not correct"
+msgstr "Det gjeldande passordet er ikkje riktig"
+
+#: ../panels/user-accounts/um-password-dialog.c:467
+#: ../panels/user-accounts/um-password-dialog.c:731
+msgctxt "Password strength"
+msgid "Too short"
+msgstr "For kort"
+
+#: ../panels/user-accounts/um-password-dialog.c:470
+#: ../panels/user-accounts/um-password-dialog.c:732
+msgctxt "Password strength"
+msgid "Weak"
+msgstr "Svakt"
+
+#
+#: ../panels/user-accounts/um-password-dialog.c:472
+#: ../panels/user-accounts/um-password-dialog.c:733
+#| msgid "Filter"
+msgctxt "Password strength"
+msgid "Fair"
+msgstr "Greitt"
+
+#: ../panels/user-accounts/um-password-dialog.c:474
+#: ../panels/user-accounts/um-password-dialog.c:734
+msgctxt "Password strength"
+msgid "Good"
+msgstr "Godt"
+
+#: ../panels/user-accounts/um-password-dialog.c:476
+#: ../panels/user-accounts/um-password-dialog.c:735
+#| msgid "Scrolling"
+msgctxt "Password strength"
+msgid "Strong"
+msgstr "Sterkt"
+
+#: ../panels/user-accounts/um-password-dialog.c:515
+msgid "Passwords do not match"
+msgstr "Passord er ikkje like"
+
+#: ../panels/user-accounts/um-password-dialog.c:541
+#| msgid "Change password"
+msgid "Wrong password"
+msgstr "Svakt passord"
+
+#: ../panels/user-accounts/um-photo-dialog.c:443
+#| msgid "Disabled"
+msgid "Disable image"
+msgstr "Slå av bilete"
+
+#: ../panels/user-accounts/um-photo-dialog.c:461
+msgid "Take a photo..."
+msgstr "Ta bilete …"
+
+#: ../panels/user-accounts/um-photo-dialog.c:479
+msgid "Browse for more pictures..."
+msgstr "Bla gjennom for fleire bilete …"
+
+#: ../panels/user-accounts/um-photo-dialog.c:704
+#, c-format
+msgid "Used by %s"
+msgstr "Brukt av %s"
+
+#: ../panels/user-accounts/um-user-manager.c:463
+#, c-format
+#| msgid "The location already exists."
+msgid "A user with name '%s' already exists."
+msgstr "Brukar med namnet «%s» finst alt."
+
+#: ../panels/user-accounts/um-user-manager.c:569
+msgid "This user does not exist."
+msgstr "Denne brukaren finst ikkje."
+
+#: ../panels/user-accounts/um-user-panel.c:355
+msgid "Failed to delete user"
+msgstr "Sletting av brukar feila"
+
+#: ../panels/user-accounts/um-user-panel.c:415
+msgid "You cannot delete your own account."
+msgstr "Du kan ikkje sletta din eigen konto"
+
+#: ../panels/user-accounts/um-user-panel.c:424
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s er fortset logga inn"
+
+#: ../panels/user-accounts/um-user-panel.c:428
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Sletting av brukar medan dei er logga inn kan etterlata systemet i ein "
+"inkonsekvent tilstand."
+
+#: ../panels/user-accounts/um-user-panel.c:437
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "Vil du behalda filene til «%s»?"
+
+#: ../panels/user-accounts/um-user-panel.c:441
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Det er mogleg å behalda heimemappa, e-postkøa og mellombels filer etter "
+"sletting av brukarkonto."
+
+#: ../panels/user-accounts/um-user-panel.c:444
+#| msgid "_Delete Fingerprints"
+msgid "_Delete Files"
+msgstr "_Slett filer"
+
+#: ../panels/user-accounts/um-user-panel.c:445
+#| msgid "All Files"
+msgid "_Keep Files"
+msgstr "_Behald filer"
+
+#: ../panels/user-accounts/um-user-panel.c:497
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Deaktivert konto"
+
+#: ../panels/user-accounts/um-user-panel.c:505
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Å verta sette under neste innlogging"
+
+#
+#: ../panels/user-accounts/um-user-panel.c:508
+#| msgid "None"
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ingen"
+
+#: ../panels/user-accounts/um-user-panel.c:860
+msgid "Failed to contact the accounts service"
+msgstr "Å få kontakt med kontotenesta feila"
+
+#: ../panels/user-accounts/um-user-panel.c:862
+#| msgid "Please make sure that the applet is properly installed"
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Kontroller at kontotenesta er installert og slått på."
+
+#: ../panels/user-accounts/um-user-panel.c:902
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"For å gjera endringar,\n"
+"trykk på *-ikonet først"
+
+#: ../panels/user-accounts/um-user-panel.c:940
+msgid "Create a user account"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:951
+#: ../panels/user-accounts/um-user-panel.c:1241
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:960
+msgid "Delete the selected user account"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:972
+#: ../panels/user-accounts/um-user-panel.c:1246
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+
+#: ../panels/user-accounts/um-user-panel.c:1149
+#| msgid "By _country"
+msgid "My Account"
+msgstr "Min konto"
+
+#: ../panels/user-accounts/um-user-panel.c:1159
+msgid "Other Accounts"
+msgstr "Andre kontoar"
+
+#: ../panels/user-accounts/um-utils.c:512
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr "Brukar med brukarnamnet «%s» finst alt"
+
+#: ../panels/user-accounts/um-utils.c:516
+#, c-format
+#| msgid "The password is too short."
+msgid "The username is too long"
+msgstr "Brukarnamnet er for langt"
+
+#: ../panels/user-accounts/um-utils.c:519
+msgid "The username cannot start with a '-'"
+msgstr "Brukarnamnet kan ikkje starta med «-»"
+
+#: ../panels/user-accounts/um-utils.c:522
+msgid ""
+"The username must only consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+msgid "Wacom Graphics Tablet"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set your Wacom tablet preferences"
+msgstr ""
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Map to Monitor..."
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map Buttons..."
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate..."
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Tracking Mode"
+msgstr ""
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Left-Handed Orientation"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr ""
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr ""
+
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:909
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:916
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:944
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:951
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:966
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:968
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:971
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:973
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:978
+#, c-format
+msgid "Mode Switch #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1050
+#, c-format
+msgid "Left Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1053
+#, c-format
+msgid "Right Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1056
+#, c-format
+msgid "Top Button #%d"
+msgstr ""
+
+#: ../panels/wacom/gsd-wacom-device.c:1059
+#, c-format
+msgid "Bottom Button #%d"
+msgstr ""
+
+#. Text printed on screen
+#: ../panels/wacom/calibrator/gui_gtk.c:70
+msgid "Screen Calibration"
+msgstr ""
+
+#: ../panels/wacom/calibrator/gui_gtk.c:71
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: ../panels/wacom/calibrator/gui_gtk.c:271
+msgid "Mis-click detected, restarting..."
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-nav-button.c:89
+#, c-format
+msgid "%d of %d"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:235
+msgid "Output:"
+msgstr ""
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:248
+msgid "Map to single monitor"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:376
+#: ../panels/wacom/cc-wacom-page.c:561
+msgid "Button"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:279
+msgid "Switch Modes"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:526
+msgid "Up"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:526
+msgid "Down"
+msgstr ""
+
+#: ../panels/wacom/cc-wacom-page.c:681
+msgid "Display Mapping"
+msgstr ""
+
+#: ../shell/control-center.c:58
+msgid "Enable verbose mode"
+msgstr ""
+
+#: ../shell/control-center.c:59
+msgid "Show the overview"
+msgstr ""
+
+#: ../shell/control-center.c:60 ../shell/control-center.c:61
+#: ../shell/control-center.c:62
+msgid "Show help options"
+msgstr "Vis hjelpeval"
+
+#: ../shell/control-center.c:63
+msgid "Panel to display"
+msgstr ""
+
+#: ../shell/control-center.c:85
+msgid "- System Settings"
+msgstr ""
+
+#: ../shell/control-center.c:93
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+
+#
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Kontrollsenter"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
+msgid "System Settings"
+msgstr "Systeminnstillingar"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr ""
+
+#: ../panels/sound-nua/gvc-channel-bar.c:901
+#| msgid "Mutt"
+msgid "Mute"
+msgstr "Demp"
+
+#: ../panels/sound-nua/gvc-mixer-dialog.c:777
+#: ../panels/sound-nua/gvc-mixer-dialog.c:950
+#, c-format
+msgid "Settings for %s"
+msgstr ""
+
+#: ../panels/sound-nua/gvc-mixer-dialog.c:806
+#: ../panels/sound-nua/gvc-mixer-dialog.c:962
+msgid "Mode:"
+msgstr ""
+
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1766
+msgid "Play sound through"
+msgstr ""
+
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1791
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1923
+msgid "Settings for the selected device"
+msgstr ""
+
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1864
+msgid "Test:"
+msgstr ""
+
+#
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1871
+msgid "Test Sound"
+msgstr "Testlyd"
+
+#: ../panels/sound-nua/gvc-mixer-dialog.c:1898
+msgid "Record sound from"
+msgstr ""
+
+#: ../panels/universal-access/gconf-property-editor.c:134
+msgid "Key"
+msgstr "Nøkkel"
+
+#: ../panels/universal-access/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr "GConf-nøkkel som denne eigenskapsredigeraren brukar"
+
+#: ../panels/universal-access/gconf-property-editor.c:141
+msgid "Callback"
+msgstr "Tilbakekall"
+
+#: ../panels/universal-access/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Send dette tilbakekallet når verdien knytta til nøkkelen vert endra"
+
+#: ../panels/universal-access/gconf-property-editor.c:147
+msgid "Change set"
+msgstr "Mengd av endringar"
+
+#: ../panels/universal-access/gconf-property-editor.c:148
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"Endringsmengda til GConf inneheld data som skal sendast vidare til gconf-"
+"klienten når endringane vert gjord verksame"
+
+#: ../panels/universal-access/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr "Konvertering til tilbakekall av skjermelement"
+
+#: ../panels/universal-access/gconf-property-editor.c:154
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+"Tilbakekall som skal sendast når data skal konverterast frå GConf til "
+"skjermelementet"
+
+#: ../panels/universal-access/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr "Konvertering frå tilbakekall av skjermelement"
+
+#: ../panels/universal-access/gconf-property-editor.c:160
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"Tilbakekall som skal sendast når data skal konverterast til GConf frå "
+"skjermelementet"
+
+#: ../panels/universal-access/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "UI-kontroll"
+
+#: ../panels/universal-access/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr "Objekt som kontrollerer eigenskapen (normalt eit skjermelement)"
+
+#: ../panels/universal-access/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr "Objektdata for redigering av eigenskapar"
+
+#: ../panels/universal-access/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr "Eigendefinerte data som trengst til eigenskapredigeringsprogrammet"
+
+#: ../panels/universal-access/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr "Tilbakekall som frigjer data frå eigenskapredigeringsprogrammet"
+
+#: ../panels/universal-access/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Tilbakekall som skal sendast når eigenskapsredigeringsprogrammet skal "
+"frigjera objektdata"
+
+#: ../panels/universal-access/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Klarte ikkje finna fila «%s»\n"
+"\n"
+"Kontroller at fila finst og prøv på nytt, eller vel eit anna bakgrunnsbilete."
+
+#: ../panels/universal-access/gconf-property-editor.c:1482
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Veit ikkje korleis fila «%s» skal opnast.\n"
+"Kanskje det er ein biletetype som ikkje er støtta.\n"
+"\n"
+"Vel eit anna bilete i staden."
+
+#: ../panels/universal-access/gconf-property-editor.c:1604
+msgid "Please select an image."
+msgstr "Vel eit bilete."
+
+#: ../shell/cc-shell-nav-bar.c:117
+msgid "_All Settings"
+msgstr "_Alle innstillingar"
+
+#: ../newstrings.desktop.in.h:1
+msgid "Application Menu"
+msgstr ""
+
+#: ../newstrings.desktop.in.h:2
+msgid "Integrated in menu bar and hidden"
+msgstr ""
+
+#: ../newstrings.desktop.in.h:3
+msgid "Integrated in menu bar and visible"
+msgstr ""
+
+#~ msgid "Cursor blinks speed"
+#~ msgstr "Kor fort skrivemerket blinkar"
+
+#~ msgid "Accel Mode"
+#~ msgstr "Snarvegtastmodus"
+
+#
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "_Resolution:"
+#~ msgstr "_Oppløysing:"
+
+#~ msgid "R_otation:"
+#~ msgstr "R_otering:"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "Klarte ikkje finna øktbussen under aktivering av skjerminnstillingar"
+
+#~| msgid "Shortcut"
+#~ msgid "New shortcut..."
+#~ msgstr "Ny snøggtast …"
+
+#~ msgid "Accelerator key"
+#~ msgstr "Snarvegstast"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Endringstastar for snarvegar"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Tastekodar for snarvegar"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Typen snarveg."
+
+#~ msgid "CD _audio:"
+#~ msgstr "CD-_lyd:"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "Medium og autokjør"
+
+#~ msgid "_DVD video:"
+#~ msgstr "_DVD-video:"
+
+#
+#~| msgid "Muine Music Player"
+#~ msgid "_Music player:"
+#~ msgstr "_Musikkspelar:"
+
+#~| msgid "_Yahoo:"
+#~ msgid "_Photos:"
+#~ msgstr "_Bilete:"
+
+#~ msgid "_Software:"
+#~ msgstr "_Programvare:"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "Set opp medium- og autostart-innstillingar"
+
+#~| msgid "Mirror Screens"
+#~ msgid "Screen"
+#~ msgstr "Skjerm"
+
+#~ msgid "Battery charging"
+#~ msgstr "Batteriet vert lada"
+
+#~ msgid "Battery discharging"
+#~ msgstr "Batteriet vert tømt"
+
+#~ msgid "UPS charging"
+#~ msgstr "UPS vert lada"
+
+#~ msgid "UPS discharging"
+#~ msgstr "UPS vert tømt"
+
+#, c-format
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s til fullada (%.0lf%%)"
+
+#, c-format
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s til utlada (%.0lf%%)"
+
+#, c-format
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% lada"
+
+#~ msgid "Unlock"
+#~ msgstr "Lås opp"
+
+#~| msgid "C_reate"
+#~ msgid "Create a user"
+#~ msgstr "Lag brukar"
+
+#~ msgid ""
+#~ "To create a user,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "For å laga brukar,\n"
+#~ "trykk på *-ikonet først"
+
+#~ msgid "Delete the selected user"
+#~ msgstr "Slett den valde brukaren"
+
+#~ msgid ""
+#~ "To delete the selected user,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "For å sletta den valde brukaren,\n"
+#~ "trykk på *-ikonet først"
+
+#~ msgid "Wallpaper;Screen;Desktop;Theme;"
+#~ msgstr "Skrivebordsbakgrunn;Skjerm;Skrivebord;Tema"
+
+#~ msgid "Theme to be used for the UI"
+#~ msgstr "Tema brukt i grensesnittet"
+
+#~ msgid "180 Degrees"
+#~ msgstr "180 grader"
+
+#~ msgid "Clockwise"
+#~ msgstr "Med klokka"
+
+#~ msgid "Counterclockwise"
+#~ msgstr "Mot klokka"
+
+#~ msgid ""
+#~ "device;system;information;memory;processor;version;default;application;fallba"
+#~ "ck;preferred;"
+#~ msgstr ""
+#~ "eining;system;informasjon;minne;prosessor;versjon;standard;program;reserveløy"
+#~ "sing;føretrekt;"
+
+#~ msgid "System Info"
+#~ msgstr "Systeminformasjon"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "Slå av/på kontrast"
+
+#~ msgid "Magnifier zoom out"
+#~ msgstr "Gjer mindre"
+
+#~ msgid "Toggle on-screen keyboard"
+#~ msgstr "Slå av/på skjermtastatur"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "Slå av/på forstørring"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "Slå av/på skjermlesar"
+
+#~ msgid "Magnifier zoom in"
+#~ msgstr "Gjer større"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "cd;dvd;usb;lyd;video;plate;"

--- a/po/nso.po
+++ b/po/nso.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center HEAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2004-11-27 17:02+0200\n"
 "Last-Translator: Zuza Software Foundation <info@translate.org.za>\n"
 "Language-Team: Northern Sotho <translate-discuss-nso@lists.sourceforge.net>\n"
@@ -18,3526 +18,7192 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n>1;\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
 #, fuzzy
-msgid "Alert Type"
-msgstr "Oketša Mohuta wa Faele"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-#, fuzzy
-msgid "The type of alert"
-msgstr "Mohuta wa seakgofiši."
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-#, fuzzy
-msgid "Alert Buttons"
-msgstr "Dikonope"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-#, fuzzy
-msgid "Show more _details"
-msgstr "Dintlha tša _Sehlogo"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-#, fuzzy
-msgid "About Me"
-msgstr "_Ka ga"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your personal information"
-msgstr "Tshedimošo ya mohuta wa MIME"
-
-#: ../capplets/about-me/gnome-about-me.c:554
-#, fuzzy
-msgid "Select Image"
-msgstr "_Kgetha"
-
-#: ../capplets/about-me/gnome-about-me.c:556
-#, fuzzy
-msgid "No Image"
-msgstr "Diswantšho"
-
-#: ../capplets/about-me/gnome-about-me.c:706
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:727
-msgid "Unable to open address book"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:739
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:770
-#: ../capplets/about-me/gnome-about-me.c:772
-#, fuzzy, c-format
-msgid "About %s"
-msgstr "_Ka ga"
-
-#: ../capplets/about-me/gnome-about-me-password.c:101
-#: ../capplets/about-me/gnome-about-me-password.c:479
-msgid "Old password is incorrect, please retype it"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:112
-msgid "System error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:113
-msgid "Could not run /usr/bin/passwd"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:114
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:117
-msgid "Unexpected error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:315
-msgid "Password is too short"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:318
-#: ../capplets/about-me/gnome-about-me-password.c:321
-msgid "Password is too simple"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:324
-msgid "Old and new passwords are too similar"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:328
-msgid "Old and new password are the same"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:406
-#, fuzzy
-msgid "Please type the passwords."
-msgstr "_Lentšuphetišo:"
-
-#: ../capplets/about-me/gnome-about-me-password.c:414
-msgid "Please type the password again, it is wrong."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:417
-msgid "Click on Change Password to change the password."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/font/font-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-msgid "    "
-msgstr "    "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-#, fuzzy
-msgid "<b>Email</b>"
-msgstr "<i>Nyenyane</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-#, fuzzy
-msgid "<b>Home</b>"
-msgstr "<b>Lebelo</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-#, fuzzy
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Go Fana ka Fonto</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-#, fuzzy
-msgid "<b>Job</b>"
-msgstr "<b>Thekgo</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-#, fuzzy
-msgid "<b>Telephone</b>"
-msgstr "<b>Dinotlelo tša go Thumaša le go Tima</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-#, fuzzy
-msgid "<b>Web</b>"
-msgstr "<b>Lebelo</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-#, fuzzy
-msgid "<b>Work</b>"
-msgstr "<b>Thekgo</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-#, fuzzy
-msgid "A_ddress:"
-msgstr "_Oketša:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-#, fuzzy
-msgid "Address"
-msgstr "_gateletšwe"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-#, fuzzy
-msgid "C_ity:"
-msgstr "_Setaele:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-#, fuzzy
-msgid "C_ompany:"
-msgstr "Ta_elo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-#, fuzzy
-msgid "Cale_ndar:"
-msgstr "Lego_ro:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-#, fuzzy
-msgid "Change Passwo_rd..."
-msgstr "Fetola peakanyo"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-#, fuzzy
-msgid "Change Password"
-msgstr "Fetola peakanyo"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-#, fuzzy
-msgid "Ci_ty:"
-msgstr "_Setaele:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-#, fuzzy
-msgid "Co_untry:"
-msgstr "Taolo"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-#, fuzzy
-msgid "Contact"
-msgstr "_Dikagare"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-#, fuzzy
-msgid "Cou_ntry:"
-msgstr "Taolo"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-#, fuzzy
-msgid "Hom_e:"
-msgstr "_Leina:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-#, fuzzy
-msgid "Old pa_ssword:"
-msgstr "_Lentšuphetišo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P.O. _box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P._O. box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-#, fuzzy
-msgid "Personal Info"
-msgstr "_Fonto ya kgokagano ya dithapo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "State/Pro_vince:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#, fuzzy
-msgid "User name:"
-msgstr "L_eina la modiriši:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Web _log:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "Wor_k:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid "Work _fax:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Zip/_Postal code:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-#, fuzzy
-msgid "_Address:"
-msgstr "_Oketša:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-#, fuzzy
-msgid "_Home page:"
-msgstr "_Leina la sehlogo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-#, fuzzy
-msgid "_Home:"
-msgstr "_Leina:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-#, fuzzy
-msgid "_Manager:"
-msgstr "_Segodiši"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-#, fuzzy
-msgid "_Mobile:"
-msgstr "_Faele"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-#, fuzzy
-msgid "_New password:"
-msgstr "_Lentšuphetišo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-#, fuzzy
-msgid "_Profession:"
-msgstr "Kgatišo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-#, fuzzy
-msgid "_Retype new password:"
-msgstr "_Lentšuphetišo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-#, fuzzy
-msgid "_Title:"
-msgstr "_Setaele:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Work:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Zip/Postal code:"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Applications</b>"
+msgid "Applications"
 msgstr "<b>Ditirišo</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Support</b>"
-msgstr "<b>Thekgo</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-"<small><i><b>Ela hloko:</b> Diphetogo tšeo di dirwago peakanyong ye di ka se "
-"šome go fihlela ge o tsena gape nakong e latelago.</i></small>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technology Preferences"
-msgstr "Tše Ratwago tša Thekinolotši tše Thušago"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr "Tswalela gomme o _Tšwe"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr "Thoma dithekinolotši tše tše thušago nako le nako ge o tsena:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr "_Kgontšha dithekinolotši tše thušago"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr "_Segodiši"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr "_Boroto ya dinotlelo e lego Sekirining"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Screenreader"
-msgstr "_Sebadi sa sekirini"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr "Thekgo ya Thekinolotši e Thušago"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr ""
-"Kgontšha thekgo bakeng sa dithekinolotši tše thušago tša GNOME go tseneng"
-
-#: ../capplets/accessibility/at-properties/main.c:60
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Ga go na Thekinolotši e Thušago yeo e lego tshepedišong ya gago.  Ngatana ya "
-"'gok' e swanetše go tsenywa gore go hwetšwe thekgo ya boroto ya dinotlelo ya "
-"sekirining, le ngatana ya 'gnopernicus' e swanetše go tsenywa bakegn sa go "
-"bala ga sekirini le bokgoni bja go godiša."
-
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-"Ga se thekinolotši ka moka tše thušago tšeo di tsentšhitšwego tshepedišong "
-"ya gago. Ngatana ya 'gok' e swanetše go tsenywa gore go hwetšwe thekgo ya "
-"boroto ya dinotlelo ya sekirining."
-
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Ga se dithekinolotši ka moka tše thušago tšeo di tsentšhitšwego tshepedišong "
-"ya gago. Ngatana ya 'gnopernicus' e swanetše go tsentšhwa bakeng sa bokgoni "
-"bja go bala sekirini le go godiša."
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr ""
-"Go bile le phošo ya go tsebagatša poledišano ya tše ratwago tša legotlwana: %"
-"s"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr ""
-"Ga e kgone go amogela dipeakanyo tša go Tsena tša X go tšwa faeleng ya '%s'"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
-msgid "Import Feature Settings File"
-msgstr "Amogela Faele ya Dipeakanyo tša Sebopego"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
-msgid "_Import"
-msgstr "_Amogela"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Boroto ya dinotlelo"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr "Beakanya tše di ratwago tša go tsenega ga boroto ya dinotlelo"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-"Tshepedišo ye ga e bonagale e na le koketšo ya XKB.  Dibopego tša go tsenega "
-"ga boroto ya dinotlelo di ka se šome ka ntle le yona."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-#: ../capplets/theme-switcher/theme-install.glade.h:1
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "<b>Kgontšha Dino_tlelo tša go Tlola</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "<b>Kgontšha Dino_tlelo tše Nanyago</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "<b>Kgontšha _Dinotlelo tša Legotlwana</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "<b>Kgontšha _Dinotlelo tša go Bušeletša</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "<b>Kgontšha _Dinotlelo tše Kgomarelago</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-msgid "<b>Features</b>"
-msgstr "<b>Dibopego</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr "<b>Dinotlelo tša go Thumaša le go Tima</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "Motheo"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr "Dira modumo ge senotlelo se ga_nwa"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
-msgstr ""
-"Dira modumo _ge dibopego di thumašwa goba di tingwa borotong ya dinotlelo"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
-msgstr "Dira modumo _ge sempshafatši se gateletšwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr "Dira modumo ge LED e thumašitšwe le medumo e mebedi ge e timilwe."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr "Dira modumo ge senotlelo se:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr "Die_giša:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr ""
-"Diegiša magareng ga go gatelelwa ga senotlelo le go šu_tha ga selaetši:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr "Pale_diša ge dinotlelo tše pedi di gateletšwe mmogo"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr "K_gontšha Dinotlelo tša go Thumaša le go Tima"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Dikgethi"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr "H_lokomologa go gatelelwa ga senotlelo mo go lego gabedi ka gare ga:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-"Hlokomologa go gatelela ka moka mo go hlatlamanago ga senotlelo se SWANAGO "
-"ge eba go direga nakong e kgethilwego ya modiriši."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr "Tše Ratwago tša go Tsenega ga Boroto ya Dinotlelo (Go Tsena ga X)"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr "Le_belo le legolo la selaetši:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr "Dinotlelo tša Legotlwana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr "Tše Ratwago _tša Legotlwana..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-"Amogela dinotlelo feela ka morago ga ge di gateletšwe le go swara tekanyo ya "
-"nako e ka lokišwago ya modiriši."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-"Dira mediro ya go gatelela senotlelo e mentši ya samma-le-tee ka go kgotla "
-"dinotlelo tša mpshafatšo ka tatelano."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "S_peed:"
-msgstr "L_ebelo:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr "Nako ya go akgo_fiša go fihla go lebelo le legolo:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr ""
-"Fetola mosemo wa dinotlelo wa dinomoro gore e ba moseme wa taolo ya "
-"legotlwana."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr "_Palediša ge eba e sa dirišwe bakeng sa:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr "_Kgontšha dibopego tša go tsenega ga boroto ya dinotlelo"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr "_Amogela Peakanyo ya Sebopego..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr "_Amogela feela dinotlelo tše swaretšwego:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Type to test settings:"
-msgstr "_Tlanya go leka dipeakanyo:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr "_amogetšwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr "_gateletšwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr "_gannwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr "ditlhaka/motsotswana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-msgid "milliseconds"
-msgstr "seripa sa metsotswana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr "dikarolwana tše bopago seswantšho/motsotswana"
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:885
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "metsotswana"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-msgid "Change your Desktop Background settings"
-msgstr "Fetola Dipeakanyo tša Bokamorago bja Teseke ya Gago"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-msgid "Desktop Background"
-msgstr "Bokamorago bja Teseke"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "<b>Pampiri ya leboteng ya _Teseke</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-msgid "<b>_Desktop Colors</b>"
-msgstr "<b>_Mebala ya Teseke</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-msgid "Desktop Background Preferences"
-msgstr "Tše Ratwago tša Bokamorago bja Teseke"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr "_Oketša Pampiri ya leboteng"
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-msgid "_Style:"
-msgstr "_Setaele:"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Go bile le phošo ya go bontšha thušo: %s"
-
-#: ../capplets/background/gnome-wp-capplet.c:1042
-#: ../capplets/background/gnome-wp-capplet.c:1060
-msgid "Centered"
-msgstr "E beilwe magareng"
-
-#: ../capplets/background/gnome-wp-capplet.c:1068
-#: ../capplets/background/gnome-wp-capplet.c:1085
-msgid "Fill Screen"
-msgstr "Tlatša Sekirini"
-
-#: ../capplets/background/gnome-wp-capplet.c:1093
-#: ../capplets/background/gnome-wp-capplet.c:1110
-msgid "Scaled"
-msgstr "Lekanyeditšwe"
-
-#: ../capplets/background/gnome-wp-capplet.c:1118
-#: ../capplets/background/gnome-wp-capplet.c:1135
-msgid "Tiled"
-msgstr "E dirilwe thaele"
-
-#: ../capplets/background/gnome-wp-capplet.c:1159
-#: ../capplets/background/gnome-wp-capplet.c:1168
-msgid "Solid Color"
-msgstr "Mmala o Tiilego"
-
-#: ../capplets/background/gnome-wp-capplet.c:1176
-#: ../capplets/background/gnome-wp-capplet.c:1185
-msgid "Horizontal Gradient"
-msgstr "Go Sekama go Rapamego"
-
-#: ../capplets/background/gnome-wp-capplet.c:1193
-#: ../capplets/background/gnome-wp-capplet.c:1202
-msgid "Vertical Gradient"
-msgstr "Go Sekama go Tsepamego"
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1251
-msgid "Add Wallpaper"
-msgstr "Oketša Pampiri ya leboteng"
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr "Ga go na Pampiri ya leboteng"
-
-#: ../capplets/background/gnome-wp-item.c:292
-#: ../capplets/background/gnome-wp-item.c:294
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/common/activate-settings-daemon.c:18
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"Ga e kgone go thoma molaodi wa dipeakanyo 'daemon ya dipeakanyo tša gnome'.\n"
-"Ka ntle le go šoma ga molaodi wa dipeakanyo tša GNOME, tše dingwe tše "
-"ratwago di ka no se šome. Se se ka laetša bothata le Bonobo, goba molaodi wa "
-"dipeakanyo yo e sego wa GNOME (ka mohlala, KDE) a ka ba a šetše a šoma e "
-"bile a lwantšhana le molaodi wa peakanyo wa GNOME."
-
-#: ../capplets/common/capplet-stock-icons.c:94
-#, c-format
-msgid "Unable to load capplet stock icon '%s'\n"
-msgstr "Ga e kgone go laiša leswao la setoko la khapolete ya '%s'\n"
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr "Diriša feela dipeakanyo gomme o tlogele"
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/default-applications/gnome-default-applications-properties.c:765
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1021
-#: ../capplets/sound/sound-properties-capplet.c:244
-msgid "Retrieve and store legacy settings"
-msgstr "Buša morago gomme go boloka dipeakanyo tše molaong"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %i of %i"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr "Go tšwa go URI"
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr "URI gona bjale e fetišetša go tšwa go"
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr "Go ya go URI"
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr "URI yeo gona bjale e fetišetšago go"
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr "Seabelo se feditšwego"
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr "Seabelo sa phetišetšo yeo gona bjale e feditšwego"
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr "Tlhatlamano ya gona bjale ya URI"
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr "Tlhatlamano ya gona bjale ya URI - e thoma go 1"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr "Palomoka ya di-URI"
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr "Palo moka ya di-URI"
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:345
+#: panels/applications/cc-applications-panel.ui:31
 #, fuzzy
-msgid "From:"
-msgstr "Go tšwa go: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:349
-#, fuzzy
-msgid "To:"
-msgstr "Go ya go: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr "Go kgokaganya..."
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Senotlelo"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr "Senotlelo sa GConf seo morulaganyi wa thoto a kgokagantšwego"
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr "Letša gape"
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Ntšha go letša gape ge boleng bjo tswalanego le senotlelo bo fetolwa"
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr "Fetola peakanyo"
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"GConf e fetola peakanyo yeo e nago le tsebišo yeo e swanetšego go fetišetšwa "
-"go modirelwa wa gconf tirišong"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr "Go fetolwa ga go letša gape ga sedirišwa"
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-"Go letša gape mo go swanetšego go ntšhwa ge tsebišo e fetoletšwe go tloga go "
-"GConf go ya go sedirišwa"
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr "Go fetolelwa go tšwa go go letša gape ga sedirišwa"
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"Go letša gape mo go swanetšego go ntšhwa ge tsebišo e swanetše go fetolelwa "
-"go GConf go tšwa go sedirišwa"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr "Taolo ya UI"
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr "Sedirišwa seo se laolago thoto (ka mo go tlwaelegilego sedirišwa)"
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr "Tsebišo ya sedirišwa ya morulaganyi wa thoto"
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr "Tsebišo ya tlwaelo e nyakwago ke morulaganyi yo a itšego wa thoto"
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr "Tsebišo ya morulaganyi wa thoto yeo e lokollago go letša gape"
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Go letša gape mo go swanetšego go ntšhwa ge tsebišo ya sedirišwa sa "
-"morulaganyi wa thoto e swanetše go lokollwa"
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Ga e kgone go hwetša faele '%s'.\n"
-"\n"
-"Hle kgonthišetša gore e gona gomme o leke gape, goba o kgethe seswantšho se "
-"bonagalago ka morago se fapanego."
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Ga ke tsebe kamoo nka bulago faele ya '%s'.\n"
-"Mohlomongwe ke mohuta wa seswantšho seo sešogo sa thekgwa.\n"
-"\n"
-"Hle kgetha seswantšho se fapanego legatong la se."
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr "Hle kgetha seswantšho."
-
-#: ../capplets/common/gconf-property-editor.c:1598
-msgid "_Select"
-msgstr "_Kgetha"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
+msgid "No applications"
 msgstr "Ditirišo tše Ratwago"
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Kgetha ditirišo tša gago tša tlhaelelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+#: panels/applications/cc-applications-panel.ui:34
 #, fuzzy
-msgid "Debian Sensible Browser"
-msgstr "Sefetleki sa Wepe sa Tlhaelelo"
+msgid "Install some…"
+msgstr "_Tsenya Sehlogo..."
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
-msgid "Epiphany"
-msgstr "Epiphany"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
-msgid "Encompass"
-msgstr "Fihlelela"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+#: panels/applications/cc-applications-panel.ui:84
 #, fuzzy
-msgid "Firebird"
-msgstr "Firebird/FireFox"
+msgid "Open"
+msgstr "_Bula"
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
+#: panels/applications/cc-applications-panel.ui:94
 #, fuzzy
-msgid "Mozilla"
-msgstr "Poso ya Mozilla"
+msgid "View Details"
+msgstr "Dintlha tša Sehlogo"
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
-msgid "Netscape Communicator"
-msgstr "Seboledi sa Netscape"
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Nyakišiša"
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
-msgid "W3M Text Browser"
-msgstr "Sefetleki sa Sengwalwa sa W3M"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
-msgid "Lynx Text Browser"
-msgstr "Sefetleki sa Sengwalwa sa Lynx"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
-msgid "Links Text Browser"
-msgstr "E Kgokaganya Sefetleki sa Sengwalwa"
-
-#. The code in gnome-default-applications-properties.c makes sure
-#. * there is only one (the first entry in this list) Evolution entry
-#. * in the list shown to the user
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
-msgid "Evolution Mail Reader"
-msgstr "Sebadi sa Poso sa Phutollo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
-msgid "KMail"
-msgstr "Poso ya K"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
-msgid "Mozilla Mail"
-msgstr "Poso ya Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
-#, fuzzy
-msgid "Debian Terminal Emulator"
-msgstr "Kgokagano ya Dithapo ya Tlhaelelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
-#, fuzzy
-msgid "GNOME Terminal"
-msgstr "Kgokagano ya dithapo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
-msgid "Standard XTerminal"
-msgstr "Kgokagano ya Dithapo ya X ya Motheo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.c:123
-msgid "Please specify a name and a command for this editor."
-msgstr "Hle laetša leina le taelo ya morulaganyi yo."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "Add..."
-msgstr "Oketša..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "C_ustom"
-msgstr "_Tlwaelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "C_ustom:"
-msgstr "_Tlwaelo:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "Can open _URIs"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-#, fuzzy
-msgid "Can open multiple _files"
-msgstr "Tirišo ye e ka bula difaele _tše dintši"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "Co_mmand:"
-msgstr "Ta_elo:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "Custom Editor Properties"
-msgstr "Dipharologantšho tša Morulaganyi wa Tlwaelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "Default Mail Reader"
-msgstr "Mmadi wa Poso wa Tlhaelelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "Default Terminal"
-msgstr "Kgokagano ya Dithapo ya Tlhaelelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Default Text Editor"
-msgstr "Morulaganyi wa Sengwalwa wa Tlhaelelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "Default Web Browser"
-msgstr "Sefetleki sa Wepe sa Tlhaelelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Default Window Manager"
-msgstr "Molaodi wa Lefesetere wa Tlhaelelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Delete"
-msgstr "Phumola"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "E_xec Flag:"
-msgstr "P_hethagatša Folaga:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Edit..."
-msgstr "Lokiša..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Mail Reader"
-msgstr "Sebadi sa Poso"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-#, fuzzy
-msgid "Run in a _terminal"
-msgstr "Diriša ka _Kgokagano ya Dithapo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-#, fuzzy
-msgid "Run in a t_erminal"
-msgstr "Diriša ka _Kgokagano ya Dithapo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid ""
-"Select the window manager you want.  You will need to hit apply, wave the "
-"magic wand, and do a magic dance for it to work."
-msgstr ""
-"Kgetha molaodi wa lefesetere yo o mo nyakago.  Go tla nyakega gore o kgotle "
-"diriša, o phagamiše seatla, gomme o bine motantsho wa mohlolo gore e šome."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Terminal"
-msgstr "Kgokagano ya dithapo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Text Editor"
-msgstr "Morulaganyi wa Sengwalwa"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Understands _Netscape Remote Control"
-msgstr "E Kwešiša _Taolo ya Kgole ya Netscape"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "Use this _editor to open text files in the file manager"
-msgstr "Diriša morulaganyi _yo go bula difaele tša sengwala molaoding wa faele"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "Web Browser"
-msgstr "Sefetleki sa Wepe"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
-msgid "Window Manager"
-msgstr "Molaodi wa Lefesetere"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
-msgid "_Command:"
-msgstr "Ta_elo:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
-msgid "_Name:"
-msgstr "_Leina:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
-msgid "_Properties..."
-msgstr "_Dipharologantšho..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
-msgid "_Select:"
-msgstr "_Kgetha:"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Fetola setlamo sa sekirini"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Setlamo sa Sekirini"
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/main.c:448
-msgid "_Resolution:"
-msgstr "_Setlamo:"
-
-#: ../capplets/display/main.c:467
-msgid "Re_fresh rate:"
-msgstr "Di_ra tekanyo gape:"
-
-#: ../capplets/display/main.c:488
-msgid "Default Settings"
-msgstr "Dipeakanyo tša Tlhaelelo"
-
-#: ../capplets/display/main.c:490
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr "Dipeakanyo tša Sekirini sa %d\n"
-
-#: ../capplets/display/main.c:516
-msgid "Screen Resolution Preferences"
-msgstr "Tše Ratwago tša Setlamo sa Sekirini"
-
-#: ../capplets/display/main.c:553
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "_Dira tlhaelelo bakeng sa khomphuthara ye ya (%s) feela"
-
-#: ../capplets/display/main.c:571
-msgid "Options"
-msgstr "Dikgetho"
-
-#: ../capplets/display/main.c:592
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"Go leka dipeakanyo tše mpsha. Ge o sa arabele ka metsotswana e %d go tla "
-"bolokwa peakanyo ya nakong e fetilego."
-msgstr[1] ""
-"Go leka dipeakanyo tše mpsha. Ge eba o sa arabele ka metsotswana e %d go tla "
-"bolokwa peakanyo ya nakong e fetilego."
-
-#: ../capplets/display/main.c:638
-msgid "Keep Resolution"
-msgstr "Boloka Setlamo"
-
-#: ../capplets/display/main.c:642
-msgid "Do you want to keep this resolution?"
-msgstr "Na o nyaka go boloka setlamo se?"
-
-#: ../capplets/display/main.c:667
-msgid "Use _previous resolution"
-msgstr "Diriša _setlamo sa nakong e fetilego"
-
-#: ../capplets/display/main.c:667
-msgid "_Keep resolution"
-msgstr "_Boloka setlamo"
-
-#: ../capplets/display/main.c:818
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"Seabi sa X ga se thekge koketšo ya XRandR.  Setlamo sa nako ya go šoma se "
-"fetogelago go bogolo bja go bontšha ga di gona."
-
-#: ../capplets/display/main.c:826
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"Kgatišo ya koketšo ya XRandR yeo e sa kwanego le lenaneo le. Diphetogo tša "
-"go šoma go bogolo bja go bontšha ga di gona."
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Fonto"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr "Kgetha difonto tša teseke"
-
-#: ../capplets/font/font-properties.glade.h:2
-msgid "<b>Font Rendering</b>"
-msgstr "<b>Go Fana ka Fonto</b>"
-
-#: ../capplets/font/font-properties.glade.h:3
-msgid "<b>Hinting</b>:"
-msgstr "<b>Go Eletša</b>:"
-
-#: ../capplets/font/font-properties.glade.h:4
-msgid "<b>Smoothing</b>:"
-msgstr "<b>Go Dira Boreledi</b>:"
-
-#: ../capplets/font/font-properties.glade.h:5
-msgid "<b>Subpixel order</b>:"
-msgstr "<b>Tatelano ya dika-dikarolwana tše bopago seswantšho</b>:"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best _shapes"
-msgstr "Dibopego _tše di phalago ka moka"
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "Best co_ntrast"
-msgstr "Go fapana go e ph_alago ka moka"
-
-#: ../capplets/font/font-properties.glade.h:8
-msgid "D_etails..."
-msgstr "D_intlha..."
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "Tše Ratwago tša Fonto"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr "Dintlha tša go Fana ka Fonto"
-
-#: ../capplets/font/font-properties.glade.h:11
-msgid "Go _to font folder"
-msgstr "Eya _sephutheding sa fonto"
-
-#: ../capplets/font/font-properties.glade.h:12
-msgid "Gra_yscale"
-msgstr "Teka_nyo e tshetla"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "G_a e gona"
-
-#: ../capplets/font/font-properties.glade.h:14
-msgid "R_esolution:"
-msgstr "S_etlamo:"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr "Dikarolwana_tše nyenyane tše bopago diswantšho (di-LCD)"
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr ""
-"Go dira gore dikarolwana_tše nyenyane tše bopago seswantšho di be boreledi "
-"(di-LCD)"
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
-msgstr "_Fonto ya tirišo:"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Desktop font:"
-msgstr "_Fonto ya teseke:"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Full"
-msgstr "_Tletšego"
-
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Medium"
-msgstr "_Magareng"
-
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Monochrome"
-msgstr "_Mmala o tee wa boso le bošweu"
-
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_None"
-msgstr "_Ga e gona"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_Slight"
-msgstr "_Ganyenyane"
-
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Terminal font:"
-msgstr "_Fonto ya kgokagano ya dithapo:"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "_Fonto ya sehlogo sa lefesetere:"
-
-#: ../capplets/font/font-properties.glade.h:30
-msgid "dots per inch"
-msgstr "dintlha go ya ka noko"
-
-#: ../capplets/font/main.c:488
-msgid "Font may be too large"
-msgstr "Fonto e ka ba e le e kgolo kudu"
-
-#: ../capplets/font/main.c:492
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Fonto e kgethilwego e bogolo bja ntlha bja %d , e bile e ka dira gore go be "
-"thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe "
-"bogolo bjo bo lego bjo bonyenyane go %d."
-msgstr[1] ""
-"Fonto e kgethilwego e bogolo bja dintlha bja %d , e bile e ka dira gore go "
-"be thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe "
-"bogolo bjo bo lego bjo bonyenyane go %d."
-
-#: ../capplets/font/main.c:505
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Fonto e kgethilwego e bogolo bja ntlha bja %d, e bile e ka dira gore go be "
-"thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe fonto "
-"ya bogolo bjo bonyenyane."
-msgstr[1] ""
-"Fonto e kgethilwego e bogolo bja dintlha bja %d, e bile e ka dira gore go be "
-"thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe fonto "
-"ya bogolo bjo bonyenyane."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "Seakgofiši se seswa..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Senotlelo sa seakgofiši"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Dimpshafatši tša seakgofiši"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Khoutu ya senotlelo ya seakgofiši"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Mokgwa wa Seakgofiši"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Mohuta wa seakgofiši."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:197
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Paledišitšwe"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:545
-msgid "<Unknown Action>"
-msgstr "<Mogato o sa Tsebjwego>"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_Lefelo:"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:566
-msgid "Desktop"
-msgstr "Teseke"
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr ""
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:567
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Diriša _Bokamorago"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Sekirini"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Ga go na Pampiri ya leboteng"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
 msgstr "Modumo"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:571
-msgid "Window Management"
-msgstr "Taolo ya Lefesetere"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:668
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
-"Kgaoletšo ya \"%s\" e šetše e dirišeditšwe:\n"
-" \"%s\"\n"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:700
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr ""
-"Phošo ya go beakanya seakgofiši se seswa datapeising ya go fetola sebopego: %"
-"s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:750
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr ""
-"Phošo ya go beakanyolla seakgofiši datapeising ya go fetola sebopego: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:857
-msgid "Action"
-msgstr "Mogato"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:881
-msgid "Shortcut"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
 msgstr "Kgaoletšo"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
 msgstr "Dikgaoletšo tša Boroto ya Dinotlelo"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
 msgstr ""
-"Go lokiša senotlelo sa kgaoletšo, kgotla mothalong o sepelelanago gomme o "
-"tlanye seakgofiši se seswa, goba o gatelele backspace gore o phumole."
 
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Abela dinotlelo tša kgaoletšo go ditaelo"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
-msgid "Unknown"
-msgstr "Tše sa Tsebjwego"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
-msgid "Layout"
-msgstr "Bea"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Oketša Mohuta wa Faele"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "_Fonto ya tirišo:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<i>Nyenyane</i>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Setaele:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 #, fuzzy
 msgid "Default"
 msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
-msgid "Models"
-msgstr "Mehlala"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:106
-#, c-format
-msgid "There was an error launching the keyboard capplet : %s"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
-"Go bile le phošo ya go tsebagatša khapolete ya boroto ya dinotlelo : %s"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "Diriša _Bokamorago"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Setlamo sa Sekirini"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Go taga go godimo"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Amogela"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "Oketša..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "_Mehlala"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "_Tloša"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Dintlha"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "metsotso"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "_Magareng"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "metsotso"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "metsotso"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Mmala o Tiilego"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "_Kgetha"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Kgetha"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_Nako e fedile:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Nyakišiša"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "Die_giša:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "Nyakišiša kgaoletšo."
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Paledišitšwe"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "metsotswana"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Lego_ro:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Fetola Dipeakanyo tša Bokamorago bja Teseke ya Gago"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "Poso ya K"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Lego_ro:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Ditirišo tše Ratwago"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Kgetha ditirišo tša gago tša tlhaelelo"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "_Diriša fonto"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<b>Thulaganyo ya Legotlwana </b>"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Setlamo:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Di_ra tekanyo gape:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Lekanyeditšwe"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Seabelo se feditšwego"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Go tšwa go: %s"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "metsotso"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "Go ya go: %s"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+#, fuzzy
+msgid "No Events"
+msgstr "Ditiragalo tša Modumo"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Leina:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Mohuta"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Kgokagano ya dithapo"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Mafesetere"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "_Leina la sehlogo:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "L_eina la modiriši:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Ka ga"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Go nolofatšwa ga bolumo"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Bolumo e tlase"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Bolumo e godimo"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Bapala (goba bapala/emiša nakwana)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Emiša senotlelo sa bapala o boele morago"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Tabogela go koša e fetilego"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Tabogela go koša e latelago"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Ntšha"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "Go Khutša ga go Tlanya"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Tabogela go koša e latelago"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Tabogela go koša e fetilego"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Tsebagatša sefetleki sa wepe"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Tsebagatša sefetleki sa thušo"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Dipeakanyo tša Tlhaelelo"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Tsebagatša sefetleki sa wepe"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Sephuthedi sa gae"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Nyakišiša"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+#, fuzzy
+msgid "System"
+msgstr "Tšhipi ya Tshepedišo"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "E-tšwa"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Notlela sekirini"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
 msgstr "_Go tsenega"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:240
-#: ../capplets/sound/sound-properties-capplet.c:242
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
 msgstr ""
-"Diriša feela dipeakanyo gomme o tlogele (go sepelelana feela; mo gona bjale "
-"go swarwago ke daemon)"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
-msgstr "Thoma letlakala dipeakanyo tša go khutša ga go tlanya di bonagala"
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "..."
-msgstr "..."
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "E-tšwa"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Cursor Blinking</b>"
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "_Boroto ya dinotlelo e lego Sekirining"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Dikgetho"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Tše ratwago"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Go bea ga boroto ya dinotlelo ya XKB"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Tloša"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Dinotlelo tša Legotlwana"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Dikgaoletšo tša Boroto ya Dinotlelo"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Mogato"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Kgaoletšo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Kgaoletšo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Kgaoletšo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Dikgaoletšo tša Boroto ya Dinotlelo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Tloša"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Leina:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Ta_elo:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Kgaoletšo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Kgaoletšo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_Ga e gona"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Beakanya di_tlhaelelo ka leswa"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Boroto ya dinotlelo"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Tshedimošo ya mohuta wa MIME"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Dipeakanyo tša Tlhaelelo"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Kakaretšo"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "_Ganyenyane"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_Lefelo:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Legotlwana"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Dinotlelo tša Legotlwana"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Go Akgofiša:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Go Akgofiša:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_Fonto ya tirišo:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Tše dingwe"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Mogato"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Go kgokaganya..."
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Dikgetho"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Kemedi ya Neteweke"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Lentšuphetišo:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Fetola peakanyo"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Mokgwa wa Seakgofiši"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "_gateletšwe"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "_gateletšwe"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "_gateletšwe"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Leina:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Oketša:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Oketša:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Paledišitšwe"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_gateletšwe"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+#, fuzzy
+msgid "Address"
+msgstr "_gateletšwe"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "metsotso"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Kemedi ya Neteweke"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Mogato"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "_gateletšwe"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Kemedi ya Neteweke"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "K_emedi ya PFSK:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "K_emedi ya PFSK:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_Kemedi ya PFF:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "M_oswari wa disokisi:"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "K_emedi ya PFSK:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "K_emedi ya PFSK:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_Kemedi ya PFF:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Go fetola sebopego mo go itiragalelago ga _STS:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Kemedi ya Neteweke"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Lentšuphetišo:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Dikgaoletšo tša Boroto ya Dinotlelo"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Diriša tiišetšo</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "L_eina la modiriši:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Lentšuphetišo:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Lentšuphetišo:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Kgatišo:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Kgatišo:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Lentšuphetišo:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "<b>_Diriša tiišetšo</b>"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Mohuta"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Bula Faele"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Lefelo:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Faele ya _modumo:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notlela kgaoletšo ya sekirini."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Notlela kgaoletšo ya sekirini."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Diriša tiišetšo</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "metsotso"
+msgstr[1] "metsotso"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "metsotso"
+msgstr[1] "metsotso"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "metsotso"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "metsotso"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "metsotso"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "metsotso"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "metsotso"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "metsotso"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "metsotso"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "metsotso"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Mokgwa wa Seakgofiši"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Tlatša Sekirini"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Sekirini"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Diegiša:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "_Gatiša"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "L_eina la modiriši:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "_Lefelo:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Go Tsenywa ga Sehlogo"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Kgetha"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Dikgetho"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Dintlha tša go Fana ka Fonto"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Beakanya di_tlhaelelo ka leswa"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Mehlala"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "_Ponelopele"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Tlatša Sekirini"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Mogato"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Mohuta:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Sekirini"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Notlela sekirini"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Sekirini"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Sekirini"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Dipeakanyo tša Sekirini sa %d\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Dikgaoletšo tša Boroto ya Dinotlelo"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Tše dingwe"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "_Lefelo:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_Fonto ya tirišo:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Nyakišiša kgaoletšo."
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Kemedi ya Neteweke"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Teseke"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Tloša"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Lentšuphetišo:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Teseke"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Taolo ya UI"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Kopiša"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<b>_Diriša tiišetšo</b>"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "L_eina la modiriši:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Tšhipi ya Tshepedišo"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Go nolofatšwa ga bolumo"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Go Fetola Sebopego ga Kemedi ya Neteweke"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Bolumo"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Dikonope"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Modumo"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Leina:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
 msgstr "<b>Go Ponya ga Leswao le Bontšhago mo o lego</b>"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Dinotlelo tša go Bušeletša</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<b>_Notlela sekirini go gapeletša go khutša ga go tlanya</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Lebelo</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Telele</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Kopana</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Nanyago</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_vailable layouts:"
-msgstr "G_o bea mo go lego gona:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "All_ow postponing of breaks"
-msgstr "Dume_elela go šuthišwa ga go khutša"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Lekola ge eba go khutša go dumeletšwe gore go šuthišwe"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 #, fuzzy
-msgid "Choose A Keyboard Model"
-msgstr "Kgetha mohlala wa boroto ya dinotlelo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-#, fuzzy
-msgid "Choose A Layout"
-msgstr "Tswalela gomme o _Tšwe"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
+msgid "Cursor blinks in text fields."
 msgstr ""
 "Leswao le bontšhago mo o lego _le ponya-ponya mapokising a sengwalwa le "
 "mapatlelong"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Duration of the break when typing is disallowed"
-msgstr "Botelele bja go khutša ge o tlanya ga bo a dumelelwa"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of work before forcing a break"
-msgstr "Botelele bja mošomo pele ga go gapeletša go khutša"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Key presses _repeat when key is held down"
-msgstr "Senotlelo se gatelela _bušeletša ge senotlelo se gateletšwe fase"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Keyboard Preferences"
-msgstr "Tše Ratwago tša Boroto ya Dinotlelo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Keyboard _model:"
-msgstr "Mohlala wa _boroto ya dinotlelo:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Layout Options"
-msgstr "Dikgetho tša go Bea"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Layouts"
-msgstr "Go bea"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-"Notlela sekirini ka morago ga botelele bjo itšego go thibela dikgobalo tša "
-"go diriša boroto ya dinotlelo ka mo go bušeleditšwego"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Microsoft Natural Keyboard"
-msgstr "Boroto ya Dinotlelo ya Tlhago ya Microsoft"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 #, fuzzy
-msgid "Preview:"
-msgstr "_Ponelopele"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-#, fuzzy
-msgid "Reset To De_faults"
-msgstr "Beakanya di_tlhaelelo ka leswa"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Separate _group for each window"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Typing Break"
-msgstr "Go Khutša ga go Tlanya"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "_Accessibility..."
-msgstr "_Go tsenega..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-#, fuzzy
-msgid "_Add..."
-msgstr "Oketša..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Break interval lasts:"
-msgstr "_Sekgoba sa go khutša se tšea:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Delay:"
-msgstr "_Diegiša:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-#, fuzzy
-msgid "_Models:"
-msgstr "_Mehlala"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Selected layouts:"
-msgstr "_Go bea mo go kgethilwego:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Speed:"
+msgid "Speed"
 msgstr "_Lebelo:"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Work interval lasts:"
-msgstr "_Sekgoba sa go šoma se tšea:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "minutes"
-msgstr "metsotso"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Beakanya tše ratwago tša gago tša boroto ya dinotlelo"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:559
-msgid "Unknown Cursor"
-msgstr "Leswao le Bontšhago mo o lego le sa Tsebjwego"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:761
-msgid "Default Cursor"
-msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Cursor - Current"
-msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo - Gona bjale"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-msgid "The default cursor that ships with X"
-msgstr "Leswao le bontšhago mo o lego la tlhaelelo le le sesago le X"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-msgid "White Cursor"
-msgstr "Leswao le Bontšhago mo o lego le Lešweu"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Cursor - Current"
-msgstr "Leswao le Bontšhago mo o lego le Lešweu - Gona bjale"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-msgid "The default cursor inverted"
-msgstr "Leswao le bontšhago mo o lego la tlhaelelo le hlanotšwego"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-msgid "Large Cursor"
-msgstr "Leswao le Bontšhago mo o lego le Legolo"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Cursor - Current"
-msgstr "Leswao le Bontšhago mo o lego le Legolo - Gona bjale"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-msgid "Large version of normal cursor"
-msgstr "Kgatišo e kgolo ya leswao le bontšhago mo o lego le tlwaelegilego"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-msgid "Large White Cursor - Current"
-msgstr "Leswao le Bontšhago mo o lego le Legolo le Lešweu - Gona bjale"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Cursor"
-msgstr "Leswao le Bontšhago mo o lego le Legolo le Lešweu"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-msgid "Large version of white cursor"
-msgstr "Kgatišo e kgolo ya leswao le bontšhago mo o lego le lešweu"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:975
-msgid "Cursor Theme"
-msgstr "Sehlogo sa Leswao le Bontšhago mo o lego"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr "<b>Kgotla go Fela ga Nako Gabedi </b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Goga o Lahlele</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Hwetša Selaetši</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>Thulaganyo ya Legotlwana </b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Speed</b>"
-msgstr "<b>Lebelo</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>Lebelo</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>Godimo</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>Kgolo</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>Tlase</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>Nanya</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>Nyenyane</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Dikonope"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 #, fuzzy
-msgid "Cursor Size:"
+msgid "Cursor blinking speed"
+msgstr "<b>Go Ponya ga Leswao le Bontšhago mo o lego</b>"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
 msgstr "Bogolo bja Leswao le Bontšhago mo o lego"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Cursors"
-msgstr "Maswao a Bontšhago mo o lego"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr "Bonagatša selaetši _ge o gatelela Ctrl"
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 #, fuzzy
-msgid "Large"
-msgstr "_Kgolo"
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kgaoletšo"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
 #, fuzzy
-msgid "Medium"
-msgstr "_Magareng"
+msgid "D_elay:"
+msgstr "_Diegiša:"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Motion"
-msgstr "Tšhišinyo"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Mouse Preferences"
-msgstr "Tše Ratwago tša Legotlwana"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#: panels/universal-access/cc-pointing-dialog.ui:166
 #, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kgaoletšo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Mojako:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "_Nyenyane"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
-msgstr "_Go Akgofiša:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
-msgstr "_Legotlwana la seatla sa lanngele"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr "_Go nyaka go swarwa ka bohlale:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr "_Mojako:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
-msgstr "_Nako e fedile:"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Legotlwana"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Beakanya tše ratwago tša legotlwana"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Kemedi ya Neteweke"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#: panels/universal-access/cc-pointing-dialog.ui:231
 #, fuzzy
-msgid "Set your network proxy preferences"
-msgstr "Tše ratwago tša kemedi ya neteweke"
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "_Kgolo"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
 #, fuzzy
-msgid "<b>D_irect internet connection</b>"
-msgstr "<b>_Kgokagano ya inthanete e lebanyago</b>"
+msgid "Repeat Keys"
+msgstr "<b>Dinotlelo tša go Bušeletša</b>"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Senotlelo se gatelela _bušeletša ge senotlelo se gateletšwe fase"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
 msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>_Go fetola sebopego ga kemedi mo go itiragalelago</b>"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>_Go fetola sebopego ga kemedi ya maitirelo</b>"
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Diriša tiišetšo</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
+#: panels/universal-access/cc-typing-dialog.ui:41
 #, fuzzy
-msgid "Advanced Configuration"
-msgstr "Go fetola sebopego mo go itiragalelago ga _STS:"
+msgid "_Sticky Keys"
+msgstr "Temošo ya Dinotlelo tše Kgomarelago"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr "Go fetola sebopego mo go itiragalelago ga _STS:"
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "Dintlha tša Kemedi tša PFSK"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "K_emedi ya PFSK:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
+#: panels/universal-access/cc-typing-dialog.ui:63
 #, fuzzy
-msgid "Network Proxy Preferences"
-msgstr "Tše ratwago tša kemedi ya neteweke"
+msgid "_Disable if two keys are pressed together"
+msgstr "Pale_diša ge dinotlelo tše pedi di gateletšwe mmogo"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Lefelo:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
+#: panels/universal-access/cc-typing-dialog.ui:71
 #, fuzzy
-msgid "Proxy Configuration"
-msgstr "Go Fetola Sebopego ga Kemedi ya Neteweke"
+msgid "Beep when a _modifier key is pressed"
+msgstr "Dira modumo _ge sempshafatši se gateletšwe"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr "M_oswari wa disokisi:"
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Temošo ya Dinotlelo tše Nanyago"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "U_sername:"
-msgstr "L_eina la modiriši:"
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_Dintlha"
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kgaoletšo"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr "_Kemedi ya PFF:"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "_Lentšuphetišo:"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr "Š_ireletša kemedi ya PFSK:"
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Dira modumo _ge sempshafatši se gateletšwe"
 
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Kgontšha modumo e bile o tswalanye medimo le ditiragalo"
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Dira modumo ge senotlelo se:"
 
-#: ../capplets/sound/sound-properties-capplet.c:271
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Sound Preferences"
-msgstr "Tše Ratwago tša Modumo"
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Dira modumo ge senotlelo se ga_nwa"
 
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "E_nable sound server startup"
-msgstr "K_gontšha go thoma ga seabi sa modumo"
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Dinotlelo tša Legotlwana"
 
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "Flash _entire screen"
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "H_lokomologa go gatelelwa ga senotlelo mo go lego gabedi ka gare ga:"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kgaoletšo"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Go tsenega"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "_Kgolo"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "_Sebadi sa sekirini"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "_Medumo:"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Bogolo bja Leswao le Bontšhago mo o lego"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "_Boroto ya dinotlelo e lego Sekirining"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Dinotlelo tša go Bušeletša</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Go Ponya ga Leswao le Bontšhago mo o lego</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Dinotlelo tša Legotlwana"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "<b>Hwetša Selaetši</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<b>Kgotla go Fela ga Nako Gabedi </b>"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
 msgstr "Phadimiša _sekirini ka moka"
 
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "Flash _window titlebar"
-msgstr "Phadimiša _bara ya sehlogo ya lefesetere"
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "General"
-msgstr "Kakaretšo"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "Sound Events"
-msgstr "Ditiragalo tša Modumo"
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "System Bell"
-msgstr "Tšhipi ya Tshepedišo"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "_Sound an audible bell"
-msgstr "_Letša tšhipi e dumago"
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "_Sounds for events"
-msgstr "_Medumo ya ditiragalo"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "_Visual feedback:"
-msgstr "_Karabelo ya pono:"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:347
-msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
-msgstr ""
-"Ga go na dihlogo tšeo di hweditšwego tshepedišong ya gago.  Se mohlomongwe "
-"se ra gore poledišano ya gago ya \"Tše Ratwago tša Sehlogo\" ga se tša "
-"tsenywa ka tshwanelo, goba ga se wa tsenya ngatana ya \"dihlogo tša gnome\"."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:227
-msgid "This theme is not in a supported format."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:244
-msgid "Failed to create temporary directory"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:264
-msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:282
-#: ../capplets/theme-switcher/gnome-theme-installer.c:319
-#: ../capplets/theme-switcher/gnome-theme-installer.c:399
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
 #, fuzzy
-msgid "Installation Failed"
-msgstr "Go Tsenywa ga Sehlogo"
+msgid "Flash the entire _window"
+msgstr "Phadimiša _sekirini ka moka"
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:302
-msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:340
-#, c-format
-msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:343
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:346
-#, c-format
-msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:349
-#, c-format
-msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:357
-msgid "The theme is an engine. You need to compile the theme."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:374
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 #, fuzzy
-msgid "The file format is invalid"
-msgstr "Faele ya %s ga se faele ya kgonthe ya wav"
+msgid "Full Screen"
+msgstr "Tlatša Sekirini"
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:468
-msgid "No theme file location specified to install"
-msgstr "Ga go na lefelo la faele ya sehlogo le laeditšwego go tsenywa"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:485
-msgid "The theme file location specified to install is invalid"
-msgstr "Lefelo la faele la sehlogo le laetšwego go tsenywa ga se la kgonthe"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:505
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:526
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 #, fuzzy
-msgid "The file format is invalid."
-msgstr "Faele ya %s ga se faele ya kgonthe ya wav"
+msgid "Zoom Options"
+msgstr "Dikgetho"
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:553
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-"%s ke tsejana yeo go yona difaele tša sehlogo di tla tsenywago. Se se ka se "
-"kgethwe bjalo ka lefelo la mothopo"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:607
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "Custom theme"
-msgstr "Sehlogo sa tlwaelo"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr "O ka boloka sehlogo se ka go kgotla konope ya Boloka Sehlogo."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr ""
-"Sekema sa sehlogo sa tlhaelelo ga se sa hwetšwa tshepedišong ya gago. Se se "
-"bolela gore mohlomongwe o tsentšitše metacity, goba gore gconf ya gago e "
-"fetotšwe sebopego ka mo go fošagetšego."
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:72
-msgid "Theme name must be present"
-msgstr "Leina la sehlogo le swanetše go ba gona"
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:104
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Sehlogo se šetše se le gona. Na o nyaka se tšeelwe legato?"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr "Kgetha dihlogo bakeng sa dikarolo tše fapa-fapanego tša teseke"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "Sehlogo"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Tsenya sehlogo</span>"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:3
-msgid "Theme Installation"
-msgstr "Go Tsenywa ga Sehlogo"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:4
-msgid "_Install"
-msgstr "_Tsenya"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:5
-msgid "_Location:"
-msgstr "_Lefelo:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Boloka Sehlogo Tisiking</span>"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Apply _Background"
-msgstr "Diriša _Bokamorago"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Apply _Font"
-msgstr "Diriša _Fonto"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Controls"
-msgstr "Ditaolo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "Icons"
-msgstr "Maswao"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "New themes can also be installed by dragging them into the window."
-msgstr "Dihlogo tše diswa di ka tsenywa gape ka go di gogela lefesetereng."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-msgid "Save Theme"
-msgstr "Boloka Sehlogo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-msgid "Select theme for the desktop"
-msgstr "Kgetha sehlogo sa teseke"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-msgid "Short _description:"
-msgstr "Tlhaloso e _kopana:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "Theme Details"
-msgstr "Dintlha tša Sehlogo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "Theme Preferences"
-msgstr "Tše Ratwago tša Sehlogo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-msgid "Theme _Details"
-msgstr "Dintlha tša _Sehlogo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-msgid "This theme does not suggest any particular font or background."
-msgstr "Sehlogo se ga se šišinye fonto e itšego le ge ele efe goba bokamorago."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-msgid "This theme suggests a background:"
-msgstr "Sehlogo se se šišinya bokamorago:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-msgid "This theme suggests a font and a background:"
-msgstr "Sehlogo se se šišinya fonto le bokamorago:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-msgid "This theme suggests a font:"
-msgstr "Sehlogo se se šišinya fonto:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "Window Border"
-msgstr "Mollwane wa Lefesetere"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-msgid "_Go To Theme Folder"
-msgstr "_Eya Sephutheding sa Sehlogo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-msgid "_Install Theme..."
-msgstr "_Tsenya Sehlogo..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-msgid "_Revert"
-msgstr "_Boela"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-msgid "_Save Theme..."
-msgstr "_Boloka Sehlogo..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-msgid "_Theme name:"
-msgstr "_Leina la sehlogo:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:24
-msgid "theme selection tree"
-msgstr "mohlare wa kgetho ya sehlogo"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
-msgstr ""
-"Tlwaelanya ponagalo ya bara ya didirišwa le bara ya lelokelelo la dikagare "
-"ditirišong"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "Malokelelo a Dikagare & Bara ya Didirišwa"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
-msgstr "<b>Boitshwaro le Ponagalo</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-msgid "<b>Preview</b>"
-msgstr "<b>Ponelopele</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "R_ipa"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-msgid "Icons only"
-msgstr "Maswao feela"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "Lelokelelo la dikagare le Tše Ratwago tša Bara ya Sedirišwa"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "Faele e Mpsha"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Bula Faele"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Boloka Faele"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr "Bontšha _maswao malokelelong a dikagare"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-msgid "Text below icons"
-msgstr "Sengwalwa ka tlase ga maswao"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-msgid "Text beside icons"
-msgstr "Sengwalwa se bapelanego le maswao"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-msgid "Text only"
-msgstr "Sengwalwa feela"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 #, fuzzy
-msgid "Toolbar _button labels:"
-msgstr "Maswao _a konope ya bara ya sedirišwa: "
+msgid "_Magnification:"
+msgstr "_Segodiši"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_Kopiša"
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "_Segodiši"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
-msgstr "_Dibara tša sedirišwa tšeo di ka kgokaganyollwago"
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "_Sebadi sa sekirini"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "_Segodiši"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Go taga go godimo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "_Dikagare"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Ga e gona"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Tletšego"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Lentšuphetišo:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Kgetha Faele ya Modumo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Molaodi wa Lefesetere"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Ga e gona"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "_Ponelopele"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Fetola peakanyo"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Fetola peakanyo"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Fetola peakanyo"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Lentšuphetišo:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Fetola peakanyo"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Lentšuphetišo:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
 msgstr "_Lokiša"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
 msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "_Faele"
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_Mpsha"
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
-msgstr "_Bula"
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "_Kgomaretša"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "_Gatiša"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "_Tlogela"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "_Boloka"
-
-#: ../capplets/windows/gnome-window-properties.c:386
-#, c-format
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
+"Administrators can add and remove other users, and can change settings for "
+"all users."
 msgstr ""
-"<b>E ka se thome tirišo ya tše ratwago bakeng sa molaodi wa gago wa "
-"lefesetere</b>\n"
-"\n"
-"%s"
 
-#: ../capplets/windows/gnome-window-properties.c:644
-msgid "Control"
-msgstr "Taolo"
-
-#: ../capplets/windows/gnome-window-properties.c:649
-msgid "Alt"
-msgstr "Tšh"
-
-#: ../capplets/windows/gnome-window-properties.c:655
-msgid "Hyper"
-msgstr "Kgahlišago"
-
-#: ../capplets/windows/gnome-window-properties.c:662
-msgid "Super (or \"Windows logo\")"
-msgstr "Godimo (goba \"Leswao la Windows\")"
-
-#: ../capplets/windows/gnome-window-properties.c:669
-msgid "Meta"
-msgstr "Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Senotlelo sa go šutha</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>Mogato wa Bara ya Sehlogo</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Kgetho ya Lefesetere</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To _move a window, press-and-hold this key then grab the window:"
-msgstr ""
-"Go šu_thiša lefesetere, gatelela o sware senotlelo se ke moka o sware "
-"lefesetere:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Tše Ratwago tša Lefesetere"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_Kgotla bara ya sehlogo gabedi go tšea mogato wo:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "_Sebaka pele ga go godiša:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_Godiša mafesetere a kgethilwego ka morago ga sebakal"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Kgetha mafesetere ge legotlwana le sepela ka godimo ga wona"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
+#: panels/user-accounts/cc-user-panel.ui:283
 #, fuzzy
-msgid "Set your window properties"
-msgstr "Dipharologantšho tša Lefesetere"
+msgid "_Parental Controls"
+msgstr "Ditaolo"
 
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Kgetha ditirišo tša gago tša tlhaelelo"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Tše dingwe"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Dikonope"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Dikonope"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Dikonope"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Dikonope"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Bea"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "E beilwe magareng"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Mafesetere"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
 msgid "Windows"
 msgstr "Mafesetere"
 
-#: ../control-center/control-center-categories.c:257
-msgid "Others"
-msgstr "Tše dingwe"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
 
-#: ../control-center/control-center.c:42
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
 #, fuzzy
-msgid "Desktop Preferences"
-msgstr "Tše Ratwago tša Bokamorago bja Teseke"
+msgid "Add"
+msgstr "Oketša..."
 
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr "Lefelo la Taolo ya GNOME"
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Boloka"
 
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "Sedirišwa sa go fetola sebopego sa GNOME"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "Bolumo"
-
-#: ../gnome-settings-daemon/factory.c:36
-msgid "Could not initialize Bonobo"
-msgstr "E ka se kgone go thomološa Bonobo"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
-msgid "Slow Keys Alert"
-msgstr "Temošo ya Dinotlelo tše Nanyago"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
 msgstr ""
-"O sa tšwa go gatelela senotlelo sa Shift metsotswana e 8.  Ye ke kgaoletšo "
-"ya sebopego sa Dinotlelo tše Nanyago, yeo e amago tsela yeo boroto ya gago "
-"ya dinotlelo e šomago ka yona."
 
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
-msgid "Do you want to activate Slow Keys?"
-msgstr "Na o nyaka go diragatša Dinotlelo tše Nanyago?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
-msgid "Do you want to deactivate Slow Keys?"
-msgstr "Na o nyaka go diragatšolla Dinotlelo tše Nanyago?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Sticky Keys Alert"
-msgstr "Temošo ya Dinotlelo tše Kgomarelago"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-"O sa tšwa go kgotla senotlelo sa Shift makga a 5 ka tatelano.  Ye ke "
-"kgaoletšo ya sebopego sa Dinotlelo tše Kgomarelago, yeo e amago tsela yeo ka "
-"yona boroto ya gago ya dinotlelo e šomago ka yona."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-"O sa tšwa go gatelela dinotlelo tše pedi ka nako e tee, goba o gateletše "
-"senotlelo sa Shift makga a 5 ka tatelano.  Se se tima sebopego sa Dinotlelo "
-"tše Kgomarelago, seo se amago tsela yeo ka yona boroto ya gago ya dinotlelo "
-"e šomago ka yona."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
-msgid "Do you want to activate Sticky Keys?"
-msgstr "Na o nyaka go diragatša Dinotlelo tše Kgomarelago?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr "Na o nyaka go diragatšolla Dinotlelo tše Kgomarelago?"
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:107
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-"E ka se kgone go hlama tšhupetšo ya \"%s\".\n"
-"Se se a nyakega go dumelela go fetola leswao le bontšhago mo o lego."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr ""
-"Go Kopanya ga Senotlelo ga (%s) go na le mogato o hlaloswago e le makga a "
-"mantši\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr ""
-"Go Kopanya ga Senotlelo ga (%s) go na le go kopanya mo go hlaloswago e le "
-"makga a mantši\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr "Go Kopanya ga Senotlelo ga (%s) ga go a felela\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr "Go Kopanya ga Senotlelo ga (%s) ga se ga kgonthe\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
-#, c-format
-msgid "It seems that another application already has access to key '%d'."
-msgstr ""
-"Go bonagala gore tirišo e nngwe e šetše e kgona go tsena senotlelong sa '%d'."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr "Go Kopanya ga Senotlelo ga (%s) go šetše go dirišwa\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-"Phošo ya ge go lekwa go dirišwa (%s)\n"
-"yeo e kgokagantšwego le senotlelo sa (%s)"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
-#, fuzzy, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-"Phošo ya go diragatša go fetola sebopego ga XKB.\n"
-"Mohlomongwe ke bothata bja ka gare bja seabi sa X.\n"
-"\n"
-"Tsebišo ya kgatišo ya seabi sa X:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"Ge eba o bega boemo bjo bjalo ka twatši, hle akaretša:\n"
-"- Dipoelo tša <b>xprop -root | grep XKB</b>\n"
-"- Dipoelo tša <b>gconftool-2 -R i/desktop/gnome/peripherals/keyboard/xkb</b>"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+#: panels/wwan/cc-wwan-details-dialog.ui:5
 #, fuzzy
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-"O diriša XFree 4.3.0.\n"
-"Go na le mathata a tsebjwago ka go fetola sebopego mo go raraganego ga XKB.\n"
-"Leka go diriša go fetola sebopego go bonolo goba go tšea kgatišo e foreshe "
-"ya software ya XFree."
+msgid "Modem Details"
+msgstr "Dintlha tša Sehlogo"
 
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
 #, fuzzy
-msgid "Do _not show this warning again"
-msgstr "_O seke wa bontšha molaetša wo gape"
+msgid "Network Type"
+msgstr "Kemedi ya Neteweke"
 
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
-msgid ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
 msgstr ""
-"Dipeakanyo tša boroto ya dinotlelo tša tshepedišo ya X di fapana le "
-"dipeakanyo tša gago tša gona bjale tša boroto ya dinotlelo tša GNOME.  Ke "
-"peakanyo efe yeo o ka ratago go e diriša?"
 
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
-msgid "Use X settings"
-msgstr "Diriša dipeakanyo tša X"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
-msgid "Use GNOME settings"
-msgstr "Diriša dipeakanyo tša GNOME"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
 msgstr ""
-"E ka se kgone go phethagatša taelo: %s\n"
-"Tiišetša gore taelo ye e gona."
 
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-"E ka se kgone go robatša motšhene.\n"
-"Tiišetša gore motšhene o fetotšwe sebopego ka mo go nepagetšego."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
-#, c-format
-msgid "Permissions on the file %s are broken\n"
-msgstr "Ditumelelo tša faele ya %s di senyegile\n"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-"E ka se kgone go laiša faele ya Sekgoba.\n"
-"Kgonthišetša gore daemon ye e tsentšhitšwe ka tshwanelo."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-"Go bile le phošo ya go thoma seboloki sa sekirini:\n"
-"\n"
-"%s\n"
-"\n"
-"Go šoma ga seboloki sa sekirini go ka se šome lenaneong le."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
-msgid "_Do not show this message again"
-msgstr "_O seke wa bontšha molaetša wo gape"
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:129
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr "E ka se kgone go laiša faele ya modumo ya %s bjalo ka mohlala %s"
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
-msgid "Cannot determine user's home directory"
-msgstr "E ka se lemoge tšhupetšo ya gae ya modiriši"
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr ""
-"Senotlelo sa GConf sa %s se beakantšwe go mohuta wa %s eupša mohuta wa sona "
-"o letetšwego e be e le %s\n"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+#: panels/wwan/cc-wwan-details-dialog.ui:151
 #, fuzzy
-msgid "A_vailable files:"
-msgstr "G_o bea mo go lego gona:"
+msgid "Device Details"
+msgstr "Dintlha tša Sehlogo"
 
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-#, fuzzy
-msgid "Do _not show this warning again."
-msgstr "_O seke wa bontšha molaetša wo gape"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
 msgstr ""
 
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
 msgstr ""
 
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-#, fuzzy
-msgid "_Loaded files:"
-msgstr "_Mehlala"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr "Phošo ya go hlama phaephe ya leswao."
-
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "Mohuta"
-
-#: ../libbackground/applier.c:256
-msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-msgstr ""
-"Mohuta wa bg_applier: BG_APPLIER_ROOT bakeng sa lefesete la modu goba "
-"BG_APPLIER_PREVIEW bakeng sa ponelopele"
-
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr "Bophara bja Ponelopele"
-
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr "Bophara ge eba sediriši e le ponelopele: Ditlhaelelo go ya go 64."
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr "Bophagamo bja Ponelopele"
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr "Bophagamo ge eba sediriši e le ponelopele: Ditlhaelelo go ya go 48."
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Sekirini"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr "Sekirini seo go sona BGApplier e swanetšego go thala go sona"
-
-#: ../libgswitchit/gswitchit_config.c:1035
-#, fuzzy, c-format
-msgid "There was an error loading an image: %s"
-msgstr "Go bile le phošo ya go bontšha thušo: %s"
-
-#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
-msgid "The sound file for this event does not exist."
-msgstr "Faele ya modumo ya tiragalo ye ga e gona."
-
-#: ../libsounds/sound-view.c:149
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package\n"
-"for a set of default sounds."
-msgstr ""
-"Faele ya modumo ya tiragalo ye ga e gona.\n"
-"O ka nyaka go tsenya sephuthelwana sa gnome-audio\n"
-"bakeng sa peakanyo ya medumo ya tlhaelelo."
-
-#: ../libsounds/sound-view.c:224
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "Faele ya %s ga se faele ya kgonthe ya wav"
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../libsounds/sound-view.c:289
-msgid "Event"
-msgstr "Tiragalo"
-
-#: ../libsounds/sound-view.c:298
-msgid "Sound File"
-msgstr "Faele ya Modumo"
-
-#: ../libsounds/sound-view.c:314
-msgid "_Sounds:"
-msgstr "_Medumo:"
-
-#: ../libsounds/sound-view.c:328
-msgid "Sound _file:"
-msgstr "Faele ya _modumo:"
-
-#: ../libsounds/sound-view.c:332
-msgid "Select Sound File"
-msgstr "Kgetha Faele ya Modumo"
-
-#: ../libsounds/sound-view.c:356
-msgid "_Play"
-msgstr "_Bapala"
-
-#: ../libsounds/sound-view.c:366
-msgid "_Remove"
-msgstr "_Tloša"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
+#: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
-"Molaodi wa lefesetere wa \"%s\" ga se a ngwadiša sedirišwa sa go fetola "
-"sebopego\n"
 
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Godiša"
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Phutha"
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Faele"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Kemedi ya Neteweke"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Kemedi ya Neteweke"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Dintlha tša Sehlogo"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Kemedi ya Neteweke"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "K_gontšha Dinotlelo tša go Thumaša le go Tima"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Go kgokaganya..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Fetola peakanyo"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Dipeakanyo tša Tlhaelelo"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
 msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
-"Ge eba e le therešo, baswari ba mime bakeng sa text/plain (sengwalwa/se se "
-"nago selo) le text/* (sengwalwa) di tla bolokwa di rulagantšwe"
 
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
+#: shell/cc-window.ui:164
+msgid "Help"
 msgstr ""
-"text/plain (sengwalwa/se se nago selo) e rulagantšwego le baswari ba text/* "
-"(sengwalwa)"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "Brightness down"
-msgstr "Go taga go tlase"
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Kakaretšo"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "Brightness down's shortcut."
-msgstr "Kgaoletšo ya go taga go tlase."
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Tlogela"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Brightness up"
-msgstr "Go taga go godimo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Brightness up's shortcut."
-msgstr "Kgaoletšo ya go taga go godimo."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "E-mail"
-msgstr "Poso ya elektronike"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "E-mail's shortcut."
-msgstr "Kgaoletšo ya poso ya elektronike."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Eject"
-msgstr "Ntšha"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-msgid "Eject's shortcut."
-msgstr "Kgaoletšo ya go tšwa."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-msgid "Home folder"
-msgstr "Sephuthedi sa gae"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-msgid "Home folder's shortcut."
-msgstr "Kgaoletšo ya sephuthedi sa gae."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-msgid "Launch help browser"
-msgstr "Tsebagatša sefetleki sa thušo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-msgid "Launch help browser's shortcut."
-msgstr "Tsebagatša kgaoletšo ya sefetleki sa thušo."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-msgid "Launch web browser"
-msgstr "Tsebagatša sefetleki sa wepe"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-msgid "Launch web browser's shortcut."
-msgstr "Tsebagatša kgaoletšo ya sefetleki sa wepe."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-msgid "Lock screen"
-msgstr "Notlela sekirini"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-msgid "Lock screen's shortcut."
-msgstr "Notlela kgaoletšo ya sekirini."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-msgid "Log out"
-msgstr "E-tšwa"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-msgid "Log out's shortcut."
-msgstr "Kgaoletšo ya go tšwa."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Next track key's shortcut."
-msgstr "Kgaoletšo ya senotlelo ya koša e latelago."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Pause"
-msgstr "Emiša nakwana"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-msgid "Pause key's shortcut."
-msgstr "Emiša kgaoletšo ya senotlelo nakwana."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Play (or play/pause)"
-msgstr "Bapala (goba bapala/emiša nakwana)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Play (or play/pause) key's shortcut."
-msgstr "Bapala (goba bapala/emiša nakwana) kgaoletšo ya senotlelo."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Previous track key's shortcut."
-msgstr "Kgaoletšo ya senotlelo ya kotša e fetilego."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Search"
 msgstr "Nyakišiša"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-msgid "Search's shortcut."
-msgstr "Nyakišiša kgaoletšo."
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Skip to next track"
-msgstr "Tabogela go koša e latelago"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Skip to previous track"
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
 msgstr "Tabogela go koša e fetilego"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-msgid "Sleep"
-msgstr "Robala"
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-msgid "Sleep's shortcut."
-msgstr "Kgaoletšo ya go robala."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Stop playback key"
-msgstr "Emiša senotlelo sa bapala o boele morago"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Stop playback key's shortcut."
-msgstr "Emiša kgaoletšo ya senotlelo sa balapa o boele morago."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
-msgid "Volume down"
-msgstr "Bolumo e tlase"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume down's shortcut."
-msgstr "Kgaoletšo ya bolumo e tlase."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-msgid "Volume mute"
-msgstr "Go nolofatšwa ga bolumo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume mute's shortcut"
-msgstr "Kgaoletšo ya go nolofatšwa ga bolumo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
-msgid "Volume step"
-msgstr "Peakanyo ya bolumo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-msgid "Volume step as percentage of volume."
-msgstr "Peakanyo ya bolumo go ya ka phesente ya bolumo."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
-msgid "Volume up"
-msgstr "Bolumo e godimo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
-msgid "Volume up's shortcut."
-msgstr "Kgaoletšo ya bolumo e godimo."
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+#: shell/org.gnome.Settings.desktop.in.in:17
 #, fuzzy
-msgid "Display a dialog when there are errors running the screensaver"
-msgstr ""
-"Bontšha poledišano ge go na le diphošo tša go diriša Seboloki sa Sekirini sa "
-"X"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-#, fuzzy
-msgid "Run screensaver at login"
-msgstr "Diriša Seboloki sa Sekirini sa X ge o tsena"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
-msgstr "Bontšha Diphošo tša go Thoma"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
-#, fuzzy
-msgid "Start screensaver"
-msgstr "Thoma Seboloki sa Sekirini sa X"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
-#, fuzzy
-msgid "Keyboard Update Handlers"
-msgstr "Mohlala wa _boroto ya dinotlelo:"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
-#, fuzzy
-msgid "Keyboard layout"
-msgstr "Go bea ga boroto ya dinotlelo ya XKB"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
-#, fuzzy
-msgid "Keyboard model"
-msgstr "Mohlala wa _boroto ya dinotlelo:"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
-#, fuzzy
-msgid "Keyboard options"
-msgstr "Dikgaoletšo tša Boroto ya Dinotlelo"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
-#, fuzzy
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
-msgstr ""
-"Dipeakanyo tša XKB go gconf di tla beelwa ka thoko tshepedišong ya ASAP"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
-#, fuzzy
-msgid "keyboard layout"
-msgstr "Go bea ga boroto ya dinotlelo ya XKB"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
-#, fuzzy
-msgid "keyboard model"
-msgstr "Mohlala wa boroto ya dinotlelo ya XKB"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "modmap file list"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:212
-msgid "_Postpone break"
-msgstr "Šu_thiša go khutša"
-
-#: ../typing-break/drw-break-window.c:259
-msgid "Take a break!"
-msgstr "Ikhutše!"
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:141
-msgid "/_Preferences"
+msgid "Preferences;Settings;"
 msgstr "/_Tše ratwago"
 
-#: ../typing-break/drwright.c:142
-msgid "/_About"
-msgstr "/_Ka ga"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
 
-#: ../typing-break/drwright.c:144
-msgid "/_Take a Break"
-msgstr "/_Ikhutše"
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
 
-#: ../typing-break/drwright.c:495
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "metsotso e %d pele ga go khutša mo go latelago"
-msgstr[1] "metsotso e %d go fihlela go khutšeng mo go latelago"
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../typing-break/drwright.c:499
-msgid "Less than one minute until the next break"
-msgstr "Ka tlase ga motsotso o tee go fihlela go khutšeng mo go latelago"
-
-#: ../typing-break/drwright.c:587
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
-msgstr ""
-"Ga e kgone go tswalanya poledišano ya dipharologantšho tša go khutša le "
-"phošo e latelago: %s"
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../typing-break/drwright.c:635
-msgid "About GNOME Typing Monitor"
-msgstr "Ka ga Lepokisana la Sekirini la go Tlanya la GNOME"
-
-#: ../typing-break/drwright.c:659
-msgid "A computer break reminder."
-msgstr "Kgopotšo ya go khutša ga khomphuthara."
-
-#: ../typing-break/drwright.c:660
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
-msgstr "E ngwadilwe ke Richard Hult &lt;richard@imendio.com&gt;"
-
-#: ../typing-break/drwright.c:661
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Lelekere la leihlo le okeditšwe ke Anders Carlsson"
-
-#: ../typing-break/drwright.c:837
-msgid "Break reminder"
-msgstr "Kgopotšo ya go khutša"
-
-#: ../typing-break/main.c:93
-msgid "The typing monitor is already running."
-msgstr "Lepokisana la sekirini la go tlanya le šetše le šoma."
-
-#: ../typing-break/main.c:106
 #, fuzzy
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
-msgstr ""
-"Lepokisana la sekirini la go tlanya le diriša lefelo la go lemoša bakeng sa "
-"go bonagatša tshedimošo. O bonagala o se na lefelo la temošo paneleng ya "
-"gago. O ka le oketša ka go kgotla go lagoja paneleng ya gago gomme o kgethe "
-"'Oketša paneleng -> Dithušo -> lefelo la Temošo'."
+#~ msgid "The type of alert"
+#~ msgstr "Mohuta wa seakgofiši."
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "Phukubjwe e tsotho ya lebelo e fofela mpsha e tšwafago. 0123456789"
+#, fuzzy
+#~ msgid "Show more _details"
+#~ msgstr "Dintlha tša _Sehlogo"
 
-#: ../vfs-methods/fontilus/font-view.c:276
-msgid "Name:"
-msgstr "Leina:"
+#, fuzzy
+#~ msgid "About Me"
+#~ msgstr "_Ka ga"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "Setaele:"
+#, fuzzy
+#~ msgid "No Image"
+#~ msgstr "Diswantšho"
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "Mohuta:"
+#, fuzzy, c-format
+#~ msgid "About %s"
+#~ msgstr "_Ka ga"
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "Boglo:"
+#, fuzzy
+#~ msgid "Please type the passwords."
+#~ msgstr "_Lentšuphetišo:"
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "Kgatišo:"
+#~ msgid " "
+#~ msgstr " "
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "Tokelo ya ngwalollo:"
+#~ msgid "    "
+#~ msgstr "    "
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "Tlhaloso:"
+#, fuzzy
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Lebelo</b>"
 
-#: ../vfs-methods/fontilus/font-view.c:408
+#, fuzzy
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Go Fana ka Fonto</b>"
+
+#, fuzzy
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Thekgo</b>"
+
+#, fuzzy
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Dinotlelo tša go Thumaša le go Tima</b>"
+
+#, fuzzy
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Lebelo</b>"
+
+#, fuzzy
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Thekgo</b>"
+
+#, fuzzy
+#~ msgid "A_ddress:"
+#~ msgstr "_Oketša:"
+
+#, fuzzy
+#~ msgid "C_ity:"
+#~ msgstr "_Setaele:"
+
+#, fuzzy
+#~ msgid "C_ompany:"
+#~ msgstr "Ta_elo:"
+
+#, fuzzy
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Fetola peakanyo"
+
+#, fuzzy
+#~ msgid "Ci_ty:"
+#~ msgstr "_Setaele:"
+
+#, fuzzy
+#~ msgid "Co_untry:"
+#~ msgstr "Taolo"
+
+#, fuzzy
+#~ msgid "Cou_ntry:"
+#~ msgstr "Taolo"
+
+#, fuzzy
+#~ msgid "Hom_e:"
+#~ msgstr "_Leina:"
+
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "_Lentšuphetišo:"
+
+#, fuzzy
+#~ msgid "Personal Info"
+#~ msgstr "_Fonto ya kgokagano ya dithapo:"
+
+#, fuzzy
+#~ msgid "_Home page:"
+#~ msgstr "_Leina la sehlogo:"
+
+#, fuzzy
+#~ msgid "_Home:"
+#~ msgstr "_Leina:"
+
+#, fuzzy
+#~ msgid "_Manager:"
+#~ msgstr "_Segodiši"
+
+#, fuzzy
+#~ msgid "_Profession:"
+#~ msgstr "Kgatišo:"
+
+#, fuzzy
+#~ msgid "_Title:"
+#~ msgstr "_Setaele:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Thekgo</b>"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>Ela hloko:</b> Diphetogo tšeo di dirwago peakanyong ye di ka "
+#~ "se šome go fihlela ge o tsena gape nakong e latelago.</i></small>"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Tše Ratwago tša Thekinolotši tše Thušago"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Tswalela gomme o _Tšwe"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Thoma dithekinolotši tše tše thušago nako le nako ge o tsena:"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Kgontšha dithekinolotši tše thušago"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "Thekgo ya Thekinolotši e Thušago"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr ""
+#~ "Kgontšha thekgo bakeng sa dithekinolotši tše thušago tša GNOME go tseneng"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Ga go na Thekinolotši e Thušago yeo e lego tshepedišong ya gago.  Ngatana "
+#~ "ya 'gok' e swanetše go tsenywa gore go hwetšwe thekgo ya boroto ya "
+#~ "dinotlelo ya sekirining, le ngatana ya 'gnopernicus' e swanetše go "
+#~ "tsenywa bakegn sa go bala ga sekirini le bokgoni bja go godiša."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Ga se thekinolotši ka moka tše thušago tšeo di tsentšhitšwego "
+#~ "tshepedišong ya gago. Ngatana ya 'gok' e swanetše go tsenywa gore go "
+#~ "hwetšwe thekgo ya boroto ya dinotlelo ya sekirining."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+#~ msgstr ""
+#~ "Ga se dithekinolotši ka moka tše thušago tšeo di tsentšhitšwego "
+#~ "tshepedišong ya gago. Ngatana ya 'gnopernicus' e swanetše go tsentšhwa "
+#~ "bakeng sa bokgoni bja go bala sekirini le go godiša."
+
 #, c-format
-msgid "usage: %s fontfile\n"
-msgstr "tirišo: %s faele ya fonto\n"
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr ""
+#~ "Go bile le phošo ya go tsebagatša poledišano ya tše ratwago tša "
+#~ "legotlwana: %s"
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
-msgstr "Beakanya Bjalo ka Fonto ya Tirišo"
+#, c-format
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr ""
+#~ "Ga e kgone go amogela dipeakanyo tša go Tsena tša X go tšwa faeleng ya "
+#~ "'%s'"
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Amogela Faele ya Dipeakanyo tša Sebopego"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Beakanya tše di ratwago tša go tsenega ga boroto ya dinotlelo"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Tshepedišo ye ga e bonagale e na le koketšo ya XKB.  Dibopego tša go "
+#~ "tsenega ga boroto ya dinotlelo di ka se šome ka ntle le yona."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>Kgontšha Dino_tlelo tša go Tlola</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>Kgontšha Dino_tlelo tše Nanyago</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Kgontšha _Dinotlelo tša Legotlwana</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>Kgontšha _Dinotlelo tša go Bušeletša</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>Kgontšha _Dinotlelo tše Kgomarelago</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Dibopego</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Dinotlelo tša go Thumaša le go Tima</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Motheo"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr ""
+#~ "Dira modumo _ge dibopego di thumašwa goba di tingwa borotong ya dinotlelo"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "Dira modumo ge LED e thumašitšwe le medumo e mebedi ge e timilwe."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr ""
+#~ "Diegiša magareng ga go gatelelwa ga senotlelo le go šu_tha ga selaetši:"
+
+#~ msgid "Filters"
+#~ msgstr "Dikgethi"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Hlokomologa go gatelela ka moka mo go hlatlamanago ga senotlelo se "
+#~ "SWANAGO ge eba go direga nakong e kgethilwego ya modiriši."
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Tše Ratwago tša go Tsenega ga Boroto ya Dinotlelo (Go Tsena ga X)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Le_belo le legolo la selaetši:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Tše Ratwago _tša Legotlwana..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Amogela dinotlelo feela ka morago ga ge di gateletšwe le go swara tekanyo "
+#~ "ya nako e ka lokišwago ya modiriši."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Dira mediro ya go gatelela senotlelo e mentši ya samma-le-tee ka go "
+#~ "kgotla dinotlelo tša mpshafatšo ka tatelano."
+
+#~ msgid "S_peed:"
+#~ msgstr "L_ebelo:"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Nako ya go akgo_fiša go fihla go lebelo le legolo:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr ""
+#~ "Fetola mosemo wa dinotlelo wa dinomoro gore e ba moseme wa taolo ya "
+#~ "legotlwana."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Palediša ge eba e sa dirišwe bakeng sa:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "_Kgontšha dibopego tša go tsenega ga boroto ya dinotlelo"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Amogela Peakanyo ya Sebopego..."
+
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "_Amogela feela dinotlelo tše swaretšwego:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Tlanya go leka dipeakanyo:"
+
+#~ msgid "_accepted"
+#~ msgstr "_amogetšwe"
+
+#~ msgid "_pressed"
+#~ msgstr "_gateletšwe"
+
+#~ msgid "_rejected"
+#~ msgstr "_gannwe"
+
+#~ msgid "characters/second"
+#~ msgstr "ditlhaka/motsotswana"
+
+#~ msgid "milliseconds"
+#~ msgstr "seripa sa metsotswana"
+
+#~ msgid "pixels/second"
+#~ msgstr "dikarolwana tše bopago seswantšho/motsotswana"
+
+#~ msgid "Desktop Background"
+#~ msgstr "Bokamorago bja Teseke"
+
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>Pampiri ya leboteng ya _Teseke</b>"
+
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>_Mebala ya Teseke</b>"
+
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Tše Ratwago tša Bokamorago bja Teseke"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Oketša Pampiri ya leboteng"
+
+#~ msgid "_Style:"
+#~ msgstr "_Setaele:"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Go bile le phošo ya go bontšha thušo: %s"
+
+#~ msgid "Tiled"
+#~ msgstr "E dirilwe thaele"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Go Sekama go Rapamego"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Go Sekama go Tsepamego"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Oketša Pampiri ya leboteng"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Ga e kgone go thoma molaodi wa dipeakanyo 'daemon ya dipeakanyo tša "
+#~ "gnome'.\n"
+#~ "Ka ntle le go šoma ga molaodi wa dipeakanyo tša GNOME, tše dingwe tše "
+#~ "ratwago di ka no se šome. Se se ka laetša bothata le Bonobo, goba molaodi "
+#~ "wa dipeakanyo yo e sego wa GNOME (ka mohlala, KDE) a ka ba a šetše a šoma "
+#~ "e bile a lwantšhana le molaodi wa peakanyo wa GNOME."
+
+#, c-format
+#~ msgid "Unable to load capplet stock icon '%s'\n"
+#~ msgstr "Ga e kgone go laiša leswao la setoko la khapolete ya '%s'\n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Diriša feela dipeakanyo gomme o tlogele"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Buša morago gomme go boloka dipeakanyo tše molaong"
+
+#~ msgid "From URI"
+#~ msgstr "Go tšwa go URI"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI gona bjale e fetišetša go tšwa go"
+
+#~ msgid "To URI"
+#~ msgstr "Go ya go URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI yeo gona bjale e fetišetšago go"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Seabelo sa phetišetšo yeo gona bjale e feditšwego"
+
+#~ msgid "Current URI index"
+#~ msgstr "Tlhatlamano ya gona bjale ya URI"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Tlhatlamano ya gona bjale ya URI - e thoma go 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "Palomoka ya di-URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Palo moka ya di-URI"
+
+#~ msgid "Key"
+#~ msgstr "Senotlelo"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Senotlelo sa GConf seo morulaganyi wa thoto a kgokagantšwego"
+
+#~ msgid "Callback"
+#~ msgstr "Letša gape"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Ntšha go letša gape ge boleng bjo tswalanego le senotlelo bo fetolwa"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf e fetola peakanyo yeo e nago le tsebišo yeo e swanetšego go "
+#~ "fetišetšwa go modirelwa wa gconf tirišong"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Go fetolwa ga go letša gape ga sedirišwa"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Go letša gape mo go swanetšego go ntšhwa ge tsebišo e fetoletšwe go tloga "
+#~ "go GConf go ya go sedirišwa"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Go fetolelwa go tšwa go go letša gape ga sedirišwa"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Go letša gape mo go swanetšego go ntšhwa ge tsebišo e swanetše go "
+#~ "fetolelwa go GConf go tšwa go sedirišwa"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Sedirišwa seo se laolago thoto (ka mo go tlwaelegilego sedirišwa)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Tsebišo ya sedirišwa ya morulaganyi wa thoto"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Tsebišo ya tlwaelo e nyakwago ke morulaganyi yo a itšego wa thoto"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Tsebišo ya morulaganyi wa thoto yeo e lokollago go letša gape"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Go letša gape mo go swanetšego go ntšhwa ge tsebišo ya sedirišwa sa "
+#~ "morulaganyi wa thoto e swanetše go lokollwa"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Ga e kgone go hwetša faele '%s'.\n"
+#~ "\n"
+#~ "Hle kgonthišetša gore e gona gomme o leke gape, goba o kgethe seswantšho "
+#~ "se bonagalago ka morago se fapanego."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Ga ke tsebe kamoo nka bulago faele ya '%s'.\n"
+#~ "Mohlomongwe ke mohuta wa seswantšho seo sešogo sa thekgwa.\n"
+#~ "\n"
+#~ "Hle kgetha seswantšho se fapanego legatong la se."
+
+#~ msgid "Please select an image."
+#~ msgstr "Hle kgetha seswantšho."
+
 #, fuzzy
-msgid "Sets the default application font"
-msgstr "Kgetha ditirišo tša gago tša tlhaelelo"
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Sefetleki sa Wepe sa Tlhaelelo"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr ""
-"Ge eba e beakantšwe gore e be therešo, gona difonto tša Mohuta o Bulegilego "
-"di tla khutsofatšwa."
+#~ msgid "Epiphany"
+#~ msgstr "Epiphany"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr ""
-"Ge eba e beakantšwe e le therešo, gona difonto tša PCF di tla khutsofatšwa."
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr ""
-"Ge eba e beakantšwe gore e be therešo, gona difonto tša Mohuta wa Therešo di "
-"tla khutsofatšwa."
+#~ msgid "Encompass"
+#~ msgstr "Fihlelela"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr ""
-"Ge eba e beakantšwe gore e be therešo, gona difonto tša Mohuta wa 1 di tla "
-"khutsofatšwa."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
-msgstr ""
-"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo tša "
-"difonto tša Mohuta o Bulegilego."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr ""
-"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo tša "
-"difonto tša PCF."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr ""
-"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo tša "
-"difonto tša Mohuta wa Therešo."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr ""
-"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo tša "
-"difonto tša Mohuta wa 1."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "Taelo ya khutsofatšo bakeng sa difonto tša Mohuta o Bulegilego"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "Taelo ya khutsofatšo bakeng sa difonto tša PCF"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "Taelo ya khutsofatšo bakeng sa difonto tša Mohuta wa Therešo"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Taelo ya khutsofatšo bakeng sa difonto tša Mohuta wa 1"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "Ge eba go swanetše go khutsofatšwe difonto tša Mohuta o Bulegilego"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "Ge eba go swanetše go khutsofatšwe difonto tša PCF"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "Ge eba go swanetše go khutsofatšwe difonto tša Mohuta wa Therešo"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "Ge eba go swanetše go khutsofatšwe difonto tša Mohuta wa 1"
-
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
 #, fuzzy
-msgid "GNOME Font Viewer"
-msgstr "Lefelo la Taolo ya GNOME"
+#~ msgid "Firebird"
+#~ msgstr "Firebird/FireFox"
 
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-msgstr "<span weight=\"bold\" size=\"larger\">Diriša fonto e mpsha?</span>"
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
 
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr "O se _ke wa diriša fonto"
-
-#: ../vfs-methods/themus/apply-font.glade.h:4
-msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
-msgstr ""
-"Sehlogo seo o se kgethilego se šišinya fonto e mpsha. Ponelopele ya fonto e "
-"bontšhitšwe ka mo tlase."
-
-#: ../vfs-methods/themus/apply-font.glade.h:5
-msgid "_Apply font"
-msgstr "_Diriša fonto"
-
-#: ../vfs-methods/themus/theme-method.c:520
-msgid "Themes"
-msgstr "Dihlogo"
-
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "Tlhaloso"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
-msgstr "Laola sehlogo"
-
-#: ../vfs-methods/themus/themus-properties-view.c:139
-msgid "Window border theme"
-msgstr "Sehlogo sa mollwane wa lefesetere"
-
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
-msgstr "Sehlogo sa leswao"
-
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
-msgstr "ABCDEFG"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
 #, fuzzy
-msgid "Apply theme"
-msgstr "_Diriša fonto"
+#~ msgid "Mozilla"
+#~ msgstr "Poso ya Mozilla"
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+#~ msgid "Netscape Communicator"
+#~ msgstr "Seboledi sa Netscape"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "Sefetleki sa Sengwalwa sa W3M"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Sefetleki sa Sengwalwa sa Lynx"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "E Kgokaganya Sefetleki sa Sengwalwa"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Sebadi sa Poso sa Phutollo"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Poso ya Mozilla"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
 #, fuzzy
-msgid "Sets the default theme"
-msgstr "Beakanya di_tlhaelelo ka leswa"
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Kgokagano ya Dithapo ya Tlhaelelo"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr ""
-"Ge eba e beakantšwe gore e be therešo, gona dihlogo tše tsentšhitšwego e tla "
-"khutsofatšwa."
+#~ msgid "Standard XTerminal"
+#~ msgstr "Kgokagano ya Dithapo ya X ya Motheo"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr ""
-"Ge eba e beakantšwe gore e be therešo, gona dihlogo di tla khutsofatšwa."
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:3
-msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
-msgstr ""
-"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo "
-"bakeng sa dihlogo tše tsentšhitšwego."
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
-msgstr ""
-"Beakanya senotlelo go taelo e dirišeditšwego go hlama dikhutsofatšo bakeng "
-"sa dihlogo."
+#~ msgid "aterm"
+#~ msgstr "aterm"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr "Taelo ya khutsofatšo bakeng sa dihlogo tše tsentšhitšwego"
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr "Taelo ya khutsofatšo bakeng sa dihlogo"
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "Hle laetša leina le taelo ya morulaganyi yo."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr "Ge eba khutsofatšo e tsentšhitše dihlogo"
+#~ msgid "C_ustom"
+#~ msgstr "_Tlwaelo"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr "Ge eba go swanetše go khutsofatšwe dihlogo"
+#~ msgid "C_ustom:"
+#~ msgstr "_Tlwaelo:"
+
+#, fuzzy
+#~ msgid "Can open multiple _files"
+#~ msgstr "Tirišo ye e ka bula difaele _tše dintši"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Ta_elo:"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Dipharologantšho tša Morulaganyi wa Tlwaelo"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "Mmadi wa Poso wa Tlhaelelo"
+
+#~ msgid "Default Terminal"
+#~ msgstr "Kgokagano ya Dithapo ya Tlhaelelo"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "Morulaganyi wa Sengwalwa wa Tlhaelelo"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "Sefetleki sa Wepe sa Tlhaelelo"
+
+#~ msgid "Default Window Manager"
+#~ msgstr "Molaodi wa Lefesetere wa Tlhaelelo"
+
+#~ msgid "Delete"
+#~ msgstr "Phumola"
+
+#~ msgid "E_xec Flag:"
+#~ msgstr "P_hethagatša Folaga:"
+
+#~ msgid "Edit..."
+#~ msgstr "Lokiša..."
+
+#~ msgid "Mail Reader"
+#~ msgstr "Sebadi sa Poso"
+
+#, fuzzy
+#~ msgid "Run in a _terminal"
+#~ msgstr "Diriša ka _Kgokagano ya Dithapo"
+
+#, fuzzy
+#~ msgid "Run in a t_erminal"
+#~ msgstr "Diriša ka _Kgokagano ya Dithapo"
+
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "Kgetha molaodi wa lefesetere yo o mo nyakago.  Go tla nyakega gore o "
+#~ "kgotle diriša, o phagamiše seatla, gomme o bine motantsho wa mohlolo gore "
+#~ "e šome."
+
+#~ msgid "Terminal"
+#~ msgstr "Kgokagano ya dithapo"
+
+#~ msgid "Text Editor"
+#~ msgstr "Morulaganyi wa Sengwalwa"
+
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "E Kwešiša _Taolo ya Kgole ya Netscape"
+
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr ""
+#~ "Diriša morulaganyi _yo go bula difaele tša sengwala molaoding wa faele"
+
+#~ msgid "Web Browser"
+#~ msgstr "Sefetleki sa Wepe"
+
+#~ msgid "_Properties..."
+#~ msgstr "_Dipharologantšho..."
+
+#~ msgid "_Select:"
+#~ msgstr "_Kgetha:"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Fetola setlamo sa sekirini"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Tše Ratwago tša Setlamo sa Sekirini"
+
+#, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Dira tlhaelelo bakeng sa khomphuthara ye ya (%s) feela"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Go leka dipeakanyo tše mpsha. Ge o sa arabele ka metsotswana e %d go tla "
+#~ "bolokwa peakanyo ya nakong e fetilego."
+#~ msgstr[1] ""
+#~ "Go leka dipeakanyo tše mpsha. Ge eba o sa arabele ka metsotswana e %d go "
+#~ "tla bolokwa peakanyo ya nakong e fetilego."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Boloka Setlamo"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Na o nyaka go boloka setlamo se?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "Diriša _setlamo sa nakong e fetilego"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Boloka setlamo"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "Seabi sa X ga se thekge koketšo ya XRandR.  Setlamo sa nako ya go šoma se "
+#~ "fetogelago go bogolo bja go bontšha ga di gona."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Kgatišo ya koketšo ya XRandR yeo e sa kwanego le lenaneo le. Diphetogo "
+#~ "tša go šoma go bogolo bja go bontšha ga di gona."
+
+#~ msgid "Font"
+#~ msgstr "Fonto"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Kgetha difonto tša teseke"
+
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<b>Go Fana ka Fonto</b>"
+
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<b>Go Eletša</b>:"
+
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<b>Go Dira Boreledi</b>:"
+
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<b>Tatelano ya dika-dikarolwana tše bopago seswantšho</b>:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Dibopego _tše di phalago ka moka"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Go fapana go e ph_alago ka moka"
+
+#~ msgid "D_etails..."
+#~ msgstr "D_intlha..."
+
+#~ msgid "Font Preferences"
+#~ msgstr "Tše Ratwago tša Fonto"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "Eya _sephutheding sa fonto"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Teka_nyo e tshetla"
+
+#~ msgid "N_one"
+#~ msgstr "G_a e gona"
+
+#~ msgid "R_esolution:"
+#~ msgstr "S_etlamo:"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Dikarolwana_tše nyenyane tše bopago diswantšho (di-LCD)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr ""
+#~ "Go dira gore dikarolwana_tše nyenyane tše bopago seswantšho di be "
+#~ "boreledi (di-LCD)"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Desktop font:"
+#~ msgstr "_Fonto ya teseke:"
+
+#~ msgid "_Medium"
+#~ msgstr "_Magareng"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Mmala o tee wa boso le bošweu"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "_Fonto ya kgokagano ya dithapo:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Fonto ya sehlogo sa lefesetere:"
+
+#~ msgid "dots per inch"
+#~ msgstr "dintlha go ya ka noko"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Fonto e ka ba e le e kgolo kudu"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Fonto e kgethilwego e bogolo bja ntlha bja %d , e bile e ka dira gore go "
+#~ "be thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe "
+#~ "bogolo bjo bo lego bjo bonyenyane go %d."
+#~ msgstr[1] ""
+#~ "Fonto e kgethilwego e bogolo bja dintlha bja %d , e bile e ka dira gore "
+#~ "go be thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o "
+#~ "kgethe bogolo bjo bo lego bjo bonyenyane go %d."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Fonto e kgethilwego e bogolo bja ntlha bja %d, e bile e ka dira gore go "
+#~ "be thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe "
+#~ "fonto ya bogolo bjo bonyenyane."
+#~ msgstr[1] ""
+#~ "Fonto e kgethilwego e bogolo bja dintlha bja %d, e bile e ka dira gore go "
+#~ "be thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe "
+#~ "fonto ya bogolo bjo bonyenyane."
+
+#~ msgid "New accelerator..."
+#~ msgstr "Seakgofiši se seswa..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Senotlelo sa seakgofiši"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Dimpshafatši tša seakgofiši"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Khoutu ya senotlelo ya seakgofiši"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Mohuta wa seakgofiši."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Mogato o sa Tsebjwego>"
+
+#~ msgid "Window Management"
+#~ msgstr "Taolo ya Lefesetere"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "Kgaoletšo ya \"%s\" e šetše e dirišeditšwe:\n"
+#~ " \"%s\"\n"
+
+#, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Phošo ya go beakanya seakgofiši se seswa datapeising ya go fetola "
+#~ "sebopego: %s\n"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Phošo ya go beakanyolla seakgofiši datapeising ya go fetola sebopego: %s\n"
+
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "Go lokiša senotlelo sa kgaoletšo, kgotla mothalong o sepelelanago gomme o "
+#~ "tlanye seakgofiši se seswa, goba o gatelele backspace gore o phumole."
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Abela dinotlelo tša kgaoletšo go ditaelo"
+
+#~ msgid "Unknown"
+#~ msgstr "Tše sa Tsebjwego"
+
+#, c-format
+#~ msgid "There was an error launching the keyboard capplet : %s"
+#~ msgstr ""
+#~ "Go bile le phošo ya go tsebagatša khapolete ya boroto ya dinotlelo : %s"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Diriša feela dipeakanyo gomme o tlogele (go sepelelana feela; mo gona "
+#~ "bjale go swarwago ke daemon)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Thoma letlakala dipeakanyo tša go khutša ga go tlanya di bonagala"
+
+#~ msgid "..."
+#~ msgstr "..."
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>_Notlela sekirini go gapeletša go khutša ga go tlanya</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Lebelo</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Telele</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Kopana</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Nanyago</i></small>"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "G_o bea mo go lego gona:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Dume_elela go šuthišwa ga go khutša"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Lekola ge eba go khutša go dumeletšwe gore go šuthišwe"
+
+#, fuzzy
+#~ msgid "Choose A Keyboard Model"
+#~ msgstr "Kgetha mohlala wa boroto ya dinotlelo"
+
+#, fuzzy
+#~ msgid "Choose A Layout"
+#~ msgstr "Tswalela gomme o _Tšwe"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Botelele bja go khutša ge o tlanya ga bo a dumelelwa"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Botelele bja mošomo pele ga go gapeletša go khutša"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Tše Ratwago tša Boroto ya Dinotlelo"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Mohlala wa _boroto ya dinotlelo:"
+
+#~ msgid "Layout Options"
+#~ msgstr "Dikgetho tša go Bea"
+
+#~ msgid "Layouts"
+#~ msgstr "Go bea"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Notlela sekirini ka morago ga botelele bjo itšego go thibela dikgobalo "
+#~ "tša go diriša boroto ya dinotlelo ka mo go bušeleditšwego"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Boroto ya Dinotlelo ya Tlhago ya Microsoft"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Go tsenega..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Sekgoba sa go khutša se tšea:"
+
+#, fuzzy
+#~ msgid "_Models:"
+#~ msgstr "_Mehlala"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Go bea mo go kgethilwego:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Sekgoba sa go šoma se tšea:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Beakanya tše ratwago tša gago tša boroto ya dinotlelo"
+
+#~ msgid "Unknown Cursor"
+#~ msgstr "Leswao le Bontšhago mo o lego le sa Tsebjwego"
+
+#~ msgid "Default Cursor"
+#~ msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo"
+
+#~ msgid "Default Cursor - Current"
+#~ msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo - Gona bjale"
+
+#~ msgid "The default cursor that ships with X"
+#~ msgstr "Leswao le bontšhago mo o lego la tlhaelelo le le sesago le X"
+
+#~ msgid "White Cursor"
+#~ msgstr "Leswao le Bontšhago mo o lego le Lešweu"
+
+#~ msgid "White Cursor - Current"
+#~ msgstr "Leswao le Bontšhago mo o lego le Lešweu - Gona bjale"
+
+#~ msgid "The default cursor inverted"
+#~ msgstr "Leswao le bontšhago mo o lego la tlhaelelo le hlanotšwego"
+
+#~ msgid "Large Cursor"
+#~ msgstr "Leswao le Bontšhago mo o lego le Legolo"
+
+#~ msgid "Large Cursor - Current"
+#~ msgstr "Leswao le Bontšhago mo o lego le Legolo - Gona bjale"
+
+#~ msgid "Large version of normal cursor"
+#~ msgstr "Kgatišo e kgolo ya leswao le bontšhago mo o lego le tlwaelegilego"
+
+#~ msgid "Large White Cursor - Current"
+#~ msgstr "Leswao le Bontšhago mo o lego le Legolo le Lešweu - Gona bjale"
+
+#~ msgid "Large White Cursor"
+#~ msgstr "Leswao le Bontšhago mo o lego le Legolo le Lešweu"
+
+#~ msgid "Large version of white cursor"
+#~ msgstr "Kgatišo e kgolo ya leswao le bontšhago mo o lego le lešweu"
+
+#~ msgid "Cursor Theme"
+#~ msgstr "Sehlogo sa Leswao le Bontšhago mo o lego"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Goga o Lahlele</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Lebelo</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Lebelo</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Godimo</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Kgolo</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Tlase</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Nanya</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Nyenyane</i>"
+
+#~ msgid "Cursors"
+#~ msgstr "Maswao a Bontšhago mo o lego"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Bonagatša selaetši _ge o gatelela Ctrl"
+
+#~ msgid "Motion"
+#~ msgstr "Tšhišinyo"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Tše Ratwago tša Legotlwana"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Legotlwana la seatla sa lanngele"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Go nyaka go swarwa ka bohlale:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Beakanya tše ratwago tša legotlwana"
+
+#, fuzzy
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Tše ratwago tša kemedi ya neteweke"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "<b>D_irect internet connection</b>"
+#~ msgstr "<b>_Kgokagano ya inthanete e lebanyago</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>_Go fetola sebopego ga kemedi mo go itiragalelago</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_Go fetola sebopego ga kemedi ya maitirelo</b>"
+
+#, fuzzy
+#~ msgid "Advanced Configuration"
+#~ msgstr "Go fetola sebopego mo go itiragalelago ga _STS:"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Dintlha tša Kemedi tša PFSK"
+
+#, fuzzy
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Tše ratwago tša kemedi ya neteweke"
+
+#~ msgid "Port:"
+#~ msgstr "Lefelo:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "Š_ireletša kemedi ya PFSK:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Kgontšha modumo e bile o tswalanye medimo le ditiragalo"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Tše Ratwago tša Modumo"
+
+#~ msgid "E_nable sound server startup"
+#~ msgstr "K_gontšha go thoma ga seabi sa modumo"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Phadimiša _bara ya sehlogo ya lefesetere"
+
+#~ msgid "_Sound an audible bell"
+#~ msgstr "_Letša tšhipi e dumago"
+
+#~ msgid "_Sounds for events"
+#~ msgstr "_Medumo ya ditiragalo"
+
+#~ msgid "_Visual feedback:"
+#~ msgstr "_Karabelo ya pono:"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Ga go na dihlogo tšeo di hweditšwego tshepedišong ya gago.  Se "
+#~ "mohlomongwe se ra gore poledišano ya gago ya \"Tše Ratwago tša Sehlogo\" "
+#~ "ga se tša tsenywa ka tshwanelo, goba ga se wa tsenya ngatana ya \"dihlogo "
+#~ "tša gnome\"."
+
+#, fuzzy
+#~ msgid "The file format is invalid"
+#~ msgstr "Faele ya %s ga se faele ya kgonthe ya wav"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Ga go na lefelo la faele ya sehlogo le laeditšwego go tsenywa"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Lefelo la faele la sehlogo le laetšwego go tsenywa ga se la kgonthe"
+
+#, fuzzy
+#~ msgid "The file format is invalid."
+#~ msgstr "Faele ya %s ga se faele ya kgonthe ya wav"
+
+#, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s ke tsejana yeo go yona difaele tša sehlogo di tla tsenywago. Se se ka "
+#~ "se kgethwe bjalo ka lefelo la mothopo"
+
+#~ msgid "Custom theme"
+#~ msgstr "Sehlogo sa tlwaelo"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "O ka boloka sehlogo se ka go kgotla konope ya Boloka Sehlogo."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "Sekema sa sehlogo sa tlhaelelo ga se sa hwetšwa tshepedišong ya gago. Se "
+#~ "se bolela gore mohlomongwe o tsentšitše metacity, goba gore gconf ya gago "
+#~ "e fetotšwe sebopego ka mo go fošagetšego."
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Leina la sehlogo le swanetše go ba gona"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Sehlogo se šetše se le gona. Na o nyaka se tšeelwe legato?"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Kgetha dihlogo bakeng sa dikarolo tše fapa-fapanego tša teseke"
+
+#~ msgid "Theme"
+#~ msgstr "Sehlogo"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Tsenya sehlogo</span>"
+
+#~ msgid "Theme Installation"
+#~ msgstr "Go Tsenywa ga Sehlogo"
+
+#~ msgid "_Install"
+#~ msgstr "_Tsenya"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+#~ msgstr ""
+#~ "<span size=\"larger\" weight=\"bold\">Boloka Sehlogo Tisiking</span>"
+
+#~ msgid "Apply _Font"
+#~ msgstr "Diriša _Fonto"
+
+#~ msgid "Icons"
+#~ msgstr "Maswao"
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr "Dihlogo tše diswa di ka tsenywa gape ka go di gogela lefesetereng."
+
+#~ msgid "Save Theme"
+#~ msgstr "Boloka Sehlogo"
+
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Kgetha sehlogo sa teseke"
+
+#~ msgid "Short _description:"
+#~ msgstr "Tlhaloso e _kopana:"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "Tše Ratwago tša Sehlogo"
+
+#~ msgid "Theme _Details"
+#~ msgstr "Dintlha tša _Sehlogo"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr ""
+#~ "Sehlogo se ga se šišinye fonto e itšego le ge ele efe goba bokamorago."
+
+#~ msgid "This theme suggests a background:"
+#~ msgstr "Sehlogo se se šišinya bokamorago:"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Sehlogo se se šišinya fonto le bokamorago:"
+
+#~ msgid "This theme suggests a font:"
+#~ msgstr "Sehlogo se se šišinya fonto:"
+
+#~ msgid "Window Border"
+#~ msgstr "Mollwane wa Lefesetere"
+
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "_Eya Sephutheding sa Sehlogo"
+
+#~ msgid "_Revert"
+#~ msgstr "_Boela"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "_Boloka Sehlogo..."
+
+#~ msgid "theme selection tree"
+#~ msgstr "mohlare wa kgetho ya sehlogo"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr ""
+#~ "Tlwaelanya ponagalo ya bara ya didirišwa le bara ya lelokelelo la "
+#~ "dikagare ditirišong"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Malokelelo a Dikagare & Bara ya Didirišwa"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Boitshwaro le Ponagalo</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Ponelopele</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "R_ipa"
+
+#~ msgid "Icons only"
+#~ msgstr "Maswao feela"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Lelokelelo la dikagare le Tše Ratwago tša Bara ya Sedirišwa"
+
+#~ msgid "New File"
+#~ msgstr "Faele e Mpsha"
+
+#~ msgid "Save File"
+#~ msgstr "Boloka Faele"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Bontšha _maswao malokelelong a dikagare"
+
+#~ msgid "Text below icons"
+#~ msgstr "Sengwalwa ka tlase ga maswao"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Sengwalwa se bapelanego le maswao"
+
+#~ msgid "Text only"
+#~ msgstr "Sengwalwa feela"
+
+#, fuzzy
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Maswao _a konope ya bara ya sedirišwa: "
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "_Dibara tša sedirišwa tšeo di ka kgokaganyollwago"
+
+#~ msgid "_File"
+#~ msgstr "_Faele"
+
+#~ msgid "_New"
+#~ msgstr "_Mpsha"
+
+#~ msgid "_Paste"
+#~ msgstr "_Kgomaretša"
+
+#, c-format
+#~ msgid ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "<b>E ka se thome tirišo ya tše ratwago bakeng sa molaodi wa gago wa "
+#~ "lefesetere</b>\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "Control"
+#~ msgstr "Taolo"
+
+#~ msgid "Alt"
+#~ msgstr "Tšh"
+
+#~ msgid "Hyper"
+#~ msgstr "Kgahlišago"
+
+#~ msgid "Super (or \"Windows logo\")"
+#~ msgstr "Godimo (goba \"Leswao la Windows\")"
+
+#~ msgid "Meta"
+#~ msgstr "Meta"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Senotlelo sa go šutha</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Mogato wa Bara ya Sehlogo</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Kgetho ya Lefesetere</b>"
+
+#~ msgid "To _move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Go šu_thiša lefesetere, gatelela o sware senotlelo se ke moka o sware "
+#~ "lefesetere:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Tše Ratwago tša Lefesetere"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Kgotla bara ya sehlogo gabedi go tšea mogato wo:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Sebaka pele ga go godiša:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Godiša mafesetere a kgethilwego ka morago ga sebakal"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Kgetha mafesetere ge legotlwana le sepela ka godimo ga wona"
+
+#, fuzzy
+#~ msgid "Set your window properties"
+#~ msgstr "Dipharologantšho tša Lefesetere"
+
+#, fuzzy
+#~ msgid "Desktop Preferences"
+#~ msgstr "Tše Ratwago tša Bokamorago bja Teseke"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Lefelo la Taolo ya GNOME"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Sedirišwa sa go fetola sebopego sa GNOME"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "E ka se kgone go thomološa Bonobo"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "O sa tšwa go gatelela senotlelo sa Shift metsotswana e 8.  Ye ke "
+#~ "kgaoletšo ya sebopego sa Dinotlelo tše Nanyago, yeo e amago tsela yeo "
+#~ "boroto ya gago ya dinotlelo e šomago ka yona."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Na o nyaka go diragatša Dinotlelo tše Nanyago?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Na o nyaka go diragatšolla Dinotlelo tše Nanyago?"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "O sa tšwa go kgotla senotlelo sa Shift makga a 5 ka tatelano.  Ye ke "
+#~ "kgaoletšo ya sebopego sa Dinotlelo tše Kgomarelago, yeo e amago tsela yeo "
+#~ "ka yona boroto ya gago ya dinotlelo e šomago ka yona."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "O sa tšwa go gatelela dinotlelo tše pedi ka nako e tee, goba o gateletše "
+#~ "senotlelo sa Shift makga a 5 ka tatelano.  Se se tima sebopego sa "
+#~ "Dinotlelo tše Kgomarelago, seo se amago tsela yeo ka yona boroto ya gago "
+#~ "ya dinotlelo e šomago ka yona."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Na o nyaka go diragatša Dinotlelo tše Kgomarelago?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Na o nyaka go diragatšolla Dinotlelo tše Kgomarelago?"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "E ka se kgone go hlama tšhupetšo ya \"%s\".\n"
+#~ "Se se a nyakega go dumelela go fetola leswao le bontšhago mo o lego."
+
+#, c-format
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr ""
+#~ "Go Kopanya ga Senotlelo ga (%s) go na le mogato o hlaloswago e le makga a "
+#~ "mantši\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr ""
+#~ "Go Kopanya ga Senotlelo ga (%s) go na le go kopanya mo go hlaloswago e le "
+#~ "makga a mantši\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Go Kopanya ga Senotlelo ga (%s) ga go a felela\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Go Kopanya ga Senotlelo ga (%s) ga se ga kgonthe\n"
+
+#, c-format
+#~ msgid "It seems that another application already has access to key '%d'."
+#~ msgstr ""
+#~ "Go bonagala gore tirišo e nngwe e šetše e kgona go tsena senotlelong sa "
+#~ "'%d'."
+
+#, c-format
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "Go Kopanya ga Senotlelo ga (%s) go šetše go dirišwa\n"
+
+#, c-format
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Phošo ya ge go lekwa go dirišwa (%s)\n"
+#~ "yeo e kgokagantšwego le senotlelo sa (%s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Phošo ya go diragatša go fetola sebopego ga XKB.\n"
+#~ "Mohlomongwe ke bothata bja ka gare bja seabi sa X.\n"
+#~ "\n"
+#~ "Tsebišo ya kgatišo ya seabi sa X:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "Ge eba o bega boemo bjo bjalo ka twatši, hle akaretša:\n"
+#~ "- Dipoelo tša <b>xprop -root | grep XKB</b>\n"
+#~ "- Dipoelo tša <b>gconftool-2 -R i/desktop/gnome/peripherals/keyboard/xkb</"
+#~ "b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "O diriša XFree 4.3.0.\n"
+#~ "Go na le mathata a tsebjwago ka go fetola sebopego mo go raraganego ga "
+#~ "XKB.\n"
+#~ "Leka go diriša go fetola sebopego go bonolo goba go tšea kgatišo e "
+#~ "foreshe ya software ya XFree."
+
+#, fuzzy
+#~ msgid "Do _not show this warning again"
+#~ msgstr "_O seke wa bontšha molaetša wo gape"
+
+#~ msgid ""
+#~ "The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.  Which set would you like to use?"
+#~ msgstr ""
+#~ "Dipeakanyo tša boroto ya dinotlelo tša tshepedišo ya X di fapana le "
+#~ "dipeakanyo tša gago tša gona bjale tša boroto ya dinotlelo tša GNOME.  Ke "
+#~ "peakanyo efe yeo o ka ratago go e diriša?"
+
+#~ msgid "Use X settings"
+#~ msgstr "Diriša dipeakanyo tša X"
+
+#~ msgid "Use GNOME settings"
+#~ msgstr "Diriša dipeakanyo tša GNOME"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "E ka se kgone go phethagatša taelo: %s\n"
+#~ "Tiišetša gore taelo ye e gona."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "E ka se kgone go robatša motšhene.\n"
+#~ "Tiišetša gore motšhene o fetotšwe sebopego ka mo go nepagetšego."
+
+#, c-format
+#~ msgid "Permissions on the file %s are broken\n"
+#~ msgstr "Ditumelelo tša faele ya %s di senyegile\n"
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "E ka se kgone go laiša faele ya Sekgoba.\n"
+#~ "Kgonthišetša gore daemon ye e tsentšhitšwe ka tshwanelo."
+
+#, c-format
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Go bile le phošo ya go thoma seboloki sa sekirini:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Go šoma ga seboloki sa sekirini go ka se šome lenaneong le."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_O seke wa bontšha molaetša wo gape"
+
+#, c-format
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "E ka se kgone go laiša faele ya modumo ya %s bjalo ka mohlala %s"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "E ka se lemoge tšhupetšo ya gae ya modiriši"
+
+#, c-format
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "Senotlelo sa GConf sa %s se beakantšwe go mohuta wa %s eupša mohuta wa "
+#~ "sona o letetšwego e be e le %s\n"
+
+#, fuzzy
+#~ msgid "A_vailable files:"
+#~ msgstr "G_o bea mo go lego gona:"
+
+#, fuzzy
+#~ msgid "Do _not show this warning again."
+#~ msgstr "_O seke wa bontšha molaetša wo gape"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "Phošo ya go hlama phaephe ya leswao."
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Mohuta wa bg_applier: BG_APPLIER_ROOT bakeng sa lefesete la modu goba "
+#~ "BG_APPLIER_PREVIEW bakeng sa ponelopele"
+
+#~ msgid "Preview Width"
+#~ msgstr "Bophara bja Ponelopele"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Bophara ge eba sediriši e le ponelopele: Ditlhaelelo go ya go 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Bophagamo bja Ponelopele"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Bophagamo ge eba sediriši e le ponelopele: Ditlhaelelo go ya go 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Sekirini seo go sona BGApplier e swanetšego go thala go sona"
+
+#, fuzzy, c-format
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Go bile le phošo ya go bontšha thušo: %s"
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Faele ya modumo ya tiragalo ye ga e gona."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package\n"
+#~ "for a set of default sounds."
+#~ msgstr ""
+#~ "Faele ya modumo ya tiragalo ye ga e gona.\n"
+#~ "O ka nyaka go tsenya sephuthelwana sa gnome-audio\n"
+#~ "bakeng sa peakanyo ya medumo ya tlhaelelo."
+
+#, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "Faele ya %s ga se faele ya kgonthe ya wav"
+
+#~ msgid "Event"
+#~ msgstr "Tiragalo"
+
+#~ msgid "Sound File"
+#~ msgstr "Faele ya Modumo"
+
+#~ msgid "_Play"
+#~ msgstr "_Bapala"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "Molaodi wa lefesetere wa \"%s\" ga se a ngwadiša sedirišwa sa go fetola "
+#~ "sebopego\n"
+
+#~ msgid "Maximize"
+#~ msgstr "Godiša"
+
+#~ msgid "Roll up"
+#~ msgstr "Phutha"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "Ge eba e le therešo, baswari ba mime bakeng sa text/plain (sengwalwa/se "
+#~ "se nago selo) le text/* (sengwalwa) di tla bolokwa di rulagantšwe"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr ""
+#~ "text/plain (sengwalwa/se se nago selo) e rulagantšwego le baswari ba text/"
+#~ "* (sengwalwa)"
+
+#~ msgid "Brightness down"
+#~ msgstr "Go taga go tlase"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Kgaoletšo ya go taga go tlase."
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Kgaoletšo ya go taga go godimo."
+
+#~ msgid "E-mail"
+#~ msgstr "Poso ya elektronike"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Kgaoletšo ya poso ya elektronike."
+
+#~ msgid "Eject's shortcut."
+#~ msgstr "Kgaoletšo ya go tšwa."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Kgaoletšo ya sephuthedi sa gae."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Tsebagatša kgaoletšo ya sefetleki sa thušo."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Tsebagatša kgaoletšo ya sefetleki sa wepe."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Kgaoletšo ya go tšwa."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Kgaoletšo ya senotlelo ya koša e latelago."
+
+#~ msgid "Pause"
+#~ msgstr "Emiša nakwana"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Emiša kgaoletšo ya senotlelo nakwana."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Bapala (goba bapala/emiša nakwana) kgaoletšo ya senotlelo."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Kgaoletšo ya senotlelo ya kotša e fetilego."
+
+#~ msgid "Sleep"
+#~ msgstr "Robala"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Kgaoletšo ya go robala."
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Emiša kgaoletšo ya senotlelo sa balapa o boele morago."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Kgaoletšo ya bolumo e tlase."
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Kgaoletšo ya go nolofatšwa ga bolumo"
+
+#~ msgid "Volume step"
+#~ msgstr "Peakanyo ya bolumo"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Peakanyo ya bolumo go ya ka phesente ya bolumo."
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Kgaoletšo ya bolumo e godimo."
+
+#, fuzzy
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr ""
+#~ "Bontšha poledišano ge go na le diphošo tša go diriša Seboloki sa Sekirini "
+#~ "sa X"
+
+#, fuzzy
+#~ msgid "Run screensaver at login"
+#~ msgstr "Diriša Seboloki sa Sekirini sa X ge o tsena"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Bontšha Diphošo tša go Thoma"
+
+#, fuzzy
+#~ msgid "Start screensaver"
+#~ msgstr "Thoma Seboloki sa Sekirini sa X"
+
+#, fuzzy
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Mohlala wa _boroto ya dinotlelo:"
+
+#, fuzzy
+#~ msgid "Keyboard model"
+#~ msgstr "Mohlala wa _boroto ya dinotlelo:"
+
+#, fuzzy
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr ""
+#~ "Dipeakanyo tša XKB go gconf di tla beelwa ka thoko tshepedišong ya ASAP"
+
+#, fuzzy
+#~ msgid "keyboard layout"
+#~ msgstr "Go bea ga boroto ya dinotlelo ya XKB"
+
+#, fuzzy
+#~ msgid "keyboard model"
+#~ msgstr "Mohlala wa boroto ya dinotlelo ya XKB"
+
+#~ msgid "_Postpone break"
+#~ msgstr "Šu_thiša go khutša"
+
+#~ msgid "Take a break!"
+#~ msgstr "Ikhutše!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Ikhutše"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "metsotso e %d pele ga go khutša mo go latelago"
+#~ msgstr[1] "metsotso e %d go fihlela go khutšeng mo go latelago"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Ka tlase ga motsotso o tee go fihlela go khutšeng mo go latelago"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Ga e kgone go tswalanya poledišano ya dipharologantšho tša go khutša le "
+#~ "phošo e latelago: %s"
+
+#~ msgid "About GNOME Typing Monitor"
+#~ msgstr "Ka ga Lepokisana la Sekirini la go Tlanya la GNOME"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Kgopotšo ya go khutša ga khomphuthara."
+
+#~ msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgstr "E ngwadilwe ke Richard Hult &lt;richard@imendio.com&gt;"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Lelekere la leihlo le okeditšwe ke Anders Carlsson"
+
+#~ msgid "Break reminder"
+#~ msgstr "Kgopotšo ya go khutša"
+
+#~ msgid "The typing monitor is already running."
+#~ msgstr "Lepokisana la sekirini la go tlanya le šetše le šoma."
+
+#, fuzzy
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Lepokisana la sekirini la go tlanya le diriša lefelo la go lemoša bakeng "
+#~ "sa go bonagatša tshedimošo. O bonagala o se na lefelo la temošo paneleng "
+#~ "ya gago. O ka le oketša ka go kgotla go lagoja paneleng ya gago gomme o "
+#~ "kgethe 'Oketša paneleng -> Dithušo -> lefelo la Temošo'."
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Phukubjwe e tsotho ya lebelo e fofela mpsha e tšwafago. 0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Boglo:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Tokelo ya ngwalollo:"
+
+#~ msgid "Description:"
+#~ msgstr "Tlhaloso:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "tirišo: %s faele ya fonto\n"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Beakanya Bjalo ka Fonto ya Tirišo"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Ge eba e beakantšwe gore e be therešo, gona difonto tša Mohuta o "
+#~ "Bulegilego di tla khutsofatšwa."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Ge eba e beakantšwe e le therešo, gona difonto tša PCF di tla "
+#~ "khutsofatšwa."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Ge eba e beakantšwe gore e be therešo, gona difonto tša Mohuta wa Therešo "
+#~ "di tla khutsofatšwa."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Ge eba e beakantšwe gore e be therešo, gona difonto tša Mohuta wa 1 di "
+#~ "tla khutsofatšwa."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo "
+#~ "tša difonto tša Mohuta o Bulegilego."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo "
+#~ "tša difonto tša PCF."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo "
+#~ "tša difonto tša Mohuta wa Therešo."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo "
+#~ "tša difonto tša Mohuta wa 1."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Taelo ya khutsofatšo bakeng sa difonto tša Mohuta o Bulegilego"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Taelo ya khutsofatšo bakeng sa difonto tša PCF"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Taelo ya khutsofatšo bakeng sa difonto tša Mohuta wa Therešo"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Taelo ya khutsofatšo bakeng sa difonto tša Mohuta wa 1"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Ge eba go swanetše go khutsofatšwe difonto tša Mohuta o Bulegilego"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Ge eba go swanetše go khutsofatšwe difonto tša PCF"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Ge eba go swanetše go khutsofatšwe difonto tša Mohuta wa Therešo"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Ge eba go swanetše go khutsofatšwe difonto tša Mohuta wa 1"
+
+#, fuzzy
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "Lefelo la Taolo ya GNOME"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Diriša fonto e mpsha?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "O se _ke wa diriša fonto"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Sehlogo seo o se kgethilego se šišinya fonto e mpsha. Ponelopele ya fonto "
+#~ "e bontšhitšwe ka mo tlase."
+
+#~ msgid "Themes"
+#~ msgstr "Dihlogo"
+
+#~ msgid "Description"
+#~ msgstr "Tlhaloso"
+
+#~ msgid "Control theme"
+#~ msgstr "Laola sehlogo"
+
+#~ msgid "Window border theme"
+#~ msgstr "Sehlogo sa mollwane wa lefesetere"
+
+#~ msgid "Icon theme"
+#~ msgstr "Sehlogo sa leswao"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#, fuzzy
+#~ msgid "Apply theme"
+#~ msgstr "_Diriša fonto"
+
+#, fuzzy
+#~ msgid "Sets the default theme"
+#~ msgstr "Beakanya di_tlhaelelo ka leswa"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr ""
+#~ "Ge eba e beakantšwe gore e be therešo, gona dihlogo tše tsentšhitšwego e "
+#~ "tla khutsofatšwa."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr ""
+#~ "Ge eba e beakantšwe gore e be therešo, gona dihlogo di tla khutsofatšwa."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo "
+#~ "bakeng sa dihlogo tše tsentšhitšwego."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "Beakanya senotlelo go taelo e dirišeditšwego go hlama dikhutsofatšo "
+#~ "bakeng sa dihlogo."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Taelo ya khutsofatšo bakeng sa dihlogo tše tsentšhitšwego"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Taelo ya khutsofatšo bakeng sa dihlogo"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Ge eba khutsofatšo e tsentšhitše dihlogo"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Ge eba go swanetše go khutsofatšwe dihlogo"

--- a/po/nso.po~
+++ b/po/nso.po~
@@ -1,0 +1,3543 @@
+# Northern Sotho translation of gnome-control-center.
+# Copyright (C) 2004 Zuza Software Foundation (Translate.org.za)
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Zuza Software Foundation <info@translate.org.za>, 2004
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center HEAD\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"PO-Revision-Date: 2004-11-27 17:02+0200\n"
+"Last-Translator: Zuza Software Foundation <info@translate.org.za>\n"
+"Language-Team: Northern Sotho <translate-discuss-nso@lists.sourceforge.net>\n"
+"Language: nso\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n>1;\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+#, fuzzy
+msgid "Alert Type"
+msgstr "Oketša Mohuta wa Faele"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+#, fuzzy
+msgid "The type of alert"
+msgstr "Mohuta wa seakgofiši."
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+#, fuzzy
+msgid "Alert Buttons"
+msgstr "Dikonope"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+#, fuzzy
+msgid "Show more _details"
+msgstr "Dintlha tša _Sehlogo"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+#, fuzzy
+msgid "About Me"
+msgstr "_Ka ga"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your personal information"
+msgstr "Tshedimošo ya mohuta wa MIME"
+
+#: ../capplets/about-me/gnome-about-me.c:554
+#, fuzzy
+msgid "Select Image"
+msgstr "_Kgetha"
+
+#: ../capplets/about-me/gnome-about-me.c:556
+#, fuzzy
+msgid "No Image"
+msgstr "Diswantšho"
+
+#: ../capplets/about-me/gnome-about-me.c:706
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:727
+msgid "Unable to open address book"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:739
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:770
+#: ../capplets/about-me/gnome-about-me.c:772
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "_Ka ga"
+
+#: ../capplets/about-me/gnome-about-me-password.c:101
+#: ../capplets/about-me/gnome-about-me-password.c:479
+msgid "Old password is incorrect, please retype it"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:112
+msgid "System error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:113
+msgid "Could not run /usr/bin/passwd"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:114
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:117
+msgid "Unexpected error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:315
+msgid "Password is too short"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:318
+#: ../capplets/about-me/gnome-about-me-password.c:321
+msgid "Password is too simple"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:324
+msgid "Old and new passwords are too similar"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:328
+msgid "Old and new password are the same"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:406
+#, fuzzy
+msgid "Please type the passwords."
+msgstr "_Lentšuphetišo:"
+
+#: ../capplets/about-me/gnome-about-me-password.c:414
+msgid "Please type the password again, it is wrong."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:417
+msgid "Click on Change Password to change the password."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/font/font-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+msgid "    "
+msgstr "    "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+#, fuzzy
+msgid "<b>Email</b>"
+msgstr "<i>Nyenyane</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+#, fuzzy
+msgid "<b>Home</b>"
+msgstr "<b>Lebelo</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+#, fuzzy
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Go Fana ka Fonto</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+#, fuzzy
+msgid "<b>Job</b>"
+msgstr "<b>Thekgo</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+#, fuzzy
+msgid "<b>Telephone</b>"
+msgstr "<b>Dinotlelo tša go Thumaša le go Tima</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+#, fuzzy
+msgid "<b>Web</b>"
+msgstr "<b>Lebelo</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+#, fuzzy
+msgid "<b>Work</b>"
+msgstr "<b>Thekgo</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+#, fuzzy
+msgid "A_ddress:"
+msgstr "_Oketša:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+#, fuzzy
+msgid "Address"
+msgstr "_gateletšwe"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+#, fuzzy
+msgid "C_ity:"
+msgstr "_Setaele:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+#, fuzzy
+msgid "C_ompany:"
+msgstr "Ta_elo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+#, fuzzy
+msgid "Cale_ndar:"
+msgstr "Lego_ro:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+#, fuzzy
+msgid "Change Passwo_rd..."
+msgstr "Fetola peakanyo"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+#, fuzzy
+msgid "Change Password"
+msgstr "Fetola peakanyo"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+#, fuzzy
+msgid "Ci_ty:"
+msgstr "_Setaele:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+#, fuzzy
+msgid "Co_untry:"
+msgstr "Taolo"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+#, fuzzy
+msgid "Contact"
+msgstr "_Dikagare"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+#, fuzzy
+msgid "Cou_ntry:"
+msgstr "Taolo"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+#, fuzzy
+msgid "Hom_e:"
+msgstr "_Leina:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+#, fuzzy
+msgid "Old pa_ssword:"
+msgstr "_Lentšuphetišo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P.O. _box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P._O. box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+#, fuzzy
+msgid "Personal Info"
+msgstr "_Fonto ya kgokagano ya dithapo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "State/Pro_vince:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#, fuzzy
+msgid "User name:"
+msgstr "L_eina la modiriši:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Web _log:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "Wor_k:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid "Work _fax:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Zip/_Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+#, fuzzy
+msgid "_Address:"
+msgstr "_Oketša:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+#, fuzzy
+msgid "_Home page:"
+msgstr "_Leina la sehlogo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+#, fuzzy
+msgid "_Home:"
+msgstr "_Leina:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+#, fuzzy
+msgid "_Manager:"
+msgstr "_Segodiši"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+#, fuzzy
+msgid "_Mobile:"
+msgstr "_Faele"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+#, fuzzy
+msgid "_New password:"
+msgstr "_Lentšuphetišo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+#, fuzzy
+msgid "_Profession:"
+msgstr "Kgatišo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+#, fuzzy
+msgid "_Retype new password:"
+msgstr "_Lentšuphetišo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+#, fuzzy
+msgid "_Title:"
+msgstr "_Setaele:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Work:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Zip/Postal code:"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Applications</b>"
+msgstr "<b>Ditirišo</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Support</b>"
+msgstr "<b>Thekgo</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+"<small><i><b>Ela hloko:</b> Diphetogo tšeo di dirwago peakanyong ye di ka se "
+"šome go fihlela ge o tsena gape nakong e latelago.</i></small>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technology Preferences"
+msgstr "Tše Ratwago tša Thekinolotši tše Thušago"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr "Tswalela gomme o _Tšwe"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr "Thoma dithekinolotši tše tše thušago nako le nako ge o tsena:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr "_Kgontšha dithekinolotši tše thušago"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr "_Segodiši"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr "_Boroto ya dinotlelo e lego Sekirining"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Screenreader"
+msgstr "_Sebadi sa sekirini"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr "Thekgo ya Thekinolotši e Thušago"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr ""
+"Kgontšha thekgo bakeng sa dithekinolotši tše thušago tša GNOME go tseneng"
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Ga go na Thekinolotši e Thušago yeo e lego tshepedišong ya gago.  Ngatana ya "
+"'gok' e swanetše go tsenywa gore go hwetšwe thekgo ya boroto ya dinotlelo ya "
+"sekirining, le ngatana ya 'gnopernicus' e swanetše go tsenywa bakegn sa go "
+"bala ga sekirini le bokgoni bja go godiša."
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+"Ga se thekinolotši ka moka tše thušago tšeo di tsentšhitšwego tshepedišong "
+"ya gago. Ngatana ya 'gok' e swanetše go tsenywa gore go hwetšwe thekgo ya "
+"boroto ya dinotlelo ya sekirining."
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Ga se dithekinolotši ka moka tše thušago tšeo di tsentšhitšwego tshepedišong "
+"ya gago. Ngatana ya 'gnopernicus' e swanetše go tsentšhwa bakeng sa bokgoni "
+"bja go bala sekirini le go godiša."
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr ""
+"Go bile le phošo ya go tsebagatša poledišano ya tše ratwago tša legotlwana: %"
+"s"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr ""
+"Ga e kgone go amogela dipeakanyo tša go Tsena tša X go tšwa faeleng ya '%s'"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
+msgid "Import Feature Settings File"
+msgstr "Amogela Faele ya Dipeakanyo tša Sebopego"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
+msgid "_Import"
+msgstr "_Amogela"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Boroto ya dinotlelo"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr "Beakanya tše di ratwago tša go tsenega ga boroto ya dinotlelo"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+"Tshepedišo ye ga e bonagale e na le koketšo ya XKB.  Dibopego tša go tsenega "
+"ga boroto ya dinotlelo di ka se šome ka ntle le yona."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+#: ../capplets/theme-switcher/theme-install.glade.h:1
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "<b>Kgontšha Dino_tlelo tša go Tlola</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "<b>Kgontšha Dino_tlelo tše Nanyago</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "<b>Kgontšha _Dinotlelo tša Legotlwana</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "<b>Kgontšha _Dinotlelo tša go Bušeletša</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "<b>Kgontšha _Dinotlelo tše Kgomarelago</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+msgid "<b>Features</b>"
+msgstr "<b>Dibopego</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr "<b>Dinotlelo tša go Thumaša le go Tima</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "Motheo"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr "Dira modumo ge senotlelo se ga_nwa"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr ""
+"Dira modumo _ge dibopego di thumašwa goba di tingwa borotong ya dinotlelo"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr "Dira modumo _ge sempshafatši se gateletšwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr "Dira modumo ge LED e thumašitšwe le medumo e mebedi ge e timilwe."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr "Dira modumo ge senotlelo se:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr "Die_giša:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr ""
+"Diegiša magareng ga go gatelelwa ga senotlelo le go šu_tha ga selaetši:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr "Pale_diša ge dinotlelo tše pedi di gateletšwe mmogo"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr "K_gontšha Dinotlelo tša go Thumaša le go Tima"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Dikgethi"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr "H_lokomologa go gatelelwa ga senotlelo mo go lego gabedi ka gare ga:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+"Hlokomologa go gatelela ka moka mo go hlatlamanago ga senotlelo se SWANAGO "
+"ge eba go direga nakong e kgethilwego ya modiriši."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr "Tše Ratwago tša go Tsenega ga Boroto ya Dinotlelo (Go Tsena ga X)"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr "Le_belo le legolo la selaetši:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr "Dinotlelo tša Legotlwana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr "Tše Ratwago _tša Legotlwana..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+"Amogela dinotlelo feela ka morago ga ge di gateletšwe le go swara tekanyo ya "
+"nako e ka lokišwago ya modiriši."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+"Dira mediro ya go gatelela senotlelo e mentši ya samma-le-tee ka go kgotla "
+"dinotlelo tša mpshafatšo ka tatelano."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "S_peed:"
+msgstr "L_ebelo:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr "Nako ya go akgo_fiša go fihla go lebelo le legolo:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr ""
+"Fetola mosemo wa dinotlelo wa dinomoro gore e ba moseme wa taolo ya "
+"legotlwana."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr "_Palediša ge eba e sa dirišwe bakeng sa:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr "_Kgontšha dibopego tša go tsenega ga boroto ya dinotlelo"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr "_Amogela Peakanyo ya Sebopego..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr "_Amogela feela dinotlelo tše swaretšwego:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Type to test settings:"
+msgstr "_Tlanya go leka dipeakanyo:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr "_amogetšwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr "_gateletšwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr "_gannwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr "ditlhaka/motsotswana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+msgid "milliseconds"
+msgstr "seripa sa metsotswana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr "dikarolwana tše bopago seswantšho/motsotswana"
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:885
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "metsotswana"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+msgid "Change your Desktop Background settings"
+msgstr "Fetola Dipeakanyo tša Bokamorago bja Teseke ya Gago"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+msgid "Desktop Background"
+msgstr "Bokamorago bja Teseke"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "<b>Pampiri ya leboteng ya _Teseke</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+msgid "<b>_Desktop Colors</b>"
+msgstr "<b>_Mebala ya Teseke</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+msgid "Desktop Background Preferences"
+msgstr "Tše Ratwago tša Bokamorago bja Teseke"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr "_Oketša Pampiri ya leboteng"
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+msgid "_Style:"
+msgstr "_Setaele:"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Go bile le phošo ya go bontšha thušo: %s"
+
+#: ../capplets/background/gnome-wp-capplet.c:1042
+#: ../capplets/background/gnome-wp-capplet.c:1060
+msgid "Centered"
+msgstr "E beilwe magareng"
+
+#: ../capplets/background/gnome-wp-capplet.c:1068
+#: ../capplets/background/gnome-wp-capplet.c:1085
+msgid "Fill Screen"
+msgstr "Tlatša Sekirini"
+
+#: ../capplets/background/gnome-wp-capplet.c:1093
+#: ../capplets/background/gnome-wp-capplet.c:1110
+msgid "Scaled"
+msgstr "Lekanyeditšwe"
+
+#: ../capplets/background/gnome-wp-capplet.c:1118
+#: ../capplets/background/gnome-wp-capplet.c:1135
+msgid "Tiled"
+msgstr "E dirilwe thaele"
+
+#: ../capplets/background/gnome-wp-capplet.c:1159
+#: ../capplets/background/gnome-wp-capplet.c:1168
+msgid "Solid Color"
+msgstr "Mmala o Tiilego"
+
+#: ../capplets/background/gnome-wp-capplet.c:1176
+#: ../capplets/background/gnome-wp-capplet.c:1185
+msgid "Horizontal Gradient"
+msgstr "Go Sekama go Rapamego"
+
+#: ../capplets/background/gnome-wp-capplet.c:1193
+#: ../capplets/background/gnome-wp-capplet.c:1202
+msgid "Vertical Gradient"
+msgstr "Go Sekama go Tsepamego"
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1251
+msgid "Add Wallpaper"
+msgstr "Oketša Pampiri ya leboteng"
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr "Ga go na Pampiri ya leboteng"
+
+#: ../capplets/background/gnome-wp-item.c:292
+#: ../capplets/background/gnome-wp-item.c:294
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/common/activate-settings-daemon.c:18
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"Ga e kgone go thoma molaodi wa dipeakanyo 'daemon ya dipeakanyo tša gnome'.\n"
+"Ka ntle le go šoma ga molaodi wa dipeakanyo tša GNOME, tše dingwe tše "
+"ratwago di ka no se šome. Se se ka laetša bothata le Bonobo, goba molaodi wa "
+"dipeakanyo yo e sego wa GNOME (ka mohlala, KDE) a ka ba a šetše a šoma e "
+"bile a lwantšhana le molaodi wa peakanyo wa GNOME."
+
+#: ../capplets/common/capplet-stock-icons.c:94
+#, c-format
+msgid "Unable to load capplet stock icon '%s'\n"
+msgstr "Ga e kgone go laiša leswao la setoko la khapolete ya '%s'\n"
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr "Diriša feela dipeakanyo gomme o tlogele"
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/default-applications/gnome-default-applications-properties.c:765
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1021
+#: ../capplets/sound/sound-properties-capplet.c:244
+msgid "Retrieve and store legacy settings"
+msgstr "Buša morago gomme go boloka dipeakanyo tše molaong"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %i of %i"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr "Go tšwa go URI"
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr "URI gona bjale e fetišetša go tšwa go"
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr "Go ya go URI"
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr "URI yeo gona bjale e fetišetšago go"
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr "Seabelo se feditšwego"
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr "Seabelo sa phetišetšo yeo gona bjale e feditšwego"
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr "Tlhatlamano ya gona bjale ya URI"
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr "Tlhatlamano ya gona bjale ya URI - e thoma go 1"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr "Palomoka ya di-URI"
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr "Palo moka ya di-URI"
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:345
+#, fuzzy
+msgid "From:"
+msgstr "Go tšwa go: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:349
+#, fuzzy
+msgid "To:"
+msgstr "Go ya go: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr "Go kgokaganya..."
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Senotlelo"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr "Senotlelo sa GConf seo morulaganyi wa thoto a kgokagantšwego"
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr "Letša gape"
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Ntšha go letša gape ge boleng bjo tswalanego le senotlelo bo fetolwa"
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr "Fetola peakanyo"
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"GConf e fetola peakanyo yeo e nago le tsebišo yeo e swanetšego go fetišetšwa "
+"go modirelwa wa gconf tirišong"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr "Go fetolwa ga go letša gape ga sedirišwa"
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+"Go letša gape mo go swanetšego go ntšhwa ge tsebišo e fetoletšwe go tloga go "
+"GConf go ya go sedirišwa"
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr "Go fetolelwa go tšwa go go letša gape ga sedirišwa"
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"Go letša gape mo go swanetšego go ntšhwa ge tsebišo e swanetše go fetolelwa "
+"go GConf go tšwa go sedirišwa"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr "Taolo ya UI"
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr "Sedirišwa seo se laolago thoto (ka mo go tlwaelegilego sedirišwa)"
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr "Tsebišo ya sedirišwa ya morulaganyi wa thoto"
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr "Tsebišo ya tlwaelo e nyakwago ke morulaganyi yo a itšego wa thoto"
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr "Tsebišo ya morulaganyi wa thoto yeo e lokollago go letša gape"
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Go letša gape mo go swanetšego go ntšhwa ge tsebišo ya sedirišwa sa "
+"morulaganyi wa thoto e swanetše go lokollwa"
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Ga e kgone go hwetša faele '%s'.\n"
+"\n"
+"Hle kgonthišetša gore e gona gomme o leke gape, goba o kgethe seswantšho se "
+"bonagalago ka morago se fapanego."
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Ga ke tsebe kamoo nka bulago faele ya '%s'.\n"
+"Mohlomongwe ke mohuta wa seswantšho seo sešogo sa thekgwa.\n"
+"\n"
+"Hle kgetha seswantšho se fapanego legatong la se."
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr "Hle kgetha seswantšho."
+
+#: ../capplets/common/gconf-property-editor.c:1598
+msgid "_Select"
+msgstr "_Kgetha"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr "Ditirišo tše Ratwago"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Kgetha ditirišo tša gago tša tlhaelelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+#, fuzzy
+msgid "Debian Sensible Browser"
+msgstr "Sefetleki sa Wepe sa Tlhaelelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
+msgid "Epiphany"
+msgstr "Epiphany"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
+msgid "Encompass"
+msgstr "Fihlelela"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+#, fuzzy
+msgid "Firebird"
+msgstr "Firebird/FireFox"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
+#, fuzzy
+msgid "Mozilla"
+msgstr "Poso ya Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
+msgid "Netscape Communicator"
+msgstr "Seboledi sa Netscape"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
+msgid "W3M Text Browser"
+msgstr "Sefetleki sa Sengwalwa sa W3M"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
+msgid "Lynx Text Browser"
+msgstr "Sefetleki sa Sengwalwa sa Lynx"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
+msgid "Links Text Browser"
+msgstr "E Kgokaganya Sefetleki sa Sengwalwa"
+
+#. The code in gnome-default-applications-properties.c makes sure
+#. * there is only one (the first entry in this list) Evolution entry
+#. * in the list shown to the user
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
+msgid "Evolution Mail Reader"
+msgstr "Sebadi sa Poso sa Phutollo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
+msgid "KMail"
+msgstr "Poso ya K"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
+msgid "Mozilla Mail"
+msgstr "Poso ya Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
+#, fuzzy
+msgid "Debian Terminal Emulator"
+msgstr "Kgokagano ya Dithapo ya Tlhaelelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
+#, fuzzy
+msgid "GNOME Terminal"
+msgstr "Kgokagano ya dithapo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
+msgid "Standard XTerminal"
+msgstr "Kgokagano ya Dithapo ya X ya Motheo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.c:123
+msgid "Please specify a name and a command for this editor."
+msgstr "Hle laetša leina le taelo ya morulaganyi yo."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "Add..."
+msgstr "Oketša..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "C_ustom"
+msgstr "_Tlwaelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "C_ustom:"
+msgstr "_Tlwaelo:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "Can open _URIs"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+#, fuzzy
+msgid "Can open multiple _files"
+msgstr "Tirišo ye e ka bula difaele _tše dintši"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "Co_mmand:"
+msgstr "Ta_elo:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "Custom Editor Properties"
+msgstr "Dipharologantšho tša Morulaganyi wa Tlwaelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "Default Mail Reader"
+msgstr "Mmadi wa Poso wa Tlhaelelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "Default Terminal"
+msgstr "Kgokagano ya Dithapo ya Tlhaelelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Default Text Editor"
+msgstr "Morulaganyi wa Sengwalwa wa Tlhaelelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "Default Web Browser"
+msgstr "Sefetleki sa Wepe sa Tlhaelelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Default Window Manager"
+msgstr "Molaodi wa Lefesetere wa Tlhaelelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Delete"
+msgstr "Phumola"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "E_xec Flag:"
+msgstr "P_hethagatša Folaga:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Edit..."
+msgstr "Lokiša..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Mail Reader"
+msgstr "Sebadi sa Poso"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+#, fuzzy
+msgid "Run in a _terminal"
+msgstr "Diriša ka _Kgokagano ya Dithapo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+#, fuzzy
+msgid "Run in a t_erminal"
+msgstr "Diriša ka _Kgokagano ya Dithapo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid ""
+"Select the window manager you want.  You will need to hit apply, wave the "
+"magic wand, and do a magic dance for it to work."
+msgstr ""
+"Kgetha molaodi wa lefesetere yo o mo nyakago.  Go tla nyakega gore o kgotle "
+"diriša, o phagamiše seatla, gomme o bine motantsho wa mohlolo gore e šome."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Terminal"
+msgstr "Kgokagano ya dithapo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Text Editor"
+msgstr "Morulaganyi wa Sengwalwa"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Understands _Netscape Remote Control"
+msgstr "E Kwešiša _Taolo ya Kgole ya Netscape"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "Use this _editor to open text files in the file manager"
+msgstr "Diriša morulaganyi _yo go bula difaele tša sengwala molaoding wa faele"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "Web Browser"
+msgstr "Sefetleki sa Wepe"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
+msgid "Window Manager"
+msgstr "Molaodi wa Lefesetere"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
+msgid "_Command:"
+msgstr "Ta_elo:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
+msgid "_Name:"
+msgstr "_Leina:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
+msgid "_Properties..."
+msgstr "_Dipharologantšho..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
+msgid "_Select:"
+msgstr "_Kgetha:"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Fetola setlamo sa sekirini"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Setlamo sa Sekirini"
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/main.c:448
+msgid "_Resolution:"
+msgstr "_Setlamo:"
+
+#: ../capplets/display/main.c:467
+msgid "Re_fresh rate:"
+msgstr "Di_ra tekanyo gape:"
+
+#: ../capplets/display/main.c:488
+msgid "Default Settings"
+msgstr "Dipeakanyo tša Tlhaelelo"
+
+#: ../capplets/display/main.c:490
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr "Dipeakanyo tša Sekirini sa %d\n"
+
+#: ../capplets/display/main.c:516
+msgid "Screen Resolution Preferences"
+msgstr "Tše Ratwago tša Setlamo sa Sekirini"
+
+#: ../capplets/display/main.c:553
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "_Dira tlhaelelo bakeng sa khomphuthara ye ya (%s) feela"
+
+#: ../capplets/display/main.c:571
+msgid "Options"
+msgstr "Dikgetho"
+
+#: ../capplets/display/main.c:592
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"Go leka dipeakanyo tše mpsha. Ge o sa arabele ka metsotswana e %d go tla "
+"bolokwa peakanyo ya nakong e fetilego."
+msgstr[1] ""
+"Go leka dipeakanyo tše mpsha. Ge eba o sa arabele ka metsotswana e %d go tla "
+"bolokwa peakanyo ya nakong e fetilego."
+
+#: ../capplets/display/main.c:638
+msgid "Keep Resolution"
+msgstr "Boloka Setlamo"
+
+#: ../capplets/display/main.c:642
+msgid "Do you want to keep this resolution?"
+msgstr "Na o nyaka go boloka setlamo se?"
+
+#: ../capplets/display/main.c:667
+msgid "Use _previous resolution"
+msgstr "Diriša _setlamo sa nakong e fetilego"
+
+#: ../capplets/display/main.c:667
+msgid "_Keep resolution"
+msgstr "_Boloka setlamo"
+
+#: ../capplets/display/main.c:818
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"Seabi sa X ga se thekge koketšo ya XRandR.  Setlamo sa nako ya go šoma se "
+"fetogelago go bogolo bja go bontšha ga di gona."
+
+#: ../capplets/display/main.c:826
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"Kgatišo ya koketšo ya XRandR yeo e sa kwanego le lenaneo le. Diphetogo tša "
+"go šoma go bogolo bja go bontšha ga di gona."
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Fonto"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr "Kgetha difonto tša teseke"
+
+#: ../capplets/font/font-properties.glade.h:2
+msgid "<b>Font Rendering</b>"
+msgstr "<b>Go Fana ka Fonto</b>"
+
+#: ../capplets/font/font-properties.glade.h:3
+msgid "<b>Hinting</b>:"
+msgstr "<b>Go Eletša</b>:"
+
+#: ../capplets/font/font-properties.glade.h:4
+msgid "<b>Smoothing</b>:"
+msgstr "<b>Go Dira Boreledi</b>:"
+
+#: ../capplets/font/font-properties.glade.h:5
+msgid "<b>Subpixel order</b>:"
+msgstr "<b>Tatelano ya dika-dikarolwana tše bopago seswantšho</b>:"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best _shapes"
+msgstr "Dibopego _tše di phalago ka moka"
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "Best co_ntrast"
+msgstr "Go fapana go e ph_alago ka moka"
+
+#: ../capplets/font/font-properties.glade.h:8
+msgid "D_etails..."
+msgstr "D_intlha..."
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "Tše Ratwago tša Fonto"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr "Dintlha tša go Fana ka Fonto"
+
+#: ../capplets/font/font-properties.glade.h:11
+msgid "Go _to font folder"
+msgstr "Eya _sephutheding sa fonto"
+
+#: ../capplets/font/font-properties.glade.h:12
+msgid "Gra_yscale"
+msgstr "Teka_nyo e tshetla"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "G_a e gona"
+
+#: ../capplets/font/font-properties.glade.h:14
+msgid "R_esolution:"
+msgstr "S_etlamo:"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr "Dikarolwana_tše nyenyane tše bopago diswantšho (di-LCD)"
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr ""
+"Go dira gore dikarolwana_tše nyenyane tše bopago seswantšho di be boreledi "
+"(di-LCD)"
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "_Fonto ya tirišo:"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Desktop font:"
+msgstr "_Fonto ya teseke:"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Full"
+msgstr "_Tletšego"
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Medium"
+msgstr "_Magareng"
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Monochrome"
+msgstr "_Mmala o tee wa boso le bošweu"
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_None"
+msgstr "_Ga e gona"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_Slight"
+msgstr "_Ganyenyane"
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Terminal font:"
+msgstr "_Fonto ya kgokagano ya dithapo:"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "_Fonto ya sehlogo sa lefesetere:"
+
+#: ../capplets/font/font-properties.glade.h:30
+msgid "dots per inch"
+msgstr "dintlha go ya ka noko"
+
+#: ../capplets/font/main.c:488
+msgid "Font may be too large"
+msgstr "Fonto e ka ba e le e kgolo kudu"
+
+#: ../capplets/font/main.c:492
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Fonto e kgethilwego e bogolo bja ntlha bja %d , e bile e ka dira gore go be "
+"thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe "
+"bogolo bjo bo lego bjo bonyenyane go %d."
+msgstr[1] ""
+"Fonto e kgethilwego e bogolo bja dintlha bja %d , e bile e ka dira gore go "
+"be thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe "
+"bogolo bjo bo lego bjo bonyenyane go %d."
+
+#: ../capplets/font/main.c:505
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Fonto e kgethilwego e bogolo bja ntlha bja %d, e bile e ka dira gore go be "
+"thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe fonto "
+"ya bogolo bjo bonyenyane."
+msgstr[1] ""
+"Fonto e kgethilwego e bogolo bja dintlha bja %d, e bile e ka dira gore go be "
+"thata go diriša khomphuthara ka mo go šomago. Go eletšwa gore o kgethe fonto "
+"ya bogolo bjo bonyenyane."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "Seakgofiši se seswa..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Senotlelo sa seakgofiši"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Dimpshafatši tša seakgofiši"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Khoutu ya senotlelo ya seakgofiši"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Mokgwa wa Seakgofiši"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Mohuta wa seakgofiši."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:197
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+msgid "Disabled"
+msgstr "Paledišitšwe"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:545
+msgid "<Unknown Action>"
+msgstr "<Mogato o sa Tsebjwego>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:566
+msgid "Desktop"
+msgstr "Teseke"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:567
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Modumo"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:571
+msgid "Window Management"
+msgstr "Taolo ya Lefesetere"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:668
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+"Kgaoletšo ya \"%s\" e šetše e dirišeditšwe:\n"
+" \"%s\"\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:700
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr ""
+"Phošo ya go beakanya seakgofiši se seswa datapeising ya go fetola sebopego: %"
+"s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:750
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr ""
+"Phošo ya go beakanyolla seakgofiši datapeising ya go fetola sebopego: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:857
+msgid "Action"
+msgstr "Mogato"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:881
+msgid "Shortcut"
+msgstr "Kgaoletšo"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Dikgaoletšo tša Boroto ya Dinotlelo"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"Go lokiša senotlelo sa kgaoletšo, kgotla mothalong o sepelelanago gomme o "
+"tlanye seakgofiši se seswa, goba o gatelele backspace gore o phumole."
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Abela dinotlelo tša kgaoletšo go ditaelo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+msgid "Unknown"
+msgstr "Tše sa Tsebjwego"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+msgid "Layout"
+msgstr "Bea"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#, fuzzy
+msgid "Default"
+msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+msgid "Models"
+msgstr "Mehlala"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:106
+#, c-format
+msgid "There was an error launching the keyboard capplet : %s"
+msgstr ""
+"Go bile le phošo ya go tsebagatša khapolete ya boroto ya dinotlelo : %s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr "_Go tsenega"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:240
+#: ../capplets/sound/sound-properties-capplet.c:242
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+"Diriša feela dipeakanyo gomme o tlogele (go sepelelana feela; mo gona bjale "
+"go swarwago ke daemon)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr "Thoma letlakala dipeakanyo tša go khutša ga go tlanya di bonagala"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "..."
+msgstr "..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Go Ponya ga Leswao le Bontšhago mo o lego</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Dinotlelo tša go Bušeletša</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<b>_Notlela sekirini go gapeletša go khutša ga go tlanya</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Lebelo</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Telele</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Kopana</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Nanyago</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_vailable layouts:"
+msgstr "G_o bea mo go lego gona:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "All_ow postponing of breaks"
+msgstr "Dume_elela go šuthišwa ga go khutša"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Lekola ge eba go khutša go dumeletšwe gore go šuthišwe"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+#, fuzzy
+msgid "Choose A Keyboard Model"
+msgstr "Kgetha mohlala wa boroto ya dinotlelo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+#, fuzzy
+msgid "Choose A Layout"
+msgstr "Tswalela gomme o _Tšwe"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr ""
+"Leswao le bontšhago mo o lego _le ponya-ponya mapokising a sengwalwa le "
+"mapatlelong"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Duration of the break when typing is disallowed"
+msgstr "Botelele bja go khutša ge o tlanya ga bo a dumelelwa"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of work before forcing a break"
+msgstr "Botelele bja mošomo pele ga go gapeletša go khutša"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Key presses _repeat when key is held down"
+msgstr "Senotlelo se gatelela _bušeletša ge senotlelo se gateletšwe fase"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Keyboard Preferences"
+msgstr "Tše Ratwago tša Boroto ya Dinotlelo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Keyboard _model:"
+msgstr "Mohlala wa _boroto ya dinotlelo:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Layout Options"
+msgstr "Dikgetho tša go Bea"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Layouts"
+msgstr "Go bea"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Notlela sekirini ka morago ga botelele bjo itšego go thibela dikgobalo tša "
+"go diriša boroto ya dinotlelo ka mo go bušeleditšwego"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Microsoft Natural Keyboard"
+msgstr "Boroto ya Dinotlelo ya Tlhago ya Microsoft"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+#, fuzzy
+msgid "Preview:"
+msgstr "_Ponelopele"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+#, fuzzy
+msgid "Reset To De_faults"
+msgstr "Beakanya di_tlhaelelo ka leswa"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Separate _group for each window"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Typing Break"
+msgstr "Go Khutša ga go Tlanya"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "_Accessibility..."
+msgstr "_Go tsenega..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#, fuzzy
+msgid "_Add..."
+msgstr "Oketša..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Break interval lasts:"
+msgstr "_Sekgoba sa go khutša se tšea:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Delay:"
+msgstr "_Diegiša:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#, fuzzy
+msgid "_Models:"
+msgstr "_Mehlala"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Selected layouts:"
+msgstr "_Go bea mo go kgethilwego:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Speed:"
+msgstr "_Lebelo:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Work interval lasts:"
+msgstr "_Sekgoba sa go šoma se tšea:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "minutes"
+msgstr "metsotso"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Beakanya tše ratwago tša gago tša boroto ya dinotlelo"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:559
+msgid "Unknown Cursor"
+msgstr "Leswao le Bontšhago mo o lego le sa Tsebjwego"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+msgid "Default Cursor"
+msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Cursor - Current"
+msgstr "Leswao le Bontšhago mo o lego la Tlhaelelo - Gona bjale"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+msgid "The default cursor that ships with X"
+msgstr "Leswao le bontšhago mo o lego la tlhaelelo le le sesago le X"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+msgid "White Cursor"
+msgstr "Leswao le Bontšhago mo o lego le Lešweu"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Cursor - Current"
+msgstr "Leswao le Bontšhago mo o lego le Lešweu - Gona bjale"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+msgid "The default cursor inverted"
+msgstr "Leswao le bontšhago mo o lego la tlhaelelo le hlanotšwego"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+msgid "Large Cursor"
+msgstr "Leswao le Bontšhago mo o lego le Legolo"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Cursor - Current"
+msgstr "Leswao le Bontšhago mo o lego le Legolo - Gona bjale"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+msgid "Large version of normal cursor"
+msgstr "Kgatišo e kgolo ya leswao le bontšhago mo o lego le tlwaelegilego"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+msgid "Large White Cursor - Current"
+msgstr "Leswao le Bontšhago mo o lego le Legolo le Lešweu - Gona bjale"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Cursor"
+msgstr "Leswao le Bontšhago mo o lego le Legolo le Lešweu"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+msgid "Large version of white cursor"
+msgstr "Kgatišo e kgolo ya leswao le bontšhago mo o lego le lešweu"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:975
+msgid "Cursor Theme"
+msgstr "Sehlogo sa Leswao le Bontšhago mo o lego"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr "<b>Kgotla go Fela ga Nako Gabedi </b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Goga o Lahlele</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Hwetša Selaetši</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>Thulaganyo ya Legotlwana </b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Speed</b>"
+msgstr "<b>Lebelo</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>Lebelo</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>Godimo</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>Kgolo</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>Tlase</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>Nanya</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>Nyenyane</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Dikonope"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#, fuzzy
+msgid "Cursor Size:"
+msgstr "Bogolo bja Leswao le Bontšhago mo o lego"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Cursors"
+msgstr "Maswao a Bontšhago mo o lego"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr "Bonagatša selaetši _ge o gatelela Ctrl"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+#, fuzzy
+msgid "Large"
+msgstr "_Kgolo"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+#, fuzzy
+msgid "Medium"
+msgstr "_Magareng"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Motion"
+msgstr "Tšhišinyo"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Mouse Preferences"
+msgstr "Tše Ratwago tša Legotlwana"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#, fuzzy
+msgid "Small"
+msgstr "_Nyenyane"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr "_Go Akgofiša:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr "_Legotlwana la seatla sa lanngele"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr "_Go nyaka go swarwa ka bohlale:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr "_Mojako:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr "_Nako e fedile:"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Legotlwana"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Beakanya tše ratwago tša legotlwana"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Kemedi ya Neteweke"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your network proxy preferences"
+msgstr "Tše ratwago tša kemedi ya neteweke"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+#, fuzzy
+msgid "<b>D_irect internet connection</b>"
+msgstr "<b>_Kgokagano ya inthanete e lebanyago</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>_Go fetola sebopego ga kemedi mo go itiragalelago</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>_Go fetola sebopego ga kemedi ya maitirelo</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Diriša tiišetšo</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+#, fuzzy
+msgid "Advanced Configuration"
+msgstr "Go fetola sebopego mo go itiragalelago ga _STS:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr "Go fetola sebopego mo go itiragalelago ga _STS:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "Dintlha tša Kemedi tša PFSK"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "K_emedi ya PFSK:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+#, fuzzy
+msgid "Network Proxy Preferences"
+msgstr "Tše ratwago tša kemedi ya neteweke"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Lefelo:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+#, fuzzy
+msgid "Proxy Configuration"
+msgstr "Go Fetola Sebopego ga Kemedi ya Neteweke"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr "M_oswari wa disokisi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "U_sername:"
+msgstr "L_eina la modiriši:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_Dintlha"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr "_Kemedi ya PFF:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "_Lentšuphetišo:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr "Š_ireletša kemedi ya PFSK:"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Kgontšha modumo e bile o tswalanye medimo le ditiragalo"
+
+#: ../capplets/sound/sound-properties-capplet.c:271
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Sound Preferences"
+msgstr "Tše Ratwago tša Modumo"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "E_nable sound server startup"
+msgstr "K_gontšha go thoma ga seabi sa modumo"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "Flash _entire screen"
+msgstr "Phadimiša _sekirini ka moka"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "Flash _window titlebar"
+msgstr "Phadimiša _bara ya sehlogo ya lefesetere"
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "General"
+msgstr "Kakaretšo"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "Sound Events"
+msgstr "Ditiragalo tša Modumo"
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "System Bell"
+msgstr "Tšhipi ya Tshepedišo"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "_Sound an audible bell"
+msgstr "_Letša tšhipi e dumago"
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "_Sounds for events"
+msgstr "_Medumo ya ditiragalo"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "_Visual feedback:"
+msgstr "_Karabelo ya pono:"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:347
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+"Ga go na dihlogo tšeo di hweditšwego tshepedišong ya gago.  Se mohlomongwe "
+"se ra gore poledišano ya gago ya \"Tše Ratwago tša Sehlogo\" ga se tša "
+"tsenywa ka tshwanelo, goba ga se wa tsenya ngatana ya \"dihlogo tša gnome\"."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:227
+msgid "This theme is not in a supported format."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:244
+msgid "Failed to create temporary directory"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:264
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:282
+#: ../capplets/theme-switcher/gnome-theme-installer.c:319
+#: ../capplets/theme-switcher/gnome-theme-installer.c:399
+#, fuzzy
+msgid "Installation Failed"
+msgstr "Go Tsenywa ga Sehlogo"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:302
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:340
+#, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:343
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:346
+#, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:349
+#, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:357
+msgid "The theme is an engine. You need to compile the theme."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:374
+#, fuzzy
+msgid "The file format is invalid"
+msgstr "Faele ya %s ga se faele ya kgonthe ya wav"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:468
+msgid "No theme file location specified to install"
+msgstr "Ga go na lefelo la faele ya sehlogo le laeditšwego go tsenywa"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:485
+msgid "The theme file location specified to install is invalid"
+msgstr "Lefelo la faele la sehlogo le laetšwego go tsenywa ga se la kgonthe"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:505
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:526
+#, fuzzy
+msgid "The file format is invalid."
+msgstr "Faele ya %s ga se faele ya kgonthe ya wav"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:553
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+"%s ke tsejana yeo go yona difaele tša sehlogo di tla tsenywago. Se se ka se "
+"kgethwe bjalo ka lefelo la mothopo"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:607
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "Custom theme"
+msgstr "Sehlogo sa tlwaelo"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr "O ka boloka sehlogo se ka go kgotla konope ya Boloka Sehlogo."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+"Sekema sa sehlogo sa tlhaelelo ga se sa hwetšwa tshepedišong ya gago. Se se "
+"bolela gore mohlomongwe o tsentšitše metacity, goba gore gconf ya gago e "
+"fetotšwe sebopego ka mo go fošagetšego."
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:72
+msgid "Theme name must be present"
+msgstr "Leina la sehlogo le swanetše go ba gona"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:104
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Sehlogo se šetše se le gona. Na o nyaka se tšeelwe legato?"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr "Kgetha dihlogo bakeng sa dikarolo tše fapa-fapanego tša teseke"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "Sehlogo"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Tsenya sehlogo</span>"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:3
+msgid "Theme Installation"
+msgstr "Go Tsenywa ga Sehlogo"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:4
+msgid "_Install"
+msgstr "_Tsenya"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:5
+msgid "_Location:"
+msgstr "_Lefelo:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Boloka Sehlogo Tisiking</span>"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Apply _Background"
+msgstr "Diriša _Bokamorago"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Apply _Font"
+msgstr "Diriša _Fonto"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Controls"
+msgstr "Ditaolo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "Icons"
+msgstr "Maswao"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "New themes can also be installed by dragging them into the window."
+msgstr "Dihlogo tše diswa di ka tsenywa gape ka go di gogela lefesetereng."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+msgid "Save Theme"
+msgstr "Boloka Sehlogo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+msgid "Select theme for the desktop"
+msgstr "Kgetha sehlogo sa teseke"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+msgid "Short _description:"
+msgstr "Tlhaloso e _kopana:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "Theme Details"
+msgstr "Dintlha tša Sehlogo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "Theme Preferences"
+msgstr "Tše Ratwago tša Sehlogo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+msgid "Theme _Details"
+msgstr "Dintlha tša _Sehlogo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+msgid "This theme does not suggest any particular font or background."
+msgstr "Sehlogo se ga se šišinye fonto e itšego le ge ele efe goba bokamorago."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+msgid "This theme suggests a background:"
+msgstr "Sehlogo se se šišinya bokamorago:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+msgid "This theme suggests a font and a background:"
+msgstr "Sehlogo se se šišinya fonto le bokamorago:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+msgid "This theme suggests a font:"
+msgstr "Sehlogo se se šišinya fonto:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "Window Border"
+msgstr "Mollwane wa Lefesetere"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+msgid "_Go To Theme Folder"
+msgstr "_Eya Sephutheding sa Sehlogo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+msgid "_Install Theme..."
+msgstr "_Tsenya Sehlogo..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+msgid "_Revert"
+msgstr "_Boela"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+msgid "_Save Theme..."
+msgstr "_Boloka Sehlogo..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+msgid "_Theme name:"
+msgstr "_Leina la sehlogo:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:24
+msgid "theme selection tree"
+msgstr "mohlare wa kgetho ya sehlogo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr ""
+"Tlwaelanya ponagalo ya bara ya didirišwa le bara ya lelokelelo la dikagare "
+"ditirišong"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "Malokelelo a Dikagare & Bara ya Didirišwa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr "<b>Boitshwaro le Ponagalo</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+msgid "<b>Preview</b>"
+msgstr "<b>Ponelopele</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "R_ipa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+msgid "Icons only"
+msgstr "Maswao feela"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "Lelokelelo la dikagare le Tše Ratwago tša Bara ya Sedirišwa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "Faele e Mpsha"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Bula Faele"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Boloka Faele"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr "Bontšha _maswao malokelelong a dikagare"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+msgid "Text below icons"
+msgstr "Sengwalwa ka tlase ga maswao"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+msgid "Text beside icons"
+msgstr "Sengwalwa se bapelanego le maswao"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+msgid "Text only"
+msgstr "Sengwalwa feela"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+#, fuzzy
+msgid "Toolbar _button labels:"
+msgstr "Maswao _a konope ya bara ya sedirišwa: "
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_Kopiša"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr "_Dibara tša sedirišwa tšeo di ka kgokaganyollwago"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_Lokiša"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "_Faele"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_Mpsha"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "_Bula"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "_Kgomaretša"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "_Gatiša"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "_Tlogela"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "_Boloka"
+
+#: ../capplets/windows/gnome-window-properties.c:386
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+"<b>E ka se thome tirišo ya tše ratwago bakeng sa molaodi wa gago wa "
+"lefesetere</b>\n"
+"\n"
+"%s"
+
+#: ../capplets/windows/gnome-window-properties.c:644
+msgid "Control"
+msgstr "Taolo"
+
+#: ../capplets/windows/gnome-window-properties.c:649
+msgid "Alt"
+msgstr "Tšh"
+
+#: ../capplets/windows/gnome-window-properties.c:655
+msgid "Hyper"
+msgstr "Kgahlišago"
+
+#: ../capplets/windows/gnome-window-properties.c:662
+msgid "Super (or \"Windows logo\")"
+msgstr "Godimo (goba \"Leswao la Windows\")"
+
+#: ../capplets/windows/gnome-window-properties.c:669
+msgid "Meta"
+msgstr "Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Senotlelo sa go šutha</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>Mogato wa Bara ya Sehlogo</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Kgetho ya Lefesetere</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To _move a window, press-and-hold this key then grab the window:"
+msgstr ""
+"Go šu_thiša lefesetere, gatelela o sware senotlelo se ke moka o sware "
+"lefesetere:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Tše Ratwago tša Lefesetere"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_Kgotla bara ya sehlogo gabedi go tšea mogato wo:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "_Sebaka pele ga go godiša:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_Godiša mafesetere a kgethilwego ka morago ga sebakal"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Kgetha mafesetere ge legotlwana le sepela ka godimo ga wona"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+#, fuzzy
+msgid "Set your window properties"
+msgstr "Dipharologantšho tša Lefesetere"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Mafesetere"
+
+#: ../control-center/control-center-categories.c:257
+msgid "Others"
+msgstr "Tše dingwe"
+
+#: ../control-center/control-center.c:42
+#, fuzzy
+msgid "Desktop Preferences"
+msgstr "Tše Ratwago tša Bokamorago bja Teseke"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr "Lefelo la Taolo ya GNOME"
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "Sedirišwa sa go fetola sebopego sa GNOME"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "Bolumo"
+
+#: ../gnome-settings-daemon/factory.c:36
+msgid "Could not initialize Bonobo"
+msgstr "E ka se kgone go thomološa Bonobo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
+msgid "Slow Keys Alert"
+msgstr "Temošo ya Dinotlelo tše Nanyago"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+"O sa tšwa go gatelela senotlelo sa Shift metsotswana e 8.  Ye ke kgaoletšo "
+"ya sebopego sa Dinotlelo tše Nanyago, yeo e amago tsela yeo boroto ya gago "
+"ya dinotlelo e šomago ka yona."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
+msgid "Do you want to activate Slow Keys?"
+msgstr "Na o nyaka go diragatša Dinotlelo tše Nanyago?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
+msgid "Do you want to deactivate Slow Keys?"
+msgstr "Na o nyaka go diragatšolla Dinotlelo tše Nanyago?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Sticky Keys Alert"
+msgstr "Temošo ya Dinotlelo tše Kgomarelago"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+"O sa tšwa go kgotla senotlelo sa Shift makga a 5 ka tatelano.  Ye ke "
+"kgaoletšo ya sebopego sa Dinotlelo tše Kgomarelago, yeo e amago tsela yeo ka "
+"yona boroto ya gago ya dinotlelo e šomago ka yona."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+"O sa tšwa go gatelela dinotlelo tše pedi ka nako e tee, goba o gateletše "
+"senotlelo sa Shift makga a 5 ka tatelano.  Se se tima sebopego sa Dinotlelo "
+"tše Kgomarelago, seo se amago tsela yeo ka yona boroto ya gago ya dinotlelo "
+"e šomago ka yona."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
+msgid "Do you want to activate Sticky Keys?"
+msgstr "Na o nyaka go diragatša Dinotlelo tše Kgomarelago?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr "Na o nyaka go diragatšolla Dinotlelo tše Kgomarelago?"
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:107
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+"E ka se kgone go hlama tšhupetšo ya \"%s\".\n"
+"Se se a nyakega go dumelela go fetola leswao le bontšhago mo o lego."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr ""
+"Go Kopanya ga Senotlelo ga (%s) go na le mogato o hlaloswago e le makga a "
+"mantši\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr ""
+"Go Kopanya ga Senotlelo ga (%s) go na le go kopanya mo go hlaloswago e le "
+"makga a mantši\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr "Go Kopanya ga Senotlelo ga (%s) ga go a felela\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr "Go Kopanya ga Senotlelo ga (%s) ga se ga kgonthe\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
+#, c-format
+msgid "It seems that another application already has access to key '%d'."
+msgstr ""
+"Go bonagala gore tirišo e nngwe e šetše e kgona go tsena senotlelong sa '%d'."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr "Go Kopanya ga Senotlelo ga (%s) go šetše go dirišwa\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+"Phošo ya ge go lekwa go dirišwa (%s)\n"
+"yeo e kgokagantšwego le senotlelo sa (%s)"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
+#, fuzzy, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+"Phošo ya go diragatša go fetola sebopego ga XKB.\n"
+"Mohlomongwe ke bothata bja ka gare bja seabi sa X.\n"
+"\n"
+"Tsebišo ya kgatišo ya seabi sa X:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"Ge eba o bega boemo bjo bjalo ka twatši, hle akaretša:\n"
+"- Dipoelo tša <b>xprop -root | grep XKB</b>\n"
+"- Dipoelo tša <b>gconftool-2 -R i/desktop/gnome/peripherals/keyboard/xkb</b>"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+#, fuzzy
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+"O diriša XFree 4.3.0.\n"
+"Go na le mathata a tsebjwago ka go fetola sebopego mo go raraganego ga XKB.\n"
+"Leka go diriša go fetola sebopego go bonolo goba go tšea kgatišo e foreshe "
+"ya software ya XFree."
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
+#, fuzzy
+msgid "Do _not show this warning again"
+msgstr "_O seke wa bontšha molaetša wo gape"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
+msgid ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+msgstr ""
+"Dipeakanyo tša boroto ya dinotlelo tša tshepedišo ya X di fapana le "
+"dipeakanyo tša gago tša gona bjale tša boroto ya dinotlelo tša GNOME.  Ke "
+"peakanyo efe yeo o ka ratago go e diriša?"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
+msgid "Use X settings"
+msgstr "Diriša dipeakanyo tša X"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
+msgid "Use GNOME settings"
+msgstr "Diriša dipeakanyo tša GNOME"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+"E ka se kgone go phethagatša taelo: %s\n"
+"Tiišetša gore taelo ye e gona."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+"E ka se kgone go robatša motšhene.\n"
+"Tiišetša gore motšhene o fetotšwe sebopego ka mo go nepagetšego."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
+#, c-format
+msgid "Permissions on the file %s are broken\n"
+msgstr "Ditumelelo tša faele ya %s di senyegile\n"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+"E ka se kgone go laiša faele ya Sekgoba.\n"
+"Kgonthišetša gore daemon ye e tsentšhitšwe ka tshwanelo."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+"Go bile le phošo ya go thoma seboloki sa sekirini:\n"
+"\n"
+"%s\n"
+"\n"
+"Go šoma ga seboloki sa sekirini go ka se šome lenaneong le."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
+msgid "_Do not show this message again"
+msgstr "_O seke wa bontšha molaetša wo gape"
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:129
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr "E ka se kgone go laiša faele ya modumo ya %s bjalo ka mohlala %s"
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
+msgid "Cannot determine user's home directory"
+msgstr "E ka se lemoge tšhupetšo ya gae ya modiriši"
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr ""
+"Senotlelo sa GConf sa %s se beakantšwe go mohuta wa %s eupša mohuta wa sona "
+"o letetšwego e be e le %s\n"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+#, fuzzy
+msgid "A_vailable files:"
+msgstr "G_o bea mo go lego gona:"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+#, fuzzy
+msgid "Do _not show this warning again."
+msgstr "_O seke wa bontšha molaetša wo gape"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+#, fuzzy
+msgid "_Loaded files:"
+msgstr "_Mehlala"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr "Phošo ya go hlama phaephe ya leswao."
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Mohuta"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+"Mohuta wa bg_applier: BG_APPLIER_ROOT bakeng sa lefesete la modu goba "
+"BG_APPLIER_PREVIEW bakeng sa ponelopele"
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr "Bophara bja Ponelopele"
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr "Bophara ge eba sediriši e le ponelopele: Ditlhaelelo go ya go 64."
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr "Bophagamo bja Ponelopele"
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr "Bophagamo ge eba sediriši e le ponelopele: Ditlhaelelo go ya go 48."
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Sekirini"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr "Sekirini seo go sona BGApplier e swanetšego go thala go sona"
+
+#: ../libgswitchit/gswitchit_config.c:1035
+#, fuzzy, c-format
+msgid "There was an error loading an image: %s"
+msgstr "Go bile le phošo ya go bontšha thušo: %s"
+
+#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
+msgid "The sound file for this event does not exist."
+msgstr "Faele ya modumo ya tiragalo ye ga e gona."
+
+#: ../libsounds/sound-view.c:149
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package\n"
+"for a set of default sounds."
+msgstr ""
+"Faele ya modumo ya tiragalo ye ga e gona.\n"
+"O ka nyaka go tsenya sephuthelwana sa gnome-audio\n"
+"bakeng sa peakanyo ya medumo ya tlhaelelo."
+
+#: ../libsounds/sound-view.c:224
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "Faele ya %s ga se faele ya kgonthe ya wav"
+
+#: ../libsounds/sound-view.c:289
+msgid "Event"
+msgstr "Tiragalo"
+
+#: ../libsounds/sound-view.c:298
+msgid "Sound File"
+msgstr "Faele ya Modumo"
+
+#: ../libsounds/sound-view.c:314
+msgid "_Sounds:"
+msgstr "_Medumo:"
+
+#: ../libsounds/sound-view.c:328
+msgid "Sound _file:"
+msgstr "Faele ya _modumo:"
+
+#: ../libsounds/sound-view.c:332
+msgid "Select Sound File"
+msgstr "Kgetha Faele ya Modumo"
+
+#: ../libsounds/sound-view.c:356
+msgid "_Play"
+msgstr "_Bapala"
+
+#: ../libsounds/sound-view.c:366
+msgid "_Remove"
+msgstr "_Tloša"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+"Molaodi wa lefesetere wa \"%s\" ga se a ngwadiša sedirišwa sa go fetola "
+"sebopego\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Godiša"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Phutha"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr ""
+"Ge eba e le therešo, baswari ba mime bakeng sa text/plain (sengwalwa/se se "
+"nago selo) le text/* (sengwalwa) di tla bolokwa di rulagantšwe"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr ""
+"text/plain (sengwalwa/se se nago selo) e rulagantšwego le baswari ba text/* "
+"(sengwalwa)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "Brightness down"
+msgstr "Go taga go tlase"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "Brightness down's shortcut."
+msgstr "Kgaoletšo ya go taga go tlase."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Brightness up"
+msgstr "Go taga go godimo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Brightness up's shortcut."
+msgstr "Kgaoletšo ya go taga go godimo."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "E-mail"
+msgstr "Poso ya elektronike"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "E-mail's shortcut."
+msgstr "Kgaoletšo ya poso ya elektronike."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Eject"
+msgstr "Ntšha"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+msgid "Eject's shortcut."
+msgstr "Kgaoletšo ya go tšwa."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+msgid "Home folder"
+msgstr "Sephuthedi sa gae"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+msgid "Home folder's shortcut."
+msgstr "Kgaoletšo ya sephuthedi sa gae."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+msgid "Launch help browser"
+msgstr "Tsebagatša sefetleki sa thušo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+msgid "Launch help browser's shortcut."
+msgstr "Tsebagatša kgaoletšo ya sefetleki sa thušo."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+msgid "Launch web browser"
+msgstr "Tsebagatša sefetleki sa wepe"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+msgid "Launch web browser's shortcut."
+msgstr "Tsebagatša kgaoletšo ya sefetleki sa wepe."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+msgid "Lock screen"
+msgstr "Notlela sekirini"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+msgid "Lock screen's shortcut."
+msgstr "Notlela kgaoletšo ya sekirini."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+msgid "Log out"
+msgstr "E-tšwa"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+msgid "Log out's shortcut."
+msgstr "Kgaoletšo ya go tšwa."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Next track key's shortcut."
+msgstr "Kgaoletšo ya senotlelo ya koša e latelago."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Pause"
+msgstr "Emiša nakwana"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Pause key's shortcut."
+msgstr "Emiša kgaoletšo ya senotlelo nakwana."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Play (or play/pause)"
+msgstr "Bapala (goba bapala/emiša nakwana)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Play (or play/pause) key's shortcut."
+msgstr "Bapala (goba bapala/emiša nakwana) kgaoletšo ya senotlelo."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Previous track key's shortcut."
+msgstr "Kgaoletšo ya senotlelo ya kotša e fetilego."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Search"
+msgstr "Nyakišiša"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+msgid "Search's shortcut."
+msgstr "Nyakišiša kgaoletšo."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Skip to next track"
+msgstr "Tabogela go koša e latelago"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Skip to previous track"
+msgstr "Tabogela go koša e fetilego"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Sleep"
+msgstr "Robala"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+msgid "Sleep's shortcut."
+msgstr "Kgaoletšo ya go robala."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Stop playback key"
+msgstr "Emiša senotlelo sa bapala o boele morago"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Stop playback key's shortcut."
+msgstr "Emiša kgaoletšo ya senotlelo sa balapa o boele morago."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume down"
+msgstr "Bolumo e tlase"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume down's shortcut."
+msgstr "Kgaoletšo ya bolumo e tlase."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume mute"
+msgstr "Go nolofatšwa ga bolumo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume mute's shortcut"
+msgstr "Kgaoletšo ya go nolofatšwa ga bolumo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+msgid "Volume step"
+msgstr "Peakanyo ya bolumo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+msgid "Volume step as percentage of volume."
+msgstr "Peakanyo ya bolumo go ya ka phesente ya bolumo."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+msgid "Volume up"
+msgstr "Bolumo e godimo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
+msgid "Volume up's shortcut."
+msgstr "Kgaoletšo ya bolumo e godimo."
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+#, fuzzy
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr ""
+"Bontšha poledišano ge go na le diphošo tša go diriša Seboloki sa Sekirini sa "
+"X"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+#, fuzzy
+msgid "Run screensaver at login"
+msgstr "Diriša Seboloki sa Sekirini sa X ge o tsena"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr "Bontšha Diphošo tša go Thoma"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#, fuzzy
+msgid "Start screensaver"
+msgstr "Thoma Seboloki sa Sekirini sa X"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+#, fuzzy
+msgid "Keyboard Update Handlers"
+msgstr "Mohlala wa _boroto ya dinotlelo:"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#, fuzzy
+msgid "Keyboard layout"
+msgstr "Go bea ga boroto ya dinotlelo ya XKB"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#, fuzzy
+msgid "Keyboard model"
+msgstr "Mohlala wa _boroto ya dinotlelo:"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+#, fuzzy
+msgid "Keyboard options"
+msgstr "Dikgaoletšo tša Boroto ya Dinotlelo"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+#, fuzzy
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr ""
+"Dipeakanyo tša XKB go gconf di tla beelwa ka thoko tshepedišong ya ASAP"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+#, fuzzy
+msgid "keyboard layout"
+msgstr "Go bea ga boroto ya dinotlelo ya XKB"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+#, fuzzy
+msgid "keyboard model"
+msgstr "Mohlala wa boroto ya dinotlelo ya XKB"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "modmap file list"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:212
+msgid "_Postpone break"
+msgstr "Šu_thiša go khutša"
+
+#: ../typing-break/drw-break-window.c:259
+msgid "Take a break!"
+msgstr "Ikhutše!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:141
+msgid "/_Preferences"
+msgstr "/_Tše ratwago"
+
+#: ../typing-break/drwright.c:142
+msgid "/_About"
+msgstr "/_Ka ga"
+
+#: ../typing-break/drwright.c:144
+msgid "/_Take a Break"
+msgstr "/_Ikhutše"
+
+#: ../typing-break/drwright.c:495
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "metsotso e %d pele ga go khutša mo go latelago"
+msgstr[1] "metsotso e %d go fihlela go khutšeng mo go latelago"
+
+#: ../typing-break/drwright.c:499
+msgid "Less than one minute until the next break"
+msgstr "Ka tlase ga motsotso o tee go fihlela go khutšeng mo go latelago"
+
+#: ../typing-break/drwright.c:587
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Ga e kgone go tswalanya poledišano ya dipharologantšho tša go khutša le "
+"phošo e latelago: %s"
+
+#: ../typing-break/drwright.c:635
+msgid "About GNOME Typing Monitor"
+msgstr "Ka ga Lepokisana la Sekirini la go Tlanya la GNOME"
+
+#: ../typing-break/drwright.c:659
+msgid "A computer break reminder."
+msgstr "Kgopotšo ya go khutša ga khomphuthara."
+
+#: ../typing-break/drwright.c:660
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr "E ngwadilwe ke Richard Hult &lt;richard@imendio.com&gt;"
+
+#: ../typing-break/drwright.c:661
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Lelekere la leihlo le okeditšwe ke Anders Carlsson"
+
+#: ../typing-break/drwright.c:837
+msgid "Break reminder"
+msgstr "Kgopotšo ya go khutša"
+
+#: ../typing-break/main.c:93
+msgid "The typing monitor is already running."
+msgstr "Lepokisana la sekirini la go tlanya le šetše le šoma."
+
+#: ../typing-break/main.c:106
+#, fuzzy
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Lepokisana la sekirini la go tlanya le diriša lefelo la go lemoša bakeng sa "
+"go bonagatša tshedimošo. O bonagala o se na lefelo la temošo paneleng ya "
+"gago. O ka le oketša ka go kgotla go lagoja paneleng ya gago gomme o kgethe "
+"'Oketša paneleng -> Dithušo -> lefelo la Temošo'."
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "Phukubjwe e tsotho ya lebelo e fofela mpsha e tšwafago. 0123456789"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "Leina:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "Setaele:"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "Mohuta:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "Boglo:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "Kgatišo:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "Tokelo ya ngwalollo:"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "Tlhaloso:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "tirišo: %s faele ya fonto\n"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr "Beakanya Bjalo ka Fonto ya Tirišo"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+#, fuzzy
+msgid "Sets the default application font"
+msgstr "Kgetha ditirišo tša gago tša tlhaelelo"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+"Ge eba e beakantšwe gore e be therešo, gona difonto tša Mohuta o Bulegilego "
+"di tla khutsofatšwa."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+"Ge eba e beakantšwe e le therešo, gona difonto tša PCF di tla khutsofatšwa."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+"Ge eba e beakantšwe gore e be therešo, gona difonto tša Mohuta wa Therešo di "
+"tla khutsofatšwa."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+"Ge eba e beakantšwe gore e be therešo, gona difonto tša Mohuta wa 1 di tla "
+"khutsofatšwa."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo tša "
+"difonto tša Mohuta o Bulegilego."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo tša "
+"difonto tša PCF."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo tša "
+"difonto tša Mohuta wa Therešo."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo tša "
+"difonto tša Mohuta wa 1."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "Taelo ya khutsofatšo bakeng sa difonto tša Mohuta o Bulegilego"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "Taelo ya khutsofatšo bakeng sa difonto tša PCF"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "Taelo ya khutsofatšo bakeng sa difonto tša Mohuta wa Therešo"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Taelo ya khutsofatšo bakeng sa difonto tša Mohuta wa 1"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "Ge eba go swanetše go khutsofatšwe difonto tša Mohuta o Bulegilego"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "Ge eba go swanetše go khutsofatšwe difonto tša PCF"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "Ge eba go swanetše go khutsofatšwe difonto tša Mohuta wa Therešo"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "Ge eba go swanetše go khutsofatšwe difonto tša Mohuta wa 1"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+#, fuzzy
+msgid "GNOME Font Viewer"
+msgstr "Lefelo la Taolo ya GNOME"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr "<span weight=\"bold\" size=\"larger\">Diriša fonto e mpsha?</span>"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr "O se _ke wa diriša fonto"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"Sehlogo seo o se kgethilego se šišinya fonto e mpsha. Ponelopele ya fonto e "
+"bontšhitšwe ka mo tlase."
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+msgid "_Apply font"
+msgstr "_Diriša fonto"
+
+#: ../vfs-methods/themus/theme-method.c:520
+msgid "Themes"
+msgstr "Dihlogo"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "Tlhaloso"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr "Laola sehlogo"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+msgid "Window border theme"
+msgstr "Sehlogo sa mollwane wa lefesetere"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr "Sehlogo sa leswao"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr "ABCDEFG"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+#, fuzzy
+msgid "Apply theme"
+msgstr "_Diriša fonto"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+#, fuzzy
+msgid "Sets the default theme"
+msgstr "Beakanya di_tlhaelelo ka leswa"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr ""
+"Ge eba e beakantšwe gore e be therešo, gona dihlogo tše tsentšhitšwego e tla "
+"khutsofatšwa."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr ""
+"Ge eba e beakantšwe gore e be therešo, gona dihlogo di tla khutsofatšwa."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+"Beakanya senotlelo se go taelo e dirišeditšwego go hlama dikhutsofatšo "
+"bakeng sa dihlogo tše tsentšhitšwego."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+"Beakanya senotlelo go taelo e dirišeditšwego go hlama dikhutsofatšo bakeng "
+"sa dihlogo."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr "Taelo ya khutsofatšo bakeng sa dihlogo tše tsentšhitšwego"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr "Taelo ya khutsofatšo bakeng sa dihlogo"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr "Ge eba khutsofatšo e tsentšhitše dihlogo"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr "Ge eba go swanetše go khutsofatšwe dihlogo"

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,10 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center HEAD\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-05 18:05+0000\n"
-"PO-Revision-Date: 2022-09-09 18:38+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-11-07 20:05+0100\n"
 "Last-Translator: Quentin PAGÈS\n"
 "Language-Team: Tot en òc\n"
 "Language: oc\n"
@@ -18,104 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.2.1\n"
 "X-DamnedLies-Scope: partial\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Bus sistèma"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Accès complet"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Bus de session"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Periferics"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Accès complet a /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Ret"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "A accès a la ret"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Dorsièr personal"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Lectura sola"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Sistèma de fichièrs"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Paramètres"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Pòt modificar los reglatges"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"Las permissions seguentas son integradas a %s. Pòdon pas èsser modificadas. "
-"Se aquelas permissions vos inquiètan, vos cal envisatjar de suprimir aquesta "
-"aplicacion."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u tipe de fichièr e ligam dubèrt per l’aplicacion"
-msgstr[1] "%u tipes de fichièr e ligam dubèrts per l’aplicacion"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> dubrís aquestes tipes de fichièrs e ligams."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s de l’espaci disc utilizat."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -131,7 +37,6 @@ msgid "Install some…"
 msgstr "Installar…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Dobrir"
 
@@ -155,24 +60,13 @@ msgstr "Recercar"
 msgid "Receive system searches and send results."
 msgstr "Recebre las recèrcas sistèma e enviar los resultats."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Desactivat"
 
@@ -199,7 +93,6 @@ msgstr "Capturas d'ecran"
 
 #: panels/applications/cc-applications-panel.ui:141
 #, fuzzy
-#| msgid "Take pictures with the camera."
 msgid "Take pictures of the screen at any time."
 msgstr "Prendre de fòtos amb la camèra."
 
@@ -339,80 +232,20 @@ msgstr "Escafar lo cache…"
 msgid "Control various application permissions and settings"
 msgstr "Contròla divèrsas permissions e reglatges d’aplicacion"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplicacion;flatpak;permission;reglatge;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Seleccionar un imatge"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Anullar"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Dobrir"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "mantuna talha"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Pas cap de rèireplan de burèu"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Rèireplan actual"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Estil"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Per defaut"
 
@@ -436,7 +269,6 @@ msgstr "Aparéncia"
 msgid "Change your background image or the UI colors"
 msgstr "Remplaçar vòstre imatge de rèireplan o la color de l’interfàcia"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -489,9 +321,7 @@ msgstr "Mòde avion material activat"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Desactivatz lo mòde avion per activar lo Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -499,7 +329,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Activa/desactiva lo Bluetooth e connècta vòstres periferics"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "partiment;partejar;bluetooth;obex;"
@@ -533,95 +362,34 @@ msgstr "Cap d’aplicacion a pas demandat l’accès a la camèra"
 msgid "Protect your pictures"
 msgstr "Protegir vòstres imatges"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "camèra;fòto;fotografia;vidèo;webcam;verrolh;barrar;privat;confidencialitat;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Pausatz vòstra sonda d’escandalhatge sul carrat e quichatz sus « Aviar »"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Desplaçatz vòstra sonda d’escandalhatge cap a l’emplaçament d'escandalhar e "
-"quichatz sus « Contunhar »"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Desplaçatz vòstra sonda d’escandalhatge a l’aplomb de l’emplaçament "
-"d'escandalhar e quichatz sus « Contunhar »"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Rabatètz l'ecran"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Una error intèrna irrecuperabla s'es produita."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Las aisinas necessàrias a l'escandalhatge son pas installadas."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Lo perfil a pas pogut èsser generat."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Lo punt blanc especificat es pas disponible."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Acabat !"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Fracàs de l'escandalhatge !"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Podètz levar la sonda d'escandalhatge."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Toquetz pas a la sonda d'escandalhatge pendent lo processus"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Escandalhatge de l'ecran"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Anullar"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -638,140 +406,6 @@ msgstr "_Reprene"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Acabat"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Ecran de portable"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Webcam integrada"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Ecran %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Numerizar %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Aparelh de fòto %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Imprimenta %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webcam %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Activar la gestion de las colors de %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Afichar los perfils de colors de %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Pas escandalhat"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Per defaut : "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Espaci colorimetric : "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Perfil de pròva : "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Seleccionatz un fichièr de perfil ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importar"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Perfils ICC preses en carga"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Totes los fichièrs"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Ecran"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Enregistrar lo perfil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Enregistrar"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Crear un perfil de color pel periferic seleccionat"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"L'instrument de mesura es pas detectat. Verificatz qu'es alucat e connectat "
-"corrèctament."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "L'instrument de mesura pren pas en carga los perfils d'imprimenta."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Lo tipe de periferic es pas actualament pres en carga."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -888,13 +522,13 @@ msgstr "Necessita un mèdia inscriptible"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Aicí, podètz consultar de conselhs utils sus l'utilizacion d'un perfil <a "
-"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a href="
-"\"windows\">Microsoft Windows</a>."
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a "
+"href=\"windows\">Microsoft Windows</a>."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -914,7 +548,6 @@ msgstr "_Importar un fichièr…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -926,9 +559,7 @@ msgstr ""
 "Cada periferic a besonh d'un perfil de color a jorn per la presa en carga de "
 "las colors."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Per ne saber mai"
 
@@ -1060,83 +691,6 @@ msgstr "D65 (fòtos e grafismes)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Espaci de colors estandard"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Perfil de pròva"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatic"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Bassa qualitat"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Qualitat mejana"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Nauta qualitat"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RVB per defaut"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMJN per defaut"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Gris per defaut"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Donadas d'escandalhatge d'usina del fabricant"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr ""
-"Correccion de l'ecran en mòde ecran complet impossibla amb aqueste perfil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Benlèu qu'aqueste perfil es pas mai precís"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Color"
@@ -1148,14 +702,9 @@ msgstr ""
 "Escandalhona la color de vòstres periferics, coma los ecrans, los aparelhs "
 "de fòtos o las imprimentas"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Color;ICC;Perfil;Escandalhar;Escandalhatge;Imprimenta;Ecran;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Autre…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1170,13 +719,8 @@ msgid "No languages found"
 msgstr "Cap de lenga pas trobada"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Mai…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Desverrolhar per modificar los paramètres"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1205,151 +749,6 @@ msgstr "Reduire las oras"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Reduire las minutas"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Uèi"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Ièr"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d ora"
-msgstr[1] "%d oras"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuta"
-msgstr[1] "%d minutas"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d segonda"
-msgstr[1] "%d segondas"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 segondas"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Punt d’accès"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 oras"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B de %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B de %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1445,17 +844,11 @@ msgid "Requires location services enabled and internet access"
 msgstr ""
 "Necessita l’activacion dels servicis de localizacion e una connexion Internet"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Activat"
 
@@ -1463,15 +856,43 @@ msgstr "Activat"
 msgid "Time Z_one"
 msgstr "Fus _orari"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desverrolhar"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format de l'ora"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datas"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 segondas"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calendièr"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Nombres"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Modificar la data e l'ora, inclús lo fus orari"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Relòtge;Fus;Ora;Data;Emplaçament;"
@@ -1517,21 +938,9 @@ msgstr "Aplicacions per defaut"
 msgid "Configure Default Applications"
 msgstr "Configurar las aplicacions per defaut"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "defaut;per defaut;aplicacion;preferida;mèdia;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Enviar de rapòrts o senhalar de problèmas tecnics nos ajuda a melhorar %s. "
-"Los rapòrts son enviats anonimament e son netejat de tota donada personala. "
-"%s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1549,44 +958,9 @@ msgstr "Diagnostics"
 msgid "Report your problems"
 msgstr "Senhalar vòstres problèmas"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostics;crash;plantatge;avaria;fracàs;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "I"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "O"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Aplicar los cambiaments ?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Los cambiaments pòdon pas èsser aplicats"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Aquò pòt venir de limitacions materialas."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1636,31 +1010,6 @@ msgstr "Ecran principal"
 msgid "Night Light"
 msgstr "Mòde nuèit"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Païsatge"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Retrait sus la dreita"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Retrait sus l'esquèrra"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Païsatge (revirat)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1684,6 +1033,17 @@ msgstr "Adaptar als televisors"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Escala"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Desfilament natural"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1778,7 +1138,6 @@ msgstr "Afichatge"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Causir lo mòde d'utilizacion dels ecrans e projectors connectats"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1787,98 +1146,6 @@ msgstr ""
 "Panèl;Projector;xrandr;Ecran;Definicion;Resolucion;Refrescament;Moniteur;"
 "Nuèit;Nuèch,Esclairatge;Lum;Lutz;Blava;redshift;descalatge;espectral;color;"
 "levar;colcar;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Aviada segura activa"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-#, fuzzy
-#| msgid ""
-#| "Secure boot prevents malicious software from being loaded when the device "
-#| "starts.\n"
-#| "\n"
-#| "For more information, contact the hardware manufacturer or IT support."
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"L’aviada segura empacha los logicials malvolents de se cargar quand "
-"l’aparelh avia.\n"
-"\n"
-"Per mai d’informacions, contactatz lo fabricants del material o "
-"l’assisténcia tecnica."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "L’aviada segura a de problèmas"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-#, fuzzy
-#| msgid ""
-#| "Secure boot prevents malicious software from being loaded when the device "
-#| "starts.\n"
-#| "\n"
-#| "For more information, contact the hardware manufacturer or IT support."
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"L’aviada segura empacha los logicials malvolents de se cargar quand "
-"l’aparelh avia.\n"
-"\n"
-"Per mai d’informacions, contactatz lo fabricants del material o "
-"l’assisténcia tecnica."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "L’aviada segura es atuda"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-#, fuzzy
-#| msgid ""
-#| "Secure boot prevents malicious software from being loaded when the device "
-#| "starts.\n"
-#| "\n"
-#| "For more information, contact the hardware manufacturer or IT support."
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"L’aviada segura empacha los logicials malvolents de se cargar quand "
-"l’aparelh avia.\n"
-"\n"
-"Per mai d’informacions, contactatz lo fabricants del material o "
-"l’assisténcia tecnica."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1893,115 +1160,9 @@ msgstr ""
 "Per mai d’informacions, contactatz lo fabricants del material o "
 "l’assisténcia tecnica."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Reüssit"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Fracàs"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "L’aparelh es confòrme al nivèl HSI %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Nivèl de seguretat 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Nivèl de seguretat 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Nivèl de seguretat 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Nivèl de seguretat 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Nivèl de seguretat"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Los nivèls de seguretat son pas disponibles per aqueste aparelh."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2015,353 +1176,9 @@ msgstr "Nivèl 2"
 msgid "Level 3"
 msgstr "Nivèl 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "L’aviada segura a de problèmas"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "D’unas proteccions quand l’aparelh es aviat."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "L’aviada segura es atuda"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Cap de proteccion a l’aviada de l’aparelh."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Exposat a de menaças de seguretat grèvas."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Proteccion limitada contra de menaças de seguretat simplas."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Protegit contra de menaças de seguretat comunas."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Protegit contra una plaja larga de menaças de seguretat."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Proteccion complèta"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Cap d’eveniment"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Proteccion d’escritura del micrologicial"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Verrolh de proteccion d’escritura del micrologicial"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Region del micrologicial de BIOS"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Descriptor del micrologicial de BIOS"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-#, fuzzy
-#| msgid "No Protection"
-msgid "Pre-boot DMA Protection"
-msgstr "Pas cap de proteccion"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-#, fuzzy
-#| msgid "Intel BootGuard verified boot"
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard aviada verificada"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-#, fuzzy
-#| msgid "Intel BootGuard ACM protected"
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM protegit"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-#, fuzzy
-#| msgid "Intel BootGuard"
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-#, fuzzy
-#| msgid "Intel BootGuard"
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-#, fuzzy
-#| msgid "Intel CET"
-msgid "Intel CET Enabled"
-msgstr "Intel CET"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr ""
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "RAM chifrada"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Proteccion IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr ""
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr ""
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Memòria d'escambi Linux"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Metre en velha en RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-#, fuzzy
-#| msgid "Suspend-to-idle"
-msgid "Suspend To Idle"
-msgstr "Ivernada-quand-inactiu"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "clau de platafòrma UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Aviada segura UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Configuracion de la platafòrma TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr ""
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Mesas a jorn del micrologicial"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Atestacion d’integritat del micrologicial"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Verificador de l’actualizador de micrologicial"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Platafòrma de desbugatge"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-#, fuzzy
-#| msgid "No Protection"
-msgid "AMD Rollback Protection"
-msgstr "Pas cap de proteccion"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-#, fuzzy
-#| msgid "Minimal Protection"
-msgid "AMD Firmware Replay Protection"
-msgstr "Proteccion minimala"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-#, fuzzy
-#| msgid "Minimal Security Protections"
-msgid "AMD Firmware Write Protection"
-msgstr "Proteccions de seguretat minimalas"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr ""
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Valid"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Pas valid"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Pas activat"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Verrolhat"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Pas verrolhat"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Chifrat"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Pas chifrat"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr ""
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-#, fuzzy
-#| msgid "Not calibrated"
-msgid "Not Tainted"
-msgstr "Pas escandalhat"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Trobat"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Pas trobat"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Pres en carga"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Pas pres en carga"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2371,7 +1188,6 @@ msgstr "Seguretat de l’aparelh"
 msgid "Host firmware security status"
 msgstr ""
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2379,49 +1195,6 @@ msgid ""
 msgstr ""
 "ecran;verrolhar;verrolhatge;diagnotic;confidencialitat;recent;temporari;nom;"
 "ret;malhum;identitat;tmp;privat;privada;vida;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Desconegut"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Desconegut"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Pas disponibla"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logotipe sistèma"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2515,11 +1288,6 @@ msgstr "A prepaus"
 msgid "View information about your system"
 msgstr "Afichar las informacions sul sistèma"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2598,6 +1366,12 @@ msgstr "Aviadors"
 msgid "Launch help browser"
 msgstr "Aviar lo navigador d'ajuda"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Paramètres"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Aviar la calculeta"
@@ -2619,7 +1393,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Recercar"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistèma"
 
@@ -2668,15 +1442,6 @@ msgstr "Reduire la talha del tèxte"
 msgid "High contrast on or off"
 msgstr "Activar o desactivar lo contraste elevat"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Cap de font d'entrada pas trobada"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Autre"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Apondre una font d'entrada"
@@ -2710,107 +1475,9 @@ msgstr "Preferéncias"
 msgid "View Keyboard Layout"
 msgstr "Veire l’agençament del clavièr"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Suprimir"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Acorchis personalizats"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Tòca de caractèrs alternatius"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Las claus de caractèrs s'utilizan per picar de caractèrs addicionals. De "
-"còps que i a son imprimits coma una tèrça opcion sul clavièr."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt d'esquèrra"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt de dreita"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Ctrl d'esquèrra"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Ctrl de dreita"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Clau de menú"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl de dreita"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Tòca de composicion"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"La tòca de composicion permet de picar una brava varietat de caractèrs. Per "
-"l’utilizar, tenètz-la quichada e quichatz una sequéncia de caractèrs. Per "
-"exemple, la tòca de composicion seguida de <b>C</b> e <b>o</b> donarà <b>©</"
-"b>, <b>a</b> seguit de <b>'</b> donarà <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Verr.Maj."
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Verrolhatge del desfilament"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Imp. Ecr."
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Òm pòt bascular las fonts d’entradas en utilizant l’acorchi de clavièr %s.\n"
-"Se pòt modificar aqueste acorchi de clavièr dins las preferéncias del "
-"clavièr."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2842,45 +1509,21 @@ msgstr ""
 "Metòdes per picar de simbòls e de variantas de letras en utilizant lo "
 "clavièr."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tòca de caractèrs alternatius"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tòca de composicion"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Acorchis de clavièr"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Veire e personalizar los acorchis"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modificat"
-msgstr[1] "%d modificats"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Reïnicializar totes los acorchis ?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Reïnicializar totes los acorchis pòt tanben afectar vòstres acorchis "
-"personalizats. Aquesta accion es irreversibla."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Anullar"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Reïnicializar tot"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2920,33 +1563,6 @@ msgstr "Apondre un acorchi"
 msgid "No keyboard shortcut found"
 msgstr "Cap d'acorchi de clavièr pas trobat"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s es ja utilizat per %s. Se lo remplaçatz, %s serà desactivat"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Picar lo novèl acorchi"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Definir un acorchi personalizat"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Definir un acorchi"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Picatz un acorchi novèl per cambiar %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Apondre un acorchi personalizat"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Suprimir"
@@ -2958,7 +1574,6 @@ msgstr "Rem_plaçar"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Definir"
 
@@ -2996,6 +1611,11 @@ msgstr "Pas cap"
 msgid "Reset the shortcut to its default value"
 msgstr "Reïnicializar l'acorchi a sa valor per defaut"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Utilizar coma imprimenta per defaut"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Clavièr"
@@ -3008,7 +1628,6 @@ msgstr ""
 "Codificar los acorchis de clavièr e definir vòstras preferéncias de picada, "
 "agençament de clavièr e fonts d’entrada"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3050,7 +1669,6 @@ msgstr "Cap d’aplicacion a pas demandat l’accès a vòstre emplaçament"
 msgid "Protect your location information"
 msgstr "Protegir vòstras informacions de localizacion"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "localizacion;gps;privat;confidencialitat;"
@@ -3085,7 +1703,6 @@ msgstr "Cap d’aplicacion a pas demandat l’accès al microfòn"
 msgid "Protect your conversations"
 msgstr "Protegir vòstras conversacions"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "microfòn;enregistrament;aplicacion;confidencialitat;"
@@ -3116,81 +1733,140 @@ msgstr "Esquèrra"
 msgid "Right"
 msgstr "Dreita"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Emplaçaments de la recèrca"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mirga"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Tòcas de la mirga"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Desfilament natural"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Desfilament cap aval"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Lo compte sul servidor serà pas suprimit."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Lo compte sul servidor serà pas suprimit."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Actiu"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Pavat tactil"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Velocitat del pavat tactil"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Picar per clicar"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Tocar per clicar"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Défilement a deux doigts"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Desac_tivar al moment de la picada"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Pavat tactil (relatiu)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Desfilament cap a dreita"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Desfilament cap aval"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Recto-verso"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Ensajatz de clicar, doble-clicar, far desfilar"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinc clics, l'epòca GEGL !"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Clic-doble, boton principal"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Clic simple, boton principal"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Clic-doble, boton del mitan"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Clic simple, boton del mitan"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Clic-doble, boton segondari"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Clic simple, boton segondari"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3203,7 +1879,6 @@ msgstr ""
 "Modificar la sensibilitat del pavat tactil e causir entre dreitièr o "
 "esquerrièr"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Pavat;Tactil;Puntador;Clic;Quichada;Doble;Boton;Bola;Desfilament;"
@@ -3283,7 +1958,6 @@ msgstr "Multiprètzfach"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Gerir las preferéncias per la productivitat e multi prètzfach"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3291,20 +1965,11 @@ msgstr ""
 "multi prètzfach;multitasca;productivitat;personalizar;burèu;caire;espaci;"
 "trabalh;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Ops, quicòm a trucat. Contactatz lo provesidor de vòstre logicial."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager deu èsser en foncionament."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Autres periferics"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3316,59 +1981,16 @@ msgstr "Apondre una connexion novèla"
 msgid "Not set up"
 msgstr "Pas configurat"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID : %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Ret pas segur (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Ret segur (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Ret segur (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Ret segur (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Ret segur"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Connectat"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opcions…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"L’activacion del punt d’accès mena a la desconnexion de %s e serà pas "
-"possible d’accedir a Internet en Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Deu conténer almens 8 caractèrs"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3419,20 +2041,6 @@ msgstr "Generar automaticament un senhal"
 msgid "_Turn On"
 msgstr "A_lucar"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Interrompre lo punt d'accès e desconnectar totes los utilizaires ?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Interrompre lo punt d'accès"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Mòde avion"
@@ -3478,89 +2086,13 @@ msgstr "Rets visiblas"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager deu èsser en foncionament"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Ops, quicòm a trucat. Contactatz lo provesidor de vòstre logicial."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Seguretat 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Seguretat"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Conservar"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Aleatòri"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Estable"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"L’adreça MAC picada aicí serà utilizada coma adreça materiala del periferic "
-"de ret activat per aquesta connexion. Aquesta foncionalitat es apelada « MAC "
-"cloning » o « spoofing ». Exemple : 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Perfil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Entrepresa"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Pas cap"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Pas jamai"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3569,183 +2101,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "I a %i jorn"
 msgstr[1] "I a %i jorns"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Pas cap"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Feble"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Corrècte"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Bon"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excellent"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Adreça IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Adreça IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Adreça IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Doblidar la connexion"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Suprimir lo perfil de la connexion"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Suprimir lo VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Detalhs"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatic"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitat"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Suprimir l'adreça"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Suprimir la rota"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Pas cap"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Clau WEP 40/128-bit (Hex o ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Frasa secreta WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinamic (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA e WPA2 privadas"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA e WPA2 d'entrepresa"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3756,8 +2111,20 @@ msgstr "Fòrça del senhal"
 msgid "Link speed"
 msgstr "Velocitat de la connexion"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguretat"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Adreça IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adreça IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Adreça materiala"
 
@@ -3766,12 +2133,17 @@ msgid "Supported Frequencies"
 msgstr "Frequéncias compatiblas"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Rota per defaut"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3836,7 +2208,7 @@ msgstr "Ret locala solament"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
@@ -3880,9 +2252,8 @@ msgstr "Palanca"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automatic"
 
@@ -3935,89 +2306,9 @@ msgstr "Automatic, DHCP solament"
 msgid "Prefix"
 msgstr "Prefix"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Impossible de dobrir l'editor de connexions"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Perfil novèl"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Paramètre invalid %s : %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Paramètre invalid %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importar dempuèi un fichièr…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Apondre un VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Seg_uretat"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Impossible d'importar la connexion VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Lo fichièr « %s » es ilegible o conten pas cap d’informacions de connexion "
-"VPN reconegudas\n"
-"\n"
-"Error : %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Seleccionar lo fichièr d'importar"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Un fichièr nomenat « %s » existís ja."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Remplaçar"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Volètz remplaçar %s amb la connexion VPN en cors d'enregistrament ?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Impossible d'exportar la connexion VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"La connexion VPN « %s » a pas pogut èsser exportada cap a %s.\n"
-"\n"
-"Error : %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Exportacion de la connexion VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4031,99 +2322,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Ret"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controlar vòstre biais de vos connectar a Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Ret;IP;LAN;Mandatari;WAN;Larga benda;Modèm;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controlar vòstre biais de vos connectar a las rets sens fial"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Ret;Sens fial;Wi-Fi;Wifi;IP;LAN;Larga benda;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "pas jamai"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "uèi"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "ièr"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Darrièra utilizacion"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Filara"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Apondre una novèla connexion"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Las informacions de las rets seleccionadas, incluses los senhals e tota "
-"configuracion personalizada seràn perduts."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Doblidar"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Rets Wi-Fi conegudas"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Doblidar"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Las règlas del sistèma interdison son utilizacion coma punt d'accès"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Lo periferic sens fial pren pas en carga lo mòde « punt d'accès »"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"« Web Proxy Autodiscovery » es utilizat quand cap d'URL de configuracion es "
-"pas provesit."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Aquò es pas recomandat per de rets publicas pas seguras."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4142,6 +2370,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Provesidor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adreça IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4226,293 +2458,6 @@ msgstr "_Alucar lo punt d’accès Wi-Fi…"
 msgid "_Known Wi-Fi Networks"
 msgstr "Rets Wi-Fi _conegudas"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Estat desconegut"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Pas gerit"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Indisponible"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Connexion en cors"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Autentificacion requesida"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Desconnexion en cors"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Fracàs de la connexion"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Estat desconegut (absent)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Fracàs de la configuracion"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Fracàs de la configuracion IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Configuracion IP expirada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "D'elements secrets, pas provesits, èran necessaris"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Lo client 802.1x s'es desconnectat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "La configuracion del client 802.1x a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Lo client 802.1x a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Lo client 802.1x a mes tròp de temps per s'autentificar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Lo servici PPP a pas capitat de s'aviar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Servici PPP desconnectat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Lo client DHCP a pas capitat de s'aviar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Error del client DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Lo client DHCP a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Lo servici de connexion partejada a pas capitat de s'aviar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Lo servici de connexion partejada a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Lo servici autoIP a pas capitat de s'aviar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Error del servici autoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Lo servici autoIP a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linha ocupada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Pas de tonalitat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Cap de portadoira a pas pogut èsser establida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Relambi de numerotacion depassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "La temptativa de numerotacion a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "L'inicializacion del modèm a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Fracàs de la seleccion de l'APN especificat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Cap de recèrca de ret pas en cors"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Enregistrament a la ret refusat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Relambi depassat per l'enregistrament a la ret"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Fracàs de l'enregistrament a la ret demandat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "La verificacion del còdi PIN a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Es possible que lo micrologicial del periferic manca"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "La connexion a desparegut"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Una connexion existenta es estada supausada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modèm pas trobat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "La connexion Bluetooth a fracassat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "La carta SIM es pas inserida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Lo còdi PIN de la SIM es necessari"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Lo còdi PUK de la SIM es requesit"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Marrida SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "La dependéncia de la connexion a fracassat"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Micrologicial absent"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Cable desbrancat"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "error de seguretat desconeguda dins 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "cap de fichièr pas seleccionat"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "error desconeguda a la validacion del fichièr eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-#, fuzzy
-#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Claus privadas DER, PEM, o PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:397
-#, fuzzy
-#| msgid "_User certificate"
-msgid "DER or PEM certificates"
-msgstr "Certificat _utilizaire"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "fichièr EAP-FAST PAC mancant"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Fichièrs PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4561,14 +2506,6 @@ msgstr "Autentificacion _intèrna"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Autorizar l’_obtencion automatica de PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "nom d’utilizaire d’EAP-LEAP mancant"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "senhal d’EAP-LEAP mancant"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4594,15 +2531,6 @@ msgstr "Se_nhal"
 msgid "Sho_w password"
 msgstr "Afi_char lo senhal"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "certificat CA d’EAP-PEAP invalid : %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "certificat CA d’EAP-PEAP invalid : cap de certificat pas especificat"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4624,7 +2552,6 @@ msgid "C_A certificate"
 msgstr "Certificat C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4639,63 +2566,6 @@ msgstr "Cap de certificat CA es pas _requesit"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Version PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "nom d’utilizaire EAP mancant"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "senhal EAP mancant"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "identitat EAP-TLS mancanta"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "certificat CA EAP-TLS invalid : %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TLS invalid : cap de certificat pas especificat"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "clau privada EAP-TLS invalida : %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificat utilizaire EAP-TLS invalid : %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Las claus privadas pas chifradas son pas fisablas"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Sembla que la clau privada seleccionada es pas protegida per un senhal. Aquò "
-"met en dangièr vòstres identificants. Seleccionatz una clau privada "
-"protegida per senhal.\n"
-"\n"
-"(Podètz protegir vòstra clau per senhal amb openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Causissètz vòstre certificat personal"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Causissètz vòstra clau privada"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4712,15 +2582,6 @@ msgstr "_Clau privada"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Senhal de la _clau privada"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "certificat CA EAP-TTLS invalid : %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TTLS invalid : cap de certificat pas especificat"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4743,14 +2604,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domeni"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Error desconeguda a la validacion de la seguretat de 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4778,61 +2640,10 @@ msgstr "EAP securizat (PEAP)"
 msgid "Au_thentication"
 msgstr "Au_tentificacion"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Seleccionar un fichièr"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "nom d’utilizaire leap mancant"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "senhal leap mancant"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Senhal Wi-Fi mancant."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipe"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "clau wep mancanta"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"clau wep invalida : una clau de %zu deu pas conténer que de caractèrs "
-"exadecimals"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"clau wep invalida : una clau de %zu deu pas conténer que de caractèrs ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"clau wep invalida : longor de clau %zu incorrècta. Deu èsser de 5 a 13 "
-"caractèrs en ascii o de 10 a 26 en exa"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "clau wep invalida : frasa secreta pas completada"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "clau wep invalida : la frasa secreta deu conténer mens de 64 caractèrs"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4857,21 +2668,6 @@ msgstr "_Afichar la clau"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Indè_x WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk invalid : longor de clau %zu incorrècta. Deu èsser de [8,63] octets "
-"o 64 caratèrs exadecimals"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk invalid : impossible de considerar una clau de 64 octets coma "
-"exadecimala"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4927,27 +2723,9 @@ msgstr "Notificacions sus _l'ecran de verrolhatge"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controlar quinas notificacions s'afichan e lor contengut"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notificacions;Messatges sorgissents;Messatge;Tirador;Popup;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Autre"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s suprimit"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Error al moment de la supression del compte"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4973,17 +2751,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Apondre un compte"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Compte %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Suprimir lo compte"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Comptes en linha"
@@ -4992,10 +2759,6 @@ msgstr "Comptes en linha"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Connectatz-vos a vòstres comptes en linha e decidètz de lor utilitat"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5003,10 +2766,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;En linha;Discussion;Agenda;Corrièr;Email;"
 "Contacte;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Durada desconeguda"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5022,13 +2781,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i ora"
 msgstr[1] "%i oras"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5040,190 +2792,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuta"
 msgstr[1] "minutas"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s abans cargament complet"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Atencion : demòra %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s restant"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Batariá plena"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Pas en carga"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Descargada"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "En carga"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "En descarga"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Mirga sens fial"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Clavièr sens fial"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Ondulator"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Assistent personal"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Telefòn portable"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Lector multimèdia"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tauleta"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Ordenador"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Periferic d’entrada per jòcs"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batariá"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principala"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Segondària"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batariás"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Quand _inactiu"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Metre en velha"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Atudar"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Ivernar"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Pas res"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Quand sus batariá"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Quand lo cable es brancat"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Pas jamai"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Mesa en _velha automatica"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Mòde performança temporàriament indisponible a causa d’una temperatura de "
-"foncionament nauta."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Lap detectada : mòde performança temporàriament desactivat.Desplaçatz lo "
-"periferic sus una susfàcia establa per restaurar."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Mòde performança temporàriament indisponible."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Batariá febla : estalviador d’energia activat. Lo mòde precedent serà "
-"restablit un còp que la batariá aja sufisentament cargat."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Mòde estalvi activat per « %s »."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Mòde performança activat per « %s »."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5284,6 +2852,15 @@ msgstr "100 minutas"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 oras"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batariá"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Periferics"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5362,33 +2939,6 @@ msgstr "Sus _batariá"
 msgid "Delay"
 msgstr "Relambi"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Performança"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Performança e consomacion nautas."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Equilibri"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Performança e utilizacion energetica estandardas."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Estalviador d'energia"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Performança e utilizacion energetica reduchas."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Energia"
@@ -5399,7 +2949,6 @@ msgstr ""
 "S'informar sus l'estat de la batariá e modificar los paramètres d'estalvi "
 "d'energia"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5407,27 +2956,6 @@ msgid ""
 msgstr ""
 "energia;alimentacion;velha;suspension;susprendre;ivernacion;ivernar;batariá;"
 "luminositat;negre;ecran;DPMS;inactiu;som;dormir;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "L’imprimenta « %s » es estada suprimida"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "L'apondon de la novèla imprimenta a fracassat."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Impossible de cargar l'interfàcia d'utilizaire : %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Desverrolhar per apondre d‘imprimentas e modificar los paramètres"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5438,7 +2966,6 @@ msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Apondre d'imprimentas, afichar los prètzfaits e decidir quand volètz imprimir"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Imprimenta;Fila;Coa;Impression;Papièr;Tinta;Toner;"
@@ -5446,8 +2973,6 @@ msgstr "Imprimenta;Fila;Coa;Impression;Papièr;Tinta;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Apondre una imprimenta"
 
@@ -5488,29 +3013,6 @@ msgstr ""
 msgid "Username"
 msgstr "Nom d'utilizaire"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Informacions sus %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Cap de pilòt adeqüat pas trobat"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Seleccionatz un fichièr PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Fichièrs de descripcion PostScript de l'imprimenta (*.ppd, *.PPD, *.ppd.gz, "
-"*.PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
@@ -5520,9 +3022,7 @@ msgstr ""
 msgid "Location"
 msgstr "Emplaçament"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Pilòt"
 
@@ -5550,141 +3050,20 @@ msgstr "Seleccionar un pilòt d'imprimenta"
 msgid "Loading drivers database…"
 msgstr "Cargament de la basa de donadas dels pilòts…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Anullar"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Seleccionar"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Imprimenta JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Imprimenta LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Recto"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Bòrd long (estandard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Bòrd cort (revirat)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Retrait"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Païsatge"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Païsatge inversat"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Retrait inversat"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Reprendre"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "En pausa"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "En espèra"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "En pausa"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Autentificacion requesida"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Tractament en cors"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Arrestada"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Interrompuda"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Anullada"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Acabada"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Plaçar aqueste prètzfach ennaut de la fila"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u prètzfait necessita una autentificacion"
 msgstr[1] "%u prètzfaits necessitan una autentificacion"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - prètzfaits d’impression actius"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr ""
-"Picatz vòstras informacions d’autentificacion per imprimir a partir de %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5712,323 +3091,17 @@ msgstr "_Autentificacion"
 msgid "No Active Printer Jobs"
 msgstr "Pas de prètzfaits d'impression actius"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Desverrolhar lo servidor d’imprimentas"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Desverrolhar %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Picatz vòstre nom d’utilizaire e vòtre senhal per afichar las imprimentas "
-"sus %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Recèrca d’imprimentas"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Pòrt seria"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Pòrt parallèl"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Emplaçament : %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adreça : %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Lo servidor necessita una autentificacion"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Recto verso"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Tipe de papièr"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Font del papièr"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Nauc de sortida"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolucion"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Prefiltratge GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Paginas per costat"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Recto-verso"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientacion"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "General"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Mesa en pagina"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opcions installablas"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Prètzfaits"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Qualitat de l'imatge"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Color"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Finicion"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avançat"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Pagina de pròva"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Pagina de pròva"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Seleccion automatica"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Opcion per defaut de l'imprimenta"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Incorporar solament las polissas GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Convertir en PS de nivèl 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Convertir en PS de nivèl 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Pas cap de prefiltratge"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Fabricant"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Pas cap de prètzfait d’impression actiu"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u prètzfait"
 msgstr[1] "%u prètzfaits"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Netejatge de las tèstas d’impression"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Toner gaireben agotat"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Pas mai de toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Revelator gaireben agotat"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Pas mai de revelator"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Cartocha de color gaireben voida"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Cartocha de color voida"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr " Tapador dobèrt"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Pòrta dobèrta"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Gaireben pas mai de papièr"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Pas mai de papièr"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Fòra linha"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Arrestada"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr " Recipient de descais gaireben plen"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Recipient de descais plen"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Lo fotoconductor optic es gaireben en fin de vida"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Lo fotoconductor optic es pas mai en estat"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Prèsta"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Accèpta pas mai de prètzfaits suplementaris"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Tractament en cors"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6052,6 +3125,10 @@ msgstr "Netejar las tèstas d’impression"
 msgid "Remove Printer"
 msgstr "Suprimir l'imprimenta"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Pas cap de prètzfait d’impression actiu"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6072,16 +3149,21 @@ msgid "Restart"
 msgstr "Reaviar"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Apondre una imprimenta…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Apondre una imprimenta…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Cap d’imprimenta"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6089,7 +3171,6 @@ msgstr ""
 "O planhèm ! Lo servici d’impression del sistèma\n"
 "    sembla pas disponible."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formats"
@@ -6117,16 +3198,6 @@ msgstr "Las recèrcas pòdon èsser per país o lenga."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Apercebut"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metric"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6164,20 +3235,25 @@ msgstr ""
 "Lo parametratge lingüistic servís pels tèxtes de l’interfàcia e de las "
 "paginas web. Lo format es utilizat pels nombres, datas e las devisas."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Installar de lengas..."
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Vòstre compte"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Lenga"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formats"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Ecran de connexion"
 
@@ -6189,101 +3265,9 @@ msgstr "País e lenga"
 msgid "Select your display language and formats"
 msgstr "Seleccionatz la lenga e lo format d’afichatge"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Lenga;Disposicion;Clavièr;Entrada;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Demandar de qué far"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Far pas res"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Dobrir lo dorsièr"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Autres mèdias"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Seleccionatz una aplicacion per vòstres CD àudio"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Seleccionatz una aplicacion per vos DVD àudio"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Seleccionatz una aplicacion d'aviar quand un lector de musica es connectat"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-"Seleccionatz una aplicacion d'aviar quand un aparelh de fòto es connectat"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Seleccionatz una aplicacion pels CD que contenon de logicials"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD àudio"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Disc Blu-ray verge"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "CD verge"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "DVD verge"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "Disc HD DVD verge"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "disc vidèo Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "lector e-book"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "disc vidèo HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Cd d’imatges"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super CD Vidèo"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "CD vidèo"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Logicials Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6333,7 +3317,6 @@ msgstr "Mèdias amovibles"
 msgid "Configure Removable Media settings"
 msgstr "Configurar los paramètres dels mèdia amovibles"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6341,114 +3324,6 @@ msgid ""
 msgstr ""
 "periferic;sistèma;per defaut;aplicacion;preferida;cd;dvd;usb;àudio;vidèo;"
 "disc;amovible;mèdia;execucion automatica;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Atudament de l’ecran"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 segondas"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuta"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutas"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutas"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutas"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutas"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 ora"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutas"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutas"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutas"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutas"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutas"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutas"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutas"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutas"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Jamai"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6487,11 +3362,16 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "Afichar las _notificacions sus l’ecran de verrolhatge"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Notificacions sus _l'ecran de verrolhatge"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Interdire los periferics _USB novèls"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6499,30 +3379,25 @@ msgstr ""
 "Empacha los periferics USB novèls d’interagir amb lo sistèma del temps que "
 "l’ecran es verrolhat."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Ecran de confidencialitat"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ecran"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Configuracion de l'ecran"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "ecran;verrolh;privat;confidencialitat;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Seleccionar un emplaçament"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_D'acòrdi"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6553,10 +3428,6 @@ msgstr "Autres"
 msgid "Add Location"
 msgstr "Apondre un emplaçament"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Cap d'aplicacion pas trobada"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Recèrca d'aplicacions"
@@ -6584,93 +3455,13 @@ msgstr ""
 "Controlar quinas aplicacions afichan los resultats d'una recèrca dins la "
 "vista d'ensemble de las activitats"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Recercar;Recèrca;Indèx;Amagar;Confidencialitat;Privat;Resultats;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Cap de ret de partiment es pas seleccionada"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Rets"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "I"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "O"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Activat"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Actiu"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Causir un dorsièr"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Apondre"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Activar lo partiment de mèdias"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Lo partiment de fichièrs vos permet de partejar vòstre dorsièr Public amb "
-"los autres sus la ret actuala en utilizant  : %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Quand la connexion distanta es activada, los utilizaires distants se pòdon "
-"connectar en utilizant la comanda Shell securizada :\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Activar lo partiment de fichièrs personals"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Nom del periferic copiat"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Adreça del periferic copiada"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Nom d’utilizaire copiat"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Senhal copiat"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6802,7 +3593,6 @@ msgstr "Dorsièrs"
 msgid "Control what you want to share with others"
 msgstr "Controlar çò que volètz partejar amb los autres"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6820,17 +3610,12 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Autentificacion requesida per activar o desactivar una connexion distanta"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Personalizada"
-
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
 msgstr "Click"
 
 #: panels/sound/cc-alert-chooser.ui:20
 #, fuzzy
-#| msgid "Sharing"
 msgid "String"
 msgstr "Partiment"
 
@@ -6857,11 +3642,6 @@ msgstr "Arrièr"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Avant"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Pròva de %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6915,11 +3695,6 @@ msgstr "Volum"
 msgid "Alert Sound"
 msgstr "Son d’alèrta"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100 %"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Mut"
@@ -6933,82 +3708,11 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Modificar los volums sonòrs, las entradas, las sortidas e las alèrtas sonòras"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Carta;Microfòn;Volum;Fondut;Balança;Bluetooth;Casc;Audio;Entrada;Sortida;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Desconnectat"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Connexion en cors"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Connectat"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Error d'autorizacion"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autorizacion en cors"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Foncionalitat reduita"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Connectats & Autorizats"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Desconegut"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autorizat per :"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Connectat a :"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Inscrit dempuèi :"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Fracàs d'autorizacion del priferic : "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Impossible de doblidar lo periferic : "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7042,57 +3746,6 @@ msgstr "Autorizar e Connectar"
 msgid "Forget Device"
 msgstr "Periferic doblidat"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Error"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorizat"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Lo sossistèma Thunderbolt (boltd) es pas installat o es mal configurat."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Autorizar l’accès dirècte als periferics tals coma las estacions d’acuèlh e "
-"processors grafics extèrnes."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Sols los periferics USB e Display Port pòdon èsser connectats."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt a pas pogut èsser detectat.\n"
-"Siá lo sistèma pren pas en carga Thunderbolt, siá es estat desactivat dins "
-"lo BIOS, siá es parametrat sus un nivèl de seguretat pas pres en carga dins "
-"lo BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "La presa en carga de Thunderbolt es estada desactivada dins lo BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Lo nivèl de seguretat Thunderbolt a pas pogut èsser determinat."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Error de bascula en mòde dirècte : %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Pas cap de presa en carga de Thunderbolt"
@@ -7104,6 +3757,12 @@ msgstr "Connexion impossibla al subsistèma Thunderbold."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Accès dirècte"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Autorizar l’accès dirècte als periferics tals coma las estacions d’acuèlh e "
+"processors grafics extèrnes."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7121,7 +3780,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Gerir los periferics Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;vidaprivada;privat;confidencialitat;"
@@ -7325,40 +3983,6 @@ msgid "Turn accessibility features on and off using the keyboard"
 msgstr ""
 "Activar e desactivar las foncionalitats d'accessibilitat a partir del clavièr"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Per defaut"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Mejan"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Grand"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Mai grand"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Lo mai grand"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixèl"
-msgstr[1] "%d pixèls"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Totjorn afichar lo menú Accès universal"
@@ -7474,31 +4098,6 @@ msgstr "Far cluquejar tot l'e_cran"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Far cluquejar tota la _fenèstra"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Corta"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ d'ecran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ecran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ d'ecran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Longa"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7655,7 +4254,6 @@ msgstr "Efèits de color"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Facilitar la vision, l'escota, la picada, la seleccion e lo clic"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7667,114 +4265,6 @@ msgstr ""
 "zoom;ecran;lector;grand;larg;tèxt;talha;clic;velocitat;àudio;picada;poliça;"
 "policia;polissa;polissas;escritura;tòca;acorchi;lent;mirga;doble;clic;"
 "relambi;delai;repetir;visual;animacions;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 ora"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 jorn"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 jorns"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 jorns"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 jorns"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 jorns"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 jorns"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 jorns"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 jorns"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 jorns"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Voidar completament l'escobilhièr ?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Tot lo contengut de l'escobilhièr serà definitivament suprimit."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Voidar l'escobilhièr"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Suprimir totes los fichièrs temporaris ?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Totes los fichièrs temporaris seràn definitivament suprimits."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Purgar los fichièrs temporaris"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 jorn"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 jorns"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 jorns"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Totjorn"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7843,7 +4333,6 @@ msgstr "Istoric e escobilhièr"
 msgid "Don't leave traces"
 msgstr "Daissar pas cap de traças"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
@@ -7851,57 +4340,6 @@ msgstr ""
 "usatge;utilizacion;usança;recents;istoric;istorial;fichiès;temporaris;tmp;"
 "privat;confidencialitat;escobilhièr;banasta;pobèlla;bordilhièr;purgar;purga;"
 "servar;conservar;memorizar;gardar;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Deu correspondre a l’adreça Web de vòstre provesidor d’accès."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "L'apondon del compte a fracassat"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Los senhals concòrdan pas."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "L'enregistrament del compte a fracassat"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Impossible de s'autentificar alprèp d'aqueste domeni"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Impossible de jónher aqueste domeni"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Aqueste identificant de connexion fonciona pas.\n"
-"Reensajatz."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Aqueste senhal de connexion fonciona pas.\n"
-"Reensajatz."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "La connexion a aqueste domeni a fracassat"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Impossible de trobar aqueste domeni. Verificatz son ortografia."
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7955,10 +4393,6 @@ msgstr ""
 "Un compte d’entrepresa autoriza l’usatge d’un compte utilizaire centralizat "
 "a partir d'aqueste periferic. Permet tanben d’accedir als diferents sites de "
 "la companhiá presents sus Internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Recercar d'autres imatges"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8029,225 +4463,6 @@ msgstr "_Suprimir las emprentas"
 msgid "Fingerprint Enroll"
 msgstr "Aprentissatge d’una emprenta"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "aqueste aparelh deu èsser declarat per realizar aquesta accion"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "aqueste aparelh es ja declarat per un autre processús"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "avètz pas la permission de realizar l’accion"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "cap d’inscripcion marcada"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Fracàs de la comunicacion amb l’aparelh pendent l’inscripcion"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Fracàs de la comunicacion amb lo lector d'emprentas digitalas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Fracàs de la comunicacion amb lo daemon d'emprentas digitalas"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Fracàs del cargament de la lista d’emprentas : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Fracàs de la supression de las emprentas enregistradas : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Poce esquèrre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Major esquèrre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Indèx _esquèrra"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Anular esquèrre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Auricular esquèrre"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Poce dreit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Major dreit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Indèx _dreit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Anular dreit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Auricular dreit"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Det desconegut"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Acabat"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Lector d’emprentas desconnectat"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "L’espaci d’emmagazinatge del lector d'emprentas digitalas es plen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Fracàs de l’aprentissatge de l’emprenta novèla"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "L’aprentissatge a pas pogut s’aviar : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Fracàs de l’aprentissatge de l’emprenta novèla"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Fracàs de l'arrèst de l’inscripcion de l’emprenta digitala : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Plaçatz lo det sul lector d'emprentas digitalas mantun còp per inscriure "
-"vòstra emprenta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Renovar l’inscripcion d’aqueste det…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Enregistrar una emprenta novèla"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Impossible de desliurar lo lector d'emprentas digitalas%s : %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problèma pendent la lectura de l’aparelh"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr ""
-"Fracàs de la temptativa de revendicacion del lector d'emprentas "
-"digitalas %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr ""
-"Fracàs de la temptativa d’obtencion del lector d'emprentas digitalas : %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Aquesta setmana"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "La setmana passada"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %B de %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Fin de session"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Començament de session"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "Activitat del compte de %s"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Precedenta"
@@ -8255,18 +4470,6 @@ msgstr "Precedenta"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Seguenta"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Causissètz un autre senhal."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Picatz tornamai vòstre senhal actual."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Lo senhal pòt pas èsser modificat"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8288,6 +4491,10 @@ msgstr "Senhal novèl"
 msgid "Confirm Password"
 msgstr "Confirmar lo senhal"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Los senhals concòrdan pas."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Autoriser l’utilizaire a changer son senhal a la prochaine connexion"
@@ -8295,135 +4502,6 @@ msgstr "Autoriser l’utilizaire a changer son senhal a la prochaine connexion"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Definir un senhal ara"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Impossible de rejónher aqueste tipe de domeni automaticament"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Cap de domeni pas trobat"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Impossible de se connectar en tant que %s al domeni %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Senhal invalid, ensajatz tornamai"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Connexion al domeni %s impossible : %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "La supression de l'utilizaire a fracassat"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "La revocacion de l'utilizaire gerit a distància a fracassat"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Podètz pas suprimir vòstre pròpri compte."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s es encara connectat"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Suprimir un utilizaire mentre qu'es connectat pòt daissar lo sistèma dins un "
-"estat instable."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Volètz conservar los fichièrs de %s ?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Es possible de conservar lo repertòri personal, los corrièrs electronics en "
-"espèra (lo « spool ») e los fichièrs temporaris d'un compte d'utilizaire al "
-"moment de sa supression."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Suprimir los fichièrs"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Conservar los fichièrs"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Sètz segur que volètz revocar lo compte distant de %s ?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Suprimir"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Compte desactivat"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "De definir al moment de la connexion que ven"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Pas cap"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Connectat"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "La connexion al servici dels comptes a fracassat"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Verificatz qu'AccountService es installat e activat."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Devètz desverrolhar aqueste panèl per modificar aqueste paramètre"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Suprimir lo compte d'utilizaire seleccionat"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Per suprimir lo compte d'utilizaire seleccionat,\n"
-"clicatz primièr sus l'icòna *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Desverrolhar per apondre d'utilizaires e modificar los paramètres"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8451,7 +4529,6 @@ msgid "Full name"
 msgstr "Nom complèt"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Modificar"
 
@@ -8513,7 +4590,6 @@ msgstr "Desverrolhatz per crear un compte d'utilizaire."
 msgid "Add or remove users and change your password"
 msgstr "Apondre o suprimir d'utilizaires e modificar vòstre senhal"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8558,178 +4634,6 @@ msgstr "Gerir los comptes utilizaire"
 msgid "Authentication is required to change user data"
 msgstr "Autentificacion requesida per modificar las donadas utilizaire"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Lo senhal novèl deu èsser diferent de l'ancian."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Ensajatz de cambiar qualques letras e chifras."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Ensajatz de modificar un pauc mai lo senhal."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Un senhal que conten pas vòstre nom d'utilizaire seriá pus fòrt."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Ensajatz d'incorporar pas vòstre patronim dins lo senhal."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Ensajatz d'evitar d'unas mots contenguts dins lo senhal."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Ensajatz d'evitar de mots usuals."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Ensajatz d'evitar de rearrengar los mots existents."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Ensajatz d'utilizar mai de chifras."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Ensajatz d'utilizar mai de letras majusculas."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Ensajatz d'utilizar mai de letras minisculas."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Ensajatz d'utilizar mai de caractèrs especials, coma las pontuacions."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Ensajatz d'utilizar una mescla de letras, de chifras e de pontuacions."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Ensajatz d'evitar la repeticion del meteis caractèr."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Ensajatz d'evitar la repeticion del meteis caractèr : vos cal mesclar de "
-"letras, de chifras e de pontuacions."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Ensajatz d'evitar de sequéncias talas coma 1234 o abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Lo senhal deu èsser mai long. Ensajatz d’apondre de letras, de chifras e de "
-"pontuacions."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Mesclatz de majusculas, de minusculas e tanben un o dos nombres."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "L’apondre de letras, de chifras e de pontuacions renforçarà lo senhal."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Fracàs d'autentificacion"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Lo senhal novèl es tròp cort"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Lo senhal novèl es tròp simple"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "L'ancian e lo senhal novèl son tròp semblants"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Lo senhal novèl es ja estat utilizat recentament."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Lo senhal novèl deu conténer de caractèrs especials o numerics"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "L'ancian e lo novèl senhal son identics"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Vòstre senhal es estat modificat dempuèi que vos sètz autentificat !"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Lo senhal novèl compòrta pas pro de caractèrs diferents"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Error desconeguda"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Un nom d’utilizaire conten pas, en principi, que de letras minusculas o "
-"majusculas de a a z e un d'aqueles caractèrs : - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"O planhèm, aqueste nom d’utilizaire es pas disponible. Causissètz-ne un "
-"autre."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Lo nom d'utilizaire es tròp long."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8763,54 +4667,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Marrit clic detectat, reaviada…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Boton %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Definit per l’aplicacion"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Mandar las quichadas sus las tòcas"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Inversar l'ecran"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Afichar l'ajuda a l'ecran"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tauleta montada sul portatil"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tauleta montada per un monitor extèrn"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Aparelh tauleta extèrna"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
-#, fuzzy
-#| msgid "External tablet device"
 msgid "External pad device"
 msgstr "Aparelh tauleta extèrna"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Totes los ecrans"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8908,22 +4768,6 @@ msgstr "Clic del boton dreit de la mirga"
 msgid "Forward"
 msgstr "En avant"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Estilò aerograf amb pression, enclinason, e barra de desfilament"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Estilò aerograf amb pression, enclinason, e rotacion"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Estilò aerograf amb pression e enclinason"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Estilò aerograf amb pression"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tauleta  Wacom"
@@ -8934,54 +4778,96 @@ msgstr ""
 "Associar los botons e ajustar la sensibilitat de l'estilet de las tauleta s "
 "graficas"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tauleta ;Wacom;Stylet;Goma;Mirga;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Acorchi novèl…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulacion del clic segondari"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Logicials Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Toner gaireben agotat"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Segondari"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Logicials Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Gerir las preferéncias per la productivitat e multi prètzfach"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Punts d’accès"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Apondre"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Enregistrar"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operacion anullada"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Error :</b> accès refusat en modificant los paramètres"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Error :</b> error de l’aparelh mobil"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Pas enregistrat"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Enregistrat"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Itinerància"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Recèrca"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Refusat"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9011,212 +4897,13 @@ msgstr "Numèro personal"
 msgid "Device Details"
 msgstr "Detalhs del periferic"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricant"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Version del micrologicial"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G sonque"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G sonque"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G sonque"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "5G sonque"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (Preferida), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (Preferida), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (Preferida), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Preferida), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Preferida), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (Preferida), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (Preferida), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (Preferida), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (Preferida), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (Preferida), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (Preferida), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (Preferida), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (Preferida), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (Preferida), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (Preferida), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (Preferida), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (Preferida)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (Preferida), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Desconegut"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Desverrolhar la carta SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Desverrolhar"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Picatz lo còdi PIN per la carta SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Picatz lo còdi PIN per desverrolhar la carta SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Picatz lo còdi PUK per la carta SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Picatz lo còdi PUK per desverrolhar la carta SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9231,26 +4918,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Vos demòra %u ensag"
 msgstr[1] "Vos demòran %u ensages"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Marrit senhal picat."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Lo còdi PIM deu èsser un nombre de 8 chifras"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Picatz lo novèl còdi PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Lo còdi PIM deu èsser un nombre de 4 a 8 chifras"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Desverrolhatge…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9308,94 +4975,6 @@ msgstr "Verrolhar las carta SIM amb PIN"
 msgid "M_odem Details"
 msgstr "Detalhs del m_odem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Error del telefòn"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Cap de connexion al telefòn"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operacion pas permesa"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operacion pas presa en carga"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Carta SIM es pas inserida"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Còdi PIN de la SIM requerit"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Còdi PUK de la SIM requerit"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Fracàs de la SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Carta SIM occupada"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Senhal incorrècte"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Còdi PIN2 de la SIM requerit"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Còdi PUK2 de la SIM requerit"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Pas trobat"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Cap de servici telefonic"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Relambi d'espèra de la ret"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Servicis GPRS pas autorizats"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "L’itinerància es pas permesa dins aqueste airal"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Error GPRS pas especificada"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Cap d’error"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Accion anullada"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Accès refusat"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Error desconeguda"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Mòde de ret"
@@ -9411,11 +4990,6 @@ msgstr "Causir la ret"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Actualizar la lista dels operators"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9473,7 +5047,6 @@ msgstr "Ret mobila"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configurar la telefonia e las connexion de donadas mobil"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "mobil;wwan;telefòn;sim;telefonet;portable;"
@@ -9490,41 +5063,13 @@ msgstr "Paramètres es l’interfàcia principala de configuracion del sistèma.
 msgid "The GNOME Project"
 msgstr "Lo projècte GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Afichar lo numèro de la version"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Activar lo mòde verbós"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Recercar la cadena"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Fa la lista dels noms possibles de panèls e quita"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panèl d'afichar"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANÈL] [ARGUMENT…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Categorias de paramètres"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Confidencialitat"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Panèls disponibles :"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9582,7 +5127,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Anullar la recèrca"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferéncias;Paramètres;Reglatges;"
@@ -9624,8 +5168,6 @@ msgstr ""
 "Un tuple que conten la largor e nautor inicialas e l'estat maximizat de la "
 "fenèstra de l’aplicacion."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9633,8 +5175,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u sortida"
 msgstr[1] "%u sortidas"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9642,9 +5182,3049 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u entrada"
 msgstr[1] "%u entradas"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sons sistèma"
+#~ msgid "System Bus"
+#~ msgstr "Bus sistèma"
+
+#~ msgid "Full access"
+#~ msgstr "Accès complet"
+
+#~ msgid "Session Bus"
+#~ msgstr "Bus de session"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Accès complet a /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "A accès a la ret"
+
+#~ msgid "Home"
+#~ msgstr "Dorsièr personal"
+
+#~ msgid "Read-only"
+#~ msgstr "Lectura sola"
+
+#~ msgid "File System"
+#~ msgstr "Sistèma de fichièrs"
+
+#~ msgid "Can change settings"
+#~ msgstr "Pòt modificar los reglatges"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "Las permissions seguentas son integradas a %s. Pòdon pas èsser "
+#~ "modificadas. Se aquelas permissions vos inquiètan, vos cal envisatjar de "
+#~ "suprimir aquesta aplicacion."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u tipe de fichièr e ligam dubèrt per l’aplicacion"
+#~ msgstr[1] "%u tipes de fichièr e ligam dubèrts per l’aplicacion"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> dubrís aquestes tipes de fichièrs e ligams."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s de l’espaci disc utilizat."
+
+#~ msgid "Select a picture"
+#~ msgstr "Seleccionar un imatge"
+
+#~ msgid "_Open"
+#~ msgstr "_Dobrir"
+
+#~ msgid "multiple sizes"
+#~ msgstr "mantuna talha"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Pas cap de rèireplan de burèu"
+
+#~ msgid "Current background"
+#~ msgstr "Rèireplan actual"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Pausatz vòstra sonda d’escandalhatge sul carrat e quichatz sus « Aviar »"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Desplaçatz vòstra sonda d’escandalhatge cap a l’emplaçament d'escandalhar "
+#~ "e quichatz sus « Contunhar »"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Desplaçatz vòstra sonda d’escandalhatge a l’aplomb de l’emplaçament "
+#~ "d'escandalhar e quichatz sus « Contunhar »"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Rabatètz l'ecran"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Una error intèrna irrecuperabla s'es produita."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Las aisinas necessàrias a l'escandalhatge son pas installadas."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Lo perfil a pas pogut èsser generat."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Lo punt blanc especificat es pas disponible."
+
+#~ msgid "Complete!"
+#~ msgstr "Acabat !"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Fracàs de l'escandalhatge !"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Podètz levar la sonda d'escandalhatge."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Toquetz pas a la sonda d'escandalhatge pendent lo processus"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Ecran de portable"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Webcam integrada"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Ecran %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Numerizar %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Aparelh de fòto %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Imprimenta %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webcam %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Activar la gestion de las colors de %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Afichar los perfils de colors de %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Pas escandalhat"
+
+#~ msgid "Default: "
+#~ msgstr "Per defaut : "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Espaci colorimetric : "
+
+#~ msgid "Test profile: "
+#~ msgstr "Perfil de pròva : "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Seleccionatz un fichièr de perfil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importar"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Perfils ICC preses en carga"
+
+#~ msgid "All files"
+#~ msgstr "Totes los fichièrs"
+
+#~ msgid "Save Profile"
+#~ msgstr "Enregistrar lo perfil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Crear un perfil de color pel periferic seleccionat"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "L'instrument de mesura es pas detectat. Verificatz qu'es alucat e "
+#~ "connectat corrèctament."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "L'instrument de mesura pren pas en carga los perfils d'imprimenta."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Lo tipe de periferic es pas actualament pres en carga."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espaci de colors estandard"
+
+#~ msgid "Test Profile"
+#~ msgstr "Perfil de pròva"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatic"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Bassa qualitat"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Qualitat mejana"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Nauta qualitat"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RVB per defaut"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMJN per defaut"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Gris per defaut"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Donadas d'escandalhatge d'usina del fabricant"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "Correccion de l'ecran en mòde ecran complet impossibla amb aqueste perfil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Benlèu qu'aqueste perfil es pas mai precís"
+
+#~ msgid "Other…"
+#~ msgstr "Autre…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Desverrolhar per modificar los paramètres"
+
+#~ msgid "Today"
+#~ msgstr "Uèi"
+
+#~ msgid "Yesterday"
+#~ msgstr "Ièr"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d ora"
+#~ msgstr[1] "%d oras"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuta"
+#~ msgstr[1] "%d minutas"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d segonda"
+#~ msgstr[1] "%d segondas"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Punt d’accès"
+
+#~ msgid "24-hour"
+#~ msgstr "24 oras"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B de %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B de %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Enviar de rapòrts o senhalar de problèmas tecnics nos ajuda a melhorar "
+#~ "%s. Los rapòrts son enviats anonimament e son netejat de tota donada "
+#~ "personala. %s"
+
+#~ msgid "On"
+#~ msgstr "I"
+
+#~ msgid "Off"
+#~ msgstr "O"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Aplicar los cambiaments ?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Los cambiaments pòdon pas èsser aplicats"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Aquò pòt venir de limitacions materialas."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Païsatge"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Retrait sus la dreita"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Retrait sus l'esquèrra"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Païsatge (revirat)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Aviada segura activa"
+
+#, fuzzy
+#~| msgid ""
+#~| "Secure boot prevents malicious software from being loaded when the "
+#~| "device starts.\n"
+#~| "\n"
+#~| "For more information, contact the hardware manufacturer or IT support."
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "L’aviada segura empacha los logicials malvolents de se cargar quand "
+#~ "l’aparelh avia.\n"
+#~ "\n"
+#~ "Per mai d’informacions, contactatz lo fabricants del material o "
+#~ "l’assisténcia tecnica."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "L’aviada segura a de problèmas"
+
+#, fuzzy
+#~| msgid ""
+#~| "Secure boot prevents malicious software from being loaded when the "
+#~| "device starts.\n"
+#~| "\n"
+#~| "For more information, contact the hardware manufacturer or IT support."
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "L’aviada segura empacha los logicials malvolents de se cargar quand "
+#~ "l’aparelh avia.\n"
+#~ "\n"
+#~ "Per mai d’informacions, contactatz lo fabricants del material o "
+#~ "l’assisténcia tecnica."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "L’aviada segura es atuda"
+
+#, fuzzy
+#~| msgid ""
+#~| "Secure boot prevents malicious software from being loaded when the "
+#~| "device starts.\n"
+#~| "\n"
+#~| "For more information, contact the hardware manufacturer or IT support."
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "L’aviada segura empacha los logicials malvolents de se cargar quand "
+#~ "l’aparelh avia.\n"
+#~ "\n"
+#~ "Per mai d’informacions, contactatz lo fabricants del material o "
+#~ "l’assisténcia tecnica."
+
+#~ msgid "Passed"
+#~ msgstr "Reüssit"
+
+#~ msgid "Failed"
+#~ msgstr "Fracàs"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "L’aparelh es confòrme al nivèl HSI %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Nivèl de seguretat 0"
+
+#~ msgid "Security Level 1"
+#~ msgstr "Nivèl de seguretat 1"
+
+#~ msgid "Security Level 2"
+#~ msgstr "Nivèl de seguretat 2"
+
+#~ msgid "Security Level 3"
+#~ msgstr "Nivèl de seguretat 3"
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Los nivèls de seguretat son pas disponibles per aqueste aparelh."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "L’aviada segura a de problèmas"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "D’unas proteccions quand l’aparelh es aviat."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "L’aviada segura es atuda"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Cap de proteccion a l’aviada de l’aparelh."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Exposat a de menaças de seguretat grèvas."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Proteccion limitada contra de menaças de seguretat simplas."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Protegit contra de menaças de seguretat comunas."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Protegit contra una plaja larga de menaças de seguretat."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Proteccion complèta"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Proteccion d’escritura del micrologicial"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Verrolh de proteccion d’escritura del micrologicial"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Region del micrologicial de BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Descriptor del micrologicial de BIOS"
+
+#, fuzzy
+#~| msgid "No Protection"
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Pas cap de proteccion"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard aviada verificada"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM protegit"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Error de politica Intel BootGuard"
+
+#, fuzzy
+#~| msgid "Intel BootGuard"
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET activat"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "RAM chifrada"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Proteccion IOMMU"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Memòria d'escambi Linux"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Metre en velha en RAM"
+
+#, fuzzy
+#~| msgid "Suspend-to-idle"
+#~ msgid "Suspend To Idle"
+#~ msgstr "Ivernada-quand-inactiu"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "clau de platafòrma UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Aviada segura UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Configuracion de la platafòrma TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Mesas a jorn del micrologicial"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Atestacion d’integritat del micrologicial"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Verificador de l’actualizador de micrologicial"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Platafòrma de desbugatge"
+
+#, fuzzy
+#~| msgid "No Protection"
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Pas cap de proteccion"
+
+#, fuzzy
+#~| msgid "Minimal Protection"
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Proteccion minimala"
+
+#, fuzzy
+#~| msgid "Minimal Security Protections"
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Proteccions de seguretat minimalas"
+
+#~ msgid "Valid"
+#~ msgstr "Valid"
+
+#~ msgid "Not Valid"
+#~ msgstr "Pas valid"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Pas activat"
+
+#~ msgid "Locked"
+#~ msgstr "Verrolhat"
+
+#~ msgid "Not Locked"
+#~ msgstr "Pas verrolhat"
+
+#~ msgid "Encrypted"
+#~ msgstr "Chifrat"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Pas chifrat"
+
+#, fuzzy
+#~| msgid "Not calibrated"
+#~ msgid "Not Tainted"
+#~ msgstr "Pas escandalhat"
+
+#~ msgid "Found"
+#~ msgstr "Trobat"
+
+#~ msgid "Not Found"
+#~ msgstr "Pas trobat"
+
+#~ msgid "Supported"
+#~ msgstr "Pres en carga"
+
+#~ msgid "Not Supported"
+#~ msgstr "Pas pres en carga"
+
+#~ msgid "Unknown"
+#~ msgstr "Desconegut"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Desconegut"
+
+#~ msgid "Not Available"
+#~ msgstr "Pas disponibla"
+
+#~ msgid "System Logo"
+#~ msgstr "Logotipe sistèma"
+
+#~ msgid "No input sources found"
+#~ msgstr "Cap de font d'entrada pas trobada"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Autre"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Acorchis personalizats"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Las claus de caractèrs s'utilizan per picar de caractèrs addicionals. De "
+#~ "còps que i a son imprimits coma una tèrça opcion sul clavièr."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt d'esquèrra"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt de dreita"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Ctrl d'esquèrra"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Ctrl de dreita"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Clau de menú"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl de dreita"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "La tòca de composicion permet de picar una brava varietat de caractèrs. "
+#~ "Per l’utilizar, tenètz-la quichada e quichatz una sequéncia de caractèrs. "
+#~ "Per exemple, la tòca de composicion seguida de <b>C</b> e <b>o</b> donarà "
+#~ "<b>©</b>, <b>a</b> seguit de <b>'</b> donarà <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Verr.Maj."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Verrolhatge del desfilament"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Imp. Ecr."
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Òm pòt bascular las fonts d’entradas en utilizant l’acorchi de clavièr "
+#~ "%s.\n"
+#~ "Se pòt modificar aqueste acorchi de clavièr dins las preferéncias del "
+#~ "clavièr."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificat"
+#~ msgstr[1] "%d modificats"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Reïnicializar totes los acorchis ?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Reïnicializar totes los acorchis pòt tanben afectar vòstres acorchis "
+#~ "personalizats. Aquesta accion es irreversibla."
+
+#~ msgid "Reset All"
+#~ msgstr "Reïnicializar tot"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s es ja utilizat per %s. Se lo remplaçatz, %s serà desactivat"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Picar lo novèl acorchi"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Definir un acorchi personalizat"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Definir un acorchi"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Picatz un acorchi novèl per cambiar %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Apondre un acorchi personalizat"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Défilement a deux doigts"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinc clics, l'epòca GEGL !"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Clic-doble, boton principal"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Clic simple, boton principal"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Clic-doble, boton del mitan"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Clic simple, boton del mitan"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Clic-doble, boton segondari"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Clic simple, boton segondari"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager deu èsser en foncionament."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID : %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Ret pas segur (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Ret segur (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Ret segur (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Ret segur (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Ret segur"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "L’activacion del punt d’accès mena a la desconnexion de %s e serà pas "
+#~ "possible d’accedir a Internet en Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Deu conténer almens 8 caractèrs"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Interrompre lo punt d'accès e desconnectar totes los utilizaires ?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Interrompre lo punt d'accès"
+
+#~ msgid "Preserve"
+#~ msgstr "Conservar"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "Aleatòri"
+
+#~ msgid "Stable"
+#~ msgstr "Estable"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "L’adreça MAC picada aicí serà utilizada coma adreça materiala del "
+#~ "periferic de ret activat per aquesta connexion. Aquesta foncionalitat es "
+#~ "apelada « MAC cloning » o « spoofing ». Exemple : 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Perfil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Entrepresa"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Pas cap"
+
+#~ msgid "Never"
+#~ msgstr "Pas jamai"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Pas cap"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Feble"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Corrècte"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bon"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excellent"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Doblidar la connexion"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Suprimir lo perfil de la connexion"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Suprimir lo VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detalhs"
+
+#~ msgid "automatic"
+#~ msgstr "automatic"
+
+#~ msgid "Identity"
+#~ msgstr "Identitat"
+
+#~ msgid "Delete Address"
+#~ msgstr "Suprimir l'adreça"
+
+#~ msgid "Delete Route"
+#~ msgstr "Suprimir la rota"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Pas cap"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Clau WEP 40/128-bit (Hex o ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Frasa secreta WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinamic (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA e WPA2 privadas"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA e WPA2 d'entrepresa"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Impossible de dobrir l'editor de connexions"
+
+#~ msgid "New Profile"
+#~ msgstr "Perfil novèl"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Paramètre invalid %s : %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Paramètre invalid %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importar dempuèi un fichièr…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Apondre un VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Impossible d'importar la connexion VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Lo fichièr « %s » es ilegible o conten pas cap d’informacions de "
+#~ "connexion VPN reconegudas\n"
+#~ "\n"
+#~ "Error : %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Seleccionar lo fichièr d'importar"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Un fichièr nomenat « %s » existís ja."
+
+#~ msgid "_Replace"
+#~ msgstr "_Remplaçar"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Volètz remplaçar %s amb la connexion VPN en cors d'enregistrament ?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Impossible d'exportar la connexion VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "La connexion VPN « %s » a pas pogut èsser exportada cap a %s.\n"
+#~ "\n"
+#~ "Error : %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportacion de la connexion VPN"
+
+#~ msgid "never"
+#~ msgstr "pas jamai"
+
+#~ msgid "today"
+#~ msgstr "uèi"
+
+#~ msgid "yesterday"
+#~ msgstr "ièr"
+
+#~ msgid "Last used"
+#~ msgstr "Darrièra utilizacion"
+
+#~ msgid "Add new connection"
+#~ msgstr "Apondre una novèla connexion"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Las informacions de las rets seleccionadas, incluses los senhals e tota "
+#~ "configuracion personalizada seràn perduts."
+
+#~ msgid "_Forget"
+#~ msgstr "_Doblidar"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Rets Wi-Fi conegudas"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Doblidar"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Las règlas del sistèma interdison son utilizacion coma punt d'accès"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Lo periferic sens fial pren pas en carga lo mòde « punt d'accès »"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "« Web Proxy Autodiscovery » es utilizat quand cap d'URL de configuracion "
+#~ "es pas provesit."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Aquò es pas recomandat per de rets publicas pas seguras."
+
+#~ msgid "Status unknown"
+#~ msgstr "Estat desconegut"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Pas gerit"
+
+#~ msgid "Unavailable"
+#~ msgstr "Indisponible"
+
+#~ msgid "Connecting"
+#~ msgstr "Connexion en cors"
+
+#~ msgid "Authentication required"
+#~ msgstr "Autentificacion requesida"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Desconnexion en cors"
+
+#~ msgid "Connection failed"
+#~ msgstr "Fracàs de la connexion"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Estat desconegut (absent)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Fracàs de la configuracion"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Fracàs de la configuracion IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Configuracion IP expirada"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "D'elements secrets, pas provesits, èran necessaris"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Lo client 802.1x s'es desconnectat"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "La configuracion del client 802.1x a fracassat"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Lo client 802.1x a fracassat"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Lo client 802.1x a mes tròp de temps per s'autentificar"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Lo servici PPP a pas capitat de s'aviar"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Servici PPP desconnectat"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP a fracassat"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Lo client DHCP a pas capitat de s'aviar"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Error del client DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Lo client DHCP a fracassat"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Lo servici de connexion partejada a pas capitat de s'aviar"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Lo servici de connexion partejada a fracassat"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Lo servici autoIP a pas capitat de s'aviar"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Error del servici autoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Lo servici autoIP a fracassat"
+
+#~ msgid "Line busy"
+#~ msgstr "Linha ocupada"
+
+#~ msgid "No dial tone"
+#~ msgstr "Pas de tonalitat"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Cap de portadoira a pas pogut èsser establida"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Relambi de numerotacion depassat"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "La temptativa de numerotacion a fracassat"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "L'inicializacion del modèm a fracassat"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Fracàs de la seleccion de l'APN especificat"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Cap de recèrca de ret pas en cors"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Enregistrament a la ret refusat"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Relambi depassat per l'enregistrament a la ret"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Fracàs de l'enregistrament a la ret demandat"
+
+#~ msgid "PIN check failed"
+#~ msgstr "La verificacion del còdi PIN a fracassat"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Es possible que lo micrologicial del periferic manca"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "La connexion a desparegut"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Una connexion existenta es estada supausada"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modèm pas trobat"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "La connexion Bluetooth a fracassat"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "La carta SIM es pas inserida"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Lo còdi PIN de la SIM es necessari"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Lo còdi PUK de la SIM es requesit"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Marrida SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "La dependéncia de la connexion a fracassat"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Micrologicial absent"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cable desbrancat"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "error de seguretat desconeguda dins 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "cap de fichièr pas seleccionat"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "error desconeguda a la validacion del fichièr eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 o claus privadas PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certificat DER o PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "fichièr EAP-FAST PAC mancant"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Fichièrs PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "nom d’utilizaire d’EAP-LEAP mancant"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "senhal d’EAP-LEAP mancant"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "certificat CA d’EAP-PEAP invalid : %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "certificat CA d’EAP-PEAP invalid : cap de certificat pas especificat"
+
+#~ msgid "missing EAP username"
+#~ msgstr "nom d’utilizaire EAP mancant"
+
+#~ msgid "missing EAP password"
+#~ msgstr "senhal EAP mancant"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "identitat EAP-TLS mancanta"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TLS invalid : %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TLS invalid : cap de certificat pas especificat"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "clau privada EAP-TLS invalida : %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificat utilizaire EAP-TLS invalid : %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Las claus privadas pas chifradas son pas fisablas"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Sembla que la clau privada seleccionada es pas protegida per un senhal. "
+#~ "Aquò met en dangièr vòstres identificants. Seleccionatz una clau privada "
+#~ "protegida per senhal.\n"
+#~ "\n"
+#~ "(Podètz protegir vòstra clau per senhal amb openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Causissètz vòstre certificat personal"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Causissètz vòstra clau privada"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TTLS invalid : %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TTLS invalid : cap de certificat pas especificat"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Error desconeguda a la validacion de la seguretat de 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Seleccionar un fichièr"
+
+#~ msgid "missing leap-username"
+#~ msgstr "nom d’utilizaire leap mancant"
+
+#~ msgid "missing leap-password"
+#~ msgstr "senhal leap mancant"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Senhal Wi-Fi mancant."
+
+#~ msgid "missing wep-key"
+#~ msgstr "clau wep mancanta"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "clau wep invalida : una clau de %zu deu pas conténer que de caractèrs "
+#~ "exadecimals"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "clau wep invalida : una clau de %zu deu pas conténer que de caractèrs "
+#~ "ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "clau wep invalida : longor de clau %zu incorrècta. Deu èsser de 5 a 13 "
+#~ "caractèrs en ascii o de 10 a 26 en exa"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "clau wep invalida : frasa secreta pas completada"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "clau wep invalida : la frasa secreta deu conténer mens de 64 caractèrs"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk invalid : longor de clau %zu incorrècta. Deu èsser de [8,63] "
+#~ "octets o 64 caratèrs exadecimals"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk invalid : impossible de considerar una clau de 64 octets coma "
+#~ "exadecimala"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Autre"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s suprimit"
+
+#~ msgid "Error removing account"
+#~ msgstr "Error al moment de la supression del compte"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Compte %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Suprimir lo compte"
+
+#~ msgid "Unknown time"
+#~ msgstr "Durada desconeguda"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s abans cargament complet"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Atencion : demòra %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s restant"
+
+#~ msgid "Fully charged"
+#~ msgstr "Batariá plena"
+
+#~ msgid "Not charging"
+#~ msgstr "Pas en carga"
+
+#~ msgid "Empty"
+#~ msgstr "Descargada"
+
+#~ msgid "Charging"
+#~ msgstr "En carga"
+
+#~ msgid "Discharging"
+#~ msgstr "En descarga"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Mirga sens fial"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Clavièr sens fial"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Ondulator"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Assistent personal"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telefòn portable"
+
+#~ msgid "Media player"
+#~ msgstr "Lector multimèdia"
+
+#~ msgid "Tablet"
+#~ msgstr "Tauleta"
+
+#~ msgid "Computer"
+#~ msgstr "Ordenador"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Periferic d’entrada per jòcs"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principala"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Segondària"
+
+#~ msgid "Batteries"
+#~ msgstr "Batariás"
+
+#~ msgid "When _idle"
+#~ msgstr "Quand _inactiu"
+
+#~ msgid "Suspend"
+#~ msgstr "Metre en velha"
+
+#~ msgid "Power Off"
+#~ msgstr "Atudar"
+
+#~ msgid "Hibernate"
+#~ msgstr "Ivernar"
+
+#~ msgid "Nothing"
+#~ msgstr "Pas res"
+
+#~ msgid "When on battery power"
+#~ msgstr "Quand sus batariá"
+
+#~ msgid "When plugged in"
+#~ msgstr "Quand lo cable es brancat"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Pas jamai"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Mesa en _velha automatica"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Mòde performança temporàriament indisponible a causa d’una temperatura de "
+#~ "foncionament nauta."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Lap detectada : mòde performança temporàriament desactivat.Desplaçatz lo "
+#~ "periferic sus una susfàcia establa per restaurar."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Mòde performança temporàriament indisponible."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Batariá febla : estalviador d’energia activat. Lo mòde precedent serà "
+#~ "restablit un còp que la batariá aja sufisentament cargat."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Mòde estalvi activat per « %s »."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Mòde performança activat per « %s »."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Performança"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Performança e consomacion nautas."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Equilibri"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Performança e utilizacion energetica estandardas."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Estalviador d'energia"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Performança e utilizacion energetica reduchas."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "L’imprimenta « %s » es estada suprimida"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "L'apondon de la novèla imprimenta a fracassat."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Impossible de cargar l'interfàcia d'utilizaire : %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Desverrolhar per apondre d‘imprimentas e modificar los paramètres"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Informacions sus %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Cap de pilòt adeqüat pas trobat"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Seleccionatz un fichièr PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Fichièrs de descripcion PostScript de l'imprimenta (*.ppd, *.PPD, *.ppd."
+#~ "gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Imprimenta JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Imprimenta LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Recto"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Bòrd long (estandard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Bòrd cort (revirat)"
+
+#~ msgid "Portrait"
+#~ msgstr "Retrait"
+
+#~ msgid "Landscape"
+#~ msgstr "Païsatge"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Païsatge inversat"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Retrait inversat"
+
+#~ msgid "Resume"
+#~ msgstr "Reprendre"
+
+#~ msgid "Pause"
+#~ msgstr "En pausa"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "En espèra"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "En pausa"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autentificacion requesida"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Tractament en cors"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Arrestada"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Interrompuda"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Anullada"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Acabada"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Plaçar aqueste prètzfach ennaut de la fila"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - prètzfaits d’impression actius"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr ""
+#~ "Picatz vòstras informacions d’autentificacion per imprimir a partir de %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Desverrolhar lo servidor d’imprimentas"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Desverrolhar %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Picatz vòstre nom d’utilizaire e vòtre senhal per afichar las imprimentas "
+#~ "sus %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Recèrca d’imprimentas"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Pòrt seria"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Pòrt parallèl"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Emplaçament : %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adreça : %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Lo servidor necessita una autentificacion"
+
+#~ msgid "Two Sided"
+#~ msgstr "Recto verso"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tipe de papièr"
+
+#~ msgid "Paper Source"
+#~ msgstr "Font del papièr"
+
+#~ msgid "Output Tray"
+#~ msgstr "Nauc de sortida"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolucion"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Prefiltratge GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Paginas per costat"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientacion"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "General"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Mesa en pagina"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opcions installablas"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Prètzfaits"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Qualitat de l'imatge"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Finicion"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avançat"
+
+#~ msgid "Test page"
+#~ msgstr "Pagina de pròva"
+
+#~ msgid "Auto Select"
+#~ msgstr "Seleccion automatica"
+
+#~ msgid "Printer Default"
+#~ msgstr "Opcion per defaut de l'imprimenta"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Incorporar solament las polissas GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Convertir en PS de nivèl 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Convertir en PS de nivèl 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Pas cap de prefiltratge"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Netejatge de las tèstas d’impression"
+
+#~ msgid "Out of toner"
+#~ msgstr "Pas mai de toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Revelator gaireben agotat"
+
+#~ msgid "Out of developer"
+#~ msgstr "Pas mai de revelator"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Cartocha de color gaireben voida"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Cartocha de color voida"
+
+#~ msgid "Open cover"
+#~ msgstr " Tapador dobèrt"
+
+#~ msgid "Open door"
+#~ msgstr "Pòrta dobèrta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Gaireben pas mai de papièr"
+
+#~ msgid "Out of paper"
+#~ msgstr "Pas mai de papièr"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Fòra linha"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Arrestada"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr " Recipient de descais gaireben plen"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Recipient de descais plen"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Lo fotoconductor optic es gaireben en fin de vida"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Lo fotoconductor optic es pas mai en estat"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Prèsta"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Accèpta pas mai de prètzfaits suplementaris"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Tractament en cors"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metric"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Demandar de qué far"
+
+#~ msgid "Do nothing"
+#~ msgstr "Far pas res"
+
+#~ msgid "Open folder"
+#~ msgstr "Dobrir lo dorsièr"
+
+#~ msgid "Other Media"
+#~ msgstr "Autres mèdias"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Seleccionatz una aplicacion per vòstres CD àudio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Seleccionatz una aplicacion per vos DVD àudio"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Seleccionatz una aplicacion d'aviar quand un lector de musica es connectat"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Seleccionatz una aplicacion d'aviar quand un aparelh de fòto es connectat"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Seleccionatz una aplicacion pels CD que contenon de logicials"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD àudio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Disc Blu-ray verge"
+
+#~ msgid "blank CD disc"
+#~ msgstr "CD verge"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "DVD verge"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Disc HD DVD verge"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "disc vidèo Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "lector e-book"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "disc vidèo HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Cd d’imatges"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super CD Vidèo"
+
+#~ msgid "Video CD"
+#~ msgstr "CD vidèo"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Atudament de l’ecran"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 segondas"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuta"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutas"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutas"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutas"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutas"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 ora"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutas"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutas"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutas"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutas"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutas"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutas"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutas"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutas"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Jamai"
+
+#~ msgid "Select Location"
+#~ msgstr "Seleccionar un emplaçament"
+
+#~ msgid "_OK"
+#~ msgstr "_D'acòrdi"
+
+#~ msgid "No applications found"
+#~ msgstr "Cap d'aplicacion pas trobada"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Cap de ret de partiment es pas seleccionada"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "I"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "O"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Activat"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Actiu"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Causir un dorsièr"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Activar lo partiment de mèdias"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Lo partiment de fichièrs vos permet de partejar vòstre dorsièr Public amb "
+#~ "los autres sus la ret actuala en utilizant  : %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Quand la connexion distanta es activada, los utilizaires distants se "
+#~ "pòdon connectar en utilizant la comanda Shell securizada :\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Activar lo partiment de fichièrs personals"
+
+#~ msgid "Device name copied"
+#~ msgstr "Nom del periferic copiat"
+
+#~ msgid "Device address copied"
+#~ msgstr "Adreça del periferic copiada"
+
+#~ msgid "Username copied"
+#~ msgstr "Nom d’utilizaire copiat"
+
+#~ msgid "Password copied"
+#~ msgstr "Senhal copiat"
+
+#~ msgid "Custom"
+#~ msgstr "Personalizada"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Pròva de %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100 %"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Desconnectat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Connexion en cors"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Connectat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Error d'autorizacion"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autorizacion en cors"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Foncionalitat reduita"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Connectats & Autorizats"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Desconegut"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorizat per :"
+
+#~ msgid "Connected at:"
+#~ msgstr "Connectat a :"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Inscrit dempuèi :"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Fracàs d'autorizacion del priferic : "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Impossible de doblidar lo periferic : "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Error"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorizat"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Lo sossistèma Thunderbolt (boltd) es pas installat o es mal configurat."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Sols los periferics USB e Display Port pòdon èsser connectats."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt a pas pogut èsser detectat.\n"
+#~ "Siá lo sistèma pren pas en carga Thunderbolt, siá es estat desactivat "
+#~ "dins lo BIOS, siá es parametrat sus un nivèl de seguretat pas pres en "
+#~ "carga dins lo BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr ""
+#~ "La presa en carga de Thunderbolt es estada desactivada dins lo BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Lo nivèl de seguretat Thunderbolt a pas pogut èsser determinat."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Error de bascula en mòde dirècte : %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Per defaut"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Mejan"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Grand"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Mai grand"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Lo mai grand"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixèl"
+#~ msgstr[1] "%d pixèls"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Corta"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ d'ecran"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ecran"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ d'ecran"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Longa"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 ora"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 jorn"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 jorns"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 jorns"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 jorns"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 jorns"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 jorns"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 jorns"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 jorns"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 jorns"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Voidar completament l'escobilhièr ?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Tot lo contengut de l'escobilhièr serà definitivament suprimit."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Voidar l'escobilhièr"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Suprimir totes los fichièrs temporaris ?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Totes los fichièrs temporaris seràn definitivament suprimits."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Purgar los fichièrs temporaris"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 jorn"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 jorns"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 jorns"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Totjorn"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Deu correspondre a l’adreça Web de vòstre provesidor d’accès."
+
+#~ msgid "Failed to add account"
+#~ msgstr "L'apondon del compte a fracassat"
+
+#~ msgid "Failed to register account"
+#~ msgstr "L'enregistrament del compte a fracassat"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Impossible de s'autentificar alprèp d'aqueste domeni"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Impossible de jónher aqueste domeni"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Aqueste identificant de connexion fonciona pas.\n"
+#~ "Reensajatz."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Aqueste senhal de connexion fonciona pas.\n"
+#~ "Reensajatz."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "La connexion a aqueste domeni a fracassat"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Impossible de trobar aqueste domeni. Verificatz son ortografia."
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Recercar d'autres imatges"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "aqueste aparelh deu èsser declarat per realizar aquesta accion"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "aqueste aparelh es ja declarat per un autre processús"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "avètz pas la permission de realizar l’accion"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "cap d’inscripcion marcada"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Fracàs de la comunicacion amb l’aparelh pendent l’inscripcion"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Fracàs de la comunicacion amb lo lector d'emprentas digitalas"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Fracàs de la comunicacion amb lo daemon d'emprentas digitalas"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Fracàs del cargament de la lista d’emprentas : %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Fracàs de la supression de las emprentas enregistradas : %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Poce esquèrre"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Major esquèrre"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Indèx _esquèrra"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Anular esquèrre"
+
+#~ msgid "Left little finger"
+#~ msgstr "Auricular esquèrre"
+
+#~ msgid "Right thumb"
+#~ msgstr "Poce dreit"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Major dreit"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Indèx _dreit"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Anular dreit"
+
+#~ msgid "Right little finger"
+#~ msgstr "Auricular dreit"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Det desconegut"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Acabat"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Lector d’emprentas desconnectat"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "L’espaci d’emmagazinatge del lector d'emprentas digitalas es plen"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Fracàs de l’aprentissatge de l’emprenta novèla"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "L’aprentissatge a pas pogut s’aviar : %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Fracàs de l’aprentissatge de l’emprenta novèla"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Fracàs de l'arrèst de l’inscripcion de l’emprenta digitala : %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Plaçatz lo det sul lector d'emprentas digitalas mantun còp per inscriure "
+#~ "vòstra emprenta"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Renovar l’inscripcion d’aqueste det…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Enregistrar una emprenta novèla"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Impossible de desliurar lo lector d'emprentas digitalas%s : %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problèma pendent la lectura de l’aparelh"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr ""
+#~ "Fracàs de la temptativa de revendicacion del lector d'emprentas "
+#~ "digitalas %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr ""
+#~ "Fracàs de la temptativa d’obtencion del lector d'emprentas digitalas : %s"
+
+#~ msgid "This Week"
+#~ msgstr "Aquesta setmana"
+
+#~ msgid "Last Week"
+#~ msgstr "La setmana passada"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %B de %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Fin de session"
+
+#~ msgid "Session Started"
+#~ msgstr "Començament de session"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "Activitat del compte de %s"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Causissètz un autre senhal."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Picatz tornamai vòstre senhal actual."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Lo senhal pòt pas èsser modificat"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Impossible de rejónher aqueste tipe de domeni automaticament"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Cap de domeni pas trobat"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Impossible de se connectar en tant que %s al domeni %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Senhal invalid, ensajatz tornamai"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Connexion al domeni %s impossible : %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "La supression de l'utilizaire a fracassat"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "La revocacion de l'utilizaire gerit a distància a fracassat"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Podètz pas suprimir vòstre pròpri compte."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s es encara connectat"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Suprimir un utilizaire mentre qu'es connectat pòt daissar lo sistèma dins "
+#~ "un estat instable."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Volètz conservar los fichièrs de %s ?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Es possible de conservar lo repertòri personal, los corrièrs electronics "
+#~ "en espèra (lo « spool ») e los fichièrs temporaris d'un compte "
+#~ "d'utilizaire al moment de sa supression."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Suprimir los fichièrs"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Conservar los fichièrs"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Sètz segur que volètz revocar lo compte distant de %s ?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Suprimir"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Compte desactivat"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "De definir al moment de la connexion que ven"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Pas cap"
+
+#~ msgid "Logged in"
+#~ msgstr "Connectat"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "La connexion al servici dels comptes a fracassat"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Verificatz qu'AccountService es installat e activat."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Devètz desverrolhar aqueste panèl per modificar aqueste paramètre"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Suprimir lo compte d'utilizaire seleccionat"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Per suprimir lo compte d'utilizaire seleccionat,\n"
+#~ "clicatz primièr sus l'icòna *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Desverrolhar per apondre d'utilizaires e modificar los paramètres"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Lo senhal novèl deu èsser diferent de l'ancian."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Ensajatz de cambiar qualques letras e chifras."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Ensajatz de modificar un pauc mai lo senhal."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Un senhal que conten pas vòstre nom d'utilizaire seriá pus fòrt."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Ensajatz d'incorporar pas vòstre patronim dins lo senhal."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Ensajatz d'evitar d'unas mots contenguts dins lo senhal."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Ensajatz d'evitar de mots usuals."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Ensajatz d'evitar de rearrengar los mots existents."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Ensajatz d'utilizar mai de chifras."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Ensajatz d'utilizar mai de letras majusculas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Ensajatz d'utilizar mai de letras minisculas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Ensajatz d'utilizar mai de caractèrs especials, coma las pontuacions."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Ensajatz d'utilizar una mescla de letras, de chifras e de pontuacions."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Ensajatz d'evitar la repeticion del meteis caractèr."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Ensajatz d'evitar la repeticion del meteis caractèr : vos cal mesclar de "
+#~ "letras, de chifras e de pontuacions."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Ensajatz d'evitar de sequéncias talas coma 1234 o abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Lo senhal deu èsser mai long. Ensajatz d’apondre de letras, de chifras e "
+#~ "de pontuacions."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Mesclatz de majusculas, de minusculas e tanben un o dos nombres."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "L’apondre de letras, de chifras e de pontuacions renforçarà lo senhal."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Fracàs d'autentificacion"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Lo senhal novèl es tròp cort"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Lo senhal novèl es tròp simple"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "L'ancian e lo senhal novèl son tròp semblants"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Lo senhal novèl es ja estat utilizat recentament."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Lo senhal novèl deu conténer de caractèrs especials o numerics"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "L'ancian e lo novèl senhal son identics"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Vòstre senhal es estat modificat dempuèi que vos sètz autentificat !"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Lo senhal novèl compòrta pas pro de caractèrs diferents"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Error desconeguda"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Un nom d’utilizaire conten pas, en principi, que de letras minusculas o "
+#~ "majusculas de a a z e un d'aqueles caractèrs : - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "O planhèm, aqueste nom d’utilizaire es pas disponible. Causissètz-ne un "
+#~ "autre."
+
+#~ msgid "The username is too long."
+#~ msgstr "Lo nom d'utilizaire es tròp long."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Boton %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Definit per l’aplicacion"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Mandar las quichadas sus las tòcas"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Inversar l'ecran"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Afichar l'ajuda a l'ecran"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tauleta montada sul portatil"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tauleta montada per un monitor extèrn"
+
+#~ msgid "External tablet device"
+#~ msgstr "Aparelh tauleta extèrna"
+
+#~ msgid "All Displays"
+#~ msgstr "Totes los ecrans"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Estilò aerograf amb pression, enclinason, e barra de desfilament"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Estilò aerograf amb pression, enclinason, e rotacion"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Estilò aerograf amb pression e enclinason"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Estilò aerograf amb pression"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Acorchi novèl…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operacion anullada"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Error :</b> accès refusat en modificant los paramètres"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Error :</b> error de l’aparelh mobil"
+
+#~ msgid "Not Registered"
+#~ msgstr "Pas enregistrat"
+
+#~ msgid "Registered"
+#~ msgstr "Enregistrat"
+
+#~ msgid "Roaming"
+#~ msgstr "Itinerància"
+
+#~ msgid "Searching"
+#~ msgstr "Recèrca"
+
+#~ msgid "Denied"
+#~ msgstr "Refusat"
+
+#~ msgid "2G Only"
+#~ msgstr "2G sonque"
+
+#~ msgid "3G Only"
+#~ msgstr "3G sonque"
+
+#~ msgid "4G Only"
+#~ msgstr "4G sonque"
+
+#~ msgid "5G Only"
+#~ msgstr "5G sonque"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (Preferida)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (Preferida), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (Preferida), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (Preferida), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Preferida)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Preferida), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Preferida), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (Preferida)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (Preferida), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (Preferida), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (Preferida)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (Preferida), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (Preferida), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (Preferida)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (Preferida), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (Preferida), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Preferida)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Preferida), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Preferida)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Preferida), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Preferida)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Preferida), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (Preferida)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (Preferida), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Preferida)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (Preferida), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (Preferida)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (Preferida), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Desconegut"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Desverrolhar la carta SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Picatz lo còdi PIN per la carta SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Picatz lo còdi PIN per desverrolhar la carta SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Picatz lo còdi PUK per la carta SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Picatz lo còdi PUK per desverrolhar la carta SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Marrit senhal picat."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Lo còdi PIM deu èsser un nombre de 8 chifras"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Picatz lo novèl còdi PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Lo còdi PIM deu èsser un nombre de 4 a 8 chifras"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Desverrolhatge…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Error del telefòn"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Cap de connexion al telefòn"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operacion pas permesa"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operacion pas presa en carga"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Carta SIM es pas inserida"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Còdi PIN de la SIM requerit"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Còdi PUK de la SIM requerit"
+
+#~ msgid "SIM failure"
+#~ msgstr "Fracàs de la SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "Carta SIM occupada"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Senhal incorrècte"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Còdi PIN2 de la SIM requerit"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Còdi PUK2 de la SIM requerit"
+
+#~ msgid "Not found"
+#~ msgstr "Pas trobat"
+
+#~ msgid "No network service"
+#~ msgstr "Cap de servici telefonic"
+
+#~ msgid "Network timeout"
+#~ msgstr "Relambi d'espèra de la ret"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Servicis GPRS pas autorizats"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "L’itinerància es pas permesa dins aqueste airal"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Error GPRS pas especificada"
+
+#~ msgid "No Error"
+#~ msgstr "Cap d’error"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Accion anullada"
+
+#~ msgid "Access denied"
+#~ msgstr "Accès refusat"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Error desconeguda"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Afichar lo numèro de la version"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Activar lo mòde verbós"
+
+#~ msgid "Search for the string"
+#~ msgstr "Recercar la cadena"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Fa la lista dels noms possibles de panèls e quita"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panèl d'afichar"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANÈL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Panèls disponibles :"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sons sistèma"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Error : determinacion del nivèl HSI impossibla"
@@ -9654,9 +8234,6 @@ msgstr "Sons sistèma"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "Certificats DER o PEM (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Apondre una imprimenta…"
 
 #~ msgid "Drip"
 #~ msgstr "Gota d'aiga"
@@ -9833,8 +8410,8 @@ msgstr "Sons sistèma"
 #~ msgstr "Pas modificable"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Las permissions especificas a las aplicacions pòdon èsser examinadas dins "
 #~ "los reglatges de <a href=\"privacy\">Confidencialitat</a>."
@@ -10046,9 +8623,6 @@ msgstr "Sons sistèma"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tauleta  (absolut)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Pavat tactil (relatiu)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Preferéncias de la tauleta"
@@ -10925,9 +9499,6 @@ msgstr "Sons sistèma"
 #~ msgid "Mirrored"
 #~ msgstr "Clonats"
 
-#~ msgid "Secondary"
-#~ msgstr "Segondari"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Organizar los ecrans associats"
 
@@ -11429,9 +10000,6 @@ msgstr "Sons sistèma"
 #~ msgid "Scroll Up"
 #~ msgstr "Desfilament cap amont"
 
-#~ msgid "Scroll Down"
-#~ msgstr "Desfilament cap aval"
-
 #~ msgid "Scroll Right"
 #~ msgstr "Desfilament cap a dreita"
 
@@ -11572,9 +10140,6 @@ msgstr "Sons sistèma"
 #~ msgctxt "touchpad pointer, speed"
 #~ msgid "Fast"
 #~ msgstr "Rapida"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Desac_tivar al moment de la picada"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr ""
@@ -12450,9 +11015,6 @@ msgstr "Sons sistèma"
 
 #~ msgid "Remove Language"
 #~ msgstr "Suprimir la lenga"
-
-#~ msgid "Install languages..."
-#~ msgstr "Installar de lengas..."
 
 #~ msgid "Select a region (change will be applied the next time you log in)"
 #~ msgstr ""

--- a/po/oc.po~
+++ b/po/oc.po~
@@ -1,0 +1,12580 @@
+# Occitan translation of gnome-control-center.
+# Copyright (C) 1998-2012 Free Software Foundation, Inc.
+# This file is under the same license as the gnome-control-center package.
+# Cédric Valmary (Tot en òc) <cvalmary@yahoo.fr>, 2015.
+# Cédric Valmary (totenoc.eu) <cvalmary@yahoo.fr>, 2016, 2018.
+# Cedric <cvalmary@yahoo.fr>, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center HEAD\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-10-25 14:38+0000\n"
+"PO-Revision-Date: 2022-11-07 20:05+0100\n"
+"Last-Translator: Quentin PAGÈS\n"
+"Language-Team: Tot en òc\n"
+"Language: oc\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.2.1\n"
+"X-DamnedLies-Scope: partial\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Bus sistèma"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Accès complet"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Bus de session"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Periferics"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Accès complet a /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Ret"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "A accès a la ret"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Dorsièr personal"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Lectura sola"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Sistèma de fichièrs"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Paramètres"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Pòt modificar los reglatges"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"Las permissions seguentas son integradas a %s. Pòdon pas èsser modificadas. "
+"Se aquelas permissions vos inquiètan, vos cal envisatjar de suprimir aquesta "
+"aplicacion."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u tipe de fichièr e ligam dubèrt per l’aplicacion"
+msgstr[1] "%u tipes de fichièr e ligam dubèrts per l’aplicacion"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> dubrís aquestes tipes de fichièrs e ligams."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s de l’espaci disc utilizat."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicacions"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Pas cap d'aplicacion"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Installar…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Dobrir"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Veire los detalhs"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Recercar"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Recebre las recèrcas sistèma e enviar los resultats."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Desactivat"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificacions"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Afichar las notificacions sistèma"
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Executar en rèireplan"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Permetre l’activitat quand l’aplicacion es tampada."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Capturas d'ecran"
+
+#: panels/applications/cc-applications-panel.ui:141
+#, fuzzy
+#| msgid "Take pictures with the camera."
+msgid "Take pictures of the screen at any time."
+msgstr "Prendre de fòtos amb la camèra."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Cambiar lo rèireplan"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Modificar lo rèireplan."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sons"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Legir los sons."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Ignorar los acorchis"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Blocar los acorchis clavièr del sistèma estandard."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Camèra"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Prendre de fòtos amb la camèra."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Micrò"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Enregistrar d’àudio amb lo microfòn."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Servicis de localizacion"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Accès a las donadas de localizacion de l’aparelh."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Permissions integradas"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "L’accès sistèma es requerit per l’aplicacion"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Fichièr e associacions"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Emmagazinatge"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Cap de resultat pas trobat"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Ensajatz una autra recèrca"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Fichièr e associacions"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Tipes de fichièr"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Tipes de ligam"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Reïnicializar"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Espaci de disc consumit per aquesta aplicacion per sas donadas e son cache."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplicacion"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Donadas"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Escafar lo cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Contròla divèrsas permissions e reglatges d’aplicacion"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplicacion;flatpak;permission;reglatge;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Seleccionar un imatge"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Anullar"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Dobrir"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "mantuna talha"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Pas cap de rèireplan de burèu"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Rèireplan actual"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Estil"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Per defaut"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Escur"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Rèireplan"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Apondre un imatge…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aparéncia"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Remplaçar vòstre imatge de rèireplan o la color de l’interfàcia"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Papièr pintrat;rèireplan;Fons;Ecran;Burèu;Estil;Clar;Escur;Fosc;Aparéncia;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Activar"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Cap d'adaptator Bluetooth pas trobat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Brancatz la clau per utilizar lo Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth desactivat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Activatz per connectar de periferics e recebre de transferiments de fichièrs."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Mòde avion activat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Lo Bluetooth es desactivat en mòde avion."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Desactivar lo mòde avion"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Mòde avion material activat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Desactivatz lo mòde avion per activar lo Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Activa/desactiva lo Bluetooth e connècta vòstres periferics"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "partiment;partejar;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "La camèra es inactiva"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Cap d’aplicacion pòt pas capturar de fotografias o vidèos."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"L’utilizacion de la camèra permet a las aplicacions de prendre de fòtos e de "
+"vidèos. En la desactivant, es possible que certanas aplicacions foncionen "
+"pas corrèctament.\n"
+"\n"
+"Autoriatz las aplicacions çai-jos a utilizar la camèra."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Cap d’aplicacion a pas demandat l’accès a la camèra"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Protegir vòstres imatges"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camèra;fòto;fotografia;vidèo;webcam;verrolh;barrar;privat;confidencialitat;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Pausatz vòstra sonda d’escandalhatge sul carrat e quichatz sus « Aviar »"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Desplaçatz vòstra sonda d’escandalhatge cap a l’emplaçament d'escandalhar e "
+"quichatz sus « Contunhar »"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Desplaçatz vòstra sonda d’escandalhatge a l’aplomb de l’emplaçament "
+"d'escandalhar e quichatz sus « Contunhar »"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Rabatètz l'ecran"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Una error intèrna irrecuperabla s'es produita."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Las aisinas necessàrias a l'escandalhatge son pas installadas."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Lo perfil a pas pogut èsser generat."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Lo punt blanc especificat es pas disponible."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Acabat !"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Fracàs de l'escandalhatge !"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Podètz levar la sonda d'escandalhatge."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Toquetz pas a la sonda d'escandalhatge pendent lo processus"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Escandalhatge de l'ecran"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "A_viar"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Reprene"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Acabat"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Ecran de portable"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Webcam integrada"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Ecran %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Numerizar %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Aparelh de fòto %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Imprimenta %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webcam %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Activar la gestion de las colors de %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Afichar los perfils de colors de %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Pas escandalhat"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Per defaut : "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Espaci colorimetric : "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Perfil de pròva : "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Seleccionatz un fichièr de perfil ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importar"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Perfils ICC preses en carga"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Totes los fichièrs"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ecran"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Enregistrar lo perfil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Enregistrar"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Crear un perfil de color pel periferic seleccionat"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"L'instrument de mesura es pas detectat. Verificatz qu'es alucat e connectat "
+"corrèctament."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "L'instrument de mesura pren pas en carga los perfils d'imprimenta."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Lo tipe de periferic es pas actualament pres en carga."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Escandalhatge de l'ecran"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Qualitat de l'escandalhatge"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"L'escandalhatge va generar un perfil que poiretz utilizar per gerir la color "
+"de vòstre ecran. Mai l'escandalhatge es long, melhora es la qualitat del "
+"perfil de color."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Poiretz pas utilizar vòstre ordenador pendent l'escandalhatge."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Qualitat"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Durada estimada"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Sonda d'escandalhatge"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Seleccionatz la sonda que volètz utilizar per l'escandalhatge."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tipe d'ecran"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Seleccionatz lo tipe d'ecran qu'es connectat."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Punt blanc del perfil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Seleccionatz un punt blanc cibla per l'ecran. La màger part dels ecrans "
+"devon èsser escandalhats a l'illuminent D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Luminositat de l'ecran"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Reglatz la luminositat de l'ecran a una valor que vos es costumièra. La "
+"gestion de color serà pas mai fisabla."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Podètz tanben utilizar la luminositat ja definida dins d'autres perfils per "
+"aqueste periferic."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nom del perfil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Podètz utilizar lo meteis perfil de colors sus diferents ordenadors e tanben "
+"crear de perfils adaptats a diferentas condicions d'esclairatge."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nom del perfil :"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Resumit"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Perfil creat amb succès !"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copiar lo perfil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Necessita un mèdia inscriptible"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Aicí, podètz consultar de conselhs utils sus l'utilizacion d'un perfil <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e <a href="
+"\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Apondre un perfil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"I a un problèma. Es possible que lo perfil foncione pas corrèctament. <a "
+"href=\"\">Afichar los detalhs</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importar un fichièr…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Apondre"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Cada periferic a besonh d'un perfil de color a jorn per la presa en carga de "
+"las colors."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Per ne saber mai"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Per ne saber mai sus la gestion de las colors"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Definir per totes los utilizaires"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Definir aqueste perfil per totes los utilizaires d'aqueste ordenador"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "A_ctivar"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Apondre un perfil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "Escan_dalhar…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Escandalhar lo periferic"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Suprimir un perfil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "A_fichar los detalhs"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Impossible de detectar un periferic per gerir sa color"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projector"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (retroesclairatge CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (retroesclairatge de LED RVB)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (retroesclairatge de LED blancas)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD a gamut larg (retroesclairatge CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD de gamut larg (retroesclairatge de LED RVB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Elevada"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutas"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Mejana"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutas"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Bassa"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutas"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Nativa amb ecran"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (impression e publicacion)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fòtos e grafismes)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Espaci de colors estandard"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Perfil de pròva"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatic"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Bassa qualitat"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Qualitat mejana"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Nauta qualitat"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RVB per defaut"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMJN per defaut"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Gris per defaut"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Donadas d'escandalhatge d'usina del fabricant"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr ""
+"Correccion de l'ecran en mòde ecran complet impossibla amb aqueste perfil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Benlèu qu'aqueste perfil es pas mai precís"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Color"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Escandalhona la color de vòstres periferics, coma los ecrans, los aparelhs "
+"de fòtos o las imprimentas"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Perfil;Escandalhar;Escandalhatge;Imprimenta;Ecran;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Autre…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Causir la lenga"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Seleccionar"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Cap de lenga pas trobada"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Mai…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Desverrolhar per modificar los paramètres"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Devètz desverrolhar certans paramètres per los modificar."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Desverrolhar…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Aumentar las oras"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Aumentar las minutas"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Orodatatge"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Reduire las oras"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Reduire las minutas"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Uèi"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Ièr"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d ora"
+msgstr[1] "%d oras"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuta"
+msgstr[1] "%d minutas"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d segonda"
+msgstr[1] "%d segondas"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 segondas"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Punt d’accès"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 oras"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B de %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B de %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data & ora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Annada"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mes"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "genièr"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "febrièr"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "març"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "abril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "mai"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "junh"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "julhet"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "agost"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "setembre"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "octobre"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "novembre"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "decembre"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Jorn"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Fus orari"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Recercar una vila"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Data &amp ora automaticas"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Necessita una connexion Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Data &amp _ora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "_Fus orari automatic"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+"Necessita l’activacion dels servicis de localizacion e una connexion Internet"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Activat"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Fus _orari"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Format de l'ora"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Modificar la data e l'ora, inclús lo fus orari"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Relòtge;Fus;Ora;Data;Emplaçament;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Modificar la data e l'ora del sistèma"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Vos cal vos autentificar per modificar la data o l'ora."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "Sites _Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Corrièr electronic"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendièr"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usica"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Vidèos"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fòtos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicacions per defaut"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configurar las aplicacions per defaut"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "defaut;per defaut;aplicacion;preferida;mèdia;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Enviar de rapòrts o senhalar de problèmas tecnics nos ajuda a melhorar %s. "
+"Los rapòrts son enviats anonimament e son netejat de tota donada personala. "
+"%s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Senhalament de problèmas"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Senhalament _automatic de problèmas"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostics"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Senhalar vòstres problèmas"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;plantatge;avaria;fracàs;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "I"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "O"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Aplicar los cambiaments ?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Los cambiaments pòdon pas èsser aplicats"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Aquò pòt venir de limitacions materialas."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Aplicar"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Precedent"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Paramètres d'afichatge desactivats"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Ecrans multiples"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Fusionar"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Clonar"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Content la barra superiora e las activitats"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Ecran principal"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Mòde nuèit"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Païsatge"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Retrait sus la dreita"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Retrait sus l'esquèrra"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Païsatge (revirat)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientacion"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Definicion"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Frequéncia de refrescament"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Adaptar als televisors"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Escala"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Mòde nuèit indisponible"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Aquò poiriá venir del pilòt en usança o que'l burèu es utilizat a distància"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Desactivat temporàriament fins a deman"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Reaviar lo filtre"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Lo mòde nuèit adocís las colors blavas de l’ecran. Pòt reduire la fatiga "
+"dels uèlhs e las riscas d’insomnias."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Oraris"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Levar al colcar del solelh"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Orari manual"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Orodatatge"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "De"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "ora"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr " :"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "minuta"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "matin"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "aprèpmiègjorn"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "a"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura de color"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Afichatge"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Causir lo mòde d'utilizacion dels ecrans e projectors connectats"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panèl;Projector;xrandr;Ecran;Definicion;Resolucion;Refrescament;Moniteur;"
+"Nuèit;Nuèch,Esclairatge;Lum;Lutz;Blava;redshift;descalatge;espectral;color;"
+"levar;colcar;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Aviada segura activa"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+#, fuzzy
+#| msgid ""
+#| "Secure boot prevents malicious software from being loaded when the device "
+#| "starts.\n"
+#| "\n"
+#| "For more information, contact the hardware manufacturer or IT support."
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"L’aviada segura empacha los logicials malvolents de se cargar quand "
+"l’aparelh avia.\n"
+"\n"
+"Per mai d’informacions, contactatz lo fabricants del material o "
+"l’assisténcia tecnica."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "L’aviada segura a de problèmas"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+#, fuzzy
+#| msgid ""
+#| "Secure boot prevents malicious software from being loaded when the device "
+#| "starts.\n"
+#| "\n"
+#| "For more information, contact the hardware manufacturer or IT support."
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"L’aviada segura empacha los logicials malvolents de se cargar quand "
+"l’aparelh avia.\n"
+"\n"
+"Per mai d’informacions, contactatz lo fabricants del material o "
+"l’assisténcia tecnica."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "L’aviada segura es atuda"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+#, fuzzy
+#| msgid ""
+#| "Secure boot prevents malicious software from being loaded when the device "
+#| "starts.\n"
+#| "\n"
+#| "For more information, contact the hardware manufacturer or IT support."
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"L’aviada segura empacha los logicials malvolents de se cargar quand "
+"l’aparelh avia.\n"
+"\n"
+"Per mai d’informacions, contactatz lo fabricants del material o "
+"l’assisténcia tecnica."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"L’aviada segura empacha los logicials malvolents de se cargar quand "
+"l’aparelh avia.\n"
+"\n"
+"Per mai d’informacions, contactatz lo fabricants del material o "
+"l’assisténcia tecnica."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Reüssit"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Fracàs"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "L’aparelh es confòrme al nivèl HSI %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Nivèl de seguretat 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Nivèl de seguretat 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Nivèl de seguretat 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Nivèl de seguretat 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Nivèl de seguretat"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Los nivèls de seguretat son pas disponibles per aqueste aparelh."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nivèl 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nivèl 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nivèl 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "L’aviada segura a de problèmas"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "D’unas proteccions quand l’aparelh es aviat."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "L’aviada segura es atuda"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Cap de proteccion a l’aviada de l’aparelh."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Exposat a de menaças de seguretat grèvas."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Proteccion limitada contra de menaças de seguretat simplas."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Protegit contra de menaças de seguretat comunas."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Protegit contra una plaja larga de menaças de seguretat."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Proteccion complèta"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Cap d’eveniment"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Proteccion d’escritura del micrologicial"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Verrolh de proteccion d’escritura del micrologicial"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Region del micrologicial de BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Descriptor del micrologicial de BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+#, fuzzy
+#| msgid "No Protection"
+msgid "Pre-boot DMA Protection"
+msgstr "Pas cap de proteccion"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard aviada verificada"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM protegit"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Error de politica Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+#, fuzzy
+#| msgid "Intel BootGuard"
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET activat"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr ""
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "RAM chifrada"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Proteccion IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr ""
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr ""
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Memòria d'escambi Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Metre en velha en RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+#, fuzzy
+#| msgid "Suspend-to-idle"
+msgid "Suspend To Idle"
+msgstr "Ivernada-quand-inactiu"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "clau de platafòrma UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Aviada segura UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Configuracion de la platafòrma TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr ""
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Mesas a jorn del micrologicial"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Atestacion d’integritat del micrologicial"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Verificador de l’actualizador de micrologicial"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Platafòrma de desbugatge"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr ""
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+#, fuzzy
+#| msgid "No Protection"
+msgid "AMD Rollback Protection"
+msgstr "Pas cap de proteccion"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+#, fuzzy
+#| msgid "Minimal Protection"
+msgid "AMD Firmware Replay Protection"
+msgstr "Proteccion minimala"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+#, fuzzy
+#| msgid "Minimal Security Protections"
+msgid "AMD Firmware Write Protection"
+msgstr "Proteccions de seguretat minimalas"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr ""
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Valid"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Pas valid"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Pas activat"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Verrolhat"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Pas verrolhat"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Chifrat"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Pas chifrat"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr ""
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+#, fuzzy
+#| msgid "Not calibrated"
+msgid "Not Tainted"
+msgstr "Pas escandalhat"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Trobat"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Pas trobat"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Pres en carga"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Pas pres en carga"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Seguretat de l’aparelh"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ecran;verrolhar;verrolhatge;diagnotic;confidencialitat;recent;temporari;nom;"
+"ret;malhum;identitat;tmp;privat;privada;vida;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Desconegut"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Desconegut"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Pas disponibla"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logotipe sistèma"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nom del periferic"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Modèl material"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memòria"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafisme"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacitat del disc"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calcul en cors…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nom de l’OS"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Identificant de construccion OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tipe d’OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Version de GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Cargament…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Gestionari de fenèstras"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualizacion"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Mesa a jorn dels logicials"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Renommar lo periferic"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Lo nom del periferic es utilizat per identificar quand es visible sus la "
+"ret, o en espèra d’associacion amb de periferics Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nom del periferic"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Tornar nomenar"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "A prepaus"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Afichar las informacions sul sistèma"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"aparelh;periferic;informacion;sistèma;nom;òste;memòria;processor;defaut;"
+"aplicacions;preferida;preferit;cd;dvd;àudio;vidèo;disc;amobile;mèdia;"
+"execucion;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Son e mèdia"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Arrestar/activar lo son"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Demesir lo son"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Montar lo son"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Arrestar/activar lo micrò"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Aviar lo lector multimèdia"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Lectura (o Lectura/Pausa)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Metre en pausa"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Arrestar la lectura"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Pista precedenta"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Pista seguenta"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Ejectar"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Picada"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Bascular cap a la font seguenta"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Bascular cap a la font precedenta"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Aviadors"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Aviar lo navigador d'ajuda"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Aviar la calculeta"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Aviar lo client de messatjariá"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Aviar lo navigador Web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Dorsièr personal"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Recercar"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistèma"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Se desconnectar"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Verrolhar l'ecran"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accessibilitat"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Activar o desactivar lo zoom"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zoom avant"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Zoom arrièr"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Activar o desactivar lo lector d'ecran"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Activar o desactivar lo clavièr visual"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Aumentar la talha del tèxte"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Reduire la talha del tèxte"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Activar o desactivar lo contraste elevat"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Cap de font d'entrada pas trobada"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Autre"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Apondre una font d'entrada"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+"Los metòdes de picada pòdon pas èsser utilizats sus l’ecran de connexion"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Cap de font d'entrada pas seleccionada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opcions"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Remontar"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Davalar"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferéncias"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Veire l’agençament del clavièr"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Suprimir"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Acorchis personalizats"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tòca de caractèrs alternatius"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Las claus de caractèrs s'utilizan per picar de caractèrs addicionals. De "
+"còps que i a son imprimits coma una tèrça opcion sul clavièr."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt d'esquèrra"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt de dreita"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Ctrl d'esquèrra"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Ctrl de dreita"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Clau de menú"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl de dreita"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tòca de composicion"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"La tòca de composicion permet de picar una brava varietat de caractèrs. Per "
+"l’utilizar, tenètz-la quichada e quichatz una sequéncia de caractèrs. Per "
+"exemple, la tòca de composicion seguida de <b>C</b> e <b>o</b> donarà <b>©</"
+"b>, <b>a</b> seguit de <b>'</b> donarà <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Verr.Maj."
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Verrolhatge del desfilament"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Imp. Ecr."
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Òm pòt bascular las fonts d’entradas en utilizant l’acorchi de clavièr %s.\n"
+"Se pòt modificar aqueste acorchi de clavièr dins las preferéncias del "
+"clavièr."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Fonts d'entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Inclutz l'agençaments de clavièr e los metòdes d’entrada."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Cambiament de font d’entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Utilizar la _meteissa font per totas las fenèstras"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Utilizar de fonts d'entrada diferentas per cada fenèstra"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Entrada de caractèrs especials"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Metòdes per picar de simbòls e de variantas de letras en utilizant lo "
+"clavièr."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Acorchis de clavièr"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Veire e personalizar los acorchis"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificat"
+msgstr[1] "%d modificats"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Reïnicializar totes los acorchis ?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Reïnicializar totes los acorchis pòt tanben afectar vòstres acorchis "
+"personalizats. Aquesta accion es irreversibla."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Anullar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Reïnicializar tot"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Reïnicializar tot…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Reïnicializar totes los acorchis a lors combinasons per defaut"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Seccion"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Acorchis"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Apondre un acorchi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Apondre un acorchi personalizat"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Definir d'acorchis personalizats per lançar las aplicacions, executar de "
+"scripts e encara mai."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Apondre un acorchi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Cap d'acorchi de clavièr pas trobat"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s es ja utilizat per %s. Se lo remplaçatz, %s serà desactivat"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Picar lo novèl acorchi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Definir un acorchi personalizat"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Definir un acorchi"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Picatz un acorchi novèl per cambiar %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Apondre un acorchi personalizat"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Suprimir"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Rem_plaçar"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Definir"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Quichar sus Escap per anullar o sus Retorn arrièr per desactivar l'acorchi "
+"de clavièr."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nom"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Comanda"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Acorchi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Definir un acorchi…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Pas cap"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Reïnicializar l'acorchi a sa valor per defaut"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Clavièr"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Codificar los acorchis de clavièr e definir vòstras preferéncias de picada, "
+"agençament de clavièr e fonts d’entrada"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Acorchi;Espaci de trabalh;Fenèstra;Redimensionar;Zoom;Contraste;Picada;Font;"
+"Verrolhar;Volum;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Servici de lozalicion desactivat"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Cap d’aplicacion obten pas d’informacions de localizacion."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Los servicis de localizacion permeton a las aplicacions de conéisser vòstra "
+"posicion. L’utilizacion del WI-FI e del ret mobil aumenta la precision.\n"
+"\n"
+"Emplega lo servici de localizacion de Mozilla : <a href='https://location."
+"services.mozilla.com/privacy'>Politica de confidencialitat</a>\n"
+"\n"
+"Permet a las aplicacions seguentas de determinar vòstra posicion."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Cap d’aplicacion a pas demandat l’accès a vòstre emplaçament"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Protegir vòstras informacions de localizacion"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "localizacion;gps;privat;confidencialitat;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Lo microfòn es inactiu"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Cap d’aplicacion pòt pas enregistrar de son."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"L’utilizacion del microfòn permet a las aplicacions d’enregistrar e "
+"d’escotar de l’àudio. En lo desactivant, es possible que certanas "
+"aplicacions foncionen pas corrèctament.\n"
+"\n"
+"Autoriatz las aplicacions çai-jos a utilizar lo microfòn."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Cap d’aplicacion a pas demandat l’accès al microfòn"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Protegir vòstras conversacions"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "microfòn;enregistrament;aplicacion;confidencialitat;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Testar vòstres p_aramètres"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "General"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Boton principal"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+"Definís l’òrdre dels botons fisics sus las mirgas e los pavats tactils."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Esquèrra"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Dreita"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mirga"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Tòcas de la mirga"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Desfilament natural"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Lo compte sul servidor serà pas suprimit."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Pavat tactil"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Velocitat del pavat tactil"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Picar per clicar"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Tocar per clicar"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Défilement a deux doigts"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Desfilament cap a dreita"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Ensajatz de clicar, doble-clicar, far desfilar"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinc clics, l'epòca GEGL !"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Clic-doble, boton principal"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Clic simple, boton principal"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Clic-doble, boton del mitan"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Clic simple, boton del mitan"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Clic-doble, boton segondari"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Clic simple, boton segondari"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mirga & pavat tac­til"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Modificar la sensibilitat del pavat tactil e causir entre dreitièr o "
+"esquerrièr"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Pavat;Tactil;Puntador;Clic;Quichada;Doble;Boton;Bola;Desfilament;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Bòrd reactiu"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Tocar lo caire naut esquèr per dobrir l’apercebut de las activitats."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Bordaduras d’ecran actiu"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Lisatz las fenèstras contra los bòrds superiors a man esquèrra e drecha per "
+"los redimencionar."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Espacis de trabalh"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Espacis de trabalh dinamics"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Suprimir automaticament los espacis de trabalhs voids."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Nombre d’espacis de trabalh fixe"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Especificatz un nombre d’espacis de trabalh permanents."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Nombre d’espacis de trabalh"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multi monitor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Espacis de trabalh solament sus l’ecran _principal"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Espacis de trabalh per tote_s los ecrans"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Alternància entre aplicacions"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Inclure totas las aplicacions dels _espacis de trabalhs estant"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Inclure totas las aplicacions de l’espaci de trabalhs actual sonque"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multiprètzfach"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Gerir las preferéncias per la productivitat e multi prètzfach"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"multi prètzfach;multitasca;productivitat;personalizar;burèu;caire;espaci;"
+"trabalh;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Ops, quicòm a trucat. Contactatz lo provesidor de vòstre logicial."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager deu èsser en foncionament."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Autres periferics"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Apondre una connexion novèla"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Pas configurat"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID : %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Ret pas segur (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Ret segur (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Ret segur (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Ret segur (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Ret segur"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Connectat"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opcions…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"L’activacion del punt d’accès mena a la desconnexion de %s e serà pas "
+"possible d’accedir a Internet en Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Deu conténer almens 8 caractèrs"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Deu conténer al maximum %d caractèrs"
+msgstr[1] "Deu conténer al maximum %d caractèrs"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Alucar lo punt d’accès Wi-Fi ?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Lo punt d’accès Wi-Fi permet a d’autras personas de partejar vòstra "
+"connexion Internet, en creant una ret Wi-Fi a la quala se pòdon connectar. "
+"Per aquò far, devètz aver una connexion Internet via una autra font que lo "
+"Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nom de la ret"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Senhal"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Generar un senhal aleatòri"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Generar automaticament un senhal"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "A_lucar"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Interrompre lo punt d'accès e desconnectar totes los utilizaires ?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Interrompre lo punt d'accès"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Mòde avion"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+"Desactiva lo Wi-Fi, lo Bluetooth e las connexions mobilas de larga benda"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Cap d'adaptator Wi-Fi pas trobat"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Asseguratz-vos qu'avètz un adaptator Wi-Fi brancat e operacional"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Mòde avion activat"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Desactivar per utilizar lo Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Punt d’accès Wi-Fi activat"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Los aparelhs mobils pòdon numerizar lo còdi QR per se connectar."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "_Atudar lo punt d’accès Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Rets visiblas"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager deu èsser en foncionament"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Seguretat 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Seguretat"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Conservar"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Aleatòri"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Estable"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"L’adreça MAC picada aicí serà utilizada coma adreça materiala del periferic "
+"de ret activat per aquesta connexion. Aquesta foncionalitat es apelada « MAC "
+"cloning » o « spoofing ». Exemple : 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Perfil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Entrepresa"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Pas cap"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Pas jamai"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "I a %i jorn"
+msgstr[1] "I a %i jorns"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Pas cap"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Feble"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Corrècte"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bon"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excellent"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Adreça IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adreça IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adreça IP"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Doblidar la connexion"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Suprimir lo perfil de la connexion"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Suprimir lo VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Detalhs"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatic"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitat"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Suprimir l'adreça"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Suprimir la rota"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Pas cap"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Clau WEP 40/128-bit (Hex o ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Frasa secreta WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinamic (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA e WPA2 privadas"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA e WPA2 d'entrepresa"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Fòrça del senhal"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Velocitat de la connexion"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Adreça materiala"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Frequéncias compatiblas"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Rota per defaut"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Darrièra utilizacion"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Connexion _automatica"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Rendre accessible als _autres utilizaires"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"Connexion _limitada  possedís una limita de donadas o pòt menar a de "
+"despensas"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Las mesas a jorn de logicials e los autres telecargaments pesucs començaràn "
+"pas automaticament."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nom"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Adreça _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Adreça _clonada"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "octets"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Metòde IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatic (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Ret locala solament"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Desactivar"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Partejada amb los autres ordenadors"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adreças"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adreça"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Cache de ret"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Palanca"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatic"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automatic"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Adreça(s) servidor DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Separar las adreças IP amb de virgulas"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rotas"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Rotas automaticas"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Utilizetz pas aquesta connexion que per las ressorsas sus aquesta ret"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Metòde IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatic, DHCP solament"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefix"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Impossible de dobrir l'editor de connexions"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Perfil novèl"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Paramètre invalid %s : %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Paramètre invalid %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importar dempuèi un fichièr…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Apondre un VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Seg_uretat"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Impossible d'importar la connexion VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Lo fichièr « %s » es ilegible o conten pas cap d’informacions de connexion "
+"VPN reconegudas\n"
+"\n"
+"Error : %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Seleccionar lo fichièr d'importar"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Un fichièr nomenat « %s » existís ja."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Remplaçar"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Volètz remplaçar %s amb la connexion VPN en cors d'enregistrament ?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Impossible d'exportar la connexion VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"La connexion VPN « %s » a pas pogut èsser exportada cap a %s.\n"
+"\n"
+"Error : %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exportacion de la connexion VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Error : impossible de cargar l'editor de connexions VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Controlar vòstre biais de vos connectar a Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Ret;IP;LAN;Mandatari;WAN;Larga benda;Modèm;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controlar vòstre biais de vos connectar a las rets sens fial"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Ret;Sens fial;Wi-Fi;Wifi;IP;LAN;Larga benda;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "pas jamai"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "uèi"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "ièr"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Darrièra utilizacion"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Filara"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Apondre una novèla connexion"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Las informacions de las rets seleccionadas, incluses los senhals e tota "
+"configuracion personalizada seràn perduts."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Doblidar"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Rets Wi-Fi conegudas"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Doblidar"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Las règlas del sistèma interdison son utilizacion coma punt d'accès"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Lo periferic sens fial pren pas en carga lo mòde « punt d'accès »"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"« Web Proxy Autodiscovery » es utilizat quand cap d'URL de configuracion es "
+"pas provesit."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Aquò es pas recomandat per de rets publicas pas seguras."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Atudar lo periferic"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Actiu"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Provesidor"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Servidor mandatari"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Servidor mandatari _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Servidor mandatari H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Servidor mandatari _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Òste _Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorar los òstes"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Pòrt del servidor mandatari HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Pòrt del servidor mandatari HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Pòrt del servidor mandatari FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Pòrt del servidor mandatari Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuracion"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Tampar la connexion VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nom de la ret"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tipe de seguretat"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Senhal"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Atudar lo Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Mai d'opcions…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Connexion a una ret amagada…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Alucar lo punt d’accès Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Rets Wi-Fi _conegudas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Estat desconegut"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Pas gerit"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Indisponible"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Connexion en cors"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Autentificacion requesida"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Desconnexion en cors"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Fracàs de la connexion"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Estat desconegut (absent)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Fracàs de la configuracion"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Fracàs de la configuracion IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Configuracion IP expirada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "D'elements secrets, pas provesits, èran necessaris"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Lo client 802.1x s'es desconnectat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "La configuracion del client 802.1x a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Lo client 802.1x a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Lo client 802.1x a mes tròp de temps per s'autentificar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Lo servici PPP a pas capitat de s'aviar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Servici PPP desconnectat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Lo client DHCP a pas capitat de s'aviar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Error del client DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Lo client DHCP a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Lo servici de connexion partejada a pas capitat de s'aviar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Lo servici de connexion partejada a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Lo servici autoIP a pas capitat de s'aviar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Error del servici autoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Lo servici autoIP a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linha ocupada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Pas de tonalitat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Cap de portadoira a pas pogut èsser establida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Relambi de numerotacion depassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "La temptativa de numerotacion a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "L'inicializacion del modèm a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Fracàs de la seleccion de l'APN especificat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Cap de recèrca de ret pas en cors"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Enregistrament a la ret refusat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Relambi depassat per l'enregistrament a la ret"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Fracàs de l'enregistrament a la ret demandat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "La verificacion del còdi PIN a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Es possible que lo micrologicial del periferic manca"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "La connexion a desparegut"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Una connexion existenta es estada supausada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modèm pas trobat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "La connexion Bluetooth a fracassat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "La carta SIM es pas inserida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Lo còdi PIN de la SIM es necessari"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Lo còdi PUK de la SIM es requesit"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Marrida SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "La dependéncia de la connexion a fracassat"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Micrologicial absent"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Cable desbrancat"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "error de seguretat desconeguda dins 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "cap de fichièr pas seleccionat"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "error desconeguda a la validacion del fichièr eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 o claus privadas PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certificat DER o PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "fichièr EAP-FAST PAC mancant"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Fichièrs PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonim"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autentificat"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Los dos"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identitat a_magada"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Fichièr PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Causir un fichièr PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autentificacion _intèrna"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Autorizar l’_obtencion automatica de PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "nom d’utilizaire d’EAP-LEAP mancant"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "senhal d’EAP-LEAP mancant"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nom d'_utilizaire"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "Se_nhal"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Afi_char lo senhal"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "certificat CA d’EAP-PEAP invalid : %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "certificat CA d’EAP-PEAP invalid : cap de certificat pas especificat"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificat C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Causir un certificat d'una autoritat de certificacion"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Cap de certificat CA es pas _requesit"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Version PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "nom d’utilizaire EAP mancant"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "senhal EAP mancant"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "identitat EAP-TLS mancanta"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "certificat CA EAP-TLS invalid : %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TLS invalid : cap de certificat pas especificat"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "clau privada EAP-TLS invalida : %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificat utilizaire EAP-TLS invalid : %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Las claus privadas pas chifradas son pas fisablas"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Sembla que la clau privada seleccionada es pas protegida per un senhal. Aquò "
+"met en dangièr vòstres identificants. Seleccionatz una clau privada "
+"protegida per senhal.\n"
+"\n"
+"(Podètz protegir vòstra clau per senhal amb openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Causissètz vòstre certificat personal"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Causissètz vòstra clau privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificat _utilizaire"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Clau privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Senhal de la _clau privada"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "certificat CA EAP-TTLS invalid : %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TTLS invalid : cap de certificat pas especificat"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (no EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domeni"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Error desconeguda a la validacion de la seguretat de 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Protocòl TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP securizat (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tentificacion"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Seleccionar un fichièr"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "nom d’utilizaire leap mancant"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "senhal leap mancant"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Senhal Wi-Fi mancant."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipe"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "clau wep mancanta"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"clau wep invalida : una clau de %zu deu pas conténer que de caractèrs "
+"exadecimals"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"clau wep invalida : una clau de %zu deu pas conténer que de caractèrs ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"clau wep invalida : longor de clau %zu incorrècta. Deu èsser de 5 a 13 "
+"caractèrs en ascii o de 10 a 26 en exa"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "clau wep invalida : frasa secreta pas completada"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "clau wep invalida : la frasa secreta deu conténer mens de 64 caractèrs"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (per defaut)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistèma dobèrt"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Clau partejada"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Clau"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Afichar la clau"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Indè_x WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk invalid : longor de clau %zu incorrècta. Deu èsser de [8,63] octets "
+"o 64 caratèrs exadecimals"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk invalid : impossible de considerar una clau de 64 octets coma "
+"exadecimala"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificacions"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alèrtas sonòras"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Bandièras de notificacions"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Las notificacions contunhan de s’afichar dins la lista del tirador quand "
+"l’afichatge de las bandièras es desactivat."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+"Afichar lo _contengut del messatge dins lo tirador de las notificacions"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notificacions sus _l'ecran de verrolhatge"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Afichar lo c_ontengut del messatge sus l'ecran verrolhat"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Destorbar _pas"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Notificacions sus _l'ecran de verrolhatge"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controlar quinas notificacions s'afichan e lor contengut"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notificacions;Messatges sorgissents;Messatge;Tirador;Popup;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Autre"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s suprimit"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Error al moment de la supression del compte"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Anullar"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Tampar las notificacions sistèma"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Connexion a vòstras donadas de la nívol"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Pas cap de connexion Internet — connectatz-vos per configurar de novèls "
+"comptes en linha"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Apondre un compte"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Compte %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Suprimir lo compte"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Comptes en linha"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Connectatz-vos a vòstres comptes en linha e decidètz de lor utilitat"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;En linha;Discussion;Agenda;Corrièr;Email;"
+"Contacte;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Durada desconeguda"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuta"
+msgstr[1] "%i minutas"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ora"
+msgstr[1] "%i oras"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ora"
+msgstr[1] "oras"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuta"
+msgstr[1] "minutas"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s abans cargament complet"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Atencion : demòra %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s restant"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Batariá plena"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Pas en carga"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Descargada"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "En carga"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "En descarga"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Mirga sens fial"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Clavièr sens fial"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Ondulator"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Assistent personal"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Telefòn portable"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Lector multimèdia"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tauleta"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Ordenador"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Periferic d’entrada per jòcs"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batariá"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principala"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Segondària"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batariás"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Quand _inactiu"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Metre en velha"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Atudar"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Ivernar"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Pas res"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Quand sus batariá"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Quand lo cable es brancat"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Pas jamai"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Mesa en _velha automatica"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Mòde performança temporàriament indisponible a causa d’una temperatura de "
+"foncionament nauta."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Lap detectada : mòde performança temporàriament desactivat.Desplaçatz lo "
+"periferic sus una susfàcia establa per restaurar."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Mòde performança temporàriament indisponible."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Batariá febla : estalviador d’energia activat. Lo mòde precedent serà "
+"restablit un còp que la batariá aja sufisentament cargat."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Mòde estalvi activat per « %s »."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Mòde performança activat per « %s »."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutas"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutas"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutas"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutas"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutas"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 ora"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutas"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutas"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutas"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 oras"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Mòde energetic"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Tòca las performança del sistèma e l’utilizacion energetica."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opcions d'estalvi d'energia"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Luminositat d'ecran automatica"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "La luminositat de l'ecran s’adapta a la luminositat ambienta."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Escuresir l’ecran"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Redusís la luminositat de l’ecran quand l'ordenador es inactiu."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Ecran void"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Atuda l’ecran aprèp un periòde d’inactivitat."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Estalviador d'energia automatic"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Activa l’estalviador d’energia quand la batariá es febla."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "Mesa en velha _automatica"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Met en pausa l’ordenador aprèp un periòde d’inactivitat."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Accion del boton d’e_xtinccion"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Afichar lo _percentatge de batariá"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Mesa en velha automatica"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Cable brancat"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Sus _batariá"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Relambi"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Performança"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Performança e consomacion nautas."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Equilibri"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Performança e utilizacion energetica estandardas."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Estalviador d'energia"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Performança e utilizacion energetica reduchas."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energia"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"S'informar sus l'estat de la batariá e modificar los paramètres d'estalvi "
+"d'energia"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"energia;alimentacion;velha;suspension;susprendre;ivernacion;ivernar;batariá;"
+"luminositat;negre;ecran;DPMS;inactiu;som;dormir;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "L’imprimenta « %s » es estada suprimida"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "L'apondon de la novèla imprimenta a fracassat."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Impossible de cargar l'interfàcia d'utilizaire : %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Desverrolhar per apondre d‘imprimentas e modificar los paramètres"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Imprimentas"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Apondre d'imprimentas, afichar los prètzfaits e decidir quand volètz imprimir"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Imprimenta;Fila;Coa;Impression;Papièr;Tinta;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Apondre una imprimenta"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Desverrolhar"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Cap d'imprimenta pas trobada"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Picatz l'adreça d'una ret o recercatz una imprimenta"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autentificacion requesida"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Picatz vòstre nom d’utilizaire e vòstre senhal per afichar las imprimentas "
+"sul servidor."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nom d'utilizaire"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Informacions sus %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Cap de pilòt adeqüat pas trobat"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Seleccionatz un fichièr PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Fichièrs de descripcion PostScript de l'imprimenta (*.ppd, *.PPD, *.ppd.gz, "
+"*.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+"Los noms d’imprimentas pòdon pas conténer d’espaci, de tabulacion, # o /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Emplaçament"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Pilòt"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Recèrca de pilòts preferits…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Recercar de pilòts"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Seleccionar a partir de la basa de donadas…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Installar lo fichièr PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Seleccionar un pilòt d'imprimenta"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Cargament de la basa de donadas dels pilòts…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Seleccionar"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Imprimenta JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Imprimenta LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Recto"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Bòrd long (estandard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Bòrd cort (revirat)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Retrait"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Païsatge"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Païsatge inversat"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Retrait inversat"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Reprendre"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "En pausa"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "En espèra"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "En pausa"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autentificacion requesida"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Tractament en cors"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Arrestada"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Interrompuda"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Anullada"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Acabada"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Plaçar aqueste prètzfach ennaut de la fila"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u prètzfait necessita una autentificacion"
+msgstr[1] "%u prètzfaits necessitan una autentificacion"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - prètzfaits d’impression actius"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+"Picatz vòstras informacions d’autentificacion per imprimir a partir de %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domeni"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utentificacion"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Escafar tot"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autentificacion"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Pas de prètzfaits d'impression actius"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Desverrolhar lo servidor d’imprimentas"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Desverrolhar %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Picatz vòstre nom d’utilizaire e vòtre senhal per afichar las imprimentas "
+"sus %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Recèrca d’imprimentas"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Pòrt seria"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Pòrt parallèl"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Emplaçament : %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adreça : %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Lo servidor necessita una autentificacion"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Recto verso"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tipe de papièr"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Font del papièr"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Nauc de sortida"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolucion"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Prefiltratge GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Paginas per costat"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Recto-verso"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientacion"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "General"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Mesa en pagina"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opcions installablas"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Prètzfaits"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Qualitat de l'imatge"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Color"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Finicion"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avançat"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Pagina de pròva"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Pagina de pròva"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Seleccion automatica"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Opcion per defaut de l'imprimenta"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Incorporar solament las polissas GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Convertir en PS de nivèl 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Convertir en PS de nivèl 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Pas cap de prefiltratge"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricant"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Pas cap de prètzfait d’impression actiu"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u prètzfait"
+msgstr[1] "%u prètzfaits"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Netejatge de las tèstas d’impression"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Toner gaireben agotat"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Pas mai de toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Revelator gaireben agotat"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Pas mai de revelator"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Cartocha de color gaireben voida"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Cartocha de color voida"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr " Tapador dobèrt"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Pòrta dobèrta"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Gaireben pas mai de papièr"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Pas mai de papièr"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Fòra linha"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Arrestada"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr " Recipient de descais gaireben plen"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Recipient de descais plen"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Lo fotoconductor optic es gaireben en fin de vida"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Lo fotoconductor optic es pas mai en estat"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Prèsta"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Accèpta pas mai de prètzfaits suplementaris"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Tractament en cors"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Opcions d’impression"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Informacions sus l’imprimenta"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Utilizar coma imprimenta per defaut"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Netejar las tèstas d’impression"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Suprimir l'imprimenta"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modèl"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nivèl de tinta"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Reaviar aprèp resolucion del problèma."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Reaviar"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Apondre una imprimenta…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Cap d’imprimenta"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"O planhèm ! Lo servici d’impression del sistèma\n"
+"    sembla pas disponible."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formats"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Cercar de lengas…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Formats comuns"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Totes los formats"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Pas cap de resultat de recèrca"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Las recèrcas pòdon èsser per país o lenga."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Apercebut"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datas"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Datas & oras"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Nombres"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mesura"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papièr"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "La lenga e lo format seràn cambiats a la connexion venenta"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Desconnexion…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Lo parametratge lingüistic servís pels tèxtes de l’interfàcia e de las "
+"paginas web. Lo format es utilizat pels nombres, datas e las devisas."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Vòstre compte"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Lenga"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formats"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Ecran de connexion"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "País e lenga"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Seleccionatz la lenga e lo format d’afichatge"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Lenga;Disposicion;Clavièr;Entrada;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Demandar de qué far"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Far pas res"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Dobrir lo dorsièr"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Autres mèdias"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Seleccionatz una aplicacion per vòstres CD àudio"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Seleccionatz una aplicacion per vos DVD àudio"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Seleccionatz una aplicacion d'aviar quand un lector de musica es connectat"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+"Seleccionatz una aplicacion d'aviar quand un aparelh de fòto es connectat"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Seleccionatz una aplicacion pels CD que contenon de logicials"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD àudio"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Disc Blu-ray verge"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "CD verge"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "DVD verge"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "Disc HD DVD verge"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "disc vidèo Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "lector e-book"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "disc vidèo HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Cd d’imatges"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super CD Vidèo"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "CD vidèo"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Logicials Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Causissètz cossí los mèdias devon èsser gerits"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_CD àudio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD vidèo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Lector de musica"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Logicials"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Autres mèdias…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Demandar o aviar pas jamai cap de programa a l'insercion de mèdias"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Causissètz cossí los autres mèdias devon èsser gerits"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Accion :"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipe :"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Mèdias amovibles"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configurar los paramètres dels mèdia amovibles"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"periferic;sistèma;per defaut;aplicacion;preferida;cd;dvd;usb;àudio;vidèo;"
+"disc;amovible;mèdia;execucion automatica;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Atudament de l’ecran"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 segondas"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuta"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutas"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutas"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutas"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutas"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 ora"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutas"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutas"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutas"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutas"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutas"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutas"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutas"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutas"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Jamai"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Verrolhatge de l'ecran"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Verrolhar automaticament l’ecran empacha qual que siá d’accedir a vòstre "
+"ordenador quand vos absentatz."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Relambi de l’ecran negre"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Periòde d’inactivitat aprèp la qual l’ecran s’atuda."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Verrolhatge automatic de l'ecran"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Relambi del _verrolhatge automatic de l’ecran"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Temps aprèp que l’ecran siá passat al negre quand se verrolha automaticament."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Afichar las _notificacions sus l’ecran de verrolhatge"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Interdire los periferics _USB novèls"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Empacha los periferics USB novèls d’interagir amb lo sistèma del temps que "
+"l’ecran es verrolhat."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Ecran de confidencialitat"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Configuracion de l'ecran"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "ecran;verrolh;privat;confidencialitat;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Seleccionar un emplaçament"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_D'acòrdi"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Emplaçaments de la recèrca"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Dorsièrs recercats per las aplicacions sistèmas, tals coma Fichièrs, Fòtos e "
+"Vidèos."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Emplaçaments"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Signets"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Autres"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Apondre un emplaçament"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Cap d'aplicacion pas trobada"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Recèrca d'aplicacions"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Inclure los resultats de recèrca provesits per l’aplicacion."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Dorsièrs recercats per las aplicacions sistèmas."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Resultats de la recèrca"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Los resultats son afichats segon l’òrdre de la lista."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controlar quinas aplicacions afichan los resultats d'una recèrca dins la "
+"vista d'ensemble de las activitats"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Recercar;Recèrca;Indèx;Amagar;Confidencialitat;Privat;Resultats;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Cap de ret de partiment es pas seleccionada"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Rets"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "I"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "O"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Activat"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Actiu"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Causir un dorsièr"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Apondre"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Activar lo partiment de mèdias"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Lo partiment de fichièrs vos permet de partejar vòstre dorsièr Public amb "
+"los autres sus la ret actuala en utilizant  : %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Quand la connexion distanta es activada, los utilizaires distants se pòdon "
+"connectar en utilizant la comanda Shell securizada :\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Activar lo partiment de fichièrs personals"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Nom del periferic copiat"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Adreça del periferic copiada"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Nom d’utilizaire copiat"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Senhal copiat"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Partiment"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Nom de l'ordenador"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Partiment de _fichièrs"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Burèu _distant"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Partejar los _mèdias"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Conne_xion distanta"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Partiment de fichièrs"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Demandar lo sen_hal"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Connexion distanta"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Burèu distant"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Lo burèu a distància permet de visualizar e controlar lo burèu a partir d’un "
+"autre ordenador."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Activar o desactivar una connexion distanta a aqueste ordenador."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Contraròtle a distància"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Autorizar los connectats a distància a contrarotlar l’ecran"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Cossí se connectar"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Connectatz-vos a aqueste ordenador en utilizant lo nom d’aparelh  o l’adreça "
+"de burèu a distància."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copiar"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Adreça burèu distant"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autentificacion"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Per se connectar a aqueste ordenador cal un nom d’utilizaire e un senhal."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nom d’utilizaire"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Verificar lo chiframent"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Chiframent per emprentas"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"L'emprunta de chiframent se vei pendent la connexion als clients e deu èsser "
+"identica."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Partejar los mèdias"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Partejar de la musica, de fòtos e de vidèos sus la ret."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Dorsièrs"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controlar çò que volètz partejar amb los autres"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"partiment;partejar;ssh;òste;nom;distant;burèu;bluetooth;obex;mèdia;àudio;"
+"vidèo;imatges;fòtos;filmes;servidor;renderer;motor de rendut;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Activar o desactivar una connexion distanta"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Autentificacion requesida per activar o desactivar una connexion distanta"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Personalizada"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Click"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+#| msgid "Sharing"
+msgid "String"
+msgstr "Partiment"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Swing"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balança"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Fondut"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Arrièr"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Avant"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Pròva de %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Clicatz sus un nautparlaire de testar"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volum sistèma"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Volum general"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Nivèls de volum"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Sortida"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Periferic de sortida"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Provar"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuracion"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Caisson de bassa"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Entrada"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Periferic d’entrada"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volum"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Son d’alèrta"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100 %"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Mut"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Son"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Modificar los volums sonòrs, las entradas, las sortidas e las alèrtas sonòras"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Carta;Microfòn;Volum;Fondut;Balança;Bluetooth;Casc;Audio;Entrada;Sortida;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Desconnectat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Connexion en cors"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Connectat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Error d'autorizacion"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autorizacion en cors"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Foncionalitat reduita"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Connectats & Autorizats"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Desconegut"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autorizat per :"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Connectat a :"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Inscrit dempuèi :"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Fracàs d'autorizacion del priferic : "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Impossible de doblidar lo periferic : "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Depend de %u autre periferic"
+msgstr[1] "Depend de %u autres periferics"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Tampar la notificacion"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nom :"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Estatut :"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID :"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autorizar e Connectar"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Periferic doblidat"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Error"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorizat"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Lo sossistèma Thunderbolt (boltd) es pas installat o es mal configurat."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Autorizar l’accès dirècte als periferics tals coma las estacions d’acuèlh e "
+"processors grafics extèrnes."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Sols los periferics USB e Display Port pòdon èsser connectats."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt a pas pogut èsser detectat.\n"
+"Siá lo sistèma pren pas en carga Thunderbolt, siá es estat desactivat dins "
+"lo BIOS, siá es parametrat sus un nivèl de seguretat pas pres en carga dins "
+"lo BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "La presa en carga de Thunderbolt es estada desactivada dins lo BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Lo nivèl de seguretat Thunderbolt a pas pogut èsser determinat."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Error de bascula en mòde dirècte : %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Pas cap de presa en carga de Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Connexion impossibla al subsistèma Thunderbold."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Accès dirècte"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Periferics en espèra"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Cap de periferic pas estacat"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Gerir los periferics Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;vidaprivada;privat;confidencialitat;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Cluquejament del cursor"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Lo cursor cluqueja dins los camps tèxte."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocitat"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Velocitat de cluquejament del cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Talha del cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"La talha del cursor pòt èsser associada al zoom per facilitar sa visibilitat."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Assistent de clic"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulacion del clic segondari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Desenclavar un clic segondari en mantenent quichat lo boton principal"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Relambi d'a_cceptacion :"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Cort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Relambi del clic segondari"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Clic per s_usvòl"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Desenclavar un clic en susvolant amb lo puntador"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Re_lambi :"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Cort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Sulhet de _desplaçament :"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Pichon"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grand"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Tòcas de repeticion"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Repeticion quand una tòca es mantenguda quichada."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Velocitat de repeticion de las tòcas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocitat de repeticion de las tòcas"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Assistent de picada"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Tòcas _remanentas"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Tractar la quichada d’una seguida de tòcas modificadoiras coma una "
+"combinason d'aquela"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desactivar se doas tòcas son quichadas simultanèament"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Emetre un bip quand una tòca _modificadoira es quichada"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Tòcas _lentas"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Introduire un relambi entre la quichada sus una tòca e son acceptacion"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Cort"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Relambi de picada de las tòcas lentas"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Emetre un bip quand una tòca es _quichada"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Emetre un bip quand una tòca es _acceptada"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Emetre un bip quand una tòca es _regetada"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Rebombs de tòcas"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorar las quichadas de tòcas rapidas e identicas"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Cort"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Relambi de picada dels rebombs de tòcas"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Long"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Activar amb lo clavièr"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Activar e desactivar las foncionalitats d'accessibilitat a partir del clavièr"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Per defaut"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Mejan"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Grand"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Mai grand"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Lo mai grand"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixèl"
+msgstr[1] "%d pixèls"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Totjorn afichar lo menú Accès universal"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Vision"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Contraste e_levat"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Grand tèxte"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Activar las a_nimacions"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Lector d'ecran"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Lo lector d'ecran legís lo tèxte afichat a mesura que desplaçatz lo focus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Tòcas _son"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Emet un bip al moment d'una quichada sus las tòcas Verr. Num. o Verr. Maj."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Talha del c_ursor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audicion"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Alèrtas _visualas"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Cla_vièr visual"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Tòcas de r_epeticion"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Cluque_jament del cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Assistent de _picada (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Puntatge e clic de mirga"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Tòcas de la m_irga"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Localizar lo puntador"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Assistent de _clic"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Relambi del _clic doble"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Relambi del clic doble"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alèrtas visualas"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Tèst rapid"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Utilizar una indicacion visuala quand una alèrta sonòra interven."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Far cluquejar tot l'e_cran"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Far cluquejar tota la _fenèstra"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Corta"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ d'ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ d'ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Longa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Ecran complet"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Mitat superiora"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Mitat inferiora"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Mitat esquèrra"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Mitat dreita"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Opcions del zoom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "A_grandiment :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posicion de la lópia :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Seguís lo cursor de la mirga"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Partida d'_ecran :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "La lópia s'_espandís en defòra de l'ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Garda lo cursor de la lópia centrat"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Lo cursor de la _lópia escarta lo contengut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Lo cursor de la lópia seguís lo _contengut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lópia"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Puntadors en _crotz :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Rec_obrís lo cursor de la mirga"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Espessor :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Fina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Espessa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Largor :"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Co_lor :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Puntadors en crotz"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efèits de color :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Blanc sus negre :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Luminositat :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contraste :"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Co_lor"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Pas cap"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Plena"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Febla"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Elevada"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Feble"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Elevat"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efèits de color"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Facilitar la vision, l'escota, la picada, la seleccion e lo clic"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Clavièr;mirga;ligam;accessibilitat;universal;contrast;contraste;cursor;son;"
+"zoom;ecran;lector;grand;larg;tèxt;talha;clic;velocitat;àudio;picada;poliça;"
+"policia;polissa;polissas;escritura;tòca;acorchi;lent;mirga;doble;clic;"
+"relambi;delai;repetir;visual;animacions;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 ora"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 jorn"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 jorns"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 jorns"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 jorns"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 jorns"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 jorns"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 jorns"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 jorns"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 jorns"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Voidar completament l'escobilhièr ?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Tot lo contengut de l'escobilhièr serà definitivament suprimit."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Voidar l'escobilhièr"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Suprimir totes los fichièrs temporaris ?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Totes los fichièrs temporaris seràn definitivament suprimits."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Purgar los fichièrs temporaris"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 jorn"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 jorns"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 jorns"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Totjorn"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Istoric de fichièrs"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"L’istoric dels fichièrs garda la traça dels fichièrs qu’avètz consultats. "
+"Aquesta informacion es partejada entre las aplicacions e simplifica la "
+"recèrca de fichièrs que poiriatz voler utilizar."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "_Istoric dels fichièrs"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Durada de l’_istoric dels fichièrs"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Escafar l’istoric…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Escobilhièr e fichièrs temporaris"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"L’escobilhièr e los fichièrs temporaris pòdon de còps conténer "
+"d’informacions personalas o sensiblas. Los suprimir automaticament pòt "
+"ajudar a protegir vòstra vida privada."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Suprimir automaticament lo contengut de l’_escobilhièr"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Suprimir automaticament los _fichièrs temporaris"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Periodicitat de la supression automatica"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Voidar l'escobilhièr…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Suprimir los fichièr temporaris…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Istoric e escobilhièr"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Daissar pas cap de traças"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usatge;utilizacion;usança;recents;istoric;istorial;fichiès;temporaris;tmp;"
+"privat;confidencialitat;escobilhièr;banasta;pobèlla;bordilhièr;purgar;purga;"
+"servar;conservar;memorizar;gardar;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Deu correspondre a l’adreça Web de vòstre provesidor d’accès."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "L'apondon del compte a fracassat"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Los senhals concòrdan pas."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "L'enregistrament del compte a fracassat"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Impossible de s'autentificar alprèp d'aqueste domeni"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Impossible de jónher aqueste domeni"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Aqueste identificant de connexion fonciona pas.\n"
+"Reensajatz."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Aqueste senhal de connexion fonciona pas.\n"
+"Reensajatz."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "La connexion a aqueste domeni a fracassat"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Impossible de trobar aqueste domeni. Verificatz son ortografia."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Apondre un utilizaire"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Los administrator pòdon apondre o suprimir d’autres utilizaires e pòdon "
+"modificar los paramètres de totes los utilizaires. Lo contraròtle parental "
+"se pòt pas aplicar als administrators."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "L’utilizaire definís son senhal a la primièra connexion"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Definir un senhal ara"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Identificant d'entrepresa"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+"Los comptes utilizaire que son gerits per una entrepresa o una organizacion."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Sètz fòra linha"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Un compte d’entrepresa autoriza l’usatge d’un compte utilizaire centralizat "
+"a partir d'aqueste periferic. Permet tanben d’accedir als diferents sites de "
+"la companhiá presents sus Internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Recercar d'autres imatges"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Seleccionar un fichièr…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Gestionari de detadas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Emprentas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Non"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Òc"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Volètz suprimir las emprentas digitalas enregistradas e desactivar atal "
+"aqueste tipe de connexion ?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Cap de periferic d’emprenta"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Cap de periferics d’emprenta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Asseguratz-vos que lo periferic es connectat coma cal."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Lector d’emprentas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Seleccionar lo lector d'emprentas digitalas que volètz configurar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Connexion per reconeissença d'emprentas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"La connexion per reconeissença d'emprentas vos permet de desverrolhar e vos "
+"connectar a vòstre ordenador amb vòstre det"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Suprimir las emprentas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Aprentissatge d’una emprenta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "aqueste aparelh deu èsser declarat per realizar aquesta accion"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "aqueste aparelh es ja declarat per un autre processús"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "avètz pas la permission de realizar l’accion"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "cap d’inscripcion marcada"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Fracàs de la comunicacion amb l’aparelh pendent l’inscripcion"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Fracàs de la comunicacion amb lo lector d'emprentas digitalas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Fracàs de la comunicacion amb lo daemon d'emprentas digitalas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Fracàs del cargament de la lista d’emprentas : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Fracàs de la supression de las emprentas enregistradas : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Poce esquèrre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Major esquèrre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "Indèx _esquèrra"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Anular esquèrre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Auricular esquèrre"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Poce dreit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Major dreit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "Indèx _dreit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Anular dreit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Auricular dreit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Det desconegut"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Acabat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Lector d’emprentas desconnectat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "L’espaci d’emmagazinatge del lector d'emprentas digitalas es plen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Fracàs de l’aprentissatge de l’emprenta novèla"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "L’aprentissatge a pas pogut s’aviar : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Fracàs de l’aprentissatge de l’emprenta novèla"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Fracàs de l'arrèst de l’inscripcion de l’emprenta digitala : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Plaçatz lo det sul lector d'emprentas digitalas mantun còp per inscriure "
+"vòstra emprenta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "_Renovar l’inscripcion d’aqueste det…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Enregistrar una emprenta novèla"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Impossible de desliurar lo lector d'emprentas digitalas%s : %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problèma pendent la lectura de l’aparelh"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr ""
+"Fracàs de la temptativa de revendicacion del lector d'emprentas "
+"digitalas %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr ""
+"Fracàs de la temptativa d’obtencion del lector d'emprentas digitalas : %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Aquesta setmana"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "La setmana passada"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %B de %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Fin de session"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Començament de session"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "Activitat del compte de %s"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Precedenta"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Seguenta"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Causissètz un autre senhal."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Picatz tornamai vòstre senhal actual."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Lo senhal pòt pas èsser modificat"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Modificar lo senhal"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Modificar"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Senhal actual"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Senhal novèl"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Confirmar lo senhal"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Autoriser l’utilizaire a changer son senhal a la prochaine connexion"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Definir un senhal ara"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Impossible de rejónher aqueste tipe de domeni automaticament"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Cap de domeni pas trobat"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Impossible de se connectar en tant que %s al domeni %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Senhal invalid, ensajatz tornamai"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Connexion al domeni %s impossible : %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "La supression de l'utilizaire a fracassat"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "La revocacion de l'utilizaire gerit a distància a fracassat"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Podètz pas suprimir vòstre pròpri compte."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s es encara connectat"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Suprimir un utilizaire mentre qu'es connectat pòt daissar lo sistèma dins un "
+"estat instable."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Volètz conservar los fichièrs de %s ?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Es possible de conservar lo repertòri personal, los corrièrs electronics en "
+"espèra (lo « spool ») e los fichièrs temporaris d'un compte d'utilizaire al "
+"moment de sa supression."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Suprimir los fichièrs"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Conservar los fichièrs"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Sètz segur que volètz revocar lo compte distant de %s ?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Suprimir"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Compte desactivat"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "De definir al moment de la connexion que ven"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Pas cap"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Connectat"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "La connexion al servici dels comptes a fracassat"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Verificatz qu'AccountService es installat e activat."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Devètz desverrolhar aqueste panèl per modificar aqueste paramètre"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Suprimir lo compte d'utilizaire seleccionat"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Per suprimir lo compte d'utilizaire seleccionat,\n"
+"clicatz primièr sus l'icòna *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Desverrolhar per apondre d'utilizaires e modificar los paramètres"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Utilizaires"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Vos cal reaviar la session per que los cambiaments sián efectius"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Reaviar ara"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Tampar"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Modificar avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Nom complèt"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Modificar"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Connexion per _reconeissença d'emprentas"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Connexion a_utomatica"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Activitat del compte"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Los administrator pòdon apondre o suprimir d’autres utilizaires e pòdon "
+"modificar los paramètres de totes los utilizaires."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "Contròle _parental"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Dobrir l'aplicacion de Contraròtle parental."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Suprimir l’utilizaire…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Autres utilizaires"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Apondre un utilizaire…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Cap d'utilizaire pas trobat"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Desverrolhatz per crear un compte d'utilizaire."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Apondre o suprimir d'utilizaires e modificar vòstre senhal"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Connexion;nom;emprenta;avatar;lògo;fàcia;more;senhal;contraròtle parental;"
+"contròla parental;temps ecran;restriccions;usatge;utilizacion;limitar;enfant;"
+"dròlle;mainatge;canalha;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Inscriure"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Identificant de l'administrator del domeni"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Per utilizar d'identificants d'entrepresa, aqueste ordenador deu\n"
+"èsser inscrit al domeni. Demandatz a vòstre administrator de\n"
+"ret de picar son senhal del domeni aicí."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nom de l'administrator"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Senhal de l'administrator"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Gerir los comptes utilizaire"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Autentificacion requesida per modificar las donadas utilizaire"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Lo senhal novèl deu èsser diferent de l'ancian."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Ensajatz de cambiar qualques letras e chifras."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Ensajatz de modificar un pauc mai lo senhal."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Un senhal que conten pas vòstre nom d'utilizaire seriá pus fòrt."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Ensajatz d'incorporar pas vòstre patronim dins lo senhal."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Ensajatz d'evitar d'unas mots contenguts dins lo senhal."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Ensajatz d'evitar de mots usuals."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Ensajatz d'evitar de rearrengar los mots existents."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Ensajatz d'utilizar mai de chifras."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Ensajatz d'utilizar mai de letras majusculas."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Ensajatz d'utilizar mai de letras minisculas."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Ensajatz d'utilizar mai de caractèrs especials, coma las pontuacions."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Ensajatz d'utilizar una mescla de letras, de chifras e de pontuacions."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Ensajatz d'evitar la repeticion del meteis caractèr."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Ensajatz d'evitar la repeticion del meteis caractèr : vos cal mesclar de "
+"letras, de chifras e de pontuacions."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Ensajatz d'evitar de sequéncias talas coma 1234 o abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Lo senhal deu èsser mai long. Ensajatz d’apondre de letras, de chifras e de "
+"pontuacions."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Mesclatz de majusculas, de minusculas e tanben un o dos nombres."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "L’apondre de letras, de chifras e de pontuacions renforçarà lo senhal."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Fracàs d'autentificacion"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Lo senhal novèl es tròp cort"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Lo senhal novèl es tròp simple"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "L'ancian e lo senhal novèl son tròp semblants"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Lo senhal novèl es ja estat utilizat recentament."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Lo senhal novèl deu conténer de caractèrs especials o numerics"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "L'ancian e lo novèl senhal son identics"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Vòstre senhal es estat modificat dempuèi que vos sètz autentificat !"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Lo senhal novèl compòrta pas pro de caractèrs diferents"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Error desconeguda"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Un nom d’utilizaire conten pas, en principi, que de letras minusculas o "
+"majusculas de a a z e un d'aqueles caractèrs : - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"O planhèm, aqueste nom d’utilizaire es pas disponible. Causissètz-ne un "
+"autre."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Lo nom d'utilizaire es tròp long."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Associar los botons"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Associar los botons a las foncions"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Per modificar un acorchi, causissètz l’accion « Send Keystroke », quichatz "
+"sul boton de l'acorchi de clavièr e tenètz quichadas las novèlas tòcas. "
+"Siquenon, quichatz sus la tòca Retorn arrièr per anullar."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Tampar"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Picatz sus las ciblas quand apareisson a l'ecran per escandalhar la tauleta ."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Marrit clic detectat, reaviada…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Boton %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Definit per l’aplicacion"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Mandar las quichadas sus las tòcas"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Inversar l'ecran"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Afichar l'ajuda a l'ecran"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tauleta montada sul portatil"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tauleta montada per un monitor extèrn"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Aparelh tauleta extèrna"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Aparelh tauleta extèrna"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Totes los ecrans"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Mòde tauleta"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Utilizar lo posicionament absolut per l'estilò"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientacion per esquerrièr"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "La tauleta e Express Keys™ son viradas per l’usatge de la man esquèrra"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Associar al monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Conservar las proporcions"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Utilizar sonque un airal reduch de la susfàcia de la tauleta per gardar la "
+"proporcion del monitor"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Calibrar"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Cap de tauleta  pas detectada"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Connectatz o alucatz vòstra tauleta Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Pression ressentida sus la punta"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Doça"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pression de la punta de l’estilò"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Fèrma"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Boton 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Boton 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Boton 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Pression ressentida sus la goma"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pression de la goma"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Clic del boton central de la mirga"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Clic del boton dreit de la mirga"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "En avant"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Estilò aerograf amb pression, enclinason, e barra de desfilament"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Estilò aerograf amb pression, enclinason, e rotacion"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Estilò aerograf amb pression e enclinason"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Estilò aerograf amb pression"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tauleta  Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Associar los botons e ajustar la sensibilitat de l'estilet de las tauleta s "
+"graficas"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tauleta ;Wacom;Stylet;Goma;Mirga;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Acorchi novèl…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Punts d’accès"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operacion anullada"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Error :</b> accès refusat en modificant los paramètres"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Error :</b> error de l’aparelh mobil"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Pas enregistrat"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Enregistrat"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Itinerància"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Recèrca"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Refusat"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Detalhs del modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Estatut del modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operator"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tipe de ret"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Estat del ret"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Numèro personal"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Detalhs del periferic"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Version del micrologicial"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G sonque"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G sonque"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G sonque"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "5G sonque"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (Preferida), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (Preferida), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (Preferida), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Preferida), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Preferida), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (Preferida), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (Preferida), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (Preferida), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (Preferida), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (Preferida), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (Preferida), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (Preferida), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (Preferida), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (Preferida), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (Preferida), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (Preferida), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (Preferida)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (Preferida), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Desverrolhar la carta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Desverrolhar"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Picatz lo còdi PIN per la carta SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Picatz lo còdi PIN per desverrolhar la carta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Picatz lo còdi PUK per la carta SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Picatz lo còdi PUK per desverrolhar la carta SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Marrit senhal picat. Vos demòra %1$u ensag"
+msgstr[1] "Marrit senhal picat. Vos demòran %1$u ensages"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Vos demòra %u ensag"
+msgstr[1] "Vos demòran %u ensages"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Marrit senhal picat."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Lo còdi PIM deu èsser un nombre de 8 chifras"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Picatz lo novèl còdi PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Lo còdi PIM deu èsser un nombre de 4 a 8 chifras"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Desverrolhatge…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Cap de carta SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Inserissètz una carta SIM per utilizar aqueste modem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "Carta SIM verrolhada"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Donadas mobil"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Accès donada en utilizant lo ret mobil"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Donadas en itinerància"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Utilizar las connexion de donadas mobil en itinerància"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Mòde de ret"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "R_et"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avançat"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Noms dels punts d’_accès"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Verrolhatge _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Verrolhar las carta SIM amb PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Detalhs del m_odem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Error del telefòn"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Cap de connexion al telefòn"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operacion pas permesa"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operacion pas presa en carga"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Carta SIM es pas inserida"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Còdi PIN de la SIM requerit"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Còdi PUK de la SIM requerit"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Fracàs de la SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Carta SIM occupada"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Senhal incorrècte"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Còdi PIN2 de la SIM requerit"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Còdi PUK2 de la SIM requerit"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Pas trobat"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Cap de servici telefonic"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Relambi d'espèra de la ret"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Servicis GPRS pas autorizats"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "L’itinerància es pas permesa dins aqueste airal"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Error GPRS pas especificada"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Cap d’error"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Accion anullada"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Accès refusat"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Error desconeguda"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Mòde de ret"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatic"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Causir la ret"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Actualizar la lista dels operators"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Activar la ret mobila"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Cap d'adaptatorWWAN pas trobat"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Asseguratz-vos qu'avètz un aparelh sens fial/mobil"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Lo ret sens fial es desactivat en mòde avion"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Desactivar lo mòde avion"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Connexion de donadas"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Carta SIM utilizada per internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Verrolhatge SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Seguent"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Verrolhar las carta SIM amb PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Modificar lo PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Picatz lo PIN actual per modificar los paramètres de verrolhatge SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Ret mobila"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configurar la telefonia e las connexion de donadas mobil"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "mobil;wwan;telefòn;sim;telefonet;portable;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilitari per configurar l’environament GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Paramètres es l’interfàcia principala de configuracion del sistèma."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Lo projècte GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Afichar lo numèro de la version"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Activar lo mòde verbós"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Recercar la cadena"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Fa la lista dels noms possibles de panèls e quita"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panèl d'afichar"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANÈL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categorias de paramètres"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Confidencialitat"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Panèls disponibles :"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Totes los paramètres"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menú principal"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Avertiment : version de desvolopament"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Aquesta version de Paramètres deuriá èsser utilizada sonque pel "
+"desvolopament. Poiriatz rescontrar de compòrtaments incorrèctes del sistèma, "
+"de pèrdas de donadas e d’autres problèmas imprevistes. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Ajuda"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "General"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Quitar"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Recercar"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panèls"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Tornar al panèl precedent"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Anullar la recèrca"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferéncias;Paramètres;Reglatges;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "L’identificant del darrièr panèl de paramètres de dobrir"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"L’identificant del darrièr panèl de paramètres de dobrir. Las valors pas "
+"reconegudas seràn ignoradas e lo primièr panèl de la lista serà seleccionat."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Afichar un avertiment al moment de l’utilizacion d’una version de "
+"desvolopament de Paramètres"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Indica se Paramètres deu afichar un avertiment al moment de l’utilizacion "
+"d’una version de desvolopament."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Estat inicial de la fenèstra"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Un tuple que conten la largor e nautor inicialas e l'estat maximizat de la "
+"fenèstra de l’aplicacion."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u sortida"
+msgstr[1] "%u sortidas"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrada"
+msgstr[1] "%u entradas"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sons sistèma"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Error : determinacion del nivèl HSI impossibla"
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Error : determinacion de nivèl HSI incorrècte impossibla"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificats DER o PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Apondre una imprimenta…"
+
+#~ msgid "Drip"
+#~ msgstr "Gota d'aiga"
+
+#~ msgid "Glass"
+#~ msgstr "Veire"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "No Protection"
+#~ msgstr "Pas cap de proteccion"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "Proteccion minimala"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Proteccion de basa"
+
+#~ msgid "Extended Protection"
+#~ msgstr "Proteccion espandida"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "Proteccions de seguretat minimalas"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Proteccions de seguretat de basicas"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Proteccions de seguretat espandidas"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Disposicion dels ecrans"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "Aviada segura inactiva"
+
+#~ msgid "SPI write"
+#~ msgstr "escritura SPI"
+
+#~ msgid "SPI lock"
+#~ msgstr "barrolh SPI"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "region SPI BIOS"
+
+#~ msgid "Suspend-to-ram"
+#~ msgstr "Ivernada-amb-ram"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "M̀òde MEI d’usina"
+
+#~ msgid "MEI version"
+#~ msgstr "Version del MEI"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "Aviada segura desactivada"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "Aviada segura activada"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Verrolhar l'ecran"
+
+#~ msgid "Light"
+#~ msgstr "Clar"
+
+#~ msgid "Set"
+#~ msgstr "Definir"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "ecran;verrolhar;verrolhatge;diagnostic;plantatge;privat;confidencial;"
+#~ "recent;temporari;tmp;indèx;nom;rets;identitat;"
+
+#~ msgid "Bark"
+#~ msgstr "Jaupadís"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Paramètres GNOME del panèl de son"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Paramètres GNOME panèl mirga &amp; e tactil"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Paramètres GNOME pel panèl rèireplan"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Paramètres GNOME pel panèl clavièr"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autentificacion"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Lo partiment d’ecran permet als utilizaires distants de veire o "
+#~ "contrarotlar vòstre ecran en se connectant a %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Partiment _de l'ecran"
+
+#~ msgid "_Password:"
+#~ msgstr "Se_nhal :"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Afichar lo senhal"
+
+#~ msgid "Access Options"
+#~ msgstr "Opcions d'accès"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Las _novèlas connexions devon èsser explicitament validadas"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Demandar lo senhal"
+
+#~ msgid "Web Links"
+#~ msgstr "Ligams Web"
+
+#~ msgid "Git Links"
+#~ msgstr "Ligams Git"
+
+#~ msgid "%s Links"
+#~ msgstr "Ligams %s"
+
+#~ msgid "Unset"
+#~ msgstr "Levar"
+
+#~ msgid "Links"
+#~ msgstr "Ligams"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Fichièrs ipertèxte"
+
+#~ msgid "Text Files"
+#~ msgstr "Fichièrs tèxte"
+
+#~ msgid "Image Files"
+#~ msgstr "Fichièrs imatge"
+
+#~ msgid "Font Files"
+#~ msgstr "Fichièrs de poliças"
+
+#~ msgid "Archive Files"
+#~ msgstr "Fichièrs d’archius"
+
+#~ msgid "Package Files"
+#~ msgstr "Fichièrs de paquets"
+
+#~ msgid "Audio Files"
+#~ msgstr "Fichièrs àudio"
+
+#~ msgid "Video Files"
+#~ msgstr "Fichièrs vidèo"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permissions e accès"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Donadas e servicis als quals aquesta aplicacion vòl accedir e permissions "
+#~ "qu'aquò implica."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Pas modificable"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Las permissions especificas a las aplicacions pòdon èsser examinadas dins "
+#~ "los reglatges de <a href=\"privacy\">Confidencialitat</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integracion"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Definir lo rèireplan"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Gestionaris per defaut"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Tipes de fichièrs e ligams qu'aquesta aplicacion dobrís."
+
+#~ msgid "Usage"
+#~ msgstr "Utilizacion"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Quantitat de ressorsas utilizadas per aquesta aplicacion."
+
+#~ msgid "Open in Software"
+#~ msgstr "Dobrir dins Logicials"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Autorizar las aplicacions çai-jos a utilizar la camèra."
+
+#~ msgid "Display Mode"
+#~ msgstr "Mòde d’afichatge"
+
+#~ msgid "Join Displays"
+#~ msgstr "Jónher los ecrans"
+
+#~ msgid "Single Display"
+#~ msgstr "Ecran unic"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Fasètz lissar los ecrans per correspondre a vòstra configuracion "
+#~ "vertadièra. Seleccionatz un ecran per modificar sos reglatges."
+
+#~ msgid "Active Display"
+#~ msgstr "Ecran actiu"
+
+#~ msgid "More Warm"
+#~ msgstr "Mai cauda"
+
+#~ msgid "Less Warm"
+#~ msgstr "Mens cauda"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Enregistrar una captura d'ecran dins $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Enregistrar la captura d'ecran d'una fenèstra dins $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Enregistrar la captura d'una partida de l'ecran dins $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copiar una captura d'ecran dins lo quichapapièrs"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copiar la captura d'ecran d'una fenèstra dins lo quichapapièrs"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copiar la captura d'una partida de l'ecran dins lo quichapapièrs"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Enregistrar una corta captura vidèo"
+
+#~ msgid "Move up"
+#~ msgstr "Montar"
+
+#~ msgid "Move down"
+#~ msgstr "Davalar"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Los servicis de localizacion permeton a las aplicacions de conéisser "
+#~ "vòstre emplaçament. Utilizar lo Wi-Fi e la ret mobila permet d’aumentar "
+#~ "la precision."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Utiliza lo service de localizacion de Mozilla : <a href='https://location."
+#~ "services.mozilla.com/privacy'>Politica de Confidencialitat</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr ""
+#~ "Autorizar las aplicacions seguentas a determinar vòstre emplaçament."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Autorizar las aplicacions çai-jos a utilizar lo microfòn."
+
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Genolh detectat : mòde performança indisponible"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Temperatura materiala nauta : mòde performança indisponible"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Mòde performança indisponible"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Causissètz lo format dels nombres, de las datas e de las devisas. Prend "
+#~ "efèit a la connexion venenta."
+
+#~ msgid "My Account"
+#~ msgstr "Mon compte"
+
+#~ msgid "Language"
+#~ msgstr "Lenga"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "La lenga d'utilizar pel tèxt de las fenèstras e de las paginas web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Reaviar la session per que los cambiaments sián preses en compte"
+
+#~ msgid "Restart…"
+#~ msgstr "Reaviar…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Los paramètres de connexion son utilizats per totes los utilizaires per "
+#~ "accedir al sistèma"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Controlar quins resultats de recèrca son afichats dins l’apercebut de las "
+#~ "activitats. L’òrdre dels resultats de recèrca pòt tanben èsser modificat "
+#~ "en desplaçant las linhas dins la lista."
+
+#~ msgid "Standard"
+#~ msgstr "Normal"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Tipe de compte"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Autorizar _l'utilizaire a definir un senhal a la connexion que ven"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Definir _un senhal ara"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Vos cal èsser en linha per apondre d'utilizaires de l’entrepresa."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Prene una fòto…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Per efectuar las modificacions,\n"
+#~ "clicatz primièr sus l'icòna *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Crear un compte d'utilizaire"
+
+#~ msgid "User Icon"
+#~ msgstr "Icòna d'utilizaire"
+
+#~ msgid "Account Settings"
+#~ msgstr "Paramètres del compte"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autentificacion e connexion"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Aquò es utilizat per nomenar vòstre dorsièr personal e pòt èsser "
+#~ "modificat."
+
+#~ msgid "Output:"
+#~ msgstr "Sortida :"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Conservar lo rapòrt d'afichatge (letterbox) :"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Associar a un sol ecran"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d sus %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Afichar la correspondéncia"
+
+#~ msgid "Stylus"
+#~ msgstr "Estilet"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tauleta  (absolut)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Pavat tactil (relatiu)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferéncias de la tauleta"
+
+#~ msgid "_Help"
+#~ msgstr "_Ajuda"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Paramètres del Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Mòde de recèrca"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Associar los botons…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Ajustar los paramètres de la mirga"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Ajustar la definicion de l'ecran"
+
+#~ msgid "No stylus found"
+#~ msgstr "Cap d'estilet pas trobat"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Plaçatz vòstre estilet sus las ciblas del bòrd de la tauleta per la "
+#~ "configurar"
+
+#~ msgid "Top Button"
+#~ msgstr "Boton superior"
+
+#~ msgid "Lower Button"
+#~ msgstr "Boton inferior"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Boton lo mai bas"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Tòcas son"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Lector d'ecran"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Lector d'ecran"
+
+#~ msgid "Activities"
+#~ msgstr "Activitats"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Fracàs de cargament del fichièr : %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Lo perfil es estat cargat dins :"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Picatz aquesta URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Reaviatz aqueste ordenador e aviatz vòstre sistèma operatiu costumièr."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Picatz aquesta URL dins vòstre navigador per telecargar e installar lo "
+#~ "perfil."
+
+#~ msgid "Upload profile"
+#~ msgstr "Mandar lo perfil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Necessita una connexion Internet"
+
+#~ msgid "_Copy"
+#~ msgstr "_Copiar"
+
+#~ msgid "Select _All"
+#~ msgstr "_Seleccionar tot"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Relambi del clic doble"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Metre en velha & atudar"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "D'unes servicis son desactivats fauta d'accès a la ret."
+
+#~ msgid "Unlocking..."
+#~ msgstr "Desverrolhar..."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Connexion;Nom;Emprenta;Avatar;Lògo;Visatge;Cap;Senhal;"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "PH-SIM PIN required"
+#~ msgstr "Lo còdi PIN de la SIM es necessari"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "PH-FSIM PIN required"
+#~ msgstr "Lo còdi PIN de la SIM es necessari"
+
+#, fuzzy
+#~| msgid "SIM Pin required"
+#~ msgid "PH-FSIM PUK required"
+#~ msgstr "Lo còdi PIN de la SIM es necessari"
+
+#~ msgid "Memory full"
+#~ msgstr "Memòria plena"
+
+#~ msgid "Memory failure"
+#~ msgstr "Fracàs memòria"
+
+#~ msgid "Network not allowed - emergency calls only"
+#~ msgstr "Ret pas autorizda - sonadas d’urgéncia sonque"
+
+#, fuzzy
+#~| msgid "Network registration denied"
+#~ msgid "Network personalization PIN required"
+#~ msgstr "Enregistrament a la ret refusat"
+
+#, fuzzy
+#~| msgid "Network registration denied"
+#~ msgid "Network personalization PUK required"
+#~ msgstr "Enregistrament a la ret refusat"
+
+#, fuzzy
+#~| msgid "Network registration denied"
+#~ msgid "Network subset personalization PIN required"
+#~ msgstr "Enregistrament a la ret refusat"
+
+#, fuzzy
+#~| msgid "Network registration denied"
+#~ msgid "Network subset personalization PUK required"
+#~ msgstr "Enregistrament a la ret refusat"
+
+#~ msgid "PLMN not allowed"
+#~ msgstr "PLMN pas autorizat"
+
+#, fuzzy
+#~| msgid "The device type is not currently supported."
+#~ msgid "Service option not supported"
+#~ msgstr "Lo tipe de periferic es pas actualament pres en carga."
+
+#~ msgid "PDP authentication failure"
+#~ msgstr "Fracàs d'autentificacion PDP"
+
+#~ msgid "Balanced Power"
+#~ msgstr "Equilibri"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Luminositat de l’e_cran"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Luminositat del _clavièr"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "E_scurezir l’ecran se inactiu"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "Ecran _negre"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Lo Wi-Fi pòt èsser atudat per estalviar d’energia."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Los periferics mobils de larga benda (LTE, 4G, 3G, etc.) pòdon èsser "
+#~ "atudats per estalviar d’energia."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Lo Bluetooth pòt èsser atudat per estalviar d’energia."
+
+#~| msgid "Show in Lock Screen"
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Definir lo rèireplan e l’ecran de verrolhatge"
+
+#~| msgid "Select Background"
+#~ msgid "Set Background"
+#~ msgstr "Definir lo rèireplan"
+
+#~| msgid "_Lock Screen"
+#~ msgid "Set Lock Screen"
+#~ msgstr "Definir l’ecran de verrolhatge"
+
+#~| msgid "Select Background"
+#~ msgid "Remove Background"
+#~ msgstr "Levar lo rèireplan"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Version %s"
+#~ msgstr "Version %s"
+
+#~ msgid "OS name"
+#~ msgstr "Nom del sistèma operatiu"
+
+#~ msgid "OS type"
+#~ msgstr "Tipe d'OS"
+
+#~ msgid "Disk"
+#~ msgstr "Disc"
+
+#~ msgid "Check for updates"
+#~ msgstr "Recèrca de mesas a jorn"
+
+#~ msgid "Universal Access"
+#~ msgstr "Accès universal"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr ""
+#~ "Amb las tòcas de modificacion solas, bascular cap a la font seguenta"
+
+#~ msgid "Network proxy"
+#~ msgstr "Servidor mandatari"
+
+#~ msgid "page 1"
+#~ msgstr "pagina 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "_Autentificacion intèrna"
+
+#~ msgid "page 2"
+#~ msgstr "pagina 2"
+
+#~| msgid "Restrict background data usage"
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Limitar l’utilizacion de las donadas en _rèireplan"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Utile per las connexions costosas o limitadas."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Para torsadada (PT)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Interfàcia de racòrdament (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "Connector BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Interfàcia de connexion MII"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mo/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mo/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Go/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Go/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Bascular sul punt d'accès sens fial vos va desconnectar de <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Podètz pas accedir a Internet per vòstra connexion sens fial pendent que "
+#~ "lo punt d'accès es actiu."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Los punts d’accès Wi-Fi son utilizats, de costuma, per partejar una "
+#~ "connexion Internet suplementària sens fial."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Connexion a_utomatica"
+
+#~ msgid "details"
+#~ msgstr "detalhs"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Afichar lo senh_al"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Metre a disposicion dels autres utilizaires"
+
+#~ msgid "identity"
+#~ msgstr "identitat"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adreças"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Adreças automaticas (DHCP) solament"
+
+#~ msgid "Link-local only"
+#~ msgstr "Connexion locala unicament"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignorar las rotas obtengudas automaticament"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Adreça MAC _clonada"
+
+#~ msgid "_Reset"
+#~ msgstr "_Reïnicializar"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Reïnicializar los paramètres d'aquesta connexion a lors valors per "
+#~ "defaut, mas se remembrar qu'es una connexion preferida."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Suprimir totas las informacions relativas a aquesta ret e ensajar pas de "
+#~ "s'i connectar automaticament."
+
+#~ msgid "Hardware"
+#~ msgstr "Material"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Reïnicializar"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Atudar per se connectar a una ret Wi-Fi"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Periferics connectats"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Senhal"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastructura"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "_Bandièras de notificacions"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "En carga"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Atencion"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Febla"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Bona"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Plena carga"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Descargada"
+
+#~ msgid "Add…"
+#~ msgstr "Apondre…"
+
+#~ msgid "In use"
+#~ msgstr "En cors d’utilizacion"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "I"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "O"
+
+#~| msgid "Off"
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Desactivat"
+
+#~| msgid "On"
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Activat"
+
+#~| msgid "Off"
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Desactivat"
+
+#~| msgid "On"
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Activat"
+
+#~ msgid "Usage & History"
+#~ msgstr "Utilizacion e istoric"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Politica de confidencialitat"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "L'enregistrament de vòstre istoric permet de retrobar las causas mai "
+#~ "aisidament. Aqueles elements son pas jamai partejats sus la ret."
+
+#~ msgid "_Recently Used"
+#~ msgstr "Utilizats _recentament"
+
+#~ msgid "Retain _History"
+#~ msgstr "Conservar l'_istoric"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Lo verrolhatge de l'ecran protegís vòstra vida privada quand vos "
+#~ "aluenhatz."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Verrolhar l'ecran inactiu _aprèp"
+
+#~| msgid "_Lock Screen Notifications"
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Notificacions sus l’ecran de verrolhatge"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Voidar automaticament l'escobilhièr e los fichièrs temporaris per "
+#~ "conservar pas d'informacions sensiblas sus vòstre ordenador."
+
+#~ msgid "Purge _After"
+#~ msgstr "Purgar _aprèp"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Lo mandadís d’informacion sus l’usatge dels logicials nos ajuda a vos "
+#~ "provesir de recomandacions mai precisas e a melhorar nòstres logicials.\n"
+#~ "\n"
+#~ "Totas las informacions que recoltam son anonimizadas, e partejarem pas "
+#~ "jamai vòstras donadas amb un tèrç."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "Mandar las _estatisticas d'utilizacion del logicial"
+
+#~| msgid "%s Camera"
+#~ msgid "_Camera"
+#~ msgstr "_Camèra"
+
+#~| msgid "Microphone Volume"
+#~ msgid "_Microphone"
+#~ msgstr "_Micrò"
+
+#~ msgid "_Location Services"
+#~ msgstr "Servicis de _localizacion"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Protegir vòstras informacions personalas e controlar çò que d'autres "
+#~ "pòdon veire"
+
+#~ msgid "No regions found"
+#~ msgstr "Cap de region pas trobada"
+
+#~| msgid "Previous track"
+#~ msgid "Previous source"
+#~ msgstr "Font precedenta"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Lògo+Maj+Barra d'espaci"
+
+#~| msgid "Resources"
+#~ msgid "Next source"
+#~ msgstr "Font seguenta"
+
+#~ msgid "Super+Space"
+#~ msgstr "Lògo+Barra d'espaci"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt de dreita+Alt d'esquèrra"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Far cluquejar la _barra de títol"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Per crear un compte d'utilizaire,\n"
+#~ "clicatz primièr sus l'icòna *"
+
+#~ msgid "Last Login"
+#~ msgstr "Darrièra connexion"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Activar l'identificacion de connexion per emprenta digitala"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Autre det :"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "L'enregistrament de vòstra emprenta digitala a capitat. Vos caldriá ara "
+#~ "poder vos identificar amb l'ajuda del lector d'emprentas digitalas."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Avètz pas accès al periferic. Contactatz vòstre administrator del sistèma."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Una error intèrna s'es produita."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Suprimir las emprentas enregistradas ?"
+
+#~ msgid "Done!"
+#~ msgstr "Acabat !"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Impossible d’accedir al periferic « %s »"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Impossible d'aviar la captura d’emprentas amb lo periferic « %s »"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Contactatz vòstre administrator del sistèma per assisténcia."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Per activar l’autentificacion per emprentas digitalas, vos cal "
+#~ "enregistrar una de vòstras emprentas amb l’ajuda del periferic « %s »."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Seleccion del det"
+
+#~ msgid "_Background"
+#~ msgstr "_Rèireplan"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Evolua al cors de la jornada"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Mosaïca"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrat"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Redimensionat"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Emplenat"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Espandit"
+
+#~ msgid "Colors"
+#~ msgstr "Colors"
+
+#~ msgid "Pictures"
+#~ msgstr "Imatges"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Cap d'imatge pas trobat"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Podètz apondre d'imatges dins vòstre dorsièr %s ont s'aficharàn"
+
+#~| msgid "Bluetooth"
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~| msgid "Preferences"
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~| msgid "Right Ring"
+#~ msgid "_Night Light"
+#~ msgstr "Mòde _nuèit"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Impossible d'obténer las informacions a prepaus de l'ecran"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "hardware"
+#~ msgstr "material"
+
+#~| msgid "Preferences;Settings;"
+#~ msgid "preferences-system-notifications"
+#~ msgstr "preferences-system-notifications"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "Mesa en velha _automatica"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Quand lo boton Aviar es quichat"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~| msgid "No printers"
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Bascular cap a la font precedenta"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Bascular cap a la font seguenta"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Basculament alternatiu cap a la font seguenta"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Anglés (Granda Bretanha)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Granda Bretanha"
+
+#~ msgid "_Options"
+#~ msgstr "_Opcions"
+
+#~ msgid "Add input source"
+#~ msgstr "Apondre la font d'entrada"
+
+#~ msgid "Remove input source"
+#~ msgstr "Suprimir la font d'entrada"
+
+#~ msgid "Move input source up"
+#~ msgstr "Desplaçar la font d'entrada cap amont"
+
+#~ msgid "Move input source down"
+#~ msgstr "Desplaçar la font d'entrada cap aval"
+
+#~ msgid "Configure input source"
+#~ msgstr "Configurar la font d'entrada"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Afichar la disposicion de clavièr de la font d'entrada"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Esquèrra"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Dreita"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimum"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maximum"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Caisson de bassa :"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Pas amplificat"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Perfil :"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Tèst dels nautparlaires"
+
+#~ msgid "Peak detect"
+#~ msgstr "Detector de pics"
+
+#~ msgid "Device"
+#~ msgstr "Periferic"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Tèst de nautparlaire per %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Seleccionar un periferic per la sortida son :"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Paramètres del periferic seleccionat :"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Volum d'entrada :"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Seleccionar un periferic per l'entrada son :"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Efèits sonòrs"
+
+#~ msgid "Built-in"
+#~ msgstr "Integrat"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferéncias del son"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Tèst d'un eveniment sonòr"
+
+#~ msgid "From theme"
+#~ msgstr "Del tèma"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "C_ausir una alèrta sonòra :"
+
+#~ msgid "Stop"
+#~ msgstr "Arrestar"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Verificar lo senhal novèl"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Senhals pas concordants."
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Normal"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrator"
+
+#~| msgid "The username cannot start with a '-'."
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Lo nom d’utilizaire pòt pas començar per « - »."
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "page 3"
+#~ msgstr "pagina 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Centre de contròle GNOME"
+
+#~| msgid ""
+#~| "The control center is GNOME's main interface for configuration of "
+#~| "various aspects of your desktop."
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Lo centre de contròle es l’interfàcia principala de GNOME per la "
+#~ "configuracion de divèrses aspèctes de vòstre environament."
+
+#~ msgid "Quit"
+#~ msgstr "Quitar"
+
+#~| msgid "Control Center"
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "Back­ground"
+#~ msgstr "Rèireplan"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Ecran rabatut"
+
+#~ msgid "Mirrored"
+#~ msgstr "Clonats"
+
+#~ msgid "Secondary"
+#~ msgstr "Segondari"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Organizar los ecrans associats"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Fasètz lisar los ecrans per los reorganizar"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Pivotar de 90° cap a esquèrra"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Pivotar de 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Pivotar de 90° cap a dreita"
+
+#~ msgid "Size"
+#~ msgstr "Talha"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr ""
+#~ "Afichar la barra superiora e la vista d'ensemble de las activitats sus "
+#~ "aqueste ecran"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Associar aqueste ecran a un autre per alarguir l'espaci de trabalh"
+
+#~ msgid "Presentation"
+#~ msgstr "Presentacion"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Afichar pas que los diaporamas e los mèdias"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Afichar vòstra vista actuala suls dos ecrans"
+
+#~ msgid "Turn Off"
+#~ msgstr "Atudar"
+
+#~ msgid "Don't use this display"
+#~ msgstr "Utilizetz pas aqueste ecran"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Organizar los ecrans clonats"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d bits"
+
+#~ msgid "Overview"
+#~ msgstr "Vista d'ensemble"
+
+#~ msgid "De­tails"
+#~ msgstr "Detalhs"
+
+#~ msgid "Base system"
+#~ msgstr "Distribucion"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Acorchi;Repeticion;Cluquejament;"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Per modificar un acorchi, clicatz sus la linha e accionatz las novèlas "
+#~ "tòcas, o alara quichatz « Retorn arrièr » per l'escafar."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Accion desconeguda>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "L'acorchi « %s » pòt pas èsser utilizat perque una picada amb aquesta "
+#~ "tòca vendriá impossibla.\n"
+#~ "Ensajatz amb una tòca tala coma Ctrl, Alt o Maj simultanèament."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "L'acorchi de clavièr « %s » es ja utilizat per \n"
+#~ "« %s »"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Se reassignatz l'acorchi a « %s », l'acorchi « %s » serà desactivat."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Reassignar"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "L'acorchi « %s » es associat a « %s ». Lo volètz definir automaticament a "
+#~ "« %s » ?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "Coma « %s » es actualament associat a « %s », aqueste acorchi serà "
+#~ "desactivat se contunhatz."
+
+#~ msgid "_Assign"
+#~ msgstr "_Assigner"
+
+#~ msgid "Server"
+#~ msgstr "Servidor"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Suprimir lo servidor DNS"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Metre a disposicion dels autres _utilizaires"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Zòna del parafuòc"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Per defaut"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "La zòna definís lo nivèl de fisança de la connexion"
+
+#~ msgid "Bond"
+#~ msgstr "Ligam"
+
+#~ msgid "Team"
+#~ msgstr "Agrégat (équipe)"
+
+#~ msgid "Bridge"
+#~ msgstr "Pont"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Impossible de cargar los empeutons del VPN"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Apondre una connexion ret"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Reïnicializar los paramètres d'aquesta ret, inclús lo senhal, mas se "
+#~ "remembrar qu'es una ret preferida"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Suprimir totes los detalhs relatius a aquesta ret e se connectar pas "
+#~ "automaticament"
+
+#~ msgid "Net­work"
+#~ msgstr "Ret"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Esclaus ligam"
+
+#~ msgid "(none)"
+#~ msgstr "(pas res)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Esclaus pont"
+
+#~ msgid "Team slaves"
+#~ msgstr "Esclaves de l’agrégat de tipe « Équipe »"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Se dispausatz d'una connexion filara cap a Internet, podètz crear un punt "
+#~ "d'accès sens fial per partejar vòstra connexion amb los autres."
+
+#~ msgid "Proxy"
+#~ msgstr "Mandatari"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Apondre un perfil…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Cap de"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manuala"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatica"
+
+#~ msgid "VPN Type"
+#~ msgstr "Tipe de VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "Nom del grop"
+
+#~ msgid "Group Password"
+#~ msgstr "Senhal del grop"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Utilizar coma punt d'accès…"
+
+#~ msgid "_History"
+#~ msgstr "_Istoric"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "Lo periferic infiniBand pren pas en carga lo mòde connectat"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Pas de certificat d'autoritat de certificacion de causit"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "La non utilizacion d'un certificat d'autoritat de certificacion (CA) pòt "
+#~ "provocar de connexions non securizadas e a un piratatge de la ret Wi-Fi. "
+#~ "Causissètz un certificat d'autoritat de certificacion ?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignorar"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Causir un certificat CA"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "D_emandar aqueste senhal a cada còp"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "M'_avertir pas mai"
+
+#~ msgid "Yes"
+#~ msgstr "Òc"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Bandièras de notificacion"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Notificacions"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "_Bandièras de notificacion"
+
+#~ msgid "Add Account"
+#~ msgstr "Apondre un compte"
+
+#~ msgid "Mail"
+#~ msgstr "Corrièr electronic"
+
+#~ msgid "Contacts"
+#~ msgstr "Contactes"
+
+#~ msgid "Chat"
+#~ msgstr "Discussion"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Error de connexion sul compte"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Vòstres identificants an expirat."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Identificatz-vos per activar aqueste compte."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Identificacion"
+
+#~ msgid "Error creating account"
+#~ msgstr "Error al moment de la creacion del compte"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Sètz segur que volètz suprimir lo compte ?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Lo compte sul servidor serà pas suprimit."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Cap de compte en linha pas configurat"
+
+#~ msgid "Add an online account"
+#~ msgstr "Apondre un compte en linha"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "L'apondon d'un compte permet a vòstras aplicacions de s'i connectar per "
+#~ "accedir a Documents, Corrièr electronic, Contactes, Agenda, Discussion e "
+#~ "plan mai encara."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Configuracion en cors"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nivèl de toner"
+
+#~ msgid "Supply Level"
+#~ msgstr "Estat dels consomables"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Installacion en cors"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u activa"
+#~ msgstr[1] "%u activas"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Apondon d'una novèla imprimenta"
+
+#~ msgid "No printers detected."
+#~ msgstr "Cap d'imprimenta pas detectada."
+
+#~ msgid "Supply"
+#~ msgstr "Consomables"
+
+#~ msgid "Jobs"
+#~ msgstr "Prètzfaits"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Afichar los _prètzfaits"
+
+#~ msgid "label"
+#~ msgstr "etiqueta"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Imprimir la pagina _tèst"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Confidencialitat"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Autre"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Partiment"
+
+#~ msgid ""
+#~ "Media sharing allows you to share music, photos and videos over the "
+#~ "network."
+#~ msgstr ""
+#~ "Lo partiment multimèdia vos permet d'escambiar de musica, de fòtos e de "
+#~ "vidèos sus la ret."
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Accès universal"
+
+#~ msgid "_Verify"
+#~ msgstr "_Verificar"
+
+#~ msgid "Login History"
+#~ msgstr "Istoric de connexion"
+
+#~ msgid "Add User Account"
+#~ msgstr "Apondre un compte d'utilizaire"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Ensajatz d'apondre mai de letras, chifras e simbòls."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Fòrça : insufisenta"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Fòrça : bassa"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Fòrça : mejana"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Fòrça : corrècta"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Fòrça : nauta"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Disable image"
+#~ msgstr "Desactivar l'imatge"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Recercar d'autres imatges…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Utilizat per %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Autres comptes"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Un utilizaire nomenat « %s » existís ja."
+
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "Un nom d'utilizaire pòt pas conténer que de letras minusculas o "
+#~ "majusculas de a a z, de chifras e un dels caractèrs « . », « - » o « _ »."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Naut"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Bas"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Pas cap"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Tauleta  Wacom"
+
+#~ msgid "Left Ring"
+#~ msgstr "Ring esquèrra"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Mòde Ring esquèrra numèro %d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Mòde Ring dreit numèro %d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Touchstrip esquèrra"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Mòde Touchstrip esquèrra numèro %d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Touchstrip dreit"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Mòde Touchstrip dreit numèro %d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Comutator del mòde Touchring esquèrra"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Comutator del mòde Touchring dreit"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Comutator del mòde Touchstrip esquèrra"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Comutator del mòde Touchstrip dreit"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Comutator de mòde numèro %d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Boton esquèrra numèro %d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Boton dreit numèro %d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Boton superior numèro %d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Boton inferior numèro %d"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Clic del boton esquèrre de la mirga"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Desfilament cap amont"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Desfilament cap aval"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Desfilament cap a dreita"
+
+#~ msgid "Show the overview"
+#~ msgstr "Afichar l'apercebut"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Material"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistèma"
+
+#~ msgid "Batariás"
+#~ msgstr "Batariás"
+
+#~ msgid "Beep when a _modificar key is pressed"
+#~ msgstr "Emetrà un bip quand una tòca _modificatritz es quichada"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Servent a déterminer vòstra position géographique"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Parametrar lo periferic novèl"
+
+#~ msgid "Paired"
+#~ msgstr "Apariat"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Paramètres de la mirga e del pavat tactil"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Paramètres del clavièr"
+
+#~ msgid "Send Files…"
+#~ msgstr "Mandar los fichièrs…"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Visibilitat de « %s »"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Levar « %s » de la lista dels periferics ?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Se levatz lo periferic, vos lo caldrà parametrar tornamai abans "
+#~ "l'utilizacion que ven."
+
+#~ msgid "Done"
+#~ msgstr "Acabat"
+
+#~ msgid "United States"
+#~ msgstr "Estats Units d'America"
+
+#~ msgid "Germany"
+#~ msgstr "Alemanha"
+
+#~ msgid "Spain"
+#~ msgstr "Espanha"
+
+#~ msgid "China"
+#~ msgstr "China"
+
+#~ msgid "Time _Zone"
+#~ msgstr "_Fus orari"
+
+#~ msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+#~ msgstr "Panèl;Projector;xrandr;Ecran;Definicion;Resolucion;Refrescament;"
+
+#~ msgid "Install Updates"
+#~ msgstr "Installar las mesas a jorn"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Sistèma a jorn"
+
+#~ msgid "Checking for Updates"
+#~ msgstr "Recèrca de mesas a jorn"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Relambi :"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Cort"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Long"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapida"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Velocitat :"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Testar vòstres paramètres"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Lent"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapid"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Esquèrre"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Dreit"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Velocitat del puntador"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapida"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapida"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Desac_tivar al moment de la picada"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr ""
+#~ "Los servicis ret del sistèma son pas compatibles amb aquesta version."
+
+#~ msgid "Export VPN connection..."
+#~ msgstr "Exportacion de la connexion VPN…"
+
+#~ msgid ""
+#~ "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
+#~ "vpn;vlan;bridge;bond;"
+#~ msgstr ""
+#~ "Ret;Sens fial;Wi-Fi;Wifi;IP;LAN;Mandatari;WAN;Benda larga;Modèm;Bluetooth;"
+#~ "vpn;vlan;pont;ligam;ligada;"
+
+#~ msgid "Choose a PAC file..."
+#~ msgstr "Causir un fichièr PAC…"
+
+#~ msgid "Choose a Certificate Authority certificate..."
+#~ msgstr "Causir un certificat d'una autoritat de certificacion…"
+
+#~ msgid "Choose your personal certificate..."
+#~ msgstr "Causissètz vòstre certificat personal…"
+
+#~ msgid "Choose your private key..."
+#~ msgstr "Causissètz vòstra clau privada…"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Afichar los messatges surgissents"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "Afichar las informacions dins los messatges"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Afichatge amb l'ecran verrolhat"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Afichar los messatges surgissents"
+
+#~ msgid ""
+#~ "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+#~ "ownCloud;Kerberos;IMAP;SMTP;"
+#~ msgstr ""
+#~ "Google;Facebook;Twitter;Yahoo;Web;En linha;Discussion;Agenda;Corrièr "
+#~ "electronic;Email;Contacte;ownCloud;Kerberos;IMAP;SMTP;"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Atuda los periferics sens fial"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Quand la resèrva d'energia es a un nivèl _critic"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Reprene l'impression"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Metre l'impression en pausa"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Recercar d'imprimentas de ret o filtrar lo resultat"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr ""
+#~ "Picatz l'adreça d'una imprimenta o del tèxte per filtrar los resultats"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Suspenduda"
+
+#~ msgid "Job Title"
+#~ msgstr "Intitulat del prètzfait"
+
+#~ msgid "Job State"
+#~ msgstr "Estat del prètzfait"
+
+#~ msgid "_Default"
+#~ msgstr "Per _defaut"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Apondre una imprimenta novèla"
+
+#~ msgid "Immediately"
+#~ msgstr "Immediatament"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Pas cap"
+
+#~ msgid "Sorry"
+#~ msgstr "O planhèm"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Lo partiment per Bluetooth vos permet de partejar de fichièrs amb "
+#~ "d'autres periferics connectats"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Partejar lo dorsièr public"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Recebre pas que dempuèi de periferics fisables"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Enregistrar los fichièrs recebuts dins lo dorsièr Telecargaments"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Partejar pas qu'amb de periferics fisables"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Partejar los mèdias sus aquesta ret"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Partejar los dorsièrs"
+
+#~ msgid "column"
+#~ msgstr "colomna"
+
+#~ msgid "Add Folder"
+#~ msgstr "Apondre un dorsièr"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Suprimir un dorsièr"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Partejar lo Dorsièr public sus aquesta ret"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Autorizar totas las connexions"
+
+#~ msgid ""
+#~ "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;"
+#~ "size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+#~ msgstr ""
+#~ "Clavièr;Mirga;ligam;Accessibilitat;Contraste;Zoom;Lector d'ecran;tèxte;"
+#~ "poliça;talha;Accedir a X;Tòcas remanentas;Tòcas lentas;Rebombs de tòcas;"
+#~ "Tòcas de la mirga;"
+
+#~ msgid "Pointing and Clicking"
+#~ msgstr "Puntatge e clic de mirga"
+
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgid "A user with the username '%s' already exists"
+#~ msgstr "Un utilizaire nomenat « %s » existís ja"
+
+#~ msgid "The username is too long"
+#~ msgstr "Lo nom d'utilizaire es tròp long"
+
+#~ msgid "The username cannot start with a '-'"
+#~ msgstr "Un nom d'utilizaire pòt pas començar per « - »"
+
+#~ msgid "Show help options"
+#~ msgstr "Aficha las opcions de l'ajuda"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Aviar « %s --help » per afichar la lista completa de las opcions en linha "
+#~ "de comanda disponiblas.\n"
+
+#~ msgid "Device type:"
+#~ msgstr "Tipe de periferic :"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Fabricant :"
+
+#~ msgid "Model:"
+#~ msgstr "Modèl :"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Des fichièrs images pòdon èsser lisats dins aquesta fenèstra per "
+#~ "completar automatiquement los camps çaisús."
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "Afichar vòstra vista principala sus aqueste ecran tanben"
+
+#~ msgid "Combine"
+#~ msgstr "Associar"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "Accoller amb l'ecran principal per élargir l'espace"
+
+#~ msgid "Don't use the display"
+#~ msgstr "Utilizar pas l'ecran"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Preferéncias de la mirga"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Seleccionar l'interface a utilizar per lo nouveau service"
+
+#~ msgid "C_reate…"
+#~ msgstr "C_rear…"
+
+#~ msgid "_Interface"
+#~ msgstr "_Interfàcia"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Modificar la fòto de :"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Causir un imatge a afichar sus l'ecran de connexion per aqueste compte."
+
+#~ msgid "Gallery"
+#~ msgstr "Colleccion d'imatges"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Prene una fòto"
+
+#~ msgid "Browse"
+#~ msgstr "Recercar"
+
+#~ msgid "Photograph"
+#~ msgstr "Fòto"
+
+#~ msgid "Account Information"
+#~ msgstr "Informacions del compte"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Bascular entre AM e PM."
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "Autonomie estimée : %s"
+
+#~ msgid "Export"
+#~ msgstr "Exporter"
+
+#~ msgid "Left Shift"
+#~ msgstr "Maj d'esquèrra"
+
+#~ msgid "Right Shift"
+#~ msgstr "Maj de dreita"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Alt+Maj d'esquèrra"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Alt+Maj de dreita"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Ctrl+Maj d'esquèrra"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Ctrl+Maj de dreita"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Maj de dreita+Maj d'esquèrra"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Ctrl d'esquèrra+Ctrl de dreita"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Maj"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Maj"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Maj+Verr.Maj."
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Verr.Maj."
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Verr.Maj."
+
+#~ msgid "_Region:"
+#~ msgstr "_Region :"
+
+#~ msgid "_City:"
+#~ msgstr "_Vila :"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Avançar la data d'una ora."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Recular la data d'una ora."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Avançar l'ora d'una minuta."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Recular l'ora d'una minuta."
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM "
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Normale"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "Sens antiorari"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Sens orari"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 grases"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Seleccionatz un ecran per modificar ses proprietats ; fasètz-lo lisar per "
+#~ "lo desplaçar."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Impossible d'enregistrar la configuracion de l'ecran"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Definicion"
+
+#~ msgid "R_otation"
+#~ msgstr "R_otacion"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Meteis imatge sus totes los ecrans"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Nòta : aquò pòt restrénher las opcions de definicion"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "Lenta"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapida"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "Lo c_ontengut pega als dets"
+
+#~ msgid "blablabla"
+#~ msgstr "blablabla"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "La seccion\n"
+#~ "adreça\n"
+#~ "ven\n"
+#~ "aicí"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "La seccion\n"
+#~ "DNS\n"
+#~ "ven\n"
+#~ "aicí"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "La seccion\n"
+#~ "routes\n"
+#~ "ven\n"
+#~ "aicí"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "Hidden"
+#~ msgstr "Amagat"
+
+#~ msgid "Visible"
+#~ msgstr "Visible"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "Nom e visibilitat"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "Controlar vòstra aparéncia a l'ecran e sus la ret."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "Afichar lo nom _complet dins la barra superiora"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "Afichar lo nom complet quand l'ecran es _verrolhat"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "Mòde _furtiu"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Elevat/inversat"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Clavièr visual"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75 %"
+
+#~ msgid "100%"
+#~ msgstr "100 %"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Normala"
+
+#~ msgid "125%"
+#~ msgstr "125 %"
+
+#~ msgid "150%"
+#~ msgstr "150 %"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Emetre un bip quand Maj. e Verr. Num. son enfoncés"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "Activar o desactivar :"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Zoom avant :"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Zoom arrièr :"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "Sostitolatge"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Aficha una descripcion textuala de la paraula e dels sons"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "Cort"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "Long"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Emetre un bip quand una tòca es"
+
+#~ msgid "pressed"
+#~ msgstr "quichada"
+
+#~ msgid "accepted"
+#~ msgstr "acceptada"
+
+#~ msgid "rejected"
+#~ msgstr "refusada"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "Relambi d'acc_eptacion :"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Contròle del puntador amb l'ajuda del pavat numeric"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Souris vidèo"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Contròle del puntador amb l'ajuda de la camèra vidèo."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "Feble"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "Elevat"
+
+#~ msgid "_Local Account"
+#~ msgstr "Compte _local"
+
+#~ msgid "_Login Name"
+#~ msgstr "No_m de connexion"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "Astúcia : domeni d'entrepresa o nom de domeni"
+
+#~ msgid "C_ontinue"
+#~ msgstr "C_ontunhar"
+
+#~ msgid "Next Week"
+#~ msgstr "La setmana seguenta"
+
+#~ msgid "Next week"
+#~ msgstr "La setmana seguenta"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Connexion sens senhal"
+
+#~ msgid "Disable this account"
+#~ msgstr "Desactivar aqueste compte"
+
+#~ msgid "Enable this account"
+#~ msgstr "Activar aqueste compte"
+
+#~ msgid "_Action"
+#~ msgstr "_Accion"
+
+#~ msgid "_Show password"
+#~ msgstr "Afi_char lo senhal"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Cossí causir un senhal fòrt"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Tròp cort"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "Insufisent"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Faible"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Corrècte"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Bon"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Fòrt"
+
+#~ msgid "_Generate a password"
+#~ msgstr "_Generar un senhal"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "Vos cal sasir un senhal novèl"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "Lo senhal novèl es trop faible"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "Vos cal confirmer lo senhal"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "Es necessari que sasiscatz vòstre senhal actual"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "Lo senhal actual es incorrècte"
+
+#~ msgid "Switch Modes"
+#~ msgstr "Inversar los mòdes"
+
+#~ msgid "Action"
+#~ msgstr "Accion"
+
+#~ msgid "_Options…"
+#~ msgstr "_Opcions…"
+
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "Pas cap"
+
+#~ msgid "Change the background"
+#~ msgstr "Modificar lo rèireplan"
+
+#~ msgid "Browse Files..."
+#~ msgstr "Recercar de fichièrs..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Perfils disponibles pels ecrans"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Perfils disponibles pels scanners"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Perfils disponibles per las imprimentas"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Perfils disponibles pels aparelhs de fòto"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Perfils disponibles per las webcams"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i an"
+#~ msgstr[1] "%i ans"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i mes"
+#~ msgstr[1] "%i meses"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i setmana"
+#~ msgstr[1] "%i setmanas"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "Moins d'una setmana"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "Aqueste periferic es pas pres en carga al nivèl des colors."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "Aqueste periferic utiliza de donadas étalonnées en usine."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "Aqueste periferic possedís pas un perfil apropriat per la correccion de "
+#~ "las colors de l'ecran complet."
+
+#~ msgid "Not specified"
+#~ msgstr "Pas especificat"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr ""
+#~ "Cap de periferic acceptant la gestion de color es pas estat detectat"
+
+#~ msgid "Add device"
+#~ msgstr "Apondre lo periferic"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "Apondre un periferic virtual"
+
+#~ msgid "Color management settings"
+#~ msgstr "Paramètres de gestion de las colors"
+
+#~ msgid "English"
+#~ msgstr "Anglés"
+
+#~ msgid "British English"
+#~ msgstr "Anglés britanic"
+
+#~ msgid "French"
+#~ msgstr "Francés"
+
+#~ msgid "Spanish"
+#~ msgstr "Espanhòl"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "Chinés (simplifié)"
+
+#~ msgid "Russian"
+#~ msgstr "Russe"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabe"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Panèl de las preferéncias per la data e l'ora"
+
+#~ msgid "%d x %d (%s)"
+#~ msgstr "%d x %d (%s)"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA : %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "Modèl desconegut"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr ""
+#~ "La configuracion estandarda serà ensajada al moment de ka connexion que "
+#~ "ven."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "Lo mode restrent, conçu per las cartas graficas non presas en carga, serà "
+#~ "utilizat al moment de ka connexion que ven."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Restrent"
+
+#~ msgid "System Information"
+#~ msgstr "Informacions sistèma"
+
+#~ msgid "_Other Media..."
+#~ msgstr "_Autres mèdias..."
+
+#~ msgid "Experience"
+#~ msgstr "Experiéncia"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "Mòde _restrent forcé"
+
+#~ msgid "Layout Settings"
+#~ msgstr "Paramètres d'agençament"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Definir las preferéncias per la mirga e lo pavat tactil"
+
+#~ msgid "_Options..."
+#~ msgstr "_Opcions..."
+
+#~ msgid "C_reate..."
+#~ msgstr "C_rear..."
+
+#~ msgid "Wireless"
+#~ msgstr "Sens fial"
+
+#~ msgid "_Disconnect"
+#~ msgstr "Se _desconnectar"
+
+#~ msgid "_Connect"
+#~ msgstr "Se _connectar"
+
+#~ msgid "Mesh"
+#~ msgstr "Mesh"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "Porteuse/ligam modificat"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "Donadas d'autentificacion expiradas. Connectatz-vos tornamai."
+
+#~ msgid "_Log In"
+#~ msgstr "Se co_nnectar"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "Gerir los comptes en linha"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "Atencion batariá febla, demòra environ %s d'utilizacion"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "Sus batariá - Demòra environ %s d'utilizacion"
+
+#~ msgid "Using battery power"
+#~ msgstr "Sus batariá"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "En carga - completament cargada"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "Sus ondulator - demòra environ %s d'utilizacion"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "Atencion, ondulator feble"
+
+#~ msgid "Using UPS power"
+#~ msgstr "Sus ondulator"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "Vòstra batariá segondària es completament cargada"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "Vòstra batariá segondària es descargada"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "En carga - completament cargada"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "Astúcia : la <a href=\"screen\">luminositat de l'ecran</a> influence la "
+#~ "consommation d'energia"
+
+#~ msgid "Power management settings"
+#~ msgstr "Paramètres de gestion de l'energia"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "Metre en velha se inactiu dempuèi"
+
+#~ msgid "%s Options"
+#~ msgstr "Opcions per %s"
+
+#~ msgid "Manufacturers"
+#~ msgstr "Fabricants"
+
+#~ msgid "Drivers"
+#~ msgstr "Pilòts"
+
+#~ msgid "_Show"
+#~ msgstr "_Afichar"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "Modificar los paramètres de país e de lenga"
+
+#~ msgid "Choose an input source"
+#~ msgstr "Seleccionar una font d'entrada"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "Seleccionar una font d'entrada a apondre"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "L'ecran de connexion, los comptes sistèma e ceux des nouveaux utilizaires "
+#~ "utilizan los paramètres de país e de lenga del sistèma."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "L'ecran de connexion, los comptes sistèma e ceux des nouveaux utilizaires "
+#~ "utilizan los paramètres de país e de lenga del sistèma. Podètz modificar "
+#~ "los paramètres del sistèma per los far correspondre als vòstres."
+
+#~ msgid "Copy Settings"
+#~ msgstr "Copiar los paramètres"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "Copiar los paramètres..."
+
+#~ msgid "Region and Language"
+#~ msgstr "Pays e lenga"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Causissètz una lenga d'afichatge (la modificacion serà presa en compte a "
+#~ "la connexion que ven)"
+
+#~ msgid "Add Language"
+#~ msgstr "Apondre una lenga"
+
+#~ msgid "Remove Language"
+#~ msgstr "Suprimir la lenga"
+
+#~ msgid "Install languages..."
+#~ msgstr "Installar de lengas..."
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr ""
+#~ "Causissètz una region (la modificacion serà presa en compte a la "
+#~ "connexion que ven)"
+
+#~ msgid "Add Region"
+#~ msgstr "Apondre una region"
+
+#~ msgid "Currency"
+#~ msgstr "Moneda"
+
+#~ msgid "Examples"
+#~ msgstr "Exemples"
+
+#~ msgid "Remove Input Source"
+#~ msgstr "Suprimir la font d'entrada"
+
+#~ msgid "Move Input Source Up"
+#~ msgstr "Desplaçar la font d'entrada cap amont"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Barra d'espaci"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "Paramètres d'acorchi"
+
+#~ msgid "Input source:"
+#~ msgstr "Font d'entrada :"
+
+#~ msgid "Format:"
+#~ msgstr "Format :"
+
+#~ msgid "Your settings"
+#~ msgstr "Vòstres paramètres"
+
+#~ msgid "System settings"
+#~ msgstr "Paramètres sistèma"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "Luminositat & verrolhatge"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Luminositat;Verrolhatge;Verrolhar;Estomper;Velha;Atudar;Ecran;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "_Diminuer la luminositat per estalviar la batariá"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "Verrolhar pas en çò seu"
+
+#~ msgid "Locations..."
+#~ msgstr "Emplaçaments..."
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Activar lo còdi de desbugatge"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — Applet del contròle de volum GNOME"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Afichar lo contròle de volum sul burèu"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Volum sonore en sortida"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "Preferéncias del _son"
+
+#~ msgid "Muted"
+#~ msgstr "Assordit"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Preferéncias de l'accès universel"
+
+#~ msgid "Options..."
+#~ msgstr "Opcions..."
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "Color"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "Pas cap"
+
+#~ msgid "User Accounts"
+#~ msgstr "Comptes utilizaire"
+
+#~ msgid "_Hint"
+#~ msgstr "_Indicacion"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "Aquesta indication es afichada sus l'ecran de connexion. Elle es visible "
+#~ "a totes los utilizaires del sistèma. <b>Ne pas</b> i inclure lo senhal."
+
+#~ msgid "Fair"
+#~ msgstr "Corrècte"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Recercar d'autres imatges..."
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "I a pas d'utilizaire nomenat « %s »."
+
+#~ msgid "This user does not exist."
+#~ msgstr "Aqueste utilizaire existís pas."
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Definir las preferéncias per la tauleta Wacom"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "Associar los botons..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "Escandalhar..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- Paramètres sistèma"
+
+#~ msgid "System Settings"
+#~ msgstr "Paramètres sistèma"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Los periferics sens fial an besonh de poténcia suplementària"
+
+#~ msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
+#~ msgstr ""
+#~ "Los periferics mobiles a large bande (3G, 4G, WiMax, etc.) ont besonh de "
+#~ "poténcia suplementària"
+
+#~ msgid "Password:"
+#~ msgstr "Senhal :"
+
+#~ msgid "_Off"
+#~ msgstr "_Désactivat"

--- a/po/or.po
+++ b/po/or.po
@@ -7,9 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.master.or\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-08-20 06:31+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-08-25 17:01+0530\n"
 "Last-Translator: Manoj Kumar Giri <mgiri@redhat.com>\n"
 "Language-Team: Oriya <oriya-it@googlegroups.com>\n"
@@ -32,523 +31,424 @@ msgstr ""
 "\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "ପ୍ରୟୋଗ"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "କୌଣସି ପ୍ରୟୋଗ ମିଳିଲା ନାହିଁ"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "ସ୍ଥାପିତ"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "ଖୋଲନ୍ତୁ (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "ବିବରଣୀ ଦେଖନ୍ତୁ"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "ଖୋଜନ୍ତୁ"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "ନିଷ୍କ୍ରିୟ ହୋଇଗଲା"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "ବିଜ୍ଞପ୍ତି ଦର୍ଶାନ୍ତୁ (_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "ପୃଷ୍ଠଭୂମି"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "ପରଦା ପ୍ରତିଛବିଗୁଡ଼ିକ"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "ୱାଲପେପରଗୁଡ଼ିକ"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "ଶବ୍ଦ"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥ"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "କିବୋର୍ଡ ସର୍ଟକଟଗୁଡିକ"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s କ୍ୟାମେରା"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "ମାଇକ୍ରୋଫନ ଭଲ୍ଯୁମ"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "ଅବସ୍ଥାନ ସର୍ଭିସ (_L)"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "ଅନ୍ତଃନିର୍ମିତ ୱେବକ୍ୟାମ୍‌"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "କୌଣସି ସ୍ଥାନ ମିଳିଲା ନାହିଁ"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "ପ୍ରଦର୍ଶନୀ ପ୍ରକାର"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "ସଂଯୋଗ ଗତି"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "ପୁନଃସ୍ଥାପନ କରନ୍ତୁ"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "ପ୍ରୟୋଗ"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>ଖୋଲନ୍ତୁ</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "ଶୈଳୀ (_S):"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "ପୃଷ୍ଠଭୂମି"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "ଦିନ ସାରା ହୋଇଥିବା ପରିବର୍ତ୍ତନଗୁଡ଼ିକ"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "ରୂପରେଖା ଯୋଗ କରନ୍ତୁ (_A)..."
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-#| msgid "Lock screen"
-msgid "Lock Screen"
-msgstr "ପରଦାକୁ ତାଲା ଦେଇ ରଖନ୍ତୁ"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "ଫ୍ରାନ୍ସ"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "ଟାଇଲ"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
+msgstr "ଆପଣଙ୍କର ପୃଷ୍ଠଭୂମି ପ୍ରତିଛବିକୁ  ୱାଲପେପର୍‌ କିମ୍ବା ଫୋଟୋ ଆକାରରେ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
 
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "ଛୋଟବଡ଼ କରନ୍ତୁ"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "କେନ୍ଦ୍ର"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "ମାପ"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "ପୂରଣ କରନ୍ତୁ"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "ଧାଡ଼ି ବିସ୍ତାର"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:442
-msgid "Select Background"
-msgstr "ପୃଷ୍ଠଭୂମି ବାଛନ୍ତୁ"
-
-#: ../panels/background/cc-background-chooser-dialog.c:463
-msgid "Wallpapers"
-msgstr "ୱାଲପେପରଗୁଡ଼ିକ"
-
-#: ../panels/background/cc-background-chooser-dialog.c:472
-msgid "Pictures"
-msgstr "ଚିତ୍ରଗୁଡିକ"
-
-#: ../panels/background/cc-background-chooser-dialog.c:481
-msgid "Colors"
-msgstr "ରଙ୍ଗଗୁଡକ"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:540
-#| msgid "No input sources found"
-msgid "No Pictures Found"
-msgstr "କୌଣସି ଛବି ମିଳିଲା ନାହିଁ"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:558
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "ମୂଳସ୍ଥାନ"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:570
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
-"ଆପଣ ନିଜର %s ଫୋଲଡରରେ ପ୍ରତିଛବିଗୁଡ଼ିକୁ ଯୋଗ କରିପାରିବେ ଏବଂ ସେଗୁଡ଼ିକ ଏଠାରେ ଦୃଶ୍ୟମାନ "
-"ହେବ"
 
-#: ../panels/background/cc-background-chooser-dialog.c:592
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1537
-#: ../panels/display/cc-display-panel.c:1976
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1240
-#: ../panels/network/net-device-wifi.c:1448
-#: ../panels/printers/cc-printers-panel.c:1947
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-#: ../panels/user-accounts/um-photo-dialog.c:95
-#: ../panels/user-accounts/um-photo-dialog.c:222
-#: ../panels/user-accounts/um-user-panel.c:513
-msgid "_Cancel"
-msgstr "ବାତିଲ କରନ୍ତୁ (_C)"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "ସକ୍ରିୟ କରନ୍ତୁ"
 
-#: ../panels/background/cc-background-chooser-dialog.c:593
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:97
-msgid "Select"
-msgstr "ବାଛନ୍ତୁ"
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "ଏକାଧିକ ଆକାର"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "କୌଣସି ଡେସ୍କଟପ ପୃଷ୍ଠଭୂମି ନାହିଁ"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "ପ୍ରଚଳିତ ପୃଷ୍ଠଭୂମି"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
-msgstr ""
-"ଆପଣଙ୍କର ପୃଷ୍ଠଭୂମି ପ୍ରତିଛବିକୁ  ୱାଲପେପର୍‌ କିମ୍ବା ଫୋଟୋ ଆକାରରେ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
-
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "ୱାଲପେପର;ପରଦା;ଡେସ୍କଟପ;"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "ବ୍ଲୁଟୁଥ ନିଷ୍କ୍ରିୟ ହୋଇଛି"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "କୌଣସି ବ୍ଲୁଟୁଥ ଏଡପଟର ମିଳିଲା ନାହିଁ"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "ବ୍ଲୁଟୁଥ ସହଭାଗ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "ବିମାନ ଧାରା (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "ବ୍ଲୁଟୁଥକୁ ହାର୍ଡୱେର ସ୍ୱିଚ ଦ୍ୱାରା ନିଷ୍କ୍ରିୟ କରାହୋଇଛି"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1688
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "ବିମାନ ଧାରା (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "ବିମାନ ଧାରା (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "ବ୍ଲୁଟୁଥ"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "ବ୍ଲୁଟୁଥ୍‌ କୁ ଅନ୍‌ କିମ୍ବା ଅଫ୍‌ କରି ଆପଣଙ୍କର ଉପକରଣ ସହିତ ସଂଯୋଗ କରନ୍ତୁ"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "ଆପଣଙ୍କର ମାପ ଉପକରଣକୁ ବର୍ଗ ଉପରେ ରଖନ୍ତୁ ଏବଂ 'ଆରମ୍ଭ କରନ୍ତୁ' କୁ ଦବାନ୍ତୁ"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "କୌଣସି ପ୍ରୟୋଗ ବର୍ତ୍ତମାନ ଧ୍ୱନି ଚଲାଉ ନାହିଁ କିମ୍ବା ଲେଖୁ ନାହିଁ।"
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"ଆପଣଙ୍କର ମାପ ଉପକରଣକୁ ମପା ହୋଇଥିବା ସ୍ଥାନକୁ ଗତିକରାନ୍ତୁ ଏବଂ 'ଆଗକୁ ବଢ଼ନ୍ତୁ' କୁ "
-"ଦବାନ୍ତୁ"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-"ଆପଣଙ୍କର ମାପ ଉପକରଣକୁ ଉପର ସ୍ଥାନକୁ ଗତିକରାନ୍ତୁ ଏବଂ 'ଆଗକୁ ବଢ଼ନ୍ତୁ' କୁ ଦବାନ୍ତୁ"
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "ଲ୍ୟାପଟପ ଲିଡ଼କୁ ବନ୍ଦ କରନ୍ତୁ"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "ଅଧିକ ଛବି ପାଇଁ ବ୍ରାଉଜ କରନ୍ତୁ"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "ଏକ ଆଭ୍ୟନ୍ତରୀଣ ତ୍ରୁଟି ଘଟିଛି ଯାହାକୁ ପୁଣି ପାଇବେ ନାହିଁ।"
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "ମାପିବା ପାଇଁ ଆବଶ୍ୟକ ସାଧନଗୁଡ଼ିକୁ ସ୍ଥାପନ କରାଯାଇନାହିଁ।"
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "ରୀପରେଖାକୁ ସୃଷ୍ଟି କରିହେବ ନାହିଁ।"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "ଲକ୍ଷ୍ଯସ୍ଥଳ ଧଳା ବିନ୍ଦୁଟି ହାସଲ ହୋଇନାହିଁ।"
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "ସମ୍ପୂର୍ଣ୍ଣ ହୋଇଛି !"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "ମାପ ବିଫଳ ହୋଇଛି!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "ଆପଣ ମାପ ଉପକରଣକୁ ବାହାର କରିପାରିବେ।"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "ମାପ ଉପକରଣକୁ କାର୍ଯ୍ୟରତ ସମୟରେ ବାଧା ଦିଅନ୍ତୁ ନାହିଁ"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "ଲ୍ୟାପଟପ୍‌ ପରଦା"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "ଅନ୍ତଃନିର୍ମିତ ୱେବକ୍ୟାମ୍‌"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s ମନିଟର୍‌"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s ସ୍କାନର"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s କ୍ୟାମେରା"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s ମୁଦ୍ରଣୀ"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s ୱେବ କାମେରା"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "ରଙ୍ଗ ପରିଚାଳନାକୁ %s ପାଇଁ ସକ୍ରିୟ କରନ୍ତୁ"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s ପାଇଁ ରଙ୍ଗ ରୂପରେଖା ଦର୍ଶାନ୍ତୁ"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-msgid "Not calibrated"
-msgstr "ମପା ହୋଇନଥିବା"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "ରଙ୍ଗ ସ୍ଥାନ:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "ପରୀକ୍ଷଣ ରୂପରେଖା: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "ICC ରୂପରେଖା ଫାଇଲ ମନୋନୀତ କରନ୍ତୁ"
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "ଆମଦାନୀ କରନ୍ତୁ (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "ସମର୍ଥିତ ICC ରୂପରେଖାଗୁଡ଼ିକ"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "ସମସ୍ତ ଫାଇଲଗୁଡ଼ିକ"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "ପରଦା"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "ଫାଇଲ ଧାରଣ କରିବାରେ ବିଫଳ : %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "ଏହି ରୂପରେଖାଟି ଏଥିରେ ଧାରଣ କରାଯାଇଛି:"
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "ଏହି URL କୁ ଲେଖନ୍ତୁ।"
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"ଏହି କମ୍ପୁଟରକୁ ପୁନଃଚାଳନ କରନ୍ତୁ ଏବଂ ଆପଣଙ୍କର ସାଧାରଣ ପ୍ରଚାଳନ ତନ୍ତ୍ରକୁ ବୁଟ କରନ୍ତୁ।"
 
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-"ରୂପରେଖାକୁ ଆହରଣ କରି ସ୍ଥାପନ କରିବା ପାଇଁ ଏହି URL କୁ ଆପଣଙ୍କ ବ୍ରାଉଜରରେ ଲେଖନ୍ତୁ।"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "ରୂପରେଖା ସରକ୍ଷଣ କରନ୍ତୁ"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "ସଂରକ୍ଷଣ (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "ବଚ୍ଛିତ ଉପକରଣ ପାଇଁ ଗୋଟିଏ ରଙ୍ଗ ରୂପରେଖା ପ୍ରସ୍ତୁତ କରନ୍ତୁ"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"ମାପ ଯନ୍ତ୍ରଟି ମିଳିନାହିଁ। ଏହା ଅନ ଅଛି କି ନାହିଁ ଏବଂ ସଠିକ ଭାବରେ ସଂଯୁକ୍ତ ହୋଇଛି କି "
-"ନାହିଁ ଯାଞ୍ଚ କରନ୍ତୁ।"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "ମାପ ଯନ୍ତ୍ରଟି ମୁଦ୍ରଣୀ ରୂପରେଖାକୁ ସମର୍ଥନ କରିନଥାଏ।"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "ଉପକରଣ ପ୍ରକାରଟି ବର୍ତ୍ତମାନ ସମର୍ଥିତ ନୁହଁ।"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "ମାନକ ସ୍ଥାନ"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "ପରୀକ୍ଷଣ ରୂପରେଖା"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "ସ୍ବୟଂଚାଳିତ"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "ନିମ୍ନ ଗୁଣବତ୍ତା"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "ମଧ୍ଯମ ଗୁଣବତ୍ତା"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "ଉଚ୍ଚ ଗୁଣବତ୍ତା"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ ଧୂସର"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "ବିକ୍ରେତା କାରଖାନା ପ୍ରଦତ୍ତ ମାପ ତଥ୍ୟ ପ୍ରଦାନ କରିଥାଏ"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "ସମ୍ପୂର୍ଣ୍ଣ ପରଦା ପ୍ରଦର୍ଶନୀ ସଂଶୋଧନ ଏହି ରୂପରେଖା ସହିତ ସମ୍ଭବ ନୁହଁ"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "ଏହି  ରୂପରେଖା ହୁଏତଃ ବର୍ତ୍ତମାନ ସଠିକ ହୋଇଥାଇନପାରେ"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "ମାପ ଦର୍ଶାନ୍ତୁ"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr "ବାତିଲ କରନ୍ତୁ"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "ବାତିଲ କରନ୍ତୁ (_C)"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "ଆରମ୍ଭ"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "ପୁନଃଚାଳନ କରନ୍ତୁ"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "ସମ୍ପନ୍ନ ହୋଇଛି"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "ସମାପ୍ତ (_D)"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "ପରଦା ମାପ"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "ମାପ ଗୁଣବତ୍ତା"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -557,6823 +457,7772 @@ msgstr ""
 "ମାପ ଦ୍ୱାରା ଏକ ରୂପରେଖା ଉତ୍ପନ୍ନ ହୋଇଥାଏ ଯାହାକୁ ଆପଣ ପରଦାର ରଙ୍ଗ ପରିଚାଳକରେ ବ୍ୟବହାର "
 "କରିପାରିବେ। ମାପିବାରେ ଆପଣ ଯେତେ ସମୟ ଦେବେ, ରଙ୍ଗ ରୂପରେଖା ସେତେ ଭଲ ହେବ।"
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "ଆପଣ ନିଜର କମ୍ପୁଟରକୁ ମାପିବା ସମୟରେ ବ୍ୟବହାର କରିପାରିବେ ନାହିଁ।"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "ଗୁଣବତ୍ତା"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "ପାଖାପାଖି ସମୟ"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "ମାପ ଗୁଣବତ୍ତା"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "ମାପିବା ପାଇଁ ଆପଣ ବ୍ୟବହାର କରୁଥିବା ସେନସର୍‌ ଉପକରଣକୁ ବାଛନ୍ତୁ।"
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "ମାପ ଉପକରଣ"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "ସଂଯୁକ୍ତ ଥିବା ପ୍ରଦର୍ଶନୀର ପ୍ରକାର ବାଛନ୍ତୁ।"
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ମାପିବା ପାଇଁ ଆପଣ ବ୍ୟବହାର କରୁଥିବା ସେନସର୍‌ ଉପକରଣକୁ ବାଛନ୍ତୁ।"
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "ପ୍ରଦର୍ଶନୀ ପ୍ରକାର"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "ସଂଯୁକ୍ତ ଥିବା ପ୍ରଦର୍ଶନୀର ପ୍ରକାର ବାଛନ୍ତୁ।"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "ରୂପରେଖା ଧଳାବିନ୍ଦୁ"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
-"ପ୍ରଦର୍ଶନୀ ଲକ୍ଷ୍ଯସ୍ଥଳ ଧଳା ବିନ୍ଦୁ ବାଛନ୍ତୁ। ଅଧିକାଂଶ ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକ D65 "
-"ପ୍ରଦୀପକରେ ବ୍ୟବସ୍ଥା "
+"ପ୍ରଦର୍ଶନୀ ଲକ୍ଷ୍ଯସ୍ଥଳ ଧଳା ବିନ୍ଦୁ ବାଛନ୍ତୁ। ଅଧିକାଂଶ ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକ D65 ପ୍ରଦୀପକରେ ବ୍ୟବସ୍ଥା "
 "କରାହୋଇଥାଏ।"
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "ରୂପରେଖା ଧଳାବିନ୍ଦୁ"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "ଉଜ୍ଜ୍ବଳତା ଦର୍ଶାନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"ଆପଣଙ୍କ ଆବଶ୍ୟକତା ମୁତାବକ ପ୍ରଦର୍ଶନୀ ଉଜ୍ଜ୍ୱଳତାକୁ ସେଟ କରନ୍ତୁ। ରଙ୍ଗ "
-"ପରିଚାଳନାଟିଉଜ୍ଜ୍ୱଳତା ସ୍ତର "
+"ଆପଣଙ୍କ ଆବଶ୍ୟକତା ମୁତାବକ ପ୍ରଦର୍ଶନୀ ଉଜ୍ଜ୍ୱଳତାକୁ ସେଟ କରନ୍ତୁ। ରଙ୍ଗ ପରିଚାଳନାଟିଉଜ୍ଜ୍ୱଳତା ସ୍ତର "
 "ଅନୁସାରେ ଅଧିକ ସଠିକ ହେବ।"
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
-msgstr ""
-"ଏହା ବ୍ୟତୀତ, ଆପଣ ଅନ୍ୟ ଉପକରଣ ପାଇଁ ବ୍ୟବହୃତ ଉଜ୍ଜ୍ୱଳତା ସ୍ତର ଅନୁସାରେ ବ୍ୟବହାର "
-"କରିପାରିବେ।"
+msgstr "ଏହା ବ୍ୟତୀତ, ଆପଣ ଅନ୍ୟ ଉପକରଣ ପାଇଁ ବ୍ୟବହୃତ ଉଜ୍ଜ୍ୱଳତା ସ୍ତର ଅନୁସାରେ ବ୍ୟବହାର କରିପାରିବେ।"
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "ଉଜ୍ଜ୍ବଳତା ଦର୍ଶାନ୍ତୁ"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "ରୂପରେଖ ନାମ"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
-"ଆପଣ ରଙ୍ଗ ରୂପରେଖାକୁ ଅନ୍ୟ ଏକ କମ୍ପୁଟରରେ ବ୍ୟବହାର କରିପାରିବେ, ଅଥବା ଭିନ୍ନ ଭିନ୍ନ ଆଲୋକ "
-"ଅନୁସାରେ "
+"ଆପଣ ରଙ୍ଗ ରୂପରେଖାକୁ ଅନ୍ୟ ଏକ କମ୍ପୁଟରରେ ବ୍ୟବହାର କରିପାରିବେ, ଅଥବା ଭିନ୍ନ ଭିନ୍ନ ଆଲୋକ ଅନୁସାରେ "
 "ରୂପରେଖା ନିର୍ମାଣ କରିପାରିବେ।"
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "ରୂପରେଖ ନାମ:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "ରୂପରେଖ ନାମ"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "ରୂପରେଖା ସଫଳତାର ସହିତ ନିର୍ମିତ!"
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "ରୂପରେଖା ନକଲ କରନ୍ତୁ"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "ଲିଖନଯୋଗ୍ୟ ମେଡିଆ ଆବଶ୍ୟକ"
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "ରୂପରେଖା ଧାରଣ କରନ୍ତୁ"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "ଇଣ୍ଟରନେଟ ସଂଯୋଗ ଆବଶ୍ୟକ କରିଥାଏ"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"ଆପଣ ଏହି ନିର୍ଦ୍ଦେଶଗୁଡ଼ିକୁ <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">"
-"Apple OS "
-"X</a> ଏବଂ <a href=\"windows\">Microsoft Windows</a> ରେ କିପରି ବ୍ୟବହାର କରିବେ "
-"ତାହା "
-"ପାଇପାରିବେ।"
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "ସାରାଂଶ"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "ଫାଇଲ ଆମଦାନୀକରନ୍ତୁ…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "ରୂପରେଖା ସଫଳତାର ସହିତ ନିର୍ମିତ!"
 
-#: ../panels/color/color.ui.h:29
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "ରୂପରେଖା ନକଲ କରନ୍ତୁ"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "ଲିଖନଯୋଗ୍ୟ ମେଡିଆ ଆବଶ୍ୟକ"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"ଆପଣ ଏହି ନିର୍ଦ୍ଦେଶଗୁଡ଼ିକୁ <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS "
+"X</a> ଏବଂ <a href=\"windows\">Microsoft Windows</a> ରେ କିପରି ବ୍ୟବହାର କରିବେ ତାହା "
+"ପାଇପାରିବେ।"
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "ରୂପରେଖା ଯୋଗ କରନ୍ତୁ"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"ସମସ୍ୟା ଦେଖାଦେଇଛି। ରୂପରେଖା ସଠିକ ଭାବରେ କାମ କରିନପାରେ।<a href=\"\">ବିବରଣୀ "
-"ଦର୍ଶାନ୍ତୁ।</a>"
+"ସମସ୍ୟା ଦେଖାଦେଇଛି। ରୂପରେଖା ସଠିକ ଭାବରେ କାମ କରିନପାରେ।<a href=\"\">ବିବରଣୀ ଦର୍ଶାନ୍ତୁ।</a>"
 
-#: ../panels/color/color.ui.h:30
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "ଫାଇଲ ଆମଦାନୀକରନ୍ତୁ…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "ଯୋଗ କରନ୍ତୁ (_A)"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
-msgstr ""
-"ପ୍ରତ୍ୟେକ ଉପକରଣ ରଙ୍ଗ ପରିଚାଳିତ ହେବା ପାଇଁ ଏକ ଅଦ୍ୟତିତ ରଙ୍ଗ ରୂପରେଖା ଆବଶ୍ୟକ କରିଥାଏ।"
+msgstr "ପ୍ରତ୍ୟେକ ଉପକରଣ ରଙ୍ଗ ପରିଚାଳିତ ହେବା ପାଇଁ ଏକ ଅଦ୍ୟତିତ ରଙ୍ଗ ରୂପରେଖା ଆବଶ୍ୟକ କରିଥାଏ।"
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "ଅଧିକ ଜ୍ଞାନ ଆହରଣ କରନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "ରଙ୍ଗ ପରିଚାଳନା ବିଷୟରେ ଅଧିକ ଜ୍ଞାନ ଆହରଣ କରନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:33
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "ସମସ୍ତ ଚାଳକମାନଙ୍କ ପାଇଁ ସେଟ କରନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "ଏହି କମ୍ପୁଟରରେ ଥିବା ସମସ୍ତ ବ୍ଯବହାରକାରୀଙ୍କ ପାଇଁ ଏହି ଉପକରଣକୁ ସେଟ କରନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:35
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "ସକ୍ରିୟ କରନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:36
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "ରୂପରେଖା ଯୋଗ କରନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:37
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "ମାପନ୍ତୁ..."
 
-#: ../panels/color/color.ui.h:38
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "ଏହି ଉପକରଣକୁ ମାପନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:39
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "ରୂପରେଖାକୁ ବାହାର କରନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:40
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "ବିବରଣୀ ଦେଖନ୍ତୁ"
 
-#: ../panels/color/color.ui.h:41
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "ରଙ୍ଗ ପରିଚାଳିତ କୌଣସି ଉପକରଣକୁ ଚିହ୍ନିବାରେ ଅସମର୍ଥ"
 
-#: ../panels/color/color.ui.h:42
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "ପ୍ରକ୍ଷେପକ"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "ପ୍ଲାଜମା"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL ବ୍ୟାକଲାଇଟ)"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED ବ୍ୟାକଲାଇଟ)"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (ଧଳା LED ବ୍ୟାକଲାଇଟ)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "ସମ୍ପୂର୍ଣ୍ଣ ପ୍ରସସ୍ତ  LCD (CCFL ବ୍ୟାକଲାଇଟ)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "ସମ୍ପୂର୍ଣ୍ଣ ପ୍ରସସ୍ତ LCD (RGB LED ବ୍ୟାକଲାଇଟ)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "ଉଚ୍ଚ"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 ମିନିଟ"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "ମଧ୍ଯମ"
 
-#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 ମିନିଟ"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "ନିମ୍ନ"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 ମିନିଟ"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "ଦର୍ଶାଇବା ପାଇଁ ସ୍ଥାନ"
 
-#: ../panels/color/color.ui.h:59
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (ମୁଦ୍ରଣ କରୁଅଛି ଏବଂ ପ୍ରକାଶ କରୁଅଛି)"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (ଫୋଟୋଗ୍ରାଫି ଏବଂ ଆଲେଖିକ)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "ରଙ୍ଗ"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
-msgstr ""
-"ଆପଣଙ୍କର ଉପକରଣର ରଙ୍ଗ ମାପନ୍ତୁ, ଯେପରିକି ପ୍ରଦର୍ଶନୀ, କ୍ୟାମେରା କିମ୍ବା ସୂଚକମାନ"
+msgstr "ଆପଣଙ୍କର ଉପକରଣର ରଙ୍ଗ ମାପନ୍ତୁ, ଯେପରିକି ପ୍ରଦର୍ଶନୀ, କ୍ୟାମେରା କିମ୍ବା ସୂଚକମାନ"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "ରଙ୍ଗ;ICC;ରୂପରେଖା;ମାପନ୍ତୁ;ମୁଦ୍ରଣୀ;ପ୍ରଦର୍ଶନୀ;"
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:684
-msgid "United States"
-msgstr "ଯୁକ୍ତରାଷ୍ଟ୍ର"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "ଗୋଟିଏ ଭାଷା ଚୟନକରନ୍ତୁ"
 
-#: ../panels/common/cc-common-language.c:685
-msgid "Germany"
-msgstr "ଜର୍ମାନୀ"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "ବାଛନ୍ତୁ (_S)"
 
-#: ../panels/common/cc-common-language.c:686
-msgid "France"
-msgstr "ଫ୍ରାନ୍ସ"
-
-#: ../panels/common/cc-common-language.c:687
-msgid "Spain"
-msgstr "ସ୍ପେନ"
-
-#: ../panels/common/cc-common-language.c:688
-msgid "China"
-msgstr "ଚାଇନା"
-
-#: ../panels/common/cc-common-language.c:758
-msgid "Other…"
-msgstr "ଅନ୍ଯାନ୍ଯ…"
-
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr "ଅଧିକ…"
-
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "କୌଣସି ଭାଷା ମିଳିଲା ନାହିଁ"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "ଭାଷା"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "ଅଧିକ…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "ସମାପ୍ତ (_D)"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-#| msgid "%b %d %l:%M %p"
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "ଆକାର ବୃଦ୍ଧିକରନ୍ତୁ:"
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "ସମୟ"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "ଆକାର ହ୍ରାସ କରନ୍ତୁ:"
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "ଜାନୁଆରୀ"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "ଫେବୃଆରୀ"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "ମାର୍ଚ୍ଚ"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "ଅପ୍ରେଲ"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "ମଇ"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "ଜୁନ"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "ଜୁଲାଇ"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "ଅଗଷ୍ଟ"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "ସେପ୍ଟେମ୍ବର"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "ଅକ୍ଟୋବର"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "ନଭେମ୍ବର"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "ଡିସେମ୍ବର"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "ତାରିଖ ଏବଂ ସମୟ"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "ଘଣ୍ଟା"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-#| msgid "minute"
-#| msgid_plural "minutes"
-msgid "Minute"
-msgstr "ମିନିଟ"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "ଦିନ"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "ମାସ"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "ବର୍ଷ"
 
-#: ../panels/datetime/datetime.ui.h:21
-#| msgid "Time"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "ମାସ"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "ଜାନୁଆରୀ"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ଫେବୃଆରୀ"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "ମାର୍ଚ୍ଚ"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "ଅପ୍ରେଲ"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "ମଇ"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "ଜୁନ"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "ଜୁଲାଇ"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "ଅଗଷ୍ଟ"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "ସେପ୍ଟେମ୍ବର"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ଅକ୍ଟୋବର"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "ନଭେମ୍ବର"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ଡିସେମ୍ବର"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "ଦିନ"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "ସମୟ ମଣ୍ଡଳ"
 
-#: ../panels/datetime/datetime.ui.h:22
-#| msgid "Search for the string"
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "ଏହି ସହରକୁ ଖୋଜନ୍ତୁ"
 
-#: ../panels/datetime/datetime.ui.h:23
-#| msgid "Date & Time"
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "ସ୍ବୟଂଚାଳିତ ତାରିଖ ଏବଂ ସମୟ (_D)"
 
-#: ../panels/datetime/datetime.ui.h:24
-#| msgid "Requires Internet connection"
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "ଇଣ୍ଟରନେଟ ସଂଯୋଗ ଆବଶ୍ୟକ କରିଥାଏ"
 
-#: ../panels/datetime/datetime.ui.h:25
-#| msgid "Automatic _Connect"
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "ତାରିଖ ଏବଂ ସମୟ (_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "ସ୍ୱୟଂଚାଳିତ ସମୟ ମଣ୍ଡଳ (_Z)"
 
-#: ../panels/datetime/datetime.ui.h:26
-#| msgid "Date & Time"
-msgid "Date & _Time"
-msgstr "ତାରିଖ ଏବଂ ସମୟ (_T)"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "ଇଣ୍ଟରନେଟ ସଂଯୋଗ ଆବଶ୍ୟକ କରିଥାଏ"
 
-#: ../panels/datetime/datetime.ui.h:27
-#| msgid "Firewall _Zone"
-msgid "Time _Zone"
-msgstr "ସମୟ ମଣ୍ଡଳ (_Z)"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "ସକ୍ରିୟ"
 
-#: ../panels/datetime/datetime.ui.h:28
-#| msgid "Formats"
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "ସମୟ ମଣ୍ଡଳ"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ଦକ୍ଷିଣାବର୍ତ୍ତୀ"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "ସମୟ ଫର୍ମାଟ (_F)"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24-ଘଣ୍ଟା"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "ତାରିଖ"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "ଦ୍ୱିତୀୟକ"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "କ୍ଯାଲେଣ୍ଡର (_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "ସଂଖ୍ଯାଗୁଡିକ"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "ସମୟ ମଣ୍ଡଳକୁ ଅନ୍ତର୍ଭୁକ୍ତ କରି ତାରିଖ ଏବଂ ସମୟକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "ଘଡ଼ି;ସମୟ ମଣ୍ଡଳ;ଅବସ୍ଥାନ;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "ତନ୍ତ୍ର ସମୟ ଏବଂ ତାରିଖ ସେଟିଙ୍ଗକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
-msgstr ""
-"ସମୟ କିମ୍ବା ତାରିଖ ବିନ୍ୟାସକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ, ଆପଣଙ୍କୁ ବୈଧିକରଣ କରିବା "
-"ଆବଶ୍ୟକ।"
+msgstr "ସମୟ କିମ୍ବା ତାରିଖ ବିନ୍ୟାସକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ, ଆପଣଙ୍କୁ ବୈଧିକରଣ କରିବା ଆବଶ୍ୟକ।"
 
-#: ../panels/display/cc-display-panel.c:487
-#| msgid "Close"
-msgid "Lid Closed"
-msgstr "ଲିଡ ବନ୍ଦକରନ୍ତୁ"
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-#| msgid "Mirrored Displays"
-msgid "Mirrored"
-msgstr "ପ୍ରତିଫଳିତ"
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2145
-#| msgid "Primary _button"
-msgid "Primary"
-msgstr "ପ୍ରାଥମିକ"
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "ଅଫ"
-
-#: ../panels/display/cc-display-panel.c:497
-#| msgid "Secondary color"
-msgid "Secondary"
-msgstr "ଦ୍ୱିତୀୟକ"
-
-#: ../panels/display/cc-display-panel.c:1533
-#| msgid "Mirrored Displays"
-msgid "Arrange Combined Displays"
-msgstr "ସଂଲଗ୍ନ ପ୍ରଦର୍ଶକଗୁଡ଼ିକୁ ସଜାଡ଼ନ୍ତୁ"
-
-#: ../panels/display/cc-display-panel.c:1539
-#: ../panels/display/cc-display-panel.c:1979
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-msgid "_Apply"
-msgstr "ପ୍ରୟୋଗ କରନ୍ତୁ (_A)"
-
-#: ../panels/display/cc-display-panel.c:1560
-msgid "Drag displays to rearrange them"
-msgstr "ସେଗୁଡ଼ିକୁ ପୁଣି ସଜାଡ଼ିବା ପାଇଁ ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକୁ ଟାଣନ୍ତୁ"
-
-#: ../panels/display/cc-display-panel.c:2081
-#| msgid "Size:"
-msgid "Size"
-msgstr "ଆକାର"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2094
-msgid "Aspect Ratio"
-msgstr "ପରିମାପ ଅନୁପାତ"
-
-#: ../panels/display/cc-display-panel.c:2115
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "ବିଭେଦ"
-
-#: ../panels/display/cc-display-panel.c:2146
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "ଉପର ପଟି ଏବଂ କାର୍ଯ୍ୟକଳାପଗୁଡ଼ିକର ସମୀକ୍ଷାକୁ ଏହି ପ୍ରଦର୍ଶନୀରେ ଦର୍ଶାନ୍ତୁ"
-
-#: ../panels/display/cc-display-panel.c:2152
-#| msgid "Secondary click delay"
-msgid "Secondary Display"
-msgstr "ଦ୍ୱିତୀୟକ ପ୍ରଦର୍ଶନୀ"
-
-#: ../panels/display/cc-display-panel.c:2153
-msgid "Join this display with another to create an extra workspace"
-msgstr ""
-"ଅତିରିକ୍ତ କାର୍ଯ୍ୟକ୍ଷେତ୍ର ସୃଷ୍ଟି କରିବା ପାଇଁ ଏହି ପ୍ରଦର୍ଶନୀକୁ ଅନ୍ୟ ଗୋଟିଏ ସହିତ "
-"ଯୋଡ଼ନ୍ତୁ"
-
-#: ../panels/display/cc-display-panel.c:2160
-#| msgid "Orientation"
-msgid "Presentation"
-msgstr "ଉପସ୍ଥାପନ"
-
-#: ../panels/display/cc-display-panel.c:2161
-msgid "Show slideshows and media only"
-msgstr "କେବଳ ସ୍ଲାଇଡ ଦୃଶ୍ୟ ଏବଂ ମେଡିଆକୁ ଦର୍ଶାନ୍ତୁ"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2166
-#| msgid "Mirror Screens"
-msgid "Mirror"
-msgstr "ପ୍ରତିଫଳକ"
-
-#: ../panels/display/cc-display-panel.c:2167
-msgid "Show your existing view on both displays"
-msgstr "ଆପଣଙ୍କର ସ୍ଥିତବାନ ଦୃଶ୍ୟକୁ ଉଭୟ ପ୍ରଦର୍ଶନୀରେ ଦର୍ଶାନ୍ତୁ"
-
-#: ../panels/display/cc-display-panel.c:2173
-#| msgid "_Turn On"
-msgid "Turn Off"
-msgstr "ଅଫ୍‌ କରନ୍ତୁ"
-
-#: ../panels/display/cc-display-panel.c:2174
-#| msgid "Panel to display"
-msgid "Don't use this display"
-msgstr "ଏହି ପ୍ରଦର୍ଶନୀକୁ ବ୍ୟବହାର କରନ୍ତୁ ନାହିଁ"
-
-#: ../panels/display/cc-display-panel.c:2383
-msgid "Could not get screen information"
-msgstr "ପରଦା ସୂଚନା ପାଇପାରିଲା ନାହିଁ"
-
-#: ../panels/display/cc-display-panel.c:2414
-#| msgid "Mirrored Displays"
-msgid "_Arrange Combined Displays"
-msgstr "ସଂଲଗ୍ନ ପ୍ରଦର୍ଶକଗୁଡ଼ିକୁ ସଜାଡ଼ନ୍ତୁ (_A)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକ"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr "ସଂଯୁକ୍ତ ମନିଟର ଏବଂ ପ୍ରଦର୍ଶିକାକୁ କିପରି ବ୍ୟବହାର କରିବେ ତାହା ବାଛନ୍ତୁ"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "ପ୍ୟାନେଲ;ପ୍ରଦର୍ଶିକା;xrandr;ପରଦା;ବିଭେଦନ;ସତେଜ;ମନିଟର;"
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr "ୱେଲ୍ୟାଣ୍ଡ"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "ଅଜଣା"
-
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-bit"
-
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr "%d-ବିଟ"
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr "କଣ କରିବାକୁ ହେବ ପଚାରନ୍ତୁ"
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr "କିଛି କରନ୍ତୁ ନାହିଁ"
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr "ଫୋଲଡର ଖୋଲନ୍ତୁ"
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr "ଅନ୍ଯାନ୍ଯ ସଞ୍ଚାର ମାଧ୍ଯମ"
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr "ଧ୍ୱନୀ CD ଗୁଡ଼ିକ ପାଇଁ ଗୋଟିଏ ପ୍ରୟୋଗ ବାଛନ୍ତୁ"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr "ଭିଡିଓ DVD ଗୁଡ଼ିକ ପାଇଁ ଗୋଟିଏ ପ୍ରୟୋଗ ବାଛନ୍ତୁ"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"ଏକ ସଙ୍ଗୀତ ଚାଳକ ସଂଯୁକ୍ତ ହୋଇଥିବା ସମୟରେ ତାହାକୁ ଚଲାଇବା ପାଇଁ ଏକ ପ୍ରୟୋଗକୁ ବାଛନ୍ତୁ"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-"ଏକ କ୍ୟାମେରା ସଂଯୁକ୍ତ ହୋଇଥିବା ସମୟରେ ତାହାକୁ ଚଲାଇବା ପାଇଁ ଏକ ପ୍ରୟୋଗକୁ ବାଛନ୍ତୁ"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr "ସଫ୍ଟୱେର CD ଗୁଡ଼ିକ ପାଇଁ ଗୋଟିଏ ପ୍ରୟୋଗ ବାଛନ୍ତୁ"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr "ଧ୍ୱନି DVD"
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr "ଖାଲି Blu-Ray ଡିସ୍କ"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr "ଖାଲି CD ଡିସ୍କ"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr "ଖାଲି DVD ଡିସ୍କ"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr "ଖାଲି HD DVD ଡିସ୍କ"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr "Blu-Ray ଭିଡିଓ ଡିସ୍କ"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr "ଇ-ପୁସ୍ତକ ପାଠକ"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr "HD DVD ଭିଡିଓ ଡିସ୍କ"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr "ଛବି CD"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr "ଉତ୍ତମ ଭିଡ଼ିଓ CD"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr "ଭିଡିଓ ସି.ଡି."
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr "Windows ସଫ୍ଟୱେର"
-
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1917
-msgid "Section"
-msgstr "ବିଭାଗ"
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "ସମୀକ୍ଷା"
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ପ୍ରୟୋଗଗୁଡ଼ିକ"
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "ଅପସାରଣଯୋଗ୍ୟ ସଞ୍ଚାରମାଧ୍ଯମ"
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr "ସଂସ୍କରଣ %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:44
-msgid "Details"
-msgstr "ବିସ୍ତୃତ ବିବରଣୀ"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr "ଆପଣଙ୍କର ତନ୍ତ୍ର ବିଷୟରେ ସୂଚନା ଦେଖନ୍ତୁ"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"ଉପକରଣ;ତନ୍ତ୍ର;ସୂଚନା;ସ୍ମୃତିସ୍ଥାନ;ସଞ୍ଚାଳକ;ସଂସ୍କରଣ;ପୂର୍ବନିର୍ଦ୍ଧାରିତ;ପ୍ରୟୋଗ;ପସନ୍ଦ "
-"ଯୋଗ୍ୟ;cd;dvd;usb;"
-"ଧ୍ୱନି;ଭିଡ଼ିଓ;ଡିସ୍କ;କଢ଼ାଯୋଗ୍ଯ;ମେଡ଼ିଆ;ସ୍ୱୟଂଚାଳନା;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "ଅନ୍ୟ ସଞ୍ଚାର ମାଧ୍ଯମ କିପରି ନିୟନ୍ତ୍ରଣ କରିବେ ତାହା ବାଛନ୍ତୁ"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "କାର୍ଯ୍ଯ (_A):"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "ପ୍ରକାର (_T):"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "ଉପକରଣର ନାମ"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "ସ୍ମୃତିସ୍ଥାନ"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "ସଞ୍ଚାଳକ"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "ମୌଳିକ ତନ୍ତ୍ର"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "ଡିସ୍କ"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "ହିସାବ କରୁଅଛି…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "ଲେଖାଚିତ୍ର"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "ଆଭାସୀକରଣ"
-
-#: ../panels/info/info.ui.h:13
-#| msgid "Checking for Updates"
-msgid "Check for updates"
-msgstr "ଅଦ୍ୟତନ ପାଇଁ ଯାଞ୍ଚକରନ୍ତୁ"
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "ୱେବ (_W)"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "ମେଲ (_M)"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "କ୍ଯାଲେଣ୍ଡର (_C)"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "ସଙ୍ଗୀତ (_u)"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "ଭିଡିଓ (_V)"
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "ଫୋଟୋଗୁଡ଼ିକ (_P)"
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "ସଞ୍ଚାର ମାଧ୍ଯମଗୁଡ଼ିକୁ କିପରି ନିୟନ୍ତ୍ରଣ କରିବେ ତାହା ବାଛନ୍ତୁ"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ପ୍ରୟୋଗଗୁଡ଼ିକ"
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "CD ଧ୍ୱନୀ (_a)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ପ୍ରୟୋଗଗୁଡ଼ିକ"
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "DVD ଭିଡିଓ (_D)"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "ସଙ୍ଗୀତ ଚାଳକ (_M)"
-
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "ସଫ୍ଟୱେର (_S)"
-
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "ଅନ୍ଯାନ୍ଯ ସଞ୍ଚାର ମାଧ୍ଯମ (_O)…"
-
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
 msgstr ""
-"ମେଡ଼ିଆ ଭର୍ତ୍ତି ସମୟରେପଚାରନ୍ତୁ ନାହିଁ କିମ୍ବା ପ୍ରଗ୍ରାମ ଆରମ୍ଭ କରନ୍ତୁ ନାହିଁ (_N)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "ପ୍ରୟୋଗ କରନ୍ତୁ (_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "ପଛ"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "ବ୍ଲୁଟୁଥ ନିଷ୍କ୍ରିୟ ହୋଇଛି"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକୁ ଯାଞ୍ଚକରନ୍ତୁ (_D)"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "ପ୍ରତିଫଳକ"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "ଦ୍ୱିତୀୟକ ପ୍ରଦର୍ଶନୀ"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "ଡ଼ାହାଣ ରିଙ୍ଗ"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "ଆବର୍ତ୍ତନ"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "ବିଭେଦ"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "ଦର_ରିଫ୍ରେସ କର:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "ମାପ"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "ଭଗ୍ନାଂଶ ସମ୍ପନ୍ନ"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "କୌଣସି ମୁଦ୍ରଣୀ ଉପଲବ୍ଧ ନାହିଁ"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "ବର୍ତ୍ତମାନ ପୁନଃଚାଳନ କରନ୍ତୁ"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "ସମୟ"
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "ୟୁ.ଆର.ଆଇ. ରୁ"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "ଘଣ୍ଟା"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "ମିନିଟ"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "ସଂଯୁକ୍ତ ମନିଟର ଏବଂ ପ୍ରଦର୍ଶିକାକୁ କିପରି ବ୍ୟବହାର କରିବେ ତାହା ବାଛନ୍ତୁ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "ପ୍ୟାନେଲ;ପ୍ରଦର୍ଶିକା;xrandr;ପରଦା;ବିଭେଦନ;ସତେଜ;ମନିଟର;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "ସୁରକ୍ଷା କି"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "କାଳି ସ୍ତର"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "କାଳି ସ୍ତର"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "କାଳି ସ୍ତର"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "ସୁରକ୍ଷା"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ଉପକରଣର ନାମ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "ହାର୍ଡୱେର ଠିକଣା"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "ସ୍ମୃତିସ୍ଥାନ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "ସଞ୍ଚାଳକ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "ଲେଖାଚିତ୍ର"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "ହିସାବ କରୁଅଛି…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "ନାମ"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "ପ୍ରକାର"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME ଟର୍ମିନାଲ"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "ବିକଳ୍ପଗୁଡିକୁ ଧାରଣ କରୁଅଛି …"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows ସଫ୍ଟୱେର"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "ଆଭାସୀକରଣ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "ସଫ୍ଟୱେର ଉପଯୋଗୀତା"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr " ଉପକରଣକୁ କାଢ଼ନ୍ତୁ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ଉପକରଣର ନାମ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "ନାମ ବଦଳାନ୍ତୁ ..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "%s ବିଷୟରେ"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "ଆପଣଙ୍କର ତନ୍ତ୍ର ବିଷୟରେ ସୂଚନା ଦେଖନ୍ତୁ"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ଉପକରଣ;ତନ୍ତ୍ର;ସୂଚନା;ସ୍ମୃତିସ୍ଥାନ;ସଞ୍ଚାଳକ;ସଂସ୍କରଣ;ପୂର୍ବନିର୍ଦ୍ଧାରିତ;ପ୍ରୟୋଗ;ପସନ୍ଦ ଯୋଗ୍ୟ;cd;dvd;usb;"
+"ଧ୍ୱନି;ଭିଡ଼ିଓ;ଡିସ୍କ;କଢ଼ାଯୋଗ୍ଯ;ମେଡ଼ିଆ;ସ୍ୱୟଂଚାଳନା;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "ସାଉଣ୍ଡ ଏବଂ ମେଡିଆ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "ଭଲ୍ଯୁମକୁ ନୀରବରେ ରଖ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "ଭଲ୍ୟୁମ କମ କରନ୍ତୁ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "ଭଲ୍ୟୁମ ଅଧିକ କରନ୍ତୁ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "ମାଇକ୍ରୋଫନ ଭଲ୍ଯୁମ"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "ମେଡ଼ିଆ ଚାଲକଙ୍କୁ ଆରମ୍ଭ କରନ୍ତୁ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "ଚଲାଅ( କିମ୍ବା ଚଲାଅ/ବିରାମ)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "ପଛଚଲାକୁ ବିରାମ ଦିଅନ୍ତୁ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "ପଛକୁ ଚଲାଇବା ବନ୍ଦ କରନ୍ତୁ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "ପୂର୍ବବର୍ତ୍ତୀ ଟ୍ରାକ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "ପରବର୍ତ୍ତୀ ଟ୍ରାକ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "ନିଷ୍କାସିତ କରନ୍ତୁ"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "ଟାଇପ କରିବା"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "ପରବର୍ତ୍ତୀ ନିବେଶ ଉତ୍ସକୁ ବଦଳ କର"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "ପୂର୍ବବର୍ତ୍ତୀ ନିବେଶ ଉତ୍ସକୁ ବଦଳ କର"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "ପ୍ରାରମ୍ଭକର୍ତ୍ତାମାନେ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "ସାହାୟ୍ଯ ବ୍ରାଉଜର ପ୍ରାରମ୍ଭ କରନ୍ତୁ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "ସେଟିଙ୍ଗଗୁଡିକ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "କାଲକୁଲେଟରକୁ ପ୍ରଚାଳନ କରନ୍ତୁ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "ଇମେଲ ଗ୍ରାହକଙ୍କୁ ପ୍ରଚାଳନ କରନ୍ତୁ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "ୱେବ ବ୍ରାଉଜର ପ୍ରାରମ୍ଭ କରନ୍ତୁ"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "ହୋମ ଫୋଲ୍ଡର"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "ଖୋଜନ୍ତୁ"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "ପରଦା ପ୍ରତିଛବିଗୁଡ଼ିକ"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "$PICTURES ମଧ୍ଯରେ ଏକ ପରଦା ପ୍ରତିଛବିକୁ ସଂରକ୍ଷଣ କରନ୍ତୁ"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "$PICTURES ମଧ୍ଯରେ ଏକ ୱିଣ୍ଡୋର ପରଦା ପ୍ରତିଛବିକୁ ସଂରକ୍ଷଣ କରନ୍ତୁ"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "$PICTURES ମଧ୍ଯରେ ଏକ ସ୍ଥାନର ପରଦା ପ୍ରତିଛବିକୁ ସଂରକ୍ଷଣ କରନ୍ତୁ"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "କ୍ଲିପବୋର୍ଡରେ ପରଦା ପ୍ରତିଛବିକୁ ନକଲ କରନ୍ତୁ"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "ଏକ ୱିଣ୍ଡୋର କ୍ଲିପବୋର୍ଡରେ ପରଦା ପ୍ରତିଛବିକୁ ନକଲ କରନ୍ତୁ"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "ଏକ ସ୍ଥାନର କ୍ଲିପବୋର୍ଡରେ ପରଦା ପ୍ରତିଛବିକୁ ନକଲ କରନ୍ତୁ"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "ସଂକ୍ଷିପ୍ତ ସ୍କ୍ରିନକାଷ୍ଟକୁ ଲିପିବଦ୍ଧ କରନ୍ତୁ"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "ତନ୍ତ୍ର"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "ଲଗଆଉଟ କରନ୍ତୁ"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "ପରଦାକୁ ତାଲା ଦେଇ ରଖନ୍ତୁ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "ସାର୍ବଜନିକ ଅଭିଗମ୍ୟତା"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "ମାଉସ ଅଭିଗମ୍ଯତା (_M)"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "ଛୋଟବଡ଼ କରିବାକୁ ଅନ କିମ୍ବା ଅଫ କରନ୍ତୁ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "ବଡ କରନ୍ତୁ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "ସାନ କରନ୍ତୁ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "ପରଦା ପାଠକକୁ ଅନ କିମ୍ବା ଅଫ କରନ୍ତୁ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "ଅନସ୍କ୍ରିନ କି ବୋର୍ଡ କୁ ଅନ କିମ୍ବା ଅଫ କରନ୍ତୁ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "ପାଠ୍ୟର ଆକାର ବୃଦ୍ଧି କରନ୍ତୁ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "ପାଠ୍ୟର ଆକାର କମ କରନ୍ତୁ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "ଅଧିକ ସ୍ପଷ୍ଟତାକୁ ଅନ କିମ୍ବା ଅଫ କରନ୍ତୁ"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1217
-#: ../panels/network/network-wifi.ui.h:29
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-#: ../panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Disabled"
-msgstr "ନିଷ୍କ୍ରିୟ ହୋଇଗଲା"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "ନିବେଶ ଉତ୍ସ ଯୋଗ କରନ୍ତୁ"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "ବୈକଳ୍ପିକ ଅକ୍ଷର କି"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "ନିବେଶ ପ୍ରଣାଳୀଗୁଡ଼ିକୁ ଲଗଇନ ପରଦାରେ ବ୍ୟବହାର କରାଯାଇପାରିବ ନାହିଁ"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "କି ପ୍ରସ୍ତୁତ କରନ୍ତୁ"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "କୌଣସି  ନିବେଶ ଉତ୍ସ ବଛା ହୋଇନାହିଁ"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "ପରବର୍ତ୍ତୀ ଉତ୍ସକୁ  କେବଳ ପରିବର୍ତ୍ତନକାରୀ ମାନେ ବଦଳାଇ ପାରିବେ"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "ବିକଳ୍ପଗୁଡିକ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "କି-ବୋର୍ଡ"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "ଉପରକୁ ଘୁଞ୍ଚାଅ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr ""
-"କିବୋର୍ଡ ସଂକ୍ଷିପ୍ତ ପଥଗୁଡ଼ିକୁ ଦେଖିକରି ପରିବର୍ତ୍ତନ କରନ୍ତୁ ଏବଂ ଆପଣଙ୍କର ଲେଖିବା "
-"ପସନ୍ଦକୁ ସେଟ କରନ୍ତୁ"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "ତଳକୁ ଘୁଞ୍ଚାଅ"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "ସଂକ୍ଷିପ୍ତ ପଥ;ପୁନରାବୃତ୍ତି;ମିଞ୍ଜି ମିଞ୍ଜି;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "ପସନ୍ଦ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "ସଂକ୍ଷିପ୍ତ ପଥକୁ ଇଚ୍ଛାରୂପଣ କରନ୍ତୁ"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "କିବୋର୍ଡ ବିନ୍ୟାସ ଦର୍ଶାନ୍ତୁ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
-msgstr "ଯୋଗ କରନ୍ତୁ (_A)"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "ଅପସାରଣ କରନ୍ତୁ (_R)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "ନାମ (_N):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "ନିର୍ଦ୍ଦେଶ (_o):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "କିଗୁଡ଼ିକୁ ପୁନରାବୃତି"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "କି ଦବାଇବା ପୁନରାବୃତ୍ତି ହୁଏ _ୟେବେ କିକୁ ଦବାଇ ଧରି ରଖାୟାଏ ।"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "_ବିଳମ୍ବ:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "_ଗତି:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "ସଂକ୍ଷିପ୍ତ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "ମନ୍ଥର"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "ପୁନରାବୃତ୍ତି କିଗୁଡିକର ଗତି"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "ଲମ୍ବା"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "ଦ୍ରୁତ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "ଦର୍ଶିକାଟି ମିଟିମିଟି କରୁଅଛି"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "ପାଠ୍ୟ କ୍ଷେତ୍ରରେ ସୂଚକ ଦପଦପ ହୋଇଥାଏ (_b)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "ଗତି (_p):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "ସୂଚକ ମିଞ୍ଜି ମିଞ୍ଜି ଗତି"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "ନିବେଶ ଉତ୍ସ"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "ସଂକ୍ଷିପ୍ତ ପଥ ଯୋଗ କରନ୍ତୁ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "ସଂକ୍ଷିପ୍ତ ପଥ ବାହାର କରନ୍ତୁ"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"ଗୋଟିଏ ସକ୍ଷିପ୍ତ ପଥ କିକୁ ସମ୍ପାଦନ କରିବା ପାଇଁ, ନିମ୍ନଲିଖିତ ଧାଡ଼ି ଉପରେ କ୍ଲିକ କରନ୍ତୁ "
-" ଏବଂ ଗୋଟିଏ ନୂତନ କି-"
-"ଯୁଗଳ ଟାଇପ କରନ୍ତୁ, କିମ୍ବା ସଫାକରିବା ପାଇଁ Backspace ଉପରେ ଦବାନ୍ତୁ।"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "ଉତ୍ସ ବିକଳ୍ପଗୁଡିକୁ ନିବେଶ କରନ୍ତୁ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "ସମସ୍ତ ୱିଣ୍ଡୋ ପାଇଁ ସମାନ ଉତ୍ସ ବ୍ୟବହାର କରନ୍ତୁ (_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "ପ୍ରତ୍ୟେକ ୱିଣ୍ଡୋ ପାଇଁ ବିଭିନ୍ନ ଉତ୍ସଗୁଡ଼ିକୁ ଅନୁମତି ଦିଅନ୍ତୁ (_d)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "ବୈକଳ୍ପିକ ଅକ୍ଷର କି"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "କି ପ୍ରସ୍ତୁତ କରନ୍ତୁ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "କିବୋର୍ଡ ସର୍ଟକଟଗୁଡିକ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥକୁ ଇଚ୍ଛାରୂପଣ କରନ୍ତୁ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "ବିଭାଗ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "ସଂକ୍ଷିପ୍ତ ପଥ"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:634
-#: ../panels/keyboard/keyboard-shortcuts.c:642
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥ ଯୋଗ କରନ୍ତୁ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "ସଂକ୍ଷିପ୍ତ ପଥକୁ ଇଚ୍ଛାରୂପଣ କରନ୍ତୁ"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:859
-msgid "<Unknown Action>"
-msgstr "<ଅଜ୍ଞାତ କାର୍ୟ୍ଯ>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1356
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"ସକ୍ଷିପ୍ତ ପଥ \"%s\" କୁ ବ୍ୟବହାର କରାଯାଇପାରିବ ନାହିଁ କାରଣ ଏହାକୁ ଏହି କି ବ୍ୟବହାର କରି "
-"ଟାଇପ କରିବା "
-"ଅସମ୍ଭବ।\n"
-"ଦୟାକରି ଏକା ସମୟରେ Control, Alt କିମ୍ବା Shift କି ସାହାଯ୍ୟରେ ଚେଷ୍ଟାକରନ୍ତୁ।"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1386
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥ ଯୋଗ କରନ୍ତୁ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "କିବୋର୍ଡ ସର୍ଟକଟଗୁଡିକ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "ଅପସାରଣ କରନ୍ତୁ (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "ବଦଳାନ୍ତୁ (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"ସଂକ୍ଷିପ୍ତ ପଥ \"%s\" ଟି ପୂର୍ବରୁ \n"
-"\"%s\" ପାଇଁ ବ୍ୟବହୃତ ହୋଇଛି"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1391
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"ଯଦି ଆପଣ \"%s\"ରେ ସଂକ୍ଷିପ୍ତ ପଥକୁ ପୁଣିଥରେ ନିର୍ଦ୍ଦିଷ୍ଟ କରନ୍ତି, ତେବେ \"%s\" "
-"ସଂକ୍ଷିପ୍ତ ପଥଟି ନିଷ୍କ୍ରିୟ "
-"ହୋଇଯିବ।"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1397
-msgid "_Reassign"
-msgstr "ପୁଣିଥରେ ନିର୍ଦ୍ଦିଷ୍ଟ କରିବା (_R)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "ନାମ"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1429
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "ନିର୍ଦ୍ଦେଶ (_o):"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "ନୂତନ ସଂକ୍ଷିପ୍ତ ପଥ…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "କିଛି ନୁହେଁ"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
 msgstr ""
-"\"%s\" ସଂକ୍ଷିପ୍ତ ପଥରେ ସଂଶ୍ଳିଷ୍ଟ\"%s\" ସଂକ୍ଷିପ୍ତ ପଥ ଥାଏ। ଆପଣ ତାହାକୁ ସ୍ୱୟଂଚାଳିତ "
-"ଭାବରେ \"%s\" ସେଟ କରିବାକୁ ଚାହୁଁଛନ୍ତି କି?"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1435
-#, c-format
-#| msgid ""
-#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
-#| "disabled."
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତରେ ପୁନଃସ୍ଥାପନ କରନ୍ତୁ (_R)"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "କି-ବୋର୍ଡ"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
 msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "କିବୋର୍ଡ ସଂକ୍ଷିପ୍ତ ପଥଗୁଡ଼ିକୁ ଦେଖିକରି ପରିବର୍ତ୍ତନ କରନ୍ତୁ ଏବଂ ଆପଣଙ୍କର ଲେଖିବା ପସନ୍ଦକୁ ସେଟ କରନ୍ତୁ"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
-"\"%s\" ବର୍ତ୍ତମାନ \"%s\" ସହିତ ସଂଶ୍ଳିଷ୍ଟ, ଆପଣ ଆଗକୁ ବଢ଼ିଲେ ଏହି ସଂକ୍ଷିପ୍ତ ପଥଟି "
-"ନିଷ୍କ୍ରିୟ "
-"ହୋଇଯିବ।"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1441
-#| msgid "_Reassign"
-msgid "_Assign"
-msgstr "ନ୍ଯସ୍ତ କରନ୍ତୁ (_A)"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "ଅବସ୍ଥାନ ସର୍ଭିସ (_L)"
 
-#: ../panels/mouse/cc-mouse-panel.c:94
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "କୌଣସି ପ୍ରୟୋଗ ବର୍ତ୍ତମାନ ଧ୍ୱନି ଚଲାଉ ନାହିଁ କିମ୍ବା ଲେଖୁ ନାହିଁ।"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "ମାଇକ୍ରୋଫନ ଭଲ୍ଯୁମ"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "କୌଣସି ପ୍ରୟୋଗ ମିଳିଲା ନାହିଁ"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "ଆପଣଙ୍କର ବିନ୍ୟାସଗୁଡ଼ିକୁ ପରୀକ୍ଷା କରନ୍ତୁ (_S)"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-#| msgid "Test Your _Settings"
-msgid "Test Your Settings"
-msgstr "ବିନ୍ୟାସଗୁଡ଼ିକୁ ପରୀକ୍ଷା କରନ୍ତୁ"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse & Touchpad"
-msgstr "ମାଉସ ଏବଂ ଟଚପ୍ୟାଡ"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid ""
-"Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr ""
-"ଆପଣଙ୍କର ମାଉସ ଏବଂ ଟଚପ୍ୟାଡ଼୍‌ ସମ୍ବେଦନଶୀଳତାକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ ଏବଂ ଡ଼ାହାଣ "
-"କିମ୍ବା ବାମ ପାଖକୁ "
-"ବାଛନ୍ତୁ"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-#| msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-msgstr "ଟ୍ରାକପ୍ୟାଡ଼;ସୂଚକ;କ୍ଲିକ;ଟ୍ୟାପ;ଦିଗୁଣ;ବଟନ;ଟ୍ରାକବଲ;ସ୍କ୍ରୋଲ୍‌;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
 msgid "General"
 msgstr "ସାଧାରଣ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "ମନ୍ଥର"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "ଦୁଇଥର ଦବାଇବାର ସମୟ ସମାପ୍ତି"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "ଦ୍ରୁତ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "ଦୁଇଥର କ୍ଲିକ (_D):"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
 msgstr "ପ୍ରାଥମିକ ବଟନ (_b)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "ବାମ (_L)"
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "ଡାହାଣ (_R)"
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "ବାମ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "ଡାହାଣ"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "ସ୍ଥାନ ସନ୍ଧାନ କରନ୍ତୁ"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "ମାଉସ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "ସୂଚକ ଗତି (_P)"
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "ମାଉସ ସେଟିଙ୍ଗଗୁଡିକ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "ମନ୍ଥର"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "ତଳକୁ ସ୍କ୍ରୋଲ  କରନ୍ତୁ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "ଦ୍ରୁତ"
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ ବିଷଯବସ୍ତୁ ସହିତ ଚାଲିଥାଏ"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "ତ୍ୱରଣ (_c):"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "ସକ୍ରିୟ"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "ଟଚପ୍ୟାଡ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "ମନ୍ଥର"
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "ଟଚପ୍ୟାଡ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "ଦ୍ରୁତ"
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "ପଦ୍ଧତି (_M)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
-msgstr "ଟାଇପ କରିବା ସମୟରେ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ (_t)"
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
 msgstr "କ୍ଲିକ କରିବା ପାଇଁ ଟ୍ୟାପ (_c)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
-msgstr "ଦୁଇ-ଅଙ୍ଗୁଳି ଟଣା (_f)"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-#| msgid "_Edge scrolling"
-msgid "_Natural scrolling"
-msgstr "ପ୍ରାକୃତିକ ଧାର ଟଣା (_N)"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "କ୍ଲିକ କରିବା ପାଇଁ ଟ୍ୟାପ (_c)"
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "ଟାଇପ କରିବା ସମୟରେ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ (_t)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "ଟଚପ୍ୟାଡ (ପାରସ୍ପରିକ)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "ସ୍କ୍ରୋଲ କରୁଛି"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "ବାମକୁ ସ୍କ୍ରୋଲ କରନ୍ତୁ"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "ଉଭୟ ପାର୍ଶ୍ବ"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "କ୍ଲିକ, ଦୁଇଥର କ୍ଲିକ, ଟାଣିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ"
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "ପାଞ୍ଚ ଥର କ୍ଲିକ, GEGL ସମୟ!"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "ମାଉସ ଏବଂ ଟଚପ୍ୟାଡ"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "ଦୁଇଥର ଦବାଇବା, ପ୍ରାଥମିକ ବଟନ"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"ଆପଣଙ୍କର ମାଉସ ଏବଂ ଟଚପ୍ୟାଡ଼୍‌ ସମ୍ବେଦନଶୀଳତାକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ ଏବଂ ଡ଼ାହାଣ କିମ୍ବା ବାମ ପାଖକୁ "
+"ବାଛନ୍ତୁ"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "ଏକ କ୍ଲିକ, ପ୍ରାଥମିକ ବଟନ"
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ଟ୍ରାକପ୍ୟାଡ଼;ସୂଚକ;କ୍ଲିକ;ଟ୍ୟାପ;ଦିଗୁଣ;ବଟନ;ଟ୍ରାକବଲ;ସ୍କ୍ରୋଲ୍‌;"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "ଦୁଇଥର କ୍ଲିକ, ମଝି ବଟନ"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "ଏକ କ୍ଲିକ, ମଝି ବଟନ"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "ଦୁଇଥର  କ୍ଲିକ, ଦ୍ୱିତୀୟ ବଟନ"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "ଏକ କ୍ଲିକ, ଦ୍ୱିତୀୟ ବଟନ"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:366
-msgid "Air_plane Mode"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "ରଙ୍ଗ ସ୍ଥାନ:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଆବର୍ଜନା ପାତ୍ରକୁ ଖାଲି କରନ୍ତୁ (_T)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "ମନିଟର"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "ପ୍ରାଥମିକ ପ୍ରଦର୍ଶନୀକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ଟାଣନ୍ତୁ।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "ପ୍ରୟୋଗ"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ଉପକରଣଗୁଡ଼ିକ"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "ନୂଆ ସଂଯୋଗ ଯୋଗକରନ୍ତୁ"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "ସଂଯୋଗିତ"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "ବିକଳ୍ପଗୁଡିକ…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi ହଟସ୍ପଟ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "ନେଟୱାର୍କ ନାମ"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "ପ୍ରବେଶ ସଙ୍କେତ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "ଗୋଟିଏ ପ୍ରବେଶ ସଙ୍କେତ ସେଟ କରନ୍ତୁ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "ଗୋଟିଏ ପ୍ରବେଶ ସଙ୍କେତ ସେଟ କରନ୍ତୁ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "ଅନ କରନ୍ତୁ (_T)"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
 msgstr "ବିମାନ ଧାରା (_p)"
 
-#: ../panels/network/cc-network-panel.c:965
-msgid "Network proxy"
-msgstr "ନେଟୱର୍କ ପ୍ରକ୍ସି"
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "କୌଣସି ଛବି ମିଳିଲା ନାହିଁ"
 
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1289
-msgid "The system network services are not compatible with this version."
-msgstr "ତନ୍ତ୍ର ନେଟୱର୍କ ସର୍ଭିସଗୁଡ଼ିକ ଏହି ସଂସ୍କରଣ ସହିତ ସୁସଙ୍ଗତ ନୁହଁ।"
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "ବିମାନ ଧାରା (_p)"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi ହଟସ୍ପଟ"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "ହଟସ୍ପଟ ପରି ବ୍ୟବହାର କରନ୍ତୁ (_U)…"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "ନେଟୱର୍କଗୁଡ଼ିକ"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x ସୁରକ୍ଷା (_S)"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "ପୃଷ୍ଠା 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "ଅଜଣା ପରିଚୟ (_m)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "ଭିତର ବୈଧିକରଣ (_a)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "ପୃଷ୍ଠା 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:4
-msgid "Security"
-msgstr "ସୁରକ୍ଷା"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "ସ୍ବୟଂଚାଳିତ"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:217
-#: ../panels/network/net-device-wifi.c:378
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:221
-#: ../panels/network/net-device-wifi.c:383
-#: ../panels/network/network-wifi.ui.h:17
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:225
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:230
-msgid "Enterprise"
-msgstr "ବାଣିଜ୍ୟିକ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:235
-#: ../panels/network/net-device-wifi.c:368
-msgctxt "Wifi security"
-msgid "None"
-msgstr "କିଛି ନାହିଁ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "କଦାପି ନୁହଁ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:819
-msgid "Today"
-msgstr "ଆଜି"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:822
-msgid "Yesterday"
-msgstr "ଗତକାଲି"
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:472
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i ଦିନ ପୂର୍ବେ"
 msgstr[1] "%i ଦିନ ପୂର୍ବେ"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:529
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:558
-msgctxt "Signal strength"
-msgid "None"
-msgstr "କିଛି ନାହିଁ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:560
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "ଦୁର୍ବଳ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ଠିକ ଅଛି"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "ଉତ୍ତମ"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "ଅତି ଉତ୍ତମ"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:45
-msgid "Identity"
-msgstr "ପରିଚୟ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "ଠିକଣା"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "ନେଟମାସ୍କ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "ଗେଟୱେ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "ଠିକଣାକୁ ଅପସାରଣ କରନ୍ତୁ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "ଯୋଗ କରନ୍ତୁ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "ସର୍ଭର"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "DNS ସର୍ଭରକୁ ଅପସାରଣ କରନ୍ତୁ"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "ମେଟ୍ରିକ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "ପଥ ଅପସାରଣ କରନ୍ତୁ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:25
-msgid "Automatic (DHCP)"
-msgstr "ସ୍ୱୟଂଚାଳିତ (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:24
-msgid "Manual"
-msgstr "ପୁସ୍ତିକା"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "କେବଳ ସଂଯୋଗ-ସ୍ଥାନୀୟ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:46
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "ଉପସର୍ଗ"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "ସ୍ବୟଂଚାଳିତ"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "ସ୍ୱୟଂଚାଳିତ, କେବଳ DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:47
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:49
-msgid "Reset"
-msgstr "ପୁନଃସ୍ଥାପନ କରନ୍ତୁ"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "କିଛି ନାହିଁ"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-ବିଟ କି (Hex କିମ୍ବା ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-ବିଟ ପ୍ରବେଶ ସଂକେତ"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "ଗତିଜ WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 ବ୍ୟକ୍ତିଗତ"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 ଉଦ୍ଦୋଗ"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:2
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "ସଂକେତ ଶକ୍ତି"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:3
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "ସଂଯୋଗ ଗତି"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "ସୁରକ୍ଷା"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 ଠିକଣା"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 ଠିକଣା"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:7
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "ହାର୍ଡୱେର ଠିକଣା"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:8
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "ସମର୍ଥିତ ICC ରୂପରେଖାଗୁଡ଼ିକ"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ପଥ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "ଶେଷରେ ବ୍ୟବହୃତ"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "ମୋଡିହୋଇଥିବା ଯୁଗଳ (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "ସଂଲଗ୍ନକ ଏକକ ଅନ୍ତରାପୃଷ୍ଠ (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "ମେଡିଆ ନିର୍ଭରଶୀଳ ହୋଇନଥିବା ଅନ୍ତରାପୃଷ୍ଠ (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "ନାମ (_N)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:36
-msgid "_MAC Address"
-msgstr "MAC ଠିକଣା(_M)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "MTU (_T)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "ପ୍ରତିରୂପି ଠିକଣା (_C)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "ବାଇଟଗୁଡିକ"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "ଅନ୍ୟ ବ୍ୟବହାରକାରୀମାନଙ୍କ ପାଇଁ ଉପଲବ୍ଧ କରାନ୍ତୁ (_u)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ସଂଯୁକ୍ତ (_a)"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "ଫାୟାରୱାଲ ସ୍ଥାନ (_Z)"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "ଏହି ସ୍ଥାନଟି ସଂଯୋଗର ବିଶ୍ୱାସ ସ୍ତରକୁ ବ୍ୟାଖ୍ୟା କରିଥାଏ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:22
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:23
-msgid "_Addresses"
-msgstr "ଠିକଣା (_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "ସ୍ବୟଂଚାଳିତ DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Routes"
-msgstr "ପଥଗୁଡ଼ିକୁ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "ସ୍ବୟଂଚାଳିତ ପଥଗୁଡ଼ିକ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Use this connection _only for resources on its network"
-msgstr "ଏହି ସଂଯୋଗକୁ କେବଳ ଏହି ନେଟୱର୍କରେ ଥିବା ଉତ୍ସଗୁଡିକ ପାଇଁ ବ୍ୟବହାର କରନ୍ତୁ (_o)"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:34
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "ସଂଯୋଗ ସମ୍ପାଦକଙ୍କୁ ଖୋଲିବାରେ ଅସମର୍ଥ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "ନୂତନ ରୂପରେଖ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "ବନ୍ଧନ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "ଦଳ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "ବ୍ରିଜ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "VPN ପ୍ଲଗଇନଗୁଡ଼ିକୁ ଧାରଣ କରିପାରିଲା ନାହିଁ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "ଫାଇଲରୁ ଆମଦାନୀ କରନ୍ତୁ…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "ନେଟୱର୍କ ସଂଯୋଗ ଯୋଗ କରନ୍ତୁ"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Reset"
-msgstr "ପୁନଃ ସ୍ଥାପନ କରନ୍ତୁ (_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1449
-#: ../panels/network/network-wifi.ui.h:40
-msgid "_Forget"
-msgstr "ଭୁଲିଯାଆନ୍ତୁ (_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"ପ୍ରବେଶ ସଂକେତକୁ ଅନ୍ତର୍ଭୁକ୍ତ କରି ଏହି ନେଟୱର୍କ ପାଇଁ ସେଟିଙ୍ଗକୁ ସେଟକରନ୍ତୁ, କିନ୍ତୁ "
-"ମନେରଖନ୍ତୁ ଯେ ଏହା ଏକ "
-"ପସନ୍ଦଯୋଗ୍ୟ ନେଟୱର୍କ"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"ଏହି ନେଟୱର୍କରୁ ସମସ୍ତ ବିବରଣୀକୁ ବାହାର କରନ୍ତୁ ଏବଂ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ସଂଯୁକ୍ତ କରିବା "
-"ପାଇଁ ଚେଷ୍ଟା "
-"କରନ୍ତୁ"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "S_ecurity"
-msgstr "ସୁରକ୍ଷା (_e)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "VPN ସଂଯୋଗକୁ ଆମଦାନୀ କରାଯାଇପାରିବ ନାହିଁ"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"ଫାଇଲ '%s' କୁ ପଢ଼ିହେଲା ନାହିଁ କିମ୍ବା କୌଣସି ପରିଚିତ VPN ସଂଯୋଗ ସୂଚନା ଧାରଣ କରିନଥାଏ\n"
-"\n"
-"ତ୍ରୁଟି: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "ଆମଦାନୀ ପାଇଁ ଫାଇଲ ଚୟନ କରନ୍ତୁ"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1948
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:223
-msgid "_Open"
-msgstr "ଖୋଲନ୍ତୁ (_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "\"%s\" ନାମକ ଗୋଟିଏ ଫାଇଲ ପୂର୍ବରୁ ଅବସ୍ଥିତ ଅଛି।"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "ବଦଳାନ୍ତୁ (_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "ଆପଣ %s କୁ ଆପଣ ସଂରକ୍ଷଣ କରୁଥିବା VPN ସଂଯୋଗ ସହିତ ବଦଳାଇବାକୁ ଚାହୁଁଛନ୍ତି କି?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "VPN ସଂଯୋଗକୁ ରପ୍ତାନୀ କରାଯାଇପାରିବ ନାହିଁ"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN ସଂଯୋଗ '%s' କୁ %sକୁ ରପ୍ତାନୀ କରାଯାଇପାରିବ ନାହିଁ।\n"
-"\n"
-"ତ୍ରୁଟି: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-#| msgid "Export VPN connection..."
-msgid "Export VPN connection"
-msgstr "VPN ସଂଯୋଗକୁ ରପ୍ତାନୀ କରନ୍ତୁ"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(ତ୍ରୁଟି: VPN ସଂଯୋଗ ସମ୍ପାଦକକୁ ଧାରଣ କରିବାରେ ଅସମର୍ଥ)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:12
-msgid "_SSID"
-msgstr "SSID (_S)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:13
-msgid "_BSSID"
-msgstr "BSSID (_B)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:16
-msgid "My Home Network"
-msgstr "ନିଜସ୍ୱ ନେଟୱର୍କ"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "ଅନ୍ୟ ଚାଳକ ମାନଙ୍କ ପାଇଁ ଉପଲବ୍ଧକରାନ୍ତୁ (_o)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "ନେଟୱର୍କ"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Control how you connect to the Internet"
-msgstr "ଇଣ୍ଟରନେଟ ସହିତ କିପରି ସଂଯୁକ୍ତ କରିବେ ତାହା ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
-#| "vpn;vlan;bridge;bond;"
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
-"ନେଟୱର୍କ;ବେତାର;ୱାଇ-ଫାଇ;ୱାଇଫାଇ;IP;LAN;ପ୍ରକ୍ସି;WAN;ବ୍ରୋଡବ୍ୟାଣ୍ଡ;ମଡେମ;ବ୍ଲୁଟୁଥ;vpn;"
-"vlan;ବ୍ରୀଜ;ବଣ୍ଡ;DNS;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "ବନ୍ଧନ ସ୍ଲେଭ"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "ନାମ (_N)"
 
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(କିଛି ନାହିଁ)"
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC ଠିକଣା(_M)"
 
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "ବ୍ରିଜ ସ୍ଲେଭ"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "MTU (_T)"
 
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:458
-msgid "never"
-msgstr "କଦାପି ନୁହଁ"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "ପ୍ରତିରୂପି ଠିକଣା (_C)"
 
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:468
-msgid "today"
-msgstr "ଆଜି"
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "ବାଇଟଗୁଡିକ"
 
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:470
-msgid "yesterday"
-msgstr "ଗତକାଲି"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "ପଦ୍ଧତି (_M)"
 
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP ଠିକଣା"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "ସ୍ୱୟଂଚାଳିତ (DHCP)"
 
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:10
-msgid "Last used"
-msgstr "ଶେଷରେ ବ୍ୟବହୃତ"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "କେବଳ ସଂଯୋଗ-ସ୍ଥାନୀୟ"
 
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "ତାରଯୁକ୍ତ"
-
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1604
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "ବିକଳ୍ପଗୁଡିକ…"
-
-#: ../panels/network/net-device-ethernet.c:474
-#, c-format
-msgid "Profile %d"
-msgstr "ରୂପରେଖା %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "ନୂଆ ସଂଯୋଗ ଯୋଗକରନ୍ତୁ"
-
-#: ../panels/network/net-device-team.c:77
-#| msgid "Bridge slaves"
-msgid "Team slaves"
-msgstr "ଦଳ ସ୍ଲେଭ"
-
-#: ../panels/network/net-device-wifi.c:1153
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-"ଯଦି ଆପଣଙ୍କ ପାଖରେ ବେତାର ବ୍ୟତୀତ ଇଣ୍ଟରନେଟ ସହିତ ସଂଯୋଗ ଅଛି, ତେବେ ଆପଣନିଜର "
-"ଇଣ୍ଟରନେଟକୁ ଅନ୍ୟ "
-"ସହିତ ବ୍ୟବହାର କରିପାରିବେ।"
-
-#: ../panels/network/net-device-wifi.c:1157
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-"ବେତାର ହଟସ୍ପଟକୁ ଅନ କରିବା ଫଳରେ ତାହା ଆପଣଙ୍କୁ <b>%s</b> ରୁ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରିବ।"
-
-#: ../panels/network/net-device-wifi.c:1161
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"ହଟସ୍ପଟ ସକ୍ରିୟ ଥିବା ସମୟରେ ବେତାର ସହାୟତାରେ ଇଣ୍ଟରନେଟକୁ ବ୍ୟବହାର କରିବା ସମ୍ଭବ ନୁହଁ।"
-
-#: ../panels/network/net-device-wifi.c:1238
-msgid "Stop hotspot and disconnect any users?"
-msgstr "ହଟସ୍ପଟକୁ ଅଟକାଇ ଏବଂ ଯେକୌଣସି ଚାଳକ ସହିତ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରବେ କି?"
-
-#: ../panels/network/net-device-wifi.c:1241
-msgid "_Stop Hotspot"
-msgstr "ହଟସ୍ପଟକୁ ଅଟକାନ୍ତୁ (_S)"
-
-#: ../panels/network/net-device-wifi.c:1313
-msgid "System policy prohibits use as a Hotspot"
-msgstr "ହଟ୍‌ସ୍ପଟ୍‌ ଭାବରେ ବ୍ୟବହାର କରିବା ପାଇଁ ତନ୍ତ୍ର ନୀତି ବାରଣ କରିଥାଏ"
-
-#: ../panels/network/net-device-wifi.c:1316
-msgid "Wireless device does not support Hotspot mode"
-msgstr "ବେତାର ଉପକରଣ ହଟ୍‌ସ୍ପଟ୍‌ ଧାରାକୁ ସହାୟତା କରିନଥାଏ"
-
-#: ../panels/network/net-device-wifi.c:1445
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"ପ୍ରବେଶ ସଂକେତ ଏବଂ ଯେ କୌଣସି ଇଚ୍ଛାକୃତ ବିନ୍ୟାସକୁ ଅନ୍ତର୍ଭୁକ୍ତ କରି ବଚ୍ଛିତ ନେଟୱର୍କ "
-"ପାଇଁ ନେଟୱର୍କ୍‌ "
-"ବିବରଣୀ ନଷ୍ଟ ହୋଇଯିବ।"
-
-#: ../panels/network/net-device-wifi.c:1753
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "ପୁରୁଣା ତଥ୍ଯ"
-
-#: ../panels/network/net-device-wifi.c:1757
-#: ../panels/wacom/cc-wacom-page.c:533
-msgid "_Close"
-msgstr "ବନ୍ଦ କରନ୍ତୁ (_C)"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1765
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "ଭୁଲିଯାଏ (_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"ୱେବ ପ୍ରୋକ୍ସି ସ୍ୱୟଂଆବିଷ୍କାରକୁ ସଂରଚନା URL ଦିଆଯାଇନଥିବା ସମୟରେ ବ୍ୟବହାର କରାଯାଇଥାଏ।"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "ଏହା ଅବିଶ୍ୱସ୍ତ ସର୍ବସାଧାରଣ ନେଟୱର୍କରେ ପରାମର୍ଶିତ ନୁହଁ।"
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "ପ୍ରକ୍ସି"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "ରୂପରେଖା ଯୋଗ କରନ୍ତୁ (_A)..."
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "ପ୍ରଦାତା"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "କିଛି ନାହିଁ"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
-msgstr "ହସ୍ତ ପୁସ୍ତିକା"
+msgstr "ପୁସ୍ତିକା"
 
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "ନିଷ୍କ୍ରିୟ ହୋଇଗଲା"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "ଅନ୍ୟ କମ୍ପୁଟର ସହିତ ସହଭାଗ କରାଯାଇଛି"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "ଠିକଣା (_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ଠିକଣା"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "ନେଟମାସ୍କ"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "ଗେଟୱେ"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "ସ୍ବୟଂଚାଳିତ"
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "ସ୍ବୟଂଚାଳିତ DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "ପଥଗୁଡ଼ିକୁ"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "ସ୍ବୟଂଚାଳିତ ପଥଗୁଡ଼ିକ"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "ମେଟ୍ରିକ"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "ଏହି ସଂଯୋଗକୁ କେବଳ ଏହି ନେଟୱର୍କରେ ଥିବା ଉତ୍ସଗୁଡିକ ପାଇଁ ବ୍ୟବହାର କରନ୍ତୁ (_o)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
 msgstr "ପଦ୍ଧତି (_M)"
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "ବିନ୍ୟାସ URL (_C)"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "ସ୍ୱୟଂଚାଳିତ, କେବଳ DHCP"
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "HTTP ପ୍ରକ୍ସି (_H)"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "ଉପସର୍ଗ"
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "HTTPS ପ୍ରକ୍ସି (_T)"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "ସୁରକ୍ଷା (_e)"
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "FTP ପ୍ରୋକ୍ସି (_F)"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ତ୍ରୁଟି: VPN ସଂଯୋଗ ସମ୍ପାଦକକୁ ଧାରଣ କରିବାରେ ଅସମର୍ଥ)"
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "ଶକ୍ସ ହୋଷ୍ଟ (_S)"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "SSID (_S)"
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "ହୋଷ୍ଟମାନଙ୍କୁ ଅଗ୍ରାହ୍ଯ କରନ୍ତୁ (_I)"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "BSSID (_B)"
 
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "HTTP ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "ନେଟୱର୍କ"
 
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "HTTPS ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "ଇଣ୍ଟରନେଟ ସହିତ କିପରି ସଂଯୁକ୍ତ କରିବେ ତାହା ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
 
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "FTP ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "Socks ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "ଉପକରଣକୁ ଅଫ କରନ୍ତୁ"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "ଉପକରଣକୁ ଯୋଗ କରନ୍ତୁ"
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr " ଉପକରଣକୁ କାଢ଼ନ୍ତୁ"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN ପ୍ରକାର"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "ଶ୍ରେଣୀ ନାମ"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "ଶ୍ରେଣୀ ପ୍ରବେଶ ସଂଙ୍କେତ"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "ଚାଳକ ନାମ"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr "VPN ସଂଯୋଗକୁ ଅଫ କରନ୍ତୁ"
-
-#: ../panels/network/network-wifi.ui.h:1
-msgid "Automatic _Connect"
-msgstr "ସ୍ୱୟଂଚାଳିତ ସଂଯୋଗ (_C)"
-
-#: ../panels/network/network-wifi.ui.h:11
-msgid "details"
-msgstr "ବିସ୍ତୃତ ବିବରଣୀ"
-
-#: ../panels/network/network-wifi.ui.h:15
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "ପ୍ରବେଶ ସଂଙ୍କେତ (_P)"
-
-#: ../panels/network/network-wifi.ui.h:18
-msgid "None"
-msgstr "କିଛି ନୁହେଁ"
-
-#: ../panels/network/network-wifi.ui.h:19
-msgid "Show P_assword"
-msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦେଖାନ୍ତୁ (_a)"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "Make available to other users"
-msgstr "ଅନ୍ୟ ବ୍ୟବହାରକାରୀଙ୍କ ପାଇଁ ଉପଲବ୍ଧ କରାନ୍ତୁ"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "identity"
-msgstr "ପରିଚୟ"
-
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Automatic (DHCP) addresses only"
-msgstr "କେବଳ ସ୍ୱୟଂଚାଳିତ (DHCP) ଠିକଣାଗୁଡ଼ିକ"
-
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Link-local only"
-msgstr "କେବଳ ସଂଯୋଗ-ସ୍ଥାନୀୟ"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Shared with other computers"
-msgstr "ଅନ୍ୟ କମ୍ପୁଟର ସହିତ ସହଭାଗ କରାଯାଇଛି"
-
-#: ../panels/network/network-wifi.ui.h:31
-msgid "_Ignore automatically obtained routes"
-msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ମିଳିଥିବା ପଥକୁ ଅଗ୍ରାହ୍ୟ କରନ୍ତୁ (_I)"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "_Cloned MAC Address"
-msgstr "ପ୍ରତିରୂପି MAC ଠିକଣା (_C)"
-
-#: ../panels/network/network-wifi.ui.h:38
-msgid "hardware"
-msgstr "ହାର୍ଡୱେର"
-
-#: ../panels/network/network-wifi.ui.h:41
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
-"ଏହି ସଂଯୋଗ ପାଇଁ ସେଟିଙ୍ଗକୁ ପୂର୍ବନିର୍ଦ୍ଧାରିତ ଭାବରେ ସେଟ କରନ୍ତୁ, କିନ୍ତୁ "
-"ପସନ୍ଦମୁତାବକ ସଂଯୋଗ ଭାବରେ "
-"ମନେରଖନ୍ତୁ।"
+"ନେଟୱର୍କ;ବେତାର;ୱାଇ-ଫାଇ;ୱାଇଫାଇ;IP;LAN;ପ୍ରକ୍ସି;WAN;ବ୍ରୋଡବ୍ୟାଣ୍ଡ;ମଡେମ;ବ୍ଲୁଟୁଥ;vpn;vlan;"
+"ବ୍ରୀଜ;ବଣ୍ଡ;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:42
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"ଏହି ନେଟୱର୍କ ପାଇଁ ସମସ୍ତ ବିବରଣୀକୁ ବାହାର କରନ୍ତୁ ଏବଂ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଏହା ସହିତ "
-"ସଂଯୋଗ କରିବା "
-"ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid "reset"
-msgstr "ପୁନଃସ୍ଥାପନ କରନ୍ତୁ"
-
-#: ../panels/network/network-wifi.ui.h:48
-msgid "Hardware"
-msgstr "ହାର୍ଡୱେର"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi ହଟସ୍ପଟ"
-
-#: ../panels/network/network-wifi.ui.h:51
-msgid "_Turn On"
-msgstr "ଅନ କରନ୍ତୁ (_T)"
-
-#: ../panels/network/network-wifi.ui.h:52
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:53
-msgid "Turn Wi-Fi off"
-msgstr "Wi-Fi କୁ ଅଫ କରନ୍ତୁ"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "ଇଣ୍ଟରନେଟ ସହିତ କିପରି ସଂଯୁକ୍ତ କରିବେ ତାହା ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
 
-#: ../panels/network/network-wifi.ui.h:54
-msgid "_Use as Hotspot…"
-msgstr "ହଟସ୍ପଟ ପରି ବ୍ୟବହାର କରନ୍ତୁ (_U)…"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"ନେଟୱର୍କ;ବେତାର;ୱାଇ-ଫାଇ;ୱାଇଫାଇ;IP;LAN;ପ୍ରକ୍ସି;WAN;ବ୍ରୋଡବ୍ୟାଣ୍ଡ;ମଡେମ;ବ୍ଲୁଟୁଥ;vpn;vlan;"
+"ବ୍ରୀଜ;ବଣ୍ଡ;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "_Connect to Hidden Network…"
-msgstr "ଲୁକ୍କାଇତ ନେଟୱର୍କ ସହିତ ସଂଯୁକ୍ତ ହୁଅନ୍ତୁ (_C)…"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "ତାରଯୁକ୍ତ"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_History"
-msgstr "ପୁରୁଣା ତଥ୍ୟ (_H)"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "ଉପକରଣକୁ ଅଫ କରନ୍ତୁ"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Wi-Fi ନେଟୱର୍କ ସହିତ ସଂଯୋଗ କରିବା ପାଇଁ ଅଫ କରନ୍ତୁ"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "ସକ୍ରିୟ"
 
-#: ../panels/network/network-wifi.ui.h:58
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "ପ୍ରଦାତା"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP ଠିକଣା"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "ନେଟୱର୍କ ପ୍ରକ୍ସି"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "HTTP ପ୍ରକ୍ସି (_H)"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTPS ପ୍ରକ୍ସି (_T)"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "FTP ପ୍ରୋକ୍ସି (_F)"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "ଶକ୍ସ ହୋଷ୍ଟ (_S)"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "ହୋଷ୍ଟମାନଙ୍କୁ ଅଗ୍ରାହ୍ଯ କରନ୍ତୁ (_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "ବିନ୍ୟାସ URL (_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN ସଂଯୋଗକୁ ଅଫ କରନ୍ତୁ"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "ନେଟୱାର୍କ ନାମ"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Connected Devices"
-msgstr "ସଂଯୁକ୍ତ ଉପକରଣଗୁଡ଼ିକ"
-
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "ସୁରକ୍ଷା ପ୍ରକାର"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Security key"
-msgstr "ସୁରକ୍ଷା କି"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "ପ୍ରବେଶ ସଙ୍କେତ"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "ଏଡ-ହକ"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi କୁ ଅଫ କରନ୍ତୁ"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "ଅବସଂରଚନା"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "ବିକଳ୍ପଗୁଡିକୁ ଧାରଣ କରୁଅଛି …"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "ସ୍ଥିତି ଅଜଣା"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "ଲୁକ୍କାଇତ ନେଟୱର୍କ ସହିତ ସଂଯୁକ୍ତ ହୁଅନ୍ତୁ (_C)…"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "ଅପରିଚାଳିତ"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi ହଟସ୍ପଟ"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "ଉପଲବ୍ଧନାହିଁ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "ସଂଯୋଗ କରୁଅଛି"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "ବୈଧିକରଣ ଆବଶ୍ଯକ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "ସଂଯୋଗିତ"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରୁଅଛି"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "ସଂୟୋଗ ଅସଫଳ ହେଲା"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "ସ୍ଥିତି ଅଜଣା (ଅନୁପସ୍ଥିତ)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "ସଂଯୋଜିତ ହୋଇ ନାହିଁ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "ବିନ୍ୟାସ ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "IP ସଂରଚନା ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "IP ସଂରଚନା ସମୟ ସମାପ୍ତି ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "ଗୁପ୍ତ ତଥ୍ୟ ଆବଶ୍ୟକ, କିନ୍ତୁ ଦିଆଯାଇ ନାହିଁ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x supplicant ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x supplicant ସଂରଚନା ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1x supplicant ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant ବୈଧକରଣ କରିବା ପାଇଁ ଅଧିକ ସମୟ ନେଉଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "PPP ସର୍ଭିସ ଆରମ୍ଭ ହେବାରେ ବିଫଳ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "PPP ସର୍ଭିସ ବିଛିନ୍ନହୋଇଥିବା"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "DHCP କ୍ଲାଏଣ୍ଟ ଆରମ୍ଭ ହେବାରେ ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP କ୍ଲାଏଣ୍ଟ ତ୍ରୁଟି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP କ୍ଲାଏଣ୍ଟ ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "ସହଭାଗୀ ସଂଯୋଗ ଆରମ୍ଭ ହେବାରେ ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "ସହଭାଗୀ ସଂଯୋଗ ସର୍ଭିସ ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "AutoIP ସର୍ଭିସ ଆରମ୍ଭ ହେବାରେ ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "AutoIP ସର୍ଭିସ ତ୍ରୁଟି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "AutoIP ସର୍ଭିସ ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "ଲାଇନ ବ୍ୟସ୍ତ ଅଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "ଡ଼ାଏଲଟନ ନାହିଁ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "କୌଣସି ସମ୍ପର୍କ ସ୍ଥାପନ ହୋଇପାରିବ ନାହିଁ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "ଡ଼ାଏଲ କରିବା ସମୟ ସମାପ୍ତି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "ଡ଼ାଏଲ ପ୍ରୟାସ ବିଫଳ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "ମଡେମ ପ୍ରାରମ୍ଭିକରଣ ବିଫଳ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "ନିର୍ଦ୍ଦିଷ୍ଟ APN ବାଛିବାରେ ବିଫଳ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "ନେଟୱର୍କ ସନ୍ଧାନ କରୁ ନାହିଁ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "ନେଟୱର୍କ ପଞ୍ଜିକରଣ ବାରଣ ହୋଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "ନେଟୱର୍କ ପଞ୍ଜିକରଣ ସମୟ ସମାପ୍ତି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "ଅନୁରୋଧ କରାଯାଇଥିବା ନେଟୱର୍କ ସହିତ ପଞ୍ଜିକରଣ କରିବାରେ ବିଫଳ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "PIN ଯାଞ୍ଚ ବିଫଳ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "ଉପକରଣ ପାଇଁ ଫର୍ମୱେର ଅନୁପସ୍ଥିତ ଅଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "ସଂଯୋଗ ଅଦୃଶ୍ୟ ହୋଇଯାଇଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "ସ୍ଥିତବାନ ସଂଯୋଗକୁ ଅନୁମାନ କରାଯାଉଛି"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "ମଡେମ ମିଳିଲା ନାହିଁ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "ବ୍ଲୁଟୁଥ ସଂୟୋଗ ବିଫଳ ହେଲା"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "SIM କାର୍ଡ ଭର୍ତ୍ତି କରାଯାଇ ନାହିଁ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "SIM ପିନ ଆବଶ୍ୟକ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "SIM Puk ଆବଶ୍ୟକ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "ଭୁଲ SIM"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "InfiniBand ଉପକରଣ ସଂଯୁକ୍ତ ଧାରାକୁ ସହାୟତା କରିନଥାଏ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "ସଂଯୋଗ ନିର୍ଭୋରୋକ ବିଫଳ ହୋଇଛି"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "ଫର୍ମୱେର ଅନୁପସ୍ଥିତ ଅଛି"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "କେବଲ ଲାଗିନାହିଁ"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "କୌଣସି ପ୍ରମାଣପତ୍ର ପ୍ରାଧିକାରୀ ପ୍ରମାଣପତ୍ର ବଛାହୋଇନାହିଁ"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"ଗୋଟିଏ ପ୍ରମାଣପତ୍ର ପ୍ରାଧିକାରୀ (CA) ପ୍ରମାଣପତ୍ରକୁ ବ୍ୟବହାର ନକରିବା ଫଳରେ ସଂଯୋଗଟି "
-"ଅସୁରକ୍ଷିତ "
-"ହୋଇପାରେ, Wi-Fi ନେଟୱର୍କଗୁଡ଼ିକୁ ଅଜ୍ଞାନ କରିପାରେ।  ଆପଣ ଗୋଟିଏ ପ୍ରମାଣପତ୍ର "
-"ପ୍ରାଧିକାରୀ ପ୍ରମାଣପତ୍ରକୁ "
-"ବାଛିବା ପାଇଁ ଚାହୁଁଛନ୍ତି କି?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "ଆଗ୍ରହ୍ଯ କରିଦିଅନ୍ତୁ"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "CA ପ୍ରମାଣପତ୍ର ବାଛନ୍ତୁ"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, କିମ୍ବା PKCS#12 ବ୍ୟକ୍ତିଗତ କିଗୁଡ଼ିକ (*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER କିମ୍ବା PEM ପ୍ରମାଣପତ୍ରଗୁଡ଼ିକ (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-#| msgid "Choose a PAC file..."
-msgid "Choose a PAC file"
-msgstr "ଗୋଟିଏ PAC ଫାଇଲ ବାଛନ୍ତୁ"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC ଫାଇଲଗୁଡ଼ିକ (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC ଫାଇଲଗୁଡ଼ିକ  (_f)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "ଭିତର ବୈଧିକରଣ (_I)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "PAC ସୁବିଧା (_v)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "ଅଜ୍ଞାତ"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "ବୈଧିକୃତ"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "ଉଭୟ"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "ଅଜଣା ପରିଚୟ (_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC ଫାଇଲଗୁଡ଼ିକ  (_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "ଗୋଟିଏ PAC ଫାଇଲ ବାଛନ୍ତୁ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "ଭିତର ବୈଧିକରଣ (_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC ସୁବିଧା (_v)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "ଚାଳକ ନାମ (_U)"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "ପ୍ରବେଶ ସଂଙ୍କେତ (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦର୍ଶାନ୍ତୁ (_w)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-#| msgid "Choose a Certificate Authority certificate..."
-msgid "Choose a Certificate Authority certificate"
-msgstr "ଗୋଟିଏ ପ୍ରମାଣପତ୍ର ଅଧିକାରୀ ପ୍ରମାଣପତ୍ର ବାଛନ୍ତୁ"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "ସଂସ୍କରଣ 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "ସଂସ୍କରଣ 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "CA ପ୍ରମାଣ ପତ୍ର (_A)"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "ଗୋଟିଏ ପ୍ରମାଣପତ୍ର ଅଧିକାରୀ ପ୍ରମାଣପତ୍ର ବାଛନ୍ତୁ"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "ବୈଧିକରଣ ଆବଶ୍ଯକ"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP ସଂସ୍କରଣ (_v)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "ପ୍ରତ୍ୟେକ ଥର ଏହି ପ୍ରବେଶ ସଂକେତକୁ ପଚାରନ୍ତୁ (_k)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "ଅସଂଗୁପ୍ତ ବ୍ୟକ୍ତିଗତ କିଗୁଡ଼ିକ ଅସୁରକ୍ଷିତ ଅଟେ"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"ବଚ୍ଛିତ ବ୍ୟକ୍ତିଗତ କି ପ୍ରବେଶ ସଂକେତ ଦ୍ୱାରା ସୁରକ୍ଷିତ ଥିବା ପରି ଦୃଶ୍ୟମାନ "
-"ହେଉନାହିଁ।ଏହା ଆପଣଙ୍କର ସୁରକ୍ଷା "
-"ପ୍ରମାଣପତ୍ରଗୁଡ଼ିକୁ ସଙ୍କଟରେ ପକାଇବା ପାଇଁ ଅନୁମତି ଦେଇଥାଏ।  ଦୟାକରି ଗୋଟିଏ ପ୍ରବେଶ "
-"ସଂକେତ-ସୁରକ୍ଷିତ "
-"ବ୍ୟକ୍ତିଗତ କି ବାଛନ୍ତୁ।\n"
-"\n"
-"(ଆପଣ ଆପମଙ୍କର ବ୍ୟକିତଗତ କିକୁ openssl ଦ୍ୱାରା ପ୍ରବେଶ ସଂକେତ-ପ୍ରତିରୋଧିତ କରିପାରିବେ)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-#| msgid "Choose your personal certificate..."
-msgid "Choose your personal certificate"
-msgstr "ଆପଣଙ୍କର ବ୍ୟକ୍ତିଗତ ପ୍ରମାଣପତ୍ରକୁ ବାଛନ୍ତୁ"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-#| msgid "Choose your private key..."
-msgid "Choose your private key"
-msgstr "ଆପଣଙ୍କର ବ୍ୟକ୍ତିଗତ କିକୁ ବାଛନ୍ତୁ"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "ପରିଚୟ (_d)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "ଚାଳକ ପ୍ରମାଣପତ୍ର (_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "ବ୍ୟକ୍ତିଗତ କି (_k)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "ବ୍ୟକ୍ତିଗତ କି ପ୍ରବେଶ ସଂକେତ (_P)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "ମୋତେ ପୁଣିଥରେ ଚେତାବନୀ ଦିଅନ୍ତୁ ନାହିଁ (_w)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "ଡମେନ (_D)"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "ନାହିଁ"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "ହଁ"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "କ୍ଷୀପ୍ର"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "ଟନେଲଯୁକ୍ତ TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "ସୁରକ୍ଷିତ EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "ବୈଧିକରଣ (_t)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "ଖୋଲା ତନ୍ତ୍ର"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "ସହଭାଗୀ କି"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "କି (_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "କି ଦର୍ଶାନ୍ତୁ (_w)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP ଅନୁକ୍ରମଣିକା (_x)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "ପ୍ରକାର (_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "ଖୋଲା ତନ୍ତ୍ର"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "ସହଭାଗୀ କି"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "କି (_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "କି ଦର୍ଶାନ୍ତୁ (_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP ଅନୁକ୍ରମଣିକା (_x)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "ଧ୍ବନୀ ସତର୍କ ସୂଚନା"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "ପପ୍‌ଅପ୍‌ ବ୍ୟାନେର ଦର୍ଶାନ୍ତୁ"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "ବ୍ୟାନେରଗୁଡ଼ିକରେ ବିସ୍ତୃତ ବିବରଣୀ ଦର୍ଶାନ୍ତୁ"
-
-#: ../panels/notifications/cc-edit-dialog.c:43
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "ତାଲା ଲାଗିଥିବା ପରଦାରେ ଦେଖନ୍ତୁ"
-
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "ତାଲା ପରଦାରେ ବିସ୍ତୃତ ବିବରଣୀ ଦର୍ଶାନ୍ତୁ"
-
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "ଅନ"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
-msgid "Control which notifications are displayed and what they show"
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
 msgstr ""
-"କେଉଁ ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକୁ ଦର୍ଶାଯିବ ଏବଂ ତାହା କଣ ଦର୍ଶାଇଥାଏ ତାହାକୁ ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "ତାଲା ପରଦାରେ ବିସ୍ତୃତ ବିବରଣୀ ଦର୍ଶାନ୍ତୁ"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "କେଉଁ ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକୁ ଦର୍ଶାଯିବ ଏବଂ ତାହା କଣ ଦର୍ଶାଇଥାଏ ତାହାକୁ ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ;ବ୍ୟାନେର;ସନ୍ଦେଶ;ଟ୍ରେ;ପପଅପ୍‌;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "ପପଅପ୍‌ ବ୍ୟାନେରଗୁଡ଼ିକୁ ଦର୍ଶାନ୍ତୁ"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "ତାଲା ପରଦାରେ ଦର୍ଶାନ୍ତୁ"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "ଭିତର ବୈଧିକରଣ (_a)"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-#| msgid "Other"
-msgctxt "Online Account"
-msgid "Other"
-msgstr "ଅନ୍ଯାନ୍ଯ"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "ଖାତା ଯୋଗ କରନ୍ତୁ"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
-msgstr "ମେଲ"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr "ସମ୍ପର୍କଗୁଡ଼ିକ"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "ବାର୍ତ୍ତାଳାପ"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "ଉତ୍ସଗୁଡ଼ିକ"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "ଖାତାରେ ଲଗଇନ କରିବାରେ ତ୍ରୁଟି"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "ଅଧିକାର ସମାପ୍ତ ହୋଇଛି।"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr "ଏହି ଖାତାକୁ ସକ୍ରିୟ କରିବା ପାଇଁ ସାଇନ୍‌ ଇନ୍‌ କରନ୍ତୁ।"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr "ସାଇନ୍‌ ଇନ୍‌ (_S)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "ଖାତା ନିର୍ମାଣ କରିବାରେ ତ୍ରୁଟି"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "ଖାତା ବାହାର କରିବାରେ ତ୍ରୁଟି"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "ଏହି ଖାତାକୁ ଅପସାରଣ କରିବାକୁ ଚାହୁଁଛନ୍ତି ବୋଲି ଆପଣ ନିଶ୍ଚିତ କି?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "ଏହା ସର୍ଭରରେ ସେହି ଖାତାକୁ ଅପସାରଣ କରିବ ନାହିଁ।"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "ଅପସାରଣ କରନ୍ତୁ (_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "ଅନଲାଇନ ଖାତାଗୁଡ଼ିକ"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
-"ଆପମଙ୍କର ଅନ୍‌ଲାଇନ୍‌ ଖାତା ସହିତ ସଂଯୋଗ କରନ୍ତୁ ଏବଂ ତାହାକୁ କଣ ପାଇଁ ବ୍ୟବହାର କରାଯିବ "
-"ତାହା ସିଦ୍ଧାନ୍ତ "
+"ଆପମଙ୍କର ଅନ୍‌ଲାଇନ୍‌ ଖାତା ସହିତ ସଂଯୋଗ କରନ୍ତୁ ଏବଂ ତାହାକୁ କଣ ପାଇଁ ବ୍ୟବହାର କରାଯିବ ତାହା ସିଦ୍ଧାନ୍ତ "
 "କରନ୍ତୁ"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
-#| "ownCloud;"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-"Google;Facebook;Twitter;Yahoo;ୱେବ;ଅନଲାଇନ;ଚାର୍ଟ;କ୍ୟାଲେଣ୍ଡର;ମେଲ;ସମ୍ପର୍କ;ownCloud"
-";"
+"Google;Facebook;Twitter;Yahoo;ୱେବ;ଅନଲାଇନ;ଚାର୍ଟ;କ୍ୟାଲେଣ୍ଡର;ମେଲ;ସମ୍ପର୍କ;ownCloud;"
 "କର୍ବୋରସ୍‌;IMAP;SMTP;ପକେଟ;ଏହାକୁ ପରେ ପଢ଼ନ୍ତୁ;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "କୌଣସି ଅନଲାଇନ ଖାତାଗୁଡ଼ିକ ବିନ୍ୟାସିତ ହୋଇନାହିଁ"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "ଖାତାକୁ ବାହାର କରନ୍ତୁ"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "ଏକ ଅନଲାଇନ ଖାତା ଯୋଗ କରନ୍ତୁ"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"ଏକ ଖାତା ଯୋଗ କିରବା ଫଳରେ ତାହା ଆପଣଙ୍କୁ ଦଲିଲ, ମେଲ, ସମ୍ପର୍କ, କ୍ୟାଲେଣ୍ଡର, ଚାଟ ଏବଂ "
-"ଆହୁରି ଅନେକ "
-"ପ୍ରୟୋଗ ପାଇଁ ଅନୁମତି ଦେଇଥାଏ।"
-
-#: ../panels/power/cc-power-panel.c:183
-msgid "Unknown time"
-msgstr "ଅଜଣା ସମୟ"
-
-#: ../panels/power/cc-power-panel.c:189
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%iମିନିଟ"
 msgstr[1] "%i ମିନଟ"
 
-#: ../panels/power/cc-power-panel.c:201
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i ଘଣ୍ଟା"
 msgstr[1] "%i ଘଣ୍ଟା"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:209
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ଘଣ୍ଟା"
 msgstr[1] "ଘଣ୍ଟା"
 
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "ମିନିଟ"
 msgstr[1] "ମିନିଟ"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:230
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହେବା ପର୍ଯ୍ୟନ୍ତ"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 ମିନିଟ"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:237
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "ବିପଦ: %s ବଳିଅଛି"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 ମିନିଟଗୁଡିକ"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:242
-#, c-format
-msgid "%s remaining"
-msgstr "%s ବଳିଅଛି"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 ମିନିଟ"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
-msgid "Fully charged"
-msgstr "ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହୋଇଛି"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 ମିନିଟ"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
-msgid "Empty"
-msgstr "ଖାଲି"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Charging"
-msgstr "ଚାର୍ଜ ହେଉଛି"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:271
-msgid "Discharging"
-msgstr "ଚାର୍ଜ କମୁଅଛି"
-
-#: ../panels/power/cc-power-panel.c:396
-msgctxt "Battery name"
-msgid "Main"
-msgstr "ମୂଖ୍ଯ"
-
-#: ../panels/power/cc-power-panel.c:398
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "ବଳକା"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:470
-msgid "Wireless mouse"
-msgstr "ବେତାର ମାଉସ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:473
-msgid "Wireless keyboard"
-msgstr "ବେତାର କିବୋର୍ଡ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:476
-msgid "Uninterruptible power supply"
-msgstr "ବାଧାପ୍ରାପ୍ତ ହୋଇନଥିବା ବିଦ୍ୟୁତ ସେବା"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Personal digital assistant"
-msgstr "ବ୍ୟକ୍ତିଗତ ଡିଜିଟାଲ ସହାୟତା"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Cellphone"
-msgstr "ସେଲଫୋନ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Media player"
-msgstr "ମେଡ଼ିଆ ଚାଲକ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Tablet"
-msgstr "ଟ୍ୟାବଲେଟ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Computer"
-msgstr "କମ୍ପୁଟର"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
-#: ../panels/power/cc-power-panel.c:2019
-msgid "Battery"
-msgstr "ବ୍ଯାଟେରୀ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "ଚାର୍ଜ ହେଉଛି"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "ସତର୍କତା"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Low"
-msgstr "ନିମ୍ନ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Good"
-msgstr "ଉତ୍ତମ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହୋଇଛି"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "ଖାଲି"
-
-#: ../panels/power/cc-power-panel.c:715
-msgid "Batteries"
-msgstr "ବ୍ଯାଟେରୀ"
-
-#: ../panels/power/cc-power-panel.c:1117
-msgid "When _idle"
-msgstr "ନିଷ୍କ୍ରିୟ ଥିବା ସମୟରେ (_i)"
-
-#: ../panels/power/cc-power-panel.c:1445
-msgid "Power Saving"
-msgstr "ଶକ୍ତି ସଂରକ୍ଷଣ"
-
-#: ../panels/power/cc-power-panel.c:1473
-#| msgid "_Screen Brightness"
-msgid "_Screen brightness"
-msgstr "ପରଦା ଉଜ୍ଜ୍ବଳତା (_S)"
-
-#: ../panels/power/cc-power-panel.c:1479
-#| msgid "Keyboard Preferences"
-msgid "_Keyboard brightness"
-msgstr "କିବୋର୍ଡ ଉଜ୍ଜ୍ୱଳତା (_K)"
-
-#: ../panels/power/cc-power-panel.c:1489
-#| msgid "_Dim Screen when Inactive"
-msgid "_Dim screen when inactive"
-msgstr "ନିଷ୍କ୍ରିୟ ଥିବା ସମୟରେ ପରଦା ଉଜ୍ଜ୍ୱଳତାକୁ କମ କରନ୍ତୁ (_D)"
-
-#: ../panels/power/cc-power-panel.c:1514
-#| msgid "_Blank Screen"
-msgid "_Blank screen"
-msgstr "ଖାଲି ପରଦା (_B)"
-
-#: ../panels/power/cc-power-panel.c:1551
-msgid "_Wi-Fi"
-msgstr "Wi-Fi (_W)"
-
-#: ../panels/power/cc-power-panel.c:1556
-msgid "Turns off wireless devices"
-msgstr "ବେତାର ଉପକରଣଗୁଡ଼ିକୁ ଅଫ୍‌ କରନ୍ତୁ"
-
-#: ../panels/power/cc-power-panel.c:1581
-#| msgid "_Mobile Broadband"
-msgid "_Mobile broadband"
-msgstr "ମୋବାଇଲ ବ୍ରୋଡ଼ବ୍ୟାଣ୍ଡ (_M)"
-
-#: ../panels/power/cc-power-panel.c:1586
-#| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "ମୋବାଇଲ ବ୍ରୋଡ଼ବ୍ୟାଣ୍ଡ (3G, 4G, WiMax, ଇତ୍ୟାଦି) ଉପକରଣଗୁଡ଼ିକୁ ଅଫ୍‌ କରନ୍ତୁ"
-
-#: ../panels/power/cc-power-panel.c:1635
-msgid "_Bluetooth"
-msgstr "ବ୍ଲୁଟୁଥ (_B)"
-
-#: ../panels/power/cc-power-panel.c:1686
-msgid "When on battery power"
-msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତିରେ ଚାଲୁଥିବା ସମୟରେ"
-
-#: ../panels/power/cc-power-panel.c:1688
-msgid "When plugged in"
-msgstr "ପ୍ଲଗଇନ ହୋଇଥିବା ସମୟରେ"
-
-#: ../panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Off"
-msgstr "ନିଲମ୍ବିତ କରନ୍ତୁ ଏବଂ ବିଦ୍ୟୁତ ପ୍ରବାହ ବନ୍ଦ କରନ୍ତୁ"
-
-#: ../panels/power/cc-power-panel.c:1851
-#| msgid "_Automatic Suspend"
-msgid "_Automatic suspend"
-msgstr "ସ୍ବୟଂଚାଳିତ ନିଲମ୍ବନ (_A)"
-
-#: ../panels/power/cc-power-panel.c:1875
-#| msgid "When Battery Power is _Critical"
-msgid "When battery power is _critical"
-msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତି ଅତି କମ ଥିବା ସମୟରେ (_c)"
-
-#: ../panels/power/cc-power-panel.c:1930
-msgid "Power Off"
-msgstr "ବିଦ୍ୟୁତ ପ୍ରବାହ ବନ୍ଦ କରନ୍ତୁ"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Devices"
-msgstr "ଉପକରଣଗୁଡ଼ିକ"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "ଶକ୍ତି"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr ""
-"ଆପଣଙ୍କର ବ୍ୟାଟେରୀ ଶକ୍ତି ଦେଖନ୍ତୁ ଏବଂ ଶକ୍ତି ସଂରକ୍ଷଣ ସଂରଚନାକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-"ଶକ୍ତି;ସୁପ୍ତ;ନିଲମ୍ବିତ;ହାଇବରନେଟ;ବ୍ୟାଟେରୀ;ଉଜ୍ଜ୍ୱଳତା;ଡ଼ିମ;ଖାଲି;ମନିଟର;DPMS;ନିଷ୍କ୍ରି"
-"ୟ;"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "ବିଦ୍ୟୁତ ଶକ୍ତି ବନ୍ଦ କରନ୍ତୁ"
-
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 ମିନିଟ"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 ଘଣ୍ଟା"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 ମିନିଟ"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 ମିନିଟ"
 
-#: ../panels/power/power.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 ମିନିଟ"
 
-#: ../panels/power/power.ui.h:10
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 ଘଣ୍ଟା"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 ମିନଟ"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "ବ୍ଯାଟେରୀ"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 ମିନିଟଗୁଡିକ"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ଉପକରଣଗୁଡ଼ିକ"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 ମିନିଟଗୁଡିକ"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "ବିଦ୍ୟୁତ ଶକ୍ତି ବନ୍ଦ କରନ୍ତୁ"
 
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "4 ମିନିଟ"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 ମିନିଟ"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "ଶକ୍ତି ସଂରକ୍ଷଣ"
 
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "8 ମିନିଟ"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "ପରଦା ଉଜ୍ଜ୍ବଳତା (_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 ମିନିଟ"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "ପରଦା ଉଜ୍ଜ୍ୱଳତା ଏବଂ ତାଲା ସଂରଚନା"
 
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "12 ମିନିଟ"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "ପରଦା"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "ପରଦା ପାଠକ (_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "ସ୍ବୟଂଚାଳିତ ପଥଗୁଡ଼ିକ"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "ସ୍ବୟଂଚାଳିତ ନିଲମ୍ବନ"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "ତଳ ବଟନ"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "ସ୍ବୟଂଚାଳିତ ନିଲମ୍ବନ"
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "ପ୍ଲଗଇନ ହୋଇଛି (_P)"
 
-#: ../panels/power/power.ui.h:22
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତିରେ ଚାଲୁଛି (_B)"
 
-#: ../panels/power/power.ui.h:23
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "ବିଳମ୍ବ"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "ବୈଧିକୃତ"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "ଶକ୍ତି"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "ପ୍ରବେଶ ସଙ୍କେତ"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "ଆପଣଙ୍କର ବ୍ୟାଟେରୀ ଶକ୍ତି ଦେଖନ୍ତୁ ଏବଂ ଶକ୍ତି ସଂରକ୍ଷଣ ସଂରଚନାକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "ବୈଧିକରଣ ଆବଶ୍ୟକ"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr "ଟୋନର କମ ଅଛି"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr "ଟୋନର ସରିଯାଇଛି"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr "ବିକାଶକାରୀ କମ ଅଛି"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr "ବିକାଶକାରୀ ସରିଯାଇଛି"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr "ଚିହ୍ନଟ ସାମଗ୍ରୀର କମ ଅଛି"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr "ଚିହ୍ନଟ ସାମଗ୍ରୀର ଅଭାବ ଅଛି"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr "ଆବରଣ ଖୋଲନ୍ତୁ"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr "ଦ୍ୱାର ଖୋଲନ୍ତୁ"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr "କାଗଜ କମ ଅଛି"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr "କାଗଜ ସରିଯାଇଛି"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ଅଫଲାଇନ"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "ଅଟକିଛି"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr "ଆବର୍ଜନା ପାତ୍ର ପ୍ରାୟତଃ ପୁରଣ ହୋଇଛି"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr "ଆବର୍ଜନା ପାତ୍ର ପୁରଣ ଅଛି"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr "ଅପଟିକାଲ ଫୋଟୋ କଣ୍ଡକଟରର ସମୟ ସମାପ୍ତ ହେବାକୁ ଯାଉଛି"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ଅପଟିକାଲ ଫୋଟୋ କଣ୍ଡକଟର ବର୍ତ୍ତମାନ କାମ କରୁନାହିଁ"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "ବିନ୍ୟାସ  କରୁଅଛି"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr "ପ୍ରସ୍ତୁତ"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "କାର୍ଯ୍ଯଗୁଡ଼ିକୁ ଗ୍ରହଣ କରିନଥାଏ"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr "କାର୍ଯ୍ୟକାରୀ କରୁଅଛି"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Toner Level"
-msgstr "ଟୋନର ସ୍ତର"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Ink Level"
-msgstr "କାଳି ସ୍ତର"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:928
-msgid "Supply Level"
-msgstr "ସାମଗ୍ରୀ ସ୍ତର"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:946
-msgctxt "printer state"
-msgid "Installing"
-msgstr "ସ୍ଥାପନ କରୁଅଛି"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1123
-msgid "No printers available"
-msgstr "କୌଣସି ମୁଦ୍ରଣୀ ଉପଲବ୍ଧ ନାହିଁ"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1433
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u ସକ୍ରିୟ"
-msgstr[1] "%u ସକ୍ରିୟ"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1777
-msgid "Failed to add new printer."
-msgstr "ନୂତନ ମୁଦ୍ରଣୀ ଯୋଗକରିବାରେ ବିଫଳ।"
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid "Select PPD File"
-msgstr "PPD ଫାଇଲ ବାଛନ୍ତୁ"
-
-#: ../panels/printers/cc-printers-panel.c:1953
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"ପୋଷ୍ଟସ୍କ୍ରିପ୍ଟ ମୁଦ୍ରଣୀ ବର୍ଣ୍ଣନା ଫାଇଲ୍ ଗୁଡାକ (*.ppd, *.PPD, *.ppd.gz, "
-"*.PPD.gz, *.PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "ଶକ୍ତି;ସୁପ୍ତ;ନିଲମ୍ବିତ;ହାଇବରନେଟ;ବ୍ୟାଟେରୀ;ଉଜ୍ଜ୍ୱଳତା;ଡ଼ିମ;ଖାଲି;ମନିଟର;DPMS;ନିଷ୍କ୍ରିୟ;"
 
-#: ../panels/printers/cc-printers-panel.c:2258
-msgid "No suitable driver found"
-msgstr "କୌଣସି  ଉପଯୁକ୍ତ ଡ୍ରାଇଭର ମିଳିଲା ନାହିଁ"
-
-#: ../panels/printers/cc-printers-panel.c:2327
-msgid "Searching for preferred drivers…"
-msgstr "ପସନ୍ଦ ଯୋଗ୍ୟ ଡ୍ରାଇଭର ଖୋଜୁଅଛି …"
-
-#: ../panels/printers/cc-printers-panel.c:2342
-msgid "Select from database…"
-msgstr "ତଥ୍ୟାଧାରରୁ ବାଛନ୍ତୁ …"
-
-#: ../panels/printers/cc-printers-panel.c:2351
-msgid "Provide PPD File…"
-msgstr "PPD ଫାଇଲ ପ୍ରଦାନ କରନ୍ତୁ…"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2502
-#: ../panels/printers/cc-printers-panel.c:2525
-msgid "Test page"
-msgstr "ପରୀକ୍ଷା ପୃଷ୍ଠା"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2933
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui କୁ ଧାରଣ କରିପାରିଲା ନାହିଁ : %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "ମୂଦ୍ରଣୀଗୁଡ଼ିକ"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
-"ମୁଦ୍ରଣୀ ଯୋଗ କରନ୍ତୁ, ମୁଦ୍ରଣୀ କାର୍ଯ୍ୟଗୁଡ଼ିକୁ ଦେଖନ୍ତୁ ଏବଂ ଆପଣ କିପରି ମୁଦ୍ରଣ କରିବେ "
-"ତାହା ସିଦ୍ଧାନ୍ତ କରନ୍ତୁ"
+"ମୁଦ୍ରଣୀ ଯୋଗ କରନ୍ତୁ, ମୁଦ୍ରଣୀ କାର୍ଯ୍ୟଗୁଡ଼ିକୁ ଦେଖନ୍ତୁ ଏବଂ ଆପଣ କିପରି ମୁଦ୍ରଣ କରିବେ ତାହା ସିଦ୍ଧାନ୍ତ କରନ୍ତୁ"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "ମୁଦ୍ରଣୀ;କ୍ରମ;ମୁଦ୍ରଣ କରନ୍ତୁ;କାଗଜ;କାଳି;ଟୋନର;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "ସକ୍ରିୟ କାର୍ଯ୍ୟଗୁଡ଼ିକ"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "ବନ୍ଦକରନ୍ତୁ"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "ମୁଦ୍ରଣ କାର୍ଯ୍ୟକୁ ପୁଣି ଚାଲୁ କରନ୍ତୁ"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "ମୁଦ୍ରଣ କାର୍ଯ୍ୟକୁ ବିରତି ଦିଅନ୍ତୁ"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "ମୁଦ୍ରଣୀ କାର୍ଯ୍ୟକୁ ବାତିଲ କରନ୍ତୁ"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "ନୂତନ ମୁଦ୍ରଣୀ ଯୋଗ କରନ୍ତୁ"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-#| msgid "Authenticate"
-msgid "A_uthenticate"
-msgstr "ବୈଧିକୃତ କରନ୍ତୁ (_u)"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "କୌଣସି ମୁଦ୍ରଣୀ ଚିହ୍ନା ହୋଇନାହିଁ।"
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-#| msgid "Search for network printers or filter result"
-msgid "Enter address of a printer or a text to filter results"
-msgstr "ଫଳାଫଳଗୁଡ଼ିକୁ ବାଛିବା ପାଇଁ ମୁଦ୍ରଣୀର ଠିକଣା ଅଥବା ପାଠ୍ୟ ଦିଅନ୍ତୁ"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "ବିକଳ୍ପଗୁଡିକୁ ଧାରଣ କରୁଅଛି …"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "ମୁଦ୍ରଣୀ ଡ୍ରାଇଭର ବାଛନ୍ତୁ"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "ଡ୍ରାଇଭର ତଥ୍ୟାଧାର ଧାରଣ କରୁଅଛି ..."
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-#| msgid "Remove Printer"
-msgid "JetDirect Printer"
-msgstr "JetDirect ମୁଦ୍ରଣୀ"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-#| msgid "%s Printer"
-msgid "LPD Printer"
-msgstr "LPD ମୁଦ୍ରଣୀ"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "ଗୋଟିଏ ପାଖ"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "ବୃହତ ଧାର (ମାନକ)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "ସଂକ୍ଷିପ୍ତ ଧାର (ଫ୍ଲିପ)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "ଚିତ୍ରପଟ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "କଡ଼ୁଆ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "ଓଲଟା ଭୂ-ଦୃଶ୍ଯ"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "ଓଲଟା ଚିତ୍ରପଟ"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "ବାକି ଅଛି"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "ଅଟକା ଯାଇଛି"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "କାର୍ଯ୍ୟକାରୀ କରୁଅଛି"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "ଅଟକିଛି"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "ବାତିଲ କରାଯାଇଛି"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "ପରିତ୍ଯାଗ କରାଯାଇଛି"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "ସମାପ୍ତ"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "କାମ ଶୀର୍ଷକ"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "କାର୍ଯ୍ୟ ସ୍ଥିତି"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "ସମୟ"
-
-#: ../panels/printers/pp-jobs-dialog.c:495
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s ସକ୍ରିୟ କାର୍ଯ୍ୟଗୁଡ଼ିକ"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Serial Port"
-msgstr "କ୍ରମିକ ପୋର୍ଟ"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1683
-msgid "Parallel Port"
-msgstr "ସମାନ୍ତରାଳ ପୋର୍ଟ"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-#| msgid "Location"
-msgid "Location: %s"
-msgstr "ଅବସ୍ଥାନ: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1744
-#, c-format
-#| msgid "A_ddress:"
-msgid "Address: %s"
-msgstr "ଠିକଣା: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1768
-#| msgid "_Inner authentication"
-msgid "Server requires authentication"
-msgstr "ସର୍ଭର ବୈଧିକରଣ ଆବଶ୍ୟକ କରିଥାଏ"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "ଉଭୟ ପାର୍ଶ୍ବ"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "କାଗଜର ପ୍ରକାର"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "କାଗଜ ଉତ୍ସ"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "ନିର୍ଗମ ଟ୍ରେ"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript ପ୍ରାକ-ଛଣା"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:531
-msgid "Pages per side"
-msgstr "ପ୍ରତ୍ଯେକ ପାର୍ଶ୍ବରେ ପୃଷ୍ଠା ସଂଖ୍ଯା"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:543
-msgid "Two-sided"
-msgstr "ଉଭୟ ପାର୍ଶ୍ବ"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:555
-msgid "Orientation"
-msgstr "ଆବର୍ତ୍ତନ"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:652
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "ସାଧାରଣ"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "ପୃଷ୍ଠା ବ୍ଯବସ୍ଥା"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "ସ୍ଥାପନ ଯୋଗ୍ଯ ବିକଳ୍ପ"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "କାର୍ଯ୍ଯ"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "ପ୍ରତିଛବି ଗୁଣବତ୍ତା"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "ରଙ୍ଗ"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "ସମ୍ପନ୍ନ କରୁଅଛି"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "ଉନ୍ନତ"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "ସ୍ବତଃ ଚୟନ"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ମୂଦ୍ରଣୀ"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "କୋବଳ GhostScript ଅକ୍ଷରରୂପଗୁଡ଼ିକୁ ଯୋଗକରନ୍ତୁ"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "PS ସ୍ତର 1କୁ ରୂପାନ୍ତରିତ କରନ୍ତୁ"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "PS ସ୍ତର 2କୁ ରୂପାନ୍ତରିତ କରନ୍ତୁ"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "କୌଣସି ପ୍ରାକ-ମୁଦ୍ରଣୀ ନାହିଁ"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "ନିର୍ମାତା"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "ଡ୍ରାଇଭର"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-"%s ରେ ଉପଲବ୍ଧ ମୁଦ୍ରଣୀଗୁଡ଼ିକୁ ଦେଖିବା ପାଇଁ ଆପଣଙ୍କର ବ୍ୟବହାରକାରୀ ନାମ ଏବଂ ପ୍ରବେଶ "
-"ସଂକେତ ଭରଣ "
-"କରନ୍ତୁ।"
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "ମୁଦ୍ରଣୀ ଯୋଗକରନ୍ତୁ"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "ମୁଦ୍ରଣୀକୁ ବାହାର କରନ୍ତୁ"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "ସାମଗ୍ରୀ"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "କୌଣସି ଛବି ମିଳିଲା ନାହିଁ"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "ବୈଧିକରଣ ଆବଶ୍ୟକ"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"%s ରେ ଉପଲବ୍ଧ ମୁଦ୍ରଣୀଗୁଡ଼ିକୁ ଦେଖିବା ପାଇଁ ଆପଣଙ୍କର ବ୍ୟବହାରକାରୀ ନାମ ଏବଂ ପ୍ରବେଶ ସଂକେତ ଭରଣ "
+"କରନ୍ତୁ।"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ଚାଳକ ନାମ"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "ସ୍ଥାନ"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-#| msgid "Default Route"
-msgid "_Default printer"
-msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ମୁଦ୍ରଣୀ (_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "ଡ୍ରାଇଭର"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "କାର୍ଯ୍ଯ"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "ପସନ୍ଦ ଯୋଗ୍ୟ ଡ୍ରାଇଭର ଖୋଜୁଅଛି …"
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "କାର୍ଯ୍ୟଗୁଡ଼ିକୁ ଦର୍ଶାନ୍ତୁ (_J)"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "ଏହି ସହରକୁ ଖୋଜନ୍ତୁ"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "ତଥ୍ୟାଧାରରୁ ବାଛନ୍ତୁ …"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "PPD ଫାଇଲ ପ୍ରଦାନ କରନ୍ତୁ…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "ମୁଦ୍ରଣୀ ଡ୍ରାଇଭର ବାଛନ୍ତୁ"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "ଡ୍ରାଇଭର ତଥ୍ୟାଧାର ଧାରଣ କରୁଅଛି ..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "ବାତିଲ କରନ୍ତୁ"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "ବାଛନ୍ତୁ"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "ସର୍ଭର ବୈଧିକରଣ ଆବଶ୍ୟକ କରିଥାଏ"
+msgstr[1] "ସର୍ଭର ବୈଧିକରଣ ଆବଶ୍ୟକ କରିଥାଏ"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "ଡମେନ (_D)"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "ବୈଧିକୃତ କରନ୍ତୁ (_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "ବୈଧିକୃତ"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s ସକ୍ରିୟ କାର୍ଯ୍ୟଗୁଡ଼ିକ"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "ପରୀକ୍ଷା ପୃଷ୍ଠା"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "ଲଗଇନ ବିକଳ୍ପଗୁଡିକ"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ମୂଦ୍ରଣୀ"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ମୂଦ୍ରଣୀ"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "ମୁଦ୍ରଣୀ କାର୍ଯ୍ୟକୁ ବାତିଲ କରନ୍ତୁ"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "ମୁଦ୍ରଣୀକୁ ବାହାର କରନ୍ତୁ"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "ସକ୍ରିୟ କାର୍ଯ୍ୟଗୁଡ଼ିକ"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "ମଡେଲ"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "ନାମପଟି"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "କାଳି ସ୍ତର"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "ନୂତନ ଡ୍ରାଇଭର ସେଟ କରୁଅଛି …"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "ପୃଷ୍ଠା 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "ପରୀକ୍ଷଣ ପୃଷ୍ଠାକୁ ମୁଦ୍ରଣ କରନ୍ତୁ (_T)"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "ବିକଳ୍ପଗୁଡ଼ିକ (_O)"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "ବର୍ତ୍ତମାନ ପୁନଃଚାଳନ କରନ୍ତୁ"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "ନୂତନ ମୁଦ୍ରଣୀ ଯୋଗ କରନ୍ତୁ"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "ମୁଦ୍ରଣୀ ଯୋଗକରନ୍ତୁ"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "ମୁଦ୍ରଣୀ ବିନ୍ୟାସକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "ମୂଦ୍ରଣୀଗୁଡ଼ିକ"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "ମୁଁ ଦୁଃଖିତ! ତନ୍ତ୍ର ମୁଦ୍ରଣୀ ସର୍ଭିସ\n"
 "ଉପଲବ୍ଧ ହେବା ପରି ଲାଗୁ ନାହିଁ।"
 
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "ପରଦା ତାଲା"
-
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "ବ୍ୟବହାର ବିଧି ଏବଂ ପୁରୁଣା ତଥ୍ଯ"
-
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
-msgstr "ଆବର୍ଜନା ପାତ୍ରରୁ ସମସ୍ତ ବସ୍ତୁକୁ ଖାଲି କରିବେ କି?"
-
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
-msgstr "ଏହି ଆବର୍ଜନା ପାତ୍ରରେ ଥିବା ସମସ୍ତ ବସ୍ତୁଗୁଡ଼ିକ ସବୁଦିନ ପାଇଁ ଅପସାରିତ ହୋଇଛି।"
-
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "ଆବର୍ଜନା ପାତ୍ରକୁ ଖାଲି କରନ୍ତୁ (_E)"
-
-#: ../panels/privacy/cc-privacy-panel.c:512
-#| msgid "Purge Trash & Temporary Files"
-msgid "Delete all the temporary files?"
-msgstr "ସମସ୍ତ ଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ଅପସାରଣ କରିବେ କି?"
-
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
-msgstr "ସମସ୍ତ ଅସ୍ଥାୟୀ ବସ୍ତୁଗୁଡ଼ିକ ସବୁଦିନ ପାଇଁ ଅପସାରିତ ହୋଇଛି।"
-
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "ଫାଇଲଗୁଡିକୁ ରଖନ୍ତୁ (_P)"
-
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "ଆବର୍ଜନା ଏବଂଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ପରିଷ୍କାର କରନ୍ତୁ"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-#| msgid "Software"
-msgid "Software Usage"
-msgstr "ସଫ୍ଟୱେର ଉପଯୋଗୀତା"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "ଗୋପନୀୟତା"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-"ଆପଣଙ୍କର ବ୍ୟକ୍ତିଗତ ସୂଚନାକୁ ସୁରକ୍ଷା ଦିଅନ୍ତୁ ଏବଂ ଅନ୍ୟମାନେ କଣ ଦେଖିପାରିବେ ତାହାକୁ "
-"ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "ପରଦା ଅଫ ହୋଇଛି"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 ସେକେଣ୍ଡ"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 ଦିନ"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 ଦିନ"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 ଦିନ"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 ଦିନ"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 ଦିନ"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 ଦିନ"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 ଦିନ"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 ଦିନ"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 ଦିନ"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "ସବୁଦିନ ପାଇଁ"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"ଆପଣଙ୍କର ପୁରୁଣା ତଥ୍ୟକୁ ମନେରଖିବା ଫଳରେ ସବୁକିଛି ପରେ ଖୋଜିବା ସମୟରେ ସହଜମୟ ହୋଇଥାଏ। "
-"ଏହି ବସ୍ତୁଗୁଡ଼ିକୁ "
-"ନେଟୱର୍କରେ ସହଭାଗ କରାଯାଇନଥାଏ।"
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "ନିକଟରେ ବ୍ୟବହାର ହୋଇଥିବା (_R)"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "ପୁରୁଣା ତଥ୍ୟ ରଖନ୍ତୁ (_H)"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "ସାମ୍ପ୍ରତିକ ପୁରୁଣା ତଥ୍ୟକୁ ସଫା କରନ୍ତୁ (_e)"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "ପରଦା ତାଲା ଆପଣଙ୍କର ଅନୁପସ୍ଥିତିରେ ଗୋପନୀୟତାକୁ ରକ୍ଷା କରିଥାଏ।"
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "ସ୍ୱୟଂଚାଳିତ ପରଦା ତାଲା (_L)"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "ଏତିକି ସମୟ ଖାଲି ରହିବା ପରେ ପରଦାକୁ ତାଲା ପକାନ୍ତୁ (_a)"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "ବିଜ୍ଞପ୍ତି ଦର୍ଶାନ୍ତୁ (_N)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"ଆପଣଙ୍କ କମ୍ପୁଟରକୁ ଅନାବଶ୍ୟକ ସମ୍ବେଦନଶୀଳ ସୂଚନାରୁ ମୁକ୍ତ ରଖିବା ପାଇଁ ସ୍ୱୟଂଚାଳିତ "
-"ଭାବରେ ଆବର୍ଜନା ଏବଂ "
-"ଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ଖାଲିକରନ୍ତୁ।"
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଆବର୍ଜନା ପାତ୍ରକୁ ଖାଲି କରନ୍ତୁ (_T)"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ଖାଲି କରନ୍ତୁ (_F)"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "ଏହା ପରେ ପରିଷ୍କାର କରନ୍ତୁ (_A)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"ଆପଣ କେଉଁ ସଫ୍ଟୱେର ବ୍ୟବହାର କରୁଛନ୍ତି ତାହା ବିଷୟରେ ସୂଚନା ଦେବା ଫଳରେ ତାହା ଆମକୁ ଅଧିକ "
-"ସଠିକ "
-"ପରାମର୍ଶଗୁଡ଼ିକୁ ଦେବା ପାଇଁ ସହାୟତା କରିଥାଏ। ଏହା ମଧ୍ଯ ଆମର ସଫ୍ଟୱେରକୁ ଉନ୍ନତ କରିବା "
-"ପାଇଁ "
-"ସହାୟତା କରିଥାଏ।\n"
-"\n"
-"ଆମେ ସଂଗ୍ରହ କରିଥିବା ସମସ୍ତ ସୂଚନା ଏହାକୁ ଅଜ୍ଞାତ କରିଥାଏ, ଏବଂ ଆମେ ତୃତୀୟ ପକ୍ଷ ସହିତ "
-"ଆପଣଙ୍କର "
-"ତଥ୍ୟକୁ ସହଭାଗ କରିନଥାଉ।"
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "ସଫ୍ଟୱେର ଉପଯୋଗୀତା ପରିସଂଖ୍ୟାନ ପଠାନ୍ତୁ (_S)"
-
-#: ../panels/privacy/privacy.ui.h:41
-#| msgid "Privacy"
-msgid "Privacy Policy"
-msgstr "ଗୋପନିୟତା ନିତୀ"
-
-#: ../panels/privacy/privacy.ui.h:42
-#| msgid "_Location name:"
-msgid "_Location Services"
-msgstr "ଅବସ୍ଥାନ ସର୍ଭିସ (_L)"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "ଆପଣଙ୍କର ଭୌଗଳିକ ସ୍ଥିତି ନିର୍ଦ୍ଧାରଣ କରିବା ପାଇଁ ବ୍ୟବହାର ହୋଇଥାଏ"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ଇମ୍ପେରୀୟାଲ"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "ମେଟ୍ରିକ"
-
-#: ../panels/region/cc-format-chooser.c:284
-msgid "No regions found"
-msgstr "କୌଣସି ସ୍ଥାନ ମିଳିଲା ନାହିଁ"
-
-#: ../panels/region/cc-input-chooser.c:179
-msgid "No input sources found"
-msgstr "କୌଣସି ନିବେଶ ଉତ୍ସ ମିଳିଲା ନାହିଁ"
-
-#: ../panels/region/cc-input-chooser.c:1076
-#| msgid "Other"
-msgctxt "Input Source"
-msgid "Other"
-msgstr "ଅନ୍ଯାନ୍ଯ"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:896
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr ""
-"ପରିବର୍ତ୍ତନଗୁଡ଼ିକୁ କାର୍ଯ୍ୟକାରୀ କରିବା ପାଇଁ ଆପଣଙ୍କର ଅଧିବେଶନକୁ ପୁନଃଚାଳନ କରିବା "
-"ଆବଶ୍ୟକ"
-
-#: ../panels/region/cc-region-panel.c:240
-#: ../panels/user-accounts/um-user-panel.c:897
-msgid "Restart Now"
-msgstr "ବର୍ତ୍ତମାନ ପୁନଃଚାଳନ କରନ୍ତୁ"
-
-#: ../panels/region/cc-region-panel.c:858
-msgid "No input source selected"
-msgstr "କୌଣସି  ନିବେଶ ଉତ୍ସ ବଛା ହୋଇନାହିଁ"
-
-#: ../panels/region/cc-region-panel.c:1088
-msgid "Sorry"
-msgstr "କ୍ଷମା କରନ୍ତୁ"
-
-#: ../panels/region/cc-region-panel.c:1090
-msgid "Input methods can't be used on the login screen"
-msgstr "ନିବେଶ ପ୍ରଣାଳୀଗୁଡ଼ିକୁ ଲଗଇନ ପରଦାରେ ବ୍ୟବହାର କରାଯାଇପାରିବ ନାହିଁ"
-
-#: ../panels/region/cc-region-panel.c:1727
-msgid "Login Screen"
-msgstr "ଲଗଇନ୍‌ ପରଦା"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ଫର୍ମାଟଗୁଡିକ"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "ସ୍ଥାନ ସନ୍ଧାନ କରନ୍ତୁ"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "ସାଧାରଣ କାର୍ୟ୍ଯଗୁଡିକ"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "ଫର୍ମାଟଗୁଡିକ"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "ପୂର୍ବଦୃଶ୍ଯ"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "ତାରିଖ"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "ସମୟ"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "ତାରିଖ ଏବଂ ସମୟ"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "ସଂଖ୍ଯାଗୁଡିକ"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "ମାପ"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "କାଗଜ"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "ଭାଷାଗୁଡ଼ିକୁ ସ୍ଥାପନ କରନ୍ତୁ..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "ମୋର ଖାତା"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "ଭାଷା (_L)"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "ଫର୍ମାଟଗୁଡିକ"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "ଲଗଇନ୍‌ ପରଦା"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "ଅଞ୍ଚଳ ଏବଂ ଭାଷା"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
-msgstr ""
-"ଆପଣଙ୍କର ପ୍ରଦର୍ଶନୀ ଭାଷା, ଶୈଳୀ, କିବୋର୍ଡ ବିନ୍ୟାସ ଏବଂ ନିବେଶ ଉତ୍ସଗୁଡ଼ିକୁ ବାଛନ୍ତୁ"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "ଆପଣଙ୍କର ପ୍ରଦର୍ଶନୀ ଭାଷା, ଶୈଳୀ, କିବୋର୍ଡ ବିନ୍ୟାସ ଏବଂ ନିବେଶ ଉତ୍ସଗୁଡ଼ିକୁ ବାଛନ୍ତୁ"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ଭାଷା;ବିନ୍ୟାସ;କିବୋର୍ଡ;ନିବେଶ;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "ନିବେଶ ଉତ୍ସ ଯୋଗ କରନ୍ତୁ"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "ସଞ୍ଚାର ମାଧ୍ଯମଗୁଡ଼ିକୁ କିପରି ନିୟନ୍ତ୍ରଣ କରିବେ ତାହା ବାଛନ୍ତୁ"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "ଉତ୍ସ ବିକଳ୍ପଗୁଡିକୁ ନିବେଶ କରନ୍ତୁ"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD ଧ୍ୱନୀ (_a)"
 
-#: ../panels/region/input-options.ui.h:2
-msgid "Use the _same source for all windows"
-msgstr "ସମସ୍ତ ୱିଣ୍ଡୋ ପାଇଁ ସମାନ ଉତ୍ସ ବ୍ୟବହାର କରନ୍ତୁ (_s)"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "DVD ଭିଡିଓ (_D)"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Allow _different sources for each window"
-msgstr "ପ୍ରତ୍ୟେକ ୱିଣ୍ଡୋ ପାଇଁ ବିଭିନ୍ନ ଉତ୍ସଗୁଡ଼ିକୁ ଅନୁମତି ଦିଅନ୍ତୁ (_d)"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "ସଙ୍ଗୀତ ଚାଳକ (_M)"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Keyboard Shortcuts"
-msgstr "କିବୋର୍ଡ ସର୍ଟକଟଗୁଡିକ"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "ସଫ୍ଟୱେର (_S)"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Switch to previous source"
-msgstr "ପୂର୍ବବର୍ତ୍ତୀ ଉତ୍ସକୁ ବଦଳ କର"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "ଅନ୍ଯାନ୍ଯ ସଞ୍ଚାର ମାଧ୍ଯମ (_O)…"
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "ମେଡ଼ିଆ ଭର୍ତ୍ତି ସମୟରେପଚାରନ୍ତୁ ନାହିଁ କିମ୍ବା ପ୍ରଗ୍ରାମ ଆରମ୍ଭ କରନ୍ତୁ ନାହିଁ (_N)"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Switch to next source"
-msgstr "ପରବର୍ତ୍ତୀ ଉତ୍ସକୁ ବଦଳ କର"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "ଅନ୍ୟ ସଞ୍ଚାର ମାଧ୍ଯମ କିପରି ନିୟନ୍ତ୍ରଣ କରିବେ ତାହା ବାଛନ୍ତୁ"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Super+Space"
-msgstr "Super+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "କାର୍ଯ୍ଯ (_A):"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "ଆପଣ ଏହି ସଂକ୍ଷିପ୍ତ ପଥଗୁଡ଼ିକୁ କିବୋର୍ଡ ସଂରଚନାରେ ପରିବର୍ତ୍ତନ କରିପାରିବେ"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "ପ୍ରକାର (_T):"
 
-#: ../panels/region/input-options.ui.h:10
-msgid "Alternative switch to next source"
-msgstr "ବୈକଳ୍ପିକ ଭାବରେ ପରବର୍ତ୍ତୀ ଉତ୍ସକୁ ବଦଳ କର"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "ଅପସାରଣଯୋଗ୍ୟ ସଞ୍ଚାରମାଧ୍ଯମ"
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Left+Right Alt"
-msgstr "ବାମ+ଡ଼ାହାଣ  Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "ବ୍ଲୁଟୁଥ ସଂରଚନାକୁ ବିନ୍ୟାସ କରନ୍ତୁ"
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "ଇରାଜୀ (ଯୁକ୍ତ ରାଜ୍ୟ)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "ଯୁକ୍ତ ରାଜ୍ଯ"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "ବିକଳ୍ପଗୁଡିକ"
-
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
-msgstr ""
-"ତନ୍ତ୍ରରେ ଲଗଇନ କରିବା ସମୟରେ ଲଗଇନ ସଂରଚନାଗୁଡ଼ିକ ସମସ୍ତ ବ୍ୟବହାରକାରୀଙ୍କ ଦ୍ୱାରା "
-"ବ୍ୟବହାର ହୋଇଥାଏ"
-
-#: ../panels/search/cc-search-locations-dialog.c:476
-#| msgid "Places"
-msgctxt "Search Location"
-msgid "Places"
-msgstr "ସ୍ଥାନଗୁଡିକ"
-
-#: ../panels/search/cc-search-locations-dialog.c:478
-#| msgid "Bookmarks"
-msgctxt "Search Location"
-msgid "Bookmarks"
-msgstr "ଚିହ୍ନିତ ସ୍ଥାନଗୁଡ଼ିକ"
-
-#: ../panels/search/cc-search-locations-dialog.c:480
-#| msgid "Other"
-msgctxt "Search Location"
-msgid "Other"
-msgstr "ଅନ୍ଯାନ୍ଯ"
-
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "ଗୋଟିଏ ସ୍ଥାନ ମନୋନୀତ କରନ୍ତୁ"
-
-#: ../panels/search/cc-search-locations-dialog.c:682
-#| msgid "GOK"
-msgid "_OK"
-msgstr "ଠିକ ଅଛି (_O)"
-
-#: ../panels/search/cc-search-panel.c:176
-msgid "No applications found"
-msgstr "କୌଣସି ପ୍ରୟୋଗ ମିଳିଲା ନାହିଁ"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "ଖୋଜନ୍ତୁ"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Control which applications show search results in the Activities Overview"
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"କାର୍ଯ୍ୟକଳାପ ସମୀକ୍ଷାରେ କେଉଁ ପ୍ରୟୋଗଗୁଡ଼ିକ ସନ୍ଧାନ ଫଳାଫଳ ଦର୍ଶାଇଥାଏ ତାହାକୁ "
-"ନିୟନ୍ତ୍ରଣ କରିଥାଏ"
+"ଉପକରଣ;ତନ୍ତ୍ର;ସୂଚନା;ସ୍ମୃତିସ୍ଥାନ;ସଞ୍ଚାଳକ;ସଂସ୍କରଣ;ପୂର୍ବନିର୍ଦ୍ଧାରିତ;ପ୍ରୟୋଗ;ପସନ୍ଦ ଯୋଗ୍ୟ;cd;dvd;usb;"
+"ଧ୍ୱନି;ଭିଡ଼ିଓ;ଡିସ୍କ;କଢ଼ାଯୋଗ୍ଯ;ମେଡ଼ିଆ;ସ୍ୱୟଂଚାଳନା;"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
-msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "ସନ୍ଧାନ କରନ୍ତୁ;ଖୋଜନ୍ତୁ;ଅନୁକ୍ରମଣିକା;ଲୁଚନ୍ତୁ;ଗୋପନୀୟତା;ଫଳାଫଳ;"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "ପରଦା ତାଲା"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "ଖାଲି ପରଦା (_B)"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "ସ୍ୱୟଂଚାଳିତ ପରଦା ତାଲା (_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "ସ୍ୱୟଂଚାଳିତ ପରଦା ତାଲା (_L)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "ତାଲା ପରଦାରେ ବିସ୍ତୃତ ବିବରଣୀ ଦର୍ଶାନ୍ତୁ"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "ପରଦାକୁ ତାଲା ଦେଇ ରଖନ୍ତୁ"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "ଗୋପନୀୟତା"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "ପରଦା"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "ଧ୍ୱନି ସେଟିଙ୍ଗଗୁଡିକ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "ସ୍ଥାନ ସନ୍ଧାନ କରନ୍ତୁ"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "ଉପରକୁ ଘୁଞ୍ଚାଅ"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "ତଳକୁ ଘୁଞ୍ଚାଅ"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "ପସନ୍ଦ"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "ଅନ"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "ଅଫ"
-
-#: ../panels/sharing/cc-sharing-panel.c:304
-#| msgid "Enabled"
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "ସକ୍ରିୟ"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-#| msgid "Active Jobs"
-msgctxt "service is active"
-msgid "Active"
-msgstr "ସକ୍ରିୟ"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "ଗୋଟିଏ ଫୋଲଡର ଖୋଲନ୍ତୁ"
-
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "ନକଲ କରନ୍ତୁ"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-msgid "Sharing"
-msgstr "ସହଭାଗ"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr "ଅନ୍ୟମାନଙ୍କ ସହିତ କଣ ସହଭାଗ କରିବେ ତାହା ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
 msgstr ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "ସୁଦୂର ଲଗଇନ୍‌କୁ ସକ୍ରିୟ ଅଥବା ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
+msgid "Places"
+msgstr "ସ୍ଥାନଗୁଡିକ"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "ସୁଦୂର ଲଗଇନକୁ ସକ୍ରିୟ କିମ୍ବା ନିଷ୍କ୍ରିୟ କରିବା ପାଇଁ ବୈଧିକରଣ ଆବଶ୍ଯକ"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
+msgid "Bookmarks"
+msgstr "ଚିହ୍ନିତ ସ୍ଥାନଗୁଡ଼ିକ"
 
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:299
-msgid "No networks selected for sharing"
-msgstr "ସହଭାଗ ପାଇଁ କୌଣସି ନେଟୱର୍କ ବଛାଯାଇ ନାହିଁ"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "ଅନ୍ଯାନ୍ଯ"
 
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
-#| msgid "Network"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "ସ୍ଥାନ"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "ପ୍ରୟୋଗ"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "ଠିକଣା ଅନୁସାରେ ସନ୍ଧାନ କରନ୍ତୁ (_S)"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"କାର୍ଯ୍ୟକଳାପ ସମୀକ୍ଷାରେ କେଉଁ ପ୍ରୟୋଗଗୁଡ଼ିକ ସନ୍ଧାନ ଫଳାଫଳ ଦର୍ଶାଇଥାଏ ତାହାକୁ ନିୟନ୍ତ୍ରଣ କରିଥାଏ"
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "ସନ୍ଧାନ କରନ୍ତୁ;ଖୋଜନ୍ତୁ;ଅନୁକ୍ରମଣିକା;ଲୁଚନ୍ତୁ;ଗୋପନୀୟତା;ଫଳାଫଳ;"
+
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "ନେଟୱର୍କଗୁଡ଼ିକ"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "ବ୍ଲୁଟୁଥ ସହଭାଗ"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "ସହଭାଗ"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-"ବ୍ଲୁଟୁଥ ସହଭାଗ ଆପଣଙ୍କୁ ଅନ୍ୟ ବ୍ଲୁଟୁଥ ସକ୍ରିୟ ଉପକରଣଗୁଡ଼ିକ ସହିତ ଫାଇଲ ସହଭାଗ କରିବା "
-"ପାଇଁ ଅନୁମତି ଦେଇଥାଏ"
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "କେବଳ ବିଶ୍ୱସ୍ତ ଉପକରଣଗୁଡ଼ିକରୁ ଗ୍ରହଣ କରନ୍ତୁ"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "ଗ୍ରହଣ କରାଯାଇଥିବା ଫାଇଲଗୁଡ଼ିକୁ ଆହରଣ ଫୋଲଡରରେ ସଂରକ୍ଷଣ କରନ୍ତୁ"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "କମ୍ପୁଟର ନାମ"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "ବ୍ୟକ୍ତିଗତ ଫାଇଲ ସହଭାଗ"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "ପରଦା ସହଭାଗ"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "ଡେସ୍କଟପ"
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
 msgstr "ମେଡ଼ିଆ ସହଭାଗ"
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "ସୁଦୂର ଲଗଇନ"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "ସହଭାଗ"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "ପ୍ରବେଶ ସଂଙ୍କେତ ଆବଶ୍ୟକ"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "ସୁଦୂର ଲଗଇନ"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "ନେଟୱର୍କ ଅଭିଗମ୍ୟତା ନଥିବା ହେତୁ କିଛି ସର୍ଭିସଗୁଡ଼ିକ ନିଷ୍କ୍ରିୟ ଅଛି।"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "ଡେସ୍କଟପ"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
-"ବ୍ୟକ୍ତିଗତ ଫାଇଲ ସହଭାଗ ଆପଣଙ୍କୁ ସାର୍ବଜନିକ ଫାଇଲକୁ ପ୍ରଚଳିତ ନେଟୱର୍କ ବ୍ୟବହାର କରୁଥିବା "
-"ଅନ୍ୟମାନଙ୍କ ସହିତ "
-"ସହଭାଗ ପାଇଁ ଅନୁମତି ଦେଇଥାଏ: <a href=\"dav://%s\">dav://%s</a>"
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr "ପ୍ରବେଶ ସଂଙ୍କେତ ଆବଶ୍ୟକ"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "ସୁଦୂର ଲଗଇନ୍‌କୁ ସକ୍ରିୟ ଅଥବା ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
 
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"ସୁରକ୍ଷିତ ସେଲ ନିର୍ଦ୍ଦେଶ ବ୍ୟବହାର କରି ସୁଦୂର ବ୍ୟବହାରକାରୀମାନଙ୍କୁ ସଂଯୋଗ କରିବା ପାଇଁ "
-"ଅନୁମତି ଦିଅନ୍ତୁ:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"ଏହା ସହିତ ସଂଯୋଗ ସ୍ଥାପନ କରି ସୁଦୂର ବ୍ୟବହାରକାରୀମାନଙ୍କୁ ଆପଣଙ୍କ ପରଦାକୁ ଦେଖିବା ଏବଂ "
-"ନିୟନ୍ତ୍ରଣ କରିବା "
-"ପାଇଁ ଅନୁମତି ଦିଅନ୍ତୁ: <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:20
-#| msgid "Remote Control"
-msgid "Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "ସୁଦୂର ନିୟନ୍ତ୍ରଣକୁ ଅନୁମତି ଦିଅନ୍ତୁ"
 
-#: ../panels/sharing/sharing.ui.h:21
-#| msgid "Password"
-msgid "Password:"
-msgstr "ପ୍ରବେଶ ସଙ୍କେତ:"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦେଖାନ୍ତୁ"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "ସଂଯୋଜିତ ହୋଇ ନାହିଁ"
 
-#: ../panels/sharing/sharing.ui.h:23
-#| msgid "%s Options"
-msgid "Access Options"
-msgstr "ଅଭିଗମ୍ୟତା ବିକଳ୍ପଗୁଡ଼ିକ"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "ନୂତନ ସଂଯୋଗଗୁଡ଼ିକ ନିଶ୍ଚିତ ଭାବରେ ଅଭିଗମ୍ୟତା ପଚାରିଥାଏ"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "ନକଲ କରନ୍ତୁ"
 
-#: ../panels/sharing/sharing.ui.h:25
-#| msgid "Require Password"
-msgid "Require a password"
-msgstr "ପ୍ରବେଶ ସଂଙ୍କେତ ଆବଶ୍ୟକ"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "ଠିକଣାକୁ ଅପସାରଣ କରନ୍ତୁ"
 
-#: ../panels/sharing/sharing.ui.h:26
-#| msgid "Share Music, Photos and Videos with others on the current network."
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "ବୈଧିକରଣ (_t)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ଚାଳକ ନାମ"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଲିପିବଦ୍ଧ କରୁଛି"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "ମେଡ଼ିଆ ସହଭାଗ"
+
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "ସଙ୍ଗୀତ, ଫୋଟ ଏବଂ ଭିଡ଼ିଓଗୁଡ଼ିକୁ ନେଟୱର୍କରେ ସହଭାଗ କରନ୍ତୁ।"
 
-#: ../panels/sharing/sharing.ui.h:27
-#| msgid "Add Folder"
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "ଫୋଲଡରଗୁଡିକ"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "ଶବ୍ଦ"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "ଅନ୍ୟମାନଙ୍କ ସହିତ କଣ ସହଭାଗ କରିବେ ତାହା ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "ଧ୍ୱନି ସ୍ତର, ନିବେଶ, ଫଳାଫଳ, ଏବଂ ସତର୍କ ସୂଚନା ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "କାର୍ଡ;ମାଇକ୍ରୋଫୋନ;ଭଲ୍ୟୁମ;ଫିକା;ସନ୍ତୁଳିତ;ବ୍ଲୁଟୁଥ;ହେଡସେଟ;ଧ୍ୱନୀ;"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "ସୁଦୂର ଲଗଇନ୍‌କୁ ସକ୍ରିୟ ଅଥବା ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "ଗରଜିବା"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "ସୁଦୂର ଲଗଇନକୁ ସକ୍ରିୟ କିମ୍ବା ନିଷ୍କ୍ରିୟ କରିବା ପାଇଁ ବୈଧିକରଣ ଆବଶ୍ଯକ"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "ପଡ଼ିବା"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "ଫ୍ଲିକର"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "କାଚ"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "ସହଭାଗ"
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "ସୋନାର"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "ବାମ"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "ଡାହାଣ"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "ସନ୍ତୁଳିତ (_B):"
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "ଫିକା (_F):"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "ପଛ"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "ସାମ୍ନା"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "ସର୍ବନିମ୍ନ"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "ସର୍ବାଧିକ"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "ସନ୍ତୁଳିତ (_B):"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "ଫିକା (_F):"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "ସବଉଫର (_S):"
-
-#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:616
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "ବଢ଼ାହୋଇନଥିବା"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "ରୂପରେଖ (_P):"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u ଫଳାଫଳ"
-msgstr[1] "%u ଫଳାଫଳଗୁଡ଼ିକ"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u ନିବେଶ"
-msgstr[1] "%u ନିବେଶଗୁଡ଼ିକ"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "ତନ୍ତ୍ର ଧ୍ୱନି"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "ସ୍ପିକରଗୁଡ଼ିକୁ ପରୀକ୍ଷା କରନ୍ତୁ (_T)"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "ଭଲ୍ୟୁମ ସତର୍କତା (_A):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "ଶୀର୍ଷ ଚିହ୍ନଟ"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "ଭଲ୍ଯୁମକୁ ନୀରବରେ ରଖ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1509
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "ନାମ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1528
-msgid "Device"
-msgstr "ଉପକରଣ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1591
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s ପାଇଁ ସ୍ପିକର ପରୀକ୍ଷଣ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1649
-msgid "_Output volume:"
-msgstr "ନିର୍ଗମ ଭଲ୍ଯୁମ (_O):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1663
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "ଫଳାଫଳ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1668
-msgid "C_hoose a device for sound output:"
-msgstr "ଧ୍ୱନି ନିର୍ଗମ ପାଇଁ ଗୋଟିଏ ଉପକରଣ ବାଛନ୍ତୁ (_h):"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "ନିର୍ଗମ ଭଲ୍ଯୁମ (_O):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1693
-msgid "Settings for the selected device:"
-msgstr "ବଚ୍ଛିତ ଉପକରଣ ପାଇଁ ବିନ୍ୟାସ:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "Input"
-msgstr "ନିବେଶ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "_Input volume:"
-msgstr "ନିବେଶ ଭଲ୍ୟୁମ (_I):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1734
-msgid "Input level:"
-msgstr "ନିବେଶ ସ୍ତର:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1762
-msgid "C_hoose a device for sound input:"
-msgstr "ଧ୍ୱନି ନିବେଶ ପାଇଁ ଗୋଟିଏ ଉପକରଣ ବାଛନ୍ତୁ (_h):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "Sound Effects"
-msgstr "ଧ୍ୱନି ପ୍ରଭାବଗୁଡ଼ିକ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-msgid "_Alert volume:"
-msgstr "ଭଲ୍ୟୁମ ସତର୍କତା (_A):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1809
-msgid "Applications"
-msgstr "ପ୍ରୟୋଗ"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1813
-msgid "No application is currently playing or recording audio."
-msgstr "କୌଣସି ପ୍ରୟୋଗ ବର୍ତ୍ତମାନ ଧ୍ୱନି ଚଲାଉ ନାହିଁ କିମ୍ବା ଲେଖୁ ନାହିଁ।"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "ଅନ୍ତଃନିର୍ମିତ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "ଧ୍ୱନି ପସନ୍ଦ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "ଘଟଣା ଧ୍ୱନି ପରୀକ୍ଷଣ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "ପ୍ରେରକ ପ୍ରସଙ୍ଗ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:769
-msgid "C_hoose an alert sound:"
-msgstr "ଗୋଟିଏ ସତର୍କ ଧ୍ୱନି ବାଛନ୍ତୁ (_h):"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "ବନ୍ଦ କରନ୍ତୁ"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "ପରୀକ୍ଷା"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "ବିନ୍ୟାସ URL (_C)"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "ସବଉଫର"
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "ଇଚ୍ଛାରୂପଣ"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "ନିବେଶ"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr ""
-"ଏହାକୁ ଦେଖିବା, ଶୁଣିବା, ଲେଖିବା, ଦର୍ଶାଇବା ଏବଂ କ୍ଲିକ କରିବା ପାଇଁ ସହଜମୟ କରନ୍ତୁ"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "ନିବେଶ ସ୍ତର:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;"
-#| "size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "ଭଲ୍ୟୁମ ଅଧିକ କରନ୍ତୁ"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "ଭଲ୍ୟୁମ ସତର୍କତା (_A):"
+
+#: panels/sound/cc-volume-slider.ui:22
+#, fuzzy
+msgid "Mute"
+msgstr "ନିରବ (_M)"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ଶବ୍ଦ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ଧ୍ୱନି ସ୍ତର, ନିବେଶ, ଫଳାଫଳ, ଏବଂ ସତର୍କ ସୂଚନା ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "କାର୍ଡ;ମାଇକ୍ରୋଫୋନ;ଭଲ୍ୟୁମ;ଫିକା;ସନ୍ତୁଳିତ;ବ୍ଲୁଟୁଥ;ହେଡସେଟ;ଧ୍ୱନୀ;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "ନାମ (_N):"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"କିବୋର୍ଡ;ମାଉସ;a11y;ପ୍ରବେଶାନୁମତି;ବିଭେଦନ;ସାନ ବଡ଼;ପରଦା "
-"ପାଠକ;ପରୀକ୍ଷା;ଅକ୍ଷରରୂପ;ଆକାର;ଅଭିଗମ୍ୟX;"
-"ଷ୍ଟିକି; କି;ମନ୍ଥର;ବାଉନ୍ସ;ମାଉସ;"
 
-#: ../panels/universal-access/uap.ui.h:1
-#| msgid "Universal Access"
-msgid "_Always Show Universal Access Menu"
-msgstr "ସର୍ବଦା ସାର୍ବଜନିନ ଅଭିଗମ୍ୟତା ତାଲିକା ଦର୍ଶାନ୍ତୁ (_A)"
-
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "ଚିତ୍ରଣକରୁଛି"
-
-#: ../panels/universal-access/uap.ui.h:3
-#| msgid "High Contrast"
-msgid "_High Contrast"
-msgstr "ଅଧିକ ସ୍ପଷ୍ଟତା (_H)"
-
-#: ../panels/universal-access/uap.ui.h:4
-#| msgid "Large Text"
-msgid "_Large Text"
-msgstr "ବୃହତ ପାଠ୍ୟ (_L)"
-
-#: ../panels/universal-access/uap.ui.h:5
-#| msgid "Zoom"
-msgid "_Zoom"
-msgstr "ସାନବଡ କରନ୍ତୁ (_Z)"
-
-#: ../panels/universal-access/uap.ui.h:7
-#| msgid "Screen Reader"
-msgid "Screen _Reader"
-msgstr "ପରଦା ପାଠକ (_R)"
-
-#: ../panels/universal-access/uap.ui.h:8
-#| msgid "Bounce Keys"
-msgid "_Sound Keys"
-msgstr "ଧ୍ବନୀ କି (_S)"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "ଶୁଣୁଅଛି"
-
-#: ../panels/universal-access/uap.ui.h:10
-#| msgid "Visual Alerts"
-msgid "_Visual Alerts"
-msgstr "ଚାକ୍ଷୁଷ ସତର୍କତା (_V)"
-
-#: ../panels/universal-access/uap.ui.h:12
-#| msgid "Screen keyboard"
-msgid "Screen _Keyboard"
-msgstr "ପରଦା କି-ବୋର୍ଡ (_K)"
-
-#: ../panels/universal-access/uap.ui.h:13
-#| msgid "Typing Assistant"
-msgid "_Typing Assist (AccessX)"
-msgstr "ଲେଖିବା ସହକାରୀ (AccessX) (_T)"
-
-#: ../panels/universal-access/uap.ui.h:14
-#| msgid "Pointing and Clicking"
-msgid "Pointing & Clicking"
-msgstr "ଇଙ୍ଗିତ କରିବା ଏବଂ କ୍ଲିକ କରିବା"
-
-#: ../panels/universal-access/uap.ui.h:15
-#| msgid "Mouse Keys"
-msgid "_Mouse Keys"
-msgstr "ମାଉସ କି (_M)"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "କ୍ଲିକ ସହାୟକ (_C)"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "ପରଦା ପାଠକ"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
 msgstr ""
-"ପରଦା ପାଠକ ଦର୍ଶାଯାଇଥିବା ପାଠ୍ୟକୁ ଲକ୍ଷ୍ୟ ପରିବର୍ତ୍ତନ କରିବା ସଙ୍ଗେ ସଙ୍ଗେ ପଢ଼ିଥାଏ।"
 
-#: ../panels/universal-access/uap.ui.h:19
-#| msgid "Screen Reader"
-msgid "_Screen Reader"
-msgstr "ପରଦା ପାଠକ (_S)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "ସ୍ୱୟଂଚାଳିତ ସଂଯୋଗ (_C)"
 
-#: ../panels/universal-access/uap.ui.h:20
-#| msgid "Bounce Keys"
-msgid "Sound Keys"
-msgstr "ଧ୍ୱନି କିଗୁଡ଼ିକ"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr " ଉପକରଣକୁ କାଢ଼ନ୍ତୁ"
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "Num Lock କିମ୍ବା Caps Lock ଅନ୍‌ ଥିବା ସମୟରେ ଦପ୍‌ ଦପ୍‌ କରନ୍ତୁ।"
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "ଚାକ୍ଷୁଷ ସତର୍କତା"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "ଫ୍ଲାସ ପରୀକ୍ଷା କରନ୍ତୁ (_T)"
-
-#: ../panels/universal-access/uap.ui.h:24
-#| msgid "Use a visual indication when an alert sound occurs"
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "ସତର୍କ ଧ୍ୱନୀ ହେଲେ ଦୃଶ୍ୟମାନ ସୂଚନା ବ୍ୟବହାର କରନ୍ତୁ।"
-
-#: ../panels/universal-access/uap.ui.h:25
-#| msgid "Flash the window title"
-msgid "Flash the _window title"
-msgstr "ଉଇଣ୍ଡୋ ଶୀର୍ଷକକୁ  ଫ୍ଲାଶ କରନ୍ତୁ (_w)"
-
-#: ../panels/universal-access/uap.ui.h:26
-#| msgid "Flash the entire screen"
-msgid "Flash the entire _screen"
-msgstr "ସମଗ୍ର ପରଦାକୁ ଫ୍ଲାଶ କରନ୍ତୁ (_s)"
-
-#: ../panels/universal-access/uap.ui.h:27
-#| msgid "Typing Assistant"
-msgid "Typing Assist"
-msgstr "ଲେଖିବା ସହକାରୀ"
-
-#: ../panels/universal-access/uap.ui.h:28
-#| msgid "Sticky Keys"
-msgid "_Sticky Keys"
-msgstr "ସାମୟିକ କିଗୁଡ଼ିକ (_S)"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "ପରିବର୍ତ୍ତନକାରୀ କିଗୁଡ଼ିକୁ କି ଯୁଗଳ ଭାବରେ ବ୍ୟବହାର କରନ୍ତୁ"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "ଦୁଇଟି କି ଏକା ସହିତ ଦବାହୋଇଥିଲେ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ (_D)"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifer key is pressed"
-msgstr "ଯଦି ପରିବର୍ତ୍ତକ କି କୁ ଦବାଯାଇଛି ତାହାହେଲେ ମିଟିମିଟି କରିବ (_m)"
-
-#: ../panels/universal-access/uap.ui.h:32
-#| msgid "Slow Keys"
-msgid "S_low Keys"
-msgstr "ମନ୍ଥର କିଗୁଡ଼ିକ (_l)"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
 msgstr ""
-"କେତେବେଳେ କି କୁ ଦବାଇବା ଉଚିତ ଏବଂ କେତେବେଳେ ଗ୍ରହଣ କରିବେ ତାହା ମଧ୍ଯରେ ବିଳମ୍ବ ସେଟ "
-"କରିଥାଏ"
 
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "ଗ୍ରହଣ କରିବାରେ ବିଳମ୍ବ (_c):"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s ଡମେନ ସହିତ ସଂଯୁକ୍ତ ହୋଇପାରିଲା ନାହିଁ: %s"
 
-#: ../panels/universal-access/uap.ui.h:35
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "ସଂକ୍ଷିପ୍ତ"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "ସାର୍ବଜନିକ ଅଭିଗମ୍ୟତା"
 
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "କିଗୁଡ଼ିକର ଲେଖିବାରେ ବିଲମ୍ବକୁ ଦର୍ଶାନ୍ତୁ"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:37
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "ଲମ୍ବା"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "ଉପକରଣକୁ ଯୋଗ କରନ୍ତୁ"
 
-#: ../panels/universal-access/uap.ui.h:38
-#| msgid "Beep when a _toggle key is pressed"
-msgid "Beep when a key is pr_essed"
-msgstr "ଆଗପଛ କି ଦବାଇବା ସମୟରେ ଦପଦପ କରନ୍ତୁ (_e)"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:39
-#| msgid "Beep when key is _accepted"
-msgid "Beep when a key is _accepted"
-msgstr "କି କୁ ଗ୍ରହଣ କରାଗଲେ ମିଟିମିଟି କରିବ (_a)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
 
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "ଯଦି କି କୁ ପ୍ରତ୍ଯାଖାନ କରାଗଲେ ମିଟିମିଟି କରିବ (_r)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:41
-#| msgid "Bounce Keys"
-msgid "_Bounce Keys"
-msgstr "ଡେଉଁଥିବା କିଗୁଡ଼ିକ (_B)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "ଦ୍ରୁତ ନକଲ କି ଦବାଇବାକୁ ଅଗ୍ରାହ୍ୟ କରନ୍ତୁ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "ଦର୍ଶିକାଟି ମିଟିମିଟି କରୁଅଛି"
 
-#: ../panels/universal-access/uap.ui.h:43
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "ସଂକ୍ଷିପ୍ତ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "ପାଠ୍ୟ କ୍ଷେତ୍ରରେ ସୂଚକ ଦପଦପ ହୋଇଥାଏ (_b)"
 
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "ଡେଉଁଥିବା କିଗୁଡ଼ିକର ଲେଖିବାରେ ବିଳମ୍ବ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_ଗତି:"
 
-#: ../panels/universal-access/uap.ui.h:45
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "ଲମ୍ବା"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "ସୂଚକ ମିଞ୍ଜି ମିଞ୍ଜି ଗତି"
 
-#: ../panels/universal-access/uap.ui.h:46
-#| msgid "Enable by Keyboard"
-msgid "_Enable by Keyboard"
-msgstr "କି ବୋର୍ଡ ଦ୍ୱାରା ସକ୍ରିୟ ହୋଇଛି (_E)"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "ସୂଚକ ମିଞ୍ଜି ମିଞ୍ଜି ଗତି"
 
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "କିବୋର୍ଡ ବ୍ୟବହାର କରି ଅଭିଗମ୍ୟତା ବିଶେଷଗୁଣଗୁଡ଼ିକୁ ଅନ ଏବଂ ଅଫ କରନ୍ତୁ"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "କ୍ଲିକ ସହାୟକ"
 
-#: ../panels/universal-access/uap.ui.h:49
-#| msgid "Simulated Secondary Click"
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "ଦ୍ୱିତୀୟକ କ୍ଲିକକୁ ଜାଗ୍ରତ କରନ୍ତୁ (_S)"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "ପ୍ରାଥମିକ ବଟନକୁ ତଳକୁ ଧରି ଦ୍ୱିତୀୟକ କ୍ଲିକକୁ ଜାଗ୍ରତ କରନ୍ତୁ"
 
-#: ../panels/universal-access/uap.ui.h:51
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "ଗ୍ରହଣ କରିବାରେ ବିଳମ୍ବ (_c):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "ସଂକ୍ଷିପ୍ତ"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "ଦ୍ୱିତୀୟକ କ୍ଲିକ ବିଳମ୍ବ"
 
-#: ../panels/universal-access/uap.ui.h:53
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "ଲମ୍ବା"
 
-#: ../panels/universal-access/uap.ui.h:54
-#| msgid "Hover Click"
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "ହଭର କ୍ଲିକ (_H)"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "ସୂଚକ ଗତିକୁ ଅଟକାଇବା ସମୟରେ କ୍ଲିକକୁ ଆରମ୍ଭ କରନ୍ତୁ"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "ବିଳମ୍ବ (_e):"
 
-#: ../panels/universal-access/uap.ui.h:57
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "ସଂକ୍ଷିପ୍ତ"
 
-#: ../panels/universal-access/uap.ui.h:58
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "ଲମ୍ବା"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "ଥ୍ରେସହୋଲ୍ଡ ଗତି (_t):"
 
-#: ../panels/universal-access/uap.ui.h:60
-#| msgctxt "universal access, text size"
-#| msgid "Small"
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "ଛୋଟ"
 
-#: ../panels/universal-access/uap.ui.h:61
-#| msgctxt "universal access, text size"
-#| msgid "Large"
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "ବଡ"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "କିଗୁଡ଼ିକୁ ପୁନରାବୃତି"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "କି ଦବାଇବା ପୁନରାବୃତ୍ତି ହୁଏ _ୟେବେ କିକୁ ଦବାଇ ଧରି ରଖାୟାଏ ।"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "ପୁନରାବୃତ୍ତି କିଗୁଡିକର ଗତି"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "ପୁନରାବୃତ୍ତି କିଗୁଡିକର ଗତି"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "ଲେଖିବା ସହକାରୀ"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "ସାମୟିକ କିଗୁଡ଼ିକ (_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "ପରିବର୍ତ୍ତନକାରୀ କିଗୁଡ଼ିକୁ କି ଯୁଗଳ ଭାବରେ ବ୍ୟବହାର କରନ୍ତୁ"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "ଦୁଇଟି କି ଏକା ସହିତ ଦବାହୋଇଥିଲେ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ (_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "ଯଦି ପରିବର୍ତ୍ତକ କି କୁ ଦବାଯାଇଛି ତାହାହେଲେ ମିଟିମିଟି କରିବ (_m)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "ମନ୍ଥର କିଗୁଡ଼ିକ (_l)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"କେତେବେଳେ କି କୁ ଦବାଇବା ଉଚିତ ଏବଂ କେତେବେଳେ ଗ୍ରହଣ କରିବେ ତାହା ମଧ୍ଯରେ ବିଳମ୍ବ ସେଟ କରିଥାଏ"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "ସଂକ୍ଷିପ୍ତ"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ପରଦା"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "କିଗୁଡ଼ିକର ଲେଖିବାରେ ବିଲମ୍ବକୁ ଦର୍ଶାନ୍ତୁ"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "1/2 ପରଦା"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ପରଦା"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "ଲମ୍ବା"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "ଆଗପଛ କି ଦବାଇବା ସମୟରେ ଦପଦପ କରନ୍ତୁ (_e)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "କି କୁ ଗ୍ରହଣ କରାଗଲେ ମିଟିମିଟି କରିବ (_a)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "ଯଦି କି କୁ ପ୍ରତ୍ଯାଖାନ କରାଗଲେ ମିଟିମିଟି କରିବ (_r)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "ଡେଉଁଥିବା କିଗୁଡ଼ିକ (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "ଦ୍ରୁତ ନକଲ କି ଦବାଇବାକୁ ଅଗ୍ରାହ୍ୟ କରନ୍ତୁ"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "ଡେଉଁଥିବା କିଗୁଡ଼ିକର ଲେଖିବାରେ ବିଳମ୍ବ"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "ଲମ୍ବା"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "କି ବୋର୍ଡ ଦ୍ୱାରା ସକ୍ରିୟ ହୋଇଛି (_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "କିବୋର୍ଡ ବ୍ୟବହାର କରି ଅଭିଗମ୍ୟତା ବିଶେଷଗୁଣଗୁଡ଼ିକୁ ଅନ ଏବଂ ଅଫ କରନ୍ତୁ"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "ସର୍ବଦା ସାର୍ବଜନିନ ଅଭିଗମ୍ୟତା ତାଲିକା ଦର୍ଶାନ୍ତୁ (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "ଚିତ୍ରଣକରୁଛି"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "ଅଧିକ ସ୍ପଷ୍ଟତା (_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "ବୃହତ ପାଠ୍ୟ (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "ପରଦା ପାଠକ (_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "ପରଦା ପାଠକ ଦର୍ଶାଯାଇଥିବା ପାଠ୍ୟକୁ ଲକ୍ଷ୍ୟ ପରିବର୍ତ୍ତନ କରିବା ସଙ୍ଗେ ସଙ୍ଗେ ପଢ଼ିଥାଏ।"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "ଧ୍ବନୀ କି (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num Lock କିମ୍ବା Caps Lock ଅନ୍‌ ଥିବା ସମୟରେ ଦପ୍‌ ଦପ୍‌ କରନ୍ତୁ।"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "ସୂଚକ ମିଞ୍ଜି ମିଞ୍ଜି ଗତି"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "ସାନବଡ କରନ୍ତୁ (_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "ଶୁଣୁଅଛି"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "ଚାକ୍ଷୁଷ ସତର୍କତା (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "ପରଦା କି-ବୋର୍ଡ (_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "କିଗୁଡ଼ିକୁ ପୁନରାବୃତି"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "ଦର୍ଶିକାଟି ମିଟିମିଟି କରୁଅଛି"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "ଲେଖିବା ସହକାରୀ (AccessX) (_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "ଇଙ୍ଗିତ କରିବା ଏବଂ କ୍ଲିକ କରିବା"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "ମାଉସ କି (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "ଧଳା ପଏଣ୍ଟର"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "କ୍ଲିକ ସହାୟକ (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "ଦୁଇଥର କ୍ଲିକ (_D):"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "ଦୁଇଥର ଦବାଇବାର ସମୟ ସମାପ୍ତି"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "ଚାକ୍ଷୁଷ ସତର୍କତା"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "ଫ୍ଲାସ ପରୀକ୍ଷା କରନ୍ତୁ (_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ସତର୍କ ଧ୍ୱନୀ ହେଲେ ଦୃଶ୍ୟମାନ ସୂଚନା ବ୍ୟବହାର କରନ୍ତୁ।"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "ସମଗ୍ର ପରଦାକୁ ଫ୍ଲାଶ କରନ୍ତୁ (_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "ସମଗ୍ର ପରଦାକୁ ଫ୍ଲାଶ କରନ୍ତୁ (_s)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "ସଂପୂର୍ଣ୍ଣ ପରଦା"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "ଉପର ଅଧା"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "ତଳ ଅଧା"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "ବାମ ପାଖ ଅଧା"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "ଡାହାଣ ପାଖ ଅଧା"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "ଛୋଟବଡ଼ ବିକଳ୍ପଗୁଡିକ"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "ସାନବଡ କରନ୍ତୁ"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "ଆବର୍ଦ୍ଧନ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "ମାଉସ ସୂଚକକୁ ଅନୁସରଣ କରନ୍ତୁ"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "ପରଦା ଅଂଶ:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "ଆବର୍ଦ୍ଧକ ପରଦା ବାହାରେ ଅନୁଲମ୍ବିତ ହୋଇଥାଏ"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ କେନ୍ଦ୍ରିତ କରନ୍ତୁ"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ ବିଷୟବସ୍ତୁକୁ ଚାରିପଟକୁ ପଠାଇଥାଏ"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ ବିଷଯବସ୍ତୁ ସହିତ ଚାଲିଥାଏ"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "ଆବର୍ଦ୍ଧକ ଅବସ୍ଥାନ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "ମାଉସ ସୂଚକକୁ ଅନୁସରଣ କରନ୍ତୁ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "ପରଦା ଅଂଶ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "ଆବର୍ଦ୍ଧକ ପରଦା ବାହାରେ ଅନୁଲମ୍ବିତ ହୋଇଥାଏ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ କେନ୍ଦ୍ରିତ କରନ୍ତୁ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ ବିଷୟବସ୍ତୁକୁ ଚାରିପଟକୁ ପଠାଇଥାଏ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ ବିଷଯବସ୍ତୁ ସହିତ ଚାଲିଥାଏ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "ଆବର୍ଦ୍ଧକ"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "କ୍ରସହେୟର:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "ମାଉସ ସୂଚକକୁ ଆବୃତ କରିଥାଏ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "ମୋଟେଇ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "ପତଳା"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "ମୋଟା"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "ଲମ୍ବ:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "ରଙ୍ଗ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "କ୍ରସହେୟର:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "ମାଉସ ସୂଚକକୁ ଆବୃତ କରିଥାଏ"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "କ୍ରସହେୟର"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "ରଙ୍ଗ ପ୍ରଭାବଗୁଡ଼ିକ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "କଳାରେ ଧଳା:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "ଉଜ୍ଜ୍ବଳତା:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "ସ୍ପଷ୍ଟତା:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "ରଙ୍ଗ"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "କିଛି ନାହିଁ"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "ପୂର୍ଣ୍ଣ"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "ନିମ୍ନ"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "ଉଚ୍ଚ"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "ନିମ୍ନ"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "ଉଚ୍ଚ"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "ରଙ୍ଗ ପ୍ରଭାବଗୁଡ଼ିକ:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "ରଙ୍ଗ ପ୍ରଭାବଗୁଡ଼ିକ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "ମାନକ"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "ଏହାକୁ ଦେଖିବା, ଶୁଣିବା, ଲେଖିବା, ଦର୍ଶାଇବା ଏବଂ କ୍ଲିକ କରିବା ପାଇଁ ସହଜମୟ କରନ୍ତୁ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "ପ୍ରଶାସକ"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-#| msgid "_Full name"
-msgid "_Full Name"
-msgstr "ପୂରା ନାମ (_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "ଖାତା ପ୍ରକାର (_T)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-#| msgid "Choose password at next login"
-msgid "Allow user to set a password when they next login"
-msgstr "ପରବର୍ତ୍ତୀ ଲଗଇନରେ ଏକ ପ୍ରବେଶ ସଂକେତ ସେଟ କରିବା ପାଇଁ ଅନୁମତି ଦିଅନ୍ତୁ"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "ବର୍ତ୍ତମାନ ଗୋଟିଏ ପ୍ରବେଶ ସଙ୍କେତ ସେଟ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "ଯାଞ୍ଚ କରନ୍ତୁ (_V)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"ବାଣିଜ୍ୟିକ ଲଗଇନ ସ୍ଥିତବାନ କେନ୍ଦ୍ରିୟ ପରିଚାଳିତ ବ୍ୟବହାରକାରୀ ଖାତାକୁ ଏହି ଉପକରଣରେ "
-"ବ୍ୟବହାର କରିବା ପାଇଁ ଅନୁମତି ଦେଇଥାଏ।"
+"କିବୋର୍ଡ;ମାଉସ;a11y;ପ୍ରବେଶାନୁମତି;ବିଭେଦନ;ସାନ ବଡ଼;ପରଦା ପାଠକ;ପରୀକ୍ଷା;ଅକ୍ଷରରୂପ;ଆକାର;ଅଭିଗମ୍ୟX;"
+"ଷ୍ଟିକି; କି;ମନ୍ଥର;ବାଉନ୍ସ;ମାଉସ;"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "ଡମେନ (_D)"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ପୁରୁଣା ତଥ୍ଯ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"ବାଣିଜ୍ୟିକ ଲଗଇନ ଖାତାଗୁଡ଼ିକୁ ଯୋଡ଼ିବା ପାଇଁ\n"
-"ଅନଲାଇନ୍‌ ହୁଅନ୍ତୁ।"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "ଆନୁଷ୍ଠାନିକ ଲଗଇନ (_E)"
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "ପୁରୁଣା ତଥ୍ଯ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "ସାମ୍ପ୍ରତିକ ପୁରୁଣା ତଥ୍ୟକୁ ସଫା କରନ୍ତୁ (_e)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "ଆବର୍ଜନା ଏବଂଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ପରିଷ୍କାର କରନ୍ତୁ"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଆବର୍ଜନା ପାତ୍ରକୁ ଖାଲି କରନ୍ତୁ (_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ଖାଲି କରନ୍ତୁ (_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଆବର୍ଜନା ପାତ୍ରକୁ ଖାଲି କରନ୍ତୁ (_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "ଆବର୍ଜନା ପାତ୍ରକୁ ଖାଲି କରନ୍ତୁ (_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "ଫାଇଲଗୁଡିକୁ ରଖନ୍ତୁ (_P)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "ବର୍ଜିତକୁ ପଠାନ୍ତୁ"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "ଚାଳକ ଯୋଗକରନ୍ତୁ"
 
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "ପ୍ରଶାସକ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "ପରବର୍ତ୍ତୀ ଲଗଇନରେ ଏକ ପ୍ରବେଶ ସଂକେତ ସେଟ କରିବା ପାଇଁ ଅନୁମତି ଦିଅନ୍ତୁ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "ବର୍ତ୍ତମାନ ଗୋଟିଏ ପ୍ରବେଶ ସଙ୍କେତ ସେଟ କରନ୍ତୁ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "ବିନ୍ୟାସ  କରୁଅଛି"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "ଆନୁଷ୍ଠାନିକ ଲଗଇନ (_E)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "ଅଫଲାଇନ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"ବାଣିଜ୍ୟିକ ଲଗଇନ ସ୍ଥିତବାନ କେନ୍ଦ୍ରିୟ ପରିଚାଳିତ ବ୍ୟବହାରକାରୀ ଖାତାକୁ ଏହି ଉପକରଣରେ ବ୍ୟବହାର କରିବା ପାଇଁ "
+"ଅନୁମତି ଦେଇଥାଏ।"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PPD ଫାଇଲ ବାଛନ୍ତୁ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "ନାହିଁ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"ଆପଣଙ୍କର ପଞ୍ଜିକୃତ ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଅପସାରଣ କରିବାକୁ ଚାହୁଁଛନ୍ତି କି ଯାହାଫଳରେ ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ ନିଷ୍କ୍ରିୟ "
+"ହୋଇଥାଏ?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "କୌଣସି ମୁଦ୍ରଣୀ ଚିହ୍ନା ହୋଇନାହିଁ।"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "ବିନ୍ୟାସ କରିବା ପାଇଁ ଗୋଟିଏ ଉପକରଣ ବାଛନ୍ତୁ (_h):"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଅପସାରଣ କରନ୍ତୁ (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ (_F)"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "ପୂର୍ବବର୍ତ୍ତୀ ସପ୍ତାହ"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "ପରବର୍ତ୍ତୀ ସପ୍ତାହ"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "ପ୍ରବେଶ ସଂକେତ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "ପରିବର୍ତ୍ତନ କରନ୍ତୁ (_a)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "ପ୍ରଚଳିତ ପ୍ରବେଶ ସଙ୍କେତ (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତ (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "ପ୍ରବେଶ ସଙ୍କେତ ନିଶ୍ଚିତ କରନ୍ତୁ (_o)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "ପ୍ରବେଶ ସଙ୍କେତଗୁଡ଼ିକ ମିଶୁ ନାହିଁ।"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "ପରବର୍ତ୍ତୀ ଲଗଇନରେ ଏକ ପ୍ରବେଶ ସଂକେତ ସେଟ କରିବା ପାଇଁ ଅନୁମତି ଦିଅନ୍ତୁ"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "ବର୍ତ୍ତମାନ ଗୋଟିଏ ପ୍ରବେଶ ସଙ୍କେତ ସେଟ କରନ୍ତୁ"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "ଚାଳକ"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "ପରିବର୍ତ୍ତନଗୁଡ଼ିକୁ କାର୍ଯ୍ୟକାରୀ କରିବା ପାଇଁ ଆପଣଙ୍କର ଅଧିବେଶନକୁ ପୁନଃଚାଳନ କରିବା ଆବଶ୍ୟକ"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "ବର୍ତ୍ତମାନ ପୁନଃଚାଳନ କରନ୍ତୁ"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "ବନ୍ଦକରନ୍ତୁ"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "ପୂରା ନାମ (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଲଗଇନ (_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "ଖାତା ପ୍ରକାର (_t)"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "ପ୍ରଶାସକ"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "ନିୟନ୍ତ୍ରଣ"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "ଚାଳକ ଖାତା ବାହାର କରନ୍ତୁ"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "ଅନ୍ୟାନ୍ୟ ଅଙ୍ଗୁଳି (_O):"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "ଚାଳକ ଯୋଗକରନ୍ତୁ"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "କୌଣସି ଛବି ମିଳିଲା ନାହିଁ"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "ଚାଳକ ଖାତା ସୃଷ୍ଟି କରନ୍ତୁ"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "ଚାଳକମାନଙ୍କୁ ଯୋଗ କିମ୍ବା ଅପସାରଣ କରନ୍ତୁ ଏବଂ ଆପଣଙ୍କର ପ୍ରବେଶ ସଂକେତ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "ନାମଙ୍କନ କରନ୍ତୁ (_E)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "ଡମେନ ପ୍ରଶାସକ ଲଗଇନ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here."
 msgstr ""
 "ବାଣିଜ୍ୟିକ ଲଗଇନ ବ୍ୟବହାର କରିବା ପାଇଁ, ଏହି କମ୍ପୁଟରକୁ ଡମେନରେ\n"
-"ଅନ୍ତର୍ଭୁକ୍ତ କରିବା ଆବଶ୍ୟକ। ଦୟାକରି ଆପଣଙ୍କର ନେଟୱର୍କ ପ୍ରଶାସକଙ୍କୁ ସେମାନଙ୍କର ଡମେନ "
-"ପ୍ରବେଶ "
+"ଅନ୍ତର୍ଭୁକ୍ତ କରିବା ଆବଶ୍ୟକ। ଦୟାକରି ଆପଣଙ୍କର ନେଟୱର୍କ ପ୍ରଶାସକଙ୍କୁ ସେମାନଙ୍କର ଡମେନ ପ୍ରବେଶ "
 "ସଂକେତକୁ \n"
 "ଏଠାରେ ଭରଣ କରିବା ଆବଶ୍ୟକ।"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "ପ୍ରଶାସକ ନାମ (_N)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "ପ୍ରଶାସକ ପ୍ରବେଶ ସଂକେତ"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "ବାମ ଆଙ୍ଗୁଠି"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "ବାମ ତର୍ଜନି"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "ବାମ ଅନାମିକା ଅଙ୍ଗୁଳି"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "ବାମ ତର୍ଜନି"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "ଡାହାଣ ଆଙ୍ଗୁଠି"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "ଡାହାଣ ମଝି ଅଙ୍ଗୁଳି"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "ଡାହାଣ ଅନାମିକା ଅଙ୍ଗୁଳି"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "ଡାହାଣ କାନି ଅଙ୍ଗୁଳି"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:697
-msgid "Enable Fingerprint Login"
-msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନକୁ ସକ୍ରିୟ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "ଡାହାଣ ତର୍ଜନି (_R)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "ବାମ ତର୍ଜନି (_L)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "ଅନ୍ୟାନ୍ୟ ଅଙ୍ଗୁଳି (_O):"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"ଆପଣଙ୍କର ଅଙ୍ଗୁଳି ଚିହ୍ନଟି ସଫଳତାର ସହିତ ସଂରକ୍ଷଣ ହୋଇଛି। ଆପଣଙ୍କୁ ବର୍ତ୍ତମାନ ଆପଣଙ୍କର "
-"ଅଙ୍ଗୁଳି ଚିହ୍ନ ପାଠକ "
-"ବ୍ୟବହାର କରି ଲଗଇନ କରିବାକୁ ହେବ।"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "ଚାଳକ"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr ""
-"ଚାଳକମାନଙ୍କୁ ଯୋଗ କିମ୍ବା ଅପସାରଣ କରନ୍ତୁ ଏବଂ ଆପଣଙ୍କର ପ୍ରବେଶ ସଂକେତ ପରିବର୍ତ୍ତନ "
-"କରନ୍ତୁ"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "ଲଗଇନ;ନାମ;ଅଙ୍ଗୁଳି ଚିହ୍ନ;ଅଭତାର;ପ୍ରତୀକ;ମୁହଁ;ପ୍ରବେଶ ସଂକେତ;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "ଲଗଇନ ପୁରୁଣା ତଥ୍ଯ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-#| msgid "Change pa_ssword"
-msgid "Change Password"
-msgstr "ପ୍ରବେଶ ସଂକେତ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "ପରିବର୍ତ୍ତନ କରନ୍ତୁ (_a)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-#| msgid "_New password"
-msgid "_Verify New Password"
-msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତକୁ ଯାଞ୍ଚ କରନ୍ତୁ (_V)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-#| msgid "_New password"
-msgid "_New Password"
-msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତ (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-#| msgid "Current _password"
-msgid "Current _Password"
-msgstr "ପ୍ରଚଳିତ ପ୍ରବେଶ ସଙ୍କେତ (_P)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "ଚାଳକ ଖାତା ଯୋଗ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "ଚାଳକ ଖାତା ବାହାର କରନ୍ତୁ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "ଲଗଇନ ବିକଳ୍ପଗୁଡିକ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "ସ୍ୱୟଂଚାଳିତ ଲଗଇନ (_u)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ (_F)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "ଚାଳକ ଚିତ୍ର ସଂକେତ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "ଭାଷା (_L)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "ଅନ୍ତିମ ଲଗଇନ"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "ବ୍ୟବହାରକାରୀ ଖାତାଗୁଡ଼ିକୁ ପରିଚାଳନା କରନ୍ତୁ"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "ବ୍ୟବହାରକାରୀ ତଥ୍ୟ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ବୈଧିକରଣ ଆବଶ୍ଯକ"
 
-#: ../panels/user-accounts/pw-utils.c:81
-#| msgid "The new password does not contain enough different characters"
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ପୁରୁଣା ଠାରୁ ଭିନ୍ନ ହୋଇଥିବା ଆବଶ୍ୟକ।"
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "କିଛି ଅକ୍ଷର ଏବଂ ସଂଖ୍ୟାଗୁଡ଼ିକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-#| msgid "Changing password for"
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "ପ୍ରବେଶ ସଙ୍କେତକୁ ଟିକିଏ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "ବିନା ବ୍ୟବହାରକାରୀ ନାମରେ ପ୍ରବେଶ ସଂକେତଟି ଅଧିକ ଶକ୍ତିଶାଳୀ ହେବ।"
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "ପ୍ରବେଶ ସଂକେତରେ ଆପଣଙ୍କର ନାମ ବ୍ୟବହାରକୁ ଏଡ଼ାନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "ପ୍ରବେଶ ସଂକେତରେ ଅନ୍ତର୍ଭୁକ୍ତ କିଛି ଶବ୍ଦକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "ସାଧାରଣ ଶବ୍ଦଗୁଡ଼ିକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "ସ୍ଥିତବାନ ଶବ୍ଦଗୁଡ଼ିକର କ୍ରମ ପରିବର୍ତ୍ତନକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "ଅଧିକ ସଂଖ୍ୟା ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "ଅଧିକ ବଡ଼ ଅକ୍ଷର ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "ଅଧିକ ଛୋଟ ଅକ୍ଷର ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-"ଅଧିକ ବିଶେଷ ଅକ୍ଷରଗୁଡ଼ିକୁ ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ, ଯେପରିକି ବିରାମ ଚିହ୍ନ।"
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-"ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ ବିରାମ ଚିହ୍ନଗୁଡ଼ିକର ମିଶ୍ରଣକୁ ବ୍ୟବହାର କରିବା ପାଇଁ ଚେଷ୍ଟା "
-"କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "ସମାନ ଅକ୍ଷରର ବାରମ୍ବାର ବ୍ୟବହାରକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"ସମାନ ପ୍ରକାରର ଅକ୍ଷରର ବାରମ୍ବାର ବ୍ୟବହାରକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ:ଆପଣଙ୍କୁ ଅକ୍ଷର, "
-"ସଂଖ୍ୟା ଏବଂ ବିରାମ ଚିହ୍ନଗୁଡ଼ିକୁ ମିଶ୍ରଣ କରିବା ଆବଶ୍ୟକ।"
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 କିମ୍ବା abcd ପରି କ୍ରମକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "ଅଧିକ ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ ସଂକେତଗୁଡ଼ିକୁ ଯୋଡ଼ିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr ""
-"ବଡ଼ ଅକ୍ଷର ଏବଂ ଛୋଟ ଅକ୍ଷର ଏବଂ ଗୋଟିଏ କିମ୍ବା ଦୁଇଟି ସଂଖ୍ୟାକୁ ମିଶ୍ରଣ କରିବାକୁ ଚେଷ୍ଟା "
-"କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-"ଭଲ ପ୍ରବେଶ ସଂକେତ! ଅଧିକ ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ ବିରାମ ଚିହ୍ନକୁ ଯୋଡ଼ିବା ଫଳରେ ଏହା ଅଧିକ "
-"ଶକ୍ତିଶାଳୀ ହେବ।"
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "ଶକ୍ତି: ଦୁର୍ବଳ"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-#| msgid "Length:"
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "ଲମ୍ବ: କମ୍"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "ଶକ୍ତି: ମଧ୍ଯମ"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "ଶକ୍ତି: ଉତ୍ତମ"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "ଶକ୍ତି:ଅତି ଉତ୍ତମ"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "ବୈଧିକରଣ ବିଫଳ"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ଅତି ଛୋଟ ଅଟେ"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ଅତି ସହଜ ଅଟେ"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "ପୁରୁଣା ଏବଂ ନୂଆ ପ୍ରବେଶ ସଙ୍କେତ ମଧ୍ଯରେ ବହୁତ ସାମଞ୍ଜସ୍ଯ ଅଛି"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତକୁ ନିକଟରେ ବ୍ୟବହାର କରାଯାଇଛି।"
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr ""
-"ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ସଂଖ୍ୟାତ୍ମକ କିମ୍ବା ବିଶେଷ ଅକ୍ଷର ମାନଙ୍କୁ ଧାରଣ କରିବା ଉଚିତ"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "ପୁରୁଣା ଏବଂ ନୂତନ ପ୍ରବେଶ ସଙ୍କେତ ଏକାପ୍ରକାରର ଅଟନ୍ତି"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "ଆପଣ ପ୍ରାରମ୍ଭରେ ପ୍ରମାଣ କରିଥିବା ପ୍ରବେଶ ସଂକେତ ପରିବର୍ତ୍ତିତ ହୋଇଛି!"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତରେ ଯଥେଷ୍ଟ ଭିନ୍ନ ବର୍ଣ୍ଣ ନାହିଁ"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "ଅଜଣା ତ୍ରୁଟି"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "ଆପଣଙ୍କର ଖାତା ପ୍ରଦାତାଙ୍କ ୱେବ ଠିକଣା ସହିତ ମେଳ ଖାଉଥିବା ଉଚିତ।"
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "ଖାତା ଯୋଗ କରିବାରେ ବିଫଳ"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-#| msgid "Passwords do not match"
-msgid "Passwords do not match."
-msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦ୍ବୟ ମିଶୁ ନାହିଁ।"
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr "ଖାତା ପଞ୍ଜିକରଣ କରିବାରେ ବିଫଳ"
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr "ଏହି ଡମେନ ସହିତ ବୈଧିକୃତ କରିବା ପାଇଁ ସହାୟତା ପ୍ରାପ୍ତ ନୁହଁ"
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr "ଡମେନରେ ଯୋଗ ହେବାରେ ବିଫଳ"
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"ସେହି ଲଗଇନ ନାମଟି କାମ କରୁ ନାହିଁ।\n"
-"ଦୟାକରି ପୁଣିଥରେ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-#| msgid "Invalid password, please try again"
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"ସେହି ଲଗଇନ ପ୍ରବେଶ ସଂକେତଟି କାମ କରୁ ନାହିଁ।\n"
-"ଦୟାକରି ପୁଣିଥରେ ଚେଷ୍ଟା କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr "ଡମେନରେ ଲଗଇନ୍‌ ହେବାରେ ବିଫଳ"
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "ଡମେନକୁ ପାଇବାରେ ଅସମର୍ଥ। ହୁଏତ ଏଥିରେ ବନାନ ଭୁଲ ଥାଇପାରେ?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:137
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"ଆପଣ ଏହି ଉପକରଣକୁ ଅଭିଗମ୍ୟ କରିବା ପାଇଁ ଅନୁମୋଦିତ ନୁହଁ। ଆପଣଙ୍କର ତନ୍ତ୍ର ପ୍ରଶାସକଙ୍କ "
-"ସହିତ ଯୋଗାଯୋଗ "
-"କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
-msgid "The device is already in use."
-msgstr "ଉପକରଣଟି ପୂର୍ବରୁ ବ୍ୟବହାରରେ ଅଛି।"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "An internal error occurred."
-msgstr "ଗୋଟେଏ ଅନ୍ତବର୍ତ୍ତୀ ତୃଟି ଘଟିଲା"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:217
-#: ../panels/user-accounts/um-fingerprint-dialog.c:218
-msgid "Enabled"
-msgstr "ସକ୍ରିୟ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:266
-msgid "Delete registered fingerprints?"
-msgstr "ପଞ୍ଜିକୃତ ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଅପସାରଣ କରିବେ କି?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:270
-msgid "_Delete Fingerprints"
-msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଅପସାରଣ କରନ୍ତୁ (_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:276
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"ଆପଣଙ୍କର ପଞ୍ଜିକୃତ ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଅପସାରଣ କରିବାକୁ ଚାହୁଁଛନ୍ତି କି ଯାହାଫଳରେ "
-"ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ ନିଷ୍କ୍ରିୟ "
-"ହୋଇଥାଏ?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:452
-msgid "Done!"
-msgstr "ସମାପ୍ତ!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:513
-#: ../panels/user-accounts/um-fingerprint-dialog.c:555
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' ଉପକରଣକୁ ଅଭିଗମ୍ୟ କରିପାରିଲା ନାହିଁ"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:596
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "'%s' ଉପକରଣରେ ଅଙ୍ଗୁଳି ଧାରଣକୁ ଆରମ୍ଭ କରିପାରିଲା ନାହିଁ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:647
-msgid "Could not access any fingerprint readers"
-msgstr "କୌଣସି ଅଙ୍ଗୁଳି ଚିହ୍ନ ପାଠକଙ୍କୁ ଅଭିଗମ୍ୟ କରିପାରିଲା ନାହିଁ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:648
-msgid "Please contact your system administrator for help."
-msgstr "ସହାୟତା ପାଇଁ ଆପଣଙ୍କ ତନ୍ତ୍ର ପ୍ରଶାସକଙ୍କ ସହିତ ଯୋଗାଯୋଗ କରନ୍ତୁ।"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:731
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନକୁ ସକ୍ରିୟ କରିବା ପାଇଁ, ଆପଣଙ୍କୁ '%s' ଉପକରଣ ବ୍ୟବହାର କରି "
-"ଆପଣଙ୍କର ଗୋଟିଏ ଅଙ୍ଗୁଳି "
-"ଚିହ୍ନକୁ ସଂରକ୍ଷଣ କରିବା ଆବଶ୍ୟକ।"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:738
-msgid "Selecting finger"
-msgstr "ଅଙ୍ଗୁଳି ଚୟନ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:739
-msgid "Enrolling fingerprints"
-msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଲିପିବଦ୍ଧ କରୁଛି"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "ଏହି ସପ୍ତାହ"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "ଗତ ସପ୍ତାହ"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-#| msgid "%b %d %Y"
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-#| msgid "%b %d %Y"
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:631
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:635
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "ଅଧିବେଶନ ସମାପ୍ତ"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "ଅଧିବେଶନ ଆରମ୍ଭ ହୋଇଛି"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "ଦୟାକରି ଅନ୍ୟଏକ ପ୍ରବେଶ ସଂକେତ ବାଛନ୍ତୁ।"
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "ଦୟାକରି ଆପଣଙ୍କ ପ୍ରବେଶ ସଙ୍କେତକୁ ପୁଣିଥରେ ଟାଇପ କରନ୍ତୁ।"
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "ପ୍ରବେଶ ସଙ୍କେତକୁ ବଦଳାଇ ହେଲା ନାହିଁ"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-#| msgid "The passwords do not match"
-msgid "The passwords do not match."
-msgstr "ପ୍ରବେଶ ସଙ୍କେତଗୁଡ଼ିକ ମିଶୁ ନାହିଁ।"
-
-#: ../panels/user-accounts/um-photo-dialog.c:219
-msgid "Browse for more pictures"
-msgstr "ଅଧିକ ଛବି ପାଇଁ ବ୍ରାଉଜ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/um-photo-dialog.c:453
-msgid "Disable image"
-msgstr "ପ୍ରତିଛବିକୁ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/um-photo-dialog.c:471
-msgid "Take a photo…"
-msgstr "ଗୋଟିଏ ଫଟୋ ନିଅନ୍ତୁ…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:489
-msgid "Browse for more pictures…"
-msgstr "ଅଧିକ ଛବିଗୁଡ଼ିକ ପାଇଁ ବ୍ରାଉଜ କରନ୍ତୁ…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:713
-#, c-format
-msgid "Used by %s"
-msgstr "%s ଦ୍ୱାରା ବ୍ୟବହୃତ"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଏହି ପ୍ରକାରର ଡମେନ ସହିତ ସଂଯୋଗ କରିପାରିବେ ନାହିଁ"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "ଏପରି କୌଣସି ଡମେନ କିମ୍ବା realm ମିଳି ନାହିଁ"
-
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s ଭାବରେ %s ଡମେନରେ ଲଗଇନ କରିପାରିବେ ନାହିଁ"
-
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
-msgstr "ଅବୈଧ ପ୍ରବେଶ ସଂକେତ, ଦୟାକରି ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ"
-
-#: ../panels/user-accounts/um-realm-manager.c:832
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "%s ଡମେନ ସହିତ ସଂଯୁକ୍ତ ହୋଇପାରିଲା ନାହିଁ: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:198
-msgid "Other Accounts"
-msgstr "ଅନ୍ୟ ଖାତାଗୁଡ଼ିକ"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "Failed to delete user"
-msgstr "ଚାଳକକୁ ଅପସାରଣ କରିବାରେ ବିଫଳ"
-
-#: ../panels/user-accounts/um-user-panel.c:482
-msgid "You cannot delete your own account."
-msgstr "ଆପଣ ନିଜର ଖାତାକୁ ଅପସାରଣ କରିପାରିବେ ନାହିଁ।"
-
-#: ../panels/user-accounts/um-user-panel.c:491
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s ଏପର୍ଯ୍ୟନ୍ତ ଲଗଇନ ଅଛି"
-
-#: ../panels/user-accounts/um-user-panel.c:495
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"ଲଗଇନ ହେବା ପରେ ଏକ ବ୍ୟବହାରକାରୀଙ୍କୁ ଅପସାରଣ କରି ତନ୍ତ୍ରକୁ ଅସ୍ଥାୟୀ ସ୍ଥିତିରେ "
-"ଛାଡ଼ିଥାଏ।"
-
-#: ../panels/user-accounts/um-user-panel.c:504
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "ଆପଣ %s ର ଫାଇଲଗୁଡ଼ିକୁ ରଖିବାକୁ ଚାହୁଁଛନ୍ତି କି?"
-
-#: ../panels/user-accounts/um-user-panel.c:508
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"ବ୍ୟବହାରକାରୀ ଖାତାକୁ ଅପସାରଣ କରିବା ସମୟରେ ହୋମ ଡିରେକ୍ଟୋରୀ, ମେଲ ସ୍ପୁଲ ଏବଂ ଅସ୍ଥାୟୀ "
-"ଫାଇଲଗୁଡ଼ିକୁ "
-"ରଖିବା ସମ୍ଭବ ଅଟେ।"
-
-#: ../panels/user-accounts/um-user-panel.c:511
-msgid "_Delete Files"
-msgstr "ଫାଇଲଗୁଡିକୁ ଅପସାରଣ କରନ୍ତୁ (_D)"
-
-#: ../panels/user-accounts/um-user-panel.c:512
-msgid "_Keep Files"
-msgstr "ଫାଇଲଗୁଡିକୁ ରଖନ୍ତୁ (_K)"
-
-#: ../panels/user-accounts/um-user-panel.c:564
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "ଖାତା ନିଷ୍କ୍ରିୟ ଅଛି"
-
-#: ../panels/user-accounts/um-user-panel.c:572
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "ପରବର୍ତ୍ତୀ ଲଗଇନରେ ସେଟ କରାଯିବ"
-
-#: ../panels/user-accounts/um-user-panel.c:575
-msgctxt "Password mode"
-msgid "None"
-msgstr "କିଛି ନାହିଁ"
-
-#: ../panels/user-accounts/um-user-panel.c:624
-msgid "Logged in"
-msgstr "ଲଗଇନ ହୋଇଛି"
-
-#: ../panels/user-accounts/um-user-panel.c:1072
-msgid "Failed to contact the accounts service"
-msgstr "ଖାତାର ସର୍ଭିସକୁ ଯୋଗାଯୋଗ କରିବାରେ ବିଫଳ"
-
-#: ../panels/user-accounts/um-user-panel.c:1074
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "ଦୟାକରି ନିଶ୍ଚିତ କରନ୍ତୁ ଯେ ଖାତା ସର୍ଭିସଟି ସ୍ଥାପିତ ହୋଇଛି ଏବଂ ସକ୍ରିୟ ଅଛି।"
-
-#: ../panels/user-accounts/um-user-panel.c:1115
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ,\n"
-"* ଚିତ୍ର ସଂକେତକୁ ପ୍ରଥମେ କ୍ଲିକ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/um-user-panel.c:1153
-msgid "Create a user account"
-msgstr "ଚାଳକ ଖାତା ସୃଷ୍ଟି କରନ୍ତୁ"
-
-#: ../panels/user-accounts/um-user-panel.c:1164
-#: ../panels/user-accounts/um-user-panel.c:1453
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"ଚାଳକ ଖାତା ସୃଷ୍ଟି କରିବା ପାଇଁ,\n"
-"* ଚିତ୍ର ସଂକେତକୁ ପ୍ରଥମେ କ୍ଲିକ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/um-user-panel.c:1174
-msgid "Delete the selected user account"
-msgstr "ବଚ୍ଛିତ ଚାଳକ ଖାତାକୁ ଅପସାରଣ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/um-user-panel.c:1186
-#: ../panels/user-accounts/um-user-panel.c:1458
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"ବଚ୍ଛିତ ଚାଳକ ଖାତାକୁ ଅପସାରଣ କରିବା ପାଇଁ,\n"
-"* ଚିତ୍ର ସଂକେତକୁ ପ୍ରଥମେ କ୍ଲିକ କରନ୍ତୁ"
-
-#: ../panels/user-accounts/um-user-panel.c:1368
-msgid "My Account"
-msgstr "ମୋର ଖାତା"
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-#| msgid "A user with the username '%s' already exists"
-msgid "A user with the username '%s' already exists."
-msgstr "'%s' ଦ୍ବାରା ନାମିତ ହୋଇଥିବା ଗୋଟିଏଚାଳକ ନାମ ପୂର୍ବରୁ ରହିଛି।"
-
-#: ../panels/user-accounts/um-utils.c:571
-#, c-format
-#| msgid "The username is too long"
-msgid "The username is too long."
-msgstr "ଚାଳକ ନାମଟି ଅତି ବଡ଼ ଅଟେ।"
-
-#: ../panels/user-accounts/um-utils.c:574
-#| msgid "The username cannot start with a '-'"
-msgid "The username cannot start with a '-'."
-msgstr "ଚାଳକ ନାମ '-' ଦ୍ୱାରା ଆରମ୍ଭ ହୋଇପାରିବ ନାହିଁ।"
-
-#: ../panels/user-accounts/um-utils.c:577
-#| msgid ""
-#| "The username must only consist of:\n"
-#| " ➣ letters from the English alphabet\n"
-#| " ➣ digits\n"
-#| " ➣ any of the characters '.', '-' and '_'"
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"ବ୍ୟବହାରକାରୀ ନାମରେ କେବଳ a-z ପର୍ଯ୍ୟନ୍ତ ଛୋଟ ଏବଂ ବଡ଼ ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ  '.', '-' "
-"ଏବଂ '_' ମଧ୍ଯରୁ ଯେକୌଣସି ବର୍ଣ୍ଣ ରହିବା ଉଚିତ।"
-
-#: ../panels/user-accounts/um-utils.c:581
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-"ଏହା ଆପଣଙ୍କର ମୂଖ୍ୟ ଫୋଲଡର୍‌କୁ ନାମକରଣ କରିବା ପାଇଁ ବ୍ୟବହାର କରାଯିବ ଏବଂ ତାହାକୁ "
-"ପରିବର୍ତ୍ତନ କରିହେବ ନାହିଁ।"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:827
-#| msgid "%b %d %Y"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:831
-#| msgid "%b %d %Y"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "ବଟନଗୁଡ଼ିକୁ ମେଳାନ୍ତୁ"
 
-#: ../panels/wacom/button-mapping.ui.h:2
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "କାମ କରିବା ପାଇଁ ବଟନଗୁଡ଼ିକୁ ମେଳାନ୍ତୁ"
 
-#: ../panels/wacom/button-mapping.ui.h:3
-#| msgid ""
-#| "To edit a shortcut, click the row and hold down the new keys or press "
-#| "Backspace to clear."
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"ଗୋଟିଏ ସକ୍ଷିପ୍ତ ପଥକୁ ସମ୍ପାଦନ କରିବା ପାଇଁ, \"କିଷ୍ଟ୍ରୋକ୍‌ ପଠାନ୍ତୁ\" କାର୍ଯ୍ୟକୁ "
-"ବାଛନ୍ତୁ,କିବୋର୍ଡ ସଂକ୍ଷିପ୍ତ ପଥ ବଟନକୁ ଦବାନ୍ତୁ ଏବଂ  ନୂତନ କି ଗୁଡ଼ିକୁ ଧରି ରଖନ୍ତୁ "
-"ଅଥବା  ସଫାକରିବା ପାଇଁ Backspace ଉପରେ ଦବାନ୍ତୁ।"
+"ଗୋଟିଏ ସକ୍ଷିପ୍ତ ପଥକୁ ସମ୍ପାଦନ କରିବା ପାଇଁ, \"କିଷ୍ଟ୍ରୋକ୍‌ ପଠାନ୍ତୁ\" କାର୍ଯ୍ୟକୁ ବାଛନ୍ତୁ,କିବୋର୍ଡ ସଂକ୍ଷିପ୍ତ "
+"ପଥ ବଟନକୁ ଦବାନ୍ତୁ ଏବଂ  ନୂତନ କି ଗୁଡ଼ିକୁ ଧରି ରଖନ୍ତୁ ଅଥବା  ସଫାକରିବା ପାଇଁ Backspace ଉପରେ ଦବାନ୍ତୁ।"
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "ବନ୍ଦ କରନ୍ତୁ (_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
-"ଲକ୍ଷ୍ଯସ୍ଥଳ ଚିହ୍ନଟଗୁଡ଼ିକୁ ପରଦାରେ ଦୃଶ୍ୟମାନ ହେବା ମାତ୍ରେ ଟ୍ୟାବଲେଟକୁ ମାପିବା ପାଇଁ  "
-"ଲିପିବଦ୍ଧ କରନ୍ତୁ।"
+"ଲକ୍ଷ୍ଯସ୍ଥଳ ଚିହ୍ନଟଗୁଡ଼ିକୁ ପରଦାରେ ଦୃଶ୍ୟମାନ ହେବା ମାତ୍ରେ ଟ୍ୟାବଲେଟକୁ ମାପିବା ପାଇଁ  ଲିପିବଦ୍ଧ କରନ୍ତୁ।"
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "ଭୁଲ ବଶତଃ ହୋଇଥିବା କ୍ଲିକ ଚିହ୍ନା ହୋଇଛି, ପୁନଃଚାଳନ କରୁଅଛି..."
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "ଉପର"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "ଗୋଟିଏ ଆଭାସୀ ଉପକରଣ ନିର୍ମାଣ କରନ୍ତୁ"
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "ତଳ"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "ଟ୍ୟାବଲେଟ"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "କିଛି ନାହିଁ"
-
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "କିଷ୍ଟ୍ରୋକ ପଠାନ୍ତୁ"
-
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "ମନିଟର ବଦଳାନ୍ତୁ"
-
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "ଅନସ୍କ୍ରିନ୍‌ ସହାୟତା ଦେଖାନ୍ତୁ"
-
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "ଫଳାଫଳ:"
-
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "ପରିମାପ ଅନୁପାତକୁ ରଖନ୍ତୁ (ଅକ୍ଷର ବାକ୍ସ):"
-
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "ଗୋଟିଏ ମନିଟରରେ ମେଳାନ୍ତୁ"
-
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d ର %d"
-
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "ମ୍ୟାପିଙ୍ଗକୁ ଦର୍ଶାନ୍ତୁ"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
-msgstr "ବଟନ"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr "ୱାକମ ଟ୍ୟାବଲେଟ"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
-"ଆଲେଖିକ ଟ୍ୟାବଲେଟ ପାଇଁ ବଟନ ମ୍ୟାପିଙ୍ଗକୁ ସେଟ କରନ୍ତୁ ଏବଂ ସମ୍ବେଦନଶୀଳ ଶୈଳୀକୁ "
-"ସଜାଡ଼ନ୍ତୁ"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "ଟେବଲ;ୱାକମ;ଶୈଳୀମୟ;ଲିଭାଳି;ମାଉସ;"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "ବାମ-ହାତ ଆବର୍ତ୍ତନ"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "ଟ୍ୟାବଲେଟ (ସମ୍ପୂର୍ଣ୍ଣ)"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "ଟଚପ୍ୟାଡ (ପାରସ୍ପରିକ)"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "ମନିଟର ସହିତ ମେଳାନ୍ତୁ…"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "ଟ୍ୟାବଲେଟ ପସନ୍ଦଗୁଡ଼ିକ"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "ପରିମାପ ଅନୁପାତ"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "ମାପନ୍ତୁ..."
+
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "କୌଣସି ଟ୍ୟାବଲେଟ ଉପସ୍ଥିତ ନାହିଁ"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "ଦୟାକରି ଆପଣଙ୍କର ୱାକମ ଟ୍ୟାବଲେଟକୁ ପ୍ଲଗଇନ କରନ୍ତୁ କିମ୍ବା ଅନ କରନ୍ତୁ"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr "ବ୍ଲୁଟୁଥ ସଂରଚନା"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Map to Monitor…"
-msgstr "ମନିଟର ସହିତ ମେଳାନ୍ତୁ…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map Buttons…"
-msgstr "ବଟନଗୁଡ଼ିକୁ ମେଳାନ୍ତୁ…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr "ପ୍ରଦର୍ଶନୀ ବିଭେଦନକୁ ସଜାଡ଼ନ୍ତୁ"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust mouse settings"
-msgstr "ମାଉସ ସେଟିଙ୍ଗଗୁଡିକୁ ସଜାଡ଼ନ୍ତୁ"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Tracking Mode"
-msgstr "ଅନୁସନ୍ଧାନ ଧାରା"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Left-Handed Orientation"
-msgstr "ବାମ-ହାତ ଆବର୍ତ୍ତନ"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-msgid "Left Ring"
-msgstr "ବାମ ରିଙ୍ଗ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "ବାମ ରିଙ୍ଗ ଧାରା #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-msgid "Right Ring"
-msgstr "ଡ଼ାହାଣ ରିଙ୍ଗ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1104
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "ଡ଼ାହାଣ ରିଙ୍ଗ ଧାରା #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-msgid "Left Touchstrip"
-msgstr "ବାମ ଟଚଷ୍ଟ୍ରିପ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1157
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "ବାମ ଟଚଷ୍ଟ୍ରିପ ଧାରା #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-msgid "Right Touchstrip"
-msgstr "ଡ଼ାହାଣ ଟଚଷ୍ଟ୍ରିପ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "ଡ଼ାହାଣ ଟଚଷ୍ଟ୍ରିପ ଧାରା #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1214
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "ବାମାବର୍ତ୍ତୀ ଟର୍ଚ ଧାରାକୁ ବଦଳାନ୍ତୁ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1216
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "ଡ଼ାହାଣବର୍ତ୍ତୀ ଟର୍ଚ ଧାରାକୁ ବଦଳାନ୍ତୁ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1219
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "ବାମାବର୍ତ୍ତୀ ଟର୍ଚଷ୍ଟ୍ରିପ ଧାରାକୁ ବଦଳାନ୍ତୁ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1221
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "ଡ଼ାହାଣବର୍ତ୍ତୀ ଟର୍ଚଷ୍ଟ୍ରିପ ଧାରାକୁ ବଦଳାନ୍ତୁ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1226
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "ଧାରା ପରିବର୍ତ୍ତନ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1334
-#, c-format
-msgid "Left Button #%d"
-msgstr "ବାମ ବଟନ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1337
-#, c-format
-msgid "Right Button #%d"
-msgstr "ଡ଼ାହାଣ ବଟନ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1340
-#, c-format
-msgid "Top Button #%d"
-msgstr "ଉପର ବଟନ #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1343
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "ତଳ ବଟମ #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-#| msgid "No shortcut set"
-msgid "New shortcut…"
-msgstr "ନୂତନ ସଂକ୍ଷିପ୍ତ ପଥ…"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "କୌଣସି କାର୍ୟ୍ଯ ନାହିଁ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "ବାମ ମାଉସ ବଟନ କ୍ଲିକ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "ମଝି ବଟନ କ୍ଲିକ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "ଡ଼ାହାଣ ମାଉସ ବଟନ କ୍ଲିକ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "ଉପରକୁ ସ୍କ୍ରୋଲ କରନ୍ତୁ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "ତଳକୁ ସ୍କ୍ରୋଲ  କରନ୍ତୁ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "ବାମକୁ ସ୍କ୍ରୋଲ କରନ୍ତୁ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "ଡ଼ାହାଣକୁ ସ୍କ୍ରୋଲ କରନ୍ତୁ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "ପଛ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "ଆଗକୁ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "ଶୈଳୀ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "ଲିଭାଳି ବକ୍ର ଚାପ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "ନରମ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "ଫର୍ମ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "ଉପର ବଟନ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "ତଳ ବଟନ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "ଉପର ଚାପ ଅନୁଭବ"
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "ଦୃଷ୍ଟ ସୂଚନାଯୁକ୍ତ ଧାରାକୁ ସକ୍ରିୟ କରନ୍ତୁ"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "ନରମ"
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "ସମୀକ୍ଷାକୁ ଦର୍ଶାନ୍ତୁ"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "ଏହି ବାକ୍ୟଖଣ୍ଡକୁ ଖୋଜନ୍ତୁ"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "ସମ୍ଭାବ୍ୟ ପ୍ୟାନେଲ ନାମଗୁଡ଼ିକୁ ତାଲିକାଭୁକ୍ତ କରନ୍ତୁ ଏବଂ ପ୍ରସ୍ଥାନ କରନ୍ତୁ"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "ସାହାଯ୍ଯ ପସନ୍ଦ ଦେଖାନ୍ତୁ"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "ଦର୍ଶାଇବା ପାଇଁ ପ୍ୟାନେଲ"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- ସେଟିଙ୍ଗଗୁଡିକ"
-
-#: ../shell/cc-application.c:163
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-"%s\n"
-"ଉପଲବ୍ଧ ନିର୍ଦ୍ଦେଶନାମା ବିକଳ୍ପଗୁଡ଼ିକର ସମ୍ପୂର୍ଣ୍ଣ ତାଲିକା ଦେଖିବା ପାଇଁ'%s --help' "
-"କୁ ଚଲାନ୍ତୁ.\n"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "ଉପଲବ୍ଧ ପ୍ୟାନେଲଗୁଡ଼ିକ:"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "ଫର୍ମ"
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "ସହାୟତା"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "ବଟନ"
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "ବିଦାୟ ନିଅନ୍ତୁ"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ବଟନ"
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ବଟନ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "ଲିଭାଳି ବକ୍ର ଚାପ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "ଲିଭାଳି ବକ୍ର ଚାପ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "ମଝି ବଟନ କ୍ଲିକ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "ଡ଼ାହାଣ ମାଉସ ବଟନ କ୍ଲିକ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "ଆଗକୁ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "ୱାକମ ଟ୍ୟାବଲେଟ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "ଆଲେଖିକ ଟ୍ୟାବଲେଟ ପାଇଁ ବଟନ ମ୍ୟାପିଙ୍ଗକୁ ସେଟ କରନ୍ତୁ ଏବଂ ସମ୍ବେଦନଶୀଳ ଶୈଳୀକୁ ସଜାଡ଼ନ୍ତୁ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "ଟେବଲ;ୱାକମ;ଶୈଳୀମୟ;ଲିଭାଳି;ମାଉସ;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "ବିନ୍ଯାସ"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "ମୂଳ ୱିଣ୍ଡୋ"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "ଦ୍ୱିତୀୟକ କ୍ଲିକକୁ ଜାଗ୍ରତ କରନ୍ତୁ (_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "ୱିଣ୍ଡୋ"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "ଟୋନର କମ ଅଛି"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "ଦ୍ୱିତୀୟକ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "ୱିଣ୍ଡୋ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "ଅଭିଗମ୍ୟତା ବିକଳ୍ପଗୁଡ଼ିକ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "ଯୋଗ କରନ୍ତୁ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "ସଂରକ୍ଷଣ (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "ବିସ୍ତୃତ ବିବରଣୀ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "ନେଟୱର୍କ ସମୟ (_N)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "ନେଟୱର୍କ ସଂରଚନା"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "ସଂଖ୍ଯାଗୁଡିକ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "ଉପକରଣ ପ୍ରକାରମାନ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "ନିର୍ମାତା"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "ଫର୍ମୱେର ଅନୁପସ୍ଥିତ ଅଛି"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "ମୋବାଇଲ ବ୍ରୋଡ଼ବ୍ୟାଣ୍ଡ (_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "ନେଟୱର୍କ ସମୟ (_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "ନେଟୱର୍କ"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "ଉନ୍ନତ"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "ଅଭିଗମ୍ୟତା ବିକଳ୍ପଗୁଡ଼ିକ"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "ତାଲା ଦେଇ ରଖନ୍ତୁ"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "ବିସ୍ତୃତ ବିବରଣୀ"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "ନେଟୱାର୍କ ନାମ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "ସ୍ବୟଂଚାଳିତ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "ନିଜସ୍ୱ ନେଟୱର୍କ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "ନିଜସ୍ୱ ନେଟୱର୍କ"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "କୌଣସି ବ୍ଲୁଟୁଥ ଏଡପଟର ମିଳିଲା ନାହିଁ"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "ବିମାନ ଧାରା (_p)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "ସଂଯୋଗ"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM କାର୍ଡ ଭର୍ତ୍ତି କରାଯାଇ ନାହିଁ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "ତାଲା ଦେଇ ରଖନ୍ତୁ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "ପରିବର୍ତ୍ତନ କରନ୍ତୁ (_a)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "ନିଜସ୍ୱ ନେଟୱର୍କ"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "ନୂତନ ଡ୍ରାଇଭର ସେଟ କରୁଅଛି …"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "ଗୋପନୀୟତା"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "ସମସ୍ତ ସେଟିଙ୍ଗଗୁଡିକ"
 
-#. Add categories
-#: ../shell/cc-window.c:876
-msgctxt "category"
-msgid "Personal"
-msgstr "ବ୍ଯକ୍ତିଗତ"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "ପ୍ରାଥମିକ"
 
-#: ../shell/cc-window.c:877
-msgctxt "category"
-msgid "Hardware"
-msgstr "ହାର୍ଡୱେର"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:878
-msgctxt "category"
-msgid "System"
-msgstr "ତନ୍ତ୍ର"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "ସହାୟତା"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "ସାଧାରଣ"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "ବିଦାୟ ନିଅନ୍ତୁ"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "ଖୋଜନ୍ତୁ"
+
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "ପ୍ୟାନେଲ ଚିତ୍ର ସଂକେତ"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "ପୂର୍ବବର୍ତ୍ତୀ ଉତ୍ସକୁ ବଦଳ କର"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "ବାତିଲ କରାଯାଇଛି"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
-#~ msgid "Flickr"
-#~ msgstr "ଫ୍ଲିକର"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u ଫଳାଫଳ"
+msgstr[1] "%u ଫଳାଫଳଗୁଡ଼ିକ"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ନିବେଶ"
+msgstr[1] "%u ନିବେଶଗୁଡ଼ିକ"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "ଦିନ ସାରା ହୋଇଥିବା ପରିବର୍ତ୍ତନଗୁଡ଼ିକ"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "ଟାଇଲ"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "ଛୋଟବଡ଼ କରନ୍ତୁ"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "କେନ୍ଦ୍ର"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "ପୂରଣ କରନ୍ତୁ"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "ଧାଡ଼ି ବିସ୍ତାର"
+
+#~ msgid "Select Background"
+#~ msgstr "ପୃଷ୍ଠଭୂମି ବାଛନ୍ତୁ"
+
+#~ msgid "Pictures"
+#~ msgstr "ଚିତ୍ରଗୁଡିକ"
+
+#~ msgid "Colors"
+#~ msgstr "ରଙ୍ଗଗୁଡକ"
+
+#~ msgid "Home"
+#~ msgstr "ମୂଳସ୍ଥାନ"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "ଆପଣ ନିଜର %s ଫୋଲଡରରେ ପ୍ରତିଛବିଗୁଡ଼ିକୁ ଯୋଗ କରିପାରିବେ ଏବଂ ସେଗୁଡ଼ିକ ଏଠାରେ ଦୃଶ୍ୟମାନ ହେବ"
+
+#~ msgid "multiple sizes"
+#~ msgstr "ଏକାଧିକ ଆକାର"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "କୌଣସି ଡେସ୍କଟପ ପୃଷ୍ଠଭୂମି ନାହିଁ"
+
+#~ msgid "Current background"
+#~ msgstr "ପ୍ରଚଳିତ ପୃଷ୍ଠଭୂମି"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "ୱାଲପେପର;ପରଦା;ଡେସ୍କଟପ;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "ଆପଣଙ୍କର ମାପ ଉପକରଣକୁ ବର୍ଗ ଉପରେ ରଖନ୍ତୁ ଏବଂ 'ଆରମ୍ଭ କରନ୍ତୁ' କୁ ଦବାନ୍ତୁ"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "ଆପଣଙ୍କର ମାପ ଉପକରଣକୁ ମପା ହୋଇଥିବା ସ୍ଥାନକୁ ଗତିକରାନ୍ତୁ ଏବଂ 'ଆଗକୁ ବଢ଼ନ୍ତୁ' କୁ ଦବାନ୍ତୁ"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "ଆପଣଙ୍କର ମାପ ଉପକରଣକୁ ଉପର ସ୍ଥାନକୁ ଗତିକରାନ୍ତୁ ଏବଂ 'ଆଗକୁ ବଢ଼ନ୍ତୁ' କୁ ଦବାନ୍ତୁ"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "ଲ୍ୟାପଟପ ଲିଡ଼କୁ ବନ୍ଦ କରନ୍ତୁ"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "ଏକ ଆଭ୍ୟନ୍ତରୀଣ ତ୍ରୁଟି ଘଟିଛି ଯାହାକୁ ପୁଣି ପାଇବେ ନାହିଁ।"
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "ମାପିବା ପାଇଁ ଆବଶ୍ୟକ ସାଧନଗୁଡ଼ିକୁ ସ୍ଥାପନ କରାଯାଇନାହିଁ।"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "ରୀପରେଖାକୁ ସୃଷ୍ଟି କରିହେବ ନାହିଁ।"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "ଲକ୍ଷ୍ଯସ୍ଥଳ ଧଳା ବିନ୍ଦୁଟି ହାସଲ ହୋଇନାହିଁ।"
+
+#~ msgid "Complete!"
+#~ msgstr "ସମ୍ପୂର୍ଣ୍ଣ ହୋଇଛି !"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "ମାପ ବିଫଳ ହୋଇଛି!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "ଆପଣ ମାପ ଉପକରଣକୁ ବାହାର କରିପାରିବେ।"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "ମାପ ଉପକରଣକୁ କାର୍ଯ୍ୟରତ ସମୟରେ ବାଧା ଦିଅନ୍ତୁ ନାହିଁ"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "ଲ୍ୟାପଟପ୍‌ ପରଦା"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s ମନିଟର୍‌"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s ସ୍କାନର"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s ମୁଦ୍ରଣୀ"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s ୱେବ କାମେରା"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "ରଙ୍ଗ ପରିଚାଳନାକୁ %s ପାଇଁ ସକ୍ରିୟ କରନ୍ତୁ"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s ପାଇଁ ରଙ୍ଗ ରୂପରେଖା ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "Not calibrated"
+#~ msgstr "ମପା ହୋଇନଥିବା"
+
+#~ msgid "Default: "
+#~ msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ: "
+
+#~ msgid "Test profile: "
+#~ msgstr "ପରୀକ୍ଷଣ ରୂପରେଖା: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC ରୂପରେଖା ଫାଇଲ ମନୋନୀତ କରନ୍ତୁ"
+
+#~ msgid "_Import"
+#~ msgstr "ଆମଦାନୀ କରନ୍ତୁ (_I)"
+
+#~ msgid "All files"
+#~ msgstr "ସମସ୍ତ ଫାଇଲଗୁଡ଼ିକ"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "ଫାଇଲ ଧାରଣ କରିବାରେ ବିଫଳ : %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "ଏହି ରୂପରେଖାଟି ଏଥିରେ ଧାରଣ କରାଯାଇଛି:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "ଏହି URL କୁ ଲେଖନ୍ତୁ।"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "ଏହି କମ୍ପୁଟରକୁ ପୁନଃଚାଳନ କରନ୍ତୁ ଏବଂ ଆପଣଙ୍କର ସାଧାରଣ ପ୍ରଚାଳନ ତନ୍ତ୍ରକୁ ବୁଟ କରନ୍ତୁ।"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "ରୂପରେଖାକୁ ଆହରଣ କରି ସ୍ଥାପନ କରିବା ପାଇଁ ଏହି URL କୁ ଆପଣଙ୍କ ବ୍ରାଉଜରରେ ଲେଖନ୍ତୁ।"
+
+#~ msgid "Save Profile"
+#~ msgstr "ରୂପରେଖା ସରକ୍ଷଣ କରନ୍ତୁ"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "ବଚ୍ଛିତ ଉପକରଣ ପାଇଁ ଗୋଟିଏ ରଙ୍ଗ ରୂପରେଖା ପ୍ରସ୍ତୁତ କରନ୍ତୁ"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "ମାପ ଯନ୍ତ୍ରଟି ମିଳିନାହିଁ। ଏହା ଅନ ଅଛି କି ନାହିଁ ଏବଂ ସଠିକ ଭାବରେ ସଂଯୁକ୍ତ ହୋଇଛି କି ନାହିଁ ଯାଞ୍ଚ କରନ୍ତୁ।"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "ମାପ ଯନ୍ତ୍ରଟି ମୁଦ୍ରଣୀ ରୂପରେଖାକୁ ସମର୍ଥନ କରିନଥାଏ।"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "ଉପକରଣ ପ୍ରକାରଟି ବର୍ତ୍ତମାନ ସମର୍ଥିତ ନୁହଁ।"
+
+#~ msgid "Standard Space"
+#~ msgstr "ମାନକ ସ୍ଥାନ"
+
+#~ msgid "Test Profile"
+#~ msgstr "ପରୀକ୍ଷଣ ରୂପରେଖା"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "ସ୍ବୟଂଚାଳିତ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "ନିମ୍ନ ଗୁଣବତ୍ତା"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "ମଧ୍ଯମ ଗୁଣବତ୍ତା"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "ଉଚ୍ଚ ଗୁଣବତ୍ତା"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ ଧୂସର"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "ବିକ୍ରେତା କାରଖାନା ପ୍ରଦତ୍ତ ମାପ ତଥ୍ୟ ପ୍ରଦାନ କରିଥାଏ"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "ସମ୍ପୂର୍ଣ୍ଣ ପରଦା ପ୍ରଦର୍ଶନୀ ସଂଶୋଧନ ଏହି ରୂପରେଖା ସହିତ ସମ୍ଭବ ନୁହଁ"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "ଏହି  ରୂପରେଖା ହୁଏତଃ ବର୍ତ୍ତମାନ ସଠିକ ହୋଇଥାଇନପାରେ"
+
+#~ msgid "Done"
+#~ msgstr "ସମ୍ପନ୍ନ ହୋଇଛି"
+
+#~ msgid "Upload profile"
+#~ msgstr "ରୂପରେଖା ଧାରଣ କରନ୍ତୁ"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "ଇଣ୍ଟରନେଟ ସଂଯୋଗ ଆବଶ୍ୟକ କରିଥାଏ"
+
+#~ msgid "United States"
+#~ msgstr "ଯୁକ୍ତରାଷ୍ଟ୍ର"
+
+#~ msgid "Germany"
+#~ msgstr "ଜର୍ମାନୀ"
+
+#~ msgid "Spain"
+#~ msgstr "ସ୍ପେନ"
+
+#~ msgid "China"
+#~ msgstr "ଚାଇନା"
+
+#~ msgid "Other…"
+#~ msgstr "ଅନ୍ଯାନ୍ଯ…"
+
+#~ msgid "Language"
+#~ msgstr "ଭାଷା"
+
+#~| msgid "%b %d %l:%M %p"
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~| msgid "Firewall _Zone"
+#~ msgid "Time _Zone"
+#~ msgstr "ସମୟ ମଣ୍ଡଳ (_Z)"
+
+#~ msgid "24-hour"
+#~ msgstr "24-ଘଣ୍ଟା"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~| msgid "Close"
+#~ msgid "Lid Closed"
+#~ msgstr "ଲିଡ ବନ୍ଦକରନ୍ତୁ"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Mirrored"
+#~ msgstr "ପ୍ରତିଫଳିତ"
+
+#~ msgid "Off"
+#~ msgstr "ଅଫ"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "ସଂଲଗ୍ନ ପ୍ରଦର୍ଶକଗୁଡ଼ିକୁ ସଜାଡ଼ନ୍ତୁ"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "ସେଗୁଡ଼ିକୁ ପୁଣି ସଜାଡ଼ିବା ପାଇଁ ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକୁ ଟାଣନ୍ତୁ"
+
+#~| msgid "Size:"
+#~ msgid "Size"
+#~ msgstr "ଆକାର"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "ଉପର ପଟି ଏବଂ କାର୍ଯ୍ୟକଳାପଗୁଡ଼ିକର ସମୀକ୍ଷାକୁ ଏହି ପ୍ରଦର୍ଶନୀରେ ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "ଅତିରିକ୍ତ କାର୍ଯ୍ୟକ୍ଷେତ୍ର ସୃଷ୍ଟି କରିବା ପାଇଁ ଏହି ପ୍ରଦର୍ଶନୀକୁ ଅନ୍ୟ ଗୋଟିଏ ସହିତ ଯୋଡ଼ନ୍ତୁ"
+
+#~| msgid "Orientation"
+#~ msgid "Presentation"
+#~ msgstr "ଉପସ୍ଥାପନ"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "କେବଳ ସ୍ଲାଇଡ ଦୃଶ୍ୟ ଏବଂ ମେଡିଆକୁ ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "ଆପଣଙ୍କର ସ୍ଥିତବାନ ଦୃଶ୍ୟକୁ ଉଭୟ ପ୍ରଦର୍ଶନୀରେ ଦର୍ଶାନ୍ତୁ"
+
+#~| msgid "_Turn On"
+#~ msgid "Turn Off"
+#~ msgstr "ଅଫ୍‌ କରନ୍ତୁ"
+
+#~| msgid "Panel to display"
+#~ msgid "Don't use this display"
+#~ msgstr "ଏହି ପ୍ରଦର୍ଶନୀକୁ ବ୍ୟବହାର କରନ୍ତୁ ନାହିଁ"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "ପରଦା ସୂଚନା ପାଇପାରିଲା ନାହିଁ"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "ସଂଲଗ୍ନ ପ୍ରଦର୍ଶକଗୁଡ଼ିକୁ ସଜାଡ଼ନ୍ତୁ (_A)"
+
+#~ msgid "Wayland"
+#~ msgstr "ୱେଲ୍ୟାଣ୍ଡ"
+
+#~ msgid "Unknown"
+#~ msgstr "ଅଜଣା"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-ବିଟ"
+
+#~ msgid "Ask what to do"
+#~ msgstr "କଣ କରିବାକୁ ହେବ ପଚାରନ୍ତୁ"
+
+#~ msgid "Do nothing"
+#~ msgstr "କିଛି କରନ୍ତୁ ନାହିଁ"
+
+#~ msgid "Open folder"
+#~ msgstr "ଫୋଲଡର ଖୋଲନ୍ତୁ"
+
+#~ msgid "Other Media"
+#~ msgstr "ଅନ୍ଯାନ୍ଯ ସଞ୍ଚାର ମାଧ୍ଯମ"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ଧ୍ୱନୀ CD ଗୁଡ଼ିକ ପାଇଁ ଗୋଟିଏ ପ୍ରୟୋଗ ବାଛନ୍ତୁ"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "ଭିଡିଓ DVD ଗୁଡ଼ିକ ପାଇଁ ଗୋଟିଏ ପ୍ରୟୋଗ ବାଛନ୍ତୁ"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "ଏକ ସଙ୍ଗୀତ ଚାଳକ ସଂଯୁକ୍ତ ହୋଇଥିବା ସମୟରେ ତାହାକୁ ଚଲାଇବା ପାଇଁ ଏକ ପ୍ରୟୋଗକୁ ବାଛନ୍ତୁ"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "ଏକ କ୍ୟାମେରା ସଂଯୁକ୍ତ ହୋଇଥିବା ସମୟରେ ତାହାକୁ ଚଲାଇବା ପାଇଁ ଏକ ପ୍ରୟୋଗକୁ ବାଛନ୍ତୁ"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "ସଫ୍ଟୱେର CD ଗୁଡ଼ିକ ପାଇଁ ଗୋଟିଏ ପ୍ରୟୋଗ ବାଛନ୍ତୁ"
+
+#~ msgid "audio DVD"
+#~ msgstr "ଧ୍ୱନି DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "ଖାଲି Blu-Ray ଡିସ୍କ"
+
+#~ msgid "blank CD disc"
+#~ msgstr "ଖାଲି CD ଡିସ୍କ"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "ଖାଲି DVD ଡିସ୍କ"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "ଖାଲି HD DVD ଡିସ୍କ"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-Ray ଭିଡିଓ ଡିସ୍କ"
+
+#~ msgid "e-book reader"
+#~ msgstr "ଇ-ପୁସ୍ତକ ପାଠକ"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD ଭିଡିଓ ଡିସ୍କ"
+
+#~ msgid "Picture CD"
+#~ msgstr "ଛବି CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "ଉତ୍ତମ ଭିଡ଼ିଓ CD"
+
+#~ msgid "Video CD"
+#~ msgstr "ଭିଡିଓ ସି.ଡି."
+
+#~ msgid "Overview"
+#~ msgstr "ସମୀକ୍ଷା"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "ସଂସ୍କରଣ %s"
+
+#~ msgid "Base system"
+#~ msgstr "ମୌଳିକ ତନ୍ତ୍ର"
+
+#~ msgid "Disk"
+#~ msgstr "ଡିସ୍କ"
+
+#~| msgid "Checking for Updates"
+#~ msgid "Check for updates"
+#~ msgstr "ଅଦ୍ୟତନ ପାଇଁ ଯାଞ୍ଚକରନ୍ତୁ"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "$PICTURES ମଧ୍ଯରେ ଏକ ପରଦା ପ୍ରତିଛବିକୁ ସଂରକ୍ଷଣ କରନ୍ତୁ"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "$PICTURES ମଧ୍ଯରେ ଏକ ୱିଣ୍ଡୋର ପରଦା ପ୍ରତିଛବିକୁ ସଂରକ୍ଷଣ କରନ୍ତୁ"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "$PICTURES ମଧ୍ଯରେ ଏକ ସ୍ଥାନର ପରଦା ପ୍ରତିଛବିକୁ ସଂରକ୍ଷଣ କରନ୍ତୁ"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "କ୍ଲିପବୋର୍ଡରେ ପରଦା ପ୍ରତିଛବିକୁ ନକଲ କରନ୍ତୁ"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "ଏକ ୱିଣ୍ଡୋର କ୍ଲିପବୋର୍ଡରେ ପରଦା ପ୍ରତିଛବିକୁ ନକଲ କରନ୍ତୁ"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "ଏକ ସ୍ଥାନର କ୍ଲିପବୋର୍ଡରେ ପରଦା ପ୍ରତିଛବିକୁ ନକଲ କରନ୍ତୁ"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ ସ୍କ୍ରିନକାଷ୍ଟକୁ ଲିପିବଦ୍ଧ କରନ୍ତୁ"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "ପରବର୍ତ୍ତୀ ଉତ୍ସକୁ  କେବଳ ପରିବର୍ତ୍ତନକାରୀ ମାନେ ବଦଳାଇ ପାରିବେ"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ ପଥ;ପୁନରାବୃତ୍ତି;ମିଞ୍ଜି ମିଞ୍ଜି;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ ପଥକୁ ଇଚ୍ଛାରୂପଣ କରନ୍ତୁ"
+
+#~ msgid "_Delay:"
+#~ msgstr "_ବିଳମ୍ବ:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "ମନ୍ଥର"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "ଲମ୍ବା"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "ଦ୍ରୁତ"
+
+#~ msgid "S_peed:"
+#~ msgstr "ଗତି (_p):"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ ପଥ ବାହାର କରନ୍ତୁ"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "ଗୋଟିଏ ସକ୍ଷିପ୍ତ ପଥ କିକୁ ସମ୍ପାଦନ କରିବା ପାଇଁ, ନିମ୍ନଲିଖିତ ଧାଡ଼ି ଉପରେ କ୍ଲିକ କରନ୍ତୁ  ଏବଂ ଗୋଟିଏ ନୂତନ "
+#~ "କି-ଯୁଗଳ ଟାଇପ କରନ୍ତୁ, କିମ୍ବା ସଫାକରିବା ପାଇଁ Backspace ଉପରେ ଦବାନ୍ତୁ।"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<ଅଜ୍ଞାତ କାର୍ୟ୍ଯ>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "ସକ୍ଷିପ୍ତ ପଥ \"%s\" କୁ ବ୍ୟବହାର କରାଯାଇପାରିବ ନାହିଁ କାରଣ ଏହାକୁ ଏହି କି ବ୍ୟବହାର କରି ଟାଇପ "
+#~ "କରିବା ଅସମ୍ଭବ।\n"
+#~ "ଦୟାକରି ଏକା ସମୟରେ Control, Alt କିମ୍ବା Shift କି ସାହାଯ୍ୟରେ ଚେଷ୍ଟାକରନ୍ତୁ।"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "ସଂକ୍ଷିପ୍ତ ପଥ \"%s\" ଟି ପୂର୍ବରୁ \n"
+#~ "\"%s\" ପାଇଁ ବ୍ୟବହୃତ ହୋଇଛି"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "ଯଦି ଆପଣ \"%s\"ରେ ସଂକ୍ଷିପ୍ତ ପଥକୁ ପୁଣିଥରେ ନିର୍ଦ୍ଦିଷ୍ଟ କରନ୍ତି, ତେବେ \"%s\" ସଂକ୍ଷିପ୍ତ ପଥଟି "
+#~ "ନିଷ୍କ୍ରିୟ ହୋଇଯିବ।"
+
+#~ msgid "_Reassign"
+#~ msgstr "ପୁଣିଥରେ ନିର୍ଦ୍ଦିଷ୍ଟ କରିବା (_R)"
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" ସଂକ୍ଷିପ୍ତ ପଥରେ ସଂଶ୍ଳିଷ୍ଟ\"%s\" ସଂକ୍ଷିପ୍ତ ପଥ ଥାଏ। ଆପଣ ତାହାକୁ ସ୍ୱୟଂଚାଳିତ ଭାବରେ "
+#~ "\"%s\" ସେଟ କରିବାକୁ ଚାହୁଁଛନ୍ତି କି?"
+
+#, c-format
+#~| msgid ""
+#~| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~| "disabled."
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" ବର୍ତ୍ତମାନ \"%s\" ସହିତ ସଂଶ୍ଳିଷ୍ଟ, ଆପଣ ଆଗକୁ ବଢ଼ିଲେ ଏହି ସଂକ୍ଷିପ୍ତ ପଥଟି ନିଷ୍କ୍ରିୟ ହୋଇଯିବ।"
+
+#~| msgid "_Reassign"
+#~ msgid "_Assign"
+#~ msgstr "ନ୍ଯସ୍ତ କରନ୍ତୁ (_A)"
+
+#~| msgid "Test Your _Settings"
+#~ msgid "Test Your Settings"
+#~ msgstr "ବିନ୍ୟାସଗୁଡ଼ିକୁ ପରୀକ୍ଷା କରନ୍ତୁ"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "ମନ୍ଥର"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "ଦୁଇଥର ଦବାଇବାର ସମୟ ସମାପ୍ତି"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "ଦ୍ରୁତ"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "ବାମ (_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "ଡାହାଣ (_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "ସୂଚକ ଗତି (_P)"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ମନ୍ଥର"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "ଦ୍ରୁତ"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ମନ୍ଥର"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "ଦ୍ରୁତ"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "ଦୁଇ-ଅଙ୍ଗୁଳି ଟଣା (_f)"
+
+#~| msgid "_Edge scrolling"
+#~ msgid "_Natural scrolling"
+#~ msgstr "ପ୍ରାକୃତିକ ଧାର ଟଣା (_N)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "ପାଞ୍ଚ ଥର କ୍ଲିକ, GEGL ସମୟ!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "ଦୁଇଥର ଦବାଇବା, ପ୍ରାଥମିକ ବଟନ"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "ଏକ କ୍ଲିକ, ପ୍ରାଥମିକ ବଟନ"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "ଦୁଇଥର କ୍ଲିକ, ମଝି ବଟନ"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "ଏକ କ୍ଲିକ, ମଝି ବଟନ"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "ଦୁଇଥର  କ୍ଲିକ, ଦ୍ୱିତୀୟ ବଟନ"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "ଏକ କ୍ଲିକ, ଦ୍ୱିତୀୟ ବଟନ"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "ତନ୍ତ୍ର ନେଟୱର୍କ ସର୍ଭିସଗୁଡ଼ିକ ଏହି ସଂସ୍କରଣ ସହିତ ସୁସଙ୍ଗତ ନୁହଁ।"
+
+#~ msgid "page 1"
+#~ msgstr "ପୃଷ୍ଠା 1"
+
+#~ msgid "page 2"
+#~ msgstr "ପୃଷ୍ଠା 2"
+
+#~ msgid "automatic"
+#~ msgstr "ସ୍ବୟଂଚାଳିତ"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "ବାଣିଜ୍ୟିକ"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "କିଛି ନାହିଁ"
+
+#~ msgid "Never"
+#~ msgstr "କଦାପି ନୁହଁ"
+
+#~ msgid "Today"
+#~ msgstr "ଆଜି"
+
+#~ msgid "Yesterday"
+#~ msgstr "ଗତକାଲି"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "କିଛି ନାହିଁ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "ଦୁର୍ବଳ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ଠିକ ଅଛି"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "ଉତ୍ତମ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "ଅତି ଉତ୍ତମ"
+
+#~ msgid "Identity"
+#~ msgstr "ପରିଚୟ"
+
+#~ msgid "Server"
+#~ msgstr "ସର୍ଭର"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS ସର୍ଭରକୁ ଅପସାରଣ କରନ୍ତୁ"
+
+#~ msgid "Delete Route"
+#~ msgstr "ପଥ ଅପସାରଣ କରନ୍ତୁ"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "କିଛି ନାହିଁ"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-ବିଟ କି (Hex କିମ୍ବା ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-ବିଟ ପ୍ରବେଶ ସଂକେତ"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "ଗତିଜ WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 ବ୍ୟକ୍ତିଗତ"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 ଉଦ୍ଦୋଗ"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "ମୋଡିହୋଇଥିବା ଯୁଗଳ (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "ସଂଲଗ୍ନକ ଏକକ ଅନ୍ତରାପୃଷ୍ଠ (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "ମେଡିଆ ନିର୍ଭରଶୀଳ ହୋଇନଥିବା ଅନ୍ତରାପୃଷ୍ଠ (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "ଅନ୍ୟ ବ୍ୟବହାରକାରୀମାନଙ୍କ ପାଇଁ ଉପଲବ୍ଧ କରାନ୍ତୁ (_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "ଫାୟାରୱାଲ ସ୍ଥାନ (_Z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "ଏହି ସ୍ଥାନଟି ସଂଯୋଗର ବିଶ୍ୱାସ ସ୍ତରକୁ ବ୍ୟାଖ୍ୟା କରିଥାଏ"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "ସଂଯୋଗ ସମ୍ପାଦକଙ୍କୁ ଖୋଲିବାରେ ଅସମର୍ଥ"
+
+#~ msgid "New Profile"
+#~ msgstr "ନୂତନ ରୂପରେଖ"
+
+#~ msgid "Bond"
+#~ msgstr "ବନ୍ଧନ"
+
+#~ msgid "Team"
+#~ msgstr "ଦଳ"
+
+#~ msgid "Bridge"
+#~ msgstr "ବ୍ରିଜ"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN ପ୍ଲଗଇନଗୁଡ଼ିକୁ ଧାରଣ କରିପାରିଲା ନାହିଁ"
+
+#~ msgid "Import from file…"
+#~ msgstr "ଫାଇଲରୁ ଆମଦାନୀ କରନ୍ତୁ…"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "ନେଟୱର୍କ ସଂଯୋଗ ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid "_Reset"
+#~ msgstr "ପୁନଃ ସ୍ଥାପନ କରନ୍ତୁ (_R)"
+
+#~ msgid "_Forget"
+#~ msgstr "ଭୁଲିଯାଆନ୍ତୁ (_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "ପ୍ରବେଶ ସଂକେତକୁ ଅନ୍ତର୍ଭୁକ୍ତ କରି ଏହି ନେଟୱର୍କ ପାଇଁ ସେଟିଙ୍ଗକୁ ସେଟକରନ୍ତୁ, କିନ୍ତୁ ମନେରଖନ୍ତୁ ଯେ ଏହା "
+#~ "ଏକ ପସନ୍ଦଯୋଗ୍ୟ ନେଟୱର୍କ"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "ଏହି ନେଟୱର୍କରୁ ସମସ୍ତ ବିବରଣୀକୁ ବାହାର କରନ୍ତୁ ଏବଂ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ସଂଯୁକ୍ତ କରିବା ପାଇଁ ଚେଷ୍ଟା "
+#~ "କରନ୍ତୁ"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN ସଂଯୋଗକୁ ଆମଦାନୀ କରାଯାଇପାରିବ ନାହିଁ"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "ଫାଇଲ '%s' କୁ ପଢ଼ିହେଲା ନାହିଁ କିମ୍ବା କୌଣସି ପରିଚିତ VPN ସଂଯୋଗ ସୂଚନା ଧାରଣ କରିନଥାଏ\n"
+#~ "\n"
+#~ "ତ୍ରୁଟି: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "ଆମଦାନୀ ପାଇଁ ଫାଇଲ ଚୟନ କରନ୍ତୁ"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "\"%s\" ନାମକ ଗୋଟିଏ ଫାଇଲ ପୂର୍ବରୁ ଅବସ୍ଥିତ ଅଛି।"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "ଆପଣ %s କୁ ଆପଣ ସଂରକ୍ଷଣ କରୁଥିବା VPN ସଂଯୋଗ ସହିତ ବଦଳାଇବାକୁ ଚାହୁଁଛନ୍ତି କି?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN ସଂଯୋଗକୁ ରପ୍ତାନୀ କରାଯାଇପାରିବ ନାହିଁ"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN ସଂଯୋଗ '%s' କୁ %sକୁ ରପ୍ତାନୀ କରାଯାଇପାରିବ ନାହିଁ।\n"
+#~ "\n"
+#~ "ତ୍ରୁଟି: %s."
+
+#~| msgid "Export VPN connection..."
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN ସଂଯୋଗକୁ ରପ୍ତାନୀ କରନ୍ତୁ"
+
+#~ msgid "Bond slaves"
+#~ msgstr "ବନ୍ଧନ ସ୍ଲେଭ"
+
+#~ msgid "(none)"
+#~ msgstr "(କିଛି ନାହିଁ)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "ବ୍ରିଜ ସ୍ଲେଭ"
+
+#~ msgid "never"
+#~ msgstr "କଦାପି ନୁହଁ"
+
+#~ msgid "today"
+#~ msgstr "ଆଜି"
+
+#~ msgid "yesterday"
+#~ msgstr "ଗତକାଲି"
+
+#~ msgid "Last used"
+#~ msgstr "ଶେଷରେ ବ୍ୟବହୃତ"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "ରୂପରେଖା %d"
+
+#~| msgid "Bridge slaves"
+#~ msgid "Team slaves"
+#~ msgstr "ଦଳ ସ୍ଲେଭ"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "ଯଦି ଆପଣଙ୍କ ପାଖରେ ବେତାର ବ୍ୟତୀତ ଇଣ୍ଟରନେଟ ସହିତ ସଂଯୋଗ ଅଛି, ତେବେ ଆପଣନିଜର ଇଣ୍ଟରନେଟକୁ ଅନ୍ୟ "
+#~ "ସହିତ ବ୍ୟବହାର କରିପାରିବେ।"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "ବେତାର ହଟସ୍ପଟକୁ ଅନ କରିବା ଫଳରେ ତାହା ଆପଣଙ୍କୁ <b>%s</b> ରୁ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରିବ।"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "ହଟସ୍ପଟ ସକ୍ରିୟ ଥିବା ସମୟରେ ବେତାର ସହାୟତାରେ ଇଣ୍ଟରନେଟକୁ ବ୍ୟବହାର କରିବା ସମ୍ଭବ ନୁହଁ।"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "ହଟସ୍ପଟକୁ ଅଟକାଇ ଏବଂ ଯେକୌଣସି ଚାଳକ ସହିତ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରବେ କି?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "ହଟସ୍ପଟକୁ ଅଟକାନ୍ତୁ (_S)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "ହଟ୍‌ସ୍ପଟ୍‌ ଭାବରେ ବ୍ୟବହାର କରିବା ପାଇଁ ତନ୍ତ୍ର ନୀତି ବାରଣ କରିଥାଏ"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "ବେତାର ଉପକରଣ ହଟ୍‌ସ୍ପଟ୍‌ ଧାରାକୁ ସହାୟତା କରିନଥାଏ"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "ପ୍ରବେଶ ସଂକେତ ଏବଂ ଯେ କୌଣସି ଇଚ୍ଛାକୃତ ବିନ୍ୟାସକୁ ଅନ୍ତର୍ଭୁକ୍ତ କରି ବଚ୍ଛିତ ନେଟୱର୍କ ପାଇଁ ନେଟୱର୍କ୍‌ "
+#~ "ବିବରଣୀ ନଷ୍ଟ ହୋଇଯିବ।"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "ଭୁଲିଯାଏ (_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "ୱେବ ପ୍ରୋକ୍ସି ସ୍ୱୟଂଆବିଷ୍କାରକୁ ସଂରଚନା URL ଦିଆଯାଇନଥିବା ସମୟରେ ବ୍ୟବହାର କରାଯାଇଥାଏ।"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "ଏହା ଅବିଶ୍ୱସ୍ତ ସର୍ବସାଧାରଣ ନେଟୱର୍କରେ ପରାମର୍ଶିତ ନୁହଁ।"
+
+#~ msgid "Proxy"
+#~ msgstr "ପ୍ରକ୍ସି"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "କିଛି ନାହିଁ"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "ହସ୍ତ ପୁସ୍ତିକା"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "ସ୍ବୟଂଚାଳିତ"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN ପ୍ରକାର"
+
+#~ msgid "Group Name"
+#~ msgstr "ଶ୍ରେଣୀ ନାମ"
+
+#~ msgid "Group Password"
+#~ msgstr "ଶ୍ରେଣୀ ପ୍ରବେଶ ସଂଙ୍କେତ"
+
+#~ msgid "details"
+#~ msgstr "ବିସ୍ତୃତ ବିବରଣୀ"
+
+#~ msgid "Show P_assword"
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦେଖାନ୍ତୁ (_a)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "ଅନ୍ୟ ବ୍ୟବହାରକାରୀଙ୍କ ପାଇଁ ଉପଲବ୍ଧ କରାନ୍ତୁ"
+
+#~ msgid "identity"
+#~ msgstr "ପରିଚୟ"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "କେବଳ ସ୍ୱୟଂଚାଳିତ (DHCP) ଠିକଣାଗୁଡ଼ିକ"
+
+#~ msgid "Link-local only"
+#~ msgstr "କେବଳ ସଂଯୋଗ-ସ୍ଥାନୀୟ"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ମିଳିଥିବା ପଥକୁ ଅଗ୍ରାହ୍ୟ କରନ୍ତୁ (_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "ପ୍ରତିରୂପି MAC ଠିକଣା (_C)"
+
+#~ msgid "hardware"
+#~ msgstr "ହାର୍ଡୱେର"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "ଏହି ସଂଯୋଗ ପାଇଁ ସେଟିଙ୍ଗକୁ ପୂର୍ବନିର୍ଦ୍ଧାରିତ ଭାବରେ ସେଟ କରନ୍ତୁ, କିନ୍ତୁ ପସନ୍ଦମୁତାବକ ସଂଯୋଗ ଭାବରେ "
+#~ "ମନେରଖନ୍ତୁ।"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "ଏହି ନେଟୱର୍କ ପାଇଁ ସମସ୍ତ ବିବରଣୀକୁ ବାହାର କରନ୍ତୁ ଏବଂ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଏହା ସହିତ ସଂଯୋଗ "
+#~ "କରିବା ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgid "reset"
+#~ msgstr "ପୁନଃସ୍ଥାପନ କରନ୍ତୁ"
+
+#~ msgid "Hardware"
+#~ msgstr "ହାର୍ଡୱେର"
+
+#~ msgid "_History"
+#~ msgstr "ପୁରୁଣା ତଥ୍ୟ (_H)"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Wi-Fi ନେଟୱର୍କ ସହିତ ସଂଯୋଗ କରିବା ପାଇଁ ଅଫ କରନ୍ତୁ"
+
+#~ msgid "Connected Devices"
+#~ msgstr "ସଂଯୁକ୍ତ ଉପକରଣଗୁଡ଼ିକ"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "ଏଡ-ହକ"
+
+#~ msgid "Infrastructure"
+#~ msgstr "ଅବସଂରଚନା"
+
+#~ msgid "Status unknown"
+#~ msgstr "ସ୍ଥିତି ଅଜଣା"
+
+#~ msgid "Unmanaged"
+#~ msgstr "ଅପରିଚାଳିତ"
+
+#~ msgid "Unavailable"
+#~ msgstr "ଉପଲବ୍ଧନାହିଁ"
+
+#~ msgid "Connecting"
+#~ msgstr "ସଂଯୋଗ କରୁଅଛି"
+
+#~ msgid "Disconnecting"
+#~ msgstr "ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରୁଅଛି"
+
+#~ msgid "Connection failed"
+#~ msgstr "ସଂୟୋଗ ଅସଫଳ ହେଲା"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "ସ୍ଥିତି ଅଜଣା (ଅନୁପସ୍ଥିତ)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "ବିନ୍ୟାସ ବିଫଳ ହୋଇଛି"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP ସଂରଚନା ବିଫଳ ହୋଇଛି"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP ସଂରଚନା ସମୟ ସମାପ୍ତି ହୋଇଛି"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "ଗୁପ୍ତ ତଥ୍ୟ ଆବଶ୍ୟକ, କିନ୍ତୁ ଦିଆଯାଇ ନାହିଁ"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x supplicant ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x supplicant ସଂରଚନା ବିଫଳ ହୋଇଛି"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x supplicant ବିଫଳ ହୋଇଛି"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant ବୈଧକରଣ କରିବା ପାଇଁ ଅଧିକ ସମୟ ନେଉଛି"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP ସର୍ଭିସ ଆରମ୍ଭ ହେବାରେ ବିଫଳ"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP ସର୍ଭିସ ବିଛିନ୍ନହୋଇଥିବା"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP ବିଫଳ ହୋଇଛି"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP କ୍ଲାଏଣ୍ଟ ଆରମ୍ଭ ହେବାରେ ବିଫଳ ହୋଇଛି"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP କ୍ଲାଏଣ୍ଟ ତ୍ରୁଟି"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP କ୍ଲାଏଣ୍ଟ ବିଫଳ ହୋଇଛି"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "ସହଭାଗୀ ସଂଯୋଗ ଆରମ୍ଭ ହେବାରେ ବିଫଳ ହୋଇଛି"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "ସହଭାଗୀ ସଂଯୋଗ ସର୍ଭିସ ବିଫଳ ହୋଇଛି"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP ସର୍ଭିସ ଆରମ୍ଭ ହେବାରେ ବିଫଳ ହୋଇଛି"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP ସର୍ଭିସ ତ୍ରୁଟି"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP ସର୍ଭିସ ବିଫଳ ହୋଇଛି"
+
+#~ msgid "Line busy"
+#~ msgstr "ଲାଇନ ବ୍ୟସ୍ତ ଅଛି"
+
+#~ msgid "No dial tone"
+#~ msgstr "ଡ଼ାଏଲଟନ ନାହିଁ"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "କୌଣସି ସମ୍ପର୍କ ସ୍ଥାପନ ହୋଇପାରିବ ନାହିଁ"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "ଡ଼ାଏଲ କରିବା ସମୟ ସମାପ୍ତି"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "ଡ଼ାଏଲ ପ୍ରୟାସ ବିଫଳ"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "ମଡେମ ପ୍ରାରମ୍ଭିକରଣ ବିଫଳ"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "ନିର୍ଦ୍ଦିଷ୍ଟ APN ବାଛିବାରେ ବିଫଳ"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "ନେଟୱର୍କ ସନ୍ଧାନ କରୁ ନାହିଁ"
+
+#~ msgid "Network registration denied"
+#~ msgstr "ନେଟୱର୍କ ପଞ୍ଜିକରଣ ବାରଣ ହୋଇଛି"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "ନେଟୱର୍କ ପଞ୍ଜିକରଣ ସମୟ ସମାପ୍ତି"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "ଅନୁରୋଧ କରାଯାଇଥିବା ନେଟୱର୍କ ସହିତ ପଞ୍ଜିକରଣ କରିବାରେ ବିଫଳ"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN ଯାଞ୍ଚ ବିଫଳ"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "ଉପକରଣ ପାଇଁ ଫର୍ମୱେର ଅନୁପସ୍ଥିତ ଅଛି"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "ସଂଯୋଗ ଅଦୃଶ୍ୟ ହୋଇଯାଇଛି"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "ସ୍ଥିତବାନ ସଂଯୋଗକୁ ଅନୁମାନ କରାଯାଉଛି"
+
+#~ msgid "Modem not found"
+#~ msgstr "ମଡେମ ମିଳିଲା ନାହିଁ"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ବ୍ଲୁଟୁଥ ସଂୟୋଗ ବିଫଳ ହେଲା"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM ପିନ ଆବଶ୍ୟକ"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk ଆବଶ୍ୟକ"
+
+#~ msgid "SIM wrong"
+#~ msgstr "ଭୁଲ SIM"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand ଉପକରଣ ସଂଯୁକ୍ତ ଧାରାକୁ ସହାୟତା କରିନଥାଏ"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "ସଂଯୋଗ ନିର୍ଭୋରୋକ ବିଫଳ ହୋଇଛି"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "କେବଲ ଲାଗିନାହିଁ"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "କୌଣସି ପ୍ରମାଣପତ୍ର ପ୍ରାଧିକାରୀ ପ୍ରମାଣପତ୍ର ବଛାହୋଇନାହିଁ"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "ଗୋଟିଏ ପ୍ରମାଣପତ୍ର ପ୍ରାଧିକାରୀ (CA) ପ୍ରମାଣପତ୍ରକୁ ବ୍ୟବହାର ନକରିବା ଫଳରେ ସଂଯୋଗଟି ଅସୁରକ୍ଷିତ "
+#~ "ହୋଇପାରେ, Wi-Fi ନେଟୱର୍କଗୁଡ଼ିକୁ ଅଜ୍ଞାନ କରିପାରେ।  ଆପଣ ଗୋଟିଏ ପ୍ରମାଣପତ୍ର ପ୍ରାଧିକାରୀ "
+#~ "ପ୍ରମାଣପତ୍ରକୁ ବାଛିବା ପାଇଁ ଚାହୁଁଛନ୍ତି କି?"
+
+#~ msgid "Ignore"
+#~ msgstr "ଆଗ୍ରହ୍ଯ କରିଦିଅନ୍ତୁ"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA ପ୍ରମାଣପତ୍ର ବାଛନ୍ତୁ"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, କିମ୍ବା PKCS#12 ବ୍ୟକ୍ତିଗତ କିଗୁଡ଼ିକ (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER କିମ୍ବା PEM ପ୍ରମାଣପତ୍ରଗୁଡ଼ିକ (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ଫାଇଲଗୁଡ଼ିକ (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "ପ୍ରତ୍ୟେକ ଥର ଏହି ପ୍ରବେଶ ସଂକେତକୁ ପଚାରନ୍ତୁ (_k)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "ଅସଂଗୁପ୍ତ ବ୍ୟକ୍ତିଗତ କିଗୁଡ଼ିକ ଅସୁରକ୍ଷିତ ଅଟେ"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "ବଚ୍ଛିତ ବ୍ୟକ୍ତିଗତ କି ପ୍ରବେଶ ସଂକେତ ଦ୍ୱାରା ସୁରକ୍ଷିତ ଥିବା ପରି ଦୃଶ୍ୟମାନ ହେଉନାହିଁ।ଏହା ଆପଣଙ୍କର "
+#~ "ସୁରକ୍ଷା ପ୍ରମାଣପତ୍ରଗୁଡ଼ିକୁ ସଙ୍କଟରେ ପକାଇବା ପାଇଁ ଅନୁମତି ଦେଇଥାଏ।  ଦୟାକରି ଗୋଟିଏ ପ୍ରବେଶ ସଂକେତ-"
+#~ "ସୁରକ୍ଷିତ ବ୍ୟକ୍ତିଗତ କି ବାଛନ୍ତୁ।\n"
+#~ "\n"
+#~ "(ଆପଣ ଆପମଙ୍କର ବ୍ୟକିତଗତ କିକୁ openssl ଦ୍ୱାରା ପ୍ରବେଶ ସଂକେତ-ପ୍ରତିରୋଧିତ କରିପାରିବେ)"
+
+#~| msgid "Choose your personal certificate..."
+#~ msgid "Choose your personal certificate"
+#~ msgstr "ଆପଣଙ୍କର ବ୍ୟକ୍ତିଗତ ପ୍ରମାଣପତ୍ରକୁ ବାଛନ୍ତୁ"
+
+#~| msgid "Choose your private key..."
+#~ msgid "Choose your private key"
+#~ msgstr "ଆପଣଙ୍କର ବ୍ୟକ୍ତିଗତ କିକୁ ବାଛନ୍ତୁ"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "ମୋତେ ପୁଣିଥରେ ଚେତାବନୀ ଦିଅନ୍ତୁ ନାହିଁ (_w)"
+
+#~ msgid "Yes"
+#~ msgstr "ହଁ"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "ପପ୍‌ଅପ୍‌ ବ୍ୟାନେର ଦର୍ଶାନ୍ତୁ"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "ବ୍ୟାନେରଗୁଡ଼ିକରେ ବିସ୍ତୃତ ବିବରଣୀ ଦର୍ଶାନ୍ତୁ"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "ତାଲା ଲାଗିଥିବା ପରଦାରେ ଦେଖନ୍ତୁ"
+
+#~ msgid "On"
+#~ msgstr "ଅନ"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "ପପଅପ୍‌ ବ୍ୟାନେରଗୁଡ଼ିକୁ ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "ତାଲା ପରଦାରେ ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "Add Account"
+#~ msgstr "ଖାତା ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid "Mail"
+#~ msgstr "ମେଲ"
+
+#~ msgid "Contacts"
+#~ msgstr "ସମ୍ପର୍କଗୁଡ଼ିକ"
+
+#~ msgid "Chat"
+#~ msgstr "ବାର୍ତ୍ତାଳାପ"
+
+#~ msgid "Resources"
+#~ msgstr "ଉତ୍ସଗୁଡ଼ିକ"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "ଖାତାରେ ଲଗଇନ କରିବାରେ ତ୍ରୁଟି"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "ଅଧିକାର ସମାପ୍ତ ହୋଇଛି।"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "ଏହି ଖାତାକୁ ସକ୍ରିୟ କରିବା ପାଇଁ ସାଇନ୍‌ ଇନ୍‌ କରନ୍ତୁ।"
+
+#~ msgid "_Sign In"
+#~ msgstr "ସାଇନ୍‌ ଇନ୍‌ (_S)"
+
+#~ msgid "Error creating account"
+#~ msgstr "ଖାତା ନିର୍ମାଣ କରିବାରେ ତ୍ରୁଟି"
+
+#~ msgid "Error removing account"
+#~ msgstr "ଖାତା ବାହାର କରିବାରେ ତ୍ରୁଟି"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "ଏହି ଖାତାକୁ ଅପସାରଣ କରିବାକୁ ଚାହୁଁଛନ୍ତି ବୋଲି ଆପଣ ନିଶ୍ଚିତ କି?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "ଏହା ସର୍ଭରରେ ସେହି ଖାତାକୁ ଅପସାରଣ କରିବ ନାହିଁ।"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "କୌଣସି ଅନଲାଇନ ଖାତାଗୁଡ଼ିକ ବିନ୍ୟାସିତ ହୋଇନାହିଁ"
+
+#~ msgid "Remove Account"
+#~ msgstr "ଖାତାକୁ ବାହାର କରନ୍ତୁ"
+
+#~ msgid "Add an online account"
+#~ msgstr "ଏକ ଅନଲାଇନ ଖାତା ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "ଏକ ଖାତା ଯୋଗ କିରବା ଫଳରେ ତାହା ଆପଣଙ୍କୁ ଦଲିଲ, ମେଲ, ସମ୍ପର୍କ, କ୍ୟାଲେଣ୍ଡର, ଚାଟ ଏବଂ ଆହୁରି "
+#~ "ଅନେକ ପ୍ରୟୋଗ ପାଇଁ ଅନୁମତି ଦେଇଥାଏ।"
+
+#~ msgid "Unknown time"
+#~ msgstr "ଅଜଣା ସମୟ"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହେବା ପର୍ଯ୍ୟନ୍ତ"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "ବିପଦ: %s ବଳିଅଛି"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s ବଳିଅଛି"
+
+#~ msgid "Fully charged"
+#~ msgstr "ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହୋଇଛି"
+
+#~ msgid "Empty"
+#~ msgstr "ଖାଲି"
+
+#~ msgid "Charging"
+#~ msgstr "ଚାର୍ଜ ହେଉଛି"
+
+#~ msgid "Discharging"
+#~ msgstr "ଚାର୍ଜ କମୁଅଛି"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "ମୂଖ୍ଯ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "ବଳକା"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "ବେତାର ମାଉସ"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "ବେତାର କିବୋର୍ଡ"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "ବାଧାପ୍ରାପ୍ତ ହୋଇନଥିବା ବିଦ୍ୟୁତ ସେବା"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "ବ୍ୟକ୍ତିଗତ ଡିଜିଟାଲ ସହାୟତା"
+
+#~ msgid "Cellphone"
+#~ msgstr "ସେଲଫୋନ"
+
+#~ msgid "Media player"
+#~ msgstr "ମେଡ଼ିଆ ଚାଲକ"
+
+#~ msgid "Computer"
+#~ msgstr "କମ୍ପୁଟର"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "ଚାର୍ଜ ହେଉଛି"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "ସତର୍କତା"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "ନିମ୍ନ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "ଉତ୍ତମ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହୋଇଛି"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "ଖାଲି"
+
+#~ msgid "Batteries"
+#~ msgstr "ବ୍ଯାଟେରୀ"
+
+#~ msgid "When _idle"
+#~ msgstr "ନିଷ୍କ୍ରିୟ ଥିବା ସମୟରେ (_i)"
+
+#~| msgid "Keyboard Preferences"
+#~ msgid "_Keyboard brightness"
+#~ msgstr "କିବୋର୍ଡ ଉଜ୍ଜ୍ୱଳତା (_K)"
+
+#~| msgid "_Dim Screen when Inactive"
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "ନିଷ୍କ୍ରିୟ ଥିବା ସମୟରେ ପରଦା ଉଜ୍ଜ୍ୱଳତାକୁ କମ କରନ୍ତୁ (_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "Wi-Fi (_W)"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "ବେତାର ଉପକରଣଗୁଡ଼ିକୁ ଅଫ୍‌ କରନ୍ତୁ"
+
+#~| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "ମୋବାଇଲ ବ୍ରୋଡ଼ବ୍ୟାଣ୍ଡ (3G, 4G, WiMax, ଇତ୍ୟାଦି) ଉପକରଣଗୁଡ଼ିକୁ ଅଫ୍‌ କରନ୍ତୁ"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "ବ୍ଲୁଟୁଥ (_B)"
+
+#~ msgid "When on battery power"
+#~ msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତିରେ ଚାଲୁଥିବା ସମୟରେ"
+
+#~ msgid "When plugged in"
+#~ msgstr "ପ୍ଲଗଇନ ହୋଇଥିବା ସମୟରେ"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "ନିଲମ୍ବିତ କରନ୍ତୁ ଏବଂ ବିଦ୍ୟୁତ ପ୍ରବାହ ବନ୍ଦ କରନ୍ତୁ"
+
+#~| msgid "_Automatic Suspend"
+#~ msgid "_Automatic suspend"
+#~ msgstr "ସ୍ବୟଂଚାଳିତ ନିଲମ୍ବନ (_A)"
+
+#~| msgid "When Battery Power is _Critical"
+#~ msgid "When battery power is _critical"
+#~ msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତି ଅତି କମ ଥିବା ସମୟରେ (_c)"
+
+#~ msgid "Power Off"
+#~ msgstr "ବିଦ୍ୟୁତ ପ୍ରବାହ ବନ୍ଦ କରନ୍ତୁ"
+
+#~ msgid "Hibernate"
+#~ msgstr "ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
+
+#~ msgid "1 minute"
+#~ msgstr "1 ମିନଟ"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 ମିନିଟଗୁଡିକ"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 ମିନିଟ"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 ମିନିଟ"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 ମିନିଟ"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 ମିନିଟ"
+
+#~ msgid "Out of toner"
+#~ msgstr "ଟୋନର ସରିଯାଇଛି"
+
+#~ msgid "Low on developer"
+#~ msgstr "ବିକାଶକାରୀ କମ ଅଛି"
+
+#~ msgid "Out of developer"
+#~ msgstr "ବିକାଶକାରୀ ସରିଯାଇଛି"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "ଚିହ୍ନଟ ସାମଗ୍ରୀର କମ ଅଛି"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "ଚିହ୍ନଟ ସାମଗ୍ରୀର ଅଭାବ ଅଛି"
+
+#~ msgid "Open cover"
+#~ msgstr "ଆବରଣ ଖୋଲନ୍ତୁ"
+
+#~ msgid "Open door"
+#~ msgstr "ଦ୍ୱାର ଖୋଲନ୍ତୁ"
+
+#~ msgid "Low on paper"
+#~ msgstr "କାଗଜ କମ ଅଛି"
+
+#~ msgid "Out of paper"
+#~ msgstr "କାଗଜ ସରିଯାଇଛି"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "ଅଟକିଛି"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "ଆବର୍ଜନା ପାତ୍ର ପ୍ରାୟତଃ ପୁରଣ ହୋଇଛି"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "ଆବର୍ଜନା ପାତ୍ର ପୁରଣ ଅଛି"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ଅପଟିକାଲ ଫୋଟୋ କଣ୍ଡକଟରର ସମୟ ସମାପ୍ତ ହେବାକୁ ଯାଉଛି"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ଅପଟିକାଲ ଫୋଟୋ କଣ୍ଡକଟର ବର୍ତ୍ତମାନ କାମ କରୁନାହିଁ"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "ପ୍ରସ୍ତୁତ"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "କାର୍ଯ୍ଯଗୁଡ଼ିକୁ ଗ୍ରହଣ କରିନଥାଏ"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "କାର୍ଯ୍ୟକାରୀ କରୁଅଛି"
+
+#~ msgid "Toner Level"
+#~ msgstr "ଟୋନର ସ୍ତର"
+
+#~ msgid "Supply Level"
+#~ msgstr "ସାମଗ୍ରୀ ସ୍ତର"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "ସ୍ଥାପନ କରୁଅଛି"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u ସକ୍ରିୟ"
+#~ msgstr[1] "%u ସକ୍ରିୟ"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "ନୂତନ ମୁଦ୍ରଣୀ ଯୋଗକରିବାରେ ବିଫଳ।"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "ପୋଷ୍ଟସ୍କ୍ରିପ୍ଟ ମୁଦ୍ରଣୀ ବର୍ଣ୍ଣନା ଫାଇଲ୍ ଗୁଡାକ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+#~ "GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "କୌଣସି  ଉପଯୁକ୍ତ ଡ୍ରାଇଭର ମିଳିଲା ନାହିଁ"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui କୁ ଧାରଣ କରିପାରିଲା ନାହିଁ : %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "ମୁଦ୍ରଣ କାର୍ଯ୍ୟକୁ ପୁଣି ଚାଲୁ କରନ୍ତୁ"
+
+#~ msgid "Pause Printing"
+#~ msgstr "ମୁଦ୍ରଣ କାର୍ଯ୍ୟକୁ ବିରତି ଦିଅନ୍ତୁ"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "ନୂତନ ମୁଦ୍ରଣୀ ଯୋଗ କରନ୍ତୁ"
+
+#~| msgid "Search for network printers or filter result"
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "ଫଳାଫଳଗୁଡ଼ିକୁ ବାଛିବା ପାଇଁ ମୁଦ୍ରଣୀର ଠିକଣା ଅଥବା ପାଠ୍ୟ ଦିଅନ୍ତୁ"
+
+#~| msgid "Remove Printer"
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect ମୁଦ୍ରଣୀ"
+
+#~| msgid "%s Printer"
+#~ msgid "LPD Printer"
+#~ msgstr "LPD ମୁଦ୍ରଣୀ"
+
+#~ msgid "One Sided"
+#~ msgstr "ଗୋଟିଏ ପାଖ"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "ବୃହତ ଧାର (ମାନକ)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ ଧାର (ଫ୍ଲିପ)"
+
+#~ msgid "Portrait"
+#~ msgstr "ଚିତ୍ରପଟ"
+
+#~ msgid "Landscape"
+#~ msgstr "କଡ଼ୁଆ"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "ଓଲଟା ଭୂ-ଦୃଶ୍ଯ"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "ଓଲଟା ଚିତ୍ରପଟ"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "ବାକି ଅଛି"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "ଅଟକା ଯାଇଛି"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "କାର୍ଯ୍ୟକାରୀ କରୁଅଛି"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "ଅଟକିଛି"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "ପରିତ୍ଯାଗ କରାଯାଇଛି"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "ସମାପ୍ତ"
+
+#~ msgid "Job Title"
+#~ msgstr "କାମ ଶୀର୍ଷକ"
+
+#~ msgid "Job State"
+#~ msgstr "କାର୍ଯ୍ୟ ସ୍ଥିତି"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "କ୍ରମିକ ପୋର୍ଟ"
+
+#~ msgid "Parallel Port"
+#~ msgstr "ସମାନ୍ତରାଳ ପୋର୍ଟ"
+
+#, c-format
+#~| msgid "Location"
+#~ msgid "Location: %s"
+#~ msgstr "ଅବସ୍ଥାନ: %s"
+
+#, c-format
+#~| msgid "A_ddress:"
+#~ msgid "Address: %s"
+#~ msgstr "ଠିକଣା: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "ଉଭୟ ପାର୍ଶ୍ବ"
+
+#~ msgid "Paper Type"
+#~ msgstr "କାଗଜର ପ୍ରକାର"
+
+#~ msgid "Paper Source"
+#~ msgstr "କାଗଜ ଉତ୍ସ"
+
+#~ msgid "Output Tray"
+#~ msgstr "ନିର୍ଗମ ଟ୍ରେ"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript ପ୍ରାକ-ଛଣା"
+
+#~ msgid "Pages per side"
+#~ msgstr "ପ୍ରତ୍ଯେକ ପାର୍ଶ୍ବରେ ପୃଷ୍ଠା ସଂଖ୍ଯା"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "ସାଧାରଣ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "ପୃଷ୍ଠା ବ୍ଯବସ୍ଥା"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "ସ୍ଥାପନ ଯୋଗ୍ଯ ବିକଳ୍ପ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "କାର୍ଯ୍ଯ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "ପ୍ରତିଛବି ଗୁଣବତ୍ତା"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "ରଙ୍ଗ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "ସମ୍ପନ୍ନ କରୁଅଛି"
+
+#~ msgid "Auto Select"
+#~ msgstr "ସ୍ବତଃ ଚୟନ"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "କୋବଳ GhostScript ଅକ୍ଷରରୂପଗୁଡ଼ିକୁ ଯୋଗକରନ୍ତୁ"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS ସ୍ତର 1କୁ ରୂପାନ୍ତରିତ କରନ୍ତୁ"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS ସ୍ତର 2କୁ ରୂପାନ୍ତରିତ କରନ୍ତୁ"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "କୌଣସି ପ୍ରାକ-ମୁଦ୍ରଣୀ ନାହିଁ"
+
+#~ msgid "Supply"
+#~ msgstr "ସାମଗ୍ରୀ"
+
+#~| msgid "Default Route"
+#~ msgid "_Default printer"
+#~ msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ମୁଦ୍ରଣୀ (_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "କାର୍ଯ୍ଯ"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "କାର୍ଯ୍ୟଗୁଡ଼ିକୁ ଦର୍ଶାନ୍ତୁ (_J)"
+
+#~ msgid "label"
+#~ msgstr "ନାମପଟି"
+
+#~ msgid "page 3"
+#~ msgstr "ପୃଷ୍ଠା 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "ପରୀକ୍ଷଣ ପୃଷ୍ଠାକୁ ମୁଦ୍ରଣ କରନ୍ତୁ (_T)"
+
+#~ msgid "_Options"
+#~ msgstr "ବିକଳ୍ପଗୁଡ଼ିକ (_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "ନୂତନ ମୁଦ୍ରଣୀ ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid "Usage & History"
+#~ msgstr "ବ୍ୟବହାର ବିଧି ଏବଂ ପୁରୁଣା ତଥ୍ଯ"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "ଆବର୍ଜନା ପାତ୍ରରୁ ସମସ୍ତ ବସ୍ତୁକୁ ଖାଲି କରିବେ କି?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "ଏହି ଆବର୍ଜନା ପାତ୍ରରେ ଥିବା ସମସ୍ତ ବସ୍ତୁଗୁଡ଼ିକ ସବୁଦିନ ପାଇଁ ଅପସାରିତ ହୋଇଛି।"
+
+#~| msgid "Purge Trash & Temporary Files"
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "ସମସ୍ତ ଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ଅପସାରଣ କରିବେ କି?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "ସମସ୍ତ ଅସ୍ଥାୟୀ ବସ୍ତୁଗୁଡ଼ିକ ସବୁଦିନ ପାଇଁ ଅପସାରିତ ହୋଇଛି।"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "ଆପଣଙ୍କର ବ୍ୟକ୍ତିଗତ ସୂଚନାକୁ ସୁରକ୍ଷା ଦିଅନ୍ତୁ ଏବଂ ଅନ୍ୟମାନେ କଣ ଦେଖିପାରିବେ ତାହାକୁ ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "ପରଦା ଅଫ ହୋଇଛି"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 ସେକେଣ୍ଡ"
+
+#~ msgid "1 day"
+#~ msgstr "1 ଦିନ"
+
+#~ msgid "2 days"
+#~ msgstr "2 ଦିନ"
+
+#~ msgid "3 days"
+#~ msgstr "3 ଦିନ"
+
+#~ msgid "4 days"
+#~ msgstr "4 ଦିନ"
+
+#~ msgid "5 days"
+#~ msgstr "5 ଦିନ"
+
+#~ msgid "6 days"
+#~ msgstr "6 ଦିନ"
+
+#~ msgid "7 days"
+#~ msgstr "7 ଦିନ"
+
+#~ msgid "14 days"
+#~ msgstr "14 ଦିନ"
+
+#~ msgid "30 days"
+#~ msgstr "30 ଦିନ"
+
+#~ msgid "Forever"
+#~ msgstr "ସବୁଦିନ ପାଇଁ"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "ଆପଣଙ୍କର ପୁରୁଣା ତଥ୍ୟକୁ ମନେରଖିବା ଫଳରେ ସବୁକିଛି ପରେ ଖୋଜିବା ସମୟରେ ସହଜମୟ ହୋଇଥାଏ। ଏହି "
+#~ "ବସ୍ତୁଗୁଡ଼ିକୁ ନେଟୱର୍କରେ ସହଭାଗ କରାଯାଇନଥାଏ।"
+
+#~ msgid "_Recently Used"
+#~ msgstr "ନିକଟରେ ବ୍ୟବହାର ହୋଇଥିବା (_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "ପୁରୁଣା ତଥ୍ୟ ରଖନ୍ତୁ (_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "ପରଦା ତାଲା ଆପଣଙ୍କର ଅନୁପସ୍ଥିତିରେ ଗୋପନୀୟତାକୁ ରକ୍ଷା କରିଥାଏ।"
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "ଏତିକି ସମୟ ଖାଲି ରହିବା ପରେ ପରଦାକୁ ତାଲା ପକାନ୍ତୁ (_a)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "ଆପଣଙ୍କ କମ୍ପୁଟରକୁ ଅନାବଶ୍ୟକ ସମ୍ବେଦନଶୀଳ ସୂଚନାରୁ ମୁକ୍ତ ରଖିବା ପାଇଁ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଆବର୍ଜନା "
+#~ "ଏବଂ ଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ଖାଲିକରନ୍ତୁ।"
+
+#~ msgid "Purge _After"
+#~ msgstr "ଏହା ପରେ ପରିଷ୍କାର କରନ୍ତୁ (_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "ଆପଣ କେଉଁ ସଫ୍ଟୱେର ବ୍ୟବହାର କରୁଛନ୍ତି ତାହା ବିଷୟରେ ସୂଚନା ଦେବା ଫଳରେ ତାହା ଆମକୁ ଅଧିକ ସଠିକ "
+#~ "ପରାମର୍ଶଗୁଡ଼ିକୁ ଦେବା ପାଇଁ ସହାୟତା କରିଥାଏ। ଏହା ମଧ୍ଯ ଆମର ସଫ୍ଟୱେରକୁ ଉନ୍ନତ କରିବା ପାଇଁ ସହାୟତା "
+#~ "କରିଥାଏ।\n"
+#~ "\n"
+#~ "ଆମେ ସଂଗ୍ରହ କରିଥିବା ସମସ୍ତ ସୂଚନା ଏହାକୁ ଅଜ୍ଞାତ କରିଥାଏ, ଏବଂ ଆମେ ତୃତୀୟ ପକ୍ଷ ସହିତ ଆପଣଙ୍କର "
+#~ "ତଥ୍ୟକୁ ସହଭାଗ କରିନଥାଉ।"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "ସଫ୍ଟୱେର ଉପଯୋଗୀତା ପରିସଂଖ୍ୟାନ ପଠାନ୍ତୁ (_S)"
+
+#~| msgid "Privacy"
+#~ msgid "Privacy Policy"
+#~ msgstr "ଗୋପନିୟତା ନିତୀ"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "ଆପଣଙ୍କର ଭୌଗଳିକ ସ୍ଥିତି ନିର୍ଦ୍ଧାରଣ କରିବା ପାଇଁ ବ୍ୟବହାର ହୋଇଥାଏ"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ଇମ୍ପେରୀୟାଲ"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "ମେଟ୍ରିକ"
+
+#~ msgid "No input sources found"
+#~ msgstr "କୌଣସି ନିବେଶ ଉତ୍ସ ମିଳିଲା ନାହିଁ"
+
+#~| msgid "Other"
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "ଅନ୍ଯାନ୍ଯ"
+
+#~ msgid "Sorry"
+#~ msgstr "କ୍ଷମା କରନ୍ତୁ"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "ପରବର୍ତ୍ତୀ ଉତ୍ସକୁ ବଦଳ କର"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "ଆପଣ ଏହି ସଂକ୍ଷିପ୍ତ ପଥଗୁଡ଼ିକୁ କିବୋର୍ଡ ସଂରଚନାରେ ପରିବର୍ତ୍ତନ କରିପାରିବେ"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "ବୈକଳ୍ପିକ ଭାବରେ ପରବର୍ତ୍ତୀ ଉତ୍ସକୁ ବଦଳ କର"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "ବାମ+ଡ଼ାହାଣ  Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "ଇରାଜୀ (ଯୁକ୍ତ ରାଜ୍ୟ)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "ଯୁକ୍ତ ରାଜ୍ଯ"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "ତନ୍ତ୍ରରେ ଲଗଇନ କରିବା ସମୟରେ ଲଗଇନ ସଂରଚନାଗୁଡ଼ିକ ସମସ୍ତ ବ୍ୟବହାରକାରୀଙ୍କ ଦ୍ୱାରା ବ୍ୟବହାର "
+#~ "ହୋଇଥାଏ"
+
+#~| msgid "Other"
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "ଅନ୍ଯାନ୍ଯ"
+
+#~ msgid "Select Location"
+#~ msgstr "ଗୋଟିଏ ସ୍ଥାନ ମନୋନୀତ କରନ୍ତୁ"
+
+#~| msgid "GOK"
+#~ msgid "_OK"
+#~ msgstr "ଠିକ ଅଛି (_O)"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "ଅନ"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "ଅଫ"
+
+#~| msgid "Enabled"
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "ସକ୍ରିୟ"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "ଗୋଟିଏ ଫୋଲଡର ଖୋଲନ୍ତୁ"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "ସହଭାଗ ପାଇଁ କୌଣସି ନେଟୱର୍କ ବଛାଯାଇ ନାହିଁ"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "ବ୍ଲୁଟୁଥ ସହଭାଗ ଆପଣଙ୍କୁ ଅନ୍ୟ ବ୍ଲୁଟୁଥ ସକ୍ରିୟ ଉପକରଣଗୁଡ଼ିକ ସହିତ ଫାଇଲ ସହଭାଗ କରିବା ପାଇଁ ଅନୁମତି "
+#~ "ଦେଇଥାଏ"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "କେବଳ ବିଶ୍ୱସ୍ତ ଉପକରଣଗୁଡ଼ିକରୁ ଗ୍ରହଣ କରନ୍ତୁ"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "ଗ୍ରହଣ କରାଯାଇଥିବା ଫାଇଲଗୁଡ଼ିକୁ ଆହରଣ ଫୋଲଡରରେ ସଂରକ୍ଷଣ କରନ୍ତୁ"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "ପରଦା ସହଭାଗ"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "ନେଟୱର୍କ ଅଭିଗମ୍ୟତା ନଥିବା ହେତୁ କିଛି ସର୍ଭିସଗୁଡ଼ିକ ନିଷ୍କ୍ରିୟ ଅଛି।"
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "ବ୍ୟକ୍ତିଗତ ଫାଇଲ ସହଭାଗ ଆପଣଙ୍କୁ ସାର୍ବଜନିକ ଫାଇଲକୁ ପ୍ରଚଳିତ ନେଟୱର୍କ ବ୍ୟବହାର କରୁଥିବା ଅନ୍ୟମାନଙ୍କ "
+#~ "ସହିତ ସହଭାଗ ପାଇଁ ଅନୁମତି ଦେଇଥାଏ: <a href=\"dav://%s\">dav://%s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "ସୁରକ୍ଷିତ ସେଲ ନିର୍ଦ୍ଦେଶ ବ୍ୟବହାର କରି ସୁଦୂର ବ୍ୟବହାରକାରୀମାନଙ୍କୁ ସଂଯୋଗ କରିବା ପାଇଁ ଅନୁମତି ଦିଅନ୍ତୁ:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "ଏହା ସହିତ ସଂଯୋଗ ସ୍ଥାପନ କରି ସୁଦୂର ବ୍ୟବହାରକାରୀମାନଙ୍କୁ ଆପଣଙ୍କ ପରଦାକୁ ଦେଖିବା ଏବଂ ନିୟନ୍ତ୍ରଣ "
+#~ "କରିବା ପାଇଁ ଅନୁମତି ଦିଅନ୍ତୁ: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~| msgid "Password"
+#~ msgid "Password:"
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତ:"
+
+#~ msgid "Show Password"
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦେଖାନ୍ତୁ"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "ନୂତନ ସଂଯୋଗଗୁଡ଼ିକ ନିଶ୍ଚିତ ଭାବରେ ଅଭିଗମ୍ୟତା ପଚାରିଥାଏ"
+
+#~| msgid "Require Password"
+#~ msgid "Require a password"
+#~ msgstr "ପ୍ରବେଶ ସଂଙ୍କେତ ଆବଶ୍ୟକ"
+
+#~ msgid "Bark"
+#~ msgstr "ଗରଜିବା"
+
+#~ msgid "Drip"
+#~ msgstr "ପଡ଼ିବା"
+
+#~ msgid "Glass"
+#~ msgstr "କାଚ"
+
+#~ msgid "Sonar"
+#~ msgstr "ସୋନାର"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "ସର୍ବନିମ୍ନ"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "ସର୍ବାଧିକ"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "ସବଉଫର (_S):"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "ବଢ଼ାହୋଇନଥିବା"
+
+#~ msgid "_Profile:"
+#~ msgstr "ରୂପରେଖ (_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "ସ୍ପିକରଗୁଡ଼ିକୁ ପରୀକ୍ଷା କରନ୍ତୁ (_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "ଶୀର୍ଷ ଚିହ୍ନଟ"
+
+#~ msgid "Device"
+#~ msgstr "ଉପକରଣ"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s ପାଇଁ ସ୍ପିକର ପରୀକ୍ଷଣ"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "ଧ୍ୱନି ନିର୍ଗମ ପାଇଁ ଗୋଟିଏ ଉପକରଣ ବାଛନ୍ତୁ (_h):"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "ବଚ୍ଛିତ ଉପକରଣ ପାଇଁ ବିନ୍ୟାସ:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "ନିବେଶ ଭଲ୍ୟୁମ (_I):"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "ଧ୍ୱନି ନିବେଶ ପାଇଁ ଗୋଟିଏ ଉପକରଣ ବାଛନ୍ତୁ (_h):"
+
+#~ msgid "Sound Effects"
+#~ msgstr "ଧ୍ୱନି ପ୍ରଭାବଗୁଡ଼ିକ"
+
+#~ msgid "Built-in"
+#~ msgstr "ଅନ୍ତଃନିର୍ମିତ"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ଧ୍ୱନି ପସନ୍ଦ"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ଘଟଣା ଧ୍ୱନି ପରୀକ୍ଷଣ"
+
+#~ msgid "From theme"
+#~ msgstr "ପ୍ରେରକ ପ୍ରସଙ୍ଗ"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "ଗୋଟିଏ ସତର୍କ ଧ୍ୱନି ବାଛନ୍ତୁ (_h):"
+
+#~ msgid "Stop"
+#~ msgstr "ବନ୍ଦ କରନ୍ତୁ"
+
+#~ msgid "Custom"
+#~ msgstr "ଇଚ୍ଛାରୂପଣ"
+
+#~ msgid "Screen Reader"
+#~ msgstr "ପରଦା ପାଠକ"
+
+#~| msgid "Screen Reader"
+#~ msgid "_Screen Reader"
+#~ msgstr "ପରଦା ପାଠକ (_S)"
+
+#~| msgid "Bounce Keys"
+#~ msgid "Sound Keys"
+#~ msgstr "ଧ୍ୱନି କିଗୁଡ଼ିକ"
+
+#~| msgid "Flash the window title"
+#~ msgid "Flash the _window title"
+#~ msgstr "ଉଇଣ୍ଡୋ ଶୀର୍ଷକକୁ  ଫ୍ଲାଶ କରନ୍ତୁ (_w)"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ପରଦା"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "1/2 ପରଦା"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ପରଦା"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "ଲମ୍ବା"
+
+#~ msgid "Zoom"
+#~ msgstr "ସାନବଡ କରନ୍ତୁ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "ରଙ୍ଗ"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "ମାନକ"
+
+#~ msgid "Account _Type"
+#~ msgstr "ଖାତା ପ୍ରକାର (_T)"
+
+#~ msgid "_Verify"
+#~ msgstr "ଯାଞ୍ଚ କରନ୍ତୁ (_V)"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "ବାଣିଜ୍ୟିକ ଲଗଇନ ଖାତାଗୁଡ଼ିକୁ ଯୋଡ଼ିବା ପାଇଁ\n"
+#~ "ଅନଲାଇନ୍‌ ହୁଅନ୍ତୁ।"
+
+#~ msgid "Left thumb"
+#~ msgstr "ବାମ ଆଙ୍ଗୁଠି"
+
+#~ msgid "Left middle finger"
+#~ msgstr "ବାମ ତର୍ଜନି"
+
+#~ msgid "Left ring finger"
+#~ msgstr "ବାମ ଅନାମିକା ଅଙ୍ଗୁଳି"
+
+#~ msgid "Left little finger"
+#~ msgstr "ବାମ ତର୍ଜନି"
+
+#~ msgid "Right thumb"
+#~ msgstr "ଡାହାଣ ଆଙ୍ଗୁଠି"
+
+#~ msgid "Right middle finger"
+#~ msgstr "ଡାହାଣ ମଝି ଅଙ୍ଗୁଳି"
+
+#~ msgid "Right ring finger"
+#~ msgstr "ଡାହାଣ ଅନାମିକା ଅଙ୍ଗୁଳି"
+
+#~ msgid "Right little finger"
+#~ msgstr "ଡାହାଣ କାନି ଅଙ୍ଗୁଳି"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନକୁ ସକ୍ରିୟ କରନ୍ତୁ"
+
+#~ msgid "_Right index finger"
+#~ msgstr "ଡାହାଣ ତର୍ଜନି (_R)"
+
+#~ msgid "_Left index finger"
+#~ msgstr "ବାମ ତର୍ଜନି (_L)"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "ଆପଣଙ୍କର ଅଙ୍ଗୁଳି ଚିହ୍ନଟି ସଫଳତାର ସହିତ ସଂରକ୍ଷଣ ହୋଇଛି। ଆପଣଙ୍କୁ ବର୍ତ୍ତମାନ ଆପଣଙ୍କର ଅଙ୍ଗୁଳି ଚିହ୍ନ "
+#~ "ପାଠକ ବ୍ୟବହାର କରି ଲଗଇନ କରିବାକୁ ହେବ।"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "ଲଗଇନ;ନାମ;ଅଙ୍ଗୁଳି ଚିହ୍ନ;ଅଭତାର;ପ୍ରତୀକ;ମୁହଁ;ପ୍ରବେଶ ସଂକେତ;"
+
+#~ msgid "Login History"
+#~ msgstr "ଲଗଇନ ପୁରୁଣା ତଥ୍ଯ"
+
+#~| msgid "_New password"
+#~ msgid "_Verify New Password"
+#~ msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତକୁ ଯାଞ୍ଚ କରନ୍ତୁ (_V)"
+
+#~ msgid "Add User Account"
+#~ msgstr "ଚାଳକ ଖାତା ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid "User Icon"
+#~ msgstr "ଚାଳକ ଚିତ୍ର ସଂକେତ"
+
+#~ msgid "Last Login"
+#~ msgstr "ଅନ୍ତିମ ଲଗଇନ"
+
+#~| msgid "The new password does not contain enough different characters"
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ପୁରୁଣା ଠାରୁ ଭିନ୍ନ ହୋଇଥିବା ଆବଶ୍ୟକ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "କିଛି ଅକ୍ଷର ଏବଂ ସଂଖ୍ୟାଗୁଡ଼ିକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~| msgid "Changing password for"
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତକୁ ଟିକିଏ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "ବିନା ବ୍ୟବହାରକାରୀ ନାମରେ ପ୍ରବେଶ ସଂକେତଟି ଅଧିକ ଶକ୍ତିଶାଳୀ ହେବ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "ପ୍ରବେଶ ସଂକେତରେ ଆପଣଙ୍କର ନାମ ବ୍ୟବହାରକୁ ଏଡ଼ାନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "ପ୍ରବେଶ ସଂକେତରେ ଅନ୍ତର୍ଭୁକ୍ତ କିଛି ଶବ୍ଦକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "ସାଧାରଣ ଶବ୍ଦଗୁଡ଼ିକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "ସ୍ଥିତବାନ ଶବ୍ଦଗୁଡ଼ିକର କ୍ରମ ପରିବର୍ତ୍ତନକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "ଅଧିକ ସଂଖ୍ୟା ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "ଅଧିକ ବଡ଼ ଅକ୍ଷର ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "ଅଧିକ ଛୋଟ ଅକ୍ଷର ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "ଅଧିକ ବିଶେଷ ଅକ୍ଷରଗୁଡ଼ିକୁ ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ, ଯେପରିକି ବିରାମ ଚିହ୍ନ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ ବିରାମ ଚିହ୍ନଗୁଡ଼ିକର ମିଶ୍ରଣକୁ ବ୍ୟବହାର କରିବା ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "ସମାନ ଅକ୍ଷରର ବାରମ୍ବାର ବ୍ୟବହାରକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "ସମାନ ପ୍ରକାରର ଅକ୍ଷରର ବାରମ୍ବାର ବ୍ୟବହାରକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ:ଆପଣଙ୍କୁ ଅକ୍ଷର, ସଂଖ୍ୟା "
+#~ "ଏବଂ ବିରାମ ଚିହ୍ନଗୁଡ଼ିକୁ ମିଶ୍ରଣ କରିବା ଆବଶ୍ୟକ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 କିମ୍ବା abcd ପରି କ୍ରମକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "ଅଧିକ ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ ସଂକେତଗୁଡ଼ିକୁ ଯୋଡ଼ିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr ""
+#~ "ବଡ଼ ଅକ୍ଷର ଏବଂ ଛୋଟ ଅକ୍ଷର ଏବଂ ଗୋଟିଏ କିମ୍ବା ଦୁଇଟି ସଂଖ୍ୟାକୁ ମିଶ୍ରଣ କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr ""
+#~ "ଭଲ ପ୍ରବେଶ ସଂକେତ! ଅଧିକ ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ ବିରାମ ଚିହ୍ନକୁ ଯୋଡ଼ିବା ଫଳରେ ଏହା ଅଧିକ ଶକ୍ତିଶାଳୀ "
+#~ "ହେବ।"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "ଶକ୍ତି: ଦୁର୍ବଳ"
+
+#~| msgid "Length:"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "ଲମ୍ବ: କମ୍"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "ଶକ୍ତି: ମଧ୍ଯମ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "ଶକ୍ତି: ଉତ୍ତମ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "ଶକ୍ତି:ଅତି ଉତ୍ତମ"
+
+#~ msgid "Authentication failed"
+#~ msgstr "ବୈଧିକରଣ ବିଫଳ"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ଅତି ଛୋଟ ଅଟେ"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ଅତି ସହଜ ଅଟେ"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "ପୁରୁଣା ଏବଂ ନୂଆ ପ୍ରବେଶ ସଙ୍କେତ ମଧ୍ଯରେ ବହୁତ ସାମଞ୍ଜସ୍ଯ ଅଛି"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତକୁ ନିକଟରେ ବ୍ୟବହାର କରାଯାଇଛି।"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ସଂଖ୍ୟାତ୍ମକ କିମ୍ବା ବିଶେଷ ଅକ୍ଷର ମାନଙ୍କୁ ଧାରଣ କରିବା ଉଚିତ"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "ପୁରୁଣା ଏବଂ ନୂତନ ପ୍ରବେଶ ସଙ୍କେତ ଏକାପ୍ରକାରର ଅଟନ୍ତି"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "ଆପଣ ପ୍ରାରମ୍ଭରେ ପ୍ରମାଣ କରିଥିବା ପ୍ରବେଶ ସଂକେତ ପରିବର୍ତ୍ତିତ ହୋଇଛି!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତରେ ଯଥେଷ୍ଟ ଭିନ୍ନ ବର୍ଣ୍ଣ ନାହିଁ"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "ଅଜଣା ତ୍ରୁଟି"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "ଆପଣଙ୍କର ଖାତା ପ୍ରଦାତାଙ୍କ ୱେବ ଠିକଣା ସହିତ ମେଳ ଖାଉଥିବା ଉଚିତ।"
+
+#~ msgid "Failed to add account"
+#~ msgstr "ଖାତା ଯୋଗ କରିବାରେ ବିଫଳ"
+
+#~| msgid "Passwords do not match"
+#~ msgid "Passwords do not match."
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦ୍ବୟ ମିଶୁ ନାହିଁ।"
+
+#~ msgid "Failed to register account"
+#~ msgstr "ଖାତା ପଞ୍ଜିକରଣ କରିବାରେ ବିଫଳ"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "ଏହି ଡମେନ ସହିତ ବୈଧିକୃତ କରିବା ପାଇଁ ସହାୟତା ପ୍ରାପ୍ତ ନୁହଁ"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "ଡମେନରେ ଯୋଗ ହେବାରେ ବିଫଳ"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ସେହି ଲଗଇନ ନାମଟି କାମ କରୁ ନାହିଁ।\n"
+#~ "ଦୟାକରି ପୁଣିଥରେ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~| msgid "Invalid password, please try again"
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ସେହି ଲଗଇନ ପ୍ରବେଶ ସଂକେତଟି କାମ କରୁ ନାହିଁ।\n"
+#~ "ଦୟାକରି ପୁଣିଥରେ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "ଡମେନରେ ଲଗଇନ୍‌ ହେବାରେ ବିଫଳ"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "ଡମେନକୁ ପାଇବାରେ ଅସମର୍ଥ। ହୁଏତ ଏଥିରେ ବନାନ ଭୁଲ ଥାଇପାରେ?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "ଆପଣ ଏହି ଉପକରଣକୁ ଅଭିଗମ୍ୟ କରିବା ପାଇଁ ଅନୁମୋଦିତ ନୁହଁ। ଆପଣଙ୍କର ତନ୍ତ୍ର ପ୍ରଶାସକଙ୍କ ସହିତ ଯୋଗାଯୋଗ "
+#~ "କରନ୍ତୁ।"
+
+#~ msgid "The device is already in use."
+#~ msgstr "ଉପକରଣଟି ପୂର୍ବରୁ ବ୍ୟବହାରରେ ଅଛି।"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "ଗୋଟେଏ ଅନ୍ତବର୍ତ୍ତୀ ତୃଟି ଘଟିଲା"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "ପଞ୍ଜିକୃତ ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଅପସାରଣ କରିବେ କି?"
+
+#~ msgid "Done!"
+#~ msgstr "ସମାପ୍ତ!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' ଉପକରଣକୁ ଅଭିଗମ୍ୟ କରିପାରିଲା ନାହିଁ"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' ଉପକରଣରେ ଅଙ୍ଗୁଳି ଧାରଣକୁ ଆରମ୍ଭ କରିପାରିଲା ନାହିଁ"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "କୌଣସି ଅଙ୍ଗୁଳି ଚିହ୍ନ ପାଠକଙ୍କୁ ଅଭିଗମ୍ୟ କରିପାରିଲା ନାହିଁ"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "ସହାୟତା ପାଇଁ ଆପଣଙ୍କ ତନ୍ତ୍ର ପ୍ରଶାସକଙ୍କ ସହିତ ଯୋଗାଯୋଗ କରନ୍ତୁ।"
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନକୁ ସକ୍ରିୟ କରିବା ପାଇଁ, ଆପଣଙ୍କୁ '%s' ଉପକରଣ ବ୍ୟବହାର କରି ଆପଣଙ୍କର ଗୋଟିଏ ଅଙ୍ଗୁଳି "
+#~ "ଚିହ୍ନକୁ ସଂରକ୍ଷଣ କରିବା ଆବଶ୍ୟକ।"
+
+#~ msgid "Selecting finger"
+#~ msgstr "ଅଙ୍ଗୁଳି ଚୟନ"
+
+#~ msgid "This Week"
+#~ msgstr "ଏହି ସପ୍ତାହ"
+
+#~ msgid "Last Week"
+#~ msgstr "ଗତ ସପ୍ତାହ"
+
+#~| msgid "%b %d %Y"
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~| msgid "%b %d %Y"
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "ଅଧିବେଶନ ସମାପ୍ତ"
+
+#~ msgid "Session Started"
+#~ msgstr "ଅଧିବେଶନ ଆରମ୍ଭ ହୋଇଛି"
+
+#~ msgid "Please choose another password."
+#~ msgstr "ଦୟାକରି ଅନ୍ୟଏକ ପ୍ରବେଶ ସଂକେତ ବାଛନ୍ତୁ।"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "ଦୟାକରି ଆପଣଙ୍କ ପ୍ରବେଶ ସଙ୍କେତକୁ ପୁଣିଥରେ ଟାଇପ କରନ୍ତୁ।"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତକୁ ବଦଳାଇ ହେଲା ନାହିଁ"
+
+#~ msgid "Disable image"
+#~ msgstr "ପ୍ରତିଛବିକୁ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
+
+#~ msgid "Take a photo…"
+#~ msgstr "ଗୋଟିଏ ଫଟୋ ନିଅନ୍ତୁ…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "ଅଧିକ ଛବିଗୁଡ଼ିକ ପାଇଁ ବ୍ରାଉଜ କରନ୍ତୁ…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s ଦ୍ୱାରା ବ୍ୟବହୃତ"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଏହି ପ୍ରକାରର ଡମେନ ସହିତ ସଂଯୋଗ କରିପାରିବେ ନାହିଁ"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "ଏପରି କୌଣସି ଡମେନ କିମ୍ବା realm ମିଳି ନାହିଁ"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s ଭାବରେ %s ଡମେନରେ ଲଗଇନ କରିପାରିବେ ନାହିଁ"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "ଅବୈଧ ପ୍ରବେଶ ସଂକେତ, ଦୟାକରି ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ"
+
+#~ msgid "Other Accounts"
+#~ msgstr "ଅନ୍ୟ ଖାତାଗୁଡ଼ିକ"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ଚାଳକକୁ ଅପସାରଣ କରିବାରେ ବିଫଳ"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "ଆପଣ ନିଜର ଖାତାକୁ ଅପସାରଣ କରିପାରିବେ ନାହିଁ।"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ଏପର୍ଯ୍ୟନ୍ତ ଲଗଇନ ଅଛି"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "ଲଗଇନ ହେବା ପରେ ଏକ ବ୍ୟବହାରକାରୀଙ୍କୁ ଅପସାରଣ କରି ତନ୍ତ୍ରକୁ ଅସ୍ଥାୟୀ ସ୍ଥିତିରେ ଛାଡ଼ିଥାଏ।"
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "ଆପଣ %s ର ଫାଇଲଗୁଡ଼ିକୁ ରଖିବାକୁ ଚାହୁଁଛନ୍ତି କି?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ବ୍ୟବହାରକାରୀ ଖାତାକୁ ଅପସାରଣ କରିବା ସମୟରେ ହୋମ ଡିରେକ୍ଟୋରୀ, ମେଲ ସ୍ପୁଲ ଏବଂ ଅସ୍ଥାୟୀ "
+#~ "ଫାଇଲଗୁଡ଼ିକୁ ରଖିବା ସମ୍ଭବ ଅଟେ।"
+
+#~ msgid "_Delete Files"
+#~ msgstr "ଫାଇଲଗୁଡିକୁ ଅପସାରଣ କରନ୍ତୁ (_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "ଫାଇଲଗୁଡିକୁ ରଖନ୍ତୁ (_K)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "ଖାତା ନିଷ୍କ୍ରିୟ ଅଛି"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "ପରବର୍ତ୍ତୀ ଲଗଇନରେ ସେଟ କରାଯିବ"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "କିଛି ନାହିଁ"
+
+#~ msgid "Logged in"
+#~ msgstr "ଲଗଇନ ହୋଇଛି"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "ଖାତାର ସର୍ଭିସକୁ ଯୋଗାଯୋଗ କରିବାରେ ବିଫଳ"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "ଦୟାକରି ନିଶ୍ଚିତ କରନ୍ତୁ ଯେ ଖାତା ସର୍ଭିସଟି ସ୍ଥାପିତ ହୋଇଛି ଏବଂ ସକ୍ରିୟ ଅଛି।"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ,\n"
+#~ "* ଚିତ୍ର ସଂକେତକୁ ପ୍ରଥମେ କ୍ଲିକ କରନ୍ତୁ"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ଚାଳକ ଖାତା ସୃଷ୍ଟି କରିବା ପାଇଁ,\n"
+#~ "* ଚିତ୍ର ସଂକେତକୁ ପ୍ରଥମେ କ୍ଲିକ କରନ୍ତୁ"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "ବଚ୍ଛିତ ଚାଳକ ଖାତାକୁ ଅପସାରଣ କରନ୍ତୁ"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ବଚ୍ଛିତ ଚାଳକ ଖାତାକୁ ଅପସାରଣ କରିବା ପାଇଁ,\n"
+#~ "* ଚିତ୍ର ସଂକେତକୁ ପ୍ରଥମେ କ୍ଲିକ କରନ୍ତୁ"
+
+#, c-format
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "'%s' ଦ୍ବାରା ନାମିତ ହୋଇଥିବା ଗୋଟିଏଚାଳକ ନାମ ପୂର୍ବରୁ ରହିଛି।"
+
+#, c-format
+#~| msgid "The username is too long"
+#~ msgid "The username is too long."
+#~ msgstr "ଚାଳକ ନାମଟି ଅତି ବଡ଼ ଅଟେ।"
+
+#~| msgid "The username cannot start with a '-'"
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "ଚାଳକ ନାମ '-' ଦ୍ୱାରା ଆରମ୍ଭ ହୋଇପାରିବ ନାହିଁ।"
+
+#~| msgid ""
+#~| "The username must only consist of:\n"
+#~| " ➣ letters from the English alphabet\n"
+#~| " ➣ digits\n"
+#~| " ➣ any of the characters '.', '-' and '_'"
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "ବ୍ୟବହାରକାରୀ ନାମରେ କେବଳ a-z ପର୍ଯ୍ୟନ୍ତ ଛୋଟ ଏବଂ ବଡ଼ ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ  '.', '-' ଏବଂ "
+#~ "'_' ମଧ୍ଯରୁ ଯେକୌଣସି ବର୍ଣ୍ଣ ରହିବା ଉଚିତ।"
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr ""
+#~ "ଏହା ଆପଣଙ୍କର ମୂଖ୍ୟ ଫୋଲଡର୍‌କୁ ନାମକରଣ କରିବା ପାଇଁ ବ୍ୟବହାର କରାଯିବ ଏବଂ ତାହାକୁ ପରିବର୍ତ୍ତନ "
+#~ "କରିହେବ ନାହିଁ।"
+
+#~| msgid "%b %d %Y"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~| msgid "%b %d %Y"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "ଉପର"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "ତଳ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "କିଛି ନାହିଁ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "କିଷ୍ଟ୍ରୋକ ପଠାନ୍ତୁ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "ମନିଟର ବଦଳାନ୍ତୁ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "ଅନସ୍କ୍ରିନ୍‌ ସହାୟତା ଦେଖାନ୍ତୁ"
+
+#~ msgid "Output:"
+#~ msgstr "ଫଳାଫଳ:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "ପରିମାପ ଅନୁପାତକୁ ରଖନ୍ତୁ (ଅକ୍ଷର ବାକ୍ସ):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "ଗୋଟିଏ ମନିଟରରେ ମେଳାନ୍ତୁ"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d ର %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "ମ୍ୟାପିଙ୍ଗକୁ ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "ଟ୍ୟାବଲେଟ (ସମ୍ପୂର୍ଣ୍ଣ)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "ଟ୍ୟାବଲେଟ ପସନ୍ଦଗୁଡ଼ିକ"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ବ୍ଲୁଟୁଥ ସଂରଚନା"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "ବଟନଗୁଡ଼ିକୁ ମେଳାନ୍ତୁ…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "ପ୍ରଦର୍ଶନୀ ବିଭେଦନକୁ ସଜାଡ଼ନ୍ତୁ"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "ମାଉସ ସେଟିଙ୍ଗଗୁଡିକୁ ସଜାଡ଼ନ୍ତୁ"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ଅନୁସନ୍ଧାନ ଧାରା"
+
+#~ msgid "Left Ring"
+#~ msgstr "ବାମ ରିଙ୍ଗ"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "ବାମ ରିଙ୍ଗ ଧାରା #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "ଡ଼ାହାଣ ରିଙ୍ଗ ଧାରା #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "ବାମ ଟଚଷ୍ଟ୍ରିପ"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "ବାମ ଟଚଷ୍ଟ୍ରିପ ଧାରା #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "ଡ଼ାହାଣ ଟଚଷ୍ଟ୍ରିପ"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "ଡ଼ାହାଣ ଟଚଷ୍ଟ୍ରିପ ଧାରା #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "ବାମାବର୍ତ୍ତୀ ଟର୍ଚ ଧାରାକୁ ବଦଳାନ୍ତୁ"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "ଡ଼ାହାଣବର୍ତ୍ତୀ ଟର୍ଚ ଧାରାକୁ ବଦଳାନ୍ତୁ"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "ବାମାବର୍ତ୍ତୀ ଟର୍ଚଷ୍ଟ୍ରିପ ଧାରାକୁ ବଦଳାନ୍ତୁ"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "ଡ଼ାହାଣବର୍ତ୍ତୀ ଟର୍ଚଷ୍ଟ୍ରିପ ଧାରାକୁ ବଦଳାନ୍ତୁ"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "ଧାରା ପରିବର୍ତ୍ତନ #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "ବାମ ବଟନ #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "ଡ଼ାହାଣ ବଟନ #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "ଉପର ବଟନ #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "ତଳ ବଟମ #%d"
+
+#~ msgid "No Action"
+#~ msgstr "କୌଣସି କାର୍ୟ୍ଯ ନାହିଁ"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "ବାମ ମାଉସ ବଟନ କ୍ଲିକ"
+
+#~ msgid "Scroll Up"
+#~ msgstr "ଉପରକୁ ସ୍କ୍ରୋଲ କରନ୍ତୁ"
+
+#~ msgid "Scroll Right"
+#~ msgstr "ଡ଼ାହାଣକୁ ସ୍କ୍ରୋଲ କରନ୍ତୁ"
+
+#~ msgid "Stylus"
+#~ msgstr "ଶୈଳୀ"
+
+#~ msgid "Top Button"
+#~ msgstr "ଉପର ବଟନ"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "ଦୃଷ୍ଟ ସୂଚନାଯୁକ୍ତ ଧାରାକୁ ସକ୍ରିୟ କରନ୍ତୁ"
+
+#~ msgid "Show the overview"
+#~ msgstr "ସମୀକ୍ଷାକୁ ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "Search for the string"
+#~ msgstr "ଏହି ବାକ୍ୟଖଣ୍ଡକୁ ଖୋଜନ୍ତୁ"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "ସମ୍ଭାବ୍ୟ ପ୍ୟାନେଲ ନାମଗୁଡ଼ିକୁ ତାଲିକାଭୁକ୍ତ କରନ୍ତୁ ଏବଂ ପ୍ରସ୍ଥାନ କରନ୍ତୁ"
+
+#~ msgid "Show help options"
+#~ msgstr "ସାହାଯ୍ଯ ପସନ୍ଦ ଦେଖାନ୍ତୁ"
+
+#~ msgid "Panel to display"
+#~ msgstr "ଦର୍ଶାଇବା ପାଇଁ ପ୍ୟାନେଲ"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- ସେଟିଙ୍ଗଗୁଡିକ"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "ଉପଲବ୍ଧ ନିର୍ଦ୍ଦେଶନାମା ବିକଳ୍ପଗୁଡ଼ିକର ସମ୍ପୂର୍ଣ୍ଣ ତାଲିକା ଦେଖିବା ପାଇଁ'%s --help' କୁ ଚଲାନ୍ତୁ.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "ଉପଲବ୍ଧ ପ୍ୟାନେଲଗୁଡ଼ିକ:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "ବ୍ଯକ୍ତିଗତ"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "ହାର୍ଡୱେର"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "ତନ୍ତ୍ର"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "ନୂତନ ଉପକରଣ ସ୍ଥାପନ କରନ୍ତୁ"
 
-#~ msgid "Connection"
-#~ msgstr "ସଂଯୋଗ"
-
 #~ msgid "Paired"
 #~ msgstr "ଯୁଗଳ"
 
-#~ msgid "Type"
-#~ msgstr "ପ୍ରକାର"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "ମାଉସ ଏବଂ ଟଚ ପ୍ୟାଡ ସେଟିଙ୍ଗଗୁଡିକ"
-
-#~ msgid "Sound Settings"
-#~ msgstr "ଧ୍ୱନି ସେଟିଙ୍ଗଗୁଡିକ"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "କିବୋର୍ଡ ବିନ୍ୟାସଗୁଡ଼ିକ"
@@ -7475,12 +8324,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "_City:"
 #~ msgstr "ସହର (_i):"
 
-#~ msgid "_Network Time"
-#~ msgstr "ନେଟୱର୍କ ସମୟ (_N)"
-
-#~ msgid ":"
-#~ msgstr ":"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "ସମୟକୁ ଗୋଟିଏ ଘଣ୍ଟା ଆଗକୁ ସେଟ କରନ୍ତୁ।"
 
@@ -7508,18 +8351,8 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgstr "ଉତ୍ତରାବର୍ତ୍ତୀ"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "ଦକ୍ଷିଣାବର୍ତ୍ତୀ"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 ଡିଗ୍ରୀ"
-
-#~ msgid "Monitor"
-#~ msgstr "ମନିଟର"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "ପ୍ରାଥମିକ ପ୍ରଦର୍ଶନୀକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ଟାଣନ୍ତୁ।"
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -7554,9 +8387,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "ଟିପ୍ପଣୀ: ହୁଏତଃ ସୀମା ବିଭେଦନ ବିକଳ୍ପଗୁଡ଼ିକ"
-
-#~ msgid "_Detect Displays"
-#~ msgstr "ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକୁ ଯାଞ୍ଚକରନ୍ତୁ (_D)"
 
 #~ msgid "Install Updates"
 #~ msgstr "ଅଦ୍ୟତନଗୁଡ଼ିକୁ ସ୍ଥାପନ କରନ୍ତୁ"
@@ -7739,12 +8569,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Large"
 #~ msgstr "ବଡ"
 
-#~ msgid "Mouse Settings"
-#~ msgstr "ମାଉସ ସେଟିଙ୍ଗଗୁଡିକ"
-
-#~ msgid "Add account"
-#~ msgstr "ଖାତା ଯୋଗ କରନ୍ତୁ"
-
 #~ msgid "_Local Account"
 #~ msgstr "ସ୍ଥାନିୟ ଖାତା (_L)"
 
@@ -7757,12 +8581,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "C_ontinue"
 #~ msgstr "ଆଗକୁ ବଢନ୍ତୁ (_o)"
 
-#~ msgid "Previous Week"
-#~ msgstr "ପୂର୍ବବର୍ତ୍ତୀ ସପ୍ତାହ"
-
-#~ msgid "Next Week"
-#~ msgstr "ପରବର୍ତ୍ତୀ ସପ୍ତାହ"
-
 #~ msgid "Next week"
 #~ msgstr "ପରବର୍ତ୍ତୀ ସପ୍ତାହ"
 
@@ -7774,12 +8592,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Enable this account"
 #~ msgstr "ଏହି ଖାତାକୁ ସକ୍ରିୟ କରନ୍ତୁ"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତ ନିଶ୍ଚିତ କରନ୍ତୁ (_o)"
-
-#~ msgid "Generate a password"
-#~ msgstr "ଗୋଟିଏ ପ୍ରବେଶ ସଙ୍କେତ ସେଟ କରନ୍ତୁ"
 
 #~ msgid "_Action"
 #~ msgstr "କାର୍ଯ୍ଯ (_A)"
@@ -7919,18 +8731,12 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Change the background"
 #~ msgstr "ପୃଷ୍ଠଭୂମିକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "ବ୍ଲୁଟୁଥ ସଂରଚନାକୁ ବିନ୍ୟାସ କରନ୍ତୁ"
-
 #~ msgid "Browse Files..."
 #~ msgstr "ଫାଇଲଗୁଡ଼ିକୁ ବ୍ରାଉଜ କରନ୍ତୁ..."
 
 #~ msgctxt "Power"
 #~ msgid "Bluetooth"
 #~ msgstr "ବ୍ଲୁଟୁଥ"
-
-#~ msgid "Create virtual device"
-#~ msgstr "ଗୋଟିଏ ଆଭାସୀ ଉପକରଣ ନିର୍ମାଣ କରନ୍ତୁ"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "ଦର୍ଶାଇବା ପାଇଁ ଉପଲବ୍ଧ ରୂପରେଖାଗୁଡ଼ିକ"
@@ -8024,12 +8830,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Unspecified"
 #~ msgstr "ଅନିର୍ଦ୍ଦିଷ୍ଟ"
 
-#~ msgid "Select a language"
-#~ msgstr "ଗୋଟିଏ ଭାଷା ଚୟନକରନ୍ତୁ"
-
-#~ msgid "_Select"
-#~ msgstr "ବାଛନ୍ତୁ (_S)"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "ତାରିଖ ଏବଂ ସମୟ ପସନ୍ଦ ପ୍ୟାନେଲ"
 
@@ -8078,9 +8878,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Set your mouse and touchpad preferences"
 #~ msgstr "ଆପଣଙ୍କର ମାଉସ  ଏବଂ ଟଚପ୍ୟାଡ ପସନ୍ଦ ଗୁଡିକୁ ସ୍ଥିର କରନ୍ତୁ"
-
-#~ msgid "Network settings"
-#~ msgstr "ନେଟୱର୍କ ସଂରଚନା"
 
 #~ msgid "Network;Wireless;IP;LAN;Proxy;"
 #~ msgstr "ନେଟୱର୍କ;ବେତାର;IP;LAN;ପ୍ରକ୍ସି;"
@@ -8182,9 +8979,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Paused"
 #~ msgstr "ବିରାମ ହୋଇଥିବା"
 
-#~ msgid "Change printer settings"
-#~ msgstr "ମୁଦ୍ରଣୀ ବିନ୍ୟାସକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
-
 #~| msgid "Manufacturer:"
 #~ msgid "Manufacturers"
 #~ msgstr "ନିର୍ମାତା"
@@ -8241,9 +9035,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Remove Language"
 #~ msgstr "ଭାଷାକୁ ବାହାର କରନ୍ତୁ"
 
-#~ msgid "Install languages..."
-#~ msgstr "ଭାଷାଗୁଡ଼ିକୁ ସ୍ଥାପନ କରନ୍ତୁ..."
-
 #~ msgid "Select a region (change will be applied the next time you log in)"
 #~ msgstr "ଏକ ଅଞ୍ଚଳ ବାଛନ୍ତୁ (ପରବର୍ତ୍ତୀ ସମୟରେ ଲଗଇନ ହେବା ସମୟରେ ପରିବର୍ତ୍ତନଗୁଡ଼ିକ ଲାଗୁ ହେବ)"
 
@@ -8267,10 +9058,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~| msgid "Input source:"
 #~ msgid "Move Input Source Up"
 #~ msgstr "ନିବେଶ ଉତ୍ସକୁ ଉପରକୁ ଘୁଞ୍ଚାନ୍ତୁ"
-
-#~| msgid "Keyboard Layout Options"
-#~ msgid "Show Keyboard Layout"
-#~ msgstr "କିବୋର୍ଡ ବିନ୍ୟାସ ଦର୍ଶାନ୍ତୁ"
 
 #~ msgid "Ctrl+Alt+Space"
 #~ msgstr "Ctrl+Alt+Space"
@@ -8298,9 +9085,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Brightness & Lock"
 #~ msgstr "ଉଜ୍ଜ୍ବଳତା ଏବଂ ତାଲା"
 
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "ପରଦା ଉଜ୍ଜ୍ୱଳତା ଏବଂ ତାଲା ସଂରଚନା"
-
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "ଉଜ୍ଜ୍ବଳତା;ତାଲା;ଧିମା;ଖାଲି;ମନିଟର;"
 
@@ -8312,9 +9096,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Locations..."
 #~ msgstr "ଅବସ୍ଥାନ..."
-
-#~ msgid "Lock"
-#~ msgstr "ତାଲା ଦେଇ ରଖନ୍ତୁ"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "ତ୍ରୁଟି ନିବାରଣ ସଂକେତକୁ ସକ୍ରିୟ କରନ୍ତୁ"
@@ -8331,14 +9112,8 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Sound Output Volume"
 #~ msgstr "ଧ୍ୱନି ଫଳାଫଳ ଭଲ୍ଯୁମ"
 
-#~ msgid "Microphone Volume"
-#~ msgstr "ମାଇକ୍ରୋଫନ ଭଲ୍ଯୁମ"
-
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "ଧ୍ୱନି ପସନ୍ଦ ଆରମ୍ଭ କରିବାରେ ବିଫଳ: %s"
-
-#~ msgid "_Mute"
-#~ msgstr "ନିରବ (_M)"
 
 #~ msgid "_Sound Preferences"
 #~ msgstr "ଧ୍ୱନି ପସନ୍ଦ (_S)"
@@ -8432,9 +9207,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Take a screenshot"
 #~ msgstr "ପରଦା ପ୍ରତିଛବି ନିଅନ୍ତୁ"
 
-#~ msgid "Shortcut"
-#~ msgstr "ସଂକ୍ଷିପ୍ତ ପଥ"
-
 #~ msgid "_Right-handed"
 #~ msgstr "ଡାହାଣ ହାତ (_R)"
 
@@ -8443,9 +9215,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Sh_ow position of pointer when the Control key is pressed"
 #~ msgstr "ନିୟନ୍ତ୍ରଣ କି କୁ ଦବାଇବା ସମୟରେ ସୂଚକର ଅବସ୍ଥିତି ଦର୍ଶାନ୍ତୁ (_o)"
-
-#~ msgid "A_cceleration:"
-#~ msgstr "ତ୍ୱରଣ (_c):"
 
 #~ msgid "_Sensitivity:"
 #~ msgstr "_ସଂବେଦନଶୀଳତା:"
@@ -8459,9 +9228,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Drag Threshold"
 #~ msgstr "ପ୍ରଭାବ ସୀମା ଟାଣନ୍ତୁ"
 
-#~ msgid "Double-Click Timeout"
-#~ msgstr "ଦୁଇଥର ଦବାଇବାର ସମୟ ସମାପ୍ତି"
-
 #~ msgid "_Timeout:"
 #~ msgstr "ସମୟ ସମାପ୍ତି (_T):"
 
@@ -8471,9 +9237,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "ମାଉସ କ୍ଲିକଗୁଡ଼ିକୁ ଟଚପ୍ୟାଡ ସହିତ ସକ୍ରିୟ କରନ୍ତୁ (_m)"
-
-#~ msgid "Scrolling"
-#~ msgstr "ସ୍କ୍ରୋଲ କରୁଛି"
 
 #~ msgid "_Disabled"
 #~ msgstr "ନିଷ୍କ୍ରିୟ ହୋଇଗଲା (_D)"
@@ -8527,9 +9290,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "affect how much power is used"
 #~ msgstr "କେତେ ମାତ୍ରାରେ ଶକ୍ତି ବ୍ୟବହୃତ ହୋଇଛି"
 
-#~ msgid "_Search by Address"
-#~ msgstr "ଠିକଣା ଅନୁସାରେ ସନ୍ଧାନ କରନ୍ତୁ (_S)"
-
 #~ msgctxt "printer type"
 #~ msgid "Local"
 #~ msgstr "ସ୍ଥାନୀୟ"
@@ -8537,9 +9297,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgctxt "printer type"
 #~ msgid "Network"
 #~ msgstr "ନେଟୱର୍କ"
-
-#~ msgid "Device types"
-#~ msgstr "ଉପକରଣ ପ୍ରକାରମାନ"
 
 #~ msgid "Automatic configuration"
 #~ msgstr "ସ୍ୱୟଂଚାଳିତ ବିନ୍ୟାସ"
@@ -8583,12 +9340,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Layouts"
 #~ msgstr "ଲେପନଗୁଡିକ"
 
-#~ msgid "Layout"
-#~ msgstr "ବିନ୍ଯାସ"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "ବିନ୍ୟାସ କରିବା ପାଇଁ ଗୋଟିଏ ଉପକରଣ ବାଛନ୍ତୁ (_h):"
-
 #~ msgid "Dasher"
 #~ msgstr "ଡେଶର"
 
@@ -8603,12 +9354,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "_Text size:"
 #~ msgstr "ପାଠ୍ୟ ଆକାର (_T):"
-
-#~ msgid "Increase size:"
-#~ msgstr "ଆକାର ବୃଦ୍ଧିକରନ୍ତୁ:"
-
-#~ msgid "Decrease size:"
-#~ msgstr "ଆକାର ହ୍ରାସ କରନ୍ତୁ:"
 
 #~ msgctxt "universal access, seeing"
 #~ msgid "Display"
@@ -8638,9 +9383,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Choose a generated password"
 #~ msgstr "ସୃଷ୍ଟି ହୋଇଥିବା ଏକ ପ୍ରବେଶ ସଙ୍କେତ ବାଛନ୍ତୁ"
-
-#~ msgid "Account _type"
-#~ msgstr "ଖାତା ପ୍ରକାର (_t)"
 
 #~ msgid "More choices..."
 #~ msgstr "ଅଧିକ ପସନ୍ଦଗୁଡ଼ିକ..."
@@ -8777,9 +9519,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Unable to open address book"
 #~ msgstr "ଠିକଣା ପୁସ୍ତିକାକୁ ଖୋଲିବାରେ ଅସମର୍ଥ"
-
-#~ msgid "About %s"
-#~ msgstr "%s ବିଷୟରେ"
 
 #~ msgid "A_IM/iChat:"
 #~ msgstr "A_IM/iChat:"
@@ -8953,9 +9692,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "_Keyboard Accessibility"
 #~ msgstr "କି-ବୋର୍ଡ ଅଭିଗମ୍ଯତା (_K)"
 
-#~ msgid "_Mouse Accessibility"
-#~ msgstr "ମାଉସ ଅଭିଗମ୍ଯତା (_M)"
-
 #~ msgid "_Preferred Applications"
 #~ msgstr "ମନପସନ୍ଦ ପ୍ରୟୋଗଗୁଡ଼ିକ (_P)"
 
@@ -9070,9 +9806,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Changing your cursor theme takes effect the next time you log in."
 #~ msgstr "ଦର୍ଶିକା ପ୍ରସଙ୍ଗ ପରିବର୍ତ୍ତନଟି ପରବର୍ତ୍ତି ଥର ଲଗଇନ କଲେ କାର୍ଯ୍ୟକାରୀ ହେବ।"
 
-#~ msgid "Controls"
-#~ msgstr "ନିୟନ୍ତ୍ରଣ"
-
 #~ msgid "Customize Theme"
 #~ msgstr "ପ୍ରସଙ୍ଗକୁ ଇଚ୍ଛାରୂପଣ କରନ୍ତୁ"
 
@@ -9163,9 +9896,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତରେ ପୁନଃସ୍ଥାପନ କରନ୍ତୁ (_R)"
-
 #~ msgid "_Selected items:"
 #~ msgstr "ବଚ୍ଛିତ ବସ୍ତୁଗୁଡ଼ିକ (_S):"
 
@@ -9174,9 +9904,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "_Slight"
 #~ msgstr "_ଅତିକମ"
-
-#~ msgid "_Style:"
-#~ msgstr "ଶୈଳୀ (_S):"
 
 #~ msgid "_Tooltips:"
 #~ msgstr "ଉପକରଣ ସୂଚନା (_T):"
@@ -9323,14 +10050,8 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Copying file: %u of %u"
 #~ msgstr "ଫାଇଲ ନକଲ କରନ୍ତୁ: %u of %u"
 
-#~ msgid "Parent Window"
-#~ msgstr "ମୂଳ ୱିଣ୍ଡୋ"
-
 #~ msgid "Parent window of the dialog"
 #~ msgstr "ଡାଏଲଗର ପ୍ଯାରେଣ୍ଡ ଉଇଣ୍ଡୋ"
-
-#~ msgid "From URI"
-#~ msgstr "ୟୁ.ଆର.ଆଇ. ରୁ"
 
 #~ msgid "URI currently transferring from"
 #~ msgstr "ୟୁ.ଆର.ଆଇ. ବର୍ତ୍ତମାନ ଏଠାରୁ ସ୍ଥାନାନ୍ତରିତ କରୁଅଛି"
@@ -9340,9 +10061,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "URI currently transferring to"
 #~ msgstr "ୟୁ.ଆର.ଆଇ. ବର୍ତ୍ତମାନ ଏଠାକୁ ସ୍ଥାନାନ୍ତରିତ ହେଉଛି"
-
-#~ msgid "Fraction completed"
-#~ msgstr "ଭଗ୍ନାଂଶ ସମ୍ପନ୍ନ"
 
 #~ msgid "Fraction of transfer currently completed"
 #~ msgstr "ବର୍ତ୍ତମାନ ସ୍ଥାନାନ୍ତରଣର ଏକ ଭାବ ସଂପୂର୍ଣ୍ଣ ହୋଇଛି"
@@ -9442,9 +10160,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Default Pointer - Current"
 #~ msgstr "ଡିଫଲ୍ଟ ପଏଣ୍ଟର  - ଚଳିତ"
-
-#~ msgid "White Pointer"
-#~ msgstr "ଧଳା ପଏଣ୍ଟର"
 
 #~ msgid "White Pointer - Current"
 #~ msgstr "ଧଳା ପଏଣ୍ଟର- ଚଳିତ"
@@ -9567,9 +10282,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "GNOME Magnifier without Screen Reader"
 #~ msgstr "ବିନା ପରଦା ପାଠକରେ GNOME ବର୍ଦ୍ଧକ"
 
-#~ msgid "GNOME Terminal"
-#~ msgstr "GNOME ଟର୍ମିନାଲ"
-
 #~ msgid "Gnopernicus"
 #~ msgstr "Gnopernicus"
 
@@ -9648,9 +10360,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "ସିଲଫିଡ-ପଞ୍ଜା"
 
-#~ msgid "Thunderbird"
-#~ msgstr "Thunderbird"
-
 #~ msgid "Totem Movie Player"
 #~ msgstr "Totem ସିନେମା ଚାଳକ"
 
@@ -9659,12 +10368,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Monitor Preferences"
 #~ msgstr "ପ୍ରଦର୍ଶିକା ପସନ୍ଦ"
-
-#~ msgid "Panel icon"
-#~ msgstr "ପ୍ୟାନେଲ ଚିତ୍ର ସଂକେତ"
-
-#~ msgid "Re_fresh rate:"
-#~ msgstr "ଦର_ରିଫ୍ରେସ କର:"
 
 #~ msgid "Sa_me image in all monitors"
 #~ msgstr "ସମସ୍ତ ପ୍ରଦର୍ଶିକାରେ ସମାନ ପ୍ରତିଛବି (_m)"
@@ -9710,9 +10413,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Could not set the default configuration for monitors"
 #~ msgstr "ପ୍ରଦର୍ଶିକା ପାଇଁ ପୂର୍ବନିର୍ଦ୍ଧାରିତ ସଂରଚନାକୁ ସଂରକ୍ଷଣ କରିପାରିଲା ନାହିଁ"
-
-#~ msgid "Desktop"
-#~ msgstr "ଡେସ୍କଟପ"
 
 #~ msgid "Accelerator key"
 #~ msgstr "ବେଗବର୍ଦ୍ଧକ କି"
@@ -9927,9 +10627,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Set your window properties"
 #~ msgstr "ଆପଣଙ୍କର ଉଇଣ୍ଡୋ ବିଶେଷତାଗୁଡିକୁ ସ୍ଥିର କର"
 
-#~ msgid "Windows"
-#~ msgstr "ୱିଣ୍ଡୋ"
-
 #~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
 #~ msgstr "ଉଇଣ୍ଡୋ ପ୍ରବନ୍ଧକ\"%s\" ଗୋଟିଏ କନଫିଗରେସନ ଉପକରଣ ପଞ୍ଜିକୃତ କରି ନାହିଁ \n"
 
@@ -9944,9 +10641,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Groups"
 #~ msgstr "ସମୂହ"
-
-#~ msgid "Common Tasks"
-#~ msgstr "ସାଧାରଣ କାର୍ୟ୍ଯଗୁଡିକ"
 
 #~ msgid "Close the control-center when a task is activated"
 #~ msgstr "କାର୍ଯ୍ୟ ସକ୍ରିୟ ହେବା ସମୟରେ ନିୟନ୍ତ୍ରଣ-କେନ୍ଦ୍ରକୁ ବନ୍ଦ କରନ୍ତୁ"
@@ -10122,9 +10816,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 #~ msgid "Description:"
 #~ msgstr "ବର୍ଣ୍ଣନା:"
 
-#~ msgid "Installed"
-#~ msgstr "ସ୍ଥାପିତ"
-
 #~ msgid "usage: %s fontfile\n"
 #~ msgstr "ଉପୟୋଗ: %s ଫଣ୍ଟଫାଇଲ\n"
 
@@ -10175,15 +10866,6 @@ msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
 
 #~ msgid "Documents"
 #~ msgstr "ଦଲିଲ"
-
-#~ msgid "<b>Open</b>"
-#~ msgstr "<b>ଖୋଲନ୍ତୁ</b>"
-
-#~ msgid "Rename..."
-#~ msgstr "ନାମ ବଦଳାନ୍ତୁ ..."
-
-#~ msgid "Move to Trash"
-#~ msgstr "ବର୍ଜିତକୁ ପଠାନ୍ତୁ"
 
 #~ msgid "If you delete an item, it is permanently lost."
 #~ msgstr "ଯଦି ଆପଣ ଗୋଟିଏ ବସ୍ତୁକୁ ଅପସାରଣ କରନ୍ତି, ଏହା ସବୁଦିନ ପାଇଁ ନଷ୍ଟ ହୋଇଯିବ."

--- a/po/or.po~
+++ b/po/or.po~
@@ -1,0 +1,10213 @@
+# translation of gnome-control-center.master.or.po to Oriya
+# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER.
+#
+# Subhransu Behera <arya_subhransu@yahoo.co.in>, 2006.
+# Manoj Kumar Giri <mgiri@redhat.com>, 2009, 2010, 2012, 2013, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.master.or\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-08-20 06:31+0000\n"
+"PO-Revision-Date: 2014-08-25 17:01+0530\n"
+"Last-Translator: Manoj Kumar Giri <mgiri@redhat.com>\n"
+"Language-Team: Oriya <oriya-it@googlegroups.com>\n"
+"Language: or\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"X-Generator: Lokalize 1.5\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "ପୃଷ୍ଠଭୂମି"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "ଦିନ ସାରା ହୋଇଥିବା ପରିବର୍ତ୍ତନଗୁଡ଼ିକ"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+#| msgid "Lock screen"
+msgid "Lock Screen"
+msgstr "ପରଦାକୁ ତାଲା ଦେଇ ରଖନ୍ତୁ"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "ଟାଇଲ"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "ଛୋଟବଡ଼ କରନ୍ତୁ"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "କେନ୍ଦ୍ର"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "ମାପ"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "ପୂରଣ କରନ୍ତୁ"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "ଧାଡ଼ି ବିସ୍ତାର"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:442
+msgid "Select Background"
+msgstr "ପୃଷ୍ଠଭୂମି ବାଛନ୍ତୁ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:463
+msgid "Wallpapers"
+msgstr "ୱାଲପେପରଗୁଡ଼ିକ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:472
+msgid "Pictures"
+msgstr "ଚିତ୍ରଗୁଡିକ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:481
+msgid "Colors"
+msgstr "ରଙ୍ଗଗୁଡକ"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:540
+#| msgid "No input sources found"
+msgid "No Pictures Found"
+msgstr "କୌଣସି ଛବି ମିଳିଲା ନାହିଁ"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:558
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "ମୂଳସ୍ଥାନ"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:570
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr ""
+"ଆପଣ ନିଜର %s ଫୋଲଡରରେ ପ୍ରତିଛବିଗୁଡ଼ିକୁ ଯୋଗ କରିପାରିବେ ଏବଂ ସେଗୁଡ଼ିକ ଏଠାରେ ଦୃଶ୍ୟମାନ "
+"ହେବ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:592
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1537
+#: ../panels/display/cc-display-panel.c:1976
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1240
+#: ../panels/network/net-device-wifi.c:1448
+#: ../panels/printers/cc-printers-panel.c:1947
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+#: ../panels/user-accounts/um-photo-dialog.c:95
+#: ../panels/user-accounts/um-photo-dialog.c:222
+#: ../panels/user-accounts/um-user-panel.c:513
+msgid "_Cancel"
+msgstr "ବାତିଲ କରନ୍ତୁ (_C)"
+
+#: ../panels/background/cc-background-chooser-dialog.c:593
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:97
+msgid "Select"
+msgstr "ବାଛନ୍ତୁ"
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "ଏକାଧିକ ଆକାର"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "କୌଣସି ଡେସ୍କଟପ ପୃଷ୍ଠଭୂମି ନାହିଁ"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "ପ୍ରଚଳିତ ପୃଷ୍ଠଭୂମି"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr ""
+"ଆପଣଙ୍କର ପୃଷ୍ଠଭୂମି ପ୍ରତିଛବିକୁ  ୱାଲପେପର୍‌ କିମ୍ବା ଫୋଟୋ ଆକାରରେ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "ୱାଲପେପର;ପରଦା;ଡେସ୍କଟପ;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "ବ୍ଲୁଟୁଥ ନିଷ୍କ୍ରିୟ ହୋଇଛି"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "କୌଣସି ବ୍ଲୁଟୁଥ ଏଡପଟର ମିଳିଲା ନାହିଁ"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "ବ୍ଲୁଟୁଥକୁ ହାର୍ଡୱେର ସ୍ୱିଚ ଦ୍ୱାରା ନିଷ୍କ୍ରିୟ କରାହୋଇଛି"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+msgid "Bluetooth"
+msgstr "ବ୍ଲୁଟୁଥ"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "ବ୍ଲୁଟୁଥ୍‌ କୁ ଅନ୍‌ କିମ୍ବା ଅଫ୍‌ କରି ଆପଣଙ୍କର ଉପକରଣ ସହିତ ସଂଯୋଗ କରନ୍ତୁ"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "ଆପଣଙ୍କର ମାପ ଉପକରଣକୁ ବର୍ଗ ଉପରେ ରଖନ୍ତୁ ଏବଂ 'ଆରମ୍ଭ କରନ୍ତୁ' କୁ ଦବାନ୍ତୁ"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+"ଆପଣଙ୍କର ମାପ ଉପକରଣକୁ ମପା ହୋଇଥିବା ସ୍ଥାନକୁ ଗତିକରାନ୍ତୁ ଏବଂ 'ଆଗକୁ ବଢ଼ନ୍ତୁ' କୁ "
+"ଦବାନ୍ତୁ"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr ""
+"ଆପଣଙ୍କର ମାପ ଉପକରଣକୁ ଉପର ସ୍ଥାନକୁ ଗତିକରାନ୍ତୁ ଏବଂ 'ଆଗକୁ ବଢ଼ନ୍ତୁ' କୁ ଦବାନ୍ତୁ"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "ଲ୍ୟାପଟପ ଲିଡ଼କୁ ବନ୍ଦ କରନ୍ତୁ"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "ଏକ ଆଭ୍ୟନ୍ତରୀଣ ତ୍ରୁଟି ଘଟିଛି ଯାହାକୁ ପୁଣି ପାଇବେ ନାହିଁ।"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "ମାପିବା ପାଇଁ ଆବଶ୍ୟକ ସାଧନଗୁଡ଼ିକୁ ସ୍ଥାପନ କରାଯାଇନାହିଁ।"
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "ରୀପରେଖାକୁ ସୃଷ୍ଟି କରିହେବ ନାହିଁ।"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "ଲକ୍ଷ୍ଯସ୍ଥଳ ଧଳା ବିନ୍ଦୁଟି ହାସଲ ହୋଇନାହିଁ।"
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "ସମ୍ପୂର୍ଣ୍ଣ ହୋଇଛି !"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "ମାପ ବିଫଳ ହୋଇଛି!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "ଆପଣ ମାପ ଉପକରଣକୁ ବାହାର କରିପାରିବେ।"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "ମାପ ଉପକରଣକୁ କାର୍ଯ୍ୟରତ ସମୟରେ ବାଧା ଦିଅନ୍ତୁ ନାହିଁ"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "ଲ୍ୟାପଟପ୍‌ ପରଦା"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "ଅନ୍ତଃନିର୍ମିତ ୱେବକ୍ୟାମ୍‌"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s ମନିଟର୍‌"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s ସ୍କାନର"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s କ୍ୟାମେରା"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s ମୁଦ୍ରଣୀ"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s ୱେବ କାମେରା"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "ରଙ୍ଗ ପରିଚାଳନାକୁ %s ପାଇଁ ସକ୍ରିୟ କରନ୍ତୁ"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s ପାଇଁ ରଙ୍ଗ ରୂପରେଖା ଦର୍ଶାନ୍ତୁ"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+msgid "Not calibrated"
+msgstr "ମପା ହୋଇନଥିବା"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "ରଙ୍ଗ ସ୍ଥାନ:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "ପରୀକ୍ଷଣ ରୂପରେଖା: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "ICC ରୂପରେଖା ଫାଇଲ ମନୋନୀତ କରନ୍ତୁ"
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "ଆମଦାନୀ କରନ୍ତୁ (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "ସମର୍ଥିତ ICC ରୂପରେଖାଗୁଡ଼ିକ"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "ସମସ୍ତ ଫାଇଲଗୁଡ଼ିକ"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "ପରଦା"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "ଫାଇଲ ଧାରଣ କରିବାରେ ବିଫଳ : %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "ଏହି ରୂପରେଖାଟି ଏଥିରେ ଧାରଣ କରାଯାଇଛି:"
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "ଏହି URL କୁ ଲେଖନ୍ତୁ।"
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+"ଏହି କମ୍ପୁଟରକୁ ପୁନଃଚାଳନ କରନ୍ତୁ ଏବଂ ଆପଣଙ୍କର ସାଧାରଣ ପ୍ରଚାଳନ ତନ୍ତ୍ରକୁ ବୁଟ କରନ୍ତୁ।"
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+"ରୂପରେଖାକୁ ଆହରଣ କରି ସ୍ଥାପନ କରିବା ପାଇଁ ଏହି URL କୁ ଆପଣଙ୍କ ବ୍ରାଉଜରରେ ଲେଖନ୍ତୁ।"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "ରୂପରେଖା ସରକ୍ଷଣ କରନ୍ତୁ"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "ସଂରକ୍ଷଣ (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "ବଚ୍ଛିତ ଉପକରଣ ପାଇଁ ଗୋଟିଏ ରଙ୍ଗ ରୂପରେଖା ପ୍ରସ୍ତୁତ କରନ୍ତୁ"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"ମାପ ଯନ୍ତ୍ରଟି ମିଳିନାହିଁ। ଏହା ଅନ ଅଛି କି ନାହିଁ ଏବଂ ସଠିକ ଭାବରେ ସଂଯୁକ୍ତ ହୋଇଛି କି "
+"ନାହିଁ ଯାଞ୍ଚ କରନ୍ତୁ।"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "ମାପ ଯନ୍ତ୍ରଟି ମୁଦ୍ରଣୀ ରୂପରେଖାକୁ ସମର୍ଥନ କରିନଥାଏ।"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "ଉପକରଣ ପ୍ରକାରଟି ବର୍ତ୍ତମାନ ସମର୍ଥିତ ନୁହଁ।"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "ମାନକ ସ୍ଥାନ"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "ପରୀକ୍ଷଣ ରୂପରେଖା"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "ସ୍ବୟଂଚାଳିତ"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "ନିମ୍ନ ଗୁଣବତ୍ତା"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "ମଧ୍ଯମ ଗୁଣବତ୍ତା"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "ଉଚ୍ଚ ଗୁଣବତ୍ତା"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ ଧୂସର"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "ବିକ୍ରେତା କାରଖାନା ପ୍ରଦତ୍ତ ମାପ ତଥ୍ୟ ପ୍ରଦାନ କରିଥାଏ"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "ସମ୍ପୂର୍ଣ୍ଣ ପରଦା ପ୍ରଦର୍ଶନୀ ସଂଶୋଧନ ଏହି ରୂପରେଖା ସହିତ ସମ୍ଭବ ନୁହଁ"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "ଏହି  ରୂପରେଖା ହୁଏତଃ ବର୍ତ୍ତମାନ ସଠିକ ହୋଇଥାଇନପାରେ"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "ମାପ ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr "ବାତିଲ କରନ୍ତୁ"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "ଆରମ୍ଭ"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "ପୁନଃଚାଳନ କରନ୍ତୁ"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "ସମ୍ପନ୍ନ ହୋଇଛି"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "ପରଦା ମାପ"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"ମାପ ଦ୍ୱାରା ଏକ ରୂପରେଖା ଉତ୍ପନ୍ନ ହୋଇଥାଏ ଯାହାକୁ ଆପଣ ପରଦାର ରଙ୍ଗ ପରିଚାଳକରେ ବ୍ୟବହାର "
+"କରିପାରିବେ। ମାପିବାରେ ଆପଣ ଯେତେ ସମୟ ଦେବେ, ରଙ୍ଗ ରୂପରେଖା ସେତେ ଭଲ ହେବ।"
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "ଆପଣ ନିଜର କମ୍ପୁଟରକୁ ମାପିବା ସମୟରେ ବ୍ୟବହାର କରିପାରିବେ ନାହିଁ।"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "ଗୁଣବତ୍ତା"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "ପାଖାପାଖି ସମୟ"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "ମାପ ଗୁଣବତ୍ତା"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ମାପିବା ପାଇଁ ଆପଣ ବ୍ୟବହାର କରୁଥିବା ସେନସର୍‌ ଉପକରଣକୁ ବାଛନ୍ତୁ।"
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "ମାପ ଉପକରଣ"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "ସଂଯୁକ୍ତ ଥିବା ପ୍ରଦର୍ଶନୀର ପ୍ରକାର ବାଛନ୍ତୁ।"
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "ପ୍ରଦର୍ଶନୀ ପ୍ରକାର"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"ପ୍ରଦର୍ଶନୀ ଲକ୍ଷ୍ଯସ୍ଥଳ ଧଳା ବିନ୍ଦୁ ବାଛନ୍ତୁ। ଅଧିକାଂଶ ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକ D65 "
+"ପ୍ରଦୀପକରେ ବ୍ୟବସ୍ଥା "
+"କରାହୋଇଥାଏ।"
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "ରୂପରେଖା ଧଳାବିନ୍ଦୁ"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"ଆପଣଙ୍କ ଆବଶ୍ୟକତା ମୁତାବକ ପ୍ରଦର୍ଶନୀ ଉଜ୍ଜ୍ୱଳତାକୁ ସେଟ କରନ୍ତୁ। ରଙ୍ଗ "
+"ପରିଚାଳନାଟିଉଜ୍ଜ୍ୱଳତା ସ୍ତର "
+"ଅନୁସାରେ ଅଧିକ ସଠିକ ହେବ।"
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"ଏହା ବ୍ୟତୀତ, ଆପଣ ଅନ୍ୟ ଉପକରଣ ପାଇଁ ବ୍ୟବହୃତ ଉଜ୍ଜ୍ୱଳତା ସ୍ତର ଅନୁସାରେ ବ୍ୟବହାର "
+"କରିପାରିବେ।"
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "ଉଜ୍ଜ୍ବଳତା ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"ଆପଣ ରଙ୍ଗ ରୂପରେଖାକୁ ଅନ୍ୟ ଏକ କମ୍ପୁଟରରେ ବ୍ୟବହାର କରିପାରିବେ, ଅଥବା ଭିନ୍ନ ଭିନ୍ନ ଆଲୋକ "
+"ଅନୁସାରେ "
+"ରୂପରେଖା ନିର୍ମାଣ କରିପାରିବେ।"
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "ରୂପରେଖ ନାମ:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "ରୂପରେଖ ନାମ"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "ରୂପରେଖା ସଫଳତାର ସହିତ ନିର୍ମିତ!"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "ରୂପରେଖା ନକଲ କରନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "ଲିଖନଯୋଗ୍ୟ ମେଡିଆ ଆବଶ୍ୟକ"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "ରୂପରେଖା ଧାରଣ କରନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "ଇଣ୍ଟରନେଟ ସଂଯୋଗ ଆବଶ୍ୟକ କରିଥାଏ"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"ଆପଣ ଏହି ନିର୍ଦ୍ଦେଶଗୁଡ଼ିକୁ <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">"
+"Apple OS "
+"X</a> ଏବଂ <a href=\"windows\">Microsoft Windows</a> ରେ କିପରି ବ୍ୟବହାର କରିବେ "
+"ତାହା "
+"ପାଇପାରିବେ।"
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+msgid "Summary"
+msgstr "ସାରାଂଶ"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "ଫାଇଲ ଆମଦାନୀକରନ୍ତୁ…"
+
+#: ../panels/color/color.ui.h:29
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"ସମସ୍ୟା ଦେଖାଦେଇଛି। ରୂପରେଖା ସଠିକ ଭାବରେ କାମ କରିନପାରେ।<a href=\"\">ବିବରଣୀ "
+"ଦର୍ଶାନ୍ତୁ।</a>"
+
+#: ../panels/color/color.ui.h:30
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"ପ୍ରତ୍ୟେକ ଉପକରଣ ରଙ୍ଗ ପରିଚାଳିତ ହେବା ପାଇଁ ଏକ ଅଦ୍ୟତିତ ରଙ୍ଗ ରୂପରେଖା ଆବଶ୍ୟକ କରିଥାଏ।"
+
+#: ../panels/color/color.ui.h:31
+msgid "Learn more"
+msgstr "ଅଧିକ ଜ୍ଞାନ ଆହରଣ କରନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:32
+msgid "Learn more about color management"
+msgstr "ରଙ୍ଗ ପରିଚାଳନା ବିଷୟରେ ଅଧିକ ଜ୍ଞାନ ଆହରଣ କରନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:33
+msgid "Set for all users"
+msgstr "ସମସ୍ତ ଚାଳକମାନଙ୍କ ପାଇଁ ସେଟ କରନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:34
+msgid "Set this profile for all users on this computer"
+msgstr "ଏହି କମ୍ପୁଟରରେ ଥିବା ସମସ୍ତ ବ୍ଯବହାରକାରୀଙ୍କ ପାଇଁ ଏହି ଉପକରଣକୁ ସେଟ କରନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:35
+msgid "Enable"
+msgstr "ସକ୍ରିୟ କରନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:36
+msgid "Add profile"
+msgstr "ରୂପରେଖା ଯୋଗ କରନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:37
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate…"
+msgstr "ମାପନ୍ତୁ..."
+
+#: ../panels/color/color.ui.h:38
+msgid "Calibrate the device"
+msgstr "ଏହି ଉପକରଣକୁ ମାପନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:39
+msgid "Remove profile"
+msgstr "ରୂପରେଖାକୁ ବାହାର କରନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:40
+msgid "View details"
+msgstr "ବିବରଣୀ ଦେଖନ୍ତୁ"
+
+#: ../panels/color/color.ui.h:41
+msgid "Unable to detect any devices that can be color managed"
+msgstr "ରଙ୍ଗ ପରିଚାଳିତ କୌଣସି ଉପକରଣକୁ ଚିହ୍ନିବାରେ ଅସମର୍ଥ"
+
+#: ../panels/color/color.ui.h:42
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:43
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:44
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:45
+msgid "Projector"
+msgstr "ପ୍ରକ୍ଷେପକ"
+
+#: ../panels/color/color.ui.h:46
+msgid "Plasma"
+msgstr "ପ୍ଲାଜମା"
+
+#: ../panels/color/color.ui.h:47
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL ବ୍ୟାକଲାଇଟ)"
+
+#: ../panels/color/color.ui.h:48
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED ବ୍ୟାକଲାଇଟ)"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (white LED backlight)"
+msgstr "LCD (ଧଳା LED ବ୍ୟାକଲାଇଟ)"
+
+#: ../panels/color/color.ui.h:50
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "ସମ୍ପୂର୍ଣ୍ଣ ପ୍ରସସ୍ତ  LCD (CCFL ବ୍ୟାକଲାଇଟ)"
+
+#: ../panels/color/color.ui.h:51
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "ସମ୍ପୂର୍ଣ୍ଣ ପ୍ରସସ୍ତ LCD (RGB LED ବ୍ୟାକଲାଇଟ)"
+
+#: ../panels/color/color.ui.h:52
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "ଉଚ୍ଚ"
+
+#: ../panels/color/color.ui.h:53
+msgid "40 minutes"
+msgstr "40 ମିନିଟ"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "ମଧ୍ଯମ"
+
+#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 ମିନିଟ"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "ନିମ୍ନ"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 ମିନିଟ"
+
+#: ../panels/color/color.ui.h:58
+msgid "Native to display"
+msgstr "ଦର୍ଶାଇବା ପାଇଁ ସ୍ଥାନ"
+
+#: ../panels/color/color.ui.h:59
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (ମୁଦ୍ରଣ କରୁଅଛି ଏବଂ ପ୍ରକାଶ କରୁଅଛି)"
+
+#: ../panels/color/color.ui.h:60
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:61
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (ଫୋଟୋଗ୍ରାଫି ଏବଂ ଆଲେଖିକ)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "ରଙ୍ଗ"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"ଆପଣଙ୍କର ଉପକରଣର ରଙ୍ଗ ମାପନ୍ତୁ, ଯେପରିକି ପ୍ରଦର୍ଶନୀ, କ୍ୟାମେରା କିମ୍ବା ସୂଚକମାନ"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "ରଙ୍ଗ;ICC;ରୂପରେଖା;ମାପନ୍ତୁ;ମୁଦ୍ରଣୀ;ପ୍ରଦର୍ଶନୀ;"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:684
+msgid "United States"
+msgstr "ଯୁକ୍ତରାଷ୍ଟ୍ର"
+
+#: ../panels/common/cc-common-language.c:685
+msgid "Germany"
+msgstr "ଜର୍ମାନୀ"
+
+#: ../panels/common/cc-common-language.c:686
+msgid "France"
+msgstr "ଫ୍ରାନ୍ସ"
+
+#: ../panels/common/cc-common-language.c:687
+msgid "Spain"
+msgstr "ସ୍ପେନ"
+
+#: ../panels/common/cc-common-language.c:688
+msgid "China"
+msgstr "ଚାଇନା"
+
+#: ../panels/common/cc-common-language.c:758
+msgid "Other…"
+msgstr "ଅନ୍ଯାନ୍ଯ…"
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr "ଅଧିକ…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "କୌଣସି ଭାଷା ମିଳିଲା ନାହିଁ"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "ଭାଷା"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "ସମାପ୍ତ (_D)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+#| msgid "%b %d %l:%M %p"
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "ଜାନୁଆରୀ"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "ଫେବୃଆରୀ"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "ମାର୍ଚ୍ଚ"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "ଅପ୍ରେଲ"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "ମଇ"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "ଜୁନ"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "ଜୁଲାଇ"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "ଅଗଷ୍ଟ"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "ସେପ୍ଟେମ୍ବର"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "ଅକ୍ଟୋବର"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "ନଭେମ୍ବର"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "ଡିସେମ୍ବର"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "ତାରିଖ ଏବଂ ସମୟ"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "ଘଣ୍ଟା"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+#| msgid "minute"
+#| msgid_plural "minutes"
+msgid "Minute"
+msgstr "ମିନିଟ"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "ଦିନ"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "ମାସ"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "ବର୍ଷ"
+
+#: ../panels/datetime/datetime.ui.h:21
+#| msgid "Time"
+msgid "Time Zone"
+msgstr "ସମୟ ମଣ୍ଡଳ"
+
+#: ../panels/datetime/datetime.ui.h:22
+#| msgid "Search for the string"
+msgid "Search for a city"
+msgstr "ଏହି ସହରକୁ ଖୋଜନ୍ତୁ"
+
+#: ../panels/datetime/datetime.ui.h:23
+#| msgid "Date & Time"
+msgid "Automatic _Date & Time"
+msgstr "ସ୍ବୟଂଚାଳିତ ତାରିଖ ଏବଂ ସମୟ (_D)"
+
+#: ../panels/datetime/datetime.ui.h:24
+#| msgid "Requires Internet connection"
+msgid "Requires internet access"
+msgstr "ଇଣ୍ଟରନେଟ ସଂଯୋଗ ଆବଶ୍ୟକ କରିଥାଏ"
+
+#: ../panels/datetime/datetime.ui.h:25
+#| msgid "Automatic _Connect"
+msgid "Automatic Time _Zone"
+msgstr "ସ୍ୱୟଂଚାଳିତ ସମୟ ମଣ୍ଡଳ (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:26
+#| msgid "Date & Time"
+msgid "Date & _Time"
+msgstr "ତାରିଖ ଏବଂ ସମୟ (_T)"
+
+#: ../panels/datetime/datetime.ui.h:27
+#| msgid "Firewall _Zone"
+msgid "Time _Zone"
+msgstr "ସମୟ ମଣ୍ଡଳ (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:28
+#| msgid "Formats"
+msgid "Time _Format"
+msgstr "ସମୟ ଫର୍ମାଟ (_F)"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24-ଘଣ୍ଟା"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "ସମୟ ମଣ୍ଡଳକୁ ଅନ୍ତର୍ଭୁକ୍ତ କରି ତାରିଖ ଏବଂ ସମୟକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "ଘଡ଼ି;ସମୟ ମଣ୍ଡଳ;ଅବସ୍ଥାନ;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "ତନ୍ତ୍ର ସମୟ ଏବଂ ତାରିଖ ସେଟିଙ୍ଗକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"ସମୟ କିମ୍ବା ତାରିଖ ବିନ୍ୟାସକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ, ଆପଣଙ୍କୁ ବୈଧିକରଣ କରିବା "
+"ଆବଶ୍ୟକ।"
+
+#: ../panels/display/cc-display-panel.c:487
+#| msgid "Close"
+msgid "Lid Closed"
+msgstr "ଲିଡ ବନ୍ଦକରନ୍ତୁ"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+#| msgid "Mirrored Displays"
+msgid "Mirrored"
+msgstr "ପ୍ରତିଫଳିତ"
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2145
+#| msgid "Primary _button"
+msgid "Primary"
+msgstr "ପ୍ରାଥମିକ"
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "ଅଫ"
+
+#: ../panels/display/cc-display-panel.c:497
+#| msgid "Secondary color"
+msgid "Secondary"
+msgstr "ଦ୍ୱିତୀୟକ"
+
+#: ../panels/display/cc-display-panel.c:1533
+#| msgid "Mirrored Displays"
+msgid "Arrange Combined Displays"
+msgstr "ସଂଲଗ୍ନ ପ୍ରଦର୍ଶକଗୁଡ଼ିକୁ ସଜାଡ଼ନ୍ତୁ"
+
+#: ../panels/display/cc-display-panel.c:1539
+#: ../panels/display/cc-display-panel.c:1979
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+msgid "_Apply"
+msgstr "ପ୍ରୟୋଗ କରନ୍ତୁ (_A)"
+
+#: ../panels/display/cc-display-panel.c:1560
+msgid "Drag displays to rearrange them"
+msgstr "ସେଗୁଡ଼ିକୁ ପୁଣି ସଜାଡ଼ିବା ପାଇଁ ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକୁ ଟାଣନ୍ତୁ"
+
+#: ../panels/display/cc-display-panel.c:2081
+#| msgid "Size:"
+msgid "Size"
+msgstr "ଆକାର"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2094
+msgid "Aspect Ratio"
+msgstr "ପରିମାପ ଅନୁପାତ"
+
+#: ../panels/display/cc-display-panel.c:2115
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "ବିଭେଦ"
+
+#: ../panels/display/cc-display-panel.c:2146
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "ଉପର ପଟି ଏବଂ କାର୍ଯ୍ୟକଳାପଗୁଡ଼ିକର ସମୀକ୍ଷାକୁ ଏହି ପ୍ରଦର୍ଶନୀରେ ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/display/cc-display-panel.c:2152
+#| msgid "Secondary click delay"
+msgid "Secondary Display"
+msgstr "ଦ୍ୱିତୀୟକ ପ୍ରଦର୍ଶନୀ"
+
+#: ../panels/display/cc-display-panel.c:2153
+msgid "Join this display with another to create an extra workspace"
+msgstr ""
+"ଅତିରିକ୍ତ କାର୍ଯ୍ୟକ୍ଷେତ୍ର ସୃଷ୍ଟି କରିବା ପାଇଁ ଏହି ପ୍ରଦର୍ଶନୀକୁ ଅନ୍ୟ ଗୋଟିଏ ସହିତ "
+"ଯୋଡ଼ନ୍ତୁ"
+
+#: ../panels/display/cc-display-panel.c:2160
+#| msgid "Orientation"
+msgid "Presentation"
+msgstr "ଉପସ୍ଥାପନ"
+
+#: ../panels/display/cc-display-panel.c:2161
+msgid "Show slideshows and media only"
+msgstr "କେବଳ ସ୍ଲାଇଡ ଦୃଶ୍ୟ ଏବଂ ମେଡିଆକୁ ଦର୍ଶାନ୍ତୁ"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2166
+#| msgid "Mirror Screens"
+msgid "Mirror"
+msgstr "ପ୍ରତିଫଳକ"
+
+#: ../panels/display/cc-display-panel.c:2167
+msgid "Show your existing view on both displays"
+msgstr "ଆପଣଙ୍କର ସ୍ଥିତବାନ ଦୃଶ୍ୟକୁ ଉଭୟ ପ୍ରଦର୍ଶନୀରେ ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/display/cc-display-panel.c:2173
+#| msgid "_Turn On"
+msgid "Turn Off"
+msgstr "ଅଫ୍‌ କରନ୍ତୁ"
+
+#: ../panels/display/cc-display-panel.c:2174
+#| msgid "Panel to display"
+msgid "Don't use this display"
+msgstr "ଏହି ପ୍ରଦର୍ଶନୀକୁ ବ୍ୟବହାର କରନ୍ତୁ ନାହିଁ"
+
+#: ../panels/display/cc-display-panel.c:2383
+msgid "Could not get screen information"
+msgstr "ପରଦା ସୂଚନା ପାଇପାରିଲା ନାହିଁ"
+
+#: ../panels/display/cc-display-panel.c:2414
+#| msgid "Mirrored Displays"
+msgid "_Arrange Combined Displays"
+msgstr "ସଂଲଗ୍ନ ପ୍ରଦର୍ଶକଗୁଡ଼ିକୁ ସଜାଡ଼ନ୍ତୁ (_A)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକ"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr "ସଂଯୁକ୍ତ ମନିଟର ଏବଂ ପ୍ରଦର୍ଶିକାକୁ କିପରି ବ୍ୟବହାର କରିବେ ତାହା ବାଛନ୍ତୁ"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "ପ୍ୟାନେଲ;ପ୍ରଦର୍ଶିକା;xrandr;ପରଦା;ବିଭେଦନ;ସତେଜ;ମନିଟର;"
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr "ୱେଲ୍ୟାଣ୍ଡ"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "ଅଜଣା"
+
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-bit"
+
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr "%d-ବିଟ"
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr "କଣ କରିବାକୁ ହେବ ପଚାରନ୍ତୁ"
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr "କିଛି କରନ୍ତୁ ନାହିଁ"
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr "ଫୋଲଡର ଖୋଲନ୍ତୁ"
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr "ଅନ୍ଯାନ୍ଯ ସଞ୍ଚାର ମାଧ୍ଯମ"
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr "ଧ୍ୱନୀ CD ଗୁଡ଼ିକ ପାଇଁ ଗୋଟିଏ ପ୍ରୟୋଗ ବାଛନ୍ତୁ"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr "ଭିଡିଓ DVD ଗୁଡ଼ିକ ପାଇଁ ଗୋଟିଏ ପ୍ରୟୋଗ ବାଛନ୍ତୁ"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"ଏକ ସଙ୍ଗୀତ ଚାଳକ ସଂଯୁକ୍ତ ହୋଇଥିବା ସମୟରେ ତାହାକୁ ଚଲାଇବା ପାଇଁ ଏକ ପ୍ରୟୋଗକୁ ବାଛନ୍ତୁ"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+"ଏକ କ୍ୟାମେରା ସଂଯୁକ୍ତ ହୋଇଥିବା ସମୟରେ ତାହାକୁ ଚଲାଇବା ପାଇଁ ଏକ ପ୍ରୟୋଗକୁ ବାଛନ୍ତୁ"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr "ସଫ୍ଟୱେର CD ଗୁଡ଼ିକ ପାଇଁ ଗୋଟିଏ ପ୍ରୟୋଗ ବାଛନ୍ତୁ"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr "ଧ୍ୱନି DVD"
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr "ଖାଲି Blu-Ray ଡିସ୍କ"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr "ଖାଲି CD ଡିସ୍କ"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr "ଖାଲି DVD ଡିସ୍କ"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr "ଖାଲି HD DVD ଡିସ୍କ"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr "Blu-Ray ଭିଡିଓ ଡିସ୍କ"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr "ଇ-ପୁସ୍ତକ ପାଠକ"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr "HD DVD ଭିଡିଓ ଡିସ୍କ"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr "ଛବି CD"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr "ଉତ୍ତମ ଭିଡ଼ିଓ CD"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr "ଭିଡିଓ ସି.ଡି."
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr "Windows ସଫ୍ଟୱେର"
+
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1917
+msgid "Section"
+msgstr "ବିଭାଗ"
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "ସମୀକ୍ଷା"
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ପ୍ରୟୋଗଗୁଡ଼ିକ"
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "ଅପସାରଣଯୋଗ୍ୟ ସଞ୍ଚାରମାଧ୍ଯମ"
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr "ସଂସ୍କରଣ %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:44
+msgid "Details"
+msgstr "ବିସ୍ତୃତ ବିବରଣୀ"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "ଆପଣଙ୍କର ତନ୍ତ୍ର ବିଷୟରେ ସୂଚନା ଦେଖନ୍ତୁ"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ଉପକରଣ;ତନ୍ତ୍ର;ସୂଚନା;ସ୍ମୃତିସ୍ଥାନ;ସଞ୍ଚାଳକ;ସଂସ୍କରଣ;ପୂର୍ବନିର୍ଦ୍ଧାରିତ;ପ୍ରୟୋଗ;ପସନ୍ଦ "
+"ଯୋଗ୍ୟ;cd;dvd;usb;"
+"ଧ୍ୱନି;ଭିଡ଼ିଓ;ଡିସ୍କ;କଢ଼ାଯୋଗ୍ଯ;ମେଡ଼ିଆ;ସ୍ୱୟଂଚାଳନା;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "ଅନ୍ୟ ସଞ୍ଚାର ମାଧ୍ଯମ କିପରି ନିୟନ୍ତ୍ରଣ କରିବେ ତାହା ବାଛନ୍ତୁ"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "କାର୍ଯ୍ଯ (_A):"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "ପ୍ରକାର (_T):"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "ଉପକରଣର ନାମ"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "ସ୍ମୃତିସ୍ଥାନ"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "ସଞ୍ଚାଳକ"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "ମୌଳିକ ତନ୍ତ୍ର"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "ଡିସ୍କ"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "ହିସାବ କରୁଅଛି…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "ଲେଖାଚିତ୍ର"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "ଆଭାସୀକରଣ"
+
+#: ../panels/info/info.ui.h:13
+#| msgid "Checking for Updates"
+msgid "Check for updates"
+msgstr "ଅଦ୍ୟତନ ପାଇଁ ଯାଞ୍ଚକରନ୍ତୁ"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "ୱେବ (_W)"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "ମେଲ (_M)"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "କ୍ଯାଲେଣ୍ଡର (_C)"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "ସଙ୍ଗୀତ (_u)"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "ଭିଡିଓ (_V)"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "ଫୋଟୋଗୁଡ଼ିକ (_P)"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "ସଞ୍ଚାର ମାଧ୍ଯମଗୁଡ଼ିକୁ କିପରି ନିୟନ୍ତ୍ରଣ କରିବେ ତାହା ବାଛନ୍ତୁ"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "CD ଧ୍ୱନୀ (_a)"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "DVD ଭିଡିଓ (_D)"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "ସଙ୍ଗୀତ ଚାଳକ (_M)"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "ସଫ୍ଟୱେର (_S)"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "ଅନ୍ଯାନ୍ଯ ସଞ୍ଚାର ମାଧ୍ଯମ (_O)…"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"ମେଡ଼ିଆ ଭର୍ତ୍ତି ସମୟରେପଚାରନ୍ତୁ ନାହିଁ କିମ୍ବା ପ୍ରଗ୍ରାମ ଆରମ୍ଭ କରନ୍ତୁ ନାହିଁ (_N)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "ସାଉଣ୍ଡ ଏବଂ ମେଡିଆ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "ଭଲ୍ଯୁମକୁ ନୀରବରେ ରଖ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "ଭଲ୍ୟୁମ କମ କରନ୍ତୁ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "ଭଲ୍ୟୁମ ଅଧିକ କରନ୍ତୁ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "ମେଡ଼ିଆ ଚାଲକଙ୍କୁ ଆରମ୍ଭ କରନ୍ତୁ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "ଚଲାଅ( କିମ୍ବା ଚଲାଅ/ବିରାମ)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "ପଛଚଲାକୁ ବିରାମ ଦିଅନ୍ତୁ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "ପଛକୁ ଚଲାଇବା ବନ୍ଦ କରନ୍ତୁ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "ପୂର୍ବବର୍ତ୍ତୀ ଟ୍ରାକ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "ପରବର୍ତ୍ତୀ ଟ୍ରାକ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "ନିଷ୍କାସିତ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "ଟାଇପ କରିବା"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "ପରବର୍ତ୍ତୀ ନିବେଶ ଉତ୍ସକୁ ବଦଳ କର"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "ପୂର୍ବବର୍ତ୍ତୀ ନିବେଶ ଉତ୍ସକୁ ବଦଳ କର"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "ପ୍ରାରମ୍ଭକର୍ତ୍ତାମାନେ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "ସାହାୟ୍ଯ ବ୍ରାଉଜର ପ୍ରାରମ୍ଭ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "ସେଟିଙ୍ଗଗୁଡିକ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "କାଲକୁଲେଟରକୁ ପ୍ରଚାଳନ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "ଇମେଲ ଗ୍ରାହକଙ୍କୁ ପ୍ରଚାଳନ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "ୱେବ ବ୍ରାଉଜର ପ୍ରାରମ୍ଭ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "ହୋମ ଫୋଲ୍ଡର"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ଖୋଜନ୍ତୁ"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "ପରଦା ପ୍ରତିଛବିଗୁଡ଼ିକ"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "$PICTURES ମଧ୍ଯରେ ଏକ ପରଦା ପ୍ରତିଛବିକୁ ସଂରକ୍ଷଣ କରନ୍ତୁ"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "$PICTURES ମଧ୍ଯରେ ଏକ ୱିଣ୍ଡୋର ପରଦା ପ୍ରତିଛବିକୁ ସଂରକ୍ଷଣ କରନ୍ତୁ"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "$PICTURES ମଧ୍ଯରେ ଏକ ସ୍ଥାନର ପରଦା ପ୍ରତିଛବିକୁ ସଂରକ୍ଷଣ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "କ୍ଲିପବୋର୍ଡରେ ପରଦା ପ୍ରତିଛବିକୁ ନକଲ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "ଏକ ୱିଣ୍ଡୋର କ୍ଲିପବୋର୍ଡରେ ପରଦା ପ୍ରତିଛବିକୁ ନକଲ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "ଏକ ସ୍ଥାନର କ୍ଲିପବୋର୍ଡରେ ପରଦା ପ୍ରତିଛବିକୁ ନକଲ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "ସଂକ୍ଷିପ୍ତ ସ୍କ୍ରିନକାଷ୍ଟକୁ ଲିପିବଦ୍ଧ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "ତନ୍ତ୍ର"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "ଲଗଆଉଟ କରନ୍ତୁ"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "ପରଦାକୁ ତାଲା ଦେଇ ରଖନ୍ତୁ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "ସାର୍ବଜନିକ ଅଭିଗମ୍ୟତା"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "ଛୋଟବଡ଼ କରିବାକୁ ଅନ କିମ୍ବା ଅଫ କରନ୍ତୁ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "ବଡ କରନ୍ତୁ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "ସାନ କରନ୍ତୁ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "ପରଦା ପାଠକକୁ ଅନ କିମ୍ବା ଅଫ କରନ୍ତୁ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "ଅନସ୍କ୍ରିନ କି ବୋର୍ଡ କୁ ଅନ କିମ୍ବା ଅଫ କରନ୍ତୁ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "ପାଠ୍ୟର ଆକାର ବୃଦ୍ଧି କରନ୍ତୁ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "ପାଠ୍ୟର ଆକାର କମ କରନ୍ତୁ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "ଅଧିକ ସ୍ପଷ୍ଟତାକୁ ଅନ କିମ୍ବା ଅଫ କରନ୍ତୁ"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1217
+#: ../panels/network/network-wifi.ui.h:29
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+#: ../panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Disabled"
+msgstr "ନିଷ୍କ୍ରିୟ ହୋଇଗଲା"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "ବୈକଳ୍ପିକ ଅକ୍ଷର କି"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "କି ପ୍ରସ୍ତୁତ କରନ୍ତୁ"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "ପରବର୍ତ୍ତୀ ଉତ୍ସକୁ  କେବଳ ପରିବର୍ତ୍ତନକାରୀ ମାନେ ବଦଳାଇ ପାରିବେ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "କି-ବୋର୍ଡ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"କିବୋର୍ଡ ସଂକ୍ଷିପ୍ତ ପଥଗୁଡ଼ିକୁ ଦେଖିକରି ପରିବର୍ତ୍ତନ କରନ୍ତୁ ଏବଂ ଆପଣଙ୍କର ଲେଖିବା "
+"ପସନ୍ଦକୁ ସେଟ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥ;ପୁନରାବୃତ୍ତି;ମିଞ୍ଜି ମିଞ୍ଜି;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥକୁ ଇଚ୍ଛାରୂପଣ କରନ୍ତୁ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr "ଯୋଗ କରନ୍ତୁ (_A)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "ନାମ (_N):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "ନିର୍ଦ୍ଦେଶ (_o):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "କିଗୁଡ଼ିକୁ ପୁନରାବୃତି"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "କି ଦବାଇବା ପୁନରାବୃତ୍ତି ହୁଏ _ୟେବେ କିକୁ ଦବାଇ ଧରି ରଖାୟାଏ ।"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "_ବିଳମ୍ବ:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "_ଗତି:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "ମନ୍ଥର"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "ପୁନରାବୃତ୍ତି କିଗୁଡିକର ଗତି"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "ଲମ୍ବା"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "ଦ୍ରୁତ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "ଦର୍ଶିକାଟି ମିଟିମିଟି କରୁଅଛି"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "ପାଠ୍ୟ କ୍ଷେତ୍ରରେ ସୂଚକ ଦପଦପ ହୋଇଥାଏ (_b)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "ଗତି (_p):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "ସୂଚକ ମିଞ୍ଜି ମିଞ୍ଜି ଗତି"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "ନିବେଶ ଉତ୍ସ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥ ଯୋଗ କରନ୍ତୁ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥ ବାହାର କରନ୍ତୁ"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"ଗୋଟିଏ ସକ୍ଷିପ୍ତ ପଥ କିକୁ ସମ୍ପାଦନ କରିବା ପାଇଁ, ନିମ୍ନଲିଖିତ ଧାଡ଼ି ଉପରେ କ୍ଲିକ କରନ୍ତୁ "
+" ଏବଂ ଗୋଟିଏ ନୂତନ କି-"
+"ଯୁଗଳ ଟାଇପ କରନ୍ତୁ, କିମ୍ବା ସଫାକରିବା ପାଇଁ Backspace ଉପରେ ଦବାନ୍ତୁ।"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥ"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:634
+#: ../panels/keyboard/keyboard-shortcuts.c:642
+msgid "Custom Shortcuts"
+msgstr "ସଂକ୍ଷିପ୍ତ ପଥକୁ ଇଚ୍ଛାରୂପଣ କରନ୍ତୁ"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:859
+msgid "<Unknown Action>"
+msgstr "<ଅଜ୍ଞାତ କାର୍ୟ୍ଯ>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1356
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"ସକ୍ଷିପ୍ତ ପଥ \"%s\" କୁ ବ୍ୟବହାର କରାଯାଇପାରିବ ନାହିଁ କାରଣ ଏହାକୁ ଏହି କି ବ୍ୟବହାର କରି "
+"ଟାଇପ କରିବା "
+"ଅସମ୍ଭବ।\n"
+"ଦୟାକରି ଏକା ସମୟରେ Control, Alt କିମ୍ବା Shift କି ସାହାଯ୍ୟରେ ଚେଷ୍ଟାକରନ୍ତୁ।"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1386
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"ସଂକ୍ଷିପ୍ତ ପଥ \"%s\" ଟି ପୂର୍ବରୁ \n"
+"\"%s\" ପାଇଁ ବ୍ୟବହୃତ ହୋଇଛି"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1391
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"ଯଦି ଆପଣ \"%s\"ରେ ସଂକ୍ଷିପ୍ତ ପଥକୁ ପୁଣିଥରେ ନିର୍ଦ୍ଦିଷ୍ଟ କରନ୍ତି, ତେବେ \"%s\" "
+"ସଂକ୍ଷିପ୍ତ ପଥଟି ନିଷ୍କ୍ରିୟ "
+"ହୋଇଯିବ।"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1397
+msgid "_Reassign"
+msgstr "ପୁଣିଥରେ ନିର୍ଦ୍ଦିଷ୍ଟ କରିବା (_R)"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1429
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"\"%s\" ସଂକ୍ଷିପ୍ତ ପଥରେ ସଂଶ୍ଳିଷ୍ଟ\"%s\" ସଂକ୍ଷିପ୍ତ ପଥ ଥାଏ। ଆପଣ ତାହାକୁ ସ୍ୱୟଂଚାଳିତ "
+"ଭାବରେ \"%s\" ସେଟ କରିବାକୁ ଚାହୁଁଛନ୍ତି କି?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1435
+#, c-format
+#| msgid ""
+#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#| "disabled."
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"\"%s\" ବର୍ତ୍ତମାନ \"%s\" ସହିତ ସଂଶ୍ଳିଷ୍ଟ, ଆପଣ ଆଗକୁ ବଢ଼ିଲେ ଏହି ସଂକ୍ଷିପ୍ତ ପଥଟି "
+"ନିଷ୍କ୍ରିୟ "
+"ହୋଇଯିବ।"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1441
+#| msgid "_Reassign"
+msgid "_Assign"
+msgstr "ନ୍ଯସ୍ତ କରନ୍ତୁ (_A)"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "ଆପଣଙ୍କର ବିନ୍ୟାସଗୁଡ଼ିକୁ ପରୀକ୍ଷା କରନ୍ତୁ (_S)"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+#| msgid "Test Your _Settings"
+msgid "Test Your Settings"
+msgstr "ବିନ୍ୟାସଗୁଡ଼ିକୁ ପରୀକ୍ଷା କରନ୍ତୁ"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "ମାଉସ ଏବଂ ଟଚପ୍ୟାଡ"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"ଆପଣଙ୍କର ମାଉସ ଏବଂ ଟଚପ୍ୟାଡ଼୍‌ ସମ୍ବେଦନଶୀଳତାକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ ଏବଂ ଡ଼ାହାଣ "
+"କିମ୍ବା ବାମ ପାଖକୁ "
+"ବାଛନ୍ତୁ"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#| msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ଟ୍ରାକପ୍ୟାଡ଼;ସୂଚକ;କ୍ଲିକ;ଟ୍ୟାପ;ଦିଗୁଣ;ବଟନ;ଟ୍ରାକବଲ;ସ୍କ୍ରୋଲ୍‌;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "ସାଧାରଣ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "ମନ୍ଥର"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "ଦୁଇଥର ଦବାଇବାର ସମୟ ସମାପ୍ତି"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "ଦ୍ରୁତ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "ଦୁଇଥର କ୍ଲିକ (_D):"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "ପ୍ରାଥମିକ ବଟନ (_b)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "ବାମ (_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "ଡାହାଣ (_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "ମାଉସ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "ସୂଚକ ଗତି (_P)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "ମନ୍ଥର"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "ଦ୍ରୁତ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "ଟଚପ୍ୟାଡ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "ମନ୍ଥର"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "ଦ୍ରୁତ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr "ଟାଇପ କରିବା ସମୟରେ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ (_t)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr "କ୍ଲିକ କରିବା ପାଇଁ ଟ୍ୟାପ (_c)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr "ଦୁଇ-ଅଙ୍ଗୁଳି ଟଣା (_f)"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+#| msgid "_Edge scrolling"
+msgid "_Natural scrolling"
+msgstr "ପ୍ରାକୃତିକ ଧାର ଟଣା (_N)"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "କ୍ଲିକ, ଦୁଇଥର କ୍ଲିକ, ଟାଣିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "ପାଞ୍ଚ ଥର କ୍ଲିକ, GEGL ସମୟ!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "ଦୁଇଥର ଦବାଇବା, ପ୍ରାଥମିକ ବଟନ"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "ଏକ କ୍ଲିକ, ପ୍ରାଥମିକ ବଟନ"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "ଦୁଇଥର କ୍ଲିକ, ମଝି ବଟନ"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "ଏକ କ୍ଲିକ, ମଝି ବଟନ"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "ଦୁଇଥର  କ୍ଲିକ, ଦ୍ୱିତୀୟ ବଟନ"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "ଏକ କ୍ଲିକ, ଦ୍ୱିତୀୟ ବଟନ"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:366
+msgid "Air_plane Mode"
+msgstr "ବିମାନ ଧାରା (_p)"
+
+#: ../panels/network/cc-network-panel.c:965
+msgid "Network proxy"
+msgstr "ନେଟୱର୍କ ପ୍ରକ୍ସି"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1289
+msgid "The system network services are not compatible with this version."
+msgstr "ତନ୍ତ୍ର ନେଟୱର୍କ ସର୍ଭିସଗୁଡ଼ିକ ଏହି ସଂସ୍କରଣ ସହିତ ସୁସଙ୍ଗତ ନୁହଁ।"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x ସୁରକ୍ଷା (_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "ପୃଷ୍ଠା 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "ଅଜଣା ପରିଚୟ (_m)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "ଭିତର ବୈଧିକରଣ (_a)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "ପୃଷ୍ଠା 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Security"
+msgstr "ସୁରକ୍ଷା"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "ସ୍ବୟଂଚାଳିତ"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:217
+#: ../panels/network/net-device-wifi.c:378
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:221
+#: ../panels/network/net-device-wifi.c:383
+#: ../panels/network/network-wifi.ui.h:17
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:225
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:230
+msgid "Enterprise"
+msgstr "ବାଣିଜ୍ୟିକ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:235
+#: ../panels/network/net-device-wifi.c:368
+msgctxt "Wifi security"
+msgid "None"
+msgstr "କିଛି ନାହିଁ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "କଦାପି ନୁହଁ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:819
+msgid "Today"
+msgstr "ଆଜି"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:822
+msgid "Yesterday"
+msgstr "ଗତକାଲି"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:472
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i ଦିନ ପୂର୍ବେ"
+msgstr[1] "%i ଦିନ ପୂର୍ବେ"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:529
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:558
+msgctxt "Signal strength"
+msgid "None"
+msgstr "କିଛି ନାହିଁ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:560
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "ଦୁର୍ବଳ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ଠିକ ଅଛି"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "ଉତ୍ତମ"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "ଅତି ଉତ୍ତମ"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:45
+msgid "Identity"
+msgstr "ପରିଚୟ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "ଠିକଣା"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "ନେଟମାସ୍କ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "ଗେଟୱେ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "ଠିକଣାକୁ ଅପସାରଣ କରନ୍ତୁ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "ଯୋଗ କରନ୍ତୁ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "ସର୍ଭର"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "DNS ସର୍ଭରକୁ ଅପସାରଣ କରନ୍ତୁ"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "ମେଟ୍ରିକ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "ପଥ ଅପସାରଣ କରନ୍ତୁ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:25
+msgid "Automatic (DHCP)"
+msgstr "ସ୍ୱୟଂଚାଳିତ (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:24
+msgid "Manual"
+msgstr "ପୁସ୍ତିକା"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "କେବଳ ସଂଯୋଗ-ସ୍ଥାନୀୟ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:46
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "ଉପସର୍ଗ"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "ସ୍ବୟଂଚାଳିତ"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "ସ୍ୱୟଂଚାଳିତ, କେବଳ DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:47
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:49
+msgid "Reset"
+msgstr "ପୁନଃସ୍ଥାପନ କରନ୍ତୁ"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "କିଛି ନାହିଁ"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-ବିଟ କି (Hex କିମ୍ବା ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-ବିଟ ପ୍ରବେଶ ସଂକେତ"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "ଗତିଜ WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 ବ୍ୟକ୍ତିଗତ"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 ଉଦ୍ଦୋଗ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:2
+msgid "Signal Strength"
+msgstr "ସଂକେତ ଶକ୍ତି"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Link speed"
+msgstr "ସଂଯୋଗ ଗତି"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 ଠିକଣା"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 ଠିକଣା"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:7
+msgid "Hardware Address"
+msgstr "ହାର୍ଡୱେର ଠିକଣା"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:8
+msgid "Default Route"
+msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ପଥ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:9
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "ଶେଷରେ ବ୍ୟବହୃତ"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "ମୋଡିହୋଇଥିବା ଯୁଗଳ (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "ସଂଲଗ୍ନକ ଏକକ ଅନ୍ତରାପୃଷ୍ଠ (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "ମେଡିଆ ନିର୍ଭରଶୀଳ ହୋଇନଥିବା ଅନ୍ତରାପୃଷ୍ଠ (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "ନାମ (_N)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:36
+msgid "_MAC Address"
+msgstr "MAC ଠିକଣା(_M)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "MTU (_T)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "ପ୍ରତିରୂପି ଠିକଣା (_C)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "ବାଇଟଗୁଡିକ"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "ଅନ୍ୟ ବ୍ୟବହାରକାରୀମାନଙ୍କ ପାଇଁ ଉପଲବ୍ଧ କରାନ୍ତୁ (_u)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ସଂଯୁକ୍ତ (_a)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "ଫାୟାରୱାଲ ସ୍ଥାନ (_Z)"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "ଏହି ସ୍ଥାନଟି ସଂଯୋଗର ବିଶ୍ୱାସ ସ୍ତରକୁ ବ୍ୟାଖ୍ୟା କରିଥାଏ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:22
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:23
+msgid "_Addresses"
+msgstr "ଠିକଣା (_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "ସ୍ବୟଂଚାଳିତ DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Routes"
+msgstr "ପଥଗୁଡ଼ିକୁ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "ସ୍ବୟଂଚାଳିତ ପଥଗୁଡ଼ିକ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Use this connection _only for resources on its network"
+msgstr "ଏହି ସଂଯୋଗକୁ କେବଳ ଏହି ନେଟୱର୍କରେ ଥିବା ଉତ୍ସଗୁଡିକ ପାଇଁ ବ୍ୟବହାର କରନ୍ତୁ (_o)"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:34
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "ସଂଯୋଗ ସମ୍ପାଦକଙ୍କୁ ଖୋଲିବାରେ ଅସମର୍ଥ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "ନୂତନ ରୂପରେଖ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "ବନ୍ଧନ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "ଦଳ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "ବ୍ରିଜ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "VPN ପ୍ଲଗଇନଗୁଡ଼ିକୁ ଧାରଣ କରିପାରିଲା ନାହିଁ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "ଫାଇଲରୁ ଆମଦାନୀ କରନ୍ତୁ…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "ନେଟୱର୍କ ସଂଯୋଗ ଯୋଗ କରନ୍ତୁ"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Reset"
+msgstr "ପୁନଃ ସ୍ଥାପନ କରନ୍ତୁ (_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1449
+#: ../panels/network/network-wifi.ui.h:40
+msgid "_Forget"
+msgstr "ଭୁଲିଯାଆନ୍ତୁ (_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"ପ୍ରବେଶ ସଂକେତକୁ ଅନ୍ତର୍ଭୁକ୍ତ କରି ଏହି ନେଟୱର୍କ ପାଇଁ ସେଟିଙ୍ଗକୁ ସେଟକରନ୍ତୁ, କିନ୍ତୁ "
+"ମନେରଖନ୍ତୁ ଯେ ଏହା ଏକ "
+"ପସନ୍ଦଯୋଗ୍ୟ ନେଟୱର୍କ"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"ଏହି ନେଟୱର୍କରୁ ସମସ୍ତ ବିବରଣୀକୁ ବାହାର କରନ୍ତୁ ଏବଂ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ସଂଯୁକ୍ତ କରିବା "
+"ପାଇଁ ଚେଷ୍ଟା "
+"କରନ୍ତୁ"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "S_ecurity"
+msgstr "ସୁରକ୍ଷା (_e)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "VPN ସଂଯୋଗକୁ ଆମଦାନୀ କରାଯାଇପାରିବ ନାହିଁ"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"ଫାଇଲ '%s' କୁ ପଢ଼ିହେଲା ନାହିଁ କିମ୍ବା କୌଣସି ପରିଚିତ VPN ସଂଯୋଗ ସୂଚନା ଧାରଣ କରିନଥାଏ\n"
+"\n"
+"ତ୍ରୁଟି: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "ଆମଦାନୀ ପାଇଁ ଫାଇଲ ଚୟନ କରନ୍ତୁ"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1948
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:223
+msgid "_Open"
+msgstr "ଖୋଲନ୍ତୁ (_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "\"%s\" ନାମକ ଗୋଟିଏ ଫାଇଲ ପୂର୍ବରୁ ଅବସ୍ଥିତ ଅଛି।"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "ବଦଳାନ୍ତୁ (_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "ଆପଣ %s କୁ ଆପଣ ସଂରକ୍ଷଣ କରୁଥିବା VPN ସଂଯୋଗ ସହିତ ବଦଳାଇବାକୁ ଚାହୁଁଛନ୍ତି କି?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "VPN ସଂଯୋଗକୁ ରପ୍ତାନୀ କରାଯାଇପାରିବ ନାହିଁ"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN ସଂଯୋଗ '%s' କୁ %sକୁ ରପ୍ତାନୀ କରାଯାଇପାରିବ ନାହିଁ।\n"
+"\n"
+"ତ୍ରୁଟି: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+#| msgid "Export VPN connection..."
+msgid "Export VPN connection"
+msgstr "VPN ସଂଯୋଗକୁ ରପ୍ତାନୀ କରନ୍ତୁ"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ତ୍ରୁଟି: VPN ସଂଯୋଗ ସମ୍ପାଦକକୁ ଧାରଣ କରିବାରେ ଅସମର୍ଥ)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:12
+msgid "_SSID"
+msgstr "SSID (_S)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:13
+msgid "_BSSID"
+msgstr "BSSID (_B)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:16
+msgid "My Home Network"
+msgstr "ନିଜସ୍ୱ ନେଟୱର୍କ"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "ଅନ୍ୟ ଚାଳକ ମାନଙ୍କ ପାଇଁ ଉପଲବ୍ଧକରାନ୍ତୁ (_o)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "ନେଟୱର୍କ"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "ଇଣ୍ଟରନେଟ ସହିତ କିପରି ସଂଯୁକ୍ତ କରିବେ ତାହା ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
+#| "vpn;vlan;bridge;bond;"
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"ନେଟୱର୍କ;ବେତାର;ୱାଇ-ଫାଇ;ୱାଇଫାଇ;IP;LAN;ପ୍ରକ୍ସି;WAN;ବ୍ରୋଡବ୍ୟାଣ୍ଡ;ମଡେମ;ବ୍ଲୁଟୁଥ;vpn;"
+"vlan;ବ୍ରୀଜ;ବଣ୍ଡ;DNS;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "ବନ୍ଧନ ସ୍ଲେଭ"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(କିଛି ନାହିଁ)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "ବ୍ରିଜ ସ୍ଲେଭ"
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:458
+msgid "never"
+msgstr "କଦାପି ନୁହଁ"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:468
+msgid "today"
+msgstr "ଆଜି"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:470
+msgid "yesterday"
+msgstr "ଗତକାଲି"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP ଠିକଣା"
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Last used"
+msgstr "ଶେଷରେ ବ୍ୟବହୃତ"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "ତାରଯୁକ୍ତ"
+
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1604
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "ବିକଳ୍ପଗୁଡିକ…"
+
+#: ../panels/network/net-device-ethernet.c:474
+#, c-format
+msgid "Profile %d"
+msgstr "ରୂପରେଖା %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "ନୂଆ ସଂଯୋଗ ଯୋଗକରନ୍ତୁ"
+
+#: ../panels/network/net-device-team.c:77
+#| msgid "Bridge slaves"
+msgid "Team slaves"
+msgstr "ଦଳ ସ୍ଲେଭ"
+
+#: ../panels/network/net-device-wifi.c:1153
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"ଯଦି ଆପଣଙ୍କ ପାଖରେ ବେତାର ବ୍ୟତୀତ ଇଣ୍ଟରନେଟ ସହିତ ସଂଯୋଗ ଅଛି, ତେବେ ଆପଣନିଜର "
+"ଇଣ୍ଟରନେଟକୁ ଅନ୍ୟ "
+"ସହିତ ବ୍ୟବହାର କରିପାରିବେ।"
+
+#: ../panels/network/net-device-wifi.c:1157
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+"ବେତାର ହଟସ୍ପଟକୁ ଅନ କରିବା ଫଳରେ ତାହା ଆପଣଙ୍କୁ <b>%s</b> ରୁ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରିବ।"
+
+#: ../panels/network/net-device-wifi.c:1161
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"ହଟସ୍ପଟ ସକ୍ରିୟ ଥିବା ସମୟରେ ବେତାର ସହାୟତାରେ ଇଣ୍ଟରନେଟକୁ ବ୍ୟବହାର କରିବା ସମ୍ଭବ ନୁହଁ।"
+
+#: ../panels/network/net-device-wifi.c:1238
+msgid "Stop hotspot and disconnect any users?"
+msgstr "ହଟସ୍ପଟକୁ ଅଟକାଇ ଏବଂ ଯେକୌଣସି ଚାଳକ ସହିତ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରବେ କି?"
+
+#: ../panels/network/net-device-wifi.c:1241
+msgid "_Stop Hotspot"
+msgstr "ହଟସ୍ପଟକୁ ଅଟକାନ୍ତୁ (_S)"
+
+#: ../panels/network/net-device-wifi.c:1313
+msgid "System policy prohibits use as a Hotspot"
+msgstr "ହଟ୍‌ସ୍ପଟ୍‌ ଭାବରେ ବ୍ୟବହାର କରିବା ପାଇଁ ତନ୍ତ୍ର ନୀତି ବାରଣ କରିଥାଏ"
+
+#: ../panels/network/net-device-wifi.c:1316
+msgid "Wireless device does not support Hotspot mode"
+msgstr "ବେତାର ଉପକରଣ ହଟ୍‌ସ୍ପଟ୍‌ ଧାରାକୁ ସହାୟତା କରିନଥାଏ"
+
+#: ../panels/network/net-device-wifi.c:1445
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"ପ୍ରବେଶ ସଂକେତ ଏବଂ ଯେ କୌଣସି ଇଚ୍ଛାକୃତ ବିନ୍ୟାସକୁ ଅନ୍ତର୍ଭୁକ୍ତ କରି ବଚ୍ଛିତ ନେଟୱର୍କ "
+"ପାଇଁ ନେଟୱର୍କ୍‌ "
+"ବିବରଣୀ ନଷ୍ଟ ହୋଇଯିବ।"
+
+#: ../panels/network/net-device-wifi.c:1753
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "ପୁରୁଣା ତଥ୍ଯ"
+
+#: ../panels/network/net-device-wifi.c:1757
+#: ../panels/wacom/cc-wacom-page.c:533
+msgid "_Close"
+msgstr "ବନ୍ଦ କରନ୍ତୁ (_C)"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1765
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "ଭୁଲିଯାଏ (_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"ୱେବ ପ୍ରୋକ୍ସି ସ୍ୱୟଂଆବିଷ୍କାରକୁ ସଂରଚନା URL ଦିଆଯାଇନଥିବା ସମୟରେ ବ୍ୟବହାର କରାଯାଇଥାଏ।"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "ଏହା ଅବିଶ୍ୱସ୍ତ ସର୍ବସାଧାରଣ ନେଟୱର୍କରେ ପରାମର୍ଶିତ ନୁହଁ।"
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "ପ୍ରକ୍ସି"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "ରୂପରେଖା ଯୋଗ କରନ୍ତୁ (_A)..."
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "ପ୍ରଦାତା"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "କିଛି ନାହିଁ"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "ହସ୍ତ ପୁସ୍ତିକା"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "ସ୍ବୟଂଚାଳିତ"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "ପଦ୍ଧତି (_M)"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "ବିନ୍ୟାସ URL (_C)"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "HTTP ପ୍ରକ୍ସି (_H)"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "HTTPS ପ୍ରକ୍ସି (_T)"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "FTP ପ୍ରୋକ୍ସି (_F)"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "ଶକ୍ସ ହୋଷ୍ଟ (_S)"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "ହୋଷ୍ଟମାନଙ୍କୁ ଅଗ୍ରାହ୍ଯ କରନ୍ତୁ (_I)"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "HTTP ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "HTTPS ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "FTP ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "Socks ପ୍ରକ୍ସି ପୋର୍ଟ୍‌"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "ଉପକରଣକୁ ଅଫ କରନ୍ତୁ"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "ଉପକରଣକୁ ଯୋଗ କରନ୍ତୁ"
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr " ଉପକରଣକୁ କାଢ଼ନ୍ତୁ"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN ପ୍ରକାର"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "ଶ୍ରେଣୀ ନାମ"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "ଶ୍ରେଣୀ ପ୍ରବେଶ ସଂଙ୍କେତ"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "ଚାଳକ ନାମ"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "VPN ସଂଯୋଗକୁ ଅଫ କରନ୍ତୁ"
+
+#: ../panels/network/network-wifi.ui.h:1
+msgid "Automatic _Connect"
+msgstr "ସ୍ୱୟଂଚାଳିତ ସଂଯୋଗ (_C)"
+
+#: ../panels/network/network-wifi.ui.h:11
+msgid "details"
+msgstr "ବିସ୍ତୃତ ବିବରଣୀ"
+
+#: ../panels/network/network-wifi.ui.h:15
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "ପ୍ରବେଶ ସଂଙ୍କେତ (_P)"
+
+#: ../panels/network/network-wifi.ui.h:18
+msgid "None"
+msgstr "କିଛି ନୁହେଁ"
+
+#: ../panels/network/network-wifi.ui.h:19
+msgid "Show P_assword"
+msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦେଖାନ୍ତୁ (_a)"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "Make available to other users"
+msgstr "ଅନ୍ୟ ବ୍ୟବହାରକାରୀଙ୍କ ପାଇଁ ଉପଲବ୍ଧ କରାନ୍ତୁ"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "identity"
+msgstr "ପରିଚୟ"
+
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Automatic (DHCP) addresses only"
+msgstr "କେବଳ ସ୍ୱୟଂଚାଳିତ (DHCP) ଠିକଣାଗୁଡ଼ିକ"
+
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Link-local only"
+msgstr "କେବଳ ସଂଯୋଗ-ସ୍ଥାନୀୟ"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Shared with other computers"
+msgstr "ଅନ୍ୟ କମ୍ପୁଟର ସହିତ ସହଭାଗ କରାଯାଇଛି"
+
+#: ../panels/network/network-wifi.ui.h:31
+msgid "_Ignore automatically obtained routes"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ମିଳିଥିବା ପଥକୁ ଅଗ୍ରାହ୍ୟ କରନ୍ତୁ (_I)"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "_Cloned MAC Address"
+msgstr "ପ୍ରତିରୂପି MAC ଠିକଣା (_C)"
+
+#: ../panels/network/network-wifi.ui.h:38
+msgid "hardware"
+msgstr "ହାର୍ଡୱେର"
+
+#: ../panels/network/network-wifi.ui.h:41
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"ଏହି ସଂଯୋଗ ପାଇଁ ସେଟିଙ୍ଗକୁ ପୂର୍ବନିର୍ଦ୍ଧାରିତ ଭାବରେ ସେଟ କରନ୍ତୁ, କିନ୍ତୁ "
+"ପସନ୍ଦମୁତାବକ ସଂଯୋଗ ଭାବରେ "
+"ମନେରଖନ୍ତୁ।"
+
+#: ../panels/network/network-wifi.ui.h:42
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"ଏହି ନେଟୱର୍କ ପାଇଁ ସମସ୍ତ ବିବରଣୀକୁ ବାହାର କରନ୍ତୁ ଏବଂ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଏହା ସହିତ "
+"ସଂଯୋଗ କରିବା "
+"ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid "reset"
+msgstr "ପୁନଃସ୍ଥାପନ କରନ୍ତୁ"
+
+#: ../panels/network/network-wifi.ui.h:48
+msgid "Hardware"
+msgstr "ହାର୍ଡୱେର"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi ହଟସ୍ପଟ"
+
+#: ../panels/network/network-wifi.ui.h:51
+msgid "_Turn On"
+msgstr "ଅନ କରନ୍ତୁ (_T)"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi କୁ ଅଫ କରନ୍ତୁ"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "_Use as Hotspot…"
+msgstr "ହଟସ୍ପଟ ପରି ବ୍ୟବହାର କରନ୍ତୁ (_U)…"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "_Connect to Hidden Network…"
+msgstr "ଲୁକ୍କାଇତ ନେଟୱର୍କ ସହିତ ସଂଯୁକ୍ତ ହୁଅନ୍ତୁ (_C)…"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_History"
+msgstr "ପୁରୁଣା ତଥ୍ୟ (_H)"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Wi-Fi ନେଟୱର୍କ ସହିତ ସଂଯୋଗ କରିବା ପାଇଁ ଅଫ କରନ୍ତୁ"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "Network Name"
+msgstr "ନେଟୱାର୍କ ନାମ"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Connected Devices"
+msgstr "ସଂଯୁକ୍ତ ଉପକରଣଗୁଡ଼ିକ"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Security type"
+msgstr "ସୁରକ୍ଷା ପ୍ରକାର"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Security key"
+msgstr "ସୁରକ୍ଷା କି"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "ଏଡ-ହକ"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "ଅବସଂରଚନା"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "ସ୍ଥିତି ଅଜଣା"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "ଅପରିଚାଳିତ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "ଉପଲବ୍ଧନାହିଁ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "ସଂଯୋଗ କରୁଅଛି"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "ବୈଧିକରଣ ଆବଶ୍ଯକ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "ସଂଯୋଗିତ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରୁଅଛି"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "ସଂୟୋଗ ଅସଫଳ ହେଲା"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "ସ୍ଥିତି ଅଜଣା (ଅନୁପସ୍ଥିତ)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "ସଂଯୋଜିତ ହୋଇ ନାହିଁ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "ବିନ୍ୟାସ ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "IP ସଂରଚନା ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "IP ସଂରଚନା ସମୟ ସମାପ୍ତି ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "ଗୁପ୍ତ ତଥ୍ୟ ଆବଶ୍ୟକ, କିନ୍ତୁ ଦିଆଯାଇ ନାହିଁ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x supplicant ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x supplicant ସଂରଚନା ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1x supplicant ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant ବୈଧକରଣ କରିବା ପାଇଁ ଅଧିକ ସମୟ ନେଉଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "PPP ସର୍ଭିସ ଆରମ୍ଭ ହେବାରେ ବିଫଳ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "PPP ସର୍ଭିସ ବିଛିନ୍ନହୋଇଥିବା"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "DHCP କ୍ଲାଏଣ୍ଟ ଆରମ୍ଭ ହେବାରେ ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP କ୍ଲାଏଣ୍ଟ ତ୍ରୁଟି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP କ୍ଲାଏଣ୍ଟ ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "ସହଭାଗୀ ସଂଯୋଗ ଆରମ୍ଭ ହେବାରେ ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "ସହଭାଗୀ ସଂଯୋଗ ସର୍ଭିସ ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "AutoIP ସର୍ଭିସ ଆରମ୍ଭ ହେବାରେ ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "AutoIP ସର୍ଭିସ ତ୍ରୁଟି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "AutoIP ସର୍ଭିସ ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "ଲାଇନ ବ୍ୟସ୍ତ ଅଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "ଡ଼ାଏଲଟନ ନାହିଁ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "କୌଣସି ସମ୍ପର୍କ ସ୍ଥାପନ ହୋଇପାରିବ ନାହିଁ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "ଡ଼ାଏଲ କରିବା ସମୟ ସମାପ୍ତି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "ଡ଼ାଏଲ ପ୍ରୟାସ ବିଫଳ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "ମଡେମ ପ୍ରାରମ୍ଭିକରଣ ବିଫଳ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "ନିର୍ଦ୍ଦିଷ୍ଟ APN ବାଛିବାରେ ବିଫଳ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "ନେଟୱର୍କ ସନ୍ଧାନ କରୁ ନାହିଁ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "ନେଟୱର୍କ ପଞ୍ଜିକରଣ ବାରଣ ହୋଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "ନେଟୱର୍କ ପଞ୍ଜିକରଣ ସମୟ ସମାପ୍ତି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "ଅନୁରୋଧ କରାଯାଇଥିବା ନେଟୱର୍କ ସହିତ ପଞ୍ଜିକରଣ କରିବାରେ ବିଫଳ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "PIN ଯାଞ୍ଚ ବିଫଳ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "ଉପକରଣ ପାଇଁ ଫର୍ମୱେର ଅନୁପସ୍ଥିତ ଅଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "ସଂଯୋଗ ଅଦୃଶ୍ୟ ହୋଇଯାଇଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "ସ୍ଥିତବାନ ସଂଯୋଗକୁ ଅନୁମାନ କରାଯାଉଛି"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "ମଡେମ ମିଳିଲା ନାହିଁ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "ବ୍ଲୁଟୁଥ ସଂୟୋଗ ବିଫଳ ହେଲା"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "SIM କାର୍ଡ ଭର୍ତ୍ତି କରାଯାଇ ନାହିଁ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "SIM ପିନ ଆବଶ୍ୟକ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "SIM Puk ଆବଶ୍ୟକ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "ଭୁଲ SIM"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "InfiniBand ଉପକରଣ ସଂଯୁକ୍ତ ଧାରାକୁ ସହାୟତା କରିନଥାଏ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "ସଂଯୋଗ ନିର୍ଭୋରୋକ ବିଫଳ ହୋଇଛି"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "ଫର୍ମୱେର ଅନୁପସ୍ଥିତ ଅଛି"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "କେବଲ ଲାଗିନାହିଁ"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "କୌଣସି ପ୍ରମାଣପତ୍ର ପ୍ରାଧିକାରୀ ପ୍ରମାଣପତ୍ର ବଛାହୋଇନାହିଁ"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"ଗୋଟିଏ ପ୍ରମାଣପତ୍ର ପ୍ରାଧିକାରୀ (CA) ପ୍ରମାଣପତ୍ରକୁ ବ୍ୟବହାର ନକରିବା ଫଳରେ ସଂଯୋଗଟି "
+"ଅସୁରକ୍ଷିତ "
+"ହୋଇପାରେ, Wi-Fi ନେଟୱର୍କଗୁଡ଼ିକୁ ଅଜ୍ଞାନ କରିପାରେ।  ଆପଣ ଗୋଟିଏ ପ୍ରମାଣପତ୍ର "
+"ପ୍ରାଧିକାରୀ ପ୍ରମାଣପତ୍ରକୁ "
+"ବାଛିବା ପାଇଁ ଚାହୁଁଛନ୍ତି କି?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "ଆଗ୍ରହ୍ଯ କରିଦିଅନ୍ତୁ"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "CA ପ୍ରମାଣପତ୍ର ବାଛନ୍ତୁ"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, କିମ୍ବା PKCS#12 ବ୍ୟକ୍ତିଗତ କିଗୁଡ଼ିକ (*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER କିମ୍ବା PEM ପ୍ରମାଣପତ୍ରଗୁଡ଼ିକ (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+#| msgid "Choose a PAC file..."
+msgid "Choose a PAC file"
+msgstr "ଗୋଟିଏ PAC ଫାଇଲ ବାଛନ୍ତୁ"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC ଫାଇଲଗୁଡ଼ିକ (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC ଫାଇଲଗୁଡ଼ିକ  (_f)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "ଭିତର ବୈଧିକରଣ (_I)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "PAC ସୁବିଧା (_v)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "ଅଜ୍ଞାତ"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "ବୈଧିକୃତ"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "ଉଭୟ"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "ଚାଳକ ନାମ (_U)"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦର୍ଶାନ୍ତୁ (_w)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+#| msgid "Choose a Certificate Authority certificate..."
+msgid "Choose a Certificate Authority certificate"
+msgstr "ଗୋଟିଏ ପ୍ରମାଣପତ୍ର ଅଧିକାରୀ ପ୍ରମାଣପତ୍ର ବାଛନ୍ତୁ"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "ସଂସ୍କରଣ 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "ସଂସ୍କରଣ 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "CA ପ୍ରମାଣ ପତ୍ର (_A)"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP ସଂସ୍କରଣ (_v)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "ପ୍ରତ୍ୟେକ ଥର ଏହି ପ୍ରବେଶ ସଂକେତକୁ ପଚାରନ୍ତୁ (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "ଅସଂଗୁପ୍ତ ବ୍ୟକ୍ତିଗତ କିଗୁଡ଼ିକ ଅସୁରକ୍ଷିତ ଅଟେ"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"ବଚ୍ଛିତ ବ୍ୟକ୍ତିଗତ କି ପ୍ରବେଶ ସଂକେତ ଦ୍ୱାରା ସୁରକ୍ଷିତ ଥିବା ପରି ଦୃଶ୍ୟମାନ "
+"ହେଉନାହିଁ।ଏହା ଆପଣଙ୍କର ସୁରକ୍ଷା "
+"ପ୍ରମାଣପତ୍ରଗୁଡ଼ିକୁ ସଙ୍କଟରେ ପକାଇବା ପାଇଁ ଅନୁମତି ଦେଇଥାଏ।  ଦୟାକରି ଗୋଟିଏ ପ୍ରବେଶ "
+"ସଂକେତ-ସୁରକ୍ଷିତ "
+"ବ୍ୟକ୍ତିଗତ କି ବାଛନ୍ତୁ।\n"
+"\n"
+"(ଆପଣ ଆପମଙ୍କର ବ୍ୟକିତଗତ କିକୁ openssl ଦ୍ୱାରା ପ୍ରବେଶ ସଂକେତ-ପ୍ରତିରୋଧିତ କରିପାରିବେ)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+#| msgid "Choose your personal certificate..."
+msgid "Choose your personal certificate"
+msgstr "ଆପଣଙ୍କର ବ୍ୟକ୍ତିଗତ ପ୍ରମାଣପତ୍ରକୁ ବାଛନ୍ତୁ"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+#| msgid "Choose your private key..."
+msgid "Choose your private key"
+msgstr "ଆପଣଙ୍କର ବ୍ୟକ୍ତିଗତ କିକୁ ବାଛନ୍ତୁ"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "ପରିଚୟ (_d)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "ଚାଳକ ପ୍ରମାଣପତ୍ର (_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "ବ୍ୟକ୍ତିଗତ କି (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "ବ୍ୟକ୍ତିଗତ କି ପ୍ରବେଶ ସଂକେତ (_P)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "ମୋତେ ପୁଣିଥରେ ଚେତାବନୀ ଦିଅନ୍ତୁ ନାହିଁ (_w)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "ନାହିଁ"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "ହଁ"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "କ୍ଷୀପ୍ର"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "ଟନେଲଯୁକ୍ତ TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "ସୁରକ୍ଷିତ EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "ବୈଧିକରଣ (_t)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "ଖୋଲା ତନ୍ତ୍ର"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "ସହଭାଗୀ କି"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "କି (_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "କି ଦର୍ଶାନ୍ତୁ (_w)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP ଅନୁକ୍ରମଣିକା (_x)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "ପ୍ରକାର (_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "ଧ୍ବନୀ ସତର୍କ ସୂଚନା"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "ପପ୍‌ଅପ୍‌ ବ୍ୟାନେର ଦର୍ଶାନ୍ତୁ"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "ବ୍ୟାନେରଗୁଡ଼ିକରେ ବିସ୍ତୃତ ବିବରଣୀ ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "ତାଲା ଲାଗିଥିବା ପରଦାରେ ଦେଖନ୍ତୁ"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "ତାଲା ପରଦାରେ ବିସ୍ତୃତ ବିବରଣୀ ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "ଅନ"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+"କେଉଁ ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକୁ ଦର୍ଶାଯିବ ଏବଂ ତାହା କଣ ଦର୍ଶାଇଥାଏ ତାହାକୁ ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "ବିଜ୍ଞପ୍ତିଗୁଡ଼ିକ;ବ୍ୟାନେର;ସନ୍ଦେଶ;ଟ୍ରେ;ପପଅପ୍‌;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "ପପଅପ୍‌ ବ୍ୟାନେରଗୁଡ଼ିକୁ ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "ତାଲା ପରଦାରେ ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+#| msgid "Other"
+msgctxt "Online Account"
+msgid "Other"
+msgstr "ଅନ୍ଯାନ୍ଯ"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "ଖାତା ଯୋଗ କରନ୍ତୁ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr "ମେଲ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr "ସମ୍ପର୍କଗୁଡ଼ିକ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "ବାର୍ତ୍ତାଳାପ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "ଉତ୍ସଗୁଡ଼ିକ"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "ଖାତାରେ ଲଗଇନ କରିବାରେ ତ୍ରୁଟି"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "ଅଧିକାର ସମାପ୍ତ ହୋଇଛି।"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr "ଏହି ଖାତାକୁ ସକ୍ରିୟ କରିବା ପାଇଁ ସାଇନ୍‌ ଇନ୍‌ କରନ୍ତୁ।"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr "ସାଇନ୍‌ ଇନ୍‌ (_S)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "ଖାତା ନିର୍ମାଣ କରିବାରେ ତ୍ରୁଟି"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "ଖାତା ବାହାର କରିବାରେ ତ୍ରୁଟି"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "ଏହି ଖାତାକୁ ଅପସାରଣ କରିବାକୁ ଚାହୁଁଛନ୍ତି ବୋଲି ଆପଣ ନିଶ୍ଚିତ କି?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "ଏହା ସର୍ଭରରେ ସେହି ଖାତାକୁ ଅପସାରଣ କରିବ ନାହିଁ।"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "ଅପସାରଣ କରନ୍ତୁ (_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "ଅନଲାଇନ ଖାତାଗୁଡ଼ିକ"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"ଆପମଙ୍କର ଅନ୍‌ଲାଇନ୍‌ ଖାତା ସହିତ ସଂଯୋଗ କରନ୍ତୁ ଏବଂ ତାହାକୁ କଣ ପାଇଁ ବ୍ୟବହାର କରାଯିବ "
+"ତାହା ସିଦ୍ଧାନ୍ତ "
+"କରନ୍ତୁ"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+#| "ownCloud;"
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;ୱେବ;ଅନଲାଇନ;ଚାର୍ଟ;କ୍ୟାଲେଣ୍ଡର;ମେଲ;ସମ୍ପର୍କ;ownCloud"
+";"
+"କର୍ବୋରସ୍‌;IMAP;SMTP;ପକେଟ;ଏହାକୁ ପରେ ପଢ଼ନ୍ତୁ;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "କୌଣସି ଅନଲାଇନ ଖାତାଗୁଡ଼ିକ ବିନ୍ୟାସିତ ହୋଇନାହିଁ"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "ଖାତାକୁ ବାହାର କରନ୍ତୁ"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "ଏକ ଅନଲାଇନ ଖାତା ଯୋଗ କରନ୍ତୁ"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"ଏକ ଖାତା ଯୋଗ କିରବା ଫଳରେ ତାହା ଆପଣଙ୍କୁ ଦଲିଲ, ମେଲ, ସମ୍ପର୍କ, କ୍ୟାଲେଣ୍ଡର, ଚାଟ ଏବଂ "
+"ଆହୁରି ଅନେକ "
+"ପ୍ରୟୋଗ ପାଇଁ ଅନୁମତି ଦେଇଥାଏ।"
+
+#: ../panels/power/cc-power-panel.c:183
+msgid "Unknown time"
+msgstr "ଅଜଣା ସମୟ"
+
+#: ../panels/power/cc-power-panel.c:189
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%iମିନିଟ"
+msgstr[1] "%i ମିନଟ"
+
+#: ../panels/power/cc-power-panel.c:201
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ଘଣ୍ଟା"
+msgstr[1] "%i ଘଣ୍ଟା"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:209
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:210
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ଘଣ୍ଟା"
+msgstr[1] "ଘଣ୍ଟା"
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "ମିନିଟ"
+msgstr[1] "ମିନିଟ"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:230
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହେବା ପର୍ଯ୍ୟନ୍ତ"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:237
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "ବିପଦ: %s ବଳିଅଛି"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:242
+#, c-format
+msgid "%s remaining"
+msgstr "%s ବଳିଅଛି"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
+msgid "Fully charged"
+msgstr "ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହୋଇଛି"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
+msgid "Empty"
+msgstr "ଖାଲି"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Charging"
+msgstr "ଚାର୍ଜ ହେଉଛି"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:271
+msgid "Discharging"
+msgstr "ଚାର୍ଜ କମୁଅଛି"
+
+#: ../panels/power/cc-power-panel.c:396
+msgctxt "Battery name"
+msgid "Main"
+msgstr "ମୂଖ୍ଯ"
+
+#: ../panels/power/cc-power-panel.c:398
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "ବଳକା"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:470
+msgid "Wireless mouse"
+msgstr "ବେତାର ମାଉସ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:473
+msgid "Wireless keyboard"
+msgstr "ବେତାର କିବୋର୍ଡ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:476
+msgid "Uninterruptible power supply"
+msgstr "ବାଧାପ୍ରାପ୍ତ ହୋଇନଥିବା ବିଦ୍ୟୁତ ସେବା"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Personal digital assistant"
+msgstr "ବ୍ୟକ୍ତିଗତ ଡିଜିଟାଲ ସହାୟତା"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Cellphone"
+msgstr "ସେଲଫୋନ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Media player"
+msgstr "ମେଡ଼ିଆ ଚାଲକ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Tablet"
+msgstr "ଟ୍ୟାବଲେଟ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Computer"
+msgstr "କମ୍ପୁଟର"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
+#: ../panels/power/cc-power-panel.c:2019
+msgid "Battery"
+msgstr "ବ୍ଯାଟେରୀ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "ଚାର୍ଜ ହେଉଛି"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "ସତର୍କତା"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Low"
+msgstr "ନିମ୍ନ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Good"
+msgstr "ଉତ୍ତମ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହୋଇଛି"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "ଖାଲି"
+
+#: ../panels/power/cc-power-panel.c:715
+msgid "Batteries"
+msgstr "ବ୍ଯାଟେରୀ"
+
+#: ../panels/power/cc-power-panel.c:1117
+msgid "When _idle"
+msgstr "ନିଷ୍କ୍ରିୟ ଥିବା ସମୟରେ (_i)"
+
+#: ../panels/power/cc-power-panel.c:1445
+msgid "Power Saving"
+msgstr "ଶକ୍ତି ସଂରକ୍ଷଣ"
+
+#: ../panels/power/cc-power-panel.c:1473
+#| msgid "_Screen Brightness"
+msgid "_Screen brightness"
+msgstr "ପରଦା ଉଜ୍ଜ୍ବଳତା (_S)"
+
+#: ../panels/power/cc-power-panel.c:1479
+#| msgid "Keyboard Preferences"
+msgid "_Keyboard brightness"
+msgstr "କିବୋର୍ଡ ଉଜ୍ଜ୍ୱଳତା (_K)"
+
+#: ../panels/power/cc-power-panel.c:1489
+#| msgid "_Dim Screen when Inactive"
+msgid "_Dim screen when inactive"
+msgstr "ନିଷ୍କ୍ରିୟ ଥିବା ସମୟରେ ପରଦା ଉଜ୍ଜ୍ୱଳତାକୁ କମ କରନ୍ତୁ (_D)"
+
+#: ../panels/power/cc-power-panel.c:1514
+#| msgid "_Blank Screen"
+msgid "_Blank screen"
+msgstr "ଖାଲି ପରଦା (_B)"
+
+#: ../panels/power/cc-power-panel.c:1551
+msgid "_Wi-Fi"
+msgstr "Wi-Fi (_W)"
+
+#: ../panels/power/cc-power-panel.c:1556
+msgid "Turns off wireless devices"
+msgstr "ବେତାର ଉପକରଣଗୁଡ଼ିକୁ ଅଫ୍‌ କରନ୍ତୁ"
+
+#: ../panels/power/cc-power-panel.c:1581
+#| msgid "_Mobile Broadband"
+msgid "_Mobile broadband"
+msgstr "ମୋବାଇଲ ବ୍ରୋଡ଼ବ୍ୟାଣ୍ଡ (_M)"
+
+#: ../panels/power/cc-power-panel.c:1586
+#| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "ମୋବାଇଲ ବ୍ରୋଡ଼ବ୍ୟାଣ୍ଡ (3G, 4G, WiMax, ଇତ୍ୟାଦି) ଉପକରଣଗୁଡ଼ିକୁ ଅଫ୍‌ କରନ୍ତୁ"
+
+#: ../panels/power/cc-power-panel.c:1635
+msgid "_Bluetooth"
+msgstr "ବ୍ଲୁଟୁଥ (_B)"
+
+#: ../panels/power/cc-power-panel.c:1686
+msgid "When on battery power"
+msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତିରେ ଚାଲୁଥିବା ସମୟରେ"
+
+#: ../panels/power/cc-power-panel.c:1688
+msgid "When plugged in"
+msgstr "ପ୍ଲଗଇନ ହୋଇଥିବା ସମୟରେ"
+
+#: ../panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Off"
+msgstr "ନିଲମ୍ବିତ କରନ୍ତୁ ଏବଂ ବିଦ୍ୟୁତ ପ୍ରବାହ ବନ୍ଦ କରନ୍ତୁ"
+
+#: ../panels/power/cc-power-panel.c:1851
+#| msgid "_Automatic Suspend"
+msgid "_Automatic suspend"
+msgstr "ସ୍ବୟଂଚାଳିତ ନିଲମ୍ବନ (_A)"
+
+#: ../panels/power/cc-power-panel.c:1875
+#| msgid "When Battery Power is _Critical"
+msgid "When battery power is _critical"
+msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତି ଅତି କମ ଥିବା ସମୟରେ (_c)"
+
+#: ../panels/power/cc-power-panel.c:1930
+msgid "Power Off"
+msgstr "ବିଦ୍ୟୁତ ପ୍ରବାହ ବନ୍ଦ କରନ୍ତୁ"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Devices"
+msgstr "ଉପକରଣଗୁଡ଼ିକ"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "ଶକ୍ତି"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"ଆପଣଙ୍କର ବ୍ୟାଟେରୀ ଶକ୍ତି ଦେଖନ୍ତୁ ଏବଂ ଶକ୍ତି ସଂରକ୍ଷଣ ସଂରଚନାକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"ଶକ୍ତି;ସୁପ୍ତ;ନିଲମ୍ବିତ;ହାଇବରନେଟ;ବ୍ୟାଟେରୀ;ଉଜ୍ଜ୍ୱଳତା;ଡ଼ିମ;ଖାଲି;ମନିଟର;DPMS;ନିଷ୍କ୍ରି"
+"ୟ;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "ବିଦ୍ୟୁତ ଶକ୍ତି ବନ୍ଦ କରନ୍ତୁ"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "45 ମିନିଟ"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 ଘଣ୍ଟା"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "80 ମିନିଟ"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "90 ମିନିଟ"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "100 ମିନିଟ"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "2 ଘଣ୍ଟା"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 ମିନଟ"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 ମିନିଟଗୁଡିକ"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 ମିନିଟଗୁଡିକ"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "4 ମିନିଟ"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 ମିନିଟ"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "8 ମିନିଟ"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 ମିନିଟ"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "12 ମିନିଟ"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "ସ୍ବୟଂଚାଳିତ ନିଲମ୍ବନ"
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr "ପ୍ଲଗଇନ ହୋଇଛି (_P)"
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତିରେ ଚାଲୁଛି (_B)"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "ବିଳମ୍ବ"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "ବୈଧିକୃତ"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "ପ୍ରବେଶ ସଙ୍କେତ"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "ବୈଧିକରଣ ଆବଶ୍ୟକ"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr "ଟୋନର କମ ଅଛି"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr "ଟୋନର ସରିଯାଇଛି"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr "ବିକାଶକାରୀ କମ ଅଛି"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr "ବିକାଶକାରୀ ସରିଯାଇଛି"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr "ଚିହ୍ନଟ ସାମଗ୍ରୀର କମ ଅଛି"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr "ଚିହ୍ନଟ ସାମଗ୍ରୀର ଅଭାବ ଅଛି"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr "ଆବରଣ ଖୋଲନ୍ତୁ"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr "ଦ୍ୱାର ଖୋଲନ୍ତୁ"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr "କାଗଜ କମ ଅଛି"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr "କାଗଜ ସରିଯାଇଛି"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ଅଫଲାଇନ"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "ଅଟକିଛି"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr "ଆବର୍ଜନା ପାତ୍ର ପ୍ରାୟତଃ ପୁରଣ ହୋଇଛି"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr "ଆବର୍ଜନା ପାତ୍ର ପୁରଣ ଅଛି"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr "ଅପଟିକାଲ ଫୋଟୋ କଣ୍ଡକଟରର ସମୟ ସମାପ୍ତ ହେବାକୁ ଯାଉଛି"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ଅପଟିକାଲ ଫୋଟୋ କଣ୍ଡକଟର ବର୍ତ୍ତମାନ କାମ କରୁନାହିଁ"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "ବିନ୍ୟାସ  କରୁଅଛି"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr "ପ୍ରସ୍ତୁତ"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "କାର୍ଯ୍ଯଗୁଡ଼ିକୁ ଗ୍ରହଣ କରିନଥାଏ"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr "କାର୍ଯ୍ୟକାରୀ କରୁଅଛି"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Toner Level"
+msgstr "ଟୋନର ସ୍ତର"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Ink Level"
+msgstr "କାଳି ସ୍ତର"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:928
+msgid "Supply Level"
+msgstr "ସାମଗ୍ରୀ ସ୍ତର"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:946
+msgctxt "printer state"
+msgid "Installing"
+msgstr "ସ୍ଥାପନ କରୁଅଛି"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1123
+msgid "No printers available"
+msgstr "କୌଣସି ମୁଦ୍ରଣୀ ଉପଲବ୍ଧ ନାହିଁ"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1433
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u ସକ୍ରିୟ"
+msgstr[1] "%u ସକ୍ରିୟ"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1777
+msgid "Failed to add new printer."
+msgstr "ନୂତନ ମୁଦ୍ରଣୀ ଯୋଗକରିବାରେ ବିଫଳ।"
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid "Select PPD File"
+msgstr "PPD ଫାଇଲ ବାଛନ୍ତୁ"
+
+#: ../panels/printers/cc-printers-panel.c:1953
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"ପୋଷ୍ଟସ୍କ୍ରିପ୍ଟ ମୁଦ୍ରଣୀ ବର୍ଣ୍ଣନା ଫାଇଲ୍ ଗୁଡାକ (*.ppd, *.PPD, *.ppd.gz, "
+"*.PPD.gz, *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2258
+msgid "No suitable driver found"
+msgstr "କୌଣସି  ଉପଯୁକ୍ତ ଡ୍ରାଇଭର ମିଳିଲା ନାହିଁ"
+
+#: ../panels/printers/cc-printers-panel.c:2327
+msgid "Searching for preferred drivers…"
+msgstr "ପସନ୍ଦ ଯୋଗ୍ୟ ଡ୍ରାଇଭର ଖୋଜୁଅଛି …"
+
+#: ../panels/printers/cc-printers-panel.c:2342
+msgid "Select from database…"
+msgstr "ତଥ୍ୟାଧାରରୁ ବାଛନ୍ତୁ …"
+
+#: ../panels/printers/cc-printers-panel.c:2351
+msgid "Provide PPD File…"
+msgstr "PPD ଫାଇଲ ପ୍ରଦାନ କରନ୍ତୁ…"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2502
+#: ../panels/printers/cc-printers-panel.c:2525
+msgid "Test page"
+msgstr "ପରୀକ୍ଷା ପୃଷ୍ଠା"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2933
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui କୁ ଧାରଣ କରିପାରିଲା ନାହିଁ : %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "ମୂଦ୍ରଣୀଗୁଡ଼ିକ"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"ମୁଦ୍ରଣୀ ଯୋଗ କରନ୍ତୁ, ମୁଦ୍ରଣୀ କାର୍ଯ୍ୟଗୁଡ଼ିକୁ ଦେଖନ୍ତୁ ଏବଂ ଆପଣ କିପରି ମୁଦ୍ରଣ କରିବେ "
+"ତାହା ସିଦ୍ଧାନ୍ତ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "ମୁଦ୍ରଣୀ;କ୍ରମ;ମୁଦ୍ରଣ କରନ୍ତୁ;କାଗଜ;କାଳି;ଟୋନର;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "ସକ୍ରିୟ କାର୍ଯ୍ୟଗୁଡ଼ିକ"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "ବନ୍ଦକରନ୍ତୁ"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "ମୁଦ୍ରଣ କାର୍ଯ୍ୟକୁ ପୁଣି ଚାଲୁ କରନ୍ତୁ"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "ମୁଦ୍ରଣ କାର୍ଯ୍ୟକୁ ବିରତି ଦିଅନ୍ତୁ"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "ମୁଦ୍ରଣୀ କାର୍ଯ୍ୟକୁ ବାତିଲ କରନ୍ତୁ"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "ନୂତନ ମୁଦ୍ରଣୀ ଯୋଗ କରନ୍ତୁ"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+#| msgid "Authenticate"
+msgid "A_uthenticate"
+msgstr "ବୈଧିକୃତ କରନ୍ତୁ (_u)"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "କୌଣସି ମୁଦ୍ରଣୀ ଚିହ୍ନା ହୋଇନାହିଁ।"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+#| msgid "Search for network printers or filter result"
+msgid "Enter address of a printer or a text to filter results"
+msgstr "ଫଳାଫଳଗୁଡ଼ିକୁ ବାଛିବା ପାଇଁ ମୁଦ୍ରଣୀର ଠିକଣା ଅଥବା ପାଠ୍ୟ ଦିଅନ୍ତୁ"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "ବିକଳ୍ପଗୁଡିକୁ ଧାରଣ କରୁଅଛି …"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "ମୁଦ୍ରଣୀ ଡ୍ରାଇଭର ବାଛନ୍ତୁ"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "ଡ୍ରାଇଭର ତଥ୍ୟାଧାର ଧାରଣ କରୁଅଛି ..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+#| msgid "Remove Printer"
+msgid "JetDirect Printer"
+msgstr "JetDirect ମୁଦ୍ରଣୀ"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+#| msgid "%s Printer"
+msgid "LPD Printer"
+msgstr "LPD ମୁଦ୍ରଣୀ"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "ଗୋଟିଏ ପାଖ"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "ବୃହତ ଧାର (ମାନକ)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "ସଂକ୍ଷିପ୍ତ ଧାର (ଫ୍ଲିପ)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "ଚିତ୍ରପଟ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "କଡ଼ୁଆ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "ଓଲଟା ଭୂ-ଦୃଶ୍ଯ"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "ଓଲଟା ଚିତ୍ରପଟ"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "ବାକି ଅଛି"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "ଅଟକା ଯାଇଛି"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "କାର୍ଯ୍ୟକାରୀ କରୁଅଛି"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "ଅଟକିଛି"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "ବାତିଲ କରାଯାଇଛି"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "ପରିତ୍ଯାଗ କରାଯାଇଛି"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "ସମାପ୍ତ"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "କାମ ଶୀର୍ଷକ"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "କାର୍ଯ୍ୟ ସ୍ଥିତି"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "ସମୟ"
+
+#: ../panels/printers/pp-jobs-dialog.c:495
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s ସକ୍ରିୟ କାର୍ଯ୍ୟଗୁଡ଼ିକ"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Serial Port"
+msgstr "କ୍ରମିକ ପୋର୍ଟ"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1683
+msgid "Parallel Port"
+msgstr "ସମାନ୍ତରାଳ ପୋର୍ଟ"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+#| msgid "Location"
+msgid "Location: %s"
+msgstr "ଅବସ୍ଥାନ: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1744
+#, c-format
+#| msgid "A_ddress:"
+msgid "Address: %s"
+msgstr "ଠିକଣା: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1768
+#| msgid "_Inner authentication"
+msgid "Server requires authentication"
+msgstr "ସର୍ଭର ବୈଧିକରଣ ଆବଶ୍ୟକ କରିଥାଏ"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "ଉଭୟ ପାର୍ଶ୍ବ"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "କାଗଜର ପ୍ରକାର"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "କାଗଜ ଉତ୍ସ"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "ନିର୍ଗମ ଟ୍ରେ"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript ପ୍ରାକ-ଛଣା"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:531
+msgid "Pages per side"
+msgstr "ପ୍ରତ୍ଯେକ ପାର୍ଶ୍ବରେ ପୃଷ୍ଠା ସଂଖ୍ଯା"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:543
+msgid "Two-sided"
+msgstr "ଉଭୟ ପାର୍ଶ୍ବ"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:555
+msgid "Orientation"
+msgstr "ଆବର୍ତ୍ତନ"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:652
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "ସାଧାରଣ"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "ପୃଷ୍ଠା ବ୍ଯବସ୍ଥା"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "ସ୍ଥାପନ ଯୋଗ୍ଯ ବିକଳ୍ପ"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "କାର୍ଯ୍ଯ"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "ପ୍ରତିଛବି ଗୁଣବତ୍ତା"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "ରଙ୍ଗ"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "ସମ୍ପନ୍ନ କରୁଅଛି"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "ଉନ୍ନତ"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "ସ୍ବତଃ ଚୟନ"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ମୂଦ୍ରଣୀ"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "କୋବଳ GhostScript ଅକ୍ଷରରୂପଗୁଡ଼ିକୁ ଯୋଗକରନ୍ତୁ"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "PS ସ୍ତର 1କୁ ରୂପାନ୍ତରିତ କରନ୍ତୁ"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "PS ସ୍ତର 2କୁ ରୂପାନ୍ତରିତ କରନ୍ତୁ"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "କୌଣସି ପ୍ରାକ-ମୁଦ୍ରଣୀ ନାହିଁ"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "ନିର୍ମାତା"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "ଡ୍ରାଇଭର"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"%s ରେ ଉପଲବ୍ଧ ମୁଦ୍ରଣୀଗୁଡ଼ିକୁ ଦେଖିବା ପାଇଁ ଆପଣଙ୍କର ବ୍ୟବହାରକାରୀ ନାମ ଏବଂ ପ୍ରବେଶ "
+"ସଂକେତ ଭରଣ "
+"କରନ୍ତୁ।"
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "ମୁଦ୍ରଣୀ ଯୋଗକରନ୍ତୁ"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "ମୁଦ୍ରଣୀକୁ ବାହାର କରନ୍ତୁ"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "ସାମଗ୍ରୀ"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "ସ୍ଥାନ"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+#| msgid "Default Route"
+msgid "_Default printer"
+msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ମୁଦ୍ରଣୀ (_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "କାର୍ଯ୍ଯ"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "କାର୍ଯ୍ୟଗୁଡ଼ିକୁ ଦର୍ଶାନ୍ତୁ (_J)"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "ମଡେଲ"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "ନାମପଟି"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "ନୂତନ ଡ୍ରାଇଭର ସେଟ କରୁଅଛି …"
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "ପୃଷ୍ଠା 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "ପରୀକ୍ଷଣ ପୃଷ୍ଠାକୁ ମୁଦ୍ରଣ କରନ୍ତୁ (_T)"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "ବିକଳ୍ପଗୁଡ଼ିକ (_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "ନୂତନ ମୁଦ୍ରଣୀ ଯୋଗ କରନ୍ତୁ"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"ମୁଁ ଦୁଃଖିତ! ତନ୍ତ୍ର ମୁଦ୍ରଣୀ ସର୍ଭିସ\n"
+"ଉପଲବ୍ଧ ହେବା ପରି ଲାଗୁ ନାହିଁ।"
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "ପରଦା ତାଲା"
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "ବ୍ୟବହାର ବିଧି ଏବଂ ପୁରୁଣା ତଥ୍ଯ"
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr "ଆବର୍ଜନା ପାତ୍ରରୁ ସମସ୍ତ ବସ୍ତୁକୁ ଖାଲି କରିବେ କି?"
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr "ଏହି ଆବର୍ଜନା ପାତ୍ରରେ ଥିବା ସମସ୍ତ ବସ୍ତୁଗୁଡ଼ିକ ସବୁଦିନ ପାଇଁ ଅପସାରିତ ହୋଇଛି।"
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "ଆବର୍ଜନା ପାତ୍ରକୁ ଖାଲି କରନ୍ତୁ (_E)"
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+#| msgid "Purge Trash & Temporary Files"
+msgid "Delete all the temporary files?"
+msgstr "ସମସ୍ତ ଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ଅପସାରଣ କରିବେ କି?"
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr "ସମସ୍ତ ଅସ୍ଥାୟୀ ବସ୍ତୁଗୁଡ଼ିକ ସବୁଦିନ ପାଇଁ ଅପସାରିତ ହୋଇଛି।"
+
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "ଫାଇଲଗୁଡିକୁ ରଖନ୍ତୁ (_P)"
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "ଆବର୍ଜନା ଏବଂଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ପରିଷ୍କାର କରନ୍ତୁ"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+#| msgid "Software"
+msgid "Software Usage"
+msgstr "ସଫ୍ଟୱେର ଉପଯୋଗୀତା"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "ଗୋପନୀୟତା"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+"ଆପଣଙ୍କର ବ୍ୟକ୍ତିଗତ ସୂଚନାକୁ ସୁରକ୍ଷା ଦିଅନ୍ତୁ ଏବଂ ଅନ୍ୟମାନେ କଣ ଦେଖିପାରିବେ ତାହାକୁ "
+"ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "ପରଦା ଅଫ ହୋଇଛି"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 ସେକେଣ୍ଡ"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 ଦିନ"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 ଦିନ"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 ଦିନ"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 ଦିନ"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 ଦିନ"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 ଦିନ"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 ଦିନ"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 ଦିନ"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 ଦିନ"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "ସବୁଦିନ ପାଇଁ"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"ଆପଣଙ୍କର ପୁରୁଣା ତଥ୍ୟକୁ ମନେରଖିବା ଫଳରେ ସବୁକିଛି ପରେ ଖୋଜିବା ସମୟରେ ସହଜମୟ ହୋଇଥାଏ। "
+"ଏହି ବସ୍ତୁଗୁଡ଼ିକୁ "
+"ନେଟୱର୍କରେ ସହଭାଗ କରାଯାଇନଥାଏ।"
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "ନିକଟରେ ବ୍ୟବହାର ହୋଇଥିବା (_R)"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "ପୁରୁଣା ତଥ୍ୟ ରଖନ୍ତୁ (_H)"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "ସାମ୍ପ୍ରତିକ ପୁରୁଣା ତଥ୍ୟକୁ ସଫା କରନ୍ତୁ (_e)"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "ପରଦା ତାଲା ଆପଣଙ୍କର ଅନୁପସ୍ଥିତିରେ ଗୋପନୀୟତାକୁ ରକ୍ଷା କରିଥାଏ।"
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "ସ୍ୱୟଂଚାଳିତ ପରଦା ତାଲା (_L)"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "ଏତିକି ସମୟ ଖାଲି ରହିବା ପରେ ପରଦାକୁ ତାଲା ପକାନ୍ତୁ (_a)"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "ବିଜ୍ଞପ୍ତି ଦର୍ଶାନ୍ତୁ (_N)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"ଆପଣଙ୍କ କମ୍ପୁଟରକୁ ଅନାବଶ୍ୟକ ସମ୍ବେଦନଶୀଳ ସୂଚନାରୁ ମୁକ୍ତ ରଖିବା ପାଇଁ ସ୍ୱୟଂଚାଳିତ "
+"ଭାବରେ ଆବର୍ଜନା ଏବଂ "
+"ଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ଖାଲିକରନ୍ତୁ।"
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଆବର୍ଜନା ପାତ୍ରକୁ ଖାଲି କରନ୍ତୁ (_T)"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଅସ୍ଥାୟୀ ଫାଇଲଗୁଡ଼ିକୁ ଖାଲି କରନ୍ତୁ (_F)"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "ଏହା ପରେ ପରିଷ୍କାର କରନ୍ତୁ (_A)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"ଆପଣ କେଉଁ ସଫ୍ଟୱେର ବ୍ୟବହାର କରୁଛନ୍ତି ତାହା ବିଷୟରେ ସୂଚନା ଦେବା ଫଳରେ ତାହା ଆମକୁ ଅଧିକ "
+"ସଠିକ "
+"ପରାମର୍ଶଗୁଡ଼ିକୁ ଦେବା ପାଇଁ ସହାୟତା କରିଥାଏ। ଏହା ମଧ୍ଯ ଆମର ସଫ୍ଟୱେରକୁ ଉନ୍ନତ କରିବା "
+"ପାଇଁ "
+"ସହାୟତା କରିଥାଏ।\n"
+"\n"
+"ଆମେ ସଂଗ୍ରହ କରିଥିବା ସମସ୍ତ ସୂଚନା ଏହାକୁ ଅଜ୍ଞାତ କରିଥାଏ, ଏବଂ ଆମେ ତୃତୀୟ ପକ୍ଷ ସହିତ "
+"ଆପଣଙ୍କର "
+"ତଥ୍ୟକୁ ସହଭାଗ କରିନଥାଉ।"
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "ସଫ୍ଟୱେର ଉପଯୋଗୀତା ପରିସଂଖ୍ୟାନ ପଠାନ୍ତୁ (_S)"
+
+#: ../panels/privacy/privacy.ui.h:41
+#| msgid "Privacy"
+msgid "Privacy Policy"
+msgstr "ଗୋପନିୟତା ନିତୀ"
+
+#: ../panels/privacy/privacy.ui.h:42
+#| msgid "_Location name:"
+msgid "_Location Services"
+msgstr "ଅବସ୍ଥାନ ସର୍ଭିସ (_L)"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "ଆପଣଙ୍କର ଭୌଗଳିକ ସ୍ଥିତି ନିର୍ଦ୍ଧାରଣ କରିବା ପାଇଁ ବ୍ୟବହାର ହୋଇଥାଏ"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ଇମ୍ପେରୀୟାଲ"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "ମେଟ୍ରିକ"
+
+#: ../panels/region/cc-format-chooser.c:284
+msgid "No regions found"
+msgstr "କୌଣସି ସ୍ଥାନ ମିଳିଲା ନାହିଁ"
+
+#: ../panels/region/cc-input-chooser.c:179
+msgid "No input sources found"
+msgstr "କୌଣସି ନିବେଶ ଉତ୍ସ ମିଳିଲା ନାହିଁ"
+
+#: ../panels/region/cc-input-chooser.c:1076
+#| msgid "Other"
+msgctxt "Input Source"
+msgid "Other"
+msgstr "ଅନ୍ଯାନ୍ଯ"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:896
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+"ପରିବର୍ତ୍ତନଗୁଡ଼ିକୁ କାର୍ଯ୍ୟକାରୀ କରିବା ପାଇଁ ଆପଣଙ୍କର ଅଧିବେଶନକୁ ପୁନଃଚାଳନ କରିବା "
+"ଆବଶ୍ୟକ"
+
+#: ../panels/region/cc-region-panel.c:240
+#: ../panels/user-accounts/um-user-panel.c:897
+msgid "Restart Now"
+msgstr "ବର୍ତ୍ତମାନ ପୁନଃଚାଳନ କରନ୍ତୁ"
+
+#: ../panels/region/cc-region-panel.c:858
+msgid "No input source selected"
+msgstr "କୌଣସି  ନିବେଶ ଉତ୍ସ ବଛା ହୋଇନାହିଁ"
+
+#: ../panels/region/cc-region-panel.c:1088
+msgid "Sorry"
+msgstr "କ୍ଷମା କରନ୍ତୁ"
+
+#: ../panels/region/cc-region-panel.c:1090
+msgid "Input methods can't be used on the login screen"
+msgstr "ନିବେଶ ପ୍ରଣାଳୀଗୁଡ଼ିକୁ ଲଗଇନ ପରଦାରେ ବ୍ୟବହାର କରାଯାଇପାରିବ ନାହିଁ"
+
+#: ../panels/region/cc-region-panel.c:1727
+msgid "Login Screen"
+msgstr "ଲଗଇନ୍‌ ପରଦା"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "ଫର୍ମାଟଗୁଡିକ"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "ପୂର୍ବଦୃଶ୍ଯ"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "ତାରିଖ"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "ସମୟ"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "ସଂଖ୍ଯାଗୁଡିକ"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "ମାପ"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "କାଗଜ"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "ଅଞ୍ଚଳ ଏବଂ ଭାଷା"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"ଆପଣଙ୍କର ପ୍ରଦର୍ଶନୀ ଭାଷା, ଶୈଳୀ, କିବୋର୍ଡ ବିନ୍ୟାସ ଏବଂ ନିବେଶ ଉତ୍ସଗୁଡ଼ିକୁ ବାଛନ୍ତୁ"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "ଭାଷା;ବିନ୍ୟାସ;କିବୋର୍ଡ;ନିବେଶ;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "ନିବେଶ ଉତ୍ସ ଯୋଗ କରନ୍ତୁ"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "ଉତ୍ସ ବିକଳ୍ପଗୁଡିକୁ ନିବେଶ କରନ୍ତୁ"
+
+#: ../panels/region/input-options.ui.h:2
+msgid "Use the _same source for all windows"
+msgstr "ସମସ୍ତ ୱିଣ୍ଡୋ ପାଇଁ ସମାନ ଉତ୍ସ ବ୍ୟବହାର କରନ୍ତୁ (_s)"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Allow _different sources for each window"
+msgstr "ପ୍ରତ୍ୟେକ ୱିଣ୍ଡୋ ପାଇଁ ବିଭିନ୍ନ ଉତ୍ସଗୁଡ଼ିକୁ ଅନୁମତି ଦିଅନ୍ତୁ (_d)"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Keyboard Shortcuts"
+msgstr "କିବୋର୍ଡ ସର୍ଟକଟଗୁଡିକ"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Switch to previous source"
+msgstr "ପୂର୍ବବର୍ତ୍ତୀ ଉତ୍ସକୁ ବଦଳ କର"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Switch to next source"
+msgstr "ପରବର୍ତ୍ତୀ ଉତ୍ସକୁ ବଦଳ କର"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "ଆପଣ ଏହି ସଂକ୍ଷିପ୍ତ ପଥଗୁଡ଼ିକୁ କିବୋର୍ଡ ସଂରଚନାରେ ପରିବର୍ତ୍ତନ କରିପାରିବେ"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "Alternative switch to next source"
+msgstr "ବୈକଳ୍ପିକ ଭାବରେ ପରବର୍ତ୍ତୀ ଉତ୍ସକୁ ବଦଳ କର"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Left+Right Alt"
+msgstr "ବାମ+ଡ଼ାହାଣ  Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "ଇରାଜୀ (ଯୁକ୍ତ ରାଜ୍ୟ)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "ଯୁକ୍ତ ରାଜ୍ଯ"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "ବିକଳ୍ପଗୁଡିକ"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"ତନ୍ତ୍ରରେ ଲଗଇନ କରିବା ସମୟରେ ଲଗଇନ ସଂରଚନାଗୁଡ଼ିକ ସମସ୍ତ ବ୍ୟବହାରକାରୀଙ୍କ ଦ୍ୱାରା "
+"ବ୍ୟବହାର ହୋଇଥାଏ"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+#| msgid "Places"
+msgctxt "Search Location"
+msgid "Places"
+msgstr "ସ୍ଥାନଗୁଡିକ"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+#| msgid "Bookmarks"
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "ଚିହ୍ନିତ ସ୍ଥାନଗୁଡ଼ିକ"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+#| msgid "Other"
+msgctxt "Search Location"
+msgid "Other"
+msgstr "ଅନ୍ଯାନ୍ଯ"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "ଗୋଟିଏ ସ୍ଥାନ ମନୋନୀତ କରନ୍ତୁ"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+#| msgid "GOK"
+msgid "_OK"
+msgstr "ଠିକ ଅଛି (_O)"
+
+#: ../panels/search/cc-search-panel.c:176
+msgid "No applications found"
+msgstr "କୌଣସି ପ୍ରୟୋଗ ମିଳିଲା ନାହିଁ"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "ଖୋଜନ୍ତୁ"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"କାର୍ଯ୍ୟକଳାପ ସମୀକ୍ଷାରେ କେଉଁ ପ୍ରୟୋଗଗୁଡ଼ିକ ସନ୍ଧାନ ଫଳାଫଳ ଦର୍ଶାଇଥାଏ ତାହାକୁ "
+"ନିୟନ୍ତ୍ରଣ କରିଥାଏ"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "ସନ୍ଧାନ କରନ୍ତୁ;ଖୋଜନ୍ତୁ;ଅନୁକ୍ରମଣିକା;ଲୁଚନ୍ତୁ;ଗୋପନୀୟତା;ଫଳାଫଳ;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "ସ୍ଥାନ ସନ୍ଧାନ କରନ୍ତୁ"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "ଉପରକୁ ଘୁଞ୍ଚାଅ"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "ତଳକୁ ଘୁଞ୍ଚାଅ"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "ପସନ୍ଦ"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "ଅନ"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "ଅଫ"
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+#| msgid "Enabled"
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "ସକ୍ରିୟ"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+#| msgid "Active Jobs"
+msgctxt "service is active"
+msgid "Active"
+msgstr "ସକ୍ରିୟ"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "ଗୋଟିଏ ଫୋଲଡର ଖୋଲନ୍ତୁ"
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "ନକଲ କରନ୍ତୁ"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "ସହଭାଗ"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "ଅନ୍ୟମାନଙ୍କ ସହିତ କଣ ସହଭାଗ କରିବେ ତାହା ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "ସୁଦୂର ଲଗଇନ୍‌କୁ ସକ୍ରିୟ ଅଥବା ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "ସୁଦୂର ଲଗଇନକୁ ସକ୍ରିୟ କିମ୍ବା ନିଷ୍କ୍ରିୟ କରିବା ପାଇଁ ବୈଧିକରଣ ଆବଶ୍ଯକ"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:299
+msgid "No networks selected for sharing"
+msgstr "ସହଭାଗ ପାଇଁ କୌଣସି ନେଟୱର୍କ ବଛାଯାଇ ନାହିଁ"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+#| msgid "Network"
+msgid "Networks"
+msgstr "ନେଟୱର୍କଗୁଡ଼ିକ"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "ବ୍ଲୁଟୁଥ ସହଭାଗ"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"ବ୍ଲୁଟୁଥ ସହଭାଗ ଆପଣଙ୍କୁ ଅନ୍ୟ ବ୍ଲୁଟୁଥ ସକ୍ରିୟ ଉପକରଣଗୁଡ଼ିକ ସହିତ ଫାଇଲ ସହଭାଗ କରିବା "
+"ପାଇଁ ଅନୁମତି ଦେଇଥାଏ"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "କେବଳ ବିଶ୍ୱସ୍ତ ଉପକରଣଗୁଡ଼ିକରୁ ଗ୍ରହଣ କରନ୍ତୁ"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "ଗ୍ରହଣ କରାଯାଇଥିବା ଫାଇଲଗୁଡ଼ିକୁ ଆହରଣ ଫୋଲଡରରେ ସଂରକ୍ଷଣ କରନ୍ତୁ"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "କମ୍ପୁଟର ନାମ"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "ବ୍ୟକ୍ତିଗତ ଫାଇଲ ସହଭାଗ"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "ପରଦା ସହଭାଗ"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "ମେଡ଼ିଆ ସହଭାଗ"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "ସୁଦୂର ଲଗଇନ"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "ନେଟୱର୍କ ଅଭିଗମ୍ୟତା ନଥିବା ହେତୁ କିଛି ସର୍ଭିସଗୁଡ଼ିକ ନିଷ୍କ୍ରିୟ ଅଛି।"
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"ବ୍ୟକ୍ତିଗତ ଫାଇଲ ସହଭାଗ ଆପଣଙ୍କୁ ସାର୍ବଜନିକ ଫାଇଲକୁ ପ୍ରଚଳିତ ନେଟୱର୍କ ବ୍ୟବହାର କରୁଥିବା "
+"ଅନ୍ୟମାନଙ୍କ ସହିତ "
+"ସହଭାଗ ପାଇଁ ଅନୁମତି ଦେଇଥାଏ: <a href=\"dav://%s\">dav://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr "ପ୍ରବେଶ ସଂଙ୍କେତ ଆବଶ୍ୟକ"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"ସୁରକ୍ଷିତ ସେଲ ନିର୍ଦ୍ଦେଶ ବ୍ୟବହାର କରି ସୁଦୂର ବ୍ୟବହାରକାରୀମାନଙ୍କୁ ସଂଯୋଗ କରିବା ପାଇଁ "
+"ଅନୁମତି ଦିଅନ୍ତୁ:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"ଏହା ସହିତ ସଂଯୋଗ ସ୍ଥାପନ କରି ସୁଦୂର ବ୍ୟବହାରକାରୀମାନଙ୍କୁ ଆପଣଙ୍କ ପରଦାକୁ ଦେଖିବା ଏବଂ "
+"ନିୟନ୍ତ୍ରଣ କରିବା "
+"ପାଇଁ ଅନୁମତି ଦିଅନ୍ତୁ: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:20
+#| msgid "Remote Control"
+msgid "Allow Remote Control"
+msgstr "ସୁଦୂର ନିୟନ୍ତ୍ରଣକୁ ଅନୁମତି ଦିଅନ୍ତୁ"
+
+#: ../panels/sharing/sharing.ui.h:21
+#| msgid "Password"
+msgid "Password:"
+msgstr "ପ୍ରବେଶ ସଙ୍କେତ:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦେଖାନ୍ତୁ"
+
+#: ../panels/sharing/sharing.ui.h:23
+#| msgid "%s Options"
+msgid "Access Options"
+msgstr "ଅଭିଗମ୍ୟତା ବିକଳ୍ପଗୁଡ଼ିକ"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "ନୂତନ ସଂଯୋଗଗୁଡ଼ିକ ନିଶ୍ଚିତ ଭାବରେ ଅଭିଗମ୍ୟତା ପଚାରିଥାଏ"
+
+#: ../panels/sharing/sharing.ui.h:25
+#| msgid "Require Password"
+msgid "Require a password"
+msgstr "ପ୍ରବେଶ ସଂଙ୍କେତ ଆବଶ୍ୟକ"
+
+#: ../panels/sharing/sharing.ui.h:26
+#| msgid "Share Music, Photos and Videos with others on the current network."
+msgid "Share music, photos and videos over the network."
+msgstr "ସଙ୍ଗୀତ, ଫୋଟ ଏବଂ ଭିଡ଼ିଓଗୁଡ଼ିକୁ ନେଟୱର୍କରେ ସହଭାଗ କରନ୍ତୁ।"
+
+#: ../panels/sharing/sharing.ui.h:27
+#| msgid "Add Folder"
+msgid "Folders"
+msgstr "ଫୋଲଡରଗୁଡିକ"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "ଶବ୍ଦ"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ଧ୍ୱନି ସ୍ତର, ନିବେଶ, ଫଳାଫଳ, ଏବଂ ସତର୍କ ସୂଚନା ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "କାର୍ଡ;ମାଇକ୍ରୋଫୋନ;ଭଲ୍ୟୁମ;ଫିକା;ସନ୍ତୁଳିତ;ବ୍ଲୁଟୁଥ;ହେଡସେଟ;ଧ୍ୱନୀ;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "ଗରଜିବା"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "ପଡ଼ିବା"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "କାଚ"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "ସୋନାର"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "ବାମ"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "ଡାହାଣ"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "ପଛ"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "ସାମ୍ନା"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "ସର୍ବନିମ୍ନ"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "ସର୍ବାଧିକ"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "ସନ୍ତୁଳିତ (_B):"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "ଫିକା (_F):"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "ସବଉଫର (_S):"
+
+#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:616
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "ବଢ଼ାହୋଇନଥିବା"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "ରୂପରେଖ (_P):"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u ଫଳାଫଳ"
+msgstr[1] "%u ଫଳାଫଳଗୁଡ଼ିକ"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ନିବେଶ"
+msgstr[1] "%u ନିବେଶଗୁଡ଼ିକ"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "ତନ୍ତ୍ର ଧ୍ୱନି"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "ସ୍ପିକରଗୁଡ଼ିକୁ ପରୀକ୍ଷା କରନ୍ତୁ (_T)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "ଶୀର୍ଷ ଚିହ୍ନଟ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1509
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "ନାମ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1528
+msgid "Device"
+msgstr "ଉପକରଣ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1591
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s ପାଇଁ ସ୍ପିକର ପରୀକ୍ଷଣ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1649
+msgid "_Output volume:"
+msgstr "ନିର୍ଗମ ଭଲ୍ଯୁମ (_O):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "Output"
+msgstr "ଫଳାଫଳ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1668
+msgid "C_hoose a device for sound output:"
+msgstr "ଧ୍ୱନି ନିର୍ଗମ ପାଇଁ ଗୋଟିଏ ଉପକରଣ ବାଛନ୍ତୁ (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1693
+msgid "Settings for the selected device:"
+msgstr "ବଚ୍ଛିତ ଉପକରଣ ପାଇଁ ବିନ୍ୟାସ:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "Input"
+msgstr "ନିବେଶ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "_Input volume:"
+msgstr "ନିବେଶ ଭଲ୍ୟୁମ (_I):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1734
+msgid "Input level:"
+msgstr "ନିବେଶ ସ୍ତର:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1762
+msgid "C_hoose a device for sound input:"
+msgstr "ଧ୍ୱନି ନିବେଶ ପାଇଁ ଗୋଟିଏ ଉପକରଣ ବାଛନ୍ତୁ (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "Sound Effects"
+msgstr "ଧ୍ୱନି ପ୍ରଭାବଗୁଡ଼ିକ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+msgid "_Alert volume:"
+msgstr "ଭଲ୍ୟୁମ ସତର୍କତା (_A):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1809
+msgid "Applications"
+msgstr "ପ୍ରୟୋଗ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1813
+msgid "No application is currently playing or recording audio."
+msgstr "କୌଣସି ପ୍ରୟୋଗ ବର୍ତ୍ତମାନ ଧ୍ୱନି ଚଲାଉ ନାହିଁ କିମ୍ବା ଲେଖୁ ନାହିଁ।"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "ଅନ୍ତଃନିର୍ମିତ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "ଧ୍ୱନି ପସନ୍ଦ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "ଘଟଣା ଧ୍ୱନି ପରୀକ୍ଷଣ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "ପ୍ରେରକ ପ୍ରସଙ୍ଗ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:769
+msgid "C_hoose an alert sound:"
+msgstr "ଗୋଟିଏ ସତର୍କ ଧ୍ୱନି ବାଛନ୍ତୁ (_h):"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "ବନ୍ଦ କରନ୍ତୁ"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "ପରୀକ୍ଷା"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "ସବଉଫର"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "ଇଚ୍ଛାରୂପଣ"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"ଏହାକୁ ଦେଖିବା, ଶୁଣିବା, ଲେଖିବା, ଦର୍ଶାଇବା ଏବଂ କ୍ଲିକ କରିବା ପାଇଁ ସହଜମୟ କରନ୍ତୁ"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;"
+#| "size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"କିବୋର୍ଡ;ମାଉସ;a11y;ପ୍ରବେଶାନୁମତି;ବିଭେଦନ;ସାନ ବଡ଼;ପରଦା "
+"ପାଠକ;ପରୀକ୍ଷା;ଅକ୍ଷରରୂପ;ଆକାର;ଅଭିଗମ୍ୟX;"
+"ଷ୍ଟିକି; କି;ମନ୍ଥର;ବାଉନ୍ସ;ମାଉସ;"
+
+#: ../panels/universal-access/uap.ui.h:1
+#| msgid "Universal Access"
+msgid "_Always Show Universal Access Menu"
+msgstr "ସର୍ବଦା ସାର୍ବଜନିନ ଅଭିଗମ୍ୟତା ତାଲିକା ଦର୍ଶାନ୍ତୁ (_A)"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "ଚିତ୍ରଣକରୁଛି"
+
+#: ../panels/universal-access/uap.ui.h:3
+#| msgid "High Contrast"
+msgid "_High Contrast"
+msgstr "ଅଧିକ ସ୍ପଷ୍ଟତା (_H)"
+
+#: ../panels/universal-access/uap.ui.h:4
+#| msgid "Large Text"
+msgid "_Large Text"
+msgstr "ବୃହତ ପାଠ୍ୟ (_L)"
+
+#: ../panels/universal-access/uap.ui.h:5
+#| msgid "Zoom"
+msgid "_Zoom"
+msgstr "ସାନବଡ କରନ୍ତୁ (_Z)"
+
+#: ../panels/universal-access/uap.ui.h:7
+#| msgid "Screen Reader"
+msgid "Screen _Reader"
+msgstr "ପରଦା ପାଠକ (_R)"
+
+#: ../panels/universal-access/uap.ui.h:8
+#| msgid "Bounce Keys"
+msgid "_Sound Keys"
+msgstr "ଧ୍ବନୀ କି (_S)"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "ଶୁଣୁଅଛି"
+
+#: ../panels/universal-access/uap.ui.h:10
+#| msgid "Visual Alerts"
+msgid "_Visual Alerts"
+msgstr "ଚାକ୍ଷୁଷ ସତର୍କତା (_V)"
+
+#: ../panels/universal-access/uap.ui.h:12
+#| msgid "Screen keyboard"
+msgid "Screen _Keyboard"
+msgstr "ପରଦା କି-ବୋର୍ଡ (_K)"
+
+#: ../panels/universal-access/uap.ui.h:13
+#| msgid "Typing Assistant"
+msgid "_Typing Assist (AccessX)"
+msgstr "ଲେଖିବା ସହକାରୀ (AccessX) (_T)"
+
+#: ../panels/universal-access/uap.ui.h:14
+#| msgid "Pointing and Clicking"
+msgid "Pointing & Clicking"
+msgstr "ଇଙ୍ଗିତ କରିବା ଏବଂ କ୍ଲିକ କରିବା"
+
+#: ../panels/universal-access/uap.ui.h:15
+#| msgid "Mouse Keys"
+msgid "_Mouse Keys"
+msgstr "ମାଉସ କି (_M)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "କ୍ଲିକ ସହାୟକ (_C)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "ପରଦା ପାଠକ"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"ପରଦା ପାଠକ ଦର୍ଶାଯାଇଥିବା ପାଠ୍ୟକୁ ଲକ୍ଷ୍ୟ ପରିବର୍ତ୍ତନ କରିବା ସଙ୍ଗେ ସଙ୍ଗେ ପଢ଼ିଥାଏ।"
+
+#: ../panels/universal-access/uap.ui.h:19
+#| msgid "Screen Reader"
+msgid "_Screen Reader"
+msgstr "ପରଦା ପାଠକ (_S)"
+
+#: ../panels/universal-access/uap.ui.h:20
+#| msgid "Bounce Keys"
+msgid "Sound Keys"
+msgstr "ଧ୍ୱନି କିଗୁଡ଼ିକ"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "Num Lock କିମ୍ବା Caps Lock ଅନ୍‌ ଥିବା ସମୟରେ ଦପ୍‌ ଦପ୍‌ କରନ୍ତୁ।"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "ଚାକ୍ଷୁଷ ସତର୍କତା"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "ଫ୍ଲାସ ପରୀକ୍ଷା କରନ୍ତୁ (_T)"
+
+#: ../panels/universal-access/uap.ui.h:24
+#| msgid "Use a visual indication when an alert sound occurs"
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ସତର୍କ ଧ୍ୱନୀ ହେଲେ ଦୃଶ୍ୟମାନ ସୂଚନା ବ୍ୟବହାର କରନ୍ତୁ।"
+
+#: ../panels/universal-access/uap.ui.h:25
+#| msgid "Flash the window title"
+msgid "Flash the _window title"
+msgstr "ଉଇଣ୍ଡୋ ଶୀର୍ଷକକୁ  ଫ୍ଲାଶ କରନ୍ତୁ (_w)"
+
+#: ../panels/universal-access/uap.ui.h:26
+#| msgid "Flash the entire screen"
+msgid "Flash the entire _screen"
+msgstr "ସମଗ୍ର ପରଦାକୁ ଫ୍ଲାଶ କରନ୍ତୁ (_s)"
+
+#: ../panels/universal-access/uap.ui.h:27
+#| msgid "Typing Assistant"
+msgid "Typing Assist"
+msgstr "ଲେଖିବା ସହକାରୀ"
+
+#: ../panels/universal-access/uap.ui.h:28
+#| msgid "Sticky Keys"
+msgid "_Sticky Keys"
+msgstr "ସାମୟିକ କିଗୁଡ଼ିକ (_S)"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "ପରିବର୍ତ୍ତନକାରୀ କିଗୁଡ଼ିକୁ କି ଯୁଗଳ ଭାବରେ ବ୍ୟବହାର କରନ୍ତୁ"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "ଦୁଇଟି କି ଏକା ସହିତ ଦବାହୋଇଥିଲେ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ (_D)"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifer key is pressed"
+msgstr "ଯଦି ପରିବର୍ତ୍ତକ କି କୁ ଦବାଯାଇଛି ତାହାହେଲେ ମିଟିମିଟି କରିବ (_m)"
+
+#: ../panels/universal-access/uap.ui.h:32
+#| msgid "Slow Keys"
+msgid "S_low Keys"
+msgstr "ମନ୍ଥର କିଗୁଡ଼ିକ (_l)"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"କେତେବେଳେ କି କୁ ଦବାଇବା ଉଚିତ ଏବଂ କେତେବେଳେ ଗ୍ରହଣ କରିବେ ତାହା ମଧ୍ଯରେ ବିଳମ୍ବ ସେଟ "
+"କରିଥାଏ"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "ଗ୍ରହଣ କରିବାରେ ବିଳମ୍ବ (_c):"
+
+#: ../panels/universal-access/uap.ui.h:35
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "କିଗୁଡ଼ିକର ଲେଖିବାରେ ବିଲମ୍ବକୁ ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/universal-access/uap.ui.h:37
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "ଲମ୍ବା"
+
+#: ../panels/universal-access/uap.ui.h:38
+#| msgid "Beep when a _toggle key is pressed"
+msgid "Beep when a key is pr_essed"
+msgstr "ଆଗପଛ କି ଦବାଇବା ସମୟରେ ଦପଦପ କରନ୍ତୁ (_e)"
+
+#: ../panels/universal-access/uap.ui.h:39
+#| msgid "Beep when key is _accepted"
+msgid "Beep when a key is _accepted"
+msgstr "କି କୁ ଗ୍ରହଣ କରାଗଲେ ମିଟିମିଟି କରିବ (_a)"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "ଯଦି କି କୁ ପ୍ରତ୍ଯାଖାନ କରାଗଲେ ମିଟିମିଟି କରିବ (_r)"
+
+#: ../panels/universal-access/uap.ui.h:41
+#| msgid "Bounce Keys"
+msgid "_Bounce Keys"
+msgstr "ଡେଉଁଥିବା କିଗୁଡ଼ିକ (_B)"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "ଦ୍ରୁତ ନକଲ କି ଦବାଇବାକୁ ଅଗ୍ରାହ୍ୟ କରନ୍ତୁ"
+
+#: ../panels/universal-access/uap.ui.h:43
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "ଡେଉଁଥିବା କିଗୁଡ଼ିକର ଲେଖିବାରେ ବିଳମ୍ବ"
+
+#: ../panels/universal-access/uap.ui.h:45
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "ଲମ୍ବା"
+
+#: ../panels/universal-access/uap.ui.h:46
+#| msgid "Enable by Keyboard"
+msgid "_Enable by Keyboard"
+msgstr "କି ବୋର୍ଡ ଦ୍ୱାରା ସକ୍ରିୟ ହୋଇଛି (_E)"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "କିବୋର୍ଡ ବ୍ୟବହାର କରି ଅଭିଗମ୍ୟତା ବିଶେଷଗୁଣଗୁଡ଼ିକୁ ଅନ ଏବଂ ଅଫ କରନ୍ତୁ"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "କ୍ଲିକ ସହାୟକ"
+
+#: ../panels/universal-access/uap.ui.h:49
+#| msgid "Simulated Secondary Click"
+msgid "_Simulated Secondary Click"
+msgstr "ଦ୍ୱିତୀୟକ କ୍ଲିକକୁ ଜାଗ୍ରତ କରନ୍ତୁ (_S)"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "ପ୍ରାଥମିକ ବଟନକୁ ତଳକୁ ଧରି ଦ୍ୱିତୀୟକ କ୍ଲିକକୁ ଜାଗ୍ରତ କରନ୍ତୁ"
+
+#: ../panels/universal-access/uap.ui.h:51
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "secondary click"
+msgid "Short"
+msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "ଦ୍ୱିତୀୟକ କ୍ଲିକ ବିଳମ୍ବ"
+
+#: ../panels/universal-access/uap.ui.h:53
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "ଲମ୍ବା"
+
+#: ../panels/universal-access/uap.ui.h:54
+#| msgid "Hover Click"
+msgid "_Hover Click"
+msgstr "ହଭର କ୍ଲିକ (_H)"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "ସୂଚକ ଗତିକୁ ଅଟକାଇବା ସମୟରେ କ୍ଲିକକୁ ଆରମ୍ଭ କରନ୍ତୁ"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "ବିଳମ୍ବ (_e):"
+
+#: ../panels/universal-access/uap.ui.h:57
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#: ../panels/universal-access/uap.ui.h:58
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "ଲମ୍ବା"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "ଥ୍ରେସହୋଲ୍ଡ ଗତି (_t):"
+
+#: ../panels/universal-access/uap.ui.h:60
+#| msgctxt "universal access, text size"
+#| msgid "Small"
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "ଛୋଟ"
+
+#: ../panels/universal-access/uap.ui.h:61
+#| msgctxt "universal access, text size"
+#| msgid "Large"
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "ବଡ"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ପରଦା"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "1/2 ପରଦା"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ପରଦା"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "ଲମ୍ବା"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "ସଂପୂର୍ଣ୍ଣ ପରଦା"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "ଉପର ଅଧା"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "ତଳ ଅଧା"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "ବାମ ପାଖ ଅଧା"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "ଡାହାଣ ପାଖ ଅଧା"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "ଛୋଟବଡ଼ ବିକଳ୍ପଗୁଡିକ"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "ସାନବଡ କରନ୍ତୁ"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "ଆବର୍ଦ୍ଧନ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "ମାଉସ ସୂଚକକୁ ଅନୁସରଣ କରନ୍ତୁ"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "ପରଦା ଅଂଶ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "ଆବର୍ଦ୍ଧକ ପରଦା ବାହାରେ ଅନୁଲମ୍ବିତ ହୋଇଥାଏ"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ କେନ୍ଦ୍ରିତ କରନ୍ତୁ"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ ବିଷୟବସ୍ତୁକୁ ଚାରିପଟକୁ ପଠାଇଥାଏ"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "ଆବର୍ଦ୍ଧକ ସୂଚକ ବିଷଯବସ୍ତୁ ସହିତ ଚାଲିଥାଏ"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "ଆବର୍ଦ୍ଧକ ଅବସ୍ଥାନ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "ଆବର୍ଦ୍ଧକ"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "ମୋଟେଇ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "ପତଳା"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "ମୋଟା"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "ଲମ୍ବ:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "ରଙ୍ଗ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "କ୍ରସହେୟର:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "ମାଉସ ସୂଚକକୁ ଆବୃତ କରିଥାଏ"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "କ୍ରସହେୟର"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "କଳାରେ ଧଳା:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "ଉଜ୍ଜ୍ବଳତା:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "ସ୍ପଷ୍ଟତା:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "ରଙ୍ଗ"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "କିଛି ନାହିଁ"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "ପୂର୍ଣ୍ଣ"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "ନିମ୍ନ"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "ଉଚ୍ଚ"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "ନିମ୍ନ"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "ଉଚ୍ଚ"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "ରଙ୍ଗ ପ୍ରଭାବଗୁଡ଼ିକ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "ରଙ୍ଗ ପ୍ରଭାବଗୁଡ଼ିକ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "ମାନକ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "ପ୍ରଶାସକ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+#| msgid "_Full name"
+msgid "_Full Name"
+msgstr "ପୂରା ନାମ (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "ଖାତା ପ୍ରକାର (_T)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+#| msgid "Choose password at next login"
+msgid "Allow user to set a password when they next login"
+msgstr "ପରବର୍ତ୍ତୀ ଲଗଇନରେ ଏକ ପ୍ରବେଶ ସଂକେତ ସେଟ କରିବା ପାଇଁ ଅନୁମତି ଦିଅନ୍ତୁ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "ବର୍ତ୍ତମାନ ଗୋଟିଏ ପ୍ରବେଶ ସଙ୍କେତ ସେଟ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "ଯାଞ୍ଚ କରନ୍ତୁ (_V)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"ବାଣିଜ୍ୟିକ ଲଗଇନ ସ୍ଥିତବାନ କେନ୍ଦ୍ରିୟ ପରିଚାଳିତ ବ୍ୟବହାରକାରୀ ଖାତାକୁ ଏହି ଉପକରଣରେ "
+"ବ୍ୟବହାର କରିବା ପାଇଁ ଅନୁମତି ଦେଇଥାଏ।"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "ଡମେନ (_D)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"ବାଣିଜ୍ୟିକ ଲଗଇନ ଖାତାଗୁଡ଼ିକୁ ଯୋଡ଼ିବା ପାଇଁ\n"
+"ଅନଲାଇନ୍‌ ହୁଅନ୍ତୁ।"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "ଆନୁଷ୍ଠାନିକ ଲଗଇନ (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "ଚାଳକ ଯୋଗକରନ୍ତୁ"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "ନାମଙ୍କନ କରନ୍ତୁ (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "ଡମେନ ପ୍ରଶାସକ ଲଗଇନ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"ବାଣିଜ୍ୟିକ ଲଗଇନ ବ୍ୟବହାର କରିବା ପାଇଁ, ଏହି କମ୍ପୁଟରକୁ ଡମେନରେ\n"
+"ଅନ୍ତର୍ଭୁକ୍ତ କରିବା ଆବଶ୍ୟକ। ଦୟାକରି ଆପଣଙ୍କର ନେଟୱର୍କ ପ୍ରଶାସକଙ୍କୁ ସେମାନଙ୍କର ଡମେନ "
+"ପ୍ରବେଶ "
+"ସଂକେତକୁ \n"
+"ଏଠାରେ ଭରଣ କରିବା ଆବଶ୍ୟକ।"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "ପ୍ରଶାସକ ନାମ (_N)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "ପ୍ରଶାସକ ପ୍ରବେଶ ସଂକେତ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "ବାମ ଆଙ୍ଗୁଠି"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "ବାମ ତର୍ଜନି"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "ବାମ ଅନାମିକା ଅଙ୍ଗୁଳି"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "ବାମ ତର୍ଜନି"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "ଡାହାଣ ଆଙ୍ଗୁଠି"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "ଡାହାଣ ମଝି ଅଙ୍ଗୁଳି"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "ଡାହାଣ ଅନାମିକା ଅଙ୍ଗୁଳି"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "ଡାହାଣ କାନି ଅଙ୍ଗୁଳି"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:697
+msgid "Enable Fingerprint Login"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନକୁ ସକ୍ରିୟ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "ଡାହାଣ ତର୍ଜନି (_R)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "ବାମ ତର୍ଜନି (_L)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "ଅନ୍ୟାନ୍ୟ ଅଙ୍ଗୁଳି (_O):"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"ଆପଣଙ୍କର ଅଙ୍ଗୁଳି ଚିହ୍ନଟି ସଫଳତାର ସହିତ ସଂରକ୍ଷଣ ହୋଇଛି। ଆପଣଙ୍କୁ ବର୍ତ୍ତମାନ ଆପଣଙ୍କର "
+"ଅଙ୍ଗୁଳି ଚିହ୍ନ ପାଠକ "
+"ବ୍ୟବହାର କରି ଲଗଇନ କରିବାକୁ ହେବ।"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "ଚାଳକ"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr ""
+"ଚାଳକମାନଙ୍କୁ ଯୋଗ କିମ୍ବା ଅପସାରଣ କରନ୍ତୁ ଏବଂ ଆପଣଙ୍କର ପ୍ରବେଶ ସଂକେତ ପରିବର୍ତ୍ତନ "
+"କରନ୍ତୁ"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "ଲଗଇନ;ନାମ;ଅଙ୍ଗୁଳି ଚିହ୍ନ;ଅଭତାର;ପ୍ରତୀକ;ମୁହଁ;ପ୍ରବେଶ ସଂକେତ;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "ଲଗଇନ ପୁରୁଣା ତଥ୍ଯ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#| msgid "Change pa_ssword"
+msgid "Change Password"
+msgstr "ପ୍ରବେଶ ସଂକେତ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "ପରିବର୍ତ୍ତନ କରନ୍ତୁ (_a)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+#| msgid "_New password"
+msgid "_Verify New Password"
+msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତକୁ ଯାଞ୍ଚ କରନ୍ତୁ (_V)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+#| msgid "_New password"
+msgid "_New Password"
+msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତ (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+#| msgid "Current _password"
+msgid "Current _Password"
+msgstr "ପ୍ରଚଳିତ ପ୍ରବେଶ ସଙ୍କେତ (_P)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "ଚାଳକ ଖାତା ଯୋଗ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "ଚାଳକ ଖାତା ବାହାର କରନ୍ତୁ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "ଲଗଇନ ବିକଳ୍ପଗୁଡିକ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଲଗଇନ (_u)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ (_F)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "ଚାଳକ ଚିତ୍ର ସଂକେତ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "ଭାଷା (_L)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "ଅନ୍ତିମ ଲଗଇନ"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "ବ୍ୟବହାରକାରୀ ଖାତାଗୁଡ଼ିକୁ ପରିଚାଳନା କରନ୍ତୁ"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "ବ୍ୟବହାରକାରୀ ତଥ୍ୟ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ବୈଧିକରଣ ଆବଶ୍ଯକ"
+
+#: ../panels/user-accounts/pw-utils.c:81
+#| msgid "The new password does not contain enough different characters"
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ପୁରୁଣା ଠାରୁ ଭିନ୍ନ ହୋଇଥିବା ଆବଶ୍ୟକ।"
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "କିଛି ଅକ୍ଷର ଏବଂ ସଂଖ୍ୟାଗୁଡ଼ିକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+#| msgid "Changing password for"
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "ପ୍ରବେଶ ସଙ୍କେତକୁ ଟିକିଏ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "ବିନା ବ୍ୟବହାରକାରୀ ନାମରେ ପ୍ରବେଶ ସଂକେତଟି ଅଧିକ ଶକ୍ତିଶାଳୀ ହେବ।"
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "ପ୍ରବେଶ ସଂକେତରେ ଆପଣଙ୍କର ନାମ ବ୍ୟବହାରକୁ ଏଡ଼ାନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "ପ୍ରବେଶ ସଂକେତରେ ଅନ୍ତର୍ଭୁକ୍ତ କିଛି ଶବ୍ଦକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "ସାଧାରଣ ଶବ୍ଦଗୁଡ଼ିକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "ସ୍ଥିତବାନ ଶବ୍ଦଗୁଡ଼ିକର କ୍ରମ ପରିବର୍ତ୍ତନକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "ଅଧିକ ସଂଖ୍ୟା ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "ଅଧିକ ବଡ଼ ଅକ୍ଷର ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "ଅଧିକ ଛୋଟ ଅକ୍ଷର ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+"ଅଧିକ ବିଶେଷ ଅକ୍ଷରଗୁଡ଼ିକୁ ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ, ଯେପରିକି ବିରାମ ଚିହ୍ନ।"
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+"ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ ବିରାମ ଚିହ୍ନଗୁଡ଼ିକର ମିଶ୍ରଣକୁ ବ୍ୟବହାର କରିବା ପାଇଁ ଚେଷ୍ଟା "
+"କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "ସମାନ ଅକ୍ଷରର ବାରମ୍ବାର ବ୍ୟବହାରକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"ସମାନ ପ୍ରକାରର ଅକ୍ଷରର ବାରମ୍ବାର ବ୍ୟବହାରକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ:ଆପଣଙ୍କୁ ଅକ୍ଷର, "
+"ସଂଖ୍ୟା ଏବଂ ବିରାମ ଚିହ୍ନଗୁଡ଼ିକୁ ମିଶ୍ରଣ କରିବା ଆବଶ୍ୟକ।"
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 କିମ୍ବା abcd ପରି କ୍ରମକୁ ଏଡ଼ାଇବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "ଅଧିକ ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ ସଂକେତଗୁଡ଼ିକୁ ଯୋଡ଼ିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr ""
+"ବଡ଼ ଅକ୍ଷର ଏବଂ ଛୋଟ ଅକ୍ଷର ଏବଂ ଗୋଟିଏ କିମ୍ବା ଦୁଇଟି ସଂଖ୍ୟାକୁ ମିଶ୍ରଣ କରିବାକୁ ଚେଷ୍ଟା "
+"କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+"ଭଲ ପ୍ରବେଶ ସଂକେତ! ଅଧିକ ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ ବିରାମ ଚିହ୍ନକୁ ଯୋଡ଼ିବା ଫଳରେ ଏହା ଅଧିକ "
+"ଶକ୍ତିଶାଳୀ ହେବ।"
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "ଶକ୍ତି: ଦୁର୍ବଳ"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+#| msgid "Length:"
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "ଲମ୍ବ: କମ୍"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "ଶକ୍ତି: ମଧ୍ଯମ"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "ଶକ୍ତି: ଉତ୍ତମ"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "ଶକ୍ତି:ଅତି ଉତ୍ତମ"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "ବୈଧିକରଣ ବିଫଳ"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ଅତି ଛୋଟ ଅଟେ"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ଅତି ସହଜ ଅଟେ"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "ପୁରୁଣା ଏବଂ ନୂଆ ପ୍ରବେଶ ସଙ୍କେତ ମଧ୍ଯରେ ବହୁତ ସାମଞ୍ଜସ୍ଯ ଅଛି"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତକୁ ନିକଟରେ ବ୍ୟବହାର କରାଯାଇଛି।"
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr ""
+"ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ସଂଖ୍ୟାତ୍ମକ କିମ୍ବା ବିଶେଷ ଅକ୍ଷର ମାନଙ୍କୁ ଧାରଣ କରିବା ଉଚିତ"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "ପୁରୁଣା ଏବଂ ନୂତନ ପ୍ରବେଶ ସଙ୍କେତ ଏକାପ୍ରକାରର ଅଟନ୍ତି"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "ଆପଣ ପ୍ରାରମ୍ଭରେ ପ୍ରମାଣ କରିଥିବା ପ୍ରବେଶ ସଂକେତ ପରିବର୍ତ୍ତିତ ହୋଇଛି!"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତରେ ଯଥେଷ୍ଟ ଭିନ୍ନ ବର୍ଣ୍ଣ ନାହିଁ"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "ଅଜଣା ତ୍ରୁଟି"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "ଆପଣଙ୍କର ଖାତା ପ୍ରଦାତାଙ୍କ ୱେବ ଠିକଣା ସହିତ ମେଳ ଖାଉଥିବା ଉଚିତ।"
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "ଖାତା ଯୋଗ କରିବାରେ ବିଫଳ"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+#| msgid "Passwords do not match"
+msgid "Passwords do not match."
+msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦ୍ବୟ ମିଶୁ ନାହିଁ।"
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr "ଖାତା ପଞ୍ଜିକରଣ କରିବାରେ ବିଫଳ"
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr "ଏହି ଡମେନ ସହିତ ବୈଧିକୃତ କରିବା ପାଇଁ ସହାୟତା ପ୍ରାପ୍ତ ନୁହଁ"
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr "ଡମେନରେ ଯୋଗ ହେବାରେ ବିଫଳ"
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"ସେହି ଲଗଇନ ନାମଟି କାମ କରୁ ନାହିଁ।\n"
+"ଦୟାକରି ପୁଣିଥରେ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+#| msgid "Invalid password, please try again"
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"ସେହି ଲଗଇନ ପ୍ରବେଶ ସଂକେତଟି କାମ କରୁ ନାହିଁ।\n"
+"ଦୟାକରି ପୁଣିଥରେ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr "ଡମେନରେ ଲଗଇନ୍‌ ହେବାରେ ବିଫଳ"
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "ଡମେନକୁ ପାଇବାରେ ଅସମର୍ଥ। ହୁଏତ ଏଥିରେ ବନାନ ଭୁଲ ଥାଇପାରେ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:137
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"ଆପଣ ଏହି ଉପକରଣକୁ ଅଭିଗମ୍ୟ କରିବା ପାଇଁ ଅନୁମୋଦିତ ନୁହଁ। ଆପଣଙ୍କର ତନ୍ତ୍ର ପ୍ରଶାସକଙ୍କ "
+"ସହିତ ଯୋଗାଯୋଗ "
+"କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid "The device is already in use."
+msgstr "ଉପକରଣଟି ପୂର୍ବରୁ ବ୍ୟବହାରରେ ଅଛି।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "An internal error occurred."
+msgstr "ଗୋଟେଏ ଅନ୍ତବର୍ତ୍ତୀ ତୃଟି ଘଟିଲା"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:217
+#: ../panels/user-accounts/um-fingerprint-dialog.c:218
+msgid "Enabled"
+msgstr "ସକ୍ରିୟ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:266
+msgid "Delete registered fingerprints?"
+msgstr "ପଞ୍ଜିକୃତ ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଅପସାରଣ କରିବେ କି?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:270
+msgid "_Delete Fingerprints"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଅପସାରଣ କରନ୍ତୁ (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:276
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"ଆପଣଙ୍କର ପଞ୍ଜିକୃତ ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଅପସାରଣ କରିବାକୁ ଚାହୁଁଛନ୍ତି କି ଯାହାଫଳରେ "
+"ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନ ନିଷ୍କ୍ରିୟ "
+"ହୋଇଥାଏ?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:452
+msgid "Done!"
+msgstr "ସମାପ୍ତ!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:513
+#: ../panels/user-accounts/um-fingerprint-dialog.c:555
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' ଉପକରଣକୁ ଅଭିଗମ୍ୟ କରିପାରିଲା ନାହିଁ"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:596
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "'%s' ଉପକରଣରେ ଅଙ୍ଗୁଳି ଧାରଣକୁ ଆରମ୍ଭ କରିପାରିଲା ନାହିଁ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:647
+msgid "Could not access any fingerprint readers"
+msgstr "କୌଣସି ଅଙ୍ଗୁଳି ଚିହ୍ନ ପାଠକଙ୍କୁ ଅଭିଗମ୍ୟ କରିପାରିଲା ନାହିଁ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:648
+msgid "Please contact your system administrator for help."
+msgstr "ସହାୟତା ପାଇଁ ଆପଣଙ୍କ ତନ୍ତ୍ର ପ୍ରଶାସକଙ୍କ ସହିତ ଯୋଗାଯୋଗ କରନ୍ତୁ।"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:731
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନକୁ ସକ୍ରିୟ କରିବା ପାଇଁ, ଆପଣଙ୍କୁ '%s' ଉପକରଣ ବ୍ୟବହାର କରି "
+"ଆପଣଙ୍କର ଗୋଟିଏ ଅଙ୍ଗୁଳି "
+"ଚିହ୍ନକୁ ସଂରକ୍ଷଣ କରିବା ଆବଶ୍ୟକ।"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:738
+msgid "Selecting finger"
+msgstr "ଅଙ୍ଗୁଳି ଚୟନ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:739
+msgid "Enrolling fingerprints"
+msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନଗୁଡ଼ିକୁ ଲିପିବଦ୍ଧ କରୁଛି"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "ଏହି ସପ୍ତାହ"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "ଗତ ସପ୍ତାହ"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+#| msgid "%b %d %Y"
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+#| msgid "%b %d %Y"
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:631
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "ଅଧିବେଶନ ସମାପ୍ତ"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "ଅଧିବେଶନ ଆରମ୍ଭ ହୋଇଛି"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "ଦୟାକରି ଅନ୍ୟଏକ ପ୍ରବେଶ ସଂକେତ ବାଛନ୍ତୁ।"
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "ଦୟାକରି ଆପଣଙ୍କ ପ୍ରବେଶ ସଙ୍କେତକୁ ପୁଣିଥରେ ଟାଇପ କରନ୍ତୁ।"
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "ପ୍ରବେଶ ସଙ୍କେତକୁ ବଦଳାଇ ହେଲା ନାହିଁ"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+#| msgid "The passwords do not match"
+msgid "The passwords do not match."
+msgstr "ପ୍ରବେଶ ସଙ୍କେତଗୁଡ଼ିକ ମିଶୁ ନାହିଁ।"
+
+#: ../panels/user-accounts/um-photo-dialog.c:219
+msgid "Browse for more pictures"
+msgstr "ଅଧିକ ଛବି ପାଇଁ ବ୍ରାଉଜ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/um-photo-dialog.c:453
+msgid "Disable image"
+msgstr "ପ୍ରତିଛବିକୁ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/um-photo-dialog.c:471
+msgid "Take a photo…"
+msgstr "ଗୋଟିଏ ଫଟୋ ନିଅନ୍ତୁ…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:489
+msgid "Browse for more pictures…"
+msgstr "ଅଧିକ ଛବିଗୁଡ଼ିକ ପାଇଁ ବ୍ରାଉଜ କରନ୍ତୁ…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:713
+#, c-format
+msgid "Used by %s"
+msgstr "%s ଦ୍ୱାରା ବ୍ୟବହୃତ"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଏହି ପ୍ରକାରର ଡମେନ ସହିତ ସଂଯୋଗ କରିପାରିବେ ନାହିଁ"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "ଏପରି କୌଣସି ଡମେନ କିମ୍ବା realm ମିଳି ନାହିଁ"
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s ଭାବରେ %s ଡମେନରେ ଲଗଇନ କରିପାରିବେ ନାହିଁ"
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr "ଅବୈଧ ପ୍ରବେଶ ସଂକେତ, ଦୟାକରି ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ"
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "%s ଡମେନ ସହିତ ସଂଯୁକ୍ତ ହୋଇପାରିଲା ନାହିଁ: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:198
+msgid "Other Accounts"
+msgstr "ଅନ୍ୟ ଖାତାଗୁଡ଼ିକ"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "Failed to delete user"
+msgstr "ଚାଳକକୁ ଅପସାରଣ କରିବାରେ ବିଫଳ"
+
+#: ../panels/user-accounts/um-user-panel.c:482
+msgid "You cannot delete your own account."
+msgstr "ଆପଣ ନିଜର ଖାତାକୁ ଅପସାରଣ କରିପାରିବେ ନାହିଁ।"
+
+#: ../panels/user-accounts/um-user-panel.c:491
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ଏପର୍ଯ୍ୟନ୍ତ ଲଗଇନ ଅଛି"
+
+#: ../panels/user-accounts/um-user-panel.c:495
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"ଲଗଇନ ହେବା ପରେ ଏକ ବ୍ୟବହାରକାରୀଙ୍କୁ ଅପସାରଣ କରି ତନ୍ତ୍ରକୁ ଅସ୍ଥାୟୀ ସ୍ଥିତିରେ "
+"ଛାଡ଼ିଥାଏ।"
+
+#: ../panels/user-accounts/um-user-panel.c:504
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "ଆପଣ %s ର ଫାଇଲଗୁଡ଼ିକୁ ରଖିବାକୁ ଚାହୁଁଛନ୍ତି କି?"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"ବ୍ୟବହାରକାରୀ ଖାତାକୁ ଅପସାରଣ କରିବା ସମୟରେ ହୋମ ଡିରେକ୍ଟୋରୀ, ମେଲ ସ୍ପୁଲ ଏବଂ ଅସ୍ଥାୟୀ "
+"ଫାଇଲଗୁଡ଼ିକୁ "
+"ରଖିବା ସମ୍ଭବ ଅଟେ।"
+
+#: ../panels/user-accounts/um-user-panel.c:511
+msgid "_Delete Files"
+msgstr "ଫାଇଲଗୁଡିକୁ ଅପସାରଣ କରନ୍ତୁ (_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:512
+msgid "_Keep Files"
+msgstr "ଫାଇଲଗୁଡିକୁ ରଖନ୍ତୁ (_K)"
+
+#: ../panels/user-accounts/um-user-panel.c:564
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "ଖାତା ନିଷ୍କ୍ରିୟ ଅଛି"
+
+#: ../panels/user-accounts/um-user-panel.c:572
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "ପରବର୍ତ୍ତୀ ଲଗଇନରେ ସେଟ କରାଯିବ"
+
+#: ../panels/user-accounts/um-user-panel.c:575
+msgctxt "Password mode"
+msgid "None"
+msgstr "କିଛି ନାହିଁ"
+
+#: ../panels/user-accounts/um-user-panel.c:624
+msgid "Logged in"
+msgstr "ଲଗଇନ ହୋଇଛି"
+
+#: ../panels/user-accounts/um-user-panel.c:1072
+msgid "Failed to contact the accounts service"
+msgstr "ଖାତାର ସର୍ଭିସକୁ ଯୋଗାଯୋଗ କରିବାରେ ବିଫଳ"
+
+#: ../panels/user-accounts/um-user-panel.c:1074
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "ଦୟାକରି ନିଶ୍ଚିତ କରନ୍ତୁ ଯେ ଖାତା ସର୍ଭିସଟି ସ୍ଥାପିତ ହୋଇଛି ଏବଂ ସକ୍ରିୟ ଅଛି।"
+
+#: ../panels/user-accounts/um-user-panel.c:1115
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ,\n"
+"* ଚିତ୍ର ସଂକେତକୁ ପ୍ରଥମେ କ୍ଲିକ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/um-user-panel.c:1153
+msgid "Create a user account"
+msgstr "ଚାଳକ ଖାତା ସୃଷ୍ଟି କରନ୍ତୁ"
+
+#: ../panels/user-accounts/um-user-panel.c:1164
+#: ../panels/user-accounts/um-user-panel.c:1453
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"ଚାଳକ ଖାତା ସୃଷ୍ଟି କରିବା ପାଇଁ,\n"
+"* ଚିତ୍ର ସଂକେତକୁ ପ୍ରଥମେ କ୍ଲିକ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/um-user-panel.c:1174
+msgid "Delete the selected user account"
+msgstr "ବଚ୍ଛିତ ଚାଳକ ଖାତାକୁ ଅପସାରଣ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/um-user-panel.c:1186
+#: ../panels/user-accounts/um-user-panel.c:1458
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"ବଚ୍ଛିତ ଚାଳକ ଖାତାକୁ ଅପସାରଣ କରିବା ପାଇଁ,\n"
+"* ଚିତ୍ର ସଂକେତକୁ ପ୍ରଥମେ କ୍ଲିକ କରନ୍ତୁ"
+
+#: ../panels/user-accounts/um-user-panel.c:1368
+msgid "My Account"
+msgstr "ମୋର ଖାତା"
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+#| msgid "A user with the username '%s' already exists"
+msgid "A user with the username '%s' already exists."
+msgstr "'%s' ଦ୍ବାରା ନାମିତ ହୋଇଥିବା ଗୋଟିଏଚାଳକ ନାମ ପୂର୍ବରୁ ରହିଛି।"
+
+#: ../panels/user-accounts/um-utils.c:571
+#, c-format
+#| msgid "The username is too long"
+msgid "The username is too long."
+msgstr "ଚାଳକ ନାମଟି ଅତି ବଡ଼ ଅଟେ।"
+
+#: ../panels/user-accounts/um-utils.c:574
+#| msgid "The username cannot start with a '-'"
+msgid "The username cannot start with a '-'."
+msgstr "ଚାଳକ ନାମ '-' ଦ୍ୱାରା ଆରମ୍ଭ ହୋଇପାରିବ ନାହିଁ।"
+
+#: ../panels/user-accounts/um-utils.c:577
+#| msgid ""
+#| "The username must only consist of:\n"
+#| " ➣ letters from the English alphabet\n"
+#| " ➣ digits\n"
+#| " ➣ any of the characters '.', '-' and '_'"
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"ବ୍ୟବହାରକାରୀ ନାମରେ କେବଳ a-z ପର୍ଯ୍ୟନ୍ତ ଛୋଟ ଏବଂ ବଡ଼ ଅକ୍ଷର, ସଂଖ୍ୟା ଏବଂ  '.', '-' "
+"ଏବଂ '_' ମଧ୍ଯରୁ ଯେକୌଣସି ବର୍ଣ୍ଣ ରହିବା ଉଚିତ।"
+
+#: ../panels/user-accounts/um-utils.c:581
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+"ଏହା ଆପଣଙ୍କର ମୂଖ୍ୟ ଫୋଲଡର୍‌କୁ ନାମକରଣ କରିବା ପାଇଁ ବ୍ୟବହାର କରାଯିବ ଏବଂ ତାହାକୁ "
+"ପରିବର୍ତ୍ତନ କରିହେବ ନାହିଁ।"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:827
+#| msgid "%b %d %Y"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:831
+#| msgid "%b %d %Y"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "ବଟନଗୁଡ଼ିକୁ ମେଳାନ୍ତୁ"
+
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr "କାମ କରିବା ପାଇଁ ବଟନଗୁଡ଼ିକୁ ମେଳାନ୍ତୁ"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+#| msgid ""
+#| "To edit a shortcut, click the row and hold down the new keys or press "
+#| "Backspace to clear."
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ଗୋଟିଏ ସକ୍ଷିପ୍ତ ପଥକୁ ସମ୍ପାଦନ କରିବା ପାଇଁ, \"କିଷ୍ଟ୍ରୋକ୍‌ ପଠାନ୍ତୁ\" କାର୍ଯ୍ୟକୁ "
+"ବାଛନ୍ତୁ,କିବୋର୍ଡ ସଂକ୍ଷିପ୍ତ ପଥ ବଟନକୁ ଦବାନ୍ତୁ ଏବଂ  ନୂତନ କି ଗୁଡ଼ିକୁ ଧରି ରଖନ୍ତୁ "
+"ଅଥବା  ସଫାକରିବା ପାଇଁ Backspace ଉପରେ ଦବାନ୍ତୁ।"
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"ଲକ୍ଷ୍ଯସ୍ଥଳ ଚିହ୍ନଟଗୁଡ଼ିକୁ ପରଦାରେ ଦୃଶ୍ୟମାନ ହେବା ମାତ୍ରେ ଟ୍ୟାବଲେଟକୁ ମାପିବା ପାଇଁ  "
+"ଲିପିବଦ୍ଧ କରନ୍ତୁ।"
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "ଭୁଲ ବଶତଃ ହୋଇଥିବା କ୍ଲିକ ଚିହ୍ନା ହୋଇଛି, ପୁନଃଚାଳନ କରୁଅଛି..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "ଉପର"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "ତଳ"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "କିଛି ନାହିଁ"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "କିଷ୍ଟ୍ରୋକ ପଠାନ୍ତୁ"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "ମନିଟର ବଦଳାନ୍ତୁ"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "ଅନସ୍କ୍ରିନ୍‌ ସହାୟତା ଦେଖାନ୍ତୁ"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "ଫଳାଫଳ:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "ପରିମାପ ଅନୁପାତକୁ ରଖନ୍ତୁ (ଅକ୍ଷର ବାକ୍ସ):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "ଗୋଟିଏ ମନିଟରରେ ମେଳାନ୍ତୁ"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d ର %d"
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "ମ୍ୟାପିଙ୍ଗକୁ ଦର୍ଶାନ୍ତୁ"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "ବଟନ"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr "ୱାକମ ଟ୍ୟାବଲେଟ"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"ଆଲେଖିକ ଟ୍ୟାବଲେଟ ପାଇଁ ବଟନ ମ୍ୟାପିଙ୍ଗକୁ ସେଟ କରନ୍ତୁ ଏବଂ ସମ୍ବେଦନଶୀଳ ଶୈଳୀକୁ "
+"ସଜାଡ଼ନ୍ତୁ"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "ଟେବଲ;ୱାକମ;ଶୈଳୀମୟ;ଲିଭାଳି;ମାଉସ;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "ଟ୍ୟାବଲେଟ (ସମ୍ପୂର୍ଣ୍ଣ)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "ଟଚପ୍ୟାଡ (ପାରସ୍ପରିକ)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "ଟ୍ୟାବଲେଟ ପସନ୍ଦଗୁଡ଼ିକ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr "କୌଣସି ଟ୍ୟାବଲେଟ ଉପସ୍ଥିତ ନାହିଁ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "ଦୟାକରି ଆପଣଙ୍କର ୱାକମ ଟ୍ୟାବଲେଟକୁ ପ୍ଲଗଇନ କରନ୍ତୁ କିମ୍ବା ଅନ କରନ୍ତୁ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr "ବ୍ଲୁଟୁଥ ସଂରଚନା"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Map to Monitor…"
+msgstr "ମନିଟର ସହିତ ମେଳାନ୍ତୁ…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map Buttons…"
+msgstr "ବଟନଗୁଡ଼ିକୁ ମେଳାନ୍ତୁ…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr "ପ୍ରଦର୍ଶନୀ ବିଭେଦନକୁ ସଜାଡ଼ନ୍ତୁ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust mouse settings"
+msgstr "ମାଉସ ସେଟିଙ୍ଗଗୁଡିକୁ ସଜାଡ଼ନ୍ତୁ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Tracking Mode"
+msgstr "ଅନୁସନ୍ଧାନ ଧାରା"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Left-Handed Orientation"
+msgstr "ବାମ-ହାତ ଆବର୍ତ୍ତନ"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+msgid "Left Ring"
+msgstr "ବାମ ରିଙ୍ଗ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "ବାମ ରିଙ୍ଗ ଧାରା #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+msgid "Right Ring"
+msgstr "ଡ଼ାହାଣ ରିଙ୍ଗ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "ଡ଼ାହାଣ ରିଙ୍ଗ ଧାରା #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+msgid "Left Touchstrip"
+msgstr "ବାମ ଟଚଷ୍ଟ୍ରିପ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "ବାମ ଟଚଷ୍ଟ୍ରିପ ଧାରା #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+msgid "Right Touchstrip"
+msgstr "ଡ଼ାହାଣ ଟଚଷ୍ଟ୍ରିପ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "ଡ଼ାହାଣ ଟଚଷ୍ଟ୍ରିପ ଧାରା #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "ବାମାବର୍ତ୍ତୀ ଟର୍ଚ ଧାରାକୁ ବଦଳାନ୍ତୁ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "ଡ଼ାହାଣବର୍ତ୍ତୀ ଟର୍ଚ ଧାରାକୁ ବଦଳାନ୍ତୁ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "ବାମାବର୍ତ୍ତୀ ଟର୍ଚଷ୍ଟ୍ରିପ ଧାରାକୁ ବଦଳାନ୍ତୁ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "ଡ଼ାହାଣବର୍ତ୍ତୀ ଟର୍ଚଷ୍ଟ୍ରିପ ଧାରାକୁ ବଦଳାନ୍ତୁ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "ଧାରା ପରିବର୍ତ୍ତନ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr "ବାମ ବଟନ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr "ଡ଼ାହାଣ ବଟନ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr "ଉପର ବଟନ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "ତଳ ବଟମ #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+#| msgid "No shortcut set"
+msgid "New shortcut…"
+msgstr "ନୂତନ ସଂକ୍ଷିପ୍ତ ପଥ…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "କୌଣସି କାର୍ୟ୍ଯ ନାହିଁ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "ବାମ ମାଉସ ବଟନ କ୍ଲିକ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "ମଝି ବଟନ କ୍ଲିକ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "ଡ଼ାହାଣ ମାଉସ ବଟନ କ୍ଲିକ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "ଉପରକୁ ସ୍କ୍ରୋଲ କରନ୍ତୁ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "ତଳକୁ ସ୍କ୍ରୋଲ  କରନ୍ତୁ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "ବାମକୁ ସ୍କ୍ରୋଲ କରନ୍ତୁ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "ଡ଼ାହାଣକୁ ସ୍କ୍ରୋଲ କରନ୍ତୁ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "ପଛ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "ଆଗକୁ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "ଶୈଳୀ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "ଲିଭାଳି ବକ୍ର ଚାପ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "ନରମ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "ଫର୍ମ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "ଉପର ବଟନ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "ତଳ ବଟନ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "ଉପର ଚାପ ଅନୁଭବ"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "ଦୃଷ୍ଟ ସୂଚନାଯୁକ୍ତ ଧାରାକୁ ସକ୍ରିୟ କରନ୍ତୁ"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "ସମୀକ୍ଷାକୁ ଦର୍ଶାନ୍ତୁ"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "ଏହି ବାକ୍ୟଖଣ୍ଡକୁ ଖୋଜନ୍ତୁ"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "ସମ୍ଭାବ୍ୟ ପ୍ୟାନେଲ ନାମଗୁଡ଼ିକୁ ତାଲିକାଭୁକ୍ତ କରନ୍ତୁ ଏବଂ ପ୍ରସ୍ଥାନ କରନ୍ତୁ"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "ସାହାଯ୍ଯ ପସନ୍ଦ ଦେଖାନ୍ତୁ"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "ଦର୍ଶାଇବା ପାଇଁ ପ୍ୟାନେଲ"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- ସେଟିଙ୍ଗଗୁଡିକ"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"ଉପଲବ୍ଧ ନିର୍ଦ୍ଦେଶନାମା ବିକଳ୍ପଗୁଡ଼ିକର ସମ୍ପୂର୍ଣ୍ଣ ତାଲିକା ଦେଖିବା ପାଇଁ'%s --help' "
+"କୁ ଚଲାନ୍ତୁ.\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "ଉପଲବ୍ଧ ପ୍ୟାନେଲଗୁଡ଼ିକ:"
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "ସହାୟତା"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "ବିଦାୟ ନିଅନ୍ତୁ"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+msgid "All Settings"
+msgstr "ସମସ୍ତ ସେଟିଙ୍ଗଗୁଡିକ"
+
+#. Add categories
+#: ../shell/cc-window.c:876
+msgctxt "category"
+msgid "Personal"
+msgstr "ବ୍ଯକ୍ତିଗତ"
+
+#: ../shell/cc-window.c:877
+msgctxt "category"
+msgid "Hardware"
+msgstr "ହାର୍ଡୱେର"
+
+#: ../shell/cc-window.c:878
+msgctxt "category"
+msgid "System"
+msgstr "ତନ୍ତ୍ର"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "ପସନ୍ଦ;ସେଟିଙ୍ଗଗୁଡ଼ିକ;"
+
+#~ msgid "Flickr"
+#~ msgstr "ଫ୍ଲିକର"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "ନୂତନ ଉପକରଣ ସ୍ଥାପନ କରନ୍ତୁ"
+
+#~ msgid "Connection"
+#~ msgstr "ସଂଯୋଗ"
+
+#~ msgid "Paired"
+#~ msgstr "ଯୁଗଳ"
+
+#~ msgid "Type"
+#~ msgstr "ପ୍ରକାର"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "ମାଉସ ଏବଂ ଟଚ ପ୍ୟାଡ ସେଟିଙ୍ଗଗୁଡିକ"
+
+#~ msgid "Sound Settings"
+#~ msgstr "ଧ୍ୱନି ସେଟିଙ୍ଗଗୁଡିକ"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "କିବୋର୍ଡ ବିନ୍ୟାସଗୁଡ଼ିକ"
+
+#~ msgid "Send Files…"
+#~ msgstr "ଫାଇଲଗୁଡ଼ିକୁ ପଠାନ୍ତୁ…"
+
+#~ msgid "Visibility"
+#~ msgstr "ଦ୍ରୁଶ୍ଯମାନ୍ଯତା"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” ର ଦେଖିବା କ୍ଷମତା"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "ଉପକରଣଗୁଡ଼ିକର ତାଲିକାରୁ '%s' କୁ କାଢ଼ିବେ କି?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "ଯଦି ଆପଣ ସେହି ଉପକରଣକୁ କାଢ଼ନ୍ତି, ତେବେ ଆପଣଙ୍କୁ ତାହା ପରବର୍ତ୍ତୀ ବ୍ୟବହାର ପୂର୍ବରୁ ପୁଣିଥରେ ସେଟ "
+#~ "କରିବାକୁ ହେବ।"
+
+#~ msgid "Device type:"
+#~ msgstr "ଉପକରଣ ପ୍ରକାର:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "ନିର୍ମାତା:"
+
+#~ msgid "Model:"
+#~ msgstr "ମୋଡେଲ:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "ଉପର ଲିଖିତ ସ୍ଥାନଗୁଡ଼ିକୁ ସ୍ୱୟଂ-ସମ୍ପୂର୍ଣ୍ଣ କରିବା ପାଇଁ ପ୍ରତିଛବି ଫାଇଲଗୁଡ଼ିକୁ ଏହି ୱିଣ୍ଡୋରେ ଅଣା ହୋଇଛି।"
+
+#~ msgid "Left Shift"
+#~ msgstr "ବାମ Shift"
+
+#~ msgid "Left Alt"
+#~ msgstr "ବାମ Alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "ବାମ Ctrl"
+
+#~ msgid "Right Shift"
+#~ msgstr "ଡାହାଣ  Shift"
+
+#~ msgid "Right Alt"
+#~ msgstr "ଡାହାଣ  Alt"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "ଡାହାଣ  Ctrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "ବାମ Alt+Shift"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "ଡ଼ାହାଣ Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "ବାମ Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "ଡ଼ାହାଣ Ctrl+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "ବାମ+ଡ଼ାହାଣ Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "ବାମ+ଡ଼ାହାଣ Ctrl"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "Caps"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "_Region:"
+#~ msgstr "ଅଞ୍ଚଳ (_R):"
+
+#~ msgid "_City:"
+#~ msgstr "ସହର (_i):"
+
+#~ msgid "_Network Time"
+#~ msgstr "ନେଟୱର୍କ ସମୟ (_N)"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "ସମୟକୁ ଗୋଟିଏ ଘଣ୍ଟା ଆଗକୁ ସେଟ କରନ୍ତୁ।"
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "ସମୟକୁ ଗୋଟିଏ ଘଣ୍ଟା ପଛକୁ ସେଟ କରନ୍ତୁ।"
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "ସମୟକୁ ଗୋଟିଏ ମିନଟ ଆଗକୁ ସେଟ କରନ୍ତୁ।"
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "ସମୟକୁ ଗୋଟିଏ ମିନଟ ପଛକୁ ସେଟ କରନ୍ତୁ।"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM ଏବଂ PM ମଧ୍ଯରେ ଅଦଳ ବଦଳ କରନ୍ତୁ।"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "ସ୍ବାଭାବିକ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "ଉତ୍ତରାବର୍ତ୍ତୀ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "ଦକ୍ଷିଣାବର୍ତ୍ତୀ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 ଡିଗ୍ରୀ"
+
+#~ msgid "Monitor"
+#~ msgstr "ମନିଟର"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "ପ୍ରାଥମିକ ପ୍ରଦର୍ଶନୀକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ଟାଣନ୍ତୁ।"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "ଏକ ମନିଟରର ଗୁଣଧର୍ମ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ ବାଛନ୍ତୁ; ତାହାର ସ୍ଥାନକୁ ପୁନଃସଂରଚନା କରିବା ପାଇଁ "
+#~ "ଟାଣନ୍ତୁ।"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "ସଂରଚନାକୁ ପ୍ରୟୋଗ କରିବାରେ ବିଫଳ : %s"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "ପ୍ରଦର୍ଶିକା ସଂରଚନାକୁ ସଂରକ୍ଷଣ କରିପାରିଲା ନାହିଁ"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "ପ୍ରଦର୍ଶନଗୁଡ଼ିକୁ ଯାଞ୍ଚକରିପାରିଲା ନାହିଁ"
+
+#~ msgid "_Resolution"
+#~ msgstr "ବିଭେଦନ (_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "ଘୂର୍ଣ୍ଣନ (_o)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "ପ୍ରତିବିମ୍ବ ପ୍ରଦର୍ଶନ (_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "ଟିପ୍ପଣୀ: ହୁଏତଃ ସୀମା ବିଭେଦନ ବିକଳ୍ପଗୁଡ଼ିକ"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "ପ୍ରଦର୍ଶନୀଗୁଡ଼ିକୁ ଯାଞ୍ଚକରନ୍ତୁ (_D)"
+
+#~ msgid "Install Updates"
+#~ msgstr "ଅଦ୍ୟତନଗୁଡ଼ିକୁ ସ୍ଥାପନ କରନ୍ତୁ"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "ତନ୍ତ୍ର ଅଦ୍ୟତିତ ଅଛି"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "ମାଉସ ପସନ୍ଦ"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "ବିଷୟବସ୍ତୁ ଅଙ୍ଗୁଳିଗୁଡ଼ିକରେ ଲାଗିଥାଏ (_o)"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "ନୂତନ ସର୍ଭିସ ପାଇଁ ବ୍ୟବହାର କରିବାକୁ ଥିବା ଅନ୍ତରାପୃଷ୍ଠକୁ ବାଛନ୍ତୁ"
+
+#~ msgid "C_reate…"
+#~ msgstr "ସୃଷ୍ଟି କରନ୍ତୁ (_r)…"
+
+#~ msgid "_Interface"
+#~ msgstr "ଅନ୍ତରାପୃଷ୍ଠ (_I)"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "ବ୍ୟାଟେରୀ କ୍ଷମତା ମାପୁଅଛି: %s"
+
+#~ msgid "_Default"
+#~ msgstr "ପୂର୍ବ ନିର୍ଦ୍ଧାରିତ (_D)"
+
+#~ msgid "Hidden"
+#~ msgstr "ଲୁକ୍କାଇତ"
+
+#~ msgid "Visible"
+#~ msgstr "ଦୃଶ୍ଯମାନ"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "ନାମ ଏବଂ ଦ୍ରୁଶ୍ଯମାନ୍ଯତା"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "ଆପଣ ପରଦା ଏବଂ ନେଟୱର୍କରେ କିପରି ଦେଖାଯିବେ ତାହାକୁ ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ।"
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "ଉପର ପଟିରେ ସମ୍ପୂର୍ଣ୍ଣ ନାମ ଦର୍ଶାନ୍ତୁ (_f)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "ତାଲା ଲାଗିଥିବା ପରଦାରେ ସମ୍ପୂର୍ଣ୍ଣ ନାମ ଦର୍ଶାନ୍ତୁ (_l)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "ବଦଳାଇବା ଧାରା (_S)"
+
+#~ msgid "Immediately"
+#~ msgstr "ଯଥାଶୀଘ୍ର"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "କିଛି ନାହିଁ"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "ସାର୍ବଜନିକ ଫୋଲଡରକୁ ସହଭାଗ କରନ୍ତୁ"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "କେବଳ ବିଶ୍ୱସ୍ତ ଉପକରଣଗୁଡ଼ିକ ସହିତ ସହଭାଗ କରନ୍ତୁ"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "ଏହି ନେଟୱର୍କରେ ମେଡିଆ ସହଭାଗ କରିପାରିବେ"
+
+#~ msgid "Shared Folders"
+#~ msgstr "ସହଭାଗୀ ଫୋଲଡରଗୁଡ଼ିକ"
+
+#~ msgid "column"
+#~ msgstr "ସ୍ତମ୍ଭ"
+
+#~ msgid "Remove Folder"
+#~ msgstr "ଫୋଲଡ଼ରକୁ କାଢ଼ିବେ କି"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "ଏହି ନେଟୱର୍କରେ ସାର୍ବଜନିକ ଫାଇଲକୁ ସହଭାଗ କରନ୍ତୁ"
+
+#~ msgid "Remote View"
+#~ msgstr "ସୁଦୂର ଦୃଶ୍ୟ"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "ସମସ୍ତ ସଂଯୋଗକୁ ଅନୁମତି ଦିଅନ୍ତୁ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "ସାଧାରଣ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "ଉଚ୍ଚ/ବିପରିତ"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "ଅନ-ସ୍କ୍ରିନ କି-ବୋର୍ଡ"
+
+#~ msgid "OnBoard"
+#~ msgstr "ଅନବୋର୍ଡ"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "ସାଧାରଣ"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "ବୃହତ୍ତର"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Caps ଏବଂ Num Lock ହୋଇଥିଲେ ଦପ ଦପ କରନ୍ତୁ"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "ଅନ କିମ୍ବା ଅଫ କରନ୍ତୁ:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "ଛୋଟବଡ଼ କରନ୍ତୁ"
+
+#~ msgid "Zoom in:"
+#~ msgstr "ବଡ଼ କରନ୍ତୁ:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "ଛୋଟ କରନ୍ତୁ:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "ବନ୍ଦଥିବା ଅନୁଶୀର୍ଷକ"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "ସ୍ୱର ଏବଂ ଧ୍ୱନୀର ପାଠ୍ୟ ବର୍ଣ୍ଣନା ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "ଅନ-ସ୍କ୍ରିନ କି-ବୋର୍ଡ"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "ଲମ୍ବା"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "ମିଟିମିଟି କରିଥାଏ ଯେତେବେଳେ ଏକ କି କୁ"
+
+#~ msgid "pressed"
+#~ msgstr "ଦବାଗଲା"
+
+#~ msgid "accepted"
+#~ msgstr "ଗୃହିତ"
+
+#~ msgid "rejected"
+#~ msgstr "ଅସ୍ବୀକୃତ"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "ଗ୍ରହଣ କରିବାରେ ବିଳମ୍ବ (_e):"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "କି ପ୍ୟାଡ ବ୍ୟବହାର କରି ସୂଚକକୁ ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ"
+
+#~ msgid "Video Mouse"
+#~ msgstr "ଭିଡ଼ିଓ ମାଉସ"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "ଭିଡ଼ିଓ କ୍ୟାମେରା ବ୍ୟବହାର କରି ସୂଚକକୁ ନିୟନ୍ତ୍ରଣ କରନ୍ତୁ।"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "ଛୋଟ"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "ବଡ"
+
+#~ msgid "Mouse Settings"
+#~ msgstr "ମାଉସ ସେଟିଙ୍ଗଗୁଡିକ"
+
+#~ msgid "Add account"
+#~ msgstr "ଖାତା ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid "_Local Account"
+#~ msgstr "ସ୍ଥାନିୟ ଖାତା (_L)"
+
+#~ msgid "_Login Name"
+#~ msgstr "ଲଗଇନ ନାମ (_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "ସୂଚନା: ବାଣିଜ୍ୟିକ ଡମେନ କିମ୍ବା realm ନାମ"
+
+#~ msgid "C_ontinue"
+#~ msgstr "ଆଗକୁ ବଢନ୍ତୁ (_o)"
+
+#~ msgid "Previous Week"
+#~ msgstr "ପୂର୍ବବର୍ତ୍ତୀ ସପ୍ତାହ"
+
+#~ msgid "Next Week"
+#~ msgstr "ପରବର୍ତ୍ତୀ ସପ୍ତାହ"
+
+#~ msgid "Next week"
+#~ msgstr "ପରବର୍ତ୍ତୀ ସପ୍ତାହ"
+
+#~ msgid "Log in without a password"
+#~ msgstr "ବିନା ପ୍ରବେଶ ସଂକେତରେ ଲଗଇନ କରନ୍ତୁ"
+
+#~ msgid "Disable this account"
+#~ msgstr "ଏହି ଖାତାକୁ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
+
+#~ msgid "Enable this account"
+#~ msgstr "ଏହି ଖାତାକୁ ସକ୍ରିୟ କରନ୍ତୁ"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତ ନିଶ୍ଚିତ କରନ୍ତୁ (_o)"
+
+#~ msgid "Generate a password"
+#~ msgstr "ଗୋଟିଏ ପ୍ରବେଶ ସଙ୍କେତ ସେଟ କରନ୍ତୁ"
+
+#~ msgid "_Action"
+#~ msgstr "କାର୍ଯ୍ଯ (_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତ ଦେଖାନ୍ତୁ (_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "ଏକ ଶକ୍ତିଶାଳୀ ପ୍ରବେଶ ସଂକେତକୁ କିପରି ବାଛିବେ"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "ଏହା ପାଇଁ ଫୋଟୋକୁ ବଦଳାଉଛି:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "ଏହି ଖାତା ପାଇଁ ଲଗଇନ ପରଦାରେ ଦର୍ଶାଇବାକୁ ଥିବା ଛବିକୁ ବାଛନ୍ତୁ।"
+
+#~ msgid "Gallery"
+#~ msgstr "ଗ୍ୟାଲେରୀ"
+
+#~ msgid "Take a photograph"
+#~ msgstr "ଗୋଟିଏ ଫଟୋ ନିଅନ୍ତୁ"
+
+#~ msgid "Browse"
+#~ msgstr "ବ୍ରାଉଜ କରନ୍ତୁ"
+
+#~ msgid "Photograph"
+#~ msgstr "ଫୋଟୋଗ୍ରାଫ"
+
+#~ msgid "Account Information"
+#~ msgstr "ଖାତା ସୂଚନା"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "ଅତି କ୍ଷୁଦ୍ର ଅଟେ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "ଯଥେଷ୍ଟ ଊଲ ନାହିଁ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "ଦୁର୍ବଳ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "ଉପଯୁକ୍ତ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "ଉତ୍ତମ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "ଶକ୍ତିଶାଳୀ"
+
+#~ msgid "_Generate a password"
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତ ସେଟ କରନ୍ତୁ (_G)"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "ଆପଣଙ୍କୁ ଗୋଟିଏ ନୂତନ ପ୍ରବେଶ ସଙ୍କେତ ଭରଣ କରିବାକୁ ହେବ"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "ନୂତନ ପ୍ରବେଶ ସଙ୍କେତଟି ଯଥେଷ୍ଟ ଛୋଟ ନୁହଁ"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "ଆପଣଙ୍କୁ ପ୍ରବେଶ ସଂକେତ ନିଶ୍ଚିତ କରିବାକୁ ହେବ"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "ଆପଣଙ୍କୁ ନିଜର ପ୍ରଚଳିତ ପ୍ରବେଶ ସଂକେତ ଭରଣ କରିବାକୁ ହେବ"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "ପ୍ରଚଳିତ ପ୍ରବେଶ ସଙ୍କେତଟି ଠିକ ନୁହଁ"
+
+#~ msgid "Wrong password"
+#~ msgstr "ଭୁଲ ପ୍ରବେଶ ସଙ୍କେତ"
+
+#~ msgid "Switch Modes"
+#~ msgstr "ବଦଳାଇବା ଧାରା"
+
+#~ msgid "Action"
+#~ msgstr "କାର୍ଯ୍ଯ"
+
+#~ msgid "Export"
+#~ msgstr "ରତ୍ପାନୀ କର"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "ମନ୍ଥର"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "ଦ୍ରୁତ"
+
+#~ msgid "_Options…"
+#~ msgstr "ବିକଳ୍ପଗୁଡ଼ିକ (_O)…"
+
+#~ msgid "blablabla"
+#~ msgstr "ଏହିପରି କିଛି"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "ଠିକଣା\n"
+#~ "ବିଭାଗ\n"
+#~ "ଯାଇଥାଏ\n"
+#~ "ଏଠାରେ"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "ବିଭାଗ\n"
+#~ "ଯାଇଥାଏ\n"
+#~ "ଏଠାରେ"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "ପଥଗୁଡ଼ିକ\n"
+#~ "ବିଭାଗ\n"
+#~ "ଯାଇଥାଏ\n"
+#~ "ଏଠାରେ"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "Change the background"
+#~ msgstr "ପୃଷ୍ଠଭୂମିକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "ବ୍ଲୁଟୁଥ ସଂରଚନାକୁ ବିନ୍ୟାସ କରନ୍ତୁ"
+
+#~ msgid "Browse Files..."
+#~ msgstr "ଫାଇଲଗୁଡ଼ିକୁ ବ୍ରାଉଜ କରନ୍ତୁ..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "ବ୍ଲୁଟୁଥ"
+
+#~ msgid "Create virtual device"
+#~ msgstr "ଗୋଟିଏ ଆଭାସୀ ଉପକରଣ ନିର୍ମାଣ କରନ୍ତୁ"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "ଦର୍ଶାଇବା ପାଇଁ ଉପଲବ୍ଧ ରୂପରେଖାଗୁଡ଼ିକ"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "କ୍ରମବୀକ୍ଷଣ ପାଇଁ ଉପଲବ୍ଧ ରୂପରେଖାଗୁଡ଼ିକ"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "ମୁଦ୍ରଣୀ ପାଇଁ ଉପଲବ୍ଧ ରୂପରେଖାଗୁଡ଼ିକ"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "କ୍ୟାମେରା ପାଇଁ ଉପଲବ୍ଧ ରୂପରେଖାଗୁଡ଼ିକ"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "ୱେବକ୍ୟାମ ପାଇଁ ଉପଲବ୍ଧ ରୂପରେଖାଗୁଡ଼ିକ"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i ବର୍ଷ"
+#~ msgstr[1] "%i ବର୍ଷ"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i ମାସ"
+#~ msgstr[1] "%i ମାସ"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i ସପ୍ତାହ"
+#~ msgstr[1] "%i ସପ୍ତାହ"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "1 ସପ୍ତାହରୁ କମ"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "ଏହି ଉପକରଣଟି ରଙ୍ଗ ଦ୍ୱାରା ପରିଚାଳିତ ନୁହଁ।"
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "ଏହି ଉପକରଣଟି ନିର୍ମାଣକର୍ତ୍ତା ମପା ତଥ୍ୟକୁ ବ୍ୟବହାର କରୁଅଛି।"
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "ସମ୍ପୂର୍ଣ୍ଣ-ପରଦା ରଙ୍ଗ ସଂଶୋଧନ ପାଇଁ ଉପଯୁକ୍ତ ରୂପରେଖା ଏହି ଉପକରଣରେ ନାହିଁ।"
+
+#~ msgid "Not specified"
+#~ msgstr " ନିର୍ଦ୍ଦିଷ୍ଟ ହୋଇ ନାହିଁ"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "ରଙ୍ଗ ପରିଚାଳନାକୁ ସହାୟତା କରୁଥିବା କୌଣସି ଉପକରଣ ମିଳୁନାହିଁ"
+
+#~ msgid "Add device"
+#~ msgstr "ଉପକରଣକୁ ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "ଗୋଟିଏ ଆଭାସୀ ଉପକରଣ ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid "Remove a device"
+#~ msgstr "ଏକ ଉପକରଣ ବାହାର କରନ୍ତୁ"
+
+#~ msgid "Color management settings"
+#~ msgstr "ରଙ୍ଗ ପରିଚାଳନା ବ୍ୟବସ୍ଥାଗୁଡ଼ିକ"
+
+#~ msgid "English"
+#~ msgstr "ଇଂରାଜୀ"
+
+#~ msgid "British English"
+#~ msgstr "ବ୍ରିଟିସ ଇଂରାଜୀ"
+
+#~ msgid "German"
+#~ msgstr "ଜର୍ମାନ"
+
+#~ msgid "French"
+#~ msgstr "ଫ୍ରେଞ୍ଚ"
+
+#~ msgid "Spanish"
+#~ msgstr "ସ୍ପେନିସ"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "ଚାଇନିଜ (ସରଳିକୃତ)"
+
+#~ msgid "Russian"
+#~ msgstr "ରୁସିଆନ"
+
+#~ msgid "Arabic"
+#~ msgstr "ଆରବିକ"
+
+#~ msgid "Select a region"
+#~ msgstr "ଏକ  ସ୍ଥାନ ବାଛନ୍ତୁ"
+
+#~ msgid "Unspecified"
+#~ msgstr "ଅନିର୍ଦ୍ଦିଷ୍ଟ"
+
+#~ msgid "Select a language"
+#~ msgstr "ଗୋଟିଏ ଭାଷା ଚୟନକରନ୍ତୁ"
+
+#~ msgid "_Select"
+#~ msgstr "ବାଛନ୍ତୁ (_S)"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "ତାରିଖ ଏବଂ ସମୟ ପସନ୍ଦ ପ୍ୟାନେଲ"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "ଅଜଣା ମଡେଲ"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "ପରବର୍ତ୍ତୀ ଲଗଇନ ମାନକ ଅଭିଜ୍ଞ୍ୟତାକୁ ବ୍ୟବହାର କରିବା ପାଇଁ ଚେଷ୍ଟା କରିବ।"
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "ଅସମର୍ଥିତ ଆଲେଖିକ ହାର୍ଡୱେର ପାଇଁ ବ୍ୟବହୃତ ପରବର୍ତ୍ତୀ ଲଗଇନଟି ଫଲବ୍ୟାକ ଧାରାକୁ ବ୍ୟବହାର କରିବ।"
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "ଆବର୍ତ୍ତନ"
+
+#~ msgid "System Information"
+#~ msgstr "ତନ୍ତ୍ର ସୂଚନା"
+
+#~ msgid "OS type"
+#~ msgstr "OS ପ୍ରକାର"
+
+#~ msgid "_Other Media..."
+#~ msgstr "ଅନ୍ଯାନ୍ଯ ସଞ୍ଚାର ମାଧ୍ଯମ (_O)..."
+
+#~ msgid "Experience"
+#~ msgstr "ଅଭିଜ୍ଞତା"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "ବାଧ୍ୟତାମୂଳକ ଫଲବ୍ୟାକ ଧାରା (_F)"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "କିବୋର୍ଡ ସଂରଚନାକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#~ msgid "Layout Settings"
+#~ msgstr "ସଂରଚନା ସେଟିଙ୍ଗଗୁଡିକ"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "ଆପଣଙ୍କର ମାଉସ  ଏବଂ ଟଚପ୍ୟାଡ ପସନ୍ଦ ଗୁଡିକୁ ସ୍ଥିର କରନ୍ତୁ"
+
+#~ msgid "Network settings"
+#~ msgstr "ନେଟୱର୍କ ସଂରଚନା"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "ନେଟୱର୍କ;ବେତାର;IP;LAN;ପ୍ରକ୍ସି;"
+
+#~| msgid "Out of toner"
+#~ msgid "Out of range"
+#~ msgstr "ସୀମା ବାହାରେ"
+
+#~ msgid "_Options..."
+#~ msgstr "ବିକଳ୍ପଗୁଡ଼ିକ (_O)..."
+
+#~ msgid "C_reate..."
+#~ msgstr "ସୃଷ୍ଟି କରନ୍ତୁ (_r)..."
+
+#~ msgid "_Configure..."
+#~ msgstr "ବିନ୍ୟାସ କରନ୍ତୁ (_C)..."
+
+#~| msgid "Wireless mouse"
+#~ msgid "Wireless Hotspot"
+#~ msgstr "ବେତାର ହଟସ୍ପଟ"
+
+#~ msgid "Wireless"
+#~ msgstr "ବେତାର"
+
+#~| msgid "Disconnected"
+#~ msgid "_Disconnect"
+#~ msgstr "ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ (_D)"
+
+#~| msgid "Connected"
+#~ msgid "_Connect"
+#~ msgstr "ସଂଯୋଗ କରନ୍ତୁ (_C)"
+
+#~ msgid "Mesh"
+#~ msgstr "ମେଶ"
+
+#~ msgid "Disconnected"
+#~ msgstr "ବିଛିନ୍ନହୋଇଥିବା"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "ବାହକ/ସଂଯୋଗିକୀ ପରିବର୍ତ୍ତନ ହୋଇଛି"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "ପ୍ରମାଣପତ୍ରର ସମୟ ସମାପ୍ତ ହୋଇଛି। ଦୟାକରି ପୁଣିଥରେ ଲଗଇନ କରନ୍ତୁ।"
+
+#~ msgid "_Log In"
+#~ msgstr "ଲଗଇନ (_L)"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "ଅନଲାଇନ ଖାତାଗୁଡ଼ିକୁ ପରିଚାଳନା କରନ୍ତୁ"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "ବିପଦ ବ୍ୟାଟେରୀ କମ ଅଛି, %s ବଳିଅଛି"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତିକୁ ବ୍ଯବହାର କରୁଅଛି - %s ବଳିଅଛି"
+
+#~ msgid "Using battery power"
+#~ msgstr "ବ୍ୟାଟେରୀ ଶକ୍ତି ବ୍ୟବହାର କରୁଅଛି"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "ଚାର୍ଜ ହେଉଅଛି - ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହୋଇଛି"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "UPS ଶକ୍ତି ବ୍ୟବହାର କରି - %s ବଳିଅଛି"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "ସତର୍କତା UPS କମ ଅଛି"
+
+#~ msgid "Using UPS power"
+#~ msgstr "UPS ଶକ୍ତି ବ୍ୟବହାର କରି"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "ଆପଣଙ୍କର ବ୍ୟାଟେରୀ ଶକ୍ତି ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହୋଇଛି"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "ଆପଣଙ୍କର ଦ୍ୱିତୀୟ ବ୍ୟାଟେରୀଟି ଖାଲି ଅଛି"
+
+#~| msgid "Charging - fully charged"
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "ଚାର୍ଜ ହେଉଅଛି - ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଚାର୍ଜ ହୋଇଛି"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "ସୂଚନା: <a href=\"screen\">ପରଦା ଉଜ୍ଜ୍ୱଳତା</a> କେତେ ବିଦ୍ୟୁତ ଶକ୍ତି ଉପରେ ପ୍ରଭାବ ପକାଇଥାଏ"
+
+#~ msgid "Power management settings"
+#~ msgstr "ଶକ୍ତି ପରିଚାଳନା ସଂରଚନା"
+
+#~ msgid "Don't suspend"
+#~ msgstr "ନିଲମ୍ବନ କରନ୍ତୁ ନାହିଁ"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "ଏତିକି ସମୟ ପାଇଁ ନିଷ୍କ୍ରିୟ ଥିବା ସମୟରେ ନିଲମ୍ବିତ କରନ୍ତୁ"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "ବିରାମ ହୋଇଥିବା"
+
+#~ msgid "Change printer settings"
+#~ msgstr "ମୁଦ୍ରଣୀ ବିନ୍ୟାସକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#~| msgid "Manufacturer:"
+#~ msgid "Manufacturers"
+#~ msgstr "ନିର୍ମାତା"
+
+#~| msgid "Driver"
+#~ msgid "Drivers"
+#~ msgstr "ଡ୍ରାଇଭର"
+
+#~ msgid "_Show"
+#~ msgstr "ଦର୍ଶାନ୍ତୁ (_S)"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "ଆପଣଙ୍କର ଅଞ୍ଚଳ ଏବଂ ଭାଷା ବିନ୍ୟାସକୁ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#~| msgid "Select an input source to add"
+#~ msgid "Choose an input source"
+#~ msgstr "ଗୋଟିଏ ନିବେଶ ଉତ୍ସ ବାଛନ୍ତୁ"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "ଯୋଗ କରିବା ପାଇଁ ଗୋଟିଏ ନିବେଶ ଉତ୍ସ ବାଛନ୍ତୁ"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "ଲଗଇନ ପରଦା, ତନ୍ତ୍ର ଖାତା ଏବଂ ଚାଳକ ଖାତା ତନ୍ତ୍ର ମୟ ସ୍ଥାନ ଏବଂ ଭାଷା ବିନ୍ୟାସକୁ ବ୍ୟବହାର "
+#~ "କରିଥାଏ।"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "ଲଗଇନ ପରଦା, ତନ୍ତ୍ର ଖାତା ଏବଂ ଚାଳକ ଖାତା ତନ୍ତ୍ର ମୟ ସ୍ଥାନ ଏବଂ ଭାଷା ବିନ୍ୟାସକୁ ବ୍ୟବହାର "
+#~ "କରିଥାଏ। ଆପଣ ନିଜ ଅନୁସାରେ ତନ୍ତ୍ର ବିନ୍ୟାସକୁ ପରିବର୍ତ୍ତନ କରିପାରିବେ।"
+
+#~ msgid "Copy Settings"
+#~ msgstr "ସେଟିଙ୍ଗଗୁଡିକୁ ନକଲ କରନ୍ତୁ"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "ସେଟିଙ୍ଗଗୁଡିକୁ ନକଲ କରନ୍ତୁ..."
+
+#~ msgid "Region and Language"
+#~ msgstr "ଅଞ୍ଚଳ ଏବଂ ଭାଷା"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "ଏକ ପ୍ରଦର୍ଶନୀ ଭାଷା ବାଛନ୍ତୁ (ପରବର୍ତ୍ତୀ ସମୟରେ ଲଗଇନ ହେବା ସମୟରେ ପରିବର୍ତ୍ତନଗୁଡ଼ିକ ଲାଗୁ ହେବ)"
+
+#~ msgid "Add Language"
+#~ msgstr "ଭାଷା ଯୋଗକରନ୍ତୁ"
+
+#~ msgid "Remove Language"
+#~ msgstr "ଭାଷାକୁ ବାହାର କରନ୍ତୁ"
+
+#~ msgid "Install languages..."
+#~ msgstr "ଭାଷାଗୁଡ଼ିକୁ ସ୍ଥାପନ କରନ୍ତୁ..."
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "ଏକ ଅଞ୍ଚଳ ବାଛନ୍ତୁ (ପରବର୍ତ୍ତୀ ସମୟରେ ଲଗଇନ ହେବା ସମୟରେ ପରିବର୍ତ୍ତନଗୁଡ଼ିକ ଲାଗୁ ହେବ)"
+
+#~ msgid "Add Region"
+#~ msgstr "ଅଞ୍ଚଳ ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid "Currency"
+#~ msgstr "ମୁଦ୍ରା"
+
+#~ msgid "Examples"
+#~ msgstr "ଉଦାହରଣ"
+
+#~| msgid "Select an input source to add"
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "କିବୋର୍ଡ କିମ୍ବା ଅନ୍ୟାନ୍ୟ ନିବେଶ ଉତ୍ସ ବାଛନ୍ତୁ"
+
+#~| msgid "Input source:"
+#~ msgid "Remove Input Source"
+#~ msgstr "ନିବେଶ ଉତ୍ସକୁ ବାହାର କରନ୍ତୁ"
+
+#~| msgid "Input source:"
+#~ msgid "Move Input Source Up"
+#~ msgstr "ନିବେଶ ଉତ୍ସକୁ ଉପରକୁ ଘୁଞ୍ଚାନ୍ତୁ"
+
+#~| msgid "Keyboard Layout Options"
+#~ msgid "Show Keyboard Layout"
+#~ msgstr "କିବୋର୍ଡ ବିନ୍ୟାସ ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~| msgid "Sound Settings"
+#~ msgid "Shortcut Settings"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ ସେଟିଙ୍ଗଗୁଡିକ"
+
+#~ msgid "Display language:"
+#~ msgstr "ଭାଷା ଦର୍ଶାନ୍ତୁ:"
+
+#~ msgid "Input source:"
+#~ msgstr "ନିବେଶ ଉତ୍ସ:"
+
+#~ msgid "Format:"
+#~ msgstr "ଫର୍ମାଟ:"
+
+#~ msgid "Your settings"
+#~ msgstr "ଆପଣଙ୍କର ବିନ୍ୟାସଗୁଡ଼ିକ"
+
+#~ msgid "System settings"
+#~ msgstr "ତନ୍ତ୍ର ବିନ୍ୟାସ"
+
+#~| msgid "Brightness and Lock"
+#~ msgid "Brightness & Lock"
+#~ msgstr "ଉଜ୍ଜ୍ବଳତା ଏବଂ ତାଲା"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "ପରଦା ଉଜ୍ଜ୍ୱଳତା ଏବଂ ତାଲା ସଂରଚନା"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "ଉଜ୍ଜ୍ବଳତା;ତାଲା;ଧିମା;ଖାଲି;ମନିଟର;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "ଶକ୍ତି ସଂରକ୍ଷଣ ପାଇଁ ପରଦାକୁ ଧିମା କରନ୍ତୁ (_D)"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "ଘରେ ଥିବା ସମୟରେ ତାଲା ପକାନ୍ତୁ ନାହିଁ"
+
+#~ msgid "Locations..."
+#~ msgstr "ଅବସ୍ଥାନ..."
+
+#~ msgid "Lock"
+#~ msgstr "ତାଲା ଦେଇ ରଖନ୍ତୁ"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "ତ୍ରୁଟି ନିବାରଣ ସଂକେତକୁ ସକ୍ରିୟ କରନ୍ତୁ"
+
+#~ msgid "Version of this application"
+#~ msgstr "ଏହି ପ୍ରୟୋଗର ସଂସ୍କରଣ"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — GNOME ଭଲ୍ୟୁମ ନିୟନ୍ତ୍ରଣ ଆପଲେଟ"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "ଡେସ୍କଟପ ଭଲ୍ୟୁମ ନିୟନ୍ତ୍ରଣ ଦର୍ଶାନ୍ତୁ"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "ଧ୍ୱନି ଫଳାଫଳ ଭଲ୍ଯୁମ"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "ମାଇକ୍ରୋଫନ ଭଲ୍ଯୁମ"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "ଧ୍ୱନି ପସନ୍ଦ ଆରମ୍ଭ କରିବାରେ ବିଫଳ: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "ନିରବ (_M)"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "ଧ୍ୱନି ପସନ୍ଦ (_S)"
+
+#~ msgid "Muted"
+#~ msgstr "ନିରବ କରାଯାଇଛି"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "ଜାଗତିକ ଅଭିଗମ୍ୟତା ପସନ୍ଦଗୁଡ଼ିକ"
+
+#~ msgid "Options..."
+#~ msgstr "ବିକଳ୍ପଗୁଡିକ..."
+
+#, fuzzy
+#~| msgid "Color"
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "ରଙ୍ଗ"
+
+#, fuzzy
+#~| msgid "None"
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "କିଛି ନୁହେଁ"
+
+#~ msgid "User Accounts"
+#~ msgstr "ଚାଳକ ଖାତା"
+
+#~ msgid "_Hint"
+#~ msgstr "ଆଭାସ (_H)"
+
+#~ msgid "Fair"
+#~ msgstr "ଉପଯୁକ୍ତ"
+
+#, fuzzy
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "'%s' ଦ୍ବାରା ନାମିତ ହୋଇଥିବା ଗୋଟିଏଚାଳକ ନାମ ପୂର୍ବରୁ ରହିଛି।"
+
+#~ msgid "This user does not exist."
+#~ msgstr "ଚାଳକ ଟିି ଅବସ୍ଥିତ ନୁହେଁ।"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "ଆପଣଙ୍କର ୱାକମ ଟ୍ୟାବଲେଟ ପସନ୍ଦ ଗୁଡିକୁ ସ୍ଥିର କରନ୍ତୁ"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "ମେଳାଇବା ବଟନଗୁଡ଼ିକ..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "ମାପନ୍ତୁ..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- ତନ୍ତ୍ର ବିନ୍ୟାସ"
+
+#~ msgid "Control Center"
+#~ msgstr "ନିୟନ୍ତ୍ରଣ କେନ୍ଦ୍ର"
+
+#~ msgid "System Settings"
+#~ msgstr "ତନ୍ତ୍ର ବିନ୍ୟାସ"
+
+#~ msgid "Security Key"
+#~ msgstr "ସୁରକ୍ଷା କି"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "ସବନେଟ ମାସ୍କ"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "ୱାଲପେପର ଯୋଗ କରନ୍ତୁ"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "ୱାଲପେପର ହଟାଅ"
+
+#~ msgid "Swap colors"
+#~ msgstr "ରଙ୍ଗ ପରିବର୍ତ୍ତନ କରନ୍ତୁ"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "ସମାନ୍ତରାଳ ଅନୁପାତ"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "ଭୂଲମ୍ବ ଅନୁପାତ"
+
+#~ msgid "Solid Color"
+#~ msgstr "କଠିନ ରଙ୍ଗ"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "ରଙ୍ଗ ଏବଂ ଅନୁପାତ"
+
+#~ msgid "Acti_on:"
+#~ msgstr "କାର୍ଯ୍ଯ (_o):"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "ପରଦା ପ୍ରତିଛବି ନିଅନ୍ତୁ"
+
+#~ msgid "Shortcut"
+#~ msgstr "ସଂକ୍ଷିପ୍ତ ପଥ"
+
+#~ msgid "_Right-handed"
+#~ msgstr "ଡାହାଣ ହାତ (_R)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "ବାମ-ହାତି  (_L)"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "ନିୟନ୍ତ୍ରଣ କି କୁ ଦବାଇବା ସମୟରେ ସୂଚକର ଅବସ୍ଥିତି ଦର୍ଶାନ୍ତୁ (_o)"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "ତ୍ୱରଣ (_c):"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_ସଂବେଦନଶୀଳତା:"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "କାଢନ୍ତୁ ଏବଂ ପକାନ୍ତୁ"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "ଦ୍ୱାର (_e):"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "ପ୍ରଭାବ ସୀମା ଟାଣନ୍ତୁ"
+
+#~ msgid "Double-Click Timeout"
+#~ msgstr "ଦୁଇଥର ଦବାଇବାର ସମୟ ସମାପ୍ତି"
+
+#~ msgid "_Timeout:"
+#~ msgstr "ସମୟ ସମାପ୍ତି (_T):"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr ""
+#~ "ଆପଣଙ୍କର ସଂରଚନାକୁ ପରୀକ୍ଷା କରିବା ପାଇଁ,ସାମ୍ନାରେ ଦୁଇଥର କ୍ଲିକ କରିବା ପାଇଁ ଚେଷ୍ଟା କରନ୍ତୁ।"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "ମାଉସ କ୍ଲିକଗୁଡ଼ିକୁ ଟଚପ୍ୟାଡ ସହିତ ସକ୍ରିୟ କରନ୍ତୁ (_m)"
+
+#~ msgid "Scrolling"
+#~ msgstr "ସ୍କ୍ରୋଲ କରୁଛି"
+
+#~ msgid "_Disabled"
+#~ msgstr "ନିଷ୍କ୍ରିୟ ହୋଇଗଲା (_D)"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "ଅନ୍ଯାନ୍ୟ..."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "ଯେକୌଣସି ପ୍ରକାର ଗୋଟିଏ ହଟସ୍ପଟ ସୃଷ୍ଟି କରନ୍ତୁ?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "%s ରୁ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରି ନୂତନ ହଟସ୍ପଟ ନିର୍ମାଣ କରିବେ କି?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "ଏହା ଇଣ୍ଟରନେଟ ସଂଯୋଗ ପାଇଁ  ଆପଣଙ୍କର କେବଳମାତ୍ର ସଂଯୋଗ।"
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "ହଟସ୍ପଟ ସୃଷ୍ଟି କରନ୍ତୁ (_H)"
+
+#~ msgid "_Network Name"
+#~ msgstr "ନେଟୱର୍କ ନାମ (_N)"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "ହଟସ୍ପଟକୁ ଅଟକାନ୍ତୁ (_S)..."
+
+#~ msgid "Disable VPN"
+#~ msgstr "VPN କୁ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ"
+
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP ପୋର୍ଟ"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "HTTPS ପୋର୍ଟ"
+
+#~ msgid "FTP Port"
+#~ msgstr "FTP ପୋର୍ଟ"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "ଗୋଟିଏ ନୂତନ ଖାତା ଯୋଗ କରିବା ପାଇଁ, ପ୍ରଥମେ ଗୋଟିଏ ଖାତା ପ୍ରକାର ବାଛନ୍ତୁ"
+
+#~ msgid "_Add..."
+#~ msgstr "ଯୋଗ କରନ୍ତୁ (_A)..."
+
+#~ msgid "Tip:"
+#~ msgstr "ପରାମର୍ଶ:"
+
+#~ msgid "Brightness Settings"
+#~ msgstr "ଉଜ୍ଜ୍ବଳତା ସେଟିଙ୍ଗ"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "କେତେ ମାତ୍ରାରେ ଶକ୍ତି ବ୍ୟବହୃତ ହୋଇଛି"
+
+#~ msgid "_Search by Address"
+#~ msgstr "ଠିକଣା ଅନୁସାରେ ସନ୍ଧାନ କରନ୍ତୁ (_S)"
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "ସ୍ଥାନୀୟ"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "ନେଟୱର୍କ"
+
+#~ msgid "Device types"
+#~ msgstr "ଉପକରଣ ପ୍ରକାରମାନ"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "ସ୍ୱୟଂଚାଳିତ ବିନ୍ୟାସ"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "mDNS ସଂଯୋଗଗୁଡ଼ିକ ପାଇଁ ଫାୟାରୱାଲ ଖୋଲୁଅଛି"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Samba ସଂଯୋଗଗୁଡ଼ିକ ପାଇଁ ଫାୟାରୱାଲ ଖୋଲୁଅଛି"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "IPP ସଂଯୋଗଗୁଡ଼ିକ ପାଇଁ ଫାୟାରୱାଲ ଖୋଲୁଅଛି"
+
+#~ msgid "_Back"
+#~ msgstr "ପଛକୁ (_B)"
+
+#~ msgid "Allowed users"
+#~ msgstr "ଚାଳକମାନଙ୍କୁ ଅନୁମତି ଦିଅନ୍ତୁ"
+
+#~ msgid "Add Layout"
+#~ msgstr "ବିନ୍ଯାସ ଯୋଗକରନ୍ତୁ"
+
+#~ msgid "Remove Layout"
+#~ msgstr "ବିନ୍ୟାସ ହଟାଓ"
+
+#~ msgid "Preview Layout"
+#~ msgstr "ବିନ୍ୟାସ ପୂର୍ବାବଲୋକନ"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "ନୂତନ ୱିଣ୍ଡୋଗୁଡ଼ିକ ପୂର୍ବନିର୍ଦ୍ଧାରିତ ବିନ୍ୟାସ ବ୍ୟବହାର କରନ୍ତି"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "ନୂତନ ୱିଣ୍ଡୋଗୁଡ଼ିକ ପୂର୍ବ ୱିଣ୍ଡୋର ବିନ୍ୟାସ ବ୍ୟବହାର କରନ୍ତି"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "କିବୋର୍ଡ ବିନ୍ୟାସ ବିକଳ୍ପଗୁଡ଼ିକୁ ଦେଖନ୍ତୁ ଏବଂ ସମ୍ପାଦନ କରନ୍ତୁ"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ଭାବରେ ପୁନଃସ୍ଥାପନ କରନ୍ତୁ (_f)"
+
+#~ msgid "Layouts"
+#~ msgstr "ଲେପନଗୁଡିକ"
+
+#~ msgid "Layout"
+#~ msgstr "ବିନ୍ଯାସ"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "ବିନ୍ୟାସ କରିବା ପାଇଁ ଗୋଟିଏ ଉପକରଣ ବାଛନ୍ତୁ (_h):"
+
+#~ msgid "Dasher"
+#~ msgstr "ଡେଶର"
+
+#~ msgid "Nomon"
+#~ msgstr "କିଛି ନୁହେଁ"
+
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~ msgid "Change contrast:"
+#~ msgstr "ସ୍ପଷ୍ଟତା ପରିବର୍ତ୍ତନ:"
+
+#~ msgid "_Text size:"
+#~ msgstr "ପାଠ୍ୟ ଆକାର (_T):"
+
+#~ msgid "Increase size:"
+#~ msgstr "ଆକାର ବୃଦ୍ଧିକରନ୍ତୁ:"
+
+#~ msgid "Decrease size:"
+#~ msgstr "ଆକାର ହ୍ରାସ କରନ୍ତୁ:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "ଦେଖାଅ"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "ଛୋଟବଡ଼ କରନ୍ତୁ"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "ପରୀକ୍ଷଣ ବିନ୍ଯାସରେ ଟାଇପ କରନ୍ତୁ"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 ପରଦା"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 ପରଦା"
+
+#~ msgid "Create new account"
+#~ msgstr "ନୂତନ ଖାତା ସୃଷ୍ଟିକରନ୍ତୁ"
+
+#~ msgid "_Account Type"
+#~ msgstr "ଖାତା ପ୍ରକାର (_A)"
+
+#~ msgid "Cr_eate"
+#~ msgstr "ସୃଷ୍ଟି କରନ୍ତୁ (_e)"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "ସୃଷ୍ଟି ହୋଇଥିବା ଏକ ପ୍ରବେଶ ସଙ୍କେତ ବାଛନ୍ତୁ"
+
+#~ msgid "Account _type"
+#~ msgstr "ଖାତା ପ୍ରକାର (_t)"
+
+#~ msgid "More choices..."
+#~ msgstr "ଅଧିକ ପସନ୍ଦଗୁଡ଼ିକ..."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "ୱାକମ ଆଲେଖିକ ଟ୍ୟାବଲେଟ"
+
+#~ msgid "Current network location"
+#~ msgstr "ପ୍ରଚଳିତ ନେଟୱର୍କ ଅବସ୍ଥାନ"
+
+#~ msgid "More themes URL"
+#~ msgstr "ଅଧିକ ପ୍ରସଙ୍ଗ URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "ଏହାକୁ ଆପଣଙ୍କର ପ୍ରଚଳିତ ଅବସ୍ଥାନ ନାମରେ ସେଟ କରନ୍ତୁ। ଏହା ସଠିକ ନେଟୱର୍କ ପ୍ରକ୍ସି ସଂରଚନାକୁ "
+#~ "ନିର୍ଦ୍ଧାରଣ କରିବା ପାଇଁ ବ୍ୟବହାର ହୋଇଥାଏ।"
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "କେଉଁଠି ଅଧିକ ଡେସ୍କଟପ ପୃଷ୍ଠଭୂମି ମିଳିବ ତାହାର URL. ଯଦି କୌଣସି ଖାଲି ବାକ୍ୟଖଣ୍ଡରେ ସେଟ କରାଯାଏ "
+#~ "ତେବେ ସଂଯୋଗଟି ଦୃଶ୍ୟମାନ ହେବ ନାହିଁ।"
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "କେଉଁଠି ଅଧିକ ଡେସ୍କଟପ ପ୍ରସଙ୍ଗ ମିଳିବ ତାହାର URL. ଯଦି କୌଣସି ଖାଲି ବାକ୍ୟଖଣ୍ଡରେ ସେଟ କରାଯାଏ "
+#~ "ତେବେ ସଂଯୋଗଟି ଦୃଶ୍ୟମାନ ହେବ ନାହିଁ।"
+
+#~ msgid "Image/label border"
+#~ msgstr "ଚିତ୍ର/ଚିହ୍ନକ ଧାର"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "ଚେତାବନୀ ସଂଳାପରେ ଚିହ୍ନକ ଓ ଚିତ୍ର ଚାରିପାଖେ ଧାରର ଓସାର"
+
+#~ msgid "The type of alert"
+#~ msgstr "ଚେତାବନୀ ପ୍ରକାର"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "ଚେତାବନୀ ସଂଳାପରେ ପ୍ରଦର୍ଶିତ ଚାବିଗୁଡ଼ିକ"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ବାମ ଅଙ୍ଗୁଠିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "%s ଉପରେ ବାମ ଆଙ୍ଗୁଠିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ବାମ ତର୍ଜନିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ବାମ ତର୍ଜନିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ବାମ ମଝି ଅଙ୍ଗୁଳିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ବାମ ମଝି ଅଙ୍ଗୁଳିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ବାମ ଅନାମିକା ଅଙ୍ଗୁଳିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ବାମ ଅନାମିକା ଅଙ୍ଗୁଳିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ବାମ କାନି ଅଙ୍ଗୁଳିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ବାମ କାନି ଅଙ୍ଗୁଳିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ ଆଙ୍ଗୁଠିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ ଆଙ୍ଗୁଠିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ ତର୍ଜନିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ ତର୍ଜନିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ ମଝି ଆଙ୍ଗୁଠିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ ମଝି ଆଙ୍ଗୁଠିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ ଅନାମିକା ଆଙ୍ଗୁଠିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ ଅନାମିକା ଆଙ୍ଗୁଠିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ କାନି ଆଙ୍ଗୁଠିକୁ ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "%s ଉପରେ ଆପଣଙ୍କର ଡାହାଣ କାନି ଆଙ୍ଗୁଠିକୁ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "ପାଠକ ଉପରେ ପୁଣିଥରେ ଆପଣଙ୍କର ଅଙ୍ଗୁଳି ରଖନ୍ତୁ"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "ଆପଣଙ୍କର ଅଙ୍ଗୁଳିକୁ ପୁଣିଥରେ ବୁଲାନ୍ତୁ"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "ବୁଲାଇବାଟି ଖୁବ ଛୋଟ ଅଛି, ପୁଣିଥରେ ଚେଷ୍ଟାକରନ୍ତୁ"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "ଆପଣଙ୍କର ଅଙ୍ଗୁଳି କେନ୍ଦ୍ରିତ ନୁହଁ, ଆପଣଙ୍କର ଅଙ୍ଗୁଳିକୁ ପୁଣିଥରେ ବୁଲାଇ ଚେଷ୍ଟା କରନ୍ତୁ"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "ଆପଣଙ୍କର ଅଙ୍ଗୁଳିକୁ କାଢ଼ନ୍ତୁ, ଏବଂ ଆପଣଙ୍କର ଅଙ୍ଗୁଳିକୁ ପୁଣିଥରେ ବୁଲାଇ ଚେଷ୍ଟା କରନ୍ତୁ"
+
+#~ msgid "No Image"
+#~ msgstr "କୌଣସି ପ୍ରତିଛବି ନାହିଁ"
+
+#~ msgid "Images"
+#~ msgstr "ପ୍ରତିଛବି"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "ଠିକଣାପୁସ୍ତକ ସୂଚନା ପ୍ରାପ୍ତ କରିବକୁ ଚେଷ୍ଟା କରିବା ବେଳେ ଗୋଟିଏ ତ୍ରୁଟି ଘଟିଥିଲା\n"
+#~ "କ୍ରମବିକାଶ ତଥ୍ଯ ସରଭର ପ୍ରୋଟକଲକୁ ପରିଚାଳନା କରିପାରିବ ନାହିଁ "
+
+#~ msgid "Unable to open address book"
+#~ msgstr "ଠିକଣା ପୁସ୍ତିକାକୁ ଖୋଲିବାରେ ଅସମର୍ଥ"
+
+#~ msgid "About %s"
+#~ msgstr "%s ବିଷୟରେ"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "କମ୍ପାନୀ (_C):"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "ପ୍ରବେଶ ସଙ୍କେତ ବଦଳାନ୍ତୁ... (_r)"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "ସହର (_t):"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "ଦେଶ (_n):"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନକୁ ନିଷ୍କ୍ରିୟ କରନ୍ତୁ (_F)..."
+
+#~ msgid "Email"
+#~ msgstr "ଇ-ଡାକ"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "ଅଙ୍ଗୁଳି ଚିହ୍ନ ଲଗଇନକୁ ସକ୍ରିୟ କରନ୍ତୁ (_F)..."
+
+#~ msgid "Hom_e:"
+#~ msgstr "ମୂଳ ସ୍ଥାନ (_e):"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "ତୁରନ୍ତ ସନ୍ଦେଶପ୍ରବାହ"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "ଡାକ ବାସ୍କ (_b):"
+
+#~ msgid "P._O. box:"
+#~ msgstr "ଡାକ ବାସ୍କ (_b):"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "ରାଜ୍ଯ/ପ୍ରଦେଶ (_v):"
+
+#~ msgid "Web _log:"
+#~ msgstr "ୱେବ ଲଗ (_l):"
+
+#~ msgid "Wor_k:"
+#~ msgstr "କାର୍ଯ୍ଯ (_k):"
+
+#~ msgid "Work"
+#~ msgstr "କାର୍ଯ୍ଯ"
+
+#~ msgid "Work _fax:"
+#~ msgstr "କାର୍ଯ୍ଯସ୍ଥଳ ଫ୍ଯାକ୍ସ (_f):"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "ZIP/ପିନ କୋଡ (_P):"
+
+#~ msgid "_GroupWise:"
+#~ msgstr "ସମୂହଗତ (_G):"
+
+#~ msgid "_Home page:"
+#~ msgstr "ମୂଳସ୍ଥାନ ପୃଷ୍ଠା (_H):"
+
+#~ msgid "_Home:"
+#~ msgstr "ମୂଳସ୍ଥାନ (_H):"
+
+#~ msgid "_State/Province:"
+#~ msgstr "ରାଜ୍ଯ/ପ୍ରଦେଶ (_S):"
+
+#~ msgid "_Work:"
+#~ msgstr "କାର୍ଯ୍ଯ (_W):"
+
+#~ msgid "_XMPP:"
+#~ msgstr "XMPP (_X):"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "ZIP/ପିନ କୋଡ (_Z):"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "ପାଠକ ଉପରେ ଅଙ୍ଗୁଳି ବୁଲାନ୍ତୁ"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "ପାଠକ ଉପରେ ଅଙ୍ଗୁଳି ରଖନ୍ତୁ"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "ନିର୍ଭରକଟି ଅପ୍ରତ୍ଯାଶିତ ଭାବରେ ପ୍ରସ୍ଥାନ କଲା"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO ଉପପଥକୁ ବନ୍ଦ କରିପାରିଲା ନାହିଁ: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdin IO ଉପପଥକୁ ବନ୍ଦ କରିପାରିଲା ନାହିଁ: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "ତନ୍ତ୍ର ତୃଟି: %s।"
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%s କୁ ଆରମ୍ଭ କରିବାରେ ଅସମର୍ଥ: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "ପୃଷ୍ଠଭାଗକୁ ଚଳାଇବାରେ ଅସମର୍ଥ"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "ଗୋଟିଏ ତନ୍ତ୍ର ତୃଟି ପରିଲିଖିତ ହେଲା"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr ""
+#~ "ଆପଣଙ୍କର ପ୍ରବେଶ ସଙ୍କେତକୁ ବଦଳାଇବା ପାଇଁ <b>ପ୍ରବେଶ ସଙ୍କେତ ପରିବର୍ତ୍ତନ କରନ୍ତୁ</b> କୁ ଦବାନ୍ତୁ।"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "ଦୟାକରି ଆପଣଙ୍କ ପ୍ରବେଶ ସଙ୍କେତକୁ ପୁନର୍ବାର <b>ନୂତନ ପ୍ରବେଶ ସଙ୍କେତ ପୁନଃ ଟାଇପ କରନ୍ତୁ</b> "
+#~ "କ୍ଷେତ୍ରରେ ଟାଇପ କରନ୍ତୁ।"
+
+#~ msgid "Change your password"
+#~ msgstr "ଆପଣଙ୍କର ପ୍ରବେଶ ସଙ୍କେତ ବଦଳାନ୍ତୁ"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "ଆପଣଙ୍କର ଗୁପ୍ତଶବ୍ଦକୁ ପରିବର୍ତ୍ତନ କରିବା ପାଇଁ, ତଳ କ୍ଷେତ୍ରରେ ଆପଣଙ୍କର ଚଳିତ ଗୁପ୍ତଶବ୍ଦକୁ ପ୍ରବିଷ୍ଟ କରନ୍ତୁ "
+#~ "ଏବଂ  <b>ପ୍ରମାଣିତକର</b>ରେ କ୍ଲିକ କରନ୍ତୁ\n"
+#~ "ଆପଣ ପ୍ରମାଣିତ କରିବା ପରେ, ଆପଣଙ୍କର ନୂଆ ଗୁପ୍ତଶବ୍ଦକୁ ପ୍ରବିଷ୍ଟ କରନ୍ତୁ, ପରୀକ୍ଷା କରିବା ପାଇଁ ଏହାକୁ "
+#~ "ପୁନଃଟାଇପ କରନ୍ତୁ ଏବଂ<b>ଗୁପ୍ତଶବ୍ଦ ପରିବର୍ତ୍ତନ</b>ରେ କ୍ଲିକ କରନ୍ତୁ ।"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "ଅଭିଗମ୍ୟ ଲଗଇନ (_g)"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "ସହକାରୀ ପ୍ରଯୁକ୍ତିବିଜ୍ଞାନ"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "ସହକାରୀ ପ୍ରଯୁକ୍ତିବିଜ୍ଞାନ ପସନ୍ଦ"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "ସହାୟକ ପ୍ରଯୁକ୍ତିଜ୍ଞାନକୁ ସକ୍ରିୟ କରିବା ପାଇଁ ପରିବର୍ତ୍ତନଗୁଡ଼ିକ ଆପଣଙ୍କର ପରବର୍ତ୍ତି ଲଗଇନ ପର୍ଯ୍ୟନ୍ତ "
+#~ "କାର୍ଯ୍ୟକାରୀ ହୋଇନାହିଁ।"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "ବନ୍ଦ ଏବଂ ଲଗଆଉଟ କରନ୍ତୁ (_L)"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "ମନପସନ୍ଦ ପ୍ରୟୋଗଗୁଡ଼ିକର ସଂଳାପକୁ ଯାଆନ୍ତୁ"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "ଅଭିଗମ୍ୟ ଲଗଇନ ସଂଳାପକୁ ଯାଆନ୍ତୁ"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "କି-ବୋର୍ଡ ଅଭିଗମ୍ଯତା ସଂଳାପକୁ ଯାଆନ୍ତୁ"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "ମାଉସ ଅଭିଗମ୍ଯ ସଂଳାପକୁ ଯାଆନ୍ତୁ"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "ସହକାରୀ ପ୍ରଯୁକ୍ତିଜ୍ଞାନକୁ ସକ୍ରିୟ କରନ୍ତୁ"
+
+#~ msgid "_Keyboard Accessibility"
+#~ msgstr "କି-ବୋର୍ଡ ଅଭିଗମ୍ଯତା (_K)"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "ମାଉସ ଅଭିଗମ୍ଯତା (_M)"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "ମନପସନ୍ଦ ପ୍ରୟୋଗଗୁଡ଼ିକ (_P)"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "ଆପଣ ଲଗଇନ ହେବା ସମୟରେ କେଉଁ ଅଭିଗମ୍ୟ ବିଶେଷଗୁଣକୁ ସକ୍ରିୟ କରିବେ ବାଛନ୍ତୁ"
+
+#~ msgid "Font may be too large"
+#~ msgstr "ଫଣ୍ଟ ହୁଏତ ବହୁତ ବଡ ହୋଇପାରେ"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "ବଚ୍ଛିତ ଅକ୍ଷରରୂପଟି ହେଉଛି %d ବଡ଼, ଏବଂ କମ୍ପୁଟର ବ୍ୟବହାର କରିବା ପାଇଁ ଏହାକୁ କଠିନ କରିପାରେ।  ଏହା "
+#~ "ପରାମର୍ଶିତ ଯେ ଆପଣ %d ଠାରୁ ଛୋଟ ଗୋଟିଏ ଆକାର ବାଛନ୍ତୁ।"
+#~ msgstr[1] ""
+#~ "ବଚ୍ଛିତ ଅକ୍ଷରରୂପଟି ହେଉଛି %d ବଡ଼, ଏବଂ କମ୍ପୁଟର ବ୍ୟବହାର କରିବା ପାଇଁ ଏହାକୁ କଠିନ କରିପାରେ।  ଏହା "
+#~ "ପରାମର୍ଶିତ ଯେ ଆପଣ %d ଠାରୁ ଛୋଟ ଗୋଟିଏ ଆକାର ବାଛନ୍ତୁ।"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "ବଚ୍ଛିତ ଅକ୍ଷରରୂପଟି ହେଉଛି %d ବଡ଼, ଏବଂ କମ୍ପୁଟର ବ୍ୟବହାର କରିବା ପାଇଁ ଏହାକୁ କଠିନ କରିପାରେ।  ଏହା "
+#~ "ପରାମର୍ଶିତ ଯେ ଆପଣ ଗୋଟିଏ ଛୋଟ ଆକାର ବିଶିଷ୍ଟ ଅକ୍ଷର ରୂପ ବାଛନ୍ତୁ।"
+#~ msgstr[1] ""
+#~ "ବଚ୍ଛିତ ଅକ୍ଷରରୂପଟି ହେଉଛି %d ବଡ଼, ଏବଂ କମ୍ପୁଟର ବ୍ୟବହାର କରିବା ପାଇଁ ଏହାକୁ କଠିନ କରିପାରେ।  ଏହା "
+#~ "ପରାମର୍ଶିତ ଯେ ଆପଣ ଗୋଟିଏ ଛୋଟ ଆକାର ବିଶିଷ୍ଟ ଅକ୍ଷର ରୂପ ବାଛନ୍ତୁ।"
+
+#~ msgid "Use selected font"
+#~ msgstr "ବଚ୍ଛିତ ଅକ୍ଷରରୂପକୁ ବ୍ୟବହାର କରନ୍ତୁ"
+
+#~ msgid "Could not load user interface file: %s"
+#~ msgstr "ଚାଳକ ଅନ୍ତରାପୃଷ୍ଠ ଫାଇଲକୁ ଧାରଣ କରିପାରିଲା ନାହିଁ: %s"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "ପ୍ରତିଷ୍ଠାପନ କରିବା ପାଇଁ ଗୋଟିଏ ଥିମର ଫାଇଲ ନାମ ନିର୍ଦ୍ଦିଷ୍ଟ କର"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "ଦର୍ଶାଇବାକୁ ଥିବା ପୃଷ୍ଠାର ନାମ ଉଲ୍ଲେଖ କରନ୍ତୁ (theme|background|fonts|interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "ପ୍ରସଙ୍ଗଟି ଆଶାକରାଯାଇଥିବା ପରି ଦୃଶ୍ୟମାନ ହେଉନାହିଁ କାରଣ ଆବଶ୍ୟକୀୟ GTK+ ପ୍ରସଙ୍ଗ ଯନ୍ତ୍ର '%s' "
+#~ "ସ୍ଥାପିତ ହୋଇନାହିଁ।"
+
+#~ msgid "Apply Background"
+#~ msgstr "ପୃଷ୍ଠଭୂମି ପ୍ରୟୋଗ କରନ୍ତୁ"
+
+#~ msgid "Apply Font"
+#~ msgstr "ଅକ୍ଷରରୂପ ପ୍ରୟୋଗ କରନ୍ତୁ"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "ପ୍ରଚଳିତ ପ୍ରସଙ୍ଗ ଗୋଟିଏ ପ୍ରଚ୍ଛଦ ଭୂମି ଏବଂ ଗୋଟିଏ ଅକ୍ଷରରୂପ ପାଇଁ ପ୍ରସ୍ତାବ ଦେଇଥାଏ। ଏବଂ ମଧ୍ଯ, ଶେଷ "
+#~ "ପ୍ରୟୋଗ ଅକ୍ଷରରୂପ ପ୍ରସ୍ତାବକୁ କଢ଼ାଯାଇପାରିବ।"
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "ପ୍ରଚଳିତ ପ୍ରସଙ୍ଗ ଗୋଟିଏ ପ୍ରଚ୍ଛଦଭୂମିକୁ ପ୍ରସ୍ଥାବ ଦେଇଥାଏ। ଏବଂ ମଧ୍ଯ, ଶେଷ ପ୍ରୟୋଗ ଅକ୍ଷରରୂପ "
+#~ "ପ୍ରସ୍ଥାବକୁ କଢ଼ାଯାଇପାରିବ।"
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "ପ୍ରଚଳିତ ପ୍ରସଙ୍ଗ ଗୋଟିଏ ପୃଷ୍ଠଭୂମି ଏବଂ ଗୋଟିଏ ଅକ୍ଷରରୂପର ପ୍ରସ୍ତାବ ଦେଇଥାଏ।"
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "ପ୍ରଚଳିତ ପ୍ରସଙ୍ଗ ଗୋଟିଏ ପୃଷ୍ଠଭୂମି ଏବଂ ଗୋଟିଏ ଅକ୍ଷରରୂପର ପ୍ରସ୍ତାବ ଦେଇଥାଏ। ଏବଂ ମଧ୍ଯ, ଶେଷ ପ୍ରୟୋଗ "
+#~ "ଅକ୍ଷରରୂପ ପ୍ରସ୍ଥାବକୁ କଢ଼ାଯାଇପାରିବ।"
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "ପ୍ରଚଳିତ ପ୍ରସଙ୍ଗ ଗୋଟିଏ ପୃଷ୍ଠଭୂମିର ପ୍ରସ୍ତାବ ଦେଇଥାଏ।"
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "ଶେଷ ରେ ପ୍ରୟୋଗ କରାଯାଇଥିବା ଅକ୍ଷରରୂପ ପ୍ରସ୍ତାବକୁ ପ୍ରତ୍ୟାବର୍ତ୍ତନ କରାଯାଇପାରିବ।"
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "ପ୍ରଚଳିତ ପ୍ରସଙ୍ଗ ଗୋଟିଏ ଅକ୍ଷରରୂପର ପ୍ରସ୍ତାବ ଦେଇଥାଏ।"
+
+#~ msgid "Best _shapes"
+#~ msgstr "ଉତ୍ତମ ଆକାର (_s)"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "ଉତ୍ତମ ଭେଦ (_n)"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "ଇଚ୍ଛାରୂପଣ କରନ୍ତୁ (_u)..."
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "ଦର୍ଶିକା ପ୍ରସଙ୍ଗ ପରିବର୍ତ୍ତନଟି ପରବର୍ତ୍ତି ଥର ଲଗଇନ କଲେ କାର୍ଯ୍ୟକାରୀ ହେବ।"
+
+#~ msgid "Controls"
+#~ msgstr "ନିୟନ୍ତ୍ରଣ"
+
+#~ msgid "Customize Theme"
+#~ msgstr "ପ୍ରସଙ୍ଗକୁ ଇଚ୍ଛାରୂପଣ କରନ୍ତୁ"
+
+#~ msgid "D_etails..."
+#~ msgstr "ବିବରଣୀ (_e)..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "ଡେସ୍କଟପ ଅକ୍ଷରରୂପ (_k):"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "ଅକ୍ଷରରୂପ ଚିତ୍ରଣ କରିବା ବିବରଣୀ"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "ଅନଲାଇନରେ ଅଧିକ ପୃଷ୍ଠଭୂମି ଗ୍ରହଣ କରନ୍ତୁ"
+
+#~ msgid "Get more themes online"
+#~ msgstr "ଅନଲାଇନରେ ଅଧିକ ପ୍ରସଙ୍ଗ ଗ୍ରହଣ କରନ୍ତୁ"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Grayscale (_y)"
+
+#~ msgid "Icons"
+#~ msgstr "ଚିତ୍ରସଙ୍କେତ"
+
+#~ msgid "Icons only"
+#~ msgstr "କେବଳ ଚିତ୍ରସଂକେତଗୁଡିକ"
+
+#~ msgid "N_one"
+#~ msgstr "କେହି ନୁହଁ (_o)"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "ରଙ୍ଗକୁ ଉଲ୍ଲେଖ କରିବା ପାଇଁ ଗୋଟିଏ ସଂଳାପକୁ ଖୋଲନ୍ତୁ"
+
+#~ msgid "R_esolution:"
+#~ msgstr "ବିଭେଦନ (_e):"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "ପ୍ରସଙ୍ଗକୁ ଏହିପରି ସଂରକ୍ଷଣ କରନ୍ତୁ..."
+
+#~ msgid "Save _As..."
+#~ msgstr "ନୂଆ ନାମରେ ସଂରକ୍ଷଣ କରନ୍ତୁ... (_A)"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "ଉପ ପିକସେଲ (LCDs) (_p)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "ଉପ ପିକସେଲ ସରଳିକରଣ (LCDs) (_p)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "ଉପପିକ୍ସେଲ କ୍ରମ"
+
+#~ msgid "Text below items"
+#~ msgstr "ନିମ୍ନ ବସ୍ତୁଗୁଡ଼ିକରେ ପାଠ୍ୟ ଲେଖନ୍ତୁ"
+
+#~ msgid "Text beside items"
+#~ msgstr "ବସ୍ତୁଗୁଡ଼ିକ ପାଖରେ ଲେଖନ୍ତୁ"
+
+#~ msgid "Text only"
+#~ msgstr "କେବଳ ପାଠ୍ଯ"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "ପ୍ରଚଳିତ ନିୟନ୍ତ୍ରଣ ପ୍ରସଙ୍ଗ ରଙ୍ଗ ଯୋଜନାକୁ ସମର୍ଥନ କରେନାହିଁ।"
+
+#~ msgid "Theme"
+#~ msgstr "ଥିମ"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "ବର୍ଣ୍ଣନା (_D):"
+
+#~ msgid "_Document font:"
+#~ msgstr "_ଦଲିଲ ଫଣ୍ଟ:"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "_ସ୍ଥିର ଓସାର ଫଣ୍ଟ:"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_ମନୋକ୍ରୋମ"
+
+#~ msgid "_None"
+#~ msgstr "କିଛି ନାହିଁ (_N)"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତରେ ପୁନଃସ୍ଥାପନ କରନ୍ତୁ (_R)"
+
+#~ msgid "_Selected items:"
+#~ msgstr "ବଚ୍ଛିତ ବସ୍ତୁଗୁଡ଼ିକ (_S):"
+
+#~ msgid "_Size:"
+#~ msgstr "ଆକାର (_S):"
+
+#~ msgid "_Slight"
+#~ msgstr "_ଅତିକମ"
+
+#~ msgid "_Style:"
+#~ msgstr "ଶୈଳୀ (_S):"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "ଉପକରଣ ସୂଚନା (_T):"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_ଉଇଣ୍ଡୋ ଶୀର୍ଷକ ଫଣ୍ଟ:"
+
+#~ msgid "_Windows:"
+#~ msgstr "ୱିଣ୍ଡୋଗୁଡ଼ିକ (_W):"
+
+#~ msgid "dots per inch"
+#~ msgstr "ପ୍ରତି ଇଂଚ ବିନ୍ଦୁଗୁଡିକ"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "ଡେସ୍କଟପର ଦୃଶ୍ୟକୁ ଇଚ୍ଛାମୁତାବକ କରନ୍ତୁ"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "ଡେସ୍କଟପର ବିଭିନ୍ନ ଅଂଶ ପାଇଁ ପ୍ରସଙ୍ଗର ପ୍ୟାକେଜଗୁଡ଼ିକୁ ସ୍ଥାପନ କରନ୍ତୁ"
+
+#~ msgid "Theme Installer"
+#~ msgstr "ପ୍ରସଙ୍ଗ ସ୍ଥାପକ"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Gnome ପ୍ରସଙ୍ଗ ପ୍ୟାକେଜ"
+
+#~ msgid "Slide Show"
+#~ msgstr "ସ୍ଲାଇଡ୍ ଦେଖାଅ"
+
+#~ msgid "Image"
+#~ msgstr "ପ୍ରତିଛବି"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "ଫୋଲଡର: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "ଫୋଲଡର: %s"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "ପ୍ରସଙ୍ଗକୁ ସ୍ଥାପନ କରିପାରିବେ ନାହିଁ"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s ଉପଯୋଗିତାଟି ସ୍ଥାପନ ହୋଇନାହିଁ।"
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "ପ୍ରସଙ୍ଗକୁ କାଢ଼ିବା ସମୟରେ ତ୍ରୁଟି।"
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "ବଚ୍ଛିତ ଫାଇଲଗୁଡ଼ିକୁ ସ୍ଥାପନ କରିବା ସମୟରେ ତ୍ରୁଟି"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" ଟି ବୈଧ ପ୍ରସଙ୍ଗ ପରି ଦେଖାଯାଉନାହିଁ।"
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" ଟି ବୈଧ ପ୍ରସଙ୍ଗ ପରି ଦେଖାଯାଉନାହିଁ। ଏହା ଗୋଟିଏ ପ୍ରସଙ୍ଗ ଯନ୍ତ୍ର ଯାହାକୁ କି ଆପଣଙ୍କୁ ସଂକଳନ "
+#~ "କରିବାକୁ ହେବ।"
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "ପ୍ରସଙ୍ଗ \"%s\" ର ସ୍ଥାପନା ବିଫଳ ହୋଇଛି।"
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "ପ୍ରସଙ୍ଗ \"%s\" ସ୍ଥାପିତ ହୋଇଛି।"
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr ""
+#~ "ଆପଣ ଏହାକୁ ବର୍ତ୍ତମାନ ପ୍ରୟୋଗ କରିବାକୁ ଚାହୁଁଛନ୍ତି, ଅଥବା ଆପଣଙ୍କର ପ୍ରଚଳିତ ପ୍ରସଙ୍ଗକୁ ରଖିବାକୁ "
+#~ "ଚାହୁଁଛନ୍ତି?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "ଚଳିତ ଥିମକୁ ରଖ"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "ନୂଆ ଥିମ ପ୍ରଯୋଗ କର"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME ଥିମ %s ସଠିକ ଭାବରେ ପ୍ରତିଷ୍ଠାପିତ ହେଲା"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "ନୂତନ ପ୍ରସଙ୍ଗ ସଫଳତାର ସହିତ ସ୍ଥାପିତ ହୋଇଛି।"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "ପ୍ରତିଷ୍ଠାପନ କରିବା ପାଇଁ କୌଣସି ଥିମ ଫାଇଲ ଅବସ୍ଥାନ ନିର୍ଦ୍ଦିଷ୍ଟ ହୋଇ ନାହିଁ ।"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "ରେ ଥିମକୁ ପ୍ରତିଷ୍ଠାପନ କରିବା ପାଇଁ ଅୟଥେଷ୍ଟ ଅନୁମତି:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "ପ୍ରସଙ୍ଗ ଚୟନ କରନ୍ତୁ"
+
+#~ msgid "Theme Packages"
+#~ msgstr "ପ୍ରସଙ୍ଗ ପ୍ୟାକେଜଗୁଡ଼ିକ"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "ଥିମର ନାମ ଉପସ୍ଥିତ ଥିବା ଆବଶ୍ଯକ"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "ଥିମ ପୂର୍ବରୁ ବିଦ୍ଯମାନ ଅଛି । ଆପଣ ଏହାକୁ ପୁନଃସ୍ଥାପିତ କରିବାକୁ ଚାହିଁବେ କି  ?"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "ଆପଣ ଏହି ପ୍ରସଙ୍ଗକୁ ଅପସାରଣ କରିବାକୁ ଚାହୁଁଛନ୍ତି କି?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "ପ୍ରସଙ୍ଗ ଯନ୍ତ୍ରକୁ ସ୍ଥାପନ କରାଯାଇପାରିଲା ନାହିଁ"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "'gnome-settings-daemon' ସଂରଚନା ପରିଚାଳକଙ୍କୁ ଆରମ୍ଭ କରିବାରେ ଅସମର୍ଥ।\n"
+#~ "GNOME ସଂରଚନା ପରିଚାଳକ ଚାଲୁ ନଥିବା ବିନା, କେତେକ ପସନ୍ଦ ପ୍ରଭାବଶାଳୀ ହୋଇ ପାରିବ ନାହିଁ। DBus "
+#~ "ଏହା ହୁଏତ ଏକ ସମସ୍ଯା ସୃଷ୍ଟି କରିପାରେ, ଅଥବା ଗୋଟିଏ ଅଣ-GNOME (ଯେପରି KDE) ସଂରଚନା ପରିଚାଳକ "
+#~ "ପୂର୍ବରୁ ସକ୍ରିୟ ଥାଇପାରେ ଏବଂ GNOME ସେଟିଙ୍ଗ ପ୍ରବନ୍ଧକ ସହିତ ଦ୍ବନ୍ଦ୍ବ କରୁଥାଇପାରେ।"
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "ପୁଞ୍ଜି ଚିତ୍ରସଙ୍କେତ %s କୁ ଧାରଣ କରିବାରେ ଅସମର୍ଥ\n"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "ସହାୟତା ଦେଖାଇବାରେ ତୃଟି: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "ଫାଇଲ ନକଲ କରନ୍ତୁ: %u of %u"
+
+#~ msgid "Parent Window"
+#~ msgstr "ମୂଳ ୱିଣ୍ଡୋ"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "ଡାଏଲଗର ପ୍ଯାରେଣ୍ଡ ଉଇଣ୍ଡୋ"
+
+#~ msgid "From URI"
+#~ msgstr "ୟୁ.ଆର.ଆଇ. ରୁ"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "ୟୁ.ଆର.ଆଇ. ବର୍ତ୍ତମାନ ଏଠାରୁ ସ୍ଥାନାନ୍ତରିତ କରୁଅଛି"
+
+#~ msgid "To URI"
+#~ msgstr "ୟୁ.ଆର.ଆଇ. କୁ"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "ୟୁ.ଆର.ଆଇ. ବର୍ତ୍ତମାନ ଏଠାକୁ ସ୍ଥାନାନ୍ତରିତ ହେଉଛି"
+
+#~ msgid "Fraction completed"
+#~ msgstr "ଭଗ୍ନାଂଶ ସମ୍ପନ୍ନ"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "ବର୍ତ୍ତମାନ ସ୍ଥାନାନ୍ତରଣର ଏକ ଭାବ ସଂପୂର୍ଣ୍ଣ ହୋଇଛି"
+
+#~ msgid "Current URI index"
+#~ msgstr "ସାମ୍ପ୍ରତିକ ୟୁ.ଆର.ଆଇ. ଅନୁକ୍ରମଣିକା"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "ସାମ୍ପ୍ରତିକ ୟୁ.ଆର.ଆଇ. ଅନୁକ୍ରମଣିକା - ୧ ରୁ ଆରମ୍ଭ ହୋଇଥାଏ"
+
+#~ msgid "Total URIs"
+#~ msgstr "ସର୍ବମୋଟ ୟୁ.ଆର.ଆଇ."
+
+#~ msgid "Total number of URIs"
+#~ msgstr "ସର୍ବମୋଟ ସଂଖ୍ଯକ ୟୁ.ଆର.ଆଇ."
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "ଫାଇଲ '%s' ପୂର୍ବରୁ ଅବସ୍ଥିତ ଅଛି। ଆପଣ ଏହାକୁ ନବଲିଖନ କରିବାକୁ ଚାହୁଁଛନ୍ତି କି?"
+
+#~ msgid "_Skip"
+#~ msgstr "ଏଡାଇ ଦିଅନ୍ତୁ (_S)"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "ସମସ୍ତଙ୍କୁ ନବଲିଖନ କରନ୍ତୁ (_A)"
+
+#~ msgid "Key"
+#~ msgstr "କି"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "GConf କି ୟାହା ସହିତ ଏହି ବିଶେଷତା ସଂପାଦନକ ସଂଲଗ୍ନ ଅଛି ।"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "ୟେବେ କି ସହିତ ସମ୍ମିଳିତ ମୂଲ୍ଯରେ ପରିବର୍ତ୍ତନ ହୋଇଥାଏ ଏହି କଲବ୍ଯାକକୁ ନିର୍ଗମ କର"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf ପରିବର୍ତ୍ତନ ସେଟରେ ଥିବା ତଥ୍ଯ ଆବେଦନରେ gconf ଗ୍ରାହକଙ୍କ ନିକଟକୁ ଅଗ୍ରସର କରାୟାଇଥାଏ ।"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "ବିଜେଟ କଲବ୍ଯାକ ପାଇଁ ସଂଭାଷଣ"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "ୟେବେ ତଥ୍ଯ GConf ରୁ ବିଗେଟକୁ ରୂପାନ୍ତରିତ ହେବାକୁ ଥାଆନ୍ତି କଲବ୍ଯାକ ନିର୍ଗମ ହେବାକୁ ଥାଏ ।"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "ବିଗେଟ କଲବ୍ଯାକରୁ ସଂଭାଷଣ"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "ୟେବେ ତଥ୍ଯ  ବିଗେଟରୁ GConfକୁ ରୂପାନ୍ତରିତ ହେବାକୁ ଥାଆନ୍ତି କଲବ୍ଯାକ ନିର୍ଗମ ହେବାକୁ ଥାଏ ।"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "ବିଶେଷତାକୁ ନିଯନ୍ତ୍ରଣ କରୁଥିବା ବସ୍ତୁ (ସାମାନ୍ଯତଃ ଏକ ବିଗେଟ)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "ବିଶେଷତା ସଂପାଦନକ  ବସ୍ତୁ ତଥ୍ଯ"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "ନିର୍ଦ୍ଦିଷ୍ଟ ବିଶେଷତା ସଂପାଦକ ଦ୍ବାରା ଆବଶ୍ଯକ ବ୍ଯବସ୍ଥାପିତ ତଥ୍ଯ"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "ବିଶେଷତା ସଂପାଦକ ତଥ୍ଯ କଲବ୍ଯାକ ମୁକ୍ତକରୁଛନ୍ତି"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "ୟେବେ ବିଶେଷତା ସଂପାଦକ ବସ୍ତୁ ତଥ୍ଯମୁକ୍ତ ହେବାକୁ ଥାଏ କଲବ୍ଯାକ ନିର୍ଗମ ହେବାକୁ ଥାଏ ।"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "ଫାଇଲ ଖୋଜିପାରିଲା ନାହିଁ '%s'। \n"
+#~ "\n"
+#~ "ଦଯାକରି ଏହା ବିଦ୍ୟମାନ ଅଛି ବୋଲି ନିଶ୍ଚିତ କରନ୍ତୁ ଏବଂ ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ, କିମ୍ବା ଗୋଟିଏ ଭିନ୍ନ ପୃଷ୍ଠଭୂମି "
+#~ "ଚିତ୍ର ବାଛନ୍ତୁ ।"
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "ଫାଇଲ କେମିତି ଖୋଲାୟାଏ ମୁଁ ଜାଣି ନାହିଁ '%s' ।\n"
+#~ "ହୁଏତ ଏହା ଏମିତି ଗୋଟିଏ ଚିତ୍ର ୟାହାକି ଏୟାଏଁ ସମର୍ଥିତ ହୋଇ ନାହିଁ \n"
+#~ "\n"
+#~ "ପରିବର୍ତ୍ତେ ଗୋଟିଏ ଭିନ୍ନ ଚିତ୍ର ମନୋନୀତ କରନ୍ତୁ ।"
+
+#~ msgid "Please select an image."
+#~ msgstr "ଦୟାକରି ଗୋଟିଏ ପ୍ରତିଛବି ବାଛନ୍ତୁ।"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "ଡିଫଲ୍ଟ ପଏଣ୍ଟର  - ଚଳିତ"
+
+#~ msgid "White Pointer"
+#~ msgstr "ଧଳା ପଏଣ୍ଟର"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "ଧଳା ପଏଣ୍ଟର- ଚଳିତ"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "ବୃହତ୍ ପଏଣ୍ଟର - ଚଳିତ"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "ବୃହତ୍ ଧଳା ପଏଣ୍ଟର - ଚଳିତ"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "ଏହି ପ୍ରସଙ୍ଗଟି ଆଶାକରାଯାଉଥିବା ପରି ଲାଗୁନାହିଁ କାରଣ ଆବଶ୍ୟକୀୟ GTK+ ପ୍ରସଙ୍ଗ '%s' ଟି ସ୍ଥାପିତ "
+#~ "ହୋଇନାହିଁ।"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "ଏହି ପ୍ରସଙ୍ଗଟି ଆଶାକରାଯାଉଥିବା ପରି ଲାଗୁନାହିଁ କାରଣ ଆବଶ୍ୟକୀୟ ୱିଣ୍ଡୋ ପରିଚାଳକ ପ୍ରସଙ୍ଗ '%s' ଟି "
+#~ "ସ୍ଥାପିତ ହୋଇନାହିଁ।"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "ଏହି ପ୍ରସଙ୍ଗଟି ଆଶାକରାଯାଉଥିବା ପରି ଲାଗୁନାହିଁ କାରଣ ଆବଶ୍ୟକୀୟ ଚିତ୍ରସଂକେତ ପ୍ରସଙ୍ଗ '%s' ଟି ସ୍ଥାପିତ "
+#~ "ହୋଇନାହିଁ।"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "ପସନ୍ଦ ପ୍ରଯୋଗଗୁଡିକ"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "ପସନ୍ଦଯୋଗ୍ୟ ଦୃଶ୍ୟମାନ ସହାୟକ ପ୍ରଯୁକ୍ତିଜ୍ଞାନକୁ ଆରମ୍ଭ କରନ୍ତୁ"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "ଦୃଶ୍ୟମାନ ସହାୟତା"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "ମୁଖ୍ୟ ଅନ୍ତରାପୃଷ୍ଠ ଧାରଣ କରିବାରେ ଅସମର୍ଥ"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr "ଦର୍ଶାଇବା ପାଇଁ ପୃଷ୍ଠାର ନାମ ଉଲ୍ଲେଖ କରନ୍ତୁ (internet|multimedia|system|a11y)"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "ସମସ୍ତ %s ଉପସ୍ଥିତି ଗୁଡିକ ପ୍ରକୃତ ଲିଙ୍କ ସହିତ ପୁନଃସ୍ଥାପିତ ହେବ "
+
+#~ msgid "Co_mmand:"
+#~ msgstr "ନିର୍ଦ୍ଦେଶ (_m):"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "ପତାକା _ କାର୍ୟ୍ଯକାରୀ କର:"
+
+#~ msgid "Image Viewer"
+#~ msgstr "ଚିତ୍ର ଦର୍ଶକ"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "ଜରୂରି ଦୂତ"
+
+#~ msgid "Mail Reader"
+#~ msgstr "ମେଲ ପାଠକ"
+
+#~ msgid "Mobility"
+#~ msgstr "ଗତିଶୀଳତା"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "ନୂଆ ଟାବରେ ଲିଙ୍କକୁ_ଖୋଲ"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "ନୂଆ ଉଇଣ୍ଡୋରେ ଲିଙ୍କ_ଖୋଲ"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "ଉଏବ ବ୍ରାଉଜର _ଡିଫଲ୍ଟ ସହିତ ଲିଙ୍କ ଖୋଲ"
+
+#~ msgid "Run at st_art"
+#~ msgstr "ଆରମ୍ଭରେ ଚଲାନ୍ତୁ (_a)"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "ଟର୍ମିନାଲରେ _ଚଲାଅ"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "ଟର୍ମିନାଲ ଯାନ୍ତ୍ରାନୁକାରୀ"
+
+#~ msgid "Text Editor"
+#~ msgstr "ପାଠ୍ଯ ସମ୍ପାଦକ"
+
+#~ msgid "_Run at start"
+#~ msgstr "ଆରମ୍ଭରେ ଚଲାନ୍ତୁ (_R)"
+
+#~ msgid "Balsa"
+#~ msgstr "ବଲସା"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "ବଂଶୀ ସଂଗୀତ ପ୍ଲେଯାର୍ / ବାଦକ "
+
+#~ msgid "Claws Mail"
+#~ msgstr "କ୍ଲଜ୍ ମେଲ"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "ଡେବିଯାନ ସମ୍ବେଦନଶୀଳ ବ୍ରାଉଜର"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "ଡେବିଯାନ ଟର୍ମିନାଲ ଇମ୍ଯୁଲେଟର"
+
+#~ msgid "ETerm"
+#~ msgstr "ଇ-ଶବ୍ଦ"
+
+#~ msgid "Encompass"
+#~ msgstr "ପରିବେଷ୍ଟନକର"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "ବିକାଶଶୀଳ ମେଲ ପାଠକ"
+
+#~ msgid "Firefox"
+#~ msgstr "ଫାଯାରଫକ୍ସ"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "ବିନା ପରଦା ପାଠକରେ GNOME ବର୍ଦ୍ଧକ"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "GNOME ଟର୍ମିନାଲ"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "ବର୍ଦ୍ଧକ ସହିତ Gnopernicus"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape ମେଲ"
+
+#~ msgid "Icedove"
+#~ msgstr "ଆଇସଡୋଭ"
+
+#~ msgid "Iceweasel"
+#~ msgstr "ଆଇସବିଜେଲ"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "ବିନା ପରଦା ପାଠକରେ KDE ବର୍ଦ୍ଧକ"
+
+#~ msgid "Konqueror"
+#~ msgstr "କଙ୍କରର"
+
+#~ msgid "Konsole"
+#~ msgstr "କୋଲସୋଲ"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "ବର୍ଦ୍ଧକ ସହିତ Linux ପରଦା ପାଠକ"
+
+#~ msgid "Listen"
+#~ msgstr "ଶୁଣନ୍ତୁ"
+
+#~ msgid "Midori"
+#~ msgstr "Midori"
+
+#~ msgid "Mozilla"
+#~ msgstr "ମୋଜିଲା"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla ମେଲ"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "NXterm"
+#~ msgstr "NXଶବ୍ଦ"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "ନେଟସ୍କେପ ସଂୟୋଜକ"
+
+#~ msgid "Orca"
+#~ msgstr "ଓର୍କା"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "ଆବର୍ଦ୍ଧକ ସହିତ Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox ସଙ୍ଗୀତ ଚାଳକ"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "SeaMonkey ମେଲ"
+
+#~ msgid "Sylpheed"
+#~ msgstr "ସିଲଫିଡ"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "ସିଲଫିଡ-ପଞ୍ଜା"
+
+#~ msgid "Thunderbird"
+#~ msgstr "Thunderbird"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem ସିନେମା ଚାଳକ"
+
+#~ msgid "Include _panel"
+#~ msgstr "ପଟ୍ଟିକାକୁ ଅନ୍ତର୍ଭୁକ୍ତ କରନ୍ତୁ (_p)"
+
+#~ msgid "Monitor Preferences"
+#~ msgstr "ପ୍ରଦର୍ଶିକା ପସନ୍ଦ"
+
+#~ msgid "Panel icon"
+#~ msgstr "ପ୍ୟାନେଲ ଚିତ୍ର ସଂକେତ"
+
+#~ msgid "Re_fresh rate:"
+#~ msgstr "ଦର_ରିଫ୍ରେସ କର:"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "ସମସ୍ତ ପ୍ରଦର୍ଶିକାରେ ସମାନ ପ୍ରତିଛବି (_m)"
+
+#~ msgid "Upside-down"
+#~ msgstr "ଉପରୁ ତଳକୁ"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "ପ୍ରଦର୍ଶିକାଗୁଡ଼ିକୁ ନିରିକ୍ଷଣ କରନ୍ତୁ (_D)"
+
+#~ msgid "Monitors"
+#~ msgstr "ପ୍ରଦର୍ଶିକା"
+
+#, fuzzy
+#~| msgid "Theme name must be present"
+#~ msgid "The source filename must be absolute"
+#~ msgstr "ଥିମର ନାମ ଉପସ୍ଥିତ ଥିବା ଆବଶ୍ଯକ"
+
+#, fuzzy
+#~| msgid "Could not get screen information"
+#~ msgid "Could not get information for %s: %s\n"
+#~ msgstr "ପରଦା ସୂଚନା ପାଇପାରିଲା ନାହିଁ"
+
+#, fuzzy
+#~| msgid "Could not access '%s' device"
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "'%s' ଉପକରଣକୁ ଅଭିଗମ୍ୟ କରିପାରିଲା ନାହିଁ"
+
+#~ msgid "Upside Down"
+#~ msgstr "ଉପରୁ ତଳକୁ"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d ହର୍ଜ"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "ପ୍ରଦର୍ଶିକା: %s"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "ପ୍ରଦର୍ଶନୀ ବିନ୍ୟାସ ପାଇଁ ପ୍ରୟୋଗ କରିବା ସମୟରେ ଅଧିବେଶନ ବସ ପାଇଲା ନାହିଁ"
+
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "ପ୍ରଦର୍ଶିକା ସଂରଚନାକୁ ସଂରକ୍ଷଣ କରାଯାଇଛି"
+
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "ପ୍ରଦର୍ଶିକା ପାଇଁ ପୂର୍ବନିର୍ଦ୍ଧାରିତ ସଂରଚନାକୁ ସଂରକ୍ଷଣ କରିପାରିଲା ନାହିଁ"
+
+#~ msgid "Desktop"
+#~ msgstr "ଡେସ୍କଟପ"
+
+#~ msgid "Accelerator key"
+#~ msgstr "ବେଗବର୍ଦ୍ଧକ କି"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "ତ୍ୱରକ ପରିବର୍ତ୍ତନ କାରୀ"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "ତ୍ୱରକ କି ସଂକେତ"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "ବେଗବର୍ଦ୍ଧକର ପ୍ରକାର"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "ନୂତନ ସଂକ୍ଷିପ୍ତ ପଥକୁ ସଂରକ୍ଷଣ କରିବାରେ ତ୍ରୁଟି"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "ବିନ୍ୟାସ ତଥ୍ୟାବଳୀରେ ତ୍ୱରକକୁ ଅବିନ୍ୟାସ କରିବାରେ ତ୍ରୁଟି: %s"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "ଅତ୍ୟଧିକ ଇଚ୍ଛାମୁତାବକ ସଂକ୍ଷିପ୍ତ ପଥ"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "ଆଦେଶଗୁଡିକୁ ସର୍ଟକଟ କିଗୁଡିକ ପ୍ରଦାନ କର"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "କେବଳ ସେଟିଙ୍ଗଗୁଡିକୁ ପ୍ରଯୋଗ କରନ୍ତୁ ଏବଂ ପ୍ରସ୍ଥାନ କରନ୍ତୁ (କେବଳ ଅନୁରୂପୟୋଗ୍ଯତା; ବର୍ତ୍ତମାନ ଡିମୋନ "
+#~ "ଦ୍ବାରା ପରିଚାଳିତ)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "ଟାଇପିଙ୍ଗ ଭଙ୍ଗ ସେଟିଙ୍ଗ ଦର୍ଶାଇବା ସହିତ ପୃଷ୍ଠା ଆରମ୍ଭ କର"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "ଦର୍ଶାଯାଇଥିବା ଅଭିଗମ୍ୟ ବିନ୍ୟାସ ପରି ପୃଷ୍ଠାକୁ ଆରମ୍ଭ କରନ୍ତୁ"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- GNOME କି-ବୋର୍ଡ ପସନ୍ଦ"
+
+#~ msgid "Beep when _accessibility features are turned on or off"
+#~ msgstr "ଅଭିଗମ୍ୟତା ବିଶେଷ ଗୁଣଗୁଡ଼ିକୁ ଅନ କିମ୍ବା ଅଫ କରିବା ସମୟରେ ଦପ ଦପ କରନ୍ତୁ (_a)"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "କି କୁ ପ୍ରତ୍ୟାଖାନ କରାଗଲେ ମିଟିମିଟି କରିବ (_r)"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "କି-ବୋର୍ଡ ଅଭିଗମ୍ଯତା ଧ୍ୱନି ପ୍ରତିକ୍ରିୟା"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "ସତର୍କ ଧ୍ୱନି ପାଇଁ ଦୃଶ୍ୟମାନ ପ୍ରତି ସୂଚନା ଦର୍ଶାନ୍ତୁ (_v)"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "ଧ୍ୱନି ପାଇଁ ଦୃଷ୍ଟିସଂକ୍ରାନ୍ତୀୟ ଧାଡ଼ି"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "ଭଙ୍ଗ ଗୁଡିକର_ସ୍ଥଗିତ କରଣକୁ ସ୍ବୀକୃତି ଦିଅ"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "ଧ୍ୱନି ପ୍ରତି ସୂଚନା (_F)..."
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "ଭଙ୍ଗଗୁଡିକୁ ସ୍ଥଗିତ କରିବା ସ୍ବୀକୃତ କି ନାହିଁ ୟାଞ୍ଚ କର  "
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "ଟାଇପ କରିବା ବେଳେ ଭଙ୍ଗର ଅବଧି ଅସ୍ବୀକୃତ ଅଟେ"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "ଗୋଟିଏ ଭଙ୍ଗ ବାଧ୍ଯ କରିବା ପୂର୍ବରୁ କାର୍ୟ୍ଯର ଅବଧି"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "କିବୋର୍ଡ ମୋଡେଲ (_m):"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "ଏକ ନିର୍ଦ୍ଦିଷ୍ଟ ଅବଧି ପରେ ସ୍କ୍ରିନକୁ ତାଲାବନ୍ଦ କରିଦିଅ ୟଦ୍ବାରା କିବୋର୍ଡକୁ ପୁନର୍ବାର ଉପୟୋଗରୁ ହେଉଥିବା "
+#~ "କ୍ଷତିକୁ ବାଧାଦେବାରେ ସହାଯକ ହେବ ।"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_ଭଙ୍ଗ ଅନ୍ତରାଳ ରହିଥାଏ:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "ଟାଇପିଙ୍ଗ ଭଙ୍ଗକୁ ବାଧ୍ଯ କରିବା ପାଇଁ ପରଦାକୁ ଅପରିବର୍ତ୍ତନୀୟ କରନ୍ତୁ (_L)"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "କେବଳ ଲମ୍ବା କି ଚାପକୁ ଗ୍ରହଣ କରନ୍ତୁ (_O)"
+
+#~ msgid "_Separate layout for each window"
+#~ msgstr "ପ୍ରତ୍ୟେକ ୱିଣ୍ଡୋ ପାଇଁ ବିନ୍ୟାସକୁ ପୃଥକ କରନ୍ତୁ (_S)"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "ସମତାଳ କି ଦବାଇବାକୁ ଜାଗ୍ରତ କରନ୍ତୁ (_S)"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_କାର୍ୟ୍ଯ ଅନ୍ତରାଳ ଶେଷ ରହେ:"
+
+#~ msgid "_Variants:"
+#~ msgstr "ଭିନ୍ନତା (_V):"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "ଗୋଟିଏ କିବୋର୍ଡ ମୋଡେଲ ବାଛ"
+
+#~ msgid "_Vendors:"
+#~ msgstr "ବିକ୍ରେତା (_V):"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "ଆପଣଙ୍କର କିବୋର୍ଡ ପସନ୍ଦ ସ୍ଥିର କରନ୍ତୁ"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "ବାମକୁ ଯାଆନ୍ତୁ"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "ଡାହାଣକୁ ଯାଆନ୍ତୁ"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "ଉପରକୁ ଯାଆନ୍ତୁ"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "ତଳକୁ ଯାଆନ୍ତୁ"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "ନିଷ୍କ୍ରିୟ ହୋଇଛି"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "ଦର୍ଶାଇବା ପାଇଁ ପୃଷ୍ଠାର ନାମ ଉଲ୍ଲେଖ କରନ୍ତୁ (general|ଅଭିଗମ୍ୟତା)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- GNOME ମାଉସ ପସନ୍ଦ"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "ହାତ ପୂର୍ବରୁ କ୍ଲିକର ପ୍ରକାର ବାଛନ୍ତୁ (_b)"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "ମାଉସ ଦୃଶ୍ୟ ସହିତ ନିଜର କ୍ଲିକ ପ୍ରକାର ବାଛନ୍ତୁ (_u)"
+
+#~ msgid "D_rag click:"
+#~ msgstr "କ୍ଲିକକୁ ଟାଣନ୍ତୁ (_r):"
+
+#~ msgid "Show click type _window"
+#~ msgstr "କ୍ଲିକ ପ୍ରକାର ୱିଣ୍ଡୋକୁ ଦର୍ଶାନ୍ତୁ (_w)"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr ""
+#~ "କ୍ଲିକ ପ୍ରକାରକୁ ଜାଣିବା ପାଇଁ ଆପଣ Dwell କ୍ଲିକ ଆପଲେଟ ପ୍ୟାନେଲକୁ ମଧ୍ଯ ବ୍ୟବହାର କରିପାରିବେ।"
+
+#~ msgid "_Single click:"
+#~ msgstr "ଗୋଟିଏ ଥର କ୍ଲିକ (_S):"
+
+#~ msgid "Location already exists"
+#~ msgstr "ସ୍ଥାନ ପୂର୍ବରୁ ଅବସ୍ଥିତ"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "ଆପଣଙ୍କର ନେଟୱର୍କ ପ୍ରକ୍ସି ପସନ୍ଦକୁ ସେଟକରନ୍ତୁ"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>ହସ୍ତଚାଳିତ ପ୍ରକ୍ସି ବିନ୍ୟାସ (_M)</b>"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP ପ୍ରକ୍ସି ବିବରଣୀ"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "ଆଧାର ତାଲିକାକୁ ଅଗ୍ରାହ୍ୟ କରନ୍ତୁ"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "ନେଟୱର୍କ ପ୍ରକ୍ସି ପସନ୍ଦଗୁଡ଼ିକ"
+
+#~ msgid "U_sername:"
+#~ msgstr "ଚାଳକ ନାମ (_s):"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_ HTTP ପ୍ରୋକ୍ସି ସୁରକ୍ଷିତକର:"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "ଆପଣଙ୍କର ୱିଣ୍ଡୋ ପରିଚାଳକ ପାଇଁ ପସନ୍ଦ ପ୍ରୟୋଗକୁ ଆରମ୍ଭ କରିପାରିବେ ନାହିଁ"
+
+#~ msgid "_Alt"
+#~ msgstr "ଅଲ୍ଟ (_Alt)"
+
+#~ msgid "H_yper"
+#~ msgstr "ଅତି_"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "ସୁପର_(କିମ୍ବା \"ଉଇଣ୍ଡୋ ଲୋଗୋ\")"
+
+#~ msgid "Movement Key"
+#~ msgstr "ଗତିବିଧି କି"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "ଗୋଟିଏ ଉଇଣ୍ଡୋକୁ ଘୁଞ୍ଚାଇବା ପାଇଁ, ଏହି କିକୁ ଧରି ରଖ ତାପରେ ଉଇଣ୍ଡୋକୁ ଟାଣିଆଣ :"
+
+#~ msgid "Window Preferences"
+#~ msgstr "ଉଇଣ୍ଡୋ ପସନ୍ଦଗୁଡିକ"
+
+#~ msgid "Window Selection"
+#~ msgstr "ୱିଣ୍ଡୋ ଚୟନ"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_ଏହି କାର୍ୟ୍ଯକୁ କରିବା ପାଇଁ ଶୀର୍ଷକବାରକୁ ଦୁଇଥର କ୍ଲିକ କର:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_ଉଠିବା ପୂର୍ବରୁ ଅନ୍ତରାଳ:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_ଏକ ଅନ୍ତରାଳ ପରେ ମନୋନୀତ ଉଇଣ୍ଡୋକୁ ଉପରକୁ ଉଠାଅ"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_ଉଇଣ୍ଡୋକୁ ମନୋନୀତ କର ୟେବେ ମାଉସ ସେଗୁଡିକ ଉପରେ ଘୁଞ୍ଚେ "
+
+#~ msgid "Set your window properties"
+#~ msgstr "ଆପଣଙ୍କର ଉଇଣ୍ଡୋ ବିଶେଷତାଗୁଡିକୁ ସ୍ଥିର କର"
+
+#~ msgid "Windows"
+#~ msgstr "ୱିଣ୍ଡୋ"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "ଉଇଣ୍ଡୋ ପ୍ରବନ୍ଧକ\"%s\" ଗୋଟିଏ କନଫିଗରେସନ ଉପକରଣ ପଞ୍ଜିକୃତ କରି ନାହିଁ \n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "ଭୂଲମ୍ବରେ ବୃଦ୍ଧିକରନ୍ତୁ"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "ସମାନ୍ତରାଳରେ ବୃଦ୍ଧିକରନ୍ତୁ"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "ଆରମ୍ଭ ସମୟରେ ଲୁଚାନ୍ତୁ (ସେଲକୁ ପୁନର୍ଦ୍ଧାରଣ କରିବା ପାଇଁ ଉପଯୋଗୀ)"
+
+#~ msgid "Groups"
+#~ msgstr "ସମୂହ"
+
+#~ msgid "Common Tasks"
+#~ msgstr "ସାଧାରଣ କାର୍ୟ୍ଯଗୁଡିକ"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "କାର୍ଯ୍ୟ ସକ୍ରିୟ ହେବା ସମୟରେ ନିୟନ୍ତ୍ରଣ-କେନ୍ଦ୍ରକୁ ବନ୍ଦ କରନ୍ତୁ"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "ଯୋଗକରନ୍ତୁ କିମ୍ବା କାଢ଼ନ୍ତୁ କାର୍ଯ୍ୟକୁ କାର୍ଯ୍ୟକାରୀ କରିବା ସମୟରେ କୋଷ ତ୍ୟାଗ କରନ୍ତୁ"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "ସହାୟତା କାର୍ଯ୍ୟ କାର୍ଯ୍ୟକାରୀ ହେବା ସମୟରେ କୋଷରୁ ପ୍ରସ୍ଥାନ କରନ୍ତୁ"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "ଆରମ୍ଭ କାର୍ଯ୍ୟ କାର୍ଯ୍ୟକାରୀ ହେବା ସମୟରେ କୋଷରୁ ପ୍ରସ୍ଥାନ କରନ୍ତୁ"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "ଉନ୍ନୟନ କିମ୍ବା ବିସ୍ଥାପନ କାର୍ଯ୍ୟକାରୀ ହେବା ସମୟରେ କୋଷରୁ ପ୍ରସ୍ଥାନ କରନ୍ତୁ"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "ସହାୟତା କାର୍ଯ୍ୟକୁ କାର୍ଯ୍ୟକାରୀ କରିବା ସମୟରେ କୋଷକୁ ବନ୍ଦ କରବା ଉଚିତ କି ନୁହଁ ଜଣାନ୍ତୁ।"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "ଆରମ୍ଭ କାର୍ଯ୍ୟକୁ କାର୍ଯ୍ୟକାରୀ କରିବା ସମୟରେ କୋଷକୁ ବନ୍ଦ କରବା ଉଚିତ କି ନୁହଁ ଜଣାନ୍ତୁ।"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "ଯୋଗକରନ୍ତୁ କିମ୍ବା କାଢନ୍ତୁ କାର୍ଯ୍ୟକୁ କାର୍ଯ୍ୟକାରୀ କରିବା ସମୟରେ କୋଷକୁ ବନ୍ଦ କରବା ଉଚିତ କି ନୁହଁ "
+#~ "ଜଣାନ୍ତୁ।"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "ଉନ୍ନୟନ କିମ୍ବା ବିସ୍ଥାପନ କାର୍ଯ୍ୟକୁ କାର୍ଯ୍ୟକାରୀ କରିବା ସମୟରେ କୋଷକୁ ବନ୍ଦ କରବା ଉଚିତ କି ନୁହଁ "
+#~ "ଜଣାନ୍ତୁ।"
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "କାର୍ଯ୍ୟ ନାମ ଏବଂ ସଂଶ୍ଳିଷ୍ଟ .desktop ଫାଇଲଗୁଡ଼ିକ"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "ନିୟନ୍ତ୍ରଣ-କେନ୍ଦ୍ରରେ ଦର୍ଶାଇବା ପାଇଁ ଥିବା କାର୍ଯ୍ୟ ନାମ ଏବଂ ତାବାପରେ ଏକ ପୃଥକିକରଣ \";\" ଏବଂ "
+#~ "ତାପରେ କାର୍ଯ୍ୟ ପାଇଁ ଆରମ୍ଭ କରିବାକୁ ଥିବା ଗୋଟିଏ .desktop ସଂଶ୍ଳିଷ୍ଟ ଫାଇଲ ନାମ।"
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[ପ୍ରସଙ୍ଗ ପରିବର୍ତ୍ତନ କରନ୍ତୁ;gtk-theme-selector.desktop,ମନପସନ୍ଦ ପ୍ରୟୋଗ ସେଟ କରନ୍ତୁ;"
+#~ "default-applications.desktop,ମୁଦ୍ରଣୀ ଯୋଡନ୍ତୁ;gnome-cups-manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "ଯଦି true, ତେବେ \"Common Task\" ସକ୍ରିୟ ହେବା ମାତ୍ରେ ନିୟନ୍ତ୍ରଣ-କେନ୍ଦ୍ର ବନ୍ଦ ହୋଇଯିବ।"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME କନଫିଗରେସନ୍ ଉପକରଣ"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "ବିରାମ ସମୟକୁ ଆଗକୁ କରନ୍ତୁ (_P)"
+
+#~ msgid "_Take a Break"
+#~ msgstr "କିଛି ସମୟ ବିରାମ କରନ୍ତୁ"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "ପରବର୍ତ୍ତି ବିରତି ପର୍ଯ୍ୟନ୍ତ %d ମିନଟ"
+#~ msgstr[1] "ପରବର୍ତ୍ତି ବିରତି ପର୍ଯ୍ୟନ୍ତ %d ମିନଟ"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "ପରବର୍ତ୍ତୀ ବିରାମ ପର୍ୟ୍ଯନ୍ତ ଗୋଟିଏ ମିନିଟରୁ କମ"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr "ନିମ୍ନଲିଖିତ ତ୍ରୁଟି ସହିତ ଟାଇପିଙ୍ଗ ଭଙ୍ଗ ବିଶେଷତା ଡାଏଲଗକୁ ଆଣିବା ପାଇଁ ଅସମର୍ଥ : %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "ରିଚାର୍ଡ ହଲ୍ଟ ଙ୍କ ଦ୍ବାରା ଲିଖିତ <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "ଆଇ କାଣ୍ଡି ଆଣ୍ଡରସନ କାର୍ଲସନଙ୍କ ଦ୍ବାରା ୟୋଗ ହୋଇଛି"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "ଏକ କମ୍ପ୍ଯୁଟର ଭଙ୍ଗ ମନେପକାଏ"
+
+#~ msgid "translator-credits"
+#~ msgstr "ଶୁଭ୍ରାଂଶୁ ବେହେରା <arya_subhransu@yahoo.co.in>"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "ବିଜ୍ଞପ୍ତି କ୍ଷେତ୍ରଗୁଡ଼ିକ ଅବସ୍ଥିତ ଅଛି କି ନାହିଁ ତାହା ଯାଞ୍ଚ କରନ୍ତୁ ନାହିଁ"
+
+#~ msgid "Typing Monitor"
+#~ msgstr "ଟାଇପିଙ୍ଗ ନିରୀକ୍ଷକ"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "ଟାଇପିଙ୍ଗ ନିରୀକ୍ଷକ ବିଜ୍ଞପ୍ତି ଅଂଚଳକୁ ସୂଚନା ପ୍ରଦର୍ଶନ କରିବା ପାଇଁ ଉପୟୋଗ କରେ । ଆପଣଙ୍କର "
+#~ "ପ୍ଯାନେଲରେ ଗୋଟିଏ ବିଜ୍ଞପ୍ତି ଅଂଚଳ ଥିଲା ପରି ମନେହେଉନାହିଁ ।  ଆପଣ ଏହାକୁ ପ୍ଯାନେଲରେ ଡାହାଣ କ୍ଲିକ "
+#~ "କରି ଏବଂ 'ପ୍ଯାନେଲକୁ ୟୋଗକର'କୁ ବାଛି, 'ବିଜ୍ଞାପ୍ତି ଅଂଚଳ' କୁ ମନୋନୀତ କରି ଏବଂ  'ୟୋଗକର' କୁ କ୍ଲିକ "
+#~ "କରି ୟୋଗ କରିପାରିବେ ।"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "ୟଦି ସତ୍ଯକୁ ସେଟ ହୁଏ, ତେବେ ଓପନଟାଇପ ଫଣ୍ଟ ଥମ୍ବନେଇଲଡ ହୋଇୟିବ ।"
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "ୟଦି ସତ୍ଯକୁ ସେଟ ହୁଏ, ତେବେ PCF ଫଣ୍ଟଗୁଡିକ ଥମ୍ବନେଇଲଡ ହୋଇୟିବ ।"
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "ୟଦି ସତ୍ଯକୁ ସେଟ ହୁଏ, ତେବେ ଟ୍ରୁଟାଇପ ଫଣ୍ଟଗୁଡିକ ଥମ୍ବନେଇଲଡ ହୋଇୟିବ ।"
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "ୟଦି ସତ୍ଯ ସେଟ ହୁଏ, ତେବେ ଟାଇପ1 ଫଣ୍ଟଗୁଡିକ ଥମ୍ବନେଇଲଡ ହୋଇୟିବ ।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "ଓପନଟାଇପ ଫଣ୍ଟ ଗୁଡିକ ପାଇଁ ଥମ୍ବନେଇଲ ସୃଷ୍ଟିକରିବା ନିମନ୍ତେ ଉପୟୋଗ ହେଉଥିବା ଏହି କିକୁ ଆଦେଶକୁ ସେଟ କର "
+#~ "।"
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ " PCF ଫଣ୍ଟ ଗୁଡିକ ପାଇଁ ଥମ୍ବନେଇଲ ସୃଷ୍ଟିକରିବା ନିମନ୍ତେ ଉପୟୋଗ ହେଉଥିବା ଏହି କିକୁ ଆଦେଶକୁ ସେଟ କର ।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "ଟ୍ରୁଟାଇପ ଫଣ୍ଟ ଗୁଡିକ ପାଇଁ ଥମ୍ବନେଇଲ ସୃଷ୍ଟିକରିବା ନିମନ୍ତେ ଉପୟୋଗ ହେଉଥିବା ଏହି କିକୁ ଆଦେଶକୁ ସେଟ କର ।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "ଟାଇପ1 ଫଣ୍ଟ ଗୁଡିକ ପାଇଁ ଥମ୍ବନେଇଲ ସୃଷ୍ଟିକରିବା ନିମନ୍ତେ ଉପୟୋଗ ହେଉଥିବା ଏହି କିକୁ ଆଦେଶକୁ ସେଟ କର ।"
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "ଥମ୍ବନେଇଲ ଆଦେଶ ଓପନଟାଇପ ଫଣ୍ଟ ଗୁଡିକ ପାଇଁ"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "ଥମ୍ବନେଇଲ ଆଦେଶ PCF ଫଣ୍ଟ ଗୁଡିକ ପାଇଁ"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "ଥମ୍ବନେଇଲ ଆଦେଶ ଟ୍ରୁ ଟାଇପ ଫଣ୍ଟ ଗୁଡିକ ପାଇଁ"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "ଥମ୍ବନେଇଲ ଆଦେଶ ଟାଇପ1 ଫଣ୍ଟ ଗୁଡିକ ପାଇଁ"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "ଓପନଟାଇପ ଫଣ୍ଟକୁ ଥମ୍ବନେଇଲ କରାୟିବ କି ନାହିଁ"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCFଫଣ୍ଟଗୁଡିକୁ ଥମ୍ବନେଇଲ କରାୟିବ କି ନାହିଁ"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "ଟ୍ରୁ ଟାଇପ ଫଣ୍ଟକୁ ଥମ୍ବନେଇଲ କରାୟିବ କି ନାହିଁ"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "ଟାଇପ 1 ଫଣ୍ଟଗୁଡିକୁ ଥମ୍ବନେଇଲ କରାୟିବ କି ନାହିଁ "
+
+#~ msgid "Copyright:"
+#~ msgstr "ସ୍ବତ୍ତ୍ବାଧୀକାର:"
+
+#~ msgid "Description:"
+#~ msgstr "ବର୍ଣ୍ଣନା:"
+
+#~ msgid "Installed"
+#~ msgstr "ସ୍ଥାପିତ"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "ଉପୟୋଗ: %s ଫଣ୍ଟଫାଇଲ\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "ଅକ୍ଷରରୂପ ସ୍ଥାପନ କରନ୍ତୁ (_n)"
+
+#~ msgid "Font Viewer"
+#~ msgstr "ଅକ୍ଷରରୂପ ପ୍ରଦର୍ଶକ"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "ପାଠ୍ୟରୁ କ୍ଷୁଦ୍ରଚିତ୍ର (ପୂର୍ବନିର୍ଦ୍ଧାରିତ: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "ଅକ୍ଷରରୂପ ଆକାର (ପୂର୍ବନିର୍ଦ୍ଧାରିତ: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "ଆପଣଙ୍କର ଛାଣକ \"%s\" କୌଣସି ବସ୍ତୁ ସହିତ ମେଳ ଖାଇନଥାଏ।"
+
+#~ msgid "Upgrade"
+#~ msgstr "ଶ୍ରେଣୀଉଚ୍ଚକର"
+
+#~ msgid "Uninstall"
+#~ msgstr "ଅପ୍ରତିଷ୍ଠାପନ କର"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "ଅତିପସନ୍ଦକୁ ୟୋଗକର"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "ଆରମ୍ଭ ପ୍ରୋଗ୍ରାମରୁ ହଟାଅ"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "ଆରମ୍ଭ ପ୍ରୋଗ୍ରାମରେ ୟୋଗ କର"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "ନୂତନ ସ୍ପ୍ରେଡସିଟ"
+
+#~ msgid "New Document"
+#~ msgstr "ନୂଆ  ଦଲିଲ"
+
+#~ msgid "Documents"
+#~ msgstr "ଦଲିଲ"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>ଖୋଲନ୍ତୁ</b>"
+
+#~ msgid "Rename..."
+#~ msgstr "ନାମ ବଦଳାନ୍ତୁ ..."
+
+#~ msgid "Move to Trash"
+#~ msgstr "ବର୍ଜିତକୁ ପଠାନ୍ତୁ"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "ଯଦି ଆପଣ ଗୋଟିଏ ବସ୍ତୁକୁ ଅପସାରଣ କରନ୍ତି, ଏହା ସବୁଦିନ ପାଇଁ ନଷ୍ଟ ହୋଇଯିବ."
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "\"%s\" ସହିତ ଖୋଲନ୍ତୁ"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "ଫାଇଲ ପରିଚାଳକରେ ଖୋଲନ୍ତୁ"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "ଆଜି %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "ଗତକାଲି %l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "ବର୍ତ୍ତମାନ ଖୋଜନ୍ତୁ"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s ଖୋଲନ୍ତୁ</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "ତନ୍ତ୍ର ବସ୍ତୁରୁ କାଢନ୍ତୁ"

--- a/po/pa.po
+++ b/po/pa.po
@@ -10,10 +10,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.HEAD\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issu"
-"es\n"
-"POT-Creation-Date: 2022-07-22 15:02+0000\n"
-"PO-Revision-Date: 2022-07-23 11:01-0700\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-10-16 17:32-0700\n"
 "Last-Translator: A S Alam <aalam@satluj.org>\n"
 "Language-Team: Punjabi <punjabi-users@list.sf.net>\n"
 "Language: pa\n"
@@ -21,104 +20,9 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Lokalize 22.04.1\n"
-
-#: panels/applications/cc-applications-panel.c:790
-msgid "System Bus"
-msgstr "ਸਿਸਟਮ ਬੱਸ"
-
-#: panels/applications/cc-applications-panel.c:790
-#: panels/applications/cc-applications-panel.c:792
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:810
-msgid "Full access"
-msgstr "ਪੂਰੀ ਪਹੁੰਚ"
-
-#: panels/applications/cc-applications-panel.c:792
-msgid "Session Bus"
-msgstr "ਸ਼ੈਸ਼ਨ ਬੱਸ"
-
-#: panels/applications/cc-applications-panel.c:796
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "ਡਿਵਾਈਸ"
-
-#: panels/applications/cc-applications-panel.c:796
-msgid "Full access to /dev"
-msgstr "/dev ਲਈ ਪੂਰੀ ਪਹੁੰਚ"
-
-#: panels/applications/cc-applications-panel.c:800
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "ਨੈੱਟਵਰਕ"
-
-#: panels/applications/cc-applications-panel.c:800
-msgid "Has network access"
-msgstr "ਨੈੱਟਵਰਕ ਪਹੁੰਚ ਹੈ"
-
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:807
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "ਘਰ"
-
-#: panels/applications/cc-applications-panel.c:807
-#: panels/applications/cc-applications-panel.c:812
-msgid "Read-only"
-msgstr "ਕੇਵਲ-ਪੜ੍ਹਨ ਲਈ"
-
-#: panels/applications/cc-applications-panel.c:810
-#: panels/applications/cc-applications-panel.c:812
-msgid "File System"
-msgstr "ਫਾਇਲ ਸਿਸਟਮ"
-
-#: panels/applications/cc-applications-panel.c:816
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "ਸੈਟਿੰਗ"
-
-#: panels/applications/cc-applications-panel.c:816
-msgid "Can change settings"
-msgstr "ਸੈਟਿੰਗਾਂ ਬਦਲ ਸਕਦੇ ਹਨ"
-
-#: panels/applications/cc-applications-panel.c:818
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s ਵਿੱਚ ਅੱਗੇ ਦਿੱਤੀਆਂ ਇਜਾਜ਼ਤਾਂ ਪਹਿਲਾਂ ਹੀ ਹਨ। ਇਹਨਾਂ ਨੂੰ ਬਦਲਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਹੈ।"
-" ਜੇ ਤੁਸੀਂ ਇਹ "
-"ਇਜਾਜ਼ਤਾਂ ਬਾਰੇ ਫ਼ਿਕਰ ਕਰਦੇ ਹੋ ਤਾਂ ਇਸ ਐਪਲੀਕੇਸ਼ਨ ਨੂੰ ਹਟਾਉਣ ਬਾਰੇ ਵਿਚਾਰ ਕਰੋ।"
-
-#: panels/applications/cc-applications-panel.c:1154
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u ਫਾਇਲ ਤੇ ਲਿੰਕ ਕਿਸਮ, ਜੋ ਕਿ ਐਪ ਵਲੋਂ ਖੋਲ੍ਹੇ ਜਾਂਦੇ ਹਨ"
-msgstr[1] "%u ਫਾਇਲ ਤੇ ਲਿੰਕ ਕਿਸਮਾਂ, ਜੋ ਕਿ ਐਪ ਵਲੋਂ ਖੋਲ੍ਹੇ ਜਾਂਦੇ ਹਨ"
-
-#: panels/applications/cc-applications-panel.c:1161
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> ਨੂੰ ਫਾਇਲਾਂ ਤੇ ਲਿੰਕਾਂ ਦੀਆਂ ਹੇਠ ਦਿੱਤੀਆਂ ਕਿਸਮਾਂ ਖੋਲ੍ਹਣ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ"
-" ਹੈ।"
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1213
-#, c-format
-msgid "%s of disk space used"
-msgstr "%s ਡਿਸਕ ਥਾਂ ਵਰਤੀ ਗਈ ਹੈ"
+"X-Generator: Lokalize 22.08.1\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1377
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -134,7 +38,6 @@ msgid "Install some…"
 msgstr "…ਕੁਝ ਇੰਸਟਾਲ ਕਰੋ"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "ਖੋਲ੍ਹੋ"
 
@@ -158,24 +61,13 @@ msgstr "ਖੋਜ"
 msgid "Receive system searches and send results."
 msgstr "ਸਿਸਟਮ ਖੋਜਾਂ ਲਵੋ ਅਤੇ ਨਤੀਜੇ ਭੇਜੋ"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "ਅਸਮਰੱਥ ਹੈ"
 
@@ -189,141 +81,149 @@ msgid "Show system notifications."
 msgstr "ਸਿਸਟਮ ਨੋਟੀਫਿਕੇਸ਼ਨ ਵੇਖਾਓ।"
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
-msgstr "ਬੈਕਗਰਾਊਂਡ ਚਲਾਓ"
+msgid "Run in Background"
+msgstr "ਬੈਕਗਰਾਊਂਡ ਵਿੱਚ ਚਲਾਓ"
 
 #: panels/applications/cc-applications-panel.ui:134
 msgid "Allow activity when the app is closed."
 msgstr "ਜਦੋਂ ਐਪ ਬੰਦ ਹੋਵੇ ਤਾਂ ਸਰਗਰਮੀ ਦੀ ਇਜਾਜ਼ਤ ਹੈ।"
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "ਸਕਰੀਨਸ਼ਾਟ"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "ਕਿਸੇ ਵੀ ਵੇਲੇ ਸਕਰੀਨ ਦੀਆਂ ਤਸਵੀਰਾਂ ਲਵੋ।"
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "ਵਾਲਪੇਪਰ ਬਦਲੋ"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "ਡੈਸਕਟਾਪ ਵਾਲਪੇਪਰ ਬਦਲੋ।"
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "ਸਾਊਂਡ"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "ਆਵਾਜ਼ਾ ਮੁੜ-ਤਿਆਰ ਕਰੋ।"
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "ਸਿਸਟਮ-ਰੋਕੂ ਸ਼ਾਰਟਕੱਟ"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "ਮਿਆਰੀ ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟਾਂ ਉੱਤੇ ਪਾਬੰਦੀ ਲਾਈ ਹੈ।"
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "ਕੈਮਰਾ"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "ਕੈਮਰੇ ਨਾਲ ਤਸਵੀਰਾਂ ਲਵੋ।"
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "ਮਾਈਕਰੋਫੋਨ"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "ਮਾਈਕਰੋਫੋਨ ਨਾਲ ਆਡੀਓ ਰਿਕਾਰਡ ਕਰੋ।"
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "ਟਿਕਾਣਾ ਸੇਵਾਵਾਂ"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "ਡਿਵਾਈਸ ਟਿਕਾਣਾ ਡਾਟੇ ਲਈ ਪਹੁੰਚ।"
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "ਬਿਲਟ-ਇਨ ਇਜਾਜ਼ਤਾਂ"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "ਐਪ ਵਲੋਂ ਚਾਹੀਦੀ ਸਿਸਟਮ ਪਹੁੰਚ"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "ਫਾਇਲ ਤੇ ਲਿੰਕ ਸੰਬੰਧ"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "ਸਟੋਰੇਜ਼"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:108
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "ਕੋਈ ਨਤੀਜੇ ਨਹੀਂ ਲੱਭੇ"
 
-#: panels/applications/cc-applications-panel.ui:304
+#: panels/applications/cc-applications-panel.ui:311
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
 #: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "ਵੱਖਰੀ ਖੋਜ ਨਾਲ ਕੋਸ਼ਿਸ਼ ਕਰੋ"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "ਫਾਇਲ ਤੇ ਲਿੰਕ ਸੰਬੰਧ"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "ਫਾਇਲ ਕਿਸਮਾਂ"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "ਲਿੰਕ ਕਿਸਮਾਂ"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "ਮੁੜ-ਸੈੱਟ"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr "ਐਪ ਡਾਟੇ ਅਤੇ ਕੈਸ਼ ਨਾਲ ਇਹ ਐਪਲੀਕੇਸ਼ਨ ਕਿੰਨੀ ਡਿਸਕ ਥਾਂ ਵਰਤ ਰਹੀ ਹੈ।"
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "ਐਪਲੀਕੇਸ਼ਨ"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "ਡਾਟਾ"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "ਕੈਸ਼"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>ਕੁੱਲ</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "…ਕੈਸ਼ ਸਾਫ਼ ਕਰੋ"
 
@@ -331,80 +231,20 @@ msgstr "…ਕੈਸ਼ ਸਾਫ਼ ਕਰੋ"
 msgid "Control various application permissions and settings"
 msgstr "ਕਈ ਐਪੀਕੇਸ਼ਨ ਇਜਾਜ਼ਤਾਂ ਅਤੇ ਸੈਟਿੰਗਾਂ ਨੂੰ ਕੰਟੋਰਲ ਕਰਦਾ ਹੈ।"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "ਐਪਲੀਕੇਸ਼ਨ;ਫਲੈਟਪੈਕ;ਇਜਾਜ਼ਤ;ਸੈਟਿੰਗ;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "ਤਸਵੀਰ ਚੁਣੋ"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:209
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "ਰੱਦ ਕਰੋ(_C)"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "ਖੋਲ੍ਹੋ(_O)"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "ਕਈ ਆਕਾਰ"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "ਕੋਈ ਡੈਸਕਟਾਪ ਬੈਕਗਰਾਊਂਡ ਨਹੀਂ"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "ਮੌਜੂਦਾ ਬੈਕਗਰਾਊਂਡ"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "ਸਟਾਇਲ"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "ਡਿਫਾਲਟ"
 
@@ -428,12 +268,9 @@ msgstr "ਦਿੱਖ"
 msgid "Change your background image or the UI colors"
 msgstr "ਆਪਣੇ ਬੈਕਗਰਾਊਂਡ ਚਿੱਤਰ ਜਾਂ UI ਨੂੰ ਬਦਲੋ"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
-msgstr ""
-"ਬੈਕਗਰਾਊਂਡ;ਵਾਲਪੇਪਰ;ਸਕਰੀਨ;ਡੈਸਕਟਾਪ;ਕੰਧ-ਚਿੱਤਰ;ਹਲਕਾ;ਗੂੜ੍ਹਾ;ਫਿੱਕਾ;ਪਿਛੋਕੜ;ਕੰਧ-ਚਿੱਤਰ;ਦ"
-"ਿੱਖ;"
+msgstr "ਬੈਕਗਰਾਊਂਡ;ਵਾਲਪੇਪਰ;ਸਕਰੀਨ;ਡੈਸਕਟਾਪ;ਕੰਧ-ਚਿੱਤਰ;ਹਲਕਾ;ਗੂੜ੍ਹਾ;ਫਿੱਕਾ;ਪਿਛੋਕੜ;ਕੰਧ-ਚਿੱਤਰ;ਦਿੱਖ;"
 
 #: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
 #: panels/datetime/cc-datetime-panel.ui:172
@@ -481,9 +318,7 @@ msgstr "ਹਾਰਡਵੇਅਰ ਏਅਰਪਲੇਨ ਮੋਡ ਚਾਲੂ �
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "ਬਲੂਟੁੱਥ ਨੂੰ ਸਮਰੱਥ ਕਰਨ ਲਈ ਏਅਰਪਲੇਨ ਮੋਡ ਨੂੰ ਬੰਦ ਕਰੋ।"
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "ਬਲੂਟੁੱਥ"
 
@@ -491,7 +326,6 @@ msgstr "ਬਲੂਟੁੱਥ"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "ਬਲੂਟੁੱਥ ਜੰਤਰ ਨੂੰ ਚਾਲੂ ਤੇ ਬੰਦ ਕਰੋ ਅਤੇ ਆਪਣੇ ਜੰਤਰਾਂ ਨਾਲ ਕਨੈਕਟ ਕਰੋ-"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "ਸਾਂਝਾ ਕਰਨਾ;ਸਾਂਝਾ;ਸ਼ੇਅਰਿੰਗ;ਬਲਿਊਟੂੱਥ;ਬਲੂਟੁੱਥ;obex;"
@@ -511,8 +345,7 @@ msgid ""
 "\n"
 "Allow the applications below to use your camera."
 msgstr ""
-"ਕੈਮਰੇ ਦੀ ਵਰਤੋਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਫੋਟੋ ਖਿੱਚਣ ਅਤੇ ਵਿਡੀਓ ਬਣਾਉਣ ਦਿੰਦੀ ਹੈ। ਕੈਮਰੇ ਨੂੰ"
-" ਅਸਮਰੱਥ ਕਰਨ ਨਾਲ ਕੁਝ "
+"ਕੈਮਰੇ ਦੀ ਵਰਤੋਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਫੋਟੋ ਖਿੱਚਣ ਅਤੇ ਵਿਡੀਓ ਬਣਾਉਣ ਦਿੰਦੀ ਹੈ। ਕੈਮਰੇ ਨੂੰ ਅਸਮਰੱਥ ਕਰਨ ਨਾਲ ਕੁਝ "
 "ਐਪਲੀਕੇਸ਼ਨਾਂ ਠੀਕ ਤਰ੍ਹਾਂ ਕੰਮ ਨਹੀਂ ਕਰ ਸਕਦੀਆਂ।\n"
 "\n"
 "ਹੇਠ ਦਿੱਤੀਆਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡਾ ਕੈਮਰਾ ਵਰਤਣ ਦੀ ਇਜਾਜ਼ਤ ਹੈ।"
@@ -525,92 +358,34 @@ msgstr "ਕੈਮਰਾ ਪਹੁੰਚ ਲਈ ਕੋਈ ਐਪਲੀਕੇਸ਼�
 msgid "Protect your pictures"
 msgstr "ਆਪਣੀਆਂ ਤਸਵੀਰਾਂ ਨੂੰ ਸੁਰੱਖਿਅਤ ਕਰੋ"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"ਕੈਮਰਾ;ਫੋਟੋ;ਫ਼ੋਟੋ;ਤਸਵੀਰ;ਵੀਡੀਓ;ਵਿਡੀਓ;ਵੈਬਕੈਮ;ਲਾਕ;ਤਾਲਾ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;ਪ੍ਰਾਈਵੇਟ;"
-"ਨਿੱਜੀ;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "ਆਪਣੇ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਵਰਗ ਉੱਤੇ ਰੱਖੋ ਅਤੇ ”ਸ਼ੁਰੂ” ਨੂੰ ਦੱਬੋ।"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"ਆਪਣੇ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਕੈਲੀਬਰੇਸ਼ਨ ਸਥਿਤੀ ਉਤੇ ਲੈ ਜਾਉ ਅਤੇ ”ਜਾਰੀ ਰੱਖੋ” ਦੱਬੋ"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "ਆਪਣੇ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਤਲ ਸਥਿਤੀ ਉਤੇ ਲੈ ਜਾਉ ਅਤੇ ”ਜਾਰੀ ਰੱਖੋ” ਦੱਬੋ"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "ਲੈਪਟਾਪ ਢੱਕਣ ਬੰਦ"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "ਅੰਦਰੂਨੀ ਗਲਤੀ ਆਈ ਹੈ, ਜਿਸ ਤੋਂ ਉਭਰਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।"
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਲਈ ਲੋੜੀਂਦੇ ਟੂਲ ਇੰਸਟਾਲ ਨਹੀਂ ਹਨ।"
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "ਪਰੋਫਾਇਲ ਤਿਆਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "ਟਾਰਗੇਟ ਚਿੱਟਾ-ਬਿੰਦੂ ਪ੍ਰਾਪਤੀ ਯੋਗ ਨਹੀਂ ਹੈ।"
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "ਪੂਰੇ ਹੋਏ!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਫੇਲ੍ਹ ਹੋਈ!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "ਤੁਸੀਂ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਹਟਾ ਸਕਦੇ ਹੋ।"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਚੱਲਣ ਦੇ ਦੌਰਾਨ ਛੇੜੋ ਨਾ"
+"ਕੈਮਰਾ;ਫੋਟੋ;ਫ਼ੋਟੋ;ਤਸਵੀਰ;ਵੀਡੀਓ;ਵਿਡੀਓ;ਵੈਬਕੈਮ;ਲਾਕ;ਤਾਲਾ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "ਡਿਸਪਲੇਅ ਕੈਲੀਬਰੇਸ਼ਨ"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "ਰੱਦ ਕਰੋ(_C)"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -628,139 +403,6 @@ msgstr "ਮੁੜ-ਪ੍ਰਾਪਤ ਕਰੋ(_R)"
 msgid "_Done"
 msgstr "ਮੁਕੰਮਲ(_D)"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "ਲੈਪਟਾਪ ਸਕਰੀਨ"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "ਬਿਲਟ-ਇਨ ਵੈਬਕੈਮ"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s ਮਾਨੀਟਰ"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s ਸਕੈਨਰ"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s ਕੈਮਰਾ"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s ਪਰਿੰਟਰ"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s ਵੈੱਬਕੈਮ"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s ਲਈ ਰੰਗ ਇੰਤਜ਼ਾਮ ਸਮਰੱਥ ਕਰੋ"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s ਲਈ ਰੰਗ ਪਰੋਫਾਇਲ ਵੇਖੋ"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "ਕੈਲੀਬਰੇਟ ਨਹੀਂ"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "ਡਿਫਾਲਟ: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "ਰੰਗ-ਸਪੇਸ: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "ਪਰੋਫਾਇਲ ਟੈਸਟ: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "ICC ਪਰੋਫਾਇਲ ਫਾਇਲ ਚੁਣੋ"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "ਇੰਪੋਰਟ(_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "ਸਹਾਇਕ ICC ਪਰੋਫਾਇਲ"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "ਸਭ ਫਾਇਲਾਂ"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "ਸਕਰੀਨ"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "ਪਰੋਫਾਇਲ ਸੰਭਾਲੋ"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "ਸੰਭਾਲੋ(_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "ਚੁਣੇ ਜੰਤਰ ਲਈ ਇੱਕ ਰੰਗ ਪਰੋਫਾਇਲ ਬਣਾਉ"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"ਮਾਪ ਜੰਤਰ ਖੋਜਿਆ ਨਹੀਂ ਗਿਆ ਹੈ। ਚੈੱਕ ਕਰੋ ਕਿ ਇਹ ਚਾਲੂ ਹੈ ਅਤੇ ਠੀਕ ਤਰ੍ਹਾਂ ਕੂਨੈਕਟ ਕੀਤਾ"
-" ਹੋਇਆ ਹੈ।"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "ਮਾਪ ਜੰਤਰ ਪਰਿੰਟਿੰਗ ਪਰੋਫਾਇਲਿੰਗ ਲਈ ਸਹਾਇਕ ਨਹੀਂ।"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "ਜੰਤਰ ਕਿਸਮ ਹਾਲੇ ਸਹਾਇਕ ਨਹੀਂ ਹੈ।"
-
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "ਸਕਰੀਨ ਕੈਲੀਬਰੇਸ਼ਨ"
@@ -775,10 +417,8 @@ msgid ""
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"ਕੈਲੀਬਰੇਸ਼ਨ ਇੱਕ ਪਰੋਫਾਇਲ ਦੇਵੇਗੀ, ਜਿਸ ਨੂੰ ਤੁਸੀਂ ਆਪਣੀ ਸਕਰੀਨ ਦੇ ਰੰਗ ਦੇ ਪਰਬੰਧ ਲਈ ਵਰਤ"
-" ਸਕਦੇ ਹੋ। "
-"ਕੈਲੀਬਰੇਸ਼ਨ ਉੱਤੇ ਜਿੰਨਾ ਵੱਧ ਸਮਾਂ ਤੁਸੀਂ ਲਗਾਉਗੇ, ਰੰਗ ਪਰੋਫਾਇਲ ਉਹਨਾਂ ਹੀ ਵੱਧ ਚੰਗਾ"
-" ਹੋਵੇਗਾ।"
+"ਕੈਲੀਬਰੇਸ਼ਨ ਇੱਕ ਪਰੋਫਾਇਲ ਦੇਵੇਗੀ, ਜਿਸ ਨੂੰ ਤੁਸੀਂ ਆਪਣੀ ਸਕਰੀਨ ਦੇ ਰੰਗ ਦੇ ਪਰਬੰਧ ਲਈ ਵਰਤ ਸਕਦੇ ਹੋ। "
+"ਕੈਲੀਬਰੇਸ਼ਨ ਉੱਤੇ ਜਿੰਨਾ ਵੱਧ ਸਮਾਂ ਤੁਸੀਂ ਲਗਾਉਗੇ, ਰੰਗ ਪਰੋਫਾਇਲ ਉਹਨਾਂ ਹੀ ਵੱਧ ਚੰਗਾ ਹੋਵੇਗਾ।"
 
 #: panels/color/cc-color-panel.ui:28
 msgid ""
@@ -820,8 +460,7 @@ msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
-"ਡਿਸਪਲੇਅ ਟਾਰਗੇਟ ਚਿੱਟਾ ਬਿੰਦੂ ਚੁਣੋ। ਬਹੁਤੇ ਡਿਸਪਲੇਅ ਨੂੰ D65 illuminant ਤੱਕ"
-" ਕੈਲੀਬਰੇਟ ਕੀਤਾ ਜਾਣਾ "
+"ਡਿਸਪਲੇਅ ਟਾਰਗੇਟ ਚਿੱਟਾ ਬਿੰਦੂ ਚੁਣੋ। ਬਹੁਤੇ ਡਿਸਪਲੇਅ ਨੂੰ D65 illuminant ਤੱਕ ਕੈਲੀਬਰੇਟ ਕੀਤਾ ਜਾਣਾ "
 "ਚਾਹੀਦਾ ਹੈ।"
 
 #: panels/color/cc-color-panel.ui:187
@@ -833,17 +472,14 @@ msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"ਡਿਸਪਲੇਅ ਲਈ ਚਮਕ ਪੱਧਰ ਸੈੱਟ ਕਰੋ, ਜੋ ਤੁਸੀਂ ਆਮ ਤੌਰ ਉੱਤੇ ਵਰਤਦੇ ਹੋ। ਰੰਗ ਪਰਬੰਧ ਉਸ ਚਮਕ"
-" ਪੱਧਰ ਉੱਤੇ ਸਭ ਤੋਂ "
+"ਡਿਸਪਲੇਅ ਲਈ ਚਮਕ ਪੱਧਰ ਸੈੱਟ ਕਰੋ, ਜੋ ਤੁਸੀਂ ਆਮ ਤੌਰ ਉੱਤੇ ਵਰਤਦੇ ਹੋ। ਰੰਗ ਪਰਬੰਧ ਉਸ ਚਮਕ ਪੱਧਰ ਉੱਤੇ ਸਭ ਤੋਂ "
 "ਵੱਧ ਸ਼ੁੱਧ ਹੋਵੇਗਾ।"
 
 #: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
-msgstr ""
-"ਬਦਲਵੇਂ ਰੂਪ ਵਿੱਚ, ਤੁਸੀਂ  ਇਹ ਜੰਤਰ ਲਈ ਹੋਰ ਪਰੋਫਾਇਲਾਂ ਵਿੱਚੋਂ ਇੱਕ ਨੂੰ ਚਮਕ ਪੱਧਰ ਲਈ"
-" ਵਰਤ ਸਕਦੇ ਹੋ।"
+msgstr "ਬਦਲਵੇਂ ਰੂਪ ਵਿੱਚ, ਤੁਸੀਂ  ਇਹ ਜੰਤਰ ਲਈ ਹੋਰ ਪਰੋਫਾਇਲਾਂ ਵਿੱਚੋਂ ਇੱਕ ਨੂੰ ਚਮਕ ਪੱਧਰ ਲਈ ਵਰਤ ਸਕਦੇ ਹੋ।"
 
 #: panels/color/cc-color-panel.ui:214
 msgid "Profile Name"
@@ -854,8 +490,7 @@ msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
-"ਤੁਸੀਂ ਵੱਖਰੇ ਕੰਪਿਊਟਰ ਉੱਤੇ ਰੰਗ ਪਰੋਫਾਇਲ ਵਰਤ ਸਕਦੇ ਹੋ ਜਾਂ ਵੱਖਰੀਆਂ ਚਾਨਣ ਸ਼ਰਤਾਂ"
-" ਮੁਤਾਬਕ ਰੰਗ ਪਰੋਫਾਇਲ ਬਣਾ "
+"ਤੁਸੀਂ ਵੱਖਰੇ ਕੰਪਿਊਟਰ ਉੱਤੇ ਰੰਗ ਪਰੋਫਾਇਲ ਵਰਤ ਸਕਦੇ ਹੋ ਜਾਂ ਵੱਖਰੀਆਂ ਚਾਨਣ ਸ਼ਰਤਾਂ ਮੁਤਾਬਕ ਰੰਗ ਪਰੋਫਾਇਲ ਬਣਾ "
 "ਸਕਦੇ ਹੋ।"
 
 #: panels/color/cc-color-panel.ui:229
@@ -880,14 +515,12 @@ msgstr "ਲਿਖਣਯੋਗ ਮੀਡਿਆ ਚਾਹੀਦਾ ਹੈ"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"ਤੁਸੀਂ ਪਰੋਫਾਇਲ ਨੂੰ <a href=\"linux\">GNU/ਲੀਨਕਸ</a>, <a href=\"osx\">ਐਪਲ OS X<"
-"/a> "
-"ਅਤੇ <a href=\"windows\">Microsoft Windows</a> ਸਿਸਟਮ ਉੱਤੇ ਕਿਵੇਂ ਵਰਤੀਏ ਬਾਰੇ"
-" ਹਦਾਇਤਾਂ "
+"ਤੁਸੀਂ ਪਰੋਫਾਇਲ ਨੂੰ <a href=\"linux\">GNU/ਲੀਨਕਸ</a>, <a href=\"osx\">ਐਪਲ OS X</a> "
+"ਅਤੇ <a href=\"windows\">Microsoft Windows</a> ਸਿਸਟਮ ਉੱਤੇ ਕਿਵੇਂ ਵਰਤੀਏ ਬਾਰੇ ਹਦਾਇਤਾਂ "
 "ਵੇਖ ਸਕਦੇ ਹੋ।"
 
 #: panels/color/cc-color-panel.ui:335
@@ -898,8 +531,7 @@ msgstr "ਪਰੋਫਾਇਲ ਜੋੜੋ"
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
-msgstr ""
-"ਸਮੱਸਿਆ ਆਈ ਹੈ। ਪਰੋਫਾਇਲ ਠੀਕ ਤਰ੍ਹਾਂ ਸ਼ਾਇਦ ਕੰਮ ਨਾ ਕਰੇ।  <a href=\"\">ਵੇਰਵਾ ਵੇਖੋ</a>"
+msgstr "ਸਮੱਸਿਆ ਆਈ ਹੈ। ਪਰੋਫਾਇਲ ਠੀਕ ਤਰ੍ਹਾਂ ਸ਼ਾਇਦ ਕੰਮ ਨਾ ਕਰੇ।  <a href=\"\">ਵੇਰਵਾ ਵੇਖੋ</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -907,7 +539,6 @@ msgstr "…ਫਾਇਲ ਇੰਪੋਰਟ ਕਰੋ(_I)"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -917,9 +548,7 @@ msgstr "ਸ਼ਾਮਲ(_A)"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "ਹਰੇਕ ਜੰਤਰ ਲਈ ਰੰਗ ਪਰਬੰਧ ਲਈ ਮਿਤੀ ਰੰਗ ਪਰੋਫਾਇਲ ਅੱਪਡੇਟ ਕਰਨ ਦੀ ਲੋੜ ਹੈ।"
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "ਹੋਰ ਸਿੱਖੋ"
 
@@ -1051,82 +680,6 @@ msgstr "D65 (ਫੋਟੋਗਰਾਫ਼ੀ ਅਤੇ ਗਰਾਫਿਕਸ)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "ਸਟੈਂਡਰਡ ਥਾਂ"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "ਪਰੋਫਾਇਲ ਟੈਸਟ"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "ਆਟੋਮੈਟਿਕ"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "ਘੱਟ ਕੁਆਲਟੀ"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "ਮੱਧਮ ਕੁਆਲਟੀ"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "ਵਧਿਆ ਕੁਆਲਟੀ"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "ਡਿਫਾਲਟ RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "ਡਿਫਾਲਟ CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "ਡਿਫਾਲਟ ਸਲੇਟੀ"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "ਵੇਂਡਰ ਵਲੋਂ ਦਿੱਤਾ ਫੈਕਟਰੀ ਕੈਲੀਬਰੇਸ਼ਨ ਡਾਟਾ"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "ਇਹ ਪਰੋਫਾਇਲ ਲਈ ਪੂਰੀ-ਸਕਰੀਨ ਡਿਸਪਲੇਅ ਸੋਧ ਸੰਭਵ ਨਹੀਂ"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "ਇਹ ਪਰੋਫਾਇਲ ਹੁਣ ਠੀਕ ਨਹੀਂ ਰਿਹਾ ਹੋ ਸਕਦਾ ਹੈ"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "ਰੰਗ"
@@ -1134,18 +687,11 @@ msgstr "ਰੰਗ"
 #: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
-msgstr ""
-"ਆਪਣੇ ਜੰਤਰਾਂ, ਜਿਵੇਂ ਕਿ ਡਿਸਪਲੇਅ, ਕੈਮਰੇ ਜਾਂ ਪਰਿੰਟਰਾਂ ਦੇ ਰੰਗ ਨੂੰ ਕੈਲੀਬਰੇਟ ਕਰੋ"
+msgstr "ਆਪਣੇ ਜੰਤਰਾਂ, ਜਿਵੇਂ ਕਿ ਡਿਸਪਲੇਅ, ਕੈਮਰੇ ਜਾਂ ਪਰਿੰਟਰਾਂ ਦੇ ਰੰਗ ਨੂੰ ਕੈਲੀਬਰੇਟ ਕਰੋ"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
-msgstr ""
-"ਰੰਗ;Color;ICC;Profile;Calibrate;ਪ੍ਰਿੰਟਰ;ਪਰਿੰਟਰ;Printer;Display;ਡਿਸਪਲੇਅ;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "…ਹੋਰ"
+msgstr "ਰੰਗ;Color;ICC;Profile;Calibrate;ਪ੍ਰਿੰਟਰ;ਪਰਿੰਟਰ;Printer;Display;ਡਿਸਪਲੇਅ;"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1160,13 +706,8 @@ msgid "No languages found"
 msgstr "ਕੋਈ ਭਾਸ਼ਾ ਨਹੀਂ ਲੱਭੀ।"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "…ਹੋਰ"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1195,151 +736,6 @@ msgstr "ਘਾਟਾ ਘੰਟਾ"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "ਘਾਟਾ ਮਿੰਟ"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "ਅੱਜ"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "ਕੱਲ੍ਹ"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d ਘੰਟਾ"
-msgstr[1] "%d ਘੰਟੇ"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d ਮਿੰਟ"
-msgstr[1] "%d ਮਿੰਟ"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d ਸਕਿੰਟ"
-msgstr[1] "%d ਸਕਿੰਟ"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 ਸਕਿੰਟ"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "ਹਾਟਸਪਾਟ"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-ਘੰਟੇ"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "ਸਵੇਰ/ਆਥਣ"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1434,15 +830,11 @@ msgstr "ਆਟੋਮੈਟਿਕ ਸਮਾਂ ਖੇਤਰ(_Z)"
 msgid "Requires location services enabled and internet access"
 msgstr "ਟਿਕਾਣਾ ਸੇਵਾਵਾ ਸਮਰੱਥ ਅਤੇ ਇੰਟਰਨੈੱਟ ਪਹੁੰਚ ਚਾਹੀਦੀ ਹੈ"
 
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
-#: panels/location/cc-location-panel.ui:9 panels/lock/cc-lock-panel.ui:39
-#: panels/lock/cc-lock-panel.ui:75 panels/lock/cc-lock-panel.ui:95
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "ਯੋਗ ਕੀਤਾ"
 
@@ -1450,15 +842,42 @@ msgstr "ਯੋਗ ਕੀਤਾ"
 msgid "Time Z_one"
 msgstr "ਸਮੇਂ ਦਾ ਇਲਾਕਾ(_o)"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ਅਣ-ਲਾਕ ਕਰੋ"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "ਸਮੇਂ ਦਾ ਫਾਰਮੈਟ(_F)"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "ਮਿਤੀ"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 ਸਕਿੰਟ"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "ਕੈਲੰਡਰ"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "ਅੰਕ"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "ਤਾਰੀਖ ਅਤੇ ਸਮਾਂ, ਸਮੇਂ ਦੇ ਇਲਾਕੇ ਸਮੇਤ ਬਦਲੋ"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "ਕਲਾਕ;ਘੜੀ;ਸਮਾਂ,ਵੇਲਾ ਇਲਾਕਾ;ਸਥਾਨ;ਥਾਂ;ਸਮਾਂ-ਖੇਤਰ;ਟਿਕਾਣਾ;"
@@ -1504,21 +923,9 @@ msgstr "ਮੂਲ ਐਪਲੀਕੇਸ਼ਨ"
 msgid "Configure Default Applications"
 msgstr "ਮੂਲ ਐਪਲੀਕੇਸ਼ਨਾਂ ਦੀ ਸੰਰਚਨਾ ਕਰੋ"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "ਡਿਫਾਲਟ;ਮੂਲ;ਐਪਲੀਕੇਸ਼ਨ;ਤਰਜੀਹੀ;ਮੀਡੀਆ;ਪਸੰਦ;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"ਤਕਨੀਕੀ ਸਮੱਸਿਆਵਾਂ ਬਾਰੇ ਰਿਪੋਰਟਾਂ ਭੇਜਣ ਨਾਲ ਸਾਨੂੰ %s ਸੁਧਾਰਨ ਲਈ ਮਦਦ ਮਿਲਦੀ ਹੈ।"
-" ਰਿਪੋਰਟ ਅਣਪਛਾਤੇ "
-"ਰੂਪ ਵਿੱਚ ਭੇਜੀਆਂ ਜਾਂਦੀਆਂ ਹਨ ਅਤੇ ਨਿੱਜੀ ਡਾਟੇ ਨੂੰ ਹਟਾਇਆ ਜਾਂਦਾ ਹੈ। %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1536,44 +943,9 @@ msgstr "ਪੜਤਾਲ"
 msgid "Report your problems"
 msgstr "ਆਪਣੀਆਂ ਸਮੱਸਿਆਵਾ ਬਾਰੇ ਰਿਪੋਰਟ ਦਿਓ"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "ਪੜਤਾਲ;ਕਰੈਸ਼;ਨਸ਼ਟ;"
-
-#: panels/display/cc-display-panel.c:516
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "ਚਾਲੂ"
-
-#: panels/display/cc-display-panel.c:518 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "ਬੰਦ"
-
-#: panels/display/cc-display-panel.c:955
-msgid "Apply Changes?"
-msgstr "ਬਦਲਾਅ ਲਾਗੂ ਕਰਨੇ ਹਨ?"
-
-#: panels/display/cc-display-panel.c:960
-msgid "Changes Cannot be Applied"
-msgstr "ਤਬਦੀਲੀਆਂ ਲਾਗੂ ਨਹੀਂ ਕੀਤੀਆਂ ਜਾ ਸਕਦੀਆਂ"
-
-#: panels/display/cc-display-panel.c:962
-msgid "This could be due to hardware limitations."
-msgstr "ਇਹ ਹਾਰਡਵੇਅਰ ਰੋਕਾਂ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ।"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1623,31 +995,6 @@ msgstr "ਪ੍ਰਾਇਮਰੀ ਡਿਸਪਲੇਅ"
 msgid "Night Light"
 msgstr "ਰਾਤ ਦੀ ਰੋਸ਼ਨੀ"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "ਲੈਂਡਸਕੇਪ"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "ਪੋਰਟਰੇਟ ਸੱਜੇ"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "ਪੋਰਟਰੇਟ ਖੱਬੇ"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "ਲੈਂਡਸਕੇਪ (ਪਲਟਿਆ)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1672,6 +1019,17 @@ msgctxt "display setting"
 msgid "Scale"
 msgstr "ਸਕੇਲ"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "ਨੈਚਰਲ ਸਕਰੋਲਿੰਗ"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
 msgstr "ਰਾਤ ਦੀ ਰੋਸ਼ਨੀ ਮੌਜੂਦ ਨਹੀਂ"
@@ -1681,8 +1039,7 @@ msgid ""
 "This could be the result of the graphics driver being used, or the desktop "
 "being used remotely"
 msgstr ""
-"ਇਹ ਵਰਤੇ ਜਾ ਰਹੇ ਗਰਾਫਿਕਸ ਡਰਾਇਵਰ ਦੇ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ ਜਾਂ ਰਿਮੋਟ ਤੋਂ ਡੈਸਕਟਾਪ ਵਰਤਣ"
-" ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ"
+"ਇਹ ਵਰਤੇ ਜਾ ਰਹੇ ਗਰਾਫਿਕਸ ਡਰਾਇਵਰ ਦੇ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ ਜਾਂ ਰਿਮੋਟ ਤੋਂ ਡੈਸਕਟਾਪ ਵਰਤਣ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ"
 
 #. Inhibit the redshift functionality until the next day starts
 #: panels/display/cc-night-light-page.ui:58
@@ -1699,8 +1056,7 @@ msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
 msgstr ""
-"ਰਾਤ ਦੀ ਰੋਸ਼ਨੀ ਸਕਰੀਨ ਰੰਗਾਂ ਨੂੰ ਨਿੱਘਾ ਬਣਾਉਂਦੀ ਹੈ। ਇਸ ਅੱਖਾਂ ਉੱਤੇ ਜ਼ੋਰ ਪੈਣ ਅਤੇ ਨੀਂਦ"
-" ਟਲਣ ਤੋਂ ਰੋਕਣ ਲਈ "
+"ਰਾਤ ਦੀ ਰੋਸ਼ਨੀ ਸਕਰੀਨ ਰੰਗਾਂ ਨੂੰ ਨਿੱਘਾ ਬਣਾਉਂਦੀ ਹੈ। ਇਸ ਅੱਖਾਂ ਉੱਤੇ ਜ਼ੋਰ ਪੈਣ ਅਤੇ ਨੀਂਦ ਟਲਣ ਤੋਂ ਰੋਕਣ ਲਈ "
 "ਮਦਦ ਕਰਦੀ ਹੈ।"
 
 #: panels/display/cc-night-light-page.ui:132
@@ -1767,79 +1123,13 @@ msgstr "ਡਿਸਪਲੇਅ"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "ਚੁਣੋ ਕਿ ਮਾਨੀਟਰਾਂ ਅਤੇ ਪਰੋਜੈਕਟਰ ਨਾਲ ਕਿਵੇਂ ਜੁੜਨਾ ਹੈ"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
 msgstr ""
-"ਪੈਨਲ;ਪਰੋਜੈਕਟਰ;xrandr;ਸਕਰੀਨ;ਰੈਜ਼ੋਲੂਸ਼ਨ;ਤਾਜ਼ਾ;ਮਾਨੀਟਰ;ਰਾਤ;ਰਾਤਰੀ;ਰੌਸ਼ਨੀ;ਪ੍ਰਕਾਸ਼;ਨੀਲਾ"
-";ਲਾਲ-"
-"ਪਰਿਵਰਤਨ;ਸੂਰਜ-ਚੜ੍ਹਨਾ;ਸੂਰਜ-ਲਹਿਣਾ;ਸੂਰਜ-ਡੁੱਬਣਾ;ਹਨੇਰਾ;ਰਾਤ-ਵੇਲਾ;ਚਾਨਣ;ਸਰਘੀ;ਤਰਕਾਲਾਂ;ਆਥ"
-"ਣ;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:106
-msgid "Secure Boot is Active"
-msgstr "ਸਕਿਉਰ ਬੂਟ ਸਰਗਰਮ ਹੈ"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:76
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:82
-msgid "Secure Boot Has Problems"
-msgstr "ਸਕਿਉਰ ਬੂਟ ਨਾਲ ਸਮੱਸਿਆਵਾਂ ਹਨ"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:86
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:89
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:92
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "ਸਹਾਇਤਾ ਲਈ ਆਪਣੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਜਾਂ IT ਸਹਾਇਤਾ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-panel.c:118
-#| msgid "Camera is Turned Off"
-msgid "Secure Boot is Turned Off"
-msgstr "ਸਕਿਉਰ ਬੂਟ ਬੰਦ ਕੀਤਾ ਹੈ"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:102
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"ਸਕਿਉਰ ਬੂਟ ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਨੂੰ ਲੋਡ ਹੋਣ ਤੋਂ ਰੋਕਦਾ ਹੈ।"
-" ਇਹ ਇਸ ਵੇਲੇ ਬੰਦ ਕੀਤਾ ਹੋਇਆ ਹੈ।"
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:105
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
+"ਪੈਨਲ;ਪਰੋਜੈਕਟਰ;xrandr;ਸਕਰੀਨ;ਰੈਜ਼ੋਲੂਸ਼ਨ;ਤਾਜ਼ਾ;ਮਾਨੀਟਰ;ਰਾਤ;ਰਾਤਰੀ;ਰੌਸ਼ਨੀ;ਪ੍ਰਕਾਸ਼;ਨੀਲਾ;ਲਾਲ-"
+"ਪਰਿਵਰਤਨ;ਸੂਰਜ-ਚੜ੍ਹਨਾ;ਸੂਰਜ-ਲਹਿਣਾ;ਸੂਰਜ-ਡੁੱਬਣਾ;ਹਨੇਰਾ;ਰਾਤ-ਵੇਲਾ;ਚਾਨਣ;ਸਰਘੀ;ਤਰਕਾਲਾਂ;ਆਥਣ;"
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1852,452 +1142,40 @@ msgstr ""
 "\n"
 "ਹੋਰ ਜਾਣਕਾਰੀ ਲਈ ਆਪਣੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਜਾਂ IT ਸਹਾਇਤਾ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
 
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:70
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-panel.c:433
-#| msgid "No Action"
-msgid "No Protection"
-msgstr "ਕੋਈ ਸੁਰੱਖਿਆ ਨਹੀਂ"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:99
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:111
-#: panels/firmware-security/cc-firmware-security-dialog.ui:80
-#: panels/firmware-security/cc-firmware-security-panel.c:440
-msgid "Minimal Protection"
-msgstr "ਘੱਟੋ-ਘੱਟ ਸੁਰੱਖਿਆ"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:112
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:127
-#: panels/firmware-security/cc-firmware-security-dialog.ui:94
-#: panels/firmware-security/cc-firmware-security-panel.c:447
-msgid "Basic Protection"
-msgstr "ਮੁੱਢਲੀ ਸੁਰੱਖਿਆ"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:128
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:146
-#: panels/firmware-security/cc-firmware-security-dialog.ui:108
-#: panels/firmware-security/cc-firmware-security-panel.c:454
-#| msgid "Add connection"
-msgid "Extended Protection"
-msgstr "ਵਾਧਾ ਕੀਤੀ ਸੁਰੱਖਿਆ"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:147
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:156
-msgid "Error: unable to determine HSI level."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:157
-msgid "Error: unable to determine Incorrect HSI level."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:241
-msgid "Minimal Security Protections"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:246
-msgid "Basic Security Protections"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:251
-msgid "Extended Security Protections"
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#| msgid "Security Key"
 msgid "Security Level"
 msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:107
-msgid "Protected against malicious software when the device starts."
-msgstr ""
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "ਪੱਧਰ 1"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot has Problems"
-msgstr "ਸਕਿਉਰ ਬੂਟ ਨਾਲ ਸਮੱਸਿਆਵਾਂ ਹਨ"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "ਪੱਧਰ 2"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Some protection when the device is started."
-msgstr ""
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "ਪੱਧਰ 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "No protection when the device is started."
-msgstr "ਜਦੋਂ ਡਿਵਾਈਸ ਸ਼ੁਰੂ ਹੁੰਦਾ ਹੈ ਤਾਂ ਕੋਈ ਸੁਰੱਖਿਆ ਨਹੀਂ ਹੈ"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:434
-msgid "Highly exposed to security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:441
-msgid "Limited protection against simple security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:448
-msgid "Protected against common security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:455
-#: panels/firmware-security/cc-firmware-security-panel.c:462
-msgid "Protected against a wide range of security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:461
-msgid "Comprehensive Protection"
-msgstr "ਸੰਪੂਰਨ ਸੁਰੱਖਿਆ"
-
-#: panels/firmware-security/cc-firmware-security-panel.ui:138
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "ਕੋਈ ਘਟਨਾ ਨਹੀਂ"
 
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:38
-msgid "SPI write"
-msgstr "SPI ਲਿਖਣ"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "ਡਿਵਾਈਸ ਸੁਰੱਖਿਆ"
 
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:40
-msgid "SPI lock"
-msgstr "SPI ਲਾਕ"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "ਹੋਸਟ ਫਿਰਮਵੇਅਰ ਸੁਰੱਖਿਆ ਸਥਿਤੀ"
 
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-#| msgid "Select a region"
-msgid "SPI BIOS region"
-msgstr "SPI BIOS ਖੇਤਰ"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:44
-#, fuzzy
-#| msgid "Description"
-msgid "SPI BIOS Descriptor"
-msgstr "ਵੇਰਵਾ"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:46
-msgid "Pre-boot DMA protection is"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
 msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:48
-msgid "Intel BootGuard"
-msgstr "Intel ਬੂਟਗਾਰਡ"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:51
-msgid "Intel BootGuard verified boot"
-msgstr "Intel ਬੂਟਗਾਰਡ ਤਸਦੀਕ ਕੀਤਾ ਬੂਟ"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:54
-msgid "Intel BootGuard ACM protected"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Intel BootGuard error policy"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * OTP = one time programmable
-#: panels/firmware-security/cc-firmware-security-utils.c:60
-msgid "Intel BootGuard OTP fuse"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:63
-msgid "Intel CET"
-msgstr "Intel CET"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:66
-msgid "Intel CET Active"
-msgstr "Intel CET ਸਰਗਰਮ"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:70
-msgid "Encrypted RAM"
-msgstr "ਇੰਕ੍ਰਿਪਟ ਕੀਤੀ RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:73
-msgid "IOMMU device protection"
-msgstr ""
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:75
-msgid "Kernel lockdown"
-msgstr "ਕਰਨਲ ਲਾਕ-ਡਾਊਨ"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:77
-msgid "Kernel tainted"
-msgstr ""
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:79
-msgid "Linux swap"
-msgstr "ਲੀਨਕਸ ਸਵੈਪ"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:81
-#| msgid "Suspend"
-msgid "Suspend-to-ram"
-msgstr "ਸਸਪੈਂਡ-ਟੂ-ਰੈਮ"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:83
-#| msgid "Suspend"
-msgid "Suspend-to-idle"
-msgstr "ਸਸਪੈਂਡ-ਟੂ-ਆਈਡਲ"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "UEFI platform key"
-msgstr "UEFI ਪਲੇਟਫਾਰਮ ਕੁੰਜੀ"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:87
-#| msgid "Secure network"
-msgid "Secure boot"
-msgstr "ਸਕਿਉਰ ਬੂਟ"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:89
-msgid "All TPM PCRs are"
-msgstr ""
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "TPM PCR0 reconstruction"
-msgstr ""
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:93
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:95
-#| msgid "Manufacturer"
-msgid "MEI manufacturing mode"
-msgstr "MEI ਨਿਰਮਾਤਾ ਢੰਗ"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the
-#. * "override" is the physical PIN that can be driven to
-#. * logic high -- luckily it is probably not accessible to
-#. * end users on consumer boards
-#: panels/firmware-security/cc-firmware-security-utils.c:100
-msgid "MEI override"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-#| msgid "PEAP _version"
-msgid "MEI version"
-msgstr "MEI ਵਰਜ਼ਨ"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:104
-#| msgid "Firmware Version"
-msgid "Firmware updates"
-msgstr "ਫਿਰਮਵੇਅਰ ਅੱਪਡੇਟ"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:106
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware attestation"
-msgstr "ਫਿਰਮਵੇਅਰ ਵਰਜ਼ਨ"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:108
-msgid "fwupd plugins"
-msgstr "fwupd ਪਲੱਗਇਨਾਂ"
-
-#. TRANSLATORS: Title: Direct Connect Interface (DCI) allows
-#. * debugging of Intel processors using the USB3 port
-#: panels/firmware-security/cc-firmware-security-utils.c:111
-#: panels/firmware-security/cc-firmware-security-utils.c:112
-msgid "Intel DCI debugger"
-msgstr ""
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:114
-msgid "Pre-boot DMA protection"
-msgstr ""
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:116
-#| msgid "Supported ICC profiles"
-msgid "Supported CPU"
-msgstr "ਸਹਾਇਕ CPU"
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:150
-msgid "IOMMU device protection enabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:156
-msgid "IOMMU device protection disabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:176
-msgid "Kernel is no longer tainted"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:182
-msgid "Kernel is tainted"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:188
-msgid "Kernel lockdown disabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:194
-msgid "Kernel lockdown enabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:200
-msgid "Pre-boot DMA protection is disabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Pre-boot DMA protection is enabled"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:212
-#| msgctxt "Password mode"
-#| msgid "Account disabled"
-msgid "Secure Boot disabled"
-msgstr "ਸਕਿਉਰ ਬੂਟ ਅਸਮਰੱਥ ਹੈ"
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:218
-msgid "Secure Boot enabled"
-msgstr "ਸਕਿਉਰ ਬੂਟ ਸਮਰੱਥ ਹੈ"
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:224
-msgid "All TPM PCRs are valid"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:230
-msgid "All TPM PCRs are now valid"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:236
-msgid "A TPM PCR is now an invalid value"
-msgstr ""
-
-#. TRANSLATORS: HSI event title
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "TPM PCR0 reconstruction is invalid"
-msgstr ""
-
-#: panels/info-overview/cc-info-overview-panel.c:296
-#: panels/info-overview/cc-info-overview-panel.c:320
-#: panels/info-overview/cc-info-overview-panel.c:366
-#: panels/info-overview/cc-info-overview-panel.c:396
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "ਅਣਪਛਾਤਾ"
-
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:328
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; ਬਿਲਡ ID: %s"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:343
-#, c-format
-msgid "64-bit"
-msgstr "64-ਬਿੱਟ"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:346
-#, c-format
-msgid "32-bit"
-msgstr "32-ਬਿੱਟ"
-
-#: panels/info-overview/cc-info-overview-panel.c:605
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:609
-msgid "Wayland"
-msgstr "ਵੇਲੈਂਡ"
-
-#: panels/info-overview/cc-info-overview-panel.c:611
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "ਅਣਪਛਾਤਾ"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:689
-msgid "Not Available"
-msgstr "ਉਪਲੱਬਧ ਨਹੀਂ"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "ਸਿਸਟਮ ਲੋਗੋ"
+"ਸਕਰੀਨ;ਲਾਕ;ਜਾਂਚ;ਪੜਤਾਲ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਆਰਜ਼ੀ;ਇੰਡੈਕਸ;ਨਾਂ;ਨੈੱਟਵਰਕ;ਪਛਾਣ;ਕਰੈਸ਼;ਤਾਜ਼ਾ;ਪਰਦੇਦਾਰੀ;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2333,49 +1211,53 @@ msgstr "...ਗਿਣਤੀ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
 msgid "OS Name"
 msgstr "ਓ.ਸਿ. ਦਾ ਨਾਂ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
-msgid "OS Type"
-msgstr "ਓ.ਸਿ ਦੀ ਕਿਸਮ"
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ਓ.ਸਿ. ਬਿਲਡ ਆਈਡੀ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "ਓ.ਸਿ. ਦੀ ਕਿਸਮ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "ਗਨੋਮ ਦਾ ਵਰਜ਼ਨ"
 
 #. translators: this is a placeholder while the GNOME version is being fetched
-#: panels/info-overview/cc-info-overview-panel.ui:116
+#: panels/info-overview/cc-info-overview-panel.ui:125
 msgid "Loading…"
 msgstr "…ਲੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:124
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "ਵਿੰਡੋਇੰਗ ਸਾਫਟਵੇਅਰ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:132
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "ਵਰਚੁਲਾਈਜੇਸ਼ਨ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:141
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "ਸਾਫਟਵੇਅਰ ਅੱਪਡੇਟ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:165
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "ਡਿਵਾਈਸ ਦਾ ਨਾਂ ਬਦਲੋ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:181
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
 msgstr ""
-"ਡਿਵਾਈਸ ਨਾਂ ਨੂੰ ਇਸ ਡਿਵਾਈਸ ਦੀ ਪਛਾਣ ਕਰਨ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ, ਜਦੋਂ ਇਸ ਨੂੰ ਨੈੱਟਵਰਕ"
-" ਉੱਤੇ ਵੇਖਦੇ ਹੋ ਜਾਂ "
+"ਡਿਵਾਈਸ ਨਾਂ ਨੂੰ ਇਸ ਡਿਵਾਈਸ ਦੀ ਪਛਾਣ ਕਰਨ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ, ਜਦੋਂ ਇਸ ਨੂੰ ਨੈੱਟਵਰਕ ਉੱਤੇ ਵੇਖਦੇ ਹੋ ਜਾਂ "
 "ਜਦੋਂ ਬਲੂਟੁੱਥ ਡਿਵਾਈਸਾਂ ਨਾਲ ਪੇਅਰ ਕੀਤਾ ਜਾਂਦਾ ਹੈ।"
 
-#: panels/info-overview/cc-info-overview-panel.ui:187
+#: panels/info-overview/cc-info-overview-panel.ui:196
 msgid "Device name"
 msgstr "ਡਿਵਾਈਸ ਦਾ ਨਾਂ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:201
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "ਨਾਂ ਬਦਲੋ(_R)"
 
@@ -2387,18 +1269,12 @@ msgstr "ਇਸ ਬਾਰੇ"
 msgid "View information about your system"
 msgstr "ਆਪਣੇ ਸਿਸਟਮ ਬਾਰੇ ਜਾਣਕਾਰੀ ਵੇਖੋ"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
 "application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
-"ਡਿਵਾਈਸ;ਡੀਵਾਈਸ;;ਜੰਤਰ;ਸਿਸਟਮ;ਜਾਣਕਾਰੀ;ਮੈਮੋਰੀ;ਪਰੋਸੈਸਰ;ਵਰਜ਼ਨ;ਪ੍ਰੋਸੈਸਰ;ਡਿਫਾਲਟ;ਐਪਲੀਕੇਸ"
-"਼ਨ;ਯੂਐਸਬੀ;"
+"ਡਿਵਾਈਸ;ਡੀਵਾਈਸ;;ਜੰਤਰ;ਸਿਸਟਮ;ਜਾਣਕਾਰੀ;ਮੈਮੋਰੀ;ਪਰੋਸੈਸਰ;ਵਰਜ਼ਨ;ਪ੍ਰੋਸੈਸਰ;ਡਿਫਾਲਟ;ਐਪਲੀਕੇਸ਼ਨ;ਯੂਐਸਬੀ;"
 "ਡੀਵੀਡੀ;ਸੀਡੀ;ਆਡੀਓ;ਔਡੀਓ;ਵੀਡੀਓ;ਵਿਡੀਓ;ਡਿਸਕ;ਆਟੋਰਨ;ਮੀਡੀਆ;ਹਟਾਉਣਯੋਗ;ਯੰਤਰ;ਹੋਸਟਨੇਮ;"
 
 #: panels/keyboard/00-multimedia.xml.in:2
@@ -2470,6 +1346,12 @@ msgstr "ਲਾਂਚਰ"
 msgid "Launch help browser"
 msgstr "ਮਦਦ-ਝਲਕਾਰਾ ਚਲਾਓ"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "ਸੈਟਿੰਗ"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "ਕੈਲਕੂਲੇਟਰ ਚਲਾਓ"
@@ -2491,7 +1373,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "ਖੋਜ"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "ਸਿਸਟਮ"
 
@@ -2540,15 +1422,6 @@ msgstr "ਟੈਕਸਟ ਅਕਾਰ ਘਟਾਓ"
 msgid "High contrast on or off"
 msgstr "ਵੱਧ-ਗੂੜ੍ਹਾ ਕਰਨਾ ਚਾਲੂ ਜਾਂ ਬੰਦ ਕਰੋ"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "ਕੋਈ ਇੰਪੁੱਟ ਸਰੋਤ ਨਹੀਂ ਲੱਭਿਆ"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "ਹੋਰ"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "ਇੰਪੁੱਟ ਸਰੋਤ ਸ਼ਾਮਲ"
@@ -2581,108 +1454,9 @@ msgstr "ਮੇਰੀ ਪਸੰਦ"
 msgid "View Keyboard Layout"
 msgstr "ਕੀਬੋਰਡ ਲੇਆਉਟ ਵੇਖੋ"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "ਹਟਾਓ"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "ਬਦਲਵੇਂ ਅੱਖਰ ਸਵਿੱਚ"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"ਬਦਲਵੀਂ ਅੱਖਰ ਸਵਿੱਚ ਨੂੰ ਹੋਰ ਅੱਖਰ ਦੇਣ ਲਈ ਵਰਤਿਆ ਜਾ ਸਕਦਾ ਹੈ। ਇਹਨਾਂ ਨੂੰ ਕਈ ਵਾਰ"
-" ਤੁਹਾਡੇ ਕੀਬੋਰਡ ਉੱਤੇ "
-"ਤੀਜੀ-ਚੋਣ ਵਜੋਂ ਛਾਪਿਆ ਗਿਆ ਹੁੰਦਾ ਹੈ।"
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "ਖੱਬਾ Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "ਸੱਜਾ Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "ਖੱਬਾ ਸੁਪਰ"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "ਸੱਜਾ ਸੁਪਰ"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "ਮੀਨੂ ਸਵਿੱਚ"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "ਸੱਜਾ Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "ਕੰਪੋਜ਼ ਸਵਿੱਚ"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"ਮਿਸ਼ਰਿਤ ਸਵਿੱਚ ਕਈ ਕਿਸਮ ਦੇ ਵੱਖ-ਵੱਖ ਅੱਖਰ ਦੇਣ ਲਈ ਕੰਮ ਆਉਂਦੀ ਹੈ। ਇਹ ਵਰਤਣ ਲਈਤਦ ਲੜੀਵਾਰ"
-" ਅੱਖਰ ਦੇਣ "
-"ਲਈ ਬਣਾਓ ਨੂੰ ਦਬਾਓ। ਮਿਸਾਲ ਲਈ <b>C</b> ਅਤੇ <b>o</b> ਦੇ ਬਾਅਦ ਬਣਾਓ ਨਾਲ <b>©</b>"
-" ਪਵੇਗਾ, "
-"<b>a</b> ਤੇ <b>'</b> ਦੇ ਬਾਅਦ ਬਣਾਓ ਦਬਾਉਣ ਨਾਲ <b>á</b> ਪਵੇਗਾ।"
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps ਲਾਕ"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "ਸਕਰੋਲ ਲਾਕ"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "ਪਰਿੰਟ ਸਕਰੀਨ"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"ਇਨਪੁੱਟ ਸਰੋਤਾਂ ਨੂੰ %s ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਵਰਤ ਕੇ ਬਦਲਿਆ ਜਾ ਸਕਦਾ ਹੈ।\n"
-"ਇਹ ਸ਼ਾਰਟਕੱਟਾਂ ਨੂੰ ਕੀਬੋਰਡ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਬਦਲਿਆ ਜਾ ਸਕਦਾ ਹੈ"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2704,54 +1478,29 @@ msgstr "ਸਭ ਵਿੰਡੋਆਂ ਲਈ ਇੱਕੋ ਸਰੋਤ ਵਰਤ�
 msgid "Switch input sources _individually for each window"
 msgstr "ਹਰੇਕ ਵਿੰਡੋ ਲਈ ਵੱਖੋ-ਵੱਖਰਾ ਇਨਪੁੱਟ ਸਰੋਤ ਬਦਲੋ(_i)"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "ਖਾਸ ਅੱਖਰ ਲਿਖੋ"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "ਕੀਬੋਰਡ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਚਿੰਨ੍ਹ, ਅੱਖਰਾਂ ਦੇ ਵੱਖੋ-ਵੱਖਰੇ ਰੂਪ ਦੇਣ ਦੇ ਢੰਗ।"
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "ਬਦਲਵੇਂ ਅੱਖਰ ਸਵਿੱਚ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "ਕੰਪੋਜ਼ ਸਵਿੱਚ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "ਕੀ-ਬੋਰਡ ਸ਼ਾਰਟਕੱਟ"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "ਸ਼ਾਰਟਕੱਟ ਵੇਖੋ ਤੇ ਕਸਟਮਾਈਜ਼ ਕਰੋ"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d ਸੋਧਿਆ"
-msgstr[1] "%d ਸੋਧੇ"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "ਕੀ ਸਾਰੇ ਸ਼ਾਰਟਕੱਟ ਮੁੜ-ਸੈੱਟ ਕਰਨੇ ਹਨ?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"ਸ਼ਾਰਟਕੱਟਾਂ ਨੂੰ ਮੁੜ-ਸੈੱਟ ਕਰਨ ਨਾਲ ਤੁਹਾਡੇ ਕਸਟਮ ਸ਼ਾਰਟਕੱਟਾਂ ਉੱਤੇ ਅਸਰ ਪੈ ਸਕਦਾ ਹੈ। ਇਸ"
-" ਨੂੰ ਵਾਪਸ ਨਹੀਂ "
-"ਪਰਤਾਇਆ ਜਾ ਸਕਦਾ ਹੈ।"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "ਰੱਦ ਕਰੋ"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "ਸਭ ਮੁੜ-ਸੈੱਟ ਕਰੋ"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2789,35 +1538,6 @@ msgstr "ਸ਼ਾਰਟਕੱਟ ਸ਼ਾਮਿਲ"
 msgid "No keyboard shortcut found"
 msgstr "ਕੋਈ ਕੀ-ਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਨਹੀਂ ਲੱਭਿਆ"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s ਨੂੰ ਪਹਿਲਾਂ ਹੀ %s ਨੂੰ ਵਰਤ ਰਿਹਾ ਹੈ। ਜੇ ਤੁਸੀਂ ਇਸ ਨੂੰ ਬਦਲਿਆ ਤਾਂ %s ਅਸਮਰੱਥ ਹੋ"
-" ਜਾਵੇਗਾ।"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "ਨਵਾਂ ਸ਼ਾਰਟਕੱਟ ਦਿਓ"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ ਸੈੱਟ ਕਰੋ"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "ਸ਼ਾਰਟਕੱਟ ਸੈੱਟ ਕਰੋ"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "%s ਨੂੰ ਬਦਲਣ ਲਈ ਨਵਾਂ ਸ਼ਾਰਟਕੱਟ ਦਿਉ।"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ ਨੂੰ ਜੋੜੋ"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "ਹਟਾਓ(_R)"
@@ -2829,7 +1549,6 @@ msgstr "ਬਦਲੋ(_p)"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "ਸੈੱਟ(_S)"
 
@@ -2865,6 +1584,11 @@ msgstr "ਕੋਈ ਨਹੀਂ"
 msgid "Reset the shortcut to its default value"
 msgstr "ਸ਼ਾਰਟਕੱਟ ਨੂੰ ਇਸ ਦੇ ਮੂਲ ਮੁੱਲ ਲਈ ਮੁੜ-ਸੈੱਟ ਕਰੋ"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "ਡਿਫਾਲਟ ਰੀ-ਸੈੱਟ ਕਰੋ(_R)"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "ਕੀ-ਬੋਰਡ"
@@ -2874,15 +1598,12 @@ msgid ""
 "Change keyboard shortcuts and set your typing preferences, keyboard layouts "
 "and input sources"
 msgstr ""
-"ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਵੇਖੋ ਤੇ ਬਦਲੋ ਅਤੇ ਆਪਣੀ ਟਾਈਪ ਕਰਨ ਲਈ ਪਸੰਦ ਦਿਓ, ਕੀਬੋਰਡ ਖਾਕੇ ਅਤੇ"
-" ਇਨਪੁੱਟ ਢੰਗ"
+"ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਵੇਖੋ ਤੇ ਬਦਲੋ ਅਤੇ ਆਪਣੀ ਟਾਈਪ ਕਰਨ ਲਈ ਪਸੰਦ ਦਿਓ, ਕੀਬੋਰਡ ਖਾਕੇ ਅਤੇ ਇਨਪੁੱਟ ਢੰਗ"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
-msgstr ""
-"ਸ਼ਾਰਟਕੱਟ;ਵਰਕਸਪੇਸ;ਵਿੰਡੋ;ਮੁੜ-ਆਕਾਰ;ਰੀਸਾਈਜ਼;ਜ਼ੂਮ;ਕਨਟਰਾਸਟ;ਇਨਪੁਟ;ਸਰੋਤ;ਲਾਕ;ਵਾਲੀਅਮ;"
+msgstr "ਸ਼ਾਰਟਕੱਟ;ਵਰਕਸਪੇਸ;ਵਿੰਡੋ;ਮੁੜ-ਆਕਾਰ;ਰੀਸਾਈਜ਼;ਜ਼ੂਮ;ਕਨਟਰਾਸਟ;ਇਨਪੁਟ;ਸਰੋਤ;ਲਾਕ;ਵਾਲੀਅਮ;"
 
 #: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
@@ -2902,12 +1623,10 @@ msgid ""
 "\n"
 "Allow the applications below to determine your location."
 msgstr ""
-"ਟਿਕਾਣਾ ਸੇਵਾਵਾਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡੇ ਟਿਕਾਣੇ ਬਾਰੇ ਪਤਾ ਦਿੰਦੀਆਂ ਹਨ। ਵੱਧ ਦਰੁਸਤ"
-" ਹੋਣ ਲਈ Wi-Fi ਅਤੇ "
+"ਟਿਕਾਣਾ ਸੇਵਾਵਾਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡੇ ਟਿਕਾਣੇ ਬਾਰੇ ਪਤਾ ਦਿੰਦੀਆਂ ਹਨ। ਵੱਧ ਦਰੁਸਤ ਹੋਣ ਲਈ Wi-Fi ਅਤੇ "
 "ਮੋਬਾਈਲ ਬਰਾਡਬੈਂਡ ਦੀ ਵਰਤੋਂ ਕਰੋ।\n"
 "\n"
-"ਮੋਜ਼ੀਲਾ ਟਿਕਾਣਾ ਸੇਵਾ ਦੀ ਵਰਤੋਂ ਕਰਦਾ ਹੈ: <a href='https://location.services.mozill"
-"a."
+"ਮੋਜ਼ੀਲਾ ਟਿਕਾਣਾ ਸੇਵਾ ਦੀ ਵਰਤੋਂ ਕਰਦਾ ਹੈ: <a href='https://location.services.mozilla."
 "com/privacy'>ਪਰਦੇਦਾਰੀ ਨੀਤੀ</a>\n"
 "\n"
 "ਹੇਠ ਦਿੱਤੀਆਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡਾ ਟਿਕਾਣਾ ਪਤਾ ਕਰਨ ਦੀ ਇਜਾਜ਼ਤ ਹੈ।"
@@ -2920,176 +1639,9 @@ msgstr "ਟਿਕਾਣੇ ਪਹੁੰਚ ਲਈ ਕੋਈ ਐਪਲੀਕੇ�
 msgid "Protect your location information"
 msgstr "ਆਪਣੀ ਟਿਕਾਣਾ ਜਾਣਕਾਰੀ ਸੁਰੱਖਿਅਤ ਕਰੋ"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "ਟਿਕਾਣਾ;ਥਾਂ;ਲੋਕੇਸ਼ਨ;ਜੀਪੀਐਸ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "ਸਕਰੀਨ ਬੰਦ ਕਰੋ"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "੩੦ ਸਕਿੰਟ"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "੧ ਮਿੰਟ"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "੨ ਮਿੰਟ"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "੩ ਮਿੰਟ"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "੫ ਮਿੰਟ"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "੩੦ ਮਿੰਟ"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "੧ ਘੰਟਾ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "੧ ਮਿੰਟ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "੨ ਮਿੰਟ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "੩ ਮਿੰਟ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "੪ ਮਿੰਟ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "੫ ਮਿੰਟ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "੮ ਮਿੰਟ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "੧੦ ਮਿੰਟ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "੧੨ ਮਿੰਟ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "੧੫ ਮਿੰਟ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "ਕਦੇ ਨਹੀਂ"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
-msgstr ""
-"ਆਪਣੇ-ਆਪ ਸਕਰੀਨ ਨੂੰ ਲਾਕ ਕਰਨ ਨਾਲ ਤੁਹਾਡੇ ਦੂਰ ਚਲੇ ਜਾਣ ਉੱਤੇ ਹੋਰਾਂ ਵਲੋਂ ਕੰਪਿਊਟਰ ਨੂੰ"
-" ਵਰਤਣ ਤੋਂ ਰੋਕਿਆ "
-"ਜਾਂਦਾ ਹੈ।"
-
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "ਖਾਲੀ ਸਕਰੀਨ ਦੇਰੀ"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "ਨਾ-ਸਰਗਰਮੀ ਦਾ ਅੰਤਰਾਲ, ਜਿਸ ਦੇ ਬਾਅਦ ਸਕਰੀਨ ਖਾਲੀ ਹੋ ਜਾਵੇਗੀ।"
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "ਆਪਣੇ-ਆਪ ਸਕਰੀਨ ਲਾਕ ਕਰੋ(_L)"
-
-#: panels/lock/cc-lock-panel.ui:49
-msgid "Automatic _Screen Lock Delay"
-msgstr "ਆਪਣੇ-ਆਪ ਸਕਰੀਨ ਲਾਕ ਦੇਰੀ(_S)"
-
-#: panels/lock/cc-lock-panel.ui:50
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "ਜਦੋਂ ਸਕਰੀਨ ਆਪਣੇ-ਆਪ ਲਾਕ ਹੁੰਦੀ ਹੈ ਤਾਂ ਸਕਰੀਨ ਦੇ ਝਪਕਣ ਦੇ ਬਾਅਦ ਅੰਤਰਾਲ ਹੈ।"
-
-#: panels/lock/cc-lock-panel.ui:68
-msgid "Show _Notifications on Lock Screen"
-msgstr "ਲਾਕ ਸਕਰੀਨ ਉੱਤੇ ਨੋਟੀਫਿਕੇਸ਼ਨ ਵੇਖਾਓ(_N)"
-
-#: panels/lock/cc-lock-panel.ui:86
-msgid "Forbid new _USB devices"
-msgstr "ਨਵੇਂ _USB ਡਿਵਾਈਸਾਂ ਉੱਤੇ ਰੋਕ"
-
-#: panels/lock/cc-lock-panel.ui:87
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"ਜਦੋਂ ਸਕਰੀਨ ਲਾਕ ਹੋਵੇ ਤਾਂ ਨਵੇਂ USB ਡਿਵਾਈਸਾਂ ਨੂੰ ਸਿਸਟਮ ਨਾਲ ਤਾਲਮੇਲ ਕਰਨ ਤੋਂ ਰੋਕਦਾ"
-" ਹੈ।"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "ਸਕਰੀਨ ਲਾਕ"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "ਆਪਣੀ ਸਕਰੀਨ ਲਾਕ ਕਰੋ"
-
-#. Translators: Search terms to find the Lock panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-msgid "screen;lock;private;privacy;"
-msgstr "ਸਕਰੀਨ;ਸਕ੍ਰੀਨ;ਪਰਦਾ;ਲਾਕ;ਤਾਲਾ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;"
 
 #: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
@@ -3107,8 +1659,7 @@ msgid ""
 "\n"
 "Allow the applications below to use your microphone."
 msgstr ""
-"ਮਾਈਕਰੋਫੋਨ ਦੀ ਵਰਤੋਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਆਡੀਓ ਰਿਕਾਰਡ ਕਰਨ ਤੇ ਸੁਣਨ ਲਈ ਸਹਿਮਤੀ ਦਿੰਦੀ ਹੈ।"
-" ਮਾਈਕਰੋਫੋਨ ਨੂੰ "
+"ਮਾਈਕਰੋਫੋਨ ਦੀ ਵਰਤੋਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਆਡੀਓ ਰਿਕਾਰਡ ਕਰਨ ਤੇ ਸੁਣਨ ਲਈ ਸਹਿਮਤੀ ਦਿੰਦੀ ਹੈ। ਮਾਈਕਰੋਫੋਨ ਨੂੰ "
 "ਅਸਮਰੱਥ ਕਰਨ ਨਾਲ ਕੁਝ ਐਪਲੀਕੇਸ਼ਨਾਂ ਠੀਕ ਤਰ੍ਹਾਂ ਕੰਮ ਨਹੀਂ ਕਰ ਸਕਦੀਆਂ।\n"
 "\n"
 "ਹੇਠ ਦਿੱਤੀਆਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡੇ ਮਾਈਕਰੋਫ਼ੋਨ ਨੂੰ ਵਰਤਣ ਦੀ ਇਜਾਜ਼ਤ ਹੈ।"
@@ -3121,7 +1672,6 @@ msgstr "ਮਾਈਕਰੋਫ਼ੋਨ ਪਹੁੰਚ ਲਈ ਕੋਈ ਐਪ�
 msgid "Protect your conversations"
 msgstr "ਤਹਾਡੀਆਂ ਗੱਲਾਂਬਾਤਾਂ ਸੁਰੱਖਿਅਤ ਕਰੋ"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "ਮਾਈਕਰੋਫੋਨ;ਮਾਈਕ੍ਰੋਫ਼ੋਨ;ਮਾਈਕਰੋਫ਼ੋਨ;ਐਪਲੀਕੇਸ਼ਨ,;ਪਰਦੇਦਾਰੀ;ਪ੍ਰਾਈਵੇਸੀ;"
@@ -3151,81 +1701,142 @@ msgstr "ਖੱਬੇ"
 msgid "Right"
 msgstr "ਸੱਜੇ"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "ਟਿਕਾਣਾ ਖੋਜ"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "ਮਾਊਸ"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "ਮਾਊਸ ਸਪੀਡ"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "ਨੈਚਰਲ ਸਕਰੋਲਿੰਗ"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "ਹੇਠਾਂ ਸਕਰੋਲ"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "ਸਕਰੋਲ ਕਰਨ ਨਾਲ ਸਮੱਗਰੀ ਹਿਲਦੀ ਹੈ, ਝਲਕ ਨਹੀਂ।"
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "ਸਕਰੋਲ ਕਰਨ ਨਾਲ ਸਮੱਗਰੀ ਹਿਲਦੀ ਹੈ, ਝਲਕ ਨਹੀਂ।"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "ਐਕਸਰਲੇਟਰ(_A):"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "ਸਰਗਰਮ"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "ਟੱਚਪੈਡ"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "ਟੱਚਪੈਡ ਸਪੀਡ"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "ਢੰਗ(_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "ਕਲਿੱਕ ਲਈ ਛੂਹੋੋ"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "ਕਲਿੱਕ ਲਈ ਛੂਹੋੋ"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "ਦੋ ਉਂਗਲਾਂ ਨਾਲ ਸਕਰੋਲ"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "ਲਿਖਣ ਦੌਰਾਨ ਬੰਦ ਕਰੋ(_t)"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "ਟੱਚਪੈਚ (ਅਨੁਸਾਰੀ)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "ਕੋਨਾ ਸਕਰੋਲਿੰਗ"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "ਹੇਠਾਂ ਸਕਰੋਲ"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "ਦੋ ਪਾਸੀਂ"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "ਕਲਿੱਕ ਕਰਕੇ, ਦੋ ਵਾਰ ਕਲਿੱਕ ਕਰਕੇ, ਸਕਰੋਲ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "ਪੰਜ ਕਲਿੱਕ, GEGL ਸਮਾਂ!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "ਡਬਲ ਕਲਿੱਕ, ਮੁੱਢਲਾ ਬਟਨ"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "ਇੱਕ ਵਾਰ ਕਲਿੱਕ, ਮੁੱਢਲਾ ਬਟਨ"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "ਡਬਲ ਕਲਿੱਕ, ਮੱਧ ਬਟਨ"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "ਇੱਕ ਵਾਰ ਕਲਿੱਕ, ਮੱਧ ਬਟਨ"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "ਡਬਲ ਕਲਿੱਕ, ਸੈਕੰਡਰੀ ਬਟਨ"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "ਇੱਕ ਵਾਰ ਕਲਿੱਕ, ਸੈਕੰਡਰੀ ਬਟਨ"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3234,10 +1845,8 @@ msgstr "ਮਾਊਸ ਤੇ ਟੱਚਪੈਚ"
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr ""
-"ਆਪਣੇ ਮਾਊਸ ਜਾਂ ਟੱਚਪੈਡ ਦੀ ਸੰਵੇਦਨਸ਼ੀਲਤਾ ਬਦਲੋ ਅਤੇ ਸੱਜੇ ਜਾਂ ਖੱਬੇ-ਹੱਥ ਦੀ ਚੋਣ ਕਰੋ"
+msgstr "ਆਪਣੇ ਮਾਊਸ ਜਾਂ ਟੱਚਪੈਡ ਦੀ ਸੰਵੇਦਨਸ਼ੀਲਤਾ ਬਦਲੋ ਅਤੇ ਸੱਜੇ ਜਾਂ ਖੱਬੇ-ਹੱਥ ਦੀ ਚੋਣ ਕਰੋ"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "ਟਰੈਕਪੈਂਡ;ਪੁਆਇੰਟਰ;ਕਲਿੱਕ;ਟੈਪ;ਡਬਲ;ਬਟਨ;ਟਰੈਕਬਾਲ;ਸਕਰੋਲ;"
@@ -3257,9 +1866,7 @@ msgstr "ਸਕਰੀਨ ਦੇ ਕੋਨੇ ਸਰਗਰਮ ਕਰੋ(_A)"
 #: panels/multitasking/cc-multitasking-panel.ui:43
 msgid ""
 "Drag windows against the top, left, and right screen edges to resize them."
-msgstr ""
-"ਵਿੰਡੋਆਂ ਨੂੰ ਮੁੜ ਆਕਾਰ ਕਰਨ ਲਈ ਸਕਰੀਨ ਕੋਨਿਆਂ ਦੇ ਉੱਤੇ, ਖੱਬੇ ਅਤੇ ਸੱਜੇ ਪਾਸੇ ਵੱਲ"
-" ਖਿੱਚੋ।"
+msgstr "ਵਿੰਡੋਆਂ ਨੂੰ ਮੁੜ ਆਕਾਰ ਕਰਨ ਲਈ ਸਕਰੀਨ ਕੋਨਿਆਂ ਦੇ ਉੱਤੇ, ਖੱਬੇ ਅਤੇ ਸੱਜੇ ਪਾਸੇ ਵੱਲ ਖਿੱਚੋ।"
 
 #: panels/multitasking/cc-multitasking-panel.ui:70
 msgid "Workspaces"
@@ -3317,26 +1924,16 @@ msgstr "ਬਹੁ-ਕੰਮਕਾਜ"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "ਉਤਪਾਦਨ ਤੇ ਬਹੁ-ਕੰਮਕਾਜ ਲਈ ਤਜਰੀਹਾਂ ਦਾ ਇੰਤਜ਼ਾਮ ਕਰੋ"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr "ਬਹੁ-ਕੰਮ;ਮਲਟੀ-ਟਾਸਕ;ਉਤਪਾਦਨ,ਕਸਟਮਾਈਜ਼ ਡੈਸਕਟਾਪ;ਹਾਟ ਕਾਰਨਰ;ਵਰਕਸਪੇਸ;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "ਓਹ ਹੋ, ਕੁਝ ਗਲਤ ਵਾਪਰਿਆ। ਆਪਣੇ ਸਾਫਟਵੇਅਰ ਵੇਂਡਰ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "ਨੈਟਵਰਕਮੈਨੇਜਰ ਚੱਲਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "ਹੋਰ ਡਿਵਾਈਸ"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:56
-#: panels/network/connection-editor/net-connection-editor.c:586
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
@@ -3344,64 +1941,20 @@ msgstr "VPN"
 msgid "Add connection"
 msgstr "ਕਨੈਕਸ਼ਨ ਜੋੜੋ"
 
-#: panels/network/cc-network-panel.ui:73
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "ਸੈੱਟ ਅੱਪ ਨਹੀਂ"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "ਅਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "ਕਨੈਕਟ ਹੈ"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "…ਚੋਣਾਂ"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"ਹਾਟਸਪਾਟ ਨੂੰ ਚਾਲੂ ਕਰਨ ਨਾਲ %s ਤੋਂ ਡਿਸ-ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇਗਾ ਅਤੇ Wi-Fi ਰਾਹੀਂ"
-" ਇੰਟਰਨੈੱਟ ਨਾਲ ਪਹੁੰਚ "
-"ਸੰਭਵ ਨਹੀਂ ਹੋਵੇਗੀ।"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "ਘੱਟੋ-ਘੱਟ 8 ਅੱਖਰ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3420,10 +1973,8 @@ msgid ""
 "Wi-Fi network that they can connect to. To do this, you must have an "
 "internet connection through a source other than Wi-Fi."
 msgstr ""
-"Wi-Fi ਹਾਟਸਪਾਟ ਹੋਰਾਂ ਨੂੰ ਤੁਹਾਡੇ ਇੰਟਰਨੈੱਟ ਕਨੈਕਸ਼ਨ ਨੂੰ ਸਾਂਝਾ ਕਰਨ ਦਿੰਦਾ ਹੈ, ਜੋ ਕਿ"
-" Wi-Fi ਨੈੱਟਵਰਕ ਬਣਾ "
-"ਕੇ ਹੁੰਦਾ ਹੈ, ਜਿਸ ਨਾਲ ਉਹ ਕਨੈਕਟ ਹੋ ਸਕਦੇ ਹਨ। ਇਹ ਕਰਨ ਲਈ ਤੁਹਾਨੂੰ Wi-Fi ਤੋਂ ਬਿਨਾਂ"
-" ਕਿਸੇ ਹੋਰ ਸਰੋਤ "
+"Wi-Fi ਹਾਟਸਪਾਟ ਹੋਰਾਂ ਨੂੰ ਤੁਹਾਡੇ ਇੰਟਰਨੈੱਟ ਕਨੈਕਸ਼ਨ ਨੂੰ ਸਾਂਝਾ ਕਰਨ ਦਿੰਦਾ ਹੈ, ਜੋ ਕਿ Wi-Fi ਨੈੱਟਵਰਕ ਬਣਾ "
+"ਕੇ ਹੁੰਦਾ ਹੈ, ਜਿਸ ਨਾਲ ਉਹ ਕਨੈਕਟ ਹੋ ਸਕਦੇ ਹਨ। ਇਹ ਕਰਨ ਲਈ ਤੁਹਾਨੂੰ Wi-Fi ਤੋਂ ਬਿਨਾਂ ਕਿਸੇ ਹੋਰ ਸਰੋਤ "
 "ਰਾਹੀਂ ਇੰਟਰਨੈੱਟ ਨਾਲ ਕਨੈਕਟ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:51
@@ -3433,7 +1984,7 @@ msgstr "ਨੈੱਟਵਰਕ ਨਾਂ"
 #. Translators: This is a password needed for printing.
 #: panels/network/cc-wifi-hotspot-dialog.ui:75
 #: panels/printers/new-printer-dialog.ui:338
-#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:391
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
 #: panels/user-accounts/cc-add-user-dialog.ui:364
@@ -3452,20 +2003,6 @@ msgstr "ਪਾਸਵਰਡ ਆਪਣੇ-ਆਪ ਤਿਆਰ ਕਰੋ"
 #: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "ਚਾਲੂ ਕਰੋ(_T)"
-
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "ਕੀ ਹਾਟਸਪਾਟ ਰੋਕਣਾ ਹੈ ਅਤੇ ਵਰਤੋਂਕਾਰ ਨੂੰ ਡਿਸ-ਕਨੈਕਟ ਕਰਨਾ ਹੈ?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "ਹਾਟਸਪਾਟ ਰੋਕੋ(_S)"
 
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
@@ -3511,91 +2048,13 @@ msgstr "ਦਿਸਦੇ ਨੈੱਟਵਰਕ"
 msgid "NetworkManager needs to be running"
 msgstr "ਨੈਟਵਰਕ-ਮੈਨੇਜਰ ਚੱਲਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "ਓਹ ਹੋ, ਕੁਝ ਗਲਤ ਵਾਪਰਿਆ। ਆਪਣੇ ਸਾਫਟਵੇਅਰ ਵੇਂਡਰ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x ਸੁਰੱਖਿਆ(_S)"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "ਸੁਰੱਖਿਆ"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "ਕਾਇਮ ਰੱਖੋ"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "ਪੱਕਾ"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "ਰਲਵਾਂ"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "ਸਥਿਰ"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"ਇੱਥੇ ਦਿੱਤਾ ਮੈਕ (MAC) ਐਡਰੈੱਸ ਨੈੱਟਵਰਕ ਡਿਵਾਈਸ ਲਈ ਹਾਰਡਵੇਅਰ ਐਡਰੈੱਸ ਵਜੋਂ ਵਰਤਿਆ"
-" ਜਾਵੇਗਾ, ਜਿਸ ਲਈ ਇਸ "
-"ਕਨੈਕਸ਼ਨ ਐਕਟੀਵੇਟ ਕੀਤਾ ਗਿਆ ਹੈ। ਇਹ ਫੀਚਰ ਨੂੰ ਮੈਕ ਕਲੋਨਿੰਗ ਜਾਂ ਸਪੂਫਿੰਗ (spoofing)"
-" ਕਹਿੰਦੇ ਹਨ। "
-"ਜਿਵੇਂ: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "ਪਰੋਫਾਈਲ %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "ਵਾਧਰਾ ਖੋਲ੍ਹੋ"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "ਇੰਟਰਪ੍ਰਾਈਜ਼"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "ਕੋਈ ਨਹੀਂ"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "ਕਦੇ ਨਹੀਂ"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3604,183 +2063,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i ਦਿਨ ਪਹਿਲਾਂ"
 msgstr[1] "%i ਦਿਨ ਪਹਿਲਾਂ"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/ਸਕਿੰਟ (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "ਕੋਈ ਨਹੀਂ"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "ਕਮਜ਼ੋਰ"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "ਠੀਕ ਹੈ"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "ਚੰਗਾ"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "ਬਹੁਤ ਵਧੀਆ"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 ਐਡਰੈੱਸ"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 ਐਡਰੈੱਸ"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP ਐਡਰੈੱਸ"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "ਕਨੈਕਸ਼ਨ ਨੂੰ ਭੁੱਲ ਜਾਓ"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "ਕਨੈਕਸ਼ਨ ਪ੍ਰੋਫਾਈਲ ਨੂੰ ਹਟਾਓ"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "VPN ਹਟਾਓ"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "ਵੇਰਵੇ"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "ਆਪਣੇ-ਆਪ"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "ਪਛਾਣ"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "ਐਡਰੈਸ ਹਟਾਓ"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "ਰੂਟ ਹਟਾਓ"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "ਕੋਈ ਨਹੀਂ"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-ਬਿੱਟ ਕੁੰਜੀ (Hex ਜਾਂ ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-ਬਿੱਟ ਵਾਕ"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "ਡਾਇਨੈਮਿਕ WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA ਤੇ WPA2 ਨਿੱਜੀ"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA ਤੇ WPA2 ਇੰਟਰਪ੍ਰਾਈਜ"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 ਪਰਸਨਲ"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3791,8 +2073,20 @@ msgstr "ਸਿਗਨਲ ਮਜ਼ਬੂਤੀ"
 msgid "Link speed"
 msgstr "ਲਿੰਕ ਸਪੀਡ"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "ਸੁਰੱਖਿਆ"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 ਐਡਰੈੱਸ"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 ਐਡਰੈੱਸ"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "ਹਾਰਡਵੇਅਰ ਐਡਰੈੱਸ"
 
@@ -3801,12 +2095,17 @@ msgid "Supported Frequencies"
 msgstr "ਸਹਾਇਕ ਫਰੀਕਿਊਂਸੀ"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "ਡਿਫਾਲਟ ਰੂਟ"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3867,7 +2166,7 @@ msgstr "ਕੇਵਲ ਲਿੰਕ-ਲੋਕਲ"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "ਦਸਤੀ"
 
@@ -3911,9 +2210,8 @@ msgstr "ਗੇਟਵੇ"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "ਆਟੋਮੈਟਿਕ"
 
@@ -3966,89 +2264,9 @@ msgstr "ਆਟੋਮੈਟਿਕ, ਕੇਵਲ DHCP"
 msgid "Prefix"
 msgstr "ਪ੍ਰੀ-ਫਿਕਸ"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "ਕਨੈਕਸ਼ਨ ਐਡੀਟਰ ਖੋਲ੍ਹਣ ਲਈ ਅਸਮਰੱਥ"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "ਨਵਾਂ ਪਰੋਫਾਇਲ"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-#| msgid "Privacy settings"
-msgid "Invalid setting %s"
-msgstr ""
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "…ਫਾਇਲ ਤੋਂ ਇੰਪੋਰਟ ਕਰੋ"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "VPN ਨੂੰ ਜੋੜੋ"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "ਸੁਰੱਖਿਆ(_e)"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "VPN ਕੁਨੈਕਸ਼ਨ ਇੰਪੋਰਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"ਫਾਇਲ ”%s” ਪੜ੍ਹੀ ਨਹੀਂ ਜਾ ਸਕੀ ਜਾਂ ਪਛਾਣਯੋਗ VPN ਕੁਨੈਕਸ਼ਨ ਜਾਣਕਾਰੀ ਨਹੀਂ ਰੱਖਦੀ ਹੈ।\n"
-"\n"
-"ਗਲਤੀ: %s।"
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "ਇੰਪੋਰਟ ਕਰਨ ਲਈ ਫਾਇਲ ਚੁਣੋ"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "”%s” ਫਾਇਲ ਨਾਂ ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹੈ।"
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "ਬਦਲੋ(_R)"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "ਕੀ ਤੁਸੀਂ %s ਨੂੰ VPN, ਜੋ ਤੁਸੀਂ ਸੰਭਾਲ ਰਹੇ ਹੋ, ਨਾਲ ਬਦਲਣਾ ਚਾਹੁੰਦੇ ਹੋ?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "VPN ਕੁਨੈਕਸ਼ਨ ਐਕਸਪੋਰਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN ਕੁਨੈਕਸ਼ਨ ”%s” %s ਲਈ ਐਕਸਪੋਰਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।\n"
-"\n"
-"ਗਲਤੀ: %s"
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "VPN ਕਨੈਕਸ਼ਨ ਐਕਸਪੋਰਟ ਕਰੋ"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4062,100 +2280,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "ਨੈੱਟਵਰਕ"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿ ਇੰਟਰਨੈੱਟ ਨਾਲ ਤੁਸੀਂ ਕਿਵੇਂ ਕਨੈਕਟ ਹੋ"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
-msgstr ""
-"ਨੈੱਟਵਰਕ;ਆਈਪੀ;ਬਰਾਡਬੈਂਡ;ਮਾਡਮ;ਬਲੂਟੁੱਥ;ਬਲੂਟੁੱਥ;ਵੀਪੀਐਨ;ਪਰਾਕਸੀ;ਵੈਨ;ਮੌਡਮ;ਡੀਐਨਐਸ;"
+msgstr "ਨੈੱਟਵਰਕ;ਆਈਪੀ;ਬਰਾਡਬੈਂਡ;ਮਾਡਮ;ਬਲੂਟੁੱਥ;ਬਲੂਟੁੱਥ;ਵੀਪੀਐਨ;ਪਰਾਕਸੀ;ਵੈਨ;ਮੌਡਮ;ਡੀਐਨਐਸ;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿ Wi-Fi ਨੈੱਟਵਰਕ ਨਾਲ ਤੁਸੀਂ ਕਿਵੇਂ ਕਨੈਕਟ ਕਰਨਾ ਹੈ"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "ਨੈੱਟਵਰਕ;ਬੇਤਾਰ;ਵਾਈ-ਫਾਈ;ਆਈਪੀ;ਬਰਾਡਬੈਂਡ;ਡੀਐਨਐਸ;ਹਾਟਸਪਾਟ;ਹੌਟਸਪੌਟ;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "ਕਦੇ ਨਹੀਂ"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "ਅੱਜ"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "ਕੱਲ੍ਹ"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "ਆਖਰੀ ਵਰਤੋਂ"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "ਤਾਰ ਵਾਲਾ"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "ਨਵਾਂ ਕੁਨੈਕਸ਼ਨ ਸ਼ਾਮਲ ਕਰੋ"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"ਚੁਣੇ ਗਏ ਨੈੱਟਵਰਕਾਂ ਲਈ ਨੈੱਟਵਰਕ ਵੇਰਵਾ, ਜਿਸ ਵਿੱਚ ਪਾਸਵਰਡ ਅਤੇ ਹੋਰ ਪਸੰਦੀਦਾ ਸੰਰਚਨਾ"
-" ਦਿੱਤੀ ਸੀ, ਖਤਮ ਹੋ "
-"ਜਾਵੇਗਾ।"
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "ਭੁੱਲ ਜਾਓ(_F)"
-
-#: panels/network/net-device-wifi.c:1047
-msgid "Known Wi-Fi Networks"
-msgstr "ਜਾਣੇ-ਪਛਾਣ Wi-Fi ਨੈੱਟਵਰਕ"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1079
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "ਭੁੱਲ ਜਾਓ(_F)"
-
-#: panels/network/net-device-wifi.c:1235
-msgid "System policy prohibits use as a Hotspot"
-msgstr "ਸਿਸਟਮ ਪਾਲਸੀ ਹਾਟ-ਸਪਾਟ ਵਜੋਂ ਵਰਤਣ ਤੋਂ ਰੋਕਦੀ ਹੈ"
-
-#: panels/network/net-device-wifi.c:1238
-msgid "Wireless device does not support Hotspot mode"
-msgstr "ਬੇਤਾਰ ਜੰਤਰ ਹਾਟਸਪਾਟ ਮੋਡ ਲਈ ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"ਵੈੱਬ ਪਰਾਕਸੀ ਆਪੇ-ਆਪ ਖੋਜ ਵਰਤੀ ਜਾਂਦੀ ਹੈ, ਜਦੋਂ ਸੰਰਚਨਾ URL ਨਾ ਦਿੱਤਾ ਗਿਆ ਹੋਵੇ।"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "ਇਹ ਪਬਲਿਕ ਨੈੱਟਵਰਕ ਬੇ-ਭਰੋਸੇਯੋਗ ਨੈੱਟਵਰਕ ਲਈ ਸਿਫਾਰਸ਼ ਨਹੀਂ ਕੀਤਾ ਜਾਂਦਾ।"
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4174,6 +2328,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "ਪਰੋਵਾਇਡਰ"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP ਐਡਰੈੱਸ"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4258,289 +2416,6 @@ msgstr "ਵਾਈ-ਫਾਈ ਹਾਟਸਪਾਟ ਚਾਲੂ ਕਰੋ(_T)…"
 msgid "_Known Wi-Fi Networks"
 msgstr "ਜਾਣੇ-ਪਛਾਣੇ ਵਾਈ-ਫਾਈ ਨੈੱਟਵਰਕ(_K)"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "ਹਾਲਤ ਅਣਜਾਣ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "ਬਿਨ-ਇੰਤਜ਼ਾਮ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "ਨਾ-ਉਪਲੱਬਧ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "ਡਿਸ-ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "ਕੁਨੈਕਸ਼ਨ ਫੇਲ੍ਹ ਹੈ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "ਹਾਲਤ ਅਣਜਾਣ (ਗੁੰਮ)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "ਸੰਰਚਨਾ ਫੇਲ੍ਹ ਹੋਈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP ਸੰਰਚਨਾ ਫੇਲ੍ਹ ਹੋਈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP ਸੰਰਚਨਾ ਦੀ ਮਿਆਦ ਪੁੱਗੀ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "ਭੇਦ ਦੀ ਲੋੜ ਸੀ, ਪਰ ਦਿੱਤਾ ਨਹੀਂ ਗਿਆ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x ਸਪਲੀਮੈਂਟ ਡਿਸ-ਕਨੈਕਟ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x ਸਪਲੀਮੈਂਟ ਸੰਰਚਨਾ ਫੇਲ੍ਹ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x ਸਪਲੀਮੈਂਟ ਫੇਲ੍ਹ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x ਸਪਲੀਮੈਂਟ ਨੇ ਪਰਮਾਣਿਤ ਹੋਣ ਲਈ ਬਹੁਤ ਲੰਮਾ ਸਮਾਂ ਲੈ ਲਿਆ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP ਸਰਵਿਸ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP ਸਰਵਿਸ ਡਿਸ-ਕਨੈਕਟ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP ਫੇਲ੍ਹ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP ਕਲਾਇਟ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP ਕਲਾਇਟ ਗਲਤੀ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP ਕਲਾਇਟ ਫੇਲ੍ਹ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "ਸਾਂਝੀ ਕੀਤੀ ਕਨੈਕਸ਼ਨ ਸਰਵਿਸ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "ਸਾਂਝਾ ਕੀਤੀ ਕਨੈਕਸ਼ਨ ਸਰਵਿਸ ਫੇਲ੍ਹ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "ਆਟੋ-IP ਸਰਵਿਸ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "ਆਟੋ-IP ਸਰਵਿਸ ਗਲਤੀ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "ਆਟੋ-IP ਸਰਵਿਸ ਫੇਲ੍ਹ ਹੋਈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "ਲਾਈਨ ਰੁਝੀ ਹੋਈ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "ਕੋਈ ਡਾਇਲ ਟੋਨ ਨਹੀਂ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "ਕੋਈ ਕੈਰੀਅਰ ਤਿਆਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "ਡਾਇਲ ਕਰਨ ਲਈ ਸਮਾਂ-ਸਮਾਪਤ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "ਡਾਇਲ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਫੇਲ੍ਹ ਹੋਈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "ਮਾਡਮ ਸ਼ੁਰੂਆਤ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "ਦਿੱਤੇ APN ਨੂੰ ਚੁਣਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "ਨੈੱਟਵਰਕ ਲਈ ਖੋਜ ਨਹੀਂ ਕੀਤੀ ਜਾ ਰਹੀ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "ਨੈੱਟਵਰਕ ਰਜਿਸਟਰੇਸ਼ਨ ਉੱਤੇ ਪਾਬੰਦੀ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "ਨੈੱਟਵਰਕ ਰਜਿਸਟਰ ਲਈ ਸਮਾਂ-ਸਮਾਪਤ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "ਮੰਗੇ ਗਏ ਨੈੱਟਵਰਕ ਉੱਤੇ ਰਜਿਸਟਰ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN ਚੈਕ ਫੇਲ੍ਹ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "ਜੰਤਰ ਲਈ ਫਿਰਮਵੇਅਰ ਸ਼ਾਇਦ ਮੌਜੂਦ ਨਹੀਂ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "ਕਨੈਕਸ਼ਨ ਅਲੋਪ ਹੋਇਆ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "ਮੌਜੂਦਾ ਕਨੈਕਸ਼ਨ ਮੁੜ-ਪ੍ਰਾਪਤ ਕੀਤਾ ਗਿਆ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "ਮਾਡਮ ਨਹੀਂ ਲੱਭਿਆ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "ਬਲਿਉਟੁੱਥ ਕੁਨੈਕਸ਼ਨ ਫੇਲ੍ਹ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM ਕਾਰਡ ਨਹੀਂ ਪਾਇਆ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM ਪਿੰਨ ਚਾਹੀਦਾ ਹੈ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM Puk ਦੀ ਲੋੜ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM ਗਲਤ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "ਕਨੈਕਸ਼ਨ ਨਿਰਭਰਤਾ ਫੇਲ੍ਹ ਹੋਈ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "ਫਿਰਮਵੇਅਰ ਮੌਜੂਦ ਨਹੀਂ ਹੈ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "ਕੇਬਲ ਕੱਢੀ ਹੋਈ ਹੈ"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "802.1X ਸੁਰੱਖਿਆ (wpa-eap) ਵਿੱਚ ਨਾ-ਪਰਿਭਾਸ਼ਿਤ ਗ਼ਲਤੀ"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਚੁਣੀ"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "eap-method ਫ਼ਾਇਲ ਨੂੰ ਪ੍ਰਮਾਣ ਕਰਨ ਦੌਰਾਨ ਨਾ-ਪਰਿਭਾਸ਼ਿਤ ਗ਼ਲਤੀ"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, ਜਾਂ PKCS#12 ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀਆਂ (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER ਜਾਂ PEM ਸਰਟੀਫਿਕੇਟ (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "ਗੁੰਮ EAP-FAST PAC ਫ਼ਾਇਲ"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC ਫਾਇਲਾਂ (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4555,7 +2430,7 @@ msgstr "MSCHAPv2"
 
 #: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
-msgstr "ਅਗਿਆਤ"
+msgstr "ਅਣਜਾਣ"
 
 #: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
@@ -4589,14 +2464,6 @@ msgstr "ਅੰਦਰੂਨੀ ਪਰਮਾਣਕਿਤਾ(_I)"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "ਆਟੋਮੈਟਿਕ PAC ਪਰੋਵਿਜ਼ਨਿੰਗ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ(_v)"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "ਗੁੰਮ EAP-LEAP ਵਰਤੋਂਕਾਰ-ਨਾਂ"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "ਗੁੰਮ EAP-LEAP ਪਾਸਵਰਡ"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4622,15 +2489,6 @@ msgstr "ਪਾਸਵਰਡ(_P)"
 msgid "Sho_w password"
 msgstr "ਪਾਸਵਰਡ ਵੇਖੋ(_w)"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "ਅਵੈਧ EAP-PEAP CA ਸਰਟੀਫਿਕੇਟ: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "ਅਵੈਧ EAP-PEAP CA ਸਰਟੀਫਿਕੇਟ: ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4652,7 +2510,6 @@ msgid "C_A certificate"
 msgstr "C_A ਸਰਟੀਫਿਕੇਟ"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4667,63 +2524,6 @@ msgstr "ਕੋਈ CA ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚਾਹੀਦਾ
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP ਵਰਜਨ(_v)"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "ਗੁੰਮ EAP ਵਰਤੋਂਕਾਰ-ਨਾਂ"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "ਗਲਤ EAP ਪਾਸਵਰਡ"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "ਗੁੰਮ EAP-TLS ਪਛਾਣ"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "ਅਵੈਧ EAP-TLS CA ਸਰਟੀਫਿਕੇਟ: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "ਅਵੈਧ EAP-TLS CA ਸਰਟੀਫਿਕੇਟ: ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "ਅਵੈਧ EAP-TLS ਪ੍ਰਾਈਵੇਟ-ਕੁੰਜੀ: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "ਅਵੈਧ EAP-TLS ਵਰਤੋਂਕਾਰ-ਸਰਟੀਫਿਕੇਟ: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "ਬਿਨ-ਇੰਕ੍ਰਿਪਸ਼ਨ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀਆਂ ਅਸੁਰੱਖਿਅਤ ਹਨ"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"ਚੁਣੀ ਗਈ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਪਾਸਵਰਡ ਨਾਲ ਸੁਰੱਖਿਅਤ ਨਹੀਂ ਜਾਪਦੀ ਹੈ। ਇਹ ਤੁਹਾਡੀ ਸੁਰੱਖਿਅਤ"
-" ਸਨਦ ਨੂੰ ਖਤਰਾ "
-"ਪੈਦਾ ਕਰ ਸਕਦੀ ਹੈ। ਪਾਸਵਰਡ ਨਾਲ ਸੁਰੱਖਿਅਤ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਚੁਣੋ ਜੀ।\n"
-"\n"
-"(ਤੁਸੀਂ openssl ਨਾਲ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਪਾਸਵਰਡ ਸੁਰੱਖਿਅਤ ਕਰ ਸਕਦੇ ਹੋ)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "ਆਪਣਾ ਨਿੱਜੀ ਸਰਟੀਫਿਕੇਟ ਚੁਣੋ"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "ਆਪਣੀ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਚੁਣੋ"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4740,15 +2540,6 @@ msgstr "ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ(_k)"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਪਾਸਵਰਡ(_P)"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "ਅਵੈਧ EAP-TLLS CA ਸਰਟੀਫਿਕੇਟ: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "ਅਵੈਧ EAP-TTLS CA ਸਰਟੀਫਿਕੇਟ: ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4771,14 +2562,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "ਡੋਮੇਨ(_D)"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "802.1X ਸੁਰੱਖਿਆ ਦੀ ਪ੍ਰਮਾਣਕਿਤ ਦੌਰਾਨ ਅਣਜਾਣ ਗਲਤੀ"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4806,59 +2598,10 @@ msgstr "ਸੁਰੱਖਿਅਤ EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "ਪਰਮਾਣਿਕਤਾ(_t)"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "ਫਾਇਲ ਚੁਣੋ"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "leap-ਵਰਤੋਂਕਾਰ ਗੁੰਮ"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "ਗੁੰਮ ਲੀਪ-ਪਾਸਵਰਡ"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "ਵਾਈ-ਫਾਈ ਪਾਸਵਰਡ ਗੁੰਮ ਹੈ।"
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "ਕਿਸਮ(_T)"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "wep-key ਗੁੰਮ"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "ਅਵੈਧ wep-key: %zu ਲੰਬਾਈ ਦੀ ਕੁੰਜੀ ਵਿੱਚ ਕੇਵਲ ਹੈਕਸਾ-ਅੰਕ ਹੀ ਹੋ ਸਕਦੇ ਹਨ"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "ਅਵੈਧ wep-key: %zu ਲੰਬਾਈ ਦੀ ਕੁੰਜੀ ਵਿੱਚ ਕੇਵਲ ASCII ਅੱਖਰ ਹੀ ਹੋ ਸਕਦੇ ਹਨ"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"ਅਵੈਧ wep-key: ਗ਼ਲਤ %zu ਕੁੰਜੀ ਲੰਬਾਈ। ਕੁੰਜੀ ਦੀ ਲੰਬਾਈ ਜਾਂ ਤਾਂ 5/13 (ascii) ਜਾਂ"
-" 10/26 "
-"(ਹੈਕਸਾ) ਹੋ ਸਕਦੇ ਹਨ"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "ਗ਼ਲਤ wep-key: ਵਾਕ ਖਾਲੀ ਨਹੀਂ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "ਗ਼ਲਤ wep-key: ਵਾਕ 64-ਅੱਖਰਾਂ ਤੋਂ ਛੋਟਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4884,20 +2627,6 @@ msgstr "ਕੁੰਜੀ ਵੇਖੋ(_w)"
 msgid "WEP inde_x"
 msgstr "WEP ਇੰਡੈਕਸ(_x)"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"ਅਵੈਧ wpa-psk: ਕੁੰਜੀ-ਲੰਬਾਈ %zu ਅਵੈਧ ਹੈ। ਜਾਂ ਤਾਂ [8,63] ਬਾਈਟ ਜਾਂ 64 ਹੈਕਸਾ-ਅੰਕ"
-" ਹੋਣੀ ਚਾਹੀਦੀ "
-"ਹੈ।"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "ਅਵੈਧ wpa-psk: 64 ਬਾਈਟਾਂ ਨੂੰ ਹੈਕਸਾ ਨਾਲ ਅਰਥ ਕੱਢੇ ਨਹੀਂ ਜਾ ਸਕਦੇ"
-
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
@@ -4920,8 +2649,7 @@ msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
 msgstr ""
-"ਜਦੋਂ ਪੋਪਅੱਪ ਅਸਮਰੱਥ ਕੀਤੇ ਜਾਂਦੇ ਹਨ ਤਾਂ ਨੋਟੀਫਿਕੇਸ਼ਨ ਸੂਚੀ ਵਿੱਚ ਨੋਟੀਫਿਕੇਸ਼ਨ ਦਿਖਾਈ"
-" ਦੇਣਾ ਜਾਰੀ ਰੱਖਣਗੇ।"
+"ਜਦੋਂ ਪੋਪਅੱਪ ਅਸਮਰੱਥ ਕੀਤੇ ਜਾਂਦੇ ਹਨ ਤਾਂ ਨੋਟੀਫਿਕੇਸ਼ਨ ਸੂਚੀ ਵਿੱਚ ਨੋਟੀਫਿਕੇਸ਼ਨ ਦਿਖਾਈ ਦੇਣਾ ਜਾਰੀ ਰੱਖਣਗੇ।"
 
 #. Popups here refers to message tray notifications in the middle of the screen.
 #: panels/notifications/cc-app-notifications-dialog.ui:56
@@ -4951,27 +2679,9 @@ msgstr "ਲਾਕ ਸਕਰੀਨ ਸੂਚਨਾਵਾਂ(_L)"
 msgid "Control which notifications are displayed and what they show"
 msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿ ਕਿਹੜੀਆਂ ਸੂਚਨਾਵਾਂ ਵੇਖਾਉਣੀਆਂ ਅਤੇ ਉਹ ਕੀ ਕੁਝ ਵੇਖਾਉਣ"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "ਸੂਚਨਾ;ਬੈਨਰ;ਸੁਨੇਹਾ;ਟਰੇ;ਪੋਪਅੱਪ;Notifications;Banner;Message;Tray;Popup;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "ਹੋਰ"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s ਨੂੰ ਹਟਾਇਆ"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:691
-msgid "Error removing account"
-msgstr "ਅਕਾਊਂਟ ਹਟਾਉਣਾ ਦੌਰਾਨ ਗਲਤੀ"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4995,43 +2705,22 @@ msgstr "ਕੋਈ ਇੰਟਰਨੈੱਟ ਕਨੈਕਸ਼ਨ ਨਹੀਂ — �
 msgid "Add an account"
 msgstr "ਖਾਤਾ ਜੋੜੋ"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s ਖਾਤਾ"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "ਅਕਾਊਂਟ ਹਟਾਓ"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "ਆਨਲਾਈਨ ਖਾਤੇ"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
-msgstr ""
-"ਆਪਣੇ ਆਨਲਾਈਨ ਖਾਤਿਆਂ ਨਾਲ ਕਨੈਕਟ ਹੋਵੋ ਅਤੇ ਫੈਸਲਾ ਕਰੋ ਕਿ ਉਹਨਾਂ ਨੂੰ ਕਿਸ ਲਈ ਵਰਤਣਾ ਹੈ"
+msgstr "ਆਪਣੇ ਆਨਲਾਈਨ ਖਾਤਿਆਂ ਨਾਲ ਕਨੈਕਟ ਹੋਵੋ ਅਤੇ ਫੈਸਲਾ ਕਰੋ ਕਿ ਉਹਨਾਂ ਨੂੰ ਕਿਸ ਲਈ ਵਰਤਣਾ ਹੈ"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-"ਗੂਗਲ;ਫੇਸਬੁੱਕ;ਟਵਿੱਟਰ;ਯਾਹੂ;ਵੈੱਬ;ਆਨਲਾਈਨ;ਗੱਲਬਾਤ;ਚੈਟ;ਕੈਲੰਡਰ;ਮੇਲ;ਸੰਪਰਕ;Google;Facebo"
-"ok;Twitter;"
+"ਗੂਗਲ;ਫੇਸਬੁੱਕ;ਟਵਿੱਟਰ;ਯਾਹੂ;ਵੈੱਬ;ਆਨਲਾਈਨ;ਗੱਲਬਾਤ;ਚੈਟ;ਕੈਲੰਡਰ;ਮੇਲ;ਸੰਪਰਕ;Google;Facebook;Twitter;"
 "Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;"
 "Packet;ReaditLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "ਅਣਜਾਣ ਸਮਾਂ"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5047,13 +2736,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i ਘੰਟਾ"
 msgstr[1] "%i ਘੰਟੇ"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5065,190 +2747,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "ਮਿੰਟ"
 msgstr[1] "ਮਿੰਟ"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "ਪੂਰਾ ਚਾਰਜ ਹੋਣ ਲਈ %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "ਸਾਵਧਾਨ: %s ਬਾਕੀ"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s ਬਾਕੀ"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "ਪੂਰੀ ਚਾਰਜ"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "ਚਾਰਜ ਨਹੀਂ ਹੋ ਰਹੀ"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "ਖਾਲੀ"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "ਚਾਰਜ ਹੋ ਰਹੀ ਹੈ"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "ਡਿਸਚਾਰਜ ਹੋ ਰਹੀ ਹੈ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "ਬੇਤਾਰ ਮਾਊਸ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "ਬੇਤਾਰ ਕੀ-ਬੋਰਡ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "ਗ਼ੈਰ-ਰੁਕਾਵਟ-ਯੋਗ ਪਾਵਰ ਸਪਲਾਈ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "ਨਿੱਜੀ ਡਿਜ਼ਿਟਲ ਸਹਾਇਕ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "ਸੈਲਫੋਨ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "ਮੀਡਿਆ ਪਲੇਅਰ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "ਟੇਬਲੇਟ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "ਕੰਪਿਊਟਰ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "ਖੇਡਾਂ ਲਈ ਇੰਪੁੱਟ ਡਿਵਾਈਸ"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "ਬੈਟਰੀ"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "ਮੁੱਖ"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "ਵਾਧੂ"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "ਬੈਟਰੀਆਂ"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "ਜਦੋਂ ਵੇਹਲਾ ਹੈ(_i)"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "ਸਸਪੈਂਡ"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "ਬੰਦ ਕਰੋ"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "ਹਾਈਬਰਨੇਟ"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "ਕੁਝ ਨਹੀਂ"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "ਜਦੋਂ ਬੈਟਰੀ ਪਾਵਰ ਉੱਤੇ ਹੋਵੇ"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "ਜਦੋਂ ਪਲੱਗ ਲੱਗਾ ਹੋਵੇ"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "ਕਦੇ ਨਹੀਂ"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "ਆਟੋਮੈਟਿਕ ਸਸਪੈਂਡ ਕਰੋ"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"ਵੱਧ ਕਾਰਜਕਾਰੀ ਤਾਪਮਾਨ ਹੋਣ ਕਰਕੇ ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਨੂੰ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਕੀਤਾ ਹੈ।"
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"ਲੈਪ ਖੋਜਿਆ: ਕਾਰਜਗੁਜ਼ਾਰੀ ਢੰਗ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਹੈ। ਬਹਾਲ ਕਰਨ ਲਈ ਡਿਵਾਈਸ ਨੂੰ"
-" ਸਥਿਰ ਤਲ ਉੱਤੇ ਰੱਖੋ।"
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਹੈ।"
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"ਘੱਟ ਬੈਟਰੀ: ਪਾਵਰ ਬੱਚਤ ਸਮਰੱਥ ਹੈ। ਜਦੋਂ ਬੈਟਰੀ ਠੀਕ-ਠਾਕ ਚਾਰਜ ਹੋ ਗਈ ਤਾਂ ਪਿਛਲੇ ਮੋਡ"
-" ਨੂੰ ਬਹਾਲ ਕੀਤਾ "
-"ਜਾਵੇਗਾ।"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "“%s” ਨੇ ਪਾਵਰਪ ਬੱਚਤ ਢੰਗ ਸਰਗਰਮ ਕੀਤਾ ਹੈ।"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "“%s” ਨੇ ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਸਰਗਰਮ ਕੀਤਾ ਹੈ।"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5309,6 +2807,15 @@ msgstr "੧੦੦ ਮਿੰਟ"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "੨ ਘੰਟੇ"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "ਬੈਟਰੀ"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ਡਿਵਾਈਸ"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5387,33 +2894,6 @@ msgstr "ਬੈਟਰੀ ਪਾਵਰ ਉੱਤੇ(_B)"
 msgid "Delay"
 msgstr "ਦੇਰੀ"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "ਕਾਰਗੁਜ਼ਾਰੀ"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "ਵੱਧ ਕਾਰਗੁਜ਼ਾਰੀ ਅਤੇ ਊਰਜਾ ਖ਼ਪਤ ਹੈ।"
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "ਸੰਤੁਲਿਤ"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "ਮਿਆਰੀ ਕਾਰਗੁਜ਼ਾਰੀ ਤੇ ਊਰਜਾ ਖਪਤ ਹੈ।"
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "ਪਾਵਰ ਬੱਚਤ"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "ਘੱਟ ਕੀਤੀ ਕਾਰਗੁਜ਼ਾਰੀ ਅਤੇ ਊਰਜਾ ਖਪਤ ਹੈ।"
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "ਪਾਵਰ"
@@ -5422,36 +2902,13 @@ msgstr "ਪਾਵਰ"
 msgid "View your battery status and change power saving settings"
 msgstr "ਆਪਣੀ ਬੈਟਰੀ ਦੀ ਸਥਿਤੀ ਵੇਖੋ ਅਤੇ ਊਰਜਾ ਬੱਚਤ ਸੈਟਿੰਗਾਂ ਬਦਲੋ"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
 msgstr ""
-"ਸਕਰੀਨ;ਚਮਕ;ਵੇਹਲਾ;ਪਾਵਰ;ਸਲੀਪ;ਸਸਪੈਂਡ;ਹਾਈਬਰਨੇਟ;ਬੈਟਰੀ;ਵੇਹਲ;ਡਿਮ;ਖਾਲੀ;ਮਾਨੀਟਰ;ਡੀਪੀਐਮਐਸ;"
-"ਮੁਅੱਤਲ;"
+"ਸਕਰੀਨ;ਚਮਕ;ਵੇਹਲਾ;ਪਾਵਰ;ਸਲੀਪ;ਸਸਪੈਂਡ;ਹਾਈਬਰਨੇਟ;ਬੈਟਰੀ;ਵੇਹਲ;ਡਿਮ;ਖਾਲੀ;ਮਾਨੀਟਰ;ਡੀਪੀਐਮਐਸ;ਮੁਅੱਤਲ;"
 "ਊਰਜਾ;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "ਪਰਿੰਟਰ “%s” ਨੂੰ ਹਟਾਇਆ ਜਾ ਚੁੱਕਾ ਹੈ"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "ਨਵਾਂ ਪਰਿੰਟਰ ਜੋੜਨ ਲਈ ਫੇਲ੍ਹ।"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui ਲੋਡ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "ਪਰਿੰਟਰ ਜੋੜਨ ਅਤੇ ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5459,10 +2916,8 @@ msgstr "ਪਰਿੰਟਰ"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
-msgstr ""
-"ਪਰਿੰਟਰ ਜੋੜੋ, ਪਰਿੰਟਰ ਜਾਬ ਵੇਖੋ ਅਤੇ ਤਹਿ ਕਰੋ ਤੁਸੀਂ ਕਿਵੇਂ ਪਰਿੰਟ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੈ"
+msgstr "ਪਰਿੰਟਰ ਜੋੜੋ, ਪਰਿੰਟਰ ਜਾਬ ਵੇਖੋ ਅਤੇ ਤਹਿ ਕਰੋ ਤੁਸੀਂ ਕਿਵੇਂ ਪਰਿੰਟ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੈ"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
@@ -5470,8 +2925,6 @@ msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "ਪਰਿੰਟਰ ਜੋੜੋ"
 
@@ -5499,8 +2952,7 @@ msgstr "ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
 
 #: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
-msgstr ""
-"ਪਰਿੰਟਰ ਸਰਵਰ ਉੱਤੇ ਪਰਿੰਟਰਾਂ ਨੂੰ ਵੇਖਣ ਲਈ ਆਪਣਾ ਵਰਤੋਂਕਾਰ-ਨਾਂ ਅਤੇ ਪਾਸਵਰਡ ਦਿਉ।"
+msgstr "ਪਰਿੰਟਰ ਸਰਵਰ ਉੱਤੇ ਪਰਿੰਟਰਾਂ ਨੂੰ ਵੇਖਣ ਲਈ ਆਪਣਾ ਵਰਤੋਂਕਾਰ-ਨਾਂ ਅਤੇ ਪਾਸਵਰਡ ਦਿਉ।"
 
 #. Translators: This is a username on a print server.
 #: panels/printers/new-printer-dialog.ui:317
@@ -5511,28 +2963,6 @@ msgstr ""
 msgid "Username"
 msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s ਵੇਰਵੇ"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "ਕੋਈ ਢੁੱਕਵਾਂ ਡਰਾਇਵਰ ਨਹੀਂ ਲੱਭਿਆ"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "PPD ਫਾਇਲ ਚੁਣੋ"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"ਪੋਸਟ-ਸਕ੍ਰਿਪਟ ਪਰਿੰਟਰ ਵੇਰਵਾ ਫਾਇਲਾਂ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "ਪਰਿੰਟਰ ਨਾਂ ਵਿੱਚ SPACE, TAB, #, ਜਾਂ / ਨਹੀਂ ਹੋ ਸਕਦੇ ਹਨ"
@@ -5541,9 +2971,7 @@ msgstr "ਪਰਿੰਟਰ ਨਾਂ ਵਿੱਚ SPACE, TAB, #, ਜਾਂ / ਨ
 msgid "Location"
 msgstr "ਟਿਕਾਣਾ"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "ਡਰਾਇਵਰ"
 
@@ -5571,143 +2999,20 @@ msgstr "ਪਰਿੰਟਰ ਡਰਾਇਵਰ ਚੁਣੋ"
 msgid "Loading drivers database…"
 msgstr "…ਡਰਾਇਵਰ ਡਾਟਾਬੇਸ ਲੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "ਰੱਦ ਕਰੋ"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "ਚੁਣੋ"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect ਪਰਿੰਟਰ"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD ਪਰਿੰਟਰ"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "ਇੱਕ ਪਾਸੇ"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "ਲੰਮਾ ਕੋਨਾ (ਸਟੈਂਡਰਡ)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "ਛੋਟਾ ਕੋਨਾ (ਪਲਟੋ)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "ਪੋਰਟਰੇਟ"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "ਲੈਂਡਸਕੇਪ"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "ਉਲਟ ਲੈਂਡਸਕੇਪ"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "ਉਲਟ ਪੋਰਟਰੇਟ"
-
-#: panels/printers/pp-job-row.c:55
-#| msgid "_Resume"
-msgid "Resume"
-msgstr "ਬਹਾਲ ਕਰੋ"
-
-#: panels/printers/pp-job-row.c:55
-#| msgctxt "print job"
-#| msgid "Paused"
-msgid "Pause"
-msgstr "ਵਿਰਾਮ"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "ਬਾਕੀ ਹਨ"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "ਵਿਰਾਮ ਹੈ"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "ਪਰੋਸੈਸ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "ਰੁਕਿਆ ਹੈ"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "ਰੱਦ ਕੀਤੇ"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "ਅਧੂਰੇ ਛੱਡੇ"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "ਪੂਰੇ ਹੋਏ"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "ਇਸ ਜਾਬ ਨੂੰ ਕਤਾਰ ਦੇ ਸਿਖਰ ਉੱਤੇ ਭੇਜੋ"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u ਜਾਬ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
 msgstr[1] "%u ਜਾਬਾਂ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — ਸਰਗਰਮ ਜਾਬਾਂ"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "%s ਉੱਤੇ ਪਰਿੰਟ ਕਰਨ ਲਈ ਸਨਦ ਦਿਓ।"
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5735,321 +3040,17 @@ msgstr "ਪਰਮਾਣਕਿਤਾ(_A)"
 msgid "No Active Printer Jobs"
 msgstr "ਕੋਈ ਸਰਗਰਮ ਪਰਿੰਟਰ ਜਾਬ ਨਹੀਂ ਹੈ"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "ਪਰਿੰਟਰ ਸਰਵਰ ਨੂੰ ਅਣ-ਲਾਕ ਕਰੋ"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s ਨੂੰ ਅਣ-ਲਾਕ ਕਰੋ"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "%s ਉੱਤੇ ਪਰਿੰਟਰ ਵੇਖਣ ਲਈ ਵਰਤੋਂਕਾਰ-ਨਾਂ ਅਤੇ ਪਾਸਵਰਡ ਦਿਉ।"
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "ਪਰਿੰਟਰਾਂ ਲਈ ਖੋਜ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "ਸੀਰੀਅਲ ਪੋਰਟ"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "ਪੈਰਲੈੱਲ ਪੋਰਟ"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "ਟਿਕਾਣਾ: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "ਸਿਰਨਾਵਾਂ: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "ਸਰਵਰ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "ਦੋ ਪਾਸੀਂ"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "ਪੇਪਰ ਕਿਸਮ"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "ਪੇਪਰ ਸਰੋਤ"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "ਆਉਟਪੁੱਟ ਟਰੇ"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "ਰੈਜ਼ੋਲੂਸ਼ਨ"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "ਗੋਸਟ-ਸਕ੍ਰਿਪਟ ਪ੍ਰੀਫਿਲਟਰਿੰਗ"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "ਹਰ ਪਾਸੇ ਸਫ਼ੇ"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "ਦੋ ਪਾਸੀਂ"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "ਸਥਿਤੀ"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "ਆਮ"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "ਸਫ਼ਾ ਸੈੱਟਅੱਪ"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "ਇੰਸਟਾਲਯੋਗ ਚੋਣਾਂ"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "ਜਾਬ"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "ਚਿੱਤਰ ਕੁਆਲਟੀ"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "ਰੰਗ"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "ਮੁਕੰਮਲ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "ਤਕਨੀਕੀ"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "ਟੈਸਟ ਸਫ਼ਾ"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "ਟੈਸਟ ਸਫ਼ਾ"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "ਆਟੋ ਚੋਣ"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "ਪਰਿੰਟਰ ਡਿਫਾਲਟ"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "ਇੰਬੈੱਡ ਕੀਤੇ ਗੋਸਟਸਕ੍ਰਿਪਟ ਫੋਂਟ ਹੀ"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "PS ਲੈਵਲ 1 ਲਈ ਬਦਲੋ"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "PS ਲੈਵਲ 2 ਲਈ ਬਦਲੋ"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "ਕੋਈ ਪ੍ਰੀ-ਫਿਲਟਰਿੰਗ ਨਹੀਂ"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "ਨਿਰਮਾਤਾ"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "ਕੋਈ ਸਰਗਰਮ ਜਾਬ ਨਹੀਂ"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u ਜਾਬ"
 msgstr[1] "%u ਜਾਬਾਂ"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "ਪਰਿੰਟ ਹੈੱਡ ਸਾਫ਼ ਕਰੋ"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "ਟੋਨਰ ਘੱਟ ਹੈ"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "ਟੋਨਰ ਖਤਮ ਹੋ ਗਿਆ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "ਡਿਵੈਲਪਰ ਲਈ ਘੱਟ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "ਡਿਵੈਲਪਰ ਲਈ ਖਤਮ"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "ਮਾਰਕਰ ਸਪਲਾਈ ਲਈ ਘੱਟ"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "ਮਾਰਕਰ ਸਪਲਾਈ ਲਈ ਖਤਮ"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "ਕਵਰ ਖੋਲ੍ਹੋ"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "ਦਰਵਾਜ਼ਾ ਖੋਲ੍ਹੋ"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "ਪੇਪਰ ਖਤਮ ਹੋਣ ਵਾਲੇ ਹਨ"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "ਪੇਪਰ ਖਤਮ ਹੋ ਗਏ ਹਨ"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ਆਫਲਾਈਨ"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "ਰੁਕਿਆ ਹੈ"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "ਵੇਸਟ ਰੇਸਪਟਕੇਟ ਲਗਭਗ ਭਰ ਗਿਆ ਹੈ"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "ਵੇਸਟ ਰੇਸਪਟਕੇਟ ਭਰ ਗਿਆ ਹੈ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "ਓਪਟੀਕਲ ਫੋਟੋ ਕੰਡਕਟਰ ਦੀ ਉਮਰ ਖਤਮ ਹੋ ਗਈ ਹੈ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ਓਪਟੀਕਲ ਫੋਟੋ ਕੰਡਕਟਰ ਹੁਣ ਕੰਮ ਨਹੀਂ ਕਰਦਾ ਹੈ"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "ਤਿਆਰ"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "ਜਾਬ ਮਨਜ਼ੂਰ ਨਾ ਕਰੋ"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "ਪਰੋਸੈਸ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6073,6 +3074,10 @@ msgstr "ਪਰਿੰਟਰ ਹੈੱਡ ਸਾਫ਼ ਕਰੋ"
 msgid "Remove Printer"
 msgstr "ਪਰਿੰਟਰ ਹਟਾਓ"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "ਕੋਈ ਸਰਗਰਮ ਜਾਬ ਨਹੀਂ"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6093,21 +3098,21 @@ msgid "Restart"
 msgstr "ਮੁੜ-ਚਾਲੂ ਕਰੋ"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "…ਪਰਿੰਟਰ ਜੋੜੋ"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "…ਪਰਿੰਟਰ ਜੋੜੋ"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "ਕੋਈ ਪਰਿੰਟਰ ਨਹੀਂ ਹੈ"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:171
-msgid "Add a Printer…"
-msgstr "…ਪਰਿੰਟਰ ਜੋੜੋ"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6115,7 +3120,6 @@ msgstr ""
 "ਅਫਸੋਸ! ਸਿਸਟਮ ਪਰਿੰਟਿਗ ਸੇਵਾ\n"
 "    ਉਪਲੱਬਧ ਨਹੀਂ ਜਾਪਦੀ ਹੈ।"
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ਫਾਰਮੈਟ"
@@ -6143,16 +3147,6 @@ msgstr "ਦੇਸ਼ਾਂ ਜਾਂ ਭਾਸ਼ਾਵਾਂ ਲਈ ਖੋਜਾਂ �
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "ਝਲਕ"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ਇੰਪਿਅਰਲ"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "ਮੈਟਰਿਕ"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6187,24 +3181,28 @@ msgid ""
 "The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
-"ਭਾਸ਼ਾ ਸੈਟਿੰਗ ਨੂੰ ਇੰਟਰਫੇਸ ਦੀ ਲਿਖਤ ਤੇ ਵੈੱਬ ਸਫ਼ਿਆਂ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ। ਅੰਕਾਂ,"
-" ਤਾਰੀਖਾਂ ਤੇ ਕਰੰਸੀਆਂ ਲਈ "
+"ਭਾਸ਼ਾ ਸੈਟਿੰਗ ਨੂੰ ਇੰਟਰਫੇਸ ਦੀ ਲਿਖਤ ਤੇ ਵੈੱਬ ਸਫ਼ਿਆਂ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ। ਅੰਕਾਂ, ਤਾਰੀਖਾਂ ਤੇ ਕਰੰਸੀਆਂ ਲਈ "
 "ਫਾਰਮੈਟ ਵਰਤੇ ਜਾਂਦੇ ਹਨ।"
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "...ਭਾਸ਼ਾ ਇੰਸਟਾਲ ਕਰੋ"
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "ਤੁਹਾਡਾ ਖਾਤਾ"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "ਭਾਸ਼ਾ(_L)"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "ਫਾਰਮੈਟ(_F)"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "ਲਾਗਇਨ ਸਕਰੀਨ"
 
@@ -6216,99 +3214,9 @@ msgstr "ਇਲਾਕਾ ਅਤੇ ਭਾਸ਼ਾ"
 msgid "Select your display language and formats"
 msgstr "ਆਪਣੀ ਦਿਖਾਉਣ ਵਾਲੀ ਭਾਸ਼ਾ ਤੇ ਫਾਰਮੈਟ ਚੁਣੋ"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ਭਾਸ਼ਾ;ਲੇਆਉਟ;ਕੀਬੋਰਡ;ਇੰਪੁੱਟ;ਖਾਕਾ;ਬੋਲੀ;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "ਪੁੱਛੋ ਕਿ ਕੀ ਕਰਨਾ ਹੈ"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "ਕੁਝ ਨਹੀਂ"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "ਫੋਲਡਰ ਖੋਲ੍ਹੋ"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "ਹੋਰ ਮੀਡਿਆ"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "ਆਡੀਓ ਸੀਡੀ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "ਵਿਡੀਓ DVD ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "ਜਦੋਂ ਸੰਗੀਤ ਪਲੇਅਰ ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇ ਤਾਂ ਚਲਾਉਣ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "ਜਦੋਂ ਕੈਮਰਾ ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇ ਤਾਂ ਚਲਾਉਣ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "ਸਾਫਟਵੇਅਰ ਸੀਡੀ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "ਆਡੀਓ DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "ਖਾਲੀ ਬਲੁ-ਰੇ ਡਿਸਕ"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "ਖਾਲੀ CD ਡਿਸਕ"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "ਖਾਲੀ DVD ਡਿਸਕ"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "ਖਾਲੀ HD DVD ਡਿਸਕ"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "ਬਲੁ-ਰੇ ਵਿਡੀਓ ਡਿਸਕ"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "ਈ-ਬੁੱਕ ਰੀਡਰ"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD ਵਿਡੀਓ ਡਿਸਕ"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "ਤਸਵੀਰ CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "ਸੁਪਰ ਵਿਡੀਓ CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "ਵਿਡੀਓ CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "ਵਿੰਡੋਜ਼ ਸਾਫਟਵੇਅਰ"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6358,23 +3266,84 @@ msgstr "ਹਟਾਉਣਯੋਗ ਮੀਡਿਆ"
 msgid "Configure Removable Media settings"
 msgstr "ਹਟਾਉਣਯੋਗ ਮੀਡੀਏ ਦੀਆਂ ਸੈਟਿੰਗਾਂ ਦੀ ਸੰਰਚਨਾ"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;"
 msgstr ""
-"ਡਿਵਾਈਸ;ਡੀਵਾਈਸ;ਯੰਤਰ;ਜੰਤਰ;ਡਿਫਾਲਟ;ਮੂਲ;ਐਪਲੀਕੇਸ਼ਨ;ਤਰਜੀਹੀ;ਪਸੰਦ;ਸੀਡੀ;ਡੀਵੀਡੀ;ਆਡੀਓ;ਯੂਐਸ"
-"ਬੀ;"
+"ਡਿਵਾਈਸ;ਡੀਵਾਈਸ;ਯੰਤਰ;ਜੰਤਰ;ਡਿਫਾਲਟ;ਮੂਲ;ਐਪਲੀਕੇਸ਼ਨ;ਤਰਜੀਹੀ;ਪਸੰਦ;ਸੀਡੀ;ਡੀਵੀਡੀ;ਆਡੀਓ;ਯੂਐਸਬੀ;"
 "ਵੀਡੀਓ;ਹਟਾਉਣਯੋਗ;ਵਿਡੀਓ;ਮੀਡੀਆ;ਆਟੋ-ਰਨ;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "ਟਿਕਾਣਾ ਚੁਣੋ"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "ਸਕਰੀਨ ਲਾਕ"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "ਠੀਕ ਹੈ(_O)"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"ਆਪਣੇ-ਆਪ ਸਕਰੀਨ ਨੂੰ ਲਾਕ ਕਰਨ ਨਾਲ ਤੁਹਾਡੇ ਦੂਰ ਚਲੇ ਜਾਣ ਉੱਤੇ ਹੋਰਾਂ ਵਲੋਂ ਕੰਪਿਊਟਰ ਨੂੰ ਵਰਤਣ ਤੋਂ ਰੋਕਿਆ "
+"ਜਾਂਦਾ ਹੈ।"
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "ਖਾਲੀ ਸਕਰੀਨ ਦੇਰੀ"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "ਨਾ-ਸਰਗਰਮੀ ਦਾ ਅੰਤਰਾਲ, ਜਿਸ ਦੇ ਬਾਅਦ ਸਕਰੀਨ ਖਾਲੀ ਹੋ ਜਾਵੇਗੀ।"
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "ਆਪਣੇ-ਆਪ ਸਕਰੀਨ ਲਾਕ ਕਰੋ(_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "ਆਪਣੇ-ਆਪ ਸਕਰੀਨ ਲਾਕ ਦੇਰੀ(_S)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "ਜਦੋਂ ਸਕਰੀਨ ਆਪਣੇ-ਆਪ ਲਾਕ ਹੁੰਦੀ ਹੈ ਤਾਂ ਸਕਰੀਨ ਦੇ ਝਪਕਣ ਦੇ ਬਾਅਦ ਅੰਤਰਾਲ ਹੈ।"
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "ਲਾਕ ਸਕਰੀਨ ਉੱਤੇ ਨੋਟੀਫਿਕੇਸ਼ਨ ਵੇਖਾਓ(_N)"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "ਲਾਕ ਸਕਰੀਨ ਸੂਚਨਾਵਾਂ(_L)"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "ਨਵੇਂ _USB ਡਿਵਾਈਸਾਂ ਉੱਤੇ ਰੋਕ"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "ਜਦੋਂ ਸਕਰੀਨ ਲਾਕ ਹੋਵੇ ਤਾਂ ਨਵੇਂ USB ਡਿਵਾਈਸਾਂ ਨੂੰ ਸਿਸਟਮ ਨਾਲ ਤਾਲਮੇਲ ਕਰਨ ਤੋਂ ਰੋਕਦਾ ਹੈ।"
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr "ਸਕਰੀਨ ਪਰਦੇਦਾਰੀ"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr "ਵੇਖਣ ਕੋਣ ਸੀਮਿਤ ਕਰੋ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "ਸਕਰੀਨ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "ਸਕਰੀਨ ਸੈਟਿੰਗਾਂ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "ਸਕਰੀਨ;ਸਕ੍ਰੀਨ;ਪਰਦਾ;ਲਾਕ;ਤਾਲਾ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6385,9 +3354,7 @@ msgstr "ਟਿਕਾਣਾ ਖੋਜ"
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
-msgstr ""
-"ਫੋਲਡਰ, ਜਿਹਨਾਂ ਨੂੰ ਸਿਸਟਮ ਐਪਲੀਕੇਸ਼ਨਾਂ, ਜਿਵੇਂ ਫਾਇਲਾਂ, ਫੋਟੋ ਅਤੇ ਵਿਡੀਓ ਵਲੋਂ ਖੋਜਿਆ"
-" ਜਾਂਦਾ ਹੈ।"
+msgstr "ਫੋਲਡਰ, ਜਿਹਨਾਂ ਨੂੰ ਸਿਸਟਮ ਐਪਲੀਕੇਸ਼ਨਾਂ, ਜਿਵੇਂ ਫਾਇਲਾਂ, ਫੋਟੋ ਅਤੇ ਵਿਡੀਓ ਵਲੋਂ ਖੋਜਿਆ ਜਾਂਦਾ ਹੈ।"
 
 #: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
@@ -6404,10 +3371,6 @@ msgstr "ਹੋਰ"
 #: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "ਟਿਕਾਣਾ ਜੋੜੋ"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "ਕੋਈ ਐਪਲੀਕੇਸ਼ਨ ਨਹੀਂ ਲੱਭੀ"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -6434,97 +3397,14 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿਹੜੀਆਂ ਐਪਲੀਕੇਸ਼ਨ ਸਰਗਰਮੀ ਝਲਕ ਵਿੱਚ ਖੋਜ ਨਤੀਜਿਆਂ ਵਿੱਚ ਦਿਸਣ"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
-"ਖੋਜ;ਲੱਭੋ;ਲੱਭਣਾ;ਇੰਡੈਕਸ;ਤਤਕਰਾ;ਪਰਾਈਵੇਸੀ;ਨਤੀਜੇ;Search;Find;Index;Hide;Privacy;Resu"
-"lts;"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "ਸਾਂਝਾ ਕਰਨ ਲਈ ਕੋਈ ਨੈੱਟਵਰਕ ਨਹੀਂ ਚੁਣਿਆ"
+"ਖੋਜ;ਲੱਭੋ;ਲੱਭਣਾ;ਇੰਡੈਕਸ;ਤਤਕਰਾ;ਪਰਾਈਵੇਸੀ;ਨਤੀਜੇ;Search;Find;Index;Hide;Privacy;Results;"
 
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "ਨੈੱਟਵਰਕ"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "ਚਾਲੂ"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "ਬੰਦ"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "ਯੋਗ ਕੀਤਾ"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "ਸਰਗਰਮ"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "ਫੋਲਡਰ ਚੁਣੋ"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "ਸ਼ਾਮਲ"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "ਮੀਡਿਆ ਸਾਂਝ ਸਮਰੱਥ"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"ਫਾਇਲ ਸਾਂਝ ਤੁਹਾਨੂੰ ਤੁਹਾਡੇ ਪਬਲਿਕ ਫੋਲਡਰ ਨੂੰ ਹੋਰਾਂ ਨਾਲ ਤੁਹਾਡੇ ਮੌਜੂਦਾ ਨੈੱਟਵਰਕ ਉੱਤੇ"
-" ਦੀ ਵਰਤੋਂ ਨਾਲ ਸਾਂਝਾ "
-"ਕਰਨ ਲਈ ਸਹਾਇਕ ਹੈ: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"ਜਦੋਂ ਰਿਮੋਟ ਲਾਗਇਨ ਸਮਰੱਥ ਹੁੰਦਾ ਹੈ ਤਾਂ ਰਿਮੋਟ ਵਰਤੋਂਕਾਰ ਨੂੰ ਸੁਰੱਖਿਅਤ ਸ਼ੈੱਲ ਕਮਾਂਡ"
-" ਰਾਹੀਂ ਕਨੈਕਟ ਹੋ ਸਕਦਾ "
-"ਹੈ:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "ਨਿੱਜੀ ਮੀਡਿਆ ਸਾਂਝ ਸਮਰੱਥ"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "ਡਿਵਾਈਸ ਦਾ ਨਾਂ ਕਾਪੀ ਕੀਤਾ"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "ਡਿਵਾਈਸ ਦਾ ਐਡਰੈਸ ਕਾਪੀ ਕੀਤਾ"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ ਕਾਪੀ ਕੀਤਾ"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "ਪਾਸਵਰਡ ਕਾਪੀ ਕੀਤਾ"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6573,9 +3453,7 @@ msgstr "ਰਿਮੋਟ ਡੈਸਕਟਾਪ"
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
-msgstr ""
-"ਰਿਮੋਟ ਡੈਸਕਟਾਪ ਹੋਰ ਕੰਪਿਊਟਰ ਤੋਂ ਤੁਹਾਡੇ ਡੈਸਕਟਾਪ ਨੂੰ ਵੇਖਣ ਜਾਂ ਕੰਟਰੋਲ ਕਰਨ ਦੀ ਇਜਾਜ਼ਤ"
-" ਦਿੰਦਾ ਹੈ।"
+msgstr "ਰਿਮੋਟ ਡੈਸਕਟਾਪ ਹੋਰ ਕੰਪਿਊਟਰ ਤੋਂ ਤੁਹਾਡੇ ਡੈਸਕਟਾਪ ਨੂੰ ਵੇਖਣ ਜਾਂ ਕੰਟਰੋਲ ਕਰਨ ਦੀ ਇਜਾਜ਼ਤ ਦਿੰਦਾ ਹੈ।"
 
 #: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
@@ -6600,8 +3478,8 @@ msgstr "ਇਸ ਕੰਪਿਊਟਰ ਨਾਲ ਡਿਵਾਈਸ ਨਾਂ ਜ�
 
 #: panels/sharing/cc-sharing-panel.ui:318
 #: panels/sharing/cc-sharing-panel.ui:345
-#: panels/sharing/cc-sharing-panel.ui:379
-#: panels/sharing/cc-sharing-panel.ui:405
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
 msgid "Copy"
 msgstr "ਕਾਪੀ ਕਰੋ"
 
@@ -6621,31 +3499,30 @@ msgstr "ਇਸ ਕੰਪਿਊਟਰ ਨਾਲ ਕਨੈਕਟ ਕਰਨ ਲਈ 
 msgid "User Name"
 msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ"
 
-#: panels/sharing/cc-sharing-panel.ui:420
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "ਇੰਕ੍ਰਿਪਸ਼ਨ ਦੀ ਜਾਂਚ ਕਰੋ"
 
-#: panels/sharing/cc-sharing-panel.ui:449
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr "ਇੰਕ੍ਰਿਪਸ਼ਨ ਫਿੰਗਰਪਰਿੰਟ"
 
-#: panels/sharing/cc-sharing-panel.ui:450
+#: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
 "identical."
 msgstr ""
-"ਇੰਕ੍ਰਿਪਸ਼ਨ ਫਿੰਗਰਪਰਿੰਟ ਕਨੈਕਟ ਹੋ ਰਹੇ ਕਲਾਇਟਾਂ ਵਿੱਚ ਵੇਖੇ ਜਾ ਸਕਦੇ ਹਨ ਅਤੇ ਮਿਲਦੇ ਹੋਣੇ"
-" ਚਾਹੀਦੇ ਹਨ।"
+"ਇੰਕ੍ਰਿਪਸ਼ਨ ਫਿੰਗਰਪਰਿੰਟ ਕਨੈਕਟ ਹੋ ਰਹੇ ਕਲਾਇਟਾਂ ਵਿੱਚ ਵੇਖੇ ਜਾ ਸਕਦੇ ਹਨ ਅਤੇ ਮਿਲਦੇ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ।"
 
-#: panels/sharing/cc-sharing-panel.ui:482
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "ਮੀਡਿਆ ਸਾਂਝ"
 
-#: panels/sharing/cc-sharing-panel.ui:504
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "ਨੈੱਟਵਰਕ ਉੱਤੇ ਹੋਰਾਂ ਨਾਲ ਸੰਗੀਤ, ਫੋਟੋ ਤੇ ਵਿਡੀਓ ਨੂੰ ਸਾਂਝਾ ਕਰੋ।"
 
-#: panels/sharing/cc-sharing-panel.ui:517
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "ਫੋਲਡਰ"
 
@@ -6653,14 +3530,12 @@ msgstr "ਫੋਲਡਰ"
 msgid "Control what you want to share with others"
 msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿ ਤੁਸੀਂ ਹੋਰਾਂ ਨਾਲ ਕੀ ਸਾਂਝਾ ਕਰਦੇ ਹੋ"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
 "movies;server;renderer;"
 msgstr ""
-"ਸਾਂਝਾ;ਸਾਂਝਾ ਕਰੋ;ਨਾਂ;ਨਾਮ;ਡੈਸਕਟਾਪ;ਮੀਡੀਆ;ਆਡੀਓ;ਵੀਡੀਓ;ਹੋਸਟ;ssh;ਰਿਮੋਟ;ਤਸਵੀਰ;ਫੋਟੋ;ਮੂਵ"
-"ੀ;ਸਰਵਰ;"
+"ਸਾਂਝਾ;ਸਾਂਝਾ ਕਰੋ;ਨਾਂ;ਨਾਮ;ਡੈਸਕਟਾਪ;ਮੀਡੀਆ;ਆਡੀਓ;ਵੀਡੀਓ;ਹੋਸਟ;ssh;ਰਿਮੋਟ;ਤਸਵੀਰ;ਫੋਟੋ;ਮੂਵੀ;ਸਰਵਰ;"
 "ਰੈਂਡਰ;"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
@@ -6671,21 +3546,21 @@ msgstr "ਰਿਮੋਟ ਲਾਗਇਨ ਸਮਰੱਥ ਜਾਂ ਅਸਮਰ�
 msgid "Authentication is required to enable or disable remote login"
 msgstr "ਰਿਮੋਟ ਲਾਗਇਨ ਨੂੰ ਬੰਦ ਜਾਂ ਚਾਲੂ ਕਰਨ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
 
-#: panels/sound/cc-alert-chooser.c:152
-msgid "Custom"
-msgstr "ਕਸਟਮ"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Drip"
-msgstr "ਚੌਂਣਾ"
+msgid "Click"
+msgstr "ਕਲਿੱਕ"
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Glass"
-msgstr "ਕੱਚ"
+msgid "String"
+msgstr "ਸਤਰ"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Sonar"
-msgstr "ਸੋਨਰ"
+msgid "Swing"
+msgstr "ਸਵਿੰਗ"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "ਹੁਮ"
 
 #: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 msgid "Balance"
@@ -6703,11 +3578,6 @@ msgstr "ਪਿਛਲਾ"
 msgid "Front"
 msgstr "ਅਗਲਾ"
 
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s ਦੀ ਜਾਂਚ ਜਾਰੀ"
-
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
 msgstr "ਜਾਂਚ ਕਰਨ ਲਈ ਸਪੀਕਰ ਨੂੰ ਕਲਿੱਕ ਕਰੋ"
@@ -6717,7 +3587,6 @@ msgid "System Volume"
 msgstr "ਸਿਸਟਮ ਆਵਾਜ਼"
 
 #: panels/sound/cc-sound-panel.ui:12
-#| msgid "System Volume"
 msgid "Master volume"
 msgstr "ਮਾਸਟਰ ਆਵਾਜ਼"
 
@@ -6761,11 +3630,6 @@ msgstr "ਆਵਾਜ਼"
 msgid "Alert Sound"
 msgstr "ਚੇਤਾਵਨੀ ਸਾਊਂਡ"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "੧੦੦%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "ਚੁੱਪ"
@@ -6778,83 +3642,10 @@ msgstr "ਸਾਊਂਡ"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "ਸਾਊਂਡ ਲੈਵਲ, ਇੰਪੁੱਟ, ਆਉਟਪੁੱਟ ਅਤੇ ਚੇਤਾਵਨੀ ਸਾਊਂਡ ਬਦਲੋ"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
-msgstr ""
-"ਕਾਰਡ;ਮਾਈਕਰੋਫੋਨ;ਵਾਲੀਅਮ;ਫੇਡ;ਬੈਲਨਸ;ਬਲਿਊਟੁੱਲ;ਹੈੱਡਸੈੱਟ;ਆਡੀਓ;ਆਉਟਪੁੱਟ;ਇੰਪੁੱਟ;ਇਨਪੁੱਟ;ਬ"
-"ਲੁਟੁੱਥ;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "ਡਿਸ-ਕੁਨੈਕਟ ਹੈ"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "ਕਨੈਕਟ ਹੈ"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "ਪਰਮਾਣਕਿਤਾ ਗਲਤੀ"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "ਪਰਮਾਣਕਿਤਾ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "ਘਟਾਈ ਗਈ ਕਾਰਜ ਸਮਰੱਥਾ"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "ਕਨੈਕਟ ਅਤੇ ਪਰਮਾਣਿਤ ਹੈ"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "ਅਣਪਛਾਤਾ"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "ਇਸ ਵੇਲੇ ਪਰਮਾਣਿਤ ਕੀਤਾ:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "ਇਸ ਵੇਲੇ ਕਨੈਕਟ ਕੀਤਾ:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "ਇਸ ਵੇਲੇ ਦਾਖਲ ਹੋਇਆ:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "ਡਿਵਾਈਸ ਨੂੰ ਪਰਮਾਣਿਤ ਕਰਨ ਲਈ ਅਸਫ਼ਲ:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "ਡਿਵਾਈਸ ਨੂੰ ਭੁੱਲਣ ਲਈ ਅਸਫ਼ਲ:"
+msgstr "ਕਾਰਡ;ਮਾਈਕਰੋਫੋਨ;ਵਾਲੀਅਮ;ਫੇਡ;ਬੈਲਨਸ;ਬਲਿਊਟੁੱਲ;ਹੈੱਡਸੈੱਟ;ਆਡੀਓ;ਆਉਟਪੁੱਟ;ਇੰਪੁੱਟ;ਇਨਪੁੱਟ;ਬਲੁਟੁੱਥ;"
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6865,7 +3656,6 @@ msgstr[1] "%u ਹੋਰ ਡਿਵਾਈਸਾਂ ਉੱਤੇ ਨਿਰਭਰ �
 
 #: panels/thunderbolt/cc-bolt-device-dialog.ui:43
 #: panels/thunderbolt/cc-bolt-panel.ui:41
-#| msgid "Close the notification"
 msgid "Close notification"
 msgstr "ਨੋਟੀਫਿਕੇਸ਼ਨ ਬੰਦ ਕਰੋ"
 
@@ -6889,56 +3679,6 @@ msgstr "ਪਰਮਾਣਿਤ ਅਤੇ ਕਨੈਕਟ ਕਰੋ"
 msgid "Forget Device"
 msgstr "ਡਿਵਾਈਸ ਭੁਲਾਓ"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "ਗ਼ਲਤੀ"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "ਪਰਮਾਣਿਤ ਹੈ"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"ਥੰਡਰਬੋਲਟ ਸਬ-ਸਿਸਟਮ (boldtd) ਠੀਕ ਤਰ੍ਹਾਂ ਇੰਸਟਾਲ ਨਹੀਂ ਹੈ ਜਾਂ ਠੀਕ ਤਰ੍ਹਾਂ ਸੈਟ ਅੱਪ"
-" ਨਹੀਂ ਕੀਤਾ ਹੈ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "ਡਿਵਾਈਸਾਂ, ਜਿਵੇਂ ਕਿ ਡੌਕ ਅਤੇ ਬਾਹਰੀ GPU ਲਈ ਸਿੱਧੀ ਪਹੁੰਚ ਲਈ ਸਹਿਮਤੀ ਦਿਓ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "ਸਿਰਫ਼ USB ਅਤੇ ਡਿਸਪਲੇਅ ਪੋਰਟ ਡਿਵਾਈਸ ਹੀ ਜੋੜ ਜਾ ਸਕਦੇ ਹਨ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"ਥੰਡਰਬੋਲਟ ਖੋਜਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।\n"
-"ਜਾਂ ਤਾਂ ਸਿਸਟਮ ਥੰਡਰਬੋਲਢ ਲਈ ਸਹਾਇਕ ਨਹੀ ਹੈ, ਇਹ BIOS ਵਿੱਚੋਂ ਅਸਮਰੱਥ ਕੀਤਾ ਹੋ ਸਕਦਾ ਹੈ"
-" ਜਾਂ BIOS "
-"ਵਿੱਚ ਗ਼ੈਰ-ਸਹਾਇਕ ਸੁਰੱਖਿਆ ਪੱਧਰ ਲਈ ਸੈੱਟ ਕੀਤਾ ਹੋ ਸਕਦਾ ਹੈ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "ਥੰਡਰਬੋਲਟ ਲਈ ਸਹਿਯੋਗ ਨੂੰ BIOS 'ਚ ਅਸਮਰੱਥ ਕੀਤਾ ਹੈ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "ਥੰਡਰਬੋਲਟ ਸੁਰੱਖਿਆ ਪੱਧਰ ਦਾ ਪਤਾ ਨਹੀਂ ਲਾਇਆ ਜਾ ਸਕਿਆ।"
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "ਸਿੱਧਾ ਮੋਡ ਬਦਲਣ ਲਈ ਗ਼ਲਤੀ: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "ਥੰਡਰਬੋਲਟ ਸਹਿਯੋਗ ਨਹੀਂ ਹੈ"
@@ -6950,6 +3690,10 @@ msgstr "ਥੰਡਰਬੋਲਟ ਸਬ-ਸਿਸਟਮ ਨਾਲ ਕਨੈਕ�
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "ਸਿੱਧੀ ਪਹੁੰਚ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "ਡਿਵਾਈਸਾਂ, ਜਿਵੇਂ ਕਿ ਡੌਕ ਅਤੇ ਬਾਹਰੀ GPU ਲਈ ਸਿੱਧੀ ਪਹੁੰਚ ਲਈ ਸਹਿਮਤੀ ਦਿਓ।"
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -6967,7 +3711,6 @@ msgstr "ਥੰਡਰਬੋਲਟ"
 msgid "Manage Thunderbolt devices"
 msgstr "ਥੰਡਰਬੋਲਟ ਡਿਵਾਈਸਾਂ ਦਾ ਇੰਤਜ਼ਾਮ ਕਰੋ"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "ਥੰਡਰਬੋਲਟ;ਪਰਦੇਦਾਰੀ;"
@@ -7167,40 +3910,6 @@ msgstr "ਕੀ-ਬੋਰਡ ਰਾਹੀਂ ਚਾਲੂ(_E)"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "ਕੀਬੋਰਡ ਤੋਂ ਅਸੈਸਬਿਲਟੀ ਫੀਚਰ ਚਾਲੂ ਅਤੇ ਬੰਦ ਕਰੋ"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "ਮੂਲ"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "ਮੱਧਮ"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "ਵੱਡਾ"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "ਹੋਰ ਵੱਡਾ"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "ਸਭ ਤੋਂ ਵੱਡਾ"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d ਪਿਕਸਲ"
-msgstr[1] "%d ਪਿਕਸਲ"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "ਹਮੇਸ਼ਾ ਯੂਨੀਵਰਸਲ ਅਸੈੱਸਬਿਲਟੀ ਮੇਨੂ ਵੇਖੋ(_A)"
@@ -7314,31 +4023,6 @@ msgstr "ਪੂਰੀ ਸਕਰੀਨ ਝਲਕਾਓ(_s)"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "ਪੂਰੀ ਵਿੰਡੋ ਝਲਕਾਓ(_w)"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "ਛੋਟਾ"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ਸਕਰੀਨ"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ਸਕਰੀਨ"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ਸਕਰੀਨ"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "ਲੰਮਾ"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7495,7 +4179,6 @@ msgstr "ਰੰਗ ਪ੍ਰਭਾਵ"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "ਵੇਖਣਾ, ਸੁਣਨਾ, ਲਿਖਣਾ, ਪੁਆਇੰਟ ਤੇ ਕਲਿੱਕ ਕਰਨਾ ਸੌਖਾ ਬਣਾਉ"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7503,120 +4186,9 @@ msgid ""
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
 "audio;typing;animations;"
 msgstr ""
-"ਕੀਬੋਰਡ;,ਮਾਊਸ;ਫੋਂਟ;ਟੈਕਸਟ;ਆਕਾਰ;ਕਰਸਰ;ਆਵਾਜ਼;ਸਾਊਂਡ;ਬਾਊਂਸ;ਕੀ-ਬੋਰਡ;ਸਵਿੱਚਾਂ,ਕੀ;ਅਸੈਸਬਲਿਟ"
-"ੀ;ਜ਼ੂਮ;ਡਬਲ "
-"ਕਲਿੱਕ;ਦੋਹਰਾ ਕਲਿੱਕ;ਦੇਰੀ;ਸਹਾਇਕ;ਰੀਡਰ;ਐਕਟਿਵਐਕਸ;ਹੌਲੀ;ਕਨਟਰਾਸਟ;ਦੁਹਰਾਉਣਾ;ਝਪਕਣਾ;ਦੁਹਰਾ;ਵ"
-"ੱਡੇ;ਵੱਡਾ;"
-"ਉੱਚ;ਹੋਰ ਵੱਡਾ;ਸਪੀਡ;ਗਤੀ;ਦਿੱਖ;ਸੁਣਨਾ;ਆਡੀਓ;ਲਿਖਣਾ;ਟਾਈਪ ਕਰਨਾ;ਟਾਈਪਿੰਗ;ਵਿਆਪਕ"
-" ਪਹੁੰਚ;ਐਨੀਮੇਸ਼ਨਾਂ;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "੧ ਘੰਟਾ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "੧ ਦਿਨ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "੨ ਦਿਨ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "੩ ਦਿਨ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "੪ ਦਿਨ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "੫ ਦਿਨ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "੬ ਦਿਨ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "੭ ਦਿਨ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "੧੪ ਦਿਨ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "੩੦ ਦਿਨ"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "ਰੱਦੀ 'ਚੋਂ ਸਭ ਆਈਟਮਾਂ ਹਟਾਉਣੀਆਂ ਹਨ?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "ਰੱਦੀ ਵਿੱਚ ਮੌਜੂਦਾ ਆਈਟਮਾਂ ਨੂੰ ਪੱਕੇ ਤੌਰ ਉੱਤੇ ਹਟਾਇਆ ਜਾਵੇਗਾ।"
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "ਰੱਦੀ ਖਾਲੀ ਕਰੋ(_E)"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "ਸਭ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਹਟਾਉਣੀਆਂ ਹਨ?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "ਸਭ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਪੱਕੇ ਤੌਰ ਉੱਤੇ ਹਟਾਇਆ ਜਾਵੇਗਾ।"
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਨਸ਼ਟ ਕਰੋ(_P)"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "੧ ਦਿਨ"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "੭ ਦਿਨ"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "੩੦ ਦਿਨ"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "ਹਮੇਸ਼ਾ"
+"ਕੀਬੋਰਡ;,ਮਾਊਸ;ਫੋਂਟ;ਟੈਕਸਟ;ਆਕਾਰ;ਕਰਸਰ;ਆਵਾਜ਼;ਸਾਊਂਡ;ਬਾਊਂਸ;ਕੀ-ਬੋਰਡ;ਸਵਿੱਚਾਂ,ਕੀ;ਅਸੈਸਬਲਿਟੀ;ਜ਼ੂਮ;ਡਬਲ "
+"ਕਲਿੱਕ;ਦੋਹਰਾ ਕਲਿੱਕ;ਦੇਰੀ;ਸਹਾਇਕ;ਰੀਡਰ;ਐਕਟਿਵਐਕਸ;ਹੌਲੀ;ਕਨਟਰਾਸਟ;ਦੁਹਰਾਉਣਾ;ਝਪਕਣਾ;ਦੁਹਰਾ;ਵੱਡੇ;ਵੱਡਾ;"
+"ਉੱਚ;ਹੋਰ ਵੱਡਾ;ਸਪੀਡ;ਗਤੀ;ਦਿੱਖ;ਸੁਣਨਾ;ਆਡੀਓ;ਲਿਖਣਾ;ਟਾਈਪ ਕਰਨਾ;ਟਾਈਪਿੰਗ;ਵਿਆਪਕ ਪਹੁੰਚ;ਐਨੀਮੇਸ਼ਨਾਂ;"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7628,10 +4200,8 @@ msgid ""
 "shared between applications, and makes it easier to find files that you "
 "might want to use."
 msgstr ""
-"ਫਾਇਲ ਅਤੀਤ ਫਾਇਲਾਂ ਦੇ ਰਿਕਾਰਡ ਰੱਖਦਾ ਹੈ, ਜੋ ਤੁਸੀਂ ਵਰਤੇ ਚੁੱਕੇ ਹੋ। ਇਹ ਜਾਣਕਾਰੀ ਨੂੰ"
-" ਐਪਲੀਕੇਸ਼ਨਾਂ ਵਿਚਾਲੇ "
-"ਸਾਂਝਾ ਕੀਤਾ ਜਾਂਦਾ ਹੈ, ਜਿਸ ਨਾਲ ਤੁਹਾਡੇ ਲਈ ਫਾਇਲਾਂ ਲੱਭਣੀਆਂ ਸੌਖੀਆਂ ਹੋ ਜਾਂਦੀਆਂ ਹਨ,"
-" ਜਦੋਂ ਵਰਤੀਆਂ ਹੋਣ।"
+"ਫਾਇਲ ਅਤੀਤ ਫਾਇਲਾਂ ਦੇ ਰਿਕਾਰਡ ਰੱਖਦਾ ਹੈ, ਜੋ ਤੁਸੀਂ ਵਰਤੇ ਚੁੱਕੇ ਹੋ। ਇਹ ਜਾਣਕਾਰੀ ਨੂੰ ਐਪਲੀਕੇਸ਼ਨਾਂ ਵਿਚਾਲੇ "
+"ਸਾਂਝਾ ਕੀਤਾ ਜਾਂਦਾ ਹੈ, ਜਿਸ ਨਾਲ ਤੁਹਾਡੇ ਲਈ ਫਾਇਲਾਂ ਲੱਭਣੀਆਂ ਸੌਖੀਆਂ ਹੋ ਜਾਂਦੀਆਂ ਹਨ, ਜਦੋਂ ਵਰਤੀਆਂ ਹੋਣ।"
 
 #: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
@@ -7654,8 +4224,7 @@ msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
 msgstr ""
-"ਰੱਦੀ ਅਤੇ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਕਈ ਵਾਰ ਨਿੱਜੀ ਅਤੇ ਸੰਵੇਦਨਸ਼ੀਲ ਜਾਣਕਾਰੀ ਰੱਖ ਸਕਦੀਆਂ ਹਨ। ਉਹਨਾਂ"
-" ਨੂੰ ਆਪਣੇ-ਆਪ "
+"ਰੱਦੀ ਅਤੇ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਕਈ ਵਾਰ ਨਿੱਜੀ ਅਤੇ ਸੰਵੇਦਨਸ਼ੀਲ ਜਾਣਕਾਰੀ ਰੱਖ ਸਕਦੀਆਂ ਹਨ। ਉਹਨਾਂ ਨੂੰ ਆਪਣੇ-ਆਪ "
 "ਹਟਾਉਣ ਨਾਲ ਪਰਦੇਦਾਰੀ ਨੂੰ ਸੁਰੱਖਿਅਤ ਕਰਨ ਲਈ ਮਦਦ ਮਿਲ ਸਕਦੀ ਹੈ।"
 
 #: panels/usage/cc-usage-panel.ui:67
@@ -7686,65 +4255,12 @@ msgstr "ਫਾਇਲ ਅਤੀਤ ਤੇ ਰੱਦੀ"
 msgid "Don't leave traces"
 msgstr "ਨਿਸ਼ਾਨ ਨਾ ਛੱਡੋ"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"ਵਰਤੋਂ;ਹਾਲੀਆ;ਸੱਜਰਾ;ਹੁਣੇ;ਅਤੀਤ;ਇਤਿਹਾਸ;ਆਰਜ਼ੀ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;ਪ੍ਰਾਈ"
-"ਵੇਸੀ;ਰੱਦੀ;"
+"ਵਰਤੋਂ;ਹਾਲੀਆ;ਸੱਜਰਾ;ਹੁਣੇ;ਅਤੀਤ;ਇਤਿਹਾਸ;ਆਰਜ਼ੀ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;ਪ੍ਰਾਈਵੇਸੀ;ਰੱਦੀ;"
 "ਬੇਕਾਰ;ਖਾਲੀ;ਰੱਖੋ;ਨਿਕਾਸ;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "ਤੁਹਾਡੇ ਲਾਗਇਨ ਪਰੋਵਾਇਡਰ ਦੇ ਵੈੱਬ ਐਡਰੈਸ ਨਾਲ ਮਿਲਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "ਅਕਾਊਂਟ ਜੋੜਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr "ਪਾਸਵਰਡ ਮਿਲਦਾ ਨਹੀਂ ਹੈ।"
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "ਅਕਾਊਂਟ ਰਜਿਸਟਰ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "ਇਹ ਡੋਮੇਨ ਨਾਲ ਪਰਮਾਣਕਿਤਾ ਦਾ ਕੋਈ ਸਹਾਇਕ ਢੰਗ ਨਹੀਂ ਹੈ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "ਡੋਮੇਨ ਜੁਆਇੰਨ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"ਉਹ ਲਾਗਇਨ ਨਾਂ ਕੰਮ ਨਹੀਂ ਕਰਦਾ।\n"
-"ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ ਜੀ।"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"ਇਹ ਲਾਗਇਨ ਪਾਸਵਰਡ ਕੰਮ ਨਹੀਂ ਕਰਦਾ ਹੈ।\n"
-"ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "ਡੋਮੇਨ ਵਿੱਚ ਲਾਗਇਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "ਡੋਮੇਨ ਲੱਭਣ ਲਈ ਅਸਮਰੱਥ, ਸ਼ਾਇਦ ਤੁਸੀਂ ਇਹ ਗਲਤ ਲਿਖੀ ਹੋਵੇ?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7760,8 +4276,7 @@ msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"ਪਰਸ਼ਾਸ਼ਕ ਹੋਰ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਜੋੜ ਜਾਂ ਹਟਾ ਸਕਦੇ ਹਨ, ਅਤੇ ਸਾਰੇ ਵਰਤੋਂਕਾਰਾਂ ਲਈ"
-" ਸੈਟਿੰਗਾਂ ਬਦਲ ਸਕਦੇ ਹਨ। "
+"ਪਰਸ਼ਾਸ਼ਕ ਹੋਰ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਜੋੜ ਜਾਂ ਹਟਾ ਸਕਦੇ ਹਨ, ਅਤੇ ਸਾਰੇ ਵਰਤੋਂਕਾਰਾਂ ਲਈ ਸੈਟਿੰਗਾਂ ਬਦਲ ਸਕਦੇ ਹਨ। "
 "ਮਾਪਿਆਂ ਲਈ ਕੰਟਰੋਲ ਪਰਸ਼ਾਸ਼ਕਾਂ ਲਈ ਲਾਗੂ ਨਹੀਂ ਹੋ ਸਕਦੇ ਹਨ।"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:149
@@ -7794,13 +4309,8 @@ msgid ""
 "used on this device. You can also use this account to access company "
 "resources on the internet."
 msgstr ""
-"ਇੰਟਰਪਰਾਈਜ਼ ਲਾਗਇਨ ਮੌਜੂਦਾ ਕੇਂਦਰੀਕ੍ਰਿਤ ਵਰਤੋਂਕਾਰ ਅਕਾਊਂਟ ਨੂੰ ਇਹ ਜੰਤਰ ਉੱਤੇ ਵਰਤਣ ਲਈ"
-" ਸਹਾਇਕ ਹੈ। ਤੁਸੀਂ "
+"ਇੰਟਰਪਰਾਈਜ਼ ਲਾਗਇਨ ਮੌਜੂਦਾ ਕੇਂਦਰੀਕ੍ਰਿਤ ਵਰਤੋਂਕਾਰ ਅਕਾਊਂਟ ਨੂੰ ਇਹ ਜੰਤਰ ਉੱਤੇ ਵਰਤਣ ਲਈ ਸਹਾਇਕ ਹੈ। ਤੁਸੀਂ "
 "ਇਸ ਅਕਾਊਂਟ ਨੂੰ ਇੰਟਰਨੈੱਟ ਉੱਤੇ ਕੰਪਨੀ ਦੇ ਸਰੋਤਾਂ ਤੱਕ ਪਹੁੰਚ ਲਈ ਵੀ ਵਰਤ ਸਕਦੇ ਹੋ।"
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "ਹੋਰ ਤਸਵੀਰਾਂ ਵੇਖੋ"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7827,8 +4337,7 @@ msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
 msgstr ""
-"ਕੀ ਤੁਸੀਂ ਆਪਣੇ ਰਜਿਸਟਰ ਕੀਤੇ ਫਿੰਗਰਪਰਿੰਟ ਹਟਾਉਣੇ ਚਾਹੁੰਦੇ ਹੋ ਤਾਂ ਕਿ ਫਿੰਗਰਪਰਿੰਟ"
-" ਲਾਗਇਨ ਨੂੰ ਆਯੋਗ ਕੀਤਾ "
+"ਕੀ ਤੁਸੀਂ ਆਪਣੇ ਰਜਿਸਟਰ ਕੀਤੇ ਫਿੰਗਰਪਰਿੰਟ ਹਟਾਉਣੇ ਚਾਹੁੰਦੇ ਹੋ ਤਾਂ ਕਿ ਫਿੰਗਰਪਰਿੰਟ ਲਾਗਇਨ ਨੂੰ ਆਯੋਗ ਕੀਤਾ "
 "ਜਾ ਸਕੇ?"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:169
@@ -7861,8 +4370,7 @@ msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
 msgstr ""
-"ਫਿੰਗਰਪਰਿੰਟ ਲਾਗਇਨ ਤੁਹਾਨੂੰ ਆਪਣੇ ਕੰਪਿਊਟਰ ਨੂੰ ਅਣ-ਲਾਕ ਕਰਨ ਤੇ ਲਾਗਇਨ ਕਰਨ ਲਈ ਤੁਹਾਡੀ"
-" ਉਂਗਲ ਵਰਤਣ ਲਈ "
+"ਫਿੰਗਰਪਰਿੰਟ ਲਾਗਇਨ ਤੁਹਾਨੂੰ ਆਪਣੇ ਕੰਪਿਊਟਰ ਨੂੰ ਅਣ-ਲਾਕ ਕਰਨ ਤੇ ਲਾਗਇਨ ਕਰਨ ਲਈ ਤੁਹਾਡੀ ਉਂਗਲ ਵਰਤਣ ਲਈ "
 "ਸਹਾਇਕ ਹੈ"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:273
@@ -7873,398 +4381,45 @@ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਹਟਾਓ(_D)"
 msgid "Fingerprint Enroll"
 msgstr "ਫਿੰਗਰਪਰਿੰਟ ਦਾਖਲਾ"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "ਇਹ ਐਕਸ਼ਨ ਕਰਨ ਲਈ ਡਿਵਾਈਸ ਨੂੰ ਮੱਲਣ ਦੀ ਲੋੜ ਹੈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "ਡਿਵਾਈਸ ਨੂੰ ਪਹਿਲਾਂ ਹੀ ਹੋਰ ਕਾਰਵਾਈ ਵੱਲੋ ਮੱਲ ਲਿਆ ਗਿਆ ਹੈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "ਤੁਹਾਡੇ ਕੋਲ ਕਾਰਵਾਈ ਕਰਨ ਲਈ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "ਕੋਈ ਪਰਿੰਟ ਦਾਖਲ ਨਹੀਂ ਕੀਤਾ ਗਿਆ ਹੈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "ਦਾਖਲ ਕਰਨ ਦੇ ਦੌਰਾਨ ਡਿਵਾਈਸ ਨਾਲ ਸੰਚਾਰ ਫੇਲ੍ਹ ਹੋ ਗਿਆ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "ਫਿੰਗਰਪਰਿੰਟ ਰੀਡਰ ਨਾਲ ਸੰਚਾਰ ਕਰਨ ਲਈ ਅਸਫ਼ਲ ਹੈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡੈਮਨ ਨਾਲ ਸੰਚਾਰ ਕਰਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "ਫਿੰਗਰਪਰਿੰਟ ਦੀ ਸੂਚੀ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "ਸੰਭਾਲੇ ਫਿੰਗਰਪਰਿੰਟ ਹਟਾਉਣ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "ਖੱਬਾ ਅੰਗੂਠਾ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "ਖੱਬੀ ਵਿਚਲੀ ਉਂਗਲ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "ਖੱਬੀ ਇੰਡੈਕਸ ਉਂਗਲ(_L)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "ਖੱਬੀ ਰਿੰਗ ਉਂਗਲ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "ਖੱਬੀ ਚੀਚੀ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "ਸੱਜਾ ਅੰਗੂਠਾ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "ਸੱਜੀ ਵਿਚਲੀ ਉਂਗਲ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "ਸੱਜੀ ਇੰਡੈਕਸ ਉਂਗਲ(_R)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "ਸੱਜੀ ਰਿੰਗ ਉਂਗਲ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "ਸੱਜੀ ਚੀਚੀ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "ਅਣਪਛਾਤੀ ਉਂਗਲ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "ਪੂਰਾ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਕਨੈਕਟ ਨਹੀਂ ਹੈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਦੀ ਸਟੋਰੇਜ਼ ਭਰ ਗਈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "ਨਵਾਂ ਫਿੰਗਰਪਰਿੰਟ ਦਾਖਲ ਕਰਨ ਲਈ ਅਸਫ਼ਲ ਹੈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "ਦਾਖਲਾ ਸ਼ੁਰੂ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "ਨਵਾਂ ਫਿੰਗਰਪਰਿੰਟ ਦਾਖਲ ਕਰਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "ਦਾਖਲਾ ਰੋਕਣ ਲਈ ਫੇਲ੍ਹ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"ਆਪਣੇ ਫਿੰਗਰਪਰਿੰਟ ਨੂੰ ਦਾਖਲ ਕਰਨ ਲਈ ਰੀਡਰ ਉੱਤੇ ਆਪਣੀ ਉਂਗਲ ਨੂੰ ਲਗਾਤਾਰ ਚੱਕੋ ਅਤੇ ਰੱਖੋ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "ਇਹ ਉਂਗਲ ਦੁਬਾਰਾ-ਦਾਖਲ ਕਰੋ(_R)…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "ਨਵਾਂ ਫਿੰਗਰਪਰਿੰਟ ਸਕੈਨ ਕਰੋ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ %s ਛੱਡਣ ਲਈ ਫੇਲ੍ਹ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "ਡਿਵਾਈਸ ਪੜ੍ਹਨ ਦੌਰਾਨ ਸਮੱਸਿਆ"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ %s ਮੱਲਣ ਲਈ ਫੇਲ੍ਹ: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਲੈਣ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "ਇਸ ਹਫ਼ਤੇ"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "ਪਿਛਲੇ ਹਫ਼ਤੇ"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "ਸ਼ੈਸ਼ਨ ਅੰਤ ਹੋਇਆ"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "ਸ਼ੈਸ਼ਨ ਸ਼ੁਰੂ ਹੋਇਆ"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — ਖਾਤਾ ਸਰਗਰਮੀ"
-
-#: panels/user-accounts/cc-login-history-dialog.ui:24
-#| msgid "Previous Week"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "ਪਿੱਛੇ"
 
-#: panels/user-accounts/cc-login-history-dialog.ui:34
-#| msgid "_Next"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "ਅੱਗੇ"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "ਵੱਖਰਾ ਪਾਸਵਰਡ ਚੁਣੋ ਜੀ।"
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "ਆਪਣਾ ਮੌਜੂਦਾ ਪਾਸਵਰਡ ਫੇਰ ਲਿਖੋ ਜੀ।"
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "ਪਾਸਵਰਡ ਬਦਲਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "ਪਾਸਵਰਡ ਬਦਲੋ"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "ਬਦਲੋ(_a)"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "ਮੌਜੂਦਾ ਪਾਸਵਰਡ"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "ਨਵਾਂ ਪਾਸਵਰਡ"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "ਪਾਸਵਰਡ ਤਸਦੀਕ ਕਰੋ"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "ਪਾਸਵਰਡ ਮਿਲਦਾ ਨਹੀਂ ਹੈ।"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "ਵਰਤੋਂਕਾਰ ਨੂੰ ਅਗਲੇ ਲਾਗਇਨ ਉੱਤੇ ਆਪਣਾ ਪਾਸਵਰਡ ਬਦਲਣ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ"
 
-#: panels/user-accounts/cc-password-dialog.ui:187
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "ਹੁਣੇ ਪਾਸਵਰਡ ਦਿਓ"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "ਡੋਮੇਨ ਦੀ ਇਹ ਕਿਸਮ ਲਈ ਆਟੋਮੈਟਿਕ ਜੁਆਇੰਨ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "ਕੋਈ ਡੋਮੇਨ ਜਾਂ ਰੀਲੇਮ ਨਹੀਂ ਲੱਭਿਆ"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s ਵਜੋਂ %s ਡੋਮੇਨ ਵਿੱਚ ਲਾਗਇਨ ਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "ਗਲਤ ਪਾਸਵਰਡ, ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ ਜੀ।"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "%s ਡੋਮੇਨ ਨਾਲ ਕਨੈਕਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "ਵਰਤੋਂਕਾਰ ਹਟਾਉਣ ਲਈ ਫੇਲ੍ਹ"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "ਰਿਮੋਟ ਤੋਂ ਇੰਤਜ਼ਾਮ ਅਧੀਨ ਵਰਤੋਂਕਾਰ ਮਨਸੂਖ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "ਤੁਸੀਂ ਆਪਣਾ ਖੁਦ ਦਾ ਅਕਾਊਂਟ ਹਟਾ ਨਹੀਂ ਸਕਦੇ।"
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s ਹਾਲੇ ਲਾਗਇਨ ਹੈ"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"ਜਦੋਂ ਵਰਤੋਂਕਾਰ ਲਾਗਇਨ ਹੋਵੇ ਤਾਂ ਉਸ ਨੂੰ ਹਟਾਉਣ ਨਾਲ ਸਿਸਟਮ ਖਰਾਬ ਹੋਣ ਦੀ ਹਾਲਤ 'ਚ ਆ"
-" ਸਕਦਾ ਹੈ।"
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "ਕੀ ਤੁਸੀਂ %s ਦੀਆਂ ਫਾਇਲਾਂ ਰੱਖਣੀਆਂ ਚਾਹੁੰਦੇ ਹੋ?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"ਘਰ ਡਾਇਰੈਕਟਰੀ, ਮੇਲ ਸਪੂਲ ਅਤੇ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਰੱਖਣਾ ਸੰਭਵ ਹੈ, ਜਦੋਂ ਵਰਤੋਂਕਾਰ ਖਾਤਾ"
-" ਹਟਾਉਣਾ ਹੋਵੇ।"
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "ਫਾਇਲਾਂ ਹਟਾਓ(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "ਫਾਇਲਾਂ ਰੱਖੋ(_K)"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "ਕੀ ਤੁਸੀਂ ਰਿਮੋਟ ਤੋਂ ਇੰਤਜ਼ਾਮ ਕੀਤੇ %s ਦੇ ਖਾਤੇ ਨੂੰ ਮਨਸੂਖ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "ਹਟਾਓ(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "ਅਕਾਊਂਟ ਬੰਦ ਹੈ"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "ਅਗਲੇ ਲਾਗਇਨ ਸਮੇਂ ਸੈੱਟ ਕਰੋ"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "ਕੋਈ ਨਹੀਂ"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "ਲਾਗਇਨ ਕੀਤਾ"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "ਅਕਾਊਂਟ ਸਰਵਿਸ ਨਾਲ ਸੰਪਰਕ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "ਯਕੀਨੀ ਬਣਾਉ ਕਿ ਅਕਾਊਂਟਸਰਵਿਸ (AccountService) ਇੰਸਟਾਲ ਹੈ ਅਤੇ ਯੋਗ ਹੈ"
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "ਇਸ ਸੈਟਿੰਗ ਬਦਲਣ ਲਈ ਇਹ ਪੈਲਨ ਅਣ-ਲਾਕ ਕੀਤਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "ਚੁਣਿਆ ਵਰਤੋਂਕਾਰ ਖਾਤਾ ਹਟਾਓ"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"ਚੁਣੇ ਵਰਤੋਂਕਾਰ ਖਾਤੇ ਨੂੰ ਹਟਾਉਣ ਲਈ,\n"
-"ਪਹਿਲਾਂ * ਆਈਕਾਨ ਉੱਤੇ ਕਲਿੱਕ ਕਰੋ"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "ਵਰਤੋਂਕਾਰ ਜੋੜਨ ਅਤੇ ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8285,15 +4440,13 @@ msgstr "ਬੰਦ ਕਰੋ"
 
 #: panels/user-accounts/cc-user-panel.ui:120
 msgid "Edit avatar"
-msgstr ""
+msgstr "ਅਵਤਾਰ ਸੋਧੋ"
 
 #: panels/user-accounts/cc-user-panel.ui:152
-#| msgid "_Full Name"
 msgid "Full name"
 msgstr "ਪੂਰਾ ਨਾਂ"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "ਸੋਧ"
 
@@ -8319,8 +4472,7 @@ msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
 msgstr ""
-"ਪਰਸ਼ਾਸ਼ਕ ਹੋਰ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਜੋੜ ਜਾਂ ਹਟਾ ਸਕਦੇ ਹਨ, ਅਤੇ ਸਾਰੇ ਵਰਤੋਂਕਾਰਾਂ ਲਈ"
-" ਸੈਟਿੰਗਾਂ ਬਦਲ ਸਕਦੇ ਹਨ।"
+"ਪਰਸ਼ਾਸ਼ਕ ਹੋਰ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਜੋੜ ਜਾਂ ਹਟਾ ਸਕਦੇ ਹਨ, ਅਤੇ ਸਾਰੇ ਵਰਤੋਂਕਾਰਾਂ ਲਈ ਸੈਟਿੰਗਾਂ ਬਦਲ ਸਕਦੇ ਹਨ।"
 
 #: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
@@ -8355,14 +4507,12 @@ msgstr "ਵਰਤੋਂਕਾਰ ਖਾਤਾ ਜੋੜਨ ਲਈ ਅਣ-ਲਾ�
 msgid "Add or remove users and change your password"
 msgstr "ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਜੋੜੋ ਜਾਂ ਹਟਾਓ ਅਤੇ ਆਪਣਾ ਪਾਸਵਰਡ ਬਦਲੋ"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
 "Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"ਲਾਗਇਨ;ਲੌਗਇਨ;ਨਾਂ;ਨਾਮ;ਫਿੰਗਰ-ਪਰਿੰਟ;ਉਂਗਲ-ਨਿਸ਼ਾਨ;ਅਵਾਤਰ,ਲੋਗੋ,ਮੂੰਹ;ਪਾਸਵਰਡ;ਚਿਹਰਾ;ਮਾਪਿਆਂ"
-" ਕੋਲ ਕੰਟਰੋਲ;"
+"ਲਾਗਇਨ;ਲੌਗਇਨ;ਨਾਂ;ਨਾਮ;ਫਿੰਗਰ-ਪਰਿੰਟ;ਉਂਗਲ-ਨਿਸ਼ਾਨ;ਅਵਾਤਰ,ਲੋਗੋ,ਮੂੰਹ;ਪਾਸਵਰਡ;ਚਿਹਰਾ;ਮਾਪਿਆਂ ਕੋਲ ਕੰਟਰੋਲ;"
 "ਸਕਰੀਨ ਸਮਾਂ;ਐਪ ਪਾਬੰਦੀਆਂ;ਵੈਬ ਪਾਬੰਦੀਆਂ;ਵਰਤੋ;ਹੱਦ;ਸੀਮ,ਬੱਚੇ;ਜਵਾਕ;ਨਿਆਣੇ;"
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
@@ -8400,177 +4550,8 @@ msgstr "ਵਰਤੋਂਕਾਰ ਖਾਤਿਆਂ ਦਾ ਇੰਤਜ਼ਾਮ"
 msgid "Authentication is required to change user data"
 msgstr "ਵਰਤੋਂਕਾਰ ਡਾਟੇ ਨੂੰ ਬਦਲਣ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਪੁਰਾਣੇ ਨਾਲੋਂ ਵੱਖਰਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "ਕੁਝ ਅੱਖਰ ਤੇ ਨੰਬਰ ਬਦਲ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "ਪਾਸਵਰਡ ਨੂੰ ਕੁਝ ਹੋਰ ਬਦਲਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "ਬਿਨਾਂ ਵਰਤੋਂਕਾਰ ਨਾਂ ਵਾਲਾ ਪਾਸਵਰਡ ਮਜ਼ਬੂਤ ਹੋਵੇਗਾ।"
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "ਆਪਣੇ ਨਾਂ ਨੂੰ ਪਾਸਵਰਡ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਨਾ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "ਪਾਸਵਰਡ ਵਿੱਚ ਦਿੱਤੇ ਕੁਝ ਸ਼ਬਦ ਛੱਡਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "ਆਮ ਸ਼ਬਦਾਂ ਦੀ ਵਰਤੋਂ ਨਾ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "ਮੌਜੂਦਾ ਸ਼ਬਦਾਂ ਨੂੰ ਅੱਗੇ ਪਿੱਛੇ ਕਰਨ ਨੂੰ ਛੱਡ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "ਹੋਰ ਅੰਕ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "ਹੋਰ ਵੱਡੇ ਅੱਖਰ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "ਹੋਰ ਛੋਟੇ ਅੱਖਰ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "ਹੋਰ ਖਾਸ ਅੱਖਰ ਜਿਵੇਂ ਵਿਰਾਮ-ਚਿੰਨ੍ਹ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "ਅੱਖਰ, ਅੰਕ ਅਤੇ ਵਿਰਾਮ-ਚਿੰਨ੍ਹ ਨੂੰ ਮਿਲਾ ਕੇ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "ਇੱਕੋ ਅੱਖਰ ਦੁਹਰਾਉਣ ਨੂੰ ਛੱਡ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"ਇੱਕੋ ਕਿਸਮ ਦੇ ਅੱਖਰ ਮੁੜ-ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ: ਤੁਸੀਂ ਅੱਖਰਾਂ, ਅੰਕਾਂ ਅਤੇ ਵਿਰਾਮ"
-" ਚਿੰਨ੍ਹਾਂ ਨੂੰ ਮਿਲ ਸਕਦੇ ਹੋ।"
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 ਜਾਂ abcd ਕ੍ਰਮ ਛੱਡਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"ਪਾਸਵਰਡ ਹੋਰ ਲੰਮਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ। ਅੱਖਰ, ਅੰਕ ਅਤੇ ਵਿਰਾਮ-ਚਿੰਨ੍ਹ ਨੂੰ ਮਿਲਾ ਕੇ ਵਰਤ ਕੇ"
-" ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "ਵੱਡੇ ਤੇ ਛੋਟੇ ਅੱਖਰ ਮਿਲਾ ਕੇ ਅਤੇ ਇੱਕ ਜਾਂ ਦੋ ਨੰਬਰ ਵਰਤੇ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "ਹੋਰ ਅੱਖਰ, ਨੰਬਰ ਤੇ ਵਿਰਾਮ ਚਿੰਨ੍ਹ ਜੋੜਨ ਨਾਲ ਪਾਸਵਰਡ ਹੋਰ ਵੀ ਮਜ਼ਬੂਤ ਬਣੇਗਾ।"
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "ਪਰਮਾਣਕਿਤਾ ਫੇਲ੍ਹ ਹੋਈ"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਬਹੁਤ ਛੋਟਾ ਹੈ"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਬਹੁਤ ਸਧਾਰਨ ਹੈ"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "ਪੁਰਾਣਾ ਅਤੇ ਨਵੇਂ ਪਾਸਵਰਡ ਇੱਕੋ ਜਿਹੇ ਜਾਪਦੇ ਹਨ"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਤਾਜ਼ਾ ਹੀ ਵਰਤਿਆ ਗਿਆ ਹੈ।"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "ਨਵੇਂ ਪਾਸਵਰਡ ਵਿੱਚ ਅੰਕ ਜਾਂ ਖਾਸ ਹੋਣੇ ਲਾਜ਼ਮੀ ਹਨ"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "ਪੁਰਾਣਾ ਅਤੇ ਨਵੇਂ ਪਾਸਵਰਡ ਇੱਕੋ ਹੀ ਹਨ"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "ਤੁਹਾਡੇ ਪਹਿਲਾਂ ਪਰਮਾਣਿਤ ਹੋਣ ਕਰਕੇ ਤੁਹਾਡਾ ਪਾਸਵਰਡ ਬਦਲਿਆ ਜਾ ਚੁੱਕਿਆ ਹੈ!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "ਨਵੇਂ ਪਾਸਵਰਡ 'ਚ ਲੋੜ ਮੁਤਾਬਕ ਵੱਖ ਵੱਖ ਕਿਸਮ ਦੇ ਅੱਖਰ ਨਹੀਂ ਹਨ"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "ਅਣਜਾਣ ਗਲਤੀ"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"ਵਰਤੋਂਕਾਰ ਨਾਂ ਵਿੱਚ ਅਕਸਰ ਕੇਵਲ ਅੰਗਰੇਜ਼ੀ ਦੇ ਛੋਟੇ ਅੱਖਰ (a-z), ਅੰਕ, ਅਤੇ ਅੱਗੇ ਦਿੱਤੇ"
-" ਅੱਖਰ ਹੋ ਸਕਦੇ ਹਨ: - __"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "ਅਫ਼ਸੋਸ ਹੈ ਪਰ ਉਹ ਵਰਤੋਂਕਾਰ ਨਾਂ ਉਪਲਬਧ ਨਹੀਂ ਹੈ। ਹੋਰ ਵਰਤ ਕੇ ਵੇਖੋ।"
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ ਬਹੁਤ ਲੰਮਾ ਹੈ।"
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:40
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "ਬਟਨ ਮਿਲਾਉ"
 
@@ -8583,8 +4564,7 @@ msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"ਸ਼ਾਰਟਕੱਟ ਸੋਧਣ ਲਈ, ”ਕੀ-ਸਟੋਰਕ ਭੇਜੋ” ਕਾਰਵਾਈ ਚੁਣੋ, ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਬਟਨ ਦੱਬੋ ਅਤੇ"
-" ਨਵੀਆਂ ਸਵਿੱਚਾਂ ਲਈ "
+"ਸ਼ਾਰਟਕੱਟ ਸੋਧਣ ਲਈ, ”ਕੀ-ਸਟੋਰਕ ਭੇਜੋ” ਕਾਰਵਾਈ ਚੁਣੋ, ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਬਟਨ ਦੱਬੋ ਅਤੇ ਨਵੀਆਂ ਸਵਿੱਚਾਂ ਲਈ "
 "ਹੋਲਡ ਕਰਕੇ ਰੱਖੋ ਜਾਂ ਬੈਕਸਪੇਸ ਸਾਫ਼ ਕਰਨ ਲਈ ਵਰਤੋਂ।"
 
 #: panels/wacom/button-mapping.ui:66
@@ -8596,54 +4576,16 @@ msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr ""
-"ਟਾਰਗੇਟ ਮਾਰਕਰ ਲਈ ਟੈਪ ਕਰੋ ਜਿਵੇਂ ਕਿ ਉਹ ਸਕਰੀਨ ਉੱਤੇ ਟੇਬਲੇਟ ਨੂੰ ਕੈਲੀਬਰੇਟ ਕਰਨ ਲਈ"
-" ਵੇਖਾਈ ਦਿੰਦਾ ਹੈ।"
+"ਟਾਰਗੇਟ ਮਾਰਕਰ ਲਈ ਟੈਪ ਕਰੋ ਜਿਵੇਂ ਕਿ ਉਹ ਸਕਰੀਨ ਉੱਤੇ ਟੇਬਲੇਟ ਨੂੰ ਕੈਲੀਬਰੇਟ ਕਰਨ ਲਈ ਵੇਖਾਈ ਦਿੰਦਾ ਹੈ।"
 
 #: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "ਮਿਸ-ਕਲਿੱਕ ਮਿਲਿਆ, ਮੁੜ-ਚਾਲੂ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "ਬਟਨ %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "ਐਪਲੀਕੇਸ਼ਨ ਪਰਿਭਾਸ਼ਿਤ"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "ਕੀਸਟਰੋਕ ਭੇਜੋ"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "ਮਾਨੀਟਰ ਬਦਲੋ"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "ਸਕਰੀਨ ਉੱਤੇ ਮਦਦ ਵੇਖਾਓ"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "ਟੇਬਲੇਟ ਲੈਪਟਾਪ ਪੈਨਲ ਉੱਤੇ ਮਾਊਂਟ ਹੈ"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "ਟੇਬਲੇਟ ਬਾਹਰੀ ਮਾਨੀਟਰ ਉੱਤੇ ਮਾਊੰਟ ਹੈ"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "ਬਾਹਰੀ ਟੇਬਲੇਟ ਡਿਵਾਈਸ"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "ਸਾਰੇ ਡਿਸਪਲੇਅ"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "ਬਾਹਰੀ ਪੈਡ ਡਿਵਾਈਸ"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8739,22 +4681,6 @@ msgstr "ਸੱਜਾ ਮਾਊਂਸ ਬਟਨ ਕਲਿੱਕ"
 msgid "Forward"
 msgstr "ਅੱਗੇ"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "ਦਬਾਓ, ਟੇਡ ਤੇ ਮੌਜੂਦ ਸਲਾਈਡਰ ਨਾਲ ਏਅਰਬਰੱਸ਼ ਸਟਾਈਲਸ"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "ਦਬਾਓ, ਟੇਡ ਤੇ ਘੁੰਮਾਉਣ ਨਾਲ ਏਅਰਬਰੱਸ਼ ਸਟਾਈਲਸ"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "ਦਬਾਓ ਤੇ ਟੇਡ ਨਾਲ ਮਿਆਰੀ ਸਟਾਈਲਸ"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "ਦਬਾਓ ਨਾਲ ਮਿਆਰੀ ਸਟਾਈਲਸ"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "ਵਾਕੋਮ ਟੇਬਲੇਟ"
@@ -8763,54 +4689,97 @@ msgstr "ਵਾਕੋਮ ਟੇਬਲੇਟ"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "ਗਰਾਫਿਕਸ ਟੇਬਲਟ ਲਈ ਬਟਨ ਮਿਲਾਨ ਕਰੋ ਅਤੇ ਸਟਾਇਲਸ ਸੰਵੇਦਨਸ਼ੀਲਤਾ ਅਡਜੱਸਟ ਕਰੋ"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;ਟੇਬਲੇਟ;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "...ਨਵਾਂ ਸ਼ਾਰਟਕੱਟ"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "ਲੇਆਉਟ"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "ਮੁੱਢਲੀ ਵਿੰਡੋ"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "ਸੈਕੰਡਰੀ ਕਲਿੱਕ ਦੀ ਨਕਲ(_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "ਵਿੰਡੋ"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "ਪੂਰਾ ਕਰਨ ਲਈ ਠੀਕ ਹੈ ਦਬਾਓ।"
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "ਟੋਨਰ ਘੱਟ ਹੈ"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "ਸੈਕੰਡਰੀ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "ਵਿੰਡੋ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "ਉਤਪਾਦਨ ਤੇ ਬਹੁ-ਕੰਮਕਾਜ ਲਈ ਤਜਰੀਹਾਂ ਦਾ ਇੰਤਜ਼ਾਮ ਕਰੋ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "ਐਕਸੈਸ ਪੁਆਇੰਟ"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "ਸ਼ਾਮਲ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "ਸੰਭਾਲੋ(_S)"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "ਕਾਰਵਾਈ ਰੱਦ ਕੀਤੀ ਗਈ ਸੀ"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>ਗਲਤੀ:</b> ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਪਹੁੰਚ ਉੱਤੇ ਪਾਬੰਦੀ ਹੈ"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>ਗਲਤੀ:</b> ਮੋਬਾਈਲ ਯੰਤਰ ਗ਼ਲਤੀ"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "ਰਜਿਸਟਰ ਨਹੀਂ ਹੈ"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "ਰਜਿਸਟਰ ਹੈ"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "ਰੋਮਿੰਗ"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "ਖੋਜ ਜਾਰੀ ਹੈ"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "ਇਨਕਾਰ"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8840,104 +4809,13 @@ msgstr "ਖੁਦ ਦਾ ਨੰਬਰ"
 msgid "Device Details"
 msgstr "ਡਿਵਾਈਸ ਦੇ ਵੇਰਵੇ"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "ਨਿਰਮਾਤਾ"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "ਫਿਰਮਵੇਅਰ ਵਰਜ਼ਨ"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "ਸਿਰਫ਼ 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "ਸਿਰਫ਼ 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "ਸਿਰਫ਼ 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (ਤਰਜੀਹੀ)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (ਤਰਜੀਹੀ), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (ਤਰਜੀਹੀ), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (ਤਰਜੀਹੀ)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (ਤਰਜੀਹੀ), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (ਤਰਜੀਹੀ)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (ਤਰਜੀਹੀ), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (ਤਰਜੀਹੀ)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (ਤਰਜੀਹੀ), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "ਅਣਪਛਾਤਾ"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "ਸਿਮ ਕਾਰਡ ਅਣ-ਲਾਕ ਕਰੋ"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "ਅਣ-ਲਾਕ ਕਰੋ"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "ਸਿਮ %d ਲਈ ਪਿੰਨ ਕੋਡ ਦਿਓ"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "ਆਪਣੇ ਸਿਮ ਨੂੰ ਅਣ-ਲਾਕ ਕਰਨ ਲਈ ਪਿੰਨ ਦਿਓ"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "ਸਿਮ %d ਲਈ PUK ਕੋਡ ਦਿਓ"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "ਆਪਣਾ ਸਿਮ ਕਾਰਡ ਅਣ-ਲਾਕ ਕਰਨ ਲਈ PUK ਦਿਓ"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8952,26 +4830,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "ਤੁਹਾਡੇ ਕੋਲ %u ਕੋਸ਼ਿਸ਼ ਬਾਕੀ ਹੈ"
 msgstr[1] "ਤੁਹਾਡੇ ਕੋਲ %u ਕੋਸ਼ਿਸ਼ਾਂ ਬਾਕੀ ਹਨ"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "ਗਲਤ ਪਾਸਵਰਡ ਦਿੱਤਾ ਗਿਆ।"
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK ਕੋਡ 8 ਅੰਕਾਂ ਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "ਨਵਾਂ ਪਿੰਨ ਦਿਓ"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "ਪਿੰਨ ਕੋਡ 4-8 ਅੰਕਾਂ ਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "…ਅਣ-ਲਾਕ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9029,94 +4887,6 @@ msgstr "ਪਿੰਨ ਨਾਲ ਸਿਮ ਲਾਕ ਕਰੋ"
 msgid "M_odem Details"
 msgstr "ਮਾਡਮ ਦੇ ਵੇਰਵਾ(_o)"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "ਫ਼ੋਨ ਅਸਫ਼ਲ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "ਫ਼ੋਨ ਲਈ ਕੋਈ ਕਨੈਕਸ਼ਨ ਨਹੀਂ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "ਕਾਰਵਾਈ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "ਕਾਰਵਾਈ ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "ਸਿਮ ਨਹੀਂ ਪਾਇਆ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "ਸਿਮ ਪਿੰਨ ਚਾਹੀਦਾ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "ਸਿਮ PUK required"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "ਸਿਮ ਅਸਫ਼ਲ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "ਸਿਮ ਰੁੱਝਿਆ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "ਗ਼ਲਤ ਪਾਸਵਰਡ"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIM ਪਿੰਨ2 ਚਾਹੀਦਾ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIM PUK2 ਚਾਹੀਦਾ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "ਨਹੀਂ ਲੱਭਿਆ"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "ਕੋਈ ਨੈੱਟਵਰਕ ਸੇਵਾ ਨਹੀਂ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "ਨੈੱਟਵਰਕ ਸਮਾਂ-ਸਮਾਪਤ"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS ਸੇਵਾਵਾਂ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "ਇਸ ਟਿਕਾਣੇ ਉੱਤੇ ਰੋਮਿੰਗ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "ਅਣਦੱਸੀ GPRS ਗ਼ਲਤੀ"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "ਕੋਈ ਗਲਤੀ ਨਹੀਂ"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "ਕਾਰਵਾਈ ਰੱਦ ਕੀਤੀ"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "ਪਹੁੰਚ ਲਈ ਪਾਬੰਦੀ ਹੈ"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "ਅਣਪਛਾਤੀ ਗਲਤੀ"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "ਨੈੱਟਵਰਕ ਢੰਗ"
@@ -9132,11 +4902,6 @@ msgstr "ਨੈੱਟਵਰਕ ਚੁਣੋ"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "ਨੈੱਟਵਰਕ ਪੂਰਕਾਂ ਨੂੰ ਤਾਜ਼ਾ ਕਰੋ"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "ਸਿਮ %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9194,7 +4959,6 @@ msgstr "ਮੋਬਾਈਲ ਨੈੱਟਵਰਕ"
 msgid "Configure Telephony and mobile data connections"
 msgstr "ਟੈਲੀਫ਼ੋਨੀ ਤੇ ਮੋਬਾਈਲ ਡਾਟਾ ਕਨੈਕਸ਼ਨਾਂ ਦੀ ਸੰਰਚਨਾ ਕਰੋ"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "ਸੈਲੂਲਰ;ਵੈਨ;ਵੈੱਨ;ਟੈਲੀਫ਼ੋਨੀ;ਸਿਮ;ਮੋਬਾਈਲ;ਮੋਬਾਇਲ;"
@@ -9211,42 +4975,13 @@ msgstr "ਸੈਟਿੰਗਾਂ ਤੁਹਾਡੇ ਸਿਸਟਮ ਦੀ ਸ�
 msgid "The GNOME Project"
 msgstr "ਗਨੋਮ ਪਰੋਜੈਕਟ"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "ਵਰਜ਼ਨ ਨੰਬਰ ਦਿਖਾਓ"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "ਵੱਧ ਜਾਣਕਾਰੀ ਮੋਡ ਚਾਲੂ"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "ਸਤਰ ਲਈ ਖੋਜੋ"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "ਸੰਭਵ ਪੈਨਲ ਨਾਂ ਵੇਖਾਉ ਅਤੇ ਬੰਦ ਕਰੋ"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "ਵੇਖਾਉਣ ਲਈ ਪੈਨਲ"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
 #: shell/cc-panel-list.ui:18
-#| msgid "Setting new driver…"
 msgid "Settings categories"
 msgstr "ਸੈਟਿੰਗਾਂ ਕੈਟਾਗਰੀਆਂ"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "ਪਰਦੇਦਾਰੀ"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "ਉਪਲੱਬਧ ਪੈਨਲ:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9266,8 +5001,7 @@ msgid ""
 "may experience incorrect system behavior, data loss, and other unexpected "
 "issues. "
 msgstr ""
-"ਸੈਟਿੰਗਾਂ ਦਾ ਇਹ ਵਰਜ਼ਨ ਡਿਵੈਲਪਮੈਂਟ ਮਕਸਦ ਲਈ ਹੀ ਵਰਤਿਆ ਜਾਣਾ ਚਾਹੀਦਾ ਹੈ। ਤੁਹਾਨੂੰ ਕੁਝ"
-" ਗਲਤ ਸਿਸਟਮ "
+"ਸੈਟਿੰਗਾਂ ਦਾ ਇਹ ਵਰਜ਼ਨ ਡਿਵੈਲਪਮੈਂਟ ਮਕਸਦ ਲਈ ਹੀ ਵਰਤਿਆ ਜਾਣਾ ਚਾਹੀਦਾ ਹੈ। ਤੁਹਾਨੂੰ ਕੁਝ ਗਲਤ ਸਿਸਟਮ "
 "ਰਵੱਈਏ, ਡਾਟਾ ਗੁਆਚਣ ਅਤੇ ਹੋਰ ਅਚਨਚੇਤ ਮਸਲਿਆਂ ਦਾ ਸਾਹਮਣਾ ਕਰਨਾ ਪੈ ਸਕਦਾ ਹੈ।"
 
 #: shell/cc-window.ui:164
@@ -9304,7 +5038,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "ਖੋਜ ਰੱਦ ਕਰੋ"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "ਮੇਰੀ ਪਸੰਦ;ਸੈਟਿੰਗ;"
@@ -9318,8 +5051,7 @@ msgid ""
 "The identifier for the last Settings panel to be opened. Unrecognised values "
 "will be ignored and the first panel in the list selected."
 msgstr ""
-"ਆਖਰੀ ਸੈਟਿੰਗਾਂ ਪੈਨਲ ਨੂੰ ਖੋਲ੍ਹਣ ਲਈ ਪਛਾਣਕਰਤਾ ਹੈ। ਬੇਪਛਾਣ ਮੁੱਲਾਂ ਨੂੰ ਅਣਡਿੱਠਾ ਕੀਤਾ"
-" ਜਾਵੇਗਾ ਅਤੇ ਸੂਚੀ "
+"ਆਖਰੀ ਸੈਟਿੰਗਾਂ ਪੈਨਲ ਨੂੰ ਖੋਲ੍ਹਣ ਲਈ ਪਛਾਣਕਰਤਾ ਹੈ। ਬੇਪਛਾਣ ਮੁੱਲਾਂ ਨੂੰ ਅਣਡਿੱਠਾ ਕੀਤਾ ਜਾਵੇਗਾ ਅਤੇ ਸੂਚੀ "
 "ਵਿੱਚੋਂ ਪਹਿਲਾਂ ਪੈਨਲ ਚੁਣਿਆ ਜਾਂਦਾ ਹੈ।"
 
 #: shell/org.gnome.Settings.gschema.xml:13
@@ -9329,8 +5061,7 @@ msgstr "ਜਦੋਂ ਸੈਟਿੰਗਾਂ ਦੀ ਡਿਵੈਲਪਮੈਂ
 #: shell/org.gnome.Settings.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
-msgstr ""
-"ਕੀ ਸੈਟਿੰਗਾਂ ਨੂੰ ਚੇਤਾਵਨੀ ਦਿਖਾਉਣੀ ਚਾਹੀਦੀ ਹੈ, ਜਦੋਂ ਡਿਵੈਲਪਮੈਂਟ ਬਿਲਡ ਚੱਲਦਾ ਹੋਵੇ।"
+msgstr "ਕੀ ਸੈਟਿੰਗਾਂ ਨੂੰ ਚੇਤਾਵਨੀ ਦਿਖਾਉਣੀ ਚਾਹੀਦੀ ਹੈ, ਜਦੋਂ ਡਿਵੈਲਪਮੈਂਟ ਬਿਲਡ ਚੱਲਦਾ ਹੋਵੇ।"
 
 #: shell/org.gnome.Settings.gschema.xml:20
 msgid "Initial state of the window"
@@ -9340,11 +5071,8 @@ msgstr "ਵਿੰਡੋ ਦੀ ਪਹਿਲੀ ਸਥਿਤੀ"
 msgid ""
 "A tuple containing the initial width, height and maximized state of the "
 "application window."
-msgstr ""
-"ਟਪਲ ਐਪਲੀਕੇਸ਼ਨ ਵਿੰਡੋ ਦੀ ਸ਼ੁਰੂਆਤੀ ਚੌੜਾਈ, ਉਚਾਈ ਤੇ ਵੱਧ ਤੋਂ ਵੱਧ ਹਾਲਤ ਰੱਖਦਾ ਹੈ।"
+msgstr "ਟਪਲ ਐਪਲੀਕੇਸ਼ਨ ਵਿੰਡੋ ਦੀ ਸ਼ੁਰੂਆਤੀ ਚੌੜਾਈ, ਉਚਾਈ ਤੇ ਵੱਧ ਤੋਂ ਵੱਧ ਹਾਲਤ ਰੱਖਦਾ ਹੈ।"
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9352,8 +5080,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u ਆਉਟਪੁੱਟ"
 msgstr[1] "%u ਆਉਟਪੁੱਟ"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9361,9 +5087,3218 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u ਇੰਪੁੱਟ"
 msgstr[1] "%u ਇੰਪੁੱਟ"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
+#~ msgid "System Bus"
+#~ msgstr "ਸਿਸਟਮ ਬੱਸ"
+
+#~ msgid "Full access"
+#~ msgstr "ਪੂਰੀ ਪਹੁੰਚ"
+
+#~ msgid "Session Bus"
+#~ msgstr "ਸ਼ੈਸ਼ਨ ਬੱਸ"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "/dev ਲਈ ਪੂਰੀ ਪਹੁੰਚ"
+
+#~ msgid "Has network access"
+#~ msgstr "ਨੈੱਟਵਰਕ ਪਹੁੰਚ ਹੈ"
+
+#~ msgid "Home"
+#~ msgstr "ਘਰ"
+
+#~ msgid "Read-only"
+#~ msgstr "ਕੇਵਲ-ਪੜ੍ਹਨ ਲਈ"
+
+#~ msgid "File System"
+#~ msgstr "ਫਾਇਲ ਸਿਸਟਮ"
+
+#~ msgid "Can change settings"
+#~ msgstr "ਸੈਟਿੰਗਾਂ ਬਦਲ ਸਕਦੇ ਹਨ"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s ਵਿੱਚ ਅੱਗੇ ਦਿੱਤੀਆਂ ਇਜਾਜ਼ਤਾਂ ਪਹਿਲਾਂ ਹੀ ਹਨ। ਇਹਨਾਂ ਨੂੰ ਬਦਲਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਹੈ। ਜੇ ਤੁਸੀਂ ਇਹ "
+#~ "ਇਜਾਜ਼ਤਾਂ ਬਾਰੇ ਫ਼ਿਕਰ ਕਰਦੇ ਹੋ ਤਾਂ ਇਸ ਐਪਲੀਕੇਸ਼ਨ ਨੂੰ ਹਟਾਉਣ ਬਾਰੇ ਵਿਚਾਰ ਕਰੋ।"
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u ਫਾਇਲ ਤੇ ਲਿੰਕ ਕਿਸਮ, ਜੋ ਕਿ ਐਪ ਵਲੋਂ ਖੋਲ੍ਹੇ ਜਾਂਦੇ ਹਨ"
+#~ msgstr[1] "%u ਫਾਇਲ ਤੇ ਲਿੰਕ ਕਿਸਮਾਂ, ਜੋ ਕਿ ਐਪ ਵਲੋਂ ਖੋਲ੍ਹੇ ਜਾਂਦੇ ਹਨ"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> ਨੂੰ ਫਾਇਲਾਂ ਤੇ ਲਿੰਕਾਂ ਦੀਆਂ ਹੇਠ ਦਿੱਤੀਆਂ ਕਿਸਮਾਂ ਖੋਲ੍ਹਣ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ।"
+
+#, c-format
+#~| msgid "%s of disk space used"
+#~ msgid "%s of disk space used."
+#~ msgstr "%s ਡਿਸਕ ਥਾਂ ਵਰਤੀ ਗਈ।"
+
+#~ msgid "Select a picture"
+#~ msgstr "ਤਸਵੀਰ ਚੁਣੋ"
+
+#~ msgid "_Open"
+#~ msgstr "ਖੋਲ੍ਹੋ(_O)"
+
+#~ msgid "multiple sizes"
+#~ msgstr "ਕਈ ਆਕਾਰ"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "ਕੋਈ ਡੈਸਕਟਾਪ ਬੈਕਗਰਾਊਂਡ ਨਹੀਂ"
+
+#~ msgid "Current background"
+#~ msgstr "ਮੌਜੂਦਾ ਬੈਕਗਰਾਊਂਡ"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "ਆਪਣੇ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਵਰਗ ਉੱਤੇ ਰੱਖੋ ਅਤੇ ”ਸ਼ੁਰੂ” ਨੂੰ ਦੱਬੋ।"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "ਆਪਣੇ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਕੈਲੀਬਰੇਸ਼ਨ ਸਥਿਤੀ ਉਤੇ ਲੈ ਜਾਉ ਅਤੇ ”ਜਾਰੀ ਰੱਖੋ” ਦੱਬੋ"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "ਆਪਣੇ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਤਲ ਸਥਿਤੀ ਉਤੇ ਲੈ ਜਾਉ ਅਤੇ ”ਜਾਰੀ ਰੱਖੋ” ਦੱਬੋ"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "ਲੈਪਟਾਪ ਢੱਕਣ ਬੰਦ"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "ਅੰਦਰੂਨੀ ਗਲਤੀ ਆਈ ਹੈ, ਜਿਸ ਤੋਂ ਉਭਰਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।"
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਲਈ ਲੋੜੀਂਦੇ ਟੂਲ ਇੰਸਟਾਲ ਨਹੀਂ ਹਨ।"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "ਪਰੋਫਾਇਲ ਤਿਆਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "ਟਾਰਗੇਟ ਚਿੱਟਾ-ਬਿੰਦੂ ਪ੍ਰਾਪਤੀ ਯੋਗ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "Complete!"
+#~ msgstr "ਪੂਰੇ ਹੋਏ!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਫੇਲ੍ਹ ਹੋਈ!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "ਤੁਸੀਂ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਹਟਾ ਸਕਦੇ ਹੋ।"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਚੱਲਣ ਦੇ ਦੌਰਾਨ ਛੇੜੋ ਨਾ"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "ਲੈਪਟਾਪ ਸਕਰੀਨ"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "ਬਿਲਟ-ਇਨ ਵੈਬਕੈਮ"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s ਮਾਨੀਟਰ"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s ਸਕੈਨਰ"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s ਕੈਮਰਾ"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s ਪਰਿੰਟਰ"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s ਵੈੱਬਕੈਮ"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s ਲਈ ਰੰਗ ਇੰਤਜ਼ਾਮ ਸਮਰੱਥ ਕਰੋ"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s ਲਈ ਰੰਗ ਪਰੋਫਾਇਲ ਵੇਖੋ"
+
+#~ msgid "Not calibrated"
+#~ msgstr "ਕੈਲੀਬਰੇਟ ਨਹੀਂ"
+
+#~ msgid "Default: "
+#~ msgstr "ਡਿਫਾਲਟ: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "ਰੰਗ-ਸਪੇਸ: "
+
+#~ msgid "Test profile: "
+#~ msgstr "ਪਰੋਫਾਇਲ ਟੈਸਟ: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC ਪਰੋਫਾਇਲ ਫਾਇਲ ਚੁਣੋ"
+
+#~ msgid "_Import"
+#~ msgstr "ਇੰਪੋਰਟ(_I)"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "ਸਹਾਇਕ ICC ਪਰੋਫਾਇਲ"
+
+#~ msgid "All files"
+#~ msgstr "ਸਭ ਫਾਇਲਾਂ"
+
+#~ msgid "Save Profile"
+#~ msgstr "ਪਰੋਫਾਇਲ ਸੰਭਾਲੋ"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "ਚੁਣੇ ਜੰਤਰ ਲਈ ਇੱਕ ਰੰਗ ਪਰੋਫਾਇਲ ਬਣਾਉ"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "ਮਾਪ ਜੰਤਰ ਖੋਜਿਆ ਨਹੀਂ ਗਿਆ ਹੈ। ਚੈੱਕ ਕਰੋ ਕਿ ਇਹ ਚਾਲੂ ਹੈ ਅਤੇ ਠੀਕ ਤਰ੍ਹਾਂ ਕੂਨੈਕਟ ਕੀਤਾ ਹੋਇਆ ਹੈ।"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "ਮਾਪ ਜੰਤਰ ਪਰਿੰਟਿੰਗ ਪਰੋਫਾਇਲਿੰਗ ਲਈ ਸਹਾਇਕ ਨਹੀਂ।"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "ਜੰਤਰ ਕਿਸਮ ਹਾਲੇ ਸਹਾਇਕ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "Standard Space"
+#~ msgstr "ਸਟੈਂਡਰਡ ਥਾਂ"
+
+#~ msgid "Test Profile"
+#~ msgstr "ਪਰੋਫਾਇਲ ਟੈਸਟ"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "ਆਟੋਮੈਟਿਕ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "ਘੱਟ ਕੁਆਲਟੀ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "ਮੱਧਮ ਕੁਆਲਟੀ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "ਵਧਿਆ ਕੁਆਲਟੀ"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "ਡਿਫਾਲਟ RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "ਡਿਫਾਲਟ CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "ਡਿਫਾਲਟ ਸਲੇਟੀ"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "ਵੇਂਡਰ ਵਲੋਂ ਦਿੱਤਾ ਫੈਕਟਰੀ ਕੈਲੀਬਰੇਸ਼ਨ ਡਾਟਾ"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "ਇਹ ਪਰੋਫਾਇਲ ਲਈ ਪੂਰੀ-ਸਕਰੀਨ ਡਿਸਪਲੇਅ ਸੋਧ ਸੰਭਵ ਨਹੀਂ"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "ਇਹ ਪਰੋਫਾਇਲ ਹੁਣ ਠੀਕ ਨਹੀਂ ਰਿਹਾ ਹੋ ਸਕਦਾ ਹੈ"
+
+#~ msgid "Other…"
+#~ msgstr "…ਹੋਰ"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#~ msgid "Today"
+#~ msgstr "ਅੱਜ"
+
+#~ msgid "Yesterday"
+#~ msgstr "ਕੱਲ੍ਹ"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d ਘੰਟਾ"
+#~ msgstr[1] "%d ਘੰਟੇ"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d ਮਿੰਟ"
+#~ msgstr[1] "%d ਮਿੰਟ"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d ਸਕਿੰਟ"
+#~ msgstr[1] "%d ਸਕਿੰਟ"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "ਹਾਟਸਪਾਟ"
+
+#~ msgid "24-hour"
+#~ msgstr "24-ਘੰਟੇ"
+
+#~ msgid "AM / PM"
+#~ msgstr "ਸਵੇਰ/ਆਥਣ"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "ਤਕਨੀਕੀ ਸਮੱਸਿਆਵਾਂ ਬਾਰੇ ਰਿਪੋਰਟਾਂ ਭੇਜਣ ਨਾਲ ਸਾਨੂੰ %s ਸੁਧਾਰਨ ਲਈ ਮਦਦ ਮਿਲਦੀ ਹੈ। ਰਿਪੋਰਟ "
+#~ "ਅਣਪਛਾਤੇ ਰੂਪ ਵਿੱਚ ਭੇਜੀਆਂ ਜਾਂਦੀਆਂ ਹਨ ਅਤੇ ਨਿੱਜੀ ਡਾਟੇ ਨੂੰ ਹਟਾਇਆ ਜਾਂਦਾ ਹੈ। %s"
+
+#~ msgid "On"
+#~ msgstr "ਚਾਲੂ"
+
+#~ msgid "Off"
+#~ msgstr "ਬੰਦ"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "ਬਦਲਾਅ ਲਾਗੂ ਕਰਨੇ ਹਨ?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "ਤਬਦੀਲੀਆਂ ਲਾਗੂ ਨਹੀਂ ਕੀਤੀਆਂ ਜਾ ਸਕਦੀਆਂ"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "ਇਹ ਹਾਰਡਵੇਅਰ ਰੋਕਾਂ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "ਲੈਂਡਸਕੇਪ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "ਪੋਰਟਰੇਟ ਸੱਜੇ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "ਪੋਰਟਰੇਟ ਖੱਬੇ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "ਲੈਂਡਸਕੇਪ (ਪਲਟਿਆ)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "ਸਕਿਉਰ ਬੂਟ ਸਰਗਰਮ ਹੈ"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "ਸਕਿਉਰ ਬੂਟ ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਨੂੰ ਲੋਡ ਹੋਣ ਤੋਂ ਰੋਕਦਾ ਹੈ। ਇਹ ਇਸ ਵੇਲੇ ਚਾਲੂ "
+#~ "ਅਤੇ ਠੀਕ ਤਰ੍ਹਾਂ ਕੰਮ ਕਰਦਾ ਹੈ।"
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "ਸਕਿਉਰ ਬੂਟ ਨਾਲ ਸਮੱਸਿਆਵਾਂ ਹਨ"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "ਸਕਿਉਰ ਬੂਟ ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਨੂੰ ਲੋਡ ਹੋਣ ਤੋਂ ਰੋਕਦਾ ਹੈ। ਇਹ ਇਸ ਵੇਲੇ ਚਾਲੂ "
+#~ "ਕੀਤਾ ਹੋਇਆ ਹੈ, ਪਰ ਗ਼ੈਰ-ਵਾਜਬ ਕੁੰਜੀ ਦੇ ਕਰਕੇ ਕੰਮ ਨਹੀਂ ਕਰੇਗਾ।"
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "ਸਕਿਉਰ ਬੂਟ ਸਮੱਸਿਆਵਾਂ ਨੂੰ ਅਕਸਰ ਤੁਹਾਡੇ ਕੰਪਿਊਟਰ ਦੇ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ (BIOS) ਵਿੱਚੋਂ  ਹੱਲ਼ "
+#~ "ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ ਅਤੇ ਤੁਹਾਡੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਵਲੋਂ ਇਹ ਹੱਲ ਕਰਨ ਬਾਰੇ ਜਾਣਕਾਰੀ ਦਿੱਤੀ ਗਈ ਹੋ "
+#~ "ਸਕਦੀ ਹੈ।"
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr "ਸਹਾਇਤਾ ਲਈ ਆਪਣੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਜਾਂ IT ਸਹਾਇਤਾ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "ਸਕਿਉਰ ਬੂਟ ਬੰਦ ਕੀਤਾ ਹੈ"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "ਸਕਿਉਰ ਬੂਟ ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਨੂੰ ਲੋਡ ਹੋਣ ਤੋਂ ਰੋਕਦਾ ਹੈ। ਇਹ ਇਸ ਵੇਲੇ ਬੰਦ "
+#~ "ਕੀਤਾ ਹੋਇਆ ਹੈ।"
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "ਸਕਿਉਰ ਬੂਟ ਨੂੰ ਅਕਸਰ ਤੁਹਾਡੇ ਕੰਪਿਊਟਰ ਦੇ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ (BIOS) ਵਿੱਚ ਚਾਲੂ ਕੀਤਾ ਜਾ "
+#~ "ਸਕਦਾ ਹੈ। ਮਦਦ ਲਈ ਆਪਣੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਜਾਂ IT ਸਹਾਇਤਾ ਦੇਣ ਵਾਲੇ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
+#~| msgid "Password"
+#~ msgid "Passed"
+#~ msgstr "ਪਾਸ ਹੈ"
+
+#~| msgid "PPP failed"
+#~ msgid "Failed"
+#~ msgstr "ਫੇਲ੍ਹ ਹੈ"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "ਡਿਵਾਈਸ HSI ਪੱਧਰ %d ਲਈ ਤਸਦੀਕ ਹੈ"
+
+#~| msgid "Security Level"
+#~ msgid "Security Level 0"
+#~ msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "ਇਹ ਡਿਵਾਈਸ ਨੂੰ ਕਿਸੇ ਵੀ ਹਾਰਡਵੇਅਰ ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਲਈ ਸੁਰੱਖਿਆ ਨਹੀਂ ਹੈ। ਇਹ ਹਾਰਡਵੇਅਰ ਜਾਂ "
+#~ "ਫਿਰਮਵੇਅਰ ਸੰਰਚਨਾ ਨਾਲ ਮਸਲਾ ਹੋਣ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ। ਤੁਹਾਨੂੰ ਆਪਣੇ ਆਈ.ਟੀ. ਸਹਾਇਤਾ ਦੇਣ ਨਾਲ "
+#~ "ਸੰਪਰਕ ਕਰਨ ਦੀ ਸਿਫਾਰਸ਼ ਕੀਤੀ ਜਾਂਦੀ ਹੈ।"
+
+#~| msgid "Security Level"
+#~ msgid "Security Level 1"
+#~ msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "ਇਸ ਡਿਵਾਈਸ ਨੂੰ ਹਾਰਡਵੇਅਰ ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਲਈ ਘੱਟੋ-ਘੱਟ ਸੁਰੱਖਿਆ ਹੈ। ਇਹ ਡਿਵਾਈਸ ਸੁਰੱਖਿਆ ਦਾ ਸਭ ਤੋਂ "
+#~ "ਘੱਟ ਪੱਧਰ ਹੈ ਅਤੇ ਸਿਰਫ਼ ਸਰਲ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਤੋਂ ਹੀ ਸੁਰੱਖਿਆ ਦਿੰਦੀ ਹੈ।"
+
+#~| msgid "Security Level"
+#~ msgid "Security Level 2"
+#~ msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "ਇਹ ਡਿਵਾਈਸ ਨੂੰ ਹਾਰਡਵੇਅਰ ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਵਿਰੁਧ ਮੁ਼ੱਢਲੀ ਸੁਰੱਖਿਆ ਹੈ। ਇਹ ਕੁਝ ਆਮ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਤੋਂ "
+#~ "ਸੁਰੱਖਿਆ ਦਿੰਦੀ ਹੈ।"
+
+#~| msgid "Security Level"
+#~ msgid "Security Level 3"
+#~ msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "ਇਸ ਡਿਵਾਈਸ ਨੂੰ ਹਾਰਡਵੇਅਰ ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਲਈ ਵਾਧਾ ਕੀਤੀ ਸੁਰੱਖਿਆ ਹੈ। ਇਹ ਡਿਵਾਈਸ ਸੁਰੱਖਿਆ ਦਾ "
+#~ "ਸਭ ਤੋਂ ਵੱਧ ਪੱਧਰ ਹੈ ਅਤੇ ਮਾਹਰ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਤੋਂ ਹੀ ਸੁਰੱਖਿਆ ਦਿੰਦੀ ਹੈ।"
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "ਇਸ ਡਿਵਾਈਸ ਲਈ ਸੁਰੱਖਿਆ ਪੱਧਰ ਮੌਜੂਦ ਨਹੀਂ ਹਨ।"
+
+#~| msgid ""
+#~| "For help, contact your hardware manufacturer or IT support provider."
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr "ਸੁਰੱਖਿਆ ਅੱਪਡੇਟਾਂ ਬਾਰੇ ਮਦਦ ਵਾਸਤੇ ਆਪਣੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "ਇਸ ਮਸਲੇ ਨੂੰ ਡਿਵਾਈਸ ਦੇ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਜਾਂ ਸਹਾਇਤਾ ਟੈਕਨੀਸ਼ੀਅਨ ਵਲੋਂ ਹੱਲ ਕਰਨਾ "
+#~ "ਸੰਭਵ ਹੈ।"
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr "ਇਸ ਮਸਲੇ ਨੂੰ ਡਿਵਾਈਸ ਦੇ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਹੱਲ ਕਰਨਾ ਸੰਭਵ ਹੈ।"
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "ਕਿਸੇ ਸਹਾਇਤਾ ਟੈਕਨੀਸ਼ੀਅਨ ਵਲੋਂ ਇਹ ਮਸਲੇ ਨੂੰ ਹੱਲ਼ ਕਰਨਾ ਸੰਭਵ ਹੈ।"
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "ਜਦੋਂ ਡਿਵਾਈਸ ਸ਼ੁਰੂ ਹੁੰਦਾ ਹੈ ਤਾਂ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਤੋਂ ਸੁਰੱਖਿਅਤ ਹੈ।"
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "ਸਕਿਉਰ ਬੂਟ ਨਾਲ ਸਮੱਸਿਆਵਾਂ ਹਨ"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਕੁਝ ਸੁਰੱਖਿਆ ਹੈ।"
+
+#~| msgid "Secure Boot is Turned Off"
+#~ msgid "Secure Boot is Off"
+#~ msgstr "ਸਕਿਉਰ ਬੂਟ ਬੰਦ ਕੀਤਾ ਹੈ"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "ਜਦੋਂ ਡਿਵਾਈਸ ਸ਼ੁਰੂ ਹੁੰਦਾ ਹੈ ਤਾਂ ਕੋਈ ਸੁਰੱਖਿਆ ਨਹੀਂ ਹੈ।"
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "ਇਹ ਮਸਲਾ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਕਿਸੇ ਤਬਦੀਲੀ, ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਸੰਰਚਨਾ ਵਿੱਚ ਤਬਦੀਲੀ "
+#~ "ਜਾਂ ਇਸ ਸਿਸਟਮ ਉੱਤੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰ ਦੇ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "ਇਹ ਮਸਲਾ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਕਿਸੇ ਤਬਦੀਲੀ, ਜਾਂ ਇਸ ਸਿਸਟਮ ਉੱਤੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰ ਦੇ "
+#~ "ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "ਇਹ ਮਸਲਾ ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਸੰਰਚਨਾ ਵਿੱਚ ਤਬਦੀਲੀ ਜਾਂ ਇਸ ਸਿਸਟਮ ਉੱਤੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰ ਦੇ ਕਰਕੇ ਹੋ "
+#~ "ਸਕਦਾ ਹੈ।"
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "ਗੰਭੀਰ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਲਈ ਖੁੱਲ੍ਹਾ ਹੈ।"
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "ਸਰਲ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਵਿਰੁੱਧ ਸੀਮਿਤ ਸੁਰੱਖਿਆ ਹੈ।"
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "ਆਮ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਵਿਰੁੱਧ ਸੁਰੱਖਿਆ ਹੈ।"
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਦੀ ਵੱਡੀ ਗਿਣਤੀ ਵਿਰੁੱਧ ਸੁਰੱਖਿਆ ਹੈ।"
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "ਸੰਪੂਰਨ ਸੁਰੱਖਿਆ"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection"
+#~ msgstr "ਫਿਰਮਵੇਅਰ ਲਿਖਣ ਸੁਰੱਖਿਆ"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "ਫਿਰਮਵੇਅਰ ਲਿਖਣ ਸੁਰੱਖਿਆ ਲਾਕ"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "ਫਿਰਮਵੇਅਰ BIOS ਖੇਤਰ"
+
+#~| msgid "Description"
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "ਫਿਰਮਵੇਅਰ BIOS ਵਰਣਨ"
+
+#~| msgid "No Protection"
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "ਪ੍ਰੀ-ਬੂਟ DMA ਸੁਰੱਖਿਆ"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel ਬੂਟਗਾਰਡ"
+
+#~| msgid "Intel BootGuard verified boot"
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel ਬੂਟਗਾਰਡ ਤਸਦੀਕ ਕੀਤਾ ਬੂਟ"
+
+#~| msgid "Intel BootGuard"
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel ਬੂਟਗਾਰਡ ACM ਸੁਰੱਖਿਅਤ"
+
+#~| msgid "Intel BootGuard"
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel ਬੂਟਗਾਰਡ ਗਲਤੀ ਪਾਲਸੀ"
+
+#~| msgid "Intel BootGuard"
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel ਬੂਟਗਾਰਡ ਫਿਊਸ"
+
+#~| msgid "Intel CET"
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET ਸਮਰੱਥ ਹੈ"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET ਸਰਗਰਮ"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "ਇੰਕ੍ਰਿਪਟ ਕੀਤੀ RAM"
+
+#~| msgid "No Protection"
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU ਸੁਰੱਖਿਆ"
+
+#~| msgid "Kernel lockdown"
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "ਲੀਨਕਸ ਕਰਨਲ ਲਾਕ-ਡਾਊਨ"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "ਲੀਨਕਸ ਕਰਨਲ ਤਸਦੀਕ"
+
+#~| msgid "Linux swap"
+#~ msgid "Linux Swap"
+#~ msgstr "ਲੀਨਕਸ ਸਵੈਪ"
+
+#~| msgid "Suspend"
+#~ msgid "Suspend To RAM"
+#~ msgstr "ਰੈਮ ਉੱਤੇ ਸਸਪੈਂਡ"
+
+#~| msgid "Suspend-to-idle"
+#~ msgid "Suspend To Idle"
+#~ msgstr "ਆਈਡਲ ਲਈ ਸਸਪੈਂਡ"
+
+#~| msgid "UEFI platform key"
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI ਪਲੇਟਫਾਰਮ ਕੁੰਜੀ"
+
+#~| msgid "Secure boot"
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI ਸਕਿਉਰ ਬੂਟ"
+
+#~| msgid "Display Configuration"
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM ਪਲੇਟਫਾਰਮ ਸੰਰਚਨਾ"
+
+#~| msgid "Restrictions:"
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM ਮੁੜ-ਨਿਰਮਾਣ"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel ਮੈਨਜੇਮੈਂਟ ਇੰਜਣ ਮੈਨੂਫਿਕਚਰਿੰਗ ਮੋਡ"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel ਮੈਨਜੇਮੈਂਟ ਇੰਜਣ ਓਵਰਰਾਈਡ"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel ਮੈਨਜੇਮੈਂਟ ਇੰਜਣ ਵਰਜ਼ਨ"
+
+#~| msgid "Firmware updates"
+#~ msgid "Firmware Updates"
+#~ msgstr "ਫਿਰਮਵੇਅਰ ਅੱਪਡੇਟ"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Attestation"
+#~ msgstr "ਫਿਰਮਵੇਅਰ ਤਸਦੀਕ"
+
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "ਫਿਰਮਵੇਅਰ ਅੱਪਡੇਟਰ ਤਸਦੀਕ"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "ਪਲੇਟਫਾਰਮ ਡੀਬੱਗ ਕਰਨਾ"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "ਪਰੋਸੈਸਰ ਸੁਰੱਖਿਆ ਜਾਂਚ"
+
+#~| msgid "No Protection"
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD ਰੋਲਬੈਕ ਸੁਰੱਖਿਆ"
+
+#~| msgid "Minimal Protection"
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD ਫਿਰਮਵੇਅਰ ਰੀਪਲੇਅ ਸੁਰੱਖਿਆ"
+
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD ਫਿਰਮਵੇਅਰ ਲਿਖਣ ਸੁਰੱਖਿਆ"
+
+#~ msgid "Fused Platform"
+#~ msgstr "ਫਿਊਜ਼ ਕੀਤਾ ਪਲੇਟਫਾਰਮ"
+
+#~ msgid "Valid"
+#~ msgstr "ਵਾਜਬ"
+
+#~| msgid "Not calibrated"
+#~ msgid "Not Valid"
+#~ msgstr "ਵਾਜਬ ਨਹੀਂ ਹੈ"
+
+#~| msgid "Enabled"
+#~ msgid "Not Enabled"
+#~ msgstr "ਸਮਰੱਥ ਨਹੀਂ ਹੈ"
+
+#~| msgid "SIM Locked"
+#~ msgid "Locked"
+#~ msgstr "ਲਾਕ ਹੈ"
+
+#~| msgid "SIM Locked"
+#~ msgid "Not Locked"
+#~ msgstr "ਲਾਕ ਨਹੀਂ"
+
+#~| msgid "Encrypted RAM"
+#~ msgid "Encrypted"
+#~ msgstr "ਇੰਕ੍ਰਿਪਟ ਹੈ"
+
+#~| msgid "Encrypted RAM"
+#~ msgid "Not Encrypted"
+#~ msgstr "ਇੰਕ੍ਰਿਪਟ ਨਹੀਂ"
+
+#~ msgid "Tainted"
+#~ msgstr "ਨੁਕਸਾਨਿਆ"
+
+#~| msgid "Not calibrated"
+#~ msgid "Not Tainted"
+#~ msgstr "ਨੁਕਸਾਨਿਆ ਨਹੀਂ"
+
+#~| msgid "Sound"
+#~ msgid "Found"
+#~ msgstr "ਲੱਭਿਆ"
+
+#~| msgid "Not found"
+#~ msgid "Not Found"
+#~ msgstr "ਨਹੀਂ ਲੱਭਿਆ"
+
+#~| msgid "Supported CPU"
+#~ msgid "Supported"
+#~ msgstr "ਸਹਾਇਕ ਹੈ"
+
+#~| msgid "Supported CPU"
+#~ msgid "Not Supported"
+#~ msgstr "ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Unknown"
+#~ msgstr "ਅਣਪਛਾਤਾ"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-ਬਿੱਟ"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-ਬਿੱਟ"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "ਵੇਲੈਂਡ"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "ਅਣਪਛਾਤਾ"
+
+#~ msgid "Not Available"
+#~ msgstr "ਉਪਲੱਬਧ ਨਹੀਂ"
+
+#~ msgid "System Logo"
+#~ msgstr "ਸਿਸਟਮ ਲੋਗੋ"
+
+#~ msgid "No input sources found"
+#~ msgstr "ਕੋਈ ਇੰਪੁੱਟ ਸਰੋਤ ਨਹੀਂ ਲੱਭਿਆ"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "ਹੋਰ"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "ਬਦਲਵੀਂ ਅੱਖਰ ਸਵਿੱਚ ਨੂੰ ਹੋਰ ਅੱਖਰ ਦੇਣ ਲਈ ਵਰਤਿਆ ਜਾ ਸਕਦਾ ਹੈ। ਇਹਨਾਂ ਨੂੰ ਕਈ ਵਾਰ ਤੁਹਾਡੇ ਕੀਬੋਰਡ "
+#~ "ਉੱਤੇ ਤੀਜੀ-ਚੋਣ ਵਜੋਂ ਛਾਪਿਆ ਗਿਆ ਹੁੰਦਾ ਹੈ।"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "ਖੱਬਾ Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "ਸੱਜਾ Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "ਖੱਬਾ ਸੁਪਰ"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "ਸੱਜਾ ਸੁਪਰ"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "ਮੀਨੂ ਸਵਿੱਚ"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "ਸੱਜਾ Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "ਮਿਸ਼ਰਿਤ ਸਵਿੱਚ ਕਈ ਕਿਸਮ ਦੇ ਵੱਖ-ਵੱਖ ਅੱਖਰ ਦੇਣ ਲਈ ਕੰਮ ਆਉਂਦੀ ਹੈ। ਇਹ ਵਰਤਣ ਲਈਤਦ ਲੜੀਵਾਰ ਅੱਖਰ "
+#~ "ਦੇਣ ਲਈ ਬਣਾਓ ਨੂੰ ਦਬਾਓ। ਮਿਸਾਲ ਲਈ <b>C</b> ਅਤੇ <b>o</b> ਦੇ ਬਾਅਦ ਬਣਾਓ ਨਾਲ <b>©</b> "
+#~ "ਪਵੇਗਾ, <b>a</b> ਤੇ <b>'</b> ਦੇ ਬਾਅਦ ਬਣਾਓ ਦਬਾਉਣ ਨਾਲ <b>á</b> ਪਵੇਗਾ।"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps ਲਾਕ"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "ਸਕਰੋਲ ਲਾਕ"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "ਪਰਿੰਟ ਸਕਰੀਨ"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "ਇਨਪੁੱਟ ਸਰੋਤਾਂ ਨੂੰ %s ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਵਰਤ ਕੇ ਬਦਲਿਆ ਜਾ ਸਕਦਾ ਹੈ।\n"
+#~ "ਇਹ ਸ਼ਾਰਟਕੱਟਾਂ ਨੂੰ ਕੀਬੋਰਡ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਬਦਲਿਆ ਜਾ ਸਕਦਾ ਹੈ"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d ਸੋਧਿਆ"
+#~ msgstr[1] "%d ਸੋਧੇ"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "ਕੀ ਸਾਰੇ ਸ਼ਾਰਟਕੱਟ ਮੁੜ-ਸੈੱਟ ਕਰਨੇ ਹਨ?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "ਸ਼ਾਰਟਕੱਟਾਂ ਨੂੰ ਮੁੜ-ਸੈੱਟ ਕਰਨ ਨਾਲ ਤੁਹਾਡੇ ਕਸਟਮ ਸ਼ਾਰਟਕੱਟਾਂ ਉੱਤੇ ਅਸਰ ਪੈ ਸਕਦਾ ਹੈ। ਇਸ ਨੂੰ ਵਾਪਸ ਨਹੀਂ "
+#~ "ਪਰਤਾਇਆ ਜਾ ਸਕਦਾ ਹੈ।"
+
+#~ msgid "Reset All"
+#~ msgstr "ਸਭ ਮੁੜ-ਸੈੱਟ ਕਰੋ"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s ਨੂੰ ਪਹਿਲਾਂ ਹੀ %s ਨੂੰ ਵਰਤ ਰਿਹਾ ਹੈ। ਜੇ ਤੁਸੀਂ ਇਸ ਨੂੰ ਬਦਲਿਆ ਤਾਂ %s ਅਸਮਰੱਥ ਹੋ ਜਾਵੇਗਾ।"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "ਨਵਾਂ ਸ਼ਾਰਟਕੱਟ ਦਿਓ"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ ਸੈੱਟ ਕਰੋ"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "ਸ਼ਾਰਟਕੱਟ ਸੈੱਟ ਕਰੋ"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "%s ਨੂੰ ਬਦਲਣ ਲਈ ਨਵਾਂ ਸ਼ਾਰਟਕੱਟ ਦਿਉ।"
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ ਨੂੰ ਜੋੜੋ"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "ਦੋ ਉਂਗਲਾਂ ਨਾਲ ਸਕਰੋਲ"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "ਪੰਜ ਕਲਿੱਕ, GEGL ਸਮਾਂ!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "ਡਬਲ ਕਲਿੱਕ, ਮੁੱਢਲਾ ਬਟਨ"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "ਇੱਕ ਵਾਰ ਕਲਿੱਕ, ਮੁੱਢਲਾ ਬਟਨ"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "ਡਬਲ ਕਲਿੱਕ, ਮੱਧ ਬਟਨ"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "ਇੱਕ ਵਾਰ ਕਲਿੱਕ, ਮੱਧ ਬਟਨ"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "ਡਬਲ ਕਲਿੱਕ, ਸੈਕੰਡਰੀ ਬਟਨ"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "ਇੱਕ ਵਾਰ ਕਲਿੱਕ, ਸੈਕੰਡਰੀ ਬਟਨ"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "ਨੈਟਵਰਕਮੈਨੇਜਰ ਚੱਲਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "ਅਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "ਹਾਟਸਪਾਟ ਨੂੰ ਚਾਲੂ ਕਰਨ ਨਾਲ %s ਤੋਂ ਡਿਸ-ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇਗਾ ਅਤੇ Wi-Fi ਰਾਹੀਂ ਇੰਟਰਨੈੱਟ ਨਾਲ "
+#~ "ਪਹੁੰਚ ਸੰਭਵ ਨਹੀਂ ਹੋਵੇਗੀ।"
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "ਘੱਟੋ-ਘੱਟ 8 ਅੱਖਰ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "ਕੀ ਹਾਟਸਪਾਟ ਰੋਕਣਾ ਹੈ ਅਤੇ ਵਰਤੋਂਕਾਰ ਨੂੰ ਡਿਸ-ਕਨੈਕਟ ਕਰਨਾ ਹੈ?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "ਹਾਟਸਪਾਟ ਰੋਕੋ(_S)"
+
+#~ msgid "Preserve"
+#~ msgstr "ਕਾਇਮ ਰੱਖੋ"
+
+#~ msgid "Permanent"
+#~ msgstr "ਪੱਕਾ"
+
+#~ msgid "Random"
+#~ msgstr "ਰਲਵਾਂ"
+
+#~ msgid "Stable"
+#~ msgstr "ਸਥਿਰ"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "ਇੱਥੇ ਦਿੱਤਾ ਮੈਕ (MAC) ਐਡਰੈੱਸ ਨੈੱਟਵਰਕ ਡਿਵਾਈਸ ਲਈ ਹਾਰਡਵੇਅਰ ਐਡਰੈੱਸ ਵਜੋਂ ਵਰਤਿਆ ਜਾਵੇਗਾ, ਜਿਸ ਲਈ "
+#~ "ਇਸ ਕਨੈਕਸ਼ਨ ਐਕਟੀਵੇਟ ਕੀਤਾ ਗਿਆ ਹੈ। ਇਹ ਫੀਚਰ ਨੂੰ ਮੈਕ ਕਲੋਨਿੰਗ ਜਾਂ ਸਪੂਫਿੰਗ (spoofing) ਕਹਿੰਦੇ "
+#~ "ਹਨ। ਜਿਵੇਂ: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "ਪਰੋਫਾਈਲ %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "ਵਾਧਰਾ ਖੋਲ੍ਹੋ"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "ਇੰਟਰਪ੍ਰਾਈਜ਼"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ"
+
+#~ msgid "Never"
+#~ msgstr "ਕਦੇ ਨਹੀਂ"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/ਸਕਿੰਟ (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "ਕਮਜ਼ੋਰ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "ਠੀਕ ਹੈ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "ਚੰਗਾ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "ਬਹੁਤ ਵਧੀਆ"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "ਕਨੈਕਸ਼ਨ ਨੂੰ ਭੁੱਲ ਜਾਓ"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "ਕਨੈਕਸ਼ਨ ਪ੍ਰੋਫਾਈਲ ਨੂੰ ਹਟਾਓ"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN ਹਟਾਓ"
+
+#~ msgid "Details"
+#~ msgstr "ਵੇਰਵੇ"
+
+#~ msgid "automatic"
+#~ msgstr "ਆਪਣੇ-ਆਪ"
+
+#~ msgid "Identity"
+#~ msgstr "ਪਛਾਣ"
+
+#~ msgid "Delete Address"
+#~ msgstr "ਐਡਰੈਸ ਹਟਾਓ"
+
+#~ msgid "Delete Route"
+#~ msgstr "ਰੂਟ ਹਟਾਓ"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-ਬਿੱਟ ਕੁੰਜੀ (Hex ਜਾਂ ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-ਬਿੱਟ ਵਾਕ"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "ਡਾਇਨੈਮਿਕ WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA ਤੇ WPA2 ਨਿੱਜੀ"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA ਤੇ WPA2 ਇੰਟਰਪ੍ਰਾਈਜ"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 ਪਰਸਨਲ"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "ਕਨੈਕਸ਼ਨ ਐਡੀਟਰ ਖੋਲ੍ਹਣ ਲਈ ਅਸਮਰੱਥ"
+
+#~ msgid "New Profile"
+#~ msgstr "ਨਵਾਂ ਪਰੋਫਾਇਲ"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "ਗਲਤ ਸੈਟਿੰਗ %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "ਗਲਤ ਸੈਟਿੰਗ %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "…ਫਾਇਲ ਤੋਂ ਇੰਪੋਰਟ ਕਰੋ"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN ਨੂੰ ਜੋੜੋ"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN ਕੁਨੈਕਸ਼ਨ ਇੰਪੋਰਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "ਫਾਇਲ ”%s” ਪੜ੍ਹੀ ਨਹੀਂ ਜਾ ਸਕੀ ਜਾਂ ਪਛਾਣਯੋਗ VPN ਕੁਨੈਕਸ਼ਨ ਜਾਣਕਾਰੀ ਨਹੀਂ ਰੱਖਦੀ ਹੈ।\n"
+#~ "\n"
+#~ "ਗਲਤੀ: %s।"
+
+#~ msgid "Select file to import"
+#~ msgstr "ਇੰਪੋਰਟ ਕਰਨ ਲਈ ਫਾਇਲ ਚੁਣੋ"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "”%s” ਫਾਇਲ ਨਾਂ ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹੈ।"
+
+#~ msgid "_Replace"
+#~ msgstr "ਬਦਲੋ(_R)"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "ਕੀ ਤੁਸੀਂ %s ਨੂੰ VPN, ਜੋ ਤੁਸੀਂ ਸੰਭਾਲ ਰਹੇ ਹੋ, ਨਾਲ ਬਦਲਣਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN ਕੁਨੈਕਸ਼ਨ ਐਕਸਪੋਰਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN ਕੁਨੈਕਸ਼ਨ ”%s” %s ਲਈ ਐਕਸਪੋਰਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।\n"
+#~ "\n"
+#~ "ਗਲਤੀ: %s"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN ਕਨੈਕਸ਼ਨ ਐਕਸਪੋਰਟ ਕਰੋ"
+
+#~ msgid "never"
+#~ msgstr "ਕਦੇ ਨਹੀਂ"
+
+#~ msgid "today"
+#~ msgstr "ਅੱਜ"
+
+#~ msgid "yesterday"
+#~ msgstr "ਕੱਲ੍ਹ"
+
+#~ msgid "Last used"
+#~ msgstr "ਆਖਰੀ ਵਰਤੋਂ"
+
+#~ msgid "Add new connection"
+#~ msgstr "ਨਵਾਂ ਕੁਨੈਕਸ਼ਨ ਸ਼ਾਮਲ ਕਰੋ"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "ਚੁਣੇ ਗਏ ਨੈੱਟਵਰਕਾਂ ਲਈ ਨੈੱਟਵਰਕ ਵੇਰਵਾ, ਜਿਸ ਵਿੱਚ ਪਾਸਵਰਡ ਅਤੇ ਹੋਰ ਪਸੰਦੀਦਾ ਸੰਰਚਨਾ ਦਿੱਤੀ ਸੀ, "
+#~ "ਖਤਮ ਹੋ ਜਾਵੇਗਾ।"
+
+#~ msgid "_Forget"
+#~ msgstr "ਭੁੱਲ ਜਾਓ(_F)"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "ਜਾਣੇ-ਪਛਾਣ Wi-Fi ਨੈੱਟਵਰਕ"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "ਭੁੱਲ ਜਾਓ(_F)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "ਸਿਸਟਮ ਪਾਲਸੀ ਹਾਟ-ਸਪਾਟ ਵਜੋਂ ਵਰਤਣ ਤੋਂ ਰੋਕਦੀ ਹੈ"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "ਬੇਤਾਰ ਜੰਤਰ ਹਾਟਸਪਾਟ ਮੋਡ ਲਈ ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "ਵੈੱਬ ਪਰਾਕਸੀ ਆਪੇ-ਆਪ ਖੋਜ ਵਰਤੀ ਜਾਂਦੀ ਹੈ, ਜਦੋਂ ਸੰਰਚਨਾ URL ਨਾ ਦਿੱਤਾ ਗਿਆ ਹੋਵੇ।"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "ਇਹ ਪਬਲਿਕ ਨੈੱਟਵਰਕ ਬੇ-ਭਰੋਸੇਯੋਗ ਨੈੱਟਵਰਕ ਲਈ ਸਿਫਾਰਸ਼ ਨਹੀਂ ਕੀਤਾ ਜਾਂਦਾ।"
+
+#~ msgid "Status unknown"
+#~ msgstr "ਹਾਲਤ ਅਣਜਾਣ"
+
+#~ msgid "Unmanaged"
+#~ msgstr "ਬਿਨ-ਇੰਤਜ਼ਾਮ"
+
+#~ msgid "Unavailable"
+#~ msgstr "ਨਾ-ਉਪਲੱਬਧ"
+
+#~ msgid "Connecting"
+#~ msgstr "ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgid "Authentication required"
+#~ msgstr "ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#~ msgid "Disconnecting"
+#~ msgstr "ਡਿਸ-ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgid "Connection failed"
+#~ msgstr "ਕੁਨੈਕਸ਼ਨ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "ਹਾਲਤ ਅਣਜਾਣ (ਗੁੰਮ)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "ਸੰਰਚਨਾ ਫੇਲ੍ਹ ਹੋਈ"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP ਸੰਰਚਨਾ ਫੇਲ੍ਹ ਹੋਈ"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP ਸੰਰਚਨਾ ਦੀ ਮਿਆਦ ਪੁੱਗੀ"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "ਭੇਦ ਦੀ ਲੋੜ ਸੀ, ਪਰ ਦਿੱਤਾ ਨਹੀਂ ਗਿਆ"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x ਸਪਲੀਮੈਂਟ ਡਿਸ-ਕਨੈਕਟ ਹੈ"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x ਸਪਲੀਮੈਂਟ ਸੰਰਚਨਾ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x ਸਪਲੀਮੈਂਟ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x ਸਪਲੀਮੈਂਟ ਨੇ ਪਰਮਾਣਿਤ ਹੋਣ ਲਈ ਬਹੁਤ ਲੰਮਾ ਸਮਾਂ ਲੈ ਲਿਆ ਹੈ"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP ਸਰਵਿਸ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP ਸਰਵਿਸ ਡਿਸ-ਕਨੈਕਟ ਹੈ"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP ਕਲਾਇਟ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP ਕਲਾਇਟ ਗਲਤੀ"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP ਕਲਾਇਟ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "ਸਾਂਝੀ ਕੀਤੀ ਕਨੈਕਸ਼ਨ ਸਰਵਿਸ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "ਸਾਂਝਾ ਕੀਤੀ ਕਨੈਕਸ਼ਨ ਸਰਵਿਸ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "ਆਟੋ-IP ਸਰਵਿਸ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "ਆਟੋ-IP ਸਰਵਿਸ ਗਲਤੀ"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "ਆਟੋ-IP ਸਰਵਿਸ ਫੇਲ੍ਹ ਹੋਈ"
+
+#~ msgid "Line busy"
+#~ msgstr "ਲਾਈਨ ਰੁਝੀ ਹੋਈ ਹੈ"
+
+#~ msgid "No dial tone"
+#~ msgstr "ਕੋਈ ਡਾਇਲ ਟੋਨ ਨਹੀਂ"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "ਕੋਈ ਕੈਰੀਅਰ ਤਿਆਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "ਡਾਇਲ ਕਰਨ ਲਈ ਸਮਾਂ-ਸਮਾਪਤ"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "ਡਾਇਲ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਫੇਲ੍ਹ ਹੋਈ"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "ਮਾਡਮ ਸ਼ੁਰੂਆਤ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "ਦਿੱਤੇ APN ਨੂੰ ਚੁਣਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "ਨੈੱਟਵਰਕ ਲਈ ਖੋਜ ਨਹੀਂ ਕੀਤੀ ਜਾ ਰਹੀ"
+
+#~ msgid "Network registration denied"
+#~ msgstr "ਨੈੱਟਵਰਕ ਰਜਿਸਟਰੇਸ਼ਨ ਉੱਤੇ ਪਾਬੰਦੀ"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "ਨੈੱਟਵਰਕ ਰਜਿਸਟਰ ਲਈ ਸਮਾਂ-ਸਮਾਪਤ"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "ਮੰਗੇ ਗਏ ਨੈੱਟਵਰਕ ਉੱਤੇ ਰਜਿਸਟਰ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN ਚੈਕ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "ਜੰਤਰ ਲਈ ਫਿਰਮਵੇਅਰ ਸ਼ਾਇਦ ਮੌਜੂਦ ਨਹੀਂ"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "ਕਨੈਕਸ਼ਨ ਅਲੋਪ ਹੋਇਆ"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "ਮੌਜੂਦਾ ਕਨੈਕਸ਼ਨ ਮੁੜ-ਪ੍ਰਾਪਤ ਕੀਤਾ ਗਿਆ"
+
+#~ msgid "Modem not found"
+#~ msgstr "ਮਾਡਮ ਨਹੀਂ ਲੱਭਿਆ"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ਬਲਿਉਟੁੱਥ ਕੁਨੈਕਸ਼ਨ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM ਕਾਰਡ ਨਹੀਂ ਪਾਇਆ"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM ਪਿੰਨ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk ਦੀ ਲੋੜ"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM ਗਲਤ"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "ਕਨੈਕਸ਼ਨ ਨਿਰਭਰਤਾ ਫੇਲ੍ਹ ਹੋਈ"
+
+#~ msgid "Firmware missing"
+#~ msgstr "ਫਿਰਮਵੇਅਰ ਮੌਜੂਦ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "ਕੇਬਲ ਕੱਢੀ ਹੋਈ ਹੈ"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "802.1X ਸੁਰੱਖਿਆ (wpa-eap) ਵਿੱਚ ਨਾ-ਪਰਿਭਾਸ਼ਿਤ ਗ਼ਲਤੀ"
+
+#~ msgid "no file selected"
+#~ msgstr "ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਚੁਣੀ"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "eap-method ਫ਼ਾਇਲ ਨੂੰ ਪ੍ਰਮਾਣ ਕਰਨ ਦੌਰਾਨ ਨਾ-ਪਰਿਭਾਸ਼ਿਤ ਗ਼ਲਤੀ"
+
+#~| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12, ਜਾਂ PGP ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀਆਂ"
+
+#~| msgid "_User certificate"
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER ਜਾਂ PEM ਸਰਟੀਫਿਕੇਟ"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "ਗੁੰਮ EAP-FAST PAC ਫ਼ਾਇਲ"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ਫਾਇਲਾਂ (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "ਗੁੰਮ EAP-LEAP ਵਰਤੋਂਕਾਰ-ਨਾਂ"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "ਗੁੰਮ EAP-LEAP ਪਾਸਵਰਡ"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "ਅਵੈਧ EAP-PEAP CA ਸਰਟੀਫਿਕੇਟ: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "ਅਵੈਧ EAP-PEAP CA ਸਰਟੀਫਿਕੇਟ: ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
+
+#~ msgid "missing EAP username"
+#~ msgstr "ਗੁੰਮ EAP ਵਰਤੋਂਕਾਰ-ਨਾਂ"
+
+#~ msgid "missing EAP password"
+#~ msgstr "ਗਲਤ EAP ਪਾਸਵਰਡ"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "ਗੁੰਮ EAP-TLS ਪਛਾਣ"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "ਅਵੈਧ EAP-TLS CA ਸਰਟੀਫਿਕੇਟ: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "ਅਵੈਧ EAP-TLS CA ਸਰਟੀਫਿਕੇਟ: ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "ਅਵੈਧ EAP-TLS ਪ੍ਰਾਈਵੇਟ-ਕੁੰਜੀ: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "ਅਵੈਧ EAP-TLS ਵਰਤੋਂਕਾਰ-ਸਰਟੀਫਿਕੇਟ: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "ਬਿਨ-ਇੰਕ੍ਰਿਪਸ਼ਨ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀਆਂ ਅਸੁਰੱਖਿਅਤ ਹਨ"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "ਚੁਣੀ ਗਈ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਪਾਸਵਰਡ ਨਾਲ ਸੁਰੱਖਿਅਤ ਨਹੀਂ ਜਾਪਦੀ ਹੈ। ਇਹ ਤੁਹਾਡੀ ਸੁਰੱਖਿਅਤ ਸਨਦ ਨੂੰ "
+#~ "ਖਤਰਾ ਪੈਦਾ ਕਰ ਸਕਦੀ ਹੈ। ਪਾਸਵਰਡ ਨਾਲ ਸੁਰੱਖਿਅਤ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਚੁਣੋ ਜੀ।\n"
+#~ "\n"
+#~ "(ਤੁਸੀਂ openssl ਨਾਲ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਪਾਸਵਰਡ ਸੁਰੱਖਿਅਤ ਕਰ ਸਕਦੇ ਹੋ)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "ਆਪਣਾ ਨਿੱਜੀ ਸਰਟੀਫਿਕੇਟ ਚੁਣੋ"
+
+#~ msgid "Choose your private key"
+#~ msgstr "ਆਪਣੀ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਚੁਣੋ"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "ਅਵੈਧ EAP-TLLS CA ਸਰਟੀਫਿਕੇਟ: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "ਅਵੈਧ EAP-TTLS CA ਸਰਟੀਫਿਕੇਟ: ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "802.1X ਸੁਰੱਖਿਆ ਦੀ ਪ੍ਰਮਾਣਕਿਤ ਦੌਰਾਨ ਅਣਜਾਣ ਗਲਤੀ"
+
+#~ msgid "Select a file"
+#~ msgstr "ਫਾਇਲ ਚੁਣੋ"
+
+#~ msgid "missing leap-username"
+#~ msgstr "leap-ਵਰਤੋਂਕਾਰ ਗੁੰਮ"
+
+#~ msgid "missing leap-password"
+#~ msgstr "ਗੁੰਮ ਲੀਪ-ਪਾਸਵਰਡ"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "ਵਾਈ-ਫਾਈ ਪਾਸਵਰਡ ਗੁੰਮ ਹੈ।"
+
+#~ msgid "missing wep-key"
+#~ msgstr "wep-key ਗੁੰਮ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr "ਅਵੈਧ wep-key: %zu ਲੰਬਾਈ ਦੀ ਕੁੰਜੀ ਵਿੱਚ ਕੇਵਲ ਹੈਕਸਾ-ਅੰਕ ਹੀ ਹੋ ਸਕਦੇ ਹਨ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr "ਅਵੈਧ wep-key: %zu ਲੰਬਾਈ ਦੀ ਕੁੰਜੀ ਵਿੱਚ ਕੇਵਲ ASCII ਅੱਖਰ ਹੀ ਹੋ ਸਕਦੇ ਹਨ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "ਅਵੈਧ wep-key: ਗ਼ਲਤ %zu ਕੁੰਜੀ ਲੰਬਾਈ। ਕੁੰਜੀ ਦੀ ਲੰਬਾਈ ਜਾਂ ਤਾਂ 5/13 (ascii) ਜਾਂ 10/26 "
+#~ "(ਹੈਕਸਾ) ਹੋ ਸਕਦੇ ਹਨ"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "ਗ਼ਲਤ wep-key: ਵਾਕ ਖਾਲੀ ਨਹੀਂ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "ਗ਼ਲਤ wep-key: ਵਾਕ 64-ਅੱਖਰਾਂ ਤੋਂ ਛੋਟਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "ਅਵੈਧ wpa-psk: ਕੁੰਜੀ-ਲੰਬਾਈ %zu ਅਵੈਧ ਹੈ। ਜਾਂ ਤਾਂ [8,63] ਬਾਈਟ ਜਾਂ 64 ਹੈਕਸਾ-ਅੰਕ ਹੋਣੀ "
+#~ "ਚਾਹੀਦੀ ਹੈ।"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "ਅਵੈਧ wpa-psk: 64 ਬਾਈਟਾਂ ਨੂੰ ਹੈਕਸਾ ਨਾਲ ਅਰਥ ਕੱਢੇ ਨਹੀਂ ਜਾ ਸਕਦੇ"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "ਹੋਰ"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s ਨੂੰ ਹਟਾਇਆ"
+
+#~ msgid "Error removing account"
+#~ msgstr "ਅਕਾਊਂਟ ਹਟਾਉਣਾ ਦੌਰਾਨ ਗਲਤੀ"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s ਖਾਤਾ"
+
+#~ msgid "Remove Account"
+#~ msgstr "ਅਕਾਊਂਟ ਹਟਾਓ"
+
+#~ msgid "Unknown time"
+#~ msgstr "ਅਣਜਾਣ ਸਮਾਂ"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "ਪੂਰਾ ਚਾਰਜ ਹੋਣ ਲਈ %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "ਸਾਵਧਾਨ: %s ਬਾਕੀ"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s ਬਾਕੀ"
+
+#~ msgid "Fully charged"
+#~ msgstr "ਪੂਰੀ ਚਾਰਜ"
+
+#~ msgid "Not charging"
+#~ msgstr "ਚਾਰਜ ਨਹੀਂ ਹੋ ਰਹੀ"
+
+#~ msgid "Empty"
+#~ msgstr "ਖਾਲੀ"
+
+#~ msgid "Charging"
+#~ msgstr "ਚਾਰਜ ਹੋ ਰਹੀ ਹੈ"
+
+#~ msgid "Discharging"
+#~ msgstr "ਡਿਸਚਾਰਜ ਹੋ ਰਹੀ ਹੈ"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "ਬੇਤਾਰ ਮਾਊਸ"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "ਬੇਤਾਰ ਕੀ-ਬੋਰਡ"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "ਗ਼ੈਰ-ਰੁਕਾਵਟ-ਯੋਗ ਪਾਵਰ ਸਪਲਾਈ"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "ਨਿੱਜੀ ਡਿਜ਼ਿਟਲ ਸਹਾਇਕ"
+
+#~ msgid "Cellphone"
+#~ msgstr "ਸੈਲਫੋਨ"
+
+#~ msgid "Media player"
+#~ msgstr "ਮੀਡਿਆ ਪਲੇਅਰ"
+
+#~ msgid "Tablet"
+#~ msgstr "ਟੇਬਲੇਟ"
+
+#~ msgid "Computer"
+#~ msgstr "ਕੰਪਿਊਟਰ"
+
+#~ msgid "Gaming input device"
+#~ msgstr "ਖੇਡਾਂ ਲਈ ਇੰਪੁੱਟ ਡਿਵਾਈਸ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "ਮੁੱਖ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "ਵਾਧੂ"
+
+#~ msgid "Batteries"
+#~ msgstr "ਬੈਟਰੀਆਂ"
+
+#~ msgid "When _idle"
+#~ msgstr "ਜਦੋਂ ਵੇਹਲਾ ਹੈ(_i)"
+
+#~ msgid "Suspend"
+#~ msgstr "ਸਸਪੈਂਡ"
+
+#~ msgid "Power Off"
+#~ msgstr "ਬੰਦ ਕਰੋ"
+
+#~ msgid "Hibernate"
+#~ msgstr "ਹਾਈਬਰਨੇਟ"
+
+#~ msgid "Nothing"
+#~ msgstr "ਕੁਝ ਨਹੀਂ"
+
+#~ msgid "When on battery power"
+#~ msgstr "ਜਦੋਂ ਬੈਟਰੀ ਪਾਵਰ ਉੱਤੇ ਹੋਵੇ"
+
+#~ msgid "When plugged in"
+#~ msgstr "ਜਦੋਂ ਪਲੱਗ ਲੱਗਾ ਹੋਵੇ"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "ਕਦੇ ਨਹੀਂ"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "ਆਟੋਮੈਟਿਕ ਸਸਪੈਂਡ ਕਰੋ"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "ਵੱਧ ਕਾਰਜਕਾਰੀ ਤਾਪਮਾਨ ਹੋਣ ਕਰਕੇ ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਨੂੰ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਕੀਤਾ ਹੈ।"
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "ਲੈਪ ਖੋਜਿਆ: ਕਾਰਜਗੁਜ਼ਾਰੀ ਢੰਗ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਹੈ। ਬਹਾਲ ਕਰਨ ਲਈ ਡਿਵਾਈਸ ਨੂੰ ਸਥਿਰ ਤਲ ਉੱਤੇ "
+#~ "ਰੱਖੋ।"
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਹੈ।"
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "ਘੱਟ ਬੈਟਰੀ: ਪਾਵਰ ਬੱਚਤ ਸਮਰੱਥ ਹੈ। ਜਦੋਂ ਬੈਟਰੀ ਠੀਕ-ਠਾਕ ਚਾਰਜ ਹੋ ਗਈ ਤਾਂ ਪਿਛਲੇ ਮੋਡ ਨੂੰ ਬਹਾਲ "
+#~ "ਕੀਤਾ ਜਾਵੇਗਾ।"
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "“%s” ਨੇ ਪਾਵਰਪ ਬੱਚਤ ਢੰਗ ਸਰਗਰਮ ਕੀਤਾ ਹੈ।"
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "“%s” ਨੇ ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਸਰਗਰਮ ਕੀਤਾ ਹੈ।"
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "ਕਾਰਗੁਜ਼ਾਰੀ"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "ਵੱਧ ਕਾਰਗੁਜ਼ਾਰੀ ਅਤੇ ਊਰਜਾ ਖ਼ਪਤ ਹੈ।"
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "ਸੰਤੁਲਿਤ"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "ਮਿਆਰੀ ਕਾਰਗੁਜ਼ਾਰੀ ਤੇ ਊਰਜਾ ਖਪਤ ਹੈ।"
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "ਪਾਵਰ ਬੱਚਤ"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "ਘੱਟ ਕੀਤੀ ਕਾਰਗੁਜ਼ਾਰੀ ਅਤੇ ਊਰਜਾ ਖਪਤ ਹੈ।"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "ਪਰਿੰਟਰ “%s” ਨੂੰ ਹਟਾਇਆ ਜਾ ਚੁੱਕਾ ਹੈ"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "ਨਵਾਂ ਪਰਿੰਟਰ ਜੋੜਨ ਲਈ ਫੇਲ੍ਹ।"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui ਲੋਡ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "ਪਰਿੰਟਰ ਜੋੜਨ ਅਤੇ ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s ਵੇਰਵੇ"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "ਕੋਈ ਢੁੱਕਵਾਂ ਡਰਾਇਵਰ ਨਹੀਂ ਲੱਭਿਆ"
+
+#~ msgid "Select PPD File"
+#~ msgstr "PPD ਫਾਇਲ ਚੁਣੋ"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "ਪੋਸਟ-ਸਕ੍ਰਿਪਟ ਪਰਿੰਟਰ ਵੇਰਵਾ ਫਾਇਲਾਂ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect ਪਰਿੰਟਰ"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD ਪਰਿੰਟਰ"
+
+#~ msgid "One Sided"
+#~ msgstr "ਇੱਕ ਪਾਸੇ"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "ਲੰਮਾ ਕੋਨਾ (ਸਟੈਂਡਰਡ)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "ਛੋਟਾ ਕੋਨਾ (ਪਲਟੋ)"
+
+#~ msgid "Portrait"
+#~ msgstr "ਪੋਰਟਰੇਟ"
+
+#~ msgid "Landscape"
+#~ msgstr "ਲੈਂਡਸਕੇਪ"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "ਉਲਟ ਲੈਂਡਸਕੇਪ"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "ਉਲਟ ਪੋਰਟਰੇਟ"
+
+#~ msgid "Resume"
+#~ msgstr "ਬਹਾਲ ਕਰੋ"
+
+#~ msgid "Pause"
+#~ msgstr "ਵਿਰਾਮ"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "ਬਾਕੀ ਹਨ"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "ਵਿਰਾਮ ਹੈ"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "ਪਰੋਸੈਸ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "ਰੁਕਿਆ ਹੈ"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "ਰੱਦ ਕੀਤੇ"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "ਅਧੂਰੇ ਛੱਡੇ"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "ਪੂਰੇ ਹੋਏ"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "ਇਸ ਜਾਬ ਨੂੰ ਕਤਾਰ ਦੇ ਸਿਖਰ ਉੱਤੇ ਭੇਜੋ"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — ਸਰਗਰਮ ਜਾਬਾਂ"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "%s ਉੱਤੇ ਪਰਿੰਟ ਕਰਨ ਲਈ ਸਨਦ ਦਿਓ।"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "ਪਰਿੰਟਰ ਸਰਵਰ ਨੂੰ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s ਨੂੰ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "%s ਉੱਤੇ ਪਰਿੰਟਰ ਵੇਖਣ ਲਈ ਵਰਤੋਂਕਾਰ-ਨਾਂ ਅਤੇ ਪਾਸਵਰਡ ਦਿਉ।"
+
+#~ msgid "Searching for Printers"
+#~ msgstr "ਪਰਿੰਟਰਾਂ ਲਈ ਖੋਜ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "ਸੀਰੀਅਲ ਪੋਰਟ"
+
+#~ msgid "Parallel Port"
+#~ msgstr "ਪੈਰਲੈੱਲ ਪੋਰਟ"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "ਟਿਕਾਣਾ: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "ਸਿਰਨਾਵਾਂ: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "ਸਰਵਰ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#~ msgid "Two Sided"
+#~ msgstr "ਦੋ ਪਾਸੀਂ"
+
+#~ msgid "Paper Type"
+#~ msgstr "ਪੇਪਰ ਕਿਸਮ"
+
+#~ msgid "Paper Source"
+#~ msgstr "ਪੇਪਰ ਸਰੋਤ"
+
+#~ msgid "Output Tray"
+#~ msgstr "ਆਉਟਪੁੱਟ ਟਰੇ"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "ਰੈਜ਼ੋਲੂਸ਼ਨ"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "ਗੋਸਟ-ਸਕ੍ਰਿਪਟ ਪ੍ਰੀਫਿਲਟਰਿੰਗ"
+
+#~ msgid "Pages per side"
+#~ msgstr "ਹਰ ਪਾਸੇ ਸਫ਼ੇ"
+
+#~ msgid "Orientation"
+#~ msgstr "ਸਥਿਤੀ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "ਆਮ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "ਸਫ਼ਾ ਸੈੱਟਅੱਪ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "ਇੰਸਟਾਲਯੋਗ ਚੋਣਾਂ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "ਜਾਬ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "ਚਿੱਤਰ ਕੁਆਲਟੀ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "ਰੰਗ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "ਮੁਕੰਮਲ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "ਤਕਨੀਕੀ"
+
+#~ msgid "Test page"
+#~ msgstr "ਟੈਸਟ ਸਫ਼ਾ"
+
+#~ msgid "Auto Select"
+#~ msgstr "ਆਟੋ ਚੋਣ"
+
+#~ msgid "Printer Default"
+#~ msgstr "ਪਰਿੰਟਰ ਡਿਫਾਲਟ"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "ਇੰਬੈੱਡ ਕੀਤੇ ਗੋਸਟਸਕ੍ਰਿਪਟ ਫੋਂਟ ਹੀ"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS ਲੈਵਲ 1 ਲਈ ਬਦਲੋ"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS ਲੈਵਲ 2 ਲਈ ਬਦਲੋ"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "ਕੋਈ ਪ੍ਰੀ-ਫਿਲਟਰਿੰਗ ਨਹੀਂ"
+
+#~ msgid "Clean print heads"
+#~ msgstr "ਪਰਿੰਟ ਹੈੱਡ ਸਾਫ਼ ਕਰੋ"
+
+#~ msgid "Out of toner"
+#~ msgstr "ਟੋਨਰ ਖਤਮ ਹੋ ਗਿਆ"
+
+#~ msgid "Low on developer"
+#~ msgstr "ਡਿਵੈਲਪਰ ਲਈ ਘੱਟ"
+
+#~ msgid "Out of developer"
+#~ msgstr "ਡਿਵੈਲਪਰ ਲਈ ਖਤਮ"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "ਮਾਰਕਰ ਸਪਲਾਈ ਲਈ ਘੱਟ"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "ਮਾਰਕਰ ਸਪਲਾਈ ਲਈ ਖਤਮ"
+
+#~ msgid "Open cover"
+#~ msgstr "ਕਵਰ ਖੋਲ੍ਹੋ"
+
+#~ msgid "Open door"
+#~ msgstr "ਦਰਵਾਜ਼ਾ ਖੋਲ੍ਹੋ"
+
+#~ msgid "Low on paper"
+#~ msgstr "ਪੇਪਰ ਖਤਮ ਹੋਣ ਵਾਲੇ ਹਨ"
+
+#~ msgid "Out of paper"
+#~ msgstr "ਪੇਪਰ ਖਤਮ ਹੋ ਗਏ ਹਨ"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "ਆਫਲਾਈਨ"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "ਰੁਕਿਆ ਹੈ"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "ਵੇਸਟ ਰੇਸਪਟਕੇਟ ਲਗਭਗ ਭਰ ਗਿਆ ਹੈ"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "ਵੇਸਟ ਰੇਸਪਟਕੇਟ ਭਰ ਗਿਆ ਹੈ"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ਓਪਟੀਕਲ ਫੋਟੋ ਕੰਡਕਟਰ ਦੀ ਉਮਰ ਖਤਮ ਹੋ ਗਈ ਹੈ"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ਓਪਟੀਕਲ ਫੋਟੋ ਕੰਡਕਟਰ ਹੁਣ ਕੰਮ ਨਹੀਂ ਕਰਦਾ ਹੈ"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "ਤਿਆਰ"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "ਜਾਬ ਮਨਜ਼ੂਰ ਨਾ ਕਰੋ"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "ਪਰੋਸੈਸ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ਇੰਪਿਅਰਲ"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "ਮੈਟਰਿਕ"
+
+#~ msgid "Ask what to do"
+#~ msgstr "ਪੁੱਛੋ ਕਿ ਕੀ ਕਰਨਾ ਹੈ"
+
+#~ msgid "Do nothing"
+#~ msgstr "ਕੁਝ ਨਹੀਂ"
+
+#~ msgid "Open folder"
+#~ msgstr "ਫੋਲਡਰ ਖੋਲ੍ਹੋ"
+
+#~ msgid "Other Media"
+#~ msgstr "ਹੋਰ ਮੀਡਿਆ"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ਆਡੀਓ ਸੀਡੀ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "ਵਿਡੀਓ DVD ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "ਜਦੋਂ ਸੰਗੀਤ ਪਲੇਅਰ ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇ ਤਾਂ ਚਲਾਉਣ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "ਜਦੋਂ ਕੈਮਰਾ ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇ ਤਾਂ ਚਲਾਉਣ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "ਸਾਫਟਵੇਅਰ ਸੀਡੀ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#~ msgid "audio DVD"
+#~ msgstr "ਆਡੀਓ DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "ਖਾਲੀ ਬਲੁ-ਰੇ ਡਿਸਕ"
+
+#~ msgid "blank CD disc"
+#~ msgstr "ਖਾਲੀ CD ਡਿਸਕ"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "ਖਾਲੀ DVD ਡਿਸਕ"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "ਖਾਲੀ HD DVD ਡਿਸਕ"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "ਬਲੁ-ਰੇ ਵਿਡੀਓ ਡਿਸਕ"
+
+#~ msgid "e-book reader"
+#~ msgstr "ਈ-ਬੁੱਕ ਰੀਡਰ"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD ਵਿਡੀਓ ਡਿਸਕ"
+
+#~ msgid "Picture CD"
+#~ msgstr "ਤਸਵੀਰ CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "ਸੁਪਰ ਵਿਡੀਓ CD"
+
+#~ msgid "Video CD"
+#~ msgstr "ਵਿਡੀਓ CD"
+
+#~ msgid "Windows software"
+#~ msgstr "ਵਿੰਡੋਜ਼ ਸਾਫਟਵੇਅਰ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "ਸਕਰੀਨ ਬੰਦ ਕਰੋ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "੩੦ ਸਕਿੰਟ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "੧ ਮਿੰਟ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "੨ ਮਿੰਟ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "੩ ਮਿੰਟ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "੫ ਮਿੰਟ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "੩੦ ਮਿੰਟ"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "੧ ਘੰਟਾ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "੧ ਮਿੰਟ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "੨ ਮਿੰਟ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "੩ ਮਿੰਟ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "੪ ਮਿੰਟ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "੫ ਮਿੰਟ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "੮ ਮਿੰਟ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "੧੦ ਮਿੰਟ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "੧੨ ਮਿੰਟ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "੧੫ ਮਿੰਟ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "ਕਦੇ ਨਹੀਂ"
+
+#~ msgid "Select Location"
+#~ msgstr "ਟਿਕਾਣਾ ਚੁਣੋ"
+
+#~ msgid "_OK"
+#~ msgstr "ਠੀਕ ਹੈ(_O)"
+
+#~ msgid "No applications found"
+#~ msgstr "ਕੋਈ ਐਪਲੀਕੇਸ਼ਨ ਨਹੀਂ ਲੱਭੀ"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "ਸਾਂਝਾ ਕਰਨ ਲਈ ਕੋਈ ਨੈੱਟਵਰਕ ਨਹੀਂ ਚੁਣਿਆ"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "ਚਾਲੂ"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "ਬੰਦ"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "ਯੋਗ ਕੀਤਾ"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "ਸਰਗਰਮ"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "ਫੋਲਡਰ ਚੁਣੋ"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "ਮੀਡਿਆ ਸਾਂਝ ਸਮਰੱਥ"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "ਫਾਇਲ ਸਾਂਝ ਤੁਹਾਨੂੰ ਤੁਹਾਡੇ ਪਬਲਿਕ ਫੋਲਡਰ ਨੂੰ ਹੋਰਾਂ ਨਾਲ ਤੁਹਾਡੇ ਮੌਜੂਦਾ ਨੈੱਟਵਰਕ ਉੱਤੇ ਦੀ ਵਰਤੋਂ ਨਾਲ "
+#~ "ਸਾਂਝਾ ਕਰਨ ਲਈ ਸਹਾਇਕ ਹੈ: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "ਜਦੋਂ ਰਿਮੋਟ ਲਾਗਇਨ ਸਮਰੱਥ ਹੁੰਦਾ ਹੈ ਤਾਂ ਰਿਮੋਟ ਵਰਤੋਂਕਾਰ ਨੂੰ ਸੁਰੱਖਿਅਤ ਸ਼ੈੱਲ ਕਮਾਂਡ ਰਾਹੀਂ ਕਨੈਕਟ ਹੋ ਸਕਦਾ "
+#~ "ਹੈ:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "ਨਿੱਜੀ ਮੀਡਿਆ ਸਾਂਝ ਸਮਰੱਥ"
+
+#~ msgid "Device name copied"
+#~ msgstr "ਡਿਵਾਈਸ ਦਾ ਨਾਂ ਕਾਪੀ ਕੀਤਾ"
+
+#~ msgid "Device address copied"
+#~ msgstr "ਡਿਵਾਈਸ ਦਾ ਐਡਰੈਸ ਕਾਪੀ ਕੀਤਾ"
+
+#~ msgid "Username copied"
+#~ msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ ਕਾਪੀ ਕੀਤਾ"
+
+#~ msgid "Password copied"
+#~ msgstr "ਪਾਸਵਰਡ ਕਾਪੀ ਕੀਤਾ"
+
+#~ msgid "Custom"
+#~ msgstr "ਕਸਟਮ"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s ਦੀ ਜਾਂਚ ਜਾਰੀ"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "੧੦੦%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "ਡਿਸ-ਕੁਨੈਕਟ ਹੈ"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "ਕਨੈਕਟ ਹੈ"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "ਪਰਮਾਣਕਿਤਾ ਗਲਤੀ"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "ਪਰਮਾਣਕਿਤਾ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "ਘਟਾਈ ਗਈ ਕਾਰਜ ਸਮਰੱਥਾ"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "ਕਨੈਕਟ ਅਤੇ ਪਰਮਾਣਿਤ ਹੈ"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "ਅਣਪਛਾਤਾ"
+
+#~ msgid "Authorized at:"
+#~ msgstr "ਇਸ ਵੇਲੇ ਪਰਮਾਣਿਤ ਕੀਤਾ:"
+
+#~ msgid "Connected at:"
+#~ msgstr "ਇਸ ਵੇਲੇ ਕਨੈਕਟ ਕੀਤਾ:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "ਇਸ ਵੇਲੇ ਦਾਖਲ ਹੋਇਆ:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "ਡਿਵਾਈਸ ਨੂੰ ਪਰਮਾਣਿਤ ਕਰਨ ਲਈ ਅਸਫ਼ਲ:"
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "ਡਿਵਾਈਸ ਨੂੰ ਭੁੱਲਣ ਲਈ ਅਸਫ਼ਲ:"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "ਗ਼ਲਤੀ"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "ਪਰਮਾਣਿਤ ਹੈ"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "ਥੰਡਰਬੋਲਟ ਸਬ-ਸਿਸਟਮ (boldtd) ਠੀਕ ਤਰ੍ਹਾਂ ਇੰਸਟਾਲ ਨਹੀਂ ਹੈ ਜਾਂ ਠੀਕ ਤਰ੍ਹਾਂ ਸੈਟ ਅੱਪ ਨਹੀਂ ਕੀਤਾ "
+#~ "ਹੈ।"
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "ਸਿਰਫ਼ USB ਅਤੇ ਡਿਸਪਲੇਅ ਪੋਰਟ ਡਿਵਾਈਸ ਹੀ ਜੋੜ ਜਾ ਸਕਦੇ ਹਨ।"
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "ਥੰਡਰਬੋਲਟ ਖੋਜਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।\n"
+#~ "ਜਾਂ ਤਾਂ ਸਿਸਟਮ ਥੰਡਰਬੋਲਢ ਲਈ ਸਹਾਇਕ ਨਹੀ ਹੈ, ਇਹ BIOS ਵਿੱਚੋਂ ਅਸਮਰੱਥ ਕੀਤਾ ਹੋ ਸਕਦਾ ਹੈ ਜਾਂ "
+#~ "BIOS ਵਿੱਚ ਗ਼ੈਰ-ਸਹਾਇਕ ਸੁਰੱਖਿਆ ਪੱਧਰ ਲਈ ਸੈੱਟ ਕੀਤਾ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "ਥੰਡਰਬੋਲਟ ਲਈ ਸਹਿਯੋਗ ਨੂੰ BIOS 'ਚ ਅਸਮਰੱਥ ਕੀਤਾ ਹੈ।"
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "ਥੰਡਰਬੋਲਟ ਸੁਰੱਖਿਆ ਪੱਧਰ ਦਾ ਪਤਾ ਨਹੀਂ ਲਾਇਆ ਜਾ ਸਕਿਆ।"
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "ਸਿੱਧਾ ਮੋਡ ਬਦਲਣ ਲਈ ਗ਼ਲਤੀ: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "ਮੂਲ"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "ਮੱਧਮ"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "ਵੱਡਾ"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "ਹੋਰ ਵੱਡਾ"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "ਸਭ ਤੋਂ ਵੱਡਾ"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d ਪਿਕਸਲ"
+#~ msgstr[1] "%d ਪਿਕਸਲ"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "ਛੋਟਾ"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ਸਕਰੀਨ"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ਸਕਰੀਨ"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ਸਕਰੀਨ"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "ਲੰਮਾ"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "੧ ਘੰਟਾ"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "੧ ਦਿਨ"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "੨ ਦਿਨ"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "੩ ਦਿਨ"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "੪ ਦਿਨ"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "੫ ਦਿਨ"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "੬ ਦਿਨ"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "੭ ਦਿਨ"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "੧੪ ਦਿਨ"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "੩੦ ਦਿਨ"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "ਰੱਦੀ 'ਚੋਂ ਸਭ ਆਈਟਮਾਂ ਹਟਾਉਣੀਆਂ ਹਨ?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "ਰੱਦੀ ਵਿੱਚ ਮੌਜੂਦਾ ਆਈਟਮਾਂ ਨੂੰ ਪੱਕੇ ਤੌਰ ਉੱਤੇ ਹਟਾਇਆ ਜਾਵੇਗਾ।"
+
+#~ msgid "_Empty Trash"
+#~ msgstr "ਰੱਦੀ ਖਾਲੀ ਕਰੋ(_E)"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "ਸਭ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਹਟਾਉਣੀਆਂ ਹਨ?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "ਸਭ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਪੱਕੇ ਤੌਰ ਉੱਤੇ ਹਟਾਇਆ ਜਾਵੇਗਾ।"
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਨਸ਼ਟ ਕਰੋ(_P)"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "੧ ਦਿਨ"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "੭ ਦਿਨ"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "੩੦ ਦਿਨ"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "ਹਮੇਸ਼ਾ"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "ਤੁਹਾਡੇ ਲਾਗਇਨ ਪਰੋਵਾਇਡਰ ਦੇ ਵੈੱਬ ਐਡਰੈਸ ਨਾਲ ਮਿਲਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
+
+#~ msgid "Failed to add account"
+#~ msgstr "ਅਕਾਊਂਟ ਜੋੜਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "Failed to register account"
+#~ msgstr "ਅਕਾਊਂਟ ਰਜਿਸਟਰ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "ਇਹ ਡੋਮੇਨ ਨਾਲ ਪਰਮਾਣਕਿਤਾ ਦਾ ਕੋਈ ਸਹਾਇਕ ਢੰਗ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "ਡੋਮੇਨ ਜੁਆਇੰਨ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ਉਹ ਲਾਗਇਨ ਨਾਂ ਕੰਮ ਨਹੀਂ ਕਰਦਾ।\n"
+#~ "ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ ਜੀ।"
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ਇਹ ਲਾਗਇਨ ਪਾਸਵਰਡ ਕੰਮ ਨਹੀਂ ਕਰਦਾ ਹੈ।\n"
+#~ "ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "ਡੋਮੇਨ ਵਿੱਚ ਲਾਗਇਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "ਡੋਮੇਨ ਲੱਭਣ ਲਈ ਅਸਮਰੱਥ, ਸ਼ਾਇਦ ਤੁਸੀਂ ਇਹ ਗਲਤ ਲਿਖੀ ਹੋਵੇ?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "ਹੋਰ ਤਸਵੀਰਾਂ ਵੇਖੋ"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "ਇਹ ਐਕਸ਼ਨ ਕਰਨ ਲਈ ਡਿਵਾਈਸ ਨੂੰ ਮੱਲਣ ਦੀ ਲੋੜ ਹੈ"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "ਡਿਵਾਈਸ ਨੂੰ ਪਹਿਲਾਂ ਹੀ ਹੋਰ ਕਾਰਵਾਈ ਵੱਲੋ ਮੱਲ ਲਿਆ ਗਿਆ ਹੈ"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "ਤੁਹਾਡੇ ਕੋਲ ਕਾਰਵਾਈ ਕਰਨ ਲਈ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "ਕੋਈ ਪਰਿੰਟ ਦਾਖਲ ਨਹੀਂ ਕੀਤਾ ਗਿਆ ਹੈ"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "ਦਾਖਲ ਕਰਨ ਦੇ ਦੌਰਾਨ ਡਿਵਾਈਸ ਨਾਲ ਸੰਚਾਰ ਫੇਲ੍ਹ ਹੋ ਗਿਆ"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਰੀਡਰ ਨਾਲ ਸੰਚਾਰ ਕਰਨ ਲਈ ਅਸਫ਼ਲ ਹੈ"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡੈਮਨ ਨਾਲ ਸੰਚਾਰ ਕਰਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਦੀ ਸੂਚੀ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "ਸੰਭਾਲੇ ਫਿੰਗਰਪਰਿੰਟ ਹਟਾਉਣ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "ਖੱਬਾ ਅੰਗੂਠਾ"
+
+#~ msgid "Left middle finger"
+#~ msgstr "ਖੱਬੀ ਵਿਚਲੀ ਉਂਗਲ"
+
+#~ msgid "_Left index finger"
+#~ msgstr "ਖੱਬੀ ਇੰਡੈਕਸ ਉਂਗਲ(_L)"
+
+#~ msgid "Left ring finger"
+#~ msgstr "ਖੱਬੀ ਰਿੰਗ ਉਂਗਲ"
+
+#~ msgid "Left little finger"
+#~ msgstr "ਖੱਬੀ ਚੀਚੀ"
+
+#~ msgid "Right thumb"
+#~ msgstr "ਸੱਜਾ ਅੰਗੂਠਾ"
+
+#~ msgid "Right middle finger"
+#~ msgstr "ਸੱਜੀ ਵਿਚਲੀ ਉਂਗਲ"
+
+#~ msgid "_Right index finger"
+#~ msgstr "ਸੱਜੀ ਇੰਡੈਕਸ ਉਂਗਲ(_R)"
+
+#~ msgid "Right ring finger"
+#~ msgstr "ਸੱਜੀ ਰਿੰਗ ਉਂਗਲ"
+
+#~ msgid "Right little finger"
+#~ msgstr "ਸੱਜੀ ਚੀਚੀ"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "ਅਣਪਛਾਤੀ ਉਂਗਲ"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "ਪੂਰਾ"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਕਨੈਕਟ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਦੀ ਸਟੋਰੇਜ਼ ਭਰ ਗਈ"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "ਨਵਾਂ ਫਿੰਗਰਪਰਿੰਟ ਦਾਖਲ ਕਰਨ ਲਈ ਅਸਫ਼ਲ ਹੈ"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "ਦਾਖਲਾ ਸ਼ੁਰੂ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "ਨਵਾਂ ਫਿੰਗਰਪਰਿੰਟ ਦਾਖਲ ਕਰਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "ਦਾਖਲਾ ਰੋਕਣ ਲਈ ਫੇਲ੍ਹ: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr "ਆਪਣੇ ਫਿੰਗਰਪਰਿੰਟ ਨੂੰ ਦਾਖਲ ਕਰਨ ਲਈ ਰੀਡਰ ਉੱਤੇ ਆਪਣੀ ਉਂਗਲ ਨੂੰ ਲਗਾਤਾਰ ਚੱਕੋ ਅਤੇ ਰੱਖੋ"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "ਇਹ ਉਂਗਲ ਦੁਬਾਰਾ-ਦਾਖਲ ਕਰੋ(_R)…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "ਨਵਾਂ ਫਿੰਗਰਪਰਿੰਟ ਸਕੈਨ ਕਰੋ"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ %s ਛੱਡਣ ਲਈ ਫੇਲ੍ਹ: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "ਡਿਵਾਈਸ ਪੜ੍ਹਨ ਦੌਰਾਨ ਸਮੱਸਿਆ"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ %s ਮੱਲਣ ਲਈ ਫੇਲ੍ਹ: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਲੈਣ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
+
+#~ msgid "This Week"
+#~ msgstr "ਇਸ ਹਫ਼ਤੇ"
+
+#~ msgid "Last Week"
+#~ msgstr "ਪਿਛਲੇ ਹਫ਼ਤੇ"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "ਸ਼ੈਸ਼ਨ ਅੰਤ ਹੋਇਆ"
+
+#~ msgid "Session Started"
+#~ msgstr "ਸ਼ੈਸ਼ਨ ਸ਼ੁਰੂ ਹੋਇਆ"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — ਖਾਤਾ ਸਰਗਰਮੀ"
+
+#~ msgid "Please choose another password."
+#~ msgstr "ਵੱਖਰਾ ਪਾਸਵਰਡ ਚੁਣੋ ਜੀ।"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "ਆਪਣਾ ਮੌਜੂਦਾ ਪਾਸਵਰਡ ਫੇਰ ਲਿਖੋ ਜੀ।"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "ਪਾਸਵਰਡ ਬਦਲਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "ਡੋਮੇਨ ਦੀ ਇਹ ਕਿਸਮ ਲਈ ਆਟੋਮੈਟਿਕ ਜੁਆਇੰਨ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "ਕੋਈ ਡੋਮੇਨ ਜਾਂ ਰੀਲੇਮ ਨਹੀਂ ਲੱਭਿਆ"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s ਵਜੋਂ %s ਡੋਮੇਨ ਵਿੱਚ ਲਾਗਇਨ ਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "ਗਲਤ ਪਾਸਵਰਡ, ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ ਜੀ।"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "%s ਡੋਮੇਨ ਨਾਲ ਕਨੈਕਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ਵਰਤੋਂਕਾਰ ਹਟਾਉਣ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "ਰਿਮੋਟ ਤੋਂ ਇੰਤਜ਼ਾਮ ਅਧੀਨ ਵਰਤੋਂਕਾਰ ਮਨਸੂਖ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "ਤੁਸੀਂ ਆਪਣਾ ਖੁਦ ਦਾ ਅਕਾਊਂਟ ਹਟਾ ਨਹੀਂ ਸਕਦੇ।"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ਹਾਲੇ ਲਾਗਇਨ ਹੈ"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "ਜਦੋਂ ਵਰਤੋਂਕਾਰ ਲਾਗਇਨ ਹੋਵੇ ਤਾਂ ਉਸ ਨੂੰ ਹਟਾਉਣ ਨਾਲ ਸਿਸਟਮ ਖਰਾਬ ਹੋਣ ਦੀ ਹਾਲਤ 'ਚ ਆ ਸਕਦਾ ਹੈ।"
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "ਕੀ ਤੁਸੀਂ %s ਦੀਆਂ ਫਾਇਲਾਂ ਰੱਖਣੀਆਂ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ਘਰ ਡਾਇਰੈਕਟਰੀ, ਮੇਲ ਸਪੂਲ ਅਤੇ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਰੱਖਣਾ ਸੰਭਵ ਹੈ, ਜਦੋਂ ਵਰਤੋਂਕਾਰ ਖਾਤਾ ਹਟਾਉਣਾ ਹੋਵੇ।"
+
+#~ msgid "_Delete Files"
+#~ msgstr "ਫਾਇਲਾਂ ਹਟਾਓ(_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "ਫਾਇਲਾਂ ਰੱਖੋ(_K)"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "ਕੀ ਤੁਸੀਂ ਰਿਮੋਟ ਤੋਂ ਇੰਤਜ਼ਾਮ ਕੀਤੇ %s ਦੇ ਖਾਤੇ ਨੂੰ ਮਨਸੂਖ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "_Delete"
+#~ msgstr "ਹਟਾਓ(_D)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "ਅਕਾਊਂਟ ਬੰਦ ਹੈ"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "ਅਗਲੇ ਲਾਗਇਨ ਸਮੇਂ ਸੈੱਟ ਕਰੋ"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ"
+
+#~ msgid "Logged in"
+#~ msgstr "ਲਾਗਇਨ ਕੀਤਾ"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "ਅਕਾਊਂਟ ਸਰਵਿਸ ਨਾਲ ਸੰਪਰਕ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "ਯਕੀਨੀ ਬਣਾਉ ਕਿ ਅਕਾਊਂਟਸਰਵਿਸ (AccountService) ਇੰਸਟਾਲ ਹੈ ਅਤੇ ਯੋਗ ਹੈ"
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "ਇਸ ਸੈਟਿੰਗ ਬਦਲਣ ਲਈ ਇਹ ਪੈਲਨ ਅਣ-ਲਾਕ ਕੀਤਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "ਚੁਣਿਆ ਵਰਤੋਂਕਾਰ ਖਾਤਾ ਹਟਾਓ"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ਚੁਣੇ ਵਰਤੋਂਕਾਰ ਖਾਤੇ ਨੂੰ ਹਟਾਉਣ ਲਈ,\n"
+#~ "ਪਹਿਲਾਂ * ਆਈਕਾਨ ਉੱਤੇ ਕਲਿੱਕ ਕਰੋ"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "ਵਰਤੋਂਕਾਰ ਜੋੜਨ ਅਤੇ ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਪੁਰਾਣੇ ਨਾਲੋਂ ਵੱਖਰਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "ਕੁਝ ਅੱਖਰ ਤੇ ਨੰਬਰ ਬਦਲ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "ਪਾਸਵਰਡ ਨੂੰ ਕੁਝ ਹੋਰ ਬਦਲਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "ਬਿਨਾਂ ਵਰਤੋਂਕਾਰ ਨਾਂ ਵਾਲਾ ਪਾਸਵਰਡ ਮਜ਼ਬੂਤ ਹੋਵੇਗਾ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "ਆਪਣੇ ਨਾਂ ਨੂੰ ਪਾਸਵਰਡ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਨਾ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "ਪਾਸਵਰਡ ਵਿੱਚ ਦਿੱਤੇ ਕੁਝ ਸ਼ਬਦ ਛੱਡਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "ਆਮ ਸ਼ਬਦਾਂ ਦੀ ਵਰਤੋਂ ਨਾ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "ਮੌਜੂਦਾ ਸ਼ਬਦਾਂ ਨੂੰ ਅੱਗੇ ਪਿੱਛੇ ਕਰਨ ਨੂੰ ਛੱਡ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "ਹੋਰ ਅੰਕ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "ਹੋਰ ਵੱਡੇ ਅੱਖਰ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "ਹੋਰ ਛੋਟੇ ਅੱਖਰ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "ਹੋਰ ਖਾਸ ਅੱਖਰ ਜਿਵੇਂ ਵਿਰਾਮ-ਚਿੰਨ੍ਹ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "ਅੱਖਰ, ਅੰਕ ਅਤੇ ਵਿਰਾਮ-ਚਿੰਨ੍ਹ ਨੂੰ ਮਿਲਾ ਕੇ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "ਇੱਕੋ ਅੱਖਰ ਦੁਹਰਾਉਣ ਨੂੰ ਛੱਡ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "ਇੱਕੋ ਕਿਸਮ ਦੇ ਅੱਖਰ ਮੁੜ-ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ: ਤੁਸੀਂ ਅੱਖਰਾਂ, ਅੰਕਾਂ ਅਤੇ ਵਿਰਾਮ ਚਿੰਨ੍ਹਾਂ ਨੂੰ ਮਿਲ ਸਕਦੇ "
+#~ "ਹੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 ਜਾਂ abcd ਕ੍ਰਮ ਛੱਡਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "ਪਾਸਵਰਡ ਹੋਰ ਲੰਮਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ। ਅੱਖਰ, ਅੰਕ ਅਤੇ ਵਿਰਾਮ-ਚਿੰਨ੍ਹ ਨੂੰ ਮਿਲਾ ਕੇ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "ਵੱਡੇ ਤੇ ਛੋਟੇ ਅੱਖਰ ਮਿਲਾ ਕੇ ਅਤੇ ਇੱਕ ਜਾਂ ਦੋ ਨੰਬਰ ਵਰਤੇ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "ਹੋਰ ਅੱਖਰ, ਨੰਬਰ ਤੇ ਵਿਰਾਮ ਚਿੰਨ੍ਹ ਜੋੜਨ ਨਾਲ ਪਾਸਵਰਡ ਹੋਰ ਵੀ ਮਜ਼ਬੂਤ ਬਣੇਗਾ।"
+
+#~ msgid "Authentication failed"
+#~ msgstr "ਪਰਮਾਣਕਿਤਾ ਫੇਲ੍ਹ ਹੋਈ"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਬਹੁਤ ਛੋਟਾ ਹੈ"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਬਹੁਤ ਸਧਾਰਨ ਹੈ"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "ਪੁਰਾਣਾ ਅਤੇ ਨਵੇਂ ਪਾਸਵਰਡ ਇੱਕੋ ਜਿਹੇ ਜਾਪਦੇ ਹਨ"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਤਾਜ਼ਾ ਹੀ ਵਰਤਿਆ ਗਿਆ ਹੈ।"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "ਨਵੇਂ ਪਾਸਵਰਡ ਵਿੱਚ ਅੰਕ ਜਾਂ ਖਾਸ ਹੋਣੇ ਲਾਜ਼ਮੀ ਹਨ"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "ਪੁਰਾਣਾ ਅਤੇ ਨਵੇਂ ਪਾਸਵਰਡ ਇੱਕੋ ਹੀ ਹਨ"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "ਤੁਹਾਡੇ ਪਹਿਲਾਂ ਪਰਮਾਣਿਤ ਹੋਣ ਕਰਕੇ ਤੁਹਾਡਾ ਪਾਸਵਰਡ ਬਦਲਿਆ ਜਾ ਚੁੱਕਿਆ ਹੈ!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "ਨਵੇਂ ਪਾਸਵਰਡ 'ਚ ਲੋੜ ਮੁਤਾਬਕ ਵੱਖ ਵੱਖ ਕਿਸਮ ਦੇ ਅੱਖਰ ਨਹੀਂ ਹਨ"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "ਅਣਜਾਣ ਗਲਤੀ"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "ਵਰਤੋਂਕਾਰ ਨਾਂ ਵਿੱਚ ਅਕਸਰ ਕੇਵਲ ਅੰਗਰੇਜ਼ੀ ਦੇ ਛੋਟੇ ਅੱਖਰ (a-z), ਅੰਕ, ਅਤੇ ਅੱਗੇ ਦਿੱਤੇ ਅੱਖਰ ਹੋ ਸਕਦੇ ਹਨ: "
+#~ "- __"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "ਅਫ਼ਸੋਸ ਹੈ ਪਰ ਉਹ ਵਰਤੋਂਕਾਰ ਨਾਂ ਉਪਲਬਧ ਨਹੀਂ ਹੈ। ਹੋਰ ਵਰਤ ਕੇ ਵੇਖੋ।"
+
+#~ msgid "The username is too long."
+#~ msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ ਬਹੁਤ ਲੰਮਾ ਹੈ।"
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "ਬਟਨ %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "ਐਪਲੀਕੇਸ਼ਨ ਪਰਿਭਾਸ਼ਿਤ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "ਕੀਸਟਰੋਕ ਭੇਜੋ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "ਮਾਨੀਟਰ ਬਦਲੋ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "ਸਕਰੀਨ ਉੱਤੇ ਮਦਦ ਵੇਖਾਓ"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "ਟੇਬਲੇਟ ਲੈਪਟਾਪ ਪੈਨਲ ਉੱਤੇ ਮਾਊਂਟ ਹੈ"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "ਟੇਬਲੇਟ ਬਾਹਰੀ ਮਾਨੀਟਰ ਉੱਤੇ ਮਾਊੰਟ ਹੈ"
+
+#~ msgid "External tablet device"
+#~ msgstr "ਬਾਹਰੀ ਟੇਬਲੇਟ ਡਿਵਾਈਸ"
+
+#~ msgid "All Displays"
+#~ msgstr "ਸਾਰੇ ਡਿਸਪਲੇਅ"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "ਦਬਾਓ, ਟੇਡ ਤੇ ਮੌਜੂਦ ਸਲਾਈਡਰ ਨਾਲ ਏਅਰਬਰੱਸ਼ ਸਟਾਈਲਸ"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "ਦਬਾਓ, ਟੇਡ ਤੇ ਘੁੰਮਾਉਣ ਨਾਲ ਏਅਰਬਰੱਸ਼ ਸਟਾਈਲਸ"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "ਦਬਾਓ ਤੇ ਟੇਡ ਨਾਲ ਮਿਆਰੀ ਸਟਾਈਲਸ"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "ਦਬਾਓ ਨਾਲ ਮਿਆਰੀ ਸਟਾਈਲਸ"
+
+#~ msgid "New shortcut…"
+#~ msgstr "...ਨਵਾਂ ਸ਼ਾਰਟਕੱਟ"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "ਕਾਰਵਾਈ ਰੱਦ ਕੀਤੀ ਗਈ ਸੀ"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>ਗਲਤੀ:</b> ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਪਹੁੰਚ ਉੱਤੇ ਪਾਬੰਦੀ ਹੈ"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>ਗਲਤੀ:</b> ਮੋਬਾਈਲ ਯੰਤਰ ਗ਼ਲਤੀ"
+
+#~ msgid "Not Registered"
+#~ msgstr "ਰਜਿਸਟਰ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Registered"
+#~ msgstr "ਰਜਿਸਟਰ ਹੈ"
+
+#~ msgid "Roaming"
+#~ msgstr "ਰੋਮਿੰਗ"
+
+#~ msgid "Searching"
+#~ msgstr "ਖੋਜ ਜਾਰੀ ਹੈ"
+
+#~ msgid "Denied"
+#~ msgstr "ਇਨਕਾਰ"
+
+#~ msgid "2G Only"
+#~ msgstr "ਸਿਰਫ਼ 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "ਸਿਰਫ਼ 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "ਸਿਰਫ਼ 4G"
+
+#~| msgid "2G Only"
+#~ msgid "5G Only"
+#~ msgstr "ਸਿਰਫ਼ 5G"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (ਤਰਜੀਹੀ)"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (ਤਰਜੀਹੀ), 5G"
+
+#~| msgid "2G, 3G (Preferred), 4G"
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (ਤਰਜੀਹੀ), 4G, 5G"
+
+#~| msgid "2G (Preferred), 3G, 4G"
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (ਤਰਜੀਹੀ), 3G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (ਤਰਜੀਹੀ)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (ਤਰਜੀਹੀ), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (ਤਰਜੀਹੀ), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (ਤਰਜੀਹੀ)"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (ਤਰਜੀਹੀ), 5G"
+
+#~| msgid "3G (Preferred), 4G"
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (ਤਰਜੀਹੀ), 4G, 5G"
+
+#~| msgid "3G, 4G"
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (ਤਰਜੀਹੀ)"
+
+#~| msgid "2G, 3G (Preferred), 4G"
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G (ਤਰਜੀਹੀ), 5G"
+
+#~| msgid "2G (Preferred), 3G, 4G"
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (ਤਰਜੀਹੀ), 3G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~| msgid "2G, 3G, 4G (Preferred)"
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (ਤਰਜੀਹੀ)"
+
+#~| msgid "2G, 3G (Preferred), 4G"
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (ਤਰਜੀਹੀ), 5G"
+
+#~| msgid "2G (Preferred), 3G, 4G"
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (ਤਰਜੀਹੀ), 3G, 5G"
+
+#~| msgid "2G, 3G, 4G"
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (ਤਰਜੀਹੀ)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (ਤਰਜੀਹੀ), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (ਤਰਜੀਹੀ)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (ਤਰਜੀਹੀ), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (ਤਰਜੀਹੀ)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (ਤਰਜੀਹੀ), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~| msgid "2G, 4G (Preferred)"
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (ਤਰਜੀਹੀ)"
+
+#~| msgid "2G (Preferred), 4G"
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (ਤਰਜੀਹੀ), 5G"
+
+#~| msgid "2G, 4G"
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (ਤਰਜੀਹੀ)"
+
+#~| msgid "3G (Preferred), 4G"
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (ਤਰਜੀਹੀ), 5G"
+
+#~| msgid "3G, 4G"
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~| msgid "3G, 4G (Preferred)"
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (ਤਰਜੀਹੀ)"
+
+#~| msgid "3G (Preferred), 4G"
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (ਤਰਜੀਹੀ), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "ਅਣਪਛਾਤਾ"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "ਸਿਮ ਕਾਰਡ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "ਸਿਮ %d ਲਈ ਪਿੰਨ ਕੋਡ ਦਿਓ"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "ਆਪਣੇ ਸਿਮ ਨੂੰ ਅਣ-ਲਾਕ ਕਰਨ ਲਈ ਪਿੰਨ ਦਿਓ"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "ਸਿਮ %d ਲਈ PUK ਕੋਡ ਦਿਓ"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "ਆਪਣਾ ਸਿਮ ਕਾਰਡ ਅਣ-ਲਾਕ ਕਰਨ ਲਈ PUK ਦਿਓ"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "ਗਲਤ ਪਾਸਵਰਡ ਦਿੱਤਾ ਗਿਆ।"
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK ਕੋਡ 8 ਅੰਕਾਂ ਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "ਨਵਾਂ ਪਿੰਨ ਦਿਓ"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "ਪਿੰਨ ਕੋਡ 4-8 ਅੰਕਾਂ ਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "Unlocking…"
+#~ msgstr "…ਅਣ-ਲਾਕ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgid "Phone failure"
+#~ msgstr "ਫ਼ੋਨ ਅਸਫ਼ਲ ਹੈ"
+
+#~ msgid "No connection to phone"
+#~ msgstr "ਫ਼ੋਨ ਲਈ ਕੋਈ ਕਨੈਕਸ਼ਨ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "ਕਾਰਵਾਈ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Operation not supported"
+#~ msgstr "ਕਾਰਵਾਈ ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "ਸਿਮ ਨਹੀਂ ਪਾਇਆ ਹੈ"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "ਸਿਮ ਪਿੰਨ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "ਸਿਮ PUK required"
+
+#~ msgid "SIM failure"
+#~ msgstr "ਸਿਮ ਅਸਫ਼ਲ ਹੈ"
+
+#~ msgid "SIM busy"
+#~ msgstr "ਸਿਮ ਰੁੱਝਿਆ ਹੈ"
+
+#~ msgid "Incorrect password"
+#~ msgstr "ਗ਼ਲਤ ਪਾਸਵਰਡ"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM ਪਿੰਨ2 ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM PUK2 ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "Not found"
+#~ msgstr "ਨਹੀਂ ਲੱਭਿਆ"
+
+#~ msgid "No network service"
+#~ msgstr "ਕੋਈ ਨੈੱਟਵਰਕ ਸੇਵਾ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Network timeout"
+#~ msgstr "ਨੈੱਟਵਰਕ ਸਮਾਂ-ਸਮਾਪਤ"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS ਸੇਵਾਵਾਂ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "ਇਸ ਟਿਕਾਣੇ ਉੱਤੇ ਰੋਮਿੰਗ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "ਅਣਦੱਸੀ GPRS ਗ਼ਲਤੀ"
+
+#~ msgid "No Error"
+#~ msgstr "ਕੋਈ ਗਲਤੀ ਨਹੀਂ"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "ਕਾਰਵਾਈ ਰੱਦ ਕੀਤੀ"
+
+#~ msgid "Access denied"
+#~ msgstr "ਪਹੁੰਚ ਲਈ ਪਾਬੰਦੀ ਹੈ"
+
+#~ msgid "Unknown Error"
+#~ msgstr "ਅਣਪਛਾਤੀ ਗਲਤੀ"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "ਸਿਮ %d"
+
+#~ msgid "Display version number"
+#~ msgstr "ਵਰਜ਼ਨ ਨੰਬਰ ਦਿਖਾਓ"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "ਵੱਧ ਜਾਣਕਾਰੀ ਮੋਡ ਚਾਲੂ"
+
+#~ msgid "Search for the string"
+#~ msgstr "ਸਤਰ ਲਈ ਖੋਜੋ"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "ਸੰਭਵ ਪੈਨਲ ਨਾਂ ਵੇਖਾਉ ਅਤੇ ਬੰਦ ਕਰੋ"
+
+#~ msgid "Panel to display"
+#~ msgstr "ਵੇਖਾਉਣ ਲਈ ਪੈਨਲ"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "ਉਪਲੱਬਧ ਪੈਨਲ:"
+
+#~ msgid "System Sounds"
+#~ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
+
+#~ msgid "Basic Protection"
+#~ msgstr "ਮੁੱਢਲੀ ਸੁਰੱਖਿਆ"
+
+#~| msgid "Add connection"
+#~ msgid "Extended Protection"
+#~ msgstr "ਵਾਧਾ ਕੀਤੀ ਸੁਰੱਖਿਆ"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI ਲਿਖਣ"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI ਲਾਕ"
+
+#~| msgid "Select a region"
+#~ msgid "SPI BIOS region"
+#~ msgstr "SPI BIOS ਖੇਤਰ"
+
+#~| msgid "Suspend"
+#~ msgid "Suspend-to-ram"
+#~ msgstr "ਸਸਪੈਂਡ-ਟੂ-ਰੈਮ"
+
+#~| msgid "Manufacturer"
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "MEI ਨਿਰਮਾਤਾ ਢੰਗ"
+
+#~| msgid "PEAP _version"
+#~ msgid "MEI version"
+#~ msgstr "MEI ਵਰਜ਼ਨ"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "fwupd ਪਲੱਗਇਨਾਂ"
+
+#~| msgctxt "Password mode"
+#~| msgid "Account disabled"
+#~ msgid "Secure Boot disabled"
+#~ msgstr "ਸਕਿਉਰ ਬੂਟ ਅਸਮਰੱਥ ਹੈ"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "ਸਕਿਉਰ ਬੂਟ ਸਮਰੱਥ ਹੈ"
+
+#~ msgid "Lock your screen"
+#~ msgstr "ਆਪਣੀ ਸਕਰੀਨ ਲਾਕ ਕਰੋ"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER ਜਾਂ PEM ਸਰਟੀਫਿਕੇਟ (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Drip"
+#~ msgstr "ਚੌਂਣਾ"
+
+#~ msgid "Glass"
+#~ msgstr "ਕੱਚ"
+
+#~ msgid "Sonar"
+#~ msgstr "ਸੋਨਰ"
 
 #~ msgid "Light"
 #~ msgstr "ਹਲਕਾ"
@@ -9375,12 +8310,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
 #~ "network;identity;"
 #~ msgstr "ਸਕਰੀਨ;ਲਾਕ;ਜਾਂਚ;ਪੜਤਾਲ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਆਰਜ਼ੀ;ਇੰਡੈਕਸ;ਨਾਂ;ਨੈੱਟਵਰਕ;ਪਛਾਣ;ਕਰੈਸ਼;ਤਾਜ਼ਾ;"
-
-#~ msgid ""
-#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-#~ "network;identity;privacy;"
-#~ msgstr ""
-#~ "ਸਕਰੀਨ;ਲਾਕ;ਜਾਂਚ;ਪੜਤਾਲ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਆਰਜ਼ੀ;ਇੰਡੈਕਸ;ਨਾਂ;ਨੈੱਟਵਰਕ;ਪਛਾਣ;ਕਰੈਸ਼;ਤਾਜ਼ਾ;ਪਰਦੇਦਾਰੀ;"
 
 #~ msgid "Set"
 #~ msgstr "ਸੈੱਟ ਕਰੋ"
@@ -9455,8 +8384,8 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ msgstr "ਬਦਲ ਨਹੀਂ ਸਕਦੇ"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "ਐਪਲੀਕੇਸ਼ਨਾਂ ਲਈ ਵੱਖੋ-ਵੱਖ ਇਜਾਜ਼ਤਾਂ ਦੀ ਪੜਤਾਲ <a href=\"privacy\">ਪਰਦੇਦਾਰੀ</a> ਸੈਟਿੰਗਾਂ "
 #~ "ਵਿੱਚ ਕੀਤੀ ਜਾ ਸਕਦੀ ਹੈ।"
@@ -9534,17 +8463,11 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ msgid "Active Display"
 #~ msgstr "ਸਰਗਰਮ ਡਿਸਪਲੇਅ"
 
-#~ msgid "Display Configuration"
-#~ msgstr "ਡਿਸਪਲੇਅ ਸੰਰਚਨਾ"
-
 #~ msgid "More Warm"
 #~ msgstr "ਵੱਧ ਗੂੜ੍ਹੇ"
 
 #~ msgid "Less Warm"
 #~ msgstr "ਘੱਟ ਗੂੜ੍ਹੇ"
-
-#~ msgid "Screenshots"
-#~ msgstr "ਸਕਰੀਨਸ਼ਾਟ"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "ਸਕਰੀਨਸ਼ਾਟ $PICTURES ਵਿੱਚ ਸੰਭਾਲੋ"
@@ -9660,9 +8583,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr "ਕੁਝ ਸਰਵਿਸਾਂ ਬੰਦ ਹਨ, ਕਿਉਂਕਿ ਕੋਈ ਨੈੱਟਵਰਕ ਪਹੁੰਚ ਨਹੀਂ ਹੈ।"
 
-#~ msgid "Screen Sharing"
-#~ msgstr "ਸਕਰੀਨ ਸਾਂਝ"
-
 #~ msgid "_Password:"
 #~ msgstr "ਪਾਸਵਰਡ(_P):"
 
@@ -9747,9 +8667,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "ਟੇਬਲੇਟ (ਅਸਲ)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "ਟੱਚਪੈਚ (ਅਨੁਸਾਰੀ)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "ਟੇਬਲੇਟ ਪਸੰਦ"
@@ -10765,9 +9682,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ msgid "Mirrored"
 #~ msgstr "ਮਿਰਰ ਕੀਤੇ"
 
-#~ msgid "Secondary"
-#~ msgstr "ਸੈਕੰਡਰੀ"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "ਜੋੜੇ ਡਿਸਪਲੇਅ ਲਗਾਉ"
 
@@ -10842,9 +9756,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ msgctxt "proxy method"
 #~ msgid "Automatic"
 #~ msgstr "ਆਟੋਮੈਟਿਕ"
-
-#~ msgid "_Method"
-#~ msgstr "ਢੰਗ(_M)"
 
 #~ msgid "Add Device"
 #~ msgstr "ਜੰਤਰ ਸ਼ਾਮਲ"
@@ -10963,10 +9874,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 
 #~ msgid "Mail"
 #~ msgstr "ਮੇਲ"
-
-#~| msgid "_Calendar"
-#~ msgid "Calendar"
-#~ msgstr "ਕੈਲੰਡਰ"
 
 #~ msgid "Contacts"
 #~ msgstr "ਸੰਪਰਕ"
@@ -11108,9 +10015,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 
 #~ msgid "Scroll Up"
 #~ msgstr "ਉੱਤੇ ਸਕਰੋਲ"
-
-#~ msgid "Scroll Down"
-#~ msgstr "ਹੇਠਾਂ ਸਕਰੋਲ"
 
 #~ msgid "Scroll Right"
 #~ msgstr "ਸੱਜਾ ਸਕਰੋਲ"
@@ -11404,9 +10308,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ msgid "China"
 #~ msgstr "ਚੀਨ"
 
-#~ msgid "Disable while _typing"
-#~ msgstr "ਲਿਖਣ ਦੌਰਾਨ ਬੰਦ ਕਰੋ(_t)"
-
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "ਸਿਸਟਮ ਨੈੱਟਵਰਕ ਸਰਵਿਸ ਇਸ ਵਰਜਨ ਨਾਲ ਕੰਮ ਨਹੀਂ ਕਰਦੀ ਹੈ।"
 
@@ -11447,9 +10348,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 
 #~ msgid "Share Public Folder On This Network"
 #~ msgstr "ਇਹ ਨੈੱਟਵਰਕ ਉੱਤੇ ਪਬਲਿਕ ਫੋਲਡਰ ਸਾਂਝਾ ਕਰੋ"
-
-#~ msgid "Flickr"
-#~ msgstr "ਫਲਿੱਕਰ"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "ਨਵਾਂ ਜੰਤਰ ਸੈੱਟਅੱਪ"
@@ -12253,9 +11151,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ "Select a display language (change will be applied next time you log in)"
 #~ msgstr "ਵੇਖਾਉਣ ਲਈ ਭਾਸ਼ਾ ਚੁਣੋ (ਇਹ ਤੁਹਾਡਾ ਵਲੋਂ ਅਗਲੀ ਵਾਰ ਲਾਗਇਨ ਸਮੇਂ ਲਾਗੂ ਕੀਤੀ ਜਾਵੇਗੀ)"
 
-#~ msgid "Install languages..."
-#~ msgstr "...ਭਾਸ਼ਾ ਇੰਸਟਾਲ ਕਰੋ"
-
 #~ msgid "Brightness & Lock"
 #~ msgstr "ਚਮਕ ਤੇ ਲਾਕ"
 
@@ -12551,9 +11446,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ "ਦਿਓ"
 
 #~ msgid "Layouts"
-#~ msgstr "ਲੇਆਉਟ"
-
-#~ msgid "Layout"
 #~ msgstr "ਲੇਆਉਟ"
 
 #~ msgid "1/2 Screen"
@@ -12862,9 +11754,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ msgid "Use previous window's layout in new windows"
 #~ msgstr "ਨਵੀਆਂ ਵਿੰਡੋਜ਼ ਵਿੱਚ ਪਿਛਲੀ ਵਿੰਡੋ ਦੇ ਲੇਆਉਟ ਵਰਤੋਂ"
 
-#~ msgid "_Acceleration:"
-#~ msgstr "ਐਕਸਰਲੇਟਰ(_A):"
-
 #~ msgid "DSL"
 #~ msgstr "DSL"
 
@@ -12988,9 +11877,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 
 #~ msgid "Put the computer to sleep when on:"
 #~ msgstr "ਕੰਪਿਊਟਰ ਨੂੰ ਸਲੀਪ ਮੋਡ 'ਚ ਰੱਖੋ, ਜਦੋਂ:"
-
-#~ msgid "Restrictions:"
-#~ msgstr "ਪਾਬੰਦੀਆਂ:"
 
 #~ msgid "add-toolbutton"
 #~ msgstr "ਐਡ-ਟੂਲਬਟਨ"
@@ -14038,9 +12924,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "ਡਿਫਾਲਟ ਰੀ-ਸੈੱਟ ਕਰੋ(_R)"
-
 #~ msgid "_Selected items:"
 #~ msgstr "ਚੁਣੀਆਂ ਆਈਟਮਾਂ(_S):"
 
@@ -14174,9 +13057,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 
 #~ msgid "Copying files"
 #~ msgstr "ਫਾਇਲਾਂ ਕਾਪੀ ਕੀਤੀਆਂ ਜਾ ਰਹੀਆਂ ਹਨ"
-
-#~ msgid "Parent Window"
-#~ msgstr "ਮੁੱਢਲੀ ਵਿੰਡੋ"
 
 #~ msgid "Parent window of the dialog"
 #~ msgstr "ਡਾਈਲਾਗ ਦੀ ਮੁੱਢਲੀ ਵਿੰਡੋ"
@@ -14695,9 +13575,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 #~ msgid "Set your window properties"
 #~ msgstr "ਆਪਣੀ ਵਿੰਡੋ ਵਿਸ਼ੇਸ਼ਤਾ ਦਿਓ"
 
-#~ msgid "Windows"
-#~ msgstr "ਵਿੰਡੋ"
-
 #~ msgid "Hide on start (useful to preload the shell)"
 #~ msgstr "ਸ਼ੁਰੂ ਉੱਤੇ ਓਹਲੇ (ਪ੍ਰੀ-ਲੋਡ ਸ਼ੈੱਲ ਲਈ ਫਾਇਦੇਮੰਦ)"
 
@@ -14992,9 +13869,6 @@ msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
 
 #~ msgid "<b>Music and Movies</b>"
 #~ msgstr "<b>ਸੰਗੀਤ ਅਤੇ ਮੂਵੀ</b>"
-
-#~ msgid "Click OK to finish."
-#~ msgstr "ਪੂਰਾ ਕਰਨ ਲਈ ਠੀਕ ਹੈ ਦਬਾਓ।"
 
 #~ msgid "Play _sound effects when buttons are clicked"
 #~ msgstr "ਜਦੋਂ ਬਟਨ ਕਲਿੱਕ ਕੀਤਾ ਜਾਵੇ ਤਾਂ ਸਾਊਂਡ ਪਰਭਾਵ ਚਲਾਓ(_s)"

--- a/po/pa.po~
+++ b/po/pa.po~
@@ -1,0 +1,16024 @@
+# translation of gnome-control-center.HEAD.po to Punjabi
+# Punjabi translation of gnome-control-center.HEAD.
+# Copyright (C) 2004 THE gnome-control-center.HEAD'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center.HEAD package.
+#
+#
+# Amanpreet Singh Alam <amanlinux@netscape.net>, 2004.
+# Amanpreet Singh Alam <aalam@users.sf.net>, 2005,2006,2007,2008,2009.
+# A S Alam <aalam@users.sf.net>, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.HEAD\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/issu"
+"es\n"
+"POT-Creation-Date: 2022-10-15 18:38+0000\n"
+"PO-Revision-Date: 2022-10-16 17:32-0700\n"
+"Last-Translator: A S Alam <aalam@satluj.org>\n"
+"Language-Team: Punjabi <punjabi-users@list.sf.net>\n"
+"Language: pa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Lokalize 22.08.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "ਸਿਸਟਮ ਬੱਸ"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "ਪੂਰੀ ਪਹੁੰਚ"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "ਸ਼ੈਸ਼ਨ ਬੱਸ"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ਡਿਵਾਈਸ"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "/dev ਲਈ ਪੂਰੀ ਪਹੁੰਚ"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "ਨੈੱਟਵਰਕ"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "ਨੈੱਟਵਰਕ ਪਹੁੰਚ ਹੈ"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "ਘਰ"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "ਕੇਵਲ-ਪੜ੍ਹਨ ਲਈ"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "ਫਾਇਲ ਸਿਸਟਮ"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "ਸੈਟਿੰਗ"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "ਸੈਟਿੰਗਾਂ ਬਦਲ ਸਕਦੇ ਹਨ"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s ਵਿੱਚ ਅੱਗੇ ਦਿੱਤੀਆਂ ਇਜਾਜ਼ਤਾਂ ਪਹਿਲਾਂ ਹੀ ਹਨ। ਇਹਨਾਂ ਨੂੰ ਬਦਲਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਹੈ।"
+" ਜੇ ਤੁਸੀਂ ਇਹ "
+"ਇਜਾਜ਼ਤਾਂ ਬਾਰੇ ਫ਼ਿਕਰ ਕਰਦੇ ਹੋ ਤਾਂ ਇਸ ਐਪਲੀਕੇਸ਼ਨ ਨੂੰ ਹਟਾਉਣ ਬਾਰੇ ਵਿਚਾਰ ਕਰੋ।"
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u ਫਾਇਲ ਤੇ ਲਿੰਕ ਕਿਸਮ, ਜੋ ਕਿ ਐਪ ਵਲੋਂ ਖੋਲ੍ਹੇ ਜਾਂਦੇ ਹਨ"
+msgstr[1] "%u ਫਾਇਲ ਤੇ ਲਿੰਕ ਕਿਸਮਾਂ, ਜੋ ਕਿ ਐਪ ਵਲੋਂ ਖੋਲ੍ਹੇ ਜਾਂਦੇ ਹਨ"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> ਨੂੰ ਫਾਇਲਾਂ ਤੇ ਲਿੰਕਾਂ ਦੀਆਂ ਹੇਠ ਦਿੱਤੀਆਂ ਕਿਸਮਾਂ ਖੋਲ੍ਹਣ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ"
+" ਹੈ।"
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+#| msgid "%s of disk space used"
+msgid "%s of disk space used."
+msgstr "%s ਡਿਸਕ ਥਾਂ ਵਰਤੀ ਗਈ।"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "ਐਪਲੀਕੇਸ਼ਨਾਂ"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "ਕੋਈ ਐਪਲੀਕੇਸ਼ਨ ਨਹੀਂ"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "…ਕੁਝ ਇੰਸਟਾਲ ਕਰੋ"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "ਖੋਲ੍ਹੋ"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "ਵੇਰਵੇ ਵੇਖੋ"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "ਖੋਜ"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "ਸਿਸਟਮ ਖੋਜਾਂ ਲਵੋ ਅਤੇ ਨਤੀਜੇ ਭੇਜੋ"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "ਅਸਮਰੱਥ ਹੈ"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "ਸੂਚਨਾਵਾਂ"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "ਸਿਸਟਮ ਨੋਟੀਫਿਕੇਸ਼ਨ ਵੇਖਾਓ।"
+
+#: panels/applications/cc-applications-panel.ui:133
+#| msgid "Run in background"
+msgid "Run in Background"
+msgstr "ਬੈਕਗਰਾਊਂਡ ਵਿੱਚ ਚਲਾਓ"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "ਜਦੋਂ ਐਪ ਬੰਦ ਹੋਵੇ ਤਾਂ ਸਰਗਰਮੀ ਦੀ ਇਜਾਜ਼ਤ ਹੈ।"
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "ਸਕਰੀਨਸ਼ਾਟ"
+
+#: panels/applications/cc-applications-panel.ui:141
+#| msgid "Take pictures with the camera."
+msgid "Take pictures of the screen at any time."
+msgstr "ਕਿਸੇ ਵੀ ਵੇਲੇ ਸਕਰੀਨ ਦੀਆਂ ਤਸਵੀਰਾਂ ਲਵੋ।"
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "ਵਾਲਪੇਪਰ ਬਦਲੋ"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "ਡੈਸਕਟਾਪ ਵਾਲਪੇਪਰ ਬਦਲੋ।"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "ਸਾਊਂਡ"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "ਆਵਾਜ਼ਾ ਮੁੜ-ਤਿਆਰ ਕਰੋ।"
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "ਸਿਸਟਮ-ਰੋਕੂ ਸ਼ਾਰਟਕੱਟ"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "ਮਿਆਰੀ ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟਾਂ ਉੱਤੇ ਪਾਬੰਦੀ ਲਾਈ ਹੈ।"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "ਕੈਮਰਾ"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "ਕੈਮਰੇ ਨਾਲ ਤਸਵੀਰਾਂ ਲਵੋ।"
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "ਮਾਈਕਰੋਫੋਨ"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "ਮਾਈਕਰੋਫੋਨ ਨਾਲ ਆਡੀਓ ਰਿਕਾਰਡ ਕਰੋ।"
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "ਟਿਕਾਣਾ ਸੇਵਾਵਾਂ"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "ਡਿਵਾਈਸ ਟਿਕਾਣਾ ਡਾਟੇ ਲਈ ਪਹੁੰਚ।"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "ਬਿਲਟ-ਇਨ ਇਜਾਜ਼ਤਾਂ"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "ਐਪ ਵਲੋਂ ਚਾਹੀਦੀ ਸਿਸਟਮ ਪਹੁੰਚ"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "ਫਾਇਲ ਤੇ ਲਿੰਕ ਸੰਬੰਧ"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "ਸਟੋਰੇਜ਼"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "ਕੋਈ ਨਤੀਜੇ ਨਹੀਂ ਲੱਭੇ"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "ਵੱਖਰੀ ਖੋਜ ਨਾਲ ਕੋਸ਼ਿਸ਼ ਕਰੋ"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "ਫਾਇਲ ਤੇ ਲਿੰਕ ਸੰਬੰਧ"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "ਫਾਇਲ ਕਿਸਮਾਂ"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "ਲਿੰਕ ਕਿਸਮਾਂ"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "ਮੁੜ-ਸੈੱਟ"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "ਐਪ ਡਾਟੇ ਅਤੇ ਕੈਸ਼ ਨਾਲ ਇਹ ਐਪਲੀਕੇਸ਼ਨ ਕਿੰਨੀ ਡਿਸਕ ਥਾਂ ਵਰਤ ਰਹੀ ਹੈ।"
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "ਐਪਲੀਕੇਸ਼ਨ"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "ਡਾਟਾ"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "ਕੈਸ਼"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>ਕੁੱਲ</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "…ਕੈਸ਼ ਸਾਫ਼ ਕਰੋ"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "ਕਈ ਐਪੀਕੇਸ਼ਨ ਇਜਾਜ਼ਤਾਂ ਅਤੇ ਸੈਟਿੰਗਾਂ ਨੂੰ ਕੰਟੋਰਲ ਕਰਦਾ ਹੈ।"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "ਐਪਲੀਕੇਸ਼ਨ;ਫਲੈਟਪੈਕ;ਇਜਾਜ਼ਤ;ਸੈਟਿੰਗ;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "ਤਸਵੀਰ ਚੁਣੋ"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "ਰੱਦ ਕਰੋ(_C)"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "ਖੋਲ੍ਹੋ(_O)"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "ਕਈ ਆਕਾਰ"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "ਕੋਈ ਡੈਸਕਟਾਪ ਬੈਕਗਰਾਊਂਡ ਨਹੀਂ"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "ਮੌਜੂਦਾ ਬੈਕਗਰਾਊਂਡ"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "ਸਟਾਇਲ"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "ਡਿਫਾਲਟ"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "ਗੂੜ੍ਹਾ"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "ਬੈਕਗਰਾਊਂਡ"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "…ਤਸਵੀਰ ਜੋੜੋ"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "ਦਿੱਖ"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "ਆਪਣੇ ਬੈਕਗਰਾਊਂਡ ਚਿੱਤਰ ਜਾਂ UI ਨੂੰ ਬਦਲੋ"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"ਬੈਕਗਰਾਊਂਡ;ਵਾਲਪੇਪਰ;ਸਕਰੀਨ;ਡੈਸਕਟਾਪ;ਕੰਧ-ਚਿੱਤਰ;ਹਲਕਾ;ਗੂੜ੍ਹਾ;ਫਿੱਕਾ;ਪਿਛੋਕੜ;ਕੰਧ-ਚਿੱਤਰ;ਦ"
+"ਿੱਖ;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "ਚਾਲੂ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "ਕੋਈ ਬਲੂਟੁੱਥ ਨਹੀਂ ਲੱਭਾ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "ਬਲੂਟੁੱਥ ਵਰਤਣ ਲਈ ਡੌਂਗਲ ਪਲੱਗਇਨ ਕਰੋ।"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "ਬਲੂਟੁੱਥ ਬੰਦ ਕਰੋ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "ਜੰਤਰਾਂ ਨਾਲ ਕਨੈਕਟ ਕਰਨ ਅਤੇ ਫਾਇਲ ਟਰਾਂਸਫਰ ਕਰਨ ਲਈ ਚਾਲੂ ਕਰੋ।"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "ਏਅਰਪਲੇਨ ਮੋਡ ਚਾਲੂ ਹੈ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "ਬਲੂਟੁੱਥ ਬੰਦ ਹੁੰਦਾ ਹੈ, ਜਦੋਂ ਏਅਰਪਲੇਨ ਮੋਡ ਚਾਲੂ ਹੈ।"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "ਏਅਰਪਲੇਨ ਮੋਡ ਬੰਦ ਕਰੋ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "ਹਾਰਡਵੇਅਰ ਏਅਰਪਲੇਨ ਮੋਡ ਚਾਲੂ ਹੈ"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "ਬਲੂਟੁੱਥ ਨੂੰ ਸਮਰੱਥ ਕਰਨ ਲਈ ਏਅਰਪਲੇਨ ਮੋਡ ਨੂੰ ਬੰਦ ਕਰੋ।"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "ਬਲੂਟੁੱਥ"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "ਬਲੂਟੁੱਥ ਜੰਤਰ ਨੂੰ ਚਾਲੂ ਤੇ ਬੰਦ ਕਰੋ ਅਤੇ ਆਪਣੇ ਜੰਤਰਾਂ ਨਾਲ ਕਨੈਕਟ ਕਰੋ-"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "ਸਾਂਝਾ ਕਰਨਾ;ਸਾਂਝਾ;ਸ਼ੇਅਰਿੰਗ;ਬਲਿਊਟੂੱਥ;ਬਲੂਟੁੱਥ;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "ਕੈਮਰਾ ਬੰਦ ਕੀਤਾ ਹੈ"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "ਕੋਈ ਐਪਲੀਕੇਸ਼ਨ ਫ਼ੋਟੋ ਖਿੱਚ ਜਾਂ ਵਿਡੀਓ ਬਣਾ ਨਹੀਂ ਸਕਦੀ ਹੈ।"
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"ਕੈਮਰੇ ਦੀ ਵਰਤੋਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਫੋਟੋ ਖਿੱਚਣ ਅਤੇ ਵਿਡੀਓ ਬਣਾਉਣ ਦਿੰਦੀ ਹੈ। ਕੈਮਰੇ ਨੂੰ"
+" ਅਸਮਰੱਥ ਕਰਨ ਨਾਲ ਕੁਝ "
+"ਐਪਲੀਕੇਸ਼ਨਾਂ ਠੀਕ ਤਰ੍ਹਾਂ ਕੰਮ ਨਹੀਂ ਕਰ ਸਕਦੀਆਂ।\n"
+"\n"
+"ਹੇਠ ਦਿੱਤੀਆਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡਾ ਕੈਮਰਾ ਵਰਤਣ ਦੀ ਇਜਾਜ਼ਤ ਹੈ।"
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "ਕੈਮਰਾ ਪਹੁੰਚ ਲਈ ਕੋਈ ਐਪਲੀਕੇਸ਼ਨ ਨੇ ਨਹੀਂ ਪੁੱਛਿਆ ਹੈ"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "ਆਪਣੀਆਂ ਤਸਵੀਰਾਂ ਨੂੰ ਸੁਰੱਖਿਅਤ ਕਰੋ"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"ਕੈਮਰਾ;ਫੋਟੋ;ਫ਼ੋਟੋ;ਤਸਵੀਰ;ਵੀਡੀਓ;ਵਿਡੀਓ;ਵੈਬਕੈਮ;ਲਾਕ;ਤਾਲਾ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;ਪ੍ਰਾਈਵੇਟ;"
+"ਨਿੱਜੀ;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "ਆਪਣੇ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਵਰਗ ਉੱਤੇ ਰੱਖੋ ਅਤੇ ”ਸ਼ੁਰੂ” ਨੂੰ ਦੱਬੋ।"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"ਆਪਣੇ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਕੈਲੀਬਰੇਸ਼ਨ ਸਥਿਤੀ ਉਤੇ ਲੈ ਜਾਉ ਅਤੇ ”ਜਾਰੀ ਰੱਖੋ” ਦੱਬੋ"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "ਆਪਣੇ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਤਲ ਸਥਿਤੀ ਉਤੇ ਲੈ ਜਾਉ ਅਤੇ ”ਜਾਰੀ ਰੱਖੋ” ਦੱਬੋ"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "ਲੈਪਟਾਪ ਢੱਕਣ ਬੰਦ"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "ਅੰਦਰੂਨੀ ਗਲਤੀ ਆਈ ਹੈ, ਜਿਸ ਤੋਂ ਉਭਰਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਲਈ ਲੋੜੀਂਦੇ ਟੂਲ ਇੰਸਟਾਲ ਨਹੀਂ ਹਨ।"
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "ਪਰੋਫਾਇਲ ਤਿਆਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "ਟਾਰਗੇਟ ਚਿੱਟਾ-ਬਿੰਦੂ ਪ੍ਰਾਪਤੀ ਯੋਗ ਨਹੀਂ ਹੈ।"
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "ਪੂਰੇ ਹੋਏ!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਫੇਲ੍ਹ ਹੋਈ!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "ਤੁਸੀਂ ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਹਟਾ ਸਕਦੇ ਹੋ।"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ ਨੂੰ ਚੱਲਣ ਦੇ ਦੌਰਾਨ ਛੇੜੋ ਨਾ"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "ਡਿਸਪਲੇਅ ਕੈਲੀਬਰੇਸ਼ਨ"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "ਸ਼ੁਰੂ ਕਰੋ(_S)"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "ਮੁੜ-ਪ੍ਰਾਪਤ ਕਰੋ(_R)"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "ਮੁਕੰਮਲ(_D)"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "ਲੈਪਟਾਪ ਸਕਰੀਨ"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "ਬਿਲਟ-ਇਨ ਵੈਬਕੈਮ"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s ਮਾਨੀਟਰ"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s ਸਕੈਨਰ"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s ਕੈਮਰਾ"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s ਪਰਿੰਟਰ"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s ਵੈੱਬਕੈਮ"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s ਲਈ ਰੰਗ ਇੰਤਜ਼ਾਮ ਸਮਰੱਥ ਕਰੋ"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s ਲਈ ਰੰਗ ਪਰੋਫਾਇਲ ਵੇਖੋ"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "ਕੈਲੀਬਰੇਟ ਨਹੀਂ"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "ਡਿਫਾਲਟ: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "ਰੰਗ-ਸਪੇਸ: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "ਪਰੋਫਾਇਲ ਟੈਸਟ: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "ICC ਪਰੋਫਾਇਲ ਫਾਇਲ ਚੁਣੋ"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "ਇੰਪੋਰਟ(_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "ਸਹਾਇਕ ICC ਪਰੋਫਾਇਲ"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "ਸਭ ਫਾਇਲਾਂ"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "ਸਕਰੀਨ"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "ਪਰੋਫਾਇਲ ਸੰਭਾਲੋ"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "ਸੰਭਾਲੋ(_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "ਚੁਣੇ ਜੰਤਰ ਲਈ ਇੱਕ ਰੰਗ ਪਰੋਫਾਇਲ ਬਣਾਉ"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"ਮਾਪ ਜੰਤਰ ਖੋਜਿਆ ਨਹੀਂ ਗਿਆ ਹੈ। ਚੈੱਕ ਕਰੋ ਕਿ ਇਹ ਚਾਲੂ ਹੈ ਅਤੇ ਠੀਕ ਤਰ੍ਹਾਂ ਕੂਨੈਕਟ ਕੀਤਾ"
+" ਹੋਇਆ ਹੈ।"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "ਮਾਪ ਜੰਤਰ ਪਰਿੰਟਿੰਗ ਪਰੋਫਾਇਲਿੰਗ ਲਈ ਸਹਾਇਕ ਨਹੀਂ।"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "ਜੰਤਰ ਕਿਸਮ ਹਾਲੇ ਸਹਾਇਕ ਨਹੀਂ ਹੈ।"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "ਸਕਰੀਨ ਕੈਲੀਬਰੇਸ਼ਨ"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਕੁਆਲਟੀ"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"ਕੈਲੀਬਰੇਸ਼ਨ ਇੱਕ ਪਰੋਫਾਇਲ ਦੇਵੇਗੀ, ਜਿਸ ਨੂੰ ਤੁਸੀਂ ਆਪਣੀ ਸਕਰੀਨ ਦੇ ਰੰਗ ਦੇ ਪਰਬੰਧ ਲਈ ਵਰਤ"
+" ਸਕਦੇ ਹੋ। "
+"ਕੈਲੀਬਰੇਸ਼ਨ ਉੱਤੇ ਜਿੰਨਾ ਵੱਧ ਸਮਾਂ ਤੁਸੀਂ ਲਗਾਉਗੇ, ਰੰਗ ਪਰੋਫਾਇਲ ਉਹਨਾਂ ਹੀ ਵੱਧ ਚੰਗਾ"
+" ਹੋਵੇਗਾ।"
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "ਤੁਸੀਂ ਕੈਲੀਬਰੇਸ਼ਨ ਹੋਣ ਦੇ ਦੌਰਾਨ ਆਪਣੇ ਕੰਪਿਊਟਰ ਨੂੰ ਵਰਤ ਨਹੀਂ ਸਕੋਗੇ।"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "ਕੁਆਲਟੀ"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "ਲਗਭਗ ਸਮਾਂ"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "ਕੈਲੀਬਰੇਸ਼ਨ ਜੰਤਰ"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "ਸੈਂਸਰ ਜੰਤਰ ਚੁਣੋ, ਜੋ ਤੁਸੀਂ ਕੈਲੀਬਰੇਸ਼ਨ ਲਈ ਵਰਤਣਾ ਚਾਹੁੰਦੇ ਹੋ।"
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "ਡਿਸਪਲੇਅ ਕਿਸਮ"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "ਕਨੈਕਟ ਕੀਤੇ ਗਏ ਡਿਸਪਲੇਅ ਦੀ ਕਿਸਮ ਚੁਣੋ।"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "ਪਰੋਫਾਇਲ ਚਿੱਟਾ-ਬਿੰਦੂ"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"ਡਿਸਪਲੇਅ ਟਾਰਗੇਟ ਚਿੱਟਾ ਬਿੰਦੂ ਚੁਣੋ। ਬਹੁਤੇ ਡਿਸਪਲੇਅ ਨੂੰ D65 illuminant ਤੱਕ"
+" ਕੈਲੀਬਰੇਟ ਕੀਤਾ ਜਾਣਾ "
+"ਚਾਹੀਦਾ ਹੈ।"
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "ਡਿਸਪਲੇਅ ਚਮਕ"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"ਡਿਸਪਲੇਅ ਲਈ ਚਮਕ ਪੱਧਰ ਸੈੱਟ ਕਰੋ, ਜੋ ਤੁਸੀਂ ਆਮ ਤੌਰ ਉੱਤੇ ਵਰਤਦੇ ਹੋ। ਰੰਗ ਪਰਬੰਧ ਉਸ ਚਮਕ"
+" ਪੱਧਰ ਉੱਤੇ ਸਭ ਤੋਂ "
+"ਵੱਧ ਸ਼ੁੱਧ ਹੋਵੇਗਾ।"
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"ਬਦਲਵੇਂ ਰੂਪ ਵਿੱਚ, ਤੁਸੀਂ  ਇਹ ਜੰਤਰ ਲਈ ਹੋਰ ਪਰੋਫਾਇਲਾਂ ਵਿੱਚੋਂ ਇੱਕ ਨੂੰ ਚਮਕ ਪੱਧਰ ਲਈ"
+" ਵਰਤ ਸਕਦੇ ਹੋ।"
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "ਫਾਇਲ ਨਾਂ"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"ਤੁਸੀਂ ਵੱਖਰੇ ਕੰਪਿਊਟਰ ਉੱਤੇ ਰੰਗ ਪਰੋਫਾਇਲ ਵਰਤ ਸਕਦੇ ਹੋ ਜਾਂ ਵੱਖਰੀਆਂ ਚਾਨਣ ਸ਼ਰਤਾਂ"
+" ਮੁਤਾਬਕ ਰੰਗ ਪਰੋਫਾਇਲ ਬਣਾ "
+"ਸਕਦੇ ਹੋ।"
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "ਪਰੋਫਾਇਲ ਨਾਂ:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "ਸੰਖੇਪ"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "ਪਰੋਫਾਇਲ ਠੀਕ ਤਰ੍ਹਾਂ ਬਣਾਇਆ ਗਿਆ!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "ਪਰੋਫਾਇਲ ਕਾਪੀ ਕਰੋ"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "ਲਿਖਣਯੋਗ ਮੀਡਿਆ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"ਤੁਸੀਂ ਪਰੋਫਾਇਲ ਨੂੰ <a href=\"linux\">GNU/ਲੀਨਕਸ</a>, <a href=\"osx\">ਐਪਲ OS X<"
+"/a> "
+"ਅਤੇ <a href=\"windows\">Microsoft Windows</a> ਸਿਸਟਮ ਉੱਤੇ ਕਿਵੇਂ ਵਰਤੀਏ ਬਾਰੇ"
+" ਹਦਾਇਤਾਂ "
+"ਵੇਖ ਸਕਦੇ ਹੋ।"
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "ਪਰੋਫਾਇਲ ਜੋੜੋ"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"ਸਮੱਸਿਆ ਆਈ ਹੈ। ਪਰੋਫਾਇਲ ਠੀਕ ਤਰ੍ਹਾਂ ਸ਼ਾਇਦ ਕੰਮ ਨਾ ਕਰੇ।  <a href=\"\">ਵੇਰਵਾ ਵੇਖੋ</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "…ਫਾਇਲ ਇੰਪੋਰਟ ਕਰੋ(_I)"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "ਸ਼ਾਮਲ(_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "ਹਰੇਕ ਜੰਤਰ ਲਈ ਰੰਗ ਪਰਬੰਧ ਲਈ ਮਿਤੀ ਰੰਗ ਪਰੋਫਾਇਲ ਅੱਪਡੇਟ ਕਰਨ ਦੀ ਲੋੜ ਹੈ।"
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "ਹੋਰ ਸਿੱਖੋ"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "ਰੰਗ ਇੰਤਜ਼ਾਮ ਬਾਰੇ ਹੋਰ ਸਿੱਖੋ"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "ਸਭ ਵਰਤੋਂਕਾਰਾਂ ਲਈ ਸੈੱਟ ਕਰੋ(_S)"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "ਇਹ ਪਰੋਫਾਇਲ ਨੂੰ ਇਸ ਕੰਪਿਊਟਰ ਦੇ ਸਭ ਵਰਤੋਂਕਾਰਾਂ ਲਈ ਸੈੱਟ ਕਰੋ"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "ਚਾਲੂ ਕਰੋ(_E)"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "ਪਰੋਫਾਇਲ ਸ਼ਾਮਲ(_A)"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "ਕੈਲੇਬਰੇਟ(_C)…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "ਜੰਤਰ ਕੈਲੀਬਰੇਟ ਕਰੋ"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "ਪਰੋਫਾਇਲ ਹਟਾਓ(_R)"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "ਵੇਰਵੇ ਵੇਖੋ(_V)"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "ਕਿਸੇ ਵੀ ਜੰਤਰ ਨੂੰ ਖੋਜਣ ਲਈ ਅਸਮਰੱਥ, ਜੋ ਕਿ ਰੰਗਾਂ ਦਾ ਇੰਤਜ਼ਾਮ ਕਰ ਸਕਦਾ ਹੈ"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "ਪਰੋਜੈਕਟਰ"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "ਪਲਾਜ਼ਮਾ"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL ਬੈਕਲਾਈਟ)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED ਬੈਕਲਾਈਟ)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (ਵਾਈਟ LED ਬੈਕਲਾਈਟ)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "ਵਾਈਡ ਗਾਮੁਟ LCD (CCFL ਬੈਕਲਾਈਟ)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "ਵਾਈਡ ਗਾਮੁਟ LCD (RGB LED ਬੈਕਲਾਈਟ)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "ਉੱਚ"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "੪੦ ਮਿੰਟ"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "ਮੱਧਮ"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "੩੦ ਮਿੰਟ"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "ਘੱਟ"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "੧੫ ਮਿੰਟ"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "ਡਿਸਪਲੇਅ ਲਈ ਨੇਟਿਵ"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (ਪਰਿੰਟ ਤੇ ਪਬਲਿਸ਼ ਕਰਨ)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (ਫੋਟੋਗਰਾਫ਼ੀ ਅਤੇ ਗਰਾਫਿਕਸ)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "ਸਟੈਂਡਰਡ ਥਾਂ"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "ਪਰੋਫਾਇਲ ਟੈਸਟ"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "ਆਟੋਮੈਟਿਕ"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "ਘੱਟ ਕੁਆਲਟੀ"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "ਮੱਧਮ ਕੁਆਲਟੀ"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "ਵਧਿਆ ਕੁਆਲਟੀ"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "ਡਿਫਾਲਟ RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "ਡਿਫਾਲਟ CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "ਡਿਫਾਲਟ ਸਲੇਟੀ"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "ਵੇਂਡਰ ਵਲੋਂ ਦਿੱਤਾ ਫੈਕਟਰੀ ਕੈਲੀਬਰੇਸ਼ਨ ਡਾਟਾ"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "ਇਹ ਪਰੋਫਾਇਲ ਲਈ ਪੂਰੀ-ਸਕਰੀਨ ਡਿਸਪਲੇਅ ਸੋਧ ਸੰਭਵ ਨਹੀਂ"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "ਇਹ ਪਰੋਫਾਇਲ ਹੁਣ ਠੀਕ ਨਹੀਂ ਰਿਹਾ ਹੋ ਸਕਦਾ ਹੈ"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "ਰੰਗ"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"ਆਪਣੇ ਜੰਤਰਾਂ, ਜਿਵੇਂ ਕਿ ਡਿਸਪਲੇਅ, ਕੈਮਰੇ ਜਾਂ ਪਰਿੰਟਰਾਂ ਦੇ ਰੰਗ ਨੂੰ ਕੈਲੀਬਰੇਟ ਕਰੋ"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"ਰੰਗ;Color;ICC;Profile;Calibrate;ਪ੍ਰਿੰਟਰ;ਪਰਿੰਟਰ;Printer;Display;ਡਿਸਪਲੇਅ;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "…ਹੋਰ"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "ਭਾਸ਼ਾ ਚੁਣੋ"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "ਚੁਣੋ(_S)"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "ਕੋਈ ਭਾਸ਼ਾ ਨਹੀਂ ਲੱਭੀ।"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "…ਹੋਰ"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "ਕੁਝ ਸੈਟਿੰਗਾਂ ਨੂੰ ਬਦਲਣ ਤੋਂ ਪਹਿਲਾਂ ਅਣ-ਲਾਕ ਕਰਨਾ ਪਵੇਗਾ।"
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "…ਅਣ-ਲਾਕ ਕਰੋ"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "ਵਾਧਾ ਘੰਟਾ"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "ਵਾਧਾ ਮਿੰਟ"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "ਸਮਾਂ"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "ਘਾਟਾ ਘੰਟਾ"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "ਘਾਟਾ ਮਿੰਟ"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "ਅੱਜ"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "ਕੱਲ੍ਹ"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d ਘੰਟਾ"
+msgstr[1] "%d ਘੰਟੇ"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d ਮਿੰਟ"
+msgstr[1] "%d ਮਿੰਟ"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d ਸਕਿੰਟ"
+msgstr[1] "%d ਸਕਿੰਟ"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 ਸਕਿੰਟ"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "ਹਾਟਸਪਾਟ"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-ਘੰਟੇ"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "ਸਵੇਰ/ਆਥਣ"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "ਮਿਤੀ ਤੇ ਸਮਾਂ"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "ਸਾਲ"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "ਮਹੀਨਾ"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "ਜਨਵਰੀ"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ਫਰਵਰੀ"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "ਮਾਰਚ"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "ਅਪਰੈਲ"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "ਮਈ"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "ਜੂਨ"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "ਜੁਲਾਈ"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "ਅਗਸਤ"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "ਸਤੰਬਰ"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ਅਕਤੂਬਰ"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "ਨਵੰਬਰ"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ਦਸੰਬਰ"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "ਦਿਨ"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "ਸਮਾਂ ਖੇਤਰ"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "ਸ਼ਹਿਰ ਲਈ ਖੋਜ"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "ਤਾਰੀਖ ਤੇ ਸਮਾਂ ਆਪਣੇ-ਆਪ ਲਵੋ(_D)"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "ਇੰਟਰਨੈੱਟ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "ਤਾਰੀਖ ਤੇ ਸਮਾਂ(_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "ਆਟੋਮੈਟਿਕ ਸਮਾਂ ਖੇਤਰ(_Z)"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "ਟਿਕਾਣਾ ਸੇਵਾਵਾ ਸਮਰੱਥ ਅਤੇ ਇੰਟਰਨੈੱਟ ਪਹੁੰਚ ਚਾਹੀਦੀ ਹੈ"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "ਯੋਗ ਕੀਤਾ"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "ਸਮੇਂ ਦਾ ਇਲਾਕਾ(_o)"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "ਸਮੇਂ ਦਾ ਫਾਰਮੈਟ(_F)"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "ਤਾਰੀਖ ਅਤੇ ਸਮਾਂ, ਸਮੇਂ ਦੇ ਇਲਾਕੇ ਸਮੇਤ ਬਦਲੋ"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "ਕਲਾਕ;ਘੜੀ;ਸਮਾਂ,ਵੇਲਾ ਇਲਾਕਾ;ਸਥਾਨ;ਥਾਂ;ਸਮਾਂ-ਖੇਤਰ;ਟਿਕਾਣਾ;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "ਸਿਸਟਮ ਦਾ ਸਮਾਂ ਅਤੇ ਤਾਰੀਖ ਸੈਟਿੰਗਾਂ ਨੂੰ ਬਦਲੋ"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "ਸਮਾਂ ਜਾਂ ਤਾਰੀਖ ਸੈਟਿੰਗਾਂ ਨੂੰ ਬਦਲਣ ਲਈ, ਤੁਹਾਨੂੰ ਪਰਮਾਣਿਤ ਹੋਣ ਦੀ ਲੋੜ ਹੈ।"
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "ਵੈੱਬ(_W)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "ਮੇਲ(_M)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "ਕੈਲੰਡਰ(_C)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "ਸੰਗੀਤ(_u)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "ਵਿਡੀਓ(_V)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "ਫੋਟੋ(_P)"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "ਮੂਲ ਐਪਲੀਕੇਸ਼ਨ"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "ਮੂਲ ਐਪਲੀਕੇਸ਼ਨਾਂ ਦੀ ਸੰਰਚਨਾ ਕਰੋ"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "ਡਿਫਾਲਟ;ਮੂਲ;ਐਪਲੀਕੇਸ਼ਨ;ਤਰਜੀਹੀ;ਮੀਡੀਆ;ਪਸੰਦ;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"ਤਕਨੀਕੀ ਸਮੱਸਿਆਵਾਂ ਬਾਰੇ ਰਿਪੋਰਟਾਂ ਭੇਜਣ ਨਾਲ ਸਾਨੂੰ %s ਸੁਧਾਰਨ ਲਈ ਮਦਦ ਮਿਲਦੀ ਹੈ।"
+" ਰਿਪੋਰਟ ਅਣਪਛਾਤੇ "
+"ਰੂਪ ਵਿੱਚ ਭੇਜੀਆਂ ਜਾਂਦੀਆਂ ਹਨ ਅਤੇ ਨਿੱਜੀ ਡਾਟੇ ਨੂੰ ਹਟਾਇਆ ਜਾਂਦਾ ਹੈ। %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "ਸਮੱਸਿਆ ਰਿਪੋਰਟ ਦੇਣੀ"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "ਸਮੱਸਿਆ ਬਾਰੇ ਆਟੋਮੈਟਿਕ ਰਿਪੋਰਟ ਕਰੋ(_A)"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "ਪੜਤਾਲ"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "ਆਪਣੀਆਂ ਸਮੱਸਿਆਵਾ ਬਾਰੇ ਰਿਪੋਰਟ ਦਿਓ"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "ਪੜਤਾਲ;ਕਰੈਸ਼;ਨਸ਼ਟ;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "ਚਾਲੂ"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "ਬੰਦ"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "ਬਦਲਾਅ ਲਾਗੂ ਕਰਨੇ ਹਨ?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "ਤਬਦੀਲੀਆਂ ਲਾਗੂ ਨਹੀਂ ਕੀਤੀਆਂ ਜਾ ਸਕਦੀਆਂ"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "ਇਹ ਹਾਰਡਵੇਅਰ ਰੋਕਾਂ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "ਲਾਗੂ ਕਰੋ(_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "ਪਿੱਛੇ"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "ਡਿਸਪਲੇਅ ਸੈਟਿੰਗਾਂ ਅਸਮਰੱਥ ਹਨ"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "ਕੋਈ ਡਿਸਪਲੇਅ"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "ਜੁਆਇੰਨ"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "ਹੂ-ਬਹੂ"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "ਸਿਖਰਲੀ ਪੱਟੀ ਜਾਂ ਸਰਗਰਮੀਆਂ ਰੱਖਦਾ ਹੈ"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "ਪ੍ਰਾਇਮਰੀ ਡਿਸਪਲੇਅ"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "ਰਾਤ ਦੀ ਰੋਸ਼ਨੀ"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "ਲੈਂਡਸਕੇਪ"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "ਪੋਰਟਰੇਟ ਸੱਜੇ"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "ਪੋਰਟਰੇਟ ਖੱਬੇ"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "ਲੈਂਡਸਕੇਪ (ਪਲਟਿਆ)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "ਸਥਿਤੀ"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "ਰੈਜ਼ੋਲੂਸ਼ਨ"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "ਤਾਜ਼ਾ ਕਰਨ ਦੀ ਦਰ"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "TV ਲਈ ਤਰਤੀਬ ਦਿਓ"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "ਸਕੇਲ"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "ਰਾਤ ਦੀ ਰੋਸ਼ਨੀ ਮੌਜੂਦ ਨਹੀਂ"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"ਇਹ ਵਰਤੇ ਜਾ ਰਹੇ ਗਰਾਫਿਕਸ ਡਰਾਇਵਰ ਦੇ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ ਜਾਂ ਰਿਮੋਟ ਤੋਂ ਡੈਸਕਟਾਪ ਵਰਤਣ"
+" ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "ਭਲਕ ਤੱਕ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਕੀਤਾ"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "ਫਿਲਟਰ ਮੁੜ-ਚਾਲੂ ਕਰੋ"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"ਰਾਤ ਦੀ ਰੋਸ਼ਨੀ ਸਕਰੀਨ ਰੰਗਾਂ ਨੂੰ ਨਿੱਘਾ ਬਣਾਉਂਦੀ ਹੈ। ਇਸ ਅੱਖਾਂ ਉੱਤੇ ਜ਼ੋਰ ਪੈਣ ਅਤੇ ਨੀਂਦ"
+" ਟਲਣ ਤੋਂ ਰੋਕਣ ਲਈ "
+"ਮਦਦ ਕਰਦੀ ਹੈ।"
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "ਸੈਡਿਊਲ"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "ਸੂਰਜ ਚੜ੍ਹਨ ਤੋਂ ਡੁੱਬਣ ਤੱਕ"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "ਖੁਦ ਦਾ ਸੈਡਿਊਲ"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "ਸਮੇਂ"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "ਤੋਂ"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "ਘੰਟਾ"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "ਮਿੰਟ"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "ਸਵੇਰ"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "ਆਥਣ"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "ਤੱਕ"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "ਰੰਗ ਦਾ ਤਾਪਮਾਨ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "ਡਿਸਪਲੇਅ"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "ਚੁਣੋ ਕਿ ਮਾਨੀਟਰਾਂ ਅਤੇ ਪਰੋਜੈਕਟਰ ਨਾਲ ਕਿਵੇਂ ਜੁੜਨਾ ਹੈ"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"ਪੈਨਲ;ਪਰੋਜੈਕਟਰ;xrandr;ਸਕਰੀਨ;ਰੈਜ਼ੋਲੂਸ਼ਨ;ਤਾਜ਼ਾ;ਮਾਨੀਟਰ;ਰਾਤ;ਰਾਤਰੀ;ਰੌਸ਼ਨੀ;ਪ੍ਰਕਾਸ਼;ਨੀਲਾ"
+";ਲਾਲ-"
+"ਪਰਿਵਰਤਨ;ਸੂਰਜ-ਚੜ੍ਹਨਾ;ਸੂਰਜ-ਲਹਿਣਾ;ਸੂਰਜ-ਡੁੱਬਣਾ;ਹਨੇਰਾ;ਰਾਤ-ਵੇਲਾ;ਚਾਨਣ;ਸਰਘੀ;ਤਰਕਾਲਾਂ;ਆਥ"
+"ਣ;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "ਸਕਿਉਰ ਬੂਟ ਸਰਗਰਮ ਹੈ"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"ਸਕਿਉਰ ਬੂਟ ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਨੂੰ ਲੋਡ ਹੋਣ ਤੋਂ ਰੋਕਦਾ ਹੈ।"
+" ਇਹ ਇਸ ਵੇਲੇ ਚਾਲੂ ਅਤੇ ਠੀਕ ਤਰ੍ਹਾਂ ਕੰਮ ਕਰਦਾ ਹੈ।"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "ਸਕਿਉਰ ਬੂਟ ਨਾਲ ਸਮੱਸਿਆਵਾਂ ਹਨ"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"ਸਕਿਉਰ ਬੂਟ ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਨੂੰ ਲੋਡ ਹੋਣ ਤੋਂ ਰੋਕਦਾ ਹੈ।"
+" ਇਹ ਇਸ ਵੇਲੇ ਚਾਲੂ ਕੀਤਾ ਹੋਇਆ ਹੈ, ਪਰ ਗ਼ੈਰ-ਵਾਜਬ ਕੁੰਜੀ ਦੇ ਕਰਕੇ ਕੰਮ ਨਹੀਂ ਕਰੇਗਾ।"
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"ਸਕਿਉਰ ਬੂਟ ਸਮੱਸਿਆਵਾਂ ਨੂੰ ਅਕਸਰ ਤੁਹਾਡੇ ਕੰਪਿਊਟਰ ਦੇ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ (BIOS)"
+" ਵਿੱਚੋਂ  ਹੱਲ਼ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ ਅਤੇ ਤੁਹਾਡੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਵਲੋਂ ਇਹ ਹੱਲ ਕਰਨ"
+" ਬਾਰੇ ਜਾਣਕਾਰੀ ਦਿੱਤੀ ਗਈ ਹੋ ਸਕਦੀ ਹੈ।"
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "ਸਹਾਇਤਾ ਲਈ ਆਪਣੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਜਾਂ IT ਸਹਾਇਤਾ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "ਸਕਿਉਰ ਬੂਟ ਬੰਦ ਕੀਤਾ ਹੈ"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"ਸਕਿਉਰ ਬੂਟ ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਨੂੰ ਲੋਡ ਹੋਣ ਤੋਂ ਰੋਕਦਾ ਹੈ।"
+" ਇਹ ਇਸ ਵੇਲੇ ਬੰਦ ਕੀਤਾ "
+"ਹੋਇਆ ਹੈ।"
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"ਸਕਿਉਰ ਬੂਟ ਨੂੰ ਅਕਸਰ ਤੁਹਾਡੇ ਕੰਪਿਊਟਰ ਦੇ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ (BIOS) ਵਿੱਚ ਚਾਲੂ"
+" ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ। ਮਦਦ ਲਈ ਆਪਣੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਜਾਂ IT ਸਹਾਇਤਾ ਦੇਣ ਵਾਲੇ ਨਾਲ"
+" ਸੰਪਰਕ ਕਰੋ।"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"ਸਕਿਉਰ ਬੂਟ ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਨੂੰ ਲੋਡ ਹੋਣ ਤੋਂ ਰੋਕਦਾ ਹੈ।\n"
+"\n"
+"ਹੋਰ ਜਾਣਕਾਰੀ ਲਈ ਆਪਣੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਜਾਂ IT ਸਹਾਇਤਾ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#| msgid "Password"
+msgid "Passed"
+msgstr "ਪਾਸ ਹੈ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#| msgid "PPP failed"
+msgid "Failed"
+msgstr "ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "ਡਿਵਾਈਸ HSI ਪੱਧਰ %d ਲਈ ਤਸਦੀਕ ਹੈ"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+#| msgid "Security Level"
+msgid "Security Level 0"
+msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"ਇਹ ਡਿਵਾਈਸ ਨੂੰ ਕਿਸੇ ਵੀ ਹਾਰਡਵੇਅਰ ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਲਈ ਸੁਰੱਖਿਆ ਨਹੀਂ ਹੈ। ਇਹ ਹਾਰਡਵੇਅਰ"
+" ਜਾਂ ਫਿਰਮਵੇਅਰ ਸੰਰਚਨਾ ਨਾਲ ਮਸਲਾ ਹੋਣ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ। ਤੁਹਾਨੂੰ ਆਪਣੇ ਆਈ.ਟੀ. ਸਹਾਇਤਾ"
+" ਦੇਣ ਨਾਲ ਸੰਪਰਕ ਕਰਨ ਦੀ ਸਿਫਾਰਸ਼ ਕੀਤੀ ਜਾਂਦੀ ਹੈ।"
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+#| msgid "Security Level"
+msgid "Security Level 1"
+msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"ਇਸ ਡਿਵਾਈਸ ਨੂੰ ਹਾਰਡਵੇਅਰ ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਲਈ ਘੱਟੋ-ਘੱਟ ਸੁਰੱਖਿਆ ਹੈ। ਇਹ ਡਿਵਾਈਸ"
+" ਸੁਰੱਖਿਆ ਦਾ ਸਭ ਤੋਂ ਘੱਟ ਪੱਧਰ ਹੈ ਅਤੇ ਸਿਰਫ਼ ਸਰਲ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਤੋਂ ਹੀ ਸੁਰੱਖਿਆ"
+" ਦਿੰਦੀ ਹੈ।"
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+#| msgid "Security Level"
+msgid "Security Level 2"
+msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"ਇਹ ਡਿਵਾਈਸ ਨੂੰ ਹਾਰਡਵੇਅਰ ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਵਿਰੁਧ ਮੁ਼ੱਢਲੀ ਸੁਰੱਖਿਆ ਹੈ। ਇਹ ਕੁਝ ਆਮ"
+" ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਤੋਂ ਸੁਰੱਖਿਆ ਦਿੰਦੀ ਹੈ।"
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+#| msgid "Security Level"
+msgid "Security Level 3"
+msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"ਇਸ ਡਿਵਾਈਸ ਨੂੰ ਹਾਰਡਵੇਅਰ ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਲਈ ਵਾਧਾ ਕੀਤੀ ਸੁਰੱਖਿਆ ਹੈ। ਇਹ ਡਿਵਾਈਸ"
+" ਸੁਰੱਖਿਆ ਦਾ ਸਭ ਤੋਂ ਵੱਧ ਪੱਧਰ ਹੈ ਅਤੇ ਮਾਹਰ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਤੋਂ ਹੀ ਸੁਰੱਖਿਆ ਦਿੰਦੀ"
+" ਹੈ।"
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "ਸੁਰੱਖਿਆ ਪੱਧਰ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "ਇਸ ਡਿਵਾਈਸ ਲਈ ਸੁਰੱਖਿਆ ਪੱਧਰ ਮੌਜੂਦ ਨਹੀਂ ਹਨ।"
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+#| msgid "For help, contact your hardware manufacturer or IT support provider."
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr "ਸੁਰੱਖਿਆ ਅੱਪਡੇਟਾਂ ਬਾਰੇ ਮਦਦ ਵਾਸਤੇ ਆਪਣੇ ਹਾਰਡਵੇਅਰ ਨਿਰਮਾਤਾ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"ਇਸ ਮਸਲੇ ਨੂੰ ਡਿਵਾਈਸ ਦੇ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਜਾਂ ਸਹਾਇਤਾ ਟੈਕਨੀਸ਼ੀਅਨ ਵਲੋਂ"
+" ਹੱਲ ਕਰਨਾ ਸੰਭਵ ਹੈ।"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "ਇਸ ਮਸਲੇ ਨੂੰ ਡਿਵਾਈਸ ਦੇ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਹੱਲ ਕਰਨਾ ਸੰਭਵ ਹੈ।"
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "ਕਿਸੇ ਸਹਾਇਤਾ ਟੈਕਨੀਸ਼ੀਅਨ ਵਲੋਂ ਇਹ ਮਸਲੇ ਨੂੰ ਹੱਲ਼ ਕਰਨਾ ਸੰਭਵ ਹੈ।"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#| msgid "Ink Level"
+msgid "Level 1"
+msgstr "ਪੱਧਰ 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#| msgid "Ink Level"
+msgid "Level 2"
+msgstr "ਪੱਧਰ 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#| msgid "Ink Level"
+msgid "Level 3"
+msgstr "ਪੱਧਰ 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "ਜਦੋਂ ਡਿਵਾਈਸ ਸ਼ੁਰੂ ਹੁੰਦਾ ਹੈ ਤਾਂ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰਾਂ ਤੋਂ ਸੁਰੱਖਿਅਤ ਹੈ।"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "ਸਕਿਉਰ ਬੂਟ ਨਾਲ ਸਮੱਸਿਆਵਾਂ ਹਨ"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "ਡਿਵਾਈਸ ਦੇ ਸ਼ੁਰੂ ਹੋਣ ਵੇਲੇ ਕੁਝ ਸੁਰੱਖਿਆ ਹੈ।"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+#| msgid "Secure Boot is Turned Off"
+msgid "Secure Boot is Off"
+msgstr "ਸਕਿਉਰ ਬੂਟ ਬੰਦ ਕੀਤਾ ਹੈ"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "ਜਦੋਂ ਡਿਵਾਈਸ ਸ਼ੁਰੂ ਹੁੰਦਾ ਹੈ ਤਾਂ ਕੋਈ ਸੁਰੱਖਿਆ ਨਹੀਂ ਹੈ।"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"ਇਹ ਮਸਲਾ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਕਿਸੇ ਤਬਦੀਲੀ, ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਸੰਰਚਨਾ ਵਿੱਚ"
+" ਤਬਦੀਲੀ ਜਾਂ ਇਸ ਸਿਸਟਮ ਉੱਤੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰ ਦੇ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"ਇਹ ਮਸਲਾ UEFI ਫਿਰਮਵੇਅਰ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਕਿਸੇ ਤਬਦੀਲੀ, ਜਾਂ ਇਸ ਸਿਸਟਮ ਉੱਤੇ ਖੁਣਸੀ"
+" ਸਾਫਟਵੇਅਰ ਦੇ ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"ਇਹ ਮਸਲਾ ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਸੰਰਚਨਾ ਵਿੱਚ ਤਬਦੀਲੀ ਜਾਂ ਇਸ ਸਿਸਟਮ ਉੱਤੇ ਖੁਣਸੀ ਸਾਫਟਵੇਅਰ ਦੇ"
+" ਕਰਕੇ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "ਗੰਭੀਰ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਲਈ ਖੁੱਲ੍ਹਾ ਹੈ।"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "ਸਰਲ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਵਿਰੁੱਧ ਸੀਮਿਤ ਸੁਰੱਖਿਆ ਹੈ।"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "ਆਮ ਸੁਰੱਖਿਆ ਖ਼ਤਰਿਆਂ ਵਿਰੁੱਧ ਸੁਰੱਖਿਆ ਹੈ।"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "ਸੁਰੱਖਿਆ ਮਸਲਿਆਂ ਦੀ ਵੱਡੀ ਗਿਣਤੀ ਵਿਰੁੱਧ ਸੁਰੱਖਿਆ ਹੈ।"
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "ਸੰਪੂਰਨ ਸੁਰੱਖਿਆ"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "ਕੋਈ ਘਟਨਾ ਨਹੀਂ"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection"
+msgstr "ਫਿਰਮਵੇਅਰ ਲਿਖਣ ਸੁਰੱਖਿਆ"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection Lock"
+msgstr "ਫਿਰਮਵੇਅਰ ਲਿਖਣ ਸੁਰੱਖਿਆ ਲਾਕ"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Region"
+msgstr "ਫਿਰਮਵੇਅਰ BIOS ਖੇਤਰ"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+#| msgid "Description"
+msgid "Firmware BIOS Descriptor"
+msgstr "ਫਿਰਮਵੇਅਰ BIOS ਵਰਣਨ"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+#| msgid "No Protection"
+msgid "Pre-boot DMA Protection"
+msgstr "ਪ੍ਰੀ-ਬੂਟ DMA ਸੁਰੱਖਿਆ"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel ਬੂਟਗਾਰਡ"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+#| msgid "Intel BootGuard verified boot"
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel ਬੂਟਗਾਰਡ ਤਸਦੀਕ ਕੀਤਾ ਬੂਟ"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+#| msgid "Intel BootGuard"
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel ਬੂਟਗਾਰਡ ACM ਸੁਰੱਖਿਅਤ"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+#| msgid "Intel BootGuard"
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel ਬੂਟਗਾਰਡ ਗਲਤੀ ਪਾਲਸੀ"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+#| msgid "Intel BootGuard"
+msgid "Intel BootGuard Fuse"
+msgstr "Intel ਬੂਟਗਾਰਡ ਫਿਊਸ"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+#| msgid "Intel CET"
+msgid "Intel CET Enabled"
+msgstr "Intel CET ਸਮਰੱਥ ਹੈ"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET ਸਰਗਰਮ"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "ਇੰਕ੍ਰਿਪਟ ਕੀਤੀ RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+#| msgid "No Protection"
+msgid "IOMMU Protection"
+msgstr "IOMMU ਸੁਰੱਖਿਆ"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+#| msgid "Kernel lockdown"
+msgid "Linux Kernel Lockdown"
+msgstr "ਲੀਨਕਸ ਕਰਨਲ ਲਾਕ-ਡਾਊਨ"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "ਲੀਨਕਸ ਕਰਨਲ ਤਸਦੀਕ"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+#| msgid "Linux swap"
+msgid "Linux Swap"
+msgstr "ਲੀਨਕਸ ਸਵੈਪ"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+#| msgid "Suspend"
+msgid "Suspend To RAM"
+msgstr "ਰੈਮ ਉੱਤੇ ਸਸਪੈਂਡ"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+#| msgid "Suspend-to-idle"
+msgid "Suspend To Idle"
+msgstr "ਆਈਡਲ ਲਈ ਸਸਪੈਂਡ"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+#| msgid "UEFI platform key"
+msgid "UEFI Platform Key"
+msgstr "UEFI ਪਲੇਟਫਾਰਮ ਕੁੰਜੀ"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+#| msgid "Secure boot"
+msgid "UEFI Secure Boot"
+msgstr "UEFI ਸਕਿਉਰ ਬੂਟ"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+#| msgid "Display Configuration"
+msgid "TPM Platform Configuration"
+msgstr "TPM ਪਲੇਟਫਾਰਮ ਸੰਰਚਨਾ"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+#| msgid "Restrictions:"
+msgid "TPM Reconstruction"
+msgstr "TPM ਮੁੜ-ਨਿਰਮਾਣ"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel ਮੈਨਜੇਮੈਂਟ ਇੰਜਣ ਮੈਨੂਫਿਕਚਰਿੰਗ ਮੋਡ"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel ਮੈਨਜੇਮੈਂਟ ਇੰਜਣ ਓਵਰਰਾਈਡ"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel ਮੈਨਜੇਮੈਂਟ ਇੰਜਣ ਵਰਜ਼ਨ"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+#| msgid "Firmware updates"
+msgid "Firmware Updates"
+msgstr "ਫਿਰਮਵੇਅਰ ਅੱਪਡੇਟ"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+#| msgid "Firmware Version"
+msgid "Firmware Attestation"
+msgstr "ਫਿਰਮਵੇਅਰ ਤਸਦੀਕ"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+#| msgid "Firmware Version"
+msgid "Firmware Updater Verification"
+msgstr "ਫਿਰਮਵੇਅਰ ਅੱਪਡੇਟਰ ਤਸਦੀਕ"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "ਪਲੇਟਫਾਰਮ ਡੀਬੱਗ ਕਰਨਾ"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "ਪਰੋਸੈਸਰ ਸੁਰੱਖਿਆ ਜਾਂਚ"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+#| msgid "No Protection"
+msgid "AMD Rollback Protection"
+msgstr "AMD ਰੋਲਬੈਕ ਸੁਰੱਖਿਆ"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+#| msgid "Minimal Protection"
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD ਫਿਰਮਵੇਅਰ ਰੀਪਲੇਅ ਸੁਰੱਖਿਆ"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+#| msgid "Firmware Version"
+msgid "AMD Firmware Write Protection"
+msgstr "AMD ਫਿਰਮਵੇਅਰ ਲਿਖਣ ਸੁਰੱਖਿਆ"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "ਫਿਊਜ਼ ਕੀਤਾ ਪਲੇਟਫਾਰਮ"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "ਵਾਜਬ"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+#| msgid "Not calibrated"
+msgid "Not Valid"
+msgstr "ਵਾਜਬ ਨਹੀਂ ਹੈ"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+#| msgid "Enabled"
+msgid "Not Enabled"
+msgstr "ਸਮਰੱਥ ਨਹੀਂ ਹੈ"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+#| msgid "SIM Locked"
+msgid "Locked"
+msgstr "ਲਾਕ ਹੈ"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+#| msgid "SIM Locked"
+msgid "Not Locked"
+msgstr "ਲਾਕ ਨਹੀਂ"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+#| msgid "Encrypted RAM"
+msgid "Encrypted"
+msgstr "ਇੰਕ੍ਰਿਪਟ ਹੈ"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+#| msgid "Encrypted RAM"
+msgid "Not Encrypted"
+msgstr "ਇੰਕ੍ਰਿਪਟ ਨਹੀਂ"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "ਨੁਕਸਾਨਿਆ"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+#| msgid "Not calibrated"
+msgid "Not Tainted"
+msgstr "ਨੁਕਸਾਨਿਆ ਨਹੀਂ"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+#| msgid "Sound"
+msgid "Found"
+msgstr "ਲੱਭਿਆ"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+#| msgid "Not found"
+msgid "Not Found"
+msgstr "ਨਹੀਂ ਲੱਭਿਆ"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+#| msgid "Supported CPU"
+msgid "Supported"
+msgstr "ਸਹਾਇਕ ਹੈ"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+#| msgid "Supported CPU"
+msgid "Not Supported"
+msgstr "ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#| msgid "Security"
+msgid "Device Security"
+msgstr "ਡਿਵਾਈਸ ਸੁਰੱਖਿਆ"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "ਹੋਸਟ ਫਿਰਮਵੇਅਰ ਸੁਰੱਖਿਆ ਸਥਿਤੀ"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ਸਕਰੀਨ;ਲਾਕ;ਜਾਂਚ;ਪੜਤਾਲ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਆਰਜ਼ੀ;ਇੰਡੈਕਸ;ਨਾਂ;ਨੈੱਟਵਰਕ;ਪਛਾਣ;ਕਰੈਸ਼;ਤਾਜ਼ਾ;ਪਰਦ"
+"ੇਦਾਰੀ;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "ਅਣਪਛਾਤਾ"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-ਬਿੱਟ"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-ਬਿੱਟ"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "ਵੇਲੈਂਡ"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "ਅਣਪਛਾਤਾ"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "ਉਪਲੱਬਧ ਨਹੀਂ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "ਸਿਸਟਮ ਲੋਗੋ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "ਡਿਵਾਈਸ ਦਾ ਨਾਂ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "ਹਾਰਡਵੇਅਰ ਮਾਡਲ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "ਮੈਮੋਰੀ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "ਪਰੋਸੈਸਰ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "ਗਰਾਫਿਕਸ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "ਡਿਸਕ ਸਮਰੱਥਾ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "...ਗਿਣਤੀ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "ਓ.ਸਿ. ਦਾ ਨਾਂ"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#| msgid "%s; Build ID: %s"
+msgid "OS Build ID"
+msgstr "ਓ.ਸਿ. ਬਿਲਡ ਆਈਡੀ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "ਓ.ਸਿ. ਦੀ ਕਿਸਮ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "ਗਨੋਮ ਦਾ ਵਰਜ਼ਨ"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "…ਲੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "ਵਿੰਡੋਇੰਗ ਸਾਫਟਵੇਅਰ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "ਵਰਚੁਲਾਈਜੇਸ਼ਨ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "ਸਾਫਟਵੇਅਰ ਅੱਪਡੇਟ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "ਡਿਵਾਈਸ ਦਾ ਨਾਂ ਬਦਲੋ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"ਡਿਵਾਈਸ ਨਾਂ ਨੂੰ ਇਸ ਡਿਵਾਈਸ ਦੀ ਪਛਾਣ ਕਰਨ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ, ਜਦੋਂ ਇਸ ਨੂੰ ਨੈੱਟਵਰਕ"
+" ਉੱਤੇ ਵੇਖਦੇ ਹੋ ਜਾਂ "
+"ਜਦੋਂ ਬਲੂਟੁੱਥ ਡਿਵਾਈਸਾਂ ਨਾਲ ਪੇਅਰ ਕੀਤਾ ਜਾਂਦਾ ਹੈ।"
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ਡਿਵਾਈਸ ਦਾ ਨਾਂ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "ਨਾਂ ਬਦਲੋ(_R)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "ਇਸ ਬਾਰੇ"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "ਆਪਣੇ ਸਿਸਟਮ ਬਾਰੇ ਜਾਣਕਾਰੀ ਵੇਖੋ"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"ਡਿਵਾਈਸ;ਡੀਵਾਈਸ;;ਜੰਤਰ;ਸਿਸਟਮ;ਜਾਣਕਾਰੀ;ਮੈਮੋਰੀ;ਪਰੋਸੈਸਰ;ਵਰਜ਼ਨ;ਪ੍ਰੋਸੈਸਰ;ਡਿਫਾਲਟ;ਐਪਲੀਕੇਸ"
+"਼ਨ;ਯੂਐਸਬੀ;"
+"ਡੀਵੀਡੀ;ਸੀਡੀ;ਆਡੀਓ;ਔਡੀਓ;ਵੀਡੀਓ;ਵਿਡੀਓ;ਡਿਸਕ;ਆਟੋਰਨ;ਮੀਡੀਆ;ਹਟਾਉਣਯੋਗ;ਯੰਤਰ;ਹੋਸਟਨੇਮ;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "ਸਾਊਂਡ ਤੇ ਮੀਡਿਆ"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "ਆਵਾਜ਼ ਚੁੱਪ/ਚਲਾਓ"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "ਆਵਾਜ਼ ਘਟਾਓ"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "ਆਵਾਜ਼ ਵਧਾਓ"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "ਮਾਈਕਰੋਫੋਨ ਚੁੱਪ/ਚਲਾਓ"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "ਮੀਡਿਆ ਪਲੇਅਰ ਚਲਾਓ"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "ਚਲਾਓ (ਜਾਂ ਚਲਾਓ/ਵਿਰਾਮ)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "ਪਲੇਅਬੈਕ ਵਿਰਾਮ ਕਰੋ"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "ਪਲੇਅਬੈਕ ਰੋਕੋ"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "ਟਰੈਕ ਪਿੱਛੇ"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "ਟਰੈਕ ਅੱਗੇ"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "ਬਾਹਰ ਕੱਢੋ"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "ਲਿਖਣਾ"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "ਅਗਲੇ ਇੰਪੁੱਟ ਸਰੋਤ ਲਈ ਬਦਲੋ"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "ਪਿਛਲੇ ਇੰਪੁੱਟ ਸਰੋਤ ਲਈ ਬਦਲੋ"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "ਲਾਂਚਰ"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "ਮਦਦ-ਝਲਕਾਰਾ ਚਲਾਓ"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "ਕੈਲਕੂਲੇਟਰ ਚਲਾਓ"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "ਈਮੇਲ ਕਲਾਇਟ ਚਲਾਓ"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "ਵੈਬ-ਬਰਾਊਜ਼ਰ ਚਲਾਓ"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "ਘਰ ਫੋਲਡਰ"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ਖੋਜ"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "ਸਿਸਟਮ"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "ਲਾਗ ਆਉਟ"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "ਸਕਰੀਨ ਲਾਕ ਕਰੋ"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "ਅਸੈੱਸਬਿਲਟੀ"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "ਜ਼ੂਮ ਚਾਲੂ ਜਾਂ ਬੰਦ ਕਰੋ"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "ਜ਼ੂਮ ਇਨ"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "ਜ਼ੂਮ ਆਉਟ"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "ਸਕਰੀਨ ਰੀਡਰ ਚਾਲੂ ਜਾਂ ਬੰਦ ਕਰੋ"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "ਆਨ-ਸਕਰੀਨ ਕੀਬੋਰਡ ਚਾਲੂ ਜਾਂ ਬੰਦ ਕਰੋ"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "ਟੈਕਸਟ ਅਕਾਰ ਵਧਾਓ"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "ਟੈਕਸਟ ਅਕਾਰ ਘਟਾਓ"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "ਵੱਧ-ਗੂੜ੍ਹਾ ਕਰਨਾ ਚਾਲੂ ਜਾਂ ਬੰਦ ਕਰੋ"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "ਕੋਈ ਇੰਪੁੱਟ ਸਰੋਤ ਨਹੀਂ ਲੱਭਿਆ"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "ਹੋਰ"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "ਇੰਪੁੱਟ ਸਰੋਤ ਸ਼ਾਮਲ"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "ਇੰਪੁੱਟ ਢੰਗ ਲਾਗਇਨ ਸਕਰੀਨ ਉੱਤੇ ਨਹੀਂ ਵਰਤੇ ਜਾ ਸਕਦੇ"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "ਕੋਈ ਇੰਪੁੱਟ ਸਰੋਤ ਨਹੀਂ ਚੁਣਿਆ"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "ਚੋਣਾਂ"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "ਉੱਤੇ ਭੇਜੋ"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "ਹੇਠਾਂ ਭੇਜੋ"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "ਮੇਰੀ ਪਸੰਦ"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "ਕੀਬੋਰਡ ਲੇਆਉਟ ਵੇਖੋ"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "ਹਟਾਓ"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "ਬਦਲਵੇਂ ਅੱਖਰ ਸਵਿੱਚ"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"ਬਦਲਵੀਂ ਅੱਖਰ ਸਵਿੱਚ ਨੂੰ ਹੋਰ ਅੱਖਰ ਦੇਣ ਲਈ ਵਰਤਿਆ ਜਾ ਸਕਦਾ ਹੈ। ਇਹਨਾਂ ਨੂੰ ਕਈ ਵਾਰ"
+" ਤੁਹਾਡੇ ਕੀਬੋਰਡ ਉੱਤੇ "
+"ਤੀਜੀ-ਚੋਣ ਵਜੋਂ ਛਾਪਿਆ ਗਿਆ ਹੁੰਦਾ ਹੈ।"
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "ਖੱਬਾ Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "ਸੱਜਾ Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "ਖੱਬਾ ਸੁਪਰ"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "ਸੱਜਾ ਸੁਪਰ"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "ਮੀਨੂ ਸਵਿੱਚ"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "ਸੱਜਾ Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "ਕੰਪੋਜ਼ ਸਵਿੱਚ"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"ਮਿਸ਼ਰਿਤ ਸਵਿੱਚ ਕਈ ਕਿਸਮ ਦੇ ਵੱਖ-ਵੱਖ ਅੱਖਰ ਦੇਣ ਲਈ ਕੰਮ ਆਉਂਦੀ ਹੈ। ਇਹ ਵਰਤਣ ਲਈਤਦ ਲੜੀਵਾਰ"
+" ਅੱਖਰ ਦੇਣ "
+"ਲਈ ਬਣਾਓ ਨੂੰ ਦਬਾਓ। ਮਿਸਾਲ ਲਈ <b>C</b> ਅਤੇ <b>o</b> ਦੇ ਬਾਅਦ ਬਣਾਓ ਨਾਲ <b>©</b>"
+" ਪਵੇਗਾ, "
+"<b>a</b> ਤੇ <b>'</b> ਦੇ ਬਾਅਦ ਬਣਾਓ ਦਬਾਉਣ ਨਾਲ <b>á</b> ਪਵੇਗਾ।"
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps ਲਾਕ"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "ਸਕਰੋਲ ਲਾਕ"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "ਪਰਿੰਟ ਸਕਰੀਨ"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"ਇਨਪੁੱਟ ਸਰੋਤਾਂ ਨੂੰ %s ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਵਰਤ ਕੇ ਬਦਲਿਆ ਜਾ ਸਕਦਾ ਹੈ।\n"
+"ਇਹ ਸ਼ਾਰਟਕੱਟਾਂ ਨੂੰ ਕੀਬੋਰਡ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਬਦਲਿਆ ਜਾ ਸਕਦਾ ਹੈ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "ਇਨਪੁੱਟ ਸਰੋਤ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "ਇਸ ਵਿੱਚ ਕੀਬੋਰਡ ਲੇਆਉਟ ਅਤੇ ਇਨਪੁੱਟ ਢੰਗ ਸ਼ਾਮਲ ਹਨ।"
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "ਇਨਪੁੱਟ ਸਰੋਤ ਬਦਲਣਾ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "ਸਭ ਵਿੰਡੋਆਂ ਲਈ ਇੱਕੋ ਸਰੋਤ ਵਰਤੋਂ(_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "ਹਰੇਕ ਵਿੰਡੋ ਲਈ ਵੱਖੋ-ਵੱਖਰਾ ਇਨਪੁੱਟ ਸਰੋਤ ਬਦਲੋ(_i)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "ਖਾਸ ਅੱਖਰ ਲਿਖੋ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "ਕੀਬੋਰਡ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਚਿੰਨ੍ਹ, ਅੱਖਰਾਂ ਦੇ ਵੱਖੋ-ਵੱਖਰੇ ਰੂਪ ਦੇਣ ਦੇ ਢੰਗ।"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "ਕੀ-ਬੋਰਡ ਸ਼ਾਰਟਕੱਟ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "ਸ਼ਾਰਟਕੱਟ ਵੇਖੋ ਤੇ ਕਸਟਮਾਈਜ਼ ਕਰੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d ਸੋਧਿਆ"
+msgstr[1] "%d ਸੋਧੇ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "ਕੀ ਸਾਰੇ ਸ਼ਾਰਟਕੱਟ ਮੁੜ-ਸੈੱਟ ਕਰਨੇ ਹਨ?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"ਸ਼ਾਰਟਕੱਟਾਂ ਨੂੰ ਮੁੜ-ਸੈੱਟ ਕਰਨ ਨਾਲ ਤੁਹਾਡੇ ਕਸਟਮ ਸ਼ਾਰਟਕੱਟਾਂ ਉੱਤੇ ਅਸਰ ਪੈ ਸਕਦਾ ਹੈ। ਇਸ"
+" ਨੂੰ ਵਾਪਸ ਨਹੀਂ "
+"ਪਰਤਾਇਆ ਜਾ ਸਕਦਾ ਹੈ।"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "ਰੱਦ ਕਰੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "ਸਭ ਮੁੜ-ਸੈੱਟ ਕਰੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "…ਸਭ ਮੁੜ-ਸੈੱਟ ਕਰੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "ਸਾਰੇ ਸ਼ਾਰਟਕੱਟਾਂ ਨੂੰ ਉਹਨਾਂ ਦੀ ਡਿਫਾਲਟ ਕੀਬਾਈਡਿੰਗ ਲਈ ਮੁੜ-ਸੈੱਟ ਕਰੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "ਭਾਗ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "ਸ਼ਾਰਟਕੱਟ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "ਸ਼ਾਰਟਕੱਟ ਜੋੜੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ ਨੂੰ ਜੋੜੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "ਐਪਾਂ ਸ਼ੁਰੂ ਕਰਨ, ਸਕ੍ਰਿਪਟ ਚਲਾਉਣ ਤੇ ਹੋਰਾਂ ਲਈ ਪਸੰਦੀਦਾ ਸ਼ਾਰਟਕੱਟ ਸੈਟ ਅੱਪ ਕਰੋ।"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "ਸ਼ਾਰਟਕੱਟ ਸ਼ਾਮਿਲ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "ਕੋਈ ਕੀ-ਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਨਹੀਂ ਲੱਭਿਆ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s ਨੂੰ ਪਹਿਲਾਂ ਹੀ %s ਨੂੰ ਵਰਤ ਰਿਹਾ ਹੈ। ਜੇ ਤੁਸੀਂ ਇਸ ਨੂੰ ਬਦਲਿਆ ਤਾਂ %s ਅਸਮਰੱਥ ਹੋ"
+" ਜਾਵੇਗਾ।"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "ਨਵਾਂ ਸ਼ਾਰਟਕੱਟ ਦਿਓ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ ਸੈੱਟ ਕਰੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "ਸ਼ਾਰਟਕੱਟ ਸੈੱਟ ਕਰੋ"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "%s ਨੂੰ ਬਦਲਣ ਲਈ ਨਵਾਂ ਸ਼ਾਰਟਕੱਟ ਦਿਉ।"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ ਨੂੰ ਜੋੜੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "ਹਟਾਓ(_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "ਬਦਲੋ(_p)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "ਸੈੱਟ(_S)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "ਅਸਮਰੱਥ ਕਰਨ ਲਈ Esc ਜਾਂ ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਮੁੜ-ਸੈੱਟ ਕਰਨ ਲਈ ਬੈਕਸਪੇਸ ਦਬਾਓ।"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "ਨਾਂ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "ਕਮਾਂਡ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "ਸ਼ਾਰਟਕੱਟ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "…ਸ਼ਾਰਟਕੱਟ ਸੈੱਟ ਕਰੋ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "ਕੋਈ ਨਹੀਂ"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "ਸ਼ਾਰਟਕੱਟ ਨੂੰ ਇਸ ਦੇ ਮੂਲ ਮੁੱਲ ਲਈ ਮੁੜ-ਸੈੱਟ ਕਰੋ"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "ਕੀ-ਬੋਰਡ"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਵੇਖੋ ਤੇ ਬਦਲੋ ਅਤੇ ਆਪਣੀ ਟਾਈਪ ਕਰਨ ਲਈ ਪਸੰਦ ਦਿਓ, ਕੀਬੋਰਡ ਖਾਕੇ ਅਤੇ"
+" ਇਨਪੁੱਟ ਢੰਗ"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"ਸ਼ਾਰਟਕੱਟ;ਵਰਕਸਪੇਸ;ਵਿੰਡੋ;ਮੁੜ-ਆਕਾਰ;ਰੀਸਾਈਜ਼;ਜ਼ੂਮ;ਕਨਟਰਾਸਟ;ਇਨਪੁਟ;ਸਰੋਤ;ਲਾਕ;ਵਾਲੀਅਮ;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "ਟਿਕਾਣਾ ਸੇਵਾਵਾਂ ਬੰਦ ਕੀਤੀਆਂ ਹਨ"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "ਕੋਈ ਵੀ ਐਪਲੀਕੇਸ਼ਨ ਟਿਕਾਣਾ ਜਾਣਕਾਰੀ ਪ੍ਰਾਪਤ ਨਹੀਂ ਕਰ ਸਕਦੀ ਹੈ।"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"ਟਿਕਾਣਾ ਸੇਵਾਵਾਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡੇ ਟਿਕਾਣੇ ਬਾਰੇ ਪਤਾ ਦਿੰਦੀਆਂ ਹਨ। ਵੱਧ ਦਰੁਸਤ"
+" ਹੋਣ ਲਈ Wi-Fi ਅਤੇ "
+"ਮੋਬਾਈਲ ਬਰਾਡਬੈਂਡ ਦੀ ਵਰਤੋਂ ਕਰੋ।\n"
+"\n"
+"ਮੋਜ਼ੀਲਾ ਟਿਕਾਣਾ ਸੇਵਾ ਦੀ ਵਰਤੋਂ ਕਰਦਾ ਹੈ: <a href='https://location.services.mozill"
+"a."
+"com/privacy'>ਪਰਦੇਦਾਰੀ ਨੀਤੀ</a>\n"
+"\n"
+"ਹੇਠ ਦਿੱਤੀਆਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡਾ ਟਿਕਾਣਾ ਪਤਾ ਕਰਨ ਦੀ ਇਜਾਜ਼ਤ ਹੈ।"
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "ਟਿਕਾਣੇ ਪਹੁੰਚ ਲਈ ਕੋਈ ਐਪਲੀਕੇਸ਼ਨ ਨੇ ਨਹੀਂ ਪੁੱਛਿਆ ਹੈ"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "ਆਪਣੀ ਟਿਕਾਣਾ ਜਾਣਕਾਰੀ ਸੁਰੱਖਿਅਤ ਕਰੋ"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "ਟਿਕਾਣਾ;ਥਾਂ;ਲੋਕੇਸ਼ਨ;ਜੀਪੀਐਸ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "ਮਾਈਕਰੋਫੋਨ ਬੰਦ ਕੀਤਾ ਹੈ"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "ਕੋਈ ਐਪਲੀਕੇਸ਼ਨ ਆਵਾਜ਼ ਰਿਕਾਰਡ ਨਹੀਂ ਕਰ ਸਕਦੀ ਹੈ।"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"ਮਾਈਕਰੋਫੋਨ ਦੀ ਵਰਤੋਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਆਡੀਓ ਰਿਕਾਰਡ ਕਰਨ ਤੇ ਸੁਣਨ ਲਈ ਸਹਿਮਤੀ ਦਿੰਦੀ ਹੈ।"
+" ਮਾਈਕਰੋਫੋਨ ਨੂੰ "
+"ਅਸਮਰੱਥ ਕਰਨ ਨਾਲ ਕੁਝ ਐਪਲੀਕੇਸ਼ਨਾਂ ਠੀਕ ਤਰ੍ਹਾਂ ਕੰਮ ਨਹੀਂ ਕਰ ਸਕਦੀਆਂ।\n"
+"\n"
+"ਹੇਠ ਦਿੱਤੀਆਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡੇ ਮਾਈਕਰੋਫ਼ੋਨ ਨੂੰ ਵਰਤਣ ਦੀ ਇਜਾਜ਼ਤ ਹੈ।"
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "ਮਾਈਕਰੋਫ਼ੋਨ ਪਹੁੰਚ ਲਈ ਕੋਈ ਐਪਲੀਕੇਸ਼ਨ ਨੇ ਨਹੀਂ ਪੁੱਛਿਆ ਹੈ"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "ਤਹਾਡੀਆਂ ਗੱਲਾਂਬਾਤਾਂ ਸੁਰੱਖਿਅਤ ਕਰੋ"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "ਮਾਈਕਰੋਫੋਨ;ਮਾਈਕ੍ਰੋਫ਼ੋਨ;ਮਾਈਕਰੋਫ਼ੋਨ;ਐਪਲੀਕੇਸ਼ਨ,;ਪਰਦੇਦਾਰੀ;ਪ੍ਰਾਈਵੇਸੀ;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "ਆਪਣੀ ਸੈਟਿੰਗ ਜਾਂਚੋ(_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "ਆਮ"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "ਪ੍ਰਾਇਮਰੀ ਬਟਨ"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "ਮਾਊਸ ਅਤੇ ਟੱਚ-ਪੈਡ ਉੱਤੇ ਮੌਜੂਦ ਬਟਨਾਂ ਦਾ ਕ੍ਰਮ ਸੈੱਟ ਕਰੋ"
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "ਖੱਬੇ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "ਸੱਜੇ"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "ਮਾਊਸ"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "ਮਾਊਸ ਸਪੀਡ"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "ਨੈਚਰਲ ਸਕਰੋਲਿੰਗ"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "ਸਕਰੋਲ ਕਰਨ ਨਾਲ ਸਮੱਗਰੀ ਹਿਲਦੀ ਹੈ, ਝਲਕ ਨਹੀਂ।"
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "ਟੱਚਪੈਡ"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "ਟੱਚਪੈਡ ਸਪੀਡ"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "ਕਲਿੱਕ ਲਈ ਛੂਹੋੋ"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "ਕਲਿੱਕ ਲਈ ਛੂਹੋੋ"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "ਦੋ ਉਂਗਲਾਂ ਨਾਲ ਸਕਰੋਲ"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "ਕੋਨਾ ਸਕਰੋਲਿੰਗ"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ਕਲਿੱਕ ਕਰਕੇ, ਦੋ ਵਾਰ ਕਲਿੱਕ ਕਰਕੇ, ਸਕਰੋਲ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "ਪੰਜ ਕਲਿੱਕ, GEGL ਸਮਾਂ!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "ਡਬਲ ਕਲਿੱਕ, ਮੁੱਢਲਾ ਬਟਨ"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "ਇੱਕ ਵਾਰ ਕਲਿੱਕ, ਮੁੱਢਲਾ ਬਟਨ"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "ਡਬਲ ਕਲਿੱਕ, ਮੱਧ ਬਟਨ"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "ਇੱਕ ਵਾਰ ਕਲਿੱਕ, ਮੱਧ ਬਟਨ"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "ਡਬਲ ਕਲਿੱਕ, ਸੈਕੰਡਰੀ ਬਟਨ"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "ਇੱਕ ਵਾਰ ਕਲਿੱਕ, ਸੈਕੰਡਰੀ ਬਟਨ"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "ਮਾਊਸ ਤੇ ਟੱਚਪੈਚ"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"ਆਪਣੇ ਮਾਊਸ ਜਾਂ ਟੱਚਪੈਡ ਦੀ ਸੰਵੇਦਨਸ਼ੀਲਤਾ ਬਦਲੋ ਅਤੇ ਸੱਜੇ ਜਾਂ ਖੱਬੇ-ਹੱਥ ਦੀ ਚੋਣ ਕਰੋ"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ਟਰੈਕਪੈਂਡ;ਪੁਆਇੰਟਰ;ਕਲਿੱਕ;ਟੈਪ;ਡਬਲ;ਬਟਨ;ਟਰੈਕਬਾਲ;ਸਕਰੋਲ;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "ਸਰਗਰਮ ਕੋਨਾ(_H)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "ਸਰਗਰਮੀ ਸਾਰ ਨੂੰ ਖੋਲ੍ਹਣ ਲਈ ਉੱਤੇ-ਖੱਬੇ ਕੋਨੇ ਨੂੰ ਛੂਹੋ।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "ਸਕਰੀਨ ਦੇ ਕੋਨੇ ਸਰਗਰਮ ਕਰੋ(_A)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"ਵਿੰਡੋਆਂ ਨੂੰ ਮੁੜ ਆਕਾਰ ਕਰਨ ਲਈ ਸਕਰੀਨ ਕੋਨਿਆਂ ਦੇ ਉੱਤੇ, ਖੱਬੇ ਅਤੇ ਸੱਜੇ ਪਾਸੇ ਵੱਲ"
+" ਖਿੱਚੋ।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "ਵਰਕਸਪੇਸ"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "ਸਫ਼ਰੀ ਵਰਕਸਪੇਸ(_D)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "ਖਾਲੀ ਵਰਕਸਪੇਸਾਂ ਨੂੰ ਆਪਣੇ-ਆਪ ਹਟਾਓ।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "ਵਰਕਸਪੇਸਾਂ ਦੀ ਪੱਕੀ ਗਿਣਤੀ(_F)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "ਪੱਕੇ ਵਰਕਸਪੇਸਾਂ ਦੀ ਗਿਣਤੀ ਦਿਓ।"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "ਵਰਕਸਪੇਸਾਂ ਦੀ ਗਿਣਤੀ(_N)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "ਬਹੁ-ਮਾਨੀਟਰ"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "ਵਰਕਸੇਪਸ ਸਿਰਫ਼ ਪ੍ਰਾਇਮਰੀ ਡਿਸਪਲੇਅ ਉੱਤੇ(_p)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "ਸਾਰੇ ਡਿਸਪਲੇਅ ਉੱਤੇ ਵਰਕਸਪੇਸ(_i)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "ਐਪਲੀਕੇਸ਼ਨ ਬਦਲਣੀਆਂ"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "ਸਾਰੀਆਂ ਵਰਕਸਪੇਸਾਂ ਤੋਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਸਮੇਤ(_w)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "ਸਿਰਫ਼ ਮੌਜੂਦਾ ਵਰਕਸਪੇਸ ਤੋਂ ਹੀ ਐਪਲੀਕੇਸ਼ਨਾਂ ਸਮੇਤ(_c)"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "ਬਹੁ-ਕੰਮਕਾਜ"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "ਉਤਪਾਦਨ ਤੇ ਬਹੁ-ਕੰਮਕਾਜ ਲਈ ਤਜਰੀਹਾਂ ਦਾ ਇੰਤਜ਼ਾਮ ਕਰੋ"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr "ਬਹੁ-ਕੰਮ;ਮਲਟੀ-ਟਾਸਕ;ਉਤਪਾਦਨ,ਕਸਟਮਾਈਜ਼ ਡੈਸਕਟਾਪ;ਹਾਟ ਕਾਰਨਰ;ਵਰਕਸਪੇਸ;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "ਓਹ ਹੋ, ਕੁਝ ਗਲਤ ਵਾਪਰਿਆ। ਆਪਣੇ ਸਾਫਟਵੇਅਰ ਵੇਂਡਰ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "ਨੈਟਵਰਕਮੈਨੇਜਰ ਚੱਲਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "ਹੋਰ ਡਿਵਾਈਸ"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "ਕਨੈਕਸ਼ਨ ਜੋੜੋ"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "ਸੈੱਟ ਅੱਪ ਨਹੀਂ"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "ਅਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "ਸੁਰੱਖਿਅਤ ਨੈੱਟਵਰਕ"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "ਕਨੈਕਟ ਹੈ"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "…ਚੋਣਾਂ"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"ਹਾਟਸਪਾਟ ਨੂੰ ਚਾਲੂ ਕਰਨ ਨਾਲ %s ਤੋਂ ਡਿਸ-ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇਗਾ ਅਤੇ Wi-Fi ਰਾਹੀਂ"
+" ਇੰਟਰਨੈੱਟ ਨਾਲ ਪਹੁੰਚ "
+"ਸੰਭਵ ਨਹੀਂ ਹੋਵੇਗੀ।"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "ਘੱਟੋ-ਘੱਟ 8 ਅੱਖਰ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "ਵੱਧ ਤੋਂ ਵੱਧ %d ਅੱਖਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+msgstr[1] "ਵੱਧ ਤੋਂ ਵੱਧ %d ਅੱਖਰ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi ਹਾਟਸਪਾਟ ਚਾਲੂ ਕਰਨਾ ਹੈ?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-Fi ਹਾਟਸਪਾਟ ਹੋਰਾਂ ਨੂੰ ਤੁਹਾਡੇ ਇੰਟਰਨੈੱਟ ਕਨੈਕਸ਼ਨ ਨੂੰ ਸਾਂਝਾ ਕਰਨ ਦਿੰਦਾ ਹੈ, ਜੋ ਕਿ"
+" Wi-Fi ਨੈੱਟਵਰਕ ਬਣਾ "
+"ਕੇ ਹੁੰਦਾ ਹੈ, ਜਿਸ ਨਾਲ ਉਹ ਕਨੈਕਟ ਹੋ ਸਕਦੇ ਹਨ। ਇਹ ਕਰਨ ਲਈ ਤੁਹਾਨੂੰ Wi-Fi ਤੋਂ ਬਿਨਾਂ"
+" ਕਿਸੇ ਹੋਰ ਸਰੋਤ "
+"ਰਾਹੀਂ ਇੰਟਰਨੈੱਟ ਨਾਲ ਕਨੈਕਟ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "ਨੈੱਟਵਰਕ ਨਾਂ"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "ਪਾਸਵਰਡ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "ਰਲਵਾਂ ਪਾਸਵਰਡ ਤਿਆਰ ਕਰੋ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "ਪਾਸਵਰਡ ਆਪਣੇ-ਆਪ ਤਿਆਰ ਕਰੋ"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "ਚਾਲੂ ਕਰੋ(_T)"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "ਕੀ ਹਾਟਸਪਾਟ ਰੋਕਣਾ ਹੈ ਅਤੇ ਵਰਤੋਂਕਾਰ ਨੂੰ ਡਿਸ-ਕਨੈਕਟ ਕਰਨਾ ਹੈ?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "ਹਾਟਸਪਾਟ ਰੋਕੋ(_S)"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "ਏਅਰਪਲੇਨ ਮੋਡ"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Wi-Fi, ਬਲੂਟੁੱਥ ਅਤੇ ਮੋਬਾਈਲ ਬਰਾਡਬੈਂਡ ਅਸਮਰੱਥ ਹੈ"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "ਕੋਈ Wi-Fi ਅਡੈਪਟਰ ਨਹੀਂ ਲੱਭਿਆ"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "ਪੱਕਾ ਕਰੋ ਕਿ ਤੁਸੀਂ Wi-Fi ਅਡੈਪਟਰ ਲਗਾਇਆ ਹੈ ਅਤੇ ਇਹ ਚਾਲੂ ਹੈ"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "ਏਅਰਪਲੇਨ ਮੋਡ ਚਾਲੂ ਹੈ"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Wi-Fi ਵਰਤਣ ਲਈ ਬੰਦ ਕਰੋ"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "ਵਾਈ-ਫਾਈ ਹਾਟਸਪਾਟ ਸਰਗਰਮ"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "ਮੋਬਾਈਡ ਡਿਵਾਈਸ ਕਨੈਕਟ ਕਰਨ ਲਈ QR ਕੋਡ ਸਕੈਨ ਕਰ ਸਕਦੇ ਹਨ।"
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr " ਹਾਟਸਪਾਟ ਬੰਦ ਕਰੋ…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "ਦਿਸਦੇ ਨੈੱਟਵਰਕ"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "ਨੈਟਵਰਕ-ਮੈਨੇਜਰ ਚੱਲਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x ਸੁਰੱਖਿਆ(_S)"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "ਸੁਰੱਖਿਆ"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "ਕਾਇਮ ਰੱਖੋ"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "ਪੱਕਾ"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "ਰਲਵਾਂ"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "ਸਥਿਰ"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"ਇੱਥੇ ਦਿੱਤਾ ਮੈਕ (MAC) ਐਡਰੈੱਸ ਨੈੱਟਵਰਕ ਡਿਵਾਈਸ ਲਈ ਹਾਰਡਵੇਅਰ ਐਡਰੈੱਸ ਵਜੋਂ ਵਰਤਿਆ"
+" ਜਾਵੇਗਾ, ਜਿਸ ਲਈ ਇਸ "
+"ਕਨੈਕਸ਼ਨ ਐਕਟੀਵੇਟ ਕੀਤਾ ਗਿਆ ਹੈ। ਇਹ ਫੀਚਰ ਨੂੰ ਮੈਕ ਕਲੋਨਿੰਗ ਜਾਂ ਸਪੂਫਿੰਗ (spoofing)"
+" ਕਹਿੰਦੇ ਹਨ। "
+"ਜਿਵੇਂ: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "ਪਰੋਫਾਈਲ %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "ਵਾਧਰਾ ਖੋਲ੍ਹੋ"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "ਇੰਟਰਪ੍ਰਾਈਜ਼"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "ਕੋਈ ਨਹੀਂ"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "ਕਦੇ ਨਹੀਂ"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i ਦਿਨ ਪਹਿਲਾਂ"
+msgstr[1] "%i ਦਿਨ ਪਹਿਲਾਂ"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/ਸਕਿੰਟ (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "ਕੋਈ ਨਹੀਂ"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "ਕਮਜ਼ੋਰ"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "ਠੀਕ ਹੈ"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "ਚੰਗਾ"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "ਬਹੁਤ ਵਧੀਆ"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 ਐਡਰੈੱਸ"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 ਐਡਰੈੱਸ"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP ਐਡਰੈੱਸ"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "ਕਨੈਕਸ਼ਨ ਨੂੰ ਭੁੱਲ ਜਾਓ"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "ਕਨੈਕਸ਼ਨ ਪ੍ਰੋਫਾਈਲ ਨੂੰ ਹਟਾਓ"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "VPN ਹਟਾਓ"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "ਵੇਰਵੇ"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "ਆਪਣੇ-ਆਪ"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "ਪਛਾਣ"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "ਐਡਰੈਸ ਹਟਾਓ"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "ਰੂਟ ਹਟਾਓ"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "ਕੋਈ ਨਹੀਂ"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-ਬਿੱਟ ਕੁੰਜੀ (Hex ਜਾਂ ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-ਬਿੱਟ ਵਾਕ"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "ਡਾਇਨੈਮਿਕ WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA ਤੇ WPA2 ਨਿੱਜੀ"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA ਤੇ WPA2 ਇੰਟਰਪ੍ਰਾਈਜ"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 ਪਰਸਨਲ"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "ਸਿਗਨਲ ਮਜ਼ਬੂਤੀ"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "ਲਿੰਕ ਸਪੀਡ"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "ਹਾਰਡਵੇਅਰ ਐਡਰੈੱਸ"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "ਸਹਾਇਕ ਫਰੀਕਿਊਂਸੀ"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "ਡਿਫਾਲਟ ਰੂਟ"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "ਆਖਰੀ ਵਰਤੋਂ"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "ਆਪਣੇ-ਆਪ ਕਨੈਕਟ ਕਰੋ(_a)"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "ਹੋਰ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਉਪਲੱਬਧ ਕਰਵਾਓ(_o)"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "ਮੀਟਰ ਕਨੈਕਸ਼ਨ: ਡਾਟਾ ਹੱਦਾਂ ਹੁੰਦੀਆਂ ਹਨ ਜਾਂ ਖ਼ਰਚੇ ਲੱਗ ਸਕਦੇ ਹਨ(_M)"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr "ਸਾਫਟਵੇਅਰ ਅੱਪਡੇਟ ਅਤੇ ਹੋਰ ਵੱਡੇ ਡਾਊਨਲੋਡ ਆਪਣੇ-ਆਪ ਸ਼ੁਰੂ ਨਹੀ ਕੀਤੇ ਜਾਣਗੇ।"
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "ਨਾਂ(_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC ਐਡਰੈਸ"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "ਕਨੋਲ ਕੀਤਾ ਐਡਰੈੱਸ(_C)"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "ਬਾਈਟ"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 ਢੰਗ"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "ਆਟੋਮੈਟਿਕ (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "ਕੇਵਲ ਲਿੰਕ-ਲੋਕਲ"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "ਦਸਤੀ"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "ਅਸਮਰੱਥ"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "ਹੋਰ ਕੰਪਿਊਟਰਾਂ ਨਾਲ ਸਾਂਝਾ ਕੀਤਾ"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "ਐਡਰੈੱਸ"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ਐਡਰੈੱਸ"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "ਨੈੱਟਮਾਸਕ"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "ਗੇਟਵੇ"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "ਆਟੋਮੈਟਿਕ"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "ਆਟੋਮੈਟਿਕ DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS ਸਰਵਰਾਂ ਦੇ ਐਡਰੈਸ"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "ਕਾਮੇ ਪਾ ਕੇ ਵੱਖਰੇ IP ਸਿਰਨਾਵੇਂ"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "ਰੂਟ"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "ਆਟੋਮੈਟਿਕ ਰੂਟ"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "ਮੈਟਰਿਕ"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "ਇਹ ਕੁਨੈਕਸ਼ਨ ਨੂੰ ਕੇਵਲ ਇਸ ਦੇ ਨੈੱਟਵਰਕ ਉੱਤੇ ਹੀ ਸਰੋਤਾਂ ਲਈ ਵਰਤੋਂ(_o)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 ਢੰਗ"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "ਆਟੋਮੈਟਿਕ, ਕੇਵਲ DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "ਪ੍ਰੀ-ਫਿਕਸ"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "ਕਨੈਕਸ਼ਨ ਐਡੀਟਰ ਖੋਲ੍ਹਣ ਲਈ ਅਸਮਰੱਥ"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "ਨਵਾਂ ਪਰੋਫਾਇਲ"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "ਗਲਤ ਸੈਟਿੰਗ %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "ਗਲਤ ਸੈਟਿੰਗ %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "…ਫਾਇਲ ਤੋਂ ਇੰਪੋਰਟ ਕਰੋ"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "VPN ਨੂੰ ਜੋੜੋ"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "ਸੁਰੱਖਿਆ(_e)"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "VPN ਕੁਨੈਕਸ਼ਨ ਇੰਪੋਰਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"ਫਾਇਲ ”%s” ਪੜ੍ਹੀ ਨਹੀਂ ਜਾ ਸਕੀ ਜਾਂ ਪਛਾਣਯੋਗ VPN ਕੁਨੈਕਸ਼ਨ ਜਾਣਕਾਰੀ ਨਹੀਂ ਰੱਖਦੀ ਹੈ।\n"
+"\n"
+"ਗਲਤੀ: %s।"
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "ਇੰਪੋਰਟ ਕਰਨ ਲਈ ਫਾਇਲ ਚੁਣੋ"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "”%s” ਫਾਇਲ ਨਾਂ ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹੈ।"
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "ਬਦਲੋ(_R)"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "ਕੀ ਤੁਸੀਂ %s ਨੂੰ VPN, ਜੋ ਤੁਸੀਂ ਸੰਭਾਲ ਰਹੇ ਹੋ, ਨਾਲ ਬਦਲਣਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "VPN ਕੁਨੈਕਸ਼ਨ ਐਕਸਪੋਰਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN ਕੁਨੈਕਸ਼ਨ ”%s” %s ਲਈ ਐਕਸਪੋਰਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।\n"
+"\n"
+"ਗਲਤੀ: %s"
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "VPN ਕਨੈਕਸ਼ਨ ਐਕਸਪੋਰਟ ਕਰੋ"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ਗਲਤੀ: VPC ਕਨੈਕਸ਼ਨ ਐਡੀਟਰ ਖੋਲ੍ਹਣ ਲਈ ਅਸਮਰੱਥ)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿ ਇੰਟਰਨੈੱਟ ਨਾਲ ਤੁਸੀਂ ਕਿਵੇਂ ਕਨੈਕਟ ਹੋ"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"ਨੈੱਟਵਰਕ;ਆਈਪੀ;ਬਰਾਡਬੈਂਡ;ਮਾਡਮ;ਬਲੂਟੁੱਥ;ਬਲੂਟੁੱਥ;ਵੀਪੀਐਨ;ਪਰਾਕਸੀ;ਵੈਨ;ਮੌਡਮ;ਡੀਐਨਐਸ;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿ Wi-Fi ਨੈੱਟਵਰਕ ਨਾਲ ਤੁਸੀਂ ਕਿਵੇਂ ਕਨੈਕਟ ਕਰਨਾ ਹੈ"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "ਨੈੱਟਵਰਕ;ਬੇਤਾਰ;ਵਾਈ-ਫਾਈ;ਆਈਪੀ;ਬਰਾਡਬੈਂਡ;ਡੀਐਨਐਸ;ਹਾਟਸਪਾਟ;ਹੌਟਸਪੌਟ;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "ਕਦੇ ਨਹੀਂ"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "ਅੱਜ"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "ਕੱਲ੍ਹ"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "ਆਖਰੀ ਵਰਤੋਂ"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "ਤਾਰ ਵਾਲਾ"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "ਨਵਾਂ ਕੁਨੈਕਸ਼ਨ ਸ਼ਾਮਲ ਕਰੋ"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"ਚੁਣੇ ਗਏ ਨੈੱਟਵਰਕਾਂ ਲਈ ਨੈੱਟਵਰਕ ਵੇਰਵਾ, ਜਿਸ ਵਿੱਚ ਪਾਸਵਰਡ ਅਤੇ ਹੋਰ ਪਸੰਦੀਦਾ ਸੰਰਚਨਾ"
+" ਦਿੱਤੀ ਸੀ, ਖਤਮ ਹੋ "
+"ਜਾਵੇਗਾ।"
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "ਭੁੱਲ ਜਾਓ(_F)"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "ਜਾਣੇ-ਪਛਾਣ Wi-Fi ਨੈੱਟਵਰਕ"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "ਭੁੱਲ ਜਾਓ(_F)"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "ਸਿਸਟਮ ਪਾਲਸੀ ਹਾਟ-ਸਪਾਟ ਵਜੋਂ ਵਰਤਣ ਤੋਂ ਰੋਕਦੀ ਹੈ"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "ਬੇਤਾਰ ਜੰਤਰ ਹਾਟਸਪਾਟ ਮੋਡ ਲਈ ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"ਵੈੱਬ ਪਰਾਕਸੀ ਆਪੇ-ਆਪ ਖੋਜ ਵਰਤੀ ਜਾਂਦੀ ਹੈ, ਜਦੋਂ ਸੰਰਚਨਾ URL ਨਾ ਦਿੱਤਾ ਗਿਆ ਹੋਵੇ।"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "ਇਹ ਪਬਲਿਕ ਨੈੱਟਵਰਕ ਬੇ-ਭਰੋਸੇਯੋਗ ਨੈੱਟਵਰਕ ਲਈ ਸਿਫਾਰਸ਼ ਨਹੀਂ ਕੀਤਾ ਜਾਂਦਾ।"
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "ਜੰਤਰ ਬੰਦ ਕਰੋ"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "ਸਰਗਰਮ"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "ਪਰੋਵਾਇਡਰ"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "ਨੈੱਟਵਰਕ ਪਰਾਕਸੀ"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP ਪਰਾਕਸੀ:"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS ਪਰਾਕਸੀ"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP ਪਰਾਕਸੀ:"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks ਹੋਸਟ"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "ਅਣਡਿੱਠੇ ਕੀਤੇ ਹੋਸਟ(_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP ਪਰਾਕਸੀ ਪੋਰਟ"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS ਪਰਾਕਸੀ ਪੋਰਟ"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP ਪਰਾਕਸੀ ਪੋਰਟ"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks ਪੋਰਟ ਪੋਰਟ"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "ਸੰਰਚਨਾ URL(_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN ਕਨੈਕਸ਼ਨ ਬੰਦ ਕਰੋ"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "ਨੈੱਟਵਰਕ ਦਾ ਨਾਂ"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "ਸੁਰੱਖਿਆ ਦੀ ਕਿਸਮ"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "ਪਾਸਵਰਡ"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "ਵਾਈ-ਫਾਈ ਬੰਦ ਕਰੋ"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "…ਹੋਰ ਚੋਣਾਂ"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "…ਲੁਕਵੇਂ ਨੈੱਟਵਰਕ ਨਾਲ ਕਨੈਕਟ ਕਰੋ(_C)"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "ਵਾਈ-ਫਾਈ ਹਾਟਸਪਾਟ ਚਾਲੂ ਕਰੋ(_T)…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "ਜਾਣੇ-ਪਛਾਣੇ ਵਾਈ-ਫਾਈ ਨੈੱਟਵਰਕ(_K)"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "ਹਾਲਤ ਅਣਜਾਣ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "ਬਿਨ-ਇੰਤਜ਼ਾਮ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "ਨਾ-ਉਪਲੱਬਧ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "ਡਿਸ-ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "ਕੁਨੈਕਸ਼ਨ ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "ਹਾਲਤ ਅਣਜਾਣ (ਗੁੰਮ)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "ਸੰਰਚਨਾ ਫੇਲ੍ਹ ਹੋਈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP ਸੰਰਚਨਾ ਫੇਲ੍ਹ ਹੋਈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP ਸੰਰਚਨਾ ਦੀ ਮਿਆਦ ਪੁੱਗੀ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "ਭੇਦ ਦੀ ਲੋੜ ਸੀ, ਪਰ ਦਿੱਤਾ ਨਹੀਂ ਗਿਆ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x ਸਪਲੀਮੈਂਟ ਡਿਸ-ਕਨੈਕਟ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x ਸਪਲੀਮੈਂਟ ਸੰਰਚਨਾ ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x ਸਪਲੀਮੈਂਟ ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x ਸਪਲੀਮੈਂਟ ਨੇ ਪਰਮਾਣਿਤ ਹੋਣ ਲਈ ਬਹੁਤ ਲੰਮਾ ਸਮਾਂ ਲੈ ਲਿਆ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP ਸਰਵਿਸ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP ਸਰਵਿਸ ਡਿਸ-ਕਨੈਕਟ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP ਕਲਾਇਟ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP ਕਲਾਇਟ ਗਲਤੀ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP ਕਲਾਇਟ ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "ਸਾਂਝੀ ਕੀਤੀ ਕਨੈਕਸ਼ਨ ਸਰਵਿਸ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "ਸਾਂਝਾ ਕੀਤੀ ਕਨੈਕਸ਼ਨ ਸਰਵਿਸ ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "ਆਟੋ-IP ਸਰਵਿਸ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "ਆਟੋ-IP ਸਰਵਿਸ ਗਲਤੀ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "ਆਟੋ-IP ਸਰਵਿਸ ਫੇਲ੍ਹ ਹੋਈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "ਲਾਈਨ ਰੁਝੀ ਹੋਈ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "ਕੋਈ ਡਾਇਲ ਟੋਨ ਨਹੀਂ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "ਕੋਈ ਕੈਰੀਅਰ ਤਿਆਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "ਡਾਇਲ ਕਰਨ ਲਈ ਸਮਾਂ-ਸਮਾਪਤ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "ਡਾਇਲ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਫੇਲ੍ਹ ਹੋਈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "ਮਾਡਮ ਸ਼ੁਰੂਆਤ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "ਦਿੱਤੇ APN ਨੂੰ ਚੁਣਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "ਨੈੱਟਵਰਕ ਲਈ ਖੋਜ ਨਹੀਂ ਕੀਤੀ ਜਾ ਰਹੀ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "ਨੈੱਟਵਰਕ ਰਜਿਸਟਰੇਸ਼ਨ ਉੱਤੇ ਪਾਬੰਦੀ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "ਨੈੱਟਵਰਕ ਰਜਿਸਟਰ ਲਈ ਸਮਾਂ-ਸਮਾਪਤ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "ਮੰਗੇ ਗਏ ਨੈੱਟਵਰਕ ਉੱਤੇ ਰਜਿਸਟਰ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN ਚੈਕ ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "ਜੰਤਰ ਲਈ ਫਿਰਮਵੇਅਰ ਸ਼ਾਇਦ ਮੌਜੂਦ ਨਹੀਂ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "ਕਨੈਕਸ਼ਨ ਅਲੋਪ ਹੋਇਆ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "ਮੌਜੂਦਾ ਕਨੈਕਸ਼ਨ ਮੁੜ-ਪ੍ਰਾਪਤ ਕੀਤਾ ਗਿਆ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "ਮਾਡਮ ਨਹੀਂ ਲੱਭਿਆ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "ਬਲਿਉਟੁੱਥ ਕੁਨੈਕਸ਼ਨ ਫੇਲ੍ਹ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM ਕਾਰਡ ਨਹੀਂ ਪਾਇਆ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM ਪਿੰਨ ਚਾਹੀਦਾ ਹੈ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM Puk ਦੀ ਲੋੜ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM ਗਲਤ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "ਕਨੈਕਸ਼ਨ ਨਿਰਭਰਤਾ ਫੇਲ੍ਹ ਹੋਈ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "ਫਿਰਮਵੇਅਰ ਮੌਜੂਦ ਨਹੀਂ ਹੈ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "ਕੇਬਲ ਕੱਢੀ ਹੋਈ ਹੈ"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "802.1X ਸੁਰੱਖਿਆ (wpa-eap) ਵਿੱਚ ਨਾ-ਪਰਿਭਾਸ਼ਿਤ ਗ਼ਲਤੀ"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਚੁਣੀ"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "eap-method ਫ਼ਾਇਲ ਨੂੰ ਪ੍ਰਮਾਣ ਕਰਨ ਦੌਰਾਨ ਨਾ-ਪਰਿਭਾਸ਼ਿਤ ਗ਼ਲਤੀ"
+
+#: panels/network/wireless-security/eap-method.c:394
+#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12, ਜਾਂ PGP ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀਆਂ"
+
+#: panels/network/wireless-security/eap-method.c:397
+#| msgid "_User certificate"
+msgid "DER or PEM certificates"
+msgstr "DER ਜਾਂ PEM ਸਰਟੀਫਿਕੇਟ"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "ਗੁੰਮ EAP-FAST PAC ਫ਼ਾਇਲ"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC ਫਾਇਲਾਂ (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "ਅਣਜਾਣ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "ਪਰਮਾਣਿਤ ਕੀਤਾ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "ਦੋਵੇਂ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "ਅਗਿਆਤ ਪਛਾਣ(_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC ਫਾਇਲ(_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PAC ਫਾਇਲ ਚੁਣੋ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "ਅੰਦਰੂਨੀ ਪਰਮਾਣਕਿਤਾ(_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "ਆਟੋਮੈਟਿਕ PAC ਪਰੋਵਿਜ਼ਨਿੰਗ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ(_v)"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "ਗੁੰਮ EAP-LEAP ਵਰਤੋਂਕਾਰ-ਨਾਂ"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "ਗੁੰਮ EAP-LEAP ਪਾਸਵਰਡ"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ(_U)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "ਪਾਸਵਰਡ(_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "ਪਾਸਵਰਡ ਵੇਖੋ(_w)"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "ਅਵੈਧ EAP-PEAP CA ਸਰਟੀਫਿਕੇਟ: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "ਅਵੈਧ EAP-PEAP CA ਸਰਟੀਫਿਕੇਟ: ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "ਵਰਜਨ 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "ਵਰਜਨ 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A ਸਰਟੀਫਿਕੇਟ"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "ਸਰਟੀਫਿਕੇਟ ਅਥਾਰਟੀ ਸਰਫੀਟਿਕੇਟ ਚੁਣੋ"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "ਕੋਈ CA ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚਾਹੀਦਾ ਹੈ(_r)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP ਵਰਜਨ(_v)"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "ਗੁੰਮ EAP ਵਰਤੋਂਕਾਰ-ਨਾਂ"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "ਗਲਤ EAP ਪਾਸਵਰਡ"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "ਗੁੰਮ EAP-TLS ਪਛਾਣ"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "ਅਵੈਧ EAP-TLS CA ਸਰਟੀਫਿਕੇਟ: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "ਅਵੈਧ EAP-TLS CA ਸਰਟੀਫਿਕੇਟ: ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "ਅਵੈਧ EAP-TLS ਪ੍ਰਾਈਵੇਟ-ਕੁੰਜੀ: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "ਅਵੈਧ EAP-TLS ਵਰਤੋਂਕਾਰ-ਸਰਟੀਫਿਕੇਟ: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "ਬਿਨ-ਇੰਕ੍ਰਿਪਸ਼ਨ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀਆਂ ਅਸੁਰੱਖਿਅਤ ਹਨ"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"ਚੁਣੀ ਗਈ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਪਾਸਵਰਡ ਨਾਲ ਸੁਰੱਖਿਅਤ ਨਹੀਂ ਜਾਪਦੀ ਹੈ। ਇਹ ਤੁਹਾਡੀ ਸੁਰੱਖਿਅਤ"
+" ਸਨਦ ਨੂੰ ਖਤਰਾ "
+"ਪੈਦਾ ਕਰ ਸਕਦੀ ਹੈ। ਪਾਸਵਰਡ ਨਾਲ ਸੁਰੱਖਿਅਤ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਚੁਣੋ ਜੀ।\n"
+"\n"
+"(ਤੁਸੀਂ openssl ਨਾਲ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਪਾਸਵਰਡ ਸੁਰੱਖਿਅਤ ਕਰ ਸਕਦੇ ਹੋ)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "ਆਪਣਾ ਨਿੱਜੀ ਸਰਟੀਫਿਕੇਟ ਚੁਣੋ"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "ਆਪਣੀ ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਚੁਣੋ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "ਪਛਾਣ(_d)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "ਵਰਤੋਂਕਾਰ ਸਰਟੀਫਿਕੇਟ(_U)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ(_k)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "ਪ੍ਰਾਈਵੇਟ ਕੁੰਜੀ ਪਾਸਵਰਡ(_P)"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "ਅਵੈਧ EAP-TLLS CA ਸਰਟੀਫਿਕੇਟ: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "ਅਵੈਧ EAP-TTLS CA ਸਰਟੀਫਿਕੇਟ: ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (EAP ਨਹੀਂ)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "ਡੋਮੇਨ(_D)"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "802.1X ਸੁਰੱਖਿਆ ਦੀ ਪ੍ਰਮਾਣਕਿਤ ਦੌਰਾਨ ਅਣਜਾਣ ਗਲਤੀ"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "ਟਨਲ TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "ਸੁਰੱਖਿਅਤ EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "ਪਰਮਾਣਿਕਤਾ(_t)"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "ਫਾਇਲ ਚੁਣੋ"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "leap-ਵਰਤੋਂਕਾਰ ਗੁੰਮ"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "ਗੁੰਮ ਲੀਪ-ਪਾਸਵਰਡ"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "ਵਾਈ-ਫਾਈ ਪਾਸਵਰਡ ਗੁੰਮ ਹੈ।"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "ਕਿਸਮ(_T)"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "wep-key ਗੁੰਮ"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "ਅਵੈਧ wep-key: %zu ਲੰਬਾਈ ਦੀ ਕੁੰਜੀ ਵਿੱਚ ਕੇਵਲ ਹੈਕਸਾ-ਅੰਕ ਹੀ ਹੋ ਸਕਦੇ ਹਨ"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "ਅਵੈਧ wep-key: %zu ਲੰਬਾਈ ਦੀ ਕੁੰਜੀ ਵਿੱਚ ਕੇਵਲ ASCII ਅੱਖਰ ਹੀ ਹੋ ਸਕਦੇ ਹਨ"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"ਅਵੈਧ wep-key: ਗ਼ਲਤ %zu ਕੁੰਜੀ ਲੰਬਾਈ। ਕੁੰਜੀ ਦੀ ਲੰਬਾਈ ਜਾਂ ਤਾਂ 5/13 (ascii) ਜਾਂ"
+" 10/26 "
+"(ਹੈਕਸਾ) ਹੋ ਸਕਦੇ ਹਨ"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "ਗ਼ਲਤ wep-key: ਵਾਕ ਖਾਲੀ ਨਹੀਂ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "ਗ਼ਲਤ wep-key: ਵਾਕ 64-ਅੱਖਰਾਂ ਤੋਂ ਛੋਟਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "੧ (ਡਿਫਾਲਟ)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "ਓਪਨ ਸਿਸਟਮ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "ਸਾਂਝੀ ਕੁੰਜੀ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "ਕੁੰਜੀ(_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "ਕੁੰਜੀ ਵੇਖੋ(_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP ਇੰਡੈਕਸ(_x)"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"ਅਵੈਧ wpa-psk: ਕੁੰਜੀ-ਲੰਬਾਈ %zu ਅਵੈਧ ਹੈ। ਜਾਂ ਤਾਂ [8,63] ਬਾਈਟ ਜਾਂ 64 ਹੈਕਸਾ-ਅੰਕ"
+" ਹੋਣੀ ਚਾਹੀਦੀ "
+"ਹੈ।"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "ਅਵੈਧ wpa-psk: 64 ਬਾਈਟਾਂ ਨੂੰ ਹੈਕਸਾ ਨਾਲ ਅਰਥ ਕੱਢੇ ਨਹੀਂ ਜਾ ਸਕਦੇ"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "ਸੂਚਨਾਵਾਂ(_N)"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "ਸਾਊਂਡ ਚੇਤਾਵਨੀਆਂ(_A)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "ਨੋਟੀਫਿਕੇਸ਼ਨ ਪੋਪਅੱਪ(_P)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"ਜਦੋਂ ਪੋਪਅੱਪ ਅਸਮਰੱਥ ਕੀਤੇ ਜਾਂਦੇ ਹਨ ਤਾਂ ਨੋਟੀਫਿਕੇਸ਼ਨ ਸੂਚੀ ਵਿੱਚ ਨੋਟੀਫਿਕੇਸ਼ਨ ਦਿਖਾਈ"
+" ਦੇਣਾ ਜਾਰੀ ਰੱਖਣਗੇ।"
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "ਪੋਪਅੱਪ ਵਿੱਚ ਸੁਨੇਹਾ ਸਮਗੱਰੀ ਵੇਖਾਓ(_C)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "ਲਾਕ ਸਕਰੀਨ ਨੋਟੀਫਿਕੇਸ਼ਨ(_L)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "ਲਾਕ ਸਕਰੀਨ ਵਿੱਚ ਸੁਨੇਹਾ ਸਮਗੱਰੀ ਵੇਖਾਓ(__o)"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "ਤੰਗ ਨਾ ਕਰੋ(_D)"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "ਲਾਕ ਸਕਰੀਨ ਸੂਚਨਾਵਾਂ(_L)"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿ ਕਿਹੜੀਆਂ ਸੂਚਨਾਵਾਂ ਵੇਖਾਉਣੀਆਂ ਅਤੇ ਉਹ ਕੀ ਕੁਝ ਵੇਖਾਉਣ"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "ਸੂਚਨਾ;ਬੈਨਰ;ਸੁਨੇਹਾ;ਟਰੇ;ਪੋਪਅੱਪ;Notifications;Banner;Message;Tray;Popup;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "ਹੋਰ"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s ਨੂੰ ਹਟਾਇਆ"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "ਅਕਾਊਂਟ ਹਟਾਉਣਾ ਦੌਰਾਨ ਗਲਤੀ"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "ਵਾਪਸ"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "ਨੋਟੀਫਿਕੇਸ਼ਨ ਬੰਦ ਕਰੋ"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "ਕਲਾਉਡ ਵਿੱਚ ਤੁਹਾਡੇ ਡਾਟੇ ਨਾਲ ਕਨੈਕਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "ਕੋਈ ਇੰਟਰਨੈੱਟ ਕਨੈਕਸ਼ਨ ਨਹੀਂ — ਨਵੇਂ ਆਨਲਾਈਨ ਖਾਤੇ ਸੈੱਟਅੱਪ ਕਰਨ ਲਈ ਕਨੈਕਟ ਕਰੋ"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "ਖਾਤਾ ਜੋੜੋ"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s ਖਾਤਾ"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "ਅਕਾਊਂਟ ਹਟਾਓ"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "ਆਨਲਾਈਨ ਖਾਤੇ"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"ਆਪਣੇ ਆਨਲਾਈਨ ਖਾਤਿਆਂ ਨਾਲ ਕਨੈਕਟ ਹੋਵੋ ਅਤੇ ਫੈਸਲਾ ਕਰੋ ਕਿ ਉਹਨਾਂ ਨੂੰ ਕਿਸ ਲਈ ਵਰਤਣਾ ਹੈ"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"ਗੂਗਲ;ਫੇਸਬੁੱਕ;ਟਵਿੱਟਰ;ਯਾਹੂ;ਵੈੱਬ;ਆਨਲਾਈਨ;ਗੱਲਬਾਤ;ਚੈਟ;ਕੈਲੰਡਰ;ਮੇਲ;ਸੰਪਰਕ;Google;Facebo"
+"ok;Twitter;"
+"Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;"
+"Packet;ReaditLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "ਅਣਜਾਣ ਸਮਾਂ"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i ਮਿੰਟ"
+msgstr[1] "%i ਮਿੰਟ"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ਘੰਟਾ"
+msgstr[1] "%i ਘੰਟੇ"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ਘੰਟਾ"
+msgstr[1] "ਘੰਟੇ"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "ਮਿੰਟ"
+msgstr[1] "ਮਿੰਟ"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "ਪੂਰਾ ਚਾਰਜ ਹੋਣ ਲਈ %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "ਸਾਵਧਾਨ: %s ਬਾਕੀ"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s ਬਾਕੀ"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "ਪੂਰੀ ਚਾਰਜ"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "ਚਾਰਜ ਨਹੀਂ ਹੋ ਰਹੀ"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "ਖਾਲੀ"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "ਚਾਰਜ ਹੋ ਰਹੀ ਹੈ"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "ਡਿਸਚਾਰਜ ਹੋ ਰਹੀ ਹੈ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "ਬੇਤਾਰ ਮਾਊਸ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "ਬੇਤਾਰ ਕੀ-ਬੋਰਡ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "ਗ਼ੈਰ-ਰੁਕਾਵਟ-ਯੋਗ ਪਾਵਰ ਸਪਲਾਈ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "ਨਿੱਜੀ ਡਿਜ਼ਿਟਲ ਸਹਾਇਕ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "ਸੈਲਫੋਨ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "ਮੀਡਿਆ ਪਲੇਅਰ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "ਟੇਬਲੇਟ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "ਕੰਪਿਊਟਰ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "ਖੇਡਾਂ ਲਈ ਇੰਪੁੱਟ ਡਿਵਾਈਸ"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "ਬੈਟਰੀ"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "ਮੁੱਖ"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "ਵਾਧੂ"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "ਬੈਟਰੀਆਂ"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "ਜਦੋਂ ਵੇਹਲਾ ਹੈ(_i)"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "ਸਸਪੈਂਡ"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "ਬੰਦ ਕਰੋ"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "ਹਾਈਬਰਨੇਟ"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "ਕੁਝ ਨਹੀਂ"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "ਜਦੋਂ ਬੈਟਰੀ ਪਾਵਰ ਉੱਤੇ ਹੋਵੇ"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "ਜਦੋਂ ਪਲੱਗ ਲੱਗਾ ਹੋਵੇ"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "ਕਦੇ ਨਹੀਂ"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "ਆਟੋਮੈਟਿਕ ਸਸਪੈਂਡ ਕਰੋ"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"ਵੱਧ ਕਾਰਜਕਾਰੀ ਤਾਪਮਾਨ ਹੋਣ ਕਰਕੇ ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਨੂੰ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਕੀਤਾ ਹੈ।"
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"ਲੈਪ ਖੋਜਿਆ: ਕਾਰਜਗੁਜ਼ਾਰੀ ਢੰਗ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਹੈ। ਬਹਾਲ ਕਰਨ ਲਈ ਡਿਵਾਈਸ ਨੂੰ"
+" ਸਥਿਰ ਤਲ ਉੱਤੇ ਰੱਖੋ।"
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਆਰਜ਼ੀ ਤੌਰ ਉੱਤੇ ਅਸਮਰੱਥ ਹੈ।"
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"ਘੱਟ ਬੈਟਰੀ: ਪਾਵਰ ਬੱਚਤ ਸਮਰੱਥ ਹੈ। ਜਦੋਂ ਬੈਟਰੀ ਠੀਕ-ਠਾਕ ਚਾਰਜ ਹੋ ਗਈ ਤਾਂ ਪਿਛਲੇ ਮੋਡ"
+" ਨੂੰ ਬਹਾਲ ਕੀਤਾ "
+"ਜਾਵੇਗਾ।"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "“%s” ਨੇ ਪਾਵਰਪ ਬੱਚਤ ਢੰਗ ਸਰਗਰਮ ਕੀਤਾ ਹੈ।"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "“%s” ਨੇ ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਸਰਗਰਮ ਕੀਤਾ ਹੈ।"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "੧੫ ਮਿੰਟ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "੨੦ ਮਿੰਟ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "੨੫ ਮਿੰਟ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "੩੦ ਮਿੰਟ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "੪੫ ਮਿੰਟ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "੧ ਘੰਟਾ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "੮੦ ਮਿੰਟ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "੯੦ ਮਿੰਟ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "੧੦੦ ਮਿੰਟ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "੨ ਘੰਟੇ"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "ਪਾਵਰ ਢੰਗ"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "ਸਿਸਟਮ ਕਾਰਗੁਜ਼ਾਰੀ ਤੇ ਪਾਵਰ ਵਰਤੋਂ ਨੂੰ ਪ੍ਰਭਾਵਿਤ ਕਰਦਾ ਹੈ।"
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "ਪਾਵਰ ਬੱਚਤ ਚੋਣਾਂ"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "ਆਟੋਮੈਟਿਕ ਸਕਰੀਨ ਚਮਕ"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "ਆਲੇ-ਦੁਆਲੇ ਦੀ ਰੋਸ਼ਨੀ ਮੁਤਾਬਕ ਸਕਰੀਨ ਦੀ ਚਮਕ ਢਾਲੋ।"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "ਸਕਰੀਨ ਡਿਮ ਕਰੋ"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "ਜਦੋਂ ਕੰਪਿਊਟਰ ਨਾ-ਸਰਗਰਮ ਹੋਵੇ ਤਾਂ ਸਕਰੀਨ ਦੀ ਚਮਕ ਨੂੰ ਘਟਾਉਂਦਾ ਹੈ।"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "ਖਾਲੀ ਸਕਰੀਨ(_B)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "ਕੁਝ ਦੇਰ ਤੱਕ ਨਾ-ਸਰਗਰਮੀ ਦੇ ਬਾਅਦ ਸਕਰੀਨ ਨੂੰ ਬੰਦ ਕਰੋ।"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "ਆਪਣੇ-ਆਪ ਪਾਵਰ ਬੱਚਤ"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "ਜਦੋਂ ਬੈਟਰੀ ਘੱਟ ਹੋਵੇ ਤਾਂ ਪਾਵਰ ਬੱਚਤਰ ਢੰਗ ਸਮਰੱਥ ਕਰਦਾ ਹੈ।"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "ਆਪਣੇ-ਆਪ ਸਸਪੈਂਡ ਕਰੋ(_A)"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "ਕੁਝ ਦੇਰ ਤੱਕ ਨਾ-ਸਰਗਰਮੀ ਦੇ ਬਾਅਦ ਕੰਪਿਊਟਰ ਨੂੰ ਵਿਰਾਮ ਕਰੋ।"
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "ਪਾਵਰ ਬਟਨ ਲਈ ਰਵੱਈਆ(_w)"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "ਬੈਟਰੀ ਫ਼ੀਸਦੀ ਵੇਖਾਓ(_P)"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "ਆਪਣੇ-ਆਪ ਸਸਪੈਂਡ ਕਰੋ"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "ਪਲੱਗ ਲੱਗਾ(_P)"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "ਬੈਟਰੀ ਪਾਵਰ ਉੱਤੇ(_B)"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "ਦੇਰੀ"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "ਕਾਰਗੁਜ਼ਾਰੀ"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "ਵੱਧ ਕਾਰਗੁਜ਼ਾਰੀ ਅਤੇ ਊਰਜਾ ਖ਼ਪਤ ਹੈ।"
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "ਸੰਤੁਲਿਤ"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "ਮਿਆਰੀ ਕਾਰਗੁਜ਼ਾਰੀ ਤੇ ਊਰਜਾ ਖਪਤ ਹੈ।"
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "ਪਾਵਰ ਬੱਚਤ"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "ਘੱਟ ਕੀਤੀ ਕਾਰਗੁਜ਼ਾਰੀ ਅਤੇ ਊਰਜਾ ਖਪਤ ਹੈ।"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "ਪਾਵਰ"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "ਆਪਣੀ ਬੈਟਰੀ ਦੀ ਸਥਿਤੀ ਵੇਖੋ ਅਤੇ ਊਰਜਾ ਬੱਚਤ ਸੈਟਿੰਗਾਂ ਬਦਲੋ"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"ਸਕਰੀਨ;ਚਮਕ;ਵੇਹਲਾ;ਪਾਵਰ;ਸਲੀਪ;ਸਸਪੈਂਡ;ਹਾਈਬਰਨੇਟ;ਬੈਟਰੀ;ਵੇਹਲ;ਡਿਮ;ਖਾਲੀ;ਮਾਨੀਟਰ;ਡੀਪੀਐਮਐਸ;"
+"ਮੁਅੱਤਲ;"
+"ਊਰਜਾ;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "ਪਰਿੰਟਰ “%s” ਨੂੰ ਹਟਾਇਆ ਜਾ ਚੁੱਕਾ ਹੈ"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "ਨਵਾਂ ਪਰਿੰਟਰ ਜੋੜਨ ਲਈ ਫੇਲ੍ਹ।"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui ਲੋਡ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "ਪਰਿੰਟਰ ਜੋੜਨ ਅਤੇ ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "ਪਰਿੰਟਰ"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"ਪਰਿੰਟਰ ਜੋੜੋ, ਪਰਿੰਟਰ ਜਾਬ ਵੇਖੋ ਅਤੇ ਤਹਿ ਕਰੋ ਤੁਸੀਂ ਕਿਵੇਂ ਪਰਿੰਟ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੈ"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "ਪਰਿੰਟਰ ਜੋੜੋ"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "ਅਣ-ਲਾਕ(_U)"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "ਕੋਈ ਪਰਿੰਟਰ ਨਹੀਂ ਲੱਭਿਆ"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "ਨੈਟਵਰਕ ਐਡਰੈਸ ਦਿਓ ਜਾਂ ਪਰਿੰਟਰ ਲਈ ਖੋਜ ਕਰੋ"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"ਪਰਿੰਟਰ ਸਰਵਰ ਉੱਤੇ ਪਰਿੰਟਰਾਂ ਨੂੰ ਵੇਖਣ ਲਈ ਆਪਣਾ ਵਰਤੋਂਕਾਰ-ਨਾਂ ਅਤੇ ਪਾਸਵਰਡ ਦਿਉ।"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s ਵੇਰਵੇ"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "ਕੋਈ ਢੁੱਕਵਾਂ ਡਰਾਇਵਰ ਨਹੀਂ ਲੱਭਿਆ"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "PPD ਫਾਇਲ ਚੁਣੋ"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"ਪੋਸਟ-ਸਕ੍ਰਿਪਟ ਪਰਿੰਟਰ ਵੇਰਵਾ ਫਾਇਲਾਂ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "ਪਰਿੰਟਰ ਨਾਂ ਵਿੱਚ SPACE, TAB, #, ਜਾਂ / ਨਹੀਂ ਹੋ ਸਕਦੇ ਹਨ"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "ਟਿਕਾਣਾ"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "ਡਰਾਇਵਰ"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "…ਢੁੱਕਵੇਂ ਡਰਾਇਵਰ ਲੱਭੇ ਜਾ ਰਹੇ ਹਨ"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "ਡਰਾਈਵਰਾਂ ਲਈ ਖੋਜ ਕਰੋ"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "…ਡਾਟਾਬੇਸ ਤੋਂ ਚੁਣੋ"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "…PPD ਫਾਇਲ ਇੰਸਟਾਲ ਕਰੋ"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "ਪਰਿੰਟਰ ਡਰਾਇਵਰ ਚੁਣੋ"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "…ਡਰਾਇਵਰ ਡਾਟਾਬੇਸ ਲੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "ਚੁਣੋ"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect ਪਰਿੰਟਰ"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD ਪਰਿੰਟਰ"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "ਇੱਕ ਪਾਸੇ"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "ਲੰਮਾ ਕੋਨਾ (ਸਟੈਂਡਰਡ)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "ਛੋਟਾ ਕੋਨਾ (ਪਲਟੋ)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "ਪੋਰਟਰੇਟ"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "ਲੈਂਡਸਕੇਪ"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "ਉਲਟ ਲੈਂਡਸਕੇਪ"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "ਉਲਟ ਪੋਰਟਰੇਟ"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "ਬਹਾਲ ਕਰੋ"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "ਵਿਰਾਮ"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "ਬਾਕੀ ਹਨ"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "ਵਿਰਾਮ ਹੈ"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "ਪਰੋਸੈਸ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "ਰੁਕਿਆ ਹੈ"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "ਰੱਦ ਕੀਤੇ"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "ਅਧੂਰੇ ਛੱਡੇ"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "ਪੂਰੇ ਹੋਏ"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "ਇਸ ਜਾਬ ਨੂੰ ਕਤਾਰ ਦੇ ਸਿਖਰ ਉੱਤੇ ਭੇਜੋ"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u ਜਾਬ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+msgstr[1] "%u ਜਾਬਾਂ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — ਸਰਗਰਮ ਜਾਬਾਂ"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "%s ਉੱਤੇ ਪਰਿੰਟ ਕਰਨ ਲਈ ਸਨਦ ਦਿਓ।"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "ਡੋਮੇਨ"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "ਪਰਮਾਣਿਤ(_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "ਸਾਰੇ ਸਾਫ਼ ਕਰੋ"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "ਪਰਮਾਣਕਿਤਾ(_A)"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "ਕੋਈ ਸਰਗਰਮ ਪਰਿੰਟਰ ਜਾਬ ਨਹੀਂ ਹੈ"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "ਪਰਿੰਟਰ ਸਰਵਰ ਨੂੰ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s ਨੂੰ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "%s ਉੱਤੇ ਪਰਿੰਟਰ ਵੇਖਣ ਲਈ ਵਰਤੋਂਕਾਰ-ਨਾਂ ਅਤੇ ਪਾਸਵਰਡ ਦਿਉ।"
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "ਪਰਿੰਟਰਾਂ ਲਈ ਖੋਜ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "ਸੀਰੀਅਲ ਪੋਰਟ"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "ਪੈਰਲੈੱਲ ਪੋਰਟ"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "ਟਿਕਾਣਾ: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "ਸਿਰਨਾਵਾਂ: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "ਸਰਵਰ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "ਦੋ ਪਾਸੀਂ"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "ਪੇਪਰ ਕਿਸਮ"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "ਪੇਪਰ ਸਰੋਤ"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "ਆਉਟਪੁੱਟ ਟਰੇ"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "ਰੈਜ਼ੋਲੂਸ਼ਨ"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "ਗੋਸਟ-ਸਕ੍ਰਿਪਟ ਪ੍ਰੀਫਿਲਟਰਿੰਗ"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "ਹਰ ਪਾਸੇ ਸਫ਼ੇ"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "ਦੋ ਪਾਸੀਂ"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "ਸਥਿਤੀ"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "ਆਮ"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "ਸਫ਼ਾ ਸੈੱਟਅੱਪ"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "ਇੰਸਟਾਲਯੋਗ ਚੋਣਾਂ"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "ਜਾਬ"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "ਚਿੱਤਰ ਕੁਆਲਟੀ"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "ਰੰਗ"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "ਮੁਕੰਮਲ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "ਤਕਨੀਕੀ"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "ਟੈਸਟ ਸਫ਼ਾ"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "ਟੈਸਟ ਸਫ਼ਾ"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "ਆਟੋ ਚੋਣ"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "ਪਰਿੰਟਰ ਡਿਫਾਲਟ"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "ਇੰਬੈੱਡ ਕੀਤੇ ਗੋਸਟਸਕ੍ਰਿਪਟ ਫੋਂਟ ਹੀ"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "PS ਲੈਵਲ 1 ਲਈ ਬਦਲੋ"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "PS ਲੈਵਲ 2 ਲਈ ਬਦਲੋ"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "ਕੋਈ ਪ੍ਰੀ-ਫਿਲਟਰਿੰਗ ਨਹੀਂ"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "ਨਿਰਮਾਤਾ"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "ਕੋਈ ਸਰਗਰਮ ਜਾਬ ਨਹੀਂ"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u ਜਾਬ"
+msgstr[1] "%u ਜਾਬਾਂ"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "ਪਰਿੰਟ ਹੈੱਡ ਸਾਫ਼ ਕਰੋ"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "ਟੋਨਰ ਘੱਟ ਹੈ"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "ਟੋਨਰ ਖਤਮ ਹੋ ਗਿਆ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "ਡਿਵੈਲਪਰ ਲਈ ਘੱਟ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "ਡਿਵੈਲਪਰ ਲਈ ਖਤਮ"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "ਮਾਰਕਰ ਸਪਲਾਈ ਲਈ ਘੱਟ"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "ਮਾਰਕਰ ਸਪਲਾਈ ਲਈ ਖਤਮ"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "ਕਵਰ ਖੋਲ੍ਹੋ"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "ਦਰਵਾਜ਼ਾ ਖੋਲ੍ਹੋ"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "ਪੇਪਰ ਖਤਮ ਹੋਣ ਵਾਲੇ ਹਨ"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "ਪੇਪਰ ਖਤਮ ਹੋ ਗਏ ਹਨ"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ਆਫਲਾਈਨ"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "ਰੁਕਿਆ ਹੈ"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "ਵੇਸਟ ਰੇਸਪਟਕੇਟ ਲਗਭਗ ਭਰ ਗਿਆ ਹੈ"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "ਵੇਸਟ ਰੇਸਪਟਕੇਟ ਭਰ ਗਿਆ ਹੈ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "ਓਪਟੀਕਲ ਫੋਟੋ ਕੰਡਕਟਰ ਦੀ ਉਮਰ ਖਤਮ ਹੋ ਗਈ ਹੈ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ਓਪਟੀਕਲ ਫੋਟੋ ਕੰਡਕਟਰ ਹੁਣ ਕੰਮ ਨਹੀਂ ਕਰਦਾ ਹੈ"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "ਤਿਆਰ"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "ਜਾਬ ਮਨਜ਼ੂਰ ਨਾ ਕਰੋ"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "ਪਰੋਸੈਸ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "ਪਰਿੰਟਰ ਚੋਣਾਂ"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "ਪਰਿੰਟਰ ਵੇਰਵੇ"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "ਪਰਿੰਟਰ ਡਿਫਾਲਟ ਰੂਪ ਵਿੱਚ ਵਰਤੋਂ"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "ਪਰਿੰਟਰ ਹੈੱਡ ਸਾਫ਼ ਕਰੋ"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "ਪਰਿੰਟਰ ਹਟਾਓ"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "ਮਾਡਲ"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "ਸਿਆਹੀ ਲੈਵਲ"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "ਜਦੋਂ ਸਮੱਸਿਆ ਹੱਲ਼ ਹੁੰਦੀ ਹੈ ਤਾਂ ਮੁੜ-ਚਾਲੂ ਕਰੋ।"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "ਮੁੜ-ਚਾਲੂ ਕਰੋ"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "…ਪਰਿੰਟਰ ਜੋੜੋ"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "ਕੋਈ ਪਰਿੰਟਰ ਨਹੀਂ ਹੈ"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"ਅਫਸੋਸ! ਸਿਸਟਮ ਪਰਿੰਟਿਗ ਸੇਵਾ\n"
+"    ਉਪਲੱਬਧ ਨਹੀਂ ਜਾਪਦੀ ਹੈ।"
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "ਫਾਰਮੈਟ"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "…ਲੋਕੇਲ ਖੋਜੋ"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "ਆਮ ਫਾਰਮੈਟ"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "ਸਾਰੇ ਫਾਰਮੈਟ"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "ਕੋਈ ਖੋਜ ਨਤੀਜੇ ਨਹੀਂ"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "ਦੇਸ਼ਾਂ ਜਾਂ ਭਾਸ਼ਾਵਾਂ ਲਈ ਖੋਜਾਂ ਹੋ ਸਕਦੀਆਂ ਹਨ।"
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "ਝਲਕ"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ਇੰਪਿਅਰਲ"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "ਮੈਟਰਿਕ"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "ਮਿਤੀ"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "ਮਿਤੀ ਤੇ ਵੇਲੇ"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "ਅੰਕ"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "ਮਾਪ"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "ਪੇਪਰ"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "ਭਾਸ਼ਾ ਅਤੇ ਫਾਰਮੈਟ ਅਗਲੀ ਵਾਰ ਲਾਗਇਨ ਕਰਨ ਦੇ ਬਾਅਦ ਬਦਲੇਗਾ"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "…ਲਾਗਆਉਟ"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"ਭਾਸ਼ਾ ਸੈਟਿੰਗ ਨੂੰ ਇੰਟਰਫੇਸ ਦੀ ਲਿਖਤ ਤੇ ਵੈੱਬ ਸਫ਼ਿਆਂ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ। ਅੰਕਾਂ,"
+" ਤਾਰੀਖਾਂ ਤੇ ਕਰੰਸੀਆਂ ਲਈ "
+"ਫਾਰਮੈਟ ਵਰਤੇ ਜਾਂਦੇ ਹਨ।"
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "ਤੁਹਾਡਾ ਖਾਤਾ"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "ਭਾਸ਼ਾ(_L)"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "ਫਾਰਮੈਟ(_F)"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "ਲਾਗਇਨ ਸਕਰੀਨ"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "ਇਲਾਕਾ ਅਤੇ ਭਾਸ਼ਾ"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "ਆਪਣੀ ਦਿਖਾਉਣ ਵਾਲੀ ਭਾਸ਼ਾ ਤੇ ਫਾਰਮੈਟ ਚੁਣੋ"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "ਭਾਸ਼ਾ;ਲੇਆਉਟ;ਕੀਬੋਰਡ;ਇੰਪੁੱਟ;ਖਾਕਾ;ਬੋਲੀ;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "ਪੁੱਛੋ ਕਿ ਕੀ ਕਰਨਾ ਹੈ"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "ਕੁਝ ਨਹੀਂ"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "ਫੋਲਡਰ ਖੋਲ੍ਹੋ"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "ਹੋਰ ਮੀਡਿਆ"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "ਆਡੀਓ ਸੀਡੀ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "ਵਿਡੀਓ DVD ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "ਜਦੋਂ ਸੰਗੀਤ ਪਲੇਅਰ ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇ ਤਾਂ ਚਲਾਉਣ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "ਜਦੋਂ ਕੈਮਰਾ ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇ ਤਾਂ ਚਲਾਉਣ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "ਸਾਫਟਵੇਅਰ ਸੀਡੀ ਲਈ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "ਆਡੀਓ DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "ਖਾਲੀ ਬਲੁ-ਰੇ ਡਿਸਕ"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "ਖਾਲੀ CD ਡਿਸਕ"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "ਖਾਲੀ DVD ਡਿਸਕ"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "ਖਾਲੀ HD DVD ਡਿਸਕ"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "ਬਲੁ-ਰੇ ਵਿਡੀਓ ਡਿਸਕ"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "ਈ-ਬੁੱਕ ਰੀਡਰ"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD ਵਿਡੀਓ ਡਿਸਕ"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "ਤਸਵੀਰ CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "ਸੁਪਰ ਵਿਡੀਓ CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "ਵਿਡੀਓ CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "ਵਿੰਡੋਜ਼ ਸਾਫਟਵੇਅਰ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "ਚੁਣੋ ਕਿ ਹੋਰ ਮੀਡਿਆ ਕੇਵਲ ਵਰਤਿਆ ਜਾਵੇ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD ਆਡੀਓ(_a)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD ਵਿਡੀਓ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "ਮਿਊਜ਼ਕ ਪਲੇਅਰ(_M)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "ਸਾਫਟਵੇਅਰ(_S)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "...ਹੋਰ ਮੀਡਿਆ(_O)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "ਮੀਡਿਆ ਪਾਉਣ ਉੱਤੇ ਕਦੇ ਵੀ ਪੁੱਛੋ ਜਾਂ ਪਰੋਗਰਾਮ ਸਟਾਰਟ ਨਾ ਕਰੋ(_N)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "ਚੁਣੋ ਕਿ ਹੋਰ ਮੀਡਿਆ ਕਿਵੇਂ ਵਰਤਿਆ ਜਾਵੇ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "ਕਾਰਵਾਈ(_A):"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "ਕਿਸਮ(_T):"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "ਹਟਾਉਣਯੋਗ ਮੀਡਿਆ"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "ਹਟਾਉਣਯੋਗ ਮੀਡੀਏ ਦੀਆਂ ਸੈਟਿੰਗਾਂ ਦੀ ਸੰਰਚਨਾ"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"ਡਿਵਾਈਸ;ਡੀਵਾਈਸ;ਯੰਤਰ;ਜੰਤਰ;ਡਿਫਾਲਟ;ਮੂਲ;ਐਪਲੀਕੇਸ਼ਨ;ਤਰਜੀਹੀ;ਪਸੰਦ;ਸੀਡੀ;ਡੀਵੀਡੀ;ਆਡੀਓ;ਯੂਐਸ"
+"ਬੀ;"
+"ਵੀਡੀਓ;ਹਟਾਉਣਯੋਗ;ਵਿਡੀਓ;ਮੀਡੀਆ;ਆਟੋ-ਰਨ;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "ਸਕਰੀਨ ਬੰਦ ਕਰੋ"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "੩੦ ਸਕਿੰਟ"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "੧ ਮਿੰਟ"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "੨ ਮਿੰਟ"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "੩ ਮਿੰਟ"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "੫ ਮਿੰਟ"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "੩੦ ਮਿੰਟ"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "੧ ਘੰਟਾ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "੧ ਮਿੰਟ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "੨ ਮਿੰਟ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "੩ ਮਿੰਟ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "੪ ਮਿੰਟ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "੫ ਮਿੰਟ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "੮ ਮਿੰਟ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "੧੦ ਮਿੰਟ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "੧੨ ਮਿੰਟ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "੧੫ ਮਿੰਟ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "ਕਦੇ ਨਹੀਂ"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "ਸਕਰੀਨ ਲਾਕ"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"ਆਪਣੇ-ਆਪ ਸਕਰੀਨ ਨੂੰ ਲਾਕ ਕਰਨ ਨਾਲ ਤੁਹਾਡੇ ਦੂਰ ਚਲੇ ਜਾਣ ਉੱਤੇ ਹੋਰਾਂ ਵਲੋਂ ਕੰਪਿਊਟਰ ਨੂੰ"
+" ਵਰਤਣ ਤੋਂ ਰੋਕਿਆ "
+"ਜਾਂਦਾ ਹੈ।"
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "ਖਾਲੀ ਸਕਰੀਨ ਦੇਰੀ"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "ਨਾ-ਸਰਗਰਮੀ ਦਾ ਅੰਤਰਾਲ, ਜਿਸ ਦੇ ਬਾਅਦ ਸਕਰੀਨ ਖਾਲੀ ਹੋ ਜਾਵੇਗੀ।"
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "ਆਪਣੇ-ਆਪ ਸਕਰੀਨ ਲਾਕ ਕਰੋ(_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "ਆਪਣੇ-ਆਪ ਸਕਰੀਨ ਲਾਕ ਦੇਰੀ(_S)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "ਜਦੋਂ ਸਕਰੀਨ ਆਪਣੇ-ਆਪ ਲਾਕ ਹੁੰਦੀ ਹੈ ਤਾਂ ਸਕਰੀਨ ਦੇ ਝਪਕਣ ਦੇ ਬਾਅਦ ਅੰਤਰਾਲ ਹੈ।"
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "ਲਾਕ ਸਕਰੀਨ ਉੱਤੇ ਨੋਟੀਫਿਕੇਸ਼ਨ ਵੇਖਾਓ(_N)"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "ਨਵੇਂ _USB ਡਿਵਾਈਸਾਂ ਉੱਤੇ ਰੋਕ"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"ਜਦੋਂ ਸਕਰੀਨ ਲਾਕ ਹੋਵੇ ਤਾਂ ਨਵੇਂ USB ਡਿਵਾਈਸਾਂ ਨੂੰ ਸਿਸਟਮ ਨਾਲ ਤਾਲਮੇਲ ਕਰਨ ਤੋਂ ਰੋਕਦਾ"
+" ਹੈ।"
+
+#: panels/screen/cc-screen-panel.ui:108
+#| msgid "Privacy"
+msgid "Screen Privacy"
+msgstr "ਸਕਰੀਨ ਪਰਦੇਦਾਰੀ"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "ਵੇਖਣ ਕੋਣ ਸੀਮਿਤ ਕਰੋ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#| msgid "Screen Sharing"
+msgid "Screen Settings"
+msgstr "ਸਕਰੀਨ ਸੈਟਿੰਗਾਂ"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "ਸਕਰੀਨ;ਸਕ੍ਰੀਨ;ਪਰਦਾ;ਲਾਕ;ਤਾਲਾ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "ਟਿਕਾਣਾ ਚੁਣੋ"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "ਠੀਕ ਹੈ(_O)"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "ਟਿਕਾਣਾ ਖੋਜ"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"ਫੋਲਡਰ, ਜਿਹਨਾਂ ਨੂੰ ਸਿਸਟਮ ਐਪਲੀਕੇਸ਼ਨਾਂ, ਜਿਵੇਂ ਫਾਇਲਾਂ, ਫੋਟੋ ਅਤੇ ਵਿਡੀਓ ਵਲੋਂ ਖੋਜਿਆ"
+" ਜਾਂਦਾ ਹੈ।"
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "ਥਾਵਾਂ"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "ਬੁੱਕਮਾਰਕ"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "ਹੋਰ"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "ਟਿਕਾਣਾ ਜੋੜੋ"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "ਕੋਈ ਐਪਲੀਕੇਸ਼ਨ ਨਹੀਂ ਲੱਭੀ"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "ਐਪਲੀਕੇਸ਼ਨ ਖੋਜੋ"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "ਐਪਲੀਕੇਸ਼ਨ ਵਲੋਂ ਦਿੱਤੇ ਖੋਜ ਨਤੀਜਿਆਂ ਸਮੇਤ।"
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "ਫੋਲਡਰ ਜਿਹਨਾਂ ਨੂੰ ਸਿਸਟਮ ਐਪਲੀਕੇਸ਼ਨਾਂ ਵਲੋਂ ਖੋਜਿਆ ਜਾਂਦਾ ਹੈ।"
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "ਖੋਜ ਦੇ ਨਤੀਜੇ"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "ਨਤੀਜੇ ਸੂਚੀਬੱਧ ਕ੍ਰਮ ਮੁਤਾਬਕ ਦਿਖਾਏ ਜਾ ਰਹੇ ਹਨ।"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿਹੜੀਆਂ ਐਪਲੀਕੇਸ਼ਨ ਸਰਗਰਮੀ ਝਲਕ ਵਿੱਚ ਖੋਜ ਨਤੀਜਿਆਂ ਵਿੱਚ ਦਿਸਣ"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"ਖੋਜ;ਲੱਭੋ;ਲੱਭਣਾ;ਇੰਡੈਕਸ;ਤਤਕਰਾ;ਪਰਾਈਵੇਸੀ;ਨਤੀਜੇ;Search;Find;Index;Hide;Privacy;Resu"
+"lts;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "ਸਾਂਝਾ ਕਰਨ ਲਈ ਕੋਈ ਨੈੱਟਵਰਕ ਨਹੀਂ ਚੁਣਿਆ"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "ਨੈੱਟਵਰਕ"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "ਚਾਲੂ"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "ਬੰਦ"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "ਯੋਗ ਕੀਤਾ"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "ਸਰਗਰਮ"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "ਫੋਲਡਰ ਚੁਣੋ"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "ਸ਼ਾਮਲ"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "ਮੀਡਿਆ ਸਾਂਝ ਸਮਰੱਥ"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"ਫਾਇਲ ਸਾਂਝ ਤੁਹਾਨੂੰ ਤੁਹਾਡੇ ਪਬਲਿਕ ਫੋਲਡਰ ਨੂੰ ਹੋਰਾਂ ਨਾਲ ਤੁਹਾਡੇ ਮੌਜੂਦਾ ਨੈੱਟਵਰਕ ਉੱਤੇ"
+" ਦੀ ਵਰਤੋਂ ਨਾਲ ਸਾਂਝਾ "
+"ਕਰਨ ਲਈ ਸਹਾਇਕ ਹੈ: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"ਜਦੋਂ ਰਿਮੋਟ ਲਾਗਇਨ ਸਮਰੱਥ ਹੁੰਦਾ ਹੈ ਤਾਂ ਰਿਮੋਟ ਵਰਤੋਂਕਾਰ ਨੂੰ ਸੁਰੱਖਿਅਤ ਸ਼ੈੱਲ ਕਮਾਂਡ"
+" ਰਾਹੀਂ ਕਨੈਕਟ ਹੋ ਸਕਦਾ "
+"ਹੈ:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "ਨਿੱਜੀ ਮੀਡਿਆ ਸਾਂਝ ਸਮਰੱਥ"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "ਡਿਵਾਈਸ ਦਾ ਨਾਂ ਕਾਪੀ ਕੀਤਾ"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "ਡਿਵਾਈਸ ਦਾ ਐਡਰੈਸ ਕਾਪੀ ਕੀਤਾ"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ ਕਾਪੀ ਕੀਤਾ"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "ਪਾਸਵਰਡ ਕਾਪੀ ਕੀਤਾ"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "ਸਾਂਝਾ"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "ਕੰਪਿਊਟਰ ਦਾ ਨਾਂ(_C)"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "ਫਾਇਲ ਸਾਂਝਾ(_F)"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "ਰਿਮੋਟ ਡੈਸਕਟਾਪ(_D)"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "ਮੀਡਿਆ ਸਾਂਝਾ ਕਰਨਾ(_M)"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "ਰਿਮੋਟ ਲਾਗਇਨ(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "ਫਾਇਲ ਸਾਂਝ"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "ਪਾਸਵਰਡ ਚਾਹੀਦਾ ਹੈ(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "ਰਿਮੋਟ ਲਾਗਇਨ"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "ਰਿਮੋਟ ਡੈਸਕਟਾਪ"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"ਰਿਮੋਟ ਡੈਸਕਟਾਪ ਹੋਰ ਕੰਪਿਊਟਰ ਤੋਂ ਤੁਹਾਡੇ ਡੈਸਕਟਾਪ ਨੂੰ ਵੇਖਣ ਜਾਂ ਕੰਟਰੋਲ ਕਰਨ ਦੀ ਇਜਾਜ਼ਤ"
+" ਦਿੰਦਾ ਹੈ।"
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "ਇਸ ਕੰਪਿਊਟਰ ਲਈ ਰਿਮੋਟ ਡੈਸਕਟਾਪ ਕਨੈਕਸ਼ਨਾਂ ਨੂੰ ਸਮਰੱਥ ਜਾਂ ਅਸਮਰੱਥ ਕਰੋ।"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "ਰਿਮੋਟ ਕੰਟਰੋਲ"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "ਸਕਰੀਨ ਨੂੰ ਕੰਟਰੋਲ ਕਰਨ ਵਾਸਤੇ ਰਿਮੋਟ ਕਨੈਕਸ਼ਨਾਂ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "ਕਿਵੇਂ ਕਨੈਕਟ ਕਰੀਏ"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr "ਇਸ ਕੰਪਿਊਟਰ ਨਾਲ ਡਿਵਾਈਸ ਨਾਂ ਜਾਂ ਰਿਮੋਟ ਡੈਸਕਟਾਪ ਐਡਰੈਸ ਵਰਤ ਕੇ ਕਨੈਕਟ ਕਰੋ।"
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "ਕਾਪੀ ਕਰੋ"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "ਰਿਮੋਟ ਡੈਸਕਟਾਪ ਸਿਰਨਾਵਾਂ"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "ਪਰਮਾਣਿਕਤਾ"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "ਇਸ ਕੰਪਿਊਟਰ ਨਾਲ ਕਨੈਕਟ ਕਰਨ ਲਈ ਵਰਤੋਂਕਾਰ ਨਾਂ ਅਤੇ ਪਾਸਵਰਡ ਚਾਹੀਦਾ ਹੈ।"
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "ਇੰਕ੍ਰਿਪਸ਼ਨ ਦੀ ਜਾਂਚ ਕਰੋ"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "ਇੰਕ੍ਰਿਪਸ਼ਨ ਫਿੰਗਰਪਰਿੰਟ"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"ਇੰਕ੍ਰਿਪਸ਼ਨ ਫਿੰਗਰਪਰਿੰਟ ਕਨੈਕਟ ਹੋ ਰਹੇ ਕਲਾਇਟਾਂ ਵਿੱਚ ਵੇਖੇ ਜਾ ਸਕਦੇ ਹਨ ਅਤੇ ਮਿਲਦੇ ਹੋਣੇ"
+" ਚਾਹੀਦੇ ਹਨ।"
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "ਮੀਡਿਆ ਸਾਂਝ"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "ਨੈੱਟਵਰਕ ਉੱਤੇ ਹੋਰਾਂ ਨਾਲ ਸੰਗੀਤ, ਫੋਟੋ ਤੇ ਵਿਡੀਓ ਨੂੰ ਸਾਂਝਾ ਕਰੋ।"
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "ਫੋਲਡਰ"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿ ਤੁਸੀਂ ਹੋਰਾਂ ਨਾਲ ਕੀ ਸਾਂਝਾ ਕਰਦੇ ਹੋ"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"ਸਾਂਝਾ;ਸਾਂਝਾ ਕਰੋ;ਨਾਂ;ਨਾਮ;ਡੈਸਕਟਾਪ;ਮੀਡੀਆ;ਆਡੀਓ;ਵੀਡੀਓ;ਹੋਸਟ;ssh;ਰਿਮੋਟ;ਤਸਵੀਰ;ਫੋਟੋ;ਮੂਵ"
+"ੀ;ਸਰਵਰ;"
+"ਰੈਂਡਰ;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "ਰਿਮੋਟ ਲਾਗਇਨ ਸਮਰੱਥ ਜਾਂ ਅਸਮਰੱਥ"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "ਰਿਮੋਟ ਲਾਗਇਨ ਨੂੰ ਬੰਦ ਜਾਂ ਚਾਲੂ ਕਰਨ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "ਕਸਟਮ"
+
+#: panels/sound/cc-alert-chooser.ui:12
+#| msgid "Flickr"
+msgid "Click"
+msgstr "ਕਲਿੱਕ"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#| msgid "Sharing"
+msgid "String"
+msgstr "ਸਤਰ"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "ਸਵਿੰਗ"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "ਹੁਮ"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "ਸੰਤੁਲਨ"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "ਫਿੱਕਾ"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "ਪਿਛਲਾ"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "ਅਗਲਾ"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s ਦੀ ਜਾਂਚ ਜਾਰੀ"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "ਜਾਂਚ ਕਰਨ ਲਈ ਸਪੀਕਰ ਨੂੰ ਕਲਿੱਕ ਕਰੋ"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "ਸਿਸਟਮ ਆਵਾਜ਼"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "ਮਾਸਟਰ ਆਵਾਜ਼"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "ਆਵਾਜ਼ ਪੱਧਰ"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "ਆਉਟਪੁੱਟ"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "ਆਉਟਪੁੱਟ ਡਿਵਾਈਸ"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "ਜਾਂਚ ਕਰੋ"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "ਸੰਰਚਨਾ"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "ਸਬਵੂਫ਼ਰ"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "ਇੰਪੁੱਟ"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "ਇੰਪੁੱਟ ਡਿਵਾਈਸ"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "ਆਵਾਜ਼"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "ਚੇਤਾਵਨੀ ਸਾਊਂਡ"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "੧੦੦%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "ਚੁੱਪ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ਸਾਊਂਡ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ਸਾਊਂਡ ਲੈਵਲ, ਇੰਪੁੱਟ, ਆਉਟਪੁੱਟ ਅਤੇ ਚੇਤਾਵਨੀ ਸਾਊਂਡ ਬਦਲੋ"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"ਕਾਰਡ;ਮਾਈਕਰੋਫੋਨ;ਵਾਲੀਅਮ;ਫੇਡ;ਬੈਲਨਸ;ਬਲਿਊਟੁੱਲ;ਹੈੱਡਸੈੱਟ;ਆਡੀਓ;ਆਉਟਪੁੱਟ;ਇੰਪੁੱਟ;ਇਨਪੁੱਟ;ਬ"
+"ਲੁਟੁੱਥ;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "ਡਿਸ-ਕੁਨੈਕਟ ਹੈ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "ਕਨੈਕਟ ਹੈ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "ਪਰਮਾਣਕਿਤਾ ਗਲਤੀ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "ਪਰਮਾਣਕਿਤਾ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "ਘਟਾਈ ਗਈ ਕਾਰਜ ਸਮਰੱਥਾ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "ਕਨੈਕਟ ਅਤੇ ਪਰਮਾਣਿਤ ਹੈ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "ਅਣਪਛਾਤਾ"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "ਇਸ ਵੇਲੇ ਪਰਮਾਣਿਤ ਕੀਤਾ:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "ਇਸ ਵੇਲੇ ਕਨੈਕਟ ਕੀਤਾ:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "ਇਸ ਵੇਲੇ ਦਾਖਲ ਹੋਇਆ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "ਡਿਵਾਈਸ ਨੂੰ ਪਰਮਾਣਿਤ ਕਰਨ ਲਈ ਅਸਫ਼ਲ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "ਡਿਵਾਈਸ ਨੂੰ ਭੁੱਲਣ ਲਈ ਅਸਫ਼ਲ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "%u ਹੋਰ ਡਿਵਾਈਸ ਉੱਤੇ ਨਿਰਭਰ ਹੈ"
+msgstr[1] "%u ਹੋਰ ਡਿਵਾਈਸਾਂ ਉੱਤੇ ਨਿਰਭਰ ਹੈ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "ਨੋਟੀਫਿਕੇਸ਼ਨ ਬੰਦ ਕਰੋ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "ਨਾਂ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "ਹਾਲਤ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "ਪਰਮਾਣਿਤ ਅਤੇ ਕਨੈਕਟ ਕਰੋ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "ਡਿਵਾਈਸ ਭੁਲਾਓ"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "ਗ਼ਲਤੀ"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "ਪਰਮਾਣਿਤ ਹੈ"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"ਥੰਡਰਬੋਲਟ ਸਬ-ਸਿਸਟਮ (boldtd) ਠੀਕ ਤਰ੍ਹਾਂ ਇੰਸਟਾਲ ਨਹੀਂ ਹੈ ਜਾਂ ਠੀਕ ਤਰ੍ਹਾਂ ਸੈਟ ਅੱਪ"
+" ਨਹੀਂ ਕੀਤਾ ਹੈ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "ਡਿਵਾਈਸਾਂ, ਜਿਵੇਂ ਕਿ ਡੌਕ ਅਤੇ ਬਾਹਰੀ GPU ਲਈ ਸਿੱਧੀ ਪਹੁੰਚ ਲਈ ਸਹਿਮਤੀ ਦਿਓ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "ਸਿਰਫ਼ USB ਅਤੇ ਡਿਸਪਲੇਅ ਪੋਰਟ ਡਿਵਾਈਸ ਹੀ ਜੋੜ ਜਾ ਸਕਦੇ ਹਨ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"ਥੰਡਰਬੋਲਟ ਖੋਜਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।\n"
+"ਜਾਂ ਤਾਂ ਸਿਸਟਮ ਥੰਡਰਬੋਲਢ ਲਈ ਸਹਾਇਕ ਨਹੀ ਹੈ, ਇਹ BIOS ਵਿੱਚੋਂ ਅਸਮਰੱਥ ਕੀਤਾ ਹੋ ਸਕਦਾ ਹੈ"
+" ਜਾਂ BIOS "
+"ਵਿੱਚ ਗ਼ੈਰ-ਸਹਾਇਕ ਸੁਰੱਖਿਆ ਪੱਧਰ ਲਈ ਸੈੱਟ ਕੀਤਾ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "ਥੰਡਰਬੋਲਟ ਲਈ ਸਹਿਯੋਗ ਨੂੰ BIOS 'ਚ ਅਸਮਰੱਥ ਕੀਤਾ ਹੈ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "ਥੰਡਰਬੋਲਟ ਸੁਰੱਖਿਆ ਪੱਧਰ ਦਾ ਪਤਾ ਨਹੀਂ ਲਾਇਆ ਜਾ ਸਕਿਆ।"
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "ਸਿੱਧਾ ਮੋਡ ਬਦਲਣ ਲਈ ਗ਼ਲਤੀ: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "ਥੰਡਰਬੋਲਟ ਸਹਿਯੋਗ ਨਹੀਂ ਹੈ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "ਥੰਡਰਬੋਲਟ ਸਬ-ਸਿਸਟਮ ਨਾਲ ਕਨੈਕਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "ਸਿੱਧੀ ਪਹੁੰਚ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "ਬਾਕੀ ਪਏ ਡਿਵਾਈਸ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "ਕੋਈ ਡਿਵਾਈਸ ਜੋੜਿਆ ਨਹੀਂ ਹੈ"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "ਥੰਡਰਬੋਲਟ"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "ਥੰਡਰਬੋਲਟ ਡਿਵਾਈਸਾਂ ਦਾ ਇੰਤਜ਼ਾਮ ਕਰੋ"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "ਥੰਡਰਬੋਲਟ;ਪਰਦੇਦਾਰੀ;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "ਝਪਕਦੀ ਕਰਸਰ"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "ਟੈਕਸਟ ਖੇਤਰਾਂ ਵਿੱਚ ਕਰਸਰ ਝਪਕਾਓ"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "ਸਪੀਡ"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "ਕਰਸਰ ਝਪਕਣ ਦੀ ਗਤੀ"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "ਕਰਸਰ ਆਕਾਰ"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "ਕਰਸਰ ਵੇਖਣ ਨੂੰ ਸੌਖਾ ਬਣਾਉਣ ਲਈ ਇਸ ਦੇ ਆਕਾਰ ਨੂੰ ਕਰਸਰ ਨਾਲ ਜੋੜਿਆ ਜਾ ਸਕਦਾ ਹੈ।"
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "ਕਲਿੱਕ ਸਹਾਇਕ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "ਸੈਕੰਡਰੀ ਕਲਿੱਕ ਦੀ ਨਕਲ(_S)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "ਪ੍ਰਾਈਮਰੀ ਬਟਨ ਨੂੰ ਹੋਲਡ ਕਰਕੇ ਰੱਖੋ, ਜਦੋਂ ਸੈਕੰਡਰੀ ਕਲਿੱਕ ਚਲਾਓ।"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "ਮਨਜ਼ੂਰ ਦੇਰੀ(_c):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "ਛੋਟਾ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "ਸੈਕੰਡਰੀ ਕਲਿੱਕ ਦੇਰੀ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "ਲੰਮਾ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "ਹੋਵਰ ਕਲਿੱਕ(_H)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "ਜਦੋਂ ਪੁਆਇੰਟਰ ਗਤੀ ਨੂੰ ਰੋਕਣਾ ਹੋਵੇ ਤਾਂ ਕਲਿੱਕ ਚਲਾਓ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "ਡਿਲੇਅ(_e):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "ਛੋਟਾ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "ਲੰਮਾ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "ਮੋਸ਼ਨ ਥਰੈਸ਼ਹੋਲਡ(_t):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "ਛੋਟਾ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "ਵੱਡਾ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "ਦੁਹਰਾਉ ਸਵਿੱਚਾਂ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "ਸਵਿੱਚ ਨੂ ਦਹਰਾਉ, ਜਦੋ ਕਿ ਸਵਿੱਚ ਨੂੰ ਦਬਾਈ ਰੱਖਿਆ ਜਾਵੇ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "ਦੁਹਰਾਉਣ ਸਵਿੱਚ ਦੇਰੀ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "ਸਵਿੱਚਾਂ ਨੂੰ ਮੁੜ-ਦਬਾਉਣ ਗਤੀ"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "ਲਿਖਣ ਸਹਾਇਕ"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "ਸਟਿੱਕੀ ਸਵਿੱਚਾਂ(_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "ਮਾਡੀਫਾਇਰ ਸਵਿੱਚਾਂ ਦੀ ਲੜੀ ਨੂੰ ਸਵਿੱਚ ਕੰਬੀਨੇਸ਼ਨ ਵਜੋਂ ਮੰਨੋ।"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "ਜੇਕਰ ਦੋ ਸਵਿੱਚਾਂ ਇਕੱਠੀਆਂ ਦਬਾਈਆਂ ਜਾਣ ਤਾਂ ਬੰਦ ਕਰੋ(_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "ਬੀਪ, ਜਦੋਂ ਕਿ ਮੋਡੀਫਾਇਰ ਨੂੰ ਦਬਾਇਆ ਜਾਵੇ(_m)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "ਹੌਲੀ-ਸਵਿੱਚਾਂ(_l)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "ਸਵਿੱਚ ਦੱਬਣ ਤੇ ਇਹ ਮਨਜ਼ੂਰ ਕਰਨ 'ਚ ਦੇਰੀ ਕਰੋ"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "ਛੋਟਾ"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "ਹੌਲੀ ਸਵਿੱਚ ਟਾਈਪ ਕਰਨ ਦੇਰੀ"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "ਲੰਮਾ"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "ਬੀਪ, ਜਦੋਂ ਕਿ ਸਵਿੱਚ ਨੂੰ ਦਬਾਇਆ ਜਾਵੇ(_e)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "ਬੀਪ, ਜਦੋਂ ਸਵਿੱਚ ਮਨਜ਼ੂਰ ਕੀਤੀ ਜਾਵੇ(_a)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "ਬੀਪ, ਜੇਕਰ ਸਵਿੱਚ ਰੱਦ ਹੋਵੇ(_r)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "ਬਾਊਂਸ ਸਵਿੱਚਾਂ(_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "ਤੇਜ਼ ਡੁਪਲੀਕੇਟ ਸਵਿੱਚ-ਦੱਬਣਾ ਅਣਡਿੱਠਾ"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "ਛੋਟਾ"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "ਬਾਊਂਸ ਸਵਿੱਚ ਟਾਈਪ ਕਰਨ ਦੇਰੀ"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "ਲੰਮਾ"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "ਕੀ-ਬੋਰਡ ਰਾਹੀਂ ਚਾਲੂ(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "ਕੀਬੋਰਡ ਤੋਂ ਅਸੈਸਬਿਲਟੀ ਫੀਚਰ ਚਾਲੂ ਅਤੇ ਬੰਦ ਕਰੋ"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "ਮੂਲ"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "ਮੱਧਮ"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "ਵੱਡਾ"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "ਹੋਰ ਵੱਡਾ"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "ਸਭ ਤੋਂ ਵੱਡਾ"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d ਪਿਕਸਲ"
+msgstr[1] "%d ਪਿਕਸਲ"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "ਹਮੇਸ਼ਾ ਯੂਨੀਵਰਸਲ ਅਸੈੱਸਬਿਲਟੀ ਮੇਨੂ ਵੇਖੋ(_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "ਵੇਖਣਾ"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "ਵੱਧ-ਗੂੜਾ(_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "ਵੱਡਾ ਟੈਕਸਟ(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "ਐਨੀਮੇਸ਼ਨ ਸਮਰੱਥ ਕਰੋ(_n)"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "ਸਕਰੀਨ ਰੀਡਰ(_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "ਸਕਰੀਨ ਰੀਡਰ ਵੇਖਾਏ ਗਏ ਟੈਕਸਟ ਨੂੰ ਪੜ੍ਹਦਾ ਹੈ, ਜਦੋਂ ਤੁਸੀਂ ਫੋਕਸ ਹਿਲਾਉਂਦੇ ਹੋ।"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "ਬਾਊਂਸ ਸਵਿੱਚਾਂ(_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "ਜਦੋਂ ਵੀ ਜਦੋਂ ਨਮ-ਲਾਕ ਜਾਂ ਕੈਪਸ ਲਾਕ ਚਾਲੂ ਜਾਂ ਬੰਦ ਹੋਵੇ ਤਾਂ ਬੀਪ ਕਰੋ।"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "ਕਰਸਰ ਆਕਾਰ(_u)"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "ਜ਼ੂਮ(_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "ਸੁਣਨ"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "ਦਿੱਖ ਚੇਤਾਵਨੀ(_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "ਸਕਰੀਨ ਕੀਬੋਰਡ(_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "ਦੁਹਰਾਉ ਸਵਿੱਚਾਂ(_e)"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "ਝਪਕਦੀ ਕਰਸਰ(_B)"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "ਲਿਖਣ ਸਹਾਇਕ(Acces_sX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "ਪੁਆਇੰਟ ਤੇ ਕਲਿੱਕ ਕਰਨਾ"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "ਮਾਊਸ ਸਵਿੱਚਾਂ(_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "ਪੁਆਇੰਟਰ ਲੱਭੋ(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "ਕਲਿੱਕ ਸਹਾਇਕ(_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "ਡਬਲ ਕਲਿੱਕ ਦੇਰੀ(_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "ਡਬਲ ਕਲਿੱਕ ਦੇਰੀ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "ਦਿੱਖ ਚੇਤਾਵਨੀ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "ਫਲੈਸ਼ ਟੈਸਟ(_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ਜਦੋਂ ਚੇਤਾਵਨੀ ਸਾਊਂਡ ਹੋਵੇ ਤਾਂ ਦਿੱਖ ਸੰਕੇਤਕ ਵਰਤੋਂ।"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "ਪੂਰੀ ਸਕਰੀਨ ਝਲਕਾਓ(_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "ਪੂਰੀ ਵਿੰਡੋ ਝਲਕਾਓ(_w)"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "ਛੋਟਾ"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ਸਕਰੀਨ"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ਸਕਰੀਨ"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ਸਕਰੀਨ"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "ਲੰਮਾ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "ਪੂਰੀ ਸਕਰੀਨ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "ਉਪਰਲਾ ਅੱਧ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "ਹੇਠਲਾ ਅੱਧ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "ਖੱਬਾ ਅੱਧ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "ਸੱਜਾ ਅੱਧ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "ਜ਼ੂਮ ਚੋਣਾਂ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "ਵੱਡਦਰਸ਼ਨ(_M):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "ਵੱਡਦਰਸ਼ੀ ਸਥਿਤੀ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "ਮਾਊਸ ਕਰਸਰ ਮੁਤਾਬਕ(_F)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "ਸਕਰੀਨ ਭਾਗ(_S):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "ਸਕਰੀਨ ਦੇ ਬਾਹਰਵਾਰ ਵਾਧੂ ਵੱਡਦਰਸ਼ੀ(_e)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "ਵੱਡਦਰਸ਼ੀ ਕਰਸਰ ਸੈਂਟਰ 'ਚ ਰੱਖੋ(_K)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "ਵੱਡਦਰਸ਼ੀ ਕਰਸਰ ਨਾਲ ਸਮੱਗਰੀ ਆਸੇ-ਪਾਸੇ ਕਰੋ(_p)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "ਸਮੱਗਰੀ ਉੱਤੇ ਕਰਸਰ ਹਿਲਾਉਣ ਨਾਲ ਵੱਡਦਰਸ਼ਨ(_c)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "ਵੱਡਦਰਸ਼ੀ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "ਕਰਾਸ-ਹੇਅਰ(_C):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "ਮਾਊਸ ਕਰਸਰ ਓਵਰਲੈਪ(_O)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "ਮੋਟਾਈ(_T):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "ਪਤਲਾ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "ਮੋਟਾ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "ਲੰਬਾਈ(_L):"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "ਰੰਗ(_l):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "ਕਰਾਸ-ਹੇਅਰ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "ਰੰਗ ਪ੍ਰਭਾਵ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "ਕਾਲੇ ਉੱਤੇ ਚਿੱਟਾ(_W):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "ਚਮਕ(_B):"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "ਕਨਟਰਾਸਟ:_(C):"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "ਰੰਗ(_l)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "ਕੋਈ ਨਹੀਂ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "ਪੂਰਾ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "ਘੱਟ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "ਵੱਧ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "ਘੱਟ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "ਉੱਚ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "ਰੰਗ ਪ੍ਰਭਾਵ"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "ਵੇਖਣਾ, ਸੁਣਨਾ, ਲਿਖਣਾ, ਪੁਆਇੰਟ ਤੇ ਕਲਿੱਕ ਕਰਨਾ ਸੌਖਾ ਬਣਾਉ"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"ਕੀਬੋਰਡ;,ਮਾਊਸ;ਫੋਂਟ;ਟੈਕਸਟ;ਆਕਾਰ;ਕਰਸਰ;ਆਵਾਜ਼;ਸਾਊਂਡ;ਬਾਊਂਸ;ਕੀ-ਬੋਰਡ;ਸਵਿੱਚਾਂ,ਕੀ;ਅਸੈਸਬਲਿਟ"
+"ੀ;ਜ਼ੂਮ;ਡਬਲ "
+"ਕਲਿੱਕ;ਦੋਹਰਾ ਕਲਿੱਕ;ਦੇਰੀ;ਸਹਾਇਕ;ਰੀਡਰ;ਐਕਟਿਵਐਕਸ;ਹੌਲੀ;ਕਨਟਰਾਸਟ;ਦੁਹਰਾਉਣਾ;ਝਪਕਣਾ;ਦੁਹਰਾ;ਵ"
+"ੱਡੇ;ਵੱਡਾ;"
+"ਉੱਚ;ਹੋਰ ਵੱਡਾ;ਸਪੀਡ;ਗਤੀ;ਦਿੱਖ;ਸੁਣਨਾ;ਆਡੀਓ;ਲਿਖਣਾ;ਟਾਈਪ ਕਰਨਾ;ਟਾਈਪਿੰਗ;ਵਿਆਪਕ"
+" ਪਹੁੰਚ;ਐਨੀਮੇਸ਼ਨਾਂ;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "੧ ਘੰਟਾ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "੧ ਦਿਨ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "੨ ਦਿਨ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "੩ ਦਿਨ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "੪ ਦਿਨ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "੫ ਦਿਨ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "੬ ਦਿਨ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "੭ ਦਿਨ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "੧੪ ਦਿਨ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "੩੦ ਦਿਨ"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "ਰੱਦੀ 'ਚੋਂ ਸਭ ਆਈਟਮਾਂ ਹਟਾਉਣੀਆਂ ਹਨ?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "ਰੱਦੀ ਵਿੱਚ ਮੌਜੂਦਾ ਆਈਟਮਾਂ ਨੂੰ ਪੱਕੇ ਤੌਰ ਉੱਤੇ ਹਟਾਇਆ ਜਾਵੇਗਾ।"
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "ਰੱਦੀ ਖਾਲੀ ਕਰੋ(_E)"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "ਸਭ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਹਟਾਉਣੀਆਂ ਹਨ?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "ਸਭ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਪੱਕੇ ਤੌਰ ਉੱਤੇ ਹਟਾਇਆ ਜਾਵੇਗਾ।"
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਨਸ਼ਟ ਕਰੋ(_P)"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "੧ ਦਿਨ"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "੭ ਦਿਨ"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "੩੦ ਦਿਨ"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "ਹਮੇਸ਼ਾ"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "ਫਾਇਲ ਅਤੀਤ"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"ਫਾਇਲ ਅਤੀਤ ਫਾਇਲਾਂ ਦੇ ਰਿਕਾਰਡ ਰੱਖਦਾ ਹੈ, ਜੋ ਤੁਸੀਂ ਵਰਤੇ ਚੁੱਕੇ ਹੋ। ਇਹ ਜਾਣਕਾਰੀ ਨੂੰ"
+" ਐਪਲੀਕੇਸ਼ਨਾਂ ਵਿਚਾਲੇ "
+"ਸਾਂਝਾ ਕੀਤਾ ਜਾਂਦਾ ਹੈ, ਜਿਸ ਨਾਲ ਤੁਹਾਡੇ ਲਈ ਫਾਇਲਾਂ ਲੱਭਣੀਆਂ ਸੌਖੀਆਂ ਹੋ ਜਾਂਦੀਆਂ ਹਨ,"
+" ਜਦੋਂ ਵਰਤੀਆਂ ਹੋਣ।"
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "ਫਾਇਲ ਅਤੀਤ(_i)"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "ਫਾਇਲ ਅਤੀਤ ਅੰਤਰਾਲ(_H)"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "ਤਾਜ਼ਾ ਅਤੀਤ ਸਾਫ਼ ਕਰੋ(_e)…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "ਰੱਦੀ ਤੇ ਆਰਜ਼ੀ ਫਾਇਲਾਂ"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"ਰੱਦੀ ਅਤੇ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਕਈ ਵਾਰ ਨਿੱਜੀ ਅਤੇ ਸੰਵੇਦਨਸ਼ੀਲ ਜਾਣਕਾਰੀ ਰੱਖ ਸਕਦੀਆਂ ਹਨ। ਉਹਨਾਂ"
+" ਨੂੰ ਆਪਣੇ-ਆਪ "
+"ਹਟਾਉਣ ਨਾਲ ਪਰਦੇਦਾਰੀ ਨੂੰ ਸੁਰੱਖਿਅਤ ਕਰਨ ਲਈ ਮਦਦ ਮਿਲ ਸਕਦੀ ਹੈ।"
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "ਰੱਦੀ ਦੀ ਸਮੱਗਰੀ ਨੂੰ ਆਪਣੇ-ਆਪ ਹਟਾਓ(_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਆਪਣੇ-ਆਪ ਹਟਾਓ(_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "ਆਪਣੇ-ਆਪ ਹਟਾਉਣ ਅੰਤਰਾਲ(_P)"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "…ਰੱਦੀ ਨੂੰ ਖਾਲੀ ਕਰੋ(_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "…ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਹਟਾਓ(_D)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "ਫਾਇਲ ਅਤੀਤ ਤੇ ਰੱਦੀ"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "ਨਿਸ਼ਾਨ ਨਾ ਛੱਡੋ"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"ਵਰਤੋਂ;ਹਾਲੀਆ;ਸੱਜਰਾ;ਹੁਣੇ;ਅਤੀਤ;ਇਤਿਹਾਸ;ਆਰਜ਼ੀ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਪਰਦੇਦਾਰੀ;ਪਰਾਈਵੇਸੀ;ਪ੍ਰਾਈ"
+"ਵੇਸੀ;ਰੱਦੀ;"
+"ਬੇਕਾਰ;ਖਾਲੀ;ਰੱਖੋ;ਨਿਕਾਸ;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "ਤੁਹਾਡੇ ਲਾਗਇਨ ਪਰੋਵਾਇਡਰ ਦੇ ਵੈੱਬ ਐਡਰੈਸ ਨਾਲ ਮਿਲਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "ਅਕਾਊਂਟ ਜੋੜਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "ਪਾਸਵਰਡ ਮਿਲਦਾ ਨਹੀਂ ਹੈ।"
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "ਅਕਾਊਂਟ ਰਜਿਸਟਰ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "ਇਹ ਡੋਮੇਨ ਨਾਲ ਪਰਮਾਣਕਿਤਾ ਦਾ ਕੋਈ ਸਹਾਇਕ ਢੰਗ ਨਹੀਂ ਹੈ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "ਡੋਮੇਨ ਜੁਆਇੰਨ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"ਉਹ ਲਾਗਇਨ ਨਾਂ ਕੰਮ ਨਹੀਂ ਕਰਦਾ।\n"
+"ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ ਜੀ।"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"ਇਹ ਲਾਗਇਨ ਪਾਸਵਰਡ ਕੰਮ ਨਹੀਂ ਕਰਦਾ ਹੈ।\n"
+"ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "ਡੋਮੇਨ ਵਿੱਚ ਲਾਗਇਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "ਡੋਮੇਨ ਲੱਭਣ ਲਈ ਅਸਮਰੱਥ, ਸ਼ਾਇਦ ਤੁਸੀਂ ਇਹ ਗਲਤ ਲਿਖੀ ਹੋਵੇ?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "ਵਰਤੋਂਕਾਰ ਸ਼ਾਮਲ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "ਪਰਸ਼ਾਸ਼ਕ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"ਪਰਸ਼ਾਸ਼ਕ ਹੋਰ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਜੋੜ ਜਾਂ ਹਟਾ ਸਕਦੇ ਹਨ, ਅਤੇ ਸਾਰੇ ਵਰਤੋਂਕਾਰਾਂ ਲਈ"
+" ਸੈਟਿੰਗਾਂ ਬਦਲ ਸਕਦੇ ਹਨ। "
+"ਮਾਪਿਆਂ ਲਈ ਕੰਟਰੋਲ ਪਰਸ਼ਾਸ਼ਕਾਂ ਲਈ ਲਾਗੂ ਨਹੀਂ ਹੋ ਸਕਦੇ ਹਨ।"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "ਵਰਤੋਂਕਾਰ ਪਹਿਲੀ ਵਾਰ ਲਾਗਇਨ ਕਰਨ ਸਮੇਂ ਪਾਸਵਰਡ ਸੈੱਟ ਕਰਦਾ ਹੈ।"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "ਹੁਣੇ ਪਾਸਵਰਡ ਸੈੱਟ ਕਰੋ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "ਤਸਦੀਕ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "ਇੰਟਰਪਰਾਈਜ਼ ਲਾਗਇਨ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "ਵਰਤੋਂਕਾਰ ਖਾਤੇ, ਜੋ ਕਿ ਕੰਪਨੀ ਜਾਂ ਸੰਗਠਨ ਦੇ ਪ੍ਰਬੰਧ ਅਧੀਨ ਹੁੰਦੇ ਹਨ।"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "ਤੁਸੀਂ ਆਫਲਾਈਨ ਹੋ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"ਇੰਟਰਪਰਾਈਜ਼ ਲਾਗਇਨ ਮੌਜੂਦਾ ਕੇਂਦਰੀਕ੍ਰਿਤ ਵਰਤੋਂਕਾਰ ਅਕਾਊਂਟ ਨੂੰ ਇਹ ਜੰਤਰ ਉੱਤੇ ਵਰਤਣ ਲਈ"
+" ਸਹਾਇਕ ਹੈ। ਤੁਸੀਂ "
+"ਇਸ ਅਕਾਊਂਟ ਨੂੰ ਇੰਟਰਨੈੱਟ ਉੱਤੇ ਕੰਪਨੀ ਦੇ ਸਰੋਤਾਂ ਤੱਕ ਪਹੁੰਚ ਲਈ ਵੀ ਵਰਤ ਸਕਦੇ ਹੋ।"
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "ਹੋਰ ਤਸਵੀਰਾਂ ਵੇਖੋ"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "…ਫਾਇਲ ਚੁਣੋ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਮੈਨੇਜਰ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "ਨਹੀਂ(_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "ਹਾਂ(_Y)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"ਕੀ ਤੁਸੀਂ ਆਪਣੇ ਰਜਿਸਟਰ ਕੀਤੇ ਫਿੰਗਰਪਰਿੰਟ ਹਟਾਉਣੇ ਚਾਹੁੰਦੇ ਹੋ ਤਾਂ ਕਿ ਫਿੰਗਰਪਰਿੰਟ"
+" ਲਾਗਇਨ ਨੂੰ ਆਯੋਗ ਕੀਤਾ "
+"ਜਾ ਸਕੇ?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "ਕੋਈ ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਨਹੀਂ ਹੈ"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "ਕੋਈ ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਨਹੀਂ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "ਪੱਕਾ ਕਰੋ ਕਿ ਡਿਵਾਈਸ ਠੀਕ ਢੰਗ ਨਾਲ ਕਨੈਕਟ ਹੈ।"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਚੁਣੋ, ਜਿਸ ਦੀ ਤੁਸੀਂ ਸੰਰਚਨਾ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਲਾਗਇਨ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"ਫਿੰਗਰਪਰਿੰਟ ਲਾਗਇਨ ਤੁਹਾਨੂੰ ਆਪਣੇ ਕੰਪਿਊਟਰ ਨੂੰ ਅਣ-ਲਾਕ ਕਰਨ ਤੇ ਲਾਗਇਨ ਕਰਨ ਲਈ ਤੁਹਾਡੀ"
+" ਉਂਗਲ ਵਰਤਣ ਲਈ "
+"ਸਹਾਇਕ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਹਟਾਓ(_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਦਾਖਲਾ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "ਇਹ ਐਕਸ਼ਨ ਕਰਨ ਲਈ ਡਿਵਾਈਸ ਨੂੰ ਮੱਲਣ ਦੀ ਲੋੜ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "ਡਿਵਾਈਸ ਨੂੰ ਪਹਿਲਾਂ ਹੀ ਹੋਰ ਕਾਰਵਾਈ ਵੱਲੋ ਮੱਲ ਲਿਆ ਗਿਆ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "ਤੁਹਾਡੇ ਕੋਲ ਕਾਰਵਾਈ ਕਰਨ ਲਈ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "ਕੋਈ ਪਰਿੰਟ ਦਾਖਲ ਨਹੀਂ ਕੀਤਾ ਗਿਆ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "ਦਾਖਲ ਕਰਨ ਦੇ ਦੌਰਾਨ ਡਿਵਾਈਸ ਨਾਲ ਸੰਚਾਰ ਫੇਲ੍ਹ ਹੋ ਗਿਆ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਰੀਡਰ ਨਾਲ ਸੰਚਾਰ ਕਰਨ ਲਈ ਅਸਫ਼ਲ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡੈਮਨ ਨਾਲ ਸੰਚਾਰ ਕਰਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਦੀ ਸੂਚੀ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "ਸੰਭਾਲੇ ਫਿੰਗਰਪਰਿੰਟ ਹਟਾਉਣ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "ਖੱਬਾ ਅੰਗੂਠਾ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "ਖੱਬੀ ਵਿਚਲੀ ਉਂਗਲ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "ਖੱਬੀ ਇੰਡੈਕਸ ਉਂਗਲ(_L)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "ਖੱਬੀ ਰਿੰਗ ਉਂਗਲ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "ਖੱਬੀ ਚੀਚੀ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "ਸੱਜਾ ਅੰਗੂਠਾ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "ਸੱਜੀ ਵਿਚਲੀ ਉਂਗਲ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "ਸੱਜੀ ਇੰਡੈਕਸ ਉਂਗਲ(_R)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "ਸੱਜੀ ਰਿੰਗ ਉਂਗਲ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "ਸੱਜੀ ਚੀਚੀ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "ਅਣਪਛਾਤੀ ਉਂਗਲ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "ਪੂਰਾ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਕਨੈਕਟ ਨਹੀਂ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਦੀ ਸਟੋਰੇਜ਼ ਭਰ ਗਈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "ਨਵਾਂ ਫਿੰਗਰਪਰਿੰਟ ਦਾਖਲ ਕਰਨ ਲਈ ਅਸਫ਼ਲ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "ਦਾਖਲਾ ਸ਼ੁਰੂ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "ਨਵਾਂ ਫਿੰਗਰਪਰਿੰਟ ਦਾਖਲ ਕਰਨ ਲਈ ਫੇਲ੍ਹ ਹੈ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "ਦਾਖਲਾ ਰੋਕਣ ਲਈ ਫੇਲ੍ਹ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"ਆਪਣੇ ਫਿੰਗਰਪਰਿੰਟ ਨੂੰ ਦਾਖਲ ਕਰਨ ਲਈ ਰੀਡਰ ਉੱਤੇ ਆਪਣੀ ਉਂਗਲ ਨੂੰ ਲਗਾਤਾਰ ਚੱਕੋ ਅਤੇ ਰੱਖੋ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "ਇਹ ਉਂਗਲ ਦੁਬਾਰਾ-ਦਾਖਲ ਕਰੋ(_R)…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "ਨਵਾਂ ਫਿੰਗਰਪਰਿੰਟ ਸਕੈਨ ਕਰੋ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ %s ਛੱਡਣ ਲਈ ਫੇਲ੍ਹ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "ਡਿਵਾਈਸ ਪੜ੍ਹਨ ਦੌਰਾਨ ਸਮੱਸਿਆ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ %s ਮੱਲਣ ਲਈ ਫੇਲ੍ਹ: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਡਿਵਾਈਸ ਲੈਣ ਲਈ ਫੇਲ੍ਹ ਹੈ: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "ਇਸ ਹਫ਼ਤੇ"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "ਪਿਛਲੇ ਹਫ਼ਤੇ"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "ਸ਼ੈਸ਼ਨ ਅੰਤ ਹੋਇਆ"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "ਸ਼ੈਸ਼ਨ ਸ਼ੁਰੂ ਹੋਇਆ"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — ਖਾਤਾ ਸਰਗਰਮੀ"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "ਪਿੱਛੇ"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "ਅੱਗੇ"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "ਵੱਖਰਾ ਪਾਸਵਰਡ ਚੁਣੋ ਜੀ।"
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "ਆਪਣਾ ਮੌਜੂਦਾ ਪਾਸਵਰਡ ਫੇਰ ਲਿਖੋ ਜੀ।"
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "ਪਾਸਵਰਡ ਬਦਲਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "ਪਾਸਵਰਡ ਬਦਲੋ"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "ਬਦਲੋ(_a)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "ਮੌਜੂਦਾ ਪਾਸਵਰਡ"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "ਨਵਾਂ ਪਾਸਵਰਡ"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "ਪਾਸਵਰਡ ਤਸਦੀਕ ਕਰੋ"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "ਵਰਤੋਂਕਾਰ ਨੂੰ ਅਗਲੇ ਲਾਗਇਨ ਉੱਤੇ ਆਪਣਾ ਪਾਸਵਰਡ ਬਦਲਣ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "ਹੁਣੇ ਪਾਸਵਰਡ ਦਿਓ"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "ਡੋਮੇਨ ਦੀ ਇਹ ਕਿਸਮ ਲਈ ਆਟੋਮੈਟਿਕ ਜੁਆਇੰਨ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "ਕੋਈ ਡੋਮੇਨ ਜਾਂ ਰੀਲੇਮ ਨਹੀਂ ਲੱਭਿਆ"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s ਵਜੋਂ %s ਡੋਮੇਨ ਵਿੱਚ ਲਾਗਇਨ ਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "ਗਲਤ ਪਾਸਵਰਡ, ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ ਜੀ।"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "%s ਡੋਮੇਨ ਨਾਲ ਕਨੈਕਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "ਵਰਤੋਂਕਾਰ ਹਟਾਉਣ ਲਈ ਫੇਲ੍ਹ"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "ਰਿਮੋਟ ਤੋਂ ਇੰਤਜ਼ਾਮ ਅਧੀਨ ਵਰਤੋਂਕਾਰ ਮਨਸੂਖ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "ਤੁਸੀਂ ਆਪਣਾ ਖੁਦ ਦਾ ਅਕਾਊਂਟ ਹਟਾ ਨਹੀਂ ਸਕਦੇ।"
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ਹਾਲੇ ਲਾਗਇਨ ਹੈ"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"ਜਦੋਂ ਵਰਤੋਂਕਾਰ ਲਾਗਇਨ ਹੋਵੇ ਤਾਂ ਉਸ ਨੂੰ ਹਟਾਉਣ ਨਾਲ ਸਿਸਟਮ ਖਰਾਬ ਹੋਣ ਦੀ ਹਾਲਤ 'ਚ ਆ"
+" ਸਕਦਾ ਹੈ।"
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "ਕੀ ਤੁਸੀਂ %s ਦੀਆਂ ਫਾਇਲਾਂ ਰੱਖਣੀਆਂ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"ਘਰ ਡਾਇਰੈਕਟਰੀ, ਮੇਲ ਸਪੂਲ ਅਤੇ ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਰੱਖਣਾ ਸੰਭਵ ਹੈ, ਜਦੋਂ ਵਰਤੋਂਕਾਰ ਖਾਤਾ"
+" ਹਟਾਉਣਾ ਹੋਵੇ।"
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "ਫਾਇਲਾਂ ਹਟਾਓ(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "ਫਾਇਲਾਂ ਰੱਖੋ(_K)"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "ਕੀ ਤੁਸੀਂ ਰਿਮੋਟ ਤੋਂ ਇੰਤਜ਼ਾਮ ਕੀਤੇ %s ਦੇ ਖਾਤੇ ਨੂੰ ਮਨਸੂਖ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "ਹਟਾਓ(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "ਅਕਾਊਂਟ ਬੰਦ ਹੈ"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "ਅਗਲੇ ਲਾਗਇਨ ਸਮੇਂ ਸੈੱਟ ਕਰੋ"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "ਕੋਈ ਨਹੀਂ"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "ਲਾਗਇਨ ਕੀਤਾ"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "ਅਕਾਊਂਟ ਸਰਵਿਸ ਨਾਲ ਸੰਪਰਕ ਕਰਨ ਲਈ ਫੇਲ੍ਹ"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "ਯਕੀਨੀ ਬਣਾਉ ਕਿ ਅਕਾਊਂਟਸਰਵਿਸ (AccountService) ਇੰਸਟਾਲ ਹੈ ਅਤੇ ਯੋਗ ਹੈ"
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "ਇਸ ਸੈਟਿੰਗ ਬਦਲਣ ਲਈ ਇਹ ਪੈਲਨ ਅਣ-ਲਾਕ ਕੀਤਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "ਚੁਣਿਆ ਵਰਤੋਂਕਾਰ ਖਾਤਾ ਹਟਾਓ"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"ਚੁਣੇ ਵਰਤੋਂਕਾਰ ਖਾਤੇ ਨੂੰ ਹਟਾਉਣ ਲਈ,\n"
+"ਪਹਿਲਾਂ * ਆਈਕਾਨ ਉੱਤੇ ਕਲਿੱਕ ਕਰੋ"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "ਵਰਤੋਂਕਾਰ ਜੋੜਨ ਅਤੇ ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "ਵਰਤੋਂਕਾਰ"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "ਬਦਲਾਅ ਪ੍ਰਭਾਵ ਬਣਾਉਣ ਲਈ ਤੁਹਾਡੇ ਸ਼ੈਸ਼ਨ ਨੂੰ ਮੁੜ-ਚਾਲੂ ਕਰਨ ਦੀ ਲੋੜ ਹੈ"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "ਹੁਣੇ ਮੁੜ-ਚਾਲੂ"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "ਬੰਦ ਕਰੋ"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "ਅਵਤਾਰ ਸੋਧੋ"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "ਪੂਰਾ ਨਾਂ"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "ਸੋਧ"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "ਫਿੰਗਰਪਰਿੰਟ ਲਾਗਇਨ(_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "ਆਟੋਮੈਟਿਕ ਲਾਗਇਨ(_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "ਖਾਤਾ ਸਰਗਰਮੀ"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "ਪਰਸ਼ਾਸ਼ਕ(_A)"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"ਪਰਸ਼ਾਸ਼ਕ ਹੋਰ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਜੋੜ ਜਾਂ ਹਟਾ ਸਕਦੇ ਹਨ, ਅਤੇ ਸਾਰੇ ਵਰਤੋਂਕਾਰਾਂ ਲਈ"
+" ਸੈਟਿੰਗਾਂ ਬਦਲ ਸਕਦੇ ਹਨ।"
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "ਮਾਪਿਆਂ ਕੋਲ ਕੰਟਰੋਲ(_P)"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "ਮਾਪਿਆਂ ਕੋਲ ਕੰਟਰੋਲ ਵਾਲੀ ਐਪਲੀਕੇਸ਼ਨ ਖੋਲ੍ਹੋ।"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "…ਵਰਤੋਂਕਾਰ ਨੂੰ ਹਟਾਓ"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "ਹੋਰ ਵਰਤੋਂਕਾਰ"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "…ਵਰਤੋਂਕਾਰ ਜੋੜੋ"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "ਕੋਈ ਵਰਤੋਂਕਾਰ ਨਹੀਂ ਲੱਭਿਆ"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "ਵਰਤੋਂਕਾਰ ਖਾਤਾ ਜੋੜਨ ਲਈ ਅਣ-ਲਾਕ ਕਰੋ।"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਜੋੜੋ ਜਾਂ ਹਟਾਓ ਅਤੇ ਆਪਣਾ ਪਾਸਵਰਡ ਬਦਲੋ"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"ਲਾਗਇਨ;ਲੌਗਇਨ;ਨਾਂ;ਨਾਮ;ਫਿੰਗਰ-ਪਰਿੰਟ;ਉਂਗਲ-ਨਿਸ਼ਾਨ;ਅਵਾਤਰ,ਲੋਗੋ,ਮੂੰਹ;ਪਾਸਵਰਡ;ਚਿਹਰਾ;ਮਾਪਿਆਂ"
+" ਕੋਲ ਕੰਟਰੋਲ;"
+"ਸਕਰੀਨ ਸਮਾਂ;ਐਪ ਪਾਬੰਦੀਆਂ;ਵੈਬ ਪਾਬੰਦੀਆਂ;ਵਰਤੋ;ਹੱਦ;ਸੀਮ,ਬੱਚੇ;ਜਵਾਕ;ਨਿਆਣੇ;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "ਚਾਲੂ ਕਰੋ(_E)"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "ਡੋਮੇਨ ਪਰਸ਼ਾਸ਼ਕੀ ਲਾਗਇਨ"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"ਇੰਟਰਪਰਾਈਜ਼ ਲਾਗਇਨ ਵਰਤਣ ਲਈ, ਉਹ ਕੰਪਿਊਟਰ ਨੂੰ ਡੋਮੇਨ ਵਰਤਣ ਦੀ ਲੋੜ ਹੈ।\n"
+"ਆਪਣੇ ਨੈੱਟਵਰਕ ਪਰਸ਼ਾਸ਼ਕ ਕਿਸਮ ਲਈ ਉਹਨਾਂ ਦਾ ਡੋਮੇਨ ਪਾਸਵਰਡ ਇੱਥੇ\n"
+"ਦਿਉ।"
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "ਪਰਸ਼ਾਸ਼ਕੀ ਨਾਂ(_N)"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "ਪਰਸ਼ਾਸ਼ਕੀ ਪਾਸਵਰਡ"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "ਵਰਤੋਂਕਾਰ ਖਾਤਿਆਂ ਦਾ ਇੰਤਜ਼ਾਮ"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "ਵਰਤੋਂਕਾਰ ਡਾਟੇ ਨੂੰ ਬਦਲਣ ਲਈ ਪਰਮਾਣਕਿਤਾ ਚਾਹੀਦੀ ਹੈ"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਪੁਰਾਣੇ ਨਾਲੋਂ ਵੱਖਰਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "ਕੁਝ ਅੱਖਰ ਤੇ ਨੰਬਰ ਬਦਲ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "ਪਾਸਵਰਡ ਨੂੰ ਕੁਝ ਹੋਰ ਬਦਲਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "ਬਿਨਾਂ ਵਰਤੋਂਕਾਰ ਨਾਂ ਵਾਲਾ ਪਾਸਵਰਡ ਮਜ਼ਬੂਤ ਹੋਵੇਗਾ।"
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "ਆਪਣੇ ਨਾਂ ਨੂੰ ਪਾਸਵਰਡ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਨਾ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "ਪਾਸਵਰਡ ਵਿੱਚ ਦਿੱਤੇ ਕੁਝ ਸ਼ਬਦ ਛੱਡਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "ਆਮ ਸ਼ਬਦਾਂ ਦੀ ਵਰਤੋਂ ਨਾ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "ਮੌਜੂਦਾ ਸ਼ਬਦਾਂ ਨੂੰ ਅੱਗੇ ਪਿੱਛੇ ਕਰਨ ਨੂੰ ਛੱਡ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "ਹੋਰ ਅੰਕ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "ਹੋਰ ਵੱਡੇ ਅੱਖਰ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "ਹੋਰ ਛੋਟੇ ਅੱਖਰ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "ਹੋਰ ਖਾਸ ਅੱਖਰ ਜਿਵੇਂ ਵਿਰਾਮ-ਚਿੰਨ੍ਹ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "ਅੱਖਰ, ਅੰਕ ਅਤੇ ਵਿਰਾਮ-ਚਿੰਨ੍ਹ ਨੂੰ ਮਿਲਾ ਕੇ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "ਇੱਕੋ ਅੱਖਰ ਦੁਹਰਾਉਣ ਨੂੰ ਛੱਡ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"ਇੱਕੋ ਕਿਸਮ ਦੇ ਅੱਖਰ ਮੁੜ-ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ: ਤੁਸੀਂ ਅੱਖਰਾਂ, ਅੰਕਾਂ ਅਤੇ ਵਿਰਾਮ"
+" ਚਿੰਨ੍ਹਾਂ ਨੂੰ ਮਿਲ ਸਕਦੇ ਹੋ।"
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 ਜਾਂ abcd ਕ੍ਰਮ ਛੱਡਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"ਪਾਸਵਰਡ ਹੋਰ ਲੰਮਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ। ਅੱਖਰ, ਅੰਕ ਅਤੇ ਵਿਰਾਮ-ਚਿੰਨ੍ਹ ਨੂੰ ਮਿਲਾ ਕੇ ਵਰਤ ਕੇ"
+" ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "ਵੱਡੇ ਤੇ ਛੋਟੇ ਅੱਖਰ ਮਿਲਾ ਕੇ ਅਤੇ ਇੱਕ ਜਾਂ ਦੋ ਨੰਬਰ ਵਰਤੇ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "ਹੋਰ ਅੱਖਰ, ਨੰਬਰ ਤੇ ਵਿਰਾਮ ਚਿੰਨ੍ਹ ਜੋੜਨ ਨਾਲ ਪਾਸਵਰਡ ਹੋਰ ਵੀ ਮਜ਼ਬੂਤ ਬਣੇਗਾ।"
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "ਪਰਮਾਣਕਿਤਾ ਫੇਲ੍ਹ ਹੋਈ"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਬਹੁਤ ਛੋਟਾ ਹੈ"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਬਹੁਤ ਸਧਾਰਨ ਹੈ"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "ਪੁਰਾਣਾ ਅਤੇ ਨਵੇਂ ਪਾਸਵਰਡ ਇੱਕੋ ਜਿਹੇ ਜਾਪਦੇ ਹਨ"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਤਾਜ਼ਾ ਹੀ ਵਰਤਿਆ ਗਿਆ ਹੈ।"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "ਨਵੇਂ ਪਾਸਵਰਡ ਵਿੱਚ ਅੰਕ ਜਾਂ ਖਾਸ ਹੋਣੇ ਲਾਜ਼ਮੀ ਹਨ"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "ਪੁਰਾਣਾ ਅਤੇ ਨਵੇਂ ਪਾਸਵਰਡ ਇੱਕੋ ਹੀ ਹਨ"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "ਤੁਹਾਡੇ ਪਹਿਲਾਂ ਪਰਮਾਣਿਤ ਹੋਣ ਕਰਕੇ ਤੁਹਾਡਾ ਪਾਸਵਰਡ ਬਦਲਿਆ ਜਾ ਚੁੱਕਿਆ ਹੈ!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "ਨਵੇਂ ਪਾਸਵਰਡ 'ਚ ਲੋੜ ਮੁਤਾਬਕ ਵੱਖ ਵੱਖ ਕਿਸਮ ਦੇ ਅੱਖਰ ਨਹੀਂ ਹਨ"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "ਅਣਜਾਣ ਗਲਤੀ"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"ਵਰਤੋਂਕਾਰ ਨਾਂ ਵਿੱਚ ਅਕਸਰ ਕੇਵਲ ਅੰਗਰੇਜ਼ੀ ਦੇ ਛੋਟੇ ਅੱਖਰ (a-z), ਅੰਕ, ਅਤੇ ਅੱਗੇ ਦਿੱਤੇ"
+" ਅੱਖਰ ਹੋ ਸਕਦੇ ਹਨ: - __"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "ਅਫ਼ਸੋਸ ਹੈ ਪਰ ਉਹ ਵਰਤੋਂਕਾਰ ਨਾਂ ਉਪਲਬਧ ਨਹੀਂ ਹੈ। ਹੋਰ ਵਰਤ ਕੇ ਵੇਖੋ।"
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ ਬਹੁਤ ਲੰਮਾ ਹੈ।"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "ਬਟਨ ਮਿਲਾਉ"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "ਬਟਨ ਨੂੰ ਫੰਕਸ਼ਨ ਨਾਲ ਮਿਲਾਉ"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ਸ਼ਾਰਟਕੱਟ ਸੋਧਣ ਲਈ, ”ਕੀ-ਸਟੋਰਕ ਭੇਜੋ” ਕਾਰਵਾਈ ਚੁਣੋ, ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਬਟਨ ਦੱਬੋ ਅਤੇ"
+" ਨਵੀਆਂ ਸਵਿੱਚਾਂ ਲਈ "
+"ਹੋਲਡ ਕਰਕੇ ਰੱਖੋ ਜਾਂ ਬੈਕਸਪੇਸ ਸਾਫ਼ ਕਰਨ ਲਈ ਵਰਤੋਂ।"
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "ਬੰਦ ਕਰੋ(_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"ਟਾਰਗੇਟ ਮਾਰਕਰ ਲਈ ਟੈਪ ਕਰੋ ਜਿਵੇਂ ਕਿ ਉਹ ਸਕਰੀਨ ਉੱਤੇ ਟੇਬਲੇਟ ਨੂੰ ਕੈਲੀਬਰੇਟ ਕਰਨ ਲਈ"
+" ਵੇਖਾਈ ਦਿੰਦਾ ਹੈ।"
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "ਮਿਸ-ਕਲਿੱਕ ਮਿਲਿਆ, ਮੁੜ-ਚਾਲੂ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "ਬਟਨ %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "ਐਪਲੀਕੇਸ਼ਨ ਪਰਿਭਾਸ਼ਿਤ"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "ਕੀਸਟਰੋਕ ਭੇਜੋ"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "ਮਾਨੀਟਰ ਬਦਲੋ"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "ਸਕਰੀਨ ਉੱਤੇ ਮਦਦ ਵੇਖਾਓ"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "ਟੇਬਲੇਟ ਲੈਪਟਾਪ ਪੈਨਲ ਉੱਤੇ ਮਾਊਂਟ ਹੈ"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "ਟੇਬਲੇਟ ਬਾਹਰੀ ਮਾਨੀਟਰ ਉੱਤੇ ਮਾਊੰਟ ਹੈ"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "ਬਾਹਰੀ ਟੇਬਲੇਟ ਡਿਵਾਈਸ"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#| msgid "External tablet device"
+msgid "External pad device"
+msgstr "ਬਾਹਰੀ ਪੈਡ ਡਿਵਾਈਸ"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "ਸਾਰੇ ਡਿਸਪਲੇਅ"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "ਟੇਬਲੇਟ ਢੰਗ"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "ਪੈਨ ਲਈ ਅਸਲ ਸਥਿਤੀ ਵਰਤੋ"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "ਖੱਬਾ ਹੱਥ ਸਥਿਤੀ"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "ਖੱਬੇ ਹੱਥ ਵਰਤੋਂ ਲਈ ਟੇਬਲੇਟ ਅਤੇ Express Keys™ ਨੂੰ ਘੁੰਮਾਇਆ ਹੈ"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "ਮਾਨੀਟਰ ਲਈ ਮਿਲਾਓ"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "ਆਕਾਰ ਅਨੁਪਾਤ ਰੱਖੋ"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "ਮਾਨੀਟਰ ਅਨੁਪਾਤੀ ਅਨੁਪਾਤ ਰੱਖਣ ਲਈ ਟੇਬਲੇਟ ਸਤ੍ਹਾ ਦੇ ਹਿੱਸੇ ਨੂੰ ਹੀ ਵਰਤੋਂ"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "ਕੈਲੇਬਰੇਟ"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "ਕੋਈ ਟੇਬਲੇਟ ਨਹੀਂ ਮਿਲਿਆ"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "ਆਪਣੇ ਵਾਕੋਮ ਟੇਬਲੇਟ ਦਾ ਪਲੱਗ ਲਾਓ ਜਾਂ ਚਾਲੂ ਕਰੋ।"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "ਟਿੱਪ ਦਬਾਉ ਮਹਿਸੂਸ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "ਸਾਫਟ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "ਸਟਾਈਲਸ ਨਿੱਬ ਦਬਾਓ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "ਫਿਰਮ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "ਬਟਨ 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ਬਟਨ 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ਬਟਨ 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "ਰਬੜ ਦਬਾਉ ਮਹਿਸੂਸ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "ਰਬੜ ਲਈ ਦਬਾਉ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "ਮੱਧਮ ਮਾਊਸ ਬਟਨ ਕਲਿੱਕ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "ਸੱਜਾ ਮਾਊਂਸ ਬਟਨ ਕਲਿੱਕ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "ਅੱਗੇ"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "ਦਬਾਓ, ਟੇਡ ਤੇ ਮੌਜੂਦ ਸਲਾਈਡਰ ਨਾਲ ਏਅਰਬਰੱਸ਼ ਸਟਾਈਲਸ"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "ਦਬਾਓ, ਟੇਡ ਤੇ ਘੁੰਮਾਉਣ ਨਾਲ ਏਅਰਬਰੱਸ਼ ਸਟਾਈਲਸ"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "ਦਬਾਓ ਤੇ ਟੇਡ ਨਾਲ ਮਿਆਰੀ ਸਟਾਈਲਸ"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "ਦਬਾਓ ਨਾਲ ਮਿਆਰੀ ਸਟਾਈਲਸ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "ਵਾਕੋਮ ਟੇਬਲੇਟ"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "ਗਰਾਫਿਕਸ ਟੇਬਲਟ ਲਈ ਬਟਨ ਮਿਲਾਨ ਕਰੋ ਅਤੇ ਸਟਾਇਲਸ ਸੰਵੇਦਨਸ਼ੀਲਤਾ ਅਡਜੱਸਟ ਕਰੋ"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;ਟੇਬਲੇਟ;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "...ਨਵਾਂ ਸ਼ਾਰਟਕੱਟ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "ਐਕਸੈਸ ਪੁਆਇੰਟ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "ਕਾਰਵਾਈ ਰੱਦ ਕੀਤੀ ਗਈ ਸੀ"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>ਗਲਤੀ:</b> ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਪਹੁੰਚ ਉੱਤੇ ਪਾਬੰਦੀ ਹੈ"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>ਗਲਤੀ:</b> ਮੋਬਾਈਲ ਯੰਤਰ ਗ਼ਲਤੀ"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "ਰਜਿਸਟਰ ਨਹੀਂ ਹੈ"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "ਰਜਿਸਟਰ ਹੈ"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "ਰੋਮਿੰਗ"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "ਖੋਜ ਜਾਰੀ ਹੈ"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "ਇਨਕਾਰ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "ਮਾਡਮ ਦੇ ਵੇਰਵੇ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "ਮਾਡਮ ਦੀ ਹਾਲਤ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "ਕੈਰੀਅਰ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "ਨੈੱਟਵਰਕ ਦੀ ਕਿਸਮ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "ਨੈੱਟਵਰਕ ਹਾਲਤ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "ਖੁਦ ਦਾ ਨੰਬਰ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "ਡਿਵਾਈਸ ਦੇ ਵੇਰਵੇ"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "ਫਿਰਮਵੇਅਰ ਵਰਜ਼ਨ"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "ਸਿਰਫ਼ 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "ਸਿਰਫ਼ 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "ਸਿਰਫ਼ 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+#| msgid "2G Only"
+msgid "5G Only"
+msgstr "ਸਿਰਫ਼ 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (ਤਰਜੀਹੀ), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+#| msgid "2G, 3G (Preferred), 4G"
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (ਤਰਜੀਹੀ), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+#| msgid "2G (Preferred), 3G, 4G"
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (ਤਰਜੀਹੀ), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+#| msgid "2G, 3G, 4G"
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (ਤਰਜੀਹੀ), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (ਤਰਜੀਹੀ), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+#| msgid "3G, 4G (Preferred)"
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+#| msgid "3G, 4G (Preferred)"
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (ਤਰਜੀਹੀ), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+#| msgid "3G (Preferred), 4G"
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (ਤਰਜੀਹੀ), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+#| msgid "3G, 4G"
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+#| msgid "2G, 3G (Preferred), 4G"
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 3G (ਤਰਜੀਹੀ), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+#| msgid "2G (Preferred), 3G, 4G"
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (ਤਰਜੀਹੀ), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+#| msgid "2G, 3G, 4G"
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+#| msgid "2G, 3G, 4G (Preferred)"
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+#| msgid "2G, 3G (Preferred), 4G"
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (ਤਰਜੀਹੀ), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+#| msgid "2G (Preferred), 3G, 4G"
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (ਤਰਜੀਹੀ), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+#| msgid "2G, 3G, 4G"
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (ਤਰਜੀਹੀ), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (ਤਰਜੀਹੀ), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (ਤਰਜੀਹੀ), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+#| msgid "2G, 4G (Preferred)"
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+#| msgid "2G (Preferred), 4G"
+msgid "2G (Preferred), 5G"
+msgstr "2G (ਤਰਜੀਹੀ), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+#| msgid "2G, 4G"
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+#| msgid "3G, 4G (Preferred)"
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+#| msgid "3G (Preferred), 4G"
+msgid "3G (Preferred), 5G"
+msgstr "3G (ਤਰਜੀਹੀ), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+#| msgid "3G, 4G"
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+#| msgid "3G, 4G (Preferred)"
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (ਤਰਜੀਹੀ)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+#| msgid "3G (Preferred), 4G"
+msgid "4G (Preferred), 5G"
+msgstr "4G (ਤਰਜੀਹੀ), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "ਅਣਪਛਾਤਾ"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "ਸਿਮ ਕਾਰਡ ਅਣ-ਲਾਕ ਕਰੋ"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "ਅਣ-ਲਾਕ ਕਰੋ"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "ਸਿਮ %d ਲਈ ਪਿੰਨ ਕੋਡ ਦਿਓ"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "ਆਪਣੇ ਸਿਮ ਨੂੰ ਅਣ-ਲਾਕ ਕਰਨ ਲਈ ਪਿੰਨ ਦਿਓ"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "ਸਿਮ %d ਲਈ PUK ਕੋਡ ਦਿਓ"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "ਆਪਣਾ ਸਿਮ ਕਾਰਡ ਅਣ-ਲਾਕ ਕਰਨ ਲਈ PUK ਦਿਓ"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "ਗਲਤ ਪਾਸਵਰਡ ਦਿੱਤਾ ਗਿਆ। ਤੁਹਾਡੇ ਕੋਲ %1$u ਕੋਸ਼ਿਸ਼ ਬਾਕੀ ਹੈ"
+msgstr[1] "ਗਲਤ ਪਾਸਵਰਡ ਦਿੱਤਾ ਗਿਆ। ਤੁਹਾਡੇ ਕੋਲ %1$u ਕੋਸ਼ਿਸ਼ਾਂ ਬਾਕੀ ਹਨ"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "ਤੁਹਾਡੇ ਕੋਲ %u ਕੋਸ਼ਿਸ਼ ਬਾਕੀ ਹੈ"
+msgstr[1] "ਤੁਹਾਡੇ ਕੋਲ %u ਕੋਸ਼ਿਸ਼ਾਂ ਬਾਕੀ ਹਨ"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "ਗਲਤ ਪਾਸਵਰਡ ਦਿੱਤਾ ਗਿਆ।"
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK ਕੋਡ 8 ਅੰਕਾਂ ਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "ਨਵਾਂ ਪਿੰਨ ਦਿਓ"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "ਪਿੰਨ ਕੋਡ 4-8 ਅੰਕਾਂ ਦਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "…ਅਣ-ਲਾਕ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "ਕੋਈ ਸਿਮ ਨਹੀਂ"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "ਇਹ ਮਾਡਮ ਵਰਤਣ ਲਈ ਸਿਮ ਕਾਰਡ ਪਾਓ"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "ਸਿਮ ਲਾਕ ਹੈ"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "ਮੋਬਾਇਲ ਡਾਟਾ(_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "ਮੋਬਾਈਲ ਨੈੱਟਵਰਕ ਵਰਤ ਕੇ ਡਾਟਾ ਵਰਤੋ"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "ਡਾਟਾ ਰੋਮਿੰਗ(_D)"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "ਜਦੋਂ ਰੋਮਿੰਗ ਵਿੱਚ ਹੋਵੋ ਤਾਂ ਮੋਬਾਈਲ ਡਾਟਾ ਵਰਤੋ"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "ਨੈੱਟਵਰਕ ਢੰਗ(_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "ਨੈੱਟਵਰਕ(_e)"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "ਤਕਨੀਕੀ"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "ਐਕਸੈਸ ਪੁਆਇੰਟ ਦੇ ਨਾਂ(_A)"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "ਸਿਮ ਲਾਕ ਕਰੋ(_S)"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "ਪਿੰਨ ਨਾਲ ਸਿਮ ਲਾਕ ਕਰੋ"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "ਮਾਡਮ ਦੇ ਵੇਰਵਾ(_o)"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "ਫ਼ੋਨ ਅਸਫ਼ਲ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "ਫ਼ੋਨ ਲਈ ਕੋਈ ਕਨੈਕਸ਼ਨ ਨਹੀਂ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "ਕਾਰਵਾਈ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "ਕਾਰਵਾਈ ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "ਸਿਮ ਨਹੀਂ ਪਾਇਆ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "ਸਿਮ ਪਿੰਨ ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "ਸਿਮ PUK required"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "ਸਿਮ ਅਸਫ਼ਲ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "ਸਿਮ ਰੁੱਝਿਆ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "ਗ਼ਲਤ ਪਾਸਵਰਡ"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM ਪਿੰਨ2 ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM PUK2 ਚਾਹੀਦਾ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "ਨਹੀਂ ਲੱਭਿਆ"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "ਕੋਈ ਨੈੱਟਵਰਕ ਸੇਵਾ ਨਹੀਂ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "ਨੈੱਟਵਰਕ ਸਮਾਂ-ਸਮਾਪਤ"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS ਸੇਵਾਵਾਂ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "ਇਸ ਟਿਕਾਣੇ ਉੱਤੇ ਰੋਮਿੰਗ ਦੀ ਇਜਾਜ਼ਤ ਨਹੀਂ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "ਅਣਦੱਸੀ GPRS ਗ਼ਲਤੀ"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "ਕੋਈ ਗਲਤੀ ਨਹੀਂ"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "ਕਾਰਵਾਈ ਰੱਦ ਕੀਤੀ"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "ਪਹੁੰਚ ਲਈ ਪਾਬੰਦੀ ਹੈ"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "ਅਣਪਛਾਤੀ ਗਲਤੀ"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "ਨੈੱਟਵਰਕ ਢੰਗ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "ਆਟੋਮੈਟਿਕ(_A)"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "ਨੈੱਟਵਰਕ ਚੁਣੋ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "ਨੈੱਟਵਰਕ ਪੂਰਕਾਂ ਨੂੰ ਤਾਜ਼ਾ ਕਰੋ"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "ਸਿਮ %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "ਮੋਬਾਈਲ ਨੈੱਟਵਰਕ ਸਮਰੱਥ ਕਰੋ"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "ਕੋਈ WWAN ਅਡੈਪਟਰ ਨਹੀਂ ਲੱਭਿਆ"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "ਪੱਕਾ ਕਰੋ ਕਿ ਤੁਹਾਡੇ ਕੋਲ ਬੇਤਾਰ ਵੈਨ/ਸੈਲੂਲਰ ਡਿਵਾਈਸ ਹੈ"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "ਜਦੋਂ ਏਅਰਪਲਾਨ ਢੰਗ ਚਾਲੂ ਹੁੰਦਾ ਹੈ ਤਾਂ ਬੇਤਾਰ ਵੈਨ ਅਸਮਰੱਥ ਹੁੰਦਾ ਹੈ"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "ਏਅਰਪਲੇਨ ਮੋਡ ਬੰਦ ਕਰੋ(_T)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "ਡਾਟਾ ਕਨੈਕਸ਼ਨ"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "ਸਿਮ ਕਾਰਡ ਇੰਟਰਨੈੱਟ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "ਸਿਮ ਲਾਕ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "ਅੱਗੇ(_N)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "ਪਿੰਨ ਨਾਲ ਸਿਮ ਲਾਕ ਕਰੋ(_L)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "ਪਿੰਨ ਬਦਲੋ"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "ਸਿਮ ਲਾਕ ਸੈਟਿੰਗਾਂ ਬਦਲਣ ਲਈ ਮੌਜੂਦਾ ਪਿੰਨ ਦਿਓ"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "ਮੋਬਾਈਲ ਨੈੱਟਵਰਕ"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "ਟੈਲੀਫ਼ੋਨੀ ਤੇ ਮੋਬਾਈਲ ਡਾਟਾ ਕਨੈਕਸ਼ਨਾਂ ਦੀ ਸੰਰਚਨਾ ਕਰੋ"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "ਸੈਲੂਲਰ;ਵੈਨ;ਵੈੱਨ;ਟੈਲੀਫ਼ੋਨੀ;ਸਿਮ;ਮੋਬਾਈਲ;ਮੋਬਾਇਲ;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "ਗਨੋਮ ਡੈਸਕਟਾਪ ਦੀ ਸੰਰਚਨਾ ਵਾਸਤੇ ਸਹੂਲਤ"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "ਸੈਟਿੰਗਾਂ ਤੁਹਾਡੇ ਸਿਸਟਮ ਦੀ ਸੰਰਚਨਾ ਕਰਨ ਲਈ ਮੁੱਢਲਾ ਦਰ ਹੈ।"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "ਗਨੋਮ ਪਰੋਜੈਕਟ"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "ਵਰਜ਼ਨ ਨੰਬਰ ਦਿਖਾਓ"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "ਵੱਧ ਜਾਣਕਾਰੀ ਮੋਡ ਚਾਲੂ"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "ਸਤਰ ਲਈ ਖੋਜੋ"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "ਸੰਭਵ ਪੈਨਲ ਨਾਂ ਵੇਖਾਉ ਅਤੇ ਬੰਦ ਕਰੋ"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "ਵੇਖਾਉਣ ਲਈ ਪੈਨਲ"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "ਸੈਟਿੰਗਾਂ ਕੈਟਾਗਰੀਆਂ"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "ਪਰਦੇਦਾਰੀ"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "ਉਪਲੱਬਧ ਪੈਨਲ:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "ਸਭ ਸੈਟਿੰਗਾਂ"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "ਪ੍ਰਾਇਮਰੀ ਮੀਨੂ"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "ਸਾਵਧਾਨ: ਵਿਕਾਸ ਅਧੀਨ ਵਰਜ਼ਨ"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"ਸੈਟਿੰਗਾਂ ਦਾ ਇਹ ਵਰਜ਼ਨ ਡਿਵੈਲਪਮੈਂਟ ਮਕਸਦ ਲਈ ਹੀ ਵਰਤਿਆ ਜਾਣਾ ਚਾਹੀਦਾ ਹੈ। ਤੁਹਾਨੂੰ ਕੁਝ"
+" ਗਲਤ ਸਿਸਟਮ "
+"ਰਵੱਈਏ, ਡਾਟਾ ਗੁਆਚਣ ਅਤੇ ਹੋਰ ਅਚਨਚੇਤ ਮਸਲਿਆਂ ਦਾ ਸਾਹਮਣਾ ਕਰਨਾ ਪੈ ਸਕਦਾ ਹੈ।"
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "ਮਦਦ"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr " ਆਮ"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "ਬਾਹਰ"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "ਖੋਜ"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "ਪੈਨਲ"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "ਪਿਛਲੇ ਪੈਨ ਉੱਤੇ ਵਾਪਸ ਜਾਓ"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "ਖੋਜ ਰੱਦ ਕਰੋ"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "ਮੇਰੀ ਪਸੰਦ;ਸੈਟਿੰਗ;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "ਆਖਰੀ ਸੈਟਿੰਗਾਂ ਪੈਨਲ ਨੂੰ ਖੋਲ੍ਹਣ ਲਈ ਪਛਾਣਕਰਤਾ"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"ਆਖਰੀ ਸੈਟਿੰਗਾਂ ਪੈਨਲ ਨੂੰ ਖੋਲ੍ਹਣ ਲਈ ਪਛਾਣਕਰਤਾ ਹੈ। ਬੇਪਛਾਣ ਮੁੱਲਾਂ ਨੂੰ ਅਣਡਿੱਠਾ ਕੀਤਾ"
+" ਜਾਵੇਗਾ ਅਤੇ ਸੂਚੀ "
+"ਵਿੱਚੋਂ ਪਹਿਲਾਂ ਪੈਨਲ ਚੁਣਿਆ ਜਾਂਦਾ ਹੈ।"
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "ਜਦੋਂ ਸੈਟਿੰਗਾਂ ਦੀ ਡਿਵੈਲਪਮੈਂਟ ਬਿਲਡ ਚੱਲਦਾ ਹੋਵੇ ਤਾਂ ਚੇਤਾਵਨੀ ਵੇਖਾਓ"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"ਕੀ ਸੈਟਿੰਗਾਂ ਨੂੰ ਚੇਤਾਵਨੀ ਦਿਖਾਉਣੀ ਚਾਹੀਦੀ ਹੈ, ਜਦੋਂ ਡਿਵੈਲਪਮੈਂਟ ਬਿਲਡ ਚੱਲਦਾ ਹੋਵੇ।"
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "ਵਿੰਡੋ ਦੀ ਪਹਿਲੀ ਸਥਿਤੀ"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"ਟਪਲ ਐਪਲੀਕੇਸ਼ਨ ਵਿੰਡੋ ਦੀ ਸ਼ੁਰੂਆਤੀ ਚੌੜਾਈ, ਉਚਾਈ ਤੇ ਵੱਧ ਤੋਂ ਵੱਧ ਹਾਲਤ ਰੱਖਦਾ ਹੈ।"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u ਆਉਟਪੁੱਟ"
+msgstr[1] "%u ਆਉਟਪੁੱਟ"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ਇੰਪੁੱਟ"
+msgstr[1] "%u ਇੰਪੁੱਟ"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "ਸਿਸਟਮ ਆਵਾਜ਼ਾਂ"
+
+#~ msgid "Basic Protection"
+#~ msgstr "ਮੁੱਢਲੀ ਸੁਰੱਖਿਆ"
+
+#~| msgid "Add connection"
+#~ msgid "Extended Protection"
+#~ msgstr "ਵਾਧਾ ਕੀਤੀ ਸੁਰੱਖਿਆ"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI ਲਿਖਣ"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI ਲਾਕ"
+
+#~| msgid "Select a region"
+#~ msgid "SPI BIOS region"
+#~ msgstr "SPI BIOS ਖੇਤਰ"
+
+#~| msgid "Suspend"
+#~ msgid "Suspend-to-ram"
+#~ msgstr "ਸਸਪੈਂਡ-ਟੂ-ਰੈਮ"
+
+#~| msgid "Manufacturer"
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "MEI ਨਿਰਮਾਤਾ ਢੰਗ"
+
+#~| msgid "PEAP _version"
+#~ msgid "MEI version"
+#~ msgstr "MEI ਵਰਜ਼ਨ"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "fwupd ਪਲੱਗਇਨਾਂ"
+
+#~| msgctxt "Password mode"
+#~| msgid "Account disabled"
+#~ msgid "Secure Boot disabled"
+#~ msgstr "ਸਕਿਉਰ ਬੂਟ ਅਸਮਰੱਥ ਹੈ"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "ਸਕਿਉਰ ਬੂਟ ਸਮਰੱਥ ਹੈ"
+
+#~ msgid "Lock your screen"
+#~ msgstr "ਆਪਣੀ ਸਕਰੀਨ ਲਾਕ ਕਰੋ"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER ਜਾਂ PEM ਸਰਟੀਫਿਕੇਟ (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "…ਪਰਿੰਟਰ ਜੋੜੋ"
+
+#~ msgid "Drip"
+#~ msgstr "ਚੌਂਣਾ"
+
+#~ msgid "Glass"
+#~ msgstr "ਕੱਚ"
+
+#~ msgid "Sonar"
+#~ msgstr "ਸੋਨਰ"
+
+#~ msgid "Light"
+#~ msgstr "ਹਲਕਾ"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "ਡਿਸਪਲੇਅ ਤਰਤੀਬ"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr "ਸਕਰੀਨ;ਲਾਕ;ਜਾਂਚ;ਪੜਤਾਲ;ਪ੍ਰਾਈਵੇਟ;ਨਿੱਜੀ;ਆਰਜ਼ੀ;ਇੰਡੈਕਸ;ਨਾਂ;ਨੈੱਟਵਰਕ;ਪਛਾਣ;ਕਰੈਸ਼;ਤਾਜ਼ਾ;"
+
+#~ msgid "Set"
+#~ msgstr "ਸੈੱਟ ਕਰੋ"
+
+#~ msgid "Bark"
+#~ msgstr "ਭੌਂਕਣਾ"
+
+#~| msgid "GNOME Settings"
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "ਗਨੋਮ ਸੈਟਿੰਗਾਂ ਸਾਊਂਡ ਪੈਨਲ"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "ਗਨੋਮ ਸੈਟਿੰਗਾਂ ਮਾਊਸ ਤੇ ਟੱਚਪੈਡ ਪੈਨਲ"
+
+#~| msgid "GNOME Settings"
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "ਗਨੋਮ ਸੈਟਿੰਗਾਂ ਬੈਕਗਰਾਊਂਡ ਪੈਨਲ"
+
+#~| msgid "GNOME OnScreen Keyboard"
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "ਗਨੋਮ ਸੈਟਿੰਗਾਂ ਕੀਬੋਰਡ ਪੈਨਲ"
+
+#~ msgid "Web Links"
+#~ msgstr "ਵੈੱਬ ਲਿੰਕ"
+
+#~ msgid "Git Links"
+#~ msgstr "Git ਲਿੰਕ"
+
+#~ msgid "%s Links"
+#~ msgstr "%s ਲਿੰਕ"
+
+#~ msgid "Unset"
+#~ msgstr "ਅਣ-ਸੈੱਟ"
+
+#~ msgid "Links"
+#~ msgstr "ਲਿੰਕ"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "ਹਾਈਪਰਟੈਕਸਟ ਫਾਇਲਾਂ"
+
+#~ msgid "Text Files"
+#~ msgstr "ਲਿਖਤ ਫਾਇਲਾਂ"
+
+#~ msgid "Image Files"
+#~ msgstr "ਚਿੱਤਰ ਫਾਇਲਾਂ"
+
+#~ msgid "Font Files"
+#~ msgstr "ਫੋਂਟ ਫਾਇਲਾਂ"
+
+#~ msgid "Archive Files"
+#~ msgstr "ਅਕਾਇਵ ਫਾਇਲਾਂ"
+
+#~ msgid "Package Files"
+#~ msgstr "ਪੈਕੇਜ ਫਾਇਲਾਂ"
+
+#~ msgid "Audio Files"
+#~ msgstr "ਆਡੀਓ ਫਾਇਲਾਂ"
+
+#~ msgid "Video Files"
+#~ msgstr "ਵਿਡੀਓ ਫਾਇਲਾਂ"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "ਇਜਾਜ਼ਤਾਂ ਤੇ ਪਹੁੰਚ"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "ਡਾਟਾ ਅਤੇ ਸੇਵਾਵਾਂ, ਜੋ ਇਸ ਐਪ ਨੇ ਪਹੁੰਚ ਲਈ ਅਤੇ ਇਜ਼ਾਜਤਾਂ ਦੀ ਮੰਗ ਕੀਤੀ ਹੈ, ਜੋ ਇਸ ਨੂੰ ਚਾਹੀਦੀਆਂ ਹਨ।"
+
+#~ msgid "Cannot be changed"
+#~ msgstr "ਬਦਲ ਨਹੀਂ ਸਕਦੇ"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "ਐਪਲੀਕੇਸ਼ਨਾਂ ਲਈ ਵੱਖੋ-ਵੱਖ ਇਜਾਜ਼ਤਾਂ ਦੀ ਪੜਤਾਲ <a href=\"privacy\">ਪਰਦੇਦਾਰੀ</a> ਸੈਟਿੰਗਾਂ "
+#~ "ਵਿੱਚ ਕੀਤੀ ਜਾ ਸਕਦੀ ਹੈ।"
+
+#~ msgid "Integration"
+#~ msgstr "ਏਕੀਕਰਨ"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "ਡੈਸਕਟਾਪ ਬੈਕਗਰਾਊਂਡ ਲਾਓ"
+
+#~ msgid "Default Handlers"
+#~ msgstr "ਮੂਲ ਹੈਂਡਲਰ"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "ਇਸ ਐਪਲੀਕੇਸ਼ਨ ਨਾਲ ਖੁੱਲ੍ਹਣ ਵਾਲੀਆਂ ਫਾਇਲਾਂ ਅਤੇ ਲਿੰਕਾਂ ਦੀਆਂ ਕਿਸਮਾਂ ਹਨ।"
+
+#~ msgid "Usage"
+#~ msgstr "ਵਰਤੋਂ"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "ਇਹ ਐਪਲੀਕੇਸ਼ਨ ਕਿੰਨੇ ਸਰੋਤ ਵਰਤ ਰਹੀ ਹੈ।"
+
+#~ msgid "Open in Software"
+#~ msgstr "ਸਾਫਟਵੇਅਰ ਵਿੱਚ ਖੋਲ੍ਹੋ"
+
+#~ msgid "Activities"
+#~ msgstr "ਸਰਗਰਮੀਆਂ"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "ਹੇਠਲੀਆਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਆਪਣਾ ਕੈਮਰਾ ਵਰਤਣ ਲਈ ਸਹਿਮਤੀ ਦਿਓ।"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "ਫਾਇਲ ਅੱਪਲੋਡ ਕਰਨ ਲਈ ਫੇਲ੍ਹ: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "ਪਰੋਫਾਇਲ ਨੂੰ ਅੱਪਲੋਡ ਕੀਤਾ ਜਾ ਚੁੱਕਾ ਹੈ:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "ਇਹ URL ਲਿਖ ਲਵੋ।"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "ਆਪਣੇ ਕੰਪਿਊਟਰ ਨੂੰ ਮੁੜ-ਚਾਲੂ ਕਰੋ ਅਟੇ ਆਪਣੇ ਸਧਾਰਨ ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਨੂੰ ਬੂਟ ਕਰੋ।"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "ਪਰੋਫਾਇਲ ਨੂੰ ਡਾਊਨਲੋਡ ਕਰਕੇ ਇੰਸਟਾਲ ਕਰਨ ਥਈ URL ਨੂੰ ਆਪਣੇ ਬਰਾਊਜ਼ਰ ਵਿੱਚ ਲਿਖੋ।"
+
+#~ msgid "Upload profile"
+#~ msgstr "ਪਰੋਫਾਇਲ ਅੱਪਲੋਡ"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "ਇੰਟਰਨੈੱਟ ਕਨੈਕਸ਼ਨ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "_Copy"
+#~ msgstr "ਕਾਪੀ ਕਰੋ(_C)"
+
+#~ msgid "Select _All"
+#~ msgstr "ਸਭ ਚੁਣੋ(_A)"
+
+#~ msgid "Single Display"
+#~ msgstr "ਇਕੱਲਾ ਡਿਸਪਲੇਅ"
+
+#~ msgid "Join Displays"
+#~ msgstr "ਡਿਸਪਲੇਅ ਨੂੰ ਜੋੜੋ"
+
+#~ msgid "Display Mode"
+#~ msgstr "ਡਿਸਪਲੇਅ ਮੋਡ"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "ਡਿਸਪਲੇਆਂ ਨੂੰ ਆਪਣੇ ਅਸਲ ਡਿਸਪਲੇਅ ਬਨਾਵਟ ਨਾਲ ਮਿਲਾਉਣ ਲਈ ਉਹਨਾਂ ਨੂੰ ਖਿਸਕਾਓ। ਡਿਸਪਲੇਅ ਦੀਆਂ "
+#~ "ਸੈਟਿੰਗਾਂ ਨੂੰ ਬਦਲਣ ਲਈ ਉਸ ਨੂੰ ਚੁਣੋ।"
+
+#~ msgid "Active Display"
+#~ msgstr "ਸਰਗਰਮ ਡਿਸਪਲੇਅ"
+
+#~ msgid "More Warm"
+#~ msgstr "ਵੱਧ ਗੂੜ੍ਹੇ"
+
+#~ msgid "Less Warm"
+#~ msgstr "ਘੱਟ ਗੂੜ੍ਹੇ"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "ਸਕਰੀਨਸ਼ਾਟ $PICTURES ਵਿੱਚ ਸੰਭਾਲੋ"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "ਵਿੰਡੋ ਦਾ ਸਕਰੀਨਸ਼ਾਟ $PICTURES ਵਿੱਚ ਸੰਭਾਲੋ"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "ਖੇਤਰ ਦਾ ਸਕਰੀਨਸ਼ਾਟ ਵਿੱਚ $PICTURES ਵਿੱਚ ਸੰਭਾਲੋ"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "ਸਕਰੀਨਸ਼ਾਟ ਕਲਿੱਪਬੋਰਡ 'ਚ ਕਾਪੀ ਕਰੋ"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "ਵਿੰਡੋ ਦੀ ਸਕਰੀਨਸ਼ਾਟ ਕਲਿੱਪਬੋਰਡ 'ਚ ਕਾਪੀ ਕਰੋ"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "ਖੇਤਰ ਦਾ ਸਕਰੀਨਸ਼ਾਟ ਕਲਿੱਪਬੋਰਡ 'ਚ ਕਾਪੀ ਕਰੋ"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "ਛੋਟਾ ਸਕਰੀਨਕਾਸਟ ਰਿਕਾਰਡ ਕਰੋ"
+
+#~ msgid "Move up"
+#~ msgstr "ਉੱਤੇ ਭੇਜੋ"
+
+#~ msgid "Move down"
+#~ msgstr "ਹੇਠਾਂ ਭੇਜੋ"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "ਟਿਕਾਣਾ ਸੇਵਾਵਾਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਤੁਹਾਡੇ ਟਿਕਾਣੇ ਦਾ ਪਤਾ ਲਗਾਉਣ ਦੀ ਇਜਾਜ਼ਤ ਦਿੰਦੀਆਂ ਹਨ। ਸਟੀਕਤਾ "
+#~ "ਵਧਾਉਣ ਲਈ Wi-Fi ਅਤੇ ਮੋਬਾਈਲ ਬਰਾਂਡਬੈਂਡ ਨੂੰ ਵਰਤੋਂ।"
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "ਮੌਜ਼ੀਲਾ ਟਿਕਾਣਾ ਸੇਵਾ ਨੂੰ ਵਰਤੋਂ: <a href='https://location.services.mozilla.com/"
+#~ "privacy'>ਪਰਦੇਦਾਰੀ ਨੀਤੀ</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "ਹੇਠਲੀਆਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਆਪਣੇ ਟਿਕਾਣੇ ਦਾ ਪਤਾ ਲਗਾਉਣ ਲਈ ਸਹਿਮਤੀ ਦਿਓ।"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "ਹੇਠਲੀਆਂ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਆਪਣੇ ਮਾਈਕਰੋਫ਼ੋਨ ਵਰਤਣ ਲਈ ਸਹਿਮਤੀ ਦਿਓ।"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "ਡਬਲ ਕਲਿੱਕ ਟਾਈਮ-ਆਉਟ"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "ਸਸਪੈਂਡ ਅਤੇ ਪਾਵਰ ਬਟਨ"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "ਲੈਪ ਖੋਜਿਆ: ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਮੌਜੂਦ ਨਹੀਂ ਹੈ"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "ਵੱਧ ਹਾਰਡਵੇਅਰ ਤਾਪਮਾਨ: ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਮੌਜੂਦ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "ਕਾਰਗੁਜ਼ਾਰੀ ਢੰਗ ਮੌਜੂਦ ਨਹੀਂ ਹੈ"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "ਪਰਮਾਣਿਤ"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr "ਅੰਕਾਂ, ਤਾਰੀਖਾਂ ਤੇ ਕਰੰਸੀਆਂ ਲਈ ਫਾਰਮੈਟ ਚੁਣੋ। ਤਬਦੀਲੀਆਂ ਅਗਲੇ ਲਾਗਇਨ ਉੱਤੇ ਲਾਗੂ ਹੁੰਦੀਆਂ ਹਨ।"
+
+#~ msgid "My Account"
+#~ msgstr "ਮੇਰਾ ਖਾਤਾ"
+
+#~ msgid "Language"
+#~ msgstr "ਭਾਸ਼ਾ"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "ਵਿੰਡੋਜ਼ ਅਤੇ ਵੈੱਬ ਸਫ਼ਿਆਂ ਵਿੱਚ ਲਿਖਤ ਲਈ ਵਰਤੀ ਜਾਂਦੀ ਭਾਸ਼ਾ ਹੈ।"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "ਤਬਦੀਲੀਆਂ ਨੂੰ ਪ੍ਰਭਾਵੀ ਬਣਾਉਣ ਲਈ ਸ਼ੈਸ਼ਨ ਨੂੰ ਮੁੜ-ਚਾਲੂ ਕਰਨ ਦੀ ਲੋੜ ਹੈ"
+
+#~ msgid "Restart…"
+#~ msgstr "…ਮੁੜ-ਚਾਲੂ ਕਰੋ"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "ਲਾਗਇਨ ਸੈਟਿੰਗਾਂ ਨੂੰ ਸਭ ਵਰਤੋਂਕਾਰਾਂ ਵਲੋਂ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ, ਜਦੋਂ ਸਿਸਟਮ ਵਿੱਚ ਲਾਗਇਨ ਕਰਦੇ ਹਨ"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "ਕੰਟਰੋਲ ਕਰੋ ਕਿ ਕਿਹੜੇ ਖੋਜ ਨਤੀਜਿਆ ਨੂੰ ਸਰਗਰਮੀ ਸਾਰ ਵਿੱਚ ਵਿਖਾਇਆ ਜਾਂਦਾ ਹੈ। ਖੋਜ ਨਤੀਜਿਆਂ ਦੀ "
+#~ "ਲੜੀ ਨੂੰ ਸੂਚੀ ਵਿੱਚ ਕਤਾਰਾਂ ਰਾਹੀਂ ਹਿਲਾ ਕੇ ਵੀ ਬਦਲਿਆ ਜਾ ਸਕਦਾ ਹੈ।"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "ਸਕਰੀਨ ਸਾਂਝਾ ਕਰਨ ਨਾਲ ਰਿਮੋਟ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਆਪਣੀ ਸਕਰੀਨ ਵੇਖਣ ਜਾਂ ਕੰਟਰੋਲ ਦਿੱਤਾ ਜਾਂਦਾ ਹੈ, %s "
+#~ "ਨਾਲ ਕਨੈਕਟ ਕਰਕੇ"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "ਸਕਰੀਨ ਸਾਂਝਾ ਕਰਨਾ(_S)"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "ਕੁਝ ਸਰਵਿਸਾਂ ਬੰਦ ਹਨ, ਕਿਉਂਕਿ ਕੋਈ ਨੈੱਟਵਰਕ ਪਹੁੰਚ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "_Password:"
+#~ msgstr "ਪਾਸਵਰਡ(_P):"
+
+#~ msgid "_Show Password"
+#~ msgstr "ਪਾਸਵਰਡ ਦਿਖਾਓ(_S)"
+
+#~ msgid "Access Options"
+#~ msgstr "ਵਰਤੋਂ ਚੋਣਾ"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "ਵਰਤਣ ਲਈ ਨਵੇਂ ਕਨੈਕਸ਼ਨ ਲਈ ਜ਼ਰੂਰ ਪੁੱਛੋ(_N)"
+
+#~ msgid "_Require a password"
+#~ msgstr "ਪਾਸਵਰਡ ਚਾਹੀਦਾ ਹੈ(_R)"
+
+#~ msgid "Sound Keys"
+#~ msgstr "ਸਾਊਂਡ ਸਵਿੱਚਾਂ"
+
+#~ msgid "Screen Reader"
+#~ msgstr "ਸਕਰੀਨ ਰੀਡਰ"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "ਸਕਰੀਨ ਰੀਡਰ(_S)"
+
+#~ msgid "Standard"
+#~ msgstr "ਸਟੈਂਡਰਡ"
+
+#~ msgid "Account _Type"
+#~ msgstr "ਅਕਾਊਂਟ ਕਿਸਮ(_T)"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "ਵਰਤੋਂਕਾਰ ਨੂੰ ਪਾਸਵਰਡ ਸੈੱਟ ਕਰਨ ਦਿਉ, ਜਦੋਂ ਕਿ ਉਹ ਅਗਲੀ ਵਾਰ ਲਾਗਇਨ ਕਰੇ(_l)"
+
+#~ msgid "Set a password _now"
+#~ msgstr "ਹੁਣੇ ਪਾਸਵਰਡ ਦਿਓ(_n)"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "ਇੰਟਰਪਰਾਈਜ਼ਨ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਜੋੜਨ ਲਈ ਤੁਹਾਨੂੰ ਆਨਲਾਈਨ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "…ਫ਼ੋਟੋ ਲਵੋ"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ਬਦਲਾਅ ਕਰਨ ਲਈ,\n"
+#~ "ਪਹਿਲਾਂ * ਆਈਕਾਨ ਉੱਤੇ ਕਲਿੱਕ ਕਰੋ"
+
+#~ msgid "Create a user account"
+#~ msgstr "ਨਵਾਂ ਵਰਤੋਂਕਾਰ ਖਾਤਾ ਬਣਾਓ"
+
+#~ msgid "User Icon"
+#~ msgstr "ਵਰਤੋਂਕਾਰ ਆਈਕਾਨ"
+
+#~ msgid "Account Settings"
+#~ msgstr "ਅਕਾਊਂਟ ਸੈਟਿੰਗਾਂ"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "ਪਰਮਾਣਿਕਤਾ ਅਤੇ ਲਾਗਇਨ"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "ਇਹ ਤੁਹਾਡੇ ਘਰ ਫੋਲਡਰ ਨਾਂ ਲਈ ਵਰਤਿਆ ਜਾਵੇਗਾ ਅਤੇ ਬਦਲਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਹੈ।"
+
+#~ msgid "Output:"
+#~ msgstr "ਆਉਟਪੁੱਟ:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "ਆਕਾਰ ਅਨੁਪਾਤ ਰੱਖੋ (ਲੈਟਰਬਾਕਸ):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "ਇੱਕਲੇ ਮਾਨੀਟਰ ਲਈ ਮੈਪ ਕਰੋ"
+
+#~ msgid "%d of %d"
+#~ msgstr "%2$d ਵਿੱਚੋਂ %1$d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "ਡਿਸਪਲੇਅ ਮਿਲਾਨ"
+
+#~ msgid "Stylus"
+#~ msgstr "ਸਟਾਇਲਸ"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "ਟੇਬਲੇਟ (ਅਸਲ)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "ਟੱਚਪੈਚ (ਅਨੁਸਾਰੀ)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "ਟੇਬਲੇਟ ਪਸੰਦ"
+
+#~ msgid "_Help"
+#~ msgstr "ਮਦਦ(_H)"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ਬਲੂਟੁੱਥ ਸੈਟਿੰਗ"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ਟਰੈਕਿੰਗ ਮੋਡ"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "…ਬਟਨ ਮਿਲਾਉ"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "ਮਾਊਸ ਸੈਟਿੰਗ ਠੀਕ ਕਰੋ"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "ਡਿਸਪਲੇਅ ਰੈਜ਼ੋਲੂਸ਼ਨ ਅਡਜੱਸਟ ਕਰੋ"
+
+#~ msgid "No stylus found"
+#~ msgstr "ਕੋਈ ਸਟਾਈਲਸ ਨਹੀਂ ਲੱਭਿਆ"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "ਆਪਣੇ ਸਟਾਈਲਸ ਦੀ ਸੰਰਚਨਾ ਕਰਨ ਲਈ ਇਸ ਨੂੰ ਟੇਬਲੇਟ ਦੇ ਨੇੜੇ ਲਿਆਉ"
+
+#~ msgid "Top Button"
+#~ msgstr "ਟਾਪ ਬਟਨ"
+
+#~ msgid "Lower Button"
+#~ msgstr "ਹੇਠਲਾ ਬਟਨ"
+
+#~ msgid "Lowest Button"
+#~ msgstr "ਸਭ ਤੋਂ ਹੇਠਲਾ ਬਟਨ"
+
+#~ msgid "Unlocking..."
+#~ msgstr "…ਅਣ-ਲਾਕ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~| msgid "Keyboard Shortcuts"
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "ਕੀ-ਬੋਰਡ ਸ਼ਾਰਟਕੱਟ"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "ਇਸ ਨੂੰ ਸ਼ਾਰਟਕੱਟ ਕਸਟਮਾਈਜ਼ ਵਿੱਚ ਬਦਲਿਆ ਜਾ ਸਕਦਾ ਹੈ"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "ਵੱਖਰੇ ਅੱਖਰ ਦੇਣ ਲਈ ਦਬਾ ਕੇ ਰੱਖੋ ਅਤੇ ਲਿਖੋ"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "ਸਕਰੀਨ ਚਮਕ(_S)"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "ਕੀ-ਬੋਰਡ ਚਮਕ(_K)"
+
+#~| msgid "_Dim Screen When Inactive"
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "ਨਾ-ਸਰਗਰਮ ਹੋਵੇ ਤਾਂ ਸਕਰੀਨ ਡਿਮ ਕਰੋ"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "ਖਾਲੀ ਸਕਰੀਨ(_B)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "ਵਾਈ-ਫਾਈ(_W)"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "ਊਰਜਾ ਬਚਾਉਣ ਲਈ Wi-Fi ਬੰਦ ਕਰੋ।"
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr "ਊਰਜਾ ਬਚਾਉਣ ਲਈ ਮੋਬਾਇਲ ਬਰਾਡਬੈਂਡ (LTE, 4G, 3G, ਆਦਿ) ਨੂੰ ਬੰਦ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ।"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "ਬਲੂਟੁੱਥ(_B)"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "ਊਰਜਾ ਬਚਾਉਣ ਲਈ ਬਲੂਟੁੱਥ ਨੂੰ ਬੰਦ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ।"
+
+#~| msgid "Balance"
+#~ msgid "Balanced Power"
+#~ msgstr "ਸੰਤੁਲਿਤ ਊਰਜਾ"
+
+#~ msgid "Add…"
+#~ msgstr "…ਜੋੜੋ"
+
+#~ msgid ""
+#~ "Select your display language, formats, keyboard layouts and input sources"
+#~ msgstr "ਆਪਣੇ ਵੇਖਾਉਣ ਵਾਲੀ ਭਾਸ਼ਾ, ਫਾਰਮੈਟ, ਕੀਬੋਰਡ ਲੇਆਉਟ ਅਤੇ ਇੰਪੁੱਟ ਸਰੋਤ ਚੁਣੋ"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "ਲਾਗਇਨ;ਨਾਂ;ਫਿੰਗਰਪਰਿੰਟ;ਅਵਤਾਰ;ਲੋਗੋ;ਚਿਹਰਾ;ਪਾਸਵਰਡ;"
+
+#~| msgid "Add or remove users and change your password"
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "ਵਰਤੋਂਕਾਰਾਂ ਖਾਤਿਆਂ ਨੂੰ ਜੋੜੋ ਅਤੇ ਪਾਸਵਰਡ ਬਦਲੋ"
+
+#~ msgid "Play and record sound"
+#~ msgstr "ਆਵਾਜ਼ ਚਲਾਓ ਅਤੇ ਰਿਕਾਰਡ ਕਰੋ"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "mDNS/DNS-SD (Bonjour/ਜ਼ੋਰ-ਕੌਨਫ਼) ਵਰਤ ਕੇ ਨੈੱਟਵਰਕ ਡਿਵਾਈਸ ਖੋਜੋ"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "ਬਲੂਟੁੱਥ ਹਾਰਡਵੇਅਰ ਲਈ ਸਿੱਧੀ ਪਹੁੰਚ"
+
+#~ msgid "Use your camera"
+#~ msgstr "ਤੁਹਾਡੇ ਕੈਮਰੇ ਨੂੰ ਵਰਤਣਾ"
+
+#~| msgid "Documents"
+#~ msgid "Print documents"
+#~ msgstr "ਡੌਕੂਮੈਂਟ ਪਰਿੰਟ ਕਰੋ"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "ਕਿਸੇ ਵੀ ਕਨੈਕਟ ਹੋਈ ਜਾਏਸਟਿੱਕ ਨੂੰ ਵਰਤਣਾ"
+
+#~| msgid "_Allow connections to control the screen"
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "ਡੌਕਰ ਸੇਵਾ ਨਾਲ ਕਨੈਕਟ ਕਰਨ ਦੀ ਸਹਿਮਤੀ ਦਿਓ"
+
+#~| msgid "Configure input source"
+#~ msgid "Configure network firewall"
+#~ msgstr "ਨੈੱਟਵਰਕ ਫਾਇਰਵਾਲ ਦੀ ਸੰਰਚਨਾ"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "ਅਧਿਕਾਰ ਪ੍ਰਾਪਤ FUSE ਫਾਇਲ-ਸਿਸਟਮਾਂ ਦਾ ਸੈਟਅੱਪ ਅਤੇ ਵਰਤੋਂ"
+
+#~| msgid "Calibrate the device"
+#~ msgid "Update firmware on this device"
+#~ msgstr "ਇਸ ਡਿਵਾਈਸ ਉੱਤੇ ਫਿਰਮਵੇਅਰ ਅੱਪਡੇਟ ਕਰੋ"
+
+#~| msgid "Account Information"
+#~ msgid "Access hardware information"
+#~ msgstr "ਹਾਰਡਵੇਅਰ ਜਾਣਕਾਰੀ ਲਈ ਪਹੁੰਚ"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "ਹਾਰਡਵੇਅਰ ਰਲਵੇਂ ਨੰਬਰ ਜਰਨੇਟਰ ਲਈ ਇੰਟਰੋਪੀ ਦਿਓ"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "ਹਾਰਡਵੇਅਰ-ਰਾਹੀਂ ਤਿਆਰ ਕੀਤੇ ਰਲਵੇਂ ਨੰਬਰ ਵਰਤੋਂ"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "ਤੁਹਾਡੇ ਘਰ ਫੋਲਡਰ ਵਿੱਚ ਫਾਇਲਾਂ ਲਈ ਪਹੁੰਚ"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "libvirt ਸੇਵਾ ਲਈ ਪਹੁੰਚ"
+
+#~| msgid "Change system time and date settings"
+#~ msgid "Change system language and region settings"
+#~ msgstr "ਸਿਸਟਮ ਭਾਸ਼ਾ ਅਤੇ ਖੇਤਰ ਸੈਟਿੰਗਾਂ ਬਦਲੋ"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "ਟਿਕਾਣਾ ਸੈਟਿੰਗਾਂ ਅਤੇ ਪੂਰਕਾਂ ਨੂੰ ਬਦਲਣਾ"
+
+#~| msgid "Could not add application"
+#~ msgid "Read system and application logs"
+#~ msgstr "ਸਿਸਟਮ ਅਤੇ ਐਪਲੀਕੇਸ਼ਨ ਲਾਗ ਪੜ੍ਹਨ"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "ਮੀਡੀਆ-ਹੱਬ ਸੇਵਾ ਲਈ ਪਹੁੰਚ"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "ਮਾਡਮ ਵਰਤਣੇ ਅਤੇ ਸੰਰਚਨਾ"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "ਸਿਸਟਮ ਮਾਊਂਟ ਜਾਣਕਾਰੀ ਅਤੇ ਡਿਸਕ ਕੋਟੇ ਨੂੰ ਪੜ੍ਹਨਾ"
+
+#~ msgid "Control music and video players"
+#~ msgstr "ਸੰਗੀਤ ਅਤੇ ਵਿਡੀਓ ਪਲੇਅਰਾਂ ਨੂੰ ਕੰਟਰੋਲ ਕਰਨਾ"
+
+#~| msgid "Change keyboard settings"
+#~ msgid "Change low-level network settings"
+#~ msgstr "ਨੀਵੇਂ ਪੱਧਰ ਦੀਆਂ ਨੈੱਟਵਰਕ ਸੈਟਿੰਗਾਂ ਬਦਲੋ"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr "ਨੈੱਟਵਰਕ ਸੈਟਿੰਗਾਂ ਪੜ੍ਹਨ ਅਤੇ ਬਦਲਣ ਵਾਸਤੇ ਨੈੱਟਵਰਕ-ਮੈਨੇਜਰ ਸੇਵਾ ਲਈ ਪਹੁੰਚ"
+
+#~| msgid "Network settings"
+#~ msgid "Read access to network settings"
+#~ msgstr "ਨੈੱਟਵਰਕ ਸੈਟਿੰਗਾਂ ਲਈ ਪੜ੍ਹਨ ਪਹੁੰਚ"
+
+#~| msgid "Change keyboard settings"
+#~ msgid "Change network settings"
+#~ msgstr "ਨੈੱਟਵਰਕ ਸੈਟਿੰਗਾਂ ਬਦਲੋ"
+
+#~| msgid "Network settings"
+#~ msgid "Read network settings"
+#~ msgstr "ਨੈੱਟਵਰਕ ਸੈਟਿੰਗਾਂ ਪੜ੍ਹਨ"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr "ਮੋਬਾਈਲ ਟੈਲੀਫੋਨ ਲਈ ਨੈੱਟਵਰਕ ਸੈਟਿੰਗਾਂ ਪੜ੍ਹਨ ਅਤੇ ਬਦਲਣ ਵਾਸਤੇ ofono ਸੇਵਾ ਲਈ ਪਹੁੰਚ"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "ਓਪਨ v-ਸਵਿੱਚ ਹਾਰਡਵੇਅਰ ਲਈ ਕੰਟਰੋਲ"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "CD/DVD ਤੋਂ ਪੜ੍ਹਨਾ"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "ਸੰਭਾਲੇ ਹੋਏ ਪਾਸਵਰਡਾਂ ਨੂੰ ਪੜ੍ਹਨਾ, ਜੋੜਨਾ, ਬਦਲਣਾ ਜਾਂ ਹਟਾਉਣਾ"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr "ਪੁਆਇੰਟ-ਟੂ-ਪੁਆਇੰਟ ਪਰੋਟੋਕਾਲ ਕਨੈਕਸ਼ਨਾਂ ਦੀ ਸੰਰਚਨਾ ਵਾਸਤੇ pppd ਅਤੇ ppp ਡਿਵਾਈਸਾਂ ਲਈ ਪਹੁੰਚ"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "ਸਿਸਟਮ ਉੱਤੇ ਕਿਸੇ ਵੀ ਕਾਰਵਾਈ ਨੂੰ ਵਿਰਾਮ ਜਾਂ ਖਤਮ ਕਕਰਨਾ"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "USB ਹਾਰਡਵੇਅਰ ਲਈ ਸਿੱਧੀ ਪਹੁੰਚ"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "ਹਟਾਉਣਯੋਗ ਸਟੋਰੇਜ਼ ਡਿਵਾਈਸਾਂ ਉੱਤੇ ਫਾਇਲਾਂ ਪੜ੍ਹਨਾ/ਲਿਖਣਾ"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "ਸਕਰੀਨ ਦੇ ਸਲੀਪ/ਲਾਕ ਹੋਣ ਤੋਂ ਰੋਕਣਾ"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "ਸੀਰੀਅਲ ਪੋਰਟ ਹਾਰਡਵੇਅਰ ਲਈ ਪਹੁੰਚ"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "ਡਿਵਾਈਸ ਨੂੰ ਮੁੜ-ਚਾਲੂ ਕਰਨਾ ਜਾਂ ਬੰਦ ਕਰਨਾ"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "ਸਾਫਟਵੇਅਰ ਇੰਸਟਾਲ ਕਰਨਾ, ਹਟਾਉਣਾ ਅਤੇ ਸੰਰਚਨਾ"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "ਸਟੋਰੇਜ਼ ਫਰੇਮਵਰਕ ਸੇਵਾ ਲਈ ਪਹੁੰਚ"
+
+#~| msgid "System Information"
+#~ msgid "Read process and system information"
+#~ msgstr "ਪਰੋਸੈਸ ਅਤੇ ਸਿਸਟਮ ਜਾਣਕਾਰੀ ਪੜ੍ਹਨ"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "ਕਿਸੇ ਵੀ ਚੱਲਦੇ ਪ੍ਰੋਗਰਾਮ ਦੀ ਨਿਗਰਾਨੀ ਅਤੇ ਕੰਟਰੋਲ"
+
+#~| msgid "Change the date and time, including time zone"
+#~ msgid "Change the date and time"
+#~ msgstr "ਤਾਰੀਖ ਅਤੇ ਸਮਾਂ ਬਦਲੋ"
+
+#~| msgid "Change keyboard settings"
+#~ msgid "Change time server settings"
+#~ msgstr "ਸਮਾਂ ਸਰਵਰ ਸੈਟਿੰਗਾਂ ਬਦਲੋ"
+
+#~| msgid "Change the background"
+#~ msgid "Change the time zone"
+#~ msgstr "ਸਮਾਂ ਖੇਤਰ ਬਦਲੋ"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr "ਡਿਸਕਾਂ ਅਤੇ ਹਟਾਉਣਯੋਗ ਮੀਡੀਆ ਦੀ ਸੰਰਚਨਾਂ ਲਈ UDisk2 ਸੇਵਾ ਵਾਸਤੇ ਪਹੁੰਚ"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "ਉਬੰਤੂ ਯੂਨਿਟੀ 8 ਵਿੱਚ ਸਾਂਝੇ ਕੈਲੰਡਰ ਈਵੈਂਟਾਂ ਲਈ ਪੜ੍ਹਨਾ/ਬਦਲਣਾ"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "ਉਬੰਤੂ ਯੂਨਿਟੀ 8 ਵਿੱਚ ਸਾਂਝੇ ਸੰਪਰਕਾਂ ਲਈ ਪੜ੍ਹਨਾ/ਬਦਲਣਾ"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "ਊਰਜਾ ਵਰਤੋ ਡਾਟੇ ਲਈ ਪਹੁੰਚ"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "U2F ਡਿਵਾਈਸਾਂ ਲਈ ਪੜ੍ਹਨ/ਲਿਖਣ ਲਈ ਪਹੁੰਚ ਪ੍ਰਗਟ ਹੈ"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "ਯੂਨੀਵਰਸਲ ਅਸੈੱਸ"
+
+#~ msgid "Left Alt"
+#~ msgstr "ਖੱਬਾ Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "ਸੱਜਾ Alt"
+
+#~| msgid "Left Ctrl"
+#~ msgid "Left Super"
+#~ msgstr "ਖੱਬਾ ਸੁਪਰ"
+
+#~| msgid "Right Ctrl"
+#~ msgid "Right Super"
+#~ msgstr "ਸੱਜਾ ਸੁਪਰ"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "ਸੱਜਾ Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "ਬਦਲਵੇਂ ਅੱਖਰ ਸਵਿੱਚ"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "ਮਾਡੀਫਾਇਰ-ਕੇਵਲ ਅਗਲੇ ਸਰੋਤ ਲਈ ਬਦਲੋ"
+
+#~| msgid "Movement Key"
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "ਮੀਨੂ ਸਵਿੱਚ"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "ਵਾਈ-ਫਾਈ ਨੈੱਟਵਰਕ ਨਾਲ ਕਨੈਕਟ ਕਰਨ ਲਈ ਬੰਦ ਕਰੋ"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "ਪਾਸਵਰਡ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "ਚਾਰਜ ਹੋ ਰਹੀ ਹੈ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "ਸਾਵਧਾਨ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "ਘੱਟ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "ਚੰਗੀ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "ਪੂਰੀ ਚਾਰਜ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "ਖਾਲੀ"
+
+#~ msgid "Previous source"
+#~ msgstr "ਪਿਛਲਾ ਸਰੋਤ"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "ਅਗਲਾ ਸਰੋਤ"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "ਖੱਬਾ+ਸੱਜਾ Alt"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ਵਰਤੋਂਕਾਰ ਖਾਤਾ ਬਣਾਉਣ ਲਈ,\n"
+#~ "ਪਹਿਲਾਂ * ਆਈਕਾਨ ਉੱਤੇ ਕਲਿੱਕ ਕਰੋ"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "ਫਿੰਗਰਪਰਿੰਟ ਲਾਗਇਨ ਚਾਲੂ"
+
+#~ msgid "_Other finger:"
+#~ msgstr "ਹੋਰ ਉਂਗਲ(_O):"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "ਤੁਹਾਡੇ ਫਿੰਗਰਪਰਿੰਟ ਸਫ਼ਲਤਾ ਨਾਲ ਸੰਭਾਲੇ ਗਏ ਹਨ। ਹੁਣ ਤੁਸੀਂ ਫਿੰਗਰਪਰਿੰਟ ਰੀਡਰ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਲਾਗਇਨ "
+#~ "ਕਰਨ ਦੇ ਯੋਗ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "ਤੁਹਾਨੂੰ ਜੰਤਰ ਵਰਤਣ ਦੀ ਇਜ਼ਾਜ਼ਤ ਨਹੀਂ ਹੈ। ਆਪਣੇ ਸਿਸਟਮ ਐਡਮਿਨਸਟੇਟਰ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "ਅੰਦਰੂਨੀ ਗਲਤੀ ਆਈ ਹੈ।"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "ਕੀ ਰਜਿਸਟਰ ਕੀਤੇ ਫਿੰਗਰ-ਪਰਿੰਟ ਹਟਾਉਣੇ ਹਨ?"
+
+#~ msgid "Done!"
+#~ msgstr "ਮੁਕੰਮਲ!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "ਜੰਤਰ ”%s” ਲਈ ਅਸੈੱਸ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "ਜੰਤਰ ”%s” ਉੱਤੇ ਉਂਗਲ ਪ੍ਰਾਪਤ ਸ਼ੁਰੂ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "ਮਦਦ ਲਈ ਆਪਣੇ ਸਿਸਟਮ ਐਡਮਿਨਸਟੇਟਰ ਨਾਲ ਸੰਪਰਕ ਕਰੋ ਜੀ।"
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "ਫਿੰਗਰਪਰਿੰਟ ਲਾਗਇਨ ਯੋਗ ਕਰਨ ਲਈ, ਤੁਹਾਨੂੰ ਆਪਣੇ ਫਿੰਗਰਪਰਿੰਟ ਸੰਭਾਲਣ ਦੀ ਲੋੜ ਹੈ, ”%s” ਜੰਤਰ ਦੀ "
+#~ "ਵਰਤੋਂ ਕਰਕੇ।"
+
+#~ msgid "Selecting finger"
+#~ msgstr "ਉਂਗਲ ਚੁਣੀ ਜਾ ਰਹੀ ਹੈ"
+
+#~| msgid "Show in Lock Screen"
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "ਬੈਕਗਰਾਊਂਡ ਅਤੇ ਲਾਕ ਸਕਰੀਨ ਲਾਓ"
+
+#~| msgid "Select Background"
+#~ msgid "Set Background"
+#~ msgstr "ਬੈਕਗਰਾਊਂਡ ਲਾਓ"
+
+#~| msgid "_Lock Screen"
+#~ msgid "Set Lock Screen"
+#~ msgstr "ਲਾਕ ਸਕਰੀਨ ਲਾਓ"
+
+#~| msgid "Select Background"
+#~ msgid "Remove Background"
+#~ msgstr "ਬੈਕਗਰਾਊਂਡ ਹਟਾਓ"
+
+#~ msgid "Version %s"
+#~ msgstr "ਵਰਜ਼ਨ %s"
+
+#~ msgid "OS name"
+#~ msgstr "ਓ.ਸਿ. ਦਾ ਨਾਂ"
+
+#~ msgid "OS type"
+#~ msgstr "OS ਕਿਸਮ"
+
+#~ msgid "Disk"
+#~ msgstr "ਡਿਸਕ"
+
+#~ msgid "Check for updates"
+#~ msgstr "ਅੱਪਡੇਟ ਲਈ ਜਾਂਚ ਕਰੋ"
+
+#~ msgid "Network proxy"
+#~ msgstr "ਨੈੱਟਵਰਕ ਪਰਾਕਸੀ"
+
+#~ msgid "page 1"
+#~ msgstr "ਸਫ਼ਾ 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "ਅੰਦਰੂਨੀ ਪਰਮਾਣਕਿਤਾ(_a)"
+
+#~ msgid "page 2"
+#~ msgstr "ਸਫ਼ਾ 2"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "ਬੈਕਗਰਾਊਂਡ ਡਾਟਾ ਵਰਤੋਂ ਨੂੰ ਸੀਮਤ ਕਰੋ"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "ਕਨੈਕਸ਼ਨ, ਜਿਹਨਾਂ ਲਈ ਡਾਟਾ ਵਰਤਣ ਉੱਤੇ ਖ਼ਰਚੇ ਲੱਗਦੇ ਹਨ ਜਾਂ ਉਹਨਾਂ ਦੀ ਹੱਦ ਹੈ, ਲਈ ਢੁੱਕਵਾਂ।"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "ਟਵਿਸਟਡ ਪੇਅਰ (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "ਅਟੈਚਮੈਂਟ ਯੂਨਿਟ ਇੰਟਰਫੇਸ (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "ਮੀਡਿਆ ਇਡੀਪੈਂਡੈਂਟ ਇੰਟਰਫੇਸ (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "ਬੇਤਾਰ ਹਾਟਸਪਾਟ ਚਾਲੂ ਕਰਨ ਨਾਲ ਤੁਹਾਨੂੰ <b>%s</b> ਤੋਂ ਡਿਸ-ਕਨੈਕਟ ਕੀਤਾ ਜਾਵੇਗਾ।"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "ਤੁਹਾਡੇ ਬੇਤਾਰ ਰਾਹੀਂ ਇੰਟਰਨੈੱਟ ਵਰਤਣਾ ਸੰਭਵ ਨਹੀਂ ਹੈ, ਜਦੋਂ ਕਿ ਹਾਟਸਪਾਟ ਸਰਗਰਮ ਹੋਵੇ।"
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr "Wi-Fi ਹਾਟਸਪਾਟਾਂ ਨੂੰ Wi-Fi 'ਤੇ ਵਾਧੂ ਇੰਟਰਨੈੱਟ ਕਨੈਕਸ਼ਨ ਸਾਂਝਾ ਕਰਨ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ।"
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "ਆਟੋਮੈਟਿਕ ਕਨੈਕਟ ਕਰੋ(_C)"
+
+#~ msgid "details"
+#~ msgstr "ਵੇਰਵੇ"
+
+#~ msgid "Show P_assword"
+#~ msgstr "ਪਾਸਵਰਡ ਵੇਖੋ(_a)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "ਹੋਰ ਵਰਤੋਂਕਾਰ ਨੂੰ ਉਪਲੱਬਧ ਕਰਵਾਓ"
+
+#~ msgid "identity"
+#~ msgstr "ਪਛਾਣ"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "ਐਡਰੈੱਸ(_A)"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "ਆਟੋਮੈਟਿਕ (DHCP) ਐਡਰੈੱਸ ਹੀ"
+
+#~ msgid "Link-local only"
+#~ msgstr "ਕੇਵਲ ਲੋਕਲ-ਲਿੰਕ"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "ਆਟੋਮੈਟਿਕ ਲਏ ਰੂਟ ਅਣਡਿੱਠੇ ਕਰੋ(_i)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "ਕਨੋਲ ਕੀਤਾ MA_C ਐਡਰੈੱਸ"
+
+#~ msgid "_Reset"
+#~ msgstr "ਮੁਡ਼-ਸੈੱਟ(_R)"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "ਇਹ ਕਨੈਕਸ਼ਨ ਲਈ ਸੈਟਿੰਗ ਉਹਨਾਂ ਦੇ ਡਿਫਾਲਟ ਲਈ ਮੁੜ-ਸੈੱਟ ਕਰੋ, ਪਰ ਪਸੰਦੀਦਾ ਕਨੈਕਸ਼ਨ ਵਜੋਂ ਯਾਦ ਰੱਖੋ।"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "ਇਹ ਨੈੱਟਵਰਕ ਨਾਲ ਸਬੰਧਿਤ ਵੇਰਵਾ ਹਟਾਉ ਅਤੇ ਇਸ ਨਾਲ ਆਟੋਮੈਟਿਕ ਕਨੈਕਟ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਨਾ ਕਰੋ।"
+
+#~ msgid "Hardware"
+#~ msgstr "ਹਾਰਡਵੇਅਰ"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "ਮੁੜ-ਸੈੱਟ ਕਰੋ"
+
+#~ msgid "Connected Devices"
+#~ msgstr "ਕਨੈਕਟ ਹੋਏ ਜੰਤਰ"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "ਐਡ-ਹਾਕ"
+
+#~ msgid "Infrastructure"
+#~ msgstr "ਇੰਫਰਾਸਟੱਕਚਰ"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "ਨੋਟੀਫਿਕੇਸ਼ਨ ਪੋਪਅੱਪ(_P)"
+
+#~ msgid "In use"
+#~ msgstr "ਵਰਤੋਂ 'ਚ"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "ਚਾਲੂ"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "ਬੰਦ"
+
+#~| msgid "Off"
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "ਬੰਦ"
+
+#~| msgid "On"
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "ਚਾਲੂ"
+
+#~| msgid "Off"
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "ਬੰਦ"
+
+#~| msgid "On"
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "ਚਾਲੂ"
+
+#~ msgid "Usage & History"
+#~ msgstr "ਵਰਤੋਂ ਅਤੇ ਅਤੀਤ"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "ਪਰਦੇਦਾਰੀ ਨੀਤੀ"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "ਤੁਹਾਡੇ ਅਤੀਤ ਨੂੰ ਯਾਦ ਰੱਖਣ ਨਾਲ ਚੀਜ਼ਾਂ ਨੂੰ ਮੁੜ-ਲੱਭਣਾ ਸੌਖਾ ਹੋ ਜਾਂਦਾ ਹੈ। ਇਹ ਚੀਜ਼ਾਂ ਨੂੰ ਨੈੱਟਵਰਕ ਉੱਤੇ "
+#~ "ਕਦੇ ਵੀ ਸਾਂਝਾ ਨਹੀਂ ਕੀਤਾ ਜਾਂਦਾ ਹੈ।"
+
+#~ msgid "_Recently Used"
+#~ msgstr "ਤਾਜ਼ਾ ਵਰਤੇ(_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "ਅਤੀਤ ਪ੍ਰਾਪਤ(_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "ਸਕਰੀਨ ਲਾਕ ਤੁਹਾਡੀ ਪਰਦੇਦਾਰੀ ਨੂੰ ਬਚਾਉਂਦੀ ਹੈ, ਜਦੋਂ ਤੁਸੀਂ ਦੂਰ ਹੁੰਦੇ ਹੋ।"
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "ਖਾਲੀ ਰਹਿਣ ਦੇ ਬਾਅਦ ਮਗਰੋਂ ਸਕਰੀਨ ਲਾਕ(_a)"
+
+#~| msgid "_Lock Screen Notifications"
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "ਲਾਕ ਸਕਰੀਨ ਸੂਚਨਾਵਾਂ(_N)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "ਆਪਣੇ ਕੰਪਿਊਟਰ ਨੂੰ ਕਿਸੇ ਵੀ ਗ਼ੈਰ-ਜ਼ਰੂਰੀ ਸੰਵੇਦਨਸ਼ੀਲ ਜਾਣਕਾਰੀ ਤੋਂ ਮੁਕਤ ਰੱਖਣ ਲਈ ਮਦਦ ਵਾਸਤੇ ਰੱਦੀ ਅਤੇ "
+#~ "ਆਰਜ਼ੀ ਫਾਇਲਾਂ ਨੂੰ ਆਪਣੇ-ਆਪ ਨਸ਼ਟ ਕਰੋ"
+
+#~ msgid "Purge _After"
+#~ msgstr "ਇਸ ਦੇ ਬਾਅਦ ਨਸ਼ਟ ਕਰੋ(_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "ਸਾਨੂੰ ਤੁਹਾਡੇ ਵਲੋਂ ਵਰਤੇ ਜਾਂਦੇ ਸਾਫਟਵੇਅਰ ਬਾਰੇ ਜਾਣਕਾਰੀ ਭੇਜਣ ਨਾਲ ਸਾਨੂੰ ਤੁਹਾਡੀ ਹੋਰ ਵੀ ਠੀਕ ਢੰਗ "
+#~ "ਨਾਲ ਸਿਫਾਰਸ਼ ਕਰਨ ਲਈ ਮਦਦ ਹੋਵੇਗੀ। ਇਸ ਨਾਲ ਸਾਡੇ ਸਾਫਟਵੇਅਰ ਵਿੱਚ ਸੁਧਾਰ ਲਈ ਵੀ ਸਾਡੀ ਮਦਦ "
+#~ "ਹੋਵੇਗੀ।\n"
+#~ "\n"
+#~ "ਸਾਡੇ ਵਲੋਂ ਇੱਕਠੀ ਕੀਤੀ ਜਾਂਦੀ ਸਾਰੀ ਜਾਣਕਾਰੀ ਅਣਪਛਾਤੇ ਵਜੋਂ ਹੈ, ਅਤੇ ਅਸੀਂ ਤੁਹਾਡੇ ਡਾਟੇ ਨੂੰ ਕਿਸੇ ਵੀ "
+#~ "ਹੋਰ ਸੁਤੰਤਰ ਧਿਰ ਨਾਲ ਸਾਂਝਾ ਨਹੀਂ ਕਰੇਗੇ।"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "ਸਾਫਟਵੇਅਰ ਵਰਤੋਂ ਅੰਕੜੇ ਭੇਜੋ(_S)"
+
+#~| msgid "%s Camera"
+#~ msgid "_Camera"
+#~ msgstr "ਕੈਮਰਾ(_C)"
+
+#~| msgid "Microphone Volume"
+#~ msgid "_Microphone"
+#~ msgstr "ਮਾਈਕਰੋਫ਼ੋਨ(_M)"
+
+#~ msgid "_Location Services"
+#~ msgstr "ਟਿਕਾਣਾ ਸੇਵਾਵਾਂ(_L)"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "ਆਪਣੀ ਨਿੱਜੀ ਜਾਣਕਾਰੀ ਸੁਰੱਖਿਅਤ ਕਰੋ ਅਤੇ ਕੰਟਰੋਲ ਕਰੋ ਕਿ ਹੋਰ ਕੀ ਵੇਖ ਸਕਦੇ ਹਨ"
+
+#~ msgid "No regions found"
+#~ msgstr "ਕੋਈ ਖੇਤਰ ਨਹੀਂ ਲੱਭਿਆ"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "ਵਿੰਡੋ ਟਾਈਟਲ ਝਲਕਾਓ(_w)"
+
+#~ msgid "Last Login"
+#~ msgstr "ਆਖਰੀ ਲਾਗਇਨ"
+
+#~ msgid "_Background"
+#~ msgstr "ਬੈਕਗਰਾਊਂਡ(_B)"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "ਬਦਲਾਅ ਪੂਰੇ ਦਿਨ ਲਈ"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "ਟਾਈਲ"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "ਜ਼ੂਮ"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "ਸੈਂਟਰ"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "ਸਕੇਲ"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "ਭਰੋ"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "ਸਪੈਨ"
+
+#~ msgid "Colors"
+#~ msgstr "ਰੰਗ"
+
+#~ msgid "Pictures"
+#~ msgstr "ਤਸਵੀਰਾਂ"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "ਕੋਈ ਤਸਵੀਰ ਨਹੀਂ ਲੱਭੀ"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "ਤੁਸੀਂ ਆਪਣੇ %s ਫੋਲਡਰ ਵਿੱਚ ਚਿੱਤਰ ਸ਼ਾਮਿਲ ਕਰ ਸਕਦੇ ਹੋ ਅਤੇ ਉਹ ਇੱਥੇ ਵੇਖਾਈ ਦੇਣਗੇ"
+
+#~| msgid "Bluetooth"
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~| msgid "Preferences"
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "_Night Light"
+#~ msgstr "ਰਾਤ ਦੀ ਰੋਸ਼ਨੀ(_N)"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "ਸਕਰੀਨ ਜਾਣਕਾਰੀ ਲਈ ਨਹੀਂ ਜਾ ਸਕੀ"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "hardware"
+#~ msgstr "ਹਾਰਡਵੇਅਰ"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "_Mobile broadband"
+#~ msgstr "ਮੋਬਾਇਲ ਬਰਾਡਬੈਂਡ(_M)"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "ਆਟੋਮੈਟਿਕ ਸਸਪੈਂਡ(_A)"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "ਜਦੋਂ ਪਾਵਰ ਬਟਨ ਦੱਬਿਆ ਜਾਵੇ ਤਾਂ(_W):"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~| msgid "No printers"
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "ਪਿਛਲੇ ਸਰੋਤ ਲਈ ਬਦਲੋ"
+
+#~ msgid "Switch to next source"
+#~ msgstr "ਅਗਲੇ ਸਰੋਤ ਲਈ ਬਦਲੋ"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "ਅਗਲੇ ਸਰੋਤ ਲਈ ਬਦਲਵੀ ਸਵਿੱਚ"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "ਅੰਗਰੇਜ਼ੀ (ਬਰਤਾਨੀਆ)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "ਬਰਤਾਨੀਆ"
+
+#~ msgid "_Options"
+#~ msgstr "ਚੋਣਾਂ(_O)"
+
+#~ msgid "Add input source"
+#~ msgstr "ਇੰਪੁੱਟ ਸਰੋਤ ਜੋੜੋ"
+
+#~ msgid "Remove input source"
+#~ msgstr "ਇੰਪੁੱਟ ਸਰੋਤ ਹਟਾਓ"
+
+#~ msgid "Move input source up"
+#~ msgstr "ਇੰਪੁੱਟ ਸਰੋਤ ਉੱਤੇ ਭੇਜੋ"
+
+#~ msgid "Move input source down"
+#~ msgstr "ਇੰਪੁੱਟ ਸਰੋਤ ਹੇਠਾਂ ਭੇਜੋ"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "ਇੰਪੁੱਟ ਸਰੋਤ ਕੀਬੋਰਡ ਲੇਆਉਟ ਵੇਖਾਓ"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "ਖੱਬੇ"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "ਸੱਜੇ"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "ਘੱਟੋ-ਘੱਟ"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "ਵੱਧੋ-ਵੱਧ"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "ਸਬਵੂਫ਼ਰ(_S):"
+
+#~ msgid "_Profile:"
+#~ msgstr "ਪਰੋਫਾਇਲ(_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "ਸਪੀਕਰ ਟੈਸਟ ਕਰੋ(_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "ਪੀਕ ਖੋਜ"
+
+#~ msgid "Device"
+#~ msgstr "ਜੰਤਰ"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s ਲਈ ਸਪੀਕਰ ਟੈਸਟਿੰਗ"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "ਸਾਊਂਡ ਆਉਟਪੁੱਟ ਲਈ ਇੱਕ ਜੰਤਰ ਚੁਣੋ(_h):"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "ਚੁਣੇ ਜੰਤਰ ਲਈ ਸੈਟਿੰਗ:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "ਇੰਪੁੱਟ ਵਾਲੀਅਮ(_I): "
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "ਸਾਊਂਡ ਇੰਪੁੱਟ ਲਈ ਇੱਕ ਜੰਤਰ ਚੁਣੋ(_h):"
+
+#~ msgid "Sound Effects"
+#~ msgstr "ਸਾਊਂਡ ਪਰਭਾਵ"
+
+#~ msgid "_Alert volume:"
+#~ msgstr "ਚੇਤਾਵਨੀ ਵਾਲੀਅਮ(_A):"
+
+#~ msgid "Built-in"
+#~ msgstr "ਬਿਲਟ-ਇਨ"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ਸਾਊਂਡ ਪਸੰਦ"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ਘਟਨਾ ਸਾਊਂਡ ਟੈਸਟ"
+
+#~ msgid "From theme"
+#~ msgstr "ਥੀਮ ਤੋਂ"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "ਇੱਕ ਚੇਤਾਵਨੀ ਸਾਊਂਡ ਚੁਣੋ(_h):"
+
+#~ msgid "Stop"
+#~ msgstr "ਰੋਕੋ"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "ਨਵੇਂ ਪਾਸਵਰਡ ਦੀ ਪੁਸ਼ਟੀ(_V)"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "ਪਾਸਵਰਡ ਮਿਲਦਾ ਨਹੀਂ ਹੈ।"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "ਸਟੈਂਡਰਡ"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "ਪਰਸ਼ਾਸ਼ਕੀ"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ ”-” ਨਾਲ ਸ਼ੁਰੂ ਨਹੀਂ ਹੋ ਸਕਦਾ ਹੈ।"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "page 3"
+#~ msgstr "ਸਫ਼ਾ 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "ਗਨੋਮ ਕੰਟਰੋਲ ਕੇਂਦਰ"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "ਕੰਟਰੋਲ ਸੈਂਟਰ ਤੁਹਾਡੇ ਡੈਸਕਟਾਪ ਦੇ ਵੱਖ-ਵੱਖ ਪੱਖਾਂ ਦੀਆਂ ਸੰਰਚਨਾ ਕਰਨ ਵਾਸਤੇ ਗਨੋਮ ਦਾ ਮੁੱਖ ਇੰਟਰਫੇਸ ਹੈ।"
+
+#~ msgid "Show the overview"
+#~ msgstr "ਸਧਾਰਨ ਰੂਪ ਵੇਖਾਓ"
+
+#~ msgid "Quit"
+#~ msgstr "ਬਾਹਰ"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "Back­ground"
+#~ msgstr "ਬੈਕਗਰਾਊਂਡ"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "ਬਲੂਟੁੱਥ"
+
+#~ msgid "Co­lor"
+#~ msgstr "ਰੰਗ"
+
+#~ msgid "Overview"
+#~ msgstr "ਸੰਖੇਪ"
+
+#~| msgid "Default Applications"
+#~ msgid "Defa­ult Applications"
+#~ msgstr "ਡਿਫਾਲਟ ਐਪਲੀਕੇਸ਼ਨਾਂ"
+
+#~ msgid "Ab­out"
+#~ msgstr "ਇਸ ਬਾਰੇ"
+
+#~ msgid "De­tails"
+#~ msgstr "ਵੇਰਵੇ"
+
+#~| msgid "Removable Media"
+#~ msgid "Remo­vable Media"
+#~ msgstr "ਹਟਾਉਣਯੋਗ ਮੀਡਿਆ"
+
+#~ msgid "Net­work"
+#~ msgstr "ਨੈੱਟਵਰਕ"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "ਸੂਚਨਾਵਾਂ"
+
+#~ msgid "Po­wer"
+#~ msgstr "ਪਾਵਰ"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "ਪਰਦੇਦਾਰੀ"
+
+#~ msgid "Sha­ring"
+#~ msgstr "ਸਾਂਝ"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "ਯੂਨੀਵਰਸਲ ਅਸੈੱਸ"
+
+#~ msgid "Disable image"
+#~ msgstr "ਚਿੱਤਰ ਹਟਾਓ"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "…ਹੋਰ ਤਸਵੀਰਾਂ ਵੇਖੋ"
+
+#~ msgid "Used by %s"
+#~ msgstr "%s ਵਲੋਂ ਵਰਤੀ"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "ਵਾਕੋਮ ਟੇਬਲੇਟ"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "ਹਾਰਡਵੇਅਰ"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "ਸਿਸਟਮ"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Lid ਬੰਦ ਕੀਤਾ"
+
+#~ msgid "Mirrored"
+#~ msgstr "ਮਿਰਰ ਕੀਤੇ"
+
+#~ msgid "Secondary"
+#~ msgstr "ਸੈਕੰਡਰੀ"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "ਜੋੜੇ ਡਿਸਪਲੇਅ ਲਗਾਉ"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "ਡਿਸਪਲੇਅ ਦਾ ਪ੍ਰਬੰਧ ਕਰਨ ਲਈ ਖਿੱਚੋ (ਡਰੈਗ)"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "ਖੱਬੇ ਦਾਅ 90° ਘੁੰਮਾਓ"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "180° ਘੁੰਮਾਓ"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "ਸੱਜੇ ਦਾਅ 90° ਘੁੰਮਾਓ"
+
+#~ msgid "Size"
+#~ msgstr "ਅਕਾਰ"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "ਟਾਪ ਪੱਟੀ ਅਤੇ ਸਰਗਰਮੀ ਝਲਕ ਨੂੰ ਇਸ ਡਿਸਪਲੇਅ ਉੱਤੇ ਵੇਖਾਓ"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "ਵਾਧੂ ਵਰਕਸਪੇਸ ਬਣਾਉਣ ਲਈ ਡਿਸਪਲੇਅ ਨੂੰ ਹੋਰ ਨਾਲ ਜੋੜੋ"
+
+#~ msgid "Presentation"
+#~ msgstr "ਪਰਿਜ਼ੈੱਨਟੇਸ਼ਨ"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "ਕੇਵਲ ਸਲਾਈਡਸ਼ੋ ਤੇ ਮੀਡਿਆ ਹੀ ਵੇਖਾਓ"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "ਤੁਹਾਡੇ ਮੌਜੂਦਾ ਵਿਊ ਨੂੰ ਦੋਵੇਂ ਡਿਸਪਲੇਅ ਉੱਤੇ ਵੇਖਾਓ"
+
+#~ msgid "Turn Off"
+#~ msgstr "ਬੰਦ ਕਰੋ"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "ਇਹ ਡਿਸਪਲੇਅ ਨੂੰ ਨਾ ਵਰਤੋਂ"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "ਜੋੜੇ ਡਿਸਪਲੇਅ ਲਗਾਉ"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "ਏਅਰਪਲੇਨ ਮੋਡ(_p)"
+
+#~ msgid "Server"
+#~ msgstr "ਸਰਵਰ"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS ਸਰਵਰ ਹਟਾਓ"
+
+#~ msgid "Proxy"
+#~ msgstr "ਪਰਾਕਸੀ"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "…ਪਰੋਫਾਇਲ ਸ਼ਾਮਲ(_A)"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "ਦਸਤੀ"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "ਆਟੋਮੈਟਿਕ"
+
+#~ msgid "_Method"
+#~ msgstr "ਢੰਗ(_M)"
+
+#~ msgid "Add Device"
+#~ msgstr "ਜੰਤਰ ਸ਼ਾਮਲ"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN ਕਿਸਮ"
+
+#~ msgid "Group Name"
+#~ msgstr "ਗਰੁੱਪ ਨਾਂ"
+
+#~ msgid "Group Password"
+#~ msgstr "ਗਰੁੱਪ ਪਾਸਵਰਡ"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-ਬਿੱਟ (ਬਿਲਡ ID: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-ਬਿੱਟ"
+
+#~ msgid "Base system"
+#~ msgstr "ਬੇਸ ਸਿਸਟਮ"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "ਸ਼ਾਰਟਕੱਟ;ਦੁਹਰਾਉ;ਬਲਿੰਕ;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "ਰੱਦ ਕਰਨ ਲਈ Esc ਨੂੰ ਦੱਬੋ।"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "ਹੋਰ ਵਰਤੋਂਕਾਰ ਨੂੰ ਉਪਲੱਬਧ ਕਰਵਾਉ(_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "ਫਾਇਰਵਾਲ ਜ਼ੋਨ(_z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "ਡਿਫਾਲਟ"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "ਜ਼ੋਨ ਕੁਨੈਕਸ਼ਨ ਲਈ ਭਰੋਸੇਯੋਗਤਾ (ਟਰਸਟ ਲੈਵਲ) ਦਰਸਾਉਂਦਾ ਹੈ"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "ਇਹ ਨੈੱਟਵਰਕ ਲਈ ਸੈਟਿੰਗ, ਜਿਸ ਵਿੱਚ ਪਾਸਵਰਡ ਹਨ, ਨੂੰ ਮੁੜ-ਸੈੱਟ ਕਰੋ, ਪਰ ਪਸੰਦੀਦਾ ਨੈੱਟਵਰਕ ਵਜੋਂ ਯਾਦ "
+#~ "ਰੱਖੋ।"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr "ਇਹ ਨੈੱਟਵਰਕ ਨਾਲ ਸਬੰਧਿਤ ਵੇਰਵਾ ਹਟਾਉ ਅਤੇ ਆਟੋਮੈਟਿਕ ਕੁਨੈਕਟ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਨਾ ਕਰੋ।"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "ਜੇ ਤੁਸੀਂ ਬੇਤਾਰ ਤੋਂ ਬਿਨਾਂ ਕਿਸੇ ਹੋਰ ਤਰ੍ਹਾਂ ਇੰਟਰਨੈੱਟ ਨਾਲ ਕੁਨੈਕਟ ਹੋ ਤਾਂ ਤੁਸੀਂ ਇਸ ਨੂੰ ਹੋਰਾਂ ਨਾਲ ਆਪਣੇ "
+#~ "ਇੰਟਰਨੈੱਟ ਕੁਨੈਕਸ਼ਨ ਨੂੰ ਸਾਂਝਾ ਕਰਨ ਲਈ ਵਰਤ ਸਕਦੇ ਹੋ।"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "…ਹਾਟਸਪਾਟ ਵਜੋਂ ਵਰਤੋਂ(_U)"
+
+#~ msgid "_History"
+#~ msgstr "ਅਤੀਤ(_H)"
+
+#~ msgid "2"
+#~ msgstr "੨"
+
+#~ msgid "3"
+#~ msgstr "੩"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "ਹੋਰ ਅੱਖਰ, ਅੰਕ ਤੇ ਨਿਸ਼ਾਨ ਵਰਤ ਕੇ ਕੋਸ਼ਿਸ਼ ਕਰੋ।"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "ਮਜ਼ਬੂਤੀ: ਹਲਕਾ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "ਮਜ਼ਬੂਤੀ: ਘੱਟ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "ਮਜ਼ਬੂਤੀ: ਮੱਧਮ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "ਮਜ਼ਬੂਤੀ: ਚੰਗੀ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "ਮਜ਼ਬੂਤੀ: ਉੱਚ"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "ਸ਼ਾਰਟਕੱਟ ਸੋਧਣ ਲਈ, ਕਤਾਰ ਕਲਿੱਕ ਕਰੋ ਅਤੇ ਨਵੀਆਂ ਸਵਿੱਚ ਹੋਲਡ ਕਰਕੇ ਰੱਖੋ ਜਾਂ ਬੈਕਸਪੇਸ ਸਾਫ਼ ਕਰਨ ਲਈ "
+#~ "ਵਰਤੋਂ।"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "ਸੂਚਨਾਵਾਂ ਬੈਨਰ(_B)"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "ਸੂਚਨਾਵਾਂ ਬੈਨਰ(_B)"
+
+#~ msgid "Add Account"
+#~ msgstr "ਅਕਾਊਂਟ ਜੋੜੋ"
+
+#~ msgid "Mail"
+#~ msgstr "ਮੇਲ"
+
+#~| msgid "_Calendar"
+#~ msgid "Calendar"
+#~ msgstr "ਕੈਲੰਡਰ"
+
+#~ msgid "Contacts"
+#~ msgstr "ਸੰਪਰਕ"
+
+#~ msgid "Chat"
+#~ msgstr "ਗੱਲਬਾਤ"
+
+#~ msgid "Error creating account"
+#~ msgstr "ਅਕਾਊਂਟ ਬਣਾਉਣ ਦੌਰਾਨ ਗਲਤੀ"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "ਕੀ ਤੁਸੀਂ ਅਕਾਊਂਟ ਹਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "ਇਹ ਸਰਵਰ ਤੋਂ ਅਕਾਊਂਟ ਨਹੀਂ ਹਟਾਏਗਾ।"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "ਕੋਈ ਆਨਲਾਈਨ ਅਕਾਊਂਟ ਸੰਰਚਿਤ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Add an online account"
+#~ msgstr "ਆਨਲਾਈਨ ਅਕਾਊਂਟ ਸ਼ਾਮਿਲ"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "ਅਕਾਊਂਟ ਸ਼ਾਮਿਲ ਕਰਨ ਨਾਲ ਤੁਹਾਡੀਆਂ ਐਪਲੀਕੇਸ਼ਨ ਉਸ ਲਈ ਡੌਕੂਮੈਂਟ, ਮੇਲ, ਸੰਪਰਕ, ਕੈਲੰਡਰ, ਚੈਟ ਅਤੇ ਹੋਰ "
+#~ "ਚੀਜ਼ਾਂ ਵਰਤ ਸਕਦੀਆਂ ਹਨ।"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "ਸੰਰਚਨਾ ਜਾਰੀ"
+
+#~ msgid "Toner Level"
+#~ msgstr "ਟੋਨਰ ਲੈਵਲ"
+
+#~ msgid "Supply Level"
+#~ msgstr "ਸਪਲਾਈ ਲੈਵਲ"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "ਇੰਸਟਾਲ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u ਸਰਗਰਮ"
+#~ msgstr[1] "%u ਸਰਗਰਮ"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "ਨਵਾਂ ਪਰਿੰਟਰ ਸ਼ਾਮਲ"
+
+#~ msgid "No printers detected."
+#~ msgstr "ਕੋਈ ਪਰਿੰਟਰ ਨਹੀਂ ਮਿਲਿਆ।"
+
+#~ msgid "Supply"
+#~ msgstr "ਸਪਲਾਈ"
+
+#~ msgid "Jobs"
+#~ msgstr "ਜਾਬ"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "ਜਾਬ ਵੇਖਾਉ(_J)"
+
+#~ msgid "label"
+#~ msgstr "ਲੇਬਲ"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "ਟੈਸਟ ਪੇਜ਼ ਪਰਿੰਟ ਕਰੋ(_T)"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "ਹੋਰ ਅਕਾਊਂਟ"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "ਉੱਤੇ"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "ਹੇਠਾਂ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ"
+
+#~ msgid "Left Ring"
+#~ msgstr "ਖੱਬੀ ਰਿੰਗ"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "ਖੱਬਾ ਰਿੰਗ ਉਂਗਲ ਮੋਡ #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "ਸੱਜੀ ਰਿੰਗ ਉਂਗਲ ਮੋਡ #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "ਖੱਬਾ ਟੱਚਸਟਰਿਪ"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "ਖੱਬਾ ਟੱਚਸਟਰਿਪ ਮੋਡ #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "ਸੱਜਾ ਟੱਚਸਟਰਿਪ"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "ਸੱਜਾ ਟੱਚਸਟਰਿਪ ਮੋਡ #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "ਖੱਬਾ ਟਾਰਚਿੰਗ ਮੋਡ ਬਦਲੋ"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "ਸੱਜਾ ਟਾਰਚਿੰਗ ਮੋਡ ਬਦਲੋ"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "ਖੱਬਾ ਟੱਚਸਟਰਿਪ ਮੋਡ ਬਦਲੋ"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "ਸੱਜਾ ਟੱਚਸਟਰਿਪ ਮੋਡ ਬਦਲੋ"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "ਮੋਡ ਬਦਲੋ #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "ਖੱਬਾ ਬਟਨ #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "ਸੱਜਾ ਬਟਨ #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "ਟਾਪ ਬਟਨ #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "ਤਲ ਬਟਨ #%d"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "ਖੱਬਾ ਮਾਊਸ ਬਟਨ ਕਲਿੱਕ"
+
+#~ msgid "Scroll Up"
+#~ msgstr "ਉੱਤੇ ਸਕਰੋਲ"
+
+#~ msgid "Scroll Down"
+#~ msgstr "ਹੇਠਾਂ ਸਕਰੋਲ"
+
+#~ msgid "Scroll Right"
+#~ msgstr "ਸੱਜਾ ਸਕਰੋਲ"
+
+#~ msgid "C_ommand:"
+#~ msgstr "ਕਮਾਂਡ(_o):"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<ਅਣਜਾਣੀ ਕਾਰਵਾਈ>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "ਸ਼ਾਰਟਕੱਟ \"%s\" ਨੂੰ ਵਰਤਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਹੈ, ਕਿਉਂਕਿ ਇਹ ਸਵਿੱਚ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਲਿਖਣਾ ਮੁਸ਼ਕਿਲ "
+#~ "ਹੋ ਜਾਵੇਗਾ।\n"
+#~ "ਇੱਕ ਅਜੇਹੀ ਸਵਿੱਚ ਨਾਲ ਕੋਸ਼ਿਸ਼ ਕਰੋ, ਜਿਸ ਵਿੱਚ ਇੱਕ ਸਮੇਂ Control, Alt ਜਾਂ Shift ਇੱਕਠੇ ਹੋਣ।"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "ਸ਼ਾਰਟਕੱਟ \"%s\" ਪਹਿਲਾਂ ਹੀ ਵਰਤਿਆ ਜਾ ਰਿਹਾ ਹੈ\n"
+#~ " \"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "ਜੇ ਤੁਸੀਂ ਸ਼ਾਰਟਕੱਟ \"%s\" ਲਈ ਦਿੱਤਾ ਤਾਂ \"%s\" ਸ਼ਾਰਟਕੱਟ ਆਯੋਗ ਹੋ ਜਾਵੇਗਾ।"
+
+#~ msgid "_Reassign"
+#~ msgstr "ਮੁੜ-ਜਾਰੀ(_R)"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "ਸ਼ਾਰਟਕੱਟ \"%s\" ਨਾਲ ਸੰਬੰਧਿਤ \"%s\" ਸ਼ਾਰਟਕ਼ਟ ਹੈ। ਕੀ ਤੁਸੀਂ ਇਸ ਨੂੰ \"%s\" ਲਈ ਆਟੋਮੈਟਿਕ ਸੈੱਟ "
+#~ "ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" ਇਸ ਸਮੇਂ \"%s\" ਨਾਲ ਸੰਬੰਧਿਤ ਹੈ, ਇਹ ਸ਼ਾਰਟਕੱਟ ਨੂੰ ਅਸਮਰੱਥ ਕਰ ਦਿੱਤਾ ਜਾਵੇਗਾ, ਜੇ ਤੁਸੀਂ "
+#~ "ਅੱਗੇ ਜਾਰੀ ਰੱਖਿਆ।"
+
+#~ msgid "_Assign"
+#~ msgstr "ਮੁੜ-ਜਾਰੀ(_A)"
+
+#~ msgid "Bond"
+#~ msgstr "ਬੌਂਡ"
+
+#~ msgid "Team"
+#~ msgstr "ਟੀਮ"
+
+#~ msgid "Bridge"
+#~ msgstr "ਬਰਿੱਜ਼"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN ਪਲੱਗਇਨ ਲੋਡ ਨਹੀਂ ਕੀਤੀਆਂ ਜਾ ਸਕੀਆਂ"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "ਨੈੱਟਵਰਕ ਕੁਨੈਕਸ਼ਨ ਸ਼ਾਮਲ"
+
+#~ msgid "Bond slaves"
+#~ msgstr "ਬੌਂਡ ਸਲੇਵ"
+
+#~ msgid "(none)"
+#~ msgstr "(ਕੋਈ ਨਹੀਂ)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "ਬਰਿੱਜ ਸਲੇਵ"
+
+#~ msgid "Team slaves"
+#~ msgstr "ਟੀਮ ਸਲੇਵ"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "ਇੰਫੀਬੀਮ ਜੰਤਰ ਕੁਨੈਕਟ ਕੀਤੇ ਮੋਡ ਵਿੱਚ ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "ਕੋਈ ਸਰਟੀਫਿਕੇਟ ਅਥਾਰਟੀ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਚੁਣਿਆ"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "ਸਰਟੀਫਿਕੇਟ ਅਥਾਰਟੀ (CA) ਸਰਟੀਫਿਕੇਟ ਦੀ ਵਰਤੋਂ ਨਾ ਕਰਨ ਨਾਲ ਕੁਨੈਕਸ਼ਨ ਅਸੁਰੱਖਿਅਤ, ਠੱਗ ਵਾਈ-ਫਾਈ "
+#~ "ਨੈੱਟਵਰਕ ਹੋ ਸਕਦੇ ਹਨ। ਕੀ ਤੁਸੀਂ ਸਰਟੀਫਿਕੇਟ ਅਥਾਰਟੀ ਸਰਟੀਫਿਕੇਟ ਚੁਣਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "Ignore"
+#~ msgstr "ਅਣਡਿੱਠਾ"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA ਸਰਟੀਫਿਕੇਟ ਚੁਣੋ"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "ਹਰ ਵਾਰ ਇਹ ਪਾਸਵਰਡ ਪੁੱਛੋ(_k)"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "ਮੈਨੂੰ ਫੇਰ ਸਾਵਧਾਨ ਨਾ ਕਰੋ(_w)"
+
+#~ msgid "Yes"
+#~ msgstr "ਹਾਂ"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "ਅਕਾਊਂਟ ਵਿੱਚ ਲਾਗਇਨ ਵਿੱਚ ਲਾਗਇਨ ਕਰਨ ਦੌਰਾਨ ਗਲਤੀ"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "ਸਨਦ ਦੀ ਮਿਆਦ ਪੁੱਗੀ।"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "ਇਹ ਅਕਾਊਂਟ ਚਾਲੂ ਕਰਨ ਲਈ ਸਾਇਨ ਕਰੋ।"
+
+#~ msgid "_Sign In"
+#~ msgstr "ਸਾਇਨ ਇਨ(_S)"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "ਤੁਹਾਡਾ ਭੂਗੋਲਿਕ ਟਿਕਾਣਾ ਪਤਾ ਲਗਾਉਣ ਲਈ ਵਰਤੀਆਂ ਜਾਂਦੀਆਂ ਹਨ"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "ਹੋਰ"
+
+#~ msgid "_Verify"
+#~ msgstr "ਜਾਂਚ(_V)"
+
+#~ msgid "Login History"
+#~ msgstr "ਲਾਗਇਨ ਅਤੀਤ"
+
+#~ msgid "Add User Account"
+#~ msgstr "ਯੂਜ਼ਰ ਅਕਾਊਂਟ ਸ਼ਾਮਲ"
+
+#~ msgid "Login Options"
+#~ msgstr "ਲਾਗਇਨ ਚੋਣ"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "'%s' ਯੂਜ਼ਰ ਨਾਂ ਨਾਲ ਯੂਜ਼ਰ ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹੈ।"
+
+#~ msgid "Done"
+#~ msgstr "ਮੁਕੰਮਲ"
+
+#~ msgid "Time _Zone"
+#~ msgstr "ਸਮਾਂ ਖੇਤਰ(_Z)"
+
+#~ msgid "_Delay:"
+#~ msgstr "ਦੇਰੀ(_D):"
+
+#~ msgid "_Speed:"
+#~ msgstr "ਸਪੀਡ(_S):"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "ਛੋਟਾ"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "ਹੌਲੀ"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "ਲੰਮਾ"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "ਤੇਜ਼"
+
+#~ msgid "S_peed:"
+#~ msgstr "ਸਪੀਡ(_p):"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "ਆਪਣੀ ਸੈਟਿੰਗ ਜਾਂਚੋ"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "ਹੌਲੀ"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "ਤੇਜ਼"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "ਖੱਬੇ(_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "ਸੱਜੇ(_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "ਪੁਆਇੰਟਰ ਸਪੀਡ(_P)"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ਹੌਲੀ"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "ਤੇਜ਼"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ਹੌਲੀ"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "ਤੇਜ਼"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "ਬੇਤਾਰ ਜੰਤਰ ਲਈ ਵਾਧੂ ਪਾਵਰ ਚਾਹੀਦੀ ਹੈ"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "ਜਦੋਂ ਬੈਟਰੀ ਪਾਵਰ ਨਾਜ਼ੁਕ ਰੂਪ 'ਚ ਘੱਟ ਹੋਵੇ (_c)"
+
+#~ msgid "No printers available"
+#~ msgstr "ਕੋਈ ਪਰਿੰਟਰ ਉਪਲੱਬਧ ਨਹੀਂ"
+
+#~ msgid "Resume Printing"
+#~ msgstr "ਪਰਿੰਟਿੰਗ ਮੁੜ-ਚਾਲੂ"
+
+#~ msgid "Pause Printing"
+#~ msgstr "ਪਰਿੰਟਿੰਗ ਰੋਕੋ"
+
+#~ msgid "Cancel Print Job"
+#~ msgstr "ਪਰਿੰਟ ਜਾਬ ਰੱਦ ਕਰੋ"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "ਹੋਲਡ"
+
+#~ msgid "Job Title"
+#~ msgstr "ਜਾਬ ਟਾਈਟਲ"
+
+#~ msgid "Job State"
+#~ msgstr "ਜਾਬ ਹਾਲਤ"
+
+#~ msgid "Add New Printer"
+#~ msgstr "ਨਵਾਂ ਪਰਿੰਟਰ ਸ਼ਾਮਲ"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr "ਬਲਿਉਟੁੱਥ ਸਾਂਝਾ ਕਰਨ ਨਾਲ ਤੁਸੀਂ ਬਲਿਊਟੁੱਥ ਰੱਖਣ ਵਾਲੇ ਜੰਤਰਾਂ ਉੱਤੇ ਫਾਇਲਾਂ ਸਾਂਝੀਆਂ ਕਰ ਸਕਦੇ ਹੋ"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "ਕੇਵਲ ਟਰੱਸਟ ਕੀਤੇ ਜੰਤਰਾਂ ਤੋਂ ਹੀ ਪ੍ਰਾਪਤ ਕਰੋ"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "ਪ੍ਰਾਪਤ ਕੀਤੀਆਂ ਫਾਇਲਾਂ ਨੂੰ ਡਾਊਨਲੋਡ ਫੋਲਡਰ ਵਿੱਚ ਸੰਭਾਲੋ"
+
+#~ msgid "Password:"
+#~ msgstr "ਪਾਸਵਰਡ:"
+
+#~ msgid "Zoom"
+#~ msgstr "ਜ਼ੂਮ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "ਰੰਗ"
+
+#~ msgid "Show help options"
+#~ msgstr "ਮੱਦਦ ਚੋਣ ਵੇਖੋ"
+
+#~ msgid "- Settings"
+#~ msgstr "- ਸੈਟਿੰਗ"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+
+#~ msgid "United States"
+#~ msgstr "ਅਮਰੀਕਾ"
+
+#~ msgid "Germany"
+#~ msgstr "ਜਰਮਨੀ"
+
+#~ msgid "France"
+#~ msgstr "ਫਰਾਂਸ"
+
+#~ msgid "Spain"
+#~ msgstr "ਸਪੇਨ"
+
+#~ msgid "China"
+#~ msgstr "ਚੀਨ"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "ਲਿਖਣ ਦੌਰਾਨ ਬੰਦ ਕਰੋ(_t)"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "ਸਿਸਟਮ ਨੈੱਟਵਰਕ ਸਰਵਿਸ ਇਸ ਵਰਜਨ ਨਾਲ ਕੰਮ ਨਹੀਂ ਕਰਦੀ ਹੈ।"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "ਪੋਪਅੱਪ ਬੈਨਰ ਵੇਖਾਓ"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "ਲਾਕ ਸਕਰੀਨ ਵਿੱਚ ਵੇਖਾਓ"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "ਪੋਪ ਅੱਪ ਬੈਨਰ ਵੇਖਾਓ"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "ਬੇਤਾਰ ਜੰਤਰ ਬੰਦ ਹਨ"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "ਪਰਿੰਟਰ ਦਾ ਐਡਰੈਸ ਦਿਉ ਜਾਂ ਨਤੀਜੇ ਛਾਣਨ ਲਈ ਸ਼ਬਦ ਦਿਉ"
+
+#~ msgid "Sorry"
+#~ msgstr "ਅਫਸੋਸ"
+
+#~ msgid "Immediately"
+#~ msgstr "ਤੁਰੰਤ"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "ਇਹ ਨੈੱਟਵਰਕ ਉੱਤੇ ਮੀਡਿਆ ਸਾਂਝਾ ਕਰੋ"
+
+#~ msgid "Shared Folders"
+#~ msgstr "ਸਾਂਝੇ ਕੀਤੇ ਫੋਲਡਰ"
+
+#~ msgid "column"
+#~ msgstr "ਕਾਲਮ"
+
+#~ msgid "Remove Folder"
+#~ msgstr "ਫੋਲਡਰ ਹਟਾਓ"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "ਇਹ ਨੈੱਟਵਰਕ ਉੱਤੇ ਪਬਲਿਕ ਫੋਲਡਰ ਸਾਂਝਾ ਕਰੋ"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "ਨਵਾਂ ਜੰਤਰ ਸੈੱਟਅੱਪ"
+
+#~ msgid "Paired"
+#~ msgstr "ਪੇਅਰ ਕੀਤੇ"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "ਮਾਊਸ ਤੇ ਟੱਚਪੈਡ ਸੈਟਿੰਗ"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "ਕੀਬੋਰਡ ਸੈਟਿੰਗ"
+
+#~ msgid "Send Files…"
+#~ msgstr "...ਫਾਇਲਾਂ ਭੇਜੋ"
+
+#~ msgid "Visibility"
+#~ msgstr "ਦਿੱਖ"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” ਦੀ ਦਿੱਖ"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "ਕੀ ਜੰਤਰਾਂ ਦੀ ਲਿਸਟ ਵਿੱਚੋਂ '%s' ਨੂੰ ਹਟਾਉਣਾ ਹੈ?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr "ਜੇ ਤੁਸੀਂ ਜੰਤਰ ਹਟਾਇਆ ਤਾਂ ਤੁਹਾਨੂੰ ਇਸ ਨੂੰ ਅਗਲੀ ਵਾਰ ਵਰਤਣ ਸਮੇਂ ਸੈੱਟਅੱਪ ਕਰਨਾ ਪਵੇਗਾ।"
+
+#~ msgid "Device type:"
+#~ msgstr "ਜੰਤਰ ਕਿਸਮ:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "ਨਿਰਮਾਤਾ:"
+
+#~ msgid "Model:"
+#~ msgstr "ਮਾਡਲ:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "ਉੱਤੇ ਦਿੱਤੇ ਖੇਤਰ ਆਟੋਮੈਟਿਕ ਭਰਨ ਲਈ ਚਿੱਤਰ ਫਾਇਲਾਂ ਨੂੰ ਇਸ ਵਿੰਡੋ ਉੱਤੇ ਸੁੱਟਿਆ ਜਾ ਸਕਦਾ ਹੈ।"
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "ਆਪਣੇ ਪ੍ਰਾਇਮਰੀ ਡਿਸਪਲੇਅ ਨੂੰ ਇਸ ਸਕਰੀਨ ਉੱਤੇ ਵੀ ਵੇਖਾਓ"
+
+#~ msgid "Combine"
+#~ msgstr "ਜੋੜੋ"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "ਵਾਧੂ ਥਾਂ ਬਣਾਉਣ ਲਈ ਪ੍ਰਾਇਮਰੀ ਡਿਸਪਲੇਅ ਨਾਲ ਜੋੜੋ"
+
+#~ msgid "Don't use the display"
+#~ msgstr "ਡਿਸਪਲੇਅ ਵਰਤਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ"
+
+#~ msgid "Install Updates"
+#~ msgstr "ਅੱਪਡੇਟ ਇੰਸਟਾਲ ਕਰੋ"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "ਸਿਸਟਮ ਅੱਪ-ਟੂ-ਡੇਟ ਹੈ"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "ਮਾਊਸ ਪਸੰਦ"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "ਨਵੀਂ ਸਰਵਿਸ ਲਈ ਵਰਤਣ ਵਾਸਤੇ ਇੰਟਰਫੇਸ ਚੁਣੋ"
+
+#~ msgid "C_reate…"
+#~ msgstr "…ਬਣਾਓ(_r)"
+
+#~ msgid "_Interface"
+#~ msgstr "ਇੰਟਰਫੇਸ(_i)"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "ਨੈੱਟਵਰਕ ਪਰਿੰਟਰ ਲੱਭੋ ਜਾਂ ਨਤੀਜਾ ਫਿਲਟਰ ਕਰੋ"
+
+#~ msgid "_Default"
+#~ msgstr "ਡਿਫਾਲਟ(_D)"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "ਪਬਲਿਕ ਫੋਲਡਰ ਸਾਂਝਾ ਕਰੋ"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "ਟਰਸਟ ਕੀਤੇ ਜੰਤਰਾਂ ਨਾਲ ਹੀ ਸਾਂਝਾ ਕਰੋ"
+
+#~ msgid "Remote View"
+#~ msgstr "ਰਿਮੋਟ ਝਲਕ"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "ਸਭ ਕੁਨੈਕਸ਼ਨ ਮਨਜ਼ੂਰ"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "ਫੋਟੋ ਬਦਲੀ ਜਾ ਰਹੀ ਹੈ:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "ਤਸਵੀਰ ਚੁਣੋ, ਜੋ ਕਿ ਇਸ ਅਕਾਊਂਟ ਲਈ ਲਾਗਇਨ ਸਕਰੀਨ ਉੱਤੇ ਵੇਖਾਈ ਜਾਵੇਗੀ।"
+
+#~ msgid "Gallery"
+#~ msgstr "ਗੈਲਰੀ"
+
+#~ msgid "Take a photograph"
+#~ msgstr "ਫੋਟੋ ਲਵੋ"
+
+#~ msgid "Browse"
+#~ msgstr "ਝਲਕ"
+
+#~ msgid "Photograph"
+#~ msgstr "ਤਸਵੀਰ"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "ਅੰਦਾਜ਼ਨ ਬੈਟਰੀ ਸਮੱਰਥਾ: %s"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "AM ਅਤੇ PM ਵਿੱਚ ਬਦਲੋ।"
+
+#~ msgid "Export"
+#~ msgstr "ਐਕਸਪੋਰਟ"
+
+#~ msgid "Left Shift"
+#~ msgstr "ਖੱਬਾ Shift"
+
+#~ msgid "Right Shift"
+#~ msgstr "ਸੱਜਾ Shift"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "ਖੱਬਾ Alt+Shift"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "ਸੱਜਾ Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "ਖੱਬਾ Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "ਸੱਜਾ Ctrl+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "ਖੱਬਾ+ਸੱਜਾ Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Left+ਸੱਜਾ Ctrl"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "_Region:"
+#~ msgstr "ਖਿੱਤਾ(_R):"
+
+#~ msgid "_City:"
+#~ msgstr "ਸ਼ਹਿਰ(_C):"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "ਸਮਾਂ ਇੱਕ ਘੰਟਾ ਅੱਗੇ ਸੈੱਟ ਕਰੋ।"
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "ਸਮਾਂ ਇੱਕ ਘੰਟਾ ਪਿੱਛੇ ਸੈੱਟ ਕਰੋ।"
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "ਸਮਾਂ ਇੱਕ ਮਿੰਟ ਅੱਗੇ ਸੈੱਟ ਕਰੋ।"
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "ਸਮਾਂ ਇੱਕ ਮਿੰਟ ਪਿੱਛੇ ਸੈੱਟ ਕਰੋ।"
+
+#~ msgid "AM/PM"
+#~ msgstr "ਸਵੇਰ/ਸ਼ਾਮ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "ਸਧਾਰਨ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "ਸੱਜੇ ਦਾਅ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 ਡਿਗਰੀ"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "ਮਾਨੀਟਰ ਦੀ ਵਿਸ਼ੇਸ਼ਤਾ ਬਦਲਣ ਲਈ ਇਹ ਚੁਣੋ; ਇਸ ਦੀ ਸਥਿਤੀ ਬਦਲਣ ਲਈ ਡਰੈਗ ਕਰੋ।"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "ਮਾਨੀਟਰ ਸੰਰਚਨਾ ਸੰਭਾਲੀ ਨਹੀਂ ਜਾ ਸਕੀ"
+
+#~ msgid "_Resolution"
+#~ msgstr "ਰੈਜ਼ੋਲੇਸ਼ਨ(_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "ਘੁੰਮਣ(_o)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "ਮਿੱਰਰ ਡਿਸਪਲੇਅ(_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "ਨੋਟ: ਰੈਜ਼ੋਲੂਸ਼ਨ ਚੋਣਾਂ ਸੀਮਿਤ ਹੋ ਸਕਦੀਆਂ ਹਨ"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "ਹੌਲੀ"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "ਤੇਜ਼"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "ਉਂਗਲਾਂ ਨਾਲ ਸਮੱਗਰੀ ਸਟਿੱਕ(_o)"
+
+#~ msgid "_Options…"
+#~ msgstr "…ਚੋਣਾਂ(_O)"
+
+#~ msgid "blablabla"
+#~ msgstr "ਯਾਯਾ"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "ਐਡਰੈਸ\n"
+#~ "ਭਾਗ\n"
+#~ "ਇੱਥੇ\n"
+#~ "ਆਵੇਗਾ"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "ਡੀਐਨਐਸ\n"
+#~ "ਭਾਗ\n"
+#~ "ਇੱਥੇ\n"
+#~ "ਆਵੇਗਾ"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "ਰੂਟ\n"
+#~ "ਭਾਗ\n"
+#~ "ਇੱਥੇ\n"
+#~ "ਆਵੇਗਾ"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "Hidden"
+#~ msgstr "ਲੁਕਵਾਂ"
+
+#~ msgid "Visible"
+#~ msgstr "ਦਿੱਖ"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "ਨਾਂ ਤੇ ਦਿੱਖ"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "ਕੰਟਰੋਲ ਕਰੋ ਕਿ ਤੁਸੀਂ ਸਕਰੀਨ ਅਤੇ ਨੈੱਟਵਰਕ ਉੱਤੇ ਕਿਵੇਂ ਵਿਖਾਈ ਦਿਉਂਗੇ।"
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "ਉੱਪਰੀ ਪੱਟੀ ਵਿੱਚ ਪੂਰਾ ਨਾਂ ਵੇਖਾਉ(_f)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "ਲਾਕ ਸਕਰੀਨ ਵਿੱਚ ਪੂਰਾ ਨਾਂ ਵੇਖਾਉ(_l)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "ਲੁਕਵਾਂ ਮੋਡ(_S)"
+
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ"
+
+#~ msgid "No shortcut set"
+#~ msgstr "ਸ਼ਾਰਟਕੱਟ ਸੈੱਟ ਨਹੀਂ ਹੈ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "ਆਮ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "ਉੱਚ/ਉਲਟ"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "ਆਨ-ਸਕਰੀਨ ਕੀਬੋਰਡ"
+
+#~ msgid "OnBoard"
+#~ msgstr "ਆਨ-ਬੋਰਡ"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "੧੦੦%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "ਆਮ"
+
+#~ msgid "125%"
+#~ msgstr "੧੨੫%"
+
+#~ msgid "150%"
+#~ msgstr "੧੫੦%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "ਬੀਪ ਕੈਪਸ ਤੇ ਨਮ ਲਾਕ ਸਮੇਂ"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "ਚਾਲੂ ਜਾਂ ਬੰਦ:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "ਜ਼ੂਮ"
+
+#~ msgid "Zoom in:"
+#~ msgstr "ਜ਼ੂਮ ਇਨ:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "ਜ਼ੂਮ ਆਉਟ:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "ਬੰਦ ਹੋਈ ਸੁਰਖੀ"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "ਸਪੀਚ ਤੇ ਸਾਊਂਡ ਦੇ ਵੇਰਵੇ ਲਈ ਟੈਕਸਟ ਵੇਖਾਓ।"
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "ਆਨ ਸਕਰੀਨ ਕੀਬੋਰਡ"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "ਛੋਟਾ"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "ਲੰਮਾ"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "ਬੀਪ, ਜਦੋਂ ਸਵਿੱਚ ਹੋਵੇ"
+
+#~ msgid "pressed"
+#~ msgstr "ਦੱਬਿਆ"
+
+#~ msgid "accepted"
+#~ msgstr "ਮਨਜ਼ੂਰ ਕੀਤਾ"
+
+#~ msgid "rejected"
+#~ msgstr "ਰੱਦ ਕੀਤਾ"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "ਮਨਜ਼ੂਰ ਦੇਰੀ(_e):"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "ਕੀਪੈਡ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਪੁਆਇੰਟਰ ਕੰਟਰੋਲ ਕਰੋ"
+
+#~ msgid "Video Mouse"
+#~ msgstr "ਵਿਡੀਓ ਮਾਊਸ"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "ਵਿਡੀਓ ਕੈਮਰੇ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਪੁਆਇੰਟਰ ਕੰਟਰੋਲ ਕਰੋ।"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "ਛੋਟਾ"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "ਵੱਡਾ"
+
+#~ msgid "_Local Account"
+#~ msgstr "ਲੋਕਲ ਅਕਾਊਂਟ(_L)"
+
+#~ msgid "_Login Name"
+#~ msgstr "ਲਾਗਇਨ ਨਾਂ(_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "ਇਸ਼ਾਰਾ: ਇੰਟਰਪਰਾਈਜ਼ ਡੋਮੇਨ ਜਾਂ ਰੀਲੇਮ ਨਾਂ"
+
+#~ msgid "C_ontinue"
+#~ msgstr "ਜਾਰੀ ਰੱਖੋ(_o)"
+
+#~ msgid "Next Week"
+#~ msgstr "ਅਗਲਾ ਹਫ਼ਤਾ"
+
+#~ msgid "Next week"
+#~ msgstr "ਹਫ਼ਤਾ ਅੱਗੇ"
+
+#~ msgid "Log in without a password"
+#~ msgstr "ਬਿਨਾਂ ਪਾਸਵਰਡ ਲਾਗਇਨ ਕਰੋ"
+
+#~ msgid "Disable this account"
+#~ msgstr "ਇਹ ਅਕਾਊਂਟ ਅਯੋਗ"
+
+#~ msgid "Enable this account"
+#~ msgstr "ਇਹ ਅਕਾਊਂਟ ਚਾਲੂ ਹੈ"
+
+#~ msgid "_Action"
+#~ msgstr "ਐਕਸ਼ਨ(_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "ਪਾਸਵਰਡ ਵੇਖੋ(_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "ਵਧੀਆ ਪਾਸਵਰਡ ਕਿਵੇਂ ਬਣਾਈਏ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "ਬਹੁਤ ਛੋਟਾ ਹੈ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "ਚੰਗਾ ਨਹੀਂ ਹੈ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "ਹਲਕਾ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "ਠੀਕ-ਠਾਕ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "ਚੰਗਾ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "ਤਕੜਾ"
+
+#~ msgid "_Generate a password"
+#~ msgstr "ਪਾਸਵਰਡ ਤਿਆਰ ਕਰੋ(_G)"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "ਤੁਹਾਨੂੰ ਨਵਾਂ ਪਾਸਵਰਡ ਦੇਣ ਦੀ ਲੋੜ ਹੈ"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "ਨਵਾਂ ਪਾਸਵਰਡ ਬਹੁਤ ਮਜ਼ਬੂਤ ਨਹੀਂ ਹੈ"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "ਤੁਹਾਨੂੰ ਪਾਸਵਰਡ ਦੀ ਪੁਸ਼ਟੀ ਕਰਨ ਦੀ ਲੋੜ ਹੈ"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "ਤੁਹਾਨੂੰ ਤੁਹਾਡਾ ਮੌਜੂਦਾ ਪਾਸਵਰਡ ਦੇਣਾ ਪਵੇਗਾ"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "ਮੌਜੂਦਾ ਪਾਸਵਰਡ ਠੀਕ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "Switch Modes"
+#~ msgstr "ਮੋਡ ਬਦਲੋ"
+
+#~ msgid "Action"
+#~ msgstr "ਕਾਰਵਾਈ"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "ਮਿਆਦ ਪੁੱਗੀ। ਫੇਰ ਲਾਗ ਇਨ ਕਰੋ ਜੀ।"
+
+#~ msgid "_Log In"
+#~ msgstr "ਲਾਗ-ਇਨ(_L)"
+
+#~ msgid "_Hint"
+#~ msgstr "ਇਸ਼ਾਰਾ(_H)"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "ਇਹ ਇਸ਼ਾਰਾ ਲਾਗਇਨ ਸਕਰੀਨ ਉੱਤੇ ਵੀ ਵੇਖਾਇਆ ਜਾ ਸਕਦਾ ਹੈ। ਇਹ ਇਸ ਸਿਸਟਮ ਦੇ ਸਭ ਯੂਜ਼ਰਾਂ ਨੂੰ ਵੇਖਾਈ "
+#~ "ਦੇਵੇਗਾ। ਇਸ ਵਿੱਚ ਪਾਸਵਰਡ ਸ਼ਾਮਲ <b>ਨਾ</b> ਕਰੋ ਜੀ।"
+
+#~ msgid "Fair"
+#~ msgstr "ਠੀਕ-ਠਾਕ"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "ਬਲਿਊਟੁੱਥ"
+
+#~ msgid "Color management settings"
+#~ msgstr "ਰੰਗ ਮੈਨੇਜਮੈਂਟ ਸੈਟਿੰਗ"
+
+#~ msgid "British English"
+#~ msgstr "ਬਰਤਾਨੀਵੀਂ ਅੰਗਰੇਜ਼ੀ"
+
+#~ msgid "Spanish"
+#~ msgstr "ਸਪੇਨੀ"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "ਚੀਨੀ (ਸਧਾਰਨ)"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "ਮਿਤੀ ਤੇ ਸਮਾਂ ਪਸੰਦ ਪੈਨਲ"
+
+#~ msgid "Layout Settings"
+#~ msgstr "ਲੇਆਉਟ ਸੈਟਿੰਗ"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "ਆਪਣੀ ਮਾਊਸ ਤੇ ਟੱਚਪੈਚ ਪਸੰਦ ਸੈੱਟ ਕਰੋ"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "ਆਨਲਾਈਨ ਅਕਾਊਂਟ ਪਰਬੰਧ"
+
+#~ msgid "Power management settings"
+#~ msgstr "ਪਾਵਰ ਮੈਨੇਜਮੈਂਟ ਸੈਟਿੰਗ"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "ਆਪਣੀ ਖੇਤਰੀ ਅਤੇ ਭਾਸ਼ਾ ਸੈਟਿੰਗ ਬਦਲੋ"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "ਲਾਗਇਨ ਸਕਰੀਨ, ਸਿਸਟਮ ਅਕਾਊਂਟ ਅਤੇ ਨਵੇਂ ਯੂਜ਼ਰ ਅਕਾਊਂਟ ਸਿਸਟਮ ਵਾਸਤੇ ਖੇਤਰ ਅਤੇ ਭਾਸ਼ਾ ਸੈਟਿੰਗ "
+#~ "ਵਰਤੇਗਾ।"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "ਲਾਗਇਨ ਸਕਰੀਨ, ਸਿਸਟਮ ਅਕਾਊਂਟ ਅਤੇ ਨਵੇਂ ਯੂਜ਼ਰ ਅਕਾਊਂਟ ਪੂਰੇ ਸਿਸਟਮ ਵਾਸਤੇ ਖੇਤਰ ਅਤੇ ਭਾਸ਼ਾ ਸੈਟਿੰਗ "
+#~ "ਵਰਤੇਗਾ। ਤੁਸੀਂ ਸਿਸਟਮ ਸੈਟਿੰਗ ਨੂੰ ਆਪਣੇ ਨਾਲ ਮਿਲਾਉਣ ਲਈ ਬਦਲ ਵੀ ਸਕਦੇ ਹੋ।"
+
+#~ msgid "Copy Settings"
+#~ msgstr "ਸੈਟਿੰਗ ਕਾਪੀ ਕਰੋ"
+
+#~ msgid "Copy Settings…"
+#~ msgstr "…ਸੈਟਿੰਗ ਕਾਪੀ"
+
+#~ msgid "Region and Language"
+#~ msgstr "ਖੇਤਰ ਅਤੇ ਭਾਸ਼ਾ"
+
+#~ msgid "Add Language"
+#~ msgstr "ਭਾਸ਼ਾ ਸ਼ਾਮਲ"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "ਖਿੱਤਾ ਚੁਣੋ (ਬਦਲਾਅ ਤੁਹਾਡੇ ਵਲੋਂ ਅਗਲੀ ਵਾਰ ਲਾਗਇਨ ਹੋਣ ਸਮੇਂ ਲਾਗੂ ਕੀਤੇ ਜਾਣਗੇ)"
+
+#~ msgid "Add Region"
+#~ msgstr "ਖਿੱਤਾ ਸ਼ਾਮਲ"
+
+#~ msgid "Remove Region"
+#~ msgstr "ਖਿੱਤਾ ਹਟਾਓ"
+
+#~ msgid "Currency"
+#~ msgstr "ਮੁਦਰਾ"
+
+#~ msgid "Examples"
+#~ msgstr "ਉਦਾਹਰਨਾਂ"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "ਕੀਬੋਰਡ ਜਾਂ ਹੋਰ ਇੰਪੁੱਟ ਸਰੋਤ ਚੁਣੋ"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "ਸ਼ਾਰਟਕੱਟ ਸੈਟਿੰਗ"
+
+#~ msgid "Input source:"
+#~ msgstr "ਇੰਪੁੱਟ ਸਰੋਤ:"
+
+#~ msgid "Format:"
+#~ msgstr "ਫਾਰਮੈਟ:"
+
+#~ msgid "Your settings"
+#~ msgstr "ਤੁਹਾਡੀ ਸੈਟਿੰਗ"
+
+#~ msgid "System settings"
+#~ msgstr "ਸਿਸਟਮ ਸੈਟਿੰਗ"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "ਯੂਨੀਵਰਸਲ ਅਸੈੱਸ ਪਸੰਦ"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "ਆਪਣੀ ਵਾਕੋਮ ਟੇਬੇਥ ਪਸੰਦ ਸੈੱਟ ਕਰੋ"
+
+#~ msgid "Mesh"
+#~ msgstr "ਮੇਸ਼"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "ਕੈਰੀਅਰ/ਲਿੰਕ ਬਦਲਿਆ"
+
+#~| msgid "Mark As Inactive After"
+#~ msgid "_Mark As Inactive After"
+#~ msgstr "ਇਸ ਦੇ ਬਾਅਦ ਨਾ-ਸਰਗਰਮ ਬਣਾਉ(_M)"
+
+#~ msgid "Manufacturers"
+#~ msgstr "ਨਿਰਮਾਤਾ"
+
+#~ msgid "Drivers"
+#~ msgstr "ਡਰਾਇਵਰ"
+
+#~ msgid "Don't retain history"
+#~ msgstr "ਅਤੀਤ ਨਾ ਰੱਖੋ"
+
+#~ msgid "Out of range"
+#~ msgstr "ਹੱਦ ਤੋਂ ਬਾਹਰ"
+
+#~ msgid "_Disconnect"
+#~ msgstr "ਡਿਸ-ਕੁਨੈਕਟ ਕਰੋ(_D)"
+
+#~ msgid "_Connect"
+#~ msgstr "ਕੁਨੈਕਸ਼ਨ ਕਰੋ(_C)"
+
+#~| msgid "Settings"
+#~ msgid "_Settings…"
+#~ msgstr "…ਸੈਟਿੰਗ(_S)"
+
+#~ msgid "Browse Files..."
+#~ msgstr "...ਫਾਇਲਾਂ ਦੀ ਝਲਕ"
+
+#~ msgid "Create virtual device"
+#~ msgstr "ਵਰਚੁਅਲ ਜੰਤਰ ਬਣਾਓ"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "ਡਿਸਪਲੇਅ ਲਈ ਉਪਲੱਬਧ ਪਰੋਫਾਇਲ"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "ਸਕੈਨਰਾਂ ਲਈ ਉਪਲੱਬਧ ਪਰੋਫਾਇਲ"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "ਪਰਿੰਟਰ ਲਈ ਉਪਲੱਬਧ ਪਰੋਫਾਇਲ"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "ਕੈਮਰੇ ਲਈ ਉਪਲੱਬਧ ਪਰੋਫਾਇਲ"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "ਵੈੱਬਕੈਮ ਲਈ ਉਪਲੱਬਧ ਪਰੋਫਾਇਲ"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i ਸਾਲ"
+#~ msgstr[1] "%i ਸਾਲ"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i ਮਹੀਨਾ"
+#~ msgstr[1] "%i ਮਹੀਨੇ"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i ਹਫ਼ਤਾ"
+#~ msgstr[1] "%i ਹਫ਼ਤੇ"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "1 ਹਫ਼ਤੇ ਤੋਂ ਘੱਟ"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "ਇਹ ਜੰਤਰ ਰੰਗ ਪਰਬੰਦ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "ਇਹ ਜੰਤਰ ਨਿਰਮਾਤਾ ਕੈਲੀਬਰੇਟ ਡਾਟਾ ਵਰਤ ਰਿਹਾ ਹੈ।"
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "ਇਹ ਜੰਤਰ ਲਈ ਪੂਰੀ-ਸਕਰੀਨ ਰੰਗ ਸੋਧ ਲਈ ਢੁੱਕਵਾਂ ਪ੍ਰੋਫਾਇਲ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "Not specified"
+#~ msgstr "ਦਿੱਤਾ ਨਹੀਂ"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "ਕੋਈ ਜੰਤਰ ਰੰਗ ਪਰਬੰਧ ਖੋਜਣ ਲਈ ਸਹਾਇਕ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Add device"
+#~ msgstr "ਜੰਤਰ ਸ਼ਾਮਲ"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "ਵਰਚੁਅਲ ਜੰਤਰ ਸ਼ਾਮਲ"
+
+#~ msgid "English"
+#~ msgstr "ਅੰਗਰੇਜ਼ੀ"
+
+#~ msgid "French"
+#~ msgstr "ਫਰੈਂਚ"
+
+#~ msgid "Russian"
+#~ msgstr "ਰੂਸੀ"
+
+#~ msgid "Arabic"
+#~ msgstr "ਅਰਬੀ"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "ਅਣਜਾਣ ਮਾਡਲ"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "ਅਗਲਾ ਲਾਗਇਨ ਸਟੈਂਡਰਡ ਤਜਰਬੇ ਨੂੰ ਵਰਤਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੇਗਾ।"
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr "ਅਗਲੀ ਵਾਰ ਲਾਗਇਨ ਗ਼ੈਰ-ਸਹਾਇਕ ਗਰਾਫਿਕਸ ਹਾਰਡਵੇਅਰ ਲਈ ਬਣਾਇਆ ਫਾਲਬੈਕ ਮੋਡ ਵਰਤੇਗਾ।"
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "ਫਾਲਬੈਕ"
+
+#~ msgid "_Other Media..."
+#~ msgstr "...ਹੋਰ ਮੀਡਿਆ(_O)"
+
+#~ msgid "Experience"
+#~ msgstr "ਤਜਰਬਾ"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "ਫਾਲਬੈਕ ਮੋਡ ਲਈ ਮਜਬੂਰ(_F)"
+
+#~ msgid "_Options..."
+#~ msgstr "...ਚੋਣਾਂ(_O)"
+
+#~ msgid "C_reate..."
+#~ msgstr "...ਬਣਾਓ(_r)"
+
+#~ msgid "_Settings..."
+#~ msgstr "ਸੈਟਿੰਗ(_S)..."
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "ਸਾਵਧਾਨ ਘੱਟ ਬੈਟਰੀ, %s ਬਾਕੀ"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "ਬੈਟਰੀ ਪਾਵਰ ਦੀ ਵਰਤੋਂ - %s ਬਾਕੀ"
+
+#~ msgid "Using battery power"
+#~ msgstr "ਬੈਟਰੀ ਪਾਵਰ ਦੀ ਵਰਤੋਂ"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "ਚਾਰਜ ਹੋ ਰਹੀ ਹੈ - ਪੂਰੀ ਚਾਰਜ"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "UPS ਪਾਵਰ ਦੀ ਵਰਤੋਂ - %s ਬਾਕੀ"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "ਸਾਵਧਾਨ ਘੱਟ UPS"
+
+#~ msgid "Using UPS power"
+#~ msgstr "UPS ਪਾਵਰ ਦੀ ਵਰਤੋਂ"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "ਤੁਹਾਡੀ ਸੈਕੰਡਰੀ ਬੈਟਰੀ ਪੂਰੀ ਚਾਰਜ ਹੋਈ"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "ਤੁਹਾਡੀ ਸੈਕੰਡਰੀ ਬੈਟਰੀ ਖਾਲੀ ਹੈ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "ਚਾਰਜ ਹੋ ਰਹੀ ਹੈ - ਪੂਰੀ ਚਾਰਜ"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "ਇਸ਼ਾਰਾ: <a href=\"screen\">ਸਕਰੀਨ ਚਮਕ</a> ਵਰਤੀ ਜਾਣ ਵਾਲੀ ਊਰਜਾ (ਪਾਵਰ) ਦੀ "
+#~ "ਪ੍ਰਭਾਵਿਤ ਕਰਦੀ ਹੈ"
+
+#~ msgid "Don't suspend"
+#~ msgstr "ਸਸਪੈਂਡ ਨਾ ਕਰੋ"
+
+#~ msgid "_Show"
+#~ msgstr "ਵੇਖੋ(_S)"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "ਸੈਟਿੰਗ ਕਾਪੀ ਕਰੋ..."
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr "ਵੇਖਾਉਣ ਲਈ ਭਾਸ਼ਾ ਚੁਣੋ (ਇਹ ਤੁਹਾਡਾ ਵਲੋਂ ਅਗਲੀ ਵਾਰ ਲਾਗਇਨ ਸਮੇਂ ਲਾਗੂ ਕੀਤੀ ਜਾਵੇਗੀ)"
+
+#~ msgid "Install languages..."
+#~ msgstr "...ਭਾਸ਼ਾ ਇੰਸਟਾਲ ਕਰੋ"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "ਚਮਕ ਤੇ ਲਾਕ"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "ਚਮਕ;ਲਾਕ;ਡਿਮ;ਖਾਲੀ;ਮਾਨੀਟਰ;Brightness;Lock;Dim;Blank;Monitor;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "ਊਰਜਾ ਬਚਾਉਣ ਲਈ ਸਕਰੀਨ ਡਿਮ ਕਰੋ(_D)"
+
+#~ msgid "_Turn screen off when inactive for:"
+#~ msgstr "ਜਦੋਂ ਨਾ-ਸਰਗਰਮ ਹੋਵੇ ਤਾਂ ਸਕਰੀਨ ਬੰਦ ਕਰੋ(_T):"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "ਜਦੋਂ ਘਰ ਹੋਵਾਂ ਤਾਂ ਲਾਕ ਨਾ ਕਰੋ"
+
+#~ msgid "Locations..."
+#~ msgstr "...ਟਿਕਾਣੇ"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "ਡੀਬੱਗਿੰਗ ਕੋਡ ਚਾਲੂ ਕਰੋ"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr "— ਗਨੋਮ ਵਾਲੀਅਮ ਕੰਟਰੋਲ ਐਪਲਿਟ"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "ਡੈਸਕਟਾਪ ਵਾਲੀਅਮ ਕੰਟਰੋਲ ਵੇਖੋ"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "ਸਾਊਂਡ ਆਉਟਪੁੱਟ ਵਾਲੀਅਮ"
+
+#~ msgid "_Mute"
+#~ msgstr "ਚੁੱਪ(_M)"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "ਸਾਊਂਡ ਪਸੰਦ(_S)"
+
+#~ msgid "Muted"
+#~ msgstr "ਚੁੱਪ ਕੀਤਾ"
+
+#~ msgid "Options..."
+#~ msgstr "...ਚੋਣਾਂ"
+
+#~ msgid "User Accounts"
+#~ msgstr "ਯੂਜ਼ਰ ਅਕਾਊਂਟ"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "...ਹੋਰ ਤਸਵੀਰਾਂ ਦੀ ਝਲਕ"
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "'%s' ਨਾਂ ਨਾਲ ਕੋਈ ਯੂਜ਼ਰ ਮੌਜੂਦ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "This user does not exist."
+#~ msgstr "ਇਹ ਯੂਜ਼ਰ ਮੌਜੂਦ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "ਨਕਸ਼ਾ ਬਟਨ.."
+
+#~ msgid "Calibrate..."
+#~ msgstr "ਕੈਲੀਬਰੇਟ..."
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "Network;Wireless;IP;LAN;ਨੈੱਟਵਰਕ,ਬੇਤਾਰ,ਆਈਪੀ,ਲੈਨ,ਪਰਾਕਸੀ"
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "ਬੇਤਾਰ ਹਾਟਸਪਾਟ"
+
+#~ msgid "Wireless"
+#~ msgstr "ਬੇਤਾਰ"
+
+#~ msgid "Remove Language"
+#~ msgstr "ਭਾਸ਼ਾ ਹਟਾਓ"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "ਰੰਗ"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ"
+
+#~ msgid "- System Settings"
+#~ msgstr "- ਸਿਸਟਮ ਸੈਟਿੰਗ"
+
+#~ msgid "System Settings"
+#~ msgstr "ਸਿਸਟਮ ਸੈਟਿੰਗ"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "ਸਬਨੈੱਟ ਮਾਸਟ"
+
+#~ msgid "_Search by Address"
+#~ msgstr "ਐਡਰੈੱਸ ਰਾਹੀਂ ਖੋਜ(_S)"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD ਚੱਲ ਨਹੀਂ ਰਿਹਾ ਹੈ। ਨੈੱਟਵਰਕ ਪਰਿੰਟਰ ਖੋਜਣ ਲਈ mdns, ipp, ipp-client ਅਤੇ "
+#~ "samba-client ਸਰਵਿਸਾਂ ਨੂੰ ਫਾਇਰਵਾਲ ਉੱਤੇ ਚਾਲੂ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ।"
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "ਲੋਕਲ"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "ਨੈੱਟਵਰਕ"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "ਆਟੋਮੈਟਿਕ ਸੰਰਚਨਾ"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "mDNS ਕੁਨੈਕਸ਼ਨ ਲਈ ਫਾਇਰਵਾਲ ਖੋਲੀ ਜਾ ਰਹੀ ਹੈ"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "ਸਾਂਬਾ ਕੁਨੈਕਸ਼ਨ ਲਈ ਫਾਇਰਵਾਲ ਖੋਲ੍ਹੀ ਜਾ ਰਹੀ ਹੈ"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "IPP ਕੁਨੈਕਸ਼ਨ ਲਈ ਫਾਇਰਵਾਲ ਖੋਲੀ ਜਾ ਰਹੀ ਹੈ"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "ਆਪਣੀ ਸੈਟਿੰਗ ਨੂੰ ਟੈਸਟ ਕਰੋ, ਚਿਹਰੇ ਉੱਤੇ ਦੋ ਵਾਰ ਕਲਿੱਕ ਕਰਕੇ ਵੇਖੋ।"
+
+#~ msgid "Dasher"
+#~ msgstr "ਡੈਸ਼ਰ"
+
+#~ msgid "Nomon"
+#~ msgstr "ਨੋਮੋਨ"
+
+#~ msgid "Caribou"
+#~ msgstr "ਕਰੀਬੋਊ"
+
+#~ msgid "_Right-handed"
+#~ msgstr "ਸੱਜੇ ਹੱਥ(_R)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "ਖੱਬਾ ਹੱਥ ਮਾਊਸ(_L)"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "ਜਦੋਂ ਕੰਟਰੋਲ ਸਵਿੱਚ ਦੱਬੀ ਜਾਵੇ ਤਾਂ ਪੁਆਇੰਟਰ ਦੀ ਸਥਿਤੀ ਵੇਖੋ(_o)"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "ਐਕਸਰਲੇਟਰ(_c):"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "ਸੰਵੇਦਨਸ਼ੀਲਤਾ(_S):"
+
+#~ msgctxt "Mouse sensitivity"
+#~ msgid "Low"
+#~ msgstr "ਘੱਟ"
+
+#~ msgctxt "Mouse sensitivity"
+#~ msgid "High"
+#~ msgstr "ਵੱਧ"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "ਚੁੱਕਣਾ ਅਤੇ ਸੁੱਟਣਾ"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "ਥਰੈਸ਼ਹੋਲਡ(_e):"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "ਚੁੱਕਣ ਸਮੱਰਥਾ"
+
+#~ msgid "_Timeout:"
+#~ msgstr "ਟਾਇਮ-ਆਉਟ(_T):"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "ਟੱਚਪੈਡ ਨਾਲ ਮਾਊਸ ਕਲਿੱਕ ਯੋਗ(_m)"
+
+#~ msgid "_Disabled"
+#~ msgstr "ਅਯੋਗ(_D)"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "ਵਾਲਪੇਪਰ ਸ਼ਾਮਲ"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "ਵਾਲਪੇਪਰ ਹਟਾਓ"
+
+#~ msgid "Swap colors"
+#~ msgstr "ਰੰਗ ਬਦਲੋ"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "ਹਰੀਜੱਟਲ ਗਰੇਡੀਐਂਟ"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "ਵਰਟੀਕਲ ਗਰੇਡੀਐਂਟ"
+
+#~ msgid "Solid Color"
+#~ msgstr "ਗੂੜ੍ਹਾ ਰੰਗ"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "ਰੰਗ ਤੇ ਗਰੇਡੀਐਂਟ"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "ਸਕਰੀਨ-ਸ਼ਾਟ ਲਵੋ"
+
+#~ msgid "Account _type"
+#~ msgstr "ਅਕਾਊਂਟ  ਕਿਸਮ(_t)"
+
+#~ msgid "Acti_on:"
+#~ msgstr "ਐਕਸ਼ਨ(_o):"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "...ਹੋਰ"
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "ਕਿਵੇਂ ਵੀ ਹਾਟਸਪਾਟ ਬਣਾਉਣਾ ਹੈ?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "%s ਤੋਂ ਡਿਸ-ਕੁਨੈਕਟ ਕਰਨਾ ਅਤੇ ਨਵਾਂ ਹਾਟਸਪਾਟ ਬਣਾਉਣਾ ਹੈ?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "ਇਹ ਇੰਟਰਨੈੱਟ ਨਾਲ ਤੁਹਾਡਾ ਕੇਵਲ ਇੱਕ ਹੀ ਕੁਨੈਕਸ਼ਨ ਹੈ।"
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "ਹਾਟਸਪਾਟ ਬਣਾਓ(_H)"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "ਹਾਟਸਪਾਟ ਰੋਕੋ(_S).."
+
+#~ msgid "_Back"
+#~ msgstr "ਪਿੱਛੇ(_B)"
+
+#~ msgid "Allowed users"
+#~ msgstr "ਮਨਜ਼ੂਰ ਕੀਤੇ ਯੂਜ਼ਰ"
+
+#~ msgid "_Network Name"
+#~ msgstr "ਨੈੱਟਵਰਕ ਨਾਂ(_N):"
+
+#~ msgid "Disable VPN"
+#~ msgstr "VPN ਆਯੋਗ"
+
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP ਪੋਰਟ"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "HTTPS ਪੋਰਟ"
+
+#~ msgid "FTP Port"
+#~ msgstr "FTP ਪੋਰਟ"
+
+#~ msgid "Select an account"
+#~ msgstr "ਅਕਾਊਂਟ ਚੁਣੋ"
+
+#~ msgid "Tip:"
+#~ msgstr "ਟਿੱਪ:"
+
+#~ msgid "Brightness Settings"
+#~ msgstr "ਚਮਕ ਸੈਟਿੰਗ"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "ਪ੍ਰਭਾਵਿਤ ਕਰਦਾ ਹੈ ਕਿ ਕਿਵੇਂ ਊਰਜਾ ਵਰਤੀ ਜਾਂਦੀ ਹੈ"
+
+#~ msgid "Create new account"
+#~ msgstr "ਨਵਾਂ ਅਕਾਊਂਟ ਬਣਾਓ"
+
+#~ msgid "Cr_eate"
+#~ msgstr "ਬਣਾਓ(_e)"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "ਨਵਾਂ ਅਕਾਊਂਟ ਜੋੜਨ ਲਈ, ਪਹਿਲਾਂ ਅਕਾਊਂਟ ਕਿਸਮ ਚੁਣੋ"
+
+#~ msgid "Account Type:"
+#~ msgstr "ਅਕਾਊਂਟ ਕਿਸਮ:"
+
+#~ msgid "_Add..."
+#~ msgstr "ਸ਼ਾਮਲ(_A)..."
+
+#~ msgid "Add Layout"
+#~ msgstr "ਲੇਆਉਟ ਸ਼ਾਮਲ"
+
+#~ msgid "Remove Layout"
+#~ msgstr "ਲੇਆਉਟ ਹਟਾਓ"
+
+#~ msgid "Preview Layout"
+#~ msgstr "ਲੇਆਉਟ ਝਲਕ"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "ਨਵੀਆਂ ਵਿੰਡੋਜ਼ ਵਿੱਚ ਵਰਤਣ ਲਈ ਡਿਫਾਲਟ ਲੇਆਉਟ"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "ਨਵੀਆਂ ਵਿੰਡੋਜ਼ ਪਿਛਲੀ ਵਿੰਡੋ ਦਾ ਲੇਆਉਟ ਵਰਤਦੀਆਂ ਹਨ"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "ਡਿਫਾਲਟ ਮੁੜ-ਸੈੱਟ ਕਰੋ(_f)"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "ਮੌਜੂਦਾ ਕੀਬੋਰਡ ਲੇਆਉਟ ਸੈਟਿੰਗ ਨੂੰ ਡਿਫਾਲਟ ਸੈਟਿੰਗ ਨਾਲ ਬਦਲ\n"
+#~ "ਦਿਓ"
+
+#~ msgid "Layouts"
+#~ msgstr "ਲੇਆਉਟ"
+
+#~ msgid "Layout"
+#~ msgstr "ਲੇਆਉਟ"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 ਸਕਰੀਨ"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 ਸਕਰੀਨ"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "ਤਿਆਰ ਕੀਤਾ ਪਾਸਵਰਡ ਚੁਣੋ"
+
+#~ msgid "More choices..."
+#~ msgstr "...ਹੋਰ ਚੋਣਾਂ"
+
+#~ msgid "Change contrast:"
+#~ msgstr "ਕੰਨਟਰਾਸਟ ਬਦਲੋ:"
+
+#~ msgid "_Text size:"
+#~ msgstr "ਅੱਖਰ ਆਕਾਰ(_T):"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "ਜ਼ੂਮ"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "ਸੈਟਿੰਗ ਟੈਸਟ ਕਰਨ ਲਈ ਇੱਥੇ ਲਿਖੋ"
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "ਵਾਕੋਮ ਗਰਾਫਿਕਸ ਟੇਬਲੇਟ"
+
+#~ msgid "R_otation:"
+#~ msgstr "ਘੁੰਮਣ(_o):"
+
+#~ msgid "Upside-down"
+#~ msgstr "ਉਤਲਾ ਹੇਠ"
+
+#~ msgid "_Resolution:"
+#~ msgstr "ਰੈਜ਼ੋਲੇਸ਼ਨ(_R):"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "ਸ਼ੈਸ਼ਨ ਬੱਸ ਡਿਸਪਲੇਅ ਸੰਰਚਨਾ ਲਾਗੂ ਕਰਨ ਦੌਰਾਨ ਲਈ ਨਹੀਂ ਜਾ ਸਕੀ"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "ਕਨਟਰਾਸਟ ਬਦਲੋ"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "ਵੱਡਦਰਸ਼ੀ ਬਦਲੋ"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "ਸਕਰੀਨ ਰੀਡਰ ਬਦਲੋ"
+
+#~ msgid "Accelerator key"
+#~ msgstr "ਐਕਸਰਲੇਟਰ ਸਵਿੱਚ"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "ਐਕਸਰਲੇਟਰ ਸੋਧਕ"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "ਐਕਸਰਲੇਟਰ ਸਵਿੱਚ-ਕੋਡ"
+
+#~ msgid "Accel Mode"
+#~ msgstr "ਐਸਲ ਢੰਗ"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "ਐਕਸਰਲੇਟਰ ਦੀ ਕਿਸਮ ਹੈ।"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "ਬਹੁਤ ਸਾਰੇ ਕਸਟਮ ਸ਼ਾਰਟਕੱਟ"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "ਮੀਡਿਆ ਅਤੇ ਆਟੋ-ਰਨ"
+
+#~ msgid "_Photos:"
+#~ msgstr "ਫੋਟੋ(_P):"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "ਮੀਡਿਆ ਅਤੇ ਆਟੋ-ਰਨ ਪਸੰਦ ਸੰਰਚਨਾ"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr ""
+#~ "ਸੀਡੀ;ਡੀਵੀਡੀ;ਯੂਐਸਬੀ;ਆਡੀਓ;ਵਿਡੀਓ;ਵੀਡਿਓ;ਡਿਸਕ;cd;dvd;usb;audio;video;disc;"
+
+#~ msgid "Battery discharging"
+#~ msgstr "ਬੈਟਰੀ ਡਿਸਚਾਰਜ ਹੋ ਰਹੀ ਹੈ"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s ਚਾਰਜ ਹੋਣ ਲਈ (%.0lf%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s ਖਤਮ ਹੋਣ ਲਈ (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% ਚਾਰਜ ਹੈ"
+
+#~ msgid "Ask me"
+#~ msgstr "ਮੈਨੂੰ ਪੁੱਛੋ"
+
+#~ msgid "Shutdown"
+#~ msgstr "ਬੰਦ ਕਰੋ"
+
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr "ਕੇਵਲ ਪਰੋਫਾਇਲ, ਜੋ ਕਿ ਉੱਤੇ ਦਿੱਤੇ ਜੰਤਰ ਨਾਲ ਅਨੁਕੂਲ ਹੋਣ।"
+
+#~ msgid "_Turn off after:"
+#~ msgstr "ਇਸ ਦੇ ਬਾਅਦ ਬੰਦ(_T):"
+
+#~ msgid "Key"
+#~ msgstr "ਸਵਿੱਚ"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "ਜੀ-ਕਾਨਫ ਕੁੰਜੀ, ਇਹ ਕਿਸ ਵਿਸ਼ੇਸ਼ਤਾ ਸੰਪਾਦਕ ਨਾਲ ਜੁੜਿਆ ਹੈ"
+
+#~ msgid "Callback"
+#~ msgstr "ਕਾਲਬੈਕ"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "ਇਹ ਕਾਲਬੈਕ ਦਿਉ, ਜਿਉ ਹੀ ਇਸ ਸਵਿੱਚ ਨਾਲ ਸਬੰਧਤ ਸਵਿੱਚ ਦਾ ਮੁੱਲ ਤਬਦੀਲ ਜੋ ਗਿਆ"
+
+#~ msgid "Change set"
+#~ msgstr "ਸੈੱਟ ਬਦਲੋ"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr "ਜੀ-ਕਾਨਫ ਡਾਟਾ ਵਿੱਚ ਦਿੱਤੀ ਤਬਦੀਲੀ ਨੂੰ ਅਗਾਂਹ ਜੀ-ਕਾਨਫ ਕਲਾਈਟ ਨੂੰ ਲਾਗੂ ਕਰਨ ਲਈ"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "ਵਿਦਗਿਟ ਕਾਲਬੈਕ ਵੱਲ ਤਬਦੀਲੀ"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "ਕਾਲਬੈਕ ਦਿੱਤੀ ਜਾਵੇਗੀ, ਜਦੋਂ ਕਿ ਜੀ-ਕਾਨਫ ਤੋਂ ਖਾਕੇ ਲਈ ਡਾਟਾ ਤਬਦੀਲ ਹੋ ਗਿਆ"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "ਵਿਦਗਿਟ ਕਾਲਬੈਕ ਤੋਂ ਤਬਦੀਲੀ"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "ਕਾਲਬੈਕ ਦਿੱਤੀ ਜਾਵੇਗੀ, ਜਦੋਂ ਕਿ ਖਾਕੇ ਤੋਂ ਜੀ-ਕਾਨਫ ਲਈ ਡਾਟਾ ਤਬਦੀਲ ਹੋ ਗਿਆ"
+
+#~ msgid "UI Control"
+#~ msgstr "UI ਕੰਟਰੋਲ"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "ਆਬਜੈਕਟ, ਜੋ ਕਿ ਵਿਸ਼ੇਸ਼ਤਾ ਨੂੰ ਕੰਟਰੋਲ ਕਰਦੀ ਹੈ (ਆਮਤੌਰ ਤੇ ਵਿਦਗਿਟ)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "ਵਿਸ਼ੇਸ਼ਤਾ ਸੰਪਾਦਕ ਆਬਜੈਕਟ ਡਾਟਾ"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "ਖਾਸ ਵਿਸ਼ੇਸ਼ਤਾ ਸੰਪਾਦਕ ਨੂੰ ਸੋਧਿਆ ਡੈਟਾ ਲੋੜੀਦਾ ਹੈ"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "ਵਿਸ਼ੇਸ਼ਤਾ ਸੰਪਾਦਕ ਇਕਾਈ ਡੈਟਾ ਫਰੀਇੰਗ ਕਾਲਬੈਕ"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "ਕਾਲਬੈਕ ਦਿੱਤੀ ਜਾਵੇ, ਜਦੋਂ ਕਿ ਵਿਸ਼ੇਸ਼ਤਾ ਸੋਧਕ ਇਕਾਈ ਡੈਟਾ ਕਦੋਂ ਮੁਕਤ ਹੋਵੇ"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "ਫਾਇਲ '%s' ਨਹੀਂ ਲੱਭੀ ਹੈ\n"
+#~ "\n"
+#~ "ਜਾਂਚ ਲਵੋ ਕਿ ਇਹ ਮੌਜੂਦ ਹੈ ਤੇ ਮੁੜ ਕੋਸ਼ਿਸ ਕਰੋ ਜੀ ਜਾਂ ਵੱਖਰੀ ਤਸਵੀਰ ਦੀ ਚੋਣ ਕਰੋ।"
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "ਮੈ ਇਹ ਨਹੀਂ ਜਾਣਦਾ ਕਿ ਫਾਇਲ '%s' ਨੂੰ ਕਿਵੇਂ ਖੋਲਣਾ ਹੈ।\n"
+#~ "ਹੋ ਸਕਦਾ ਹੈ ਕਿ ਇਹ ਤਸਵੀਰ ਹੋਵੋ, ਜੋ ਕਿ ਅਜੇ ਮੱਦਦ ਪ੍ਰਾਪਤ ਨਹੀਂ ਹੈ।\n"
+#~ "\n"
+#~ "ਹੋਰ ਤਸਵੀਰ ਚੁਣੋ ਜੀ।"
+
+#~ msgid "Please select an image."
+#~ msgstr "ਇੱਕ ਚਿੱਤਰ ਚੁਣੋ ਜੀ।"
+
+#~ msgid "Create a user"
+#~ msgstr "ਯੂਜ਼ਰ ਬਣਾਓ"
+
+#~ msgid "24-_Hour Time"
+#~ msgstr "24-ਘੰਟੇ ਸਮਾਂ(_H)"
+
+#~ msgid "On AC _power:"
+#~ msgstr "AC ਪਾਵਰ ਉੱਤੇ ਹੋਵੇ(_p):"
+
+#~ msgid "When the _sleep button is pressed:"
+#~ msgstr "ਜਦੋਂ ਸਲੀਪ ਬਟਨ ਦੱਬਿਆ ਜਾਵੇ ਤਾਂ(_s):"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "ਕੀਬੋਰਡ;ਮਾਊਸ;a11y;ਅਸੈਸਬਿਲਟੀ;"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f KB"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f MB"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f GB"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TB"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PB"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EB"
+
+#~| msgid "<b>Email</b>"
+#~ msgid "<b>Example</b>"
+#~ msgstr "<i>ਉਦਾਹਰਨ</i>"
+
+#~| msgid "System Settings"
+#~ msgid "<b>System settings</b>"
+#~ msgstr "<b>ਸਿਸਟਮ ਸੈਟਿੰਗ</b>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">ਉੱਚ/ਉਲਟ</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">ਵੱਧ</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">ਘੱਟ</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">ਸਧਾਰਨ</span>"
+
+#~ msgid "Current network location"
+#~ msgstr "ਮੌਜੂਦਾ ਨੈੱਟਵਰਕ ਟਿਕਾਣਾ"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "ਹੋਰ ਬੈਕਗਰਾਊਂਡ URL"
+
+#~ msgid "More themes URL"
+#~ msgstr "ਹੋਰ ਥੀਮ URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "ਆਪਣੇ ਮੌਜੂਦਾ ਨਾਂ ਲਈ ਇਹ ਸੈੱਟ ਕਰੋ। ਇਸ ਨੂੰ ਨੈੱਟਵਰਕ ਪਰਾਕਸੀ ਸੰਰਚਨਾ ਦਾ ਅੰਦਾਜ਼ਾ ਲਾਉਣ ਲਈ ਵਰਤਿਆ "
+#~ "ਜਾਂਦਾ ਹੈ।"
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "URL, ਜਿੱਥੋ ਡੈਸਕਟਾਪ ਬੈਕਗਰਾਊਂਡ ਮਿਲ ਸਕਦੀਆਂ ਹਨ। ਜੇ ਇੱਕ ਖਾਲੀ ਲਾਈਨ ਦਿੱਤੀ ਤਾਂ ਲਿੰਕ ਮੌਜੂਦ ਨਹੀਂ "
+#~ "ਰਹੇਗਾ।"
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "URL, ਜਿੱਥੋ ਡੈਸਕਟਾਪ ਥੀਮ ਮਿਲ ਸਕਦੇ ਹਨ। ਜੇ ਇੱਕ ਖਾਲੀ ਲਾਈਨ ਦਿੱਤੀ ਤਾਂ ਲਿੰਕ ਮੌਜੂਦ ਨਹੀਂ ਰਹੇਗਾ।"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "ਡਾਈਲਾਗ ਅਣ-ਲਾਕ ਹੈ।\n"
+#~ "ਹੋਰ ਬਦਲਾਅ ਰੋਕਣ ਲਈ ਕਲਿੱਕ ਕਰੋ"
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "ਡਾਈਲਾਗ ਲਾਕ ਹੈ।\n"
+#~ "ਬਦਲਣ ਲਈ ਕਲਿੱਕ ਕਰੋ"
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "ਸਿਸਟਮ ਪਾਲਸੀ ਬਦਲਣ ਤੋਂ ਰੋਕਦੀ ਹੈ।\n"
+#~ "ਆਪਣੇ ਸਿਸਟਮ ਪਰਸ਼ਾਸ਼ਕ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।"
+
+#~ msgid "Photos"
+#~ msgstr "ਫੋਟੋ"
+
+#~ msgid "An error has occured during a maintenance command."
+#~ msgstr "ਮੇਨਟੇਨਸ ਕਮਾਂਡ ਲਈ ਗਲਤੀ ਆਈ ਹੈ।"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "ਨਵੀਆਂ ਵਿੰਡੋਜ਼ ਵਿੱਚ ਡਿਫਾਲਟ ਲੇਆਉਟ ਵਰਤੋਂ"
+
+#~ msgid "Use previous window's layout in new windows"
+#~ msgstr "ਨਵੀਆਂ ਵਿੰਡੋਜ਼ ਵਿੱਚ ਪਿਛਲੀ ਵਿੰਡੋ ਦੇ ਲੇਆਉਟ ਵਰਤੋਂ"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "ਐਕਸਰਲੇਟਰ(_A):"
+
+#~ msgid "DSL"
+#~ msgstr "DSL"
+
+#~ msgid "Beep when a modifer key is pressed"
+#~ msgstr "ਬੀਪ, ਜਦੋਂ ਕਿ  ਮੋਡੀਫਾਇਰ ਸਵਿੱਚ ਦੱਬੀ ਜਾਵੇ"
+
+#~ msgid "16"
+#~ msgstr "੧੬"
+
+#~ msgid "2010"
+#~ msgstr "੨੦੧੦"
+
+#~ msgid "Info"
+#~ msgstr "ਜਾਣਕਾਰੀ"
+
+#~ msgid "Set the system proxy settings"
+#~ msgstr "ਸਿਸਟਮ ਪਰਾਕਸੀ ਸੈਟਿੰਗ ਸੈੱਟ ਕਰੋ"
+
+#~ msgid "Virtual private network"
+#~ msgstr "ਵੁਰਚੁਅਲ ਪ੍ਰਾਈਵੇਟ ਨੈੱਟਵਰਕ"
+
+#~ msgid "The running NetworkManager version is not compatible (too new)."
+#~ msgstr "ਚੱਲ ਰਿਹਾ ਨੈੱਟਵਰਕਮੈਨੇਜਰ ਵਰਜਨ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ (ਬਹੁਤ ਨਵਾਂ ਹੈ)।"
+
+#~ msgid "The running NetworkManager version is not compatible (too old)."
+#~ msgstr "ਚੱਲ ਰਿਹਾ ਨੈੱਟਵਰਕਮੈਨੇਜਰ ਵਰਜਨ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ (ਬਹੁਤ ਪੁਰਾਣਾ ਹੈ)।"
+
+#~ msgid "IP Address:"
+#~ msgstr "IP ਐਡਰੈੱਸ:"
+
+#~ msgid "Secure HTTP Proxy:"
+#~ msgstr "ਸੁਰੱਖਿਅਤ HTTP ਪਰਾਕਸੀ:"
+
+#~ msgid "Preparing connection"
+#~ msgstr "ਕੁਨੈਕਸ਼ਨ ਤਿਆਰ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#~ msgctxt "Account type"
+#~ msgid "Supervised"
+#~ msgstr "ਸੁਪਰ-ਵਿਜ਼ਨ"
+
+#~ msgid "Chipset"
+#~ msgstr "ਚਿਪਸੈੱਟ"
+
+#~ msgid "LowContrast"
+#~ msgstr "ਘੱਟ-ਗੂੜ੍ਹਾ"
+
+#~ msgid "%i kb/s"
+#~ msgstr "%i kb/s"
+
+#~ msgid "Ctrl+Alt+0"
+#~ msgstr "Ctrl+Alt+੦"
+
+#~ msgid "Ctrl+Alt+4"
+#~ msgstr "Ctrl+Alt+੪"
+
+#~ msgid "Ctrl+Alt+8"
+#~ msgstr "Ctrl+Alt+੮"
+
+#~ msgid "Ctrl+Alt+="
+#~ msgstr "Ctrl+Alt+="
+
+#~ msgid "Shift+Ctrl+Alt+-"
+#~ msgstr "Shift+Ctrl+Alt+-"
+
+#~ msgid "Shift+Ctrl+Alt+="
+#~ msgstr "Shift+Ctrl+Alt+="
+
+#~ msgid "Use an alternative form of text input"
+#~ msgstr "ਟੈਕਸਟ ਇੰਪੁੱਟ ਲਈ ਬਦਲਵਾਂ ਰੂਪ ਵਰਤੋਂ"
+
+#~ msgid "Language:"
+#~ msgstr "ਭਾਸ਼ਾ:"
+
+#~ msgid "More Info"
+#~ msgstr "ਹੋਰ ਜਾਣਕਾਰੀ"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "ਗਲਤੀ, ਸੰਰਚਨਾ ਡੈਟਾਬੇਸ ਵਿੱਚ ਨਵਾਂ ਐਕਸਰਲੇਟਰ ਅਣ-ਸੈਟਿੰਗ ਕਰਨ ਵਿੱਚ: %s"
+
+#~| msgid "Idle"
+#~ msgctxt "printer state"
+#~ msgid "Idle"
+#~ msgstr "ਵੇਹਲਾ"
+
+#~| msgid "_Deactivate"
+#~ msgid "0 active"
+#~ msgstr "0 ਸਰਗਰਮ"
+
+#~ msgid "By _country"
+#~ msgstr "ਦੇਸ਼ ਰਾਹੀਂ(_c)"
+
+#~ msgid "By _language"
+#~ msgstr "ਭਾਸ਼ਾ ਰਾਹੀਂ(_l)"
+
+#~ msgid "Preview:"
+#~ msgstr "ਝਲਕ:"
+
+#~ msgid "_Country:"
+#~ msgstr "ਦੇਸ਼(_C):"
+
+#~ msgid "_Variants:"
+#~ msgstr "ਦਿੱਖ(_V):"
+
+#~ msgid "Upside Down"
+#~ msgstr "ਉਤਲਾ ਹੇਠ"
+
+#~ msgid "\t"
+#~ msgstr "\t"
+
+#~ msgid "Description:"
+#~ msgstr "ਵੇਰਵਾ:"
+
+#~ msgid "Queue"
+#~ msgstr "ਕਤਾਰ"
+
+#~ msgid "Show / hide printer's jobs"
+#~ msgstr "ਪਰਿੰਟਰ ਦਾ ਕੰਮ ਵੇਖੋ / ਓਹਲੇ ਕਰੋ"
+
+#~ msgid "Battery power and inactive for:"
+#~ msgstr "ਬੈਟਰੀ ਪਾਵਰ ਅਤੇ ਨਾ-ਸਰਗਰਮ ਹੋਵੇ:"
+
+#~ msgid "Put the computer to sleep when on:"
+#~ msgstr "ਕੰਪਿਊਟਰ ਨੂੰ ਸਲੀਪ ਮੋਡ 'ਚ ਰੱਖੋ, ਜਦੋਂ:"
+
+#~ msgid "add-toolbutton"
+#~ msgstr "ਐਡ-ਟੂਲਬਟਨ"
+
+#~ msgid "remove-toolbutton"
+#~ msgstr "ਹਟਾਓ-ਟੂਲਬਟਨ"
+
+#~ msgid "Hold"
+#~ msgstr "ਹੋਲਡ"
+
+#~ msgid "Release"
+#~ msgstr "ਰੀਲਿਜ਼"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "ਕੀ-ਬੋਰਡ ਮਾਡਲ(_m):"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "ਚੁਣੇ ਕੀਬੋਰਡ ਲੇਆਉਟ ਨੂੰ ਲਿਸਟ ਵਿੱਚ ਉੱਤੇ ਭੇਜੋ"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "ਚੁਣੇ ਕੀਬੋਰਡ ਲੇਆਉਟ ਦੀ ਸ਼ਕਲ ਪਰਿੰਟ ਕਰੋ"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "ਚੁਣਿਆ ਕੀਬੋਰਡ ਲੇਆਉਟ ਲਿਸਟ 'ਚੋਂ ਹਟਾ ਦਿਓ"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "ਲਿਸਟ 'ਚ ਜੋੜਨ ਲਈ ਕੀਬੋਰਡ ਲੇਆਉਟ ਚੁਣੋ"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "ਇੱਕ ਕੀ-ਬੋਰਡ ਮਾਡਲ ਚੁਣੋ"
+
+#~ msgid "_Models:"
+#~ msgstr "ਮਾਡਲ(_M):"
+
+#~ msgid "_Vendors:"
+#~ msgstr "ਵੇਂਡਰ(_V):"
+
+#~ msgid "Vendors"
+#~ msgstr "ਵੇਂਡਰ"
+
+#~| msgid ""
+#~| "A guest account will allow anyone to temporarily log in to this computer "
+#~| "without a password.  For security, remote logins to this account are not "
+#~| "allowed.\n"
+#~| "\n"
+#~| "<b>When the guest user logs out, all files and data associated with the "
+#~| "account will be deleted.</b>"
+#~ msgid ""
+#~ "A guest account will allow anyone to temporarily log in to this computer "
+#~ "without a password.  For security, remote logins to this account are not "
+#~ "allowed.\n"
+#~ "\n"
+#~ "                    <b>When the guest user logs out, all files and data "
+#~ "associated with the account will be deleted.</b>"
+#~ msgstr ""
+#~ "ਮਹਿਮਾਨ (ਗੈਸਟ) ਅਕਾਊਂਟ ਇਸ ਕੰਪਿਊਟਰ ਉੱਤੇ ਕਿਸੇ ਨੂੰ ਵੀ ਬਿਨਾਂ ਪਾਸਵਰਡ ਲਾਗਇਨ ਕਰਨ ਦਿੰਦਾ ਹੈ। "
+#~ "ਸੁਰੱਖਿਆ ਕਾਰਨਾਂ ਕਰਕੇ ਇਹ ਅਕਾਊਂਟ ਨਾਲ ਰਿਮੋਟ ਤੋਂ ਲਾਗਇਨ ਮਨਜ਼ੂਰ ਨਹੀਂ ਹਨ।\n"
+#~ "\n"
+#~ "                    <b>ਜਦੋਂ ਮਹਿਮਾਨ ਯੂਜ਼ਰ ਲਾਗ ਆਉਟ ਕਰੇਗਾ ਤਾਂ ਅਕਾਊਂਟ ਨਾਲ ਸਬੰਧਿਤ ਸਭ "
+#~ "ਫਾਇਲਾਂ ਤੇ ਡਾਟੇ ਨੂੰ ਹਟਾ ਦਿੱਤਾ ਜਾਵੇਗਾ।</b>"
+
+#~ msgid "Accounts"
+#~ msgstr "ਅਕਾਊਂਟ"
+
+#~ msgid "Address Book Card:"
+#~ msgstr "ਐਡਰੈੱਸ ਬੁੱਕ ਕਾਰਡ:"
+
+#~ msgid "Allow guests to log in to this computer"
+#~ msgstr "ਮਹਿਮਾਨ (ਗੈਸਟ) ਨੂੰ ਇਹ ਕੰਪਿਊਟਰ ਉੱਤੇ ਲਾਗਇਨ ਕਰਨ ਦਿਉ"
+
+#~ msgid "E-mail address:"
+#~ msgstr "ਈਮੇਲ ਐਡਰੈੱਸ:"
+
+#~ msgid "Show Shutdown, Suspend and Restart actions"
+#~ msgstr "ਬੰਦ ਕਰੋ, ਸਸਪੈਂਡ ਅਤੇ ਮੁੜ-ਚਾਲੂ ਕਾਰਵਾਈਆਂ ਵੇਖੋ"
+
+#~ msgid "Show list of users"
+#~ msgstr "ਯੂਜ਼ਰ ਦੀ ਲਿਸਟ ਵੇਖੋ"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "ਪਸੰਦੀਦਾ ਐਪਲੀਕੇਸ਼ਨ"
+
+#~ msgid "Select your default applications"
+#~ msgstr "ਆਪਣੇ ਡਿਫਾਲਟ ਐਪਲੀਕੇਸ਼ਨ ਚੁਣੋ"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "ਪਸੰਦੀਦਾ ਦਿੱਖ ਅਸੈੱਸਟਿਵ ਤਕਨਾਲੋਜੀ ਸਟਾਰਟ"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "ਦਿੱਖ ਸਹਾਇਤਾ"
+
+#~ msgid "Error setting default browser: %s"
+#~ msgstr "ਡਿਫਾਲਟ ਬਰਾਊਜ਼ਰ ਸੈੱਟ ਕਰਨ ਦੌਰਾਨ ਗਲਤੀ: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "ਮੁੱਖ ਇੰਟਰਫੇਸ ਲੋਡ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "ਸਭ %s ਮੌਜੂਦਗੀਆਂ ਨੂੰ ਅਸਲ ਲਿੰਕ ਨਾਲ ਤਬਦੀਲ ਕਰ ਦਿੱਤਾ ਜਾਵੇਗਾ"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "ਕਮਾਂਡ(_m):"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "ਚੱਲਣ ਨਿਸ਼ਾਨ(_x):"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "ਤਰੁੰਤ ਸੁਨੇਹਾਦਾਰ"
+
+#~ msgid "Mail Reader"
+#~ msgstr "ਮੇਲ ਰੀਡਰ"
+
+#~ msgid "Mobility"
+#~ msgstr "ਮੋਬਾਇਲਟੀ"
+
+#~ msgid "Run at st_art"
+#~ msgstr "ਸ਼ੁਰੂ ਸਮੇਂ ਚਲਾਓ(_a)"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "ਟਰਮੀਨਲ 'ਚ ਚਲਾਓ(_e)"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "ਟਰਮੀਨਲ ਸਮਰੂਪ"
+
+#~ msgid "Text Editor"
+#~ msgstr "ਟੈਕਸਟ ਐਡੀਟਰ"
+
+#~ msgid "Visual"
+#~ msgstr "ਦਿੱਖ"
+
+#~ msgid "Web Browser"
+#~ msgstr "ਵੈਬ ਬਰਾਊਜ਼ਰ"
+
+#~ msgid "_Run at start"
+#~ msgstr "ਸ਼ੁਰੂ ਸਮੇਂ ਚਲਾਓ(_R)"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "ਬਾਂਸ਼ੀ ਸੰਗੀਤ ਪਲੇਅਰ"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "ਡੇਬੀਅਨ ਟਰਮੀਨਲ ਸਮਰੂਪ"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "ਸਕਰੀਨ ਰੀਡਰ ਦੇ ਬਿਨਾਂ ਗਨੋਮ ਵੱਡਦਰਸ਼ੀ"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "ਜੀ-ਨੋਪੀਰਕਿਸ"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "ਵੱਡਦਰਸ਼ੀ ਨਾਲ ਜੀ-ਨੋਪੀਰਕਿਸ"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "KDE ਵੱਡਦਰਸ਼ੀ ਬਿਨਾਂ ਸਕਰੀਨ ਰੀਡਰ ਦੇ"
+
+#~ msgid "Konsole"
+#~ msgstr "ਕਨਸੋਂਲ"
+
+#~ msgid "Linux Screen Reader"
+#~ msgstr "ਲੀਨਕਸ ਸਕਰੀਨ ਰੀਡਰ"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "ਵੱਡਦਰਸ਼ੀ ਨਾਲ ਲਿਨਕਸ ਸਕਰੀਨ ਰੀਡਰ"
+
+#~ msgid "Listen"
+#~ msgstr "ਲਿਸਨ"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "ਮੂਇਮ ਸੰਗੀਤ ਪਲੇਅਰ"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Orca"
+#~ msgstr "ਓਰਕਾ"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "ਓਰਕਾ ਨਾਲ ਵੱਡਦਰਸ਼ੀ"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "ਰੀਥਮਬਾਕਸ ਸੰਗੀਤ ਪਲੇਅਰ"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "ਸਟੈਂਡਰਡ XTerminal"
+
+#~ msgid "Terminator"
+#~ msgstr "ਟਰਮੀਨੇਟਰ"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "ਟੋਟੇਮ ਮੂਵੀ ਪਲੇਅਰ"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "ਪੁਆਇੰਟਰ ਨੂੰ ਕੀ-ਪੈਡ ਦੀ ਵਰਤੋਂ ਰਕੇ ਕੰਟਰੋਲ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ(_P)"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "ਸੈਟਿੰਗ ਟੈਸਟ ਲਈ ਲਿਖੋ(_T):"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "ਹੱਥ ਤੋਂ ਪਹਿਲਾਂ ਕਲਿੱਕ ਦੀ ਟਾਈਪ ਚੁਣੋ(_b)"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "ਮਾਊਂਸ ਜੈਸਚਰ ਨਾਲ ਕਲਿੱਕ ਦੀ ਟਾਈਪ ਚੁਣੋ(_u)"
+
+#~ msgid "D_rag click:"
+#~ msgstr "ਡਰੈੱਗ ਕਲਿੱਕ(_r):"
+
+#~ msgid "Dwell Click"
+#~ msgstr "ਡੀਵੈੱਲ ਕਲਿੱਕ"
+
+#~ msgid "Show click type _window"
+#~ msgstr "ਕਲਿੱਕ ਟਾਈਪ ਵਿੰਡੋ ਵੇਖੋ(_w)"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr "ਤੁਸੀਂ ਕਲਿੱਕ ਟਾਈਪ ਚੁਣਨ ਲਈ ਡੀਵੈੱਲ ਕਲਿੱਕ ਪੈਨਲ ਐਪਲਿਟ ਦੀ ਵਰਤੋਂ ਵੀ ਕਰ ਸਕਦੇ ਹੋ।"
+
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "ਜਦੋਂ ਪੁਆਇੰਟਰ ਗਤੀ ਨੂੰ ਰੋਕਣਾ ਹੋਵੇ ਤਾਂ ਸ਼ੁਰੂਆਤੀ ਕਲਿੱਕ(_I)"
+
+#~ msgid "_Single click:"
+#~ msgstr "ਸਿੰਗਲ ਕਲਿੱਕ(_S):"
+
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr "ਪ੍ਰਾਈਮਰੀ ਬਟਨ ਨੂੰ ਹੋਲਡ ਕਰਕੇ ਰੱਖੋ, ਜਦੋਂ ਸੈਕੰਡਰੀ ਕਲਿੱਕ ਸ਼ੁਰੂ ਕਰਨਾ ਹੋਵੇ(_T)"
+
+#~ msgid "Example preferences panel"
+#~ msgstr "ਉਦਾਹਰਨ ਪਸੰਦ ਪੈਨਲ"
+
+#~ msgid "Foo;Bar;Baz;"
+#~ msgstr "ਫੂ;ਬਾਰ;ਬੱਜ;"
+
+#~ msgid "12 hour format"
+#~ msgstr "੧੨ ਘੰਟੇ ਫਾਰਮੈਟ"
+
+#~ msgid "24 hour format"
+#~ msgstr "੨੪ ਘੰਟੇ ਫਾਰਮੈਟ"
+
+#~ msgid "Orange"
+#~ msgstr "ਸੰਤਰੀ"
+
+#~ msgid "Chocolate"
+#~ msgstr "ਚਾਕਲੇਟ"
+
+#~ msgid "Chameleon"
+#~ msgstr "ਚਮੇਲੋਨ"
+
+#~ msgid "Plum"
+#~ msgstr "ਪਲੁਮ"
+
+#~ msgid "Aluminium"
+#~ msgstr "ਐਲੂਮੀਨੀਅਮ"
+
+#~ msgid "Slide Show"
+#~ msgstr "ਸਲਾਈਡ-ਸ਼ੋ"
+
+#~ msgid "Image"
+#~ msgstr "ਚਿੱਤਰ"
+
+#~ msgid "%d %s by %d %s"
+#~ msgstr "%d %s x %d %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "ਫੋਲਡਰ: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "ਫੋਲਡਰ: %s"
+
+#~ msgid "Image missing"
+#~ msgstr "ਚਿੱਤਰ ਗੁੰਮ ਹੈ"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "ਮਾਨੀਟਰ ਖੋਜ(_D)"
+
+#~ msgid "_Mirror Screens"
+#~ msgstr "ਸਕਰੀਨਾਂ ਮਿੱਰਰ(_M)"
+
+#~ msgid "Mirror Screens"
+#~ msgstr "ਦਰਪਨ ਸਕਰੀਨਾਂ"
+
+#~| msgid "Open"
+#~ msgid "Open %s"
+#~ msgstr "%s ਖੋਲ੍ਹੋ"
+
+#~| msgid "Could not get screen information"
+#~ msgid "Could not run application"
+#~ msgstr "ਐਫਲੀਕੇਸ਼ਨ ਚਲਾਈ ਨਹੀਂ ਜਾ ਸਕੀ"
+
+#~| msgid "Could not open %s: %s\n"
+#~ msgid "Could not find '%s'"
+#~ msgstr "'%s' ਨਹੀਂ ਲੱਭੀ ਜਾ ਸਕੀ"
+
+#~| msgid "Version of this application"
+#~ msgid "Could not find application"
+#~ msgstr "ਐਪਲੀਕੇਸ਼ਣ ਨਹੀਂ ਲੱਭੀ ਜਾ ਸਕੀ"
+
+#~ msgid "Could not add application to the application database: %s"
+#~ msgstr "ਐਪਲੀਕੇਸ਼ਨ ਨੂੰ ਐਪਲੀਕੇਸ਼ਨ ਡਾਟਾਬੇਸ ਵਿੱਚ ਸ਼ਾਮਲ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ: %s"
+
+#~| msgid "Could not get information for %s: %s\n"
+#~ msgid "Could not set application as the default: %s"
+#~ msgstr "ਐਪਲੀਕੇਸ਼ਨ ਨੂੰ ਡਿਫਾਲਟ ਸੈੱਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ: %s"
+
+#~| msgid "Select your default applications"
+#~ msgid "Could not set as default application"
+#~ msgstr "ਡਿਫਾਲਟ ਐਪਲੀਕੇਸ਼ਨ ਸੈੱਟ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ"
+
+#~| msgid "Open with \"%s\""
+#~ msgid "Open With"
+#~ msgstr "ਇਸ ਨਾਲ ਖੋਲ੍ਹੋ"
+
+#~ msgid "_Use a custom command"
+#~ msgstr "ਇੱਕ ਪਸੰਦੀਦਾ ਕਮਾਂਡ ਵਰਤੋਂ(_U)"
+
+#~ msgid "Open %s and other %s document with:"
+#~ msgstr "%s ਅਤੇ ਹੋਰ %s ਡੌਕੂਮੈਂਟ ਖੋਲ੍ਹੋ:"
+
+#~| msgid "Open with \"%s\""
+#~ msgid "Open %s with:"
+#~ msgstr "%s ਨਾਲ ਖੋਲ੍ਹੋ:"
+
+#~ msgid "_Remember this application for %s documents"
+#~ msgstr "%s ਡੌਕੂਮੈਂਟ ਲਈ ਇਹ ਐਪਲੀਕੇਸ਼ਨ ਯਾਦ ਰੱਖੋ(_R)"
+
+#~ msgid "Open all %s documents with:"
+#~ msgstr "ਸਭ %s ਡੌਕੂਮੈਂਟ ਖੋਲ੍ਹੋ:"
+
+#~ msgid "Open %s and other \"%s\" files with:"
+#~ msgstr "%s ਅਤੇ ਹੋਰ \"%s\" ਫਾਇਲਾਂ ਇਸ ਨਾਲ ਖੋਲ੍ਹੋ:"
+
+#~ msgid "_Remember this application for \"%s\" files"
+#~ msgstr "\"%s\" ਫਾਇਲਾਂ ਲਈ ਇਹ ਐਪਲੀਕੇਸ਼ਨ ਯਾਦ ਰੱਖੋ(_R)"
+
+#~ msgid "Open all \"%s\" files with:"
+#~ msgstr "ਸਭ \"%s\" ਫਾਇਲਾਂ ਇਸ ਨਾਲ ਖੋਲ੍ਹੋ:"
+
+#~| msgid "Applications"
+#~ msgid "Add Application"
+#~ msgstr "ਐਪਲੀਕੇਸ਼ਨ ਸ਼ਾਮਲ"
+
+#~ msgid "Location already exists"
+#~ msgstr "ਟਿਕਾਣਾ ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹੈ"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "ਆਪਣੀ ਨੈੱਟਵਰਕ ਪਰਾਕਸੀ ਪਸੰਦ ਦਿਓ"
+
+#~| msgid "Location:"
+#~ msgid "Web;Location;"
+#~ msgstr "ਵੈੱਬ;ਟਿਕਾਣਾ;"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>ਦਸਤੀ ਪਰਾਕਸੀ ਸੰਰਚਨਾ(_M)</b>"
+
+#~ msgid "Create New Location"
+#~ msgstr "ਨਵਾਂ ਟਿਕਾਣਾ ਬਣਾਓ"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP ਪਰਾਕਸੀ ਵੇਰਵਾ"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "ਹੋਸਟ ਲਿਸਟ ਅਣਡਿੱਠੀ"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "ਨੈੱਟਵਰਕ ਪਰਾਕਸੀ ਪਸੰਦ"
+
+#~ msgid "The location already exists."
+#~ msgstr "ਟਿਕਾਣਾ ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹੈ।"
+
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "ਸਭ ਪਰੋਟੋਕਾਲਾਂ ਲਈ ਇੱਕੋ ਪਰਕਾਸੀ ਵਰਤੋਂ(_U)"
+
+#~ msgid "Balsa"
+#~ msgstr "ਬਲਸਾ"
+
+#~ msgid "Claws Mail"
+#~ msgstr "ਕਲਾਅਸ ਮੇਲ"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "ਡੇਬੀਅਨ ਸੁਲਝਿਆ ਬਰਾਊਜ਼ਰ"
+
+#~ msgid "Encompass"
+#~ msgstr "ਈ-ਕੰਪਾਸ"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "ਏਪੀਫਨੀ ਵੈੱਬ ਬਰਾਊਜ਼ਰ"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "ਈਵੂਲੇਸ਼ਨ ਮੇਲ ਰੀਡਰ"
+
+#~ msgid "Firefox"
+#~ msgstr "ਫਾਇਰਫਾਕਸ"
+
+#~ msgid "Galeon"
+#~ msgstr "ਗਲੇਓਨ"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "Iceape ਮੇਲ"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Konqueror"
+#~ msgstr "ਕੋਨਕਿਉਰੋਰ"
+
+#~ msgid "Midori"
+#~ msgstr "ਮੀਡੋਰੀ"
+
+#~ msgid "Mozilla"
+#~ msgstr "ਮੋਜ਼ੀਲਾ"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "ਮੋਜ਼ੀਲਾ ੧.੬"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "ਮੋਜ਼ੀਲਾ ਮੇਲ"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "ਮੋਜ਼ੀਲਾ ਥੰਡਰਬਰਡ"
+
+#~ msgid "Mutt"
+#~ msgstr "ਮੱਟ"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "ਸਾਅਮਾਂਕੀ"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "ਸਾਅਮਾਂਕੀ ਮੇਲ"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Re_fresh rate:"
+#~ msgstr "ਤਾਜ਼ਾ ਦਰ(_f):"
+
+#~ msgid "_Include Top Menu Bar"
+#~ msgstr "ਉੱਤੇ ਮੇਨੂ ਪੱਟੀ ਸਮੇਤ(_I)"
+
+#~ msgid "Monitors"
+#~ msgstr "ਮਾਨੀਟਰ"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "ਮਾਨੀਟਰ: %s"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "ਕਮਾਡਾਂ ਨੂੰ ਸ਼ਾਰਟਕੱਟ ਮੁਹੱਈਆ ਕਰੋ:"
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "ਬੀਪ, ਜਦੋਂ ਕਿ ਟਾਗਲ ਸਵਿੱਚ ਨੂੰ ਦਬਾਇਆ ਜਾਵੇ(_t)"
+
+#~ msgid "Beep when a key is reje_cted"
+#~ msgstr "ਬੀਪ, ਜੇਕਰ ਸਵਿੱਚ ਰੱਦ ਹੋਵੇ(_c)"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "ਬੀਪ, ਜੇਕਰ ਸਵਿੱਚ ਰੱਦ ਹੋਵੇ(_r)"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "ਵਿੰਡੋ ਟਾਈਟਲਬਾਰ ਝਲਕਾਉ(_w)"
+
+#~ msgid "Flash entire _screen"
+#~ msgstr "ਪੂਰੀ ਸਕਰੀਨ ਝਲਕਾਉ(_s)"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "ਕੀਬੋਰਡ ਅਸੈੱਸਬਿਲਟੀ ਆਡੀਓ ਫੀਡਬੈਕ"
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "ਚੇਤਾਵਨੀ ਸਾਊਂਡ ਲਈ ਦਿੱਖ ਫੀਡਬੈਕ ਵੇਖੋ(_v)"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "ਸਾਊਂਡ ਲਈ ਦਿੱਖ ਨਿਸ਼ਾਨ"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "ਆਡੀਓ ਫੀਡਬੈਕ(_F)..."
+
+#~ msgid "Disa_ble sticky keys if two keys are pressed together"
+#~ msgstr "ਜੇਕਰ ਦੋ ਸਵਿੱਚਾਂ ਇਕੱਠੀਆਂ ਦਬਾਈਆਂ ਜਾਣ ਤਾਂ ਸਟਿੱਕੀ ਸਵਿੱਚਾਂ ਆਯੋਗ(_b)"
+
+#~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#~ msgstr "ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਨਾਲ ਅਸੈੱਸਬਿਲਟੀ ਫੀਚਰ ਬਦਲੇ ਜਾ ਸਕਦੇ ਹਨ(_A)"
+
+#~ msgid "_Ignore fast duplicate keypresses"
+#~ msgstr "ਤੇਜ਼ ਡੁਪਲੀਕੇਟ ਸਵਿੱਚ-ਦੱਬਣਾ ਅਣਡਿੱਠਾ(_I)"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "ਲੰਮਾ ਚਿਰ ਦਬਾਈਆਂ ਸਵਿੱਚਾਂ ਹੀ ਸਵੀਕਾਰ(_O)"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "ਇੱਕੋ ਵਾਰ ਸਵਿੱਚ ਦੱਬਣ ਦੀ ਨਕਲ(_S)"
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "ਸਟਾਕ ਆਈਕਾਨ '%s' ਲੋਡ ਕਰਨ ਲਈ ਅਸਮਰੱਥ\n"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "ਖੱਬੇ ਭੇਜੋ"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "ਸੱਜੇ ਭੇਜੋ"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "ਉੱਤੇ ਭੇਜੋ"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "ਹੇਠਾਂ ਭੇਜੋ"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "ਅਯੋਗ ਹੈ"
+
+#~ msgid "Waiting for sound system to respond"
+#~ msgstr "ਸਾਊਂਡ ਸਿਸਟਮ ਦੇ ਜਵਾਬ ਦੀ ਉਡੀਕ ਜਾਰੀ"
+
+#~| msgid "Icon theme"
+#~ msgid "Sound _theme:"
+#~ msgstr "ਸਾਊਂਡ ਥੀਮ(_t):"
+
+#~| msgctxt "Sound event"
+#~| msgid "Windows and Buttons"
+#~ msgid "Enable _window and button sounds"
+#~ msgstr "ਵਿੰਡੋ ਅਤੇ ਬਟਨ ਸਾਊਂਡ ਚਾਲੂ(_w)"
+
+#~ msgctxt "Sound event"
+#~ msgid "Windows and Buttons"
+#~ msgstr "ਵਿੰਡੋ ਅਤੇ ਬਟਨ"
+
+#~ msgctxt "Sound event"
+#~ msgid "Button clicked"
+#~ msgstr "ਬਟਨ ਕਲਿੱਕ ਕੀਤਾ"
+
+#~ msgctxt "Sound event"
+#~ msgid "Toggle button clicked"
+#~ msgstr "ਕਲਿੱਕ ਕੀਤਾ ਬਟਨ ਬਦਲੋ"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window maximized"
+#~ msgstr "ਵਿੰਡੋ ਵੱਧੋ-ਵੱਧ"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window unmaximized"
+#~ msgstr "ਵਿੰਡੋ ਅਣ-ਵੱਧੋ-ਵੱਧ"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window minimised"
+#~ msgstr "ਵਿੰਡੋ ਘੱਟੋ-ਘੱਟ ਕੀਤੀ"
+
+#~ msgctxt "Sound event"
+#~ msgid "Desktop"
+#~ msgstr "ਡੈਸਕਟਾਪ"
+
+#~ msgctxt "Sound event"
+#~ msgid "Long action completed (download, CD burning, etc.)"
+#~ msgstr "ਲੰਮਾ ਐਕਸ਼ਨ ਪੂਰੀ ਹੋਈ (ਡਾਊਨਲੋਡ, CD ਲਿਖਣਾ ਆਦਿ)"
+
+#~ msgctxt "Sound event"
+#~ msgid "Alerts"
+#~ msgstr "ਚੇਤਾਵਨੀਆਂ"
+
+#~ msgctxt "Sound event"
+#~ msgid "Information or question"
+#~ msgstr "ਜਾਣਕਾਰੀ ਜਾਂ ਸਵਾਲ"
+
+#~| msgid "Hearing"
+#~ msgctxt "Sound event"
+#~ msgid "Warning"
+#~ msgstr "ਚੇਤਾਵਨੀ"
+
+#~| msgid "Custom"
+#~ msgid "Custom…"
+#~ msgstr "ਪਸੰਦੀਦਾ…"
+
+#~| msgid "<b>Sound Theme</b>"
+#~ msgid "Sound Theme:"
+#~ msgstr "ਸਾਊਂਡ ਥੀਮ:"
+
+#~| msgctxt "Sound event"
+#~| msgid "Windows and Buttons"
+#~ msgid "Enable window and button sounds"
+#~ msgstr "ਵਿੰਡੋ ਅਤੇ ਬਟਨ ਸਾਊਂਡ ਚਾਲੂ"
+
+#~ msgid ""
+#~ "Accessibility features can be turned on or off with keyboard shortcuts"
+#~ msgstr "ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ ਨਾਲ ਅਸੈੱਸਬਿਲਟੀ ਫੀਚਰ ਚਾਲੂ ਜਾਂ ਬੰਦ ਕੀਤੇ ਜਾ ਸਕਦੇ ਹਨ"
+
+#~ msgid "I need assistance with:"
+#~ msgstr "ਮੈਂ ਸਹਾਇਤਾ ਦੀ ਲੋੜ ਹੈ:"
+
+#~ msgid "Test:"
+#~ msgstr "ਟੈਸਟ:"
+
+#~ msgid "Image/label border"
+#~ msgstr "ਚਿੱਤਰ/ਲੇਬਲ ਹਾਸ਼ੀਆ"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "ਚੇਤਾਵਨੀ ਬਕਸੇ 'ਚ ਲੇਬਲ ਅਤੇ ਚਿੱਤਰ ਦੇ ਦੁਆਲੇ ਹਾਸ਼ੀਏ ਦੀ ਚੌੜਾਈ"
+
+#~ msgid "The type of alert"
+#~ msgstr "ਚੇਤਾਵਨੀ ਦੀ ਕਿਸਮ ਹੈ।"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "ਚੇਤਾਵਨੀ ਡਾਈਲਾਗ 'ਚ ਬਟਨ ਵੇਖੋ"
+
+#~ msgid "Show more _details"
+#~ msgstr "ਹੋਰ ਵੇਰਵਾ ਵੇਖੋ(_d)"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "%s ਉੱਤੇ ਸੱਜਾ ਅੰਗੂਠਾ ਰੱਖੋ"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣਾ ਖੱਬਾ ਅੰਗੂਠਾ ਘਸਾਉ"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਖੱਬੀ ਇੰਡੈਕਸ ਉਂਗਲ ਰੱਖੋ"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਖੱਬੀ ਇੰਡੈਕਸ ਉਂਗਲ ਘਸਾਉ"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਉੱਤੇ ਆਪਣੀ ਖੱਬੀ ਵਿਚਲੀ ਉਂਗਲ ਰੱਖੋ"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਖੱਬੀ ਵਿਚਲੀ ਉਂਗਲ ਘਸਾਉ"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਖੱਬੀ ਅੰਗੂਠੀ ਉਂਗਲ ਰੱਖੋ"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਖੱਬੀ ਵਿਚਲੀ ਉਂਗਲ ਘਸਾਉ"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਖੱਬੀ ਚੀਚੀ ਰੱਖੋ"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਖੱਬੀ ਚੀਚੀ ਘਸਾਉ"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣਾ ਸੱਜਾ ਅੰਗੂਠਾ ਰੱਖੋ"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣਾ ਸੱਜਾ ਅੰਗੂਠਾ ਘਸਾਉ"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਸੱਜੀ ਇੰਡੈਕਸ ਉਂਗਲ ਰੱਖੋ"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਸੱਜੀ ਇੰਡੈਕਸ ਉਂਗਲ ਘਸਾਉ"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਸੱਜੀ ਵਿਚਲੀ ਉਂਗਲ ਰੱਖੋ"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਸੱਜੀ ਵਿਚਲੀ ਉਂਗਲ ਘਸਾਉ"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਸੱਜੀ ਅੰਗੂਠੀ ਉਂਗਲ ਰੱਖੋ"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਅੰਗੂਠੀ ਉਂਗਲ ਘਸਾਉ"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "ਆਪਣੀ ਸੱਜੀ ਚੀਚੀ ਨੂੰ %s ਉੱਤੇ ਰੱਖੋ"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "%s ਉੱਤੇ ਆਪਣੀ ਸੱਜੀ ਚੀਂਚੀ ਘਸਾਉ"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "ਆਪਣੀ ਉਂਗਲ ਰੀਡਰ ਉੱਤੇ ਫੇਰ ਰੱਖੋ"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "ਆਪਣੀ ਉਂਗਲ ਫੇਰ ਘਸਾਉ"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "ਉਂਗਲ ਥੋੜੀ ਘਸਾਈ ਹੈ, ਮੁੜ ਟਰਾਈ ਕਰੋ ਜੀ"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "ਤੁਹਾਡੀ ਉਂਗਲ ਸੈਂਟਰਡ ਨਹੀਂ ਸੀ, ਆਪਣੀ ਉਂਗਲ ਫੇਰ ਸਵੈਪ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "ਆਪਣੀ ਉਂਗਲ ਹਟਾਉ ਅਤੇ ਫੇਰ ਆਪਣੀ ਉਂਗਲ ਦੁਬਾਰਾ ਲੰਘਾਉਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ"
+
+#~ msgid "No Image"
+#~ msgstr "ਕੋਈ ਚਿੱਤਰ ਨਹੀਂ"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "ਐਡਰੈੱਸ-ਬੁੱਕ ਜਾਣਕਾਰੀ ਨੂੰ ਪਰਾਪਤ ਕਰਨ ਦੌਰਾਨ ਗਲਤੀ ਆਈ ਹੈ\n"
+#~ "ਈਵੇਲੂਸ਼ਨ ਡਾਟਾ ਸਰਵਰ ਪਰੋਟੋਕਾਲ ਨੂੰ ਹੈਂਡਲ ਨਹੀਂ ਕਰ ਸਕਦਾ ਹੈ।"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "ਐਡਰੈੱਸ ਕਿਤਾਬ ਖੋਲ੍ਹਣ ਲਈ ਅਸਫ਼ਲ"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "ਸਹਾਇਕ(_s):"
+
+#~ msgid "C_ompany:"
+#~ msgstr "ਕੰਪਨੀ(_o):"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "ਪਾਸਵਰਡ ਬਦਲੋ(_r)..."
+
+#~ msgid "Ci_ty:"
+#~ msgstr "ਸ਼ਹਿਰ(_t):"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "ਦੇਸ਼(_n):"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "ਫਿੰਗਰ-ਪਰਿੰਟ ਲਾਗਇਨ ਬੰਦ ਕਰੋ(_F)..."
+
+#~ msgid "Email"
+#~ msgstr "ਈ-ਮੇਲ"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "ਫਿੰਗਰ-ਪਰਿੰਟ ਲਾਗਇਨ ਚਾਲੂ ਕਰੋ(_F)..."
+
+#~ msgid "Hom_e:"
+#~ msgstr "ਘਰ(_e):"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "ਤੁਰੰਤ ਸੁਨੇਹੇ"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O.ਬਾਕਸ(_b):"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. ਬਾਕਸ:"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "ਸੂਬਾ/ਖੇਤਰ(_v):"
+
+#~ msgid "Web _log:"
+#~ msgstr "ਵੈਬ ਲਾਗ(_l):"
+
+#~ msgid "Wor_k:"
+#~ msgstr "ਕੰਮ(_k):"
+
+#~ msgid "Work"
+#~ msgstr "ਕੰਮ"
+
+#~ msgid "Work _fax:"
+#~ msgstr "ਕੰਮ ਫੈਕਸ(_f):"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "ਜ਼ਿਪ/ਡਾਕ ਕੋਡ(_P):"
+
+#~ msgid "_Home page:"
+#~ msgstr "ਘਰ ਸਫ਼ਾ(_H):"
+
+#~ msgid "_Home:"
+#~ msgstr "ਘਰ(_H):"
+
+#~ msgid "_State/Province:"
+#~ msgstr "ਸੂਬਾ/ਖੇਤਰ(_S):"
+
+#~ msgid "_Work:"
+#~ msgstr "ਕੰਮ(_W):"
+
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "ਜ਼ਿਪ/ਡਾਕ ਕੋਡ(_Z):"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "ਰੀਡਰ ਉੱਤੇ ਉਂਗਲ ਘਸਾਉ"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "ਰੀਡਰ ਉੱਤੇ ਉਂਗਲ ਰੱਖੋ"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "ਚਲਾਇਡ ਅਚਾਨਕ ਬੰਦ ਹੋ ਗਿਆ"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO ਚੈਨਲ ਬੰਦ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ ਹੈ: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO ਚੈਨਲ ਬੰਦ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "ਸਿਸਟਮ ਗਲਤੀ: %s"
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "%s ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਅਸਮਰੱਥ: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "ਬੈਕਐਂਡ ਚਲਾਉਣ ਲਈ ਅਸਫ਼ਲ"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "ਇੱਕ ਸਿਸਟਮ ਗਲਤੀ ਆਈ ਹੈ"
+
+#~ msgid "Checking password..."
+#~ msgstr "ਪਾਸਵਰਡ ਦੀ ਜਾਂਚ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "ਪਾਸਵਰਡ ਬਦਲਣ ਲਈ <b>ਪਾਸਵਰਡ ਬਦਲੋ</b> ਬਟਨ ਨੂੰ ਦਬਾਓ।"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "<b>ਨਵਾਂ ਪਾਸਵਰਡ ਮੁੜ-ਲਿਖੋ</b> ਖੇਤਰ ਵਿੱਚ ਆਪਣਾ ਪਾਸਵਰਡ ਮੁੜ-ਲਿਖੋ।"
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "ਦੋ ਪਾਸਵਰਡ ਬਰਾਬਰ ਨਹੀਂ ਹਨ।"
+
+#~ msgid "Change your password"
+#~ msgstr "ਆਪਣਾ ਪਾਸਵਰਡ ਬਦਲੋ"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "ਆਪਣਾ ਪਾਸਵਰਡ ਬਦਲਣ ਲਈ, ਹੇਠ ਦਿੱਤੇ ਖੇਤਰ ਵਿੱਚ ਆਪਣਾ ਮੌਜੂਦਾ ਪਾਸਵਰਡ ਦਿਓ ਅਤੇ <b>ਪਰਮਾਣਿਤ</"
+#~ "b> ਨੂੰ ਦਬਾਓ।\n"
+#~ "ਤੁਹਾਡੇ ਪਰਮਾਣਿਤ ਹੋਣ ਦੇ ਬਾਅਦ, ਆਪਣਾ ਨਵਾਂ ਪਾਸਵਰਡ ਦਿਓ, ਪੁਸ਼ਟੀ ਲਈ ਮੁੜ-ਦਬਾਓ ਅਤੇ <b>ਪਾਸਵਰਡ "
+#~ "ਬਦਲੋ</b> ਦਬਾਓ।"
+
+#~ msgid "Font may be too large"
+#~ msgstr "ਫੋਂਟ ਬਹੁਤ ਵੱਡੇ ਹਨ"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "ਚੁਣੇ ਫੋਂਟ %d ਪੁਆਇੰਟ ਵੱਡੇ ਹਨ ਅਤੇ ਕੰਪਿਊਟਰ ਤੇ ਵਰਤਣੇ ਵਧੀਆ ਤਰੀਕੇ ਨਾਲ ਵਰਤਣੇ ਔਖੇ ਹਨ। ਇਹ ਸਿਫ਼ਾਰਸ "
+#~ "ਕੀਤੀ ਜਾਦੀ ਹੈ ਇਹ ਅਕਾਰ %d ਤੋਂ ਛੋਟਾ ਹੋਣਾ ਜਰੂਰੀ ਹੈ।"
+#~ msgstr[1] ""
+#~ "ਚੁਣੇ ਫੋਂਟ %d ਪੁਆਇੰਟ ਵੱਡੇ ਹਨ ਅਤੇ ਕੰਪਿਊਟਰ ਤੇ ਵਰਤਣੇ ਵਧੀਆ ਤਰੀਕੇ ਨਾਲ ਵਰਤਣੇ ਔਖੇ ਹਨ। ਇਹ ਸਿਫ਼ਾਰਸ "
+#~ "ਕੀਤੀ ਜਾਦੀ ਹੈ ਇਹ ਅਕਾਰ %d ਤੋਂ ਛੋਟਾ ਹੋਣਾ ਜਰੂਰੀ ਹੈ।"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "ਚੁਣੇ ਫੋਂਟ %d ਪੁਆਇੰਟ ਵੱਡੇ ਹਨ ਅਤੇ ਕੰਪਿਊਟਰ ਤੇ ਵਰਤਣੇ ਵਧੀਆ ਤਰੀਕੇ ਨਾਲ ਵਰਤਣੇ ਔਖੇ ਹਨ। ਇਹ ਸਿਫ਼ਾਰਸ "
+#~ "ਕੀਤੀ ਜਾਦੀ ਹੈ ਛੋਟੇ ਅਕਾਰ ਦੇ ਫੋਂਟ ਚੁਣੋ।"
+#~ msgstr[1] ""
+#~ "ਚੁਣੇ ਫੋਂਟ %d ਪੁਆਇੰਟ ਵੱਡੇ ਹਨ ਅਤੇ ਕੰਪਿਊਟਰ ਤੇ ਵਰਤਣੇ ਵਧੀਆ ਤਰੀਕੇ ਨਾਲ ਵਰਤਣੇ ਔਖੇ ਹਨ। ਇਹ ਸਿਫ਼ਾਰਸ "
+#~ "ਕੀਤੀ ਜਾਦੀ ਹੈ ਛੋਟੇ ਅਕਾਰ ਦੇ ਫੋਂਟ ਚੁਣੋ।"
+
+#~ msgid "Use previous font"
+#~ msgstr "ਪੁਰਾਣੇ ਫੋਂਟ ਵਰਤੋਂ"
+
+#~ msgid "Use selected font"
+#~ msgstr "ਚੁਣੇ ਫੋਂਟ ਵਰਤੋਂ"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "ਇੱਕ ਥੀਮ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਫਾਇਲ ਨਾਂ ਦਿਓ"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr "ਵੇਖਣ ਲਈ ਸਫ਼ੇ ਦਾ ਨਾਂ ਦਿਓ (theme|background|fonts|interface)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "ਇਹ ਥੀਮ ਦੱਸੇ ਮੁਤਾਬਕ ਨਹੀਂ ਲੱਗਦਾ ਹੈ, ਕਿਉਂਕਿ ਲੋੜੀਦਾ GTK+ ਥੀਮ ਇੰਜਣ '%s' ਇੰਸਟਾਲ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "Apply Background"
+#~ msgstr "ਬੈਕਗਰਾਊਂਡ ਲਾਗੂ ਕਰੋ"
+
+#~ msgid "Apply Font"
+#~ msgstr "ਫੋਂਟ ਲਾਗੂ ਕਰੋ"
+
+#~ msgid "Revert Font"
+#~ msgstr "ਫੋਂਟ ਬਦਲੋ"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "ਮੌਜੂਦਾ ਥੀਮ ਇੱਕ ਬੈਕਗਰਾਊਂਡ ਅਤੇ ਫੋਂਟ ਲਈ ਸੁਝਾਅ ਦਿਓ। ਨਾਲ ਹੀ ਆਖਰੀ ਲਾਗੂ ਕੀਤੇ ਫੋਂਟ ਵਾਪਸ ਬਦਲੇ "
+#~ "ਜਾਣਗੇ।"
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "ਮੌਜੂਦਾ ਥੀਮ ਇੱਕ ਬੈਕਗਰਾਊਂਡ ਸੁਝਾਅ ਦਿੰਦੇ ਹਨ। ਨਾਲ ਹੀ ਆਖਰੀ ਲਾਗੂ ਕੀਤੇ ਫੋਂਟ ਵਾਪਸ ਲੈਣ ਦਾ ਸੁਝਾਅ ਹੈ।"
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "ਮੌਜੂਦਾ ਥੀਮ ਇੱਕ ਬੈਕਗਰਾਊਂਡ ਅਤੇ ਫੋਂਟ ਦਿੰਦਾ ਹੈ।"
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "ਮੌਜੂਦਾ ਥੀਮ ਇੱਕ ਫੋਂਟ ਲਈ ਮੰਗ ਕਰਦਾ ਹੈ। ਇਸ ਨਾਲ ਹੀ ਆਖਰੀ ਲਾਗੂ ਕੀਤੇ ਫੋਂਟ ਸੁਝਾਅ ਵੀ ਰੀਵਰਟ ਕੀਤੇ "
+#~ "ਜਾਣਗੇ।"
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "ਮੌਜੂਦਾ ਥੀਮ ਇੱਕ ਬੈਕਗਰਾਊਂਡ ਦਿੰਦਾ ਹੈ।"
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "ਆਖਰੀ ਲਾਗੂ ਕੀਤੇ ਫੋਂਟ ਸੁਝਾਅ ਵਾਪਸ ਲਏ ਜਾ ਸਕਦੇ ਹਨ।"
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "ਮੌਜੂਦਾ ਥੀਮ ਇੱਕ ਫੋਂਟ ਦਿੰਦਾ ਹੈ।"
+
+#~ msgid "Best _shapes"
+#~ msgstr "ਉੱਤਮ ਸ਼ਕਲ(_s)"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "ਬਹੁਤ ਗੂੜਾ(_n)"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "ਕਸਟਮਾਈਜ਼(_u)..."
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "ਤੁਹਾਡੇ ਕਰਸਰ ਥੀਮ ਵਿੱਚ ਕੀਤੇ ਬਦਲਾਅ ਤੁਹਾਡੇ ਅਗਲੀ ਵਾਰ ਲਾਗਇਨ ਕਰਨ ਸਮੇਂ ਅਸਰ ਕਰਨਗੇ।"
+
+#~ msgid "Customize Theme"
+#~ msgstr "ਕਸਮਾਈਜ਼ ਥੀਮ"
+
+#~ msgid "D_etails..."
+#~ msgstr "ਵੇਰਵਾ(_e)..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "ਡੈਸਕਟਾਪ ਫੋਂਟ(_k):"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "ਫੋਂਟ ਰੈਡਰਇੰਗ ਵੇਰਵਾ"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "ਹੋਰ ਬੈਕਗਰਾਊਂਡ ਆਨਲਾਈਨ ਲਵੋ"
+
+#~ msgid "Get more themes online"
+#~ msgstr "ਹੋਰ ਥੀਮ ਆਨਲਾਈਨ ਲਵੋ"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "ਸਲੇਟੀ(_y)"
+
+#~ msgid "Icons"
+#~ msgstr "ਆਈਕਾਨ"
+
+#~ msgid "Icons only"
+#~ msgstr "ਕੇਵਲ ਆਈਕਾਨ"
+
+#~ msgid "N_one"
+#~ msgstr "ਕੋਈ ਨਹੀਂ(_o)"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "ਰੰਗ ਦੱਸਣ ਲਈ ਇੱਕ ਡਾਈਲਾਗ ਖੋਲ੍ਹੋ"
+
+#~ msgid "R_esolution:"
+#~ msgstr "ਰੈਜ਼ੋਲੇਸ਼ਨ(_e):"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "ਥੀਮ ਇੰਝ ਸੰਭਾਲੋ..."
+
+#~ msgid "Save _As..."
+#~ msgstr "ਇੰਝ ਸੰਭਾਲੋ(_A)..."
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "ਸਬ-ਪਿਕਸਲ (LCD)(_p)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "ਸਬ-ਪਿਕਸਲ ਮੁਲਾਇਮ(LCD)(_p)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "ਸਬ-ਪਿਕਸਲ ਕ੍ਰਮ"
+
+#~ msgid "Text"
+#~ msgstr "ਟੈਕਸਟ"
+
+#~ msgid "Text below items"
+#~ msgstr "ਆਈਟਮਾਂ ਹੇਠ ਟੈਕਸਟ"
+
+#~ msgid "Text beside items"
+#~ msgstr "ਆਈਟਮਾਂ ਨਾਲ ਟੈਕਸਟ"
+
+#~ msgid "Text only"
+#~ msgstr "ਕੇਵਲ ਟੈਕਸਟ"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "ਮੌਜੂਦਾ ਕੰਟਰੋਲ ਥੀਮ ਰੰਗ ਸਕੀਮਾਂ ਲਈ ਸਹਾਇਕ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "Theme"
+#~ msgstr "ਥੀਮ"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Document font:"
+#~ msgstr "ਡੌਕੂਮੈਂਟ ਫੋਂਟ(_D):"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "ਸਥਿਰ ਚੌੜਾਈ ਫੋਂਟ(_F):"
+
+#~ msgid "_Monochrome"
+#~ msgstr "ਮੋਨੋਕਰੋਮਿਕ(_M)"
+
+#~ msgid "_None"
+#~ msgstr "ਕੋਈ ਨਹੀਂ(_N)"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "ਡਿਫਾਲਟ ਰੀ-ਸੈੱਟ ਕਰੋ(_R)"
+
+#~ msgid "_Selected items:"
+#~ msgstr "ਚੁਣੀਆਂ ਆਈਟਮਾਂ(_S):"
+
+#~ msgid "_Size:"
+#~ msgstr "ਅਕਾਰ(_S):"
+
+#~ msgid "_Slight"
+#~ msgstr "ਹਲਕਾ(_S)"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "ਟੂਲ-ਟਿੱਪ(_T):"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "ਵਿੰਡੋ ਟਾਇਟਲ ਫੋਂਟ(_W):"
+
+#~ msgid "_Windows:"
+#~ msgstr "ਵਿੰਡੋ(_W):"
+
+#~ msgid "dots per inch"
+#~ msgstr "ਬਿੰਦੂ ਪ੍ਰਤੀ ਇੰਚ"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "ਡੈਸਕਟਾਪ ਲਈ ਪਸੰਦੀਦਾ ਦਿੱਖ"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "ਡੈਸਕਟਾਪ ਦੇ ਵੱਖ-ਵੱਖ ਹਿੱਸਿਆਂ ਲਈ ਥੀਮ ਪੈਕੇਜ ਇੰਸਟਾਲ ਕਰਦਾ ਹੈ"
+
+#~ msgid "Theme Installer"
+#~ msgstr "ਥੀਮ ਇੰਸਟਾਲਰ"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "ਗਨੋਮ ਥੀਮ ਪੈਕੇਜ"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "ਥੀਮ ਇੰਸਟਾਲ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s ਸਹੂਲਤ ਇੰਸਟਾਲ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ ਹੈ।"
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "ਥੀਮ ਖੋਲ੍ਹਣ ਦੌਰਾਨ ਇੱਕ ਸਮੱਸਿਆ ਆਈ ਹੈ।"
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "ਚੁਣੀ ਫਾਈਲ ਇੰਸਟਾਲ ਕਰਨ ਦੌਰਾਨ ਗਲਤੀ ਆਈ ਹੈ"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" ਇੱਕ ਠੀਕ ਥੀਮ ਨਹੀਂ ਜਾਪਦਾ ਹੈ।"
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" ਇੱਕ ਠੀਕ ਥੀਮ ਨਹੀਂ ਜਾਪਦਾ ਹੈ। ਇਹ ਇੱਕ ਥੀਮ ਇੰਜਣ ਹੋ ਸਕਦਾ ਹੈ, ਜਿਸ ਨੂੰ ਤੁਹਾਨੂੰ ਕੰਪਾਇਲ "
+#~ "ਕਰਨਾ ਪਵੇਗਾ।"
+
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr " ਥੀਮ \"%s\" ਦੀ ਇੰਸਟਾਲੇਸ਼ਨ ਫੇਲ੍ਹ ਹੋਈ ਹੈ।"
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "ਥੀਮ \"%s\" ਇੰਸਟਾਲ ਹੋ ਗਿਆ ਹੈ।"
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "ਕੀ ਤੁਸੀਂ ਹੁਣੇ ਲਾਗੂ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ ਜਾਂ ਆਪਣਾ ਮੌਜੂਦ ਥੀਮ ਹੀ ਰੱਖਣਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "ਮੌਜੂਦਾ ਥੀਮ ਰੱਖੋ"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "ਨਵਾਂ ਥੀਮ ਲਾਗੂ ਕਰੋ"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "ਗਨੋਮ ਥੀਮ %s ਠੀਕ ਤਰ੍ਹਾਂ ਇੰਸਟਾਲ ਹੈ"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "ਨਵੇਂ ਥੀਮ ਠੀਕ ਤਰ੍ਹਾਂ ਇੰਸਟਾਲ ਹੋ ਗਏ ਹਨ।"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਕੋਈ ਥੀਮ ਫਾਇਲ ਟਿਕਾਣਾ ਨਹੀਂ ਦਿੱਤਾ ਗਿਆ"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "ਥੀਮ ਨੂੰ ਇੱਥੇ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਲੋੜੀਦੇ ਅਧਿਕਾਰ ਨਹੀਂ ਹਨ:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "ਥੀਮ ਚੁਣੋ"
+
+#~ msgid "Theme Packages"
+#~ msgstr "ਥੀਮ ਪੈਕੇਜ"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "ਥੀਮ ਨਾਂ ਹੋਣਾ ਜ਼ਰੂਰੀ ਹੈ"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "ਥੀਮ ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹੈ। ਕੀ ਤੁਸੀਂ ਇਸ ਨੂੰ ਤਬਦੀਲ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "ਉੱਤੇ ਲਿਖੋ(_O)"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "ਕੀ ਤੁਸੀਂ ਇਹ ਥੀਮ ਹਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "ਥੀਮ ਇੰਜਣ ਇੰਸਟਾਲ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "ਸੈਟਿੰਗ ਮੈਨੇਜਰ 'gnome-settings-daemon' ਨੂੰ ਸ਼ੁਰੂ ਕਰਨ ਵਿੱਚ ਅਸਫਲ ਹੈ।\n"
+#~ "ਗਨੋਮ ਸੈਟਿੰਗ ਮੈਨੇਜਰ ਬਿਨਾਂ ਚਲਾਏ, ਕੁਝ ਪਸੰਦ ਕੰਮ ਨਹੀਂ ਕਰਨਗੀਆਂ। ਇਹ ਡੀਬੱਸ ਨਾਲ ਸੰਬੰਧ ਮੁਸ਼ਕਿਲ "
+#~ "ਦਿਖਾਰਿਹਾ ਹੈ ਜਾਂ ਨਾ-ਗਨੋਮ (ਜਿਵੇਂ ਕਿ ਕੇਡੀਈ (KDE)) ਸੈਟਿੰਗ ਮੈਨੇਜਰ ਦਾ ਮੈਨੇਜਰ ਪਹਿਲਾਂ ਹੀ ਸਰਗਰਮ "
+#~ "ਹੈ ਅਤੇ ਗਨੋਮ ਸੈਟਿੰਗ ਮੈਨੇਜਰ ਨਾਲ ਅਪਵਾਦ ਕਰ ਰਿਹਾ ਹੈ।"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "ਮੱਦਦ ਵੇਖਾਉਣ ਗਲਤੀ ਹੈ: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "ਫਾਇਲ ਕਾਪੀ ਜਾਰੀ: %2$u ਵਿੱਚੋਂ %1$u"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' ਕਾਪੀ ਜਾਰੀ"
+
+#~ msgid "Copying files"
+#~ msgstr "ਫਾਇਲਾਂ ਕਾਪੀ ਕੀਤੀਆਂ ਜਾ ਰਹੀਆਂ ਹਨ"
+
+#~ msgid "Parent Window"
+#~ msgstr "ਮੁੱਢਲੀ ਵਿੰਡੋ"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "ਡਾਈਲਾਗ ਦੀ ਮੁੱਢਲੀ ਵਿੰਡੋ"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "ਇਸ ਸਮੇਂ URI ਤਬਦੀਲ ਹੋ ਰਿਹਾ ਹੈ ਵੱਲੋਂ"
+
+#~ msgid "To URI"
+#~ msgstr "ਵੱਲ URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "ਇਸ ਸਮੇਂ URI ਤਬਦੀਲ ਹੋ ਰਿਹਾ ਹੈ ਵੱਲ"
+
+#~ msgid "Fraction completed"
+#~ msgstr "ਭਾਗ ਪੂਰਾ ਹੋ ਗਿਆ"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "ਤਬਦੀਲੀ ਦਾ ਹਿੱਸਾ ਹੁਣ ਪੂਰਾ ਹੋ ਗਿਆ ਹੈ"
+
+#~ msgid "Current URI index"
+#~ msgstr "ਮੌਜੂਦਾ URI ਇੰਡੈਕਸ"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "ਮੌਜੂਦਾ URI ਇੰਡੈਕਸ- ਸ਼ੁਰੂ ਹੁੰਦਾ ਹੈ 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "ਕੁੱਲ URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "URI ਦੀ ਕੁੱਲ ਗਿਣਤੀ"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "ਫਾਈਲ '%s' ਮੌਜੂਦਾ ਨਹੀਂ ਹੈ। ਕੀ ਤੁਸੀਂ ਉੱਤੇ ਲਿਖਣਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "_Skip"
+#~ msgstr "ਛੱਡੋ(_S)"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "ਸਭ ਉੱਤੇ ਲਿਖੋ(_A)"
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "ਮੂਲ ਪੁਆਇੰਟਰ - ਮੌਜੂਦਾ"
+
+#~ msgid "White Pointer"
+#~ msgstr "ਸਫੈਦ ਪੁਆਇੰਟਰ"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "ਸਫੈਦ ਪੁਆਇੰਟਰ - ਮੌਜੂਦਾ"
+
+#~ msgid "Large Pointer"
+#~ msgstr "ਵੱਡਾ ਪੁਆਇੰਟਰ"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "ਵੱਡਾ ਪੁਆਇੰਟਰ - ਮੌਜੂਦਾ"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "ਵੱਡਾ ਸਫ਼ੈਦ ਪੁਆਇੰਟਰ - ਮੌਜੂਦਾ"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "ਇਹ ਥੀਮ ਜਿਸ ਤਰ੍ਹਾਂ ਦਾ ਵੇਖਾਈ ਦਿੰਦਾ ਹੈ, ਉਂਝ ਦਾ ਹੋਵੇਗਾ ਨਹੀਂ, ਕਿਉਂਕਿ ਲੋੜੀਦਾ GTK+ ਥੀਮ '%s' "
+#~ "ਇੰਸਟਾਲ ਨਹੀਂ ਹੈ।"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "ਇਹ ਥੀਮ ਜਿਸ ਤਰ੍ਹਾਂ ਦਾ ਵੇਖਾਈ ਦਿੰਦਾ ਹੈ, ਉਂਝ ਦਾ ਹੋਵੇਗਾ ਨਹੀਂ, ਕਿਉਂਕਿ ਵਿੰਡੋ ਮੈਨੇਜਰ ਥੀਮ '%s' "
+#~ "ਇੰਸਟਾਲ ਨਹੀਂ ਹੈ।"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "ਇਹ ਥੀਮ ਜਿਸਤਰ੍ਹਾਂ ਦਾ ਵੇਖਾਈ ਦਿੰਦਾ ਹੈ, ਉਂਝ ਦਾ ਹੈ ਨਹੀਂ, ਕਿਉਂਕਿ ਲੋੜੀਦਾ ਆਈਕਾਨ ਥੀਮ '%s' "
+#~ "ਇੰਸਟਾਲ ਨਹੀਂ ਹੋਵੇਗਾ।"
+
+#~ msgid "Image Viewer"
+#~ msgstr "ਚਿੱਤਰ ਦਰਸ਼ਕ"
+
+#~ msgid "Multimedia"
+#~ msgstr "ਮਲਟੀਮੀਡਿਆ"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "ਲਿੰਕ ਨਵੀਂ ਟੈਬ ਵਿੱਚ ਖੋਲ੍ਹੋ(_t)"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "ਨਵੀਂ ਵਿੰਡੋ ਵਿੱਚ ਖੋਲ੍ਹੋ(_w)"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "ਲਿੰਕ ਡਿਫਾਲਟ ਵੈੱਬ ਬਰਾਊਜ਼ਰ ਨਾਲ ਖੋਲ੍ਹੋ(_d)"
+
+#~ msgid "Opera"
+#~ msgstr "ਓਪਰਾ"
+
+#~ msgid "Include _panel"
+#~ msgstr "ਪੈਨਲ ਸਮੇਤ(_P)"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "ਸਭ ਮਾਨੀਟਰਾਂ ਵਿੱਚ ਇੱਕੋ ਚਿੱਤਰ(_m)"
+
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "ਇਹ ਪਰੋਗਰਾਮ ਕੇਵਲ ਰੂਟ ਯੂਜ਼ਰ ਵਲੋਂ ਹੀ ਵਰਤਿਆ ਜਾ ਸਕਦਾ ਹੈ"
+
+#~ msgid "The source filename must be absolute"
+#~ msgstr "ਸਰੋਤ ਫਾਇਲ ਨਾਂ ਅਸਲ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s ਨਿਯਮਤ ਫਾਇਲ ਹੋਣੀ ਲਾਜ਼ਮੀ ਹੈ।\n"
+
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "ਇਹ ਪਰੋਗਰਾਮ pkexec(1) ਰਾਹੀਂ ਹੀ ਚਲਾਇਆ ਜਾਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "PKEXEC_UID ਪੂਰਨ ਅੰਕ ਸੈੱਟ ਕੀਤਾ ਹੋਣਾ ਲਾਜ਼ਮੀ ਹੈ"
+
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "%s ਤੁਹਾਡੀ ਮਲਕੀਅਤ (ਓਨਰ) ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ\n"
+
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s ਕੋਈ ਡਾਇਰੈਕਟਰੀ ਭਾਗ ਨਹੀਂ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ\n"
+
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s ਡਾਇਰੈਕਟਰੀ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ\n"
+
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "%s/%s ਖੋਲ੍ਹੀ ਨਹੀਂ ਜਾ ਸਕੀ: %s\n"
+
+#~ msgid ""
+#~ "Authentication is required to install multi-monitor settings for all users"
+#~ msgstr "ਸਭ ਯੂਜ਼ਰਾਂ ਵਾਸਤੇ ਮਲਟ-ਮਾਨੀਟਰ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਪਰਮਾਣਿਤਾ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "ਪੂਰੇ ਸਿਸਟਮ ਲਈ ਮਲਟੀ-ਮਾਨੀਟਰ ਸੈਟਿੰਗ ਇੰਸਟਾਲ ਕਰੋ"
+
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "ਮਾਨੀਟਰ ਸੰਰਚਨਾ ਸੰਭਾਲੀ ਜਾ ਚੁੱਕੀ ਹੈ"
+
+#~ msgid "This configuration will be used the next time someone logs in."
+#~ msgstr "ਇਹ ਸੰਰਚਨਾ ਅਗਲੀ ਵਾਰ ਕਿਸੇ ਦੇ ਲਾਗਇਨ ਕਰਨ ਸਮੇਂ ਵਰਤੀ ਜਾਵੇਗੀ।"
+
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "ਮਾਨੀਟਰ ਲਈ ਡਿਫਾਲਟ ਸੰਰਚਨਾ ਸੈੱਟ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "ਅੰਤਰਾਲ ਨੂੰ ਮੁਲਤਵੀ ਕਰਨ ਦੀ ਇਜ਼ਾਜਤ ਦਿਓ(_o)"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "ਜਾਂਚ ਕਰੋ ਕਿ ਅੰਤਰਾਲ ਨੂੰ ਮੁਲਤਵੀ ਕਰਨ ਦੀ ਇਜ਼ਾਜਤ ਹੈ"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "ਅੰਤਰਾਲ, ਜਦੋਂ ਕਿ ਟਾਇਪਇੰਗ ਦੀ ਇਜ਼ਾਜਤ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "ਅੰਤਰਾਲ ਕੰਮ ਦਾ, ਬੰਦ ਕਰਨ ਲਈ ਮਜਬੂਰ ਕਰਨ ਤੋ ਪਹਿਲਾਂ"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr "ਕੀ-ਬੋਰਡ ਦੀਆਂ ਸਵਿੱਚਾਂ ਦੇ ਮੁੜ ਦੱਬਣ ਨਾਲ ਹੋਣ ਵਾਲੇ ਨੁਕਸਾਨ ਤੋਂ ਬਚਣ ਲਈ ਸਕਰੀਨ ਲਾਕ ਕਰੋ"
+
+#~ msgid "Typing Break"
+#~ msgstr "ਲਿਖਣ ਬਰੇਕ"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "ਆਖਰੀ ਅੰਤਰਾਲ ਸਮਾਂ(_B):"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "ਟਾਈਪ ਬਰੇਕ ਲਾਗੂ ਕਰਨ ਲਈ ਸਕਰੀਨ ਲਾਕ ਕਰੋ(_L)"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "ਕੰਮ ਕਰਨ ਦਾ ਅੰਤਰਾਲ(_W):"
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "ਵਿੰਡੋ ਮੈਨੇਜਰ \"%s\" ਨੇ ਸੰਰਚਨਾ ਟੂਲ ਨੂੰ ਰਜਿਸਟਰ ਨਹੀਂ ਕਰਵਾਇਆ ਹੈ।\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "ਵੱਧੋ-ਵੱਧ ਵਰਟੀਕਲ"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "ਵੱਧੋ-ਵੱਧ ਹਰੀਜੱਟਲ"
+
+#~ msgid "Roll up"
+#~ msgstr "ਸਮੇਟੋ"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "ਜਦੋਂ ਇੱਕ ਕੰਮ ਸਰਗਰਮ ਹੋਵੇ ਤਾਂ ਕੰਟਰੋਲ-ਕੇਂਦਰ ਬੰਦ ਕਰੋ"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "ਜੋੜਨ ਜਾਂ ਹਟਾਉਣ ਕਾਰਵਾਈ ਦੌਰਾਨ ਸ਼ੈੱਲ ਬੰਦ ਕਰੋ"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "ਮੱਦਦ ਕਾਰਵਾਈ ਦੌਰਾਨ ਸ਼ੈੱਲ ਬੰਦ ਕਰੋ"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "ਕਾਰਵਾਈ ਸ਼ੁਰੂ ਕਰਨ ਦੇ ਦੌਰਾਨ ਸ਼ੈੱਲ ਬੰਦ ਕਰੋ"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "ਅੱਪਗਰੇਡ ਜਾਂ ਅਣ-ਇੰਸਟਾਲ ਕਰਨ ਦੇ ਦੌਰਾਨ ਸ਼ੈੱਲ ਬੰਦ ਕਰੋ"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "ਵੇਖਾਉਦਾ ਹੈ ਕਿ ਕੀ ਇੱਕ ਮੱਦਦ ਕਾਰਵਾਈ ਕਰਨ ਦੇ ਦੌਰਾਨ ਸ਼ੈੱਲ ਬੰਦ ਹੋ ਜਾਵੇ।"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "ਵੇਖਾਉਦਾ ਹੈ ਕਿ ਕੀ ਇੱਕ ਕਾਰਵਾਈ ਸ਼ੁਰੂ ਹੋਣ ਦੇ ਦੌਰਾਨ ਸ਼ੈਲ ਬੰਦ ਹੋ ਜਾਵੇ।"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr "ਵੇਖਾਉਦਾ ਹੈ ਕਿ ਕੀ ਸ਼ਾਮਿਲ ਕਰਨ ਜਾਂ ਹਟਾਉਣ ਦੀ ਕਾਰਵਾਈ ਦੇ ਦੌਰਾਨ ਸ਼ੈੱਲ ਬੰਦ ਹੋਵੇ ਜਾਵੇ।"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr "ਵੇਖਾਉਦਾ ਹੈ ਕਿ ਕੀ ਅੱਪਗਰੇਡ ਜਾਂ ਅਣ-ਇੰਸਟਾਲ ਕਾਰਵਾਈ ਦੇ ਦੌਰਾਨ ਸ਼ੈੱਲ ਬੰਦ ਹੋ ਜਾਵੇ।"
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "ਕੰਮ ਨਾਂ ਅਤੇ ਸਬੰਧਿਤ .desktop ਫਾਇਲਾਂ"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "ਕੰਟਰੋਲ-ਸੈਂਟਰ 'ਚ ਵੇਖਾਉਣ ਲਈ ਟਾਸਕ ਨਾਂ, ਜਿਸ ਦੇ ਬਾਅਦ \";\" ਹੋਵੇਗਾ, ਜਿਸ ਦੇ ਬਾਅਦ ਸਬੰਧਿਤ ."
+#~ "desktop ਫਾਇਲ ਨਾਂ, ਜੋ ਕਿ ਕੰਮ ਨੂੰ ਸ਼ੁਰੂ ਕਰੇਗੀ।"
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[ਥੀਮ ਬਦਲੋ;gtk-theme-selector.desktop,ਪਸੰਦੀਦਾ ਐਪਲੀਕੇਸ਼ਨ ਸੈੱਟ ਕਰੋ;default-"
+#~ "applications.desktop,ਪਰਿੰਟਰ ਸ਼ਾਮਲ;gnome-cups-manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr "ਜੇ ਠੀਕ ਹੋਇਆ ਤਾਂ ਕੰਟਰੋਲ-ਕੇਂਦਰ ਬੰਦ ਹੋ ਜਾਵੇਗਾ, ਜਦੋਂ \"ਆਮ ਟਾਸਕ\" ਐਕਟੀਵੇਟਡ ਹੋ ਗਈ।"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "ਗਨੋਮ ਸੰਰਚਨਾ ਟੂਲ"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "ਅੰਤਰਾਲ ਮੁਲਤਵੀ ਕਰੋ(_P)"
+
+#~ msgid "_Take a Break"
+#~ msgstr "ਇੱਕ ਬਰੇਕ ਲਵੋ(_T)"
+
+#~ msgid "Take a break now (next in %dm)"
+#~ msgstr "ਹੁਣੇ ਅੰਤਰਾਲ ਲਵੋ ( %dm ਵਿੱਚ ਅੱਗੇ)"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "ਅਗਲੇ ਅੰਤਰਾਲ ਲਈ %d ਮਿੰਟ ਰਹਿੰਦੇ ਹਨ"
+#~ msgstr[1] "ਅਗਲੇ ਅੰਤਰਾਲ ਲਈ %d ਮਿੰਟ ਰਹਿੰਦੇ ਹਨ"
+
+#~ msgid "Take a break now (next in less than one minute)"
+#~ msgstr "ਹੁਣੇ ਅੰਤਰਾਲ ਲਵੋ (ਇੱਕ ਮਿੰਟ ਤੋਂ ਘੱਟ ਅੱਗੇ)"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "ਅਗਲੇ ਅੰਤਰਾਲ ਲਈ ਇੱਕ ਤੋਂ ਘੱਟ ਮਿੰਟ ਰਹਿੰਦਾ ਹੈ"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr "ਟਾਇਪ ਅੰਤਰਾਲ ਵਿਸ਼ੇਸਤਾ ਡਾਈਲਾਗ ਲਿਆਉਣ ਵਿੱਚ ਅਸਫਲ, ਇਹ ਗਲਤੀ ਹੈ: %s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "ਰਿੱਚਡ ਹਲਟ <richard@imendio.com> ਨੇ ਲਿਖਿਆ ਹੈ"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "ਅੰਨਡਰੇਸ ਕਾਰਲੇਸਨ ਨੇ ਆਈ ਕਨਡੀ ਜੋੜਿਆ"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "ਕੰਪਿਊਟਰ ਅੰਤਰਾਲ ਯਾਦਗਾਰ ਹੈ।"
+
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "ਅਮਨਪਰੀਤ ਸਿੰਘ ਆਲਮ ੨੦੦੪-੨੦੧੦\n"
+#~ "ਪੰਜਾਬੀ ਓਪਨਸੋਰਸ ਟੀਮ (POST)\n"
+#~ "http://www.satuj.com"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "ਜਾਂਚ ਨਾ ਕਰੋ ਕਿ ਕੀ ਨੋਟੀਫਿਕੇਸ਼ਨ ਖੇਤਰ ਮੌਜੂਦ ਹੈ"
+
+#~ msgid "Typing Monitor"
+#~ msgstr "ਲਿਖਣ ਨਿਗਰਾਨ"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "ਟਾਇਪਇੰਗ ਨਿਗਰਾਨ ਸੂਚਨਾ-ਖੇਤਰ ਵਿੱਚ ਜਾਣਕਾਰੀ ਵੇਖਾਉਣ ਦੇ ਕੰਮ ਆਉਦਾ ਹੈ। ਤੁਹਾਡੇ ਪੈਨਲ ਵਿੱਚ ਸੂਚਨਾ-"
+#~ "ਖੇਤਰ ਹੈ ਹੀ ਨਹੀਂ। ਤੁਸੀ ਇਸ ਨੂੰ ਪੈਨਲ ਤੇ ਸੱਜਾ ਬਟਨ ਦਬਾਕੇ ਅਤੇ 'ਪੈਨਲ ਵਿੱਚ ਸ਼ਾਮਿਲ', 'ਸੂਚਨਾ-ਖੇਤਰ' "
+#~ "ਚੁਣਨ ਨਾਲ ਇਸ ਨੂੰ ਲਿਆ ਸਕਦੇ ਹੋ।"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "ਜੇਕਰ ਇਹ ਸੱਚ ਹੈ ਤਾਂ, ਓਪਨ-ਟਾਈਪ (OpenType) ਫੋਂਟ ਥੰਬਨੇਲ ਬਣ ਜਾਣਗੇ।"
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "ਜੇਕਰ ਇਹ ਸੱਚ ਹੈ ਤਾਂ, ਪੀਸੀਐਫ (PCF) ਫੋਂਟ ਥੰਬਨੇਲ ਬਣ ਜਾਣਗੇ।"
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "ਜੇਕਰ ਇਹ ਸੱਚ ਹੈ ਤਾਂ, ਟਰੂ-ਟਾਇਪ (TrueType) ਫੋਂਟ ਥੰਬਨੇਲ ਬਣ ਜਾਣਗੇ।"
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "ਜੇਕਰ ਇਹ ਸੱਚ ਹੈ ਤਾਂ, Type1 ਫੋਂਟ ਥੰਬਨੇਲ ਬਣ ਜਾਣਗੇ।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr "ਕਮਾਂਡ, ਜੋ ਫੋਂਟ ਓਪਨ-ਟਾਈਪ (OpenType) ਲਈ ਥੰਬਨੇਲ ਬਣਾਉਦੀ ਹੈ, ਨੂੰ ਇਹ ਸਵਿੱਚ ਦਿਓ।"
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "ਕਮਾਂਡ, ਜੋ ਫੋਂਟ ਪੀਸੀਐਫ (PCF) ਲਈ ਥੰਬਨੇਲ ਬਣਾਉਦੀ ਹੈ, ਨੂੰ ਇਹ ਸਵਿੱਚ ਦਿਓ।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr "ਕਮਾਂਡ, ਜੋ ਫੋਂਟ ਟਰੂ-ਟਾਈਪ (TrueType) ਲਈ ਥੰਬਨੇਲ ਬਣਾਉਦੀ ਹੈ, ਨੂੰ ਇਹ ਸਵਿੱਚ ਦਿਓ।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "ਕਮਾਂਡ, ਜੋ ਫੋਂਟ ਟਾਈਪ ੧ (Type1) ਲਈ ਥੰਬਨੇਲ ਬਣਾਉਦੀ ਹੈ, ਨੂੰ ਇਹ ਸਵਿੱਚ ਦਿਓ।"
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "ਫੋਂਟ ਓਪਨਟਾਈਪ (OpenType) ਲਈ ਥੰਬਨੇਲ ਕਮਾਂਡ"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "ਫੋਂਟ ਪੀਸੀਐਫ (PCF) ਲਈ ਥੰਬਨੇਲ ਕਮਾਂਡ"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "ਫੋਂਟ ਟਰੂ-ਟਾਈਪ (TrueType) ਲਈ ਥੰਬਨੇਲ ਕਮਾਂਡ"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "ਫੋਂਟ ਟਾਈਪ1 (Type1) ਲਈ ਥੰਬਨੇਲ ਕਮਾਂਡ"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "ਕੀ ਫੋਂਟ ਓਪਨ-ਟਾਈਪ(OpenType) ਨੂੰ ਥੰਬਨੇਲ ਕਰਨਾ ਹੈ"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "ਕੀ ਫੋਂਟ ਪੀਸੀਐਫ(PCF) ਨੂੰ ਥੰਬਨੇਲ ਕਰਨਾ ਹੈ"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "ਕੀ ਫੋਂਟ ਟਰੂ-ਟਾਈਪ(TrueType) ਨੂੰ ਥੰਬਨੇਲ ਕਰਨਾ ਹੈ"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "ਕੀ ਫੋਂਟ ਟਾਈਪ1 (Type1) ਨੂੰ ਥੰਬਨੇਲ ਕਰਨਾ ਹੈ"
+
+#~ msgid "Copyright:"
+#~ msgstr "ਹੱਕ ਰਾਖਵੇਂ ਹਨ:"
+
+#~ msgid "Installed"
+#~ msgstr "ਇੰਸਟਾਲ ਹੋਇਆ"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "ਵਰਤੋਂ: %s fontfile\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "ਫੋਂਟ ਇੰਸਟਾਲ ਕਰੋ(_n)"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "ਥੰਬਨੇਲ ਕਰਨ ਲਈ ਟੈਕਸਟ (ਡਿਫਾਲਟ: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "ਫੋਂਟ ਆਕਾਰ (ਡਿਫਾਲਟ: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "_Jabber:"
+#~ msgstr "ਜੱਬਰ(_J):"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "ਸਹੂਲਤ ਲਾਗਇਨ(_g)"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "ਸਹਾਇਕ ਤਕਨਾਲੋਜੀ ਯੋਗ"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "ਸਹਾਇਕ ਤਕਨਾਲੋਜੀ ਪਸੰਦ"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "ਸਹਾਇਕ ਤਕਨਾਲੋਜੀ ਯੋਗ ਕਰਨ ਲਈ ਬਦਲਾਅ ਤੁਹਾਡੇ ਅਗਲੀ ਵਾਰ ਲਾਗਇਨ ਕਰਨ ਤੱਕ ਲਾਗੂ ਨਹੀਂ ਹੋਣਗੇ।"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "ਬੰਦ ਕਰੋ ਅਤੇ ਲਾਗਆਉਟ(_L)"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "ਪਸੰਦੀਦਾ ਕਾਰਜ ਡਾਈਲਾਗ ਉੱਤੇ ਜਾਓ"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "ਸੁਲੱਭਤਾ ਲਾਗਇਨ ਡਾਈਲਾਗ ਉੱਤੇ ਜਾਓ"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "ਕੀ-ਬੋਰਡ ਸਹੂਲਤ ਡਾਈਲਾਗ ਉੱਤੇ ਜਾਓ"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "ਮਾਊਂਸ ਅਸੈੱਸਬਿਲਟੀ ਡਾਈਲਾਗ ਲਈ ਜਾਓ"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "ਸਹਾਇਕ ਤਕਨਾਲੋਜੀ ਯੋਗ(_E)"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "ਮਾਊਂਸ ਅਸੈੱਸਬਿਲਟੀ(_M)"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "ਪਸੰਦੀਦਾ ਐਪਲੀਕੇਸ਼ਨ(_P)"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "ਜਦੋਂ ਤੁਸੀਂ ਲਾਗ ਕਰੋ ਤਾਂ ਅਸੈੱਸਬਿਲਟੀ ਫੀਚਰ ਯੋਗ ਕਰਨਾ ਚੁਣੋ"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr "ਵੇਖਾਉਣ ਲਈ ਪੇਜ਼ ਦਾ ਨਾਂ ਦਿਓ (internet|multimedia|system|a11y)"
+
+#~| msgid "Mouse Preferences"
+#~ msgid "Monitor Preferences"
+#~ msgstr "ਮਾਊਸ ਪਸੰਦ"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "ਸਿਰਫ ਸੈਟਿੰਗ ਲਾਗੂ ਕਰੋ ਤੇ ਬਾਹਰ ਜਾਓ (ਸਿਰਫ ਅਨੁਕੂਲਤਾ; ਡੇਮੋਨ ਸੰਭਾਲੇਗੀ)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "ਸਫ਼ਾ ਸ਼ੁਰੂ ਕਰੋ, ਟਾਇਪ ਅੰਤਰਾਲ ਦੀ ਸੈਟਿੰਗ ਵੇਖਾਉਣ ਨਾਲ"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "ਪੇਜ਼ ਅਸੈੱਸਬਿਲਟੀ ਸੈਟਿੰਗ ਵੇਖਾਉਣ ਨਾਲ ਸ਼ੁਰੂ ਕਰੋ"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- ਗਨੋਮ ਕੀ-ਬੋਰਡ ਪਸੰਦ"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "ਵੇਖਾਉਣ ਵਾਸਤੇ ਪੇਜ਼ ਦਾ ਨਾਂ ਦਿਓ (general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- ਗਨੋਮ ਮਾਊਂਸ ਪਸੰਦ"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "ਤੁਹਾਡੇ ਵਿੰਡੋ ਮੈਨੇਜਰ ਲਈ ਮੇਰੀ-ਪਸੰਦ ਕਾਰਜ ਨੂੰ ਸ਼ੁਰੂ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "ਸੁਪਰ (ਜਾਂ \"ਵਿੰਡੋ ਲੋਗੋ\")(_u)"
+
+#~ msgid "_Meta"
+#~ msgstr "ਮੈਟਾ(_M)"
+
+#~ msgid "Titlebar Action"
+#~ msgstr "ਟਾਈਟਲਬਾਰ ਐਕਸ਼ਨ"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "ਵਿੰਡੋ ਨੂੰ ਏਧਰ-ਓਧਰ ਕਰਨ ਲਈ, ਇਹ ਸਵਿੱਚ ਦਬਾਉ ਅਤੇ ਦਬਾਈ ਰੱਖੋ, ਤਦ ਵਿੰਡੋ ਨੂੰ ਫੜ ਲਵੋ:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "ਵਿੰਡੋ ਪਸੰਦ"
+
+#~ msgid "Window Selection"
+#~ msgstr "ਵਿੰਡੋ ਚੋਣ"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "ਉਭਾਰਨ ਤੋਂ ਪਹਿਲਾਂ ਦਾ ਅੰਤਰਾਲ(_I):"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "ਇੱਕ ਅੰਤਰਾਲ ਮਗਰੋਂ ਚੁਣੀ ਵਿੰਡੋ ਨੂੰ ਉਭਾਰੋ(_R)"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "ਵਿੰਡੋ ਚੁਣੋ, ਜਦੋ ਕਿ ਮਾਊਸ ਇਸ ਉੱਤੇ ਹੋਵੇ(_S)"
+
+#~ msgid "Set your window properties"
+#~ msgstr "ਆਪਣੀ ਵਿੰਡੋ ਵਿਸ਼ੇਸ਼ਤਾ ਦਿਓ"
+
+#~ msgid "Windows"
+#~ msgstr "ਵਿੰਡੋ"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "ਸ਼ੁਰੂ ਉੱਤੇ ਓਹਲੇ (ਪ੍ਰੀ-ਲੋਡ ਸ਼ੈੱਲ ਲਈ ਫਾਇਦੇਮੰਦ)"
+
+#~ msgid "Filter"
+#~ msgstr "ਫਿਲਟਰ"
+
+#~ msgid "Groups"
+#~ msgstr "ਗਰੁੱਪ"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "ਤੁਹਾਡਾ ਫਿਲਟਰ \"%s\" ਕਿਸੇ ਵੀ ਆਈਟਮ ਨਾਲ ਨਹੀਂ ਮਿਲਦਾ।"
+
+#~ msgid "Upgrade"
+#~ msgstr "ਅੱਪਗਰੇਡ"
+
+#~ msgid "Uninstall"
+#~ msgstr "ਅਣ-ਇੰਸਟਾਲ"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "ਪਸੰਦ 'ਚ ਸ਼ਾਮਲ"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "ਸਟਾਰਟਅੱਪ ਪਰੋਗਰਾਮਾਂ 'ਚੋਂ ਹਟਾਓ"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "ਸਟਾਰਟਅੱਪ ਪਰੋਗਰਾਮਾਂ 'ਚ ਸ਼ਾਮਲ"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "ਨਵੀਂ ਸਪਰੈੱਡਸ਼ੀਟ"
+
+#~ msgid "New Document"
+#~ msgstr "ਨਵਾਂ ਡੌਕੂਮੈਂਟ"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>ਖੋਲ੍ਹੋ</b>"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "ਜੇ ਤੁਸੀਂ ਇੱਕ ਆਈਟਮ ਹਟਾਈ ਤਾਂ ਇਹ ਪੱਕੇ ਤੌਰ ਉੱਤੇ ਖਤਮ ਹੋ ਜਾਵੇਗੀ।"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "ਫਾਈਲ ਮੈਨੇਜਰ 'ਚ ਖੋਲ੍ਹੋ"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "ਅੱਜ %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "ਕੱਲ੍ਹ %l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "ਹੁਣੇ ਖੋਜ"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s ਖੋਲ੍ਹੋ</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "ਸਿਸਟਮ ਆਈਟਮਾਂ ਵਿੱਚੋਂ ਹਟਾਓ"
+
+#~ msgid "Display Preferences"
+#~ msgstr "ਡਿਸਪਲੇਅ ਪਸੰਦ"
+
+#~ msgid "Drag the monitors to set their place"
+#~ msgstr "ਮਾਨੀਟਰਾਂ ਦੀ ਥਾਂ ਸੈੱਟ ਕਰਨ ਲਈ ਹਿਲਾਓ"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "ਸਕਰੀਨ ਦੀ ਰੈਜੋਲੇਸ਼ਨ ਬਦਲੋ"
+
+#~| msgid "<b>Menus and Toolbars</b>"
+#~ msgid "Menus and Toolbars"
+#~ msgstr "ਮੇਨੂ ਅਤੇ ਟੂਲਬਾਰ"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "ਮੇਨੂ 'ਚ ਆਈਕਾਨ ਵੇਖੋ(_i)"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "ਟੂਲਬਾਰ ਬਟਨ ਲੇਬਲ(_b):"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "ਸੋਧਯੋਗ ਮੇਨੂ ਸ਼ਾਰਟਕੱਟ ਸਵਿੱਚਾਂ(_E)"
+
+#~ msgid "_File"
+#~ msgstr "ਫਾਇਲ(_F)"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "ਚੁਣੇ ਲੇਆਉਟ(_S):"
+
+#~ msgid "C_ontrol"
+#~ msgstr "C_ontrol"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "ੳਅੲਸਹ ਕਖਗਘਙ ਚਛਜਝਞ ਟਠਡਢਣ ਤਥਦਧਨ ਪਫਬਭਮ ਯਰਲਵੜ ਸ਼ਖ਼ਗ਼ਜ਼ਲ਼ਫ਼। ੦੧੨੩੪੫੬੭੮੯"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr "ਅਣਜਾਣ ਲਾਗਇਨ ID, ਯੂਜ਼ਰ ਡਾਟਾਬੇਸ ਨਿਕਾਰਾ ਹੋ ਗਿਆ ਹੈ"
+
+#~ msgid ""
+#~ "Left thumb\n"
+#~ "Left middle finger\n"
+#~ "Left ring finger\n"
+#~ "Left little finger\n"
+#~ "Right thumb\n"
+#~ "Right middle finger\n"
+#~ "Right ring finger\n"
+#~ "Right little finger"
+#~ msgstr ""
+#~ "ਖੱਬਾ ਅੰਗੂਠਾ\n"
+#~ "ਖੱਬੀ ਵਿਚਲੀ ਉਂਗਲ\n"
+#~ "ਖੱਬੀ ਅੰਗੂਠੀ ਉਂਗਲ\n"
+#~ "ਖੱਬੀ ਚੀਂਚੀ\n"
+#~ "ਸੱਜਾ ਅੰਗੂਠਾ\n"
+#~ "ਸੱਜੀ ਵਿਚਲੀ ਉਂਗਲ\n"
+#~ "ਸੱਜੀ ਅੰਗੂਠੀ ਉਂਗਲ\n"
+#~ "ਸੱਜੀ ਚੀਂਚੀ"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>ਘਰ</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>ਵੈਬ</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>ਕੰਮ</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">ਆਪਣਾ ਪਾਸਵਰਡ ਬਦਲੋ</span>"
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>ਸਹਾਇਕ ਤਕਨਾਲੋਜੀ ਯੋਗ</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>ਮੇਰੀ ਪਸੰਦ</b>"
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>ਰੰਗ(_o)</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>ਝਲਕ</b>"
+
+#~ msgid "<b>_Desktop Background</b>"
+#~ msgstr "<b>ਡੈਸਕਟਾਪ ਬੈਕਗਰਾਊਂਡ(_D)</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "ਕੱਟੋ(_u)"
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "ਇੱਕ ਗੂੜਾ ਰੰਗ\n"
+#~ "ਖਿਤਿਜੀ ਢਾਲਵਾਂ\n"
+#~ "ਲੰਬਕਾਰੀ ਢਾਲਵਾਂ"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "ਆਈਟਮਾਂ ਹੇਠ ਟੈਕਸਟ\n"
+#~ "ਆਈਟਮਾਂ ਨਾਲ ਟੈਕਸਟ\n"
+#~ "ਆਈਕਾਨ ਹੀ\n"
+#~ "ਟੈਕਸਟ ਹੀ"
+
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "ਤਣਿਆ\n"
+#~ "ਜ਼ੂਮ\n"
+#~ "ਸੈਂਟਰਡ\n"
+#~ "ਸਕੇਲ\n"
+#~ "ਸਕਰੀਨ ਭਰੋ"
+
+#~ msgid "_New"
+#~ msgstr "ਨਵਾਂ(_N)"
+
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b>ਦਿੱਖ</b>"
+
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "ਆਮ\n"
+#~ "ਖੱਬੇ\n"
+#~ "ਸੱਜੇ\n"
+#~ "ਉੱਤਲਾ-ਹੇਠਾਂ\n"
+
+#~ msgid "Could not apply the selected configuration"
+#~ msgstr "ਚੁਣੀ ਸੰਰਚਨਾ ਲਾਗੂ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ"
+
+#~ msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+#~ msgstr "org.gnome.SettingsDaemon.XRANDR ਲਈ ਨਹੀਂ ਜਾ ਸਕੀ"
+
+#~ msgid "<b>Bounce Keys</b>"
+#~ msgstr "<b>ਬਾਊਸ ਸਵਿੱਚਾਂ ਯੋਗ</b>"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>ਆਮ</b>"
+
+#~ msgid "<b>Sticky Keys</b>"
+#~ msgstr "<b>ਸਟਿੱਕੀ ਸਵਿੱਚਾਂ</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>ਤੇਜ਼</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>ਲੰਮਾ</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>ਛੋਟਾ</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>ਹੌਲੀ</i></small>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>ਪੁਆਇੰਟਰ ਦੱਸੋ<b>"
+
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i>ਵੱਧ</i></small>"
+
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i>ਵੱਡਾ</i></small>"
+
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>ਘੱਟ</i></small>"
+
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i>ਛੋਟਾ</i></small>"
+
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>ਹੋਸਟ ਲਿਸਟ ਅਣਡਿੱਠੀ</b>"
+
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>ਕੋਈ ਮੇਲ ਨਹੀਂ ਲੱਭਿਆ।</b></span><span>\n"
+#~ "\n"
+#~ "ਤੁਹਾਡਾ ਫਿਲਟਰ \"<b> %s</b>\" ਕਿਸੇ ਇਕਾਈ ਨਾਲ ਨਹੀਂ ਮਿਲਦਾ ਹੈ।</span>"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>ਵਾਲਪੇਪਰ(_W)</b>"
+
+#~ msgid "Screen Resolution"
+#~ msgstr "ਸਕਰੀਨ ਰੈਜੋਲੇਸ਼ਨ"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "ਮੁੜ ਪੁਰਾਣੀ ਸੈਟਿੰਗ ਪਰਤਾਓ ਅਤੇ ਸੰਭਾਲੋ"
+
+#~ msgid "Unknown Volume Control %d"
+#~ msgstr "ਅਣਜਾਣ ਵਾਲੀਅਮ ਕੰਟਰੋਲ %d"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - ਅਡਵਾਂਸ ਲੀਨਕਸ ਸਾਊਂਡ ਆਰਚੀਟੈਕਚਰ"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART ਸਾਊਂਡ ਡੈਮਨ"
+
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ESD - ਈਨਹਾਂਸਡ ਸਾਊਂਡ ਡੈਮਨ"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - ਓਪਨ ਸਾਊਂਡ ਸਿਸਟਮ"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "PulseAudio ਸਾਊਂਡ ਸਰਵਰ"
+
+#~ msgid "Silence"
+#~ msgstr "ਚੁੱਪ"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "- ਗਨੋਮ ਸਾਊਂਡ ਪਸੰਦ"
+
+#~ msgid "<b>Alerts and Sound Effects</b>"
+#~ msgstr "<b>ਚੇਤਾਵਨੀਆਂ ਅਤੇ ਸਾਊਂਡ ਪਰਭਾਵ</b>"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>ਆਡੀਓ ਕਨਫਰੰਸ</b>"
+
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>ਡਿਫਾਲਟ ਮਿਕਸਰ ਟਰੈਕ</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>ਸੰਗੀਤ ਅਤੇ ਮੂਵੀ</b>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "ਪੂਰਾ ਕਰਨ ਲਈ ਠੀਕ ਹੈ ਦਬਾਓ।"
+
+#~ msgid "Play _sound effects when buttons are clicked"
+#~ msgstr "ਜਦੋਂ ਬਟਨ ਕਲਿੱਕ ਕੀਤਾ ਜਾਵੇ ਤਾਂ ਸਾਊਂਡ ਪਰਭਾਵ ਚਲਾਓ(_s)"
+
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+#~ msgstr ""
+#~ "ਕੀ-ਬੋਰਡ ਨਾਲ ਕੰਟਰੋਲ ਕਰਨ ਜੰਤਰ ਅਤੇ ਟਰੈਕ ਚੁਣੋ। ਜੇ ਬਹੁਤੇ ਟਰੈਕ ਇਕੋ ਵਾਰ ਚੁਣਨੇ ਹੋਣ ਤਾਂ ਸਿਫ਼ਟ ਅਤੇ "
+#~ "ਕੰਟਰੋਲ (Ctrl) ਸਵਿੱਚਾਂ ਦੀ ਵਰਤੋਂ ਕੀਤੀ ਜਾ ਸਕਦੀ ਹੈ।"
+
+#~ msgid "So_und playback:"
+#~ msgstr "ਸਾਊਂਡ ਸੁਣਾਓ(_u):"
+
+#~ msgid "Sou_nd capture:"
+#~ msgstr "ਸਾਊਂਡ ਕੈਪਚਰ(_n):"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "ਟੈਸਟਿੰਗ ਪਾਇਪਲਾਇਨ"
+
+#~ msgid "_Play alerts and sound effects"
+#~ msgstr "ਚੇਤਾਵਨੀਆਂ ਅਤੇ ਸਾਊਂਡ ਪਰਭਾਵ ਚਲਾਓ(_P)"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "ਸਾਊਂਡ ਸੁਣਾਓ(_S):"
+
+#~ msgid "Custom..."
+#~ msgstr "ਕਸਟਮ..."
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "ਗਨੋਮ ਸਹਾਇਕ ਤਕਨਾਲੋਜੀ ਲਈ ਮੱਦਦ ਲਾਗਇਨ ਸਮੇਂ ਚਾਲੂ"
+
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s ਰਾਹ ਹੈ, ਜਿਥੇ ਕਿ ਥੀਮ ਫਾਇਲਾਂ ਇੰਸਟਾਲ ਹੋਣਗੀਆ। ਇਸ ਨੂੰ ਸਰੋਤ ਨਹੀਂ ਬਣਾਇਆ ਜਾ ਸਕਦਾ ਹੈ"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "ਸਕਰੀਨ ਰੈਜੋਲੇਸ਼ਨ ਪਸੰਦ"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "ਸਿਰਫ ਕੰਪਿਊਟਰ (%s) ਲਈ ਹੀ ਮੂਲ ਬਣਾਓ(_M)"
+
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "ਨਵੀਂ ਸੈਟਿੰਗ ਦੀ ਜਾਂਚ। ਜੇਕਰ ਤੁਸੀ %d ਸਕਿੰਟ ਵਿੱਚ ਕੋਈ ਜਵਾਬ ਨਾ ਦਿੱਤਾ ਮੁੜ ਪੁਰਾਣੀ ਸੈਟਿੰਗ ਸੰਭਾਲੀ "
+#~ "ਜਾਵੇਗੀ"
+#~ msgstr[1] ""
+#~ "ਨਵੀਂ ਸੈਟਿੰਗ ਦੀ ਜਾਂਚ। ਜੇਕਰ ਤੁਸੀ %d ਸਕਿੰਟਾਂ ਵਿੱਚ ਕੋਈ ਜਵਾਬ ਨਾ ਦਿੱਤਾ ਮੁੜ ਪੁਰਾਣੀ ਸੈਟਿੰਗ ਸੰਭਾਲੀ "
+#~ "ਜਾਵੇਗੀ"
+
+#~ msgid "Keep Resolution"
+#~ msgstr "ਰੈਜੋਲੇਸ਼ਨ ਰੱਖੋ"
+
+#~ msgid "Use _Previous Resolution"
+#~ msgstr "ਪੁਰਾਣਾ ਰੈਜੋਲੇਸ਼ਨ ਵਰਤੋਂ(_P)"
+
+#~ msgid "_Keep Resolution"
+#~ msgstr "ਰੈਜੋਲੇਸ਼ਨ ਰੱਖੋ(_K)"
+
+#~ msgid ""
+#~ "The X server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "X-ਸਰਵਰ XRandR ਇਕਸ਼ਟੇਸ਼ਨ ਨੂੰ ਸਹਾਇਕ ਨਹੀਂ ਹੈ। ਡਿਸਪਲੇਅ ਸਾਈਜ਼ ਲਈ ਰਨ-ਟਾਈਮ ਰੈਜ਼ੋਲੇਸ਼ਨ ਬਦਲਾ ਸੰਭਵ "
+#~ "ਨਹੀਂ ਹੈ।"
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "XRandR ਦਾ ਵਰਜਨ ਇਸ ਕਾਰਜ ਨਾਲ ਅਨੁਕੂਲ ਨਹੀਂ ਹੈ। ਵੇਖਣ ਆਕਾਰ ਵਿੱਚ ਰਨ-ਟਾਇਮ ਤਬਦੀਲੀ ਉਪਲੱਬਧ "
+#~ "ਨਹੀਂ ਹੋਵੇਗੀ।"
+
+#~ msgid "New accelerator..."
+#~ msgstr "ਨਵਾਂ ਐਕਸਰਲੇਟਰ..."
+
+#~ msgid "Error setting new accelerator in configuration database: %s"
+#~ msgstr "ਗਲਤੀ, ਸੰਰਚਨਾ ਡੈਟਾਬੇਸ ਵਿੱਚ ਨਵਾਂ ਐਕਸਰਲੇਟਰ ਸੈਟ ਕਰਨ ਵਿੱਚ: %s"
+
+#~ msgid "E_nable software sound mixing"
+#~ msgstr "ਸਾਫਟਵੇਅਰ ਧੁਨੀ ਮਿਕਸਿੰਗ ਯੋਗ (ESD)(_n)"
+
+#~ msgid "System Beep"
+#~ msgstr "ਸਿਸਟਮ ਘੰਟੀ"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "ਸਿਸਟਮ ਘੰਟੀ ਯੋਗ(_E)"
+
+#~ msgid "_Visual system beep"
+#~ msgstr "ਦਿੱਖ ਸਿਸਟਮ ਘੰਟੀ(_V)"
+
+#~ msgid "Unexpected attribute '%s' for element '%s'"
+#~ msgstr "'%2$s' ਐਲੀਮੈਂਟ ਦਾ '%1$s' ਗੁਣ ਗਲਤ ਹੈ"
+
+#~ msgid "Attribute '%s' of element '%s' not found"
+#~ msgstr "'%2$s' ਐਲੀਮੈਂਟ ਦਾ '%1$s' ਗੁਣ ਨਹੀਂ ਲੱਭਿਆ"
+
+#~ msgid "Unexpected tag '%s', tag '%s' expected"
+#~ msgstr "ਗਲਤ ਟੈਗ '%s', ਟੈਗ '%s' ਦੀ ਲੋੜ ਸੀ"
+
+#~ msgid "Unexpected tag '%s' inside '%s'"
+#~ msgstr "'%2$s' ਵਿੱਚ ਗਲਤ '%1$s' ਟੈਗ"
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "ਡਾਟਾ ਡਾਇਰੈਕਟਰੀ ਵਿੱਚ ਕੋਈ ਠੀਕ ਬੁੱਕਮਾਰਕ ਫਾਇਲ ਨਹੀਂ ਲੱਭੀ"
+
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "URI '%s' ਲਈ ਕੋਈ ਬੁੱਕਮਾਰਕ ਨਹੀਂ ਲੱਭਾ"
+
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "URI '%s' ਲਈ ਬੁੱਕਮਾਰਕ ਵਿੱਚ ਕੋਈ MIME ਕਿਸਮ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "No private flag has been defined in bookmark for URI '%s'"
+#~ msgstr "URI '%s' ਲਈ ਬੁੱਕਮਾਰਕ ਵਿੱਚ ਕੋਈ ਪ੍ਰਾਈਵੇਟ ਫਲੈਸ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "No groups set in bookmark for URI '%s'"
+#~ msgstr "URI '%s' ਲਈ ਬੁੱਕਮਾਰਕ ਵਿੱਚ ਕੋਈ ਗਰੁੱਪ ਨਹੀਂ ਦਿੱਤਾ"
+
+#~ msgid "No application with name '%s' registered a bookmark for '%s'"
+#~ msgstr "'%s' ਨਾਂ ਨਾਲ ਕੋਈ ਵੀ ਕਾਰਜ '%s' ਲਈ ਬੁੱਕਮਾਰਕ ਦੇ ਤੌਰ ਉੱਤੇ ਰਜਿਸਟਰ ਨਹੀਂ ਹੋਇਆ।"
+
+#~ msgid "Beep"
+#~ msgstr "ਬੀਪ"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "ਇਹ ਘਟਨਾ ਲਈ ਧੁਨੀ ਸੈੱਟ ਨਹੀਂ ਹੈ।"
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
+#~ msgstr ""
+#~ "ਇਹ ਘਟਨਾ ਲਈ ਧੁਨੀ ਫਾਇਲ ਮੌਜੂਦ ਨਹੀਂ ਹੈ।\n"
+#~ "ਤੁਸੀਂ ਮੂਲ ਧੁਨੀਆਂ ਦੇਣ ਲਈ gnome-audio ਪੈਕੇਜ ਇੰਸਟਾਲ ਕਰ ਸਕਦੇ ਹੋ।"
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "ਫਾਇਲ %s ਇੱਕ ਠੀਕ ਵੇਵ (wav) ਫਾਇਲ ਨਹੀਂ ਹੈ"
+
+#~ msgid "Sets the default application font"
+#~ msgstr "ਮੂਲ ਕਾਰਜ ਫੋਂਟ ਦਿਓ"
+
+#~ msgid ""
+#~ "Centered\n"
+#~ "Fill screen\n"
+#~ "Scaled\n"
+#~ "Zoom\n"
+#~ "Tiled"
+#~ msgstr ""
+#~ "ਕੇਂਦਰੀ\n"
+#~ "ਪੂਰੀ ਸਕਰੀਨ\n"
+#~ "ਸਕੇਲ ਕੀਤਾ\n"
+#~ "ਜ਼ੂਮ\n"
+#~ "ਟਾਇਲ"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "ਸੈਟਿੰਗ ਲਾਗੂ ਕਰੋ ਅਤੇ ਬਾਹਰ"
+
+#~ msgid "Keyboard Accessibility Notifications"
+#~ msgstr "ਕੀ-ਬੋਰਡ ਅਸੈੱਸਬਿਲਟੀ ਨੋਟੀਫਿਕੇਸ਼ਨ"
+
+#~ msgid "_Layouts:"
+#~ msgstr "ਲੇਆਉਟ(_L):"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "ਤਕਨੀਕੀ ਸੰਰਚਨਾ"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">ਕੀ ਨਵੇਂ ਫੋਂਟ ਲਾਗੂ ਕਰਨੇ ਹਨ?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "ਫੋਂਟ ਲਾਗੂ ਨਾ ਕਰੋ(_n)"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "ਥੀਮ, ਜੋ ਤੁਸੀਂ ਚੁਣਿਆ ਹੈ, ਉਹ ਨਵੇਂ ਫੋਂਟ ਸੁਝਾਅ ਰਿਹਾ ਹੈ। ਫੋਂਟ ਦੀ ਝਲਕ ਹੇਠ ਦਿੱਤੀ ਜਾ ਰਹੀ ਹੈ।"
+
+#~ msgid "Themes"
+#~ msgstr "ਥੀਮ"
+
+#~ msgid "Control theme"
+#~ msgstr "ਕੰਟਰੋਲ ਥੀਮ"
+
+#~ msgid "Window border theme"
+#~ msgstr "ਵਿੰਡੋ ਹਾਸ਼ੀਆ ਥੀਮ"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "ਜੇਕਰ ਸੱਚ ਹੈ ਤਾਂ, ਇੰਸਟਾਲ ਥੀਮ ਥੰਬਨੇਲ ਬਣ ਜਾਣਗੇ।"
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "ਜੇਕਰ ਸੱਚ ਹੈ ਤਾਂ, ਥੀਮ ਥੰਬਨੇਲ ਬਣ ਜਾਣਗੇ।"
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr "ਇੰਸਟਾਲ ਥੀਮਾਂ ਦੇ ਥੰਬਨੇਲ ਬਣਾਉਣ ਲਈ ਵਰਤਣੀ ਕਮਾਂਡ ਨੂੰ ਇਹ ਸਵਿੱਚ ਦਿਓ।"
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr "ਥੀਮਾਂ ਦੇ ਥੰਬਨੇਲ ਬਣਾਉਣ ਲਈ ਵਰਤਣੀ ਕਮਾਂਡ ਨੂੰ ਇਹ ਸਵਿੱਚ ਦਿਓ।"
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "ਇੰਸਟਾਲ ਥੀਮਾਂ ਲਈ ਥੰਬਨੇਲ ਕਮਾਂਡ"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "ਥੀਮਾਂ ਲਈ ਥੰਬਨੇਲ ਕਮਾਂਡ"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "ਕੀ ਇੰਸਟਾਲ ਥੀਮ ਨੂੰ ਥੰਬਨੇਲ ਕਰਨਾ ਹੈ"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "ਕੀ ਥੀਮ ਨੂੰ ਥੰਬਨੇਲ ਕਰਨਾ ਹੈ"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#~ msgid "[FILE]"
+#~ msgstr "[ਫਾਇਲ]"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "ਡਿਫਾਲਟ ਥੀਮ ਬਣਾਓ"
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "ਮਾਊਸ ਪਸੰਦ ਡਾਈਲਾਗ ਨੂੰ ਚਲਾਉਣ ਵਿੱਚ ਗਲਤੀ ਹੈ: %s"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "ਫਾਇਲ '%s' ਤੋਂ AccessX ਸੈਟਿੰਗ (ਸਥਾਪਨ) ਖੋਲ੍ਹਣ ਵਿੱਚ ਅਸਮਰੱਥ"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "ਫੀਚਰ ਸੈਟਿੰਗ ਫਾਇਲ ਲਿਆਓ"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "ਆਪਣੀ ਕੀ-ਬੋਰਡ ਸਹੂਲਤ ਪਸੰਦ ਦਿਓ"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "ਸਿਸਟਮ 'ਤੇ XKB ਐਕਸਟੇਸ਼ਨ ਉਪਲੱਬਧ ਨਹੀਂ ਹੈ। ਕੀ-ਬੋਰਡ ਸੁਲੱਭਤਾ ਦੀ ਸਹੂਲਤ ਇਸ ਬਿਨਾਂ ਕੰਮ ਨਹੀਂ ਕਰੇਗੀ।"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>ਮਾਊਸ ਸਵਿੱਚਾਂ ਯੋਗ(_M)</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>ਦੁਹਰਾਉ ਸਵਿੱਚਾਂ ਯੋਗ(_R)</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>ਫੀਚਰ</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>ਤਬਦੀਲ ਸਵਿੱਚਾਂ</b>"
+
+#~ msgid "Basic"
+#~ msgstr "ਬੇਸਿਕ"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "ਬੀਪ, ਜਦੋਂ ਕਿ LED ਚਾਲੂ ਹੋਵੇ ਅਤੇ ਦੋ-ਵਾਰ ਧੁਨ, ਜਦੋਂ ਕਿ ਇਹ ਬੰਦ ਹੋਵੇ।"
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "ਅੰਤਰਾਲ ਕੀ-ਦਬਾਉਣ ਅਤੇ ਪੁਆਇੰਟਰ ਦੀ ਹਿਲਜੁੱਲ ਵਿੱਚ(_v):"
+
+#~ msgid "E_nable Toggle Keys"
+#~ msgstr "ਤਬਦੀਲ ਸਵਿੱਚਾਂ ਯੋਗ(_n)"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr "ਇੱਕੋ ਸਵਿੱਚ ਨੂੰ ਮੁੜ ਕੇ ਦਬਾਉਣਾ ਰੱਦ ਕਰ ਦਿਓ, ਜੇਕਰ ਇਹ ਯੂਜ਼ਰ ਦੇ ਚੁਣੇ ਸਮੇਂ ਦੇ ਅੰਦਰ ਹੀ ਹੋਵੇ।"
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "ਕੀ-ਬੋਰਡ ਸੁਲੱਭਤਾ ਪਸੰਦ (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "ਪੁਆਇੰਟਰ ਦੀ ਵੱਧੋ-ਵੱਧ ਗਤੀ(_x):"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "ਮਾਊਸ ਪਸੰਦ(_P)..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "ਸਵਿੱਚ ਉਦੋਂ ਹੀ ਸਵੀਕਾਰ ਕਰੋ, ਜਦੋਂ ਕਿ ਉਹ ਦਬਾਇਆ ਜਾਣ ਅਤੇ ਸਹੂਲਤ ਸੋਧ ਯੋਗ ਸਮੇ ਲਈ ਦਬਾਈਆਂ ਜਾਣ।"
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr "ਬਹੁ ਸੈਮੂਲੇਸ਼ਨ ਸਵਿੱਚ ਦਬਾਉਣ ਕਾਰਵਾਈ ਕਰੋ, ਮਾਡੀਫਾਇਰ ਸਵਿੱਚ ਨੂੰ ਤਰਤੀਬ ਵਿੱਚ ਦਬਾਉਣ ਨਾਲ।"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "ਵੱਧੋ-ਵੱਧ ਗਤੀ ਅਤੇ ਐਕਸਰਲੇਟ ਕਰਨ ਲਈ ਸਮਾਂ(_l):"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "ਅੰਕੀ ਕੀ-ਪੈਡ ਨੂੰ ਮਾਊਸ ਕੰਟਰੋਲ ਪੈਡ ਵਿੱਚ ਬਦਲ ਦਿਓ।"
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "ਜੇਕਰ ਨਾ ਵਰਤਿਆ ਜਾਵੇ ਤਾਂ ਆਯੋਗ(_D):"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "ਕੀ-ਬੋਰਡ ਸਹੂਲਤਾਂ ਫੀਚਰ ਯੋਗ(_E)"
+
+#~ msgid "characters/second"
+#~ msgstr "ਅੱਖਰ/ਸਕਿੰਟ"
+
+#~ msgid "pixels/second"
+#~ msgstr "ਪਿਕਸਲ /ਸਕਿੰਟ"
+
+#~ msgid "Go _to Fonts Folder"
+#~ msgstr "ਫੋਂਟ ਫੋਲਡਰ ਉੱਤੇ ਜਾਓ(_t)"
+
+#~ msgid "The theme is an engine. You need to compile it."
+#~ msgstr "ਥੀਮ ਇੱਕ ਇੰਜਣ ਹੈ। ਤੁਹਾਨੂੰ ਥੀਮ ਕੰਪਾਇਲ ਕਰਨ ਦੀ ਲੋੜ ਹੈ।"
+
+#~ msgid "The file format is invalid"
+#~ msgstr "ਫਾਇਲ ਫਾਰਮੈਟ ਗਲਤ ਹੈ"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "ਫਾਇਲ ਫਾਰਮੈਟ ਠੀਕ ਨਹੀਂ ਹੈ।"
+
+#~ msgid "Autostart the preferred AT"
+#~ msgstr "ਪਸੰਦੀਦਾ AT ਆਟੋ-ਚਲਾਓ"
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "ਈਵੂਲੇਸ਼ਨ ਮੇਲ ਰੀਡਰ 1.4"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "ਈਵੂਲੇਸ਼ਨ ਮੇਲ ਰੀਡਰ 1.5"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "ਈਵੂਲੇਸ਼ਨ ਮੇਲ ਰੀਡਰ 1.6"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "ਈਵੂਲੇਸ਼ਨ ਮੇਲ ਰੀਡਰ 2.0"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "ਈਵੂਲੇਸ਼ਨ ਮੇਲ ਰੀਡਰ 2.2"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "ਈਵੂਲੇਸ਼ਨ ਮੇਲ ਰੀਡਰ 2.4"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Links ਟੈਕਸਟ ਬਰਾਊਜ਼ਰ"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Lynx ਟੈਕਸਟ ਬਰਾਊਜ਼ਰ"
+
+#~ msgid "Simple OnScreen Keyboard"
+#~ msgstr "ਸਧਾਰਨ ਆਨ-ਸਕਰੀਨ ਕੀਬੋਰਡ"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M ਟੈਕਸਟ ਝਲਕਾਰਾ"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "ਰੈਜੋਲੇਸ਼ਨ ਰੱਖੋ(_K)"
+
+#~ msgid "There was an error launching the keyboard tool: %s"
+#~ msgstr "ਕੀ-ਬੋਰਡ ਸੰਦ ਨੂੰ ਸ਼ੁਰੂ ਕਰਨ ਵਿੱਚ ਗਲਤੀ ਹੈ: %s"
+
+#~ msgid "Choose..."
+#~ msgstr "ਚੁਣੋ..."
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "ਮਾਈਕਰੋਸਾਫਟ ਸਧਾਰਨ ਕੀ-ਬੋਰਡ"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>ਤੇਜ਼</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>ਜ਼ਿਆਦਾ</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>ਵੱਡਾ</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>ਘੱਟ</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>ਹੌਲੀ</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>ਛੋਟਾ</i>"
+
+#~ msgid "Motion"
+#~ msgstr "ਗਤੀ"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "ਤੁਸੀ ਸਿਫਟ (Shift) ਸਵਿੱਚ ਨੂੰ ਸਿਰਫ 8 ਵਾਰ ਦਬਾਉਣਾ ਹੈ। ਇਹ ਹੌਲੀ-ਸਵਿੱਚ ਫੀਚਰ ਦਾ ਸ਼ਾਰਟਕੱਟ "
+#~ "ਹੈ, ਜੋ ਕਿ ਤੁਹਾਡੇ ਕੀ-ਬੋਰਡ ਦੇ ਕੰਮ ਕਰਨ ਦੇ ਢੰਗ ਨੂੰ ਪ੍ਰਭਾਵਿਤ ਕਰੇਗਾ।"
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "ਕੀ ਤੁਸੀ ਹੌਲੀ-ਸਵਿੱਚ ਨੂੰ ਸਰਗਰਮ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "ਕੀ ਤੁਸੀ ਹੌਲੀ-ਸਵਿੱਚ ਨੂੰ ਬੇਅਸਰ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "ਸਰਗਰਮ ਨਾ ਕਰੋ(_n)"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "ਤੁਸੀ ਸਿਫਟ (Shift) ਸਵਿੱਚ ਨੂੰ ਸਿਰਫ 5 ਵਾਰ ਦਬਾਉਣਾ ਹੈ। ਇਹ ਸਟਿੱਕੀ-ਸਵਿੱਚ ਫੀਚਰ ਦਾ ਸ਼ਾਰਟਕੱਟ "
+#~ "ਹੈ, ਜੋ ਕਿ ਤੁਹਾਡੇ ਕੀ-ਬੋਰਡ ਦੇ ਕੰਮ ਕਰਨ ਦੇ ਢੰਗ ਨੂੰ ਪ੍ਰਭਾਵਿਤ ਕਰੇਗਾ।"
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "ਤੁਸੀ ਇੱਕ ਕਤਾਰ ਵਿੱਚੋ ਦੋ ਕੀ ਇੱਕ ਵਾਰ ਦਬਾ ਸਕਦੇ ਹੋ ਜਾਂ ਸਿਫਟ (Shift) ਸਵਿੱਚ ਨੂੰ 5 ਵਾਰ ਇਹ "
+#~ "ਸਟਿੱਕੀ ਸਵਿੱਚ ਫੀਚਰ ਨੂੰ ਚਾਲੂ ਕਰ ਸਕਦੇ ਹੋ, ਜੋ ਕਿ ਤੁਹਾਡਾ ਕੀ-ਬੋਰਡ ਤੇ ਕੰਮ ਕਰਨ ਦੇ ਢੰਗ ਨੂੰ ਤਬਦੀਲ "
+#~ "ਕਰਦਾ ਹੈ।"
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "ਕੀ ਤੁਸੀ ਸਟਿੱਕੀ-ਸਵਿੱਚ ਨੂੰ ਸਰਗਰਮ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "ਕੀ ਤੁਸੀ ਸਟਿੱਕੀ-ਸਵਿੱਚ ਨੂੰ ਬੇਅਸਰ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing the mouse pointer theme."
+#~ msgstr ""
+#~ "ਡਾਇਰੈਕਟਰੀ \"%s\" ਬਣਾਈ ਨਹੀਂ ਜਾ ਸਕਦੀ ਹੈ।\n"
+#~ "ਇਹ ਮਾਊਸ ਪੁਆਇੰਟਰ ਥੀਮ ਤਬਦੀਲ ਕਰਨ ਲਈ ਲਾਜ਼ਮੀ ਹੈ।"
+
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "ਡਾਇਰੈਕਟਰੀ \"%s\" ਬਣਾਈ ਨਹੀਂ ਜਾ ਸਕਦੀ ਹੈ।\n"
+#~ "ਇਹ ਕਰਸਰ ਤਬਦੀਲ ਕਰਨ ਲਈ ਲੋੜੀਦੀਂ ਹੈ।"
+
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "ਕੀ-ਬਾਈਡਿੰਗ (%s) ਦੀ ਕਾਰਵਾਈ ਬਹੁਤ ਵਾਰ ਪ੍ਰਭਾਸ਼ਿਤ ਕੀਤੀ ਜਾ ਚੁੱਕੀ ਹੈ।\n"
+
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "ਕੀ-ਬਾਈਡਿੰਗ (%s) ਦੀ ਬਾਈਡਿੰਗ ਬਹੁਤ ਵਾਰ ਪ੍ਰਭਾਸ਼ਿਤ ਕੀਤੀ ਜਾ ਚੁੱਕੀ ਹੈ।\n"
+
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "ਕੀ-ਬਾਈਡਿੰਗ (%s) ਪੂਰੀ ਨਹੀਂ ਹੈ\n"
+
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "ਕੀ-ਬਾਈਡਿੰਗ (%s) ਠੀਕ ਨਹੀਂ ਹੈ\n"
+
+#~ msgid "It seems that another application already has access to key '%u'."
+#~ msgstr "ਇਹ ਲੱਗ ਰਿਹਾ ਹੈ ਕਿ ਇੱਕ ਹੋਰ ਕਾਰਜ ਸਵਿੱਚ '%u' ਨੂੰ ਵਰਤ ਰਿਹਾ ਹੈ।"
+
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "ਗਲਤੀ, ਜਦੋਂ ਕਿ ਚਲਾਉਣ (%s) ਦੀ ਕੋਸ਼ਿਸ ਕੀਤੀ,\n"
+#~ "ਜੋ ਕਿ ਸਵਿੱਚ (%s) ਨਾਲ ਸਬੰਧਤ ਹੈ"
+
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "ਗਲਤੀ XKB ਸੰਰਚਨਾ ਨੂੰ ਸਰਗਰਮ ਕਰਨ ਲਈ\n"
+#~ "ਇਹ ਸਿਰਫ ਤਾਂ ਹੀ ਵਪਾਰਦਾ ਹੈ:\n"
+#~ "- ਲਾਇਬਰੇਰੀ libxklavier ਵਿੱਚ ਬੱਗ ਹੋਵੇ\n"
+#~ "- X ਸਰਵਰ 'ਚ ਬੱਗ ਹੁੰਦਾ ਹੈ (xkbcomp, xmodmap ਸਹੂਲਤਾਂ)\n"
+#~ "- X ਸਰਵਰ libxkbfile ਸਥਾਪਨ ਦੇ ਅਨੁਕੂਲ ਨਾ ਹੋਵੇ\n"
+#~ "\n"
+#~ "X ਸਰਵਰ ਵਰਜਨ ਜਾਣਕਾਰੀ:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "ਜੇਕਰ ਤੁਸੀ ਇਸ ਸਥਿਤੀ ਨੂੰ ਬੱਗ ਦੇ ਤੌਰ 'ਤੇ ਜਾਣਕਾਰੀ ਦੇਣੀ ਚਾਹੋ ਤਾਂ ਇਹ ਜਾਣਕਾਰੀ ਇੱਕਠੀ ਕਰੋ:\n"
+#~ "- %s ਦਾ ਨਤੀਜਾ\n"
+#~ "- %s ਦਾ ਨਤੀਜਾ"
+
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "ਤੁਸੀ XFree 4.3.0 ਵਰਤ ਰਹੇ ਹੋ।\n"
+#~ "ਜਟਿਲ XKB ਸੰਰਚਨਾ ਵਿੱਚ ਜਾਣੀ-ਪਛਾਣੀਆਂ ਮੁਸ਼ਕਿਲ ਹਨ।\n"
+#~ "ਸਧਾਰਨ ਸੰਰਚਨਾ ਵਰਤੋ ਜਾਂ XFree ਦਾ ਹੋਰ ਨਵਾਂ ਵਰਜਨ ਲੈਕੇ ਕੋਸ਼ਿਸ ਕਰੋ।"
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "ਇਹ ਸੁਨੇਹਾ ਮੁੜ ਨਾ ਵੇਖਾਓ(_n)"
+
+#~ msgid ""
+#~ "<b>The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.</b>\n"
+#~ "\n"
+#~ "Expected was %s, but the the following settings were found: %s.\n"
+#~ "\n"
+#~ "Which set would you like to use?"
+#~ msgstr ""
+#~ "<b>X ਸਿਸਟਮ ਕੀ-ਬੋਰਡ ਸੈਟਿੰਗ ਗਨੋਮ ਕੀ-ਬੋਰਡ ਸੈਟਿੰਗ ਤੋਂ ਵੱਖਰੀ ਹੈ।</b>\n"
+#~ "\n"
+#~ "%s ਦੀ ਮੰਗ ਸੀ, ਪਰ ਅੱਗੇ ਦਿੱਤਾ ਸੈਟਿੰਗ ਮਿਲੀ ਹੈ: %s।\n"
+#~ "\n"
+#~ "ਤੁਸੀਂ ਕਿਹੜੀ ਦੀ ਵਰਤੋਂ ਕਰਨੀ ਚਾਹੁੰਦੇ ਹੋ?"
+
+#~ msgid ""
+#~ "Could not get default terminal. Verify that your default terminal command "
+#~ "is set and points to a valid application."
+#~ msgstr ""
+#~ "ਮੂਲ ਟਰਮੀਨਲ ਕਾਰਜ ਨਹੀਂ ਮਿਲਿਆ। ਜਾਂਚ ਕਰੋ ਕੀ ਤੁਹਾਡੀ ਮੂਲ ਟਰਮੀਨਲ ਕਮਾਂਡ ਸੈੱਟ ਕੀਤੀ ਹੋਈ ਹੈ ਅਤੇ "
+#~ "ਇੱਕ ਠੀਕ ਕਾਰਜ ਲਈ ਇਸ਼ਾਰਾ ਕਰਦੀ ਹੈ।"
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this is a valid command."
+#~ msgstr ""
+#~ "ਕਮਾਂਡ ਨੂੰ ਚਲਾਇਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਹੈ: %s\n"
+#~ "ਜਾਂਚ ਲਵੋ ਕਿ ਇਹ ਕਮਾਂਡ ਠੀਕ ਹੈ"
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "ਮਸ਼ੀਨ ਨੂੰ ਵਿਰਾਮ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ।\n"
+#~ "ਆਪਣੀ ਮਸ਼ੀਨ ਦੀ ਸੰਰਚਨਾ ਦੀ ਜਾਂਚ ਕਰੋ, ਕੀ ਇਹ ਸਹੀ ਹੈ।"
+
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "ਸਕਰੀਨ-ਸੇਵਰ ਵੇਖਾਉਣ ਵਿੱਚ ਗਲਤੀ ਹੈ:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "ਸਕਰੀਨ-ਸੇਵਰ ਕਾਰਵਾਈ ਇਸ ਸ਼ੈਸ਼ਨ ਵਿੱਚ ਕੰਮ ਨਹੀਂ ਕਰੇਗੀ।"
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "ਇਹ ਸੁਨੇਹਾ ਮੁੜ ਨਾ ਵੇਖਾਓ(_D)"
+
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "ਸਾਊਂਡ ਫਾਇਲ %s ਨੂੰ ਸੈਂਪਲ %s ਦੇ ਤੌਰ ਉੱਤੇ ਲੋਡ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ ਹੈ"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "ਯੂਜ਼ਰ ਦੀ ਘਰ ਡਾਇਰੈਕਟਰੀ ਨਹੀਂ ਜਾਣੀ ਜਾ ਸਕਦੀ ਹੈ"
+
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr "ਜੀ-ਕਾਨਫ ਕੁੰਜੀ %s ਦੀ ਦਿੱਤੀ ਕਿਸਮ %s ਹੈ, ਪਰ ਇਸ ਕਿਸਮ %s ਦੀ ਉਮੀਦ ਸੀ।\n"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "ਇਹ ਸੁਨੇਹਾ ਮੁੜ ਨਾ ਵੇਖਾਓ(_n)।"
+
+#~ msgid "Load modmap files"
+#~ msgstr "modmap ਫਾਇਲਾਂ ਲੋਡ"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "ਕੀ ਤੁਸੀਂ modmap ਫਾਇਲਾਂ ਨੂੰ ਲੋਡ ਕਰਨਾ ਪਸੰਦ ਕਰੋਗੇ?"
+
+#~ msgid "_Load"
+#~ msgstr "ਲੋਡ(_L)"
+
+#~ msgid "_Loaded files:"
+#~ msgstr "ਲੋਡ ਕੀਤੀਆਂ ਫਾਇਲਾਂ(_L):"
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "bg_applier ਦੀ ਕਿਸਮ: BG_APPLIER_ROOT ਰੂਟ( root) ਵਿੰਡੋ ਲਈ ਜਾਂ "
+#~ "BG_APPLIER_PREVIEW ਝਲਕ ਲਈ"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "ਚੌੜਾਈ, ਜੇਕਰ ਅਪਲਾਇਰ ਝਲਕ ਹੈ: ਮੂਲ 64"
+
+#~ msgid "Preview Height"
+#~ msgstr "ਝਲਕ ਉਚਾਈ"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "ਉਚਾਈ, ਜੇਕਰ ਅਪਲਾਇਰ ਝਲਕ ਹੈ: ਮੂਲ 48"
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "ਸਕਰੀਨ, ਜਿਸ ਉਪੱਰ BGApplier ਨੂੰ ਉਲੀਕਣਾ ਹੈ"
+
+#~ msgid "Edited %m/%d/%Y"
+#~ msgstr "%d/%m/%Y ਨੂੰ ਸੋਧਿਆ"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr "ਜੇਕਰ ਸੱਚ ਹੈ ਤਾਂ, ਟੈਕਸਟ/plain ਅਤੇ ਟੈਕਸਟ/* ਲਈ mime ਨੂੰ sync ਵਿੱਚ ਰੱਖਿਆ ਜਾਵੇਗਾ।"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Sync ਟੈਕਸਟ/plain ਅਤੇ ਟੈਕਸਟ/* ਹੈਂਡਲਰ"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "ਈ-ਮੇਲ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "ਘਰ ਫੋਲਡਰ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "ਮੱਦਦ-ਝਲਕਾਰਾ ਨੂੰ ਸ਼ੁਰੂ ਕਰਨ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "ਵੈਬ-ਝਲਕਾਰਾ ਨੂੰ ਸ਼ੁਰੂ ਕਰਨ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Lock screen's shortcut."
+#~ msgstr "ਪਰਦਾ ਤਾਲਾਬੰਦ ਕਰਨ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "ਲਾਗਆਉਟ (ਬਾਹਰੀ ਦਰ) ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Media player key's shortcut."
+#~ msgstr "ਮੀਡਿਆ ਪਲੇਅਰ ਸਵਿੱਚ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "ਅਗਲਾ ਟਰੈਕ ਸਵਿੱਚ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "ਵਿਰਾਮ ਸਵਿੱਚ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "ਚਲਾਓ (ਜਾਂ ਚਲਾਓ/ਵਿਰਾਮ) ਸਵਿੱਚ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "ਪਿਛਲਾ ਟਰੈਕ ਸਵਿੱਚ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Search's shortcut."
+#~ msgstr "ਖੋਜ ਲਈ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Sleep"
+#~ msgstr "ਸ਼ਾਂਤ"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "ਸ਼ਾਂਤ ਲਈ ਸ਼ਾਰਟਕੱਟ ਹੈ"
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "ਸੰਗੀਤ ਰੋਕਣ ਸਵਿੱਚ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "ਆਵਾਜ਼ ਘੱਟ ਕਰਨ ਲਈ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Volume mute's shortcut."
+#~ msgstr "ਆਵਾਜ਼ ਚੁੱਪ ਦਾ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Volume step"
+#~ msgstr "ਆਵਾਜ਼ ਵਾਧਾ"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "ਆਵਾਜ਼ ਵਧੇ, ਜਿਵੇਂ ਅਵਾਜ਼ ਦੀ ਪ੍ਰਤੀਸ਼ਤ ਨਾਲ ਹੈ।"
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "ਆਵਾਜ਼ ਵਧਾਉਣ ਲਈ ਸ਼ਾਰਟਕੱਟ ਹੈ।"
+
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "ਡਾਈਲਾਗ ਵੇਖਾਓ, ਜਦੋਂ ਕਿ ਸਕਰੀਨ-ਸੇਵਰ ਚਲਾਉਣ ਵਿੱਚ ਗਲਤੀ ਹੋਵੇ"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "ਲਾਗ-ਇਨ ਸਮੇਂ ਸਕਰੀਨ-ਸੇਵਰ ਚਲਾਓ"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "ਸ਼ੁਰੂਆਤੀ ਗਲਤੀ ਵੇਖਾਓ"
+
+#~ msgid "Start screensaver"
+#~ msgstr "ਸਕਰੀਨ-ਸੇਵਰ ਸ਼ੁਰੂ ਕਰੋ"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,9 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-12 07:38+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-12 17:10+0200\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish <community-poland@mozilla.org>\n"
@@ -25,102 +24,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Magistrala systemowa"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Pełny dostęp"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Magistrala sesji"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Urządzenia"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Pełny dostęp do katalogu /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Sieć"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Ma dostęp do sieci"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Katalog domowy"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Tylko do odczytu"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "System plików"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Ustawienia"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Może zmieniać ustawienia"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s ma poniższe wbudowane uprawnienia. Nie można ich zmieniać. W razie obaw "
-"dotyczących tych uprawień można usunąć ten program."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u typ plików i odnośników otwierany przez program"
-msgstr[1] "%u typy plików i odnośników otwierane przez program"
-msgstr[2] "%u typów plików i odnośników otwieranych przez program"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"Program <b>%s</b> jest używany do otwierania poniższych typów plików "
-"i odnośników."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "Używa %s miejsca na dysku."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -136,7 +40,6 @@ msgid "Install some…"
 msgstr "Zainstaluj programy…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Otwórz"
 
@@ -160,24 +63,13 @@ msgstr "Wyszukiwanie"
 msgid "Receive system searches and send results."
 msgstr "Odbieranie wyszukiwań systemowych i odsyłanie wyników."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Wyłączone"
 
@@ -343,82 +235,22 @@ msgstr "Wyczyść pamięć podręczną…"
 msgid "Control various application permissions and settings"
 msgstr "Sterowanie różnymi uprawnieniami i ustawieniami programów"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "programy;aplikacja;aplikacje;flatpak;flatpack;uprawnienie;uprawnienia;"
 "pozwolenie;zezwolenie;ustawienie;ustawienia;opcje;"
 
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Wybór obrazu"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Anuluj"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Otwórz"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "wiele rozmiarów"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d×%d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Bez tła pulpitu"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Obecne tło"
-
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Styl"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Domyślne"
 
@@ -442,7 +274,6 @@ msgstr "Wygląd"
 msgid "Change your background image or the UI colors"
 msgstr "Zmiana obrazu tła i kolorów interfejsu"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Tło;Tapeta;Ekran;Pulpit;Styl;Jasny;Ciemny;Wygląd;"
@@ -493,9 +324,7 @@ msgstr "Sprzętowy tryb samolotowy jest włączony"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Należy wyłączyć przełącznik trybu sprzętowego, aby włączyć Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -503,7 +332,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Włączanie Bluetooth i łączenie z urządzeniami"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr ""
@@ -538,96 +366,35 @@ msgstr "Żadne programy nie poprosiły o dostęp do kamery"
 msgid "Protect your pictures"
 msgstr "Ochrona zdjęć"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "aparat;kamera;camera;zdjęcia;fotografie;filmy;wideo;video;webcam;kamerka;"
 "blokada;zablokuj;prywatne;prywatność;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Proszę umieścić urządzenie na kwadracie i nacisnąć przycisk „Rozpocznij”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Proszę umieścić urządzenie w pozycji kalibracji i nacisnąć przycisk "
-"„Kontynuuj”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Proszę umieścić urządzenie w pozycji powierzchni i nacisnąć przycisk "
-"„Kontynuuj”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Proszę zamknąć pokrywę laptopa"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Wystąpił wewnętrzny błąd, z którego nie można przywrócić."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Narzędzia wymagane do kalibracji nie są zainstalowane."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Nie można utworzyć profilu."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Nie można uzyskać docelowego punktu bieli."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Ukończono"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibracja się nie powiodła"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Można usunąć urządzenie kalibracji."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Nie należy usuwać urządzenia podczas trwania kalibracji"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kalibracja ekranu"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Anuluj"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -644,140 +411,6 @@ msgstr "_Wznów"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Gotowe"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Ekran laptopa"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Wbudowana kamera internetowa"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Skaner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Aparat %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Drukarka %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Kamera internetowa %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Włącz zarządzanie kolorami dla %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Wyświetl profile kolorów dla %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Nieskalibrowane"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Domyślny: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Przestrzeń kolorów: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Profil testowy: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Wybór pliku profilu ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "Zai_mportuj"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Obsługiwane profile ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Wszystkie pliki"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Ekran"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Zapis profilu"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Zapisz"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Tworzy profil kolorów dla wybranego urządzenia"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Nie wykryto urządzenia pomiarowego. Proszę sprawdzić, czy jest włączone "
-"i poprawnie podłączone."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Urządzenie pomiarowe nie obsługuje profilowania drukarek."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Typ urządzenia nie jest obecnie obsługiwany."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -919,7 +552,6 @@ msgstr "Za_importuj plik…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -931,9 +563,7 @@ msgstr ""
 "Każde urządzenie wymaga aktualnego profilu kolorów, aby podlegać zarządzaniu "
 "kolorami."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Więcej informacji"
 
@@ -1065,82 +695,6 @@ msgstr "D65 (fotografia i grafika)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standardowa przestrzeń"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Profil testowy"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatyczny"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Niska jakość"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Średnia jakość"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Wysoka jakość"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Domyślna RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Domyślna CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Domyślna skala szarości"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Fabryczne dane kalibracji dostarczone przez producenta"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Pełnoekranowa korekcja kolorów nie jest możliwa za pomocą tego profilu"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Ten profil może już nie być dokładny"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Kolor"
@@ -1151,14 +705,9 @@ msgid ""
 msgstr ""
 "Kalibracja kolorów urządzeń, takich jak ekrany, aparaty, kamery i drukarki"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Kolor;ICC;Profil;Kalibracja;Drukarka;Ekran;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Inny…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1173,13 +722,8 @@ msgid "No languages found"
 msgstr "Nie odnaleziono języków"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Więcej…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Odblokowanie umożliwi zmianę ustawień"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1208,154 +752,6 @@ msgstr "Odejmij godzinę"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Odejmij minutę"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Dzisiaj"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Wczoraj"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%-d %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%-d %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d godzina"
-msgstr[1] "%d godziny"
-msgstr[2] "%d godzin"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuta"
-msgstr[1] "%d minuty"
-msgstr[2] "%d minut"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekunda"
-msgstr[1] "%d sekundy"
-msgstr[2] "%d sekund"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s, %s i %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s i %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s i %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekund"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-godzinny"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "12-godzinny"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%-d %B %Y, %-l∶%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%-d %B %Y, %H∶%M"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%-l∶%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%H∶%M"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1450,17 +846,11 @@ msgstr "Automatyczna _strefa czasowa"
 msgid "Requires location services enabled and internet access"
 msgstr "Wymaga dostępu do Internetu i włączenia usług położenia"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Włączone"
 
@@ -1468,15 +858,43 @@ msgstr "Włączone"
 msgid "Time Z_one"
 msgstr "S_trefa czasowa"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Odblokuj"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format czasu"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Data"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekund"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Kalendarz"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Liczby"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Zmiana daty i czasu, w tym strefy czasowej"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr ""
@@ -1523,20 +941,9 @@ msgstr "Domyślne programy"
 msgid "Configure Default Applications"
 msgstr "Konfiguracja domyślnych programów"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "domyślne;programy;aplikacje;preferowane;nośnik;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Wysyłanie informacji o problemach technicznych pomaga ulepszyć system %s. "
-"Zgłoszenia są anonimowe i pozbawione danych osobistych. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1554,44 +961,9 @@ msgstr "Diagnostyka"
 msgid "Report your problems"
 msgstr "Zgłaszanie problemów"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostyka;awaria;awarie;crash;krasz;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Włączone"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Wyłączone"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Zastosować zmiany?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Nie można zastosować zmian"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Może to być spowodowane ograniczeniami sprzętu."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1641,31 +1013,6 @@ msgstr "Główny ekran"
 msgid "Night Light"
 msgstr "Nocne światło"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Pozioma"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Pionowa (w prawo)"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Pionowa (w lewo)"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Pozioma (odwrócona)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1689,6 +1036,17 @@ msgstr "Dostosowanie do telewizora"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Skalowanie"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Naturalne przewijanie"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1784,7 +1142,6 @@ msgstr "Ekrany"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Wybór sposobu używania podłączonych monitorów i projektorów"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1793,82 +1150,6 @@ msgstr ""
 "Panel;Projektor;xrandr;Ekran;Rozdzielczość;Odświeżanie;Monitor;Nocne;światło;"
 "Niebieski;Przesunięcie ku czerwieni;Poczerwienienie;Redshift;Kolory;Kolorów;"
 "Wschód;Zachód;słońca;Słońce;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Zabezpieczone uruchamianie jest aktywne"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
-"oprogramowania podczas uruchamiania urządzenia. Jest obecnie włączone "
-"i działa poprawnie."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Zabezpieczone uruchamianie ma problemy"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
-"oprogramowania podczas uruchamiania urządzenia. Jest obecnie włączone, ale "
-"nie będzie działać z powodu nieprawidłowego klucza."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Problemy z zabezpieczonym uruchamianiem często można rozwiązać "
-"w ustawieniach oprogramowania sprzętowego UEFI (BIOS-ie) komputera, "
-"a producent sprzętu może podawać informacje, jak to zrobić."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Należy skontaktować się z producentem używanego sprzętu lub dostawcą "
-"wsparcia informatycznego w celu uzyskania pomocy."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Zabezpieczone uruchamianie jest wyłączone"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
-"oprogramowania podczas uruchamiania urządzenia. Jest obecnie wyłączone."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Zabezpieczone uruchamianie często można włączyć w ustawieniach "
-"oprogramowania sprzętowego UEFI (BIOS-ie) komputera. Należy skontaktować się "
-"z producentem używanego sprzętu lub dostawcą wsparcia informatycznego w celu "
-"uzyskania pomocy."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1883,134 +1164,9 @@ msgstr ""
 "Należy skontaktować się z producentem używanego sprzętu lub dostawcą "
 "wsparcia informatycznego w celu uzyskania pomocy."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Powodzenie"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Niepowodzenie"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Urządzenie jest zgodne z %d. poziomem HSI"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "0. poziom zabezpieczeń"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"To urządzenie nie ma ochrony przed sprzętowymi problemami bezpieczeństwa. "
-"Może to być spowodowane problemem z konfiguracją sprzętu lub oprogramowania "
-"sprzętowego. Zalecane jest skontaktowanie się z dostawcą wsparcia "
-"informatycznego."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "1. poziom zabezpieczeń"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"To urządzenie ma minimalną ochronę przed sprzętowymi problemami "
-"bezpieczeństwa. To najniższy poziom zabezpieczeń urządzenia, który zapewnia "
-"ochronę tylko przed prostymi zagrożeniami bezpieczeństwa."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "2. poziom zabezpieczeń"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"To urządzenie ma podstawową ochronę przed sprzętowymi problemami "
-"bezpieczeństwa. Zapewnia to ochronę przed częścią często występujących "
-"zagrożeń bezpieczeństwa."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "3. poziom zabezpieczeń"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"To urządzenie ma rozszerzoną ochronę przed sprzętowymi problemami "
-"bezpieczeństwa. To najwyższy poziom zabezpieczeń urządzenia, który zapewnia "
-"ochronę przed zaawansowanymi zagrożeniami bezpieczeństwa."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Poziom zabezpieczeń"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Poziomy zabezpieczeń nie są dostępne dla tego urządzenia."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Należy skontaktować się z producentem sprzętu, aby uzyskać pomoc "
-"z aktualizacjami zabezpieczeń."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Rozwiązanie tego problemu może być możliwe w ustawieniach oprogramowania "
-"sprzętowego UEFI lub przez pracownika wsparcia."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Rozwiązanie tego problemu może być możliwe w ustawieniach oprogramowania "
-"sprzętowego UEFI."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Rozwiązanie tego problemu może być możliwe przez pracownika wsparcia."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2024,339 +1180,9 @@ msgstr "2. poziom"
 msgid "Level 3"
 msgstr "3. poziom"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr ""
-"Ochrona przed złośliwym oprogramowaniem podczas uruchamiania urządzenia."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Zabezpieczone uruchamianie ma problemy"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Pewna ochrona podczas uruchamiania urządzenia."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Zabezpieczone uruchamianie jest wyłączone"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Brak ochrony podczas uruchamiania urządzenia."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Ten problem mógł być spowodowany przez zmianę ustawień oprogramowania "
-"sprzętowego UEFI, zmianę konfiguracji systemu operacyjnego lub z powodu "
-"złośliwego oprogramowania na tym komputerze."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Ten problem mógł być spowodowany przez zmianę ustawień oprogramowania "
-"sprzętowego UEFI lub z powodu złośliwego oprogramowania na tym komputerze."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Ten problem mógł być spowodowany przez zmianę konfiguracji systemu "
-"operacyjnego lub z powodu złośliwego oprogramowania na tym komputerze."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Podatność na poważne zagrożenia bezpieczeństwa."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Ograniczona ochrona przed prostymi zagrożeniami bezpieczeństwa."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Ochrona przed często występującymi zagrożeniami bezpieczeństwa."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Ochrona przed szerokim zakresem zagrożeń bezpieczeństwa."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Pełna ochrona"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Brak zdarzeń"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Ochrona przed zapisem oprogramowania sprzętowego"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Blokada ochrony przed zapisem oprogramowania sprzętowego"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Region BIOS-u oprogramowania sprzętowego"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Deskryptor BIOS-u oprogramowania sprzętowego"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Ochrona DMA przed uruchomieniem"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Uruchamianie zweryfikowane przez Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "ACM chronione przez Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Zasady postępowania Intel BootGuard w przypadku błędów"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Bezpiecznik Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET jest włączone"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET jest aktywne"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Zaszyfrowana pamięć RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Ochrona IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Blokada jądra Linux"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Weryfikacja jądra Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Obszar wymiany systemu Linux"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Uśpienie do pamięci RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Uśpienie do trybu bezczynności"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Klucz platformy UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Zabezpieczone uruchamianie UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Konfiguracja platformy TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Rekonstrukcja TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Tryb serwisowy Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Obejście Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Wersja Intel Management Engine"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Aktualizacje oprogramowania sprzętowego"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Zaświadczenie oprogramowania sprzętowego"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Weryfikacja aktualizatora oprogramowania sprzętowego"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Debugowanie platformy"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Testy zabezpieczeń procesora"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Ochrona przed wycofaniem AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Ochrona przed odtwarzaniem oprogramowania sprzętowego AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Ochrona przed zapisem oprogramowania sprzętowego AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Platforma z bezpiecznikiem"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Prawidłowe"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Nieprawidłowe"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Niewłączone"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Zablokowane"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Niezablokowane"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Zaszyfrowane"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Niezaszyfrowane"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Skażone"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Nieskażone"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Odnaleziono"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Nie odnaleziono"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Obsługiwane"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Nieobsługiwane"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2366,7 +1192,6 @@ msgstr "Zabezpieczenia urządzenia"
 msgid "Host firmware security status"
 msgstr "Stan zabezpieczeń oprogramowania sprzętowego komputera"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2374,49 +1199,6 @@ msgid ""
 msgstr ""
 "ekran;blokada;diagnostyka;awaria;prywatne;ostatnie;ostatnio;tymczasowe;tmp;"
 "indeksowanie;index;nazwa;sieć;tożsamość;prywatność;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Nieznany"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bitowy"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bitowy"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Nieznany"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Niedostępna"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo systemu"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2510,11 +1292,6 @@ msgstr "Informacje"
 msgid "View information about your system"
 msgstr "Wyświetlanie informacji o systemie"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2594,6 +1371,12 @@ msgstr "Uruchamianie"
 msgid "Launch help browser"
 msgstr "Uruchomienie przeglądarki pomocy"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Ustawienia"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Uruchomienie kalkulatora"
@@ -2615,7 +1398,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Wyszukiwanie"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "System"
 
@@ -2664,15 +1447,6 @@ msgstr "Zmniejszenie rozmiaru tekstu"
 msgid "High contrast on or off"
 msgstr "Włączenie lub wyłączenie wysokiego kontrastu"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nie odnaleziono źródeł wprowadzania"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Inne"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Dodanie źródła wprowadzania"
@@ -2705,106 +1479,9 @@ msgstr "Preferencje"
 msgid "View Keyboard Layout"
 msgstr "Wyświetl układ klawiatury"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Usuń"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Niestandardowe skróty"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Klawisz wprowadzania alternatywnych znaków"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Klawisz alternatywnych znaków może być używany do wprowadzania dodatkowych "
-"znaków. Są one czasami oznaczone jako opcje trzeciego poziomu na klawiszach."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Lewy Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Prawy Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Lewy klawisz Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Prawy klawisz Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Klawisz Menu"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Prawy Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Klawisz Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Klawisz Compose umożliwia wprowadzanie szerokiego zakresu znaków. Aby go "
-"użyć, należy wcisnąć klawisz Compose, a następnie sekwencję znaków. Na "
-"przykład, klawisz Compose plus znaki <b>C</b> i <b>o</b> wprowadzą znak "
-"<b>©</b>, <b>a</b> i <b>'</b> wprowadzą <b>á</b> itp."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Źródła wprowadzania można przełączać za pomocą skrótu klawiszowego %s.\n"
-"Można to zmienić w ustawieniach skrótów klawiszowych."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2834,46 +1511,21 @@ msgstr "Wpisywanie znaków specjalnych"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Metody wprowadzania symboli i wariantów liter za pomocą klawiatury."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Klawisz wprowadzania alternatywnych znaków"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Klawisz Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Skróty klawiszowe"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Wyświetl i dostosuj skróty"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d zmodyfikowany"
-msgstr[1] "%d zmodyfikowane"
-msgstr[2] "%d zmodyfikowanych"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Przywrócić wszystkie skróty?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Przywrócenie skrótów może wpłynąć na skróty ustawione przez użytkownika. Nie "
-"można tego cofnąć."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Przywróć wszystko"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2913,33 +1565,6 @@ msgstr "Dodaj skrót"
 msgid "No keyboard shortcut found"
 msgstr "Nie odnaleziono skrótów klawiszowych"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s jest już używane dla „%s”. Po zastąpieniu „%s” zostanie wyłączone."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Proszę wprowadzić nowy skrót"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Ustawienie niestandardowego skrótu"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Ustawienie skrótu"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Proszę wprowadzić nowy skrót, aby zmienić „%s”."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Dodanie niestandardowego skrótu"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Usuń"
@@ -2951,7 +1576,6 @@ msgstr "_Zastąp"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Ustaw"
 
@@ -2987,6 +1611,11 @@ msgstr "Brak"
 msgid "Reset the shortcut to its default value"
 msgstr "Przywraca skrót do domyślnej wartości"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Domyślna drukarka"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Klawiatura"
@@ -2999,7 +1628,6 @@ msgstr ""
 "Zmiana skrótów klawiszowych oraz ustawianie preferencji pisania, układów "
 "klawiatury i źródeł wprowadzania"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3041,7 +1669,6 @@ msgstr "Żadne programy nie poprosiły o dostęp do położenia"
 msgid "Protect your location information"
 msgstr "Ochrona informacji o położeniu użytkownika"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr ""
@@ -3078,7 +1705,6 @@ msgstr "Żadne programy nie poprosiły o dostęp do mikrofonu"
 msgid "Protect your conversations"
 msgstr "Ochrona rozmów"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofon;nagrywanie;nagraj;prywatność;"
@@ -3108,81 +1734,139 @@ msgstr "Lewy"
 msgid "Right"
 msgstr "Prawy"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Położenia wyszukiwania"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mysz"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Prędkość myszy"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Naturalne przewijanie"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Sekcja"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Przewijanie przesuwa treść, a nie widok."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Przewijanie przesuwa treść, a nie widok."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktywne"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Panel dotykowy"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Prędkość panelu dotykowego"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Klikanie przez stuknięcie"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Klikanie przez stuknięcie"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Przewijanie dwoma palcami"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Prędkość panelu dotykowego"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Przewijanie przy krawędziach"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dwustronnie"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Można testować klikanie, podwójne kliknięcie i przewijanie"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Pięć kliknięć, czas na GEGL-a!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Podwójne kliknięcie, przycisk podstawowy"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Pojedyncze kliknięcie, przycisk podstawowy"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Podwójne kliknięcie, środkowy przycisk"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Pojedyncze kliknięcie, środkowy przycisk"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Podwójne kliknięcie, przycisk pomocniczy"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Pojedyncze kliknięcie, przycisk pomocniczy"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3195,7 +1879,6 @@ msgstr ""
 "Zmiana wrażliwości myszy i panelu dotykowego oraz wybór trybu praworęcznego "
 "lub leworęcznego"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3277,7 +1960,6 @@ msgstr "Wielozadaniowość"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Zarządzanie preferencjami efektywności i wielozadaniowości"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3285,21 +1967,11 @@ msgstr ""
 "Wielozadaniowość;Multitasking;Efektywność;Produktywność;Dostosuj;"
 "Dostosowanie;Pulpit;Desktop;Aktywny róg;Gorący róg;Obszary robocze;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Coś się nie powiodło. Proszę skontaktować się z producentem oprogramowania."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Usługa NetworkManager musi być uruchomiona."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Inne urządzenia"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3311,59 +1983,16 @@ msgstr "Dodaj połączenie"
 msgid "Not set up"
 msgstr "Nie ustawiono"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Niezabezpieczona sieć (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Zabezpieczona sieć (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Zabezpieczona sieć (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Zabezpieczona sieć (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Zabezpieczona sieć"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Połączone"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opcje…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Włączenie hotspotu spowoduje rozłączenie z sieci %s, i nie będzie można "
-"korzystać z Internetu przez Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Musi mieć co najmniej 8 znaków"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3414,20 +2043,6 @@ msgstr "Automatycznie utwórz hasło"
 msgid "_Turn On"
 msgstr "_Włącz"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Zatrzymać hotspot i rozłączyć wszystkich użytkowników?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Zatrzymaj hotspot"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Tryb samolotowy"
@@ -3472,89 +2087,14 @@ msgstr "Widoczne sieci"
 msgid "NetworkManager needs to be running"
 msgstr "Usługa NetworkManager musi być uruchomiona"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Coś się nie powiodło. Proszę skontaktować się z producentem oprogramowania."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Zabezpieczenia 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Zabezpieczenia"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Zachowywanie"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Stały"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Losowy"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabilny"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Podany tutaj adres MAC będzie używany jako adres sprzętowy urządzenia "
-"sieciowego, na którym włączono to połączenie. Ta funkcja jest znana jako "
-"klonowanie lub „spoofing” adresu MAC. Przykład: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "%d. profil"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Wzmocnione otwarte"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Brak"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Nigdy"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3565,183 +2105,6 @@ msgstr[0] "%i dzień temu"
 msgstr[1] "%i dni temu"
 msgstr[2] "%i dni temu"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2,4 GHz/5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2,4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Brak"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Słaba"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Dostateczna"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Dobra"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Doskonała"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Adres IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Adres IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Adres IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Zapomnij połączenie"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Usuń profil połączenia"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Usuń połączenie VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Informacje"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatycznie"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Tożsamość"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Usuń adres"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Usuń trasę"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Brak"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "40/128-bitowy klucz WEP (szesnastkowy lub ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "128-bitowe hasło WEP"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamiczny WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA i WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA i WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3751,8 +2114,20 @@ msgstr "Siła sygnału"
 msgid "Link speed"
 msgstr "Prędkość połączenia"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Zabezpieczenia"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Adres IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adres IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Adres sprzętowy"
 
@@ -3761,12 +2136,17 @@ msgid "Supported Frequencies"
 msgstr "Obsługiwane częstotliwości"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Domyślna trasa"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3829,7 +2209,7 @@ msgstr "Tylko Link-Local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Ręcznie"
 
@@ -3873,9 +2253,8 @@ msgstr "Brama"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automatycznie"
 
@@ -3928,89 +2307,9 @@ msgstr "Automatycznie, tylko DHCP"
 msgid "Prefix"
 msgstr "Przedrostek"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Nie można otworzyć edytora połączeń"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Nowy profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Nieprawidłowe ustawienie %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Nieprawidłowe ustawienie %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Zaimportuj z pliku…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Dodanie połączenia VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Zab_ezpieczenia"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Nie można zaimportować połączenia VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Plik „%s” nie może zostać odczytany lub nie zawiera rozpoznawanych "
-"informacji o połączeniu VPN\n"
-"\n"
-"Błąd: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Wybór pliku do zaimportowania"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Plik o nazwie „%s” już istnieje."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "Za_mień"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Zastąpić połączenie „%s” zapisywanym połączeniem VPN?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Nie można wyeksportować połączenia VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Połączenie VPN „%s” nie może zostać wyeksportowane do %s.\n"
-"\n"
-"Błąd: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Eksport połączenia VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4024,103 +2323,40 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Sieć"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Sterowanie sposobem łączenia z Internetem"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Sieć;Sieci;IP;LAN;Kabel;Pośrednik;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
 "DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Sterowanie sposobem łączenia z sieciami Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Sieć;Sieci;Bezprzewodowa;Wireless;Wi-Fi;Wifi;IP;LAN;Kabel;DNS;Hotspot;Punkt;"
 "dostępowy;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nigdy"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "dzisiaj"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "wczoraj"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Ostatnio użyte"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Przewodowe"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Dodaj nowe połączenie"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Informacje o zaznaczonych sieciach, w tym hasła i konfiguracja, zostaną "
-"utracone."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Zapomnij"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Znane sieci Wi-Fi"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Zapomnij"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Ustawienia systemu uniemożliwiają użycie jako hotspot"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Urządzenie bezprzewodowe nie obsługuje trybu hotspot"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Automatyczne wykrywanie pośrednika sieciowego jest używane, jeśli nie podano "
-"adresu URL konfiguracji."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Nie jest zalecane dla niezaufanych sieci publicznych."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4139,6 +2375,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Dostawca"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adres IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4223,290 +2463,6 @@ msgstr "_Włącz hotspot Wi-Fi…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Znane sieci Wi-Fi"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Stan nieznany"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Niezarządzane"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Niedostępne"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Łączenie"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Wymagane jest uwierzytelnienie"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Rozłączanie"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Połączenie się nie powiodło"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Stan nieznany (brak)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Konfiguracja się nie powiodła"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Konfiguracja adresu IP się nie powiodła"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Konfiguracja adresu IP wygasła"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Wymagane są hasła, których nie podano"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Suplikant 802.1x się rozłączył"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Konfiguracja suplikanta 802.1x się nie powiodła"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Suplikant 802.1x się nie powiódł"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Suplikant 802.1x za długo się uwierzytelniał"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Uruchomienie usługi PPP się nie powiodło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Usługa PPP została rozłączona"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Usługa PPP się nie powiodła"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Uruchomienie klienta DHCP się nie powiodło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Błąd klienta DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Klient DHCP się nie powiódł"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Uruchomienie usługi współdzielonego połączenie się nie powiodło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Usługa współdzielonego połączenia się nie powiodła"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr ""
-"Uruchomienie usługi automatycznego wykrywania adresu IP się nie powiodło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Błąd usługi automatycznego wykrywania adresu IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Usługa automatycznego wykrywania adresu IP się nie powiodła"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linia jest zajęta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Brak wybierania tonowego"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Nie można ustanowić żadnego operatora"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Żądanie wdzwonienia przekroczyło czas oczekiwania"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Próba wdzwonienia się nie powiodła"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Zainicjowanie modemu się nie powiodło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Wybranie podanego APN się nie powiodło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Sieci nie są wyszukiwane"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Odmówiono rejestracji sieci"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Rejestracja sieci przekroczyła czas oczekiwania"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Zarejestrowanie za pomocą żądanej sieci się nie powiodło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Sprawdzenie kodu PIN się nie powiodło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Brak oprogramowania sprzętowego urządzenia"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Połączenie zniknęło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Przyjęto istniejące połączenie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Nie odnaleziono modemu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Połączenie Bluetooth się nie powiodło"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Nie włożono karty SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Wymagany jest kod PIN karty SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Wymagany jest kod PUK karty SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Błędna karta SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Zależność połączenia się nie powiodła"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Brak oprogramowania sprzętowego"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabel jest niepodłączony"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "nieokreślony błąd w zabezpieczeniach 802.1X (WPA-EAP)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "nie wybrano żadnego pliku"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "nieokreślony błąd podczas sprawdzania poprawności pliku eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Klucze prywatne DER, PEM, PKCS#12 lub PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Certyfikaty DER lub PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "brak pliku PAC EAP-FAST"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Pliki PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4555,14 +2511,6 @@ msgstr "Wewnętrzne uw_ierzytelnianie"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Automatyczne za_bezpieczanie PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "brak nazwy użytkownika EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "brak hasła EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4589,15 +2537,6 @@ msgstr "_Hasło"
 msgid "Sho_w password"
 msgstr "_Wyświetlanie hasła"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "nieprawidłowy certyfikat CA EAP-PEAP: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "nieprawidłowy certyfikat CA EAP-PEAP: nie podano certyfikatu"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4619,7 +2558,6 @@ msgid "C_A certificate"
 msgstr "Certyfikat C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4634,63 +2572,6 @@ msgstr "Certyfikat CA nie jest _wymagany"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Wersja PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "brak nazwy użytkownika EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "brak hasła EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "brak tożsamości EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "nieprawidłowy certyfikat CA EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "nieprawidłowy certyfikat CA EAP-TLS: nie podano certyfikatu"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "nieprawidłowy klucz prywatny EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "nieprawidłowy certyfikat użytkownika EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Niezaszyfrowane klucze prywatne są niezabezpieczone"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Wybrany klucz prywatny nie jest chroniony hasłem. Może to umożliwić "
-"ujawnienie danych zabezpieczeń. Proszę wybrać klucz prywatny chroniony "
-"hasłem.\n"
-"\n"
-"(można ochronić klucz prywatny hasłem za pomocą oprogramowania OpenSSL)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Wybór osobistego certyfikatu"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Wybór klucza prywatnego"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4707,15 +2588,6 @@ msgstr "_Klucz prywatny"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Hasło klucza prywatnego"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "nieprawidłowy certyfikat CA EAP-TTLS: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "nieprawidłowy certyfikat CA EAP-TTLS: nie podano certyfikatu"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4738,14 +2610,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domena"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Nieznany błąd podczas sprawdzania poprawności zabezpieczeń 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4773,61 +2646,10 @@ msgstr "Chronione EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "Uwierzy_telnianie"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Wybierz plik"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "brak nazwy użytkownika LEAP"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "brak hasła LEAP"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Brak hasła Wi-Fi."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Typ"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "brak klucza WEP"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"nieprawidłowy klucz WEP: klucz o długości %zu może zawierać tylko cyfry "
-"szesnastkowe"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"nieprawidłowy klucz WEP: klucz o długości %zu może zawierać tylko znaki ASCII"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"nieprawidłowy klucz WEP: błędna długość klucza %zu. Klucz musi być długości "
-"5/13 (ASCII) lub 10/26 (szesnastkowy)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "nieprawidłowy klucz WEP: hasło nie może być puste"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "nieprawidłowy klucz WEP: hasło musi być krótsze niż 64 znaki"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4853,21 +2675,6 @@ msgstr "_Wyświetlanie klucza"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Inde_ks WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"nieprawidłowe WPA-PSK: nieprawidłowa długość klucza %zu. Musi mieć [8,63] "
-"bajty lub 64 cyfry szesnastkowe"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"nieprawidłowe WPA-PSK: nie można zinterpretować klucza o 64 bajtach jako "
-"szesnastkowy"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4922,29 +2729,11 @@ msgstr "Powiadomienia na ekranie _blokady"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Sterowanie wyświetlaniem powiadomień i ich treści"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Powiadomienia;Notyfikacje;Baner;Banner;Wiadomość;Komunikat;Obszar;Tacka;Tray;"
 "Wyskakujące;Popup;Pop-up;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Inne"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "Usunięto „%s”"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Błąd podczas usuwania konta"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4970,17 +2759,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Dodawanie konta"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Konto %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Usuń konto"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Konta online"
@@ -4989,10 +2767,6 @@ msgstr "Konta online"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Łączenie z kontami online i ustalanie, do czego mają być używane"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5001,10 +2775,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;WWW;Web;Online;Sieciowe;Komunikator;Chat;Czat;"
 "Kalendarz;Poczta;e-mail;email;Kontakt;Chmura;Cloud;Nextcloud;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;Flickr;Windows;Live;Microsoft;Exchange;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Nieznany czas"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5022,13 +2792,6 @@ msgstr[0] "%i godzina"
 msgstr[1] "%i godziny"
 msgstr[2] "%i godzin"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s i %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5042,191 +2805,6 @@ msgid_plural "minutes"
 msgstr[0] "minuta"
 msgstr[1] "minuty"
 msgstr[2] "minut"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "Do pełnego naładowania: %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Uwaga, pozostało: %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Pozostało: %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "W pełni naładowany"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Nie jest ładowany"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Pusty"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Ładowanie"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Rozładowywanie"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Mysz bezprzewodowa"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Klawiatura bezprzewodowa"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Urządzenie UPS"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Urządzenie PDA"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Telefon komórkowy"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Odtwarzacz multimediów"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Komputer"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Kontroler do gier"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Akumulator"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Główny"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Dodatkowy"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Akumulatory"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Podczas _bezczynności"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Uśpienie"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Wyłączenie komputera"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hibernacja"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nic"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Na zasilaniu z akumulatora"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Kiedy jest podłączony do prądu"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nigdy"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automatyczne usypianie"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Tryb wydajności jest tymczasowo wyłączony z powodu wysokiej temperatury "
-"działania."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Wykryto kolana: tryb wydajności jest tymczasowo niedostępny. Należy "
-"przenieść urządzenie na stabilną powierzchnię, aby przywrócić."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Tryb wydajności jest tymczasowo wyłączony."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Niski poziom naładowania akumulatora: włączono tryb oszczędzania energii. "
-"Poprzedni tryb zostanie przywrócony po wystarczającym naładowaniu "
-"akumulatora."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Tryb oszczędzania energii został włączony przez program „%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Tryb wydajności został włączony przez program „%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5287,6 +2865,15 @@ msgstr "100 minut"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 godziny"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akumulator"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Urządzenia"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5367,33 +2954,6 @@ msgstr "Na zasilaniu z _akumulatora"
 msgid "Delay"
 msgstr "Opóźnienie"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Wydajność"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Wysoka wydajność i pobór energii."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Zrównoważone zasilanie"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standardowa wydajność i pobór energii."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Oszczędzanie energii"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Zmniejszona wydajność i pobór energii."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Zasilanie"
@@ -5404,7 +2964,6 @@ msgstr ""
 "Wyświetlanie stanu naładowania akumulatora i zmiana ustawień oszczędzania "
 "energii"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5414,27 +2973,6 @@ msgstr ""
 "Wyłącz;Wstrzymaj;Hibernuj;Akumulator;Bateria;Jasność;Przygaszenie;Wygaszenie;"
 "Monitor;DPMS;Bezczynność;Nieaktywność;Wi-Fi;Wifi;Bluetooth;Bezprzewodowe;"
 "Wireless;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Usunięto drukarkę „%s”"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Dodanie nowej drukarki się nie powiodło."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Nie można wczytać interfejsu użytkownika: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Odblokowanie umożliwi dodawanie drukarek i zmianę ustawień"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5446,7 +2984,6 @@ msgstr ""
 "Dodawanie drukarek, wyświetlanie zadań drukowania i ustalanie sposobu "
 "drukowania"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Drukarka;Kolejka;Drukowanie;Papier;Atrament;Tusz;Toner;CUPS;IPP;"
@@ -5454,8 +2991,6 @@ msgstr "Drukarka;Kolejka;Drukowanie;Papier;Atrament;Tusz;Toner;CUPS;IPP;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Dodanie drukarki"
 
@@ -5496,29 +3031,6 @@ msgstr ""
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Informacje o „%s”"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Nie odnaleziono odpowiedniego sterownika"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Wybór pliku PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Pliki PostScriptowego opisu drukarki (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Nazwy drukarek nie mogą zawierać spacji, znaków tabulacji, # ani /"
@@ -5527,9 +3039,7 @@ msgstr "Nazwy drukarek nie mogą zawierać spacji, znaków tabulacji, # ani /"
 msgid "Location"
 msgstr "Położenie"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Sterownik"
 
@@ -5557,121 +3067,14 @@ msgstr "Wybór sterownika drukarki"
 msgid "Loading drivers database…"
 msgstr "Wczytywanie bazy danych sterowników…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Anuluj"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Wybierz"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Drukarka JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Drukarka LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Jednostronnie"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Długa krawędź (standardowo)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Krótka krawędź (odwrócenie)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Portret"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Pejzaż"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Odwrócony pejzaż"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Odwrócony portret"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Wznów"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Wstrzymaj"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Oczekuje"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Wstrzymane"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Wymagane jest uwierzytelnienie"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Przetwarzanie"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Zatrzymane"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Anulowane"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Przerwane"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Ukończone"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Przenosi to zadanie na początek kolejki"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5679,21 +3082,6 @@ msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u zadanie wymaga uwierzytelnienia"
 msgstr[1] "%u zadania wymagają uwierzytelnienia"
 msgstr[2] "%u zadań wymaga uwierzytelnienia"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — aktywne zadania"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr ""
-"Proszę wprowadzić dane uwierzytelniające, aby wydrukować za pomocą drukarki "
-"„%s”."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5721,207 +3109,11 @@ msgstr "U_wierzytelnij"
 msgid "No Active Printer Jobs"
 msgstr "Brak aktywnych zadań drukarki"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Odblokowanie serwera wydruku"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Odblokowanie „%s”."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Proszę wprowadzić nazwę użytkownika i hasło, aby wyświetlić drukarki w „%s”."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Wyszukiwanie drukarek"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Port szeregowy"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Port równoległy"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Położenie: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adres: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Serwer wymaga uwierzytelnienia"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dwustronnie"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Typ papieru"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Źródło papieru"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Podajnik wyjściowy"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Rozdzielczość"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Filtrowanie GhostScript przed wydrukiem"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Stron na kartkę"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dwustronnie"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientacja"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Ogólne"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Ustawienia strony"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opcje instalacyjne"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Zadanie"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Jakość obrazu"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Kolor"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Kończenie"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Zaawansowane"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Strona testowa"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Strona testowa"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Wybór automatyczny"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Domyślne drukarki"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Osadzanie tylko czcionek GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Konwertowanie na PostScript 1. poziomu"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Konwertowanie na PostScript 2. poziomu"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Brak filtrowania przed wydrukiem"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Producent"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Brak aktywnych zadań"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5929,115 +3121,6 @@ msgid_plural "%u Jobs"
 msgstr[0] "%u zadanie"
 msgstr[1] "%u zadania"
 msgstr[2] "%u zadań"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Czyszczenie głowic drukujących"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Mało tonera"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Brak tonera"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Mało wywoływacza"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Brak wywoływacza"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Mało atramentu"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Brak atramentu"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Otwarta pokrywa"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Otwarte drzwiczki"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Mało papieru"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Brak papieru"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Offline"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Zatrzymana"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Pojemnik na odpady jest prawie pełny"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Pojemnik na odpady jest pełny"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Warstwa światłoczuła ledwo działa"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Warstwa światłoczuła już nie działa"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Gotowa"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Nie przyjmuje zadań"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Przetwarzanie"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6061,6 +3144,10 @@ msgstr "Wyczyść głowice drukujące"
 msgid "Remove Printer"
 msgstr "Usuń drukarkę"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Brak aktywnych zadań"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6081,22 +3168,26 @@ msgid "Restart"
 msgstr "Uruchom ponownie"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Dodaj drukarkę…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Dodaj drukarkę…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Brak drukarek"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
 msgstr "Systemowa usługa drukowania jest niedostępna."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formaty"
@@ -6124,16 +3215,6 @@ msgstr "Można wyszukiwać kraje i języki."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Podgląd"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "anglosaskie (imperialne)"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "metryczne"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6171,20 +3252,24 @@ msgstr ""
 "Język używany w tekście interfejsu i na stronach WWW oraz format liczb, dat "
 "i walut."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Obecnie zalogowane konto"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Język"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formaty"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Ekran logowania"
 
@@ -6196,99 +3281,9 @@ msgstr "Region i język"
 msgid "Select your display language and formats"
 msgstr "Wybór języka wyświetlania i formatów"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Język;Dialekt;Układ;Layout;Klawiatura;Wprowadzanie;Wejście;Pisanie;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Pytanie, co robić"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Nierobienie niczego"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Otwarcie katalogu"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Inne nośniki"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Wybór programu dla płyt CD-Audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Wybór programu dla płyt wideo DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Wybór programu do uruchomienia po podłączeniu odtwarzacza multimediów"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Wybór programu do uruchomienia po podłączeniu aparatu"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Wybór programu dla płyt CD z oprogramowaniem"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "Płyta DVD-Audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Pusta płyta Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "Pusta płyta CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "Pusta płyta DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "Pusta płyta HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Płyta wideo Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "Czytnik e-booków"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Płyta wideo HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Oprogramowanie systemu Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6338,7 +3333,6 @@ msgstr "Nośniki wymienne"
 msgid "Configure Removable Media settings"
 msgstr "Konfiguracja nośników wymiennych"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6347,114 +3341,6 @@ msgstr ""
 "urządzenie;system;domyślne;programy;aplikacje;domyślny;program;aplikacja;"
 "preferowane;cd;dvd;usb;dźwięk;audio;wideo;video;płyta;dysk;wymienny;nośnik;"
 "automatyczne;uruchamianie;autorun;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Natychmiast"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekund"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuta"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minuty"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minuty"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minut"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minut"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 godzina"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minuty"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minuty"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minuty"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nigdy"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6493,11 +3379,16 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "_Powiadomienia na ekranie blokady"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Powiadomienia na ekranie _blokady"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Bez włączania nowych urządzeń _USB"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6505,30 +3396,25 @@ msgstr ""
 "Uniemożliwia urządzeniom USB działanie na komputerze, kiedy ekran jest "
 "zablokowany."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Prywatność ekranu"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Ograniczenie kąta widzenia"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekran"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Ustawienia ekranu"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "ekran;blokada;zablokuj;prywatne;prywatność;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Wybór położenia"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6559,10 +3445,6 @@ msgstr "Inne"
 msgid "Add Location"
 msgstr "Dodaj położenie"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nie odnaleziono programów"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Przeszukiwanie programów"
@@ -6589,94 +3471,15 @@ msgid ""
 msgstr ""
 "Sterowanie programami wyświetlającymi wyniki wyszukiwania na ekranie podglądu"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Wyszukiwanie;Znajdź;Szukaj;Wyszukaj;Indeksowanie;Index;Ukryj;Ukrywanie;"
 "Prywatność;Wyniki;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Nie wybrano żadnych sieci do udostępniania"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Sieci"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Włączone"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Wyłączone"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Włączone"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktywne"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Wybór katalogu"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Dodaj"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Włącz udostępnianie multimediów"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Udostępnianie plików umożliwia udostępnianie katalogu Publiczne z innymi "
-"użytkownikami bieżącej sieci za pomocą: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Umożliwia zdalnym użytkownikom na łączenie się za pomocą polecenia SSH:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Włącz udostępnianie multimediów osobistych"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Skopiowano nazwę urządzenia"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Skopiowano adres urządzenia"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Skopiowano nazwę użytkownika"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Skopiowano hasło"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6808,7 +3611,6 @@ msgstr "Katalogi"
 msgid "Control what you want to share with others"
 msgstr "Sterowanie udostępnianiem innym użytkownikom"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6827,10 +3629,6 @@ msgstr "Włączenie lub wyłączenie zdalnego logowania"
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Wymagane jest uwierzytelnienie, aby włączyć lub wyłączyć zdalne logowanie"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Niestandardowy"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6863,11 +3661,6 @@ msgstr "Tył"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Przód"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Testowanie „%s”"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6921,11 +3714,6 @@ msgstr "Głośność"
 msgid "Alert Sound"
 msgstr "Dźwięk alarmu"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Wycisz"
@@ -6939,7 +3727,6 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Zmiana poziomu głośności, wejść i wyjść dźwięku oraz zdarzeń dźwiękowych"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6947,76 +3734,6 @@ msgstr ""
 "Karta;Mikrofon;Głośność;Oddalenie;Balans;Bluetooth;Headset;Słuchawki;"
 "Głośniki;Audio;Wyjście;Wejście;Efekty;Alarmy;Odtwarzanie;Nagrywanie;Mono;"
 "Stereo;Surround;Dookolny;PCM;S/PDIF;HDMI;DTS;Dolby;Digital;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Rozłączone"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Łączenie"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Połączone"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Błąd upoważnienia"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Upoważnianie"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Ograniczona funkcjonalność"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Połączone i upoważnione"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Nieznane"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Upoważniono:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Połączono:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Zapisano:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Upoważnienie urządzenia się nie powiodło: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Zapomnienie urządzenia się nie powiodło: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7051,57 +3768,6 @@ msgstr "Upoważnij i połącz"
 msgid "Forget Device"
 msgstr "Zapomnij urządzenie"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Błąd"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Upoważnione"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Podsystem Thunderbolt (boltd) nie jest zainstalowany lub właściwie "
-"skonfigurowany."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Zezwolenie na bezpośredni dostęp do urządzeń takich jak stacje dokujące "
-"i zewnętrzne karty graficzne."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Tylko urządzenia USB i Display Port mogą być podłączane."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Nie można wykryć sprzętu Thunderbolt.\n"
-"Komputer nie ma obsługi Thunderbolt, został wyłączony w BIOS-ie lub "
-"ustawiony na nieobsługiwany poziom zabezpieczeń."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Obsługa Thunderbolt została wyłączona w BIOS-ie."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Nie można ustalić poziomu zabezpieczeń Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Błąd podczas przełączania trybu bezpośredniego: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Brak obsługi Thunderbolt"
@@ -7113,6 +3779,12 @@ msgstr "Nie można połączyć się z podsystemem Thunderbolt."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Bezpośredni dostęp"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Zezwolenie na bezpośredni dostęp do urządzeń takich jak stacje dokujące "
+"i zewnętrzne karty graficzne."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7130,7 +3802,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Zarządzanie urządzeniami Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;prywatność;"
@@ -7332,41 +4003,6 @@ msgstr "_Włączanie za pomocą klawiatury"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Włączanie funkcji ułatwień dostępu za pomocą klawiatury"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Domyślny"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Średni"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Duży"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Większy"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Największy"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d piksel"
-msgstr[1] "%d piksele"
-msgstr[2] "%d pikseli"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Zawsze widoczne menu ułatwień dostępu"
@@ -7481,31 +4117,6 @@ msgstr "Miganie całym _ekranem"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Miganie całym _oknem"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Krótki"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ekranu"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ekranu"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ekranu"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Długi"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7662,7 +4273,6 @@ msgstr "Zmiana kolorów"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Ułatwienia widzenia, słyszenia, pisania oraz wskazywania i klikania"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7676,114 +4286,6 @@ msgstr ""
 "wielkość;AccessX;Trwałe;Klawisze;Powolne;Odbijające;Myszy;Podwójne;Dwukrotne;"
 "kliknięcie;Opóźnienie;Prędkość;Szybkość;Wspomaganie;Asysta;Powtarzanie;"
 "Miganie;wzrok;wizualne;słuch;dźwięk;audio;pisanie;klikanie;animacje;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 godzina"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dzień"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "2 tygodnie"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "Miesiąc"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Usunąć wszystkie elementy z kosza?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Wszystkie elementy w koszu zostaną trwale usunięte."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Opróżnij kosz"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Usunąć wszystkie pliki tymczasowe?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Wszystkie pliki tymczasowe zostaną trwale usunięte."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Usuń pliki tymczasowe"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dzień"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dni"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "Miesiąc"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Bez ograniczenia"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7851,7 +4353,6 @@ msgstr "Historia plików i kosz"
 msgid "Don't leave traces"
 msgstr "Nie zostawiaj śladów"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
@@ -7859,57 +4360,6 @@ msgstr ""
 "użycie;ostatnie;ostatnio;używane;użyte;historia;pliki;plików;tymczasowe;tmp;"
 "prywatne;prywatność;kosz;śmietnik;czyszczenie;wyczyść;przeczyść;usuwanie;"
 "usuń;kasowanie;skasuj;kasuj;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Powinno zgadzać się z adresem WWW dostawcy konta."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Dodanie konta się nie powiodło"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Hasła się nie zgadzają."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Zarejestrowanie konta się nie powiodło"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Brak obsługiwanego sposobu na uwierzytelnienie w tej domenie"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Dołączenie do domeny się nie powiodło"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Ten login nie zadziałał.\n"
-"Proszę spróbować ponownie."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"To hasło nie zadziałało.\n"
-"Proszę spróbować ponownie."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Zalogowanie do domeny się nie powiodło"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Nie można odnaleźć domeny. Może ją niepoprawnie wpisano?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7962,10 +4412,6 @@ msgstr ""
 "Logowanie firmowe umożliwia używanie istniejącego, centralnie zarządzanego "
 "konta użytkownika na tym urządzeniu. Można użyć tego konta także do "
 "uzyskania dostępu do zasobów firmy w Internecie."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Przeglądanie innych obrazów"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8036,222 +4482,6 @@ msgstr "_Usuń odciski palców"
 msgid "Fingerprint Enroll"
 msgstr "Pobieranie odcisku palca"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "urządzenie musi zostać zajęte, aby wykonać to działanie"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "urządzenie jest już zajęte przez inny proces"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "brak uprawnienia do wykonania działania"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "nie pobrano żadnych odcisków"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Komunikacja z urządzeniem podczas pobierania się nie powiodła"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Komunikacja z czytnikiem odcisku palca się nie powiodła"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Komunikacja z usługą czytnika odcisku palca się nie powiodła"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Wyświetlenie listy odcisków palców się nie powiodło: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Usunięcie zapisanych odcisków palców się nie powiodło: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Lewy kciuk"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Lewy palec środkowy"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Lewy palec wskazujący"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Lewy palec serdeczny"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Lewy mały palec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Prawy kciuk"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Prawy palec środkowy"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Prawy palec wskazujący"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Prawy palec serdeczny"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Prawy mały palec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Nieznany palec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Ukończono"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Czytnik odcisków palców został rozłączony"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Czytnik odcisków palców jest pełny"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Pobranie nowego odciska palca się nie powiodło"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Rozpoczęcie pobierania odcisku palca się nie powiodło: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Pobranie nowego odcisku palca się nie powiodło"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Zatrzymanie pobierania odcisku palca się nie powiodło: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Proszę kilkakrotnie podnieść i położyć palec na czytniku, aby pobrać odcisk "
-"palca"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Ponownie pobierz ten odcisk palca…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Pobierz nowy odcisk palca"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Zwolnienie czytnika odcisków palców %s się nie powiodło: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problem podczas odczytu czytnika"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Zajęcie czytnika odcisków palców %s się nie powiodło: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Uzyskanie czytników odcisków palców się nie powiodło: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Ten tydzień"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Ostatni tydzień"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%-d %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%-d %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%H∶%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Koniec sesji"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Początek sesji"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — aktywność konta"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Wstecz"
@@ -8259,18 +4489,6 @@ msgstr "Wstecz"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Dalej"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Proszę wybrać inne hasło."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Proszę ponownie wprowadzić obecne hasło."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Nie można zmienić hasła"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8292,6 +4510,10 @@ msgstr "Nowe hasło"
 msgid "Confirm Password"
 msgstr "Potwierdzenie hasła"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Hasła się nie zgadzają."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Użytkownik będzie mógł zmienić hasło podczas następnego logowania"
@@ -8299,135 +4521,6 @@ msgstr "Użytkownik będzie mógł zmienić hasło podczas następnego logowania
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Ustawienie hasła teraz"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Nie można automatycznie dołączyć do tego typu domeny"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Nie odnaleziono takiej domeny lub obszaru"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Nie można zalogować jako „%s” w domenie %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Nieprawidłowe hasło, proszę spróbować ponownie"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Nie można połączyć z domeną %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Usunięcie użytkownika się nie powiodło"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Unieważnienie zdalnie zarządzanego użytkownika się nie powiodło"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Nie można usunąć własnego konta."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "Użytkownik „%s” jest nadal zalogowany"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Usunięcie nadal zalogowanego użytkownika może pozostawić system w niespójnym "
-"stanie."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Zachować pliki użytkownika „%s”?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Możliwe jest zachowanie katalogu domowego, kolejki poczty i plików "
-"tymczasowych podczas usuwania konta użytkownika."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Usuń pliki"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Zachowaj pliki"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Na pewno unieważnić zdalnie zarządzane konto użytkownika „%s”?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Usuń"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Konto jest wyłączone"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Zostanie ustawione podczas następnego logowania"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Brak"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Zalogowano"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Skontaktowanie się z usługą kont się nie powiodło"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Proszę się upewnić, że usługa AccountService jest zainstalowana i włączona."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Należy odblokować ten panel, aby zmienić to ustawienie"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Usuwa wybrane konto użytkownika"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Aby usunąć wybrane konto użytkownika,\n"
-"najpierw należy kliknąć ikonę *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Odblokowanie umożliwi dodawanie użytkowników i zmianę ustawień"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8455,7 +4548,6 @@ msgid "Full name"
 msgstr "Imię i nazwisko"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Modyfikuj"
 
@@ -8517,7 +4609,6 @@ msgstr "Odblokowanie umożliwi dodanie konta użytkownika."
 msgid "Add or remove users and change your password"
 msgstr "Dodawanie lub usuwanie użytkowników i zmienianie hasła"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8567,177 +4658,6 @@ msgstr "Zarządzanie kontami użytkowników"
 msgid "Authentication is required to change user data"
 msgstr "Wymagane jest uwierzytelnienie, aby zmienić dane użytkowników"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Nowe hasło musi się różnić od poprzedniego."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Proszę zmienić jakieś litery i cyfry."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Proszę trochę bardziej zmienić hasło."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Hasło bez nazwy użytkownika byłoby silniejsze."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Proszę unikać używania swojego imienia lub nazwiska w haśle."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Proszę unikać niektórych słów użytych w haśle."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Proszę unikać często używanych słów."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Proszę unikać zmieniania kolejności liter w istniejących słowach."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Proszę użyć więcej cyfr."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Proszę użyć więcej wielkich liter."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Proszę użyć więcej małych liter."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-"Proszę użyć więcej znaków specjalnych, takich jak znaki interpunkcyjne."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Proszę użyć mieszanki liter, cyfr i znaków interpunkcyjnych."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Proszę unikać powtarzania tego samego znaku."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Proszę unikać powtarzania tego samego rodzaju znaków: należy mieszać litery, "
-"liczby i znaki interpunkcyjne."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Proszę unikać ciągów takich jak 1234 lub abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Hasło musi być dłuższe. Proszę dodać więcej liter, cyfr i znaków "
-"interpunkcyjnych."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Należy mieszać wielkie i małe litery oraz dodać cyfrę lub dwie."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Dodanie więcej liter, liczb i znaków interpunkcyjnych wzmocni hasło."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Uwierzytelnienie się nie powiodło"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Nowe hasło jest za krótkie"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Nowe hasło jest zbyt proste"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Nowe hasło jest zbyt podobne do poprzedniego"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Nowe hasło zostało już niedawno użyte."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Nowe hasło musi zawierać znaki numeryczne lub specjalne"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Nowe hasło jest takie same jak poprzednie"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Hasło zostało zmienione po początkowym uwierzytelnieniu."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Nowe hasło nie zawiera wystarczającej liczby różnych znaków"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Nieznany błąd"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Nazwa użytkownika zwykle powinna zawierać tylko małe litery z alfabetu "
-"łacińskiego, cyfry oraz te znaki: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Ta nazwa użytkownika jest niedostępna. Proszę wybrać inną."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Nazwa użytkownika jest za długa."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8772,52 +4692,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Wykryto błędne kliknięcie, ponowne uruchamianie…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "%d. przycisk"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Określone przez program"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Wysłanie naciśnięcia klawisza"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Przełączenie monitora"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Ekran pomocy"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tablet zamontowany w panelu laptopa"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tablet zamontowany w zewnętrznym ekranie"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Tablet jako urządzenie zewnętrzne"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Oddzielny panel"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Wszystkie ekrany"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8914,22 +4792,6 @@ msgstr "Kliknięcie prawym przyciskiem myszy"
 msgid "Forward"
 msgstr "Dalej"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Aerograf z czujnikiem nacisku i pochylenia oraz zintegrowanym suwakiem"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Aerograf z czujnikiem nacisku, pochylenia i obrotu"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standardowy rysik z czujnikiem nacisku i pochylenia"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standardowy rysik z czujnikiem nacisku"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tablet firmy Wacom"
@@ -8940,54 +4802,96 @@ msgstr ""
 "Ustawienie mapowania przycisków i dostosowanie wrażliwości rysika dla "
 "tabletów graficznych"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Rysik;Stylus;Gumka;Mysz;Myszka;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Nowy skrót…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Symulowanie przycisku pomocniczego"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Oprogramowanie systemu Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Mało tonera"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Opóźnienie kliknięcia pomocniczego"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Oprogramowanie systemu Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Zarządzanie preferencjami efektywności i wielozadaniowości"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Punkty dostępu"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Dodaj"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Zapisz"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Anulowano działanie"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Błąd:</b> odmowa dostępu podczas zmiany ustawień"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Błąd:</b> błąd wyposażenia komórkowego"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Nie zarejestrowano"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Zarejestrowano"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Wyszukiwanie"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Odmowa"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9017,212 +4921,13 @@ msgstr "Własny numer"
 msgid "Device Details"
 msgstr "Informacje o urządzeniu"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Producent"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Wersja oprogramowania sprzętowego"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Tylko 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Tylko 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Tylko 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Tylko 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (preferowane), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (preferowane), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (preferowane), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (preferowane), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (preferowane), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (preferowane), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (preferowane), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (preferowane), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (preferowane), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (preferowane), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (preferowane), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (preferowane), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (preferowane), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (preferowane), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (preferowane), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (preferowane), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (preferowane)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (preferowane), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Nieznany"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Odblokowanie karty SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Odblokuj"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Proszę podać kod PIN dla %d. karty SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Proszę podać kod PIN, aby odblokować kartę SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Proszę podać kod PUK dla %d. karty SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Proszę podać kod PUK, aby odblokować kartę SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9239,26 +4944,6 @@ msgid_plural "You have %u tries left"
 msgstr[0] "Pozostała %u próba"
 msgstr[1] "Pozostały %u próby"
 msgstr[2] "Pozostało %u prób"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Podano błędne hasło."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Kod PUK musi być liczbą ośmio­cyfrową"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Proszę podać nowy kod PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Kod PIN musi być liczbą o czterech do ośmiu cyfr"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Odblokowywanie…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9316,94 +5001,6 @@ msgstr "Zablokuj kartę SIM za pomocą kodu PIN"
 msgid "M_odem Details"
 msgstr "_Informacje o modemie"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Niepowodzenie telefonu"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Brak połączenia z telefonem"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Działanie jest niedozwolone"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Działanie jest nieobsługiwane"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Nie włożono karty SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Wymagany jest kod PIN karty SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Wymagany jest kod PUK karty SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Niepowodzenie karty SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Karta SIM jest zajęta"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Niewłaściwe hasło"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Wymagany jest kod PIN2 karty SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Wymagany jest kod PUK2 karty SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Nie odnaleziono"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Brak zasięgu sieci"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Przekroczenie czasu oczekiwania sieci"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Usługi GPRS są niedozwolone"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming jest niedozwolony w tym położeniu"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Nieokreślony błąd GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Brak błędu"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Anulowano działanie"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Odmowa dostępu"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Nieznany błąd"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Tryb sieci"
@@ -9419,11 +5016,6 @@ msgstr "Wybór sieci"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Odśwież dostawców sieci"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "%d. karta SIM"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9484,7 +5076,6 @@ msgstr "Sieć komórkowa"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Konfiguracja połączeń telefonicznych i komórkowych"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "komórkowa;komórka;wwan;telefon;telefonia;sim;pin;puk;mobilna;"
@@ -9501,41 +5092,13 @@ msgstr "Główny interfejs do konfigurowania komputera."
 msgid "The GNOME Project"
 msgstr "Projekt GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Wyświetla numer wersji"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Wyświetla więcej komunikatów"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Wyszukuje tekst"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Wyświetla listę dostępnych paneli i kończy działanie"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel do wyświetlenia"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [PARAMETR…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Kategorie ustawień"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Prywatność"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Dostępne panele:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9593,7 +5156,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Anulowanie wyszukiwania"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferencje;Ustawienia;Konfiguracja;Opcje;"
@@ -9634,8 +5196,6 @@ msgstr ""
 "Krotka zawierająca początkową szerokość, wysokość i stan maksymalizacji okna "
 "programu."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9644,8 +5204,6 @@ msgstr[0] "%u wyjście"
 msgstr[1] "%u wyjścia"
 msgstr[2] "%u wyjść"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9654,6 +5212,3142 @@ msgstr[0] "%u wejście"
 msgstr[1] "%u wejścia"
 msgstr[2] "%u wejść"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Dźwięki systemowe"
+#~ msgid "System Bus"
+#~ msgstr "Magistrala systemowa"
+
+#~ msgid "Full access"
+#~ msgstr "Pełny dostęp"
+
+#~ msgid "Session Bus"
+#~ msgstr "Magistrala sesji"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Pełny dostęp do katalogu /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Ma dostęp do sieci"
+
+#~ msgid "Home"
+#~ msgstr "Katalog domowy"
+
+#~ msgid "Read-only"
+#~ msgstr "Tylko do odczytu"
+
+#~ msgid "File System"
+#~ msgstr "System plików"
+
+#~ msgid "Can change settings"
+#~ msgstr "Może zmieniać ustawienia"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s ma poniższe wbudowane uprawnienia. Nie można ich zmieniać. W razie "
+#~ "obaw dotyczących tych uprawień można usunąć ten program."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u typ plików i odnośników otwierany przez program"
+#~ msgstr[1] "%u typy plików i odnośników otwierane przez program"
+#~ msgstr[2] "%u typów plików i odnośników otwieranych przez program"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "Program <b>%s</b> jest używany do otwierania poniższych typów plików "
+#~ "i odnośników."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "Używa %s miejsca na dysku."
+
+#~ msgid "Select a picture"
+#~ msgstr "Wybór obrazu"
+
+#~ msgid "_Open"
+#~ msgstr "_Otwórz"
+
+#~ msgid "multiple sizes"
+#~ msgstr "wiele rozmiarów"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d×%d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Bez tła pulpitu"
+
+#~ msgid "Current background"
+#~ msgstr "Obecne tło"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Proszę umieścić urządzenie na kwadracie i nacisnąć przycisk „Rozpocznij”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Proszę umieścić urządzenie w pozycji kalibracji i nacisnąć przycisk "
+#~ "„Kontynuuj”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Proszę umieścić urządzenie w pozycji powierzchni i nacisnąć przycisk "
+#~ "„Kontynuuj”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Proszę zamknąć pokrywę laptopa"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Wystąpił wewnętrzny błąd, z którego nie można przywrócić."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Narzędzia wymagane do kalibracji nie są zainstalowane."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Nie można utworzyć profilu."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Nie można uzyskać docelowego punktu bieli."
+
+#~ msgid "Complete!"
+#~ msgstr "Ukończono"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibracja się nie powiodła"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Można usunąć urządzenie kalibracji."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Nie należy usuwać urządzenia podczas trwania kalibracji"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Ekran laptopa"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Wbudowana kamera internetowa"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Skaner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Aparat %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Drukarka %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Kamera internetowa %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Włącz zarządzanie kolorami dla %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Wyświetl profile kolorów dla %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nieskalibrowane"
+
+#~ msgid "Default: "
+#~ msgstr "Domyślny: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Przestrzeń kolorów: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Profil testowy: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Wybór pliku profilu ICC"
+
+#~ msgid "_Import"
+#~ msgstr "Zai_mportuj"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Obsługiwane profile ICC"
+
+#~ msgid "All files"
+#~ msgstr "Wszystkie pliki"
+
+#~ msgid "Save Profile"
+#~ msgstr "Zapis profilu"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Tworzy profil kolorów dla wybranego urządzenia"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Nie wykryto urządzenia pomiarowego. Proszę sprawdzić, czy jest włączone "
+#~ "i poprawnie podłączone."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Urządzenie pomiarowe nie obsługuje profilowania drukarek."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Typ urządzenia nie jest obecnie obsługiwany."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standardowa przestrzeń"
+
+#~ msgid "Test Profile"
+#~ msgstr "Profil testowy"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatyczny"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Niska jakość"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Średnia jakość"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Wysoka jakość"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Domyślna RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Domyślna CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Domyślna skala szarości"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Fabryczne dane kalibracji dostarczone przez producenta"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr ""
+#~ "Pełnoekranowa korekcja kolorów nie jest możliwa za pomocą tego profilu"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Ten profil może już nie być dokładny"
+
+#~ msgid "Other…"
+#~ msgstr "Inny…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Odblokowanie umożliwi zmianę ustawień"
+
+#~ msgid "Today"
+#~ msgstr "Dzisiaj"
+
+#~ msgid "Yesterday"
+#~ msgstr "Wczoraj"
+
+#~ msgid "%b %e"
+#~ msgstr "%-d %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-d %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d godzina"
+#~ msgstr[1] "%d godziny"
+#~ msgstr[2] "%d godzin"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuta"
+#~ msgstr[1] "%d minuty"
+#~ msgstr[2] "%d minut"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekunda"
+#~ msgstr[1] "%d sekundy"
+#~ msgstr[2] "%d sekund"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s, %s i %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s i %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s i %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "24-hour"
+#~ msgstr "24-godzinny"
+
+#~ msgid "AM / PM"
+#~ msgstr "12-godzinny"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%-d %B %Y, %-l∶%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%-d %B %Y, %H∶%M"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%-l∶%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%H∶%M"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Wysyłanie informacji o problemach technicznych pomaga ulepszyć system %s. "
+#~ "Zgłoszenia są anonimowe i pozbawione danych osobistych. %s"
+
+#~ msgid "On"
+#~ msgstr "Włączone"
+
+#~ msgid "Off"
+#~ msgstr "Wyłączone"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Zastosować zmiany?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Nie można zastosować zmian"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Może to być spowodowane ograniczeniami sprzętu."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Pozioma"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Pionowa (w prawo)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Pionowa (w lewo)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Pozioma (odwrócona)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Zabezpieczone uruchamianie jest aktywne"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
+#~ "oprogramowania podczas uruchamiania urządzenia. Jest obecnie włączone "
+#~ "i działa poprawnie."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Zabezpieczone uruchamianie ma problemy"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
+#~ "oprogramowania podczas uruchamiania urządzenia. Jest obecnie włączone, "
+#~ "ale nie będzie działać z powodu nieprawidłowego klucza."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Problemy z zabezpieczonym uruchamianiem często można rozwiązać "
+#~ "w ustawieniach oprogramowania sprzętowego UEFI (BIOS-ie) komputera, "
+#~ "a producent sprzętu może podawać informacje, jak to zrobić."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Należy skontaktować się z producentem używanego sprzętu lub dostawcą "
+#~ "wsparcia informatycznego w celu uzyskania pomocy."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Zabezpieczone uruchamianie jest wyłączone"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
+#~ "oprogramowania podczas uruchamiania urządzenia. Jest obecnie wyłączone."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Zabezpieczone uruchamianie często można włączyć w ustawieniach "
+#~ "oprogramowania sprzętowego UEFI (BIOS-ie) komputera. Należy skontaktować "
+#~ "się z producentem używanego sprzętu lub dostawcą wsparcia informatycznego "
+#~ "w celu uzyskania pomocy."
+
+#~ msgid "Passed"
+#~ msgstr "Powodzenie"
+
+#~ msgid "Failed"
+#~ msgstr "Niepowodzenie"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Urządzenie jest zgodne z %d. poziomem HSI"
+
+#~ msgid "Security Level 0"
+#~ msgstr "0. poziom zabezpieczeń"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "To urządzenie nie ma ochrony przed sprzętowymi problemami bezpieczeństwa. "
+#~ "Może to być spowodowane problemem z konfiguracją sprzętu lub "
+#~ "oprogramowania sprzętowego. Zalecane jest skontaktowanie się z dostawcą "
+#~ "wsparcia informatycznego."
+
+#~ msgid "Security Level 1"
+#~ msgstr "1. poziom zabezpieczeń"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "To urządzenie ma minimalną ochronę przed sprzętowymi problemami "
+#~ "bezpieczeństwa. To najniższy poziom zabezpieczeń urządzenia, który "
+#~ "zapewnia ochronę tylko przed prostymi zagrożeniami bezpieczeństwa."
+
+#~ msgid "Security Level 2"
+#~ msgstr "2. poziom zabezpieczeń"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "To urządzenie ma podstawową ochronę przed sprzętowymi problemami "
+#~ "bezpieczeństwa. Zapewnia to ochronę przed częścią często występujących "
+#~ "zagrożeń bezpieczeństwa."
+
+#~ msgid "Security Level 3"
+#~ msgstr "3. poziom zabezpieczeń"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "To urządzenie ma rozszerzoną ochronę przed sprzętowymi problemami "
+#~ "bezpieczeństwa. To najwyższy poziom zabezpieczeń urządzenia, który "
+#~ "zapewnia ochronę przed zaawansowanymi zagrożeniami bezpieczeństwa."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Poziomy zabezpieczeń nie są dostępne dla tego urządzenia."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Należy skontaktować się z producentem sprzętu, aby uzyskać pomoc "
+#~ "z aktualizacjami zabezpieczeń."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Rozwiązanie tego problemu może być możliwe w ustawieniach oprogramowania "
+#~ "sprzętowego UEFI lub przez pracownika wsparcia."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Rozwiązanie tego problemu może być możliwe w ustawieniach oprogramowania "
+#~ "sprzętowego UEFI."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Rozwiązanie tego problemu może być możliwe przez pracownika wsparcia."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr ""
+#~ "Ochrona przed złośliwym oprogramowaniem podczas uruchamiania urządzenia."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Zabezpieczone uruchamianie ma problemy"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Pewna ochrona podczas uruchamiania urządzenia."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Zabezpieczone uruchamianie jest wyłączone"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Brak ochrony podczas uruchamiania urządzenia."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Ten problem mógł być spowodowany przez zmianę ustawień oprogramowania "
+#~ "sprzętowego UEFI, zmianę konfiguracji systemu operacyjnego lub z powodu "
+#~ "złośliwego oprogramowania na tym komputerze."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Ten problem mógł być spowodowany przez zmianę ustawień oprogramowania "
+#~ "sprzętowego UEFI lub z powodu złośliwego oprogramowania na tym komputerze."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Ten problem mógł być spowodowany przez zmianę konfiguracji systemu "
+#~ "operacyjnego lub z powodu złośliwego oprogramowania na tym komputerze."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Podatność na poważne zagrożenia bezpieczeństwa."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Ograniczona ochrona przed prostymi zagrożeniami bezpieczeństwa."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Ochrona przed często występującymi zagrożeniami bezpieczeństwa."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Ochrona przed szerokim zakresem zagrożeń bezpieczeństwa."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Pełna ochrona"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Ochrona przed zapisem oprogramowania sprzętowego"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Blokada ochrony przed zapisem oprogramowania sprzętowego"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Region BIOS-u oprogramowania sprzętowego"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Deskryptor BIOS-u oprogramowania sprzętowego"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Ochrona DMA przed uruchomieniem"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Uruchamianie zweryfikowane przez Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "ACM chronione przez Intel BootGuard"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Zasady postępowania Intel BootGuard w przypadku błędów"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Bezpiecznik Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET jest włączone"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET jest aktywne"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Zaszyfrowana pamięć RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Ochrona IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Blokada jądra Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Weryfikacja jądra Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Obszar wymiany systemu Linux"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Uśpienie do pamięci RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Uśpienie do trybu bezczynności"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Klucz platformy UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Zabezpieczone uruchamianie UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Konfiguracja platformy TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Rekonstrukcja TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Tryb serwisowy Intel Management Engine"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Obejście Intel Management Engine"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Wersja Intel Management Engine"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Aktualizacje oprogramowania sprzętowego"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Zaświadczenie oprogramowania sprzętowego"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Weryfikacja aktualizatora oprogramowania sprzętowego"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Debugowanie platformy"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Testy zabezpieczeń procesora"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Ochrona przed wycofaniem AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Ochrona przed odtwarzaniem oprogramowania sprzętowego AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Ochrona przed zapisem oprogramowania sprzętowego AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Platforma z bezpiecznikiem"
+
+#~ msgid "Valid"
+#~ msgstr "Prawidłowe"
+
+#~ msgid "Not Valid"
+#~ msgstr "Nieprawidłowe"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Niewłączone"
+
+#~ msgid "Locked"
+#~ msgstr "Zablokowane"
+
+#~ msgid "Not Locked"
+#~ msgstr "Niezablokowane"
+
+#~ msgid "Encrypted"
+#~ msgstr "Zaszyfrowane"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Niezaszyfrowane"
+
+#~ msgid "Tainted"
+#~ msgstr "Skażone"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Nieskażone"
+
+#~ msgid "Found"
+#~ msgstr "Odnaleziono"
+
+#~ msgid "Not Found"
+#~ msgstr "Nie odnaleziono"
+
+#~ msgid "Supported"
+#~ msgstr "Obsługiwane"
+
+#~ msgid "Not Supported"
+#~ msgstr "Nieobsługiwane"
+
+#~ msgid "Unknown"
+#~ msgstr "Nieznany"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bitowy"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bitowy"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Nieznany"
+
+#~ msgid "Not Available"
+#~ msgstr "Niedostępna"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo systemu"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nie odnaleziono źródeł wprowadzania"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Inne"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Niestandardowe skróty"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Klawisz alternatywnych znaków może być używany do wprowadzania "
+#~ "dodatkowych znaków. Są one czasami oznaczone jako opcje trzeciego poziomu "
+#~ "na klawiszach."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Lewy Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Prawy Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Lewy klawisz Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Prawy klawisz Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Klawisz Menu"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Prawy Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Klawisz Compose umożliwia wprowadzanie szerokiego zakresu znaków. Aby go "
+#~ "użyć, należy wcisnąć klawisz Compose, a następnie sekwencję znaków. Na "
+#~ "przykład, klawisz Compose plus znaki <b>C</b> i <b>o</b> wprowadzą znak "
+#~ "<b>©</b>, <b>a</b> i <b>'</b> wprowadzą <b>á</b> itp."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Źródła wprowadzania można przełączać za pomocą skrótu klawiszowego %s.\n"
+#~ "Można to zmienić w ustawieniach skrótów klawiszowych."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d zmodyfikowany"
+#~ msgstr[1] "%d zmodyfikowane"
+#~ msgstr[2] "%d zmodyfikowanych"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Przywrócić wszystkie skróty?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Przywrócenie skrótów może wpłynąć na skróty ustawione przez użytkownika. "
+#~ "Nie można tego cofnąć."
+
+#~ msgid "Reset All"
+#~ msgstr "Przywróć wszystko"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s jest już używane dla „%s”. Po zastąpieniu „%s” zostanie wyłączone."
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Proszę wprowadzić nowy skrót"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Ustawienie niestandardowego skrótu"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Ustawienie skrótu"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Proszę wprowadzić nowy skrót, aby zmienić „%s”."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Dodanie niestandardowego skrótu"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Przewijanie dwoma palcami"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Pięć kliknięć, czas na GEGL-a!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Podwójne kliknięcie, przycisk podstawowy"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Pojedyncze kliknięcie, przycisk podstawowy"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Podwójne kliknięcie, środkowy przycisk"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Pojedyncze kliknięcie, środkowy przycisk"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Podwójne kliknięcie, przycisk pomocniczy"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Pojedyncze kliknięcie, przycisk pomocniczy"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Usługa NetworkManager musi być uruchomiona."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Niezabezpieczona sieć (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Zabezpieczona sieć (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Zabezpieczona sieć (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Zabezpieczona sieć (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Zabezpieczona sieć"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Włączenie hotspotu spowoduje rozłączenie z sieci %s, i nie będzie można "
+#~ "korzystać z Internetu przez Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Musi mieć co najmniej 8 znaków"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Zatrzymać hotspot i rozłączyć wszystkich użytkowników?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Zatrzymaj hotspot"
+
+#~ msgid "Preserve"
+#~ msgstr "Zachowywanie"
+
+#~ msgid "Permanent"
+#~ msgstr "Stały"
+
+#~ msgid "Random"
+#~ msgstr "Losowy"
+
+#~ msgid "Stable"
+#~ msgstr "Stabilny"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Podany tutaj adres MAC będzie używany jako adres sprzętowy urządzenia "
+#~ "sieciowego, na którym włączono to połączenie. Ta funkcja jest znana jako "
+#~ "klonowanie lub „spoofing” adresu MAC. Przykład: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "%d. profil"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Wzmocnione otwarte"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Brak"
+
+#~ msgid "Never"
+#~ msgstr "Nigdy"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2,4 GHz/5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2,4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Brak"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Słaba"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Dostateczna"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Dobra"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Doskonała"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Zapomnij połączenie"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Usuń profil połączenia"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Usuń połączenie VPN"
+
+#~ msgid "Details"
+#~ msgstr "Informacje"
+
+#~ msgid "automatic"
+#~ msgstr "automatycznie"
+
+#~ msgid "Identity"
+#~ msgstr "Tożsamość"
+
+#~ msgid "Delete Address"
+#~ msgstr "Usuń adres"
+
+#~ msgid "Delete Route"
+#~ msgstr "Usuń trasę"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Brak"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "40/128-bitowy klucz WEP (szesnastkowy lub ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "128-bitowe hasło WEP"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamiczny WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA i WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA i WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Nie można otworzyć edytora połączeń"
+
+#~ msgid "New Profile"
+#~ msgstr "Nowy profil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Nieprawidłowe ustawienie %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Nieprawidłowe ustawienie %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Zaimportuj z pliku…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Dodanie połączenia VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Nie można zaimportować połączenia VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Plik „%s” nie może zostać odczytany lub nie zawiera rozpoznawanych "
+#~ "informacji o połączeniu VPN\n"
+#~ "\n"
+#~ "Błąd: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Wybór pliku do zaimportowania"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Plik o nazwie „%s” już istnieje."
+
+#~ msgid "_Replace"
+#~ msgstr "Za_mień"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Zastąpić połączenie „%s” zapisywanym połączeniem VPN?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Nie można wyeksportować połączenia VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Połączenie VPN „%s” nie może zostać wyeksportowane do %s.\n"
+#~ "\n"
+#~ "Błąd: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Eksport połączenia VPN"
+
+#~ msgid "never"
+#~ msgstr "nigdy"
+
+#~ msgid "today"
+#~ msgstr "dzisiaj"
+
+#~ msgid "yesterday"
+#~ msgstr "wczoraj"
+
+#~ msgid "Last used"
+#~ msgstr "Ostatnio użyte"
+
+#~ msgid "Add new connection"
+#~ msgstr "Dodaj nowe połączenie"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Informacje o zaznaczonych sieciach, w tym hasła i konfiguracja, zostaną "
+#~ "utracone."
+
+#~ msgid "_Forget"
+#~ msgstr "_Zapomnij"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Znane sieci Wi-Fi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Zapomnij"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Ustawienia systemu uniemożliwiają użycie jako hotspot"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Urządzenie bezprzewodowe nie obsługuje trybu hotspot"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Automatyczne wykrywanie pośrednika sieciowego jest używane, jeśli nie "
+#~ "podano adresu URL konfiguracji."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Nie jest zalecane dla niezaufanych sieci publicznych."
+
+#~ msgid "Status unknown"
+#~ msgstr "Stan nieznany"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Niezarządzane"
+
+#~ msgid "Unavailable"
+#~ msgstr "Niedostępne"
+
+#~ msgid "Connecting"
+#~ msgstr "Łączenie"
+
+#~ msgid "Authentication required"
+#~ msgstr "Wymagane jest uwierzytelnienie"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Rozłączanie"
+
+#~ msgid "Connection failed"
+#~ msgstr "Połączenie się nie powiodło"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Stan nieznany (brak)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Konfiguracja się nie powiodła"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Konfiguracja adresu IP się nie powiodła"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Konfiguracja adresu IP wygasła"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Wymagane są hasła, których nie podano"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Suplikant 802.1x się rozłączył"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Konfiguracja suplikanta 802.1x się nie powiodła"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Suplikant 802.1x się nie powiódł"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Suplikant 802.1x za długo się uwierzytelniał"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Uruchomienie usługi PPP się nie powiodło"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Usługa PPP została rozłączona"
+
+#~ msgid "PPP failed"
+#~ msgstr "Usługa PPP się nie powiodła"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Uruchomienie klienta DHCP się nie powiodło"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Błąd klienta DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Klient DHCP się nie powiódł"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Uruchomienie usługi współdzielonego połączenie się nie powiodło"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Usługa współdzielonego połączenia się nie powiodła"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr ""
+#~ "Uruchomienie usługi automatycznego wykrywania adresu IP się nie powiodło"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Błąd usługi automatycznego wykrywania adresu IP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Usługa automatycznego wykrywania adresu IP się nie powiodła"
+
+#~ msgid "Line busy"
+#~ msgstr "Linia jest zajęta"
+
+#~ msgid "No dial tone"
+#~ msgstr "Brak wybierania tonowego"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Nie można ustanowić żadnego operatora"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Żądanie wdzwonienia przekroczyło czas oczekiwania"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Próba wdzwonienia się nie powiodła"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Zainicjowanie modemu się nie powiodło"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Wybranie podanego APN się nie powiodło"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Sieci nie są wyszukiwane"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Odmówiono rejestracji sieci"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Rejestracja sieci przekroczyła czas oczekiwania"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Zarejestrowanie za pomocą żądanej sieci się nie powiodło"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Sprawdzenie kodu PIN się nie powiodło"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Brak oprogramowania sprzętowego urządzenia"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Połączenie zniknęło"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Przyjęto istniejące połączenie"
+
+#~ msgid "Modem not found"
+#~ msgstr "Nie odnaleziono modemu"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Połączenie Bluetooth się nie powiodło"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Nie włożono karty SIM"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Wymagany jest kod PIN karty SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Wymagany jest kod PUK karty SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Błędna karta SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Zależność połączenia się nie powiodła"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Brak oprogramowania sprzętowego"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel jest niepodłączony"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "nieokreślony błąd w zabezpieczeniach 802.1X (WPA-EAP)"
+
+#~ msgid "no file selected"
+#~ msgstr "nie wybrano żadnego pliku"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "nieokreślony błąd podczas sprawdzania poprawności pliku eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Klucze prywatne DER, PEM, PKCS#12 lub PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certyfikaty DER lub PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "brak pliku PAC EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Pliki PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "brak nazwy użytkownika EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "brak hasła EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "nieprawidłowy certyfikat CA EAP-PEAP: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "nieprawidłowy certyfikat CA EAP-PEAP: nie podano certyfikatu"
+
+#~ msgid "missing EAP username"
+#~ msgstr "brak nazwy użytkownika EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "brak hasła EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "brak tożsamości EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "nieprawidłowy certyfikat CA EAP-TLS: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "nieprawidłowy certyfikat CA EAP-TLS: nie podano certyfikatu"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "nieprawidłowy klucz prywatny EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "nieprawidłowy certyfikat użytkownika EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Niezaszyfrowane klucze prywatne są niezabezpieczone"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Wybrany klucz prywatny nie jest chroniony hasłem. Może to umożliwić "
+#~ "ujawnienie danych zabezpieczeń. Proszę wybrać klucz prywatny chroniony "
+#~ "hasłem.\n"
+#~ "\n"
+#~ "(można ochronić klucz prywatny hasłem za pomocą oprogramowania OpenSSL)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Wybór osobistego certyfikatu"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Wybór klucza prywatnego"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "nieprawidłowy certyfikat CA EAP-TTLS: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "nieprawidłowy certyfikat CA EAP-TTLS: nie podano certyfikatu"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Nieznany błąd podczas sprawdzania poprawności zabezpieczeń 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Wybierz plik"
+
+#~ msgid "missing leap-username"
+#~ msgstr "brak nazwy użytkownika LEAP"
+
+#~ msgid "missing leap-password"
+#~ msgstr "brak hasła LEAP"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Brak hasła Wi-Fi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "brak klucza WEP"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "nieprawidłowy klucz WEP: klucz o długości %zu może zawierać tylko cyfry "
+#~ "szesnastkowe"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "nieprawidłowy klucz WEP: klucz o długości %zu może zawierać tylko znaki "
+#~ "ASCII"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "nieprawidłowy klucz WEP: błędna długość klucza %zu. Klucz musi być "
+#~ "długości 5/13 (ASCII) lub 10/26 (szesnastkowy)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "nieprawidłowy klucz WEP: hasło nie może być puste"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "nieprawidłowy klucz WEP: hasło musi być krótsze niż 64 znaki"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "nieprawidłowe WPA-PSK: nieprawidłowa długość klucza %zu. Musi mieć [8,63] "
+#~ "bajty lub 64 cyfry szesnastkowe"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "nieprawidłowe WPA-PSK: nie można zinterpretować klucza o 64 bajtach jako "
+#~ "szesnastkowy"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Inne"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "Usunięto „%s”"
+
+#~ msgid "Error removing account"
+#~ msgstr "Błąd podczas usuwania konta"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Konto %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Usuń konto"
+
+#~ msgid "Unknown time"
+#~ msgstr "Nieznany czas"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s i %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "Do pełnego naładowania: %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Uwaga, pozostało: %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Pozostało: %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "W pełni naładowany"
+
+#~ msgid "Not charging"
+#~ msgstr "Nie jest ładowany"
+
+#~ msgid "Empty"
+#~ msgstr "Pusty"
+
+#~ msgid "Charging"
+#~ msgstr "Ładowanie"
+
+#~ msgid "Discharging"
+#~ msgstr "Rozładowywanie"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Mysz bezprzewodowa"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Klawiatura bezprzewodowa"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Urządzenie UPS"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Urządzenie PDA"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telefon komórkowy"
+
+#~ msgid "Media player"
+#~ msgstr "Odtwarzacz multimediów"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Komputer"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Kontroler do gier"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Główny"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Dodatkowy"
+
+#~ msgid "Batteries"
+#~ msgstr "Akumulatory"
+
+#~ msgid "When _idle"
+#~ msgstr "Podczas _bezczynności"
+
+#~ msgid "Suspend"
+#~ msgstr "Uśpienie"
+
+#~ msgid "Power Off"
+#~ msgstr "Wyłączenie komputera"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernacja"
+
+#~ msgid "Nothing"
+#~ msgstr "Nic"
+
+#~ msgid "When on battery power"
+#~ msgstr "Na zasilaniu z akumulatora"
+
+#~ msgid "When plugged in"
+#~ msgstr "Kiedy jest podłączony do prądu"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nigdy"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatyczne usypianie"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Tryb wydajności jest tymczasowo wyłączony z powodu wysokiej temperatury "
+#~ "działania."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Wykryto kolana: tryb wydajności jest tymczasowo niedostępny. Należy "
+#~ "przenieść urządzenie na stabilną powierzchnię, aby przywrócić."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Tryb wydajności jest tymczasowo wyłączony."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Niski poziom naładowania akumulatora: włączono tryb oszczędzania energii. "
+#~ "Poprzedni tryb zostanie przywrócony po wystarczającym naładowaniu "
+#~ "akumulatora."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Tryb oszczędzania energii został włączony przez program „%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Tryb wydajności został włączony przez program „%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Wydajność"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Wysoka wydajność i pobór energii."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Zrównoważone zasilanie"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standardowa wydajność i pobór energii."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Oszczędzanie energii"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Zmniejszona wydajność i pobór energii."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Usunięto drukarkę „%s”"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Dodanie nowej drukarki się nie powiodło."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Nie można wczytać interfejsu użytkownika: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Odblokowanie umożliwi dodawanie drukarek i zmianę ustawień"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Informacje o „%s”"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nie odnaleziono odpowiedniego sterownika"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Wybór pliku PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Pliki PostScriptowego opisu drukarki (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Drukarka JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Drukarka LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Jednostronnie"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Długa krawędź (standardowo)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Krótka krawędź (odwrócenie)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portret"
+
+#~ msgid "Landscape"
+#~ msgstr "Pejzaż"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Odwrócony pejzaż"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Odwrócony portret"
+
+#~ msgid "Resume"
+#~ msgstr "Wznów"
+
+#~ msgid "Pause"
+#~ msgstr "Wstrzymaj"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Oczekuje"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Wstrzymane"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Wymagane jest uwierzytelnienie"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Przetwarzanie"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Zatrzymane"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Anulowane"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Przerwane"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Ukończone"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Przenosi to zadanie na początek kolejki"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — aktywne zadania"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr ""
+#~ "Proszę wprowadzić dane uwierzytelniające, aby wydrukować za pomocą "
+#~ "drukarki „%s”."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Odblokowanie serwera wydruku"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Odblokowanie „%s”."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Proszę wprowadzić nazwę użytkownika i hasło, aby wyświetlić drukarki "
+#~ "w „%s”."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Wyszukiwanie drukarek"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Port szeregowy"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Port równoległy"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Położenie: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adres: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Serwer wymaga uwierzytelnienia"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dwustronnie"
+
+#~ msgid "Paper Type"
+#~ msgstr "Typ papieru"
+
+#~ msgid "Paper Source"
+#~ msgstr "Źródło papieru"
+
+#~ msgid "Output Tray"
+#~ msgstr "Podajnik wyjściowy"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Rozdzielczość"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Filtrowanie GhostScript przed wydrukiem"
+
+#~ msgid "Pages per side"
+#~ msgstr "Stron na kartkę"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientacja"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Ogólne"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Ustawienia strony"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opcje instalacyjne"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Zadanie"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Jakość obrazu"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Kolor"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Kończenie"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Zaawansowane"
+
+#~ msgid "Test page"
+#~ msgstr "Strona testowa"
+
+#~ msgid "Auto Select"
+#~ msgstr "Wybór automatyczny"
+
+#~ msgid "Printer Default"
+#~ msgstr "Domyślne drukarki"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Osadzanie tylko czcionek GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Konwertowanie na PostScript 1. poziomu"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Konwertowanie na PostScript 2. poziomu"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Brak filtrowania przed wydrukiem"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Czyszczenie głowic drukujących"
+
+#~ msgid "Out of toner"
+#~ msgstr "Brak tonera"
+
+#~ msgid "Low on developer"
+#~ msgstr "Mało wywoływacza"
+
+#~ msgid "Out of developer"
+#~ msgstr "Brak wywoływacza"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Mało atramentu"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Brak atramentu"
+
+#~ msgid "Open cover"
+#~ msgstr "Otwarta pokrywa"
+
+#~ msgid "Open door"
+#~ msgstr "Otwarte drzwiczki"
+
+#~ msgid "Low on paper"
+#~ msgstr "Mało papieru"
+
+#~ msgid "Out of paper"
+#~ msgstr "Brak papieru"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Offline"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Zatrzymana"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Pojemnik na odpady jest prawie pełny"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Pojemnik na odpady jest pełny"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Warstwa światłoczuła ledwo działa"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Warstwa światłoczuła już nie działa"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Gotowa"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Nie przyjmuje zadań"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Przetwarzanie"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "anglosaskie (imperialne)"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "metryczne"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Pytanie, co robić"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nierobienie niczego"
+
+#~ msgid "Open folder"
+#~ msgstr "Otwarcie katalogu"
+
+#~ msgid "Other Media"
+#~ msgstr "Inne nośniki"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Wybór programu dla płyt CD-Audio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Wybór programu dla płyt wideo DVD"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Wybór programu do uruchomienia po podłączeniu odtwarzacza multimediów"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Wybór programu do uruchomienia po podłączeniu aparatu"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Wybór programu dla płyt CD z oprogramowaniem"
+
+#~ msgid "audio DVD"
+#~ msgstr "Płyta DVD-Audio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Pusta płyta Blu-ray"
+
+#~ msgid "blank CD disc"
+#~ msgstr "Pusta płyta CD"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "Pusta płyta DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Pusta płyta HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Płyta wideo Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "Czytnik e-booków"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Płyta wideo HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Natychmiast"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekund"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuta"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuty"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuty"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minut"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minut"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 godzina"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuty"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minuty"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minuty"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nigdy"
+
+#~ msgid "Select Location"
+#~ msgstr "Wybór położenia"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Nie odnaleziono programów"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nie wybrano żadnych sieci do udostępniania"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Włączone"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Wyłączone"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Włączone"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktywne"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Wybór katalogu"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Włącz udostępnianie multimediów"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Udostępnianie plików umożliwia udostępnianie katalogu Publiczne z innymi "
+#~ "użytkownikami bieżącej sieci za pomocą: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Umożliwia zdalnym użytkownikom na łączenie się za pomocą polecenia SSH:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Włącz udostępnianie multimediów osobistych"
+
+#~ msgid "Device name copied"
+#~ msgstr "Skopiowano nazwę urządzenia"
+
+#~ msgid "Device address copied"
+#~ msgstr "Skopiowano adres urządzenia"
+
+#~ msgid "Username copied"
+#~ msgstr "Skopiowano nazwę użytkownika"
+
+#~ msgid "Password copied"
+#~ msgstr "Skopiowano hasło"
+
+#~ msgid "Custom"
+#~ msgstr "Niestandardowy"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Testowanie „%s”"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Rozłączone"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Łączenie"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Połączone"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Błąd upoważnienia"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Upoważnianie"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Ograniczona funkcjonalność"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Połączone i upoważnione"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Nieznane"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Upoważniono:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Połączono:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Zapisano:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Upoważnienie urządzenia się nie powiodło: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Zapomnienie urządzenia się nie powiodło: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Błąd"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Upoważnione"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Podsystem Thunderbolt (boltd) nie jest zainstalowany lub właściwie "
+#~ "skonfigurowany."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Tylko urządzenia USB i Display Port mogą być podłączane."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Nie można wykryć sprzętu Thunderbolt.\n"
+#~ "Komputer nie ma obsługi Thunderbolt, został wyłączony w BIOS-ie lub "
+#~ "ustawiony na nieobsługiwany poziom zabezpieczeń."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Obsługa Thunderbolt została wyłączona w BIOS-ie."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Nie można ustalić poziomu zabezpieczeń Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Błąd podczas przełączania trybu bezpośredniego: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Domyślny"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Średni"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Duży"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Większy"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Największy"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d piksel"
+#~ msgstr[1] "%d piksele"
+#~ msgstr[2] "%d pikseli"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Krótki"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ekranu"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ekranu"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ekranu"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Długi"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 godzina"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dzień"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "2 tygodnie"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "Miesiąc"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Usunąć wszystkie elementy z kosza?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Wszystkie elementy w koszu zostaną trwale usunięte."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Opróżnij kosz"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Usunąć wszystkie pliki tymczasowe?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Wszystkie pliki tymczasowe zostaną trwale usunięte."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Usuń pliki tymczasowe"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dzień"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dni"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "Miesiąc"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Bez ograniczenia"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Powinno zgadzać się z adresem WWW dostawcy konta."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Dodanie konta się nie powiodło"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Zarejestrowanie konta się nie powiodło"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Brak obsługiwanego sposobu na uwierzytelnienie w tej domenie"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Dołączenie do domeny się nie powiodło"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ten login nie zadziałał.\n"
+#~ "Proszę spróbować ponownie."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "To hasło nie zadziałało.\n"
+#~ "Proszę spróbować ponownie."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Zalogowanie do domeny się nie powiodło"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Nie można odnaleźć domeny. Może ją niepoprawnie wpisano?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Przeglądanie innych obrazów"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "urządzenie musi zostać zajęte, aby wykonać to działanie"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "urządzenie jest już zajęte przez inny proces"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "brak uprawnienia do wykonania działania"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "nie pobrano żadnych odcisków"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Komunikacja z urządzeniem podczas pobierania się nie powiodła"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Komunikacja z czytnikiem odcisku palca się nie powiodła"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Komunikacja z usługą czytnika odcisku palca się nie powiodła"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Wyświetlenie listy odcisków palców się nie powiodło: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Usunięcie zapisanych odcisków palców się nie powiodło: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Lewy kciuk"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Lewy palec środkowy"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Lewy palec wskazujący"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Lewy palec serdeczny"
+
+#~ msgid "Left little finger"
+#~ msgstr "Lewy mały palec"
+
+#~ msgid "Right thumb"
+#~ msgstr "Prawy kciuk"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Prawy palec środkowy"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Prawy palec wskazujący"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Prawy palec serdeczny"
+
+#~ msgid "Right little finger"
+#~ msgstr "Prawy mały palec"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Nieznany palec"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Ukończono"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Czytnik odcisków palców został rozłączony"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Czytnik odcisków palców jest pełny"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Pobranie nowego odciska palca się nie powiodło"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Rozpoczęcie pobierania odcisku palca się nie powiodło: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Pobranie nowego odcisku palca się nie powiodło"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Zatrzymanie pobierania odcisku palca się nie powiodło: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Proszę kilkakrotnie podnieść i położyć palec na czytniku, aby pobrać "
+#~ "odcisk palca"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Ponownie pobierz ten odcisk palca…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Pobierz nowy odcisk palca"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Zwolnienie czytnika odcisków palców %s się nie powiodło: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problem podczas odczytu czytnika"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Zajęcie czytnika odcisków palców %s się nie powiodło: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Uzyskanie czytników odcisków palców się nie powiodło: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Ten tydzień"
+
+#~ msgid "Last Week"
+#~ msgstr "Ostatni tydzień"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%-d %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-d %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%H∶%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Koniec sesji"
+
+#~ msgid "Session Started"
+#~ msgstr "Początek sesji"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — aktywność konta"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Proszę wybrać inne hasło."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Proszę ponownie wprowadzić obecne hasło."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Nie można zmienić hasła"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Nie można automatycznie dołączyć do tego typu domeny"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nie odnaleziono takiej domeny lub obszaru"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Nie można zalogować jako „%s” w domenie %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Nieprawidłowe hasło, proszę spróbować ponownie"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Nie można połączyć z domeną %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Usunięcie użytkownika się nie powiodło"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Unieważnienie zdalnie zarządzanego użytkownika się nie powiodło"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nie można usunąć własnego konta."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "Użytkownik „%s” jest nadal zalogowany"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Usunięcie nadal zalogowanego użytkownika może pozostawić system "
+#~ "w niespójnym stanie."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Zachować pliki użytkownika „%s”?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Możliwe jest zachowanie katalogu domowego, kolejki poczty i plików "
+#~ "tymczasowych podczas usuwania konta użytkownika."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Usuń pliki"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Zachowaj pliki"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Na pewno unieważnić zdalnie zarządzane konto użytkownika „%s”?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Usuń"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Konto jest wyłączone"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Zostanie ustawione podczas następnego logowania"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Brak"
+
+#~ msgid "Logged in"
+#~ msgstr "Zalogowano"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Skontaktowanie się z usługą kont się nie powiodło"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Proszę się upewnić, że usługa AccountService jest zainstalowana "
+#~ "i włączona."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Należy odblokować ten panel, aby zmienić to ustawienie"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Usuwa wybrane konto użytkownika"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Aby usunąć wybrane konto użytkownika,\n"
+#~ "najpierw należy kliknąć ikonę *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Odblokowanie umożliwi dodawanie użytkowników i zmianę ustawień"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Nowe hasło musi się różnić od poprzedniego."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Proszę zmienić jakieś litery i cyfry."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Proszę trochę bardziej zmienić hasło."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Hasło bez nazwy użytkownika byłoby silniejsze."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Proszę unikać używania swojego imienia lub nazwiska w haśle."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Proszę unikać niektórych słów użytych w haśle."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Proszę unikać często używanych słów."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Proszę unikać zmieniania kolejności liter w istniejących słowach."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Proszę użyć więcej cyfr."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Proszę użyć więcej wielkich liter."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Proszę użyć więcej małych liter."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Proszę użyć więcej znaków specjalnych, takich jak znaki interpunkcyjne."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Proszę użyć mieszanki liter, cyfr i znaków interpunkcyjnych."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Proszę unikać powtarzania tego samego znaku."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Proszę unikać powtarzania tego samego rodzaju znaków: należy mieszać "
+#~ "litery, liczby i znaki interpunkcyjne."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Proszę unikać ciągów takich jak 1234 lub abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Hasło musi być dłuższe. Proszę dodać więcej liter, cyfr i znaków "
+#~ "interpunkcyjnych."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Należy mieszać wielkie i małe litery oraz dodać cyfrę lub dwie."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Dodanie więcej liter, liczb i znaków interpunkcyjnych wzmocni hasło."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Uwierzytelnienie się nie powiodło"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Nowe hasło jest za krótkie"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Nowe hasło jest zbyt proste"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Nowe hasło jest zbyt podobne do poprzedniego"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Nowe hasło zostało już niedawno użyte."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Nowe hasło musi zawierać znaki numeryczne lub specjalne"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Nowe hasło jest takie same jak poprzednie"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Hasło zostało zmienione po początkowym uwierzytelnieniu."
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Nowe hasło nie zawiera wystarczającej liczby różnych znaków"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Nieznany błąd"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Nazwa użytkownika zwykle powinna zawierać tylko małe litery z alfabetu "
+#~ "łacińskiego, cyfry oraz te znaki: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Ta nazwa użytkownika jest niedostępna. Proszę wybrać inną."
+
+#~ msgid "The username is too long."
+#~ msgstr "Nazwa użytkownika jest za długa."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "%d. przycisk"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Określone przez program"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Wysłanie naciśnięcia klawisza"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Przełączenie monitora"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Ekran pomocy"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tablet zamontowany w panelu laptopa"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tablet zamontowany w zewnętrznym ekranie"
+
+#~ msgid "External tablet device"
+#~ msgstr "Tablet jako urządzenie zewnętrzne"
+
+#~ msgid "All Displays"
+#~ msgstr "Wszystkie ekrany"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Aerograf z czujnikiem nacisku i pochylenia oraz zintegrowanym suwakiem"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Aerograf z czujnikiem nacisku, pochylenia i obrotu"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standardowy rysik z czujnikiem nacisku i pochylenia"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standardowy rysik z czujnikiem nacisku"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nowy skrót…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Anulowano działanie"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Błąd:</b> odmowa dostępu podczas zmiany ustawień"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Błąd:</b> błąd wyposażenia komórkowego"
+
+#~ msgid "Not Registered"
+#~ msgstr "Nie zarejestrowano"
+
+#~ msgid "Registered"
+#~ msgstr "Zarejestrowano"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Wyszukiwanie"
+
+#~ msgid "Denied"
+#~ msgstr "Odmowa"
+
+#~ msgid "2G Only"
+#~ msgstr "Tylko 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Tylko 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Tylko 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Tylko 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (preferowane)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (preferowane), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (preferowane), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (preferowane), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (preferowane)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (preferowane), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (preferowane), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (preferowane)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (preferowane), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (preferowane), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (preferowane)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (preferowane), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (preferowane), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (preferowane)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (preferowane), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (preferowane), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (preferowane)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (preferowane), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (preferowane)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (preferowane), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (preferowane)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (preferowane), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (preferowane)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (preferowane), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (preferowane)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (preferowane), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (preferowane)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (preferowane), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Nieznany"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Odblokowanie karty SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Proszę podać kod PIN dla %d. karty SIM"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Proszę podać kod PIN, aby odblokować kartę SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Proszę podać kod PUK dla %d. karty SIM"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Proszę podać kod PUK, aby odblokować kartę SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Podano błędne hasło."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Kod PUK musi być liczbą ośmio­cyfrową"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Proszę podać nowy kod PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Kod PIN musi być liczbą o czterech do ośmiu cyfr"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Odblokowywanie…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Niepowodzenie telefonu"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Brak połączenia z telefonem"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Działanie jest niedozwolone"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Działanie jest nieobsługiwane"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Nie włożono karty SIM"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Wymagany jest kod PIN karty SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Wymagany jest kod PUK karty SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Niepowodzenie karty SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "Karta SIM jest zajęta"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Niewłaściwe hasło"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Wymagany jest kod PIN2 karty SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Wymagany jest kod PUK2 karty SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Nie odnaleziono"
+
+#~ msgid "No network service"
+#~ msgstr "Brak zasięgu sieci"
+
+#~ msgid "Network timeout"
+#~ msgstr "Przekroczenie czasu oczekiwania sieci"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Usługi GPRS są niedozwolone"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming jest niedozwolony w tym położeniu"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Nieokreślony błąd GPRS"
+
+#~ msgid "No Error"
+#~ msgstr "Brak błędu"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Anulowano działanie"
+
+#~ msgid "Access denied"
+#~ msgstr "Odmowa dostępu"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Nieznany błąd"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "%d. karta SIM"
+
+#~ msgid "Display version number"
+#~ msgstr "Wyświetla numer wersji"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Wyświetla więcej komunikatów"
+
+#~ msgid "Search for the string"
+#~ msgstr "Wyszukuje tekst"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Wyświetla listę dostępnych paneli i kończy działanie"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel do wyświetlenia"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [PARAMETR…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Dostępne panele:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Dźwięki systemowe"

--- a/po/pl.po~
+++ b/po/pl.po~
@@ -1,0 +1,9659 @@
+# Polish translation for gnome-control-center.
+# Copyright © 1998-2022 the gnome-control-center authors.
+# This file is distributed under the same license as the gnome-control-center package.
+# Zbigniew Chyla <chyla@alice.ci.pwr.wroc.pl>, 1998-2003.
+# Artur Flinta <aflinta@at.kernel.pl>, 2003-2007.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2007-2009.
+# Wadim Dziedzic <wdziedzic@aviary.pl>, 2007.
+# Piotr Drąg <piotrdrag@gmail.com>, 2009-2022.
+# Wojciech Szczęsny <wszczesny@aviary.pl>, 2013.
+# Aviary.pl <community-poland@mozilla.org>, 2007-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-12 07:38+0000\n"
+"PO-Revision-Date: 2022-09-12 17:10+0200\n"
+"Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
+"Language-Team: Polish <community-poland@mozilla.org>\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Magistrala systemowa"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Pełny dostęp"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Magistrala sesji"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Urządzenia"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Pełny dostęp do katalogu /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Sieć"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Ma dostęp do sieci"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Katalog domowy"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Tylko do odczytu"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "System plików"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Ustawienia"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Może zmieniać ustawienia"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s ma poniższe wbudowane uprawnienia. Nie można ich zmieniać. W razie obaw "
+"dotyczących tych uprawień można usunąć ten program."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u typ plików i odnośników otwierany przez program"
+msgstr[1] "%u typy plików i odnośników otwierane przez program"
+msgstr[2] "%u typów plików i odnośników otwieranych przez program"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"Program <b>%s</b> jest używany do otwierania poniższych typów plików "
+"i odnośników."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "Używa %s miejsca na dysku."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Programy"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Brak programów"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Zainstaluj programy…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Otwórz"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Wyświetl szczegóły"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Wyszukiwanie"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Odbieranie wyszukiwań systemowych i odsyłanie wyników."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Wyłączone"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Powiadomienia"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Wyświetlanie powiadomień systemowych."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Działanie w tle"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Umożliwia działanie po zamknięciu programu."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Zrzuty ekranu"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Wykonywanie zrzutów ekranu w dowolnym czasie."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Zmiana tapety"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Zmienianie tapety pulpitu."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Dźwięki"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Odtwarzanie dźwięków."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Wyłączanie skrótów"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Blokowanie standardowych skrótów klawiszowych."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Robienie zdjęć kamerą."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Nagrywanie dźwięku mikrofonem."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Usługi położenia"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Dostęp do danych o położeniu urządzenia."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Wbudowane uprawnienia"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Dostęp systemowy wymagany przez program"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Powiązania plików i odnośników"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Miejsce na dysku"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Brak wyników"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Proszę spróbować innych słów"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Powiązania plików i odnośników"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Typy plików"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Typy odnośników"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Przywróć"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Ile miejsca na dysku zajmuje ten program razem z danymi programu i pamięcią "
+"podręczną."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Program"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Dane"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Pamięć podręczna"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Razem</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Wyczyść pamięć podręczną…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Sterowanie różnymi uprawnieniami i ustawieniami programów"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"programy;aplikacja;aplikacje;flatpak;flatpack;uprawnienie;uprawnienia;"
+"pozwolenie;zezwolenie;ustawienie;ustawienia;opcje;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Wybór obrazu"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Anuluj"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Otwórz"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "wiele rozmiarów"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d×%d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Bez tła pulpitu"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Obecne tło"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Styl"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Domyślne"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Ciemny"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Tło"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Dodaj obraz…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Wygląd"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Zmiana obrazu tła i kolorów interfejsu"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Tło;Tapeta;Ekran;Pulpit;Styl;Jasny;Ciemny;Wygląd;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Włącz"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Nie odnaleziono adapterów Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Należy podłączyć adapter, aby używać Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth jest wyłączony"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Należy go włączyć, aby łączyć z urządzeniami i odbierać pliki."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Tryb samolotowy jest włączony"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth jest wyłączony, kiedy tryb samolotowy jest włączony."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Wyłącz tryb samolotowy"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Sprzętowy tryb samolotowy jest włączony"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Należy wyłączyć przełącznik trybu sprzętowego, aby włączyć Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Włączanie Bluetooth i łączenie z urządzeniami"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+"udostępnianie;udostępnij;udostępniaj;współdzielenie;wysyłanie;wyślij;"
+"odbieranie;odbierz;odbiór;przesyłanie;prześlij;pliki;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera jest wyłączona"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Żadne programy nie mogą robić zdjęć ani nagrywać wideo."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Użycie kamery umożliwia programom robienie zdjęć i filmów. Wyłączenie kamery "
+"może spowodować niepoprawne działanie części programów.\n"
+"\n"
+"Można zezwolić poniższym programom na używanie kamery."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Żadne programy nie poprosiły o dostęp do kamery"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Ochrona zdjęć"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"aparat;kamera;camera;zdjęcia;fotografie;filmy;wideo;video;webcam;kamerka;"
+"blokada;zablokuj;prywatne;prywatność;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Proszę umieścić urządzenie na kwadracie i nacisnąć przycisk „Rozpocznij”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Proszę umieścić urządzenie w pozycji kalibracji i nacisnąć przycisk "
+"„Kontynuuj”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Proszę umieścić urządzenie w pozycji powierzchni i nacisnąć przycisk "
+"„Kontynuuj”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Proszę zamknąć pokrywę laptopa"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Wystąpił wewnętrzny błąd, z którego nie można przywrócić."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Narzędzia wymagane do kalibracji nie są zainstalowane."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Nie można utworzyć profilu."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Nie można uzyskać docelowego punktu bieli."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Ukończono"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibracja się nie powiodła"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Można usunąć urządzenie kalibracji."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Nie należy usuwać urządzenia podczas trwania kalibracji"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Kalibracja ekranu"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Rozpocznij"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Wznów"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Gotowe"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Ekran laptopa"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Wbudowana kamera internetowa"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Skaner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Aparat %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Drukarka %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Kamera internetowa %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Włącz zarządzanie kolorami dla %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Wyświetl profile kolorów dla %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Nieskalibrowane"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Domyślny: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Przestrzeń kolorów: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Profil testowy: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Wybór pliku profilu ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "Zai_mportuj"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Obsługiwane profile ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Wszystkie pliki"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekran"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Zapis profilu"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Zapisz"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Tworzy profil kolorów dla wybranego urządzenia"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Nie wykryto urządzenia pomiarowego. Proszę sprawdzić, czy jest włączone "
+"i poprawnie podłączone."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Urządzenie pomiarowe nie obsługuje profilowania drukarek."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Typ urządzenia nie jest obecnie obsługiwany."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Kalibracja ekranu"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Jakość kalibracji"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibracja utworzy profil, którego można używać do zarządzania kolorami "
+"ekranu. Im dłużej trwa kalibracja, tym lepszej jakości jest profil kolorów."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Nie będzie można używać komputera podczas trwania kalibracji."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Jakość"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Szacowany czas"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Urządzenie kalibracji"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Proszę wybrać urządzenie, które zostanie użyte do kalibracji."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Typ ekranu"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Proszę wybrać typ podłączonego ekranu."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Punkt bieli profilu"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Proszę wybrać docelowy punkt bieli. Większość ekranów powinna być "
+"kalibrowana do elementu oświetleniowego D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Jasność ekranu"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Proszę ustawić jasność ekranu na typowo używaną. Zarządzanie kolorami będzie "
+"najdokładniejsze przy tym poziomie jasności."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Można też użyć poziomu jasności użytego z jednym z pozostałych profilów dla "
+"tego urządzenia."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nazwa profilu"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Można używać profilu kolorów na innych komputerach, albo utworzyć profile "
+"dla różnych warunków oświetleniowych."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nazwa profilu:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Podsumowanie"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Pomyślnie utworzono profil."
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Skopiuj profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Wymaga zapisywalnego nośnika"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Przydatne mogą być instrukcje, jak używać profilu kolorów w systemach <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> i <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Dodanie profilu"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Wykryto problemy. Profil może nie działać poprawnie. <a href=\"\">Wyświetl "
+"szczegóły.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "Za_importuj plik…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Dodaj"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Każde urządzenie wymaga aktualnego profilu kolorów, aby podlegać zarządzaniu "
+"kolorami."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Więcej informacji"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Więcej informacji o zarządzaniu kolorami"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Ustaw dla wszystkich użytkowników"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Ustawia ten profil dla wszystkich użytkowników tego komputera"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "Włą_cz"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Dodaj profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "S_kalibruj…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibruje urządzenie"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Usuń profil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Wyświetl szczegóły"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Nie można wykryć urządzeń, które mogą korzystać z zarządzania kolorami"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Ekran plazmowy"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (podświetlanie CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (podświetlanie RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (białe podświetlanie LED)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD o szerokim gamucie (podświetlanie CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD o szerokim gamucie (podświetlanie RGB LED)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Wysoka"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minut"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Średnia"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minut"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Niska"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minut"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Natywna wartość dla ekranu"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (drukowanie i publikowanie)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografia i grafika)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standardowa przestrzeń"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Profil testowy"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatyczny"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Niska jakość"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Średnia jakość"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Wysoka jakość"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Domyślna RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Domyślna CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Domyślna skala szarości"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Fabryczne dane kalibracji dostarczone przez producenta"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Pełnoekranowa korekcja kolorów nie jest możliwa za pomocą tego profilu"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Ten profil może już nie być dokładny"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Kolor"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Kalibracja kolorów urządzeń, takich jak ekrany, aparaty, kamery i drukarki"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Kolor;ICC;Profil;Kalibracja;Drukarka;Ekran;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Inny…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Wybór języka"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Wybierz"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nie odnaleziono języków"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Więcej…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Odblokowanie umożliwi zmianę ustawień"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Część ustawień musi zostać odblokowana, zanim można je zmieniać."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Odblokuj…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Dodaj godzinę"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Dodaj minutę"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Czas"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Odejmij godzinę"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Odejmij minutę"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Dzisiaj"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Wczoraj"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%-d %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%-d %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d godzina"
+msgstr[1] "%d godziny"
+msgstr[2] "%d godzin"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuta"
+msgstr[1] "%d minuty"
+msgstr[2] "%d minut"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekunda"
+msgstr[1] "%d sekundy"
+msgstr[2] "%d sekund"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s, %s i %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s i %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s i %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekund"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-godzinny"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "12-godzinny"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%-d %B %Y, %-l∶%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%-d %B %Y, %H∶%M"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%-l∶%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%H∶%M"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data i czas"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Rok"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Miesiąc"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "styczeń"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "luty"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "marzec"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "kwiecień"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "maj"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "czerwiec"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "lipiec"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "sierpień"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "wrzesień"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "październik"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "listopad"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "grudzień"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dzień"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Strefa czasowa"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Wyszukiwanie miasta"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatyczna _data i czas"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Wymaga dostępu do Internetu"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Data i _czas"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automatyczna _strefa czasowa"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Wymaga dostępu do Internetu i włączenia usług położenia"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Włączone"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "S_trefa czasowa"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Format czasu"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Zmiana daty i czasu, w tym strefy czasowej"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+"Zegar;Strefa;Czasowa;Położenie;Miejsce;Lokacja;Miasto;Państwo;Kraj;NTP;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Zmiana ustawień czasu i daty systemu"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Wymagane jest uwierzytelnienie, aby zmienić ustawienia czasu lub daty."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_WWW"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Poczta"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalendarz"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_uzyka"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "Wi_deo"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Zdjęcia"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Domyślne programy"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Konfiguracja domyślnych programów"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "domyślne;programy;aplikacje;preferowane;nośnik;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Wysyłanie informacji o problemach technicznych pomaga ulepszyć system %s. "
+"Zgłoszenia są anonimowe i pozbawione danych osobistych. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Zgłaszanie problemów"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatyczne zgłaszanie problemów"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostyka"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Zgłaszanie problemów"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostyka;awaria;awarie;crash;krasz;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Włączone"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Wyłączone"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Zastosować zmiany?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Nie można zastosować zmian"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Może to być spowodowane ograniczeniami sprzętu."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Zastosuj"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Wstecz"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Ustawienia ekranu są wyłączone"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Wiele ekranów"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Połączone"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Ten sam obraz"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Zawiera górny pasek i ekran podglądu"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Główny ekran"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Nocne światło"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Pozioma"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Pionowa (w prawo)"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Pionowa (w lewo)"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Pozioma (odwrócona)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientacja"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Rozdzielczość"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Częstotliwość odświeżania"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Dostosowanie do telewizora"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skalowanie"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nocne światło jest niedostępne"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Może to wynikać z używanego sterownika karty graficznej lub zdalnego "
+"korzystania z pulpitu"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Tymczasowo wyłączone do jutra"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Włącz"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Nocne światło sprawia, że wyświetlane kolory są cieplejsze. Może to "
+"zmniejszyć przemęczenie wzroku i pomóc z bezsennością."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Czas działania"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Od zachodu do wschodu słońca"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "W podanych godzinach"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Czas"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Od"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Godzina"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr "∶"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuta"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Do"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura kolorów"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ekrany"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Wybór sposobu używania podłączonych monitorów i projektorów"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projektor;xrandr;Ekran;Rozdzielczość;Odświeżanie;Monitor;Nocne;światło;"
+"Niebieski;Przesunięcie ku czerwieni;Poczerwienienie;Redshift;Kolory;Kolorów;"
+"Wschód;Zachód;słońca;Słońce;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Zabezpieczone uruchamianie jest aktywne"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
+"oprogramowania podczas uruchamiania urządzenia. Jest obecnie włączone "
+"i działa poprawnie."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Zabezpieczone uruchamianie ma problemy"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
+"oprogramowania podczas uruchamiania urządzenia. Jest obecnie włączone, ale "
+"nie będzie działać z powodu nieprawidłowego klucza."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Problemy z zabezpieczonym uruchamianiem często można rozwiązać "
+"w ustawieniach oprogramowania sprzętowego UEFI (BIOS-ie) komputera, "
+"a producent sprzętu może podawać informacje, jak to zrobić."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Należy skontaktować się z producentem używanego sprzętu lub dostawcą "
+"wsparcia informatycznego w celu uzyskania pomocy."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Zabezpieczone uruchamianie jest wyłączone"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
+"oprogramowania podczas uruchamiania urządzenia. Jest obecnie wyłączone."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Zabezpieczone uruchamianie często można włączyć w ustawieniach "
+"oprogramowania sprzętowego UEFI (BIOS-ie) komputera. Należy skontaktować się "
+"z producentem używanego sprzętu lub dostawcą wsparcia informatycznego w celu "
+"uzyskania pomocy."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Zabezpieczone uruchamianie uniemożliwia wczytywanie złośliwego "
+"oprogramowania podczas uruchamiania urządzenia.\n"
+"\n"
+"Należy skontaktować się z producentem używanego sprzętu lub dostawcą "
+"wsparcia informatycznego w celu uzyskania pomocy."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Powodzenie"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Niepowodzenie"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Urządzenie jest zgodne z %d. poziomem HSI"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "0. poziom zabezpieczeń"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"To urządzenie nie ma ochrony przed sprzętowymi problemami bezpieczeństwa. "
+"Może to być spowodowane problemem z konfiguracją sprzętu lub oprogramowania "
+"sprzętowego. Zalecane jest skontaktowanie się z dostawcą wsparcia "
+"informatycznego."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "1. poziom zabezpieczeń"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"To urządzenie ma minimalną ochronę przed sprzętowymi problemami "
+"bezpieczeństwa. To najniższy poziom zabezpieczeń urządzenia, który zapewnia "
+"ochronę tylko przed prostymi zagrożeniami bezpieczeństwa."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "2. poziom zabezpieczeń"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"To urządzenie ma podstawową ochronę przed sprzętowymi problemami "
+"bezpieczeństwa. Zapewnia to ochronę przed częścią często występujących "
+"zagrożeń bezpieczeństwa."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "3. poziom zabezpieczeń"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"To urządzenie ma rozszerzoną ochronę przed sprzętowymi problemami "
+"bezpieczeństwa. To najwyższy poziom zabezpieczeń urządzenia, który zapewnia "
+"ochronę przed zaawansowanymi zagrożeniami bezpieczeństwa."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Poziom zabezpieczeń"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Poziomy zabezpieczeń nie są dostępne dla tego urządzenia."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Należy skontaktować się z producentem sprzętu, aby uzyskać pomoc "
+"z aktualizacjami zabezpieczeń."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Rozwiązanie tego problemu może być możliwe w ustawieniach oprogramowania "
+"sprzętowego UEFI lub przez pracownika wsparcia."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Rozwiązanie tego problemu może być możliwe w ustawieniach oprogramowania "
+"sprzętowego UEFI."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Rozwiązanie tego problemu może być możliwe przez pracownika wsparcia."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "1. poziom"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "2. poziom"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "3. poziom"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+"Ochrona przed złośliwym oprogramowaniem podczas uruchamiania urządzenia."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Zabezpieczone uruchamianie ma problemy"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Pewna ochrona podczas uruchamiania urządzenia."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Zabezpieczone uruchamianie jest wyłączone"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Brak ochrony podczas uruchamiania urządzenia."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Ten problem mógł być spowodowany przez zmianę ustawień oprogramowania "
+"sprzętowego UEFI, zmianę konfiguracji systemu operacyjnego lub z powodu "
+"złośliwego oprogramowania na tym komputerze."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Ten problem mógł być spowodowany przez zmianę ustawień oprogramowania "
+"sprzętowego UEFI lub z powodu złośliwego oprogramowania na tym komputerze."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Ten problem mógł być spowodowany przez zmianę konfiguracji systemu "
+"operacyjnego lub z powodu złośliwego oprogramowania na tym komputerze."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Podatność na poważne zagrożenia bezpieczeństwa."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Ograniczona ochrona przed prostymi zagrożeniami bezpieczeństwa."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Ochrona przed często występującymi zagrożeniami bezpieczeństwa."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Ochrona przed szerokim zakresem zagrożeń bezpieczeństwa."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Pełna ochrona"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Brak zdarzeń"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Ochrona przed zapisem oprogramowania sprzętowego"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Blokada ochrony przed zapisem oprogramowania sprzętowego"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Region BIOS-u oprogramowania sprzętowego"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Deskryptor BIOS-u oprogramowania sprzętowego"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Ochrona DMA przed uruchomieniem"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Uruchamianie zweryfikowane przez Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "ACM chronione przez Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Zasady postępowania Intel BootGuard w przypadku błędów"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Bezpiecznik Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET jest włączone"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET jest aktywne"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Zaszyfrowana pamięć RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Ochrona IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Blokada jądra Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Weryfikacja jądra Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Obszar wymiany systemu Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Uśpienie do pamięci RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Uśpienie do trybu bezczynności"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Klucz platformy UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Zabezpieczone uruchamianie UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Konfiguracja platformy TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Rekonstrukcja TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Tryb serwisowy Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Obejście Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Wersja Intel Management Engine"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Aktualizacje oprogramowania sprzętowego"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Zaświadczenie oprogramowania sprzętowego"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Weryfikacja aktualizatora oprogramowania sprzętowego"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Debugowanie platformy"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Testy zabezpieczeń procesora"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Ochrona przed wycofaniem AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Ochrona przed odtwarzaniem oprogramowania sprzętowego AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Ochrona przed zapisem oprogramowania sprzętowego AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Platforma z bezpiecznikiem"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Prawidłowe"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Nieprawidłowe"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Niewłączone"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Zablokowane"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Niezablokowane"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Zaszyfrowane"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Niezaszyfrowane"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Skażone"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Nieskażone"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Odnaleziono"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Nie odnaleziono"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Obsługiwane"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Nieobsługiwane"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Zabezpieczenia urządzenia"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Stan zabezpieczeń oprogramowania sprzętowego komputera"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ekran;blokada;diagnostyka;awaria;prywatne;ostatnie;ostatnio;tymczasowe;tmp;"
+"indeksowanie;index;nazwa;sieć;tożsamość;prywatność;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Nieznany"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bitowy"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bitowy"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Nieznany"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Niedostępna"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo systemu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nazwa urządzenia"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Model sprzętu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Pamięć"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Pojemność dysku"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Obliczanie…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nazwa systemu operacyjnego"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Identyfikator systemu operacyjnego"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Typ systemu operacyjnego"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Wersja GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Wczytywanie…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "System okien"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Wirtualizacja"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Aktualizacje oprogramowania"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Zmiana nazwy komputera"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Nazwa urządzenia jest używana do identyfikowania go przez sieć lub podczas "
+"łączenia urządzeń Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nazwa urządzenia"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Zmień nazwę"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Informacje"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Wyświetlanie informacji o systemie"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"urządzenie;system;informacje;nazwa;komputera;hosta;hostname;pamięć;procesor;"
+"grafika;karta;graficzna;wersja;domyślne;programy;aplikacje;preferowane;cd;"
+"dvd;usb;dźwięk;audio;wideo;video;płyta;dysk;wymienny;nośnik;automatyczne;"
+"uruchamianie;szczegóły;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Dźwięk i multimedia"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Wyciszenie/włączenie dźwięku"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Głośność w dół"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Głośność w górę"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Wyciszenie/włączenie mikrofonu"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Uruchomienie odtwarzacza multimediów"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Odtwarzanie (lub odtwarzanie/wstrzymanie)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Wstrzymanie odtwarzania"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Zatrzymanie odtwarzania"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Poprzednia ścieżka"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Następna ścieżka"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Wysunięcie"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Pisanie"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Przełączenie na następne źródło wprowadzania"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Przełączenie na poprzednie źródło wprowadzania"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Uruchamianie"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Uruchomienie przeglądarki pomocy"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Uruchomienie kalkulatora"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Uruchomienie klienta poczty"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Uruchomienie przeglądarki WWW"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Katalog domowy"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Wyszukiwanie"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Wylogowanie"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Blokowanie ekranu"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Ułatwienia dostępu"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Włączenie lub wyłączenie powiększania"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Powiększenie"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Pomniejszenie"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Włączenie lub wyłączenie czytnika ekranowego"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Włączenie lub wyłączenie klawiatury ekranowej"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Zwiększenie rozmiaru tekstu"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Zmniejszenie rozmiaru tekstu"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Włączenie lub wyłączenie wysokiego kontrastu"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nie odnaleziono źródeł wprowadzania"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Inne"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Dodanie źródła wprowadzania"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Metody wprowadzania nie mogą być używane na ekranie logowania"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nie wybrano żadnego źródła wprowadzania"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opcje"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Przesuń w górę"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Przesuń w dół"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferencje"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Wyświetl układ klawiatury"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Usuń"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Niestandardowe skróty"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Klawisz wprowadzania alternatywnych znaków"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Klawisz alternatywnych znaków może być używany do wprowadzania dodatkowych "
+"znaków. Są one czasami oznaczone jako opcje trzeciego poziomu na klawiszach."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Lewy Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Prawy Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Lewy klawisz Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Prawy klawisz Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Klawisz Menu"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Prawy Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Klawisz Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Klawisz Compose umożliwia wprowadzanie szerokiego zakresu znaków. Aby go "
+"użyć, należy wcisnąć klawisz Compose, a następnie sekwencję znaków. Na "
+"przykład, klawisz Compose plus znaki <b>C</b> i <b>o</b> wprowadzą znak "
+"<b>©</b>, <b>a</b> i <b>'</b> wprowadzą <b>á</b> itp."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Źródła wprowadzania można przełączać za pomocą skrótu klawiszowego %s.\n"
+"Można to zmienić w ustawieniach skrótów klawiszowych."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Źródła wprowadzania"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Obejmuje układy klawiatury i metody wprowadzania."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Przełączanie źródeł wprowadzania"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "To _samo źródło dla wszystkich okien"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "_Oddzielne źródło dla każdego okna"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Wpisywanie znaków specjalnych"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Metody wprowadzania symboli i wariantów liter za pomocą klawiatury."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Skróty klawiszowe"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Wyświetl i dostosuj skróty"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d zmodyfikowany"
+msgstr[1] "%d zmodyfikowane"
+msgstr[2] "%d zmodyfikowanych"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Przywrócić wszystkie skróty?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Przywrócenie skrótów może wpłynąć na skróty ustawione przez użytkownika. Nie "
+"można tego cofnąć."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Przywróć wszystko"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Przywróć wszystko…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Przywraca wszystkie skróty do domyślnych wartości"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sekcja"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Skróty"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Dodaj skrót"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Dodanie niestandardowych skrótów"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Ustawianie niestandardowych skrótów do uruchamiania programów, wykonywania "
+"skryptów i nie tylko."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Dodaj skrót"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nie odnaleziono skrótów klawiszowych"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s jest już używane dla „%s”. Po zastąpieniu „%s” zostanie wyłączone."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Proszę wprowadzić nowy skrót"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Ustawienie niestandardowego skrótu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Ustawienie skrótu"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Proszę wprowadzić nowy skrót, aby zmienić „%s”."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Dodanie niestandardowego skrótu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Usuń"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Zastąp"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Ustaw"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Klawisz Esc anuluje, a Backspace wyłączy skrót klawiszowy."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nazwa"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Polecenie"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Skrót"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Ustaw skrót…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Brak"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Przywraca skrót do domyślnej wartości"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klawiatura"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Zmiana skrótów klawiszowych oraz ustawianie preferencji pisania, układów "
+"klawiatury i źródeł wprowadzania"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Skrót;Skróty;Obszar;roboczy;Okno;Zmień;rozmiar;Zmiana;rozmiaru;Powiększanie;"
+"Przybliżanie;Zoom;Kontrast;Źródło;wprowadzania;Blokada;Zablokuj;Głośność;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Usługi położenia są wyłączone"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Żadne programy nie mogą uzyskiwać informacji o położeniu."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Usługi położenia umożliwiają programom ustalanie położenia geograficznego. "
+"Użycie Wi-Fi i połączenia komórkowego zwiększa dokładność.\n"
+"\n"
+"Używa Usług lokalizacji Mozilli: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Można zezwolić poniższym programom na ustalanie położenia użytkownika."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Żadne programy nie poprosiły o dostęp do położenia"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Ochrona informacji o położeniu użytkownika"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+"położenie;geograficzne;miejsce;lokacja;lokalizacja;geolokalizacja;GPS;GNSS;"
+"GLONASS;Galileo;IRNSS;BDS;BeiDou;GeoClue;geocode;prywatne;prywatność;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofon jest wyłączony"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Żadne programy nie mogą nagrywać dźwięku."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Użycie mikrofonu umożliwia programom nagrywanie i odsłuchiwanie dźwięku. "
+"Wyłączenie mikrofonu może spowodować niepoprawne działanie części "
+"programów.\n"
+"\n"
+"Można zezwolić poniższym programom na używanie mikrofonu."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Żadne programy nie poprosiły o dostęp do mikrofonu"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Ochrona rozmów"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofon;nagrywanie;nagraj;prywatność;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Test _ustawień"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Ogólne"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Przycisk podstawowy"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Ustawia kolejność fizycznych przycisków myszy i paneli dotykowych."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Lewy"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Prawy"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mysz"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Prędkość myszy"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Naturalne przewijanie"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Przewijanie przesuwa treść, a nie widok."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Panel dotykowy"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Prędkość panelu dotykowego"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Klikanie przez stuknięcie"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Klikanie przez stuknięcie"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Przewijanie dwoma palcami"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Przewijanie przy krawędziach"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Można testować klikanie, podwójne kliknięcie i przewijanie"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Pięć kliknięć, czas na GEGL-a!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Podwójne kliknięcie, przycisk podstawowy"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Pojedyncze kliknięcie, przycisk podstawowy"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Podwójne kliknięcie, środkowy przycisk"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Pojedyncze kliknięcie, środkowy przycisk"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Podwójne kliknięcie, przycisk pomocniczy"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Pojedyncze kliknięcie, przycisk pomocniczy"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mysz i panel dotykowy"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Zmiana wrażliwości myszy i panelu dotykowego oraz wybór trybu praworęcznego "
+"lub leworęcznego"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Kursor;Wskaźnik;Wskazywanie;Kliknięcie;Puknięcie;Stuknięcie;"
+"Pacnięcie;Podwójne;Przycisk;Trackball;Touchpad;Przewijanie;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Aktywny róg"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Dotknięcie lewego górnego rogu otwiera ekran podglądu."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Aktywne _krawędzie ekranu"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Przeciągnięcie okna do górnej, lewej lub prawej krawędzi ekranu zmienia jego "
+"rozmiar."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Obszary robocze"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dynamiczne"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Automatycznie usuwa puste obszary robocze."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Stała liczba"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Można podać liczbę stałych obszarów roboczych."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Liczba obszarów roboczych"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Wiele monitorów"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "_Obszary robocze tylko na głównym ekranie"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "O_bszary robocze na wszystkich ekranach"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Przełączanie programów"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "_Programy ze wszystkich obszarów roboczych"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Progra_my tylko z obecnego obszaru roboczego"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Wielozadaniowość"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Zarządzanie preferencjami efektywności i wielozadaniowości"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Wielozadaniowość;Multitasking;Efektywność;Produktywność;Dostosuj;"
+"Dostosowanie;Pulpit;Desktop;Aktywny róg;Gorący róg;Obszary robocze;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Coś się nie powiodło. Proszę skontaktować się z producentem oprogramowania."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Usługa NetworkManager musi być uruchomiona."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Inne urządzenia"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Dodaj połączenie"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nie ustawiono"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Niezabezpieczona sieć (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Zabezpieczona sieć (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Zabezpieczona sieć (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Zabezpieczona sieć (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Zabezpieczona sieć"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Połączone"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opcje…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Włączenie hotspotu spowoduje rozłączenie z sieci %s, i nie będzie można "
+"korzystać z Internetu przez Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Musi mieć co najmniej 8 znaków"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Może mieć maksymalnie %d znak"
+msgstr[1] "Może mieć maksymalnie %d znaki"
+msgstr[2] "Może mieć maksymalnie %d znaków"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Włączyć hotspot Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Hotspot Wi-Fi umożliwia innym korzystanie z połączenia z Internetem tego "
+"komputera przez utworzenie sieci Wi-Fi, z którą mogą się połączyć. Aby to "
+"zrobić, należy mieć połączenie z Internetem z innego źródła niż Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nazwa sieci"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Hasło"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Tworzy losowe hasło"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Automatycznie utwórz hasło"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Włącz"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Zatrzymać hotspot i rozłączyć wszystkich użytkowników?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Zatrzymaj hotspot"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Tryb samolotowy"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Wyłącza sieci Wi-Fi, Bluetooth i komórkowe"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nie odnaleziono adapterów Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Proszę się upewnić, że adapter Wi-Fi jest podłączony i włączony"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Tryb samolotowy jest włączony"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Jego wyłączenie umożliwi używanie sieci Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Hotspot Wi-Fi jest aktywny"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Można zeskanować kod QR telefonem, aby się połączyć."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Wyłącz hotspot Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Widoczne sieci"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Usługa NetworkManager musi być uruchomiona"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Zabezpieczenia 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Zabezpieczenia"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Zachowywanie"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Stały"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Losowy"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabilny"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Podany tutaj adres MAC będzie używany jako adres sprzętowy urządzenia "
+"sieciowego, na którym włączono to połączenie. Ta funkcja jest znana jako "
+"klonowanie lub „spoofing” adresu MAC. Przykład: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "%d. profil"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Wzmocnione otwarte"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Brak"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nigdy"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i dzień temu"
+msgstr[1] "%i dni temu"
+msgstr[2] "%i dni temu"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2,4 GHz/5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2,4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Brak"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Słaba"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Dostateczna"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Dobra"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Doskonała"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Adres IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adres IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adres IP"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Zapomnij połączenie"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Usuń profil połączenia"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Usuń połączenie VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Informacje"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatycznie"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Tożsamość"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Usuń adres"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Usuń trasę"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Brak"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "40/128-bitowy klucz WEP (szesnastkowy lub ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "128-bitowe hasło WEP"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamiczny WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA i WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA i WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Siła sygnału"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Prędkość połączenia"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Adres sprzętowy"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Obsługiwane częstotliwości"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Domyślna trasa"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Ostatnio użyte"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Łączenie _automatyczne"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "_Dostępna dla innych użytkowników"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "_Połączenie taryfowe: ma ograniczenia danych lub wiąże się z opłatami"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Aktualizacje oprogramowania i inne duże pobierania nie będą rozpoczynane "
+"automatycznie."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nazwa"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Adres _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Sk_lonowany adres"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "B"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Metoda IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatycznie (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Tylko Link-Local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Ręcznie"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Wyłączone"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Udostępniane innym komputerom"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresy"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adres"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Maska sieci"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Brama"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatycznie"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatyczny DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Adresy serwerów DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Należy oddzielić adresy IP przecinkami"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Trasy"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatyczne trasy"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Parametry"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Używanie tego połączenia tylk_o dla zasobów w jej sieci"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Metoda IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatycznie, tylko DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Przedrostek"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Nie można otworzyć edytora połączeń"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Nowy profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Nieprawidłowe ustawienie %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Nieprawidłowe ustawienie %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Zaimportuj z pliku…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Dodanie połączenia VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Zab_ezpieczenia"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Nie można zaimportować połączenia VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Plik „%s” nie może zostać odczytany lub nie zawiera rozpoznawanych "
+"informacji o połączeniu VPN\n"
+"\n"
+"Błąd: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Wybór pliku do zaimportowania"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Plik o nazwie „%s” już istnieje."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "Za_mień"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Zastąpić połączenie „%s” zapisywanym połączeniem VPN?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Nie można wyeksportować połączenia VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Połączenie VPN „%s” nie może zostać wyeksportowane do %s.\n"
+"\n"
+"Błąd: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Eksport połączenia VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Błąd: nie można wczytać edytora połączeń VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Sterowanie sposobem łączenia z Internetem"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Sieć;Sieci;IP;LAN;Kabel;Pośrednik;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Sterowanie sposobem łączenia z sieciami Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Sieć;Sieci;Bezprzewodowa;Wireless;Wi-Fi;Wifi;IP;LAN;Kabel;DNS;Hotspot;Punkt;"
+"dostępowy;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nigdy"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "dzisiaj"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "wczoraj"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Ostatnio użyte"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Przewodowe"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Dodaj nowe połączenie"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Informacje o zaznaczonych sieciach, w tym hasła i konfiguracja, zostaną "
+"utracone."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Zapomnij"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Znane sieci Wi-Fi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Zapomnij"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Ustawienia systemu uniemożliwiają użycie jako hotspot"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Urządzenie bezprzewodowe nie obsługuje trybu hotspot"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Automatyczne wykrywanie pośrednika sieciowego jest używane, jeśli nie podano "
+"adresu URL konfiguracji."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Nie jest zalecane dla niezaufanych sieci publicznych."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Wyłącz urządzenie"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktywne"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Dostawca"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Pośrednik sieciowy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Pośrednik _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Pośrednik H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Pośrednik _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Serwer _SOCKS"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorowanie komputerów"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Port pośrednika HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Port pośrednika HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Port pośrednika FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Port pośrednika SOCKS"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "Adres URL _konfiguracji"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Wyłącz połączenie VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nazwa sieci"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Typ zabezpieczeń"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Hasło"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wyłącz Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Więcej opcji…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Połącz z ukrytą siecią…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Włącz hotspot Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Znane sieci Wi-Fi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Stan nieznany"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Niezarządzane"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Niedostępne"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Łączenie"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Wymagane jest uwierzytelnienie"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Rozłączanie"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Połączenie się nie powiodło"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Stan nieznany (brak)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Konfiguracja się nie powiodła"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Konfiguracja adresu IP się nie powiodła"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Konfiguracja adresu IP wygasła"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Wymagane są hasła, których nie podano"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Suplikant 802.1x się rozłączył"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Konfiguracja suplikanta 802.1x się nie powiodła"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Suplikant 802.1x się nie powiódł"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Suplikant 802.1x za długo się uwierzytelniał"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Uruchomienie usługi PPP się nie powiodło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Usługa PPP została rozłączona"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Usługa PPP się nie powiodła"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Uruchomienie klienta DHCP się nie powiodło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Błąd klienta DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Klient DHCP się nie powiódł"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Uruchomienie usługi współdzielonego połączenie się nie powiodło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Usługa współdzielonego połączenia się nie powiodła"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr ""
+"Uruchomienie usługi automatycznego wykrywania adresu IP się nie powiodło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Błąd usługi automatycznego wykrywania adresu IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Usługa automatycznego wykrywania adresu IP się nie powiodła"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linia jest zajęta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Brak wybierania tonowego"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Nie można ustanowić żadnego operatora"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Żądanie wdzwonienia przekroczyło czas oczekiwania"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Próba wdzwonienia się nie powiodła"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Zainicjowanie modemu się nie powiodło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Wybranie podanego APN się nie powiodło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Sieci nie są wyszukiwane"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Odmówiono rejestracji sieci"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Rejestracja sieci przekroczyła czas oczekiwania"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Zarejestrowanie za pomocą żądanej sieci się nie powiodło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Sprawdzenie kodu PIN się nie powiodło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Brak oprogramowania sprzętowego urządzenia"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Połączenie zniknęło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Przyjęto istniejące połączenie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Nie odnaleziono modemu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Połączenie Bluetooth się nie powiodło"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Nie włożono karty SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Wymagany jest kod PIN karty SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Wymagany jest kod PUK karty SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Błędna karta SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Zależność połączenia się nie powiodła"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Brak oprogramowania sprzętowego"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabel jest niepodłączony"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "nieokreślony błąd w zabezpieczeniach 802.1X (WPA-EAP)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "nie wybrano żadnego pliku"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "nieokreślony błąd podczas sprawdzania poprawności pliku eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Klucze prywatne DER, PEM, PKCS#12 lub PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certyfikaty DER lub PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "brak pliku PAC EAP-FAST"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Pliki PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonimowo"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Uwierzytelnienie"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Oba"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anoni_mowa tożsamość"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Plik PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Wybór pliku PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Wewnętrzne uw_ierzytelnianie"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Automatyczne za_bezpieczanie PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "brak nazwy użytkownika EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "brak hasła EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nazwa _użytkownika"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Hasło"
+
+# checkbox
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Wyświetlanie hasła"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "nieprawidłowy certyfikat CA EAP-PEAP: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "nieprawidłowy certyfikat CA EAP-PEAP: nie podano certyfikatu"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Wersja 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Wersja 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certyfikat C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Wybór certyfikatu CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Certyfikat CA nie jest _wymagany"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Wersja PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "brak nazwy użytkownika EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "brak hasła EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "brak tożsamości EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "nieprawidłowy certyfikat CA EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "nieprawidłowy certyfikat CA EAP-TLS: nie podano certyfikatu"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "nieprawidłowy klucz prywatny EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "nieprawidłowy certyfikat użytkownika EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Niezaszyfrowane klucze prywatne są niezabezpieczone"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Wybrany klucz prywatny nie jest chroniony hasłem. Może to umożliwić "
+"ujawnienie danych zabezpieczeń. Proszę wybrać klucz prywatny chroniony "
+"hasłem.\n"
+"\n"
+"(można ochronić klucz prywatny hasłem za pomocą oprogramowania OpenSSL)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Wybór osobistego certyfikatu"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Wybór klucza prywatnego"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Tożsamość"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certyfikat _użytkownika"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Klucz prywatny"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Hasło klucza prywatnego"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "nieprawidłowy certyfikat CA EAP-TTLS: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "nieprawidłowy certyfikat CA EAP-TTLS: nie podano certyfikatu"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (bez EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domena"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Nieznany błąd podczas sprawdzania poprawności zabezpieczeń 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunelowane TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Chronione EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Uwierzy_telnianie"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Wybierz plik"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "brak nazwy użytkownika LEAP"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "brak hasła LEAP"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Brak hasła Wi-Fi."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Typ"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "brak klucza WEP"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"nieprawidłowy klucz WEP: klucz o długości %zu może zawierać tylko cyfry "
+"szesnastkowe"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"nieprawidłowy klucz WEP: klucz o długości %zu może zawierać tylko znaki ASCII"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"nieprawidłowy klucz WEP: błędna długość klucza %zu. Klucz musi być długości "
+"5/13 (ASCII) lub 10/26 (szesnastkowy)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "nieprawidłowy klucz WEP: hasło nie może być puste"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "nieprawidłowy klucz WEP: hasło musi być krótsze niż 64 znaki"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (domyślnie)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "System otwarty"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Klucz współdzielony"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Klucz"
+
+# checkbox
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Wyświetlanie klucza"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Inde_ks WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"nieprawidłowe WPA-PSK: nieprawidłowa długość klucza %zu. Musi mieć [8,63] "
+"bajty lub 64 cyfry szesnastkowe"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"nieprawidłowe WPA-PSK: nie można zinterpretować klucza o 64 bajtach jako "
+"szesnastkowy"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Powiadomienia"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alarmy dźwiękowe"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Wyskakujące powiadomienia"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Powiadomienia będą nadal pojawiać się na liście powiadomień, nawet jeśli "
+"wyłączono wyskakujące powiadomienia."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "_Treść wiadomości na wyskakujących powiadomieniach"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Powiadomienia na ekranie _blokady"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "T_reść wiadomości na ekranie blokady"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Nie przeszkadzać"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Powiadomienia na ekranie _blokady"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Sterowanie wyświetlaniem powiadomień i ich treści"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Powiadomienia;Notyfikacje;Baner;Banner;Wiadomość;Komunikat;Obszar;Tacka;Tray;"
+"Wyskakujące;Popup;Pop-up;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Inne"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "Usunięto „%s”"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Błąd podczas usuwania konta"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Cofnij"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Zamknij powiadomienie"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Łączenie z danymi w chmurze"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Brak połączenia z Internetem — należy się połączyć, aby ustawić nowe konta "
+"online"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Dodawanie konta"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Konto %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Usuń konto"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Konta online"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Łączenie z kontami online i ustalanie, do czego mają być używane"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;WWW;Web;Online;Sieciowe;Komunikator;Chat;Czat;"
+"Kalendarz;Poczta;e-mail;email;Kontakt;Chmura;Cloud;Nextcloud;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;Flickr;Windows;Live;Microsoft;Exchange;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Nieznany czas"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuta"
+msgstr[1] "%i minuty"
+msgstr[2] "%i minut"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i godzina"
+msgstr[1] "%i godziny"
+msgstr[2] "%i godzin"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s i %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "godzina"
+msgstr[1] "godziny"
+msgstr[2] "godzin"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuta"
+msgstr[1] "minuty"
+msgstr[2] "minut"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "Do pełnego naładowania: %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Uwaga, pozostało: %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Pozostało: %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "W pełni naładowany"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Nie jest ładowany"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Pusty"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Ładowanie"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Rozładowywanie"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Mysz bezprzewodowa"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Klawiatura bezprzewodowa"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Urządzenie UPS"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Urządzenie PDA"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Telefon komórkowy"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Odtwarzacz multimediów"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Komputer"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Kontroler do gier"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Akumulator"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Główny"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Dodatkowy"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Akumulatory"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Podczas _bezczynności"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Uśpienie"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Wyłączenie komputera"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernacja"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nic"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Na zasilaniu z akumulatora"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Kiedy jest podłączony do prądu"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nigdy"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatyczne usypianie"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Tryb wydajności jest tymczasowo wyłączony z powodu wysokiej temperatury "
+"działania."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Wykryto kolana: tryb wydajności jest tymczasowo niedostępny. Należy "
+"przenieść urządzenie na stabilną powierzchnię, aby przywrócić."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Tryb wydajności jest tymczasowo wyłączony."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Niski poziom naładowania akumulatora: włączono tryb oszczędzania energii. "
+"Poprzedni tryb zostanie przywrócony po wystarczającym naładowaniu "
+"akumulatora."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Tryb oszczędzania energii został włączony przez program „%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Tryb wydajności został włączony przez program „%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 godzina"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 godziny"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Tryb zasilania"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Wpływa na wydajność komputera i pobór energii."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opcje oszczędzania energii"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatyczna jasność ekranu"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Jasność ekranu dopasowuje się do oświetlenia otoczenia."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Przygaszanie ekranu"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Zmniejsza jasność ekranu, kiedy komputer nie jest używany."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Wygaszanie ekranu"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Wyłącza ekran po określonym czasie nieużywania komputera."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatyczne oszczędzanie energii"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+"Włącza tryb oszczędzania energii, kiedy poziom naładowania akumulatora jest "
+"niski."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatyczne usypianie"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Wstrzymuje komputer po określonym czasie nieużywania komputera."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "_Zachowanie przycisku zasilania"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "_Poziom naładowania akumulatora w procentach"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatyczne usypianie"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "P_odłączony do prądu"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Na zasilaniu z _akumulatora"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Opóźnienie"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Wydajność"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Wysoka wydajność i pobór energii."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Zrównoważone zasilanie"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standardowa wydajność i pobór energii."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Oszczędzanie energii"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Zmniejszona wydajność i pobór energii."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Zasilanie"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Wyświetlanie stanu naładowania akumulatora i zmiana ustawień oszczędzania "
+"energii"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Zasilanie;Energia;Prąd;Oszczędzanie;Uśpienie;Wstrzymanie;Hibernacja;Uśpij;"
+"Wyłącz;Wstrzymaj;Hibernuj;Akumulator;Bateria;Jasność;Przygaszenie;Wygaszenie;"
+"Monitor;DPMS;Bezczynność;Nieaktywność;Wi-Fi;Wifi;Bluetooth;Bezprzewodowe;"
+"Wireless;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Usunięto drukarkę „%s”"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Dodanie nowej drukarki się nie powiodło."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Nie można wczytać interfejsu użytkownika: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Odblokowanie umożliwi dodawanie drukarek i zmianę ustawień"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Drukarki"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Dodawanie drukarek, wyświetlanie zadań drukowania i ustalanie sposobu "
+"drukowania"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Drukarka;Kolejka;Drukowanie;Papier;Atrament;Tusz;Toner;CUPS;IPP;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Dodanie drukarki"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Odblokuj"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Nie odnaleziono drukarek"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Proszę wprowadzić adres sieciowy lub wyszukać drukarkę"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Wymagane jest uwierzytelnienie"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Proszę wprowadzić nazwę użytkownika i hasło, aby wyświetlić drukarki na "
+"serwerze wydruku."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nazwa użytkownika"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Informacje o „%s”"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Nie odnaleziono odpowiedniego sterownika"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Wybór pliku PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Pliki PostScriptowego opisu drukarki (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Nazwy drukarek nie mogą zawierać spacji, znaków tabulacji, # ani /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Położenie"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Sterownik"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Wyszukiwanie preferowanych sterowników…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Wyszukaj sterowniki"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Wybierz z bazy danych…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Zainstaluj plik PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Wybór sterownika drukarki"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Wczytywanie bazy danych sterowników…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Wybierz"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Drukarka JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Drukarka LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Jednostronnie"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Długa krawędź (standardowo)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Krótka krawędź (odwrócenie)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portret"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Pejzaż"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Odwrócony pejzaż"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Odwrócony portret"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Wznów"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Wstrzymaj"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Oczekuje"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Wstrzymane"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Wymagane jest uwierzytelnienie"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Przetwarzanie"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Zatrzymane"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Anulowane"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Przerwane"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Ukończone"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Przenosi to zadanie na początek kolejki"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u zadanie wymaga uwierzytelnienia"
+msgstr[1] "%u zadania wymagają uwierzytelnienia"
+msgstr[2] "%u zadań wymaga uwierzytelnienia"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — aktywne zadania"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+"Proszę wprowadzić dane uwierzytelniające, aby wydrukować za pomocą drukarki "
+"„%s”."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domena"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Uwierzytelnij"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Wyczyść wszystko"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "U_wierzytelnij"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Brak aktywnych zadań drukarki"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Odblokowanie serwera wydruku"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Odblokowanie „%s”."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Proszę wprowadzić nazwę użytkownika i hasło, aby wyświetlić drukarki w „%s”."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Wyszukiwanie drukarek"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Port szeregowy"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Port równoległy"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Położenie: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adres: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Serwer wymaga uwierzytelnienia"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dwustronnie"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Typ papieru"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Źródło papieru"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Podajnik wyjściowy"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Rozdzielczość"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Filtrowanie GhostScript przed wydrukiem"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Stron na kartkę"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dwustronnie"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientacja"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Ogólne"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Ustawienia strony"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opcje instalacyjne"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Zadanie"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Jakość obrazu"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Kolor"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Kończenie"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Strona testowa"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Strona testowa"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Wybór automatyczny"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Domyślne drukarki"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Osadzanie tylko czcionek GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Konwertowanie na PostScript 1. poziomu"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Konwertowanie na PostScript 2. poziomu"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Brak filtrowania przed wydrukiem"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Producent"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Brak aktywnych zadań"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u zadanie"
+msgstr[1] "%u zadania"
+msgstr[2] "%u zadań"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Czyszczenie głowic drukujących"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Mało tonera"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Brak tonera"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Mało wywoływacza"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Brak wywoływacza"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Mało atramentu"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Brak atramentu"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Otwarta pokrywa"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Otwarte drzwiczki"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Mało papieru"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Brak papieru"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Offline"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Zatrzymana"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Pojemnik na odpady jest prawie pełny"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Pojemnik na odpady jest pełny"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Warstwa światłoczuła ledwo działa"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Warstwa światłoczuła już nie działa"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Gotowa"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Nie przyjmuje zadań"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Przetwarzanie"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Opcje drukowania"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Informacje o drukarce"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Domyślna drukarka"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Wyczyść głowice drukujące"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Usuń drukarkę"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Poziom atramentu"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Proszę uruchomić ponownie po rozwiązaniu problemu."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Uruchom ponownie"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Dodaj drukarkę…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Brak drukarek"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr "Systemowa usługa drukowania jest niedostępna."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formaty"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Wyszukiwanie języków…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Często używane formaty"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Wszystkie formaty"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Brak wyników wyszukiwania"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Można wyszukiwać kraje i języki."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Podgląd"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "anglosaskie (imperialne)"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "metryczne"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Data"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Data i czas"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Liczby"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Jednostki miary"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papier"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Język i format zostaną zmienione po następnym zalogowaniu"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Wyloguj się…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Język używany w tekście interfejsu i na stronach WWW oraz format liczb, dat "
+"i walut."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Obecnie zalogowane konto"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Język"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formaty"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Ekran logowania"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Region i język"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Wybór języka wyświetlania i formatów"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Język;Dialekt;Układ;Layout;Klawiatura;Wprowadzanie;Wejście;Pisanie;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Pytanie, co robić"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Nierobienie niczego"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Otwarcie katalogu"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Inne nośniki"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Wybór programu dla płyt CD-Audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Wybór programu dla płyt wideo DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Wybór programu do uruchomienia po podłączeniu odtwarzacza multimediów"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Wybór programu do uruchomienia po podłączeniu aparatu"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Wybór programu dla płyt CD z oprogramowaniem"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "Płyta DVD-Audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Pusta płyta Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "Pusta płyta CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "Pusta płyta DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "Pusta płyta HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Płyta wideo Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "Czytnik e-booków"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Płyta wideo HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Oprogramowanie systemu Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Wybór, jak obsługiwać nośniki"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "Płyta CD-_Audio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "Płyta wideo _DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Odtwarzacz _muzyki"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Oprogramowanie"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Inne nośniki…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Bez pytania lub uruchamiania programów po wsunięciu nośnika"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Wybór, jak obsługiwać inne nośniki"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "Dzi_ałanie:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Typ:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Nośniki wymienne"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Konfiguracja nośników wymiennych"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"urządzenie;system;domyślne;programy;aplikacje;domyślny;program;aplikacja;"
+"preferowane;cd;dvd;usb;dźwięk;audio;wideo;video;płyta;dysk;wymienny;nośnik;"
+"automatyczne;uruchamianie;autorun;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Natychmiast"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekund"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuta"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minuty"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minuty"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minut"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minut"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 godzina"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minuty"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minuty"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minuty"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nigdy"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Blokada ekranu"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatyczne blokowanie ekranu uniemożliwia innym dostęp do komputera, kiedy "
+"użytkownik nie jest w pobliżu."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Opóźnienie wygaszenia ekranu"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Okres nieaktywności, po którym ekran zostanie wygaszony."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatyczne _blokowanie ekranu"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Opóźnienie automatycznego blokowania ekranu"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Okres po wygaszeniu ekranu, po którym ekran jest automatycznie blokowany."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Powiadomienia na ekranie blokady"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Bez włączania nowych urządzeń _USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Uniemożliwia urządzeniom USB działanie na komputerze, kiedy ekran jest "
+"zablokowany."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Prywatność ekranu"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Ograniczenie kąta widzenia"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Ustawienia ekranu"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "ekran;blokada;zablokuj;prywatne;prywatność;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Wybór położenia"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Położenia wyszukiwania"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Katalogi przeszukiwane przez programy systemu, takie jak menedżer plików, "
+"menedżer zdjęć i odtwarzacz filmów."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Miejsca"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Zakładki"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Inne"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Dodaj położenie"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nie odnaleziono programów"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Przeszukiwanie programów"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Dołączanie wyników wyszukiwania z programów."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Katalogi przeszukiwane przez programy systemowe."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Wyniki wyszukiwania"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Wyniki są wyświetlane zgodnie z kolejnością na liście."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Sterowanie programami wyświetlającymi wyniki wyszukiwania na ekranie podglądu"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Wyszukiwanie;Znajdź;Szukaj;Wyszukaj;Indeksowanie;Index;Ukryj;Ukrywanie;"
+"Prywatność;Wyniki;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Nie wybrano żadnych sieci do udostępniania"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Sieci"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Włączone"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Wyłączone"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Włączone"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktywne"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Wybór katalogu"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Dodaj"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Włącz udostępnianie multimediów"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Udostępnianie plików umożliwia udostępnianie katalogu Publiczne z innymi "
+"użytkownikami bieżącej sieci za pomocą: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Umożliwia zdalnym użytkownikom na łączenie się za pomocą polecenia SSH:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Włącz udostępnianie multimediów osobistych"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Skopiowano nazwę urządzenia"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Skopiowano adres urządzenia"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Skopiowano nazwę użytkownika"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Skopiowano hasło"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Udostępnianie"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Nazwa _komputera"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Ud_ostępnianie plików"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Z_dalny pulpit"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Udostępnianie _multimediów"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Zdalne logowanie"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Udostępnianie plików"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Wymaganie _hasła"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Zdalne logowanie"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Zdalny pulpit"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Zdalny pulpit umożliwia wyświetlanie i sterowanie systemem z innego "
+"komputera."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Włącza lub wyłącza zdalne połączenia z pulpitem tego komputera."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Zdalne sterowanie"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Zdalne połączenia mogą sterować ekranem."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Jak się połączyć"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Można połączyć się z tym komputerem za pomocą nazwy urządzenia lub adresu "
+"zdalnego pulpitu."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Skopiuj"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Adres zdalnego pulpitu"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Uwierzytelnianie"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Nazwa użytkownika i hasło są wymagane do połączenia się z tym komputerem."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nazwa użytkownika"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Sprawdź poprawność szyfrowania"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Odcisk szyfrowania"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Odcisk szyfrowania można zobaczyć w łączących się klientach i powinien być "
+"identyczny."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Udostępnianie multimediów"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Udostępnianie muzyki, zdjęć i filmów przez sieć."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Katalogi"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Sterowanie udostępnianiem innym użytkownikom"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"udostępnianie;współdzielenie;share;sharing;ssh;vnc;rfb;rdp;nx;spice;vino;"
+"vinagre;komputer;host;nazwa;zdalnie;zdalny;zdalne;pulpit;desktop;ekran;"
+"multimedia;media;dźwięk;audio;wideo;obraz;video;zdjęcia;filmy;serwer;"
+"renderer;rygel;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Włączenie lub wyłączenie zdalnego logowania"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Wymagane jest uwierzytelnienie, aby włączyć lub wyłączyć zdalne logowanie"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Niestandardowy"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klik"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Plum"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Ciach"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Bzyk"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balans"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Oddalenie"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Tył"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Przód"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Testowanie „%s”"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Kliknięcie głośnika przetestuje go"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Głośność systemu"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Główna głośność"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Poziomy głośności"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Wyjście"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Urządzenie wyjściowe"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testuj"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Konfiguracja"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Głośnik niskotonowy"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Wejście"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Urządzenie wejściowe"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Głośność"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Dźwięk alarmu"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Wycisz"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Dźwięk"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Zmiana poziomu głośności, wejść i wyjść dźwięku oraz zdarzeń dźwiękowych"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Karta;Mikrofon;Głośność;Oddalenie;Balans;Bluetooth;Headset;Słuchawki;"
+"Głośniki;Audio;Wyjście;Wejście;Efekty;Alarmy;Odtwarzanie;Nagrywanie;Mono;"
+"Stereo;Surround;Dookolny;PCM;S/PDIF;HDMI;DTS;Dolby;Digital;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Rozłączone"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Łączenie"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Połączone"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Błąd upoważnienia"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Upoważnianie"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Ograniczona funkcjonalność"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Połączone i upoważnione"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Nieznane"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Upoważniono:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Połączono:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Zapisano:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Upoważnienie urządzenia się nie powiodło: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Zapomnienie urządzenia się nie powiodło: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Zależy od %u innego urządzenia"
+msgstr[1] "Zależy od %u innych urządzeń"
+msgstr[2] "Zależy od %u innych urządzeń"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Zamknij powiadomienie"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nazwa:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Stan:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Upoważnij i połącz"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Zapomnij urządzenie"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Błąd"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Upoważnione"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Podsystem Thunderbolt (boltd) nie jest zainstalowany lub właściwie "
+"skonfigurowany."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Zezwolenie na bezpośredni dostęp do urządzeń takich jak stacje dokujące "
+"i zewnętrzne karty graficzne."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Tylko urządzenia USB i Display Port mogą być podłączane."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Nie można wykryć sprzętu Thunderbolt.\n"
+"Komputer nie ma obsługi Thunderbolt, został wyłączony w BIOS-ie lub "
+"ustawiony na nieobsługiwany poziom zabezpieczeń."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Obsługa Thunderbolt została wyłączona w BIOS-ie."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Nie można ustalić poziomu zabezpieczeń Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Błąd podczas przełączania trybu bezpośredniego: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Brak obsługi Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Nie można połączyć się z podsystemem Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Bezpośredni dostęp"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Oczekujące urządzenia"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Brak podłączonych urządzeń"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Zarządzanie urządzeniami Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;prywatność;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Miganie kursora"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Miganie kursora w polach tekstowych."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Prędkość"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Prędkość migania kursora"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Rozmiar kursora"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Powiększanie połączone z większym rozmiarem ułatwia korzystanie z kursora."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Wspomaganie klikania"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Symulowanie przycisku pomocniczego"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+"Wywołanie kliknięcia pomocniczego po przytrzymaniu przycisku podstawowego"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Opóźnienie ak_ceptacji:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Krótkie"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Opóźnienie kliknięcia pomocniczego"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Długie"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Klikanie po _najechaniu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Wywołanie kliknięcia po najechaniu kursorem"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Opóź_nienie:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Krótkie"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Długie"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Próg prze_sunięcia:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Mały"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Duży"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Powtarzanie klawiszy"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Powtarzanie naciśnięcia klawisza po jego przytrzymaniu."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Opóźnienie powtarzania klawiszy"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Prędkość powtarzania klawiszy"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Wspomaganie pisania"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Trwałe klawisze"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Traktuje sekwencję klawiszy modyfikacji jako kombinację klawiszy"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Wyłą_czenie po jednoczesnym przyciśnięciu dwóch klawiszy"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Sygnał dźwiękowy po naciśnięciu klawisza _modyfikacji"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Powolne k_lawisze"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Umieszcza opóźnienie między naciśnięciem klawisza a jego akceptacją"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Krótkie"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Opóźnienie wpisywania powolnych klawiszy"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Długie"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Sygnał dźwiękowy po _naciśnięciu klawisza"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Sygnał dźwiękowy po _akceptacji klawisza"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Sygnał dźwiękowy po od_rzuceniu klawisza"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Odskakujące klawisze"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignoruje szybkie podwójne naciśnięcia klawiszy"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Krótkie"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Opóźnienie wpisywania odbijających klawiszy"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Długie"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Włączanie za pomocą klawiatury"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Włączanie funkcji ułatwień dostępu za pomocą klawiatury"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Domyślny"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Średni"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Duży"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Większy"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Największy"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d piksel"
+msgstr[1] "%d piksele"
+msgstr[2] "%d pikseli"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Zawsze widoczne menu ułatwień dostępu"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Wzrok"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Wysoki kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Duży tekst"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "_Animacje"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Czytnik ekranowy"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Czytnik ekranowy odczytuje wyświetlany tekst."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Słyszalne klawisze"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Sygnał dźwiękowy, kiedy klawisz Num Lock lub Caps Lock został przełączony."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Rozmiar k_ursora"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Powiększanie"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Słuch"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Alarmy wizualne"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Klawiatura ek_ranowa"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Powtarzanie klawiszy"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Miganie kursora"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Wsp_omaganie pisania (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Wskazywanie i klikanie"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Klawisze _myszy"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Wyróżnianie kursora"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Wspomaganie _klikania"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Opóźnienie po_dwójnego kliknięcia"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Opóźnienie podwójnego kliknięcia"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alarmy wizualne"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Prze_testuj miganie"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Wizualny wskaźnik po wystąpieniu dźwięku alarmu."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Miganie całym _ekranem"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Miganie całym _oknem"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Krótki"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ekranu"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ekranu"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ekranu"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Długi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Pełny ekran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Górna połowa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Dolna połowa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Lewa połowa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Prawa połowa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Opcje powiększania"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Powiększenie:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Położenie lupy:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "P_odążanie za kursorem myszy"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Część ekranu:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "_Lupa także poza ekranem"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Wyśrodkowanie kursora lupy"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "K_ursor lupy przesuwa treść"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Ku_rsor lupy podąża za treścią"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Celownik:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "P_okrywanie kursora myszy"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Grubość:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Cienka"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Gruba"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Długość:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Ko_lor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Celownik"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Zmiana kolorów:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "B_iałe na czarnym:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Jasność:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Ko_lor"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Brak"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Pełne"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Niska"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Wysoka"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Niski"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Wysoki"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Zmiana kolorów"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Ułatwienia widzenia, słyszenia, pisania oraz wskazywania i klikania"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Klawiatura;Mysz;Myszka;a11y;Dostępność;Uniwersalny;Kontrast;Kursor;Wskaźnik;"
+"Dźwięk;Przybliżanie;Powiększanie;Lupa;Zoom;Czytnik;ekranowy;ekranu;duży;"
+"wysoki;wielki;tekst;text;większy;zwiększ;powiększ;czcionka;font;rozmiar;"
+"wielkość;AccessX;Trwałe;Klawisze;Powolne;Odbijające;Myszy;Podwójne;Dwukrotne;"
+"kliknięcie;Opóźnienie;Prędkość;Szybkość;Wspomaganie;Asysta;Powtarzanie;"
+"Miganie;wzrok;wizualne;słuch;dźwięk;audio;pisanie;klikanie;animacje;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 godzina"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dzień"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "2 tygodnie"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "Miesiąc"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Usunąć wszystkie elementy z kosza?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Wszystkie elementy w koszu zostaną trwale usunięte."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Opróżnij kosz"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Usunąć wszystkie pliki tymczasowe?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Wszystkie pliki tymczasowe zostaną trwale usunięte."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Usuń pliki tymczasowe"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dzień"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dni"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "Miesiąc"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Bez ograniczenia"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Historia plików"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Historia plików zachowuje listę plików, które zostały użyte. Te informacje "
+"są współdzielone przez programy i ułatwiają wyszukiwanie plików potrzebnych "
+"użytkownikowi."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "_Historia plików"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "C_zas przechowywania historii plików"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Wy_czyść historię…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Kosz i pliki tymczasowe"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Kosz i pliki tymczasowe mogą czasami zawierać prywatne lub wrażliwe "
+"informacje. Usuwanie ich automatycznie może pomóc chronić prywatność."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Automatyczne opróżnianie _kosza"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automatyczne usuwanie plików _tymczasowych"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "O_kres, po którym usuwać pliki"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Opróżnij kosz…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Usuń pliki tymczasowe…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Historia plików i kosz"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Nie zostawiaj śladów"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"użycie;ostatnie;ostatnio;używane;użyte;historia;pliki;plików;tymczasowe;tmp;"
+"prywatne;prywatność;kosz;śmietnik;czyszczenie;wyczyść;przeczyść;usuwanie;"
+"usuń;kasowanie;skasuj;kasuj;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Powinno zgadzać się z adresem WWW dostawcy konta."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Dodanie konta się nie powiodło"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Hasła się nie zgadzają."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Zarejestrowanie konta się nie powiodło"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Brak obsługiwanego sposobu na uwierzytelnienie w tej domenie"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Dołączenie do domeny się nie powiodło"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ten login nie zadziałał.\n"
+"Proszę spróbować ponownie."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"To hasło nie zadziałało.\n"
+"Proszę spróbować ponownie."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Zalogowanie do domeny się nie powiodło"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Nie można odnaleźć domeny. Może ją niepoprawnie wpisano?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Dodanie użytkownika"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administratorzy mogą dodawać i usuwać innych użytkowników oraz zmieniać "
+"ustawienia dla wszystkich użytkowników. Kontrola rodzicielska nie może być "
+"nakładana na administratorów."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Użytkownik ustawi hasło podczas pierwszego logowania"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Ustawienie hasła teraz"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Potwierdzenie"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Logowanie firmowe"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Konta użytkowników zarządzane przez firmę lub organizację."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Tryb offline"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Logowanie firmowe umożliwia używanie istniejącego, centralnie zarządzanego "
+"konta użytkownika na tym urządzeniu. Można użyć tego konta także do "
+"uzyskania dostępu do zasobów firmy w Internecie."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Przeglądanie innych obrazów"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Wybierz plik…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Menedżer odcisków palców"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Odcisk palca"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Nie"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Tak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Usunąć zarejestrowane odciski palców, aby wyłączyć logowanie za pomocą "
+"odcisku palca?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Brak czytnika odcisków palców"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Brak czytnika odcisków palców"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Proszę się upewnić, że czytnik jest właściwie podłączony."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Czytnik odcisków palców"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Proszę wybrać czytnik odcisków palców do skonfigurowania"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Logowanie za pomocą odcisku palca"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Logowanie za pomocą odcisku palca umożliwia odblokowywanie i logowanie się "
+"do komputera za pomocą odcisku palca"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Usuń odciski palców"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Pobieranie odcisku palca"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "urządzenie musi zostać zajęte, aby wykonać to działanie"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "urządzenie jest już zajęte przez inny proces"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "brak uprawnienia do wykonania działania"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "nie pobrano żadnych odcisków"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Komunikacja z urządzeniem podczas pobierania się nie powiodła"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Komunikacja z czytnikiem odcisku palca się nie powiodła"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Komunikacja z usługą czytnika odcisku palca się nie powiodła"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Wyświetlenie listy odcisków palców się nie powiodło: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Usunięcie zapisanych odcisków palców się nie powiodło: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Lewy kciuk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Lewy palec środkowy"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Lewy palec wskazujący"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Lewy palec serdeczny"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Lewy mały palec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Prawy kciuk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Prawy palec środkowy"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Prawy palec wskazujący"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Prawy palec serdeczny"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Prawy mały palec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Nieznany palec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Ukończono"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Czytnik odcisków palców został rozłączony"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Czytnik odcisków palców jest pełny"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Pobranie nowego odciska palca się nie powiodło"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Rozpoczęcie pobierania odcisku palca się nie powiodło: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Pobranie nowego odcisku palca się nie powiodło"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Zatrzymanie pobierania odcisku palca się nie powiodło: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Proszę kilkakrotnie podnieść i położyć palec na czytniku, aby pobrać odcisk "
+"palca"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Ponownie pobierz ten odcisk palca…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Pobierz nowy odcisk palca"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Zwolnienie czytnika odcisków palców %s się nie powiodło: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problem podczas odczytu czytnika"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Zajęcie czytnika odcisków palców %s się nie powiodło: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Uzyskanie czytników odcisków palców się nie powiodło: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Ten tydzień"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Ostatni tydzień"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%-d %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%-d %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%H∶%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Koniec sesji"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Początek sesji"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — aktywność konta"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Wstecz"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Dalej"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Proszę wybrać inne hasło."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Proszę ponownie wprowadzić obecne hasło."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Nie można zmienić hasła"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Zmiana hasła"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Zmień"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Obecne hasło"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nowe hasło"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Potwierdzenie hasła"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Użytkownik będzie mógł zmienić hasło podczas następnego logowania"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Ustawienie hasła teraz"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Nie można automatycznie dołączyć do tego typu domeny"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Nie odnaleziono takiej domeny lub obszaru"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Nie można zalogować jako „%s” w domenie %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Nieprawidłowe hasło, proszę spróbować ponownie"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Nie można połączyć z domeną %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Usunięcie użytkownika się nie powiodło"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Unieważnienie zdalnie zarządzanego użytkownika się nie powiodło"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Nie można usunąć własnego konta."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "Użytkownik „%s” jest nadal zalogowany"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Usunięcie nadal zalogowanego użytkownika może pozostawić system w niespójnym "
+"stanie."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Zachować pliki użytkownika „%s”?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Możliwe jest zachowanie katalogu domowego, kolejki poczty i plików "
+"tymczasowych podczas usuwania konta użytkownika."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Usuń pliki"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Zachowaj pliki"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Na pewno unieważnić zdalnie zarządzane konto użytkownika „%s”?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Usuń"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Konto jest wyłączone"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Zostanie ustawione podczas następnego logowania"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Brak"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Zalogowano"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Skontaktowanie się z usługą kont się nie powiodło"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Proszę się upewnić, że usługa AccountService jest zainstalowana i włączona."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Należy odblokować ten panel, aby zmienić to ustawienie"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Usuwa wybrane konto użytkownika"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Aby usunąć wybrane konto użytkownika,\n"
+"najpierw należy kliknąć ikonę *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Odblokowanie umożliwi dodawanie użytkowników i zmianę ustawień"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Użytkownicy"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Sesja musi zostać ponownie uruchomiona, aby zastosować zmiany"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Uruchom ponownie"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Zamknij"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Modyfikuj awatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Imię i nazwisko"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Modyfikuj"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Logowanie za pomocą _odcisku palca"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Logowanie a_utomatyczne"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Aktywność konta"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administratorzy mogą dodawać i usuwać innych użytkowników oraz zmieniać "
+"ustawienia dla wszystkich użytkowników."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Kontrola rodzicielska"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Otwiera program do sterowania kontrolą rodzicielską."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Usuń użytkownika…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Inni użytkownicy"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Dodaj użytkownika…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Nie odnaleziono użytkowników"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Odblokowanie umożliwi dodanie konta użytkownika."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Dodawanie lub usuwanie użytkowników i zmienianie hasła"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Logowanie;Automatyczne;Historia;Sesja;Nazwa;Odcisk;Palców;Linie;Linii;"
+"Papilarne;Papilarnych;Awatar;Avatar;Logo;Twarz;Obrazek;Hasło;Konto;Konta;"
+"Administrator;Firmowe;Centralne;Uwierzytelnianie;Authentication;Enterprise;"
+"Kerberos;KRB5;Hesiod;LDAP;NSS;NIS;Winbind;Samba;SSSD;IPA;FreeIPA;Kontrola "
+"rodzicielska;Ograniczanie;Restrykcje;Limity;Ograniczenia programów;"
+"Ograniczenia aplikacji;Ograniczenia przeglądarki internetowej;WWW;OARS;"
+"Użycie;Użytek;Czas korzystania;Limit korzystania;Dziecko;Dzieciak;Dzieci;"
+"Children;Kids;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Zapisz"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Login administratora domeny"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Aby używać tej logowania firmowego, komputer wymaga zapisania\n"
+"do domeny. Należy poprosić administratora sieci, aby wpisał\n"
+"hasło domeny w tym miejscu."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nazwa administratora"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Hasło administratora"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Zarządzanie kontami użytkowników"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Wymagane jest uwierzytelnienie, aby zmienić dane użytkowników"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Nowe hasło musi się różnić od poprzedniego."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Proszę zmienić jakieś litery i cyfry."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Proszę trochę bardziej zmienić hasło."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Hasło bez nazwy użytkownika byłoby silniejsze."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Proszę unikać używania swojego imienia lub nazwiska w haśle."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Proszę unikać niektórych słów użytych w haśle."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Proszę unikać często używanych słów."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Proszę unikać zmieniania kolejności liter w istniejących słowach."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Proszę użyć więcej cyfr."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Proszę użyć więcej wielkich liter."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Proszę użyć więcej małych liter."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+"Proszę użyć więcej znaków specjalnych, takich jak znaki interpunkcyjne."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Proszę użyć mieszanki liter, cyfr i znaków interpunkcyjnych."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Proszę unikać powtarzania tego samego znaku."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Proszę unikać powtarzania tego samego rodzaju znaków: należy mieszać litery, "
+"liczby i znaki interpunkcyjne."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Proszę unikać ciągów takich jak 1234 lub abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Hasło musi być dłuższe. Proszę dodać więcej liter, cyfr i znaków "
+"interpunkcyjnych."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Należy mieszać wielkie i małe litery oraz dodać cyfrę lub dwie."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Dodanie więcej liter, liczb i znaków interpunkcyjnych wzmocni hasło."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Uwierzytelnienie się nie powiodło"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Nowe hasło jest za krótkie"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Nowe hasło jest zbyt proste"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Nowe hasło jest zbyt podobne do poprzedniego"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Nowe hasło zostało już niedawno użyte."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Nowe hasło musi zawierać znaki numeryczne lub specjalne"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Nowe hasło jest takie same jak poprzednie"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Hasło zostało zmienione po początkowym uwierzytelnieniu."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Nowe hasło nie zawiera wystarczającej liczby różnych znaków"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Nieznany błąd"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Nazwa użytkownika zwykle powinna zawierać tylko małe litery z alfabetu "
+"łacińskiego, cyfry oraz te znaki: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Ta nazwa użytkownika jest niedostępna. Proszę wybrać inną."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Nazwa użytkownika jest za długa."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Mapuj przyciski"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Mapuje przyciski do funkcji"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Aby zmodyfikować skrót, należy wybrać działanie „Wyślij klawisze”, wcisnąć "
+"przycisk skrótu klawiszowego i przytrzymać nowe klawisze lub nacisnąć "
+"klawisz Backspace, aby wyczyścić obecne."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "Za_mknij"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Proszę stuknąć znaczniki docelowe po ich pojawieniu się na ekranie, aby "
+"skalibrować tablet."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Wykryto błędne kliknięcie, ponowne uruchamianie…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "%d. przycisk"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Określone przez program"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Wysłanie naciśnięcia klawisza"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Przełączenie monitora"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Ekran pomocy"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tablet zamontowany w panelu laptopa"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tablet zamontowany w zewnętrznym ekranie"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Tablet jako urządzenie zewnętrzne"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Oddzielny panel"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Wszystkie ekrany"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Tryb tabletu"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Bezwzględne pozycjonowanie rysika"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientacja leworęczna"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Klawisze na tablecie i Express Keys™ są obrócone do używania lewą ręką"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapowanie do monitora"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Zachowanie proporcji"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Używanie tylko części powierzchni tabletu, aby zachować proporcje monitora"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Skalibruj"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nie wykryto tabletu"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Proszę podłączyć lub włączyć tablet firmy Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Siła nacisku czubka"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Lekka"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Nacisk czubka rysika"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Mocna"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "1. przycisk"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "2. przycisk"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "3. przycisk"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Siła nacisku gumki"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Nacisk gumki"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Kliknięcie środkowym przyciskiem myszy"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Kliknięcie prawym przyciskiem myszy"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Dalej"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Aerograf z czujnikiem nacisku i pochylenia oraz zintegrowanym suwakiem"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Aerograf z czujnikiem nacisku, pochylenia i obrotu"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standardowy rysik z czujnikiem nacisku i pochylenia"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standardowy rysik z czujnikiem nacisku"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tablet firmy Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Ustawienie mapowania przycisków i dostosowanie wrażliwości rysika dla "
+"tabletów graficznych"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Rysik;Stylus;Gumka;Mysz;Myszka;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Nowy skrót…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Punkty dostępu"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Anulowano działanie"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Błąd:</b> odmowa dostępu podczas zmiany ustawień"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Błąd:</b> błąd wyposażenia komórkowego"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Nie zarejestrowano"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Zarejestrowano"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Wyszukiwanie"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Odmowa"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Informacje o modemie"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Stan modemu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operator"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Typ sieci"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Stan sieci"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Własny numer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Informacje o urządzeniu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Wersja oprogramowania sprzętowego"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Tylko 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Tylko 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Tylko 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Tylko 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (preferowane), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (preferowane), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (preferowane), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (preferowane), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (preferowane), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (preferowane), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (preferowane), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (preferowane), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (preferowane), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (preferowane), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (preferowane), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (preferowane), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (preferowane), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (preferowane), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (preferowane), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (preferowane), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (preferowane)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (preferowane), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Nieznany"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Odblokowanie karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Odblokuj"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Proszę podać kod PIN dla %d. karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Proszę podać kod PIN, aby odblokować kartę SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Proszę podać kod PUK dla %d. karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Proszę podać kod PUK, aby odblokować kartę SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Podano błędne hasło. Pozostała %1$u próba"
+msgstr[1] "Podano błędne hasło. Pozostały %1$u próby"
+msgstr[2] "Podano błędne hasło. Pozostało %1$u prób"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Pozostała %u próba"
+msgstr[1] "Pozostały %u próby"
+msgstr[2] "Pozostało %u prób"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Podano błędne hasło."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Kod PUK musi być liczbą ośmio­cyfrową"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Proszę podać nowy kod PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Kod PIN musi być liczbą o czterech do ośmiu cyfr"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Odblokowywanie…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Brak karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Proszę włożyć kartę SIM, aby używać tego modemu"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "Karta SIM jest zablokowana"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Internet przez sieć komórkową"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Dostęp do Internetu za pomocą sieci komórkowej"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "I_nternet podczas roamingu"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Dostęp do Internetu podczas używania roamingu"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Tryb sieci"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Sieć"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Nazwy punktów dostępu"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_Blokada SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Zablokuj kartę SIM za pomocą kodu PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "_Informacje o modemie"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Niepowodzenie telefonu"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Brak połączenia z telefonem"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Działanie jest niedozwolone"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Działanie jest nieobsługiwane"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Nie włożono karty SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Wymagany jest kod PIN karty SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Wymagany jest kod PUK karty SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Niepowodzenie karty SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Karta SIM jest zajęta"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Niewłaściwe hasło"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Wymagany jest kod PIN2 karty SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Wymagany jest kod PUK2 karty SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Nie odnaleziono"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Brak zasięgu sieci"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Przekroczenie czasu oczekiwania sieci"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Usługi GPRS są niedozwolone"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming jest niedozwolony w tym położeniu"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Nieokreślony błąd GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Brak błędu"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Anulowano działanie"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Odmowa dostępu"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Nieznany błąd"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Tryb sieci"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatycznie"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Wybór sieci"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Odśwież dostawców sieci"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "%d. karta SIM"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Włącz sieć komórkową"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nie odnaleziono adapterów WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+"Proszę się upewnić, że urządzenie bezprzewodowej sieci WAN/komórkowe jest "
+"podłączone"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+"Bezprzewodowa sieć WAN jest wyłączona, kiedy tryb samolotowy jest włączony"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Wyłącz tryb samolotowy"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Połączenie internetowe"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Karta SIM używana do dostępu do Internetu"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Blokada SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Dalej"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "Za_blokuj kartę SIM za pomocą kodu PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Zmień kod PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Proszę podać obecny kod PIN, aby zmienić ustawienia blokady SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Sieć komórkowa"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Konfiguracja połączeń telefonicznych i komórkowych"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "komórkowa;komórka;wwan;telefon;telefonia;sim;pin;puk;mobilna;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Narzędzie do konfigurowania środowiska GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Główny interfejs do konfigurowania komputera."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Projekt GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Wyświetla numer wersji"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Wyświetla więcej komunikatów"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Wyszukuje tekst"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Wyświetla listę dostępnych paneli i kończy działanie"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel do wyświetlenia"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [PARAMETR…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Kategorie ustawień"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Prywatność"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Dostępne panele:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Wszystkie ustawienia"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menu główne"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Ostrzeżenie: wersja rozwojowa"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Ta wersja Ustawień powinna być używana tylko w celach rozwojowych. Może "
+"występować niewłaściwe zachowanie komputera, utrata danych i inne "
+"nieoczekiwane problemy. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Pomoc"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Ogólne"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Zakończenie działania"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Wyszukiwanie"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panele"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Powrót do poprzedniego panelu"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Anulowanie wyszukiwania"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferencje;Ustawienia;Konfiguracja;Opcje;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Identyfikator ostatnio otwartego panelu ustawień"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Identyfikator ostatnio otwartego panelu ustawień. Nierozpoznane wartości "
+"będą ignorowane i zostanie otwarty pierwszy panel na liście."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Wyświetlanie ostrzeżenia podczas uruchamiania rozwojowej wersji Ustawień"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Czy Ustawienia mają wyświetlać ostrzeżenie podczas uruchamiania wersji "
+"rozwojowej."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Początkowy stan okna"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Krotka zawierająca początkową szerokość, wysokość i stan maksymalizacji okna "
+"programu."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u wyjście"
+msgstr[1] "%u wyjścia"
+msgstr[2] "%u wyjść"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u wejście"
+msgstr[1] "%u wejścia"
+msgstr[2] "%u wejść"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Dźwięki systemowe"

--- a/po/pt.po
+++ b/po/pt.po
@@ -13,9 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.8\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-12 15:11+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-13 19:53+0100\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <https://l10n.gnome.org/teams/pt/>\n"
@@ -29,100 +28,7 @@ msgstr ""
 "X-Source-Language: C\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Barramento do sistema"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Acesso total"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Barramento da sessão"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Dispositivos"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Acesso total a /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Rede"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Tem acesso à rede"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Início"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Apenas-leitura"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Sistema de ficheiros"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Definições"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Pode alterar as definições"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s tem as seguintes permissões internas. Estas não podem ser alteradas. Caso "
-"esteja inseguro acerca delas, considere remover a aplicação."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u tipo de ficheiro e ligação que é aberto pela aplicação"
-msgstr[1] "%u tipos de ficheiro e ligação que são abertos pela aplicação"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> é usado para abrir os seguintes tipos de ficheiros e ligações."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s de espaço em disco utilizado."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -138,7 +44,6 @@ msgid "Install some…"
 msgstr "Instale algumas…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Abrir"
 
@@ -162,24 +67,13 @@ msgstr "Procurar"
 msgid "Receive system searches and send results."
 msgstr "Receber as pesquisas do sistema e enviar os resultados."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Inativo"
 
@@ -345,80 +239,20 @@ msgstr "Limpar cache…"
 msgid "Control various application permissions and settings"
 msgstr "Controlar várias permissões e definições de aplicações"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplicação;flatpak;permissão;definição;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Selecionar uma foto"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Cancelar"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Abrir"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "múltiplos tamanhos"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Nenhum fundo de área de trabalho"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Fundo atual"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Estilo"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Predefinição"
 
@@ -442,7 +276,6 @@ msgstr "Aparência"
 msgid "Change your background image or the UI colors"
 msgstr "Alterar a sua imagem de fundo ou as cores da Interface do Utilizador"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -500,9 +333,7 @@ msgstr "O Modo de avião físico está ligado"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Desligue o interruptor do modo de avião para ativar o Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -510,7 +341,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Ligar e desligar o Bluetooth e ligar os seus dispositivos"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "partilhar;partilha;bluetooth;obex;"
@@ -544,95 +374,33 @@ msgstr "Nenhuma aplicação requisitou acesso à câmara"
 msgid "Protect your pictures"
 msgstr "Proteja as suas fotos"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "câmara;fotos;vídeo;webcam;bloquear;privado;privacidade;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Coloque o seu dispositivo de calibração sobre o quadrado e clique em "
-"“Iniciar”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Mova o dispositivo de calibração para a posição de calibrar e clique em "
-"“Prosseguir”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Mova o dispositivo de calibração para a posição de superfície e clique em "
-"“Prosseguir”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Fechar a tampa do portátil"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Ocorreu um erro interno do qual não foi possível recuperar."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "As ferramentas necessárias para calibrar não estão instaladas."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "O perfil não pôde ser gerado."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Impossível obter o ponto branco pretendido."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Terminado!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Falha na calibração!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Pode remover o dispositivo de calibração."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Não incomodar o dispositivo de calibração durante o processo"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibração do ecrã"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancelar"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -649,140 +417,6 @@ msgstr "_Retomar"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Concluído"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Ecrã do portátil"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Webcam interna"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Digitalizadora %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Câmara %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Impressora %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webcam %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Ativar a gestão de cor para %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Ver os perfis de cor para %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Não calibrado"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Predefinição: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Espaço de cores: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Perfil de teste: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Selecionar o ficheiro de perfil ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importar"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Perfis ICC suportados"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Todos os ficheiros"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Ecrã"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Gravar o perfil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Gravar"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Criar um perfil de cor para o dispositivo selecionado"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Impossível detetar o instrumento de medição. Certifique-se que está ligado e "
-"corretamente instalado."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "O instrumento de medição não suporta traçar o perfil da impressora."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "O tipo de dispositivo não é atualmente suportado."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -901,9 +535,9 @@ msgstr "Requer suporte em que se possa escrever"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Poderá considerar úteis estas instruções em como utilizar o perfil em "
 "sistemas <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e "
@@ -918,8 +552,8 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Problemas detetados. O perfil poderá não funcionar corretamente. <a href="
-"\"\">Ver detalhes.</a>"
+"Problemas detetados. O perfil poderá não funcionar corretamente. <a "
+"href=\"\">Ver detalhes.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -927,7 +561,6 @@ msgstr "_Importar ficheiro…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -939,9 +572,7 @@ msgstr ""
 "Cada dispositivo necessita de um perfil de cor atualizado para poder ser "
 "gerido."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Aprenda mais"
 
@@ -1073,82 +704,6 @@ msgstr "D65 (Fotografia e gráficos)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Espaço padrão"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Perfil de teste"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automático"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Qualidade reduzida"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Qualidade média"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Qualidade elevada"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB predefinido"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK predefinido"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Cinzento predefinido"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Dados de calibração disponibilizados pelo fabricante"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Não é possível realizar correção de ecrã inteiro com este perfil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Este dispositivo poderá já não ser preciso"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Cor"
@@ -1159,14 +714,9 @@ msgid ""
 msgstr ""
 "Calibre a cor dos seus dispositivos, tais como ecrãs, câmaras ou impressoras"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Cor;ICC;Perfil;Calibrar;Impressora;Ecrã;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Outro…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1181,13 +731,8 @@ msgid "No languages found"
 msgstr "Nenhum idioma encontrado"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Mais…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Desbloquear para alterar as definições"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1217,151 +762,6 @@ msgstr "Decremento de hora"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Decremento de minuto"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Hoje"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Ontem"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e de %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d hora"
-msgstr[1] "%d horas"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuto"
-msgstr[1] "%d minutos"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d segundo"
-msgstr[1] "%d segundos"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s e %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s e %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 segundos"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Ponto de acesso"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 horas"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e de %B de %Y, %l∶%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e de %B de %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1456,17 +856,11 @@ msgstr "Fuso _horário automático"
 msgid "Requires location services enabled and internet access"
 msgstr "Requer serviço de localização ativado e acesso à Internet"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Ativo"
 
@@ -1474,15 +868,42 @@ msgstr "Ativo"
 msgid "Time Z_one"
 msgstr "Fuso h_orário"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desbloquear"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Formato da hora"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datas"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 segundos"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Calendário"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Números"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Alterar a data e hora, incluindo o fuso horário"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Relógio;Fuso horário;Fuso;Localização;Hora;"
@@ -1528,21 +949,9 @@ msgstr "Aplicações predefinidas"
 msgid "Configure Default Applications"
 msgstr "Configurar as aplicações predefinidas"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "predefinição;aplicação;preferida;média;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Enviar relatórios de problemas técnicos ajuda-nos a melhorar o %s. Os "
-"relatórios são enviados anonimamente e são removidos todos os dados "
-"pessoais. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1560,44 +969,9 @@ msgstr "Diagnósticos"
 msgid "Report your problems"
 msgstr "Relate os seus problemas"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnósticos;falha;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Ligado"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Desligado"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Aplicar as alterações?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "As alterações não foram aplicadas"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Isto pode ser devido a limitações do equipamento informático."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1647,31 +1021,6 @@ msgstr "Ecrã principal"
 msgid "Night Light"
 msgstr "Luz noturna"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Paisagem"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Retrato direito"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Retrato esquerdo"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Paisagem (invertida)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1695,6 +1044,17 @@ msgstr "Ajustar para TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Dimensionar"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Deslocamento natural"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1790,7 +1150,6 @@ msgstr "Ecrãs"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Alterar como utilizar os monitores e projetores ligados"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1798,80 +1157,6 @@ msgid ""
 msgstr ""
 "Painel;Projetor;xrandr;Ecrã;Resolução;Atualizar;Monitor;Noturno;Noite;Luz;"
 "Azul;cor;redshift;anoitecer;amanhecer;nascer do sol;pôr do sol;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "O Arranque Seguro está ativo"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"O arranque seguro evita que software malicioso seja carregado quando o "
-"dispositivo inicia. Está atualmente ligado e a funcionar corretamente."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "O Arranque Seguro tem problemas"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"O arranque seguro evita que software malicioso seja carregado quando o "
-"dispositivo inicia. Está atualmente ligado, mas não funcionará devido a ter "
-"uma chave inválida."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Os problemas de arranque seguro podem muitas vezes ser resolvidos a partir "
-"das definições de firmware UEFI (BIOS) do seu computador e o fabricante do "
-"seu equipamento pode fornecer informações sobre como o fazer."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Para obter ajuda, entre em contacto com o seu fabricante de equipamento ou "
-"fornecedor de suporte de TI."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "O Arranque Seguro está desligado"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"O arranque seguro evita que software malicioso seja carregado quando o "
-"dispositivo arranca. Está atualmente desligado."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"O arranque seguro pode muitas vezes ser ligado a partir das definições de "
-"firmware UEFI (BIOS) do seu computador. Para obter ajuda, contacte o "
-"fabricante do seu equipamento ou o fornecedor de suporte informático."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1886,132 +1171,9 @@ msgstr ""
 "Para obter mais informações, entre em contato com o fabricante de hardware "
 "ou suporte a TI."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Aprovado"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Falhou"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Dispositivo está em conformidade com o nível HSI %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Nível de segurança 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Este dispositivo não tem proteção contra problemas de segurança de hardware. "
-"Isso pode ser devido a um problema de configuração de hardware ou firmware. "
-"Recomenda-se entrar em contato com o seu fornecedor de suporte de TI."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Nível de segurança 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Este dispositivo tem proteção mínima contra problemas de segurança de "
-"hardware. Este é o nível mais baixo de segurança do dispositivo e apenas "
-"fornece proteção contra simples ameaças à segurança."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Nível de segurança 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Este dispositivo tem proteção básica contra problemas de segurança de "
-"hardware. Isto fornece proteção contra algumas ameaças comuns à segurança."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Nível de segurança 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Este dispositivo tem proteção estendida contra problemas de segurança de "
-"hardware. Este é o mais alto nível de segurança do dispositivo e fornece "
-"proteção contra ameaças avançadas à segurança."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Nível de segurança"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Os níveis de segurança não estão disponíveis para este dispositivo."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Contacte o fabricante do seu equipamento para obter ajuda com atualizações "
-"de segurança."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Poderá ser possível resolver este problema nas definições de firmware UEFI "
-"do dispositivo, ou por um técnico de suporte."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Poderá ser possível resolver este problema nas definições de firmware UEFI "
-"do dispositivo."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Poderá ser possível a um técnico de apoio resolver este problema."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2025,338 +1187,9 @@ msgstr "Nível 2"
 msgid "Level 3"
 msgstr "Nível 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Protegido contra software malicioso quando o dispositivo é iniciado."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "O Arranque Seguro tem problemas"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Alguma proteção quando o dispositivo é iniciado."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "O Arranque Seguro está desligado"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Sem proteção quando o dispositivo é iniciado."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Este problema poderia ter sido causado por uma alteração nas definições de "
-"firmware UEFI, uma alteração na configuração do sistema operativo, ou devido "
-"a software malicioso neste sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Este problema poderia ter sido causado por uma alteração nas definições do "
-"firmware UEFI, ou devido a software malicioso neste sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Este problema poderia ter sido causada por uma alteração na configuração do "
-"sistema operativo, ou devido a software malicioso neste sistema."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Expostos a sérias ameaças à segurança."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Proteção limitada contra simples ameaças à segurança."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Protegido contra ameaças comuns à segurança."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Protegido contra uma ampla gama de ameaças à segurança."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Proteção abrangente"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Sem eventos"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Proteção de gravação de firmware"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Bloqueio de proteção de gravação de firmware"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Região do BIOS de firmware"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Descritor de BIOS de firmware"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Proteção de DMA pré-arranque"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Arranque verificado do Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM protegido"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Política de erros do Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Fuse Intel BootGuard OTP"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET ativado"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET Ativo"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "RAM encriptada"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Proteção IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Bloqueio do Kernel Linux"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Verificação do Kernel Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux Swap"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Suspender para a RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Suspender para inativo"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Chave de plataforma UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Arranque Seguro UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Configuração da plataforma TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Reconstrução TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Modo de fabrico do mecanismo de gestão Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Substituição do mecanismo de gestão Intel"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Versão do mecanismo de gestão Intel"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Atualizações de firmware"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Atestado de firmware"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Verificação do atualizador do firmware"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Depuração de plataforma"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Verificações de segurança do processador"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Proteção de reversão AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Proteção de repetição de firmware AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Proteção de gravação de firmware AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Plataforma Fused"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Válido"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Não válido"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Não ativado"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Bloqueado"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Não bloqueado"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Encriptado"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Não encriptado"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Contaminado"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Não contaminado"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Encontrado"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Não encontrado"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Suportado"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Não suportado"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2366,7 +1199,6 @@ msgstr "Segurança do dispositivo"
 msgid "Host firmware security status"
 msgstr "Estado de segurança do firmware anfitrião"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2374,49 +1206,6 @@ msgid ""
 msgstr ""
 "ecrã;bloquear;trancar;diagnósticos;falha;privado;recente;temporário;tmp;"
 "índice;nome;rede;identidade;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Não disponível"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logotipo do sistema"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2510,11 +1299,6 @@ msgstr "Acerca"
 msgid "View information about your system"
 msgstr "Ver informação acerca do sistema"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2592,6 +1376,12 @@ msgstr "Iniciadores"
 msgid "Launch help browser"
 msgstr "Navegador de ajuda"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Definições"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Calculadora"
@@ -2613,7 +1403,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Procurar"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
@@ -2662,15 +1452,6 @@ msgstr "Reduzir o tamanho do texto"
 msgid "High contrast on or off"
 msgstr "Ativar ou desativar o alto contraste"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nenhuma fonte de introdução encontrada"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Outro"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Adicionar uma fonte de introdução"
@@ -2703,108 +1484,9 @@ msgstr "Preferências"
 msgid "View Keyboard Layout"
 msgstr "Ver disposição do teclado"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Remover"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Atalhos personalizados"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Tecla de carateres alternativos"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"A tecla de caracteres alternativos pode ser usada para inserir caracteres "
-"adicionais. Estes são, por vezes, impressos como uma terceira opção no seu "
-"teclado."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt esquerdo"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt direito"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Super esquerdo"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Super direito"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tecla menu"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl direito"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Tecla de composição"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"A tecla de composição permite a introdução de uma grande variedade de "
-"caracteres. Para a utilizar, prima composição depois uma sequência de "
-"caracteres. Por exemplo, a tecla composição seguida de <b>C</b> e <b>o</b> "
-"irá introduzir <b>©</b>, <b>a</b> seguida de <b>'</b> irá introduzir <b>á</"
-"b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"As fontes de entrada podem ser comutadas usando o atalho do teclado %s.\n"
-"Isto pode ser alterado nas definições do atalho do teclado."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2834,45 +1516,21 @@ msgstr "Entrada de caracteres especiais"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Métodos para inserir símbolos e variantes de letras usando o teclado."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de carateres alternativos"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composição"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Atalhos de teclado"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Ver e personalizar atalhos"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modificado"
-msgstr[1] "%d modificados"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Repor todos os atalhos?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Repor os atalhos pode afetar os seus atalhos personalizados. Isto não pode "
-"ser desfeito."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Repor tudo"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2912,33 +1570,6 @@ msgstr "Adicionar atalho"
 msgid "No keyboard shortcut found"
 msgstr "Nenhuma tecla de atalho encontrada"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s já está a ser usado para %s. Caso o reponha, %s será desativado"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Insira um novo atalho"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Definir um atalho personalizado"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Definir um atalho"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Insira um novo atalho para %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Adicionar um atalho personalizado"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Remover"
@@ -2950,7 +1581,6 @@ msgstr "_Substituir"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "Definir"
 
@@ -2986,6 +1616,11 @@ msgstr "Nenhum"
 msgid "Reset the shortcut to its default value"
 msgstr "Repor o atalho para o seu valor predefinido"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Usar a impressora por predefinição"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Teclado"
@@ -2998,7 +1633,6 @@ msgstr ""
 "Alterar teclas de atalho e definir as suas preferências de escrita, esquemas "
 "de teclado e fontes de entrada"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3040,7 +1674,6 @@ msgstr "Nenhuma aplicação requisitou acesso à localização"
 msgid "Protect your location information"
 msgstr "Proteger os seus dados de localização"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "localização;gps;privado;privacidade;"
@@ -3075,7 +1708,6 @@ msgstr "Nenhuma aplicação requisitou acesso ao microfone"
 msgid "Protect your conversations"
 msgstr "Proteja as suas conversas"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "microfone;gravação;aplicação;privacidade;"
@@ -3105,81 +1737,140 @@ msgstr "Esquerdo"
 msgid "Right"
 msgstr "Direito"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Localizações onde procurar"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Rato"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Velocidade do rato"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Deslocamento natural"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Rolar abaixo"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "O deslocamento move o conteúdo, não a vista."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "O deslocamento move o conteúdo, não a vista."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Ativo"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Painel tátil"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Velocidade do painel tátil"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Tocar para clicar"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Tocar para clicar"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Deslocamento com dois dedos"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Desativar a imagem"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Painel tátil (relativo)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Deslocamento lateral"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Rolar abaixo"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dois-lados"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Tente clicar, realizar duplo clique e deslocar"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinco cliques, hora de GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Clique duplo, botão principal"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Clique único, botão principal"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Clique duplo, botão do meio"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Clique único, botão do meio"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Clique duplo, botão secundário"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Clique único, botão secundário"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3192,7 +1883,6 @@ msgstr ""
 "Alterar a sensibilidade do seu rato ou painel tátil e escolher entre destro "
 "ou canhoto"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Trackpad;Cursor;Clique;Toque;Duplo;Botão;Trackball;Deslocar;"
@@ -3273,7 +1963,6 @@ msgstr "Multitarefa"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Gerir preferências para produtividade e multitarefa"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3281,20 +1970,11 @@ msgstr ""
 "Multitarefas;Multitarefa;Produtividade;Personalização;Ambiente de trabalho;"
 "Desktop;Canto ativo;Áreas de trabalho;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Algo correu mal. Contacte o seu fornecedor de software."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "O gestor de redes tem de estar em execução."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Outros dispositivos"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3306,59 +1986,16 @@ msgstr "Adicionar ligação"
 msgid "Not set up"
 msgstr "Indefinido"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Rede insegura (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Rede segura (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Rede segura (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Rede segura (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Rede segura"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Ligado"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opções…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Ligar o ponto de acesso há de desligá-lo de %s, e não será possível aceder à "
-"Internet por Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Requer um mínimo de 8 caracteres"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3408,20 +2045,6 @@ msgstr "Auto-gerar palavra-passe"
 msgid "_Turn On"
 msgstr "_Ligar"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Parar o ponto de acesso e desligar quaisquer utilizadores?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Parar o ponto de acesso"
-
 # Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
@@ -3468,90 +2091,13 @@ msgstr "Redes visíveis"
 msgid "NetworkManager needs to be running"
 msgstr "O gestor de redes tem de estar em execução"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Algo correu mal. Contacte o seu fornecedor de software."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Segurança 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Segurança"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Guardar"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanente"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Aleatório"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Estável"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"O endereço MAC inserido aqui será usado como endereço de equipamento "
-"informático nas redes em que este dispositivo está ligado. Esta "
-"funcionalidade é conhecida como clonagem ou alteração de MAC. Exemplo: "
-"00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Perfil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Aberta (Otimizada)"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Empresarial"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nenhuma"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Nunca"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3560,183 +2106,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i dia atrás"
 msgstr[1] "%i dias atrás"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nenhum"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Fraca"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Normal"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Boa"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excelente"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Endereço IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Endereço IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Endereço IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Esquecer a ligação"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Eliminar o perfil de ligação"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Eliminar VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Detalhes"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automático"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identidade"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Eliminar endereço"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Eliminar rota"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Nenhuma"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Chave WEP 40/128-bit (Hex ou ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Frase-passe WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP (802.1x) dinâmico"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA e WPA2 pessoal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA e WPA2 empresarial"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 pessoal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3747,8 +2116,20 @@ msgstr "Força do sinal"
 msgid "Link speed"
 msgstr "Velocidade da ligação"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Segurança"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Endereço IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Endereço IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Endereço do equipamento (MAC)"
 
@@ -3757,12 +2138,17 @@ msgid "Supported Frequencies"
 msgstr "Frequências suportadas"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Rota predefinida"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3826,7 +2212,7 @@ msgstr "Apenas Ligação-Local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
@@ -3870,9 +2256,8 @@ msgstr "Gateway"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automático"
 
@@ -3925,89 +2310,9 @@ msgstr "Automático, apenas DHCP"
 msgid "Prefix"
 msgstr "Prefixo"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Impossível abrir o editor de ligação"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Novo perfil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Definição inválida %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Definição inválida %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importar de ficheiro…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Adicionar VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_egurança"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Impossível importar a ligação VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"O ficheiro “%s” não pode ser lido ou não contém informação reconhecível de "
-"ligação VPN\n"
-"\n"
-"Erro: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Selecionar o ficheiro a importar"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Já existe um ficheiro com o nome “%s”."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "Substitui_r"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Deseja substituir %s com a ligação VPN que está a gravar?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Impossível exportar a ligação VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Não foi possível exportar a ligação VPN “%s” para %s.\n"
-"\n"
-"Erro: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Exportar a ligação VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4021,103 +2326,39 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rede"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controlar como se liga à Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Rede;IP;LAN;Proxy;WAN;Broadband;Banda;larga;Modem;Bluetooth;vpn;vlan;bridge;"
 "bond;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controlar como se liga à redes Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Rede;Wireless;Sem-fios;Wi-Fi;Wifi;IP;LAN;WAN;Broadband;Banda;larga;DNS;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nunca"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "hoje"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "ontem"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Última utilização"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Com cabo"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Adicionar uma nova ligação"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Os detalhes de rede das redes selecionadas, incluindo palavras-passe e "
-"quaisquer configurações personalizadas, serão perdidos."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Esquecer"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Redes Wi-FI conhecidas"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Esquecer"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "A política de sistema proíbe o uso como ponto de acesso"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "O dispositivo sem-fio não suporta o modo ponto de acesso"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"A descoberta automática de proxy Web é utilizada quando não é especificado "
-"um URL de configuração."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr ""
-"Esta opção não é recomendada em redes públicas que não são de confiança."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4136,6 +2377,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Fornecedor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Endereço IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4220,289 +2465,6 @@ msgstr "Ligar o pon_to de acesso Wi-Fi…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Redes Wi-Fi conhecidas"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Estado desconhecido"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Sem gestão"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Indisponível"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "A ligar"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Autenticação necessária"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "A desligar"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Falha na ligação"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Estado desconhecido (em falta)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Falha na configuração"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Falha na configuração de IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Configuração de IP expirou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Eram requeridos segredos mas não foram fornecidos"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Suplicante 802.1x desligado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Falha ao configurar suplicante 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Falha no suplicante 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Suplicante 802.1x demorou demasiado tempo a autenticar-se"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Falha ao iniciar o serviço PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Serviço PPP desligado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Falha no PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Falha ao iniciar o cliente DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Erro no cliente DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Falha no cliente DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Falha ao iniciar o serviço de partilha de ligação"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Falha no serviço de partilha de ligação"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Falha ao iniciar o serviço AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Erro no serviço AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Falha no serviço AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linha ocupada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Sem som de ligação"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Impossível estabelecer uma ligação"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Pedido de ligação expirou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Falha ao tentar ligar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Falha ao inicializar o modem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Falha ao selecionar a APN especificada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Não procurar redes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Registo de rede negado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Expirou o registo de rede"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Falha ao registar na rede pedida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Falha ao verificar o PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Poderá faltar firmware no dispositivo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "A ligação desapareceu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "A ligação existente foi assumida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem não encontrado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Falha na ligação Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "O cartão SIM não está inserido"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Necessário o pin do SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Necessário o PUK do SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM incorreto"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Falha na dependência da ligação"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Falta firmware"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Cabo desligado"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "erro não definido na segurança 802.1x (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "nenhum ficheiro selecionado"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "erro não especificado ao validar o ficheiro eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Chaves privadas DER, PEM, PKCS#12, ou PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Certificados DER ou PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "ficheiro EAP-FAST PAC em falta"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Ficheiros PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4551,14 +2513,6 @@ msgstr "Autenticação _interna"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Permitir apro_visionamento automático PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "nome de utilizador EAP-LEAP em falta"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "palavra-passe EAP-LEAP em falta"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4584,15 +2538,6 @@ msgstr "P_alavra-passe"
 msgid "Sho_w password"
 msgstr "Ver _palavra-passe"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "certificado EAP-PEAP inválido: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "certificado EAP-PEAP inválido: nenhum certificado especificado"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4614,7 +2559,6 @@ msgid "C_A certificate"
 msgstr "Certificado _AC"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4629,63 +2573,6 @@ msgstr "Nenhum certificado AC é _necessário"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versão PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "nome de utilizador EAP em falta"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "palavra-passe EAP em falta"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "identidade EAP-TLS em falta"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "certificado AC EAP-TLS inválido: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "certificado AC EAP-TLS inválido: nenhum certificado especificado"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "chave privada EAP-TLS inválida: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificado de utilizador EAP-TLS inválido: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Chaves privadas não encriptadas são inseguras"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"A chave privada selecionada não parece estar protegida por uma palavra-"
-"passe. Isto poderá permitir que as suas credenciais de segurança sejam "
-"comprometidas. Selecione uma chave privada protegida por palavra-passe.\n"
-"\n"
-"(Pode proteger com palavra-passe a sua chave privada utilizando o openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Escolha o seu certificado pessoal"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Escolha a sua chave privada"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4702,15 +2589,6 @@ msgstr "C_have privada"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Palavra-passe da chave _privada"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "certificado EAP-TTLS inválido: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "certificado EAP-TTLS CA inválido: nenhum certificado especificado"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4733,14 +2611,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domínio"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Erro desconhecido ao validar a segurança 802.11x"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4768,62 +2647,10 @@ msgstr "EAP protegido (PEAP)"
 msgid "Au_thentication"
 msgstr "Au_tenticação"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Selecionar um ficheiro"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "utilizador-leap em falta"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "palavra-chave-leap em falta"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Palavra-passe Wi-Fi em falta."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipo"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "chave-wep em falta"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"chave-wep inválida: a chave com um comprimento de %zu tem de ter apenas "
-"dígitos hexadecimais"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"chave-wep inválida: a chave com um comprimento de %zu tem de ter apenas "
-"carateres ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"chave-wep inválida: comprimento errado de %zu. A chave tem de ter "
-"comprimento 5/13 (ascii) ou 10/26 (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "chave-wep inválida: a frase-passe não pode estar vazia"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "chave-wep inválida: a frase-passe não pode ter menos de 64 carateres"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4848,21 +2675,6 @@ msgstr "Ver cha_ve"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Índice _WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk inválido: comprimento-chave inválido %zu. Tem de ser [8,63] bytes ou "
-"64 dígitos hexadecimais"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk inválido: não foi possível interpretar a chave com 64 bytes como "
-"hexadecimal"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4917,27 +2729,9 @@ msgstr "Notificações no ecrã b_loqueado"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controlar que notificações são apresentadas e o que mostram"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notificações;Faixas;Mensagem;Área de Notificação;Instantâneas;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Outro"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s removido"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Erro ao remover conta"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4961,17 +2755,6 @@ msgstr "Sem ligação à Internet — ligue-se para definir novas contas online"
 msgid "Add an account"
 msgstr "Adicionar uma conta"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Conta %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Remover conta"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Contas online"
@@ -4980,10 +2763,6 @@ msgstr "Contas online"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Ligar-se às suas contas online e decidir como as utilizar"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4991,10 +2770,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Diálogo;Calendário;Correio;Contacto;"
 "ownCloud;Kerberos;IMAP;SMTP;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Tempo desconhecido"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5010,13 +2785,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i hora"
 msgstr[1] "%i horas"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s e %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5028,190 +2796,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minutos"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s até que esteja completamente carregada"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Atenção: restam %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Restam %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Completamente carregada"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Não está a carregar"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Descarregada"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "A carregar"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "A descarregar"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Rato sem fios"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Teclado sem fios"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Fonte de energia de segurança (UPS)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Assistente digital pessoal"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Telemóvel"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Reprodutor multimédia"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Computador"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Dispositivo para jogos"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Bateria"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principal"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Extra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Baterias"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Quando _inativo"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Suspender"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Desligar"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hibernar"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nada"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Quando funciona da bateria"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Quando ligado à corrente"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nunca"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Suspender automaticamente"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Modo de desempenho temporariamente desativado devido à alta temperatura de "
-"funcionamento."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Colo detetado: modo de desempenho temporariamente indisponível. Mova o "
-"dispositivo para uma superfície estável para restaurar."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Modo de desempenho temporariamente desativado."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Bateria fraca: poupança de energia ativada. O modo anterior será restaurado "
-"quando a bateria estiver suficientemente carregada."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Modo poupança de energia ativado por \"%s\"."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Modo de desempenho ativado por \"%s\"."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5272,6 +2856,15 @@ msgstr "100 minutos"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 horas"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bateria"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositivos"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5350,33 +2943,6 @@ msgstr "A funcionar da _bateria"
 msgid "Delay"
 msgstr "Atraso"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Desempenho"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Alto desempenho e utilização de energia."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Equilibrado"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Desempenho padrão e utilização de energia."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Poupança de energia"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Redução do desempenho e do consumo de energia."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Energia"
@@ -5386,7 +2952,6 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Ver o estado da sua bateria e alterar as definições de poupança de energia"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5394,27 +2959,6 @@ msgid ""
 msgstr ""
 "Energia;Dormir;Suspender;Hibernar;Bateria;Brilho;Escurecer;Desligar;"
 "Monitorizar;DPMS;Inativo;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "A impressora “%s” foi eliminada"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Falha ao adicionar uma nova impressora."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Impossível carregar o UI: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Desbloquear para adicionar impressoras e alterar as definições"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5426,7 +2970,6 @@ msgstr ""
 "Adicionar impressoras, ver trabalhos de impressão e decidir como os deseja "
 "imprimir"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Impressora;Pilha;Imprimir;Papel;Tinta;Toner;"
@@ -5434,8 +2977,6 @@ msgstr "Impressora;Pilha;Imprimir;Papel;Tinta;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Adicionar impressora"
 
@@ -5476,29 +3017,6 @@ msgstr ""
 msgid "Username"
 msgstr "Utilizador"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Detalhes da impressora %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Não foi encontrado controlador adequado"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Selecionar ficheiro PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Ficheiros PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Os nomes das impressoras não podem conter ESPAÇO, TAB, #, ou /"
@@ -5507,9 +3025,7 @@ msgstr "Os nomes das impressoras não podem conter ESPAÇO, TAB, #, ou /"
 msgid "Location"
 msgstr "Localização"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Controlador"
 
@@ -5537,140 +3053,20 @@ msgstr "Selecione o controlador da impressora"
 msgid "Loading drivers database…"
 msgstr "A carregar a base de dados de controladores…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Cancelar"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Selecionar"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Impressora JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Impressora LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Um lado"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Margem longa (padrão)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Margem curta (invertida)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Retrato"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Paisagem"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Paisagem invertida"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Retrato invertido"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Retomar"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pausa"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Pendente"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pausado"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Autenticação necessária"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "A processar"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Parado"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Cancelado"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Abortado"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Terminado"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Mover este trabalho para o topo da fila"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u trabalho requer autenticação"
 msgstr[1] "%u trabalhos requerem autenticação"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - Trabalhos ativos"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Insira as credenciais para imprimir em %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5698,323 +3094,17 @@ msgstr "_Autenticar"
 msgid "No Active Printer Jobs"
 msgstr "Sem trabalhos de impressão ativos"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Desbloquear o servidor de impressão"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Desbloquear %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Insira o seu utilizador e palavra-passe para ver as impressoras disponíveis "
-"em %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "A procurar por impressoras"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Porta série"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Porta paralela"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Localização: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Endereço: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "O servidor requer autenticação"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dois lados"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Tipo de papel"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Origem do papel"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Tabuleiro de saída"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolução"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Pré-filtragem GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Páginas por lado"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dois-lados"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientação"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Geral"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Configuração de página"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opções de instalação"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Trabalho"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Qualidade de imagem"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Cor"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Acabamento"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avançado"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Página de teste"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Página de teste"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Selecionar automaticamente"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Predefinição da impressora"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Embutir apenas fontes GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Converter em PS nível 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Converter em PS nível 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Nenhuma pré-filtragem"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Fabricante"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Sem trabalhos ativos"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u Trabalho"
 msgstr[1] "%u Trabalhos"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Limpar as cabeças de impressão"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Com pouco toner"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Sem toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Com pouco revelador"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Sem revelador"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Com pouco de uma das cores"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Sem uma das cores"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Tampa aberta"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Porta aberta"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Com pouco papel"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Sem papel"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Desligada"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Parada"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Depósito de lixo quase cheio"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Depósito de lixo cheio"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Está a aproximar-se o final da vida útil do condutor ótico de imagem"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "O condutor ótico de imagem deixou de funcionar"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Preparada"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Não aceita trabalhos"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "A processar"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6038,6 +3128,10 @@ msgstr "Limpar as cabeças de impressão"
 msgid "Remove Printer"
 msgstr "Remover a impressora"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Sem trabalhos ativos"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6058,16 +3152,21 @@ msgid "Restart"
 msgstr "Reiniciar"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Adicionar impressora…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Adicionar uma impressora…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Sem impressoras"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6075,7 +3174,6 @@ msgstr ""
 "Desculpe! O serviço de impressão do sistema\n"
 "    aparenta estar indisponível."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formatos"
@@ -6103,16 +3201,6 @@ msgstr "A procura pode ser por países ou idiomas."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Antever"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Métrico"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6150,20 +3238,24 @@ msgstr ""
 "A definição do idioma é utilizada para o texto de interface e páginas web. "
 "Os formatos são utilizados para números, datas e moedas."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "A sua Conta"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Idioma"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formatos"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Ecrã de acesso"
 
@@ -6175,102 +3267,9 @@ msgstr "Região e Idioma"
 msgid "Select your display language and formats"
 msgstr "Selecionar o seu idioma de apresentação e formatos"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Disposição;Esquema;Teclado;Introdução;Entrada;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Perguntar o que fazer"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Não fazer nada"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Abrir pasta"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Outro suporte"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Selecione uma aplicação para CDs de áudio"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Selecione uma aplicação para DVDs de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Selecione uma aplicação a executar ao ligar um reprodutor de música"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Selecione uma aplicação a executar ao ligar uma câmara"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Selecione uma aplicação para CDs de dados"
-
-# DVD de áudio
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "áudio DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "disco Blu-ray virgem"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "disco CD virgem"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "disco DVD virgem"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "disco HD DVD virgem"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Disco Blu-ray de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "leitor de e-books"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Disco HD DVD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "CD de imagens"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "CD super vídeo (SVCD)"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "CD de vídeo (VCD)"
-
-# Software Windows
-# Software do Windows
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Aplicação Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6320,7 +3319,6 @@ msgstr "Suportes removíveis"
 msgid "Configure Removable Media settings"
 msgstr "Configurar as definições de suportes removíveis"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6328,114 +3326,6 @@ msgid ""
 msgstr ""
 "dispositivo;sistema;predefinição;aplicação;preferido;cd;dvd;usb;áudio;vídeo;"
 "disco;removível;media;autoiniciar;suporte;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "O ecrã desliga-se em"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 segundos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nunca"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6473,11 +3363,16 @@ msgstr "Período até o ecrã desligar-se após o bloqueio automático."
 msgid "Show _Notifications on Lock Screen"
 msgstr "Ver as _notificações no ecrã bloqueado"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "B_loquear ecrã"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Ignorar novos dispositivos _USB"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6485,30 +3380,25 @@ msgstr ""
 "Impede que novos dispositivos USB interajam com o sistema quando o ecrã está "
 "bloqueado."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Privacidade de ecrã"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Ângulo de visão restrita"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ecrã"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Definições do ecrã"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "ecrã;bloquear;privado;privacidade;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Selecionar localização"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Aceitar"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6539,10 +3429,6 @@ msgstr "Outros"
 msgid "Add Location"
 msgstr "Adicionar localização"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nenhuma aplicação encontrada"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Pesquisa de aplicações"
@@ -6570,94 +3456,14 @@ msgstr ""
 "Controlar que aplicações mostram resultados de pesquisa no Resumo de "
 "Atividades"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Procurar;Pesquisar;Localizar;Índice;Ocultar;Esconder;Privacidade;Resultados;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Sem rede selecionada para partilha"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Redes"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Ligado"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Desligado"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Ativo"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Ativo"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Selecione uma pasta"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Adicionar"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Ativar partilha de ficheiros"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Partilha de ficheiros permite-lhe partilhar a sua Pasta pública com outros "
-"na sua rede atual utilizando: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Se as autenticações remotas estão ativadas, utilizadores remotos podem ligar-"
-"se utilizando o comando de terminal seguro:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Ativar partilha de ficheiros pessoais"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Nome do dispositivo copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Endereço do dispositivo copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Nome de utilizador copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Palavra-passe copiada"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6790,7 +3596,6 @@ msgstr "Pastas"
 msgid "Control what you want to share with others"
 msgstr "Controlar o que deseja partilhar com outros"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6806,10 +3611,6 @@ msgstr "Ativar ou desativar o acesso remoto"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "É necessária autenticação para ativar ou desativar o acesso remoto"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Personalizado"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6842,11 +3643,6 @@ msgstr "Traseiro"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Frontal"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "A testar %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6900,11 +3696,6 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Alerta sonoro"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Silenciar"
@@ -6917,82 +3708,11 @@ msgstr "Som"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Alterar o volume do som, entradas, saídas e os sons de alerta"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Placa;Cartão;Microfone;Volume;Baixar;Balanço;Bluetooth;Auscultadores;Áudio;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Desligado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "A ligar"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Ligado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Erro de autenticação"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "A autenticar"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Funcionalidade reduzida"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Ligado e Autenticado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autenticado às:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Ligado às:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Registado às:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Falha ao autenticar o dispositivo: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Falha ao esquecer o dispositivo: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7026,56 +3746,6 @@ msgstr "Autenticar e ligar"
 msgid "Forget Device"
 msgstr "Esquecer dispositivo"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Erro"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autenticado"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"O subsistema Thunderbolt (boltd) não está instalado ou não pode ser definido "
-"corretamente."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Permitir acesso direto a dispositivos como as acoplagens e GPUs externas."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Apenas dispositivos USB e Display Port podem acoplar."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"O Thunderbolt não pôde ser detetado.\n"
-"A razão pode ser a falta de suporte ao Thunderbolt no sistema, a desativação "
-"dele ou a definição para um nível de segurança não suportado na BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "O suporte ao Thunderbolt foi desativado no BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "O nível de segurança do Thunderbolt não pôde ser determinado."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Erro as alterar o modo direto: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Sem suporte ao Thunderbolt"
@@ -7087,6 +3757,11 @@ msgstr "Não foi possível a ligação ao subsistema do thunderbolt."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Acesso direto"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Permitir acesso direto a dispositivos como as acoplagens e GPUs externas."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7104,7 +3779,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Gerir dispositivos Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacidade;"
@@ -7309,40 +3983,6 @@ msgid "Turn accessibility features on and off using the keyboard"
 msgstr ""
 "Ativar ou desativar funcionalidades de acessibilidade utilizando o teclado"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Predefinição"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Médio"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Grande"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Maior"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Maior ainda"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixels"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "V_er sempre o menu de acessibilidade"
@@ -7456,31 +4096,6 @@ msgstr "Piscar o _ecrã inteiro"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Piscar a _janela inteira"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Curta"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ do ecrã"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ do ecrã"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ do ecrã"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Longa"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7637,7 +4252,6 @@ msgstr "Efeitos de cor"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Tornar mais simples ver, ouvir, escrever, apontar e clicar"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7649,114 +4263,6 @@ msgstr ""
 "Universal;Contraste;Cursor;Zoom;Ampliação;Leitor;Ecrã;Texto;Fonte;Letra;"
 "Tamanho;AccessX;Pegajosas;Lentas;Saltantes;Rato;Duplo;Clique;Assistente;"
 "Velocidade;Repitição;Piscar;visual;audição;digitação;animações;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dia"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dias"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Esvaziar todos os itens do lixo?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Todos os itens no lixo serão apagados permanentemente."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Esvaziar o lixo"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Eliminar todos os ficheiros temporários?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Todos os ficheiros temporários serão apagados permanentemente."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Eliminar ficheiros tem_porários"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dia"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dias"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dias"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Para sempre"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7825,64 +4331,12 @@ msgstr "Histórico de ficheiros e Lixo"
 msgid "Don't leave traces"
 msgstr "Não deixar rastros"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "utilização;recente;histórico;ficheiros;temporário;tmp;privado;privacidade;"
 "lixo;purga;retenção;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Deve coincidir com o endereço Web do seu fornecedor de conta."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Falha ao adicionar conta"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "As palavras-passe não coincidem."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Falha ao registar conta"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Nenhuma forma suportada de autenticar com este domínio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Falha ao ligar-se ao domínio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Este nome de acesso não funcionou.\n"
-"Tente novamente."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Esta palavra-passe de acesso não funcionou.\n"
-"Tente novamente."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Falha ao ligar-se ao domínio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Impossível encontrar o domínio. Talvez o tenha escrito mal?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7935,10 +4389,6 @@ msgstr ""
 "O acesso empresarial permite que uma conta existente gerida centralmente "
 "seja usada neste dispositivo. Pode também utilizar esta conta para aceder "
 "aos recursos da companhia através da Internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Procurar por mais imagens"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8009,222 +4459,6 @@ msgstr "_Eliminar as impressões digitais"
 msgid "Fingerprint Enroll"
 msgstr "Registo de impressão digital"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "o dispositivo precisa de ser reivindicado para executar esta acção"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "o dispositivo já é reclamado por outro processo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "não tem permissão para executar a ação"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "não foram registadas impressões digitais"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Falha de comunicação com o dispositivo durante o registo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Falha na comunicação com o leitor de impressões digitais"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Falha na comunicação com o daemon das impressões digitais"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Falhou ao listar as impressões digitais: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Falhou ao eliminar as impressões digitais gravadas: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Polegar esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Dedo médio esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Dedo indicador _esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Dedo anelar esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Dedo mindinho esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Polegar direito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Dedo médio direito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Dedo indicador _direito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Dedo anelar direito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Dedo mindinho direito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Dedo desconhecido"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Feito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Dispositivo de impressão digital desligado"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "O armazenamento de impressões digitais está cheio"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Falhou ao registar a nova impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Falhou ao iniciar a transcrição do registo: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Falhou ao registar a nova impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Falhou ao terminar a transcrição do registo: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Tire e ponha o seu dedo repetidamente no leitor para registar a sua "
-"impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Regravar este dedo…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Digitalizar um nova impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Falhou em largar o dispositivo de impressão digital %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problemas ao ler o dispositivo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Falhou ao requisitar pelo dispositivo de impressão digital %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Falhou ao obter dispositivos de impressão digital: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Esta semana"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Última semana"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e de %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, às %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sessão terminou"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sessão iniciada"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Atividade da conta"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Anterior"
@@ -8232,18 +4466,6 @@ msgstr "Anterior"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Seguinte"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Selecione uma palavra-passe diferente."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Insira novamente a sua palavra-passe atual."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Impossível alterar a palavra-passe"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8265,6 +4487,10 @@ msgstr "Nova palavra-passe"
 msgid "Confirm Password"
 msgstr "Confirmar palavra-passe"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "As palavras-passe não coincidem."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
@@ -8273,134 +4499,6 @@ msgstr ""
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Definir uma palavra-passe agora"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Impossível ligar-se automaticamente a este tipo de domínio"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Domínio ou reino não encontrado"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Impossível iniciar sessão como %s no domínio %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Palavra-passe inválida. Tente novamente"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Impossível ligar-se ao domínio %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Falha ao eliminar o utilizador"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Falha ao revogar o utilizador gerido remotamente"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Não pode eliminar a sua própria conta."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s ainda tem uma sessão ativa"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Eliminar um utilizador enquanto este tem uma sessão ativa pode deixar o "
-"sistema num estado inconsistente."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Deseja manter os ficheiros de %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"É possível manter a pasta pessoal, spool de email e ficheiros temporários ao "
-"eliminar a conta de um utilizador."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Eliminar os ficheiros"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Manter os ficheiros"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Tem a certeza de que deseja revogar a conta gerida remotamente de %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Eliminar"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Conta desativada"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "A ser definida ao iniciar a próxima sessão"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Nenhuma"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Com sessão ativa"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Falha ao contactar o serviço de contas"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Certifique-se que o AccountService está instalado e ativo."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Este painel deve ser desbloqueado para alterar esta definição"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Eliminar a conta de utilizador selecionada"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Para eliminar a conta de utilizador selecionada,\n"
-"clique primeiro no ícone *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Desbloquear para adicionar utilizadores e alterar as definições"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8429,7 +4527,6 @@ msgid "Full name"
 msgstr "Nome completo"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Editar"
 
@@ -8491,7 +4588,6 @@ msgstr "Desbloquear para criar uma conta de utilizador."
 msgid "Add or remove users and change your password"
 msgstr "Adicionar ou eliminar utilizadores e alterar a sua palavra-passe"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8536,179 +4632,6 @@ msgstr "Gerir contas de utilizador"
 msgid "Authentication is required to change user data"
 msgstr "É necessária autenticação para alterar dados de utilizador"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "A nova palavra-passe tem de ser diferente da antiga."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Tente alterar algumas letras e números."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Tente alterar um pouco mais a palavra-passe."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Uma palavra-passe sem o seu nome de utilizador seria mais segura."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Tente não utilizar o seu nome na palavra-passe."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Tente não utilizar algumas das palavras incluídas na palavra-passe."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Tente evitar palavras comuns."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Tente evitar reordenar palavras existentes."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Tente utilizar mais números."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Tente utilizar mais letras maiúsculas."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Tente utilizar mais letras minúsculas."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Tente utilizar mais caracteres especiais, como pontuação."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Tente utilizar uma mistura de letras, números e pontuação."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Tente evitar repetir o mesmo carácter."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Tente evitar a repetição do mesmo tipo de carácter: deve misturar letras, "
-"números e pontuação."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Tente evitar sequências como 1234 ou abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"As palavras-passe tem de ser longas. Tente adicionar mais letras, números e "
-"pontuação."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Misture letras maiúsculas com minúsculas e tente utilizar um ou dois números."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Adicionar mais letras, números e pontuação há de tornar a palavra-passe mais "
-"forte."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Falha na autenticação"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "A nova palavra-passe é demasiado curta"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "A nova palavra-passe é demasiado simples"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "As palavras-passe antiga e nova são demasiado semelhantes"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "A nova palavra-passe já foi utilizada recentemente."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "A nova palavra-passe tem de conter caracteres numéricos ou especiais"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "As palavras-passe antiga e nova são idênticas"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "A sua palavra-passe foi alterada após se ter autenticado!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "A nova palavra-passe não contém caracteres distintos suficientes"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Erro desconhecido"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"O nome de utilizador apenas pode ser composto por letras minúsculas e "
-"maiúsculas de a-z, dígitos e os seguintes caracteres: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Este nome de utilizador não está disponível. Tente outro."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "O nome de utilizador é demasiado extenso."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8743,52 +4666,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Detetada uma falha de clique, a reiniciar…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Botão %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplicação definida"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Enviar toque de tecla"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Trocar monitor"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Mostrar ajuda no ecrã"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tablet montado no painel do portátil"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tablet montado no ecrã externo"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Dispositivo de tablet externo"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Dispositivo de painel externo"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Todos os ecrãs"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8886,22 +4767,6 @@ msgstr "Clique no botão direito do rato"
 msgid "Forward"
 msgstr "Avançar"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Caneta stylus airbrush com pressão, inclinação e deslizador integrado"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Caneta stylus airbrush com pressão, inclinação e rotação"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Caneta stylus padrão com pressão e inclinação"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Caneta stylus padrão com pressão"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tablet Wacom"
@@ -8912,54 +4777,100 @@ msgstr ""
 "Ver o mapeamento dos botões e ajustar a sensibilidade do estilo de tablets "
 "gráficos"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Caneta;Stylus;Borracha;Rato;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Novo atalho…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Clique secundário _simulado"
+
+# Software Windows
+# Software do Windows
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Aplicação Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Com pouco toner"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Secundário"
+
+# Software Windows
+# Software do Windows
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Aplicação Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Gerir preferências para produtividade e multitarefa"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Pontos de acesso"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Adicionar"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Gravar"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operação cancelada"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Error:</b> Acesso negado a alteração de definições"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Error:</b> Erro de equipamento móvel"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Não registado"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registado"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "A procurar"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Negado"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8991,212 +4902,13 @@ msgstr "Número próprio"
 msgid "Device Details"
 msgstr "Detalhes do dispositivo"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricante"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Versão de firmware"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Apenas 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Apenas 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Apenas 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Apenas 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (Preferencial), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (Preferencial), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (Preferencial), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Preferencial), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Preferencial), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (Preferencial), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (Preferencial), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (Preferencial), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (Preferencial), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (Preferencial), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (Preferencial), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (Preferencial), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (Preferencial), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (Preferencial), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (Preferencial), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (Preferencial), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (Preferencial)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (Preferencial), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Desbloquear o cartão SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Desbloquear"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Forneça o código PIN do SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Inserir o PIN para desbloquear o cartão SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Forneça o código PUK do SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Inserir o PUK para desbloquear o cartão SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9211,26 +4923,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Tem %u tentativa restante"
 msgstr[1] "Tem %u tentativas restantes"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Palavra-passe incorreta introduzida."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "O código PUK deve ser um número de 8 dígitos"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Introduza novo PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "O código PIN deve ser um número de 4-8 dígitos"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "A desbloquear…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9288,94 +4980,6 @@ msgstr "Bloquear SIM com PIN"
 msgid "M_odem Details"
 msgstr "Detalhes do m_odem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Falha no telemóvel"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Sem ligação ao telemóvel"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operação não permitida"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operação não suportada"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Cartão SIM não está inserido"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Necessário PIN do cartão SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Necessário PUK do cartão SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Falha no cartão SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Cartão SIM ocupado"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Palavra-passe incorreta"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Necessário PIN2 do cartão SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Necessário PUK2 do cartão SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Não encontrado"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Sem serviço de rede"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Tempo limite de rede"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Serviços GPRS não permitidos"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming não permitido nesta área de localização"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Erro GPRS não especificado"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Nenhum erro"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Ação cancelada"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Acesso negado"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Erro desconhecido"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Modo de rede"
@@ -9391,11 +4995,6 @@ msgstr "Escolha a rede"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Atualizar operadoras de rede"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9455,7 +5054,6 @@ msgstr "Rede móvel"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configurar ligações telefónicas e de dados móveis"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;wwan;telephony;sim;mobile;"
@@ -9472,41 +5070,13 @@ msgstr "Definições é a sua interface principal para configurar o seu sistema.
 msgid "The GNOME Project"
 msgstr "Projeto GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Mostrar número de versão"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Ativar modo detalhado"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Procurar pela cadeia"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Listar nomes possíveis de painel e sair"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Painel a mostrar"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PAINEL] [ARGUMENTO…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Categorias de definições"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacidade"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Painéis disponíveis:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9564,7 +5134,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Cancelar procura"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferências;Definições;"
@@ -9606,8 +5175,6 @@ msgstr ""
 "Um \"tuple\" contendo a largura inicial, altura e estado maximizado da "
 "janela de aplicação."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9615,8 +5182,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u saída"
 msgstr[1] "%u saídas"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9624,18 +5189,3150 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u entrada"
 msgstr[1] "%u entradas"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sons do sistema"
+#~ msgid "System Bus"
+#~ msgstr "Barramento do sistema"
+
+#~ msgid "Full access"
+#~ msgstr "Acesso total"
+
+#~ msgid "Session Bus"
+#~ msgstr "Barramento da sessão"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Acesso total a /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Tem acesso à rede"
+
+#~ msgid "Home"
+#~ msgstr "Início"
+
+#~ msgid "Read-only"
+#~ msgstr "Apenas-leitura"
+
+#~ msgid "File System"
+#~ msgstr "Sistema de ficheiros"
+
+#~ msgid "Can change settings"
+#~ msgstr "Pode alterar as definições"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s tem as seguintes permissões internas. Estas não podem ser alteradas. "
+#~ "Caso esteja inseguro acerca delas, considere remover a aplicação."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u tipo de ficheiro e ligação que é aberto pela aplicação"
+#~ msgstr[1] "%u tipos de ficheiro e ligação que são abertos pela aplicação"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> é usado para abrir os seguintes tipos de ficheiros e ligações."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s de espaço em disco utilizado."
+
+#~ msgid "Select a picture"
+#~ msgstr "Selecionar uma foto"
+
+#~ msgid "_Open"
+#~ msgstr "_Abrir"
+
+#~ msgid "multiple sizes"
+#~ msgstr "múltiplos tamanhos"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Nenhum fundo de área de trabalho"
+
+#~ msgid "Current background"
+#~ msgstr "Fundo atual"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Coloque o seu dispositivo de calibração sobre o quadrado e clique em "
+#~ "“Iniciar”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Mova o dispositivo de calibração para a posição de calibrar e clique em "
+#~ "“Prosseguir”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Mova o dispositivo de calibração para a posição de superfície e clique em "
+#~ "“Prosseguir”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Fechar a tampa do portátil"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Ocorreu um erro interno do qual não foi possível recuperar."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "As ferramentas necessárias para calibrar não estão instaladas."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "O perfil não pôde ser gerado."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Impossível obter o ponto branco pretendido."
+
+#~ msgid "Complete!"
+#~ msgstr "Terminado!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Falha na calibração!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Pode remover o dispositivo de calibração."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Não incomodar o dispositivo de calibração durante o processo"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Ecrã do portátil"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Webcam interna"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Digitalizadora %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Câmara %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Impressora %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webcam %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Ativar a gestão de cor para %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Ver os perfis de cor para %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Não calibrado"
+
+#~ msgid "Default: "
+#~ msgstr "Predefinição: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Espaço de cores: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Perfil de teste: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Selecionar o ficheiro de perfil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importar"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Perfis ICC suportados"
+
+#~ msgid "All files"
+#~ msgstr "Todos os ficheiros"
+
+#~ msgid "Save Profile"
+#~ msgstr "Gravar o perfil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Criar um perfil de cor para o dispositivo selecionado"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Impossível detetar o instrumento de medição. Certifique-se que está "
+#~ "ligado e corretamente instalado."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "O instrumento de medição não suporta traçar o perfil da impressora."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "O tipo de dispositivo não é atualmente suportado."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espaço padrão"
+
+#~ msgid "Test Profile"
+#~ msgstr "Perfil de teste"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automático"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Qualidade reduzida"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Qualidade média"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Qualidade elevada"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB predefinido"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK predefinido"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Cinzento predefinido"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Dados de calibração disponibilizados pelo fabricante"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Não é possível realizar correção de ecrã inteiro com este perfil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Este dispositivo poderá já não ser preciso"
+
+#~ msgid "Other…"
+#~ msgstr "Outro…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Desbloquear para alterar as definições"
+
+#~ msgid "Today"
+#~ msgstr "Hoje"
+
+#~ msgid "Yesterday"
+#~ msgstr "Ontem"
+
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d hora"
+#~ msgstr[1] "%d horas"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuto"
+#~ msgstr[1] "%d minutos"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d segundo"
+#~ msgstr[1] "%d segundos"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s e %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s e %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Ponto de acesso"
+
+#~ msgid "24-hour"
+#~ msgstr "24 horas"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e de %B de %Y, %l∶%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e de %B de %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Enviar relatórios de problemas técnicos ajuda-nos a melhorar o %s. Os "
+#~ "relatórios são enviados anonimamente e são removidos todos os dados "
+#~ "pessoais. %s"
+
+#~ msgid "On"
+#~ msgstr "Ligado"
+
+#~ msgid "Off"
+#~ msgstr "Desligado"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Aplicar as alterações?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "As alterações não foram aplicadas"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Isto pode ser devido a limitações do equipamento informático."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Paisagem"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Retrato direito"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Retrato esquerdo"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Paisagem (invertida)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "O Arranque Seguro está ativo"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "O arranque seguro evita que software malicioso seja carregado quando o "
+#~ "dispositivo inicia. Está atualmente ligado e a funcionar corretamente."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "O Arranque Seguro tem problemas"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "O arranque seguro evita que software malicioso seja carregado quando o "
+#~ "dispositivo inicia. Está atualmente ligado, mas não funcionará devido a "
+#~ "ter uma chave inválida."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Os problemas de arranque seguro podem muitas vezes ser resolvidos a "
+#~ "partir das definições de firmware UEFI (BIOS) do seu computador e o "
+#~ "fabricante do seu equipamento pode fornecer informações sobre como o "
+#~ "fazer."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Para obter ajuda, entre em contacto com o seu fabricante de equipamento "
+#~ "ou fornecedor de suporte de TI."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "O Arranque Seguro está desligado"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "O arranque seguro evita que software malicioso seja carregado quando o "
+#~ "dispositivo arranca. Está atualmente desligado."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "O arranque seguro pode muitas vezes ser ligado a partir das definições de "
+#~ "firmware UEFI (BIOS) do seu computador. Para obter ajuda, contacte o "
+#~ "fabricante do seu equipamento ou o fornecedor de suporte informático."
+
+#~ msgid "Passed"
+#~ msgstr "Aprovado"
+
+#~ msgid "Failed"
+#~ msgstr "Falhou"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Dispositivo está em conformidade com o nível HSI %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Nível de segurança 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Este dispositivo não tem proteção contra problemas de segurança de "
+#~ "hardware. Isso pode ser devido a um problema de configuração de hardware "
+#~ "ou firmware. Recomenda-se entrar em contato com o seu fornecedor de "
+#~ "suporte de TI."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Nível de segurança 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Este dispositivo tem proteção mínima contra problemas de segurança de "
+#~ "hardware. Este é o nível mais baixo de segurança do dispositivo e apenas "
+#~ "fornece proteção contra simples ameaças à segurança."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Nível de segurança 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Este dispositivo tem proteção básica contra problemas de segurança de "
+#~ "hardware. Isto fornece proteção contra algumas ameaças comuns à segurança."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Nível de segurança 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Este dispositivo tem proteção estendida contra problemas de segurança de "
+#~ "hardware. Este é o mais alto nível de segurança do dispositivo e fornece "
+#~ "proteção contra ameaças avançadas à segurança."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Os níveis de segurança não estão disponíveis para este dispositivo."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Contacte o fabricante do seu equipamento para obter ajuda com "
+#~ "atualizações de segurança."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Poderá ser possível resolver este problema nas definições de firmware "
+#~ "UEFI do dispositivo, ou por um técnico de suporte."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Poderá ser possível resolver este problema nas definições de firmware "
+#~ "UEFI do dispositivo."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Poderá ser possível a um técnico de apoio resolver este problema."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr ""
+#~ "Protegido contra software malicioso quando o dispositivo é iniciado."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "O Arranque Seguro tem problemas"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Alguma proteção quando o dispositivo é iniciado."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "O Arranque Seguro está desligado"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Sem proteção quando o dispositivo é iniciado."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Este problema poderia ter sido causado por uma alteração nas definições "
+#~ "de firmware UEFI, uma alteração na configuração do sistema operativo, ou "
+#~ "devido a software malicioso neste sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Este problema poderia ter sido causado por uma alteração nas definições "
+#~ "do firmware UEFI, ou devido a software malicioso neste sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Este problema poderia ter sido causada por uma alteração na configuração "
+#~ "do sistema operativo, ou devido a software malicioso neste sistema."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Expostos a sérias ameaças à segurança."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Proteção limitada contra simples ameaças à segurança."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Protegido contra ameaças comuns à segurança."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Protegido contra uma ampla gama de ameaças à segurança."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Proteção abrangente"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Proteção de gravação de firmware"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Bloqueio de proteção de gravação de firmware"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Região do BIOS de firmware"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Descritor de BIOS de firmware"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Proteção de DMA pré-arranque"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Arranque verificado do Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM protegido"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Política de erros do Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Fuse Intel BootGuard OTP"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET ativado"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET Ativo"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "RAM encriptada"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Proteção IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Bloqueio do Kernel Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Verificação do Kernel Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Suspender para a RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Suspender para inativo"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Chave de plataforma UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Arranque Seguro UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Configuração da plataforma TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Reconstrução TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Modo de fabrico do mecanismo de gestão Intel"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Substituição do mecanismo de gestão Intel"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Versão do mecanismo de gestão Intel"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Atualizações de firmware"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Atestado de firmware"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Verificação do atualizador do firmware"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Depuração de plataforma"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Verificações de segurança do processador"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Proteção de reversão AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Proteção de repetição de firmware AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Proteção de gravação de firmware AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Plataforma Fused"
+
+#~ msgid "Valid"
+#~ msgstr "Válido"
+
+#~ msgid "Not Valid"
+#~ msgstr "Não válido"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Não ativado"
+
+#~ msgid "Locked"
+#~ msgstr "Bloqueado"
+
+#~ msgid "Not Locked"
+#~ msgstr "Não bloqueado"
+
+#~ msgid "Encrypted"
+#~ msgstr "Encriptado"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Não encriptado"
+
+#~ msgid "Tainted"
+#~ msgstr "Contaminado"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Não contaminado"
+
+#~ msgid "Found"
+#~ msgstr "Encontrado"
+
+#~ msgid "Not Found"
+#~ msgstr "Não encontrado"
+
+#~ msgid "Supported"
+#~ msgstr "Suportado"
+
+#~ msgid "Not Supported"
+#~ msgstr "Não suportado"
+
+#~ msgid "Unknown"
+#~ msgstr "Desconhecido"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Desconhecido"
+
+#~ msgid "Not Available"
+#~ msgstr "Não disponível"
+
+#~ msgid "System Logo"
+#~ msgstr "Logotipo do sistema"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nenhuma fonte de introdução encontrada"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Outro"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Atalhos personalizados"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "A tecla de caracteres alternativos pode ser usada para inserir caracteres "
+#~ "adicionais. Estes são, por vezes, impressos como uma terceira opção no "
+#~ "seu teclado."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt esquerdo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt direito"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super esquerdo"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super direito"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tecla menu"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl direito"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "A tecla de composição permite a introdução de uma grande variedade de "
+#~ "caracteres. Para a utilizar, prima composição depois uma sequência de "
+#~ "caracteres. Por exemplo, a tecla composição seguida de <b>C</b> e <b>o</"
+#~ "b> irá introduzir <b>©</b>, <b>a</b> seguida de <b>'</b> irá introduzir "
+#~ "<b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "As fontes de entrada podem ser comutadas usando o atalho do teclado %s.\n"
+#~ "Isto pode ser alterado nas definições do atalho do teclado."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificado"
+#~ msgstr[1] "%d modificados"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Repor todos os atalhos?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Repor os atalhos pode afetar os seus atalhos personalizados. Isto não "
+#~ "pode ser desfeito."
+
+#~ msgid "Reset All"
+#~ msgstr "Repor tudo"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s já está a ser usado para %s. Caso o reponha, %s será desativado"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Insira um novo atalho"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Definir um atalho personalizado"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Definir um atalho"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Insira um novo atalho para %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Adicionar um atalho personalizado"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Deslocamento com dois dedos"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinco cliques, hora de GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Clique duplo, botão principal"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Clique único, botão principal"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Clique duplo, botão do meio"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Clique único, botão do meio"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Clique duplo, botão secundário"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Clique único, botão secundário"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "O gestor de redes tem de estar em execução."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Rede insegura (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Rede segura (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Rede segura (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Rede segura (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Rede segura"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Ligar o ponto de acesso há de desligá-lo de %s, e não será possível "
+#~ "aceder à Internet por Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Requer um mínimo de 8 caracteres"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Parar o ponto de acesso e desligar quaisquer utilizadores?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Parar o ponto de acesso"
+
+#~ msgid "Preserve"
+#~ msgstr "Guardar"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanente"
+
+#~ msgid "Random"
+#~ msgstr "Aleatório"
+
+#~ msgid "Stable"
+#~ msgstr "Estável"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "O endereço MAC inserido aqui será usado como endereço de equipamento "
+#~ "informático nas redes em que este dispositivo está ligado. Esta "
+#~ "funcionalidade é conhecida como clonagem ou alteração de MAC. Exemplo: "
+#~ "00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Perfil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Aberta (Otimizada)"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Empresarial"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nenhuma"
+
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nenhum"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Fraca"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Normal"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Boa"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excelente"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Esquecer a ligação"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Eliminar o perfil de ligação"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Eliminar VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detalhes"
+
+#~ msgid "automatic"
+#~ msgstr "automático"
+
+#~ msgid "Identity"
+#~ msgstr "Identidade"
+
+#~ msgid "Delete Address"
+#~ msgstr "Eliminar endereço"
+
+#~ msgid "Delete Route"
+#~ msgstr "Eliminar rota"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Nenhuma"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Chave WEP 40/128-bit (Hex ou ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Frase-passe WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP (802.1x) dinâmico"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA e WPA2 pessoal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA e WPA2 empresarial"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 pessoal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Impossível abrir o editor de ligação"
+
+#~ msgid "New Profile"
+#~ msgstr "Novo perfil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Definição inválida %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Definição inválida %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importar de ficheiro…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Adicionar VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Impossível importar a ligação VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "O ficheiro “%s” não pode ser lido ou não contém informação reconhecível "
+#~ "de ligação VPN\n"
+#~ "\n"
+#~ "Erro: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Selecionar o ficheiro a importar"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Já existe um ficheiro com o nome “%s”."
+
+#~ msgid "_Replace"
+#~ msgstr "Substitui_r"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Deseja substituir %s com a ligação VPN que está a gravar?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Impossível exportar a ligação VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Não foi possível exportar a ligação VPN “%s” para %s.\n"
+#~ "\n"
+#~ "Erro: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportar a ligação VPN"
+
+#~ msgid "never"
+#~ msgstr "nunca"
+
+#~ msgid "today"
+#~ msgstr "hoje"
+
+#~ msgid "yesterday"
+#~ msgstr "ontem"
+
+#~ msgid "Last used"
+#~ msgstr "Última utilização"
+
+#~ msgid "Add new connection"
+#~ msgstr "Adicionar uma nova ligação"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Os detalhes de rede das redes selecionadas, incluindo palavras-passe e "
+#~ "quaisquer configurações personalizadas, serão perdidos."
+
+#~ msgid "_Forget"
+#~ msgstr "_Esquecer"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Redes Wi-FI conhecidas"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Esquecer"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "A política de sistema proíbe o uso como ponto de acesso"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "O dispositivo sem-fio não suporta o modo ponto de acesso"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "A descoberta automática de proxy Web é utilizada quando não é "
+#~ "especificado um URL de configuração."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr ""
+#~ "Esta opção não é recomendada em redes públicas que não são de confiança."
+
+#~ msgid "Status unknown"
+#~ msgstr "Estado desconhecido"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Sem gestão"
+
+#~ msgid "Unavailable"
+#~ msgstr "Indisponível"
+
+#~ msgid "Connecting"
+#~ msgstr "A ligar"
+
+#~ msgid "Authentication required"
+#~ msgstr "Autenticação necessária"
+
+#~ msgid "Disconnecting"
+#~ msgstr "A desligar"
+
+#~ msgid "Connection failed"
+#~ msgstr "Falha na ligação"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Estado desconhecido (em falta)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Falha na configuração"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Falha na configuração de IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Configuração de IP expirou"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Eram requeridos segredos mas não foram fornecidos"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Suplicante 802.1x desligado"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Falha ao configurar suplicante 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Falha no suplicante 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Suplicante 802.1x demorou demasiado tempo a autenticar-se"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Falha ao iniciar o serviço PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Serviço PPP desligado"
+
+#~ msgid "PPP failed"
+#~ msgstr "Falha no PPP"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Falha ao iniciar o cliente DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Erro no cliente DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Falha no cliente DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Falha ao iniciar o serviço de partilha de ligação"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Falha no serviço de partilha de ligação"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Falha ao iniciar o serviço AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Erro no serviço AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Falha no serviço AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "Linha ocupada"
+
+#~ msgid "No dial tone"
+#~ msgstr "Sem som de ligação"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Impossível estabelecer uma ligação"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Pedido de ligação expirou"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Falha ao tentar ligar"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Falha ao inicializar o modem"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Falha ao selecionar a APN especificada"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Não procurar redes"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Registo de rede negado"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Expirou o registo de rede"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Falha ao registar na rede pedida"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Falha ao verificar o PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Poderá faltar firmware no dispositivo"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "A ligação desapareceu"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "A ligação existente foi assumida"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem não encontrado"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Falha na ligação Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "O cartão SIM não está inserido"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Necessário o pin do SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Necessário o PUK do SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM incorreto"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Falha na dependência da ligação"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Falta firmware"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cabo desligado"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "erro não definido na segurança 802.1x (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "nenhum ficheiro selecionado"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "erro não especificado ao validar o ficheiro eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Chaves privadas DER, PEM, PKCS#12, ou PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certificados DER ou PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "ficheiro EAP-FAST PAC em falta"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Ficheiros PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "nome de utilizador EAP-LEAP em falta"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "palavra-passe EAP-LEAP em falta"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "certificado EAP-PEAP inválido: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "certificado EAP-PEAP inválido: nenhum certificado especificado"
+
+#~ msgid "missing EAP username"
+#~ msgstr "nome de utilizador EAP em falta"
+
+#~ msgid "missing EAP password"
+#~ msgstr "palavra-passe EAP em falta"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "identidade EAP-TLS em falta"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "certificado AC EAP-TLS inválido: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "certificado AC EAP-TLS inválido: nenhum certificado especificado"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "chave privada EAP-TLS inválida: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificado de utilizador EAP-TLS inválido: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Chaves privadas não encriptadas são inseguras"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "A chave privada selecionada não parece estar protegida por uma palavra-"
+#~ "passe. Isto poderá permitir que as suas credenciais de segurança sejam "
+#~ "comprometidas. Selecione uma chave privada protegida por palavra-passe.\n"
+#~ "\n"
+#~ "(Pode proteger com palavra-passe a sua chave privada utilizando o openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Escolha o seu certificado pessoal"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Escolha a sua chave privada"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "certificado EAP-TTLS inválido: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "certificado EAP-TTLS CA inválido: nenhum certificado especificado"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Erro desconhecido ao validar a segurança 802.11x"
+
+#~ msgid "Select a file"
+#~ msgstr "Selecionar um ficheiro"
+
+#~ msgid "missing leap-username"
+#~ msgstr "utilizador-leap em falta"
+
+#~ msgid "missing leap-password"
+#~ msgstr "palavra-chave-leap em falta"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Palavra-passe Wi-Fi em falta."
+
+#~ msgid "missing wep-key"
+#~ msgstr "chave-wep em falta"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "chave-wep inválida: a chave com um comprimento de %zu tem de ter apenas "
+#~ "dígitos hexadecimais"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "chave-wep inválida: a chave com um comprimento de %zu tem de ter apenas "
+#~ "carateres ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "chave-wep inválida: comprimento errado de %zu. A chave tem de ter "
+#~ "comprimento 5/13 (ascii) ou 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "chave-wep inválida: a frase-passe não pode estar vazia"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "chave-wep inválida: a frase-passe não pode ter menos de 64 carateres"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk inválido: comprimento-chave inválido %zu. Tem de ser [8,63] bytes "
+#~ "ou 64 dígitos hexadecimais"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk inválido: não foi possível interpretar a chave com 64 bytes como "
+#~ "hexadecimal"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Outro"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s removido"
+
+#~ msgid "Error removing account"
+#~ msgstr "Erro ao remover conta"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Conta %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Remover conta"
+
+#~ msgid "Unknown time"
+#~ msgstr "Tempo desconhecido"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s e %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s até que esteja completamente carregada"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Atenção: restam %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Restam %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Completamente carregada"
+
+#~ msgid "Not charging"
+#~ msgstr "Não está a carregar"
+
+#~ msgid "Empty"
+#~ msgstr "Descarregada"
+
+#~ msgid "Charging"
+#~ msgstr "A carregar"
+
+#~ msgid "Discharging"
+#~ msgstr "A descarregar"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Rato sem fios"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Teclado sem fios"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Fonte de energia de segurança (UPS)"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Assistente digital pessoal"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telemóvel"
+
+#~ msgid "Media player"
+#~ msgstr "Reprodutor multimédia"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Computador"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Dispositivo para jogos"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principal"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Extra"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterias"
+
+#~ msgid "When _idle"
+#~ msgstr "Quando _inativo"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspender"
+
+#~ msgid "Power Off"
+#~ msgstr "Desligar"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernar"
+
+#~ msgid "Nothing"
+#~ msgstr "Nada"
+
+#~ msgid "When on battery power"
+#~ msgstr "Quando funciona da bateria"
+
+#~ msgid "When plugged in"
+#~ msgstr "Quando ligado à corrente"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Suspender automaticamente"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Modo de desempenho temporariamente desativado devido à alta temperatura "
+#~ "de funcionamento."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Colo detetado: modo de desempenho temporariamente indisponível. Mova o "
+#~ "dispositivo para uma superfície estável para restaurar."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Modo de desempenho temporariamente desativado."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Bateria fraca: poupança de energia ativada. O modo anterior será "
+#~ "restaurado quando a bateria estiver suficientemente carregada."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Modo poupança de energia ativado por \"%s\"."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Modo de desempenho ativado por \"%s\"."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Desempenho"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Alto desempenho e utilização de energia."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Equilibrado"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Desempenho padrão e utilização de energia."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Poupança de energia"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Redução do desempenho e do consumo de energia."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "A impressora “%s” foi eliminada"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Falha ao adicionar uma nova impressora."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Impossível carregar o UI: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Desbloquear para adicionar impressoras e alterar as definições"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detalhes da impressora %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Não foi encontrado controlador adequado"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Selecionar ficheiro PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Ficheiros PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+#~ "gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Impressora JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Impressora LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Um lado"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Margem longa (padrão)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Margem curta (invertida)"
+
+#~ msgid "Portrait"
+#~ msgstr "Retrato"
+
+#~ msgid "Landscape"
+#~ msgstr "Paisagem"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Paisagem invertida"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Retrato invertido"
+
+#~ msgid "Resume"
+#~ msgstr "Retomar"
+
+#~ msgid "Pause"
+#~ msgstr "Pausa"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Pendente"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pausado"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autenticação necessária"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "A processar"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Parado"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Cancelado"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Abortado"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Terminado"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Mover este trabalho para o topo da fila"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - Trabalhos ativos"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Insira as credenciais para imprimir em %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Desbloquear o servidor de impressão"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Desbloquear %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Insira o seu utilizador e palavra-passe para ver as impressoras "
+#~ "disponíveis em %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "A procurar por impressoras"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Porta série"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Porta paralela"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Localização: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Endereço: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "O servidor requer autenticação"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dois lados"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tipo de papel"
+
+#~ msgid "Paper Source"
+#~ msgstr "Origem do papel"
+
+#~ msgid "Output Tray"
+#~ msgstr "Tabuleiro de saída"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolução"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Pré-filtragem GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Páginas por lado"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientação"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Geral"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Configuração de página"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opções de instalação"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Trabalho"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Qualidade de imagem"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Cor"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Acabamento"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avançado"
+
+#~ msgid "Test page"
+#~ msgstr "Página de teste"
+
+#~ msgid "Auto Select"
+#~ msgstr "Selecionar automaticamente"
+
+#~ msgid "Printer Default"
+#~ msgstr "Predefinição da impressora"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Embutir apenas fontes GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Converter em PS nível 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Converter em PS nível 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Nenhuma pré-filtragem"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Limpar as cabeças de impressão"
+
+#~ msgid "Out of toner"
+#~ msgstr "Sem toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Com pouco revelador"
+
+#~ msgid "Out of developer"
+#~ msgstr "Sem revelador"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Com pouco de uma das cores"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Sem uma das cores"
+
+#~ msgid "Open cover"
+#~ msgstr "Tampa aberta"
+
+#~ msgid "Open door"
+#~ msgstr "Porta aberta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Com pouco papel"
+
+#~ msgid "Out of paper"
+#~ msgstr "Sem papel"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Desligada"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Parada"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Depósito de lixo quase cheio"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Depósito de lixo cheio"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr ""
+#~ "Está a aproximar-se o final da vida útil do condutor ótico de imagem"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "O condutor ótico de imagem deixou de funcionar"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Preparada"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Não aceita trabalhos"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "A processar"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Métrico"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Perguntar o que fazer"
+
+#~ msgid "Do nothing"
+#~ msgstr "Não fazer nada"
+
+#~ msgid "Open folder"
+#~ msgstr "Abrir pasta"
+
+#~ msgid "Other Media"
+#~ msgstr "Outro suporte"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Selecione uma aplicação para CDs de áudio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Selecione uma aplicação para DVDs de vídeo"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Selecione uma aplicação a executar ao ligar um reprodutor de música"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Selecione uma aplicação a executar ao ligar uma câmara"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Selecione uma aplicação para CDs de dados"
+
+# DVD de áudio
+#~ msgid "audio DVD"
+#~ msgstr "áudio DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "disco Blu-ray virgem"
+
+#~ msgid "blank CD disc"
+#~ msgstr "disco CD virgem"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "disco DVD virgem"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "disco HD DVD virgem"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disco Blu-ray de vídeo"
+
+#~ msgid "e-book reader"
+#~ msgstr "leitor de e-books"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disco HD DVD de vídeo"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD de imagens"
+
+#~ msgid "Super Video CD"
+#~ msgstr "CD super vídeo (SVCD)"
+
+#~ msgid "Video CD"
+#~ msgstr "CD de vídeo (VCD)"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "O ecrã desliga-se em"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 segundos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#~ msgid "Select Location"
+#~ msgstr "Selecionar localização"
+
+#~ msgid "_OK"
+#~ msgstr "_Aceitar"
+
+#~ msgid "No applications found"
+#~ msgstr "Nenhuma aplicação encontrada"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Sem rede selecionada para partilha"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Ligado"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Desligado"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Ativo"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Ativo"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Selecione uma pasta"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Ativar partilha de ficheiros"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Partilha de ficheiros permite-lhe partilhar a sua Pasta pública com "
+#~ "outros na sua rede atual utilizando: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Se as autenticações remotas estão ativadas, utilizadores remotos podem "
+#~ "ligar-se utilizando o comando de terminal seguro:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Ativar partilha de ficheiros pessoais"
+
+#~ msgid "Device name copied"
+#~ msgstr "Nome do dispositivo copiado"
+
+#~ msgid "Device address copied"
+#~ msgstr "Endereço do dispositivo copiado"
+
+#~ msgid "Username copied"
+#~ msgstr "Nome de utilizador copiado"
+
+#~ msgid "Password copied"
+#~ msgstr "Palavra-passe copiada"
+
+#~ msgid "Custom"
+#~ msgstr "Personalizado"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "A testar %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Desligado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "A ligar"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Ligado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Erro de autenticação"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "A autenticar"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Funcionalidade reduzida"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Ligado e Autenticado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Desconhecido"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autenticado às:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Ligado às:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Registado às:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Falha ao autenticar o dispositivo: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Falha ao esquecer o dispositivo: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Erro"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autenticado"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "O subsistema Thunderbolt (boltd) não está instalado ou não pode ser "
+#~ "definido corretamente."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Apenas dispositivos USB e Display Port podem acoplar."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "O Thunderbolt não pôde ser detetado.\n"
+#~ "A razão pode ser a falta de suporte ao Thunderbolt no sistema, a "
+#~ "desativação dele ou a definição para um nível de segurança não suportado "
+#~ "na BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "O suporte ao Thunderbolt foi desativado no BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "O nível de segurança do Thunderbolt não pôde ser determinado."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Erro as alterar o modo direto: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Predefinição"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Médio"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Grande"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Maior"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Maior ainda"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixels"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Curta"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ do ecrã"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ do ecrã"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ do ecrã"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Longa"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dia"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dias"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Esvaziar todos os itens do lixo?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Todos os itens no lixo serão apagados permanentemente."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Esvaziar o lixo"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Eliminar todos os ficheiros temporários?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Todos os ficheiros temporários serão apagados permanentemente."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Eliminar ficheiros tem_porários"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dia"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dias"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dias"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Para sempre"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Deve coincidir com o endereço Web do seu fornecedor de conta."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Falha ao adicionar conta"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Falha ao registar conta"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nenhuma forma suportada de autenticar com este domínio"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Falha ao ligar-se ao domínio"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Este nome de acesso não funcionou.\n"
+#~ "Tente novamente."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Esta palavra-passe de acesso não funcionou.\n"
+#~ "Tente novamente."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Falha ao ligar-se ao domínio"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Impossível encontrar o domínio. Talvez o tenha escrito mal?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Procurar por mais imagens"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "o dispositivo precisa de ser reivindicado para executar esta acção"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "o dispositivo já é reclamado por outro processo"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "não tem permissão para executar a ação"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "não foram registadas impressões digitais"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Falha de comunicação com o dispositivo durante o registo"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Falha na comunicação com o leitor de impressões digitais"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Falha na comunicação com o daemon das impressões digitais"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Falhou ao listar as impressões digitais: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Falhou ao eliminar as impressões digitais gravadas: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Polegar esquerdo"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Dedo médio esquerdo"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Dedo indicador _esquerdo"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Dedo anelar esquerdo"
+
+#~ msgid "Left little finger"
+#~ msgstr "Dedo mindinho esquerdo"
+
+#~ msgid "Right thumb"
+#~ msgstr "Polegar direito"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Dedo médio direito"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Dedo indicador _direito"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Dedo anelar direito"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dedo mindinho direito"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Dedo desconhecido"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Feito"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Dispositivo de impressão digital desligado"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "O armazenamento de impressões digitais está cheio"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Falhou ao registar a nova impressão digital"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Falhou ao iniciar a transcrição do registo: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Falhou ao registar a nova impressão digital"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Falhou ao terminar a transcrição do registo: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Tire e ponha o seu dedo repetidamente no leitor para registar a sua "
+#~ "impressão digital"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Regravar este dedo…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Digitalizar um nova impressão digital"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Falhou em largar o dispositivo de impressão digital %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problemas ao ler o dispositivo"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Falhou ao requisitar pelo dispositivo de impressão digital %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Falhou ao obter dispositivos de impressão digital: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Esta semana"
+
+#~ msgid "Last Week"
+#~ msgstr "Última semana"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, às %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sessão terminou"
+
+#~ msgid "Session Started"
+#~ msgstr "Sessão iniciada"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Atividade da conta"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Selecione uma palavra-passe diferente."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Insira novamente a sua palavra-passe atual."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Impossível alterar a palavra-passe"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Impossível ligar-se automaticamente a este tipo de domínio"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Domínio ou reino não encontrado"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Impossível iniciar sessão como %s no domínio %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Palavra-passe inválida. Tente novamente"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Impossível ligar-se ao domínio %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Falha ao eliminar o utilizador"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Falha ao revogar o utilizador gerido remotamente"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Não pode eliminar a sua própria conta."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ainda tem uma sessão ativa"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Eliminar um utilizador enquanto este tem uma sessão ativa pode deixar o "
+#~ "sistema num estado inconsistente."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Deseja manter os ficheiros de %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "É possível manter a pasta pessoal, spool de email e ficheiros temporários "
+#~ "ao eliminar a conta de um utilizador."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Eliminar os ficheiros"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Manter os ficheiros"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Tem a certeza de que deseja revogar a conta gerida remotamente de %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Eliminar"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Conta desativada"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "A ser definida ao iniciar a próxima sessão"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Nenhuma"
+
+#~ msgid "Logged in"
+#~ msgstr "Com sessão ativa"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Falha ao contactar o serviço de contas"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Certifique-se que o AccountService está instalado e ativo."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Este painel deve ser desbloqueado para alterar esta definição"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Eliminar a conta de utilizador selecionada"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para eliminar a conta de utilizador selecionada,\n"
+#~ "clique primeiro no ícone *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Desbloquear para adicionar utilizadores e alterar as definições"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "A nova palavra-passe tem de ser diferente da antiga."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Tente alterar algumas letras e números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Tente alterar um pouco mais a palavra-passe."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Uma palavra-passe sem o seu nome de utilizador seria mais segura."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Tente não utilizar o seu nome na palavra-passe."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Tente não utilizar algumas das palavras incluídas na palavra-passe."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Tente evitar palavras comuns."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Tente evitar reordenar palavras existentes."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Tente utilizar mais números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Tente utilizar mais letras maiúsculas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Tente utilizar mais letras minúsculas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Tente utilizar mais caracteres especiais, como pontuação."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Tente utilizar uma mistura de letras, números e pontuação."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Tente evitar repetir o mesmo carácter."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Tente evitar a repetição do mesmo tipo de carácter: deve misturar letras, "
+#~ "números e pontuação."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Tente evitar sequências como 1234 ou abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "As palavras-passe tem de ser longas. Tente adicionar mais letras, números "
+#~ "e pontuação."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Misture letras maiúsculas com minúsculas e tente utilizar um ou dois "
+#~ "números."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Adicionar mais letras, números e pontuação há de tornar a palavra-passe "
+#~ "mais forte."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Falha na autenticação"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "A nova palavra-passe é demasiado curta"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "A nova palavra-passe é demasiado simples"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "As palavras-passe antiga e nova são demasiado semelhantes"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "A nova palavra-passe já foi utilizada recentemente."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr ""
+#~ "A nova palavra-passe tem de conter caracteres numéricos ou especiais"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "As palavras-passe antiga e nova são idênticas"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "A sua palavra-passe foi alterada após se ter autenticado!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "A nova palavra-passe não contém caracteres distintos suficientes"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Erro desconhecido"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "O nome de utilizador apenas pode ser composto por letras minúsculas e "
+#~ "maiúsculas de a-z, dígitos e os seguintes caracteres: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Este nome de utilizador não está disponível. Tente outro."
+
+#~ msgid "The username is too long."
+#~ msgstr "O nome de utilizador é demasiado extenso."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Botão %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Aplicação definida"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Enviar toque de tecla"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Trocar monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Mostrar ajuda no ecrã"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tablet montado no painel do portátil"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tablet montado no ecrã externo"
+
+#~ msgid "External tablet device"
+#~ msgstr "Dispositivo de tablet externo"
+
+#~ msgid "All Displays"
+#~ msgstr "Todos os ecrãs"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Caneta stylus airbrush com pressão, inclinação e deslizador integrado"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Caneta stylus airbrush com pressão, inclinação e rotação"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Caneta stylus padrão com pressão e inclinação"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Caneta stylus padrão com pressão"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Novo atalho…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operação cancelada"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Error:</b> Acesso negado a alteração de definições"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Error:</b> Erro de equipamento móvel"
+
+#~ msgid "Not Registered"
+#~ msgstr "Não registado"
+
+#~ msgid "Registered"
+#~ msgstr "Registado"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "A procurar"
+
+#~ msgid "Denied"
+#~ msgstr "Negado"
+
+#~ msgid "2G Only"
+#~ msgstr "Apenas 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Apenas 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Apenas 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Apenas 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (Preferencial)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (Preferencial), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (Preferencial), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (Preferencial), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Preferencial)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Preferencial), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Preferencial), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (Preferencial)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (Preferencial), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (Preferencial), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (Preferencial)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (Preferencial), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (Preferencial), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (Preferencial)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (Preferencial), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (Preferencial), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Preferencial)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Preferencial), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Preferencial)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Preferencial), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Preferencial)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Preferencial), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (Preferencial)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (Preferencial), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Preferencial)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (Preferencial), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (Preferencial)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (Preferencial), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Desconhecido"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Desbloquear o cartão SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Forneça o código PIN do SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Inserir o PIN para desbloquear o cartão SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Forneça o código PUK do SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Inserir o PUK para desbloquear o cartão SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Palavra-passe incorreta introduzida."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "O código PUK deve ser um número de 8 dígitos"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Introduza novo PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "O código PIN deve ser um número de 4-8 dígitos"
+
+#~ msgid "Unlocking…"
+#~ msgstr "A desbloquear…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Falha no telemóvel"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Sem ligação ao telemóvel"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operação não permitida"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operação não suportada"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Cartão SIM não está inserido"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Necessário PIN do cartão SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Necessário PUK do cartão SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Falha no cartão SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "Cartão SIM ocupado"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Palavra-passe incorreta"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Necessário PIN2 do cartão SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Necessário PUK2 do cartão SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Não encontrado"
+
+#~ msgid "No network service"
+#~ msgstr "Sem serviço de rede"
+
+#~ msgid "Network timeout"
+#~ msgstr "Tempo limite de rede"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Serviços GPRS não permitidos"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming não permitido nesta área de localização"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Erro GPRS não especificado"
+
+#~ msgid "No Error"
+#~ msgstr "Nenhum erro"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Ação cancelada"
+
+#~ msgid "Access denied"
+#~ msgstr "Acesso negado"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Erro desconhecido"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Mostrar número de versão"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Ativar modo detalhado"
+
+#~ msgid "Search for the string"
+#~ msgstr "Procurar pela cadeia"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Listar nomes possíveis de painel e sair"
+
+#~ msgid "Panel to display"
+#~ msgstr "Painel a mostrar"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PAINEL] [ARGUMENTO…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Painéis disponíveis:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sons do sistema"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Erro: incapaz de determinar o nível HSI."
 
 #~ msgid "Error: unable to determine Incorrect HSI level."
 #~ msgstr "Erro: incapaz de determinar o nível de HSI incorreto."
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Adicionar uma impressora…"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "Certificados DER ou PEM (*.der, *.pem, *.crt, *.cer)"
@@ -9943,9 +8640,6 @@ msgstr "Sons do sistema"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablet (absoluto)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Painel tátil (relativo)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Preferências do tablet"
 
@@ -10065,8 +8759,8 @@ msgstr "Sons do sistema"
 #~ msgstr "Impossível alterar"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Permissões individuais para aplicações podem ser revistas nas Definições "
 #~ "de <a href=\"privacy\">Privacidade</a>."
@@ -10381,9 +9075,6 @@ msgstr "Sons do sistema"
 #~ msgid "Changes throughout the day"
 #~ msgstr "É alterado ao longo do dia"
 
-#~ msgid "_Lock Screen"
-#~ msgstr "B_loquear ecrã"
-
 #~ msgctxt "background, style"
 #~ msgid "Tile"
 #~ msgstr "Em mosaico"
@@ -10433,9 +9124,6 @@ msgstr "Sons do sistema"
 
 #~ msgid "Mirrored"
 #~ msgstr "Ecrãs em espelho"
-
-#~ msgid "Secondary"
-#~ msgstr "Secundário"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Organizar ecrãs combinados"
@@ -10767,9 +9455,6 @@ msgstr "Sons do sistema"
 
 #~ msgid "Mail"
 #~ msgstr "Correio"
-
-#~ msgid "Calendar"
-#~ msgstr "Calendário"
 
 #~ msgid "Contacts"
 #~ msgstr "Contactos"
@@ -11138,9 +9823,6 @@ msgstr "Sons do sistema"
 #~ msgid "%s - %s"
 #~ msgstr "%s - %s"
 
-#~ msgid "Disable image"
-#~ msgstr "Desativar a imagem"
-
 #~ msgid "Browse for more pictures…"
 #~ msgstr "Procurar por mais imagens…"
 
@@ -11228,9 +9910,6 @@ msgstr "Sons do sistema"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Rolar acima"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Rolar abaixo"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Rolar à direita"

--- a/po/pt.po~
+++ b/po/pt.po~
@@ -1,0 +1,11293 @@
+# gnome-control-center's Portuguese Translation
+# Copyright © 1999-2022 gnome-control-center
+# Distributed under the same licence as the gnome-control-center package
+# Duarte Loreto <happyguy_pt@hotmail.com>, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014.
+# Nuno Ferreira <nmrf@rnl.ist.utl.pt>, 1999.
+# António Lima <amrlima@gmail.com>, 2013.
+# Tiago Santos <tiagofsantos81@sapo.pt>, 2014 - 2016.
+# Pedro Albuquerque <palbuquerque73@gmail.com>, 2015.
+# Sérgio Cardeira <cardeira.sergio@gmail.com>, 2016.
+# Juliano de Souza Camargo <julianosc@protonmail.com>, 2020.
+# Hugo Carvalho <hugokarvalho@hotmail.com>, 2020, 2021, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 3.8\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-12 15:11+0000\n"
+"PO-Revision-Date: 2022-09-13 19:53+0100\n"
+"Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
+"Language-Team: Portuguese <https://l10n.gnome.org/teams/pt/>\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.1.1\n"
+"X-Language: pt_PT\n"
+"X-Source-Language: C\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Barramento do sistema"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Acesso total"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Barramento da sessão"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositivos"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Acesso total a /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rede"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Tem acesso à rede"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Início"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Apenas-leitura"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Sistema de ficheiros"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Definições"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Pode alterar as definições"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s tem as seguintes permissões internas. Estas não podem ser alteradas. Caso "
+"esteja inseguro acerca delas, considere remover a aplicação."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u tipo de ficheiro e ligação que é aberto pela aplicação"
+msgstr[1] "%u tipos de ficheiro e ligação que são abertos pela aplicação"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> é usado para abrir os seguintes tipos de ficheiros e ligações."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s de espaço em disco utilizado."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicações"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Sem aplicações"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Instale algumas…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Abrir"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Ver detalhes"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Procurar"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Receber as pesquisas do sistema e enviar os resultados."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Inativo"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificações"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Mostrar notificações do sistema."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Executar em segundo plano"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Permitir atividade quando a aplicação está fechada."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Capturas de ecrã"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Tirar fotos do ecrã em qualquer altura."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Alterar o papel de parede"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Alterar o papel de parede da área de trabalho."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sons"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reproduzir sons."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Inibir atalhos"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Bloquear teclas de atalho predefinidas."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Câmara"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Tirar fotos com a câmara."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microfone"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Gravar áudio com o microfone."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Serviços de localização"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Aceder aos dados de localização do dispositivo."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Permissões internas"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Acesso ao sistema que é exigido pela aplicação"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Associações de ficheiros e ligações"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Armazenamento de dados"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Sem resultados"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Tente uma procura diferente"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Associações de ficheiros e ligações"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Tipos de ficheiro"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Tipos de ligação"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Reiniciar"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Quanto do espaço em disco esta aplicação está a ocupar com dados de "
+"aplicação e memória transitória."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplicação"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Dados"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Memória transitória"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Limpar cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Controlar várias permissões e definições de aplicações"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplicação;flatpak;permissão;definição;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Selecionar uma foto"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancelar"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Abrir"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "múltiplos tamanhos"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Nenhum fundo de área de trabalho"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Fundo atual"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Estilo"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Predefinição"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Escuro"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Fundo"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Adicionar imagem…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aparência"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Alterar a sua imagem de fundo ou as cores da Interface do Utilizador"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Fundo;Papel de parede;Ecrã;Área de trabalho;Estilo;Claro;Escuro;Aparência;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Ativo"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Bluetooth não encontrado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Inserir um periférico \"dongle\" para usar o bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth desligado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+"Ligar para ligar-se a dispositivos e receber transferências de ficheiros."
+
+# Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "O Modo de avião está ligado"
+
+# Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "O Bluetooth é desativado quando o modo de avião está ligado."
+
+# Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Desligar o modo de avião"
+
+# Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "O Modo de avião físico está ligado"
+
+# Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Desligue o interruptor do modo de avião para ativar o Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Ligar e desligar o Bluetooth e ligar os seus dispositivos"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "partilhar;partilha;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "A câmara está desligada"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Nenhuma aplicação pode capturar fotos ou vídeos."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"A utilização da câmara permite que as aplicações capturarem fotos e vídeos. "
+"A desativação da câmara pode fazer com que algumas aplicações não funcionem "
+"corretamente.\n"
+"\n"
+"Permita que as aplicações abaixo indicadas utilizem a câmara."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Nenhuma aplicação requisitou acesso à câmara"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Proteja as suas fotos"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "câmara;fotos;vídeo;webcam;bloquear;privado;privacidade;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Coloque o seu dispositivo de calibração sobre o quadrado e clique em "
+"“Iniciar”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Mova o dispositivo de calibração para a posição de calibrar e clique em "
+"“Prosseguir”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Mova o dispositivo de calibração para a posição de superfície e clique em "
+"“Prosseguir”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Fechar a tampa do portátil"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Ocorreu um erro interno do qual não foi possível recuperar."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "As ferramentas necessárias para calibrar não estão instaladas."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "O perfil não pôde ser gerado."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Impossível obter o ponto branco pretendido."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Terminado!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Falha na calibração!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Pode remover o dispositivo de calibração."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Não incomodar o dispositivo de calibração durante o processo"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Calibração do ecrã"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Iniciar"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Retomar"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Concluído"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Ecrã do portátil"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Webcam interna"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Digitalizadora %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Câmara %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Impressora %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webcam %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Ativar a gestão de cor para %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Ver os perfis de cor para %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Não calibrado"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Predefinição: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Espaço de cores: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Perfil de teste: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Selecionar o ficheiro de perfil ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importar"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Perfis ICC suportados"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Todos os ficheiros"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ecrã"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Gravar o perfil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Gravar"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Criar um perfil de cor para o dispositivo selecionado"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Impossível detetar o instrumento de medição. Certifique-se que está ligado e "
+"corretamente instalado."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "O instrumento de medição não suporta traçar o perfil da impressora."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "O tipo de dispositivo não é atualmente suportado."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Calibração de ecrã"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Qualidade da calibração"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Calibração irá produzir um perfil que poderá utilizar para gerir as cores do "
+"seu ecrã. Quanto mais tempo despender na calibração, melhor a qualidade do "
+"perfil de cor."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Não poderá utilizar o seu computador enquanto a calibração estiver a "
+"decorrer."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Qualidade"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Duração aproximada"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Dispositivo de calibração"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Selecione o dispositivo sensor que deseja utilizar para calibrar."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tipo de monitor"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Selecione o tipo de ecrã que está ligado."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Ponto branco do perfil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Selecione um objetivo de ponto branco para o ecrã. A maioria dos ecrãs "
+"deveria ser calibrada para D65 illuminant."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Brilho do ecrã"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Defina um brilho de ecrã típico para si. A gestão de cor será mais precisa "
+"neste nível de brilho."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Em alternativa, pode utilizar o nível de brilho utilizado por um dos outros "
+"perfis neste dispositivo."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nome do perfil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Pode utilizar um perfil de cor em computadores diferentes, ou mesmo criar "
+"perfis para condições distintas de iluminação."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nome do perfil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Resumo"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Perfil criado com sucesso!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copiar perfil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Requer suporte em que se possa escrever"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Poderá considerar úteis estas instruções em como utilizar o perfil em "
+"sistemas <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e "
+"<a href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Adicionar perfil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Problemas detetados. O perfil poderá não funcionar corretamente. <a href="
+"\"\">Ver detalhes.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importar ficheiro…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Adicionar"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Cada dispositivo necessita de um perfil de cor atualizado para poder ser "
+"gerido."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Aprenda mais"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Aprender mais sobre gestão de cor"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Definir para todos os utilizadores"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Definir este perfil para todos os utilizadores neste computador"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Ativo"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Adicionar perfil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibrar…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibrar o dispositivo"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Remover perfil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Ver detalhes"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Impossível detetar quaisquer dispositivos cuja cor possa ser gerida"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projetor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (retro-iluminação CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (retro-iluminação RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (retro-iluminação LED branca)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD de gama de cores ampla (retro-iluminação CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD de gama de cores ampla (retro-iluminação RGB LED)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alta"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutos"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Média"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Baixa"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Nativo do ecrã"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Impressão e publicação)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografia e gráficos)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Espaço padrão"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Perfil de teste"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automático"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Qualidade reduzida"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Qualidade média"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Qualidade elevada"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB predefinido"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK predefinido"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Cinzento predefinido"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Dados de calibração disponibilizados pelo fabricante"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Não é possível realizar correção de ecrã inteiro com este perfil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Este dispositivo poderá já não ser preciso"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Cor"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibre a cor dos seus dispositivos, tais como ecrãs, câmaras ou impressoras"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Cor;ICC;Perfil;Calibrar;Impressora;Ecrã;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Outro…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Selecionar idioma"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Selecionar"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nenhum idioma encontrado"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Mais…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Desbloquear para alterar as definições"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+"Algumas definições devem ser desbloqueadas antes que as possam alterar."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Desbloquear…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Incremento de hora"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Incremento de minuto"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Horas"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Decremento de hora"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Decremento de minuto"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Hoje"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Ontem"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e de %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hora"
+msgstr[1] "%d horas"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuto"
+msgstr[1] "%d minutos"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d segundo"
+msgstr[1] "%d segundos"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s e %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s e %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 segundos"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Ponto de acesso"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 horas"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e de %B de %Y, %l∶%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e de %B de %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data e Hora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Ano"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mês"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Janeiro"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Fevereiro"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Março"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Abril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maio"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Junho"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Julho"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Agosto"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Setembro"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Outubro"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembro"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Dezembro"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dia"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Fuso horário"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Procurar uma cidade"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Data e Hora automática"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Requer acesso à Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Data e _Hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Fuso _horário automático"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Requer serviço de localização ativado e acesso à Internet"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Ativo"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Fuso h_orário"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Formato da hora"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Alterar a data e hora, incluindo o fuso horário"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Relógio;Fuso horário;Fuso;Localização;Hora;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Alterar as definições de data e hora do sistema"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Para alterar as definições de data ou hora, tem de se autenticar."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Correio"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendário"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Música"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Vídeo"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotografias"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicações predefinidas"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configurar as aplicações predefinidas"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "predefinição;aplicação;preferida;média;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Enviar relatórios de problemas técnicos ajuda-nos a melhorar o %s. Os "
+"relatórios são enviados anonimamente e são removidos todos os dados "
+"pessoais. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Relatar problemas"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Relatar problemas _automaticamente"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnósticos"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Relate os seus problemas"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnósticos;falha;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Ligado"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Desligado"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Aplicar as alterações?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "As alterações não foram aplicadas"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Isto pode ser devido a limitações do equipamento informático."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Aplicar"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Recuar"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Definições de ecrã desativadas"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Múltiplos ecrãs"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Juntar"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Espelhar"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Contém a barra superior e as Atividades"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Ecrã principal"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Luz noturna"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Paisagem"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Retrato direito"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Retrato esquerdo"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Paisagem (invertida)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientação"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolução"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Taxa de atualização"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Ajustar para TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Dimensionar"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Luz noturna indisponível"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Isto pode ser o resultado da utilização do controlador gráfico, ou da "
+"utilização remota do ambiente de trabalho"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Desativar temporariamente até amanhã"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Reiniciar filtro"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"A luz noturna torna a cor do ecrã mais quente. Isto pode ajudar a prevenir a "
+"tensão ocular e a insónia."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Agendar"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Do pôr do sol ao nascer do sol"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Agendamento manual"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Horas"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Das"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hora"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuto"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Às"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura da cor"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ecrãs"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Alterar como utilizar os monitores e projetores ligados"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Painel;Projetor;xrandr;Ecrã;Resolução;Atualizar;Monitor;Noturno;Noite;Luz;"
+"Azul;cor;redshift;anoitecer;amanhecer;nascer do sol;pôr do sol;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "O Arranque Seguro está ativo"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"O arranque seguro evita que software malicioso seja carregado quando o "
+"dispositivo inicia. Está atualmente ligado e a funcionar corretamente."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "O Arranque Seguro tem problemas"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"O arranque seguro evita que software malicioso seja carregado quando o "
+"dispositivo inicia. Está atualmente ligado, mas não funcionará devido a ter "
+"uma chave inválida."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Os problemas de arranque seguro podem muitas vezes ser resolvidos a partir "
+"das definições de firmware UEFI (BIOS) do seu computador e o fabricante do "
+"seu equipamento pode fornecer informações sobre como o fazer."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Para obter ajuda, entre em contacto com o seu fabricante de equipamento ou "
+"fornecedor de suporte de TI."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "O Arranque Seguro está desligado"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"O arranque seguro evita que software malicioso seja carregado quando o "
+"dispositivo arranca. Está atualmente desligado."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"O arranque seguro pode muitas vezes ser ligado a partir das definições de "
+"firmware UEFI (BIOS) do seu computador. Para obter ajuda, contacte o "
+"fabricante do seu equipamento ou o fornecedor de suporte informático."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"O arranque seguro impede que o software malicioso seja carregado quando o "
+"dispositivo é iniciado.\n"
+"\n"
+"Para obter mais informações, entre em contato com o fabricante de hardware "
+"ou suporte a TI."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Aprovado"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Falhou"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Dispositivo está em conformidade com o nível HSI %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Nível de segurança 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Este dispositivo não tem proteção contra problemas de segurança de hardware. "
+"Isso pode ser devido a um problema de configuração de hardware ou firmware. "
+"Recomenda-se entrar em contato com o seu fornecedor de suporte de TI."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Nível de segurança 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Este dispositivo tem proteção mínima contra problemas de segurança de "
+"hardware. Este é o nível mais baixo de segurança do dispositivo e apenas "
+"fornece proteção contra simples ameaças à segurança."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Nível de segurança 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Este dispositivo tem proteção básica contra problemas de segurança de "
+"hardware. Isto fornece proteção contra algumas ameaças comuns à segurança."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Nível de segurança 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Este dispositivo tem proteção estendida contra problemas de segurança de "
+"hardware. Este é o mais alto nível de segurança do dispositivo e fornece "
+"proteção contra ameaças avançadas à segurança."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Nível de segurança"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Os níveis de segurança não estão disponíveis para este dispositivo."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Contacte o fabricante do seu equipamento para obter ajuda com atualizações "
+"de segurança."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Poderá ser possível resolver este problema nas definições de firmware UEFI "
+"do dispositivo, ou por um técnico de suporte."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Poderá ser possível resolver este problema nas definições de firmware UEFI "
+"do dispositivo."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Poderá ser possível a um técnico de apoio resolver este problema."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nível 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nível 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nível 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Protegido contra software malicioso quando o dispositivo é iniciado."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "O Arranque Seguro tem problemas"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Alguma proteção quando o dispositivo é iniciado."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "O Arranque Seguro está desligado"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Sem proteção quando o dispositivo é iniciado."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Este problema poderia ter sido causado por uma alteração nas definições de "
+"firmware UEFI, uma alteração na configuração do sistema operativo, ou devido "
+"a software malicioso neste sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Este problema poderia ter sido causado por uma alteração nas definições do "
+"firmware UEFI, ou devido a software malicioso neste sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Este problema poderia ter sido causada por uma alteração na configuração do "
+"sistema operativo, ou devido a software malicioso neste sistema."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Expostos a sérias ameaças à segurança."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Proteção limitada contra simples ameaças à segurança."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Protegido contra ameaças comuns à segurança."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Protegido contra uma ampla gama de ameaças à segurança."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Proteção abrangente"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Sem eventos"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Proteção de gravação de firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Bloqueio de proteção de gravação de firmware"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Região do BIOS de firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Descritor de BIOS de firmware"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Proteção de DMA pré-arranque"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Arranque verificado do Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM protegido"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Política de erros do Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Fuse Intel BootGuard OTP"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET ativado"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET Ativo"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "RAM encriptada"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Proteção IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Bloqueio do Kernel Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Verificação do Kernel Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Suspender para a RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Suspender para inativo"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Chave de plataforma UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Arranque Seguro UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Configuração da plataforma TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Reconstrução TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Modo de fabrico do mecanismo de gestão Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Substituição do mecanismo de gestão Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Versão do mecanismo de gestão Intel"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Atualizações de firmware"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Atestado de firmware"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Verificação do atualizador do firmware"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Depuração de plataforma"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Verificações de segurança do processador"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Proteção de reversão AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Proteção de repetição de firmware AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Proteção de gravação de firmware AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Plataforma Fused"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Válido"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Não válido"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Não ativado"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Bloqueado"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Não bloqueado"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Encriptado"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Não encriptado"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Contaminado"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Não contaminado"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Encontrado"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Não encontrado"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Suportado"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Não suportado"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Segurança do dispositivo"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Estado de segurança do firmware anfitrião"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ecrã;bloquear;trancar;diagnósticos;falha;privado;recente;temporário;tmp;"
+"índice;nome;rede;identidade;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Não disponível"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logotipo do sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nome do dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Modelo do equipamento"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memória"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processador"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Gráficos"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacidade do disco"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "A calcular…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nome do SO"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID de compilação do sistema operativo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tipo de SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Versão do GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "A carregar…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Gestor de janelas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualização"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Atualização de Software"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Mudar o nome do dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"O nome do dispositivo é utilizado para identificá-lo quando este for visto "
+"pela rede, ou quando a emparelhar dispositivos Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nome do dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Mudar o nome"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Acerca"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Ver informação acerca do sistema"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;informação;memória;processador;versão;aplicação;"
+"preferido;cd;dvd;usb;áudio;vídeo;disco;removível;media;autoiniciar;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Som e Multimédia"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Emudecer/desemudecer o volume"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Reduzir o volume"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Aumentar o volume"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Emudecer/desemudecer o microfone"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Iniciar o reprodutor multimédia"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Reproduzir (ou reproduzir/pausar)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pausar a reprodução"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Parar a reprodução"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Faixa anterior"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Faixa seguinte"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Ejetar"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Escrita"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Alternar para a fonte de introdução seguinte"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Alternar para fonte de introdução anterior"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Iniciadores"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Navegador de ajuda"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Calculadora"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Cliente de correio eletrónico"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Navegador Web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Pasta pessoal"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Procurar"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Terminar sessão"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Bloquear ecrã"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Acessibilidade"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Ativar ou desativar a ampliação"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Ampliar"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Reduzir"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Ativar ou desativar o leitor de ecrã"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Ativar ou desativar o teclado no ecrã"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Aumentar o tamanho do texto"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Reduzir o tamanho do texto"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Ativar ou desativar o alto contraste"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nenhuma fonte de introdução encontrada"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Outro"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Adicionar uma fonte de introdução"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Não é possível utilizar métodos de entrada no ecrã de acesso"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nenhuma fonte de introdução selecionada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opções"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Mover acima"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Mover abaixo"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferências"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Ver disposição do teclado"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Remover"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Atalhos personalizados"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de carateres alternativos"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"A tecla de caracteres alternativos pode ser usada para inserir caracteres "
+"adicionais. Estes são, por vezes, impressos como uma terceira opção no seu "
+"teclado."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt esquerdo"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt direito"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super esquerdo"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super direito"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tecla menu"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl direito"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composição"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"A tecla de composição permite a introdução de uma grande variedade de "
+"caracteres. Para a utilizar, prima composição depois uma sequência de "
+"caracteres. Por exemplo, a tecla composição seguida de <b>C</b> e <b>o</b> "
+"irá introduzir <b>©</b>, <b>a</b> seguida de <b>'</b> irá introduzir <b>á</"
+"b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"As fontes de entrada podem ser comutadas usando o atalho do teclado %s.\n"
+"Isto pode ser alterado nas definições do atalho do teclado."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Fontes de introdução"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Inclui esquemas de teclado e métodos de entrada."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Mudança da fonte de introdução"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Utilizar a _mesma fonte em todas as janelas"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Mudar as fontes de entrada _individualmente para cada janela"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Entrada de caracteres especiais"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Métodos para inserir símbolos e variantes de letras usando o teclado."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Atalhos de teclado"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Ver e personalizar atalhos"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificado"
+msgstr[1] "%d modificados"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Repor todos os atalhos?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Repor os atalhos pode afetar os seus atalhos personalizados. Isto não pode "
+"ser desfeito."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Repor tudo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Repor tudo…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Repor todos os atalhos para as suas posições predefinidas"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Secção"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Adicionar um atalho"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Adicionar atalhos personalizados"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Configurar atalhos personalizados para iniciar aplicações, executar scripts, "
+"e muito mais."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Adicionar atalho"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nenhuma tecla de atalho encontrada"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s já está a ser usado para %s. Caso o reponha, %s será desativado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Insira um novo atalho"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Definir um atalho personalizado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Definir um atalho"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Insira um novo atalho para %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Adicionar um atalho personalizado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Remover"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Substituir"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "Definir"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Prima Esc para cancelar ou Backspace para desativar a tecla de atalho."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nome"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Comando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Atalho"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Definir um atalho…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Nenhum"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Repor o atalho para o seu valor predefinido"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Teclado"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Alterar teclas de atalho e definir as suas preferências de escrita, esquemas "
+"de teclado e fontes de entrada"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Atalho;Área de trabalho;Janela;Redimensionar;Zoom;Inserir;Fonte;Bloquear;"
+"Volume;Trancar;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Serviços de localização desligados"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Nenhuma aplicação pode obter informação de localização."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Os serviços de localização permitem às aplicações saber a sua localização. A "
+"utilização de Wi-Fi e banda larga móvel aumenta a precisão.\n"
+"\n"
+"Utiliza o serviço de localização Mozilla: <a href='https://location.services."
+"mozilla.com/privacy'>Política de Privacidade</a>\n"
+"\n"
+"Permita que as aplicações abaixo indicadas determinem a sua localização."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Nenhuma aplicação requisitou acesso à localização"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Proteger os seus dados de localização"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "localização;gps;privado;privacidade;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Microfone desligado"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Nenhuma aplicação pode gravar som."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"A utilização do microfone permite às aplicações gravar e ouvir áudio. A "
+"desativação do microfone pode fazer com que algumas aplicações não funcionem "
+"corretamente.\n"
+"\n"
+"Permita que as aplicações abaixo indicadas utilizem o microfone."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Nenhuma aplicação requisitou acesso ao microfone"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Proteja as suas conversas"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "microfone;gravação;aplicação;privacidade;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Teste as _suas definições"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Geral"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Botão principal"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Define a ordem dos botões físicos no rato e painel tátil."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Esquerdo"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Direito"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Rato"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Velocidade do rato"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Deslocamento natural"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "O deslocamento move o conteúdo, não a vista."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Painel tátil"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Velocidade do painel tátil"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Tocar para clicar"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Tocar para clicar"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Deslocamento com dois dedos"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Deslocamento lateral"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Tente clicar, realizar duplo clique e deslocar"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinco cliques, hora de GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Clique duplo, botão principal"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Clique único, botão principal"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Clique duplo, botão do meio"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Clique único, botão do meio"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Clique duplo, botão secundário"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Clique único, botão secundário"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Rato e Painel tátil"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Alterar a sensibilidade do seu rato ou painel tátil e escolher entre destro "
+"ou canhoto"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Cursor;Clique;Toque;Duplo;Botão;Trackball;Deslocar;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Canto ativo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+"Toque no canto superior esquerdo para abrir a Visão geral das Atividades."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Margens de ecrã ativas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Arraste janelas contra os lados ou a parte superior do ecrã para as "
+"redimensionar."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Áreas de trabalho"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "Áreas de trabalho _dinâmicas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Remove automaticamente áreas de trabalho vazias."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "Número fixo de áreas de trabalho"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Especifique um número de áreas de trabalho permanentes."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Número de áreas de trabalho"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multi-Monitor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Áreas de trabalho apenas no ecrã _principal"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Áreas de trabalho em todos os ecrãs"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Comutação de aplicações"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Incluir aplicações de todas as áreas de trabalho"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Incluir apenas aplicações da área de trabalho atual"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitarefa"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Gerir preferências para produtividade e multitarefa"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitarefas;Multitarefa;Produtividade;Personalização;Ambiente de trabalho;"
+"Desktop;Canto ativo;Áreas de trabalho;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Algo correu mal. Contacte o seu fornecedor de software."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "O gestor de redes tem de estar em execução."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Outros dispositivos"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Adicionar ligação"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Indefinido"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Rede insegura (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Rede segura (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Rede segura (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Rede segura (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Rede segura"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Ligado"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opções…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Ligar o ponto de acesso há de desligá-lo de %s, e não será possível aceder à "
+"Internet por Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Requer um mínimo de 8 caracteres"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Deve ter um máximo de %d carácter"
+msgstr[1] "Deve ter um máximo de %d caracteres"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Ligar o ponto de acesso Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Um ponto de acesso Wi-Fi permite que outros partilhem a sua ligação à "
+"Internet ao criar uma rede Wi-Fi onde eles possam ligar-se. Para fazê-lo, "
+"deve ter acesso à Internet por outra fonte que não seja Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nome da rede"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Palavra-passe"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Gerar palavra-passe aleatória"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Auto-gerar palavra-passe"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Ligar"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Parar o ponto de acesso e desligar quaisquer utilizadores?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Parar o ponto de acesso"
+
+# Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Modo de avião"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Desativa o Wi-Fi, o Bluetooth e as redes móveis"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nenhum adaptador Wi-Fi encontrado"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Tenha a certeza de que tem um adaptador Wi-Fi ligado e ativado"
+
+# Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Modo de avião ligado"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Desligue-o para usar o Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Ponto de acesso Wi-Fi ativo"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Dispositivos móveis podem digitalizar o código QR para ligarem-se."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Desligar o ponto de acesso…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Redes visíveis"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "O gestor de redes tem de estar em execução"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Segurança 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Segurança"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Guardar"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanente"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Aleatório"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Estável"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"O endereço MAC inserido aqui será usado como endereço de equipamento "
+"informático nas redes em que este dispositivo está ligado. Esta "
+"funcionalidade é conhecida como clonagem ou alteração de MAC. Exemplo: "
+"00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Perfil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Aberta (Otimizada)"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Empresarial"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nenhuma"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i dia atrás"
+msgstr[1] "%i dias atrás"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nenhum"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Fraca"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Normal"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Boa"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excelente"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Endereço IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Endereço IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Endereço IP"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Esquecer a ligação"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Eliminar o perfil de ligação"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Eliminar VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Detalhes"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automático"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identidade"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Eliminar endereço"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Eliminar rota"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Nenhuma"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Chave WEP 40/128-bit (Hex ou ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Frase-passe WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP (802.1x) dinâmico"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA e WPA2 pessoal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA e WPA2 empresarial"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 pessoal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Força do sinal"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Velocidade da ligação"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Endereço do equipamento (MAC)"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Frequências suportadas"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Rota predefinida"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Última utilização"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Ligar _automaticamente"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Disponibilizar a _outros utilizadores"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Ligação com tráfego limitado: tem limite de dados ou pode decorrer encargos"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Atualização de aplicações e outras transferências demasiado grande não serão "
+"iniciadas automaticamente."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nome"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Endereço _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Endereço _clonado"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Método IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automático (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Apenas Ligação-Local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Desativar"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Partilhar com outros computadores"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Endereços"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Endereço"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Máscara de rede"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automático"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automático"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Endereço(s) do(s) servidor(es) DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Separar endereços de IP com vírgulas"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rotas"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Rotas automáticas"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Métrica"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Utilize esta ligaçã_o apenas para recursos na sua rede"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Método IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automático, apenas DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefixo"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Impossível abrir o editor de ligação"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Novo perfil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Definição inválida %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Definição inválida %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importar de ficheiro…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Adicionar VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_egurança"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Impossível importar a ligação VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"O ficheiro “%s” não pode ser lido ou não contém informação reconhecível de "
+"ligação VPN\n"
+"\n"
+"Erro: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Selecionar o ficheiro a importar"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Já existe um ficheiro com o nome “%s”."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "Substitui_r"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Deseja substituir %s com a ligação VPN que está a gravar?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Impossível exportar a ligação VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Não foi possível exportar a ligação VPN “%s” para %s.\n"
+"\n"
+"Erro: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exportar a ligação VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Erro: impossível ler o editor de ligação VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Controlar como se liga à Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Rede;IP;LAN;Proxy;WAN;Broadband;Banda;larga;Modem;Bluetooth;vpn;vlan;bridge;"
+"bond;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controlar como se liga à redes Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Rede;Wireless;Sem-fios;Wi-Fi;Wifi;IP;LAN;WAN;Broadband;Banda;larga;DNS;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nunca"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "hoje"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "ontem"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Última utilização"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Com cabo"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Adicionar uma nova ligação"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Os detalhes de rede das redes selecionadas, incluindo palavras-passe e "
+"quaisquer configurações personalizadas, serão perdidos."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Esquecer"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Redes Wi-FI conhecidas"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Esquecer"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "A política de sistema proíbe o uso como ponto de acesso"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "O dispositivo sem-fio não suporta o modo ponto de acesso"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"A descoberta automática de proxy Web é utilizada quando não é especificado "
+"um URL de configuração."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr ""
+"Esta opção não é recomendada em redes públicas que não são de confiança."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Desligar o dispositivo"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Ativo"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Fornecedor"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy de rede"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Servidor _Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorar servidores"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Porta do proxy HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Porta do proxy HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Porta do proxy FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Porta do proxy Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL de _configuração"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Desligar a ligação VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nome da rede"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tipo de segurança"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Palavra-passe"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Desativar o Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Mais opções…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Ligar-se a uma rede oculta…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Ligar o pon_to de acesso Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Redes Wi-Fi conhecidas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Estado desconhecido"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Sem gestão"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Indisponível"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "A ligar"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Autenticação necessária"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "A desligar"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Falha na ligação"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Estado desconhecido (em falta)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Falha na configuração"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Falha na configuração de IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Configuração de IP expirou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Eram requeridos segredos mas não foram fornecidos"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Suplicante 802.1x desligado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Falha ao configurar suplicante 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Falha no suplicante 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Suplicante 802.1x demorou demasiado tempo a autenticar-se"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Falha ao iniciar o serviço PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Serviço PPP desligado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Falha no PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Falha ao iniciar o cliente DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Erro no cliente DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Falha no cliente DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Falha ao iniciar o serviço de partilha de ligação"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Falha no serviço de partilha de ligação"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Falha ao iniciar o serviço AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Erro no serviço AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Falha no serviço AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linha ocupada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Sem som de ligação"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Impossível estabelecer uma ligação"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Pedido de ligação expirou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Falha ao tentar ligar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Falha ao inicializar o modem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Falha ao selecionar a APN especificada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Não procurar redes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Registo de rede negado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Expirou o registo de rede"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Falha ao registar na rede pedida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Falha ao verificar o PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Poderá faltar firmware no dispositivo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "A ligação desapareceu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "A ligação existente foi assumida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem não encontrado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Falha na ligação Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "O cartão SIM não está inserido"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Necessário o pin do SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Necessário o PUK do SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM incorreto"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Falha na dependência da ligação"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Falta firmware"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Cabo desligado"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "erro não definido na segurança 802.1x (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "nenhum ficheiro selecionado"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "erro não especificado ao validar o ficheiro eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Chaves privadas DER, PEM, PKCS#12, ou PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certificados DER ou PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "ficheiro EAP-FAST PAC em falta"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Ficheiros PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anónimo"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autenticado"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ambos"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Identidade anóni_ma"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Ficheiro PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Escolha um ficheiro PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autenticação _interna"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Permitir apro_visionamento automático PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "nome de utilizador EAP-LEAP em falta"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "palavra-passe EAP-LEAP em falta"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Utilizador"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "P_alavra-passe"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Ver _palavra-passe"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "certificado EAP-PEAP inválido: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "certificado EAP-PEAP inválido: nenhum certificado especificado"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versão 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versão 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificado _AC"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Escolha um certificado de Autoridade Certificadora"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Nenhum certificado AC é _necessário"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Versão PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "nome de utilizador EAP em falta"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "palavra-passe EAP em falta"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "identidade EAP-TLS em falta"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "certificado AC EAP-TLS inválido: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "certificado AC EAP-TLS inválido: nenhum certificado especificado"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "chave privada EAP-TLS inválida: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificado de utilizador EAP-TLS inválido: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Chaves privadas não encriptadas são inseguras"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"A chave privada selecionada não parece estar protegida por uma palavra-"
+"passe. Isto poderá permitir que as suas credenciais de segurança sejam "
+"comprometidas. Selecione uma chave privada protegida por palavra-passe.\n"
+"\n"
+"(Pode proteger com palavra-passe a sua chave privada utilizando o openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Escolha o seu certificado pessoal"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Escolha a sua chave privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentidade"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificado do _utilizador"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "C_have privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Palavra-passe da chave _privada"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "certificado EAP-TTLS inválido: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "certificado EAP-TTLS CA inválido: nenhum certificado especificado"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (sem EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domínio"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Erro desconhecido ao validar a segurança 802.11x"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS por túnel"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP protegido (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tenticação"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Selecionar um ficheiro"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "utilizador-leap em falta"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "palavra-chave-leap em falta"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Palavra-passe Wi-Fi em falta."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipo"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "chave-wep em falta"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"chave-wep inválida: a chave com um comprimento de %zu tem de ter apenas "
+"dígitos hexadecimais"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"chave-wep inválida: a chave com um comprimento de %zu tem de ter apenas "
+"carateres ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"chave-wep inválida: comprimento errado de %zu. A chave tem de ter "
+"comprimento 5/13 (ascii) ou 10/26 (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "chave-wep inválida: a frase-passe não pode estar vazia"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "chave-wep inválida: a frase-passe não pode ter menos de 64 carateres"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (predefinição)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistema aberto"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Chave partilhada"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "C_have"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Ver cha_ve"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Índice _WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk inválido: comprimento-chave inválido %zu. Tem de ser [8,63] bytes ou "
+"64 dígitos hexadecimais"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk inválido: não foi possível interpretar a chave com 64 bytes como "
+"hexadecimal"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificações"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alertas sonoros"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Notificações instantâneas"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"As notificações hão de aparecer na lista de notificações quando as "
+"notificações instantâneas estiverem desativadas."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Ver o _conteúdo da mensagem como notificações instantâneas"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notificações no ecrã b_loqueado"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Ver o _conteúdo da mensagem no ecrã bloqueado"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Não incomodar"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Notificações no ecrã b_loqueado"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controlar que notificações são apresentadas e o que mostram"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notificações;Faixas;Mensagem;Área de Notificação;Instantâneas;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Outro"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s removido"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Erro ao remover conta"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Desfazer"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Fechar a notificação"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Ligue-se aos seus dados na nuvem"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Sem ligação à Internet — ligue-se para definir novas contas online"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Adicionar uma conta"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Conta %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Remover conta"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Contas online"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Ligar-se às suas contas online e decidir como as utilizar"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Diálogo;Calendário;Correio;Contacto;"
+"ownCloud;Kerberos;IMAP;SMTP;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Tempo desconhecido"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuto"
+msgstr[1] "%i minutos"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hora"
+msgstr[1] "%i horas"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s e %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hora"
+msgstr[1] "horas"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuto"
+msgstr[1] "minutos"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s até que esteja completamente carregada"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Atenção: restam %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Restam %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Completamente carregada"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Não está a carregar"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Descarregada"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "A carregar"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "A descarregar"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Rato sem fios"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Teclado sem fios"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Fonte de energia de segurança (UPS)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Assistente digital pessoal"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Telemóvel"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Reprodutor multimédia"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Computador"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Dispositivo para jogos"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bateria"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principal"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Extra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Baterias"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Quando _inativo"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Suspender"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Desligar"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernar"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nada"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Quando funciona da bateria"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Quando ligado à corrente"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Suspender automaticamente"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Modo de desempenho temporariamente desativado devido à alta temperatura de "
+"funcionamento."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Colo detetado: modo de desempenho temporariamente indisponível. Mova o "
+"dispositivo para uma superfície estável para restaurar."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Modo de desempenho temporariamente desativado."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Bateria fraca: poupança de energia ativada. O modo anterior será restaurado "
+"quando a bateria estiver suficientemente carregada."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Modo poupança de energia ativado por \"%s\"."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Modo de desempenho ativado por \"%s\"."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 horas"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Modo de energia"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Afeta o desempenho do sistema e o uso de energia."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opções de poupança de energia"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Luminosidade automática do ecrã"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "O brilho do ecrã ajusta-se à luz envolvente."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Ecrã com pouca luz"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Reduz a luminosidade do ecrã quando o computador está inativo."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Ecrã em branco"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Desliga o ecrã após um período de inatividade."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Poupança de energia automática"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Ativa o modo de poupança de energia quando a bateria está fraca."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Suspender automaticamente"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Suspende o computador após um período de inatividade."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Comportamento do botão de desligar"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Ver a percentagem da bateria"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Suspender automaticamente"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Ligado à corrente"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "A funcionar da _bateria"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Atraso"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Desempenho"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Alto desempenho e utilização de energia."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Equilibrado"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Desempenho padrão e utilização de energia."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Poupança de energia"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Redução do desempenho e do consumo de energia."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energia"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Ver o estado da sua bateria e alterar as definições de poupança de energia"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Energia;Dormir;Suspender;Hibernar;Bateria;Brilho;Escurecer;Desligar;"
+"Monitorizar;DPMS;Inativo;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "A impressora “%s” foi eliminada"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Falha ao adicionar uma nova impressora."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Impossível carregar o UI: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Desbloquear para adicionar impressoras e alterar as definições"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Impressoras"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Adicionar impressoras, ver trabalhos de impressão e decidir como os deseja "
+"imprimir"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Impressora;Pilha;Imprimir;Papel;Tinta;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Adicionar impressora"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Desbloquear"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Nenhuma impressora encontrada"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Insira um endereço de rede ou nome o de uma"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autenticação necessária"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Insira o seu utilizador e palavra-passe para ver as impressoras disponíveis "
+"no servidor de impressão."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Utilizador"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Detalhes da impressora %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Não foi encontrado controlador adequado"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Selecionar ficheiro PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Ficheiros PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Os nomes das impressoras não podem conter ESPAÇO, TAB, #, ou /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Localização"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Controlador"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "A procurar por controladores preferidos…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Procurar por controladores"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Selecionar da base de dados…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instalar o ficheiro PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Selecione o controlador da impressora"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "A carregar a base de dados de controladores…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Selecionar"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Impressora JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Impressora LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Um lado"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Margem longa (padrão)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Margem curta (invertida)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Retrato"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Paisagem"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Paisagem invertida"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Retrato invertido"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Retomar"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pausa"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Pendente"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pausado"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autenticação necessária"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "A processar"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Parado"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Cancelado"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Abortado"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Terminado"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Mover este trabalho para o topo da fila"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u trabalho requer autenticação"
+msgstr[1] "%u trabalhos requerem autenticação"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - Trabalhos ativos"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Insira as credenciais para imprimir em %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domínio"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utenticar"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Fechar tudo"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autenticar"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Sem trabalhos de impressão ativos"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Desbloquear o servidor de impressão"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Desbloquear %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Insira o seu utilizador e palavra-passe para ver as impressoras disponíveis "
+"em %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "A procurar por impressoras"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Porta série"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Porta paralela"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Localização: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Endereço: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "O servidor requer autenticação"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dois lados"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tipo de papel"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Origem do papel"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Tabuleiro de saída"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolução"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Pré-filtragem GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Páginas por lado"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dois-lados"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientação"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Geral"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Configuração de página"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opções de instalação"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Trabalho"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Qualidade de imagem"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Cor"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Acabamento"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avançado"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Página de teste"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Página de teste"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Selecionar automaticamente"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Predefinição da impressora"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Embutir apenas fontes GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Converter em PS nível 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Converter em PS nível 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Nenhuma pré-filtragem"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricante"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Sem trabalhos ativos"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u Trabalho"
+msgstr[1] "%u Trabalhos"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Limpar as cabeças de impressão"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Com pouco toner"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Sem toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Com pouco revelador"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Sem revelador"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Com pouco de uma das cores"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Sem uma das cores"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Tampa aberta"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Porta aberta"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Com pouco papel"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Sem papel"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Desligada"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Parada"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Depósito de lixo quase cheio"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Depósito de lixo cheio"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Está a aproximar-se o final da vida útil do condutor ótico de imagem"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "O condutor ótico de imagem deixou de funcionar"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Preparada"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Não aceita trabalhos"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "A processar"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Opções de impressão"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Detalhes da impressora"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Usar a impressora por predefinição"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Limpar as cabeças de impressão"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Remover a impressora"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modelo"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nível da tinta"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Reinicie quando o problema for solucionado."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Reiniciar"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Adicionar impressora…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Sem impressoras"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Desculpe! O serviço de impressão do sistema\n"
+"    aparenta estar indisponível."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Procurar localizações…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Formatos comum"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Todos os formatos"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Sem resultados"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "A procura pode ser por países ou idiomas."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Antever"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Métrico"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datas"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Data e Hora"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Números"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Medida"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papel"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "O idioma e o formato serão alterados após o próximo acesso"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Terminar sessão…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"A definição do idioma é utilizada para o texto de interface e páginas web. "
+"Os formatos são utilizados para números, datas e moedas."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "A sua Conta"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Idioma"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formatos"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Ecrã de acesso"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Região e Idioma"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Selecionar o seu idioma de apresentação e formatos"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Idioma;Disposição;Esquema;Teclado;Introdução;Entrada;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Perguntar o que fazer"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Não fazer nada"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Abrir pasta"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Outro suporte"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Selecione uma aplicação para CDs de áudio"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Selecione uma aplicação para DVDs de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Selecione uma aplicação a executar ao ligar um reprodutor de música"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Selecione uma aplicação a executar ao ligar uma câmara"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Selecione uma aplicação para CDs de dados"
+
+# DVD de áudio
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "áudio DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "disco Blu-ray virgem"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "disco CD virgem"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "disco DVD virgem"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "disco HD DVD virgem"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Disco Blu-ray de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "leitor de e-books"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Disco HD DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "CD de imagens"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "CD super vídeo (SVCD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "CD de vídeo (VCD)"
+
+# Software Windows
+# Software do Windows
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Aplicação Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Selecione como gerir multimédia"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD de á_udio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Reprodutor de _música"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Aplicação"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Outro multimédia…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nunca questionar ou iniciar aplicações ao inserir um suporte"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Selecione como gerir outros suportes"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Ação:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipo:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Suportes removíveis"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configurar as definições de suportes removíveis"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;predefinição;aplicação;preferido;cd;dvd;usb;áudio;vídeo;"
+"disco;removível;media;autoiniciar;suporte;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "O ecrã desliga-se em"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 segundos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Bloqueio de ecrã"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Bloquear automaticamente o ecrã impede que outros acedam ao computador "
+"enquanto está ausente."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Compasso de espera para desligar o ecrã"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Período de inatividade após o qual o ecrã desliga-se."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "B_loquear o ecrã automaticamente"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Compasso de e_spera para bloquear automaticamente o ecrã"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Período até o ecrã desligar-se após o bloqueio automático."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Ver as _notificações no ecrã bloqueado"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Ignorar novos dispositivos _USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Impede que novos dispositivos USB interajam com o sistema quando o ecrã está "
+"bloqueado."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Privacidade de ecrã"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Ângulo de visão restrita"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Definições do ecrã"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "ecrã;bloquear;privado;privacidade;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Selecionar localização"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Aceitar"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Localizações onde procurar"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Pastas em que é feita a procura pelas aplicações do sistema, como "
+"Documentos, Imagens e Vídeos."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Locais"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Outros"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Adicionar localização"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nenhuma aplicação encontrada"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Pesquisa de aplicações"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Incluir resultados de pesquisa fornecidos pela aplicação."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Pastas que são pesquisadas por aplicações do sistema."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Resultados da pesquisa"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Os resultados são exibidos de acordo com a ordem da lista."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controlar que aplicações mostram resultados de pesquisa no Resumo de "
+"Atividades"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Procurar;Pesquisar;Localizar;Índice;Ocultar;Esconder;Privacidade;Resultados;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Sem rede selecionada para partilha"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Redes"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Ligado"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Desligado"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Ativo"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Ativo"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Selecione uma pasta"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Adicionar"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Ativar partilha de ficheiros"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Partilha de ficheiros permite-lhe partilhar a sua Pasta pública com outros "
+"na sua rede atual utilizando: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Se as autenticações remotas estão ativadas, utilizadores remotos podem ligar-"
+"se utilizando o comando de terminal seguro:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Ativar partilha de ficheiros pessoais"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Nome do dispositivo copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Endereço do dispositivo copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Nome de utilizador copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Palavra-passe copiada"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Partilhar"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Nome do _computador"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Partilha de _ficheiros"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Ambiente _de trabalho remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Partilha de _multimédia"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Início de sessão _remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Partilha de ficheiros"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Requerer palavra-passe"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Início de sessão remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Ambiente de trabalho remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"O ambiente de trabalho remoto permite visualizar e controlar o seu ambiente "
+"de trabalho a partir de outro computador."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Ativar ou desativar as ligações remotas a este computador."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Controlo remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Permite ligações remotas para controlar o ecrã."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Como estabelecer ligação"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Ligar a este computador usando o nome do dispositivo ou o endereço remoto do "
+"ambiente de trabalho."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copiar"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Endereço do ambiente de trabalho remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autenticação"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"O nome de utilizador e a palavra-passe são necessários para se ligar a este "
+"computador."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nome de utilizador"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Verificar encriptação"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Impressão digital encriptada"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"A impressão digital encriptada pode ser vista na ligação de clientes e deve "
+"ser idêntica."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Partilha de multimédia"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Partilhar música, fotografias e vídeos pela rede."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Pastas"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controlar o que deseja partilhar com outros"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"partilhar;partilha;ssh;máquina;nome;remota;desktop;média;áudio;vídeo;imagens;"
+"fotografias;filmes;servidor;desenho;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Ativar ou desativar o acesso remoto"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "É necessária autenticação para ativar ou desativar o acesso remoto"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Personalizado"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Clique"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Corda"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Movimento"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Zumbido"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balanço"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Desvanecimento"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Traseiro"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Frontal"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "A testar %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Clique num altifalante para o testar"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volume do sistema"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Volume principal"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Níveis de volume"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Saída"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Dispositivos de saída"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Teste"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuração"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Entrada"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Dispositivos de entrada"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volume"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Alerta sonoro"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Silenciar"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Som"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Alterar o volume do som, entradas, saídas e os sons de alerta"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Placa;Cartão;Microfone;Volume;Baixar;Balanço;Bluetooth;Auscultadores;Áudio;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Desligado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "A ligar"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Ligado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Erro de autenticação"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "A autenticar"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Funcionalidade reduzida"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Ligado e Autenticado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autenticado às:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Ligado às:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Registado às:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Falha ao autenticar o dispositivo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Falha ao esquecer o dispositivo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Depende de %u outro dispositivo"
+msgstr[1] "Depende de %u outros dispositivos"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Fechar notificação"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nome:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Estado:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autenticar e ligar"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Esquecer dispositivo"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Erro"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autenticado"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"O subsistema Thunderbolt (boltd) não está instalado ou não pode ser definido "
+"corretamente."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Permitir acesso direto a dispositivos como as acoplagens e GPUs externas."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Apenas dispositivos USB e Display Port podem acoplar."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"O Thunderbolt não pôde ser detetado.\n"
+"A razão pode ser a falta de suporte ao Thunderbolt no sistema, a desativação "
+"dele ou a definição para um nível de segurança não suportado na BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "O suporte ao Thunderbolt foi desativado no BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "O nível de segurança do Thunderbolt não pôde ser determinado."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Erro as alterar o modo direto: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Sem suporte ao Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Não foi possível a ligação ao subsistema do thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Acesso direto"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Dispositivos pendentes"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Sem dispositivos acoplados"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Gerir dispositivos Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacidade;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Piscar do cursor"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "O piscar do cursor nos campos de texto."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocidade"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Velocidade do piscar do cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Tamanho do cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"O tamanho do cursor pode ser combinado com a ampliação para torná-lo "
+"facilmente visível."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Assistente de Clique"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Clique secundário _simulado"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Gera um clique secundário premindo e mantendo o botão principal"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Atraso na a_ceitação:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Atraso no clique secundário"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Clique ao _pairar"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Gera um clique quando o ponteiro paira"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Atraso:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Tolerância de movimento:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Pequena"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetição de teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Teclado repete ao manter a tecla premida."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Atraso da repetição das teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocidade de repetição das teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Assistente de digitação"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Tecla_s pegajosas"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Considera uma sequência de teclas modificadoras como uma combinação de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desativar se forem premidas duas teclas simultaneamente"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Emitir som quando uma tecla _modificadora é premida"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Teclas _lentas"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Cria um compasso de espera entre a pressão de uma tecla e a sua aceitação"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Atraso na escrita das teclas lentas"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Emitir som ao premir uma t_ecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Emitir som quando uma tecla é _aceite"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Emitir som quando uma tecla é _rejeitada"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Teclas _saltantes"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignora pressões duplicadas rápidas de tecla"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Atraso na escrita das teclas saltantes"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Ativar por t_eclado"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Ativar ou desativar funcionalidades de acessibilidade utilizando o teclado"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Predefinição"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Médio"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Maior"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Maior ainda"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixels"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "V_er sempre o menu de acessibilidade"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Visão"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Alto _contraste"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Texto _grande"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Ativar a_nimações"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Locuto_r de ecrã"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "O locutor de ecrã lê o texto mostrado à medida que o foco é movido."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Teclas _sonorizadas"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Apitar quando Num Lock ou Caps Lock são ligados ou desligados."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Tamanho do cur_sor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Ampliação"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audição"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Alertas _visuais"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Teclado de ecrã"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "R_epetição de teclas"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Piscar do cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Assistente de _digitação (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Apontar e clicar"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Teclas de _rato"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Localizar o cursor"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Assistente de _clique"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Atraso do clique _duplo"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Atraso do clique duplo"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alertas Visuais"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Testar o flash"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Utilizar uma indicação visual quando ocorre um alerta sonoro."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Piscar o _ecrã inteiro"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Piscar a _janela inteira"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Curta"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ do ecrã"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ do ecrã"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ do ecrã"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Longa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Ecrã inteiro"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Metade superior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Metade inferior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Metade esquerda"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Metade direita"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Opções de ampliação"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "A_mpliação:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posição da ampliação:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Seguir o cursor do rato"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Parte do _ecrã:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Ampliação e_stende-se para lá do ecrã"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "M_anter o cursor de ampliação centrado"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Cursor da am_pliação move o conteúdo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Curs_or da ampliação move-se com o conteúdo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Ampliação"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Mira:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "S_obrepõe-se ao cursor do rato"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Espessura:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Fina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Espessa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Comprimento:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "C_or:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Mira"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efeitos de cor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Branco sobre preto:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Brilho:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contraste:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Cor"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Nenhuma"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Completa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Baixo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alto"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Baixo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alto"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efeitos de cor"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Tornar mais simples ver, ouvir, escrever, apontar e clicar"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Teclado;Rato;a11y;Acessibilidade;Acesso\n"
+"Universal;Contraste;Cursor;Zoom;Ampliação;Leitor;Ecrã;Texto;Fonte;Letra;"
+"Tamanho;AccessX;Pegajosas;Lentas;Saltantes;Rato;Duplo;Clique;Assistente;"
+"Velocidade;Repitição;Piscar;visual;audição;digitação;animações;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dia"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dias"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Esvaziar todos os itens do lixo?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Todos os itens no lixo serão apagados permanentemente."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Esvaziar o lixo"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Eliminar todos os ficheiros temporários?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Todos os ficheiros temporários serão apagados permanentemente."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Eliminar ficheiros tem_porários"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dia"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dias"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dias"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Para sempre"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Histórico de ficheiros"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"O histórico de ficheiros mantém um registo dos ficheiros que foram "
+"utilizados. Esta informação é partilhada entre as aplicações, e torna mais "
+"fácil encontrar ficheiros que pode querer utilizar."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "H_istórico de ficheiros"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Duração do _histórico de ficheiros"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Limpar o históri_co…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Lixo e ficheiros temporários"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"O lixo e os ficheiros temporários podem, por vezes, incluir informação "
+"pessoal e sensitiva. Eliminá-los automaticamente ajuda a proteger a sua "
+"privacidade."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Esvaziar o _lixo automaticamente"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Expurgar os _ficheiros temporários automaticamente"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Compasso de espera entre o esvaziar de lixo automaticamente"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Esvaziar o lixo…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Eliminar os ficheiros temporários…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Histórico de ficheiros e Lixo"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Não deixar rastros"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"utilização;recente;histórico;ficheiros;temporário;tmp;privado;privacidade;"
+"lixo;purga;retenção;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Deve coincidir com o endereço Web do seu fornecedor de conta."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Falha ao adicionar conta"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "As palavras-passe não coincidem."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Falha ao registar conta"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Nenhuma forma suportada de autenticar com este domínio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Falha ao ligar-se ao domínio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Este nome de acesso não funcionou.\n"
+"Tente novamente."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Esta palavra-passe de acesso não funcionou.\n"
+"Tente novamente."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Falha ao ligar-se ao domínio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Impossível encontrar o domínio. Talvez o tenha escrito mal?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Adicionar Utilizador"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrador"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Os administradores podem adicionar e remover outros utilizadores, e podem "
+"alterar as definições para todos os utilizadores. O controlo parental não "
+"pode ser aplicado aos administradores."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "O utilizador define a palavra-passe no primeiro acesso"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Definir palavra-passe agora"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Autenticação Empresarial"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Contas de utilizadores que são geridas por uma empresa ou organização."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Está desligado"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"O acesso empresarial permite que uma conta existente gerida centralmente "
+"seja usada neste dispositivo. Pode também utilizar esta conta para aceder "
+"aos recursos da companhia através da Internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Procurar por mais imagens"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Selecionar um ficheiro…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Gestor de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Não"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Sim"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Deseja eliminar as suas impressões digitais registadas de forma a que o "
+"acesso por impressões digitais seja desativado?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Nenhum dispositivo de impressão digital"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Nenhum dispositivo de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Tenha a certeza de que o dispositivo está ligado corretamente."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Dispositivo de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Escolha o dispositivo de impressão digital que quer configurar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Início de sessão com impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"O acesso por impressão digital permite-lhe desbloquear e autenticar-se no "
+"computador com o seu dedo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Eliminar as impressões digitais"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Registo de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "o dispositivo precisa de ser reivindicado para executar esta acção"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "o dispositivo já é reclamado por outro processo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "não tem permissão para executar a ação"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "não foram registadas impressões digitais"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Falha de comunicação com o dispositivo durante o registo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Falha na comunicação com o leitor de impressões digitais"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Falha na comunicação com o daemon das impressões digitais"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Falhou ao listar as impressões digitais: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Falhou ao eliminar as impressões digitais gravadas: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Polegar esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Dedo médio esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "Dedo indicador _esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Dedo anelar esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Dedo mindinho esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Polegar direito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Dedo médio direito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Dedo indicador _direito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Dedo anelar direito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Dedo mindinho direito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Dedo desconhecido"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Feito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Dispositivo de impressão digital desligado"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "O armazenamento de impressões digitais está cheio"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Falhou ao registar a nova impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Falhou ao iniciar a transcrição do registo: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Falhou ao registar a nova impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Falhou ao terminar a transcrição do registo: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Tire e ponha o seu dedo repetidamente no leitor para registar a sua "
+"impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Regravar este dedo…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Digitalizar um nova impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Falhou em largar o dispositivo de impressão digital %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problemas ao ler o dispositivo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Falhou ao requisitar pelo dispositivo de impressão digital %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Falhou ao obter dispositivos de impressão digital: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Esta semana"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Última semana"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e de %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, às %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sessão terminou"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sessão iniciada"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Atividade da conta"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Anterior"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Seguinte"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Selecione uma palavra-passe diferente."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Insira novamente a sua palavra-passe atual."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Impossível alterar a palavra-passe"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Alterar palavra-passe"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Alterar"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Palavra-passe atual"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nova palavra-passe"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Confirmar palavra-passe"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Permitir que o utilizador mude a palavra-passe ao iniciar a próxima sessão"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Definir uma palavra-passe agora"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Impossível ligar-se automaticamente a este tipo de domínio"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Domínio ou reino não encontrado"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Impossível iniciar sessão como %s no domínio %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Palavra-passe inválida. Tente novamente"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Impossível ligar-se ao domínio %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Falha ao eliminar o utilizador"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Falha ao revogar o utilizador gerido remotamente"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Não pode eliminar a sua própria conta."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ainda tem uma sessão ativa"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Eliminar um utilizador enquanto este tem uma sessão ativa pode deixar o "
+"sistema num estado inconsistente."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Deseja manter os ficheiros de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"É possível manter a pasta pessoal, spool de email e ficheiros temporários ao "
+"eliminar a conta de um utilizador."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Eliminar os ficheiros"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Manter os ficheiros"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Tem a certeza de que deseja revogar a conta gerida remotamente de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Eliminar"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Conta desativada"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "A ser definida ao iniciar a próxima sessão"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Nenhuma"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Com sessão ativa"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Falha ao contactar o serviço de contas"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Certifique-se que o AccountService está instalado e ativo."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Este painel deve ser desbloqueado para alterar esta definição"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Eliminar a conta de utilizador selecionada"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Para eliminar a conta de utilizador selecionada,\n"
+"clique primeiro no ícone *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Desbloquear para adicionar utilizadores e alterar as definições"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Utilizadores"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+"A sua sessão tem de ser reiniciada para que as alterações tenham efeito"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Reiniciar agora"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Fechar"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Editar avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Nome completo"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Editar"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Início de sessão com _impressão digital"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Início de sessão a_utomático"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "_Atividade da conta"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrador"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administradores podem adicionar ou remover outros utilizadores e podem mudar "
+"as definições de todos eles."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Controlo Parental"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Abrir a aplicação de Controlo Parental."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Remover utilizador…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Outros Utilizadores"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Adicionar Utilizador…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Sem utilizadores"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Desbloquear para criar uma conta de utilizador."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Adicionar ou eliminar utilizadores e alterar a sua palavra-passe"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Acesso;Nome;Impressão digital;Avatar;Logotipo;Rosto;Palavra-passe;Controlos "
+"parentais;Tempo de ecrã; Restrições de aplicações;Restrições da Web;Uso;"
+"Limite de uso;Miúdo,Criança;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Registar"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Início de sessão de administrador de domínio"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"De forma a utilizar contas empresariais, este computador\n"
+"tem de ser adicionado ao domínio. Peça ao administrador\n"
+"da sua rede para inserir aqui a sua palavra-passe de domínio."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nome do administrador"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Palavra-passe do administrador"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Gerir contas de utilizador"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "É necessária autenticação para alterar dados de utilizador"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "A nova palavra-passe tem de ser diferente da antiga."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Tente alterar algumas letras e números."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Tente alterar um pouco mais a palavra-passe."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Uma palavra-passe sem o seu nome de utilizador seria mais segura."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Tente não utilizar o seu nome na palavra-passe."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Tente não utilizar algumas das palavras incluídas na palavra-passe."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Tente evitar palavras comuns."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Tente evitar reordenar palavras existentes."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Tente utilizar mais números."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Tente utilizar mais letras maiúsculas."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Tente utilizar mais letras minúsculas."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Tente utilizar mais caracteres especiais, como pontuação."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Tente utilizar uma mistura de letras, números e pontuação."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Tente evitar repetir o mesmo carácter."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Tente evitar a repetição do mesmo tipo de carácter: deve misturar letras, "
+"números e pontuação."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Tente evitar sequências como 1234 ou abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"As palavras-passe tem de ser longas. Tente adicionar mais letras, números e "
+"pontuação."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Misture letras maiúsculas com minúsculas e tente utilizar um ou dois números."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Adicionar mais letras, números e pontuação há de tornar a palavra-passe mais "
+"forte."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Falha na autenticação"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "A nova palavra-passe é demasiado curta"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "A nova palavra-passe é demasiado simples"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "As palavras-passe antiga e nova são demasiado semelhantes"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "A nova palavra-passe já foi utilizada recentemente."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "A nova palavra-passe tem de conter caracteres numéricos ou especiais"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "As palavras-passe antiga e nova são idênticas"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "A sua palavra-passe foi alterada após se ter autenticado!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "A nova palavra-passe não contém caracteres distintos suficientes"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Erro desconhecido"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"O nome de utilizador apenas pode ser composto por letras minúsculas e "
+"maiúsculas de a-z, dígitos e os seguintes caracteres: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Este nome de utilizador não está disponível. Tente outro."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "O nome de utilizador é demasiado extenso."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Mapear botões"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Mapear botões para funções"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Para editar um atalho, escolha a ação \"Enviar toque de tecla\", prima o "
+"botão da tecla de atalho e mantenha premidas as novas teclas ou prima "
+"Backspace para limpar."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "Fe_char"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Toque nos respetivos marcadores à medida que surgem no ecrã para calibrar o "
+"tablet."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Detetada uma falha de clique, a reiniciar…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Botão %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplicação definida"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Enviar toque de tecla"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Trocar monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Mostrar ajuda no ecrã"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tablet montado no painel do portátil"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tablet montado no ecrã externo"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Dispositivo de tablet externo"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Dispositivo de painel externo"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Todos os ecrãs"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Modo tablet"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Utilizar posicionamento absoluto para a caneta"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientação da mão esquerda"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tablet e Express Keys™ são rodados para utilização com a mão esquerda"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapa para Monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Manter proporção"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Utilizar apenas uma parte da superfície do tablet para manter a proporção do "
+"monitor"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Calibrar"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nenhum tablet detetado"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Primeiro conecte ou ligue o seu tablet Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensibilidade da pressão da caneta"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Suave"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pressão da ponta da caneta stylus"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Botão 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botão 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botão 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensibilidade da pressão da borracha"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pressão da borracha"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Clique no botão do meio do rato"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Clique no botão direito do rato"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Avançar"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Caneta stylus airbrush com pressão, inclinação e deslizador integrado"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Caneta stylus airbrush com pressão, inclinação e rotação"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Caneta stylus padrão com pressão e inclinação"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Caneta stylus padrão com pressão"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tablet Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Ver o mapeamento dos botões e ajustar a sensibilidade do estilo de tablets "
+"gráficos"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Caneta;Stylus;Borracha;Rato;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Novo atalho…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Pontos de acesso"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operação cancelada"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Error:</b> Acesso negado a alteração de definições"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Error:</b> Erro de equipamento móvel"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Não registado"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registado"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "A procurar"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Negado"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Detalhes do modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Estado do modem"
+
+# Aqui creio que o termo certo é Operadora
+# Tipo "Operadora de telecomunicações"
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operadora"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tipo de rede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Estado da rede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Número próprio"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Detalhes do dispositivo"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Versão de firmware"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Apenas 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Apenas 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Apenas 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Apenas 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (Preferencial), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (Preferencial), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (Preferencial), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Preferencial), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Preferencial), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (Preferencial), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (Preferencial), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (Preferencial), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (Preferencial), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (Preferencial), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (Preferencial), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (Preferencial), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (Preferencial), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (Preferencial), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (Preferencial), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (Preferencial), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (Preferencial)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (Preferencial), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Desbloquear o cartão SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Desbloquear"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Forneça o código PIN do SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Inserir o PIN para desbloquear o cartão SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Forneça o código PUK do SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Inserir o PUK para desbloquear o cartão SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Palavra-passe incorreta introduzida. Ainda tem %1$u tentativa"
+msgstr[1] "Palavra-passe incorreta introduzida. Ainda tem %1$u tentativas"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Tem %u tentativa restante"
+msgstr[1] "Tem %u tentativas restantes"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Palavra-passe incorreta introduzida."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "O código PUK deve ser um número de 8 dígitos"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Introduza novo PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "O código PIN deve ser um número de 4-8 dígitos"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "A desbloquear…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Sem SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Insira um cartão SIM para usar este modem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM Bloqueado"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "Dados _moveis"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Aceder aos dados utilizando a rede móvel"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "Roaming de _dados"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Utilizar dados móveis em roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Modo de rede"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "R_ede"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avançado"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Nomes de pontos de _acesso"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Bloqueio _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Bloquear SIM com PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Detalhes do m_odem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Falha no telemóvel"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Sem ligação ao telemóvel"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operação não permitida"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operação não suportada"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Cartão SIM não está inserido"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Necessário PIN do cartão SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Necessário PUK do cartão SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Falha no cartão SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Cartão SIM ocupado"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Palavra-passe incorreta"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Necessário PIN2 do cartão SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Necessário PUK2 do cartão SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Não encontrado"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Sem serviço de rede"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Tempo limite de rede"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Serviços GPRS não permitidos"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming não permitido nesta área de localização"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Erro GPRS não especificado"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Nenhum erro"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Ação cancelada"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Acesso negado"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Erro desconhecido"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Modo de rede"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automático"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Escolha a rede"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Atualizar operadoras de rede"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Ativar rede móvel"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nenhum adaptador WWAN encontrado"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Certifique-se de que tem um dispositivo sem fios Wan/Celular"
+
+# Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "A Wan sem fios é desativada quando o modo de avião está ligado"
+
+# Em alternativa, em Portugal também se pode usar a expressão "Modo de voo"
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Desligar o modo de avião"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Ligação de dados"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Cartão SIM usado para internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Bloqueio SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Seguinte"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "Bloquear SIM com PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Alterar PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Introduza o PIN atual para alterar as definições de bloqueio do SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Rede móvel"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configurar ligações telefónicas e de dados móveis"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;wwan;telephony;sim;mobile;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilitários para configurar o ambiente de trabalho GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Definições é a sua interface principal para configurar o seu sistema."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Projeto GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Mostrar número de versão"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Ativar modo detalhado"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Procurar pela cadeia"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Listar nomes possíveis de painel e sair"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Painel a mostrar"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PAINEL] [ARGUMENTO…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categorias de definições"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privacidade"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Painéis disponíveis:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Todas as definições"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menu principal"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Aviso: versão em desenvolvimento"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Esta versão de Definições deve ser usada apenas para desenvolvimento. Pode "
+"incorrer em comportamento anormal do sistema, perda de dados, e outras "
+"falhas inesperadas. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Ajuda"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Geral"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Sair"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Procurar"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Painéis"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Voltar ao painel anterior"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Cancelar procura"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferências;Definições;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "O identificado do último painel de Definições a ser aberto"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"O identificado do último painel de Definições a ser aberto. Valores "
+"irreconhecíveis serão ignorados e o primeiro painel na lista há de ser "
+"selecionado."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Ver aviso quando a executar uma versão em desenvolvimento de Definições"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Se Definições deve mostrar um aviso quando a executar uma versão em "
+"desenvolvimento."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Estado inicial da janela"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Um \"tuple\" contendo a largura inicial, altura e estado maximizado da "
+"janela de aplicação."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u saída"
+msgstr[1] "%u saídas"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrada"
+msgstr[1] "%u entradas"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sons do sistema"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Erro: incapaz de determinar o nível HSI."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Erro: incapaz de determinar o nível de HSI incorreto."
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Adicionar uma impressora…"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificados DER ou PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Drip"
+#~ msgstr "Gotejar"
+
+#~ msgid "Glass"
+#~ msgstr "Tilintar"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "No Protection"
+#~ msgstr "Sem proteção"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "Proteção mínima"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Proteção básica"
+
+#~ msgid "Extended Protection"
+#~ msgstr "Proteção estendida"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "Proteções mínimas de segurança"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Proteções básicas de segurança"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Proteções de segurança estendidas"
+
+#~ msgid "SPI write"
+#~ msgstr "Gravação SPI"
+
+#~ msgid "SPI lock"
+#~ msgstr "Bloqueio SPI"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "Região de BIOS SPI"
+
+#~ msgid "Pre-boot DMA protection is"
+#~ msgstr "A proteção de DMA pré-arranque é"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "Kernel contaminado"
+
+#~ msgid "Suspend-to-ram"
+#~ msgstr "Suspender-para-ram"
+
+#~ msgid "All TPM PCRs are"
+#~ msgstr "Todos os PCRs TPM são"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "Modo de fabricação MEI"
+
+#~ msgid "MEI override"
+#~ msgstr "Substituição MEI"
+
+#~ msgid "MEI version"
+#~ msgstr "Versão MEI"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "plugins fwupd"
+
+#~ msgid "Intel DCI debugger"
+#~ msgstr "Depurador Intel DCI"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "Proteção de dispositivos IOMMU ativada"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "Proteção de dispositivos IOMMU desativada"
+
+#~ msgid "Kernel is no longer tainted"
+#~ msgstr "O Kernel já não está contaminado"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "O Kernel está contaminado"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "Bloqueio do kernel desativado"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "Bloqueio do kernel ativado"
+
+#~ msgid "Pre-boot DMA protection is disabled"
+#~ msgstr "A proteção de DMA pré-arranque está desativada"
+
+#~ msgid "Pre-boot DMA protection is enabled"
+#~ msgstr "A proteção de DMA pré-arranque está ativada"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "Arranque Seguro desativado"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "Arranque Seguro ativado"
+
+#~ msgid "All TPM PCRs are valid"
+#~ msgstr "Todos os PCRs TPM são válidos"
+
+#~ msgid "All TPM PCRs are now valid"
+#~ msgstr "Todos os PCRs TPM são agora válidos"
+
+#~ msgid "A TPM PCR is now an invalid value"
+#~ msgstr "Um PCR TPM é agora um valor inválido"
+
+#~ msgid "TPM PCR0 reconstruction is invalid"
+#~ msgstr "Reconstrução do TPM PCR0 é inválida"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Bloquear o seu ecrã"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Disposição de ecrãs"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "O Arranque Seguro está inativo"
+
+#~ msgid "Light"
+#~ msgstr "Claro"
+
+#~ msgid "Set"
+#~ msgstr "Definir"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "ecrã;bloquear;trancar;diagnósticos;falha;privado;recente;temporário;tmp;"
+#~ "índice;nome;rede;identidade;"
+
+#~ msgid "Bark"
+#~ msgstr "Ladrar"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Painel de som das definições GNOME"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Painel do Rato e Painel tátil das Definições GNOME"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Painel de fundo das definições GNOME"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Painel de teclado das definições GNOME"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autenticar"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Partilha de ecrã permite que os utilizadores remotos vejam ou controlem o "
+#~ "seu ecrã ligando-se a: %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Partilha do _ecrã"
+
+#~ msgid "_Password:"
+#~ msgstr "_Palavra-passe:"
+
+#~ msgid "_Show Password"
+#~ msgstr "Ver _palavra-passe"
+
+#~ msgid "Access Options"
+#~ msgstr "Opções de acesso"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Novas ligações têm de pedir acesso"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Requerer uma palavra-passe"
+
+#~ msgid "More Warm"
+#~ msgstr "Mais quente"
+
+#~ msgid "Less Warm"
+#~ msgstr "Menos quente"
+
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "Show the screenshot UI"
+#~ msgstr "Mostra a interface da captura de ecrã"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Tirar um captura de ecrã"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "Tirar uma captura de ecrã de uma janela"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "Mostra a interface de gravação do ecrã"
+
+#~ msgid "Move up"
+#~ msgstr "Mover acima"
+
+#~ msgid "Move down"
+#~ msgstr "Mover abaixo"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Permitir que as aplicações abaixo usem o seu microfone."
+
+#~ msgid "Standard"
+#~ msgstr "Padrão"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Tipo de conta"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Permitir que o uti_lizador defina uma palavra-passe ao iniciar a próxima "
+#~ "sessão"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Definir uma palavra-passe _agora"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "Tem de estar online para adicionar contas de utilizadores empresariais."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Tirar uma fotografia…"
+
+#~ msgid "Your account"
+#~ msgstr "A sua conta"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para realizar alterações,\n"
+#~ "clique primeiro no ícone *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Criar uma conta de utilizador"
+
+#~ msgid "User Icon"
+#~ msgstr "Ícone de utilizador"
+
+#~ msgid "Account Settings"
+#~ msgstr "Definições de conta"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autenticação e início de sessão"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Este será utilizado para dar o nome à sua pasta pessoal e não pode ser "
+#~ "alterado."
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Escolha o formato dos números, datas e moedas. As mudanças terão efeito "
+#~ "no próximo início de sessão."
+
+#~ msgid "My Account"
+#~ msgstr "Minha Conta"
+
+#~ msgid "Language"
+#~ msgstr "Idioma"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "O idioma utilizado para o texto em janelas e páginas web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr ""
+#~ "A sua sessão tem de ser reiniciada para que as alterações tenham efeito"
+
+#~ msgid "Restart…"
+#~ msgstr "Reiniciar…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Definições de início de sessão são utilizadas por todos os utilizadores "
+#~ "ao entrarem no sistema"
+
+#~ msgid "Output:"
+#~ msgstr "Saída:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Manter proporção (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapear para monitor único"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Mapeamento de disposição"
+
+#~ msgid "Stylus"
+#~ msgstr "Caneta"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (absoluto)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Painel tátil (relativo)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferências do tablet"
+
+#~ msgid "_Help"
+#~ msgstr "A_juda"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Definições de Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Modo de rastreio"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Mapear botões…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Ajustar definições de rato"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Ajustar a resolução do ecrã"
+
+#~ msgid "Decouple Display"
+#~ msgstr "Descolar ecrãs"
+
+#~ msgid "No stylus found"
+#~ msgstr "Nenhuma caneta encontrada"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Por favor, mova a sua caneta para perto do tablet para configurá-lo"
+
+#~ msgid "Top Button"
+#~ msgstr "Botão de topo"
+
+#~ msgid "Lower Button"
+#~ msgstr "Botão de fundo"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Botão mais ao fundo"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Gravar uma captura do ecrã em $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Gravar uma captura de uma área em $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copiar uma captura de ecrã para a área de transferência"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copiar uma captura de uma janela para a área de transferência"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copiar uma captura de uma área para a área de transferência"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Gravar um pequeno filme do ecrã"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Controle quais resultados da procura são expostos no Resumo de "
+#~ "Atividades. A ordem dos resultados da procura pode ser alterada ao mover "
+#~ "a posição das linhas na lista."
+
+#~ msgid "Web Links"
+#~ msgstr "Ligações Web"
+
+#~ msgid "Git Links"
+#~ msgstr "Ligações Git"
+
+#~ msgid "%s Links"
+#~ msgstr "Ligações %s"
+
+#~ msgid "Unset"
+#~ msgstr "Indefinida"
+
+#~ msgid "Links"
+#~ msgstr "Ligações"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Ficheiros de hipertexto"
+
+#~ msgid "Text Files"
+#~ msgstr "Ficheiros de texto"
+
+#~ msgid "Image Files"
+#~ msgstr "Ficheiros de imagem"
+
+#~ msgid "Font Files"
+#~ msgstr "Ficheiros de fonte"
+
+#~ msgid "Archive Files"
+#~ msgstr "Ficheiros de arquivo"
+
+#~ msgid "Package Files"
+#~ msgstr "Ficheiros de pacote"
+
+#~ msgid "Audio Files"
+#~ msgstr "Ficheiros de áudio"
+
+#~ msgid "Video Files"
+#~ msgstr "Ficheiros de vídeo"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permissões e Acesso"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Dados e serviços a que esta aplicação requisitou acesso e permissões "
+#~ "necessárias."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Impossível alterar"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Permissões individuais para aplicações podem ser revistas nas Definições "
+#~ "de <a href=\"privacy\">Privacidade</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integração"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Definir o fundo da área de trabalho"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Gestores predefinidos"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Tipo de ficheiros e ligações que esta aplicação abre."
+
+#~ msgid "Usage"
+#~ msgstr "Utilização"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Quanto dos recursos esta aplicação está a utilizar."
+
+#~ msgid "Open in Software"
+#~ msgstr "Abrir com Aplicações"
+
+#~ msgid "Display Mode"
+#~ msgstr "Modo de visualização"
+
+#~ msgid "Join Displays"
+#~ msgstr "Juntar ecrãs"
+
+#~ msgid "Single Display"
+#~ msgstr "Ecrã único"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Arraste ecrãs para igualá-los a sua configuração física de ecrãs. "
+#~ "Selecione um ecrã para alterar suas definições."
+
+#~ msgid "Active Display"
+#~ msgstr "Ecrã ativo"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Permitir que as aplicações abaixo usem a câmara."
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Os serviços de localização permitem às suas aplicações saberem a sua "
+#~ "localização. Utilizar Wi-Fi e redes móveis aumenta a sua eficácia."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Usa o serviço de localização Mozilla: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Políticas de Privacidade</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Permitir que as aplicações abaixo determinem a sua localização."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Portátil detetado: modo de desempenho indisponível"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Alta temperatura de equipamento: modo de desempenho indisponível"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Modo de desempenho indisponível"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Teclas de som"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Locutor de ecrã"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Locutor de ecrã"
+
+#~ msgid "Activities"
+#~ msgstr "Atividades"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Falha ao enviar o ficheiro: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "O perfil foi enviado para:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Anote este URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Reinicie este computador e inicie o seu sistema operativo normal."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Introduza este URL no seu navegador para transferir e instalar o perfil."
+
+#~ msgid "Upload profile"
+#~ msgstr "Enviar perfil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Requer ligação à Internet"
+
+#~ msgid "_Copy"
+#~ msgstr "_Copiar"
+
+#~ msgid "Select _All"
+#~ msgstr "Selecion_ar tudo"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Expiração de clique duplo"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Botão de suspender e desligar"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Alguns serviços estão inativos por não haver acesso à rede."
+
+#~ msgid "Unlocking..."
+#~ msgstr "A desbloquear..."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Iniciar sessão;Nome;Impressões digitais;Avatar;Imagem de perfil;Logótipo;"
+#~ "Cara;Face;Senha;Palavra;passe;"
+
+#~ msgid "Phone-adaptor link reserved"
+#~ msgstr "Ligação de adaptador de telefone reservada"
+
+#~ msgid "PH-SIM PIN required"
+#~ msgstr "PIN PH-SIM necessário"
+
+#~ msgid "PH-FSIM PIN required"
+#~ msgstr "PIN PH-FSIM necessário"
+
+#~ msgid "PH-FSIM PUK required"
+#~ msgstr "PUK PH-FSIM necessário"
+
+#~ msgid "Memory full"
+#~ msgstr "Memória cheia"
+
+#~ msgid "Memory failure"
+#~ msgstr "Falha de memória"
+
+#~ msgid "Network not allowed - emergency calls only"
+#~ msgstr "Rede não permitida - apenas chamadas de emergência"
+
+#~ msgid "Network personalization PIN required"
+#~ msgstr "PIN de personalização de rede necessário"
+
+#~ msgid "Network personalization PUK required"
+#~ msgstr "PUK de personalização de rede necessário"
+
+#~ msgid "Network subset personalization PIN required"
+#~ msgstr "PIN de personalização de subconjunto de rede necessário"
+
+#~ msgid "Network subset personalization PUK required"
+#~ msgstr "Personalização do subconjunto de rede PUK necessária"
+
+#~ msgid "Service provider personalization PIN required"
+#~ msgstr "PIN de personalização do prestador de serviços necessário"
+
+#~ msgid "Service provider personalization PUK required"
+#~ msgstr "PUK de personalização do prestador de serviços necessário"
+
+#~ msgid "Corporate personalization PIN required"
+#~ msgstr "PIN de personalização corporativa necessário"
+
+#~ msgid "Corporate personalization PUK required"
+#~ msgstr "PUK de personalização corporativa necessário"
+
+#~ msgid "Illegal MS"
+#~ msgstr "MS ilegal"
+
+#~ msgid "Illegal ME"
+#~ msgstr "Me ilegal"
+
+#~ msgid "PLMN not allowed"
+#~ msgstr "PLMN não permitido"
+
+#~ msgid "Location area not allowed"
+#~ msgstr "Área de localização não permitida"
+
+#~ msgid "Service option not supported"
+#~ msgstr "Opção de serviço não suportada"
+
+#~ msgid "Requested service option not subscribed"
+#~ msgstr "Opção de serviço solicitada não subscrita"
+
+#~ msgid "Service option temporarily out of order"
+#~ msgstr "Opção de serviço temporariamente fora de serviço"
+
+#~ msgid "PDP authentication failure"
+#~ msgstr "Falha na autenticação do PDP"
+
+#~ msgid "Invalid mobile class"
+#~ msgstr "Classe móvel inválida"
+
+#~ msgid "Balanced Power"
+#~ msgstr "Energia equilibrada"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Brilho do ecrã"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Brilho do teclado"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Escurecer o ecrã quando inativo"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "Ecrã _desligado"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "O Wi-Fi pode desligar-se para poupar energia."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "A banda larga móvel (3G, 4G, LTE, etc.) pode ser desligada para poupar "
+#~ "energia."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "O Bluetooth pode ser desligado para poupar energia."
+
+#~ msgid "Add…"
+#~ msgstr "Adicionar…"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Teclas de atalho"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Isso pode ser alterado em Personalizar atalhos"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Prima e digite para inserir caracteres alternativos"
+
+#~ msgid "Left Alt"
+#~ msgstr "Alt esquerdo"
+
+#~ msgid "Right Alt"
+#~ msgstr "Alt direito"
+
+#~ msgid "Left Super"
+#~ msgstr "Super esquerdo"
+
+#~ msgid "Right Super"
+#~ msgstr "Super direito"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl direito"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Tecla de carateres alternativos"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Alternar para fonte seguinte só com modificadoras"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Tecla Menu"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "A carregar"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Atenção"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Baixa"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Boa"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Completamente carregada"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Descarregada"
+
+#~ msgid "Previous source"
+#~ msgstr "Fonte anterior"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Espaço"
+
+#~ msgid "Next source"
+#~ msgstr "Fonte posterior"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Espaço"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt Esquerdo+Direito"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "É alterado ao longo do dia"
+
+#~ msgid "_Lock Screen"
+#~ msgstr "B_loquear ecrã"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Em mosaico"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Ampliação"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrado"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Preencher"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Esticar"
+
+#~ msgid "Colors"
+#~ msgstr "Cores"
+
+#~ msgid "Select Background"
+#~ msgstr "Selecionar o fundo"
+
+#~ msgid "Pictures"
+#~ msgstr "Imagens"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Pode adicionar imagens à sua pasta %s e estas vão aparecer aqui"
+
+#~ msgid "Back­ground"
+#~ msgstr "Fundo"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Cor"
+
+#~ msgid "∶"
+#~ msgstr ":"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Tampa fechada"
+
+#~ msgid "Mirrored"
+#~ msgstr "Ecrãs em espelho"
+
+#~ msgid "Secondary"
+#~ msgstr "Secundário"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Organizar ecrãs combinados"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Arraste os ecrãs para os reorganizar"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Rodar 90° à esquerda"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Rodar 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Rodar 90° à direita"
+
+#~ msgid "Size"
+#~ msgstr "Tamanho"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Mostrar a barra superior e a vista geral de atividades neste ecrã"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Unir este ecrã a outro para criar uma área de trabalho extra"
+
+#~ msgid "Presentation"
+#~ msgstr "Apresentação"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Mostrar só diaporamas e média"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Mostrar a sua vista existente em ambos os ecrãs"
+
+#~ msgid "Turn Off"
+#~ msgstr "Desligar"
+
+#~ msgid "Don't use this display"
+#~ msgstr "Não utilizar este ecrã"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Impossível obter informação do ecrã"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Organizar ecrãs combinados"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (ID da versão: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Overview"
+#~ msgstr "Resumo"
+
+#~ msgid "Version %s"
+#~ msgstr "Versão %s"
+
+#~ msgid "De­tails"
+#~ msgstr "Detalhes"
+
+#~ msgid "Base system"
+#~ msgstr "Sistema base"
+
+#~ msgid "Disk"
+#~ msgstr "Disco"
+
+#~ msgid "Check for updates"
+#~ msgstr "Procurar atualizações"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Atalho;Repetição;Piscar;"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Para editar um atalho, clique na linha correspondente e introduza uma "
+#~ "nova combinação de teclas ou prima Recuo para limpar."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Ação desconhecida>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "O atalho \"%s\" não pode ser utilizado pois tornará impossível escrever "
+#~ "utilizando esta tecla.\n"
+#~ "Por favor, tente com outra tecla tal como Control, Alt ou Shift "
+#~ "simultaneamente."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "O atalho \"%s\" já está a ser utilizado para\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "Se reatribuir o atalho a \"%s\", o atalho \"%s\" será desativado."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Reatribuir"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "O atalho \"%s\" tem um atalho \"%s\" associado. Quer defini-lo "
+#~ "automaticamente para \"%s\"?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" está atualmente associado a \"%s\", este atalho será desativado se "
+#~ "continuar."
+
+#~ msgid "_Assign"
+#~ msgstr "_Atribuir"
+
+#~ msgid "page 1"
+#~ msgstr "página 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "_Autenticação interna"
+
+#~ msgid "page 2"
+#~ msgstr "página 2"
+
+#~ msgid "Server"
+#~ msgstr "Servidor"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Eliminar o servidor DNS"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Par torcido (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Interface de unidade anexa (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Interface independente do media (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Disponibilizar a outros _utilizadores"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Zona de Firewall"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Predefinição"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "A zona define o nível de confiança da ligação"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "_Reset"
+#~ msgstr "_Repor"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Repor as definições desta rede, incluindo as senhas, mas recordá-la como "
+#~ "uma rede preferida"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Remover todos os detalhes relacionados com esta rede e não tentar ligar-"
+#~ "se automaticamente"
+
+#~ msgid "Net­work"
+#~ msgstr "Rede"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Se possuir uma ligação à Internet sem ser wireless, pode configurar um "
+#~ "hotspot wireless para a partilhar com outros."
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Ligar o hotspot wireless vai desligá-lo de <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Não é possível aceder à Internet através do seu wireless enquanto o "
+#~ "hotspot estiver ativo."
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Nenhum"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manual"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automático"
+
+#~ msgid "Group Name"
+#~ msgstr "Nome do grupo"
+
+#~ msgid "details"
+#~ msgstr "detalhes"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Mostr_ar a Senha"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Disponibilizar a outros utilizadores"
+
+#~ msgid "identity"
+#~ msgstr "identidade"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Só endereços automáticos (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Só ligação local"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignorar rotas obtidas automaticamente"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Endereço MAC _clonado"
+
+#~ msgid "hardware"
+#~ msgstr "equipamento"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Repor as predefinições desta ligação, mas recordá-la como uma ligação "
+#~ "preferida."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Remover todos os detalhes relacionados com esta rede e não tentar ligar-"
+#~ "se-lhe automaticamente."
+
+#~ msgid "Hardware"
+#~ msgstr "Equipamento"
+
+#~ msgid "_History"
+#~ msgstr "_Histórico"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Desligar para se ligar a uma rede Wi-Fi"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infraestrutura"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Faixas de _notificação"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Notificações"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Faixas de _notificação"
+
+#~ msgid "Add Account"
+#~ msgstr "Adicionar conta"
+
+#~ msgid "Mail"
+#~ msgstr "Correio"
+
+#~ msgid "Calendar"
+#~ msgstr "Calendário"
+
+#~ msgid "Contacts"
+#~ msgstr "Contactos"
+
+#~ msgid "Chat"
+#~ msgstr "Chat"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Erro ao iniciar sessão na conta"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Credenciais expiraram."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Iniciar sessão para ativar esta conta."
+
+#~ msgid "_Sign In"
+#~ msgstr "Iniciar _sessão"
+
+#~ msgid "Error creating account"
+#~ msgstr "Erro ao criar conta"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Tem a certeza que quer apagar a conta?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Isto não irá remover a conta no servidor."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Nenhuma conta online configurada"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Adicionar uma conta permite às suas aplicações aceder-lhe para obter "
+#~ "documentos, e-mail, contactos, calendário, diálogos e mais."
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "Suspender _automaticamente"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Quando o botão ligar é premido"
+
+#~ msgid "Po­wer"
+#~ msgstr "Energia"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "A configurar"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nível do toner"
+
+#~ msgid "Supply Level"
+#~ msgstr "Nível dos consumíveis"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "A instalar"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u ativo"
+#~ msgstr[1] "%u ativos"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Adicionar uma nova impressora"
+
+#~ msgid "Supply"
+#~ msgstr "Fornecer"
+
+#~ msgid "Jobs"
+#~ msgstr "Trabalhos"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Mostrar _trabalhos"
+
+#~ msgid "label"
+#~ msgstr "etiqueta"
+
+#~ msgid "page 3"
+#~ msgstr "página 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Imprimir página de _teste"
+
+#~ msgid "In use"
+#~ msgstr "A ser utilizado"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Ligado"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Desligado"
+
+#~ msgid "Usage & History"
+#~ msgstr "Utilização & Histórico"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Privacidade"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Proteja a sua informação pessoal e controle o que os outros podem ver"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Recordar o seu histórico torna as coisas mais fáceis de encontrar "
+#~ "novamente. Estes itens nunca são partilhados através da rede."
+
+#~ msgid "_Recently Used"
+#~ msgstr "Utilizado _recentemente"
+
+#~ msgid "Retain _History"
+#~ msgstr "Reter _histórico"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "O Bloqueio de ecrã protege a sua privacidade quando está ausente."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Bloquear o ecrã _após desligado por"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Expurgar automaticamente o lixo e os ficheiros temporários para ajudar a "
+#~ "manter o seu computador livre de dados sensíveis desnecessários."
+
+#~ msgid "Purge _After"
+#~ msgstr "Expurgar _após"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Ao enviar informação sobre que aplicações utiliza está a ajudar-nos a "
+#~ "oferecer-lhe recomendações mais detalhadas. Também nos ajuda a melhorar "
+#~ "as nossas aplicações.\n"
+#~ "\n"
+#~ "Toda a informação recolhida é anonimizada e os seus dados nunca serão "
+#~ "partilhados com terceiros."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Enviar estatísticas de utilização de aplicações"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Localização dos serviços"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Alternar para fonte anterior"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Alternar para fonte seguinte"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Mudança alternativa para fonte seguinte"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Inglês (Reino Unido)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Reino Unido"
+
+#~ msgid "Add input source"
+#~ msgstr "Adicionar fonte de entrada"
+
+#~ msgid "Remove input source"
+#~ msgstr "Remover fonte de entrada"
+
+#~ msgid "Move input source up"
+#~ msgstr "Mover fonte de entrada acima"
+
+#~ msgid "Move input source down"
+#~ msgstr "Mover fonte de entrada abaixo"
+
+#~ msgid "Configure input source"
+#~ msgstr "Configurar fonte de entrada"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Mostrar disposição de teclado da fonte de entrada"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Partilhar"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Esquerda"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Direita"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Mínimo"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Máximo"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Perfil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Testar os altifalantes"
+
+#~ msgid "Peak detect"
+#~ msgstr "Deteção de picos"
+
+#~ msgid "Device"
+#~ msgstr "Dispositivo"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "A testar os altifalantes para %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Escol_ha um dispositivo para saída de som:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Definições para o dispositivo selecionado:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Volume de _entrada:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Escol_ha um dispositivo para entrada de som:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Efeitos sonoros"
+
+#~ msgid "Built-in"
+#~ msgstr "Interno"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferências de som"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Testar o som de evento"
+
+#~ msgid "From theme"
+#~ msgstr "Do tema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Escol_ha um som de alerta:"
+
+#~ msgid "Stop"
+#~ msgstr "Parar"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Acesso universal"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Piscar o título da _janela"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Ativar início de sessão por impressões digitais"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Outro dedo:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "A sua impressão digital foi gravada com sucesso. Deverá agora ser capaz "
+#~ "de iniciar sessão usando o seu leitor de impressões digitais."
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Verificar nova senha"
+
+#~ msgid "Add User Account"
+#~ msgstr "Adicionar conta de utilizador"
+
+#~ msgid "Last Login"
+#~ msgstr "Última sessão"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Tente adicionar mais letras, números e símbolos."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Força: fraca"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Força: baixa"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Força: média"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Força: boa"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Força: alta"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Senhas não coincidem."
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Padrão"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrador"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Não possui permissões para aceder a este dispositivo. Contacte o "
+#~ "administrador do seu sistema."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Ocorreu um erro interno."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Eliminar as impressões digitais registadas?"
+
+#~ msgid "Done!"
+#~ msgstr "Terminado!"
+
+#~ msgid "Could not access '%s' device"
+#~ msgstr "Impossível aceder ao dispositivo \"%s\""
+
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr ""
+#~ "Impossível iniciar a captura de impressões digitais no dispositivo \"%s\""
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Impossível aceder a qualquer leitor de impressões digitais"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr ""
+#~ "Por favor, contacte o administrador do seu sistema para que o ajude."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "Para ativar o início de sessão por impressões digitais, tem de gravar uma "
+#~ "das suas impressões digitais utilizando o dispositivo \"%s\"."
+
+#~ msgid "Selecting finger"
+#~ msgstr "A selecionar o dedo"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Disable image"
+#~ msgstr "Desativar a imagem"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Procurar por mais imagens…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Utilizado por %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Outras contas"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para criar uma conta de utilizador,\n"
+#~ "clique primeiro no ícone *"
+
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "O nome de utilizador não pode começar por \"-\"."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Acima"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Abaixo"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Nenhuma"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Tablet Wacom"
+
+#~ msgid "Left Ring"
+#~ msgstr "Ring esquerdo"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Modo nº %d de Ring esquerdo"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Modo nº %d de Ring direito"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Touchstrip esquerdo"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Modo nº %d de Touchstrip esquerdo"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Touchstrip direito"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Modo nº %d de Touchstrip direito"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Interruptor de modo do Touchring esquerdo"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Interruptor de modo do Touchring direito"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Interruptor de modo do Touchstrip esquerdo"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Interruptor de modo do Touchstrip direito"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Interruptor de modo nº %d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Botão esquerdo nº%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Botão direito nº%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Botão de topo nº%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Botão de fundo nº%d"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Clique no botão esquerdo do rato"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Rolar acima"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Rolar abaixo"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Rolar à direita"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Centro de controlo GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME's main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "O centro de controlo é o ambiente principal para configuração de vários "
+#~ "apetos do seu ambiente de trabalho."
+
+#~ msgid "Show the overview"
+#~ msgstr "Mostrar o resumo"
+
+#~ msgid "Quit"
+#~ msgstr "Sair"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Equipamento"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistema"
+
+#~ msgid "Login History"
+#~ msgstr "Histórico de início de sessão"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Adicionar ligação de rede"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Nenhum certificado de autoridade certificadora selecionado"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Não utilizar um certificado de Autoridade Certificadora (AC) pode "
+#~ "resultar em ligações a redes Wi-Fi inseguras ou comprometidas. Deseja "
+#~ "selecionar um certificado de Autoridade Certificadora?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignorar"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Selecionar um certificado de AC"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "P_erguntar sempre por esta senha"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Não me avisar _novamente"
+
+#~ msgid "Yes"
+#~ msgstr "Sim"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -33,9 +33,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-05 19:41+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-06 21:36-0300\n"
 "Last-Translator: Enrico Nicoletto <hiko@duck.com>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -53,100 +52,7 @@ msgstr ""
 "X-DL-Domain: po\n"
 "X-DL-State: Translating\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Barramento de sistema"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Acesso completo"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Barramento de sessão"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Dispositivos"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Acesso completo a /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Rede"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Tem acesso à rede"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Pasta pessoal"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Somente leitura"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Sistema de arquivos"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Configurações"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Pode alterar as configurações"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s tem as seguintes permissões incorporadas. Estas não podem ser alteradas. "
-"Se você estiver preocupado com essas permissões, considere remover esse "
-"aplicativo."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u tipo de arquivo e link que é aberto pelo aplicativo"
-msgstr[1] "%u tipos de arquivo e link que são abertos pelo aplicativo"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> é usado para abrir os seguintes tipos de arquivos e links."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s de espaço em disco usado."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -162,7 +68,6 @@ msgid "Install some…"
 msgstr "Instalar alguns…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Abrir"
 
@@ -186,24 +91,13 @@ msgstr "Pesquisa"
 msgid "Receive system searches and send results."
 msgstr "Recebe pesquisa do sistema e envia resultados."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Desabilitado"
 
@@ -369,81 +263,21 @@ msgstr "Limpar cache…"
 msgid "Control various application permissions and settings"
 msgstr "Controle várias permissões e configurações de aplicativos"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "aplicativo;application;flatpak;permissão;permission;configuração;setting;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Selecionar uma imagem"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Cancelar"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Abrir"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "múltiplos tamanhos"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Nenhum plano de fundo"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Plano de fundo atual"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Estilo"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Padrão"
 
@@ -467,7 +301,6 @@ msgstr "Aparência"
 msgid "Change your background image or the UI colors"
 msgstr "Altere sua imagem de plano de fundo ou as cores da interface"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -523,9 +356,7 @@ msgstr "Modo avião via hardware está ligado"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Desligue o alternador do modo avião para habilitar o Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -533,7 +364,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Ligue e desligue o Bluetooth e conecte seus dispositivos"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "compartilhar;compartilhamento;bluetooth;obex;"
@@ -567,94 +397,33 @@ msgstr "Nenhum aplicativo pediu por acesso à câmera"
 msgid "Protect your pictures"
 msgstr "Proteja suas imagens"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "câmera;fotos;vídeo;webcam;bloqueio;privado;privacidade;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Posicione o dispositivo de calibração sobre o quadrado e pressione “Começar”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Mova seu dispositivo de calibração para a posição de calibração e pressione "
-"“Continuar”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Mova seu dispositivo de calibração para a posição da superfície e pressione "
-"“Continuar”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Feche a tampa do laptop"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Ocorreu um erro interno do qual não se pôde recuperar."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Ferramentas necessárias para a calibração não estão instaladas."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "O perfil não pôde ser gerado."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "O ponto branco alvo era impossível de se obter."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Concluído!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Configuração falhou!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Você pode remover o dispositivo de calibração."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Não interrompa o dispositivo de calibração durante o progresso"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibração da tela"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancelar"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -671,141 +440,6 @@ msgstr "Continua_r"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "Concluí_do"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Tela de laptop"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Webcam embutida"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Scanner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Câmera %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Impressora %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webcam %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Habilitar gerenciamento de cor para %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Mostrar perfis de cor de %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Não calibrado"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Padrão: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Espaço de cores: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Perfil de teste: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Selecionar perfil ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importar"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Perfis ICC suportados"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Todos arquivos"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Tela"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Salvar perfil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Salvar"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Criar um perfil de cor para o dispositivo selecionado"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"O instrumento de medição não foi detectado. Por favor, verifique se está "
-"ligado e conectado corretamente."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr ""
-"O instrumento de medição não tem suporte a criação de perfis de impressora."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Atualmente, não há suporte ao tipo de dispositivo."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -923,9 +557,9 @@ msgstr "Requer uma mídia gravável"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Você pode considerar úteis, essas instruções sobre como usar o perfil em "
 "sistemas <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e "
@@ -940,8 +574,8 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Detectaram-se problemas. O perfil pode não funcionar corretamente. <a href="
-"\"\">Mostrar detalhes.</a>"
+"Detectaram-se problemas. O perfil pode não funcionar corretamente. <a "
+"href=\"\">Mostrar detalhes.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -949,7 +583,6 @@ msgstr "_Importar arquivo…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -961,9 +594,7 @@ msgstr ""
 "Cada dispositivo precisa de uma atualização do perfil de cor para ter "
 "gerenciamento de cor."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Saiba mais"
 
@@ -1098,82 +729,6 @@ msgstr "D65 (fotografia e vídeos)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Espaço padrão"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Perfil de teste"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automático"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Baixa qualidade"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Média qualidade"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Alta qualidade"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Padrão RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Padrão CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Padrão cinza"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Dados de calibração de fábrica fornecidos pelo fabricante"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Correção de tela em tela cheia não é possível com este perfil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Este perfil pode não estar mais preciso"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Cor"
@@ -1185,14 +740,9 @@ msgstr ""
 "Calibre a cor dos seus dispositivos, tais como monitores, câmeras ou "
 "impressoras"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Cor;ICC;Perfil;Calibração;Impressão;Tela;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Outro…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1207,13 +757,8 @@ msgid "No languages found"
 msgstr "Nenhum idioma encontrado"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Mais…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Desbloquear para alterar as configurações"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1244,153 +789,6 @@ msgstr "Reduzir hora"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Reduzir minuto"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Hoje"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Ontem"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e de %b de %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d hora"
-msgstr[1] "%d horas"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minuto"
-msgstr[1] "%d minutos"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d segundo"
-msgstr[1] "%d segundos"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 segundos"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Ponto de acesso"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 horas"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-# Formato 12hs, não alterar para 24h
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e de %B de %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e de %B de %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-# Formato 12hs, não alterar para 24h
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1485,17 +883,11 @@ msgstr "_Fuso horário automático"
 msgid "Requires location services enabled and internet access"
 msgstr "Requer serviços de local habilitado e acesso à Internet"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Habilitado"
 
@@ -1503,15 +895,43 @@ msgstr "Habilitado"
 msgid "Time Z_one"
 msgstr "Fuso h_orário"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Desbloquear"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Formato da hora"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datas"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 segundos"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calendário"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Números"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Altere a data e hora, incluindo fuso horário"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Relógio;Fuso horário;Localização;"
@@ -1558,20 +978,9 @@ msgstr "Aplicativos padrão"
 msgid "Configure Default Applications"
 msgstr "Configure os aplicativos padrão"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "padrão;aplicativo;preferido;mídia;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Enviar relatórios de problemas técnicos nos ajuda a melhorar o %s. Os "
-"relatórios são enviados anonimamente e não contêm dados pessoais. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1589,44 +998,9 @@ msgstr "Diagnóstico"
 msgid "Report your problems"
 msgstr "Relate seus problemas"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnósticos;falha;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Ligada"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Desligada"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Aplicar alterações?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Alterações não puderam ser aplicadas"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Isso pode ser devido a limitações de hardware."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1676,31 +1050,6 @@ msgstr "Tela primária"
 msgid "Night Light"
 msgstr "Luz noturna"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Paisagem"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Retrato (virado)"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Retrato"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Paisagem (virada)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1724,6 +1073,21 @@ msgstr "Ajustar para TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Dimensão"
+
+# Todas as referências que encontrei em português falavam em "zona de
+# rolagem"; em inglês "edge scrolling" é feito na "scroll zone" mas não achei
+# algo como "rolagem na borda" em português. -- Leonardo Fontenelle
+#
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Rolagem natural"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1821,7 +1185,6 @@ msgstr "Telas"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Escolha como usar os monitores e projetores conectados"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1830,81 +1193,6 @@ msgstr ""
 "Painel;Projetor;xrandr;Tela;Resolução;Atualizar;Atualização;Monitor;Noite;"
 "Noturna;Luz;Azul;Desvio para o vermelho;redshift;cor;pôr do sol;nascer do "
 "sol;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "A inicialização segura esta ativa"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"A inicialização segura impede que softwares maliciosos sejam carregados "
-"quando o dispositivo é iniciado. Ela está atualmente ligada e está "
-"funcionando corretamente."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "A inicialização segura apresenta problemas"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"A inicialização segura impede que softwares maliciosos sejam carregados "
-"quando o dispositivo é iniciado. Ela está ativada no momento, mas não "
-"funcionará devido a uma chave inválida."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Os problemas com inicialização segura geralmente podem ser resolvidos nas "
-"configurações de firmware UEFI (BIOS) do seu computador e o fabricante do "
-"hardware pode fornecer informações sobre como fazer isso."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Para obter ajuda, entre em contato com o fabricante do hardware ou com o "
-"provedor de suporte de TI."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "A inicialização segura está desativada"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"A inicialização segura impede que o software malicioso seja carregado quando "
-"o dispositivo for iniciado. Atualmente está desligada."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"A inicialização segura geralmente pode ser ativada nas configurações de "
-"firmware UEFI (BIOS) do seu computador. Para obter ajuda, entre em contato "
-"com o fabricante do hardware ou com o provedor de suporte de TI."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1919,132 +1207,9 @@ msgstr ""
 "Para obter mais informações, entre em contato com o fabricante do hardware "
 "ou com o suporte de TI."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Passou"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Falhou"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "O dispositivo está em conformidade com o nível de segurança HSI %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Nível de segurança 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Este dispositivo não tem proteção contra problemas de segurança de hardware. "
-"Isso pode ser devido a um problema de configuração de hardware ou firmware. "
-"É recomendável entrar em contato com seu provedor de suporte de TI."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Nível de segurança 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Este dispositivo tem proteção mínima contra problemas de segurança de "
-"hardware. Este é o nível de segurança mais baixo do dispositivo e fornece "
-"proteção apenas contra ameaças de segurança simples."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Nível de segurança 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Este dispositivo tem proteção básica contra problemas de segurança de "
-"hardware. Isso fornece proteção contra algumas ameaças de segurança comuns."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Nível de segurança 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Este dispositivo tem proteção estendida contra problemas de segurança de "
-"hardware. Este é o nível mais alto de segurança do dispositivo e oferece "
-"proteção contra ameaças de segurança avançadas."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Nível de segurança"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Os níveis de segurança não estão disponíveis para este dispositivo."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Entre em contato com o fabricante do hardware para obter ajuda com "
-"atualizações de segurança."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Talvez seja possível resolver esse problema nas configurações de firmware "
-"UEFI do dispositivo ou por um técnico de suporte."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Talvez seja possível resolver esse problema nas configurações de firmware "
-"UEFI do dispositivo."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Talvez um técnico de suporte possa resolver esse problema."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2058,338 +1223,9 @@ msgstr "Nível 2"
 msgid "Level 3"
 msgstr "Nível 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Protegido contra software malicioso quando o dispositivo é iniciado."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "A inicialização segura está com problemas"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Alguma proteção é fornecida quando o dispositivo é iniciado."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "A Inicialização segura está desligada"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Sem proteção quando o dispositivo é iniciado."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Esse problema pode ter sido causado por uma alteração nas configurações do "
-"firmware UEFI, uma alteração na configuração do sistema operacional, ou por "
-"software malicioso no sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Esse problema pode ter sido causado por uma alteração nas configurações do "
-"firmware UEFI, ou por software malicioso no sistema."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Esse problema pode ter sido causado por uma alteração na configuração do "
-"sistema operacional, ou por software malicioso no sistema."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Altamente exposto a ameaças de segurança."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Proteção limitada contra falhas de segurança simples."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Protegido contra falhas de segurança comuns."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Protegido contra uma ampla gama de falhas de segurança."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Proteção compreensiva"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Sem eventos"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Proteção contra gravação do firmware"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Trava de proteção contra gravação do firmware"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Região Firmware do BIOS"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Descritor Firmware do BIOS"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Proteção de DMA na pré-inicialização"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Inicialização verificada pelo Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Protegido pelo ACM do Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Política de erros do Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Fusão do Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET Ativado"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET ativado"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "RAM Encriptada"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Proteção IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux Kernel Lockdown"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Verificação do Kernel Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Área de troca"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Suspender para RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Suspender para inativo"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Chave da plataforma UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "inicialização segura UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Configuração da Plataforma TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Reconstrução do TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel Management Engine em Modo de Fabrica"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Substituição do Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Substituição do Intel Management Engine"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Atualizações de firmware"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Atestação do firmware"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Verificação do atualizador do firmware"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Depuração de plataforma"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Verificação de segurança do processador"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Proteção de reversão AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Proteção contra reprodução de firmware AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Proteção contra gravação do firmware AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Plataforma fundida"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Válido"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Inválido"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Desabilitado"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Bloqueado"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Desbloqueado"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Encriptado"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Não encriptado"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Comprometido"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Não comprometido"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Encontrado"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Não localizado"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Suportado"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Sem suporte"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2399,7 +1235,6 @@ msgstr "Segurança do dispositivo"
 msgid "Host firmware security status"
 msgstr "Status de segurança do firmware do dispositivo"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2407,49 +1242,6 @@ msgid ""
 msgstr ""
 "tela;bloqueio;diagnostico;travamento;privado;recente;temporário;índice;nome;"
 "rede;identidade;privacidade;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64 bits"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32 bits"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Indisponível"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logotipo do sistema"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2543,11 +1335,6 @@ msgstr "Sobre"
 msgid "View information about your system"
 msgstr "Veja informações sobre seu sistema"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2627,6 +1414,12 @@ msgstr "Lançadores"
 msgid "Launch help browser"
 msgstr "Navegador de ajuda"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Configurações"
+
 # Retirado Lançar conforme sugestão em https://gitlab.gnome.org/Teams/Translation/pt_BR/-/issues/14
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -2651,7 +1444,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Pesquisar"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistema"
 
@@ -2700,15 +1493,6 @@ msgstr "Diminuir o tamanho do texto"
 msgid "High contrast on or off"
 msgstr "Ativar ou desativar o alto contraste"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nenhuma fonte de entrada encontrada"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Outro"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Adicionar uma fonte de entrada"
@@ -2741,106 +1525,9 @@ msgstr "Preferências"
 msgid "View Keyboard Layout"
 msgstr "Ver disposição de teclado"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Remover"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Atalhos personalizados"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Tecla de caracteres alternativos"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"A tecla de caracteres alternativos pode ser usada para inserir caracteres "
-"adicionais. Às vezes, eles são impressos como uma terceira opção no teclado."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt da esquerda"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt da direita"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Super da esquerda"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Super da direita"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tecla de menu"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl da direita"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Tecla de composição"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"A tecla de composição permite que uma ampla variedade de caracteres sejam "
-"inseridos. Para usá-la, pressione a composição seguida pela sequência de "
-"caracteres. Por exemplo, tecla de composição seguida por <b>C</b> e <b>o</b> "
-"vai inserir <b>©</b>, <b>a</b> seguido por <b>'</b> vai inserir <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"As fontes de entrada podem ser alternadas usando o atalho de teclado %s.\n"
-"Isso pode ser alterado nas configurações de atalhos de teclado."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2870,45 +1557,21 @@ msgstr "Entrada de caracteres especiais"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Métodos para inserir símbolos e variantes de letras usando o teclado."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de caracteres alternativos"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composição"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Atalhos de teclado"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Veja e personalize atalhos"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modificado"
-msgstr[1] "%d modificados"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Redefinir todos os atalhos?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Redefinir os atalhos pode afetar seus atalhos personalizados. Isso não pode "
-"ser desfeito."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Redefinir todos"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2948,34 +1611,6 @@ msgstr "Adicionar atalho"
 msgid "No keyboard shortcut found"
 msgstr "Nenhum atalho de teclado localizado"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s está sendo usado para %s. Se você substituí-lo, %s será desabilitada"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Insira um novo atalho"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Definir atalhos personalizados"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Definir atalho"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Insira um novo atalho para %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Adicionar atalho personalizado"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "Remover"
@@ -2987,7 +1622,6 @@ msgstr "Substituir"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "De_finir"
 
@@ -3025,6 +1659,11 @@ msgstr "Nenhum"
 msgid "Reset the shortcut to its default value"
 msgstr "Redefine o atalho para seu valor padrão"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Usar como impressora padrão"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Teclado"
@@ -3037,7 +1676,6 @@ msgstr ""
 "Altere os atalhos de teclado e defina suas preferências de digitação, "
 "disposições de teclado e fontes de entrada"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3079,7 +1717,6 @@ msgstr "Nenhum aplicativo pediu por acesso à localização"
 msgid "Protect your location information"
 msgstr "Proteja suas informações de localização"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "localização;gps;privado;privacidade;"
@@ -3114,7 +1751,6 @@ msgstr "Nenhum aplicativo pediu por acesso ao microfone"
 msgid "Protect your conversations"
 msgstr "Projeta suas conversas"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "microfone;gravação;aplicação;privacidade;"
@@ -3144,85 +1780,139 @@ msgstr "Esquerda"
 msgid "Right"
 msgstr "Direita"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Pesquisar localizações"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mouse"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Velocidade do mouse"
 
-# Todas as referências que encontrei em português falavam em "zona de
-# rolagem"; em inglês "edge scrolling" é feito na "scroll zone" mas não achei
-# algo como "rolagem na borda" em português. -- Leonardo Fontenelle
-#
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Rolagem natural"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Seção"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "A rolagem move o conteúdo, não a visão."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "A rolagem move o conteúdo, não a visão."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Ativo"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Velocidade do touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Toque para clicar"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Toque para clicar"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Rolagem com dois dedos"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relativo)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Rolagem na borda"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dois lados"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Tente realizar um clique, clique duplo, rolagem"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinco cliques, hora de GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Clique duplo, botão primário"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Clique único, botão primário"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Clique duplo, botão do meio"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Clique único, botão do meio"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Clique duplo, botão secundário"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Clique único, botão secundário"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3235,7 +1925,6 @@ msgstr ""
 "Altere a sensibilidade do seu mouse ou touchpad e selecione modo canhoto ou "
 "destro"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3318,7 +2007,6 @@ msgstr "Multitarefas"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Gerencie preferências para produtividade e multitarefas"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3326,20 +2014,11 @@ msgstr ""
 "Multitarefas;Multitarefa;Produtividade;Personalizar;Área de trabalho;Canto "
 "ativo;Espaços de trabalho;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Oops, algo deu errado. Por favor contate o seu fornecedor de software."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "O NetworkManager precisa estar em execução."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Outros dispositivos"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3351,59 +2030,16 @@ msgstr "Adicionar nova conexão"
 msgid "Not set up"
 msgstr "Não configurado"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Rede insegura (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Rede segura (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Rede segura (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Rede segura (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Rede segura"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Conectado"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opções…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Ligar o ponto de acesso vai lhe desconectar de %s e não será possível "
-"acessar a Internet por meio do Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Deve haver um mínimo de 8 caracteres"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3454,20 +2090,6 @@ msgstr "Gerar senha automaticamente"
 msgid "_Turn On"
 msgstr "_Ligar"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Parar ponto de acesso e desconectar todos os usuários?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Parar ponto de acesso"
-
 # Traduções viáveis são "Modo avião", "Modo voo" ou até "Modo de avião". Achei por melhor manter a primeira opção
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
@@ -3514,89 +2136,13 @@ msgstr "Redes visíveis"
 msgid "NetworkManager needs to be running"
 msgstr "O NetworkManager precisa estar em execução"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Oops, algo deu errado. Por favor contate o seu fornecedor de software."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Segurança 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Segurança"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Preservar"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanente"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Aleatório"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Estável"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"O endereço MAC inserido aqui será usado como endereço de hardware para o "
-"dispositivo de rede em que esta conexão está ligada. Esse recurso é "
-"conhecido como clonagem ou falsificação de MAC. Exemplo: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Perfil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Empresarial"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nenhuma"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Nunca"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3605,183 +2151,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i dia atrás"
 msgstr[1] "%i dias atrás"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nenhum"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Fraca"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Boa"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excelente"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Endereço IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Endereço IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Endereço IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Esquecer conexão"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Remover o perfil de conexão"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Remover VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Detalhes"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automático"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identidade"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Excluir endereço"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Excluir rota"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Nenhum"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP chave de 40/128-bit (Hex ou ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP senha de 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP dinâmico (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 pessoal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 empresarial"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 pessoal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3792,8 +2161,20 @@ msgstr "Força do sinal"
 msgid "Link speed"
 msgstr "Velocidade do link"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Segurança"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Endereço IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Endereço IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Endereço físico"
 
@@ -3802,12 +2183,17 @@ msgid "Supported Frequencies"
 msgstr "Frequências suportadas"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Rota padrão"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3871,7 +2257,7 @@ msgstr "Apenas conexão local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
@@ -3915,9 +2301,8 @@ msgstr "Gateway"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automático"
 
@@ -3970,89 +2355,9 @@ msgstr "Automático, somente DHCP"
 msgid "Prefix"
 msgstr "Prefixo"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Não foi possível abrir o editor de conexão"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Novo perfil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Configuração inválida %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Configuração inválida %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importar de arquivo…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Adicionar VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_egurança"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Não foi possível importar conexão VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"O arquivo “%s” não pode ser lido ou não possui informações de conexão VPN "
-"reconhecíveis\n"
-"\n"
-"Erro: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Selecione um arquivo para importar"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Um arquivo de nome “%s” já existe."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Substituir"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Deseja substituir %s com a conexão VPN que você está salvando?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Não foi possível exportar conexão VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"A conexão VPN “%s” não pode ser exportada para %s.\n"
-"\n"
-"Erro: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Exportar conexão VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4066,103 +2371,39 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rede"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controle como você conecta à Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Rede;Network;IP,LAN;Proxy;WAN;Banda larga;Broadband;Modem;Bluetooth;vpn;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controle como você conecta a redes Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Rede;Network;Sem fio;Wireless;Wi-Fi;Wifi;IP;LAN;Banda larga;Broadband;DNS;"
 "Ponto de acesso;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nunca"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "hoje"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "ontem"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Último uso"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Com fio"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Adicionar nova conexão"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Detalhes de rede selecionadas, incluindo senhas e qualquer configuração "
-"personalizada serão perdidos."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Esquecer"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Redes Wi-Fi conhecidas"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Esquecer"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "A política do sistema proíbe o uso de um ponto de acesso"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr ""
-"O dispositivo de rede sem fio não possui suporte a modo de ponto de acesso"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Autodescoberta de um Proxy Web é usada quando a URL de configuração não é "
-"fornecida."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Isto não é recomendado para as redes públicas não confiáveis."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4181,6 +2422,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Provedor"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Endereço IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4265,291 +2510,6 @@ msgstr "_Ligar ponto de acesso Wi-Fi…"
 msgid "_Known Wi-Fi Networks"
 msgstr "Redes _Wi-Fi conhecidas"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Estado desconhecido"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Não gerenciável"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Indisponível"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Conectando"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Autenticação necessária"
-
-# http://en.wikipedia.org/wiki/Font_hinting
-# (não entendi a relação link-frase, mas vou deixar - Rafael)
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Desconectando"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Conexão falhou"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Estado desconhecido (perdido)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Configuração falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Configuração de IP falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Configuração de IP expirou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Senhas foram exigidas, mas não foram fornecidas"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Suplicante 802.1x desconectado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Configuração do suplicante 802.1x falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Suplicante 802.1x falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Suplicante 802.1x levou tempo demais para autenticar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Serviço PPP falhou em iniciar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Serviço PPP desconectado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Serviço PPP falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Cliente DHCP falhou em iniciar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Erro no cliente DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Cliente DHCP falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "O serviço de conexão compartilhada falhou ao iniciar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "O serviço de conexão compartilhada falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Serviço de AutoIP falhou em iniciar"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Erro no serviço AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Serviço de AutoIP falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linha ocupada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Não há tom de discagem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Nenhuma transportadora pode ser estabelecida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Requisição de discagem alcançou limite de tempo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Tentativa de discagem falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Inicialização do modem falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Falha ao selecionar o APN especificado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Não está pesquisando por redes"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Registro à rede negado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Registro de rede alcançou limite de tempo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Falhou ao registrar com a rede requisitada"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Verificação de PIN falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Firmware do dispositivo pode estar faltando"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Conexão desapareceu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "A conexão existente foi presumida"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem não encontrado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Conexão Bluetooth falhou"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Cartão SIM não inserido"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Pin do SIM obrigatório"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Puk do SIM obrigatório"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM errado"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Falha na dependência da conexão"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Faltando firmware"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Cabo desconectado"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "erro indefinido na segurança 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "nenhum arquivo selecionado"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "erro não especificado ao validar arquivo de método eap"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Chaves privadas DER, PEM ou PKCS#12 "
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Certificados DER ou PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "faltando arquivo PAC EAP-FAST"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Arquivos PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4598,14 +2558,6 @@ msgstr "Autenticação _interna"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Permitir pro_visionamento PAC automático"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "faltando nome de usuário EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "faltando senha EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4631,15 +2583,6 @@ msgstr "_Senha"
 msgid "Sho_w password"
 msgstr "_Mostrar senha"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "certificado de AC EAP-PEAP inválido: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "certificado de AC EAP-PEAP inválido: nenhum certificado especificado"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4661,7 +2604,6 @@ msgid "C_A certificate"
 msgstr "Certificado de A_C"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4676,63 +2618,6 @@ msgstr "Nenhum certificado de AC é necessá_rio"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versão PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "faltando nome de usuário EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "faltando senha EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "faltando identidade EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "certificado de AC EAP-TLS inválido: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "certificado de AC EAP-TLS inválido: nenhum certificado especificado"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "chave privada EAP-TLS inválida: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificado EAP-TLS inválido: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Chaves privadas sem criptografia são inseguras"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"A chave privada selecionada não aparenta estar protegida por uma senha. Isso "
-"pode permitir que suas credenciais de segurança estejam comprometidas. Por "
-"favor, selecione uma chave privada protegida por senha.\n"
-"\n"
-"(Você pode proteger com senha sua chave privada usando openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Escolha seu certificado pessoal"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Escolha sua chave privada"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4749,15 +2634,6 @@ msgstr "Chave pri_vada"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Senha da chave _privada"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "certificado de AC EAP-TTLS inválido: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "certificado de AC EAP-TTLS inválido: nenhum certificado especificado"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4780,14 +2656,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domínio"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Erro desconhecido ao validade segurança 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4816,62 +2693,10 @@ msgstr "EAP protegido (PEAP)"
 msgid "Au_thentication"
 msgstr "Au_tenticação"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Selecione um arquivo"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "faltando nome de usuário leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "faltando senha leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Senha do Wi-Fi faltando."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipo"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "faltando chave wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"chave wep inválida: chave com um tamanho de %zu deve conter apenas dígitos "
-"hexadecimais"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"chave wep inválida: chave com um tamanho de %zu deve conter apenas dígitos "
-"ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"chave wep inválida: tamanho de chave %zu inválido. Um chave deve estar entre "
-"o tamanho 5/13 (ascii) ou 10/26 (hexadecimal)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "chave wep inválida: frase secreta não pode estar vazia"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "chave wep inválida: frase secreta deve ser menor que 64 caracteres"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4896,21 +2721,6 @@ msgstr "_Mostrar chave"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Índice _WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk inválido: tamanho de chave %zu inválido. Deve ser de [8,63] bytes ou "
-"64 dígitos hexadecimais"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk inválido: não é possível interpretar chave com 64 bytes como "
-"hexadecimal"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4965,27 +2775,9 @@ msgstr "Notificações na tela de b_loqueio"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controle quais notificações são exibidas e o que elas mostram"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notificações;Banner;Mensagem;Bandeja;Janelas instantâneas;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Outro"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s removido(a)"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Erro ao remover conta"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -5010,17 +2802,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Adicionar uma conta"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Conta %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Remover conta"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Contas online"
@@ -5030,10 +2811,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Conecte-se às suas contas on-line e decida para que usá-las"
 
 # Não podemos esquecer de deixar o sinal de ponto-e-vírgula após a última palavra chave!! --Enrico
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5042,10 +2819,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Conectado;Online;Bate-papo;Chat;Calendário;"
 "Agenda;E-mail;Correio;Contato;Contatos;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
 "ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Hora desconhecida"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5061,13 +2834,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i hora"
 msgstr[1] "%i horas"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5079,192 +2845,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minuto"
 msgstr[1] "minutos"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s até carga completa"
-
-# Fonte de alimentação ininterrupta, também conhecida pelo acrônimo UPS (sigla em inglês de Uninterruptible Power Supply) ou no-break.
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Cuidado: %s restante"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s restantes"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Carga completa"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Não está carregando"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Vazia"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Carregando"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Descarregando"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Mouse sem fio"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Teclado sem fio"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Fonte de alimentação ininterrupta (no-break)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Assistente pessoal digital (PDA)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Celular"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Reprodutor de multimídia"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Computador"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Dispositivo de entrada de jogo"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Bateria"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principal"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Extra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Baterias"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "_Quando ocioso"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Suspender"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Desligar"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Hibernar"
-
-# "Comportamento do botão de energia"
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Nenhum"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Quando estiver usando a energia da bateria"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Ligado na tomada"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nunca"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Suspensão automática"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Modo de desempenho temporariamente desabilitado devido à alta temperatura de "
-"operação."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Superfície instável detectada: modo de desempenho temporariamente "
-"indisponível. Coloque o dispositivo em uma superfície estável para restaurar."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Modo de desempenho temporariamente desabilitado."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Bateria fraca: economia de energia habilitada. O modo anterior será "
-"restaurado quando a bateria estiver suficientemente carregada."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Modo de economia de energia ativado por “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Modo de desempenho ativado por “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5325,6 +2905,15 @@ msgstr "100 minutos"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 horas"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bateria"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositivos"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5403,33 +2992,6 @@ msgstr "Energia da _bateria"
 msgid "Delay"
 msgstr "Atraso"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Desempenho"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Desempenho e uso de energia altos."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Balanceado"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Desempenho e uso de energia padrão."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Economia de energia"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Desempenho e uso de energia reduzidos."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Energia"
@@ -5439,7 +3001,6 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Veja o estado da sua bateria e altere as configurações de economia de energia"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5447,27 +3008,6 @@ msgid ""
 msgstr ""
 "Energia;Dormir;Suspender;Hibernar;Bateria;Brilho;Escurecer;Vazio;Branca;"
 "Monitor;DPMS;Inativo;Bateria;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "A impressora “%s” foi excluída"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Falha ao adicionar nova impressora."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Não foi possível carregar a interface: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Desbloqueie para adicionar impressoras e alterar as configurações"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5479,7 +3019,6 @@ msgstr ""
 "Adicione impressoras, veja trabalhos de impressão e decida como você "
 "gostaria de imprimir"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Impressora;Fila;Imprimir;Papel;Tinta;Toner;"
@@ -5487,8 +3026,6 @@ msgstr "Impressora;Fila;Imprimir;Papel;Tinta;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Adicionar impressora"
 
@@ -5529,29 +3066,6 @@ msgstr ""
 msgid "Username"
 msgstr "Nome de usuário"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Detalhes de %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Não foi encontrado um driver adequado"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Selecionar um arquivo PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Arquivos de descrição de impressora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
-"PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Nomes de impressoras não podem conter SPACE, TAB, #, ou /"
@@ -5560,9 +3074,7 @@ msgstr "Nomes de impressoras não podem conter SPACE, TAB, #, ou /"
 msgid "Location"
 msgstr "Localização"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Driver"
 
@@ -5590,140 +3102,20 @@ msgstr "Selecionar driver de impressora"
 msgid "Loading drivers database…"
 msgstr "Carregando banco de dados de drivers…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Cancelar"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Selecionar"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Impressora JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Impressora LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Um lado"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Lado maior (padrão)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Lado menor (virar)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Retrato"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Paisagem"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Paisagem invertida"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Retrato invertido"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Continuar"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pausada"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Pendente"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pausada"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Autenticação necessária"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Processando"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Parado"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Cancelado"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Abortado"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Concluído"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Move este trabalho para o topo da fila"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u trabalho requer autenticação"
 msgstr[1] "%u trabalhos requerem autenticação"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Trabalhos ativos"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Digite as credenciais para imprimir de %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5751,321 +3143,17 @@ msgstr "_Autenticar"
 msgid "No Active Printer Jobs"
 msgstr "Nenhum trabalho de impressão ativo"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Desbloquear servidor de impressão"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Desbloquear %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Digite nome de usuário e senha para ver as impressoras em %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Pesquisando por impressoras"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Porta serial"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Porta paralela"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Localização: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Endereço: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "O servidor requer autenticação"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dois lados"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Tipo de papel"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Origem do papel"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Bandeja de saída"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Resolução"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Pré-filtragem do GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Páginas por lado"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dois lados"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientação"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Geral"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Configuração da página"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opções instaláveis"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Trabalho"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Qualidade da imagem"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Cor"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Finalização"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avançado"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Página de teste"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Página de teste"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Autosselecionar"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Padrão da impressora"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Apenas fontes embutidas do GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Converter para PS nível 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Converter para PS nível 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Nenhum pré-filtro"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Fabricante"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Sem trabalhos ativos"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u trabalho"
 msgstr[1] "%u trabalhos"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Limpeza cabeças de impressão"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Com pouco toner"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Sem toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Com pouco revelador"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Sem revelador"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Pouco suprimento de marcador"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Sem suprimento de marcador"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Abrir capa"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Abrir porta"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Com pouco papel"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Sem papel"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Desconectado"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Parado"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Recipiente de descarte quase cheio"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Recipiente de descarte cheio"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "O condutor de foto ótica está quase no fim da vida"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "O condutor de foto ótica não está funcionando"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Pronto"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Não aceitar trabalhos"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Processando"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6089,6 +3177,10 @@ msgstr "Limpar cabeças de impressão"
 msgid "Remove Printer"
 msgstr "Remover impressora"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Sem trabalhos ativos"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6109,16 +3201,21 @@ msgid "Restart"
 msgstr "Reiniciar"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Adicionar impressora…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Adicionar uma impressora…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Sem impressora"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6126,7 +3223,6 @@ msgstr ""
 "Desculpe! O serviço de impressão do sistema\n"
 "    parece não estar disponível."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formatos"
@@ -6154,16 +3250,6 @@ msgstr "Pesquisas podem ser por países ou idiomas."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Visualizar"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Métrico"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6201,20 +3287,24 @@ msgstr ""
 "A configuração de idioma é usada para texto de interface e páginas da web. "
 "Formatos é usado para números, datas e moedas."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Sua Conta"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Idioma"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formatos"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Tela de início de sessão"
 
@@ -6226,101 +3316,9 @@ msgstr "Região & idioma"
 msgid "Select your display language and formats"
 msgstr "Selecione o seus idioma de exibição e formatos"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Disposição;Teclado;Entrada;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Pergunte o que fazer"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Não fazer nada"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Abrir pasta"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Outra mídia"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Selecione um aplicativo para CDs de áudio"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Selecione um aplicativo para DVDs de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Selecione um aplicativo para executar quando um reprodutor de música é "
-"conectado"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Selecione um aplicativo para executar quando uma câmera é conectada"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Selecione um aplicativo para CDs de software"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD de áudio"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "Disco Blu-ray vazio"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "Disco CD vazio"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "Disco DVD vazio"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "Disco HD DVD vazio"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Disco Blu-ray de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "Leitor de e-book"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Disco HD DVD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "CD de imagem"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "CD de vídeo"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Software do Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6370,7 +3368,6 @@ msgstr "Mídia removível"
 msgid "Configure Removable Media settings"
 msgstr "Configure as configurações de mídias removíveis"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6378,115 +3375,6 @@ msgid ""
 msgstr ""
 "dispositivo;sistema;padrão;aplicativo;preferido;cd;dvd;usb;áudio;vídeo;"
 "unidade;removível;mídia;autorun;"
-
-# Em Privacidade, complementa a mensagem "Lock screen _after blank for"
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Ao desligar a tela"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 segundos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minutos"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuto"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minutos"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nunca"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6526,11 +3414,16 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "Mostrar _notificações na tela de bloqueio"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Notificações na tela de b_loqueio"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Proibir novos dispositivos _USB"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6538,30 +3431,25 @@ msgstr ""
 "Impede novos dispositivos USB de interagirem com sistema quando a tela está "
 "bloqueada."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Privacidade da tela"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Restringir ângulo de visão"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Tela"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Configurações da tela"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "tela;bloqueio;privado;privacidade;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Selecione localização"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6592,10 +3480,6 @@ msgstr "Outros"
 msgid "Add Location"
 msgstr "Adicionar localização"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nenhum aplicativo encontrado"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Pesquisa do aplicativo"
@@ -6623,93 +3507,13 @@ msgstr ""
 "Controle quais aplicativos mostram resultados de pesquisa no panorama de "
 "atividades"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Pesquisa;Localizar;Índice;Ocultar;Privacidade;Resultados;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Sem redes selecionadas para compartilhamento"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Redes"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Ligado"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Desligado"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Habilitado"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Ativo"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Escolha uma pasta"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Adicionar"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Habilitar compartilhamento multimídia"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"O compartilhamento de arquivos permite que você compartilhe sua pasta "
-"Pública com outros na sua rede atual usando: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Quando a sessão remota está habilitada, usuários remotos podem se conectar "
-"usando o comando de Shell Seguro:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Habilitar compartilhamento de mídia pessoal"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Nome do dispositivo copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Endereço do dispositivo copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Nome de usuário copiado"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Senha copiada"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6843,7 +3647,6 @@ msgstr "Pastas"
 msgid "Control what you want to share with others"
 msgstr "Controle o que você quer compartilhar com outros"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6859,10 +3662,6 @@ msgstr "Habilitar ou desabilitar sessão remota"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "É necessário autenticação para habilitar ou desabilitar sessão remota"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Personalizado"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6895,11 +3694,6 @@ msgstr "Traseiro"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Frontal"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Testando %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6953,11 +3747,6 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Som de alerta"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Mudo"
@@ -6972,85 +3761,12 @@ msgstr ""
 "Alterar níveis, entradas saídas e alertas de som volume de som e eventos de "
 "som"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Placa;Card;Microfone;Microphone;Volume;Desaparecer;Fade;Balanço;Bluetooth;"
 "Fone de ouvido com microfone;Headset;Áudio;Saída;Output;Entrada;Input;"
-
-# http://en.wikipedia.org/wiki/Font_hinting
-# (não entendi a relação link-frase, mas vou deixar - Rafael)
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Desconectando"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Conectando"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Conectado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Erro de autorização"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autorizando"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Funcionalidade reduzida"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Conectado & Autorizado"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Autorizado em:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Conectado a:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Registrado em:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Falha ao autorizar dispositivo: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Falha ao esquecer dispositivo: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7084,56 +3800,6 @@ msgstr "Autorizar e conectar"
 msgid "Forget Device"
 msgstr "Esquecer dispositivo"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Erro"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorizado"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"O subsistema Thunderbolt (boltd) não está instalado ou não configurado "
-"adequadamente."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Permite acesso direto a dispositivos como GPUs externas e docks."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Apenas dispositivos USB e Display Port podem se conectar."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt não pôde ser detectado.\n"
-"O sistema não tem suporte a Thunderbolt, tendo sido desabilitado na BIOS ou "
-"estando configurado para um nível de segurança ao qual a BIOS não oferece "
-"suporte."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "O suporte a Thunderbolt foi desabilitado no BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "O nível de segurança do Thunderbolt não pôde ser determinado."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Erro ao trocar o modo direto: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Sem suporte a Thuderbolt"
@@ -7145,6 +3811,10 @@ msgstr "Não foi possível conectar ao subsistema do thunderbolt."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Acesso direto"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Permite acesso direto a dispositivos como GPUs externas e docks."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7162,7 +3832,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Gerencie dispositivos Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacidade;"
@@ -7367,40 +4036,6 @@ msgstr "_Habilitar por teclado"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Ativar e desativar os recursos de acessibilidade usando o teclado"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Padrão"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Médio"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Grande"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Maior"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Gigante"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixels"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Sempre mostrar o menu de _acessibilidade"
@@ -7514,31 +4149,6 @@ msgstr "Piscar a tela _inteira"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Piscar a _janela inteira"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Curto"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ da tela"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ da tela"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ da tela"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Longo"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7695,7 +4305,6 @@ msgstr "Efeitos de cor"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Torna mais fácil ver, ouvir, digitar, apontar e clicar"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7707,114 +4316,6 @@ msgstr ""
 "Tela;Leitor;grande;alta;grande;texto;fonte;tamanho;AccessX;Pegajoso;Teclas;"
 "Lento;Repercursão;Mouse;Duplo;clique ;Atraso;Velocidade;Assistência;Repetir;"
 "Piscar;visual;audição;áudio;digitação;animações;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 hora"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dia"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dias"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dias"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Esvaziar todos os itens da lixeira?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Todos os itens na lixeira serão permanentemente excluídos."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Es_vaziar lixeira"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Excluir todos os arquivos temporários?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Todos os arquivos temporários serão permanentemente excluídos."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Excluir _permanentemente arquivos temporários"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dia"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dias"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dias"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Para sempre"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7883,64 +4384,12 @@ msgstr "Histórico de arquivos & lixeira"
 msgid "Don't leave traces"
 msgstr "Não deixe rastros"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "uso;recente;histórico;arquivos;temporário;tmp;privado;privacidade;lixo;"
 "limpar;reter;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Deveria corresponder ao endereço web do seu provedor de sessão."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Falha ao adicionar conta"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "As senhas não conferem."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Falha ao registrar conta"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Nenhuma forma suportada para autenticar neste domínio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Falha em entrar no domínio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Aquele nome de sessão não funcionou.\n"
-"Por favor, tente novamente."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Aquela senha de sessão não funcionou.\n"
-"Por favor, tente novamente."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Falha em fazer login no domínio"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Não foi possível localizar o domínio. Será que você escreveu errado?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7993,10 +4442,6 @@ msgstr ""
 "A sessão corporativa permite que uma conta existente de usuário gerenciada "
 "centralmente seja usada neste dispositivo. Você também pode usar essa conta "
 "para acessar recursos corporativos na Internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Procurar por mais imagens"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8067,222 +4512,6 @@ msgstr "E_xcluir impressões digitais"
 msgid "Fingerprint Enroll"
 msgstr "Registro de impressão digital"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "o dispositivo precisa ser reivindicado para executar esta ação"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "o dispositivo já foi reivindicado por outro processo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "você não tem permissão para executar a ação"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "nenhuma impressão foi registrada"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Falha ao se comunicar com o dispositivo durante o registro"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Falha ao se comunicar com o leitor de impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Falha ao se comunicar com o daemon de impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Falha ao lista impressões digitais: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Falha ao excluir impressões digitais salvas: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Polegar esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Dedo médio esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "De_do indicador esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Dedo anelar esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Dedo pequeno esquerdo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Polegar direito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Dedo médio direito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Dedo indicador di_reito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Dedo anelar direito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Dedo pequeno direito"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Dedo desconhecido"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Concluído"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Dispositivo de impressão digital desconectado"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "O armazenamento do dispositivo de impressão digital está cheio"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Falha ao registar nova impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Falha ao iniciar registro: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Falha ao registrar nova impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Falha ao parar registro: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Levante e coloque repetidamente o dedo no leitor para registrar sua "
-"impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Registrar novamente este dedo…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Registrar nova impressão digital"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Falha ao liberar o dispositivo de impressão digital %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problema ao ler o dispositivo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Falha ao reivindicar o dispositivo de impressão digital %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Falha ao obter dispositivo de impressão digital: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Esta semana"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Semana passada"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e de %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e de %b de %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Sessão finalizada"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Sessão iniciada"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Atividade da conta"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Anterior"
@@ -8290,18 +4519,6 @@ msgstr "Anterior"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Próximo"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Por favor, escolha outra senha."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Por favor, digite sua senha atual novamente."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "A senha não pode ser alterada"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8323,6 +4540,10 @@ msgstr "Nova senha"
 msgid "Confirm Password"
 msgstr "Confirmar senha"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "As senhas não conferem."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
@@ -8331,137 +4552,6 @@ msgstr ""
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Definir uma senha agora"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Não é possível participar automaticamente deste tipo de domínio"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "O domínio não existe"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Não foi possível fazer login como %s no domínio %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Senha inválida, por favor tente novamente"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Não foi possível conectar ao domínio %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Falha ao excluir usuário"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Falha ao revogar usuário gerenciado remotamente"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Você não pode excluir sua própria conta."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s ainda está conectado"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Excluindo um usuário enquanto ele está conectado pode deixar o sistema em um "
-"estado inconsistente."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Você deseja manter os arquivos de %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"É possível manter o diretório home, fila de e-mail e arquivos temporários ao "
-"excluir uma conta de usuário."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Excluir arquivos"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Manter arquivos"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Tem certeza de que deseja revogar a conta gerenciada remotamente do %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Excluir"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Conta desabilitada"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Para ser definido no próximo início de sessão"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Nenhum"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Acesso autorizado"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Falhou ao contactar o serviço de contas"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Por favor, certifique-se de que o Serviço de Contas esteja instalado "
-"corretamente."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Este painel deve ser desbloqueado para alterar esta configuração"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Exclui a conta de usuário selecionada"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Para excluir a conta de usuário selecionada,\n"
-"clique primeiro no ícone *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Desbloqueie para adicionar usuários e alterar as configurações"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8490,7 +4580,6 @@ msgid "Full name"
 msgstr "Nome _completo"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Editar"
 
@@ -8552,7 +4641,6 @@ msgstr "Desbloquear para adicionar uma conta de usuário."
 msgid "Add or remove users and change your password"
 msgstr "Adicionar ou remover usuários e alterar sua senha"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8598,177 +4686,6 @@ msgstr "Gerenciar contas de usuários"
 msgid "Authentication is required to change user data"
 msgstr "Autenticação é obrigatória para alterar dados de usuário"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "A nova senha precisa ser diferente da antiga."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Tente mudar algumas letras e números."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Tente alterar a senha um pouco mais."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Uma senha que não utilize seu nome de usuário será mais forte."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Evite usar seu nome na senha."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Evite algumas das palavras incluídas na senha."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Evite palavras comuns."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Evite reordenar palavras existentes."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Tente usar mais números."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Tente usar mais letras maiúsculas."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Tente usar mais letras minúsculas."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Tente usar mais caracteres especiais, como pontuação."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Tente usar uma mistura de letras, números e pontuação."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Evite repetir o mesmo caractere."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Evite repetir o mesmo tipo de caractere: você precisa misturar letras, "
-"números e pontuação."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Evite sequências como 1234 ou abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"A senha precisa ser mais longa. Tente adicionar mais letras, números e "
-"pontuação."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Misture maiúsculas e minúsculas e tente usar um ou dois números."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Adicionar mais letras, números e pontuação tornará a senha mais forte."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Falha na autenticação"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "A nova senha é curta demais"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "A nova senha é simples demais"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "As senhas antiga e nova são semelhantes demais"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "A nova senha foi usada recentemente."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "A nova senha deve conter caracteres numéricos ou especiais"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "As senhas antiga e nova são iguais"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Sua senha foi alterada desde que você se autenticou inicialmente!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "A nova senha não contém caracteres diferentes o bastante"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Erro desconhecido"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"O nome de usuário deve, geralmente, consistir apenas de letras minúsculas de "
-"a-z, dígitos e dos seguintes caracteres: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Desculpe, o nome de usuário informado não é válido. Por favor, tente outro."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "O nome de usuário é muito longo."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8803,52 +4720,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Foi detectado clique errado, reiniciando…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Botão %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Aplicativos definidos"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Enviar sequência de teclas"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Alternar monitor"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Mostrar ajuda na tela"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tablet montado no painel de um laptop"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tablet montado em uma tela externa"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Dispositivo tablet externo"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Dispositivo tablet externo"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Todas as telas"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8947,23 +4822,6 @@ msgstr "Clique no botão direito do mouse"
 msgid "Forward"
 msgstr "Avanço"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
-"Caneta de aerógrafo com pressão, inclinação e controle deslizante integrado"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Caneta de aerógrafo com pressão, inclinação e rotação"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Caneta padrão com pressão e inclinação"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Caneta padrão com pressão"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tablet Wacom"
@@ -8973,54 +4831,96 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Defina mapeamentos de botão e ajuste a sensibilidade de estilo para tablets"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Caneta;Borracha;Mouse;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Novo atalho…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Clique secundário _simulado"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Software do Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Com pouco toner"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Atraso do clique secundário"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Software do Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Gerencie preferências para produtividade e multitarefas"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Pontos de acesso"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Adicionar"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salvar"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operação cancelada"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Erro:</b> Acesso negado ao alterar configurações"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Erro:</b> Erro de Equipamento Móvel"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Não registrado"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registrado"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Pesquisando"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Negado"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9050,212 +4950,13 @@ msgstr "Número próprio"
 msgid "Device Details"
 msgstr "Detalhes do dispositivo"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricante"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Versão do firmware"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "2G apenas"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "3G apenas"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "4G apenas"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "5G apenas"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (preferido), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (preferido), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (preferido), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (preferido), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (preferido), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (preferido), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (preferido), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (preferido), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (preferido), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (preferido), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (preferido)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (preferido), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Desbloquear cartão SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Desbloquear"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Por gentileza forneça o código PIN para o SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Digite o PIN para desbloquear seu cartão SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Por gentileza forneça o código PUK para o SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Digite o PUK para desbloquear seu cartão SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9270,26 +4971,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Você tem %u tentativa restante"
 msgstr[1] "Você tem %u tentativas restantes"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Informada senha incorreta."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Código PUK deve ser um número de 8 dígitos"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Digite novo PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Código PIN deve ser um número entre 4-8 dígitos"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Desbloqueando…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9347,94 +5028,6 @@ msgstr "Bloquear SIM com PIN"
 msgid "M_odem Details"
 msgstr "Detalhes do M_odem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Telefone falhou"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Sem conexão com telefone"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operação não permitida"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Não há suporte para a operação"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM não inserido"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "PIN do SIM obrigatório"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "PUK do SIM obrigatório"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM falhou"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM ocupado"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Senha incorreta"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "PIN2 do SIM obrigatório"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "PUK2 do SIM obrigatório"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Não localizado"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Sem serviço de rede"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Tempo esgotado de rede"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Serviços de GPRS não permitidos"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming não permitido nesta área de localização"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Erro GPRS não especificado"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Sem erro"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Ação cancelada"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Acesso negado"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Erro desconhecido"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Modo de rede"
@@ -9450,11 +5043,6 @@ msgstr "Escolha a rede"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Atualizar provedores de rede"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9513,7 +5101,6 @@ msgstr "Rede móvel"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configure telefonia e conexões de dados móveis"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "célula;celular;wwan;telefonia;sim;mobile;móvel;"
@@ -9530,41 +5117,13 @@ msgstr "Configurações é a interface primária para configurar seu sistema."
 msgid "The GNOME Project"
 msgstr "O Projeto GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Exibir número da versão"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Habilitar modo detalhado"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Pesquisar por string"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Lista possíveis nomes de painéis e sai"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Painel para exibir"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PAINEL] [ARGUMENTO…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Categoria das configurações"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Privacidade"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Painéis disponíveis:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9622,7 +5181,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Cancelar pesquisa"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferências;Configurações;Ajustes;"
@@ -9665,8 +5223,6 @@ msgstr ""
 "Uma tupla contendo a largura, altura e estado maximizado iniciais da janela "
 "do aplicativo."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9674,8 +5230,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u saída"
 msgstr[1] "%u saídas"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9683,9 +5237,3155 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u entrada"
 msgstr[1] "%u entradas"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sons do sistema"
+#~ msgid "System Bus"
+#~ msgstr "Barramento de sistema"
+
+#~ msgid "Full access"
+#~ msgstr "Acesso completo"
+
+#~ msgid "Session Bus"
+#~ msgstr "Barramento de sessão"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Acesso completo a /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Tem acesso à rede"
+
+#~ msgid "Home"
+#~ msgstr "Pasta pessoal"
+
+#~ msgid "Read-only"
+#~ msgstr "Somente leitura"
+
+#~ msgid "File System"
+#~ msgstr "Sistema de arquivos"
+
+#~ msgid "Can change settings"
+#~ msgstr "Pode alterar as configurações"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s tem as seguintes permissões incorporadas. Estas não podem ser "
+#~ "alteradas. Se você estiver preocupado com essas permissões, considere "
+#~ "remover esse aplicativo."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u tipo de arquivo e link que é aberto pelo aplicativo"
+#~ msgstr[1] "%u tipos de arquivo e link que são abertos pelo aplicativo"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> é usado para abrir os seguintes tipos de arquivos e links."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s de espaço em disco usado."
+
+#~ msgid "Select a picture"
+#~ msgstr "Selecionar uma imagem"
+
+#~ msgid "_Open"
+#~ msgstr "_Abrir"
+
+#~ msgid "multiple sizes"
+#~ msgstr "múltiplos tamanhos"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Nenhum plano de fundo"
+
+#~ msgid "Current background"
+#~ msgstr "Plano de fundo atual"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Posicione o dispositivo de calibração sobre o quadrado e pressione "
+#~ "“Começar”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Mova seu dispositivo de calibração para a posição de calibração e "
+#~ "pressione “Continuar”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Mova seu dispositivo de calibração para a posição da superfície e "
+#~ "pressione “Continuar”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Feche a tampa do laptop"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Ocorreu um erro interno do qual não se pôde recuperar."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Ferramentas necessárias para a calibração não estão instaladas."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "O perfil não pôde ser gerado."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "O ponto branco alvo era impossível de se obter."
+
+#~ msgid "Complete!"
+#~ msgstr "Concluído!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Configuração falhou!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Você pode remover o dispositivo de calibração."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Não interrompa o dispositivo de calibração durante o progresso"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Tela de laptop"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Webcam embutida"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Scanner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Câmera %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Impressora %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webcam %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Habilitar gerenciamento de cor para %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Mostrar perfis de cor de %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Não calibrado"
+
+#~ msgid "Default: "
+#~ msgstr "Padrão: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Espaço de cores: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Perfil de teste: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Selecionar perfil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importar"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Perfis ICC suportados"
+
+#~ msgid "All files"
+#~ msgstr "Todos arquivos"
+
+#~ msgid "Save Profile"
+#~ msgstr "Salvar perfil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Criar um perfil de cor para o dispositivo selecionado"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "O instrumento de medição não foi detectado. Por favor, verifique se está "
+#~ "ligado e conectado corretamente."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr ""
+#~ "O instrumento de medição não tem suporte a criação de perfis de "
+#~ "impressora."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Atualmente, não há suporte ao tipo de dispositivo."
+
+#~ msgid "Standard Space"
+#~ msgstr "Espaço padrão"
+
+#~ msgid "Test Profile"
+#~ msgstr "Perfil de teste"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automático"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Baixa qualidade"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Média qualidade"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Alta qualidade"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Padrão RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Padrão CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Padrão cinza"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Dados de calibração de fábrica fornecidos pelo fabricante"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Correção de tela em tela cheia não é possível com este perfil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Este perfil pode não estar mais preciso"
+
+#~ msgid "Other…"
+#~ msgstr "Outro…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Desbloquear para alterar as configurações"
+
+#~ msgid "Today"
+#~ msgstr "Hoje"
+
+#~ msgid "Yesterday"
+#~ msgstr "Ontem"
+
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b de %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d hora"
+#~ msgstr[1] "%d horas"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minuto"
+#~ msgstr[1] "%d minutos"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d segundo"
+#~ msgstr[1] "%d segundos"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Ponto de acesso"
+
+#~ msgid "24-hour"
+#~ msgstr "24 horas"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+# Formato 12hs, não alterar para 24h
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e de %B de %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e de %B de %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+# Formato 12hs, não alterar para 24h
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Enviar relatórios de problemas técnicos nos ajuda a melhorar o %s. Os "
+#~ "relatórios são enviados anonimamente e não contêm dados pessoais. %s"
+
+#~ msgid "On"
+#~ msgstr "Ligada"
+
+#~ msgid "Off"
+#~ msgstr "Desligada"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Aplicar alterações?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Alterações não puderam ser aplicadas"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Isso pode ser devido a limitações de hardware."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Paisagem"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Retrato (virado)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Retrato"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Paisagem (virada)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "A inicialização segura esta ativa"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "A inicialização segura impede que softwares maliciosos sejam carregados "
+#~ "quando o dispositivo é iniciado. Ela está atualmente ligada e está "
+#~ "funcionando corretamente."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "A inicialização segura apresenta problemas"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "A inicialização segura impede que softwares maliciosos sejam carregados "
+#~ "quando o dispositivo é iniciado. Ela está ativada no momento, mas não "
+#~ "funcionará devido a uma chave inválida."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Os problemas com inicialização segura geralmente podem ser resolvidos nas "
+#~ "configurações de firmware UEFI (BIOS) do seu computador e o fabricante do "
+#~ "hardware pode fornecer informações sobre como fazer isso."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Para obter ajuda, entre em contato com o fabricante do hardware ou com o "
+#~ "provedor de suporte de TI."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "A inicialização segura está desativada"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "A inicialização segura impede que o software malicioso seja carregado "
+#~ "quando o dispositivo for iniciado. Atualmente está desligada."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "A inicialização segura geralmente pode ser ativada nas configurações de "
+#~ "firmware UEFI (BIOS) do seu computador. Para obter ajuda, entre em "
+#~ "contato com o fabricante do hardware ou com o provedor de suporte de TI."
+
+#~ msgid "Passed"
+#~ msgstr "Passou"
+
+#~ msgid "Failed"
+#~ msgstr "Falhou"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "O dispositivo está em conformidade com o nível de segurança HSI %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Nível de segurança 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Este dispositivo não tem proteção contra problemas de segurança de "
+#~ "hardware. Isso pode ser devido a um problema de configuração de hardware "
+#~ "ou firmware. É recomendável entrar em contato com seu provedor de suporte "
+#~ "de TI."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Nível de segurança 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Este dispositivo tem proteção mínima contra problemas de segurança de "
+#~ "hardware. Este é o nível de segurança mais baixo do dispositivo e fornece "
+#~ "proteção apenas contra ameaças de segurança simples."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Nível de segurança 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Este dispositivo tem proteção básica contra problemas de segurança de "
+#~ "hardware. Isso fornece proteção contra algumas ameaças de segurança "
+#~ "comuns."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Nível de segurança 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Este dispositivo tem proteção estendida contra problemas de segurança de "
+#~ "hardware. Este é o nível mais alto de segurança do dispositivo e oferece "
+#~ "proteção contra ameaças de segurança avançadas."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Os níveis de segurança não estão disponíveis para este dispositivo."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Entre em contato com o fabricante do hardware para obter ajuda com "
+#~ "atualizações de segurança."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Talvez seja possível resolver esse problema nas configurações de firmware "
+#~ "UEFI do dispositivo ou por um técnico de suporte."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Talvez seja possível resolver esse problema nas configurações de firmware "
+#~ "UEFI do dispositivo."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Talvez um técnico de suporte possa resolver esse problema."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr ""
+#~ "Protegido contra software malicioso quando o dispositivo é iniciado."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "A inicialização segura está com problemas"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Alguma proteção é fornecida quando o dispositivo é iniciado."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "A Inicialização segura está desligada"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Sem proteção quando o dispositivo é iniciado."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Esse problema pode ter sido causado por uma alteração nas configurações "
+#~ "do firmware UEFI, uma alteração na configuração do sistema operacional, "
+#~ "ou por software malicioso no sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Esse problema pode ter sido causado por uma alteração nas configurações "
+#~ "do firmware UEFI, ou por software malicioso no sistema."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Esse problema pode ter sido causado por uma alteração na configuração do "
+#~ "sistema operacional, ou por software malicioso no sistema."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Altamente exposto a ameaças de segurança."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Proteção limitada contra falhas de segurança simples."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Protegido contra falhas de segurança comuns."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Protegido contra uma ampla gama de falhas de segurança."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Proteção compreensiva"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Proteção contra gravação do firmware"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Trava de proteção contra gravação do firmware"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Região Firmware do BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Descritor Firmware do BIOS"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Proteção de DMA na pré-inicialização"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Inicialização verificada pelo Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Protegido pelo ACM do Intel BootGuard"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Política de erros do Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Fusão do Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET Ativado"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET ativado"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "RAM Encriptada"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Proteção IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux Kernel Lockdown"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Verificação do Kernel Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Área de troca"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Suspender para RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Suspender para inativo"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Chave da plataforma UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "inicialização segura UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Configuração da Plataforma TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Reconstrução do TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine em Modo de Fabrica"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Substituição do Intel Management Engine"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Substituição do Intel Management Engine"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Atualizações de firmware"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Atestação do firmware"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Verificação do atualizador do firmware"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Depuração de plataforma"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Verificação de segurança do processador"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Proteção de reversão AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Proteção contra reprodução de firmware AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Proteção contra gravação do firmware AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Plataforma fundida"
+
+#~ msgid "Valid"
+#~ msgstr "Válido"
+
+#~ msgid "Not Valid"
+#~ msgstr "Inválido"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Desabilitado"
+
+#~ msgid "Locked"
+#~ msgstr "Bloqueado"
+
+#~ msgid "Not Locked"
+#~ msgstr "Desbloqueado"
+
+#~ msgid "Encrypted"
+#~ msgstr "Encriptado"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Não encriptado"
+
+#~ msgid "Tainted"
+#~ msgstr "Comprometido"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Não comprometido"
+
+#~ msgid "Found"
+#~ msgstr "Encontrado"
+
+#~ msgid "Not Found"
+#~ msgstr "Não localizado"
+
+#~ msgid "Supported"
+#~ msgstr "Suportado"
+
+#~ msgid "Not Supported"
+#~ msgstr "Sem suporte"
+
+#~ msgid "Unknown"
+#~ msgstr "Desconhecido"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 bits"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 bits"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Desconhecido"
+
+#~ msgid "Not Available"
+#~ msgstr "Indisponível"
+
+#~ msgid "System Logo"
+#~ msgstr "Logotipo do sistema"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nenhuma fonte de entrada encontrada"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Outro"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Atalhos personalizados"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "A tecla de caracteres alternativos pode ser usada para inserir caracteres "
+#~ "adicionais. Às vezes, eles são impressos como uma terceira opção no "
+#~ "teclado."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt da esquerda"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt da direita"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super da esquerda"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super da direita"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tecla de menu"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl da direita"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "A tecla de composição permite que uma ampla variedade de caracteres sejam "
+#~ "inseridos. Para usá-la, pressione a composição seguida pela sequência de "
+#~ "caracteres. Por exemplo, tecla de composição seguida por <b>C</b> e <b>o</"
+#~ "b> vai inserir <b>©</b>, <b>a</b> seguido por <b>'</b> vai inserir <b>á</"
+#~ "b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "As fontes de entrada podem ser alternadas usando o atalho de teclado %s.\n"
+#~ "Isso pode ser alterado nas configurações de atalhos de teclado."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificado"
+#~ msgstr[1] "%d modificados"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Redefinir todos os atalhos?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Redefinir os atalhos pode afetar seus atalhos personalizados. Isso não "
+#~ "pode ser desfeito."
+
+#~ msgid "Reset All"
+#~ msgstr "Redefinir todos"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s está sendo usado para %s. Se você substituí-lo, %s será desabilitada"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Insira um novo atalho"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Definir atalhos personalizados"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Definir atalho"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Insira um novo atalho para %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Adicionar atalho personalizado"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Rolagem com dois dedos"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinco cliques, hora de GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Clique duplo, botão primário"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Clique único, botão primário"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Clique duplo, botão do meio"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Clique único, botão do meio"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Clique duplo, botão secundário"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Clique único, botão secundário"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "O NetworkManager precisa estar em execução."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Rede insegura (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Rede segura (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Rede segura (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Rede segura (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Rede segura"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Ligar o ponto de acesso vai lhe desconectar de %s e não será possível "
+#~ "acessar a Internet por meio do Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Deve haver um mínimo de 8 caracteres"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Parar ponto de acesso e desconectar todos os usuários?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Parar ponto de acesso"
+
+#~ msgid "Preserve"
+#~ msgstr "Preservar"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanente"
+
+#~ msgid "Random"
+#~ msgstr "Aleatório"
+
+#~ msgid "Stable"
+#~ msgstr "Estável"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "O endereço MAC inserido aqui será usado como endereço de hardware para o "
+#~ "dispositivo de rede em que esta conexão está ligada. Esse recurso é "
+#~ "conhecido como clonagem ou falsificação de MAC. Exemplo: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Perfil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Empresarial"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nenhuma"
+
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nenhum"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Fraca"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Boa"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excelente"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Esquecer conexão"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Remover o perfil de conexão"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Remover VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detalhes"
+
+#~ msgid "automatic"
+#~ msgstr "automático"
+
+#~ msgid "Identity"
+#~ msgstr "Identidade"
+
+#~ msgid "Delete Address"
+#~ msgstr "Excluir endereço"
+
+#~ msgid "Delete Route"
+#~ msgstr "Excluir rota"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Nenhum"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP chave de 40/128-bit (Hex ou ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP senha de 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP dinâmico (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 pessoal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 empresarial"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 pessoal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Não foi possível abrir o editor de conexão"
+
+#~ msgid "New Profile"
+#~ msgstr "Novo perfil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Configuração inválida %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Configuração inválida %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importar de arquivo…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Adicionar VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Não foi possível importar conexão VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "O arquivo “%s” não pode ser lido ou não possui informações de conexão VPN "
+#~ "reconhecíveis\n"
+#~ "\n"
+#~ "Erro: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Selecione um arquivo para importar"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Um arquivo de nome “%s” já existe."
+
+#~ msgid "_Replace"
+#~ msgstr "_Substituir"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Deseja substituir %s com a conexão VPN que você está salvando?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Não foi possível exportar conexão VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "A conexão VPN “%s” não pode ser exportada para %s.\n"
+#~ "\n"
+#~ "Erro: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportar conexão VPN"
+
+#~ msgid "never"
+#~ msgstr "nunca"
+
+#~ msgid "today"
+#~ msgstr "hoje"
+
+#~ msgid "yesterday"
+#~ msgstr "ontem"
+
+#~ msgid "Last used"
+#~ msgstr "Último uso"
+
+#~ msgid "Add new connection"
+#~ msgstr "Adicionar nova conexão"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Detalhes de rede selecionadas, incluindo senhas e qualquer configuração "
+#~ "personalizada serão perdidos."
+
+#~ msgid "_Forget"
+#~ msgstr "_Esquecer"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Redes Wi-Fi conhecidas"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Esquecer"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "A política do sistema proíbe o uso de um ponto de acesso"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr ""
+#~ "O dispositivo de rede sem fio não possui suporte a modo de ponto de acesso"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Autodescoberta de um Proxy Web é usada quando a URL de configuração não é "
+#~ "fornecida."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Isto não é recomendado para as redes públicas não confiáveis."
+
+#~ msgid "Status unknown"
+#~ msgstr "Estado desconhecido"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Não gerenciável"
+
+#~ msgid "Unavailable"
+#~ msgstr "Indisponível"
+
+#~ msgid "Connecting"
+#~ msgstr "Conectando"
+
+#~ msgid "Authentication required"
+#~ msgstr "Autenticação necessária"
+
+# http://en.wikipedia.org/wiki/Font_hinting
+# (não entendi a relação link-frase, mas vou deixar - Rafael)
+#~ msgid "Disconnecting"
+#~ msgstr "Desconectando"
+
+#~ msgid "Connection failed"
+#~ msgstr "Conexão falhou"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Estado desconhecido (perdido)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Configuração falhou"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Configuração de IP falhou"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Configuração de IP expirou"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Senhas foram exigidas, mas não foram fornecidas"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Suplicante 802.1x desconectado"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Configuração do suplicante 802.1x falhou"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Suplicante 802.1x falhou"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Suplicante 802.1x levou tempo demais para autenticar"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Serviço PPP falhou em iniciar"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Serviço PPP desconectado"
+
+#~ msgid "PPP failed"
+#~ msgstr "Serviço PPP falhou"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Cliente DHCP falhou em iniciar"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Erro no cliente DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Cliente DHCP falhou"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "O serviço de conexão compartilhada falhou ao iniciar"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "O serviço de conexão compartilhada falhou"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Serviço de AutoIP falhou em iniciar"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Erro no serviço AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Serviço de AutoIP falhou"
+
+#~ msgid "Line busy"
+#~ msgstr "Linha ocupada"
+
+#~ msgid "No dial tone"
+#~ msgstr "Não há tom de discagem"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Nenhuma transportadora pode ser estabelecida"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Requisição de discagem alcançou limite de tempo"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Tentativa de discagem falhou"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Inicialização do modem falhou"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Falha ao selecionar o APN especificado"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Não está pesquisando por redes"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Registro à rede negado"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Registro de rede alcançou limite de tempo"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Falhou ao registrar com a rede requisitada"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Verificação de PIN falhou"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firmware do dispositivo pode estar faltando"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Conexão desapareceu"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "A conexão existente foi presumida"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem não encontrado"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Conexão Bluetooth falhou"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Cartão SIM não inserido"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Pin do SIM obrigatório"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Puk do SIM obrigatório"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM errado"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Falha na dependência da conexão"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Faltando firmware"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cabo desconectado"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "erro indefinido na segurança 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "nenhum arquivo selecionado"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "erro não especificado ao validar arquivo de método eap"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Chaves privadas DER, PEM ou PKCS#12 "
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certificados DER ou PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "faltando arquivo PAC EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Arquivos PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "faltando nome de usuário EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "faltando senha EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "certificado de AC EAP-PEAP inválido: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "certificado de AC EAP-PEAP inválido: nenhum certificado especificado"
+
+#~ msgid "missing EAP username"
+#~ msgstr "faltando nome de usuário EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "faltando senha EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "faltando identidade EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "certificado de AC EAP-TLS inválido: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "certificado de AC EAP-TLS inválido: nenhum certificado especificado"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "chave privada EAP-TLS inválida: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificado EAP-TLS inválido: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Chaves privadas sem criptografia são inseguras"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "A chave privada selecionada não aparenta estar protegida por uma senha. "
+#~ "Isso pode permitir que suas credenciais de segurança estejam "
+#~ "comprometidas. Por favor, selecione uma chave privada protegida por "
+#~ "senha.\n"
+#~ "\n"
+#~ "(Você pode proteger com senha sua chave privada usando openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Escolha seu certificado pessoal"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Escolha sua chave privada"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "certificado de AC EAP-TTLS inválido: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "certificado de AC EAP-TTLS inválido: nenhum certificado especificado"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Erro desconhecido ao validade segurança 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Selecione um arquivo"
+
+#~ msgid "missing leap-username"
+#~ msgstr "faltando nome de usuário leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "faltando senha leap"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Senha do Wi-Fi faltando."
+
+#~ msgid "missing wep-key"
+#~ msgstr "faltando chave wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "chave wep inválida: chave com um tamanho de %zu deve conter apenas "
+#~ "dígitos hexadecimais"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "chave wep inválida: chave com um tamanho de %zu deve conter apenas "
+#~ "dígitos ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "chave wep inválida: tamanho de chave %zu inválido. Um chave deve estar "
+#~ "entre o tamanho 5/13 (ascii) ou 10/26 (hexadecimal)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "chave wep inválida: frase secreta não pode estar vazia"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "chave wep inválida: frase secreta deve ser menor que 64 caracteres"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk inválido: tamanho de chave %zu inválido. Deve ser de [8,63] bytes "
+#~ "ou 64 dígitos hexadecimais"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk inválido: não é possível interpretar chave com 64 bytes como "
+#~ "hexadecimal"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Outro"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s removido(a)"
+
+#~ msgid "Error removing account"
+#~ msgstr "Erro ao remover conta"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Conta %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Remover conta"
+
+#~ msgid "Unknown time"
+#~ msgstr "Hora desconhecida"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s até carga completa"
+
+# Fonte de alimentação ininterrupta, também conhecida pelo acrônimo UPS (sigla em inglês de Uninterruptible Power Supply) ou no-break.
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Cuidado: %s restante"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s restantes"
+
+#~ msgid "Fully charged"
+#~ msgstr "Carga completa"
+
+#~ msgid "Not charging"
+#~ msgstr "Não está carregando"
+
+#~ msgid "Empty"
+#~ msgstr "Vazia"
+
+#~ msgid "Charging"
+#~ msgstr "Carregando"
+
+#~ msgid "Discharging"
+#~ msgstr "Descarregando"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Mouse sem fio"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Teclado sem fio"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Fonte de alimentação ininterrupta (no-break)"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Assistente pessoal digital (PDA)"
+
+#~ msgid "Cellphone"
+#~ msgstr "Celular"
+
+#~ msgid "Media player"
+#~ msgstr "Reprodutor de multimídia"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Computador"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Dispositivo de entrada de jogo"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principal"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Extra"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterias"
+
+#~ msgid "When _idle"
+#~ msgstr "_Quando ocioso"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspender"
+
+#~ msgid "Power Off"
+#~ msgstr "Desligar"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernar"
+
+# "Comportamento do botão de energia"
+#~ msgid "Nothing"
+#~ msgstr "Nenhum"
+
+#~ msgid "When on battery power"
+#~ msgstr "Quando estiver usando a energia da bateria"
+
+#~ msgid "When plugged in"
+#~ msgstr "Ligado na tomada"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Suspensão automática"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Modo de desempenho temporariamente desabilitado devido à alta temperatura "
+#~ "de operação."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Superfície instável detectada: modo de desempenho temporariamente "
+#~ "indisponível. Coloque o dispositivo em uma superfície estável para "
+#~ "restaurar."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Modo de desempenho temporariamente desabilitado."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Bateria fraca: economia de energia habilitada. O modo anterior será "
+#~ "restaurado quando a bateria estiver suficientemente carregada."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Modo de economia de energia ativado por “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Modo de desempenho ativado por “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Desempenho"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Desempenho e uso de energia altos."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Balanceado"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Desempenho e uso de energia padrão."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Economia de energia"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Desempenho e uso de energia reduzidos."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "A impressora “%s” foi excluída"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Falha ao adicionar nova impressora."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Não foi possível carregar a interface: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Desbloqueie para adicionar impressoras e alterar as configurações"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detalhes de %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Não foi encontrado um driver adequado"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Selecionar um arquivo PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Arquivos de descrição de impressora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
+#~ "PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Impressora JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Impressora LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Um lado"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Lado maior (padrão)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Lado menor (virar)"
+
+#~ msgid "Portrait"
+#~ msgstr "Retrato"
+
+#~ msgid "Landscape"
+#~ msgstr "Paisagem"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Paisagem invertida"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Retrato invertido"
+
+#~ msgid "Resume"
+#~ msgstr "Continuar"
+
+#~ msgid "Pause"
+#~ msgstr "Pausada"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Pendente"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pausada"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autenticação necessária"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Processando"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Parado"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Cancelado"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Abortado"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Concluído"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Move este trabalho para o topo da fila"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Trabalhos ativos"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Digite as credenciais para imprimir de %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Desbloquear servidor de impressão"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Desbloquear %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Digite nome de usuário e senha para ver as impressoras em %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Pesquisando por impressoras"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Porta serial"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Porta paralela"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Localização: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Endereço: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "O servidor requer autenticação"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dois lados"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tipo de papel"
+
+#~ msgid "Paper Source"
+#~ msgstr "Origem do papel"
+
+#~ msgid "Output Tray"
+#~ msgstr "Bandeja de saída"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Resolução"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Pré-filtragem do GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Páginas por lado"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientação"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Geral"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Configuração da página"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opções instaláveis"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Trabalho"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Qualidade da imagem"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Cor"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Finalização"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avançado"
+
+#~ msgid "Test page"
+#~ msgstr "Página de teste"
+
+#~ msgid "Auto Select"
+#~ msgstr "Autosselecionar"
+
+#~ msgid "Printer Default"
+#~ msgstr "Padrão da impressora"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Apenas fontes embutidas do GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Converter para PS nível 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Converter para PS nível 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Nenhum pré-filtro"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Limpeza cabeças de impressão"
+
+#~ msgid "Out of toner"
+#~ msgstr "Sem toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Com pouco revelador"
+
+#~ msgid "Out of developer"
+#~ msgstr "Sem revelador"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Pouco suprimento de marcador"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Sem suprimento de marcador"
+
+#~ msgid "Open cover"
+#~ msgstr "Abrir capa"
+
+#~ msgid "Open door"
+#~ msgstr "Abrir porta"
+
+#~ msgid "Low on paper"
+#~ msgstr "Com pouco papel"
+
+#~ msgid "Out of paper"
+#~ msgstr "Sem papel"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Desconectado"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Parado"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Recipiente de descarte quase cheio"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Recipiente de descarte cheio"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "O condutor de foto ótica está quase no fim da vida"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "O condutor de foto ótica não está funcionando"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Pronto"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Não aceitar trabalhos"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Processando"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Métrico"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Pergunte o que fazer"
+
+#~ msgid "Do nothing"
+#~ msgstr "Não fazer nada"
+
+#~ msgid "Open folder"
+#~ msgstr "Abrir pasta"
+
+#~ msgid "Other Media"
+#~ msgstr "Outra mídia"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Selecione um aplicativo para CDs de áudio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Selecione um aplicativo para DVDs de vídeo"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Selecione um aplicativo para executar quando um reprodutor de música é "
+#~ "conectado"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Selecione um aplicativo para executar quando uma câmera é conectada"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Selecione um aplicativo para CDs de software"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD de áudio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "Disco Blu-ray vazio"
+
+#~ msgid "blank CD disc"
+#~ msgstr "Disco CD vazio"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "Disco DVD vazio"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Disco HD DVD vazio"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disco Blu-ray de vídeo"
+
+#~ msgid "e-book reader"
+#~ msgstr "Leitor de e-book"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disco HD DVD de vídeo"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD de imagem"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "CD de vídeo"
+
+# Em Privacidade, complementa a mensagem "Lock screen _after blank for"
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Ao desligar a tela"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 segundos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minutos"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuto"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minutos"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nunca"
+
+#~ msgid "Select Location"
+#~ msgstr "Selecione localização"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Nenhum aplicativo encontrado"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Sem redes selecionadas para compartilhamento"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Ligado"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Desligado"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Habilitado"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Ativo"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Escolha uma pasta"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Habilitar compartilhamento multimídia"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "O compartilhamento de arquivos permite que você compartilhe sua pasta "
+#~ "Pública com outros na sua rede atual usando: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Quando a sessão remota está habilitada, usuários remotos podem se "
+#~ "conectar usando o comando de Shell Seguro:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Habilitar compartilhamento de mídia pessoal"
+
+#~ msgid "Device name copied"
+#~ msgstr "Nome do dispositivo copiado"
+
+#~ msgid "Device address copied"
+#~ msgstr "Endereço do dispositivo copiado"
+
+#~ msgid "Username copied"
+#~ msgstr "Nome de usuário copiado"
+
+#~ msgid "Password copied"
+#~ msgstr "Senha copiada"
+
+#~ msgid "Custom"
+#~ msgstr "Personalizado"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Testando %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+# http://en.wikipedia.org/wiki/Font_hinting
+# (não entendi a relação link-frase, mas vou deixar - Rafael)
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Desconectando"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Conectando"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Conectado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Erro de autorização"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autorizando"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Funcionalidade reduzida"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Conectado & Autorizado"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Desconhecido"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorizado em:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Conectado a:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Registrado em:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Falha ao autorizar dispositivo: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Falha ao esquecer dispositivo: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Erro"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorizado"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "O subsistema Thunderbolt (boltd) não está instalado ou não configurado "
+#~ "adequadamente."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Apenas dispositivos USB e Display Port podem se conectar."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt não pôde ser detectado.\n"
+#~ "O sistema não tem suporte a Thunderbolt, tendo sido desabilitado na BIOS "
+#~ "ou estando configurado para um nível de segurança ao qual a BIOS não "
+#~ "oferece suporte."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "O suporte a Thunderbolt foi desabilitado no BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "O nível de segurança do Thunderbolt não pôde ser determinado."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Erro ao trocar o modo direto: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Padrão"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Médio"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Grande"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Maior"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Gigante"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixels"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Curto"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ da tela"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ da tela"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ da tela"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Longo"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 hora"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dia"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dias"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dias"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Esvaziar todos os itens da lixeira?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Todos os itens na lixeira serão permanentemente excluídos."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Es_vaziar lixeira"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Excluir todos os arquivos temporários?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Todos os arquivos temporários serão permanentemente excluídos."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Excluir _permanentemente arquivos temporários"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dia"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dias"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dias"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Para sempre"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Deveria corresponder ao endereço web do seu provedor de sessão."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Falha ao adicionar conta"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Falha ao registrar conta"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nenhuma forma suportada para autenticar neste domínio"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Falha em entrar no domínio"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Aquele nome de sessão não funcionou.\n"
+#~ "Por favor, tente novamente."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Aquela senha de sessão não funcionou.\n"
+#~ "Por favor, tente novamente."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Falha em fazer login no domínio"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr ""
+#~ "Não foi possível localizar o domínio. Será que você escreveu errado?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Procurar por mais imagens"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "o dispositivo precisa ser reivindicado para executar esta ação"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "o dispositivo já foi reivindicado por outro processo"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "você não tem permissão para executar a ação"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "nenhuma impressão foi registrada"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Falha ao se comunicar com o dispositivo durante o registro"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Falha ao se comunicar com o leitor de impressão digital"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Falha ao se comunicar com o daemon de impressão digital"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Falha ao lista impressões digitais: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Falha ao excluir impressões digitais salvas: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Polegar esquerdo"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Dedo médio esquerdo"
+
+#~ msgid "_Left index finger"
+#~ msgstr "De_do indicador esquerdo"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Dedo anelar esquerdo"
+
+#~ msgid "Left little finger"
+#~ msgstr "Dedo pequeno esquerdo"
+
+#~ msgid "Right thumb"
+#~ msgstr "Polegar direito"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Dedo médio direito"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Dedo indicador di_reito"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Dedo anelar direito"
+
+#~ msgid "Right little finger"
+#~ msgstr "Dedo pequeno direito"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Dedo desconhecido"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Concluído"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Dispositivo de impressão digital desconectado"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "O armazenamento do dispositivo de impressão digital está cheio"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Falha ao registar nova impressão digital"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Falha ao iniciar registro: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Falha ao registrar nova impressão digital"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Falha ao parar registro: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Levante e coloque repetidamente o dedo no leitor para registrar sua "
+#~ "impressão digital"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Registrar novamente este dedo…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Registrar nova impressão digital"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Falha ao liberar o dispositivo de impressão digital %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problema ao ler o dispositivo"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Falha ao reivindicar o dispositivo de impressão digital %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Falha ao obter dispositivo de impressão digital: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Esta semana"
+
+#~ msgid "Last Week"
+#~ msgstr "Semana passada"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e de %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e de %b de %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sessão finalizada"
+
+#~ msgid "Session Started"
+#~ msgstr "Sessão iniciada"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Atividade da conta"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Por favor, escolha outra senha."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Por favor, digite sua senha atual novamente."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "A senha não pode ser alterada"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Não é possível participar automaticamente deste tipo de domínio"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "O domínio não existe"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Não foi possível fazer login como %s no domínio %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Senha inválida, por favor tente novamente"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Não foi possível conectar ao domínio %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Falha ao excluir usuário"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Falha ao revogar usuário gerenciado remotamente"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Você não pode excluir sua própria conta."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ainda está conectado"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Excluindo um usuário enquanto ele está conectado pode deixar o sistema em "
+#~ "um estado inconsistente."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Você deseja manter os arquivos de %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "É possível manter o diretório home, fila de e-mail e arquivos temporários "
+#~ "ao excluir uma conta de usuário."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Excluir arquivos"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Manter arquivos"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Tem certeza de que deseja revogar a conta gerenciada remotamente do %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Excluir"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Conta desabilitada"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Para ser definido no próximo início de sessão"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Nenhum"
+
+#~ msgid "Logged in"
+#~ msgstr "Acesso autorizado"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Falhou ao contactar o serviço de contas"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Por favor, certifique-se de que o Serviço de Contas esteja instalado "
+#~ "corretamente."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Este painel deve ser desbloqueado para alterar esta configuração"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Exclui a conta de usuário selecionada"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para excluir a conta de usuário selecionada,\n"
+#~ "clique primeiro no ícone *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Desbloqueie para adicionar usuários e alterar as configurações"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "A nova senha precisa ser diferente da antiga."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Tente mudar algumas letras e números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Tente alterar a senha um pouco mais."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Uma senha que não utilize seu nome de usuário será mais forte."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Evite usar seu nome na senha."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Evite algumas das palavras incluídas na senha."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Evite palavras comuns."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Evite reordenar palavras existentes."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Tente usar mais números."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Tente usar mais letras maiúsculas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Tente usar mais letras minúsculas."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Tente usar mais caracteres especiais, como pontuação."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Tente usar uma mistura de letras, números e pontuação."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Evite repetir o mesmo caractere."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Evite repetir o mesmo tipo de caractere: você precisa misturar letras, "
+#~ "números e pontuação."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Evite sequências como 1234 ou abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "A senha precisa ser mais longa. Tente adicionar mais letras, números e "
+#~ "pontuação."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Misture maiúsculas e minúsculas e tente usar um ou dois números."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Adicionar mais letras, números e pontuação tornará a senha mais forte."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Falha na autenticação"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "A nova senha é curta demais"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "A nova senha é simples demais"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "As senhas antiga e nova são semelhantes demais"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "A nova senha foi usada recentemente."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "A nova senha deve conter caracteres numéricos ou especiais"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "As senhas antiga e nova são iguais"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Sua senha foi alterada desde que você se autenticou inicialmente!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "A nova senha não contém caracteres diferentes o bastante"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Erro desconhecido"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "O nome de usuário deve, geralmente, consistir apenas de letras minúsculas "
+#~ "de a-z, dígitos e dos seguintes caracteres: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Desculpe, o nome de usuário informado não é válido. Por favor, tente "
+#~ "outro."
+
+#~ msgid "The username is too long."
+#~ msgstr "O nome de usuário é muito longo."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Botão %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Aplicativos definidos"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Enviar sequência de teclas"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Alternar monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Mostrar ajuda na tela"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tablet montado no painel de um laptop"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tablet montado em uma tela externa"
+
+#~ msgid "External tablet device"
+#~ msgstr "Dispositivo tablet externo"
+
+#~ msgid "All Displays"
+#~ msgstr "Todas as telas"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Caneta de aerógrafo com pressão, inclinação e controle deslizante "
+#~ "integrado"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Caneta de aerógrafo com pressão, inclinação e rotação"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Caneta padrão com pressão e inclinação"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Caneta padrão com pressão"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Novo atalho…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operação cancelada"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Erro:</b> Acesso negado ao alterar configurações"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Erro:</b> Erro de Equipamento Móvel"
+
+#~ msgid "Not Registered"
+#~ msgstr "Não registrado"
+
+#~ msgid "Registered"
+#~ msgstr "Registrado"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Pesquisando"
+
+#~ msgid "Denied"
+#~ msgstr "Negado"
+
+#~ msgid "2G Only"
+#~ msgstr "2G apenas"
+
+#~ msgid "3G Only"
+#~ msgstr "3G apenas"
+
+#~ msgid "4G Only"
+#~ msgstr "4G apenas"
+
+#~ msgid "5G Only"
+#~ msgstr "5G apenas"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (preferido)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (preferido), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (preferido), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (preferido), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (preferido)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (preferido), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (preferido), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (preferido)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (preferido), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (preferido), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (preferido)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (preferido), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (preferido), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (preferido)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (preferido), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (preferido), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (preferido)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (preferido), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (preferido)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (preferido), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (preferido)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (preferido), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (preferido)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (preferido), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (preferido)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (preferido), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (preferido)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (preferido), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Desconhecido"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Desbloquear cartão SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Por gentileza forneça o código PIN para o SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Digite o PIN para desbloquear seu cartão SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Por gentileza forneça o código PUK para o SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Digite o PUK para desbloquear seu cartão SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Informada senha incorreta."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Código PUK deve ser um número de 8 dígitos"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Digite novo PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Código PIN deve ser um número entre 4-8 dígitos"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Desbloqueando…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Telefone falhou"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Sem conexão com telefone"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operação não permitida"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Não há suporte para a operação"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM não inserido"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "PIN do SIM obrigatório"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "PUK do SIM obrigatório"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM falhou"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM ocupado"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Senha incorreta"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "PIN2 do SIM obrigatório"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "PUK2 do SIM obrigatório"
+
+#~ msgid "Not found"
+#~ msgstr "Não localizado"
+
+#~ msgid "No network service"
+#~ msgstr "Sem serviço de rede"
+
+#~ msgid "Network timeout"
+#~ msgstr "Tempo esgotado de rede"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Serviços de GPRS não permitidos"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming não permitido nesta área de localização"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Erro GPRS não especificado"
+
+#~ msgid "No Error"
+#~ msgstr "Sem erro"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Ação cancelada"
+
+#~ msgid "Access denied"
+#~ msgstr "Acesso negado"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Erro desconhecido"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Exibir número da versão"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Habilitar modo detalhado"
+
+#~ msgid "Search for the string"
+#~ msgstr "Pesquisar por string"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Lista possíveis nomes de painéis e sai"
+
+#~ msgid "Panel to display"
+#~ msgstr "Painel para exibir"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PAINEL] [ARGUMENTO…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Painéis disponíveis:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sons do sistema"
 
 #~ msgid "Light"
 #~ msgstr "Claro"
@@ -9708,9 +8408,6 @@ msgstr "Sons do sistema"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "Certificados DER ou PEM (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Adicionar uma impressora…"
 
 #~ msgid "Bark"
 #~ msgstr "Latido"
@@ -9894,9 +8591,6 @@ msgstr "Sons do sistema"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablet (absoluto)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Touchpad (relativo)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Preferências do tablet"
 
@@ -10018,8 +8712,8 @@ msgstr "Sons do sistema"
 #~ msgstr "Não foi possível ser alterado"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Permissões individuais por aplicativos podem ser revisadas nas "
 #~ "configurações de <a href=\"privacy\">Privacidade</a>."

--- a/po/pt_BR.po~
+++ b/po/pt_BR.po~
@@ -1,0 +1,10147 @@
+# Brazilian Portuguese translation of GNOME Control Center.
+# Copyright (C) 2022 The GNOME Control Center authors.
+# This file is distributed under the same license as the gnome-control-center package.
+# Ivan Passos <ivan@cyclades.com>, 1999.
+# Sandro Nunes Henrique <sandro@conectiva.com.br>, 1999.
+# Gustavo Maciel Dias Vieira <gustavo@sagui.org>, 2000-2001.
+# Tiago Cardoso Menezes <zion@via-rs.net>, 2003.
+# Evandro Fernandes Giovanini <evandrofg@ig.com.br>, 2004, 2006.
+# Alex Camacho Castilho <gnomebr@uol.com.br>, 2004.
+# Guilherme de S. Pastore <gpastore@colband.com.br>, 2004-2005.
+# Leonardo Ferreira Fontenelle <leonardof@gnome.org>, 2006, 2008.
+# Luiz Armesto <luiz.armesto@gmail.com>, 2007-2008.
+# Og Maciel <ogmaciel@ubuntu.com>, 2007, 2009-2011.
+# Washington Lins <washington-lins@uol.com.br>, 2007.
+# Raul Pereira <contato@raulpereira.com>, 2007.
+# Jonh Wendell <wendell@bani.com.br>, 2008, 2009
+# Henrique P Machado <zehrique@gmail.com>, 2008-2009.
+# Fabrício Godoy <skarllot@gmail.com>, 2008.
+# Djavan Fagundes <djavanf@gnome.org>, 2008, 2009, 2011.
+# André Gondim <andregondim@ubuntu.com>, 2009.
+# Krix Apolinário <krixapolinario@gmail.com>, 2009, 2011.
+# Antonio Fernandes C. Neto <fernandes@pelivre.org>, 2010, 2013.
+# Hugo Vaz Sampaio <hvazsampaio@gmail.com>, 2010.
+# Djavan Fagundes <djavan@comum.org>, 2012.
+# Gustavo Marques <gutodisse@gmail.com>, 2015, 2016.
+# Artur de Aquino Morais <artur.morais93@outlook.com>, 2016.
+# Georges Basile Stavracas Neto <georges.stavracas@gmail.com>, 2013-2019.
+# Bruno Lopes <brunolopesdsilv@gmail.com>, 2021.
+# Enrico Nicoletto <hiko@duck.com>, 2012-2016, 2018-2019, 2021-2022.
+# Rafael Fontenelle <rafaelff@gnome.org>, 2012-2022.
+# Leônidas Araújo <leorusvellt@hotmail.com>, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-05 19:41+0000\n"
+"PO-Revision-Date: 2022-09-06 21:36-0300\n"
+"Last-Translator: Enrico Nicoletto <hiko@duck.com>\n"
+"Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+"X-DamnedLies-Scope: partial\n"
+"X-Project-Style: gnome\n"
+"X-DL-Team: pt_BR\n"
+"X-DL-Module: gnome-control-center\n"
+"X-DL-Branch: master\n"
+"X-DL-Domain: po\n"
+"X-DL-State: Translating\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Barramento de sistema"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Acesso completo"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Barramento de sessão"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispositivos"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Acesso completo a /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rede"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Tem acesso à rede"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Pasta pessoal"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Somente leitura"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Sistema de arquivos"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Configurações"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Pode alterar as configurações"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s tem as seguintes permissões incorporadas. Estas não podem ser alteradas. "
+"Se você estiver preocupado com essas permissões, considere remover esse "
+"aplicativo."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u tipo de arquivo e link que é aberto pelo aplicativo"
+msgstr[1] "%u tipos de arquivo e link que são abertos pelo aplicativo"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> é usado para abrir os seguintes tipos de arquivos e links."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s de espaço em disco usado."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplicativos"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Nenhum aplicativo"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Instalar alguns…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Abrir"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Ver detalhes"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Pesquisa"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Recebe pesquisa do sistema e envia resultados."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Desabilitado"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificações"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Mostra notificações do sistema."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Executar em segundo plano"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Permite atividade quando o aplicativo é fechado."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Capturas de tela"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Capture as imagens da tela a qualquer momento."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Alterar papel de parede"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Altera o papel de parede da área de trabalho."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sons"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reproduz sons."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Inibir atalhos"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Bloqueia atalhos de teclado padrão."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Câmera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Captura imagens com a câmera."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microfone"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Grava áudio com o microfone."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Serviços de localização"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Acessa dados de localização do dispositivo."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Permissões incorporadas"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Acesso ao sistema exigido pelo aplicativo"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Associações de arquivo &amp; link"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Armazenamento"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Nenhum resultado encontrado"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Tente uma pesquisa diferente"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Associações de arquivo & link"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Tipos de arquivos"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Tipos de links"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Restaurar"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Quanto espaço em disco esse aplicativo está ocupando com dados e caches de "
+"aplicativos."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplicativo"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Dados"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Limpar cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Controle várias permissões e configurações de aplicativos"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"aplicativo;application;flatpak;permissão;permission;configuração;setting;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Selecionar uma imagem"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Cancelar"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Abrir"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "múltiplos tamanhos"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Nenhum plano de fundo"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Plano de fundo atual"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Estilo"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Padrão"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Escuro"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Plano de fundo"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Adicionar imagem…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Aparência"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Altere sua imagem de plano de fundo ou as cores da interface"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Plano de fundo;Papel de parede;Tela;Área de trabalho;Estilo;Claro;Escuro;"
+"Aparência;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Habilitar"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Não foi encontrado Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Plugue um dongle para usar Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth desligado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Ligue para conectar dispositivos e receber transferência de arquivos."
+
+# Traduções viáveis são "Modo avião", "Modo voo" ou até "Modo de avião". Achei por melhor manter a primeira opção
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Modo avião está ligado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Ao ligar o modo avião, o Bluetooth é desligado."
+
+# Traduções viáveis são "Modo avião", "Modo voo" ou até "Modo de avião". Achei por melhor manter a primeira opção
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Desligar modo avião"
+
+# Traduções viáveis são "Modo avião", "Modo voo" ou até "Modo de avião". Achei por melhor manter a primeira opção
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Modo avião via hardware está ligado"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Desligue o alternador do modo avião para habilitar o Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Ligue e desligue o Bluetooth e conecte seus dispositivos"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "compartilhar;compartilhamento;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Câmera está desligada"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Nenhum aplicativo pode capturar fotos e vídeo."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"O uso da câmera permite que os aplicativos capturem fotos e vídeos. "
+"Desabilitar a câmera pode fazer com que alguns aplicativos não funcionem "
+"corretamente.\n"
+"\n"
+"Permita que o aplicativo abaixo use sua câmera."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Nenhum aplicativo pediu por acesso à câmera"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Proteja suas imagens"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "câmera;fotos;vídeo;webcam;bloqueio;privado;privacidade;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Posicione o dispositivo de calibração sobre o quadrado e pressione “Começar”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Mova seu dispositivo de calibração para a posição de calibração e pressione "
+"“Continuar”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Mova seu dispositivo de calibração para a posição da superfície e pressione "
+"“Continuar”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Feche a tampa do laptop"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Ocorreu um erro interno do qual não se pôde recuperar."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Ferramentas necessárias para a calibração não estão instaladas."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "O perfil não pôde ser gerado."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "O ponto branco alvo era impossível de se obter."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Concluído!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Configuração falhou!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Você pode remover o dispositivo de calibração."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Não interrompa o dispositivo de calibração durante o progresso"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Calibração da tela"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Começar"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "Continua_r"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "Concluí_do"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Tela de laptop"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Webcam embutida"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Scanner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Câmera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Impressora %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webcam %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Habilitar gerenciamento de cor para %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Mostrar perfis de cor de %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Não calibrado"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Padrão: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Espaço de cores: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Perfil de teste: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Selecionar perfil ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importar"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Perfis ICC suportados"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Todos arquivos"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Tela"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Salvar perfil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salvar"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Criar um perfil de cor para o dispositivo selecionado"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"O instrumento de medição não foi detectado. Por favor, verifique se está "
+"ligado e conectado corretamente."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr ""
+"O instrumento de medição não tem suporte a criação de perfis de impressora."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Atualmente, não há suporte ao tipo de dispositivo."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Calibração de tela"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Calibração de qualidade"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"A calibração vai produzir um perfil que você pode usar para gerenciar cores "
+"de sua tela. Quanto mais tempo você gastar calibrando, melhor será a "
+"qualidade do perfil de cores."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Você não será capaz de usar seu computador enquanto a calibração ocorre."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Qualidade"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Tempo aproximado"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Calibração de dispositivo"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Selecione o dispositivo sensor que você deseja usar para a calibração."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Tipo de tela"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Selecione o tipo de tela que está conectada."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Ponto branco do perfil"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Selecione o ponto branco alvo da tela. A maioria das telas deveria ser "
+"calibrada para um iluminante D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Brilho da tela"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Por favor, defina a tela com um brilho que seja comum para você. O "
+"gerenciamento de cores será mais preciso neste nível de brilho."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativamente, você pode usar o nível de brilho usado por um dos outros "
+"perfis deste dispositivo."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nome do perfil"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Você usar um perfil de cor em computadores diferentes ou. até mesmo, criar "
+"perfis para condições de iluminação diferente."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Nome do perfil:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Resumo"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Perfil criado com sucesso!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copiar perfil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Requer uma mídia gravável"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Você pode considerar úteis, essas instruções sobre como usar o perfil em "
+"sistemas <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> e "
+"<a href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Adicionar perfil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Detectaram-se problemas. O perfil pode não funcionar corretamente. <a href="
+"\"\">Mostrar detalhes.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importar arquivo…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Adicionar"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Cada dispositivo precisa de uma atualização do perfil de cor para ter "
+"gerenciamento de cor."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Saiba mais"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Saiba mais sobre gerenciamento de cores"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Definir para todos os usuários"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Define este perfil para todos os usuários neste computador"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Habilitar"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Adicionar perfil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Calibração…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Calibra o dispositivo"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Remover perfil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Ver detalhes"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+"Não foi possível detectar quaisquer dispositivos que podem ter gerenciamento "
+"de cor"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projetor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (luz de fundo CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (luz de fundo LED RGB)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (luz de fundo LED branco)"
+
+# Referências: http://blog.geraldogarcia.com/index.php/2011/08/avaliacao-do-monitor-dell-u2410-um-campeao-temperamental/#axzz2QrMzWtDy
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD de amplo espectro/wide gamut (luz de fundo CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD de amplo espectro/wide gamut (luz de fundo LED RGB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Alta"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minutos"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Média"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Baixa"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Nativo do monitor"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (impressão e publicação)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografia e vídeos)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Espaço padrão"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Perfil de teste"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automático"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Baixa qualidade"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Média qualidade"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Alta qualidade"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Padrão RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Padrão CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Padrão cinza"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Dados de calibração de fábrica fornecidos pelo fabricante"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Correção de tela em tela cheia não é possível com este perfil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Este perfil pode não estar mais preciso"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Cor"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibre a cor dos seus dispositivos, tais como monitores, câmeras ou "
+"impressoras"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Cor;ICC;Perfil;Calibração;Impressão;Tela;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Outro…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Selecionar idioma"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Selecionar"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nenhum idioma encontrado"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Mais…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Desbloquear para alterar as configurações"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+"Algumas configurações devem estar desbloqueadas antes delas poderem ser "
+"alteradas."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Desbloquear…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Incrementar hora"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Incrementar monitor"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Hora"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Reduzir hora"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Reduzir minuto"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Hoje"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Ontem"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e de %b de %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hora"
+msgstr[1] "%d horas"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuto"
+msgstr[1] "%d minutos"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d segundo"
+msgstr[1] "%d segundos"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 segundos"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Ponto de acesso"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 horas"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+# Formato 12hs, não alterar para 24h
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e de %B de %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e de %B de %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+# Formato 12hs, não alterar para 24h
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data & hora"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Ano"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mês"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Janeiro"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Fevereiro"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Março"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Abril"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maio"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Junho"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Julho"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Agosto"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Setembro"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Outubro"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembro"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Dezembro"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dia"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Fuso horário"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Pesquisar por uma cidade"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "_Data &amp; hora automática"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Requer acesso à Internet"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Data &amp; _hora"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "_Fuso horário automático"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Requer serviços de local habilitado e acesso à Internet"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Fuso h_orário"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Formato da hora"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Altere a data e hora, incluindo fuso horário"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Relógio;Fuso horário;Localização;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Alterar o horário do sistema e configurações de data"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Para modificar configurações de data ou hora você precisa se autenticar."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "C_orreio"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Calendário"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "Mús_ica"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Vídeo"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotos"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicativos padrão"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configure os aplicativos padrão"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "padrão;aplicativo;preferido;mídia;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Enviar relatórios de problemas técnicos nos ajuda a melhorar o %s. Os "
+"relatórios são enviados anonimamente e não contêm dados pessoais. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Informe de erros"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Relatório _automático de problemas"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnóstico"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Relate seus problemas"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnósticos;falha;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Ligada"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Desligada"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Aplicar alterações?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Alterações não puderam ser aplicadas"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Isso pode ser devido a limitações de hardware."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Aplicar"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Voltar"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Configurações de telas desabilitadas"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Várias telas"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Unir"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Espelhar"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Contém barra superior e Atividades"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Tela primária"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Luz noturna"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Paisagem"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Retrato (virado)"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Retrato"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Paisagem (virada)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientação"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Resolução"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Taxa de atualização"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Ajustar para TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Dimensão"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Luz noturna indisponível"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Isso pode ser o resultado do uso do driver gráfico, ou da área de trabalho "
+"estar sendo usada remotamente"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Temporariamente desabilitado até amanhã"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Redefinir filtro"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"A luz noturna deixa a cor da tela mais quente. Isso pode auxiliar evitando "
+"tensão ocular e sonolência."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Agendar"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Pôr do sol ao nascer do sol"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Agendamento manual"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Horários"
+
+# Neste caso melhor traduzir como "Das", já que indica um período de tempo, ex.: Das 03h até as 5h --Enrico
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Das"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hora"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minuto"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+# Neste caso melhor traduzir como "até", já que indica um período de tempo, ex.: Das 03h até as 5h --Enrico
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Até"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura de cor"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Telas"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Escolha como usar os monitores e projetores conectados"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Painel;Projetor;xrandr;Tela;Resolução;Atualizar;Atualização;Monitor;Noite;"
+"Noturna;Luz;Azul;Desvio para o vermelho;redshift;cor;pôr do sol;nascer do "
+"sol;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "A inicialização segura esta ativa"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"A inicialização segura impede que softwares maliciosos sejam carregados "
+"quando o dispositivo é iniciado. Ela está atualmente ligada e está "
+"funcionando corretamente."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "A inicialização segura apresenta problemas"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"A inicialização segura impede que softwares maliciosos sejam carregados "
+"quando o dispositivo é iniciado. Ela está ativada no momento, mas não "
+"funcionará devido a uma chave inválida."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Os problemas com inicialização segura geralmente podem ser resolvidos nas "
+"configurações de firmware UEFI (BIOS) do seu computador e o fabricante do "
+"hardware pode fornecer informações sobre como fazer isso."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Para obter ajuda, entre em contato com o fabricante do hardware ou com o "
+"provedor de suporte de TI."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "A inicialização segura está desativada"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"A inicialização segura impede que o software malicioso seja carregado quando "
+"o dispositivo for iniciado. Atualmente está desligada."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"A inicialização segura geralmente pode ser ativada nas configurações de "
+"firmware UEFI (BIOS) do seu computador. Para obter ajuda, entre em contato "
+"com o fabricante do hardware ou com o provedor de suporte de TI."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"A inicialização segura impede que softwares maliciosos sejam carregados "
+"quando o dispositivo é iniciado.\n"
+"\n"
+"Para obter mais informações, entre em contato com o fabricante do hardware "
+"ou com o suporte de TI."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Passou"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Falhou"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "O dispositivo está em conformidade com o nível de segurança HSI %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Nível de segurança 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Este dispositivo não tem proteção contra problemas de segurança de hardware. "
+"Isso pode ser devido a um problema de configuração de hardware ou firmware. "
+"É recomendável entrar em contato com seu provedor de suporte de TI."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Nível de segurança 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Este dispositivo tem proteção mínima contra problemas de segurança de "
+"hardware. Este é o nível de segurança mais baixo do dispositivo e fornece "
+"proteção apenas contra ameaças de segurança simples."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Nível de segurança 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Este dispositivo tem proteção básica contra problemas de segurança de "
+"hardware. Isso fornece proteção contra algumas ameaças de segurança comuns."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Nível de segurança 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Este dispositivo tem proteção estendida contra problemas de segurança de "
+"hardware. Este é o nível mais alto de segurança do dispositivo e oferece "
+"proteção contra ameaças de segurança avançadas."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Nível de segurança"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Os níveis de segurança não estão disponíveis para este dispositivo."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Entre em contato com o fabricante do hardware para obter ajuda com "
+"atualizações de segurança."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Talvez seja possível resolver esse problema nas configurações de firmware "
+"UEFI do dispositivo ou por um técnico de suporte."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Talvez seja possível resolver esse problema nas configurações de firmware "
+"UEFI do dispositivo."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Talvez um técnico de suporte possa resolver esse problema."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nível 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nível 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nível 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Protegido contra software malicioso quando o dispositivo é iniciado."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "A inicialização segura está com problemas"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Alguma proteção é fornecida quando o dispositivo é iniciado."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "A Inicialização segura está desligada"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Sem proteção quando o dispositivo é iniciado."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Esse problema pode ter sido causado por uma alteração nas configurações do "
+"firmware UEFI, uma alteração na configuração do sistema operacional, ou por "
+"software malicioso no sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Esse problema pode ter sido causado por uma alteração nas configurações do "
+"firmware UEFI, ou por software malicioso no sistema."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Esse problema pode ter sido causado por uma alteração na configuração do "
+"sistema operacional, ou por software malicioso no sistema."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Altamente exposto a ameaças de segurança."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Proteção limitada contra falhas de segurança simples."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Protegido contra falhas de segurança comuns."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Protegido contra uma ampla gama de falhas de segurança."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Proteção compreensiva"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Sem eventos"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Proteção contra gravação do firmware"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Trava de proteção contra gravação do firmware"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Região Firmware do BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Descritor Firmware do BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Proteção de DMA na pré-inicialização"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Inicialização verificada pelo Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Protegido pelo ACM do Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Política de erros do Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Fusão do Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET Ativado"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET ativado"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "RAM Encriptada"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Proteção IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux Kernel Lockdown"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Verificação do Kernel Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Área de troca"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Suspender para RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Suspender para inativo"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Chave da plataforma UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "inicialização segura UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Configuração da Plataforma TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Reconstrução do TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine em Modo de Fabrica"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Substituição do Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Substituição do Intel Management Engine"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Atualizações de firmware"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Atestação do firmware"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Verificação do atualizador do firmware"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Depuração de plataforma"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Verificação de segurança do processador"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Proteção de reversão AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Proteção contra reprodução de firmware AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Proteção contra gravação do firmware AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Plataforma fundida"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Válido"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Inválido"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Desabilitado"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Bloqueado"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Desbloqueado"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Encriptado"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Não encriptado"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Comprometido"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Não comprometido"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Encontrado"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Não localizado"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Suportado"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Sem suporte"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Segurança do dispositivo"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Status de segurança do firmware do dispositivo"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"tela;bloqueio;diagnostico;travamento;privado;recente;temporário;índice;nome;"
+"rede;identidade;privacidade;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64 bits"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32 bits"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Indisponível"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logotipo do sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Nome do dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Modelo do hardware"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memória"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processador"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Gráficos"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Capacidade de disco"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Calculando…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Nome do SO"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID da compilação do SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Tipo do SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Versão do GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Carregando…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Sistema de janelas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualização"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Atualizações de software"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Renomear dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"O nome do dispositivo é usado para identificar este dispositivo quando é "
+"visualizado na rede ou ao parear dispositivos Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Nome do dispositivo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Renomear"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Sobre"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Veja informações sobre seu sistema"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;informação;informações;nome de máquina; hostname;memória;"
+"processado;cpu;versão;aplicativo;padrão;preferido;cd;dvd;usb;áudio;som;vídeo;"
+"disco;unidade;removível;mídia;autorun;autoinicialização;autoinicializável;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Som e mídia"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Ativar/Desativar o volume"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Diminuir volume"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Aumentar volume"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Ativar/Desativar microfone"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Iniciar reprodutor de multimídia"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Reproduzir (ou reproduzir/pausar)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pausar reprodução"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Parar reprodução"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Faixa anterior"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Próxima faixa"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Ejetar"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Digitação"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Alternar para a próxima fonte de entrada"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Alternar para a fonte de entrada anterior"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lançadores"
+
+# Retirado Lançar conforme sugestão em https://gitlab.gnome.org/Teams/Translation/pt_BR/-/issues/14
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Navegador de ajuda"
+
+# Retirado Lançar conforme sugestão em https://gitlab.gnome.org/Teams/Translation/pt_BR/-/issues/14
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Calculadora"
+
+# Retirado Lançar conforme sugestão em https://gitlab.gnome.org/Teams/Translation/pt_BR/-/issues/14
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Cliente de e-mail"
+
+# Retirado Lançar conforme sugestão em https://gitlab.gnome.org/Teams/Translation/pt_BR/-/issues/14
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Navegador web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Pasta pessoal"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Pesquisar"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistema"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Encerrar sessão"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Bloquear tela"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Acessibilidade"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Ativar ou desativar a ampliação"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Ampliar"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Reduzir"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Ativar ou desativar o leitor de tela"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Ativar ou desativar o teclado virtual"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Aumentar o tamanho do texto"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Diminuir o tamanho do texto"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Ativar ou desativar o alto contraste"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nenhuma fonte de entrada encontrada"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Outro"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Adicionar uma fonte de entrada"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Métodos de entrada não podem ser usados na tela de início de sessão"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nenhuma fonte de entrada selecionada"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opções"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Mover para cima"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Mover para baixo"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Preferências"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Ver disposição de teclado"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Remover"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Atalhos personalizados"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tecla de caracteres alternativos"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"A tecla de caracteres alternativos pode ser usada para inserir caracteres "
+"adicionais. Às vezes, eles são impressos como uma terceira opção no teclado."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt da esquerda"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt da direita"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super da esquerda"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super da direita"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tecla de menu"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl da direita"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tecla de composição"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"A tecla de composição permite que uma ampla variedade de caracteres sejam "
+"inseridos. Para usá-la, pressione a composição seguida pela sequência de "
+"caracteres. Por exemplo, tecla de composição seguida por <b>C</b> e <b>o</b> "
+"vai inserir <b>©</b>, <b>a</b> seguido por <b>'</b> vai inserir <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"As fontes de entrada podem ser alternadas usando o atalho de teclado %s.\n"
+"Isso pode ser alterado nas configurações de atalhos de teclado."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Fontes de entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Inclui layouts de teclado e métodos de entrada."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Alternar fonte de entrada"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Usar a me_sma fonte para todas as janelas"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Alternar fontes _individualmente para cada janela"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Entrada de caracteres especiais"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Métodos para inserir símbolos e variantes de letras usando o teclado."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Atalhos de teclado"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Veja e personalize atalhos"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificado"
+msgstr[1] "%d modificados"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Redefinir todos os atalhos?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Redefinir os atalhos pode afetar seus atalhos personalizados. Isso não pode "
+"ser desfeito."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Redefinir todos"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Redefinir todos…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Redefine todos os atalhos suas combinações de teclas padrão"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Seção"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Adicionar atalho"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Adicionar atalhos personalizados"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Defina atalhos personalizados para iniciar aplicativos, executar scripts e "
+"mais."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Adicionar atalho"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nenhum atalho de teclado localizado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s está sendo usado para %s. Se você substituí-lo, %s será desabilitada"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Insira um novo atalho"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Definir atalhos personalizados"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Definir atalho"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Insira um novo atalho para %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Adicionar atalho personalizado"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Remover"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Substituir"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "De_finir"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Pressione Esc para cancelar ou Backspace para desabilitar o atalho de "
+"teclado."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Nome"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Comando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Atalho"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Definir atalho…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Nenhum"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Redefine o atalho para seu valor padrão"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Teclado"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Altere os atalhos de teclado e defina suas preferências de digitação, "
+"disposições de teclado e fontes de entrada"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Atalho;Teclado;Espaço;Trabalho;Janela;Redimensionar;Tela;Contraste;Fonte;"
+"Entrada;Bloqueio;Bloquear;Volume;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Serviços de localização desligados"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Nenhum aplicativo pode obter informações de localização."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Serviços de localização permitem que aplicativo saibam sua localização. O "
+"uso de Wi-Fi e de banda larga móvel aumenta a precisão.\n"
+"\n"
+"Usa Mozilla Location Service: <a href='https://location.services.mozilla.com/"
+"privacy'>Política de privacidade</a>\n"
+"\n"
+"Permita que o aplicativo abaixo determine sua localização."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Nenhum aplicativo pediu por acesso à localização"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Proteja suas informações de localização"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "localização;gps;privado;privacidade;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Microfone desligado"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Nenhum aplicativo pode gravar som."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"O uso do microfone permite que os aplicativos gravem ou escutem ao áudio. "
+"Desabilitar o microfone pode fazer com que alguns aplicativos não funcionem "
+"corretamente.\n"
+"\n"
+"Permita que os aplicativos abaixo usem seu microfone."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Nenhum aplicativo pediu por acesso ao microfone"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Projeta suas conversas"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "microfone;gravação;aplicação;privacidade;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Testar suas configurações"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Geral"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Botão primário"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Defina a ordem dos botões do mouse e touchpads."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Esquerda"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Direita"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mouse"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Velocidade do mouse"
+
+# Todas as referências que encontrei em português falavam em "zona de
+# rolagem"; em inglês "edge scrolling" é feito na "scroll zone" mas não achei
+# algo como "rolagem na borda" em português. -- Leonardo Fontenelle
+#
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Rolagem natural"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "A rolagem move o conteúdo, não a visão."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Velocidade do touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Toque para clicar"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Toque para clicar"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Rolagem com dois dedos"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Rolagem na borda"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Tente realizar um clique, clique duplo, rolagem"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinco cliques, hora de GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Clique duplo, botão primário"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Clique único, botão primário"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Clique duplo, botão do meio"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Clique único, botão do meio"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Clique duplo, botão secundário"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Clique único, botão secundário"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mouse & touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Altere a sensibilidade do seu mouse ou touchpad e selecione modo canhoto ou "
+"destro"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Ponteiro;Clicar;Tap;Toque;Batida;Duplo;Botão;Trackball;Rolagem;"
+"Scroll;"
+
+# Traduzido como "Canto ativo" conforme tradução do Módulo "gsettings-desktop-schemas" - Enrico.
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Canto at_ivo"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Toque o canto superior esquerdo para abrir o Panorama de Atividades."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Bordas de tela _ativas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Arrasta janelas para as bordas de tela superior, esquerda e direita para "
+"redimensioná-las."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Espaços de trabalho"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "Espaços de trabalho _dinâmicos"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Remove automaticamente espaços de trabalho vazios."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "Número _fixo de espaços de trabalho"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Especifica um número permanente de espaços de trabalho."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Número de espaços de trabalho"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Multi-Monitor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Espaços de trabalho somente na tela _principal"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Espaços de trabalho em todas as t_elas"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Alternador de aplicativos"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Incluir aplicativos de todos os es_paços de trabalho"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Incluir aplicativos somente do espaço de trabalho at_ual"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multitarefas"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Gerencie preferências para produtividade e multitarefas"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitarefas;Multitarefa;Produtividade;Personalizar;Área de trabalho;Canto "
+"ativo;Espaços de trabalho;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Oops, algo deu errado. Por favor contate o seu fornecedor de software."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "O NetworkManager precisa estar em execução."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Outros dispositivos"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Adicionar nova conexão"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Não configurado"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Rede insegura (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Rede segura (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Rede segura (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Rede segura (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Rede segura"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Conectado"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Opções…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Ligar o ponto de acesso vai lhe desconectar de %s e não será possível "
+"acessar a Internet por meio do Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Deve haver um mínimo de 8 caracteres"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Deve ter um máximo de %d caractere"
+msgstr[1] "Deve ter um máximo de %d caracteres"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Ligar o ponto de acesso Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"O ponto de acesso Wi-Fi permite que outras pessoas compartilhem sua conexão "
+"com a Internet, criando uma rede Wi-Fi à qual eles possam se conectar. Para "
+"fazer isso, você deve ter uma conexão com a Internet através de uma fonte "
+"diferente de Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nome da rede"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Senha"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Gerar senha aleatória"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Gerar senha automaticamente"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Ligar"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Parar ponto de acesso e desconectar todos os usuários?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Parar ponto de acesso"
+
+# Traduções viáveis são "Modo avião", "Modo voo" ou até "Modo de avião". Achei por melhor manter a primeira opção
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Modo avião"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Desabilita Wi-Fi, Bluetooth e banda larga móvel"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nenhum adaptador Wi-Fi encontrado"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Certifique-se de que você tenha um adaptador Wi-Fi conectado e ligado"
+
+# Traduções viáveis são "Modo avião", "Modo voo" ou até "Modo de avião". Achei por melhor manter a primeira opção
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Modo avião ligado"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Desligue para usar o Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Ponto de acesso Wi-Fi ativo"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Dispositivos móveis podem ler o código QR para conectar."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Desligar ponto de acesso Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Redes visíveis"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "O NetworkManager precisa estar em execução"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Segurança 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Segurança"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Preservar"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanente"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Aleatório"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Estável"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"O endereço MAC inserido aqui será usado como endereço de hardware para o "
+"dispositivo de rede em que esta conexão está ligada. Esse recurso é "
+"conhecido como clonagem ou falsificação de MAC. Exemplo: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Perfil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Empresarial"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nenhuma"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i dia atrás"
+msgstr[1] "%i dias atrás"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nenhum"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Fraca"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Boa"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excelente"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Endereço IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Endereço IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Endereço IP"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Esquecer conexão"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Remover o perfil de conexão"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Remover VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Detalhes"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automático"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identidade"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Excluir endereço"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Excluir rota"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Nenhum"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP chave de 40/128-bit (Hex ou ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP senha de 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP dinâmico (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 pessoal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 empresarial"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 pessoal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Força do sinal"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Velocidade do link"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Endereço físico"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Frequências suportadas"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Rota padrão"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Último uso"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Conectar _automaticamente"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Disponibilizar para _outros usuários"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"Conexão _limitada: possui limites de dados ou pode incorrer em cobranças"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Atualizações de software e outros downloads grandes não serão iniciados "
+"automaticamente."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Nome"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Endereço _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Endereço _clonado"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Método IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automático (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Apenas conexão local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Desabilitar"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Compartilhada com outros computadores"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Endereços"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Endereço"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Máscara de rede"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automático"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS automático"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Endereço(s) do servidor DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Separe os endereços IP com vírgulas"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rotas"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Rotas automáticas"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Métrica"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Usar esta c_onexão apenas para recursos nesta rede"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Método IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automático, somente DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefixo"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Não foi possível abrir o editor de conexão"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Novo perfil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Configuração inválida %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Configuração inválida %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importar de arquivo…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Adicionar VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "S_egurança"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Não foi possível importar conexão VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"O arquivo “%s” não pode ser lido ou não possui informações de conexão VPN "
+"reconhecíveis\n"
+"\n"
+"Erro: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Selecione um arquivo para importar"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Um arquivo de nome “%s” já existe."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Substituir"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Deseja substituir %s com a conexão VPN que você está salvando?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Não foi possível exportar conexão VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"A conexão VPN “%s” não pode ser exportada para %s.\n"
+"\n"
+"Erro: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exportar conexão VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Erro: não foi possível carregar o editor de conexão VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Controle como você conecta à Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Rede;Network;IP,LAN;Proxy;WAN;Banda larga;Broadband;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controle como você conecta a redes Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Rede;Network;Sem fio;Wireless;Wi-Fi;Wifi;IP;LAN;Banda larga;Broadband;DNS;"
+"Ponto de acesso;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nunca"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "hoje"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "ontem"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Último uso"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Com fio"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Adicionar nova conexão"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Detalhes de rede selecionadas, incluindo senhas e qualquer configuração "
+"personalizada serão perdidos."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Esquecer"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Redes Wi-Fi conhecidas"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Esquecer"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "A política do sistema proíbe o uso de um ponto de acesso"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr ""
+"O dispositivo de rede sem fio não possui suporte a modo de ponto de acesso"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Autodescoberta de um Proxy Web é usada quando a URL de configuração não é "
+"fornecida."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Isto não é recomendado para as redes públicas não confiáveis."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Desligar dispositivo"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Ativo"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Provedor"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy de rede"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Proxy _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Servidor _socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorar máquinas"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Porta proxy HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Porta proxy HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Porta proxy FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Porta proxy socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_URL de configuração"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Desligar conexão VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nome da rede"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tipo de segurança"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Senha"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Desligar Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Mais Opções…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Conectar a uma rede oculta…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Ligar ponto de acesso Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Redes _Wi-Fi conhecidas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Estado desconhecido"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Não gerenciável"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Indisponível"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Conectando"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Autenticação necessária"
+
+# http://en.wikipedia.org/wiki/Font_hinting
+# (não entendi a relação link-frase, mas vou deixar - Rafael)
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Desconectando"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Conexão falhou"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Estado desconhecido (perdido)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Configuração falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Configuração de IP falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Configuração de IP expirou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Senhas foram exigidas, mas não foram fornecidas"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Suplicante 802.1x desconectado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Configuração do suplicante 802.1x falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Suplicante 802.1x falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Suplicante 802.1x levou tempo demais para autenticar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Serviço PPP falhou em iniciar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Serviço PPP desconectado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Serviço PPP falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Cliente DHCP falhou em iniciar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Erro no cliente DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Cliente DHCP falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "O serviço de conexão compartilhada falhou ao iniciar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "O serviço de conexão compartilhada falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Serviço de AutoIP falhou em iniciar"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Erro no serviço AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Serviço de AutoIP falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linha ocupada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Não há tom de discagem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Nenhuma transportadora pode ser estabelecida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Requisição de discagem alcançou limite de tempo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Tentativa de discagem falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Inicialização do modem falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Falha ao selecionar o APN especificado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Não está pesquisando por redes"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Registro à rede negado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Registro de rede alcançou limite de tempo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Falhou ao registrar com a rede requisitada"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Verificação de PIN falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Firmware do dispositivo pode estar faltando"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Conexão desapareceu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "A conexão existente foi presumida"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem não encontrado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Conexão Bluetooth falhou"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Cartão SIM não inserido"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Pin do SIM obrigatório"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Puk do SIM obrigatório"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM errado"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Falha na dependência da conexão"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Faltando firmware"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Cabo desconectado"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "erro indefinido na segurança 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "nenhum arquivo selecionado"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "erro não especificado ao validar arquivo de método eap"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Chaves privadas DER, PEM ou PKCS#12 "
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certificados DER ou PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "faltando arquivo PAC EAP-FAST"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Arquivos PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anônimo"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autenticado"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ambos"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "I_dentidade anônima"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "A_rquivo PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Escolha um arquivo PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Autenticação _interna"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Permitir pro_visionamento PAC automático"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "faltando nome de usuário EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "faltando senha EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "Nome de _usuário"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Senha"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Mostrar senha"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "certificado de AC EAP-PEAP inválido: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "certificado de AC EAP-PEAP inválido: nenhum certificado especificado"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versão 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versão 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Certificado de A_C"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Escolha um certificado da autoridade certificadora"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Nenhum certificado de AC é necessá_rio"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Versão PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "faltando nome de usuário EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "faltando senha EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "faltando identidade EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "certificado de AC EAP-TLS inválido: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "certificado de AC EAP-TLS inválido: nenhum certificado especificado"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "chave privada EAP-TLS inválida: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificado EAP-TLS inválido: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Chaves privadas sem criptografia são inseguras"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"A chave privada selecionada não aparenta estar protegida por uma senha. Isso "
+"pode permitir que suas credenciais de segurança estejam comprometidas. Por "
+"favor, selecione uma chave privada protegida por senha.\n"
+"\n"
+"(Você pode proteger com senha sua chave privada usando openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Escolha seu certificado pessoal"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Escolha sua chave privada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentidade"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Certificado do _usuário"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Chave pri_vada"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Senha da chave _privada"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "certificado de AC EAP-TTLS inválido: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "certificado de AC EAP-TTLS inválido: nenhum certificado especificado"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (sem EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domínio"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Erro desconhecido ao validade segurança 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+# "Tunelado" não existe, então não enventemos.
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS encapsulado"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP protegido (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tenticação"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Selecione um arquivo"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "faltando nome de usuário leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "faltando senha leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Senha do Wi-Fi faltando."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tipo"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "faltando chave wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"chave wep inválida: chave com um tamanho de %zu deve conter apenas dígitos "
+"hexadecimais"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"chave wep inválida: chave com um tamanho de %zu deve conter apenas dígitos "
+"ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"chave wep inválida: tamanho de chave %zu inválido. Um chave deve estar entre "
+"o tamanho 5/13 (ascii) ou 10/26 (hexadecimal)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "chave wep inválida: frase secreta não pode estar vazia"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "chave wep inválida: frase secreta deve ser menor que 64 caracteres"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (padrão)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistema aberto"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Chave compartilhada"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "C_have"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Mostrar chave"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Índice _WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk inválido: tamanho de chave %zu inválido. Deve ser de [8,63] bytes ou "
+"64 dígitos hexadecimais"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk inválido: não é possível interpretar chave com 64 bytes como "
+"hexadecimal"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificações"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alertas de som"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Janelas instantâneas de notificação"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"As notificações continuarão aparecendo na lista de notificações quando as "
+"janelas instantâneas estão desabilitadas."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Mostrar o _conteúdo da mensagem nas janelas instantâneas"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notificações na tela de b_loqueio"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Mostrar c_onteúdo da mensagem na tela de bloqueio"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Não perturbe"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Notificações na tela de b_loqueio"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controle quais notificações são exibidas e o que elas mostram"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notificações;Banner;Mensagem;Bandeja;Janelas instantâneas;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Outro"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s removido(a)"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Erro ao remover conta"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Desfazer"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Fechar a notificação"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Conecte seus dados na nuvem"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Nenhuma conexão com a Internet — conecte para configurar novas contas on-line"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Adicionar uma conta"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Conta %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Remover conta"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Contas online"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Conecte-se às suas contas on-line e decida para que usá-las"
+
+# Não podemos esquecer de deixar o sinal de ponto-e-vírgula após a última palavra chave!! --Enrico
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Conectado;Online;Bate-papo;Chat;Calendário;"
+"Agenda;E-mail;Correio;Contato;Contatos;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
+"ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Hora desconhecida"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minuto"
+msgstr[1] "%i minutos"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hora"
+msgstr[1] "%i horas"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hora"
+msgstr[1] "horas"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuto"
+msgstr[1] "minutos"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s até carga completa"
+
+# Fonte de alimentação ininterrupta, também conhecida pelo acrônimo UPS (sigla em inglês de Uninterruptible Power Supply) ou no-break.
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Cuidado: %s restante"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s restantes"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Carga completa"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Não está carregando"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Vazia"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Carregando"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Descarregando"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Mouse sem fio"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Teclado sem fio"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Fonte de alimentação ininterrupta (no-break)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Assistente pessoal digital (PDA)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Celular"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Reprodutor de multimídia"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Computador"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Dispositivo de entrada de jogo"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Bateria"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principal"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Extra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Baterias"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "_Quando ocioso"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Suspender"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Desligar"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernar"
+
+# "Comportamento do botão de energia"
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nenhum"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Quando estiver usando a energia da bateria"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Ligado na tomada"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Suspensão automática"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Modo de desempenho temporariamente desabilitado devido à alta temperatura de "
+"operação."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Superfície instável detectada: modo de desempenho temporariamente "
+"indisponível. Coloque o dispositivo em uma superfície estável para restaurar."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Modo de desempenho temporariamente desabilitado."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Bateria fraca: economia de energia habilitada. O modo anterior será "
+"restaurado quando a bateria estiver suficientemente carregada."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Modo de economia de energia ativado por “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Modo de desempenho ativado por “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minutos"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 horas"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Modo de energia"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Afeta o desempenho e uso de energia do sistema."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Opções de economia de energia"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Brilho de tela automático"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Ajusta o brilho da tela à luz ambiente."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Escurecer a tela"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Reduz o brilho da tela quando o computador está inativo."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Apagar a _tela"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Desliga a tela após um período de inatividade."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Economia de energia automática"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Habilita o modo de economia de energia quando a bateria está baixa."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "Suspensão _automática"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pausa o computador após um período de inatividade."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Comportamento do botão de e_nergia"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Mostrar _porcentagem da bateria"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Suspensão automática"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Ligado na tomada"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Energia da _bateria"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Atraso"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Desempenho"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Desempenho e uso de energia altos."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Balanceado"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Desempenho e uso de energia padrão."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Economia de energia"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Desempenho e uso de energia reduzidos."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Energia"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Veja o estado da sua bateria e altere as configurações de economia de energia"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Energia;Dormir;Suspender;Hibernar;Bateria;Brilho;Escurecer;Vazio;Branca;"
+"Monitor;DPMS;Inativo;Bateria;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "A impressora “%s” foi excluída"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Falha ao adicionar nova impressora."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Não foi possível carregar a interface: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Desbloqueie para adicionar impressoras e alterar as configurações"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Impressoras"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Adicione impressoras, veja trabalhos de impressão e decida como você "
+"gostaria de imprimir"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Impressora;Fila;Imprimir;Papel;Tinta;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Adicionar impressora"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Desbloquear"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Nenhuma impressora encontrada"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Digite um endereço de rede ou pesquise por uma impressora"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autenticação necessária"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Digite nome de usuário e senha para ver as impressoras no servidor de "
+"impressão."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nome de usuário"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Detalhes de %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Não foi encontrado um driver adequado"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Selecionar um arquivo PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Arquivos de descrição de impressora PostScript (*.ppd, *.PPD, *.ppd.gz, *."
+"PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Nomes de impressoras não podem conter SPACE, TAB, #, ou /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Localização"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Pesquisando por drivers preferidos…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Pesquisar por drivers"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Selecionar do banco de dados…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instalar um arquivo PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Selecionar driver de impressora"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Carregando banco de dados de drivers…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Selecionar"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Impressora JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Impressora LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Um lado"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Lado maior (padrão)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Lado menor (virar)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Retrato"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Paisagem"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Paisagem invertida"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Retrato invertido"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Continuar"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pausada"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Pendente"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pausada"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autenticação necessária"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Processando"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Parado"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Cancelado"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Abortado"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Concluído"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Move este trabalho para o topo da fila"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u trabalho requer autenticação"
+msgstr[1] "%u trabalhos requerem autenticação"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Trabalhos ativos"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Digite as credenciais para imprimir de %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domínio"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utenticar"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Limpar tudo"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autenticar"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Nenhum trabalho de impressão ativo"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Desbloquear servidor de impressão"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Desbloquear %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Digite nome de usuário e senha para ver as impressoras em %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Pesquisando por impressoras"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Porta serial"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Porta paralela"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Localização: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Endereço: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "O servidor requer autenticação"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dois lados"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tipo de papel"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Origem do papel"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Bandeja de saída"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Resolução"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Pré-filtragem do GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Páginas por lado"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dois lados"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientação"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Geral"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Configuração da página"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opções instaláveis"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Trabalho"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Qualidade da imagem"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Cor"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Finalização"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avançado"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Página de teste"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Página de teste"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Autosselecionar"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Padrão da impressora"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Apenas fontes embutidas do GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Converter para PS nível 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Converter para PS nível 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Nenhum pré-filtro"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Fabricante"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Sem trabalhos ativos"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u trabalho"
+msgstr[1] "%u trabalhos"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Limpeza cabeças de impressão"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Com pouco toner"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Sem toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Com pouco revelador"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Sem revelador"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Pouco suprimento de marcador"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Sem suprimento de marcador"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Abrir capa"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Abrir porta"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Com pouco papel"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Sem papel"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Desconectado"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Parado"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Recipiente de descarte quase cheio"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Recipiente de descarte cheio"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "O condutor de foto ótica está quase no fim da vida"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "O condutor de foto ótica não está funcionando"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Pronto"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Não aceitar trabalhos"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Processando"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Opções da impressão"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Detalhes da impressora"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Usar como impressora padrão"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Limpar cabeças de impressão"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Remover impressora"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modelo"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Nível de tinta"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Por favor, reinicie quando o problema estiver resolvido."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Reiniciar"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Adicionar impressora…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Sem impressora"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Desculpe! O serviço de impressão do sistema\n"
+"    parece não estar disponível."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formatos"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Pesquisar localidades…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Formatos comuns"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Todos os formatos"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Nenhum resultado de pesquisa"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Pesquisas podem ser por países ou idiomas."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Visualizar"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Métrico"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datas"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Datas & horas"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Números"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Medidas"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papel"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "O idioma e o formato serão alterados após o próximo início de sessão"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Sair…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"A configuração de idioma é usada para texto de interface e páginas da web. "
+"Formatos é usado para números, datas e moedas."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Sua Conta"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Idioma"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formatos"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Tela de início de sessão"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Região & idioma"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Selecione o seus idioma de exibição e formatos"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Idioma;Disposição;Teclado;Entrada;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Pergunte o que fazer"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Não fazer nada"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Abrir pasta"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Outra mídia"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Selecione um aplicativo para CDs de áudio"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Selecione um aplicativo para DVDs de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Selecione um aplicativo para executar quando um reprodutor de música é "
+"conectado"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Selecione um aplicativo para executar quando uma câmera é conectada"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Selecione um aplicativo para CDs de software"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD de áudio"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "Disco Blu-ray vazio"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "Disco CD vazio"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "Disco DVD vazio"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "Disco HD DVD vazio"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Disco Blu-ray de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "Leitor de e-book"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Disco HD DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "CD de imagem"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "CD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Software do Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Selecione como a mídia deve ser manuseada"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD de á_udio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD de vídeo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "Reprodutor de _música"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Outra mídia…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nunca perguntar ou iniciar programas de inserção na mídia"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Selecione como outras mídias devem ser manipuladas"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Ação:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tipo:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Mídia removível"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configure as configurações de mídias removíveis"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"dispositivo;sistema;padrão;aplicativo;preferido;cd;dvd;usb;áudio;vídeo;"
+"unidade;removível;mídia;autorun;"
+
+# Em Privacidade, complementa a mensagem "Lock screen _after blank for"
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Ao desligar a tela"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 segundos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuto"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nunca"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Tela de bloqueio"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"O bloqueio automático da tela impede outras pessoas de acessar o computador "
+"enquanto você estiver ausente."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Atraso para apagar a tela"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "O período de inatividade após o qual a tela será apagada."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "B_loqueio de tela automático"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Atraso para bloquear a tela automaticamente"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"O período após o apagamento da tela quando a tela é bloqueada "
+"automaticamente."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Mostrar _notificações na tela de bloqueio"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Proibir novos dispositivos _USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Impede novos dispositivos USB de interagirem com sistema quando a tela está "
+"bloqueada."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Privacidade da tela"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Restringir ângulo de visão"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Configurações da tela"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "tela;bloqueio;privado;privacidade;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Selecione localização"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Pesquisar localizações"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Pastas que são pesquisadas por aplicativos de sistema, como Arquivos, Fotos "
+"e Vídeos."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Locais"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Outros"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Adicionar localização"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nenhum aplicativo encontrado"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Pesquisa do aplicativo"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Inclui resultados de pesquisa fornecidos pelo aplicativo."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Pastas que são pesquisadas por aplicativos de sistema."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Resultados de pesquisa"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Resultados são exibidos de acordo com a ordem da lista."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controle quais aplicativos mostram resultados de pesquisa no panorama de "
+"atividades"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Pesquisa;Localizar;Índice;Ocultar;Privacidade;Resultados;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Sem redes selecionadas para compartilhamento"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Redes"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Ligado"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Desligado"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Ativo"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Escolha uma pasta"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Adicionar"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Habilitar compartilhamento multimídia"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"O compartilhamento de arquivos permite que você compartilhe sua pasta "
+"Pública com outros na sua rede atual usando: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Quando a sessão remota está habilitada, usuários remotos podem se conectar "
+"usando o comando de Shell Seguro:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Habilitar compartilhamento de mídia pessoal"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Nome do dispositivo copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Endereço do dispositivo copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Nome de usuário copiado"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Senha copiada"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Compartilhamento"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Nome do _computador"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Compartilhamento de _arquivos"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Área _de trabalho remota"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Compartilhamento de _multimídia"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Sessão _remota"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Compartilhamento de arquivos"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Exigi_r senha"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Sessão remota"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Área de trabalho remota"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Área de trabalho remota permite visualizar e controlar seu ambiente de outro "
+"computador."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Habilita ou desabilita conexões de área de trabalho remota para este "
+"computador."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Controle remoto"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Permite que conexões remotas controlem a tela."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Como ser conectar"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Conecte a este computador usando o nome do dispositivo ou o endereço da área "
+"de trabalho remota."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copiar"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Endereço da área de trabalho remota"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autenticação"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"O nome de usuário e senha são necessários para se conectar a este computador."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Nome de usuário"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Verificar criptografia"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Impressão digital de criptografia"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"A impressão digital de criptografia pode ser vista na conexão de clientes e "
+"deve ser idêntica."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Compartilhamento de multimídia"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Compartilhe músicas, fotos e vídeos através da rede."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Pastas"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controle o que você quer compartilhar com outros"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"compartilhar;compartilhamento;ssh;máquina;host;nome;remoto;desktop;área de "
+"trabalho;mídia;áudio;som;vídeo;imagens;fotos;filmes;servidor;renderizador;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Habilitar ou desabilitar sessão remota"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "É necessário autenticação para habilitar ou desabilitar sessão remota"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Personalizado"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Clique"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Texto"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Swing"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Hum"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balanço"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Desaparecer"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Traseiro"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Frontal"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Testando %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Clique em um alto-falante para testar"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volume do sistema"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Volume do sistema"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Níveis de volume"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Saída"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Dispositivo de saída"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testar"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configuração"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Entrada"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Dispositivo de entrada"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volume"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Som de alerta"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Mudo"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Som"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Alterar níveis, entradas saídas e alertas de som volume de som e eventos de "
+"som"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Placa;Card;Microfone;Microphone;Volume;Desaparecer;Fade;Balanço;Bluetooth;"
+"Fone de ouvido com microfone;Headset;Áudio;Saída;Output;Entrada;Input;"
+
+# http://en.wikipedia.org/wiki/Font_hinting
+# (não entendi a relação link-frase, mas vou deixar - Rafael)
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Desconectando"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Conectando"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Conectado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Erro de autorização"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autorizando"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Funcionalidade reduzida"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Conectado & Autorizado"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Autorizado em:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Conectado a:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Registrado em:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Falha ao autorizar dispositivo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Falha ao esquecer dispositivo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Depende de %u outro disponível"
+msgstr[1] "Depende de %u outros disponíveis"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Fechar notificação"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Nome:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Estado:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Autorizar e conectar"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Esquecer dispositivo"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Erro"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorizado"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"O subsistema Thunderbolt (boltd) não está instalado ou não configurado "
+"adequadamente."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Permite acesso direto a dispositivos como GPUs externas e docks."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Apenas dispositivos USB e Display Port podem se conectar."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt não pôde ser detectado.\n"
+"O sistema não tem suporte a Thunderbolt, tendo sido desabilitado na BIOS ou "
+"estando configurado para um nível de segurança ao qual a BIOS não oferece "
+"suporte."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "O suporte a Thunderbolt foi desabilitado no BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "O nível de segurança do Thunderbolt não pôde ser determinado."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Erro ao trocar o modo direto: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Sem suporte a Thuderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Não foi possível conectar ao subsistema do thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Acesso direto"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Dispositivos pendentes"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Nenhum dispositivo anexado"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Gerencie dispositivos Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacidade;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Cursor intermitente"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Cursor intermitente nos campos de texto."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Velocidade"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Velocidade do piscar do cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Tamanho do cursor"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"O tamanho do cursor pode ser combinado com a ampliação para facilitar a "
+"visão do cursor."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Assistência de clique"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Clique secundário _simulado"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Disparar clique secundário ao manter pressionado o botão primário"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Atraso de a_ceitação:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Atraso do clique secundário"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Clique _flutuante"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Disparar clique secundário ao manter pressionado o botão primário"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Espera:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Limiar de movimen_to:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Pequeno"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Repetição de teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "A tecla é repetida quando mantida pressionada."
+
+# Compreendo que seja atraso na repetição, pois isto permite que as teclas sejam repetidas em uma velocidade menor,  desde que o usuário mantenha a tecla pressionada. --Enrico
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Atraso na repetição das teclas"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Velocidade de repetição das teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Assistência de digitação"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Teclas de aderê_ncia"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+"Dispõe de uma sequência de teclas modificadoras como uma combinação de teclas"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Desabilitar se duas teclas forem pressionadas juntas"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Soar um bipe quando uma tecla _modificadora for pressionada"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Teclas _lentas"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Colocar um atraso entre quando a tecla é pressionada e quando ela é aceita"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Atraso das teclas lentas ao digitar"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Soar um bipe quando uma tecla for pr_essionada"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Soar um bipe quando a tecla for _aceita"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Soar um bipe quando a tecla for _rejeitada"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Teclas de _repercussão"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorar pressionamentos duplicados rápidos"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Atraso das teclas de repercussão ao digitar"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Habilitar por teclado"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Ativar e desativar os recursos de acessibilidade usando o teclado"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Padrão"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Médio"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Grande"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Maior"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Gigante"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixels"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Sempre mostrar o menu de _acessibilidade"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Visão"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "A_lto contraste"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Texto _grande"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Habilitar a_nimações"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Leito_r de tela"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "O leitor de tela lê o texto exibido à medida que você move o foco."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Teclas _sonorizadas"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Soa um bipe quando Num Lock ou Caps Lock são ativados ou desativados."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Tamanho do c_ursor"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Ampliação"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Audição"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Alertas _visuais"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Teclado virtual"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "R_epetição de teclas"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Cursor _intermitente"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Assistência de _digitação (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Apontamento &amp; clique"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Teclas do _mouse"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Localizar ponteiro"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Assistência de _clique"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Atraso do clique _duplo"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Atraso do clique duplo"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Alertas visuais"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Testar flash"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Usa uma indicação visual quando um alerta de som ocorrer."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Piscar a tela _inteira"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Piscar a _janela inteira"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Curto"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ da tela"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ da tela"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ da tela"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Longo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Tela cheia"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Metade superior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Metade inferior"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Metade esquerda"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Metade direita"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Opções de ampliação"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Ampliação:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Posição do ampliador:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Seguir o cursor do mouse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Parte da _tela:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "O ampliador _estende-se para fora da tela"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Manter o cursor do ampliador _centralizado"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "O cursor do ampliador em_purra o conteúdo ao redor"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "O cursor do ampliador move-se com o _conteúdo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lente de aumento"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Mira:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "S_obrepor o cursor do mouse"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Espessura:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Fina"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Espessa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "C_omprimento:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Cor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Mira"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efeitos de cor:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Preto no branco:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Brilho:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Contraste:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "C_or"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Nenhuma"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Completa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Baixo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Alto"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Baixo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Alto"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Efeitos de cor"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Torna mais fácil ver, ouvir, digitar, apontar e clicar"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Teclado;Mouse;a11y;Acessibilidade;Acesso Universal;Contraste;Cursor;Som;Zoom;"
+"Tela;Leitor;grande;alta;grande;texto;fonte;tamanho;AccessX;Pegajoso;Teclas;"
+"Lento;Repercursão;Mouse;Duplo;clique ;Atraso;Velocidade;Assistência;Repetir;"
+"Piscar;visual;audição;áudio;digitação;animações;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 hora"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dia"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dias"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dias"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Esvaziar todos os itens da lixeira?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Todos os itens na lixeira serão permanentemente excluídos."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Es_vaziar lixeira"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Excluir todos os arquivos temporários?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Todos os arquivos temporários serão permanentemente excluídos."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Excluir _permanentemente arquivos temporários"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dia"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dias"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dias"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Para sempre"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Histórico de arquivos"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"O histórico de arquivos mantém um registro dos arquivos que você usou. Essas "
+"informações são compartilhadas entre aplicativos e facilitam a localização "
+"de arquivos que você deseja usar."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "H_istórico de arquivos"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Duração do _histórico de arquivos"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Limpar histórico…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Arquivos da lixeira &amp; temporários"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Arquivos da lixeira e temporários às vezes podem incluir informações "
+"pessoais ou confidenciais. A exclusão automática deles pode ajudar a "
+"proteger a privacidade."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Esvaziar conteúdo da _lixeira automaticamente"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Excluir arquivos _temporários automaticamente"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Período de exclusão automática"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Esvaziar lixeira…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "E_xcluir arquivos temporários…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Histórico de arquivos & lixeira"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Não deixe rastros"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"uso;recente;histórico;arquivos;temporário;tmp;privado;privacidade;lixo;"
+"limpar;reter;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Deveria corresponder ao endereço web do seu provedor de sessão."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Falha ao adicionar conta"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "As senhas não conferem."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Falha ao registrar conta"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Nenhuma forma suportada para autenticar neste domínio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Falha em entrar no domínio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Aquele nome de sessão não funcionou.\n"
+"Por favor, tente novamente."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Aquela senha de sessão não funcionou.\n"
+"Por favor, tente novamente."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Falha em fazer login no domínio"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Não foi possível localizar o domínio. Será que você escreveu errado?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Adicionar usuário"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administrador"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administradores podem adicionar e remover outros usuários e podem alterar "
+"configurações de todos os usuários. Controle parental não se aplica a "
+"administradores."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Usuário define a senha no primeiro início de sessão"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Definir senha agora"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Sessão corporativa"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Contas de usuário que são gerenciadas por uma empresa ou organização."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Você está desconectado"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"A sessão corporativa permite que uma conta existente de usuário gerenciada "
+"centralmente seja usada neste dispositivo. Você também pode usar essa conta "
+"para acessar recursos corporativos na Internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Procurar por mais imagens"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Selecionar um arquivo…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Gerenciador de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Não"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Sim"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Você deseja excluir suas impressões digitais registradas para desabilitar o "
+"início de sessão por impressão digital?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Nenhum dispositivo de impressão digital"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Nenhum dispositivo de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Certifique-se que o dispositivo está conectado adequadamente."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Dispositivo de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Escolha o dispositivo de impressão digital que você deseja configurar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Início de sessão por impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"O início de sessão por impressão digital permite desbloquear e iniciar a "
+"sessão no seu computador com seu dedo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "E_xcluir impressões digitais"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Registro de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "o dispositivo precisa ser reivindicado para executar esta ação"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "o dispositivo já foi reivindicado por outro processo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "você não tem permissão para executar a ação"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "nenhuma impressão foi registrada"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Falha ao se comunicar com o dispositivo durante o registro"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Falha ao se comunicar com o leitor de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Falha ao se comunicar com o daemon de impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Falha ao lista impressões digitais: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Falha ao excluir impressões digitais salvas: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Polegar esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Dedo médio esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "De_do indicador esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Dedo anelar esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Dedo pequeno esquerdo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Polegar direito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Dedo médio direito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Dedo indicador di_reito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Dedo anelar direito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Dedo pequeno direito"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Dedo desconhecido"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Concluído"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Dispositivo de impressão digital desconectado"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "O armazenamento do dispositivo de impressão digital está cheio"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Falha ao registar nova impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Falha ao iniciar registro: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Falha ao registrar nova impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Falha ao parar registro: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Levante e coloque repetidamente o dedo no leitor para registrar sua "
+"impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Registrar novamente este dedo…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Registrar nova impressão digital"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Falha ao liberar o dispositivo de impressão digital %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problema ao ler o dispositivo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Falha ao reivindicar o dispositivo de impressão digital %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Falha ao obter dispositivo de impressão digital: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Esta semana"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Semana passada"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e de %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e de %b de %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Sessão finalizada"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Sessão iniciada"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Atividade da conta"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Anterior"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Próximo"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Por favor, escolha outra senha."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Por favor, digite sua senha atual novamente."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "A senha não pode ser alterada"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Alterar senha"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Alter_ar"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Senha atual"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nova senha"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Confirmar senha"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Permitir que os usuários alterem suas senhas no próximo início de sessão"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Definir uma senha agora"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Não é possível participar automaticamente deste tipo de domínio"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "O domínio não existe"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Não foi possível fazer login como %s no domínio %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Senha inválida, por favor tente novamente"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Não foi possível conectar ao domínio %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Falha ao excluir usuário"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Falha ao revogar usuário gerenciado remotamente"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Você não pode excluir sua própria conta."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ainda está conectado"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Excluindo um usuário enquanto ele está conectado pode deixar o sistema em um "
+"estado inconsistente."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Você deseja manter os arquivos de %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"É possível manter o diretório home, fila de e-mail e arquivos temporários ao "
+"excluir uma conta de usuário."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Excluir arquivos"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Manter arquivos"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Tem certeza de que deseja revogar a conta gerenciada remotamente do %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Excluir"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Conta desabilitada"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Para ser definido no próximo início de sessão"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Nenhum"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Acesso autorizado"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Falhou ao contactar o serviço de contas"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Por favor, certifique-se de que o Serviço de Contas esteja instalado "
+"corretamente."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Este painel deve ser desbloqueado para alterar esta configuração"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Exclui a conta de usuário selecionada"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Para excluir a conta de usuário selecionada,\n"
+"clique primeiro no ícone *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Desbloqueie para adicionar usuários e alterar as configurações"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Usuários"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+"Sua sessão precisa ser reiniciada para que as alterações sejam efetivadas"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Reiniciar agora"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Fechar"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Editar avatar"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Nome _completo"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Editar"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Início de sessão por _impressão digital"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Início a_utomático de sessão"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Atividade da conta"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administrador"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administradores podem adicionar e remover outros usuários e podem alterar "
+"configurações para todos os usuários."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "Controle _parental"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Abre o aplicativo Controle parental."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Remover usuário…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Outros usuários"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Adicionar usuário…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Nenhum usuário encontrado"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Desbloquear para adicionar uma conta de usuário."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Adicionar ou remover usuários e alterar sua senha"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Início de sessão;Nome;Impressão digital;Digital;Digitais;Avatar;"
+"Logotipo;Rosto;Face;Senha;Controles parentais;Controle dos pais;Tempo de "
+"tela;Restrições de aplicativos;Restrições da Web;Uso;Utilização;Limite de "
+"uso;Criança;Filho;Filha;Garoto;Garota;Infantil;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Registrar"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Sessão do administrador de domínio"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"A fim de usar logins corporativos, este computador deve estar\n"
+"registrado no domínio. Por gentileza, peça ao administrador\n"
+"de rede para digitar a senha de domínio aqui."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Nome do administrador"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Senha do administrador"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Gerenciar contas de usuários"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Autenticação é obrigatória para alterar dados de usuário"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "A nova senha precisa ser diferente da antiga."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Tente mudar algumas letras e números."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Tente alterar a senha um pouco mais."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Uma senha que não utilize seu nome de usuário será mais forte."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Evite usar seu nome na senha."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Evite algumas das palavras incluídas na senha."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Evite palavras comuns."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Evite reordenar palavras existentes."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Tente usar mais números."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Tente usar mais letras maiúsculas."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Tente usar mais letras minúsculas."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Tente usar mais caracteres especiais, como pontuação."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Tente usar uma mistura de letras, números e pontuação."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Evite repetir o mesmo caractere."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Evite repetir o mesmo tipo de caractere: você precisa misturar letras, "
+"números e pontuação."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Evite sequências como 1234 ou abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"A senha precisa ser mais longa. Tente adicionar mais letras, números e "
+"pontuação."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Misture maiúsculas e minúsculas e tente usar um ou dois números."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Adicionar mais letras, números e pontuação tornará a senha mais forte."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Falha na autenticação"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "A nova senha é curta demais"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "A nova senha é simples demais"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "As senhas antiga e nova são semelhantes demais"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "A nova senha foi usada recentemente."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "A nova senha deve conter caracteres numéricos ou especiais"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "As senhas antiga e nova são iguais"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Sua senha foi alterada desde que você se autenticou inicialmente!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "A nova senha não contém caracteres diferentes o bastante"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Erro desconhecido"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"O nome de usuário deve, geralmente, consistir apenas de letras minúsculas de "
+"a-z, dígitos e dos seguintes caracteres: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Desculpe, o nome de usuário informado não é válido. Por favor, tente outro."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "O nome de usuário é muito longo."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Associar botões"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Associar botões a funções"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Para editar um atalho, escolha a ação “Enviar sequência de teclas”, "
+"pressione o botão de atalho no teclado e mantenha pressionada as novas "
+"teclas ou pressione a tecla Backspace para limpar."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "Fe_char"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Por gentileza, “bata” nos marcadores-alvo a medida que eles aparecem na tela "
+"para calibrar o tablet."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Foi detectado clique errado, reiniciando…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Botão %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Aplicativos definidos"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Enviar sequência de teclas"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Alternar monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Mostrar ajuda na tela"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tablet montado no painel de um laptop"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tablet montado em uma tela externa"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Dispositivo tablet externo"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Dispositivo tablet externo"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Todas as telas"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Modo tablet"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Usa o posicionamento absoluto para a caneta"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientação da mão esquerda"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+"O tablet e as teclas Express™ são rotacionados para uso com a mão esquerda"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Associar ao monitor"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Manter proporção"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Usa apenas uma parte da superfície do tablet para manter a proporção do "
+"monitor"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Calibrar"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nenhum tablet detectado"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Por favor, conecte ou ligue o seu tablet Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Sensação de pressão da ponta"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Macia"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pressão da ponta da caneta"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Firme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Botão 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botão 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botão 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Sensação de pressão da borracha"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pressão da borracha"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Clique no botão do meio do mouse"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Clique no botão direito do mouse"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Avanço"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+"Caneta de aerógrafo com pressão, inclinação e controle deslizante integrado"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Caneta de aerógrafo com pressão, inclinação e rotação"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Caneta padrão com pressão e inclinação"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Caneta padrão com pressão"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tablet Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Defina mapeamentos de botão e ajuste a sensibilidade de estilo para tablets"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Caneta;Borracha;Mouse;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Novo atalho…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Pontos de acesso"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operação cancelada"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Erro:</b> Acesso negado ao alterar configurações"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Erro:</b> Erro de Equipamento Móvel"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Não registrado"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registrado"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Pesquisando"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Negado"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Detalhes do modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Estado do Modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Transportadora"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Tipo da rede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Estado da Rede"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Número próprio"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Detalhes do dispositivo"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Versão do firmware"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "2G apenas"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "3G apenas"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "4G apenas"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "5G apenas"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (preferido), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (preferido), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (preferido), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (preferido), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (preferido), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (preferido), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (preferido), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (preferido), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (preferido), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (preferido), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (preferido)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (preferido), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Desbloquear cartão SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Desbloquear"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Por gentileza forneça o código PIN para o SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Digite o PIN para desbloquear seu cartão SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Por gentileza forneça o código PUK para o SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Digite o PUK para desbloquear seu cartão SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Informada senha incorreta. Você tem %1$u tentativa restante"
+msgstr[1] "Informada senha incorreta. Você tem %1$u tentativas restantes"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Você tem %u tentativa restante"
+msgstr[1] "Você tem %u tentativas restantes"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Informada senha incorreta."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Código PUK deve ser um número de 8 dígitos"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Digite novo PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Código PIN deve ser um número entre 4-8 dígitos"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Desbloqueando…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Nenhum SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Insira um cartão SIM para usar esse modem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM Bloqueado"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "Dados _móveis"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Acessar dados usando a rede móvel"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "Roaming de _dados"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Use dados móveis quando estiver em roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Modo de _rede"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "Re_de"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avançado"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Nomes de ponto de _acesso"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Bloqueio _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Bloquear SIM com PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Detalhes do M_odem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Telefone falhou"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Sem conexão com telefone"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operação não permitida"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Não há suporte para a operação"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM não inserido"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "PIN do SIM obrigatório"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "PUK do SIM obrigatório"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM falhou"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM ocupado"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Senha incorreta"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "PIN2 do SIM obrigatório"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "PUK2 do SIM obrigatório"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Não localizado"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Sem serviço de rede"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Tempo esgotado de rede"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Serviços de GPRS não permitidos"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming não permitido nesta área de localização"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Erro GPRS não especificado"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Sem erro"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Ação cancelada"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Acesso negado"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Erro desconhecido"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Modo de rede"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automático"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Escolha a rede"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Atualizar provedores de rede"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Habilitar rede móvel"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nenhum adaptador WWAN localizado"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Certifique-se de que você tenha um dispositivo celular/WAN sem fio"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Ao ligar o modo avião, a rede sem fio é desligada"
+
+# Traduções viáveis são "Modo avião", "Modo voo" ou até "Modo de avião". Achei por melhor manter a primeira opção
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Desli_gar modo avião"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Conexão de dados"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Cartão SIM usado para internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Bloqueio de SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "Pró_ximo"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Bloquear SIM com PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Alterar PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Digite o PIN atual para alterar as configurações de bloqueio do SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Rede móvel"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configure telefonia e conexões de dados móveis"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "célula;celular;wwan;telefonia;sim;mobile;móvel;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilitário para configurar o ambiente GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Configurações é a interface primária para configurar seu sistema."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "O Projeto GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Exibir número da versão"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Habilitar modo detalhado"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Pesquisar por string"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Lista possíveis nomes de painéis e sai"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Painel para exibir"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PAINEL] [ARGUMENTO…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Categoria das configurações"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Privacidade"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Painéis disponíveis:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Todas as configurações"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Menu primária"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Aviso: Versão de desenvolvimento"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Esta versão de Configurações deve ser usada apenas para fins de "
+"desenvolvimento. Você pode perceber um comportamento incorreto do sistema, "
+"perda de dados e outros problemas inesperados. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Ajuda"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Geral"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Sair"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Pesquisar"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Painéis"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Vai para o painel anterior"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Cancelar pesquisa"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferências;Configurações;Ajustes;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "O identificador para abrir o último painel de configurações"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"O identificador para abrir o último painel de configurações. Valores "
+"irreconhecíveis serão ignorados e o primeiro painel da lista será "
+"selecionado."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Mostrar aviso quando estiver em uma compilação de desenvolvimento de "
+"Configurações"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Se Configurações deve mostrar um aviso quando estiver sendo executando como "
+"uma compilação de desenvolvimento."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Estado inicial da janela"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Uma tupla contendo a largura, altura e estado maximizado iniciais da janela "
+"do aplicativo."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u saída"
+msgstr[1] "%u saídas"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u entrada"
+msgstr[1] "%u entradas"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sons do sistema"
+
+#~ msgid "Light"
+#~ msgstr "Claro"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "tela;bloqueio;diagnostico;travamento;privado;recente;temporário;índice;"
+#~ "nome;rede;identidade;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Organização de telas"
+
+#~ msgid "Set"
+#~ msgstr "Definir"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Bloqueie sua tela"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificados DER ou PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Adicionar uma impressora…"
+
+#~ msgid "Bark"
+#~ msgstr "Latido"
+
+#~ msgid "Drip"
+#~ msgstr "Pingo d'água"
+
+#~ msgid "Glass"
+#~ msgstr "Copo"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+# A tradução com painel e o nome próprio Configurações ficou estranha. Então, a tradução foi adaptada. Sugestão de Perry Werneck. -- Rafael
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Configurações de som do GNOME"
+
+# A tradução com painel e o nome próprio Configurações ficou estranha. Então, a tradução foi adaptada. Sugestão de Perry Werneck. -- Rafael
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Configurações de mouse &amp; touchpad do GNOME"
+
+# A tradução com painel e o nome próprio Configurações ficou estranha. Então, a tradução foi adaptada. Sugestão de Perry Werneck. -- Rafael
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Configurações de plano de fundo do GNOME"
+
+# A tradução com painel e o nome próprio Configurações ficou estranha. Então, a tradução foi adaptada. Sugestão de Perry Werneck. -- Rafael
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Configurações de teclado do GNOME"
+
+#~ msgid "More Warm"
+#~ msgstr "Mais quente"
+
+#~ msgid "Less Warm"
+#~ msgstr "Menos quente"
+
+#~ msgid "Move up"
+#~ msgstr "Mover para cima"
+
+#~ msgid "Move down"
+#~ msgstr "Mover para baixo"
+
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autenticar"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Compartilhamento de tela permite que usuários remotos vejam e controlem "
+#~ "sua tela conectando a %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Compartilhamento de _tela"
+
+#~ msgid "_Password:"
+#~ msgstr "_Senha:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Mostrar senha"
+
+#~ msgid "Access Options"
+#~ msgstr "Opções de acesso"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Novas conexões devem solicitar acesso"
+
+#~ msgid "_Require a password"
+#~ msgstr "Exigi_r uma senha"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 day"
+#~ msgstr "7 dias"
+
+#~ msgid "Show the screenshot UI"
+#~ msgstr "Mostra a UI de captura de tela"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Captura uma imagem da tela"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "Captura a tela de uma janela"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "Mostra a UI de gravação de tela"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Permite que os aplicativos abaixo usem seu microfone."
+
+#~ msgid "Standard"
+#~ msgstr "Padrão"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Tipo de conta"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Permitir que usuários definam a senha no próximo _início de sessão"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Definir uma senha _agora"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Conecte-se para adicionar contas de sessão corporativa."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Tirar uma foto…"
+
+#~ msgid "Your account"
+#~ msgstr "Sua conta"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Para fazer alterações,\n"
+#~ "clique no ícone * primeiro"
+
+#~ msgid "Create a user account"
+#~ msgstr "Cria uma conta de usuário"
+
+#~ msgid "User Icon"
+#~ msgstr "Ícone do usuário"
+
+#~ msgid "Account Settings"
+#~ msgstr "Configurações da conta"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autenticação & Início de sessão"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Isto será usado para nomear sua pasta pessoal e não pode ser modificado."
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Escolha o formato para números, datas e moedas. As alterações entram em "
+#~ "vigor na próxima sessão."
+
+#~ msgid "My Account"
+#~ msgstr "Minha conta"
+
+#~ msgid "Language"
+#~ msgstr "Idioma"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "O idioma usado para os textos em janelas e páginas web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Reiniciar a sessão para as alterações sejam efetivadas"
+
+#~ msgid "Restart…"
+#~ msgstr "Reiniciar…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Configurações de inicialização são usadas por todos os usuários ao "
+#~ "iniciar sessão no sistema"
+
+#~ msgid "Output:"
+#~ msgstr "Saída:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Associar a monitor único"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Exibir associação"
+
+#~ msgid "Stylus"
+#~ msgstr "Caneta"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (absoluto)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Touchpad (relativo)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferências do tablet"
+
+#~ msgid "_Help"
+#~ msgstr "Aj_uda"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Configurações de Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Modo de rastreamento"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Associar botões…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Ajustar configurações do mouse"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Ajustar resolução de tela"
+
+#~ msgid "Decouple Display"
+#~ msgstr "Desacoplar janela"
+
+#~ msgid "No stylus found"
+#~ msgstr "Nenhuma caneta encontrada"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Por favor, mova a caneta para a proximidade do tablet para configurá-lo"
+
+#~ msgid "Top Button"
+#~ msgstr "Botão superior"
+
+#~ msgid "Lower Button"
+#~ msgstr "Botão inferior"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Botão inferior"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Salvar uma captura de tela para $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Salvar uma captura de tela de uma área para $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copiar uma captura de tela para a área de transferência"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr ""
+#~ "Copiar uma captura de tela de uma janela para a área de transferência"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copiar uma captura de tela de uma área para a área de transferência"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Fazer uma pequena gravação de tela"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Controla quais resultados de pesquisa são mostrados no Panorama de "
+#~ "Atividades. A ordem dos resultados de pesquisa podem ser alterados ao "
+#~ "mover as linhas da lista."
+
+#~ msgid "Web Links"
+#~ msgstr "Links web"
+
+#~ msgid "Git Links"
+#~ msgstr "Links git"
+
+#~ msgid "%s Links"
+#~ msgstr "Links %s"
+
+#~ msgid "Unset"
+#~ msgstr "Remover definição"
+
+#~ msgid "Links"
+#~ msgstr "Links"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Arquivos de hipertexto"
+
+#~ msgid "Text Files"
+#~ msgstr "Arquivos de texto"
+
+#~ msgid "Image Files"
+#~ msgstr "Arquivos de imagem"
+
+#~ msgid "Font Files"
+#~ msgstr "Arquivos de fonte"
+
+#~ msgid "Archive Files"
+#~ msgstr "Arquivos de arquivamento"
+
+#~ msgid "Package Files"
+#~ msgstr "Arquivos de pacote"
+
+#~ msgid "Audio Files"
+#~ msgstr "Arquivos de áudio"
+
+#~ msgid "Video Files"
+#~ msgstr "Arquivos de vídeo"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permissões & acesso"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Os dados e serviços aos quais esse aplicativo pediu por acesso e "
+#~ "permissões que ele requer."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Não foi possível ser alterado"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Permissões individuais por aplicativos podem ser revisadas nas "
+#~ "configurações de <a href=\"privacy\">Privacidade</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integração"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Definir plano de fundo da área de trabalho"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Manipuladores padrão"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Tipos de arquivos e links que este aplicativo abre."
+
+#~ msgid "Usage"
+#~ msgstr "Uso"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Quanto recursos este aplicativo está usando."
+
+#~ msgid "Open in Software"
+#~ msgstr "Abrir no Software"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Permite aos aplicativos abaixo usar sua câmera."
+
+#~ msgid "Display Mode"
+#~ msgstr "Modo da tela"
+
+#~ msgid "Join Displays"
+#~ msgstr "Juntar as telas"
+
+#~ msgid "Single Display"
+#~ msgstr "Tela única"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Arraste as telas para corresponder a sua configuração física de telas. "
+#~ "Selecione uma tela para alterar suas configurações."
+
+#~ msgid "Active Display"
+#~ msgstr "Tela ativa"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Os serviços de localização permitem que os aplicativos saibam sua posição "
+#~ "geográfica. Há maior precisão ao usar Wi-Fi e banda larga móvel."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Usa o Serviço de Localização do Mozilla: <a href='https://location."
+#~ "services.mozilla.com/privacy'>Política de Privacidade</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Permite que os aplicativos abaixo determinem sua localização."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Lap detectado: modo de desempenho indisponível"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr ""
+#~ "O hardware está em alta temperatura: modo de desempenho indisponível"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Modo de desempenho indisponível"
+
+#~ msgid "Activities"
+#~ msgstr "Atividades"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Falha ao enviar arquivo: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "O perfil foi enviado para:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Anote esta URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Reinicie este computador e inicie o seu sistema operacional normal."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Digite a URL no seu navegador para baixar e instalar o perfil."
+
+#~ msgid "Upload profile"
+#~ msgstr "Enviar perfil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Requer conexão com a Internet"
+
+#~ msgid "_Copy"
+#~ msgstr "_Copiar"
+
+#~ msgid "Select _All"
+#~ msgstr "Selecionar _todos"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Tempo de espera do clique duplo"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Botão de suspender & desligar"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "Alguns serviços estão desabilitados devido a falta de acesso à rede."
+
+#~ msgid "Sound Keys"
+#~ msgstr "Teclas sonorizadas"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Leitor de tela"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Leitor de _tela"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Desbloqueando…"

--- a/po/ro.po
+++ b/po/ro.po
@@ -15,9 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2021-09-08 08:29+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2021-09-09 13:24+0200\n"
 "Last-Translator: Florentina Mușat <florentina.musat.28@gmail.com>\n"
 "Language-Team: Romanian Gnome Team\n"
@@ -31,321 +30,223 @@ msgstr ""
 "X-Launchpad-Export-Date: 2014-07-13 17:08+0000\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:823
-msgid "System Bus"
-msgstr "Magistrala sistemului"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-#: panels/applications/cc-applications-panel.c:838
-#: panels/applications/cc-applications-panel.c:843
-msgid "Full access"
-msgstr "Acces complet"
-
-#: panels/applications/cc-applications-panel.c:825
-msgid "Session Bus"
-msgstr "Magistrala sesiunilor"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/power/cc-power-panel.ui:85 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525
-msgid "Devices"
-msgstr "Dispozitive"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Full access to /dev"
-msgstr "Acces total la /dev"
-
-#: panels/applications/cc-applications-panel.c:833
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:288 panels/wwan/cc-wwan-device-page.ui:114
-#: panels/wwan/cc-wwan-network-dialog.ui:4
-msgid "Network"
-msgstr "Rețea"
-
-#: panels/applications/cc-applications-panel.c:833
-msgid "Has network access"
-msgstr "Are acces la rețea"
-
-#: panels/applications/cc-applications-panel.c:838
-#: panels/applications/cc-applications-panel.c:840
-#: panels/search/cc-search-locations-dialog.c:362
-msgid "Home"
-msgstr "Acasă"
-
-#: panels/applications/cc-applications-panel.c:840
-#: panels/applications/cc-applications-panel.c:845
-msgid "Read-only"
-msgstr "Doar citire"
-
-#: panels/applications/cc-applications-panel.c:843
-#: panels/applications/cc-applications-panel.c:845
-msgid "File System"
-msgstr "Sistem de fișiere"
-
-#: panels/applications/cc-applications-panel.c:849
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:279
-#: shell/cc-window.c:938 shell/cc-window.ui:121
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr "Configurări"
-
-#: panels/applications/cc-applications-panel.c:849
-msgid "Can change settings"
-msgstr "Poate administra configurări"
-
-#: panels/applications/cc-applications-panel.c:851
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s are următoarele permisiuni încorporate. Acestea nu pot fi modificate. "
-"Dacă sunteți îngrijorat de aceste permisiuni, considerați eliminarea acestei "
-"aplicații."
-
-#: panels/applications/cc-applications-panel.c:1024
-msgid "Web Links"
-msgstr "Legături web"
-
-#: panels/applications/cc-applications-panel.c:1034
-msgid "Git Links"
-msgstr "Legături git"
-
-#: panels/applications/cc-applications-panel.c:1040
-#, c-format
-msgid "%s Links"
-msgstr "Legături %s"
-
-#: panels/applications/cc-applications-panel.c:1048
-#: panels/applications/cc-applications-panel.c:1084
-msgid "Unset"
-msgstr "Nestabilit"
-
-#: panels/applications/cc-applications-panel.c:1139
-msgid "Links"
-msgstr "Legături"
-
-#: panels/applications/cc-applications-panel.c:1147
-msgid "Hypertext Files"
-msgstr "Fișiere hypertext"
-
-#: panels/applications/cc-applications-panel.c:1161
-msgid "Text Files"
-msgstr "Fișiere text"
-
-#: panels/applications/cc-applications-panel.c:1175
-msgid "Image Files"
-msgstr "Fișiere imagine"
-
-#: panels/applications/cc-applications-panel.c:1191
-msgid "Font Files"
-msgstr "Fișiere font"
-
-#: panels/applications/cc-applications-panel.c:1252
-msgid "Archive Files"
-msgstr "Arhivează fișiere"
-
-#: panels/applications/cc-applications-panel.c:1272
-msgid "Package Files"
-msgstr "Împachetează fișiere"
-
-#: panels/applications/cc-applications-panel.c:1295
-msgid "Audio Files"
-msgstr "Fișiere audio"
-
-#: panels/applications/cc-applications-panel.c:1312
-msgid "Video Files"
-msgstr "Fișiere video"
-
-#: panels/applications/cc-applications-panel.c:1320
-msgid "Other Files"
-msgstr "Alte fișiere"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1660
-#: panels/applications/cc-applications-panel.ui:416
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:70
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr "Aplicații"
 
-#: panels/applications/cc-applications-panel.ui:43
+#: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
 msgstr "Nicio aplicație"
 
-#: panels/applications/cc-applications-panel.ui:57
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr "Instalează câteva…"
 
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Deschide"
+
 #: panels/applications/cc-applications-panel.ui:94
-msgid "Permissions & Access"
-msgstr "Permisiuni și acces"
+#, fuzzy
+msgid "View Details"
+msgstr "_Vizualizare detalii"
 
-#: panels/applications/cc-applications-panel.ui:106
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-"Datele și serviciile pentru care această aplicație a cerut acces la și "
-"permisiunile pe care le necesită."
-
-#: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:127
-#: panels/camera/gnome-camera-panel.desktop.in.in:3
-msgid "Camera"
-msgstr "Cameră"
-
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:128
-#: panels/applications/cc-applications-panel.ui:140
-#: panels/applications/cc-applications-panel.ui:152
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:262
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:85
-#: panels/keyboard/cc-xkb-modifier-dialog.c:353
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:129
-#: panels/user-accounts/cc-user-panel.c:848
-#: panels/user-accounts/cc-user-panel.c:938
-#: panels/wwan/cc-wwan-device-page.c:445
-#: subprojects/gvc/gvc-mixer-control.c:1900
-msgid "Disabled"
-msgstr "Dezactivat"
-
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:139
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
-msgid "Microphone"
-msgstr "Microfon"
-
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:151
-#: panels/location/gnome-location-panel.desktop.in.in:3
-msgid "Location Services"
-msgstr "Servicii de locație"
-
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:500
-msgid "Built-in Permissions"
-msgstr "Permisiuni încorporate"
-
-#: panels/applications/cc-applications-panel.ui:158
-msgid "Cannot be changed"
-msgstr "Nu poate fi modificată"
-
-#: panels/applications/cc-applications-panel.ui:175
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-"Permisiuni individuale pentru aplicații pot fi revizuite în configurările de "
-"<a href=\"privacy\">Confidențialitate</a>."
-
-#: panels/applications/cc-applications-panel.ui:199
-msgid "Integration"
-msgstr "Integrare"
-
-#: panels/applications/cc-applications-panel.ui:211
-msgid "System features used by this application."
-msgstr "Funcționalități de sistem utilizate de această aplicație."
-
-#: panels/applications/cc-applications-panel.ui:225
-#: panels/applications/cc-applications-panel.ui:231
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:151
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Căutare"
 
-#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr "Notificări"
 
-#: panels/applications/cc-applications-panel.ui:243
-msgid "Run in background"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Arată _notificări"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "Rulează în fundal"
 
-#: panels/applications/cc-applications-panel.ui:249
-msgid "Set Desktop Background"
-msgstr "Stabilește fundalul desktopului"
+#: panels/applications/cc-applications-panel.ui:134
+#, fuzzy
+msgid "Allow activity when the app is closed."
+msgstr "Când capacul este închis"
 
-#: panels/applications/cc-applications-panel.ui:255
-#: panels/applications/cc-applications-panel.ui:261
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Capturi de ecran"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Imagini de fundal"
+
+#: panels/applications/cc-applications-panel.ui:148
+#, fuzzy
+msgid "Change the desktop wallpaper."
+msgstr "preferences-desktop-wallpaper"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Sunete"
 
-#: panels/applications/cc-applications-panel.ui:267
-msgid "Inhibit system keyboard shortcuts"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Stabilește scurtătură"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
 msgstr "Blochează scurtăturile de tastatură ale sistemului"
 
-#: panels/applications/cc-applications-panel.ui:300
-msgid "Default Handlers"
-msgstr "Operatori impliciți"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Cameră"
 
-#: panels/applications/cc-applications-panel.ui:312
-msgid "Types of files and links that this application opens."
-msgstr "Tipuri de fișiere și legături pe care această aplicație le deschide."
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:328
-msgid "Reset"
-msgstr "Restabilește"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microfon"
 
-#: panels/applications/cc-applications-panel.ui:364
-msgid "Usage"
-msgstr "Utilizare"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:376
-msgid "How much resources this application is using."
-msgstr "Cât de multe resurse utilizează această aplicație."
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Servicii de locație"
 
-#: panels/applications/cc-applications-panel.ui:391
-#: panels/applications/cc-applications-panel.ui:537
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+#, fuzzy
+msgid "Access device location data."
+msgstr "Opțiuni de acces"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Permisiuni încorporate"
+
+#: panels/applications/cc-applications-panel.ui:223
+#, fuzzy
+msgid "System access that is required by the app"
+msgstr "Funcționalități de sistem utilizate de această aplicație."
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Stocare"
 
-#: panels/applications/cc-applications-panel.ui:424
-msgid "Open in Software"
-msgstr "Deschide în Aplicații"
-
-#: panels/applications/cc-applications-panel.ui:474 shell/cc-panel-list.ui:121
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Nu s-au găsit rezultate"
 
-#: panels/applications/cc-applications-panel.ui:485
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:177
-#: shell/cc-panel-list.ui:132
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Încercați o căutare diferită"
 
-#: panels/applications/cc-applications-panel.ui:555
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Sistem de fișiere"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Viteză legătură"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Restabilește"
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Cât de mult spațiu pe disc ocupă această aplicație cu date și date "
 "prestocate."
 
-#: panels/applications/cc-applications-panel.ui:564
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Aplicație"
 
-#: panels/applications/cc-applications-panel.ui:570
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Date"
 
-#: panels/applications/cc-applications-panel.ui:576
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Date prestocate"
 
-#: panels/applications/cc-applications-panel.ui:582
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Total</b>"
 
-#: panels/applications/cc-applications-panel.ui:599
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Curăță datele prestocate…"
 
@@ -353,136 +254,101 @@ msgstr "Curăță datele prestocate…"
 msgid "Control various application permissions and settings"
 msgstr "Controlează permisiuni și configurări variate ale aplicației"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "application;flatpak;permission;setting;aplicație;permisiune;configurare;"
 
-#: panels/background/cc-background-chooser.c:344
-msgid "Select a picture"
-msgstr "Selectați o fotografie"
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Creion"
 
-#: panels/background/cc-background-chooser.c:347
-#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:238
-#: panels/color/cc-color-panel.c:886 panels/color/cc-color-panel.ui:657
-#: panels/common/cc-language-chooser.ui:25
-#: panels/display/cc-display-panel.c:1006
-#: panels/info-overview/cc-info-overview-panel.ui:243
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:122
-#: panels/network/cc-wifi-panel.c:866
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:176
-#: panels/network/connection-editor/vpn-helpers.c:299
-#: panels/network/net-device-wifi.c:854
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:235
-#: panels/region/cc-format-chooser.ui:28
-#: panels/search/cc-search-locations-dialog.c:639
-#: panels/sharing/cc-sharing-panel.c:396 panels/usage/cc-usage-panel.c:133
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:105
-#: panels/user-accounts/cc-avatar-chooser.c:228
-#: panels/user-accounts/cc-fingerprint-dialog.ui:36
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:638
-#: panels/user-accounts/cc-user-panel.c:656
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/wwan/cc-wwan-mode-dialog.ui:35
-#: panels/wwan/cc-wwan-network-dialog.ui:166
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:297
-msgid "_Cancel"
-msgstr "_Renunță"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Implicit"
 
-#: panels/background/cc-background-chooser.c:348
-#: panels/network/connection-editor/vpn-helpers.c:177
-#: panels/printers/pp-details-dialog.c:236
-#: panels/sharing/cc-sharing-panel.c:397
-#: panels/user-accounts/cc-avatar-chooser.c:229
-msgid "_Open"
-msgstr "_Deschide"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
 
-#: panels/background/cc-background-item.c:140
-msgid "multiple sizes"
-msgstr "dimensiuni multiple"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:144
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:282
-msgid "No Desktop Background"
-msgstr "Fără fundal desktop"
-
-#: panels/background/cc-background-panel.c:110
-msgid "Current background"
-msgstr "Fundalul curent"
-
-#: panels/background/cc-background-panel.ui:55
-msgid "Add Picture…"
-msgstr "Adaugă fotografie…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Activități"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Fundal"
 
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Adaugă fotografie…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "Franța"
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Schimbă imaginea de fundal într-un tapet sau o fotografie"
 
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Wallpaper;Screen;Desktop;Tapet;Ecran;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "Activ_ează"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Nu a fost găsit un adaptor Bluetooth"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Introduceți un dispozitiv pentru a folosi Bluetooth."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:69
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth este oprit"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:80
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Deschideți pentru a putea conecta dispozitive și transfera fișiere."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:107
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "Mod avion este pornit"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:118
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth este dezactivat când modul avion este pornit."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:124
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Închide modul Avion"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:154
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
 msgstr "Mod hardware avion este pornit"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:165
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Opriți modul avion pentru a putea activa Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1392
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -490,32 +356,31 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Deschideți și închideți Bluetooth și conectați-vă dispozitivele"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;partajează;partajare;"
 
-#: panels/camera/cc-camera-panel.ui:34
-msgid "Camera is turned off"
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
 msgstr "Camera este oprită"
 
-#: panels/camera/cc-camera-panel.ui:43
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Nu s-au găsit aplicații care pot captura fotografii sau video."
 
-#: panels/camera/cc-camera-panel.ui:75
+#: panels/camera/cc-camera-panel.ui:39
+#, fuzzy
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 "Utilizarea camerei permite aplicațiilor să captureze fotografii și videouri. "
 "Dezactivarea camerei poate cauza ca unele aplicații să nu funcționeze corect."
 
-#: panels/camera/cc-camera-panel.ui:85
-msgid "Allow the applications below to use your camera."
-msgstr "Permite aplicațiilor de mai jos să utilizeze camera."
-
-#: panels/camera/cc-camera-panel.ui:105
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Nu sunt aplicații care au cerut accesul la cameră"
 
@@ -523,280 +388,59 @@ msgstr "Nu sunt aplicații care au cerut accesul la cameră"
 msgid "Protect your pictures"
 msgstr "Protejați-vă fotografiile"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;ecran;încuiere;recent;rețea;nume;identitate;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Plasați dispozitivul de calibrare deasupra pătratului și apăsați „Start”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Mutați dispozitivul de calibrare pe poziția de calibrare și apăsați "
-"„Continuare”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Mutați dispozitivul de calibrare pe poziția de suprafață și apăsați "
-"„Continuare”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Închideți capacul laptopului"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "A apărut o eroare internă nerecuperabilă."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Uneltele pentru calibrare nu sunt instalate."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Nu s-a putut genera profilul."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Nu s-a putut găsi punctul de țintă alb."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Gata!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Calibrare eșuată!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Puteți deconecta dispozitivul de calibrare."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Nu deranjați dispozitivul în timpul calibrării"
-
-#: panels/color/cc-color-calibrate.ui:7
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Calibrare afișaj"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Renunță"
+
 #. This starts the calibration process
-#: panels/color/cc-color-calibrate.ui:40
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "_Pornește"
 
 #. This resumes the calibration process
-#: panels/color/cc-color-calibrate.ui:54
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "_Continuă"
 
 #. This button returns the user back to the color control panel
-#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
-#: panels/user-accounts/cc-fingerprint-dialog.ui:73
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Gata"
 
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Ecran laptop"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Cameră web încorporată"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Monitor %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Scanner %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Cameră %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Imprimantă %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Cameră web %s"
-
-#: panels/color/cc-color-device.c:90
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Activare management culori pentru %s"
-
-#: panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Arată profile de culori pentru %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Necalibrat"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:167
-msgid "Default: "
-msgstr "Implicit: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:175
-msgid "Colorspace: "
-msgstr "Spațiu culoare: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:182
-msgid "Test profile: "
-msgstr "Profil de test: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:236
-msgid "Select ICC Profile File"
-msgstr "Selectați un fișier profil ICC"
-
-#: panels/color/cc-color-panel.c:239
-msgid "_Import"
-msgstr "_Importă"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:250
-msgid "Supported ICC profiles"
-msgstr "Profile ICC recunoscute"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:257
-#: panels/network/wireless-security/eap-method-fast.c:356
-msgid "All files"
-msgstr "Toate fișierele"
-
-#: panels/color/cc-color-panel.c:549
-msgid "Screen"
-msgstr "Ecran"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:839
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Eșec la încărcarea fișierului: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:851
-msgid "The profile has been uploaded to:"
-msgstr "Profilul a fost încărcat în:"
-
-#: panels/color/cc-color-panel.c:853
-msgid "Write down this URL."
-msgstr "Scrieți acest URL."
-
-#: panels/color/cc-color-panel.c:854
-msgid "Restart this computer and boot your normal operating system."
-msgstr "Reporniți calculatorul și intrați în sistemul de operare obișnuit."
-
-#: panels/color/cc-color-panel.c:855
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "Scrieți URL-ul în navigator pentru a descărca și instala profilul."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:883
-msgid "Save Profile"
-msgstr "Salvare profil"
-
-#: panels/color/cc-color-panel.c:887
-#: panels/network/connection-editor/vpn-helpers.c:300
-#: panels/wwan/cc-wwan-apn-dialog.ui:64
-msgid "_Save"
-msgstr "_Salvare"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1196
-msgid "Create a color profile for the selected device"
-msgstr "Creează un profil de culoare pentru dispozitivul ales"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1211 panels/color/cc-color-panel.c:1235
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Instrumentul de măsură nu este detectat. Verificați dacă este pornit și "
-"conectat."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1245
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Instrumentul de măsură nu suportă profilarea pentru imprimante."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1256
-msgid "The device type is not currently supported."
-msgstr "Tipul de dispozitiv nu este recunoscut."
-
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Calibrare ecran"
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Calitatea calibrării"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -806,43 +450,43 @@ msgstr ""
 "culorile ecranului. Cu cât durează mai mult calibrarea, cu atât crește "
 "calitatea profilului de culoare."
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "Nu veți mai putea folosi calculatorul în timpul calibrării."
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Calitate"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Timp aproximativ"
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr "Calitatea calibrării"
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Dispozitiv de calibrare"
 
-#: panels/color/cc-color-panel.ui:137
+#: panels/color/cc-color-panel.ui:90
 msgid "Select the sensor device you want to use for calibration."
 msgstr ""
 "Selectați dispozitivul senzor pe care doriți să-l folosiți pentru calibrare."
 
-#: panels/color/cc-color-panel.ui:174
-msgid "Calibration Device"
-msgstr "Dispozitiv de calibrare"
-
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
-msgstr "Selectați tipul de afișaj conectat."
-
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Tip de afișaj"
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Selectați tipul de afișaj conectat."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profil punct alb"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -850,11 +494,11 @@ msgstr ""
 "Selectați un punct alb țintă pentru afișaj. Majoritatea afișajelor ar trebui "
 "calibrate pentru un iluminant D65."
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
-msgstr "Profil punct alb"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Luminozitatea afișajului"
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -862,7 +506,7 @@ msgstr ""
 "Configurați afișajul la o luminozitate potrivită. Gestiunea culorilor va "
 "avea precizie maximă la acest nivel de luminozitate."
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -870,11 +514,11 @@ msgstr ""
 "Sau puteți folosi nivelul de luminozitate folosit de un alt profil pe "
 "dispozitiv."
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr "Luminozitatea afișajului"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Nume profil"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -882,64 +526,41 @@ msgstr ""
 "Puteți folosi un profil de culoare pe mai multe calculatoare, sau să creați "
 "profiluri pentru nivele diferite de iluminare."
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Nume profil:"
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "Nume profil"
-
-#: panels/color/cc-color-panel.ui:392
-msgid "Profile successfully created!"
-msgstr "Profil creat cu succes!"
-
-#: panels/color/cc-color-panel.ui:443
-msgid "Copy profile"
-msgstr "Copiază profilul"
-
-#: panels/color/cc-color-panel.ui:456
-msgid "Requires writable media"
-msgstr "Necesită mediu inscriptibil"
-
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr "Încarcă profilul"
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr "Necesită conexiune la internet"
-
-#: panels/color/cc-color-panel.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"Puteți găsi instrucțiuni utile despre folosirea profilelor pentru sistemele "
-"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> și <a href="
-"\"windows\">Microsoft Windows</a>."
-
-#: panels/color/cc-color-panel.ui:607
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Rezumat"
 
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil creat cu succes!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Copiază profilul"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Necesită mediu inscriptibil"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Puteți găsi instrucțiuni utile despre folosirea profilelor pentru sistemele "
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> și <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "Adaugă profil"
 
-#: panels/color/cc-color-panel.ui:643
-msgid "_Import File…"
-msgstr "_Importă fișier…"
-
-#: panels/color/cc-color-panel.ui:672 panels/keyboard/cc-input-chooser.ui:20
-#: panels/network/connection-editor/net-connection-editor.c:504
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr "_Adaugă"
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
@@ -947,223 +568,156 @@ msgstr ""
 "S-au detectat probleme. Profilul s-ar putea să nu funcționeze corect. <a "
 "href=\"\">Arată detalii.</a>"
 
-#: panels/color/cc-color-panel.ui:788
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importă fișier…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Adaugă"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Pentru a fi administrat, fiecare dispozitiv are nevoie de actualizarea "
 "profilului de culoare ."
 
-#. translators: Text used in link to privacy policy
-#: panels/color/cc-color-panel.ui:810
-#: panels/diagnostics/cc-diagnostics-panel.c:144
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Aflați mai multe"
 
-#: panels/color/cc-color-panel.ui:815
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Aflați mai multe despre administrarea profilurilor de culoare"
 
-#: panels/color/cc-color-panel.ui:863
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "_Stabilește pentru toți utilizatorii"
 
-#: panels/color/cc-color-panel.ui:867 panels/color/cc-color-panel.ui:882
-#: panels/color/cc-color-panel.ui:883
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr ""
 "Configurează acest profil pentru toți utilizatorii de pe acest calculator"
 
-#: panels/color/cc-color-panel.ui:878
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "Activ_ează"
 
-#: panels/color/cc-color-panel.ui:909
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "_Adaugă profil"
 
-#: panels/color/cc-color-panel.ui:922
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "_Calibrează…"
 
-#: panels/color/cc-color-panel.ui:926
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Calibrare dispozitiv"
 
-#: panels/color/cc-color-panel.ui:937
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "_Elimină profilul"
 
-#: panels/color/cc-color-panel.ui:950
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "_Vizualizare detalii"
 
-#: panels/color/cc-color-panel.ui:986
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr ""
 "Nu s-au putut detecta dispozitive pentru care pot fi gestionate culorile"
 
-#: panels/color/cc-color-panel.ui:1030
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/cc-color-panel.ui:1035
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/cc-color-panel.ui:1040
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: panels/color/cc-color-panel.ui:1045
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Proiector"
 
-#: panels/color/cc-color-panel.ui:1050
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plasmă"
 
-#: panels/color/cc-color-panel.ui:1055
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (iluminat CCFL)"
 
-#: panels/color/cc-color-panel.ui:1060
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (iluminat LED-uri RGB)"
 
-#: panels/color/cc-color-panel.ui:1065
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (iluminat LED-uri albe)"
 
-#: panels/color/cc-color-panel.ui:1070
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "LCD cu gamă largă (iluminat CCFL)"
 
-#: panels/color/cc-color-panel.ui:1075
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "LCD cu gamă largă (iluminat LED-uri RGB)"
 
-#: panels/color/cc-color-panel.ui:1092
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Lung"
 
-#: panels/color/cc-color-panel.ui:1093
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 de minute"
 
-#: panels/color/cc-color-panel.ui:1097
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Mediu"
 
-#: panels/color/cc-color-panel.ui:1098
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 de minute"
 
-#: panels/color/cc-color-panel.ui:1102
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Scurt"
 
-#: panels/color/cc-color-panel.ui:1103
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 minute"
 
-#: panels/color/cc-color-panel.ui:1125
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Nativ pentru afișaj"
 
-#: panels/color/cc-color-panel.ui:1129
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Imprimare și publicare)"
 
-#: panels/color/cc-color-panel.ui:1133
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/cc-color-panel.ui:1137
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Fotografie și grafică)"
 
-#: panels/color/cc-color-panel.ui:1141
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Spațiu standard"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Profil de test"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automat"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Calitate slabă"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Calitate medie"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Calitate înaltă"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB implicit"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK implicit"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Gri implicit"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Date de calibrare furnizate de producător"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Nu este posibilă corecția în mod „tot ecranul” pentru acest profil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Este posibil ca acest profil să nu mai fie corect"
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1176,16 +730,11 @@ msgstr ""
 "Calibrează culoarea pentru dispozitive cum ar fi afișaje, camere sau "
 "imprimante"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Color;ICC;Profile;Calibrate;Printer;Display;Culoare;Culori;Profil;Calibrare;"
 "Imprimantă;Afișaj;Afișaje;Ecran;Ecrane;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Altele…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1195,310 +744,187 @@ msgstr "Selectați limba"
 msgid "_Select"
 msgstr "_Selectează"
 
-#: panels/common/cc-language-chooser.ui:69
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Nu s-au găsit limbi"
 
-#: panels/common/cc-language-chooser.ui:82
-#: panels/keyboard/cc-input-chooser.c:178
+#: panels/common/cc-language-chooser.ui:69
 msgid "More…"
 msgstr "Mai mult…"
 
-#: panels/common/cc-permission-infobar.c:107
-msgid "Unlock to Change Settings"
-msgstr "Deblochează pentru a modifica configurările"
-
-#: panels/common/cc-permission-infobar.ui:20
-msgid "Unlock…"
-msgstr "Deblochează…"
-
-#: panels/common/cc-permission-infobar.ui:56
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr ""
 "Unele configurări trebuie să fie deblocate înainte ca să poată fi modificate."
 
-#: panels/common/cc-time-editor.ui:33
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Deblochează…"
+
+#: panels/common/cc-time-editor.ui:25
 msgid "Increment Hour"
 msgstr "Incrementează ora"
 
-#: panels/common/cc-time-editor.ui:65
+#: panels/common/cc-time-editor.ui:53
 msgid "Increment Minute"
 msgstr "Incrementează minutul"
 
-#: panels/common/cc-time-editor.ui:80
+#: panels/common/cc-time-editor.ui:73
 msgid "Time"
 msgstr "Ora"
 
-#: panels/common/cc-time-editor.ui:113
+#: panels/common/cc-time-editor.ui:94
 msgid "Decrement Hour"
 msgstr "Decrementează ora"
 
-#: panels/common/cc-time-editor.ui:145
+#: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Decrementează minutul"
 
-#: panels/common/cc-time-entry.c:219
-msgid "_Copy"
-msgstr "_Copiază"
-
-#: panels/common/cc-time-entry.c:225
-msgid "Select _All"
-msgstr "Selectează to_ate"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Azi"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Ieri"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d oră"
-msgstr[1] "%d ore"
-msgstr[2] "%d de ore"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:973
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minut"
-msgstr[1] "%d minute"
-msgstr[2] "%d de minute"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d secundă"
-msgstr[1] "%d secunde"
-msgstr[2] "%d de secunde"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s și %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s și %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 secunde"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Hotspot"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:262
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:267
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:449
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:476
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:483
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:488
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:493
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:498
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "January"
-msgstr "Ianuarie"
-
-#: panels/datetime/cc-datetime-panel.ui:46
-msgid "February"
-msgstr "Februarie"
-
-#: panels/datetime/cc-datetime-panel.ui:54
-msgid "March"
-msgstr "Martie"
-
-#: panels/datetime/cc-datetime-panel.ui:62
-msgid "April"
-msgstr "Aprilie"
-
-#: panels/datetime/cc-datetime-panel.ui:70
-msgid "May"
-msgstr "Mai"
-
-#: panels/datetime/cc-datetime-panel.ui:78
-msgid "June"
-msgstr "Iunie"
-
-#: panels/datetime/cc-datetime-panel.ui:86
-msgid "July"
-msgstr "Iulie"
-
-#: panels/datetime/cc-datetime-panel.ui:94
-msgid "August"
-msgstr "August"
-
-#: panels/datetime/cc-datetime-panel.ui:102
-msgid "September"
-msgstr "Septembrie"
-
-#: panels/datetime/cc-datetime-panel.ui:110
-msgid "October"
-msgstr "Octombrie"
-
-#: panels/datetime/cc-datetime-panel.ui:118
-msgid "November"
-msgstr "Noiembrie"
-
-#: panels/datetime/cc-datetime-panel.ui:126
-msgid "December"
-msgstr "Decembrie"
-
-#: panels/datetime/cc-datetime-panel.ui:136
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Data și ora"
 
-#: panels/datetime/cc-datetime-panel.ui:187
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "An"
 
-#: panels/datetime/cc-datetime-panel.ui:220
+#: panels/datetime/cc-datetime-panel.ui:66
 msgid "Month"
 msgstr "Lună"
 
-#: panels/datetime/cc-datetime-panel.ui:257
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Ianuarie"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februarie"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Martie"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Aprilie"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mai"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Iunie"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Iulie"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Septembrie"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Octombrie"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Noiembrie"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Decembrie"
+
+#: panels/datetime/cc-datetime-panel.ui:92
 msgid "Day"
 msgstr "Zi"
 
-#: panels/datetime/cc-datetime-panel.ui:286
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Fus orar"
 
-#: panels/datetime/cc-datetime-panel.ui:307
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Căutare oraș"
 
-#: panels/datetime/cc-datetime-panel.ui:375
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "_Data și ora automată"
 
-#: panels/datetime/cc-datetime-panel.ui:376
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Necesită acces internet"
 
-#: panels/datetime/cc-datetime-panel.ui:396
-msgid "Date & _Time"
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
 msgstr "Data și _ora"
 
-#: panels/datetime/cc-datetime-panel.ui:430
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Fus orar au_tomat"
 
-#: panels/datetime/cc-datetime-panel.ui:431
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "Necesită serviciile de localizare activate și acces la internet"
 
-#: panels/datetime/cc-datetime-panel.ui:446
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Activat"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Fus _orar"
 
-#: panels/datetime/cc-datetime-panel.ui:481
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Deblochează"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Format timp"
 
-#: panels/datetime/cc-datetime-panel.ui:490
-msgid "24-hour"
-msgstr "24 de ore"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:491
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Date"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 secunde"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Calendar"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Numere"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Schimbați data și ora, inclusiv fusul orar"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;Ceas;Timp;Fus orar;Locație;"
@@ -1511,28 +937,28 @@ msgstr "Modifică data și ora sistemului"
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Pentru a schimba data sau ora, trebuie să vă autentificați."
 
-#: panels/default-apps/cc-default-apps-panel.ui:31
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "_Web"
 
-#: panels/default-apps/cc-default-apps-panel.ui:43
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "E-_mail"
 
-#: panels/default-apps/cc-default-apps-panel.ui:59
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "_Calendar"
 
-#: panels/default-apps/cc-default-apps-panel.ui:75
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "M_uzică"
 
-#: panels/default-apps/cc-default-apps-panel.ui:91
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "_Video"
 
-#: panels/default-apps/cc-default-apps-panel.ui:162
-#: panels/removable-media/cc-removable-media-panel.ui:162
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "_Fotografii"
 
@@ -1544,28 +970,17 @@ msgstr "Aplicații implicite"
 msgid "Configure Default Applications"
 msgstr "Configurează aplicații implicite"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "default;application;preferred;media;implicit;implicită;implicite;aplicație;"
 "preferată;preferate;"
 
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:146
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Trimiterea de rapoarte ale problemelor tehnice ne ajută să îmbunătățim %s. "
-"Rapoartele sunt trimise anonim și sunt curățate de date personale. %s"
-
-#: panels/diagnostics/cc-diagnostics-panel.ui:28
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
 msgstr "Raportarea problemelor"
 
-#: panels/diagnostics/cc-diagnostics-panel.ui:65
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
 msgid "_Automatic Problem Reporting"
 msgstr "Raportarea _automată a problemelor"
 
@@ -1577,161 +992,118 @@ msgstr "Diagnostice"
 msgid "Report your problems"
 msgstr "Raportați problemele"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;ecran;blocare;diagnostice;pană;privat;temporar;nume;"
-"rețeaidentitate;confidențialitate;"
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "Diagnostice"
 
-#: panels/display/cc-display-panel.c:1017
-#: panels/network/connection-editor/connection-editor.ui:27
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Aplică"
 
-#: panels/display/cc-display-panel.c:1038
-msgid "Apply Changes?"
-msgstr "Aplicați modificările?"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Înapoi"
 
-#: panels/display/cc-display-panel.c:1043
-msgid "Changes Cannot be Applied"
-msgstr "Nu se pot aplica modificările"
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Bluetooth-ul este dezactivat"
 
-#: panels/display/cc-display-panel.c:1044
-msgid "This could be due to hardware limitations."
-msgstr "Aceasta poate fi din cauza limitărilor de hardware."
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Decuplează afișajul"
 
-#: panels/display/cc-display-panel.ui:89
-msgid "Single Display"
-msgstr "Afișaj singular"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
 
-#: panels/display/cc-display-panel.ui:108
-#: panels/display/cc-display-panel.ui:310
-msgid "Join Displays"
-msgstr "Unește afișaje"
-
-#: panels/display/cc-display-panel.ui:126
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Oglindire"
 
-#: panels/display/cc-display-panel.ui:151
-msgid "Display Mode"
-msgstr "Modul de afișaj"
-
-#: panels/display/cc-display-panel.ui:220
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Conține bara de sus și activitățile"
 
-#: panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Afișaj primar"
 
-#: panels/display/cc-display-panel.ui:243
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
-msgstr ""
-"Trageți afișaje pentru a le potrivi configurației fizice. Selectați un "
-"afișaj pentru a-i modifica configurările."
-
-#: panels/display/cc-display-panel.ui:250
-msgid "Display Arrangement"
-msgstr "Aranjamentul afișajelor"
-
-#: panels/display/cc-display-panel.ui:374
-msgid "Active Display"
-msgstr "Afișaj activ"
-
-#: panels/display/cc-display-panel.ui:421
-msgid "Display Configuration"
-msgstr "Configurația afișajelor"
-
-#: panels/display/cc-display-panel.ui:440
-#: panels/display/gnome-display-panel.desktop.in.in:3
-msgid "Displays"
-msgstr "Ecrane"
-
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:451
-#: panels/display/cc-night-light-page.ui:111
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Lumină nocturnă"
 
-#: panels/display/cc-display-settings.c:107
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Peisaj"
-
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Portret dreapta"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Portret stânga"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Peisaj (inversat)"
-
-#: panels/display/cc-display-settings.c:190
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:15
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Orientare"
 
-#: panels/display/cc-display-settings.ui:24
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Rezoluție"
 
-#: panels/display/cc-display-settings.ui:33
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Rata de reîmprospătare"
 
-#: panels/display/cc-display-settings.ui:42
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Reglează pentru TV"
 
-#: panels/display/cc-display-settings.ui:59
-#: panels/display/cc-display-settings.ui:76
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Scalare"
 
-#: panels/display/cc-night-light-page.c:627
-msgid "More Warm"
-msgstr "Mai cald"
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Derulare naturală"
 
-#: panels/display/cc-night-light-page.c:639
-msgid "Less Warm"
-msgstr "Mai rece"
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:28
-msgid "Restart Filter"
-msgstr "Repornește filtrul"
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Lumină nocturnă"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:61
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Dezactivat temporar până mâine"
 
-#: panels/display/cc-night-light-page.ui:88
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Repornește filtrul"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1739,67 +1111,70 @@ msgstr ""
 "Lumina nocturnă face culoarea ecranului mai caldă. Aceasta poate ajuta la "
 "prevenirea extenuării ochilor și a lipsei de somn."
 
-#: panels/display/cc-night-light-page.ui:127
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Planifică"
 
-#: panels/display/cc-night-light-page.ui:136
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Apus la răsărit"
 
-#: panels/display/cc-night-light-page.ui:137
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Planificare manuală"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/region/cc-format-preview.ui:40
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Repere orare"
 
-#: panels/display/cc-night-light-page.ui:165
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "De la"
 
-#: panels/display/cc-night-light-page.ui:194
-#: panels/display/cc-night-light-page.ui:297
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Oră"
 
-#: panels/display/cc-night-light-page.ui:203
-#: panels/display/cc-night-light-page.ui:306
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:222
-#: panels/display/cc-night-light-page.ui:325
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Minut"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:234
-#: panels/display/cc-night-light-page.ui:337
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "AM"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:247
-#: panels/display/cc-night-light-page.ui:350
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PM"
 
-#: panels/display/cc-night-light-page.ui:267
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "La"
 
-#: panels/display/cc-night-light-page.ui:374
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Temperatura culorilor"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ecrane"
 
 #: panels/display/gnome-display-panel.desktop.in.in:4
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Alege cum să fie folosite monitoarele și proiectoarele conectate"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1809,106 +1184,127 @@ msgstr ""
 "redshift;color;sunset;sunrise;Panou;Proiector;Ecran;Rezoluție;Lumină;"
 "Albastru;culoare;apus;răsărit;"
 
-#: panels/info-overview/cc-info-overview-panel.c:413
-#: panels/info-overview/cc-info-overview-panel.c:437
-#: panels/info-overview/cc-info-overview-panel.c:483
-#: panels/info-overview/cc-info-overview-panel.c:513
-#: panels/wwan/cc-wwan-details-dialog.c:101
-msgid "Unknown"
-msgstr "Necunoscut"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:445
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; ID-ul compilării: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Tip de securitate"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:460
-#, c-format
-msgid "64-bit"
-msgstr "64-biți"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Nivelul de cerneală"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:463
-#, c-format
-msgid "32-bit"
-msgstr "32-biți"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Nivelul de cerneală"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Nivelul de cerneală"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Necunoscut"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Securitate"
 
-#: panels/info-overview/cc-info-overview-panel.ui:52
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;ecran;blocare;diagnostice;pană;privat;temporar;nume;"
+"rețeaidentitate;confidențialitate;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Nume dispozitiv"
 
-#: panels/info-overview/cc-info-overview-panel.ui:74
+#: panels/info-overview/cc-info-overview-panel.ui:50
 msgid "Hardware Model"
 msgstr "Model hardware"
 
-#: panels/info-overview/cc-info-overview-panel.ui:83
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "Memorie"
 
-#: panels/info-overview/cc-info-overview-panel.ui:92
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "Procesor"
 
-#: panels/info-overview/cc-info-overview-panel.ui:101
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "Grafică"
 
-#: panels/info-overview/cc-info-overview-panel.ui:110
+#: panels/info-overview/cc-info-overview-panel.ui:82
 msgid "Disk Capacity"
 msgstr "Capacitate disc"
 
-#: panels/info-overview/cc-info-overview-panel.ui:111
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "Se calculează…"
 
 #. translators: this field contains the distro name and version
-#: panels/info-overview/cc-info-overview-panel.ui:133
+#: panels/info-overview/cc-info-overview-panel.ui:98
 msgid "OS Name"
 msgstr "Nume SO"
 
-#: panels/info-overview/cc-info-overview-panel.ui:142
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; ID-ul compilării: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Tip de SO"
 
-#: panels/info-overview/cc-info-overview-panel.ui:151
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Versiune GNOME"
 
-#: panels/info-overview/cc-info-overview-panel.ui:161
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Se încarcă opțiunile…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Sistem de ferestre"
 
-#: panels/info-overview/cc-info-overview-panel.ui:169
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Virtualizare"
 
-#: panels/info-overview/cc-info-overview-panel.ui:178
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Actualizări software"
 
-#: panels/info-overview/cc-info-overview-panel.ui:199
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Redenumește dispozitivul"
 
-#: panels/info-overview/cc-info-overview-panel.ui:216
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1916,7 +1312,12 @@ msgstr ""
 "Numele dispozitivului este utilizat pentru a identifica acest dispozitiv "
 "când este vizualizat prin rețea, sau la asocierea dispozitivelor Bluetooth."
 
-#: panels/info-overview/cc-info-overview-panel.ui:234
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Nume dispozitiv"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "_Redenumește"
 
@@ -1928,11 +1329,6 @@ msgstr "Despre"
 msgid "View information about your system"
 msgstr "Vedeți informații despre sistem"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1992,7 +1388,7 @@ msgid "Eject"
 msgstr "Ejectează"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:580
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Tastare"
 
@@ -2011,6 +1407,12 @@ msgstr "Lansatori"
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "Lansează navigatorul de ajutor"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Configurări"
 
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -2033,39 +1435,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Căutare"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "Capturi de ecran"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "Salvează capturile în $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Salvează captura unei ferestre în $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Salvează o captură a unei selecții de ecran în $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "Copiază o captură de ecran în clipboard"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Copiază o captură de ecran a unei ferestre în clipboard"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Copiază o captură de ecran a unei zone selectate în clipboard"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "Înregistrează un scurt video cu capturi de ecran"
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistem"
 
@@ -2114,322 +1484,181 @@ msgstr "Micșorează dimensiunea textului"
 msgid "High contrast on or off"
 msgstr "Activează sau dezactivează contrastul puternic"
 
-#: panels/keyboard/cc-input-chooser.c:193
-msgid "No input sources found"
-msgstr "Nu s-au găsit surse de intrare"
-
-#: panels/keyboard/cc-input-chooser.c:964
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Altele"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Adaugă o limbă"
 
-#: panels/keyboard/cc-input-chooser.ui:77
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Metodele de intrare nu pot fi folosite la ecranul de autentificare"
 
-#: panels/keyboard/cc-input-list-box.ui:23
+#: panels/keyboard/cc-input-list-box.ui:24
 msgid "No input source selected"
 msgstr "Nicio sursă de intrare selectată"
 
-#: panels/keyboard/cc-input-row.ui:75
-msgid "Move up"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Opțiuni"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
 msgstr "Mută în sus"
 
-#: panels/keyboard/cc-input-row.ui:86
-msgid "Move down"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
 msgstr "Mută în jos"
 
-#: panels/keyboard/cc-input-row.ui:103
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Preferințe"
 
-#: panels/keyboard/cc-input-row.ui:120
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Vizualizează aranjamentul tastaturii"
 
-#: panels/keyboard/cc-input-row.ui:137
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:286
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Elimină"
 
-#: panels/keyboard/cc-keyboard-manager.c:486
-#: panels/keyboard/cc-keyboard-manager.c:494
-#: panels/keyboard/cc-keyboard-manager.c:779
-msgid "Custom Shortcuts"
-msgstr "Scurtături personalizate"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.ui:213
-msgid "Alternate Characters Key"
-msgstr "Tastă de caractere alternative"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Tasta de caractere alternative poate fi utilizată pentru a introduce "
-"caractere adiționale. Acestea sunt câteodată tipărite ca o a treia opțiune "
-"pe tastatură."
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt stânga"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt dreapta"
-
-#: panels/keyboard/cc-keyboard-panel.c:73
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Super stânga"
-
-#: panels/keyboard/cc-keyboard-panel.c:74
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Super dreapta"
-
-#: panels/keyboard/cc-keyboard-panel.c:75
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tasta meniului"
-
-#: panels/keyboard/cc-keyboard-panel.c:76
-#: panels/keyboard/cc-keyboard-panel.c:94
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl dreapta"
-
-#: panels/keyboard/cc-keyboard-panel.c:84
-#: panels/keyboard/cc-keyboard-panel.ui:237
-msgid "Compose Key"
-msgstr "Tasta Compunere"
-
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Tasta de compunere permite introducerea a unei varietăți largi de caractere. "
-"Pentru a o utiliza, apăsați compune apoi o secvență de caractere.  De "
-"exemplu, tasta compune urmată de <b>C</b> și <b>o</b> va introduce <b>©</b>, "
-"<b>a</b> urmat de <b>'</b> va introduce <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:95
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Majuscule"
-
-#: panels/keyboard/cc-keyboard-panel.c:96
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Blocare derulare"
-
-#: panels/keyboard/cc-keyboard-panel.c:97
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Captură de ecran"
-
-#: panels/keyboard/cc-keyboard-panel.c:233
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Sursele de intrare pot fi comutate utilizând scurtătura de tastatură %s.\n"
-"Acest lucru poate fi modificat în configurările de scurtături de tastatură."
-
-#: panels/keyboard/cc-keyboard-panel.ui:48
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "Surse de intrare"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:18
 msgid "Includes keyboard layouts and input methods."
 msgstr "Include aranjamentele de tastatură și metodele de intrare."
 
-#: panels/keyboard/cc-keyboard-panel.ui:85
+#: panels/keyboard/cc-keyboard-panel.ui:28
 msgid "Input Source Switching"
 msgstr "Comutarea sursei de intrare"
 
-#: panels/keyboard/cc-keyboard-panel.ui:131
+#: panels/keyboard/cc-keyboard-panel.ui:31
 msgid "Use the _same source for all windows"
 msgstr "Folosește aceeași _limbă pentru toate ferestrele"
 
-#: panels/keyboard/cc-keyboard-panel.ui:158
+#: panels/keyboard/cc-keyboard-panel.ui:43
 msgid "Switch input sources _individually for each window"
 msgstr "Comută sursele de intrare _individual pentru fiecare fereastră"
 
-#: panels/keyboard/cc-keyboard-panel.ui:177
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Introducere caractere speciale"
 
-#: panels/keyboard/cc-keyboard-panel.ui:188
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Metode de a introduce variante de simboluri și litere utilizând tastatura."
 
-#: panels/keyboard/cc-keyboard-panel.ui:263
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:306
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:322 shell/cc-window.ui:326
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Tastă de caractere alternative"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Tasta Compunere"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Scurtături tastatură"
 
-#: panels/keyboard/cc-keyboard-panel.ui:283
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Vizualizează și personalizează scurtături"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:283
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d modificat"
-msgstr[1] "%d modificate"
-msgstr[2] "%d modificate"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Restabiliește toate…"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:428
-msgid "Reset All Shortcuts?"
-msgstr "Restabilesc toate scurtăturile?"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Restabilește toate scurtăturile la valorile implicite"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:431
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Restabilirea scurtăturilor poate afecta scurtăturile personalizate. Această "
-"acțiune nu poate fi refăcută."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Secțiune"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:435
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:275
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-#: panels/wwan/cc-wwan-device-page.c:143
-msgid "Cancel"
-msgstr "Renunță"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Scurtătură"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:436
-msgid "Reset All"
-msgstr "Restabiliește tot"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Adaugă scurtătură"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:115
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Adaugă scurtături personalizate"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:124
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 "Stabilește scurtături personalizate pentru lansarea de aplicații, rularea de "
 "scripturi, și mai multe."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Adaugă scurtătură"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:166
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Nicio scurtătură de tastatură găsită"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:211
-#: panels/region/cc-format-chooser.ui:48
-#: panels/user-accounts/cc-fingerprint-dialog.ui:53
-#: panels/wacom/wacom-stylus-page.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
-#: shell/cc-window.ui:230
-msgid "Back"
-msgstr "Înapoi"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "Elimină"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:235
-msgid "Reset All…"
-msgstr "Restabiliește toate…"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "Înlocuiește"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:236
-msgid "Reset all shortcuts to their default keybindings"
-msgstr "Restabilește toate scurtăturile la valorile implicite"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "Stabilește"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:391
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s este deja utilizat pentru %s. Dacă îl înlocuiți, %s va fi dezactivat"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:535
-msgid "Enter the new shortcut"
-msgstr "Introduceți noua scurtătură"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
-msgid "Set Custom Shortcut"
-msgstr "Stabilește scurtătură personalizată"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
-msgid "Set Shortcut"
-msgstr "Stabilește scurtătură"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:561
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Introduceți o scurtătură nouă pentru a modifica %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:987
-msgid "Add Custom Shortcut"
-msgstr "Adaugă scurtățură personalizată"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:60
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Apăsați Esc pentru a anula sau Backspace pentru a dezactiva scurtătura de "
 "tastatură."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:135
-#: panels/printers/pp-details-dialog.ui:40
-#: panels/wwan/cc-wwan-apn-dialog.ui:132
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Nume"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:147
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Comandă"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:159
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Scurtătură"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:238
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Stabilește scurtătura…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Niciuna"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:296
-#: panels/wwan/cc-wwan-apn-dialog.ui:44
-msgid "Add"
-msgstr "Adaugă"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:311
-msgid "Replace"
-msgstr "Înlocuiește"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:325
-msgid "Set"
-msgstr "Stabilește"
-
-#: panels/keyboard/cc-keyboard-shortcut-row.ui:27
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Restabilește scurtătura la valoarea ei inițială"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Utilizează camera"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2443,7 +1672,6 @@ msgstr ""
 "Modificați scurtăturile de tastatură și configurați preferințele de tastare, "
 "aranjamentele de tastatură și sursele de intrare"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2451,35 +1679,27 @@ msgstr ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 "Scurtătură;Scurtături;Fereastră;Redimensionează;Sursă;Blochează;Volum;"
 
-#: panels/location/cc-location-panel.ui:31
-msgid "Location services turned off"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
 msgstr "Serviciile de locație sunt oprite"
 
-#: panels/location/cc-location-panel.ui:40
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Nu s-au găsit aplicații care pot obține informațiile de locație."
 
-#: panels/location/cc-location-panel.ui:72
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"Serviciile de locație permit aplicațiilor să cunoască locația dumneavoastră. "
-"Folosind Wi-Fi și rețele mobile de bandă largă măresc acuratețea."
-
-#: panels/location/cc-location-panel.ui:81
-msgid ""
+"mobile broadband increases accuracy.\n"
+"\n"
 "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
-"Utilizează Serviciul de localizare Mozilla: <a href='https://location."
-"services.mozilla.com/privacy'>Politică de confidențialitate</a>"
 
-#: panels/location/cc-location-panel.ui:94
-msgid "Allow the applications below to determine your location."
-msgstr "Permite aplicațiilor de mai jos să vă determine locația."
-
-#: panels/location/cc-location-panel.ui:114
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Nu sunt aplicații care au cerut accesul la locație"
 
@@ -2487,191 +1707,33 @@ msgstr "Nu sunt aplicații care au cerut accesul la locație"
 msgid "Protect your location information"
 msgstr "Protejați informațiile de locație"
 
-#. FIXME
-#: panels/lock/cc-lock-panel.ui:27
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"Blocarea automată a ecranului previne ca alții să acceseze calculatorul în "
-"timp ce sunteți plecat."
 
-#: panels/lock/cc-lock-panel.ui:44
-msgid "Blank Screen Delay"
-msgstr "Întârziere ecran întunecat"
-
-#: panels/lock/cc-lock-panel.ui:45
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Perioada de inactivitate după care ecranul va fi vid."
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Automatic Screen _Lock"
-msgstr "B_locare automată ecran"
-
-#: panels/lock/cc-lock-panel.ui:82
-msgid "Automatic _Screen Lock Delay"
-msgstr "Întârziere automată a blocării _ecranului"
-
-#: panels/lock/cc-lock-panel.ui:83
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "Perioada după care ecranul este vid când ecranul este blocat automat."
-
-#: panels/lock/cc-lock-panel.ui:103
-msgid "Show _Notifications on Lock Screen"
-msgstr "Arată _notificările pe ecranul blocat"
-
-#: panels/lock/cc-lock-panel.ui:120
-msgid "Forbid new _USB devices"
-msgstr "Interzice dispozitive _USB noi"
-
-#: panels/lock/cc-lock-panel.ui:121
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Previne dispozitivele USB noi să interacționeze cu sistemul când ecranul "
-"este blocat."
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:166
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Ecranul se închide"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:170
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 de secunde"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:174
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "un minut"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:178
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "două minute"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:182
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minute"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:186
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minute"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:190
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 de minute"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/lock/cc-lock-panel.ui:194
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "o oră"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:209
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "un minut"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:213
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "două minute"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:217
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minute"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:221
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minute"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:225
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minute"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:229
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minute"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:233
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minute"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:237
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minute"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:241
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minute"
-
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/lock/cc-lock-panel.ui:245
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Niciodată"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Blocare ecran"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Blochează ecranul"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:34
-msgid "Microphone is turned off"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
 msgstr "Microfonul este oprit"
 
-#: panels/microphone/cc-microphone-panel.ui:43
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Nu s-au găsit aplicații care pot înregistra sunetul."
 
-#: panels/microphone/cc-microphone-panel.ui:75
+#: panels/microphone/cc-microphone-panel.ui:37
+#, fuzzy
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
-"properly."
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
 msgstr ""
 "Utilizarea microfonului permite aplicațiilor să înregistreze și să asculte "
 "audio. Dezactivarea microfonului poate determina unele aplicații să nu "
 "funcționeze corect."
 
-#: panels/microphone/cc-microphone-panel.ui:85
-msgid "Allow the applications below to use your microphone."
-msgstr "Permite aplicațiilor de mai jos să utilizeze microfonul."
-
-#: panels/microphone/cc-microphone-panel.ui:105
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Nu sunt aplicații care au cerut accesul la microfon"
 
@@ -2679,105 +1741,172 @@ msgstr "Nu sunt aplicații care au cerut accesul la microfon"
 msgid "Protect your conversations"
 msgstr "Protejați conversațiile"
 
-#. FIXME
-#: panels/mouse/cc-mouse-panel.ui:37
-#: panels/multitasking/cc-multitasking-panel.ui:31
-msgid "General"
-msgstr "Generale"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:57
-msgid "Primary Button"
-msgstr "Buton principal"
-
-#: panels/mouse/cc-mouse-panel.ui:58
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "Stabilește ordinea butoanelor fizice pentru mausuri și touchpaduri."
-
-#: panels/mouse/cc-mouse-panel.ui:84 panels/sound/cc-balance-slider.ui:13
-msgid "Left"
-msgstr "Stânga"
-
-#: panels/mouse/cc-mouse-panel.ui:94 panels/sound/cc-balance-slider.ui:15
-msgid "Right"
-msgstr "Dreapta"
-
-#: panels/mouse/cc-mouse-panel.ui:122
-msgid "Mouse"
-msgstr "Maus"
-
-#: panels/mouse/cc-mouse-panel.ui:142
-msgid "Mouse Speed"
-msgstr "Viteza mausului"
-
-#: panels/mouse/cc-mouse-panel.ui:154 panels/mouse/cc-mouse-panel.ui:258
-msgid "Double-click timeout"
-msgstr "Reglaj clic dublu"
-
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:166 panels/mouse/cc-mouse-panel.ui:230
-msgid "Natural Scrolling"
-msgstr "Derulare naturală"
-
-#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:231
-msgid "Scrolling moves the content, not the view."
-msgstr "Derularea mută conținutul, nu vizualizarea."
-
-#: panels/mouse/cc-mouse-panel.ui:193 panels/mouse/cc-mouse-panel.ui:213
-msgid "Touchpad"
-msgstr "Touchpad"
-
-#: panels/mouse/cc-mouse-panel.ui:247
-msgid "Touchpad Speed"
-msgstr "Viteza touchpadului"
-
-#: panels/mouse/cc-mouse-panel.ui:270
-msgid "Tap to Click"
-msgstr "Clic tactil"
-
-#: panels/mouse/cc-mouse-panel.ui:286
-msgid "Two-finger Scrolling"
-msgstr "Derulare cu două degete"
-
-#: panels/mouse/cc-mouse-panel.ui:303
-msgid "Edge Scrolling"
-msgstr "Derulare pe margini"
-
-#: panels/mouse/cc-mouse-panel.ui:335 panels/wacom/cc-wacom-panel.c:441
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Te_stează configurările"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:25
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Generale"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Buton principal"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Stabilește ordinea butoanelor fizice pentru mausuri și touchpaduri."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Stânga"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Dreapta"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Căutare locații"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Maus"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "Viteza mausului"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Derulare în jos"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "Derularea mută conținutul, nu vizualizarea."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Derularea mută conținutul, nu vizualizarea."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "Accelerator nou…"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Activ"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "Viteza touchpadului"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Metodă"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "Clic tactil"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Clic tactil"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Dezactivează în timp ce se _tastează"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relativ)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Derulare pe margini"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Derulare în jos"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Pe ambele părți"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Încercați să efectuați clic, clic dublu și derulare"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Cinci clicuri, e timpul pentru GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dublu clic, buton principal"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Un clic, buton principal"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dublu clic, buton mijloc"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Un clic, buton mijloc"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dublu clic, buton secundar"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Un clic, buton secundar"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2790,78 +1919,77 @@ msgstr ""
 "Schimbați sensibilitatea mausului sau a touchpad-ului și selectați "
 "orientarea de mână dreaptă sau stângă"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;Clic;Derulare;"
 
-#: panels/multitasking/cc-multitasking-panel.ui:56
+#: panels/multitasking/cc-multitasking-panel.ui:15
 msgid "_Hot Corner"
 msgstr "Colț _important"
 
-#: panels/multitasking/cc-multitasking-panel.ui:57
+#: panels/multitasking/cc-multitasking-panel.ui:16
 msgid "Touch the top-left corner to open the Activities Overview."
 msgstr ""
 "Atingeți colțul din dreapta sus pentru a deschide Vederea de ansamblu a "
 "Activităților."
 
-#: panels/multitasking/cc-multitasking-panel.ui:84
+#: panels/multitasking/cc-multitasking-panel.ui:42
 msgid "_Active Screen Edges"
 msgstr "Margini de ecran _active"
 
-#: panels/multitasking/cc-multitasking-panel.ui:85
+#: panels/multitasking/cc-multitasking-panel.ui:43
 msgid ""
 "Drag windows against the top, left, and right screen edges to resize them."
 msgstr ""
 "Trageți ferestrele spre marginile de sus, stânga și dreapta pentru a le "
 "redimensiona."
 
-#: panels/multitasking/cc-multitasking-panel.ui:114
+#: panels/multitasking/cc-multitasking-panel.ui:70
 msgid "Workspaces"
 msgstr "Spații de lucru"
 
-#: panels/multitasking/cc-multitasking-panel.ui:139
+#: panels/multitasking/cc-multitasking-panel.ui:76
 msgid "_Dynamic workspaces"
 msgstr "Spații de lucru _dinamice"
 
-#: panels/multitasking/cc-multitasking-panel.ui:140
+#: panels/multitasking/cc-multitasking-panel.ui:77
 msgid "Automatically removes empty workspaces."
 msgstr "Elimină automat spații de lucru goale."
 
-#: panels/multitasking/cc-multitasking-panel.ui:158
+#: panels/multitasking/cc-multitasking-panel.ui:91
 msgid "_Fixed number of workspaces"
 msgstr "Spații de lucru _fixe"
 
-#: panels/multitasking/cc-multitasking-panel.ui:159
+#: panels/multitasking/cc-multitasking-panel.ui:92
 msgid "Specify a number of permanent workspaces."
 msgstr "Specifică un număr permanent de spații de lucru."
 
-#: panels/multitasking/cc-multitasking-panel.ui:179
+#: panels/multitasking/cc-multitasking-panel.ui:108
 msgid "_Number of Workspaces"
 msgstr "_Număr de spații de lucru"
 
-#: panels/multitasking/cc-multitasking-panel.ui:200
+#: panels/multitasking/cc-multitasking-panel.ui:124
 msgid "Multi-Monitor"
 msgstr "Monitoare multiple"
 
-#: panels/multitasking/cc-multitasking-panel.ui:225
+#: panels/multitasking/cc-multitasking-panel.ui:130
 msgid "Workspaces on _primary display only"
 msgstr "Spațiile de lucru doar pe afișajul _principal"
 
-#: panels/multitasking/cc-multitasking-panel.ui:252
+#: panels/multitasking/cc-multitasking-panel.ui:156
 msgid "Workspaces on all d_isplays"
 msgstr "Spații de lucru pe toate _ecranele"
 
-#: panels/multitasking/cc-multitasking-panel.ui:282
+#: panels/multitasking/cc-multitasking-panel.ui:184
 msgid "Application Switching"
 msgstr "Schimbarea între aplicații"
 
-#: panels/multitasking/cc-multitasking-panel.ui:307
+#: panels/multitasking/cc-multitasking-panel.ui:190
 msgid "Include applications from all _workspaces"
 msgstr "Include aplicații de pe toate _spațiile de lucru"
 
-#: panels/multitasking/cc-multitasking-panel.ui:325
+#: panels/multitasking/cc-multitasking-panel.ui:204
 msgid "Include applications from the _current workspace only"
 msgstr "Include aplicații numai de pe spațiul de lucru _curent"
 
@@ -2875,100 +2003,55 @@ msgstr ""
 "Administrează preferințele pentru productivitate și efectuarea de sarcini "
 "multiple"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+#, fuzzy
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Sarcini;Sarcini "
 "multiple;Productivitate;Personalizează;Personalizare;"
 
-#: panels/network/cc-network-panel.c:686 panels/network/cc-wifi-panel.ui:307
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Ups, ceva nu a funcționat corect. Vă rugăm să contactați distribuitorul de "
-"software."
-
-#: panels/network/cc-network-panel.c:692
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager trebuie să funcționeze."
-
-#: panels/network/cc-network-panel.ui:66
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Alte dispozitive"
 
-#: panels/network/cc-network-panel.ui:107
-#: panels/network/connection-editor/net-connection-editor.c:587
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:151
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Adaugă o nouă conexiune"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Neconfigurat"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:262
-msgid "Insecure network (WEP)"
-msgstr "Rețea nesigură (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "Rețea sigură (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:272
-msgid "Secure network (WPA2)"
-msgstr "Rețea sigură (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:277
-msgid "Secure network (WPA3)"
-msgstr "Rețea sigură (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:282
-msgid "Secure network"
-msgstr "Rețea securizată"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:68 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Conectat"
 
-#: panels/network/cc-wifi-connection-row.ui:102
-#: panels/network/net-device-ethernet.c:333
-#: panels/network/network-bluetooth.ui:76
-#: panels/network/network-ethernet.ui:111 panels/network/network-mobile.ui:450
-#: panels/network/network-vpn.ui:77
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Opțiuni…"
 
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:134
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Activarea hotspot-ului vă va deconecta de la %s, și nu va fi posibil să "
-"accesați internetul prin Wi-Fi."
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, fuzzy, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Trebuie să aibă un maxim de %d de caractere"
+msgstr[1] "Trebuie să aibă un maxim de %d de caractere"
+msgstr[2] "Trebuie să aibă un maxim de %d de caractere"
 
-#: panels/network/cc-wifi-hotspot-dialog.c:267
-msgid "Must have a minimum of 8 characters"
-msgstr "Trebuie să aibă minimum 8 caractere"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:272
-#, c-format
-msgid "Must have a maximum of %d characters"
-msgstr "Trebuie să aibă un maxim de %d de caractere"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:488
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
 msgid "Turn On Wi-Fi Hotspot?"
 msgstr "Porinți hotspot Wi-Fi?"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:19
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
 "Wi-Fi hotspot allows others to share your internet connection, by creating a "
 "Wi-Fi network that they can connect to. To do this, you must have an "
@@ -2978,177 +2061,89 @@ msgstr ""
 "crearea unei rețele Wi-Fi la care se pot conecta. Pentru a face asta, "
 "trebuie să aveți o conexiune la internet printr-o sursă alta decât Wi-Fi."
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:44
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
 msgstr "Nume rețea"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:69
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:389
-#: panels/printers/pp-jobs-dialog.ui:70
-#: panels/user-accounts/cc-add-user-dialog.ui:249
-#: panels/wwan/cc-wwan-apn-dialog.ui:214
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Parolă"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:83
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Generează o parolă la întâmplare"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:84
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Generează automat o parolă"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:130
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Pornește"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:53
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:864
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Oprire hotspot și deconectare utilizatori?"
-
-#: panels/network/cc-wifi-panel.c:867
-msgid "_Stop Hotspot"
-msgstr "Oprire hot_spot"
-
-#: panels/network/cc-wifi-panel.ui:46
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Modul avion"
 
-#: panels/network/cc-wifi-panel.ui:47
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Dezactivează Wi-Fi, Bluetooth și conexiunea de date mobile"
 
-#: panels/network/cc-wifi-panel.ui:87
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Nu au fost găsit niciun adaptor Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:99
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Asigurați-vă că aveți un adaptor Wi-Fi conectat și pornit"
 
-#: panels/network/cc-wifi-panel.ui:134 panels/wwan/cc-wwan-panel.ui:143
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Modul avion este pornit"
 
-#: panels/network/cc-wifi-panel.ui:146
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Opriți pentru a utiliza Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:184
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Hotspot Wi-Fi activ"
 
-#: panels/network/cc-wifi-panel.ui:195
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Dispozitivele mobile pot scana codul QR pentru a se conecta."
 
-#: panels/network/cc-wifi-panel.ui:205
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Oprește hotspot-ul…"
 
-#: panels/network/cc-wifi-panel.ui:227
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Rețele vizibile"
 
-#: panels/network/cc-wifi-panel.ui:296
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager trebuie să funcționeze"
 
-#: panels/network/connection-editor/8021x-security-page.ui:20
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ups, ceva nu a funcționat corect. Vă rugăm să contactați distribuitorul de "
+"software."
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Securitate 802.1x"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:112
-#: panels/network/connection-editor/ce-page-security.c:424
-#: panels/network/connection-editor/details-page.ui:90
-msgid "Security"
-msgstr "Securitate"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Păstrează"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Aleator"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabil"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Adresa MAC introdusă aici va fi utilizată ca adresa de hardware pentru "
-"dispozitivul de rețea pe care este activată această conexiune. Această "
-"funcționalitate este cunoscută ca clonare MAC sau spoofing. Exemplu: "
-"00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profilul %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:228
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:233
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:279
-msgid "Enhanced Open"
-msgstr "Îmbunătățit deschis"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:218
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Nimic"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Niciodată"
-
-#: panels/network/connection-editor/ce-page-details.c:166
-#: panels/network/net-device-ethernet.c:108
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
@@ -3156,952 +2151,363 @@ msgstr[0] "acum %i zi"
 msgstr[1] "acum %i zile"
 msgstr[2] "acum %i de zile"
 
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:220
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:308
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:332
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nimic"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Slab"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "În regulă"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Bun"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Excelent"
-
-#: panels/network/connection-editor/ce-page-details.c:407
-#: panels/network/connection-editor/details-page.ui:108
-#: panels/network/net-device-ethernet.c:147
-#: panels/network/net-device-mobile.c:442
-msgid "IPv4 Address"
-msgstr "Adresă IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:408
-#: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-mobile.c:443 panels/network/network-mobile.ui:218
-msgid "IPv6 Address"
-msgstr "Adresă IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/ce-page-details.c:411
-#: panels/network/net-device-ethernet.c:152
-#: panels/network/net-device-ethernet.c:154
-#: panels/network/net-device-mobile.c:446
-#: panels/network/net-device-mobile.c:447 panels/network/network-mobile.ui:201
-msgid "IP Address"
-msgstr "Adresă IP"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-mobile.c:451
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/net-device-ethernet.c:170
-#: panels/network/net-device-mobile.c:452
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/connection-editor/details-page.ui:199
-#: panels/network/connection-editor/details-page.ui:218
-#: panels/network/connection-editor/ip4-page.ui:211
-#: panels/network/connection-editor/ip6-page.ui:225
-#: panels/network/net-device-ethernet.c:172
-#: panels/network/net-device-ethernet.c:174
-#: panels/network/net-device-mobile.c:454
-#: panels/network/net-device-mobile.c:455 panels/network/network-mobile.ui:253
-#: panels/network/network-mobile.ui:271
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:471
-msgid "Forget Connection"
-msgstr "Uită conexiunea"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Remove Connection Profile"
-msgstr "Elimină profilul conexiunii"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove VPN"
-msgstr "Elimină VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:493
-msgid "Details"
-msgstr "Detalii"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automat"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:150
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitate"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Șterge adresa"
-
-#: panels/network/connection-editor/ce-page-ip4.c:400
-#: panels/network/connection-editor/ce-page-ip6.c:370
-msgid "Delete Route"
-msgstr "Șterge ruta"
-
-#: panels/network/connection-editor/ce-page-ip4.c:754
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:726
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:268
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Nimic"
-
-#: panels/network/connection-editor/ce-page-security.c:303
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP cheie 40/128-bit (Hex sau ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:313
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit frază secretă"
-
-#: panels/network/connection-editor/ce-page-security.c:326
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:339
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP Dinamic (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:353
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:367
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:381
-msgid "WPA3 Personal"
-msgstr "WPA3 personal"
-
-#: panels/network/connection-editor/details-page.ui:18
-#: panels/wwan/cc-wwan-details-dialog.ui:105
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Putere semnal"
 
-#: panels/network/connection-editor/details-page.ui:54
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Viteză legătură"
 
-#: panels/network/connection-editor/details-page.ui:144
-#: panels/network/net-device-ethernet.c:157
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Securitate"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Adresă IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adresă IPv6"
+
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Adresă hardware"
 
-#: panels/network/connection-editor/details-page.ui:162
+#: panels/network/connection-editor/details-page.ui:142
 msgid "Supported Frequencies"
 msgstr "Frecvențe suportate"
 
-#: panels/network/connection-editor/details-page.ui:180
-#: panels/network/net-device-ethernet.c:161
-#: panels/network/net-device-ethernet.c:163
-#: panels/network/net-device-ethernet.c:165
-#: panels/network/network-mobile.ui:235
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Rută implicită"
 
-#: panels/network/connection-editor/details-page.ui:236
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Ultima utilizare"
 
-#: panels/network/connection-editor/details-page.ui:415
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "Conectare _automată"
 
-#: panels/network/connection-editor/details-page.ui:434
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Disp_onibil și pentru alți utilizatori"
 
-#: panels/network/connection-editor/details-page.ui:467
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr "Conexiune _măsurată: are limite de date și poate suporta taxe"
 
-#: panels/network/connection-editor/details-page.ui:478
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
 "Actualizările software și alte descărcări mai mari nu vor fi începute "
 "automat."
 
-#: panels/network/connection-editor/ethernet-page.ui:25
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Nume"
 
-#: panels/network/connection-editor/ethernet-page.ui:54
-#: panels/network/connection-editor/wifi-page.ui:67
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "Adresă _MAC"
 
-#: panels/network/connection-editor/ethernet-page.ui:105
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: panels/network/connection-editor/ethernet-page.ui:122
-#: panels/network/connection-editor/wifi-page.ui:102
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "Adresă _clonată"
 
-#: panels/network/connection-editor/ethernet-page.ui:137
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "bytes"
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "Metodă IPv_4"
 
-#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "Automat (DHCP)"
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "Doar link-local"
 
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:118
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manual"
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "Dezactivează"
 
-#: panels/network/connection-editor/ip4-page.ui:97
-#: panels/network/connection-editor/ip6-page.ui:111
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
 msgid "Shared to other computers"
 msgstr "Partajat cu alte calculatoare"
 
-#: panels/network/connection-editor/ip4-page.ui:125
-#: panels/network/connection-editor/ip6-page.ui:139
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "Adrese"
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
-#: panels/printers/pp-details-dialog.ui:95
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Adresă"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Netmask"
 
-#: panels/network/connection-editor/ip4-page.ui:171
-#: panels/network/connection-editor/ip4-page.ui:355
-#: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:369
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Gateway"
 
-#: panels/network/connection-editor/ip4-page.ui:223
-#: panels/network/connection-editor/ip4-page.ui:291
-#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/connection-editor/ip6-page.ui:305
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:107
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "Automat"
 
-#: panels/network/connection-editor/ip4-page.ui:234
-#: panels/network/connection-editor/ip6-page.ui:248
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "DNS automat"
 
-#: panels/network/connection-editor/ip4-page.ui:258
-#: panels/network/connection-editor/ip6-page.ui:272
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Adrese IP separate prin virgulă"
 
-#: panels/network/connection-editor/ip4-page.ui:279
-#: panels/network/connection-editor/ip6-page.ui:293
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Rute"
 
-#: panels/network/connection-editor/ip4-page.ui:302
-#: panels/network/connection-editor/ip6-page.ui:316
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Rute automate"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:368
-#: panels/network/connection-editor/ip6-page.ui:382
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metric"
 
-#: panels/network/connection-editor/ip4-page.ui:398
-#: panels/network/connection-editor/ip6-page.ui:412
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Folosiți conexiunea d_oar pentru resurse aflate pe rețeaua proprie"
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "_Metodă IPv_6"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "Automat, doar DHCP"
 
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Prefix"
 
-#: panels/network/connection-editor/net-connection-editor.c:280
-msgid "Unable to open connection editor"
-msgstr "Nu se poate deschide editorul de conexiuni"
-
-#: panels/network/connection-editor/net-connection-editor.c:296
-msgid "New Profile"
-msgstr "Profil nou"
-
-#: panels/network/connection-editor/net-connection-editor.c:731
-msgid "Import from file…"
-msgstr "Importă din fișier…"
-
-#: panels/network/connection-editor/net-connection-editor.c:763
-msgid "Add VPN"
-msgstr "Adaugă VPN"
-
-#: panels/network/connection-editor/security-page.ui:20
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "S_ecuritate"
 
-#: panels/network/connection-editor/vpn-helpers.c:139
-msgid "Cannot import VPN connection"
-msgstr "Nu se poate importa conexiunea VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:141
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Fișierul „%s” nu a putut fi citit sau nu conține informația de conexiune VPN "
-"recunoscută\n"
-"\n"
-"Eroare: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:173
-msgid "Select file to import"
-msgstr "Selectează fișierul de importat"
-
-#: panels/network/connection-editor/vpn-helpers.c:225
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Există deja un fișier cu numele „%s”."
-
-#: panels/network/connection-editor/vpn-helpers.c:227
-msgid "_Replace"
-msgstr "Înlocui_re"
-
-#: panels/network/connection-editor/vpn-helpers.c:229
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Doriți să înlocuiți %s cu conexiunea VPN pe care o salvați?"
-
-#: panels/network/connection-editor/vpn-helpers.c:264
-msgid "Cannot export VPN connection"
-msgstr "Nu se poate exporta conexiunea VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:266
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Conexiunea VPN „%s” nu poate fi exportată în %s.\n"
-"\n"
-"Eroare: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:296
-msgid "Export VPN connection"
-msgstr "Exportă conexiunea VPN"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(Eroare: nu se poate încărca editorul de conexiuni VPN)"
 
-#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Rețea"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Controlați modul în care vă conectați la Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
 "DNS;Rețea;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Controlați modul în care vă conectați la rețele Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;Rețea;"
 
-#: panels/network/net-device-ethernet.c:96
-msgid "never"
-msgstr "niciodată"
-
-#: panels/network/net-device-ethernet.c:104
-msgid "today"
-msgstr "azi"
-
-#: panels/network/net-device-ethernet.c:106
-msgid "yesterday"
-msgstr "ieri"
-
-#: panels/network/net-device-ethernet.c:180
-msgid "Last used"
-msgstr "Ultima utilizare"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:267
-#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Cu fir"
 
-#: panels/network/net-device-mobile.c:209
-msgid "Add new connection"
-msgstr "Adaugă o nouă conexiune"
-
-#: panels/network/net-device-wifi.c:851
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Detaliile rețelei pentru rețelile selectate, inclusiv parolele și alte "
-"configurări se vor pierde."
-
-#: panels/network/net-device-wifi.c:855
-msgid "_Forget"
-msgstr "_Uită"
-
-#: panels/network/net-device-wifi.c:1034 panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Rețele Wi-Fi cunoscute"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1076
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Uită"
-
-#: panels/network/net-device-wifi.c:1217
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Politica de sistem nu permite folosirea ca hotspot"
-
-#: panels/network/net-device-wifi.c:1220
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Dispozitivul wireless nu suporta modul Hotspot"
-
-#: panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:260
-#: panels/power/cc-power-panel.c:856 panels/power/cc-power-panel.c:867
-#: panels/universal-access/cc-ua-panel.c:331
-#: panels/universal-access/cc-ua-panel.c:612
-#: panels/universal-access/cc-ua-panel.c:622
-#: panels/universal-access/cc-ua-panel.c:634
-#: panels/universal-access/cc-ua-panel.c:677
-#: panels/universal-access/cc-ua-panel.ui:338
-#: panels/universal-access/cc-ua-panel.ui:384
-#: panels/universal-access/cc-ua-panel.ui:430
-#: panels/universal-access/cc-ua-panel.ui:536
-#: panels/universal-access/cc-ua-panel.ui:689
-#: panels/universal-access/cc-ua-panel.ui:735
-#: panels/universal-access/cc-ua-panel.ui:781
-#: panels/universal-access/cc-ua-panel.ui:965
-msgid "Off"
-msgstr "Oprit"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Autodescoperirea proxy-ului web este utilizată când nu a fost furnizat un "
-"URL de configurare."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Această opțiune nu este recomandată pentru rețelele publice."
-
-#. update title
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/net-vpn.c:65 panels/network/net-vpn.c:158
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#: panels/network/network-bluetooth.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Închide dispozitivul"
 
-#: panels/network/network-mobile.ui:29
-#: panels/wwan/cc-wwan-details-dialog.ui:286
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Activ"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
 msgid "IMEI"
 msgstr "IMEI"
 
-#: panels/network/network-mobile.ui:47
+#: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Furnizor"
 
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:96
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adresă IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Proxy rețea"
 
-#: panels/network/network-proxy.ui:180
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "Proxy _HTTP"
 
-#: panels/network/network-proxy.ui:199
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "Proxy H_TTPS"
 
-#: panels/network/network-proxy.ui:218
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "Proxy _FTP"
 
-#: panels/network/network-proxy.ui:237
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Gazdă _socks"
 
-#: panels/network/network-proxy.ui:256
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "_Ignoră hosts"
 
-#: panels/network/network-proxy.ui:294
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "HTTP proxy port"
 
-#: panels/network/network-proxy.ui:371
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "HTTPS proxy port"
 
-#: panels/network/network-proxy.ui:392
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "FTP proxy port"
 
-#: panels/network/network-proxy.ui:413
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Socks proxy port"
 
-#: panels/network/network-proxy.ui:442
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "_URL de configurare"
 
-#: panels/network/network-vpn.ui:56
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "Închide conexiunea VPN"
 
-#: panels/network/network-wifi.ui:22
+#: panels/network/network-wifi.ui:34
 msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Nume rețea"
 
-#: panels/network/network-wifi.ui:28
+#: panels/network/network-wifi.ui:40
 msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Tip de securitate"
 
-#: panels/network/network-wifi.ui:34
+#: panels/network/network-wifi.ui:46
 msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Parolă"
 
-#: panels/network/network-wifi.ui:84
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Închide Wi-Fi"
 
-#: panels/network/network-wifi.ui:116
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Se încarcă opțiunile…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Conectare la rețea ascunsă…"
 
-#: panels/network/network-wifi.ui:127
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Porneș_te hotspot Wi-Fi…"
 
-#: panels/network/network-wifi.ui:138
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "Rețele _Wi-Fi cunoscute"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Stare necunoscută"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Negestionat"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Indisponibil"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Se conectează"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Autentificare necesară"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Se deconectează"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Conexiunea a eșuat"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Stare necunoscută (lipsește)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Configurare eșuată"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Configurare IP eșuată"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Configurare IP expirată"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Au fost solicitate elemente de secretizare, dar nu au fost furnizate"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Solicitant 802.1x deconectat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Configurare de solicitant 802.1x eșuată"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Solicitant 802.1x eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Solicitantul 802.1x a necesitat prea mult timp pentru autentificare"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Pornirea serviciului PPP a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Serviciul PPP este deconectat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Pornirea clientului DHCP a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Eroare client DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Clientul DHCP a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Pornirea serviciului de conexiune partajată a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Serviciul de conexiune partajată a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Pornirea serviciului AutoIP a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Eroare serviciu AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Serviciul AutoIP a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linie ocupată"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Fără ton"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Nu poate fi identificată nicio rețea (carrier)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Timp de apel expirat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Încercare de apel eșuată"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Inițializarea modemului a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Eșec la selectarea APN-ului solicitat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Nu se caută rețele"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Înregistrarea în rețea a fost refuzată"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Înregistrarea în rețea a expirat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Eșec la înregistrarea în rețeaua solicitată"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Verificarea PIN-ului a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Firmware-ul pentru acest dispozitiv s-ar putea să lipsească"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Conexiune dispărută"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "S-a preluat conexiunea existentă"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Nu s-a identificat un modem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Conexiunea Bluetooth a eșuat"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Cartela SIM nu este inserată"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Este necesar PIN-ul pentru SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Este necesar PUK-ul pentru SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM greșit"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Dependeță de conectare eșuată"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Lipsă firmware"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Cablu neconectat"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "eroare nespecificată în securitatea 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:195
-msgid "no file selected"
-msgstr "niciun fișier selectat"
-
-#: panels/network/wireless-security/eap-method.c:222
-msgid "unspecified error validating eap-method file"
-msgstr "eroare nespecificată la validarea fișierului metodă eap"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, sau chei private PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:400
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Certificate DER sau PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:87
-msgid "missing EAP-FAST PAC file"
-msgstr "lipsește fișierul EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:347
-msgid "Choose a PAC file"
-msgstr "Alegeți un fișier PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:352
-msgid "PAC files (*.pac)"
-msgstr "Fișiere PAC (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4127,77 +2533,54 @@ msgstr "Autentificat"
 msgid "Both"
 msgstr "Ambele"
 
-#: panels/network/wireless-security/eap-method-fast.ui:49
-#: panels/network/wireless-security/eap-method-peap.ui:52
-#: panels/network/wireless-security/eap-method-ttls.ui:51
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
 msgid "Anony_mous identity"
 msgstr "Identitate anoni_mă"
 
-#: panels/network/wireless-security/eap-method-fast.ui:75
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "_Fișier PAC"
 
-#: panels/network/wireless-security/eap-method-fast.ui:115
-#: panels/network/wireless-security/eap-method-peap.ui:150
-#: panels/network/wireless-security/eap-method-ttls.ui:143
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Alegeți un fișier PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "Autentificare _internă"
 
-#: panels/network/wireless-security/eap-method-fast.ui:144
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Permite pro_vizionarea PAC automată"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "lipsește utilizatorul EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "lipsește parola EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.ui:17
-#: panels/network/wireless-security/eap-method-simple.ui:17
-#: panels/network/wireless-security/ws-leap.ui:18
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "Nume _utilizator"
 
-#: panels/network/wireless-security/eap-method-leap.ui:31
-#: panels/network/wireless-security/eap-method-simple.ui:31
-#: panels/network/wireless-security/ws-leap.ui:32
-#: panels/network/wireless-security/ws-sae.ui:14
-#: panels/network/wireless-security/ws-wpa-psk.ui:14
-#: panels/sharing/cc-sharing-panel.ui:202
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:365
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Parolă"
 
-#: panels/network/wireless-security/eap-method-leap.ui:55
-#: panels/network/wireless-security/eap-method-simple.ui:73
-#: panels/network/wireless-security/eap-method-tls.ui:157
-#: panels/network/wireless-security/ws-leap.ui:56
-#: panels/network/wireless-security/ws-sae.ui:54
-#: panels/network/wireless-security/ws-wpa-psk.ui:64
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Arată paro_la"
-
-#: panels/network/wireless-security/eap-method-peap.c:87
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "certificat CA EAP-PEAP nevalid: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:96
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "certificat CA EAP-PEAP nevalid: niciun certificat specificat"
-
-#: panels/network/wireless-security/eap-method-peap.c:328
-#: panels/network/wireless-security/eap-method-tls.c:513
-#: panels/network/wireless-security/eap-method-ttls.c:336
-msgid "Choose a Certificate Authority certificate"
-msgstr "Alege un certificat semnat de o autoritate de certificare"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4213,103 +2596,43 @@ msgstr "Versiunea 0"
 msgid "Version 1"
 msgstr "Versiunea 1"
 
-#: panels/network/wireless-security/eap-method-peap.ui:78
-#: panels/network/wireless-security/eap-method-tls.ui:68
-#: panels/network/wireless-security/eap-method-ttls.ui:102
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "Certificat C_A"
 
-#: panels/network/wireless-security/eap-method-peap.ui:100
-#: panels/network/wireless-security/eap-method-tls.ui:90
-#: panels/network/wireless-security/eap-method-ttls.ui:125
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Alege un certificat semnat de o autoritate de certificare"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "Nu este necesar niciun ce_rtificat CA"
 
-#: panels/network/wireless-security/eap-method-peap.ui:118
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Versiune PEAP"
 
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "lipsește utilizatorul EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "lipsește parola EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:92
-msgid "missing EAP-TLS identity"
-msgstr "lipsește identitatea EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:102
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "certificat CA EAP-TLS nevalid: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:112
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TLS nevalid: niciun certificat specificat"
-
-#: panels/network/wireless-security/eap-method-tls.c:129
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "cheie privată EAP-TLS nevalidă: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:139
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "certificat EAP-TLS al utilizatorului nevalid: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:272
-msgid "Unencrypted private keys are insecure"
-msgstr "Cheile private necriptate nu sunt sigure"
-
-#: panels/network/wireless-security/eap-method-tls.c:275
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Cheia privată selectată nu pare a fi protejată de o parolă. Aceasta ar putea "
-"duce la compromiterea datelor de autentificare. Vă rugăm selectați o cheie "
-"privată protejată de o parolă.\n"
-"\n"
-"(Puteți proteja o cheie privată cu o parolă cu ajutorul openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:506
-msgid "Choose your personal certificate"
-msgstr "Alegeți un certificat personal"
-
-#: panels/network/wireless-security/eap-method-tls.c:520
-msgid "Choose your private key"
-msgstr "Alegeți o cheie privată"
-
-#: panels/network/wireless-security/eap-method-tls.ui:17
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "I_dentitate"
 
-#: panels/network/wireless-security/eap-method-tls.ui:43
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "Certificat _utilizator"
 
-#: panels/network/wireless-security/eap-method-tls.ui:108
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "Cheie p_rivată"
 
-#: panels/network/wireless-security/eap-method-tls.ui:133
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Parolă cheie _privată"
-
-#: panels/network/wireless-security/eap-method-ttls.c:98
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "certificat CA EAP-TTLS nevalid: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:106
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "certificat CA EAP-TTLS: niciun certificat specificat"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4327,20 +2650,20 @@ msgstr "MSCHAPv2 (fără EAP)"
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.ui:76
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
 msgid "_Domain"
 msgstr "_Domeniu"
-
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Eroare necunoscută la validarea securității 802.1X"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4362,66 +2685,16 @@ msgstr "Tunneled TLS"
 msgid "Protected EAP (PEAP)"
 msgstr "Protejată EAP (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:56
-#: panels/network/wireless-security/ws-wep-key.ui:102
-#: panels/network/wireless-security/ws-wpa-eap.ui:61
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Au_tentificare"
 
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "lipsește utilizatorul leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "lipsește parola leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Parola Wi-Fi lipsește."
-
-#: panels/network/wireless-security/ws-sae.ui:42
-#: panels/network/wireless-security/ws-wpa-psk.ui:42
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tipul"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "lipsește cheia wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"cheie wep nevalidă: cheia cu lungimea de %zu trebuie să conțină numai cifre "
-"hexazecimale"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"cheie wep nevalidă: cheia cu lungimea de %zu trebuie să conțină numai "
-"caractere ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"cheie wep nevalidă: lungimea (%zu) cheii este incorectă. O  cheie trebuie să "
-"fie de lungimea 5/13 (ascii) sau 10/26 (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "cheie wep nevalidă: fraza de acces nu trebuie să fie goală"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"cheie wep nevalidă: fraza de acces trebuie să fie mai scurtă de 64 de "
-"caractere"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4435,49 +2708,36 @@ msgstr "Sistem deschis"
 msgid "Shared Key"
 msgstr "Cheie comună"
 
-#: panels/network/wireless-security/ws-wep-key.ui:48
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "Che_ie"
 
-#: panels/network/wireless-security/ws-wep-key.ui:84
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "Arată c_heia"
 
-#: panels/network/wireless-security/ws-wep-key.ui:134
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP inde_x"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-spk nevalidă: lungimea (%zu) cheii nevalidă. Trebuie să fie [8,63] bytes "
-"sau 64 cifre hexazecimale"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "wpa-psk nevalidă: nu se poate interpreta cheia de 64 de bytes ca hex"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:60
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "_Notificări"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:112
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "_Alerte sonore"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:168
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "Notificări _popup"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:184
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
@@ -4486,36 +2746,26 @@ msgstr ""
 "sunt dezactivate."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:249
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "Arată _conținutul mesajelor în popup-uri"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:300
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "Notificări ecran de _blocare"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:351
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "Arată c_onținutul mesajelor pe ecranul blocat"
 
-#: panels/notifications/cc-notifications-panel.c:260
-#: panels/power/cc-power-panel.c:862 panels/power/cc-power-panel.c:869
-#: panels/universal-access/cc-ua-panel.c:331
-#: panels/universal-access/cc-ua-panel.c:612
-#: panels/universal-access/cc-ua-panel.c:622
-#: panels/universal-access/cc-ua-panel.c:634
-#: panels/universal-access/cc-ua-panel.c:677
-msgid "On"
-msgstr "Pornit"
-
-#: panels/notifications/cc-notifications-panel.ui:44
+#: panels/notifications/cc-notifications-panel.ui:10
 msgid "_Do Not Disturb"
 msgstr "_Nu deranja"
 
-#: panels/notifications/cc-notifications-panel.ui:52
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr "Notificări ecran de blocare"
 
@@ -4523,34 +2773,34 @@ msgstr "Notificări ecran de blocare"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Controlează tipurile de notificări afișate și ce afișează acestea"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifications;Banner;Message;Tray;Popup;"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:148
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Altele"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Refă"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:576
-#, c-format
-msgid "%s Account"
-msgstr "Cont %s"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Autentificare _internă"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:870
-msgid "Error removing account"
-msgstr "Eroare la eliminarea contului"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Conectați-vă la datele dumneavoastră din nor"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:936
-#, c-format
-msgid "%s removed"
-msgstr "%s eliminat"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Nicio conexiune la internet — conectați-vă pentru a configura noi conturi "
+"online"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Adaugă un cont"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4561,10 +2811,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Conectați-vă la conturile online și decideți modul în care să le folosiți"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4572,33 +2818,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:61
-msgid "Undo"
-msgstr "Refă"
-
-#: panels/online-accounts/online-accounts.ui:94
-msgid "Connect to your data in the cloud"
-msgstr "Conectați-vă la datele dumneavoastră din nor"
-
-#: panels/online-accounts/online-accounts.ui:109
-msgid "No internet connection — connect to set up new online accounts"
-msgstr ""
-"Nicio conexiune la internet — conectați-vă pentru a configura noi conturi "
-"online"
-
-#: panels/online-accounts/online-accounts.ui:134
-msgid "Add an account"
-msgstr "Adaugă un cont"
-
-#: panels/online-accounts/online-accounts.ui:223
-msgid "Remove Account"
-msgstr "Ștergere cont"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Timp necunoscut"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4616,13 +2835,6 @@ msgstr[0] "%i oră"
 msgstr[1] "%i ore"
 msgstr[2] "%i de ore"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4637,371 +2849,152 @@ msgstr[0] "minut"
 msgstr[1] "minute"
 msgstr[2] "de minute"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s până e încărcată complet"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Atenție: au mai rămas %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "au mai rămas %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Complet încărcată"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Nu se încarcă"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Descărcată complet"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Se încarcă"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Se descarcă"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Mouse fără fir"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Tastatură fără fir"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Sursă de curent neîntreruptibilă"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Asistent personal digital"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Telefon celular"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Player media"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209 panels/wacom/cc-wacom-panel.c:728
-msgid "Tablet"
-msgstr "Tabletă"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Calculator"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Dispozitiv de intrare pentru jocuri"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:384
-#: panels/power/cc-power-panel.ui:63
-msgid "Battery"
-msgstr "Baterie"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Principal"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Extra"
-
-#: panels/power/cc-power-panel.c:382
-msgid "Batteries"
-msgstr "Baterii"
-
-#: panels/power/cc-power-panel.c:644
-msgid "When _idle"
-msgstr "Când e _inactiv"
-
-#: panels/power/cc-power-panel.c:796
-msgid "Suspend"
-msgstr "Suspendă"
-
-#: panels/power/cc-power-panel.c:797
-msgid "Power Off"
-msgstr "Oprește"
-
-#: panels/power/cc-power-panel.c:798
-msgid "Hibernate"
-msgstr "Hibernează"
-
-#: panels/power/cc-power-panel.c:799
-msgid "Nothing"
-msgstr "Nimic"
-
-#: panels/power/cc-power-panel.c:858
-msgid "When on battery power"
-msgstr "Când funcționează pe baterie"
-
-#: panels/power/cc-power-panel.c:860
-msgid "When plugged in"
-msgstr "Alimentat de la rețea"
-
-#: panels/power/cc-power-panel.c:980
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Niciodată"
-
-#: panels/power/cc-power-panel.c:1066
-msgid "Automatic suspend"
-msgstr "Suspendare automată"
-
-#: panels/power/cc-power-panel.c:1171
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Modul de performanță este dezactivat temporar din cauza temperaturii înalte "
-"de operare."
-
-#: panels/power/cc-power-panel.c:1173
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Suprafață neregulată detectată: modul de performanță este indisponibil. "
-"Mutați dispozitivul la o suprafață stabilă pentru restaurare."
-
-#: panels/power/cc-power-panel.c:1175
-msgid "Performance mode temporarily disabled."
-msgstr "Modul de performanță este dezactivat temporar."
-
-#: panels/power/cc-power-panel.c:1218
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Baterie pe terminate: economizorul de energie activat. Modul anterior va fi "
-"restaurat când bateria este încărcată suficient."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1226
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Modul de economizare energie activat de „%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1230
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Modul de performanță a fost activat de „%s”."
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "15 minute"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "20 de minute"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "25 de minute"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 de minute"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 de minute"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "o oră"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 de minute"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 de minute"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 de minute"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "două ore"
 
-#: panels/power/cc-power-panel.ui:107
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterie"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispozitive"
+
+#: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Modul de alimentare"
 
-#: panels/power/cc-power-panel.ui:108
+#: panels/power/cc-power-panel.ui:94
 msgid "Affects system performance and power usage."
 msgstr "Afectează performanța sistemului și consumul de energie."
 
-#: panels/power/cc-power-panel.ui:142
+#: panels/power/cc-power-panel.ui:123
 msgid "Power Saving Options"
 msgstr "Opțiuni de economisire de energie"
 
-#: panels/power/cc-power-panel.ui:146
+#: panels/power/cc-power-panel.ui:126
 msgid "Automatic Screen Brightness"
 msgstr "Luminozitate automată pentru ecran"
 
-#: panels/power/cc-power-panel.ui:147
+#: panels/power/cc-power-panel.ui:127
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "Luminozitatea ecranului se ajustează după lumina ambientală."
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Diminuează luminozitatea ecranului"
 
-#: panels/power/cc-power-panel.ui:161
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "Reduce luminozitatea ecranului când calculatorul este inactiv."
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "Înnegrește ecranul"
 
-#: panels/power/cc-power-panel.ui:175
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "Oprește ecranul după o perioadă de inactivitate."
 
-#: panels/power/cc-power-panel.ui:183
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Economizor de energie automat"
 
-#: panels/power/cc-power-panel.ui:184
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr ""
 "Activează modul de economizare de energie când bateria este pe terminate."
 
-#: panels/power/cc-power-panel.ui:198
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "Suspendare _automată"
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "Pune calculatorul pe pauză după o perioadă de inactivitate."
 
-#: panels/power/cc-power-panel.ui:217
-msgid "Suspend & Power Button"
-msgstr "Buton de suspendare și oprire"
-
-#: panels/power/cc-power-panel.ui:221
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Comportament butonului de alimen_tare"
 
-#: panels/power/cc-power-panel.ui:229
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Arată _procentajul bateriei"
 
-#: panels/power/cc-power-panel.ui:268
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Suspendare automată"
 
-#: panels/power/cc-power-panel.ui:293
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "Alimentat la _rețea"
 
-#: panels/power/cc-power-panel.ui:309
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Pe _baterie"
 
-#: panels/power/cc-power-panel.ui:354 panels/power/cc-power-panel.ui:414
-#: panels/universal-access/cc-repeat-keys-dialog.ui:74
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Întârziere"
-
-#: panels/power/cc-power-profile-row.c:61
-msgid "Lap detected: performance mode unavailable"
-msgstr "Etapă detectată: modul de performanță nedisponibil"
-
-#: panels/power/cc-power-profile-row.c:63
-msgid "High hardware temperature: performance mode unavailable"
-msgstr "Temperatură de hardware ridicată: modul de performanță nedisponibil"
-
-#: panels/power/cc-power-profile-row.c:64
-msgid "Performance mode unavailable"
-msgstr "Modul de performanță nedisponibil"
-
-#: panels/power/cc-power-profile-row.c:86
-#: panels/power/cc-power-profile-row.c:185
-msgid "High performance and power usage."
-msgstr "Performanță și consum de energie ridicate."
-
-#: panels/power/cc-power-profile-row.c:184
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Performanță"
-
-#: panels/power/cc-power-profile-row.c:188
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Echilibrată"
-
-#: panels/power/cc-power-profile-row.c:189
-msgid "Standard performance and power usage."
-msgstr "Performanță și consum de energie standard."
-
-#: panels/power/cc-power-profile-row.c:192
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Economizor de energie"
-
-#: panels/power/cc-power-profile-row.c:193
-msgid "Reduced performance and power usage."
-msgstr "Performanță și consum de energie reduse."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -5011,7 +3004,6 @@ msgstr "Consum"
 msgid "View your battery status and change power saving settings"
 msgstr "Stare baterie și schimbare setări consum energie"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5021,47 +3013,6 @@ msgstr ""
 "Energy;Putere;Somn;Suspendă;Hibernează;Baterie;Luminozitate;Întunecos;Vid;În "
 "așteptare;Energie;"
 
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "Autentificare"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/new-printer-dialog.ui:366
-#: panels/printers/pp-jobs-dialog.ui:57 panels/wwan/cc-wwan-apn-dialog.ui:188
-msgid "Username"
-msgstr "Nume utilizator"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:339
-msgid "Authentication Required"
-msgstr "Necesită autentificare"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:682
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Imprimanta „%s” a fost ștearsă"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:926
-msgid "Failed to add new printer."
-msgstr "Nu s-a putut adăuga imprimanta nouă."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1225
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Nu s-a putut încărca interfața cu utilizatorul: %s"
-
-#: panels/printers/cc-printers-panel.c:1293
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Deblocați pentru a adăuga imprimante și schimba configurări"
-
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "Imprimante"
@@ -5070,7 +3021,6 @@ msgstr "Imprimante"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Adaugă imprimante, sarcini de tipărire și ce trebuie imprimat"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -5078,196 +3028,93 @@ msgstr ""
 "Hârtie;Cerneală;Toner;Laser;"
 
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:254
-#: panels/printers/pp-new-printer-dialog.c:311
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Adăugare imprimantă"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
-#: panels/wwan/cc-wwan-device-page.ui:90
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Deblochează"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Nu au fost găsite imprimante"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Introduceți o adresă de rețea sau căutați o imprimantă"
 
-#: panels/printers/new-printer-dialog.ui:356
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Necesită autentificare"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Introduceți numele de utilizator și parola pentru a vedea imprimantele de pe "
 "serverul de imprimare."
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:351
-#, c-format
-msgid "%s Details"
-msgstr "Detalii %s"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Nume utilizator"
 
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Nu s-a găsit un driver potrivit"
-
-#: panels/printers/pp-details-dialog.c:232
-msgid "Select PPD File"
-msgstr "Specificați fișierul PPD"
-
-#: panels/printers/pp-details-dialog.c:241
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"Fișiere descriere imprimantă PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
 
-#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Locație"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:122
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Driver"
 
-#: panels/printers/pp-details-dialog.ui:162
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Se caută drivere preferate…"
 
-#: panels/printers/pp-details-dialog.ui:183
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Caută drivere"
 
-#: panels/printers/pp-details-dialog.ui:192
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Selectează din baza de date…"
 
-#: panels/printers/pp-details-dialog.ui:201
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Instalează fișier PPD…"
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "Selectați driverul imprimantei"
-
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:107
-msgid "Select"
-msgstr "Selectează"
 
 #: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "Se încarcă baza de date cu drivere…"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Imprimantă JetDirect"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Renunță"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Imprimantă PLD"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Selectează"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Pe o parte"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Margine lungă (standard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Margine scurtă (întoarsă)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Portret"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Peisaj"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Peisaj inversat"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Portret inversat"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:106
-msgctxt "print job"
-msgid "Pending"
-msgstr "În așteptare"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:112
-msgctxt "print job"
-msgid "Paused"
-msgstr "În pauză"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:117
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Autentificare necesară"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:122
-msgctxt "print job"
-msgid "Processing"
-msgstr "Se procesează"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:126
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Oprită"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:130
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Anulată"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Oprită forțat"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:138
-msgctxt "print job"
-msgid "Completed"
-msgstr "Finalizată"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:249
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
@@ -5275,247 +3122,38 @@ msgstr[0] "%u sarcină necesită autentificare"
 msgstr[1] "%u sarcini necesită autentificare"
 msgstr[2] "%u de sarcini necesită autentificare"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:401
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — sarcini active"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:405
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Introduceți credențialele pentru a tipări de la %s."
-
 #. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/pp-jobs-dialog.ui:44
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
 msgid "Domain"
 msgstr "Domeniu"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:129
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "A_utentificare"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:169
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Curăță tot"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:232
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Autentificare"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:358
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Nu sunt sarcini active pentru imprimantă"
 
-#: panels/printers/pp-new-printer-dialog.c:269
-msgid "Unlock Print Server"
-msgstr "Deblocați serverul de imprimare"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:273
-#, c-format
-msgid "Unlock %s."
-msgstr "Deblochează %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:277
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Introduceți numele de utilizator și parola pentru a vedea imprimantele "
-"disponibile pe %s."
-
-#: panels/printers/pp-new-printer-dialog.c:587
-msgid "Searching for Printers"
-msgstr "Se caută imprimante"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1375
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1380
-msgid "Serial Port"
-msgstr "Port serial"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1387
-msgid "Parallel Port"
-msgstr "Port paralel"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1429
-#, c-format
-msgid "Location: %s"
-msgstr "Locație: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1434
-#, c-format
-msgid "Address: %s"
-msgstr "Adresă: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1461
-msgid "Server requires authentication"
-msgstr "Serverul necesită autentificare"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Pe ambele părți"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Tip de hârtie"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Sursă hârtie"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Tavă de ieșire"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Rezoluție"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Pre-filtrare GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:530
-msgid "Pages per side"
-msgstr "Pagini pe foaie"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:542
-msgid "Two-sided"
-msgstr "Pe ambele părți"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:554
-msgid "Orientation"
-msgstr "Orientare"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:651
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "General"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Configurare pagină"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Opțiuni instalabile"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Sarcină"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Calitate imagine"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Culoare"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Se finalizează"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avansat"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:857
-#: panels/printers/pp-options-dialog.ui:18
+#: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Pagină de test"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:870
-msgid "Test page"
-msgstr "Pagină de test"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Selectare automată"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Configurări implicite pentru imprimantă"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Permite numai fonturile GhostScript înglobate"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Convertește la PS nivelul 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Convertește la PS nivelul 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Fără pre-filtrare"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:203
-msgid "Manufacturer"
-msgstr "Producător"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:523 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr "Nicio sarcină activă"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:528
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
@@ -5523,288 +3161,161 @@ msgstr[0] "%u sarcină"
 msgstr[1] "%u sarcini"
 msgstr[2] "%u de sarcini"
 
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:648
-msgid "Clean print heads"
-msgstr "Curăță capetele de imprimare"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:713
-msgid "Low on toner"
-msgstr "Toner puțin"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:715
-msgid "Out of toner"
-msgstr "Fără toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:718
-msgid "Low on developer"
-msgstr "Developator puțin"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of developer"
-msgstr "Fără developator"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:723
-msgid "Low on a marker supply"
-msgstr "Stoc de culoare scăzut"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:725
-msgid "Out of a marker supply"
-msgstr "Stoc de culoare terminat"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:727
-msgid "Open cover"
-msgstr "Capac deschis"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:729
-msgid "Open door"
-msgstr "Ușă deschisă"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:731
-msgid "Low on paper"
-msgstr "Hârtie puțină"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:733
-msgid "Out of paper"
-msgstr "Fără hârtie"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:735
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Deconectată"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:737
-#: panels/printers/pp-printer-entry.c:880
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Oprită"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:739
-msgid "Waste receptacle almost full"
-msgstr "Recipientul pentru deșeuri este aproape plin"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:741
-msgid "Waste receptacle full"
-msgstr "Recipientul pentru deșeuri este plin"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:743
-msgid "The optical photo conductor is near end of life"
-msgstr "Foto-conductorul optic este aproape de sfârșitul vieții"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:745
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Foto-conductorul optic nu mai funcționează"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:866
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Pregătită"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:871
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Nu acceptă sarcini de imprimare"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:876
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Procesează"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "Opțiuni de imprimare"
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "Detaliile imprimantei"
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "Utilizează imprimanta în mod implicit"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "Curăță capetele de imprimare"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Ștergere imprimantă"
 
-#: panels/printers/printer-entry.ui:193
-#: panels/wwan/cc-wwan-details-dialog.ui:229
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nicio sarcină activă"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Nivelul de cerneală"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:313
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Reporniți când problema s-a rezolvat."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:320
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Repornește"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:12
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Adaugă imprimantă…"
 
-#: panels/printers/printers.ui:187
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Adăugă o imprimantă…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Fără imprimante"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:201
-msgid "Add a Printer…"
-msgstr "Adăugă o imprimantă…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:233
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Ne pare rău! Se pare că serviciul\n"
 "de tipărire al sistemului nu este disponibil."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:189
-#: panels/region/cc-format-chooser.ui:6 panels/region/cc-region-panel.ui:203
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formate"
 
-#: panels/region/cc-format-chooser.ui:101
-msgid ""
-"Choose the format for numbers, dates and currencies. Changes take effect on "
-"next login."
-msgstr ""
-"Alege formatul pentru numere, date și valute. Modificările își fac efectul "
-"la următoarea autentificare."
-
-#: panels/region/cc-format-chooser.ui:117
-msgid "Search locales..."
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
 msgstr "Caută localizări..."
 
-#: panels/region/cc-format-chooser.ui:158
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Formate comune"
 
-#: panels/region/cc-format-chooser.ui:189
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Toate formatele"
 
-#: panels/region/cc-format-chooser.ui:242
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Nu s-au găsit rezultate"
 
-#: panels/region/cc-format-chooser.ui:255
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Căutările pot fi pentru țări sau limbi străine."
 
-#: panels/region/cc-format-chooser.ui:300
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Previzualizare"
 
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Anglo-saxon"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metric"
-
-#: panels/region/cc-format-preview.ui:18
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Date"
 
-#: panels/region/cc-format-preview.ui:62
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "Date și ore"
 
-#: panels/region/cc-format-preview.ui:84
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Numere"
 
-#: panels/region/cc-format-preview.ui:106
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Unități de măsură"
 
-#: panels/region/cc-format-preview.ui:128
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Hârtie"
 
-#: panels/region/cc-region-panel.ui:42
-msgid "My Account"
-msgstr "Contul meu"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#: panels/region/cc-region-panel.ui:53
-msgid "Login Screen"
-msgstr "Ecran de autentificare"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-#: panels/region/cc-region-panel.ui:78
-msgid "Language"
-msgstr "Limba"
+#: panels/region/cc-region-panel.ui:45
+#, fuzzy
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr "Formatul utilizat pentru numere, date și monede."
 
-#: panels/region/cc-region-panel.ui:89
-msgid "The language used for text in windows and web pages."
-msgstr "Limba străină utilizată pentru text în ferestre și pagini web."
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "Instalează limbi..."
 
-#: panels/region/cc-region-panel.ui:129
-#: panels/user-accounts/cc-user-panel.ui:311
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Contul tău"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Limbă"
 
-#: panels/region/cc-region-panel.ui:164
-msgid "Restart the session for changes to take effect"
-msgstr "Reporniți sesiunea pentru ca modificările să aibă efect"
-
-#: panels/region/cc-region-panel.ui:179
-msgid "Restart…"
-msgstr "Repornește…"
-
-#: panels/region/cc-region-panel.ui:214
-msgid "The format used for numbers, dates, and currencies."
-msgstr "Formatul utilizat pentru numere, date și monede."
-
-#: panels/region/cc-region-panel.ui:248
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formate"
 
-#: panels/region/cc-region-panel.ui:275
-msgid "Login settings are used by all users when logging into the system"
-msgstr ""
-"Configurările de autentificare sunt folosite pentru toți utilizatorii la "
-"autentificarea în sistem"
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "Ecran de autentificare"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
@@ -5814,139 +3325,49 @@ msgstr "Regiune și limbă"
 msgid "Select your display language and formats"
 msgstr "Selectați limba afișată și formatele"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;Limbă;Aranjament;Intrare;"
 
-#: panels/removable-media/cc-removable-media-panel.c:267
-msgid "Ask what to do"
-msgstr "Întreabă-mă ce să fac"
-
-#: panels/removable-media/cc-removable-media-panel.c:271
-msgid "Do nothing"
-msgstr "Nu fă nimic"
-
-#: panels/removable-media/cc-removable-media-panel.c:275
-msgid "Open folder"
-msgstr "Deschide dosarul"
-
-#: panels/removable-media/cc-removable-media-panel.c:341
-msgid "Other Media"
-msgstr "Deschide suportul multimedia"
-
-#: panels/removable-media/cc-removable-media-panel.c:362
-msgid "Select an application for audio CDs"
-msgstr "Selectați o aplicație pentru CD-uri audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:363
-msgid "Select an application for video DVDs"
-msgstr "Selectați o aplicație pentru DVD-uri video"
-
-#: panels/removable-media/cc-removable-media-panel.c:364
-msgid "Select an application to run when a music player is connected"
-msgstr "Selectați o aplicație de rulat la conectarea unui player de muzică"
-
-#: panels/removable-media/cc-removable-media-panel.c:365
-msgid "Select an application to run when a camera is connected"
-msgstr "Selectați o aplicație de rulat la conectarea unei camere"
-
-#: panels/removable-media/cc-removable-media-panel.c:366
-msgid "Select an application for software CDs"
-msgstr "Selectați o aplicație pentru CD-uri software"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "audio DVD"
-msgstr "DVD audio"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "blank Blu-ray disc"
-msgstr "disc Blu-Ray gol"
-
-#: panels/removable-media/cc-removable-media-panel.c:380
-msgid "blank CD disc"
-msgstr "disc CD gol"
-
-#: panels/removable-media/cc-removable-media-panel.c:381
-msgid "blank DVD disc"
-msgstr "disc DVD gol"
-
-#: panels/removable-media/cc-removable-media-panel.c:382
-msgid "blank HD DVD disc"
-msgstr "disc HD DVD gol"
-
-#: panels/removable-media/cc-removable-media-panel.c:383
-msgid "Blu-ray video disc"
-msgstr "Disc video Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:384
-msgid "e-book reader"
-msgstr "cititor de cărți electronice"
-
-#: panels/removable-media/cc-removable-media-panel.c:385
-msgid "HD DVD video disc"
-msgstr "Disc video HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:386
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:387
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:388
-msgid "Video CD"
-msgstr "CD video"
-
-#: panels/removable-media/cc-removable-media-panel.c:389
-msgid "Windows software"
-msgstr "Software Windows"
-
-#: panels/removable-media/cc-removable-media-panel.ui:44
+#: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
 msgstr "Selectați cum ar trebui să se opereze cu fișiere media"
 
-#: panels/removable-media/cc-removable-media-panel.ui:75
+#: panels/removable-media/cc-removable-media-panel.ui:52
 msgid "CD _audio"
 msgstr "CD _audio"
 
-#: panels/removable-media/cc-removable-media-panel.ui:92
+#: panels/removable-media/cc-removable-media-panel.ui:67
 msgid "_DVD video"
 msgstr "_DVD video"
 
-#: panels/removable-media/cc-removable-media-panel.ui:133
+#: panels/removable-media/cc-removable-media-panel.ui:102
 msgid "_Music player"
 msgstr "Player _muzical"
 
-#: panels/removable-media/cc-removable-media-panel.ui:191
+#: panels/removable-media/cc-removable-media-panel.ui:152
 msgid "_Software"
 msgstr "_Software"
 
-#: panels/removable-media/cc-removable-media-panel.ui:229
+#: panels/removable-media/cc-removable-media-panel.ui:178
 msgid "_Other Media…"
 msgstr "Alte medii de st_ocare…"
 
-#: panels/removable-media/cc-removable-media-panel.ui:288
+#: panels/removable-media/cc-removable-media-panel.ui:195
 msgid "_Never prompt or start programs on media insertion"
 msgstr ""
 "_Nu solicita și nu porni niciodată programe la introducerea dispozitivelor "
 "detașabile"
 
-#: panels/removable-media/cc-removable-media-panel.ui:342
+#: panels/removable-media/cc-removable-media-panel.ui:225
 msgid "Select how other media should be handled"
 msgstr "Selectați cum ar trebui să se opereze cu alte fișiere media"
 
-#: panels/removable-media/cc-removable-media-panel.ui:389
+#: panels/removable-media/cc-removable-media-panel.ui:259
 msgid "_Action:"
 msgstr "_Acțiune:"
 
-#: panels/removable-media/cc-removable-media-panel.ui:412
+#: panels/removable-media/cc-removable-media-panel.ui:278
 msgid "_Type:"
 msgstr "_Tip:"
 
@@ -5958,7 +3379,6 @@ msgstr "Medii detașabile"
 msgid "Configure Removable Media settings"
 msgstr "Configurează medii detașabile"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5968,22 +3388,87 @@ msgstr ""
 "removable;media;autorun;dispozitiv;sistem;implicit;implicită;implicite;"
 "aplicație;aplicații;preferate;preferată;amovibil;autopornire;"
 
-#: panels/search/cc-search-locations-dialog.c:636
-msgid "Select Location"
-msgstr "Selectează locația"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Blocare ecran"
 
-#: panels/search/cc-search-locations-dialog.c:640
-msgid "_OK"
-msgstr "_Ok"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Blocarea automată a ecranului previne ca alții să acceseze calculatorul în "
+"timp ce sunteți plecat."
 
-#: panels/search/cc-search-locations-dialog.ui:9
-#: panels/search/cc-search-panel.ui:57
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Întârziere ecran întunecat"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Perioada de inactivitate după care ecranul va fi vid."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "B_locare automată ecran"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Întârziere automată a blocării _ecranului"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Perioada după care ecranul este vid când ecranul este blocat automat."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Arată _notificările pe ecranul blocat"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Notificări ecran de blocare"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Interzice dispozitive _USB noi"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Previne dispozitivele USB noi să interacționeze cu sistemul când ecranul "
+"este blocat."
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Confidențialitate"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ecran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Partajarea ecranului"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "Căutare locații"
 
-#: panels/search/cc-search-locations-dialog.ui:32
-#: panels/search/cc-search-locations-dialog.ui:69
-#: panels/search/cc-search-locations-dialog.ui:107
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and "
 "Videos."
@@ -5991,38 +3476,49 @@ msgstr ""
 "Dosarele în care aplicațiile sistemului ― cum ar fi Fișiere, Fotografii și "
 "Videouri ― vor efectua căutări."
 
-#: panels/search/cc-search-locations-dialog.ui:52
+#: panels/search/cc-search-locations-dialog.ui:18
 msgid "Places"
 msgstr "Locuri"
 
-#: panels/search/cc-search-locations-dialog.ui:91
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Semne de carte"
 
-#: panels/search/cc-search-locations-dialog.ui:156
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "Altele"
 
-#: panels/search/cc-search-panel.c:151
-msgid "No applications found"
-msgstr "Nu s-au găsit aplicații"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Locație"
 
-#: panels/search/cc-search-panel-row.ui:92
-msgid "Move Up"
-msgstr "Mută în sus"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Schimbarea între aplicații"
 
-#: panels/search/cc-search-panel-row.ui:102
-msgid "Move Down"
-msgstr "Mută în jos"
+#: panels/search/cc-search-panel.ui:11
+#, fuzzy
+msgid "Include application-provided search results."
+msgstr "Include aplicații de pe toate _spațiile de lucru"
 
-#: panels/search/cc-search-panel.ui:31
-msgid ""
-"Control which search results are shown in the Activities Overview. The order "
-"of search results can also be changed by moving rows in the list."
+#: panels/search/cc-search-panel.ui:23
+#, fuzzy
+msgid "Folders which are searched by system applications."
 msgstr ""
-"Controlează ce rezultate ale căutării sunt afișate în vederea de ansamblu "
-"Activități. Ordinea rezultatelor căutării poate fi modificată și prin "
-"mutarea rândurilor în listă."
+"Dosarele în care aplicațiile sistemului ― cum ar fi Fișiere, Fotografii și "
+"Videouri ― vor efectua căutări."
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Nu s-au găsit rezultate"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
@@ -6030,164 +3526,141 @@ msgid ""
 msgstr ""
 "Controlează ce aplicații arată rezultate de căutare în panorama de activități"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Search;Find;Index;Hide;Privacy;Results;Caută;Căutare;Găsire;Ascunde;"
 "Confidențialitate;Rezultate;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:306
-msgid "No networks selected for sharing"
-msgstr "Nicio rețea selectată pentru partajare"
-
-#: panels/sharing/cc-sharing-networks.ui:19
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Rețele"
 
-#: panels/sharing/cc-sharing-panel.c:289
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Pornit"
-
-#: panels/sharing/cc-sharing-panel.c:291 panels/sharing/cc-sharing-panel.c:318
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Oprit"
-
-#: panels/sharing/cc-sharing-panel.c:321
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Activat"
-
-#: panels/sharing/cc-sharing-panel.c:324
-msgctxt "service is active"
-msgid "Active"
-msgstr "Activ"
-
-#: panels/sharing/cc-sharing-panel.c:393
-msgid "Choose a Folder"
-msgstr "Alegeți un director"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:696
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Partajarea de fișiere vă permite să vă împărțiți dosarul Public cu alții pe "
-"rețeaua curentă utilizând: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:702
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Când autentificarea la distanță este activată, utilizatorii de la distanță "
-"se pot conecta utilizând comanda Secure Shell:\n"
-"%s"
-
-#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:708
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to %s"
-msgstr ""
-"Partajarea ecranului permite utilizatorilor de la distanță să vizualizeze "
-"sau să controleze ecranul prin conectarea la %s"
-
-#: panels/sharing/cc-sharing-panel.c:813
-msgid "Copy"
-msgstr "Copiere"
-
-#: panels/sharing/cc-sharing-panel.c:1203
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Partajare"
 
-#: panels/sharing/cc-sharing-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:31
 msgid "_Computer Name"
 msgstr "Nume _calculator"
 
-#: panels/sharing/cc-sharing-panel.ui:79
+#: panels/sharing/cc-sharing-panel.ui:58
 msgid "_File Sharing"
 msgstr "Partajare _fișiere"
 
-#: panels/sharing/cc-sharing-panel.ui:87
-msgid "_Screen Sharing"
-msgstr "Partajarea _ecranului"
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:95
+#: panels/sharing/cc-sharing-panel.ui:72
 msgid "_Media Sharing"
 msgstr "Partajare _media"
 
-#: panels/sharing/cc-sharing-panel.ui:103
+#: panels/sharing/cc-sharing-panel.ui:79
 msgid "_Remote Login"
 msgstr "Autentifica_re la distanță"
 
-#: panels/sharing/cc-sharing-panel.ui:119
-msgid "Some services are disabled because of no network access."
-msgstr "Unele servicii sunt dezactivate din lipsa accesului la rețea."
-
-#: panels/sharing/cc-sharing-panel.ui:137
-#: panels/sharing/cc-sharing-panel.ui:264
+#: panels/sharing/cc-sharing-panel.ui:92
 msgid "File Sharing"
 msgstr "Partajare fișiere"
 
-#: panels/sharing/cc-sharing-panel.ui:184
+#: panels/sharing/cc-sharing-panel.ui:138
 msgid "_Require Password"
 msgstr "Necesită o _parolă"
 
-#: panels/sharing/cc-sharing-panel.ui:275
-#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "Autentificare la distanță"
 
-#: panels/sharing/cc-sharing-panel.ui:368
-#: panels/sharing/cc-sharing-panel.ui:590
-msgid "Screen Sharing"
-msgstr "Partajarea ecranului"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Autentificare la distanță"
 
-#: panels/sharing/cc-sharing-panel.ui:422
-msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Activare sau dezactivare autentificare la distanță"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Permite control de la dist_anță"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
 msgstr "Permite conexiunilor să controleze ecr_anul"
 
-#: panels/sharing/cc-sharing-panel.ui:447
-msgid "_Password:"
-msgstr "_Parolă:"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Uită conexiunea"
 
-#: panels/sharing/cc-sharing-panel.ui:477
-msgid "_Show Password"
-msgstr "_Arată parola"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:508
-msgid "Access Options"
-msgstr "Opțiuni de acces"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Copiere"
 
-#: panels/sharing/cc-sharing-panel.ui:522
-msgid "_New connections must ask for access"
-msgstr "_Noile conexiuni trebuie să solicite accesul"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Șterge adresa"
 
-#: panels/sharing/cc-sharing-panel.ui:540
-msgid "_Require a password"
-msgstr "_Necesită parolă"
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Au_tentificare"
 
-#: panels/sharing/cc-sharing-panel.ui:601
-#: panels/sharing/cc-sharing-panel.ui:695
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Nume utilizator"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Amprentă"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Partajare fișiere"
 
-#: panels/sharing/cc-sharing-panel.ui:634
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Partajați muzică, fotografii și videouri prin rețea."
 
-#: panels/sharing/cc-sharing-panel.ui:649
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Dosare"
 
@@ -6195,7 +3668,6 @@ msgstr "Dosare"
 msgid "Control what you want to share with others"
 msgstr "Controlați ce partajați cu alții"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6214,99 +3686,97 @@ msgstr ""
 "Este necesară autentificarea pentru a permite sau dezactiva autentificarea "
 "la distanță"
 
-#: panels/sound/cc-alert-chooser.c:151
-msgid "Custom"
-msgstr "Personalizat"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Lătrat"
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
 
-#: panels/sound/cc-alert-chooser.ui:19
-msgid "Drip"
-msgstr "Susur"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Partajare"
 
-#: panels/sound/cc-alert-chooser.ui:26
-msgid "Glass"
-msgstr "Sticlă"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: panels/sound/cc-alert-chooser.ui:33
-msgid "Sonar"
-msgstr "Sonar"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
-msgid "Rear"
-msgstr "Spate"
-
-#: panels/sound/cc-fade-slider.ui:15
-msgid "Front"
-msgstr "Față"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Se testează %s"
-
-#: panels/sound/cc-output-test-dialog.ui:127
-msgid "Click a speaker to test"
-msgstr "Clic pe un difuzor pentru a-l testa"
-
-#: panels/sound/cc-sound-panel.ui:27
-msgid "System Volume"
-msgstr "Volumul sistemului"
-
-#: panels/sound/cc-sound-panel.ui:43
-msgid "Volume Levels"
-msgstr "Nivele de volum"
-
-#: panels/sound/cc-sound-panel.ui:63
-msgid "Output"
-msgstr "Ieșire"
-
-#: panels/sound/cc-sound-panel.ui:90
-msgid "Output Device"
-msgstr "Dispozitiv de ieșire"
-
-#: panels/sound/cc-sound-panel.ui:113
-msgid "Test"
-msgstr "Test"
-
-#: panels/sound/cc-sound-panel.ui:144 panels/sound/cc-sound-panel.ui:319
-msgid "Configuration"
-msgstr "Configurație"
-
-#: panels/sound/cc-sound-panel.ui:177
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 msgid "Balance"
 msgstr "Balanță"
 
-#: panels/sound/cc-sound-panel.ui:204
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 msgid "Fade"
 msgstr "Estompare"
 
-#: panels/sound/cc-sound-panel.ui:231
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Spate"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Față"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Clic pe un difuzor pentru a-l testa"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Volumul sistemului"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Volumul sistemului"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Nivele de volum"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Ieșire"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Dispozitiv de ieșire"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Test"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Configurație"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Subwoofer"
 
-#: panels/sound/cc-sound-panel.ui:251
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Intrare"
 
-#: panels/sound/cc-sound-panel.ui:278
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Dispozitiv de intrare"
 
-#: panels/sound/cc-sound-panel.ui:352
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Volum"
 
-#: panels/sound/cc-sound-panel.ui:372
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Sunet de alertă"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+#, fuzzy
+msgid "Mute"
+msgstr "_Mut"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6316,7 +3786,6 @@ msgstr "Sunet"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Schimbă nivelurile de sunet, intrările, ieșirile și sunetele de alertă"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6324,77 +3793,7 @@ msgstr ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Microfon;Căști;"
 "Volum;Balansat;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Deconectat"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Se conectează"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Conectat"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Eroare de autorizare"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Autorizare"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Funcționalitate redusă"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Conectat și autorizat"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Necunoscut"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr "Autorizat la:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-msgid "Connected at:"
-msgstr "Conectat la:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-msgid "Enrolled at:"
-msgstr "Înscris la:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-msgid "Failed to authorize device: "
-msgstr "Nu s-a putut autoriza dispozitivul: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-msgid "Failed to forget device: "
-msgstr "Nu s-a putut uita dispozitivul: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
@@ -6402,87 +3801,56 @@ msgstr[0] "Depinde de un alt dispozitiv"
 msgstr[1] "Depinde de %u alte dispozitive"
 msgstr[2] "Depinde de %u alte dispozitive"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Notificări"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Nume:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Stare:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Autorizează și conectează"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Uită dispozitivul"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Eroare"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Autorizat"
-
-#: panels/thunderbolt/cc-bolt-panel.c:175
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Subsistemul Thunderbolt (boltd) nu este instalat sau configurat corect."
-
-#: panels/thunderbolt/cc-bolt-panel.c:468
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Nu s-a putut detecta Thunderbolt.\n"
-"Fie sistemul nu are suport pentru Thunderbolt, a fost dezactivat în BIOS sau "
-"este stabilit la un nivel de securitate nesuportat în BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:512
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Suportul pentru Thunderbolt a fost dezactivat în BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:516
-msgid "Thunderbolt security level could not be determined."
-msgstr "Nivelul de securitate Thunderbolt nu a putut fi determinat."
-
-#: panels/thunderbolt/cc-bolt-panel.c:621
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Eroare la comutarea modului direct: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+#, fuzzy
+msgid "No Thunderbolt Support"
 msgstr "Nu este suport pentru Thunderbolt"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:246
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Nu se poate realiza conectarea la domeniul %s: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Acces direct"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 "Permite accesul direct la dispozitive precum docurile și GPU-urile externe."
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr "Doar dispozitivele USB sau port de afișaj pot atașa."
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Dispozitive în așteptare"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Nu sunt dispozitive atașate"
 
@@ -6494,400 +3862,327 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Administrează dispozitive Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;confidențialitate;"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:7
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 msgid "Cursor Blinking"
 msgstr "Cursor clipitor"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:37
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Cursorul clipește în câmpuri de text."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:74
-#: panels/universal-access/cc-repeat-keys-dialog.ui:145
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Viteză"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:101
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Viteza de clipire a cursorului"
 
-#: panels/universal-access/cc-cursor-size-dialog.ui:7
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr "Dimensiunea cursorului"
 
-#: panels/universal-access/cc-cursor-size-dialog.ui:29
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 "Dimensiunea cursorului poate fi combinată cu zoom pentru a face ecranul mai "
 "lizibil."
 
-#: panels/universal-access/cc-pointing-dialog.ui:7
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "Asistență la clic"
 
-#: panels/universal-access/cc-pointing-dialog.ui:43
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "Clic secundar _simulat"
 
-#: panels/universal-access/cc-pointing-dialog.ui:56
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr ""
 "Declanșează un clic secundar în timp ce este menținut butonul principal"
 
-#: panels/universal-access/cc-pointing-dialog.ui:79
-#: panels/universal-access/cc-typing-dialog.ui:158
-#: panels/universal-access/cc-typing-dialog.ui:307
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
 msgid "A_cceptance delay:"
 msgstr "Întârziere a_cceptată:"
 
-#: panels/universal-access/cc-pointing-dialog.ui:95
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Scurtă"
 
-#: panels/universal-access/cc-pointing-dialog.ui:110
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "Întârziere pentru clic secundar"
 
-#: panels/universal-access/cc-pointing-dialog.ui:120
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Lungă"
 
-#: panels/universal-access/cc-pointing-dialog.ui:157
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "_Clic plutitor"
 
-#: panels/universal-access/cc-pointing-dialog.ui:170
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "Declanșează un clic când se oprește mișcarea cursorului"
 
-#: panels/universal-access/cc-pointing-dialog.ui:193
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "Întârzi_ere:"
 
-#: panels/universal-access/cc-pointing-dialog.ui:210
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Scurtă"
 
-#: panels/universal-access/cc-pointing-dialog.ui:232
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Lungă"
 
-#: panels/universal-access/cc-pointing-dialog.ui:253
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "_Prag de mișcare:"
 
-#: panels/universal-access/cc-pointing-dialog.ui:270
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Mică"
 
-#: panels/universal-access/cc-pointing-dialog.ui:292
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Mare"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:7
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
 msgid "Repeat Keys"
 msgstr "Repetare taste"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:37
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Tastele apăsate se repetă până la eliberare."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:102
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Întârziere la repetarea tastelor"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:174
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Viteză repetare taste"
 
-#: panels/universal-access/cc-sound-keys-dialog.ui:7
-msgid "Sound Keys"
-msgstr "Taste sonor"
-
-#: panels/universal-access/cc-sound-keys-dialog.ui:25
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr ""
-"Alertează atunci când Num Lock sau Caps Lock sunt activate sau dezactivate."
-
-#: panels/universal-access/cc-sound-keys-dialog.ui:45
-#: panels/universal-access/cc-ua-panel.ui:412
-msgid "_Sound Keys"
-msgstr "Taste pentru control _sunet"
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:7
-msgid "Screen Reader"
-msgstr "Cititor de ecran"
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:24
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr ""
-"Cititorul de ecran citește textul afișat în timp ce mutați focalizarea."
-
-#: panels/universal-access/cc-screen-reader-dialog.ui:52
-msgid "_Screen Reader"
-msgstr "Citit_or de ecran"
-
-#: panels/universal-access/cc-typing-dialog.ui:7
+#: panels/universal-access/cc-typing-dialog.ui:4
 msgid "Typing Assist"
 msgstr "Asistență la tastare"
 
-#: panels/universal-access/cc-typing-dialog.ui:46
+#: panels/universal-access/cc-typing-dialog.ui:41
 msgid "_Sticky Keys"
 msgstr "Taste lipicioa_se"
 
-#: panels/universal-access/cc-typing-dialog.ui:58
+#: panels/universal-access/cc-typing-dialog.ui:51
 msgid "Treats a sequence of modifier keys as a key combination"
 msgstr "Tratează o secvență de taste modificatoare ca o combinație de taste"
 
-#: panels/universal-access/cc-typing-dialog.ui:72
+#: panels/universal-access/cc-typing-dialog.ui:63
 msgid "_Disable if two keys are pressed together"
 msgstr "_Dezactivează dacă două taste sunt apăsate concomitent"
 
-#: panels/universal-access/cc-typing-dialog.ui:85
+#: panels/universal-access/cc-typing-dialog.ui:71
 msgid "Beep when a _modifier key is pressed"
 msgstr "Bipăie când e apăsată o tastă _modificatoare"
 
-#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:96
 msgid "S_low Keys"
 msgstr "Taste _lente"
 
-#: panels/universal-access/cc-typing-dialog.ui:135
+#: panels/universal-access/cc-typing-dialog.ui:106
 msgid "Puts a delay between when a key is pressed and when it is accepted"
 msgstr ""
 "Introduce o întârziere între momentul în care o tastă este apăsată și cel în "
 "care este acceptată"
 
-#: panels/universal-access/cc-typing-dialog.ui:175
+#: panels/universal-access/cc-typing-dialog.ui:135
 msgctxt "slow keys delay"
 msgid "Short"
 msgstr "Scurtă"
 
-#: panels/universal-access/cc-typing-dialog.ui:190
+#: panels/universal-access/cc-typing-dialog.ui:147
 msgid "Slow keys typing delay"
 msgstr "Întârziere pentru taste încete"
 
-#: panels/universal-access/cc-typing-dialog.ui:200
+#: panels/universal-access/cc-typing-dialog.ui:154
 msgctxt "slow keys delay"
 msgid "Long"
 msgstr "Lungă"
 
-#: panels/universal-access/cc-typing-dialog.ui:212
+#: panels/universal-access/cc-typing-dialog.ui:166
 msgid "Beep when a key is pr_essed"
 msgstr "Bipăi_e la apăsarea unei taste"
 
-#: panels/universal-access/cc-typing-dialog.ui:224
+#: panels/universal-access/cc-typing-dialog.ui:173
 msgid "Beep when a key is _accepted"
 msgstr "Bipăie când e _acceptată o tastă"
 
-#: panels/universal-access/cc-typing-dialog.ui:236
-#: panels/universal-access/cc-typing-dialog.ui:361
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
 msgid "Beep when a key is _rejected"
 msgstr "Bipăie dacă o tastă este _respinsă"
 
-#: panels/universal-access/cc-typing-dialog.ui:272
+#: panels/universal-access/cc-typing-dialog.ui:203
 msgid "_Bounce Keys"
 msgstr "Taste fără re_petiție"
 
-#: panels/universal-access/cc-typing-dialog.ui:284
+#: panels/universal-access/cc-typing-dialog.ui:213
 msgid "Ignores fast duplicate keypresses"
 msgstr "Ignoră apăsările repetate și rapide de taste"
 
-#: panels/universal-access/cc-typing-dialog.ui:324
+#: panels/universal-access/cc-typing-dialog.ui:242
 msgctxt "bounce keys delay"
 msgid "Short"
 msgstr "Scurtă"
 
-#: panels/universal-access/cc-typing-dialog.ui:339
+#: panels/universal-access/cc-typing-dialog.ui:254
 msgid "Bounce keys typing delay"
 msgstr "Întârziere pentru taste săritoare"
 
-#: panels/universal-access/cc-typing-dialog.ui:349
+#: panels/universal-access/cc-typing-dialog.ui:261
 msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Lungă"
 
-#: panels/universal-access/cc-typing-dialog.ui:437
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "Activ_ează cu tastatura"
 
-#: panels/universal-access/cc-typing-dialog.ui:449
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr ""
 "Activează și dezactivează opțiunile de accesibilitate folosind tastatura"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:351
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Implicită"
-
-#: panels/universal-access/cc-ua-panel.c:354
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Medie"
-
-#: panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Mare"
-
-#: panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Mai mare"
-
-#: panels/universal-access/cc-ua-panel.c:363
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Cel mai mare"
-
-#: panels/universal-access/cc-ua-panel.c:367
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixel"
-msgstr[1] "%d pixeli"
-msgstr[2] "%d de pixeli"
-
-#: panels/universal-access/cc-ua-panel.ui:55
+#: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Arată întotdeauna meniul de accesibilitate"
 
-#: panels/universal-access/cc-ua-panel.ui:97
+#: panels/universal-access/cc-ua-panel.ui:31
 msgid "Seeing"
 msgstr "Văz"
 
-#: panels/universal-access/cc-ua-panel.ui:143
+#: panels/universal-access/cc-ua-panel.ui:34
 msgid "_High Contrast"
 msgstr "_Contrast ridicat"
 
-#: panels/universal-access/cc-ua-panel.ui:190
+#: panels/universal-access/cc-ua-panel.ui:46
 msgid "_Large Text"
 msgstr "_Text mărit"
 
-#: panels/universal-access/cc-ua-panel.ui:238
+#: panels/universal-access/cc-ua-panel.ui:58
 msgid "Enable A_nimations"
 msgstr "Activează a_nimații"
 
-#: panels/universal-access/cc-ua-panel.ui:273
-msgid "C_ursor Size"
-msgstr "Dimenisunea c_ursorului"
-
-#: panels/universal-access/cc-ua-panel.ui:320
-#: panels/universal-access/cc-zoom-options-dialog.ui:91
-msgid "_Zoom"
-msgstr "_Zoom"
-
-#: panels/universal-access/cc-ua-panel.ui:366
+#: panels/universal-access/cc-ua-panel.ui:70
 msgid "Screen _Reader"
 msgstr "Cititor de ec_ran"
 
-#: panels/universal-access/cc-ua-panel.ui:474
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Cititorul de ecran citește textul afișat în timp ce mutați focalizarea."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Taste pentru control _sunet"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Alertează atunci când Num Lock sau Caps Lock sunt activate sau dezactivate."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Dimenisunea c_ursorului"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:138
 msgid "Hearing"
 msgstr "Auz"
 
-#: panels/universal-access/cc-ua-panel.ui:518
-#: panels/universal-access/cc-visual-alerts-dialog.ui:68
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
 msgid "_Visual Alerts"
 msgstr "Alerte _vizuale"
 
-#: panels/universal-access/cc-ua-panel.ui:626
+#: panels/universal-access/cc-ua-panel.ui:166
 msgid "Screen _Keyboard"
 msgstr "Tastatura pe ecra_n"
 
-#: panels/universal-access/cc-ua-panel.ui:671
+#: panels/universal-access/cc-ua-panel.ui:178
 msgid "R_epeat Keys"
 msgstr "R_epetare taste"
 
-#: panels/universal-access/cc-ua-panel.ui:717
+#: panels/universal-access/cc-ua-panel.ui:198
 msgid "Cursor _Blinking"
 msgstr "Cursor _clipitor"
 
-#: panels/universal-access/cc-ua-panel.ui:763
+#: panels/universal-access/cc-ua-panel.ui:218
 msgid "_Typing Assist (AccessX)"
 msgstr "Asistență la tastare (Acces_X)"
 
-#: panels/universal-access/cc-ua-panel.ui:824
-msgid "Pointing & Clicking"
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
 msgstr "Cursor și maus"
 
-#: panels/universal-access/cc-ua-panel.ui:870
+#: panels/universal-access/cc-ua-panel.ui:243
 msgid "_Mouse Keys"
 msgstr "Taste _Maus"
 
-#: panels/universal-access/cc-ua-panel.ui:915
+#: panels/universal-access/cc-ua-panel.ui:255
 msgid "_Locate Pointer"
 msgstr "_Localizează indicatorul"
 
-#: panels/universal-access/cc-ua-panel.ui:947
+#: panels/universal-access/cc-ua-panel.ui:267
 msgid "_Click Assist"
 msgstr "Asistență la _clic"
 
-#: panels/universal-access/cc-ua-panel.ui:993
+#: panels/universal-access/cc-ua-panel.ui:287
 msgid "_Double-Click Delay"
 msgstr "Întârziere pentru clic-_dublu"
 
-#: panels/universal-access/cc-ua-panel.ui:1013
+#: panels/universal-access/cc-ua-panel.ui:297
 msgid "Double-Click Delay"
 msgstr "Întârziere pentru clic-dublu"
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:15
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
 msgid "Visual Alerts"
 msgstr "Alerte vizuale"
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:19
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
 msgid "_Test flash"
 msgstr "_Testare flash"
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:48
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
 msgid "Use a visual indication when an alert sound occurs."
 msgstr "Folosește indicarea vizuală atunci când se produce o alertă sonoră."
 
-#: panels/universal-access/cc-visual-alerts-dialog.ui:94
-msgid "Flash the entire _window"
-msgstr "Clipește întreaga _fereastră"
-
-#: panels/universal-access/cc-visual-alerts-dialog.ui:112
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
 msgid "Flash the entire _screen"
 msgstr "Clipește între_g ecranul"
 
-#: panels/universal-access/cc-zoom-options-dialog.c:303
-msgctxt "Distance"
-msgid "Short"
-msgstr "Scurtă"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:304
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ de ecran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:305
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ de ecran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ de ecran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "Long"
-msgstr "Lungă"
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Clipește întreaga _fereastră"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6909,134 +4204,134 @@ msgstr "Jumătatea stângă"
 msgid "Right Half"
 msgstr "Jumătatea dreaptă"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:70
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "Opțiuni zoom"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:151
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
 msgstr "_Mărire:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:201
-msgid "_Follow mouse cursor"
-msgstr "_Urmărește cursorul mausului"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:221
-msgid "_Screen part:"
-msgstr "Parte _ecran:"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:278
-msgid "Magnifier _extends outside of screen"
-msgstr "Lupa se _extinde peste marginile ecranului"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:292
-msgid "_Keep magnifier cursor centered"
-msgstr "_Păstrează centrat cursorul lupei"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:307
-msgid "Magnifier cursor _pushes contents around"
-msgstr "Cursorul lupei îm_pinge conținutul"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:322
-msgid "Magnifier cursor moves with _contents"
-msgstr "Cursorul lupei se mișcă odată cu _conținutul"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:347
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "Poziție lupă:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:362
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Urmărește cursorul mausului"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Parte _ecran:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Lupa se _extinde peste marginile ecranului"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Păstrează centrat cursorul lupei"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Cursorul lupei îm_pinge conținutul"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Cursorul lupei se mișcă odată cu _conținutul"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Lupă"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:410
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "Țin_tă:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Suprapune peste curs_orul mausului"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
 msgstr "_Grosime:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:436
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "Subțire"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:458
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Gros"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:479
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
 msgstr "_Lungime:"
 
 #. The color of the accessibility crosshair
-#: panels/universal-access/cc-zoom-options-dialog.ui:523
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
 msgstr "Cu_loare:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:577
-msgid "_Crosshairs:"
-msgstr "Țin_tă:"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:610
-msgid "_Overlaps mouse cursor"
-msgstr "Suprapune peste curs_orul mausului"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:634
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "Țintă"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:683
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Efecte de culoare:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
 msgstr "_Alb pe negru:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:703
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
 msgstr "_Luminozitate:"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:724
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
 msgstr "_Contrast:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/cc-zoom-options-dialog.ui:744
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
 msgid "Co_lor"
 msgstr "Cu_loare"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:769
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Niciuna"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:791
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Completă"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:844
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Scăzută"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:867
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Ridicată"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:893
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Scăzut"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:916
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Ridicat"
 
-#: panels/universal-access/cc-zoom-options-dialog.ui:942
-msgid "Color Effects:"
-msgstr "Efecte de culoare:"
-
-#: panels/universal-access/cc-zoom-options-dialog.ui:958
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "Efecte de culoare"
 
@@ -7045,13 +4340,13 @@ msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
 "Facilitează vederea, auzul, tastatul, mutatul mausului și apăsarea clicului"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
 "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
-"audio;typing;"
+"audio;typing;animations;"
 msgstr ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
@@ -7061,35 +4356,11 @@ msgstr ""
 "repetiție;dublu;clic;amânare;viteză;asistență;repetă;clipește;vizual;auz;"
 "tastare;"
 
-#: panels/usage/cc-usage-panel.c:154
-msgid "Empty all items from Trash?"
-msgstr "Golește coșul de gunoi?"
-
-#: panels/usage/cc-usage-panel.c:155
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Toate elementele din coșul de gunoi vor fi șterse permanent."
-
-#: panels/usage/cc-usage-panel.c:156
-msgid "_Empty Trash"
-msgstr "Gol_ește gunoiul"
-
-#: panels/usage/cc-usage-panel.c:177
-msgid "Delete all the temporary files?"
-msgstr "Șterge toate fișierele temporare?"
-
-#: panels/usage/cc-usage-panel.c:178
-msgid "All the temporary files will be permanently deleted."
-msgstr "Toate fișierele temporare vor fi șterse permanent."
-
-#: panels/usage/cc-usage-panel.c:179
-msgid "_Purge Temporary Files"
-msgstr "Șterge fișierele tem_porare"
-
-#: panels/usage/cc-usage-panel.ui:29
+#: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
 msgstr "Istoric fișiere"
 
-#: panels/usage/cc-usage-panel.ui:41
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
 "File history keeps a record of files that you have used. This information is "
 "shared between applications, and makes it easier to find files that you "
@@ -7099,23 +4370,24 @@ msgstr ""
 "utilizat. Aceste informații sunt partajate între aplicații, și face mai ușor "
 "găsirea fișierelor pe care poate doriți să le utilizați."
 
-#: panels/usage/cc-usage-panel.ui:56
+#: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
 msgstr "Istoric f_ișiere"
 
-#: panels/usage/cc-usage-panel.ui:78
+#: panels/usage/cc-usage-panel.ui:25
 msgid "File _History Duration"
 msgstr "Durata _istoricului fișierelor"
 
-#: panels/usage/cc-usage-panel.ui:119
+#: panels/usage/cc-usage-panel.ui:48
 msgid "_Clear History…"
 msgstr "_Curăță istoricul…"
 
-#: panels/usage/cc-usage-panel.ui:135
-msgid "Trash & Temporary Files"
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
 msgstr "Gunoi și fișiere temporare"
 
-#: panels/usage/cc-usage-panel.ui:145
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
@@ -7124,109 +4396,25 @@ msgstr ""
 "sau senzitive. Ștergerea lor automată poate ajuta să vă protejați "
 "confidențialitatea."
 
-#: panels/usage/cc-usage-panel.ui:159
+#: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
 msgstr "Șterge automat conținutul _gunoiului"
 
-#: panels/usage/cc-usage-panel.ui:174
+#: panels/usage/cc-usage-panel.ui:79
 msgid "Automatically Delete Temporary _Files"
 msgstr "Șterge automat _fișierele temporare"
 
-#: panels/usage/cc-usage-panel.ui:196
+#: panels/usage/cc-usage-panel.ui:91
 msgid "Automatically Delete _Period"
 msgstr "_Perioadă pentru ștergerea automată"
 
-#: panels/usage/cc-usage-panel.ui:238
+#: panels/usage/cc-usage-panel.ui:115
 msgid "_Empty Trash…"
 msgstr "Gol_ește gunoiul…"
 
-#: panels/usage/cc-usage-panel.ui:250
+#: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
 msgstr "Ș_terge fișierele temporare…"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:278
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "o oră"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:282
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "o zi"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:286
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "două zile"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:290
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 zile"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:294
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 zile"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:298
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 zile"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:302
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 zile"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:306
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 zile"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:310
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 zile"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/usage/cc-usage-panel.ui:314
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 de zile"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:329
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "o zi"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:333
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 zile"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:337
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 de zile"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/usage/cc-usage-panel.ui:341
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Pentru totdeauna"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
@@ -7236,93 +4424,58 @@ msgstr "Gunoi și istoricul fișierelor"
 msgid "Don't leave traces"
 msgstr "Nu lăsa urme"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "Trebuie să potriviți adresele web a furnizorului de logare."
-
-#: panels/user-accounts/cc-add-user-dialog.c:204
-msgid "Failed to add account"
-msgstr "Eșec la adăugarea contului"
-
-#: panels/user-accounts/cc-add-user-dialog.c:661
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "Parolele nu se potrivesc."
-
-#: panels/user-accounts/cc-add-user-dialog.c:875
-#: panels/user-accounts/cc-add-user-dialog.c:914
-#: panels/user-accounts/cc-add-user-dialog.c:932
-msgid "Failed to register account"
-msgstr "Eșec la înregistrarea contului"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1047
-msgid "No supported way to authenticate with this domain"
-msgstr "Nici o metodă suportată pentru autentificarea cu acest domeniu"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1111
-msgid "Failed to join domain"
-msgstr "Eșec la înregistrarea domeniului"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1166
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Numele de autentificare nu a funcționat.\n"
-"Încercați din nou."
 
-#: panels/user-accounts/cc-add-user-dialog.c:1173
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Parola de autentificare nu a funcționat.\n"
-"Încercați din nou."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid "Failed to log into domain"
-msgstr "Eșec la conectarea în domeniu"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1236
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Nu se poate găsi domeniul. Poate l-ați scris greșit?"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Adaugă utilizator"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr "Nume _complet"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-msgid "Standard"
-msgstr "Standard"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "Administrator"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-msgid "Account _Type"
-msgstr "_Tip cont"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+#, fuzzy
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administratorii pot adăuga sau elimina alți utilizatori, și pot modifica "
+"configurări pentru toți utilizatorii."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-msgid "Allow user to set a password when they next _login"
-msgstr "Permite stabilirea unei parole folosită la următoarea _autentificare"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Permite utilizatorului să-și schimbe parola la următoarea logare"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
-msgid "Set a password _now"
-msgstr "Definește o parolă acu_m"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Definește o parolă nouă"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "_Confirmă"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "Autentificare _enterprise"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Sunteți deconectat"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7332,28 +4485,7 @@ msgstr ""
 "să fie folosit pe acest dispozitiv. Puteți folosi acest cont pentru a accesa "
 "resursele companiei de pe internet."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:732
-msgid "You are Offline"
-msgstr "Sunteți deconectat"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-msgid "You must be online in order to add enterprise users."
-msgstr ""
-"Trebuie să fiți conectat la internet pentru a adăuga utilizatori enterprise."
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "Autentificare _enterprise"
-
-#: panels/user-accounts/cc-avatar-chooser.c:225
-msgid "Browse for more pictures"
-msgstr "Răsfoiește pentru mai multe imagini"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:39
-msgid "Take a Picture…"
-msgstr "Faceți o fotografie…"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:46
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "Selectați un fișier…"
 
@@ -7361,19 +4493,19 @@ msgstr "Selectați un fișier…"
 msgid "Fingerprint Manager"
 msgstr "Administrator de amprente"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:23
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
 msgid "Fingerprint"
 msgstr "Amprentă"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:118
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_Nu"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:128
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Da"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:155
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7381,28 +4513,32 @@ msgstr ""
 "Doriți să ștergeți amprentele înregistrate astfel încât autentificarea pe "
 "bază de amprente să fie dezactivată?"
 
-#. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
-msgid "No Fingerprint device"
-msgstr "Niciun dispozitiv de amprente"
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:259
-msgid "Ensure the device is properly connected."
-msgstr "Asigurați-vă că dispozitivul este conectat corespunzător."
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:264
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Niciun dispozitiv de amprente"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:280
-msgid "Choose the fingerprint device you want to configure"
-msgstr "Alegeți un dispozitiv pentru amprente pentru configurare"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Niciun dispozitiv de amprente"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:309
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Asigurați-vă că dispozitivul este conectat corespunzător."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Dispozitiv de amprente"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:322
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Alegeți un dispozitiv pentru amprente pentru configurare"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Autentificare prin amprentă"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7410,452 +4546,107 @@ msgstr ""
 "Autentificarea cu amprentă vă permite să deblocați și să vă autentificați la "
 "calculator cu degetul"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:352
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "Ș_terge amprentele"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:363
-msgid "Fingerprint Login"
-msgstr "Autentificare prin amprentă"
-
-#: panels/user-accounts/cc-fingerprint-dialog.ui:412
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Înregistrarea amprentei"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:436
-msgid "_Re-enroll this finger…"
-msgstr "_Re-înregistrați acest deget…"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Piesa precedentă"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:236
-msgid "the device needs to be claimed to perform this action"
-msgstr ""
-"dispozitivul trebuie să fie revendicat pentru a executa această acțiune"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "_Următorul"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:238
-msgid "the device is already claimed by another process"
-msgstr "dispozitivul este revendicat deja de către alt proces"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:240
-msgid "you do not have permission to perform the action"
-msgstr "nu aveți permisiune pentru a executa această acțiune"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:242
-msgid "no prints have been enrolled"
-msgstr "nu a fost înscrisă nicio tipărire"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:251
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Comunicarea nu a reușit cu dispozitivul în timpul înscrierii"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:255
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Comunicarea nu a reușit cu cititorul de amprente"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:257
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Comunicarea nu a reușit cu serviciul de amprente"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:585
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Eșec la listarea amprentelor: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:652
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Eșec la ștergerea amprentelor salvate: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:683
-msgid "Left thumb"
-msgstr "Degetul mare stâng"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:685
-msgid "Left middle finger"
-msgstr "Degetul mijlociu stâng"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:687
-msgid "_Left index finger"
-msgstr "Arătătoru_l mâinii stângi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:689
-msgid "Left ring finger"
-msgstr "Degetul inelar stâng"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:691
-msgid "Left little finger"
-msgstr "Degetul mic stâng"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:693
-msgid "Right thumb"
-msgstr "Degetul mare drept"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:695
-msgid "Right middle finger"
-msgstr "Degetul mijlociu drept"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:697
-msgid "_Right index finger"
-msgstr "Arătătorul mâinii d_repte"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:699
-msgid "Right ring finger"
-msgstr "Degetul inelar drept"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:701
-msgid "Right little finger"
-msgstr "Degetul mic drept"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:703
-msgid "Unknown Finger"
-msgstr "Deget necunoscut"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:837
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Complet"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:848
-msgid "Fingerprint device disconnected"
-msgstr "Dispozitivul de amprente este deconectat"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:854
-msgid "Fingerprint device storage is full"
-msgstr "Dispozitivul de stocare amprente este plin"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:858
-msgid "Failed to enroll new fingerprint"
-msgstr "Eșec la înregistrarea noii amprente"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:889
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Eșec la pornirea înregistrării: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:897
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Eșec la înregistrarea noii amprente"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Eșec la oprirea înregistrării: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:974
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Ridicați și plasați degetul pe cititor în mod repetat pentru a vă înregistra "
-"amprenta"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1118
-msgid "Scan new fingerprint"
-msgstr "Scanați amprentă nouă"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1157
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Eșec la detașarea dispozitivului de amprente %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1229
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problemă la citirea dispozitiivului"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1264
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Eșec la asumarea dispozitivului de amprente %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1413
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Eșec la obținerea dispozitivelor de amprente: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "Această săptămână"
-
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
-msgstr "Săptămâna trecută"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:771
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:775
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr "Sesiune terminată"
-
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr "Sesiunea a început"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Activitatea contului"
-
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr "Alegeți altă parolă."
-
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
-msgstr "Tastează parola curentă încă o dată."
-
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
-msgstr "Parola nu a putut fi schimbată"
-
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Schimbă parola"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "_Schimbă"
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr "_Confirmare parolă nouă"
-
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr "Parola _nouă"
-
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "_Parola curentă"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Parola _nouă"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "_Confirmare parolă nouă"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Parolele nu se potrivesc."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Permite utilizatorului să-și schimbe parola la următoarea logare"
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Definește o parolă nouă"
 
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Nu se poate conecta automat la acest tip de domeniu"
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Utilizatori"
 
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Nu este găsit niciun domeniu și nicio valoare reală"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Nu se poate realiza conectarea ca %s în domeniul %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Parola nu este validă, încercați din nou"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Nu se poate realiza conectarea la domeniul %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:222
-msgid "Your account"
-msgstr "Contul tău"
-
-#: panels/user-accounts/cc-user-panel.c:402
-msgid "Failed to delete user"
-msgstr "Ștergerea utilizatorului a eșuat"
-
-#: panels/user-accounts/cc-user-panel.c:457
-#: panels/user-accounts/cc-user-panel.c:512
-#: panels/user-accounts/cc-user-panel.c:558
-msgid "Failed to revoke remotely managed user"
-msgstr "A eșuat eliminarea utilizatorului gestionat la distanță"
-
-#: panels/user-accounts/cc-user-panel.c:607
-msgid "You cannot delete your own account."
-msgstr "Nu vă puteți șterge propriul cont."
-
-#: panels/user-accounts/cc-user-panel.c:616
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s este încă autentificat"
-
-#: panels/user-accounts/cc-user-panel.c:620
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Ștergerea unui utilizator când acesta este încă autentificat poate aduce "
-"sistemul într-o stare inconsistentă."
-
-#: panels/user-accounts/cc-user-panel.c:629
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Doriți să păstrați fișierele lui %s?"
-
-#: panels/user-accounts/cc-user-panel.c:633
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Este posibil să păstrați dosarul personal, emailurile și fișierele temporare "
-"după ștergerea unui cont."
-
-#: panels/user-accounts/cc-user-panel.c:636
-msgid "_Delete Files"
-msgstr "Ș_terge fișierele"
-
-#: panels/user-accounts/cc-user-panel.c:637
-msgid "_Keep Files"
-msgstr "_Păstrează fișierele"
-
-#: panels/user-accounts/cc-user-panel.c:651
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Sigur doriți să eliminați contul %s gestionat de la distanță?"
-
-#: panels/user-accounts/cc-user-panel.c:655
-msgid "_Delete"
-msgstr "Ș_terge fișierele"
-
-#: panels/user-accounts/cc-user-panel.c:705
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Cont dezactivat"
-
-#: panels/user-accounts/cc-user-panel.c:713
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Va fi definită la următoarea autentificare"
-
-#: panels/user-accounts/cc-user-panel.c:716
-msgctxt "Password mode"
-msgid "None"
-msgstr "Niciuna"
-
-#: panels/user-accounts/cc-user-panel.c:759
-msgid "Logged in"
-msgstr "Autentificat"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:846
-#: panels/user-accounts/cc-user-panel.c:935
-#: panels/wwan/cc-wwan-device-page.c:443
-msgid "Enabled"
-msgstr "Activat"
-
-#: panels/user-accounts/cc-user-panel.c:1259
-msgid "Failed to contact the accounts service"
-msgstr "Contactarea serviciului pentru conturi a eșuat"
-
-#: panels/user-accounts/cc-user-panel.c:1261
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Asigurați-vă că aplicația AccountService este corect instalată."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Pentru a face schimbări,\n"
-"apăsați întâi clic pe iconița *"
-
-#: panels/user-accounts/cc-user-panel.c:1366
-msgid "Delete the selected user account"
-msgstr "Șterge contul de utilizator selectat"
-
-#: panels/user-accounts/cc-user-panel.c:1378
-#: panels/user-accounts/cc-user-panel.c:1489
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Pentru a șterge un cont de utilizator,\n"
-"efectuați clic pe iconița *"
-
-#: panels/user-accounts/cc-user-panel.c:1535
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Deblocați pentru a adăuga utilizatori și schimba configurări"
-
-#: panels/user-accounts/cc-user-panel.ui:6
-msgid "_Add User…"
-msgstr "_Adaugă utilizator…"
-
-#: panels/user-accounts/cc-user-panel.ui:9
-msgid "Create a user account"
-msgstr "Creează un cont de utilizator"
-
-#: panels/user-accounts/cc-user-panel.ui:64
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "Sesiunea trebuie repornită pentru ca schimbările să aibă efect"
 
-#: panels/user-accounts/cc-user-panel.ui:72
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Repornește acum"
 
-#: panels/user-accounts/cc-user-panel.ui:157
-#: panels/user-accounts/cc-user-panel.ui:173
-msgid "User Icon"
-msgstr "Iconiță utilizator"
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Închide"
 
-#: panels/user-accounts/cc-user-panel.ui:249
-msgid "Account Settings"
-msgstr "Configurări cont"
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
 
-#: panels/user-accounts/cc-user-panel.ui:267
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Nume _complet"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Autenti_ficare cu amprentă digitală"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Autentificare a_utomată"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Activitate cont"
+
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Administrator"
 
-#: panels/user-accounts/cc-user-panel.ui:268
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7863,52 +4654,41 @@ msgstr ""
 "Administratorii pot adăuga sau elimina alți utilizatori, și pot modifica "
 "configurări pentru toți utilizatorii."
 
-#: panels/user-accounts/cc-user-panel.ui:284
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "Control _parental"
 
-#: panels/user-accounts/cc-user-panel.ui:285
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Deschide aplicația de Control parental."
 
-#: panels/user-accounts/cc-user-panel.ui:347
-msgid "Authentication & Login"
-msgstr "Autentificare și login"
-
-#: panels/user-accounts/cc-user-panel.ui:390
-msgid "_Fingerprint Login"
-msgstr "Autenti_ficare cu amprentă digitală"
-
-#: panels/user-accounts/cc-user-panel.ui:415
-msgid "A_utomatic Login"
-msgstr "Autentificare a_utomată"
-
-#: panels/user-accounts/cc-user-panel.ui:429
-msgid "Account Activity"
-msgstr "Activitate cont"
-
-#: panels/user-accounts/cc-user-panel.ui:460
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Șterge utilizator…"
 
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Alte fișiere"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "_Adaugă utilizator…"
+
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:501
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Nu au fost găsiți utilizatori"
 
-#: panels/user-accounts/cc-user-panel.ui:511
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Deblochează pentru a adăuga un cont de utilizator."
-
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
-msgid "Users"
-msgstr "Utilizatori"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "Adăugați și ștergeți utilizatori și schimbați parola"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7921,15 +4701,15 @@ msgstr ""
 "Copil;Copii;"
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "Înscr_ie"
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Conectare administrator domeniu"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -7939,11 +4719,11 @@ msgstr ""
 "acest calculator trebuie să fie înregistrat în domeniu. Cereți \n"
 " administratorului de rețea să scrie aici parola pentru domeniu."
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "_Nume administrator"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Parolă administrator"
 
@@ -7955,199 +4735,16 @@ msgstr "Administrare conturi de utilizator"
 msgid "Authentication is required to change user data"
 msgstr "Pentru modificarea datelor utilizatorilor trebuie să vă autentificați"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Noua parolă trebuie să fie diferită de parola veche."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Încercați să șchimbați unele litere sau numere."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Încercați să mai schimbați puțin parola."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "O parolă fără nume utilizator trebuie să fie mai puternică."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Încercați să evitați folosirea numelui în parolă."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Încercați să evitați unele cuvinte incluse în parolă."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Încercați să evitați cuvinte comune."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Încercați să evitați rearanjarea cuvintelor existente."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Încercați folosirea mai multor numere."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Încercați mai multe litere mari."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Încercați mai multe litere mici."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Încercați mai multe caractere speciale, cum ar fi punctuația."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Încercați o combinație de litere, numere și punctuație."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Evitați repetarea aceluiași caracter."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Evitați repetarea aceluiași top de caracter: trebuie să amestecați litere, "
-"numere și punctuație."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Evitați secvențele de top 1234 sau abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Parola trebuie să fie mai lungă. Adăugați mai multe litere, numere și semne "
-"de punctuație."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Amestecați literele mari și mici și folosiți unul sau două numere."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Adăugând mai multe litere, numere și semne de punctuație va face parola mai "
-"puternică."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Autentificarea a eșuat"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "Parola nouă este prea scurtă"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "Parola nouă este prea simplă"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Vechea și noua parolă sunt foarte asemănătoare"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Noua parolă a mai fost utilizată recent."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Noua parolă trebuie să conțină caractere numerice sau speciale"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Noua și vechea parolă sunt identice"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Vi s-a modificat parola de când v-ați autentificat!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Noua parolă nu conține suficiente caractere diferite"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Eroare necunoscută"
-
-#: panels/user-accounts/user-utils.c:432
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Numele de utilizator poate conține numai litere mari și mici de la a la z, "
-"cifre și următoarele caractere: - _"
-
-#: panels/user-accounts/user-utils.c:436
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Ne pare rău dar numele de utilizator nu este disponibil. Încercați altul."
-
-#: panels/user-accounts/user-utils.c:478
-msgid "The username is too long."
-msgstr "Numele utilizatorului este prea lung."
-
-#: panels/user-accounts/user-utils.c:537
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr ""
-"Aceasta va fi folosit pentru denumirea dosarului personal și nu poate fi "
-"modificat."
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Alocare butoane"
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "În_chide"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Alocare butoane pentru funcții"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -8155,7 +4752,11 @@ msgstr ""
 "Pentru a edita o scurtătură, clic pe rândul corespunzător și tastați o nouă "
 "scurtătură, sau apăsați „Backspace” pentru a o șterge."
 
-#: panels/wacom/calibrator/calibrator.ui:61
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "În_chide"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -8163,68 +4764,121 @@ msgstr ""
 "Apăsați pe zonele marcate în ordinea apariției pe ecran pentru a calibra "
 "tableta."
 
-#: panels/wacom/calibrator/calibrator.ui:78
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "S-a detectat un clic pierdut, se repornește…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Buton %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "Creează dispozitiv virtual"
 
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Definit de aplicație"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tabletă"
 
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Trimitere apăsare de tastă"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Comută monitorul"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Orientare pentru mâna stângă"
 
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Arată ajutorul pe ecran"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:245
-msgid "Output:"
-msgstr "Ieșire:"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Asociere la monitorul…"
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:257
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Păstrează raportul de aspect (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Proporție de aspect"
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:268
-msgid "Map to single monitor"
-msgstr "Asociază unui singur monitor"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
-msgstr "%d din %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Se calibrează…"
 
-#: panels/wacom/cc-wacom-page.c:516
-msgid "Display Mapping"
-msgstr "Afișează alocarea"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nu a fost detectată nicio tabletă"
 
-#: panels/wacom/cc-wacom-panel.c:725 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
-msgstr "Creion"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Conectați sau porniți tableta Wacom"
 
-#: panels/wacom/cc-wacom-stylus-page.c:357
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Presiune vârf"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Fină"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Puternică"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Buton"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Buton"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Buton"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Presiune radieră"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Presiune radieră"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Clic cu butonul din mijloc al mausului"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Clic cu butonul din dreapta al mausului"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Înainte"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr "Tabletă Wacom"
 
@@ -8234,296 +4888,136 @@ msgstr ""
 "Configurează funcțiile butoanelor și ajustează sensibilitatea creionului "
 "pentru tablete grafice"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tabletă;Wacom;Stylus;Radieră;Mouse;Maus;Creion;Stilou;"
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "Tabletă (absolut)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
-msgstr "Touchpad (relativ)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "Preferințe tabletă"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "A_jutor"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
-msgstr "Nu a fost detectată nicio tabletă"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Conectați sau porniți tableta Wacom"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
-msgstr "Configurări bluetooth"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
-msgstr "Mod de urmărire"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
-msgstr "Orientare pentru mâna stângă"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Clic secundar _simulat"
 
-#: panels/wacom/gnome-wacom-properties.ui:296
-#: panels/wacom/gnome-wacom-properties.ui:401
-msgid "Map to Monitor…"
-msgstr "Asociere la monitorul…"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Software Windows"
 
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
-msgstr "Alocare butoane…"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
-msgstr "Se calibrează…"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Toner puțin"
 
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
-msgstr "Configurări maus"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Secundar"
 
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
-msgstr "Ajustare rezoluție afișaj"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Software Windows"
 
-#: panels/wacom/gnome-wacom-properties.ui:376
-msgid "Decouple Display"
-msgstr "Decuplează afișajul"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+"Administrează preferințele pentru productivitate și efectuarea de sarcini "
+"multiple"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr "Scurtătură nouă…"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "Implicit"
-
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "Clic cu butonul din mijloc al mausului"
-
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "Clic cu butonul din dreapta al mausului"
-
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "Înainte"
-
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
-msgstr "Nu s-a găsit stylus"
-
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr "Mutați stylusul în proximitatea tabletei pentru a-l configura"
-
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
-msgstr "Presiune radieră"
-
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
-msgid "Soft"
-msgstr "Fină"
-
-#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
-msgid "Firm"
-msgstr "Puternică"
-
-#: panels/wacom/wacom-stylus-page.ui:234
-msgid "Top Button"
-msgstr "Buton superior"
-
-#: panels/wacom/wacom-stylus-page.ui:263
-msgid "Lower Button"
-msgstr "Buton inferior"
-
-#: panels/wacom/wacom-stylus-page.ui:292
-msgid "Lowest Button"
-msgstr "Buton inferior"
-
-#: panels/wacom/wacom-stylus-page.ui:321
-msgid "Tip Pressure Feel"
-msgstr "Presiune vârf"
-
-#: panels/wwan/cc-wwan-apn-dialog.ui:11
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Puncte de acces"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:160
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Adaugă"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Salvare"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
 
-#: panels/wwan/cc-wwan-data.c:543
-msgid "Operation Cancelled"
-msgstr "Operație anulată"
-
-#: panels/wwan/cc-wwan-data.c:546
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Eroare:</b> Accesul restricționat la modificarea configurărilor"
-
-#: panels/wwan/cc-wwan-data.c:549
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Eroare:</b> Eroare la echipamentul mobil"
-
-#: panels/wwan/cc-wwan-details-dialog.c:81
-msgid "Not Registered"
-msgstr "Neînregistrat"
-
-#: panels/wwan/cc-wwan-details-dialog.c:85
-msgid "Registered"
-msgstr "Înregistrat"
-
-#: panels/wwan/cc-wwan-details-dialog.c:89
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:93
-msgid "Searching"
-msgstr "Căutare"
-
-#: panels/wwan/cc-wwan-details-dialog.c:97
-msgid "Denied"
-msgstr "Refuzat"
-
-#: panels/wwan/cc-wwan-details-dialog.ui:4
+#: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
 msgstr "Detalii modem"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:33
+#: panels/wwan/cc-wwan-details-dialog.ui:16
 msgid "Modem Status"
 msgstr "Stare modem"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:53
+#: panels/wwan/cc-wwan-details-dialog.ui:25
 msgid "Carrier"
 msgstr "Furnizor"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:79
+#: panels/wwan/cc-wwan-details-dialog.ui:49
 msgid "Network Type"
 msgstr "Tip de rețea"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:131
+#: panels/wwan/cc-wwan-details-dialog.ui:97
 msgid "Network Status"
 msgstr "Starea rețelei"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:158
+#: panels/wwan/cc-wwan-details-dialog.ui:122
 msgid "Own Number"
 msgstr "Numărul propriu"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:185
+#: panels/wwan/cc-wwan-details-dialog.ui:151
 msgid "Device Details"
 msgstr "Detaliile dispozitivului"
 
-#: panels/wwan/cc-wwan-details-dialog.ui:257
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Producător"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Versiune firmware"
 
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Numai 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Numai 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Numai 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Preferat)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Preferat), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Preferat), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Preferat)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (Preferat), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Preferat)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (Preferat), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Preferat)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (Preferat), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Necunoscută"
-
-#: panels/wwan/cc-wwan-device-page.c:141
-msgid "Unlock SIM card"
-msgstr "Deblochează cardul SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:142 panels/wwan/cc-wwan-device-page.c:190
-msgid "Unlock"
-msgstr "Deblochează"
-
-#: panels/wwan/cc-wwan-device-page.c:147
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Oferiți codul PIN pentru SIM-ul %d"
-
-#: panels/wwan/cc-wwan-device-page.c:148
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Introduceți PIN-ul pentru a debloca cardul SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:152
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Oferiți codul PUK pentru SIM-ul %d"
-
-#: panels/wwan/cc-wwan-device-page.c:153
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Introduceți PUK-ul pentru a debloca cardul SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:171
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
 msgid "Wrong password entered. You have %1$u try left"
 msgid_plural "Wrong password entered. You have %1$u tries left"
@@ -8531,7 +5025,7 @@ msgstr[0] "Parola introdusă a fost greșită. Mai aveți %1$u încercare rămas
 msgstr[1] "Parola introdusă a fost greșită. Mai aveți %1$u încercări rămase"
 msgstr[2] "Parola introdusă a fost greșită. Mai aveți %1$u de încercări rămase"
 
-#: panels/wwan/cc-wwan-device-page.c:174
+#: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
@@ -8539,243 +5033,123 @@ msgstr[0] "Mai aveți %u încercare rămasă"
 msgstr[1] "Mai aveți %u încercări rămase"
 msgstr[2] "Mai aveți %u de încercări rămase"
 
-#: panels/wwan/cc-wwan-device-page.c:179
-msgid "Wrong password entered."
-msgstr "Parola introdusă a fost greșită."
-
-#: panels/wwan/cc-wwan-device-page.c:224
-msgid "PUK code should be an 8 digit number"
-msgstr "Codul PUK ar trebui să fie un număr natural de 8 cifre"
-
-#: panels/wwan/cc-wwan-device-page.c:248
-msgid "Enter New PIN"
-msgstr "Introduceți noul PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:252
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Codul PIN ar trebui să fie un număr natural de 4-8 cifre"
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "Unlocking..."
-msgstr "Se deblochează..."
-
-#: panels/wwan/cc-wwan-device-page.ui:34
+#: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
 msgstr "Niciun SIM"
 
-#: panels/wwan/cc-wwan-device-page.ui:45
+#: panels/wwan/cc-wwan-device-page.ui:19
 msgid "Insert a SIM card to use this modem"
 msgstr "Introduceți un card SIM pentru a utiliza acest modem"
 
-#: panels/wwan/cc-wwan-device-page.ui:78
+#: panels/wwan/cc-wwan-device-page.ui:33
 msgid "SIM Locked"
 msgstr "SIM blocat"
 
-#: panels/wwan/cc-wwan-device-page.ui:139
+#: panels/wwan/cc-wwan-device-page.ui:77
 msgid "_Mobile Data"
 msgstr "Date _mobile"
 
-#: panels/wwan/cc-wwan-device-page.ui:140
+#: panels/wwan/cc-wwan-device-page.ui:78
 msgid "Access data using mobile network"
 msgstr "Accesați datele utilizând o rețea mobilă"
 
-#: panels/wwan/cc-wwan-device-page.ui:151
+#: panels/wwan/cc-wwan-device-page.ui:88
 msgid "_Data Roaming"
 msgstr "Roaming de _date"
 
-#: panels/wwan/cc-wwan-device-page.ui:152
+#: panels/wwan/cc-wwan-device-page.ui:89
 msgid "Use mobile data when roaming"
 msgstr "Utilizați datele mobile în roaming"
 
-#: panels/wwan/cc-wwan-device-page.ui:177
+#: panels/wwan/cc-wwan-device-page.ui:115
 msgid "_Network Mode"
 msgstr "_Mod de rețea"
 
-#: panels/wwan/cc-wwan-device-page.ui:187
+#: panels/wwan/cc-wwan-device-page.ui:122
 msgid "N_etwork"
 msgstr "R_ețea"
 
-#: panels/wwan/cc-wwan-device-page.ui:199
+#: panels/wwan/cc-wwan-device-page.ui:132
 msgid "Advanced"
 msgstr "Avansate"
 
-#: panels/wwan/cc-wwan-device-page.ui:225
+#: panels/wwan/cc-wwan-device-page.ui:146
 msgid "_Access Point Names"
 msgstr "Nume puncte de _acces"
 
-#: panels/wwan/cc-wwan-device-page.ui:235
+#: panels/wwan/cc-wwan-device-page.ui:155
 msgid "_SIM Lock"
 msgstr "Blocare _SIM"
 
-#: panels/wwan/cc-wwan-device-page.ui:236
+#: panels/wwan/cc-wwan-device-page.ui:156
 msgid "Lock SIM with PIN"
 msgstr "Blochează SIM-ul cu un PIN"
 
-#: panels/wwan/cc-wwan-device-page.ui:246
+#: panels/wwan/cc-wwan-device-page.ui:165
 msgid "M_odem Details"
 msgstr "Detalii m_odem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Eșec telefon"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Nicio conexiune la telefon"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operația nu este permisă"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operația nu este suportată"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM-ul nu este inserat"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "PIN-ul SIM necesar"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "PUK-ul SIM necesar"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Eșec SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM ocupat"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Parolă incorectă"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "PIN2 SIM necesar"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "PUK2 SIM necesar"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Negăsit"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Nu este semnal de rețea"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Timp expirat"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Serviciile GPRS nu sunt permise"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming-ul nu este permis la această locație"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Eroare GPRS nespecificată"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "Acțiune anulată"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Acces refuzat"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Eroare necunoscută"
-
-#: panels/wwan/cc-wwan-mode-dialog.ui:4
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Mod de rețea"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:44
-#: panels/wwan/cc-wwan-network-dialog.ui:175
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:230
-msgid "_Set"
-msgstr "Stabilește"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:46 panels/wwan/cc-wwan-panel.ui:39
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:101
-msgid "Close"
-msgstr "Închide"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Automată"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:100
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Alegeți rețeaua"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:118
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Reîmprospătează Furnizorii de rețea"
 
-#: panels/wwan/cc-wwan-panel.c:453 panels/wwan/cc-wwan-panel.c:482
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
-
-#: panels/wwan/cc-wwan-panel.ui:101
-msgid "No WWAN Adapter Found"
-msgstr "Nu au fost găsit niciun adaptor WWAN"
-
-#: panels/wwan/cc-wwan-panel.ui:112
-msgid "Make sure you have a Wireless Wan/Cellular device"
-msgstr "Asigurați-vă că aveți un adaptor Wireless Wan/Dispozitiv celular"
-
-#: panels/wwan/cc-wwan-panel.ui:154
-msgid "Wireless Wan is disabled when airplane mode is on"
-msgstr "Wireless Wan este dezactivat când modul avion este pornit"
-
-#: panels/wwan/cc-wwan-panel.ui:163
-msgid "_Turn off Airplane Mode"
-msgstr "Î_nchide modul Avion"
-
-#: panels/wwan/cc-wwan-panel.ui:210
-msgid "Data Connection"
-msgstr "Conexiune de date"
-
-#: panels/wwan/cc-wwan-panel.ui:224
-msgid "SIM card used for internet"
-msgstr "Cartela SIM folosită pentru internet"
-
-#: panels/wwan/cc-wwan-panel.ui:332
+#: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "Activează rețeaua mobilă"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:11
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nu au fost găsit niciun adaptor WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Asigurați-vă că aveți un adaptor Wireless Wan/Dispozitiv celular"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Wireless Wan este dezactivat când modul avion este pornit"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Î_nchide modul Avion"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Conexiune de date"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Cartela SIM folosită pentru internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
 msgid "SIM Lock"
 msgstr "Blocare SIM"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:22
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
 msgid "_Next"
 msgstr "_Următorul"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:141
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "B_lochează SIM-ul cu un PIN"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:158
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "Schimbați PIN-ul"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:256
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr ""
 "Introduceți PIN-ul curent pentru a modifica configurările de blocare ale SIM-"
@@ -8789,73 +5163,44 @@ msgstr "Rețea mobilă"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Configurează Telefonia și conexiunile de date mobile"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/wwan/gnome-wwan-panel.desktop.in.in:17
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;wwan;telephony;sim;mobile;celular;telefonie;mobilă;"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Settings"
-msgstr "Configurări GNOME"
-
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
 msgstr "Utilitate de configurare pentru desktopul GNOME"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr "Configurări este interfața primară pentru a vă configura sistemul."
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:20
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "Proiectul Gnome"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Afișează număr versiune"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "Configurări pentru %s"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Activează modul volubil"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Caută un șir"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Listează nume posibile pentru panouri și apoi închide fereastra"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panou de afișat"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: shell/cc-panel-list.ui:45 shell/cc-window.c:275
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Confidențialitate"
 
-#: shell/cc-panel-loader.c:299
-msgid "Available panels:"
-msgstr "Panouri disponibile:"
-
-#: shell/cc-window.ui:136
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Toate configurările"
 
-#: shell/cc-window.ui:174
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr "Meniul principal"
 
-#: shell/cc-window.ui:318
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr "Avertisment: versiune de dezvoltare"
 
-#: shell/cc-window.ui:319
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
@@ -8865,14 +5210,9 @@ msgstr ""
 "dezvoltare. Este posibil să experimentați un comportament incorect al "
 "sistemului, pierderi de date, și alte probleme neașteptate. "
 
-#: shell/cc-window.ui:330
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Ajutor"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "Preferences;Settings;Preferințe;Configurări;"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -8904,6 +5244,10 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Anulează căutarea"
 
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;Preferințe;Configurări;"
+
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
 msgstr "Identificatorul ultimului panou de configurări de deschis"
@@ -8928,9 +5272,17 @@ msgstr ""
 "Dacă programul Configurări ar trebui să arate un avertisment când se rulează "
 "o versiune de dezvoltare."
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
@@ -8938,9 +5290,7 @@ msgstr[0] "o ieșire"
 msgstr[1] "%u ieșiri"
 msgstr[2] "%u de ieșiri"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
@@ -8948,9 +5298,3026 @@ msgstr[0] "o intrare"
 msgstr[1] "%u intrări"
 msgstr[2] "%u de intrări"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "Sunete de sistem"
+#~ msgid "System Bus"
+#~ msgstr "Magistrala sistemului"
+
+#~ msgid "Full access"
+#~ msgstr "Acces complet"
+
+#~ msgid "Session Bus"
+#~ msgstr "Magistrala sesiunilor"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Acces total la /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Are acces la rețea"
+
+#~ msgid "Home"
+#~ msgstr "Acasă"
+
+#~ msgid "Read-only"
+#~ msgstr "Doar citire"
+
+#~ msgid "Can change settings"
+#~ msgstr "Poate administra configurări"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s are următoarele permisiuni încorporate. Acestea nu pot fi modificate. "
+#~ "Dacă sunteți îngrijorat de aceste permisiuni, considerați eliminarea "
+#~ "acestei aplicații."
+
+#~ msgid "Web Links"
+#~ msgstr "Legături web"
+
+#~ msgid "Git Links"
+#~ msgstr "Legături git"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "Legături %s"
+
+#~ msgid "Unset"
+#~ msgstr "Nestabilit"
+
+#~ msgid "Links"
+#~ msgstr "Legături"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Fișiere hypertext"
+
+#~ msgid "Text Files"
+#~ msgstr "Fișiere text"
+
+#~ msgid "Image Files"
+#~ msgstr "Fișiere imagine"
+
+#~ msgid "Font Files"
+#~ msgstr "Fișiere font"
+
+#~ msgid "Archive Files"
+#~ msgstr "Arhivează fișiere"
+
+#~ msgid "Package Files"
+#~ msgstr "Împachetează fișiere"
+
+#~ msgid "Audio Files"
+#~ msgstr "Fișiere audio"
+
+#~ msgid "Video Files"
+#~ msgstr "Fișiere video"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Permisiuni și acces"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Datele și serviciile pentru care această aplicație a cerut acces la și "
+#~ "permisiunile pe care le necesită."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Nu poate fi modificată"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Permisiuni individuale pentru aplicații pot fi revizuite în configurările "
+#~ "de <a href=\"privacy\">Confidențialitate</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integrare"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Stabilește fundalul desktopului"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Operatori impliciți"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr ""
+#~ "Tipuri de fișiere și legături pe care această aplicație le deschide."
+
+#~ msgid "Usage"
+#~ msgstr "Utilizare"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Cât de multe resurse utilizează această aplicație."
+
+#~ msgid "Open in Software"
+#~ msgstr "Deschide în Aplicații"
+
+#~ msgid "Select a picture"
+#~ msgstr "Selectați o fotografie"
+
+#~ msgid "multiple sizes"
+#~ msgstr "dimensiuni multiple"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Fără fundal desktop"
+
+#~ msgid "Current background"
+#~ msgstr "Fundalul curent"
+
+#~ msgid "Activities"
+#~ msgstr "Activități"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Wallpaper;Screen;Desktop;Tapet;Ecran;"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Permite aplicațiilor de mai jos să utilizeze camera."
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;ecran;încuiere;recent;rețea;nume;identitate;"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Plasați dispozitivul de calibrare deasupra pătratului și apăsați „Start”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Mutați dispozitivul de calibrare pe poziția de calibrare și apăsați "
+#~ "„Continuare”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Mutați dispozitivul de calibrare pe poziția de suprafață și apăsați "
+#~ "„Continuare”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Închideți capacul laptopului"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "A apărut o eroare internă nerecuperabilă."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Uneltele pentru calibrare nu sunt instalate."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Nu s-a putut genera profilul."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Nu s-a putut găsi punctul de țintă alb."
+
+#~ msgid "Complete!"
+#~ msgstr "Gata!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Calibrare eșuată!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Puteți deconecta dispozitivul de calibrare."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Nu deranjați dispozitivul în timpul calibrării"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Ecran laptop"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Cameră web încorporată"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Monitor %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Scanner %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Cameră %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Imprimantă %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Cameră web %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Activare management culori pentru %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Arată profile de culori pentru %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Necalibrat"
+
+#~ msgid "Default: "
+#~ msgstr "Implicit: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Spațiu culoare: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Profil de test: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Selectați un fișier profil ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importă"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Profile ICC recunoscute"
+
+#~ msgid "All files"
+#~ msgstr "Toate fișierele"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Eșec la încărcarea fișierului: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profilul a fost încărcat în:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Scrieți acest URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Reporniți calculatorul și intrați în sistemul de operare obișnuit."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Scrieți URL-ul în navigator pentru a descărca și instala profilul."
+
+#~ msgid "Save Profile"
+#~ msgstr "Salvare profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Creează un profil de culoare pentru dispozitivul ales"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Instrumentul de măsură nu este detectat. Verificați dacă este pornit și "
+#~ "conectat."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Instrumentul de măsură nu suportă profilarea pentru imprimante."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Tipul de dispozitiv nu este recunoscut."
+
+#~ msgid "Upload profile"
+#~ msgstr "Încarcă profilul"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Necesită conexiune la internet"
+
+#~ msgid "Standard Space"
+#~ msgstr "Spațiu standard"
+
+#~ msgid "Test Profile"
+#~ msgstr "Profil de test"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automat"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Calitate slabă"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Calitate medie"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Calitate înaltă"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB implicit"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK implicit"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Gri implicit"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Date de calibrare furnizate de producător"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Nu este posibilă corecția în mod „tot ecranul” pentru acest profil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Este posibil ca acest profil să nu mai fie corect"
+
+#~ msgid "Other…"
+#~ msgstr "Altele…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Deblochează pentru a modifica configurările"
+
+#~ msgid "_Copy"
+#~ msgstr "_Copiază"
+
+#~ msgid "Select _All"
+#~ msgstr "Selectează to_ate"
+
+#~ msgid "Today"
+#~ msgstr "Azi"
+
+#~ msgid "Yesterday"
+#~ msgstr "Ieri"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d oră"
+#~ msgstr[1] "%d ore"
+#~ msgstr[2] "%d de ore"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minut"
+#~ msgstr[1] "%d minute"
+#~ msgstr[2] "%d de minute"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d secundă"
+#~ msgstr[1] "%d secunde"
+#~ msgstr[2] "%d de secunde"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s și %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s și %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Hotspot"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "24-hour"
+#~ msgstr "24 de ore"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Trimiterea de rapoarte ale problemelor tehnice ne ajută să îmbunătățim "
+#~ "%s. Rapoartele sunt trimise anonim și sunt curățate de date personale. %s"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Aplicați modificările?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Nu se pot aplica modificările"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Aceasta poate fi din cauza limitărilor de hardware."
+
+#~ msgid "Single Display"
+#~ msgstr "Afișaj singular"
+
+#~ msgid "Join Displays"
+#~ msgstr "Unește afișaje"
+
+#~ msgid "Display Mode"
+#~ msgstr "Modul de afișaj"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Trageți afișaje pentru a le potrivi configurației fizice. Selectați un "
+#~ "afișaj pentru a-i modifica configurările."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Aranjamentul afișajelor"
+
+#~ msgid "Active Display"
+#~ msgstr "Afișaj activ"
+
+#~ msgid "Display Configuration"
+#~ msgstr "Configurația afișajelor"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Peisaj"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Portret dreapta"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Portret stânga"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Peisaj (inversat)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "More Warm"
+#~ msgstr "Mai cald"
+
+#~ msgid "Less Warm"
+#~ msgstr "Mai rece"
+
+#~ msgid "Unknown"
+#~ msgstr "Necunoscut"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-biți"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-biți"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Necunoscut"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Salvează capturile în $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Salvează captura unei ferestre în $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Salvează o captură a unei selecții de ecran în $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Copiază o captură de ecran în clipboard"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Copiază o captură de ecran a unei ferestre în clipboard"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Copiază o captură de ecran a unei zone selectate în clipboard"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Înregistrează un scurt video cu capturi de ecran"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nu s-au găsit surse de intrare"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Altele"
+
+#~ msgid "Move up"
+#~ msgstr "Mută în sus"
+
+#~ msgid "Move down"
+#~ msgstr "Mută în jos"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Scurtături personalizate"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Tasta de caractere alternative poate fi utilizată pentru a introduce "
+#~ "caractere adiționale. Acestea sunt câteodată tipărite ca o a treia "
+#~ "opțiune pe tastatură."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt stânga"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt dreapta"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Super stânga"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Super dreapta"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tasta meniului"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl dreapta"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Tasta de compunere permite introducerea a unei varietăți largi de "
+#~ "caractere. Pentru a o utiliza, apăsați compune apoi o secvență de "
+#~ "caractere.  De exemplu, tasta compune urmată de <b>C</b> și <b>o</b> va "
+#~ "introduce <b>©</b>, <b>a</b> urmat de <b>'</b> va introduce <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Majuscule"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Blocare derulare"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Captură de ecran"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Sursele de intrare pot fi comutate utilizând scurtătura de tastatură %s.\n"
+#~ "Acest lucru poate fi modificat în configurările de scurtături de "
+#~ "tastatură."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d modificat"
+#~ msgstr[1] "%d modificate"
+#~ msgstr[2] "%d modificate"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Restabilesc toate scurtăturile?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Restabilirea scurtăturilor poate afecta scurtăturile personalizate. "
+#~ "Această acțiune nu poate fi refăcută."
+
+#~ msgid "Reset All"
+#~ msgstr "Restabiliește tot"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s este deja utilizat pentru %s. Dacă îl înlocuiți, %s va fi dezactivat"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Introduceți noua scurtătură"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Stabilește scurtătură personalizată"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Introduceți o scurtătură nouă pentru a modifica %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Adaugă scurtățură personalizată"
+
+#~ msgid "Set"
+#~ msgstr "Stabilește"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Serviciile de locație permit aplicațiilor să cunoască locația "
+#~ "dumneavoastră. Folosind Wi-Fi și rețele mobile de bandă largă măresc "
+#~ "acuratețea."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Utilizează Serviciul de localizare Mozilla: <a href='https://location."
+#~ "services.mozilla.com/privacy'>Politică de confidențialitate</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Permite aplicațiilor de mai jos să vă determine locația."
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Ecranul se închide"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 de secunde"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "un minut"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "două minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 de minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "o oră"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "un minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "două minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Niciodată"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Blochează ecranul"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Permite aplicațiilor de mai jos să utilizeze microfonul."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Reglaj clic dublu"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Derulare cu două degete"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Cinci clicuri, e timpul pentru GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dublu clic, buton principal"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Un clic, buton principal"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dublu clic, buton mijloc"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Un clic, buton mijloc"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dublu clic, buton secundar"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Un clic, buton secundar"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager trebuie să funcționeze."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Rețea nesigură (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Rețea sigură (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Rețea sigură (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Rețea sigură (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Rețea securizată"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Activarea hotspot-ului vă va deconecta de la %s, și nu va fi posibil să "
+#~ "accesați internetul prin Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Trebuie să aibă minimum 8 caractere"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Oprire hotspot și deconectare utilizatori?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "Oprire hot_spot"
+
+#~ msgid "Preserve"
+#~ msgstr "Păstrează"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "Aleator"
+
+#~ msgid "Stable"
+#~ msgstr "Stabil"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Adresa MAC introdusă aici va fi utilizată ca adresa de hardware pentru "
+#~ "dispozitivul de rețea pe care este activată această conexiune. Această "
+#~ "funcționalitate este cunoscută ca clonare MAC sau spoofing. Exemplu: "
+#~ "00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profilul %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Îmbunătățit deschis"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Nimic"
+
+#~ msgid "Never"
+#~ msgstr "Niciodată"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nimic"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Slab"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "În regulă"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bun"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Excelent"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Elimină profilul conexiunii"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Elimină VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detalii"
+
+#~ msgid "automatic"
+#~ msgstr "automat"
+
+#~ msgid "Identity"
+#~ msgstr "Identitate"
+
+#~ msgid "Delete Route"
+#~ msgstr "Șterge ruta"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Nimic"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP cheie 40/128-bit (Hex sau ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit frază secretă"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP Dinamic (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Nu se poate deschide editorul de conexiuni"
+
+#~ msgid "New Profile"
+#~ msgstr "Profil nou"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importă din fișier…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Adaugă VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Nu se poate importa conexiunea VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Fișierul „%s” nu a putut fi citit sau nu conține informația de conexiune "
+#~ "VPN recunoscută\n"
+#~ "\n"
+#~ "Eroare: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Selectează fișierul de importat"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Există deja un fișier cu numele „%s”."
+
+#~ msgid "_Replace"
+#~ msgstr "Înlocui_re"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Doriți să înlocuiți %s cu conexiunea VPN pe care o salvați?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Nu se poate exporta conexiunea VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Conexiunea VPN „%s” nu poate fi exportată în %s.\n"
+#~ "\n"
+#~ "Eroare: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportă conexiunea VPN"
+
+#~ msgid "never"
+#~ msgstr "niciodată"
+
+#~ msgid "today"
+#~ msgstr "azi"
+
+#~ msgid "yesterday"
+#~ msgstr "ieri"
+
+#~ msgid "Last used"
+#~ msgstr "Ultima utilizare"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Detaliile rețelei pentru rețelile selectate, inclusiv parolele și alte "
+#~ "configurări se vor pierde."
+
+#~ msgid "_Forget"
+#~ msgstr "_Uită"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Rețele Wi-Fi cunoscute"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Uită"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Politica de sistem nu permite folosirea ca hotspot"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Dispozitivul wireless nu suporta modul Hotspot"
+
+#~ msgid "Off"
+#~ msgstr "Oprit"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Autodescoperirea proxy-ului web este utilizată când nu a fost furnizat un "
+#~ "URL de configurare."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Această opțiune nu este recomandată pentru rețelele publice."
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Status unknown"
+#~ msgstr "Stare necunoscută"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Negestionat"
+
+#~ msgid "Unavailable"
+#~ msgstr "Indisponibil"
+
+#~ msgid "Connecting"
+#~ msgstr "Se conectează"
+
+#~ msgid "Authentication required"
+#~ msgstr "Autentificare necesară"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Se deconectează"
+
+#~ msgid "Connection failed"
+#~ msgstr "Conexiunea a eșuat"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Stare necunoscută (lipsește)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Configurare eșuată"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Configurare IP eșuată"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Configurare IP expirată"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr ""
+#~ "Au fost solicitate elemente de secretizare, dar nu au fost furnizate"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Solicitant 802.1x deconectat"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Configurare de solicitant 802.1x eșuată"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Solicitant 802.1x eșuat"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Solicitantul 802.1x a necesitat prea mult timp pentru autentificare"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Pornirea serviciului PPP a eșuat"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Serviciul PPP este deconectat"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP a eșuat"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Pornirea clientului DHCP a eșuat"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Eroare client DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Clientul DHCP a eșuat"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Pornirea serviciului de conexiune partajată a eșuat"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Serviciul de conexiune partajată a eșuat"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Pornirea serviciului AutoIP a eșuat"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Eroare serviciu AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Serviciul AutoIP a eșuat"
+
+#~ msgid "Line busy"
+#~ msgstr "Linie ocupată"
+
+#~ msgid "No dial tone"
+#~ msgstr "Fără ton"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Nu poate fi identificată nicio rețea (carrier)"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Timp de apel expirat"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Încercare de apel eșuată"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Inițializarea modemului a eșuat"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Eșec la selectarea APN-ului solicitat"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Nu se caută rețele"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Înregistrarea în rețea a fost refuzată"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Înregistrarea în rețea a expirat"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Eșec la înregistrarea în rețeaua solicitată"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Verificarea PIN-ului a eșuat"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firmware-ul pentru acest dispozitiv s-ar putea să lipsească"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Conexiune dispărută"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "S-a preluat conexiunea existentă"
+
+#~ msgid "Modem not found"
+#~ msgstr "Nu s-a identificat un modem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Conexiunea Bluetooth a eșuat"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Cartela SIM nu este inserată"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Este necesar PIN-ul pentru SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Este necesar PUK-ul pentru SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM greșit"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Dependeță de conectare eșuată"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Lipsă firmware"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Cablu neconectat"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "eroare nespecificată în securitatea 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "niciun fișier selectat"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "eroare nespecificată la validarea fișierului metodă eap"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "DER, PEM, sau chei private PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certificate DER sau PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "lipsește fișierul EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Fișiere PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "lipsește utilizatorul EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "lipsește parola EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "certificat CA EAP-PEAP nevalid: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-PEAP nevalid: niciun certificat specificat"
+
+#~ msgid "missing EAP username"
+#~ msgstr "lipsește utilizatorul EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "lipsește parola EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "lipsește identitatea EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TLS nevalid: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TLS nevalid: niciun certificat specificat"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "cheie privată EAP-TLS nevalidă: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "certificat EAP-TLS al utilizatorului nevalid: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Cheile private necriptate nu sunt sigure"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Cheia privată selectată nu pare a fi protejată de o parolă. Aceasta ar "
+#~ "putea duce la compromiterea datelor de autentificare. Vă rugăm selectați "
+#~ "o cheie privată protejată de o parolă.\n"
+#~ "\n"
+#~ "(Puteți proteja o cheie privată cu o parolă cu ajutorul openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Alegeți un certificat personal"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Alegeți o cheie privată"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "certificat CA EAP-TTLS nevalid: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "certificat CA EAP-TTLS: niciun certificat specificat"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Eroare necunoscută la validarea securității 802.1X"
+
+#~ msgid "missing leap-username"
+#~ msgstr "lipsește utilizatorul leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "lipsește parola leap"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Parola Wi-Fi lipsește."
+
+#~ msgid "missing wep-key"
+#~ msgstr "lipsește cheia wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "cheie wep nevalidă: cheia cu lungimea de %zu trebuie să conțină numai "
+#~ "cifre hexazecimale"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "cheie wep nevalidă: cheia cu lungimea de %zu trebuie să conțină numai "
+#~ "caractere ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "cheie wep nevalidă: lungimea (%zu) cheii este incorectă. O  cheie trebuie "
+#~ "să fie de lungimea 5/13 (ascii) sau 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "cheie wep nevalidă: fraza de acces nu trebuie să fie goală"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "cheie wep nevalidă: fraza de acces trebuie să fie mai scurtă de 64 de "
+#~ "caractere"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-spk nevalidă: lungimea (%zu) cheii nevalidă. Trebuie să fie [8,63] "
+#~ "bytes sau 64 cifre hexazecimale"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk nevalidă: nu se poate interpreta cheia de 64 de bytes ca hex"
+
+#~ msgid "On"
+#~ msgstr "Pornit"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Altele"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Cont %s"
+
+#~ msgid "Error removing account"
+#~ msgstr "Eroare la eliminarea contului"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s eliminat"
+
+#~ msgid "Remove Account"
+#~ msgstr "Ștergere cont"
+
+#~ msgid "Unknown time"
+#~ msgstr "Timp necunoscut"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s până e încărcată complet"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Atenție: au mai rămas %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "au mai rămas %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Complet încărcată"
+
+#~ msgid "Not charging"
+#~ msgstr "Nu se încarcă"
+
+#~ msgid "Empty"
+#~ msgstr "Descărcată complet"
+
+#~ msgid "Charging"
+#~ msgstr "Se încarcă"
+
+#~ msgid "Discharging"
+#~ msgstr "Se descarcă"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Mouse fără fir"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Tastatură fără fir"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Sursă de curent neîntreruptibilă"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Asistent personal digital"
+
+#~ msgid "Cellphone"
+#~ msgstr "Telefon celular"
+
+#~ msgid "Media player"
+#~ msgstr "Player media"
+
+#~ msgid "Computer"
+#~ msgstr "Calculator"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Dispozitiv de intrare pentru jocuri"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Principal"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Extra"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterii"
+
+#~ msgid "When _idle"
+#~ msgstr "Când e _inactiv"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspendă"
+
+#~ msgid "Power Off"
+#~ msgstr "Oprește"
+
+#~ msgid "Hibernate"
+#~ msgstr "Hibernează"
+
+#~ msgid "Nothing"
+#~ msgstr "Nimic"
+
+#~ msgid "When on battery power"
+#~ msgstr "Când funcționează pe baterie"
+
+#~ msgid "When plugged in"
+#~ msgstr "Alimentat de la rețea"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Niciodată"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Suspendare automată"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Modul de performanță este dezactivat temporar din cauza temperaturii "
+#~ "înalte de operare."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Suprafață neregulată detectată: modul de performanță este indisponibil. "
+#~ "Mutați dispozitivul la o suprafață stabilă pentru restaurare."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Modul de performanță este dezactivat temporar."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Baterie pe terminate: economizorul de energie activat. Modul anterior va "
+#~ "fi restaurat când bateria este încărcată suficient."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Modul de economizare energie activat de „%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Modul de performanță a fost activat de „%s”."
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Buton de suspendare și oprire"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Etapă detectată: modul de performanță nedisponibil"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Temperatură de hardware ridicată: modul de performanță nedisponibil"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Modul de performanță nedisponibil"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Performanță și consum de energie ridicate."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Performanță"
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Echilibrată"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Performanță și consum de energie standard."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Economizor de energie"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Performanță și consum de energie reduse."
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autentificare"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Imprimanta „%s” a fost ștearsă"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Nu s-a putut adăuga imprimanta nouă."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Nu s-a putut încărca interfața cu utilizatorul: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Deblocați pentru a adăuga imprimante și schimba configurări"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detalii %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nu s-a găsit un driver potrivit"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Specificați fișierul PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Fișiere descriere imprimantă PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD."
+#~ "gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Imprimantă JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Imprimantă PLD"
+
+#~ msgid "One Sided"
+#~ msgstr "Pe o parte"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Margine lungă (standard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Margine scurtă (întoarsă)"
+
+#~ msgid "Portrait"
+#~ msgstr "Portret"
+
+#~ msgid "Landscape"
+#~ msgstr "Peisaj"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Peisaj inversat"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Portret inversat"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "În așteptare"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "În pauză"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autentificare necesară"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Se procesează"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Oprită"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Anulată"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Oprită forțat"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Finalizată"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — sarcini active"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Introduceți credențialele pentru a tipări de la %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Deblocați serverul de imprimare"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Deblochează %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Introduceți numele de utilizator și parola pentru a vedea imprimantele "
+#~ "disponibile pe %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Se caută imprimante"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Port serial"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Port paralel"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Locație: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresă: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Serverul necesită autentificare"
+
+#~ msgid "Two Sided"
+#~ msgstr "Pe ambele părți"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tip de hârtie"
+
+#~ msgid "Paper Source"
+#~ msgstr "Sursă hârtie"
+
+#~ msgid "Output Tray"
+#~ msgstr "Tavă de ieșire"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Rezoluție"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Pre-filtrare GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Pagini pe foaie"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientare"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "General"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Configurare pagină"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Opțiuni instalabile"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Sarcină"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Calitate imagine"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Culoare"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Se finalizează"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avansat"
+
+#~ msgid "Test page"
+#~ msgstr "Pagină de test"
+
+#~ msgid "Auto Select"
+#~ msgstr "Selectare automată"
+
+#~ msgid "Printer Default"
+#~ msgstr "Configurări implicite pentru imprimantă"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Permite numai fonturile GhostScript înglobate"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Convertește la PS nivelul 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Convertește la PS nivelul 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Fără pre-filtrare"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Curăță capetele de imprimare"
+
+#~ msgid "Out of toner"
+#~ msgstr "Fără toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Developator puțin"
+
+#~ msgid "Out of developer"
+#~ msgstr "Fără developator"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Stoc de culoare scăzut"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Stoc de culoare terminat"
+
+#~ msgid "Open cover"
+#~ msgstr "Capac deschis"
+
+#~ msgid "Open door"
+#~ msgstr "Ușă deschisă"
+
+#~ msgid "Low on paper"
+#~ msgstr "Hârtie puțină"
+
+#~ msgid "Out of paper"
+#~ msgstr "Fără hârtie"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Deconectată"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Oprită"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Recipientul pentru deșeuri este aproape plin"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Recipientul pentru deșeuri este plin"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Foto-conductorul optic este aproape de sfârșitul vieții"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Foto-conductorul optic nu mai funcționează"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Pregătită"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Nu acceptă sarcini de imprimare"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Procesează"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Alege formatul pentru numere, date și valute. Modificările își fac "
+#~ "efectul la următoarea autentificare."
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Anglo-saxon"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metric"
+
+#~ msgid "My Account"
+#~ msgstr "Contul meu"
+
+#~ msgid "Language"
+#~ msgstr "Limba"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Limba străină utilizată pentru text în ferestre și pagini web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Reporniți sesiunea pentru ca modificările să aibă efect"
+
+#~ msgid "Restart…"
+#~ msgstr "Repornește…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Configurările de autentificare sunt folosite pentru toți utilizatorii la "
+#~ "autentificarea în sistem"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Întreabă-mă ce să fac"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nu fă nimic"
+
+#~ msgid "Open folder"
+#~ msgstr "Deschide dosarul"
+
+#~ msgid "Other Media"
+#~ msgstr "Deschide suportul multimedia"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Selectați o aplicație pentru CD-uri audio"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Selectați o aplicație pentru DVD-uri video"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Selectați o aplicație de rulat la conectarea unui player de muzică"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Selectați o aplicație de rulat la conectarea unei camere"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Selectați o aplicație pentru CD-uri software"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD audio"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "disc Blu-Ray gol"
+
+#~ msgid "blank CD disc"
+#~ msgstr "disc CD gol"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "disc DVD gol"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "disc HD DVD gol"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Disc video Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "cititor de cărți electronice"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Disc video HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "CD video"
+
+#~ msgid "Select Location"
+#~ msgstr "Selectează locația"
+
+#~ msgid "_OK"
+#~ msgstr "_Ok"
+
+#~ msgid "No applications found"
+#~ msgstr "Nu s-au găsit aplicații"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Controlează ce rezultate ale căutării sunt afișate în vederea de ansamblu "
+#~ "Activități. Ordinea rezultatelor căutării poate fi modificată și prin "
+#~ "mutarea rândurilor în listă."
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nicio rețea selectată pentru partajare"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Pornit"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Oprit"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Activat"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Alegeți un director"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Partajarea de fișiere vă permite să vă împărțiți dosarul Public cu alții "
+#~ "pe rețeaua curentă utilizând: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Când autentificarea la distanță este activată, utilizatorii de la "
+#~ "distanță se pot conecta utilizând comanda Secure Shell:\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Partajarea ecranului permite utilizatorilor de la distanță să vizualizeze "
+#~ "sau să controleze ecranul prin conectarea la %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Partajarea _ecranului"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Unele servicii sunt dezactivate din lipsa accesului la rețea."
+
+#~ msgid "_Password:"
+#~ msgstr "_Parolă:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Arată parola"
+
+#~ msgid "Access Options"
+#~ msgstr "Opțiuni de acces"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Noile conexiuni trebuie să solicite accesul"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Necesită parolă"
+
+#~ msgid "Custom"
+#~ msgstr "Personalizat"
+
+#~ msgid "Bark"
+#~ msgstr "Lătrat"
+
+#~ msgid "Drip"
+#~ msgstr "Susur"
+
+#~ msgid "Glass"
+#~ msgstr "Sticlă"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Se testează %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Deconectat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Se conectează"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Conectat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Eroare de autorizare"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Autorizare"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Funcționalitate redusă"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Conectat și autorizat"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Necunoscut"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Autorizat la:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Conectat la:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Înscris la:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Nu s-a putut autoriza dispozitivul: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Nu s-a putut uita dispozitivul: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Eroare"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Autorizat"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Subsistemul Thunderbolt (boltd) nu este instalat sau configurat corect."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Nu s-a putut detecta Thunderbolt.\n"
+#~ "Fie sistemul nu are suport pentru Thunderbolt, a fost dezactivat în BIOS "
+#~ "sau este stabilit la un nivel de securitate nesuportat în BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Suportul pentru Thunderbolt a fost dezactivat în BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Nivelul de securitate Thunderbolt nu a putut fi determinat."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Eroare la comutarea modului direct: %s"
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Doar dispozitivele USB sau port de afișaj pot atașa."
+
+#~ msgid "Sound Keys"
+#~ msgstr "Taste sonor"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Cititor de ecran"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Citit_or de ecran"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Implicită"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Medie"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Mare"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Mai mare"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Cel mai mare"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixel"
+#~ msgstr[1] "%d pixeli"
+#~ msgstr[2] "%d de pixeli"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Scurtă"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ de ecran"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ de ecran"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ de ecran"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Lungă"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Golește coșul de gunoi?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Toate elementele din coșul de gunoi vor fi șterse permanent."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Gol_ește gunoiul"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Șterge toate fișierele temporare?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Toate fișierele temporare vor fi șterse permanent."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Șterge fișierele tem_porare"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "o oră"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "o zi"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "două zile"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 zile"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 zile"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 zile"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 zile"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 zile"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 zile"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 de zile"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "o zi"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 zile"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 de zile"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Pentru totdeauna"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Trebuie să potriviți adresele web a furnizorului de logare."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Eșec la adăugarea contului"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Eșec la înregistrarea contului"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nici o metodă suportată pentru autentificarea cu acest domeniu"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Eșec la înregistrarea domeniului"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Numele de autentificare nu a funcționat.\n"
+#~ "Încercați din nou."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Parola de autentificare nu a funcționat.\n"
+#~ "Încercați din nou."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Eșec la conectarea în domeniu"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Nu se poate găsi domeniul. Poate l-ați scris greșit?"
+
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Tip cont"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Permite stabilirea unei parole folosită la următoarea _autentificare"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Definește o parolă acu_m"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "Trebuie să fiți conectat la internet pentru a adăuga utilizatori "
+#~ "enterprise."
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Răsfoiește pentru mai multe imagini"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Faceți o fotografie…"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Re-înregistrați acest deget…"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr ""
+#~ "dispozitivul trebuie să fie revendicat pentru a executa această acțiune"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "dispozitivul este revendicat deja de către alt proces"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "nu aveți permisiune pentru a executa această acțiune"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "nu a fost înscrisă nicio tipărire"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Comunicarea nu a reușit cu dispozitivul în timpul înscrierii"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Comunicarea nu a reușit cu cititorul de amprente"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Comunicarea nu a reușit cu serviciul de amprente"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Eșec la listarea amprentelor: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Eșec la ștergerea amprentelor salvate: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Degetul mare stâng"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Degetul mijlociu stâng"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Arătătoru_l mâinii stângi"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Degetul inelar stâng"
+
+#~ msgid "Left little finger"
+#~ msgstr "Degetul mic stâng"
+
+#~ msgid "Right thumb"
+#~ msgstr "Degetul mare drept"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Degetul mijlociu drept"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Arătătorul mâinii d_repte"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Degetul inelar drept"
+
+#~ msgid "Right little finger"
+#~ msgstr "Degetul mic drept"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Deget necunoscut"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Complet"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Dispozitivul de amprente este deconectat"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Dispozitivul de stocare amprente este plin"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Eșec la înregistrarea noii amprente"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Eșec la pornirea înregistrării: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Eșec la înregistrarea noii amprente"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Eșec la oprirea înregistrării: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Ridicați și plasați degetul pe cititor în mod repetat pentru a vă "
+#~ "înregistra amprenta"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Scanați amprentă nouă"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Eșec la detașarea dispozitivului de amprente %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problemă la citirea dispozitiivului"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Eșec la asumarea dispozitivului de amprente %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Eșec la obținerea dispozitivelor de amprente: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Această săptămână"
+
+#~ msgid "Last Week"
+#~ msgstr "Săptămâna trecută"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Sesiune terminată"
+
+#~ msgid "Session Started"
+#~ msgstr "Sesiunea a început"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Activitatea contului"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Alegeți altă parolă."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Tastează parola curentă încă o dată."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Parola nu a putut fi schimbată"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Nu se poate conecta automat la acest tip de domeniu"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nu este găsit niciun domeniu și nicio valoare reală"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Nu se poate realiza conectarea ca %s în domeniul %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Parola nu este validă, încercați din nou"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Ștergerea utilizatorului a eșuat"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "A eșuat eliminarea utilizatorului gestionat la distanță"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nu vă puteți șterge propriul cont."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s este încă autentificat"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Ștergerea unui utilizator când acesta este încă autentificat poate aduce "
+#~ "sistemul într-o stare inconsistentă."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Doriți să păstrați fișierele lui %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Este posibil să păstrați dosarul personal, emailurile și fișierele "
+#~ "temporare după ștergerea unui cont."
+
+#~ msgid "_Delete Files"
+#~ msgstr "Ș_terge fișierele"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Păstrează fișierele"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Sigur doriți să eliminați contul %s gestionat de la distanță?"
+
+#~ msgid "_Delete"
+#~ msgstr "Ș_terge fișierele"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Cont dezactivat"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Va fi definită la următoarea autentificare"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Niciuna"
+
+#~ msgid "Logged in"
+#~ msgstr "Autentificat"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Contactarea serviciului pentru conturi a eșuat"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Asigurați-vă că aplicația AccountService este corect instalată."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pentru a face schimbări,\n"
+#~ "apăsați întâi clic pe iconița *"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Șterge contul de utilizator selectat"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pentru a șterge un cont de utilizator,\n"
+#~ "efectuați clic pe iconița *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Deblocați pentru a adăuga utilizatori și schimba configurări"
+
+#~ msgid "Create a user account"
+#~ msgstr "Creează un cont de utilizator"
+
+#~ msgid "User Icon"
+#~ msgstr "Iconiță utilizator"
+
+#~ msgid "Account Settings"
+#~ msgstr "Configurări cont"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autentificare și login"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Noua parolă trebuie să fie diferită de parola veche."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Încercați să șchimbați unele litere sau numere."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Încercați să mai schimbați puțin parola."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "O parolă fără nume utilizator trebuie să fie mai puternică."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Încercați să evitați folosirea numelui în parolă."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Încercați să evitați unele cuvinte incluse în parolă."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Încercați să evitați cuvinte comune."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Încercați să evitați rearanjarea cuvintelor existente."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Încercați folosirea mai multor numere."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Încercați mai multe litere mari."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Încercați mai multe litere mici."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Încercați mai multe caractere speciale, cum ar fi punctuația."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Încercați o combinație de litere, numere și punctuație."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Evitați repetarea aceluiași caracter."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Evitați repetarea aceluiași top de caracter: trebuie să amestecați "
+#~ "litere, numere și punctuație."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Evitați secvențele de top 1234 sau abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Parola trebuie să fie mai lungă. Adăugați mai multe litere, numere și "
+#~ "semne de punctuație."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Amestecați literele mari și mici și folosiți unul sau două numere."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Adăugând mai multe litere, numere și semne de punctuație va face parola "
+#~ "mai puternică."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autentificarea a eșuat"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Parola nouă este prea scurtă"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Parola nouă este prea simplă"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Vechea și noua parolă sunt foarte asemănătoare"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Noua parolă a mai fost utilizată recent."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Noua parolă trebuie să conțină caractere numerice sau speciale"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Noua și vechea parolă sunt identice"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Vi s-a modificat parola de când v-ați autentificat!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Noua parolă nu conține suficiente caractere diferite"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Eroare necunoscută"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Numele de utilizator poate conține numai litere mari și mici de la a la "
+#~ "z, cifre și următoarele caractere: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Ne pare rău dar numele de utilizator nu este disponibil. Încercați altul."
+
+#~ msgid "The username is too long."
+#~ msgstr "Numele utilizatorului este prea lung."
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Aceasta va fi folosit pentru denumirea dosarului personal și nu poate fi "
+#~ "modificat."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Buton %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Definit de aplicație"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Trimitere apăsare de tastă"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Comută monitorul"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Arată ajutorul pe ecran"
+
+#~ msgid "Output:"
+#~ msgstr "Ieșire:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Păstrează raportul de aspect (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Asociază unui singur monitor"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d din %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Afișează alocarea"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tabletă (absolut)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Preferințe tabletă"
+
+#~ msgid "_Help"
+#~ msgstr "A_jutor"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Configurări bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Mod de urmărire"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Alocare butoane…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Configurări maus"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Ajustare rezoluție afișaj"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Scurtătură nouă…"
+
+#~ msgid "No stylus found"
+#~ msgstr "Nu s-a găsit stylus"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Mutați stylusul în proximitatea tabletei pentru a-l configura"
+
+#~ msgid "Top Button"
+#~ msgstr "Buton superior"
+
+#~ msgid "Lower Button"
+#~ msgstr "Buton inferior"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Buton inferior"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operație anulată"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Eroare:</b> Accesul restricționat la modificarea configurărilor"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Eroare:</b> Eroare la echipamentul mobil"
+
+#~ msgid "Not Registered"
+#~ msgstr "Neînregistrat"
+
+#~ msgid "Registered"
+#~ msgstr "Înregistrat"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Căutare"
+
+#~ msgid "Denied"
+#~ msgstr "Refuzat"
+
+#~ msgid "2G Only"
+#~ msgstr "Numai 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Numai 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Numai 4G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Preferat)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Preferat), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Preferat), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Preferat)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Preferat), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Preferat)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Preferat), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Preferat)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Preferat), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Necunoscută"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Deblochează cardul SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Oferiți codul PIN pentru SIM-ul %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Introduceți PIN-ul pentru a debloca cardul SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Oferiți codul PUK pentru SIM-ul %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Introduceți PUK-ul pentru a debloca cardul SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Parola introdusă a fost greșită."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Codul PUK ar trebui să fie un număr natural de 8 cifre"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Introduceți noul PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Codul PIN ar trebui să fie un număr natural de 4-8 cifre"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Se deblochează..."
+
+#~ msgid "Phone failure"
+#~ msgstr "Eșec telefon"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Nicio conexiune la telefon"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operația nu este permisă"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operația nu este suportată"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM-ul nu este inserat"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "PIN-ul SIM necesar"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "PUK-ul SIM necesar"
+
+#~ msgid "SIM failure"
+#~ msgstr "Eșec SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM ocupat"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Parolă incorectă"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "PIN2 SIM necesar"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "PUK2 SIM necesar"
+
+#~ msgid "Not found"
+#~ msgstr "Negăsit"
+
+#~ msgid "No network service"
+#~ msgstr "Nu este semnal de rețea"
+
+#~ msgid "Network timeout"
+#~ msgstr "Timp expirat"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Serviciile GPRS nu sunt permise"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming-ul nu este permis la această locație"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Eroare GPRS nespecificată"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Acțiune anulată"
+
+#~ msgid "Access denied"
+#~ msgstr "Acces refuzat"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Eroare necunoscută"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "Configurări GNOME"
+
+#~ msgid "Display version number"
+#~ msgstr "Afișează număr versiune"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Activează modul volubil"
+
+#~ msgid "Search for the string"
+#~ msgstr "Caută un șir"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Listează nume posibile pentru panouri și apoi închide fereastra"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panou de afișat"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Panouri disponibile:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sunete de sistem"
 
 #~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
 #~ msgstr ""
@@ -9156,9 +8523,6 @@ msgstr "Sunete de sistem"
 #~ msgid "Use bluetooth devices"
 #~ msgstr "Configurări bluetooth"
 
-#~ msgid "Use your camera"
-#~ msgstr "Utilizează camera"
-
 #, fuzzy
 #~| msgid "Printers"
 #~ msgid "Print documents"
@@ -9211,11 +8575,6 @@ msgstr "Sunete de sistem"
 #~| msgid "Change resolution and position of monitors and projectors"
 #~ msgid "Change location settings and providers"
 #~ msgstr "Schimbă rezoluția și poziția monitoarelor și a proiectoarelor"
-
-#, fuzzy
-#~| msgid "Access Options"
-#~ msgid "Access your location"
-#~ msgstr "Opțiuni de acces"
 
 #~ msgid "Read system and application logs"
 #~ msgstr "Citește jurnalele de sistem și ale aplicațiilor"
@@ -9643,9 +9002,6 @@ msgstr "Sunete de sistem"
 #~ msgid "Span"
 #~ msgstr "Extins"
 
-#~ msgid "Wallpapers"
-#~ msgstr "Imagini de fundal"
-
 #~ msgid "Colors"
 #~ msgstr "Culori"
 
@@ -9671,14 +9027,8 @@ msgstr "Sunete de sistem"
 #~ msgid "_When the Power Button is pressed"
 #~ msgstr "_Când butonul de oprire este apăsat"
 
-#~ msgid "Show _Notifications"
-#~ msgstr "Arată _notificări"
-
 #~ msgid "application-x-executable"
 #~ msgstr "application-x-executable"
-
-#~ msgid "preferences-desktop-wallpaper"
-#~ msgstr "preferences-desktop-wallpaper"
 
 #~ msgid "bluetooth"
 #~ msgstr "bluetooth"
@@ -9912,9 +9262,6 @@ msgstr "Sunete de sistem"
 #~ msgid "Co­lor"
 #~ msgstr "Culoare"
 
-#~ msgid "Section"
-#~ msgstr "Secțiune"
-
 #~ msgid "Overview"
 #~ msgstr "Imagine de ansamblu"
 
@@ -9978,9 +9325,6 @@ msgstr "Sunete de sistem"
 #~ msgid "Mirrored"
 #~ msgstr "Oglindit"
 
-#~ msgid "Secondary"
-#~ msgstr "Secundar"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Aranjează ecrane combinate"
 
@@ -10004,9 +9348,6 @@ msgstr "Sunete de sistem"
 
 #~ msgid "Size"
 #~ msgstr "Mărime"
-
-#~ msgid "Aspect Ratio"
-#~ msgstr "Proporție de aspect"
 
 #~ msgid "Show the top bar and Activities Overview on this display"
 #~ msgstr "Arată bara de sus și Ecran Actvități pe acest ecran"
@@ -10063,9 +9404,6 @@ msgstr "Sunete de sistem"
 #~ msgctxt "proxy method"
 #~ msgid "Automatic"
 #~ msgstr "Automată"
-
-#~ msgid "_Method"
-#~ msgstr "_Metodă"
 
 #~ msgid "VPN Type"
 #~ msgstr "Tip de VPN"
@@ -10324,9 +9662,6 @@ msgstr "Sunete de sistem"
 #~ msgid "No printers detected."
 #~ msgstr "Nicio imprimantă detectată."
 
-#~ msgid "Loading options…"
-#~ msgstr "Se încarcă opțiunile…"
-
 #~ msgid "Supply"
 #~ msgstr "Aprovizionare"
 
@@ -10351,9 +9686,6 @@ msgstr "Sunete de sistem"
 
 #~ msgid "Personal File Sharing"
 #~ msgstr "Partajare personală fișiere"
-
-#~ msgid "_Allow Remote Control"
-#~ msgstr "Permite control de la dist_anță"
 
 #~ msgid "_Verify"
 #~ msgstr "_Verifică"
@@ -10467,9 +9799,6 @@ msgstr "Sunete de sistem"
 #~ msgid "Scroll Up"
 #~ msgstr "Derulare în sus"
 
-#~ msgid "Scroll Down"
-#~ msgstr "Derulare în jos"
-
 #~ msgid "Scroll Right"
 #~ msgstr "Derulare la dreapta"
 
@@ -10564,9 +9893,6 @@ msgstr "Sunete de sistem"
 #~ msgid "Used to determine your geographical location"
 #~ msgstr "Folosit pentru a vă determina locația geografică"
 
-#~ msgid "Options"
-#~ msgstr "Opțiuni"
-
 #~ msgid "Password:"
 #~ msgstr "Parola:"
 
@@ -10576,9 +9902,6 @@ msgstr "Sunete de sistem"
 #~ msgctxt "universal access, contrast"
 #~ msgid "Color"
 #~ msgstr "Culoare"
-
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "Bluetooth-ul este dezactivat"
 
 #, fuzzy
 #~| msgid "When power is _critically low"
@@ -10595,9 +9918,6 @@ msgstr "Sunete de sistem"
 #~ "%s\n"
 #~ "Executați „%s --help” pentru a vedea întreaga listă a comenzilor "
 #~ "disponibile.\n"
-
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "Configurare dispozitiv nou"
@@ -10636,9 +9956,6 @@ msgstr "Sunete de sistem"
 
 #~ msgid "United States"
 #~ msgstr "Statele Unite"
-
-#~ msgid "France"
-#~ msgstr "Franța"
 
 #~ msgid "Spain"
 #~ msgstr "Spania"
@@ -10721,9 +10038,6 @@ msgstr "Sunete de sistem"
 
 #~ msgid "Mouse Preferences"
 #~ msgstr "Preferințe maus"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Dezactivează în timp ce se _tastează"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr ""
@@ -10972,9 +10286,6 @@ msgstr "Sunete de sistem"
 #~ msgid "_Other Media..."
 #~ msgstr "A_lte tipuri de fișiere media..."
 
-#~ msgid "Install languages..."
-#~ msgstr "Instalează limbi..."
-
 #~ msgid "Region and Language"
 #~ msgstr "Regiune și limbă"
 
@@ -11027,9 +10338,6 @@ msgstr "Sunete de sistem"
 
 #~ msgid "Sound Output Volume"
 #~ msgstr "Volum ieșire"
-
-#~ msgid "_Mute"
-#~ msgstr "_Mut"
 
 #~ msgid "_Sound Preferences"
 #~ msgstr "Preferințe _sunet"
@@ -11172,9 +10480,6 @@ msgstr "Sunete de sistem"
 
 #~ msgid "Cannot remove automatically added profile"
 #~ msgstr "Profilele adăugate automat nu pot fi șterse"
-
-#~ msgid "Create virtual device"
-#~ msgstr "Creează dispozitiv virtual"
 
 #~ msgid "Uncalibrated"
 #~ msgstr "Necalibrat"
@@ -11365,9 +10670,6 @@ msgstr "Sunete de sistem"
 #~ msgid "Suspend when inactive for"
 #~ msgstr "Suspendă dacă este inactiv pentru"
 
-#~ msgid "When the lid is closed"
-#~ msgstr "Când capacul este închis"
-
 #~ msgid "Show battery status in the _menu bar"
 #~ msgstr "Arată starea bateriei în bara de _meniu"
 
@@ -11394,9 +10696,6 @@ msgstr "Sunete de sistem"
 
 #~ msgid "Settings for the selected device"
 #~ msgstr "Configurări pentru dispozitivul selectat"
-
-#~ msgid "Settings for %s"
-#~ msgstr "Configurări pentru %s"
 
 #~ msgid "Play sound through"
 #~ msgstr "Redare sunet prin"
@@ -11519,9 +10818,6 @@ msgstr "Sunete de sistem"
 
 #~ msgid "Shortcut Settings"
 #~ msgstr "Configurări acceleratori"
-
-#~ msgid "New accelerator…"
-#~ msgstr "Accelerator nou…"
 
 #~ msgctxt "Zoom Grayscale"
 #~ msgid "None"

--- a/po/ro.po~
+++ b/po/ro.po~
@@ -1,0 +1,11542 @@
+# Romanian translation for gnome-control-center
+# This file is distributed under the same license as the gnome-control-center package.
+# Mugurel Tudor <mugurelu@gnome.ro>, 2002, 2003.
+# Mișu Moldovan <dumol@gnome.ro> 2003, 2004.
+# Sebastian Ivan <sebastian.ivan@ubuntu.ro>, 2005.
+# Dan Damian <dand@gnome.ro>, 2005-2006.
+# Adi Roiban https://launchpad.net/~adiroiban, 2008, 2009.
+# Lucian Adrian Grijincu https://launchpad.net/~lucian.grijincu, 2009.
+# Lucian Adrian Grijincu <lucian.grijincu@gmail.com>, 2010, 2011.
+# Cătălin Bălan <laserbeam333@gmail.com>, 2010.
+# Lupescu Mircea <mircea.crazy@yahoo.com>, 2011.
+# Lupescu Mircea <mircea.crazy@gmail.com>, 2011.
+# Jobava <jobaval10n@gmail.com>, 2015.
+# Daniel Șerbănescu <daniel [at] serbanescu [dot] dk>, 2011, 2016-2018, 2020.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2021-09-08 08:29+0000\n"
+"PO-Revision-Date: 2021-09-09 13:24+0200\n"
+"Last-Translator: Florentina Mușat <florentina.musat.28@gmail.com>\n"
+"Language-Team: Romanian Gnome Team\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2);\n"
+"X-Generator: Poedit 3.0\n"
+"X-Launchpad-Export-Date: 2014-07-13 17:08+0000\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:823
+msgid "System Bus"
+msgstr "Magistrala sistemului"
+
+#: panels/applications/cc-applications-panel.c:823
+#: panels/applications/cc-applications-panel.c:825
+#: panels/applications/cc-applications-panel.c:838
+#: panels/applications/cc-applications-panel.c:843
+msgid "Full access"
+msgstr "Acces complet"
+
+#: panels/applications/cc-applications-panel.c:825
+msgid "Session Bus"
+msgstr "Magistrala sesiunilor"
+
+#: panels/applications/cc-applications-panel.c:829
+#: panels/power/cc-power-panel.ui:85 panels/thunderbolt/cc-bolt-panel.ui:466
+#: panels/thunderbolt/cc-bolt-panel.ui:525
+msgid "Devices"
+msgstr "Dispozitive"
+
+#: panels/applications/cc-applications-panel.c:829
+msgid "Full access to /dev"
+msgstr "Acces total la /dev"
+
+#: panels/applications/cc-applications-panel.c:833
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:288 panels/wwan/cc-wwan-device-page.ui:114
+#: panels/wwan/cc-wwan-network-dialog.ui:4
+msgid "Network"
+msgstr "Rețea"
+
+#: panels/applications/cc-applications-panel.c:833
+msgid "Has network access"
+msgstr "Are acces la rețea"
+
+#: panels/applications/cc-applications-panel.c:838
+#: panels/applications/cc-applications-panel.c:840
+#: panels/search/cc-search-locations-dialog.c:362
+msgid "Home"
+msgstr "Acasă"
+
+#: panels/applications/cc-applications-panel.c:840
+#: panels/applications/cc-applications-panel.c:845
+msgid "Read-only"
+msgstr "Doar citire"
+
+#: panels/applications/cc-applications-panel.c:843
+#: panels/applications/cc-applications-panel.c:845
+msgid "File System"
+msgstr "Sistem de fișiere"
+
+#: panels/applications/cc-applications-panel.c:849
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:279
+#: shell/cc-window.c:938 shell/cc-window.ui:121
+#: shell/gnome-control-center.desktop.in.in:3
+msgid "Settings"
+msgstr "Configurări"
+
+#: panels/applications/cc-applications-panel.c:849
+msgid "Can change settings"
+msgstr "Poate administra configurări"
+
+#: panels/applications/cc-applications-panel.c:851
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s are următoarele permisiuni încorporate. Acestea nu pot fi modificate. "
+"Dacă sunteți îngrijorat de aceste permisiuni, considerați eliminarea acestei "
+"aplicații."
+
+#: panels/applications/cc-applications-panel.c:1024
+msgid "Web Links"
+msgstr "Legături web"
+
+#: panels/applications/cc-applications-panel.c:1034
+msgid "Git Links"
+msgstr "Legături git"
+
+#: panels/applications/cc-applications-panel.c:1040
+#, c-format
+msgid "%s Links"
+msgstr "Legături %s"
+
+#: panels/applications/cc-applications-panel.c:1048
+#: panels/applications/cc-applications-panel.c:1084
+msgid "Unset"
+msgstr "Nestabilit"
+
+#: panels/applications/cc-applications-panel.c:1139
+msgid "Links"
+msgstr "Legături"
+
+#: panels/applications/cc-applications-panel.c:1147
+msgid "Hypertext Files"
+msgstr "Fișiere hypertext"
+
+#: panels/applications/cc-applications-panel.c:1161
+msgid "Text Files"
+msgstr "Fișiere text"
+
+#: panels/applications/cc-applications-panel.c:1175
+msgid "Image Files"
+msgstr "Fișiere imagine"
+
+#: panels/applications/cc-applications-panel.c:1191
+msgid "Font Files"
+msgstr "Fișiere font"
+
+#: panels/applications/cc-applications-panel.c:1252
+msgid "Archive Files"
+msgstr "Arhivează fișiere"
+
+#: panels/applications/cc-applications-panel.c:1272
+msgid "Package Files"
+msgstr "Împachetează fișiere"
+
+#: panels/applications/cc-applications-panel.c:1295
+msgid "Audio Files"
+msgstr "Fișiere audio"
+
+#: panels/applications/cc-applications-panel.c:1312
+msgid "Video Files"
+msgstr "Fișiere video"
+
+#: panels/applications/cc-applications-panel.c:1320
+msgid "Other Files"
+msgstr "Alte fișiere"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1660
+#: panels/applications/cc-applications-panel.ui:416
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:70
+msgid "Applications"
+msgstr "Aplicații"
+
+#: panels/applications/cc-applications-panel.ui:43
+msgid "No applications"
+msgstr "Nicio aplicație"
+
+#: panels/applications/cc-applications-panel.ui:57
+msgid "Install some…"
+msgstr "Instalează câteva…"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "Permissions & Access"
+msgstr "Permisiuni și acces"
+
+#: panels/applications/cc-applications-panel.ui:106
+msgid ""
+"Data and services that this app has asked for access to and permissions that "
+"it requires."
+msgstr ""
+"Datele și serviciile pentru care această aplicație a cerut acces la și "
+"permisiunile pe care le necesită."
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:127
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Cameră"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:128
+#: panels/applications/cc-applications-panel.ui:140
+#: panels/applications/cc-applications-panel.ui:152
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:262
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:85
+#: panels/keyboard/cc-xkb-modifier-dialog.c:353
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:129
+#: panels/user-accounts/cc-user-panel.c:848
+#: panels/user-accounts/cc-user-panel.c:938
+#: panels/wwan/cc-wwan-device-page.c:445
+#: subprojects/gvc/gvc-mixer-control.c:1900
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: panels/applications/cc-applications-panel.ui:133
+#: panels/applications/cc-applications-panel.ui:139
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Microfon"
+
+#: panels/applications/cc-applications-panel.ui:145
+#: panels/applications/cc-applications-panel.ui:151
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Servicii de locație"
+
+#: panels/applications/cc-applications-panel.ui:157
+#: panels/applications/cc-applications-panel.ui:500
+msgid "Built-in Permissions"
+msgstr "Permisiuni încorporate"
+
+#: panels/applications/cc-applications-panel.ui:158
+msgid "Cannot be changed"
+msgstr "Nu poate fi modificată"
+
+#: panels/applications/cc-applications-panel.ui:175
+msgid ""
+"Individual permissions for applications can be reviewed in the <a href="
+"\"privacy\">Privacy</a> Settings."
+msgstr ""
+"Permisiuni individuale pentru aplicații pot fi revizuite în configurările de "
+"<a href=\"privacy\">Confidențialitate</a>."
+
+#: panels/applications/cc-applications-panel.ui:199
+msgid "Integration"
+msgstr "Integrare"
+
+#: panels/applications/cc-applications-panel.ui:211
+msgid "System features used by this application."
+msgstr "Funcționalități de sistem utilizate de această aplicație."
+
+#: panels/applications/cc-applications-panel.ui:225
+#: panels/applications/cc-applications-panel.ui:231
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:151
+msgid "Search"
+msgstr "Căutare"
+
+#: panels/applications/cc-applications-panel.ui:237
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Notificări"
+
+#: panels/applications/cc-applications-panel.ui:243
+msgid "Run in background"
+msgstr "Rulează în fundal"
+
+#: panels/applications/cc-applications-panel.ui:249
+msgid "Set Desktop Background"
+msgstr "Stabilește fundalul desktopului"
+
+#: panels/applications/cc-applications-panel.ui:255
+#: panels/applications/cc-applications-panel.ui:261
+msgid "Sounds"
+msgstr "Sunete"
+
+#: panels/applications/cc-applications-panel.ui:267
+msgid "Inhibit system keyboard shortcuts"
+msgstr "Blochează scurtăturile de tastatură ale sistemului"
+
+#: panels/applications/cc-applications-panel.ui:300
+msgid "Default Handlers"
+msgstr "Operatori impliciți"
+
+#: panels/applications/cc-applications-panel.ui:312
+msgid "Types of files and links that this application opens."
+msgstr "Tipuri de fișiere și legături pe care această aplicație le deschide."
+
+#: panels/applications/cc-applications-panel.ui:328
+msgid "Reset"
+msgstr "Restabilește"
+
+#: panels/applications/cc-applications-panel.ui:364
+msgid "Usage"
+msgstr "Utilizare"
+
+#: panels/applications/cc-applications-panel.ui:376
+msgid "How much resources this application is using."
+msgstr "Cât de multe resurse utilizează această aplicație."
+
+#: panels/applications/cc-applications-panel.ui:391
+#: panels/applications/cc-applications-panel.ui:537
+msgid "Storage"
+msgstr "Stocare"
+
+#: panels/applications/cc-applications-panel.ui:424
+msgid "Open in Software"
+msgstr "Deschide în Aplicații"
+
+#: panels/applications/cc-applications-panel.ui:474 shell/cc-panel-list.ui:121
+msgid "No results found"
+msgstr "Nu s-au găsit rezultate"
+
+#: panels/applications/cc-applications-panel.ui:485
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:177
+#: shell/cc-panel-list.ui:132
+msgid "Try a different search"
+msgstr "Încercați o căutare diferită"
+
+#: panels/applications/cc-applications-panel.ui:555
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Cât de mult spațiu pe disc ocupă această aplicație cu date și date "
+"prestocate."
+
+#: panels/applications/cc-applications-panel.ui:564
+msgid "Application"
+msgstr "Aplicație"
+
+#: panels/applications/cc-applications-panel.ui:570
+msgid "Data"
+msgstr "Date"
+
+#: panels/applications/cc-applications-panel.ui:576
+msgid "Cache"
+msgstr "Date prestocate"
+
+#: panels/applications/cc-applications-panel.ui:582
+msgid "<b>Total</b>"
+msgstr "<b>Total</b>"
+
+#: panels/applications/cc-applications-panel.ui:599
+msgid "Clear Cache…"
+msgstr "Curăță datele prestocate…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Controlează permisiuni și configurări variate ale aplicației"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"application;flatpak;permission;setting;aplicație;permisiune;configurare;"
+
+#: panels/background/cc-background-chooser.c:344
+msgid "Select a picture"
+msgstr "Selectați o fotografie"
+
+#: panels/background/cc-background-chooser.c:347
+#: panels/color/cc-color-calibrate.ui:25 panels/color/cc-color-panel.c:238
+#: panels/color/cc-color-panel.c:886 panels/color/cc-color-panel.ui:657
+#: panels/common/cc-language-chooser.ui:25
+#: panels/display/cc-display-panel.c:1006
+#: panels/info-overview/cc-info-overview-panel.ui:243
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/network/cc-wifi-hotspot-dialog.ui:122
+#: panels/network/cc-wifi-panel.c:866
+#: panels/network/connection-editor/connection-editor.ui:17
+#: panels/network/connection-editor/vpn-helpers.c:176
+#: panels/network/connection-editor/vpn-helpers.c:299
+#: panels/network/net-device-wifi.c:854
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:235
+#: panels/region/cc-format-chooser.ui:28
+#: panels/search/cc-search-locations-dialog.c:639
+#: panels/sharing/cc-sharing-panel.c:396 panels/usage/cc-usage-panel.c:133
+#: panels/user-accounts/cc-add-user-dialog.ui:28
+#: panels/user-accounts/cc-avatar-chooser.c:105
+#: panels/user-accounts/cc-avatar-chooser.c:228
+#: panels/user-accounts/cc-fingerprint-dialog.ui:36
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:638
+#: panels/user-accounts/cc-user-panel.c:656
+#: panels/user-accounts/data/join-dialog.ui:20
+#: panels/wwan/cc-wwan-mode-dialog.ui:35
+#: panels/wwan/cc-wwan-network-dialog.ui:166
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:297
+msgid "_Cancel"
+msgstr "_Renunță"
+
+#: panels/background/cc-background-chooser.c:348
+#: panels/network/connection-editor/vpn-helpers.c:177
+#: panels/printers/pp-details-dialog.c:236
+#: panels/sharing/cc-sharing-panel.c:397
+#: panels/user-accounts/cc-avatar-chooser.c:229
+msgid "_Open"
+msgstr "_Deschide"
+
+#: panels/background/cc-background-item.c:140
+msgid "multiple sizes"
+msgstr "dimensiuni multiple"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:144
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:282
+msgid "No Desktop Background"
+msgstr "Fără fundal desktop"
+
+#: panels/background/cc-background-panel.c:110
+msgid "Current background"
+msgstr "Fundalul curent"
+
+#: panels/background/cc-background-panel.ui:55
+msgid "Add Picture…"
+msgstr "Adaugă fotografie…"
+
+#: panels/background/cc-background-preview.ui:55
+msgid "Activities"
+msgstr "Activități"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "Fundal"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Schimbă imaginea de fundal într-un tapet sau o fotografie"
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Wallpaper;Screen;Desktop;Tapet;Ecran;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "No Bluetooth Found"
+msgstr "Nu a fost găsit un adaptor Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Introduceți un dispozitiv pentru a folosi Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:69
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth este oprit"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:80
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Deschideți pentru a putea conecta dispozitive și transfera fișiere."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:107
+msgid "Airplane Mode is on"
+msgstr "Mod avion este pornit"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:118
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth este dezactivat când modul avion este pornit."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:124
+msgid "Turn Off Airplane Mode"
+msgstr "Închide modul Avion"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:154
+msgid "Hardware Airplane Mode is on"
+msgstr "Mod hardware avion este pornit"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:165
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Opriți modul avion pentru a putea activa Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1392
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Deschideți și închideți Bluetooth și conectați-vă dispozitivele"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;partajează;partajare;"
+
+#: panels/camera/cc-camera-panel.ui:34
+msgid "Camera is turned off"
+msgstr "Camera este oprită"
+
+#: panels/camera/cc-camera-panel.ui:43
+msgid "No applications can capture photos or video."
+msgstr "Nu s-au găsit aplicații care pot captura fotografii sau video."
+
+#: panels/camera/cc-camera-panel.ui:75
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly."
+msgstr ""
+"Utilizarea camerei permite aplicațiilor să captureze fotografii și videouri. "
+"Dezactivarea camerei poate cauza ca unele aplicații să nu funcționeze corect."
+
+#: panels/camera/cc-camera-panel.ui:85
+msgid "Allow the applications below to use your camera."
+msgstr "Permite aplicațiilor de mai jos să utilizeze camera."
+
+#: panels/camera/cc-camera-panel.ui:105
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Nu sunt aplicații care au cerut accesul la cameră"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Protejați-vă fotografiile"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;ecran;încuiere;recent;rețea;nume;identitate;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Plasați dispozitivul de calibrare deasupra pătratului și apăsați „Start”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Mutați dispozitivul de calibrare pe poziția de calibrare și apăsați "
+"„Continuare”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Mutați dispozitivul de calibrare pe poziția de suprafață și apăsați "
+"„Continuare”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Închideți capacul laptopului"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "A apărut o eroare internă nerecuperabilă."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Uneltele pentru calibrare nu sunt instalate."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Nu s-a putut genera profilul."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Nu s-a putut găsi punctul de țintă alb."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Gata!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Calibrare eșuată!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Puteți deconecta dispozitivul de calibrare."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Nu deranjați dispozitivul în timpul calibrării"
+
+#: panels/color/cc-color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr "Calibrare afișaj"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:40
+msgid "_Start"
+msgstr "_Pornește"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:54
+msgid "_Resume"
+msgstr "_Continuă"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:67 panels/region/cc-format-chooser.ui:64
+#: panels/user-accounts/cc-fingerprint-dialog.ui:73
+msgid "_Done"
+msgstr "_Gata"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Ecran laptop"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Cameră web încorporată"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Monitor %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Scanner %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Cameră %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Imprimantă %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Cameră web %s"
+
+#: panels/color/cc-color-device.c:90
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Activare management culori pentru %s"
+
+#: panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Arată profile de culori pentru %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Necalibrat"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:167
+msgid "Default: "
+msgstr "Implicit: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:175
+msgid "Colorspace: "
+msgstr "Spațiu culoare: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:182
+msgid "Test profile: "
+msgstr "Profil de test: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:236
+msgid "Select ICC Profile File"
+msgstr "Selectați un fișier profil ICC"
+
+#: panels/color/cc-color-panel.c:239
+msgid "_Import"
+msgstr "_Importă"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:250
+msgid "Supported ICC profiles"
+msgstr "Profile ICC recunoscute"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:257
+#: panels/network/wireless-security/eap-method-fast.c:356
+msgid "All files"
+msgstr "Toate fișierele"
+
+#: panels/color/cc-color-panel.c:549
+msgid "Screen"
+msgstr "Ecran"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:839
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Eșec la încărcarea fișierului: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:851
+msgid "The profile has been uploaded to:"
+msgstr "Profilul a fost încărcat în:"
+
+#: panels/color/cc-color-panel.c:853
+msgid "Write down this URL."
+msgstr "Scrieți acest URL."
+
+#: panels/color/cc-color-panel.c:854
+msgid "Restart this computer and boot your normal operating system."
+msgstr "Reporniți calculatorul și intrați în sistemul de operare obișnuit."
+
+#: panels/color/cc-color-panel.c:855
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "Scrieți URL-ul în navigator pentru a descărca și instala profilul."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:883
+msgid "Save Profile"
+msgstr "Salvare profil"
+
+#: panels/color/cc-color-panel.c:887
+#: panels/network/connection-editor/vpn-helpers.c:300
+#: panels/wwan/cc-wwan-apn-dialog.ui:64
+msgid "_Save"
+msgstr "_Salvare"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1196
+msgid "Create a color profile for the selected device"
+msgstr "Creează un profil de culoare pentru dispozitivul ales"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1211 panels/color/cc-color-panel.c:1235
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Instrumentul de măsură nu este detectat. Verificați dacă este pornit și "
+"conectat."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1245
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Instrumentul de măsură nu suportă profilarea pentru imprimante."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1256
+msgid "The device type is not currently supported."
+msgstr "Tipul de dispozitiv nu este recunoscut."
+
+#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:48
+msgid "Screen Calibration"
+msgstr "Calibrare ecran"
+
+#: panels/color/cc-color-panel.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Calibrarea va produce un profil pe care-l puteți folosi pentru a gestiona "
+"culorile ecranului. Cu cât durează mai mult calibrarea, cu atât crește "
+"calitatea profilului de culoare."
+
+#: panels/color/cc-color-panel.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Nu veți mai putea folosi calculatorul în timpul calibrării."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:58
+msgid "Quality"
+msgstr "Calitate"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:75
+msgid "Approximate Time"
+msgstr "Timp aproximativ"
+
+#: panels/color/cc-color-panel.ui:121
+msgid "Calibration Quality"
+msgstr "Calitatea calibrării"
+
+#: panels/color/cc-color-panel.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+"Selectați dispozitivul senzor pe care doriți să-l folosiți pentru calibrare."
+
+#: panels/color/cc-color-panel.ui:174
+msgid "Calibration Device"
+msgstr "Dispozitiv de calibrare"
+
+#: panels/color/cc-color-panel.ui:189
+msgid "Select the type of display that is connected."
+msgstr "Selectați tipul de afișaj conectat."
+
+#: panels/color/cc-color-panel.ui:226
+msgid "Display Type"
+msgstr "Tip de afișaj"
+
+#: panels/color/cc-color-panel.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Selectați un punct alb țintă pentru afișaj. Majoritatea afișajelor ar trebui "
+"calibrate pentru un iluminant D65."
+
+#: panels/color/cc-color-panel.ui:278
+msgid "Profile Whitepoint"
+msgstr "Profil punct alb"
+
+#: panels/color/cc-color-panel.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Configurați afișajul la o luminozitate potrivită. Gestiunea culorilor va "
+"avea precizie maximă la acest nivel de luminozitate."
+
+#: panels/color/cc-color-panel.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Sau puteți folosi nivelul de luminozitate folosit de un alt profil pe "
+"dispozitiv."
+
+#: panels/color/cc-color-panel.ui:318
+msgid "Display Brightness"
+msgstr "Luminozitatea afișajului"
+
+#: panels/color/cc-color-panel.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Puteți folosi un profil de culoare pe mai multe calculatoare, sau să creați "
+"profiluri pentru nivele diferite de iluminare."
+
+#: panels/color/cc-color-panel.ui:348
+msgid "Profile Name:"
+msgstr "Nume profil:"
+
+#: panels/color/cc-color-panel.ui:377
+msgid "Profile Name"
+msgstr "Nume profil"
+
+#: panels/color/cc-color-panel.ui:392
+msgid "Profile successfully created!"
+msgstr "Profil creat cu succes!"
+
+#: panels/color/cc-color-panel.ui:443
+msgid "Copy profile"
+msgstr "Copiază profilul"
+
+#: panels/color/cc-color-panel.ui:456
+msgid "Requires writable media"
+msgstr "Necesită mediu inscriptibil"
+
+#: panels/color/cc-color-panel.ui:519
+msgid "Upload profile"
+msgstr "Încarcă profilul"
+
+#: panels/color/cc-color-panel.ui:532
+msgid "Requires Internet connection"
+msgstr "Necesită conexiune la internet"
+
+#: panels/color/cc-color-panel.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Puteți găsi instrucțiuni utile despre folosirea profilelor pentru sistemele "
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> și <a href="
+"\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:607
+msgid "Summary"
+msgstr "Rezumat"
+
+#: panels/color/cc-color-panel.ui:621
+msgid "Add Profile"
+msgstr "Adaugă profil"
+
+#: panels/color/cc-color-panel.ui:643
+msgid "_Import File…"
+msgstr "_Importă fișier…"
+
+#: panels/color/cc-color-panel.ui:672 panels/keyboard/cc-input-chooser.ui:20
+#: panels/network/connection-editor/net-connection-editor.c:504
+#: panels/printers/new-printer-dialog.ui:80
+#: panels/user-accounts/cc-add-user-dialog.ui:47
+msgid "_Add"
+msgstr "_Adaugă"
+
+#: panels/color/cc-color-panel.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"S-au detectat probleme. Profilul s-ar putea să nu funcționeze corect. <a "
+"href=\"\">Arată detalii.</a>"
+
+#: panels/color/cc-color-panel.ui:788
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Pentru a fi administrat, fiecare dispozitiv are nevoie de actualizarea "
+"profilului de culoare ."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:810
+#: panels/diagnostics/cc-diagnostics-panel.c:144
+msgid "Learn more"
+msgstr "Aflați mai multe"
+
+#: panels/color/cc-color-panel.ui:815
+msgid "Learn more about color management"
+msgstr "Aflați mai multe despre administrarea profilurilor de culoare"
+
+#: panels/color/cc-color-panel.ui:863
+msgid "_Set for all users"
+msgstr "_Stabilește pentru toți utilizatorii"
+
+#: panels/color/cc-color-panel.ui:867 panels/color/cc-color-panel.ui:882
+#: panels/color/cc-color-panel.ui:883
+msgid "Set this profile for all users on this computer"
+msgstr ""
+"Configurează acest profil pentru toți utilizatorii de pe acest calculator"
+
+#: panels/color/cc-color-panel.ui:878
+msgid "_Enable"
+msgstr "Activ_ează"
+
+#: panels/color/cc-color-panel.ui:909
+msgid "_Add profile"
+msgstr "_Adaugă profil"
+
+#: panels/color/cc-color-panel.ui:922
+msgid "_Calibrate…"
+msgstr "_Calibrează…"
+
+#: panels/color/cc-color-panel.ui:926
+msgid "Calibrate the device"
+msgstr "Calibrare dispozitiv"
+
+#: panels/color/cc-color-panel.ui:937
+msgid "_Remove profile"
+msgstr "_Elimină profilul"
+
+#: panels/color/cc-color-panel.ui:950
+msgid "_View details"
+msgstr "_Vizualizare detalii"
+
+#: panels/color/cc-color-panel.ui:986
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+"Nu s-au putut detecta dispozitive pentru care pot fi gestionate culorile"
+
+#: panels/color/cc-color-panel.ui:1030
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:1035
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:1040
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:1045
+msgid "Projector"
+msgstr "Proiector"
+
+#: panels/color/cc-color-panel.ui:1050
+msgid "Plasma"
+msgstr "Plasmă"
+
+#: panels/color/cc-color-panel.ui:1055
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (iluminat CCFL)"
+
+#: panels/color/cc-color-panel.ui:1060
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (iluminat LED-uri RGB)"
+
+#: panels/color/cc-color-panel.ui:1065
+msgid "LCD (white LED backlight)"
+msgstr "LCD (iluminat LED-uri albe)"
+
+#: panels/color/cc-color-panel.ui:1070
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD cu gamă largă (iluminat CCFL)"
+
+#: panels/color/cc-color-panel.ui:1075
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD cu gamă largă (iluminat LED-uri RGB)"
+
+#: panels/color/cc-color-panel.ui:1092
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Lung"
+
+#: panels/color/cc-color-panel.ui:1093
+msgid "40 minutes"
+msgstr "40 de minute"
+
+#: panels/color/cc-color-panel.ui:1097
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Mediu"
+
+#: panels/color/cc-color-panel.ui:1098
+msgid "30 minutes"
+msgstr "30 de minute"
+
+#: panels/color/cc-color-panel.ui:1102
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Scurt"
+
+#: panels/color/cc-color-panel.ui:1103
+msgid "15 minutes"
+msgstr "15 minute"
+
+#: panels/color/cc-color-panel.ui:1125
+msgid "Native to display"
+msgstr "Nativ pentru afișaj"
+
+#: panels/color/cc-color-panel.ui:1129
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Imprimare și publicare)"
+
+#: panels/color/cc-color-panel.ui:1133
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:1137
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografie și grafică)"
+
+#: panels/color/cc-color-panel.ui:1141
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Spațiu standard"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Profil de test"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automat"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Calitate slabă"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Calitate medie"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Calitate înaltă"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB implicit"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK implicit"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Gri implicit"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Date de calibrare furnizate de producător"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Nu este posibilă corecția în mod „tot ecranul” pentru acest profil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Este posibil ca acest profil să nu mai fie corect"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Culoare"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Calibrează culoarea pentru dispozitive cum ar fi afișaje, camere sau "
+"imprimante"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Color;ICC;Profile;Calibrate;Printer;Display;Culoare;Culori;Profil;Calibrare;"
+"Imprimantă;Afișaj;Afișaje;Ecran;Ecrane;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Altele…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Selectați limba"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Selectează"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "No languages found"
+msgstr "Nu s-au găsit limbi"
+
+#: panels/common/cc-language-chooser.ui:82
+#: panels/keyboard/cc-input-chooser.c:178
+msgid "More…"
+msgstr "Mai mult…"
+
+#: panels/common/cc-permission-infobar.c:107
+msgid "Unlock to Change Settings"
+msgstr "Deblochează pentru a modifica configurările"
+
+#: panels/common/cc-permission-infobar.ui:20
+msgid "Unlock…"
+msgstr "Deblochează…"
+
+#: panels/common/cc-permission-infobar.ui:56
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+"Unele configurări trebuie să fie deblocate înainte ca să poată fi modificate."
+
+#: panels/common/cc-time-editor.ui:33
+msgid "Increment Hour"
+msgstr "Incrementează ora"
+
+#: panels/common/cc-time-editor.ui:65
+msgid "Increment Minute"
+msgstr "Incrementează minutul"
+
+#: panels/common/cc-time-editor.ui:80
+msgid "Time"
+msgstr "Ora"
+
+#: panels/common/cc-time-editor.ui:113
+msgid "Decrement Hour"
+msgstr "Decrementează ora"
+
+#: panels/common/cc-time-editor.ui:145
+msgid "Decrement Minute"
+msgstr "Decrementează minutul"
+
+#: panels/common/cc-time-entry.c:219
+msgid "_Copy"
+msgstr "_Copiază"
+
+#: panels/common/cc-time-entry.c:225
+msgid "Select _All"
+msgstr "Selectează to_ate"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:162
+msgid "Today"
+msgstr "Azi"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:164
+msgid "Yesterday"
+msgstr "Ieri"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d oră"
+msgstr[1] "%d ore"
+msgstr[2] "%d de ore"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:973
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minut"
+msgstr[1] "%d minute"
+msgstr[2] "%d de minute"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d secundă"
+msgstr[1] "%d secunde"
+msgstr[2] "%d de secunde"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s și %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s și %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 secunde"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:262
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:267
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:449
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:476
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:483
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:488
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:493
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:498
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:38
+msgid "January"
+msgstr "Ianuarie"
+
+#: panels/datetime/cc-datetime-panel.ui:46
+msgid "February"
+msgstr "Februarie"
+
+#: panels/datetime/cc-datetime-panel.ui:54
+msgid "March"
+msgstr "Martie"
+
+#: panels/datetime/cc-datetime-panel.ui:62
+msgid "April"
+msgstr "Aprilie"
+
+#: panels/datetime/cc-datetime-panel.ui:70
+msgid "May"
+msgstr "Mai"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "June"
+msgstr "Iunie"
+
+#: panels/datetime/cc-datetime-panel.ui:86
+msgid "July"
+msgstr "Iulie"
+
+#: panels/datetime/cc-datetime-panel.ui:94
+msgid "August"
+msgstr "August"
+
+#: panels/datetime/cc-datetime-panel.ui:102
+msgid "September"
+msgstr "Septembrie"
+
+#: panels/datetime/cc-datetime-panel.ui:110
+msgid "October"
+msgstr "Octombrie"
+
+#: panels/datetime/cc-datetime-panel.ui:118
+msgid "November"
+msgstr "Noiembrie"
+
+#: panels/datetime/cc-datetime-panel.ui:126
+msgid "December"
+msgstr "Decembrie"
+
+#: panels/datetime/cc-datetime-panel.ui:136
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Data și ora"
+
+#: panels/datetime/cc-datetime-panel.ui:187
+msgid "Year"
+msgstr "An"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Month"
+msgstr "Lună"
+
+#: panels/datetime/cc-datetime-panel.ui:257
+msgid "Day"
+msgstr "Zi"
+
+#: panels/datetime/cc-datetime-panel.ui:286
+msgid "Time Zone"
+msgstr "Fus orar"
+
+#: panels/datetime/cc-datetime-panel.ui:307
+msgid "Search for a city"
+msgstr "Căutare oraș"
+
+#: panels/datetime/cc-datetime-panel.ui:375
+msgid "Automatic _Date & Time"
+msgstr "_Data și ora automată"
+
+#: panels/datetime/cc-datetime-panel.ui:376
+msgid "Requires internet access"
+msgstr "Necesită acces internet"
+
+#: panels/datetime/cc-datetime-panel.ui:396
+msgid "Date & _Time"
+msgstr "Data și _ora"
+
+#: panels/datetime/cc-datetime-panel.ui:430
+msgid "Automatic Time _Zone"
+msgstr "Fus orar au_tomat"
+
+#: panels/datetime/cc-datetime-panel.ui:431
+msgid "Requires location services enabled and internet access"
+msgstr "Necesită serviciile de localizare activate și acces la internet"
+
+#: panels/datetime/cc-datetime-panel.ui:446
+msgid "Time Z_one"
+msgstr "Fus _orar"
+
+#: panels/datetime/cc-datetime-panel.ui:481
+msgid "Time _Format"
+msgstr "_Format timp"
+
+#: panels/datetime/cc-datetime-panel.ui:490
+msgid "24-hour"
+msgstr "24 de ore"
+
+#: panels/datetime/cc-datetime-panel.ui:491
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Schimbați data și ora, inclusiv fusul orar"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;Ceas;Timp;Fus orar;Locație;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Modifică data și ora sistemului"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Pentru a schimba data sau ora, trebuie să vă autentificați."
+
+#: panels/default-apps/cc-default-apps-panel.ui:31
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:43
+msgid "_Mail"
+msgstr "E-_mail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:59
+msgid "_Calendar"
+msgstr "_Calendar"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "M_usic"
+msgstr "M_uzică"
+
+#: panels/default-apps/cc-default-apps-panel.ui:91
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:162
+#: panels/removable-media/cc-removable-media-panel.ui:162
+msgid "_Photos"
+msgstr "_Fotografii"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Aplicații implicite"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Configurează aplicații implicite"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"default;application;preferred;media;implicit;implicită;implicite;aplicație;"
+"preferată;preferate;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:146
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Trimiterea de rapoarte ale problemelor tehnice ne ajută să îmbunătățim %s. "
+"Rapoartele sunt trimise anonim și sunt curățate de date personale. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:28
+msgid "Problem Reporting"
+msgstr "Raportarea problemelor"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:65
+msgid "_Automatic Problem Reporting"
+msgstr "Raportarea _automată a problemelor"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostice"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Raportați problemele"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;ecran;blocare;diagnostice;pană;privat;temporar;nume;"
+"rețeaidentitate;confidențialitate;"
+
+#: panels/display/cc-display-panel.c:1017
+#: panels/network/connection-editor/connection-editor.ui:27
+msgid "_Apply"
+msgstr "_Aplică"
+
+#: panels/display/cc-display-panel.c:1038
+msgid "Apply Changes?"
+msgstr "Aplicați modificările?"
+
+#: panels/display/cc-display-panel.c:1043
+msgid "Changes Cannot be Applied"
+msgstr "Nu se pot aplica modificările"
+
+#: panels/display/cc-display-panel.c:1044
+msgid "This could be due to hardware limitations."
+msgstr "Aceasta poate fi din cauza limitărilor de hardware."
+
+#: panels/display/cc-display-panel.ui:89
+msgid "Single Display"
+msgstr "Afișaj singular"
+
+#: panels/display/cc-display-panel.ui:108
+#: panels/display/cc-display-panel.ui:310
+msgid "Join Displays"
+msgstr "Unește afișaje"
+
+#: panels/display/cc-display-panel.ui:126
+msgid "Mirror"
+msgstr "Oglindire"
+
+#: panels/display/cc-display-panel.ui:151
+msgid "Display Mode"
+msgstr "Modul de afișaj"
+
+#: panels/display/cc-display-panel.ui:220
+msgid "Contains top bar and Activities"
+msgstr "Conține bara de sus și activitățile"
+
+#: panels/display/cc-display-panel.ui:221
+msgid "Primary Display"
+msgstr "Afișaj primar"
+
+#: panels/display/cc-display-panel.ui:243
+msgid ""
+"Drag displays to match your physical display setup. Select a display to "
+"change its settings."
+msgstr ""
+"Trageți afișaje pentru a le potrivi configurației fizice. Selectați un "
+"afișaj pentru a-i modifica configurările."
+
+#: panels/display/cc-display-panel.ui:250
+msgid "Display Arrangement"
+msgstr "Aranjamentul afișajelor"
+
+#: panels/display/cc-display-panel.ui:374
+msgid "Active Display"
+msgstr "Afișaj activ"
+
+#: panels/display/cc-display-panel.ui:421
+msgid "Display Configuration"
+msgstr "Configurația afișajelor"
+
+#: panels/display/cc-display-panel.ui:440
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ecrane"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:451
+#: panels/display/cc-night-light-page.ui:111
+msgid "Night Light"
+msgstr "Lumină nocturnă"
+
+#: panels/display/cc-display-settings.c:107
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Peisaj"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Portret dreapta"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Portret stânga"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Peisaj (inversat)"
+
+#: panels/display/cc-display-settings.c:190
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:15
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientare"
+
+#: panels/display/cc-display-settings.ui:24
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Rezoluție"
+
+#: panels/display/cc-display-settings.ui:33
+msgid "Refresh Rate"
+msgstr "Rata de reîmprospătare"
+
+#: panels/display/cc-display-settings.ui:42
+msgid "Adjust for TV"
+msgstr "Reglează pentru TV"
+
+#: panels/display/cc-display-settings.ui:59
+#: panels/display/cc-display-settings.ui:76
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Scalare"
+
+#: panels/display/cc-night-light-page.c:627
+msgid "More Warm"
+msgstr "Mai cald"
+
+#: panels/display/cc-night-light-page.c:639
+msgid "Less Warm"
+msgstr "Mai rece"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:28
+msgid "Restart Filter"
+msgstr "Repornește filtrul"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:61
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Dezactivat temporar până mâine"
+
+#: panels/display/cc-night-light-page.ui:88
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Lumina nocturnă face culoarea ecranului mai caldă. Aceasta poate ajuta la "
+"prevenirea extenuării ochilor și a lipsei de somn."
+
+#: panels/display/cc-night-light-page.ui:127
+msgid "Schedule"
+msgstr "Planifică"
+
+#: panels/display/cc-night-light-page.ui:136
+msgid "Sunset to Sunrise"
+msgstr "Apus la răsărit"
+
+#: panels/display/cc-night-light-page.ui:137
+msgid "Manual Schedule"
+msgstr "Planificare manuală"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/region/cc-format-preview.ui:40
+msgid "Times"
+msgstr "Repere orare"
+
+#: panels/display/cc-night-light-page.ui:165
+msgid "From"
+msgstr "De la"
+
+#: panels/display/cc-night-light-page.ui:194
+#: panels/display/cc-night-light-page.ui:297
+msgid "Hour"
+msgstr "Oră"
+
+#: panels/display/cc-night-light-page.ui:203
+#: panels/display/cc-night-light-page.ui:306
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:222
+#: panels/display/cc-night-light-page.ui:325
+msgid "Minute"
+msgstr "Minut"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:234
+#: panels/display/cc-night-light-page.ui:337
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:247
+#: panels/display/cc-night-light-page.ui:350
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:267
+msgid "To"
+msgstr "La"
+
+#: panels/display/cc-night-light-page.ui:374
+msgid "Color Temperature"
+msgstr "Temperatura culorilor"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Alege cum să fie folosite monitoarele și proiectoarele conectate"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;Panou;Proiector;Ecran;Rezoluție;Lumină;"
+"Albastru;culoare;apus;răsărit;"
+
+#: panels/info-overview/cc-info-overview-panel.c:413
+#: panels/info-overview/cc-info-overview-panel.c:437
+#: panels/info-overview/cc-info-overview-panel.c:483
+#: panels/info-overview/cc-info-overview-panel.c:513
+#: panels/wwan/cc-wwan-details-dialog.c:101
+msgid "Unknown"
+msgstr "Necunoscut"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:445
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; ID-ul compilării: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:460
+#, c-format
+msgid "64-bit"
+msgstr "64-biți"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:463
+#, c-format
+msgid "32-bit"
+msgstr "32-biți"
+
+#: panels/info-overview/cc-info-overview-panel.c:720
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:724
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:726
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Necunoscut"
+
+#: panels/info-overview/cc-info-overview-panel.ui:52
+msgid "Device Name"
+msgstr "Nume dispozitiv"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Hardware Model"
+msgstr "Model hardware"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Memory"
+msgstr "Memorie"
+
+#: panels/info-overview/cc-info-overview-panel.ui:92
+msgid "Processor"
+msgstr "Procesor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:101
+msgid "Graphics"
+msgstr "Grafică"
+
+#: panels/info-overview/cc-info-overview-panel.ui:110
+msgid "Disk Capacity"
+msgstr "Capacitate disc"
+
+#: panels/info-overview/cc-info-overview-panel.ui:111
+msgid "Calculating…"
+msgstr "Se calculează…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "OS Name"
+msgstr "Nume SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:142
+msgid "OS Type"
+msgstr "Tip de SO"
+
+#: panels/info-overview/cc-info-overview-panel.ui:151
+msgid "GNOME Version"
+msgstr "Versiune GNOME"
+
+#: panels/info-overview/cc-info-overview-panel.ui:161
+msgid "Windowing System"
+msgstr "Sistem de ferestre"
+
+#: panels/info-overview/cc-info-overview-panel.ui:169
+msgid "Virtualization"
+msgstr "Virtualizare"
+
+#: panels/info-overview/cc-info-overview-panel.ui:178
+msgid "Software Updates"
+msgstr "Actualizări software"
+
+#: panels/info-overview/cc-info-overview-panel.ui:199
+msgid "Rename Device"
+msgstr "Redenumește dispozitivul"
+
+#: panels/info-overview/cc-info-overview-panel.ui:216
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Numele dispozitivului este utilizat pentru a identifica acest dispozitiv "
+"când este vizualizat prin rețea, sau la asocierea dispozitivelor Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:234
+msgid "_Rename"
+msgstr "_Redenumește"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Despre"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Vedeți informații despre sistem"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"dispozitiv;sistem;informații;nume gazdă;memorie;procesor;vesiune;implicit;"
+"aplicație;preferată;detașabil;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Sunet și media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Volum pornit/oprit"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Redu volumul"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Mărește volumul"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Microfon pornit/oprit"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Lansează playerul multimedia"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Redare (sau redare/pauză)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pauză redare"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Oprește redarea"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Piesa precedentă"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Piesa următoare"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Ejectează"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:580
+msgid "Typing"
+msgstr "Tastare"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Comutare la următoarea sursă"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Comutare la sursa precedentă"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Lansatori"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Lansează navigatorul de ajutor"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Lansează calculatorul"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Lansează clientul de e-mail"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Lansează navigatorul web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Dosar personal"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Căutare"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "Capturi de ecran"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr "Salvează capturile în $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Salvează captura unei ferestre în $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Salvează o captură a unei selecții de ecran în $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "Copiază o captură de ecran în clipboard"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Copiază o captură de ecran a unei ferestre în clipboard"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Copiază o captură de ecran a unei zone selectate în clipboard"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr "Înregistrează un scurt video cu capturi de ecran"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistem"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Închide sesiunea"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Blochează ecranul"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Accesibilitate"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Activează sau dezactivează zoom-ul"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Mărește"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Micșorează"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Activează sau dezactivează cititorul de ecran"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Activează sau dezactivează tastatura virtuală"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Mărește dimensiunea textului"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Micșorează dimensiunea textului"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Activează sau dezactivează contrastul puternic"
+
+#: panels/keyboard/cc-input-chooser.c:193
+msgid "No input sources found"
+msgstr "Nu s-au găsit surse de intrare"
+
+#: panels/keyboard/cc-input-chooser.c:964
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Altele"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Adaugă o limbă"
+
+#: panels/keyboard/cc-input-chooser.ui:77
+msgid "Input methods can’t be used on the login screen"
+msgstr "Metodele de intrare nu pot fi folosite la ecranul de autentificare"
+
+#: panels/keyboard/cc-input-list-box.ui:23
+msgid "No input source selected"
+msgstr "Nicio sursă de intrare selectată"
+
+#: panels/keyboard/cc-input-row.ui:75
+msgid "Move up"
+msgstr "Mută în sus"
+
+#: panels/keyboard/cc-input-row.ui:86
+msgid "Move down"
+msgstr "Mută în jos"
+
+#: panels/keyboard/cc-input-row.ui:103
+msgid "Preferences"
+msgstr "Preferințe"
+
+#: panels/keyboard/cc-input-row.ui:120
+msgid "View Keyboard Layout"
+msgstr "Vizualizează aranjamentul tastaturii"
+
+#: panels/keyboard/cc-input-row.ui:137
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:286
+msgid "Remove"
+msgstr "Elimină"
+
+#: panels/keyboard/cc-keyboard-manager.c:486
+#: panels/keyboard/cc-keyboard-manager.c:494
+#: panels/keyboard/cc-keyboard-manager.c:779
+msgid "Custom Shortcuts"
+msgstr "Scurtături personalizate"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.ui:213
+msgid "Alternate Characters Key"
+msgstr "Tastă de caractere alternative"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Tasta de caractere alternative poate fi utilizată pentru a introduce "
+"caractere adiționale. Acestea sunt câteodată tipărite ca o a treia opțiune "
+"pe tastatură."
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt stânga"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt dreapta"
+
+#: panels/keyboard/cc-keyboard-panel.c:73
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Super stânga"
+
+#: panels/keyboard/cc-keyboard-panel.c:74
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Super dreapta"
+
+#: panels/keyboard/cc-keyboard-panel.c:75
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tasta meniului"
+
+#: panels/keyboard/cc-keyboard-panel.c:76
+#: panels/keyboard/cc-keyboard-panel.c:94
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl dreapta"
+
+#: panels/keyboard/cc-keyboard-panel.c:84
+#: panels/keyboard/cc-keyboard-panel.ui:237
+msgid "Compose Key"
+msgstr "Tasta Compunere"
+
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Tasta de compunere permite introducerea a unei varietăți largi de caractere. "
+"Pentru a o utiliza, apăsați compune apoi o secvență de caractere.  De "
+"exemplu, tasta compune urmată de <b>C</b> și <b>o</b> va introduce <b>©</b>, "
+"<b>a</b> urmat de <b>'</b> va introduce <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:95
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Majuscule"
+
+#: panels/keyboard/cc-keyboard-panel.c:96
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Blocare derulare"
+
+#: panels/keyboard/cc-keyboard-panel.c:97
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Captură de ecran"
+
+#: panels/keyboard/cc-keyboard-panel.c:233
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Sursele de intrare pot fi comutate utilizând scurtătura de tastatură %s.\n"
+"Acest lucru poate fi modificat în configurările de scurtături de tastatură."
+
+#: panels/keyboard/cc-keyboard-panel.ui:48
+msgid "Input Sources"
+msgstr "Surse de intrare"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Includes keyboard layouts and input methods."
+msgstr "Include aranjamentele de tastatură și metodele de intrare."
+
+#: panels/keyboard/cc-keyboard-panel.ui:85
+msgid "Input Source Switching"
+msgstr "Comutarea sursei de intrare"
+
+#: panels/keyboard/cc-keyboard-panel.ui:131
+msgid "Use the _same source for all windows"
+msgstr "Folosește aceeași _limbă pentru toate ferestrele"
+
+#: panels/keyboard/cc-keyboard-panel.ui:158
+msgid "Switch input sources _individually for each window"
+msgstr "Comută sursele de intrare _individual pentru fiecare fereastră"
+
+#: panels/keyboard/cc-keyboard-panel.ui:177
+msgid "Special Character Entry"
+msgstr "Introducere caractere speciale"
+
+#: panels/keyboard/cc-keyboard-panel.ui:188
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Metode de a introduce variante de simboluri și litere utilizând tastatura."
+
+#: panels/keyboard/cc-keyboard-panel.ui:263
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:306
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:322 shell/cc-window.ui:326
+msgid "Keyboard Shortcuts"
+msgstr "Scurtături tastatură"
+
+#: panels/keyboard/cc-keyboard-panel.ui:283
+msgid "View and Customize Shortcuts"
+msgstr "Vizualizează și personalizează scurtături"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:283
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d modificat"
+msgstr[1] "%d modificate"
+msgstr[2] "%d modificate"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:428
+msgid "Reset All Shortcuts?"
+msgstr "Restabilesc toate scurtăturile?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:431
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Restabilirea scurtăturilor poate afecta scurtăturile personalizate. Această "
+"acțiune nu poate fi refăcută."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:435
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:275
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+#: panels/wwan/cc-wwan-device-page.c:143
+msgid "Cancel"
+msgstr "Renunță"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:436
+msgid "Reset All"
+msgstr "Restabiliește tot"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:115
+msgid "Add Custom Shortcuts"
+msgstr "Adaugă scurtături personalizate"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:124
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Stabilește scurtături personalizate pentru lansarea de aplicații, rularea de "
+"scripturi, și mai multe."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:131
+msgid "Add Shortcut"
+msgstr "Adaugă scurtătură"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:166
+msgid "No keyboard shortcut found"
+msgstr "Nicio scurtătură de tastatură găsită"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:211
+#: panels/region/cc-format-chooser.ui:48
+#: panels/user-accounts/cc-fingerprint-dialog.ui:53
+#: panels/wacom/wacom-stylus-page.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
+#: shell/cc-window.ui:230
+msgid "Back"
+msgstr "Înapoi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:235
+msgid "Reset All…"
+msgstr "Restabiliește toate…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:236
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Restabilește toate scurtăturile la valorile implicite"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:391
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s este deja utilizat pentru %s. Dacă îl înlocuiți, %s va fi dezactivat"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:535
+msgid "Enter the new shortcut"
+msgstr "Introduceți noua scurtătură"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
+msgid "Set Custom Shortcut"
+msgstr "Stabilește scurtătură personalizată"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:550
+msgid "Set Shortcut"
+msgstr "Stabilește scurtătură"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:561
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Introduceți o scurtătură nouă pentru a modifica %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:987
+msgid "Add Custom Shortcut"
+msgstr "Adaugă scurtățură personalizată"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:60
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Apăsați Esc pentru a anula sau Backspace pentru a dezactiva scurtătura de "
+"tastatură."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:135
+#: panels/printers/pp-details-dialog.ui:40
+#: panels/wwan/cc-wwan-apn-dialog.ui:132
+msgid "Name"
+msgstr "Nume"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:147
+msgid "Command"
+msgstr "Comandă"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:159
+msgid "Shortcut"
+msgstr "Scurtătură"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:238
+msgid "Set Shortcut…"
+msgstr "Stabilește scurtătura…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "Niciuna"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:296
+#: panels/wwan/cc-wwan-apn-dialog.ui:44
+msgid "Add"
+msgstr "Adaugă"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:311
+msgid "Replace"
+msgstr "Înlocuiește"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:325
+msgid "Set"
+msgstr "Stabilește"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:27
+msgid "Reset the shortcut to its default value"
+msgstr "Restabilește scurtătura la valoarea ei inițială"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatură"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Modificați scurtăturile de tastatură și configurați preferințele de tastare, "
+"aranjamentele de tastatură și sursele de intrare"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+"Scurtătură;Scurtături;Fereastră;Redimensionează;Sursă;Blochează;Volum;"
+
+#: panels/location/cc-location-panel.ui:31
+msgid "Location services turned off"
+msgstr "Serviciile de locație sunt oprite"
+
+#: panels/location/cc-location-panel.ui:40
+msgid "No applications can obtain location information."
+msgstr "Nu s-au găsit aplicații care pot obține informațiile de locație."
+
+#: panels/location/cc-location-panel.ui:72
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"Serviciile de locație permit aplicațiilor să cunoască locația dumneavoastră. "
+"Folosind Wi-Fi și rețele mobile de bandă largă măresc acuratețea."
+
+#: panels/location/cc-location-panel.ui:81
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+"Utilizează Serviciul de localizare Mozilla: <a href='https://location."
+"services.mozilla.com/privacy'>Politică de confidențialitate</a>"
+
+#: panels/location/cc-location-panel.ui:94
+msgid "Allow the applications below to determine your location."
+msgstr "Permite aplicațiilor de mai jos să vă determine locația."
+
+#: panels/location/cc-location-panel.ui:114
+msgid "No Applications Have Asked for Location Access"
+msgstr "Nu sunt aplicații care au cerut accesul la locație"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Protejați informațiile de locație"
+
+#. FIXME
+#: panels/lock/cc-lock-panel.ui:27
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Blocarea automată a ecranului previne ca alții să acceseze calculatorul în "
+"timp ce sunteți plecat."
+
+#: panels/lock/cc-lock-panel.ui:44
+msgid "Blank Screen Delay"
+msgstr "Întârziere ecran întunecat"
+
+#: panels/lock/cc-lock-panel.ui:45
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Perioada de inactivitate după care ecranul va fi vid."
+
+#: panels/lock/cc-lock-panel.ui:65
+msgid "Automatic Screen _Lock"
+msgstr "B_locare automată ecran"
+
+#: panels/lock/cc-lock-panel.ui:82
+msgid "Automatic _Screen Lock Delay"
+msgstr "Întârziere automată a blocării _ecranului"
+
+#: panels/lock/cc-lock-panel.ui:83
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Perioada după care ecranul este vid când ecranul este blocat automat."
+
+#: panels/lock/cc-lock-panel.ui:103
+msgid "Show _Notifications on Lock Screen"
+msgstr "Arată _notificările pe ecranul blocat"
+
+#: panels/lock/cc-lock-panel.ui:120
+msgid "Forbid new _USB devices"
+msgstr "Interzice dispozitive _USB noi"
+
+#: panels/lock/cc-lock-panel.ui:121
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Previne dispozitivele USB noi să interacționeze cu sistemul când ecranul "
+"este blocat."
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:166
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Ecranul se închide"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:170
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 de secunde"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:174
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "un minut"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:178
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "două minute"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:182
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minute"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:186
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minute"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:190
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 de minute"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/lock/cc-lock-panel.ui:194
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "o oră"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:209
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "un minut"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:213
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "două minute"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:217
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minute"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:221
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minute"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:225
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minute"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:229
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minute"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:233
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minute"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:237
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minute"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:241
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minute"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/lock/cc-lock-panel.ui:245
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Niciodată"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "Blocare ecran"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr "Blochează ecranul"
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid "Microphone is turned off"
+msgstr "Microfonul este oprit"
+
+#: panels/microphone/cc-microphone-panel.ui:43
+msgid "No applications can record sound."
+msgstr "Nu s-au găsit aplicații care pot înregistra sunetul."
+
+#: panels/microphone/cc-microphone-panel.ui:75
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly."
+msgstr ""
+"Utilizarea microfonului permite aplicațiilor să înregistreze și să asculte "
+"audio. Dezactivarea microfonului poate determina unele aplicații să nu "
+"funcționeze corect."
+
+#: panels/microphone/cc-microphone-panel.ui:85
+msgid "Allow the applications below to use your microphone."
+msgstr "Permite aplicațiilor de mai jos să utilizeze microfonul."
+
+#: panels/microphone/cc-microphone-panel.ui:105
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Nu sunt aplicații care au cerut accesul la microfon"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Protejați conversațiile"
+
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:37
+#: panels/multitasking/cc-multitasking-panel.ui:31
+msgid "General"
+msgstr "Generale"
+
+#: panels/mouse/cc-mouse-panel.ui:57
+msgid "Primary Button"
+msgstr "Buton principal"
+
+#: panels/mouse/cc-mouse-panel.ui:58
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Stabilește ordinea butoanelor fizice pentru mausuri și touchpaduri."
+
+#: panels/mouse/cc-mouse-panel.ui:84 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Stânga"
+
+#: panels/mouse/cc-mouse-panel.ui:94 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Dreapta"
+
+#: panels/mouse/cc-mouse-panel.ui:122
+msgid "Mouse"
+msgstr "Maus"
+
+#: panels/mouse/cc-mouse-panel.ui:142
+msgid "Mouse Speed"
+msgstr "Viteza mausului"
+
+#: panels/mouse/cc-mouse-panel.ui:154 panels/mouse/cc-mouse-panel.ui:258
+msgid "Double-click timeout"
+msgstr "Reglaj clic dublu"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:166 panels/mouse/cc-mouse-panel.ui:230
+msgid "Natural Scrolling"
+msgstr "Derulare naturală"
+
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:231
+msgid "Scrolling moves the content, not the view."
+msgstr "Derularea mută conținutul, nu vizualizarea."
+
+#: panels/mouse/cc-mouse-panel.ui:193 panels/mouse/cc-mouse-panel.ui:213
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:247
+msgid "Touchpad Speed"
+msgstr "Viteza touchpadului"
+
+#: panels/mouse/cc-mouse-panel.ui:270
+msgid "Tap to Click"
+msgstr "Clic tactil"
+
+#: panels/mouse/cc-mouse-panel.ui:286
+msgid "Two-finger Scrolling"
+msgstr "Derulare cu două degete"
+
+#: panels/mouse/cc-mouse-panel.ui:303
+msgid "Edge Scrolling"
+msgstr "Derulare pe margini"
+
+#: panels/mouse/cc-mouse-panel.ui:335 panels/wacom/cc-wacom-panel.c:441
+msgid "Test Your _Settings"
+msgstr "Te_stează configurările"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:25
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Încercați să efectuați clic, clic dublu și derulare"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Cinci clicuri, e timpul pentru GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dublu clic, buton principal"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Un clic, buton principal"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dublu clic, buton mijloc"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Un clic, buton mijloc"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dublu clic, buton secundar"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Un clic, buton secundar"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Maus și touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Schimbați sensibilitatea mausului sau a touchpad-ului și selectați "
+"orientarea de mână dreaptă sau stângă"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;Clic;Derulare;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:56
+msgid "_Hot Corner"
+msgstr "Colț _important"
+
+#: panels/multitasking/cc-multitasking-panel.ui:57
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+"Atingeți colțul din dreapta sus pentru a deschide Vederea de ansamblu a "
+"Activităților."
+
+#: panels/multitasking/cc-multitasking-panel.ui:84
+msgid "_Active Screen Edges"
+msgstr "Margini de ecran _active"
+
+#: panels/multitasking/cc-multitasking-panel.ui:85
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Trageți ferestrele spre marginile de sus, stânga și dreapta pentru a le "
+"redimensiona."
+
+#: panels/multitasking/cc-multitasking-panel.ui:114
+msgid "Workspaces"
+msgstr "Spații de lucru"
+
+#: panels/multitasking/cc-multitasking-panel.ui:139
+msgid "_Dynamic workspaces"
+msgstr "Spații de lucru _dinamice"
+
+#: panels/multitasking/cc-multitasking-panel.ui:140
+msgid "Automatically removes empty workspaces."
+msgstr "Elimină automat spații de lucru goale."
+
+#: panels/multitasking/cc-multitasking-panel.ui:158
+msgid "_Fixed number of workspaces"
+msgstr "Spații de lucru _fixe"
+
+#: panels/multitasking/cc-multitasking-panel.ui:159
+msgid "Specify a number of permanent workspaces."
+msgstr "Specifică un număr permanent de spații de lucru."
+
+#: panels/multitasking/cc-multitasking-panel.ui:179
+msgid "_Number of Workspaces"
+msgstr "_Număr de spații de lucru"
+
+#: panels/multitasking/cc-multitasking-panel.ui:200
+msgid "Multi-Monitor"
+msgstr "Monitoare multiple"
+
+#: panels/multitasking/cc-multitasking-panel.ui:225
+msgid "Workspaces on _primary display only"
+msgstr "Spațiile de lucru doar pe afișajul _principal"
+
+#: panels/multitasking/cc-multitasking-panel.ui:252
+msgid "Workspaces on all d_isplays"
+msgstr "Spații de lucru pe toate _ecranele"
+
+#: panels/multitasking/cc-multitasking-panel.ui:282
+msgid "Application Switching"
+msgstr "Schimbarea între aplicații"
+
+#: panels/multitasking/cc-multitasking-panel.ui:307
+msgid "Include applications from all _workspaces"
+msgstr "Include aplicații de pe toate _spațiile de lucru"
+
+#: panels/multitasking/cc-multitasking-panel.ui:325
+msgid "Include applications from the _current workspace only"
+msgstr "Include aplicații numai de pe spațiul de lucru _curent"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Sarcini multiple"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+"Administrează preferințele pentru productivitate și efectuarea de sarcini "
+"multiple"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Sarcini;Sarcini "
+"multiple;Productivitate;Personalizează;Personalizare;"
+
+#: panels/network/cc-network-panel.c:686 panels/network/cc-wifi-panel.ui:307
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ups, ceva nu a funcționat corect. Vă rugăm să contactați distribuitorul de "
+"software."
+
+#: panels/network/cc-network-panel.c:692
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager trebuie să funcționeze."
+
+#: panels/network/cc-network-panel.ui:66
+msgid "Other Devices"
+msgstr "Alte dispozitive"
+
+#: panels/network/cc-network-panel.ui:107
+#: panels/network/connection-editor/net-connection-editor.c:587
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:151
+msgid "Not set up"
+msgstr "Neconfigurat"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:207
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:262
+msgid "Insecure network (WEP)"
+msgstr "Rețea nesigură (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:267
+msgid "Secure network (WPA)"
+msgstr "Rețea sigură (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:272
+msgid "Secure network (WPA2)"
+msgstr "Rețea sigură (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:277
+msgid "Secure network (WPA3)"
+msgstr "Rețea sigură (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:282
+msgid "Secure network"
+msgstr "Rețea securizată"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:68 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Conectat"
+
+#: panels/network/cc-wifi-connection-row.ui:102
+#: panels/network/net-device-ethernet.c:333
+#: panels/network/network-bluetooth.ui:76
+#: panels/network/network-ethernet.ui:111 panels/network/network-mobile.ui:450
+#: panels/network/network-vpn.ui:77
+msgid "Options…"
+msgstr "Opțiuni…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:134
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Activarea hotspot-ului vă va deconecta de la %s, și nu va fi posibil să "
+"accesați internetul prin Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:267
+msgid "Must have a minimum of 8 characters"
+msgstr "Trebuie să aibă minimum 8 caractere"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:272
+#, c-format
+msgid "Must have a maximum of %d characters"
+msgstr "Trebuie să aibă un maxim de %d de caractere"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:488
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Porinți hotspot Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:19
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Hotspot Wi-Fi permite altora să vă partajeze conexiunea la internet, prin "
+"crearea unei rețele Wi-Fi la care se pot conecta. Pentru a face asta, "
+"trebuie să aveți o conexiune la internet printr-o sursă alta decât Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:44
+msgid "Network Name"
+msgstr "Nume rețea"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:69
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:389
+#: panels/printers/pp-jobs-dialog.ui:70
+#: panels/user-accounts/cc-add-user-dialog.ui:249
+#: panels/wwan/cc-wwan-apn-dialog.ui:214
+msgid "Password"
+msgstr "Parolă"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:83
+msgid "Generate Random Password"
+msgstr "Generează o parolă la întâmplare"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:84
+msgid "Autogenerate Password"
+msgstr "Generează automat o parolă"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:130
+msgid "_Turn On"
+msgstr "_Pornește"
+
+#: panels/network/cc-wifi-panel.c:544
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:53
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:864
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Oprire hotspot și deconectare utilizatori?"
+
+#: panels/network/cc-wifi-panel.c:867
+msgid "_Stop Hotspot"
+msgstr "Oprire hot_spot"
+
+#: panels/network/cc-wifi-panel.ui:46
+msgid "Airplane Mode"
+msgstr "Modul avion"
+
+#: panels/network/cc-wifi-panel.ui:47
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Dezactivează Wi-Fi, Bluetooth și conexiunea de date mobile"
+
+#: panels/network/cc-wifi-panel.ui:87
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nu au fost găsit niciun adaptor Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:99
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Asigurați-vă că aveți un adaptor Wi-Fi conectat și pornit"
+
+#: panels/network/cc-wifi-panel.ui:134 panels/wwan/cc-wwan-panel.ui:143
+msgid "Airplane Mode On"
+msgstr "Modul avion este pornit"
+
+#: panels/network/cc-wifi-panel.ui:146
+msgid "Turn off to use Wi-Fi"
+msgstr "Opriți pentru a utiliza Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:184
+msgid "Wi-Fi Hotspot Active"
+msgstr "Hotspot Wi-Fi activ"
+
+#: panels/network/cc-wifi-panel.ui:195
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Dispozitivele mobile pot scana codul QR pentru a se conecta."
+
+#: panels/network/cc-wifi-panel.ui:205
+msgid "Turn Off Hotspot…"
+msgstr "Oprește hotspot-ul…"
+
+#: panels/network/cc-wifi-panel.ui:227
+msgid "Visible Networks"
+msgstr "Rețele vizibile"
+
+#: panels/network/cc-wifi-panel.ui:296
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager trebuie să funcționeze"
+
+#: panels/network/connection-editor/8021x-security-page.ui:20
+msgid "802.1x _Security"
+msgstr "_Securitate 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:112
+#: panels/network/connection-editor/ce-page-security.c:424
+#: panels/network/connection-editor/details-page.ui:90
+msgid "Security"
+msgstr "Securitate"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Păstrează"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Aleator"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabil"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Adresa MAC introdusă aici va fi utilizată ca adresa de hardware pentru "
+"dispozitivul de rețea pe care este activată această conexiune. Această "
+"funcționalitate este cunoscută ca clonare MAC sau spoofing. Exemplu: "
+"00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profilul %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:228
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:101
+#: panels/network/net-device-wifi.c:233
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:107
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:112
+#: panels/network/connection-editor/ce-page-security.c:279
+msgid "Enhanced Open"
+msgstr "Îmbunătățit deschis"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:119
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:130
+#: panels/network/net-device-wifi.c:218
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Nimic"
+
+#: panels/network/connection-editor/ce-page-details.c:151
+msgid "Never"
+msgstr "Niciodată"
+
+#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/net-device-ethernet.c:108
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "acum %i zi"
+msgstr[1] "acum %i zile"
+msgstr[2] "acum %i de zile"
+
+#: panels/network/connection-editor/ce-page-details.c:293
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:295
+#: panels/network/net-device-ethernet.c:220
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:308
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:312
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:332
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nimic"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Slab"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "În regulă"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bun"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Excelent"
+
+#: panels/network/connection-editor/ce-page-details.c:407
+#: panels/network/connection-editor/details-page.ui:108
+#: panels/network/net-device-ethernet.c:147
+#: panels/network/net-device-mobile.c:442
+msgid "IPv4 Address"
+msgstr "Adresă IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:408
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-mobile.c:443 panels/network/network-mobile.ui:218
+msgid "IPv6 Address"
+msgstr "Adresă IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:410
+#: panels/network/connection-editor/ce-page-details.c:411
+#: panels/network/net-device-ethernet.c:152
+#: panels/network/net-device-ethernet.c:154
+#: panels/network/net-device-mobile.c:446
+#: panels/network/net-device-mobile.c:447 panels/network/network-mobile.ui:201
+msgid "IP Address"
+msgstr "Adresă IP"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-mobile.c:451
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/net-device-ethernet.c:170
+#: panels/network/net-device-mobile.c:452
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/connection-editor/details-page.ui:199
+#: panels/network/connection-editor/details-page.ui:218
+#: panels/network/connection-editor/ip4-page.ui:211
+#: panels/network/connection-editor/ip6-page.ui:225
+#: panels/network/net-device-ethernet.c:172
+#: panels/network/net-device-ethernet.c:174
+#: panels/network/net-device-mobile.c:454
+#: panels/network/net-device-mobile.c:455 panels/network/network-mobile.ui:253
+#: panels/network/network-mobile.ui:271
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:471
+msgid "Forget Connection"
+msgstr "Uită conexiunea"
+
+#: panels/network/connection-editor/ce-page-details.c:473
+msgid "Remove Connection Profile"
+msgstr "Elimină profilul conexiunii"
+
+#: panels/network/connection-editor/ce-page-details.c:475
+msgid "Remove VPN"
+msgstr "Elimină VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:493
+msgid "Details"
+msgstr "Detalii"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automat"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:150
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitate"
+
+#: panels/network/connection-editor/ce-page-ip4.c:245
+#: panels/network/connection-editor/ce-page-ip6.c:226
+msgid "Delete Address"
+msgstr "Șterge adresa"
+
+#: panels/network/connection-editor/ce-page-ip4.c:400
+#: panels/network/connection-editor/ce-page-ip6.c:370
+msgid "Delete Route"
+msgstr "Șterge ruta"
+
+#: panels/network/connection-editor/ce-page-ip4.c:754
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:726
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:268
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Nimic"
+
+#: panels/network/connection-editor/ce-page-security.c:303
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP cheie 40/128-bit (Hex sau ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:313
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit frază secretă"
+
+#: panels/network/connection-editor/ce-page-security.c:326
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:339
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP Dinamic (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:353
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:367
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:381
+msgid "WPA3 Personal"
+msgstr "WPA3 personal"
+
+#: panels/network/connection-editor/details-page.ui:18
+#: panels/wwan/cc-wwan-details-dialog.ui:105
+msgid "Signal Strength"
+msgstr "Putere semnal"
+
+#: panels/network/connection-editor/details-page.ui:54
+msgid "Link speed"
+msgstr "Viteză legătură"
+
+#: panels/network/connection-editor/details-page.ui:144
+#: panels/network/net-device-ethernet.c:157
+msgid "Hardware Address"
+msgstr "Adresă hardware"
+
+#: panels/network/connection-editor/details-page.ui:162
+msgid "Supported Frequencies"
+msgstr "Frecvențe suportate"
+
+#: panels/network/connection-editor/details-page.ui:180
+#: panels/network/net-device-ethernet.c:161
+#: panels/network/net-device-ethernet.c:163
+#: panels/network/net-device-ethernet.c:165
+#: panels/network/network-mobile.ui:235
+msgid "Default Route"
+msgstr "Rută implicită"
+
+#: panels/network/connection-editor/details-page.ui:236
+msgid "Last Used"
+msgstr "Ultima utilizare"
+
+#: panels/network/connection-editor/details-page.ui:415
+msgid "Connect _automatically"
+msgstr "Conectare _automată"
+
+#: panels/network/connection-editor/details-page.ui:434
+msgid "Make available to _other users"
+msgstr "Disp_onibil și pentru alți utilizatori"
+
+#: panels/network/connection-editor/details-page.ui:467
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "Conexiune _măsurată: are limite de date și poate suporta taxe"
+
+#: panels/network/connection-editor/details-page.ui:478
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Actualizările software și alte descărcări mai mari nu vor fi începute "
+"automat."
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "_Nume"
+
+#: panels/network/connection-editor/ethernet-page.ui:54
+#: panels/network/connection-editor/wifi-page.ui:67
+msgid "_MAC Address"
+msgstr "Adresă _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:105
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:122
+#: panels/network/connection-editor/wifi-page.ui:102
+msgid "_Cloned Address"
+msgstr "Adresă _clonată"
+
+#: panels/network/connection-editor/ethernet-page.ui:137
+msgid "bytes"
+msgstr "bytes"
+
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr "Metodă IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:42
+msgid "Automatic (DHCP)"
+msgstr "Automat (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr "Doar link-local"
+
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:118
+msgid "Manual"
+msgstr "Manual"
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr "Dezactivează"
+
+#: panels/network/connection-editor/ip4-page.ui:97
+#: panels/network/connection-editor/ip6-page.ui:111
+msgid "Shared to other computers"
+msgstr "Partajat cu alte calculatoare"
+
+#: panels/network/connection-editor/ip4-page.ui:125
+#: panels/network/connection-editor/ip6-page.ui:139
+msgid "Addresses"
+msgstr "Adrese"
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/printers/pp-details-dialog.ui:95
+msgid "Address"
+msgstr "Adresă"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+msgid "Netmask"
+msgstr "Netmask"
+
+#: panels/network/connection-editor/ip4-page.ui:171
+#: panels/network/connection-editor/ip4-page.ui:355
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:369
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:291
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/connection-editor/ip6-page.ui:305
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:107
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Automat"
+
+#: panels/network/connection-editor/ip4-page.ui:234
+#: panels/network/connection-editor/ip6-page.ui:248
+msgid "Automatic DNS"
+msgstr "DNS automat"
+
+#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Separate IP addresses with commas"
+msgstr "Adrese IP separate prin virgulă"
+
+#: panels/network/connection-editor/ip4-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:293
+msgid "Routes"
+msgstr "Rute"
+
+#: panels/network/connection-editor/ip4-page.ui:302
+#: panels/network/connection-editor/ip6-page.ui:316
+msgid "Automatic Routes"
+msgstr "Rute automate"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:368
+#: panels/network/connection-editor/ip6-page.ui:382
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/network/connection-editor/ip4-page.ui:398
+#: panels/network/connection-editor/ip6-page.ui:412
+msgid "Use this connection _only for resources on its network"
+msgstr "Folosiți conexiunea d_oar pentru resurse aflate pe rețeaua proprie"
+
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr "_Metodă IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr "Automat, doar DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Prefix"
+msgstr "Prefix"
+
+#: panels/network/connection-editor/net-connection-editor.c:280
+msgid "Unable to open connection editor"
+msgstr "Nu se poate deschide editorul de conexiuni"
+
+#: panels/network/connection-editor/net-connection-editor.c:296
+msgid "New Profile"
+msgstr "Profil nou"
+
+#: panels/network/connection-editor/net-connection-editor.c:731
+msgid "Import from file…"
+msgstr "Importă din fișier…"
+
+#: panels/network/connection-editor/net-connection-editor.c:763
+msgid "Add VPN"
+msgstr "Adaugă VPN"
+
+#: panels/network/connection-editor/security-page.ui:20
+msgid "S_ecurity"
+msgstr "S_ecuritate"
+
+#: panels/network/connection-editor/vpn-helpers.c:139
+msgid "Cannot import VPN connection"
+msgstr "Nu se poate importa conexiunea VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Fișierul „%s” nu a putut fi citit sau nu conține informația de conexiune VPN "
+"recunoscută\n"
+"\n"
+"Eroare: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:173
+msgid "Select file to import"
+msgstr "Selectează fișierul de importat"
+
+#: panels/network/connection-editor/vpn-helpers.c:225
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Există deja un fișier cu numele „%s”."
+
+#: panels/network/connection-editor/vpn-helpers.c:227
+msgid "_Replace"
+msgstr "Înlocui_re"
+
+#: panels/network/connection-editor/vpn-helpers.c:229
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Doriți să înlocuiți %s cu conexiunea VPN pe care o salvați?"
+
+#: panels/network/connection-editor/vpn-helpers.c:264
+msgid "Cannot export VPN connection"
+msgstr "Nu se poate exporta conexiunea VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:266
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Conexiunea VPN „%s” nu poate fi exportată în %s.\n"
+"\n"
+"Eroare: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:296
+msgid "Export VPN connection"
+msgstr "Exportă conexiunea VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Eroare: nu se poate încărca editorul de conexiuni VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:20
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:36
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Controlați modul în care vă conectați la Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;Rețea;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Controlați modul în care vă conectați la rețele Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;Rețea;"
+
+#: panels/network/net-device-ethernet.c:96
+msgid "never"
+msgstr "niciodată"
+
+#: panels/network/net-device-ethernet.c:104
+msgid "today"
+msgstr "azi"
+
+#: panels/network/net-device-ethernet.c:106
+msgid "yesterday"
+msgstr "ieri"
+
+#: panels/network/net-device-ethernet.c:180
+msgid "Last used"
+msgstr "Ultima utilizare"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:267
+#: panels/network/network-bluetooth.ui:38 panels/network/network-ethernet.ui:18
+msgid "Wired"
+msgstr "Cu fir"
+
+#: panels/network/net-device-mobile.c:209
+msgid "Add new connection"
+msgstr "Adaugă o nouă conexiune"
+
+#: panels/network/net-device-wifi.c:851
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Detaliile rețelei pentru rețelile selectate, inclusiv parolele și alte "
+"configurări se vor pierde."
+
+#: panels/network/net-device-wifi.c:855
+msgid "_Forget"
+msgstr "_Uită"
+
+#: panels/network/net-device-wifi.c:1034 panels/network/net-device-wifi.c:1041
+msgid "Known Wi-Fi Networks"
+msgstr "Rețele Wi-Fi cunoscute"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1076
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Uită"
+
+#: panels/network/net-device-wifi.c:1217
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Politica de sistem nu permite folosirea ca hotspot"
+
+#: panels/network/net-device-wifi.c:1220
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Dispozitivul wireless nu suporta modul Hotspot"
+
+#: panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:260
+#: panels/power/cc-power-panel.c:856 panels/power/cc-power-panel.c:867
+#: panels/universal-access/cc-ua-panel.c:331
+#: panels/universal-access/cc-ua-panel.c:612
+#: panels/universal-access/cc-ua-panel.c:622
+#: panels/universal-access/cc-ua-panel.c:634
+#: panels/universal-access/cc-ua-panel.c:677
+#: panels/universal-access/cc-ua-panel.ui:338
+#: panels/universal-access/cc-ua-panel.ui:384
+#: panels/universal-access/cc-ua-panel.ui:430
+#: panels/universal-access/cc-ua-panel.ui:536
+#: panels/universal-access/cc-ua-panel.ui:689
+#: panels/universal-access/cc-ua-panel.ui:735
+#: panels/universal-access/cc-ua-panel.ui:781
+#: panels/universal-access/cc-ua-panel.ui:965
+msgid "Off"
+msgstr "Oprit"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Autodescoperirea proxy-ului web este utilizată când nu a fost furnizat un "
+"URL de configurare."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Această opțiune nu este recomandată pentru rețelele publice."
+
+#. update title
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/net-vpn.c:65 panels/network/net-vpn.c:158
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#: panels/network/network-bluetooth.ui:50
+msgid "Turn device off"
+msgstr "Închide dispozitivul"
+
+#: panels/network/network-mobile.ui:29
+#: panels/wwan/cc-wwan-details-dialog.ui:286
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:47
+msgid "Provider"
+msgstr "Furnizor"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:96
+msgid "Network Proxy"
+msgstr "Proxy rețea"
+
+#: panels/network/network-proxy.ui:180
+msgid "_HTTP Proxy"
+msgstr "Proxy _HTTP"
+
+#: panels/network/network-proxy.ui:199
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTPS"
+
+#: panels/network/network-proxy.ui:218
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP"
+
+#: panels/network/network-proxy.ui:237
+msgid "_Socks Host"
+msgstr "Gazdă _socks"
+
+#: panels/network/network-proxy.ui:256
+msgid "_Ignore Hosts"
+msgstr "_Ignoră hosts"
+
+#: panels/network/network-proxy.ui:294
+msgid "HTTP proxy port"
+msgstr "HTTP proxy port"
+
+#: panels/network/network-proxy.ui:371
+msgid "HTTPS proxy port"
+msgstr "HTTPS proxy port"
+
+#: panels/network/network-proxy.ui:392
+msgid "FTP proxy port"
+msgstr "FTP proxy port"
+
+#: panels/network/network-proxy.ui:413
+msgid "Socks proxy port"
+msgstr "Socks proxy port"
+
+#: panels/network/network-proxy.ui:442
+msgid "_Configuration URL"
+msgstr "_URL de configurare"
+
+#: panels/network/network-vpn.ui:56
+msgid "Turn VPN connection off"
+msgstr "Închide conexiunea VPN"
+
+#: panels/network/network-wifi.ui:22
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nume rețea"
+
+#: panels/network/network-wifi.ui:28
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Tip de securitate"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Parolă"
+
+#: panels/network/network-wifi.ui:84
+msgid "Turn Wi-Fi off"
+msgstr "Închide Wi-Fi"
+
+#: panels/network/network-wifi.ui:116
+msgid "_Connect to Hidden Network…"
+msgstr "_Conectare la rețea ascunsă…"
+
+#: panels/network/network-wifi.ui:127
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Porneș_te hotspot Wi-Fi…"
+
+#: panels/network/network-wifi.ui:138
+msgid "_Known Wi-Fi Networks"
+msgstr "Rețele _Wi-Fi cunoscute"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Stare necunoscută"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Negestionat"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Indisponibil"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Se conectează"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Autentificare necesară"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Se deconectează"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Conexiunea a eșuat"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Stare necunoscută (lipsește)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Configurare eșuată"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Configurare IP eșuată"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Configurare IP expirată"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Au fost solicitate elemente de secretizare, dar nu au fost furnizate"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Solicitant 802.1x deconectat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Configurare de solicitant 802.1x eșuată"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Solicitant 802.1x eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Solicitantul 802.1x a necesitat prea mult timp pentru autentificare"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Pornirea serviciului PPP a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Serviciul PPP este deconectat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Pornirea clientului DHCP a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Eroare client DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Clientul DHCP a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Pornirea serviciului de conexiune partajată a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Serviciul de conexiune partajată a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Pornirea serviciului AutoIP a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Eroare serviciu AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Serviciul AutoIP a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linie ocupată"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Fără ton"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Nu poate fi identificată nicio rețea (carrier)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Timp de apel expirat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Încercare de apel eșuată"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Inițializarea modemului a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Eșec la selectarea APN-ului solicitat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Nu se caută rețele"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Înregistrarea în rețea a fost refuzată"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Înregistrarea în rețea a expirat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Eșec la înregistrarea în rețeaua solicitată"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Verificarea PIN-ului a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Firmware-ul pentru acest dispozitiv s-ar putea să lipsească"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Conexiune dispărută"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "S-a preluat conexiunea existentă"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Nu s-a identificat un modem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Conexiunea Bluetooth a eșuat"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Cartela SIM nu este inserată"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Este necesar PIN-ul pentru SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Este necesar PUK-ul pentru SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM greșit"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Dependeță de conectare eșuată"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Lipsă firmware"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Cablu neconectat"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "eroare nespecificată în securitatea 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:195
+msgid "no file selected"
+msgstr "niciun fișier selectat"
+
+#: panels/network/wireless-security/eap-method.c:222
+msgid "unspecified error validating eap-method file"
+msgstr "eroare nespecificată la validarea fișierului metodă eap"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "DER, PEM, sau chei private PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:400
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "Certificate DER sau PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:87
+msgid "missing EAP-FAST PAC file"
+msgstr "lipsește fișierul EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:347
+msgid "Choose a PAC file"
+msgstr "Alegeți un fișier PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:352
+msgid "PAC files (*.pac)"
+msgstr "Fișiere PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonim"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autentificat"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Ambele"
+
+#: panels/network/wireless-security/eap-method-fast.ui:49
+#: panels/network/wireless-security/eap-method-peap.ui:52
+#: panels/network/wireless-security/eap-method-ttls.ui:51
+msgid "Anony_mous identity"
+msgstr "Identitate anoni_mă"
+
+#: panels/network/wireless-security/eap-method-fast.ui:75
+msgid "PAC _file"
+msgstr "_Fișier PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:115
+#: panels/network/wireless-security/eap-method-peap.ui:150
+#: panels/network/wireless-security/eap-method-ttls.ui:143
+msgid "_Inner authentication"
+msgstr "Autentificare _internă"
+
+#: panels/network/wireless-security/eap-method-fast.ui:144
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Permite pro_vizionarea PAC automată"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "lipsește utilizatorul EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "lipsește parola EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:17
+#: panels/network/wireless-security/eap-method-simple.ui:17
+#: panels/network/wireless-security/ws-leap.ui:18
+#: panels/user-accounts/cc-add-user-dialog.ui:146
+#: panels/user-accounts/cc-add-user-dialog.ui:527
+msgid "_Username"
+msgstr "Nume _utilizator"
+
+#: panels/network/wireless-security/eap-method-leap.ui:31
+#: panels/network/wireless-security/eap-method-simple.ui:31
+#: panels/network/wireless-security/ws-leap.ui:32
+#: panels/network/wireless-security/ws-sae.ui:14
+#: panels/network/wireless-security/ws-wpa-psk.ui:14
+#: panels/sharing/cc-sharing-panel.ui:202
+#: panels/user-accounts/cc-add-user-dialog.ui:310
+#: panels/user-accounts/cc-add-user-dialog.ui:547
+#: panels/user-accounts/cc-user-panel.ui:365
+msgid "_Password"
+msgstr "_Parolă"
+
+#: panels/network/wireless-security/eap-method-leap.ui:55
+#: panels/network/wireless-security/eap-method-simple.ui:73
+#: panels/network/wireless-security/eap-method-tls.ui:157
+#: panels/network/wireless-security/ws-leap.ui:56
+#: panels/network/wireless-security/ws-sae.ui:54
+#: panels/network/wireless-security/ws-wpa-psk.ui:64
+msgid "Sho_w password"
+msgstr "Arată paro_la"
+
+#: panels/network/wireless-security/eap-method-peap.c:87
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "certificat CA EAP-PEAP nevalid: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:96
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "certificat CA EAP-PEAP nevalid: niciun certificat specificat"
+
+#: panels/network/wireless-security/eap-method-peap.c:328
+#: panels/network/wireless-security/eap-method-tls.c:513
+#: panels/network/wireless-security/eap-method-ttls.c:336
+msgid "Choose a Certificate Authority certificate"
+msgstr "Alege un certificat semnat de o autoritate de certificare"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Versiunea 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Versiunea 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:78
+#: panels/network/wireless-security/eap-method-tls.ui:68
+#: panels/network/wireless-security/eap-method-ttls.ui:102
+msgid "C_A certificate"
+msgstr "Certificat C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:100
+#: panels/network/wireless-security/eap-method-tls.ui:90
+#: panels/network/wireless-security/eap-method-ttls.ui:125
+msgid "No CA certificate is _required"
+msgstr "Nu este necesar niciun ce_rtificat CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:118
+msgid "PEAP _version"
+msgstr "_Versiune PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "lipsește utilizatorul EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "lipsește parola EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:92
+msgid "missing EAP-TLS identity"
+msgstr "lipsește identitatea EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:102
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "certificat CA EAP-TLS nevalid: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:112
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TLS nevalid: niciun certificat specificat"
+
+#: panels/network/wireless-security/eap-method-tls.c:129
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "cheie privată EAP-TLS nevalidă: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:139
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "certificat EAP-TLS al utilizatorului nevalid: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:272
+msgid "Unencrypted private keys are insecure"
+msgstr "Cheile private necriptate nu sunt sigure"
+
+#: panels/network/wireless-security/eap-method-tls.c:275
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Cheia privată selectată nu pare a fi protejată de o parolă. Aceasta ar putea "
+"duce la compromiterea datelor de autentificare. Vă rugăm selectați o cheie "
+"privată protejată de o parolă.\n"
+"\n"
+"(Puteți proteja o cheie privată cu o parolă cu ajutorul openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:506
+msgid "Choose your personal certificate"
+msgstr "Alegeți un certificat personal"
+
+#: panels/network/wireless-security/eap-method-tls.c:520
+msgid "Choose your private key"
+msgstr "Alegeți o cheie privată"
+
+#: panels/network/wireless-security/eap-method-tls.ui:17
+msgid "I_dentity"
+msgstr "I_dentitate"
+
+#: panels/network/wireless-security/eap-method-tls.ui:43
+msgid "_User certificate"
+msgstr "Certificat _utilizator"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "Private _key"
+msgstr "Cheie p_rivată"
+
+#: panels/network/wireless-security/eap-method-tls.ui:133
+msgid "_Private key password"
+msgstr "Parolă cheie _privată"
+
+#: panels/network/wireless-security/eap-method-ttls.c:98
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "certificat CA EAP-TTLS nevalid: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:106
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "certificat CA EAP-TTLS: niciun certificat specificat"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (fără EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:76
+#: panels/user-accounts/cc-add-user-dialog.ui:507
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "_Domeniu"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Eroare necunoscută la validarea securității 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunneled TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Protejată EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:102
+#: panels/network/wireless-security/ws-wpa-eap.ui:61
+msgid "Au_thentication"
+msgstr "Au_tentificare"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "lipsește utilizatorul leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "lipsește parola leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Parola Wi-Fi lipsește."
+
+#: panels/network/wireless-security/ws-sae.ui:42
+#: panels/network/wireless-security/ws-wpa-psk.ui:42
+msgid "_Type"
+msgstr "_Tipul"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "lipsește cheia wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"cheie wep nevalidă: cheia cu lungimea de %zu trebuie să conțină numai cifre "
+"hexazecimale"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"cheie wep nevalidă: cheia cu lungimea de %zu trebuie să conțină numai "
+"caractere ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"cheie wep nevalidă: lungimea (%zu) cheii este incorectă. O  cheie trebuie să "
+"fie de lungimea 5/13 (ascii) sau 10/26 (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "cheie wep nevalidă: fraza de acces nu trebuie să fie goală"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"cheie wep nevalidă: fraza de acces trebuie să fie mai scurtă de 64 de "
+"caractere"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (implicit)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Sistem deschis"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Cheie comună"
+
+#: panels/network/wireless-security/ws-wep-key.ui:48
+msgid "_Key"
+msgstr "Che_ie"
+
+#: panels/network/wireless-security/ws-wep-key.ui:84
+msgid "Sho_w key"
+msgstr "Arată c_heia"
+
+#: panels/network/wireless-security/ws-wep-key.ui:134
+msgid "WEP inde_x"
+msgstr "WEP inde_x"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-spk nevalidă: lungimea (%zu) cheii nevalidă. Trebuie să fie [8,63] bytes "
+"sau 64 cifre hexazecimale"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "wpa-psk nevalidă: nu se poate interpreta cheia de 64 de bytes ca hex"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:60
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Notificări"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:112
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Alerte sonore"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:168
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Notificări _popup"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:184
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Notificările vor contiuna să apară în lista cu notificări când popup-urile "
+"sunt dezactivate."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:249
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Arată _conținutul mesajelor în popup-uri"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:300
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Notificări ecran de _blocare"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:351
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Arată c_onținutul mesajelor pe ecranul blocat"
+
+#: panels/notifications/cc-notifications-panel.c:260
+#: panels/power/cc-power-panel.c:862 panels/power/cc-power-panel.c:869
+#: panels/universal-access/cc-ua-panel.c:331
+#: panels/universal-access/cc-ua-panel.c:612
+#: panels/universal-access/cc-ua-panel.c:622
+#: panels/universal-access/cc-ua-panel.c:634
+#: panels/universal-access/cc-ua-panel.c:677
+msgid "On"
+msgstr "Pornit"
+
+#: panels/notifications/cc-notifications-panel.ui:44
+msgid "_Do Not Disturb"
+msgstr "_Nu deranja"
+
+#: panels/notifications/cc-notifications-panel.ui:52
+msgid "_Lock Screen Notifications"
+msgstr "Notificări ecran de blocare"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Controlează tipurile de notificări afișate și ce afișează acestea"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Banner;Message;Tray;Popup;"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:148
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Altele"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:576
+#, c-format
+msgid "%s Account"
+msgstr "Cont %s"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:870
+msgid "Error removing account"
+msgstr "Eroare la eliminarea contului"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:936
+#, c-format
+msgid "%s removed"
+msgstr "%s eliminat"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Conturi online"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Conectați-vă la conturile online și decideți modul în care să le folosiți"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:61
+msgid "Undo"
+msgstr "Refă"
+
+#: panels/online-accounts/online-accounts.ui:94
+msgid "Connect to your data in the cloud"
+msgstr "Conectați-vă la datele dumneavoastră din nor"
+
+#: panels/online-accounts/online-accounts.ui:109
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Nicio conexiune la internet — conectați-vă pentru a configura noi conturi "
+"online"
+
+#: panels/online-accounts/online-accounts.ui:134
+msgid "Add an account"
+msgstr "Adaugă un cont"
+
+#: panels/online-accounts/online-accounts.ui:223
+msgid "Remove Account"
+msgstr "Ștergere cont"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Timp necunoscut"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minut"
+msgstr[1] "%i minute"
+msgstr[2] "%i de minute"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i oră"
+msgstr[1] "%i ore"
+msgstr[2] "%i de ore"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "oră"
+msgstr[1] "ore"
+msgstr[2] "de ore"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minute"
+msgstr[2] "de minute"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s până e încărcată complet"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Atenție: au mai rămas %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "au mai rămas %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Complet încărcată"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Nu se încarcă"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Descărcată complet"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Se încarcă"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Se descarcă"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Mouse fără fir"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Tastatură fără fir"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Sursă de curent neîntreruptibilă"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Asistent personal digital"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Telefon celular"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Player media"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209 panels/wacom/cc-wacom-panel.c:728
+msgid "Tablet"
+msgstr "Tabletă"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Calculator"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Dispozitiv de intrare pentru jocuri"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:384
+#: panels/power/cc-power-panel.ui:63
+msgid "Battery"
+msgstr "Baterie"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Principal"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Extra"
+
+#: panels/power/cc-power-panel.c:382
+msgid "Batteries"
+msgstr "Baterii"
+
+#: panels/power/cc-power-panel.c:644
+msgid "When _idle"
+msgstr "Când e _inactiv"
+
+#: panels/power/cc-power-panel.c:796
+msgid "Suspend"
+msgstr "Suspendă"
+
+#: panels/power/cc-power-panel.c:797
+msgid "Power Off"
+msgstr "Oprește"
+
+#: panels/power/cc-power-panel.c:798
+msgid "Hibernate"
+msgstr "Hibernează"
+
+#: panels/power/cc-power-panel.c:799
+msgid "Nothing"
+msgstr "Nimic"
+
+#: panels/power/cc-power-panel.c:858
+msgid "When on battery power"
+msgstr "Când funcționează pe baterie"
+
+#: panels/power/cc-power-panel.c:860
+msgid "When plugged in"
+msgstr "Alimentat de la rețea"
+
+#: panels/power/cc-power-panel.c:980
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Niciodată"
+
+#: panels/power/cc-power-panel.c:1066
+msgid "Automatic suspend"
+msgstr "Suspendare automată"
+
+#: panels/power/cc-power-panel.c:1171
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Modul de performanță este dezactivat temporar din cauza temperaturii înalte "
+"de operare."
+
+#: panels/power/cc-power-panel.c:1173
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Suprafață neregulată detectată: modul de performanță este indisponibil. "
+"Mutați dispozitivul la o suprafață stabilă pentru restaurare."
+
+#: panels/power/cc-power-panel.c:1175
+msgid "Performance mode temporarily disabled."
+msgstr "Modul de performanță este dezactivat temporar."
+
+#: panels/power/cc-power-panel.c:1218
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Baterie pe terminate: economizorul de energie activat. Modul anterior va fi "
+"restaurat când bateria este încărcată suficient."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1226
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Modul de economizare energie activat de „%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1230
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Modul de performanță a fost activat de „%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:13
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minute"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:17
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 de minute"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:21
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 de minute"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:25
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 de minute"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:29
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 de minute"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:33
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "o oră"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:37
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 de minute"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:41
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 de minute"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:45
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 de minute"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:49
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "două ore"
+
+#: panels/power/cc-power-panel.ui:107
+msgid "Power Mode"
+msgstr "Modul de alimentare"
+
+#: panels/power/cc-power-panel.ui:108
+msgid "Affects system performance and power usage."
+msgstr "Afectează performanța sistemului și consumul de energie."
+
+#: panels/power/cc-power-panel.ui:142
+msgid "Power Saving Options"
+msgstr "Opțiuni de economisire de energie"
+
+#: panels/power/cc-power-panel.ui:146
+msgid "Automatic Screen Brightness"
+msgstr "Luminozitate automată pentru ecran"
+
+#: panels/power/cc-power-panel.ui:147
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Luminozitatea ecranului se ajustează după lumina ambientală."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Dim Screen"
+msgstr "Diminuează luminozitatea ecranului"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Reduce luminozitatea ecranului când calculatorul este inactiv."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "Screen _Blank"
+msgstr "Înnegrește ecranul"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Oprește ecranul după o perioadă de inactivitate."
+
+#: panels/power/cc-power-panel.ui:183
+msgid "Automatic Power Saver"
+msgstr "Economizor de energie automat"
+
+#: panels/power/cc-power-panel.ui:184
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+"Activează modul de economizare de energie când bateria este pe terminate."
+
+#: panels/power/cc-power-panel.ui:198
+msgid "_Automatic Suspend"
+msgstr "Suspendare _automată"
+
+#: panels/power/cc-power-panel.ui:199
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pune calculatorul pe pauză după o perioadă de inactivitate."
+
+#: panels/power/cc-power-panel.ui:217
+msgid "Suspend & Power Button"
+msgstr "Buton de suspendare și oprire"
+
+#: panels/power/cc-power-panel.ui:221
+msgid "Po_wer Button Behavior"
+msgstr "Comportament butonului de alimen_tare"
+
+#: panels/power/cc-power-panel.ui:229
+msgid "Show Battery _Percentage"
+msgstr "Arată _procentajul bateriei"
+
+#: panels/power/cc-power-panel.ui:268
+msgid "Automatic Suspend"
+msgstr "Suspendare automată"
+
+#: panels/power/cc-power-panel.ui:293
+msgid "_Plugged In"
+msgstr "Alimentat la _rețea"
+
+#: panels/power/cc-power-panel.ui:309
+msgid "On _Battery Power"
+msgstr "Pe _baterie"
+
+#: panels/power/cc-power-panel.ui:354 panels/power/cc-power-panel.ui:414
+#: panels/universal-access/cc-repeat-keys-dialog.ui:74
+msgid "Delay"
+msgstr "Întârziere"
+
+#: panels/power/cc-power-profile-row.c:61
+msgid "Lap detected: performance mode unavailable"
+msgstr "Etapă detectată: modul de performanță nedisponibil"
+
+#: panels/power/cc-power-profile-row.c:63
+msgid "High hardware temperature: performance mode unavailable"
+msgstr "Temperatură de hardware ridicată: modul de performanță nedisponibil"
+
+#: panels/power/cc-power-profile-row.c:64
+msgid "Performance mode unavailable"
+msgstr "Modul de performanță nedisponibil"
+
+#: panels/power/cc-power-profile-row.c:86
+#: panels/power/cc-power-profile-row.c:185
+msgid "High performance and power usage."
+msgstr "Performanță și consum de energie ridicate."
+
+#: panels/power/cc-power-profile-row.c:184
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Performanță"
+
+#: panels/power/cc-power-profile-row.c:188
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Echilibrată"
+
+#: panels/power/cc-power-profile-row.c:189
+msgid "Standard performance and power usage."
+msgstr "Performanță și consum de energie standard."
+
+#: panels/power/cc-power-profile-row.c:192
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Economizor de energie"
+
+#: panels/power/cc-power-profile-row.c:193
+msgid "Reduced performance and power usage."
+msgstr "Performanță și consum de energie reduse."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Consum"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Stare baterie și schimbare setări consum energie"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;Putere;Somn;Suspendă;Hibernează;Baterie;Luminozitate;Întunecos;Vid;În "
+"așteptare;Energie;"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "Autentificare"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/new-printer-dialog.ui:366
+#: panels/printers/pp-jobs-dialog.ui:57 panels/wwan/cc-wwan-apn-dialog.ui:188
+msgid "Username"
+msgstr "Nume utilizator"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:339
+msgid "Authentication Required"
+msgstr "Necesită autentificare"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:682
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Imprimanta „%s” a fost ștearsă"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:926
+msgid "Failed to add new printer."
+msgstr "Nu s-a putut adăuga imprimanta nouă."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1225
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Nu s-a putut încărca interfața cu utilizatorul: %s"
+
+#: panels/printers/cc-printers-panel.c:1293
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Deblocați pentru a adăuga imprimante și schimba configurări"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Imprimante"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Adaugă imprimante, sarcini de tipărire și ce trebuie imprimat"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"Printer;Queue;Print;Paper;Ink;Toner;Imprimantă;Tipărire;Coadă;Tipărire;"
+"Hârtie;Cerneală;Toner;Laser;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:254
+#: panels/printers/pp-new-printer-dialog.c:311
+msgid "Add Printer"
+msgstr "Adăugare imprimantă"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+#: panels/wwan/cc-wwan-device-page.ui:90
+msgid "_Unlock"
+msgstr "_Deblochează"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:211
+msgid "No Printers Found"
+msgstr "Nu au fost găsite imprimante"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:284
+msgid "Enter a network address or search for a printer"
+msgstr "Introduceți o adresă de rețea sau căutați o imprimantă"
+
+#: panels/printers/new-printer-dialog.ui:356
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Introduceți numele de utilizator și parola pentru a vedea imprimantele de pe "
+"serverul de imprimare."
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:351
+#, c-format
+msgid "%s Details"
+msgstr "Detalii %s"
+
+#: panels/printers/pp-details-dialog.c:101
+msgid "No suitable driver found"
+msgstr "Nu s-a găsit un driver potrivit"
+
+#: panels/printers/pp-details-dialog.c:232
+msgid "Select PPD File"
+msgstr "Specificați fișierul PPD"
+
+#: panels/printers/pp-details-dialog.c:241
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Fișiere descriere imprimantă PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:68 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "Locație"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:122
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Driver"
+
+#: panels/printers/pp-details-dialog.ui:162
+msgid "Searching for preferred drivers…"
+msgstr "Se caută drivere preferate…"
+
+#: panels/printers/pp-details-dialog.ui:183
+msgid "Search for Drivers"
+msgstr "Caută drivere"
+
+#: panels/printers/pp-details-dialog.ui:192
+msgid "Select from Database…"
+msgstr "Selectează din baza de date…"
+
+#: panels/printers/pp-details-dialog.ui:201
+msgid "Install PPD File…"
+msgstr "Instalează fișier PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr "Selectați driverul imprimantei"
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/cc-avatar-chooser.c:107
+msgid "Select"
+msgstr "Selectează"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Se încarcă baza de date cu drivere…"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Imprimantă JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Imprimantă PLD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Pe o parte"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Margine lungă (standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Margine scurtă (întoarsă)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Portret"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Peisaj"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Peisaj inversat"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Portret inversat"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:106
+msgctxt "print job"
+msgid "Pending"
+msgstr "În așteptare"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:112
+msgctxt "print job"
+msgid "Paused"
+msgstr "În pauză"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:117
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autentificare necesară"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:122
+msgctxt "print job"
+msgid "Processing"
+msgstr "Se procesează"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:126
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Oprită"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:130
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Anulată"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:134
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Oprită forțat"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:138
+msgctxt "print job"
+msgid "Completed"
+msgstr "Finalizată"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:249
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u sarcină necesită autentificare"
+msgstr[1] "%u sarcini necesită autentificare"
+msgstr[2] "%u de sarcini necesită autentificare"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:401
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — sarcini active"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:405
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Introduceți credențialele pentru a tipări de la %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:44
+msgid "Domain"
+msgstr "Domeniu"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:129
+msgid "A_uthenticate"
+msgstr "A_utentificare"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:169
+msgid "Clear All"
+msgstr "Curăță tot"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:232
+msgid "_Authenticate"
+msgstr "_Autentificare"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:358
+msgid "No Active Printer Jobs"
+msgstr "Nu sunt sarcini active pentru imprimantă"
+
+#: panels/printers/pp-new-printer-dialog.c:269
+msgid "Unlock Print Server"
+msgstr "Deblocați serverul de imprimare"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:273
+#, c-format
+msgid "Unlock %s."
+msgstr "Deblochează %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:277
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Introduceți numele de utilizator și parola pentru a vedea imprimantele "
+"disponibile pe %s."
+
+#: panels/printers/pp-new-printer-dialog.c:587
+msgid "Searching for Printers"
+msgstr "Se caută imprimante"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1375
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1380
+msgid "Serial Port"
+msgstr "Port serial"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1387
+msgid "Parallel Port"
+msgstr "Port paralel"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1429
+#, c-format
+msgid "Location: %s"
+msgstr "Locație: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1434
+#, c-format
+msgid "Address: %s"
+msgstr "Adresă: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1461
+msgid "Server requires authentication"
+msgstr "Serverul necesită autentificare"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Pe ambele părți"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Tip de hârtie"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Sursă hârtie"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Tavă de ieșire"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Rezoluție"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Pre-filtrare GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:530
+msgid "Pages per side"
+msgstr "Pagini pe foaie"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:542
+msgid "Two-sided"
+msgstr "Pe ambele părți"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:554
+msgid "Orientation"
+msgstr "Orientare"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:651
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "General"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Configurare pagină"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Opțiuni instalabile"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Sarcină"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Calitate imagine"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Culoare"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Se finalizează"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avansat"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:857
+#: panels/printers/pp-options-dialog.ui:18
+msgid "Test Page"
+msgstr "Pagină de test"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:870
+msgid "Test page"
+msgstr "Pagină de test"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Selectare automată"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Configurări implicite pentru imprimantă"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Permite numai fonturile GhostScript înglobate"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Convertește la PS nivelul 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Convertește la PS nivelul 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Fără pre-filtrare"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:203
+msgid "Manufacturer"
+msgstr "Producător"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:523 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr "Nicio sarcină activă"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:528
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u sarcină"
+msgstr[1] "%u sarcini"
+msgstr[2] "%u de sarcini"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:648
+msgid "Clean print heads"
+msgstr "Curăță capetele de imprimare"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:713
+msgid "Low on toner"
+msgstr "Toner puțin"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:715
+msgid "Out of toner"
+msgstr "Fără toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:718
+msgid "Low on developer"
+msgstr "Developator puțin"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of developer"
+msgstr "Fără developator"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:723
+msgid "Low on a marker supply"
+msgstr "Stoc de culoare scăzut"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:725
+msgid "Out of a marker supply"
+msgstr "Stoc de culoare terminat"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:727
+msgid "Open cover"
+msgstr "Capac deschis"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:729
+msgid "Open door"
+msgstr "Ușă deschisă"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:731
+msgid "Low on paper"
+msgstr "Hârtie puțină"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:733
+msgid "Out of paper"
+msgstr "Fără hârtie"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:735
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Deconectată"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:737
+#: panels/printers/pp-printer-entry.c:880
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Oprită"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:739
+msgid "Waste receptacle almost full"
+msgstr "Recipientul pentru deșeuri este aproape plin"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:741
+msgid "Waste receptacle full"
+msgstr "Recipientul pentru deșeuri este plin"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:743
+msgid "The optical photo conductor is near end of life"
+msgstr "Foto-conductorul optic este aproape de sfârșitul vieții"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:745
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Foto-conductorul optic nu mai funcționează"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:866
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Pregătită"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:871
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Nu acceptă sarcini de imprimare"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:876
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Procesează"
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr "Opțiuni de imprimare"
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr "Detaliile imprimantei"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr "Utilizează imprimanta în mod implicit"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr "Curăță capetele de imprimare"
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "Ștergere imprimantă"
+
+#: panels/printers/printer-entry.ui:193
+#: panels/wwan/cc-wwan-details-dialog.ui:229
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr "Nivelul de cerneală"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:313
+msgid "Please restart when the problem is resolved."
+msgstr "Reporniți când problema s-a rezolvat."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:320
+msgid "Restart"
+msgstr "Repornește"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:12
+msgid "Add Printer…"
+msgstr "Adaugă imprimantă…"
+
+#: panels/printers/printers.ui:187
+msgid "No printers"
+msgstr "Fără imprimante"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:201
+msgid "Add a Printer…"
+msgstr "Adăugă o imprimantă…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:233
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"Ne pare rău! Se pare că serviciul\n"
+"de tipărire al sistemului nu este disponibil."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:189
+#: panels/region/cc-format-chooser.ui:6 panels/region/cc-region-panel.ui:203
+msgid "Formats"
+msgstr "Formate"
+
+#: panels/region/cc-format-chooser.ui:101
+msgid ""
+"Choose the format for numbers, dates and currencies. Changes take effect on "
+"next login."
+msgstr ""
+"Alege formatul pentru numere, date și valute. Modificările își fac efectul "
+"la următoarea autentificare."
+
+#: panels/region/cc-format-chooser.ui:117
+msgid "Search locales..."
+msgstr "Caută localizări..."
+
+#: panels/region/cc-format-chooser.ui:158
+msgid "Common Formats"
+msgstr "Formate comune"
+
+#: panels/region/cc-format-chooser.ui:189
+msgid "All Formats"
+msgstr "Toate formatele"
+
+#: panels/region/cc-format-chooser.ui:242
+msgid "No Search Results"
+msgstr "Nu s-au găsit rezultate"
+
+#: panels/region/cc-format-chooser.ui:255
+msgid "Searches can be for countries or languages."
+msgstr "Căutările pot fi pentru țări sau limbi străine."
+
+#: panels/region/cc-format-chooser.ui:300
+msgid "Preview"
+msgstr "Previzualizare"
+
+#: panels/region/cc-format-preview.c:135
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Anglo-saxon"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/region/cc-format-preview.ui:18
+msgid "Dates"
+msgstr "Date"
+
+#: panels/region/cc-format-preview.ui:62
+msgid "Dates & Times"
+msgstr "Date și ore"
+
+#: panels/region/cc-format-preview.ui:84
+msgid "Numbers"
+msgstr "Numere"
+
+#: panels/region/cc-format-preview.ui:106
+msgid "Measurement"
+msgstr "Unități de măsură"
+
+#: panels/region/cc-format-preview.ui:128
+msgid "Paper"
+msgstr "Hârtie"
+
+#: panels/region/cc-region-panel.ui:42
+msgid "My Account"
+msgstr "Contul meu"
+
+#: panels/region/cc-region-panel.ui:53
+msgid "Login Screen"
+msgstr "Ecran de autentificare"
+
+#: panels/region/cc-region-panel.ui:78
+msgid "Language"
+msgstr "Limba"
+
+#: panels/region/cc-region-panel.ui:89
+msgid "The language used for text in windows and web pages."
+msgstr "Limba străină utilizată pentru text în ferestre și pagini web."
+
+#: panels/region/cc-region-panel.ui:129
+#: panels/user-accounts/cc-user-panel.ui:311
+msgid "_Language"
+msgstr "_Limbă"
+
+#: panels/region/cc-region-panel.ui:164
+msgid "Restart the session for changes to take effect"
+msgstr "Reporniți sesiunea pentru ca modificările să aibă efect"
+
+#: panels/region/cc-region-panel.ui:179
+msgid "Restart…"
+msgstr "Repornește…"
+
+#: panels/region/cc-region-panel.ui:214
+msgid "The format used for numbers, dates, and currencies."
+msgstr "Formatul utilizat pentru numere, date și monede."
+
+#: panels/region/cc-region-panel.ui:248
+msgid "_Formats"
+msgstr "_Formate"
+
+#: panels/region/cc-region-panel.ui:275
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"Configurările de autentificare sunt folosite pentru toți utilizatorii la "
+"autentificarea în sistem"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Regiune și limbă"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Selectați limba afișată și formatele"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;Limbă;Aranjament;Intrare;"
+
+#: panels/removable-media/cc-removable-media-panel.c:267
+msgid "Ask what to do"
+msgstr "Întreabă-mă ce să fac"
+
+#: panels/removable-media/cc-removable-media-panel.c:271
+msgid "Do nothing"
+msgstr "Nu fă nimic"
+
+#: panels/removable-media/cc-removable-media-panel.c:275
+msgid "Open folder"
+msgstr "Deschide dosarul"
+
+#: panels/removable-media/cc-removable-media-panel.c:341
+msgid "Other Media"
+msgstr "Deschide suportul multimedia"
+
+#: panels/removable-media/cc-removable-media-panel.c:362
+msgid "Select an application for audio CDs"
+msgstr "Selectați o aplicație pentru CD-uri audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:363
+msgid "Select an application for video DVDs"
+msgstr "Selectați o aplicație pentru DVD-uri video"
+
+#: panels/removable-media/cc-removable-media-panel.c:364
+msgid "Select an application to run when a music player is connected"
+msgstr "Selectați o aplicație de rulat la conectarea unui player de muzică"
+
+#: panels/removable-media/cc-removable-media-panel.c:365
+msgid "Select an application to run when a camera is connected"
+msgstr "Selectați o aplicație de rulat la conectarea unei camere"
+
+#: panels/removable-media/cc-removable-media-panel.c:366
+msgid "Select an application for software CDs"
+msgstr "Selectați o aplicație pentru CD-uri software"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "audio DVD"
+msgstr "DVD audio"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "blank Blu-ray disc"
+msgstr "disc Blu-Ray gol"
+
+#: panels/removable-media/cc-removable-media-panel.c:380
+msgid "blank CD disc"
+msgstr "disc CD gol"
+
+#: panels/removable-media/cc-removable-media-panel.c:381
+msgid "blank DVD disc"
+msgstr "disc DVD gol"
+
+#: panels/removable-media/cc-removable-media-panel.c:382
+msgid "blank HD DVD disc"
+msgstr "disc HD DVD gol"
+
+#: panels/removable-media/cc-removable-media-panel.c:383
+msgid "Blu-ray video disc"
+msgstr "Disc video Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:384
+msgid "e-book reader"
+msgstr "cititor de cărți electronice"
+
+#: panels/removable-media/cc-removable-media-panel.c:385
+msgid "HD DVD video disc"
+msgstr "Disc video HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:386
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:387
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:388
+msgid "Video CD"
+msgstr "CD video"
+
+#: panels/removable-media/cc-removable-media-panel.c:389
+msgid "Windows software"
+msgstr "Software Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:44
+msgid "Select how media should be handled"
+msgstr "Selectați cum ar trebui să se opereze cu fișiere media"
+
+#: panels/removable-media/cc-removable-media-panel.ui:75
+msgid "CD _audio"
+msgstr "CD _audio"
+
+#: panels/removable-media/cc-removable-media-panel.ui:92
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:133
+msgid "_Music player"
+msgstr "Player _muzical"
+
+#: panels/removable-media/cc-removable-media-panel.ui:191
+msgid "_Software"
+msgstr "_Software"
+
+#: panels/removable-media/cc-removable-media-panel.ui:229
+msgid "_Other Media…"
+msgstr "Alte medii de st_ocare…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:288
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Nu solicita și nu porni niciodată programe la introducerea dispozitivelor "
+"detașabile"
+
+#: panels/removable-media/cc-removable-media-panel.ui:342
+msgid "Select how other media should be handled"
+msgstr "Selectați cum ar trebui să se opereze cu alte fișiere media"
+
+#: panels/removable-media/cc-removable-media-panel.ui:389
+msgid "_Action:"
+msgstr "_Acțiune:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:412
+msgid "_Type:"
+msgstr "_Tip:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Medii detașabile"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Configurează medii detașabile"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;dispozitiv;sistem;implicit;implicită;implicite;"
+"aplicație;aplicații;preferate;preferată;amovibil;autopornire;"
+
+#: panels/search/cc-search-locations-dialog.c:636
+msgid "Select Location"
+msgstr "Selectează locația"
+
+#: panels/search/cc-search-locations-dialog.c:640
+msgid "_OK"
+msgstr "_Ok"
+
+#: panels/search/cc-search-locations-dialog.ui:9
+#: panels/search/cc-search-panel.ui:57
+msgid "Search Locations"
+msgstr "Căutare locații"
+
+#: panels/search/cc-search-locations-dialog.ui:32
+#: panels/search/cc-search-locations-dialog.ui:69
+#: panels/search/cc-search-locations-dialog.ui:107
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Dosarele în care aplicațiile sistemului ― cum ar fi Fișiere, Fotografii și "
+"Videouri ― vor efectua căutări."
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Places"
+msgstr "Locuri"
+
+#: panels/search/cc-search-locations-dialog.ui:91
+msgid "Bookmarks"
+msgstr "Semne de carte"
+
+#: panels/search/cc-search-locations-dialog.ui:156
+msgid "Other"
+msgstr "Altele"
+
+#: panels/search/cc-search-panel.c:151
+msgid "No applications found"
+msgstr "Nu s-au găsit aplicații"
+
+#: panels/search/cc-search-panel-row.ui:92
+msgid "Move Up"
+msgstr "Mută în sus"
+
+#: panels/search/cc-search-panel-row.ui:102
+msgid "Move Down"
+msgstr "Mută în jos"
+
+#: panels/search/cc-search-panel.ui:31
+msgid ""
+"Control which search results are shown in the Activities Overview. The order "
+"of search results can also be changed by moving rows in the list."
+msgstr ""
+"Controlează ce rezultate ale căutării sunt afișate în vederea de ansamblu "
+"Activități. Ordinea rezultatelor căutării poate fi modificată și prin "
+"mutarea rândurilor în listă."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Controlează ce aplicații arată rezultate de căutare în panorama de activități"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Find;Index;Hide;Privacy;Results;Caută;Căutare;Găsire;Ascunde;"
+"Confidențialitate;Rezultate;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:306
+msgid "No networks selected for sharing"
+msgstr "Nicio rețea selectată pentru partajare"
+
+#: panels/sharing/cc-sharing-networks.ui:19
+msgid "Networks"
+msgstr "Rețele"
+
+#: panels/sharing/cc-sharing-panel.c:289
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Pornit"
+
+#: panels/sharing/cc-sharing-panel.c:291 panels/sharing/cc-sharing-panel.c:318
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Oprit"
+
+#: panels/sharing/cc-sharing-panel.c:321
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Activat"
+
+#: panels/sharing/cc-sharing-panel.c:324
+msgctxt "service is active"
+msgid "Active"
+msgstr "Activ"
+
+#: panels/sharing/cc-sharing-panel.c:393
+msgid "Choose a Folder"
+msgstr "Alegeți un director"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:696
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Partajarea de fișiere vă permite să vă împărțiți dosarul Public cu alții pe "
+"rețeaua curentă utilizând: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:702
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Când autentificarea la distanță este activată, utilizatorii de la distanță "
+"se pot conecta utilizând comanda Secure Shell:\n"
+"%s"
+
+#. TRANSLATORS: %s is replaced with a link to a vnc://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:708
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to %s"
+msgstr ""
+"Partajarea ecranului permite utilizatorilor de la distanță să vizualizeze "
+"sau să controleze ecranul prin conectarea la %s"
+
+#: panels/sharing/cc-sharing-panel.c:813
+msgid "Copy"
+msgstr "Copiere"
+
+#: panels/sharing/cc-sharing-panel.c:1203
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Partajare"
+
+#: panels/sharing/cc-sharing-panel.ui:32
+msgid "_Computer Name"
+msgstr "Nume _calculator"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_File Sharing"
+msgstr "Partajare _fișiere"
+
+#: panels/sharing/cc-sharing-panel.ui:87
+msgid "_Screen Sharing"
+msgstr "Partajarea _ecranului"
+
+#: panels/sharing/cc-sharing-panel.ui:95
+msgid "_Media Sharing"
+msgstr "Partajare _media"
+
+#: panels/sharing/cc-sharing-panel.ui:103
+msgid "_Remote Login"
+msgstr "Autentifica_re la distanță"
+
+#: panels/sharing/cc-sharing-panel.ui:119
+msgid "Some services are disabled because of no network access."
+msgstr "Unele servicii sunt dezactivate din lipsa accesului la rețea."
+
+#: panels/sharing/cc-sharing-panel.ui:137
+#: panels/sharing/cc-sharing-panel.ui:264
+msgid "File Sharing"
+msgstr "Partajare fișiere"
+
+#: panels/sharing/cc-sharing-panel.ui:184
+msgid "_Require Password"
+msgstr "Necesită o _parolă"
+
+#: panels/sharing/cc-sharing-panel.ui:275
+#: panels/sharing/cc-sharing-panel.ui:345
+msgid "Remote Login"
+msgstr "Autentificare la distanță"
+
+#: panels/sharing/cc-sharing-panel.ui:368
+#: panels/sharing/cc-sharing-panel.ui:590
+msgid "Screen Sharing"
+msgstr "Partajarea ecranului"
+
+#: panels/sharing/cc-sharing-panel.ui:422
+msgid "_Allow connections to control the screen"
+msgstr "Permite conexiunilor să controleze ecr_anul"
+
+#: panels/sharing/cc-sharing-panel.ui:447
+msgid "_Password:"
+msgstr "_Parolă:"
+
+#: panels/sharing/cc-sharing-panel.ui:477
+msgid "_Show Password"
+msgstr "_Arată parola"
+
+#: panels/sharing/cc-sharing-panel.ui:508
+msgid "Access Options"
+msgstr "Opțiuni de acces"
+
+#: panels/sharing/cc-sharing-panel.ui:522
+msgid "_New connections must ask for access"
+msgstr "_Noile conexiuni trebuie să solicite accesul"
+
+#: panels/sharing/cc-sharing-panel.ui:540
+msgid "_Require a password"
+msgstr "_Necesită parolă"
+
+#: panels/sharing/cc-sharing-panel.ui:601
+#: panels/sharing/cc-sharing-panel.ui:695
+msgid "Media Sharing"
+msgstr "Partajare fișiere"
+
+#: panels/sharing/cc-sharing-panel.ui:634
+msgid "Share music, photos and videos over the network."
+msgstr "Partajați muzică, fotografii și videouri prin rețea."
+
+#: panels/sharing/cc-sharing-panel.ui:649
+msgid "Folders"
+msgstr "Dosare"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Controlați ce partajați cu alții"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;partajare;împărtășire;nume;poze;imagini;filme;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Activare sau dezactivare autentificare la distanță"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Este necesară autentificarea pentru a permite sau dezactiva autentificarea "
+"la distanță"
+
+#: panels/sound/cc-alert-chooser.c:151
+msgid "Custom"
+msgstr "Personalizat"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr "Lătrat"
+
+#: panels/sound/cc-alert-chooser.ui:19
+msgid "Drip"
+msgstr "Susur"
+
+#: panels/sound/cc-alert-chooser.ui:26
+msgid "Glass"
+msgstr "Sticlă"
+
+#: panels/sound/cc-alert-chooser.ui:33
+msgid "Sonar"
+msgstr "Sonar"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "Spate"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "Față"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Se testează %s"
+
+#: panels/sound/cc-output-test-dialog.ui:127
+msgid "Click a speaker to test"
+msgstr "Clic pe un difuzor pentru a-l testa"
+
+#: panels/sound/cc-sound-panel.ui:27
+msgid "System Volume"
+msgstr "Volumul sistemului"
+
+#: panels/sound/cc-sound-panel.ui:43
+msgid "Volume Levels"
+msgstr "Nivele de volum"
+
+#: panels/sound/cc-sound-panel.ui:63
+msgid "Output"
+msgstr "Ieșire"
+
+#: panels/sound/cc-sound-panel.ui:90
+msgid "Output Device"
+msgstr "Dispozitiv de ieșire"
+
+#: panels/sound/cc-sound-panel.ui:113
+msgid "Test"
+msgstr "Test"
+
+#: panels/sound/cc-sound-panel.ui:144 panels/sound/cc-sound-panel.ui:319
+msgid "Configuration"
+msgstr "Configurație"
+
+#: panels/sound/cc-sound-panel.ui:177
+msgid "Balance"
+msgstr "Balanță"
+
+#: panels/sound/cc-sound-panel.ui:204
+msgid "Fade"
+msgstr "Estompare"
+
+#: panels/sound/cc-sound-panel.ui:231
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:251
+msgid "Input"
+msgstr "Intrare"
+
+#: panels/sound/cc-sound-panel.ui:278
+msgid "Input Device"
+msgstr "Dispozitiv de intrare"
+
+#: panels/sound/cc-sound-panel.ui:352
+msgid "Volume"
+msgstr "Volum"
+
+#: panels/sound/cc-sound-panel.ui:372
+msgid "Alert Sound"
+msgstr "Sunet de alertă"
+
+#: panels/sound/cc-volume-slider.c:117
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Sunet"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Schimbă nivelurile de sunet, intrările, ieșirile și sunetele de alertă"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Microfon;Căști;"
+"Volum;Balansat;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:94
+#: panels/thunderbolt/cc-bolt-device-entry.c:125
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Deconectat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:97
+#: panels/thunderbolt/cc-bolt-device-entry.c:128
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Se conectează"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:100
+#: panels/thunderbolt/cc-bolt-device-entry.c:132
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Conectat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:103
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Eroare de autorizare"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:106
+#: panels/thunderbolt/cc-bolt-device-entry.c:138
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Autorizare"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Funcționalitate redusă"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:115
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Conectat și autorizat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:121
+#: panels/thunderbolt/cc-bolt-device-entry.c:152
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Necunoscut"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:177
+msgid "Authorized at:"
+msgstr "Autorizat la:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:183
+msgid "Connected at:"
+msgstr "Conectat la:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:190
+msgid "Enrolled at:"
+msgstr "Înscris la:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:264
+msgid "Failed to authorize device: "
+msgstr "Nu s-a putut autoriza dispozitivul: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:333
+msgid "Failed to forget device: "
+msgstr "Nu s-a putut uita dispozitivul: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Depinde de un alt dispozitiv"
+msgstr[1] "Depinde de %u alte dispozitive"
+msgstr[2] "Depinde de %u alte dispozitive"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+msgid "Name:"
+msgstr "Nume:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "Status:"
+msgstr "Stare:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+msgid "Authorize and Connect"
+msgstr "Autorizează și conectează"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+msgid "Forget Device"
+msgstr "Uită dispozitivul"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:135
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Eroare"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:146
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Autorizat"
+
+#: panels/thunderbolt/cc-bolt-panel.c:175
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Subsistemul Thunderbolt (boltd) nu este instalat sau configurat corect."
+
+#: panels/thunderbolt/cc-bolt-panel.c:468
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Nu s-a putut detecta Thunderbolt.\n"
+"Fie sistemul nu are suport pentru Thunderbolt, a fost dezactivat în BIOS sau "
+"este stabilit la un nivel de securitate nesuportat în BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:512
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Suportul pentru Thunderbolt a fost dezactivat în BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:516
+msgid "Thunderbolt security level could not be determined."
+msgstr "Nivelul de securitate Thunderbolt nu a putut fi determinat."
+
+#: panels/thunderbolt/cc-bolt-panel.c:621
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Eroare la comutarea modului direct: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:143
+msgid "No Thunderbolt support"
+msgstr "Nu este suport pentru Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:246
+msgid "Direct Access"
+msgstr "Acces direct"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:269
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Permite accesul direct la dispozitive precum docurile și GPU-urile externe."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:289
+msgid "Only USB and Display Port devices can attach."
+msgstr "Doar dispozitivele USB sau port de afișaj pot atașa."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:397
+msgid "Pending Devices"
+msgstr "Dispozitive în așteptare"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:535
+msgid "No devices attached"
+msgstr "Nu sunt dispozitive atașate"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Administrează dispozitive Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;confidențialitate;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:7
+msgid "Cursor Blinking"
+msgstr "Cursor clipitor"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:37
+msgid "Cursor blinks in text fields."
+msgstr "Cursorul clipește în câmpuri de text."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:74
+#: panels/universal-access/cc-repeat-keys-dialog.ui:145
+msgid "Speed"
+msgstr "Viteză"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:101
+msgid "Cursor blinking speed"
+msgstr "Viteza de clipire a cursorului"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:7
+msgid "Cursor Size"
+msgstr "Dimensiunea cursorului"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:29
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Dimensiunea cursorului poate fi combinată cu zoom pentru a face ecranul mai "
+"lizibil."
+
+#: panels/universal-access/cc-pointing-dialog.ui:7
+msgid "Click Assist"
+msgstr "Asistență la clic"
+
+#: panels/universal-access/cc-pointing-dialog.ui:43
+msgid "_Simulated Secondary Click"
+msgstr "Clic secundar _simulat"
+
+#: panels/universal-access/cc-pointing-dialog.ui:56
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+"Declanșează un clic secundar în timp ce este menținut butonul principal"
+
+#: panels/universal-access/cc-pointing-dialog.ui:79
+#: panels/universal-access/cc-typing-dialog.ui:158
+#: panels/universal-access/cc-typing-dialog.ui:307
+msgid "A_cceptance delay:"
+msgstr "Întârziere a_cceptată:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:95
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Scurtă"
+
+#: panels/universal-access/cc-pointing-dialog.ui:110
+msgid "Secondary click delay"
+msgstr "Întârziere pentru clic secundar"
+
+#: panels/universal-access/cc-pointing-dialog.ui:120
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lungă"
+
+#: panels/universal-access/cc-pointing-dialog.ui:157
+msgid "_Hover Click"
+msgstr "_Clic plutitor"
+
+#: panels/universal-access/cc-pointing-dialog.ui:170
+msgid "Trigger a click when the pointer hovers"
+msgstr "Declanșează un clic când se oprește mișcarea cursorului"
+
+#: panels/universal-access/cc-pointing-dialog.ui:193
+msgid "D_elay:"
+msgstr "Întârzi_ere:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:210
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Scurtă"
+
+#: panels/universal-access/cc-pointing-dialog.ui:232
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lungă"
+
+#: panels/universal-access/cc-pointing-dialog.ui:253
+msgid "Motion _threshold:"
+msgstr "_Prag de mișcare:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:270
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Mică"
+
+#: panels/universal-access/cc-pointing-dialog.ui:292
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Mare"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:7
+msgid "Repeat Keys"
+msgstr "Repetare taste"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:37
+msgid "Key presses repeat when key is held down."
+msgstr "Tastele apăsate se repetă până la eliberare."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:102
+msgid "Repeat keys delay"
+msgstr "Întârziere la repetarea tastelor"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:174
+msgid "Repeat keys speed"
+msgstr "Viteză repetare taste"
+
+#: panels/universal-access/cc-sound-keys-dialog.ui:7
+msgid "Sound Keys"
+msgstr "Taste sonor"
+
+#: panels/universal-access/cc-sound-keys-dialog.ui:25
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Alertează atunci când Num Lock sau Caps Lock sunt activate sau dezactivate."
+
+#: panels/universal-access/cc-sound-keys-dialog.ui:45
+#: panels/universal-access/cc-ua-panel.ui:412
+msgid "_Sound Keys"
+msgstr "Taste pentru control _sunet"
+
+#: panels/universal-access/cc-screen-reader-dialog.ui:7
+msgid "Screen Reader"
+msgstr "Cititor de ecran"
+
+#: panels/universal-access/cc-screen-reader-dialog.ui:24
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Cititorul de ecran citește textul afișat în timp ce mutați focalizarea."
+
+#: panels/universal-access/cc-screen-reader-dialog.ui:52
+msgid "_Screen Reader"
+msgstr "Citit_or de ecran"
+
+#: panels/universal-access/cc-typing-dialog.ui:7
+msgid "Typing Assist"
+msgstr "Asistență la tastare"
+
+#: panels/universal-access/cc-typing-dialog.ui:46
+msgid "_Sticky Keys"
+msgstr "Taste lipicioa_se"
+
+#: panels/universal-access/cc-typing-dialog.ui:58
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Tratează o secvență de taste modificatoare ca o combinație de taste"
+
+#: panels/universal-access/cc-typing-dialog.ui:72
+msgid "_Disable if two keys are pressed together"
+msgstr "_Dezactivează dacă două taste sunt apăsate concomitent"
+
+#: panels/universal-access/cc-typing-dialog.ui:85
+msgid "Beep when a _modifier key is pressed"
+msgstr "Bipăie când e apăsată o tastă _modificatoare"
+
+#: panels/universal-access/cc-typing-dialog.ui:123
+msgid "S_low Keys"
+msgstr "Taste _lente"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Introduce o întârziere între momentul în care o tastă este apăsată și cel în "
+"care este acceptată"
+
+#: panels/universal-access/cc-typing-dialog.ui:175
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Scurtă"
+
+#: panels/universal-access/cc-typing-dialog.ui:190
+msgid "Slow keys typing delay"
+msgstr "Întârziere pentru taste încete"
+
+#: panels/universal-access/cc-typing-dialog.ui:200
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lungă"
+
+#: panels/universal-access/cc-typing-dialog.ui:212
+msgid "Beep when a key is pr_essed"
+msgstr "Bipăi_e la apăsarea unei taste"
+
+#: panels/universal-access/cc-typing-dialog.ui:224
+msgid "Beep when a key is _accepted"
+msgstr "Bipăie când e _acceptată o tastă"
+
+#: panels/universal-access/cc-typing-dialog.ui:236
+#: panels/universal-access/cc-typing-dialog.ui:361
+msgid "Beep when a key is _rejected"
+msgstr "Bipăie dacă o tastă este _respinsă"
+
+#: panels/universal-access/cc-typing-dialog.ui:272
+msgid "_Bounce Keys"
+msgstr "Taste fără re_petiție"
+
+#: panels/universal-access/cc-typing-dialog.ui:284
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignoră apăsările repetate și rapide de taste"
+
+#: panels/universal-access/cc-typing-dialog.ui:324
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Scurtă"
+
+#: panels/universal-access/cc-typing-dialog.ui:339
+msgid "Bounce keys typing delay"
+msgstr "Întârziere pentru taste săritoare"
+
+#: panels/universal-access/cc-typing-dialog.ui:349
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lungă"
+
+#: panels/universal-access/cc-typing-dialog.ui:437
+msgid "_Enable by Keyboard"
+msgstr "Activ_ează cu tastatura"
+
+#: panels/universal-access/cc-typing-dialog.ui:449
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Activează și dezactivează opțiunile de accesibilitate folosind tastatura"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:351
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Implicită"
+
+#: panels/universal-access/cc-ua-panel.c:354
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Medie"
+
+#: panels/universal-access/cc-ua-panel.c:357
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Mare"
+
+#: panels/universal-access/cc-ua-panel.c:360
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Mai mare"
+
+#: panels/universal-access/cc-ua-panel.c:363
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Cel mai mare"
+
+#: panels/universal-access/cc-ua-panel.c:367
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixel"
+msgstr[1] "%d pixeli"
+msgstr[2] "%d de pixeli"
+
+#: panels/universal-access/cc-ua-panel.ui:55
+msgid "_Always Show Accessibility Menu"
+msgstr "_Arată întotdeauna meniul de accesibilitate"
+
+#: panels/universal-access/cc-ua-panel.ui:97
+msgid "Seeing"
+msgstr "Văz"
+
+#: panels/universal-access/cc-ua-panel.ui:143
+msgid "_High Contrast"
+msgstr "_Contrast ridicat"
+
+#: panels/universal-access/cc-ua-panel.ui:190
+msgid "_Large Text"
+msgstr "_Text mărit"
+
+#: panels/universal-access/cc-ua-panel.ui:238
+msgid "Enable A_nimations"
+msgstr "Activează a_nimații"
+
+#: panels/universal-access/cc-ua-panel.ui:273
+msgid "C_ursor Size"
+msgstr "Dimenisunea c_ursorului"
+
+#: panels/universal-access/cc-ua-panel.ui:320
+#: panels/universal-access/cc-zoom-options-dialog.ui:91
+msgid "_Zoom"
+msgstr "_Zoom"
+
+#: panels/universal-access/cc-ua-panel.ui:366
+msgid "Screen _Reader"
+msgstr "Cititor de ec_ran"
+
+#: panels/universal-access/cc-ua-panel.ui:474
+msgid "Hearing"
+msgstr "Auz"
+
+#: panels/universal-access/cc-ua-panel.ui:518
+#: panels/universal-access/cc-visual-alerts-dialog.ui:68
+msgid "_Visual Alerts"
+msgstr "Alerte _vizuale"
+
+#: panels/universal-access/cc-ua-panel.ui:626
+msgid "Screen _Keyboard"
+msgstr "Tastatura pe ecra_n"
+
+#: panels/universal-access/cc-ua-panel.ui:671
+msgid "R_epeat Keys"
+msgstr "R_epetare taste"
+
+#: panels/universal-access/cc-ua-panel.ui:717
+msgid "Cursor _Blinking"
+msgstr "Cursor _clipitor"
+
+#: panels/universal-access/cc-ua-panel.ui:763
+msgid "_Typing Assist (AccessX)"
+msgstr "Asistență la tastare (Acces_X)"
+
+#: panels/universal-access/cc-ua-panel.ui:824
+msgid "Pointing & Clicking"
+msgstr "Cursor și maus"
+
+#: panels/universal-access/cc-ua-panel.ui:870
+msgid "_Mouse Keys"
+msgstr "Taste _Maus"
+
+#: panels/universal-access/cc-ua-panel.ui:915
+msgid "_Locate Pointer"
+msgstr "_Localizează indicatorul"
+
+#: panels/universal-access/cc-ua-panel.ui:947
+msgid "_Click Assist"
+msgstr "Asistență la _clic"
+
+#: panels/universal-access/cc-ua-panel.ui:993
+msgid "_Double-Click Delay"
+msgstr "Întârziere pentru clic-_dublu"
+
+#: panels/universal-access/cc-ua-panel.ui:1013
+msgid "Double-Click Delay"
+msgstr "Întârziere pentru clic-dublu"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:15
+msgid "Visual Alerts"
+msgstr "Alerte vizuale"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:19
+msgid "_Test flash"
+msgstr "_Testare flash"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:48
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Folosește indicarea vizuală atunci când se produce o alertă sonoră."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:94
+msgid "Flash the entire _window"
+msgstr "Clipește întreaga _fereastră"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:112
+msgid "Flash the entire _screen"
+msgstr "Clipește între_g ecranul"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:303
+msgctxt "Distance"
+msgid "Short"
+msgstr "Scurtă"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:304
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ de ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:305
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ de ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ de ecran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "Long"
+msgstr "Lungă"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Ecran complet"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Jumătatea superioară"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Jumătatea inferioară"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Jumătatea stângă"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Jumătatea dreaptă"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:70
+msgid "Zoom Options"
+msgstr "Opțiuni zoom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:151
+msgid "_Magnification:"
+msgstr "_Mărire:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:201
+msgid "_Follow mouse cursor"
+msgstr "_Urmărește cursorul mausului"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:221
+msgid "_Screen part:"
+msgstr "Parte _ecran:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:278
+msgid "Magnifier _extends outside of screen"
+msgstr "Lupa se _extinde peste marginile ecranului"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:292
+msgid "_Keep magnifier cursor centered"
+msgstr "_Păstrează centrat cursorul lupei"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:307
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Cursorul lupei îm_pinge conținutul"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:322
+msgid "Magnifier cursor moves with _contents"
+msgstr "Cursorul lupei se mișcă odată cu _conținutul"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:347
+msgid "Magnifier Position:"
+msgstr "Poziție lupă:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:362
+msgid "Magnifier"
+msgstr "Lupă"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:410
+msgid "_Thickness:"
+msgstr "_Grosime:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:436
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Subțire"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:458
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Gros"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:479
+msgid "_Length:"
+msgstr "_Lungime:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:523
+msgid "Co_lor:"
+msgstr "Cu_loare:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:577
+msgid "_Crosshairs:"
+msgstr "Țin_tă:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:610
+msgid "_Overlaps mouse cursor"
+msgstr "Suprapune peste curs_orul mausului"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:634
+msgid "Crosshairs"
+msgstr "Țintă"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:683
+msgid "_White on black:"
+msgstr "_Alb pe negru:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:703
+msgid "_Brightness:"
+msgstr "_Luminozitate:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:724
+msgid "_Contrast:"
+msgstr "_Contrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:744
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Cu_loare"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:769
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Niciuna"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:791
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Completă"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:844
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Scăzută"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:867
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Ridicată"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:893
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Scăzut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:916
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Ridicat"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:942
+msgid "Color Effects:"
+msgstr "Efecte de culoare:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:958
+msgid "Color Effects"
+msgstr "Efecte de culoare"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"Facilitează vederea, auzul, tastatul, mutatul mausului și apăsarea clicului"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;Tastatură;Maus;Accesibilitate;Acces universal;Sunet;Focalizare;"
+"Cititor;mare;înalt;larg;dimensiune;persistent;taste;lent;încet;fără "
+"repetiție;dublu;clic;amânare;viteză;asistență;repetă;clipește;vizual;auz;"
+"tastare;"
+
+#: panels/usage/cc-usage-panel.c:154
+msgid "Empty all items from Trash?"
+msgstr "Golește coșul de gunoi?"
+
+#: panels/usage/cc-usage-panel.c:155
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Toate elementele din coșul de gunoi vor fi șterse permanent."
+
+#: panels/usage/cc-usage-panel.c:156
+msgid "_Empty Trash"
+msgstr "Gol_ește gunoiul"
+
+#: panels/usage/cc-usage-panel.c:177
+msgid "Delete all the temporary files?"
+msgstr "Șterge toate fișierele temporare?"
+
+#: panels/usage/cc-usage-panel.c:178
+msgid "All the temporary files will be permanently deleted."
+msgstr "Toate fișierele temporare vor fi șterse permanent."
+
+#: panels/usage/cc-usage-panel.c:179
+msgid "_Purge Temporary Files"
+msgstr "Șterge fișierele tem_porare"
+
+#: panels/usage/cc-usage-panel.ui:29
+msgid "File History"
+msgstr "Istoric fișiere"
+
+#: panels/usage/cc-usage-panel.ui:41
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Istoricul fișierelor păstrează o înregistrare a fișierelor pe care le-ați "
+"utilizat. Aceste informații sunt partajate între aplicații, și face mai ușor "
+"găsirea fișierelor pe care poate doriți să le utilizați."
+
+#: panels/usage/cc-usage-panel.ui:56
+msgid "File H_istory"
+msgstr "Istoric f_ișiere"
+
+#: panels/usage/cc-usage-panel.ui:78
+msgid "File _History Duration"
+msgstr "Durata _istoricului fișierelor"
+
+#: panels/usage/cc-usage-panel.ui:119
+msgid "_Clear History…"
+msgstr "_Curăță istoricul…"
+
+#: panels/usage/cc-usage-panel.ui:135
+msgid "Trash & Temporary Files"
+msgstr "Gunoi și fișiere temporare"
+
+#: panels/usage/cc-usage-panel.ui:145
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Gunoiul și fișierele temporare pot câteodată conține informații personale "
+"sau senzitive. Ștergerea lor automată poate ajuta să vă protejați "
+"confidențialitatea."
+
+#: panels/usage/cc-usage-panel.ui:159
+msgid "Automatically Delete _Trash Content"
+msgstr "Șterge automat conținutul _gunoiului"
+
+#: panels/usage/cc-usage-panel.ui:174
+msgid "Automatically Delete Temporary _Files"
+msgstr "Șterge automat _fișierele temporare"
+
+#: panels/usage/cc-usage-panel.ui:196
+msgid "Automatically Delete _Period"
+msgstr "_Perioadă pentru ștergerea automată"
+
+#: panels/usage/cc-usage-panel.ui:238
+msgid "_Empty Trash…"
+msgstr "Gol_ește gunoiul…"
+
+#: panels/usage/cc-usage-panel.ui:250
+msgid "_Delete Temporary Files…"
+msgstr "Ș_terge fișierele temporare…"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:278
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "o oră"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:282
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "o zi"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:286
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "două zile"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:290
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 zile"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:294
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 zile"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:298
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 zile"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:302
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 zile"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:306
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 zile"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:310
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 zile"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/usage/cc-usage-panel.ui:314
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 de zile"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:329
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "o zi"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:333
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 zile"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:337
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 de zile"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/usage/cc-usage-panel.ui:341
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Pentru totdeauna"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Gunoi și istoricul fișierelor"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Nu lăsa urme"
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "Trebuie să potriviți adresele web a furnizorului de logare."
+
+#: panels/user-accounts/cc-add-user-dialog.c:204
+msgid "Failed to add account"
+msgstr "Eșec la adăugarea contului"
+
+#: panels/user-accounts/cc-add-user-dialog.c:661
+#: panels/user-accounts/cc-password-dialog.c:261
+msgid "The passwords do not match."
+msgstr "Parolele nu se potrivesc."
+
+#: panels/user-accounts/cc-add-user-dialog.c:875
+#: panels/user-accounts/cc-add-user-dialog.c:914
+#: panels/user-accounts/cc-add-user-dialog.c:932
+msgid "Failed to register account"
+msgstr "Eșec la înregistrarea contului"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1047
+msgid "No supported way to authenticate with this domain"
+msgstr "Nici o metodă suportată pentru autentificarea cu acest domeniu"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1111
+msgid "Failed to join domain"
+msgstr "Eșec la înregistrarea domeniului"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1166
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Numele de autentificare nu a funcționat.\n"
+"Încercați din nou."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1173
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Parola de autentificare nu a funcționat.\n"
+"Încercați din nou."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid "Failed to log into domain"
+msgstr "Eșec la conectarea în domeniu"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1236
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Nu se poate găsi domeniul. Poate l-ați scris greșit?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "Adaugă utilizator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:180
+msgid "_Full Name"
+msgstr "Nume _complet"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:206
+msgid "Standard"
+msgstr "Standard"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:216
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:232
+msgid "Account _Type"
+msgstr "_Tip cont"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:269
+msgid "Allow user to set a password when they next _login"
+msgstr "Permite stabilirea unei parole folosită la următoarea _autentificare"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:283
+msgid "Set a password _now"
+msgstr "Definește o parolă acu_m"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:405
+msgid "_Confirm"
+msgstr "_Confirmă"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:485
+#: panels/user-accounts/cc-add-user-dialog.ui:692
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Autentificarea pentru companii permite unui utilizator administrat central "
+"să fie folosit pe acest dispozitiv. Puteți folosi acest cont pentru a accesa "
+"resursele companiei de pe internet."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:732
+msgid "You are Offline"
+msgstr "Sunteți deconectat"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:751
+msgid "You must be online in order to add enterprise users."
+msgstr ""
+"Trebuie să fiți conectat la internet pentru a adăuga utilizatori enterprise."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:782
+msgid "_Enterprise Login"
+msgstr "Autentificare _enterprise"
+
+#: panels/user-accounts/cc-avatar-chooser.c:225
+msgid "Browse for more pictures"
+msgstr "Răsfoiește pentru mai multe imagini"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:39
+msgid "Take a Picture…"
+msgstr "Faceți o fotografie…"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:46
+msgid "Select a File…"
+msgstr "Selectați un fișier…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Administrator de amprente"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:23
+msgid "Fingerprint"
+msgstr "Amprentă"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:118
+msgid "_No"
+msgstr "_Nu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:128
+msgid "_Yes"
+msgstr "_Da"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:155
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Doriți să ștergeți amprentele înregistrate astfel încât autentificarea pe "
+"bază de amprente să fie dezactivată?"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid "No Fingerprint device"
+msgstr "Niciun dispozitiv de amprente"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:259
+msgid "Ensure the device is properly connected."
+msgstr "Asigurați-vă că dispozitivul este conectat corespunzător."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:264
+msgid "No fingerprint device"
+msgstr "Niciun dispozitiv de amprente"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:280
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Alegeți un dispozitiv pentru amprente pentru configurare"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:309
+msgid "Fingerprint Device"
+msgstr "Dispozitiv de amprente"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:322
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Autentificarea cu amprentă vă permite să deblocați și să vă autentificați la "
+"calculator cu degetul"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:352
+msgid "_Delete Fingerprints"
+msgstr "Ș_terge amprentele"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:363
+msgid "Fingerprint Login"
+msgstr "Autentificare prin amprentă"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:412
+msgid "Fingerprint Enroll"
+msgstr "Înregistrarea amprentei"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:436
+msgid "_Re-enroll this finger…"
+msgstr "_Re-înregistrați acest deget…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:236
+msgid "the device needs to be claimed to perform this action"
+msgstr ""
+"dispozitivul trebuie să fie revendicat pentru a executa această acțiune"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:238
+msgid "the device is already claimed by another process"
+msgstr "dispozitivul este revendicat deja de către alt proces"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:240
+msgid "you do not have permission to perform the action"
+msgstr "nu aveți permisiune pentru a executa această acțiune"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:242
+msgid "no prints have been enrolled"
+msgstr "nu a fost înscrisă nicio tipărire"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:251
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Comunicarea nu a reușit cu dispozitivul în timpul înscrierii"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:255
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Comunicarea nu a reușit cu cititorul de amprente"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:257
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Comunicarea nu a reușit cu serviciul de amprente"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:585
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Eșec la listarea amprentelor: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:652
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Eșec la ștergerea amprentelor salvate: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:683
+msgid "Left thumb"
+msgstr "Degetul mare stâng"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:685
+msgid "Left middle finger"
+msgstr "Degetul mijlociu stâng"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:687
+msgid "_Left index finger"
+msgstr "Arătătoru_l mâinii stângi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:689
+msgid "Left ring finger"
+msgstr "Degetul inelar stâng"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:691
+msgid "Left little finger"
+msgstr "Degetul mic stâng"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:693
+msgid "Right thumb"
+msgstr "Degetul mare drept"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:695
+msgid "Right middle finger"
+msgstr "Degetul mijlociu drept"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:697
+msgid "_Right index finger"
+msgstr "Arătătorul mâinii d_repte"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:699
+msgid "Right ring finger"
+msgstr "Degetul inelar drept"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:701
+msgid "Right little finger"
+msgstr "Degetul mic drept"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:703
+msgid "Unknown Finger"
+msgstr "Deget necunoscut"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:837
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Complet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:848
+msgid "Fingerprint device disconnected"
+msgstr "Dispozitivul de amprente este deconectat"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:854
+msgid "Fingerprint device storage is full"
+msgstr "Dispozitivul de stocare amprente este plin"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:858
+msgid "Failed to enroll new fingerprint"
+msgstr "Eșec la înregistrarea noii amprente"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:889
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Eșec la pornirea înregistrării: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:897
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Eșec la înregistrarea noii amprente"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Eșec la oprirea înregistrării: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:974
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Ridicați și plasați degetul pe cititor în mod repetat pentru a vă înregistra "
+"amprenta"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1118
+msgid "Scan new fingerprint"
+msgstr "Scanați amprentă nouă"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1157
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Eșec la detașarea dispozitivului de amprente %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1229
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problemă la citirea dispozitiivului"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1264
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Eșec la asumarea dispozitivului de amprente %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1413
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Eșec la obținerea dispozitivelor de amprente: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:69
+msgid "This Week"
+msgstr "Această săptămână"
+
+#: panels/user-accounts/cc-login-history-dialog.c:72
+msgid "Last Week"
+msgstr "Săptămâna trecută"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:82
+#: panels/user-accounts/cc-login-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:91
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:96
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:173
+#: panels/user-accounts/cc-user-panel.c:771
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:176
+#: panels/user-accounts/cc-user-panel.c:775
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:243
+msgid "Session Ended"
+msgstr "Sesiune terminată"
+
+#: panels/user-accounts/cc-login-history-dialog.c:249
+msgid "Session Started"
+msgstr "Sesiunea a început"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:343
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Activitatea contului"
+
+#: panels/user-accounts/cc-password-dialog.c:125
+msgid "Please choose another password."
+msgstr "Alegeți altă parolă."
+
+#: panels/user-accounts/cc-password-dialog.c:134
+msgid "Please type your current password again."
+msgstr "Tastează parola curentă încă o dată."
+
+#: panels/user-accounts/cc-password-dialog.c:140
+msgid "Password could not be changed"
+msgstr "Parola nu a putut fi schimbată"
+
+#: panels/user-accounts/cc-password-dialog.ui:7
+msgid "Change Password"
+msgstr "Schimbă parola"
+
+#: panels/user-accounts/cc-password-dialog.ui:37
+msgid "Ch_ange"
+msgstr "_Schimbă"
+
+#: panels/user-accounts/cc-password-dialog.ui:145
+msgid "_Confirm New Password"
+msgstr "_Confirmare parolă nouă"
+
+#: panels/user-accounts/cc-password-dialog.ui:162
+msgid "_New Password"
+msgstr "Parola _nouă"
+
+#: panels/user-accounts/cc-password-dialog.ui:216
+msgid "Current _Password"
+msgstr "_Parola curentă"
+
+#: panels/user-accounts/cc-password-dialog.ui:254
+msgid "Allow user to change their password on next login"
+msgstr "Permite utilizatorului să-și schimbe parola la următoarea logare"
+
+#: panels/user-accounts/cc-password-dialog.ui:267
+msgid "Set a password now"
+msgstr "Definește o parolă nouă"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Nu se poate conecta automat la acest tip de domeniu"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Nu este găsit niciun domeniu și nicio valoare reală"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Nu se poate realiza conectarea ca %s în domeniul %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Parola nu este validă, încercați din nou"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Nu se poate realiza conectarea la domeniul %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:222
+msgid "Your account"
+msgstr "Contul tău"
+
+#: panels/user-accounts/cc-user-panel.c:402
+msgid "Failed to delete user"
+msgstr "Ștergerea utilizatorului a eșuat"
+
+#: panels/user-accounts/cc-user-panel.c:457
+#: panels/user-accounts/cc-user-panel.c:512
+#: panels/user-accounts/cc-user-panel.c:558
+msgid "Failed to revoke remotely managed user"
+msgstr "A eșuat eliminarea utilizatorului gestionat la distanță"
+
+#: panels/user-accounts/cc-user-panel.c:607
+msgid "You cannot delete your own account."
+msgstr "Nu vă puteți șterge propriul cont."
+
+#: panels/user-accounts/cc-user-panel.c:616
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s este încă autentificat"
+
+#: panels/user-accounts/cc-user-panel.c:620
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Ștergerea unui utilizator când acesta este încă autentificat poate aduce "
+"sistemul într-o stare inconsistentă."
+
+#: panels/user-accounts/cc-user-panel.c:629
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Doriți să păstrați fișierele lui %s?"
+
+#: panels/user-accounts/cc-user-panel.c:633
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Este posibil să păstrați dosarul personal, emailurile și fișierele temporare "
+"după ștergerea unui cont."
+
+#: panels/user-accounts/cc-user-panel.c:636
+msgid "_Delete Files"
+msgstr "Ș_terge fișierele"
+
+#: panels/user-accounts/cc-user-panel.c:637
+msgid "_Keep Files"
+msgstr "_Păstrează fișierele"
+
+#: panels/user-accounts/cc-user-panel.c:651
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Sigur doriți să eliminați contul %s gestionat de la distanță?"
+
+#: panels/user-accounts/cc-user-panel.c:655
+msgid "_Delete"
+msgstr "Ș_terge fișierele"
+
+#: panels/user-accounts/cc-user-panel.c:705
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Cont dezactivat"
+
+#: panels/user-accounts/cc-user-panel.c:713
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Va fi definită la următoarea autentificare"
+
+#: panels/user-accounts/cc-user-panel.c:716
+msgctxt "Password mode"
+msgid "None"
+msgstr "Niciuna"
+
+#: panels/user-accounts/cc-user-panel.c:759
+msgid "Logged in"
+msgstr "Autentificat"
+
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:846
+#: panels/user-accounts/cc-user-panel.c:935
+#: panels/wwan/cc-wwan-device-page.c:443
+msgid "Enabled"
+msgstr "Activat"
+
+#: panels/user-accounts/cc-user-panel.c:1259
+msgid "Failed to contact the accounts service"
+msgstr "Contactarea serviciului pentru conturi a eșuat"
+
+#: panels/user-accounts/cc-user-panel.c:1261
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Asigurați-vă că aplicația AccountService este corect instalată."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Pentru a face schimbări,\n"
+"apăsați întâi clic pe iconița *"
+
+#: panels/user-accounts/cc-user-panel.c:1366
+msgid "Delete the selected user account"
+msgstr "Șterge contul de utilizator selectat"
+
+#: panels/user-accounts/cc-user-panel.c:1378
+#: panels/user-accounts/cc-user-panel.c:1489
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Pentru a șterge un cont de utilizator,\n"
+"efectuați clic pe iconița *"
+
+#: panels/user-accounts/cc-user-panel.c:1535
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Deblocați pentru a adăuga utilizatori și schimba configurări"
+
+#: panels/user-accounts/cc-user-panel.ui:6
+msgid "_Add User…"
+msgstr "_Adaugă utilizator…"
+
+#: panels/user-accounts/cc-user-panel.ui:9
+msgid "Create a user account"
+msgstr "Creează un cont de utilizator"
+
+#: panels/user-accounts/cc-user-panel.ui:64
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Sesiunea trebuie repornită pentru ca schimbările să aibă efect"
+
+#: panels/user-accounts/cc-user-panel.ui:72
+msgid "Restart Now"
+msgstr "Repornește acum"
+
+#: panels/user-accounts/cc-user-panel.ui:157
+#: panels/user-accounts/cc-user-panel.ui:173
+msgid "User Icon"
+msgstr "Iconiță utilizator"
+
+#: panels/user-accounts/cc-user-panel.ui:249
+msgid "Account Settings"
+msgstr "Configurări cont"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid "_Administrator"
+msgstr "_Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:268
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administratorii pot adăuga sau elimina alți utilizatori, și pot modifica "
+"configurări pentru toți utilizatorii."
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "_Parental Controls"
+msgstr "Control _parental"
+
+#: panels/user-accounts/cc-user-panel.ui:285
+msgid "Open the Parental Controls application."
+msgstr "Deschide aplicația de Control parental."
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Authentication & Login"
+msgstr "Autentificare și login"
+
+#: panels/user-accounts/cc-user-panel.ui:390
+msgid "_Fingerprint Login"
+msgstr "Autenti_ficare cu amprentă digitală"
+
+#: panels/user-accounts/cc-user-panel.ui:415
+msgid "A_utomatic Login"
+msgstr "Autentificare a_utomată"
+
+#: panels/user-accounts/cc-user-panel.ui:429
+msgid "Account Activity"
+msgstr "Activitate cont"
+
+#: panels/user-accounts/cc-user-panel.ui:460
+msgid "Remove User…"
+msgstr "Șterge utilizator…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:501
+msgid "No Users Found"
+msgstr "Nu au fost găsiți utilizatori"
+
+#: panels/user-accounts/cc-user-panel.ui:511
+msgid "Unlock to add a user account."
+msgstr "Deblochează pentru a adăuga un cont de utilizator."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Utilizatori"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Adăugați și ștergeți utilizatori și schimbați parola"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+"Autentificare;Nume;Amprentă;Față;Parolă;Control parental;Restricții "
+"aplicații;Restricții web;Utilizare;Limita de utilizare;Limită de utilizare;"
+"Copil;Copii;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr "Înscr_ie"
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "Conectare administrator domeniu"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Pentru a folosi autentificarea enterprise, \n"
+"acest calculator trebuie să fie înregistrat în domeniu. Cereți \n"
+" administratorului de rețea să scrie aici parola pentru domeniu."
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "_Nume administrator"
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "Parolă administrator"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Administrare conturi de utilizator"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Pentru modificarea datelor utilizatorilor trebuie să vă autentificați"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Noua parolă trebuie să fie diferită de parola veche."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Încercați să șchimbați unele litere sau numere."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Încercați să mai schimbați puțin parola."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "O parolă fără nume utilizator trebuie să fie mai puternică."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Încercați să evitați folosirea numelui în parolă."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Încercați să evitați unele cuvinte incluse în parolă."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Încercați să evitați cuvinte comune."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Încercați să evitați rearanjarea cuvintelor existente."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Încercați folosirea mai multor numere."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Încercați mai multe litere mari."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Încercați mai multe litere mici."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Încercați mai multe caractere speciale, cum ar fi punctuația."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Încercați o combinație de litere, numere și punctuație."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Evitați repetarea aceluiași caracter."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Evitați repetarea aceluiași top de caracter: trebuie să amestecați litere, "
+"numere și punctuație."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Evitați secvențele de top 1234 sau abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Parola trebuie să fie mai lungă. Adăugați mai multe litere, numere și semne "
+"de punctuație."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Amestecați literele mari și mici și folosiți unul sau două numere."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Adăugând mai multe litere, numere și semne de punctuație va face parola mai "
+"puternică."
+
+#: panels/user-accounts/run-passwd.c:413
+msgid "Authentication failed"
+msgstr "Autentificarea a eșuat"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The new password is too short"
+msgstr "Parola nouă este prea scurtă"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password is too simple"
+msgstr "Parola nouă este prea simplă"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Vechea și noua parolă sunt foarte asemănătoare"
+
+#: panels/user-accounts/run-passwd.c:507
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Noua parolă a mai fost utilizată recent."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Noua parolă trebuie să conțină caractere numerice sau speciale"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Noua și vechea parolă sunt identice"
+
+#: panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Vi s-a modificat parola de când v-ați autentificat!"
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Noua parolă nu conține suficiente caractere diferite"
+
+#: panels/user-accounts/run-passwd.c:526
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Eroare necunoscută"
+
+#: panels/user-accounts/user-utils.c:432
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Numele de utilizator poate conține numai litere mari și mici de la a la z, "
+"cifre și următoarele caractere: - _"
+
+#: panels/user-accounts/user-utils.c:436
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Ne pare rău dar numele de utilizator nu este disponibil. Încercați altul."
+
+#: panels/user-accounts/user-utils.c:478
+msgid "The username is too long."
+msgstr "Numele utilizatorului este prea lung."
+
+#: panels/user-accounts/user-utils.c:537
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr ""
+"Aceasta va fi folosit pentru denumirea dosarului personal și nu poate fi "
+"modificat."
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr "Alocare butoane"
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:519
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "În_chide"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr "Alocare butoane pentru funcții"
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Pentru a edita o scurtătură, clic pe rândul corespunzător și tastați o nouă "
+"scurtătură, sau apăsați „Backspace” pentru a o șterge."
+
+#: panels/wacom/calibrator/calibrator.ui:61
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Apăsați pe zonele marcate în ordinea apariției pe ecran pentru a calibra "
+"tableta."
+
+#: panels/wacom/calibrator/calibrator.ui:78
+msgid "Mis-click detected, restarting…"
+msgstr "S-a detectat un clic pierdut, se repornește…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Buton %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Definit de aplicație"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Trimitere apăsare de tastă"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Comută monitorul"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Arată ajutorul pe ecran"
+
+#: panels/wacom/cc-wacom-mapping-panel.c:245
+msgid "Output:"
+msgstr "Ieșire:"
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:257
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Păstrează raportul de aspect (letterbox):"
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:268
+msgid "Map to single monitor"
+msgstr "Asociază unui singur monitor"
+
+#: panels/wacom/cc-wacom-nav-button.c:84
+#, c-format
+msgid "%d of %d"
+msgstr "%d din %d"
+
+#: panels/wacom/cc-wacom-page.c:516
+msgid "Display Mapping"
+msgstr "Afișează alocarea"
+
+#: panels/wacom/cc-wacom-panel.c:725 panels/wacom/wacom-stylus-page.ui:119
+msgid "Stylus"
+msgstr "Creion"
+
+#: panels/wacom/cc-wacom-stylus-page.c:357
+msgid "Button"
+msgstr "Buton"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:200
+msgid "Wacom Tablet"
+msgstr "Tabletă Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Configurează funcțiile butoanelor și ajustează sensibilitatea creionului "
+"pentru tablete grafice"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tabletă;Wacom;Stylus;Radieră;Mouse;Maus;Creion;Stilou;"
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr "Tabletă (absolut)"
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr "Touchpad (relativ)"
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr "Preferințe tabletă"
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "A_jutor"
+
+#: panels/wacom/gnome-wacom-properties.ui:125
+msgid "No tablet detected"
+msgstr "Nu a fost detectată nicio tabletă"
+
+#: panels/wacom/gnome-wacom-properties.ui:141
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Conectați sau porniți tableta Wacom"
+
+#: panels/wacom/gnome-wacom-properties.ui:161
+msgid "Bluetooth Settings"
+msgstr "Configurări bluetooth"
+
+#: panels/wacom/gnome-wacom-properties.ui:238
+msgid "Tracking Mode"
+msgstr "Mod de urmărire"
+
+#: panels/wacom/gnome-wacom-properties.ui:266
+msgid "Left-Handed Orientation"
+msgstr "Orientare pentru mâna stângă"
+
+#: panels/wacom/gnome-wacom-properties.ui:296
+#: panels/wacom/gnome-wacom-properties.ui:401
+msgid "Map to Monitor…"
+msgstr "Asociere la monitorul…"
+
+#: panels/wacom/gnome-wacom-properties.ui:309
+msgid "Map Buttons…"
+msgstr "Alocare butoane…"
+
+#: panels/wacom/gnome-wacom-properties.ui:322
+msgid "Calibrate…"
+msgstr "Se calibrează…"
+
+#: panels/wacom/gnome-wacom-properties.ui:340
+msgid "Adjust mouse settings"
+msgstr "Configurări maus"
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Adjust display resolution"
+msgstr "Ajustare rezoluție afișaj"
+
+#: panels/wacom/gnome-wacom-properties.ui:376
+msgid "Decouple Display"
+msgstr "Decuplează afișajul"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
+msgid "New shortcut…"
+msgstr "Scurtătură nouă…"
+
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "Implicit"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr "Clic cu butonul din mijloc al mausului"
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr "Clic cu butonul din dreapta al mausului"
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "Înainte"
+
+#: panels/wacom/wacom-stylus-page.ui:79
+msgid "No stylus found"
+msgstr "Nu s-a găsit stylus"
+
+#: panels/wacom/wacom-stylus-page.ui:93
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr "Mutați stylusul în proximitatea tabletei pentru a-l configura"
+
+#: panels/wacom/wacom-stylus-page.ui:159
+msgid "Eraser Pressure Feel"
+msgstr "Presiune radieră"
+
+#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:341
+msgid "Soft"
+msgstr "Fină"
+
+#: panels/wacom/wacom-stylus-page.ui:211 panels/wacom/wacom-stylus-page.ui:372
+msgid "Firm"
+msgstr "Puternică"
+
+#: panels/wacom/wacom-stylus-page.ui:234
+msgid "Top Button"
+msgstr "Buton superior"
+
+#: panels/wacom/wacom-stylus-page.ui:263
+msgid "Lower Button"
+msgstr "Buton inferior"
+
+#: panels/wacom/wacom-stylus-page.ui:292
+msgid "Lowest Button"
+msgstr "Buton inferior"
+
+#: panels/wacom/wacom-stylus-page.ui:321
+msgid "Tip Pressure Feel"
+msgstr "Presiune vârf"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:11
+msgid "Access Points"
+msgstr "Puncte de acces"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:160
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:543
+msgid "Operation Cancelled"
+msgstr "Operație anulată"
+
+#: panels/wwan/cc-wwan-data.c:546
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Eroare:</b> Accesul restricționat la modificarea configurărilor"
+
+#: panels/wwan/cc-wwan-data.c:549
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Eroare:</b> Eroare la echipamentul mobil"
+
+#: panels/wwan/cc-wwan-details-dialog.c:81
+msgid "Not Registered"
+msgstr "Neînregistrat"
+
+#: panels/wwan/cc-wwan-details-dialog.c:85
+msgid "Registered"
+msgstr "Înregistrat"
+
+#: panels/wwan/cc-wwan-details-dialog.c:89
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:93
+msgid "Searching"
+msgstr "Căutare"
+
+#: panels/wwan/cc-wwan-details-dialog.c:97
+msgid "Denied"
+msgstr "Refuzat"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:4
+msgid "Modem Details"
+msgstr "Detalii modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:33
+msgid "Modem Status"
+msgstr "Stare modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:53
+msgid "Carrier"
+msgstr "Furnizor"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:79
+msgid "Network Type"
+msgstr "Tip de rețea"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:131
+msgid "Network Status"
+msgstr "Starea rețelei"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:158
+msgid "Own Number"
+msgstr "Numărul propriu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:185
+msgid "Device Details"
+msgstr "Detaliile dispozitivului"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:257
+msgid "Firmware Version"
+msgstr "Versiune firmware"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Numai 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Numai 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Numai 4G"
+
+#: panels/wwan/cc-wwan-device.c:1003
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Preferat)"
+
+#: panels/wwan/cc-wwan-device.c:1005
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Preferat), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Preferat), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Preferat)"
+
+#: panels/wwan/cc-wwan-device.c:1017
+msgid "3G (Preferred), 4G"
+msgstr "3G (Preferat), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1019
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1025
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Preferat)"
+
+#: panels/wwan/cc-wwan-device.c:1027
+msgid "2G (Preferred), 4G"
+msgstr "2G (Preferat), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1029
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Preferat)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "2G (Preferred), 3G"
+msgstr "2G (Preferat), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1043
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Necunoscută"
+
+#: panels/wwan/cc-wwan-device-page.c:141
+msgid "Unlock SIM card"
+msgstr "Deblochează cardul SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:142 panels/wwan/cc-wwan-device-page.c:190
+msgid "Unlock"
+msgstr "Deblochează"
+
+#: panels/wwan/cc-wwan-device-page.c:147
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Oferiți codul PIN pentru SIM-ul %d"
+
+#: panels/wwan/cc-wwan-device-page.c:148
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Introduceți PIN-ul pentru a debloca cardul SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:152
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Oferiți codul PUK pentru SIM-ul %d"
+
+#: panels/wwan/cc-wwan-device-page.c:153
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Introduceți PUK-ul pentru a debloca cardul SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:171
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Parola introdusă a fost greșită. Mai aveți %1$u încercare rămasă"
+msgstr[1] "Parola introdusă a fost greșită. Mai aveți %1$u încercări rămase"
+msgstr[2] "Parola introdusă a fost greșită. Mai aveți %1$u de încercări rămase"
+
+#: panels/wwan/cc-wwan-device-page.c:174
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Mai aveți %u încercare rămasă"
+msgstr[1] "Mai aveți %u încercări rămase"
+msgstr[2] "Mai aveți %u de încercări rămase"
+
+#: panels/wwan/cc-wwan-device-page.c:179
+msgid "Wrong password entered."
+msgstr "Parola introdusă a fost greșită."
+
+#: panels/wwan/cc-wwan-device-page.c:224
+msgid "PUK code should be an 8 digit number"
+msgstr "Codul PUK ar trebui să fie un număr natural de 8 cifre"
+
+#: panels/wwan/cc-wwan-device-page.c:248
+msgid "Enter New PIN"
+msgstr "Introduceți noul PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:252
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Codul PIN ar trebui să fie un număr natural de 4-8 cifre"
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "Unlocking..."
+msgstr "Se deblochează..."
+
+#: panels/wwan/cc-wwan-device-page.ui:34
+msgid "No SIM"
+msgstr "Niciun SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:45
+msgid "Insert a SIM card to use this modem"
+msgstr "Introduceți un card SIM pentru a utiliza acest modem"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "SIM Locked"
+msgstr "SIM blocat"
+
+#: panels/wwan/cc-wwan-device-page.ui:139
+msgid "_Mobile Data"
+msgstr "Date _mobile"
+
+#: panels/wwan/cc-wwan-device-page.ui:140
+msgid "Access data using mobile network"
+msgstr "Accesați datele utilizând o rețea mobilă"
+
+#: panels/wwan/cc-wwan-device-page.ui:151
+msgid "_Data Roaming"
+msgstr "Roaming de _date"
+
+#: panels/wwan/cc-wwan-device-page.ui:152
+msgid "Use mobile data when roaming"
+msgstr "Utilizați datele mobile în roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:177
+msgid "_Network Mode"
+msgstr "_Mod de rețea"
+
+#: panels/wwan/cc-wwan-device-page.ui:187
+msgid "N_etwork"
+msgstr "R_ețea"
+
+#: panels/wwan/cc-wwan-device-page.ui:199
+msgid "Advanced"
+msgstr "Avansate"
+
+#: panels/wwan/cc-wwan-device-page.ui:225
+msgid "_Access Point Names"
+msgstr "Nume puncte de _acces"
+
+#: panels/wwan/cc-wwan-device-page.ui:235
+msgid "_SIM Lock"
+msgstr "Blocare _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:236
+msgid "Lock SIM with PIN"
+msgstr "Blochează SIM-ul cu un PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:246
+msgid "M_odem Details"
+msgstr "Detalii m_odem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Eșec telefon"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Nicio conexiune la telefon"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operația nu este permisă"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operația nu este suportată"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM-ul nu este inserat"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "PIN-ul SIM necesar"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "PUK-ul SIM necesar"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Eșec SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM ocupat"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Parolă incorectă"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "PIN2 SIM necesar"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "PUK2 SIM necesar"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Negăsit"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Nu este semnal de rețea"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Timp expirat"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Serviciile GPRS nu sunt permise"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming-ul nu este permis la această locație"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Eroare GPRS nespecificată"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "Action Cancelled"
+msgstr "Acțiune anulată"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Access denied"
+msgstr "Acces refuzat"
+
+#: panels/wwan/cc-wwan-errors-private.h:103
+msgid "Unknown Error"
+msgstr "Eroare necunoscută"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:4
+msgid "Network Mode"
+msgstr "Mod de rețea"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:44
+#: panels/wwan/cc-wwan-network-dialog.ui:175
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:230
+msgid "_Set"
+msgstr "Stabilește"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:46 panels/wwan/cc-wwan-panel.ui:39
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:101
+msgid "Close"
+msgstr "Închide"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:84
+msgid "_Automatic"
+msgstr "_Automată"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:100
+msgid "Choose Network"
+msgstr "Alegeți rețeaua"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:118
+msgid "Refresh Network Providers"
+msgstr "Reîmprospătează Furnizorii de rețea"
+
+#: panels/wwan/cc-wwan-panel.c:453 panels/wwan/cc-wwan-panel.c:482
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:101
+msgid "No WWAN Adapter Found"
+msgstr "Nu au fost găsit niciun adaptor WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Asigurați-vă că aveți un adaptor Wireless Wan/Dispozitiv celular"
+
+#: panels/wwan/cc-wwan-panel.ui:154
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Wireless Wan este dezactivat când modul avion este pornit"
+
+#: panels/wwan/cc-wwan-panel.ui:163
+msgid "_Turn off Airplane Mode"
+msgstr "Î_nchide modul Avion"
+
+#: panels/wwan/cc-wwan-panel.ui:210
+msgid "Data Connection"
+msgstr "Conexiune de date"
+
+#: panels/wwan/cc-wwan-panel.ui:224
+msgid "SIM card used for internet"
+msgstr "Cartela SIM folosită pentru internet"
+
+#: panels/wwan/cc-wwan-panel.ui:332
+msgid "Enable Mobile Network"
+msgstr "Activează rețeaua mobilă"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:11
+msgid "SIM Lock"
+msgstr "Blocare SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:22
+msgid "_Next"
+msgstr "_Următorul"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:141
+msgid "_Lock SIM with PIN"
+msgstr "B_lochează SIM-ul cu un PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:158
+msgid "Change PIN"
+msgstr "Schimbați PIN-ul"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:256
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+"Introduceți PIN-ul curent pentru a modifica configurările de blocare ale SIM-"
+"ului"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Rețea mobilă"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Configurează Telefonia și conexiunile de date mobile"
+
+#. FIXME
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:17
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;wwan;telephony;sim;mobile;celular;telefonie;mobilă;"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+msgid "GNOME Settings"
+msgstr "Configurări GNOME"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Utilitate de configurare pentru desktopul GNOME"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Configurări este interfața primară pentru a vă configura sistemul."
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:20
+msgid "The GNOME Project"
+msgstr "Proiectul Gnome"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Afișează număr versiune"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Activează modul volubil"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Caută un șir"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Listează nume posibile pentru panouri și apoi închide fereastra"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panou de afișat"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:45 shell/cc-window.c:275
+msgid "Privacy"
+msgstr "Confidențialitate"
+
+#: shell/cc-panel-loader.c:299
+msgid "Available panels:"
+msgstr "Panouri disponibile:"
+
+#: shell/cc-window.ui:136
+msgid "All Settings"
+msgstr "Toate configurările"
+
+#: shell/cc-window.ui:174
+msgid "Primary Menu"
+msgstr "Meniul principal"
+
+#: shell/cc-window.ui:318
+msgid "Warning: Development Version"
+msgstr "Avertisment: versiune de dezvoltare"
+
+#: shell/cc-window.ui:319
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Această versiune a Configurări ar trebui să fie utilizată doar în scopuri de "
+"dezvoltare. Este posibil să experimentați un comportament incorect al "
+"sistemului, pierderi de date, și alte probleme neașteptate. "
+
+#: shell/cc-window.ui:330
+msgid "Help"
+msgstr "Ajutor"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;Preferințe;Configurări;"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Generale"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Ieșire"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Caută"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panouri"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Înapoi la panoul anterior"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Anulează căutarea"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Identificatorul ultimului panou de configurări de deschis"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Identificatorul ultimului panou de configurări de deschis. Valorile "
+"nerecunoscute vor fi ignorate și primul panou din listă va fi selectat."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Arată avertismentul când se rulează o versiune de dezvoltare a Configurări"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Dacă programul Configurări ar trebui să arate un avertisment când se rulează "
+"o versiune de dezvoltare."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1907
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "o ieșire"
+msgstr[1] "%u ieșiri"
+msgstr[2] "%u de ieșiri"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1917
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "o intrare"
+msgstr[1] "%u intrări"
+msgstr[2] "%u de intrări"
+
+#: subprojects/gvc/gvc-mixer-control.c:2867
+msgid "System Sounds"
+msgstr "Sunete de sistem"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Nume;Amprentă;Avatar;Logo;Figură;Parolă;Autentificare;Amprente;Față;"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Luminozitatea _ecranului"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Luminozitate _tastatură"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Diminuează luminozitatea la inactivitate"
+
+# This is the "blank screen" setting label under the power settings. It is connected with a drop-down where you can choose the amount of minutes until the screen goes black.
+#~ msgid "_Blank Screen"
+#~ msgstr "Întunecă _ecranul"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wi-Fi poate fi oprit pentru a economisi energia."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Conexiunea mobilă de bandă largă (3G, 4G, LTE, etc.) poate fi oprită "
+#~ "pentru a economisi energie."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth poate fi oprit pentru a economisi energie."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Consum echilibrat"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Scurtătură de tastatură"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Acest lucru poate fi modificat în Personalizează scurtături"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Mențineți apăsat și tastați pentru a introduce caractere diferite"
+
+#~ msgid "Add…"
+#~ msgstr "Adaugă…"
+
+#~ msgid "Input Source Options"
+#~ msgstr "Opțiuni limbi tastatură"
+
+#~ msgid "Allow _different sources for each window"
+#~ msgstr "Permite limbi _diferite pentru fiecare fereastră"
+
+#~ msgid "Previous source"
+#~ msgstr "Sursa precedentă"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "Sursa următoare"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt Stânga+Dreapta"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Taste caractere alternative"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Doar modificatori, comută sursa următoare"
+
+#~ msgid "Left Alt"
+#~ msgstr "Alt stânga"
+
+#~ msgid "Right Alt"
+#~ msgstr "Alt dreapta"
+
+#~ msgid "Left Super"
+#~ msgstr "Super stânga"
+
+#~ msgid "Right Super"
+#~ msgstr "Super dreapta"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl dreapta"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Tasta meniului"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Se încarcă"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Atenție"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Scăzută"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Bună"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Complet încărcată"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Descărcată complet"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Închide pentru conectarea la o rețea Wi-Fi"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Parolă"
+
+#~ msgid "Universal Access"
+#~ msgstr "Acces universal"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Autentificare pe bază de amprente"
+
+#~ msgid "_Other finger:"
+#~ msgstr "Al_t deget:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Amprenta dumneavoastră a fost salvată cu succes. Acum ar trebui să vă "
+#~ "puteți autentifica folosind cititorul de amprente."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Nu sunteți autorizat să accesați acest dispozitiv. Contactați "
+#~ "administratorul de sistem."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "A apărut o eroare internă."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Ștergeți amprentele înregistrate?"
+
+#~ msgid "Done!"
+#~ msgstr "Gata!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Nu s-a putut accesa dispozitivul „%s”"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Nu s-a putut porni înregistrarea degetului pe dispozitivul „%s”"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Nu s-a putut accesa niciun cititor de amprente"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Contactați administratorul de sistem pentru ajutor."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Pentru a activa autentificarea pe bază de amprente, trebuie să salvați "
+#~ "una din amprentele dumneavoastră folosind dispozitivul „%s”."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Selectare deget"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#, fuzzy
+#~| msgid "Add or remove users and change your password"
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Adăugați și ștergeți utilizatori și schimbați parola"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Redă și înregistrează sunet"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr ""
+#~ "Detectează dispozitivul de rețea folosind mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Accesează dispozitivul bluetooth direct"
+
+#, fuzzy
+#~| msgid "Bluetooth Settings"
+#~ msgid "Use bluetooth devices"
+#~ msgstr "Configurări bluetooth"
+
+#~ msgid "Use your camera"
+#~ msgstr "Utilizează camera"
+
+#, fuzzy
+#~| msgid "Printers"
+#~ msgid "Print documents"
+#~ msgstr "Imprimante"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Utilizează orice joystick conectat"
+
+#, fuzzy
+#~| msgid "_Allow connections to control the screen"
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Permite conexiunilor să controleze ecr_anul"
+
+#, fuzzy
+#~| msgid "Configure input source"
+#~ msgid "Configure network firewall"
+#~ msgstr "Configurare limbă tastatură"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Configurează și folosește sisteme de fișiere privilegiate FUSE"
+
+#, fuzzy
+#~| msgid "Calibrate the device"
+#~ msgid "Update firmware on this device"
+#~ msgstr "Calibrare dispozitiv"
+
+#, fuzzy
+#~| msgid "Account Information"
+#~ msgid "Access hardware information"
+#~ msgstr "Informații cont"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Oferă entropie pentru generarea aleatorie a numerelor prin hardware"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Utilizează numere generate aleatoriu prin hardware"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Accesează fișierele din dosarul personal"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Accesează serviciul libvirt"
+
+#, fuzzy
+#~| msgid "Change system time and date settings"
+#~ msgid "Change system language and region settings"
+#~ msgstr "Modifică data și ora sistemului"
+
+#, fuzzy
+#~| msgid "Change resolution and position of monitors and projectors"
+#~ msgid "Change location settings and providers"
+#~ msgstr "Schimbă rezoluția și poziția monitoarelor și a proiectoarelor"
+
+#, fuzzy
+#~| msgid "Access Options"
+#~ msgid "Access your location"
+#~ msgstr "Opțiuni de acces"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Citește jurnalele de sistem și ale aplicațiilor"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "accesează serviciul media-hub"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Utilizează și configurează modemuri"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Citește informații de montare ale sistemelor și cotele discurilor"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Controlează muzica și playerele video"
+
+#, fuzzy
+#~| msgid "Network settings"
+#~ msgid "Change low-level network settings"
+#~ msgstr "Configurări de rețea"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Accesează serviciul NetworkManager pentru a citi și modifica configurări "
+#~ "de rețea"
+
+#, fuzzy
+#~| msgid "Network settings"
+#~ msgid "Read access to network settings"
+#~ msgstr "Configurări de rețea"
+
+#, fuzzy
+#~| msgid "Network settings"
+#~ msgid "Change network settings"
+#~ msgstr "Configurări de rețea"
+
+#, fuzzy
+#~| msgid "Network settings"
+#~ msgid "Read network settings"
+#~ msgstr "Configurări de rețea"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Accesează serviciul ofono pentru a citi și modifica configurări de rețea "
+#~ "pentru telefonia mobilă"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Controlează hardware deschis vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Citește de pe CD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Citește, adaugă, modifică, sau elimină parole salvate"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Accesează dispozitive pppd și ppp pentru configurarea conexiunilor ce "
+#~ "folosesc Point-to-Point Protocol"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Pune pe pauză sau termină orice proces din sistem"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Accesează direct hardware USB"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Citește/scrie fișiere pe dispozitive de stocare amovibile"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Previne adormirea/blocarea ecranului"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Accesează hardware prin port serial"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Repornește sau oprește dispozitivul"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Instalează, elimină și configurează software"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Accesează serviciul Storage Framework"
+
+#, fuzzy
+#~| msgid "System Information"
+#~ msgid "Read process and system information"
+#~ msgstr "Informații de sistem"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Monitorizează și controlează orice program ce rulează"
+
+#, fuzzy
+#~| msgid "Change the date and time, including time zone"
+#~ msgid "Change the date and time"
+#~ msgstr "Schimbați data și ora, inclusiv fusul orar"
+
+#, fuzzy
+#~| msgid "Change system time and date settings"
+#~ msgid "Change time server settings"
+#~ msgstr "Modifică data și ora sistemului"
+
+#, fuzzy
+#~| msgid "Change the background"
+#~ msgid "Change the time zone"
+#~ msgstr "Schimbă fundalul"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Accesează serviciul UDisks2 pentru a configura discuri și medii amovibile"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Pentru a crea un cont de utilizator,\n"
+#~ "efectuați clic pe iconița *"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Stabilește fundalul și ecranul de blocare"
+
+#~ msgid "Set Background"
+#~ msgstr "Stabilește fundalul"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Stabilește ecranul de blocare"
+
+#~ msgid "Remove Background"
+#~ msgstr "Elimină fundalul"
+
+#~ msgid "Version %s"
+#~ msgstr "Versiunea %s"
+
+#~ msgid "OS name"
+#~ msgstr "Numele sistemului de operare"
+
+#~ msgid "OS type"
+#~ msgstr "Tipul sistemului de operare"
+
+#~ msgid "Disk"
+#~ msgstr "Disc"
+
+#~ msgid "Check for updates"
+#~ msgstr "Căutare actualizări"
+
+#~ msgid "Network proxy"
+#~ msgstr "Proxy rețea"
+
+#~ msgid "page 1"
+#~ msgstr "pagina 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "_Autentificare internă"
+
+#~ msgid "page 2"
+#~ msgstr "pagina 2"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Restricționează uzul de date în _fundal"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Adecvat pentru conexiuni care au limite sau taxe pentru date."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Pornirea hotspotului wireless vă va deconecta de la <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Nu se poate accesa Internetul prin wireless în timp ce hotspot-ul este "
+#~ "activ."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Hotspot-urile Wi-Fi sunt folosite de obicei pentru a partaja o conexiune "
+#~ "la Internet adițională prin Wi-Fi."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "_Conectare automată"
+
+#~ msgid "details"
+#~ msgstr "detalii"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Arată p_arola"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Pune la dispoziția altora"
+
+#~ msgid "identity"
+#~ msgstr "identitate"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adrese"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Doar adresare automată (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Doar link-local"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignoră rutele obținute automat"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Adresă MAC _clonată"
+
+#~ msgid "_Reset"
+#~ msgstr "_Resetează"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Resetează setările conexiunii la cele implicite, dar reține faptul că "
+#~ "este o conexiune preferată."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Șterge toate detaliile acestei rețele și nu te conecta automat la aceasta."
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Restabilește"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Dispozitive conectate"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastructură"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Notificări _popup"
+
+#~ msgid "In use"
+#~ msgstr "În uz"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Pornit"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Oprit"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Oprită"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Pornită"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Oprit"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Pornit"
+
+#~ msgid "Usage & History"
+#~ msgstr "Utilizare și istoric folosire"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Politică de confidențialitate"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Prin păstrarea istoricului puteți găsi lucrurile mai ușor. Aceste "
+#~ "elemente nu sunt niciodată împărtășite prin rețea."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Recent folosite"
+
+#~ msgid "Retain _History"
+#~ msgstr "Reține _istoricul"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Blocarea ecranului vă protejează confidențialitatea când nu sunteți la "
+#~ "calculator."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Bloche_ază ecranul timp de"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "Notificări ecran de blocare"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Golește automat gunoiul și șterge fișierele temporare pentru a nu păstra "
+#~ "informația sensibilă pe calculator."
+
+#~ msgid "Purge _After"
+#~ msgstr "Gol_ește după"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Trimiterea de informații despre ce software utilizați ne ajută să "
+#~ "furnizăm recomandări mai precise. Ne ajută și la îmbunătățirea software-"
+#~ "ului.\n"
+#~ "\n"
+#~ "Toate informațiile colectate sunt anonime, și nu le vom partaja niciodată "
+#~ "cu părți terțe."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "Trimite _statistici de utilizare software"
+
+#~ msgid "_Camera"
+#~ msgstr "_Cameră"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Microfon"
+
+#~ msgid "_Location Services"
+#~ msgstr "Servicii de _locație"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Protejați-vă înformația personală și controlați ce pot alții să vadă"
+
+#~ msgid "No regions found"
+#~ msgstr "Nu s-au găsit regiuni"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Cli_pește titlul ferestrei"
+
+#~ msgid "Last Login"
+#~ msgstr "Ultimul login"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Numele utilizatorului nu poate începe cu „-”."
+
+#~ msgid "_Background"
+#~ msgstr "_Fundal"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Se modifică pe parcursul zilei"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Mozaic"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrat"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Scalat"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Ecran complet"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Extins"
+
+#~ msgid "Wallpapers"
+#~ msgstr "Imagini de fundal"
+
+#~ msgid "Colors"
+#~ msgstr "Culori"
+
+#~ msgid "Pictures"
+#~ msgstr "Imagini"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Nu au fost găsite imagini"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Puteți adăuga imagini în directorul %s și acestea vor fi afișate aici"
+
+#~ msgid "_Off"
+#~ msgstr "_Dezactivat"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Conexiune/SSID"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "Suspendare _automată"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Când butonul de oprire este apăsat"
+
+#~ msgid "Show _Notifications"
+#~ msgstr "Arată _notificări"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "preferences-desktop-wallpaper"
+#~ msgstr "preferences-desktop-wallpaper"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "preferences-system-notifications"
+#~ msgstr "preferences-system-notifications"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "_Night Light"
+#~ msgstr "Lumină _nocturnă"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Nu s-au putut obține informații despre ecran"
+
+#~ msgid "hardware"
+#~ msgstr "hardware"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Comutare la limba precedentă"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Comutare la următoarea limbă"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Comutare alternativă la următoarea limbă"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Engleză (Regatul Unit)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Regatul Unit"
+
+#~ msgid "_Options"
+#~ msgstr "_Opțiuni"
+
+#~ msgid "Add input source"
+#~ msgstr "Adaugă limbă tastatură"
+
+#~ msgid "Remove input source"
+#~ msgstr "Elimină limbă tastatură"
+
+#~ msgid "Move input source up"
+#~ msgstr "Mută limba mai sus"
+
+#~ msgid "Move input source down"
+#~ msgstr "Mută limba mai jos"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Arată aranjamentul de taste"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Stânga"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Dreapta"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minim"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maxim"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Testare boxe"
+
+#~ msgid "Peak detect"
+#~ msgstr "Detecție vârf"
+
+#~ msgid "Device"
+#~ msgstr "Dispozitiv"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Test de difuzor pentru %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Ale_geți un dispozitiv pentru ieșire sunet:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Configurări pentru dispozitivul selectat:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Volum _intrare:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Ale_geți un dispozitiv pentru intrare sunet:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Efecte sonore"
+
+#~ msgid "_Alert volume:"
+#~ msgstr "Volum _alerte:"
+
+#~ msgid "Built-in"
+#~ msgstr "Integrat"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferințe sunet"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Se testează sunetul evenimentelor"
+
+#~ msgid "From theme"
+#~ msgstr "Din temă"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Ale_geți un sunet de alertă:"
+
+#~ msgid "Stop"
+#~ msgstr "Stop"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrator"
+
+#~ msgid "page 3"
+#~ msgstr "pagina 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Centrul de control GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Centrul de control este interfața principală GNOME pentru configurări ale "
+#~ "calculatorului dumneavoastră."
+
+#~ msgid "Quit"
+#~ msgstr "Ieșire"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Verifică nouă parolă"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Parolele nu se potrivesc."
+
+#~ msgid "Show the overview"
+#~ msgstr "Afișează prezentarea generală"
+
+#~ msgid "Back­ground"
+#~ msgstr "Fundal"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Culoare"
+
+#~ msgid "Section"
+#~ msgstr "Secțiune"
+
+#~ msgid "Overview"
+#~ msgstr "Imagine de ansamblu"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Aplicații implicite"
+
+#~ msgid "Ab­out"
+#~ msgstr "Despre"
+
+#~ msgid "De­tails"
+#~ msgstr "Detalii"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Medii detașabile"
+
+#~ msgid "Net­work"
+#~ msgstr "Rețea"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Notificări"
+
+#~ msgid "Po­wer"
+#~ msgstr "Consum"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Confidențialitate"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Partajare"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Acces universal"
+
+#~ msgid "Disable image"
+#~ msgstr "Dezactivează imaginea"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Răsfoiește pentru mai multe imagini…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Folosit de %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Tabletă Wacom"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistem"
+
+#~| msgid "_Apply"
+#~ msgid "Apply"
+#~ msgstr "Aplică"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Capac închis"
+
+#~ msgid "Mirrored"
+#~ msgstr "Oglindit"
+
+#~ msgid "Secondary"
+#~ msgstr "Secundar"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Aranjează ecrane combinate"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Trage de ecrane pentru a le rearanja"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Rotește antiorar la 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Rotește cu 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Rotește orar cu 90°"
+
+#~ msgid "Size"
+#~ msgstr "Mărime"
+
+#~ msgid "Aspect Ratio"
+#~ msgstr "Proporție de aspect"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Arată bara de sus și Ecran Actvități pe acest ecran"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Combină acest ecran cu altul pentru a crea un spațiu de lucru suplimentar"
+
+#~ msgid "Presentation"
+#~ msgstr "Prezentare"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Arată doar diapozitive și medii de stocare"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Arată imaginea curentă pe ambele ecrane"
+
+#~ msgid "Turn Off"
+#~ msgstr "Închide"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Nu folosi acest ecran"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Aranjează ecrane combinate"
+
+#~ msgid "Air_plane Mode"
+#~ msgstr "Modul a_vion"
+
+#~ msgid "Server"
+#~ msgstr "Server"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Șterge serverul DNS"
+
+#~ msgctxt "network parameters"
+#~ msgid "Metric"
+#~ msgstr "Metric"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Adaugă profil…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Niciuna"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manuală"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automată"
+
+#~ msgid "_Method"
+#~ msgstr "_Metodă"
+
+#~ msgid "VPN Type"
+#~ msgstr "Tip de VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "Numele grupului"
+
+#~ msgid "Group Password"
+#~ msgstr "Parola grupului"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bit"
+
+#~ msgid "Base system"
+#~ msgstr "Sistem de bază"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;Scurtatură;"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Pentru a edita o scurtătură, clic pe rândul corespunzător și tastați o "
+#~ "nouă scurtătură, sau apăsați „Backspace” pentru a o șterge."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Acțiune necunoscută>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Scurtătura „%s” nu poate fi folosită deoarece nu se va putea scrie "
+#~ "folosind această tastă.\n"
+#~ "Încercați o combinație cu tastele Control, Alt sau Shift."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Scurtătura „%s” este deja folosită pentru\n"
+#~ "„%s”"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Dacă reasociați scurtătura la „%s”, scurtătura „%s” va fi dezactivată."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Reasociază"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Scurtătura „%s” are o scurtătură asociată „%s”. Vreți să o configurați "
+#~ "automat la „%s”?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "Dacă reasociați scurtătura la „%s”, scurtătura „%s” va fi dezactivată."
+
+#~ msgid "_Assign"
+#~ msgstr "_Asociază"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Faceți disponibil și altor _utilizatori"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Zonă firewall"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Implicit"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Zona definește un nivel de încredere pentru conexiune"
+
+#~ msgid "Bond"
+#~ msgstr "Bond"
+
+#~ msgid "Team"
+#~ msgstr "Team"
+
+#~ msgid "Bridge"
+#~ msgstr "Bridge"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Nu s-au putut încărca pluginuri VPN"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Adaugă conexiune la rețea"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Resetează setările pentru această rețea, inclusiv parole, dar reține ca "
+#~ "rețea preferată"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Șterge toate detaliile acestei conexiuni și nu încerca conectarea automată"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Bond slaves"
+
+#~ msgid "(none)"
+#~ msgstr "(niciuna)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Bridge slaves"
+
+#~ msgid "Team slaves"
+#~ msgstr "Team slaves"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Dacă aveți o conexiune la internet alta decât wireless, puteți configura "
+#~ "o conexiune hotspot prin care să împărțiți conexiunea cu alții."
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Utilizează ca Hotspot…"
+
+#~ msgid "_History"
+#~ msgstr "_Istoric"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "Dispozitivul InfiniBand nu suportă modul conectat"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Nu a fost aleasă o autoritate de certificare"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Dacă nu se utilizează un certificat aprobat de o autoritate de "
+#~ "certificare (CA), aceasta poate rezulta în conectarea la rețele Wi-Fi "
+#~ "nesigure sau malițioase. Doriți utilizarea unui certificat al unei "
+#~ "autorități de certificare?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignoră"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Alege un certificat CA"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Întreabă-_mă parola de fiecare dată"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Nu mă mai a_vertiza"
+
+#~ msgid "Yes"
+#~ msgstr "Da"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Bannere de notificare"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "_Bannere de notificare"
+
+#~ msgid "Add Account"
+#~ msgstr "Adaugă cont"
+
+#~ msgid "Mail"
+#~ msgstr "Email"
+
+#~ msgid "Contacts"
+#~ msgstr "Contacte"
+
+#~ msgid "Chat"
+#~ msgstr "Chat"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Eroare la autentificare"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Datele de autentificare au expirat."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Autentificați-vă pentru a activa acest cont."
+
+#~ msgid "_Sign In"
+#~ msgstr "Autentifica_re"
+
+#~ msgid "Error creating account"
+#~ msgstr "Eroare la crearea contului"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Sigur doriți să eliminați contul?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Această acțiune nu va elimina contul de pe server."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Nuexistă conturi online configurate"
+
+#~ msgid "Add an online account"
+#~ msgstr "Adăugare cont online"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Adăugarea unui cont permite aplicațiilor să-l acceseze pentru documente, "
+#~ "e-mail, contacte, calendar, chat și altele."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Configurare"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nivelul de toner"
+
+#~ msgid "Supply Level"
+#~ msgstr "Nivelul de aprovizionare"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Se instalează"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u activă"
+#~ msgstr[1] "%u active"
+#~ msgstr[2] "%u active"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Adaugă o imprimantă nouă"
+
+#~ msgid "No printers detected."
+#~ msgstr "Nicio imprimantă detectată."
+
+#~ msgid "Loading options…"
+#~ msgstr "Se încarcă opțiunile…"
+
+#~ msgid "Supply"
+#~ msgstr "Aprovizionare"
+
+#~ msgid "Jobs"
+#~ msgstr "Sarcină"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Arată _sarcinile"
+
+#~ msgid "label"
+#~ msgstr "etichetă"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "Se configurează un nou driver…"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Tipărire pagină de _test"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Altele"
+
+#~ msgid "Personal File Sharing"
+#~ msgstr "Partajare personală fișiere"
+
+#~ msgid "_Allow Remote Control"
+#~ msgstr "Permite control de la dist_anță"
+
+#~ msgid "_Verify"
+#~ msgstr "_Verifică"
+
+#~ msgid "Login History"
+#~ msgstr "Istoric autentificare"
+
+#~ msgid "Add User Account"
+#~ msgstr "Adăugare cont utilizator"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Încercați să adăugați mai multe litere, numere sau simboluri."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Putere: slabă"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Putere: scăzută"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Putere: medie"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Putere: bună"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Putere: înaltă"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Alte conturi"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Un utilizator cu numele „%s” există deja."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Sus"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Jos"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Nimic"
+
+#~ msgid "Left Ring"
+#~ msgstr "Inel stânga"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Mod inel stânga #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Mod inel dreapta #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Bandă tactilă stânga"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Mod bandă tactilă stânga #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Bandă tactilă dreapta"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Mod bandă tactilă dreapta #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Mod inel tactil stânga"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Mod inel tactil dreapta"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Mod bandă tactilă stânga"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Mod bandă tactilă dreapta"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Schimbare mod #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Buton stânga #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Buton dreapta #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Buton superior #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Buton inferior #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Nicio acțiune"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Clic cu butonul stânga al mausului"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Derulare în sus"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Derulare în jos"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Derulare la dreapta"
+
+#~ msgid "Done"
+#~ msgstr "Gata"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Fus _orar"
+
+#~ msgid "_Delay:"
+#~ msgstr "Î_ntârziere:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Scurtă"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Înceată"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Lungă"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapidă"
+
+#~ msgid "S_peed:"
+#~ msgstr "Vite_ză:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Testați configurările"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Încet"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapid"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "Stâ_nga"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "D_reapta"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Viteză cursor"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Încet"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapid"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Încet"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Rapid"
+
+#~ msgid "No printers available"
+#~ msgstr "Nicio imprimantă disponibilă"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Reia tipărirea"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Suspendă tipărirea"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Reținută"
+
+#~ msgid "Job Title"
+#~ msgstr "Titlu sarcină"
+
+#~ msgid "Job State"
+#~ msgstr "Stare sarcină"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Adaugă o imprimantă nouă"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Folosit pentru a vă determina locația geografică"
+
+#~ msgid "Options"
+#~ msgstr "Opțiuni"
+
+#~ msgid "Password:"
+#~ msgstr "Parola:"
+
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Culoare"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "Bluetooth-ul este dezactivat"
+
+#, fuzzy
+#~| msgid "When power is _critically low"
+#~ msgid "When battery power is _critical"
+#~ msgstr "Când bateria este descărcată _critic"
+
+#~ msgid "Show help options"
+#~ msgstr "Arată opțiunile de ajutor"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Executați „%s --help” pentru a vedea întreaga listă a comenzilor "
+#~ "disponibile.\n"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Configurare dispozitiv nou"
+
+#~ msgid "Paired"
+#~ msgstr "Asociat"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Vizibilitatea pentru „%s”"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Eliminați „%s” din lista dispozitivelor?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Dacă eliminați acest dispozitiv, va trebui să îl configurați din nou "
+#~ "înainte de următoarea utilizare."
+
+#~ msgid "Device type:"
+#~ msgstr "Tip dispozitiv:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Producător:"
+
+#~ msgid "Model:"
+#~ msgstr "Model:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Puteți adăuga fișiere imagine în această fereastră pentru auto-"
+#~ "completarea câmpurilor de mai sus."
+
+#~ msgid "United States"
+#~ msgstr "Statele Unite"
+
+#~ msgid "France"
+#~ msgstr "Franța"
+
+#~ msgid "Spain"
+#~ msgstr "Spania"
+
+#~ msgid "China"
+#~ msgstr "China"
+
+#~ msgid "_Region:"
+#~ msgstr "_Regiune"
+
+#~ msgid "_City:"
+#~ msgstr "_Oraș:"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Configurați ceasul cu o oră în avans."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Configurați ceasul cu o oră în devans."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Configurați ceasul cu un minut înainte."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Configurați ceasul cu un minut înapoi."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Comutare între AM și PM."
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "În sens orar"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 de grade"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Selectați un monitor pentru a-i schimba proprietățile; trageți-l pentru a-"
+#~ "l rearanja."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Nu s-a putut salva configurația monitorului"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "Nu s-au putut detecta monitoarele"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Rezoluție"
+
+#~ msgid "R_otation"
+#~ msgstr "R_otație"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "Oglindește _monitoarele"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Notă: poate limita opțiunile de rezoluție"
+
+#~ msgid "Install Updates"
+#~ msgstr "Instalare actualizări"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Sistem actualizat"
+
+#~ msgid "Launch terminal"
+#~ msgstr "Pornește aplicația Terminal"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Preferințe maus"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Dezactivează în timp ce se _tastează"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr ""
+#~ "Serviciile de rețea ale sistemului nu sunt compatibile cu această "
+#~ "versiune."
+
+#~ msgid "Apply system wide"
+#~ msgstr "Aplică pentru tot sistemul"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Selectați interfața de utilizat pentru noul serviciu"
+
+#~ msgid "_Interface"
+#~ msgstr "_Interfață"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Caută pentru imprimante în rețea sau filtrează rezultate"
+
+#~ msgid "_Default"
+#~ msgstr "_Implicit"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Ridicat/Invers"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Tastatură pe ecran"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Small"
+#~ msgstr "Mic"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Large"
+#~ msgstr "Mare"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Bip la Caps și Num Lock"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "Activează sau dezactivează:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Zoom"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Apropiere:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Depărtare:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "Subtitrări pentru persoane cu dizabilități"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Afișează o descriere textuală a vorbirii și a sunetelor"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Emite un sunet când o tastă este"
+
+#~ msgid "pressed"
+#~ msgstr "apăsată"
+
+#~ msgid "accepted"
+#~ msgstr "acceptată"
+
+#~ msgid "rejected"
+#~ msgstr "respinsă"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "Întârziere acc_eptare:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Controlează cursorul folosind tastele numerice"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Maus video"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Controlează cursorul folosind camera video."
+
+#~ msgid "_Local Account"
+#~ msgstr "Cont _local"
+
+#~ msgid "_Login Name"
+#~ msgstr "_Nume pentru conectare"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "Sfat: domeniu de companie sau nume real"
+
+#~ msgid "C_ontinue"
+#~ msgstr "C_ontinuare"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Autentificare fără parolă"
+
+#~ msgid "Disable this account"
+#~ msgstr "Dezactivează acest cont"
+
+#~ msgid "Enable this account"
+#~ msgstr "Activează acest cont"
+
+#~ msgid "_Action"
+#~ msgstr "_Acțiune"
+
+#~ msgid "_Show password"
+#~ msgstr "_Arată parola"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Cum să alegeți o parolă puternică"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Se schimbă fotografia pentru:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Alegeți o imagine ce va fi afișată la ecranul de autentificare pentru "
+#~ "acest cont."
+
+#~ msgid "Gallery"
+#~ msgstr "Galerie"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Fă o fotografie"
+
+#~ msgid "Browse"
+#~ msgstr "Navighează"
+
+#~ msgid "Photograph"
+#~ msgstr "Fotografie"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Prea scurtă"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "Nu este suficient de puternică"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Slabă"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Acceptabilă"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Bună"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Puternică"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "Trebuie să introduceți o parolă nouă"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "Trebuie să confirmați parola"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "Trebuie să introduceți parola curentă"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "Parola curentă este incorectă"
+
+#~ msgid "Switch Modes"
+#~ msgstr "Moduri comutare"
+
+#~ msgid "Action"
+#~ msgstr "Acțiune"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "Activează codul pentru depanare"
+
+#~ msgid "Low"
+#~ msgstr "Scăzută"
+
+#~ msgid "High"
+#~ msgstr "Ridicată"
+
+#~| msgid "Layout _Options..."
+#~ msgid "_Options..."
+#~ msgstr "_Opțiuni..."
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "Panoul de preferințe pentru dată și oră"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "Model necunoscut"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr ""
+#~ "Următoarea autentificare va încerca să folosească experiența standard."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "Următoarea autentificare va folosi modul de rezervă destinat pentru "
+#~ "hardware grafic nesuportat."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "Modul de rezervă"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgid "Experience"
+#~ msgstr "Experiență"
+
+#~ msgid "_Other Media..."
+#~ msgstr "A_lte tipuri de fișiere media..."
+
+#~ msgid "Install languages..."
+#~ msgstr "Instalează limbi..."
+
+#~ msgid "Region and Language"
+#~ msgstr "Regiune și limbă"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "Selectați limba de afișare (modificarea va fi aplicată la următoarea "
+#~ "autentificare)"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "Selectați o sursă de intrare de adăugat"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "Schimbă configurările de regiune și limbă"
+
+#~ msgid "Language;Layout;Keyboard;"
+#~ msgstr "Language;Layout;Limbă;Aranjamente;Limba;"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "Definiți preferințele pentru maus și touchpad"
+
+#~ msgid "Wireless"
+#~ msgstr "Fără fir"
+
+#~ msgid "Mesh"
+#~ msgstr "Mesh"
+
+#~ msgid "Power management settings"
+#~ msgstr "Configurări administrare consum"
+
+#~ msgid "Power;Sleep;Suspend;Hibernate;Battery;"
+#~ msgstr ""
+#~ "Power;Sleep;Suspend;Hibernate;Consum;Odihnă;Repaus;Suspendare;Hibernare;"
+#~ "Putere;"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "Brightness;Lock;Dim;Blank;Luminozitate;Blocare;Spațiu;Neclar;"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "Nu bloca ecranul când sunt acasă"
+
+#~ msgid "Locations..."
+#~ msgstr "Locații..."
+
+#~ msgid "Screen turns off"
+#~ msgstr "Ecranul se stinge"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — Miniaplicație control volum GNOME"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "Volum ieșire"
+
+#~ msgid "_Mute"
+#~ msgstr "_Mut"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "Preferințe _sunet"
+
+#~ msgid "Muted"
+#~ msgstr "Muțit"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "Arată controlul volumului pe desktop"
+
+#~ msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;"
+#~ msgstr ""
+#~ "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Microfon;Volum;"
+#~ "Estompare;Balans;Căști;"
+
+#~ msgid "Change sound volume and sound events"
+#~ msgstr "Modifică volumul și efectele sonore"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "Preferințe acces universal"
+
+#~ msgid "Options..."
+#~ msgstr "Opțiuni..."
+
+#~ msgid "Take a photo..."
+#~ msgstr "Fă o fotografie..."
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "Răsfoiește pentru mai multe imagini..."
+
+#~ msgid "A user with name '%s' already exists."
+#~ msgstr "Un utilizator cu numele „%s” există deja."
+
+#~ msgid "This user does not exist."
+#~ msgstr "Acest utilizator nu există."
+
+#~ msgid "Add or remove users"
+#~ msgstr "Adaugă sau șterge utilizatori"
+
+#~ msgid "User Accounts"
+#~ msgstr "Conturi utilizatori"
+
+#~ msgid "Fair"
+#~ msgstr "Acceptabilă"
+
+#~ msgid "_Hint"
+#~ msgstr "I_ndiciu"
+
+#~ msgid "- System Settings"
+#~ msgstr "- Configurări de sistem"
+
+#~ msgid "System Settings"
+#~ msgstr "Configurări de sistem"
+
+#~ msgid "_All Settings"
+#~ msgstr "To_ate configurările"
+
+#~ msgid "Calculating..."
+#~ msgstr "Se calculează..."
+
+#~ msgid "_Log In"
+#~ msgstr "_Autentificare"
+
+#~ msgid "_Show"
+#~ msgstr "_Afișează"
+
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgid "Examples"
+#~ msgstr "Exemple"
+
+#~ msgid "Currency"
+#~ msgstr "Monedă"
+
+#~ msgid "Format:"
+#~ msgstr "Format:"
+
+#~ msgid "System settings"
+#~ msgstr "Configurări de sistem"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "Mod de siguranță imp_us"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "Autorizare expirată. Vă rugăm să vă autentificați din nou."
+
+#~ msgid "Manage online accounts"
+#~ msgstr "Administrare conturi online"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr ""
+#~ "Selectați o regiune (modificarea va apărea la următoarea autentificare)"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "Ecranul de autentificare, conturile de sistem și conturile de utilizator "
+#~ "noi folosesc configurările pentru regiune și limbă ale sistemului. Puteți "
+#~ "schimba configurările de sistem pentru a se potrivi cu ale dumneavoastră."
+
+#~ msgid "Copy Settings..."
+#~ msgstr "Copiere configurări..."
+
+#~ msgid "Your settings"
+#~ msgstr "Configurările dumneavoastră"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "Ecranul de autentificare, conturile de sistem și conturile de utilizator "
+#~ "noi folosesc configurările pentru regiune și limbă ale sistemului."
+
+#~ msgid "Input source:"
+#~ msgstr "Sursă introducere"
+
+#~ msgid "Copy Settings"
+#~ msgstr "Copiere configurări"
+
+#~ msgid "Don't suspend"
+#~ msgstr "Nu se suspendă"
+
+#~ msgid "_Use as Hotspot..."
+#~ msgstr "_Utilizează ca Hotspot..."
+
+#~ msgid "On battery power"
+#~ msgstr "Alimentat de la baterie"
+
+#~ msgid "Other profile…"
+#~ msgstr "Alt profil…"
+
+#~ msgid "Color management settings"
+#~ msgstr "Administrare configurări culoare"
+
+#~ msgid "Calibration"
+#~ msgstr "Calibrare"
+
+#~ msgid "Cannot remove automatically added profile"
+#~ msgstr "Profilele adăugate automat nu pot fi șterse"
+
+#~ msgid "Create virtual device"
+#~ msgstr "Creează dispozitiv virtual"
+
+#~ msgid "Uncalibrated"
+#~ msgstr "Necalibrat"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i an"
+#~ msgstr[1] "%i ani"
+#~ msgstr[2] "%i de ani"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i lună"
+#~ msgstr[1] "%i luni"
+#~ msgstr[2] "%i de luni"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "Mai puțin de o săptămână"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i săptămână"
+#~ msgstr[1] "%i săptămâni"
+#~ msgstr[2] "%i de săptămâni"
+
+#~ msgid "This device is not color managed."
+#~ msgstr ""
+#~ "Administrarea profilurilor de culoare nu este activă pentru acest "
+#~ "dispozitiv."
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr ""
+#~ "Nu a fost detectat niciun dispozitiv care să recunoască administrarea "
+#~ "profilurilor de culoare"
+
+#~ msgctxt "Device kind"
+#~ msgid "Scanner"
+#~ msgstr "Scaner"
+
+#~ msgid "This device has an old profile that may no longer be accurate."
+#~ msgstr "Acest dispozitiv are un profil învechit, posibil imprecis."
+
+#~ msgid "Not specified"
+#~ msgstr "Nespecificată"
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "Acest dispozitiv nu are un profil potrivit pentru corecția de culoare în "
+#~ "modul pe tot ecranul."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "Acest dispozitiv utilizează date calibrate de producător."
+
+#~ msgctxt "Device kind"
+#~ msgid "Webcam"
+#~ msgstr "Cameră web"
+
+#~ msgid "Add device"
+#~ msgstr "Adaugă dispozitiv"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "Adaugă un dispozitiv virtual"
+
+#~ msgid "Available Profiles"
+#~ msgstr "Profile disponibile"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "Re_du iluminarea ecranului pentru economisire baterie"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "Acest indiciu poate fi afișat în ecranul de autentificare. Va fi vizibil "
+#~ "pentru toți utilizatorii definiți pe sistem. <b>Nu</b> includeți aici și "
+#~ "parola."
+
+#~ msgid "Calibrate..."
+#~ msgstr "Calibrare..."
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Configurați preferințele pentru tableta Wacom"
+
+#~ msgid "Mouse and Touchpad Settings"
+#~ msgstr "Configurări pentru mouse și touchpad"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Browse Files..."
+#~ msgstr "Navighează prin fișiere..."
+
+#~ msgid "Send Files..."
+#~ msgstr "Trimite fișiere..."
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "Profile disponibile pentru ecran"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "Profile disponibile pentru scannere"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "Profile disponibile pentru camere web"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "Profile disponibile pentru camere video"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "Profile disponibile pentru imprimante"
+
+#~ msgid ""
+#~ "device;system;information;memory;processor;version;default;application;"
+#~ "fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+#~ msgstr ""
+#~ "dispozitiv;sistem;informație;memorie;procesor;versiune;implicit;aplicație;"
+#~ "mod de siguranță;preferat;cd;dvd;usb;audio;video;disc;removable;media;"
+#~ "autorun;"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "Realizează o captură a unei ferestre"
+
+#~ msgid "Take a screenshot of an area"
+#~ msgstr "Realizează o captură a unei zone"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Realizează o captură de ecran"
+
+#~ msgid "When battery is charging/in use"
+#~ msgstr "Când bateria se încarcă/este utilizată"
+
+#~ msgid "Remove Region"
+#~ msgstr "Ștergere regiune"
+
+#~ msgid "Add Region"
+#~ msgstr "Adăugare regiune"
+
+#~ msgid "Add Language"
+#~ msgstr "Adăugare limbă"
+
+#~ msgid "Thick"
+#~ msgstr "Gros"
+
+#~ msgid "Thin"
+#~ msgstr "Subțire"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "Mapare butoane..."
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "Se încarcă - încărcare completă"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "Atenție baterie consumată, disponibil %s"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "Se utilizează bateria - disponibil %s"
+
+#~ msgid "Using battery power"
+#~ msgstr "Se utilizeză bateria"
+
+#~ msgid "Forget"
+#~ msgstr "Uită"
+
+#~ msgid "Charging - %s until fully charged"
+#~ msgstr "Se încarcă - %s până la încărcarea completă"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "Atenție UPS descărcat"
+
+#~ msgid "Using UPS power"
+#~ msgstr "Se utilizează UPS"
+
+#~ msgid "Caution low UPS, %s remaining"
+#~ msgstr "Atenție UPS descărcat, disponibil %s"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "Se utilizează UPS - disponibil %s"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "Bateria secundară este descărcată complet"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "Bateria secundară este încărcată complet"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "Suspendă dacă este inactiv pentru"
+
+#~ msgid "When the lid is closed"
+#~ msgstr "Când capacul este închis"
+
+#~ msgid "Show battery status in the _menu bar"
+#~ msgstr "Arată starea bateriei în bara de _meniu"
+
+#~ msgid "Map to Monitor..."
+#~ msgstr "Alocare pe monitor..."
+
+#~ msgid "Mode:"
+#~ msgstr "Mod:"
+
+#~ msgid "Test:"
+#~ msgstr "Test:"
+
+#~ msgid "Down"
+#~ msgstr "Descrescător"
+
+#~ msgid "Up"
+#~ msgstr "Crescător"
+
+#~ msgid "Require my password when waking from suspend"
+#~ msgstr "Solicită parola la revenirea din suspendare"
+
+#~ msgid "Record sound from"
+#~ msgstr "Înregistrare sunet de la"
+
+#~ msgid "Settings for the selected device"
+#~ msgstr "Configurări pentru dispozitivul selectat"
+
+#~ msgid "Settings for %s"
+#~ msgstr "Configurări pentru %s"
+
+#~ msgid "Play sound through"
+#~ msgstr "Redare sunet prin"
+
+#~ msgid "All displays"
+#~ msgstr "Toate ecranele"
+
+#~ msgid "L_auncher placement"
+#~ msgstr "Plasare L_ansator"
+
+#~ msgid "S_ticky edges"
+#~ msgstr "Mar_gini lipicioase"
+
+#~ msgid "Select from database..."
+#~ msgstr "Selectați din baza de date..."
+
+#~ msgid "Loading options..."
+#~ msgstr "Se încarcă opțiunile..."
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "Selectați tastaturile sau alte surse de introducere"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Ctrl+Alt+Shift+Space"
+#~ msgstr "Ctrl+Alt+Shift+Space"
+
+#~ msgid "Use the same source for all windows"
+#~ msgstr "Utilizați aceeași sursă pentru toate ferestrele"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "Luminozitate și blocare"
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "Nu există utilizator cu numele '%s'."
+
+#~ msgid "Language;Layout;Keyboard;Input Method;Text Entry;"
+#~ msgstr "Limbă;Aspect;Tastatură;Metodă introducere;Introducere text;"
+
+#~ msgid "Legal Notice"
+#~ msgstr "Informații juridice"
+
+#~ msgid "_Right"
+#~ msgstr "D_reapta"
+
+#~ msgid "_Left"
+#~ msgstr "_Stânga"
+
+#~ msgid "Out of range"
+#~ msgstr "În afara valorilor admise"
+
+#~ msgid "C_reate..."
+#~ msgstr "C_reează..."
+
+#~ msgid ""
+#~ "Network details for %s including password and any custom configuration "
+#~ "will be lost."
+#~ msgstr ""
+#~ "Detaliile de rețea pentru %s,  inclusiv parola și orice configurație "
+#~ "personalizată, vor fi pierdute."
+
+#~ msgid ""
+#~ "It is not possible to access the internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Nu este posibilă accesarea internetului prin wireless în timp ce hotspot-"
+#~ "ul este activ."
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can use "
+#~ "it to share your internet connection with others."
+#~ msgstr ""
+#~ "Dacă aveți o conexiune la Internet alta decât cea wireless, o puteți "
+#~ "folosi pentru partajarea conexiunii la internet."
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "Hotspot wireless"
+
+#~ msgid "_Settings..."
+#~ msgstr "Config_urări..."
+
+#~ msgid "_Connect"
+#~ msgstr "_Conectare"
+
+#~ msgid "_Disconnect"
+#~ msgstr "_Deconectare"
+
+#~ msgid "Switch off to connect to a wireless network"
+#~ msgstr "Oprește pentru conectarea la o rețea wireless"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "Legătura/purtătorul s-a modificat"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "Sfat: <a href=\"screen\">luminozitatea ecranului</a> influențează "
+#~ "consumul de energie"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "Se încarcă - încărcare completă"
+
+#~ msgid "Searching for preferred drivers..."
+#~ msgstr "Se caută pentru drivere preferate..."
+
+#~ msgid "Provide PPD File..."
+#~ msgstr "Furnizați fișier PPD..."
+
+#~ msgid "Manufacturers"
+#~ msgstr "Producători"
+
+#~ msgid "Setting new driver..."
+#~ msgstr "Se configurează noul driver..."
+
+#~ msgid "Drivers"
+#~ msgstr "Drivere"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "Configurări acceleratori"
+
+#~ msgid "New accelerator…"
+#~ msgstr "Accelerator nou…"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "Nimic"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Full"
+#~ msgstr "Complet"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "Culoare"
+
+#~ msgid "Text Entry"
+#~ msgstr "Intrare text"
+
+#~ msgid "Contents"
+#~ msgstr "Cuprins"

--- a/po/ru.po
+++ b/po/ru.po
@@ -22,10 +22,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ru\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-08-24 14:39+0000\n"
-"PO-Revision-Date: 2022-08-24 19:42+0300\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-12-10 18:56+0300\n"
 "Last-Translator: Aleksandr Melman <Alexmelman88@gmail.com>\n"
 "Language-Team: Русский <gnome-cyr@gnome.org>\n"
 "Language: ru\n"
@@ -34,103 +33,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Poedit 3.1\n"
-
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Системная шина"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Полный доступ"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Шина сеанса"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Устройства"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Полный доступ к /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Сеть"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Имеет доступ к сети"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Домашняя папка"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Только для чтения"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Файловая система"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Настройки"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Может изменять настройки"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s имеет следующие встроенные разрешения. Они не могут быть изменены. Если "
-"вас беспокоят эти разрешения, рассмотрите возможность удаления этого "
-"приложения."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u тип файла и ссылки, которые открываются приложением"
-msgstr[1] "%u типа файлов и ссылок, которые открываются приложением"
-msgstr[2] "%u типов файлов и ссылок, которые открываются приложением"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> используется для открытия следующих типов файлов и ссылок."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s дискового пространства использовано."
+"X-Generator: Poedit 3.2.2\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -146,7 +51,6 @@ msgid "Install some…"
 msgstr "Установить какое-нибудь…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Открыть"
 
@@ -170,24 +74,13 @@ msgstr "Поиск"
 msgid "Receive system searches and send results."
 msgstr "Получение результатов поиска в системе и их отправка."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Выключено"
 
@@ -353,80 +246,20 @@ msgstr "Очистить кэш…"
 msgid "Control various application permissions and settings"
 msgstr "Управление различными разрешениями и настройками приложения"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "приложение;flatpak;права;доступ;настройки;параметры;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Выберите изображение"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Отменить"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Открыть"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "множество размеров"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Без фона рабочего стола"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Текущий фон"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Стиль"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "По умолчанию"
 
@@ -450,7 +283,6 @@ msgstr "Внешний вид"
 msgid "Change your background image or the UI colors"
 msgstr "Изменить фоновое изображение или цвета пользовательского интерфейса"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr "Фон;Обои;Экран;Рабочий;Стиль;Светлый;Темный;Внешний вид;"
@@ -501,9 +333,7 @@ msgstr "Аппаратный авиарежим включен"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Для включения Bluetooth выключите авиарежим."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -511,7 +341,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Включение и отключение Bluetooth. Подключение устройств Bluetooth"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "общий;доступ;bluetooth;obex;"
@@ -531,9 +360,8 @@ msgid ""
 "\n"
 "Allow the applications below to use your camera."
 msgstr ""
-"Использование камеры позволяет приложениям захватывать фотографии и видео. "
-"Отключение камеры может привести к неправильной работе некоторых "
-"приложений.\n"
+"Использование камеры позволяет приложениям снимать фото и видео. Отключение "
+"камеры может привести к неправильной работе некоторых приложений.\n"
 "\n"
 "Разрешить перечисленным ниже приложениям использовать вашу камеру."
 
@@ -545,91 +373,33 @@ msgstr "Нет приложений запросивших доступ к ка�
 msgid "Protect your pictures"
 msgstr "Защитите ваши изображения"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "камера;фото;видео;веб-камера;блокировка;частное;конфиденциальность;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Поместите устройство калибровки на квадрат и нажмите «Запустить»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Наведите устройство калибровки на место калибровки и нажмите «Продолжить»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Переместите устройство калибровки на поверхность и нажмите «Продолжить»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Закройте крышку ноутбука"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Произошла внутренняя ошибка, которая не может быть исправлена."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Необходимые для калибровки инструменты не установлены."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Ошибка при создании профиля."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Целевая точка белого не получена."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Выполнено!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Сбой калибровки!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Можно убрать устройство калибровки."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Не трогайте устройство калибровки в процессе выполнения"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Калибровка экрана"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Отменить"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -646,140 +416,6 @@ msgstr "_Продолжить"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Готово"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Экран ноутбука"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Встроенная веб-камера"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Монитор %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Сканер %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Камера %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Принтер %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Веб-камера %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Включить управление цветом для %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Показать цветовые профили для %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Неоткалиброванный"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "По умолчанию: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Цветовое пространство: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Тестовый профиль: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Выберите файл профиля ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Импортировать"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Поддерживаемые профили ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Все файлы"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Экран"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Сохранить профиль"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Сохранить"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Создать цветовой профиль для выбранного устройства"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Измерительный инструмент не обнаружен. Проверьте, что он включён и правильно "
-"подключён."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Измерительный инструмент не поддерживает профилирование принтеров."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Этот тип устройств ещё не поддерживается."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -923,7 +559,6 @@ msgstr "_Импортировать файл…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -935,9 +570,7 @@ msgstr ""
 "Для управления цветом каждому устройству требуется обновление цветового "
 "профиля."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Узнать больше"
 
@@ -1072,83 +705,6 @@ msgstr "D65 (Фото и графика)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Стандартное цветовое пространство"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Тестовый профиль"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Автоматический"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Низкое качество"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Среднее качество"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Высокое качество"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB по умолчанию"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK по умолчанию"
-
-# Цветовое пространство
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Серое по умолчанию"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Предоставленные производителем данные заводской калибровки"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Полноэкранный режим коррекции не возможен с этим профилем"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Возможно этот профиль уже неточный"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Цвет"
@@ -1158,14 +714,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Калибровка цвета устройств, таких как экраны, камеры или принтеры"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Цвет;ICC;Профиль;Калибровка;Принтер;Экран;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Другой…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1180,13 +731,8 @@ msgid "No languages found"
 msgstr "Ни один язык не найден"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Ещё…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Разблокировать для изменения настроек"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1215,156 +761,6 @@ msgstr "Убавление часа"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Убавление минуты"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Сегодня"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Вчера"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%-d %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%-d %b %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d час"
-msgstr[1] "%d часа"
-msgstr[2] "%d часов"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d минута"
-msgstr[1] "%d минуты"
-msgstr[2] "%d минут"
-
-# Блокировать экран после:
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d секунда"
-msgstr[1] "%d секунды"
-msgstr[2] "%d секунд"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-# Блокировать экран после:
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 секунд"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Точка доступа"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-часовой"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "12-часовой"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%-d %B %Y, %l∶%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%-d %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l∶%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1459,17 +855,11 @@ msgstr "Автоматическое определение _часового п
 msgid "Requires location services enabled and internet access"
 msgstr "Требуются сервисы определения местоположения и доступ в интернет"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Включено"
 
@@ -1477,15 +867,44 @@ msgstr "Включено"
 msgid "Time Z_one"
 msgstr "_Часовой пояс"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Разблокировать"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Формат времени"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Дата"
+
+# Блокировать экран после:
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 секунд"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Календарь"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Числа"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Изменить дату и время, включая часовой пояс"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Часы;Часовой;пояс;Местоположение;"
@@ -1531,20 +950,9 @@ msgstr "Приложения по умолчанию"
 msgid "Configure Default Applications"
 msgstr "Настроить приложения по умолчанию"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "по умолчанию;приложение;предпочтительное;носитель;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Отправка сообщения о технических проблемах помогает нам улучшить %s. Отчеты "
-"отправляются анонимно и не содержат персональных данных. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1562,44 +970,9 @@ msgstr "Диагностика"
 msgid "Report your problems"
 msgstr "Сообщить об ошибках"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "диагностика;крах;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Включено"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Выключено"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Применить изменения?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Изменения не могут быть применены"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Это может быть связано с аппаратными ограничениями."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1649,31 +1022,6 @@ msgstr "Основной дисплей"
 msgid "Night Light"
 msgstr "Ночной свет"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Ландшафтная"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Портретная справа"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Портретная слева"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Ландшафтная (перевернутая)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Гц"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1697,6 +1045,17 @@ msgstr "Отрегулировать для ТВ"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Масштаб"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Естественная прокрутка"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1792,7 +1151,6 @@ msgstr "Дисплеи"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Выберите, как использовать подключённые мониторы и проекторы"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1800,81 +1158,6 @@ msgid ""
 msgstr ""
 "Панель;Проектор;xrandr;Экран;Разрешение;Обновить;Монитор;Ночь;Подсветка;"
 "Синий;смещение;цвет;закат;рассвет;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "Безопасная загрузка активна"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Безопасная загрузка предотвращает загрузку вредоносного программного "
-"обеспечения при запуске устройства. В настоящее время она включена и "
-"функционирует правильно."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Проблемы с безопасной загрузкой"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Безопасная загрузка предотвращает загрузку вредоносного программного "
-"обеспечения при запуске устройства. В настоящее время она включена, но не "
-"будет работать из-за наличия недействительного ключа."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Проблемы с безопасной загрузкой часто можно решить из настроек прошивки UEFI "
-"(BIOS) вашего компьютера, и производитель оборудования может предоставить "
-"информацию о том, как это сделать."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"За помощью обратитесь к производителю оборудования или поставщику ИТ-"
-"поддержки."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Безопасная загрузка отключена"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Безопасная загрузка предотвращает загрузку вредоносного программного "
-"обеспечения при запуске устройства. В настоящее время она отключена."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Безопасную загрузку обычно можно включить в настройках прошивки UEFI (BIOS) "
-"компьютера. За помощью обратитесь к производителю оборудования или "
-"поставщику ИТ-поддержки."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1889,131 +1172,9 @@ msgstr ""
 "Для получения дополнительной информации обратитесь к производителю "
 "оборудования или в службу ИТ-поддержки."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Пройдено"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Неудачно"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Устройство соответствует %d уровню HSI"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "Уровень безопасности 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Это устройство не имеет защиты от аппаратных проблем безопасности. Это может "
-"быть связано с проблемой конфигурации оборудования или прошивки. "
-"Рекомендуется обратиться к поставщику услуг ИТ-поддержки."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "Уровень безопасности 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Это устройство имеет минимальную защиту от аппаратных проблем безопасности. "
-"Это самый низкий уровень безопасности устройства, обеспечивающий защиту "
-"только от простых угроз безопасности."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "Уровень безопасности 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Это устройство имеет базовую защиту от аппаратных проблем безопасности. Это "
-"обеспечивает защиту от некоторых распространенных угроз безопасности."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "Уровень безопасности 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Это устройство имеет расширенную защиту от аппаратных проблем безопасности. "
-"Это самый высокий уровень безопасности устройства, обеспечивающий защиту от "
-"современных угроз безопасности."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "Уровень безопасности"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr "Уровни безопасности для этого устройства недоступны."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Обратитесь к производителю оборудования за помощью в обновлении системы "
-"безопасности."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Возможно, эту проблему можно решить в настройках прошивки UEFI устройства "
-"или с помощью специалиста службы поддержки."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Возможно, эту проблему можно решить в настройках прошивки UEFI устройства."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Возможно, специалист службы поддержки сможет решить эту проблему."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2027,338 +1188,9 @@ msgstr "Уровень 2"
 msgid "Level 3"
 msgstr "Уровень 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr "Обеспечена защита от вредоносных программ при запуске устройства."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "Проблемы с безопасной загрузкой"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "Некоторая защита при запуске устройства."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "Безопасная загрузка отключена"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "Без защиты при запуске устройства."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Эта проблема могла быть вызвана изменением настроек прошивки UEFI, "
-"изменением конфигурации операционной системы или наличием вредоносного "
-"программного обеспечения в этой системе."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Эта проблема могла быть вызвана изменением настроек прошивки UEFI или "
-"наличием вредоносного программного обеспечения в данной системе."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Эта проблема могла быть вызвана изменением конфигурации операционной системы "
-"или наличием вредоносного программного обеспечения в этой системе."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "Подвержен серьезным угрозам безопасности."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "Ограниченная защита от простых угроз безопасности."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "Обеспечена защита от распространенных угроз безопасности."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "Обеспечена защита от широкого спектра угроз безопасности."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "Комплексная защита"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Событий нет"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Защита от записи прошивки"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Блокировка защиты от записи прошивки"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Регион прошивки BIOS"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Дескриптор прошивки BIOS"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Предзагрузочная защита DMA"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Проверенная загрузка Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Защищенный ACM Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Политика ошибок Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Предохранитель Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET включена"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET активна"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Зашифрованное ОЗУ"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Защита IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Блокировка ядра Linux"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Проверка ядра Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Подкачка Linux"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Режим сна"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Режим ожидания"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Ключ платформы UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Безопасная загрузка UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Конфигурация платформы TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Реконструкция TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Производственный режим Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Переопределение Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Версия Intel Management Engine"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Обновления прошивки"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Аттестация прошивки"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Подтверждение программы обновления прошивки"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Отладка платформы"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Проверка безопасности процессора"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Защита от отката прошивки AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Защита от повтора прошивки AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Защита от записи прошивки AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Объединенная платформа"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Действительно"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Недействительно"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Не включено"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Заблокировано"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Не заблокировано"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Зашифровано"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Не зашифровано"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Испорчено"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Не испорчено"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Найдено"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Не найдено"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Поддерживается"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Не поддерживается"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2368,7 +1200,6 @@ msgstr "Безопасность устройства"
 msgid "Host firmware security status"
 msgstr "Статус безопасности прошивки хоста"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2376,49 +1207,6 @@ msgid ""
 msgstr ""
 "экран;блокировка;диагностика;сбой;личный;приватный;недавние;временные;tmp;"
 "индекс;имя;сеть;идентификация;личность;конфиденциальность;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Неизвестно"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-бит"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-бит"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Неизвестно"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Недоступно"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Логотип системы"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2513,11 +1301,6 @@ msgstr "О системе"
 msgid "View information about your system"
 msgstr "Просмотр информации о системе"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2596,6 +1379,12 @@ msgstr "Запуск приложений"
 msgid "Launch help browser"
 msgstr "Запустить справочный браузер"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Настройки"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Запустить калькулятор"
@@ -2617,7 +1406,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Найти"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Система"
 
@@ -2632,7 +1421,7 @@ msgstr "Заблокировать экран"
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
 msgid "Accessibility"
-msgstr "Доступность"
+msgstr "Специальные возможности"
 
 #: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
@@ -2666,15 +1455,6 @@ msgstr "Уменьшить размер текста"
 msgid "High contrast on or off"
 msgstr "Включить или выключить высокую контрастность"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Источники ввода не найдены"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Другое"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Добавить источник ввода"
@@ -2707,108 +1487,9 @@ msgstr "Настройки"
 msgid "View Keyboard Layout"
 msgstr "Показать раскладку"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Удалить"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Дополнительные комбинации клавиш"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Клавиша альтернативных символов"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Клавиша альтернативных символов может использоваться для ввода "
-"дополнительных символов. Они иногда изображены на кнопках клавиатуры как "
-"третий вариант."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Левый Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Правый Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Левый Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Правый Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Кнопка меню"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Правый Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Клавиша Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Клавиша compose позволяет вводить самые разнообразные символы. Чтобы "
-"использовать это, нажмите клавишу compose, затем последовательность "
-"символов.  Например, нажав клавишу compose, за которой следуют <b>C</b> и "
-"<b>o</b>, получим <b>©</b>, клавиша compose и <b>a</b>, за которой следует "
-"<b>'</b>, получим <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Переключить источники ввода можно сочетанием клавиш %s.\n"
-"Эту комбинацию можно изменить в настройках сочетаний."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2838,46 +1519,21 @@ msgstr "Ввод специальных знаков"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Методы ввода символов и вариантов букв, используя клавиатуры."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Клавиша альтернативных символов"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Клавиша Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Комбинации клавиш"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Просмотр и изменение комбинаций клавиш"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d изменена"
-msgstr[1] "%d изменены"
-msgstr[2] "%d изменено"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Сбросить все комбинации клавиш?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Сброс комбинаций клавиш может также повлиять на пользовательские комбинации "
-"клавиш. Это действие нельзя отменить."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Отменить"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Сбросить все"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2916,34 +1572,6 @@ msgstr "Добавить комбинацию"
 msgid "No keyboard shortcut found"
 msgstr "Комбинация клавиш не найдена"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s уже используется для %s. Если применить, комбинация для %s будет отключена"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Введите новую комбинацию"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Установить пользовательскую комбинацию клавиш"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Установить комбинацию клавиш"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Введите новую комбинацию для изменения %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Добавить пользовательскую комбинацию клавиш"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Удалить"
@@ -2955,7 +1583,6 @@ msgstr "За_менить"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Установить"
 
@@ -2991,6 +1618,11 @@ msgstr "Нет"
 msgid "Reset the shortcut to its default value"
 msgstr "Сбросить комбинацию на значение по умолчанию"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Использовать по умолчанию"
+
 # спецсимвол-невидимый перенос тут между стрелок <­>, копировать через vim или nano
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -3004,7 +1636,6 @@ msgstr ""
 "Просмотр и изменение комбинаций клавиш, а также настройка ввода, раскладок "
 "клавиатуры и источников ввода"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3047,7 +1678,6 @@ msgstr "Нет приложений запросивших доступ к ме�
 msgid "Protect your location information"
 msgstr "Защитите вашу информацию о местоположении"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "местоположение;gps;частное;конфиденциальность;"
@@ -3082,7 +1712,6 @@ msgstr "Нет приложений запросивших доступ к ми�
 msgid "Protect your conversations"
 msgstr "Защитите ваш обмен сообщениями"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "микрофон;запись;приложение;конфиденциальность;"
@@ -3112,82 +1741,141 @@ msgstr "Левая"
 msgid "Right"
 msgstr "Правая"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Места поиска"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Мышь"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Скорость указателя мыши"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Естественная прокрутка"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Без защиты"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr ""
 "При прокрутке перемещается содержимое на экране, а не полоса прокрутки."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr ""
+"При прокрутке перемещается содержимое на экране, а не полоса прокрутки."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Запущено"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Сенсорная панель"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Скорость указателя сенсорной панели"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Нажатие касанием"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Нажатие касанием"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Прокрутка двумя пальцами"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Скорость указателя сенсорной панели"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Участки прокрутки по краям"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Двусторонняя печать"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Проверьте щелчок, двойной щелчок, прокрутку"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Сделайте пять щелчков мышью, чтобы открыть «пасхальное яйцо»!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Двойной щелчок, основная кнопка"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Один щелчок, основная кнопка"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Двойной щелчок, средняя кнопка"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Один щелчок, средняя кнопка"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Двойной щелчок, вторичная кнопка"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Один щелчок, вторичная кнопка"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3200,7 +1888,6 @@ msgstr ""
 "Изменение чувствительности мыши или сенсорной панели, а также настройки "
 "кнопок для правши или левши"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Трэкпад;Указатель;Щелчок;Нажатие;Двойной;Кнопка;Трэкбол;Прокрутка;"
@@ -3280,7 +1967,6 @@ msgstr "Многозадачность"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Управляйте предпочтениями продуктивности и многозадачности"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3288,22 +1974,11 @@ msgstr ""
 "Многозадачность;Продуктивность;Фокус;Настройка;Рабочий стол;Горячий угол;"
 "Рабочее место;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"К сожалению, что-то пошло не так. Обратитесь к поставщику программного "
-"обеспечения."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager должен быть запущен."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Другие устройства"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3315,59 +1990,16 @@ msgstr "Добавить подключение"
 msgid "Not set up"
 msgstr "Не настроено"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Незащищённая сеть (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Защищённая сеть (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Защищённая сеть (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Защищённая сеть (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Защищённая сеть"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Подключено"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Параметры…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Включение точки доступа приведёт к отключению от %s, и доступ в интернет "
-"через Wi-Fi будет невозможен ."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Должно содержать не менее 8 символов"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3419,20 +2051,6 @@ msgstr "Автоматически сгенерировать пароль"
 msgid "_Turn On"
 msgstr "_Включить"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Остановить точку доступа и отключить всех пользователей?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Остановить точку доступа"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Авиарежим"
@@ -3477,90 +2095,15 @@ msgstr "Видимые сети"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager должен быть запущен"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"К сожалению, что-то пошло не так. Обратитесь к поставщику программного "
+"обеспечения."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Безопасность 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Безопасность"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Предустановленный"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Постоянный"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Случайный"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Стабильный"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Введенный здесь MAC-адрес будет использоваться в качестве аппаратного адреса "
-"для сетевого устройства, на котором установлено это соединение. Эта функция "
-"известна как клонирование или подмена MAC. Пример: 00: 11: 22: 33: 44: 55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Профиль %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-# Enhanced open provides improved data encryption in open Wi-Fi networks and protects data from sniffing. Enhanced open replaces open system as the default option. With enhanced open, the client and WLAN perform Diffie-Hellman key exchange during the access procedure and use the resulting pairwise key with a 4-way handshake.
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Предприятие"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Нет"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Никогда"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3571,183 +2114,6 @@ msgstr[0] "%i день назад"
 msgstr[1] "%i дня назад"
 msgstr[2] "%i дней назад"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Мб/с (%1.1f ГГц)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Мб/с"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 ГГц / 5 ГГц"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 ГГц"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 ГГц"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Нет"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Слабый"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Средний"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Хороший"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Отличный"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Адрес IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Адрес IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Адрес IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Забыть соединение"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Удалить профиль соединения"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Удалить VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Подробности"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "автоматический"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Идентификация"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Удалить адрес"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Удалить маршрут"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Нет"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "40/128-битный ключ WEP (Hex или ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "128-битная парольная фраза WEP"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Динамический WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "Персональный WPA и WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "Корпоративный WPA и WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "Персональный WPA3"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3757,8 +2123,20 @@ msgstr "Мощность сигнала"
 msgid "Link speed"
 msgstr "Скорость передачи данных"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Безопасность"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Адрес IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Адрес IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Аппаратный адрес"
 
@@ -3767,12 +2145,17 @@ msgid "Supported Frequencies"
 msgstr "Поддерживаемые частоты"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Маршрут по умолчанию"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3836,7 +2219,7 @@ msgstr "Только для локальной сети"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Вручную"
 
@@ -3880,9 +2263,8 @@ msgstr "Шлюз"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Автоматический"
 
@@ -3935,89 +2317,9 @@ msgstr "Автоматический, только DHCP"
 msgid "Prefix"
 msgstr "Префикс"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Не удалось открыть редактор соединений"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Создать профиль"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Неверная настройка %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Неверная настройка %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Импортировать из файла…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Добавить VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Безопасность"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Не удалось импортировать соединение VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Невозможно прочитать файл «%s» или файл не содержит корректную информацию о "
-"VPN-соединении\n"
-"\n"
-"Ошибка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Выберите файл для импортирования"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Файл с именем «%s» уже существует."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Заменить"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Заменить %s сохраняемым VPN-соединением?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Не удалось экспортировать соединение VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Невозможно экспортировать VPN-соединение «%s» в %s.\n"
-"\n"
-"Ошибка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Экспортировать VPN-соединение"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4031,99 +2333,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Сеть"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Управление подключением к Интернету"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Сеть;IP;LAN;Прокси;WAN;Мобильная;Модем;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Контролируйте, как вы подключаетесь к сетям Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Сеть;Беспроводная;Wi-Fi;Wifi;IP;LAN;Мобильная;DNS;Точка;доступа;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "никогда"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "сегодня"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "вчера"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Последнее использование"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Проводное соединение"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Добавить новое подключение"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Сетевые данные для выделенных сетей, включая пароли и любые пользовательские "
-"настройки, будут утеряны."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Забыть"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Известные сети Wi-Fi"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Забыть"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Использование в качестве точки доступа запрещено системной политикой"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Беспроводное устройство не поддерживает режим точки доступа"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"При отсутствии URL для автоматической настройки используется метод Web Proxy "
-"Autodiscovery."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Не рекомендуется использовать для непроверенных общедоступных сетей."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4143,49 +2382,53 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Провайдер"
 
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Адрес IP"
+
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Сетевой прокси"
 
 #: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
-msgstr "Прокси для H_TTP"
+msgstr "_HTTP-прокси"
 
 #: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
-msgstr "Прокси для H_TTPS"
+msgstr "H_TTPS-прокси"
 
 #: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
-msgstr "Прокси для _FTP"
+msgstr "_FTP-прокси"
 
 #: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
-msgstr "Узел S_ocks"
+msgstr "Хост _SOCKS"
 
 #: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
-msgstr "_Игнорировать узлы"
+msgstr "_Игнорировать хосты"
 
 #: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
-msgstr "Порт прокси для HTTP"
+msgstr "Порт HTTP-прокси"
 
 #: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
-msgstr "Порт прокси для HTTPS"
+msgstr "Порт HTTPS-прокси"
 
 #: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
-msgstr "Порт прокси для FTP"
+msgstr "Порт FTP-прокси"
 
 #: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
-msgstr "Порт прокси для Socks"
+msgstr "Порт Socks-прокси"
 
 #: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
-msgstr "URL _автоматической настройки"
+msgstr "URL _конфигурации"
 
 #: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
@@ -4225,289 +2468,6 @@ msgstr "_Включить точку доступа Wi-Fi…"
 #: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Известные сети Wi-Fi"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Состояние неизвестно"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Неуправляемое"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Недоступно"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Подключение"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Требуется аутентификация"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Отключение"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Сбой подключения"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Состояние неизвестно (отсутствует)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Сбой настройки"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Сбой настройки IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Истёк срок настроек IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Требуется пароль, но он не задан"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Клиент 802.1x отключён"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Сбой настройки клиента 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Сбой клиента 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Клиент 802.1x слишком долго ожидал аутентификации"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Не удалось запустить службу PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Служба PPP отключена"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Сбой PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Не удалось запустить клиент DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Ошибка клиента DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Сбой клиента DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Не удалось запустить службу общего подключения"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Сбой службы общего подключения"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Не удалось запустить службу AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Ошибка службы AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Сбой службы AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Линия занята"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Нет гудка в линии"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Невозможно установить несущую"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Время, отведённое на звонок, истекло"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Не удалось дозвониться"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Не удалось инициализировать модем"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Не удалось выбрать указанный APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Нет сетей для поиска"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Отказано в регистрации в сети"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Время в регистрации сети истекло"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Не удалось зарегистрироваться в запрошенной сети"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Сбой проверки PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Возможно, отсутствует микропрограмма устройства"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Подключение пропало"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Предполагалось, что соединение существует"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Модем не найден"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Сбой подключения по Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Не вставлена SIM-карта"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Требуется SIM Pin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Требуется SIM Puk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Некорректный SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Сбой зависимости подключения"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Отсутствует прошивка"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Кабель не подключён"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "неизвестная ошибка в безопасности 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "файлы не выбраны"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "неизвестная ошибка проверки файла ЕАР-методом"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12 или приватные ключи PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Сертификаты DER или PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "отсутствует файл EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Файлы PAC (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4557,14 +2517,6 @@ msgstr "_Внутренняя аутентификация"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Разрешить автоматическое _выделение ресурсов PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "отсутствует имя пользователя EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "отсутствует пароль EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4590,15 +2542,6 @@ msgstr "_Пароль"
 msgid "Sho_w password"
 msgstr "_Показывать пароль"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "недействительный сертификат EAP-PEAP CA: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "недействительный сертификат EAP-PEAP CA: сертификат не указан"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4620,7 +2563,6 @@ msgid "C_A certificate"
 msgstr "Сертификат C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4635,63 +2577,6 @@ msgstr "Сертификат CA не _требуется"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Версия PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "отсутствует имя пользователя EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "отсутствует пароль EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "отсутствует идентичность EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "недействительный сертификат EAP-TLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "недействительный сертификат EAP-TLS CA: сертификат не указан"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "недействительный секретный ключ EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "недействительный пользовательский сертификат EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Незашифрованные закрытые ключи являются небезопасными"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Возможно, выбранный приватный ключ не защищён паролем. Это может привести к "
-"компрометированию ваших учётных данных. Выберите приватный ключ, защищённый "
-"паролем.\n"
-"\n"
-"(Вы можете защитить приватный ключ с помощью openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Выберите свой персональный сертификат"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Выберите ваш приватный ключ"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4708,15 +2593,6 @@ msgstr "Приватный _ключ"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Пароль приватного ключа"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "недействительный сертификат EAP-TTLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "недействительный сертификат EAP-TTLS CA: сертификат не указан"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4739,14 +2615,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Домен"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Неизвестная ошибка проверки безопасности 802.1X"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4774,63 +2651,10 @@ msgstr "Защищённый EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "А_утентификация"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Выберите файл"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "отсутствует leap-имя пользователя"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "отсутствует leap-пароль"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Пароль Wi-Fi отсутствует."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Тип"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "отсутствует wep-ключ"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"недействительный wep-ключ: ключ с длиной %zu должен содержать только "
-"шестнадцатеричные цифры"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"недействительный wep-ключ: ключ с длиной %zu должен содержать только символы "
-"ASCII"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"недействительный wep-ключ: ключ с неверной длиной %zu. Ключ должен быть "
-"длины 5/13 (ASCII) или 10/26 (HEX)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "недействительный wep-ключ: парольная фраза не может быть пустой"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"недействительный wep-ключ: парольная фраза должна быть короче 64 символов"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4855,21 +2679,6 @@ msgstr "_Показать ключ"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "_Индекс WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"недействительный wpa-psk: ключ неверной длины %zu. Должен быть [8,63] байт "
-"или 64 шестнадцатеричных цифр"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"недействительный wpa-psk: невозможно интерпретировать ключ с 64 байт как "
-"шестнадцатеричный"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4924,27 +2733,9 @@ msgstr "Уведомления на экране _блокировки"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Управление отображением и содержанием уведомлений"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Уведомления;Всплывающее;Сообщение;Лоток;Всплывающее;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Другое"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s удалён"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Ошибка при удалении учётной записи"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4970,17 +2761,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Добавить учётную запись"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Учётная запись %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Удалить учётную запись"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Сетевые ­учётные записи"
@@ -4990,10 +2770,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Подключиться к сетевым учётным записям и решить для чего их использовать"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5001,10 +2777,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Онлайн;Чат;Календарь;Почта;Контакт;"
 "ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Время неизвестно"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5022,13 +2794,6 @@ msgstr[0] "%i час"
 msgstr[1] "%i часа"
 msgstr[2] "%i часов"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5042,191 +2807,6 @@ msgid_plural "minutes"
 msgstr[0] "минута"
 msgstr[1] "минуты"
 msgstr[2] "минут"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "Полностью зарядится через %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Внимание: разрядится через %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Разрядится через %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Полностью заряжена"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Не заряжается"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Разряжена"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Зарядка"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Разрядка"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Беспроводная мышь"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Беспроводная клавиатура"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Источник бесперебойного питания"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "КПК"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Мобильный телефон"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Медиапроигрыватель"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Планшет"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Компьютер"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Игровое устройство ввода"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Батарея"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Основная"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Дополнительная"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Батареи"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "При п_ростое"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Режим ожидания"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Выключить"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Режим гибернации"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Ничего не делать"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "При работе от батареи"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "При подключении к сети"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Никогда"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Автоматический режим ожидания"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Режим высокой производительности временно запрещён из-за высокой температуры "
-"устройства."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Режим высокой производительности временно запрещён из-за обнаруженной работы "
-"на коленях. Переместите устройство на ровную поверхность для возобновления "
-"режима."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Режим высокой производительности запрещён."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Низкий заряд батареи: включён режим низкого потребления. Предыдущий режим "
-"будет автоматически включён когда батарея будет заряжена."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Режим низкого потребления активирован «%s»."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Режим высокой производительности активирован «%s»."
 
 # Выключать экран при простое после:
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
@@ -5297,6 +2877,15 @@ msgstr "100 минут"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 часа"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батарея"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Устройства"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5375,33 +2964,6 @@ msgstr "При работе от _батареи"
 msgid "Delay"
 msgstr "Задержка"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Производительный"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Высокая производительность и энергопотребление."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Сбалансированный"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Стандартная производительность и энергопотребление."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Энергосберегающий"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Уменьшенная производительность и энергопотребление."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Электропитание"
@@ -5410,7 +2972,6 @@ msgstr "Электропитание"
 msgid "View your battery status and change power saving settings"
 msgstr "Просмотр состояния батареи и изменение настроек энергосбережения"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5418,27 +2979,6 @@ msgid ""
 msgstr ""
 "Электропитание;Спящий;Ждущий;Батарея;Яркость;Затемнение;Экран;DPMS;"
 "Бездействующий;Энергия;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Принтер «%s» удалён"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Не удалось добавить новый принтер."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Не удалось загрузить интерфейс пользователя: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Разблокировать для добавления принтеров и изменения настроек"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5448,7 +2988,6 @@ msgstr "Принтеры"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Добавление принтеров, просмотр текущих заданий и выбор способа печати"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Принтер;Очередь;Печать;Бумага;Чернила;Тонер;"
@@ -5456,8 +2995,6 @@ msgstr "Принтер;Очередь;Печать;Бумага;Чернила;�
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Добавить принтер"
 
@@ -5497,29 +3034,6 @@ msgstr ""
 msgid "Username"
 msgstr "Имя пользователя"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Подробности %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Подходящий драйвер не найден"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Выберите файл PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Файлы PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Имена принтеров не могут содержать пробел, TAB, # или /"
@@ -5528,9 +3042,7 @@ msgstr "Имена принтеров не могут содержать про�
 msgid "Location"
 msgstr "Местоположение"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Драйвер"
 
@@ -5558,121 +3070,14 @@ msgstr "Выберите драйвер принтера"
 msgid "Loading drivers database…"
 msgstr "Загрузка базы данных драйверов…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Отменить"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Выбрать"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Принтер JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Принтер LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Односторонняя печать"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "По длинной стороне (стандарт)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "По короткой стороне (переворот)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Портретная"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Ландшафтная"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Перевёрнутая ландшафтная"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Перевёрнутая портретная"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Продолжить"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Приостановить"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Ожидание"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Приостановлено"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Требуется аутентификация"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Выполняется"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Остановлено"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Отменено"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Прервано"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Выполнено"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Переместить это задание в начало очереди"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5680,19 +3085,6 @@ msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u задание требует аутентификацию"
 msgstr[1] "%u задания требуют аутентификацию"
 msgstr[2] "%u заданий требуют аутентификацию"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "Текущие задания — %s"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Введите учётные данные для печати из %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5720,206 +3112,11 @@ msgstr "_Авторизоваться"
 msgid "No Active Printer Jobs"
 msgstr "Нет активных заданий печати"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Разблокировать сервер печати"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Разблокировать %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Введите имя пользователя и пароль для просмотра принтеров на %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Поиск принтеров"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Последовательный порт"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Параллельный порт"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Расположение: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Адрес: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Сервер требует аутентификацию"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Двусторонняя печать"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Тип бумаги"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Источники бумаги"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Приёмный лоток"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Разрешение"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Предварительная фильтрация GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Страниц на сторону"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Двусторонняя печать"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Ориентация"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Общие"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Настройка страницы"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Устанавливаемые параметры"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Задание"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Качество изображения"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Цвет"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Отделка"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Дополнительно"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Пробная страница"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Пробная страница"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Выбрать автоматически"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Параметры по умолчанию"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Встраивать только шрифты GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Преобразовать в PS level 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Преобразовать в PS level 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Без предварительной фильтрации"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Производитель"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Нет активных заданий"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5927,115 +3124,6 @@ msgid_plural "%u Jobs"
 msgstr[0] "%u задание"
 msgstr[1] "%u задания"
 msgstr[2] "%u заданий"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Очистка печатающих головок принтера"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Мало тонера"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Тонер закончился"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Мало проявителя"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Проявитель закончился"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Маркер скоро закончится"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Маркер закончился"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Открыта крышка"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Открыта дверца"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Мало бумаги"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Бумага закончилась"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Выключен"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Остановлен"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Резервуар почти полон"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Резервуар заполнен"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Фотобарабан скоро выйдет из строя"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Фотобарабан перестал работать"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Готов"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Не принимает задания"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Обработка"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6059,6 +3147,10 @@ msgstr "Очистить печатающие головки"
 msgid "Remove Printer"
 msgstr "Удалить принтер"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Нет активных заданий"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6079,16 +3171,21 @@ msgid "Restart"
 msgstr "Перезапустить"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Добавить принтер…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Добавить принтер…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Принтеров нет"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6096,7 +3193,6 @@ msgstr ""
 "Сожалеем! Системная служба печати\n"
 "    похоже, недоступна."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Форматы"
@@ -6124,16 +3220,6 @@ msgstr "Возможен поиск стран и языков."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Предпросмотр"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Имперская"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Метрическая"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6171,20 +3257,24 @@ msgstr ""
 "Настройка языка используется для текста интерфейса и веб-страниц. Форматы "
 "используются для чисел, дат и валют."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Ваша учётная запись"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Язык"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Форматы"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Экран входа"
 
@@ -6196,99 +3286,9 @@ msgstr "Регион и язык"
 msgid "Select your display language and formats"
 msgstr "Выбор языка интерфейса и форматов"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Язык;Раскладка;Клавиатура;Ввод;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Спрашивать, что делать"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Ничего не делать"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Открыть папку"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Другой носитель"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Выберите приложение для звуковых компакт-дисков"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Выберите приложения для видео DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Выберите приложение, запускаемое при подключении музыкального плеера"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Выберите приложение, запускаемое при подключении камеры"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Выберите приложение для компакт-дисков с программами"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "звуковой DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "чистый диск Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "чистый компакт-диск"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "чистый диск DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "чистый диск HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Видеодиск Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "устройство чтения электронных книг"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Видеодиск HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Диск Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Компакт-диск Super Video"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Видеодиск VCD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Приложение Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6339,7 +3339,6 @@ msgstr "Съёмный носитель"
 msgid "Configure Removable Media settings"
 msgstr "Настроить съёмный носитель"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6347,130 +3346,6 @@ msgid ""
 msgstr ""
 "устройство;система;по умолчанию;приложение;предпочтительный;cd;dvd;usb;аудио;"
 "видео;диск;съёмный;съемный;носитель;автозапуск;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Выключение экрана"
-
-# Блокировать экран после:
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 секунд"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 минута"
-
-# Блокировать экран после:
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 минуты"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 минуты"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 минут"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 минут"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 час"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 минута"
-
-# Блокировать экран после:
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 минуты"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 минуты"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 минуты"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 минут"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 минут"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 минут"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 минут"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 минут"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Никогда"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6508,11 +3383,16 @@ msgstr "Задержка автоматической блокировки по�
 msgid "Show _Notifications on Lock Screen"
 msgstr "Показывать _уведомления на экране блокировки"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Уведомления на экране _блокировки"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Запрещать новые USB _устройств"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6520,30 +3400,25 @@ msgstr ""
 "Предотвращать взаимодействие новых USB устройств с системой когда экран "
 "заблокирован."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Конфиденциальность экрана"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Ограничение угла обзора"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Экран"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Настройки экрана"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "экран;блокировка;частное;конфиденциальность;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Выберите расположение"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6574,10 +3449,6 @@ msgstr "Прочие"
 msgid "Add Location"
 msgstr "Добавить расположение"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Приложения не найдены"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Поиск приложения"
@@ -6603,93 +3474,13 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "Какие приложения показывают результаты поиска в режиме «Обзор»"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Поиск;Найти;Индекс;Скрыть;Конфиденциальность;Результаты;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Не выбрано ни одной сети для обеспечения общего доступа"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Сети"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Включено"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Выключено"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Включено"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Запущено"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Выберите папку"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Добавить"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Включить общий доступ к медиа"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Общий доступ к файлам позволяет открыть доступ к вашим папкам другим "
-"пользователям сети с помощью: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"При включённом удалённом входе, удалённые пользователи могут подключаться "
-"используя команду Secure Shell:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Включить общий доступ к личным медиа"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Имя устройства скопировано"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Адрес устройства скопирован"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Имя пользователя скопировано"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Пароль скопирован"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6823,13 +3614,12 @@ msgstr "Папки"
 msgid "Control what you want to share with others"
 msgstr "Общий доступ для других пользователей"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
 "movies;server;renderer;"
 msgstr ""
-"общий;доступ;ssh;узел;имя;удалённый;рабочий;стол;медиа;аудио;видео;"
+"общий;доступ;ssh;хост;имя;удалённый;рабочий;стол;медиа;аудио;видео;"
 "изображения;фото;фильмы;сервер;обработчик;"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
@@ -6841,10 +3631,6 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Для включения или выключения удалённого доступа необходимо выполнить "
 "проверку подлинности"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Другой"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6877,11 +3663,6 @@ msgstr "Задний"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Передний"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Проверка %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6935,11 +3716,6 @@ msgstr "Громкость"
 msgid "Alert Sound"
 msgstr "Звук уведомления"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Отключить звук"
@@ -6952,83 +3728,12 @@ msgstr "Звук"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Изменение громкости звука входов, выходов и уведомлений"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Карта;Микрофон;Громкость;Затухание;Баланс;Bluetooth;Наушники;Аудио;Вход;"
 "Выход;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Отключено"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Подключение"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Подключено"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Ошибка авторизации"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Авторизация"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Сокращённая функциональность"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Подключено и авторизовано"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Неизвестно"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Авторизовано в:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Подключено в:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Зарегистрировано в:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Не удалось авторизовать устройство: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Не удалось забыть устройство: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7063,56 +3768,6 @@ msgstr "Подключить и авторизовать"
 msgid "Forget Device"
 msgstr "Забыть устройство"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Ошибка"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Авторизовано"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Подсистема Thunderbolt (boltd) не установлена или настроена неправильно."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Разрешить прямой доступ к таким устройствам, как док-станции и внешние "
-"графические процессоры."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Возможно подключение только устройств USB и Display Port."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Не удалось обнаружить Thunderbolt.\n"
-"Либо в системе отсутствует поддержка Thunderbolt, отключено в BIOS, либо "
-"установлено на неподдерживаемый уровень безопасности в BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Поддержка Thunderbolt отключена в BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Уровень безопасности Thunderbolt не может быть определен."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Ошибка переключения в режим прямого доступа: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Нет поддержки Thunderbolt"
@@ -7124,6 +3779,12 @@ msgstr "Не удалось подключиться к подсистеме thu
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Прямой доступ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Разрешить прямой доступ к таким устройствам, как док-станции и внешние "
+"графические процессоры."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7141,7 +3802,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Управление устройствами Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;приватность;"
@@ -7343,44 +4003,9 @@ msgstr "_Управляется клавиатурой"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Включать и выключать специальные возможности с помощью клавиатуры"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "По умолчанию"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Средний"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Увеличенный"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Большой"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Огромный"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d пиксель"
-msgstr[1] "%d пикселя"
-msgstr[2] "%d пикселей"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
-msgstr "_Всегда показывать меню универсального доступа"
+msgstr "_Всегда показывать меню специальных возможностей"
 
 #: panels/universal-access/cc-ua-panel.ui:31
 msgid "Seeing"
@@ -7493,31 +4118,6 @@ msgstr "Мигать всем _экраном"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Мигать всем _окном"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Короткая"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ экрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ экрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ экрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Длинная"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7676,7 +4276,6 @@ msgstr ""
 "Упрощение ввода, наведения и нажатия, а также улучшение видимости и "
 "слышимости"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7688,117 +4287,6 @@ msgstr ""
 "Чтение;текст;шрифт;размер;AccessX;Залипающие;клавиши;Медленные;Отскакивающие;"
 "Мышь;Двойное;нажатие;Задержка;скорость;Помощь;Повтор;Мигающий;визуальный;"
 "слышимость;слух;аудио;набор;печать;анимации;"
-
-# Выключать экран при простое после:
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 час"
-
-# Очищать корзину через / сохранять историю:
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 день"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 дня"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 дня"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 дня"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 дней"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 дней"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 дней"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 дней"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 дней"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Удалить все объекты из корзины?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Все объекты корзины будут безвозвратно удалены."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Очистить корзину"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Удалить все временные файлы?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Все временные файлы будут безвозвратно удалены."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Удалить временные файлы"
-
-# Очищать корзину через / сохранять историю:
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 день"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 дней"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 дней"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Неограниченно"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7867,64 +4355,12 @@ msgstr "История файлов и корзина"
 msgid "Don't leave traces"
 msgstr "Не оставлять следов"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "использование;недавние;история;файлы;временные;tmp;частные;"
 "конфиденциальность;мусор;очистить;сохранить;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Должно совпадать с веб-адресом провайдера вашей учётной записи."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Не удалось добавить учётную запись"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Пароли не совпадают."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Не удалось зарегистрировать учётную запись"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Нет поддерживаемого метода аутентификации в этом домене"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Не удалось подключить к домену"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Неправильное имя пользователя.\n"
-"Попробуйте ещё раз."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Неправильный пароль.\n"
-"Попробуйте ещё раз."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Не удалось войти в домен"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Не удалось найти домен. Может быть, он написан с ошибкой?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7979,10 +4415,6 @@ msgstr ""
 "централизованно учётную запись пользователя на этом устройстве. Также можно "
 "использовать данную учётную запись для доступа к ресурсам компании в "
 "интернете."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Найти дополнительные изображения"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8052,222 +4484,6 @@ msgstr "_Удалить отпечатки"
 msgid "Fingerprint Enroll"
 msgstr "Ввод по отпечатка"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "устройство должно быть зарезервирована для этого действия"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "устройство уже зарезервировано другим процессом"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "у вас нет доступа, чтобы выполнить это действие"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "нет сканированных отпечатков"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Не удалось связаться с устройством для сканирования"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Не удалось связаться с устройством сканирования отпечатков"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Не удалось связаться с сервисом отпечатков"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Не удалось перечислить отпечатки: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Не удалось удалить сохранённые отпечатки: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Левый большой палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Левый средний палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Левый указательный палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Левый безымянный палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Левый мизинец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Правый большой палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Правый средний палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Правый указательный палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Правый безымянный палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Правый мизинец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Неизвестный палец"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Выполнено"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Устройство чтения отпечатков отключено"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Память устройства чтения отпечатков заполнена"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Не удалось добавить новый отпечаток"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Не удалось начать сканирование: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Не удалось добавить новый отпечаток"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Не удалось прекратить сканирование: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Поднимайте и прикладывайте ваш палец к устройству чтения несколько раз для "
-"добавления"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Сканируйте этот палец ещё раз…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Отсканировать новый отпечаток"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Не удалось освободить устройство чтения %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Проблема с чтением с устройства"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Не удалось зарезервировать устройство чтения %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Не удалось получить устройство чтения: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "На этой неделе"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "На прошлой неделе"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%-d %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%-d %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Сеанс завершён"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Сеанс начат"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — активность учётной записи"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Предыдущее"
@@ -8275,18 +4491,6 @@ msgstr "Предыдущее"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Следующее"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Выберите другой пароль."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Введите пароль ещё раз."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Не удалось изменить пароль"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8308,6 +4512,10 @@ msgstr "Новый пароль"
 msgid "Confirm Password"
 msgstr "Подтвердите пароль"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Пароли не совпадают."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Разрешить пользователю изменить пароль при следующем входе в систему"
@@ -8315,134 +4523,6 @@ msgstr "Разрешить пользователю изменить парол�
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Установите пароль сейчас"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Не удалось автоматически присоединиться к этому типу домена"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Домен или realm не найден"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Не удалось войти как %s в домене %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Неправильный пароль, попробуйте ещё раз"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Не удалось подключиться к домену %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Не удалось удалить пользователя"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Не удалось аннулировать удалённого пользователя"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Нельзя удалить собственную учётную запись."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s всё ещё находится в системе"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Удаление пользователя, с незавершённым сеансом, может привести систему в "
-"противоречивое состояние."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Хотите сохранить файлы пользователя %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Можно сохранить домашнюю папку, почтовый ящик и временные файлы при удалении "
-"учётной записи пользователя."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Удалить файлы"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Сохранить файлы"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Действительно аннулировать удалённую учётную запись %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Удалить"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Учётная запись отключена"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Установить при следующем входе в систему"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Нет"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Авторизованная"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Не удалось связаться со службой учётных записей"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Убедитесь, что AccountService установлен и включён."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Для изменения этой настройки панель должна быть разблокирована"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Удалить выбранную учётную запись пользователя"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Чтобы удалить выбранную учётную запись пользователя,\n"
-"сначала нажмите на значок *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Разблокировать для добавления пользователей и изменения настроек"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8470,7 +4550,6 @@ msgid "Full name"
 msgstr "Полное имя"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Редактировать"
 
@@ -8532,7 +4611,6 @@ msgstr "Разблокируйте для добавления учётной з
 msgid "Add or remove users and change your password"
 msgstr "Добавить или удалить пользователей или изменить пароль"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8575,180 +4653,6 @@ msgstr "Управление учётными записями"
 msgid "Authentication is required to change user data"
 msgstr "Для изменения данных пользователя требуется аутентификация"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Новый пароль должен отличаться от старого."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Попробуйте изменить некоторые буквы и цифры."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Попробуйте изменить пароль немного больше."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Пароль не содержащий имя пользователя будет надёжнее."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Старайтесь избегать использования вашего имени в пароле."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Старайтесь избегать слов из которых состоит пароль."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Старайтесь избегать общих слов."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Старайтесь избегать перестановки существующих слов."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Попробуйте использовать больше чисел."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Попробуйте использовать больше заглавных букв."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Попробуйте использовать больше строчных букв."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-"Попробуйте использовать больше специальных символов, например знаки "
-"препинания."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Попробуйте использовать вперемешку буквы, цифры и знаки препинания."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Старайтесь избегать повторения одного и того же символа."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Старайтесь избегать повторения одного и того же символа: используйте "
-"вперемешку буквы, цифры и знаки препинания."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Старайтесь избегать последовательностей, например 1234 или abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Пароль должен быть длиннее. Попробуйте добавить больше букв, цифр и знаков "
-"препинания."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Смешайте заглавные и строчные буквы несколько раз."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Добавление большего количества букв, цифр и знаков препинания сделает пароль "
-"надёжнее."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Сбой аутентификации"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Новый пароль слишком короткий"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Новый пароль слишком прост"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Старый и новый пароли слишком похожи"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Новый пароль уже недавно использовался."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Новый пароль должен содержать цифровые или специальные символы"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Новый пароль совпадает со старым"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Ваш пароль изменился с момента последней аутентификации!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "В новом пароле недостаточно различных символов"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Неизвестная ошибка"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Имя пользователя может состоять только из букв латинского алфавита в верхнем "
-"и нижнем регистре, цифр и следующих символов: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Данное имя пользователя недоступно. Попробуйте ввести другое."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Имя пользователя слишком длинное."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8783,52 +4687,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Обнаружено ложное нажатие, выполняется перезапуск…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Кнопка %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Приложение определено"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Событие нажатие клавиши"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Переключение монитора"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Показывать справку на экране"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Планшет, подключенный к панели ноутбука"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Планшет, подключенный к внешнему дисплею"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Внешнее планшетное устройство"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Внешнее накладное устройство"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Все дисплеи"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8928,23 +4790,6 @@ msgstr "Щелчок правой кнопкой мыши"
 msgid "Forward"
 msgstr "Дальше"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
-"Стилус для аэрографа с функцией нажатия, наклона и встроенным слайдером"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Стилус для аэрографа с функцией нажатия, наклона и вращения"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Стандартный стилус с функцией нажатия и наклона"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Стандартный стилус с функцией нажатия"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Планшет Wacom"
@@ -8955,54 +4800,96 @@ msgstr ""
 "Установка отображения кнопок и настройка чувствительности пера для "
 "графических планшетов"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Планшет;Wacom;Перо;Ластик;Мышь;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Новая комбинация…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Симуляция вторичного нажатия"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Приложение Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Мало тонера"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Задержка вторичного нажатия"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Приложение Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Управляйте предпочтениями продуктивности и многозадачности"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Точки доступа"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Добавить"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Сохранить"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Операция отменена"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Ошибка:</b> Доступ запрещён для смены настроек"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Ошибка:</b> Ошибка мобильного оборудования"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Не зарегистрирован"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Зарегистрирован"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Роуминг"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Поиск"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Отклонено"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9032,212 +4919,13 @@ msgstr "Собственный номер"
 msgid "Device Details"
 msgstr "Сведения об устройстве"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Производитель"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Версия прошивки"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Только 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Только 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Только 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Только 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (Предпочтительно), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (Предпочтительно), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (Предпочтительно), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Предпочтительно), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Предпочтительно), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (Предпочтительно), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (Предпочтительно), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (Предпочтительно), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (Предпочтительно), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (Предпочтительно), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (Предпочтительно), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (Предпочтительно), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (Предпочтительно), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (Предпочтительно), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (Предпочтительно), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (Предпочтительно), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (Предпочтительно)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (Предпочтительно), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Неизвестно"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Разблокирование SIM-карты"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Разблокировать"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Пожалуйста, введите PIN код для SIM карты %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Введите PIN, чтобы разблокировать вашу SIM карту"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Пожалуйста, предоставьте код PUK для SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Введите PUK код, чтобы разблокировать вашу SIM карту"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9254,26 +4942,6 @@ msgid_plural "You have %u tries left"
 msgstr[0] "У вас осталось %u попытка"
 msgstr[1] "У вас осталось %u попытки"
 msgstr[2] "У вас осталось %u попыток"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Введён неверный код."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Код PUK должен состоять из 8 цифр"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Введите новый PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Код PIN должен состоять из от 4 до 8 цифр"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Разблокировка…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9331,94 +4999,6 @@ msgstr "Заблокировать SIM карту PIN кодом"
 msgid "M_odem Details"
 msgstr "Подробности о _модеме"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Сбой телефона"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Телефон не подключён"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Операция не разрешена"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Операция не поддерживается"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Не вставлена SIM-карта"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Требуется SIM пин-код"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Требуется SIM PUK-код"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Отказ SIM-карты"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM-карта занята"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Неверный код"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Требуется SIM PIN2-код"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Требуется SIM PUK2-код"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Не найден"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Сетевой сервис отсутствует"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Тайм-аут сети"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Службы GPRS не разрешены"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Роуминг не разрешён в этом местоположении"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Неуказанная ошибка GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Ошибок нет"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Действие отменено"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Доступ запрещён"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Неизвестная ошибка"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Режим сети"
@@ -9434,11 +5014,6 @@ msgstr "Выберите сеть"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Обновить список провайдеров"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9496,7 +5071,6 @@ msgstr "Мобильная сеть"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Настроить телефонию и соединения для мобильных данных"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "сотовый;мобильник;мобильный;мобильная;wwan;телефония;телефон;sim;сим;"
@@ -9513,41 +5087,13 @@ msgstr "Настройки — основной интерфейс для нас
 msgid "The GNOME Project"
 msgstr "The GNOME Project"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Показать номер версии"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Включить информативный режим"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Поиск строки"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Вывести список возможных имён панелей и выйти"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Область для отображения"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[ПАНЕЛЬ] [АРГУМЕНТ…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Категории настроек"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Конфиденциальность"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Доступные панели:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9605,7 +5151,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Отменить поиск"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Настройки;Параметры;"
@@ -9646,8 +5191,6 @@ msgstr ""
 "Запись, содержащая начальную ширину, высоту и развернутое состояние окна "
 "приложения."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9656,8 +5199,6 @@ msgstr[0] "%u выход"
 msgstr[1] "%u выхода"
 msgstr[2] "%u выходов"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9666,18 +5207,3198 @@ msgstr[0] "%u вход"
 msgstr[1] "%u входа"
 msgstr[2] "%u входов"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Системные звуки"
+#~ msgid "System Bus"
+#~ msgstr "Системная шина"
+
+#~ msgid "Full access"
+#~ msgstr "Полный доступ"
+
+#~ msgid "Session Bus"
+#~ msgstr "Шина сеанса"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Полный доступ к /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Имеет доступ к сети"
+
+#~ msgid "Home"
+#~ msgstr "Домашняя папка"
+
+#~ msgid "Read-only"
+#~ msgstr "Только для чтения"
+
+#~ msgid "File System"
+#~ msgstr "Файловая система"
+
+#~ msgid "Can change settings"
+#~ msgstr "Может изменять настройки"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s имеет следующие встроенные разрешения. Они не могут быть изменены. "
+#~ "Если вас беспокоят эти разрешения, рассмотрите возможность удаления этого "
+#~ "приложения."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u тип файла и ссылки, которые открываются приложением"
+#~ msgstr[1] "%u типа файлов и ссылок, которые открываются приложением"
+#~ msgstr[2] "%u типов файлов и ссылок, которые открываются приложением"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> используется для открытия следующих типов файлов и ссылок."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s дискового пространства использовано."
+
+#~ msgid "Select a picture"
+#~ msgstr "Выберите изображение"
+
+#~ msgid "_Open"
+#~ msgstr "_Открыть"
+
+#~ msgid "multiple sizes"
+#~ msgstr "множество размеров"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Без фона рабочего стола"
+
+#~ msgid "Current background"
+#~ msgstr "Текущий фон"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Поместите устройство калибровки на квадрат и нажмите «Запустить»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Наведите устройство калибровки на место калибровки и нажмите «Продолжить»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Переместите устройство калибровки на поверхность и нажмите «Продолжить»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Закройте крышку ноутбука"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Произошла внутренняя ошибка, которая не может быть исправлена."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Необходимые для калибровки инструменты не установлены."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Ошибка при создании профиля."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Целевая точка белого не получена."
+
+#~ msgid "Complete!"
+#~ msgstr "Выполнено!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Сбой калибровки!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Можно убрать устройство калибровки."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Не трогайте устройство калибровки в процессе выполнения"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Экран ноутбука"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Встроенная веб-камера"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Монитор %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Сканер %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Камера %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Принтер %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Веб-камера %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Включить управление цветом для %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Показать цветовые профили для %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Неоткалиброванный"
+
+#~ msgid "Default: "
+#~ msgstr "По умолчанию: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Цветовое пространство: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Тестовый профиль: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Выберите файл профиля ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Импортировать"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Поддерживаемые профили ICC"
+
+#~ msgid "All files"
+#~ msgstr "Все файлы"
+
+#~ msgid "Save Profile"
+#~ msgstr "Сохранить профиль"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Создать цветовой профиль для выбранного устройства"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Измерительный инструмент не обнаружен. Проверьте, что он включён и "
+#~ "правильно подключён."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Измерительный инструмент не поддерживает профилирование принтеров."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Этот тип устройств ещё не поддерживается."
+
+#~ msgid "Standard Space"
+#~ msgstr "Стандартное цветовое пространство"
+
+#~ msgid "Test Profile"
+#~ msgstr "Тестовый профиль"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Автоматический"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Низкое качество"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Среднее качество"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Высокое качество"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB по умолчанию"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK по умолчанию"
+
+# Цветовое пространство
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Серое по умолчанию"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Предоставленные производителем данные заводской калибровки"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Полноэкранный режим коррекции не возможен с этим профилем"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Возможно этот профиль уже неточный"
+
+#~ msgid "Other…"
+#~ msgstr "Другой…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Разблокировать для изменения настроек"
+
+#~ msgid "Today"
+#~ msgstr "Сегодня"
+
+#~ msgid "Yesterday"
+#~ msgstr "Вчера"
+
+#~ msgid "%b %e"
+#~ msgstr "%-d %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-d %b %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d час"
+#~ msgstr[1] "%d часа"
+#~ msgstr[2] "%d часов"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d минута"
+#~ msgstr[1] "%d минуты"
+#~ msgstr[2] "%d минут"
+
+# Блокировать экран после:
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d секунда"
+#~ msgstr[1] "%d секунды"
+#~ msgstr[2] "%d секунд"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Точка доступа"
+
+#~ msgid "24-hour"
+#~ msgstr "24-часовой"
+
+#~ msgid "AM / PM"
+#~ msgstr "12-часовой"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%-d %B %Y, %l∶%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%-d %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l∶%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Отправка сообщения о технических проблемах помогает нам улучшить %s. "
+#~ "Отчеты отправляются анонимно и не содержат персональных данных. %s"
+
+#~ msgid "On"
+#~ msgstr "Включено"
+
+#~ msgid "Off"
+#~ msgstr "Выключено"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Применить изменения?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Изменения не могут быть применены"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Это может быть связано с аппаратными ограничениями."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Ландшафтная"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Портретная справа"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Портретная слева"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Ландшафтная (перевернутая)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Гц"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Безопасная загрузка активна"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Безопасная загрузка предотвращает загрузку вредоносного программного "
+#~ "обеспечения при запуске устройства. В настоящее время она включена и "
+#~ "функционирует правильно."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Проблемы с безопасной загрузкой"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Безопасная загрузка предотвращает загрузку вредоносного программного "
+#~ "обеспечения при запуске устройства. В настоящее время она включена, но не "
+#~ "будет работать из-за наличия недействительного ключа."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Проблемы с безопасной загрузкой часто можно решить из настроек прошивки "
+#~ "UEFI (BIOS) вашего компьютера, и производитель оборудования может "
+#~ "предоставить информацию о том, как это сделать."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "За помощью обратитесь к производителю оборудования или поставщику ИТ-"
+#~ "поддержки."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Безопасная загрузка отключена"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Безопасная загрузка предотвращает загрузку вредоносного программного "
+#~ "обеспечения при запуске устройства. В настоящее время она отключена."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Безопасную загрузку обычно можно включить в настройках прошивки UEFI "
+#~ "(BIOS) компьютера. За помощью обратитесь к производителю оборудования или "
+#~ "поставщику ИТ-поддержки."
+
+#~ msgid "Passed"
+#~ msgstr "Пройдено"
+
+#~ msgid "Failed"
+#~ msgstr "Неудачно"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Устройство соответствует %d уровню HSI"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Уровень безопасности 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Это устройство не имеет защиты от аппаратных проблем безопасности. Это "
+#~ "может быть связано с проблемой конфигурации оборудования или прошивки. "
+#~ "Рекомендуется обратиться к поставщику услуг ИТ-поддержки."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Уровень безопасности 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Это устройство имеет минимальную защиту от аппаратных проблем "
+#~ "безопасности. Это самый низкий уровень безопасности устройства, "
+#~ "обеспечивающий защиту только от простых угроз безопасности."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Уровень безопасности 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Это устройство имеет базовую защиту от аппаратных проблем безопасности. "
+#~ "Это обеспечивает защиту от некоторых распространенных угроз безопасности."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Уровень безопасности 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Это устройство имеет расширенную защиту от аппаратных проблем "
+#~ "безопасности. Это самый высокий уровень безопасности устройства, "
+#~ "обеспечивающий защиту от современных угроз безопасности."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Уровни безопасности для этого устройства недоступны."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Обратитесь к производителю оборудования за помощью в обновлении системы "
+#~ "безопасности."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Возможно, эту проблему можно решить в настройках прошивки UEFI устройства "
+#~ "или с помощью специалиста службы поддержки."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Возможно, эту проблему можно решить в настройках прошивки UEFI устройства."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Возможно, специалист службы поддержки сможет решить эту проблему."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Обеспечена защита от вредоносных программ при запуске устройства."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Проблемы с безопасной загрузкой"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Некоторая защита при запуске устройства."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Безопасная загрузка отключена"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Без защиты при запуске устройства."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Эта проблема могла быть вызвана изменением настроек прошивки UEFI, "
+#~ "изменением конфигурации операционной системы или наличием вредоносного "
+#~ "программного обеспечения в этой системе."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Эта проблема могла быть вызвана изменением настроек прошивки UEFI или "
+#~ "наличием вредоносного программного обеспечения в данной системе."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Эта проблема могла быть вызвана изменением конфигурации операционной "
+#~ "системы или наличием вредоносного программного обеспечения в этой системе."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Подвержен серьезным угрозам безопасности."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Ограниченная защита от простых угроз безопасности."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Обеспечена защита от распространенных угроз безопасности."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Обеспечена защита от широкого спектра угроз безопасности."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Комплексная защита"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Защита от записи прошивки"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Блокировка защиты от записи прошивки"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Регион прошивки BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Дескриптор прошивки BIOS"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Предзагрузочная защита DMA"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Проверенная загрузка Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Защищенный ACM Intel BootGuard"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Политика ошибок Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Предохранитель Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET включена"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET активна"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Зашифрованное ОЗУ"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Защита IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Блокировка ядра Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Проверка ядра Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Подкачка Linux"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Режим сна"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Режим ожидания"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Ключ платформы UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Безопасная загрузка UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Конфигурация платформы TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Реконструкция TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Производственный режим Intel Management Engine"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Переопределение Intel Management Engine"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Версия Intel Management Engine"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Обновления прошивки"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Аттестация прошивки"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Подтверждение программы обновления прошивки"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Отладка платформы"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Проверка безопасности процессора"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Защита от отката прошивки AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Защита от повтора прошивки AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Защита от записи прошивки AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Объединенная платформа"
+
+#~ msgid "Valid"
+#~ msgstr "Действительно"
+
+#~ msgid "Not Valid"
+#~ msgstr "Недействительно"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Не включено"
+
+#~ msgid "Locked"
+#~ msgstr "Заблокировано"
+
+#~ msgid "Not Locked"
+#~ msgstr "Не заблокировано"
+
+#~ msgid "Encrypted"
+#~ msgstr "Зашифровано"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Не зашифровано"
+
+#~ msgid "Tainted"
+#~ msgstr "Испорчено"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Не испорчено"
+
+#~ msgid "Found"
+#~ msgstr "Найдено"
+
+#~ msgid "Not Found"
+#~ msgstr "Не найдено"
+
+#~ msgid "Supported"
+#~ msgstr "Поддерживается"
+
+#~ msgid "Not Supported"
+#~ msgstr "Не поддерживается"
+
+#~ msgid "Unknown"
+#~ msgstr "Неизвестно"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-бит"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-бит"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Неизвестно"
+
+#~ msgid "Not Available"
+#~ msgstr "Недоступно"
+
+#~ msgid "System Logo"
+#~ msgstr "Логотип системы"
+
+#~ msgid "No input sources found"
+#~ msgstr "Источники ввода не найдены"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Другое"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Дополнительные комбинации клавиш"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Клавиша альтернативных символов может использоваться для ввода "
+#~ "дополнительных символов. Они иногда изображены на кнопках клавиатуры как "
+#~ "третий вариант."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Левый Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Правый Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Левый Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Правый Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Кнопка меню"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Правый Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Клавиша compose позволяет вводить самые разнообразные символы. Чтобы "
+#~ "использовать это, нажмите клавишу compose, затем последовательность "
+#~ "символов.  Например, нажав клавишу compose, за которой следуют <b>C</b> и "
+#~ "<b>o</b>, получим <b>©</b>, клавиша compose и <b>a</b>, за которой "
+#~ "следует <b>'</b>, получим <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Переключить источники ввода можно сочетанием клавиш %s.\n"
+#~ "Эту комбинацию можно изменить в настройках сочетаний."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d изменена"
+#~ msgstr[1] "%d изменены"
+#~ msgstr[2] "%d изменено"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Сбросить все комбинации клавиш?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Сброс комбинаций клавиш может также повлиять на пользовательские "
+#~ "комбинации клавиш. Это действие нельзя отменить."
+
+#~ msgid "Reset All"
+#~ msgstr "Сбросить все"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s уже используется для %s. Если применить, комбинация для %s будет "
+#~ "отключена"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Введите новую комбинацию"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Установить пользовательскую комбинацию клавиш"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Установить комбинацию клавиш"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Введите новую комбинацию для изменения %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Добавить пользовательскую комбинацию клавиш"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Прокрутка двумя пальцами"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Сделайте пять щелчков мышью, чтобы открыть «пасхальное яйцо»!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Двойной щелчок, основная кнопка"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Один щелчок, основная кнопка"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Двойной щелчок, средняя кнопка"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Один щелчок, средняя кнопка"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Двойной щелчок, вторичная кнопка"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Один щелчок, вторичная кнопка"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager должен быть запущен."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Незащищённая сеть (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Защищённая сеть (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Защищённая сеть (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Защищённая сеть (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Защищённая сеть"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Включение точки доступа приведёт к отключению от %s, и доступ в интернет "
+#~ "через Wi-Fi будет невозможен ."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Должно содержать не менее 8 символов"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Остановить точку доступа и отключить всех пользователей?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Остановить точку доступа"
+
+#~ msgid "Preserve"
+#~ msgstr "Предустановленный"
+
+#~ msgid "Permanent"
+#~ msgstr "Постоянный"
+
+#~ msgid "Random"
+#~ msgstr "Случайный"
+
+#~ msgid "Stable"
+#~ msgstr "Стабильный"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Введенный здесь MAC-адрес будет использоваться в качестве аппаратного "
+#~ "адреса для сетевого устройства, на котором установлено это соединение. "
+#~ "Эта функция известна как клонирование или подмена MAC. Пример: 00: 11: "
+#~ "22: 33: 44: 55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Профиль %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+# Enhanced open provides improved data encryption in open Wi-Fi networks and protects data from sniffing. Enhanced open replaces open system as the default option. With enhanced open, the client and WLAN perform Diffie-Hellman key exchange during the access procedure and use the resulting pairwise key with a 4-way handshake.
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Предприятие"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Нет"
+
+#~ msgid "Never"
+#~ msgstr "Никогда"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Мб/с (%1.1f ГГц)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Мб/с"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 ГГц / 5 ГГц"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 ГГц"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 ГГц"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Нет"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Слабый"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Средний"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Хороший"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Отличный"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Забыть соединение"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Удалить профиль соединения"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Удалить VPN"
+
+#~ msgid "Details"
+#~ msgstr "Подробности"
+
+#~ msgid "automatic"
+#~ msgstr "автоматический"
+
+#~ msgid "Identity"
+#~ msgstr "Идентификация"
+
+#~ msgid "Delete Address"
+#~ msgstr "Удалить адрес"
+
+#~ msgid "Delete Route"
+#~ msgstr "Удалить маршрут"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Нет"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "40/128-битный ключ WEP (Hex или ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "128-битная парольная фраза WEP"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Динамический WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "Персональный WPA и WPA2"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Корпоративный WPA и WPA2"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "Персональный WPA3"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Не удалось открыть редактор соединений"
+
+#~ msgid "New Profile"
+#~ msgstr "Создать профиль"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Неверная настройка %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Неверная настройка %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Импортировать из файла…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Добавить VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Не удалось импортировать соединение VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Невозможно прочитать файл «%s» или файл не содержит корректную информацию "
+#~ "о VPN-соединении\n"
+#~ "\n"
+#~ "Ошибка: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Выберите файл для импортирования"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Файл с именем «%s» уже существует."
+
+#~ msgid "_Replace"
+#~ msgstr "_Заменить"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Заменить %s сохраняемым VPN-соединением?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Не удалось экспортировать соединение VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Невозможно экспортировать VPN-соединение «%s» в %s.\n"
+#~ "\n"
+#~ "Ошибка: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Экспортировать VPN-соединение"
+
+#~ msgid "never"
+#~ msgstr "никогда"
+
+#~ msgid "today"
+#~ msgstr "сегодня"
+
+#~ msgid "yesterday"
+#~ msgstr "вчера"
+
+#~ msgid "Last used"
+#~ msgstr "Последнее использование"
+
+#~ msgid "Add new connection"
+#~ msgstr "Добавить новое подключение"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Сетевые данные для выделенных сетей, включая пароли и любые "
+#~ "пользовательские настройки, будут утеряны."
+
+#~ msgid "_Forget"
+#~ msgstr "_Забыть"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Известные сети Wi-Fi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Забыть"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr ""
+#~ "Использование в качестве точки доступа запрещено системной политикой"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Беспроводное устройство не поддерживает режим точки доступа"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Web Proxy Autodiscovery используется, когда URL конфигурации не "
+#~ "предоставлен."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr ""
+#~ "Не рекомендуется использовать для непроверенных общедоступных сетей."
+
+#~ msgid "Status unknown"
+#~ msgstr "Состояние неизвестно"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Неуправляемое"
+
+#~ msgid "Unavailable"
+#~ msgstr "Недоступно"
+
+#~ msgid "Connecting"
+#~ msgstr "Подключение"
+
+#~ msgid "Authentication required"
+#~ msgstr "Требуется аутентификация"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Отключение"
+
+#~ msgid "Connection failed"
+#~ msgstr "Сбой подключения"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Состояние неизвестно (отсутствует)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Сбой настройки"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Сбой настройки IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Истёк срок настроек IP"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Требуется пароль, но он не задан"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Клиент 802.1x отключён"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Сбой настройки клиента 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Сбой клиента 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Клиент 802.1x слишком долго ожидал аутентификации"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Не удалось запустить службу PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Служба PPP отключена"
+
+#~ msgid "PPP failed"
+#~ msgstr "Сбой PPP"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Не удалось запустить клиент DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Ошибка клиента DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Сбой клиента DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Не удалось запустить службу общего подключения"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Сбой службы общего подключения"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Не удалось запустить службу AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Ошибка службы AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Сбой службы AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "Линия занята"
+
+#~ msgid "No dial tone"
+#~ msgstr "Нет гудка в линии"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Невозможно установить несущую"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Время, отведённое на звонок, истекло"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Не удалось дозвониться"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Не удалось инициализировать модем"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Не удалось выбрать указанный APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Нет сетей для поиска"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Отказано в регистрации в сети"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Время в регистрации сети истекло"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Не удалось зарегистрироваться в запрошенной сети"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Сбой проверки PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Возможно, отсутствует микропрограмма устройства"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Подключение пропало"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Предполагалось, что соединение существует"
+
+#~ msgid "Modem not found"
+#~ msgstr "Модем не найден"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Сбой подключения по Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Не вставлена SIM-карта"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Требуется SIM Pin"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Требуется SIM Puk"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Некорректный SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Сбой зависимости подключения"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Отсутствует прошивка"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Кабель не подключён"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "неизвестная ошибка в безопасности 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "файлы не выбраны"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "неизвестная ошибка проверки файла ЕАР-методом"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 или приватные ключи PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Сертификаты DER или PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "отсутствует файл EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Файлы PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "отсутствует имя пользователя EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "отсутствует пароль EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "недействительный сертификат EAP-PEAP CA: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "недействительный сертификат EAP-PEAP CA: сертификат не указан"
+
+#~ msgid "missing EAP username"
+#~ msgstr "отсутствует имя пользователя EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "отсутствует пароль EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "отсутствует идентичность EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "недействительный сертификат EAP-TLS CA: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "недействительный сертификат EAP-TLS CA: сертификат не указан"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "недействительный секретный ключ EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "недействительный пользовательский сертификат EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Незашифрованные закрытые ключи являются небезопасными"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Возможно, выбранный приватный ключ не защищён паролем. Это может привести "
+#~ "к компрометированию ваших учётных данных. Выберите приватный ключ, "
+#~ "защищённый паролем.\n"
+#~ "\n"
+#~ "(Вы можете защитить приватный ключ с помощью openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Выберите свой персональный сертификат"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Выберите ваш приватный ключ"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "недействительный сертификат EAP-TTLS CA: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "недействительный сертификат EAP-TTLS CA: сертификат не указан"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Неизвестная ошибка проверки безопасности 802.1X"
+
+#~ msgid "Select a file"
+#~ msgstr "Выберите файл"
+
+#~ msgid "missing leap-username"
+#~ msgstr "отсутствует leap-имя пользователя"
+
+#~ msgid "missing leap-password"
+#~ msgstr "отсутствует leap-пароль"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Пароль Wi-Fi отсутствует."
+
+#~ msgid "missing wep-key"
+#~ msgstr "отсутствует wep-ключ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "недействительный wep-ключ: ключ с длиной %zu должен содержать только "
+#~ "шестнадцатеричные цифры"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "недействительный wep-ключ: ключ с длиной %zu должен содержать только "
+#~ "символы ASCII"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "недействительный wep-ключ: ключ с неверной длиной %zu. Ключ должен быть "
+#~ "длины 5/13 (ASCII) или 10/26 (HEX)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "недействительный wep-ключ: парольная фраза не может быть пустой"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "недействительный wep-ключ: парольная фраза должна быть короче 64 символов"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "недействительный wpa-psk: ключ неверной длины %zu. Должен быть [8,63] "
+#~ "байт или 64 шестнадцатеричных цифр"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "недействительный wpa-psk: невозможно интерпретировать ключ с 64 байт как "
+#~ "шестнадцатеричный"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Другое"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s удалён"
+
+#~ msgid "Error removing account"
+#~ msgstr "Ошибка при удалении учётной записи"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Учётная запись %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Удалить учётную запись"
+
+#~ msgid "Unknown time"
+#~ msgstr "Время неизвестно"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "Полностью зарядится через %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Внимание: разрядится через %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Разрядится через %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Полностью заряжена"
+
+#~ msgid "Not charging"
+#~ msgstr "Не заряжается"
+
+#~ msgid "Empty"
+#~ msgstr "Разряжена"
+
+#~ msgid "Charging"
+#~ msgstr "Зарядка"
+
+#~ msgid "Discharging"
+#~ msgstr "Разрядка"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Беспроводная мышь"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Беспроводная клавиатура"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Источник бесперебойного питания"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "КПК"
+
+#~ msgid "Cellphone"
+#~ msgstr "Мобильный телефон"
+
+#~ msgid "Media player"
+#~ msgstr "Медиапроигрыватель"
+
+#~ msgid "Tablet"
+#~ msgstr "Планшет"
+
+#~ msgid "Computer"
+#~ msgstr "Компьютер"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Игровое устройство ввода"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Основная"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Дополнительная"
+
+#~ msgid "Batteries"
+#~ msgstr "Батареи"
+
+#~ msgid "When _idle"
+#~ msgstr "При п_ростое"
+
+#~ msgid "Suspend"
+#~ msgstr "Режим ожидания"
+
+#~ msgid "Power Off"
+#~ msgstr "Выключить"
+
+#~ msgid "Hibernate"
+#~ msgstr "Режим гибернации"
+
+#~ msgid "Nothing"
+#~ msgstr "Ничего не делать"
+
+#~ msgid "When on battery power"
+#~ msgstr "При работе от батареи"
+
+#~ msgid "When plugged in"
+#~ msgstr "При подключении к сети"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Никогда"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Автоматический режим ожидания"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Режим высокой производительности временно запрещён из-за высокой "
+#~ "температуры устройства."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Режим высокой производительности временно запрещён из-за обнаруженной "
+#~ "работы на коленях. Переместите устройство на ровную поверхность для "
+#~ "возобновления режима."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Режим высокой производительности запрещён."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Низкий заряд батареи: включён режим низкого потребления. Предыдущий режим "
+#~ "будет автоматически включён когда батарея будет заряжена."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Режим низкого потребления активирован «%s»."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Режим высокой производительности активирован «%s»."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Производительный"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Высокая производительность и энергопотребление."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Сбалансированный"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Стандартная производительность и энергопотребление."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Энергосберегающий"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Уменьшенная производительность и энергопотребление."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Принтер «%s» удалён"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Не удалось добавить новый принтер."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Не удалось загрузить интерфейс пользователя: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Разблокировать для добавления принтеров и изменения настроек"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Подробности %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Подходящий драйвер не найден"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Выберите файл PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Файлы PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Принтер JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Принтер LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Односторонняя печать"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "По длинной стороне (стандарт)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "По короткой стороне (переворот)"
+
+#~ msgid "Portrait"
+#~ msgstr "Портретная"
+
+#~ msgid "Landscape"
+#~ msgstr "Ландшафтная"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Перевёрнутая ландшафтная"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Перевёрнутая портретная"
+
+#~ msgid "Resume"
+#~ msgstr "Продолжить"
+
+#~ msgid "Pause"
+#~ msgstr "Приостановить"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Ожидание"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Приостановлено"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Требуется аутентификация"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Выполняется"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Остановлено"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Отменено"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Прервано"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Выполнено"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Переместить это задание в начало очереди"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "Текущие задания — %s"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Введите учётные данные для печати из %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Разблокировать сервер печати"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Разблокировать %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Введите имя пользователя и пароль для просмотра принтеров на %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Поиск принтеров"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Последовательный порт"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Параллельный порт"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Расположение: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Адрес: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Сервер требует аутентификацию"
+
+#~ msgid "Two Sided"
+#~ msgstr "Двусторонняя печать"
+
+#~ msgid "Paper Type"
+#~ msgstr "Тип бумаги"
+
+#~ msgid "Paper Source"
+#~ msgstr "Источники бумаги"
+
+#~ msgid "Output Tray"
+#~ msgstr "Приёмный лоток"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Разрешение"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Предварительная фильтрация GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Страниц на сторону"
+
+#~ msgid "Orientation"
+#~ msgstr "Ориентация"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Общие"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Настройка страницы"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Устанавливаемые параметры"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Задание"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Качество изображения"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Цвет"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Отделка"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Дополнительно"
+
+#~ msgid "Test page"
+#~ msgstr "Пробная страница"
+
+#~ msgid "Auto Select"
+#~ msgstr "Выбрать автоматически"
+
+#~ msgid "Printer Default"
+#~ msgstr "Параметры по умолчанию"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Встраивать только шрифты GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Преобразовать в PS level 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Преобразовать в PS level 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Без предварительной фильтрации"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Очистка печатающих головок принтера"
+
+#~ msgid "Out of toner"
+#~ msgstr "Тонер закончился"
+
+#~ msgid "Low on developer"
+#~ msgstr "Мало проявителя"
+
+#~ msgid "Out of developer"
+#~ msgstr "Проявитель закончился"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Маркер скоро закончится"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Маркер закончился"
+
+#~ msgid "Open cover"
+#~ msgstr "Открыта крышка"
+
+#~ msgid "Open door"
+#~ msgstr "Открыта дверца"
+
+#~ msgid "Low on paper"
+#~ msgstr "Мало бумаги"
+
+#~ msgid "Out of paper"
+#~ msgstr "Бумага закончилась"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Выключен"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Остановлен"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Резервуар почти полон"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Резервуар заполнен"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Фотобарабан скоро выйдет из строя"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Фотобарабан перестал работать"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Готов"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Не принимает задания"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Обработка"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Имперская"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Метрическая"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Спрашивать, что делать"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ничего не делать"
+
+#~ msgid "Open folder"
+#~ msgstr "Открыть папку"
+
+#~ msgid "Other Media"
+#~ msgstr "Другой носитель"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Выберите приложение для звуковых компакт-дисков"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Выберите приложения для видео DVD"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Выберите приложение, запускаемое при подключении музыкального плеера"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Выберите приложение, запускаемое при подключении камеры"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Выберите приложение для компакт-дисков с программами"
+
+#~ msgid "audio DVD"
+#~ msgstr "звуковой DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "чистый диск Blu-ray"
+
+#~ msgid "blank CD disc"
+#~ msgstr "чистый компакт-диск"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "чистый диск DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "чистый диск HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Видеодиск Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "устройство чтения электронных книг"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Видеодиск HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Диск Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Компакт-диск Super Video"
+
+#~ msgid "Video CD"
+#~ msgstr "Видеодиск VCD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Выключение экрана"
+
+# Блокировать экран после:
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 секунд"
+
+# Выключать экран при простое после:
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 минута"
+
+# Блокировать экран после:
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 минуты"
+
+# Выключать экран при простое после:
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 минуты"
+
+# Выключать экран при простое после:
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 минут"
+
+# Выключать экран при простое после:
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 минут"
+
+# Выключать экран при простое после:
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 час"
+
+# Выключать экран при простое после:
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 минута"
+
+# Блокировать экран после:
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 минуты"
+
+# Выключать экран при простое после:
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 минуты"
+
+# Выключать экран при простое после:
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 минуты"
+
+# Выключать экран при простое после:
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 минут"
+
+# Выключать экран при простое после:
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 минут"
+
+# Выключать экран при простое после:
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 минут"
+
+# Выключать экран при простое после:
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 минут"
+
+# Выключать экран при простое после:
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 минут"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Никогда"
+
+#~ msgid "Select Location"
+#~ msgstr "Выберите расположение"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Приложения не найдены"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Не выбрано ни одной сети для обеспечения общего доступа"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Включено"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Выключено"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Включено"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Запущено"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Выберите папку"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Включить общий доступ к медиа"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Общий доступ к файлам позволяет открыть доступ к вашим папкам другим "
+#~ "пользователям сети с помощью: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "При включённом удалённом входе, удалённые пользователи могут подключаться "
+#~ "используя команду Secure Shell:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Включить общий доступ к личным медиа"
+
+#~ msgid "Device name copied"
+#~ msgstr "Имя устройства скопировано"
+
+#~ msgid "Device address copied"
+#~ msgstr "Адрес устройства скопирован"
+
+#~ msgid "Username copied"
+#~ msgstr "Имя пользователя скопировано"
+
+#~ msgid "Password copied"
+#~ msgstr "Пароль скопирован"
+
+#~ msgid "Custom"
+#~ msgstr "Другой"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Проверка %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Отключено"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Подключение"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Подключено"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Ошибка авторизации"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Авторизация"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Сокращённая функциональность"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Подключено и авторизовано"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Неизвестно"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Авторизовано в:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Подключено в:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Зарегистрировано в:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Не удалось авторизовать устройство: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Не удалось забыть устройство: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Ошибка"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Авторизовано"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Подсистема Thunderbolt (boltd) не установлена или настроена неправильно."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Возможно подключение только устройств USB и Display Port."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Не удалось обнаружить Thunderbolt.\n"
+#~ "Либо в системе отсутствует поддержка Thunderbolt, отключено в BIOS, либо "
+#~ "установлено на неподдерживаемый уровень безопасности в BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Поддержка Thunderbolt отключена в BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Уровень безопасности Thunderbolt не может быть определен."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Ошибка переключения в режим прямого доступа: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "По умолчанию"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Средний"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Увеличенный"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Большой"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Огромный"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d пиксель"
+#~ msgstr[1] "%d пикселя"
+#~ msgstr[2] "%d пикселей"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Короткая"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ экрана"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ экрана"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ экрана"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Длинная"
+
+# Выключать экран при простое после:
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 час"
+
+# Очищать корзину через / сохранять историю:
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 день"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 дня"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 дня"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 дня"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 дней"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 дней"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 дней"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 дней"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 дней"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Удалить все объекты из корзины?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Все объекты корзины будут безвозвратно удалены."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Очистить корзину"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Удалить все временные файлы?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Все временные файлы будут безвозвратно удалены."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Удалить временные файлы"
+
+# Очищать корзину через / сохранять историю:
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 день"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 дней"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 дней"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Неограниченно"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Должно совпадать с веб-адресом провайдера вашей учётной записи."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Не удалось добавить учётную запись"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Не удалось зарегистрировать учётную запись"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Нет поддерживаемого метода аутентификации в этом домене"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Не удалось подключить к домену"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Неправильное имя пользователя.\n"
+#~ "Попробуйте ещё раз."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Неправильный пароль.\n"
+#~ "Попробуйте ещё раз."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Не удалось войти в домен"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Не удалось найти домен. Может быть, он написан с ошибкой?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Найти дополнительные изображения"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "устройство должно быть зарезервирована для этого действия"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "устройство уже зарезервировано другим процессом"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "у вас нет доступа, чтобы выполнить это действие"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "нет сканированных отпечатков"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Не удалось связаться с устройством для сканирования"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Не удалось связаться с устройством сканирования отпечатков"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Не удалось связаться с сервисом отпечатков"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Не удалось перечислить отпечатки: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Не удалось удалить сохранённые отпечатки: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Левый большой палец"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Левый средний палец"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Левый указательный палец"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Левый безымянный палец"
+
+#~ msgid "Left little finger"
+#~ msgstr "Левый мизинец"
+
+#~ msgid "Right thumb"
+#~ msgstr "Правый большой палец"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Правый средний палец"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Правый указательный палец"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Правый безымянный палец"
+
+#~ msgid "Right little finger"
+#~ msgstr "Правый мизинец"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Неизвестный палец"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Выполнено"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Устройство чтения отпечатков отключено"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Память устройства чтения отпечатков заполнена"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Не удалось добавить новый отпечаток"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Не удалось начать сканирование: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Не удалось добавить новый отпечаток"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Не удалось прекратить сканирование: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Поднимайте и прикладывайте ваш палец к устройству чтения несколько раз "
+#~ "для добавления"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Сканируйте этот палец ещё раз…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Отсканировать новый отпечаток"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Не удалось освободить устройство чтения %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Проблема с чтением с устройства"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Не удалось зарезервировать устройство чтения %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Не удалось получить устройство чтения: %s"
+
+#~ msgid "This Week"
+#~ msgstr "На этой неделе"
+
+#~ msgid "Last Week"
+#~ msgstr "На прошлой неделе"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%-d %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%-d %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Сеанс завершён"
+
+#~ msgid "Session Started"
+#~ msgstr "Сеанс начат"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — активность учётной записи"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Выберите другой пароль."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Введите пароль ещё раз."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Не удалось изменить пароль"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Не удалось автоматически присоединиться к этому типу домена"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Домен или realm не найден"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Не удалось войти как %s в домене %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Неправильный пароль, попробуйте ещё раз"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Не удалось подключиться к домену %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Не удалось удалить пользователя"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Не удалось аннулировать удалённого пользователя"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Нельзя удалить собственную учётную запись."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s всё ещё находится в системе"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Удаление пользователя, с незавершённым сеансом, может привести систему в "
+#~ "противоречивое состояние."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Хотите сохранить файлы пользователя %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Можно сохранить домашнюю папку, почтовый ящик и временные файлы при "
+#~ "удалении учётной записи пользователя."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Удалить файлы"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Сохранить файлы"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Действительно аннулировать удалённую учётную запись %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Удалить"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Учётная запись отключена"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Установить при следующем входе в систему"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Нет"
+
+#~ msgid "Logged in"
+#~ msgstr "Авторизованная"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Не удалось связаться со службой учётных записей"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Убедитесь, что AccountService установлен и включён."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Для изменения этой настройки панель должна быть разблокирована"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Удалить выбранную учётную запись пользователя"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Чтобы удалить выбранную учётную запись пользователя,\n"
+#~ "сначала нажмите на значок *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Разблокировать для добавления пользователей и изменения настроек"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Новый пароль должен отличаться от старого."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Попробуйте изменить некоторые буквы и цифры."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Попробуйте изменить пароль немного больше."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Пароль не содержащий имя пользователя будет надёжнее."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Старайтесь избегать использования вашего имени в пароле."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Старайтесь избегать слов из которых состоит пароль."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Старайтесь избегать общих слов."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Старайтесь избегать перестановки существующих слов."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Попробуйте использовать больше чисел."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Попробуйте использовать больше заглавных букв."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Попробуйте использовать больше строчных букв."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Попробуйте использовать больше специальных символов, например знаки "
+#~ "препинания."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Попробуйте использовать вперемешку буквы, цифры и знаки препинания."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Старайтесь избегать повторения одного и того же символа."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Старайтесь избегать повторения одного и того же символа: используйте "
+#~ "вперемешку буквы, цифры и знаки препинания."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Старайтесь избегать последовательностей, например 1234 или abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Пароль должен быть длиннее. Попробуйте добавить больше букв, цифр и "
+#~ "знаков препинания."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Смешайте заглавные и строчные буквы несколько раз."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Добавление большего количества букв, цифр и знаков препинания сделает "
+#~ "пароль надёжнее."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Сбой аутентификации"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Новый пароль слишком короткий"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Новый пароль слишком прост"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Старый и новый пароли слишком похожи"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Новый пароль уже недавно использовался."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Новый пароль должен содержать цифровые или специальные символы"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Новый пароль совпадает со старым"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Ваш пароль изменился с момента последней аутентификации!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "В новом пароле недостаточно различных символов"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Неизвестная ошибка"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Имя пользователя может состоять только из букв латинского алфавита в "
+#~ "верхнем и нижнем регистре, цифр и следующих символов: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Данное имя пользователя недоступно. Попробуйте ввести другое."
+
+#~ msgid "The username is too long."
+#~ msgstr "Имя пользователя слишком длинное."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Кнопка %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Приложение определено"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Событие нажатие клавиши"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Переключение монитора"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Показывать справку на экране"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Планшет, подключенный к панели ноутбука"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Планшет, подключенный к внешнему дисплею"
+
+#~ msgid "External tablet device"
+#~ msgstr "Внешнее планшетное устройство"
+
+#~ msgid "All Displays"
+#~ msgstr "Все дисплеи"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Стилус для аэрографа с функцией нажатия, наклона и встроенным слайдером"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Стилус для аэрографа с функцией нажатия, наклона и вращения"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Стандартный стилус с функцией нажатия и наклона"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Стандартный стилус с функцией нажатия"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Новая комбинация…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Операция отменена"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Ошибка:</b> Доступ запрещён для смены настроек"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Ошибка:</b> Ошибка мобильного оборудования"
+
+#~ msgid "Not Registered"
+#~ msgstr "Не зарегистрирован"
+
+#~ msgid "Registered"
+#~ msgstr "Зарегистрирован"
+
+#~ msgid "Roaming"
+#~ msgstr "Роуминг"
+
+#~ msgid "Searching"
+#~ msgstr "Поиск"
+
+#~ msgid "Denied"
+#~ msgstr "Отклонено"
+
+#~ msgid "2G Only"
+#~ msgstr "Только 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Только 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Только 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Только 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (Предпочтительно)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (Предпочтительно), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (Предпочтительно), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (Предпочтительно), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Предпочтительно)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Предпочтительно), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Предпочтительно), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (Предпочтительно)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (Предпочтительно), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (Предпочтительно), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (Предпочтительно)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (Предпочтительно), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (Предпочтительно), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (Предпочтительно)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (Предпочтительно), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (Предпочтительно), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Предпочтительно)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Предпочтительно), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Предпочтительно)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Предпочтительно), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Предпочтительно)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Предпочтительно), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (Предпочтительно)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (Предпочтительно), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Предпочтительно)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (Предпочтительно), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (Предпочтительно)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (Предпочтительно), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Неизвестно"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Разблокирование SIM-карты"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Пожалуйста, введите PIN код для SIM карты %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Введите PIN, чтобы разблокировать вашу SIM карту"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Пожалуйста, предоставьте код PUK для SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Введите PUK код, чтобы разблокировать вашу SIM карту"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Введён неверный код."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Код PUK должен состоять из 8 цифр"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Введите новый PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Код PIN должен состоять из от 4 до 8 цифр"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Разблокировка…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Сбой телефона"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Телефон не подключён"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Операция не разрешена"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Операция не поддерживается"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Не вставлена SIM-карта"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Требуется SIM пин-код"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Требуется SIM PUK-код"
+
+#~ msgid "SIM failure"
+#~ msgstr "Отказ SIM-карты"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM-карта занята"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Неверный код"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Требуется SIM PIN2-код"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Требуется SIM PUK2-код"
+
+#~ msgid "Not found"
+#~ msgstr "Не найден"
+
+#~ msgid "No network service"
+#~ msgstr "Сетевой сервис отсутствует"
+
+#~ msgid "Network timeout"
+#~ msgstr "Тайм-аут сети"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Службы GPRS не разрешены"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Роуминг не разрешён в этом местоположении"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Неуказанная ошибка GPRS"
+
+#~ msgid "No Error"
+#~ msgstr "Ошибок нет"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Действие отменено"
+
+#~ msgid "Access denied"
+#~ msgstr "Доступ запрещён"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Неизвестная ошибка"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Показать номер версии"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Включить информативный режим"
+
+#~ msgid "Search for the string"
+#~ msgstr "Поиск строки"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Вывести список возможных имён панелей и выйти"
+
+#~ msgid "Panel to display"
+#~ msgstr "Область для отображения"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[ПАНЕЛЬ] [АРГУМЕНТ…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Доступные панели:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Системные звуки"
+
+#, c-format
+#~ msgid "%1$s, %2$s"
+#~ msgstr "%1$s, %2$s"
+
+#~ msgid "Ca_lls"
+#~ msgstr "Вы_зовы"
+
+#~ msgid "_SMS"
+#~ msgstr "_SMS"
+
+#~ msgid "Kernel Version"
+#~ msgstr "Версия ядра"
+
+#~ msgid "Proxy"
+#~ msgstr "Прокси"
+
+#~ msgid "Save"
+#~ msgstr "Сохранить"
+
+#~ msgid "URL"
+#~ msgstr "URL"
+
+#~ msgid "Port"
+#~ msgstr "Порт"
+
+#~ msgid "SOCKS Host"
+#~ msgstr "Хост SOCKS"
+
+#~ msgid "SOCKS host port"
+#~ msgstr "Порт хоста SOCKS"
+
+#~ msgid "Fingerprint is duplicate"
+#~ msgstr "Отпечаток пальца дублируется"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Ошибка: невозможно определить уровень HSI."
 
 #~ msgid "Error: unable to determine Incorrect HSI level."
 #~ msgstr "Ошибка: невозможно определить Неправильный уровень HSI."
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Добавить принтер…"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "Сертификаты DER или PEM (*.der, *.pem, *.crt, *.cer)"
@@ -9693,9 +8414,6 @@ msgstr "Системные звуки"
 
 #~ msgid "Take screenshots of application windows and the desktop."
 #~ msgstr "Делайте снимки окон приложений и рабочего стола."
-
-#~ msgid "No Protection"
-#~ msgstr "Без защиты"
 
 #~ msgid "Minimal Protection"
 #~ msgstr "Минимальная защита"

--- a/po/ru.po~
+++ b/po/ru.po~
@@ -1,0 +1,9866 @@
+# translation of gnome-control-center.master.ru.po to Russian
+# translation of gnome-control-center to Russian
+#
+#
+# Max Valianskiy <maxcom@vinchi.ru>, 1998-99.
+# Sergey Panov <sipan@mit.edu>, 1999.
+# Valek Filippov <frob@df.ru>, 2000-2002.
+# Dmitry G. Mastrukov <dmitry@taurussoft.org>, 2002-2004.
+# Andrew W. Nosenko <awn@bcs.zp.ua>, 2003.
+# Leonid Kanter <leon@asplinux.ru>, 2003, 2004, 2005, 2006, 2007, 2009, 2010.
+# Maxim Popov <ravemax@hotbox.ru>, 2006.
+# Yuri Kozlov <kozlov.y@gmail.com>, 2008.
+# Valery Inozemtsev <inozemtsev@gmail.com>, 2009.
+# Alexandre Prokoudine <alexandre.prokoudine@gmail.com>, 2009.
+# Yuri Kozlov <yuray@komyakino.ru>, 2010, 2012.
+# Dmitry Shachnev <mitya57@ubuntu.com>, 2012.
+# Mihail Gurin <mikegurin@yandex.ru>, 2015.
+# Yuri Myasoedov <ymyasoedov@yandex.ru>, 2012, 2014, 2015.
+# Stas Solovey <whats_up@tut.by>, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020.
+# Ivan Komaritsyn <vantu5z@mail.ru>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ru\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-11-13 22:50+0000\n"
+"PO-Revision-Date: 2022-12-10 18:56+0300\n"
+"Last-Translator: Aleksandr Melman <Alexmelman88@gmail.com>\n"
+"Language-Team: Русский <gnome-cyr@gnome.org>\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Системная шина"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Полный доступ"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Шина сеанса"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Устройства"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Полный доступ к /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Сеть"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Имеет доступ к сети"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Домашняя папка"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Только для чтения"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Файловая система"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Настройки"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Может изменять настройки"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s имеет следующие встроенные разрешения. Они не могут быть изменены. Если "
+"вас беспокоят эти разрешения, рассмотрите возможность удаления этого "
+"приложения."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u тип файла и ссылки, которые открываются приложением"
+msgstr[1] "%u типа файлов и ссылок, которые открываются приложением"
+msgstr[2] "%u типов файлов и ссылок, которые открываются приложением"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> используется для открытия следующих типов файлов и ссылок."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s дискового пространства использовано."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Приложения"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Нет приложений"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Установить какое-нибудь…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Открыть"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Подробности"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Поиск"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Получение результатов поиска в системе и их отправка."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Выключено"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Уведомления"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Показывать системные уведомления."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Запуск в фоновом режиме"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Разрешить активность, когда приложение закрыто."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Снимки экрана"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Делать снимки экрана в любое время."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Смена обоев"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Изменение обоев рабочего стола."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Звуки"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Воспроизведение звуков."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Запретить комбинации клавиш"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Блокировать стандартные сочетания клавиш."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Камера"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Делать снимки с помощью камеры."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Микрофон"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Запись звука с помощью микрофона."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Сервисы местоположения"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Доступ к данным о местоположении устройства."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Встроенные разрешения"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Доступ к системе, который требуется приложению"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Ассоциации файлов и ссылок"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Хранилище"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Результатов не найдено"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Попробуйте другой поисковый запрос"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Ассоциации файлов и ссылок"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Типы файлов"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Типы ссылок"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Сбросить"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Сколько дискового пространства занимает это приложение с его данными и "
+"кэшами."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Приложение"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Данные"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Кэш"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Всего</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Очистить кэш…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Управление различными разрешениями и настройками приложения"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "приложение;flatpak;права;доступ;настройки;параметры;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Выберите изображение"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Отменить"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Открыть"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "множество размеров"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Без фона рабочего стола"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Текущий фон"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Стиль"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "По умолчанию"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Темный"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Фон"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Добавить изображение…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Внешний вид"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Изменить фоновое изображение или цвета пользовательского интерфейса"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Фон;Обои;Экран;Рабочий;Стиль;Светлый;Темный;Внешний вид;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Включить"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Адаптеры Bluetooth не найдены"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Для использования Bluetooth подключите адаптер."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Адаптер Bluetooth выключен"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Включите для подключения устройств и передачи файлов."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Авиарежим включен"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth отключается, когда включен авиарежим."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Выключить авиарежим"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Аппаратный авиарежим включен"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Для включения Bluetooth выключите авиарежим."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Включение и отключение Bluetooth. Подключение устройств Bluetooth"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "общий;доступ;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Камера отключена"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Нет приложений способных снимать фото и видео."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Использование камеры позволяет приложениям снимать фото и видео. Отключение "
+"камеры может привести к неправильной работе некоторых приложений.\n"
+"\n"
+"Разрешить перечисленным ниже приложениям использовать вашу камеру."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Нет приложений запросивших доступ к камере"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Защитите ваши изображения"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "камера;фото;видео;веб-камера;блокировка;частное;конфиденциальность;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Поместите устройство калибровки на квадрат и нажмите «Запустить»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Наведите устройство калибровки на место калибровки и нажмите «Продолжить»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Переместите устройство калибровки на поверхность и нажмите «Продолжить»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Закройте крышку ноутбука"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Произошла внутренняя ошибка, которая не может быть исправлена."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Необходимые для калибровки инструменты не установлены."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Ошибка при создании профиля."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Целевая точка белого не получена."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Выполнено!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Сбой калибровки!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Можно убрать устройство калибровки."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Не трогайте устройство калибровки в процессе выполнения"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Калибровка экрана"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Начать"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Продолжить"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Готово"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Экран ноутбука"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Встроенная веб-камера"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Монитор %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Сканер %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Камера %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Принтер %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Веб-камера %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Включить управление цветом для %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Показать цветовые профили для %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Неоткалиброванный"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "По умолчанию: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Цветовое пространство: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Тестовый профиль: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Выберите файл профиля ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Импортировать"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Поддерживаемые профили ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Все файлы"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Экран"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Сохранить профиль"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Сохранить"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Создать цветовой профиль для выбранного устройства"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Измерительный инструмент не обнаружен. Проверьте, что он включён и правильно "
+"подключён."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Измерительный инструмент не поддерживает профилирование принтеров."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Этот тип устройств ещё не поддерживается."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Калибровка экрана"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Качество калибровки"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"После калибровки будет создан профиль, который можно использовать для "
+"управления цветом экрана. Чем дольше калибровка, тем лучше качество "
+"цветового профиля."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Вы не сможете использовать ваш компьютер во время выполнения калибровки."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Качество"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Приблизительное время"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Устройство калибровки"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Выберите используемое для калибровки измерительное устройство."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Тип монитора"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Выберите тип подключённого монитора."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Профиль точки белого"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Выберите целевую точку белого данного экрана. Большинство экранов "
+"откалибровано на цветовую температуру освещения D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Яркость экрана"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Установите яркость экрана, которую обычно используете. Управление цветом "
+"будет наиболее точным на этом уровне яркости."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Кроме того, можно использовать уровень яркости, который используется с одним "
+"из других профилей для данного устройства."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Имя профиля"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Цветовой профиль можно использовать на различных компьютерах или даже "
+"создавать профили для различных режимов освещённости."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Имя профиля:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Краткая информация"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Профиль успешно создан!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Копировать профиль"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Требуется носитель с возможностью записи"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Данные инструкции об использовании цветовых профилей применимы для систем <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> и <a "
+"href=\"windows\">Microsoft Windows</a>."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Добавить профиль"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Обнаружены неполадки. Профиль может работать некорректно. <a "
+"href=\"\">Показать подробности.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Импортировать файл…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Добавить"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Для управления цветом каждому устройству требуется обновление цветового "
+"профиля."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Узнать больше"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Узнать больше об управлении цветом"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Установить для всех пользователей"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Установить этот профиль для всех пользователей этого компьютера"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Включить"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Добавить профиль"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Калибровать…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Калибровать устройство"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "У_далить профиль"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "П_одробности"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Устройства с возможностью управления цветом не обнаружены"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Проектор"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Плазменная панель"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL-подсветка)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED-подсветка)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (белая LED-подсветка)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD с расширенной цветовой палитрой (CCFL-подсветка)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD с расширенной цветовой палитрой (RGB LED-подсветка)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Высокое"
+
+# Выключать экран при простое после:
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 минут"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Среднее"
+
+# Выключать экран при простое после:
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 минут"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Низкое"
+
+# Выключать экран при простое после:
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 минут"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Нативный для экрана"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Полиграфия и издательская деятельность)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Фото и графика)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Стандартное цветовое пространство"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Тестовый профиль"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Автоматический"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Низкое качество"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Среднее качество"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Высокое качество"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB по умолчанию"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK по умолчанию"
+
+# Цветовое пространство
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Серое по умолчанию"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Предоставленные производителем данные заводской калибровки"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Полноэкранный режим коррекции не возможен с этим профилем"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Возможно этот профиль уже неточный"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Цвет"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Калибровка цвета устройств, таких как экраны, камеры или принтеры"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Цвет;ICC;Профиль;Калибровка;Принтер;Экран;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Другой…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Выберите язык"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Выбрать"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Ни один язык не найден"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Ещё…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Разблокировать для изменения настроек"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Некоторые настройки перед изменением нужно разблокировать."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Разблокировать…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Прибавление часа"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Прибавление минуты"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Время"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Убавление часа"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Убавление минуты"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Сегодня"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Вчера"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%-d %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%-d %b %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d час"
+msgstr[1] "%d часа"
+msgstr[2] "%d часов"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d минута"
+msgstr[1] "%d минуты"
+msgstr[2] "%d минут"
+
+# Блокировать экран после:
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d секунда"
+msgstr[1] "%d секунды"
+msgstr[2] "%d секунд"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+# Блокировать экран после:
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 секунд"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Точка доступа"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-часовой"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "12-часовой"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%-d %B %Y, %l∶%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%-d %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l∶%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Дата и время"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Год"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Месяц"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Январь"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Февраль"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Март"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Апрель"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Май"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Июнь"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Июль"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Август"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Сентябрь"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Октябрь"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Ноябрь"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Декабрь"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "День"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Часовой пояс"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Поиск местоположения"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Автоматическое определение _даты и времени"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Требуется подключение к Интернету"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Дата и _время"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Автоматическое определение _часового пояса"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Требуются сервисы определения местоположения и доступ в интернет"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Включено"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "_Часовой пояс"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Формат времени"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Изменить дату и время, включая часовой пояс"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Часы;Часовой;пояс;Местоположение;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Изменить системное время и дату"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Для изменения времени или даты требуется аутентификация."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Интернет"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Почта"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Календарь"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Музыка"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Видео"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Фото"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Приложения по умолчанию"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Настроить приложения по умолчанию"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "по умолчанию;приложение;предпочтительное;носитель;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Отправка сообщения о технических проблемах помогает нам улучшить %s. Отчеты "
+"отправляются анонимно и не содержат персональных данных. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Сообщение об ошибках"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Автоматическое сообщение об ошибках"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Диагностика"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Сообщить об ошибках"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "диагностика;крах;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Включено"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Выключено"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Применить изменения?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Изменения не могут быть применены"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Это может быть связано с аппаратными ограничениями."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Применить"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Назад"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Настройки дисплея отключены"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Несколько дисплеев"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Объединить"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Зеркальное отображение"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Содержит верхнюю панель и меню Обзор"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Основной дисплей"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Ночной свет"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Ландшафтная"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Портретная справа"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Портретная слева"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Ландшафтная (перевернутая)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Гц"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Ориентация"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Разрешение"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Частота обновления"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Отрегулировать для ТВ"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Масштаб"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Ночной свет недоступен"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Это может быть результатом используемого графического драйвера или "
+"удаленного использования рабочего стола"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Временно отключено до завтра"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Перезапустить фильтр"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Ночной свет делает цвет экрана теплее. Это может помочь предотвратить "
+"напряжение глаз и бессонницу."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Расписание"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "От заката до восхода солнца"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Установленное вручную"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Время"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "От"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Часы"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Минуты"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "ДП (AM)"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "ПП (PM)"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "До"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Цветовая температура"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Дисплеи"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Выберите, как использовать подключённые мониторы и проекторы"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Панель;Проектор;xrandr;Экран;Разрешение;Обновить;Монитор;Ночь;Подсветка;"
+"Синий;смещение;цвет;закат;рассвет;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Безопасная загрузка активна"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Безопасная загрузка предотвращает загрузку вредоносного программного "
+"обеспечения при запуске устройства. В настоящее время она включена и "
+"функционирует правильно."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Проблемы с безопасной загрузкой"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Безопасная загрузка предотвращает загрузку вредоносного программного "
+"обеспечения при запуске устройства. В настоящее время она включена, но не "
+"будет работать из-за наличия недействительного ключа."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Проблемы с безопасной загрузкой часто можно решить из настроек прошивки UEFI "
+"(BIOS) вашего компьютера, и производитель оборудования может предоставить "
+"информацию о том, как это сделать."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"За помощью обратитесь к производителю оборудования или поставщику ИТ-"
+"поддержки."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Безопасная загрузка отключена"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Безопасная загрузка предотвращает загрузку вредоносного программного "
+"обеспечения при запуске устройства. В настоящее время она отключена."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Безопасную загрузку обычно можно включить в настройках прошивки UEFI (BIOS) "
+"компьютера. За помощью обратитесь к производителю оборудования или "
+"поставщику ИТ-поддержки."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Безопасная загрузка предотвращает загрузку вредоносного программного "
+"обеспечения при запуске устройства.\n"
+"\n"
+"Для получения дополнительной информации обратитесь к производителю "
+"оборудования или в службу ИТ-поддержки."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Пройдено"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Неудачно"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Устройство соответствует %d уровню HSI"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Уровень безопасности 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Это устройство не имеет защиты от аппаратных проблем безопасности. Это может "
+"быть связано с проблемой конфигурации оборудования или прошивки. "
+"Рекомендуется обратиться к поставщику услуг ИТ-поддержки."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Уровень безопасности 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Это устройство имеет минимальную защиту от аппаратных проблем безопасности. "
+"Это самый низкий уровень безопасности устройства, обеспечивающий защиту "
+"только от простых угроз безопасности."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Уровень безопасности 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Это устройство имеет базовую защиту от аппаратных проблем безопасности. Это "
+"обеспечивает защиту от некоторых распространенных угроз безопасности."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Уровень безопасности 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Это устройство имеет расширенную защиту от аппаратных проблем безопасности. "
+"Это самый высокий уровень безопасности устройства, обеспечивающий защиту от "
+"современных угроз безопасности."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Уровень безопасности"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Уровни безопасности для этого устройства недоступны."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Обратитесь к производителю оборудования за помощью в обновлении системы "
+"безопасности."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Возможно, эту проблему можно решить в настройках прошивки UEFI устройства "
+"или с помощью специалиста службы поддержки."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Возможно, эту проблему можно решить в настройках прошивки UEFI устройства."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Возможно, специалист службы поддержки сможет решить эту проблему."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Уровень 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Уровень 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Уровень 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Обеспечена защита от вредоносных программ при запуске устройства."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Проблемы с безопасной загрузкой"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Некоторая защита при запуске устройства."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Безопасная загрузка отключена"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Без защиты при запуске устройства."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Эта проблема могла быть вызвана изменением настроек прошивки UEFI, "
+"изменением конфигурации операционной системы или наличием вредоносного "
+"программного обеспечения в этой системе."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Эта проблема могла быть вызвана изменением настроек прошивки UEFI или "
+"наличием вредоносного программного обеспечения в данной системе."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Эта проблема могла быть вызвана изменением конфигурации операционной системы "
+"или наличием вредоносного программного обеспечения в этой системе."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Подвержен серьезным угрозам безопасности."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Ограниченная защита от простых угроз безопасности."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Обеспечена защита от распространенных угроз безопасности."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Обеспечена защита от широкого спектра угроз безопасности."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Комплексная защита"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Событий нет"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Защита от записи прошивки"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Блокировка защиты от записи прошивки"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Регион прошивки BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Дескриптор прошивки BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Предзагрузочная защита DMA"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Проверенная загрузка Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Защищенный ACM Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Политика ошибок Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Предохранитель Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET включена"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET активна"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Зашифрованное ОЗУ"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Защита IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Блокировка ядра Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Проверка ядра Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Подкачка Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Режим сна"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Режим ожидания"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Ключ платформы UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Безопасная загрузка UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Конфигурация платформы TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Реконструкция TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Производственный режим Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Переопределение Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Версия Intel Management Engine"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Обновления прошивки"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Аттестация прошивки"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Подтверждение программы обновления прошивки"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Отладка платформы"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Проверка безопасности процессора"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Защита от отката прошивки AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Защита от повтора прошивки AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Защита от записи прошивки AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Объединенная платформа"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Действительно"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Недействительно"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Не включено"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Заблокировано"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Не заблокировано"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Зашифровано"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Не зашифровано"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Испорчено"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Не испорчено"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Найдено"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Не найдено"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Поддерживается"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Не поддерживается"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Безопасность устройства"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Статус безопасности прошивки хоста"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"экран;блокировка;диагностика;сбой;личный;приватный;недавние;временные;tmp;"
+"индекс;имя;сеть;идентификация;личность;конфиденциальность;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-бит"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-бит"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Недоступно"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Логотип системы"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Имя устройства"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Модель оборудования"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Память"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Процессор"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Графика"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Ёмкость диска"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Вычисление…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Название ОС"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID сборки ОС"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Тип ОС"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Версия GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Загрузка…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Оконный интерфейс"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Виртуализация"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Обновление ПО"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Переименовать устройство"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Имя устройства используется для идентификации этого устройства при просмотре "
+"в сети или при сопряжении устройств Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Имя устройства"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Переименовать"
+
+# На экране демонстрируются именно сведения о системе, не о конкретном приложении
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "О системе"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Просмотр информации о системе"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"устройство;система;информация;имя;хоста;память;процессор;версия;умолчанию;"
+"приложение;альтернативный;предпочтительный;cd;dvd;usb;аудио;видео;диск;"
+"съёмный;съемный;носитель;автозапуск;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Звук и носители"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Включить/выключить звук"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Уменьшить громкость"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Увеличить громкость"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Включить/выключить микрофон"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Запустить медиапроигрыватель"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Воспроизвести (или воспроизвести/приостановить)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Приостановить воспроизведение"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Остановить воспроизведение"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Предыдущая дорожка"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Следующая дорожка"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Извлечь"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Ввод"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Переключиться на следующий источник ввода"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Переключиться на предыдущий источник ввода"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Запуск приложений"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Запустить справочный браузер"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Запустить калькулятор"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Запустить клиент эл. почты"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Запустить веб-браузер"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Домашняя папка"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Найти"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Система"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Выйти"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Заблокировать экран"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Специальные возможности"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Включить или выключить увеличение"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Приблизить"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Отдалить"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Включить или выключить чтение с экрана"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Включить или выключить экранную клавиатуру"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Увеличить размер текста"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Уменьшить размер текста"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Включить или выключить высокую контрастность"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Источники ввода не найдены"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Другое"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Добавить источник ввода"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Методы ввода нельзя использовать на экране входа в систему"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Не выбран источник ввода"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Параметры"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Поднять"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Опустить"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Настройки"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Показать раскладку"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Удалить"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Дополнительные комбинации клавиш"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Клавиша альтернативных символов"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Клавиша альтернативных символов может использоваться для ввода "
+"дополнительных символов. Они иногда изображены на кнопках клавиатуры как "
+"третий вариант."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Левый Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Правый Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Левый Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Правый Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Кнопка меню"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Правый Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Клавиша Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Клавиша compose позволяет вводить самые разнообразные символы. Чтобы "
+"использовать это, нажмите клавишу compose, затем последовательность "
+"символов.  Например, нажав клавишу compose, за которой следуют <b>C</b> и "
+"<b>o</b>, получим <b>©</b>, клавиша compose и <b>a</b>, за которой следует "
+"<b>'</b>, получим <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Переключить источники ввода можно сочетанием клавиш %s.\n"
+"Эту комбинацию можно изменить в настройках сочетаний."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Источники ввода"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Включает раскладки клавиатуры и методы ввода."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Переключение источников ввода"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Использовать _один источник для всех окон"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Использовать _свой источник для каждого окна"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Ввод специальных знаков"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Методы ввода символов и вариантов букв, используя клавиатуры."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Комбинации клавиш"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Просмотр и изменение комбинаций клавиш"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d изменена"
+msgstr[1] "%d изменены"
+msgstr[2] "%d изменено"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Сбросить все комбинации клавиш?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Сброс комбинаций клавиш может также повлиять на пользовательские комбинации "
+"клавиш. Это действие нельзя отменить."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Отменить"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Сбросить все"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Сбросить все…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Сбросить все комбинации клавиш на значения по умолчанию"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Раздел"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Комбинации клавиш"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Добавить комбинацию"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Добавить свою комбинацию клавиш"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Установка своих комбинаций для запуска приложений, сценариев и прочего."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Добавить комбинацию"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Комбинация клавиш не найдена"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s уже используется для %s. Если применить, комбинация для %s будет отключена"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Введите новую комбинацию"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Установить пользовательскую комбинацию клавиш"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Установить комбинацию клавиш"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Введите новую комбинацию для изменения %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Добавить пользовательскую комбинацию клавиш"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Удалить"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "За_менить"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Установить"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Нажмите Esc для отмены или Backspace для отключения комбинации клавиш."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Имя"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Команда"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Комбинация клавиш"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Установить комбинацию клавиш…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Нет"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Сбросить комбинацию на значение по умолчанию"
+
+# спецсимвол-невидимый перенос тут между стрелок <­>, копировать через vim или nano
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Клавиатура"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Просмотр и изменение комбинаций клавиш, а также настройка ввода, раскладок "
+"клавиатуры и источников ввода"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Комбинация;Рабочая;область;Окно;Изменение;размера;масштабирование;Контраст;"
+"Ввод;Источник;Блокировка;Том;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Сервисы местоположения отключены"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Нет приложений способных получить информацию о местоположении."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Службы определения местоположения позволяют приложениям узнавать ваше "
+"местоположение. Использование Wi-Fi и мобильной широкополосной связи "
+"повышает точность.\n"
+"\n"
+"Используется служба определения местоположения Mozilla: <a href='https://"
+"location .services.mozilla.com/privacy '>Политика конфиденциальности</a>\n"
+"\n"
+"Разрешить перечисленным ниже приложениям определять ваше местоположение."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Нет приложений запросивших доступ к местоположению"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Защитите вашу информацию о местоположении"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "местоположение;gps;частное;конфиденциальность;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Микрофон выключен"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Нет приложений способных записывать звук."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Использование микрофона позволяет приложениям записывать и прослушивать "
+"звуки. Отключение микрофона может привести к неправильной работе некоторых "
+"приложений.\n"
+"\n"
+"Разрешить перечисленным ниже приложениям использовать ваш микрофон."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Нет приложений запросивших доступ к микрофону"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Защитите ваш обмен сообщениями"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "микрофон;запись;приложение;конфиденциальность;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Проверить настройки"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Общие"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Основная кнопка"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Устанавливает порядок физических кнопок на мышке и сенсорной панели."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Левая"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Правая"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Мышь"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Скорость указателя мыши"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Естественная прокрутка"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr ""
+"При прокрутке перемещается содержимое на экране, а не полоса прокрутки."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Сенсорная панель"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Скорость указателя сенсорной панели"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Нажатие касанием"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Нажатие касанием"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Прокрутка двумя пальцами"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Участки прокрутки по краям"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Проверьте щелчок, двойной щелчок, прокрутку"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Сделайте пять щелчков мышью, чтобы открыть «пасхальное яйцо»!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Двойной щелчок, основная кнопка"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Один щелчок, основная кнопка"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Двойной щелчок, средняя кнопка"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Один щелчок, средняя кнопка"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Двойной щелчок, вторичная кнопка"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Один щелчок, вторичная кнопка"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Мышь и сенсорная панель"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Изменение чувствительности мыши или сенсорной панели, а также настройки "
+"кнопок для правши или левши"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Трэкпад;Указатель;Щелчок;Нажатие;Двойной;Кнопка;Трэкбол;Прокрутка;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Горячий угол"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Прикоснитесь к верхнему левому углу экрана, чтобы открыть Обзор."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Активные границы экрана"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Перетащите окна к верхней, левой или правой границе экрана, чтобы "
+"автоматически изменить размер."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Рабочие столы"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Автоматическое управление столами"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Автоматически убирать пустые столы."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Фиксированное количество столов"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Укажите количество столов, которое нужно вам постоянно."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Количество столов"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Для нескольких мониторов"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Рабочие столы только на _главном дисплее"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Рабочие столы на _всех дисплеях"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Переключение между приложениями"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Включать приложения со всех _столов"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Включать приложения _только с текущего стола"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Многозадачность"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Управляйте предпочтениями продуктивности и многозадачности"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Многозадачность;Продуктивность;Фокус;Настройка;Рабочий стол;Горячий угол;"
+"Рабочее место;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"К сожалению, что-то пошло не так. Обратитесь к поставщику программного "
+"обеспечения."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager должен быть запущен."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Другие устройства"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Добавить подключение"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Не настроено"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Незащищённая сеть (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Защищённая сеть (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Защищённая сеть (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Защищённая сеть (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Защищённая сеть"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Подключено"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Параметры…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Включение точки доступа приведёт к отключению от %s, и доступ в интернет "
+"через Wi-Fi будет невозможен ."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Должно содержать не менее 8 символов"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Должно содержать максимум %d символ"
+msgstr[1] "Должно содержать максимум %d символа"
+msgstr[2] "Должно содержать максимум %d символов"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Включить точку доступа Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Точка доступа Wi-Fi позволяет другим пользователям использовать ваше "
+"интернет-соединение, создавая сеть Wi-Fi, к которой они могут подключаться. "
+"Для этого у вас должно быть подключение к Интернету через источник, отличный "
+"от Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Название сети"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Сгенерировать случайный пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Автоматически сгенерировать пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Включить"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Остановить точку доступа и отключить всех пользователей?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Остановить точку доступа"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Авиарежим"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Отключает Wi-Fi, Bluetooth и мобильную связь"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Адаптеры Wi-Fi не найдены"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Убедитесь, что адаптер Wi-Fi вставлен в разъём и включён"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Включён авиарежим"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Выключите чтобы воспользоваться Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Точка доступа Wi-Fi активна"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Можно сканировать QR на мобильном устройстве для подключения."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Выключить точку доступа Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Видимые сети"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager должен быть запущен"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Безопасность 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Безопасность"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Предустановленный"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Постоянный"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Случайный"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Стабильный"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Введенный здесь MAC-адрес будет использоваться в качестве аппаратного адреса "
+"для сетевого устройства, на котором установлено это соединение. Эта функция "
+"известна как клонирование или подмена MAC. Пример: 00: 11: 22: 33: 44: 55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Профиль %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+# Enhanced open provides improved data encryption in open Wi-Fi networks and protects data from sniffing. Enhanced open replaces open system as the default option. With enhanced open, the client and WLAN perform Diffie-Hellman key exchange during the access procedure and use the resulting pairwise key with a 4-way handshake.
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Предприятие"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Нет"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Никогда"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i день назад"
+msgstr[1] "%i дня назад"
+msgstr[2] "%i дней назад"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Мб/с (%1.1f ГГц)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Мб/с"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 ГГц / 5 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Нет"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Слабый"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Средний"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Хороший"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Отличный"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Адрес IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Адрес IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Адрес IP"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Забыть соединение"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Удалить профиль соединения"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Удалить VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Подробности"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "автоматический"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Идентификация"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Удалить адрес"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Удалить маршрут"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Нет"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "40/128-битный ключ WEP (Hex или ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "128-битная парольная фраза WEP"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Динамический WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "Персональный WPA и WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "Корпоративный WPA и WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "Персональный WPA3"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Мощность сигнала"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Скорость передачи данных"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Аппаратный адрес"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Поддерживаемые частоты"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Маршрут по умолчанию"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Последнее использование"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Подключаться _автоматически"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Сделать доступным для _других пользователей"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Тарифицируемое соединение: возможны ограничения объёма данных и "
+"дополнительные расходы"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Обновление программ и другие большие загрузки не начнутся автоматически."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Название"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC-а_дрес"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Клонированный адрес"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "байт"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Метод IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Автоматический (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Только для локальной сети"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Вручную"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Выключить"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Общий доступ другим компьютерам"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Адреса"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Адрес"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Маска сети"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Автоматический"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Автоматический DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Адрес(ы) сервера DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Отделяйте IP-адреса запятыми"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Маршруты"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Автоматические маршруты"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Метрика"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Использовать это подключение _только для ресурсов в этой сети"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Метод IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Автоматический, только DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Префикс"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Не удалось открыть редактор соединений"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Создать профиль"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Неверная настройка %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Неверная настройка %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Импортировать из файла…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Добавить VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_Безопасность"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Не удалось импортировать соединение VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Невозможно прочитать файл «%s» или файл не содержит корректную информацию о "
+"VPN-соединении\n"
+"\n"
+"Ошибка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Выберите файл для импортирования"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Файл с именем «%s» уже существует."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Заменить"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Заменить %s сохраняемым VPN-соединением?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Не удалось экспортировать соединение VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Невозможно экспортировать VPN-соединение «%s» в %s.\n"
+"\n"
+"Ошибка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Экспортировать VPN-соединение"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Ошибка: не удалось загрузить редактор VPN-соединений)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Управление подключением к Интернету"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Сеть;IP;LAN;Прокси;WAN;Мобильная;Модем;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Контролируйте, как вы подключаетесь к сетям Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Сеть;Беспроводная;Wi-Fi;Wifi;IP;LAN;Мобильная;DNS;Точка;доступа;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "никогда"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "сегодня"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "вчера"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Последнее использование"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Проводное соединение"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Добавить новое подключение"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Сетевые данные для выделенных сетей, включая пароли и любые пользовательские "
+"настройки, будут утеряны."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Забыть"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Известные сети Wi-Fi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Забыть"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Использование в качестве точки доступа запрещено системной политикой"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Беспроводное устройство не поддерживает режим точки доступа"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Web Proxy Autodiscovery используется, когда URL конфигурации не предоставлен."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Не рекомендуется использовать для непроверенных общедоступных сетей."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Выключить устройство"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Запущено"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Провайдер"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Сетевой прокси"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP-прокси"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS-прокси"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP-прокси"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Хост _SOCKS"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Игнорировать хосты"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Порт HTTP-прокси"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Порт HTTPS-прокси"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Порт FTP-прокси"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Порт Socks-прокси"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL _конфигурации"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Выключить VPN-соединение"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Название сети"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Тип безопасности"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Пароль"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Выключить Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Больше параметров…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Подключиться к скрытой сети…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Включить точку доступа Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Известные сети Wi-Fi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Состояние неизвестно"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Неуправляемое"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Недоступно"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Подключение"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Требуется аутентификация"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Отключение"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Сбой подключения"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Состояние неизвестно (отсутствует)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Сбой настройки"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Сбой настройки IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Истёк срок настроек IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Требуется пароль, но он не задан"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Клиент 802.1x отключён"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Сбой настройки клиента 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Сбой клиента 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Клиент 802.1x слишком долго ожидал аутентификации"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Не удалось запустить службу PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Служба PPP отключена"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Сбой PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Не удалось запустить клиент DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Ошибка клиента DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Сбой клиента DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Не удалось запустить службу общего подключения"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Сбой службы общего подключения"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Не удалось запустить службу AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Ошибка службы AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Сбой службы AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Линия занята"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Нет гудка в линии"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Невозможно установить несущую"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Время, отведённое на звонок, истекло"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Не удалось дозвониться"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Не удалось инициализировать модем"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Не удалось выбрать указанный APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Нет сетей для поиска"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Отказано в регистрации в сети"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Время в регистрации сети истекло"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Не удалось зарегистрироваться в запрошенной сети"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Сбой проверки PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Возможно, отсутствует микропрограмма устройства"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Подключение пропало"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Предполагалось, что соединение существует"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Модем не найден"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Сбой подключения по Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Не вставлена SIM-карта"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Требуется SIM Pin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Требуется SIM Puk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Некорректный SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Сбой зависимости подключения"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Отсутствует прошивка"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Кабель не подключён"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "неизвестная ошибка в безопасности 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "файлы не выбраны"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "неизвестная ошибка проверки файла ЕАР-методом"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 или приватные ключи PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Сертификаты DER или PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "отсутствует файл EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Файлы PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Анонимный"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Аутентифицированный"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Оба"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "А_нонимная аутентификация"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Файл PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Выберите PAC-файл"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Внутренняя аутентификация"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Разрешить автоматическое _выделение ресурсов PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "отсутствует имя пользователя EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "отсутствует пароль EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Имя пользователя"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Пароль"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Показывать пароль"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "недействительный сертификат EAP-PEAP CA: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "недействительный сертификат EAP-PEAP CA: сертификат не указан"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Версия 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Версия 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Сертификат C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Выберите сертификат центра сертификации"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Сертификат CA не _требуется"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Версия PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "отсутствует имя пользователя EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "отсутствует пароль EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "отсутствует идентичность EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "недействительный сертификат EAP-TLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "недействительный сертификат EAP-TLS CA: сертификат не указан"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "недействительный секретный ключ EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "недействительный пользовательский сертификат EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Незашифрованные закрытые ключи являются небезопасными"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Возможно, выбранный приватный ключ не защищён паролем. Это может привести к "
+"компрометированию ваших учётных данных. Выберите приватный ключ, защищённый "
+"паролем.\n"
+"\n"
+"(Вы можете защитить приватный ключ с помощью openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Выберите свой персональный сертификат"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Выберите ваш приватный ключ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Подлинность"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Сертификат пользователя"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Приватный _ключ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Пароль приватного ключа"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "недействительный сертификат EAP-TTLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "недействительный сертификат EAP-TTLS CA: сертификат не указан"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (без EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Домен"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Неизвестная ошибка проверки безопасности 802.1X"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Туннелированный TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Защищённый EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "А_утентификация"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Выберите файл"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "отсутствует leap-имя пользователя"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "отсутствует leap-пароль"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Пароль Wi-Fi отсутствует."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Тип"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "отсутствует wep-ключ"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"недействительный wep-ключ: ключ с длиной %zu должен содержать только "
+"шестнадцатеричные цифры"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"недействительный wep-ключ: ключ с длиной %zu должен содержать только символы "
+"ASCII"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"недействительный wep-ключ: ключ с неверной длиной %zu. Ключ должен быть "
+"длины 5/13 (ASCII) или 10/26 (HEX)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "недействительный wep-ключ: парольная фраза не может быть пустой"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"недействительный wep-ключ: парольная фраза должна быть короче 64 символов"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (по умолчанию)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Open System"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Общий ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Показать ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "_Индекс WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"недействительный wpa-psk: ключ неверной длины %zu. Должен быть [8,63] байт "
+"или 64 шестнадцатеричных цифр"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"недействительный wpa-psk: невозможно интерпретировать ключ с 64 байт как "
+"шестнадцатеричный"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "У_ведомления"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Звуковые уведомления"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Всплывающие у_ведомления"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"При отключённых всплывающих уведомлениях, уведомления по-прежнему будут "
+"отображаться в списке уведомлений."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "По_казывать содержимое сообщения в всплывающих уведомлениях"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Уведомления на _экране блокировки"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "По_казывать содержимое сообщения на заблокированном экране"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Не беспокоить"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Уведомления на экране _блокировки"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Управление отображением и содержанием уведомлений"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Уведомления;Всплывающее;Сообщение;Лоток;Всплывающее;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Другое"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s удалён"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Ошибка при удалении учётной записи"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Отменить"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Закрыть уведомление"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Подключение к данным в облаке"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Нет подключения к Интернету — подключитесь для настройки новой сетевой "
+"учётной записи"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Добавить учётную запись"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Учётная запись %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Удалить учётную запись"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Сетевые ­учётные записи"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Подключиться к сетевым учётным записям и решить для чего их использовать"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Онлайн;Чат;Календарь;Почта;Контакт;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Время неизвестно"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i минута"
+msgstr[1] "%i минуты"
+msgstr[2] "%i минут"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i час"
+msgstr[1] "%i часа"
+msgstr[2] "%i часов"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "час"
+msgstr[1] "часа"
+msgstr[2] "часов"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "минута"
+msgstr[1] "минуты"
+msgstr[2] "минут"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "Полностью зарядится через %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Внимание: разрядится через %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Разрядится через %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Полностью заряжена"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Не заряжается"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Разряжена"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Зарядка"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Разрядка"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Беспроводная мышь"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Беспроводная клавиатура"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Источник бесперебойного питания"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "КПК"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Мобильный телефон"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Медиапроигрыватель"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Планшет"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Компьютер"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Игровое устройство ввода"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батарея"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Основная"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Дополнительная"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Батареи"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "При п_ростое"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Режим ожидания"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Выключить"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Режим гибернации"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ничего не делать"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "При работе от батареи"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "При подключении к сети"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Никогда"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Автоматический режим ожидания"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Режим высокой производительности временно запрещён из-за высокой температуры "
+"устройства."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Режим высокой производительности временно запрещён из-за обнаруженной работы "
+"на коленях. Переместите устройство на ровную поверхность для возобновления "
+"режима."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Режим высокой производительности запрещён."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Низкий заряд батареи: включён режим низкого потребления. Предыдущий режим "
+"будет автоматически включён когда батарея будет заряжена."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Режим низкого потребления активирован «%s»."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Режим высокой производительности активирован «%s»."
+
+# Выключать экран при простое после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 минут"
+
+# Блокировать экран после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 час"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 часа"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Режим электропитания"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Влияет на производительность системы и время работы."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Опции энергосбережения"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Автоматическая регулировка яркости"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Яркость подстраивается под окружающее освещение."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Уменьшить яркость экрана"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Уменьшает яркость экрана когда компьютером не пользуются."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Выключение экрана"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Выключает экран после периода простоя."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Автоматическое энергосбережение"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Включает режим энергосбережения, когда батарея разряжена."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Автоматический режим ожидания"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Приостанавливает компьютер после периода простоя."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Действие _кнопки питания устройства"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Показать процент _заряда батареи"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Автоматический режим ожидания"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "При _подключении"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "При работе от _батареи"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Задержка"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Производительный"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Высокая производительность и энергопотребление."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Сбалансированный"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Стандартная производительность и энергопотребление."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Энергосберегающий"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Уменьшенная производительность и энергопотребление."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Электропитание"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Просмотр состояния батареи и изменение настроек энергосбережения"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Электропитание;Спящий;Ждущий;Батарея;Яркость;Затемнение;Экран;DPMS;"
+"Бездействующий;Энергия;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Принтер «%s» удалён"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Не удалось добавить новый принтер."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Не удалось загрузить интерфейс пользователя: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Разблокировать для добавления принтеров и изменения настроек"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Принтеры"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Добавление принтеров, просмотр текущих заданий и выбор способа печати"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Принтер;Очередь;Печать;Бумага;Чернила;Тонер;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Добавить принтер"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Разблокировать"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Принтеры не найдены"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Введите сетевой адрес или найдите принтер"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Требуется аутентификация"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Введите имя пользователя и пароль для просмотра принтеров на сервере печати."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Имя пользователя"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Подробности %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Подходящий драйвер не найден"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Выберите файл PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Файлы PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Имена принтеров не могут содержать пробел, TAB, # или /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Местоположение"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Драйвер"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Поиск предпочтительных драйверов…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Поиск драйверов"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Выбрать из базы данных…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Использовать файл PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Выберите драйвер принтера"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Загрузка базы данных драйверов…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Выбрать"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Принтер JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Принтер LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Односторонняя печать"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "По длинной стороне (стандарт)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "По короткой стороне (переворот)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Портретная"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Ландшафтная"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Перевёрнутая ландшафтная"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Перевёрнутая портретная"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Продолжить"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Приостановить"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Ожидание"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Приостановлено"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Требуется аутентификация"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Выполняется"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Остановлено"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Отменено"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Прервано"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Выполнено"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Переместить это задание в начало очереди"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u задание требует аутентификацию"
+msgstr[1] "%u задания требуют аутентификацию"
+msgstr[2] "%u заданий требуют аутентификацию"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "Текущие задания — %s"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Введите учётные данные для печати из %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Домен"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "А_утентификация"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Очистить все"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Авторизоваться"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Нет активных заданий печати"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Разблокировать сервер печати"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Разблокировать %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Введите имя пользователя и пароль для просмотра принтеров на %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Поиск принтеров"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Последовательный порт"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Параллельный порт"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Расположение: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Адрес: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Сервер требует аутентификацию"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Двусторонняя печать"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Тип бумаги"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Источники бумаги"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Приёмный лоток"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Разрешение"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Предварительная фильтрация GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Страниц на сторону"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Двусторонняя печать"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Ориентация"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Общие"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Настройка страницы"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Устанавливаемые параметры"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Задание"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Качество изображения"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Цвет"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Отделка"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Дополнительно"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Пробная страница"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Пробная страница"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Выбрать автоматически"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Параметры по умолчанию"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Встраивать только шрифты GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Преобразовать в PS level 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Преобразовать в PS level 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Без предварительной фильтрации"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Производитель"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Нет активных заданий"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u задание"
+msgstr[1] "%u задания"
+msgstr[2] "%u заданий"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Очистка печатающих головок принтера"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Мало тонера"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Тонер закончился"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Мало проявителя"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Проявитель закончился"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Маркер скоро закончится"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Маркер закончился"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Открыта крышка"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Открыта дверца"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Мало бумаги"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Бумага закончилась"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Выключен"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Остановлен"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Резервуар почти полон"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Резервуар заполнен"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Фотобарабан скоро выйдет из строя"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Фотобарабан перестал работать"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Готов"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Не принимает задания"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Обработка"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Параметры печати"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Сведения о принтере"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Использовать по умолчанию"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Очистить печатающие головки"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Удалить принтер"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Модель"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Уровень чернил"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Запустите снова когда проблема будет решена."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Перезапустить"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Добавить принтер…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Принтеров нет"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Сожалеем! Системная служба печати\n"
+"    похоже, недоступна."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Форматы"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Поиск местоположений…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Основные форматы"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Все форматы"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Результатов не найдено"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Возможен поиск стран и языков."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Предпросмотр"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Имперская"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Метрическая"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Дата"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Дата и время"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Числа"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Система мер"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Бумага"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Язык и формат будут изменены после следующего входа в систему"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Выйти…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Настройка языка используется для текста интерфейса и веб-страниц. Форматы "
+"используются для чисел, дат и валют."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Ваша учётная запись"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Язык"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Форматы"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Экран входа"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Регион и язык"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Выбор языка интерфейса и форматов"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Язык;Раскладка;Клавиатура;Ввод;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Спрашивать, что делать"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Ничего не делать"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Открыть папку"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Другой носитель"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Выберите приложение для звуковых компакт-дисков"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Выберите приложения для видео DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Выберите приложение, запускаемое при подключении музыкального плеера"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Выберите приложение, запускаемое при подключении камеры"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Выберите приложение для компакт-дисков с программами"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "звуковой DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "чистый диск Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "чистый компакт-диск"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "чистый диск DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "чистый диск HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Видеодиск Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "устройство чтения электронных книг"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Видеодиск HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Диск Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Компакт-диск Super Video"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Видеодиск VCD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Приложение Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Выберите способ обработки носителя"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Звуковой компакт-диск"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_Видео-DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Музыкальный плеер"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Приложение"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "Д_ругой носитель…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Никогда не спрашивать и не запускать программы при подключении носителя"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Выберите способ обработки другого носителя"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Действие:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Тип:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Съёмный носитель"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Настроить съёмный носитель"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"устройство;система;по умолчанию;приложение;предпочтительный;cd;dvd;usb;аудио;"
+"видео;диск;съёмный;съемный;носитель;автозапуск;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Выключение экрана"
+
+# Блокировать экран после:
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 секунд"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 минута"
+
+# Блокировать экран после:
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 минуты"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 минуты"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 час"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 минута"
+
+# Блокировать экран после:
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 минуты"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 минуты"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 минуты"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 минут"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 минут"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Никогда"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Блокировка экрана"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Автоматическая блокировка экрана предотвращает доступ к компьютеру, пока вас "
+"нет."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Задержка выключения экрана"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Период бездействия, после которого экран выключится."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Автоматическая _блокировка экрана"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Задержка _автоматической блокировки экрана"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Задержка автоматической блокировки после отключения экрана."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Показывать _уведомления на экране блокировки"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Запрещать новые USB _устройств"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Предотвращать взаимодействие новых USB устройств с системой когда экран "
+"заблокирован."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Конфиденциальность экрана"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Ограничение угла обзора"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Настройки экрана"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "экран;блокировка;частное;конфиденциальность;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Выберите расположение"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Места поиска"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Папки, такие как Файлы, Изображения и Видео, в которых осуществляется поиск "
+"системными приложениями."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Места"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Закладки"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Прочие"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Добавить расположение"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Приложения не найдены"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Поиск приложения"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Включать результаты поиска, предоставляемые приложением."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Папки, в которых осуществляется поиск системными приложениями."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Результаты поиска"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Результаты отображаются в соответствии с порядком списка."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "Какие приложения показывают результаты поиска в режиме «Обзор»"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Поиск;Найти;Индекс;Скрыть;Конфиденциальность;Результаты;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Не выбрано ни одной сети для обеспечения общего доступа"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Сети"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Включено"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Выключено"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Включено"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Запущено"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Выберите папку"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Добавить"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Включить общий доступ к медиа"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Общий доступ к файлам позволяет открыть доступ к вашим папкам другим "
+"пользователям сети с помощью: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"При включённом удалённом входе, удалённые пользователи могут подключаться "
+"используя команду Secure Shell:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Включить общий доступ к личным медиа"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Имя устройства скопировано"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Адрес устройства скопирован"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Имя пользователя скопировано"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Пароль скопирован"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Общий доступ"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Имя _компьютера"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Общий доступ к _файлам"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Удаленный _рабочий стол"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Общий доступ к _медиа"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Удалённая авторизация"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Общий доступ к файлам"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Требовать пароль"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Удалённая авторизация"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Удаленный рабочий стол"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Удаленный рабочий стол позволяет просматривать и управлять рабочим столом с "
+"другого компьютера."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Включение или отключение подключений удаленного рабочего стола к этому "
+"компьютеру."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Удаленное управление"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Разрешить удаленное подключение для управления экраном."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Как подключиться"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Подключиться к этому компьютеру, используя имя устройства или адрес "
+"удаленного рабочего стола."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Копировать"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Адрес удаленного рабочего стола"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Аутентификация"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Имя пользователя и пароль необходимы для подключения к этому компьютеру."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Имя пользователя"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Проверить шифрование"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Отпечаток пальца для шифрования"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Отпечаток пальца для шифрования виден подключающимся клиентам и должен быть "
+"идентичным."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Общий доступ к медиа"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Общий доступ к музыке, фото и видео по сети."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Папки"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Общий доступ для других пользователей"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"общий;доступ;ssh;хост;имя;удалённый;рабочий;стол;медиа;аудио;видео;"
+"изображения;фото;фильмы;сервер;обработчик;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Включение или отключение удалённого входа в систему"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Для включения или выключения удалённого доступа необходимо выполнить "
+"проверку подлинности"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Другой"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Щелчок"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Струна"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Взмах"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Гул"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Баланс"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Затухание"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Задний"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Передний"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Проверка %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Нажмите на динамик, чтобы проверить"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Системная громкость"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Общая громкость"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Уровни громкости"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Выход"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Устройство вывода"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Проверить"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Конфигурация"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Сабвуфер"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Вход"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Устройство ввода"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Громкость"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Звук уведомления"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Отключить звук"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Звук"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Изменение громкости звука входов, выходов и уведомлений"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Карта;Микрофон;Громкость;Затухание;Баланс;Bluetooth;Наушники;Аудио;Вход;"
+"Выход;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Отключено"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Подключение"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Подключено"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Ошибка авторизации"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Авторизация"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Сокращённая функциональность"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Подключено и авторизовано"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Авторизовано в:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Подключено в:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Зарегистрировано в:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Не удалось авторизовать устройство: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Не удалось забыть устройство: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Зависит от %u другого устройства"
+msgstr[1] "Зависит от %u других устройств"
+msgstr[2] "Зависит от %u других устройств"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Уведомление о закрытии"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Имя:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Состояние:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Подключить и авторизовать"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Забыть устройство"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Ошибка"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Авторизовано"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Подсистема Thunderbolt (boltd) не установлена или настроена неправильно."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Разрешить прямой доступ к таким устройствам, как док-станции и внешние "
+"графические процессоры."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Возможно подключение только устройств USB и Display Port."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Не удалось обнаружить Thunderbolt.\n"
+"Либо в системе отсутствует поддержка Thunderbolt, отключено в BIOS, либо "
+"установлено на неподдерживаемый уровень безопасности в BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Поддержка Thunderbolt отключена в BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Уровень безопасности Thunderbolt не может быть определен."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Ошибка переключения в режим прямого доступа: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Нет поддержки Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Не удалось подключиться к подсистеме thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Прямой доступ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Ожидающие устройства"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Нет подключённых устройств"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Управление устройствами Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;приватность;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Мигание курсора"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Курсор мигает в текстовых полях ввода."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Скорость"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Частота мигания курсора"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Размер курсора"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Размер курсора можно выбрать в соответствии с масштабом для улучшения его "
+"видимости."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Помощник нажатия"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Симуляция вторичного нажатия"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Двойное нажатие удержанием главной кнопки"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "За_держка принятия:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Короткая"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Задержка вторичного нажатия"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Длинная"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Нажатие при на_ведении"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Нажатие при наведении указателя"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "За_держка:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Короткая"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Длинная"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Двигательный _порог:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Уменьшенный"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Увеличенный"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Автоповтор клавиш"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Повторять нажатую удерживаемую клавишу."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Задержка повтора клавиш"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Скорость повтора клавиш"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Помощник ввода"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Залипающие клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Обрабатывает последовательность модификаторов как комбинацию клавиш"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Отключать, если две клавиши нажаты вместе"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Подавать сигнал при нажатии _модификатора"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Медленные клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Вставляет задержку между нажатием клавиши и его обработкой"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Короткая"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Задержка ввода «медленных» клавиш"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Длинная"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Подавать сигнал при _нажатии клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Подавать сигнал при _отпускании клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Подавать сигнал при _игнорировании клавиш"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Отскакивающие клавиши"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Игнорирует быстрые нажатия клавиш"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Короткая"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Задержка ввода «отскакивающих» клавиш"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Длинная"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Управляется клавиатурой"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Включать и выключать специальные возможности с помощью клавиатуры"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "По умолчанию"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Средний"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Увеличенный"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Большой"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Огромный"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d пиксель"
+msgstr[1] "%d пикселя"
+msgstr[2] "%d пикселей"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Всегда показывать меню специальных возможностей"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Зрение"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "В_ысокая контрастность"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Крупный текст"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Разрешить _Анимацию"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "_Чтение с экрана"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Приложение для чтения с экрана читает отображённый текст при перемещении "
+"фокуса."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Звук при нажатии клавиш"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Подавать сигнал при нажатии Num Lock или Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Размер _курсора"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Масштабирование"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Слух"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Визуальные уведомления"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Экранная клавиатура"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Автоповтор клавиш"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Мигание курсора"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Помощник ввода (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Наведение и нажатие"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Клавиши мыши"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "О_бнаружить принтер"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Помощник _нажатия"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Задержка _двойного нажатия"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Задержка двойного нажатия"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Визуальные уведомления"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Проверить мигание"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Использовать визуальную индикацию для звуковых уведомлений."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Мигать всем _экраном"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Мигать всем _окном"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Короткая"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ экрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ экрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ экрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Длинная"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "На весь экран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Верхняя половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Нижняя половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Левая половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Правая половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Параметры масштабирования"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Увеличение:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Положение увеличителя:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Следовать за курсором мыши"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Часть экрана:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Область увеличения выходит за пределы _экрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Курсор увеличителя находится по _центру"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Курсор увеличения перемещается по _области увеличения"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Курсор увеличителя перемещается с _содержимым"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Увеличитель"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Перекрестие:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "П_ерекрывать курсор мыши"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Толщина:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Тоньше"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Толще"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Длина:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Цвет:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Перекрестие"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Цветовые эффекты:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Белый на чёрном:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Яркость:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Контрастность:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Цвет"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Нет"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Полный"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Низкая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Высокая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Низкая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Высокая"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Цветовые эффекты"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"Упрощение ввода, наведения и нажатия, а также улучшение видимости и "
+"слышимости"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Клавиатура;Мышь;a11y;Специальные;возможности;Контрастность;Масштаб;Экран;"
+"Чтение;текст;шрифт;размер;AccessX;Залипающие;клавиши;Медленные;Отскакивающие;"
+"Мышь;Двойное;нажатие;Задержка;скорость;Помощь;Повтор;Мигающий;визуальный;"
+"слышимость;слух;аудио;набор;печать;анимации;"
+
+# Выключать экран при простое после:
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 час"
+
+# Очищать корзину через / сохранять историю:
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 день"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 дня"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 дня"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 дня"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 дней"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 дней"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 дней"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 дней"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 дней"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Удалить все объекты из корзины?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Все объекты корзины будут безвозвратно удалены."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Очистить корзину"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Удалить все временные файлы?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Все временные файлы будут безвозвратно удалены."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Удалить временные файлы"
+
+# Очищать корзину через / сохранять историю:
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 день"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 дней"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 дней"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Неограниченно"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "История файлов"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"История файлов ведёт учёт файлов, которые вы использовали. Эта информация "
+"распределяется между приложениями и облегчает поиск файлов, которые вы, "
+"возможно, захотите использовать."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "История _файлов"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Продолжительность истории файлов"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "О_чистить историю…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Корзина и временные файлы"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Корзина и временные файлы могут иногда содержать личную или конфиденциальную "
+"информацию. Автоматическое удаление этих файлов может помочь защитить "
+"конфиденциальность."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Автоматически очищать _корзину"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Автоматически удалять временные _файлы"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Интервал _автоматического удаления"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Очистить корзину…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Удалить временные файлы…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "История файлов и корзина"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Не оставлять следов"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"использование;недавние;история;файлы;временные;tmp;частные;"
+"конфиденциальность;мусор;очистить;сохранить;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Должно совпадать с веб-адресом провайдера вашей учётной записи."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Не удалось добавить учётную запись"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Пароли не совпадают."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Не удалось зарегистрировать учётную запись"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Нет поддерживаемого метода аутентификации в этом домене"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Не удалось подключить к домену"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Неправильное имя пользователя.\n"
+"Попробуйте ещё раз."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Неправильный пароль.\n"
+"Попробуйте ещё раз."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Не удалось войти в домен"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Не удалось найти домен. Может быть, он написан с ошибкой?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Добавить пользователя"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Администратор"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Администраторы могут добавлять и удалять других пользователей, а также "
+"изменять настройки для всех пользователей. Родительский контроль не может "
+"быть применен к администраторам."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Пользователь устанавливает пароль при первом входе в систему"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Установить пароль сейчас"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Подтвердить"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Корпоративная учётная запись"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+"Учетные записи пользователей, которыми управляет компания или организация."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Сетевое подключение отсутствует"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Корпоративный вход в систему позволяет использовать существующую управляемую "
+"централизованно учётную запись пользователя на этом устройстве. Также можно "
+"использовать данную учётную запись для доступа к ресурсам компании в "
+"интернете."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Найти дополнительные изображения"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Выберите файл…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Управление отпечатками"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Отпечаток пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Нет"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Да"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Удалить зарегистрированные отпечатки пальцев и запретить доступ по отпечатку?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Нет устройства чтения отпечатков"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Нет устройства чтения отпечатков"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Убедитесь, что устройство правильно подключено."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Устройство чтения отпечатков"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Выберите устройство чтения отпечатков для настройки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Вход по отпечатку"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Вход по отпечатку позволяет вам разблокировать и войти в компьютер с помощью "
+"пальца"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Удалить отпечатки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Ввод по отпечатка"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "устройство должно быть зарезервирована для этого действия"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "устройство уже зарезервировано другим процессом"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "у вас нет доступа, чтобы выполнить это действие"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "нет сканированных отпечатков"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Не удалось связаться с устройством для сканирования"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Не удалось связаться с устройством сканирования отпечатков"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Не удалось связаться с сервисом отпечатков"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Не удалось перечислить отпечатки: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Не удалось удалить сохранённые отпечатки: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Левый большой палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Левый средний палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "_Левый указательный палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Левый безымянный палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Левый мизинец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Правый большой палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Правый средний палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "_Правый указательный палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Правый безымянный палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Правый мизинец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Неизвестный палец"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Выполнено"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Устройство чтения отпечатков отключено"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Память устройства чтения отпечатков заполнена"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Не удалось добавить новый отпечаток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Не удалось начать сканирование: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Не удалось добавить новый отпечаток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Не удалось прекратить сканирование: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Поднимайте и прикладывайте ваш палец к устройству чтения несколько раз для "
+"добавления"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "_Сканируйте этот палец ещё раз…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Отсканировать новый отпечаток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Не удалось освободить устройство чтения %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Проблема с чтением с устройства"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Не удалось зарезервировать устройство чтения %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Не удалось получить устройство чтения: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "На этой неделе"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "На прошлой неделе"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%-d %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%-d %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Сеанс завершён"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Сеанс начат"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — активность учётной записи"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Предыдущее"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Следующее"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Выберите другой пароль."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Введите пароль ещё раз."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Не удалось изменить пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Изменить пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Из_менить"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Текущий пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Новый пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Подтвердите пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Разрешить пользователю изменить пароль при следующем входе в систему"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Установите пароль сейчас"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Не удалось автоматически присоединиться к этому типу домена"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Домен или realm не найден"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Не удалось войти как %s в домене %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Неправильный пароль, попробуйте ещё раз"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Не удалось подключиться к домену %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Не удалось удалить пользователя"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Не удалось аннулировать удалённого пользователя"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Нельзя удалить собственную учётную запись."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s всё ещё находится в системе"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Удаление пользователя, с незавершённым сеансом, может привести систему в "
+"противоречивое состояние."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Хотите сохранить файлы пользователя %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Можно сохранить домашнюю папку, почтовый ящик и временные файлы при удалении "
+"учётной записи пользователя."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Удалить файлы"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Сохранить файлы"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Действительно аннулировать удалённую учётную запись %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Удалить"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Учётная запись отключена"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Установить при следующем входе в систему"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Нет"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Авторизованная"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Не удалось связаться со службой учётных записей"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Убедитесь, что AccountService установлен и включён."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Для изменения этой настройки панель должна быть разблокирована"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Удалить выбранную учётную запись пользователя"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Чтобы удалить выбранную учётную запись пользователя,\n"
+"сначала нажмите на значок *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Разблокировать для добавления пользователей и изменения настроек"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Пользователи"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Необходимо перезапустить сеанс, чтобы изменения вступили в силу"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Перезапустить сейчас"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Закрыть"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Редактировать аватар"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Полное имя"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Редактировать"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Вход по отпечатку"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Автоматический в_ход"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Активность учётной записи"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Администратор"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Администраторы могут добавлять и удалять пользователей, а также изменять "
+"настройки всех пользователей."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Родительский контроль"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Запустить программу для управления Родительским контролем."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Удалить пользователя…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Другие пользователи"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Добавить пользователя…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Пользователи не найдены"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Разблокируйте для добавления учётной записи пользователя."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Добавить или удалить пользователей или изменить пароль"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Вход;Имя;Отпечаток;Аватар;Логотип;Лицо;Пароль;Родительский контроль;Экран;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Зарегистрировать"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Вход для администратора домена"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Для использования корпоративного входа этот компьютер необходимо\n"
+"внести в домен. Попросите системного администратора ввести сюда\n"
+"пароль домена."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Имя _администратора"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Пароль администратора"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Управление учётными записями"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Для изменения данных пользователя требуется аутентификация"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Новый пароль должен отличаться от старого."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Попробуйте изменить некоторые буквы и цифры."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Попробуйте изменить пароль немного больше."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Пароль не содержащий имя пользователя будет надёжнее."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Старайтесь избегать использования вашего имени в пароле."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Старайтесь избегать слов из которых состоит пароль."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Старайтесь избегать общих слов."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Старайтесь избегать перестановки существующих слов."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Попробуйте использовать больше чисел."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Попробуйте использовать больше заглавных букв."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Попробуйте использовать больше строчных букв."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+"Попробуйте использовать больше специальных символов, например знаки "
+"препинания."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Попробуйте использовать вперемешку буквы, цифры и знаки препинания."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Старайтесь избегать повторения одного и того же символа."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Старайтесь избегать повторения одного и того же символа: используйте "
+"вперемешку буквы, цифры и знаки препинания."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Старайтесь избегать последовательностей, например 1234 или abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Пароль должен быть длиннее. Попробуйте добавить больше букв, цифр и знаков "
+"препинания."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Смешайте заглавные и строчные буквы несколько раз."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Добавление большего количества букв, цифр и знаков препинания сделает пароль "
+"надёжнее."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Сбой аутентификации"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Новый пароль слишком короткий"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Новый пароль слишком прост"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Старый и новый пароли слишком похожи"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Новый пароль уже недавно использовался."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Новый пароль должен содержать цифровые или специальные символы"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Новый пароль совпадает со старым"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Ваш пароль изменился с момента последней аутентификации!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "В новом пароле недостаточно различных символов"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Неизвестная ошибка"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Имя пользователя может состоять только из букв латинского алфавита в верхнем "
+"и нижнем регистре, цифр и следующих символов: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Данное имя пользователя недоступно. Попробуйте ввести другое."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Имя пользователя слишком длинное."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Отображение кнопок"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Соответствие кнопок и функций"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Чтобы изменить комбинацию клавиш, выберите «Событие нажатие клавиши», "
+"нажмите кнопку комбинации клавиш и нажмите новые клавиши или нажмите "
+"Backspace для очистки."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Закрыть"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Коснитесь маркеров, которые будут появляться на экране, чтобы откалибровать "
+"планшет."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Обнаружено ложное нажатие, выполняется перезапуск…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Кнопка %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Приложение определено"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Событие нажатие клавиши"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Переключение монитора"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Показывать справку на экране"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Планшет, подключенный к панели ноутбука"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Планшет, подключенный к внешнему дисплею"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Внешнее планшетное устройство"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Внешнее накладное устройство"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Все дисплеи"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Режим планшета"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Использовать абсолютное позиционирование для пера"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Ориентация на левую руку"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+"Планшет и клавиши Express Keys™ расположены с поворотом для использования "
+"левой рукой"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Отображать на мониторе"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Сохранить соотношение сторон"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Использовать только часть площади планшета, чтобы сохранить соотношение "
+"сторон монитора"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Калибровать"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Планшет не обнаружен"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Пожалуйста, подключите или включите планшет Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Чувствительность нажатия пера"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Мягкая"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Нажим наконечника стилуса"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Твердая"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Кнопка 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Кнопка 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Кнопка 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Чувствительность нажатия ластика"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Нажим ластика"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Щелчок средней кнопкой мыши"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Щелчок правой кнопкой мыши"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Дальше"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+"Стилус для аэрографа с функцией нажатия, наклона и встроенным слайдером"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Стилус для аэрографа с функцией нажатия, наклона и вращения"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Стандартный стилус с функцией нажатия и наклона"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Стандартный стилус с функцией нажатия"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Планшет Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Установка отображения кнопок и настройка чувствительности пера для "
+"графических планшетов"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Планшет;Wacom;Перо;Ластик;Мышь;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Новая комбинация…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Точки доступа"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Операция отменена"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Ошибка:</b> Доступ запрещён для смены настроек"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Ошибка:</b> Ошибка мобильного оборудования"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Не зарегистрирован"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Зарегистрирован"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Роуминг"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Поиск"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Отклонено"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Подробности о модеме"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Состояние модема"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Оператор"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Тип сети"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Статус сети"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Собственный номер"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Сведения об устройстве"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Версия прошивки"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Только 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Только 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Только 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Только 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (Предпочтительно), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (Предпочтительно), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (Предпочтительно), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Предпочтительно), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Предпочтительно), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (Предпочтительно), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (Предпочтительно), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (Предпочтительно), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (Предпочтительно), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (Предпочтительно), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (Предпочтительно), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (Предпочтительно), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (Предпочтительно), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (Предпочтительно), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (Предпочтительно), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (Предпочтительно), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (Предпочтительно)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (Предпочтительно), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Разблокирование SIM-карты"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Разблокировать"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Пожалуйста, введите PIN код для SIM карты %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Введите PIN, чтобы разблокировать вашу SIM карту"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Пожалуйста, предоставьте код PUK для SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Введите PUK код, чтобы разблокировать вашу SIM карту"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Введён неверный код. У вас осталось %1$u попытка"
+msgstr[1] "Введён неверный код. У вас осталось %1$u попытки"
+msgstr[2] "Введён неверный код. У вас осталось %1$u попыток"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "У вас осталось %u попытка"
+msgstr[1] "У вас осталось %u попытки"
+msgstr[2] "У вас осталось %u попыток"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Введён неверный код."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Код PUK должен состоять из 8 цифр"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Введите новый PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Код PIN должен состоять из от 4 до 8 цифр"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Разблокировка…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "SIM отсутствует"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Вставьте SIM карту для использования этого модема"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM заблокирована"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Мобильные данные"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Доступ к данным с использованием мобильной сети"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Роуминг данных"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Используйте мобильные данный в роуминге"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Режим сети"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Сеть"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Дополнительно"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Имена точки доступа"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_Блокировка SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Заблокировать SIM карту PIN кодом"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Подробности о _модеме"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Сбой телефона"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Телефон не подключён"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Операция не разрешена"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Операция не поддерживается"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Не вставлена SIM-карта"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Требуется SIM пин-код"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Требуется SIM PUK-код"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Отказ SIM-карты"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM-карта занята"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Неверный код"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Требуется SIM PIN2-код"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Требуется SIM PUK2-код"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Не найден"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Сетевой сервис отсутствует"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Тайм-аут сети"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Службы GPRS не разрешены"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Роуминг не разрешён в этом местоположении"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Неуказанная ошибка GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Ошибок нет"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Действие отменено"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Доступ запрещён"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Неизвестная ошибка"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Режим сети"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Автоматический"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Выберите сеть"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Обновить список провайдеров"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Разрешить мобильную сеть"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Адаптеры WWAN не найдены"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Убедитесь, что у вас есть устройство доступа к беспроводным сетям"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Беспроводные сети отключаются при включённом авиарежиме"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Выключить авиарежим"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Соединение данных"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM-карта, используемая для доступа в Интернет"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Блокировка SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Следующий"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Заблокировать SIM с ПИН-кодом"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Изменить ПИН-код"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Введите текущий ПИН-код, чтобы изменить настройки блокировки SIM-карты"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Мобильная сеть"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Настроить телефонию и соединения для мобильных данных"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "сотовый;мобильник;мобильный;мобильная;wwan;телефония;телефон;sim;сим;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Инструмент для настройки рабочего стола GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Настройки — основной интерфейс для настройки вашей системы."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "The GNOME Project"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Показать номер версии"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Включить информативный режим"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Поиск строки"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Вывести список возможных имён панелей и выйти"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Область для отображения"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[ПАНЕЛЬ] [АРГУМЕНТ…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Категории настроек"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Конфиденциальность"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Доступные панели:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Все настройки"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Основное меню"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Предупреждение: версия для разработки"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Эта версия приложения Настройки должна использоваться только в целях "
+"разработки. Вы можете столкнуться с неправильным поведением системы, потерей "
+"данных и другими непредвиденными проблемами. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Справка"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Общие"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Завершить"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Поиск"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Панели"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Вернуться к предыдущей панели"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Отменить поиск"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Настройки;Параметры;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Идентификатор последней панели настроек открывается"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Идентификатор последней панели настроек открывается. Нераспознанные значения "
+"будут проигнорированы и выбрана первая панель в списке."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Показывать предупреждение при запуске сборки приложения Настройки для "
+"разработки"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Должно ли показываться предупреждение при запуске сборки для разработки."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Начальное состояние окна"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Запись, содержащая начальную ширину, высоту и развернутое состояние окна "
+"приложения."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u выход"
+msgstr[1] "%u выхода"
+msgstr[2] "%u выходов"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u вход"
+msgstr[1] "%u входа"
+msgstr[2] "%u входов"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Системные звуки"
+
+#, c-format
+#~ msgid "%1$s, %2$s"
+#~ msgstr "%1$s, %2$s"
+
+#~ msgid "Ca_lls"
+#~ msgstr "Вы_зовы"
+
+#~ msgid "_SMS"
+#~ msgstr "_SMS"
+
+#~ msgid "Kernel Version"
+#~ msgstr "Версия ядра"
+
+#~ msgid "Proxy"
+#~ msgstr "Прокси"
+
+#~ msgid "Save"
+#~ msgstr "Сохранить"
+
+#~ msgid "URL"
+#~ msgstr "URL"
+
+#~ msgid "Port"
+#~ msgstr "Порт"
+
+#~ msgid "SOCKS Host"
+#~ msgstr "Хост SOCKS"
+
+#~ msgid "SOCKS host port"
+#~ msgstr "Порт хоста SOCKS"
+
+#~ msgid "Fingerprint is duplicate"
+#~ msgstr "Отпечаток пальца дублируется"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Ошибка: невозможно определить уровень HSI."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Ошибка: невозможно определить Неправильный уровень HSI."
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Добавить принтер…"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Сертификаты DER или PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Drip"
+#~ msgstr "Капля"
+
+#~ msgid "Glass"
+#~ msgstr "Стекло"
+
+#~ msgid "Sonar"
+#~ msgstr "Сонар"
+
+#~ msgid "Take screenshots of application windows and the desktop."
+#~ msgstr "Делайте снимки окон приложений и рабочего стола."
+
+#~ msgid "No Protection"
+#~ msgstr "Без защиты"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "Минимальная защита"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Базовая защита"
+
+#~ msgid "Extended Protection"
+#~ msgstr "Расширенная защита"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "Минимальные меры безопасности"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Базовые меры безопасности"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Расширенные меры безопасности"
+
+#~ msgid "Security Events"
+#~ msgstr "События безопасности"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI запись"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI блокировка"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "Регион SPI BIOS"
+
+#~ msgid "Pre-boot DMA protection is"
+#~ msgstr "Предзагрузочная защита DMA представлена"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "Испорченное ядро"
+
+#~ msgid "Suspend-to-ram"
+#~ msgstr "Режим сна"
+
+#~ msgid "All TPM PCRs are"
+#~ msgstr "Все TPM PCRs представлены"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "Производственный режим MEI"
+
+#~ msgid "MEI override"
+#~ msgstr "Переопределение MEI"
+
+#~ msgid "MEI version"
+#~ msgstr "Версия MEI"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "плагины fwupd"
+
+#~ msgid "Intel DCI debugger"
+#~ msgstr "Отладчик Intel DCI"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "Защита устройства IOMMU включена"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "Защита устройства IOMMU отключена"
+
+#~ msgid "Kernel is no longer tainted"
+#~ msgstr "Ядро больше не испорчено"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "Ядро испорчено"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "Блокировка ядра отключена"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "Блокировка ядра включена"
+
+#~ msgid "Pre-boot DMA protection is disabled"
+#~ msgstr "Предзагрузочная защита DMA отключена"
+
+#~ msgid "Pre-boot DMA protection is enabled"
+#~ msgstr "Предзагрузочная защита DMA включена"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "Безопасная загрузка отключена"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "Безопасная загрузка включена"
+
+#~ msgid "All TPM PCRs are valid"
+#~ msgstr "Все TPM PCRs действительны"
+
+#~ msgid "All TPM PCRs are now valid"
+#~ msgstr "Все TPM PCRs сейчас действительны"
+
+#~ msgid "A TPM PCR is now an invalid value"
+#~ msgstr "TPM PCR сейчас имеет недействительное значение"
+
+#~ msgid "TPM PCR0 reconstruction is invalid"
+#~ msgstr "Реконструкция TPM PCR0 недействительна"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Заблокировать экран"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Расположение дисплея"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "Безопасная загрузка неактивна"
+
+#~ msgid "Light"
+#~ msgstr "Светлый"
+
+#~ msgid "Set"
+#~ msgstr "Установить"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "экран;блокировка;диагностика;сбой;личный;приватный;недавние;временные;tmp;"
+#~ "индекс;имя;сеть;идентификация;"
+
+#~ msgid "Bark"
+#~ msgstr "Лай"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Настройки Звуковой Панели GNOME"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Настройки Мыши и Сенсорной Панели GNOME"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Настройки Фоновой Панели GNOME"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Настройки Клавиатурной Панели GNOME"

--- a/po/rw.po
+++ b/po/rw.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center HEAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2005-03-31 20:55-0700\n"
 "Last-Translator: Steve Murphy <murf@e-tools.com>\n"
 "Language-Team: Kinyarwanda <translation-team-rw@lists.sourceforge.net>\n"
@@ -25,2490 +25,4381 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
 #, fuzzy
-msgid "The type of alert"
-msgstr "Ubwoko Bya"
-
-# sfx2/source\toolbox\tbxcust.src:RID_USERDEFBMP.GB_FUNCTION.text
-#: ../capplets/about-me/eel-alert-dialog.c:133
-#, fuzzy
-msgid "Alert Buttons"
-msgstr "Utubuto"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-#, fuzzy
-msgid "About Me"
-msgstr "/Bigyanye"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your personal information"
-msgstr "Mburabuzi Porogaramu"
-
-# basctl/source\basicide\tbxctl.src:RID_TOOLBOX.SID_INSERT_SELECT.text
-#: ../capplets/about-me/gnome-about-me.c:554
-#, fuzzy
-msgid "Select Image"
-msgstr "Guhitamo"
-
-#: ../capplets/about-me/gnome-about-me.c:556
-msgid "No Image"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:706
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:727
-msgid "Unable to open address book"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:739
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:770
-#: ../capplets/about-me/gnome-about-me.c:772
-#, fuzzy, c-format
-msgid "About %s"
-msgstr "/Bigyanye"
-
-#: ../capplets/about-me/gnome-about-me-password.c:101
-#: ../capplets/about-me/gnome-about-me-password.c:479
-msgid "Old password is incorrect, please retype it"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:112
-msgid "System error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:113
-msgid "Could not run /usr/bin/passwd"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:114
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:117
-msgid "Unexpected error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:315
-msgid "Password is too short"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:318
-#: ../capplets/about-me/gnome-about-me-password.c:321
-msgid "Password is too simple"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:324
-msgid "Old and new passwords are too similar"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:328
-msgid "Old and new password are the same"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:406
-msgid "Please type the passwords."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:414
-msgid "Please type the password again, it is wrong."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:417
-msgid "Click on Change Password to change the password."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/font/font-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-msgid "    "
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-#, fuzzy
-msgid "<b>Email</b>"
-msgstr "<i i"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-#, fuzzy
-msgid "<b>Home</b>"
+msgid "Applications"
 msgstr "<B B"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:5
+#: panels/applications/cc-applications-panel.ui:31
 #, fuzzy
-msgid "<b>Instant Messaging</b>"
+msgid "No applications"
 msgstr "<B B"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-#, fuzzy
-msgid "<b>Job</b>"
-msgstr "<B B"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-#, fuzzy
-msgid "<b>Telephone</b>"
-msgstr "<B B"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-#, fuzzy
-msgid "<b>Web</b>"
-msgstr "<B B"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-#, fuzzy
-msgid "<b>Work</b>"
-msgstr "<B B"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "A_ddress:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "Address"
-msgstr ""
-
-# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-#, fuzzy
-msgid "C_ity:"
-msgstr "Imisusire"
-
-# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_COMMAND.text
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-#, fuzzy
-msgid "C_ompany:"
-msgstr "Komandi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Cale_ndar:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change Passwo_rd..."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-#, fuzzy
-msgid "Change Password"
-msgstr "Gushyiraho"
-
-# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-#, fuzzy
-msgid "Ci_ty:"
-msgstr "Imisusire"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-#, fuzzy
-msgid "Co_untry:"
-msgstr "Igenzura"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Contact"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-#, fuzzy
-msgid "Cou_ntry:"
-msgstr "Igenzura"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Hom_e:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr ""
-
-# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-#, fuzzy
-msgid "Old pa_ssword:"
-msgstr "Ijambobanga..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P.O. _box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P._O. box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "Personal Info"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "State/Pro_vince:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#, fuzzy
-msgid "User name:"
-msgstr "Izina ry'ukoresha"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Web _log:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "Wor_k:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid "Work _fax:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Zip/_Postal code:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "_Address:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-#, fuzzy
-msgid "_Home page:"
-msgstr "Izina:"
-
-# basctl/source\basicide\moduldlg.src:RID_DLG_NEWLIB.RID_FT_NEWLIB.text
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-#, fuzzy
-msgid "_Home:"
-msgstr "Izina:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-#, fuzzy
-msgid "_Manager:"
-msgstr "Umuyobozi w'idirishya"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-#, fuzzy
-msgid "_Mobile:"
-msgstr "Ingerofatizo"
-
-# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-#, fuzzy
-msgid "_New password:"
-msgstr "Ijambobanga..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-#, fuzzy
-msgid "_Profession:"
-msgstr "Verisiyo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Retype new password:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr ""
-
-# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-#, fuzzy
-msgid "_Title:"
-msgstr "Imisusire"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Work:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Zip/Postal code:"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-#, fuzzy
-msgid "<b>Applications</b>"
-msgstr "<B B"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-#, fuzzy
-msgid "<b>Support</b>"
-msgstr "<B B"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-#, fuzzy
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-"<Gitoya i B B Kuri iyi Igenamiterere OYA INGARUKA Komeza>> LOG in i Gitoya"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technology Preferences"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-#, fuzzy
-msgid "Close and _Log Out"
-msgstr "Funga Na"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-#, fuzzy
-msgid "Start these assistive technologies every time you log in:"
-msgstr "Gutangira buri Igihe LOG in"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-#, fuzzy
-msgid "_On-screen keyboard"
-msgstr "Mugaragaza Mwandikisho"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Screenreader"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-#, fuzzy
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr "Gushigikira kugirango ku Ifashayinjira"
-
-#: ../capplets/accessibility/at-properties/main.c:60
-#, fuzzy
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"ni Bihari ku Sisitemu in Itondekanya Kuri Kubona ku Mugaragaza Mwandikisho "
-"Gushigikira Na i kugirango Na"
-
-#: ../capplets/accessibility/at-properties/main.c:62
-#, fuzzy
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-"Byose Bihari ku Sisitemu in Itondekanya Kuri Kubona ku Mugaragaza "
-"Mwandikisho Gushigikira"
-
-#: ../capplets/accessibility/at-properties/main.c:64
-#, fuzzy
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr "Byose Bihari ku Sisitemu kugirango Na"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
-#, fuzzy, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr "Ikosa i Imbeba Ibyahiswemo Ikiganiro"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
-#, fuzzy, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr "Kuri Kuzana Amagenamiterere Bivuye IDOSIYE"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
-#, fuzzy
-msgid "Import Feature Settings File"
-msgstr "Idosiye"
-
-# filter/source\xsltdialog\xmlfiltertestdialog.src:DLG_XML_FILTER_TEST_DIALOG.FL_IMPORT.text
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
-#, fuzzy
-msgid "_Import"
-msgstr "Kuzana"
-
-# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
-# sfx2/source\accel\accel.src:STR_ACCEL_CFGITEM.text
-# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
-# sfx2/source\dialog\cfg.src:DLG_CONFIG.1.TP_CONFIG_ACCEL.text
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Mwandikisho"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your keyboard accessibility preferences"
-msgstr "Mwandikisho Ubushobozi bwo gukoreshwa Ibyahiswemo"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-#, fuzzy
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-"Sisitemu OYA Kuri i Umugereka Mwandikisho Ubushobozi bwo gukoreshwa Ibiranga "
-"OYA"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-#: ../capplets/theme-switcher/theme-install.glade.h:1
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-#, fuzzy
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "<B B"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-#, fuzzy
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "<B B"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-#, fuzzy
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "<B B"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-#, fuzzy
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "<B B"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-#, fuzzy
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "<B B"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-#, fuzzy
-msgid "<b>Features</b>"
-msgstr "<B B"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-#, fuzzy
-msgid "<b>Toggle Keys</b>"
-msgstr "<B B"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "By'ibanze"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-#, fuzzy
-msgid "Beep if key is re_jected"
-msgstr "NIBA Urufunguzo ni Byanzwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-#, fuzzy
-msgid "Beep when _features turned on or off from keyboard"
-msgstr "Ryari: Ibiranga ku Cyangwa Bidakora Bivuye Mwandikisho"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-#, fuzzy
-msgid "Beep when _modifier is pressed"
-msgstr "Ryari: ni"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-#, fuzzy
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr "Ryari: ni ku Na Ryari: ni Bidakora"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-#, fuzzy
-msgid "Beep when key is:"
-msgstr "Ryari: Urufunguzo ni"
-
-# svx/source\dialog\textanim.src:RID_SVXPAGE_TEXTANIMATION.FT_DELAY.text
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-#, fuzzy
-msgid "Del_ay:"
-msgstr "Gutinda"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-#, fuzzy
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr "hagati Na Mweretsi Igenda"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-#, fuzzy
-msgid "Disa_ble if two keys pressed together"
-msgstr "NIBA Utubuto"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr ""
-
-# framework/source\classes\fltdlg.src:DLG_FILTER_SELECT.FL_FILTER.text
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Muyunguruzi"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-#, fuzzy
-msgid "I_gnore duplicate keypresses within:"
-msgstr "Gusubiramo muri"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-#, fuzzy
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr "Byose Bya i Urufunguzo NIBA muri a Ukoresha: Igihe Bya Igihe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-#, fuzzy
-msgid "Ma_ximum pointer speed:"
-msgstr "Mweretsi Umuvuduko"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-#, fuzzy
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr "Kwemera Utubuto Nyuma Na kugirango a Ukoresha: Igiteranyo Bya Igihe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-#, fuzzy
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr "Igikubo Urufunguzo Kanda Ibikorwa: ku Utubuto in"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-#, fuzzy
-msgid "S_peed:"
-msgstr "Umuvuduko"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-#, fuzzy
-msgid "Time to acce_lerate to maximum speed:"
-msgstr "Kuri Kuri Kinini Umuvuduko"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-#, fuzzy
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr "i Bikurikije umubare a Imbeba Igenzura"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-#, fuzzy
-msgid "_Disable if unused for:"
-msgstr "NIBA Kidakoreshwa kugirango"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-#, fuzzy
-msgid "_Enable keyboard accessibility features"
-msgstr "Mwandikisho Ubushobozi bwo gukoreshwa Ibiranga"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-#, fuzzy
-msgid "_Only accept keys held for:"
-msgstr "Kwemera Utubuto kugirango"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-#, fuzzy
-msgid "_Type to test settings:"
-msgstr "Kuri Igerageza Amagenamiterere"
-
-# sc/source\ui\miscdlgs\acredlin.src:RID_SCDLG_CHANGES.STR_ACCEPTED.text
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-#, fuzzy
-msgid "_accepted"
-msgstr "Byemewe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr ""
-
-# sc/source\ui\miscdlgs\acredlin.src:RID_SCDLG_CHANGES.STR_REJECTED.text
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-#, fuzzy
-msgid "_rejected"
-msgstr "Byanzwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-#, fuzzy
-msgid "characters/second"
-msgstr "Inyuguti ISEGONDA"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-msgid "milliseconds"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-#, fuzzy
-msgid "pixels/second"
-msgstr "Pigiseli ISEGONDA"
-
-# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_MISC.FT_HELPAGENT_TIME_UNIT.text
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:885
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "amasogonda"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-#, fuzzy
-msgid "Change your Desktop Background settings"
-msgstr "Amagenamiterere"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-msgid "Desktop Background"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-#, fuzzy
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "<B B"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-#, fuzzy
-msgid "<b>_Desktop Colors</b>"
-msgstr "<B B"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-msgid "Desktop Background Preferences"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr ""
-
-# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
-#: ../capplets/background/gnome-background-properties.glade.h:6
-#, fuzzy
-msgid "_Style:"
-msgstr "Imisusire"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, fuzzy, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Ikosa Ifashayobora"
-
-#: ../capplets/background/gnome-wp-capplet.c:1042
-#: ../capplets/background/gnome-wp-capplet.c:1060
-msgid "Centered"
-msgstr "Biri hagati"
-
-#: ../capplets/background/gnome-wp-capplet.c:1068
-#: ../capplets/background/gnome-wp-capplet.c:1085
-msgid "Fill Screen"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-capplet.c:1093
-#: ../capplets/background/gnome-wp-capplet.c:1110
-msgid "Scaled"
-msgstr "Scaled"
-
-# #-#-#-#-#  wizards.pot (PACKAGE VERSION)  #-#-#-#-#
-# wizards/source\formwizard\dbwizres.src:RID_DB_FORM_WIZARD_START_+_56.text
-# #-#-#-#-#  wizards.pot (PACKAGE VERSION)  #-#-#-#-#
-# wizards/source\webwizard\webwizar.src:WEBDIALOG_+_7.text
-#: ../capplets/background/gnome-wp-capplet.c:1118
-#: ../capplets/background/gnome-wp-capplet.c:1135
-#, fuzzy
-msgid "Tiled"
-msgstr "Cy'udukaro"
-
-#: ../capplets/background/gnome-wp-capplet.c:1159
-#: ../capplets/background/gnome-wp-capplet.c:1168
-msgid "Solid Color"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-capplet.c:1176
-#: ../capplets/background/gnome-wp-capplet.c:1185
-msgid "Horizontal Gradient"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-capplet.c:1193
-#: ../capplets/background/gnome-wp-capplet.c:1202
-msgid "Vertical Gradient"
-msgstr ""
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1251
-msgid "Add Wallpaper"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-item.c:292
-#: ../capplets/background/gnome-wp-item.c:294
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/common/activate-settings-daemon.c:18
-#, fuzzy
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr "g."
-
-#: ../capplets/common/capplet-stock-icons.c:94
-#, fuzzy, c-format
-msgid "Unable to load capplet stock icon '%s'\n"
-msgstr "Kuri Ibirimo Agashushondanga"
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-#, fuzzy
-msgid "Just apply settings and quit"
-msgstr "Gukurikiza Amagenamiterere Na Kuvamo"
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/default-applications/gnome-default-applications-properties.c:765
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1021
-#: ../capplets/sound/sound-properties-capplet.c:244
-#, fuzzy
-msgid "Retrieve and store legacy settings"
-msgstr "Na Amagenamiterere"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %i of %i"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:194
-#, fuzzy
-msgid "URI currently transferring from"
-msgstr "Bivuye"
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:202
-#, fuzzy
-msgid "URI currently transferring to"
-msgstr "Kuri"
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:210
-#, fuzzy
-msgid "Fraction of transfer currently completed"
-msgstr "Bya"
-
-#: ../capplets/common/file-transfer-dialog.c:217
-#, fuzzy
-msgid "Current URI index"
-msgstr "Umubarendanga"
-
-#: ../capplets/common/file-transfer-dialog.c:218
-#, fuzzy
-msgid "Current URI index - starts from 1"
-msgstr "Umubarendanga Bivuye 1."
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:226
-#, fuzzy
-msgid "Total number of URIs"
-msgstr "Umubare Bya"
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr ""
-
-# officecfg/registry\schema\org\openoffice\Office\Writer.xcs:....Wizard.Memo.Elements.From.text
-#: ../capplets/common/file-transfer-dialog.c:345
-#, fuzzy
-msgid "From:"
-msgstr "Bivuye"
-
-# Buttons
-#: ../capplets/common/file-transfer-dialog.c:349
-#, fuzzy
-msgid "To:"
-msgstr "Kuri->"
-
-# sw/source\ui\app\app.src:STR_STATSTR_LAYOUTINIT.text
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr "Kwihuza..."
-
-# 3348
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Urufunguzo"
-
-#: ../capplets/common/gconf-property-editor.c:171
-#, fuzzy
-msgid "GConf key to which this property editor is attached"
-msgstr "Urufunguzo Kuri iyi indangakintu Muhinduzi ni"
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:178
-#, fuzzy
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "iyi Ryari: i Agaciro Na: Urufunguzo Byahinduwe"
-
-#: ../capplets/common/gconf-property-editor.c:183
-#, fuzzy
-msgid "Change set"
-msgstr "Gushyiraho"
-
-#: ../capplets/common/gconf-property-editor.c:184
-#, fuzzy
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr "Guhindura>> Gushyiraho Ibyatanzwe Kuri Kuri i Umukiriya ku Gukurikiza"
-
-#: ../capplets/common/gconf-property-editor.c:189
-#, fuzzy
-msgid "Conversion to widget callback"
-msgstr "Kuri"
-
-#: ../capplets/common/gconf-property-editor.c:190
-#, fuzzy
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr "Kuri Byasohowe Ryari: Ibyatanzwe Kuri Bivuye Kuri i"
-
-#: ../capplets/common/gconf-property-editor.c:195
-#, fuzzy
-msgid "Conversion from widget callback"
-msgstr "Bivuye"
-
-#: ../capplets/common/gconf-property-editor.c:196
-#, fuzzy
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr "Kuri Byasohowe Ryari: Ibyatanzwe Kuri Kuri Bivuye i"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:202
-#, fuzzy
-msgid "Object that controls the property (normally a widget)"
-msgstr "Amagenzura i indangakintu a"
-
-#: ../capplets/common/gconf-property-editor.c:217
-#, fuzzy
-msgid "Property editor object data"
-msgstr "Muhinduzi Igikoresho Ibyatanzwe"
-
-#: ../capplets/common/gconf-property-editor.c:218
-#, fuzzy
-msgid "Custom data required by the specific property editor"
-msgstr "Kugena Ibyatanzwe Bya ngombwa ku i indangakintu Muhinduzi"
-
-#: ../capplets/common/gconf-property-editor.c:224
-#, fuzzy
-msgid "Property editor data freeing callback"
-msgstr "Muhinduzi Ibyatanzwe"
-
-#: ../capplets/common/gconf-property-editor.c:225
-#, fuzzy
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Kuri Byasohowe Ryari: indangakintu Muhinduzi Igikoresho Ibyatanzwe ni Kuri"
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, fuzzy, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr "Gushaka i IDOSIYE Ubwoko Na Cyangwa Guhitamo a Mbuganyuma() y'Ishusho"
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, fuzzy, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Kuri Gufungura i IDOSIYE a Bya() y'Ishusho ni OYA Guhitamo a() y'Ishusho"
-
-#: ../capplets/common/gconf-property-editor.c:1593
-#, fuzzy
-msgid "Please select an image."
-msgstr "Guhitamo Ishusho"
-
-# basctl/source\basicide\tbxctl.src:RID_TOOLBOX.SID_INSERT_SELECT.text
-#: ../capplets/common/gconf-property-editor.c:1598
-#, fuzzy
-msgid "_Select"
-msgstr "Guhitamo"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-#, fuzzy
-msgid "Select your default applications"
-msgstr "Mburabuzi Porogaramu"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
-msgid "Debian Sensible Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
-msgid "Epiphany"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
-msgid "Galeon"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
-msgid "Encompass"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
-msgid "Firebird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
-msgid "Firefox"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
-#, fuzzy
-msgid "Netscape Communicator"
-msgstr "Netscape"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
-msgid "Konqueror"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
-msgid "W3M Text Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
-msgid "Lynx Text Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
-msgid "Links Text Browser"
-msgstr ""
-
-#. The code in gnome-default-applications-properties.c makes sure
-#. * there is only one (the first entry in this list) Evolution entry
-#. * in the list shown to the user
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
-msgid "Evolution Mail Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
-msgid "Balsa"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
-msgid "KMail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
-msgid "Thunderbird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
-#, fuzzy
-msgid "Mozilla Mail"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
-msgid "Mutt"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
-msgid "Debian Terminal Emulator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
-msgid "GNOME Terminal"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
-msgid "Standard XTerminal"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
-msgid "NXterm"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
-msgid "RXVT"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
-msgid "aterm"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
-msgid "ETerm"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.c:123
-#, fuzzy
-msgid "Please specify a name and a command for this editor."
-msgstr "a Izina: Na a Komandi: kugirango iyi Muhinduzi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "Add..."
-msgstr "Kingeraho"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-#, fuzzy
-msgid "C_ustom"
-msgstr "Guhanga"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-#, fuzzy
-msgid "C_ustom:"
-msgstr "Kunoza"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-#, fuzzy
-msgid "Can open _URIs"
-msgstr "Gufungura"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-#, fuzzy
-msgid "Can open multiple _files"
-msgstr "Gufungura Igikubo Idosiye"
-
-# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_COMMAND.text
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-#, fuzzy
-msgid "Co_mmand:"
-msgstr "Komandi:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-#, fuzzy
-msgid "Custom Editor Properties"
-msgstr "Kugena"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "Default Mail Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "Default Terminal"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Default Text Editor"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "Default Web Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Default Window Manager"
-msgstr ""
-
-# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
-# basctl/source\basicide\basidesh.src:RID_POPUP_TABBAR.SID_BASICIDE_DELETECURRENT.text
-# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
-# basctl/source\basicide\brkdlg.src:RID_BASICIDE_BREAKPOINTDLG.RID_PB_DEL.text
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Delete"
-msgstr "Gusiba"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "E_xec Flag:"
-msgstr ""
-
-# dbaccess/source/ui/inc/toolbox.hrc:MID_DBUI_QUERY_EDIT_JOINCONNECTION.text
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Edit..."
-msgstr "Kwandika..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Mail Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-#, fuzzy
-msgid "Run in a _terminal"
-msgstr "in a"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-#, fuzzy
-msgid "Run in a t_erminal"
-msgstr "in a"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-#, fuzzy
-msgid ""
-"Select the window manager you want.  You will need to hit apply, wave the "
-"magic wand, and do a magic dance for it to work."
-msgstr ""
-"i Idirishya Muyobozi Kuri kanda Gukurikiza UMUVUMBA i Na a kugirango Kuri "
-"Akazi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Terminal"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Text Editor"
-msgstr "Umuhinduzi w'inyandiko"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-#, fuzzy
-msgid "Understands _Netscape Remote Control"
-msgstr "Netscape"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-#, fuzzy
-msgid "Use this _editor to open text files in the file manager"
-msgstr "iyi Muhinduzi Kuri Gufungura Umwandiko Idosiye in i IDOSIYE Muyobozi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "Web Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
-msgid "Window Manager"
-msgstr "Umuyobozi w'idirishya"
-
-# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_COMMAND.text
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
-#, fuzzy
-msgid "_Command:"
-msgstr "Komandi:"
-
-# basctl/source\basicide\moduldlg.src:RID_DLG_NEWLIB.RID_FT_NEWLIB.text
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
-#, fuzzy
-msgid "_Name:"
-msgstr "Izina:"
-
-# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
-# basctl/source\basicide\basidesh.src:RID_POPUP_BRKPROPS.RID_BRKPROPS.text
-# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
-# basctl/source\basicide\basidesh.src:RID_POPUP_DLGED.SID_SHOW_PROPERTYBROWSER.text
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
-#, fuzzy
-msgid "_Properties..."
-msgstr "Indangakintu..."
-
-# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
-# sc/source\ui\src\menue.src:SCCFG_PLUGINMENU.SUBMENU_EDIT.SUBMENU_EDIT_TABLE.SID_SELECT_TABLES.text
-# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
-# sc/source\ui\src\menue.src:SCCFG_MENUBAR.SUBMENU_EDIT.SUBMENU_EDIT_TABLE.SID_SELECT_TABLES.text
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
-#, fuzzy
-msgid "_Select:"
-msgstr "Guhitamo..."
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-#, fuzzy
-msgid "Change screen resolution"
-msgstr "Mugaragaza Imikemurire"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr ""
-
-# officecfg/registry\schema\org\openoffice\Office\Common.xcs:....Filter.Graphic.Export.BMP.Resolution.text
-#: ../capplets/display/main.c:448
-#, fuzzy
-msgid "_Resolution:"
-msgstr "Imikemurire"
-
-#: ../capplets/display/main.c:467
-#, fuzzy
-msgid "Re_fresh rate:"
-msgstr "Igipimo"
-
-# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
-# sc/source\ui\src\solvrdlg.src:RID_SCDLG_SOLVER.FL_VARIABLES.text
-# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
-# sc/source\ui\src\tabopdlg.src:RID_SCDLG_TABOP.FL_VARIABLES.text
-#: ../capplets/display/main.c:488
-#, fuzzy
-msgid "Default Settings"
-msgstr "Amaboneza mburabuzi"
-
-#: ../capplets/display/main.c:490
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr ""
-
-#: ../capplets/display/main.c:516
-msgid "Screen Resolution Preferences"
-msgstr ""
-
-#: ../capplets/display/main.c:553
-#, fuzzy, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "Mburabuzi kugirango iyi"
-
-# basctl/source\basicide\moduldlg.src:RID_DLG_LIBS.RID_FL_OPTIONS.text
-#: ../capplets/display/main.c:571
-msgid "Options"
-msgstr "Amahitamo"
-
-#: ../capplets/display/main.c:592
-#, fuzzy, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] "i Gishya Amagenamiterere in ISEGONDA i Ibanjirije Amagenamiterere"
-
-#: ../capplets/display/main.c:638
-msgid "Keep Resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:642
-#, fuzzy
-msgid "Do you want to keep this resolution?"
-msgstr "Kuri Gumana: iyi Imikemurire"
-
-#: ../capplets/display/main.c:667
-#, fuzzy
-msgid "Use _previous resolution"
-msgstr "Ibanjirije Imikemurire"
-
-#: ../capplets/display/main.c:667
-#, fuzzy
-msgid "_Keep resolution"
-msgstr "Imikemurire"
-
-#: ../capplets/display/main.c:818
-#, fuzzy
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"OYA Gushigikira i Umugereka Imikemurire Amahinduka Kuri i Kugaragaza Ingano "
-"OYA Bihari"
-
-#: ../capplets/display/main.c:826
-#, fuzzy
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"Verisiyo Bya i Umugereka ni Na: iyi Porogaramu Amahinduka Kuri i Kugaragaza "
-"Ingano OYA Bihari"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Intego-nyuguti"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-#, fuzzy
-msgid "Select fonts for the desktop"
-msgstr "Imyandikire kugirango i Ibiro"
-
-#: ../capplets/font/font-properties.glade.h:2
-#, fuzzy
-msgid "<b>Font Rendering</b>"
-msgstr "<B B"
-
-#: ../capplets/font/font-properties.glade.h:3
-#, fuzzy
-msgid "<b>Hinting</b>:"
-msgstr "<B B"
-
-#: ../capplets/font/font-properties.glade.h:4
-#, fuzzy
-msgid "<b>Smoothing</b>:"
-msgstr "<B B"
-
-#: ../capplets/font/font-properties.glade.h:5
-#, fuzzy
-msgid "<b>Subpixel order</b>:"
-msgstr "<B Itondekanya B"
-
-#: ../capplets/font/font-properties.glade.h:6
-#, fuzzy
-msgid "Best _shapes"
-msgstr "Imisusire- shusho"
-
-#: ../capplets/font/font-properties.glade.h:7
-#, fuzzy
-msgid "Best co_ntrast"
-msgstr "Inyuranyamigaragarire"
-
-#: ../capplets/font/font-properties.glade.h:8
-#, fuzzy
-msgid "D_etails..."
-msgstr "Isesengurabyose..."
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:11
-#, fuzzy
-msgid "Go _to font folder"
-msgstr "Kuri Intego- nyuguti Ububiko"
-
-# goodies/source\filter.vcl\eps\dlgeps.src:DLG_EXPORT_EPS.RB_GRAYSCALE.text
-#: ../capplets/font/font-properties.glade.h:12
-#, fuzzy
-msgid "Gra_yscale"
-msgstr "Ingano y'ubwijime"
-
-#: ../capplets/font/font-properties.glade.h:13
-#, fuzzy
-msgid "N_one"
-msgstr "Ntacyo"
-
-# officecfg/registry\schema\org\openoffice\Office\Common.xcs:....Filter.Graphic.Export.BMP.Resolution.text
-#: ../capplets/font/font-properties.glade.h:14
-#, fuzzy
-msgid "R_esolution:"
-msgstr "Imikemurire"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:18
-#, fuzzy
-msgid "_Application font:"
-msgstr "Intego- nyuguti"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:20
-#, fuzzy
-msgid "_Desktop font:"
-msgstr "Intego- nyuguti"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Full"
-msgstr ""
-
-# officecfg/registry\schema\org\openoffice\Office\Math.xcs:....FontFormat.Weight..6.text
-#: ../capplets/font/font-properties.glade.h:22
-#, fuzzy
-msgid "_Medium"
-msgstr "biringaniye"
-
-# 3916
-#: ../capplets/font/font-properties.glade.h:23
-#, fuzzy
-msgid "_Monochrome"
-msgstr "bararimwe"
-
-#: ../capplets/font/font-properties.glade.h:24
-#, fuzzy
-msgid "_None"
-msgstr "Ntacyo"
-
-# svx/source\dialog\tabarea.src:RID_SVXPAGE_COLOR.LB_COLORMODEL.1.text
-#: ../capplets/font/font-properties.glade.h:25
-#, fuzzy
-msgid "_RGB"
-msgstr "UmutukuIcyatsiUbururu"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_Slight"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:27
-#, fuzzy
-msgid "_Terminal font:"
-msgstr "Intego- nyuguti"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:29
-#, fuzzy
-msgid "_Window title font:"
-msgstr "Umutwe Intego- nyuguti"
-
-#: ../capplets/font/font-properties.glade.h:30
-#, fuzzy
-msgid "dots per inch"
-msgstr "Utudomo Inci"
-
-#: ../capplets/font/main.c:488
-#, fuzzy
-msgid "Font may be too large"
-msgstr "Gicurasi Binini"
-
-#: ../capplets/font/main.c:492
-#, fuzzy, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Intego- nyuguti Byahiswemo ni Akadomo Binini Na Gicurasi Ubwoko Kuri "
-"Gukoresha i ni Guhitamo a Ingano Gitoya"
-
-#: ../capplets/font/main.c:505
-#, fuzzy, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Intego- nyuguti Byahiswemo ni Akadomo Binini Na Gicurasi Ubwoko Kuri "
-"Gukoresha i ni Guhitamo a Gitoya Intego- nyuguti"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-#, fuzzy
-msgid "Accelerator key"
-msgstr "Ifunguzo yihutisha:"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-#, fuzzy
-msgid "The type of accelerator."
-msgstr "Ubwoko Bya"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:197
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
-msgid "Disabled"
-msgstr "Yahagaritswe"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:545
-msgid "<Unknown Action>"
-msgstr ""
-
-# sfx2/source\explorer\explorer.src:STR_SFX_DESKTOP.text
-#: ../capplets/keybindings/gnome-keybinding-properties.c:566
-msgid "Desktop"
-msgstr "Ibiro"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:567
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
-msgstr "Ijwi"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:571
-msgid "Window Management"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:668
-#, fuzzy, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-msgstr "Iy'ibusamo ni kugirango"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:700
-#, fuzzy, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr "Igenamiterere Gishya in Iboneza Ububikoshingiro"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:750
-#, fuzzy, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr "in Iboneza Ububikoshingiro"
-
-# sc/source\ui\miscdlgs\acredlin.src:RID_POPUP_CHANGES.SC_SUB_SORT.SC_SORT_ACTION.text
-#: ../capplets/keybindings/gnome-keybinding-properties.c:857
-msgid "Action"
-msgstr "Igikorwa"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:881
-msgid "Shortcut"
-msgstr "Iy'ubusamo"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-#, fuzzy
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
-msgstr ""
-"Guhindura a Iy'ibusamo Urufunguzo Kanda ku i Urubariro Na Ubwoko a Gishya "
-"Cyangwa Kanda Gusiba usubira inyuma Kuri Gusiba"
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-#, fuzzy
-msgid "Assign shortcut keys to commands"
-msgstr "Iy'ibusamo Utubuto Kuri Amabwiriza"
-
-# filter/source\xsltdialog\xmlfilterdialogstrings.src:STR_UNKNOWN_APPLICATION.text
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
-msgid "Unknown"
-msgstr "Kitazwi"
-
-# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
-# sch/source\core\glob.src:STR_LAYOUT.text
-# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
-# sch/source\ui\dlg\attrib.src:TAB_DATA_POINT.1.TP_LAYOUT.text
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
-msgid "Layout"
-msgstr "Imigaragarire"
-
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
-msgid "Default"
-msgstr "Mburabuzi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
-#, fuzzy
-msgid "Models"
-msgstr "Ingerofatizo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:106
-#, fuzzy, c-format
-msgid "There was an error launching the keyboard capplet : %s"
-msgstr "Ikosa i Mwandikisho"
-
-# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_GENERAL_OPTIONS.13.text
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-#, fuzzy
-msgid "_Accessibility"
-msgstr "Ubushobozi bwo gukoreshwa"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:240
-#: ../capplets/sound/sound-properties-capplet.c:242
-#, fuzzy
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr "Gukurikiza Amagenamiterere Na Kuvamo Bihuye neza NONEAHA ku"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-#, fuzzy
-msgid "Start the page with the typing break settings showing"
-msgstr "Gutangira i Ipaji Na: i Kwandika: itandukanya Amagenamiterere"
-
-# #-#-#-#-#  svx.pot (PACKAGE VERSION)  #-#-#-#-#
-# svx/source\dialog\ctredlin.src:SID_REDLIN_FILTER_PAGE.BTN_REF.text
-# #-#-#-#-#  svx.pot (PACKAGE VERSION)  #-#-#-#-#
-# svx/source\form\fmsearch.src:RID_SVXDLG_SEARCHFORM.PB_APPROXSETTINGS.text
-# #-#-#-#-#  svx.pot (PACKAGE VERSION)  #-#-#-#-#
-# svx/source\form\fmsearch.src:RID_SVXDLG_SEARCHFORM.PB_SOUNDSLIKESETTINGS.text
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "..."
-msgstr "..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-#, fuzzy
-msgid "<b>Cursor Blinking</b>"
-msgstr "<B B"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-#, fuzzy
-msgid "<b>Repeat Keys</b>"
-msgstr "<B B"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-#, fuzzy
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<B Mugaragaza Kuri Kwandika: itandukanya B"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-#, fuzzy
-msgid "<small><i>Fast</i></small>"
-msgstr "<Gitoya i i Gitoya"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-#, fuzzy
-msgid "<small><i>Long</i></small>"
-msgstr "<Gitoya i i Gitoya"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-#, fuzzy
-msgid "<small><i>Short</i></small>"
-msgstr "<Gitoya i i Gitoya"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-#, fuzzy
-msgid "<small><i>Slow</i></small>"
-msgstr "<Gitoya i i Gitoya"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-#, fuzzy
-msgid "A_vailable layouts:"
-msgstr "Imigaragarire"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-#, fuzzy
-msgid "All_ow postponing of breaks"
-msgstr "Bya Amataruka"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-#, fuzzy
-msgid "Check if breaks are allowed to be postponed"
-msgstr "NIBA Amataruka Kuri"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-#, fuzzy
-msgid "Choose A Keyboard Model"
-msgstr "A"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-#, fuzzy
-msgid "Choose A Layout"
-msgstr "A"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-#, fuzzy
-msgid "Cursor _blinks in text boxes and fields"
-msgstr "in Umwandiko Na Imyanya"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-#, fuzzy
-msgid "Duration of the break when typing is disallowed"
-msgstr "Igihebimara Bya i itandukanya Ryari: Kwandika: ni"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-#, fuzzy
-msgid "Duration of work before forcing a break"
-msgstr "Igihebimara Bya Akazi Mbere a itandukanya"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-#, fuzzy
-msgid "Key presses _repeat when key is held down"
-msgstr "Gusubiramo Ryari: Urufunguzo ni Hasi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Keyboard Preferences"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-#, fuzzy
-msgid "Keyboard _model:"
-msgstr "Urugero"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Layout Options"
-msgstr ""
-
-# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
-# sch/source\core\glob.src:STR_LAYOUT.text
-# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
-# sch/source\ui\dlg\attrib.src:TAB_DATA_POINT.1.TP_LAYOUT.text
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Layouts"
-msgstr "Imigaragarire"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-#, fuzzy
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-"Mugaragaza Nyuma a Igihe- ngombwa Kuri Ifashayobora Mwandikisho Gukoresha"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Microsoft Natural Keyboard"
-msgstr ""
-
-# svx/source\dialog\rubydialog.src:RID_SVXDLG_RUBY.FT_PREVIEW.text
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Preview:"
-msgstr "Igaragazambere:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Reset To De_faults"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-#, fuzzy
-msgid "Separate _group for each window"
-msgstr "Itsinda kugirango Idirishya"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Typing Break"
-msgstr ""
-
-# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_GENERAL_OPTIONS.13.text
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-#, fuzzy
-msgid "_Accessibility..."
-msgstr "Ubushobozi bwo gukoreshwa"
-
-# padmin/source\padialog.src:RID_FONTNAMEDIALOG.RID_FNTNM_BTN_IMPORT.text
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-#, fuzzy
-msgid "_Add..."
-msgstr "Kongeraho"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-#, fuzzy
-msgid "_Break interval lasts:"
-msgstr "Intera"
-
-# svx/source\dialog\textanim.src:RID_SVXPAGE_TEXTANIMATION.FT_DELAY.text
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-#, fuzzy
-msgid "_Delay:"
-msgstr "Gutinda"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-#, fuzzy
-msgid "_Models:"
-msgstr "Ingerofatizo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-#, fuzzy
-msgid "_Selected layouts:"
-msgstr "Imigaragarire"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-#, fuzzy
-msgid "_Speed:"
-msgstr "Umuvuduko"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-#, fuzzy
-msgid "_Work interval lasts:"
-msgstr "Intera"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "minutes"
-msgstr "iminota"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your keyboard preferences"
-msgstr "Mwandikisho Ibyahiswemo"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:559
-msgid "Unknown Cursor"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:761
-msgid "Default Cursor"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Cursor - Current"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-#, fuzzy
-msgid "The default cursor that ships with X"
-msgstr "Mburabuzi indanga Na:"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-msgid "White Cursor"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Cursor - Current"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-#, fuzzy
-msgid "The default cursor inverted"
-msgstr "Mburabuzi indanga"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-msgid "Large Cursor"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Cursor - Current"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-#, fuzzy
-msgid "Large version of normal cursor"
-msgstr "Verisiyo Bya Bisanzwe indanga"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-msgid "Large White Cursor - Current"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Cursor"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-#, fuzzy
-msgid "Large version of white cursor"
-msgstr "Verisiyo Bya Umweru indanga"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:975
-msgid "Cursor Theme"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-#, fuzzy
-msgid "<b>Double-Click Timeout </b>"
-msgstr "<B B"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-#, fuzzy
-msgid "<b>Drag and Drop</b>"
-msgstr "<B Na B"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-#, fuzzy
-msgid "<b>Locate Pointer</b>"
-msgstr "<B B"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-#, fuzzy
-msgid "<b>Mouse Orientation</b>"
-msgstr "<B B"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-#, fuzzy
-msgid "<b>Speed</b>"
-msgstr "<B B"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-#, fuzzy
-msgid "<i>Fast</i>"
-msgstr "<i i"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-#, fuzzy
-msgid "<i>High</i>"
-msgstr "<i i"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-#, fuzzy
-msgid "<i>Large</i>"
-msgstr "<i i"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-#, fuzzy
-msgid "<i>Low</i>"
-msgstr "<i i"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-#, fuzzy
-msgid "<i>Slow</i>"
-msgstr "<i i"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-#, fuzzy
-msgid "<i>Small</i>"
-msgstr "<i i"
-
-# sfx2/source\toolbox\tbxcust.src:RID_USERDEFBMP.GB_FUNCTION.text
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Utubuto"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
-msgid "Cursor Size:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Cursors"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-#, fuzzy
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr "i Mweretsi Ryari: Kanda"
-
-# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.LB_BIG.3.text
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-#, fuzzy
-msgid "Large"
-msgstr "Binini"
-
-# officecfg/registry\schema\org\openoffice\Office\Math.xcs:....FontFormat.Weight..6.text
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-#, fuzzy
-msgid "Medium"
-msgstr "biringaniye"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Motion"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Mouse Preferences"
-msgstr ""
-
-# officecfg/registry\schema\org\openoffice\Office\Common.xcs:....View.Window.Flag..02.text
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-#, fuzzy
-msgid "Small"
-msgstr "Gitoya"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-#, fuzzy
-msgid "_Left-handed mouse"
-msgstr "Imbeba"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-#, fuzzy
-msgid "_Timeout:"
-msgstr "Igihe cyarenze:"
-
-# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.FL_MOUSE.text
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Imbeba"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your mouse preferences"
-msgstr "Imbeba Ibyahiswemo"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your network proxy preferences"
-msgstr "urusobe Porogisi Ibyahiswemo"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-#, fuzzy
-msgid "<b>D_irect internet connection</b>"
-msgstr "<B Interineti Ukwihuza B"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-#, fuzzy
-msgid "<b>Ignore Host List</b>"
-msgstr "<B Ubuturo Urutonde B"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-#, fuzzy
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<B Porogisi Iboneza B"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-#, fuzzy
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<B Porogisi Iboneza B"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-#, fuzzy
-msgid "<b>_Use authentication</b>"
-msgstr "<B B"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "Advanced Configuration"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-#, fuzzy
-msgid "H_TTP proxy:"
-msgstr "Porogosi ya HTTP"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Network Proxy Preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Impagikiro:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-#, fuzzy
-msgid "Proxy Configuration"
-msgstr "Iboneza rya porogosi..."
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-#, fuzzy
-msgid "S_ocks host:"
-msgstr "Inturo SOCKS:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-#, fuzzy
-msgid "U_sername:"
-msgstr "Izina ry'ukoresha"
-
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-#, fuzzy
-msgid "_Details"
-msgstr "Birambuye"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-#, fuzzy
-msgid "_FTP proxy:"
-msgstr "Porogosi ya FTP:"
-
-# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-#, fuzzy
-msgid "_Password:"
-msgstr "Ijambobanga..."
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-#, fuzzy
-msgid "_Secure HTTP proxy:"
-msgstr "Porogisi"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-#, fuzzy
-msgid "Enable sound and associate sounds with events"
-msgstr "Ijwi Na Amajwi Na: Ibyabaye"
-
-#: ../capplets/sound/sound-properties-capplet.c:271
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Sound Preferences"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:1
-#, fuzzy
-msgid "E_nable sound server startup"
-msgstr "Ijwi Seriveri"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-#, fuzzy
-msgid "Flash _entire screen"
-msgstr "Mugaragaza"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-#, fuzzy
-msgid "Flash _window titlebar"
-msgstr "Idirishya"
-
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "General"
-msgstr "Rusange"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "Sound Events"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "System Bell"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "_Sound an audible bell"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:9
-#, fuzzy
-msgid "_Sounds for events"
-msgstr "kugirango Ibyabaye"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "_Visual feedback:"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:347
-#, fuzzy
-msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
-msgstr ""
-"Insanganyamatsiko Byabonetse ku Sisitemu Ikiganiro Cyangwa i "
-"Insanganyamatsiko"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:227
-#, fuzzy
-msgid "This theme is not in a supported format."
-msgstr "ni OYA in a Imiterere"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:244
-#, fuzzy
-msgid "Failed to create temporary directory"
-msgstr "Kuri Kurema By'igihe gito bushyinguro"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:264
-#, fuzzy
-msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
-msgstr "OYA Kwinjiza porogaramu ni OYA"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:282
-#: ../capplets/theme-switcher/gnome-theme-installer.c:319
-#: ../capplets/theme-switcher/gnome-theme-installer.c:399
-msgid "Installation Failed"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:302
-#, fuzzy
-msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
-msgstr "OYA Kwinjiza porogaramu Insanganyamatsiko ni OYA"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:340
-#, fuzzy, c-format
-msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr "Guhitamo in i Birambuye"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:343
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:346
-#, fuzzy, c-format
-msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr "Guhitamo in i Birambuye"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:349
-#, fuzzy, c-format
-msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr "Guhitamo in i Birambuye"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:357
-#, fuzzy
-msgid "The theme is an engine. You need to compile the theme."
-msgstr "ni Kuri Gukusanya i"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:374
-#, fuzzy
-msgid "The file format is invalid"
-msgstr "IDOSIYE Imiterere ni Sibyo"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:468
-#, fuzzy
-msgid "No theme file location specified to install"
-msgstr "IDOSIYE Ahantu Kuri Kwinjiza porogaramu"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:485
-#, fuzzy
-msgid "The theme file location specified to install is invalid"
-msgstr "IDOSIYE Ahantu Kuri Kwinjiza porogaramu ni Sibyo"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:505
-#, fuzzy, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr "Uruhushya Kuri Kwinjiza porogaramu i in"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:526
-#, fuzzy
-msgid "The file format is invalid."
-msgstr "IDOSIYE Imiterere ni Sibyo"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:553
-#, fuzzy, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr "%sni i Inzira i Idosiye OYA Byahiswemo Nka i Inkomoko Ahantu"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:607
-#, fuzzy
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
-msgstr "Kwinjiza porogaramu Porogaramu ni OYA ku Sisitemu"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-#, fuzzy
-msgid "Custom theme"
-msgstr "Kugena"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-#, fuzzy
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr "Kubika iyi ku i Kubika Akabuto"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
-#, fuzzy
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr "Mburabuzi OYA Byabonetse ku Sisitemu Cyangwa ni"
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:72
-#, fuzzy
-msgid "Theme name must be present"
-msgstr "Izina:"
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:104
-#, fuzzy
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "nka Kuri Gusimbura"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-#, fuzzy
-msgid "Select themes for various parts of the desktop"
-msgstr "Insanganyamatsiko kugirango Bya i Ibiro"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-install.glade.h:2
-#, fuzzy
-msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-msgstr "<Ingano Kinini Uburemere UTSINDAGIYE a"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:3
-msgid "Theme Installation"
-msgstr ""
 
 # #-#-#-#-#  setup2.pot (PACKAGE VERSION)  #-#-#-#-#
 # setup2/source\ui\pages\plang.src:RESID_PAGE_PAGELANGUAGE.STR_PROG.text
 # #-#-#-#-#  setup2.pot (PACKAGE VERSION)  #-#-#-#-#
 # setup2/source\uibase\agentdlg.src:RC_AGENTDLG.RESID_DLG_AGENT_STR_INSTALL.text
-#: ../capplets/theme-switcher/theme-install.glade.h:4
+#: panels/applications/cc-applications-panel.ui:34
 #, fuzzy
-msgid "_Install"
+msgid "Install some…"
 msgstr "Kwinjiza porogaramu"
 
-# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_LOCATION.text
-#: ../capplets/theme-switcher/theme-install.glade.h:5
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\accel\accel.src:STR_OPEN.text
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\cfg.src:STR_OPEN.text
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\versdlg.src:DLG_VERSIONS.PB_OPEN.text
+#: panels/applications/cc-applications-panel.ui:84
 #, fuzzy
-msgid "_Location:"
+msgid "Open"
+msgstr "Gufungura"
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Birambuye"
+
+# #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
+# offmgr/source\offapp\dialog\inetdlg.src:RID_OFADLG_INTERNET.1.RID_SVXPAGE_INET_SEARCH.text
+# #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
+# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_INET_DLG.3.text
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Gushaka"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Yahagaritswe"
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_LOCATION.text
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
 msgstr "Intaho:"
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
+#: panels/applications/cc-applications-panel.ui:127
 #, fuzzy
-msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-msgstr "<Ingano Kinini Uburemere UTSINDAGIYE Kubika Kuri"
+msgid "Show system notifications."
+msgstr "Ifashayobora Amahitamo"
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Apply _Background"
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
 msgstr ""
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Apply _Font"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Mugaragaza"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Gushyiraho"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Ijwi"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Iy'ubusamo"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Intego- nyuguti"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<i i"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Imisusire"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Mburabuzi"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Hejuru"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+# filter/source\xsltdialog\xmlfiltertestdialog.src:DLG_XML_FILTER_TEST_DIALOG.FL_IMPORT.text
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "Kuzana"
+
+# padmin/source\padialog.src:RID_FONTNAMEDIALOG.RID_FNTNM_BTN_IMPORT.text
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "Kongeraho"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "Idosiye"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_FONTSUBSTPAGE.RID_RTS_FS_REMOVE_BTN.text
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_COMMANDPAGE.RID_RTS_CMD_BTN_REMOVE.text
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "Gukuraho"
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "Birambuye"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "iminota"
+
+# officecfg/registry\schema\org\openoffice\Office\Math.xcs:....FontFormat.Weight..6.text
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "biringaniye"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "iminota"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "iminota"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+# basctl/source\basicide\tbxctl.src:RID_TOOLBOX.SID_INSERT_SELECT.text
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Guhitamo"
+
+# basctl/source\basicide\tbxctl.src:RID_TOOLBOX.SID_INSERT_SELECT.text
+#: panels/common/cc-language-chooser.ui:13
+#, fuzzy
+msgid "_Select"
+msgstr "Guhitamo"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "Igihe cyarenze:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+# #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
+# offmgr/source\offapp\dialog\inetdlg.src:RID_OFADLG_INTERNET.1.RID_SVXPAGE_INET_SEARCH.text
+# #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
+# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_INET_DLG.3.text
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Gushaka"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+# svx/source\dialog\textanim.src:RID_SVXPAGE_TEXTANIMATION.FT_DELAY.text
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "Gutinda"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "Iy'ibusamo"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Yahagaritswe"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_MISC.FT_HELPAGENT_TIME_UNIT.text
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "amasogonda"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Amagenamiterere"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Mburabuzi Porogaramu"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Mburabuzi Porogaramu"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Intego- nyuguti"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<B B"
+
+# officecfg/registry\schema\org\openoffice\Office\Common.xcs:....Filter.Graphic.Export.BMP.Resolution.text
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Imikemurire"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Igipimo"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Scaled"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+# officecfg/registry\schema\org\openoffice\Office\Writer.xcs:....Wizard.Memo.Elements.From.text
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Bivuye"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "iminota"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+# Buttons
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "Kuri->"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\eventdlg.src:TP_CONFIG_EVENT.STR_EVENT.text
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\macropg.src:RID_SFX_TP_MACROASSIGN.STR_EVENT.text
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+#, fuzzy
+msgid "No Events"
+msgstr "Icyabaye"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+# sc/source\ui\dbgui\pvfundlg.src:RID_SCDLG_PIVOTSUBT.FT_NAMELABEL.text
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Izina:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+# filter/source\xsltdialog\xmlfilterdialogstrings.src:STR_COLUMN_HEADER_TYPE.text
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Ubwoko"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Verisiyo:"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Umuyobozi w'idirishya"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Izina:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Izina ry'ukoresha"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/Bigyanye"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Mute"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+#, fuzzy
+msgid "Volume down"
+msgstr "Hasi"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+#, fuzzy
+msgid "Volume up"
+msgstr "Hejuru"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+#, fuzzy
+msgid "Play (or play/pause)"
+msgstr "Cyangwa Gukina Akaruhuko..."
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Urufunguzo"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Kuri Ibanjirije"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Kuri Komeza>>"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Kuri Komeza>>"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Kuri Ibanjirije"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Urubuga Mucukumbuzi"
+
+#: panels/keyboard/01-launchers.xml.in:4
+#, fuzzy
+msgid "Launch help browser"
+msgstr "Ifashayobora Mucukumbuzi"
+
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\solvrdlg.src:RID_SCDLG_SOLVER.FL_VARIABLES.text
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\tabopdlg.src:RID_SCDLG_TABOP.FL_VARIABLES.text
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Amaboneza mburabuzi"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+#, fuzzy
+msgid "Launch web browser"
+msgstr "Urubuga Mucukumbuzi"
+
+#: panels/keyboard/01-launchers.xml.in:14
+#, fuzzy
+msgid "Home folder"
+msgstr "Ububiko"
+
+# #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
+# offmgr/source\offapp\dialog\inetdlg.src:RID_OFADLG_INTERNET.1.RID_SVXPAGE_INET_SEARCH.text
+# #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
+# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_INET_DLG.3.text
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Gushaka"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:4
+#, fuzzy
+msgid "Log out"
+msgstr "Kuvamo"
+
+#: panels/keyboard/01-system.xml.in:6
+#, fuzzy
+msgid "Lock screen"
+msgstr "Mugaragaza"
+
+# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_GENERAL_OPTIONS.13.text
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "Ubushobozi bwo gukoreshwa"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Kuvamo"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "Mugaragaza Mwandikisho"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_DLG_LIBS.RID_FL_OPTIONS.text
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Amahitamo"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Imigaragarire"
+
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_FONTSUBSTPAGE.RID_RTS_FS_REMOVE_BTN.text
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_COMMANDPAGE.RID_RTS_CMD_BTN_REMOVE.text
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "Gukuraho"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+# sc/source\ui\miscdlgs\acredlin.src:RID_POPUP_CHANGES.SC_SUB_SORT.SC_SORT_ACTION.text
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Igikorwa"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Iy'ubusamo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Iy'ubusamo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Iy'ubusamo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr ""
+
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_FONTSUBSTPAGE.RID_RTS_FS_REMOVE_BTN.text
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_COMMANDPAGE.RID_RTS_CMD_BTN_REMOVE.text
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "Gukuraho"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+# sc/source\ui\dbgui\pvfundlg.src:RID_SCDLG_PIVOTSUBT.FT_NAMELABEL.text
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Izina:"
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_COMMAND.text
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Komandi:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Iy'ubusamo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Iy'ubusamo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "Ntacyo"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\accel\accel.src:STR_ACCEL_CFGITEM.text
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\cfg.src:DLG_CONFIG.1.TP_CONFIG_ACCEL.text
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Mwandikisho"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Mburabuzi Porogaramu"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\solvrdlg.src:RID_SCDLG_SOLVER.FL_VARIABLES.text
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\tabopdlg.src:RID_SCDLG_TABOP.FL_VARIABLES.text
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Amaboneza mburabuzi"
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Rusange"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr ""
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_LOCATION.text
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Intaho:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.FL_MOUSE.text
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Imbeba"
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.FL_MOUSE.text
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Imbeba"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "Ifunguzo yihutisha:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Intego- nyuguti"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+# starmath/source\smres.src:RID_TOOLBOXWINDOW.10.RID_MISC_CAT.text
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Ibindi"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+# sc/source\ui\miscdlgs\acredlin.src:RID_POPUP_CHANGES.SC_SUB_SORT.SC_SORT_ACTION.text
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Igikorwa"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+# sw/source\ui\app\app.src:STR_STATSTR_LAYOUTINIT.text
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Kwihuza..."
+
+# basctl/source\basicide\moduldlg.src:RID_DLG_LIBS.RID_FL_OPTIONS.text
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Amahitamo"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "Ijambobanga..."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Gushyiraho"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:126
+msgid "Hardware Address"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Mburabuzi"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_DLG_NEWLIB.RID_FT_NEWLIB.text
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "Izina:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Yahagaritswe"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "iminota"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+# sc/source\ui\miscdlgs\acredlin.src:RID_POPUP_CHANGES.SC_SUB_SORT.SC_SORT_ACTION.text
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Igikorwa"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr ""
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "Porogosi ya HTTP"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "Porogosi ya HTTP"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "Porogosi ya FTP:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Inturo SOCKS:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "<B Ubuturo Urutonde B"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "Porogosi ya HTTP"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "Porogosi ya HTTP"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "Porogosi ya FTP:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Iboneza rya porogosi..."
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr ""
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Ijambobanga..."
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Amahitamo"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<B B"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "Izina ry'ukoresha"
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "Ijambobanga..."
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "Ijambobanga..."
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Verisiyo:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Verisiyo:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "Ijambobanga..."
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "<B B"
+
+# filter/source\xsltdialog\xmlfilterdialogstrings.src:STR_COLUMN_HEADER_TYPE.text
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Ubwoko"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Mburabuzi"
+
+# sfx2/sdi\sfxslots.src:SID_OPENDOC.text
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Gufungura Dosiye"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_LOCATION.text
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Intaho:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "IDOSIYE"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Iy'ibusamo"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Iy'ibusamo"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<B B"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "iminota"
+msgstr[1] "iminota"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "iminota"
+msgstr[1] "iminota"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "iminota"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "iminota"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "iminota"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "iminota"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "iminota"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "iminota"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "iminota"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "iminota"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Mugaragaza"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Mugaragaza"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+# svx/source\dialog\textanim.src:RID_SVXPAGE_TEXTANIMATION.FT_DELAY.text
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "Gutinda"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "Gucapa"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "Izina ry'ukoresha"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_LOCATION.text
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Intaho:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+# basctl/source\basicide\tbxctl.src:RID_TOOLBOX.SID_INSERT_SELECT.text
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "Guhitamo"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+# basctl/source\basicide\moduldlg.src:RID_DLG_LIBS.RID_FL_OPTIONS.text
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Amahitamo"
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Birambuye"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Ingerofatizo"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+# svx/source\dialog\rubydialog.src:RID_SVXDLG_RUBY.FT_PREVIEW.text
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Igaragazambere:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Mugaragaza"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+# sc/source\ui\miscdlgs\acredlin.src:RID_POPUP_CHANGES.SC_SUB_SORT.SC_SORT_ACTION.text
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Igikorwa"
+
+# sfx2/source\dialog\dinfdlg.src:TP_DOCINFODOC.FT_FILE_TYP.text
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Ubwoko"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Mugaragaza"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Mugaragaza"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Mugaragaza"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Mugaragaza"
+
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\solvrdlg.src:RID_SCDLG_SOLVER.FL_VARIABLES.text
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\tabopdlg.src:RID_SCDLG_TABOP.FL_VARIABLES.text
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Amaboneza mburabuzi"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Amahitamo"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+# starmath/source\smres.src:RID_TOOLBOXWINDOW.10.RID_MISC_CAT.text
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Ibindi"
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_LOCATION.text
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Intaho:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Intego- nyuguti"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Iy'ibusamo"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+# sfx2/source\explorer\explorer.src:STR_SFX_DESKTOP.text
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Ibiro"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_FONTSUBSTPAGE.RID_RTS_FS_REMOVE_BTN.text
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_COMMANDPAGE.RID_RTS_CMD_BTN_REMOVE.text
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "Gukuraho"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "Ijambobanga..."
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+# sfx2/source\explorer\explorer.src:STR_SFX_DESKTOP.text
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Ibiro"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Igenzura"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+# dbaccess/source/ui/inc/toolbox.hrc:MID_SBA_QRY_COPY.text
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "Gukoporora"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<B B"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Izina ry'ukoresha"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Igice"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Mute"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Iboneza rya porogosi..."
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Igice"
+
+# sfx2/source\toolbox\tbxcust.src:RID_USERDEFBMP.GB_FUNCTION.text
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Utubuto"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Ijwi"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+# sc/source\ui\dbgui\pvfundlg.src:RID_SCDLG_PIVOTSUBT.FT_NAMELABEL.text
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Izina:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<B B"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "in Umwandiko Na Imyanya"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "Umuvuduko"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "<B B"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Iy'ubusamo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+# svx/source\dialog\textanim.src:RID_SVXPAGE_TEXTANIMATION.FT_DELAY.text
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "Gutinda"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Iy'ubusamo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+# officecfg/registry\schema\org\openoffice\Office\Common.xcs:....View.Window.Flag..02.text
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Gitoya"
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.LB_BIG.3.text
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Binini"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<B B"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Gusubiramo Ryari: Urufunguzo ni Hasi"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "<B B"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "NIBA Utubuto"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Ryari: ni"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Iy'ubusamo"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Ryari: ni"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Ryari: Urufunguzo ni"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "NIBA Urufunguzo ni Byanzwe"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Gusubiramo muri"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Iy'ubusamo"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_GENERAL_OPTIONS.13.text
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Ubushobozi bwo gukoreshwa"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.LB_BIG.3.text
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Binini"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Mugaragaza"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+# svx/source\gallery2\galtheme.src:RID_GALLERYSTR_THEME_SOUNDS.text
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Amajwi"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Mugaragaza Mwandikisho"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<B B"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<B B"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.FL_MOUSE.text
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Imbeba"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "<B B"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<B B"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Mugaragaza"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Mugaragaza"
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Mugaragaza"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_DLG_LIBS.RID_FL_OPTIONS.text
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Amahitamo"
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_LOCATION.text
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "Intaho:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Mugaragaza"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Hejuru"
 
 # #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
 # basctl/source\basicide\basidesh.src:RID_BASICIDE_OBJECTBAR.SID_CHOOSE_CONTROLS.text
@@ -2516,183 +4407,320 @@ msgstr ""
 # basctl/source\basicide\tbxctl.src:RID_TBXCONTROLS.RID_TOOLBOX.text
 # #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
 # basctl/source\basicide\tbxctl.src:RID_TBXCONTROLS.text
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Controls"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "Amagenzura"
 
-# sfx2/source\appl\app.src:STR_KEY_BITMAP_PATH.text
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "Icons"
-msgstr "Udushushondanga"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-#, fuzzy
-msgid "New themes can also be installed by dragging them into the window."
-msgstr "Insanganyamatsiko ku i Idirishya"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-#, fuzzy
-msgid "Save Theme"
-msgstr "Kubika"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-#, fuzzy
-msgid "Select theme for the desktop"
-msgstr "kugirango i Ibiro"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-#, fuzzy
-msgid "Short _description:"
-msgstr "Isobanuramiterere"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "Theme Details"
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
 msgstr ""
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "Theme Preferences"
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ntacyo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
 msgstr ""
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-msgid "Theme _Details"
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
 msgstr ""
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-#, fuzzy
-msgid "This theme does not suggest any particular font or background."
-msgstr "OYA Intego- nyuguti Cyangwa Mbuganyuma"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-#, fuzzy
-msgid "This theme suggests a background:"
-msgstr "a Mbuganyuma"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-#, fuzzy
-msgid "This theme suggests a font and a background:"
-msgstr "a Intego- nyuguti Na a Mbuganyuma"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-#, fuzzy
-msgid "This theme suggests a font:"
-msgstr "a Intego- nyuguti"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "Window Border"
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
 msgstr ""
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-msgid "_Go To Theme Folder"
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
 msgstr ""
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-msgid "_Install Theme..."
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
 msgstr ""
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-#, fuzzy
-msgid "_Revert"
-msgstr "Kugaruza"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-#, fuzzy
-msgid "_Save Theme..."
-msgstr "Kubika"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-#, fuzzy
-msgid "_Theme name:"
-msgstr "Izina:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:24
-#, fuzzy
-msgid "theme selection tree"
-msgstr "Ihitamo"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-#, fuzzy
-msgid "Customize the appearance of toolbars and menubars in applications"
-msgstr "i Imigaragarire Bya Imyanya y'ibikoresho Na in Porogaramu"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
 msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-#, fuzzy
-msgid "<b>Behavior and Appearance</b>"
-msgstr "<B Na B"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<B B"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
 
-# dbaccess/source/ui/inc/toolbox.hrc:MID_SBA_QRY_CUT.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-#, fuzzy
-msgid "C_ut"
-msgstr "Gukata"
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-#, fuzzy
-msgid "Icons only"
-msgstr "Udushushondanga Gusa"
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-#, fuzzy
-msgid "Menu and Toolbar Preferences"
-msgstr "Na"
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: panels/user-accounts/cc-add-user-dialog.ui:161
 #, fuzzy
-msgid "New File"
+msgid "Set password now"
+msgstr "Ijambobanga..."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
 msgstr "Idosiye"
 
-# sfx2/sdi\sfxslots.src:SID_OPENDOC.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Gufungura Dosiye"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Bika idosiye"
-
-# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.CB_MENU_ICONS.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
 #, fuzzy
-msgid "Show _icons in menus"
-msgstr "Kugaragaza udushushondanga mu bikubiyemo"
+msgid "Fingerprint Manager"
+msgstr "Umuyobozi w'idirishya"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 #, fuzzy
-msgid "Text below icons"
-msgstr "munsi Udushushondanga"
+msgid "_No"
+msgstr "Ntacyo"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+# svx/source\dialog\rubydialog.src:RID_SVXDLG_RUBY.FT_PREVIEW.text
+#: panels/user-accounts/cc-login-history-dialog.ui:30
 #, fuzzy
-msgid "Text beside icons"
-msgstr "Udushushondanga"
+msgid "Previous"
+msgstr "Igaragazambere:"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-msgid "Text only"
-msgstr "Umwandiko gusa"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+#: panels/user-accounts/cc-password-dialog.ui:4
 #, fuzzy
-msgid "Toolbar _button labels:"
-msgstr "Akabuto Uturango..."
+msgid "Change Password"
+msgstr "Gushyiraho"
 
-# dbaccess/source/ui/inc/toolbox.hrc:MID_SBA_QRY_COPY.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+#: panels/user-accounts/cc-password-dialog.ui:34
 #, fuzzy
-msgid "_Copy"
-msgstr "Gukoporora"
+msgid "Ch_ange"
+msgstr "Gushyiraho"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+#: panels/user-accounts/cc-password-dialog.ui:53
 #, fuzzy
-msgid "_Detachable toolbars"
-msgstr "Imyanya y'ibikoresho"
+msgid "Current Password"
+msgstr "Gushyiraho"
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Ijambobanga..."
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Gushyiraho"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "Ijambobanga..."
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
 
 # #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
 # basctl/source\basicide\basidesh.src:RID_BASICMENU.MN_EDIT.text
@@ -2704,1201 +4732,2572 @@ msgstr "Imyanya y'ibikoresho"
 # basctl/source\basicide\moduldlg.src:RID_TP_MODULS.RID_PB_EDIT.text
 # #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
 # basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_EDIT.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+#: panels/user-accounts/cc-user-panel.ui:171
 #, fuzzy
-msgid "_Edit"
+msgid "Edit"
 msgstr "Guhindura"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-#, fuzzy
-msgid "_Editable menu accelerators"
-msgstr "Ibikubiyemo"
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
 
-# sc/source\ui\src\globstr.src:RID_GLOBSTR.STR_HFCMD_FILE.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-#, fuzzy
-msgid "_File"
-msgstr "IDOSIYE"
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
 
-# basctl/source\basicide\brkdlg.src:RID_BASICIDE_BREAKPOINTDLG.RID_PB_NEW.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-#, fuzzy
-msgid "_New"
-msgstr "Gishya"
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
 
-# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
-# sfx2/source\accel\accel.src:STR_OPEN.text
-# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
-# sfx2/source\dialog\cfg.src:STR_OPEN.text
-# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
-# sfx2/source\dialog\versdlg.src:DLG_VERSIONS.PB_OPEN.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-#, fuzzy
-msgid "_Open"
-msgstr "Gufungura"
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
 
-# dbaccess/source/ui/inc/toolbox.hrc:MID_SBA_QRY_PASTE.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-#, fuzzy
-msgid "_Paste"
-msgstr "Komeka"
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
 
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_BASICIDE_OBJECTBAR.SID_CHOOSE_CONTROLS.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\tbxctl.src:RID_TBXCONTROLS.RID_TOOLBOX.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\tbxctl.src:RID_TBXCONTROLS.text
+#: panels/user-accounts/cc-user-panel.ui:283
 #, fuzzy
-msgid "_Print"
-msgstr "Gucapa"
+msgid "_Parental Controls"
+msgstr "Amagenzura"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+#: panels/user-accounts/cc-user-panel.ui:284
 #, fuzzy
-msgid "_Quit"
-msgstr "Kuvamo"
+msgid "Open the Parental Controls application."
+msgstr "i Mburabuzi Porogaramu Intego- nyuguti"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+# starmath/source\smres.src:RID_TOOLBOXWINDOW.10.RID_MISC_CAT.text
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Ibindi"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+# sfx2/source\toolbox\tbxcust.src:RID_USERDEFBMP.GB_FUNCTION.text
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Utubuto"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+# sfx2/source\toolbox\tbxcust.src:RID_USERDEFBMP.GB_FUNCTION.text
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Utubuto"
+
+# sfx2/source\toolbox\tbxcust.src:RID_USERDEFBMP.GB_FUNCTION.text
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Utubuto"
+
+# sfx2/source\toolbox\tbxcust.src:RID_USERDEFBMP.GB_FUNCTION.text
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Utubuto"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
+# sch/source\core\glob.src:STR_LAYOUT.text
+# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
+# sch/source\ui\dlg\attrib.src:TAB_DATA_POINT.1.TP_LAYOUT.text
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Imigaragarire"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Biri hagati"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+msgid "Windows Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Kingeraho"
 
 # basctl/source\basicide\basidesh.src:RID_STR_SAVE.text
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
 #, fuzzy
 msgid "_Save"
 msgstr "Kubika"
 
-#: ../capplets/windows/gnome-window-properties.c:386
-#, fuzzy, c-format
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Birambuye"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Birambuye"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "Ingerofatizo"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Birambuye"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+# sw/source\ui\app\app.src:STR_STATSTR_LAYOUTINIT.text
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Kwihuza..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Gushyiraho"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\solvrdlg.src:RID_SCDLG_SOLVER.FL_VARIABLES.text
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\tabopdlg.src:RID_SCDLG_TABOP.FL_VARIABLES.text
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Amaboneza mburabuzi"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
 msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
-msgstr "<B Gutangira i Ibyahiswemo Porogaramu kugirango Idirishya Muyobozi B"
-
-#: ../capplets/windows/gnome-window-properties.c:644
-msgid "Control"
-msgstr "Igenzura"
-
-#: ../capplets/windows/gnome-window-properties.c:649
-msgid "Alt"
-msgstr "Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:655
-msgid "Hyper"
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.c:662
-#, fuzzy
-msgid "Super (or \"Windows logo\")"
-msgstr "Cyangwa ikirango"
-
-# the command key
-#: ../capplets/windows/gnome-window-properties.c:669
-msgid "Meta"
-msgstr "Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-#, fuzzy
-msgid "<b>Movement Key</b>"
-msgstr "<B B"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-#, fuzzy
-msgid "<b>Titlebar Action</b>"
-msgstr "<B B"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-#, fuzzy
-msgid "<b>Window Selection</b>"
-msgstr "<B B"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-#, fuzzy
-msgid "To _move a window, press-and-hold this key then grab the window:"
-msgstr "Kwimura a Idirishya Kanda Na iyi Urufunguzo Hanyuma i Idirishya"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
+#: shell/cc-window.ui:164
+msgid "Help"
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.glade.h:6
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: shell/help-overlay.ui:15
 #, fuzzy
-msgid "_Double-click titlebar to perform this action:"
-msgstr "Kanda Kuri iyi Igikorwa"
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Rusange"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:7
+#: shell/help-overlay.ui:20
 #, fuzzy
-msgid "_Interval before raising:"
-msgstr "Mbere"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-#, fuzzy
-msgid "_Raise selected windows after an interval"
-msgstr "Byahiswemo Nyuma Intera"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-#, fuzzy
-msgid "_Select windows when the mouse moves over them"
-msgstr "Ryari: i Imbeba KURI"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-#, fuzzy
-msgid "Set your window properties"
-msgstr "Idirishya Indangakintu..."
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr ""
-
-# starmath/source\smres.src:RID_TOOLBOXWINDOW.10.RID_MISC_CAT.text
-#: ../control-center/control-center-categories.c:257
-msgid "Others"
-msgstr "Ibindi"
-
-#: ../control-center/control-center.c:42
-msgid "Desktop Preferences"
-msgstr ""
-
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr ""
-
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-#, fuzzy
-msgid "The GNOME configuration tool"
-msgstr "Iboneza"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "Igice"
-
-#: ../gnome-settings-daemon/factory.c:36
-#, fuzzy
-msgid "Could not initialize Bonobo"
-msgstr "OYA gutangiza"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
-msgid "Slow Keys Alert"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
-#, fuzzy
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-msgstr ""
-"Hasi i Urufunguzo kugirango 8 amasogonda ni i Iy'ibusamo kugirango i i "
-"Mwandikisho"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
-#, fuzzy
-msgid "Do you want to activate Slow Keys?"
-msgstr "Kuri Kureka bigakora"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
-#, fuzzy
-msgid "Do you want to deactivate Slow Keys?"
-msgstr "Kuri Kubuza gukora"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Sticky Keys Alert"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-#, fuzzy
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-"i Urufunguzo 5 Times in a Urubariro ni i Iy'ibusamo kugirango i i Mwandikisho"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
-#, fuzzy
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-"Utubuto ku Rimwe Cyangwa i Urufunguzo 5 Times in a Urubariro Bidakora i i "
-"Mwandikisho"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
-#, fuzzy
-msgid "Do you want to activate Sticky Keys?"
-msgstr "Kuri Kureka bigakora"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
-#, fuzzy
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr "Kuri Kubuza gukora"
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:107
-#, fuzzy, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr "Kurema i bushyinguro ni Kuri Kwemerera"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
-#, fuzzy, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr "Igikorwa Igikubo"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
-#, fuzzy, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr "Bifatanya Igikubo"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
-#, fuzzy, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr "ni"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
-#, fuzzy, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr "ni"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
-#, fuzzy, c-format
-msgid "It seems that another application already has access to key '%d'."
-msgstr "Porogaramu Kuri Urufunguzo"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
-#, fuzzy, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr "ni in"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
-#, fuzzy, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr "Kuri Gukoresha ni Kuri i Urufunguzo"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
-#, fuzzy, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-"Iboneza a in a in Seriveri Seriveri Na: Seriveri Verisiyo Ibyatanzwe "
-"Icyegeranyo iyi Nka a Gushyiramo Igisubizo Bya Igisubizo Bya"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
-#, fuzzy
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr "3.. 0."
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
-#, fuzzy
-msgid "Do _not show this warning again"
-msgstr "Nta kongera kwerekana iri burira"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
-#, fuzzy
-msgid ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
-msgstr ""
-"Sisitemu Mwandikisho Amagenamiterere Bivuye KIGEZWEHO Mwandikisho "
-"Amagenamiterere Gushyiraho nka Kuri Gukoresha"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
-#, fuzzy
-msgid "Use X settings"
-msgstr "Amagenamiterere"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
-#, fuzzy
-msgid "Use GNOME settings"
-msgstr "Amagenamiterere"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
-#, fuzzy, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
-msgstr "Gukora Komandi: iyi Komandi:"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
-#, fuzzy
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr "Gushyira i Kuri i ni"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
-#, fuzzy, c-format
-msgid "Permissions on the file %s are broken\n"
-msgstr "ku i IDOSIYE"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
-#, fuzzy
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr "Ibirimo i IDOSIYE iyi ni"
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
-#, fuzzy, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr "Ikosa Hejuru i OYA Akazi in iyi Umukoro"
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
-#, fuzzy
-msgid "_Do not show this message again"
-msgstr "OYA Garagaza iyi Ubutumwa"
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:129
-#, fuzzy, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr "Ibirimo Ijwi IDOSIYE Nka Urugero"
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
-#, fuzzy
-msgid "Cannot determine user's home directory"
-msgstr "Ku Ntangiriro bushyinguro"
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
-#, fuzzy, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr "Urufunguzo Gushyiraho Kuri Ubwoko Ikitezwe: Ubwoko"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-#, fuzzy
-msgid "A_vailable files:"
-msgstr "Idosiye"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-#, fuzzy
-msgid "Do _not show this warning again."
-msgstr "Nta kongera kwerekana iri burira"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-#, fuzzy
-msgid "Load modmap files"
-msgstr "Idosiye"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-#, fuzzy
-msgid "Would you like to load the modmap file(s)?"
-msgstr "nka Kuri Ibirimo i IDOSIYE S"
-
-# basctl/source\basicide\basidesh.src:RID_STR_OPEN.text
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-#, fuzzy
-msgid "_Load"
-msgstr "Ibirimo"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-#, fuzzy
-msgid "_Loaded files:"
-msgstr "Idosiye"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr ""
-
-# filter/source\xsltdialog\xmlfilterdialogstrings.src:STR_COLUMN_HEADER_TYPE.text
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "Ubwoko"
-
-#: ../libbackground/applier.c:256
-#, fuzzy
-msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-msgstr "Bya kugirango Imizi Idirishya Cyangwa kugirango Igaragazambere"
-
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr ""
-
-#: ../libbackground/applier.c:264
-#, fuzzy
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr "NIBA ni a Igaragazambere Kuri"
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr ""
-
-#: ../libbackground/applier.c:272
-#, fuzzy
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr "NIBA ni a Igaragazambere Kuri"
-
-# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Mugaragaza"
-
-#: ../libbackground/applier.c:280
-#, fuzzy
-msgid "Screen on which BGApplier is to draw"
-msgstr "ku ni Kuri Gushushanya"
-
-#: ../libgswitchit/gswitchit_config.c:1035
-#, fuzzy, c-format
-msgid "There was an error loading an image: %s"
-msgstr "Ikosa Ifashayobora"
-
-#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
-#, fuzzy
-msgid "The sound file for this event does not exist."
-msgstr "Ijwi IDOSIYE kugirango iyi Icyabaye OYA"
-
-#: ../libsounds/sound-view.c:149
-#, fuzzy
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package\n"
-"for a set of default sounds."
-msgstr ""
-"Ijwi IDOSIYE kugirango iyi Icyabaye OYA Gicurasi Kuri Kwinjiza porogaramu i "
-"a Gushyiraho Bya Mburabuzi Amajwi"
-
-#: ../libsounds/sound-view.c:224
-#, fuzzy, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "IDOSIYE ni OYA a Byemewe IDOSIYE"
-
-# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
-# sfx2/source\dialog\eventdlg.src:TP_CONFIG_EVENT.STR_EVENT.text
-# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
-# sfx2/source\dialog\macropg.src:RID_SFX_TP_MACROASSIGN.STR_EVENT.text
-#: ../libsounds/sound-view.c:289
-msgid "Event"
-msgstr "Icyabaye"
-
-#: ../libsounds/sound-view.c:298
-#, fuzzy
-msgid "Sound File"
-msgstr "Idosiye"
-
-# svx/source\gallery2\galtheme.src:RID_GALLERYSTR_THEME_SOUNDS.text
-#: ../libsounds/sound-view.c:314
-#, fuzzy
-msgid "_Sounds:"
-msgstr "Amajwi"
-
-#: ../libsounds/sound-view.c:328
-#, fuzzy
-msgid "Sound _file:"
-msgstr "IDOSIYE"
-
-#: ../libsounds/sound-view.c:332
-#, fuzzy
-msgid "Select Sound File"
-msgstr "Idosiye"
-
-#: ../libsounds/sound-view.c:356
-#, fuzzy
-msgid "_Play"
-msgstr "Gukina"
-
-# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
-# padmin/source\rtsetup.src:RID_RTS_FONTSUBSTPAGE.RID_RTS_FS_REMOVE_BTN.text
-# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
-# padmin/source\rtsetup.src:RID_RTS_COMMANDPAGE.RID_RTS_CMD_BTN_REMOVE.text
-#: ../libsounds/sound-view.c:366
-#, fuzzy
-msgid "_Remove"
-msgstr "Gukuraho"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, fuzzy, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "Muyobozi OYA a Iboneza"
-
-# sc/source\ui\formdlg\formdlgs.src:RID_SCDLG_FORMULA.RB_REF.quickhelptext
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Kugira kinini"
-
-# vcl/source\src\helptext.src:SV_HELPTEXT_ROLLUP.text
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Kuzamura"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-#, fuzzy
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr "NIBYO i kugirango Umwandiko Byuzuye Na Umwandiko in"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-#, fuzzy
-msgid "Sync text/plain and text/* handlers"
-msgstr "Umwandiko Byuzuye Na Umwandiko"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-#, fuzzy
-msgid "Brightness down"
-msgstr "Hasi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-#, fuzzy
-msgid "Brightness down's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-#, fuzzy
-msgid "Brightness up"
-msgstr "Hejuru"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-#, fuzzy
-msgid "Brightness up's shortcut."
-msgstr "Iy'ibusamo"
-
-# #-#-#-#-#  officecfg.pot (PACKAGE VERSION)  #-#-#-#-#
-# officecfg/registry\data\org\openoffice\Office\DataAccess.xcu:..DataAccess.DriverSettings.com.sun.star.comp.sdbc.MozabDriver.ColumnAliases.PrimaryEmail.text
-# #-#-#-#-#  officecfg.pot (PACKAGE VERSION)  #-#-#-#-#
-# officecfg/registry\schema\org\openoffice\Office\Writer.xcs:....BusinessCard.PrivateAddress.Email.text
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "E-mail"
-msgstr "Imeli"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-#, fuzzy
-msgid "E-mail's shortcut."
-msgstr "E Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Eject"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-#, fuzzy
-msgid "Eject's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-#, fuzzy
-msgid "Home folder"
-msgstr "Ububiko"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-#, fuzzy
-msgid "Home folder's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-#, fuzzy
-msgid "Launch help browser"
-msgstr "Ifashayobora Mucukumbuzi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-#, fuzzy
-msgid "Launch help browser's shortcut."
-msgstr "Ifashayobora Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-#, fuzzy
-msgid "Launch web browser"
-msgstr "Urubuga Mucukumbuzi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-#, fuzzy
-msgid "Launch web browser's shortcut."
-msgstr "Urubuga Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-#, fuzzy
-msgid "Lock screen"
-msgstr "Mugaragaza"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-#, fuzzy
-msgid "Lock screen's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-#, fuzzy
-msgid "Log out"
+msgctxt "shortcut window"
+msgid "Quit"
 msgstr "Kuvamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-#, fuzzy
-msgid "Log out's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-#, fuzzy
-msgid "Next track key's shortcut."
-msgstr "Iy'ibusamo"
-
-# 4630
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Pause"
-msgstr "akaruhuko"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-#, fuzzy
-msgid "Pause key's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-#, fuzzy
-msgid "Play (or play/pause)"
-msgstr "Cyangwa Gukina Akaruhuko..."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-#, fuzzy
-msgid "Play (or play/pause) key's shortcut."
-msgstr "Cyangwa Gukina Akaruhuko... Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-#, fuzzy
-msgid "Previous track key's shortcut."
-msgstr "Iy'ibusamo"
 
 # #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
 # offmgr/source\offapp\dialog\inetdlg.src:RID_OFADLG_INTERNET.1.RID_SVXPAGE_INET_SEARCH.text
 # #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
 # offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_INET_DLG.3.text
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Search"
 msgstr "Gushaka"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-#, fuzzy
-msgid "Search's shortcut."
-msgstr "Iy'ibusamo"
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 #, fuzzy
-msgid "Skip to next track"
-msgstr "Kuri Komeza>>"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-#, fuzzy
-msgid "Skip to previous track"
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
 msgstr "Kuri Ibanjirije"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-msgid "Sleep"
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-#, fuzzy
-msgid "Sleep's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-#, fuzzy
-msgid "Stop playback key"
-msgstr "Urufunguzo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-#, fuzzy
-msgid "Stop playback key's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
-#, fuzzy
-msgid "Volume down"
-msgstr "Hasi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-#, fuzzy
-msgid "Volume down's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-#, fuzzy
-msgid "Volume mute"
-msgstr "Mute"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-#, fuzzy
-msgid "Volume mute's shortcut"
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
-#, fuzzy
-msgid "Volume step"
-msgstr "Intera"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-#, fuzzy
-msgid "Volume step as percentage of volume."
-msgstr "Intera Nka Ijanisha Bya Igice"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
-#, fuzzy
-msgid "Volume up"
-msgstr "Hejuru"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
-#, fuzzy
-msgid "Volume up's shortcut."
-msgstr "Iy'ibusamo"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
-#, fuzzy
-msgid "Display a dialog when there are errors running the screensaver"
-msgstr "a Ikiganiro Ryari: Amakosa"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-#, fuzzy
-msgid "Run screensaver at login"
-msgstr "ku Ifashayinjira"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
-#, fuzzy
-msgid "Start screensaver"
-msgstr "Gutangira"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-#, fuzzy
+#: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
-msgstr ""
-"A Bya Inyandikoporogaramu Kuri Gukoresha i Mwandikisho Leta ni kugirango"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-#, fuzzy
-msgid "A list of modmap files available in the $HOME directory."
-msgstr "A Urutonde Bya Idosiye Bihari in i bushyinguro"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-#, fuzzy
-msgid "Default group, assigned on window creation"
-msgstr "Itsinda ku Idirishya"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-#, fuzzy
-msgid "Keep and manage separate group per window"
-msgstr "Na kuyobora Itsinda Idirishya"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
-msgid "Keyboard Update Handlers"
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
-#, fuzzy
-msgid "Keyboard layout"
-msgstr "Imigaragarire"
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
-#, fuzzy
-msgid "Keyboard model"
-msgstr "Urugero"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
-#, fuzzy
-msgid "Keyboard options"
-msgstr "Amahitamo"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
-#, fuzzy
+#: shell/org.gnome.Settings.gschema.xml:14
 msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
-msgstr "Amagenamiterere in Bivuye i Sisitemu"
+"Whether Settings should show a warning when running a development build."
+msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-#, fuzzy
-msgid "Save/restore indicators together with layout groups"
-msgstr "Kubika Kugarura Na: Imigaragarire Amatsinda"
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-#, fuzzy
-msgid "Show layout names instead of group names"
-msgstr "Imigaragarire Amazina Bya Itsinda Amazina"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-#, fuzzy
+#: shell/org.gnome.Settings.gschema.xml:21
 msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
-msgstr ""
-"Imigaragarire Amazina Bya Itsinda Amazina kugirango Uburyo Bya Igikubo "
-"Imigaragarire"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-#, fuzzy
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr "i Byahinduwe Iburira Ubutumwa"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
 #, fuzzy
-msgid "keyboard layout"
-msgstr "Mwandikisho Imigaragarire"
+#~ msgid "The type of alert"
+#~ msgstr "Ubwoko Bya"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
 #, fuzzy
-msgid "keyboard model"
-msgstr "Mwandikisho Urugero"
+#~ msgid "About Me"
+#~ msgstr "/Bigyanye"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-#, fuzzy
-msgid "modmap file list"
-msgstr "IDOSIYE Urutonde"
-
-#: ../typing-break/drw-break-window.c:212
-#, fuzzy
-msgid "_Postpone break"
-msgstr "itandukanya"
-
-#: ../typing-break/drw-break-window.c:259
-#, fuzzy
-msgid "Take a break!"
-msgstr "a itandukanya"
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:141
-msgid "/_Preferences"
-msgstr ""
-
-#: ../typing-break/drwright.c:142
-#, fuzzy
-msgid "/_About"
-msgstr "/Bigyanye"
-
-#: ../typing-break/drwright.c:144
-#, fuzzy
-msgid "/_Take a Break"
-msgstr "/a"
-
-#: ../typing-break/drwright.c:495
 #, fuzzy, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "%dUMUNOTA i Komeza>> itandukanya"
+#~ msgid "About %s"
+#~ msgstr "/Bigyanye"
 
-#: ../typing-break/drwright.c:499
+#~ msgid " "
+#~ msgstr " "
+
 #, fuzzy
-msgid "Less than one minute until the next break"
-msgstr "UMUNOTA i Komeza>> itandukanya"
+#~ msgid "<b>Home</b>"
+#~ msgstr "<B B"
 
-#: ../typing-break/drwright.c:587
-#, fuzzy, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
-msgstr ""
-"Kuri Hejuru i Kwandika: itandukanya Indangakintu... Ikiganiro Na: i Ikosa"
-
-#: ../typing-break/drwright.c:635
-msgid "About GNOME Typing Monitor"
-msgstr ""
-
-#: ../typing-break/drwright.c:659
 #, fuzzy
-msgid "A computer break reminder."
-msgstr "A itandukanya Mwibutsa"
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<B B"
 
-#: ../typing-break/drwright.c:660
 #, fuzzy
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
-msgstr "ku"
+#~ msgid "<b>Job</b>"
+#~ msgstr "<B B"
 
-#: ../typing-break/drwright.c:661
 #, fuzzy
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Kyongewe ku"
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<B B"
 
-#: ../typing-break/drwright.c:837
 #, fuzzy
-msgid "Break reminder"
-msgstr "Mwibutsa"
+#~ msgid "<b>Web</b>"
+#~ msgstr "<B B"
 
-#: ../typing-break/main.c:93
 #, fuzzy
-msgid "The typing monitor is already running."
-msgstr "Kwandika: ni"
-
-#: ../typing-break/main.c:106
-#, fuzzy
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
-msgstr ""
-"Kwandika: i Ikimenyetso Ubuso Kuri Kugaragaza Ibisobanuro Kuri a Ikimenyetso "
-"Ubuso ku Kongeramo ku Iburyo: ku Na Kuri Na"
-
-#: ../vfs-methods/fontilus/font-view.c:115
-#, fuzzy
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "Igihogo KURI i"
-
-# sc/source\ui\dbgui\pvfundlg.src:RID_SCDLG_PIVOTSUBT.FT_NAMELABEL.text
-#: ../vfs-methods/fontilus/font-view.c:276
-msgid "Name:"
-msgstr "Izina:"
+#~ msgid "<b>Work</b>"
+#~ msgstr "<B B"
 
 # sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "Imisusire"
+#, fuzzy
+#~ msgid "C_ity:"
+#~ msgstr "Imisusire"
 
-# sfx2/source\dialog\dinfdlg.src:TP_DOCINFODOC.FT_FILE_TYP.text
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "Ubwoko"
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_COMMAND.text
+#, fuzzy
+#~ msgid "C_ompany:"
+#~ msgstr "Komandi:"
+
+# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
+#, fuzzy
+#~ msgid "Ci_ty:"
+#~ msgstr "Imisusire"
+
+#, fuzzy
+#~ msgid "Co_untry:"
+#~ msgstr "Igenzura"
+
+#, fuzzy
+#~ msgid "Cou_ntry:"
+#~ msgstr "Igenzura"
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "Ijambobanga..."
+
+#, fuzzy
+#~ msgid "_Home page:"
+#~ msgstr "Izina:"
+
+# basctl/source\basicide\moduldlg.src:RID_DLG_NEWLIB.RID_FT_NEWLIB.text
+#, fuzzy
+#~ msgid "_Home:"
+#~ msgstr "Izina:"
+
+#, fuzzy
+#~ msgid "_Manager:"
+#~ msgstr "Umuyobozi w'idirishya"
+
+#, fuzzy
+#~ msgid "_Profession:"
+#~ msgstr "Verisiyo:"
+
+# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
+#, fuzzy
+#~ msgid "_Title:"
+#~ msgstr "Imisusire"
+
+#, fuzzy
+#~ msgid "<b>Support</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<Gitoya i B B Kuri iyi Igenamiterere OYA INGARUKA Komeza>> LOG in i Gitoya"
+
+#, fuzzy
+#~ msgid "Close and _Log Out"
+#~ msgstr "Funga Na"
+
+#, fuzzy
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Gutangira buri Igihe LOG in"
+
+#, fuzzy
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr "Gushigikira kugirango ku Ifashayinjira"
+
+#, fuzzy
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "ni Bihari ku Sisitemu in Itondekanya Kuri Kubona ku Mugaragaza "
+#~ "Mwandikisho Gushigikira Na i kugirango Na"
+
+#, fuzzy
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Byose Bihari ku Sisitemu in Itondekanya Kuri Kubona ku Mugaragaza "
+#~ "Mwandikisho Gushigikira"
+
+#, fuzzy
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+#~ msgstr "Byose Bihari ku Sisitemu kugirango Na"
+
+#, fuzzy, c-format
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "Ikosa i Imbeba Ibyahiswemo Ikiganiro"
+
+#, fuzzy, c-format
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Kuri Kuzana Amagenamiterere Bivuye IDOSIYE"
+
+#, fuzzy
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Idosiye"
+
+#, fuzzy
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Mwandikisho Ubushobozi bwo gukoreshwa Ibyahiswemo"
+
+#, fuzzy
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Sisitemu OYA Kuri i Umugereka Mwandikisho Ubushobozi bwo gukoreshwa "
+#~ "Ibiranga OYA"
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#, fuzzy
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Features</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<B B"
+
+#~ msgid "Basic"
+#~ msgstr "By'ibanze"
+
+#, fuzzy
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr "Ryari: Ibiranga ku Cyangwa Bidakora Bivuye Mwandikisho"
+
+#, fuzzy
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "Ryari: ni ku Na Ryari: ni Bidakora"
+
+#, fuzzy
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "hagati Na Mweretsi Igenda"
+
+# framework/source\classes\fltdlg.src:DLG_FILTER_SELECT.FL_FILTER.text
+#~ msgid "Filters"
+#~ msgstr "Muyunguruzi"
+
+#, fuzzy
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr "Byose Bya i Urufunguzo NIBA muri a Ukoresha: Igihe Bya Igihe"
+
+#, fuzzy
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Mweretsi Umuvuduko"
+
+#, fuzzy
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr "Kwemera Utubuto Nyuma Na kugirango a Ukoresha: Igiteranyo Bya Igihe"
+
+#, fuzzy
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr "Igikubo Urufunguzo Kanda Ibikorwa: ku Utubuto in"
+
+#, fuzzy
+#~ msgid "S_peed:"
+#~ msgstr "Umuvuduko"
+
+#, fuzzy
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Kuri Kuri Kinini Umuvuduko"
+
+#, fuzzy
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "i Bikurikije umubare a Imbeba Igenzura"
+
+#, fuzzy
+#~ msgid "_Disable if unused for:"
+#~ msgstr "NIBA Kidakoreshwa kugirango"
+
+#, fuzzy
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "Mwandikisho Ubushobozi bwo gukoreshwa Ibiranga"
+
+#, fuzzy
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "Kwemera Utubuto kugirango"
+
+#, fuzzy
+#~ msgid "_Type to test settings:"
+#~ msgstr "Kuri Igerageza Amagenamiterere"
+
+# sc/source\ui\miscdlgs\acredlin.src:RID_SCDLG_CHANGES.STR_ACCEPTED.text
+#, fuzzy
+#~ msgid "_accepted"
+#~ msgstr "Byemewe"
+
+# sc/source\ui\miscdlgs\acredlin.src:RID_SCDLG_CHANGES.STR_REJECTED.text
+#, fuzzy
+#~ msgid "_rejected"
+#~ msgstr "Byanzwe"
+
+#, fuzzy
+#~ msgid "characters/second"
+#~ msgstr "Inyuguti ISEGONDA"
+
+#, fuzzy
+#~ msgid "pixels/second"
+#~ msgstr "Pigiseli ISEGONDA"
+
+#, fuzzy
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<B B"
+
+# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
+#, fuzzy
+#~ msgid "_Style:"
+#~ msgstr "Imisusire"
+
+#, fuzzy, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Ikosa Ifashayobora"
+
+# #-#-#-#-#  wizards.pot (PACKAGE VERSION)  #-#-#-#-#
+# wizards/source\formwizard\dbwizres.src:RID_DB_FORM_WIZARD_START_+_56.text
+# #-#-#-#-#  wizards.pot (PACKAGE VERSION)  #-#-#-#-#
+# wizards/source\webwizard\webwizar.src:WEBDIALOG_+_7.text
+#, fuzzy
+#~ msgid "Tiled"
+#~ msgstr "Cy'udukaro"
+
+#, fuzzy
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr "g."
+
+#, fuzzy, c-format
+#~ msgid "Unable to load capplet stock icon '%s'\n"
+#~ msgstr "Kuri Ibirimo Agashushondanga"
+
+#, fuzzy
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Gukurikiza Amagenamiterere Na Kuvamo"
+
+#, fuzzy
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Na Amagenamiterere"
+
+#, fuzzy
+#~ msgid "URI currently transferring from"
+#~ msgstr "Bivuye"
+
+#, fuzzy
+#~ msgid "URI currently transferring to"
+#~ msgstr "Kuri"
+
+#, fuzzy
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Bya"
+
+#, fuzzy
+#~ msgid "Current URI index"
+#~ msgstr "Umubarendanga"
+
+#, fuzzy
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Umubarendanga Bivuye 1."
+
+#, fuzzy
+#~ msgid "Total number of URIs"
+#~ msgstr "Umubare Bya"
+
+# 3348
+#~ msgid "Key"
+#~ msgstr "Urufunguzo"
+
+#, fuzzy
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Urufunguzo Kuri iyi indangakintu Muhinduzi ni"
+
+#, fuzzy
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "iyi Ryari: i Agaciro Na: Urufunguzo Byahinduwe"
+
+#, fuzzy
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Guhindura>> Gushyiraho Ibyatanzwe Kuri Kuri i Umukiriya ku Gukurikiza"
+
+#, fuzzy
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Kuri"
+
+#, fuzzy
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "Kuri Byasohowe Ryari: Ibyatanzwe Kuri Bivuye Kuri i"
+
+#, fuzzy
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Bivuye"
+
+#, fuzzy
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "Kuri Byasohowe Ryari: Ibyatanzwe Kuri Kuri Bivuye i"
+
+#, fuzzy
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Amagenzura i indangakintu a"
+
+#, fuzzy
+#~ msgid "Property editor object data"
+#~ msgstr "Muhinduzi Igikoresho Ibyatanzwe"
+
+#, fuzzy
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Kugena Ibyatanzwe Bya ngombwa ku i indangakintu Muhinduzi"
+
+#, fuzzy
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Muhinduzi Ibyatanzwe"
+
+#, fuzzy
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Kuri Byasohowe Ryari: indangakintu Muhinduzi Igikoresho Ibyatanzwe ni Kuri"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Gushaka i IDOSIYE Ubwoko Na Cyangwa Guhitamo a Mbuganyuma() y'Ishusho"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Kuri Gufungura i IDOSIYE a Bya() y'Ishusho ni OYA Guhitamo a() y'Ishusho"
+
+#, fuzzy
+#~ msgid "Please select an image."
+#~ msgstr "Guhitamo Ishusho"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#, fuzzy
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape"
+
+#, fuzzy
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla"
+
+#, fuzzy
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "a Izina: Na a Komandi: kugirango iyi Muhinduzi"
+
+#, fuzzy
+#~ msgid "C_ustom"
+#~ msgstr "Guhanga"
+
+#, fuzzy
+#~ msgid "C_ustom:"
+#~ msgstr "Kunoza"
+
+#, fuzzy
+#~ msgid "Can open _URIs"
+#~ msgstr "Gufungura"
+
+#, fuzzy
+#~ msgid "Can open multiple _files"
+#~ msgstr "Gufungura Igikubo Idosiye"
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_COMMAND.text
+#, fuzzy
+#~ msgid "Co_mmand:"
+#~ msgstr "Komandi:"
+
+#, fuzzy
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Kugena"
+
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_POPUP_TABBAR.SID_BASICIDE_DELETECURRENT.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\brkdlg.src:RID_BASICIDE_BREAKPOINTDLG.RID_PB_DEL.text
+#~ msgid "Delete"
+#~ msgstr "Gusiba"
+
+# dbaccess/source/ui/inc/toolbox.hrc:MID_DBUI_QUERY_EDIT_JOINCONNECTION.text
+#~ msgid "Edit..."
+#~ msgstr "Kwandika..."
+
+#, fuzzy
+#~ msgid "Run in a _terminal"
+#~ msgstr "in a"
+
+#, fuzzy
+#~ msgid "Run in a t_erminal"
+#~ msgstr "in a"
+
+#, fuzzy
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "i Idirishya Muyobozi Kuri kanda Gukurikiza UMUVUMBA i Na a kugirango Kuri "
+#~ "Akazi"
+
+#~ msgid "Text Editor"
+#~ msgstr "Umuhinduzi w'inyandiko"
+
+#, fuzzy
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "Netscape"
+
+#, fuzzy
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr ""
+#~ "iyi Muhinduzi Kuri Gufungura Umwandiko Idosiye in i IDOSIYE Muyobozi"
+
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_POPUP_BRKPROPS.RID_BRKPROPS.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_POPUP_DLGED.SID_SHOW_PROPERTYBROWSER.text
+#, fuzzy
+#~ msgid "_Properties..."
+#~ msgstr "Indangakintu..."
+
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\menue.src:SCCFG_PLUGINMENU.SUBMENU_EDIT.SUBMENU_EDIT_TABLE.SID_SELECT_TABLES.text
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\menue.src:SCCFG_MENUBAR.SUBMENU_EDIT.SUBMENU_EDIT_TABLE.SID_SELECT_TABLES.text
+#, fuzzy
+#~ msgid "_Select:"
+#~ msgstr "Guhitamo..."
+
+#, fuzzy
+#~ msgid "Change screen resolution"
+#~ msgstr "Mugaragaza Imikemurire"
+
+#, fuzzy, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "Mburabuzi kugirango iyi"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "i Gishya Amagenamiterere in ISEGONDA i Ibanjirije Amagenamiterere"
+
+#, fuzzy
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Kuri Gumana: iyi Imikemurire"
+
+#, fuzzy
+#~ msgid "Use _previous resolution"
+#~ msgstr "Ibanjirije Imikemurire"
+
+#, fuzzy
+#~ msgid "_Keep resolution"
+#~ msgstr "Imikemurire"
+
+#, fuzzy
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "OYA Gushigikira i Umugereka Imikemurire Amahinduka Kuri i Kugaragaza "
+#~ "Ingano OYA Bihari"
+
+#, fuzzy
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Verisiyo Bya i Umugereka ni Na: iyi Porogaramu Amahinduka Kuri i "
+#~ "Kugaragaza Ingano OYA Bihari"
+
+#~ msgid "Font"
+#~ msgstr "Intego-nyuguti"
+
+#, fuzzy
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Imyandikire kugirango i Ibiro"
+
+#, fuzzy
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<B Itondekanya B"
+
+#, fuzzy
+#~ msgid "Best _shapes"
+#~ msgstr "Imisusire- shusho"
+
+#, fuzzy
+#~ msgid "Best co_ntrast"
+#~ msgstr "Inyuranyamigaragarire"
+
+#, fuzzy
+#~ msgid "D_etails..."
+#~ msgstr "Isesengurabyose..."
+
+#, fuzzy
+#~ msgid "Go _to font folder"
+#~ msgstr "Kuri Intego- nyuguti Ububiko"
+
+# goodies/source\filter.vcl\eps\dlgeps.src:DLG_EXPORT_EPS.RB_GRAYSCALE.text
+#, fuzzy
+#~ msgid "Gra_yscale"
+#~ msgstr "Ingano y'ubwijime"
+
+#, fuzzy
+#~ msgid "N_one"
+#~ msgstr "Ntacyo"
+
+# officecfg/registry\schema\org\openoffice\Office\Common.xcs:....Filter.Graphic.Export.BMP.Resolution.text
+#, fuzzy
+#~ msgid "R_esolution:"
+#~ msgstr "Imikemurire"
+
+#, fuzzy
+#~ msgid "_Desktop font:"
+#~ msgstr "Intego- nyuguti"
+
+# officecfg/registry\schema\org\openoffice\Office\Math.xcs:....FontFormat.Weight..6.text
+#, fuzzy
+#~ msgid "_Medium"
+#~ msgstr "biringaniye"
+
+# 3916
+#, fuzzy
+#~ msgid "_Monochrome"
+#~ msgstr "bararimwe"
+
+# svx/source\dialog\tabarea.src:RID_SVXPAGE_COLOR.LB_COLORMODEL.1.text
+#, fuzzy
+#~ msgid "_RGB"
+#~ msgstr "UmutukuIcyatsiUbururu"
+
+#, fuzzy
+#~ msgid "_Terminal font:"
+#~ msgstr "Intego- nyuguti"
+
+#, fuzzy
+#~ msgid "_Window title font:"
+#~ msgstr "Umutwe Intego- nyuguti"
+
+#, fuzzy
+#~ msgid "dots per inch"
+#~ msgstr "Utudomo Inci"
+
+#, fuzzy
+#~ msgid "Font may be too large"
+#~ msgstr "Gicurasi Binini"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Intego- nyuguti Byahiswemo ni Akadomo Binini Na Gicurasi Ubwoko Kuri "
+#~ "Gukoresha i ni Guhitamo a Ingano Gitoya"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Intego- nyuguti Byahiswemo ni Akadomo Binini Na Gicurasi Ubwoko Kuri "
+#~ "Gukoresha i ni Guhitamo a Gitoya Intego- nyuguti"
+
+#, fuzzy
+#~ msgid "The type of accelerator."
+#~ msgstr "Ubwoko Bya"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr "Iy'ibusamo ni kugirango"
+
+#, fuzzy, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "Igenamiterere Gishya in Iboneza Ububikoshingiro"
+
+#, fuzzy, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "in Iboneza Ububikoshingiro"
+
+#, fuzzy
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "Guhindura a Iy'ibusamo Urufunguzo Kanda ku i Urubariro Na Ubwoko a Gishya "
+#~ "Cyangwa Kanda Gusiba usubira inyuma Kuri Gusiba"
+
+#, fuzzy
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Iy'ibusamo Utubuto Kuri Amabwiriza"
+
+# filter/source\xsltdialog\xmlfilterdialogstrings.src:STR_UNKNOWN_APPLICATION.text
+#~ msgid "Unknown"
+#~ msgstr "Kitazwi"
+
+#, fuzzy, c-format
+#~ msgid "There was an error launching the keyboard capplet : %s"
+#~ msgstr "Ikosa i Mwandikisho"
+
+#, fuzzy
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "Gukurikiza Amagenamiterere Na Kuvamo Bihuye neza NONEAHA ku"
+
+#, fuzzy
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Gutangira i Ipaji Na: i Kwandika: itandukanya Amagenamiterere"
+
+# #-#-#-#-#  svx.pot (PACKAGE VERSION)  #-#-#-#-#
+# svx/source\dialog\ctredlin.src:SID_REDLIN_FILTER_PAGE.BTN_REF.text
+# #-#-#-#-#  svx.pot (PACKAGE VERSION)  #-#-#-#-#
+# svx/source\form\fmsearch.src:RID_SVXDLG_SEARCHFORM.PB_APPROXSETTINGS.text
+# #-#-#-#-#  svx.pot (PACKAGE VERSION)  #-#-#-#-#
+# svx/source\form\fmsearch.src:RID_SVXDLG_SEARCHFORM.PB_SOUNDSLIKESETTINGS.text
+#~ msgid "..."
+#~ msgstr "..."
+
+#, fuzzy
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<B Mugaragaza Kuri Kwandika: itandukanya B"
+
+#, fuzzy
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<Gitoya i i Gitoya"
+
+#, fuzzy
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<Gitoya i i Gitoya"
+
+#, fuzzy
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<Gitoya i i Gitoya"
+
+#, fuzzy
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<Gitoya i i Gitoya"
+
+#, fuzzy
+#~ msgid "A_vailable layouts:"
+#~ msgstr "Imigaragarire"
+
+#, fuzzy
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Bya Amataruka"
+
+#, fuzzy
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "NIBA Amataruka Kuri"
+
+#, fuzzy
+#~ msgid "Choose A Keyboard Model"
+#~ msgstr "A"
+
+#, fuzzy
+#~ msgid "Choose A Layout"
+#~ msgstr "A"
+
+#, fuzzy
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Igihebimara Bya i itandukanya Ryari: Kwandika: ni"
+
+#, fuzzy
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Igihebimara Bya Akazi Mbere a itandukanya"
+
+#, fuzzy
+#~ msgid "Keyboard _model:"
+#~ msgstr "Urugero"
+
+# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
+# sch/source\core\glob.src:STR_LAYOUT.text
+# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
+# sch/source\ui\dlg\attrib.src:TAB_DATA_POINT.1.TP_LAYOUT.text
+#~ msgid "Layouts"
+#~ msgstr "Imigaragarire"
+
+#, fuzzy
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Mugaragaza Nyuma a Igihe- ngombwa Kuri Ifashayobora Mwandikisho Gukoresha"
+
+#, fuzzy
+#~ msgid "Separate _group for each window"
+#~ msgstr "Itsinda kugirango Idirishya"
+
+# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_GENERAL_OPTIONS.13.text
+#, fuzzy
+#~ msgid "_Accessibility..."
+#~ msgstr "Ubushobozi bwo gukoreshwa"
+
+#, fuzzy
+#~ msgid "_Break interval lasts:"
+#~ msgstr "Intera"
+
+#, fuzzy
+#~ msgid "_Models:"
+#~ msgstr "Ingerofatizo"
+
+#, fuzzy
+#~ msgid "_Selected layouts:"
+#~ msgstr "Imigaragarire"
+
+#, fuzzy
+#~ msgid "_Work interval lasts:"
+#~ msgstr "Intera"
+
+#, fuzzy
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Mwandikisho Ibyahiswemo"
+
+#, fuzzy
+#~ msgid "The default cursor that ships with X"
+#~ msgstr "Mburabuzi indanga Na:"
+
+#, fuzzy
+#~ msgid "The default cursor inverted"
+#~ msgstr "Mburabuzi indanga"
+
+#, fuzzy
+#~ msgid "Large version of normal cursor"
+#~ msgstr "Verisiyo Bya Bisanzwe indanga"
+
+#, fuzzy
+#~ msgid "Large version of white cursor"
+#~ msgstr "Verisiyo Bya Umweru indanga"
+
+#, fuzzy
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<B Na B"
+
+#, fuzzy
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i i"
+
+#, fuzzy
+#~ msgid "<i>High</i>"
+#~ msgstr "<i i"
+
+#, fuzzy
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i i"
+
+#, fuzzy
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i i"
+
+#, fuzzy
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i i"
+
+#, fuzzy
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i i"
+
+#, fuzzy
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "i Mweretsi Ryari: Kanda"
+
+#, fuzzy
+#~ msgid "_Left-handed mouse"
+#~ msgstr "Imbeba"
+
+#, fuzzy
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Imbeba Ibyahiswemo"
+
+#, fuzzy
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "urusobe Porogisi Ibyahiswemo"
+
+#, fuzzy
+#~ msgid "<b>D_irect internet connection</b>"
+#~ msgstr "<B Interineti Ukwihuza B"
+
+#, fuzzy
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<B Porogisi Iboneza B"
+
+#, fuzzy
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<B Porogisi Iboneza B"
+
+#~ msgid "Port:"
+#~ msgstr "Impagikiro:"
+
+#, fuzzy
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "Porogisi"
+
+#, fuzzy
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Ijwi Na Amajwi Na: Ibyabaye"
+
+#, fuzzy
+#~ msgid "E_nable sound server startup"
+#~ msgstr "Ijwi Seriveri"
+
+#, fuzzy
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Idirishya"
+
+#, fuzzy
+#~ msgid "_Sounds for events"
+#~ msgstr "kugirango Ibyabaye"
+
+#, fuzzy
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Insanganyamatsiko Byabonetse ku Sisitemu Ikiganiro Cyangwa i "
+#~ "Insanganyamatsiko"
+
+#, fuzzy
+#~ msgid "This theme is not in a supported format."
+#~ msgstr "ni OYA in a Imiterere"
+
+#, fuzzy
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Kuri Kurema By'igihe gito bushyinguro"
+
+#, fuzzy
+#~ msgid ""
+#~ "Can not install theme. \n"
+#~ "The bzip2 utility is not installed."
+#~ msgstr "OYA Kwinjiza porogaramu ni OYA"
+
+#, fuzzy
+#~ msgid ""
+#~ "Can not install themes. \n"
+#~ "The gzip utility is not installed."
+#~ msgstr "OYA Kwinjiza porogaramu Insanganyamatsiko ni OYA"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Icon Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr "Guhitamo in i Birambuye"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Windows Border Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr "Guhitamo in i Birambuye"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Controls Theme %s correctly installed.\n"
+#~ "You can select it in the theme details."
+#~ msgstr "Guhitamo in i Birambuye"
+
+#, fuzzy
+#~ msgid "The theme is an engine. You need to compile the theme."
+#~ msgstr "ni Kuri Gukusanya i"
+
+#, fuzzy
+#~ msgid "The file format is invalid"
+#~ msgstr "IDOSIYE Imiterere ni Sibyo"
+
+#, fuzzy
+#~ msgid "No theme file location specified to install"
+#~ msgstr "IDOSIYE Ahantu Kuri Kwinjiza porogaramu"
+
+#, fuzzy
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "IDOSIYE Ahantu Kuri Kwinjiza porogaramu ni Sibyo"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr "Uruhushya Kuri Kwinjiza porogaramu i in"
+
+#, fuzzy
+#~ msgid "The file format is invalid."
+#~ msgstr "IDOSIYE Imiterere ni Sibyo"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr "%sni i Inzira i Idosiye OYA Byahiswemo Nka i Inkomoko Ahantu"
+
+#, fuzzy
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "The tar program is not installed on your system."
+#~ msgstr "Kwinjiza porogaramu Porogaramu ni OYA ku Sisitemu"
+
+#, fuzzy
+#~ msgid "Custom theme"
+#~ msgstr "Kugena"
+
+#, fuzzy
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "Kubika iyi ku i Kubika Akabuto"
+
+#, fuzzy
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr "Mburabuzi OYA Byabonetse ku Sisitemu Cyangwa ni"
+
+#, fuzzy
+#~ msgid "Theme name must be present"
+#~ msgstr "Izina:"
+
+#, fuzzy
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "nka Kuri Gusimbura"
+
+#, fuzzy
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Insanganyamatsiko kugirango Bya i Ibiro"
+
+#, fuzzy
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<Ingano Kinini Uburemere UTSINDAGIYE a"
+
+#, fuzzy
+#~ msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+#~ msgstr "<Ingano Kinini Uburemere UTSINDAGIYE Kubika Kuri"
+
+# sfx2/source\appl\app.src:STR_KEY_BITMAP_PATH.text
+#~ msgid "Icons"
+#~ msgstr "Udushushondanga"
+
+#, fuzzy
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr "Insanganyamatsiko ku i Idirishya"
+
+#, fuzzy
+#~ msgid "Save Theme"
+#~ msgstr "Kubika"
+
+#, fuzzy
+#~ msgid "Select theme for the desktop"
+#~ msgstr "kugirango i Ibiro"
+
+#, fuzzy
+#~ msgid "Short _description:"
+#~ msgstr "Isobanuramiterere"
+
+#, fuzzy
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "OYA Intego- nyuguti Cyangwa Mbuganyuma"
+
+#, fuzzy
+#~ msgid "This theme suggests a background:"
+#~ msgstr "a Mbuganyuma"
+
+#, fuzzy
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "a Intego- nyuguti Na a Mbuganyuma"
+
+#, fuzzy
+#~ msgid "This theme suggests a font:"
+#~ msgstr "a Intego- nyuguti"
+
+#, fuzzy
+#~ msgid "_Revert"
+#~ msgstr "Kugaruza"
+
+#, fuzzy
+#~ msgid "_Save Theme..."
+#~ msgstr "Kubika"
+
+#, fuzzy
+#~ msgid "theme selection tree"
+#~ msgstr "Ihitamo"
+
+#, fuzzy
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "i Imigaragarire Bya Imyanya y'ibikoresho Na in Porogaramu"
+
+#, fuzzy
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<B Na B"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<B B"
+
+# dbaccess/source/ui/inc/toolbox.hrc:MID_SBA_QRY_CUT.text
+#, fuzzy
+#~ msgid "C_ut"
+#~ msgstr "Gukata"
+
+#, fuzzy
+#~ msgid "Icons only"
+#~ msgstr "Udushushondanga Gusa"
+
+#, fuzzy
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Na"
+
+#, fuzzy
+#~ msgid "New File"
+#~ msgstr "Idosiye"
+
+#~ msgid "Save File"
+#~ msgstr "Bika idosiye"
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.CB_MENU_ICONS.text
+#, fuzzy
+#~ msgid "Show _icons in menus"
+#~ msgstr "Kugaragaza udushushondanga mu bikubiyemo"
+
+#, fuzzy
+#~ msgid "Text below icons"
+#~ msgstr "munsi Udushushondanga"
+
+#, fuzzy
+#~ msgid "Text beside icons"
+#~ msgstr "Udushushondanga"
+
+#~ msgid "Text only"
+#~ msgstr "Umwandiko gusa"
+
+#, fuzzy
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Akabuto Uturango..."
+
+#, fuzzy
+#~ msgid "_Detachable toolbars"
+#~ msgstr "Imyanya y'ibikoresho"
+
+#, fuzzy
+#~ msgid "_Editable menu accelerators"
+#~ msgstr "Ibikubiyemo"
+
+# sc/source\ui\src\globstr.src:RID_GLOBSTR.STR_HFCMD_FILE.text
+#, fuzzy
+#~ msgid "_File"
+#~ msgstr "IDOSIYE"
+
+# basctl/source\basicide\brkdlg.src:RID_BASICIDE_BREAKPOINTDLG.RID_PB_NEW.text
+#, fuzzy
+#~ msgid "_New"
+#~ msgstr "Gishya"
+
+# dbaccess/source/ui/inc/toolbox.hrc:MID_SBA_QRY_PASTE.text
+#, fuzzy
+#~ msgid "_Paste"
+#~ msgstr "Komeka"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "<B Gutangira i Ibyahiswemo Porogaramu kugirango Idirishya Muyobozi B"
+
+#~ msgid "Alt"
+#~ msgstr "Alt"
+
+#, fuzzy
+#~ msgid "Super (or \"Windows logo\")"
+#~ msgstr "Cyangwa ikirango"
+
+# the command key
+#~ msgid "Meta"
+#~ msgstr "Meta"
+
+#, fuzzy
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<B B"
+
+#, fuzzy
+#~ msgid "To _move a window, press-and-hold this key then grab the window:"
+#~ msgstr "Kwimura a Idirishya Kanda Na iyi Urufunguzo Hanyuma i Idirishya"
+
+#, fuzzy
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "Kanda Kuri iyi Igikorwa"
+
+#, fuzzy
+#~ msgid "_Interval before raising:"
+#~ msgstr "Mbere"
+
+#, fuzzy
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "Byahiswemo Nyuma Intera"
+
+#, fuzzy
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "Ryari: i Imbeba KURI"
+
+#, fuzzy
+#~ msgid "Set your window properties"
+#~ msgstr "Idirishya Indangakintu..."
+
+#, fuzzy
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Iboneza"
+
+#, fuzzy
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "OYA gutangiza"
+
+#, fuzzy
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Hasi i Urufunguzo kugirango 8 amasogonda ni i Iy'ibusamo kugirango i i "
+#~ "Mwandikisho"
+
+#, fuzzy
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Kuri Kureka bigakora"
+
+#, fuzzy
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Kuri Kubuza gukora"
+
+#, fuzzy
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "i Urufunguzo 5 Times in a Urubariro ni i Iy'ibusamo kugirango i i "
+#~ "Mwandikisho"
+
+#, fuzzy
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "Utubuto ku Rimwe Cyangwa i Urufunguzo 5 Times in a Urubariro Bidakora i i "
+#~ "Mwandikisho"
+
+#, fuzzy
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Kuri Kureka bigakora"
+
+#, fuzzy
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Kuri Kubuza gukora"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr "Kurema i bushyinguro ni Kuri Kwemerera"
+
+#, fuzzy, c-format
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "Igikorwa Igikubo"
+
+#, fuzzy, c-format
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "Bifatanya Igikubo"
+
+#, fuzzy, c-format
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "ni"
+
+#, fuzzy, c-format
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "ni"
+
+#, fuzzy, c-format
+#~ msgid "It seems that another application already has access to key '%d'."
+#~ msgstr "Porogaramu Kuri Urufunguzo"
+
+#, fuzzy, c-format
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "ni in"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr "Kuri Gukoresha ni Kuri i Urufunguzo"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Iboneza a in a in Seriveri Seriveri Na: Seriveri Verisiyo Ibyatanzwe "
+#~ "Icyegeranyo iyi Nka a Gushyiramo Igisubizo Bya Igisubizo Bya"
+
+#, fuzzy
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr "3.. 0."
+
+#, fuzzy
+#~ msgid "Do _not show this warning again"
+#~ msgstr "Nta kongera kwerekana iri burira"
+
+#, fuzzy
+#~ msgid ""
+#~ "The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.  Which set would you like to use?"
+#~ msgstr ""
+#~ "Sisitemu Mwandikisho Amagenamiterere Bivuye KIGEZWEHO Mwandikisho "
+#~ "Amagenamiterere Gushyiraho nka Kuri Gukoresha"
+
+#, fuzzy
+#~ msgid "Use X settings"
+#~ msgstr "Amagenamiterere"
+
+#, fuzzy
+#~ msgid "Use GNOME settings"
+#~ msgstr "Amagenamiterere"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr "Gukora Komandi: iyi Komandi:"
+
+#, fuzzy
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr "Gushyira i Kuri i ni"
+
+#, fuzzy, c-format
+#~ msgid "Permissions on the file %s are broken\n"
+#~ msgstr "ku i IDOSIYE"
+
+#, fuzzy
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr "Ibirimo i IDOSIYE iyi ni"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr "Ikosa Hejuru i OYA Akazi in iyi Umukoro"
+
+#, fuzzy
+#~ msgid "_Do not show this message again"
+#~ msgstr "OYA Garagaza iyi Ubutumwa"
+
+#, fuzzy, c-format
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "Ibirimo Ijwi IDOSIYE Nka Urugero"
+
+#, fuzzy
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Ku Ntangiriro bushyinguro"
+
+#, fuzzy, c-format
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr "Urufunguzo Gushyiraho Kuri Ubwoko Ikitezwe: Ubwoko"
+
+#, fuzzy
+#~ msgid "A_vailable files:"
+#~ msgstr "Idosiye"
+
+#, fuzzy
+#~ msgid "Do _not show this warning again."
+#~ msgstr "Nta kongera kwerekana iri burira"
+
+#, fuzzy
+#~ msgid "Load modmap files"
+#~ msgstr "Idosiye"
+
+#, fuzzy
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "nka Kuri Ibirimo i IDOSIYE S"
+
+# basctl/source\basicide\basidesh.src:RID_STR_OPEN.text
+#, fuzzy
+#~ msgid "_Load"
+#~ msgstr "Ibirimo"
+
+#, fuzzy
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr "Bya kugirango Imizi Idirishya Cyangwa kugirango Igaragazambere"
+
+#, fuzzy
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "NIBA ni a Igaragazambere Kuri"
+
+#, fuzzy
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "NIBA ni a Igaragazambere Kuri"
+
+#, fuzzy
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "ku ni Kuri Gushushanya"
+
+#, fuzzy, c-format
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Ikosa Ifashayobora"
+
+#, fuzzy
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Ijwi IDOSIYE kugirango iyi Icyabaye OYA"
+
+#, fuzzy
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package\n"
+#~ "for a set of default sounds."
+#~ msgstr ""
+#~ "Ijwi IDOSIYE kugirango iyi Icyabaye OYA Gicurasi Kuri Kwinjiza porogaramu "
+#~ "i a Gushyiraho Bya Mburabuzi Amajwi"
+
+#, fuzzy, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "IDOSIYE ni OYA a Byemewe IDOSIYE"
+
+#, fuzzy
+#~ msgid "Sound File"
+#~ msgstr "Idosiye"
+
+#, fuzzy
+#~ msgid "_Play"
+#~ msgstr "Gukina"
+
+#, fuzzy, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Muyobozi OYA a Iboneza"
+
+# sc/source\ui\formdlg\formdlgs.src:RID_SCDLG_FORMULA.RB_REF.quickhelptext
+#~ msgid "Maximize"
+#~ msgstr "Kugira kinini"
+
+# vcl/source\src\helptext.src:SV_HELPTEXT_ROLLUP.text
+#~ msgid "Roll up"
+#~ msgstr "Kuzamura"
+
+#, fuzzy
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr "NIBYO i kugirango Umwandiko Byuzuye Na Umwandiko in"
+
+#, fuzzy
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Umwandiko Byuzuye Na Umwandiko"
+
+#, fuzzy
+#~ msgid "Brightness down"
+#~ msgstr "Hasi"
+
+#, fuzzy
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+# #-#-#-#-#  officecfg.pot (PACKAGE VERSION)  #-#-#-#-#
+# officecfg/registry\data\org\openoffice\Office\DataAccess.xcu:..DataAccess.DriverSettings.com.sun.star.comp.sdbc.MozabDriver.ColumnAliases.PrimaryEmail.text
+# #-#-#-#-#  officecfg.pot (PACKAGE VERSION)  #-#-#-#-#
+# officecfg/registry\schema\org\openoffice\Office\Writer.xcs:....BusinessCard.PrivateAddress.Email.text
+#~ msgid "E-mail"
+#~ msgstr "Imeli"
+
+#, fuzzy
+#~ msgid "E-mail's shortcut."
+#~ msgstr "E Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Eject's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Ifashayobora Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Urubuga Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Log out's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+# 4630
+#~ msgid "Pause"
+#~ msgstr "akaruhuko"
+
+#, fuzzy
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Cyangwa Gukina Akaruhuko... Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Volume step"
+#~ msgstr "Intera"
+
+#, fuzzy
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Intera Nka Ijanisha Bya Igice"
+
+#, fuzzy
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Iy'ibusamo"
+
+#, fuzzy
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "a Ikiganiro Ryari: Amakosa"
+
+#, fuzzy
+#~ msgid "Run screensaver at login"
+#~ msgstr "ku Ifashayinjira"
+
+#, fuzzy
+#~ msgid "Start screensaver"
+#~ msgstr "Gutangira"
+
+#, fuzzy
+#~ msgid ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+#~ msgstr ""
+#~ "A Bya Inyandikoporogaramu Kuri Gukoresha i Mwandikisho Leta ni kugirango"
+
+#, fuzzy
+#~ msgid "A list of modmap files available in the $HOME directory."
+#~ msgstr "A Urutonde Bya Idosiye Bihari in i bushyinguro"
+
+#, fuzzy
+#~ msgid "Default group, assigned on window creation"
+#~ msgstr "Itsinda ku Idirishya"
+
+#, fuzzy
+#~ msgid "Keep and manage separate group per window"
+#~ msgstr "Na kuyobora Itsinda Idirishya"
+
+#, fuzzy
+#~ msgid "Keyboard model"
+#~ msgstr "Urugero"
+
+#, fuzzy
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr "Amagenamiterere in Bivuye i Sisitemu"
+
+#, fuzzy
+#~ msgid "Save/restore indicators together with layout groups"
+#~ msgstr "Kubika Kugarura Na: Imigaragarire Amatsinda"
+
+#, fuzzy
+#~ msgid "Show layout names instead of group names"
+#~ msgstr "Imigaragarire Amazina Bya Itsinda Amazina"
+
+#, fuzzy
+#~ msgid ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+#~ msgstr ""
+#~ "Imigaragarire Amazina Bya Itsinda Amazina kugirango Uburyo Bya Igikubo "
+#~ "Imigaragarire"
+
+#, fuzzy
+#~ msgid "Suppress the \"X sysconfig changed\" warning message"
+#~ msgstr "i Byahinduwe Iburira Ubutumwa"
+
+#, fuzzy
+#~ msgid "keyboard layout"
+#~ msgstr "Mwandikisho Imigaragarire"
+
+#, fuzzy
+#~ msgid "keyboard model"
+#~ msgstr "Mwandikisho Urugero"
+
+#, fuzzy
+#~ msgid "modmap file list"
+#~ msgstr "IDOSIYE Urutonde"
+
+#, fuzzy
+#~ msgid "_Postpone break"
+#~ msgstr "itandukanya"
+
+#, fuzzy
+#~ msgid "Take a break!"
+#~ msgstr "a itandukanya"
+
+#, fuzzy
+#~ msgid "/_Take a Break"
+#~ msgstr "/a"
+
+#, fuzzy, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%dUMUNOTA i Komeza>> itandukanya"
+
+#, fuzzy
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "UMUNOTA i Komeza>> itandukanya"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Kuri Hejuru i Kwandika: itandukanya Indangakintu... Ikiganiro Na: i Ikosa"
+
+#, fuzzy
+#~ msgid "A computer break reminder."
+#~ msgstr "A itandukanya Mwibutsa"
+
+#, fuzzy
+#~ msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgstr "ku"
+
+#, fuzzy
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Kyongewe ku"
+
+#, fuzzy
+#~ msgid "Break reminder"
+#~ msgstr "Mwibutsa"
+
+#, fuzzy
+#~ msgid "The typing monitor is already running."
+#~ msgstr "Kwandika: ni"
+
+#, fuzzy
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Kwandika: i Ikimenyetso Ubuso Kuri Kugaragaza Ibisobanuro Kuri a "
+#~ "Ikimenyetso Ubuso ku Kongeramo ku Iburyo: ku Na Kuri Na"
+
+#, fuzzy
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Igihogo KURI i"
 
 # sfx2/source\dialog\dinfdlg.src:TP_DOCINFODOC.FT_FILE_SIZE.text
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "Ingano"
+#~ msgid "Size:"
+#~ msgstr "Ingano"
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "Verisiyo:"
-
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
 #, fuzzy
-msgid "Copyright:"
-msgstr "Uburenganzira bw'umuhimbyi"
+#~ msgid "Copyright:"
+#~ msgstr "Uburenganzira bw'umuhimbyi"
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "Umwirondoro"
+#~ msgid "Description:"
+#~ msgstr "Umwirondoro"
 
-#: ../vfs-methods/fontilus/font-view.c:408
 #, fuzzy, c-format
-msgid "usage: %s fontfile\n"
-msgstr "Ikoresha:"
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "Ikoresha:"
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
 #, fuzzy
-msgid "Set as Application Font"
-msgstr "Nka"
+#~ msgid "Set as Application Font"
+#~ msgstr "Nka"
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
 #, fuzzy
-msgid "Sets the default application font"
-msgstr "i Mburabuzi Porogaramu Intego- nyuguti"
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
 #, fuzzy
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
 #, fuzzy
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
 #, fuzzy
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
 #, fuzzy
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
 #, fuzzy
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
-msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
 #, fuzzy
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
 #, fuzzy
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
 #, fuzzy
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Komandi: kugirango Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
 #, fuzzy
-msgid "Thumbnail command for OpenType fonts"
-msgstr "Komandi: kugirango Imyandikire"
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Komandi: kugirango Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
 #, fuzzy
-msgid "Thumbnail command for PCF fonts"
-msgstr "Komandi: kugirango Imyandikire"
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Komandi: kugirango Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
 #, fuzzy
-msgid "Thumbnail command for TrueType fonts"
-msgstr "Komandi: kugirango Imyandikire"
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Komandi: kugirango Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
 #, fuzzy
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Komandi: kugirango Imyandikire"
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Kuri Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
 #, fuzzy
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "Kuri Imyandikire"
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Kuri Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
 #, fuzzy
-msgid "Whether to thumbnail PCF fonts"
-msgstr "Kuri Imyandikire"
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Kuri Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
 #, fuzzy
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "Kuri Imyandikire"
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Kuri Imyandikire"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
 #, fuzzy
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "Kuri Imyandikire"
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<Uburemere UTSINDAGIYE Ingano Kinini Gishya Intego- nyuguti"
 
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
-msgid "GNOME Font Viewer"
-msgstr ""
-
-#: ../vfs-methods/themus/apply-font.glade.h:2
 #, fuzzy
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-msgstr "<Uburemere UTSINDAGIYE Ingano Kinini Gishya Intego- nyuguti"
+#~ msgid "Do _not apply font"
+#~ msgstr "OYA Gukurikiza Intego- nyuguti"
 
-#: ../vfs-methods/themus/apply-font.glade.h:3
 #, fuzzy
-msgid "Do _not apply font"
-msgstr "OYA Gukurikiza Intego- nyuguti"
-
-#: ../vfs-methods/themus/apply-font.glade.h:4
-#, fuzzy
-msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
-msgstr ""
-"Byahiswemo a Gishya Intego- nyuguti A Igaragazambere Bya i Intego- nyuguti "
-"ni munsi"
-
-#: ../vfs-methods/themus/apply-font.glade.h:5
-#, fuzzy
-msgid "_Apply font"
-msgstr "Intego- nyuguti"
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Byahiswemo a Gishya Intego- nyuguti A Igaragazambere Bya i Intego- "
+#~ "nyuguti ni munsi"
 
 # LOCALIZATION NOTE : FILE Theme management prefs
-#: ../vfs-methods/themus/theme-method.c:520
-msgid "Themes"
-msgstr "Insanganyamatsiko"
+#~ msgid "Themes"
+#~ msgstr "Insanganyamatsiko"
 
 # #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
 # basctl/source\basicide\moptions.src:RID_MACROOPTIONS.RID_FT_DESCR.text
 # #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
 # basctl/source\basicide\moptions.src:RID_MACROOPTIONS.text
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "Isobanuramiterere"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
-msgstr ""
-
-#: ../vfs-methods/themus/themus-properties-view.c:139
-#, fuzzy
-msgid "Window border theme"
-msgstr "Imbibi"
-
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
-msgstr ""
-
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
-msgstr ""
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-#, fuzzy
-msgid "Apply theme"
-msgstr "Gushyiraho insanganyamatsiko"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-#, fuzzy
-msgid "Sets the default theme"
-msgstr "i Mburabuzi"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-#, fuzzy
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr "Gushyiraho Kuri NIBYO Hanyuma Insanganyamatsiko"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-#, fuzzy
-msgid "If set to true, then themes will be thumbnailed."
-msgstr "Gushyiraho Kuri NIBYO Hanyuma Insanganyamatsiko"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:3
-#, fuzzy
-msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
-msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Insanganyamatsiko"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-#, fuzzy
-msgid "Set this key to the command used to create thumbnails for themes."
-msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Insanganyamatsiko"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-#, fuzzy
-msgid "Thumbnail command for installed themes"
-msgstr "Komandi: kugirango Insanganyamatsiko"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-#, fuzzy
-msgid "Thumbnail command for themes"
-msgstr "Komandi: kugirango Insanganyamatsiko"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-#, fuzzy
-msgid "Whether to thumbnail installed themes"
-msgstr "Kuri Insanganyamatsiko"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-#, fuzzy
-msgid "Whether to thumbnail themes"
-msgstr "Kuri Insanganyamatsiko"
+#~ msgid "Description"
+#~ msgstr "Isobanuramiterere"
 
 #, fuzzy
-msgid "Show help options"
-msgstr "Ifashayobora Amahitamo"
+#~ msgid "Window border theme"
+#~ msgstr "Imbibi"
+
+#, fuzzy
+#~ msgid "Apply theme"
+#~ msgstr "Gushyiraho insanganyamatsiko"
+
+#, fuzzy
+#~ msgid "Sets the default theme"
+#~ msgstr "i Mburabuzi"
+
+#, fuzzy
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "Gushyiraho Kuri NIBYO Hanyuma Insanganyamatsiko"
+
+#, fuzzy
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "Gushyiraho Kuri NIBYO Hanyuma Insanganyamatsiko"
+
+#, fuzzy
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Insanganyamatsiko"
+
+#, fuzzy
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Insanganyamatsiko"
+
+#, fuzzy
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Komandi: kugirango Insanganyamatsiko"
+
+#, fuzzy
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Komandi: kugirango Insanganyamatsiko"
+
+#, fuzzy
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Kuri Insanganyamatsiko"
+
+#, fuzzy
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Kuri Insanganyamatsiko"

--- a/po/rw.po~
+++ b/po/rw.po~
@@ -1,0 +1,3904 @@
+# translation of gnome-control-center to Kinyarwanda.
+# Copyright (C) 2005 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+# Steve Murphy <murf@e-tools.com>, 2005
+# Steve performed initial rough translation from compendium built from translations provided by the following translators:
+# Philibert Ndandali  <ndandali@yahoo.fr>, 2005.
+# Viateur MUGENZI <muvia1@yahoo.fr>, 2005.
+# Noëlla Mupole <s24211045@tuks.co.za>, 2005.
+# Carole Karema <karemacarole@hotmail.com>, 2005.
+# JEAN BAPTISTE NGENDAHAYO <ngenda_denis@yahoo.co.uk>, 2005.
+# Augustin KIBERWA  <akiberwa@yahoo.co.uk>, 2005.
+# Donatien NSENGIYUMVA <ndonatienuk@yahoo.co.uk>, 2005..
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center HEAD\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"PO-Revision-Date: 2005-03-31 20:55-0700\n"
+"Last-Translator: Steve Murphy <murf@e-tools.com>\n"
+"Language-Team: Kinyarwanda <translation-team-rw@lists.sourceforge.net>\n"
+"Language: rw\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+#, fuzzy
+msgid "The type of alert"
+msgstr "Ubwoko Bya"
+
+# sfx2/source\toolbox\tbxcust.src:RID_USERDEFBMP.GB_FUNCTION.text
+#: ../capplets/about-me/eel-alert-dialog.c:133
+#, fuzzy
+msgid "Alert Buttons"
+msgstr "Utubuto"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+#, fuzzy
+msgid "About Me"
+msgstr "/Bigyanye"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your personal information"
+msgstr "Mburabuzi Porogaramu"
+
+# basctl/source\basicide\tbxctl.src:RID_TOOLBOX.SID_INSERT_SELECT.text
+#: ../capplets/about-me/gnome-about-me.c:554
+#, fuzzy
+msgid "Select Image"
+msgstr "Guhitamo"
+
+#: ../capplets/about-me/gnome-about-me.c:556
+msgid "No Image"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:706
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:727
+msgid "Unable to open address book"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:739
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:770
+#: ../capplets/about-me/gnome-about-me.c:772
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "/Bigyanye"
+
+#: ../capplets/about-me/gnome-about-me-password.c:101
+#: ../capplets/about-me/gnome-about-me-password.c:479
+msgid "Old password is incorrect, please retype it"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:112
+msgid "System error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:113
+msgid "Could not run /usr/bin/passwd"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:114
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:117
+msgid "Unexpected error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:315
+msgid "Password is too short"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:318
+#: ../capplets/about-me/gnome-about-me-password.c:321
+msgid "Password is too simple"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:324
+msgid "Old and new passwords are too similar"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:328
+msgid "Old and new password are the same"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:406
+msgid "Please type the passwords."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:414
+msgid "Please type the password again, it is wrong."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:417
+msgid "Click on Change Password to change the password."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/font/font-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+msgid "    "
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+#, fuzzy
+msgid "<b>Email</b>"
+msgstr "<i i"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+#, fuzzy
+msgid "<b>Home</b>"
+msgstr "<B B"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+#, fuzzy
+msgid "<b>Instant Messaging</b>"
+msgstr "<B B"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+#, fuzzy
+msgid "<b>Job</b>"
+msgstr "<B B"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+#, fuzzy
+msgid "<b>Telephone</b>"
+msgstr "<B B"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+#, fuzzy
+msgid "<b>Web</b>"
+msgstr "<B B"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+#, fuzzy
+msgid "<b>Work</b>"
+msgstr "<B B"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "A_ddress:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "Address"
+msgstr ""
+
+# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+#, fuzzy
+msgid "C_ity:"
+msgstr "Imisusire"
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_COMMAND.text
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+#, fuzzy
+msgid "C_ompany:"
+msgstr "Komandi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Cale_ndar:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change Passwo_rd..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+#, fuzzy
+msgid "Change Password"
+msgstr "Gushyiraho"
+
+# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+#, fuzzy
+msgid "Ci_ty:"
+msgstr "Imisusire"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+#, fuzzy
+msgid "Co_untry:"
+msgstr "Igenzura"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Contact"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+#, fuzzy
+msgid "Cou_ntry:"
+msgstr "Igenzura"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Hom_e:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr ""
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+#, fuzzy
+msgid "Old pa_ssword:"
+msgstr "Ijambobanga..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P.O. _box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P._O. box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "Personal Info"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "State/Pro_vince:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#, fuzzy
+msgid "User name:"
+msgstr "Izina ry'ukoresha"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Web _log:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "Wor_k:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid "Work _fax:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Zip/_Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "_Address:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+#, fuzzy
+msgid "_Home page:"
+msgstr "Izina:"
+
+# basctl/source\basicide\moduldlg.src:RID_DLG_NEWLIB.RID_FT_NEWLIB.text
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+#, fuzzy
+msgid "_Home:"
+msgstr "Izina:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+#, fuzzy
+msgid "_Manager:"
+msgstr "Umuyobozi w'idirishya"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+#, fuzzy
+msgid "_Mobile:"
+msgstr "Ingerofatizo"
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+#, fuzzy
+msgid "_New password:"
+msgstr "Ijambobanga..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+#, fuzzy
+msgid "_Profession:"
+msgstr "Verisiyo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Retype new password:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr ""
+
+# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+#, fuzzy
+msgid "_Title:"
+msgstr "Imisusire"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Work:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Zip/Postal code:"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+#, fuzzy
+msgid "<b>Applications</b>"
+msgstr "<B B"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+#, fuzzy
+msgid "<b>Support</b>"
+msgstr "<B B"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+#, fuzzy
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+"<Gitoya i B B Kuri iyi Igenamiterere OYA INGARUKA Komeza>> LOG in i Gitoya"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technology Preferences"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+#, fuzzy
+msgid "Close and _Log Out"
+msgstr "Funga Na"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+#, fuzzy
+msgid "Start these assistive technologies every time you log in:"
+msgstr "Gutangira buri Igihe LOG in"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+#, fuzzy
+msgid "_On-screen keyboard"
+msgstr "Mugaragaza Mwandikisho"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Screenreader"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+#, fuzzy
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr "Gushigikira kugirango ku Ifashayinjira"
+
+#: ../capplets/accessibility/at-properties/main.c:60
+#, fuzzy
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"ni Bihari ku Sisitemu in Itondekanya Kuri Kubona ku Mugaragaza Mwandikisho "
+"Gushigikira Na i kugirango Na"
+
+#: ../capplets/accessibility/at-properties/main.c:62
+#, fuzzy
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+"Byose Bihari ku Sisitemu in Itondekanya Kuri Kubona ku Mugaragaza "
+"Mwandikisho Gushigikira"
+
+#: ../capplets/accessibility/at-properties/main.c:64
+#, fuzzy
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr "Byose Bihari ku Sisitemu kugirango Na"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
+#, fuzzy, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr "Ikosa i Imbeba Ibyahiswemo Ikiganiro"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
+#, fuzzy, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr "Kuri Kuzana Amagenamiterere Bivuye IDOSIYE"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
+#, fuzzy
+msgid "Import Feature Settings File"
+msgstr "Idosiye"
+
+# filter/source\xsltdialog\xmlfiltertestdialog.src:DLG_XML_FILTER_TEST_DIALOG.FL_IMPORT.text
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
+#, fuzzy
+msgid "_Import"
+msgstr "Kuzana"
+
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\accel\accel.src:STR_ACCEL_CFGITEM.text
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\cfg.src:DLG_CONFIG.1.TP_CONFIG_ACCEL.text
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Mwandikisho"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your keyboard accessibility preferences"
+msgstr "Mwandikisho Ubushobozi bwo gukoreshwa Ibyahiswemo"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+#, fuzzy
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+"Sisitemu OYA Kuri i Umugereka Mwandikisho Ubushobozi bwo gukoreshwa Ibiranga "
+"OYA"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+#: ../capplets/theme-switcher/theme-install.glade.h:1
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+#, fuzzy
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "<B B"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+#, fuzzy
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "<B B"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+#, fuzzy
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "<B B"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+#, fuzzy
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "<B B"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+#, fuzzy
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "<B B"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+#, fuzzy
+msgid "<b>Features</b>"
+msgstr "<B B"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+#, fuzzy
+msgid "<b>Toggle Keys</b>"
+msgstr "<B B"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "By'ibanze"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+#, fuzzy
+msgid "Beep if key is re_jected"
+msgstr "NIBA Urufunguzo ni Byanzwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+#, fuzzy
+msgid "Beep when _features turned on or off from keyboard"
+msgstr "Ryari: Ibiranga ku Cyangwa Bidakora Bivuye Mwandikisho"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+#, fuzzy
+msgid "Beep when _modifier is pressed"
+msgstr "Ryari: ni"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+#, fuzzy
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr "Ryari: ni ku Na Ryari: ni Bidakora"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+#, fuzzy
+msgid "Beep when key is:"
+msgstr "Ryari: Urufunguzo ni"
+
+# svx/source\dialog\textanim.src:RID_SVXPAGE_TEXTANIMATION.FT_DELAY.text
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+#, fuzzy
+msgid "Del_ay:"
+msgstr "Gutinda"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+#, fuzzy
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr "hagati Na Mweretsi Igenda"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+#, fuzzy
+msgid "Disa_ble if two keys pressed together"
+msgstr "NIBA Utubuto"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr ""
+
+# framework/source\classes\fltdlg.src:DLG_FILTER_SELECT.FL_FILTER.text
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Muyunguruzi"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+#, fuzzy
+msgid "I_gnore duplicate keypresses within:"
+msgstr "Gusubiramo muri"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+#, fuzzy
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr "Byose Bya i Urufunguzo NIBA muri a Ukoresha: Igihe Bya Igihe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+#, fuzzy
+msgid "Ma_ximum pointer speed:"
+msgstr "Mweretsi Umuvuduko"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+#, fuzzy
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr "Kwemera Utubuto Nyuma Na kugirango a Ukoresha: Igiteranyo Bya Igihe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+#, fuzzy
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr "Igikubo Urufunguzo Kanda Ibikorwa: ku Utubuto in"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+#, fuzzy
+msgid "S_peed:"
+msgstr "Umuvuduko"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+#, fuzzy
+msgid "Time to acce_lerate to maximum speed:"
+msgstr "Kuri Kuri Kinini Umuvuduko"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+#, fuzzy
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr "i Bikurikije umubare a Imbeba Igenzura"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+#, fuzzy
+msgid "_Disable if unused for:"
+msgstr "NIBA Kidakoreshwa kugirango"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+#, fuzzy
+msgid "_Enable keyboard accessibility features"
+msgstr "Mwandikisho Ubushobozi bwo gukoreshwa Ibiranga"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+#, fuzzy
+msgid "_Only accept keys held for:"
+msgstr "Kwemera Utubuto kugirango"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+#, fuzzy
+msgid "_Type to test settings:"
+msgstr "Kuri Igerageza Amagenamiterere"
+
+# sc/source\ui\miscdlgs\acredlin.src:RID_SCDLG_CHANGES.STR_ACCEPTED.text
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+#, fuzzy
+msgid "_accepted"
+msgstr "Byemewe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr ""
+
+# sc/source\ui\miscdlgs\acredlin.src:RID_SCDLG_CHANGES.STR_REJECTED.text
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+#, fuzzy
+msgid "_rejected"
+msgstr "Byanzwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+#, fuzzy
+msgid "characters/second"
+msgstr "Inyuguti ISEGONDA"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+msgid "milliseconds"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+#, fuzzy
+msgid "pixels/second"
+msgstr "Pigiseli ISEGONDA"
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_MISC.FT_HELPAGENT_TIME_UNIT.text
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:885
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "amasogonda"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+#, fuzzy
+msgid "Change your Desktop Background settings"
+msgstr "Amagenamiterere"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+msgid "Desktop Background"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+#, fuzzy
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "<B B"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+#, fuzzy
+msgid "<b>_Desktop Colors</b>"
+msgstr "<B B"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+msgid "Desktop Background Preferences"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr ""
+
+# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
+#: ../capplets/background/gnome-background-properties.glade.h:6
+#, fuzzy
+msgid "_Style:"
+msgstr "Imisusire"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, fuzzy, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Ikosa Ifashayobora"
+
+#: ../capplets/background/gnome-wp-capplet.c:1042
+#: ../capplets/background/gnome-wp-capplet.c:1060
+msgid "Centered"
+msgstr "Biri hagati"
+
+#: ../capplets/background/gnome-wp-capplet.c:1068
+#: ../capplets/background/gnome-wp-capplet.c:1085
+msgid "Fill Screen"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-capplet.c:1093
+#: ../capplets/background/gnome-wp-capplet.c:1110
+msgid "Scaled"
+msgstr "Scaled"
+
+# #-#-#-#-#  wizards.pot (PACKAGE VERSION)  #-#-#-#-#
+# wizards/source\formwizard\dbwizres.src:RID_DB_FORM_WIZARD_START_+_56.text
+# #-#-#-#-#  wizards.pot (PACKAGE VERSION)  #-#-#-#-#
+# wizards/source\webwizard\webwizar.src:WEBDIALOG_+_7.text
+#: ../capplets/background/gnome-wp-capplet.c:1118
+#: ../capplets/background/gnome-wp-capplet.c:1135
+#, fuzzy
+msgid "Tiled"
+msgstr "Cy'udukaro"
+
+#: ../capplets/background/gnome-wp-capplet.c:1159
+#: ../capplets/background/gnome-wp-capplet.c:1168
+msgid "Solid Color"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-capplet.c:1176
+#: ../capplets/background/gnome-wp-capplet.c:1185
+msgid "Horizontal Gradient"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-capplet.c:1193
+#: ../capplets/background/gnome-wp-capplet.c:1202
+msgid "Vertical Gradient"
+msgstr ""
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1251
+msgid "Add Wallpaper"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-item.c:292
+#: ../capplets/background/gnome-wp-item.c:294
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/common/activate-settings-daemon.c:18
+#, fuzzy
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr "g."
+
+#: ../capplets/common/capplet-stock-icons.c:94
+#, fuzzy, c-format
+msgid "Unable to load capplet stock icon '%s'\n"
+msgstr "Kuri Ibirimo Agashushondanga"
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+#, fuzzy
+msgid "Just apply settings and quit"
+msgstr "Gukurikiza Amagenamiterere Na Kuvamo"
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/default-applications/gnome-default-applications-properties.c:765
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1021
+#: ../capplets/sound/sound-properties-capplet.c:244
+#, fuzzy
+msgid "Retrieve and store legacy settings"
+msgstr "Na Amagenamiterere"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %i of %i"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:194
+#, fuzzy
+msgid "URI currently transferring from"
+msgstr "Bivuye"
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:202
+#, fuzzy
+msgid "URI currently transferring to"
+msgstr "Kuri"
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:210
+#, fuzzy
+msgid "Fraction of transfer currently completed"
+msgstr "Bya"
+
+#: ../capplets/common/file-transfer-dialog.c:217
+#, fuzzy
+msgid "Current URI index"
+msgstr "Umubarendanga"
+
+#: ../capplets/common/file-transfer-dialog.c:218
+#, fuzzy
+msgid "Current URI index - starts from 1"
+msgstr "Umubarendanga Bivuye 1."
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:226
+#, fuzzy
+msgid "Total number of URIs"
+msgstr "Umubare Bya"
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr ""
+
+# officecfg/registry\schema\org\openoffice\Office\Writer.xcs:....Wizard.Memo.Elements.From.text
+#: ../capplets/common/file-transfer-dialog.c:345
+#, fuzzy
+msgid "From:"
+msgstr "Bivuye"
+
+# Buttons
+#: ../capplets/common/file-transfer-dialog.c:349
+#, fuzzy
+msgid "To:"
+msgstr "Kuri->"
+
+# sw/source\ui\app\app.src:STR_STATSTR_LAYOUTINIT.text
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr "Kwihuza..."
+
+# 3348
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Urufunguzo"
+
+#: ../capplets/common/gconf-property-editor.c:171
+#, fuzzy
+msgid "GConf key to which this property editor is attached"
+msgstr "Urufunguzo Kuri iyi indangakintu Muhinduzi ni"
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:178
+#, fuzzy
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "iyi Ryari: i Agaciro Na: Urufunguzo Byahinduwe"
+
+#: ../capplets/common/gconf-property-editor.c:183
+#, fuzzy
+msgid "Change set"
+msgstr "Gushyiraho"
+
+#: ../capplets/common/gconf-property-editor.c:184
+#, fuzzy
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr "Guhindura>> Gushyiraho Ibyatanzwe Kuri Kuri i Umukiriya ku Gukurikiza"
+
+#: ../capplets/common/gconf-property-editor.c:189
+#, fuzzy
+msgid "Conversion to widget callback"
+msgstr "Kuri"
+
+#: ../capplets/common/gconf-property-editor.c:190
+#, fuzzy
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr "Kuri Byasohowe Ryari: Ibyatanzwe Kuri Bivuye Kuri i"
+
+#: ../capplets/common/gconf-property-editor.c:195
+#, fuzzy
+msgid "Conversion from widget callback"
+msgstr "Bivuye"
+
+#: ../capplets/common/gconf-property-editor.c:196
+#, fuzzy
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr "Kuri Byasohowe Ryari: Ibyatanzwe Kuri Kuri Bivuye i"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:202
+#, fuzzy
+msgid "Object that controls the property (normally a widget)"
+msgstr "Amagenzura i indangakintu a"
+
+#: ../capplets/common/gconf-property-editor.c:217
+#, fuzzy
+msgid "Property editor object data"
+msgstr "Muhinduzi Igikoresho Ibyatanzwe"
+
+#: ../capplets/common/gconf-property-editor.c:218
+#, fuzzy
+msgid "Custom data required by the specific property editor"
+msgstr "Kugena Ibyatanzwe Bya ngombwa ku i indangakintu Muhinduzi"
+
+#: ../capplets/common/gconf-property-editor.c:224
+#, fuzzy
+msgid "Property editor data freeing callback"
+msgstr "Muhinduzi Ibyatanzwe"
+
+#: ../capplets/common/gconf-property-editor.c:225
+#, fuzzy
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Kuri Byasohowe Ryari: indangakintu Muhinduzi Igikoresho Ibyatanzwe ni Kuri"
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, fuzzy, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr "Gushaka i IDOSIYE Ubwoko Na Cyangwa Guhitamo a Mbuganyuma() y'Ishusho"
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, fuzzy, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Kuri Gufungura i IDOSIYE a Bya() y'Ishusho ni OYA Guhitamo a() y'Ishusho"
+
+#: ../capplets/common/gconf-property-editor.c:1593
+#, fuzzy
+msgid "Please select an image."
+msgstr "Guhitamo Ishusho"
+
+# basctl/source\basicide\tbxctl.src:RID_TOOLBOX.SID_INSERT_SELECT.text
+#: ../capplets/common/gconf-property-editor.c:1598
+#, fuzzy
+msgid "_Select"
+msgstr "Guhitamo"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+#, fuzzy
+msgid "Select your default applications"
+msgstr "Mburabuzi Porogaramu"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+msgid "Debian Sensible Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
+msgid "Epiphany"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
+msgid "Galeon"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
+msgid "Encompass"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+msgid "Firebird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
+msgid "Firefox"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
+#, fuzzy
+msgid "Netscape Communicator"
+msgstr "Netscape"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
+msgid "Konqueror"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
+msgid "W3M Text Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
+msgid "Lynx Text Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
+msgid "Links Text Browser"
+msgstr ""
+
+#. The code in gnome-default-applications-properties.c makes sure
+#. * there is only one (the first entry in this list) Evolution entry
+#. * in the list shown to the user
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
+msgid "Evolution Mail Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
+msgid "Balsa"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
+msgid "KMail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
+msgid "Thunderbird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
+#, fuzzy
+msgid "Mozilla Mail"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
+msgid "Mutt"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
+msgid "Debian Terminal Emulator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
+msgid "GNOME Terminal"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
+msgid "Standard XTerminal"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
+msgid "NXterm"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
+msgid "RXVT"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
+msgid "aterm"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
+msgid "ETerm"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.c:123
+#, fuzzy
+msgid "Please specify a name and a command for this editor."
+msgstr "a Izina: Na a Komandi: kugirango iyi Muhinduzi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "Add..."
+msgstr "Kingeraho"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+#, fuzzy
+msgid "C_ustom"
+msgstr "Guhanga"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+#, fuzzy
+msgid "C_ustom:"
+msgstr "Kunoza"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+#, fuzzy
+msgid "Can open _URIs"
+msgstr "Gufungura"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+#, fuzzy
+msgid "Can open multiple _files"
+msgstr "Gufungura Igikubo Idosiye"
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_COMMAND.text
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+#, fuzzy
+msgid "Co_mmand:"
+msgstr "Komandi:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+#, fuzzy
+msgid "Custom Editor Properties"
+msgstr "Kugena"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "Default Mail Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "Default Terminal"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Default Text Editor"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "Default Web Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Default Window Manager"
+msgstr ""
+
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_POPUP_TABBAR.SID_BASICIDE_DELETECURRENT.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\brkdlg.src:RID_BASICIDE_BREAKPOINTDLG.RID_PB_DEL.text
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Delete"
+msgstr "Gusiba"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "E_xec Flag:"
+msgstr ""
+
+# dbaccess/source/ui/inc/toolbox.hrc:MID_DBUI_QUERY_EDIT_JOINCONNECTION.text
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Edit..."
+msgstr "Kwandika..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Mail Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+#, fuzzy
+msgid "Run in a _terminal"
+msgstr "in a"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+#, fuzzy
+msgid "Run in a t_erminal"
+msgstr "in a"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+#, fuzzy
+msgid ""
+"Select the window manager you want.  You will need to hit apply, wave the "
+"magic wand, and do a magic dance for it to work."
+msgstr ""
+"i Idirishya Muyobozi Kuri kanda Gukurikiza UMUVUMBA i Na a kugirango Kuri "
+"Akazi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Terminal"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Text Editor"
+msgstr "Umuhinduzi w'inyandiko"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+#, fuzzy
+msgid "Understands _Netscape Remote Control"
+msgstr "Netscape"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+#, fuzzy
+msgid "Use this _editor to open text files in the file manager"
+msgstr "iyi Muhinduzi Kuri Gufungura Umwandiko Idosiye in i IDOSIYE Muyobozi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "Web Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
+msgid "Window Manager"
+msgstr "Umuyobozi w'idirishya"
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_COMMAND.text
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
+#, fuzzy
+msgid "_Command:"
+msgstr "Komandi:"
+
+# basctl/source\basicide\moduldlg.src:RID_DLG_NEWLIB.RID_FT_NEWLIB.text
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
+#, fuzzy
+msgid "_Name:"
+msgstr "Izina:"
+
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_POPUP_BRKPROPS.RID_BRKPROPS.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_POPUP_DLGED.SID_SHOW_PROPERTYBROWSER.text
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
+#, fuzzy
+msgid "_Properties..."
+msgstr "Indangakintu..."
+
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\menue.src:SCCFG_PLUGINMENU.SUBMENU_EDIT.SUBMENU_EDIT_TABLE.SID_SELECT_TABLES.text
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\menue.src:SCCFG_MENUBAR.SUBMENU_EDIT.SUBMENU_EDIT_TABLE.SID_SELECT_TABLES.text
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
+#, fuzzy
+msgid "_Select:"
+msgstr "Guhitamo..."
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+#, fuzzy
+msgid "Change screen resolution"
+msgstr "Mugaragaza Imikemurire"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+# officecfg/registry\schema\org\openoffice\Office\Common.xcs:....Filter.Graphic.Export.BMP.Resolution.text
+#: ../capplets/display/main.c:448
+#, fuzzy
+msgid "_Resolution:"
+msgstr "Imikemurire"
+
+#: ../capplets/display/main.c:467
+#, fuzzy
+msgid "Re_fresh rate:"
+msgstr "Igipimo"
+
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\solvrdlg.src:RID_SCDLG_SOLVER.FL_VARIABLES.text
+# #-#-#-#-#  sc.pot (PACKAGE VERSION)  #-#-#-#-#
+# sc/source\ui\src\tabopdlg.src:RID_SCDLG_TABOP.FL_VARIABLES.text
+#: ../capplets/display/main.c:488
+#, fuzzy
+msgid "Default Settings"
+msgstr "Amaboneza mburabuzi"
+
+#: ../capplets/display/main.c:490
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr ""
+
+#: ../capplets/display/main.c:516
+msgid "Screen Resolution Preferences"
+msgstr ""
+
+#: ../capplets/display/main.c:553
+#, fuzzy, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "Mburabuzi kugirango iyi"
+
+# basctl/source\basicide\moduldlg.src:RID_DLG_LIBS.RID_FL_OPTIONS.text
+#: ../capplets/display/main.c:571
+msgid "Options"
+msgstr "Amahitamo"
+
+#: ../capplets/display/main.c:592
+#, fuzzy, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] "i Gishya Amagenamiterere in ISEGONDA i Ibanjirije Amagenamiterere"
+
+#: ../capplets/display/main.c:638
+msgid "Keep Resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:642
+#, fuzzy
+msgid "Do you want to keep this resolution?"
+msgstr "Kuri Gumana: iyi Imikemurire"
+
+#: ../capplets/display/main.c:667
+#, fuzzy
+msgid "Use _previous resolution"
+msgstr "Ibanjirije Imikemurire"
+
+#: ../capplets/display/main.c:667
+#, fuzzy
+msgid "_Keep resolution"
+msgstr "Imikemurire"
+
+#: ../capplets/display/main.c:818
+#, fuzzy
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"OYA Gushigikira i Umugereka Imikemurire Amahinduka Kuri i Kugaragaza Ingano "
+"OYA Bihari"
+
+#: ../capplets/display/main.c:826
+#, fuzzy
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"Verisiyo Bya i Umugereka ni Na: iyi Porogaramu Amahinduka Kuri i Kugaragaza "
+"Ingano OYA Bihari"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Intego-nyuguti"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+#, fuzzy
+msgid "Select fonts for the desktop"
+msgstr "Imyandikire kugirango i Ibiro"
+
+#: ../capplets/font/font-properties.glade.h:2
+#, fuzzy
+msgid "<b>Font Rendering</b>"
+msgstr "<B B"
+
+#: ../capplets/font/font-properties.glade.h:3
+#, fuzzy
+msgid "<b>Hinting</b>:"
+msgstr "<B B"
+
+#: ../capplets/font/font-properties.glade.h:4
+#, fuzzy
+msgid "<b>Smoothing</b>:"
+msgstr "<B B"
+
+#: ../capplets/font/font-properties.glade.h:5
+#, fuzzy
+msgid "<b>Subpixel order</b>:"
+msgstr "<B Itondekanya B"
+
+#: ../capplets/font/font-properties.glade.h:6
+#, fuzzy
+msgid "Best _shapes"
+msgstr "Imisusire- shusho"
+
+#: ../capplets/font/font-properties.glade.h:7
+#, fuzzy
+msgid "Best co_ntrast"
+msgstr "Inyuranyamigaragarire"
+
+#: ../capplets/font/font-properties.glade.h:8
+#, fuzzy
+msgid "D_etails..."
+msgstr "Isesengurabyose..."
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:11
+#, fuzzy
+msgid "Go _to font folder"
+msgstr "Kuri Intego- nyuguti Ububiko"
+
+# goodies/source\filter.vcl\eps\dlgeps.src:DLG_EXPORT_EPS.RB_GRAYSCALE.text
+#: ../capplets/font/font-properties.glade.h:12
+#, fuzzy
+msgid "Gra_yscale"
+msgstr "Ingano y'ubwijime"
+
+#: ../capplets/font/font-properties.glade.h:13
+#, fuzzy
+msgid "N_one"
+msgstr "Ntacyo"
+
+# officecfg/registry\schema\org\openoffice\Office\Common.xcs:....Filter.Graphic.Export.BMP.Resolution.text
+#: ../capplets/font/font-properties.glade.h:14
+#, fuzzy
+msgid "R_esolution:"
+msgstr "Imikemurire"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:18
+#, fuzzy
+msgid "_Application font:"
+msgstr "Intego- nyuguti"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:20
+#, fuzzy
+msgid "_Desktop font:"
+msgstr "Intego- nyuguti"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Full"
+msgstr ""
+
+# officecfg/registry\schema\org\openoffice\Office\Math.xcs:....FontFormat.Weight..6.text
+#: ../capplets/font/font-properties.glade.h:22
+#, fuzzy
+msgid "_Medium"
+msgstr "biringaniye"
+
+# 3916
+#: ../capplets/font/font-properties.glade.h:23
+#, fuzzy
+msgid "_Monochrome"
+msgstr "bararimwe"
+
+#: ../capplets/font/font-properties.glade.h:24
+#, fuzzy
+msgid "_None"
+msgstr "Ntacyo"
+
+# svx/source\dialog\tabarea.src:RID_SVXPAGE_COLOR.LB_COLORMODEL.1.text
+#: ../capplets/font/font-properties.glade.h:25
+#, fuzzy
+msgid "_RGB"
+msgstr "UmutukuIcyatsiUbururu"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_Slight"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:27
+#, fuzzy
+msgid "_Terminal font:"
+msgstr "Intego- nyuguti"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:29
+#, fuzzy
+msgid "_Window title font:"
+msgstr "Umutwe Intego- nyuguti"
+
+#: ../capplets/font/font-properties.glade.h:30
+#, fuzzy
+msgid "dots per inch"
+msgstr "Utudomo Inci"
+
+#: ../capplets/font/main.c:488
+#, fuzzy
+msgid "Font may be too large"
+msgstr "Gicurasi Binini"
+
+#: ../capplets/font/main.c:492
+#, fuzzy, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Intego- nyuguti Byahiswemo ni Akadomo Binini Na Gicurasi Ubwoko Kuri "
+"Gukoresha i ni Guhitamo a Ingano Gitoya"
+
+#: ../capplets/font/main.c:505
+#, fuzzy, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Intego- nyuguti Byahiswemo ni Akadomo Binini Na Gicurasi Ubwoko Kuri "
+"Gukoresha i ni Guhitamo a Gitoya Intego- nyuguti"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+#, fuzzy
+msgid "Accelerator key"
+msgstr "Ifunguzo yihutisha:"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+#, fuzzy
+msgid "The type of accelerator."
+msgstr "Ubwoko Bya"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:197
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+msgid "Disabled"
+msgstr "Yahagaritswe"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:545
+msgid "<Unknown Action>"
+msgstr ""
+
+# sfx2/source\explorer\explorer.src:STR_SFX_DESKTOP.text
+#: ../capplets/keybindings/gnome-keybinding-properties.c:566
+msgid "Desktop"
+msgstr "Ibiro"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:567
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Ijwi"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:571
+msgid "Window Management"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:668
+#, fuzzy, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr "Iy'ibusamo ni kugirango"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:700
+#, fuzzy, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr "Igenamiterere Gishya in Iboneza Ububikoshingiro"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:750
+#, fuzzy, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr "in Iboneza Ububikoshingiro"
+
+# sc/source\ui\miscdlgs\acredlin.src:RID_POPUP_CHANGES.SC_SUB_SORT.SC_SORT_ACTION.text
+#: ../capplets/keybindings/gnome-keybinding-properties.c:857
+msgid "Action"
+msgstr "Igikorwa"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:881
+msgid "Shortcut"
+msgstr "Iy'ubusamo"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+#, fuzzy
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"Guhindura a Iy'ibusamo Urufunguzo Kanda ku i Urubariro Na Ubwoko a Gishya "
+"Cyangwa Kanda Gusiba usubira inyuma Kuri Gusiba"
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+#, fuzzy
+msgid "Assign shortcut keys to commands"
+msgstr "Iy'ibusamo Utubuto Kuri Amabwiriza"
+
+# filter/source\xsltdialog\xmlfilterdialogstrings.src:STR_UNKNOWN_APPLICATION.text
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+msgid "Unknown"
+msgstr "Kitazwi"
+
+# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
+# sch/source\core\glob.src:STR_LAYOUT.text
+# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
+# sch/source\ui\dlg\attrib.src:TAB_DATA_POINT.1.TP_LAYOUT.text
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+msgid "Layout"
+msgstr "Imigaragarire"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+msgid "Default"
+msgstr "Mburabuzi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+#, fuzzy
+msgid "Models"
+msgstr "Ingerofatizo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:106
+#, fuzzy, c-format
+msgid "There was an error launching the keyboard capplet : %s"
+msgstr "Ikosa i Mwandikisho"
+
+# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_GENERAL_OPTIONS.13.text
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+#, fuzzy
+msgid "_Accessibility"
+msgstr "Ubushobozi bwo gukoreshwa"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:240
+#: ../capplets/sound/sound-properties-capplet.c:242
+#, fuzzy
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr "Gukurikiza Amagenamiterere Na Kuvamo Bihuye neza NONEAHA ku"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+#, fuzzy
+msgid "Start the page with the typing break settings showing"
+msgstr "Gutangira i Ipaji Na: i Kwandika: itandukanya Amagenamiterere"
+
+# #-#-#-#-#  svx.pot (PACKAGE VERSION)  #-#-#-#-#
+# svx/source\dialog\ctredlin.src:SID_REDLIN_FILTER_PAGE.BTN_REF.text
+# #-#-#-#-#  svx.pot (PACKAGE VERSION)  #-#-#-#-#
+# svx/source\form\fmsearch.src:RID_SVXDLG_SEARCHFORM.PB_APPROXSETTINGS.text
+# #-#-#-#-#  svx.pot (PACKAGE VERSION)  #-#-#-#-#
+# svx/source\form\fmsearch.src:RID_SVXDLG_SEARCHFORM.PB_SOUNDSLIKESETTINGS.text
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "..."
+msgstr "..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+#, fuzzy
+msgid "<b>Cursor Blinking</b>"
+msgstr "<B B"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+#, fuzzy
+msgid "<b>Repeat Keys</b>"
+msgstr "<B B"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+#, fuzzy
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<B Mugaragaza Kuri Kwandika: itandukanya B"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+#, fuzzy
+msgid "<small><i>Fast</i></small>"
+msgstr "<Gitoya i i Gitoya"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+#, fuzzy
+msgid "<small><i>Long</i></small>"
+msgstr "<Gitoya i i Gitoya"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+#, fuzzy
+msgid "<small><i>Short</i></small>"
+msgstr "<Gitoya i i Gitoya"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+#, fuzzy
+msgid "<small><i>Slow</i></small>"
+msgstr "<Gitoya i i Gitoya"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+#, fuzzy
+msgid "A_vailable layouts:"
+msgstr "Imigaragarire"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+#, fuzzy
+msgid "All_ow postponing of breaks"
+msgstr "Bya Amataruka"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+#, fuzzy
+msgid "Check if breaks are allowed to be postponed"
+msgstr "NIBA Amataruka Kuri"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+#, fuzzy
+msgid "Choose A Keyboard Model"
+msgstr "A"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+#, fuzzy
+msgid "Choose A Layout"
+msgstr "A"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+#, fuzzy
+msgid "Cursor _blinks in text boxes and fields"
+msgstr "in Umwandiko Na Imyanya"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+#, fuzzy
+msgid "Duration of the break when typing is disallowed"
+msgstr "Igihebimara Bya i itandukanya Ryari: Kwandika: ni"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+#, fuzzy
+msgid "Duration of work before forcing a break"
+msgstr "Igihebimara Bya Akazi Mbere a itandukanya"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+#, fuzzy
+msgid "Key presses _repeat when key is held down"
+msgstr "Gusubiramo Ryari: Urufunguzo ni Hasi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Keyboard Preferences"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+#, fuzzy
+msgid "Keyboard _model:"
+msgstr "Urugero"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Layout Options"
+msgstr ""
+
+# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
+# sch/source\core\glob.src:STR_LAYOUT.text
+# #-#-#-#-#  sch.pot (PACKAGE VERSION)  #-#-#-#-#
+# sch/source\ui\dlg\attrib.src:TAB_DATA_POINT.1.TP_LAYOUT.text
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Layouts"
+msgstr "Imigaragarire"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+#, fuzzy
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Mugaragaza Nyuma a Igihe- ngombwa Kuri Ifashayobora Mwandikisho Gukoresha"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Microsoft Natural Keyboard"
+msgstr ""
+
+# svx/source\dialog\rubydialog.src:RID_SVXDLG_RUBY.FT_PREVIEW.text
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Preview:"
+msgstr "Igaragazambere:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Reset To De_faults"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+#, fuzzy
+msgid "Separate _group for each window"
+msgstr "Itsinda kugirango Idirishya"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Typing Break"
+msgstr ""
+
+# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_GENERAL_OPTIONS.13.text
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+#, fuzzy
+msgid "_Accessibility..."
+msgstr "Ubushobozi bwo gukoreshwa"
+
+# padmin/source\padialog.src:RID_FONTNAMEDIALOG.RID_FNTNM_BTN_IMPORT.text
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#, fuzzy
+msgid "_Add..."
+msgstr "Kongeraho"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+#, fuzzy
+msgid "_Break interval lasts:"
+msgstr "Intera"
+
+# svx/source\dialog\textanim.src:RID_SVXPAGE_TEXTANIMATION.FT_DELAY.text
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+#, fuzzy
+msgid "_Delay:"
+msgstr "Gutinda"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#, fuzzy
+msgid "_Models:"
+msgstr "Ingerofatizo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+#, fuzzy
+msgid "_Selected layouts:"
+msgstr "Imigaragarire"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+#, fuzzy
+msgid "_Speed:"
+msgstr "Umuvuduko"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+#, fuzzy
+msgid "_Work interval lasts:"
+msgstr "Intera"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "minutes"
+msgstr "iminota"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your keyboard preferences"
+msgstr "Mwandikisho Ibyahiswemo"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:559
+msgid "Unknown Cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+msgid "Default Cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+#, fuzzy
+msgid "The default cursor that ships with X"
+msgstr "Mburabuzi indanga Na:"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+msgid "White Cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+#, fuzzy
+msgid "The default cursor inverted"
+msgstr "Mburabuzi indanga"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+msgid "Large Cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+#, fuzzy
+msgid "Large version of normal cursor"
+msgstr "Verisiyo Bya Bisanzwe indanga"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+msgid "Large White Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+#, fuzzy
+msgid "Large version of white cursor"
+msgstr "Verisiyo Bya Umweru indanga"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:975
+msgid "Cursor Theme"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+#, fuzzy
+msgid "<b>Double-Click Timeout </b>"
+msgstr "<B B"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+#, fuzzy
+msgid "<b>Drag and Drop</b>"
+msgstr "<B Na B"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+#, fuzzy
+msgid "<b>Locate Pointer</b>"
+msgstr "<B B"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+#, fuzzy
+msgid "<b>Mouse Orientation</b>"
+msgstr "<B B"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+#, fuzzy
+msgid "<b>Speed</b>"
+msgstr "<B B"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+#, fuzzy
+msgid "<i>Fast</i>"
+msgstr "<i i"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+#, fuzzy
+msgid "<i>High</i>"
+msgstr "<i i"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+#, fuzzy
+msgid "<i>Large</i>"
+msgstr "<i i"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+#, fuzzy
+msgid "<i>Low</i>"
+msgstr "<i i"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+#, fuzzy
+msgid "<i>Slow</i>"
+msgstr "<i i"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+#, fuzzy
+msgid "<i>Small</i>"
+msgstr "<i i"
+
+# sfx2/source\toolbox\tbxcust.src:RID_USERDEFBMP.GB_FUNCTION.text
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Utubuto"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+msgid "Cursor Size:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Cursors"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+#, fuzzy
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr "i Mweretsi Ryari: Kanda"
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.LB_BIG.3.text
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+#, fuzzy
+msgid "Large"
+msgstr "Binini"
+
+# officecfg/registry\schema\org\openoffice\Office\Math.xcs:....FontFormat.Weight..6.text
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+#, fuzzy
+msgid "Medium"
+msgstr "biringaniye"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Motion"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Mouse Preferences"
+msgstr ""
+
+# officecfg/registry\schema\org\openoffice\Office\Common.xcs:....View.Window.Flag..02.text
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#, fuzzy
+msgid "Small"
+msgstr "Gitoya"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+#, fuzzy
+msgid "_Left-handed mouse"
+msgstr "Imbeba"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+#, fuzzy
+msgid "_Timeout:"
+msgstr "Igihe cyarenze:"
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.FL_MOUSE.text
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Imbeba"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your mouse preferences"
+msgstr "Imbeba Ibyahiswemo"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your network proxy preferences"
+msgstr "urusobe Porogisi Ibyahiswemo"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+#, fuzzy
+msgid "<b>D_irect internet connection</b>"
+msgstr "<B Interineti Ukwihuza B"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+#, fuzzy
+msgid "<b>Ignore Host List</b>"
+msgstr "<B Ubuturo Urutonde B"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+#, fuzzy
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<B Porogisi Iboneza B"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+#, fuzzy
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<B Porogisi Iboneza B"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+#, fuzzy
+msgid "<b>_Use authentication</b>"
+msgstr "<B B"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "Advanced Configuration"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+#, fuzzy
+msgid "H_TTP proxy:"
+msgstr "Porogosi ya HTTP"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Network Proxy Preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Impagikiro:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+#, fuzzy
+msgid "Proxy Configuration"
+msgstr "Iboneza rya porogosi..."
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+#, fuzzy
+msgid "S_ocks host:"
+msgstr "Inturo SOCKS:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+#, fuzzy
+msgid "U_sername:"
+msgstr "Izina ry'ukoresha"
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+#, fuzzy
+msgid "_Details"
+msgstr "Birambuye"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+#, fuzzy
+msgid "_FTP proxy:"
+msgstr "Porogosi ya FTP:"
+
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_PASSWORD.text
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+#, fuzzy
+msgid "_Password:"
+msgstr "Ijambobanga..."
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+#, fuzzy
+msgid "_Secure HTTP proxy:"
+msgstr "Porogisi"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+#, fuzzy
+msgid "Enable sound and associate sounds with events"
+msgstr "Ijwi Na Amajwi Na: Ibyabaye"
+
+#: ../capplets/sound/sound-properties-capplet.c:271
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Sound Preferences"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:1
+#, fuzzy
+msgid "E_nable sound server startup"
+msgstr "Ijwi Seriveri"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+#, fuzzy
+msgid "Flash _entire screen"
+msgstr "Mugaragaza"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+#, fuzzy
+msgid "Flash _window titlebar"
+msgstr "Idirishya"
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "General"
+msgstr "Rusange"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "Sound Events"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "System Bell"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "_Sound an audible bell"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:9
+#, fuzzy
+msgid "_Sounds for events"
+msgstr "kugirango Ibyabaye"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "_Visual feedback:"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:347
+#, fuzzy
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+"Insanganyamatsiko Byabonetse ku Sisitemu Ikiganiro Cyangwa i "
+"Insanganyamatsiko"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:227
+#, fuzzy
+msgid "This theme is not in a supported format."
+msgstr "ni OYA in a Imiterere"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:244
+#, fuzzy
+msgid "Failed to create temporary directory"
+msgstr "Kuri Kurema By'igihe gito bushyinguro"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:264
+#, fuzzy
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr "OYA Kwinjiza porogaramu ni OYA"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:282
+#: ../capplets/theme-switcher/gnome-theme-installer.c:319
+#: ../capplets/theme-switcher/gnome-theme-installer.c:399
+msgid "Installation Failed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:302
+#, fuzzy
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr "OYA Kwinjiza porogaramu Insanganyamatsiko ni OYA"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:340
+#, fuzzy, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr "Guhitamo in i Birambuye"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:343
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:346
+#, fuzzy, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr "Guhitamo in i Birambuye"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:349
+#, fuzzy, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr "Guhitamo in i Birambuye"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:357
+#, fuzzy
+msgid "The theme is an engine. You need to compile the theme."
+msgstr "ni Kuri Gukusanya i"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:374
+#, fuzzy
+msgid "The file format is invalid"
+msgstr "IDOSIYE Imiterere ni Sibyo"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:468
+#, fuzzy
+msgid "No theme file location specified to install"
+msgstr "IDOSIYE Ahantu Kuri Kwinjiza porogaramu"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:485
+#, fuzzy
+msgid "The theme file location specified to install is invalid"
+msgstr "IDOSIYE Ahantu Kuri Kwinjiza porogaramu ni Sibyo"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:505
+#, fuzzy, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr "Uruhushya Kuri Kwinjiza porogaramu i in"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:526
+#, fuzzy
+msgid "The file format is invalid."
+msgstr "IDOSIYE Imiterere ni Sibyo"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:553
+#, fuzzy, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr "%sni i Inzira i Idosiye OYA Byahiswemo Nka i Inkomoko Ahantu"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:607
+#, fuzzy
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr "Kwinjiza porogaramu Porogaramu ni OYA ku Sisitemu"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+#, fuzzy
+msgid "Custom theme"
+msgstr "Kugena"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+#, fuzzy
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr "Kubika iyi ku i Kubika Akabuto"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
+#, fuzzy
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr "Mburabuzi OYA Byabonetse ku Sisitemu Cyangwa ni"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:72
+#, fuzzy
+msgid "Theme name must be present"
+msgstr "Izina:"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:104
+#, fuzzy
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "nka Kuri Gusimbura"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+#, fuzzy
+msgid "Select themes for various parts of the desktop"
+msgstr "Insanganyamatsiko kugirango Bya i Ibiro"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-install.glade.h:2
+#, fuzzy
+msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+msgstr "<Ingano Kinini Uburemere UTSINDAGIYE a"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:3
+msgid "Theme Installation"
+msgstr ""
+
+# #-#-#-#-#  setup2.pot (PACKAGE VERSION)  #-#-#-#-#
+# setup2/source\ui\pages\plang.src:RESID_PAGE_PAGELANGUAGE.STR_PROG.text
+# #-#-#-#-#  setup2.pot (PACKAGE VERSION)  #-#-#-#-#
+# setup2/source\uibase\agentdlg.src:RC_AGENTDLG.RESID_DLG_AGENT_STR_INSTALL.text
+#: ../capplets/theme-switcher/theme-install.glade.h:4
+#, fuzzy
+msgid "_Install"
+msgstr "Kwinjiza porogaramu"
+
+# padmin/source\padialog.src:RID_PADIALOG.RID_PA_TXT_LOCATION.text
+#: ../capplets/theme-switcher/theme-install.glade.h:5
+#, fuzzy
+msgid "_Location:"
+msgstr "Intaho:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+#, fuzzy
+msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+msgstr "<Ingano Kinini Uburemere UTSINDAGIYE Kubika Kuri"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Apply _Background"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Apply _Font"
+msgstr ""
+
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_BASICIDE_OBJECTBAR.SID_CHOOSE_CONTROLS.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\tbxctl.src:RID_TBXCONTROLS.RID_TOOLBOX.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\tbxctl.src:RID_TBXCONTROLS.text
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Controls"
+msgstr "Amagenzura"
+
+# sfx2/source\appl\app.src:STR_KEY_BITMAP_PATH.text
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "Icons"
+msgstr "Udushushondanga"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+#, fuzzy
+msgid "New themes can also be installed by dragging them into the window."
+msgstr "Insanganyamatsiko ku i Idirishya"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+#, fuzzy
+msgid "Save Theme"
+msgstr "Kubika"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+#, fuzzy
+msgid "Select theme for the desktop"
+msgstr "kugirango i Ibiro"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+#, fuzzy
+msgid "Short _description:"
+msgstr "Isobanuramiterere"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "Theme Details"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "Theme Preferences"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+msgid "Theme _Details"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+#, fuzzy
+msgid "This theme does not suggest any particular font or background."
+msgstr "OYA Intego- nyuguti Cyangwa Mbuganyuma"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+#, fuzzy
+msgid "This theme suggests a background:"
+msgstr "a Mbuganyuma"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+#, fuzzy
+msgid "This theme suggests a font and a background:"
+msgstr "a Intego- nyuguti Na a Mbuganyuma"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+#, fuzzy
+msgid "This theme suggests a font:"
+msgstr "a Intego- nyuguti"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "Window Border"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+msgid "_Go To Theme Folder"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+msgid "_Install Theme..."
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+#, fuzzy
+msgid "_Revert"
+msgstr "Kugaruza"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+#, fuzzy
+msgid "_Save Theme..."
+msgstr "Kubika"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+#, fuzzy
+msgid "_Theme name:"
+msgstr "Izina:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:24
+#, fuzzy
+msgid "theme selection tree"
+msgstr "Ihitamo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+#, fuzzy
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr "i Imigaragarire Bya Imyanya y'ibikoresho Na in Porogaramu"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+#, fuzzy
+msgid "<b>Behavior and Appearance</b>"
+msgstr "<B Na B"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+#, fuzzy
+msgid "<b>Preview</b>"
+msgstr "<B B"
+
+# dbaccess/source/ui/inc/toolbox.hrc:MID_SBA_QRY_CUT.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+#, fuzzy
+msgid "C_ut"
+msgstr "Gukata"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+#, fuzzy
+msgid "Icons only"
+msgstr "Udushushondanga Gusa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+#, fuzzy
+msgid "Menu and Toolbar Preferences"
+msgstr "Na"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+#, fuzzy
+msgid "New File"
+msgstr "Idosiye"
+
+# sfx2/sdi\sfxslots.src:SID_OPENDOC.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Gufungura Dosiye"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Bika idosiye"
+
+# offmgr/source\offapp\dialog\optgdlg.src:OFA_TP_VIEW.CB_MENU_ICONS.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+#, fuzzy
+msgid "Show _icons in menus"
+msgstr "Kugaragaza udushushondanga mu bikubiyemo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+#, fuzzy
+msgid "Text below icons"
+msgstr "munsi Udushushondanga"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+#, fuzzy
+msgid "Text beside icons"
+msgstr "Udushushondanga"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+msgid "Text only"
+msgstr "Umwandiko gusa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+#, fuzzy
+msgid "Toolbar _button labels:"
+msgstr "Akabuto Uturango..."
+
+# dbaccess/source/ui/inc/toolbox.hrc:MID_SBA_QRY_COPY.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+#, fuzzy
+msgid "_Copy"
+msgstr "Gukoporora"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+#, fuzzy
+msgid "_Detachable toolbars"
+msgstr "Imyanya y'ibikoresho"
+
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_BASICMENU.MN_EDIT.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\basidesh.src:RID_BASICPLUGINMENU.MN_PLEDIT.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\macrodlg.src:RID_MACROCHOOSER.RID_PB_EDIT.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\moduldlg.src:RID_TP_MODULS.RID_PB_EDIT.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\moduldlg.src:RID_TP_LIBS.RID_PB_EDIT.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+#, fuzzy
+msgid "_Edit"
+msgstr "Guhindura"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+#, fuzzy
+msgid "_Editable menu accelerators"
+msgstr "Ibikubiyemo"
+
+# sc/source\ui\src\globstr.src:RID_GLOBSTR.STR_HFCMD_FILE.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+#, fuzzy
+msgid "_File"
+msgstr "IDOSIYE"
+
+# basctl/source\basicide\brkdlg.src:RID_BASICIDE_BREAKPOINTDLG.RID_PB_NEW.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+#, fuzzy
+msgid "_New"
+msgstr "Gishya"
+
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\accel\accel.src:STR_OPEN.text
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\cfg.src:STR_OPEN.text
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\versdlg.src:DLG_VERSIONS.PB_OPEN.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+#, fuzzy
+msgid "_Open"
+msgstr "Gufungura"
+
+# dbaccess/source/ui/inc/toolbox.hrc:MID_SBA_QRY_PASTE.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+#, fuzzy
+msgid "_Paste"
+msgstr "Komeka"
+
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+# #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+#, fuzzy
+msgid "_Print"
+msgstr "Gucapa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+#, fuzzy
+msgid "_Quit"
+msgstr "Kuvamo"
+
+# basctl/source\basicide\basidesh.src:RID_STR_SAVE.text
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+#, fuzzy
+msgid "_Save"
+msgstr "Kubika"
+
+#: ../capplets/windows/gnome-window-properties.c:386
+#, fuzzy, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr "<B Gutangira i Ibyahiswemo Porogaramu kugirango Idirishya Muyobozi B"
+
+#: ../capplets/windows/gnome-window-properties.c:644
+msgid "Control"
+msgstr "Igenzura"
+
+#: ../capplets/windows/gnome-window-properties.c:649
+msgid "Alt"
+msgstr "Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:655
+msgid "Hyper"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:662
+#, fuzzy
+msgid "Super (or \"Windows logo\")"
+msgstr "Cyangwa ikirango"
+
+# the command key
+#: ../capplets/windows/gnome-window-properties.c:669
+msgid "Meta"
+msgstr "Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+#, fuzzy
+msgid "<b>Movement Key</b>"
+msgstr "<B B"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+#, fuzzy
+msgid "<b>Titlebar Action</b>"
+msgstr "<B B"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+#, fuzzy
+msgid "<b>Window Selection</b>"
+msgstr "<B B"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+#, fuzzy
+msgid "To _move a window, press-and-hold this key then grab the window:"
+msgstr "Kwimura a Idirishya Kanda Na iyi Urufunguzo Hanyuma i Idirishya"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+#, fuzzy
+msgid "_Double-click titlebar to perform this action:"
+msgstr "Kanda Kuri iyi Igikorwa"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+#, fuzzy
+msgid "_Interval before raising:"
+msgstr "Mbere"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+#, fuzzy
+msgid "_Raise selected windows after an interval"
+msgstr "Byahiswemo Nyuma Intera"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+#, fuzzy
+msgid "_Select windows when the mouse moves over them"
+msgstr "Ryari: i Imbeba KURI"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+#, fuzzy
+msgid "Set your window properties"
+msgstr "Idirishya Indangakintu..."
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr ""
+
+# starmath/source\smres.src:RID_TOOLBOXWINDOW.10.RID_MISC_CAT.text
+#: ../control-center/control-center-categories.c:257
+msgid "Others"
+msgstr "Ibindi"
+
+#: ../control-center/control-center.c:42
+msgid "Desktop Preferences"
+msgstr ""
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr ""
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+#, fuzzy
+msgid "The GNOME configuration tool"
+msgstr "Iboneza"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "Igice"
+
+#: ../gnome-settings-daemon/factory.c:36
+#, fuzzy
+msgid "Could not initialize Bonobo"
+msgstr "OYA gutangiza"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
+msgid "Slow Keys Alert"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
+#, fuzzy
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Hasi i Urufunguzo kugirango 8 amasogonda ni i Iy'ibusamo kugirango i i "
+"Mwandikisho"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
+#, fuzzy
+msgid "Do you want to activate Slow Keys?"
+msgstr "Kuri Kureka bigakora"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
+#, fuzzy
+msgid "Do you want to deactivate Slow Keys?"
+msgstr "Kuri Kubuza gukora"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Sticky Keys Alert"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+#, fuzzy
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+"i Urufunguzo 5 Times in a Urubariro ni i Iy'ibusamo kugirango i i Mwandikisho"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
+#, fuzzy
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+"Utubuto ku Rimwe Cyangwa i Urufunguzo 5 Times in a Urubariro Bidakora i i "
+"Mwandikisho"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
+#, fuzzy
+msgid "Do you want to activate Sticky Keys?"
+msgstr "Kuri Kureka bigakora"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
+#, fuzzy
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr "Kuri Kubuza gukora"
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:107
+#, fuzzy, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr "Kurema i bushyinguro ni Kuri Kwemerera"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
+#, fuzzy, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr "Igikorwa Igikubo"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
+#, fuzzy, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr "Bifatanya Igikubo"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
+#, fuzzy, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr "ni"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
+#, fuzzy, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr "ni"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
+#, fuzzy, c-format
+msgid "It seems that another application already has access to key '%d'."
+msgstr "Porogaramu Kuri Urufunguzo"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
+#, fuzzy, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr "ni in"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
+#, fuzzy, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr "Kuri Gukoresha ni Kuri i Urufunguzo"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
+#, fuzzy, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+"Iboneza a in a in Seriveri Seriveri Na: Seriveri Verisiyo Ibyatanzwe "
+"Icyegeranyo iyi Nka a Gushyiramo Igisubizo Bya Igisubizo Bya"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+#, fuzzy
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr "3.. 0."
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
+#, fuzzy
+msgid "Do _not show this warning again"
+msgstr "Nta kongera kwerekana iri burira"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
+#, fuzzy
+msgid ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+msgstr ""
+"Sisitemu Mwandikisho Amagenamiterere Bivuye KIGEZWEHO Mwandikisho "
+"Amagenamiterere Gushyiraho nka Kuri Gukoresha"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
+#, fuzzy
+msgid "Use X settings"
+msgstr "Amagenamiterere"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
+#, fuzzy
+msgid "Use GNOME settings"
+msgstr "Amagenamiterere"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
+#, fuzzy, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr "Gukora Komandi: iyi Komandi:"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
+#, fuzzy
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr "Gushyira i Kuri i ni"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
+#, fuzzy, c-format
+msgid "Permissions on the file %s are broken\n"
+msgstr "ku i IDOSIYE"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
+#, fuzzy
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr "Ibirimo i IDOSIYE iyi ni"
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
+#, fuzzy, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr "Ikosa Hejuru i OYA Akazi in iyi Umukoro"
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
+#, fuzzy
+msgid "_Do not show this message again"
+msgstr "OYA Garagaza iyi Ubutumwa"
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:129
+#, fuzzy, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr "Ibirimo Ijwi IDOSIYE Nka Urugero"
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
+#, fuzzy
+msgid "Cannot determine user's home directory"
+msgstr "Ku Ntangiriro bushyinguro"
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
+#, fuzzy, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr "Urufunguzo Gushyiraho Kuri Ubwoko Ikitezwe: Ubwoko"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+#, fuzzy
+msgid "A_vailable files:"
+msgstr "Idosiye"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+#, fuzzy
+msgid "Do _not show this warning again."
+msgstr "Nta kongera kwerekana iri burira"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+#, fuzzy
+msgid "Load modmap files"
+msgstr "Idosiye"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+#, fuzzy
+msgid "Would you like to load the modmap file(s)?"
+msgstr "nka Kuri Ibirimo i IDOSIYE S"
+
+# basctl/source\basicide\basidesh.src:RID_STR_OPEN.text
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+#, fuzzy
+msgid "_Load"
+msgstr "Ibirimo"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+#, fuzzy
+msgid "_Loaded files:"
+msgstr "Idosiye"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr ""
+
+# filter/source\xsltdialog\xmlfilterdialogstrings.src:STR_COLUMN_HEADER_TYPE.text
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Ubwoko"
+
+#: ../libbackground/applier.c:256
+#, fuzzy
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr "Bya kugirango Imizi Idirishya Cyangwa kugirango Igaragazambere"
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr ""
+
+#: ../libbackground/applier.c:264
+#, fuzzy
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr "NIBA ni a Igaragazambere Kuri"
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr ""
+
+#: ../libbackground/applier.c:272
+#, fuzzy
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr "NIBA ni a Igaragazambere Kuri"
+
+# offmgr/source\offapp\dialog\fontsubs.src:RID_SVX_FONT_SUBSTITUTION.STR_HEADER2.text
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Mugaragaza"
+
+#: ../libbackground/applier.c:280
+#, fuzzy
+msgid "Screen on which BGApplier is to draw"
+msgstr "ku ni Kuri Gushushanya"
+
+#: ../libgswitchit/gswitchit_config.c:1035
+#, fuzzy, c-format
+msgid "There was an error loading an image: %s"
+msgstr "Ikosa Ifashayobora"
+
+#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
+#, fuzzy
+msgid "The sound file for this event does not exist."
+msgstr "Ijwi IDOSIYE kugirango iyi Icyabaye OYA"
+
+#: ../libsounds/sound-view.c:149
+#, fuzzy
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package\n"
+"for a set of default sounds."
+msgstr ""
+"Ijwi IDOSIYE kugirango iyi Icyabaye OYA Gicurasi Kuri Kwinjiza porogaramu i "
+"a Gushyiraho Bya Mburabuzi Amajwi"
+
+#: ../libsounds/sound-view.c:224
+#, fuzzy, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "IDOSIYE ni OYA a Byemewe IDOSIYE"
+
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\eventdlg.src:TP_CONFIG_EVENT.STR_EVENT.text
+# #-#-#-#-#  sfx2.pot (PACKAGE VERSION)  #-#-#-#-#
+# sfx2/source\dialog\macropg.src:RID_SFX_TP_MACROASSIGN.STR_EVENT.text
+#: ../libsounds/sound-view.c:289
+msgid "Event"
+msgstr "Icyabaye"
+
+#: ../libsounds/sound-view.c:298
+#, fuzzy
+msgid "Sound File"
+msgstr "Idosiye"
+
+# svx/source\gallery2\galtheme.src:RID_GALLERYSTR_THEME_SOUNDS.text
+#: ../libsounds/sound-view.c:314
+#, fuzzy
+msgid "_Sounds:"
+msgstr "Amajwi"
+
+#: ../libsounds/sound-view.c:328
+#, fuzzy
+msgid "Sound _file:"
+msgstr "IDOSIYE"
+
+#: ../libsounds/sound-view.c:332
+#, fuzzy
+msgid "Select Sound File"
+msgstr "Idosiye"
+
+#: ../libsounds/sound-view.c:356
+#, fuzzy
+msgid "_Play"
+msgstr "Gukina"
+
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_FONTSUBSTPAGE.RID_RTS_FS_REMOVE_BTN.text
+# #-#-#-#-#  padmin.pot (PACKAGE VERSION)  #-#-#-#-#
+# padmin/source\rtsetup.src:RID_RTS_COMMANDPAGE.RID_RTS_CMD_BTN_REMOVE.text
+#: ../libsounds/sound-view.c:366
+#, fuzzy
+msgid "_Remove"
+msgstr "Gukuraho"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, fuzzy, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "Muyobozi OYA a Iboneza"
+
+# sc/source\ui\formdlg\formdlgs.src:RID_SCDLG_FORMULA.RB_REF.quickhelptext
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Kugira kinini"
+
+# vcl/source\src\helptext.src:SV_HELPTEXT_ROLLUP.text
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Kuzamura"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+#, fuzzy
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr "NIBYO i kugirango Umwandiko Byuzuye Na Umwandiko in"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+#, fuzzy
+msgid "Sync text/plain and text/* handlers"
+msgstr "Umwandiko Byuzuye Na Umwandiko"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+#, fuzzy
+msgid "Brightness down"
+msgstr "Hasi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+#, fuzzy
+msgid "Brightness down's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+#, fuzzy
+msgid "Brightness up"
+msgstr "Hejuru"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+#, fuzzy
+msgid "Brightness up's shortcut."
+msgstr "Iy'ibusamo"
+
+# #-#-#-#-#  officecfg.pot (PACKAGE VERSION)  #-#-#-#-#
+# officecfg/registry\data\org\openoffice\Office\DataAccess.xcu:..DataAccess.DriverSettings.com.sun.star.comp.sdbc.MozabDriver.ColumnAliases.PrimaryEmail.text
+# #-#-#-#-#  officecfg.pot (PACKAGE VERSION)  #-#-#-#-#
+# officecfg/registry\schema\org\openoffice\Office\Writer.xcs:....BusinessCard.PrivateAddress.Email.text
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "E-mail"
+msgstr "Imeli"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+#, fuzzy
+msgid "E-mail's shortcut."
+msgstr "E Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Eject"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+#, fuzzy
+msgid "Eject's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+#, fuzzy
+msgid "Home folder"
+msgstr "Ububiko"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+#, fuzzy
+msgid "Home folder's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+#, fuzzy
+msgid "Launch help browser"
+msgstr "Ifashayobora Mucukumbuzi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+#, fuzzy
+msgid "Launch help browser's shortcut."
+msgstr "Ifashayobora Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+#, fuzzy
+msgid "Launch web browser"
+msgstr "Urubuga Mucukumbuzi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+#, fuzzy
+msgid "Launch web browser's shortcut."
+msgstr "Urubuga Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+#, fuzzy
+msgid "Lock screen"
+msgstr "Mugaragaza"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+#, fuzzy
+msgid "Lock screen's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+#, fuzzy
+msgid "Log out"
+msgstr "Kuvamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+#, fuzzy
+msgid "Log out's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+#, fuzzy
+msgid "Next track key's shortcut."
+msgstr "Iy'ibusamo"
+
+# 4630
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Pause"
+msgstr "akaruhuko"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+#, fuzzy
+msgid "Pause key's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+#, fuzzy
+msgid "Play (or play/pause)"
+msgstr "Cyangwa Gukina Akaruhuko..."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+#, fuzzy
+msgid "Play (or play/pause) key's shortcut."
+msgstr "Cyangwa Gukina Akaruhuko... Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+#, fuzzy
+msgid "Previous track key's shortcut."
+msgstr "Iy'ibusamo"
+
+# #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
+# offmgr/source\offapp\dialog\inetdlg.src:RID_OFADLG_INTERNET.1.RID_SVXPAGE_INET_SEARCH.text
+# #-#-#-#-#  offmgr.pot (PACKAGE VERSION)  #-#-#-#-#
+# offmgr/source\offapp\dialog\treeopt.src:RID_OFADLG_OPTIONS_TREE_PAGES.SID_INET_DLG.3.text
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Search"
+msgstr "Gushaka"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+#, fuzzy
+msgid "Search's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+#, fuzzy
+msgid "Skip to next track"
+msgstr "Kuri Komeza>>"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+#, fuzzy
+msgid "Skip to previous track"
+msgstr "Kuri Ibanjirije"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Sleep"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+#, fuzzy
+msgid "Sleep's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+#, fuzzy
+msgid "Stop playback key"
+msgstr "Urufunguzo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+#, fuzzy
+msgid "Stop playback key's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+#, fuzzy
+msgid "Volume down"
+msgstr "Hasi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+#, fuzzy
+msgid "Volume down's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+#, fuzzy
+msgid "Volume mute"
+msgstr "Mute"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+#, fuzzy
+msgid "Volume mute's shortcut"
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+#, fuzzy
+msgid "Volume step"
+msgstr "Intera"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+#, fuzzy
+msgid "Volume step as percentage of volume."
+msgstr "Intera Nka Ijanisha Bya Igice"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+#, fuzzy
+msgid "Volume up"
+msgstr "Hejuru"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
+#, fuzzy
+msgid "Volume up's shortcut."
+msgstr "Iy'ibusamo"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+#, fuzzy
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr "a Ikiganiro Ryari: Amakosa"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+#, fuzzy
+msgid "Run screensaver at login"
+msgstr "ku Ifashayinjira"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#, fuzzy
+msgid "Start screensaver"
+msgstr "Gutangira"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+#, fuzzy
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+"A Bya Inyandikoporogaramu Kuri Gukoresha i Mwandikisho Leta ni kugirango"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+#, fuzzy
+msgid "A list of modmap files available in the $HOME directory."
+msgstr "A Urutonde Bya Idosiye Bihari in i bushyinguro"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+#, fuzzy
+msgid "Default group, assigned on window creation"
+msgstr "Itsinda ku Idirishya"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+#, fuzzy
+msgid "Keep and manage separate group per window"
+msgstr "Na kuyobora Itsinda Idirishya"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+msgid "Keyboard Update Handlers"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#, fuzzy
+msgid "Keyboard layout"
+msgstr "Imigaragarire"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#, fuzzy
+msgid "Keyboard model"
+msgstr "Urugero"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+#, fuzzy
+msgid "Keyboard options"
+msgstr "Amahitamo"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+#, fuzzy
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr "Amagenamiterere in Bivuye i Sisitemu"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+#, fuzzy
+msgid "Save/restore indicators together with layout groups"
+msgstr "Kubika Kugarura Na: Imigaragarire Amatsinda"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+#, fuzzy
+msgid "Show layout names instead of group names"
+msgstr "Imigaragarire Amazina Bya Itsinda Amazina"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+#, fuzzy
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+"Imigaragarire Amazina Bya Itsinda Amazina kugirango Uburyo Bya Igikubo "
+"Imigaragarire"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+#, fuzzy
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr "i Byahinduwe Iburira Ubutumwa"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+#, fuzzy
+msgid "keyboard layout"
+msgstr "Mwandikisho Imigaragarire"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+#, fuzzy
+msgid "keyboard model"
+msgstr "Mwandikisho Urugero"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+#, fuzzy
+msgid "modmap file list"
+msgstr "IDOSIYE Urutonde"
+
+#: ../typing-break/drw-break-window.c:212
+#, fuzzy
+msgid "_Postpone break"
+msgstr "itandukanya"
+
+#: ../typing-break/drw-break-window.c:259
+#, fuzzy
+msgid "Take a break!"
+msgstr "a itandukanya"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:141
+msgid "/_Preferences"
+msgstr ""
+
+#: ../typing-break/drwright.c:142
+#, fuzzy
+msgid "/_About"
+msgstr "/Bigyanye"
+
+#: ../typing-break/drwright.c:144
+#, fuzzy
+msgid "/_Take a Break"
+msgstr "/a"
+
+#: ../typing-break/drwright.c:495
+#, fuzzy, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "%dUMUNOTA i Komeza>> itandukanya"
+
+#: ../typing-break/drwright.c:499
+#, fuzzy
+msgid "Less than one minute until the next break"
+msgstr "UMUNOTA i Komeza>> itandukanya"
+
+#: ../typing-break/drwright.c:587
+#, fuzzy, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Kuri Hejuru i Kwandika: itandukanya Indangakintu... Ikiganiro Na: i Ikosa"
+
+#: ../typing-break/drwright.c:635
+msgid "About GNOME Typing Monitor"
+msgstr ""
+
+#: ../typing-break/drwright.c:659
+#, fuzzy
+msgid "A computer break reminder."
+msgstr "A itandukanya Mwibutsa"
+
+#: ../typing-break/drwright.c:660
+#, fuzzy
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr "ku"
+
+#: ../typing-break/drwright.c:661
+#, fuzzy
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Kyongewe ku"
+
+#: ../typing-break/drwright.c:837
+#, fuzzy
+msgid "Break reminder"
+msgstr "Mwibutsa"
+
+#: ../typing-break/main.c:93
+#, fuzzy
+msgid "The typing monitor is already running."
+msgstr "Kwandika: ni"
+
+#: ../typing-break/main.c:106
+#, fuzzy
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Kwandika: i Ikimenyetso Ubuso Kuri Kugaragaza Ibisobanuro Kuri a Ikimenyetso "
+"Ubuso ku Kongeramo ku Iburyo: ku Na Kuri Na"
+
+#: ../vfs-methods/fontilus/font-view.c:115
+#, fuzzy
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "Igihogo KURI i"
+
+# sc/source\ui\dbgui\pvfundlg.src:RID_SCDLG_PIVOTSUBT.FT_NAMELABEL.text
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "Izina:"
+
+# sfx2/source\dialog\filedlghelper.src:STR_LB_IMAGE_TEMPLATE.text
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "Imisusire"
+
+# sfx2/source\dialog\dinfdlg.src:TP_DOCINFODOC.FT_FILE_TYP.text
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "Ubwoko"
+
+# sfx2/source\dialog\dinfdlg.src:TP_DOCINFODOC.FT_FILE_SIZE.text
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "Ingano"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "Verisiyo:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+#, fuzzy
+msgid "Copyright:"
+msgstr "Uburenganzira bw'umuhimbyi"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "Umwirondoro"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, fuzzy, c-format
+msgid "usage: %s fontfile\n"
+msgstr "Ikoresha:"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+#, fuzzy
+msgid "Set as Application Font"
+msgstr "Nka"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+#, fuzzy
+msgid "Sets the default application font"
+msgstr "i Mburabuzi Porogaramu Intego- nyuguti"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+#, fuzzy
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+#, fuzzy
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+#, fuzzy
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+#, fuzzy
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "Gushyiraho Kuri NIBYO Hanyuma Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+#, fuzzy
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+#, fuzzy
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+#, fuzzy
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+#, fuzzy
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+#, fuzzy
+msgid "Thumbnail command for OpenType fonts"
+msgstr "Komandi: kugirango Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+#, fuzzy
+msgid "Thumbnail command for PCF fonts"
+msgstr "Komandi: kugirango Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+#, fuzzy
+msgid "Thumbnail command for TrueType fonts"
+msgstr "Komandi: kugirango Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+#, fuzzy
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Komandi: kugirango Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+#, fuzzy
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "Kuri Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+#, fuzzy
+msgid "Whether to thumbnail PCF fonts"
+msgstr "Kuri Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+#, fuzzy
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "Kuri Imyandikire"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+#, fuzzy
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "Kuri Imyandikire"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+msgid "GNOME Font Viewer"
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+#, fuzzy
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr "<Uburemere UTSINDAGIYE Ingano Kinini Gishya Intego- nyuguti"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+#, fuzzy
+msgid "Do _not apply font"
+msgstr "OYA Gukurikiza Intego- nyuguti"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+#, fuzzy
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"Byahiswemo a Gishya Intego- nyuguti A Igaragazambere Bya i Intego- nyuguti "
+"ni munsi"
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+#, fuzzy
+msgid "_Apply font"
+msgstr "Intego- nyuguti"
+
+# LOCALIZATION NOTE : FILE Theme management prefs
+#: ../vfs-methods/themus/theme-method.c:520
+msgid "Themes"
+msgstr "Insanganyamatsiko"
+
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\moptions.src:RID_MACROOPTIONS.RID_FT_DESCR.text
+# #-#-#-#-#  basctl.pot (PACKAGE VERSION)  #-#-#-#-#
+# basctl/source\basicide\moptions.src:RID_MACROOPTIONS.text
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "Isobanuramiterere"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr ""
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+#, fuzzy
+msgid "Window border theme"
+msgstr "Imbibi"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr ""
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr ""
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+#, fuzzy
+msgid "Apply theme"
+msgstr "Gushyiraho insanganyamatsiko"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+#, fuzzy
+msgid "Sets the default theme"
+msgstr "i Mburabuzi"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+#, fuzzy
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr "Gushyiraho Kuri NIBYO Hanyuma Insanganyamatsiko"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+#, fuzzy
+msgid "If set to true, then themes will be thumbnailed."
+msgstr "Gushyiraho Kuri NIBYO Hanyuma Insanganyamatsiko"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+#, fuzzy
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Insanganyamatsiko"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+#, fuzzy
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr "iyi Urufunguzo Kuri i Komandi: Kuri Kurema kugirango Insanganyamatsiko"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+#, fuzzy
+msgid "Thumbnail command for installed themes"
+msgstr "Komandi: kugirango Insanganyamatsiko"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+#, fuzzy
+msgid "Thumbnail command for themes"
+msgstr "Komandi: kugirango Insanganyamatsiko"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+#, fuzzy
+msgid "Whether to thumbnail installed themes"
+msgstr "Kuri Insanganyamatsiko"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+#, fuzzy
+msgid "Whether to thumbnail themes"
+msgstr "Kuri Insanganyamatsiko"
+
+#, fuzzy
+msgid "Show help options"
+msgstr "Ifashayobora Amahitamo"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: si\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2007-08-08 03:22+0100\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2007-08-08 14:58+0530\n"
 "Last-Translator: Danishka Navin <snavin@redhat.com>\n"
 "Language-Team: Sinhala <en@li.org>\n"
@@ -18,3753 +18,5452 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: KBabel 1.11.4\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "පිළිඹිබුව/ලේබලය රාමුව"
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "විපරම් සංවාද කොටුව තුළ වූ ලේබලය සහ පිළිඹිබුව වටා ඇති රාමුවේ ඝනකම"
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr "විපරම් වර්ගය"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "විපරමෙහි වර්ගය"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "විපරම් බොත්තම්"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "විපරම් සංවාද කොටුව තුළ පෙන්වන බොත්තම් වර්‍ග"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "වැඩි විස්තර පෙන්වන්න (_d)"
-
-#: ../capplets/about-me/gnome-about-me.c:635
-msgid "Select Image"
-msgstr "පිළිඹිබුව තෝරන්න"
-
-#: ../capplets/about-me/gnome-about-me.c:637
-msgid "No Image"
-msgstr "පිළිඹිබු නැත"
-
-#: ../capplets/about-me/gnome-about-me.c:665
-#: ../capplets/appearance/appearance-desktop.c:1059
-msgid "Images"
-msgstr "පිළිඹිබු"
-
-#: ../capplets/about-me/gnome-about-me.c:669
-#: ../capplets/appearance/theme-installer.c:619
-msgid "All Files"
-msgstr "සියළුම ගොනු"
-
-#: ../capplets/about-me/gnome-about-me.c:806
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:827
-msgid "Unable to open address book"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:839
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:869
-#: ../capplets/about-me/gnome-about-me.c:871
-#, c-format
-msgid "About %s"
-msgstr "%s සම්බන්ධව"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "About Me"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/appearance/data/appearance.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-msgid "    "
-msgstr "    "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Email</b>"
-msgstr "<b>විද්‍යුත් තැපැල</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Home</b>"
-msgstr "<b>නිවස</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>ක්‍ෂණික පණිවිඩ</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Job</b>"
-msgstr "<b>කාර්‍යය</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Telephone</b>"
-msgstr "<b>දුරකතනය</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<b>Web</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "<b>Work</b>"
-msgstr "<b>වැඩ</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "A_ddress:"
-msgstr "ලිපිනය (_d):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "Address"
-msgstr "ලිපිනය"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "C_ity:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "C_ompany:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Cale_ndar:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change Passwo_rd..."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Change pa_ssword"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Change password"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Ci_ty:"
-msgstr "නගතය (_t):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Co_untry:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Contact"
-msgstr "සම්බන්දතාව"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Cou_ntry:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Current _password:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "Full Name"
-msgstr "සම්පූර්ණ නම"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "Hom_e:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P.O. _box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "P._O. box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "Personal Info"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#: ../capplets/about-me/gnome-about-me-password.c:905
-msgid ""
-"Please type your password again in the <b>Retype new password</b> field."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Select your photo"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "State/Pro_vince:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid ""
-"To change your password, enter your current password in the field below and "
-"click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for "
-"verification and click <b>Change password</b>."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "User name:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "Web _log:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "Wor_k:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "Work _fax:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "Zip/_Postal code:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Address:"
-msgstr "ලිපිනය (_A):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Authenticate"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Department:"
-msgstr "දෙපාර්තුමෙන්තුව (_D):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_Groupwise:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Home page:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Home:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_Jabber:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Manager:"
-msgstr "කළමණාකරු (_M):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Mobile:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_New password:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Profession:"
-msgstr "වෘතිය (_P):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:55
-msgid "_Retype new password:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:56
-msgid "_State/Province:"
-msgstr "ප්‍රාන්තය/පළාත: (_S)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:57
-msgid "_Title:"
-msgstr "සිරස්තලය: (_T)"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:58
-msgid "_Work:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:59
-msgid "_Yahoo:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:60
-msgid "_Zip/Postal code:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:162
-msgid "Child exited unexpectedly"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:297
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:310
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:451
-msgid "Authenticated!"
-msgstr ""
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:468
-#: ../capplets/about-me/gnome-about-me-password.c:541
-msgid ""
-"Your password has been changed since you initially authenticated! Please re-"
-"authenticate."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:470
-msgid "That password was incorrect."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:516
-msgid "Your password has been changed."
-msgstr ""
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:526
-#, c-format
-msgid "System error: %s."
-msgstr "පද්ධති දෝෂය: %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:528
-msgid "The password is too short."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:530
-#: ../capplets/about-me/gnome-about-me-password.c:532
-msgid "The password is too simple."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:534
-msgid "The old and new passwords are too similar."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:536
-msgid "The new password must contain numeric or special character(s)."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:538
-msgid "The old and new passwords are the same."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:789
-#, c-format
-msgid "Unable to launch %s: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:792
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:793
-msgid "A system error has occurred"
-msgstr ""
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:813
-msgid "Checking password..."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:899
-msgid "Click <b>Change password</b> to change your password."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:902
-msgid "Please type your password in the <b>New password</b> field."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:908
-msgid "The two passwords are not equal."
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Assistive Technologies</b>"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Preferences</b>"
-msgstr "<b>අභිප්‍රේත</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid "Accessible Lo_gin"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Preferences"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid ""
-"Changes to enable assistive technologies will not take effect until your "
-"next log in."
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Close and _Log Out"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "Jump to Preferred Applications dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "Jump to the Accessible Login dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "Jump to the Keyboard Accessibility dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Enable assistive technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
-msgid "_Keyboard Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
-msgid "_Preferred Applications"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:250
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:346
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:407
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:444
-msgid "Import Feature Settings File"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:448
-msgid "_Import"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-msgid "Keyboard Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Features</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-msgid "<b>Toggle Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "Basic"
-msgstr "සරළ"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Beep if key is re_jected"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep when _features turned on or off from keyboard"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _modifier is pressed"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when key is:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Del_ay:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Disa_ble if two keys pressed together"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "E_nable Toggle Keys"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "Filters"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "I_gnore duplicate keypresses within:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Ma_ximum pointer speed:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Mouse Keys"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse _Preferences..."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "S_peed:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-msgid "Time to acce_lerate to maximum speed:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "_Disable if unused for:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Enable keyboard accessibility features"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Import Feature Settings..."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Only accept keys held for:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Type to test settings:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-msgid "_accepted"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_pressed"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_rejected"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "characters/second"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "milliseconds"
-msgstr "මිලි තත්පර"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-msgid "pixels/second"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "තත්පර"
-
-#: ../capplets/appearance/appearance-desktop.c:1038
-msgid "Add Wallpaper"
-msgstr ""
-
-#: ../capplets/appearance/appearance-desktop.c:1063
-msgid "All files"
-msgstr "සියළු ගොනු"
-
-#: ../capplets/appearance/appearance-font.c:493
-msgid "Font may be too large"
-msgstr ""
-
-#: ../capplets/appearance/appearance-font.c:497
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:510
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:532
-msgid "Use previous font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-font.c:534
-msgid "Use selected font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:108
-msgid "Specify the filename of a theme to install"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:109
-msgid "filename"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:115
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:116
-msgid "page"
-msgstr "පිටුව"
-
-#: ../capplets/appearance/appearance-main.c:123
-msgid "[WALLPAPER...]"
-msgstr "[WALLPAPER...]"
-
-#: ../capplets/appearance/appearance-themes.c:505
-msgid "Apply Background"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:509
-msgid "Apply Font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:534
-msgid "The current theme suggests a background and a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:539
-msgid "The current theme suggests a background."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:544
-msgid "The current theme suggests a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:821
-#: ../capplets/default-applications/gnome-da-capplet.c:1080
-#: ../capplets/sound/sound-properties-capplet.c:327
-msgid "Custom"
-msgstr "රිසිකළ"
-
-#: ../capplets/appearance/data/appearance.glade.h:2
-msgid "<b>C_olors</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:3
-msgid "<b>Hinting</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:4
-msgid "<b>Menus and Toolbars</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:5
-msgid "<b>Preview</b>"
-msgstr "<b>පූර්‍වදසුන</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:6
-msgid "<b>Rendering</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:7
-msgid "<b>Smoothing</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:8
-msgid "<b>Subpixel Order</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:9
-msgid "<b>_Wallpaper</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:10
-msgid "Appearance Preferences"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:11
-msgid "Background"
-msgstr "පසුබිම"
-
-#: ../capplets/appearance/data/appearance.glade.h:12
-msgid "Best _shapes"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:13
-msgid "Best co_ntrast"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:14
-msgid "C_ustomize..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:15
-msgid "C_ut"
-msgstr "කපන්න (_u)"
-
-#: ../capplets/appearance/data/appearance.glade.h:16
-msgid ""
-"Centered\n"
-"Fill screen\n"
-"Scaled\n"
-"Zoom\n"
-"Tiled"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:21
-msgid "Changing your cursor theme takes effect the next time you log in."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:22
-msgid "Colors"
-msgstr "වර්‍ණ"
-
-#: ../capplets/appearance/data/appearance.glade.h:23
-msgid "Controls"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:24
-msgid "Customize Theme"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:25
-msgid "D_etails..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:26
-msgid "Des_ktop font:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:27
-msgid "Edit"
-msgstr "සැකසුම්"
-
-#: ../capplets/appearance/data/appearance.glade.h:28
-msgid "Font Rendering Details"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:29
-msgid "Fonts"
-msgstr "අකුරු"
-
-#: ../capplets/appearance/data/appearance.glade.h:30
-msgid "Go _to Fonts Folder"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:31
-msgid "Gra_yscale"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:32
-msgid "Icons"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:33
-msgid "Interface"
-msgstr "අතුරු මූණත"
-
-#: ../capplets/appearance/data/appearance.glade.h:34
-msgid "Large"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:35
-msgid "N_one"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:36
-msgid "New File"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:37
-msgid "Open File"
-msgstr "ගොනුව විවෘත කරන්න "
-
-#: ../capplets/appearance/data/appearance.glade.h:38
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:39
-msgid "Pointer"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:40
-msgid "R_esolution:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:41
-msgid "Save File"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:42
-msgid "Save Theme As..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:43
-msgid "Save _background image"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:44
-msgid "Show _icons in menus"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:45
-msgid "Small"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:46
-msgid ""
-"Solid color\n"
-"Horizontal gradient\n"
-"Vertical gradient"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:49
-msgid "Sub_pixel (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:50
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:51
-msgid "Text"
-msgstr "පෙළ"
-
-#: ../capplets/appearance/data/appearance.glade.h:52
-msgid ""
-"Text below items\n"
-"Text beside items\n"
-"Icons only\n"
-"Text only"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:56
-msgid "The current controls theme does not support color schemes."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:57
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:58
-msgid "Toolbar _button labels:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:59
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/appearance/data/appearance.glade.h:60
-msgid "Window Border"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:61
-msgid "_Add..."
-msgstr "එක් කරන්න... (_A)"
-
-#: ../capplets/appearance/data/appearance.glade.h:62
-msgid "_Application font:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:63
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/appearance/data/appearance.glade.h:64
-msgid "_Copy"
-msgstr "පිටපත් කරන්න (_C)"
-
-#: ../capplets/appearance/data/appearance.glade.h:65
-msgid "_Description:"
-msgstr "විස්තරය (_D):"
-
-#: ../capplets/appearance/data/appearance.glade.h:66
-msgid "_Document font:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:67
-msgid "_Editable menu shortcut keys"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:68
-msgid "_File"
-msgstr "ගොනු (_F)"
-
-#: ../capplets/appearance/data/appearance.glade.h:69
-msgid "_Fixed width font:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:70
-msgid "_Full"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:71
-msgid "_Input boxes:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:72
-msgid "_Install..."
-msgstr "ස්ථාපනය... (_I)"
-
-#: ../capplets/appearance/data/appearance.glade.h:73
-msgid "_Medium"
-msgstr "මධ්‍යම (_M)"
-
-#: ../capplets/appearance/data/appearance.glade.h:74
-msgid "_Monochrome"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:75
-msgid "_Name:"
-msgstr "නම (_N):"
-
-#: ../capplets/appearance/data/appearance.glade.h:76
-msgid "_New"
-msgstr "නව (_N)"
-
-#: ../capplets/appearance/data/appearance.glade.h:77
-msgid "_None"
-msgstr "කිසිවක් නැත (_N)"
-
-#: ../capplets/appearance/data/appearance.glade.h:78
-msgid "_Open"
-msgstr "විවෘත කරන්න (_O)"
-
-#: ../capplets/appearance/data/appearance.glade.h:79
-msgid "_Paste"
-msgstr "අලවන්න (_P)"
-
-#: ../capplets/appearance/data/appearance.glade.h:80
-msgid "_Print"
-msgstr "මුද්‍රණය (_P)"
-
-#: ../capplets/appearance/data/appearance.glade.h:81
-msgid "_Quit"
-msgstr "ඉවත් වන්න (_Q)"
-
-#: ../capplets/appearance/data/appearance.glade.h:82
-msgid "_RGB"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:83
-msgid "_Reset to Defaults"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:84
-msgid "_Save"
-msgstr "සුරකින්න (_S)"
-
-#: ../capplets/appearance/data/appearance.glade.h:85
-msgid "_Selected items:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:86
-msgid "_Size:"
-msgstr "ප්‍රමාණය: (_S)"
-
-#: ../capplets/appearance/data/appearance.glade.h:87
-msgid "_Slight"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:88
-msgid "_Style:"
-msgstr "රටාව (_S):"
-
-#: ../capplets/appearance/data/appearance.glade.h:89
-msgid "_Tooltips:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:90
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:91
-msgid "_Window title font:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:92
-msgid "_Windows:"
-msgstr "කවුළු (_W):"
-
-#: ../capplets/appearance/data/appearance.glade.h:93
-msgid "dots per inch"
-msgstr "අඟලට තිත්"
-
-#: ../capplets/appearance/data/appearance.glade.h:94
-msgid "gtk-delete"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-info.c:45
-msgid "No Wallpaper"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-item.c:364
-#, c-format
-msgid ""
-"<b>%s</b>\n"
-"%s, %d %s by %d %s\n"
-"Folder: %s"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-item.c:370
-#: ../capplets/appearance/gnome-wp-item.c:372
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "පික්සලය"
-msgstr[1] "පික්සලය"
-
-#: ../capplets/appearance/theme-installer.c:149
-#, c-format
-msgid ""
-"Cannot install theme.\n"
-"The %s utility is not installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:197
-msgid ""
-"Cannot install theme.\n"
-"There was a problem while extracting the theme."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:237
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:249
-msgid "The theme is an engine. You need to compile it."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:258
-msgid "The file format is invalid"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:309
-msgid "Installation Failed"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:330
-#, c-format
-msgid "The theme \"%s\" has been installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:336
-msgid "Would you like to apply it now, or keep your current theme?"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:338
-msgid "Keep Current Theme"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:340
-msgid "Apply New Theme"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:413
-msgid "This theme is not in a supported format."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:438
-msgid "Failed to create temporary directory"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:496
-msgid "No theme file location specified to install"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:516
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:535
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:556
-msgid "The file format is invalid."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:609
-msgid "Select Theme"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:612
-msgid "Theme Packages"
-msgstr ""
-
-#: ../capplets/appearance/theme-save.c:91
-msgid "Theme name must be present"
-msgstr ""
-
-#: ../capplets/appearance/theme-save.c:161
-msgid "The theme already exists. Would you like to replace it?"
-msgstr ""
-
-#: ../capplets/appearance/theme-save.c:162
-msgid "_Overwrite"
-msgstr "මත ලියන්න (_O)"
-
-#: ../capplets/appearance/theme-util.c:43
-msgid "Would you like to delete this theme?"
-msgstr ""
-
-#: ../capplets/appearance/theme-util.c:90
-msgid "Theme cannot be deleted"
-msgstr ""
-
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-
-#: ../capplets/common/capplet-stock-icons.c:92
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:240 ../capplets/common/capplet-util.c:242
-msgid "Just apply settings and quit"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:244
-#: ../capplets/keyboard/gnome-keyboard-properties.c:236
-#: ../capplets/sound/sound-properties-capplet.c:1030
-msgid "Retrieve and store legacy settings"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:344
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:392
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "සහාය දර්ශණය කිරිමේදි දෝෂයක් තිබුනි: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "ගොනු පිටපත් කරමින් සිටී: %u of %u"
-
-#: ../capplets/common/file-transfer-dialog.c:123
-#, c-format
-msgid "Copying '%s'"
-msgstr "පිටපත් කරමින් සිටී '%s'"
-
-#: ../capplets/common/file-transfer-dialog.c:154
-#: ../capplets/common/file-transfer-dialog.c:278
-msgid "Copying files"
-msgstr "ගොනු පිටපත් කරමින් සිටී"
-
-#: ../capplets/common/file-transfer-dialog.c:190
-msgid "Parent Window"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:191
-msgid "Parent window of the dialog"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:197
-msgid "From URI"
-msgstr "URI වෙතින්"
-
-#: ../capplets/common/file-transfer-dialog.c:198
-msgid "URI currently transferring from"
-msgstr "URI දැනට වෙතින් මාරුවෙමින් පවතින්නේ"
-
-#: ../capplets/common/file-transfer-dialog.c:205
-msgid "To URI"
-msgstr "URI වෙත"
-
-#: ../capplets/common/file-transfer-dialog.c:206
-msgid "URI currently transferring to"
-msgstr "URI දැනට මාරුවන්නේ"
-
-#: ../capplets/common/file-transfer-dialog.c:213
-msgid "Fraction completed"
-msgstr "සුළු කොටස සම්පුර්ණ විය"
-
-#: ../capplets/common/file-transfer-dialog.c:214
-msgid "Fraction of transfer currently completed"
-msgstr "මාරු කිරිමේ සුළු කොටස දැනට සම්පුර්ණයි"
-
-#: ../capplets/common/file-transfer-dialog.c:221
-msgid "Current URI index"
-msgstr "දැනට ඇති URI පටුන"
-
-#: ../capplets/common/file-transfer-dialog.c:222
-msgid "Current URI index - starts from 1"
-msgstr "වර්තමාන URI පටුණ - 1න් පටන් ගන්න"
-
-#: ../capplets/common/file-transfer-dialog.c:229
-msgid "Total URIs"
-msgstr "සියළුම URIs"
-
-#: ../capplets/common/file-transfer-dialog.c:230
-msgid "Total number of URIs"
-msgstr "URI එකතුව"
-
-#: ../capplets/common/file-transfer-dialog.c:391
-msgid "Connecting..."
-msgstr "සම්බන්ද වෙමින්..."
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "යතුර"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1468
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1476
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1595
-msgid "Please select an image."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1600
-msgid "_Select"
-msgstr "තෝරන්න (_S)"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid "Preferred Applications"
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Autostart the preferred AT"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual"
-msgstr "දෘශ්‍ය"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:80
-#: ../capplets/default-applications/gnome-da-capplet.c:112
-#: ../capplets/default-applications/gnome-da-capplet.c:133
-#: ../capplets/default-applications/gnome-da-capplet.c:177
-#: ../capplets/default-applications/gnome-da-capplet.c:222
-#: ../capplets/default-applications/gnome-da-capplet.c:279
-#: ../capplets/default-applications/gnome-da-capplet.c:330
-#: ../capplets/default-applications/gnome-da-capplet.c:381
-#: ../capplets/default-applications/gnome-da-capplet.c:434
-#: ../capplets/default-applications/gnome-da-capplet.c:484
-#: ../capplets/default-applications/gnome-da-capplet.c:877
-#: ../capplets/default-applications/gnome-da-capplet.c:899
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:1100
-msgid "Could not load the main interface"
-msgstr "ප්‍රධාන මුහුණත පුරණය කළ නොහැක"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:1102
-msgid "Please make sure that the applet is properly installed"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Image Viewer</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Instant Messenger</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Mail Reader</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mobility</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Multimedia Player</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Terminal Emulator</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Text Editor</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Video Player</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "<b>Visual</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "<b>Web Browser</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Accessibility"
-msgstr "පිවිසුම් හැකියාව"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Co_mmand:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "E_xecute flag:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Internet"
-msgstr "අන්තර්ජාලය"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Multimedia"
-msgstr "බහුමාධ්‍ය"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Open link in new _tab"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Open link in new _window"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "Open link with web browser _default"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Run at st_art"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Run in t_erminal"
-msgstr "ටර්මිනලයේ ක්‍රියා කරවන්න"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "System"
-msgstr "පද්දති"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Evolution Mail Reader 1.4"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Evolution Mail Reader 1.5"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "Evolution Mail Reader 1.6"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "Evolution Mail Reader 2.0"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "Evolution Mail Reader 2.2"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Evolution Mail Reader 2.4"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Firebird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Firefox"
-msgstr "ෆයර්ෆොක්ස්"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "GNOME Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "GNOME OnScreen Keyboard"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "GNOME Terminal"
-msgstr "GNOME අග්‍රය"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Galeon"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "Gnopernicus"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "Gnopernicus with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Icedove"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Iceweasel"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "KDE Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "KMail"
-msgstr "කේමේල්"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Konqueror"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Links Text Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Linux Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Linux Screen Reader with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Lynx Text Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Mozilla"
-msgstr "මොසිලා"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Mozilla 1.6"
-msgstr "මොසිලා 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "Mozilla Mail"
-msgstr "මොසිලා තැපැල්"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-msgid "Mozilla Thunderbird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Muine Music Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Mutt"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "NXterm"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "Netscape Communicator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-msgid "Opera"
-msgstr "ඔපෙරා"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-msgid "Orca"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-msgid "Orca with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Rhythmbox Music Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-msgid "SeaMonkey"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-msgid "SeaMonkey Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Simple OnScreen Keyboard"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Standard XTerminal"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "Sylpheed"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
-msgid "Sylpheed-Claws"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:53
-msgid "Thunderbird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:54
-msgid "Totem Movie Player"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:55
-msgid "W3M Text Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:56
-msgid "aterm"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:25
-msgid "Normal"
-msgstr "සාමාන්‍ය"
-
-#: ../capplets/display/main.c:26
-msgid "Left"
-msgstr "වම"
-
-#: ../capplets/display/main.c:27
-msgid "Inverted"
-msgstr ""
-
-#: ../capplets/display/main.c:28
-msgid "Right"
-msgstr "දකුණ"
-
-#: ../capplets/display/main.c:388
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/main.c:534
-msgid "_Resolution:"
-msgstr "විභේදනය (_R):"
-
-#: ../capplets/display/main.c:553
-msgid "Re_fresh rate:"
-msgstr ""
-
-#: ../capplets/display/main.c:573
-msgid "R_otation:"
-msgstr ""
-
-#: ../capplets/display/main.c:593
-msgid "Default Settings"
-msgstr "පෙරනිමි සැකසුම්"
-
-#: ../capplets/display/main.c:595
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr ""
-
-#: ../capplets/display/main.c:621
-msgid "Screen Resolution Preferences"
-msgstr ""
-
-#: ../capplets/display/main.c:658
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr ""
-
-#: ../capplets/display/main.c:677
-msgid "Options"
-msgstr "විකල්ප"
-
-#: ../capplets/display/main.c:698
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"නව පරිස්ථිතියන් පරීක්‍ෂාකරමින්. ඔබ තත්පර %d තුල ප්‍රතිචාර නොදැක්වුවහොත් පෙර පරිස්ථිතියන් නැවත ස්ථපිත "
-"කෙරෙනු ඇත."
-msgstr[1] ""
-"නව පරිස්ථිතියන් පරීක්‍ෂාකරමින්. ඔබ තත්පර %d තුල ප්‍රතිචාර නොදැක්වුවහොත් පෙර පරිස්ථිතියන් නැවත ස්ථපිත "
-"කෙරෙනු ඇත."
-
-#: ../capplets/display/main.c:741
-msgid "Keep Resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:745
-msgid "Do you want to keep this resolution?"
-msgstr ""
-
-#: ../capplets/display/main.c:770
-msgid "Use _previous resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:770
-msgid "_Keep resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:920
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-
-#: ../capplets/display/main.c:928
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
-msgstr "ශබ්දය"
-
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-msgid "Desktop"
-msgstr "මූලික තිරය"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "නව ත්වරකය..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "ත්වරක යතුර"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "ත්නරකයේ විකරණ"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "ත්වරකයේ යතුරුකේත"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:112
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:482
-msgid "Disabled"
-msgstr "අක්‍රීය"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:523
-msgid "<Unknown Action>"
-msgstr "<නොදන්නා ක්‍රියා>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:915
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time.\n"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:944
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:976
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1026
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1141
-msgid "Action"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
 msgstr "ක්‍රියාව"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1165
-msgid "Shortcut"
-msgstr "කෙටි මාර්‍ගය"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "යතුරු පුවරු කෙටි මාර්‍ඟ"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
-msgstr ""
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:119
-#, c-format
-msgid "There was an error launching the keyboard tool: %s"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:212
-msgid "_Accessibility"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:232
-#: ../capplets/keyboard/gnome-keyboard-properties.c:234
-#: ../capplets/sound/sound-properties-capplet.c:1026
-#: ../capplets/sound/sound-properties-capplet.c:1028
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:238
-msgid "Start the page with the typing break settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:246
-msgid "- GNOME Keyboard Preferences"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-msgid "<b>Cursor Blinking</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "<b>Repeat Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<small><i>Fast</i></small>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<small><i>Long</i></small>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Short</i></small>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Slow</i></small>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "All_ow postponing of breaks"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "Check if breaks are allowed to be postponed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "Choose a Keyboard Model"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "Choose a Layout"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Choose..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "Cursor _blinks in text boxes and fields"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Cursor blinks speed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Duration of the break when typing is disallowed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Duration of work before forcing a break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Key presses _repeat when key is held down"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Keyboard Preferences"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Keyboard _model:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Layout Options"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Layouts"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Microsoft Natural Keyboard"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Preview:"
-msgstr "පූර්‍වදසුන:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Repeat keys speed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Reset to De_faults"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Separate _layout for each window"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Typing Break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "_Accessibility..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-msgid "_Break interval lasts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Delay:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Layouts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "_Models:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Selected layouts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Speed:"
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Variants:"
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "_Vendors:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "_Work interval lasts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "minutes"
-msgstr "මිනිත්තු"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
-msgid "Unknown"
-msgstr "නොදන්නා"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbltadd.c:206
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:303
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:243
-msgid "Default"
-msgstr "ප්‍රකෘතිය"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:297
-msgid "Layout"
-msgstr "පසුබිම"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:174
-msgid "Vendors"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:240
-msgid "Models"
-msgstr ""
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr ""
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/mouse/gnome-mouse-properties.c:126
-#: ../capplets/mouse/gnome-mouse-properties.c:384
-#, c-format
-msgid "%d millisecond"
-msgid_plural "%d milliseconds"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Mouse Orientation</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Speed</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<i>Fast</i>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>High</i>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>Large</i>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Low</i>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Slow</i>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Small</i>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "Buttons"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Motion"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
-msgid "Mouse Preferences"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "_Acceleration:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "_Left-handed mouse"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "_Sensitivity:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-msgid "_Threshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "_Timeout:"
-msgstr "කාලය ඉකුත් ඉවිය (_T):"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr ""
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>Di_rect internet connection</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "Advanced Configuration"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Network Proxy Preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "කෙවනිය:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "Proxy Configuration"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "U_sername:"
-msgstr ""
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "විවෘත කරන්න (_O)"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
 msgstr "විස්තර (_D)"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "රහස්පදය: (_P)"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:20
-msgid "_Use the same proxy for all protocols"
-msgstr ""
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr ""
-
-#: ../capplets/sound/mixer-support.c:79
-#, c-format
-msgid "Unknown Volume Control %d"
-msgstr ""
-
-#: ../capplets/sound/pipeline-tests.c:84
-#, c-format
-msgid "Failed to construct test pipeline for '%s'"
-msgstr ""
-
-#: ../capplets/sound/sound-properties-capplet.c:325
-#: ../capplets/sound/sound-properties-capplet.c:378
-msgid "Not connected"
-msgstr "සම්බන්ධ නොවීය"
-
-#: ../capplets/sound/sound-properties-capplet.c:661
-msgid "Autodetect"
-msgstr ""
-
-#: ../capplets/sound/sound-properties-capplet.c:666
-#: ../capplets/sound/sound-properties-capplet.c:667
-msgid "ALSA - Advanced Linux Sound Architecture"
-msgstr ""
-
-#: ../capplets/sound/sound-properties-capplet.c:668
-msgid "Artsd - ART Sound Daemon"
-msgstr ""
-
-#: ../capplets/sound/sound-properties-capplet.c:669
-#: ../capplets/sound/sound-properties-capplet.c:670
-msgid "ESD - Enlightened Sound Daemon"
-msgstr ""
-
-#: ../capplets/sound/sound-properties-capplet.c:671
-#: ../capplets/sound/sound-properties-capplet.c:672
-msgid "OSS - Open Sound System"
-msgstr "OSS - විවෘත හඬ පද්ධතිය"
-
-#: ../capplets/sound/sound-properties-capplet.c:673
-#: ../capplets/sound/sound-properties-capplet.c:674
-msgid "PulseAudio Sound Server"
-msgstr ""
-
-#: ../capplets/sound/sound-properties-capplet.c:675
-msgid "Test Sound"
-msgstr "හඬ පරීක්‍ෂාව"
-
-#: ../capplets/sound/sound-properties-capplet.c:676
-msgid "Silence"
-msgstr "නිහඬ"
-
-#: ../capplets/sound/sound-properties-capplet.c:1043
-msgid "- GNOME Sound Preferences"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "<b>Audio Conferencing</b>"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "<b>Default Mixer Tracks</b>"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "<b>Music and Movies</b>"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "<b>Sound Events</b>"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
-msgstr "<span weight=\"bold\" size=\"x-large\">පරික්‍ෂා කරමින්...</span>"
-
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Click OK to finish."
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "Devices"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "E_nable software sound mixing (ESD)"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "Flash _entire screen"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "Flash _window titlebar"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:11
-msgid "S_ound playback:"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:12
-msgid ""
-"Select the device and tracks to control with the keyboard. Use the Shift and "
-"Control keys to select multiple tracks if required."
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:13
-msgid "So_und playback:"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:14
-msgid "Sou_nd capture:"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:15
-msgid "Sound Preferences"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:16
-msgid "Sounds"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:17
-msgid "System Beep"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:18
-msgid "Test"
-msgstr "පරික්‍ෂණය"
-
-#: ../capplets/sound/sound-properties.glade.h:19
-msgid "Testing Pipeline"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:20
-msgid "_Device:"
-msgstr "උපාංගය (_D):"
-
-#: ../capplets/sound/sound-properties.glade.h:21
-msgid "_Enable system beep"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:22
-msgid "_Play system sounds"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:23
-msgid "_Sound playback:"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:24
-msgid "_Visual system beep"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:344
-msgid "Cannot start the preferences application for your window manager"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:601
-msgid "C_ontrol"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:606
-msgid "_Alt"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:612
-msgid "H_yper"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:619
-msgid "S_uper (or \"Windows logo\")"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:626
-msgid "_Meta"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr ""
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr ""
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "කවුළු"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "හඬ"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:465
-msgid "Slow Keys Alert"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:466
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:468
-msgid "Do you want to activate Slow Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:469
-msgid "Do you want to deactivate Slow Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:470
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:487
-msgid "_Activate"
-msgstr "සක්‍රීය කරන්න (_A)"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:470
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:487
-msgid "_Deactivate"
-msgstr "අක්‍රීය කරන්න (_D)"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:471
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:488
-msgid "Do_n't activate"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:471
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:488
-msgid "Do_n't deactivate"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:480
-msgid "Sticky Keys Alert"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:481
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:483
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:485
-msgid "Do you want to activate Sticky Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:486
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:150
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing the mouse pointer theme."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:171
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:275
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:281
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:289
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:316
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:353
-#, c-format
-msgid "It seems that another application already has access to key '%u'."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:418
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:489
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:106
-#, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:120
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:250
-msgid "Do _not show this warning again"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:264
-#, c-format
-msgid ""
-"<b>The X system keyboard settings differ from your current GNOME keyboard "
-"settings.</b>\n"
-"\n"
-"Expected was %s, but the the following settings were found: %s.\n"
-"\n"
-"Which set would you like to use?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:287
-msgid "Use X settings"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:289
-msgid "Keep GNOME settings"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:188
-msgid ""
-"Could not get default terminal. Verify that your default terminal command is "
-"set and points to a valid application."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:216
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this is a valid command."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:231
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:190
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:200
-msgid "_Do not show this message again"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:199
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:243
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:291
-msgid "Cannot determine user's home directory"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:301
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-msgid "A_vailable files:"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-msgid "Do _not show this warning again."
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-msgid "_Loaded files:"
-msgstr ""
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr "සංඥා නළය නිර්මාණය කිරිම දෝෂ සහිතයි."
-
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "වර්‍ගය"
-
-#: ../libbackground/applier.c:256
-msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-msgstr ""
-
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr ""
-
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr ""
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr ""
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr ""
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "තිරය"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr ""
-
-#. make start action
-#: ../libslab/application-tile.c:362
-#, c-format
-msgid "<b>Start %s</b>"
-msgstr ""
-
-#: ../libslab/application-tile.c:381
-msgid "Help"
-msgstr "උදව්"
-
-#: ../libslab/application-tile.c:428
-msgid "Upgrade"
-msgstr ""
-
-#: ../libslab/application-tile.c:443
-msgid "Uninstall"
-msgstr ""
-
-#: ../libslab/application-tile.c:770 ../libslab/document-tile.c:526
-msgid "Remove from Favorites"
-msgstr ""
-
-#: ../libslab/application-tile.c:772 ../libslab/document-tile.c:528
-msgid "Add to Favorites"
-msgstr ""
-
-#: ../libslab/application-tile.c:857
-msgid "Remove from Startup Programs"
-msgstr ""
-
-#: ../libslab/application-tile.c:859
-msgid "Add to Startup Programs"
-msgstr ""
-
-#: ../libslab/app-shell.c:747
-#, c-format
-msgid ""
-"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
-"\n"
-" Your filter \"<b>%s</b>\" does not match any items.</span>"
-msgstr ""
-
-#: ../libslab/app-shell.c:897
-msgid "Other"
-msgstr "වෙනත්"
-
-#: ../libslab/bookmark-agent.c:1067
-msgid "New Spreadsheet"
-msgstr ""
-
-#: ../libslab/bookmark-agent.c:1071
-msgid "New Document"
-msgstr ""
-
-#: ../libslab/bookmark-agent.c:1121
-msgid "Home"
-msgstr "නිවස"
-
-#: ../libslab/bookmark-agent.c:1137
-msgid "File System"
-msgstr "ගොනු පද්ධතිය"
-
-#: ../libslab/bookmark-agent.c:1141
-msgid "Network Servers"
-msgstr "ජාල සේවාදායක"
-
-#: ../libslab/bookmark-agent.c:1170
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "සොයන්න"
 
-#. make open with default action
-#: ../libslab/directory-tile.c:168
-msgid "<b>Open</b>"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#. make rename action
-#: ../libslab/directory-tile.c:187 ../libslab/document-tile.c:232
-msgid "Rename..."
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "අක්‍රීය"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "සහාය විකල්ප දර්ශනය කරන්න"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "පසුබිම"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "තිරය"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "යතුරු පුවරු කෙටි මාර්‍ඟ"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "හඬ පරීක්‍ෂාව"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "විපරම් වර්ගය"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "ක්‍රියාව"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>විද්‍යුත් තැපැල</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "රටාව (_S):"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "ප්‍රකෘතිය"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "පසුබිම"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "ගොනු පිටපත් කරමින් සිටී"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "සියළු ගොනු"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "එක් කරන්න... (_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "විස්තර (_D)"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "මිනිත්තු"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "මධ්‍යම (_M)"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "මිනිත්තු"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "මිනිත්තු"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "වර්‍ණ"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "පිළිඹිබුව තෝරන්න"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "තෝරන්න (_S)"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "කාලය ඉකුත් ඉවිය (_T):"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "සොයන්න"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "අක්‍රීය"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "තත්පර"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "කේමේල්"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "පෙරනිමි සැකසුම්"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "විභේදනය (_R):"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "සුළු කොටස සම්පුර්ණ විය"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "පෙරනය"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "URI වෙතින්"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "මිනිත්තු"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "උපාංගය (_D):"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "නම:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "වර්‍ගය"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME අග්‍රය"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "කවුළු"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "උපාංගය (_D):"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
 msgstr "නම වෙනස් කරන්න..."
 
-#: ../libslab/directory-tile.c:201 ../libslab/directory-tile.c:210
-#: ../libslab/document-tile.c:246 ../libslab/document-tile.c:255
-msgid "Send To..."
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "%s සම්බන්ධව"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
 msgstr ""
 
-#. make move to trash action
-#: ../libslab/directory-tile.c:225 ../libslab/document-tile.c:281
-msgid "Move to Trash"
-msgstr "ඉවතලන්න"
-
-#: ../libslab/directory-tile.c:235 ../libslab/directory-tile.c:448
-#: ../libslab/document-tile.c:291 ../libslab/document-tile.c:639
-msgid "Delete"
-msgstr "මකන්න"
-
-#: ../libslab/document-tile.c:153
-msgid "Edited %m/%d/%Y"
-msgstr ""
-
-#: ../libslab/document-tile.c:193
-#, c-format
-msgid "<b>Open with \"%s\"</b>"
-msgstr ""
-
-#: ../libslab/document-tile.c:205
-msgid "Open with Default Application"
-msgstr ""
-
-#: ../libslab/document-tile.c:216
-msgid "Open in File Manager"
-msgstr ""
-
-#: ../libslab/libslab-bookmarkfile.c:700 ../libslab/libslab-bookmarkfile.c:777
-#: ../libslab/libslab-bookmarkfile.c:856 ../libslab/libslab-bookmarkfile.c:903
-#, c-format
-msgid "Unexpected attribute '%s' for element '%s'"
-msgstr "'%s' මූලය සඳහා බලාපොරොත්තු නොවු '%s' විශේෂණය"
-
-#: ../libslab/libslab-bookmarkfile.c:711 ../libslab/libslab-bookmarkfile.c:788
-#: ../libslab/libslab-bookmarkfile.c:798 ../libslab/libslab-bookmarkfile.c:914
-#, c-format
-msgid "Attribute '%s' of element '%s' not found"
-msgstr "'%s' මූලයෙහි '%s' විශේෂණය හමුවුයේ නැත"
-
-#: ../libslab/libslab-bookmarkfile.c:1087
-#: ../libslab/libslab-bookmarkfile.c:1152
-#: ../libslab/libslab-bookmarkfile.c:1216
-#: ../libslab/libslab-bookmarkfile.c:1226
-#, c-format
-msgid "Unexpected tag '%s', tag '%s' expected"
-msgstr "'%s'බලාපොරොත්තු නොවු ටැගයකි, බලාපොරොත්තු වුයේ '%s' ටැගයයි"
-
-#: ../libslab/libslab-bookmarkfile.c:1112
-#: ../libslab/libslab-bookmarkfile.c:1126
-#: ../libslab/libslab-bookmarkfile.c:1194
-#: ../libslab/libslab-bookmarkfile.c:1246
-#, c-format
-msgid "Unexpected tag '%s' inside '%s'"
-msgstr "'%s'බලාපොරොත්තු නොවු ටැගයක් '%s' තුළ ඇත"
-
-#: ../libslab/libslab-bookmarkfile.c:1929
-msgid "No valid bookmark file found in data dirs"
-msgstr "දත්ත බහලුම් තුළ නිරවද්‍ය පිටු සළකුණක් හමුවූයෙ නැත"
-
-#: ../libslab/libslab-bookmarkfile.c:2130
-#, c-format
-msgid "A bookmark for URI '%s' already exists"
-msgstr "'%s' URI සඳහා වු  පිටු සළකුණ දැනට භාවිතයේ ඇත"
-
-#: ../libslab/libslab-bookmarkfile.c:2176
-#: ../libslab/libslab-bookmarkfile.c:2333
-#: ../libslab/libslab-bookmarkfile.c:2418
-#: ../libslab/libslab-bookmarkfile.c:2499
-#: ../libslab/libslab-bookmarkfile.c:2584
-#: ../libslab/libslab-bookmarkfile.c:2667
-#: ../libslab/libslab-bookmarkfile.c:2745
-#: ../libslab/libslab-bookmarkfile.c:2824
-#: ../libslab/libslab-bookmarkfile.c:2866
-#: ../libslab/libslab-bookmarkfile.c:2963
-#: ../libslab/libslab-bookmarkfile.c:3089
-#: ../libslab/libslab-bookmarkfile.c:3279
-#: ../libslab/libslab-bookmarkfile.c:3355
-#: ../libslab/libslab-bookmarkfile.c:3508
-#: ../libslab/libslab-bookmarkfile.c:3573
-#: ../libslab/libslab-bookmarkfile.c:3663
-#: ../libslab/libslab-bookmarkfile.c:3790
-#, c-format
-msgid "No bookmark found for URI '%s'"
-msgstr "'%s' URI සඳහා පිටු සළකුණු හමුවුයේ නැත"
-
-#: ../libslab/libslab-bookmarkfile.c:2508
-#, c-format
-msgid "No MIME type defined in the bookmark for URI '%s'"
-msgstr "'%s' URI සඳහා වු පිටු සළකුණු තුළ MIME වර්‍හගයක් සදහන් කරුයේ නැත"
-
-#: ../libslab/libslab-bookmarkfile.c:2593
-#, c-format
-msgid "No private flag has been defined in bookmark for URI '%s'"
-msgstr ""
-
-#: ../libslab/libslab-bookmarkfile.c:2972
-#, c-format
-msgid "No groups set in bookmark for URI '%s'"
-msgstr "'%s' URI සඳහා වු පිටු සළකුණු තුළ සමූහ කට්ටලය නැත"
-
-#: ../libslab/libslab-bookmarkfile.c:3373
-#: ../libslab/libslab-bookmarkfile.c:3518
-#, c-format
-msgid "No application with name '%s' registered a bookmark for '%s'"
-msgstr ""
-
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
-msgstr ""
-
-#: ../libslab/system-tile.c:128
-#, c-format
-msgid "<b>Open %s</b>"
-msgstr ""
-
-#: ../libslab/system-tile.c:141
-msgid "Remove from System Items"
-msgstr ""
-
-#: ../libsounds/sound-view.c:44
-msgid "Login"
-msgstr ""
-
-#: ../libsounds/sound-view.c:45
-msgid "Logout"
-msgstr ""
-
-#: ../libsounds/sound-view.c:46
-msgid "Boing"
-msgstr ""
-
-#: ../libsounds/sound-view.c:47
-msgid "Siren"
-msgstr ""
-
-#: ../libsounds/sound-view.c:48
-msgid "Clink"
-msgstr ""
-
-#: ../libsounds/sound-view.c:49
-msgid "Beep"
-msgstr "බීප් හඬ"
-
-#: ../libsounds/sound-view.c:50
-msgid "No sound"
-msgstr ""
-
-#: ../libsounds/sound-view.c:132
-msgid "Sound not set for this event."
-msgstr ""
-
-#: ../libsounds/sound-view.c:141
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package for a set of default sounds."
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 
-#: ../libsounds/sound-view.c:152
-msgid "The sound file for this event does not exist."
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
 msgstr ""
 
-#: ../libsounds/sound-view.c:183
-msgid "Select Sound File"
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
 msgstr ""
 
-#: ../libsounds/sound-view.c:203
-#, c-format
-msgid "The file %s is not a valid wav file"
-msgstr ""
-
-#: ../libsounds/sound-view.c:264
-msgid "Select sound file..."
-msgstr ""
-
-#: ../libsounds/sound-view.c:366
-msgid "System Sounds"
-msgstr ""
-
-#: ../libwindow-settings/gnome-wm-manager.c:318
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr ""
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "E-mail"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "E-mail's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Eject"
-msgstr "ඉවත් කරන්න"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Eject's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "Home folder"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "Home folder's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Launch help browser"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-msgid "Launch help browser's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-msgid "Launch web browser"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-msgid "Launch web browser's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-msgid "Lock screen"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-msgid "Lock screen's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-msgid "Log out"
-msgstr "ඉවත් වීම"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-msgid "Log out's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-msgid "Media player"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-msgid "Media player key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-msgid "Next track key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-msgid "Pause"
-msgstr "විරාමය"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Pause key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Play (or play/pause)"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-msgid "Play (or play/pause) key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Previous track key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Search's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
-msgid "Skip to next track"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-msgid "Skip to previous track"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Sleep"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Sleep's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-msgid "Stop playback key"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-msgid "Stop playback key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "හඬ අඩු කරන්න"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Volume down's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
-msgid "Volume mute"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume mute's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-msgid "Volume step"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume step as percentage of volume."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "හඬ වැඩි කරන්න"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-msgid "Volume up's shortcut."
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
-msgid "Display a dialog when there are errors running the screensaver"
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-msgid "Run screensaver at login"
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
-msgid "Start screensaver"
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
 msgstr ""
 
-#: ../shell/control-center.c:62
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "ඉවත් කරන්න"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "පෙරනිමි සැකසුම්"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "සොයන්න"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "පද්දති"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "ඉවත් වීම"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "පිවිසුම් හැකියාව"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "ඉවත් වීම"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "විකල්ප"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "<b>අභිප්‍රේත</b>"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "යතුරු පුවරු කෙටි මාර්‍ඟ"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "යතුරු පුවරු කෙටි මාර්‍ඟ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "ක්‍රියාව"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "යතුරු පුවරු කෙටි මාර්‍ඟ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "නම:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "කිසිවක් නැත (_N)"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "පෙරනිමි සැකසුම්"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "වම"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "දකුණ"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+msgid "Pointer Location"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "නව ත්වරකය..."
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "ක්‍රියාව"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "සම්බන්ධ නොවීය"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "විකල්ප"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "key not found [%s]\n"
-msgstr ""
-
-#: ../shell/control-center.c:159
-msgid "Filter"
-msgstr "පෙරනය"
-
-#: ../shell/control-center.c:159
-msgid "Groups"
-msgstr ""
-
-#: ../shell/control-center.c:159
-msgid "Common Tasks"
-msgstr ""
-
-#: ../shell/control-center.c:163 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:5
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:8
-msgid ""
-"Indicates whether to close the shell when an add or remove action is "
-"performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:9
-msgid ""
-"Indicates whether to close the shell when an upgrade or uninstall action is "
-"performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:11
-msgid ""
-"The task name to be displayed in the control-center (thus needing to be "
-"translated) followed by a \";\" separator then the filename of an "
-"associated .desktop file to launch for that task."
-msgstr ""
-
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
-msgid ""
-"[Change Desktop Background;background.desktop,Change Theme;gtk-theme-"
-"selector.desktop,Set Preferred Applications;default-applications.desktop,Add "
-"Printer;gnome-cups-manager.desktop]"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:14
-msgid ""
-"if true, the control-center will close when a \"Common Task\" is activated"
-msgstr ""
-
-#: ../shell/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:188
-msgid "_Postpone Break"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:244
-msgid "Take a break!"
-msgstr ""
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:128
-msgid "/_Preferences"
-msgstr ""
-
-#: ../typing-break/drwright.c:129
-msgid "/_About"
-msgstr ""
-
-#: ../typing-break/drwright.c:131
-msgid "/_Take a Break"
-msgstr ""
-
-#: ../typing-break/drwright.c:500
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../typing-break/drwright.c:504
-msgid "Less than one minute until the next break"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
 msgstr ""
 
-#: ../typing-break/drwright.c:591
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "ජාල සේවාදායක"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "රහස්පදය: (_P)"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "ලිපිනය"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "ලිපිනය"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "ලිපිනය"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "ප්‍රකෘතිය"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: ../typing-break/drwright.c:610
-msgid "Written by Richard Hult <richard@imendio.com>"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "නම (_N):"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "ලිපිනය (_A):"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
 msgstr ""
 
-#: ../typing-break/drwright.c:611
-msgid "Eye candy added by Anders Carlsson"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "ලිපිනය (_A):"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
 msgstr ""
 
-#: ../typing-break/drwright.c:620
-msgid "A computer break reminder."
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
 msgstr ""
 
-#: ../typing-break/drwright.c:622
-msgid "translator-credits"
-msgstr "පරිවර්තන ස්තුතිය"
-
-#: ../typing-break/main.c:61
-msgid "Enable debugging code"
-msgstr "දෝෂහරිණ කේත සක්‍රිය කරන්න"
-
-#: ../typing-break/main.c:63
-msgid "Don't check whether the notification area exists"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
 msgstr ""
 
-#: ../typing-break/main.c:89
-msgid "Typing Monitor"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
 msgstr ""
 
-#: ../typing-break/main.c:105
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "අක්‍රීය"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "ලිපිනය"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ලිපිනය"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "මිනිත්තු"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "ජාල සේවාදායක"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "සක්‍රීය කරන්න (_A)"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "ලිපිනය"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr ""
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr ""
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "ජාල සේවාදායක"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "රහස්පදය: (_P)"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "සහාය විකල්ප දර්ශනය කරන්න"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "සියළු ගොනු"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "රහස්පදය: (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "රහස්පදය: (_P)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "වෙළුම:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "වෙළුම:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr ""
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "වර්‍ගය"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "ප්‍රකෘතිය"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "ගොනු පද්ධතිය"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr ""
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
-msgid "Sets the default application font"
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "මිනිත්තු"
+msgstr[1] "මිනිත්තු"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "මිනිත්තු"
+msgstr[1] "මිනිත්තු"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "මිනිත්තු"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "මිනිත්තු"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "මිනිත්තු"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "මිනිත්තු"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "මිනිත්තු"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "මිනිත්තු"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "මිනිත්තු"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "මිනිත්තු"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "තිරය"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "තිරය"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "මුද්‍රණය (_P)"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
 msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:276
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "ක්‍රියාව"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "තෝරන්න (_S)"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "පරික්‍ෂණය"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "විකල්ප"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "විස්තර (_D)"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "සාමාන්‍ය"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "සියළුම ගොනු"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "පූර්‍වදසුන:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "දෙපාර්තුමෙන්තුව (_D):"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "තිරය"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "ක්‍රියාව"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "වර්‍ගය:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "තිරය"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+msgid "Lock Screen on Suspend"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "තිරය"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "තිරය"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "පෙරනිමි සැකසුම්"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "වෙනත්"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "ක්‍රියාව"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "සොයන්න"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "ජාල සේවාදායක"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "මූලික තිරය"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "රහස්පදය: (_P)"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "මූලික තිරය"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "සම්බන්ධ නොවීය"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "පිටපත් කරන්න (_C)"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "ක්‍රියාව"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "පද්දති"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "හඬ වැඩි කරන්න"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "පරික්‍ෂණය"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "උපාංගය (_D):"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "හඬ"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "හඬ පරීක්‍ෂාව"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ශබ්දය"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "නම:"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "වර්‍ගය:"
-
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "විශාලත්වය:"
-
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "වෙළුම:"
-
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
 msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "විස්තරය:"
-
-#: ../vfs-methods/fontilus/font-view.c:408
-#, c-format
-msgid "usage: %s fontfile\n"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
 msgstr ""
 
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
-msgid "GNOME Font Viewer"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
 msgstr ""
 
-#: ../vfs-methods/fontilus/thumbnailer.c:242
-msgid "Text to thumbnail (default: Aa)"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
 msgstr ""
 
-#: ../vfs-methods/fontilus/thumbnailer.c:242
-msgid "TEXT"
-msgstr "TEXT"
-
-#: ../vfs-methods/fontilus/thumbnailer.c:244
-msgid "Font size (default: 64)"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
 msgstr ""
 
-#: ../vfs-methods/fontilus/thumbnailer.c:244
-msgid "SIZE"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
 msgstr ""
 
-#: ../vfs-methods/fontilus/thumbnailer.c:246
-msgid "FONT-FILE OUTPUT-FILE"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 
-#: ../vfs-methods/fontilus/thumbnailer.c:262
-#, c-format
-msgid "Error parsing arguments: %s\n"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
 msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
 msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
 msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:4
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
+"Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-msgid "_Apply font"
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
 msgstr ""
 
-#: ../vfs-methods/themus/theme-method.c:485
-msgid "Themes"
-msgstr "තේමා"
-
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "විස්තරය"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
 msgstr ""
 
-#: ../vfs-methods/themus/themus-properties-view.c:139
-msgid "Window border theme"
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
 msgstr ""
 
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:3
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "කෙටි මාර්‍ගය"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "තිරය"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "ශබ්දය"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "දෘශ්‍ය"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+#, fuzzy
+msgid "Visual Alerts"
+msgstr "දෘශ්‍ය"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "තිරය"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "වම"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "දකුණ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "විකල්ප"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "තිරය"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "වර්‍ණ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "සම්බන්දතාව"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "කිසිවක් නැත (_N)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "සම්පූර්ණ නම"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "වර්‍ණ"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ගොනු පද්ධතිය"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
 msgstr ""
 
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:58
-msgid "ABCDEFG"
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
 msgstr ""
 
-#: ../vfs-methods/themus/themus-theme-applier.c:84
-msgid "[FILE]"
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
 msgstr ""
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-msgid "Apply theme"
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
 msgstr ""
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-msgid "Sets the default theme"
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
 msgstr ""
 
-msgid "Show help options"
-msgstr "සහාය විකල්ප දර්ශනය කරන්න"
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "ඉවතලන්න"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "පිළිඹිබුව තෝරන්න"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "කිසිවක් නැත (_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "පූර්‍වදසුන:"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "රහස්පදය: (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "රහස්පදය: (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "රහස්පදය: (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "රහස්පදය: (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "සම්පූර්ණ නම"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "සැකසුම්"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "වෙනත්"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "විපරම් බොත්තම්"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "පසුබිම"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "කවුළු"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "කවුළු"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "පිවිසුම් හැකියාව"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "ලිපිනය"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "සුරකින්න (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "විස්තර (_D)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "ජාල සේවාදායක"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "ජාල සේවාදායක"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "විස්තර (_D)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "ජාල සේවාදායක"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "ජාල සේවාදායක"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "විස්තර (_D)"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "ජාල සේවාදායක"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "ජාල සේවාදායක"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "සම්බන්ද වෙමින්..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "පෙරනිමි සැකසුම්"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "උදව්"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "ඉවත් වන්න (_Q)"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "සොයන්න"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgid "Image/label border"
+#~ msgstr "පිළිඹිබුව/ලේබලය රාමුව"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "විපරම් සංවාද කොටුව තුළ වූ ලේබලය සහ පිළිඹිබුව වටා ඇති රාමුවේ ඝනකම"
+
+#~ msgid "The type of alert"
+#~ msgstr "විපරමෙහි වර්ගය"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "විපරම් සංවාද කොටුව තුළ පෙන්වන බොත්තම් වර්‍ග"
+
+#~ msgid "Show more _details"
+#~ msgstr "වැඩි විස්තර පෙන්වන්න (_d)"
+
+#~ msgid "No Image"
+#~ msgstr "පිළිඹිබු නැත"
+
+#~ msgid "Images"
+#~ msgstr "පිළිඹිබු"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>නිවස</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>ක්‍ෂණික පණිවිඩ</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>කාර්‍යය</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>දුරකතනය</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>වැඩ</b>"
+
+#~ msgid "A_ddress:"
+#~ msgstr "ලිපිනය (_d):"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "නගතය (_t):"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "_Manager:"
+#~ msgstr "කළමණාකරු (_M):"
+
+#~ msgid "_Profession:"
+#~ msgstr "වෘතිය (_P):"
+
+#~ msgid "_State/Province:"
+#~ msgstr "ප්‍රාන්තය/පළාත: (_S)"
+
+#~ msgid "_Title:"
+#~ msgstr "සිරස්තලය: (_T)"
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "පද්ධති දෝෂය: %s."
+
+#~ msgid "Basic"
+#~ msgstr "සරළ"
+
+#~ msgid "milliseconds"
+#~ msgstr "මිලි තත්පර"
+
+#~ msgid "page"
+#~ msgstr "පිටුව"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid "Custom"
+#~ msgstr "රිසිකළ"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>පූර්‍වදසුන</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "කපන්න (_u)"
+
+#~ msgid "Fonts"
+#~ msgstr "අකුරු"
+
+#~ msgid "Interface"
+#~ msgstr "අතුරු මූණත"
+
+#~ msgid "Open File"
+#~ msgstr "ගොනුව විවෘත කරන්න "
+
+#~ msgid "Text"
+#~ msgstr "පෙළ"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "විස්තරය (_D):"
+
+#~ msgid "_File"
+#~ msgstr "ගොනු (_F)"
+
+#~ msgid "_Install..."
+#~ msgstr "ස්ථාපනය... (_I)"
+
+#~ msgid "_New"
+#~ msgstr "නව (_N)"
+
+#~ msgid "_Paste"
+#~ msgstr "අලවන්න (_P)"
+
+#~ msgid "_Size:"
+#~ msgstr "ප්‍රමාණය: (_S)"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Windows:"
+#~ msgstr "කවුළු (_W):"
+
+#~ msgid "dots per inch"
+#~ msgstr "අඟලට තිත්"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "පික්සලය"
+#~ msgstr[1] "පික්සලය"
+
+#~ msgid "_Overwrite"
+#~ msgstr "මත ලියන්න (_O)"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "සහාය දර්ශණය කිරිමේදි දෝෂයක් තිබුනි: %s"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "ගොනු පිටපත් කරමින් සිටී: %u of %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "පිටපත් කරමින් සිටී '%s'"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI දැනට වෙතින් මාරුවෙමින් පවතින්නේ"
+
+#~ msgid "To URI"
+#~ msgstr "URI වෙත"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI දැනට මාරුවන්නේ"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "මාරු කිරිමේ සුළු කොටස දැනට සම්පුර්ණයි"
+
+#~ msgid "Current URI index"
+#~ msgstr "දැනට ඇති URI පටුන"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "වර්තමාන URI පටුණ - 1න් පටන් ගන්න"
+
+#~ msgid "Total URIs"
+#~ msgstr "සියළුම URIs"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "URI එකතුව"
+
+#~ msgid "Key"
+#~ msgstr "යතුර"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "ප්‍රධාන මුහුණත පුරණය කළ නොහැක"
+
+#~ msgid "Internet"
+#~ msgstr "අන්තර්ජාලය"
+
+#~ msgid "Multimedia"
+#~ msgstr "බහුමාධ්‍ය"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "ටර්මිනලයේ ක්‍රියා කරවන්න"
+
+#~ msgid "Firefox"
+#~ msgstr "ෆයර්ෆොක්ස්"
+
+#~ msgid "Mozilla"
+#~ msgstr "මොසිලා"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "මොසිලා 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "මොසිලා තැපැල්"
+
+#~ msgid "Opera"
+#~ msgstr "ඔපෙරා"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "නව පරිස්ථිතියන් පරීක්‍ෂාකරමින්. ඔබ තත්පර %d තුල ප්‍රතිචාර නොදැක්වුවහොත් පෙර පරිස්ථිතියන් නැවත "
+#~ "ස්ථපිත කෙරෙනු ඇත."
+#~ msgstr[1] ""
+#~ "නව පරිස්ථිතියන් පරීක්‍ෂාකරමින්. ඔබ තත්පර %d තුල ප්‍රතිචාර නොදැක්වුවහොත් පෙර පරිස්ථිතියන් නැවත "
+#~ "ස්ථපිත කෙරෙනු ඇත."
+
+#~ msgid "Accelerator key"
+#~ msgstr "ත්වරක යතුර"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "ත්නරකයේ විකරණ"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "ත්වරකයේ යතුරුකේත"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<නොදන්නා ක්‍රියා>"
+
+#~ msgid "Unknown"
+#~ msgstr "නොදන්නා"
+
+#~ msgid "Port:"
+#~ msgstr "කෙවනිය:"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - විවෘත හඬ පද්ධතිය"
+
+#~ msgid "Silence"
+#~ msgstr "නිහඬ"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">පරික්‍ෂා කරමින්...</span>"
+
+#~ msgid "_Deactivate"
+#~ msgstr "අක්‍රීය කරන්න (_D)"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "සංඥා නළය නිර්මාණය කිරිම දෝෂ සහිතයි."
+
+#~ msgid "Home"
+#~ msgstr "නිවස"
+
+#~ msgid "Delete"
+#~ msgstr "මකන්න"
+
+#, c-format
+#~ msgid "Unexpected attribute '%s' for element '%s'"
+#~ msgstr "'%s' මූලය සඳහා බලාපොරොත්තු නොවු '%s' විශේෂණය"
+
+#, c-format
+#~ msgid "Attribute '%s' of element '%s' not found"
+#~ msgstr "'%s' මූලයෙහි '%s' විශේෂණය හමුවුයේ නැත"
+
+#, c-format
+#~ msgid "Unexpected tag '%s', tag '%s' expected"
+#~ msgstr "'%s'බලාපොරොත්තු නොවු ටැගයකි, බලාපොරොත්තු වුයේ '%s' ටැගයයි"
+
+#, c-format
+#~ msgid "Unexpected tag '%s' inside '%s'"
+#~ msgstr "'%s'බලාපොරොත්තු නොවු ටැගයක් '%s' තුළ ඇත"
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "දත්ත බහලුම් තුළ නිරවද්‍ය පිටු සළකුණක් හමුවූයෙ නැත"
+
+#, c-format
+#~ msgid "A bookmark for URI '%s' already exists"
+#~ msgstr "'%s' URI සඳහා වු  පිටු සළකුණ දැනට භාවිතයේ ඇත"
+
+#, c-format
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "'%s' URI සඳහා පිටු සළකුණු හමුවුයේ නැත"
+
+#, c-format
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "'%s' URI සඳහා වු පිටු සළකුණු තුළ MIME වර්‍හගයක් සදහන් කරුයේ නැත"
+
+#, c-format
+#~ msgid "No groups set in bookmark for URI '%s'"
+#~ msgstr "'%s' URI සඳහා වු පිටු සළකුණු තුළ සමූහ කට්ටලය නැත"
+
+#~ msgid "Beep"
+#~ msgstr "බීප් හඬ"
+
+#~ msgid "Pause"
+#~ msgstr "විරාමය"
+
+#~ msgid "translator-credits"
+#~ msgstr "පරිවර්තන ස්තුතිය"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "දෝෂහරිණ කේත සක්‍රිය කරන්න"
+
+#~ msgid "Size:"
+#~ msgstr "විශාලත්වය:"
+
+#~ msgid "Description:"
+#~ msgstr "විස්තරය:"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Themes"
+#~ msgstr "තේමා"
+
+#~ msgid "Description"
+#~ msgstr "විස්තරය"

--- a/po/si.po~
+++ b/po/si.po~
@@ -1,0 +1,3770 @@
+# translation of si.po to Sinhala
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Danishka Navin <snavin@redhat.com>, 2007.
+msgid ""
+msgstr ""
+"Project-Id-Version: si\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2007-08-08 03:22+0100\n"
+"PO-Revision-Date: 2007-08-08 14:58+0530\n"
+"Last-Translator: Danishka Navin <snavin@redhat.com>\n"
+"Language-Team: Sinhala <en@li.org>\n"
+"Language: si\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: KBabel 1.11.4\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "පිළිඹිබුව/ලේබලය රාමුව"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "විපරම් සංවාද කොටුව තුළ වූ ලේබලය සහ පිළිඹිබුව වටා ඇති රාමුවේ ඝනකම"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "විපරම් වර්ගය"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "විපරමෙහි වර්ගය"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "විපරම් බොත්තම්"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "විපරම් සංවාද කොටුව තුළ පෙන්වන බොත්තම් වර්‍ග"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "වැඩි විස්තර පෙන්වන්න (_d)"
+
+#: ../capplets/about-me/gnome-about-me.c:635
+msgid "Select Image"
+msgstr "පිළිඹිබුව තෝරන්න"
+
+#: ../capplets/about-me/gnome-about-me.c:637
+msgid "No Image"
+msgstr "පිළිඹිබු නැත"
+
+#: ../capplets/about-me/gnome-about-me.c:665
+#: ../capplets/appearance/appearance-desktop.c:1059
+msgid "Images"
+msgstr "පිළිඹිබු"
+
+#: ../capplets/about-me/gnome-about-me.c:669
+#: ../capplets/appearance/theme-installer.c:619
+msgid "All Files"
+msgstr "සියළුම ගොනු"
+
+#: ../capplets/about-me/gnome-about-me.c:806
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:827
+msgid "Unable to open address book"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:839
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:869
+#: ../capplets/about-me/gnome-about-me.c:871
+#, c-format
+msgid "About %s"
+msgstr "%s සම්බන්ධව"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "About Me"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/appearance/data/appearance.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+msgid "    "
+msgstr "    "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Email</b>"
+msgstr "<b>විද්‍යුත් තැපැල</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Home</b>"
+msgstr "<b>නිවස</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>ක්‍ෂණික පණිවිඩ</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Job</b>"
+msgstr "<b>කාර්‍යය</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Telephone</b>"
+msgstr "<b>දුරකතනය</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<b>Web</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "<b>Work</b>"
+msgstr "<b>වැඩ</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "A_ddress:"
+msgstr "ලිපිනය (_d):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "Address"
+msgstr "ලිපිනය"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "C_ity:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "C_ompany:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Cale_ndar:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change Passwo_rd..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Change pa_ssword"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Change password"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Ci_ty:"
+msgstr "නගතය (_t):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Co_untry:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Contact"
+msgstr "සම්බන්දතාව"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Cou_ntry:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Current _password:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "Full Name"
+msgstr "සම්පූර්ණ නම"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "Hom_e:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P.O. _box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "P._O. box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "Personal Info"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#: ../capplets/about-me/gnome-about-me-password.c:905
+msgid ""
+"Please type your password again in the <b>Retype new password</b> field."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Select your photo"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "State/Pro_vince:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid ""
+"To change your password, enter your current password in the field below and "
+"click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for "
+"verification and click <b>Change password</b>."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "User name:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "Web _log:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "Wor_k:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "Work _fax:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "Zip/_Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Address:"
+msgstr "ලිපිනය (_A):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Authenticate"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Department:"
+msgstr "දෙපාර්තුමෙන්තුව (_D):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_Groupwise:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Home page:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Home:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_Jabber:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Manager:"
+msgstr "කළමණාකරු (_M):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Mobile:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_New password:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Profession:"
+msgstr "වෘතිය (_P):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:55
+msgid "_Retype new password:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:56
+msgid "_State/Province:"
+msgstr "ප්‍රාන්තය/පළාත: (_S)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:57
+msgid "_Title:"
+msgstr "සිරස්තලය: (_T)"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:58
+msgid "_Work:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:59
+msgid "_Yahoo:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:60
+msgid "_Zip/Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:162
+msgid "Child exited unexpectedly"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:297
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:310
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:451
+msgid "Authenticated!"
+msgstr ""
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:468
+#: ../capplets/about-me/gnome-about-me-password.c:541
+msgid ""
+"Your password has been changed since you initially authenticated! Please re-"
+"authenticate."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:470
+msgid "That password was incorrect."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:516
+msgid "Your password has been changed."
+msgstr ""
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:526
+#, c-format
+msgid "System error: %s."
+msgstr "පද්ධති දෝෂය: %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:528
+msgid "The password is too short."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:530
+#: ../capplets/about-me/gnome-about-me-password.c:532
+msgid "The password is too simple."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:534
+msgid "The old and new passwords are too similar."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:536
+msgid "The new password must contain numeric or special character(s)."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:538
+msgid "The old and new passwords are the same."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:789
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:792
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:793
+msgid "A system error has occurred"
+msgstr ""
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:813
+msgid "Checking password..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:899
+msgid "Click <b>Change password</b> to change your password."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:902
+msgid "Please type your password in the <b>New password</b> field."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:908
+msgid "The two passwords are not equal."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Assistive Technologies</b>"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Preferences</b>"
+msgstr "<b>අභිප්‍රේත</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid "Accessible Lo_gin"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Preferences"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid ""
+"Changes to enable assistive technologies will not take effect until your "
+"next log in."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Close and _Log Out"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "Jump to Preferred Applications dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "Jump to the Accessible Login dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Enable assistive technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
+msgid "_Keyboard Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
+msgid "_Preferred Applications"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:250
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:346
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:407
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:444
+msgid "Import Feature Settings File"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:448
+msgid "_Import"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+msgid "Keyboard Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Features</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+msgid "<b>Toggle Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "Basic"
+msgstr "සරළ"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Beep if key is re_jected"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep when _features turned on or off from keyboard"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _modifier is pressed"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when key is:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Del_ay:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Disa_ble if two keys pressed together"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "E_nable Toggle Keys"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "Filters"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "I_gnore duplicate keypresses within:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Ma_ximum pointer speed:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Mouse Keys"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse _Preferences..."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "S_peed:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+msgid "Time to acce_lerate to maximum speed:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "_Disable if unused for:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Enable keyboard accessibility features"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Import Feature Settings..."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Only accept keys held for:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Type to test settings:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+msgid "_accepted"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_pressed"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_rejected"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "characters/second"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "milliseconds"
+msgstr "මිලි තත්පර"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+msgid "pixels/second"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "තත්පර"
+
+#: ../capplets/appearance/appearance-desktop.c:1038
+msgid "Add Wallpaper"
+msgstr ""
+
+#: ../capplets/appearance/appearance-desktop.c:1063
+msgid "All files"
+msgstr "සියළු ගොනු"
+
+#: ../capplets/appearance/appearance-font.c:493
+msgid "Font may be too large"
+msgstr ""
+
+#: ../capplets/appearance/appearance-font.c:497
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:510
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:532
+msgid "Use previous font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-font.c:534
+msgid "Use selected font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:108
+msgid "Specify the filename of a theme to install"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:109
+msgid "filename"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:115
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:116
+msgid "page"
+msgstr "පිටුව"
+
+#: ../capplets/appearance/appearance-main.c:123
+msgid "[WALLPAPER...]"
+msgstr "[WALLPAPER...]"
+
+#: ../capplets/appearance/appearance-themes.c:505
+msgid "Apply Background"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:509
+msgid "Apply Font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:534
+msgid "The current theme suggests a background and a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:539
+msgid "The current theme suggests a background."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:544
+msgid "The current theme suggests a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:821
+#: ../capplets/default-applications/gnome-da-capplet.c:1080
+#: ../capplets/sound/sound-properties-capplet.c:327
+msgid "Custom"
+msgstr "රිසිකළ"
+
+#: ../capplets/appearance/data/appearance.glade.h:2
+msgid "<b>C_olors</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:3
+msgid "<b>Hinting</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:4
+msgid "<b>Menus and Toolbars</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:5
+msgid "<b>Preview</b>"
+msgstr "<b>පූර්‍වදසුන</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:6
+msgid "<b>Rendering</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:7
+msgid "<b>Smoothing</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:8
+msgid "<b>Subpixel Order</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:9
+msgid "<b>_Wallpaper</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:10
+msgid "Appearance Preferences"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:11
+msgid "Background"
+msgstr "පසුබිම"
+
+#: ../capplets/appearance/data/appearance.glade.h:12
+msgid "Best _shapes"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:13
+msgid "Best co_ntrast"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:14
+msgid "C_ustomize..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:15
+msgid "C_ut"
+msgstr "කපන්න (_u)"
+
+#: ../capplets/appearance/data/appearance.glade.h:16
+msgid ""
+"Centered\n"
+"Fill screen\n"
+"Scaled\n"
+"Zoom\n"
+"Tiled"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:21
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:22
+msgid "Colors"
+msgstr "වර්‍ණ"
+
+#: ../capplets/appearance/data/appearance.glade.h:23
+msgid "Controls"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:24
+msgid "Customize Theme"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:25
+msgid "D_etails..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:26
+msgid "Des_ktop font:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:27
+msgid "Edit"
+msgstr "සැකසුම්"
+
+#: ../capplets/appearance/data/appearance.glade.h:28
+msgid "Font Rendering Details"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:29
+msgid "Fonts"
+msgstr "අකුරු"
+
+#: ../capplets/appearance/data/appearance.glade.h:30
+msgid "Go _to Fonts Folder"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:31
+msgid "Gra_yscale"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:32
+msgid "Icons"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:33
+msgid "Interface"
+msgstr "අතුරු මූණත"
+
+#: ../capplets/appearance/data/appearance.glade.h:34
+msgid "Large"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:35
+msgid "N_one"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:36
+msgid "New File"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:37
+msgid "Open File"
+msgstr "ගොනුව විවෘත කරන්න "
+
+#: ../capplets/appearance/data/appearance.glade.h:38
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:39
+msgid "Pointer"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:40
+msgid "R_esolution:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:41
+msgid "Save File"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:42
+msgid "Save Theme As..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:43
+msgid "Save _background image"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:44
+msgid "Show _icons in menus"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:45
+msgid "Small"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:46
+msgid ""
+"Solid color\n"
+"Horizontal gradient\n"
+"Vertical gradient"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:49
+msgid "Sub_pixel (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:50
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:51
+msgid "Text"
+msgstr "පෙළ"
+
+#: ../capplets/appearance/data/appearance.glade.h:52
+msgid ""
+"Text below items\n"
+"Text beside items\n"
+"Icons only\n"
+"Text only"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:56
+msgid "The current controls theme does not support color schemes."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:57
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:58
+msgid "Toolbar _button labels:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:59
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/appearance/data/appearance.glade.h:60
+msgid "Window Border"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:61
+msgid "_Add..."
+msgstr "එක් කරන්න... (_A)"
+
+#: ../capplets/appearance/data/appearance.glade.h:62
+msgid "_Application font:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:63
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/appearance/data/appearance.glade.h:64
+msgid "_Copy"
+msgstr "පිටපත් කරන්න (_C)"
+
+#: ../capplets/appearance/data/appearance.glade.h:65
+msgid "_Description:"
+msgstr "විස්තරය (_D):"
+
+#: ../capplets/appearance/data/appearance.glade.h:66
+msgid "_Document font:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:67
+msgid "_Editable menu shortcut keys"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:68
+msgid "_File"
+msgstr "ගොනු (_F)"
+
+#: ../capplets/appearance/data/appearance.glade.h:69
+msgid "_Fixed width font:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:70
+msgid "_Full"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:71
+msgid "_Input boxes:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:72
+msgid "_Install..."
+msgstr "ස්ථාපනය... (_I)"
+
+#: ../capplets/appearance/data/appearance.glade.h:73
+msgid "_Medium"
+msgstr "මධ්‍යම (_M)"
+
+#: ../capplets/appearance/data/appearance.glade.h:74
+msgid "_Monochrome"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:75
+msgid "_Name:"
+msgstr "නම (_N):"
+
+#: ../capplets/appearance/data/appearance.glade.h:76
+msgid "_New"
+msgstr "නව (_N)"
+
+#: ../capplets/appearance/data/appearance.glade.h:77
+msgid "_None"
+msgstr "කිසිවක් නැත (_N)"
+
+#: ../capplets/appearance/data/appearance.glade.h:78
+msgid "_Open"
+msgstr "විවෘත කරන්න (_O)"
+
+#: ../capplets/appearance/data/appearance.glade.h:79
+msgid "_Paste"
+msgstr "අලවන්න (_P)"
+
+#: ../capplets/appearance/data/appearance.glade.h:80
+msgid "_Print"
+msgstr "මුද්‍රණය (_P)"
+
+#: ../capplets/appearance/data/appearance.glade.h:81
+msgid "_Quit"
+msgstr "ඉවත් වන්න (_Q)"
+
+#: ../capplets/appearance/data/appearance.glade.h:82
+msgid "_RGB"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:83
+msgid "_Reset to Defaults"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:84
+msgid "_Save"
+msgstr "සුරකින්න (_S)"
+
+#: ../capplets/appearance/data/appearance.glade.h:85
+msgid "_Selected items:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:86
+msgid "_Size:"
+msgstr "ප්‍රමාණය: (_S)"
+
+#: ../capplets/appearance/data/appearance.glade.h:87
+msgid "_Slight"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:88
+msgid "_Style:"
+msgstr "රටාව (_S):"
+
+#: ../capplets/appearance/data/appearance.glade.h:89
+msgid "_Tooltips:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:90
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:91
+msgid "_Window title font:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:92
+msgid "_Windows:"
+msgstr "කවුළු (_W):"
+
+#: ../capplets/appearance/data/appearance.glade.h:93
+msgid "dots per inch"
+msgstr "අඟලට තිත්"
+
+#: ../capplets/appearance/data/appearance.glade.h:94
+msgid "gtk-delete"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-info.c:45
+msgid "No Wallpaper"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:364
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %d %s by %d %s\n"
+"Folder: %s"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:370
+#: ../capplets/appearance/gnome-wp-item.c:372
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "පික්සලය"
+msgstr[1] "පික්සලය"
+
+#: ../capplets/appearance/theme-installer.c:149
+#, c-format
+msgid ""
+"Cannot install theme.\n"
+"The %s utility is not installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:197
+msgid ""
+"Cannot install theme.\n"
+"There was a problem while extracting the theme."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:237
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:249
+msgid "The theme is an engine. You need to compile it."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:258
+msgid "The file format is invalid"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:309
+msgid "Installation Failed"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:330
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:336
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:338
+msgid "Keep Current Theme"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:340
+msgid "Apply New Theme"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:413
+msgid "This theme is not in a supported format."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:438
+msgid "Failed to create temporary directory"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:496
+msgid "No theme file location specified to install"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:516
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:535
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:556
+msgid "The file format is invalid."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:609
+msgid "Select Theme"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:612
+msgid "Theme Packages"
+msgstr ""
+
+#: ../capplets/appearance/theme-save.c:91
+msgid "Theme name must be present"
+msgstr ""
+
+#: ../capplets/appearance/theme-save.c:161
+msgid "The theme already exists. Would you like to replace it?"
+msgstr ""
+
+#: ../capplets/appearance/theme-save.c:162
+msgid "_Overwrite"
+msgstr "මත ලියන්න (_O)"
+
+#: ../capplets/appearance/theme-util.c:43
+msgid "Would you like to delete this theme?"
+msgstr ""
+
+#: ../capplets/appearance/theme-util.c:90
+msgid "Theme cannot be deleted"
+msgstr ""
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+
+#: ../capplets/common/capplet-stock-icons.c:92
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:240 ../capplets/common/capplet-util.c:242
+msgid "Just apply settings and quit"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:244
+#: ../capplets/keyboard/gnome-keyboard-properties.c:236
+#: ../capplets/sound/sound-properties-capplet.c:1030
+msgid "Retrieve and store legacy settings"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:344
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:392
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "සහාය දර්ශණය කිරිමේදි දෝෂයක් තිබුනි: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "ගොනු පිටපත් කරමින් සිටී: %u of %u"
+
+#: ../capplets/common/file-transfer-dialog.c:123
+#, c-format
+msgid "Copying '%s'"
+msgstr "පිටපත් කරමින් සිටී '%s'"
+
+#: ../capplets/common/file-transfer-dialog.c:154
+#: ../capplets/common/file-transfer-dialog.c:278
+msgid "Copying files"
+msgstr "ගොනු පිටපත් කරමින් සිටී"
+
+#: ../capplets/common/file-transfer-dialog.c:190
+msgid "Parent Window"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:191
+msgid "Parent window of the dialog"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:197
+msgid "From URI"
+msgstr "URI වෙතින්"
+
+#: ../capplets/common/file-transfer-dialog.c:198
+msgid "URI currently transferring from"
+msgstr "URI දැනට වෙතින් මාරුවෙමින් පවතින්නේ"
+
+#: ../capplets/common/file-transfer-dialog.c:205
+msgid "To URI"
+msgstr "URI වෙත"
+
+#: ../capplets/common/file-transfer-dialog.c:206
+msgid "URI currently transferring to"
+msgstr "URI දැනට මාරුවන්නේ"
+
+#: ../capplets/common/file-transfer-dialog.c:213
+msgid "Fraction completed"
+msgstr "සුළු කොටස සම්පුර්ණ විය"
+
+#: ../capplets/common/file-transfer-dialog.c:214
+msgid "Fraction of transfer currently completed"
+msgstr "මාරු කිරිමේ සුළු කොටස දැනට සම්පුර්ණයි"
+
+#: ../capplets/common/file-transfer-dialog.c:221
+msgid "Current URI index"
+msgstr "දැනට ඇති URI පටුන"
+
+#: ../capplets/common/file-transfer-dialog.c:222
+msgid "Current URI index - starts from 1"
+msgstr "වර්තමාන URI පටුණ - 1න් පටන් ගන්න"
+
+#: ../capplets/common/file-transfer-dialog.c:229
+msgid "Total URIs"
+msgstr "සියළුම URIs"
+
+#: ../capplets/common/file-transfer-dialog.c:230
+msgid "Total number of URIs"
+msgstr "URI එකතුව"
+
+#: ../capplets/common/file-transfer-dialog.c:391
+msgid "Connecting..."
+msgstr "සම්බන්ද වෙමින්..."
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "යතුර"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1468
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1476
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1595
+msgid "Please select an image."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1600
+msgid "_Select"
+msgstr "තෝරන්න (_S)"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid "Preferred Applications"
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Autostart the preferred AT"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual"
+msgstr "දෘශ්‍ය"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:80
+#: ../capplets/default-applications/gnome-da-capplet.c:112
+#: ../capplets/default-applications/gnome-da-capplet.c:133
+#: ../capplets/default-applications/gnome-da-capplet.c:177
+#: ../capplets/default-applications/gnome-da-capplet.c:222
+#: ../capplets/default-applications/gnome-da-capplet.c:279
+#: ../capplets/default-applications/gnome-da-capplet.c:330
+#: ../capplets/default-applications/gnome-da-capplet.c:381
+#: ../capplets/default-applications/gnome-da-capplet.c:434
+#: ../capplets/default-applications/gnome-da-capplet.c:484
+#: ../capplets/default-applications/gnome-da-capplet.c:877
+#: ../capplets/default-applications/gnome-da-capplet.c:899
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:1100
+msgid "Could not load the main interface"
+msgstr "ප්‍රධාන මුහුණත පුරණය කළ නොහැක"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:1102
+msgid "Please make sure that the applet is properly installed"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Image Viewer</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Instant Messenger</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Mail Reader</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mobility</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Multimedia Player</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Terminal Emulator</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Text Editor</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Video Player</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "<b>Visual</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "<b>Web Browser</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Accessibility"
+msgstr "පිවිසුම් හැකියාව"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Co_mmand:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "E_xecute flag:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Internet"
+msgstr "අන්තර්ජාලය"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Multimedia"
+msgstr "බහුමාධ්‍ය"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Open link in new _tab"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Open link in new _window"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "Open link with web browser _default"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Run at st_art"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Run in t_erminal"
+msgstr "ටර්මිනලයේ ක්‍රියා කරවන්න"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "System"
+msgstr "පද්දති"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Evolution Mail Reader 1.4"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Evolution Mail Reader 1.5"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "Evolution Mail Reader 1.6"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "Evolution Mail Reader 2.0"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "Evolution Mail Reader 2.2"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Evolution Mail Reader 2.4"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Firebird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Firefox"
+msgstr "ෆයර්ෆොක්ස්"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "GNOME Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "GNOME OnScreen Keyboard"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "GNOME Terminal"
+msgstr "GNOME අග්‍රය"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Galeon"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "Gnopernicus"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "Gnopernicus with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Icedove"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Iceweasel"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "KDE Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "KMail"
+msgstr "කේමේල්"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Konqueror"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Links Text Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Linux Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Linux Screen Reader with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Lynx Text Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Mozilla"
+msgstr "මොසිලා"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Mozilla 1.6"
+msgstr "මොසිලා 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "Mozilla Mail"
+msgstr "මොසිලා තැපැල්"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+msgid "Mozilla Thunderbird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Muine Music Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Mutt"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "NXterm"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "Netscape Communicator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+msgid "Opera"
+msgstr "ඔපෙරා"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+msgid "Orca"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+msgid "Orca with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Rhythmbox Music Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+msgid "SeaMonkey"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+msgid "SeaMonkey Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Simple OnScreen Keyboard"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Standard XTerminal"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "Sylpheed"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
+msgid "Sylpheed-Claws"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:53
+msgid "Thunderbird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:54
+msgid "Totem Movie Player"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:55
+msgid "W3M Text Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:56
+msgid "aterm"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:25
+msgid "Normal"
+msgstr "සාමාන්‍ය"
+
+#: ../capplets/display/main.c:26
+msgid "Left"
+msgstr "වම"
+
+#: ../capplets/display/main.c:27
+msgid "Inverted"
+msgstr ""
+
+#: ../capplets/display/main.c:28
+msgid "Right"
+msgstr "දකුණ"
+
+#: ../capplets/display/main.c:388
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/main.c:534
+msgid "_Resolution:"
+msgstr "විභේදනය (_R):"
+
+#: ../capplets/display/main.c:553
+msgid "Re_fresh rate:"
+msgstr ""
+
+#: ../capplets/display/main.c:573
+msgid "R_otation:"
+msgstr ""
+
+#: ../capplets/display/main.c:593
+msgid "Default Settings"
+msgstr "පෙරනිමි සැකසුම්"
+
+#: ../capplets/display/main.c:595
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr ""
+
+#: ../capplets/display/main.c:621
+msgid "Screen Resolution Preferences"
+msgstr ""
+
+#: ../capplets/display/main.c:658
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr ""
+
+#: ../capplets/display/main.c:677
+msgid "Options"
+msgstr "විකල්ප"
+
+#: ../capplets/display/main.c:698
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"නව පරිස්ථිතියන් පරීක්‍ෂාකරමින්. ඔබ තත්පර %d තුල ප්‍රතිචාර නොදැක්වුවහොත් පෙර පරිස්ථිතියන් නැවත ස්ථපිත "
+"කෙරෙනු ඇත."
+msgstr[1] ""
+"නව පරිස්ථිතියන් පරීක්‍ෂාකරමින්. ඔබ තත්පර %d තුල ප්‍රතිචාර නොදැක්වුවහොත් පෙර පරිස්ථිතියන් නැවත ස්ථපිත "
+"කෙරෙනු ඇත."
+
+#: ../capplets/display/main.c:741
+msgid "Keep Resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:745
+msgid "Do you want to keep this resolution?"
+msgstr ""
+
+#: ../capplets/display/main.c:770
+msgid "Use _previous resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:770
+msgid "_Keep resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:920
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+
+#: ../capplets/display/main.c:928
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "ශබ්දය"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+msgid "Desktop"
+msgstr "මූලික තිරය"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "නව ත්වරකය..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "ත්වරක යතුර"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "ත්නරකයේ විකරණ"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "ත්වරකයේ යතුරුකේත"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:112
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:482
+msgid "Disabled"
+msgstr "අක්‍රීය"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:523
+msgid "<Unknown Action>"
+msgstr "<නොදන්නා ක්‍රියා>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:915
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time.\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:944
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:976
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1026
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1141
+msgid "Action"
+msgstr "ක්‍රියාව"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1165
+msgid "Shortcut"
+msgstr "කෙටි මාර්‍ගය"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "යතුරු පුවරු කෙටි මාර්‍ඟ"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:119
+#, c-format
+msgid "There was an error launching the keyboard tool: %s"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:212
+msgid "_Accessibility"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:232
+#: ../capplets/keyboard/gnome-keyboard-properties.c:234
+#: ../capplets/sound/sound-properties-capplet.c:1026
+#: ../capplets/sound/sound-properties-capplet.c:1028
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:238
+msgid "Start the page with the typing break settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:246
+msgid "- GNOME Keyboard Preferences"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+msgid "<b>Cursor Blinking</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "<b>Repeat Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<small><i>Fast</i></small>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<small><i>Long</i></small>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Short</i></small>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Slow</i></small>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "All_ow postponing of breaks"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "Check if breaks are allowed to be postponed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "Choose a Keyboard Model"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "Choose a Layout"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Choose..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "Cursor _blinks in text boxes and fields"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Cursor blinks speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Duration of the break when typing is disallowed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Duration of work before forcing a break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Key presses _repeat when key is held down"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Keyboard Preferences"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Keyboard _model:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Layout Options"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Layouts"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Microsoft Natural Keyboard"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Preview:"
+msgstr "පූර්‍වදසුන:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Repeat keys speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Reset to De_faults"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Separate _layout for each window"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Typing Break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "_Accessibility..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+msgid "_Break interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Delay:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Layouts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "_Models:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Selected layouts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Speed:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Variants:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "_Vendors:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "_Work interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "minutes"
+msgstr "මිනිත්තු"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
+msgid "Unknown"
+msgstr "නොදන්නා"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbltadd.c:206
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:303
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:243
+msgid "Default"
+msgstr "ප්‍රකෘතිය"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:297
+msgid "Layout"
+msgstr "පසුබිම"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:174
+msgid "Vendors"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:240
+msgid "Models"
+msgstr ""
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr ""
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/mouse/gnome-mouse-properties.c:126
+#: ../capplets/mouse/gnome-mouse-properties.c:384
+#, c-format
+msgid "%d millisecond"
+msgid_plural "%d milliseconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Mouse Orientation</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Speed</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<i>Fast</i>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>High</i>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>Large</i>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Low</i>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Slow</i>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Small</i>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "Buttons"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Motion"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+msgid "Mouse Preferences"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "_Acceleration:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "_Left-handed mouse"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "_Sensitivity:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+msgid "_Threshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "_Timeout:"
+msgstr "කාලය ඉකුත් ඉවිය (_T):"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr ""
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>Di_rect internet connection</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "Advanced Configuration"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Network Proxy Preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "කෙවනිය:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "Proxy Configuration"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "U_sername:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "විස්තර (_D)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "රහස්පදය: (_P)"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:20
+msgid "_Use the same proxy for all protocols"
+msgstr ""
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr ""
+
+#: ../capplets/sound/mixer-support.c:79
+#, c-format
+msgid "Unknown Volume Control %d"
+msgstr ""
+
+#: ../capplets/sound/pipeline-tests.c:84
+#, c-format
+msgid "Failed to construct test pipeline for '%s'"
+msgstr ""
+
+#: ../capplets/sound/sound-properties-capplet.c:325
+#: ../capplets/sound/sound-properties-capplet.c:378
+msgid "Not connected"
+msgstr "සම්බන්ධ නොවීය"
+
+#: ../capplets/sound/sound-properties-capplet.c:661
+msgid "Autodetect"
+msgstr ""
+
+#: ../capplets/sound/sound-properties-capplet.c:666
+#: ../capplets/sound/sound-properties-capplet.c:667
+msgid "ALSA - Advanced Linux Sound Architecture"
+msgstr ""
+
+#: ../capplets/sound/sound-properties-capplet.c:668
+msgid "Artsd - ART Sound Daemon"
+msgstr ""
+
+#: ../capplets/sound/sound-properties-capplet.c:669
+#: ../capplets/sound/sound-properties-capplet.c:670
+msgid "ESD - Enlightened Sound Daemon"
+msgstr ""
+
+#: ../capplets/sound/sound-properties-capplet.c:671
+#: ../capplets/sound/sound-properties-capplet.c:672
+msgid "OSS - Open Sound System"
+msgstr "OSS - විවෘත හඬ පද්ධතිය"
+
+#: ../capplets/sound/sound-properties-capplet.c:673
+#: ../capplets/sound/sound-properties-capplet.c:674
+msgid "PulseAudio Sound Server"
+msgstr ""
+
+#: ../capplets/sound/sound-properties-capplet.c:675
+msgid "Test Sound"
+msgstr "හඬ පරීක්‍ෂාව"
+
+#: ../capplets/sound/sound-properties-capplet.c:676
+msgid "Silence"
+msgstr "නිහඬ"
+
+#: ../capplets/sound/sound-properties-capplet.c:1043
+msgid "- GNOME Sound Preferences"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "<b>Audio Conferencing</b>"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "<b>Default Mixer Tracks</b>"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "<b>Music and Movies</b>"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "<b>Sound Events</b>"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+msgstr "<span weight=\"bold\" size=\"x-large\">පරික්‍ෂා කරමින්...</span>"
+
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Click OK to finish."
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "Devices"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "E_nable software sound mixing (ESD)"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "Flash _entire screen"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "Flash _window titlebar"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:11
+msgid "S_ound playback:"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:12
+msgid ""
+"Select the device and tracks to control with the keyboard. Use the Shift and "
+"Control keys to select multiple tracks if required."
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:13
+msgid "So_und playback:"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:14
+msgid "Sou_nd capture:"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:15
+msgid "Sound Preferences"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:16
+msgid "Sounds"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:17
+msgid "System Beep"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:18
+msgid "Test"
+msgstr "පරික්‍ෂණය"
+
+#: ../capplets/sound/sound-properties.glade.h:19
+msgid "Testing Pipeline"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:20
+msgid "_Device:"
+msgstr "උපාංගය (_D):"
+
+#: ../capplets/sound/sound-properties.glade.h:21
+msgid "_Enable system beep"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:22
+msgid "_Play system sounds"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:23
+msgid "_Sound playback:"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:24
+msgid "_Visual system beep"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:344
+msgid "Cannot start the preferences application for your window manager"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:601
+msgid "C_ontrol"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:606
+msgid "_Alt"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:612
+msgid "H_yper"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:619
+msgid "S_uper (or \"Windows logo\")"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:626
+msgid "_Meta"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr ""
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr ""
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "කවුළු"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "හඬ"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:465
+msgid "Slow Keys Alert"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:466
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:468
+msgid "Do you want to activate Slow Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:469
+msgid "Do you want to deactivate Slow Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:470
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:487
+msgid "_Activate"
+msgstr "සක්‍රීය කරන්න (_A)"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:470
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:487
+msgid "_Deactivate"
+msgstr "අක්‍රීය කරන්න (_D)"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:471
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:488
+msgid "Do_n't activate"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:471
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:488
+msgid "Do_n't deactivate"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:480
+msgid "Sticky Keys Alert"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:481
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:483
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:485
+msgid "Do you want to activate Sticky Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:486
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:150
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing the mouse pointer theme."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:171
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:275
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:281
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:289
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:316
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:353
+#, c-format
+msgid "It seems that another application already has access to key '%u'."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:418
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:489
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:106
+#, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:120
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:250
+msgid "Do _not show this warning again"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:264
+#, c-format
+msgid ""
+"<b>The X system keyboard settings differ from your current GNOME keyboard "
+"settings.</b>\n"
+"\n"
+"Expected was %s, but the the following settings were found: %s.\n"
+"\n"
+"Which set would you like to use?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:287
+msgid "Use X settings"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:289
+msgid "Keep GNOME settings"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:188
+msgid ""
+"Could not get default terminal. Verify that your default terminal command is "
+"set and points to a valid application."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:216
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this is a valid command."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:231
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:190
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:200
+msgid "_Do not show this message again"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:199
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:243
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:291
+msgid "Cannot determine user's home directory"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:301
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+msgid "A_vailable files:"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+msgid "Do _not show this warning again."
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+msgid "_Loaded files:"
+msgstr ""
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr "සංඥා නළය නිර්මාණය කිරිම දෝෂ සහිතයි."
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "වර්‍ගය"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr ""
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr ""
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr ""
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr ""
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "තිරය"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr ""
+
+#. make start action
+#: ../libslab/application-tile.c:362
+#, c-format
+msgid "<b>Start %s</b>"
+msgstr ""
+
+#: ../libslab/application-tile.c:381
+msgid "Help"
+msgstr "උදව්"
+
+#: ../libslab/application-tile.c:428
+msgid "Upgrade"
+msgstr ""
+
+#: ../libslab/application-tile.c:443
+msgid "Uninstall"
+msgstr ""
+
+#: ../libslab/application-tile.c:770 ../libslab/document-tile.c:526
+msgid "Remove from Favorites"
+msgstr ""
+
+#: ../libslab/application-tile.c:772 ../libslab/document-tile.c:528
+msgid "Add to Favorites"
+msgstr ""
+
+#: ../libslab/application-tile.c:857
+msgid "Remove from Startup Programs"
+msgstr ""
+
+#: ../libslab/application-tile.c:859
+msgid "Add to Startup Programs"
+msgstr ""
+
+#: ../libslab/app-shell.c:747
+#, c-format
+msgid ""
+"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+"\n"
+" Your filter \"<b>%s</b>\" does not match any items.</span>"
+msgstr ""
+
+#: ../libslab/app-shell.c:897
+msgid "Other"
+msgstr "වෙනත්"
+
+#: ../libslab/bookmark-agent.c:1067
+msgid "New Spreadsheet"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1071
+msgid "New Document"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1121
+msgid "Home"
+msgstr "නිවස"
+
+#: ../libslab/bookmark-agent.c:1137
+msgid "File System"
+msgstr "ගොනු පද්ධතිය"
+
+#: ../libslab/bookmark-agent.c:1141
+msgid "Network Servers"
+msgstr "ජාල සේවාදායක"
+
+#: ../libslab/bookmark-agent.c:1170
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Search"
+msgstr "සොයන්න"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:168
+msgid "<b>Open</b>"
+msgstr ""
+
+#. make rename action
+#: ../libslab/directory-tile.c:187 ../libslab/document-tile.c:232
+msgid "Rename..."
+msgstr "නම වෙනස් කරන්න..."
+
+#: ../libslab/directory-tile.c:201 ../libslab/directory-tile.c:210
+#: ../libslab/document-tile.c:246 ../libslab/document-tile.c:255
+msgid "Send To..."
+msgstr ""
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:225 ../libslab/document-tile.c:281
+msgid "Move to Trash"
+msgstr "ඉවතලන්න"
+
+#: ../libslab/directory-tile.c:235 ../libslab/directory-tile.c:448
+#: ../libslab/document-tile.c:291 ../libslab/document-tile.c:639
+msgid "Delete"
+msgstr "මකන්න"
+
+#: ../libslab/document-tile.c:153
+msgid "Edited %m/%d/%Y"
+msgstr ""
+
+#: ../libslab/document-tile.c:193
+#, c-format
+msgid "<b>Open with \"%s\"</b>"
+msgstr ""
+
+#: ../libslab/document-tile.c:205
+msgid "Open with Default Application"
+msgstr ""
+
+#: ../libslab/document-tile.c:216
+msgid "Open in File Manager"
+msgstr ""
+
+#: ../libslab/libslab-bookmarkfile.c:700 ../libslab/libslab-bookmarkfile.c:777
+#: ../libslab/libslab-bookmarkfile.c:856 ../libslab/libslab-bookmarkfile.c:903
+#, c-format
+msgid "Unexpected attribute '%s' for element '%s'"
+msgstr "'%s' මූලය සඳහා බලාපොරොත්තු නොවු '%s' විශේෂණය"
+
+#: ../libslab/libslab-bookmarkfile.c:711 ../libslab/libslab-bookmarkfile.c:788
+#: ../libslab/libslab-bookmarkfile.c:798 ../libslab/libslab-bookmarkfile.c:914
+#, c-format
+msgid "Attribute '%s' of element '%s' not found"
+msgstr "'%s' මූලයෙහි '%s' විශේෂණය හමුවුයේ නැත"
+
+#: ../libslab/libslab-bookmarkfile.c:1087
+#: ../libslab/libslab-bookmarkfile.c:1152
+#: ../libslab/libslab-bookmarkfile.c:1216
+#: ../libslab/libslab-bookmarkfile.c:1226
+#, c-format
+msgid "Unexpected tag '%s', tag '%s' expected"
+msgstr "'%s'බලාපොරොත්තු නොවු ටැගයකි, බලාපොරොත්තු වුයේ '%s' ටැගයයි"
+
+#: ../libslab/libslab-bookmarkfile.c:1112
+#: ../libslab/libslab-bookmarkfile.c:1126
+#: ../libslab/libslab-bookmarkfile.c:1194
+#: ../libslab/libslab-bookmarkfile.c:1246
+#, c-format
+msgid "Unexpected tag '%s' inside '%s'"
+msgstr "'%s'බලාපොරොත්තු නොවු ටැගයක් '%s' තුළ ඇත"
+
+#: ../libslab/libslab-bookmarkfile.c:1929
+msgid "No valid bookmark file found in data dirs"
+msgstr "දත්ත බහලුම් තුළ නිරවද්‍ය පිටු සළකුණක් හමුවූයෙ නැත"
+
+#: ../libslab/libslab-bookmarkfile.c:2130
+#, c-format
+msgid "A bookmark for URI '%s' already exists"
+msgstr "'%s' URI සඳහා වු  පිටු සළකුණ දැනට භාවිතයේ ඇත"
+
+#: ../libslab/libslab-bookmarkfile.c:2176
+#: ../libslab/libslab-bookmarkfile.c:2333
+#: ../libslab/libslab-bookmarkfile.c:2418
+#: ../libslab/libslab-bookmarkfile.c:2499
+#: ../libslab/libslab-bookmarkfile.c:2584
+#: ../libslab/libslab-bookmarkfile.c:2667
+#: ../libslab/libslab-bookmarkfile.c:2745
+#: ../libslab/libslab-bookmarkfile.c:2824
+#: ../libslab/libslab-bookmarkfile.c:2866
+#: ../libslab/libslab-bookmarkfile.c:2963
+#: ../libslab/libslab-bookmarkfile.c:3089
+#: ../libslab/libslab-bookmarkfile.c:3279
+#: ../libslab/libslab-bookmarkfile.c:3355
+#: ../libslab/libslab-bookmarkfile.c:3508
+#: ../libslab/libslab-bookmarkfile.c:3573
+#: ../libslab/libslab-bookmarkfile.c:3663
+#: ../libslab/libslab-bookmarkfile.c:3790
+#, c-format
+msgid "No bookmark found for URI '%s'"
+msgstr "'%s' URI සඳහා පිටු සළකුණු හමුවුයේ නැත"
+
+#: ../libslab/libslab-bookmarkfile.c:2508
+#, c-format
+msgid "No MIME type defined in the bookmark for URI '%s'"
+msgstr "'%s' URI සඳහා වු පිටු සළකුණු තුළ MIME වර්‍හගයක් සදහන් කරුයේ නැත"
+
+#: ../libslab/libslab-bookmarkfile.c:2593
+#, c-format
+msgid "No private flag has been defined in bookmark for URI '%s'"
+msgstr ""
+
+#: ../libslab/libslab-bookmarkfile.c:2972
+#, c-format
+msgid "No groups set in bookmark for URI '%s'"
+msgstr "'%s' URI සඳහා වු පිටු සළකුණු තුළ සමූහ කට්ටලය නැත"
+
+#: ../libslab/libslab-bookmarkfile.c:3373
+#: ../libslab/libslab-bookmarkfile.c:3518
+#, c-format
+msgid "No application with name '%s' registered a bookmark for '%s'"
+msgstr ""
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr ""
+
+#: ../libslab/system-tile.c:128
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr ""
+
+#: ../libslab/system-tile.c:141
+msgid "Remove from System Items"
+msgstr ""
+
+#: ../libsounds/sound-view.c:44
+msgid "Login"
+msgstr ""
+
+#: ../libsounds/sound-view.c:45
+msgid "Logout"
+msgstr ""
+
+#: ../libsounds/sound-view.c:46
+msgid "Boing"
+msgstr ""
+
+#: ../libsounds/sound-view.c:47
+msgid "Siren"
+msgstr ""
+
+#: ../libsounds/sound-view.c:48
+msgid "Clink"
+msgstr ""
+
+#: ../libsounds/sound-view.c:49
+msgid "Beep"
+msgstr "බීප් හඬ"
+
+#: ../libsounds/sound-view.c:50
+msgid "No sound"
+msgstr ""
+
+#: ../libsounds/sound-view.c:132
+msgid "Sound not set for this event."
+msgstr ""
+
+#: ../libsounds/sound-view.c:141
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package for a set of default sounds."
+msgstr ""
+
+#: ../libsounds/sound-view.c:152
+msgid "The sound file for this event does not exist."
+msgstr ""
+
+#: ../libsounds/sound-view.c:183
+msgid "Select Sound File"
+msgstr ""
+
+#: ../libsounds/sound-view.c:203
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr ""
+
+#: ../libsounds/sound-view.c:264
+msgid "Select sound file..."
+msgstr ""
+
+#: ../libsounds/sound-view.c:366
+msgid "System Sounds"
+msgstr ""
+
+#: ../libwindow-settings/gnome-wm-manager.c:318
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "E-mail"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "E-mail's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Eject"
+msgstr "ඉවත් කරන්න"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Eject's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "Home folder"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "Home folder's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Launch help browser"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+msgid "Launch help browser's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+msgid "Launch web browser"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+msgid "Launch web browser's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+msgid "Lock screen"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+msgid "Lock screen's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+msgid "Log out"
+msgstr "ඉවත් වීම"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+msgid "Log out's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+msgid "Media player"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+msgid "Media player key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+msgid "Next track key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+msgid "Pause"
+msgstr "විරාමය"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Pause key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Play (or play/pause) key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Previous track key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Search's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Skip to next track"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+msgid "Skip to previous track"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Sleep"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Sleep's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Stop playback key"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+msgid "Stop playback key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Volume down"
+msgstr "හඬ අඩු කරන්න"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Volume down's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume mute"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume mute's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume step"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume step as percentage of volume."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+msgid "Volume up"
+msgstr "හඬ වැඩි කරන්න"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+msgid "Volume up's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+msgid "Run screensaver at login"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+msgid "Start screensaver"
+msgstr ""
+
+#: ../shell/control-center.c:62
+#, c-format
+msgid "key not found [%s]\n"
+msgstr ""
+
+#: ../shell/control-center.c:159
+msgid "Filter"
+msgstr "පෙරනය"
+
+#: ../shell/control-center.c:159
+msgid "Groups"
+msgstr ""
+
+#: ../shell/control-center.c:159
+msgid "Common Tasks"
+msgstr ""
+
+#: ../shell/control-center.c:163 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:5
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:8
+msgid ""
+"Indicates whether to close the shell when an add or remove action is "
+"performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:9
+msgid ""
+"Indicates whether to close the shell when an upgrade or uninstall action is "
+"performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:11
+msgid ""
+"The task name to be displayed in the control-center (thus needing to be "
+"translated) followed by a \";\" separator then the filename of an "
+"associated .desktop file to launch for that task."
+msgstr ""
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+msgid ""
+"[Change Desktop Background;background.desktop,Change Theme;gtk-theme-"
+"selector.desktop,Set Preferred Applications;default-applications.desktop,Add "
+"Printer;gnome-cups-manager.desktop]"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:14
+msgid ""
+"if true, the control-center will close when a \"Common Task\" is activated"
+msgstr ""
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:188
+msgid "_Postpone Break"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:244
+msgid "Take a break!"
+msgstr ""
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:128
+msgid "/_Preferences"
+msgstr ""
+
+#: ../typing-break/drwright.c:129
+msgid "/_About"
+msgstr ""
+
+#: ../typing-break/drwright.c:131
+msgid "/_Take a Break"
+msgstr ""
+
+#: ../typing-break/drwright.c:500
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../typing-break/drwright.c:504
+msgid "Less than one minute until the next break"
+msgstr ""
+
+#: ../typing-break/drwright.c:591
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+
+#: ../typing-break/drwright.c:610
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr ""
+
+#: ../typing-break/drwright.c:611
+msgid "Eye candy added by Anders Carlsson"
+msgstr ""
+
+#: ../typing-break/drwright.c:620
+msgid "A computer break reminder."
+msgstr ""
+
+#: ../typing-break/drwright.c:622
+msgid "translator-credits"
+msgstr "පරිවර්තන ස්තුතිය"
+
+#: ../typing-break/main.c:61
+msgid "Enable debugging code"
+msgstr "දෝෂහරිණ කේත සක්‍රිය කරන්න"
+
+#: ../typing-break/main.c:63
+msgid "Don't check whether the notification area exists"
+msgstr ""
+
+#: ../typing-break/main.c:89
+msgid "Typing Monitor"
+msgstr ""
+
+#: ../typing-break/main.c:105
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+msgid "Sets the default application font"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "නම:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "වර්‍ගය:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "විශාලත්වය:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "වෙළුම:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "විස්තරය:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr ""
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+msgid "GNOME Font Viewer"
+msgstr ""
+
+#: ../vfs-methods/fontilus/thumbnailer.c:242
+msgid "Text to thumbnail (default: Aa)"
+msgstr ""
+
+#: ../vfs-methods/fontilus/thumbnailer.c:242
+msgid "TEXT"
+msgstr "TEXT"
+
+#: ../vfs-methods/fontilus/thumbnailer.c:244
+msgid "Font size (default: 64)"
+msgstr ""
+
+#: ../vfs-methods/fontilus/thumbnailer.c:244
+msgid "SIZE"
+msgstr ""
+
+#: ../vfs-methods/fontilus/thumbnailer.c:246
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr ""
+
+#: ../vfs-methods/fontilus/thumbnailer.c:262
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+msgid "_Apply font"
+msgstr ""
+
+#: ../vfs-methods/themus/theme-method.c:485
+msgid "Themes"
+msgstr "තේමා"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "විස්තරය"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr ""
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+msgid "Window border theme"
+msgstr ""
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr ""
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:58
+msgid "ABCDEFG"
+msgstr ""
+
+#: ../vfs-methods/themus/themus-theme-applier.c:84
+msgid "[FILE]"
+msgstr ""
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+msgid "Apply theme"
+msgstr ""
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+msgid "Sets the default theme"
+msgstr ""
+
+msgid "Show help options"
+msgstr "සහාය විකල්ප දර්ශනය කරන්න"

--- a/po/sk.po
+++ b/po/sk.po
@@ -11,125 +11,21 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-03-07 17:29+0000\n"
-"PO-Revision-Date: 2022-03-09 10:43+0100\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-11-05 13:30+0100\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: Slovak <gnome-sk-list@gnome.org>\n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 1 : (n>=2 && n<=4) ? 2 : 0\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 1 : (n>=2 && n<=4) ? 2 : 0;\n"
 "X-Launchpad-Export-Date: 2012-10-06 09:48+0000\n"
-"X-Generator: Gtranslator 40.0\n"
-
-#: panels/applications/cc-applications-panel.c:803
-msgid "System Bus"
-msgstr "Zbernica systému"
-
-# GtkLabel
-#: panels/applications/cc-applications-panel.c:803
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:823
-msgid "Full access"
-msgstr "Plný prístup"
-
-# DK: zaznam v historii relacie
-#: panels/applications/cc-applications-panel.c:805
-msgid "Session Bus"
-msgstr "Zbernica relácie"
-
-# label
-#: panels/applications/cc-applications-panel.c:809
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Zariadenia"
-
-#: panels/applications/cc-applications-panel.c:809
-msgid "Full access to /dev"
-msgstr "Plný prístup k adresáru /dev"
-
-# desktop entry name
-#: panels/applications/cc-applications-panel.c:813
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Sieť"
-
-# GtkLabel label
-#: panels/applications/cc-applications-panel.c:813
-msgid "Has network access"
-msgstr "Má prístup k sieti"
-
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:820
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Domov"
-
-#: panels/applications/cc-applications-panel.c:820
-#: panels/applications/cc-applications-panel.c:825
-msgid "Read-only"
-msgstr "Iba na čítanie"
-
-# Overenie totožnosti
-# GtkListStore item
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-msgid "File System"
-msgstr "Systém súborov"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Nastavenia"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Can change settings"
-msgstr "Môže meniť nastavenia"
-
-#: panels/applications/cc-applications-panel.c:831
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"Aplikácia %s obsahuje nasledovné vstavané oprávnenia, ktoré nemôžu byť "
-"zmenené. Ak vás tieto oprávnenia znepokojujú, zvážte odstránenie tejto "
-"aplikácie."
-
-#: panels/applications/cc-applications-panel.c:1164
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u typov súborov a odkazov, ktoré sú otvárané aplikáciou"
-msgstr[1] "%u typ súboru a odkazu, ktorý je otváraný aplikáciou"
-msgstr[2] "%u typy súborov a odkazov, ktoré sú otvárané aplikáciou"
-
-#: panels/applications/cc-applications-panel.c:1171
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"Aplikácia <b>%s</b> sa používa na otváranie nasledovných typov súborov a "
-"odkazov."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1223
-#, c-format
-msgid "%s of disk space used"
-msgstr "%s využitého miesta na disku"
+"X-Generator: Poedit 3.1.1\n"
 
 # tab
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1387
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -146,14 +42,11 @@ msgid "Install some…"
 msgstr "Nainštalovať nejaké…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
-#| msgid "_Open"
 msgid "Open"
 msgstr "Otvoriť"
 
 # GtkButton label
 #: panels/applications/cc-applications-panel.ui:94
-#| msgid "_View details"
 msgid "View Details"
 msgstr "Zobraziť podrobnosti"
 
@@ -161,6 +54,10 @@ msgstr "Zobraziť podrobnosti"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Vyhľadávanie"
@@ -171,24 +68,13 @@ msgid "Receive system searches and send results."
 msgstr "Prijíma systémové hľadania a odosiela výsledky."
 
 # 4. GtkComboBox item (manual, dhcp, link-local...)
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1900
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Zakázané"
 
@@ -199,139 +85,142 @@ msgid "Notifications"
 msgstr "Oznámenia"
 
 #: panels/applications/cc-applications-panel.ui:127
-#| msgid "preferences-system-notifications"
 msgid "Show system notifications."
 msgstr "Zobrazuje systémové oznámenia."
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+msgid "Run in Background"
 msgstr "Spustenie na pozadí"
 
 #: panels/applications/cc-applications-panel.ui:134
 msgid "Allow activity when the app is closed."
 msgstr "Umožňuje aktivitu, keď je aplikácia zavretá."
 
-# radio_button
+# KeyListEntries name
 #: panels/applications/cc-applications-panel.ui:140
-#| msgid "Wallpapers"
+msgid "Screenshots"
+msgstr "Snímky obrazoviek"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Zachytáva obrázky obrazovky kedykoľvek."
+
+# radio_button
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "Zmeniť tapetu"
 
-#: panels/applications/cc-applications-panel.ui:141
-#| msgid "preferences-desktop-wallpaper"
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "Mení tapetu pracovnej plochy"
 
 # desktop entry name
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Zvuky"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "Reprodukuje zvuky."
 
 # tab
-#: panels/applications/cc-applications-panel.ui:161
-#| msgid "Set Shortcut"
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "Potlačenie skratiek"
 
 # GtkLabel label
-#: panels/applications/cc-applications-panel.ui:162
-#| msgid "Inhibit system keyboard shortcuts"
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "Blokuje štandardné klávesové skratky."
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "Kamera"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "Zachytáva obrázky pomocou kamery."
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "Mikrofón"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "Zaznamenáva zvuk pomocou mikrofónu."
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Služby umiestnenia"
 
 # GtkButton label
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
-#| msgid "Access your location"
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "Pristupuje k údajom umiestnenia zariadenia."
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "Zabudované oprávnenia"
 
-#: panels/applications/cc-applications-panel.ui:216
-#| msgid "System features used by this application."
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "Systémový prístup, ktorý je vyžadovaný aplikáciou"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "Priradenia súborov a odkazov"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Úložisko"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Nenašli sa žiadne výsledky"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Skúste vyhľadať niečo iné"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "Priradenie súborov a odkazov"
 
 # Overenie totožnosti
 # GtkListStore item
-#: panels/applications/cc-applications-panel.ui:367
-#| msgid "File System"
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "Typy súborov"
 
 # GtkLabel label
-#: panels/applications/cc-applications-panel.ui:373
-#| msgid "Link speed"
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "Typy odkazov"
 
 # GtkListStore item; page
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Vrátiť pôvodné"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
@@ -339,23 +228,23 @@ msgstr ""
 "vyrovnávacími pamäťami."
 
 # tab
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Aplikácia"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Údaje"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Vyrovnávacia pamäť"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Celkom</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Vymazať vyrovnávaciu pamäť…"
 
@@ -363,164 +252,106 @@ msgstr "Vymazať vyrovnávaciu pamäť…"
 msgid "Control various application permissions and settings"
 msgstr "Ovláda rozličné oprávnenia a nastavenia aplikácií"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "aplikácia;flatpak;oprávnenie;nastavenie;"
 
-# file chooser dialog title
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "Výber obrázka"
-
-# GtkButton label
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:226
-#: panels/network/connection-editor/vpn-helpers.c:346
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "_Zrušiť"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:227
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:524
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Otvoriť"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "viac veľkostí"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Bez pozadia plochy"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Aktuálne pozadie"
-
 #: panels/background/cc-background-panel.ui:9
-#| msgid "Stylus"
 msgid "Style"
 msgstr "Štýl"
 
-#: panels/background/cc-background-panel.ui:45
-#| msgid "Right"
-msgid "Light"
-msgstr "Svetlý"
+# sound id
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Predvolený"
 
-#: panels/background/cc-background-panel.ui:72
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "Tmavý"
 
 # desktop entry name
-#: panels/background/cc-background-panel.ui:91
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Pozadie"
 
 # GtkToolButton label
-#: panels/background/cc-background-panel.ui:97
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "Pridať obrázok…"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
-#| msgid "France"
 msgid "Appearance"
 msgstr "Vzhľad"
 
 # desktop entry comment
 #: panels/background/gnome-background-panel.desktop.in.in:4
-#| msgid "Change your background image to a wallpaper or photo"
 msgid "Change your background image or the UI colors"
 msgstr "Mení obrázok vášho pozadia alebo farby používateľského rozhrania"
 
 # desktop entry keywords
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-#| msgid "Wallpaper;Screen;Desktop;"
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
-msgstr "Pozadie;Tapeta;Obrazovka;Plocha;Pozadie;Štýl;Svetlý;Tmavý;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Pozadie;Tapeta;Obrazovka;Plocha;Pozadie;Štýl;Svetlý;Tmavý;Vzhľad;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+# zariadenie
+# GtkButton label
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Povoliť"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Nenašli sa žiadne Bluetooth zariadenia"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Pre použitie rozhrania Bluetooth pripojte adaptér."
 
 #  GtkDialog title
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth je vypnutý"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Zapnite ho, ak chcete pripojiť zariadenia a prijať prenosy súborov."
 
 # label
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
-#| msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "Režim v lietadle je zapnutý"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth je zakázaný, keď je zapnutý režim v lietadle."
 
 # label
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Vypnúť režim v lietadle"
 
 # label
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
-#| msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "Hardvérový režim v lietadle je zapnutý"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Vypnite prepínač režimu v lietadle na povolenie rozhrania Bluetooth."
 
 # desktop entry name
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -529,27 +360,22 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Zapína a vypína rozhranie Bluetooth a pripája vaše zariadenia"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 "spoločné používanie;spoločne používať;zdieľať;zdieľanie;sprístupniť;"
 "sprístupnenie;bluetooth;obex;"
 
-#: panels/camera/cc-camera-panel.ui:21
-#| msgid "Camera is turned off"
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "Kamera je vypnutá"
 
 # label
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Žiadne aplikácie nemôžu zachytávať fotografie alebo videá."
 
-#: panels/camera/cc-camera-panel.ui:36
-#| msgid ""
-#| "Use of the camera allows applications to capture photos and video. "
-#| "Disabling the camera may cause some applications to not function properly."
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
@@ -561,7 +387,7 @@ msgstr ""
 "\n"
 "Umožnite nasledovným aplikáciám používať kameru."
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Žiadne aplikácie si nevyžiadali prístup ku kamere"
 
@@ -571,101 +397,37 @@ msgstr "Žiadne aplikácie si nevyžiadali prístup ku kamere"
 msgid "Protect your pictures"
 msgstr "Ochráňte vaše obrázky"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"obrazovka;zámok;uzamknutie;diagnostika;pád;súkromný;nedávny;dočasný;tmp;"
-"index;meno;sieť;identita;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Umiestnite vaše kalibračné zariadenie nad štvorec a stlačte tlačidlo „Začať“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Presuňte vaše kalibračné zariadenie do kalibračnej pozície a stlačte "
-"tlačidlo „Pokračovať“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Presuňte vaše kalibračné zariadenie do pozície na povrchu a stlačte tlačidlo "
-"„Pokračovať“"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Zavrite kryt notebooku"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Vyskytla sa vnútorná chyba, ktorú sa nepodarilo rozpoznať."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Nástroje vyžadované na kalibráciu nie sú nainštalované."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Nepodarilo sa vygenerovať profil."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Nepodarilo sa získať cieľový biely bod."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Dokončená!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrácia zlyhala!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Môžete odstrániť kalibračné zariadenie."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Nemanipulujte s kalibračným zariadením počas kalibrácie"
+"kamera;fotoaparát;fotky;fotografie;video;webkamera;zámok;uzamknúť;súkromie;"
+"súkromný;súkromná;"
 
 # GtkDialog title
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Kalibrácia displeja"
+
+# GtkButton label
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Zrušiť"
 
 # GtkButton label
 #. This starts the calibration process
@@ -682,146 +444,9 @@ msgstr "_Pokračovať"
 # GtkButton label
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Dokončiť"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Obrazovka prenosného počítača"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Zabudovaná webkamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Displej %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Skener %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Kamera %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Tlačiareň %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webkamera %s"
-
-# atk
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Povoliť správu farieb pre %s"
-
-# atk
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Zobraziť farebné profily pre %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Nenakalibrované"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Predvolený: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Farebný priestor: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Skúšobný profil: "
-
-# dialog title
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Výber súboru s profilom ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importovať"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Podporované profily ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Všetky súbory"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Obrazovka"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Uloženie profilu"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:347
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Uložiť"
-
-# tooltip
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Vytvorí profil farieb pre vybrané zariadenie"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Merací nástroj nebol detegovaný. Overte, prosím, či je zapnutý a správne "
-"pripojený."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Merací nástroj nepodporuje profilovanie tlačiarne."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Typ zariadenia momentálne nie je podporovaný."
 
 # GtkAssistant title
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
@@ -959,9 +584,9 @@ msgstr "Vyžaduje zapisovateľný nosič"
 # GtkLabel label
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Tieto inštrukcie môžete nájsť v sekcii ako užitočne využívať profil v "
 "systémoch <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> a "
@@ -987,8 +612,8 @@ msgid "_Import File…"
 msgstr "_Importovať súbor…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "P_ridať"
@@ -999,9 +624,7 @@ msgid "Each device needs an up to date color profile to be color managed."
 msgstr "Každé zariadenie potrebuje na správu farieb aktuálny profil farieb."
 
 # GtkLinkButton label
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Zistiť viac"
 
@@ -1163,85 +786,6 @@ msgstr "D65 (fotografie a grafika)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Štandardný farebný priestor"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Skúšobný profil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatický"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Nízka kvalita"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Stredná kvalita"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Vysoká kvalita"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Predvolený RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Predvolený CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Predvolený čiernobiely"
-
-# tooltip
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Kalibračné údaje dodané výrobcom"
-
-# toolip
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Celoobrazovková korekcia displeja nie je možná s týmto profilom"
-
-# tooltip
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Tento profil môže byť už nepresný"
-
 # 1. GtkWindow title; 2. desktop entry name;
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1254,15 +798,9 @@ msgid ""
 msgstr ""
 "Kalibruje farby vašich zariadení, ako napr. displeje, kamery alebo tlačiarne"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Farba;Farby;ICC;Profil;Kalibrovať;Tlačiareň;Displej;"
-
-# region
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Iný…"
 
 # GtkDialog title; GtkLabel label
 #: panels/common/cc-language-chooser.ui:5
@@ -1279,20 +817,15 @@ msgid "No languages found"
 msgstr "Nenašli sa žiadne jazyky"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Viac…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Odomknutím zmeníte nastavenia"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr ""
 "Niektoré nastavenia musia byť odomknuté, pred tým než môžu byť zmenené."
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "Odomknúť…"
 
@@ -1315,166 +848,6 @@ msgstr "Znížiť hodinu"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Znížiť minútu"
-
-# naposledy použité
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Dnes"
-
-# naposledy použité
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Včera"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d hodín"
-msgstr[1] "%d hodina"
-msgstr[2] "%d hodiny"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minút"
-msgstr[1] "%d minúta"
-msgstr[2] "%d minúty"
-
-# GtkListStore item
-# za
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekúnd"
-msgstr[1] "%d sekunda"
-msgstr[2] "%d sekundy"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-# GtkListStore item
-# za
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekúnd"
-
-# button
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Prístupový bod"
-
-# GtkRadioButton label
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-hodinový"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-# MČ: %p je tam zbytočne, bude to prázdny reťazec.
-# pre 12-hodinový čas
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e. %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e. %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-# MČ: %p je tam zbytočne, bude to prázdny reťazec.
-# pre 12-hodinový čas
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 # desktop entry name
 #: panels/datetime/cc-datetime-panel.ui:15
@@ -1567,7 +940,6 @@ msgid "Search for a city"
 msgstr "Vyhľadajte mesto"
 
 #: panels/datetime/cc-datetime-panel.ui:164
-#| msgid "Automatic _Date & Time"
 msgid "Automatic _Date &amp; Time"
 msgstr "Automatický _dátum a čas"
 
@@ -1577,37 +949,77 @@ msgid "Requires internet access"
 msgstr "Vyžaduje prístup na internet"
 
 # desktop entry name
-#: panels/datetime/cc-datetime-panel.ui:177
-#| msgid "Date & _Time"
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "_Dátum a čas"
 
 # GtkLabel label
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Automatické časové _pásmo"
 
 # liststore item
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "Vyžaduje povolené služby umiestnenia a prístup na internet"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+# zariadenie
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Povolené"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Ča_sové pásmo"
 
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Odomknúť"
+
 # TODO lepšia alternatíva?
 # GtkDialog title; GtkLabel label
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Formát času"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+# GtkLabel label
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Dátumy"
+
+# GtkListStore item
+# za
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekúnd"
+
+# GtkLabel label
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Kalendár"
+
+# GtkLabel label
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Čísla"
 
 # desktop entry comment
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Mení dátum a čas vrátané časového pásma"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Hodiny;Čas;Zóna;Pásmo;Poloha;Umiestnenie;"
@@ -1665,22 +1077,11 @@ msgstr "Predvolené aplikácie"
 msgid "Configure Default Applications"
 msgstr "Nastavuje predvolené aplikácie"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "predvolená;predvolený;predvolené;aplikácia;uprednostňovaná;uprednostňovaný;"
 "uprednostňované;médium;médiá;nosič,nosiče;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Odoslaním hlásení o technických problémoch nám pomôže vylepšiť systém %s. "
-"Hlásenia sú odosielané anonymne a neobsahujú osobné údaje. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1698,55 +1099,9 @@ msgstr "Diagnostika"
 msgid "Report your problems"
 msgstr "Nahláste vaše problémy"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"obrazovka;zámok;uzamknutie;diagnostika;pád;súkromný;nedávny;dočasný;tmp;"
-"index;meno;názov;sieť;identita;súkromie;"
-
-#
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:337
-#: panels/universal-access/cc-ua-panel.c:469
-#: panels/universal-access/cc-ua-panel.c:479
-#: panels/universal-access/cc-ua-panel.c:491
-#: panels/universal-access/cc-ua-panel.c:527
-msgid "On"
-msgstr "Zapnuté"
-
-# MČ: ak displej tak vypnutý. V iných prípadoch to môže byť inak. Treba skontrolovať pre všetky výskyty, prípadne dať rozdeliť.
-# * https://bugzilla.gnome.org/show_bug.cgi?id=708580
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:337
-#: panels/universal-access/cc-ua-panel.c:469
-#: panels/universal-access/cc-ua-panel.c:479
-#: panels/universal-access/cc-ua-panel.c:491
-#: panels/universal-access/cc-ua-panel.c:527
-msgid "Off"
-msgstr "Vypnuté"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "Použiť zmeny?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "Zmeny sa nedajú použiť"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "Môže to byť spôsobené obmedzeniami hardvéru."
+msgid "diagnostics;crash;"
+msgstr "diagnostika;pád;zlyhanie;"
 
 # GtkButton label
 #: panels/display/cc-display-panel.ui:43
@@ -1754,111 +1109,111 @@ msgstr "Môže to byť spôsobené obmedzeniami hardvéru."
 msgid "_Apply"
 msgstr "_Použiť"
 
-#: panels/display/cc-display-panel.ui:97
-#| msgid "Bluetooth is disabled"
+# GtkListStore row
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Späť"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr "Nastavenia displeja sú zakázané"
 
-# PK: mozno priradenie
-# PM: doriesit v master vetve
-# PM: dalej je priradiť k displeju
-# dialog title
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "Rozloženie displejov"
-
 # atkobject
-#: panels/display/cc-display-panel.ui:124
-#| msgid "Decouple Display"
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "Viacero displejov"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "Zlúčiť"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Zrkadliť"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Obsahuje hornú lištu a Aktivity"
 
 # atkobject
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Hlavný displej"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Nočné osvetlenie"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Na šírku"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Na výšku doprava"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Na výšku doľava"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Na šírku (obrátene)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Orientácia"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Rozlíšenie"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Obnovovacia frekvencia"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Úprava pre TV"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Mierka"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Prirodzené rolovanie"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nočné osvetlenie nie je dostupné"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"To môže byť spôsobené použitým grafickým ovládačom, alebo tým, že sa "
+"pracovná plocha používa vzdialene"
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Dočasne zakázané do zajtra"
 
 # button
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "Reštartovať filter"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1866,60 +1221,60 @@ msgstr ""
 "Nočné osvetlenie spôsobí, že bude farba obrazovky teplejšia. Tým sa pomôže "
 "znížiť námaha očí a zabrániť nespavosti."
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Plánovanie"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Od západu slnka do východu slnka"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Ručné plánovanie"
 
 # GtkLabel label
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Časy"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Od"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Hodina"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Minúta"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "dopoludnia"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "odpoludnia"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Do"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Teplota farieb"
 
@@ -1933,7 +1288,6 @@ msgstr "Displeje"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Volí spôsob použitia pripojených displejov a projektorov"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1942,63 +1296,55 @@ msgstr ""
 "Panel;Projektor;xrandr;Obrazovka;Rozlíšenie;Obnovovanie;Displej;Noc;Nočné;"
 "Svetlo;Osvetlenie;Modrá;Farba;Redshift;Západ;Východ;Slnka;"
 
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# grafika, AP typ
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Neznámy"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; ID zostavy: %s"
+# GtkLabel label
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr "Úroveň zabezpečenia"
 
-# Typ OS
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64-bitový"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Úroveň 1"
 
-# Typ OS
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32-bitový"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Úroveň 2"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Úroveň 3"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Žiadne udalosti"
 
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# grafika, AP typ
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Neznámy"
+#  1.2. page; 3. 4. GtkLabel label
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Zabezpečenie zariadenia"
 
-# KeyListEntries name
-#: panels/info-overview/cc-info-overview-panel.ui:17
-#| msgid "System"
-msgid "System Logo"
-msgstr "Systémové logo"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Stav zabezpečenia firmvéru hostiteľa"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"obrazovka;zámok;uzamknutie;diagnostika;pád;súkromný;nedávny;dočasný;tmp;"
+"index;meno;názov;sieť;identita;súkromie;"
 
 # GtkLabel label
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Názov zariadenia"
 
@@ -2037,36 +1383,47 @@ msgstr "Počíta sa…"
 msgid "OS Name"
 msgstr "Názov OS"
 
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID zostavy OS"
+
 # GtkLabel label
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Typ OS"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Verzia prostredia GNOME"
 
+# GtkLabel label
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Načítava sa…"
+
 # listore item
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Systém na správu okien"
 
 # GtkLabel label
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Virtualizácia"
 
 # GtkLabel label
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Aktualizácie softvéru"
 
 # GtkToolButton label
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Premenovanie zariadenia"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -2075,7 +1432,12 @@ msgstr ""
 "v sieti, alebo pri párovaní zariadení Bluetooth."
 
 # GtkLabel label
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Názov zariadenia"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "_Premenovať"
 
@@ -2089,11 +1451,6 @@ msgid "View information about your system"
 msgstr "Zobrazuje informácie o vašom systéme"
 
 # desktop entry keywords
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2188,6 +1545,12 @@ msgstr "Spúšťače"
 msgid "Launch help browser"
 msgstr "Spustiť prehliadač pomocníka"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Nastavenia"
+
 # KeyListEntry description
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
@@ -2215,7 +1578,7 @@ msgid "Search"
 msgstr "Hľadať"
 
 # KeyListEntries name
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Systém"
 
@@ -2274,21 +1637,12 @@ msgstr "Zmenšiť text"
 msgid "High contrast on or off"
 msgstr "Zapnúť alebo vypnúť vysoký kontrast"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Nenašli sa žiadne zdroje vstupu"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Iný"
-
 # GtkDialog title
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Pridanie zdroja vstupu"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Vstupné metódy nemôžu byť použité na prihlasovacej obrazovke"
 
@@ -2296,138 +1650,35 @@ msgstr "Vstupné metódy nemôžu byť použité na prihlasovacej obrazovke"
 msgid "No input source selected"
 msgstr "Nebol vybraný žiadny zdroj vstupu"
 
+# GtkButton label
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Voľby"
+
 # GtkButton AtkObject
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "Presunúť nahor"
 
 # GtkButton AtkObject
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "Presunúť nadol"
 
 # GtkButton AtkObject
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Nastavenia"
 
 # GtkLabel label
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Zobraziť rozloženie klávesnice"
 
 # button
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Odstrániť"
-
-# KeyListEntry name
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Vlastné skratky"
-
-# https://bugzilla.gnome.org/show_bug.cgi?id=697213
-# PM: chcelo by to komentár od vývojárov čo to je - typujem že dajaká modifikačná klávesa na neštandardnej klávesnici
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "Kláves alternatívnych znakov"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Kláves alternatívnych znakov môže byť použitý na zadávanie dodatočných "
-"znakov. Tie sú niekedy vyznačené ako tretia voľba na vašej klávesnici."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Ľavý kláves Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Pravý kláves Alt"
-
-# GtkListStore item
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Ľavý kláves Super"
-
-# GtkListStore item
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Pravý kláves Super"
-
-# GtkLabel label
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Kláves ponuky"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Pravý kláves Ctrl"
-
-# https://bugzilla.gnome.org/show_bug.cgi?id=697213
-# PM: chcelo by to komentár od vývojárov čo to je
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Kláves Compose"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Kláves Compose umožňuje zadávanie širokej škály znakov. Pre jeho použitie "
-"stlačte kláves Compose a potom postupnosť znakov.  Napríklad kláves Compose "
-"nasledovaný znakmi <b>C</b> a <b>o</b> zadá znak <b>©</b>, znak <b>a</b> "
-"nasledovaný znakom <b>'</b> zadá znak <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-# GtkListStore row
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-# toggle button
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-# GtkLabel label
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Zdroje vstupu môžu byť prepnuté pomocou klávesovej skratky %s.\n"
-"Tá môže byť zmenená v nastaveniach klávesových skratiek."
 
 # GtkLinkButton label;
 #: panels/keyboard/cc-keyboard-panel.ui:17
@@ -2453,61 +1704,35 @@ msgstr "Použiť r_ovnaký zdroj pre všetky okná"
 msgid "Switch input sources _individually for each window"
 msgstr "Prepnúť zdroje vstupu _individuálne pre každé okno"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Záznam so špeciálnym znakom"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Metódy zadávania symbolov a variantov písmen pomocou klávesnice."
 
+# https://bugzilla.gnome.org/show_bug.cgi?id=697213
+# PM: chcelo by to komentár od vývojárov čo to je - typujem že dajaká modifikačná klávesa na neštandardnej klávesnici
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Kláves alternatívnych znakov"
+
+# https://bugzilla.gnome.org/show_bug.cgi?id=697213
+# PM: chcelo by to komentár od vývojárov čo to je
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Kláves Compose"
+
 # GtkLabel label
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Klávesové skratky"
 
 # KeyListEntry name
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Zobraziť a prispôsobiť skratky"
-
-# hlasitosť
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d upravených"
-msgstr[1] "%d upravená"
-msgstr[2] "%d upravené"
-
-# tab
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
-msgid "Reset All Shortcuts?"
-msgstr "Obnoviť všetky skratky?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Obnovenie skratiek môže mať vplyv na vaše vlastné skratky. Táto akcia je "
-"nenávratná."
-
-# GtkButton label
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Zrušiť"
-
-# GtkListStore item; page
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
-msgid "Reset All"
-msgstr "Obnoviť všetky"
 
 # GtkListStore item; page
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
@@ -2519,107 +1744,89 @@ msgstr "Obnoviť všetky…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Obnoví všetky skratky na ich pôvodné kombinácie klávesov"
 
+# 1.,2. treeviewcolumn;
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sekcia"
+
+# tab
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Skratky"
+
+# GtkToolButton label
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Pridať skratku"
+
 # PM: že ide o klávesovú vyplýva z kontextu
 # GtkDialog title
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Pridanie vlastných skratiek"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr "Nastavuje vlastné skratky na spúšťanie aplikácií, skriptov a viac."
 
 # GtkToolButton label
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Pridať skratku"
 
 # GtkLabel label
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Nenašla sa žiadna klávesová skratka"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"Skratka %s sa už používa pre akciu %s. Ak ju nahradíte, akcia %s bude "
-"zakázaná"
+# button
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "O_dstrániť"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Zadajte novú skratku"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Nah_radiť"
 
-# KeyListEntry name
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Nastavenie vlastnej skratky"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "_Nastaviť"
 
-# tab
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Nastaviť skratku"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Zadajte novú skratku na zmenu akcie %s."
-
-# PM: že ide o klávesovú vyplýva z kontextu
-# GtkDialog title
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Pridanie vlastnej skratky"
-
-# button atk
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Pridať"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
-msgstr "Nahradiť"
-
-# tlačidlo
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "Nastaviť"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
 "Stlačením klávesu Esc zrušíte a klávesom Backspace zakážete klávesovú "
 "skratku."
 
 # tree view column
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Názov"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Príkaz"
 
 # tab
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Skratka"
 
 # tab
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Nastaviť skratku…"
 
 # PK: to druhe neni v tom subore
 # PM: to druhé máš tu https://git.gnome.org/browse/gnome-control-center/tree/panels/universal-access/uap.ui?h=gnome-3-8#n77 - vyzerá to na výber programu pre klávesnicu na obrazovke asi to treba rozdeliť
 # 1. combobox item s položkou WPA 2.
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Žiadne"
 
@@ -2627,6 +1834,11 @@ msgstr "Žiadne"
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Obnoví skratku na predvolenú hodnotu"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Používanie vyšej kamery"
 
 # desktop entry name; GtkDialog title
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
@@ -2642,7 +1854,6 @@ msgstr ""
 "Mení klávesové skratky a nastavuje vaše predvoľby písania, rozložení "
 "klávesnice a zdroje vstupu"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2650,17 +1861,16 @@ msgstr ""
 "odkaz;skratka;pracovný;priestor;okno;zmena;veľkosti;lupa;priblíženie;"
 "kontrast;vstup;vstupný;zdroj;zámok;uzamknutie;hlasitosť;"
 
-#: panels/location/cc-location-panel.ui:20
-#| msgid "Location services turned off"
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "Služby umiestnenia sú vypnuté"
 
 # label
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Žiadne aplikácie nemôžu získať informácie o umiestnení."
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2671,7 +1881,7 @@ msgid ""
 "Allow the applications below to determine your location."
 msgstr ""
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Žiadne aplikácie si nevyžiadali prístup k umiestneniu"
 
@@ -2679,236 +1889,19 @@ msgstr "Žiadne aplikácie si nevyžiadali prístup k umiestneniu"
 msgid "Protect your location information"
 msgstr "Ochráňte informácie o vašom umiestnení"
 
-# GtkListStore item
-# Uzamknut obrazovku pri necinnosti za
-#. FIXME
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "vypnutím obrazovky"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "umiestnenie;lokalita;gps;súkromie;súkromný;"
 
-# GtkListStore item
-# za
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekúnd"
-
-# Blank Screen
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minútu"
-
-# Blank Screen
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minúty"
-
-# Blank Screen
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74 panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minúty"
-
-# MČ: pre color.ui je to odhadovaný čas, pre power.ui po akom čase má uspať počítač., pre privacy.ui po akom čase má vypnúť obrazovku. Bude to treba asi dať rozdeliť.
-# MČ: Odhadujem, že pri ostatných reťazcoch to bude podobné, len sa ich pokusim pooznačovať, skús to preveriť.
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# 1. approx_time; 2. Oneskorenie; 3
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minút"
-
-# Oddialiť o
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 hodinu"
-
-# Blank Screen
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minútu"
-
-# Blank Screen
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minúty"
-
-# Blank Screen
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minúty"
-
-# Blank Screen
-# GtkListStore item
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minúty"
-
-# Blank Screen
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minút"
-
-# Blank Screen
-# GtkListStore item
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minút"
-
-# Blank Screen
-# GtkListStore item
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minút"
-
-# Blank Screen
-# GtkListStore item
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minút"
-
-#  * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# approx_time; Oneskorenie
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minút"
-
-# naposledy použité
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nikdy"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
-msgstr ""
-"Automatické uzamykanie obrazovky zabraňuje ostatným pristupovať k vášmu "
-"počítaču, pokiaľ ste preč."
-
-# PK: toto je divne, skor vypnut obrazovku
-# PM: no blank screen praveze nie je vypnutie obrazovky, balnk screen je vyplnenie obrazovky čiernou ale je stále zapnutá. Používa sa to pri starých monitoroch, ktoré zobrazujú pri ATM hlásku ze nie je signál.
-# label
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "Oneskorenie vyprázdnenia obrazovky"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Doba nečinnosti, po ktorej sa vyprázdni obrazovka."
-
-# GtkLabel label
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "A_utomatické uzamykanie obrazovky"
-
-# GtkLabel label
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "Oneskorenie a_utomatického uzamykania obrazovky"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr ""
-"Doba, po ktorej sa obrazovka vyprázdni, keď je obrazovka automaticky "
-"uzamknutá."
-
-# GtkLabel label
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "_Zobrazovať oznámenia v uzamknutej obrazovke"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "Zakázať nové zariadenia _USB"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr ""
-"Zabráni novým zariadeniam USB ovplyvniť systém počas uzamknutej obrazovky."
-
-# 2 GtkDialog title
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Uzamknutie obrazovky"
-
-# KeyListEntry description
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Uzamknúť vašu obrazovku"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:20
-#| msgid "Microphone is turned off"
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "Mikrofón je vypnutý"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Žiadne aplikácie nedokážu nahrávať zvuk."
 
-#: panels/microphone/cc-microphone-panel.ui:34
-#| msgid ""
-#| "Use of the microphone allows applications to record and listen to audio. "
-#| "Disabling the microphone may cause some applications to not function "
-#| "properly."
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2921,7 +1914,7 @@ msgstr ""
 "\n"
 "Umožnite nasledovným aplikáciám používať mikrofón."
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Žiadne aplikácie si nevyžiadali prístup k mikrofónu"
 
@@ -2929,8 +1922,11 @@ msgstr "Žiadne aplikácie si nevyžiadali prístup k mikrofónu"
 msgid "Protect your conversations"
 msgstr "Ochráňte vaše konverzácie"
 
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofón;nahrávanie;záznam;zaznamenávanie;aplikácia;súkromie;"
+
 # toggle button
-#. FIXME
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "_Vyskúšať vaše nastavenia"
@@ -2950,91 +1946,163 @@ msgstr "Hlavné tlačidlo"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "Nastaví poradie fyzických tlačidiel myší a touchpadov."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Ľavé"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Pravé"
 
+# GtkDialog title
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Vyhľadávanie v umiestneniach"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
 # GtkLabel label
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Myš"
 
 # GtkLabel
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Rýchlosť myši"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "Prirodzené rolovanie"
+# GtkListStore row
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Rolovať nadol"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Rolovaním sa posunie obsah a nie zobrazenie."
 
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Rolovaním sa posunie obsah a nie zobrazenie."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktívne"
+
 # GtkLabel label
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
 # GtkLabel label
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Rýchlosť touchpadu"
 
+# GtkLabel label
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Metóda"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
 # GtkCheckButton label
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Kliknúť dotykom"
 
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
 # GtkCheckButton label
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "Rolovať dvoma prstami"
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr "Ťuknutím kliknete"
+
+# GtkCheckButton label
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Zakázať počas _písania"
+
+# GtkListStore item
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (relatívny)"
 
 # GtkListStore row
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Rolovať hranou"
 
+# GtkListStore row
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Rolovať nadol"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Obojstranne"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
 # GtkLabel label
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Vyskúšajte kliknutie, dvojité kliknutie a rolovanie"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Päť kliknutí, čas pre GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dvojité kliknutie, hlavné tlačidlo"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Kliknutie, hlavné tlačidlo"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dvojité kliknutie, stredné tlačidlo"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Kliknutie, stredné tlačidlo"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dvojité kliknutie, sekundárne tlačidlo"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Kliknutie, sekundárne tlačidlo"
 
 # desktop entry name
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
@@ -3049,7 +2117,6 @@ msgstr ""
 "Mení citlivosť vašej myši a touchpadu a umožňuje vybrať, či má byť pre "
 "ľavákov alebo pravákov"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3133,93 +2200,45 @@ msgstr "Súbežná práca"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Spravuje predvoľby pre produktivitu a súbežnú prácu"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "multitasking;súbežná;práca;produktivita;prispôsobiť;prispôsobenie;pracovná;"
-"plocha;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Ale nie. Niekde nastala chyba. Prosím, kontaktuje vášho dodávateľa softvéru."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager musí byť spustený."
+"plocha;aktívny roh;pracovné priestory;"
 
 # button
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Ostatné zariadenia"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+# button label
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Pridať pripojenie"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Nenastavené"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "Nezabezpečená sieť (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "Zabezpečená sieť (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "Zabezpečená sieť (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "Zabezpečená sieť (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "Zabezpečená sieť"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Pripojené"
 
 # button atk;
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Voľby…"
 
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Zapnutím prístupového bodu sa odpojí od siete %s a nebude možné pristupovať "
-"na internet prostredníctvom Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Musí obsahovať minimálne 8 znakov"
-
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-#| msgid "Must have a maximum of %d characters"
 msgid "Must have a maximum of %d character"
 msgid_plural "Must have a maximum of %d characters"
 msgstr[0] "Musí obsahovať maximálne %d znakov"
@@ -3249,192 +2268,92 @@ msgstr "Názov siete"
 
 # GtkLabel label
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Heslo"
 
 # GtkLabel label
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Vygeneruje náhodné heslo"
 
 # GtkLabel
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Automaticky generovať heslo"
 
 # GtkButton label
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Zapnúť"
 
-# GtkLabel label
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Zastaviť prístupový bod a odpojiť všetkých používateľov?"
-
-# button
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "_Zastaviť prístupový bod"
-
 # label
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Režim v lietadle"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Zakáže Wi-Fi, Bluetooth a mobilné širokopásmové pripojenie"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Nenašiel sa žiadny Wi-Fi adaptér"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Uistite sa, že máte Wi-Fi adaptér pripojený a zapnutý"
 
 # label
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Režim v lietadle zapnutý"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Vypnutím použijete sieť Wi-Fi"
 
 # GtkLabel label
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Prístupový bod Wi-Fi aktívny"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Mobilné zariadenia sa môžu pripojiť oskenovaním QR kódu."
 
 # GtkLabel label
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Vypnúť prístupový bod Wi-Fi…"
 
 # desktop entry name
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Viditeľné siete"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager musí byť spustený"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ale nie. Niekde nastala chyba. Prosím, kontaktuje vášho dodávateľa softvéru."
 
 # GtkLabel label
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Zabezpečenie 802.1x"
 
-#  1.2. page; 3. 4. GtkLabel label
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Zabezpečenie"
-
-# tab
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Zachovaná"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Trvalá"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Náhodná"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabilná"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Tu zadaná adresa MAC bude použitá ako hardvérová adresa sieťového "
-"zariadenia, na ktorom je aktivované toto pripojenie. Táto funkcia je známa "
-"ako klonovanie adresy MAC. Príklad: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil č. %d"
-
-# zabezpečenie
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-# zabezpečenie
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-# zabezpečenie
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-# PM: toto je v NMA preložené
-# zabezpečenie
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Podnikové"
-
-# zabezpečenie
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Žiadne"
-
 # naposledy použité
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Nikdy"
-
-# naposledy použité
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
@@ -3442,207 +2361,6 @@ msgid_plural "%i days ago"
 msgstr[0] "pred %i dňami"
 msgstr[1] "pred %i dňom"
 msgstr[2] "pred %i dňami"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-# rýchlosť pripojenia
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mbit/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-# sila signálu
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Žiadny"
-
-# sila signálu
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Slabý"
-
-# sila signálu
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-# sila signálu
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Dobrý"
-
-# sila signálu
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Vynikajúci"
-
-# GtkLabel label
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Adresa IPv4"
-
-# GtkLabel label
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "Adresa IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Adresa IP"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-# GtkLabel label
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "Systém pre názvy domén (DNS)"
-
-# gtk button
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "Zabudnúť pripojenie"
-
-# gtk button
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "Odstrániť profil pripojenia"
-
-# gtk button
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "Odstrániť VPN"
-
-# 1.desktop entry name;2. page; 3. GtkListStore item
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "Podrobnosti"
-
-# PM: rod? na akých miestach tento spinbutton je? Ja to vidím pri MTU, ale možno je to aj inde
-# DK: nenechame tvar: "automaticky" ?
-# spinbutton default
-# doriesit v master vetve
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automaticky"
-
-# 1.2.3. page; GtkListStore item
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Totožnosť"
-
-# button atk
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Odstrániť adresu"
-
-# button atk
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "Odstrániť smerovanie"
-
-# GtkListStore item
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-# GtkListStore item
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-# GtkListStore item
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Žiadne"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128 bitový kľúč (šestnástkový alebo ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128 bitové heslo"
-
-# liststore item
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamické WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "Osobný WPA a WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "Podnikový WPA a WPA 2"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "Osobný WPA3"
 
 # GtkLabel label
 #: panels/network/connection-editor/details-page.ui:14
@@ -3655,9 +2373,24 @@ msgstr "Signál"
 msgid "Link speed"
 msgstr "Rýchlosť pripojenia"
 
+#  1.2. page; 3. 4. GtkLabel label
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Zabezpečenie"
+
+# GtkLabel label
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Adresa IPv4"
+
+# GtkLabel label
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adresa IPv6"
+
 # GtkLabel label
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hardvérová adresa"
 
@@ -3667,12 +2400,18 @@ msgstr "Podporované frekvencie"
 
 # GtkLabel label
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Predvolené smerovanie"
+
+# GtkLabel label
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "Systém pre názvy domén (DNS)"
 
 # pripojenie - je za tým čas kedy bolo definované pripojenie naposledy použité
 # GtkLabel
@@ -3689,12 +2428,12 @@ msgstr "Pripojiť _automaticky"
 msgid "Make available to _other users"
 msgstr "Sprístupniť _ostatným používateľom"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 "O_bmedzené pripojenie: má obmedzené dáta alebo sa môžu účtovať poplatky"
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3751,7 +2490,7 @@ msgstr "Len lokálne pripojenie"
 # GtkComboBox item
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Ručné"
 
@@ -3775,36 +2514,35 @@ msgstr "Adresy"
 
 # GtkLabel label
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Adresa"
 
 # label
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Maska siete"
 
 # label
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Brána"
 
 # GtkListStore (tp;aui;bnc;mii); GtkListStore (10Mb/s, 100Mb/s ...)
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Zistiť automaticky"
 
@@ -3814,32 +2552,37 @@ msgstr "Zistiť automaticky"
 msgid "Automatic DNS"
 msgstr "Automatické zistenie adresy DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Adresy serverov DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "IP adresy oddeľte čiarkami"
 
 # GtkLabel label
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Smerovania"
 
 # GtkSwitch AtkObject
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Automatické zistenie smerovania"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metrika"
 
 # GtkCheckButton label
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Použiť toto pripojenie _iba na zdroje v jeho sieti"
 
@@ -3856,90 +2599,14 @@ msgstr "Automatické, len DHCP"
 
 # label
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Predpona"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Nepodarilo sa otvoriť nástroj na zmenu pripojení"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Nový profil"
-
-# label
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Importovať zo súboru…"
-
-# window title
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "Pridanie VPN"
 
 # GtkLabel label
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Z_abezpečenie"
-
-#: panels/network/connection-editor/vpn-helpers.c:191
-msgid "Cannot import VPN connection"
-msgstr "Nedá sa importovať pripojenie VPN"
-
-# PK: recognized moze byt aj nieco ze to neni standard
-#: panels/network/connection-editor/vpn-helpers.c:193
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Súbor „%s“ sa nepodarilo prečítať alebo neobsahuje rozpoznané informácie o "
-"pripojení VPN\n"
-"\n"
-"Chyba: %s."
-
-# window title
-#: panels/network/connection-editor/vpn-helpers.c:223
-msgid "Select file to import"
-msgstr "Výber súboru na importovanie"
-
-#: panels/network/connection-editor/vpn-helpers.c:276
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Súbor s názvom „%s“ už existuje."
-
-#: panels/network/connection-editor/vpn-helpers.c:278
-msgid "_Replace"
-msgstr "_Nahradiť"
-
-#: panels/network/connection-editor/vpn-helpers.c:280
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Chcete nahradiť %s s pripojením VPN, ktoré sa pokúšate uložiť?"
-
-#: panels/network/connection-editor/vpn-helpers.c:315
-msgid "Cannot export VPN connection"
-msgstr "Pripojenie VPN sa nedá exportovať"
-
-# druhe je subor (moze byt none)
-#: panels/network/connection-editor/vpn-helpers.c:317
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Nepodarilo sa exportovať pripojenie VPN „%s“ do %s.\n"
-"\n"
-"Chyba: %s."
-
-# window title
-#: panels/network/connection-editor/vpn-helpers.c:343
-msgid "Export VPN connection"
-msgstr "Exportovanie pripojenia VPN"
 
 # GtkLabel label
 #: panels/network/connection-editor/vpn-page.ui:34
@@ -3956,117 +2623,54 @@ msgstr "Identifikátor obsluhy (_SSID)"
 msgid "_BSSID"
 msgstr "Identifikátor základnej obsluhy (_BSSID)"
 
+# desktop entry name
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Sieť"
+
 # desktop entry comment
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Ovláda spôsob pripojenia k internetu"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "sieť;IP;LAN;proxy;sprostredkovateľ;WAN;širokopásmové;modem;Bluetooth;vpn;DNS;"
+
+# GtkLabel label
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 # desktop entry comment
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Ovláda spôsob pripojenia k sieťam Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "sieť;bezdrôtová;Wi-Fi;wifi;IP;LAN;širokopásmové;pripojenie;DNS;hotspot;"
 "aktívny;bod;"
 
-# last used
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nikdy"
-
-# last used
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "dnes"
-
-# last used
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "včera"
-
 # GtkLabel label
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Naposledy použité"
-
-# GtkLabel label
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Drôtové"
-
-# liststore item
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Pridať nové pripojenie"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Podrobnosti o vybraných sietiach, vrátane hesla a vlastných nastavení, budú "
-"stratené."
-
-# GtkButton label
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "_Zabudnúť"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Známe siete Wi-Fi"
-
-# button
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Zabudnúť"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Systémové pravidlá zakazujú použitie režimu prístupového bodu"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Bezdrôtové zariadenie nepodporuje režim prístupového bodu"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Ak nezadáte URL konfigurácie, použije sa automatické zistenie "
-"sprostredkovateľa."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Toto sa neodporúča pre nedôveryhodné verejné siete."
 
 # GtkSwitch AtkObject
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Vypnúť zariadenie"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktívne"
 
 # GtkLabel label
 #: panels/network/network-mobile.ui:27
@@ -4079,57 +2683,61 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Poskytovateľ"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adresa IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Sieťový sprostredkovateľ (proxy)"
 
 # GtkLabel label
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "Sprostredkovateľ _HTTP"
 
 # GtkLabel label
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "Sprostredkovateľ H_TTPS"
 
 # GtkLabel label
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "Sprostredkovateľ _FTP"
 
 # GtkLabel label
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Hostiteľ _Socks"
 
 # GtkLabel label
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "_Ignorovať hostiteľov"
 
 # GtkSpinButton AtkObject
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Port sprostredkovateľa _HTTP"
 
 # GtkSpinButton AtkObject
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Port sprostredkovateľa H_TTPS"
 
 # GtkSpinButton AtkObject
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Port sprostredkovateľa _FTP"
 
 # GtkSpinButton AtkObject
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Port sprostredkovateľa Socks"
 
 # GtkLabel label
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "_URL konfigurácie"
 
@@ -4161,307 +2769,24 @@ msgstr "Heslo"
 msgid "Turn Wi-Fi off"
 msgstr "Vypnúť Wi-Fi"
 
+# GtkLabel label
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Viac volieb…"
+
 # GtkButton label
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Pripojiť sa k skrytej sieti…"
 
 # GtkLabel label
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "Zapnúť _prístupový bod Wi-Fi…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "Známe siete _Wi-Fi"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Neznámy stav"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Nespravované"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Nedostupné"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Pripája sa"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Vyžadované je overenie totožnosti"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Odpája sa"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Pripojenie zlyhalo"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Stav neznámy (chýba)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Nastavenie zlyhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Nastavenie IP zlyhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Platnosť nastavenia IP vypršala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Boli požadované tajné informácie, ale neboli poskytnuté"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Žiadateľ 802.1x bol odpojený"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Zlyhalo nastavenia žiadateľa 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Žiadateľ 802.1x zlyhal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Overenie totožnosti žiadateľa 802.1x trvalo príliš dlho"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Služba PPP zlyhala pri štarte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Služba PPP bola odpojená"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP zlyhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Klient DHCP zlyhal pri štarte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Chyba klienta DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Klient DHCP zlyhal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Nepodarilo sa spustiť službu sprístupneného pripojenia"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Služba sprístupneného pripojenia zlyhala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Nepodarilo sa spustiť službu AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Chyba služby AutoIP"
-
-# AutoIP je termin, ako napr. DHCP
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Služba AutoIP zlyhala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linka je zaneprázdnená"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Nie je oznamovací tón"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Nepodarilo sa pripojiť k žiadnemu poskytovateľovi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Vypršal časový limit pre požiadavku na vytáčanie"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Pokus o vytáčanie zlyhal"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Inicializácia modemu zlyhala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Zlyhalo vybratie určeného APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Nehľadá siete"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Registrácia siete bola zamietnutá"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Vypršal limit pre registráciu siete"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Nepodarilo sa zaregistrovať v požadovanej sieti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Zlyhala kontrola kódu PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Firmvér pre toto zariadenie môže chýbať"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Pripojenie sa stratilo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Existujúce pripojenie bolo odhadnuté"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Nenájdený modem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth pripojenie zlyhalo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Karta SIM nie je vložená"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Vyžadovaný kód Pin pre kartu SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Vyžadovaný kód Puk pre kartu SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Zlá karta SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Závislosť pripojenia zlyhala"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Chýba firmvér"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kábel odpojený"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "nedefinovaná chyba v zabezpečení protokolu 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "Nebol vybratý žiadny súbor"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "nešpecifikovaná chyba pri overovaní súboru metódy protokolu eap"
-
-# PK: pkcs#12 je zauzivane
-# file filter
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr ""
-"Súkromné kľúče typu DER, PEM alebo PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-# file filter
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Certifikáty typu DER alebo PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "chýba súbor PAC protokolu EAP-FAST"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Súbory PAC (*.pac)"
 
 # liststore item
 #: panels/network/wireless-security/eap-method-fast.ui:13
@@ -4523,14 +2848,6 @@ msgstr "_Vnútorné overenie totožnosti"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Umožniť automatické zaobstarávanie PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "chýba používateľské meno protokolu EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "chýba heslo protokolu EAP-LEAP"
-
 # GtkLabel label
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
@@ -4545,7 +2862,7 @@ msgstr "_Používateľské meno"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Heslo"
 
@@ -4558,15 +2875,6 @@ msgstr "_Heslo"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Zobraziť heslo"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "neplatný certifikát protokolu EAP-PEAP CA: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "neplatný certifikát protokolu EAP-PEAP CA: certifikát nebol určený"
 
 # liststore (MSCHAPv2,GTC)
 #: panels/network/wireless-security/eap-method-peap.ui:17
@@ -4597,7 +2905,6 @@ msgstr "_Certifikát certifikačnej autority (CA)"
 
 # DK:všetko dialog title
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4613,67 +2920,6 @@ msgstr "Nie je vyžadovaný žiadny certifikát CA"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Verzia PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "chýba používateľské meno protokolu EAP"
-
-# DK:dialog title
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "chýba heslo EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "chýba identita protokolu EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "neplatný certifikát protokolu EAP-TLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "neplatný certifikát protokolu EAP-TLS CA: certifikát nebol určený"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "neplatný súkromný kľúč protokolu EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "neplatný certifikát používateľa protokolu EAP-TLS: %s"
-
-# gtkdialog title
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Nezašifrované súkromné kľúče nie sú bezpečné"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Zvolený súkromný kľúč sa nejaví byť chránený heslom. To by mohlo umožniť "
-"zneužitiu bezpečnostných poverení. Prosím, zvoľte súkromný kľúč chránený "
-"heslom\n"
-"\n"
-"(Váš súkromný kľúč môžete opatriť heslom pomocou nástroja openssl)"
-
-# DK:button
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Vybrať váš osobný certifikát"
-
-# DK:button
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Vybrať váš súkromný kľúč"
 
 # GtkLabel label
 #: panels/network/wireless-security/eap-method-tls.ui:11
@@ -4694,15 +2940,6 @@ msgstr "Súkromný _kľúč"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Heslo súkromného kľúča"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "neplatný certifikát protokolu EAP-TTLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "neplatný certifikát protokolu EAP-TTLS CA: certifikát nebol určený"
 
 # litstore item
 #: panels/network/wireless-security/eap-method-ttls.ui:13
@@ -4730,15 +2967,17 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Doména"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Neznáma chyba pri overovaní bezpečnosti štandardu 802.1X"
-
 # litstore item
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+# liststore item
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4770,65 +3009,11 @@ msgstr "Chránený EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Overenie totožnosti"
 
-# file chooser dialog title
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-#| msgid "Select a File…"
-msgid "Select a file"
-msgstr "Vybrať súbor"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "chýba používateľské meno protokolu leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "chýba heslo protokolu leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Chýba heslo k sieti Wi-Fi."
-
 # GtkLabel label
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Typ"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "chýba kľúč zabezpečenia wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"neplatný kľúč zabezpečenia wep: kľúč o dĺžke %zu musí obsahovať iba "
-"hexadecimálne čísla"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"neplatný kľúč zabezpečenia wep: kľúč o dĺžke %zu musí obsahovať iba znaky v "
-"kódovaní ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"neplatný kľúč zabezpečenia wep: nesprávna dĺžka kľúča %zu. Kľúč musí byť o "
-"dĺžke buď 5/13 (ascii) alebo 10/26 (hexadecimálne)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "neplatný kľúč zabezpečenia wep: heslo nemôže byť prázdne"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "neplatný kľúč zabezpečenia wep: heslo musí byť kratšie ako 64 znakov"
 
 # WEP index
 # GtkListStore item
@@ -4862,21 +3047,6 @@ msgstr "_Zobraziť kľúč"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP inde_x"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"neplatné zabezpečenie wpa-psk: neplatná dĺžka kľúča %zu. Musí byť o dĺžke "
-"[8,63] bajtov alebo 64 hexadecimálnych čísel"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"neplatné zabezpečenie wpa-psk: nedá sa interpretovať 64 bajtový kľúč ako "
-"hexadecimálny"
 
 # policy_settings
 #. This is the per application switch for message tray usage.
@@ -4939,59 +3109,33 @@ msgstr "Oznámenia v _uzamknutej obrazovke"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Ovláda zobrazovanie oznámení a ich obsah"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Oznámenia;Bublina;Správa;Oblasť upozornení;Vyskakovacie;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "Účet %s bol odstránený"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Iný"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Chyba pri odstraňovaní účtu"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Vrátiť späť"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Zavrieť oznámenie"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "Pripojte sa k vašim údajom v cloude"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "Bez pripojenia k internetu — pripojte sa pre nastavenie nového účtu služieb"
 
 # GtkButton label
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Pridať účet"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:426
-#, c-format
-msgid "%s Account"
-msgstr "Účet služby %s"
-
-# GtkToolButton label
-#: panels/online-accounts/gnome-control-center-goa-helper.c:429
-msgid "Remove Account"
-msgstr "Odstrániť účet"
 
 # desktop entry name
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
@@ -5004,10 +3148,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Pripojí vás k vašim účtom sieťových služieb a rozhodne na čo sa použijú"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5015,10 +3155,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;web;on-line;rozhovor;chat;kalendár;e-mail;mail;"
 "email;pošta;kontakt;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Neznámy čas"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5036,13 +3172,6 @@ msgstr[0] "%i hodín"
 msgstr[1] "%i hodina"
 msgstr[2] "%i hodiny"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s, %i %s"
-
 # prasácky kód
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
@@ -5057,197 +3186,6 @@ msgid_plural "minutes"
 msgstr[0] "minút"
 msgstr[1] "minúta"
 msgstr[2] "minúty"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s do úplného nabitia"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Výstraha: zostáva %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "zostáva %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Úplne nabitá"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Nenabíja sa"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Vybitá"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Nabíja sa"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Vybíja sa"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Bezdrôtová myš"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Bezdrôtová klávesnica"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Neprerušiteľný zdroj napájania (UPS)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Vreckový počítač (PDA)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobilný telefón"
-
-#  PM: takýto preklad je v inom module
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Prenosný prehrávač"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Počítač"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Herné vstupné zariadenie"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batéria"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Hlavná"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Dodatočná"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batérie"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "Pri neč_innosti"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "Uspať"
-
-# label
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "Vypnúť"
-
-# GtkListStore item
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "Hibernovať"
-
-# chooser_button
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "Nespraviť nič"
-
-#  label
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "Pri napájaní z batérie"
-
-# PK: ked je zastrceny v zasuvke
-#  label
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "Pri napájaní zo siete"
-
-# naposledy použité
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nikdy"
-
-# label
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "Automatické uspanie"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "Výkonný režim je dočasne zakázaný kvôli vysokej pracovnej teplote."
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Zistené lono: výkonný režim je dočasne nedostupný. Obnovíte ho presunutím "
-"zariadenia na stabilný povrch."
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr "Výkonný režim je dočasne zakázaný."
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Vybitá batéria: je povolený šetrič energie. Predchádzajúci režim bude "
-"obnovený po dostatočnom nabití batérie."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Režim šetriča energie aktivovaný aplikáciou „%s“."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Výkonný režim aktivovaný aplikáciou „%s“."
 
 #  * https://bugzilla.gnome.org/show_bug.cgi?id=695517
 # approx_time; Oneskorenie
@@ -5337,6 +3275,16 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 hodiny"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batéria"
+
+# label
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Zariadenia"
+
 # GtkListStore item
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5360,100 +3308,71 @@ msgstr "Automatický jas obrazovky"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "Jas obrazovky sa upraví podľa okolitého svetla."
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Stmaviť obrazovku"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr "Zníži jas obrazovky, keď počítač nie je aktívny."
 
 # MČ: nemám to ako teraz posúdiť, ale nie sú na rovnakej obrazovke s "High Contrast"? Potom je tam problém s akcelerátorom.
 # PM: je to v samostatnom okne vid web glade runner
 # GtkLabel
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "Vyprázdniť _obrazovku"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "Vypne obrazovku po časovom úseku nečinnosti."
 
 # label
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Automatický šetrič energie"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr "Povolí režim šetriča energie, keď je batéria vybitá."
 
 # GtkDialog title
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "_Automatické uspanie"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "Pozastaví počítač po časovom úseku nečinnosti."
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Správanie _tlačidla napájania"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Zobraziť _percentá batérie"
 
 # GtkDialog title
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Automatické uspanie"
 
 # GtkLabel label
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_Pripojený k sieti"
 
 # GtkLabel label
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Napájaný z _batérie"
 
 # GtkLabel label
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Oddialiť o"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Výkon"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Vysoký výkon a spotreba energie."
-
-# vľavo - vpravo
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Vyvážený"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Štandardný výkon a spotreba energie."
-
-# label
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Šetrič energie"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Znížený výkon a spotreba energie."
 
 # desktop entry name
 #: panels/power/gnome-power-panel.desktop.in.in:3
@@ -5466,7 +3385,6 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Zobrazuje stav vašej batérie a umožňuje zmenu nastavení šetrenia energie"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5474,27 +3392,6 @@ msgid ""
 msgstr ""
 "Napájanie;Uspať;Hibernovať;Batéria;Jas;Stmavenie;Prázdny;Displej;Obrazovka;"
 "DPMS;Nečinnosť;Energia;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Tlačiareň „%s“ bola odstránená"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "Pridávanie novej tlačiarne zlyhalo."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Nepodarilo sa načítať súbor používateľského rozhrania: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Odomknutím pridáte tlačiarne a zmeníte nastavenia"
 
 # desktop entry name
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
@@ -5508,7 +3405,6 @@ msgstr ""
 "Pridáva tlačiarne, zobrazuje úlohy a umožňuje vám rozhodnúť ako sa bude "
 "tlačiť"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Tlačiareň;Rad;Fronta;Tlač;Papier;Atrament;Toner;"
@@ -5517,35 +3413,33 @@ msgstr "Tlačiareň;Rad;Fronta;Tlač;Papier;Atrament;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Pridať tlačiareň"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "Odo_mknúť"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Nenašli sa žiadne tlačiarne"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Zadajte sieťovú adresu, alebo vyhľadajte tlačiareň"
 
 # GtkLabel label
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Vyžaduje sa overenie totožnosti"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Zadajte používateľské meno a heslo pre zobrazenie tlačiarní na tlačovom "
@@ -5553,68 +3447,44 @@ msgstr ""
 
 # GtkLabel label
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Meno používateľa"
 
-# 1.desktop entry name;2. page; 3. GtkListStore item
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "Podrobnosti o tlačiarni %s"
-
-# gtk_menu_item
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Nenašiel sa žiadny vhodný ovládač"
-
-# file chooser dialog title
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "Výber súboru PPD"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Súbory popisu PostScriptu tlačiarne (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Názvy tlačiarní nemôžu obsahovať MEDZERU, TABULÁTOR, znak # alebo /"
 
 # GtkLabel label
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Umiestnenie"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Ovládač"
 
 # gtk_image_menu_item
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Hľadajú sa preferované ovládače…"
 
 # gtkbutton label
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Vyhľadať ovládače"
 
 # gtk_image_menu_item
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Vybrať z databázy…"
 
 # gtk_image_menu_item
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Inštalovať súbor PPD…"
 
@@ -5628,118 +3498,16 @@ msgstr "Výber ovládača pre tlačiareň"
 msgid "Loading drivers database…"
 msgstr "Načítava sa databáza ovládačov…"
 
+# GtkButton label
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Zrušiť"
+
 # tlačidlo
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Vybrať"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Tlačiareň s technológiou JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Tlačiareň protokolu LPD"
-
-# PK: prosim, ak mas tlaciaren otestuj, ja nemam
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Jednostranne"
-
-# ako sa prevrati stranka
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Dlhý okraj (štandard)"
-
-# ako sa prevrati stranka
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Krátky okraj (prevrátiť)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Na výšku"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Na šírku"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Opačne na šírku"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Opačne na výšku"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "Čaká"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pozastavená"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Vyžaduje sa overenie totožnosti"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "Spracúva sa"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Zastavená"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Zrušená"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Prerušená"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Dokončená"
-
-# tooltip
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "Presunie túto úlohu navrch fronty"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5747,19 +3515,6 @@ msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u úloh vyžaduje overenie totožnosti"
 msgstr[1] "%u úloha vyžaduje overenie totožnosti"
 msgstr[2] "%u úlohy vyžadujú overenie totožnosti"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Aktívne úlohy"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Zadajte poverenia na tlač z tlačiarne %s."
 
 # GtkLabel
 #. Translators: This is a windows domain used with SMB protocol.
@@ -5770,235 +3525,32 @@ msgstr "Doména"
 
 # GtkButton label
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "Overiť _totožnosť"
 
 # GtkButton label
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Vymazať všetky"
 
 # GtkButton label
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Overiť totožnosť"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Žiadne aktívne úlohy tlačiarne"
 
-# headerbar
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Odomknutie tlačového servera"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Odomknúť %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Zadajte používateľské meno a heslo pre zobrazenie tlačiarní na serveri %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Vyhľadávajú sa tlačiarne"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Sériový Port"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Paralelný port"
-
-# GtkLabel label
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Umiestnenie: %s"
-
-# GtkLabel label
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adresa: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Server vyžaduje overenie totožnosti"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Obojstranne"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Typ papiera"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Zdroj papiera"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Výstupný zásobník"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Rozlíšenie"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Predfiltrovanie pre GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Stránok na stranu"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Obojstranne"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientácia"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Všeobecné"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Nastavenie stránky"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Inštalované vybavenie"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Úloha"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Kvalita obrázkov"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Farba"
-
-# PM: toto asi nebude dobre
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Dokončovanie"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Pokročilé"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Skúšobná stránka"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Skúšobná stránka"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Automatický výber"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Predvolené hodnoty tlačiarne"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Vkladať len písma GhostScript"
-
-# MČ: PostScript Level 1 - PostScript Verzie 1, ale pri PS sa verzie nazývajú Level. teda aspoň ja to tak chápem
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Konvertovať na PS verzie 1"
-
-# MČ: PostScript Level 1 - PostScript Verzie 1, ale pri PS sa verzie nazývajú Level. teda aspoň ja to tak chápem
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Konvertovať na PS verzie 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Žiadne predfiltrovanie"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Výrobca"
-
-# GtkDialog title
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Žiadne aktívne úlohy"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -6006,115 +3558,6 @@ msgid_plural "%u Jobs"
 msgstr[0] "%u úloh"
 msgstr[1] "%u úloha"
 msgstr[2] "%u úlohy"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Čistenie tlačových hláv"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Málo tonera"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Minul sa toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Málo vývojky"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Minula sa vývojka"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Málo farby"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Minula sa farba"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Otvorený kryt"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Otvorené dvierka"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Málo papiera"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Minul sa papier"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Vypnutá"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Zastavená"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Odpadová nádržka takmer plná"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Odpadová nádržka plná"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Fotovalcu onedlho skončí životnosť"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Fotovalec už nie je funkčný"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Pripravená"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Neprijíma úlohy"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Pracuje"
 
 # GtkLabel
 #: panels/printers/printer-entry.ui:18
@@ -6141,49 +3584,51 @@ msgstr "Vyčistiť tlačové hlavy"
 msgid "Remove Printer"
 msgstr "Odstrániť tlačiareň"
 
+# GtkDialog title
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Žiadne aktívne úlohy"
+
 # GtkLabel label
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Model"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Úroveň atramentu"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Prosím, vykonajte reštart, keď bude problém vyriešený."
 
 # button
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Reštartovať"
 
 # GtkToolButton label
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Pridať tlačiareň…"
 
+# GtkToolButton label
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Pridať tlačiareň…"
+
 # desktop entry name
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Žiadne tlačiarne"
 
-# GtkToolButton label
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Pridať tlačiareň…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
-#| msgid ""
-#| "Sorry! The system printing service\n"
-#| "doesn’t seem to be available."
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6193,56 +3638,39 @@ msgstr ""
 
 # TODO lepšia alternatíva?
 # GtkDialog title; GtkLabel label
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Formáty"
 
-# GtkListStore row
-#: panels/region/cc-format-chooser.ui:37 panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "Späť"
-
 # GtkDialog title
 #: panels/region/cc-format-chooser.ui:76
-#| msgid "Search locales..."
 msgid "Search locales…"
 msgstr "Vyhľadajte miestne nastavenia…"
 
 # TODO lepšia alternatíva?
 # GtkDialog title; GtkLabel label
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Spoločné formáty"
 
 # TODO lepšia alternatíva?
 # GtkDialog title; GtkLabel label
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Všetky formáty"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Žiadne výsledky vyhľadávania"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Vyhľadávané môžu byť krajiny alebo jazyky."
 
 # GtkLabel label
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Ukážka"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperiálne"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrické"
 
 # GtkLabel label
 #: panels/region/cc-format-preview.ui:17
@@ -6278,33 +3706,35 @@ msgid "Logout…"
 msgstr "Odhlásiť sa…"
 
 #: panels/region/cc-region-panel.ui:45
-#| msgid "The format used for numbers, dates, and currencies."
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
-"Nastavenia jazyka je použité pre text rozhrania a webové stránky. Formát je "
-"použitý pre čísla, dátumy a meny."
+"Nastavenia jazyka je použité pre text rozhrania a webové stránky. Formáty sú "
+"použité pre čísla, dátumy a meny."
 
-#: panels/region/cc-region-panel.ui:51
-#| msgid "Your account"
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Váš účet"
 
 # GtkLabel
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Jazyk"
 
 # TODO lepšia alternatíva?
 # GtkDialog title; GtkLabel label
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Formáty"
 
 # toggle button
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Prihlasovacia obrazovka"
 
@@ -6318,122 +3748,9 @@ msgstr "Región a jazyk"
 msgid "Select your display language and formats"
 msgstr "Vyberá váš zobrazovaný jazyk a formáty"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Jazyk;Rozloženie;Klávesnica;Vstup;"
-
-# chooser_button
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Spýtať sa, čo robiť"
-
-# chooser_button
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Nespraviť nič"
-
-# chooser_button
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Otvoriť priečinok"
-
-# window title
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Ostatné nosiče"
-
-# window heading
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Vyberte si aplikáciu pre audio CD"
-
-# window heading
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Vyberte si aplikáciu pre video DVD"
-
-#  window heading
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Vyberte si aplikáciu, ktorá sa spustí pri pripojení hudobného prehrávača"
-
-# window heading
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Vyberte si aplikáciu, ktorá sa spustí pri pripojení fotoaparátu"
-
-# window heading
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Vyberte si aplikáciu pre CD so softvérom"
-
-# listore item
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "audio DVD"
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "prázdny disk Blu-ray"
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "prázdny disk CD"
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "prázdny disk DVD"
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "prázdny disk HD DVD"
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "video disk Blu-ray "
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "elektronická čítačka kníh"
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "video disk HD DVD"
-
-# PM: je to názov formátu od Kodaku
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-# listore item
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "softvér systému Windows"
 
 # GtkLabel label
 #: panels/removable-media/cc-removable-media-panel.ui:32
@@ -6496,7 +3813,6 @@ msgid "Configure Removable Media settings"
 msgstr "Nastavuje vymeniteľné nosiče"
 
 # desktop entry keywords
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6506,15 +3822,89 @@ msgstr ""
 "video;disk;vymeniteľný;nosič;médium;médiá;spustenie;samospustenie;"
 "automatické;otvorenie;otváranie;"
 
-# file chooser dialog title
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Výber miesta"
+# 2 GtkDialog title
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Uzamknutie obrazovky"
 
-# liststore item
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Ok"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatické uzamykanie obrazovky zabraňuje ostatným pristupovať k vášmu "
+"počítaču, pokiaľ ste preč."
+
+# PK: toto je divne, skor vypnut obrazovku
+# PM: no blank screen praveze nie je vypnutie obrazovky, balnk screen je vyplnenie obrazovky čiernou ale je stále zapnutá. Používa sa to pri starých monitoroch, ktoré zobrazujú pri ATM hlásku ze nie je signál.
+# label
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Oneskorenie vyprázdnenia obrazovky"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Doba nečinnosti, po ktorej sa vyprázdni obrazovka."
+
+# GtkLabel label
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "A_utomatické uzamykanie obrazovky"
+
+# GtkLabel label
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Oneskorenie a_utomatického uzamykania obrazovky"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Doba, po ktorej sa obrazovka vyprázdni, keď je obrazovka automaticky "
+"uzamknutá."
+
+# GtkLabel label
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Zobrazovať oznámenia v uzamknutej obrazovke"
+
+# desktop entry name
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Oznámenia v _uzamknutej obrazovke"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Zakázať nové zariadenia _USB"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Zabráni novým zariadeniam USB ovplyvniť systém počas uzamknutej obrazovky."
+
+# desktop entry name
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr "Súkromie obrazovky"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr "Obmedziť pozorovací uhol"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Obrazovka"
+
+# GtkDialog title
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Nastavenia obrazovky"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "obrazovka;zámok;uzamknutie;súkromie;súkromná;"
 
 # GtkDialog title
 #: panels/search/cc-search-locations-dialog.ui:8
@@ -6534,45 +3924,33 @@ msgstr ""
 msgid "Places"
 msgstr "Miesta"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Záložky"
 
-#: panels/search/cc-search-locations-dialog.ui:48
-#| msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "Ostatné"
 
 # GtkLabel label
-#: panels/search/cc-search-locations-dialog.ui:55
-#| msgid "Location"
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Pridať umiestnenie"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Nenašli sa žiadne aplikácie"
-
 # tab
 #: panels/search/cc-search-panel.ui:10
-#| msgid "Application Switching"
 msgid "Application Search"
 msgstr "Vyhľadávanie aplikácií"
 
 #: panels/search/cc-search-panel.ui:11
-#| msgid "Include applications from all _workspaces"
 msgid "Include application-provided search results."
 msgstr "Zahŕňa výsledky vyhľadávania poskytnuté aplikáciami."
 
 #: panels/search/cc-search-panel.ui:23
-#| msgid ""
-#| "Folders which are searched by system applications, such as Files, Photos "
-#| "and Videos."
 msgid "Folders which are searched by system applications."
 msgstr "Priečinky, ktoré sú prehľadávané systémovými aplikáciami."
 
 #: panels/search/cc-search-panel.ui:37
-#| msgid "No Search Results"
 msgid "Search Results"
 msgstr "Výsledky vyhľadávania"
 
@@ -6587,69 +3965,14 @@ msgid ""
 msgstr ""
 "Ovláda zoznam aplikácií, ktoré môžu zobraziť výsledky v prehľade aktivít"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Vyhľadávanie;Nájsť;Index;Skryť;Súkromie;Výsledky;"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "Nie sú vybraté žiadne siete na sprístupnenie"
 
 # desktop entry name
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Siete"
-
-#: panels/sharing/cc-sharing-panel.c:367
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Zapnuté"
-
-#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Vypnuté"
-
-#: panels/sharing/cc-sharing-panel.c:399
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Povolená"
-
-#: panels/sharing/cc-sharing-panel.c:402
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktívne"
-
-# file chooser dialog title
-#: panels/sharing/cc-sharing-panel.c:520
-msgid "Choose a Folder"
-msgstr "Výber priečinka"
-
-# GtkLabel label
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:748
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Spoločné používanie súborov umožňuje spoločne sprístupniť váš priečinok "
-"„Verejné“ s ostatnými na aktuálnej sieti použitím: %s"
-
-# GtkLabel label
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:754
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Keď je povolené vzdialené prihlásenie, vzdialení používatelia sa môžu "
-"pripojiť pomocou príkazu Secure Shell:\n"
-"%s"
 
 # desktop entry name
 #: panels/sharing/cc-sharing-panel.ui:9
@@ -6697,13 +4020,12 @@ msgid "Remote Login"
 msgstr "Vzdialené prihlásenie"
 
 # GtkDialog title
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
-#| msgid "Remote Login"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "Vzdialená pracovná plocha"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
@@ -6712,89 +4034,90 @@ msgstr ""
 "plochy z iného počítača."
 
 #  policy action description
-#: panels/sharing/cc-sharing-panel.ui:268
-#| msgid "Enable or disable remote login"
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr ""
 "Povoľuje alebo zakazuje vzdialené pripojenia k pracovnej ploche tohto "
 "počítača."
 
 # GtkLabel label
-#: panels/sharing/cc-sharing-panel.ui:280
-#| msgid "_Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "Vzdialené ovládanie"
 
-#: panels/sharing/cc-sharing-panel.ui:281
-#| msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
 msgstr "Umožňuje vzdialené pripojenia na ovládanie obrazovky."
 
 # gtk button
-#: panels/sharing/cc-sharing-panel.ui:294
-#| msgid "Forget Connection"
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
 msgstr "Ako sa pripojiť"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
 "Pripojí sa k tomuto počítaču pomocou názvu zariadenia alebo adresy "
 "vzdialenej pracovnej plochy."
 
+# menu item
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopírovať"
+
 # button atk
-#: panels/sharing/cc-sharing-panel.ui:323
-#| msgid "Delete Address"
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "Adresa vzdialenej pracovnej plochy"
 
 # GtkLabel label
-#: panels/sharing/cc-sharing-panel.ui:350
-#| msgid "Au_thentication"
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "Overenie totožnosti"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr "Na pripojenie k tomuto počítaču sa vyžaduje meno používateľa a heslo."
 
 # GtkLabel label
-#: panels/sharing/cc-sharing-panel.ui:355
-#| msgid "Username"
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "Meno používateľa"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "Overiť šifrovanie"
 
 # GtkLabel
-#: panels/sharing/cc-sharing-panel.ui:430
-#| msgid "Fingerprint"
+#: panels/sharing/cc-sharing-panel.ui:434
 msgid "Encryption Fingerprint"
 msgstr "Odtlačok prsta pre overenie totožnosti"
 
-#: panels/sharing/cc-sharing-panel.ui:431
+#: panels/sharing/cc-sharing-panel.ui:435
+#, fuzzy
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
 "Odtlačok prsta pre overenie totožnosti môže byť viditeľný v pripojovacích "
 "klientoch a mal by byť identický."
 
 # GtkDialog title
-#: panels/sharing/cc-sharing-panel.ui:463
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Spoločné používanie multimédií"
 
 # GtkLabel label
-#: panels/sharing/cc-sharing-panel.ui:485
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "Sprístupnite hudbu, fotografie a videá cez sieť."
 
 # GtkToolButton label
-#: panels/sharing/cc-sharing-panel.ui:498
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Priečinky"
 
@@ -6803,7 +4126,6 @@ msgstr "Priečinky"
 msgid "Control what you want to share with others"
 msgstr "Ovláda, ktoré údaje chcete sprístupniť ostatným"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6825,41 +4147,43 @@ msgstr ""
 "Na povolenie alebo zakázanie vzdialeného prihlásenia je vyžadované overenie "
 "totožnosti"
 
-# téma
-#: panels/sound/cc-alert-chooser.c:150
-msgid "Custom"
-msgstr "Vlastná"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Brechanie"
+msgid "Click"
+msgstr ""
 
+# desktop entry name
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "Kvapkanie vody"
+#, fuzzy
+msgid "String"
+msgstr "Sprístupnenie"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "Ťukanie na sklo"
+msgid "Swing"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "Sonar"
+msgid "Hum"
+msgstr ""
+
+# vľavo - vpravo
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Rovnováha"
+
+# vpredu - dozadu
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Prelínanie"
 
 # Prelínanie:
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Dozadu"
 
 # Prelínanie:
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Dopredu"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Skúša sa %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6869,70 +4193,63 @@ msgstr "Kliknutím vyberiete reproduktor na vyskúšanie"
 msgid "System Volume"
 msgstr "Systémová hlasitosť"
 
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Hlavná hlasitosť"
+
 # KeyListEntry description
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Úrovne hlasitosti"
 
 # tab
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Výstup"
 
 # label
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Výstupné zariadenie"
 
 # button label
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Vyskúšať"
 
 # GtkLabel label
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Konfigurácia"
 
-# vľavo - vpravo
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "Rovnováha"
-
-# vpredu - dozadu
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "Prelínanie"
-
 # channel position
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Basový reproduktor"
 
 # tab
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Vstup"
 
 # label
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Vstupné zariadenie"
 
 # KeyListEntry description
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Hlasitosť"
 
 # label
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Zvuk varovania"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100 %"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Stlmiť"
 
 # desktop entry name
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
@@ -6944,86 +4261,12 @@ msgstr "Zvuk"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Mení hlasitosť zvuku, vstupy, výstupy a zvukové varovania"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "karta;mikrofón;hlasitosť;rovnováha;vyváženie;bluetooth;slúchadlo;náhlavná;"
 "súprava;zvuk;audio;výstup;vstup;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Odpojené"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Pripája sa"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Pripojené"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Chyba overenia totožnosti"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Overuje sa totožnosť"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Obmedzená funkčnosť"
-
-# GtkLabel label
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Pripojené a overená totožnosť"
-
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# grafika, AP typ
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Neznáme"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Overená totožnosť o:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Pripojené o:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Zaregistrované o:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Zlyhalo overenie totožnosti zariadenia: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Zlyhalo zabudnutie zariadenia: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7033,102 +4276,59 @@ msgstr[0] "Závisí na %u ďalších zariadeniach"
 msgstr[1] "Závisí na %u ďalšom zariadení"
 msgstr[2] "Závisí na %u ďalších zariadeniach"
 
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Zavrieť oznámenie"
+
 # GtkLabel label
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Názov:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Stav:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
 # GtkLabel label
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Overiť totožnosť a pripojiť"
 
 # GtkToolButton label
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Zabudnúť zariadenie"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Chyba"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Žiadna podpora zariadení Thunderbolt"
 
-# PAC provisioning
-# GtkListStore item
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Overená totožnosť"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Nepodarilo sa pripojiť k podsystému rozhrania thunderbolt."
 
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Podsystém Thunderbolt (boltd) nie je nainštalovaný alebo správne nastavený."
+# KeyListEntries name; desktop entry name
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Priamy prístup"
 
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 "Umožnenie priameho prístupu k zariadeniami, ako sú doky a externé grafické "
 "procesory."
 
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Môžu byť pripojené iba zariadenia typu USB a Display Port."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Rozhranie Thunderbolt sa nepodarilo rozpoznať.\n"
-"Buď systém nepodporuje rozhranie Thunderbolt, alebo bola zakázaná v BIOSe, "
-"alebo je nastavená na nepodporovanú bezpečnostnú úroveň v BIOSe."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Podpora zariadení Thunderbolt bola zakázaná v systéme BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Nepodarilo sa zistiť úroveň bezpečnosti zariadenia Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Chyba počas prepínania priameho režimu: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
-#| msgid "No Thunderbolt support"
-msgid "No Thunderbolt Support"
-msgstr "Žiadna podpora zariadení Thunderbolt"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:104
-#| msgid "Couldn’t connect to the %s domain: %s"
-msgid "Could not connect to the thunderbolt subsystem."
-msgstr "Nepodarilo sa pripojiť k podsystému rozhrania thunderbolt."
-
-# KeyListEntries name; desktop entry name
-#: panels/thunderbolt/cc-bolt-panel.ui:153
-msgid "Direct Access"
-msgstr "Priamy prístup"
-
 # GtkToolButton label
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Čakajúce zariadenia"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Žiadne pripojené zariadenia"
 
@@ -7140,7 +4340,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Spravuje zariadenia Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;súkromie;"
@@ -7151,18 +4350,18 @@ msgid "Cursor Blinking"
 msgstr "Blikanie kurzora"
 
 # GtkCheckButton label
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Kurzor v textových poliach bliká."
 
 # GtkLabel label
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Rýchlosť"
 
 # GtkHScale AtkObject
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Rýchlosť blikania kurzora"
 
@@ -7263,17 +4462,17 @@ msgid "Repeat Keys"
 msgstr "Opakovanie klávesov"
 
 # GtkCheckButton label
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Opakovanie klávesu pri držaní."
 
 # GtkHScale AtkObject
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Oneskorenie opakovania klávesov"
 
 # GtkHScale AtkObject
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Rýchlosť opakovania kláves"
 
@@ -7375,50 +4574,14 @@ msgid "Long"
 msgstr "Dlhé"
 
 # GtkLabel
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "_Povoliť klávesnicou"
 
 # GtkLabel
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Zapnúť funkcie sprístupnenia z klávesnice"
-
-# sound id
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:357
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Predvolená"
-
-#: panels/universal-access/cc-ua-panel.c:360
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Stredná"
-
-#: panels/universal-access/cc-ua-panel.c:363
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Veľká"
-
-#: panels/universal-access/cc-ua-panel.c:366
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Väčšia"
-
-#: panels/universal-access/cc-ua-panel.c:369
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Najväčšia"
-
-#: panels/universal-access/cc-ua-panel.c:373
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d pixelov"
-msgstr[1] "%d pixel"
-msgstr[2] "%d pixely"
 
 # KeyListEntries name; desktop entry name
 #: panels/universal-access/cc-ua-panel.ui:17
@@ -7506,7 +4669,6 @@ msgid "_Typing Assist (AccessX)"
 msgstr "Asistované _písanie (AccessX)"
 
 #: panels/universal-access/cc-ua-panel.ui:240
-#| msgid "Pointing & Clicking"
 msgid "Pointing &amp; Clicking"
 msgstr "Ukazovanie a klikanie"
 
@@ -7558,32 +4720,6 @@ msgstr "Blik_núť celou obrazovkou"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Bliknúť celým o_knom"
-
-# dlzka krizu
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Krátky"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ obrazovky"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ obrazovky"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ obrazovky"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Dlhý"
 
 # Cast obrazovky:
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
@@ -7770,13 +4906,7 @@ msgid "Make it easier to see, hear, type, point and click"
 msgstr "Uľahčuje videnie, písanie, počúvanie, ukazovanie a klikanie"
 
 # desktorp entry keywords
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
-#| msgid ""
-#| "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
-#| "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
-#| "Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
-#| "audio;typing;"
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
 "Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
@@ -7787,151 +4917,6 @@ msgstr ""
 "Obrazovka;Čítačka obrazovky;text;písmo;veľkosť;AccessX;Lepkavé;Klávesy;"
 "Pomalé;Poskakujúce;Myš;dvojklik;dvojité;kliknutie;oneskorenie;asistencia;"
 "pomoc;opakovanie;blikanie;vizuálne;počúvanie;zvuk;písanie;animácie;"
-
-# Oddialiť o
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 hodina"
-
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-# po dobu
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 deň"
-
-# GtkListStore item
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dni"
-
-# GtkListStore item
-# po dobe
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dni"
-
-# GtkListStore item
-# po dobe
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dni"
-
-# GtkListStore item
-# po dobe
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dní"
-
-# GtkListStore item
-# po dobe
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dní"
-
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-# po dobu
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dní"
-
-# GtkListStore item
-# po dobe
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dní"
-
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-# po dobu
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dní"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Vysypať všetky položky z Koša?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Všetky položky v koši budú natrvalo odstránené."
-
-# GtkButton label
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Vyprázdniť kôš"
-
-# 2 GtkDialog title
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Odstrániť všetky dočasné súbory?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Všetky dočasné súbory budú natrvalo odstránené."
-
-# GtkButton label
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Vymazať dočasné súbory"
-
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-# po dobu
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 deň"
-
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-# po dobu
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dní"
-
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-# po dobu
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dní"
-
-# GtkListStore item
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Navždy"
 
 # window title;
 #: panels/usage/cc-usage-panel.ui:9
@@ -7964,7 +4949,6 @@ msgstr "Vy_mazať históriu…"
 
 # 2 GtkDialog title
 #: panels/usage/cc-usage-panel.ui:63
-#| msgid "Trash & Temporary Files"
 msgid "Trash &amp; Temporary Files"
 msgstr "Kôš a dočasné súbory"
 
@@ -8009,57 +4993,12 @@ msgstr "História súborov a kôš"
 msgid "Don't leave traces"
 msgstr "Nezanechávajte stopy"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Mala by sa zhodovať s webovou adresou vášho poskytovateľa prihlásenia."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Zlyhalo pridanie účtu"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:258
-msgid "The passwords do not match."
-msgstr "Heslá sa nezhodujú."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Zlyhala registrácia účtu"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Overenie totožnosti nie je pri tejto doméne podporované"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Zlyhalo pripojenie k doméne"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Prihlasovacie meno nefunguje.\n"
-"Prosím, skúste to znovu."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Prihlasovacie heslo nefunguje.\n"
-"Prosím, skúste to znovu."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Zlyhalo prihlásenie do domény"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Nepodarilo sa nájsť doménu. Napísali ste ju správne?"
+"využitie;nedávne;história;súbory;dočasné;dočasne;tmp;súkromné;súkromie;kôš;"
+"čistenie;vysypanie;vysypať;ponechať;uchovať;"
 
 # GtkToolButton label
 #: panels/user-accounts/cc-add-user-dialog.ui:15
@@ -8073,9 +5012,6 @@ msgid "Administrator"
 msgstr "Správca"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:132
-#| msgid ""
-#| "Administrators can add and remove other users, and can change settings "
-#| "for all users."
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users. Parental controls cannot be applied to administrators."
@@ -8085,37 +5021,33 @@ msgstr ""
 
 # GtkListStore item
 #: panels/user-accounts/cc-add-user-dialog.ui:149
-#| msgid "Allow user to change their password on next login"
 msgid "User sets password on first login"
 msgstr "Používateľ si nastaví heslo pri prvom prihlásení"
 
 # GtkListStore item
 #: panels/user-accounts/cc-add-user-dialog.ui:161
-#| msgid "Set a password now"
 msgid "Set password now"
 msgstr "Nastaviť heslo teraz"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:224
-#| msgid "_Confirm"
 msgid "Confirm"
 msgstr "Potvrdiť"
 
 # GtkToggleButton label
 #: panels/user-accounts/cc-add-user-dialog.ui:278
-#| msgid "_Enterprise Login"
 msgid "Enterprise Login"
 msgstr "Podnikové prihlásenie"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+msgid "User accounts which are managed by a company or organization."
 msgstr ""
 "Používateľské účty, ktoré sú spravované spoločnosťou alebo organizáciou."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "Ste odpojený"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -8124,12 +5056,6 @@ msgstr ""
 "Podnikové prihlásenie umožňuje použitie existujúceho, centrálne "
 "spravovaného, používateľského účtu na tomto zariadení. Tiež môžete použiť "
 "tento účet na prístup k prostriedkom spoločnosti na internete."
-
-# DK: nechajme zatial tento tvar, kym to rozdelia.je to neskodny preklad
-# DK: https://bugzilla.gnome.org/show_bug.cgi?id=701344
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Výber ďalších obrázkov"
 
 # file chooser dialog title
 #: panels/user-accounts/cc-avatar-chooser.ui:32
@@ -8146,15 +5072,15 @@ msgstr "Správca odtlačkov prstov"
 msgid "Fingerprint"
 msgstr "Odtlačok prsta"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "_Nie"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "Á_no"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -8162,35 +5088,35 @@ msgstr ""
 "Chcete odstrániť vaše zaregistrované odtlačky prstov, čím sa zakáže "
 "prihlásenie odtlačkom prsta?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Žiadne zariadenie na snímanie odtlačkov prstov"
 
 # GtkLabel
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "Žiadne zariadenie na snímanie odtlačkov prstov"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "Uistite sa, že je zariadenie správne pripojené."
 
 # GtkLabel
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Zariadenie na snímanie odtlačkov prstov"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "Zvoľte zariadenie na snímanie odtlačkov prstov, ktoré chcete nastaviť"
 
 # GtkLabel
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "Prihlásenie odtlačkom prsta"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -8198,254 +5124,23 @@ msgstr ""
 "Prihlásenie odtlačkom prsta vám umožňuje odomknúť a prihlásiť sa do vášho "
 "počítača pomocou vášho prsta"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "O_dstrániť odtlačky prstov"
 
 # GtkLabel
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Nasnímanie odtlačku prsta"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "zariadenie musí byť požiadané o vykonanie tejto akcie"
+# KeyListEntry description
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Predchádzajúci"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "zariadenie je už žiadané iným procesom"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "nemáte oprávnenie na vykonanie tejto akcie"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "žiadne odtlačky neboli nasnímané"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Zlyhala komunikácia so zariadením počas snímania"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Zlyhala komunikácia s čítačkou odtlačkov prstov"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Zlyhala komunikácia so službou odtlačkov prstov"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Zlyhalo vypísanie zoznamu odtlačkov prstov: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Zlyhalo odstránenie uložených odtlačkov prstov: %s"
-
-# GtkListStore item
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Ľavý palec"
-
-# GtkListStore item
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Ľavý prostredník"
-
-# GtkRadioButton label
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Ľavý _ukazovák"
-
-# GtkListStore item
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Ľavý prstenník"
-
-# GtkListStore item
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Ľavý malíček"
-
-# GtkListStore item
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Pravý palec"
-
-# GtkListStore item
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Pravý prostredník"
-
-# GtkRadioButton label
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "P_ravý ukazovák"
-
-# GtkListStore item
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Pravý prstenník"
-
-# GtkListStore item
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Pravý malíček"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Neznámy prst"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Dokončené"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Zariadenie na snímanie odtlačkov prstov odpojené"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Úložisko zariadenia na snímanie odtlačkov prstov je plné"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Zlyhalo nasnímanie nového odtlačku prsta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Zlyhalo spustenie snímania: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Zlyhalo nasnímanie nového odtlačku prsta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Zlyhalo zastavenie snímania: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Opakovane zdvihnite a priložte váš prst na čítačku pre nasnímanie odtlačku "
-"prsta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Znovu nasnímať tento prst…"
-
-# assistant page title
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Oskenovať nový odtlačok prsta"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Zlyhalo uvoľnenie zariadenia na snímanie odtlačkov prstov %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problém s čítaním zariadenia"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Zlyhalo vyžiadanie zariadenia na snímanie odtlačkov prstov %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Zlyhalo získanie zariadení na snímanie odtlačkov prstov: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Tento týždeň"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Minulý týždeň"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-# DK: zaznam v historii relacie
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Ukončenie relácie"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Spustenie relácie"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Aktivita účtu"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Prosím, zvoľte si iné heslo."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Prosím, zadajte vaše aktuálne heslo ešte raz."
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Heslo nemohlo byť zmenené"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Nasledujúci"
 
 # DK:dialog title
 #: panels/user-accounts/cc-password-dialog.ui:4
@@ -8453,176 +5148,38 @@ msgid "Change Password"
 msgstr "Zmena hesla"
 
 # GtkButton label
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "Zm_eniť"
 
 # GtkLabel
-#: panels/user-accounts/cc-password-dialog.ui:51
-#| msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "Aktuálne heslo"
 
 # GtkLabel
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "Nové heslo"
 
 # GtkLabel
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "Potvrdenie hesla"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Heslá sa nezhodujú."
+
 # GtkListStore item
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Umožniť používateľovi zmeniť heslo pri najbližšom prihlásení"
 
 # GtkListStore item
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Nastaviť heslo teraz"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "S takýmto typom domény sa nedá automaticky spojiť"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Nebola nájdená taká doména alebo pôsobisko"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Nedá sa prihlásiť ako %s do domény %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Neplatné heslo, skúste to znovu"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Nepodarilo sa pripojiť k doméne %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "Odstránenie používateľa zlyhalo"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "Zlyhalo zrušenie na diaľku spravovaného používateľa"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "Nemôžete odstrániť vlastný účet."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "Používateľ %s je stále prihlásený"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Odstránenie prihláseného používateľa môže spôsobiť nestabilitu systému."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Chcete ponechať súbory používateľa %s?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Pri odstraňovaní používateľa je možné ponechať jeho domovský priečinok, "
-"súbory pošty a dočasné súbory."
-
-# button
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "O_dstrániť súbory"
-
-# button
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "Po_nechať súbory"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Naozaj chcete zrušiť na diaľku spravovaný účet používateľa %s?"
-
-# button
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "O_dstrániť"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Účet je zakázaný"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Nastaviť pri najbližšom prihlásení"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Žiadne"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Prihlásený"
-
-# zariadenie
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "Povolené"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "Spojenie so službou účtov zlyhalo"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Uistite sa, prosím, že je služba AccountService nainštalovaná a povolená."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "Pre zmenu tohto nastavenia musí byť panel odomknutý"
-
-# tooltip
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "Odstráni vybraný používateľský účet"
-
-# tooltip
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Keď chcete odstrániť používateľský účet,\n"
-"kliknite najskôr na ikonu *"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Odomknutím pridáte používateľov a zmeníte nastavenia"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8630,36 +5187,55 @@ msgid "Users"
 msgstr "Používatelia"
 
 # label
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr "Aby sa prejavili zmeny, musíte reštartovať vašu reláciu"
 
 # button
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Reštartovať teraz"
 
+# GtkButton label
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Zavrieť"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Upraviť podobizeň"
+
+# GtkLabel
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Celé meno"
+
+# button label
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Upraviť"
+
 # GtkLabel
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Prihlásenie _odtlačkom prsta"
 
 # GtkLabel
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "A_utomatické prihlásenie"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "Aktivita účtu"
 
 # GtkListStore item
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Správca"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -8667,38 +5243,36 @@ msgstr ""
 "Správcovia môžu pridávať a odstraňovať iných používateľov a meniť nastavenia "
 "všetkým používateľom."
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "_Rodičovská kontrola"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Otvoriť aplikáciu Rodičovská kontrola."
 
 # GtkToolButton label
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Odstrániť používateľský účet…"
 
 # button
-#: panels/user-accounts/cc-user-panel.ui:340
-#| msgid "Other Files"
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "Ostatní používatelia"
 
 # GtkToolButton label
-#: panels/user-accounts/cc-user-panel.ui:353
-#| msgid "_Add User…"
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "Pridať používateľa…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Nenašli sa žiadni používatelia"
 
 # tooltip
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Odomknutím pridáte používateľský účet."
 
@@ -8707,7 +5281,6 @@ msgstr "Odomknutím pridáte používateľský účet."
 msgid "Add or remove users and change your password"
 msgstr "Pridáva alebo odstraňuje používateľov a mení vaše heslo"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8758,181 +5331,9 @@ msgstr "Správa používateľských účtov"
 msgid "Authentication is required to change user data"
 msgstr "Na zmenu používateľských údajov je vyžadované overenie totožnosti"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Nové heslo musí byť odlišné od pôvodného hesla."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Skúste zmeniť niektoré písmená a čísla."
-
-# GtkLabel
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Skúste ešte viac zmeniť heslo."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Heslo bez vášho mena bude silnejšie."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Skúste sa vyhnúť použitiu vášho mena v hesle."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Skúste sa vyhnúť slovám, ktoré sú obsiahnuté v hesle."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Skúste sa vyhnúť často používaným slovám."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Skúste sa vyhnúť zmene poradia existujúcich slov."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Skúste použiť viac čísel."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Skúste použiť viac veľkých písmen."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Skúste použiť viac malých písmen."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Skúste použiť viac špeciálnych znakov ako sú interpunkčné znamienka."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Skúste použiť zmes písmen, čísel a interpunkčných znamienok."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Skúste sa vyhnúť opakovaniu toho istého znaku."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Skúste sa vyhnúť opakovaniu toho istého znaku: musíte zmiešať písmená, čísla "
-"a interpunkčné znamienka."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Skúste sa vyhnúť frázam ako 1234 alebo abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Heslo musí byť dlhšie. Skúste pridať viac písmen, čísel a interpunkčných "
-"znamienok."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Zmiešajte veľké a malé písmená a skúste použiť jedno alebo viac číslic."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Pridaním viacerých písmen, čísel a interpunkčných heslo zosilníte."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Overenie totožnosti zlyhalo"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "Nové heslo je príliš krátke"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "Nové heslo je príliš jednoduché"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Nové heslo je príliš podobné starému"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Nové heslo už bolo nedávno použité."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Nové heslo musí obsahovať číselné alebo špeciálne znaky"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Nové heslo je rovnaké ako staré"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Vaše heslo sa od pôvodného overenia totožnosti zmenilo!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Nové heslo neobsahuje dostatočný počet rôznych znakov"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Neznáma chyba"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Používateľské meno by sa malo skladať iba z malých písmen a-z, číslic a "
-"nasledovných znakov: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-"Prepáčte, ale toto používateľské meno nie je dostupné. Prosím, skúste iné."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Používateľské meno je príliš dlhé."
-
 # window title
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Priradenie tlačidiel"
 
@@ -8967,50 +5368,11 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Zistené kliknutie mimo, reštartuje sa…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Tlačidlo č. %d"
-
-# tab
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Definované aplikáciou"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Odoslať stlačenie klávesu"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Prepnúť displej"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Zobraziť pomocníka na obrazovke"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tablet pripojený k panelu notebooku"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tablet pripojený k externému displeju"
-
 # GtkLinkButton label
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr "Externé zariadenie s tabletom"
-
-# desktop entry name
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Všetky displeje"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -9018,38 +5380,33 @@ msgstr "Režim tabletu"
 
 #: panels/wacom/cc-wacom-page.ui:17
 msgid "Use absolute positioning for the pen"
-msgstr ""
+msgstr "Použitie absolútnej pozície pre pero"
 
 # GtkLabel
-#: panels/wacom/cc-wacom-page.ui:27
-#| msgid "Left-Handed Orientation"
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "Orientácia pre ľavákov"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
 
 # GtkButton
-#: panels/wacom/cc-wacom-page.ui:56
-#, fuzzy
-#| msgid "Map to Monitor…"
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
-msgstr "Priradiť k displeju…"
+msgstr "Priradiť k displeju"
 
-#: panels/wacom/cc-wacom-page.ui:62
-#| msgid "Aspect Ratio"
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "Zachovať pomer strán"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr ""
 
 # GtkButton label
-#: panels/wacom/cc-wacom-page.ui:73
-#| msgid "Calibrate…"
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "Kalibrovať"
 
@@ -9067,20 +5424,33 @@ msgstr "Prosím, zapojte alebo zapnite váš tablet Wacom."
 msgid "Tip Pressure Feel"
 msgstr "Pocit tlaku hrotu"
 
+# pocit tlaku pera a gumy
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Jemný"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Tlak hrotu pera"
+
+# pocit tlaku pera a gumy
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Tvrdý"
+
 #: panels/wacom/cc-wacom-stylus-page.ui:54
-#| msgid "Button"
 msgctxt "display setting"
 msgid "Button 1"
 msgstr "Tlačidlo č. 1"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:62
-#| msgid "Button"
 msgctxt "display setting"
 msgid "Button 2"
 msgstr "Tlačidlo č. 2"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:70
-#| msgid "Button"
 msgctxt "display setting"
 msgid "Button 3"
 msgstr "Tlačidlo č. 3"
@@ -9089,21 +5459,24 @@ msgstr "Tlačidlo č. 3"
 msgid "Eraser Pressure Feel"
 msgstr "Pocit tlaku gumy"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Rozprašovacie pero s tlakom, naklonením a integrovaným posuvníkom"
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Tlak gumy"
 
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Rozprašovacie pero s tlakom, naklonením a otočením"
+# GtkListStore row
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Kliknutie stredným tlačidlom myši"
 
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Štandardné pero s tlakom a naklonením"
+# GtkListStore row
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Kliknutie pravým tlačidlom myši"
 
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Štandardné pero s tlakom"
+# GtkListStore row
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Dopredu"
 
 # desktop entry name
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
@@ -9118,58 +5491,102 @@ msgstr ""
 
 # DK: nechal by som aj Stylus.niekto ma zauzivene toto slovo
 # desktop entry keywords
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Pero;Guma;Myš;"
 
-# label
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Nová skratka…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+# GtkLabel
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulované sekundárne kliknutie"
+
+# listore item
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "softvér systému Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Málo tonera"
+
+# atkobject
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Vedľajší"
+
+# listore item
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "softvér systému Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Spravuje predvoľby pre produktivitu a súbežnú prácu"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 # GtkButton label
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Prístupové body"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+# button atk
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Pridať"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Uložiť"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operácia zrušená"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Chyba:</b> Prístup zamietnutý pre zmenu nastavení"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Chyba:</b> Chyba mobilného vybavenia"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Neregistrovaná"
-
-# naposledy použité
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registrovaná"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-# desktop entry name
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Vyhľadávanie"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Zamietnuté"
 
 # 1.desktop entry name;2. page; 3. GtkListStore item
 #: panels/wwan/cc-wwan-details-dialog.ui:5
@@ -9203,105 +5620,13 @@ msgstr "Vlastné číslo"
 msgid "Device Details"
 msgstr "Podrobnosti o zariadení"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Výrobca"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Verzia firmvéru"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Iba 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Iba 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Iba 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (uprednostňované)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (uprednostňované), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (uprednostňované), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (uprednostňované)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (uprednostňované), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (uprednostňované)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (uprednostňované), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (uprednostňované)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (uprednostňované), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-# network mode
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Neznámy"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Odomknutie karty SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Odomknúť"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Prosím, poskytnite kód PIN pre kartu SIM č. %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Zadajte kód PIN na odomknutie vašej karty SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Prosím, poskytnite kód PUK pre kartu SIM č. %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Zadajte kód PUK na odomknutie vašej karty SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9318,26 +5643,6 @@ msgid_plural "You have %u tries left"
 msgstr[0] "Zostáva vám %u pokusov"
 msgstr[1] "Zostáva vám %u pokus"
 msgstr[2] "Zostávajú vám %u pokusy"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Bolo zadané nesprávne heslo."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Kód PUK by malo byť 8 ciferné číslo"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Zadajte nový kód PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Kód PIN by malo byť 4 až 8 ciferné číslo"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Odomykanie…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9401,158 +5706,54 @@ msgstr "Uzamknutie karty SIM pomocou kódu PIN"
 msgid "M_odem Details"
 msgstr "Podrobnosti o m_odeme"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Zlyhanie telefónu"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Žiadne pripojenie k telefónu"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operácia nie je umožnená"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operácia nie je podporovaná"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Karta SIM nie je vložená"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Vyžadovaný kód PIN pre kartu SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Vyžadovaný kód PIN pre kartu SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Zlyhanie karty SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Karta SIM je zaneprázdnená"
-
-# GtkLabel
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Nesprávne heslo"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Vyžadovaný kód PIN2 pre kartu SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Vyžadovaný kód PUK2 pre kartu SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Nenájdené"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Žiadna sieťová služba"
-
-# GtkLabel label
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Čas siete vypršal"
-
-# AutoIP je termin, ako napr. DHCP
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Služby siete GPRS "
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming nie je povolený v tejto oblasti"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Nešpecifikovaná chyba siete GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "Akcia bola zrušená"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Prístup zamietnutý"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Neznáma chyba"
-
 # GtkLabel label
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Režim siete"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "_Nastaviť"
-
-# GtkButton label
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "Zavrieť"
-
 # GtkListStore (tp;aui;bnc;mii); GtkListStore (10Mb/s, 100Mb/s ...)
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Automaticky"
 
 # GtkEntry text
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Voľba siete"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Obnoviť poskytovateľov siete"
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "Karta SIM č. %d"
 
 # GtkEntry text
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "Povoliť mobilnú sieť"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "Nenašiel sa žiadny adaptér WWAN"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "Uistite sa, že máte zariadenie pre bezdrôtovú WAN/mobilnú sieť"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr ""
 "Bezdrôtové WAN pripojenie je zakázané, keď je zapnutý režim v lietadle."
 
 # label
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "Vy_pnúť režim v lietadle"
 
 # gtk button
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "Dátové pripojenie"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "Karta SIM použitá pre internet"
 
@@ -9565,16 +5766,16 @@ msgstr "Uzamknutie karty SIM"
 msgid "_Next"
 msgstr "Ď_alej"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "_Uzamknúť kartu SIM pomocou kódu PIN"
 
 # GtkButton label
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "Zmena kódu PIN"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr "Zadajte aktuálny kód PIN na zmenu nastavení uzamknutia karty SIM"
 
@@ -9588,8 +5789,6 @@ msgstr "Mobilná sieť"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Nastavuje telefónne a mobilné dátové pripojenia"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "mobil;mobilná;wwan;telefón;telefonovanie;sim;"
@@ -9603,65 +5802,19 @@ msgid "Settings is the primary interface for configuring your system."
 msgstr ""
 "Aplikácia Nastavenia je hlavným rozhraním na konfiguráciu vášho systému."
 
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:17
-msgid "GNOME Settings Sound Panel"
-msgstr "Panel so zvukom v nastaveniach prostredia GNOME"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:21
-msgid "GNOME Settings Mouse &amp; Touchpad Panel"
-msgstr "Panel s myšou a touchpadom v nastaveniach prostredia GNOME"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:25
-msgid "GNOME Settings Background Panel"
-msgstr "Panel s pozadím v nastaveniach prostredia GNOME"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:29
-msgid "GNOME Settings Keyboard Panel"
-msgstr "Panel s klávesnicou v nastaveniach prostredia GNOME"
-
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:38
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr "Projekt GNOME"
 
-# cmd line desc
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Vypíše číslo verzie"
-
-# PM: takto to tuším máme v iných moduloch
-# cmd desc
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Povolí podrobné výpisy"
-
-# cmd desc
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Vyhľadá reťazec"
-
-# cmd desc
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Vypíše možné názvy panelov a ukončí sa"
-
-# cmd desc
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel na zobrazenie"
-
-# cmd desc
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [PARAMETER…]"
+# GtkLabel label
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Kategórie nastavení"
 
 # desktop entry name
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Súkromie"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Dostupné panely:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9724,7 +5877,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Zrušenie vyhľadávania"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Nastavenia;Konfigurácia;"
@@ -9762,9 +5914,7 @@ msgid ""
 "application window."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1907
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
@@ -9772,9 +5922,7 @@ msgstr[0] "%u výstupov"
 msgstr[1] "%u výstup"
 msgstr[2] "%u výstupy"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1917
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
@@ -9782,9 +5930,3332 @@ msgstr[0] "%u vstupov"
 msgstr[1] "%u vstup"
 msgstr[2] "%u vstupy"
 
-#: subprojects/gvc/gvc-mixer-control.c:2867
-msgid "System Sounds"
-msgstr "Systémové zvuky"
+#~ msgid "System Bus"
+#~ msgstr "Zbernica systému"
+
+# GtkLabel
+#~ msgid "Full access"
+#~ msgstr "Plný prístup"
+
+# DK: zaznam v historii relacie
+#~ msgid "Session Bus"
+#~ msgstr "Zbernica relácie"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Plný prístup k adresáru /dev"
+
+# GtkLabel label
+#~ msgid "Has network access"
+#~ msgstr "Má prístup k sieti"
+
+#~ msgid "Home"
+#~ msgstr "Domov"
+
+#~ msgid "Read-only"
+#~ msgstr "Iba na čítanie"
+
+# Overenie totožnosti
+# GtkListStore item
+#~ msgid "File System"
+#~ msgstr "Systém súborov"
+
+#~ msgid "Can change settings"
+#~ msgstr "Môže meniť nastavenia"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "Aplikácia %s obsahuje nasledovné vstavané oprávnenia, ktoré nemôžu byť "
+#~ "zmenené. Ak vás tieto oprávnenia znepokojujú, zvážte odstránenie tejto "
+#~ "aplikácie."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u typov súborov a odkazov, ktoré sú otvárané aplikáciou"
+#~ msgstr[1] "%u typ súboru a odkazu, ktorý je otváraný aplikáciou"
+#~ msgstr[2] "%u typy súborov a odkazov, ktoré sú otvárané aplikáciou"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "Aplikácia <b>%s</b> sa používa na otváranie nasledovných typov súborov a "
+#~ "odkazov."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s využitého miesta na disku."
+
+# file chooser dialog title
+#~ msgid "Select a picture"
+#~ msgstr "Výber obrázka"
+
+#~ msgid "_Open"
+#~ msgstr "_Otvoriť"
+
+#~ msgid "multiple sizes"
+#~ msgstr "viac veľkostí"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Bez pozadia plochy"
+
+#~ msgid "Current background"
+#~ msgstr "Aktuálne pozadie"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Umiestnite vaše kalibračné zariadenie nad štvorec a stlačte tlačidlo "
+#~ "„Začať“"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Presuňte vaše kalibračné zariadenie do kalibračnej pozície a stlačte "
+#~ "tlačidlo „Pokračovať“"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Presuňte vaše kalibračné zariadenie do pozície na povrchu a stlačte "
+#~ "tlačidlo „Pokračovať“"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Zavrite kryt notebooku"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Vyskytla sa vnútorná chyba, ktorú sa nepodarilo rozpoznať."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Nástroje vyžadované na kalibráciu nie sú nainštalované."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Nepodarilo sa vygenerovať profil."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Nepodarilo sa získať cieľový biely bod."
+
+#~ msgid "Complete!"
+#~ msgstr "Dokončená!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrácia zlyhala!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Môžete odstrániť kalibračné zariadenie."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Nemanipulujte s kalibračným zariadením počas kalibrácie"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Obrazovka prenosného počítača"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Zabudovaná webkamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Displej %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Skener %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Kamera %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Tlačiareň %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webkamera %s"
+
+# atk
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Povoliť správu farieb pre %s"
+
+# atk
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Zobraziť farebné profily pre %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nenakalibrované"
+
+#~ msgid "Default: "
+#~ msgstr "Predvolený: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Farebný priestor: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Skúšobný profil: "
+
+# dialog title
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Výber súboru s profilom ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Importovať"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Podporované profily ICC"
+
+#~ msgid "All files"
+#~ msgstr "Všetky súbory"
+
+#~ msgid "Save Profile"
+#~ msgstr "Uloženie profilu"
+
+# tooltip
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Vytvorí profil farieb pre vybrané zariadenie"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Merací nástroj nebol detegovaný. Overte, prosím, či je zapnutý a správne "
+#~ "pripojený."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Merací nástroj nepodporuje profilovanie tlačiarne."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Typ zariadenia momentálne nie je podporovaný."
+
+#~ msgid "Standard Space"
+#~ msgstr "Štandardný farebný priestor"
+
+#~ msgid "Test Profile"
+#~ msgstr "Skúšobný profil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatický"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Nízka kvalita"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Stredná kvalita"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Vysoká kvalita"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Predvolený RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Predvolený CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Predvolený čiernobiely"
+
+# tooltip
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Kalibračné údaje dodané výrobcom"
+
+# toolip
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Celoobrazovková korekcia displeja nie je možná s týmto profilom"
+
+# tooltip
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Tento profil môže byť už nepresný"
+
+# region
+#~ msgid "Other…"
+#~ msgstr "Iný…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Odomknutím zmeníte nastavenia"
+
+# naposledy použité
+#~ msgid "Today"
+#~ msgstr "Dnes"
+
+# naposledy použité
+#~ msgid "Yesterday"
+#~ msgstr "Včera"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d hodín"
+#~ msgstr[1] "%d hodina"
+#~ msgstr[2] "%d hodiny"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minút"
+#~ msgstr[1] "%d minúta"
+#~ msgstr[2] "%d minúty"
+
+# GtkListStore item
+# za
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekúnd"
+#~ msgstr[1] "%d sekunda"
+#~ msgstr[2] "%d sekundy"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+# button
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Prístupový bod"
+
+# GtkRadioButton label
+#~ msgid "24-hour"
+#~ msgstr "24-hodinový"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+# MČ: %p je tam zbytočne, bude to prázdny reťazec.
+# pre 12-hodinový čas
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e. %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e. %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+# MČ: %p je tam zbytočne, bude to prázdny reťazec.
+# pre 12-hodinový čas
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Odoslaním hlásení o technických problémoch nám pomôže vylepšiť systém %s. "
+#~ "Hlásenia sú odosielané anonymne a neobsahujú osobné údaje. %s"
+
+#
+#~ msgid "On"
+#~ msgstr "Zapnuté"
+
+# MČ: ak displej tak vypnutý. V iných prípadoch to môže byť inak. Treba skontrolovať pre všetky výskyty, prípadne dať rozdeliť.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=708580
+#~ msgid "Off"
+#~ msgstr "Vypnuté"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Použiť zmeny?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Zmeny sa nedajú použiť"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Môže to byť spôsobené obmedzeniami hardvéru."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Na šírku"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Na výšku doprava"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Na výšku doľava"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Na šírku (obrátene)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#, fuzzy
+#~| msgid "Camera is Turned Off"
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Kamera je vypnutá"
+
+# GtkLabel label
+#, fuzzy
+#~| msgid "Password"
+#~ msgid "Passed"
+#~ msgstr "Heslo"
+
+#, fuzzy
+#~| msgid "PPP failed"
+#~ msgid "Failed"
+#~ msgstr "PPP zlyhalo"
+
+# GtkLabel label
+#~ msgid "Security Level 0"
+#~ msgstr "Úroveň zabezpečenia 0"
+
+# GtkLabel label
+#~ msgid "Security Level 1"
+#~ msgstr "Úroveň zabezpečenia 1"
+
+# GtkLabel label
+#~ msgid "Security Level 2"
+#~ msgstr "Úroveň zabezpečenia 2"
+
+# GtkLabel label
+#~ msgid "Security Level 3"
+#~ msgstr "Úroveň zabezpečenia 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Toto zariadenie má rozšírenú ochranu pred hardvérovými bezpečnostnými "
+#~ "problémami. Toto je najvyššia úroveň zabezpečenia zariadenia a poskytuje "
+#~ "ochranu pred pokročilými bezpečnostnými hrozbami."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Úrovne bezpečnosti nie sú pre toto zariadenie dostupné."
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Čiastočná ochrana po spustení zariadenia."
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Žiadna ochrana po spustení zariadenia."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Vystavené závažným bezpečnostným hrozbám."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Obmedzená ochrana pred jednoduchými bezpečnostnými hrozbami."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Ochránené pred bežnými bezpečnostnými hrozbami."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Ochránené pred veľkým množstvom bezpečnostných hrozieb."
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Verzia firmvéru"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Verzia firmvéru"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Verzia firmvéru"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Verzia firmvéru"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Zašifrované pamäť RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Ochrana IOMMU"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Overenie jadra systému Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Odkladací priestor systému Linux"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Uspať do pamäte RAM"
+
+#, fuzzy
+#~| msgid "Suspend"
+#~ msgid "Suspend To Idle"
+#~ msgstr "Uspať"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Kľúč platformy UEFI"
+
+# GtkDialog title
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Konfigurácia platformy TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Rekonštrukcia TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+# GtkLabel label
+#~ msgid "Firmware Updates"
+#~ msgstr "Aktualizácie firmvéru"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Atestácia firmvéru"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Overenie nástroja na aktualizáciu firmvéru"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Ladenie platformy"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Bezpečnostné kontroly procesora"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Verzia firmvéru"
+
+#, fuzzy
+#~| msgid "Firmware Version"
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Verzia firmvéru"
+
+#~ msgid "Valid"
+#~ msgstr "Platné"
+
+#~ msgid "Not Valid"
+#~ msgstr "Neplatné"
+
+# zariadenie
+#~ msgid "Not Enabled"
+#~ msgstr "Nepovolené"
+
+#~ msgid "Locked"
+#~ msgstr "Uzamknuté"
+
+#~ msgid "Not Locked"
+#~ msgstr "Neuzamknuté"
+
+#~ msgid "Encrypted"
+#~ msgstr "Zašifrované"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Nezašifrované"
+
+#, fuzzy
+#~| msgid "Not calibrated"
+#~ msgid "Not Tainted"
+#~ msgstr "Nenakalibrované"
+
+# desktop entry name
+#~ msgid "Found"
+#~ msgstr "Nájdené"
+
+#~| msgid "Not found"
+#~ msgid "Not Found"
+#~ msgstr "Nenájdené"
+
+#~ msgid "Supported"
+#~ msgstr "Podporované"
+
+#~ msgid "Not Supported"
+#~ msgstr "Nepodporované"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# grafika, AP typ
+#~ msgid "Unknown"
+#~ msgstr "Neznámy"
+
+# Typ OS
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bitový"
+
+# Typ OS
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bitový"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# grafika, AP typ
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Neznámy"
+
+#~ msgid "Not Available"
+#~ msgstr "Nedostupná"
+
+# KeyListEntries name
+#~ msgid "System Logo"
+#~ msgstr "Systémové logo"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nenašli sa žiadne zdroje vstupu"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Iný"
+
+# KeyListEntry name
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Vlastné skratky"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Kláves alternatívnych znakov môže byť použitý na zadávanie dodatočných "
+#~ "znakov. Tie sú niekedy vyznačené ako tretia voľba na vašej klávesnici."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Ľavý kláves Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Pravý kláves Alt"
+
+# GtkListStore item
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Ľavý kláves Super"
+
+# GtkListStore item
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Pravý kláves Super"
+
+# GtkLabel label
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Kláves ponuky"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Pravý kláves Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Kláves Compose umožňuje zadávanie širokej škály znakov. Pre jeho použitie "
+#~ "stlačte kláves Compose a potom postupnosť znakov.  Napríklad kláves "
+#~ "Compose nasledovaný znakmi <b>C</b> a <b>o</b> zadá znak <b>©</b>, znak "
+#~ "<b>a</b> nasledovaný znakom <b>'</b> zadá znak <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+# GtkListStore row
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+# toggle button
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+# GtkLabel label
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Zdroje vstupu môžu byť prepnuté pomocou klávesovej skratky %s.\n"
+#~ "Tá môže byť zmenená v nastaveniach klávesových skratiek."
+
+# hlasitosť
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d upravených"
+#~ msgstr[1] "%d upravená"
+#~ msgstr[2] "%d upravené"
+
+# tab
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Obnoviť všetky skratky?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Obnovenie skratiek môže mať vplyv na vaše vlastné skratky. Táto akcia je "
+#~ "nenávratná."
+
+# GtkListStore item; page
+#~ msgid "Reset All"
+#~ msgstr "Obnoviť všetky"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "Skratka %s sa už používa pre akciu %s. Ak ju nahradíte, akcia %s bude "
+#~ "zakázaná"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Zadajte novú skratku"
+
+# KeyListEntry name
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Nastavenie vlastnej skratky"
+
+# tab
+#~ msgid "Set Shortcut"
+#~ msgstr "Nastaviť skratku"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Zadajte novú skratku na zmenu akcie %s."
+
+# PM: že ide o klávesovú vyplýva z kontextu
+# GtkDialog title
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Pridanie vlastnej skratky"
+
+# GtkCheckButton label
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Rolovať dvoma prstami"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Päť kliknutí, čas pre GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dvojité kliknutie, hlavné tlačidlo"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Kliknutie, hlavné tlačidlo"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dvojité kliknutie, stredné tlačidlo"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Kliknutie, stredné tlačidlo"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dvojité kliknutie, sekundárne tlačidlo"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Kliknutie, sekundárne tlačidlo"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager musí byť spustený."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Nezabezpečená sieť (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Zabezpečená sieť (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Zabezpečená sieť (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Zabezpečená sieť (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Zabezpečená sieť"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Zapnutím prístupového bodu sa odpojí od siete %s a nebude možné "
+#~ "pristupovať na internet prostredníctvom Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Musí obsahovať minimálne 8 znakov"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Zastaviť prístupový bod a odpojiť všetkých používateľov?"
+
+# button
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Zastaviť prístupový bod"
+
+# tab
+#~ msgid "Preserve"
+#~ msgstr "Zachovaná"
+
+#~ msgid "Permanent"
+#~ msgstr "Trvalá"
+
+#~ msgid "Random"
+#~ msgstr "Náhodná"
+
+#~ msgid "Stable"
+#~ msgstr "Stabilná"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Tu zadaná adresa MAC bude použitá ako hardvérová adresa sieťového "
+#~ "zariadenia, na ktorom je aktivované toto pripojenie. Táto funkcia je "
+#~ "známa ako klonovanie adresy MAC. Príklad: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil č. %d"
+
+# zabezpečenie
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+# zabezpečenie
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+# zabezpečenie
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+# PM: toto je v NMA preložené
+# zabezpečenie
+#~ msgid "Enterprise"
+#~ msgstr "Podnikové"
+
+# zabezpečenie
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Žiadne"
+
+# naposledy použité
+#~ msgid "Never"
+#~ msgstr "Nikdy"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+# rýchlosť pripojenia
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mbit/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+# sila signálu
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Žiadny"
+
+# sila signálu
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Slabý"
+
+# sila signálu
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+# sila signálu
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Dobrý"
+
+# sila signálu
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Vynikajúci"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+# gtk button
+#~ msgid "Forget Connection"
+#~ msgstr "Zabudnúť pripojenie"
+
+# gtk button
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Odstrániť profil pripojenia"
+
+# gtk button
+#~ msgid "Remove VPN"
+#~ msgstr "Odstrániť VPN"
+
+# 1.desktop entry name;2. page; 3. GtkListStore item
+#~ msgid "Details"
+#~ msgstr "Podrobnosti"
+
+# PM: rod? na akých miestach tento spinbutton je? Ja to vidím pri MTU, ale možno je to aj inde
+# DK: nenechame tvar: "automaticky" ?
+# spinbutton default
+# doriesit v master vetve
+#~ msgid "automatic"
+#~ msgstr "automaticky"
+
+# 1.2.3. page; GtkListStore item
+#~ msgid "Identity"
+#~ msgstr "Totožnosť"
+
+# button atk
+#~ msgid "Delete Address"
+#~ msgstr "Odstrániť adresu"
+
+# button atk
+#~ msgid "Delete Route"
+#~ msgstr "Odstrániť smerovanie"
+
+# GtkListStore item
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+# GtkListStore item
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+# GtkListStore item
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Žiadne"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128 bitový kľúč (šestnástkový alebo ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128 bitové heslo"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamické WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "Osobný WPA a WPA2"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Podnikový WPA a WPA 2"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "Osobný WPA3"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Nepodarilo sa otvoriť nástroj na zmenu pripojení"
+
+#~ msgid "New Profile"
+#~ msgstr "Nový profil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Neplatné nastavenie %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Neplatné nastavenie %s"
+
+# label
+#~ msgid "Import from file…"
+#~ msgstr "Importovať zo súboru…"
+
+# window title
+#~ msgid "Add VPN"
+#~ msgstr "Pridanie VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Nedá sa importovať pripojenie VPN"
+
+# PK: recognized moze byt aj nieco ze to neni standard
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Súbor „%s“ sa nepodarilo prečítať alebo neobsahuje rozpoznané informácie "
+#~ "o pripojení VPN\n"
+#~ "\n"
+#~ "Chyba: %s."
+
+# window title
+#~ msgid "Select file to import"
+#~ msgstr "Výber súboru na importovanie"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Súbor s názvom „%s“ už existuje."
+
+#~ msgid "_Replace"
+#~ msgstr "_Nahradiť"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Chcete nahradiť %s s pripojením VPN, ktoré sa pokúšate uložiť?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Pripojenie VPN sa nedá exportovať"
+
+# druhe je subor (moze byt none)
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Nepodarilo sa exportovať pripojenie VPN „%s“ do %s.\n"
+#~ "\n"
+#~ "Chyba: %s."
+
+# window title
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportovanie pripojenia VPN"
+
+# last used
+#~ msgid "never"
+#~ msgstr "nikdy"
+
+# last used
+#~ msgid "today"
+#~ msgstr "dnes"
+
+# last used
+#~ msgid "yesterday"
+#~ msgstr "včera"
+
+# GtkLabel label
+#~ msgid "Last used"
+#~ msgstr "Naposledy použité"
+
+# liststore item
+#~ msgid "Add new connection"
+#~ msgstr "Pridať nové pripojenie"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Podrobnosti o vybraných sietiach, vrátane hesla a vlastných nastavení, "
+#~ "budú stratené."
+
+# GtkButton label
+#~ msgid "_Forget"
+#~ msgstr "_Zabudnúť"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Známe siete Wi-Fi"
+
+# button
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Zabudnúť"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Systémové pravidlá zakazujú použitie režimu prístupového bodu"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Bezdrôtové zariadenie nepodporuje režim prístupového bodu"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Ak nezadáte URL konfigurácie, použije sa automatické zistenie "
+#~ "sprostredkovateľa."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Toto sa neodporúča pre nedôveryhodné verejné siete."
+
+#~ msgid "Status unknown"
+#~ msgstr "Neznámy stav"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Nespravované"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nedostupné"
+
+#~ msgid "Connecting"
+#~ msgstr "Pripája sa"
+
+#~ msgid "Authentication required"
+#~ msgstr "Vyžadované je overenie totožnosti"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Odpája sa"
+
+#~ msgid "Connection failed"
+#~ msgstr "Pripojenie zlyhalo"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Stav neznámy (chýba)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Nastavenie zlyhalo"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Nastavenie IP zlyhalo"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Platnosť nastavenia IP vypršala"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Boli požadované tajné informácie, ale neboli poskytnuté"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Žiadateľ 802.1x bol odpojený"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Zlyhalo nastavenia žiadateľa 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Žiadateľ 802.1x zlyhal"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Overenie totožnosti žiadateľa 802.1x trvalo príliš dlho"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Služba PPP zlyhala pri štarte"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Služba PPP bola odpojená"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP zlyhalo"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Klient DHCP zlyhal pri štarte"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Chyba klienta DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Klient DHCP zlyhal"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Nepodarilo sa spustiť službu sprístupneného pripojenia"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Služba sprístupneného pripojenia zlyhala"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Nepodarilo sa spustiť službu AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Chyba služby AutoIP"
+
+# AutoIP je termin, ako napr. DHCP
+#~ msgid "AutoIP service failed"
+#~ msgstr "Služba AutoIP zlyhala"
+
+#~ msgid "Line busy"
+#~ msgstr "Linka je zaneprázdnená"
+
+#~ msgid "No dial tone"
+#~ msgstr "Nie je oznamovací tón"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Nepodarilo sa pripojiť k žiadnemu poskytovateľovi"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Vypršal časový limit pre požiadavku na vytáčanie"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Pokus o vytáčanie zlyhal"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Inicializácia modemu zlyhala"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Zlyhalo vybratie určeného APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Nehľadá siete"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Registrácia siete bola zamietnutá"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Vypršal limit pre registráciu siete"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Nepodarilo sa zaregistrovať v požadovanej sieti"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Zlyhala kontrola kódu PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Firmvér pre toto zariadenie môže chýbať"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Pripojenie sa stratilo"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Existujúce pripojenie bolo odhadnuté"
+
+#~ msgid "Modem not found"
+#~ msgstr "Nenájdený modem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth pripojenie zlyhalo"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Karta SIM nie je vložená"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Vyžadovaný kód Pin pre kartu SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Vyžadovaný kód Puk pre kartu SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Zlá karta SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Závislosť pripojenia zlyhala"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Chýba firmvér"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kábel odpojený"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "nedefinovaná chyba v zabezpečení protokolu 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "Nebol vybratý žiadny súbor"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "nešpecifikovaná chyba pri overovaní súboru metódy protokolu eap"
+
+# PK: pkcs#12 je zauzivane
+# file filter
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Súkromné kľúče typu DER, PEM, PKCS#12 alebo PGP"
+
+# GtkLabel label
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Certifikáty typu DER alebo PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "chýba súbor PAC protokolu EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Súbory PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "chýba používateľské meno protokolu EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "chýba heslo protokolu EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "neplatný certifikát protokolu EAP-PEAP CA: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "neplatný certifikát protokolu EAP-PEAP CA: certifikát nebol určený"
+
+#~ msgid "missing EAP username"
+#~ msgstr "chýba používateľské meno protokolu EAP"
+
+# DK:dialog title
+#~ msgid "missing EAP password"
+#~ msgstr "chýba heslo EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "chýba identita protokolu EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "neplatný certifikát protokolu EAP-TLS CA: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "neplatný certifikát protokolu EAP-TLS CA: certifikát nebol určený"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "neplatný súkromný kľúč protokolu EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "neplatný certifikát používateľa protokolu EAP-TLS: %s"
+
+# gtkdialog title
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Nezašifrované súkromné kľúče nie sú bezpečné"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Zvolený súkromný kľúč sa nejaví byť chránený heslom. To by mohlo umožniť "
+#~ "zneužitiu bezpečnostných poverení. Prosím, zvoľte súkromný kľúč chránený "
+#~ "heslom\n"
+#~ "\n"
+#~ "(Váš súkromný kľúč môžete opatriť heslom pomocou nástroja openssl)"
+
+# DK:button
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Vybrať váš osobný certifikát"
+
+# DK:button
+#~ msgid "Choose your private key"
+#~ msgstr "Vybrať váš súkromný kľúč"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "neplatný certifikát protokolu EAP-TTLS CA: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "neplatný certifikát protokolu EAP-TTLS CA: certifikát nebol určený"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Neznáma chyba pri overovaní bezpečnosti štandardu 802.1X"
+
+# file chooser dialog title
+#~ msgid "Select a file"
+#~ msgstr "Vybrať súbor"
+
+#~ msgid "missing leap-username"
+#~ msgstr "chýba používateľské meno protokolu leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "chýba heslo protokolu leap"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Chýba heslo k sieti Wi-Fi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "chýba kľúč zabezpečenia wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "neplatný kľúč zabezpečenia wep: kľúč o dĺžke %zu musí obsahovať iba "
+#~ "hexadecimálne čísla"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "neplatný kľúč zabezpečenia wep: kľúč o dĺžke %zu musí obsahovať iba znaky "
+#~ "v kódovaní ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "neplatný kľúč zabezpečenia wep: nesprávna dĺžka kľúča %zu. Kľúč musí byť "
+#~ "o dĺžke buď 5/13 (ascii) alebo 10/26 (hexadecimálne)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "neplatný kľúč zabezpečenia wep: heslo nemôže byť prázdne"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "neplatný kľúč zabezpečenia wep: heslo musí byť kratšie ako 64 znakov"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "neplatné zabezpečenie wpa-psk: neplatná dĺžka kľúča %zu. Musí byť o dĺžke "
+#~ "[8,63] bajtov alebo 64 hexadecimálnych čísel"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "neplatné zabezpečenie wpa-psk: nedá sa interpretovať 64 bajtový kľúč ako "
+#~ "hexadecimálny"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Iný"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "Účet %s bol odstránený"
+
+#~ msgid "Error removing account"
+#~ msgstr "Chyba pri odstraňovaní účtu"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Účet služby %s"
+
+# GtkToolButton label
+#~ msgid "Remove Account"
+#~ msgstr "Odstrániť účet"
+
+#~ msgid "Unknown time"
+#~ msgstr "Neznámy čas"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s, %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s do úplného nabitia"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Výstraha: zostáva %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "zostáva %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Úplne nabitá"
+
+#~ msgid "Not charging"
+#~ msgstr "Nenabíja sa"
+
+#~ msgid "Empty"
+#~ msgstr "Vybitá"
+
+#~ msgid "Charging"
+#~ msgstr "Nabíja sa"
+
+#~ msgid "Discharging"
+#~ msgstr "Vybíja sa"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Bezdrôtová myš"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Bezdrôtová klávesnica"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Neprerušiteľný zdroj napájania (UPS)"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Vreckový počítač (PDA)"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobilný telefón"
+
+#  PM: takýto preklad je v inom module
+#~ msgid "Media player"
+#~ msgstr "Prenosný prehrávač"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Počítač"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Herné vstupné zariadenie"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Hlavná"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Dodatočná"
+
+#~ msgid "Batteries"
+#~ msgstr "Batérie"
+
+#~ msgid "When _idle"
+#~ msgstr "Pri neč_innosti"
+
+#~ msgid "Suspend"
+#~ msgstr "Uspať"
+
+# label
+#~ msgid "Power Off"
+#~ msgstr "Vypnúť"
+
+# GtkListStore item
+#~ msgid "Hibernate"
+#~ msgstr "Hibernovať"
+
+# chooser_button
+#~ msgid "Nothing"
+#~ msgstr "Nespraviť nič"
+
+#  label
+#~ msgid "When on battery power"
+#~ msgstr "Pri napájaní z batérie"
+
+# PK: ked je zastrceny v zasuvke
+#  label
+#~ msgid "When plugged in"
+#~ msgstr "Pri napájaní zo siete"
+
+# naposledy použité
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nikdy"
+
+# label
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatické uspanie"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "Výkonný režim je dočasne zakázaný kvôli vysokej pracovnej teplote."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Zistené lono: výkonný režim je dočasne nedostupný. Obnovíte ho presunutím "
+#~ "zariadenia na stabilný povrch."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Výkonný režim je dočasne zakázaný."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Vybitá batéria: je povolený šetrič energie. Predchádzajúci režim bude "
+#~ "obnovený po dostatočnom nabití batérie."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Režim šetriča energie aktivovaný aplikáciou „%s“."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Výkonný režim aktivovaný aplikáciou „%s“."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Výkon"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Vysoký výkon a spotreba energie."
+
+# vľavo - vpravo
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Vyvážený"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Štandardný výkon a spotreba energie."
+
+# label
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Šetrič energie"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Znížený výkon a spotreba energie."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Tlačiareň „%s“ bola odstránená"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Pridávanie novej tlačiarne zlyhalo."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Nepodarilo sa načítať súbor používateľského rozhrania: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Odomknutím pridáte tlačiarne a zmeníte nastavenia"
+
+# 1.desktop entry name;2. page; 3. GtkListStore item
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Podrobnosti o tlačiarni %s"
+
+# gtk_menu_item
+#~ msgid "No suitable driver found"
+#~ msgstr "Nenašiel sa žiadny vhodný ovládač"
+
+# file chooser dialog title
+#~ msgid "Select PPD File"
+#~ msgstr "Výber súboru PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Súbory popisu PostScriptu tlačiarne (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Tlačiareň s technológiou JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Tlačiareň protokolu LPD"
+
+# PK: prosim, ak mas tlaciaren otestuj, ja nemam
+#~ msgid "One Sided"
+#~ msgstr "Jednostranne"
+
+# ako sa prevrati stranka
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Dlhý okraj (štandard)"
+
+# ako sa prevrati stranka
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Krátky okraj (prevrátiť)"
+
+#~ msgid "Portrait"
+#~ msgstr "Na výšku"
+
+#~ msgid "Landscape"
+#~ msgstr "Na šírku"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Opačne na šírku"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Opačne na výšku"
+
+# GtkButton label
+#~ msgid "Resume"
+#~ msgstr "Pokračovať"
+
+#~ msgid "Pause"
+#~ msgstr "Pozastaviť"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Čaká"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pozastavená"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Vyžaduje sa overenie totožnosti"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Spracúva sa"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Zastavená"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Zrušená"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Prerušená"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Dokončená"
+
+# tooltip
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Presunie túto úlohu navrch fronty"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Aktívne úlohy"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Zadajte poverenia na tlač z tlačiarne %s."
+
+# headerbar
+#~ msgid "Unlock Print Server"
+#~ msgstr "Odomknutie tlačového servera"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Odomknúť %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Zadajte používateľské meno a heslo pre zobrazenie tlačiarní na serveri %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Vyhľadávajú sa tlačiarne"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Sériový Port"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralelný port"
+
+# GtkLabel label
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Umiestnenie: %s"
+
+# GtkLabel label
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresa: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Server vyžaduje overenie totožnosti"
+
+#~ msgid "Two Sided"
+#~ msgstr "Obojstranne"
+
+#~ msgid "Paper Type"
+#~ msgstr "Typ papiera"
+
+#~ msgid "Paper Source"
+#~ msgstr "Zdroj papiera"
+
+#~ msgid "Output Tray"
+#~ msgstr "Výstupný zásobník"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Rozlíšenie"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Predfiltrovanie pre GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Stránok na stranu"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientácia"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Všeobecné"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Nastavenie stránky"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Inštalované vybavenie"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Úloha"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Kvalita obrázkov"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Farba"
+
+# PM: toto asi nebude dobre
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Dokončovanie"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Pokročilé"
+
+#~ msgid "Test page"
+#~ msgstr "Skúšobná stránka"
+
+#~ msgid "Auto Select"
+#~ msgstr "Automatický výber"
+
+#~ msgid "Printer Default"
+#~ msgstr "Predvolené hodnoty tlačiarne"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Vkladať len písma GhostScript"
+
+# MČ: PostScript Level 1 - PostScript Verzie 1, ale pri PS sa verzie nazývajú Level. teda aspoň ja to tak chápem
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Konvertovať na PS verzie 1"
+
+# MČ: PostScript Level 1 - PostScript Verzie 1, ale pri PS sa verzie nazývajú Level. teda aspoň ja to tak chápem
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Konvertovať na PS verzie 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Žiadne predfiltrovanie"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Čistenie tlačových hláv"
+
+#~ msgid "Out of toner"
+#~ msgstr "Minul sa toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Málo vývojky"
+
+#~ msgid "Out of developer"
+#~ msgstr "Minula sa vývojka"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Málo farby"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Minula sa farba"
+
+#~ msgid "Open cover"
+#~ msgstr "Otvorený kryt"
+
+#~ msgid "Open door"
+#~ msgstr "Otvorené dvierka"
+
+#~ msgid "Low on paper"
+#~ msgstr "Málo papiera"
+
+#~ msgid "Out of paper"
+#~ msgstr "Minul sa papier"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Vypnutá"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Zastavená"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Odpadová nádržka takmer plná"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Odpadová nádržka plná"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Fotovalcu onedlho skončí životnosť"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Fotovalec už nie je funkčný"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Pripravená"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Neprijíma úlohy"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Pracuje"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperiálne"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrické"
+
+# chooser_button
+#~ msgid "Ask what to do"
+#~ msgstr "Spýtať sa, čo robiť"
+
+# chooser_button
+#~ msgid "Do nothing"
+#~ msgstr "Nespraviť nič"
+
+# chooser_button
+#~ msgid "Open folder"
+#~ msgstr "Otvoriť priečinok"
+
+# window title
+#~ msgid "Other Media"
+#~ msgstr "Ostatné nosiče"
+
+# window heading
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Vyberte si aplikáciu pre audio CD"
+
+# window heading
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Vyberte si aplikáciu pre video DVD"
+
+#  window heading
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Vyberte si aplikáciu, ktorá sa spustí pri pripojení hudobného prehrávača"
+
+# window heading
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Vyberte si aplikáciu, ktorá sa spustí pri pripojení fotoaparátu"
+
+# window heading
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Vyberte si aplikáciu pre CD so softvérom"
+
+# listore item
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+# listore item
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "prázdny disk Blu-ray"
+
+# listore item
+#~ msgid "blank CD disc"
+#~ msgstr "prázdny disk CD"
+
+# listore item
+#~ msgid "blank DVD disc"
+#~ msgstr "prázdny disk DVD"
+
+# listore item
+#~ msgid "blank HD DVD disc"
+#~ msgstr "prázdny disk HD DVD"
+
+# listore item
+#~ msgid "Blu-ray video disc"
+#~ msgstr "video disk Blu-ray "
+
+# listore item
+#~ msgid "e-book reader"
+#~ msgstr "elektronická čítačka kníh"
+
+# listore item
+#~ msgid "HD DVD video disc"
+#~ msgstr "video disk HD DVD"
+
+# PM: je to názov formátu od Kodaku
+# listore item
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+# listore item
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+# listore item
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+# GtkListStore item
+# Uzamknut obrazovku pri necinnosti za
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "vypnutím obrazovky"
+
+# GtkListStore item
+# za
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekúnd"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minútu"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minúty"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minúty"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minút"
+
+# MČ: pre color.ui je to odhadovaný čas, pre power.ui po akom čase má uspať počítač., pre privacy.ui po akom čase má vypnúť obrazovku. Bude to treba asi dať rozdeliť.
+# MČ: Odhadujem, že pri ostatných reťazcoch to bude podobné, len sa ich pokusim pooznačovať, skús to preveriť.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# 1. approx_time; 2. Oneskorenie; 3
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minút"
+
+# Oddialiť o
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 hodinu"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minútu"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minúty"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minúty"
+
+# Blank Screen
+# GtkListStore item
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minúty"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minút"
+
+# Blank Screen
+# GtkListStore item
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minút"
+
+# Blank Screen
+# GtkListStore item
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minút"
+
+# Blank Screen
+# GtkListStore item
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minút"
+
+#  * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# approx_time; Oneskorenie
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minút"
+
+# naposledy použité
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nikdy"
+
+# file chooser dialog title
+#~ msgid "Select Location"
+#~ msgstr "Výber miesta"
+
+# liststore item
+#~ msgid "_OK"
+#~ msgstr "_Ok"
+
+#~ msgid "No applications found"
+#~ msgstr "Nenašli sa žiadne aplikácie"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nie sú vybraté žiadne siete na sprístupnenie"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Zapnutá"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Vypnutá"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Povolená"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktívna"
+
+# file chooser dialog title
+#~ msgid "Choose a Folder"
+#~ msgstr "Výber priečinka"
+
+# GtkDialog title
+#~ msgid "Enable media sharing"
+#~ msgstr "Povoliť spoločné používanie multimédií"
+
+# GtkLabel label
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Spoločné používanie súborov umožňuje spoločne sprístupniť váš priečinok "
+#~ "„Verejné“ s ostatnými na aktuálnej sieti použitím: %s"
+
+# GtkLabel label
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Keď je povolené vzdialené prihlásenie, vzdialení používatelia sa môžu "
+#~ "pripojiť pomocou príkazu Secure Shell:\n"
+#~ "%s"
+
+# GtkDialog title
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Povoliť spoločné používanie osobných multimédií"
+
+# GtkLabel label
+#~ msgid "Device name copied"
+#~ msgstr "Názov zariadenia bol skopírovaný"
+
+#~ msgid "Device address copied"
+#~ msgstr "Adresa zariadenia bola skopírovaná"
+
+# GtkLabel label
+#~ msgid "Username copied"
+#~ msgstr "Meno používateľa bolo skopírované"
+
+# GtkLabel label
+#~ msgid "Password copied"
+#~ msgstr "Heslo bolo skopírované"
+
+# téma
+#~ msgid "Custom"
+#~ msgstr "Vlastná"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Skúša sa %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100 %"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Odpojené"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Pripája sa"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Pripojené"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Chyba overenia totožnosti"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Overuje sa totožnosť"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Obmedzená funkčnosť"
+
+# GtkLabel label
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Pripojené a overená totožnosť"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# grafika, AP typ
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Neznáme"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Overená totožnosť o:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Pripojené o:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Zaregistrované o:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Zlyhalo overenie totožnosti zariadenia: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Zlyhalo zabudnutie zariadenia: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Chyba"
+
+# PAC provisioning
+# GtkListStore item
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Overená totožnosť"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Podsystém Thunderbolt (boltd) nie je nainštalovaný alebo správne "
+#~ "nastavený."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Môžu byť pripojené iba zariadenia typu USB a Display Port."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Rozhranie Thunderbolt sa nepodarilo rozpoznať.\n"
+#~ "Buď systém nepodporuje rozhranie Thunderbolt, alebo bola zakázaná v "
+#~ "BIOSe, alebo je nastavená na nepodporovanú bezpečnostnú úroveň v BIOSe."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Podpora zariadení Thunderbolt bola zakázaná v systéme BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Nepodarilo sa zistiť úroveň bezpečnosti zariadenia Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Chyba počas prepínania priameho režimu: %s"
+
+# sound id
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Predvolená"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Stredná"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Veľká"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Väčšia"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Najväčšia"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d pixelov"
+#~ msgstr[1] "%d pixel"
+#~ msgstr[2] "%d pixely"
+
+# dlzka krizu
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Krátky"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ obrazovky"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ obrazovky"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ obrazovky"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Dlhý"
+
+# Oddialiť o
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 hodina"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 deň"
+
+# GtkListStore item
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dni"
+
+# GtkListStore item
+# po dobe
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dni"
+
+# GtkListStore item
+# po dobe
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dni"
+
+# GtkListStore item
+# po dobe
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dní"
+
+# GtkListStore item
+# po dobe
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dní"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dní"
+
+# GtkListStore item
+# po dobe
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dní"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dní"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Vysypať všetky položky z Koša?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Všetky položky v koši budú natrvalo odstránené."
+
+# GtkButton label
+#~ msgid "_Empty Trash"
+#~ msgstr "_Vyprázdniť kôš"
+
+# 2 GtkDialog title
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Odstrániť všetky dočasné súbory?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Všetky dočasné súbory budú natrvalo odstránené."
+
+# GtkButton label
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Vymazať dočasné súbory"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 deň"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dní"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dní"
+
+# GtkListStore item
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Navždy"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr ""
+#~ "Mala by sa zhodovať s webovou adresou vášho poskytovateľa prihlásenia."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Zlyhalo pridanie účtu"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Zlyhala registrácia účtu"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Overenie totožnosti nie je pri tejto doméne podporované"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Zlyhalo pripojenie k doméne"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Prihlasovacie meno nefunguje.\n"
+#~ "Prosím, skúste to znovu."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Prihlasovacie heslo nefunguje.\n"
+#~ "Prosím, skúste to znovu."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Zlyhalo prihlásenie do domény"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Nepodarilo sa nájsť doménu. Napísali ste ju správne?"
+
+# DK: nechajme zatial tento tvar, kym to rozdelia.je to neskodny preklad
+# DK: https://bugzilla.gnome.org/show_bug.cgi?id=701344
+#~ msgid "Browse for more pictures"
+#~ msgstr "Výber ďalších obrázkov"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "zariadenie musí byť požiadané o vykonanie tejto akcie"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "zariadenie je už žiadané iným procesom"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "nemáte oprávnenie na vykonanie tejto akcie"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "žiadne odtlačky neboli nasnímané"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Zlyhala komunikácia so zariadením počas snímania"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Zlyhala komunikácia s čítačkou odtlačkov prstov"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Zlyhala komunikácia so službou odtlačkov prstov"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Zlyhalo vypísanie zoznamu odtlačkov prstov: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Zlyhalo odstránenie uložených odtlačkov prstov: %s"
+
+# GtkListStore item
+#~ msgid "Left thumb"
+#~ msgstr "Ľavý palec"
+
+# GtkListStore item
+#~ msgid "Left middle finger"
+#~ msgstr "Ľavý prostredník"
+
+# GtkRadioButton label
+#~ msgid "_Left index finger"
+#~ msgstr "Ľavý _ukazovák"
+
+# GtkListStore item
+#~ msgid "Left ring finger"
+#~ msgstr "Ľavý prstenník"
+
+# GtkListStore item
+#~ msgid "Left little finger"
+#~ msgstr "Ľavý malíček"
+
+# GtkListStore item
+#~ msgid "Right thumb"
+#~ msgstr "Pravý palec"
+
+# GtkListStore item
+#~ msgid "Right middle finger"
+#~ msgstr "Pravý prostredník"
+
+# GtkRadioButton label
+#~ msgid "_Right index finger"
+#~ msgstr "P_ravý ukazovák"
+
+# GtkListStore item
+#~ msgid "Right ring finger"
+#~ msgstr "Pravý prstenník"
+
+# GtkListStore item
+#~ msgid "Right little finger"
+#~ msgstr "Pravý malíček"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Neznámy prst"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Dokončené"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Zariadenie na snímanie odtlačkov prstov odpojené"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Úložisko zariadenia na snímanie odtlačkov prstov je plné"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Zlyhalo nasnímanie nového odtlačku prsta"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Zlyhalo spustenie snímania: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Zlyhalo nasnímanie nového odtlačku prsta"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Zlyhalo zastavenie snímania: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Opakovane zdvihnite a priložte váš prst na čítačku pre nasnímanie "
+#~ "odtlačku prsta"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Znovu nasnímať tento prst…"
+
+# assistant page title
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Oskenovať nový odtlačok prsta"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Zlyhalo uvoľnenie zariadenia na snímanie odtlačkov prstov %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problém s čítaním zariadenia"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Zlyhalo vyžiadanie zariadenia na snímanie odtlačkov prstov %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Zlyhalo získanie zariadení na snímanie odtlačkov prstov: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Tento týždeň"
+
+#~ msgid "Last Week"
+#~ msgstr "Minulý týždeň"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+# DK: zaznam v historii relacie
+#~ msgid "Session Ended"
+#~ msgstr "Ukončenie relácie"
+
+#~ msgid "Session Started"
+#~ msgstr "Spustenie relácie"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Aktivita účtu"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Prosím, zvoľte si iné heslo."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Prosím, zadajte vaše aktuálne heslo ešte raz."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Heslo nemohlo byť zmenené"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "S takýmto typom domény sa nedá automaticky spojiť"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nebola nájdená taká doména alebo pôsobisko"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Nedá sa prihlásiť ako %s do domény %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Neplatné heslo, skúste to znovu"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Nepodarilo sa pripojiť k doméne %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Odstránenie používateľa zlyhalo"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Zlyhalo zrušenie na diaľku spravovaného používateľa"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Nemôžete odstrániť vlastný účet."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "Používateľ %s je stále prihlásený"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Odstránenie prihláseného používateľa môže spôsobiť nestabilitu systému."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Chcete ponechať súbory používateľa %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Pri odstraňovaní používateľa je možné ponechať jeho domovský priečinok, "
+#~ "súbory pošty a dočasné súbory."
+
+# button
+#~ msgid "_Delete Files"
+#~ msgstr "O_dstrániť súbory"
+
+# button
+#~ msgid "_Keep Files"
+#~ msgstr "Po_nechať súbory"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Naozaj chcete zrušiť na diaľku spravovaný účet používateľa %s?"
+
+# button
+#~ msgid "_Delete"
+#~ msgstr "O_dstrániť"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Účet je zakázaný"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Nastaviť pri najbližšom prihlásení"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Žiadne"
+
+#~ msgid "Logged in"
+#~ msgstr "Prihlásený"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Spojenie so službou účtov zlyhalo"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Uistite sa, prosím, že je služba AccountService nainštalovaná a povolená."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Pre zmenu tohto nastavenia musí byť panel odomknutý"
+
+# tooltip
+#~ msgid "Delete the selected user account"
+#~ msgstr "Odstráni vybraný používateľský účet"
+
+# tooltip
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Keď chcete odstrániť používateľský účet,\n"
+#~ "kliknite najskôr na ikonu *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Odomknutím pridáte používateľov a zmeníte nastavenia"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Nové heslo musí byť odlišné od pôvodného hesla."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Skúste zmeniť niektoré písmená a čísla."
+
+# GtkLabel
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Skúste ešte viac zmeniť heslo."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Heslo bez vášho mena bude silnejšie."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Skúste sa vyhnúť použitiu vášho mena v hesle."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Skúste sa vyhnúť slovám, ktoré sú obsiahnuté v hesle."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Skúste sa vyhnúť často používaným slovám."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Skúste sa vyhnúť zmene poradia existujúcich slov."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Skúste použiť viac čísel."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Skúste použiť viac veľkých písmen."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Skúste použiť viac malých písmen."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Skúste použiť viac špeciálnych znakov ako sú interpunkčné znamienka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Skúste použiť zmes písmen, čísel a interpunkčných znamienok."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Skúste sa vyhnúť opakovaniu toho istého znaku."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Skúste sa vyhnúť opakovaniu toho istého znaku: musíte zmiešať písmená, "
+#~ "čísla a interpunkčné znamienka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Skúste sa vyhnúť frázam ako 1234 alebo abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Heslo musí byť dlhšie. Skúste pridať viac písmen, čísel a interpunkčných "
+#~ "znamienok."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Zmiešajte veľké a malé písmená a skúste použiť jedno alebo viac číslic."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "Pridaním viacerých písmen, čísel a interpunkčných heslo zosilníte."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Overenie totožnosti zlyhalo"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Nové heslo je príliš krátke"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Nové heslo je príliš jednoduché"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Nové heslo je príliš podobné starému"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Nové heslo už bolo nedávno použité."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Nové heslo musí obsahovať číselné alebo špeciálne znaky"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Nové heslo je rovnaké ako staré"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Vaše heslo sa od pôvodného overenia totožnosti zmenilo!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Nové heslo neobsahuje dostatočný počet rôznych znakov"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Neznáma chyba"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Používateľské meno by sa malo skladať iba z malých písmen a-z, číslic a "
+#~ "nasledovných znakov: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Prepáčte, ale toto používateľské meno nie je dostupné. Prosím, skúste iné."
+
+#~ msgid "The username is too long."
+#~ msgstr "Používateľské meno je príliš dlhé."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Tlačidlo č. %d"
+
+# tab
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Definované aplikáciou"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Odoslať stlačenie klávesu"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Prepnúť displej"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Zobraziť pomocníka na obrazovke"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tablet pripojený k panelu notebooku"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tablet pripojený k externému displeju"
+
+# GtkLinkButton label
+#~ msgid "External tablet device"
+#~ msgstr "Externé zariadenie s tabletom"
+
+# desktop entry name
+#~ msgid "All Displays"
+#~ msgstr "Všetky displeje"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Rozprašovacie pero s tlakom, naklonením a integrovaným posuvníkom"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Rozprašovacie pero s tlakom, naklonením a otočením"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Štandardné pero s tlakom a naklonením"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Štandardné pero s tlakom"
+
+# label
+#~ msgid "New shortcut…"
+#~ msgstr "Nová skratka…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operácia zrušená"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Chyba:</b> Prístup zamietnutý pre zmenu nastavení"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Chyba:</b> Chyba mobilného vybavenia"
+
+#~ msgid "Not Registered"
+#~ msgstr "Neregistrovaná"
+
+# naposledy použité
+#~ msgid "Registered"
+#~ msgstr "Registrovaná"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+# desktop entry name
+#~ msgid "Searching"
+#~ msgstr "Vyhľadávanie"
+
+#~ msgid "Denied"
+#~ msgstr "Zamietnuté"
+
+#~ msgid "2G Only"
+#~ msgstr "Iba 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Iba 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Iba 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Iba 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (uprednostňované)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (uprednostňované), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (uprednostňované), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (uprednostňované), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (uprednostňované)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (uprednostňované), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (uprednostňované), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (uprednostňované)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (uprednostňované), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (uprednostňované), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (uprednostňované)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (uprednostňované), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (uprednostňované), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (uprednostňované)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (uprednostňované), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (uprednostňované), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (uprednostňované)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (uprednostňované), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (uprednostňované)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (uprednostňované), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (uprednostňované)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (uprednostňované), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (uprednostňované)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (uprednostňované), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (uprednostňované)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (uprednostňované), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "3G, 5G (uprednostňované)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (uprednostňované), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+# network mode
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Neznámy"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Odomknutie karty SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Prosím, poskytnite kód PIN pre kartu SIM č. %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Zadajte kód PIN na odomknutie vašej karty SIM"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Prosím, poskytnite kód PUK pre kartu SIM č. %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Zadajte kód PUK na odomknutie vašej karty SIM"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Bolo zadané nesprávne heslo."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Kód PUK by malo byť 8 ciferné číslo"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Zadajte nový kód PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Kód PIN by malo byť 4 až 8 ciferné číslo"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Odomykanie…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Zlyhanie telefónu"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Žiadne pripojenie k telefónu"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operácia nie je umožnená"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operácia nie je podporovaná"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Karta SIM nie je vložená"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Vyžadovaný kód PIN pre kartu SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Vyžadovaný kód PIN pre kartu SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Zlyhanie karty SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "Karta SIM je zaneprázdnená"
+
+# GtkLabel
+#~ msgid "Incorrect password"
+#~ msgstr "Nesprávne heslo"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Vyžadovaný kód PIN2 pre kartu SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Vyžadovaný kód PUK2 pre kartu SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Nenájdené"
+
+#~ msgid "No network service"
+#~ msgstr "Žiadna sieťová služba"
+
+# GtkLabel label
+#~ msgid "Network timeout"
+#~ msgstr "Čas siete vypršal"
+
+# AutoIP je termin, ako napr. DHCP
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Služby siete GPRS nie sú povolené"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming nie je povolený v tejto oblasti"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Nešpecifikovaná chyba siete GPRS"
+
+#~ msgid "No Error"
+#~ msgstr "Bez chyby"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Akcia bola zrušená"
+
+#~ msgid "Access denied"
+#~ msgstr "Prístup zamietnutý"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Neznáma chyba"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "Karta SIM č. %d"
+
+# cmd line desc
+#~ msgid "Display version number"
+#~ msgstr "Vypíše číslo verzie"
+
+# PM: takto to tuším máme v iných moduloch
+# cmd desc
+#~ msgid "Enable verbose mode"
+#~ msgstr "Povolí podrobné výpisy"
+
+# cmd desc
+#~ msgid "Search for the string"
+#~ msgstr "Vyhľadá reťazec"
+
+# cmd desc
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Vypíše možné názvy panelov a ukončí sa"
+
+# cmd desc
+#~ msgid "Panel to display"
+#~ msgstr "Panel na zobrazenie"
+
+# cmd desc
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [PARAMETER…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Dostupné panely:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Systémové zvuky"
+
+#~| msgid "Right"
+#~ msgid "Light"
+#~ msgstr "Svetlý"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "obrazovka;zámok;uzamknutie;diagnostika;pád;súkromný;nedávny;dočasný;tmp;"
+#~ "index;meno;sieť;identita;"
+
+# PK: mozno priradenie
+# PM: doriesit v master vetve
+# PM: dalej je priradiť k displeju
+# dialog title
+#~ msgid "Display Arrangement"
+#~ msgstr "Rozloženie displejov"
+
+# tlačidlo
+#~ msgid "Set"
+#~ msgstr "Nastaviť"
+
+# KeyListEntry description
+#~ msgid "Lock your screen"
+#~ msgstr "Uzamknúť vašu obrazovku"
+
+# file filter
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certifikáty typu DER alebo PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Bark"
+#~ msgstr "Brechanie"
+
+#~ msgid "Drip"
+#~ msgstr "Kvapkanie vody"
+
+#~ msgid "Glass"
+#~ msgstr "Ťukanie na sklo"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Panel so zvukom v nastaveniach prostredia GNOME"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Panel s myšou a touchpadom v nastaveniach prostredia GNOME"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Panel s pozadím v nastaveniach prostredia GNOME"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Panel s klávesnicou v nastaveniach prostredia GNOME"
 
 #~ msgid "Web Links"
 #~ msgstr "Webové odkazy"
@@ -9845,11 +9316,11 @@ msgstr "Systémové zvuky"
 #~ msgstr "Nie je možné zmeniť"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "Jednotlivé oprávnenia aplikácií môžu byť prezreté v nastaveniach <a href="
-#~ "\"privacy\">Súkromia</a>."
+#~ "Jednotlivé oprávnenia aplikácií môžu byť prezreté v nastaveniach <a "
+#~ "href=\"privacy\">Súkromia</a>."
 
 #~ msgid "Integration"
 #~ msgstr "Integrácia"
@@ -9935,19 +9406,11 @@ msgstr "Systémové zvuky"
 #~ msgid "Active Display"
 #~ msgstr "Aktívny displej"
 
-# GtkDialog title
-#~ msgid "Display Configuration"
-#~ msgstr "Konfigurácia displeja"
-
 #~ msgid "More Warm"
 #~ msgstr "Teplejšia"
 
 #~ msgid "Less Warm"
 #~ msgstr "Studenšia"
-
-# KeyListEntries name
-#~ msgid "Screenshots"
-#~ msgstr "Snímky obrazoviek"
 
 # KeyListEntry description
 #~ msgid "Save a screenshot to $PICTURES"
@@ -10001,14 +9464,6 @@ msgstr "Systémové zvuky"
 
 #~ msgid "Allow the applications below to determine your location."
 #~ msgstr "Umožnite nasledovným aplikáciám zisťovať vaše umiestnenie."
-
-# Blank Screen
-# Uzamknut obrazovku pri necinnosti za
-# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
-# GtkListStore item
-#~ msgctxt "lock_screen"
-#~ msgid "5 minutes"
-#~ msgstr "5 minút"
 
 #~ msgid "Allow the applications below to use your microphone."
 #~ msgstr "Umožnite nasledovným aplikáciám používať váš mikrofón."
@@ -10088,10 +9543,6 @@ msgstr "Systémové zvuky"
 #~ "Sprístupnenie obrazovky umožňuje vzdialeným používateľom zobraziť alebo "
 #~ "ovládať vašu obrazovku pripojením k %s"
 
-# menu item
-#~ msgid "Copy"
-#~ msgstr "Kopírovať"
-
 # GtkDialog title
 #~ msgid "_Screen Sharing"
 #~ msgstr "S_prístupnenie obrazovky"
@@ -10100,10 +9551,6 @@ msgstr "Systémové zvuky"
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr ""
 #~ "Niektoré služby sú zakázané kvôli nedostupnosti sieťového pripojenia."
-
-# GtkDialog title
-#~ msgid "Screen Sharing"
-#~ msgstr "Sprístupnenie obrazovky"
 
 # GtkLabel label
 #~ msgid "_Password:"
@@ -10135,10 +9582,6 @@ msgstr "Systémové zvuky"
 # GtkLabel
 #~ msgid "_Screen Reader"
 #~ msgstr "Čítačka obrazovk_y"
-
-# GtkLabel
-#~ msgid "_Full Name"
-#~ msgstr "_Celé meno"
 
 # GtkListStore item
 #~ msgid "Standard"
@@ -10215,10 +9658,6 @@ msgstr "Systémové zvuky"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Tablet (absolútny)"
 
-# GtkListStore item
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Touchpad (relatívny)"
-
 # GtkDialog title
 #~ msgid "Tablet Preferences"
 #~ msgstr "Nastavenia tabletu"
@@ -10246,22 +9685,6 @@ msgstr "Systémové zvuky"
 #~ msgid "Adjust display resolution"
 #~ msgstr "Upraviť rozlíšenie displeja"
 
-# sound id
-#~ msgid "Default"
-#~ msgstr "Predvolený"
-
-# GtkListStore row
-#~ msgid "Middle Mouse Button Click"
-#~ msgstr "Kliknutie stredným tlačidlom myši"
-
-# GtkListStore row
-#~ msgid "Right Mouse Button Click"
-#~ msgstr "Kliknutie pravým tlačidlom myši"
-
-# GtkListStore row
-#~ msgid "Forward"
-#~ msgstr "Dopredu"
-
 #~ msgid "No stylus found"
 #~ msgstr "Nenašlo sa žiadne pero"
 
@@ -10269,14 +9692,6 @@ msgstr "Systémové zvuky"
 #~ "Please move your stylus to the proximity of the tablet to configure it"
 #~ msgstr ""
 #~ "Prosím, umiestnite vaše pero do vzdialenosti tabletu pre jeho konfiguráciu"
-
-# pocit tlaku pera a gumy
-#~ msgid "Soft"
-#~ msgstr "Jemný"
-
-# pocit tlaku pera a gumy
-#~ msgid "Firm"
-#~ msgstr "Tvrdý"
 
 #~ msgid "Top Button"
 #~ msgstr "Horné tlačidlo"
@@ -10438,9 +9853,6 @@ msgstr "Systémové zvuky"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Priamy prístup k hardvéru bluetooth"
-
-#~ msgid "Use your camera"
-#~ msgstr "Používanie vyšej kamery"
 
 # desktop entry name
 #~ msgid "Print documents"
@@ -11349,10 +10761,6 @@ msgstr "Systémové zvuky"
 #~ msgid "Co­lor"
 #~ msgstr "Farba"
 
-# 1.,2. treeviewcolumn;
-#~ msgid "Section"
-#~ msgstr "Sekcia"
-
 # 1. listore item; tab
 #~ msgid "Overview"
 #~ msgstr "Prehľad"
@@ -11416,10 +10824,6 @@ msgstr "Systémové zvuky"
 
 #~ msgid "Mirrored"
 #~ msgstr "Zrkadlený"
-
-# atkobject
-#~ msgid "Secondary"
-#~ msgstr "Vedľajší"
 
 # dialog title
 #~ msgid "Arrange Combined Displays"
@@ -11515,10 +10919,6 @@ msgstr "Systémové zvuky"
 #~ msgid "Automatic"
 #~ msgstr "Zistiť automaticky"
 
-# GtkLabel label
-#~ msgid "_Method"
-#~ msgstr "_Metóda"
-
 # týka sa (Cisco) VPN
 # GtkLabel label
 #~ msgid "Group Name"
@@ -11601,10 +11001,6 @@ msgstr "Systémové zvuky"
 #~ msgid "4"
 #~ msgstr "4"
 
-# GtkLabel label
-#~ msgid "Loading options…"
-#~ msgstr "Načítavajú sa voľby…"
-
 #~ msgctxt "Password hint"
 #~ msgid "Try to add more letters, numbers and symbols."
 #~ msgstr "Skúste pridať viac písmen, čísel a symbolov."
@@ -11643,10 +11039,6 @@ msgstr "Systémové zvuky"
 # account dialog group
 #~ msgid "Mail"
 #~ msgstr "Pošta"
-
-# GtkLabel label
-#~ msgid "Calendar"
-#~ msgstr "Kalendár"
 
 # account dialog group
 #~ msgid "Contacts"
@@ -11696,16 +11088,8 @@ msgstr "Systémové zvuky"
 #~ msgid "label"
 #~ msgstr "menovka"
 
-# GtkLabel label
-#~ msgid "Setting new driver…"
-#~ msgstr "Nastavuje sa nový ovládač…"
-
 #~ msgid "Print _Test Page"
 #~ msgstr "Vytlačiť _skúšobnú stranu"
-
-# button label
-#~ msgid "Edit"
-#~ msgstr "Upraviť"
 
 #~ msgctxt "button"
 #~ msgid "Set Shortcut"
@@ -11736,10 +11120,6 @@ msgstr "Systémové zvuky"
 
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "Toto neodstráni účet zo servera."
-
-# button
-#~ msgid "_Remove"
-#~ msgstr "O_dstrániť"
 
 # GtkLabel label
 #~ msgid "No online accounts configured"
@@ -11837,10 +11217,6 @@ msgstr "Systémové zvuky"
 #~ msgstr "Rolovať nahor"
 
 # GtkListStore row
-#~ msgid "Scroll Down"
-#~ msgstr "Rolovať nadol"
-
-# GtkListStore row
 #~ msgid "Scroll Right"
 #~ msgstr "Rolovať doprava"
 
@@ -11927,10 +11303,6 @@ msgstr "Systémové zvuky"
 # window title
 #~ msgid "Add Network Connection"
 #~ msgstr "Pridanie nového pripojenia"
-
-# GtkDialog title
-#~ msgid "Personal File Sharing"
-#~ msgstr "Spoločné používanie osobných súborov"
 
 # GtkDialog title
 #~ msgid "Login History"
@@ -12051,10 +11423,6 @@ msgstr "Systémové zvuky"
 #~ msgid "Time _Zone"
 #~ msgstr "Časové _pásmo"
 
-# GtkButton label
-#~ msgid "Options"
-#~ msgstr "Voľby"
-
 # GtkLabel label
 #~ msgid "Password:"
 #~ msgstr "Heslo:"
@@ -12161,9 +11529,6 @@ msgstr "Systémové zvuky"
 #~ msgid "Fast"
 #~ msgstr "Vysoká"
 
-#~ msgid "No printers available"
-#~ msgstr "Žiadne dostupné tlačiarne"
-
 #~ msgid "Add New Printer"
 #~ msgstr "Pridať novú tlačiareň"
 
@@ -12215,10 +11580,6 @@ msgstr "Systémové zvuky"
 
 #~ msgid "China"
 #~ msgstr "Čína"
-
-# GtkCheckButton label
-#~ msgid "Disable while _typing"
-#~ msgstr "Zakázať počas _písania"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "Sieťové služby systému nie sú kompatibilné s touto verziou."

--- a/po/sk.po~
+++ b/po/sk.po~
@@ -1,0 +1,13083 @@
+# Slovak translation for gnome-control-center.
+# Copyright (C) 2000-2005, 2007-2009, 2011-2013 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+# Stanislav Višňovsky <visnovsky@nenya.ms.mff.cuni.cz>, 2000-2004.
+# Marcel Telka <marcel@telka.sk>, 2005.
+# Peter Tuhársky <tuharsky@misbb.sk>, 2007.
+# Pavol Šimo <palo.simo@gmail.com>, 2007-2011.
+# Pavol Klačanský <pavol@klacansky.com>, 2012, 2013.
+# Dušan Kazik <prescott66@gmail.com>, 2013-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-10-25 14:38+0000\n"
+"PO-Revision-Date: 2022-11-05 13:30+0100\n"
+"Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
+"Language-Team: Slovak <gnome-sk-list@gnome.org>\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 1 : (n>=2 && n<=4) ? 2 : 0;\n"
+"X-Launchpad-Export-Date: 2012-10-06 09:48+0000\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Zbernica systému"
+
+# GtkLabel
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Plný prístup"
+
+# DK: zaznam v historii relacie
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Zbernica relácie"
+
+# label
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Zariadenia"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Plný prístup k adresáru /dev"
+
+# desktop entry name
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Sieť"
+
+# GtkLabel label
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Má prístup k sieti"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Domov"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Iba na čítanie"
+
+# Overenie totožnosti
+# GtkListStore item
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Systém súborov"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Nastavenia"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Môže meniť nastavenia"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"Aplikácia %s obsahuje nasledovné vstavané oprávnenia, ktoré nemôžu byť "
+"zmenené. Ak vás tieto oprávnenia znepokojujú, zvážte odstránenie tejto "
+"aplikácie."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u typov súborov a odkazov, ktoré sú otvárané aplikáciou"
+msgstr[1] "%u typ súboru a odkazu, ktorý je otváraný aplikáciou"
+msgstr[2] "%u typy súborov a odkazov, ktoré sú otvárané aplikáciou"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"Aplikácia <b>%s</b> sa používa na otváranie nasledovných typov súborov a "
+"odkazov."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s využitého miesta na disku."
+
+# tab
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Aplikácie"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Žiadne aplikácie"
+
+# gtk_image_menu_item
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Nainštalovať nejaké…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Otvoriť"
+
+# GtkButton label
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Zobraziť podrobnosti"
+
+# desktop entry name
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Vyhľadávanie"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Prijíma systémové hľadania a odosiela výsledky."
+
+# 4. GtkComboBox item (manual, dhcp, link-local...)
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Zakázané"
+
+# policy_settings
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Oznámenia"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Zobrazuje systémové oznámenia."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Spustenie na pozadí"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Umožňuje aktivitu, keď je aplikácia zavretá."
+
+# KeyListEntries name
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Snímky obrazoviek"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Zachytáva obrázky obrazovky kedykoľvek."
+
+# radio_button
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Zmeniť tapetu"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Mení tapetu pracovnej plochy"
+
+# desktop entry name
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Zvuky"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Reprodukuje zvuky."
+
+# tab
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Potlačenie skratiek"
+
+# GtkLabel label
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Blokuje štandardné klávesové skratky."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Zachytáva obrázky pomocou kamery."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofón"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Zaznamenáva zvuk pomocou mikrofónu."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Služby umiestnenia"
+
+# GtkButton label
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Pristupuje k údajom umiestnenia zariadenia."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Zabudované oprávnenia"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Systémový prístup, ktorý je vyžadovaný aplikáciou"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Priradenia súborov a odkazov"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Úložisko"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Nenašli sa žiadne výsledky"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Skúste vyhľadať niečo iné"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Priradenie súborov a odkazov"
+
+# Overenie totožnosti
+# GtkListStore item
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Typy súborov"
+
+# GtkLabel label
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Typy odkazov"
+
+# GtkListStore item; page
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Vrátiť pôvodné"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Koľko priestoru na disku obsadzuje táto aplikácia svojimi údajmi a "
+"vyrovnávacími pamäťami."
+
+# tab
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Aplikácia"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Údaje"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Vyrovnávacia pamäť"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Celkom</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Vymazať vyrovnávaciu pamäť…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Ovláda rozličné oprávnenia a nastavenia aplikácií"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "aplikácia;flatpak;oprávnenie;nastavenie;"
+
+# file chooser dialog title
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Výber obrázka"
+
+# GtkButton label
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Zrušiť"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Otvoriť"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "viac veľkostí"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Bez pozadia plochy"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Aktuálne pozadie"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Štýl"
+
+# sound id
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Predvolený"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Tmavý"
+
+# desktop entry name
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Pozadie"
+
+# GtkToolButton label
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Pridať obrázok…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Vzhľad"
+
+# desktop entry comment
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Mení obrázok vášho pozadia alebo farby používateľského rozhrania"
+
+# desktop entry keywords
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr "Pozadie;Tapeta;Obrazovka;Plocha;Pozadie;Štýl;Svetlý;Tmavý;Vzhľad;"
+
+# zariadenie
+# GtkButton label
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Povoliť"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Nenašli sa žiadne Bluetooth zariadenia"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Pre použitie rozhrania Bluetooth pripojte adaptér."
+
+#  GtkDialog title
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth je vypnutý"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Zapnite ho, ak chcete pripojiť zariadenia a prijať prenosy súborov."
+
+# label
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Režim v lietadle je zapnutý"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth je zakázaný, keď je zapnutý režim v lietadle."
+
+# label
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Vypnúť režim v lietadle"
+
+# label
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Hardvérový režim v lietadle je zapnutý"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Vypnite prepínač režimu v lietadle na povolenie rozhrania Bluetooth."
+
+# desktop entry name
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+# desktop entry comment
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Zapína a vypína rozhranie Bluetooth a pripája vaše zariadenia"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+"spoločné používanie;spoločne používať;zdieľať;zdieľanie;sprístupniť;"
+"sprístupnenie;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera je vypnutá"
+
+# label
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Žiadne aplikácie nemôžu zachytávať fotografie alebo videá."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Použitie kamery umožňuje aplikáciám snímať fotografie a videá. Zakázanie "
+"kamery môže spôsobiť nesprávne fungovanie niektorých aplikácií.\n"
+"\n"
+"Umožnite nasledovným aplikáciám používať kameru."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Žiadne aplikácie si nevyžiadali prístup ku kamere"
+
+# DK: nechajme zatial tento tvar, kym to rozdelia.je to neskodny preklad
+# DK: https://bugzilla.gnome.org/show_bug.cgi?id=701344
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Ochráňte vaše obrázky"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"kamera;fotoaparát;fotky;fotografie;video;webkamera;zámok;uzamknúť;súkromie;"
+"súkromný;súkromná;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Umiestnite vaše kalibračné zariadenie nad štvorec a stlačte tlačidlo „Začať“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Presuňte vaše kalibračné zariadenie do kalibračnej pozície a stlačte "
+"tlačidlo „Pokračovať“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Presuňte vaše kalibračné zariadenie do pozície na povrchu a stlačte tlačidlo "
+"„Pokračovať“"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Zavrite kryt notebooku"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Vyskytla sa vnútorná chyba, ktorú sa nepodarilo rozpoznať."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Nástroje vyžadované na kalibráciu nie sú nainštalované."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Nepodarilo sa vygenerovať profil."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Nepodarilo sa získať cieľový biely bod."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Dokončená!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrácia zlyhala!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Môžete odstrániť kalibračné zariadenie."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Nemanipulujte s kalibračným zariadením počas kalibrácie"
+
+# GtkDialog title
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Kalibrácia displeja"
+
+# GtkButton label
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Začať"
+
+# GtkButton label
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Pokračovať"
+
+# GtkButton label
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Dokončiť"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Obrazovka prenosného počítača"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Zabudovaná webkamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Displej %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Skener %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Kamera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Tlačiareň %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webkamera %s"
+
+# atk
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Povoliť správu farieb pre %s"
+
+# atk
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Zobraziť farebné profily pre %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Nenakalibrované"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Predvolený: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Farebný priestor: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Skúšobný profil: "
+
+# dialog title
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Výber súboru s profilom ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importovať"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Podporované profily ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Všetky súbory"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Obrazovka"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Uloženie profilu"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Uložiť"
+
+# tooltip
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Vytvorí profil farieb pre vybrané zariadenie"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Merací nástroj nebol detegovaný. Overte, prosím, či je zapnutý a správne "
+"pripojený."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Merací nástroj nepodporuje profilovanie tlačiarne."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Typ zariadenia momentálne nie je podporovaný."
+
+# GtkAssistant title
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Kalibrovanie obrazovky"
+
+# GtkAssistant title
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kvalita kalibrácie"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrácia vytvorí profil, ktorý môžete použiť na správu farieb vašej "
+"obrazovky. Kvalita farebného profilu je priamo úmerná času stráveného "
+"kalibráciou."
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Počas kalibrácie nebudete môcť používať váš počítač."
+
+# GtkLabel label
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kvalita"
+
+# GtkLabel label
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Odhadovaný čas"
+
+# GtkAssistant title
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibračné zariadenie"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Vyberte zariadenie so senzorom, ktoré chcete použiť na kalibráciu."
+
+# GtkAssistant title
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Typ displeja"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Vyberte typ pripojeného displeja."
+
+# GtkAssistant title
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Biely bod profilu"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Vyberte cieľový biely bod displeja. Väčšina displejov by mala byť "
+"nakalibrovaná na osvetlenie D65."
+
+# GtkAssistant title
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Jas displeja"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Prosím, nastavte displej na jas ktorý bežne používate. Správa farieb bude "
+"najpresnejšia pri tejto úrovni jasu."
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alebo môžete tiež použiť úroveň jasu z iného profilu tohoto zariadenia."
+
+# GtkAssistant title
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Názov profilu"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Farebný profil môžete použiť na rôznych počítačoch, alebo dokonca vytvoriť "
+"profily pre rozličné svetelné podmienky."
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Názov profilu:"
+
+# 1. GtkAssistant title;
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Zhrnutie"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil bol úspešne vytvorený!"
+
+# GtkButton label
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopírovať profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Vyžaduje zapisovateľný nosič"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Tieto inštrukcie môžete nájsť v sekcii ako užitočne využívať profil v "
+"systémoch <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> a "
+"<a href=\"windows\">Microsoft Windows</a>."
+
+# dialog title
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Pridanie profilu"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Bol zistený problém. Profil nemusí fungovať správne. <a href=\"\">Zobraziť "
+"podrobnosti.</a>"
+
+# GtkButton label
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importovať súbor…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "P_ridať"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "Každé zariadenie potrebuje na správu farieb aktuálny profil farieb."
+
+# GtkLinkButton label
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Zistiť viac"
+
+# GtkLinkButton tooltip
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Zistite viac o správe farieb"
+
+# GtkButton label
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Nastaviť pre všetkých používateľov"
+
+# GtkButton tooltip
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Nastaví tento profil pre všetkých používateľov tohto počítača"
+
+# zariadenie
+# GtkButton label
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "Povo_liť"
+
+# GtkButton label
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Pridať pro_fil"
+
+# GtkButton label
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrovať…"
+
+# GtkButton tooltip
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibruje zariadenie"
+
+# GtkButton label
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "O_dstrániť profil"
+
+# GtkButton label
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "Zobraz_iť podrobnosti"
+
+# GtkLabel label
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Nepodarilo sa zistiť žiadne zariadenia, ktoré podporujú správu farieb"
+
+# display_kind
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+# display_kind
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+# display_kind
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+# display_kind
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektor"
+
+# display_kind
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plazma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (technológia podsvietenia CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (technológia podsvietenia RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (technológia podsvietenia bielymi LED diódami)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD so širokým farebným priestorom (technológia podsvietenia CCFL)"
+
+# PK: mozno to Wide by som prelozil
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD so širokým farebným priestorom (technológia podsvietenia RGB LED)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Vysoká"
+
+# approx_time
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minút"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Stredná"
+
+# MČ: pre color.ui je to odhadovaný čas, pre power.ui po akom čase má uspať počítač., pre privacy.ui po akom čase má vypnúť obrazovku. Bude to treba asi dať rozdeliť.
+# MČ: Odhadujem, že pri ostatných reťazcoch to bude podobné, len sa ich pokusim pooznačovať, skús to preveriť.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# 1. approx_time; 2. Oneskorenie; 3
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minút"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Nízka"
+
+#  * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# approx_time; Oneskorenie
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minút"
+
+# farebny profil
+# temp_desc
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Pôvodný pre displej"
+
+# temp_desc
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (tlačenie a publikovanie"
+
+# temp_desc
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+# temp_desc
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografie a grafika)"
+
+# temp_desc
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Štandardný farebný priestor"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Skúšobný profil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatický"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Nízka kvalita"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Stredná kvalita"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Vysoká kvalita"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Predvolený RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Predvolený CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Predvolený čiernobiely"
+
+# tooltip
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Kalibračné údaje dodané výrobcom"
+
+# toolip
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Celoobrazovková korekcia displeja nie je možná s týmto profilom"
+
+# tooltip
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Tento profil môže byť už nepresný"
+
+# 1. GtkWindow title; 2. desktop entry name;
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Farby"
+
+# desktop entry comment
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Kalibruje farby vašich zariadení, ako napr. displeje, kamery alebo tlačiarne"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Farba;Farby;ICC;Profil;Kalibrovať;Tlačiareň;Displej;"
+
+# region
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Iný…"
+
+# GtkDialog title; GtkLabel label
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Výber jazyka"
+
+# tlačidlo
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Vybrať"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Nenašli sa žiadne jazyky"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Viac…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Odomknutím zmeníte nastavenia"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+"Niektoré nastavenia musia byť odomknuté, pred tým než môžu byť zmenené."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Odomknúť…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Navýšiť hodinu"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Navýšiť minútu"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Čas"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Znížiť hodinu"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Znížiť minútu"
+
+# naposledy použité
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Dnes"
+
+# naposledy použité
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Včera"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hodín"
+msgstr[1] "%d hodina"
+msgstr[2] "%d hodiny"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minút"
+msgstr[1] "%d minúta"
+msgstr[2] "%d minúty"
+
+# GtkListStore item
+# za
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekúnd"
+msgstr[1] "%d sekunda"
+msgstr[2] "%d sekundy"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+# GtkListStore item
+# za
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekúnd"
+
+# button
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Prístupový bod"
+
+# GtkRadioButton label
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-hodinový"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+# MČ: %p je tam zbytočne, bude to prázdny reťazec.
+# pre 12-hodinový čas
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e. %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e. %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+# MČ: %p je tam zbytočne, bude to prázdny reťazec.
+# pre 12-hodinový čas
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+# desktop entry name
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Dátum a čas"
+
+# GtkSpinButton AtkObject
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Rok"
+
+# GtkComboBox AtkObject
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mesiac"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "január"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "február"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "marec"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "apríl"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "máj"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "jún"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "júl"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "august"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "september"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "október"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "november"
+
+# GtkListStore item
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "december"
+
+# GtkSpinButton AtkObject
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Deň"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Časové pásmo"
+
+# DK: default text v poli pre zadavanie textu
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Vyhľadajte mesto"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatický _dátum a čas"
+
+# liststore item
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Vyžaduje prístup na internet"
+
+# desktop entry name
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "_Dátum a čas"
+
+# GtkLabel label
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Automatické časové _pásmo"
+
+# liststore item
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Vyžaduje povolené služby umiestnenia a prístup na internet"
+
+# zariadenie
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Povolené"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Ča_sové pásmo"
+
+# TODO lepšia alternatíva?
+# GtkDialog title; GtkLabel label
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Formát času"
+
+# desktop entry comment
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Mení dátum a čas vrátané časového pásma"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Hodiny;Čas;Zóna;Pásmo;Poloha;Umiestnenie;"
+
+# policy description
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Zmena systémového nastavenia času a dátumu"
+
+# policy message
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Keď chcete zmeniť nastavenia času a dátumu, musíte najskôr overiť vašu "
+"totožnosť."
+
+# GtkLabel label
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+# GtkLabel label
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Email"
+
+# GtkLabel label
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalendár"
+
+# GtkLabel label
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Hudba"
+
+# GtkLabel label
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "Vide_o"
+
+# GtkLabel label
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotografie"
+
+# 1. listore item; tab
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Predvolené aplikácie"
+
+# 1. listore item; tab
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Nastavuje predvolené aplikácie"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"predvolená;predvolený;predvolené;aplikácia;uprednostňovaná;uprednostňovaný;"
+"uprednostňované;médium;médiá;nosič,nosiče;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Odoslaním hlásení o technických problémoch nám pomôže vylepšiť systém %s. "
+"Hlásenia sú odosielané anonymne a neobsahujú osobné údaje. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Hlásenie problémov"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatické hlásenie problémov"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostika"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Nahláste vaše problémy"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostika;pád;zlyhanie;"
+
+#
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Zapnuté"
+
+# MČ: ak displej tak vypnutý. V iných prípadoch to môže byť inak. Treba skontrolovať pre všetky výskyty, prípadne dať rozdeliť.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=708580
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Vypnuté"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Použiť zmeny?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Zmeny sa nedajú použiť"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Môže to byť spôsobené obmedzeniami hardvéru."
+
+# GtkButton label
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Použiť"
+
+# GtkListStore row
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Späť"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Nastavenia displeja sú zakázané"
+
+# atkobject
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Viacero displejov"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Zlúčiť"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Zrkadliť"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Obsahuje hornú lištu a Aktivity"
+
+# atkobject
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Hlavný displej"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Nočné osvetlenie"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Na šírku"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Na výšku doprava"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Na výšku doľava"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Na šírku (obrátene)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientácia"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Rozlíšenie"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Obnovovacia frekvencia"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Úprava pre TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Mierka"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nočné osvetlenie nie je dostupné"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"To môže byť spôsobené použitým grafickým ovládačom, alebo tým, že sa "
+"pracovná plocha používa vzdialene"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Dočasne zakázané do zajtra"
+
+# button
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Reštartovať filter"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Nočné osvetlenie spôsobí, že bude farba obrazovky teplejšia. Tým sa pomôže "
+"znížiť námaha očí a zabrániť nespavosti."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Plánovanie"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Od západu slnka do východu slnka"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Ručné plánovanie"
+
+# GtkLabel label
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Časy"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Od"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Hodina"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minúta"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "dopoludnia"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "odpoludnia"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Do"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Teplota farieb"
+
+# desktop entry name
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Displeje"
+
+# desktop entry comment
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Volí spôsob použitia pripojených displejov a projektorov"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projektor;xrandr;Obrazovka;Rozlíšenie;Obnovovanie;Displej;Noc;Nočné;"
+"Svetlo;Osvetlenie;Modrá;Farba;Redshift;Západ;Východ;Slnka;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr ""
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr ""
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+#, fuzzy
+#| msgid "Camera is Turned Off"
+msgid "Secure Boot is Turned Off"
+msgstr "Kamera je vypnutá"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+# GtkLabel label
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#, fuzzy
+#| msgid "Password"
+msgid "Passed"
+msgstr "Heslo"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+#, fuzzy
+#| msgid "PPP failed"
+msgid "Failed"
+msgstr "PPP zlyhalo"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr ""
+
+# GtkLabel label
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Úroveň zabezpečenia 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+
+# GtkLabel label
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Úroveň zabezpečenia 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+
+# GtkLabel label
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Úroveň zabezpečenia 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+
+# GtkLabel label
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Úroveň zabezpečenia 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Toto zariadenie má rozšírenú ochranu pred hardvérovými bezpečnostnými "
+"problémami. Toto je najvyššia úroveň zabezpečenia zariadenia a poskytuje "
+"ochranu pred pokročilými bezpečnostnými hrozbami."
+
+# GtkLabel label
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Úroveň zabezpečenia"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Úrovne bezpečnosti nie sú pre toto zariadenie dostupné."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Úroveň 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Úroveň 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Úroveň 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Čiastočná ochrana po spustení zariadenia."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Žiadna ochrana po spustení zariadenia."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Vystavené závažným bezpečnostným hrozbám."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Obmedzená ochrana pred jednoduchými bezpečnostnými hrozbami."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Ochránené pred bežnými bezpečnostnými hrozbami."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Ochránené pred veľkým množstvom bezpečnostných hrozieb."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Žiadne udalosti"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection"
+msgstr "Verzia firmvéru"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware Write Protection Lock"
+msgstr "Verzia firmvéru"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Region"
+msgstr "Verzia firmvéru"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "Firmware BIOS Descriptor"
+msgstr "Verzia firmvéru"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr ""
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr ""
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr ""
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr ""
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Zašifrované pamäť RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Ochrana IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr ""
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Overenie jadra systému Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Odkladací priestor systému Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Uspať do pamäte RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+#, fuzzy
+#| msgid "Suspend"
+msgid "Suspend To Idle"
+msgstr "Uspať"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Kľúč platformy UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr ""
+
+# GtkDialog title
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Konfigurácia platformy TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Rekonštrukcia TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr ""
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr ""
+
+# GtkLabel label
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Aktualizácie firmvéru"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Atestácia firmvéru"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Overenie nástroja na aktualizáciu firmvéru"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Ladenie platformy"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Bezpečnostné kontroly procesora"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr ""
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "AMD Firmware Replay Protection"
+msgstr "Verzia firmvéru"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+#, fuzzy
+#| msgid "Firmware Version"
+msgid "AMD Firmware Write Protection"
+msgstr "Verzia firmvéru"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr ""
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Platné"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Neplatné"
+
+# zariadenie
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Nepovolené"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Uzamknuté"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Neuzamknuté"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Zašifrované"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Nezašifrované"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr ""
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+#, fuzzy
+#| msgid "Not calibrated"
+msgid "Not Tainted"
+msgstr "Nenakalibrované"
+
+# desktop entry name
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Nájdené"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+#| msgid "Not found"
+msgid "Not Found"
+msgstr "Nenájdené"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Podporované"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Nepodporované"
+
+#  1.2. page; 3. 4. GtkLabel label
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Zabezpečenie zariadenia"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Stav zabezpečenia firmvéru hostiteľa"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"obrazovka;zámok;uzamknutie;diagnostika;pád;súkromný;nedávny;dočasný;tmp;"
+"index;meno;názov;sieť;identita;súkromie;"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# grafika, AP typ
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Neznámy"
+
+# Typ OS
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bitový"
+
+# Typ OS
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bitový"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# grafika, AP typ
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Neznámy"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Nedostupná"
+
+# KeyListEntries name
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Systémové logo"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Názov zariadenia"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Model hardvéru"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Pamäť"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesor"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Kapacita disku"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Počíta sa…"
+
+# tree view column
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Názov OS"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID zostavy OS"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Typ OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Verzia prostredia GNOME"
+
+# GtkLabel label
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Načítava sa…"
+
+# listore item
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Systém na správu okien"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualizácia"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Aktualizácie softvéru"
+
+# GtkToolButton label
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Premenovanie zariadenia"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Názov zariadenia je použitý na identifikáciu tohoto zariadenia pri prezeraní "
+"v sieti, alebo pri párovaní zariadení Bluetooth."
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Názov zariadenia"
+
+# GtkLabel label
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Premenovať"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "O aplikácii"
+
+# desktop entry comment
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Zobrazuje informácie o vašom systéme"
+
+# desktop entry keywords
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"zariadenie;systém;informácie;pamäť;procesor;verzia;predvolené;predvolená;"
+"aplikácia;cd;dvd;usb;audio;video;disk;vymeniteľný;nosič;médium;médiá;"
+"spustenie;samospustenie;automatické;otvorenie;otváranie;"
+
+# KeyListEntries name
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Zvuky a multimédiá"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Stlmenie/obnovenie zvuku"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Znížiť hlasitosť"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Zvýšiť hlasitosť"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Stlmenie/obnovenie mikrofónu"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Spustiť prehrávač multimédií"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Prehrať (alebo prehrať/pozastaviť)"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pozastaviť prehrávanie"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Zastaviť prehrávanie"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Predchádzajúca stopa"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Nasledujúca stopa"
+
+# KeyListEntry description
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Vysunúť"
+
+# 1. KeyListEntries name; tab; tab;
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Písanie"
+
+# KeyListEntry description
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Prepnúť na ďalší zdroj vstupu"
+
+# KeyListEntry description
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Prepnúť na predchádzajúci zdroj vstupu"
+
+# KeyListEntries name
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Spúšťače"
+
+# KeyListEntry description
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Spustiť prehliadač pomocníka"
+
+# KeyListEntry description
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Spustiť kalkulačku"
+
+# KeyListEntry description
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Spustiť emailového klienta"
+
+# KeyListEntry description
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Spustiť webový prehliadač"
+
+# KeyListEntry description
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Domovský priečinok"
+
+# KeyListEntry description
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Hľadať"
+
+# KeyListEntries name
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Systém"
+
+# KeyListEntry description
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Odhlásiť sa"
+
+# KeyListEntry description
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Uzamknúť obrazovku"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Zjednodušenie ovládania"
+
+# KeyListEntry description
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Zapnúť alebo vypnúť lupu"
+
+# KeyListEntry description
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zväčšiť"
+
+# KeyListEntry description
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Zmenšiť"
+
+# KeyListEntry description
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Zapnúť alebo vypnúť čítačku obrazovky"
+
+# KeyListEntry description
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Zapnúť alebo vypnúť klávesnicu na obrazovke"
+
+# KeyListEntry description
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Zväčšiť text"
+
+# KeyListEntry description
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Zmenšiť text"
+
+# KeyListEntry description
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Zapnúť alebo vypnúť vysoký kontrast"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Nenašli sa žiadne zdroje vstupu"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Iný"
+
+# GtkDialog title
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Pridanie zdroja vstupu"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Vstupné metódy nemôžu byť použité na prihlasovacej obrazovke"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nebol vybraný žiadny zdroj vstupu"
+
+# GtkButton label
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Voľby"
+
+# GtkButton AtkObject
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Presunúť nahor"
+
+# GtkButton AtkObject
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Presunúť nadol"
+
+# GtkButton AtkObject
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Nastavenia"
+
+# GtkLabel label
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Zobraziť rozloženie klávesnice"
+
+# button
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Odstrániť"
+
+# KeyListEntry name
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Vlastné skratky"
+
+# https://bugzilla.gnome.org/show_bug.cgi?id=697213
+# PM: chcelo by to komentár od vývojárov čo to je - typujem že dajaká modifikačná klávesa na neštandardnej klávesnici
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Kláves alternatívnych znakov"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Kláves alternatívnych znakov môže byť použitý na zadávanie dodatočných "
+"znakov. Tie sú niekedy vyznačené ako tretia voľba na vašej klávesnici."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Ľavý kláves Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Pravý kláves Alt"
+
+# GtkListStore item
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Ľavý kláves Super"
+
+# GtkListStore item
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Pravý kláves Super"
+
+# GtkLabel label
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Kláves ponuky"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Pravý kláves Ctrl"
+
+# https://bugzilla.gnome.org/show_bug.cgi?id=697213
+# PM: chcelo by to komentár od vývojárov čo to je
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Kláves Compose"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Kláves Compose umožňuje zadávanie širokej škály znakov. Pre jeho použitie "
+"stlačte kláves Compose a potom postupnosť znakov.  Napríklad kláves Compose "
+"nasledovaný znakmi <b>C</b> a <b>o</b> zadá znak <b>©</b>, znak <b>a</b> "
+"nasledovaný znakom <b>'</b> zadá znak <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+# GtkListStore row
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+# toggle button
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+# GtkLabel label
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Zdroje vstupu môžu byť prepnuté pomocou klávesovej skratky %s.\n"
+"Tá môže byť zmenená v nastaveniach klávesových skratiek."
+
+# GtkLinkButton label;
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Zdroje vstupu"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Zahŕňa rozloženia klávesnice a vstupné metódy."
+
+# GtkDialog title
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Prepínanie zdroja vstupu"
+
+# GtkRadioButton label
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Použiť r_ovnaký zdroj pre všetky okná"
+
+# GtkRadioButton label
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Prepnúť zdroje vstupu _individuálne pre každé okno"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Záznam so špeciálnym znakom"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Metódy zadávania symbolov a variantov písmen pomocou klávesnice."
+
+# GtkLabel label
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Klávesové skratky"
+
+# KeyListEntry name
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Zobraziť a prispôsobiť skratky"
+
+# hlasitosť
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d upravených"
+msgstr[1] "%d upravená"
+msgstr[2] "%d upravené"
+
+# tab
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Obnoviť všetky skratky?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Obnovenie skratiek môže mať vplyv na vaše vlastné skratky. Táto akcia je "
+"nenávratná."
+
+# GtkButton label
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Zrušiť"
+
+# GtkListStore item; page
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Obnoviť všetky"
+
+# GtkListStore item; page
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Obnoviť všetky…"
+
+# tooltip
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Obnoví všetky skratky na ich pôvodné kombinácie klávesov"
+
+# 1.,2. treeviewcolumn;
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sekcia"
+
+# tab
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Skratky"
+
+# GtkToolButton label
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Pridať skratku"
+
+# PM: že ide o klávesovú vyplýva z kontextu
+# GtkDialog title
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Pridanie vlastných skratiek"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "Nastavuje vlastné skratky na spúšťanie aplikácií, skriptov a viac."
+
+# GtkToolButton label
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Pridať skratku"
+
+# GtkLabel label
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nenašla sa žiadna klávesová skratka"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"Skratka %s sa už používa pre akciu %s. Ak ju nahradíte, akcia %s bude "
+"zakázaná"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Zadajte novú skratku"
+
+# KeyListEntry name
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Nastavenie vlastnej skratky"
+
+# tab
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Nastaviť skratku"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Zadajte novú skratku na zmenu akcie %s."
+
+# PM: že ide o klávesovú vyplýva z kontextu
+# GtkDialog title
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Pridanie vlastnej skratky"
+
+# button
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "O_dstrániť"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Nah_radiť"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Nastaviť"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Stlačením klávesu Esc zrušíte a klávesom Backspace zakážete klávesovú "
+"skratku."
+
+# tree view column
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Názov"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Príkaz"
+
+# tab
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Skratka"
+
+# tab
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Nastaviť skratku…"
+
+# PK: to druhe neni v tom subore
+# PM: to druhé máš tu https://git.gnome.org/browse/gnome-control-center/tree/panels/universal-access/uap.ui?h=gnome-3-8#n77 - vyzerá to na výber programu pre klávesnicu na obrazovke asi to treba rozdeliť
+# 1. combobox item s položkou WPA 2.
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Žiadne"
+
+# tooltip
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Obnoví skratku na predvolenú hodnotu"
+
+# desktop entry name; GtkDialog title
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klávesnica"
+
+# desktop entry comment
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Mení klávesové skratky a nastavuje vaše predvoľby písania, rozložení "
+"klávesnice a zdroje vstupu"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"odkaz;skratka;pracovný;priestor;okno;zmena;veľkosti;lupa;priblíženie;"
+"kontrast;vstup;vstupný;zdroj;zámok;uzamknutie;hlasitosť;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Služby umiestnenia sú vypnuté"
+
+# label
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Žiadne aplikácie nemôžu získať informácie o umiestnení."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Žiadne aplikácie si nevyžiadali prístup k umiestneniu"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Ochráňte informácie o vašom umiestnení"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "umiestnenie;lokalita;gps;súkromie;súkromný;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofón je vypnutý"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Žiadne aplikácie nedokážu nahrávať zvuk."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Použitie mikrofónu umožňuje aplikáciám zachytávať a počúvať zvuky. Zakázanie "
+"mikrofónu môže spôsobiť nesprávne fungovanie niektorých aplikácií.\n"
+"\n"
+"Umožnite nasledovným aplikáciám používať mikrofón."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Žiadne aplikácie si nevyžiadali prístup k mikrofónu"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Ochráňte vaše konverzácie"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofón;nahrávanie;záznam;zaznamenávanie;aplikácia;súkromie;"
+
+# toggle button
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Vyskúšať vaše nastavenia"
+
+# GtkLabel label
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Všeobecné"
+
+# GtkLabel label
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Hlavné tlačidlo"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Nastaví poradie fyzických tlačidiel myší a touchpadov."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Ľavé"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Pravé"
+
+# GtkLabel label
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Myš"
+
+# GtkLabel
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Rýchlosť myši"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Prirodzené rolovanie"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Rolovaním sa posunie obsah a nie zobrazenie."
+
+# GtkLabel label
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Touchpad"
+
+# GtkLabel label
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Rýchlosť touchpadu"
+
+# GtkCheckButton label
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Kliknúť dotykom"
+
+# GtkCheckButton label
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Ťuknutím kliknete"
+
+# GtkCheckButton label
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Rolovať dvoma prstami"
+
+# GtkListStore row
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Rolovať hranou"
+
+# GtkLabel label
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Vyskúšajte kliknutie, dvojité kliknutie a rolovanie"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Päť kliknutí, čas pre GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dvojité kliknutie, hlavné tlačidlo"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Kliknutie, hlavné tlačidlo"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dvojité kliknutie, stredné tlačidlo"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Kliknutie, stredné tlačidlo"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dvojité kliknutie, sekundárne tlačidlo"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Kliknutie, sekundárne tlačidlo"
+
+# desktop entry name
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Myš a touchpad"
+
+# desktop entry comment
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Mení citlivosť vašej myši a touchpadu a umožňuje vybrať, či má byť pre "
+"ľavákov alebo pravákov"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Ukazovateľ;Kurzor;Klik;Dotyk;Dvojité;Tlačidlo;Trackball;Rolovanie;"
+"Posúvanie;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Aktívny _roh"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Dotykom horného ľavého rohu otvoríte prehľad aktivít."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Aktívne rohy obrazovky"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Potiahnutím okien k hornej, ľavej a pravej hrane obrazovky mu zmeníte "
+"veľkosť."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Pracovné priestory"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dynamické pracovné priestory"
+
+# GtkLabel label
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Automaticky odstraňuje prázdne pracovné priestory."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Pevný počet pracovných priestorov"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Určí počet trvalých pracovných priestorov."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Počet pracovných priestorov"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Viacero monitorov"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Pracovné priestory iba na _hlavnom displeji"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Pracovné priestory na všetkých _displejoch"
+
+# tab
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Prepínanie aplikácií"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Zahrnúť aplikácie zo všetkých _pracovných priestorov"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Zahrnúť aplikácie iba z _aktuálneho pracovného priestoru"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Súbežná práca"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Spravuje predvoľby pre produktivitu a súbežnú prácu"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"multitasking;súbežná;práca;produktivita;prispôsobiť;prispôsobenie;pracovná;"
+"plocha;aktívny roh;pracovné priestory;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ale nie. Niekde nastala chyba. Prosím, kontaktuje vášho dodávateľa softvéru."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager musí byť spustený."
+
+# button
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Ostatné zariadenia"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+# button label
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Pridať pripojenie"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nenastavené"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Nezabezpečená sieť (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Zabezpečená sieť (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Zabezpečená sieť (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Zabezpečená sieť (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Zabezpečená sieť"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Pripojené"
+
+# button atk;
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Voľby…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Zapnutím prístupového bodu sa odpojí od siete %s a nebude možné pristupovať "
+"na internet prostredníctvom Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Musí obsahovať minimálne 8 znakov"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Musí obsahovať maximálne %d znakov"
+msgstr[1] "Musí obsahovať maximálne %d znak"
+msgstr[2] "Musí obsahovať maximálne %d znaky"
+
+# GtkLabel label
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Zapnúť prístupový bod Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Prístupový bod Wi-Fi sprístupní ostatným vaše pripojenie k internetu "
+"vytvorením siete Wi-Fi, ku ktorej sa môžu pripojiť. Aby to bolo možné "
+"uskutočniť, musíte byť pripojený k internetu prostredníctvom iného zdroja "
+"ako Wi-Fi."
+
+# GtkLabel label
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Názov siete"
+
+# GtkLabel label
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Heslo"
+
+# GtkLabel label
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Vygeneruje náhodné heslo"
+
+# GtkLabel
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Automaticky generovať heslo"
+
+# GtkButton label
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Zapnúť"
+
+# GtkLabel label
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Zastaviť prístupový bod a odpojiť všetkých používateľov?"
+
+# button
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Zastaviť prístupový bod"
+
+# label
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Režim v lietadle"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Zakáže Wi-Fi, Bluetooth a mobilné širokopásmové pripojenie"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nenašiel sa žiadny Wi-Fi adaptér"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Uistite sa, že máte Wi-Fi adaptér pripojený a zapnutý"
+
+# label
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Režim v lietadle zapnutý"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Vypnutím použijete sieť Wi-Fi"
+
+# GtkLabel label
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Prístupový bod Wi-Fi aktívny"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobilné zariadenia sa môžu pripojiť oskenovaním QR kódu."
+
+# GtkLabel label
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Vypnúť prístupový bod Wi-Fi…"
+
+# desktop entry name
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Viditeľné siete"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager musí byť spustený"
+
+# GtkLabel label
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Zabezpečenie 802.1x"
+
+#  1.2. page; 3. 4. GtkLabel label
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Zabezpečenie"
+
+# tab
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Zachovaná"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Trvalá"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Náhodná"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabilná"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Tu zadaná adresa MAC bude použitá ako hardvérová adresa sieťového "
+"zariadenia, na ktorom je aktivované toto pripojenie. Táto funkcia je známa "
+"ako klonovanie adresy MAC. Príklad: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil č. %d"
+
+# zabezpečenie
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+# zabezpečenie
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+# zabezpečenie
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+# PM: toto je v NMA preložené
+# zabezpečenie
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Podnikové"
+
+# zabezpečenie
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Žiadne"
+
+# naposledy použité
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nikdy"
+
+# naposledy použité
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "pred %i dňami"
+msgstr[1] "pred %i dňom"
+msgstr[2] "pred %i dňami"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+# rýchlosť pripojenia
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mbit/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+# sila signálu
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Žiadny"
+
+# sila signálu
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Slabý"
+
+# sila signálu
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+# sila signálu
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Dobrý"
+
+# sila signálu
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Vynikajúci"
+
+# GtkLabel label
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Adresa IPv4"
+
+# GtkLabel label
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Adresa IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Adresa IP"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+# GtkLabel label
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "Systém pre názvy domén (DNS)"
+
+# gtk button
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Zabudnúť pripojenie"
+
+# gtk button
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Odstrániť profil pripojenia"
+
+# gtk button
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Odstrániť VPN"
+
+# 1.desktop entry name;2. page; 3. GtkListStore item
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Podrobnosti"
+
+# PM: rod? na akých miestach tento spinbutton je? Ja to vidím pri MTU, ale možno je to aj inde
+# DK: nenechame tvar: "automaticky" ?
+# spinbutton default
+# doriesit v master vetve
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automaticky"
+
+# 1.2.3. page; GtkListStore item
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Totožnosť"
+
+# button atk
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Odstrániť adresu"
+
+# button atk
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Odstrániť smerovanie"
+
+# GtkListStore item
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+# GtkListStore item
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+# GtkListStore item
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Žiadne"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128 bitový kľúč (šestnástkový alebo ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128 bitové heslo"
+
+# liststore item
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamické WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "Osobný WPA a WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "Podnikový WPA a WPA 2"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "Osobný WPA3"
+
+# GtkLabel label
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signál"
+
+# GtkLabel label
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Rýchlosť pripojenia"
+
+# GtkLabel label
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hardvérová adresa"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Podporované frekvencie"
+
+# GtkLabel label
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Predvolené smerovanie"
+
+# pripojenie - je za tým čas kedy bolo definované pripojenie naposledy použité
+# GtkLabel
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Naposledy použité"
+
+# GtkCheckButton label
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Pripojiť _automaticky"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Sprístupniť _ostatným používateľom"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"O_bmedzené pripojenie: má obmedzené dáta alebo sa môžu účtovať poplatky"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Aktualizácie softvéru a iné veľké preberania nebudú automaticky spustené."
+
+# GtkLabel label
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Názov"
+
+# GtkLabel label
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Adresa _MAC"
+
+# GtkLabel label
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_aximálna prenosová jednotka (MTU)"
+
+# GtkLabel label
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonovaná adresa"
+
+# PM: viaže sa k MTU navrhujem tu dať medzeru a do MTU doplniť (v bajtoch)
+# PK: preco nie plural forms?
+# PM: pretoze by to zaviselo od hodnoty na spinbutone a to by sa musel formular pri kazdej zmene refreshovat, neviem ci budú vývojári takúto vec spravit. Navrhujem urobit to zatial tak ako som povedal a ked to vývojári náhodou budú ochotní urobiť tak to potom zmeníš.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkLabel label
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bajtov"
+
+# GtkLabel label
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Metóda IPv_4"
+
+# GtkComboBox item
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Zistiť automaticky (DHCP)"
+
+# ListStore item (Manual, Automatic (DHCP))
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Len lokálne pripojenie"
+
+# GtkComboBox item
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Ručné"
+
+# gtk radio button
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Zakázať"
+
+# GtkComboBox item
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Sprístupnené ostatným počítačom"
+
+# GtkLabel label
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresy"
+
+# GtkLabel label
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresa"
+
+# label
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Maska siete"
+
+# label
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Brána"
+
+# GtkListStore (tp;aui;bnc;mii); GtkListStore (10Mb/s, 100Mb/s ...)
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Zistiť automaticky"
+
+# GtkSwitch AtkObject
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatické zistenie adresy DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Adresy serverov DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "IP adresy oddeľte čiarkami"
+
+# GtkLabel label
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Smerovania"
+
+# GtkSwitch AtkObject
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatické zistenie smerovania"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrika"
+
+# GtkCheckButton label
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Použiť toto pripojenie _iba na zdroje v jeho sieti"
+
+# GtkLabel label
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Metóda IPv_6"
+
+# PM asi tiež Zistiť automaticky
+#  ListStore item (Automatic, manual, link-local)
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatické, len DHCP"
+
+# label
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Predpona"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Nepodarilo sa otvoriť nástroj na zmenu pripojení"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Nový profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Neplatné nastavenie %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Neplatné nastavenie %s"
+
+# label
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importovať zo súboru…"
+
+# window title
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Pridanie VPN"
+
+# GtkLabel label
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Z_abezpečenie"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Nedá sa importovať pripojenie VPN"
+
+# PK: recognized moze byt aj nieco ze to neni standard
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Súbor „%s“ sa nepodarilo prečítať alebo neobsahuje rozpoznané informácie o "
+"pripojení VPN\n"
+"\n"
+"Chyba: %s."
+
+# window title
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Výber súboru na importovanie"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Súbor s názvom „%s“ už existuje."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Nahradiť"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Chcete nahradiť %s s pripojením VPN, ktoré sa pokúšate uložiť?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Pripojenie VPN sa nedá exportovať"
+
+# druhe je subor (moze byt none)
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Nepodarilo sa exportovať pripojenie VPN „%s“ do %s.\n"
+"\n"
+"Chyba: %s."
+
+# window title
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exportovanie pripojenia VPN"
+
+# GtkLabel label
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Chyba: nepodarilo sa načítať program na úpravu pripojenia VPN)"
+
+# GtkLabel label
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "Identifikátor obsluhy (_SSID)"
+
+# GtkLabel label
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "Identifikátor základnej obsluhy (_BSSID)"
+
+# desktop entry comment
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Ovláda spôsob pripojenia k internetu"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"sieť;IP;LAN;proxy;sprostredkovateľ;WAN;širokopásmové;modem;Bluetooth;vpn;DNS;"
+
+# desktop entry comment
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Ovláda spôsob pripojenia k sieťam Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"sieť;bezdrôtová;Wi-Fi;wifi;IP;LAN;širokopásmové;pripojenie;DNS;hotspot;"
+"aktívny;bod;"
+
+# last used
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nikdy"
+
+# last used
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "dnes"
+
+# last used
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "včera"
+
+# GtkLabel label
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Naposledy použité"
+
+# GtkLabel label
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Drôtové"
+
+# liststore item
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Pridať nové pripojenie"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Podrobnosti o vybraných sietiach, vrátane hesla a vlastných nastavení, budú "
+"stratené."
+
+# GtkButton label
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Zabudnúť"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Známe siete Wi-Fi"
+
+# button
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Zabudnúť"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Systémové pravidlá zakazujú použitie režimu prístupového bodu"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Bezdrôtové zariadenie nepodporuje režim prístupového bodu"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Ak nezadáte URL konfigurácie, použije sa automatické zistenie "
+"sprostredkovateľa."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Toto sa neodporúča pre nedôveryhodné verejné siete."
+
+# GtkSwitch AtkObject
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Vypnúť zariadenie"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktívne"
+
+# GtkLabel label
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+# GtkLabel label
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Poskytovateľ"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Sieťový sprostredkovateľ (proxy)"
+
+# GtkLabel label
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Sprostredkovateľ _HTTP"
+
+# GtkLabel label
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Sprostredkovateľ H_TTPS"
+
+# GtkLabel label
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Sprostredkovateľ _FTP"
+
+# GtkLabel label
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Hostiteľ _Socks"
+
+# GtkLabel label
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorovať hostiteľov"
+
+# GtkSpinButton AtkObject
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Port sprostredkovateľa _HTTP"
+
+# GtkSpinButton AtkObject
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Port sprostredkovateľa H_TTPS"
+
+# GtkSpinButton AtkObject
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Port sprostredkovateľa _FTP"
+
+# GtkSpinButton AtkObject
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Port sprostredkovateľa Socks"
+
+# GtkLabel label
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_URL konfigurácie"
+
+# GtkSwitch AtkObject
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Vypnúť pripojenie VPN"
+
+# GtkLabel label
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Názov siete"
+
+# GtkLabel label
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Typ zabezpečenia"
+
+# GtkLabel label
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Heslo"
+
+# GtkSwitch AtkObject
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Vypnúť Wi-Fi"
+
+# GtkLabel label
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Viac volieb…"
+
+# GtkButton label
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Pripojiť sa k skrytej sieti…"
+
+# GtkLabel label
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Zapnúť _prístupový bod Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "Známe siete _Wi-Fi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Neznámy stav"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Nespravované"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Nedostupné"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Pripája sa"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Vyžadované je overenie totožnosti"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Odpája sa"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Pripojenie zlyhalo"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Stav neznámy (chýba)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Nastavenie zlyhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Nastavenie IP zlyhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Platnosť nastavenia IP vypršala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Boli požadované tajné informácie, ale neboli poskytnuté"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Žiadateľ 802.1x bol odpojený"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Zlyhalo nastavenia žiadateľa 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Žiadateľ 802.1x zlyhal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Overenie totožnosti žiadateľa 802.1x trvalo príliš dlho"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Služba PPP zlyhala pri štarte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Služba PPP bola odpojená"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP zlyhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Klient DHCP zlyhal pri štarte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Chyba klienta DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Klient DHCP zlyhal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Nepodarilo sa spustiť službu sprístupneného pripojenia"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Služba sprístupneného pripojenia zlyhala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Nepodarilo sa spustiť službu AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Chyba služby AutoIP"
+
+# AutoIP je termin, ako napr. DHCP
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Služba AutoIP zlyhala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linka je zaneprázdnená"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Nie je oznamovací tón"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Nepodarilo sa pripojiť k žiadnemu poskytovateľovi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Vypršal časový limit pre požiadavku na vytáčanie"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Pokus o vytáčanie zlyhal"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Inicializácia modemu zlyhala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Zlyhalo vybratie určeného APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Nehľadá siete"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Registrácia siete bola zamietnutá"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Vypršal limit pre registráciu siete"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Nepodarilo sa zaregistrovať v požadovanej sieti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Zlyhala kontrola kódu PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Firmvér pre toto zariadenie môže chýbať"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Pripojenie sa stratilo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Existujúce pripojenie bolo odhadnuté"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Nenájdený modem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth pripojenie zlyhalo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Karta SIM nie je vložená"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Vyžadovaný kód Pin pre kartu SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Vyžadovaný kód Puk pre kartu SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Zlá karta SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Závislosť pripojenia zlyhala"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Chýba firmvér"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kábel odpojený"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "nedefinovaná chyba v zabezpečení protokolu 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "Nebol vybratý žiadny súbor"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "nešpecifikovaná chyba pri overovaní súboru metódy protokolu eap"
+
+# PK: pkcs#12 je zauzivane
+# file filter
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Súkromné kľúče typu DER, PEM, PKCS#12 alebo PGP"
+
+# GtkLabel label
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Certifikáty typu DER alebo PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "chýba súbor PAC protokolu EAP-FAST"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Súbory PAC (*.pac)"
+
+# liststore item
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+# liststore item
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+# PAC provisioning
+# GtkListStore item
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonymné"
+
+# PAC provisioning
+# GtkListStore item
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Overením totožnosti"
+
+# PAC provisioning
+# GtkListStore item
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Oba spôsoby"
+
+# PM: je to dobre? je to label pred vstupným polom. Asi je to nejaký spoločný názov v prípade anonymného spojenia. zdá sa mi to nelogické. ak je to nejaký zadaný názov už to nie je anonym
+# GtkLabel label
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anony_mná identita"
+
+# PM: nebude lepšie súbor s povereniami?
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Súbor PAC"
+
+# DK:dialog title
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Výber súboru PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Vnútorné overenie totožnosti"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Umožniť automatické zaobstarávanie PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "chýba používateľské meno protokolu EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "chýba heslo protokolu EAP-LEAP"
+
+# GtkLabel label
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Používateľské meno"
+
+# GtkLabel label
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Heslo"
+
+# GtkCheckButton label
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Zobraziť heslo"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "neplatný certifikát protokolu EAP-PEAP CA: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "neplatný certifikát protokolu EAP-PEAP CA: certifikát nebol určený"
+
+# liststore (MSCHAPv2,GTC)
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+# PEAP version
+# GtkListStore item
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Verzia 0"
+
+# PEAP version
+# GtkListStore item
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Verzia 1"
+
+# PM: to CA v zátvorke by som tam asi už nedával lebo význam skratky je preložený
+# GtkLabel label
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "_Certifikát certifikačnej autority (CA)"
+
+# DK:všetko dialog title
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Výber certifikátu certifikačnej autority"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Nie je vyžadovaný žiadny certifikát CA"
+
+# GtkLabel label
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Verzia PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "chýba používateľské meno protokolu EAP"
+
+# DK:dialog title
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "chýba heslo EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "chýba identita protokolu EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "neplatný certifikát protokolu EAP-TLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "neplatný certifikát protokolu EAP-TLS CA: certifikát nebol určený"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "neplatný súkromný kľúč protokolu EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "neplatný certifikát používateľa protokolu EAP-TLS: %s"
+
+# gtkdialog title
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Nezašifrované súkromné kľúče nie sú bezpečné"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Zvolený súkromný kľúč sa nejaví byť chránený heslom. To by mohlo umožniť "
+"zneužitiu bezpečnostných poverení. Prosím, zvoľte súkromný kľúč chránený "
+"heslom\n"
+"\n"
+"(Váš súkromný kľúč môžete opatriť heslom pomocou nástroja openssl)"
+
+# DK:button
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Vybrať váš osobný certifikát"
+
+# DK:button
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Vybrať váš súkromný kľúč"
+
+# GtkLabel label
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentita"
+
+# GtkLabel label
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Používateľský certifikát"
+
+# GtkLabel label
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Súkromný _kľúč"
+
+# GtkLabel label
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Heslo súkromného kľúča"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "neplatný certifikát protokolu EAP-TTLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "neplatný certifikát protokolu EAP-TTLS CA: certifikát nebol určený"
+
+# litstore item
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+# litstore item
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+# liststore item
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (bez EAP)"
+
+# litstore item
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+# GtkLabel
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Doména"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Neznáma chyba pri overovaní bezpečnosti štandardu 802.1X"
+
+# litstore item
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+# litstore item
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+# litstore item
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunelované TLS"
+
+# litstore item
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Chránený EAP (PEAP)"
+
+# GtkLabel label
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Overenie totožnosti"
+
+# file chooser dialog title
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Vybrať súbor"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "chýba používateľské meno protokolu leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "chýba heslo protokolu leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Chýba heslo k sieti Wi-Fi."
+
+# GtkLabel label
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Typ"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "chýba kľúč zabezpečenia wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"neplatný kľúč zabezpečenia wep: kľúč o dĺžke %zu musí obsahovať iba "
+"hexadecimálne čísla"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"neplatný kľúč zabezpečenia wep: kľúč o dĺžke %zu musí obsahovať iba znaky v "
+"kódovaní ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"neplatný kľúč zabezpečenia wep: nesprávna dĺžka kľúča %zu. Kľúč musí byť o "
+"dĺžke buď 5/13 (ascii) alebo 10/26 (hexadecimálne)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "neplatný kľúč zabezpečenia wep: heslo nemôže byť prázdne"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "neplatný kľúč zabezpečenia wep: heslo musí byť kratšie ako 64 znakov"
+
+# WEP index
+# GtkListStore item
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (predvolený)"
+
+# Overenie totožnosti
+# GtkListStore item
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Bez overovania"
+
+# Overenie totožnosti
+# GtkListStore item
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Spoločným kľúčom"
+
+# GtkLabel label
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Kľúč"
+
+# GtkCheckButton label
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Zobraziť kľúč"
+
+# PM: ak som tomu dobre porozumel niektoré systémy umožňujú definovať 4 klúče, dosť dobre som ale nepochopil na čo je to dobré ked klient moze použit len jeden
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP inde_x"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"neplatné zabezpečenie wpa-psk: neplatná dĺžka kľúča %zu. Musí byť o dĺžke "
+"[8,63] bajtov alebo 64 hexadecimálnych čísel"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"neplatné zabezpečenie wpa-psk: nedá sa interpretovať 64 bajtový kľúč ako "
+"hexadecimálny"
+
+# policy_settings
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "O_známenia"
+
+# policy_settings
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Zvukové va_rovania"
+
+# policy_settings
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Vy_skakovacie oznámenia"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Oznámenia sa budú naďalej zobrazovať v zozname oznámení, aj keď sú "
+"vyskakovacie oznámenia zakázané."
+
+# policy_settings
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Zobrazovať obsah správ vo vyskakova_cích oznámeniach"
+
+# policy_settings
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "O_známenia v uzamknutej obrazovke"
+
+# policy_settings
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Zobrazovať _obsah správ v uzamknutej obrazovke"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Nevyr_ušovať"
+
+# desktop entry name
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Oznámenia v _uzamknutej obrazovke"
+
+# desktop entry comment
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Ovláda zobrazovanie oznámení a ich obsah"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Oznámenia;Bublina;Správa;Oblasť upozornení;Vyskakovacie;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Iný"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "Účet %s bol odstránený"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Chyba pri odstraňovaní účtu"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Vrátiť späť"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Zavrieť oznámenie"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Pripojte sa k vašim údajom v cloude"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Bez pripojenia k internetu — pripojte sa pre nastavenie nového účtu služieb"
+
+# GtkButton label
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Pridať účet"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Účet služby %s"
+
+# GtkToolButton label
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Odstrániť účet"
+
+# desktop entry name
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Účty služieb"
+
+# desktop entry comment
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Pripojí vás k vašim účtom sieťových služieb a rozhodne na čo sa použijú"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;web;on-line;rozhovor;chat;kalendár;e-mail;mail;"
+"email;pošta;kontakt;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Neznámy čas"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minút"
+msgstr[1] "%i minúta"
+msgstr[2] "%i minúty"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i hodín"
+msgstr[1] "%i hodina"
+msgstr[2] "%i hodiny"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s, %i %s"
+
+# prasácky kód
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "hodín"
+msgstr[1] "hodina"
+msgstr[2] "hodiny"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minút"
+msgstr[1] "minúta"
+msgstr[2] "minúty"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s do úplného nabitia"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Výstraha: zostáva %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "zostáva %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Úplne nabitá"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Nenabíja sa"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Vybitá"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Nabíja sa"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Vybíja sa"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Bezdrôtová myš"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Bezdrôtová klávesnica"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Neprerušiteľný zdroj napájania (UPS)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Vreckový počítač (PDA)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobilný telefón"
+
+#  PM: takýto preklad je v inom module
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Prenosný prehrávač"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Počítač"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Herné vstupné zariadenie"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batéria"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Hlavná"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Dodatočná"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batérie"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Pri neč_innosti"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Uspať"
+
+# label
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Vypnúť"
+
+# GtkListStore item
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Hibernovať"
+
+# chooser_button
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Nespraviť nič"
+
+#  label
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Pri napájaní z batérie"
+
+# PK: ked je zastrceny v zasuvke
+#  label
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Pri napájaní zo siete"
+
+# naposledy použité
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nikdy"
+
+# label
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatické uspanie"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "Výkonný režim je dočasne zakázaný kvôli vysokej pracovnej teplote."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Zistené lono: výkonný režim je dočasne nedostupný. Obnovíte ho presunutím "
+"zariadenia na stabilný povrch."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Výkonný režim je dočasne zakázaný."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Vybitá batéria: je povolený šetrič energie. Predchádzajúci režim bude "
+"obnovený po dostatočnom nabití batérie."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Režim šetriča energie aktivovaný aplikáciou „%s“."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Výkonný režim aktivovaný aplikáciou „%s“."
+
+#  * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# approx_time; Oneskorenie
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minút"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minút"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minút"
+
+# MČ: pre color.ui je to odhadovaný čas, pre power.ui po akom čase má uspať počítač., pre privacy.ui po akom čase má vypnúť obrazovku. Bude to treba asi dať rozdeliť.
+# MČ: Odhadujem, že pri ostatných reťazcoch to bude podobné, len sa ich pokusim pooznačovať, skús to preveriť.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# 1. approx_time; 2. Oneskorenie; 3
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minút"
+
+# Oddialiť o
+# GtkListStore item
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minút"
+
+# Oddialiť o
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 hodinu"
+
+# Oddialiť o
+# GtkListStore item
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minút"
+
+# Oddialiť o
+# GtkListStore item
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minút"
+
+# Oddialiť o
+# GtkListStore item
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minút"
+
+# Oddialiť o
+# GtkListStore item
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 hodiny"
+
+# GtkListStore item
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Režim spotreby energie"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Ovplyvní výkon systému a spotrebu energie."
+
+# label
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Voľby šetrenia energie"
+
+# GtkSwitch AtkObject
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatický jas obrazovky"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Jas obrazovky sa upraví podľa okolitého svetla."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Stmaviť obrazovku"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Zníži jas obrazovky, keď počítač nie je aktívny."
+
+# MČ: nemám to ako teraz posúdiť, ale nie sú na rovnakej obrazovke s "High Contrast"? Potom je tam problém s akcelerátorom.
+# PM: je to v samostatnom okne vid web glade runner
+# GtkLabel
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Vyprázdniť _obrazovku"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Vypne obrazovku po časovom úseku nečinnosti."
+
+# label
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatický šetrič energie"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Povolí režim šetriča energie, keď je batéria vybitá."
+
+# GtkDialog title
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatické uspanie"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pozastaví počítač po časovom úseku nečinnosti."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Správanie _tlačidla napájania"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Zobraziť _percentá batérie"
+
+# GtkDialog title
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatické uspanie"
+
+# GtkLabel label
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Pripojený k sieti"
+
+# GtkLabel label
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Napájaný z _batérie"
+
+# GtkLabel label
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Oddialiť o"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Výkon"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Vysoký výkon a spotreba energie."
+
+# vľavo - vpravo
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Vyvážený"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Štandardný výkon a spotreba energie."
+
+# label
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Šetrič energie"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Znížený výkon a spotreba energie."
+
+# desktop entry name
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Napájanie"
+
+# desktop entry comment
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Zobrazuje stav vašej batérie a umožňuje zmenu nastavení šetrenia energie"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Napájanie;Uspať;Hibernovať;Batéria;Jas;Stmavenie;Prázdny;Displej;Obrazovka;"
+"DPMS;Nečinnosť;Energia;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Tlačiareň „%s“ bola odstránená"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Pridávanie novej tlačiarne zlyhalo."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Nepodarilo sa načítať súbor používateľského rozhrania: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Odomknutím pridáte tlačiarne a zmeníte nastavenia"
+
+# desktop entry name
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Tlačiarne"
+
+# desktop entry comment
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Pridáva tlačiarne, zobrazuje úlohy a umožňuje vám rozhodnúť ako sa bude "
+"tlačiť"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Tlačiareň;Rad;Fronta;Tlač;Papier;Atrament;Toner;"
+
+# GtkToolButton label
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Pridať tlačiareň"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "Odo_mknúť"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Nenašli sa žiadne tlačiarne"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Zadajte sieťovú adresu, alebo vyhľadajte tlačiareň"
+
+# GtkLabel label
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Vyžaduje sa overenie totožnosti"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Zadajte používateľské meno a heslo pre zobrazenie tlačiarní na tlačovom "
+"serveri."
+
+# GtkLabel label
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Meno používateľa"
+
+# 1.desktop entry name;2. page; 3. GtkListStore item
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Podrobnosti o tlačiarni %s"
+
+# gtk_menu_item
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Nenašiel sa žiadny vhodný ovládač"
+
+# file chooser dialog title
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Výber súboru PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Súbory popisu PostScriptu tlačiarne (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Názvy tlačiarní nemôžu obsahovať MEDZERU, TABULÁTOR, znak # alebo /"
+
+# GtkLabel label
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Umiestnenie"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Ovládač"
+
+# gtk_image_menu_item
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Hľadajú sa preferované ovládače…"
+
+# gtkbutton label
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Vyhľadať ovládače"
+
+# gtk_image_menu_item
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Vybrať z databázy…"
+
+# gtk_image_menu_item
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Inštalovať súbor PPD…"
+
+# GtkDialog title
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Výber ovládača pre tlačiareň"
+
+# GtkLabel label
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Načítava sa databáza ovládačov…"
+
+# tlačidlo
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Vybrať"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Tlačiareň s technológiou JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Tlačiareň protokolu LPD"
+
+# PK: prosim, ak mas tlaciaren otestuj, ja nemam
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Jednostranne"
+
+# ako sa prevrati stranka
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Dlhý okraj (štandard)"
+
+# ako sa prevrati stranka
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Krátky okraj (prevrátiť)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Na výšku"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Na šírku"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Opačne na šírku"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Opačne na výšku"
+
+# GtkButton label
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Pokračovať"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pozastaviť"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Čaká"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pozastavená"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Vyžaduje sa overenie totožnosti"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Spracúva sa"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Zastavená"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Zrušená"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Prerušená"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Dokončená"
+
+# tooltip
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Presunie túto úlohu navrch fronty"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u úloh vyžaduje overenie totožnosti"
+msgstr[1] "%u úloha vyžaduje overenie totožnosti"
+msgstr[2] "%u úlohy vyžadujú overenie totožnosti"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Aktívne úlohy"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Zadajte poverenia na tlač z tlačiarne %s."
+
+# GtkLabel
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Doména"
+
+# GtkButton label
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "Overiť _totožnosť"
+
+# GtkButton label
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Vymazať všetky"
+
+# GtkButton label
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Overiť totožnosť"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Žiadne aktívne úlohy tlačiarne"
+
+# headerbar
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Odomknutie tlačového servera"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Odomknúť %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Zadajte používateľské meno a heslo pre zobrazenie tlačiarní na serveri %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Vyhľadávajú sa tlačiarne"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Sériový Port"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Paralelný port"
+
+# GtkLabel label
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Umiestnenie: %s"
+
+# GtkLabel label
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adresa: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Server vyžaduje overenie totožnosti"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Obojstranne"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Typ papiera"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Zdroj papiera"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Výstupný zásobník"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Rozlíšenie"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Predfiltrovanie pre GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Stránok na stranu"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Obojstranne"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientácia"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Všeobecné"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Nastavenie stránky"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Inštalované vybavenie"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Úloha"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Kvalita obrázkov"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Farba"
+
+# PM: toto asi nebude dobre
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Dokončovanie"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Skúšobná stránka"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Skúšobná stránka"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Automatický výber"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Predvolené hodnoty tlačiarne"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Vkladať len písma GhostScript"
+
+# MČ: PostScript Level 1 - PostScript Verzie 1, ale pri PS sa verzie nazývajú Level. teda aspoň ja to tak chápem
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Konvertovať na PS verzie 1"
+
+# MČ: PostScript Level 1 - PostScript Verzie 1, ale pri PS sa verzie nazývajú Level. teda aspoň ja to tak chápem
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Konvertovať na PS verzie 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Žiadne predfiltrovanie"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Výrobca"
+
+# GtkDialog title
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Žiadne aktívne úlohy"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u úloh"
+msgstr[1] "%u úloha"
+msgstr[2] "%u úlohy"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Čistenie tlačových hláv"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Málo tonera"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Minul sa toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Málo vývojky"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Minula sa vývojka"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Málo farby"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Minula sa farba"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Otvorený kryt"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Otvorené dvierka"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Málo papiera"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Minul sa papier"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Vypnutá"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Zastavená"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Odpadová nádržka takmer plná"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Odpadová nádržka plná"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Fotovalcu onedlho skončí životnosť"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Fotovalec už nie je funkčný"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Pripravená"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Neprijíma úlohy"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Pracuje"
+
+# GtkLabel
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Voľby tlače"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Podrobnosti o tlačiarni"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Použiť ako predvolenú tlačiareň"
+
+# GtkToolButton label
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Vyčistiť tlačové hlavy"
+
+# GtkToolButton label
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Odstrániť tlačiareň"
+
+# GtkLabel label
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Úroveň atramentu"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Prosím, vykonajte reštart, keď bude problém vyriešený."
+
+# button
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Reštartovať"
+
+# GtkToolButton label
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Pridať tlačiareň…"
+
+# desktop entry name
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Žiadne tlačiarne"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Ľutujeme, ale systémová služba tlače\n"
+"    sa zdá byť nedostupná."
+
+# TODO lepšia alternatíva?
+# GtkDialog title; GtkLabel label
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Formáty"
+
+# GtkDialog title
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Vyhľadajte miestne nastavenia…"
+
+# TODO lepšia alternatíva?
+# GtkDialog title; GtkLabel label
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Spoločné formáty"
+
+# TODO lepšia alternatíva?
+# GtkDialog title; GtkLabel label
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Všetky formáty"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Žiadne výsledky vyhľadávania"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Vyhľadávané môžu byť krajiny alebo jazyky."
+
+# GtkLabel label
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Ukážka"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperiálne"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrické"
+
+# GtkLabel label
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Dátumy"
+
+# desktop entry name
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dátumy a časy"
+
+# GtkLabel label
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Čísla"
+
+# GtkLabel label
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Miery"
+
+# GtkLabel label
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papier"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Jazyk a formát budú zmenené po ďalšom prihlásení"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Odhlásiť sa…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Nastavenia jazyka je použité pre text rozhrania a webové stránky. Formáty sú "
+"použité pre čísla, dátumy a meny."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Váš účet"
+
+# GtkLabel
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Jazyk"
+
+# TODO lepšia alternatíva?
+# GtkDialog title; GtkLabel label
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Formáty"
+
+# toggle button
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Prihlasovacia obrazovka"
+
+# desktop entry name
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Región a jazyk"
+
+# desktop entry comment
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Vyberá váš zobrazovaný jazyk a formáty"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Jazyk;Rozloženie;Klávesnica;Vstup;"
+
+# chooser_button
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Spýtať sa, čo robiť"
+
+# chooser_button
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Nespraviť nič"
+
+# chooser_button
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Otvoriť priečinok"
+
+# window title
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Ostatné nosiče"
+
+# window heading
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Vyberte si aplikáciu pre audio CD"
+
+# window heading
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Vyberte si aplikáciu pre video DVD"
+
+#  window heading
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Vyberte si aplikáciu, ktorá sa spustí pri pripojení hudobného prehrávača"
+
+# window heading
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Vyberte si aplikáciu, ktorá sa spustí pri pripojení fotoaparátu"
+
+# window heading
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Vyberte si aplikáciu pre CD so softvérom"
+
+# listore item
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "audio DVD"
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "prázdny disk Blu-ray"
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "prázdny disk CD"
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "prázdny disk DVD"
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "prázdny disk HD DVD"
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "video disk Blu-ray "
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "elektronická čítačka kníh"
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "video disk HD DVD"
+
+# PM: je to názov formátu od Kodaku
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+# listore item
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "softvér systému Windows"
+
+# GtkLabel label
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Vyberte si, ako sa bude zaobchádzať s nosičmi"
+
+# GtkLabel label
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "A_udio CD"
+
+# GtkLabel label
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "V_ideo DVD"
+
+# GtkLabel label
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Hudobný prehrávač"
+
+# GtkLabel label
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Softvér"
+
+# GtkButton label
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Ostatné nosiče…"
+
+# GtkCheckButton label
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nikdy sa nepýtať ani nespúšťať programy pri vložení nosiča"
+
+# GtkLabel label
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Vyberte si, ako sa bude zaobchádzať s inými nosičmi"
+
+# GtkLabel label
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Akcia:"
+
+# GtkLabel label
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Typ:"
+
+# 1. listore item; tab
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Vymeniteľné nosiče"
+
+# 1. listore item; tab
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Nastavuje vymeniteľné nosiče"
+
+# desktop entry keywords
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"zariadenie;systém;predvolené;aplikácia;uprednostňované;cd;dvd;usb;audio;"
+"video;disk;vymeniteľný;nosič;médium;médiá;spustenie;samospustenie;"
+"automatické;otvorenie;otváranie;"
+
+# GtkListStore item
+# Uzamknut obrazovku pri necinnosti za
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "vypnutím obrazovky"
+
+# GtkListStore item
+# za
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekúnd"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minútu"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minúty"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minúty"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minút"
+
+# MČ: pre color.ui je to odhadovaný čas, pre power.ui po akom čase má uspať počítač., pre privacy.ui po akom čase má vypnúť obrazovku. Bude to treba asi dať rozdeliť.
+# MČ: Odhadujem, že pri ostatných reťazcoch to bude podobné, len sa ich pokusim pooznačovať, skús to preveriť.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# 1. approx_time; 2. Oneskorenie; 3
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minút"
+
+# Oddialiť o
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 hodinu"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minútu"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minúty"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minúty"
+
+# Blank Screen
+# GtkListStore item
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minúty"
+
+# Blank Screen
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minút"
+
+# Blank Screen
+# GtkListStore item
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minút"
+
+# Blank Screen
+# GtkListStore item
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minút"
+
+# Blank Screen
+# GtkListStore item
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minút"
+
+#  * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# approx_time; Oneskorenie
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minút"
+
+# naposledy použité
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nikdy"
+
+# 2 GtkDialog title
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Uzamknutie obrazovky"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Automatické uzamykanie obrazovky zabraňuje ostatným pristupovať k vášmu "
+"počítaču, pokiaľ ste preč."
+
+# PK: toto je divne, skor vypnut obrazovku
+# PM: no blank screen praveze nie je vypnutie obrazovky, balnk screen je vyplnenie obrazovky čiernou ale je stále zapnutá. Používa sa to pri starých monitoroch, ktoré zobrazujú pri ATM hlásku ze nie je signál.
+# label
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Oneskorenie vyprázdnenia obrazovky"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Doba nečinnosti, po ktorej sa vyprázdni obrazovka."
+
+# GtkLabel label
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "A_utomatické uzamykanie obrazovky"
+
+# GtkLabel label
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Oneskorenie a_utomatického uzamykania obrazovky"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Doba, po ktorej sa obrazovka vyprázdni, keď je obrazovka automaticky "
+"uzamknutá."
+
+# GtkLabel label
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Zobrazovať oznámenia v uzamknutej obrazovke"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Zakázať nové zariadenia _USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Zabráni novým zariadeniam USB ovplyvniť systém počas uzamknutej obrazovky."
+
+# desktop entry name
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Súkromie obrazovky"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Obmedziť pozorovací uhol"
+
+# GtkDialog title
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Nastavenia obrazovky"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "obrazovka;zámok;uzamknutie;súkromie;súkromná;"
+
+# file chooser dialog title
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Výber miesta"
+
+# liststore item
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Ok"
+
+# GtkDialog title
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Vyhľadávanie v umiestneniach"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Priečinky, ktoré sú prehľadávané systémovými aplikáciami, ako sú Súbory, "
+"Fotografie a Videá."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Miesta"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Záložky"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Ostatné"
+
+# GtkLabel label
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Pridať umiestnenie"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Nenašli sa žiadne aplikácie"
+
+# tab
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Vyhľadávanie aplikácií"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Zahŕňa výsledky vyhľadávania poskytnuté aplikáciami."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Priečinky, ktoré sú prehľadávané systémovými aplikáciami."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Výsledky vyhľadávania"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Výsledky sú zobrazené podľa poradia zoznamu."
+
+# desktop entry comment
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Ovláda zoznam aplikácií, ktoré môžu zobraziť výsledky v prehľade aktivít"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Vyhľadávanie;Nájsť;Index;Skryť;Súkromie;Výsledky;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Nie sú vybraté žiadne siete na sprístupnenie"
+
+# desktop entry name
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Siete"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Zapnutá"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Vypnutá"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Povolená"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktívna"
+
+# file chooser dialog title
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Výber priečinka"
+
+# button atk
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Pridať"
+
+# GtkDialog title
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Povoliť spoločné používanie multimédií"
+
+# GtkLabel label
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Spoločné používanie súborov umožňuje spoločne sprístupniť váš priečinok "
+"„Verejné“ s ostatnými na aktuálnej sieti použitím: %s"
+
+# GtkLabel label
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Keď je povolené vzdialené prihlásenie, vzdialení používatelia sa môžu "
+"pripojiť pomocou príkazu Secure Shell:\n"
+"%s"
+
+# GtkDialog title
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Povoliť spoločné používanie osobných multimédií"
+
+# GtkLabel label
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Názov zariadenia bol skopírovaný"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Adresa zariadenia bola skopírovaná"
+
+# GtkLabel label
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Meno používateľa bolo skopírované"
+
+# GtkLabel label
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Heslo bolo skopírované"
+
+# desktop entry name
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Sprístupnenie"
+
+# GtkLabel label
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Názov _počítača"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Spoločné používanie súborov"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Vzdialená _pracovná plocha"
+
+# GtkDialog title
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Spoločné používanie _multimédií"
+
+# GtkDialog title
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "V_zdialené prihlásenie"
+
+# gtkdialog title
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Spoločné používanie súborov"
+
+# GtkLabel label
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Vyžadovať _heslo"
+
+# GtkDialog title
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Vzdialené prihlásenie"
+
+# GtkDialog title
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Vzdialená pracovná plocha"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Vzdialená pracovná plocha umožňuje zobrazenie a ovládanie vašej pracovnej "
+"plochy z iného počítača."
+
+#  policy action description
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Povoľuje alebo zakazuje vzdialené pripojenia k pracovnej ploche tohto "
+"počítača."
+
+# GtkLabel label
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Vzdialené ovládanie"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Umožňuje vzdialené pripojenia na ovládanie obrazovky."
+
+# gtk button
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Ako sa pripojiť"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Pripojí sa k tomuto počítaču pomocou názvu zariadenia alebo adresy "
+"vzdialenej pracovnej plochy."
+
+# menu item
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopírovať"
+
+# button atk
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Adresa vzdialenej pracovnej plochy"
+
+# GtkLabel label
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Overenie totožnosti"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "Na pripojenie k tomuto počítaču sa vyžaduje meno používateľa a heslo."
+
+# GtkLabel label
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Meno používateľa"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Overiť šifrovanie"
+
+# GtkLabel
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Odtlačok prsta pre overenie totožnosti"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+#, fuzzy
+#| msgid ""
+#| "The encryption fingerprint can be seen in connecting clients and should "
+#| "be identical"
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Odtlačok prsta pre overenie totožnosti môže byť viditeľný v pripojovacích "
+"klientoch a mal by byť identický."
+
+# GtkDialog title
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Spoločné používanie multimédií"
+
+# GtkLabel label
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Sprístupnite hudbu, fotografie a videá cez sieť."
+
+# GtkToolButton label
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Priečinky"
+
+# desktop entry comment
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Ovláda, ktoré údaje chcete sprístupniť ostatným"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"spoločné používanie;spoločne používať;ssh;hostiteľ;názov;vzdialený;vzdialená;"
+"pracovná plocha;multimédiá;médiá;audio;zvuk;video;obrázky;fotografie;filmy;"
+"videá;server;vykreslovač;"
+
+#  policy action description
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Povoliť alebo zakázať vzdialené prihlásenie"
+
+# policy action message
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Na povolenie alebo zakázanie vzdialeného prihlásenia je vyžadované overenie "
+"totožnosti"
+
+# téma
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Vlastná"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+# desktop entry name
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+#| msgid "Sharing"
+msgid "String"
+msgstr "Sprístupnenie"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+# vľavo - vpravo
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Rovnováha"
+
+# vpredu - dozadu
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Prelínanie"
+
+# Prelínanie:
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Dozadu"
+
+# Prelínanie:
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Dopredu"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Skúša sa %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Kliknutím vyberiete reproduktor na vyskúšanie"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Systémová hlasitosť"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Hlavná hlasitosť"
+
+# KeyListEntry description
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Úrovne hlasitosti"
+
+# tab
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Výstup"
+
+# label
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Výstupné zariadenie"
+
+# button label
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Vyskúšať"
+
+# GtkLabel label
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Konfigurácia"
+
+# channel position
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Basový reproduktor"
+
+# tab
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Vstup"
+
+# label
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Vstupné zariadenie"
+
+# KeyListEntry description
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Hlasitosť"
+
+# label
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Zvuk varovania"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100 %"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Stlmiť"
+
+# desktop entry name
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Zvuk"
+
+# desktop entry comment
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Mení hlasitosť zvuku, vstupy, výstupy a zvukové varovania"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"karta;mikrofón;hlasitosť;rovnováha;vyváženie;bluetooth;slúchadlo;náhlavná;"
+"súprava;zvuk;audio;výstup;vstup;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Odpojené"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Pripája sa"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Pripojené"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Chyba overenia totožnosti"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Overuje sa totožnosť"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Obmedzená funkčnosť"
+
+# GtkLabel label
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Pripojené a overená totožnosť"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# grafika, AP typ
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Neznáme"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Overená totožnosť o:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Pripojené o:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Zaregistrované o:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Zlyhalo overenie totožnosti zariadenia: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Zlyhalo zabudnutie zariadenia: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Závisí na %u ďalších zariadeniach"
+msgstr[1] "Závisí na %u ďalšom zariadení"
+msgstr[2] "Závisí na %u ďalších zariadeniach"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Zavrieť oznámenie"
+
+# GtkLabel label
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Názov:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Stav:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+# GtkLabel label
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Overiť totožnosť a pripojiť"
+
+# GtkToolButton label
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Zabudnúť zariadenie"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Chyba"
+
+# PAC provisioning
+# GtkListStore item
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Overená totožnosť"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Podsystém Thunderbolt (boltd) nie je nainštalovaný alebo správne nastavený."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Umožnenie priameho prístupu k zariadeniami, ako sú doky a externé grafické "
+"procesory."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Môžu byť pripojené iba zariadenia typu USB a Display Port."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Rozhranie Thunderbolt sa nepodarilo rozpoznať.\n"
+"Buď systém nepodporuje rozhranie Thunderbolt, alebo bola zakázaná v BIOSe, "
+"alebo je nastavená na nepodporovanú bezpečnostnú úroveň v BIOSe."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Podpora zariadení Thunderbolt bola zakázaná v systéme BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Nepodarilo sa zistiť úroveň bezpečnosti zariadenia Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Chyba počas prepínania priameho režimu: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Žiadna podpora zariadení Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Nepodarilo sa pripojiť k podsystému rozhrania thunderbolt."
+
+# KeyListEntries name; desktop entry name
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Priamy prístup"
+
+# GtkToolButton label
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Čakajúce zariadenia"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Žiadne pripojené zariadenia"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Spravuje zariadenia Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;súkromie;"
+
+# GtkLabel label
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Blikanie kurzora"
+
+# GtkCheckButton label
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Kurzor v textových poliach bliká."
+
+# GtkLabel label
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Rýchlosť"
+
+# GtkHScale AtkObject
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Rýchlosť blikania kurzora"
+
+# GtkLabel label
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Veľkosť kurzora"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Veľkosť kurzora môže byť skombinovaná s lupou, aby bol kurzor ľahšie "
+"viditeľný."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Asistované kliknutie"
+
+# GtkLabel
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulované sekundárne kliknutie"
+
+# GtkLabel
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Vyvolať sekundárne kliknutie podržaním hlavného tlačidla"
+
+# GtkLabel
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Zdržanie prijatia:"
+
+# Čakanie:
+# GtkLabel label
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Krátke"
+
+# atkobject
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Oneskorenie sekundárneho kliknutia"
+
+# GtkLabel label
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Dlhé"
+
+# GtkLabel
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Kliknutie zotrvaním"
+
+# GtkLabel
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Vyvolať kliknutie keď sa ukazovateľ zastaví"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "On_eskorenie:"
+
+# GtkLabel label
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Krátke"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Dlhé"
+
+# GtkLabel
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "M_edza pohybu:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Malá"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Veľká"
+
+# GtkLabel label
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Opakovanie klávesov"
+
+# GtkCheckButton label
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Opakovanie klávesu pri držaní."
+
+# GtkHScale AtkObject
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Oneskorenie opakovania klávesov"
+
+# GtkHScale AtkObject
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Rýchlosť opakovania kláves"
+
+# 1. KeyListEntries name; tab; tab;
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Asistované písanie"
+
+# GtkLabel
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Lepkavé kláve_sy"
+
+# GtkLabel
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Považovať sled modifikátorov kláves za kombináciu kláves"
+
+# GtkCheckButton
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "Zakázať _ak sú stlačené dva klávesy naraz"
+
+# GtkCheckButton
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pípnuť pri stlačení _modifikátora"
+
+# GtkLabel
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Poma_lé klávesy"
+
+# GtkLabel
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Vložiť pauzu medzi stlačenie klávesu a jeho prijatie"
+
+# GtkLabel label
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Krátke"
+
+# atkobject
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Oneskorenie písania pomalých kláves"
+
+# GtkLabel label
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Dlhé"
+
+# GtkCheckButton
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Pípnuť pri stlačení kláv_esu"
+
+# GtkCheckButton
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Pípnuť, ak je kláves prij_atý"
+
+# GtkCheckButton
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Pípnuť, ak je kláves _odmietnutý"
+
+# GtkLabel
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Pos_kakujúce klávesy"
+
+# GtkLabel
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorovať rýchlo opakované stlačenie kláves"
+
+# Čakanie:
+# GtkLabel label
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Krátke"
+
+# atkobject
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Oneskorenie písania poskakujúcich kláves"
+
+# čakanie:
+# GtkLabel label
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Dlhé"
+
+# GtkLabel
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Povoliť klávesnicou"
+
+# GtkLabel
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Zapnúť funkcie sprístupnenia z klávesnice"
+
+# sound id
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Predvolená"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Stredná"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Veľká"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Väčšia"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Najväčšia"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d pixelov"
+msgstr[1] "%d pixel"
+msgstr[2] "%d pixely"
+
+# KeyListEntries name; desktop entry name
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Vždy zobr_aziť ponuku zjednodušeného ovládania"
+
+# názov karty (Zrak, Sluch, Písanie, Klikanie)
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Zrak"
+
+# GtkLabel
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Vys_oký kontrast"
+
+# GtkLabel
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Veľký text"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Povoliť a_nimácie"
+
+# MČ: nemám to ako teraz posúdiť, ale nie sú na rovnakej obrazovke s "High Contrast"? Potom je tam problém s akcelerátorom.
+# PM: je to v samostatnom okne vid web glade runner
+# GtkLabel
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Čítačka _obrazovky"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"Čítačka obrazovky číta zobrazený text podľa toho ako pohybujete zameriavačom."
+
+# GtkLabel
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Zvukové klávesy"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pípnuť pri zapnutí alebo vypnutí funkcie Num Lock alebo Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Veľkosť k_urzora"
+
+# GtkLabel
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Lupa"
+
+# tab
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Sluch"
+
+# GtkLabel
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Vizuálne varovania"
+
+# GtkLabel
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Klávesnica na obrazovke"
+
+# GtkLabel label
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "O_pakovanie klávesov"
+
+# GtkLabel label
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Blikanie kurzora"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Asistované _písanie (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Ukazovanie a klikanie"
+
+# GtkLabel
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Myš klávesmi"
+
+# GtkToolButton label
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Lokalizovať ukazovateľ"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Asistované _kliknutie"
+
+# GtkLabel label
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Oneskorenie _dvojkliku"
+
+# GtkLabel label
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Oneskorenie _dvojkliku"
+
+# GtkLabel
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Vizuálne varovania"
+
+# GtkButton
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "V_yskúšať blikanie"
+
+# GtkLabel
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Použiť vizuálny náznak, keď sa vydá zvuk varovania."
+
+# GtkRadioButton
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Blik_núť celou obrazovkou"
+
+# GtkRadioButton
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Bliknúť celým o_knom"
+
+# dlzka krizu
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Krátky"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ obrazovky"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ obrazovky"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ obrazovky"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Dlhý"
+
+# Cast obrazovky:
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Celá"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Horná polovica"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Dolná polovica"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Ľavá polovica"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Pravá polovica"
+
+# GtkDialog title
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Nastavenia lupy"
+
+# GtkLabel
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Zväčšenie:"
+
+# GtkLabel
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Pozícia lupy:"
+
+# GtkRadioButton
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "Sledovať kurzor _myši"
+
+# GtkRadioButton
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Č_asť obrazovky:"
+
+# GtkCheckButton
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "_Lupa zasahuje aj mimo obrazovky"
+
+# GtkRadioButton
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Ud_ržovať kurzor lupy v strede"
+
+# GtkRadioButton
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Kurzor lupy po_súva obsah"
+
+# GtkRadioButton
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Kurzor lupy sa posúva s _obsahom"
+
+# tab
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Lupa"
+
+# GtkLabel
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Nitkový kríž:"
+
+# GtkCheckButton
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Prekrývať kurzor myši"
+
+# GtkLabel
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Hrúbka:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tenký"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Hrubý"
+
+# GtkLabel
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Dĺžka:"
+
+# GtkLabel
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Fa_rba:"
+
+# tab
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Nitkový kríž"
+
+# GtkLabel
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Farebné efekty:"
+
+# GtkLabel
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "Čiern_e na bielom:"
+
+# GtkLabel
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Jas:"
+
+# GtkLabel
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Far_ba"
+
+# farba
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Žiadna"
+
+# farba
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Úplná"
+
+# jas
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Nízky"
+
+# jas
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Vysoký"
+
+# liststore item
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Nízky"
+
+# liststore item
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Vysoký"
+
+# tab
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Farebné efekty"
+
+# desktop entry comment
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Uľahčuje videnie, písanie, počúvanie, ukazovanie a klikanie"
+
+# desktorp entry keywords
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Klávesnica;Myš;a11y;Zjednodušenie;Ovládanie;Prístupnosť;Kontrast;Kurzor;Lupa;"
+"Obrazovka;Čítačka obrazovky;text;písmo;veľkosť;AccessX;Lepkavé;Klávesy;"
+"Pomalé;Poskakujúce;Myš;dvojklik;dvojité;kliknutie;oneskorenie;asistencia;"
+"pomoc;opakovanie;blikanie;vizuálne;počúvanie;zvuk;písanie;animácie;"
+
+# Oddialiť o
+# Uzamknut obrazovku pri necinnosti za
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 hodina"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 deň"
+
+# GtkListStore item
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dni"
+
+# GtkListStore item
+# po dobe
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dni"
+
+# GtkListStore item
+# po dobe
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dni"
+
+# GtkListStore item
+# po dobe
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dní"
+
+# GtkListStore item
+# po dobe
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dní"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dní"
+
+# GtkListStore item
+# po dobe
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dní"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dní"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Vysypať všetky položky z Koša?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Všetky položky v koši budú natrvalo odstránené."
+
+# GtkButton label
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Vyprázdniť kôš"
+
+# 2 GtkDialog title
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Odstrániť všetky dočasné súbory?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Všetky dočasné súbory budú natrvalo odstránené."
+
+# GtkButton label
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Vymazať dočasné súbory"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 deň"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dní"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+# po dobu
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dní"
+
+# GtkListStore item
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Navždy"
+
+# window title;
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "História súborov"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"História súborov uchováva záznamy súborov, ktoré ste používali. Tieto "
+"informácie sú sprístupnené aplikáciám a uľahčuje im nájsť súbory, ktoré "
+"možno budete chcieť použiť."
+
+# window title;
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "H_istória súborov"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Doba _histórie súborov"
+
+# GtkButton label
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Vy_mazať históriu…"
+
+# 2 GtkDialog title
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Kôš a dočasné súbory"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Kôš a dočasné súbory môžu niekedy obsahovať osobné alebo citlivé informácie. "
+"Ich automatickým odstránením môžete pomôcť ochrániť súkromie."
+
+# GtkLabel label
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Automaticky odstrániť obsah _Koša"
+
+# GtkLabel label
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Automaticky odstrániť Dočasné _súbory"
+
+# GtkLabel label
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Interval automatického o_dstránenia"
+
+# GtkButton label
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Vyprázdniť kôš…"
+
+# GtkButton label
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "O_dstrániť dočasné súbory…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "História súborov a kôš"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Nezanechávajte stopy"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"využitie;nedávne;história;súbory;dočasné;dočasne;tmp;súkromné;súkromie;kôš;"
+"čistenie;vysypanie;vysypať;ponechať;uchovať;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Mala by sa zhodovať s webovou adresou vášho poskytovateľa prihlásenia."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Zlyhalo pridanie účtu"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Heslá sa nezhodujú."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Zlyhala registrácia účtu"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Overenie totožnosti nie je pri tejto doméne podporované"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Zlyhalo pripojenie k doméne"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Prihlasovacie meno nefunguje.\n"
+"Prosím, skúste to znovu."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Prihlasovacie heslo nefunguje.\n"
+"Prosím, skúste to znovu."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Zlyhalo prihlásenie do domény"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Nepodarilo sa nájsť doménu. Napísali ste ju správne?"
+
+# GtkToolButton label
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Pridať používateľa"
+
+# GtkListStore item
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Správca"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Správcovia môžu pridávať a odstraňovať iných používateľov a meniť nastavenia "
+"všetkým používateľom. Rodičovská kontrola nemôže byť použitá na správcov."
+
+# GtkListStore item
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Používateľ si nastaví heslo pri prvom prihlásení"
+
+# GtkListStore item
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Nastaviť heslo teraz"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Potvrdiť"
+
+# GtkToggleButton label
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Podnikové prihlásenie"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+"Používateľské účty, ktoré sú spravované spoločnosťou alebo organizáciou."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Ste odpojený"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Podnikové prihlásenie umožňuje použitie existujúceho, centrálne "
+"spravovaného, používateľského účtu na tomto zariadení. Tiež môžete použiť "
+"tento účet na prístup k prostriedkom spoločnosti na internete."
+
+# DK: nechajme zatial tento tvar, kym to rozdelia.je to neskodny preklad
+# DK: https://bugzilla.gnome.org/show_bug.cgi?id=701344
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Výber ďalších obrázkov"
+
+# file chooser dialog title
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Vybrať súbor…"
+
+# GtkLabel
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Správca odtlačkov prstov"
+
+# GtkLabel
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Odtlačok prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Nie"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "Á_no"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Chcete odstrániť vaše zaregistrované odtlačky prstov, čím sa zakáže "
+"prihlásenie odtlačkom prsta?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Žiadne zariadenie na snímanie odtlačkov prstov"
+
+# GtkLabel
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Žiadne zariadenie na snímanie odtlačkov prstov"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Uistite sa, že je zariadenie správne pripojené."
+
+# GtkLabel
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Zariadenie na snímanie odtlačkov prstov"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Zvoľte zariadenie na snímanie odtlačkov prstov, ktoré chcete nastaviť"
+
+# GtkLabel
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Prihlásenie odtlačkom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Prihlásenie odtlačkom prsta vám umožňuje odomknúť a prihlásiť sa do vášho "
+"počítača pomocou vášho prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "O_dstrániť odtlačky prstov"
+
+# GtkLabel
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Nasnímanie odtlačku prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "zariadenie musí byť požiadané o vykonanie tejto akcie"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "zariadenie je už žiadané iným procesom"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "nemáte oprávnenie na vykonanie tejto akcie"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "žiadne odtlačky neboli nasnímané"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Zlyhala komunikácia so zariadením počas snímania"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Zlyhala komunikácia s čítačkou odtlačkov prstov"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Zlyhala komunikácia so službou odtlačkov prstov"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Zlyhalo vypísanie zoznamu odtlačkov prstov: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Zlyhalo odstránenie uložených odtlačkov prstov: %s"
+
+# GtkListStore item
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Ľavý palec"
+
+# GtkListStore item
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Ľavý prostredník"
+
+# GtkRadioButton label
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "Ľavý _ukazovák"
+
+# GtkListStore item
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Ľavý prstenník"
+
+# GtkListStore item
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Ľavý malíček"
+
+# GtkListStore item
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Pravý palec"
+
+# GtkListStore item
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Pravý prostredník"
+
+# GtkRadioButton label
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "P_ravý ukazovák"
+
+# GtkListStore item
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Pravý prstenník"
+
+# GtkListStore item
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Pravý malíček"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Neznámy prst"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Dokončené"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Zariadenie na snímanie odtlačkov prstov odpojené"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Úložisko zariadenia na snímanie odtlačkov prstov je plné"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Zlyhalo nasnímanie nového odtlačku prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Zlyhalo spustenie snímania: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Zlyhalo nasnímanie nového odtlačku prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Zlyhalo zastavenie snímania: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Opakovane zdvihnite a priložte váš prst na čítačku pre nasnímanie odtlačku "
+"prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "_Znovu nasnímať tento prst…"
+
+# assistant page title
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Oskenovať nový odtlačok prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Zlyhalo uvoľnenie zariadenia na snímanie odtlačkov prstov %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problém s čítaním zariadenia"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Zlyhalo vyžiadanie zariadenia na snímanie odtlačkov prstov %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Zlyhalo získanie zariadení na snímanie odtlačkov prstov: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Tento týždeň"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Minulý týždeň"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+# DK: zaznam v historii relacie
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Ukončenie relácie"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Spustenie relácie"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Aktivita účtu"
+
+# KeyListEntry description
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Predchádzajúci"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Nasledujúci"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Prosím, zvoľte si iné heslo."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Prosím, zadajte vaše aktuálne heslo ešte raz."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Heslo nemohlo byť zmenené"
+
+# DK:dialog title
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Zmena hesla"
+
+# GtkButton label
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Zm_eniť"
+
+# GtkLabel
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Aktuálne heslo"
+
+# GtkLabel
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nové heslo"
+
+# GtkLabel
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Potvrdenie hesla"
+
+# GtkListStore item
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Umožniť používateľovi zmeniť heslo pri najbližšom prihlásení"
+
+# GtkListStore item
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Nastaviť heslo teraz"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "S takýmto typom domény sa nedá automaticky spojiť"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Nebola nájdená taká doména alebo pôsobisko"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Nedá sa prihlásiť ako %s do domény %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Neplatné heslo, skúste to znovu"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Nepodarilo sa pripojiť k doméne %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Odstránenie používateľa zlyhalo"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Zlyhalo zrušenie na diaľku spravovaného používateľa"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Nemôžete odstrániť vlastný účet."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "Používateľ %s je stále prihlásený"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Odstránenie prihláseného používateľa môže spôsobiť nestabilitu systému."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Chcete ponechať súbory používateľa %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Pri odstraňovaní používateľa je možné ponechať jeho domovský priečinok, "
+"súbory pošty a dočasné súbory."
+
+# button
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "O_dstrániť súbory"
+
+# button
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "Po_nechať súbory"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Naozaj chcete zrušiť na diaľku spravovaný účet používateľa %s?"
+
+# button
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "O_dstrániť"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Účet je zakázaný"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Nastaviť pri najbližšom prihlásení"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Žiadne"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Prihlásený"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Spojenie so službou účtov zlyhalo"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Uistite sa, prosím, že je služba AccountService nainštalovaná a povolená."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Pre zmenu tohto nastavenia musí byť panel odomknutý"
+
+# tooltip
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Odstráni vybraný používateľský účet"
+
+# tooltip
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Keď chcete odstrániť používateľský účet,\n"
+"kliknite najskôr na ikonu *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Odomknutím pridáte používateľov a zmeníte nastavenia"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Používatelia"
+
+# label
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Aby sa prejavili zmeny, musíte reštartovať vašu reláciu"
+
+# button
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Reštartovať teraz"
+
+# GtkButton label
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Zavrieť"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Upraviť podobizeň"
+
+# GtkLabel
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Celé meno"
+
+# button label
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Upraviť"
+
+# GtkLabel
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Prihlásenie _odtlačkom prsta"
+
+# GtkLabel
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatické prihlásenie"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Aktivita účtu"
+
+# GtkListStore item
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Správca"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Správcovia môžu pridávať a odstraňovať iných používateľov a meniť nastavenia "
+"všetkým používateľom."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Rodičovská kontrola"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Otvoriť aplikáciu Rodičovská kontrola."
+
+# GtkToolButton label
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Odstrániť používateľský účet…"
+
+# button
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Ostatní používatelia"
+
+# GtkToolButton label
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Pridať používateľa…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Nenašli sa žiadni používatelia"
+
+# tooltip
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Odomknutím pridáte používateľský účet."
+
+#  desktop entry comment
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Pridáva alebo odstraňuje používateľov a mení vaše heslo"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"prihlásenie;prihlásiť;odtlačok prsta;avatar;podobizeň;logo;heslo;rodičovská "
+"kontrola;čas obrazovky;obmedzenia aplikácií;obmedzenia webu;využitie;limit "
+"využitia;dieťa;deti;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "Zar_egistrovať"
+
+# GtkLabel label
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Prihlásenie správcu domény"
+
+# GtkLabel label
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Aby bolo možné použiť podnikové prihlásenia, tento počítač\n"
+"musí byť súčasťou domény. Požiadajte, prosím, vášho správcu,\n"
+"aby sem zadal heslo k doméne."
+
+# GtkLabel
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Meno správcu"
+
+# GtkLabel
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Heslo správcu"
+
+# policy action desc
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Správa používateľských účtov"
+
+# policy action message
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Na zmenu používateľských údajov je vyžadované overenie totožnosti"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Nové heslo musí byť odlišné od pôvodného hesla."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Skúste zmeniť niektoré písmená a čísla."
+
+# GtkLabel
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Skúste ešte viac zmeniť heslo."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Heslo bez vášho mena bude silnejšie."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Skúste sa vyhnúť použitiu vášho mena v hesle."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Skúste sa vyhnúť slovám, ktoré sú obsiahnuté v hesle."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Skúste sa vyhnúť často používaným slovám."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Skúste sa vyhnúť zmene poradia existujúcich slov."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Skúste použiť viac čísel."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Skúste použiť viac veľkých písmen."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Skúste použiť viac malých písmen."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Skúste použiť viac špeciálnych znakov ako sú interpunkčné znamienka."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Skúste použiť zmes písmen, čísel a interpunkčných znamienok."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Skúste sa vyhnúť opakovaniu toho istého znaku."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Skúste sa vyhnúť opakovaniu toho istého znaku: musíte zmiešať písmená, čísla "
+"a interpunkčné znamienka."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Skúste sa vyhnúť frázam ako 1234 alebo abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Heslo musí byť dlhšie. Skúste pridať viac písmen, čísel a interpunkčných "
+"znamienok."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Zmiešajte veľké a malé písmená a skúste použiť jedno alebo viac číslic."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Pridaním viacerých písmen, čísel a interpunkčných heslo zosilníte."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Overenie totožnosti zlyhalo"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Nové heslo je príliš krátke"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Nové heslo je príliš jednoduché"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Nové heslo je príliš podobné starému"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Nové heslo už bolo nedávno použité."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Nové heslo musí obsahovať číselné alebo špeciálne znaky"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Nové heslo je rovnaké ako staré"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Vaše heslo sa od pôvodného overenia totožnosti zmenilo!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Nové heslo neobsahuje dostatočný počet rôznych znakov"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Neznáma chyba"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Používateľské meno by sa malo skladať iba z malých písmen a-z, číslic a "
+"nasledovných znakov: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+"Prepáčte, ale toto používateľské meno nie je dostupné. Prosím, skúste iné."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Používateľské meno je príliš dlhé."
+
+# window title
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Priradenie tlačidiel"
+
+# Label
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Priraďte tlačidlá k funkciám"
+
+# GtkLabel label
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Na úpravu skratky zvoľte akciu „Odoslať stlačenie klávesu“, stlačte tlačidlo "
+"klávesovej skratky a držte nové klávesy, alebo stlačte kláves Backspace."
+
+# GtkButton label
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Zavrieť"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Prosím, dotknite sa cieľových značiek, tak ako sa objavujú na obrazovke, aby "
+"sa tablet nakalibroval."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Zistené kliknutie mimo, reštartuje sa…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Tlačidlo č. %d"
+
+# tab
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Definované aplikáciou"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Odoslať stlačenie klávesu"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Prepnúť displej"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Zobraziť pomocníka na obrazovke"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tablet pripojený k panelu notebooku"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tablet pripojený k externému displeju"
+
+# GtkLinkButton label
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Externé zariadenie s tabletom"
+
+# GtkLinkButton label
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Externé zariadenie s tabletom"
+
+# desktop entry name
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Všetky displeje"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Režim tabletu"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Použitie absolútnej pozície pre pero"
+
+# GtkLabel
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Orientácia pre ľavákov"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+# GtkButton
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Priradiť k displeju"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Zachovať pomer strán"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+# GtkButton label
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibrovať"
+
+# GtkLabel
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Nebol nájdený žiadny tablet"
+
+# GtkLabel
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Prosím, zapojte alebo zapnite váš tablet Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Pocit tlaku hrotu"
+
+# pocit tlaku pera a gumy
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Jemný"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Tlak hrotu pera"
+
+# pocit tlaku pera a gumy
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Tvrdý"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Tlačidlo č. 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Tlačidlo č. 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Tlačidlo č. 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Pocit tlaku gumy"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Tlak gumy"
+
+# GtkListStore row
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Kliknutie stredným tlačidlom myši"
+
+# GtkListStore row
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Kliknutie pravým tlačidlom myši"
+
+# GtkListStore row
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Dopredu"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Rozprašovacie pero s tlakom, naklonením a integrovaným posuvníkom"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Rozprašovacie pero s tlakom, naklonením a otočením"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Štandardné pero s tlakom a naklonením"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Štandardné pero s tlakom"
+
+# desktop entry name
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tablet Wacom"
+
+# desktop entry comment
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Nastavuje mapovanie tlačidiel a upravuje citlivosť pera grafických tabletov"
+
+# DK: nechal by som aj Stylus.niekto ma zauzivene toto slovo
+# desktop entry keywords
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Pero;Guma;Myš;"
+
+# label
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Nová skratka…"
+
+# GtkButton label
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Prístupové body"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operácia zrušená"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Chyba:</b> Prístup zamietnutý pre zmenu nastavení"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Chyba:</b> Chyba mobilného vybavenia"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Neregistrovaná"
+
+# naposledy použité
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registrovaná"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+# desktop entry name
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Vyhľadávanie"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Zamietnuté"
+
+# 1.desktop entry name;2. page; 3. GtkListStore item
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Podrobnosti o modeme"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Stav modemu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Poskytovateľ"
+
+# GtkLabel label
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Typ siete"
+
+# desktop entry name
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Stav siete"
+
+# GtkLabel label
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Vlastné číslo"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Podrobnosti o zariadení"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Verzia firmvéru"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Iba 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Iba 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Iba 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Iba 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (uprednostňované), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (uprednostňované), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (uprednostňované), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (uprednostňované), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (uprednostňované), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (uprednostňované), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (uprednostňované), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (uprednostňované), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (uprednostňované), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (uprednostňované), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (uprednostňované), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (uprednostňované), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (uprednostňované), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (uprednostňované), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (uprednostňované), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (uprednostňované), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "3G, 5G (uprednostňované)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (uprednostňované), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+# network mode
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Neznámy"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Odomknutie karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Odomknúť"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Prosím, poskytnite kód PIN pre kartu SIM č. %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Zadajte kód PIN na odomknutie vašej karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Prosím, poskytnite kód PUK pre kartu SIM č. %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Zadajte kód PUK na odomknutie vašej karty SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Bolo zadané nesprávne heslo. Zostáva vám %1$u pokusov."
+msgstr[1] "Bolo zadané nesprávne heslo. Zostáva vám %1$u pokus."
+msgstr[2] "Bolo zadané nesprávne heslo. Zostávajú vám %1$u pokusy."
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Zostáva vám %u pokusov"
+msgstr[1] "Zostáva vám %u pokus"
+msgstr[2] "Zostávajú vám %u pokusy"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Bolo zadané nesprávne heslo."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Kód PUK by malo byť 8 ciferné číslo"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Zadajte nový kód PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Kód PIN by malo byť 4 až 8 ciferné číslo"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Odomykanie…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Žiadna karta SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Pre použitie tohto modemu vložte kartu SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM uzamknutá"
+
+# label
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobilné dáta"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Prístup k dátam prostredníctvom mobilnej siete"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Dátový roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Použitie mobilných dát počas roamingu"
+
+# GtkLabel label
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Režim siete"
+
+# desktop entry name
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "Si_eť"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Pokročilé"
+
+# GtkButton label
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Názvy prístupových bodov"
+
+# 2 GtkDialog title
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Zamknúť kartu _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Uzamknutie karty SIM pomocou kódu PIN"
+
+# 1.desktop entry name;2. page; 3. GtkListStore item
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Podrobnosti o m_odeme"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Zlyhanie telefónu"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Žiadne pripojenie k telefónu"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operácia nie je umožnená"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operácia nie je podporovaná"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Karta SIM nie je vložená"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Vyžadovaný kód PIN pre kartu SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Vyžadovaný kód PIN pre kartu SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Zlyhanie karty SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Karta SIM je zaneprázdnená"
+
+# GtkLabel
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Nesprávne heslo"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Vyžadovaný kód PIN2 pre kartu SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Vyžadovaný kód PUK2 pre kartu SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Nenájdené"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Žiadna sieťová služba"
+
+# GtkLabel label
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Čas siete vypršal"
+
+# AutoIP je termin, ako napr. DHCP
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Služby siete GPRS nie sú povolené"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming nie je povolený v tejto oblasti"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Nešpecifikovaná chyba siete GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Bez chyby"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Akcia bola zrušená"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Prístup zamietnutý"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Neznáma chyba"
+
+# GtkLabel label
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Režim siete"
+
+# GtkListStore (tp;aui;bnc;mii); GtkListStore (10Mb/s, 100Mb/s ...)
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automaticky"
+
+# GtkEntry text
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Voľba siete"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Obnoviť poskytovateľov siete"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "Karta SIM č. %d"
+
+# GtkEntry text
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Povoliť mobilnú sieť"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Nenašiel sa žiadny adaptér WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Uistite sa, že máte zariadenie pre bezdrôtovú WAN/mobilnú sieť"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+"Bezdrôtové WAN pripojenie je zakázané, keď je zapnutý režim v lietadle."
+
+# label
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Vy_pnúť režim v lietadle"
+
+# gtk button
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Dátové pripojenie"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Karta SIM použitá pre internet"
+
+# 2 GtkDialog title
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Uzamknutie karty SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "Ď_alej"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Uzamknúť kartu SIM pomocou kódu PIN"
+
+# GtkButton label
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Zmena kódu PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Zadajte aktuálny kód PIN na zmenu nastavení uzamknutia karty SIM"
+
+# GtkEntry text
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobilná sieť"
+
+# 1. listore item; tab
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Nastavuje telefónne a mobilné dátové pripojenia"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "mobil;mobilná;wwan;telefón;telefonovanie;sim;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Nástroj na konfiguráciu prostredia GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+"Aplikácia Nastavenia je hlavným rozhraním na konfiguráciu vášho systému."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Projekt GNOME"
+
+# cmd line desc
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Vypíše číslo verzie"
+
+# PM: takto to tuším máme v iných moduloch
+# cmd desc
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Povolí podrobné výpisy"
+
+# cmd desc
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Vyhľadá reťazec"
+
+# cmd desc
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Vypíše možné názvy panelov a ukončí sa"
+
+# cmd desc
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel na zobrazenie"
+
+# cmd desc
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [PARAMETER…]"
+
+# GtkLabel label
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Kategórie nastavení"
+
+# desktop entry name
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Súkromie"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Dostupné panely:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Všetky nastavenia"
+
+# DK: displej
+# GtkLabel label
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Hlavná ponuka"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Upozornenie: Vývojárska verzia"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Táto verzia aplikácie Nastavenia by mala byť použitá iba za účelom vývoja. "
+"Môže sa vyskytnúť nesprávne správanie systému, strata údajov a iné "
+"neočakávané problémy. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Pomocník"
+
+# GtkLabel label
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Všeobecné"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Ukončenie"
+
+# desktop entry name
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Vyhľadávanie"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Panely"
+
+# cmd desc
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Prejdenie späť na panel predchádzajúcich"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Zrušenie vyhľadávania"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Nastavenia;Konfigurácia;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Identifikátor naposledy otvoreného panela nastavení"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Identifikátor naposledy otvoreného panela nastavení. Nerozpoznané hodnoty "
+"budú ignorované a bude vybraný prvý panel v zozname."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+"Zobraziť upozornenie pri spustení vývojovej zostavy aplikácie Nastavenia"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Určuje, či sa má zobraziť upozornenie, keď je spustená vývojová zostava."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Počiatočný stav okna"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u výstupov"
+msgstr[1] "%u výstup"
+msgstr[2] "%u výstupy"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u vstupov"
+msgstr[1] "%u vstup"
+msgstr[2] "%u vstupy"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Systémové zvuky"
+
+#~| msgid "Right"
+#~ msgid "Light"
+#~ msgstr "Svetlý"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "obrazovka;zámok;uzamknutie;diagnostika;pád;súkromný;nedávny;dočasný;tmp;"
+#~ "index;meno;sieť;identita;"
+
+# PK: mozno priradenie
+# PM: doriesit v master vetve
+# PM: dalej je priradiť k displeju
+# dialog title
+#~ msgid "Display Arrangement"
+#~ msgstr "Rozloženie displejov"
+
+# tlačidlo
+#~ msgid "Set"
+#~ msgstr "Nastaviť"
+
+# KeyListEntry description
+#~ msgid "Lock your screen"
+#~ msgstr "Uzamknúť vašu obrazovku"
+
+# file filter
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Certifikáty typu DER alebo PEM (*.der, *.pem, *.crt, *.cer)"
+
+# GtkToolButton label
+#~ msgid "Add a Printer…"
+#~ msgstr "Pridať tlačiareň…"
+
+#~ msgid "Bark"
+#~ msgstr "Brechanie"
+
+#~ msgid "Drip"
+#~ msgstr "Kvapkanie vody"
+
+#~ msgid "Glass"
+#~ msgstr "Ťukanie na sklo"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Panel so zvukom v nastaveniach prostredia GNOME"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Panel s myšou a touchpadom v nastaveniach prostredia GNOME"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Panel s pozadím v nastaveniach prostredia GNOME"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Panel s klávesnicou v nastaveniach prostredia GNOME"
+
+#~ msgid "Web Links"
+#~ msgstr "Webové odkazy"
+
+#~ msgid "Git Links"
+#~ msgstr "Odkazy Git"
+
+#~ msgid "%s Links"
+#~ msgstr "Odkazy %s"
+
+#~ msgid "Unset"
+#~ msgstr "Zrušiť nastavenie"
+
+# GtkLabel label
+#~ msgid "Links"
+#~ msgstr "Odkazy"
+
+# button
+#~ msgid "Hypertext Files"
+#~ msgstr "Hypertextové súbory"
+
+# button
+#~ msgid "Text Files"
+#~ msgstr "Textové súbory"
+
+# button
+#~ msgid "Image Files"
+#~ msgstr "Súbory obrázkov"
+
+# button
+#~ msgid "Font Files"
+#~ msgstr "Súbory písiem"
+
+#~ msgid "Archive Files"
+#~ msgstr "Súbory archívov"
+
+#~ msgid "Package Files"
+#~ msgstr "Súbory balíkov"
+
+#~ msgid "Audio Files"
+#~ msgstr "Zvukové súbory"
+
+# button
+#~ msgid "Video Files"
+#~ msgstr "Video súbory"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Oprávnenia a prístup"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Požadované oprávnenia na údaje a služby, ktoré si vyžiadala táto "
+#~ "aplikácia."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Nie je možné zmeniť"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Jednotlivé oprávnenia aplikácií môžu byť prezreté v nastaveniach <a "
+#~ "href=\"privacy\">Súkromia</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Integrácia"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Nastavenie pozadia pracovnej plochy"
+
+# GtkLabel label
+#~ msgid "Default Handlers"
+#~ msgstr "Predvolené obslužné programy"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Typy súborov a odkazov, ktoré otvára táto aplikácia."
+
+#~ msgid "Usage"
+#~ msgstr "Využitie"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Koľko prostriedkov táto aplikácia využíva."
+
+# GtkLabel label
+#~ msgid "Open in Software"
+#~ msgstr "Otvoriť v aplikácii Softvér"
+
+#~ msgid "Activities"
+#~ msgstr "Aktivity"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Umožnite nasledovným aplikáciám používať vašu kameru."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Zlyhalo odovzdanie súboru: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profil bol odovzdaný do:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Opíšte si túto adresu URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Reštartujte počítač a spustite váš obvyklý operačný systém."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Profil prevezmete a nainštalujete zadaním adresy URL do vášho prehliadača."
+
+# GtkButton label
+#~ msgid "Upload profile"
+#~ msgstr "Odovzdať profil"
+
+# liststore item
+#~ msgid "Requires Internet connection"
+#~ msgstr "Vyžaduje pripojenie k internetu"
+
+# menu item
+#~ msgid "_Copy"
+#~ msgstr "_Kopírovať"
+
+# tlačidlo
+#~ msgid "Select _All"
+#~ msgstr "Vybrať _všetko"
+
+# atkobject
+#~ msgid "Single Display"
+#~ msgstr "Jeden displej"
+
+# desktop entry name
+#~ msgid "Join Displays"
+#~ msgstr "Zlúčiť displeje"
+
+# GtkAssistant title
+#~ msgid "Display Mode"
+#~ msgstr "Režim displejov"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Potiahnite displeje tak, aby vyhovovali vášmu fyzickému rozloženiu "
+#~ "displejov. Vyberte displej, ktorého nastavenia chcete zmeniť."
+
+# atkobject
+#~ msgid "Active Display"
+#~ msgstr "Aktívny displej"
+
+#~ msgid "More Warm"
+#~ msgstr "Teplejšia"
+
+#~ msgid "Less Warm"
+#~ msgstr "Studenšia"
+
+# KeyListEntry description
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Uložiť snímku obrazovky do priečinka „$PICTURES“"
+
+# KeyListEntry description
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Uložiť snímku okna do priečinka „$PICTURES“"
+
+# KeyListEntry description
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Uložiť snímku oblasti do priečinka „$PICTURES“"
+
+# KeyListEntry description
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopírovať snímku obrazovky do schránky"
+
+# KeyListEntry description
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopírovať snímku okna do schránky"
+
+# KeyListEntry description
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopírovať snímku oblasti do schránky"
+
+# KeyListEntry name
+#~ msgid "Record a short screencast"
+#~ msgstr "Zaznamenať krátku nahrávku obrazovky"
+
+# GtkButton AtkObject
+#~ msgid "Move up"
+#~ msgstr "Presunúť nahor"
+
+# GtkButton AtkObject
+#~ msgid "Move down"
+#~ msgstr "Presunúť nadol"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Služby umiestnenia umožňujú aplikáciám spoznať vaše umiestnenie. Presnosť "
+#~ "sa zvýši použitím siete WiFi a mobilného širokopásmového pripojenia."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Využíva lokalizačnú službu spoločnosti Mozilla: <a href='https://location."
+#~ "services.mozilla.com/privacy'>Zásady súkromia</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Umožnite nasledovným aplikáciám zisťovať vaše umiestnenie."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Umožnite nasledovným aplikáciám používať váš mikrofón."
+
+# GtkHScale AtkObject
+#~ msgid "Double-click timeout"
+#~ msgstr "Interval dvojitého kliknutia"
+
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+# label
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Tlačidlo uspania a napájania"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Zistené lono: výkonný režim nie je dostupný"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Vysoká teplota hardvéru: výkonný režim nie je dostupný"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Výkonný režim nie je dostupný"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+# GtkListStore item
+#~ msgid " "
+#~ msgstr " "
+
+# GtkButton label
+#~ msgid "Authenticate"
+#~ msgstr "Overeniť totožnosť"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Zvoľte formát čísel, dátumov a mien. Zmeny sa prejavia po ďalšom "
+#~ "prihlásení."
+
+#~ msgid "My Account"
+#~ msgstr "Môj účet"
+
+# GtkLabel
+#~ msgid "Language"
+#~ msgstr "Jazyk"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Jazyk použitý pre text okien a webových stránok."
+
+# label
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Aby sa prejavili zmeny, musíte reštartovať reláciu"
+
+# button
+#~ msgid "Restart…"
+#~ msgstr "Reštartovať…"
+
+# GtkLabel label
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Nastavenia prihlásenia sú používané všetkými používateľmi na tomto systéme"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Ovláda, aké výsledky vyhľadávania sú zobrazované v prehľade Aktivít. "
+#~ "Poradie výsledkov vyhľadávania môže byť tiež zmenené presunom riadkov v "
+#~ "zozname."
+
+# GtkLabel label
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Sprístupnenie obrazovky umožňuje vzdialeným používateľom zobraziť alebo "
+#~ "ovládať vašu obrazovku pripojením k %s"
+
+# GtkDialog title
+#~ msgid "_Screen Sharing"
+#~ msgstr "S_prístupnenie obrazovky"
+
+# GtkLabel label
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "Niektoré služby sú zakázané kvôli nedostupnosti sieťového pripojenia."
+
+# GtkLabel label
+#~ msgid "_Password:"
+#~ msgstr "_Heslo:"
+
+# GtkCheckButton label
+#~ msgid "_Show Password"
+#~ msgstr "Zobraziť hes_lo"
+
+# GtkButton label
+#~ msgid "Access Options"
+#~ msgstr "Voľby prístupu"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Nové spojenia musia vyžadovať prístup"
+
+# GtkLabel label
+#~ msgid "_Require a password"
+#~ msgstr "Vyžadu_je heslo"
+
+# GtkLabel
+#~ msgid "Sound Keys"
+#~ msgstr "Zvukové klávesy"
+
+# GtkLabel
+#~ msgid "Screen Reader"
+#~ msgstr "Čítačka obrazovky"
+
+# GtkLabel
+#~ msgid "_Screen Reader"
+#~ msgstr "Čítačka obrazovk_y"
+
+# GtkListStore item
+#~ msgid "Standard"
+#~ msgstr "Štandardný"
+
+# GtkLabel
+#~ msgid "Account _Type"
+#~ msgstr "_Typ účtu"
+
+# GtkListStore item
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Umožniť používateľovi nastaviť heslo pri najbližšom _prihlásení"
+
+# GtkListStore item
+#~ msgid "Set a password _now"
+#~ msgstr "Nastaviť heslo _teraz"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Na pridanie podnikových účtov sa musíte pripojiť."
+
+# menuitem
+#~ msgid "Take a Picture…"
+#~ msgstr "Odfotografovať…"
+
+# tooltip
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Keď chcete vykonať zmeny,\n"
+#~ "kliknite najskôr na ikonu *"
+
+# tooltip
+#~ msgid "Create a user account"
+#~ msgstr "Vytvorí používateľský účet"
+
+# AtkObject
+#~ msgid "User Icon"
+#~ msgstr "Ikona používateľa"
+
+#~ msgid "Account Settings"
+#~ msgstr "Nastavenia účtu"
+
+# GtkLabel label
+#~ msgid "Authentication & Login"
+#~ msgstr "Overenie totožnosti a prihlásenie"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Toto sa použije ako názov vášho domovského priečinka a nie je možné ho "
+#~ "zmeniť."
+
+#~ msgid "Output:"
+#~ msgstr "Výstup:"
+
+# * http://en.wikipedia.org/wiki/Letterboxing_(filming)
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Zachovať pomer strán (širokouhlý):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapovať na jeden displej"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d. z %d"
+
+# PK: mozno priradenie
+# PM: doriesit v master vetve
+# PM: dalej je priradiť k displeju
+# dialog title
+#~ msgid "Display Mapping"
+#~ msgstr "Priradenie zobrazenia"
+
+# GtkListStore item
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (absolútny)"
+
+# GtkListStore item
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Touchpad (relatívny)"
+
+# GtkDialog title
+#~ msgid "Tablet Preferences"
+#~ msgstr "Nastavenia tabletu"
+
+#~ msgid "_Help"
+#~ msgstr "_Pomocník"
+
+# GtkLinkButton label
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Nastavenia Bluetooth"
+
+# GtkLabel
+#~ msgid "Tracking Mode"
+#~ msgstr "Režim sledovania"
+
+# GtkButton
+#~ msgid "Map Buttons…"
+#~ msgstr "Priradiť tlačidlá…"
+
+# GtkLinkButton
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Upraviť nastavenia myši"
+
+# GtkLinkButton
+#~ msgid "Adjust display resolution"
+#~ msgstr "Upraviť rozlíšenie displeja"
+
+#~ msgid "No stylus found"
+#~ msgstr "Nenašlo sa žiadne pero"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Prosím, umiestnite vaše pero do vzdialenosti tabletu pre jeho konfiguráciu"
+
+#~ msgid "Top Button"
+#~ msgstr "Horné tlačidlo"
+
+#~ msgid "Lower Button"
+#~ msgstr "Spodné tlačidlo"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Najspodnejšie tlačidlo"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Odomyká sa..."
+
+# label
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Jas obrazovky"
+
+# label
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Jas _klávesnice"
+
+# label
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Stmaviť obrazovku pri neaktivite"
+
+# PK: toto je divne, skor vypnut obrazovku
+# PM: no blank screen praveze nie je vypnutie obrazovky, balnk screen je vyplnenie obrazovky čiernou ale je stále zapnutá. Používa sa to pri starých monitoroch, ktoré zobrazujú pri ATM hlásku ze nie je signál.
+# label
+#~ msgid "_Blank Screen"
+#~ msgstr "Vy_prázdniť obrazovku o"
+
+# PM: pozerám že je tam aj reťazec Turns off wireless devices ako label, nemá byť aj on na preklad?
+# PK: nie, je to label v tom dialogu hruby a potom prepinac
+# label
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Sieť Wi-Fi môže byť vypnutá kvôli šetreniu energie."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Šírokopásmové mobilné zariadenia (3G, 4G, LTE, atď) môžu byť vypnuté "
+#~ "kvôli šetreniu energie."
+
+# label
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Rozhranie Bluetooth môže byť vypnuté kvôli šetreniu energie."
+
+# vľavo - vpravo
+#~ msgid "Balanced Power"
+#~ msgstr "Vyvážená spotreba energie"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Prihlásenie;Meno;Odtlačok prsta;Podobizeň;Logo;Tvár;Heslo;"
+
+# GtkLabel label
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Klávesová skratka"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Toto môže byť zmenené v ponuke Prispôsobiť skratky"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Stlačením a písaním zadáte iné znaky"
+
+#~ msgid "Add…"
+#~ msgstr "Pridať…"
+
+#~ msgid "Left Alt"
+#~ msgstr "Ľavý kláves Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Pravý kláves Alt"
+
+# GtkListStore item
+#~ msgid "Left Super"
+#~ msgstr "Ľavý kláves Super"
+
+# GtkListStore item
+#~ msgid "Right Super"
+#~ msgstr "Pravý kláves Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Pravý kláves Ctrl"
+
+# https://bugzilla.gnome.org/show_bug.cgi?id=697213
+# PM: chcelo by to komentár od vývojárov čo to je - typujem že dajaká modifikačná klávesa na neštandardnej klávesnici
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Kláves pre alternatívne znaky"
+
+# description
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Prepnutie na ďalší zdroj iba pomocou modifikátorov"
+
+# GtkLabel
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Kláves ponuky"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Nabíja sa"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Výstraha"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Nízka"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Dobrá"
+
+# Cast obrazovky:
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Úplne nabitá"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Vybitá"
+
+# KeyListEntry description
+#~ msgid "Previous source"
+#~ msgstr "Predchádzajúci zdroj"
+
+# GtkLabel label
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Win+Shift+Medzerník"
+
+# account dialog group
+#~ msgid "Next source"
+#~ msgstr "Nasledujúci zdroj"
+
+# GtkLabel label
+#~ msgid "Super+Space"
+#~ msgstr "Win+Medzerník"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Ľavý a pravý Alt"
+
+#  desktop entry comment
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Pridanie používateľských účtov a zmena hesiel"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Prehrávanie a záznam zvuku"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr ""
+#~ "Rozpoznanie sieťových zariadení pomocou mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Priamy prístup k hardvéru bluetooth"
+
+#~ msgid "Use your camera"
+#~ msgstr "Používanie vyšej kamery"
+
+# desktop entry name
+#~ msgid "Print documents"
+#~ msgstr "Tlač dokumentov"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Používanie akéhokoľvek pripojeného pákového ovládača"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Umožnenie pripojenia k službe Docker"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Nastavenie brány firewall siete"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Nastavenie a používanie privilegovaných súborových systémov FUSE"
+
+# GtkButton tooltip
+#~ msgid "Update firmware on this device"
+#~ msgstr "Aktualizácia firmvéru tohoto zariadenia"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Prístup k informáciám o hardvéri"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Poskytnutie entropie pre hardvérový generátor náhodných čísel."
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Používanie hardvérom generovaných náhodných čísel"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Prístup k súborom vo vašom domovskom priečinku"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Prístup k službe libvirt"
+
+# policy description
+#~ msgid "Change system language and region settings"
+#~ msgstr "Zmena systémového jazyka a nastavení oblasti"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Zmena nastavení a poskytovateľov umiestnenia"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Čítanie systémových a aplikačných záznamov"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "Prístup k službe media-hub"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Používanie a nastavovanie modemov"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Čítanie informácií o pripojenom systéme a diskových kvótach"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Ovládanie prehrávačov hudby a videa"
+
+# policy description
+#~ msgid "Change low-level network settings"
+#~ msgstr "Zmena nízko úrovňových nastavení siete"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Prístup k službe NetworkManager pre čítanie a zmenu sieťových nastavení"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Prístup k čítaniu sieťových nastavení"
+
+#~ msgid "Change network settings"
+#~ msgstr "Zmena nastavení siete"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Prístup k službe ofono pre čítanie a zmenu sieťových nastavení mobilných "
+#~ "telefónov"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Ovládanie hardvéru Open vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Čítanie z diskov CD/DVD"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Čítanie, pridávanie, zmena alebo odstraňovanie uložených hesiel"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Prístup k zariadeniam pppd a ppp pre nastavovanie pripojení protokolu "
+#~ "Point-to-Point"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Pozastavenie alebo ukončenie akéhokoľvek procesu v systéme"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Priamy prístup k hardvéru na zbernici USB"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Čítanie alebo zápis súborov na vymeniteľné zariadenia"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Zabránenie uspatiu alebo uzamknutiu obrazovky"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Prístup k hardvéru cez sériový port"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Řeštartovanie alebo vypnutie zariadenia"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Inštalácia, odstránenie a nastavenie softvéru"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Prístup k službe rozhrania úložiska"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Čítanie informácií o procesoch a systéme"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Sledovanie a ovládanie akéhokoľvek spusteného programu"
+
+# desktop entry comment
+#~ msgid "Change the date and time"
+#~ msgstr "Zmena dátumu a času"
+
+# policy description
+#~ msgid "Change time server settings"
+#~ msgstr "Zmena nastavení časového servera"
+
+# desktop entry comment
+#~ msgid "Change the time zone"
+#~ msgstr "Zmena časového pásma"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Prístup k službe UDisks2 pre nastavovanie diskov a vymeniteľných nosičov"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr ""
+#~ "Čítanie/zápis udalostí zdieľaného kalendára v prostredí Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Čítanie/zápis zdieľaných kontaktov v prostredí Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Prístup k údajom využitia energie"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Prístup na čítanie/zápis zariadení vystavených cez U2F"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+# KeyListEntries name; desktop entry name
+#~ msgid "Universal Access"
+#~ msgstr "Bezbariérový prístup"
+
+# GtkLabel label
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Vypnutím sa pripojíte k sieti Wi-Fi"
+
+# GtkLabel label
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Heslo"
+
+# tooltip
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Keď chcete vytvoriť používateľský účet,\n"
+#~ "kliknite najskôr na ikonu *"
+
+# GtkAssistant title
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Povolenie prihlásenia odtlačkom prsta"
+
+# GtkRadioButton label
+#~ msgid "_Other finger:"
+#~ msgstr "_Iný prst:"
+
+# GtkLabel label
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Odtlačok vášho prsta bol úspešne uložený. Teraz by sa vám už malo podariť "
+#~ "prihlásiť sa pomocou čítačky odtlačkov prstov."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Nemáte povolený prístup k zariadeniu. Kontaktujte vášho správcu systému."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Vyskytla sa vnútorná chyba."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Odstrániť zaregistrované odtlačky prstov?"
+
+#~ msgid "Done!"
+#~ msgstr "Hotovo!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Nepodaril sa prístup k zariadeniu „%s“"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Nepodarilo sa spustiť čítanie odtlačku na zariadení „%s“"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Nepodaril sa prístup k žiadnej čítačke odtlačkov prstov"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Ak potrebujete pomoc, prosím, kontaktujte správcu vášho systému."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Ak chcete povoliť prihlásenie odtlačkom prsta, musíte uložiť jeden z "
+#~ "vašich odtlačkov prstov, pomocou zariadenia „%s“."
+
+# assistant page title
+#~ msgid "Selecting finger"
+#~ msgstr "Výber prsta"
+
+# gtk button
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Nastaviť pozadie a uzamknutú obrazovku"
+
+# window title
+#~ msgid "Set Background"
+#~ msgstr "Nastaviť pozadie"
+
+# KeyListEntry description
+#~ msgid "Set Lock Screen"
+#~ msgstr "Nastaviť uzamknutú obrazovku"
+
+# gtk button
+#~ msgid "Remove Background"
+#~ msgstr "Odstrániť pozadie"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "Hlásenia sú odosielané anonymne a neobsahujú osobné údaje."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Odoslaním hlásení o technických problémoch nám pomôže vylepšiť tento "
+#~ "operačný systém."
+
+# GtkLabel
+#~ msgid "Last Login"
+#~ msgstr "Posledné prihlásenie"
+
+# policy_settings
+#~ msgid "Notification _Popups"
+#~ msgstr "Vy_skakovacie oznámenia"
+
+#~ msgid "Version %s"
+#~ msgstr "Verzia %s"
+
+#~ msgid "OS name"
+#~ msgstr "Názov OS"
+
+# GtkLabel label
+#~ msgid "OS type"
+#~ msgstr "Typ OS"
+
+# GtkLabel label
+#~ msgid "Disk"
+#~ msgstr "Disk"
+
+# button label
+#~ msgid "Check for updates"
+#~ msgstr "Skontrolovať aktualizácie"
+
+#~ msgid "Network proxy"
+#~ msgstr "Sieťový sprostredkovateľ (proxy)"
+
+# tab
+#~ msgid "page 1"
+#~ msgstr "stránka č. 1"
+
+# GtkLabel label
+#~ msgid "Inner _authentication"
+#~ msgstr "Vnútorné _overenie totožnosti"
+
+# tab
+#~ msgid "page 2"
+#~ msgstr "stránka č. 2"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Obmedziť využitie dát na _pozadí"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr ""
+#~ "Vhodné pre pripojenia, ktoré sú spoplatnené podľa prenesených dát, alebo "
+#~ "obmedzené."
+
+# GtkListStore item
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Krútená dvojlinka (TP)"
+
+# GtkListStore item
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Rozhranie pripájacej jednotky (AUI)"
+
+# GtkListStore item
+#~ msgid "BNC"
+#~ msgstr "Konektor BNC"
+
+# GtkListStore item
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Rozhranie nezávislé od nosiča (MII)"
+
+# GtkListStore item
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+# GtkListStore item
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+# GtkListStore item
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+# GtkListStore item
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Zapnutím bezdrôtového prístupového bodu budete odpojený od siete <b>%s</"
+#~ "b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Ak je aktívny prístupový bod, tak nie je možné pristupovať k internetu "
+#~ "pomocou bezdrôtovej siete."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Prístupové body Wi-Fi sa obvykle používajú na sprístupnenie dodatočného "
+#~ "internetového pripojenia cez sieť Wi-Fi."
+
+# GtkLabel label
+#~ msgid "Automatic _Connect"
+#~ msgstr "Automaticky _pripojiť"
+
+# tab
+# desktop entry name
+#~ msgid "details"
+#~ msgstr "podrobnosti"
+
+# GtkCheckButton label
+#~ msgid "Show P_assword"
+#~ msgstr "_Zobraziť heslo"
+
+# DK:https://bugzilla.gnome.org/show_bug.cgi?id=697210
+# GtkCheckButton label
+#~ msgid "Make available to other users"
+#~ msgstr "Sprístupniť ostatným používateľom"
+
+# tab
+#~ msgid "identity"
+#~ msgstr "identita"
+
+# GtkLabel label
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+# GtkLabel label
+#~ msgid "_Addresses"
+#~ msgstr "_Adresy"
+
+# PM: podľa mňa to hovorí, že sa automaticky majú vyplniť len sieťové adresy (DHCP poskytuje aj všeličo iné napr názov počítača)
+# GtkComboBox item
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Len adresy zistené automaticky (DHCP)"
+
+# PM: Statická adresa len pre lokálne pripojenie bez prístupu k bráne
+# GtkComboBox item
+#~ msgid "Link-local only"
+#~ msgstr "Len lokálne pripojenie"
+
+# GtkCheckButton label
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignorovať automaticky získané smerovania"
+
+# tab
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+# GtkLabel label
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+# tab
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+# GtkLabel label
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Klonovaná adresa MAC"
+
+# GtkButton label
+#~ msgid "_Reset"
+#~ msgstr "_Vrátiť predvolené"
+
+# DK:tie stringy nie vobec rovnake
+# GtkLabel label
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Vrátiť pôvodné nastavenia pre toto pripojenie vrátane hesiel, ale "
+#~ "zapamätať si ho ako prednostné."
+
+# GtkLabel label
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Odstrániť všetky podrobnosti týkajúce sa tejto siete a automaticky sa k "
+#~ "nej nepripájať."
+
+# GtkListStore item
+#~ msgid "Hardware"
+#~ msgstr "Hardvér"
+
+# gtk button
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Obnoviť"
+
+# GtkLabel label
+#~ msgid "Connected Devices"
+#~ msgstr "Pripojené zariadenia"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infraštruktúra"
+
+#~ msgid "In use"
+#~ msgstr "Používa sa"
+
+#
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Zapnuté"
+
+# MČ: ak displej tak vypnutý. V iných prípadoch to môže byť inak. Treba skontrolovať pre všetky výskyty, prípadne dať rozdeliť.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=708580
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Vypnuté"
+
+# MČ: ak displej tak vypnutý. V iných prípadoch to môže byť inak. Treba skontrolovať pre všetky výskyty, prípadne dať rozdeliť.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=708580
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Vypnutý"
+
+#
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Zapnutý"
+
+# MČ: ak displej tak vypnutý. V iných prípadoch to môže byť inak. Treba skontrolovať pre všetky výskyty, prípadne dať rozdeliť.
+# * https://bugzilla.gnome.org/show_bug.cgi?id=708580
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Vypnutý"
+
+#
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Zapnutý"
+
+# 2 GtkDialog title
+#~ msgid "Usage & History"
+#~ msgstr "Použitie a história"
+
+# desktop entry name
+#~ msgid "Privacy Policy"
+#~ msgstr "Zabezpečenie súkromia"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Ukladanie vašej histórie uľahčuje hľadanie vecí znovu. Tieto položky "
+#~ "nikdy nebudú sprístupnené cez sieť."
+
+# GtkLabel label
+#~ msgid "_Recently Used"
+#~ msgstr "_Nedávno použité"
+
+# GtkLabel label
+#~ msgid "Retain _History"
+#~ msgstr "Ukladať _históriu po dobu"
+
+# GtkLabel label
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Uzamknutá obrazovka chráni vašu bezpečnosť pri neprítomnosti."
+
+# GtkLabel label
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "_Uzamknúť obrazovku pri nečinnosti za"
+
+# desktop entry name
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "Oznámenia na _uzamknutej obrazovke"
+
+# GtkLabel label
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Automatické vymazanie Koša a dočasných súborov pomáha udržiavať váš "
+#~ "počítač bez nepotrebných citlivých informácií."
+
+# GtkLabel label
+#~ msgid "Purge _After"
+#~ msgstr "Vymazať _po"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Odoslaním informácií o používaní softvéru nám umožníte poskytnúť vám "
+#~ "presnejšie odporúčania. Tiež nám takto pomáhate zlepšovať softvér.\n"
+#~ "\n"
+#~ "Všetky zozbierané informácie sú uchovávané anonymne a vaše údaje nebudeme "
+#~ "nikdy zdieľať s tretími stranami."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Odoslať štatistiku o používaní softvéru"
+
+#~ msgid "_Camera"
+#~ msgstr "_Fotoaparát"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Mikrofón"
+
+#~ msgid "_Location Services"
+#~ msgstr "Služby _umiestnenia"
+
+# desktop entry comment
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Chráni vaše osobné údaje a obmedzuje prístup pre ostatných"
+
+#~ msgid "No regions found"
+#~ msgstr "Nenašli sa žiadne regióny"
+
+# GtkRadioButton
+#~ msgid "Flash the _window title"
+#~ msgstr "Bliknúť _titulkom okna"
+
+# desktop entry name
+#~ msgid "_Background"
+#~ msgstr "_Pozadie"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Mení sa počas dňa"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Dlaždice"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zväčšiť"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Vystrediť"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Prispôsobiť mierku"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Vyplniť"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Rozprestrieť"
+
+# radio_button
+#~ msgid "Colors"
+#~ msgstr "Farby"
+
+# radio_button
+#~ msgid "Pictures"
+#~ msgstr "Obrázky"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Nenašli sa žiadne obrázky"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "Môžete pridať obrázky do vášho priečinka %s a potom sa zobrazia tu"
+
+#~ msgid "_Off"
+#~ msgstr "Vy_pnuté"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Pripojenie/SSID"
+
+# label
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automaticky uspať"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "K_eď je stlačené tlačidlo napájania"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Používateľské meno nemôže začínať znakom „-“."
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Nočné osvetlenie"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Nepodarilo sa získať informácie o obrazovke"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+# desktop entry name
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+# GtkLabel label
+#~ msgid "Switch to previous source"
+#~ msgstr "Prepnúť na predchádzajúci zdroj"
+
+# GtkLabel label
+#~ msgid "Switch to next source"
+#~ msgstr "Prepnúť na ďalší zdroj"
+
+# GtkLabel label
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Alternatívny prepínač na ďalší zdroj"
+
+#~ msgid "_Options"
+#~ msgstr "_Voľby"
+
+#~ msgid "Add input source"
+#~ msgstr "Pridať zdroj vstupu"
+
+#~ msgid "Remove input source"
+#~ msgstr "Odstrániť zdroj vstupu"
+
+#~ msgid "Move input source up"
+#~ msgstr "Presunúť zdroj vstupu hore"
+
+#~ msgid "Move input source down"
+#~ msgstr "Presunúť zdroj vstupu dole"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Zobraziť rozloženie klávesnice zdroja vstupu"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+# Rovnováha:
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Vľavo"
+
+# Rovnováha:
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Vpravo"
+
+# Basový reproduktor:
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimum"
+
+# Basový reproduktor:
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maximum"
+
+# minimum / maximum
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Basový reproduktor:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profil:"
+
+# button lablel
+#~ msgid "_Test Speakers"
+#~ msgstr "V_yskúšať reproduktory"
+
+#~ msgid "Peak detect"
+#~ msgstr "Detekcia špičiek"
+
+# tree view column
+#~ msgid "Device"
+#~ msgstr "Zariadenie"
+
+# dialog title
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Skúška reproduktorov pre %s"
+
+# frame
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Zv_oľte zariadenie pre výstup zvuku:"
+
+# frame
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Nastavenia zvoleného zariadenia:"
+
+# label
+#~ msgid "_Input volume:"
+#~ msgstr "_Hlasitosť vstupu:"
+
+# frame
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Zv_oľte zariadenie pre vstup zvuku:"
+
+# tab
+#~ msgid "Sound Effects"
+#~ msgstr "Zvukové efekty"
+
+# DK:zvuková téma
+# DK: https://bugzilla.gnome.org/show_bug.cgi?id=701810
+#~ msgid "Built-in"
+#~ msgstr "Zabudovaná"
+
+# widget name
+#~ msgid "Sound Preferences"
+#~ msgstr "Nastavenia zvuku"
+
+# event description
+#~ msgid "Testing event sound"
+#~ msgstr "Skúška zvukovej udalosti"
+
+# sound type
+#~ msgid "From theme"
+#~ msgstr "Z témy"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Zvoľte varovný zvuk:"
+
+# button label
+#~ msgid "Stop"
+#~ msgstr "Zastaviť"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+# GtkListStore item
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Štandardný"
+
+# GtkListStore item
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Správca"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Ovládacie stredisko prostredia GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Ovládacie stredisko je hlavným rozhraním prostredia GNOME na konfiguráciu "
+#~ "rôznych vlastností vášho prostredia."
+
+#~ msgid "Quit"
+#~ msgstr "Ukončiť"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+# tab
+#~ msgid "hardware"
+#~ msgstr "hardvér"
+
+# GtkLabel label
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Anglický (Spojené Kráľovstvo)"
+
+# GtkLabel label
+#~ msgid "United Kingdom"
+#~ msgstr "Spojené Kráľovstvo"
+
+# GtkLabel
+#~ msgid "_Verify New Password"
+#~ msgstr "_Overenie nového hesla"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Heslá sa nezhodujú."
+
+# tab
+#~ msgid "page 3"
+#~ msgstr "stránka č. 3"
+
+# cmd desc
+#~ msgid "Show the overview"
+#~ msgstr "Zobrazí prehľad"
+
+# menuitem
+#~ msgid "Disable image"
+#~ msgstr "Zakázať obrázok"
+
+# menuitem
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Prehliadať ďalšie obrázky…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Používa ho %s"
+
+# desktop entry name
+#~ msgid "Back­ground"
+#~ msgstr "Pozadie"
+
+# desktop entry name
+#~ msgid "Blue­tooth"
+#~ msgstr "Bluetooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Farba"
+
+# 1. listore item; tab
+#~ msgid "Overview"
+#~ msgstr "Prehľad"
+
+# 1. listore item; tab
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Predvolené aplikácie"
+
+#~ msgid "Ab­out"
+#~ msgstr "O aplikácii"
+
+# 1.desktop entry name;2. page; 3. GtkListStore item
+#~ msgid "De­tails"
+#~ msgstr "Podrobnosti"
+
+# 1. listore item; tab
+#~ msgid "Remo­vable Media"
+#~ msgstr "Vymeniteľné nosiče"
+
+# desktop entry name
+#~ msgid "Net­work"
+#~ msgstr "Sieť"
+
+# desktop entry name
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Oznámenia"
+
+#~ msgid "Po­wer"
+#~ msgstr "Napájanie"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Súkromie"
+
+# desktop entry name
+#~ msgid "Sha­ring"
+#~ msgstr "Sprístupnenie"
+
+# KeyListEntries name; desktop entry name
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Bezbariérový prístup"
+
+# desktop entry name
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Tablet Wacom"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hardvér"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Systém"
+
+# GtkButton label
+#~ msgid "Apply"
+#~ msgstr "Použiť"
+
+# GtkButton label
+#~ msgid "Lid Closed"
+#~ msgstr "Zavretý kryt"
+
+#~ msgid "Mirrored"
+#~ msgstr "Zrkadlený"
+
+# atkobject
+#~ msgid "Secondary"
+#~ msgstr "Vedľajší"
+
+# dialog title
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Rozmiestnenie kombinovaných displejov"
+
+# GtkLabel
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Potiahnutím displejov zmeníte ich rozmiestnenie"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+# tooltip
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Otočí o 90° doľava"
+
+# tooltip
+#~ msgid "Rotate by 180°"
+#~ msgstr "Otočí o 180°"
+
+# tooltip
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Otočí o 90° doprava"
+
+#~ msgid "Size"
+#~ msgstr "Veľkosť"
+
+# tooltip
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Zobrazí hornú lištu a Prehľad aktivít na tomto displeji"
+
+# tooltip
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Spojí tento displej s iným a rozšíri tým pracovný priestor"
+
+#~ msgid "Presentation"
+#~ msgstr "Prezentácia"
+
+# tooltip
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Zobrazí iba prezentácie a médiá"
+
+# tooltip
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Zobrazí vaše existujúce zobrazenie na oboch displejoch"
+
+# GtkButton label
+#~ msgid "Turn Off"
+#~ msgstr "Vypnúť"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Nepoužívať tento displej"
+
+# DK: preklad je presny. overil som to vo fedore 20. Po kliknuti na tlacidlo s tymto textom sa otvori dialog, v ktorom su miniatury displejov a uzivatel ich moze "rozmiestnit" ako chce.
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Rozmiestniť kombináciu displejov"
+
+# label
+#~ msgid "Air_plane Mode"
+#~ msgstr "Režim v _lietadle"
+
+# label
+#~ msgid "Server"
+#~ msgstr "Server"
+
+# button atk
+#~ msgid "Delete DNS Server"
+#~ msgstr "Odstrániť server DNS"
+
+# label
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+# GtkButton label
+#~ msgid "_Add Profile…"
+#~ msgstr "_Pridať profil…"
+
+# GtkListStore item
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Bez proxy"
+
+# GtkListStore item
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Zadať ručne"
+
+# GtkListStore item
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Zistiť automaticky"
+
+# GtkLabel label
+#~ msgid "_Method"
+#~ msgstr "_Metóda"
+
+# týka sa (Cisco) VPN
+# GtkLabel label
+#~ msgid "Group Name"
+#~ msgstr "Skupinový názov"
+
+# GtkButton label
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "Po_užiť ako prístupový bod…"
+
+# GtkButton label
+#~ msgid "_History"
+#~ msgstr "_História"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bitový (ID zostavy: %s)"
+
+# Typ OS
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d bitový"
+
+# GtkLabel label
+#~ msgid "Base system"
+#~ msgstr "Základný systém"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Skratka;Skratky;Opakovanie;Blikanie;Rýchlosť;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Stlačte kláves Esc na zrušenie."
+
+# GtkCheckButton label
+#~ msgid "Make available to other _users"
+#~ msgstr "Sprístupniť ostatným _používateľom"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Zóna firewallu"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Predvolená"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Zóna určuje úroveň dôveryhodnosti pripojenia"
+
+# GtkLabel label
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Vrátiť pôvodné nastavenia pre túto sieť vrátane hesiel, ale zapamätať si "
+#~ "ju ako prednostnú"
+
+# GtkLabel label
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Odstrániť všetky podrobnosti týkajúce sa tejto siete a automaticky sa k "
+#~ "nej nepripájať"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Ak ste pripojený k internetu bez použitia bezdrôtovej siete, tak môžete "
+#~ "vytvoriť bezdrôtový prístupový bod a sprístupniť pripojenie ostatným."
+
+# WEP index
+# GtkListStore item
+#~ msgid "2"
+#~ msgstr "2"
+
+# WEP index
+# GtkListStore item
+#~ msgid "3"
+#~ msgstr "3"
+
+# WEP index
+# GtkListStore item
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Skúste pridať viac písmen, čísel a symbolov."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Sila: Slabé"
+
+# GtkLabel
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Sila: Nepostačujúce"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Sila: Priemerné"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Sila: Postačujúce"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Sila: Silné"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Váš účet</small>"
+
+#~ msgid "0"
+#~ msgstr "0"
+
+# * https://bugzilla.gnome.org/show_bug.cgi?id=695517
+#~ msgid "Add Account"
+#~ msgstr "Pridanie účtu"
+
+# account dialog group
+#~ msgid "Mail"
+#~ msgstr "Pošta"
+
+# GtkLabel label
+#~ msgid "Calendar"
+#~ msgstr "Kalendár"
+
+# account dialog group
+#~ msgid "Contacts"
+#~ msgstr "Kontakty"
+
+#~ msgid "Chat"
+#~ msgstr "Rozhovor"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Nastavuje sa"
+
+#~ msgid "Toner Level"
+#~ msgstr "Úroveň tonera"
+
+#~ msgid "Supply Level"
+#~ msgstr "Úroveň náplne"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Inštaluje sa"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktívnych"
+#~ msgstr[1] "%u aktívna"
+#~ msgstr[2] "%u aktívne"
+
+# button atk
+#~ msgctxt "button"
+#~ msgid "Add"
+#~ msgstr "Pridať"
+
+# GtkLabel label
+#~ msgid "Supply"
+#~ msgstr "Náplň"
+
+# GtkLabel label
+#~ msgid "Jobs"
+#~ msgstr "Úlohy"
+
+# GtkButton label
+#~ msgid "Show _Jobs"
+#~ msgstr "_Zobraziť úlohy"
+
+# GtkLabel label
+#~ msgid "label"
+#~ msgstr "menovka"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Vytlačiť _skúšobnú stranu"
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Nastaviť skratku"
+
+# GtkToolButton label
+#~ msgctxt "button"
+#~ msgid "Add Printer"
+#~ msgstr "Pridať tlačiareň"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Iné účty"
+
+# policy_settings
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Oznáme_nia v bublinách"
+
+# desktop entry name
+#~ msgid "Notification _Banners"
+#~ msgstr "Oznámenia v _bublinách"
+
+#~ msgid "Error creating account"
+#~ msgstr "Chyba pri vytváraní nového účtu"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Naozaj chcete odstrániť tento účet?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Toto neodstráni účet zo servera."
+
+# GtkLabel label
+#~ msgid "No online accounts configured"
+#~ msgstr "Žiadny účet služieb nie je nastavený"
+
+# GtkLabel label
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Pridanie účtu umožní aplikáciam pristupovať k vašim dokumentom, pošte, "
+#~ "kontaktom, kalendáru, rozhovorom a ďalším službám."
+
+# GtkDialog title
+#~ msgid "Add a New Printer"
+#~ msgstr "Pridajte novú tlačiareň"
+
+#~ msgid "No printers detected."
+#~ msgstr "Neboli nájdené žiadne tlačiarne."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Hore"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Dole"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Nerobiť nič"
+
+#~ msgid "Left Ring"
+#~ msgstr "Ľavý kruh"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Režim ľavého kruhu č. %d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Režim pravého kruhu č. %d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Ľavý dotykový pruh"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Režim ľavého dotykového pruhu č. %d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Pravý dotykový pruh"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Režim pravého dotykového pruhu č. %d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Prepínač režimu ľavého dotykového kruhu"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Prepínač režimu ľavého dotykového kruhu"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Prepínač režimu ľavého dotykového pruhu"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Prepínač režimu pravého dotykového pruhu"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Prepínač režimu č. %d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Ľavé tlačidlo č. %d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Pravé tlačidlo č. %d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Horné tlačidlo č. %d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Spodné tlačidlo č. %d"
+
+# GtkListStore row
+#~ msgid "No Action"
+#~ msgstr "Žiadna akcia"
+
+# GtkListStore row
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Kliknutie ľavým tlačidlom myši"
+
+# GtkListStore row
+#~ msgid "Scroll Up"
+#~ msgstr "Rolovať nahor"
+
+# GtkListStore row
+#~ msgid "Scroll Down"
+#~ msgstr "Rolovať nadol"
+
+# GtkListStore row
+#~ msgid "Scroll Right"
+#~ msgstr "Rolovať doprava"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr "Klávesová skratka pre <b>%s</b>. Zadaním novej skratky ju zmeníte"
+
+# GtkLabel label
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Klávesovú skratku môžete upraviť tak, že kliknete na príslušný riadok a "
+#~ "stlačíte novú skratku, alebo ju vymažete stlačením klávesu Backspace."
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Chyba pri prihlásení do účtu"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Poverenia vypršali."
+
+# PM: poverenia vypršali takže je potrebné znova aktivovať účet ručným prihlásením
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Keď chcete tento účet povoliť, prihláste sa."
+
+# button
+#~ msgid "_Sign In"
+#~ msgstr "_Prihlásiť sa"
+
+# GtkToolButton label
+#~ msgid "Remove Shortcut"
+#~ msgstr "Odstrániť skratku"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Neznáma akcia>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Skratka „%s“ sa nedá použiť, pretože by potom nebolo možné normálne písať "
+#~ "týmto klávesom.\n"
+#~ "Prosím, skúste to súčasne s klávesmi ako Ctrl, Alt alebo Shift."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Klávesová skratka „%s“ sa už používa pre\n"
+#~ "„%s“"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Ak pridelíte klávesovú skratku pre „%s“, skratka pre „%s“ bude zrušená."
+
+# button
+#~ msgid "_Reassign"
+#~ msgstr "P_rideliť"
+
+# DK:https://bugzilla.gnome.org/show_bug.cgi?id=736336
+# PV:https://git.gnome.org/browse/gnome-control-center/commit/?id=72cd2e69e13d1c21986cf71ada4d08e5a9a2c210
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Skratka pre akciu „%s“ je previazaná so skratkou pre akciu „%s“. Chcete "
+#~ "automaticky prideliť klávesovú skratku „%s“?"
+
+# DK:https://bugzilla.gnome.org/show_bug.cgi?id=736336
+# PV:https://git.gnome.org/browse/gnome-control-center/commit/?id=72cd2e69e13d1c21986cf71ada4d08e5a9a2c210
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "Skratka „%s“ je momentálne pridelená k akcii „%s“. Ak budete pokračovať, "
+#~ "bude táto skratka zrušená."
+
+# button
+#~ msgid "_Assign"
+#~ msgstr "P_rideliť"
+
+# window title
+#~ msgid "Add Network Connection"
+#~ msgstr "Pridanie nového pripojenia"
+
+# GtkDialog title
+#~ msgid "Login History"
+#~ msgstr "História prihlásení"
+
+# GtkToolButton label
+#~ msgid "Add User Account"
+#~ msgstr "Pridať používateľský účet"
+
+#~ msgid "Welcome to the Control Center"
+#~ msgstr "Vitajte v ovládacom stredisku"
+
+#~ msgid "Select a panel in the sidelist to see the available options"
+#~ msgstr "Vyberte panel v bočnom zozname na zobrazenie dostupných volieb"
+
+#~ msgid "Bond"
+#~ msgstr "Previazanie"
+
+#~ msgid "Team"
+#~ msgstr "Spolupráca"
+
+#~ msgid "Bridge"
+#~ msgstr "Premostenie"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Nepodarilo sa načítať zásuvné moduly VPN"
+
+# asi názov virtuálneho zariadenia
+#~ msgid "Bond slaves"
+#~ msgstr "Členovia previazania"
+
+#~ msgid "(none)"
+#~ msgstr "(žiadne)"
+
+# asi názov virtuálneho zariadenia
+#~ msgid "Bridge slaves"
+#~ msgstr "Členovia premostenia"
+
+# asi názov virtuálneho zariadenia
+#~ msgid "Team slaves"
+#~ msgstr "Členovia spolupráce"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "Zariadenie InfiniBand nepodporuje pripojený režim"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Nebol zvolený certifikát certifikačnej autority"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Nepoužitie certifikátu certifikačnej autority môže viesť k nezabezpečeným "
+#~ "pripojeniam a narušiteľným sieťam Wi-FI. Chcete zvoliť certifikát "
+#~ "certifikačnej autority?"
+
+# button
+#~ msgid "Ignore"
+#~ msgstr "Ignorovať"
+
+# PK: aby to nebolo moc dlhe
+# button
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Zvoliť certifikát CA"
+
+# GtkCheckButton
+#~ msgid "As_k for this password every time"
+#~ msgstr "Vždy sa _pýtať na heslo"
+
+# GtkCheckButton label
+#~ msgid "Don't _warn me again"
+#~ msgstr "Znovu _ma neupozorňovať"
+
+#~ msgid "Yes"
+#~ msgstr "Áno"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Iné"
+
+#~ msgid "_Verify"
+#~ msgstr "O_veriť"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Používateľ s menom „%s“ už existuje."
+
+# label
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Použije sa na určenie vášho geografického umiestnenia"
+
+# GtkToolButton label
+#~ msgid "Resume Printing"
+#~ msgstr "Pokračovať v tlači"
+
+# GtkToolButton label
+#~ msgid "Pause Printing"
+#~ msgstr "Pozastaviť tlač"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Pozdržaná"
+
+# ze je to ulohy vyplyva z kontextu
+#~ msgid "Job Title"
+#~ msgstr "Názov"
+
+#~ msgid "Job State"
+#~ msgstr "Stav"
+
+# GtkButton label
+#~ msgid "Done"
+#~ msgstr "Dokončiť"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Časové _pásmo"
+
+# GtkLabel label
+#~ msgid "Password:"
+#~ msgstr "Heslo:"
+
+# GtkLabel label
+#~ msgid "_Repeat Keys"
+#~ msgstr "Opakovanie kláve_sov"
+
+# GtkLabel label
+#~ msgid "_Cursor Blinking"
+#~ msgstr "Blikanie _kurzora"
+
+# GtkLabel
+#~ msgid "Zoom"
+#~ msgstr "Lupa"
+
+# DK: https://bugzilla.gnome.org/show_bug.cgi?id=701343
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Farba"
+
+# GtkLabel label
+#~ msgid "_Delay:"
+#~ msgstr "Č_akanie:"
+
+# Čakanie:
+# GtkLabel label
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Krátke"
+
+# GtkLabel label
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Nízka"
+
+# čakanie:
+# GtkLabel label
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Dlhé"
+
+# GtkLabel label
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Vysoká"
+
+# GtkLabel label
+#~ msgid "S_peed:"
+#~ msgstr "Rýchlo_sť:"
+
+#~ msgid "For mice and touchpads."
+#~ msgstr "Pre myši a touchpady."
+
+# dialog title
+#~ msgid "Test Your Settings"
+#~ msgstr "Vyskúšanie vašich nastavení"
+
+# GtkLabel label
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Pomaly"
+
+# GtkLabel label
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Rýchlo"
+
+# GtkRadopButton label
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "Ľ_avé"
+
+# GtkRadopButton label
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Pravé"
+
+# PM: nehovoríme tomuto kurzor?
+#  PK: kurzor je v terminali
+# PM: ja som počul iba o textovom kurzore a kurzore myši, tak je to podľa mňa zaužívané (aj keď je diskutabilné či je to zaužívané správne)
+# PK: ja trvam na ukazovatel, nebudeme vsade pisat textovyy kurzor alebo kurzor mysi
+# GtkLabel label
+#~ msgid "_Pointer speed"
+#~ msgstr "Rých_losť ukazovateľa"
+
+# GtkLabel label
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Nízka"
+
+# GtkLabel label
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Vysoká"
+
+# GtkLabel label
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Nízka"
+
+# GtkLabel label
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Vysoká"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Pridať novú tlačiareň"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Bezdrôtové zariadenia vyžadujú mimoriadne napájanie"
+
+# GtkLabel label
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Sprístupnenie cez Bluetooth umožňuje sprístupniť súbory ostatným "
+#~ "zariadeniam"
+
+# GtkLabel label
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Prijímať len z dôverných zariadení"
+
+# MČ: „Preberania“ je šialený preklad. Pozeral som si aj ten modul, čo si nahodil tam tieto šialené preklady a radšej som ho odmietol kontrolovať, lebo by som ti tie preklady všetky zrušil. Nech sa na to podujme niekto iný.
+# PK: tak ako ten priecinok prekladame??
+# PM: názov priečinka má byť "Preberanie" - v jednotnom čísle tak je to aj v iných moduloch aj vo Windowse
+# GtkLabel label
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Uložiť prijaté súbory do priečinka Preberanie"
+
+# cmd desc
+#~ msgid "Show help options"
+#~ msgstr "Zobrazí voľby pomocníka"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Úplný zoznam dostupných volieb zobrazíte zadaním príkazu „%s --help“.\n"
+
+# label
+#~ msgid "When battery power is _critical"
+#~ msgstr "Pri _kritickom vybití batérie"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Vypne bezdrôtové zariadenia"
+
+#~ msgid "United States"
+#~ msgstr "Spojené Štáty"
+
+#~ msgid "Spain"
+#~ msgstr "Španielsko"
+
+#~ msgid "China"
+#~ msgstr "Čína"
+
+# GtkCheckButton label
+#~ msgid "Disable while _typing"
+#~ msgstr "Zakázať počas _písania"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Sieťové služby systému nie sú kompatibilné s touto verziou."
+
+# policy_settings
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Zobrazovať vyskakovacie bubliny"
+
+# policy_settings
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Zobrazovať v uzamknutej obrazovke"
+
+# GtkLabel label
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Zobraziť vyskakovacie bubliny"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Zadajte adresu tlačiarne alebo text na filtrovanie výsledkov"
+
+# dialog title
+#~ msgid "Sorry"
+#~ msgstr "Prepáčte"

--- a/po/sl.po
+++ b/po/sl.po
@@ -10,11 +10,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-09 16:38+0000\n"
-"PO-Revision-Date: 2022-09-09 22:56+0200\n"
-"Last-Translator: Matej Urbančič <mateju@src.gnome.org>\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-09-20 22:11+0200\n"
+"Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
 "Language-Team: Slovenian GNOME Translation Team <gnome-si@googlegroups.com>\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
@@ -23,105 +22,9 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || "
 "n%100==4 ? 3 : 0);\n"
 "X-Poedit-SourceCharset: utf-8\n"
-"X-Generator: Poedit 3.0.1\n"
-
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Sistemsko vodilo"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Poln dostop"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Vodilo seje"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Naprave"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Poln dostop do mape /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Omrežje"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Ima dostop do omrežja"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Domača mapa"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Le za branje"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Datotečni sistem"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Nastavitve"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Dovoljeno spreminjati nastavitve"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"Program %s ima že vgrajena nekatera dovoljenja in teh ni mogoče spreminjati. "
-"V kolikor vas dovoljenja skrbijo, razmislite o odstranitvi oziroma zamenjavi "
-"programa."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "Datoteka in vrste povezav %u, ki so odprte s programom."
-msgstr[1] "Datoteka in vrsta povezave %u, ki je odprta s programom."
-msgstr[2] "Datoteka in vrste povezav %u, ki so odprte s programom."
-msgstr[3] "Datoteka in vrste povezav %u, ki so odprte s programom."
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "Program <b>%s</b> omogoča odpiranje navedenih datotek in povezav."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, fuzzy, c-format
-#| msgid "%s of disk space used"
-msgid "%s of disk space used."
-msgstr "Uporabljenega je %s prostora na disku"
+"X-Generator: Poedit 3.1.1\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -137,7 +40,6 @@ msgid "Install some…"
 msgstr "Namesti …"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Odpri"
 
@@ -161,24 +63,13 @@ msgstr "Iskanje ~"
 msgid "Receive system searches and send results."
 msgstr "Prejmi sistemska iskanja in pošlji zadetke."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Onemogočeno"
 
@@ -192,8 +83,6 @@ msgid "Show system notifications."
 msgstr "Prikaz sistemskih obvestil."
 
 #: panels/applications/cc-applications-panel.ui:133
-#, fuzzy
-#| msgid "Run in background"
 msgid "Run in Background"
 msgstr "Zaženi v ozadju"
 
@@ -206,10 +95,8 @@ msgid "Screenshots"
 msgstr "Zajemanje zaslona"
 
 #: panels/applications/cc-applications-panel.ui:141
-#, fuzzy
-#| msgid "Take pictures with the camera."
 msgid "Take pictures of the screen at any time."
-msgstr "Zajemanje slik s kamero."
+msgstr "Zajemanje zaslonskih slik v vsakem trenutku."
 
 #: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
@@ -348,80 +235,20 @@ msgstr "Počisti predpomnilnik …"
 msgid "Control various application permissions and settings"
 msgstr "Nadzor nad dovoljenji in nastavitvami številnih programov"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "program;flatpak;dovoljenja;nastavitve;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Izbor slike"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Prekliči"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Odpri"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "različne velikosti"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Ni ozadja namizja"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Trenutno ozadje"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Slog"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Privzeto"
 
@@ -445,12 +272,10 @@ msgstr "Videz"
 msgid "Change your background image or the UI colors"
 msgstr "Spremeni sliko ozadja aku barve vmesnika"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-#, fuzzy
-#| msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
-msgstr "Ozadje;slika ozadja;zaslon;Namizje;Stil;Slog;Temna;Svetla;tema;"
+msgstr ""
+"ozadje;slika ozadja;zaslon;Namizje;Stil;Slog;Temna;Svetla;tema;videz;oblika;"
 
 #: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
 #: panels/datetime/cc-datetime-panel.ui:172
@@ -498,9 +323,7 @@ msgstr "Omogočen je strojni letalski način"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Za uporabo vmesnika Bluetooth je treba izklopiti letalski način."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -508,7 +331,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Vklopite in izklopite Bluetooth in povežite naprave"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "souporaba;izmenjava;obex;bluetooth;povezovanje;"
@@ -541,95 +363,35 @@ msgstr "Ni programov, ki bi zahtevali dostop do kamere"
 msgid "Protect your pictures"
 msgstr "Zaščita slik in fotografij"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Postavite napravo za umerjanje na označen kvadrat in pritisnite tipko za "
-"začetek."
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Premaknite napravo za umerjanje na mesto za umerjanje in pritisnite tipko za "
-"nadaljevanje."
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Premaknite napravo za umerjanje na površino in pritisnite tipko za "
-"nadaljevanje."
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Zapri pokrov prenosnika"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Prišlo je do notranje napake, ki ne ni mogoče razrešiti."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Orodja, zahtevana za umerjanje, niso nameščena."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Profila ni mogoče ustvariti."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Ciljne bele točke ni bilo mogoče pridobiti."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Dokončano!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Umerjanje je spodletelo!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Napravo za umerjanje je dovoljeno odstraniti."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ne motite umeritvene naprave med merjenjem"
+"camera;photos;video;webcam;lock;private;privacy;kamera;slike;video;spletna "
+"kamera;zasebnost;posnetek;"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Umerjanje zaslona"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Prekliči"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -646,140 +408,6 @@ msgstr "Na_daljuj"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Končano"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Zaslon prenosnika"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Vgrajena spletna kamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Zaslon %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Optični bralnik %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Kamera %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Tiskalnik %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Spletna kamera %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Omogoči upravljanje barv za %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Pokaži barvne profile za %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Ni umerjeno"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Privzeto: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Barvni prostor: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Preizkusni profil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Izbor datoteke profila ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Uvozi"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Podprti profili ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Vse datoteke"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Zaslon"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Shrani profil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Shrani"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Ustvari barvni profil za izbrane naprave"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Merilne naprave ni mogoče zaznati. Preverite ali je priklopljena in povezana "
-"na ustrezen način."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Merilna naprava ne podpira profiliranja tiskalnika."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Vrsta naprave trenutno ni podprta."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -922,7 +550,6 @@ msgstr "_Uvozi datoteko …"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -934,9 +561,7 @@ msgstr ""
 "Vsaka naprava zahteva posodobljen barvni profil za ustrezno barvno "
 "upravljanje."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Več podrobnosti"
 
@@ -1068,82 +693,6 @@ msgstr "D65 (fotografija in grafika)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standardni barvni prostor"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Preizkusni profil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Samodejno"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Nizka kakovost"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Srednja kakovost"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Visoka kakovost"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Privzeta barva RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Privzeta barva CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Privzeta sivina"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Tovarniški umeritveni podatki, ki jih zagotavlja proizvajalec"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Celozaslonsko popravilo zaslona s tem profilom ni mogoče."
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Ta profil morda ni več natančen."
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Barva"
@@ -1153,14 +702,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Umerite barvo svojih naprav kot so zasloni, fotoaparati ali tiskalniki"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Barva;ICC;Profil;Umerjanje;Tiskalnik;Zaslon;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Drugo …"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1175,13 +719,8 @@ msgid "No languages found"
 msgstr "Ni najdenih jezikov"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Več …"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Odklenite za spreminjanje nastavitev"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1212,157 +751,6 @@ msgstr "Zmanjšanje ure"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Zmanjšanje minute"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Danes"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Včeraj"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d ur"
-msgstr[1] "%d ura"
-msgstr[2] "%d uri"
-msgstr[3] "%d ure"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minut"
-msgstr[1] "%d minuta"
-msgstr[2] "%d minuti"
-msgstr[3] "%d minute"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekund"
-msgstr[1] "%d sekunda"
-msgstr[2] "%d sekundi"
-msgstr[3] "%d sekunde"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekund"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Vroča točka"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-urni"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "12-urni"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1457,17 +845,11 @@ msgstr "Samodejni izbor _časovnega pasu"
 msgid "Requires location services enabled and internet access"
 msgstr "Zahteva dostop do omrežja in omogočene geolokacijske storitve"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Omogočeno"
 
@@ -1475,15 +857,43 @@ msgstr "Omogočeno"
 msgid "Time Z_one"
 msgstr "_Časovni pas"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Odkleni"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Oblika _izpisa časa"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datumi"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekund"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Koledar"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Števila"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Spreminjanje sistemskega časa, datuma in časovnega območja"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Ura;Časovni pas;Mesto;"
@@ -1530,22 +940,11 @@ msgstr "Privzeti programi"
 msgid "Configure Default Applications"
 msgstr "Nastavitev privzetih programov"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "privzeto;program;prednostno;priljubljeno;media;predstavnost;sistem;"
 "podrobnosti;info;informacije;različica;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Pošiljanje poročil o tehničnih napakah omogoča izboljšave distribucije %s. "
-"Poročila so poslana brezimno in brez kakršnihkoli osebnih podatkov. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1563,46 +962,9 @@ msgstr "Diagnostika napak"
 msgid "Report your problems"
 msgstr "Pošiljajte poročila o težavah"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#, fuzzy
-#| msgid "Diagnostics"
 msgid "diagnostics;crash;"
-msgstr "Diagnostika napak"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Omogočeno"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Onemogočeno"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Ali naj se uveljavijo spremembe?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Sprememb ni mogoče uveljaviti"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "To je lahko zaradi strojnih omejitev."
+msgstr "diagnostika;spori;napake;sesutje;"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1652,31 +1014,6 @@ msgstr "Prvi zaslon"
 msgid "Night Light"
 msgstr "Nočna osvetlitev"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Ležeče"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Pokončno desno"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Pokončno levo"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Ležeče (obrnjeno)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1701,17 +1038,28 @@ msgctxt "display setting"
 msgid "Scale"
 msgstr "Prilagodi velikost"
 
-#: panels/display/cc-night-light-page.ui:22
+#: panels/display/cc-display-settings.ui:101
 #, fuzzy
-#| msgid "Night Light"
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Naravno drsenje"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
-msgstr "Nočna osvetlitev"
+msgstr "Nočna osvetlitev ni na voljo"
 
 #: panels/display/cc-night-light-page.ui:33
 msgid ""
 "This could be the result of the graphics driver being used, or the desktop "
 "being used remotely"
 msgstr ""
+"To je lahko posledica uporabljenega grafičnega gonilnika ali namizja, ki se "
+"uporablja na daljavo."
 
 #. Inhibit the redshift functionality until the next day starts
 #: panels/display/cc-night-light-page.ui:58
@@ -1795,7 +1143,6 @@ msgstr "Zasloni"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Izbor načina uporabe povezanih zaslonov in projektorjev"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1804,67 +1151,6 @@ msgstr ""
 "pult;panel;projektor;xrandr;zaslon;ločljivost;osveževanje;monitor;noč;"
 "svetloba;svetlost;modra;rdeči zamik;zora;mrak;barve;"
 
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr ""
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr ""
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-#, fuzzy
-#| msgid "Camera is Turned Off"
-msgid "Secure Boot is Turned Off"
-msgstr "Kamera je izklopljena"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
 "Secure boot prevents malicious software from being loaded when the device "
@@ -1872,116 +1158,14 @@ msgid ""
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
+"Varen zagon preprečuje nalaganje zlonamerne programske opreme ob zagonu "
+"naprave.\n"
+"\n"
+"Za več podrobnosti se obrnite na proizvajalca strojne opreme ali podporo."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Uspešno končano"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Spodletelo"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Varnostna raven 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Varnostna raven 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Varnostna raven 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Varnostna raven 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Varnostna raven"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr ""
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -1995,355 +1179,9 @@ msgstr "Raven 2"
 msgid "Level 3"
 msgstr "Raven 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
-msgstr ""
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection"
-msgstr "Različica strojne programske opreme"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware Write Protection Lock"
-msgstr "Različica strojne programske opreme"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Region"
-msgstr "Različica strojne programske opreme"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware BIOS Descriptor"
-msgstr "Različica strojne programske opreme"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr ""
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr ""
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr ""
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr ""
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr ""
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr ""
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-#, fuzzy
-#| msgid "Suspend"
-msgid "Suspend To RAM"
-msgstr "Zaustavi"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-#, fuzzy
-#| msgid "Suspend"
-msgid "Suspend To Idle"
-msgstr "Zaustavi"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr ""
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr ""
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-#, fuzzy
-#| msgid "Display Configuration"
-msgid "TPM Platform Configuration"
-msgstr "Nastavitve zaslona"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr ""
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Posodobitve strojne programske opreme"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware Attestation"
-msgstr "Različica strojne programske opreme"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "Firmware Updater Verification"
-msgstr "Različica strojne programske opreme"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr ""
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "AMD Firmware Replay Protection"
-msgstr "Različica strojne programske opreme"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-#, fuzzy
-#| msgid "Firmware Version"
-msgid "AMD Firmware Write Protection"
-msgstr "Različica strojne programske opreme"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr ""
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr ""
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Ni veljavno"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Ni onemogočeno"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Zaklenjeno"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Ni zaklenjeno"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr ""
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Ni šifrirano"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr ""
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-#, fuzzy
-#| msgid "Not calibrated"
-msgid "Not Tainted"
-msgstr "Ni umerjeno"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "NAjdeno"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Ni mogoče najti"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Podprto"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Ni podprto"
+msgstr "Ni dogodkov"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2351,9 +1189,8 @@ msgstr "Varnost naprave"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
 msgid "Host firmware security status"
-msgstr ""
+msgstr "Varnostno stanje vdelane programske opreme gostitelja"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2361,49 +1198,6 @@ msgid ""
 msgstr ""
 "zaslon;zaklep;diagnostika;crash;sesutje;zasebnost;hrošči;nedavno;začasno;tmp;"
 "index;ime;network;omrežje;istovetnost;identiteta;podatki;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Neznano"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bitni sistem"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bitni sistem"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Neznano"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Ni na voljo"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo sistema"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2497,11 +1291,6 @@ msgstr "O programu"
 msgid "View information about your system"
 msgstr "Pregled podrobnosti sistema"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2580,6 +1369,12 @@ msgstr "Zaganjalniki"
 msgid "Launch help browser"
 msgstr "Zagon brskalnika pomoči"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Nastavitve"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Zagon računala"
@@ -2601,7 +1396,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Iskanje"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistem"
 
@@ -2650,15 +1445,6 @@ msgstr "Zmanjšaj velikost pisave"
 msgid "High contrast on or off"
 msgstr "Omogoči ali onemogoči visok kontrast slike"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Ni najdenih vhodnih virov"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Drugo"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Dodaj vhodni vir"
@@ -2691,107 +1477,9 @@ msgstr "Možnosti"
 msgid "View Keyboard Layout"
 msgstr "Pokaži razporeditev tipkovnice"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Odstrani"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Bližnjica po meri"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Drugotna tipka"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Tipka za izmenjavo omogoča uporabo dodatnih znakov. Ti so pogosto natisnjeni "
-"na tipkovnici kot tretja možnost."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Leva izmenjalka (Alt)"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Desna izmenjalka (Alt)"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Leva tipka Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Desna tipka Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Tipka Meni"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Desna krmilka (Ctrl)"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Sestavljalna tipka"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Sestavljalna tipka omogoča vnos velikega števila različnih znakov. Za "
-"uporabo najprej pritisnite sestavljalno tipko, nato pa zaporedje drugih "
-"znakov. Na primer; pritisnite sestavljalko, potem <b>C</b> in nato <b>o</b>. "
-"Izpisal se bo znak <b>©</b>. Z zaporedjem sestavljalka, <b>a</b> in nato "
-"<b>'</b> pa ustvari znak <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Zaklep črk"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Zaklep drsnika"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Posnemi zaslon"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Vhodni vir je mogoče preklopiti z uporabo tipkovne bližnjice %s.\n"
-"Nastavitve je mogoče spremeniti med nastavitvami bližnjic tipkovnice."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2821,47 +1509,21 @@ msgstr "Vnos posebnih znakov"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Načini vpisovanja simbolov in različic črk z uporabo tipkovnice."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Drugotna tipka"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Sestavljalna tipka"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Tipkovne bližnjice"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Pregled in prilagoditev bližnjic"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d spremenjenih"
-msgstr[1] "%d spremenjena"
-msgstr[2] "%d spremenjeni"
-msgstr[3] "%d spremenjene"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Ali želite ponastaviti vse tipkovne bližnjice?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Ponastavljanje tipkovnih bližnjic lahko vpliva na tiste po meri. Dejanja ni "
-"mogoče povrniti."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Prekliči"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Ponastavi vse"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2901,33 +1563,6 @@ msgstr "Dodaj tipkovno bližnjico"
 msgid "No keyboard shortcut found"
 msgstr "Ni določene tipkovne bližnjice"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s je že uporabljen za %s. Če ga zamenjate, bo %s onemogočen."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Vpišite novo tipkovno bližnjico"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Nastavi bližnjico po meri"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Nastavi tipkovno bližnjico"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Vpišite novo tipkovno bližnjico za zamenjavo %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Dodaj bližnjico po meri"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Odstrani"
@@ -2939,7 +1574,6 @@ msgstr "_Zamenjaj"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Nastavi"
 
@@ -2977,6 +1611,11 @@ msgstr "Brez"
 msgid "Reset the shortcut to its default value"
 msgstr "Ponastavi tipkovno bližnjico na privzeto vrednost"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Privzeto uporabi tiskalnik"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Tipkovnica"
@@ -2989,7 +1628,6 @@ msgstr ""
 "Prilagajanje tipkovnih bližnjic, nastavite možnosti tipkanja, razporeditve "
 "in vhodni viri"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3031,7 +1669,6 @@ msgstr "Ni programov, ki bi zahtevali dostop do geolokacijskih podatkov"
 msgid "Protect your location information"
 msgstr "Zaščitite podrobnosti o trenutnem mestu"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "location;gps;private;privacy;lokacija;mesto;zasebnost;osebno;satelit;"
@@ -3065,10 +1702,9 @@ msgstr "Ni programov, ki bi zahtevali dostop do mikrofona"
 msgid "Protect your conversations"
 msgstr "Zaščita pogovorov"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
-msgstr ""
+msgstr "mikrofon;snemanje;aplikacija;zasebnost;"
 
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
@@ -3095,83 +1731,139 @@ msgstr "Leva"
 msgid "Right"
 msgstr "Desna"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Preišči mesta"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Miška"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Hitrost kazalke miške"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Naravno drsenje"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Odsek"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Drsenje premika vsebino in ne pogleda."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Drsenje premika vsebino in ne pogleda."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Dejavno"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Sledilna ploščica"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Hitrost kazalke sledilne ploščice"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Udarjanje za klik"
 
-#: panels/mouse/cc-mouse-panel.ui:150
-#, fuzzy
-#| msgid "Tap to _click"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
-msgstr "Udarjanje za _klik"
+msgstr "Udarjanje za klik"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Dvo-_prstno drsenje"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Hitrost kazalke sledilne ploščice"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Robni drsnik"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Zaklep drsnika"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dvostransko"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Poskusite klikniti, dvojno klikniti in drseti"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Pet klikov za GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dvojni klik, osnovni gumb"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Enojni klik, osnovni gumb"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dvojni klik, srednji gumb"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Enojni klik, srednji gumb"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dvojni klik, drugi gumb"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Enojni klik, drugi gumb"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3184,7 +1876,6 @@ msgstr ""
 "Spremenite občutljivost svoje miške ali drsne ploščice in izberite desno ali "
 "levo ročnost"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3266,31 +1957,18 @@ msgstr "Večopravilnost"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Upravljanje nastavitev za učinkovito delo in večopravilnost"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-#, fuzzy
-#| msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Namizje;Večopravilnost;"
-"Učinkovitost;Prilagajanje;Delo;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Ojoj, prišlo je do napake. Stopite v stik s ponudnikom programske opreme."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Program NetworkManager mora biti zagnan."
+"Učinkovitost;Prilagajanje;Delo;delovne površine;vroči kot;kot;namizja;"
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Druge naprave"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3302,59 +1980,16 @@ msgstr "Dodaj povezavo"
 msgid "Not set up"
 msgstr "Ni nastavljeno"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Ne-varno omrežje (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Varno omrežje (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Varno omrežje (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Varno omrežje (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Varno omrežje"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Povezano"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Možnosti …"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Ob priklopu vroče točke se onemogoči povezava z omrežjem %s, zato dostop po "
-"Wi-Fi ne bo več mogoč."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Vsebovati mora najmanj 8 znakov"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3406,22 +2041,6 @@ msgstr "Samodejno ustvari geslo"
 msgid "_Turn On"
 msgstr "_Vklopi"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Omrežje Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-"Ali naj se zaustavi vroča vstopna točka in se prekine povezava vseh "
-"uporabnikov?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Zaustavi vročo vstopno točko"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Letalski način"
@@ -3466,89 +2085,14 @@ msgstr "Vidna omrežja"
 msgid "NetworkManager needs to be running"
 msgstr "Program NetworkManager mora biti zagnan."
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ojoj, prišlo je do napake. Stopite v stik s ponudnikom programske opreme."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "Varnost 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Varnost"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Ohrani"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Trajno"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Naključno"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabilo"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Naslov MAC, vpisan na tem mestu, bo uporabljen kot strojni naslov za omrežno "
-"napravo, ki ustvarja povezavo. Zmožnost je poznana kot kloniranje naslova "
-"MAC oziroma lažno predstavljanje. Primer: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Napredno odpiranje"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Podjetniški"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Brez"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Nikoli"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3560,183 +2104,6 @@ msgstr[1] "pred %i dnem"
 msgstr[2] "pred %i dnevoma"
 msgstr[3] "pred %i dnevi"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Brez"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Šibko"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "V redu"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Dobro"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Odlično"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Naslov IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Naslov IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP naslov"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Pozabi povezavo"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Odstrani profil povezave"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Odstrani VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Podrobnosti"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "samodejno"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Istovetnost"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Izbriši naslov"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Izbriši smer"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "↓Brez"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "↓Ključ WEP 40/128-bit (Šestnajstiški ali ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "↓128-bitno šifrirno geslo WEP"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "↓LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "↓Dinamični WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "↓Osebni WPA in WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "↓Podjetniški WPA in WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "Osebni WPA3"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3746,8 +2113,20 @@ msgstr "Moč signala"
 msgid "Link speed"
 msgstr "Hitrost povezave"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Varnost"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Naslov IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Naslov IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Strojni naslov"
 
@@ -3756,12 +2135,17 @@ msgid "Supported Frequencies"
 msgstr "Podprte frekvence"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Privzeta smer"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3825,7 +2209,7 @@ msgstr "Poveži le krajevno"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Ročno"
 
@@ -3869,9 +2253,8 @@ msgstr "Prehod"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Samodejno"
 
@@ -3883,7 +2266,7 @@ msgstr "Samodejni DNS"
 #: panels/network/connection-editor/ip4-page.ui:192
 #: panels/network/connection-editor/ip6-page.ui:202
 msgid "DNS server address(es)"
-msgstr ""
+msgstr "Naslovi strežnika DNS"
 
 #: panels/network/connection-editor/ip4-page.ui:200
 #: panels/network/connection-editor/ip6-page.ui:210
@@ -3924,92 +2307,9 @@ msgstr "Samodejno, le DHCP"
 msgid "Prefix"
 msgstr "Predpona"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Ni mogoče odpreti urejevalnika povezav"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Nov profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Neveljavna nastavitev %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, fuzzy, c-format
-#| msgid "Privacy settings"
-msgid "Invalid setting %s"
-msgstr "Nastavitve zasebnosti"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Uvozi iz datoteke …"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Dodaj VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Varnost"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Povezave VPN ni mogoče uvoziti "
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Datoteke »%s« ni mogoče prebrati ali pa ta ne vsebuje prepoznanih podatkov o "
-"povezavi VPN\n"
-"\n"
-"Napaka: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Izbor datoteke za uvoz"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Datoteka z imenom »%s« že obstaja."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Zamenjaj"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-"Ali želite zamenjati povezavo %s z nastavitvami povezave VPN, ki jih "
-"shranjujete?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Ni mogoče izvoziti povezave VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Povezave VPN »%s« ni mogoče izvoziti v %s.\n"
-"\n"
-"Napaka: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Izvoz povezavo VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4023,103 +2323,40 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Omrežje"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Nadzor nad načini povezovanja v internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "omrežje;brezžično;Wi-Fi;Wifi;IP;LAN;Proxy;Posredniški;širokopasovno;modem;"
 "bluetooth;vpn;vlan;most;vez;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Omrežje Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Nadzor nad načini povezovanja v omrežja Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "omrežje;brezžično;Wi-Fi;Wifi;IP;LAN;Proxy;Posredniški;širokopasovno;modem;"
 "bluetooth;vpn;vlan;most;vez;DNS;vroča točka;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "nikoli"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "danes"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "včeraj"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Nazadnje uporabljeno"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Žično"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Dodaj novo povezavo"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Omrežne podrobnosti o izbranem omrežju z nastavitvami po meri in "
-"pripadajočimi gesli bodo izgubljene."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Izbriši"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Znana omrežja Wi-Fi"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Izbriši"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Sistemska pravila onemogočajo uporabo vročih točk"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Brezžična naprava ne podpira načina vročih točk"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Samodejno odkrivanje posredniškega strežnika je uporabljena, kadar "
-"nastavitveni naslov URL ni naveden."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Možnost ni priporočljiva za nezavarovana javna omrežja."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4138,6 +2375,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Ponudnik"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP naslov"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4222,289 +2463,6 @@ msgstr "_Omogoči vročo točko Wi-Fi …"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Znana omrežja Wi-Fi"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Neznano stanje"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Neupravljano"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Nedostopno"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "V povezovanju"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Zahtevana je overitev"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Prekinjanje povezave"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Povezovanje je spodletelo"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Stanje baterije ni znano (manjka)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Nastavitev je spodletela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Nastavljanje IP je spodletelo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Nastavitev IP je časovno poteklo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Zahtevana so bila ustrezna gesla, ki pa niso bila podana"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Prosilnik 802.1X je odklopljen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Nastavitev prosilnika 802.1X je spodletela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Prosilnik 802.1X je spodletel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Prosilnik 802.1X je potreboval preveč časa za overjanje"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Storitev PPP ni uspešno zagnana"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Storitev PPP je prekinjena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP je spodletel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Začenjanje odjemalca DHCP je spodletelo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Napaka odjemalca DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Odjemalec DHCP je spodletel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Začenjanje storitve souporabe povezave je spodletelo."
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Storitev souporabe povezave je spodletela."
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Začenjanje storitve AutoIP je spodletelo."
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Napaka storitve AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Storitev AutoIP je spodletela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Povezava je zasedena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Ni klicnega signala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Ni mogoče vzpostaviti signala povezave"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Zahteva klicanja je časovno potekla"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Poskus klicanja je spodletel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Začenjanje modema je spodletelo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Izbor določenega APN je spodletel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Iskanje omrežij ni dejavno"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Vpis omrežja je zavrnjen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Čas za vpis omrežja je potekel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Vpis v zahtevano omrežju je spodletela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Preverjanje PIN je spodletelo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Napravi morda manjka zahtevana strojna programska oprema"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Dejavna povezava je izginila"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Predviden je bila obstoječa povezava"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modema ni mogoče najti"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Povezava Bluetooth je spodletela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Kartica SIM ni vstavljena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Zahtevana je šifra SIM PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Zahtevana je šifra SIM PUK"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Kartica SIM je neustrezna"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Odvisnost povezave je spodletela"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Manjka strojna programska oprema"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabel ni priklopljen"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "nedoločena napaka varnostnega protokola 802.1x (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "ni izbrane datoteke"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "nedoločena napaka overjenja datoteke eap-method"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Zasebni ključi DER, PEM, PGP ali PKCS#12"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Potrdila DER ali PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "manjka datoteka EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Datoteke PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4553,14 +2511,6 @@ msgstr "_Notranja overitev"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Dovoli samodejno _odbiro PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "manjka uporabniško ime EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "manjka geslo EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4586,15 +2536,6 @@ msgstr "_Geslo"
 msgid "Sho_w password"
 msgstr "Pokaži _geslo"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "neveljavno potrdilo EAP-PEAP CA: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "neveljavno potrdilo EAP-PEAP CA: potrdilo ni določeno"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4616,7 +2557,6 @@ msgid "C_A certificate"
 msgstr "Potrdilo _CA"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4631,62 +2571,6 @@ msgstr "Ni zahtevanega dovoljenja _CA"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Različica PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "manjka uporabniško ime EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "manjka geslo EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "manjka istovetnost EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "neveljavno potrdilo EAP-TLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "neveljavno potrdilo EAP-TLS CA: potrdilo ni določeno"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "neveljaven zasebni ključ EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "neveljavno uporabniško potrdilo EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Nešifrirani zasebni ključi niso varni"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Videti je, da izbrani zasebni ključi niso zaščiteni z geslom. To bi lahko "
-"ogrozilo varnost podatkov. Izberite z geslom zaščiten zasebni ključ.\n"
-"\n"
-"(Zasebne ključe lahko zaščitite z geslom z OpenSSL.)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Izbor osebnega potrdila"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Izbor osebnega ključa"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4703,15 +2587,6 @@ msgstr "Osebni _ključ"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Geslo _zasebnega ključa"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "neveljavno potrdilo EAP-TTLS CA: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "neveljavno potrdilo EAP-TTLS CA: potrdilo ni določeno"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4734,14 +2609,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domena"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Prišlo je do neznane napake overjanja varnosti 802.1x."
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "↓LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4769,62 +2645,10 @@ msgstr "Varovani EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "_Overitev"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Izbor datoteke"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "manjka uporabniško ime za leap"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "manjka geslo leap"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Ni vpisanega gesla za Wi-Fi"
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Vrsta"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "manjka ključ wep"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"neveljavni podatki wpa-psk: ključ dolžine %zu mora vsebovati le števila v "
-"šestnajstiškem sistemu"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"neveljavni podatki wpa-psk: ključ dolžine %zu mora vsebovati le znake ASCII"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"neveljavni podatki wpa-psk: napačna dolžina ključa %zu. Biti mora biti ali "
-"5/13 (ASCII) oziroma 10/26 (šestnajstiško)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "neveljavni podatki wpa-psk: šifrirna koda mora biti vpisana"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
-"neveljavni podatki wpa-psk: šifrirna koda mura biti krajša od 64 znakov"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4849,21 +2673,6 @@ msgstr "_Pokaži ključ"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "Določilo _WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"neveljavni podatki wpa-psk: neustrezna dolžina ključa %zu. Biti mora [8,63] "
-"bajtov oziroma 64 števil v šestnajstiškem sistemu"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"neveljavni podatki wpa-psk: ni mogoče tolmačiti 64-bitnega ključa v "
-"šestnajstiškem sistemu"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4918,27 +2727,9 @@ msgstr "Pokaži _obvestila na zaklenjenem zaslonu"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Nadzirajte katera obvestila so prikazana in kaj prikazujejo"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Obvestila;sporočila;pojavna sporočila;opozorila;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Drugi"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "Račun %s je odstranjen."
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Napaka med odstranjevanjem računa"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4964,17 +2755,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Dodaj račun"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Račun %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Odstrani račun"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Spletni računi"
@@ -4984,10 +2764,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Nadzirajte svoje spletne račune in se odločite za kaj jih boste uporabili"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4995,10 +2771,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Splet;Klepet;Koledar;Elektronska pošta;Stiki;"
 "Računi;ownCloud;oblak;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Neznan čas"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5018,13 +2790,6 @@ msgstr[1] "%i ura"
 msgstr[2] "%i uri"
 msgstr[3] "%i ure"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5040,190 +2805,6 @@ msgstr[0] "minut"
 msgstr[1] "minuta"
 msgstr[2] "minuti"
 msgstr[3] "minute"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "Še %s do polne napolnjenosti"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Opozorilo: na voljo je še %s delovanja"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Še %s do konca delovanja"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Polna napolnjenost"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Naprava se ne polni"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Prazno"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Polnjenje"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Praznjenje"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Brezžična miška"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Brezžična tipkovnica"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Neprekinjen oskrba z napetostjo"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Digitalni pomočnik"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobilni telefon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Predvajalnik predstavnih datotek"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablični računalnik"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Računalnik"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Igralniška vhodna naprava"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Baterija"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Glavno"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Dodatno"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Baterije"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Ob _nedejavnosti"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Zaustavi"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Izklop"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Preidi v mirovanje"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Ničesar"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Med delovanjem na bateriji"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Ob priklopu"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Nikoli"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Samodejen prehod v pripravljenost"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Zmogljivostni način delovanja je začasno onemogočen zaradi visoke delovne "
-"temperature."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Sprememba delovanja: zmogljivostni način začasno ni na voljo. Za ponovno "
-"vzpostavitev je treba napravo premakniti na stabilno površino."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Zmogljivostni način je začasno onemogočen."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Nizko stanje baterije: omogočen je varčevalni način delovanja. Predhodno "
-"uporabljeni način bo obnovljen, ko bo baterija dovolj napolnjena."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Varčevalni način delovanja je sprožil program »%s«."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Zmogljivostni način delovanja je sprožil program »%s«."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5284,6 +2865,15 @@ msgstr "100 minut"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 uri"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterija"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Naprave"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5362,33 +2952,6 @@ msgstr "Napajanje iz _baterije"
 msgid "Delay"
 msgstr "Časovni zamik"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Zmogljivost"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Visoka zmogljivost delovanja in velika poraba energije."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Uravnoteženo"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Običajna zmogljivost delovanja in zmerna poraba energije."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Varčno"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Zmanjšana zmogljivost delovanja in majhna poraba energije."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Napajanje"
@@ -5398,7 +2961,6 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Oglejte si stanje baterije in spremenite nastavitve varčevanje z energijo"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5406,27 +2968,6 @@ msgid ""
 msgstr ""
 "v delovanju;v pripravljenosti;hiberniranje;v mirovanju;baterija;zaslon;DPMS;"
 "nedejavnost;svetlost;energija;poraba;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Tiskalnik »%s« je bil izbrisan."
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Dodajanje novega tiskalnika je spodletelo."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Ni mogoče naložiti uporabniškega vmesnika: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Odklenite za dodajanje tiskalnikov in spreminjanje nastavitev"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5438,7 +2979,6 @@ msgstr ""
 "Dodajte tiskalnike, oglejte si posle tiskalnika in se odločite, kako želite "
 "tiskati"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Tiskalnik;Vrsta;Tiskanje;Papir;Črnilo;Toner;"
@@ -5446,8 +2986,6 @@ msgstr "Tiskalnik;Vrsta;Tiskanje;Papir;Črnilo;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Dodaj tiskalnik"
 
@@ -5487,40 +3025,17 @@ msgstr ""
 msgid "Username"
 msgstr "Uporabniško ime"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Podrobnosti %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Ni mogoče najti ustreznega gonilnika"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Izbor datoteke PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Datoteke opisa tiskalnika PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
+"Imena tiskalnika ne smejo vsebovati presledka, tabulatorja, lojtre (#) ali "
+"poševnice (/)."
 
 #: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Mesto"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Gonilnik"
 
@@ -5548,121 +3063,14 @@ msgstr "Izbor gonilnik tiskalnika"
 msgid "Loading drivers database…"
 msgstr "Poteka nalaganje zbirke gonilnikov …"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Prekliči"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Izberi"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Tiskalnik JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Tiskalnik LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Enostransko"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Dolga stranica (standardno)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Kratka stranica (zrcaljeno)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Pokončno"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Ležeče"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Obrnjeno ležeče"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Obrnjeno pokončno"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Nadaljuj"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Premor"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "V čakanju"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Premor"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Zahtevana je overitev"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Izvajanje"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Zaustavljeno"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Preklicano"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Prekinjeno"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Zaključeno"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Premakni opravilo na vrh vrste"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5671,19 +3079,6 @@ msgstr[0] "%u opravil tiskalnika zahteva overitev"
 msgstr[1] "%u opravilo tiskalnika zahteva overitev"
 msgstr[2] "%u opravili tiskalnika zahtevata overitev"
 msgstr[3] "%u opravila tiskalnika zahtevajo overitev"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s – dejavni posli"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Vpišite poverila za tiskanje na %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5711,206 +3106,11 @@ msgstr "_Overi"
 msgid "No Active Printer Jobs"
 msgstr "Ni dejavnih poslov tiskalnika"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Odkleni strežnik tiskanja"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Odkleni %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Vnesite uporabniško ime in geslo za ogled tiskalnikov na %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Poteka iskanje tiskalnikov"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Zaporedna vrata"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Vzporedna vrata"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Mesto: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Naslov: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Strežnik zahteva overitev"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dvostransko"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Vrsta papirja"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Vir papirja"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Pladenj za papir"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Ločljivost"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Predhodno filtriranje GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Strani na stran"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dvostransko"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Usmerjenost"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Splošno"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Nastavitev strani"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Namestitvene možnosti"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Posel"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Kakovost slike"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Barvni profili"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Zaključevanje"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Napredno"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Preizkusna stran"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Preizkusna stran"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Samodejno izberi"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Privzeto za tiskalnik"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Vstavi samo pisave GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Pretvori v PS ravni 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Pretvori v PS ravni 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Brez predhodnega filtriranja"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Proizvajalec"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Ni dejavnih poslov"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5919,115 +3119,6 @@ msgstr[0] "%u poslov"
 msgstr[1] "%u posel"
 msgstr[2] "%u posla"
 msgstr[3] "%u posli"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Počisti glave tiskalnika"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Tonerja je malo"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Zmanjkalo je tonerja"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Razvijalca je malo"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Zmanjkalo je razvijalca"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Zaloge označevalnika je malo"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Zaloge označevalnika je zmanjkalo"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Odprt pokrov"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Odprta vrata"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Malo papirja"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Ni papirja"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Nepovezano"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Zaustavljeno"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Zbiralnik odpadkov je skoraj poln"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Zbiralnik odpadkov je poln"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Optični foto prevodnik ne bo več dolgo deloval"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Optični foto prevodnik ne deluje več"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Pripravljen"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Ne sprejema poslov"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Obdelovanje"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6051,6 +3142,10 @@ msgstr "Počisti glave tiskalnika"
 msgid "Remove Printer"
 msgstr "Odstrani tiskalnik"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ni dejavnih poslov"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6071,16 +3166,21 @@ msgid "Restart"
 msgstr "Ponoven zagon"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Dodaj tiskalnik …"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Dodaj tiskalnik …"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Ni nastavljenih tiskalnikov"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6088,7 +3188,6 @@ msgstr ""
 "Kaže, da sistemska storitev\n"
 "za tiskanje trenutno ni na voljo."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Jezikovna določila"
@@ -6116,16 +3215,6 @@ msgstr "Iskati je mogoče države ali jezike."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Predogled"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperialni"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrični"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6156,10 +3245,6 @@ msgid "Logout…"
 msgstr "Odjava …"
 
 #: panels/region/cc-region-panel.ui:45
-#, fuzzy
-#| msgid ""
-#| "The language setting is used for interface text and web pages. Formats is "
-#| "used for numbers, dates, and currencies."
 msgid ""
 "The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
@@ -6167,20 +3252,24 @@ msgstr ""
 "Jezikovne nastavitve določajo jezik besedila vmesnika in spletnih strani. "
 "Uporabijo se zapisi števil, datumov in denarnih enot."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Račun"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Jezik"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Jezikovna določila"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Prijavni zaslon"
 
@@ -6192,100 +3281,9 @@ msgstr "Področje in Jezik"
 msgid "Select your display language and formats"
 msgstr "Izbor jezika za zapisov"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "jezik,razporeditev;tipkovnica;vnos;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Vprašaj, kaj storiti"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Ne naredi ničesar"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Odpri mapo"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Drugi nosilci"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Izbor programa za zvočne CD-je"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Izberite program za video DVD-je"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr ""
-"Izberite kateri program naj se zažene, ko je predvajalnik glasbe povezan"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Izberite program, ki naj teče, ko je povezan fotoaparat"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Izbor programa za programske CD-je"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "zvočni DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "prazen Blu-Ray disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "prazen CD disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "prazen DVD disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "Prazen disk HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "Bralnik e-knjig"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD video disk"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Slikovni CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Programska oprema za okolje Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6335,7 +3333,6 @@ msgstr "Odstranljivi nosilci"
 msgid "Configure Removable Media settings"
 msgstr "Nastavitve odstranljivih nosilcev"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6344,114 +3341,6 @@ msgstr ""
 "naprava;sistem;podrobnosti;pomnilnik;procesor;različica;privzeto;program;"
 "povrnjeno:prednostno;cd;dvd;usb;zvok;slika;video;disk;odstrani;predstavnost;"
 "samodejni zagon;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Zaslon se izklopi"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekund"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 minuta"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 minuti"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 minute"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 minut"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minut"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 ura"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 minuta"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 minuti"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 minute"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 minute"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Nikoli"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6489,43 +3378,41 @@ msgstr "Čas po katerem se po ugasnjenem zaslonu ta tudi samodejno zaklene."
 msgid "Show _Notifications on Lock Screen"
 msgstr "Pokaži _obvestila na zaklenjenem"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Pokaži _obvestila na zaklenjenem zaslonu"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Prepovej nove naprave _USB"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr ""
 "Prepreči novi napravam USB povezovanje v sistem, ko je zaslon zaklenjen"
 
-#: panels/screen/cc-screen-panel.ui:108
-#, fuzzy
-#| msgid "Privacy"
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
-msgstr "Zasebnost"
+msgstr "Zasebnost zaslona"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Omeji kot pogleda"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Zaslon"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Nastavitve zaslona"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "screen;lock;private;privacy;zaslon;zaklep;zasebno;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Izbor mesta"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_V redu"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6556,10 +3443,6 @@ msgstr "Drugi"
 msgid "Add Location"
 msgstr "Dodaj mesto"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Ni najdenih programov"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Iskanje programov"
@@ -6587,101 +3470,13 @@ msgstr ""
 "Nadzirajte, kateri programi v pregledu dejavnosti prikazujejo rezultate "
 "iskanja"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "iskanje;išči;najdi;kazalo;skrij;zasebnost;zadetki;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Ni izbranega omrežja za souporabo"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Omrežja"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Omogočeno"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Onemogočeno"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Omogočeno"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Dejavno"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Izbor mape"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Dodaj"
-
-#: panels/sharing/cc-sharing-panel.c:736
-#, fuzzy
-#| msgid "Media Sharing"
-msgid "Enable media sharing"
-msgstr "Souporaba predstavnih datotek"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Možnost souporabe datotek omogoča drugim uporabnikom  na trenutnem omrežju "
-"dostop do Javne mape s protokolom: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Oddaljenim uporabnikom dovoli povezavo z ukazom Secure Shell, če je "
-"oddaljena prijava omogočena:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-#, fuzzy
-#| msgid "Personal File Sharing"
-msgid "Enable personal media sharing"
-msgstr "Osebna souporaba datotek"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-#, fuzzy
-#| msgid "Device Name"
-msgid "Device name copied"
-msgstr "Ime naprave"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Naslov naprave je kopiran"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Uporabniško ime je kopirano"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-#, fuzzy
-#| msgid "Password"
-msgid "Password copied"
-msgstr "Geslo"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6789,16 +3584,12 @@ msgid "Encryption Fingerprint"
 msgstr "Prstni odtis šifriranja"
 
 #: panels/sharing/cc-sharing-panel.ui:435
-#, fuzzy
-#| msgid ""
-#| "The encryption fingerprint can be seen in connecting clients and should "
-#| "be identical"
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
 "identical."
 msgstr ""
-"Šifrirni prstni odtis je viden v programih, ki omogočajo povezovanje in mora "
-"biti enak vpisanemu"
+"Šifrirni prstni odtis je viden v programih, ki omogočajo povezovanje, in "
+"mora biti povsod enak."
 
 #: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
@@ -6816,7 +3607,6 @@ msgstr "Mape"
 msgid "Control what you want to share with others"
 msgstr "Nadzor nad souporabo podatkov in datotek z drugimi uporabniki"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6833,10 +3623,6 @@ msgstr "Omogoči ali onemogoči oddaljene prijave"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Za spremembo možnosti oddaljenega prijavljanja je zahtevana overitev"
 
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Po meri"
-
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
 msgstr "Klik"
@@ -6847,15 +3633,15 @@ msgstr "Niz znakov"
 
 #: panels/sound/cc-alert-chooser.ui:28
 msgid "Swing"
-msgstr ""
+msgstr "Nihanje"
 
 #: panels/sound/cc-alert-chooser.ui:36
 msgid "Hum"
-msgstr ""
+msgstr "Brnenje"
 
 #: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 msgid "Balance"
-msgstr "Uravnoteženost"
+msgstr "Uravnoteženo"
 
 #: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 msgid "Fade"
@@ -6869,11 +3655,6 @@ msgstr "Zadaj"
 msgid "Front"
 msgstr "Spredaj"
 
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Preizkušanje %s"
-
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
 msgstr "Kliknite zvočnik za preizkus"
@@ -6883,10 +3664,8 @@ msgid "System Volume"
 msgstr "Sistemska glasnost"
 
 #: panels/sound/cc-sound-panel.ui:12
-#, fuzzy
-#| msgid "System Volume"
 msgid "Master volume"
-msgstr "Sistemska glasnost"
+msgstr "Glavna glasnost"
 
 #: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
@@ -6928,11 +3707,6 @@ msgstr "Glasnost"
 msgid "Alert Sound"
 msgstr "Zvok opozoril"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100 %"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Nemo"
@@ -6946,83 +3720,12 @@ msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr ""
 "Spreminjanje zvokovnih naprav, glasnosti zvoka in povezljivost z dogodki"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Kartica;Mikrofon;Glasnost;Pojemanje;Uravnavanje;Bluetooth;Naglavne slušalke;"
 "Zvok;Dovod;Odvod;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Prekinjena povezava"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "V povezovanju"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Povezano"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Napaka overitve"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Poteka overjanje"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Zmanjšana zmogljivost"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Povezano in overjeno"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Neznano"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Naprava je bila overjena ob:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Povezava je bila vzpostavljena ob:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Naprava je bila vpisana ob:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Overjanje naprave je spodletelo: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Pozabljanje naprave je spodletelo: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7058,56 +3761,6 @@ msgstr "Overi in poveži"
 msgid "Forget Device"
 msgstr "Pozabi napravo"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Napaka"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Overjeno"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Podsistem Thunderbolt (boltd) ni nameščen oziroma je neustrezno nastavljen."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "Dovoli neposreden dostop do naprav, kot so sidrišča in zunanje GPE."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr ""
-"Naprave je mogoče pripeti le z uporabo priklopa USB oziroma zaslonskega "
-"priklopa."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Sistema Thunderbolt ni mogoče zaznati.\n"
-"Podpora sistemu morda ni na voljo, sistem je v zaganjalniku BIOS onemogočen, "
-"ali pa je nastavljen na nepodprto varnostno raven."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Podpora Thunderbolt je onemogočena med nastavitvami BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Varnostne ravni Thunderbolt ni mogoče določiti."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Napaka preklapljanja neposrednega načina: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Ni podpore za naprave Thunderbolt"
@@ -7119,6 +3772,10 @@ msgstr "Povezava s podsistemom Thunderbolt ni mogoča."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Neposredni dostop"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Dovoli neposreden dostop do naprav, kot so sidrišča in zunanje GPE."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7136,7 +3793,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Upravljanje naprav Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;zasebnost;"
@@ -7337,42 +3993,6 @@ msgstr "_Omogoči s tipkovnico"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Vklopi ali izklopi zmožnosti dostopnosti s tipkovnico"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "privzeta"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "srednja"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "velika"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "zelo velika"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "največja"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d točk"
-msgstr[1] "%d točka"
-msgstr[2] "%d točki"
-msgstr[3] "%d točke"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Vedno pokaži meni dostopnosti"
@@ -7487,31 +4107,6 @@ msgstr "Zabliskaj _celoten zaslon"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Zabliskaj _celotno okno"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Kratko"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ zaslona"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ zaslona"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ zaslona"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Dolgo"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7668,7 +4263,6 @@ msgstr "Barvni učinki"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Naj bo enostavnejše videti, slišati, tipkati, kazati in klikati"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7680,114 +4274,6 @@ msgstr ""
 "besedilo;pisava;velikost;AccessX;lepljive;počasne;odskočne;tipke;zamik;"
 "odskočne;dvojne;klik;ponovitev;zvok;tipkanje;tipkovnica,nastavitve;sluh;"
 "kontrast;zvok;približanje;zoom;zaslon;velikost;prilagoditve;prikrojitve;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 ura"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 dan"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dni"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dni"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Ali naj se izbrišejo vsi predmeti iz smeti?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Vsi predmeti v smeteh bodo trajno izbrisani."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Izprazni _smeti"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Ali naj se izbrišejo vse začasne datoteke?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Vse začasne datoteke bodo trajno izbrisane."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Počisti začasne datoteke"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 dan"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 dni"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dni"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Trajno"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7854,7 +4340,6 @@ msgstr "Zgodovina datoteke in smeti"
 msgid "Don't leave traces"
 msgstr "Ne puščaj sledi"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
@@ -7862,57 +4347,6 @@ msgstr ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 "uporaba;nedavno;zgodovina;datoteke;začasno;zasebno;osebno;smeti;brisanje;"
 "povrnitev;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Vpis mora biti skladen s spletnim naslovom ponudnika prijave."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Dodajanje računa je spodletelo"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Gesli se ne skladata."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Vpis računa je spodletel"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Ni podprtega načina za overitev s to domeno"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Pridružitev v domeno je spodletela"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Prijavno ime ne deluje.\n"
-"Poskusite vpisati drugo ime."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Prijavno geslo je napačno.\n"
-"Poskusite vpisati drugo geslo."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Prijava v domeno je spodletela"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Domene ni mogoče najti. Morda je vpisana napačno."
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7948,8 +4382,6 @@ msgid "Enterprise Login"
 msgstr "Prijava v poslovno domeno"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-#, fuzzy
-#| msgid "User accounts which are managed by a company or organisation."
 msgid "User accounts which are managed by a company or organization."
 msgstr "Uporabniški računi, ki jih upravlja podjetje ali ustanova."
 
@@ -7966,10 +4398,6 @@ msgstr ""
 "Poslovna prijava omogoča prijavo na to napravo z obstoječim poslovnim "
 "uporabniškim računom. Ta račun je mogoče uporabiti tudi za dostop do "
 "poslovnih virov na internetu."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Brskanje med več slikami"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8039,224 +4467,6 @@ msgstr "_Izbriši prstne odtise"
 msgid "Fingerprint Enroll"
 msgstr "Prijava s prstnim odtisom"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr ""
-"pred izvajanjem tega opravila mora biti vzpostavljena povezava z napravo"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "naprava je že v uporabi v drugem opravilu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "ni ustreznih dovoljenj za izvajanje tega dejanja"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "ni poslanih opravil za tiskanje"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Povezovanje z napravo med vpisovanjem je spodletelo."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Povezovanje s čitalcem prstnih odtisov je spodletelo."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr ""
-"Povezovanje z ozadnjim programom čitalca prstnih odtisov je spodletelo."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Prikaz prstnih odtisov je spodletel: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Brisanje prstnih odtisov je spodletelo: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Levi palec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Levi sredinec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Levi kazalec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Levi prstanec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Levi mezinec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Desni palec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Desni sredinec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Desni kazalec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Desni prstanec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Desni mezinec"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Neznan prst"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Končano"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Naprava za prijavo s prstnim odtisom ni priklopljena"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Shramba naprave za branje prstnega odtisa je polna"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Odčitavanje novega prstnega odtisa je spodletelo."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Začenjanje odčitavanja je spodletelo: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Odčitavanje novega prstnega odtisa je spodletelo."
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Zaustavljanje odčitavanja je spodletelo: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Ponavljajoče dvignite in položite prst na bralnik za odčitavanje prstnega "
-"odtisa"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Ponovno odčitaj ta prst …"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Odčitaj nov prstni odtis"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Sproščanje naprave za branje prstnega odtisa %s je spodletelo: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Napaka branja naprave"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Povezovanje naprave za branje prstnega odtisa %s je spodletelo: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Pridobivanje naprav za prstni odtis je spodletelo: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Ta teden"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Predhodni teden"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s – %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Seja je končana"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Seja je začeta"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s – dejavnost računa"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Predhodno"
@@ -8264,18 +4474,6 @@ msgstr "Predhodno"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Naslednje"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Izberite drugo geslo."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Znova vnesite trenutno geslo."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Gesla ni mogoče spremeniti."
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8297,6 +4495,10 @@ msgstr "Novo geslo"
 msgid "Confirm Password"
 msgstr "Potrdi geslo"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Gesli se ne skladata."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Dovoli uporabniku nastavljanje gesla ob naslednji prijavi."
@@ -8304,135 +4506,6 @@ msgstr "Dovoli uporabniku nastavljanje gesla ob naslednji prijavi."
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Nastavi geslo"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Ni mogoče samodejno pridružiti tej vrsti domene"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Ni mogoče najti take domene ali takega področja"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Ni se mogoče prijaviti kot %s v domeno %s."
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Napačno geslo, poskusite znova."
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Z domeno %s povezava ni mogoča: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Napaka med brisanjem uporabnika"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Preklic oddaljeno vodenega uporabnika je spodletel"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Ni mogoče izbrisati lastnega računa."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s je še vedno prijavljen"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Izbris uporabnika, ki je trenutno prijavljen, lahko vpliva na delovanje "
-"sistema."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Ali želite obdržati datoteke uporabnika %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Mogoče je ohraniti domačo mapo, vrstilno mapo pošte in začasne datoteke tudi "
-"med brisanjem uporabniškega računa."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Izbriši datoteke"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Ohrani datoteke"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Ali ste prepričani, da želite preklicati oddaljeno voden račun uporabnika %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Izbriši"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Račun je onemogočen"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Nastavljeno bo ob naslednji prijavi"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Brez"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Trenutno dejavna prijava"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Napaka med povezovanjem s storitvijo računov"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Prepričajte se, da je paket AccoutnService nameščen in omogočen."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Okno je treba za spreminjanje nastavitev najprej odkleniti"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Izbriši izbran uporabniški račun"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Za izbris izbranega uporabniškega\n"
-"računa, kliknite na ikono *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Odklenite za spreminjanje nastavitev in uporabnikov"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8460,7 +4533,6 @@ msgid "Full name"
 msgstr "Polno Ime"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Uredi"
 
@@ -8522,7 +4594,6 @@ msgstr "Odklenite za dodajanje uporabniškega računa."
 msgid "Add or remove users and change your password"
 msgstr "Upravljanje uporabnikov in spreminjanje gesel"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8567,177 +4638,6 @@ msgstr "Upravljanje uporabniških računov"
 msgid "Authentication is required to change user data"
 msgstr "Za spremembo podatkov uporabnika je zahtevana overitev"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Novo geslo mora biti drugačno od starega."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Zamenjajte nekaj črk in številk."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Poskusite še malo spremeniti geslo."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Geslo brez uporabniškega imena bi bilo bolj varno."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Nikoli ne uporabite imena za geslo."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Poskusite se izogniti nekaterim besedam, ki so del geslu."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Izogibajte se uporabi pogostih besed."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Izogibajte se zgolj zamenjavi razvrstitve obstoječih besed."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Dodajte več številk."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Dodajte več velikih črk."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Dodajte več malih črk."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Uporabite posebne znake, kot so na primer ločila."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Priporočljivo je uporabiti različne črke številke in posebne znake."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Poskusite se izogniti ponavljanju znakov."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Poskusite se izogniti ponavljanju znakov. Priporočljivo je uporabiti "
-"različne črke številke in posebne znake."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Izognite se zaporedjem, kot sta 1234 in abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Geslo mora biti daljše. Poskusite dodati črke, številke in druge znake."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Priporočeno je uporabiti male in velike črke, vmes pa dodati tudi kakšno "
-"številko."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Dodajanje črk, številk in ločil poveča moč gesla."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Overitev je spodletela"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Novo geslo je prekratko"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Novo geslo je preveč enostavno"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Novo geslo je preveč podobno staremu"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Novo geslo je bilo nedavno že uporabljeno."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Novo geslo mora vsebovati številke ali posebne znake"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Novo geslo je enako staremu"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Vaše geslo je bilo spremenjeno od začetne overitve!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Novo geslo ne vsebuje dovolj različnih znakov"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Neznana napaka"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Uporabniško ime je lahko sestavljeno iz malih črk angleške abecede, številk "
-"in posebnih znakov » - _ «."
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Uporabniško ime ni na voljo! Izberite drugo ime."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Uporabniško ime je predolgo."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8770,52 +4670,10 @@ msgstr "Z udarjanjem na ciljna mest se umeri zaslon zaslona na dotik."
 msgid "Mis-click detected, restarting…"
 msgstr "Zaznan je napačen klik, opravilo bo znova začeto …"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Gumb %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Določeno programi"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Pošlji kode tipk"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Preklop zaslona"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Pokaži zaslonsko pomoč"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Na prenosnik je priklopljena tablica"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Na zunanji zaslon je priklopljena tablica"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Zunanja tablična naprava"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Zunanja tablična naprava"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Vsi zasloni"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8913,22 +4771,6 @@ msgstr "Klik desnega gumba miške"
 msgid "Forward"
 msgstr "Posreduj"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Običajno pisalo, občutljivo na moč in vgrajeni drsnik"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Običajno pisalo, občutljivo na moč, kot in vrtljivi pritisk"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Običajno pisalo, občutljivo na moč in kot pritiska"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Običajno pisalo, občutljivo na moč pritiska"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Tablica Wacom"
@@ -8939,54 +4781,96 @@ msgstr ""
 "Nastavitev preslikave gumbov in prilagoditev občutljivosti paličice grafične "
 "tablice"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablica;Wacom;Stylus;Radirka;Eraser;Miška;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Nova bližnjica …"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulirani drugi klik"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Programska oprema za okolje Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Tonerja je malo"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Časovni zamik drugotnega klika"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Programska oprema za okolje Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Upravljanje nastavitev za učinkovito delo in večopravilnost"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Dostopne točke"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Dodaj"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Shrani"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Opravilo je preklicano"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Napakar:</b> dostop do spreminjanja nastavitev je onemogočen"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Napaka:</b> Napaka mobilne naprave"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Ni registrirano"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registrirano"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Gostovanje"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Poteka iskanje …"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Zavrnjeno"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9016,231 +4900,13 @@ msgstr "Lastna številka"
 msgid "Device Details"
 msgstr "Podrobnosti naprave"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Proizvajalec"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Različica strojne programske opreme"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Le G2"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Le G3"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Le G4"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Le 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (prednostno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-#| msgid "2G, 3G (Preferred), 4G"
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (prednostno), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-#| msgid "2G (Preferred), 3G, 4G"
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (prednostno), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (prednostno), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (prednostno), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-#| msgid "3G, 4G (Preferred)"
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-#| msgid "3G, 4G (Preferred)"
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (prednostno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-#| msgid "3G (Preferred), 4G"
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (prednostno), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-#| msgid "2G, 3G (Preferred), 4G"
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (prednostno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-#| msgid "2G (Preferred), 3G, 4G"
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (prednostno), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-#| msgid "2G, 3G, 4G (Preferred)"
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-#| msgid "2G, 3G (Preferred), 4G"
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (prednostno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-#| msgid "2G (Preferred), 3G, 4G"
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (prednostno), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (prednostno), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (prednostno), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (prednostno), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-#| msgid "2G, 4G (Preferred)"
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-#| msgid "2G (Preferred), 4G"
-msgid "2G (Preferred), 5G"
-msgstr "2G (prednostno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-#| msgid "3G, 4G (Preferred)"
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-#| msgid "3G (Preferred), 4G"
-msgid "3G (Preferred), 5G"
-msgstr "3G (prednostno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-#| msgid "3G, 4G (Preferred)"
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (prednostno)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-#| msgid "3G (Preferred), 4G"
-msgid "4G (Preferred), 5G"
-msgstr "4G (prednostno), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Neznano"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Odkleni kartico SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Odkleni"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Vpisati je treba kodo PIN za kartico SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Vpišite kodo PIN za odklepanje kartice SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Vpisati je treba kodo PUK za kartico SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Vpišite kodo PUK za odklepanje kartice SIM"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9259,26 +4925,6 @@ msgstr[0] "Na voljo imate še %u poskusov."
 msgstr[1] "Na voljo imate še %u poskus."
 msgstr[2] "Na voljo imate še %u poskusa"
 msgstr[3] "Na voljo imate še %u poskuse."
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Vpisano je napačno geslo"
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Koda PUK mora biti 8-znakovna vrednost"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Vpiši novo kodo PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Koda PIN mora biti dolžine 4–8 znakov"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Poteka odklepanje …"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9336,94 +4982,6 @@ msgstr "Zakleni kartico SIM s kodo PIN"
 msgid "M_odem Details"
 msgstr "Podrobnosti _modema"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Delovanje telefona je spodletelo"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "NI vzpostavljene povezave s telefonom"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Opravilo ni dovoljeno!"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Opravilo ni podprto"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Kartica SIM ni vstavljena"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Zahtevana je koda PIN za kartico SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Zahtevana je koda PUK za kartico SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Kartica SIM je nedostopna"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "Kartica SIM je zasedena"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Neveljavno geslo"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Zahtevana je koda PIN2 za kartico SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Zahtevana je koda PIN2 za kartico SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Predmeta ni mogoče najti"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Ni dostopnih omrežnih storitev"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Zakasnitev omrežja"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Uporaba storitve GPRS ni dovoljena"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Gostovanje na tem območju ni dovoljeno"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Nedoločena napaka GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Brez napake"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Dejanje je preklicano"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Dostop je zavrnjen"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Neznana napaka"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Način omrežja"
@@ -9439,11 +4997,6 @@ msgstr "Izbor omrežja"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Osveži omrežne ponudnike"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9501,7 +5054,6 @@ msgstr "Mobilno omrežje"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Nastavitve telefonije in mobilnih podatkovnih povezav"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;wwan;telephony;telefon;kartica;klicanje;mobilno;sim;mobile;"
@@ -9518,41 +5070,13 @@ msgstr "Program je osnovni vmesnik za prilagajanje nastavitev sistema."
 msgid "The GNOME Project"
 msgstr "Projekt GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Pokaži različico"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Omogoči podrobni način"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Poišči niz"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Izpiši možna imena pultov in končaj"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Pult za prikaz"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PULT][ARGUMENT …]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Kategorije nastavitev"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Zasebnost"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Razpoložljivi pulti:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9610,7 +5134,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Prekliče iskanje"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Možnosti;Nastavitve;"
@@ -9648,8 +5171,6 @@ msgid ""
 msgstr ""
 "Niz s shranjenimi podatki višine, širine in razpetega stanja okna programa."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9659,8 +5180,6 @@ msgstr[1] "%u izhod"
 msgstr[2] "%u izhoda"
 msgstr[3] "%u izhodi"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9670,3104 +5189,3140 @@ msgstr[1] "%u vhod"
 msgstr[2] "%u vhoda"
 msgstr[3] "%u vhodi"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sistemski zvoki"
+#~ msgid "System Bus"
+#~ msgstr "Sistemsko vodilo"
 
-#~ msgid "Light"
-#~ msgstr "Svetlo"
+#~ msgid "Full access"
+#~ msgstr "Poln dostop"
 
-#~ msgid ""
-#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-#~ "network;identity;"
-#~ msgstr ""
-#~ "zaslon;zaklep;diagnostika;zasebnost;hrošči;sesutje;nedavno;začasno;tmp;"
-#~ "index;ime;omrežje;istovetnost;"
+#~ msgid "Session Bus"
+#~ msgstr "Vodilo seje"
 
-#~ msgid "Display Arrangement"
-#~ msgstr "Upravljanje zaslonov"
+#~ msgid "Full access to /dev"
+#~ msgstr "Poln dostop do mape /dev"
 
-#~ msgid "Set"
-#~ msgstr "Nastavi"
+#~ msgid "Has network access"
+#~ msgstr "Ima dostop do omrežja"
 
-#~ msgid "Lock your screen"
-#~ msgstr "Zakleni zaslon"
+#~ msgid "Home"
+#~ msgstr "Domača mapa"
 
-#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-#~ msgstr "DER ali PEM potrdila (*.der, *.pem, *.crt, *.cer)"
+#~ msgid "Read-only"
+#~ msgstr "Le za branje"
 
-#~ msgid "Add a Printer…"
-#~ msgstr "Dodaj tiskalnik …"
+#~ msgid "File System"
+#~ msgstr "Datotečni sistem"
 
-#~ msgid "Bark"
-#~ msgstr "Lajež"
-
-#~ msgid "Drip"
-#~ msgstr "Kapljanje vode"
-
-#~ msgid "Glass"
-#~ msgstr "Udarec po steklu"
-
-#~ msgid "Sonar"
-#~ msgstr "Zvok sonarja"
-
-#~ msgid "GNOME Settings Sound Panel"
-#~ msgstr "Nastavitve zvoka GNOME"
-
-#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
-#~ msgstr "Nastavitve miške in sledilne naprave GNOME"
-
-#~ msgid "GNOME Settings Background Panel"
-#~ msgstr "Nastavitve ozadja GNOME"
-
-#~ msgid "GNOME Settings Keyboard Panel"
-#~ msgstr "Nastavitve tipkovnice GNOME"
-
-#~ msgid "More Warm"
-#~ msgstr "Bolj toplo"
-
-#~ msgid "Less Warm"
-#~ msgstr "Manj toplo"
-
-#, c-format
-#~ msgid "%s VPN"
-#~ msgstr "VPN %s"
-
-#~ msgid " "
-#~ msgstr " "
-
-#~ msgid "Authenticate"
-#~ msgstr "Overi"
+#~ msgid "Can change settings"
+#~ msgstr "Dovoljeno spreminjati nastavitve"
 
 #, c-format
 #~ msgid ""
-#~ "Screen sharing allows remote users to view or control your screen by "
-#~ "connecting to %s"
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
 #~ msgstr ""
-#~ "Prikaz zaslona omogoča oddaljenim uporabnikom ogled in tudi nadzor čez "
-#~ "zaslona po povezavi %s"
-
-#~ msgid "_Screen Sharing"
-#~ msgstr "Souporaba _zaslona"
-
-#~ msgid "_Password:"
-#~ msgstr "_Geslo:"
-
-#~ msgid "_Show Password"
-#~ msgstr "Pokaži _geslo"
-
-#~ msgid "Access Options"
-#~ msgstr "Možnosti dostopa"
-
-#~ msgid "_New connections must ask for access"
-#~ msgstr "_Nove povezave morajo zahtevati dovoljenje za dostop"
-
-#~ msgid "_Require a password"
-#~ msgstr "_Zahtevaj geslo"
-
-#~ msgid "Show the screenshot UI"
-#~ msgstr "Pokaži vmesnik zajemalnika zaslona"
-
-#~ msgid "Take a screenshot"
-#~ msgstr "Zajemi zaslonsko sliko"
-
-#~ msgid "Take a screenshot of a window"
-#~ msgstr "Zajemi zaslonsko sliko okna"
-
-#~ msgid "Show the screen recording UI"
-#~ msgstr "Pokaži vmesnik zajemalnika zaslona"
-
-#~ msgid "Move up"
-#~ msgstr "Premakni navzgor"
-
-#~ msgid "Move down"
-#~ msgstr "Premakni navzdol"
-
-#~ msgid "Allow the applications below to use your microphone."
-#~ msgstr "Dovoli navedenim programom uporabo mikrofona."
-
-#~ msgid "Standard"
-#~ msgstr "Običajno"
-
-#~ msgid "Account _Type"
-#~ msgstr "Vrsta _računa"
-
-#~ msgid "Allow user to set a password when they next _login"
-#~ msgstr "Dovoli uporabniku nastaviti geslo ob naslednji _prijavi"
-
-#~ msgid "Set a password _now"
-#~ msgstr "_Nastavi geslo"
-
-#~ msgid "You must be online in order to add enterprise users."
-#~ msgstr "Vzpostavite povezavo za dodajanje poslovnih prijavnih računov."
-
-#~ msgid "Take a Picture…"
-#~ msgstr "Zajem slike …"
-
-#~ msgid "Your account"
-#~ msgstr "Račun"
-
-#~ msgid ""
-#~ "To make changes,\n"
-#~ "click the * icon first"
-#~ msgstr ""
-#~ "Za spreminjanje,\n"
-#~ "kliknite na ikono *"
-
-#~ msgid "Create a user account"
-#~ msgstr "Ustvari uporabniški račun"
-
-#~ msgid "User Icon"
-#~ msgstr "Uporabniška ikona"
-
-#~ msgid "Account Settings"
-#~ msgstr "Nastavitve računa"
-
-#~ msgid "Authentication & Login"
-#~ msgstr "Overitev in prijava"
-
-#~ msgid "This will be used to name your home folder and can’t be changed."
-#~ msgstr ""
-#~ "S tem imenom bo poimenovana osebna mapa. Izbire kasneje ni mogoče "
-#~ "spreminjati."
-
-#~ msgid ""
-#~ "Choose the format for numbers, dates and currencies. Changes take effect "
-#~ "on next login."
-#~ msgstr ""
-#~ "Izbor zapisa števil, datumov in denarne enote. Spremembe se uveljavijo ob "
-#~ "naslednji prijavi."
-
-#~ msgid "My Account"
-#~ msgstr "Moj račun"
-
-#~ msgid "Language"
-#~ msgstr "Jezik"
-
-#~ msgid "The language used for text in windows and web pages."
-#~ msgstr "Jezik, uporabljen za besedilo oken in spletnih strani."
-
-#~ msgid "Restart the session for changes to take effect"
-#~ msgstr "Za uveljavitev sprememb se je treba v sejo ponovno zagnati"
-
-#~ msgid "Restart…"
-#~ msgstr "Ponovno zaženi …"
-
-#~ msgid "Login settings are used by all users when logging into the system"
-#~ msgstr ""
-#~ "Nastavitve prijave uporabljajo vsi uporabniki, ki so prijavljeni v sistem"
-
-#~ msgid "Output:"
-#~ msgstr "Izhod:"
-
-#~ msgid "Keep aspect ratio (letterbox):"
-#~ msgstr "Ohrani razmerje velikosti (pisemsko):"
-
-#~ msgid "Map to single monitor"
-#~ msgstr "Preslikaj na en zaslon"
+#~ "Program %s ima že vgrajena nekatera dovoljenja in teh ni mogoče "
+#~ "spreminjati. V kolikor vas dovoljenja skrbijo, razmislite o odstranitvi "
+#~ "oziroma zamenjavi programa."
 
 #, c-format
-#~ msgid "%d of %d"
-#~ msgstr "%d od %d"
-
-#~ msgid "Display Mapping"
-#~ msgstr "Preslikava prikaza"
-
-#~ msgid "Stylus"
-#~ msgstr "Stylus"
-
-#~ msgid "Tablet (absolute)"
-#~ msgstr "Tablica (absolutno)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Sledilna ploščica (relativno)"
-
-#~ msgid "Tablet Preferences"
-#~ msgstr "Možnosti tablice"
-
-#~ msgid "_Help"
-#~ msgstr "Pomo_č"
-
-#~ msgid "Bluetooth Settings"
-#~ msgstr "Nastavitve vmesnika Bluetooth"
-
-#~ msgid "Tracking Mode"
-#~ msgstr "Način sledenja"
-
-#~ msgid "Map Buttons…"
-#~ msgstr "Preslikaj gumbe …"
-
-#~ msgid "Adjust mouse settings"
-#~ msgstr "Nastavitve miške"
-
-#~ msgid "Adjust display resolution"
-#~ msgstr "Prilagodi ločljivost zaslona"
-
-#~ msgid "Decouple Display"
-#~ msgstr "Loči zaslon"
-
-#~ msgid "No stylus found"
-#~ msgstr "Ni zaznanega pisala"
-
-#~ msgid ""
-#~ "Please move your stylus to the proximity of the tablet to configure it"
-#~ msgstr "Približajte pisalo nad ploščico za prilagajanje nastavitev."
-
-#~ msgid "Top Button"
-#~ msgstr "Zgornji gumb"
-
-#~ msgid "Lower Button"
-#~ msgstr "Spodnji gumb"
-
-#~ msgid "Lowest Button"
-#~ msgstr "Spodnji gumb"
-
-#~ msgid "Save a screenshot to $PICTURES"
-#~ msgstr "Shrani zaslonsko sliko v mapo $PICTURES"
-
-#~ msgid "Save a screenshot of an area to $PICTURES"
-#~ msgstr "Shrani zaslonsko sliko področja v mapo $PICTURES"
-
-#~ msgid "Copy a screenshot to clipboard"
-#~ msgstr "Kopiraj zaslonsko sliko v odložišče"
-
-#~ msgid "Copy a screenshot of a window to clipboard"
-#~ msgstr "Kopiraj zaslonsko sliko okna v odložišče."
-
-#~ msgid "Copy a screenshot of an area to clipboard"
-#~ msgstr "Kopiraj zaslonsko sliko področja v odložišče"
-
-#~ msgid "Record a short screencast"
-#~ msgstr "Posnemi kratek posnetek zaslona"
-
-#~ msgid ""
-#~ "Control which search results are shown in the Activities Overview. The "
-#~ "order of search results can also be changed by moving rows in the list."
-#~ msgstr ""
-#~ "Prikaz zadetkov iskanja v predogledu dejavnosti je prilagodljiv po meri. "
-#~ "Vrstni red iskanja je mogoče tudi spremeniti z razporejanjem vrstic v "
-#~ "seznamu."
-
-#~ msgid "Web Links"
-#~ msgstr "Spletne povezave"
-
-#~ msgid "Git Links"
-#~ msgstr "Povezave Git"
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "Datoteka in vrste povezav %u, ki so odprte s programom."
+#~ msgstr[1] "Datoteka in vrsta povezave %u, ki je odprta s programom."
+#~ msgstr[2] "Datoteka in vrste povezav %u, ki so odprte s programom."
+#~ msgstr[3] "Datoteka in vrste povezav %u, ki so odprte s programom."
 
 #, c-format
-#~ msgid "%s Links"
-#~ msgstr "Povezave %s"
-
-#~ msgid "Unset"
-#~ msgstr "Odstrani nastavitve"
-
-#~ msgid "Links"
-#~ msgstr "Povezave"
-
-#~ msgid "Hypertext Files"
-#~ msgstr "Spletne datoteke"
-
-#~ msgid "Text Files"
-#~ msgstr "Besedilne datoteke"
-
-#~ msgid "Image Files"
-#~ msgstr "Slikovne datoteke"
-
-#~ msgid "Font Files"
-#~ msgstr "Datoteke pisav"
-
-#~ msgid "Archive Files"
-#~ msgstr "Datoteke arhivov"
-
-#~ msgid "Package Files"
-#~ msgstr "Datoteke paketov"
-
-#~ msgid "Audio Files"
-#~ msgstr "Zvokovne datoteke"
-
-#~ msgid "Video Files"
-#~ msgstr "Video datoteke"
-
-#~ msgid "Permissions & Access"
-#~ msgstr "Dovoljenja in dostop"
-
-#~ msgid ""
-#~ "Data and services that this app has asked for access to and permissions "
-#~ "that it requires."
-#~ msgstr ""
-#~ "Podatki in storitve, do katerih dostop zahteva program za pravilno "
-#~ "delovanje."
-
-#~ msgid "Cannot be changed"
-#~ msgstr "Ni mogoče spreminjati"
-
-#~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a "
-#~ "href=\"privacy\">Privacy</a> Settings."
-#~ msgstr ""
-#~ "Posamezna dovoljenja za programe je mogoče pregledati med nastavitvami <a "
-#~ "href=\"privacy\">zasebnosti</a>."
-
-#~ msgid "Integration"
-#~ msgstr "Podpora"
-
-#~ msgid "Set Desktop Background"
-#~ msgstr "Nastavi ozadje namizja"
-
-#~ msgid "Default Handlers"
-#~ msgstr "Privzeti ročniki"
-
-#~ msgid "Types of files and links that this application opens."
-#~ msgstr "Vrste datotek in povezave, ki jih ta program odpira."
-
-#~ msgid "Usage"
-#~ msgstr "Uporaba"
-
-#~ msgid "How much resources this application is using."
-#~ msgstr "Podatki o vrstah virov, ki jih program uporablja."
-
-#~ msgid "Open in Software"
-#~ msgstr "Odpri v namestilniku"
-
-#~ msgid "Activities"
-#~ msgstr "Dejavnosti"
-
-#~ msgid "Allow the applications below to use your camera."
-#~ msgstr "Dovoli navedenim programom uporabo kamere."
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "Program <b>%s</b> omogoča odpiranje navedenih datotek in povezav."
 
 #, c-format
-#~ msgid "Failed to upload file: %s"
-#~ msgstr "Pošiljanje datoteke je spodletelo: %s"
+#~ msgid "%s of disk space used."
+#~ msgstr "Uporabljenega je %s prostora na disku."
 
-#~ msgid "The profile has been uploaded to:"
-#~ msgstr "Profil je posodobljen na:"
+#~ msgid "Select a picture"
+#~ msgstr "Izbor slike"
 
-#~ msgid "Write down this URL."
-#~ msgstr "Zapišite si ta naslov URL."
+#~ msgid "_Open"
+#~ msgstr "_Odpri"
 
-#~ msgid "Restart this computer and boot your normal operating system."
-#~ msgstr "Ponovno zaženite računalnik v običajno okolje."
+#~ msgid "multiple sizes"
+#~ msgstr "različne velikosti"
 
-#~ msgid "Type the URL into your browser to download and install the profile."
-#~ msgstr "Vpišite naslov URL v brskalnik za prejem in namestitev profila."
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
 
-#~ msgid "Upload profile"
-#~ msgstr "Pošlji profil"
+#~ msgid "No Desktop Background"
+#~ msgstr "Ni ozadja namizja"
 
-#~ msgid "Requires Internet connection"
-#~ msgstr "Zahteva internetno povezavo"
+#~ msgid "Current background"
+#~ msgstr "Trenutno ozadje"
 
-#~ msgid "_Copy"
-#~ msgstr "_Kopiraj"
-
-#~ msgid "Select _All"
-#~ msgstr "Izberi _vse"
-
-#~ msgid "Single Display"
-#~ msgstr "En zaslon"
-
-#~ msgid "Join Displays"
-#~ msgstr "Združi zaslone"
-
-#~ msgid "Display Mode"
-#~ msgstr "Način prikaza"
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Postavite napravo za umerjanje na označen kvadrat in pritisnite tipko za "
+#~ "začetek."
 
 #~ msgid ""
-#~ "Drag displays to match your physical display setup. Select a display to "
-#~ "change its settings."
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
 #~ msgstr ""
-#~ "Premaknite zaslone, da bodo skladni z dejansko postavitvijo zaslonov. Z "
-#~ "izborom zaslona je mogoče prilagoditi tudi lastnosti."
-
-#~ msgid "Active Display"
-#~ msgstr "Dejaven zaslon"
+#~ "Premaknite napravo za umerjanje na mesto za umerjanje in pritisnite tipko "
+#~ "za nadaljevanje."
 
 #~ msgid ""
-#~ "Location services allow applications to know your location. Using Wi-Fi "
-#~ "and mobile broadband increases accuracy."
+#~ "Move your calibration device to the surface position and press “Continue”"
 #~ msgstr ""
-#~ "Storitve določanja trenutnega mesta omogočajo programom dostop do "
-#~ "geolokacijskih podatkov. Uporaba omrežij Wi-Fi in širokopasovnih mobilnih "
-#~ "povezav poveča natančnost določevanja."
+#~ "Premaknite napravo za umerjanje na površino in pritisnite tipko za "
+#~ "nadaljevanje."
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Zapri pokrov prenosnika"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Prišlo je do notranje napake, ki ne ni mogoče razrešiti."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Orodja, zahtevana za umerjanje, niso nameščena."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profila ni mogoče ustvariti."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Ciljne bele točke ni bilo mogoče pridobiti."
+
+#~ msgid "Complete!"
+#~ msgstr "Dokončano!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Umerjanje je spodletelo!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Napravo za umerjanje je dovoljeno odstraniti."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ne motite umeritvene naprave med merjenjem"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Zaslon prenosnika"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Vgrajena spletna kamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Zaslon %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Optični bralnik %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Kamera %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Tiskalnik %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Spletna kamera %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Omogoči upravljanje barv za %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Pokaži barvne profile za %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Ni umerjeno"
+
+#~ msgid "Default: "
+#~ msgstr "Privzeto: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Barvni prostor: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Preizkusni profil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Izbor datoteke profila ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Uvozi"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Podprti profili ICC"
+
+#~ msgid "All files"
+#~ msgstr "Vse datoteke"
+
+#~ msgid "Save Profile"
+#~ msgstr "Shrani profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Ustvari barvni profil za izbrane naprave"
 
 #~ msgid ""
-#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-#~ "com/privacy'>Privacy Policy</a>"
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
 #~ msgstr ""
-#~ "Uporablja storitve za določevanje geolokacije Mozilla: <a href='https://"
-#~ "location.services.mozilla.com/privacy'>Pravila zasebnosti</a>"
+#~ "Merilne naprave ni mogoče zaznati. Preverite ali je priklopljena in "
+#~ "povezana na ustrezen način."
 
-#~ msgid "Allow the applications below to determine your location."
-#~ msgstr "Dovoli navedenim programom uporabo geolokacijskih podatkov."
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Merilna naprava ne podpira profiliranja tiskalnika."
 
-#~ msgid "Double-click timeout"
-#~ msgstr "Časovna omejitev dvojnega klika"
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Vrsta naprave trenutno ni podprta."
 
-#~ msgid "Suspend & Power Button"
-#~ msgstr "Gumb za izklop in prehod v pripravljenost"
+#~ msgid "Standard Space"
+#~ msgstr "Standardni barvni prostor"
 
-#~ msgid "Lap detected: performance mode unavailable"
-#~ msgstr "Sprememba delovanja: zmogljivostni način ni na voljo"
+#~ msgid "Test Profile"
+#~ msgstr "Preizkusni profil"
 
-#~ msgid "High hardware temperature: performance mode unavailable"
-#~ msgstr "Visoka temperatura strojne opreme: zmogljivostni način ni na voljo"
-
-#~ msgid "Performance mode unavailable"
-#~ msgstr "Zmogljivostni način delovanja ni na voljo"
-
-#~ msgid "Some services are disabled because of no network access."
-#~ msgstr ""
-#~ "Nekatere storitve so onemogočene zaradi nevzpostavljene povezave v "
-#~ "omrežje."
-
-#~ msgid "Sound Keys"
-#~ msgstr "Ozvočene tipke"
-
-#~ msgid "Screen Reader"
-#~ msgstr "Zaslonski bralnik"
-
-#~ msgid "_Screen Reader"
-#~ msgstr "_Zaslonski bralnik"
-
-#~ msgid "Unlocking..."
-#~ msgstr "Poteka odklepanje ..."
-
-#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-#~ msgstr "Prijava;Ime;Prstni odtis;Podoba;Logotip;Obraz;Geslo;"
-
-#~ msgid ""
-#~ "Select your display language, formats, keyboard layouts and input sources"
-#~ msgstr "Izberite jezik prikaza, oblike, razporeditve tipk in vnosne vire"
-
-#~ msgid "_Screen Brightness"
-#~ msgstr "_Svetlost zaslona"
-
-#~ msgid "_Keyboard Brightness"
-#~ msgstr "_Svetlost tipkovnice"
-
-#~ msgid "Dim Screen When Inactive"
-#~ msgstr "Zamegli zaslon ob nedejavnosti"
-
-#~ msgid "_Blank Screen"
-#~ msgstr "_Zatemni zaslon"
-
-#~ msgid "_Wi-Fi"
-#~ msgstr "_Omrežje Wi-Fi"
-
-#~ msgid "Wi-Fi can be turned off to save power."
-#~ msgstr "Delovanje Wi-Fi je mogoče izklopiti za varčevanje z energijo."
-
-#~ msgid ""
-#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
-#~ msgstr ""
-#~ "Mobilni širokopasovni (3G, 4G, LTE, ...) prenos je mogoče izklopiti za "
-#~ "varčevanje z energijo."
-
-#~ msgid "_Bluetooth"
-#~ msgstr "_Bluetooth"
-
-#~ msgid "Bluetooth can be turned off to save power."
-#~ msgstr "Delovanje Bluetooth je mogoče izklopiti za varčevanje z energijo."
-
-#~ msgid "Balanced Power"
-#~ msgstr "Uravnotežena poraba"
-
-#~ msgid "Keyboard Shortcut"
-#~ msgstr "Tipkovne bližnjice"
-
-#~ msgid "This can be changed in Customize Shortcuts"
-#~ msgstr ""
-#~ "Nastavitve je mogoče spremeniti med prilagajanjem tipkovnih bližnjic"
-
-#~ msgid "Hold down and type to enter different characters"
-#~ msgstr "Pritisnite in vpišite različne znake"
-
-#~ msgid "Add…"
-#~ msgstr "Dodaj …"
-
-#~ msgid "Left Alt"
-#~ msgstr "Leva izmenjalka (Alt)"
-
-#~ msgid "Right Alt"
-#~ msgstr "Desna izmenjalka (Alt)"
-
-#~ msgid "Left Super"
-#~ msgstr "Leva tipka pop"
-
-#~ msgid "Right Super"
-#~ msgstr "Desna tipka pop"
-
-#~ msgid "Right Ctrl"
-#~ msgstr "Desna krmilka (Ctrl)"
-
-#~ msgid "Alternative Characters Key"
-#~ msgstr "Drugotna tipka"
-
-#~ msgid "Modifiers-only switch to next source"
-#~ msgstr "Preklopi na naslednji vir le s spremenilniki"
-
-#~ msgctxt "keyboard key"
-#~ msgid "Menu Key"
-#~ msgstr "Tipka Meni"
-
-#~ msgctxt "Battery power"
-#~ msgid "Charging"
-#~ msgstr "Polnjenje"
-
-#~ msgctxt "Battery power"
-#~ msgid "Caution"
-#~ msgstr "Opozorilo"
-
-#~ msgctxt "Battery power"
-#~ msgid "Low"
-#~ msgstr "Nizko"
-
-#~ msgctxt "Battery power"
-#~ msgid "Good"
-#~ msgstr "Dobro"
-
-#~ msgctxt "Battery power"
-#~ msgid "Fully charged"
-#~ msgstr "Polna napolnjenost"
-
-#~ msgctxt "Battery power"
-#~ msgid "Empty"
-#~ msgstr "Prazno"
-
-#~ msgid "Previous source"
-#~ msgstr "Predhodni vir"
-
-#~ msgid "Super+Shift+Space"
-#~ msgstr "Tipka pop+Shift+Preslednica"
-
-#~ msgid "Next source"
-#~ msgstr "Naslednji vir"
-
-#~ msgid "Super+Space"
-#~ msgstr "Tipka pop+Preslednica"
-
-#~ msgid "Left+Right Alt"
-#~ msgstr "Leva + desna izmenjalka (Alt)"
-
-#~ msgid "Add user accounts and change passwords"
-#~ msgstr "Upravljanje uporabnikov in spreminjanje gesel"
-
-#~ msgid "Play and record sound"
-#~ msgstr "Predvajaj in snemaj zvok"
-
-#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
-#~ msgstr "Zaznaj omrežnih naprav z uporabo mDNS/DNS-SD (Bonjour/zeroconf)"
-
-#~ msgid "Access bluetooth hardware directly"
-#~ msgstr "Neposreden dostop do bluetooth"
-
-#~ msgid "Use your camera"
-#~ msgstr "Uporabi kamero"
-
-#~ msgid "Print documents"
-#~ msgstr "Natisni dokumente"
-
-#~ msgid "Use any connected joystick"
-#~ msgstr "Uporabi priklopljeno igralno palico"
-
-#~ msgid "Allow connecting to the Docker service"
-#~ msgstr "Dovoli povezave na storitve Docker"
-
-#~ msgid "Configure network firewall"
-#~ msgstr "Nastavi omrežni požarni zid"
-
-#~ msgid "Setup and use privileged FUSE filesystems"
-#~ msgstr "Nastavitev in uporaba datotečnega sistema FUSE"
-
-#~ msgid "Update firmware on this device"
-#~ msgstr "Posodobi strojno programsko opremo na tej napravi"
-
-#~ msgid "Access hardware information"
-#~ msgstr "Dostop do podrobnosti strojne opreme"
-
-#~ msgid "Provide entropy to hardware random number generator"
-#~ msgstr "Omogoča entropijo za strojni ustvarjalnik naključnih števil"
-
-#~ msgid "Use hardware-generated random numbers"
-#~ msgstr "Uporabi strojno ustvarjena naključna števila"
-
-#~ msgid "Access files in your home folder"
-#~ msgstr "Dostop do datotek v osebni mapi"
-
-#~ msgid "Access libvirt service"
-#~ msgstr "Dostop do storitev libvirt"
-
-#~ msgid "Change system language and region settings"
-#~ msgstr "Spremenite sistemski jezik in območne nastavitve"
-
-#~ msgid "Change location settings and providers"
-#~ msgstr "Spreminjanje geolokacijskih nastavitev in ponudnikov"
-
-#~ msgid "Read system and application logs"
-#~ msgstr "Branje sistemskih in programskih dnevnikov"
-
-#~ msgid "access the media-hub service"
-#~ msgstr "dostop do storitev media-hub"
-
-#~ msgid "Use and configure modems"
-#~ msgstr "Uporaba in nastavitev modema"
-
-#~ msgid "Read system mount information and disk quotas"
-#~ msgstr "Branje podrobnosti priklopov sistema in prostorske omejitve diska"
-
-#~ msgid "Control music and video players"
-#~ msgstr "Nadziraj predvajalnike predstavnih vsebin"
-
-#~ msgid "Change low-level network settings"
-#~ msgstr "Spreminjanje osnovnih omrežnih nastavitev"
-
-#~ msgid ""
-#~ "Access the NetworkManager service to read and change network settings"
-#~ msgstr ""
-#~ "Dostop do storitve NetworkManager za branje in spreminjanje nastavitev "
-#~ "omrežja"
-
-#~ msgid "Read access to network settings"
-#~ msgstr "Bralni dostop do omrežnih nastavitev"
-
-#~ msgid "Change network settings"
-#~ msgstr "Spremeni omrežne nastavitve"
-
-#~ msgid "Read network settings"
-#~ msgstr "Preberi omrežne nastavitve"
-
-#~ msgid ""
-#~ "Access the ofono service to read and change network settings for mobile "
-#~ "telephony"
-#~ msgstr ""
-#~ "Dostop do storitve ofono za branje in spreminjanje nastavitev omrežja za "
-#~ "mobilno telefonijo"
-
-#~ msgid "Control Open vSwitch hardware"
-#~ msgstr "Nadzor nad strojno opremo Open vSwitch"
-
-#~ msgid "Read from CD/DVD"
-#~ msgstr "Branje nosilca CD/DVD"
-
-#~ msgid "Read, add, change, or remove saved passwords"
-#~ msgstr "Branje, dodajanje, spreminjanje in odstranjevanje shranjenih gesel"
-
-#~ msgid ""
-#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
-#~ "connections"
-#~ msgstr ""
-#~ "Dostop do naprav pppd in ppp za nastavljanje povezav prek protokola P2P "
-#~ "(od točke do točke)"
-
-#~ msgid "Pause or end any process on the system"
-#~ msgstr "Upravljanje kateregakoli sistemskega procesa"
-
-#~ msgid "Access USB hardware directly"
-#~ msgstr "Neposreden dostop do strojne opreme USB"
-
-#~ msgid "Read/write files on removable storage devices"
-#~ msgstr "Branje/Pisanje datotek na oddaljene naprave shrambe"
-
-#~ msgid "Prevent screen sleep/lock"
-#~ msgstr "Prepreči zaklepanje zaslona in prehod v pripravljenost"
-
-#~ msgid "Access serial port hardware"
-#~ msgstr "Dostop do strojne opreme serijskih vrat"
-
-#~ msgid "Restart or power off the device"
-#~ msgstr "Ponovni zagon in izklapljanje naprave"
-
-#~ msgid "Install, remove and configure software"
-#~ msgstr "Namesti, odstrani in prilagajaj programsko opremo"
-
-#~ msgid "Access Storage Framework service"
-#~ msgstr "Dostop do storitev okolja shrambe"
-
-#~ msgid "Read process and system information"
-#~ msgstr "Opravila branja in sistemske podrobnosti"
-
-#~ msgid "Monitor and control any running program"
-#~ msgstr "Nadzor in upravljanje z zagnanimi programi"
-
-#~ msgid "Change the date and time"
-#~ msgstr "Spreminjanje sistemskega časa in datuma"
-
-#~ msgid "Change time server settings"
-#~ msgstr "Spremeni nastavitve časovnega strežnika"
-
-#~ msgid "Change the time zone"
-#~ msgstr "Spremeni časovni pas"
-
-#~ msgid "Access the UDisks2 service for configuring disks and removable media"
-#~ msgstr ""
-#~ "Dostop do storitev UDisks2 za nastavljanje diskovja in odstranljivih "
-#~ "nosilcev"
-
-#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
-#~ msgstr "Branje/Spreminjanje dogodko v koledarju Ubuntu Unity 8"
-
-#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
-#~ msgstr "Branje/Spreminjanje stikov v souporabi v Ubuntu Unity 8"
-
-#~ msgid "Access energy usage data"
-#~ msgstr "Dostop do podatkov o porabi energije"
-
-#~ msgid "Read/write access to U2F devices exposed"
-#~ msgstr "Branje/Spreminjanje dostopa do naprav U2F"
-
-#~ msgid "∶"
-#~ msgstr "∶"
-
-#~ msgid "Universal Access"
-#~ msgstr "Posebne možnosti"
-
-#~ msgid "Switch off to connect to a Wi-Fi network"
-#~ msgstr "Izklopi za povezavo v brezžično omrežje"
-
-#~ msgctxt "Wi-Fi passkey"
-#~ msgid "Password"
-#~ msgstr "Geslo"
-
-#~ msgid ""
-#~ "To create a user account,\n"
-#~ "click the * icon first"
-#~ msgstr ""
-#~ "Za ustvarjanje uporabniškega\n"
-#~ "računa, kliknite na ikono *"
-
-#~ msgid "Enable Fingerprint Login"
-#~ msgstr "Omogoči prijavo s prstnimi odtisi"
-
-#~ msgid "_Other finger:"
-#~ msgstr "_Drugi prst:"
-
-#~ msgid ""
-#~ "Your fingerprint was successfully saved. You should now be able to log in "
-#~ "using your fingerprint reader."
-#~ msgstr ""
-#~ "Prstni odtis je uspešno shranjen. Sedaj se je mogoče prijaviti z uporabo "
-#~ "bralnika prstnih odtisov."
-
-#~ msgid ""
-#~ "You are not allowed to access the device. Contact your system "
-#~ "administrator."
-#~ msgstr ""
-#~ "Ni ustreznih dovoljenj za uporabo naprave. Stopite v stik s skrbnikom."
-
-#~ msgid "An internal error occurred."
-#~ msgstr "Prišlo je do notranje napake."
-
-#~ msgid "Delete registered fingerprints?"
-#~ msgstr "Ali naj bodo izbrisani obstoječi prstni odtisi?"
-
-#~ msgid "Done!"
-#~ msgstr "Končano!"
-
-#~ msgid "Could not access “%s” device"
-#~ msgstr "Dostop do naprave »%s« ni mogoč."
-
-#~ msgid "Could not start finger capture on “%s” device"
-#~ msgstr "Ni mogoče začeti z branjem prstnih odtisov na napravi »%s«"
-
-#~ msgid "Could not access any fingerprint readers"
-#~ msgstr "Ni mogoč dostop do bralnikov prstnih odtisov"
-
-#~ msgid "Please contact your system administrator for help."
-#~ msgstr "Za pomoč se obrnite na skrbnika."
-
-#~ msgid ""
-#~ "To enable fingerprint login, you need to save one of your fingerprints, "
-#~ "using the “%s” device."
-#~ msgstr ""
-#~ "Za prijavo s prstnim odtisom, je treba najprej shraniti vaš prstni odtis "
-#~ "z uporabo naprave »%s«."
-
-#~ msgid "Selecting finger"
-#~ msgstr "Izbor prsta"
-
-#~ msgid "Set Background and Lock Screen"
-#~ msgstr "Nastavitev ozadja iz zaklenjenega zaslona"
-
-#~ msgid "Set Background"
-#~ msgstr "Nastavi ozadje"
-
-#~ msgid "Set Lock Screen"
-#~ msgstr "Nastavi zaklenjen zaslon"
-
-#~ msgid "Remove Background"
-#~ msgstr "Odstrani ozadje"
-
-#~ msgid "Version %s"
-#~ msgstr "Različica %s"
-
-#~ msgid "OS name"
-#~ msgstr "Naziv OS"
-
-#~ msgid "OS type"
-#~ msgstr "Vrsta OS"
-
-#~ msgid "Disk"
-#~ msgstr "Disk"
-
-#~ msgid "Check for updates"
-#~ msgstr "Preveri za posodobitve"
-
-#~ msgid "Network proxy"
-#~ msgstr "Omrežni posredniški strežnik"
-
-#~ msgid "page 1"
-#~ msgstr "stran 1"
-
-#~ msgid "Inner _authentication"
-#~ msgstr "_Notranja overitev"
-
-#~ msgid "page 2"
-#~ msgstr "stran 2"
-
-#~ msgid "Restrict _background data usage"
-#~ msgstr "Omeji uporabo podatkov v _ozadju"
-
-#~ msgid "Appropriate for connections that have data charges or limits."
-#~ msgstr ""
-#~ "Priporočljivo za povezave, ki zahtevajo obračun podatkov ali omejujejo "
-#~ "dostop."
-
-#~ msgid "Twisted Pair (TP)"
-#~ msgstr "Parica (TP)"
-
-#~ msgid "Attachment Unit Interface (AUI)"
-#~ msgstr "Vmesnik enote pripenjanja (AUI)"
-
-#~ msgid "BNC"
-#~ msgstr "BNC"
-
-#~ msgid "Media Independent Interface (MII)"
-#~ msgstr "Od nosilca neodvisen vmesnik (MII)"
-
-#~ msgid "10 Mb/s"
-#~ msgstr "10 Mb/s"
-
-#~ msgid "100 Mb/s"
-#~ msgstr "100 Mb/s"
-
-#~ msgid "1 Gb/s"
-#~ msgstr "1 Gb/s"
-
-#~ msgid "10 Gb/s"
-#~ msgstr "10 Gb/s"
-
-#~ msgid ""
-#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-#~ msgstr "Preklop na brezžično vročo točko bo prekinilo povezavo z <b>%s</b>."
-
-#~ msgid ""
-#~ "It is not possible to access the Internet through your wireless while the "
-#~ "hotspot is active."
-#~ msgstr ""
-#~ "Kadar je vroča točka dejavna, dostop do interneta preko brezžične "
-#~ "povezave ni mogoč."
-
-#~ msgid ""
-#~ "Wi-Fi hotspots are usually used to share an additional Internet "
-#~ "connection over Wi-Fi."
-#~ msgstr ""
-#~ "Vroče točke Wi-Fi so običajno uporabljene za souporabo povezave v omrežje "
-#~ "prek Wi-Fi."
-
-#~ msgid "Automatic _Connect"
-#~ msgstr "Samodejna _povezava"
-
-#~ msgid "details"
-#~ msgstr "podrobnosti"
-
-#~ msgid "Show P_assword"
-#~ msgstr "Pokaži _geslo"
-
-#~ msgid "Make available to other users"
-#~ msgstr "Naj bo na voljo tudi drugim uporabnikom"
-
-#~ msgid "identity"
-#~ msgstr "istovetnost"
-
-#~ msgid "IPv_4"
-#~ msgstr "IPv_4"
-
-#~ msgid "_Addresses"
-#~ msgstr "_Naslovi"
-
-#~ msgid "Automatic (DHCP) addresses only"
-#~ msgstr "Le samodejni (DHCP) naslovi"
-
-#~ msgid "Link-local only"
-#~ msgstr "Poveži le krajevno"
-
-#~ msgid "_Ignore automatically obtained routes"
-#~ msgstr "_Prezri samodejno pridobljene smeri"
-
-#~ msgid "ipv4"
-#~ msgstr "ipv4"
-
-#~ msgid "IPv_6"
-#~ msgstr "IPv_6"
-
-#~ msgid "ipv6"
-#~ msgstr "ipv6"
-
-#~ msgid "_Cloned MAC Address"
-#~ msgstr "_Kloniran naslov MAC"
-
-#~ msgid "_Reset"
-#~ msgstr "_Ponastavi"
-
-#~ msgid ""
-#~ "Reset the settings for this connection to their defaults, but remember as "
-#~ "a preferred connection."
-#~ msgstr ""
-#~ "Ponastavi nastavitve za to povezavo na privzete vrednosti, vendar si jo "
-#~ "zapomni kot prednostno povezavo."
-
-#~ msgid ""
-#~ "Remove all details relating to this network and do not try to "
-#~ "automatically connect to it."
-#~ msgstr ""
-#~ "Odstrani vse podrobnosti, ki so povezane s tem omrežjem in se ne poskusi "
-#~ "samodejno povezati z njim."
-
-#~ msgid "Hardware"
-#~ msgstr "Strojna oprema"
-
-#~ msgctxt "tab"
-#~ msgid "Reset"
-#~ msgstr "Ponastavi"
-
-#~ msgid "Connected Devices"
-#~ msgstr "Priklopljene naprave"
-
-#~ msgid "Ad-hoc"
-#~ msgstr "Ad-hoc"
-
-#~ msgid "Infrastructure"
-#~ msgstr "Infrastruktura"
-
-#~ msgid "Notification _Popups"
-#~ msgstr "Pojavna _obvestila"
-
-#~ msgid "In use"
-#~ msgstr "V uporabi"
-
-#~ msgctxt "Location services status"
-#~ msgid "On"
-#~ msgstr "Vklopljeno"
-
-#~ msgctxt "Location services status"
-#~ msgid "Off"
-#~ msgstr "Onemogočeno"
-
-#~ msgctxt "Camera status"
-#~ msgid "Off"
-#~ msgstr "Onemogočena"
-
-#~ msgctxt "Camera status"
-#~ msgid "On"
-#~ msgstr "Omogočena"
-
-#~ msgctxt "Microphone status"
-#~ msgid "Off"
-#~ msgstr "Onemogočen"
-
-#~ msgctxt "Microphone status"
-#~ msgid "On"
-#~ msgstr "Omogočen"
-
-#~ msgid "Usage & History"
-#~ msgstr "Uporaba in zgodovina"
-
-#~ msgid "Privacy Policy"
-#~ msgstr "Pravila zasebnosti"
-
-#~ msgid ""
-#~ "Remembering your history makes things easier to find again. These items "
-#~ "are never shared over the network."
-#~ msgstr ""
-#~ "Pomnjenje zgodovine pohitri pogosta iskanja. Ti podatki se ne objavljajo "
-#~ "prek omrežja."
-
-#~ msgid "_Recently Used"
-#~ msgstr "_Nedavno uporabljeno"
-
-#~ msgid "Retain _History"
-#~ msgstr "Ohrani _zgodovino"
-
-#~ msgid "The Screen Lock protects your privacy when you are away."
-#~ msgstr "Zaklep zaslona ohranja vašo zasebnost, ko vas ni v bližini."
-
-#~ msgid "Lock screen _after blank for"
-#~ msgstr "_Zakleni zaslon ob nedejavnosti"
-
-#~ msgid "Lock Screen _Notifications"
-#~ msgstr "Obvestila na _zaklenjenem zaslonu"
-
-#~ msgid ""
-#~ "Automatically purge the Trash and temporary files to help keep your "
-#~ "computer free of unnecessary sensitive information."
-#~ msgstr ""
-#~ "S samodejnim praznjenjem smeti in brisanjem začasnih datotek se "
-#~ "odstranjujejo nepotrebni, vendar občutljivi podatki."
-
-#~ msgid "Purge _After"
-#~ msgstr "Počisti _po"
-
-#~ msgid ""
-#~ "Sending us information about which software you use helps us provide you "
-#~ "with more accurate recommendations. It also helps us to improve our "
-#~ "software.\n"
-#~ "\n"
-#~ "All the information we collect is made anonymous, and we will never share "
-#~ "your data with third parties."
-#~ msgstr ""
-#~ "Pošiljanje podatkov o rabi programske opreme omogoča natančnejša "
-#~ "priporočila in seveda izboljšanje delovanja.\n"
-#~ "\n"
-#~ "Vsi zbrani podatki so poslani brezimno in nikoli niso posredovani tretjim "
-#~ "osebam."
-
-#~ msgid "_Send software usage statistics"
-#~ msgstr "_Pošlji statistiko o rabi programov"
-
-#~ msgid "_Camera"
-#~ msgstr "_Kamera"
-
-#~ msgid "_Microphone"
-#~ msgstr "_Mikrofon"
-
-#~ msgid "_Location Services"
-#~ msgstr "Storitve določanja položaja"
-
-#~ msgid "Protect your personal information and control what others might see"
-#~ msgstr ""
-#~ "Zaščitite osebne podatke in ohranite nadzor nad javno vidnimi zapisi"
-
-#~ msgid "No regions found"
-#~ msgstr "Ni najdenih območij"
-
-#~ msgid "Flash the _window title"
-#~ msgstr "Zabliskaj _nazivno vrstico okna"
-
-#~ msgid "Last Login"
-#~ msgstr "Zadnja prijava"
-
-#~ msgid "_Background"
-#~ msgstr "_Ozadje"
-
-#~ msgid "Changes throughout the day"
-#~ msgstr "Spremembe preko dneva"
-
-#~ msgid "_Lock Screen"
-#~ msgstr "_Zaklenjen zaslon"
-
-#~ msgctxt "background, style"
-#~ msgid "Tile"
-#~ msgstr "Razpostavi"
-
-#~ msgctxt "background, style"
-#~ msgid "Zoom"
-#~ msgstr "Približaj"
-
-#~ msgctxt "background, style"
-#~ msgid "Center"
-#~ msgstr "Sredini"
-
-#~ msgctxt "background, style"
-#~ msgid "Scale"
-#~ msgstr "Prilagodi velikost"
-
-#~ msgctxt "background, style"
-#~ msgid "Fill"
-#~ msgstr "Zapolni"
-
-#~ msgctxt "background, style"
-#~ msgid "Span"
-#~ msgstr "Razmakni"
-
-#~ msgid "Colors"
-#~ msgstr "Barve"
-
-#~ msgid "Pictures"
-#~ msgstr "Slike"
-
-#~ msgid "No Pictures Found"
-#~ msgstr "Ni najdenih slik"
-
-#~ msgid "You can add images to your %s folder and they will show up here"
-#~ msgstr "Slike, dodane v mapo %s, bodo prikazane v tem pogledu"
-
-#~ msgid "_Off"
-#~ msgstr "_Onemogočeno"
-
-#~ msgid "Connection/SSID"
-#~ msgstr "Povezava/SSID"
-
-#~ msgid "_Mobile broadband"
-#~ msgstr "_Mobilni širokopasovni dostop"
-
-#~ msgid "_Automatic suspend"
-#~ msgstr "_Samodejno pošlji v pripravljenost"
-
-#~ msgid "_When the Power Button is pressed"
-#~ msgstr "Ko je pritisnjen gumb za _vklop računalnika"
-
-#~ msgid "The username cannot start with a “-”."
-#~ msgstr "Uporabniškega imena ni mogoče začeti z vezajem » - «."
-
-#~ msgid "application-x-executable"
-#~ msgstr "application-x-executable"
-
-#~ msgid "bluetooth"
-#~ msgstr "Bluetooth"
-
-#~ msgid "preferences-color"
-#~ msgstr "preferences-color"
-
-#~ msgid "preferences-system-time"
-#~ msgstr "preferences-system-time"
-
-#~ msgid "preferences-desktop-display"
-#~ msgstr "preferences-desktop-display"
-
-#~ msgid "starred"
-#~ msgstr "starred"
-
-#~ msgid "help-about"
-#~ msgstr "help-about"
-
-#~ msgid "media-removable"
-#~ msgstr "media-removable"
-
-#~ msgid "input-keyboard"
-#~ msgstr "input-keyboard"
-
-#~ msgid "input-mouse"
-#~ msgstr "input-mouse"
-
-#~ msgid "network-workgroup"
-#~ msgstr "network-workgroup"
-
-#~ msgid "network-wireless"
-#~ msgstr "network-wireless"
-
-#~ msgid "goa-panel"
-#~ msgstr "goa-panel"
-
-#~ msgid "gnome-power-manager"
-#~ msgstr "gnome-power-manager"
-
-#~ msgid "printer"
-#~ msgstr "printer"
-
-#~ msgid "preferences-system-privacy"
-#~ msgstr "preferences-system-privacy"
-
-#~ msgid "preferences-desktop-locale"
-#~ msgstr "preferences-desktop-locale"
-
-#~ msgid "preferences-system-search"
-#~ msgstr "preferences-system-search"
-
-#~ msgid "preferences-system-sharing"
-#~ msgstr "preferences-system-sharing"
-
-#~ msgid "multimedia-volume-control"
-#~ msgstr "multimedia-volume-control"
-
-#~ msgid "thunderbolt"
-#~ msgstr "thunderbolt"
-
-#~ msgid "preferences-desktop-accessibility"
-#~ msgstr "preferences-desktop-accessibility"
-
-#~ msgid "system-users"
-#~ msgstr "system-users"
-
-#~ msgid "input-tablet"
-#~ msgstr "input-tablet"
-
-#~ msgid "org.gnome.Settings"
-#~ msgstr "org.gnome.Settings"
-
-#~ msgid "_Night Light"
-#~ msgstr "_Nočna osvetlitev"
-
-#~ msgid "Could not get screen information"
-#~ msgstr "Ni mogoče dobiti podatkov zaslona"
-
-#~ msgid "Add input source"
-#~ msgstr "Dodaj vhodni vir"
-
-#~ msgid "Remove input source"
-#~ msgstr "Odstrani vhodni vir"
-
-#~ msgid "Move input source up"
-#~ msgstr "Premakni vhodni vir gor"
-
-#~ msgid "Move input source down"
-#~ msgstr "Premakni vhodni vir dol"
-
-#~ msgid "Show input source keyboard layout"
-#~ msgstr "Pokaži vir vhoda razporeditve tipkovnice"
-
-#~ msgctxt "balance"
-#~ msgid "Left"
-#~ msgstr "Levo"
-
-#~ msgctxt "balance"
-#~ msgid "Right"
-#~ msgstr "Desno"
-
-#~ msgctxt "balance"
-#~ msgid "Minimum"
-#~ msgstr "Najmanj"
-
-#~ msgctxt "balance"
-#~ msgid "Maximum"
-#~ msgstr "Največ"
-
-#~ msgid "_Subwoofer:"
-#~ msgstr "_Nizkotonski zvočnik:"
-
-#~ msgid "_Profile:"
-#~ msgstr "_Profil:"
-
-#~ msgid "_Test Speakers"
-#~ msgstr "Preizkus _zvočnikov"
-
-#~ msgid "Peak detect"
-#~ msgstr "Zaznava vrhov"
-
-#~ msgid "Device"
-#~ msgstr "Naprava"
-
-#~ msgid "Speaker Testing for %s"
-#~ msgstr "Preizkus zvočnikov za %s"
-
-#~ msgid "C_hoose a device for sound output:"
-#~ msgstr "_Izbor naprave za izhod zvoka:"
-
-#~ msgid "Settings for the selected device:"
-#~ msgstr "Nastavitve izbrane naprave:"
-
-#~ msgid "_Input volume:"
-#~ msgstr "_Glasnost vhoda: "
-
-#~ msgid "C_hoose a device for sound input:"
-#~ msgstr "_Izbor naprave za vhod zvoka:"
-
-#~ msgid "Sound Effects"
-#~ msgstr "Zvočni učinki"
-
-#~ msgid "Built-in"
-#~ msgstr "Vgrajeno"
-
-#~ msgid "Sound Preferences"
-#~ msgstr "Možnosti zvoka"
-
-#~ msgid "Testing event sound"
-#~ msgstr "Preizkus zvoka dogodkov"
-
-#~ msgid "From theme"
-#~ msgstr "Iz teme"
-
-#~ msgid "C_hoose an alert sound:"
-#~ msgstr "_Izbor zvoka opozorila:"
-
-#~ msgid "Stop"
-#~ msgstr "Zaustavi"
-
-#~ msgid "GNOME Control Center"
-#~ msgstr "Nadzorno središče GNOME"
-
-#~ msgid ""
-#~ "The control center is GNOME’s main interface for configuration of various "
-#~ "aspects of your desktop."
-#~ msgstr ""
-#~ "Nadzorno središče je osnovni vmesnik za spreminjanje različnih nastavitev "
-#~ "namizja GNOME."
-
-#~ msgid "Switch to previous source"
-#~ msgstr "Preklopi na predhodni vir"
-
-#~ msgid "Switch to next source"
-#~ msgstr "Preklopi na naslednji vir"
-
-#~ msgid "Alternative switch to next source"
-#~ msgstr "Preklop na naslednji vir"
-
-#~ msgid "_Options"
-#~ msgstr "_Možnosti"
-
-#~ msgctxt "Account type"
-#~ msgid "Standard"
-#~ msgstr "Običajno"
-
-#~ msgctxt "Account type"
-#~ msgid "Administrator"
-#~ msgstr "Skrbnik"
-
-#~ msgid "Quit"
-#~ msgstr "Končaj"
-
-#~ msgid "gnome-control-center"
-#~ msgstr "gnome-control-center"
-
-#~ msgid "hardware"
-#~ msgstr "strojna oprema"
-
-#~ msgid "English (United Kingdom)"
-#~ msgstr "Angleščina (Združeno kraljestvo)"
-
-#~ msgid "United Kingdom"
-#~ msgstr "Velika Britanija"
-
-#~ msgid "page 3"
-#~ msgstr "stran 3"
-
-#~ msgid "_Verify New Password"
-#~ msgstr "_Overi novo geslo"
-
-#~ msgid "Passwords do not match."
-#~ msgstr "Gesli se ne skladata."
-
-#~ msgid "Show the overview"
-#~ msgstr "Pokaži pregled"
-
-#~ msgid "Back­ground"
-#~ msgstr "Ozadje"
-
-#~ msgid "Blue­tooth"
-#~ msgstr "Bluetooth"
-
-#~ msgid "Co­lor"
-#~ msgstr "Barva"
-
-#~ msgid "Overview"
-#~ msgstr "Pregled"
-
-#~ msgid "Defa­ult Applications"
-#~ msgstr "Privzeti programi"
-
-#~ msgid "Ab­out"
-#~ msgstr "O programu"
-
-#~ msgid "De­tails"
-#~ msgstr "Podrobnosti"
-
-#~ msgid "Remo­vable Media"
-#~ msgstr "Odstranljivi nosilci"
-
-#~ msgid "Net­work"
-#~ msgstr "Omrežje"
-
-#~ msgid "No­ti­fi­ca­tions"
-#~ msgstr "Obvestila"
-
-#~ msgid "Po­wer"
-#~ msgstr "Napajanje ↥"
-
-#~ msgid "Pri­va­cy"
-#~ msgstr "Zasebnost"
-
-#~ msgid "Sha­ring"
-#~ msgstr "Souporaba"
-
-#~ msgid "Uni­ver­sal Access"
-#~ msgstr "Posebne možnosti"
-
-#~ msgid "Disable image"
-#~ msgstr "Onemogoči sliko"
-
-#~ msgid "Browse for more pictures…"
-#~ msgstr "Brskanje med več slikami ..."
-
-#~ msgid "Used by %s"
-#~ msgstr "Uporablja ga %s"
-
-#~ msgid "Wa­com Tab­let"
-#~ msgstr "Tablica Wacom"
-
-#~ msgctxt "category"
-#~ msgid "Hardware"
-#~ msgstr "Strojna oprema"
-
-#~ msgctxt "category"
-#~ msgid "System"
-#~ msgstr "Sistem"
-
-#~ msgid "Lid Closed"
-#~ msgstr "Pokrov je zaprt"
-
-#~ msgid "Mirrored"
-#~ msgstr "Zrcalno"
-
-#~ msgid "Secondary"
-#~ msgstr "Drugi"
-
-#~ msgid "Arrange Combined Displays"
-#~ msgstr "Prikaže združen prikaz"
-
-#~ msgid "Drag displays to rearrange them"
-#~ msgstr "Potegni zaslone za preurejanje"
-
-#~ msgid "%d Hz (NTSC)"
-#~ msgstr "%d Hz (NTSC)"
-
-#~ msgid "%d Hz"
-#~ msgstr "%d Hz"
-
-#~ msgid "Rotate counterclockwise by 90°"
-#~ msgstr "Zavrti sliko za 90° v levo"
-
-#~ msgid "Rotate by 180°"
-#~ msgstr "Obrni za 180°"
-
-#~ msgid "Rotate clockwise by 90°"
-#~ msgstr "Zavrti sliko za 90° v desno"
-
-#~ msgid "Size"
-#~ msgstr "Velikost"
-
-#~ msgid "Show the top bar and Activities Overview on this display"
-#~ msgstr "Pokaži vrhnjo vrstico in pregled dejavnosti na tem zaslonu"
-
-#~ msgid "Join this display with another to create an extra workspace"
-#~ msgstr "Združi zaslon z drugim za ustvarjanje dodatne delovne površine"
-
-#~ msgid "Presentation"
-#~ msgstr "Predstavitev"
-
-#~ msgid "Show slideshows and media only"
-#~ msgstr "Pokaži le predstavitve in predstavne datoteke"
-
-#~ msgid "Show your existing view on both displays"
-#~ msgstr "Pokaži obstoječ pogled na obeh zaslonih"
-
-#~ msgid "Turn Off"
-#~ msgstr "Izklopi"
-
-#~ msgid "Don’t use this display"
-#~ msgstr "Ne uporabi tega zaslona"
-
-#~ msgid "_Arrange Combined Displays"
-#~ msgstr "_Preuredi združene zaslone"
-
-#~ msgid "Air_plane Mode"
-#~ msgstr "_Letalski način"
-
-#~ msgid "Server"
-#~ msgstr "Strežnik"
-
-#~ msgid "Delete DNS Server"
-#~ msgstr "Izbriši strežnik DNS"
-
-#~ msgid "Proxy"
-#~ msgstr "Posredniški strežnik"
-
-#~ msgid "_Add Profile…"
-#~ msgstr "_Dodaj profil ..."
-
-#~ msgctxt "proxy method"
-#~ msgid "None"
-#~ msgstr "Brez"
-
-#~ msgctxt "proxy method"
-#~ msgid "Manual"
-#~ msgstr "Ročno"
-
-#~ msgctxt "proxy method"
+#~ msgctxt "Automatically generated profile"
 #~ msgid "Automatic"
 #~ msgstr "Samodejno"
 
-#~ msgid "_Method"
-#~ msgstr "_Način"
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Nizka kakovost"
 
-#~ msgid "VPN Type"
-#~ msgstr "Vrsto povezave VPN"
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Srednja kakovost"
 
-#~ msgid "Group Name"
-#~ msgstr "Ime skupine"
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Visoka kakovost"
 
-#~ msgid "Group Password"
-#~ msgstr "Geslo skupine"
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Privzeta barva RGB"
 
-#~ msgid "%s %d-bit (Build ID: %s)"
-#~ msgstr "%s %d-bit (ID Izgradnje: %s)"
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Privzeta barva CMYK"
 
-#~ msgid "%s %d-bit"
-#~ msgstr "%s %d-bitni"
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Privzeta sivina"
 
-#~ msgid "Base system"
-#~ msgstr "Osnovno sistem"
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Tovarniški umeritveni podatki, ki jih zagotavlja proizvajalec"
 
-#~ msgid "Shortcut;Repeat;Blink;"
-#~ msgstr "Bližnjica;Ponovi;Zabliskaj;"
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Celozaslonsko popravilo zaslona s tem profilom ni mogoče."
 
-#~ msgid "Press Esc to cancel."
-#~ msgstr "Pritisnite tipko Esc za preklic."
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Ta profil morda ni več natančen."
 
-#~ msgid "Make available to other _users"
-#~ msgstr "Na voljo tudi _drugim uporabnikom"
+#~ msgid "Other…"
+#~ msgstr "Drugo …"
 
-#~ msgid "Firewall _Zone"
-#~ msgstr "Območje _požarnega zidu"
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Odklenite za spreminjanje nastavitev"
 
-#~ msgctxt "Firewall zone"
-#~ msgid "Default"
-#~ msgstr "Privzeto"
+#~ msgid "Today"
+#~ msgstr "Danes"
 
-#~ msgid "The zone defines the trust level of the connection"
-#~ msgstr "Območje določa raven zaupanja v povezavo"
+#~ msgid "Yesterday"
+#~ msgstr "Včeraj"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d ur"
+#~ msgstr[1] "%d ura"
+#~ msgstr[2] "%d uri"
+#~ msgstr[3] "%d ure"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minut"
+#~ msgstr[1] "%d minuta"
+#~ msgstr[2] "%d minuti"
+#~ msgstr[3] "%d minute"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekund"
+#~ msgstr[1] "%d sekunda"
+#~ msgstr[2] "%d sekundi"
+#~ msgstr[3] "%d sekunde"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Vroča točka"
+
+#~ msgid "24-hour"
+#~ msgstr "24-urni"
+
+#~ msgid "AM / PM"
+#~ msgstr "12-urni"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Pošiljanje poročil o tehničnih napakah omogoča izboljšave distribucije "
+#~ "%s. Poročila so poslana brezimno in brez kakršnihkoli osebnih podatkov. %s"
+
+#~ msgid "On"
+#~ msgstr "Omogočeno"
+
+#~ msgid "Off"
+#~ msgstr "Onemogočeno"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Ali naj se uveljavijo spremembe?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Sprememb ni mogoče uveljaviti"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "To je lahko zaradi strojnih omejitev."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Ležeče"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Pokončno desno"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Pokončno levo"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Ležeče (obrnjeno)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Varen zagon je omogočen"
 
 #~ msgid ""
-#~ "Reset the settings for this network, including passwords, but remember it "
-#~ "as a preferred network"
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
 #~ msgstr ""
-#~ "Ponastavi vse nastavitve za to omrežje, vključno z gesli, vendar si ga "
-#~ "zapomni kot prednostno omrežje"
+#~ "Varen zagon preprečuje nalaganje zlonamerne programske opreme ob zagonu "
+#~ "naprave. Trenutno je vklopljena in deluje pravilno."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Zaznane so težave v delovanju varnega zagons"
 
 #~ msgid ""
-#~ "Remove all details relating to this network and do not try to "
-#~ "automatically connect"
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
 #~ msgstr ""
-#~ "Odstrani vse podrobnosti za to omrežje in se ne poskušaj samodejno "
-#~ "povezati"
+#~ "Varen zagon preprečuje nalaganje zlonamerne programske opreme ob zagonu "
+#~ "naprave. Trenutno je vklopljen, a ne deluje zaradi neveljavnega ključa."
 
 #~ msgid ""
-#~ "If you have a connection to the Internet other than wireless, you can set "
-#~ "up a wireless hotspot to share the connection with others."
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
 #~ msgstr ""
-#~ "V kolikor imate povezavo v omrežje, ki ni brezžična, jo lahko delite kot "
-#~ "vročo točko z drugimi uporabniki za dostop do interneta."
+#~ "Težave z varnim zagonom je mogoče pogosto odpraviti s prilagajanjem "
+#~ "nastavitev strojne programske opreme UEFI (BIOS) računalnika, "
+#~ "proizvajalec strojne opreme pa lahko zagotovi informacije o tem, kako to "
+#~ "storiti."
 
-#~ msgid "_Use as Hotspot…"
-#~ msgstr "_Uporabi kot vročo točko ..."
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Za pomoč stopite v stik s ponudnikom strojne programske opreme ali "
+#~ "podporno službo."
 
-#~ msgid "_History"
-#~ msgstr "_Zgodovina"
-
-#~ msgid "2"
-#~ msgstr "2"
-
-#~ msgid "3"
-#~ msgstr "3"
-
-#~ msgid "4"
-#~ msgstr "4"
-
-#~ msgctxt "Password hint"
-#~ msgid "Try to add more letters, numbers and symbols."
-#~ msgstr "Poskusite dodati več črk, številk in posebnih znakov."
-
-#~ msgctxt "Password strength"
-#~ msgid "Strength: Weak"
-#~ msgstr "Neuporabno"
-
-#~ msgctxt "Password strength"
-#~ msgid "Strength: Low"
-#~ msgstr "Šibko"
-
-#~ msgctxt "Password strength"
-#~ msgid "Strength: Medium"
-#~ msgstr "Zadovoljivo"
-
-#~ msgctxt "Password strength"
-#~ msgid "Strength: Good"
-#~ msgstr "Dobro"
-
-#~ msgctxt "Password strength"
-#~ msgid "Strength: High"
-#~ msgstr "Odlično"
-
-#~ msgctxt "notifications"
-#~ msgid "Notification _Banners"
-#~ msgstr "Obvestilne _pasice"
-
-#~ msgid "Notification _Banners"
-#~ msgstr "Obvestilne _pasice"
-
-#~ msgid "Add Account"
-#~ msgstr "Dodaj račun"
-
-#~ msgid "Mail"
-#~ msgstr "Pošta"
-
-#~ msgid "Calendar"
-#~ msgstr "Koledar"
-
-#~ msgid "Contacts"
-#~ msgstr "Stiki"
-
-#~ msgid "Chat"
-#~ msgstr "Klepet"
-
-#~ msgid "Error creating account"
-#~ msgstr "Napaka med ustvarjanjem računa"
-
-#~ msgid "Are you sure you want to remove the account?"
-#~ msgstr "Ali ste prepričani, da želite izbrisati račun?"
-
-#~ msgid "This will not remove the account on the server."
-#~ msgstr "S tem dejanjem ne bo odstranjen račun s strežnika."
-
-#~ msgid "No online accounts configured"
-#~ msgstr "Spletni računi niso nastavljeni"
-
-#~ msgid "Add an online account"
-#~ msgstr "Dodaj spletni račun"
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Varni zagon je izklopljen"
 
 #~ msgid ""
-#~ "Adding an account allows your applications to access it for documents, "
-#~ "mail, contacts, calendar, chat and more."
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
 #~ msgstr ""
-#~ "Z dodajanjem računa je omogočen dostop za dokumente, pošto, stike, "
-#~ "koledar, klepet in drugo."
-
-#~ msgctxt "printer state"
-#~ msgid "Configuring"
-#~ msgstr "Nastavljanje"
-
-#~ msgid "Toner Level"
-#~ msgstr "Raven tonerja"
-
-#~ msgid "Supply Level"
-#~ msgstr "Raven zaloge"
-
-#~ msgctxt "printer state"
-#~ msgid "Installing"
-#~ msgstr "Nameščanje"
-
-#~ msgid "%u active"
-#~ msgid_plural "%u active"
-#~ msgstr[0] "%u dejavnih"
-#~ msgstr[1] "%u dejaven"
-#~ msgstr[2] "%u dejavna"
-#~ msgstr[3] "%u dejavni"
-
-#~ msgid "Add a New Printer"
-#~ msgstr "Dodaj nov tiskalnik"
-
-#~ msgid "No printers detected."
-#~ msgstr "Ni zaznanih tiskalnikov."
-
-#~ msgid "Supply"
-#~ msgstr "Zaloga"
-
-#~ msgid "Jobs"
-#~ msgstr "Posli"
-
-#~ msgid "Show _Jobs"
-#~ msgstr "Pokaži _posle"
-
-#~ msgid "label"
-#~ msgstr "oznaka"
-
-#~ msgid "Print _Test Page"
-#~ msgstr "Natisni _preizkusno stran"
-
-#~ msgctxt "login history week label"
-#~ msgid "%s - %s"
-#~ msgstr "%s – %s"
-
-#~ msgid "Other Accounts"
-#~ msgstr "Drugi računi"
-
-#~ msgctxt "Wacom tablet button"
-#~ msgid "Up"
-#~ msgstr "Navzgor"
-
-#~ msgctxt "Wacom tablet button"
-#~ msgid "Down"
-#~ msgstr "Navzdol"
-
-#~ msgctxt "Wacom action-type"
-#~ msgid "None"
-#~ msgstr "Brez"
-
-#~ msgid "Left Ring"
-#~ msgstr "Levi drsni obroč"
-
-#~ msgid "Left Ring Mode #%d"
-#~ msgstr "Levi način drsnega obroča #%d"
-
-#~ msgid "Right Ring Mode #%d"
-#~ msgstr "Desni način drsnega obroča #%d"
-
-#~ msgid "Left Touchstrip"
-#~ msgstr "Levi način drsne ploščice"
-
-#~ msgid "Left Touchstrip Mode #%d"
-#~ msgstr "Levi način drsne ploščice #%d"
-
-#~ msgid "Right Touchstrip"
-#~ msgstr "Desni način drsne ploščice"
-
-#~ msgid "Right Touchstrip Mode #%d"
-#~ msgstr "Desni način drsne ploščice #%d"
-
-#~ msgid "Left Touchring Mode Switch"
-#~ msgstr "Levi gumb preklopa drsnega obroča"
-
-#~ msgid "Right Touchring Mode Switch"
-#~ msgstr "Desni gumb preklopa drsnega obroča"
-
-#~ msgid "Left Touchstrip Mode Switch"
-#~ msgstr "Levi gumb preklopa drsne ploščice"
-
-#~ msgid "Right Touchstrip Mode Switch"
-#~ msgstr "Desni gumb preklopa drsne ploščice"
-
-#~ msgid "Mode Switch #%d"
-#~ msgstr "Gumb preklopa #%d"
-
-#~ msgid "Left Button #%d"
-#~ msgstr "Levi gumb #%d"
-
-#~ msgid "Right Button #%d"
-#~ msgstr "Desni gumb #%d"
-
-#~ msgid "Top Button #%d"
-#~ msgstr "Zgornji gumb #%d"
-
-#~ msgid "Bottom Button #%d"
-#~ msgstr "Spodnji gumb #%d"
-
-#~ msgid "No Action"
-#~ msgstr "Ni dejanja"
-
-#~ msgid "Left Mouse Button Click"
-#~ msgstr "Klik levega gumba miške"
-
-#~ msgid "Scroll Up"
-#~ msgstr "Zdrsni navzgor"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Zdrsni navzdol"
-
-#~ msgid "Scroll Right"
-#~ msgstr "Zdrsni v desno"
-
-#~ msgid "Remove Shortcut"
-#~ msgstr "Odstrani tipkovno bližnjico"
+#~ "Varen zagon preprečuje nalaganje zlonamerne programske opreme ob zagonu "
+#~ "naprave. Trenutno je možnost izklopljena."
 
 #~ msgid ""
-#~ "To edit a shortcut, click the row and hold down the new keys or press "
-#~ "Backspace to clear."
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
 #~ msgstr ""
-#~ "Izberite predmet na desni in pritisnite tipke nove bližnjice. Nastavitev "
-#~ "povrnete s povratno tipko."
+#~ "Varen zagon lahko omogočite v nastavitvah vdelane programske opreme UEFI "
+#~ "(BIOS) računalnika. Za pomoč se obrnite na proizvajalca strojne opreme "
+#~ "ali ponudnika skrbniške podpore."
 
-#~ msgid "<Unknown Action>"
-#~ msgstr "<Neznano dejanje>"
+#~ msgid "Passed"
+#~ msgstr "Uspešno končano"
+
+#~ msgid "Failed"
+#~ msgstr "Spodletelo"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Naprava podpira raven varnosti HSI %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Varnostna raven 0"
 
 #~ msgid ""
-#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
-#~ "type using this key.\n"
-#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
 #~ msgstr ""
-#~ "Bližnjice »%s« ni mogoče uporabiti, saj to pomeni, da ta tipka ne bo več "
-#~ "na voljo pri pisanju.\n"
-#~ "Poskusite uporabiti to tipko s hkrati pritisnjeno tipko Control, Alt ali "
-#~ "Shift."
+#~ "Naprava nima ustrezne zaščite pred strojnimi varnostnimi težavami. Vzrok "
+#~ "so lahko nastavitve strojne ali programske opreme. Priporočljivo se je "
+#~ "obrniti na podporo."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Varnostna raven 1"
 
 #~ msgid ""
-#~ "The shortcut \"%s\" is already used for\n"
-#~ "\"%s\""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
 #~ msgstr ""
-#~ "Bližnjica »%s« je že v uporabi za\n"
-#~ " »%s«"
+#~ "Naprava ima le najmanjšo zaščito pred strojnimi varnostnimi "
+#~ "težavamiNajnižja raven zagotavlja le zaščito pred preprostimi varnostnimi "
+#~ "grožnjami."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Varnostna raven 2"
 
 #~ msgid ""
-#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
-#~ "disabled."
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
 #~ msgstr ""
-#~ "V primeru, da določite bližnjico kot »%s«, bo bližnjica »%s« onemogočena."
+#~ "Naprava ima osnovno zaščito pred strojnimi varnostnimi težavami. "
+#~ "Zagotavlja zaščito pred običajnimi varnostnimi grožnjami.\\"
 
-#~ msgid "_Reassign"
-#~ msgstr "_Določitev bližnjice"
+#~ msgid "Security Level 3"
+#~ msgstr "Varnostna raven 3"
 
 #~ msgid ""
-#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-#~ "automatically set it to \"%s\"?"
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
 #~ msgstr ""
-#~ "Bližnjica »%s« je povezana z bližnico »%s«. Ali jo želite samodejno "
-#~ "nastaviti na »%s«?"
+#~ "Ta naprava ima razširjeno zaščito pred težavami s strojno varnostjo. To "
+#~ "je najvišja varnostna raven naprave in zagotavlja zaščito pred naprednimi "
+#~ "varnostnimi grožnjami."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Za to napravo ravni varnosti niso na voljo"
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Za pomoč pri varnostnih posodobitvah stopite v stik s ponudnikom strojne."
 
 #~ msgid ""
-#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
-#~ "disabled if you move forward."
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
 #~ msgstr ""
-#~ "»%s« je trenutno povezano z »%s«, povezava pa bo onemogočena, če se "
-#~ "opravilo nadaljuje."
-
-#~ msgid "_Assign"
-#~ msgstr "_Dodeli"
-
-#~ msgid "Bond"
-#~ msgstr "Vez"
-
-#~ msgid "Team"
-#~ msgstr "Skupina"
-
-#~ msgid "Bridge"
-#~ msgstr "Premoščanje"
-
-#~ msgid "VLAN"
-#~ msgstr "VLAN"
-
-#~ msgid "Could not load VPN plugins"
-#~ msgstr "Ni mogoče naložiti vstavkov VPN"
-
-#~ msgid "Add Network Connection"
-#~ msgstr "Dodaj omrežno povezavo"
-
-#~ msgid "Bond slaves"
-#~ msgstr "Podrejene vezi"
-
-#~ msgid "(none)"
-#~ msgstr "(brez)"
-
-#~ msgid "Bridge slaves"
-#~ msgstr "Podrejene vezi"
-
-#~ msgid "Team slaves"
-#~ msgstr "Podrejene skupine"
-
-#~ msgid "InfiniBand device does not support connected mode"
-#~ msgstr "Naprava InfiniBand ne podpira povezanega načina"
-
-#~ msgid "No Certificate Authority certificate chosen"
-#~ msgstr "Potrdilo pooblastitelja potrdil ni izbrano"
+#~ "To težavo lahko odpravite v nastavitvah strojne programske opreme UEFI "
+#~ "naprave ali s strani podpornega tehnika."
 
 #~ msgid ""
-#~ "Not using a Certificate Authority (CA) certificate can result in "
-#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
-#~ "a Certificate Authority certificate?"
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
 #~ msgstr ""
-#~ "Neuporaba potrdila pooblastitelja potrdil (CA) lahko vodi k povezovanju z "
-#~ "nezavarovanimi brezžičnimi omrežji. Ali želite izbrati potrdilo "
-#~ "pooblastitelja potrdil? "
+#~ "To težavo lahko odpravite v nastavitvah strojne programske opreme naprave "
+#~ "UEFI."
 
-#~ msgid "Ignore"
-#~ msgstr "Prezri"
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "To težavo lahko reši podporni tehnik."
 
-#~ msgid "Choose CA Certificate"
-#~ msgstr "Izbor potrdila CA"
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Zaščiteno pred zlonamerno programsko opremo, ko se naprava zažene."
 
-#~ msgid "As_k for this password every time"
-#~ msgstr "Vsakokrat _vprašaj za to geslo"
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Zaznane so težave v delovanju varnega zagons"
 
-#~ msgid "Don't _warn me again"
-#~ msgstr "_Ne opozori več"
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Osnovna zaščita, ko je naprava zagnana."
 
-#~ msgid "Yes"
-#~ msgstr "Da"
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Varni zagon je izklopljen"
 
-#~ msgid "Error logging into the account"
-#~ msgstr "Napaka med prijavljanjem v račun"
+#~ msgid "No protection when the device is started."
+#~ msgstr "Ni zaščite, ko je naprava zagnana."
 
-#~ msgid "Credentials have expired."
-#~ msgstr "Poverila so potekla."
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "To težavo bi lahko povzročila sprememba nastavitev strojne programske "
+#~ "opreme UEFI, sprememba prilagoditve operacijskega sistema ali zlonamerna "
+#~ "programska oprema v tem sistemu."
 
-#~ msgid "Sign in to enable this account."
-#~ msgstr "Za omogočanje računa je zahtevana prijava"
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "To težavo bi lahko povzročila sprememba nastavitev strojne programske "
+#~ "opreme UEFI ali zlonamerne programske opreme v tem sistemu."
 
-#~ msgid "_Sign In"
-#~ msgstr "_Prijava"
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "To težavo bi lahko povzročila sprememba prilagoditve operacijskega "
+#~ "sistema ali zlonamerna programska oprema v tem sistemu."
 
-#~ msgctxt "Search Location"
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Izpostavljeno resnim varnostnim tveganjem."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Omejena zaščita pred preprostimi varnostnimi grožnjami."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Zaščiten pred splošnimi varnostnimi grožnjami."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Zaščiteno pred široko paleto varnostnih groženj."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Celovita zaščita"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Strojna programska zaščita pisanja"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Zaklep strojne programske zaščite pisanja"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Območje strojne programske opreme BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Opisnik strojne programske opreme BIOS"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Zaščita pred zagonom DMA"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Preverjen zagon Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Zaščiten Intel BootGuard ACM"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Pravilnik o napakah za Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Varovalka Intel Boot Guard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Omogočena podpora Intel CET"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Podpora Intel CET je dejavna"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Šifriran RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Zaščita IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Zaklep jedra Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Overjanje jedra Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Izmenjevalni razdelek Linux"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Premakni v pripravljenost s pomnilnikom RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Premakni v stanje nedejavnosti seje"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Ključ okolja UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Varni zagon UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Prilagoditev platforme TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Obnova TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Proizvajalski način upravljalskega okolja Intel"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Prepis upravljalskega okolja Intel"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Različica upravljalskega okolja Intel"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Posodobitve strojne programske opreme"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Atest strojne programske opreme"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Preverjanje posodobitve strojne programske opreme"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Razhroščevanje okolja"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Varnostni pregledi procesorja"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Zaščita pred povratom AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Zaščita za ponovno predvajanje strojne programske opreme AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Strojna programska zaščita pisanja AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Okolje Fused"
+
+#~ msgid "Valid"
+#~ msgstr "Veljavno"
+
+#~ msgid "Not Valid"
+#~ msgstr "Ni veljavno"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Ni onemogočeno"
+
+#~ msgid "Locked"
+#~ msgstr "Zaklenjeno"
+
+#~ msgid "Not Locked"
+#~ msgstr "Ni zaklenjeno"
+
+#~ msgid "Encrypted"
+#~ msgstr "Šifrirano"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Ni šifrirano"
+
+#~ msgid "Tainted"
+#~ msgstr "Okvarjeno"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Neokvarjeno"
+
+#~ msgid "Found"
+#~ msgstr "Najdeno"
+
+#~ msgid "Not Found"
+#~ msgstr "Ni najdeno"
+
+#~ msgid "Supported"
+#~ msgstr "Podprto"
+
+#~ msgid "Not Supported"
+#~ msgstr "Nepodprto"
+
+#~ msgid "Unknown"
+#~ msgstr "Neznano"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bitni sistem"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bitni sistem"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Neznano"
+
+#~ msgid "Not Available"
+#~ msgstr "Ni na voljo"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo sistema"
+
+#~ msgid "No input sources found"
+#~ msgstr "Ni najdenih vhodnih virov"
+
+#~ msgctxt "Input Source"
 #~ msgid "Other"
 #~ msgstr "Drugo"
 
-#~ msgid "_Allow Remote Control"
-#~ msgstr "Dovoli _daljinski upravljalnik"
-
-#~ msgid "_Verify"
-#~ msgstr "_Overi"
-
-#~ msgid "Login History"
-#~ msgstr "Zgodovina prijav"
-
-#~ msgid "Add User Account"
-#~ msgstr "Dodaj uporabniški račun"
-
-#~ msgid "A user with the username '%s' already exists."
-#~ msgstr "Uporabnik z uporabniškim imenom »%s« že obstaja."
-
-#~ msgid "Start"
-#~ msgstr "Začni"
-
-#~ msgid "Done"
-#~ msgstr "Končano"
-
-#~ msgid "Import File…"
-#~ msgstr "Uvozi datoteko ..."
-
-#~ msgid "Set for all users"
-#~ msgstr "Nastavi za vse uporabnike"
-
-#~ msgid "Remove profile"
-#~ msgstr "Odstrani profil"
-
-#~ msgid "Time _Zone"
-#~ msgstr "Časovni _pas"
-
-#~ msgid "Key presses _repeat when key is held down"
-#~ msgstr "Ponavljanje p_ritiskov tipk, ko je tipka pritisnjena zadržano"
-
-#~ msgid "_Delay:"
-#~ msgstr "_Zamik:"
-
-#~ msgid "_Speed:"
-#~ msgstr "_Hitrost:"
-
-#~ msgctxt "keyboard, delay"
-#~ msgid "Short"
-#~ msgstr "Kratek"
-
-#~ msgctxt "keyboard, speed"
-#~ msgid "Slow"
-#~ msgstr "Počasi"
-
-#~ msgctxt "keyboard, delay"
-#~ msgid "Long"
-#~ msgstr "Dolg"
-
-#~ msgctxt "keyboard, speed"
-#~ msgid "Fast"
-#~ msgstr "Hitro"
-
-#~ msgid "Cursor _blinks in text fields"
-#~ msgstr "Kazalka v besedilnih poljih _utripa"
-
-#~ msgid "S_peed:"
-#~ msgstr "_Hitrost:"
-
-#~ msgid "Test Your Settings"
-#~ msgstr "Preizkus nastavitev"
-
-#~ msgctxt "double click, speed"
-#~ msgid "Slow"
-#~ msgstr "Počasno"
-
-#~ msgctxt "double click, speed"
-#~ msgid "Fast"
-#~ msgstr "Hitro"
-
-#~ msgid "_Double-click"
-#~ msgstr "_Dvojni klik"
-
-#~ msgid "Primary _button"
-#~ msgstr "Osnovni _gumb"
-
-#~ msgctxt "mouse, left button as primary"
-#~ msgid "_Left"
-#~ msgstr "_Levo"
-
-#~ msgctxt "mouse, right button as primary"
-#~ msgid "_Right"
-#~ msgstr "_Desno"
-
-#~ msgid "_Pointer speed"
-#~ msgstr "_Hitrost kazalnika"
-
-#~ msgctxt "mouse pointer, speed"
-#~ msgid "Slow"
-#~ msgstr "Počasno"
-
-#~ msgctxt "mouse pointer, speed"
-#~ msgid "Fast"
-#~ msgstr "Hitro"
-
-#~ msgctxt "touchpad pointer, speed"
-#~ msgid "Slow"
-#~ msgstr "Počasno"
-
-#~ msgctxt "touchpad pointer, speed"
-#~ msgid "Fast"
-#~ msgstr "Hitro"
-
-#~ msgid "_Natural scrolling"
-#~ msgstr "_Naravno drsenje"
-
-#~ msgctxt "notifications"
-#~ msgid "Sound Alerts"
-#~ msgstr "Zvočna opozorila"
-
-#~ msgctxt "notifications"
-#~ msgid "Notification Banners"
-#~ msgstr "Obvestilne pasice"
-
-#~ msgctxt "notifications"
-#~ msgid "Show Message Content in Banners"
-#~ msgstr "Pokaži vsebino sporočila v pasicah"
-
-#~ msgctxt "notifications"
-#~ msgid "Lock Screen Notifications"
-#~ msgstr "Obvestila na zaklenjenem zaslonu"
-
-#~ msgctxt "notifications"
-#~ msgid "Show Message Content on Lock Screen"
-#~ msgstr "Pokaži sporočila tudi na zaklenjenem zaslonu"
-
-#~ msgid "Notification Banners"
-#~ msgstr "Obvestilne pasice"
-
-#~ msgid "Suspend & Power Off"
-#~ msgstr "Izklop in prehod v pripravljenost"
-
-#~ msgid "Resume Printing"
-#~ msgstr "Nadaljuj tiskanje"
-
-#~ msgid "Pause Printing"
-#~ msgstr "Premor tiskanja"
-
-#~ msgctxt "print job"
-#~ msgid "Held"
-#~ msgstr "Zadrži"
-
-#~ msgid "Job Title"
-#~ msgstr "Naslov posla"
-
-#~ msgid "Job State"
-#~ msgstr "Stanje posla"
-
-#~ msgid "%s Active Jobs"
-#~ msgstr "%s dejavni posli"
-
-#~ msgid "Add New Printer"
-#~ msgstr "Dodaj nov tiskalnik"
-
-#~ msgid "Used to determine your geographical location"
-#~ msgstr "Uporabljeno za določanje geografskega položaja"
-
-#~ msgid "Computer Name"
-#~ msgstr "Ime računalnika"
-
-#~ msgid "Require Password"
-#~ msgstr "Zahtevaj geslo"
-
-#~ msgid "Password:"
-#~ msgstr "Geslo:"
-
-#~ msgid "Show Password"
-#~ msgstr "Pokaži geslo"
-
-#~ msgid "New connections must ask for access"
-#~ msgstr "Nove povezave morajo zahtevati dovoljenje za dostop"
-
-#~ msgid "Require a password"
-#~ msgstr "Zahtevano geslo"
-
-#~ msgid "Zoom"
-#~ msgstr "Približanje"
-
-#~ msgid "Magnification:"
-#~ msgstr "Približevanje:"
-
-#~ msgid "Follow mouse cursor"
-#~ msgstr "Sledi kazalki miške"
-
-#~ msgid "Screen part:"
-#~ msgstr "Del zaslona:"
-
-#~ msgid "Magnifier extends outside of screen"
-#~ msgstr "Približevalnik deluje tudi izven zaslona"
-
-#~ msgid "Keep magnifier cursor centered"
-#~ msgstr "Ohrani kazalko približevalnika na sredini"
-
-#~ msgid "Magnifier cursor pushes contents around"
-#~ msgstr "Kazalka približevalnika odriva vsebino"
-
-#~ msgid "Magnifier cursor moves with contents"
-#~ msgstr "Kazalka približevalnika se premika z vsebino"
-
-#~ msgid "Thickness:"
-#~ msgstr "Debelina:"
-
-#~ msgid "Length:"
-#~ msgstr "Dolžina:"
-
-#~ msgid "Color:"
-#~ msgstr "Barva:"
-
-#~ msgid "Crosshairs:"
-#~ msgstr "Merki:"
-
-#~ msgid "Overlaps mouse cursor"
-#~ msgstr "Prekrivanje kazalke miške"
-
-#~ msgid "White on black:"
-#~ msgstr "Črno na belem:"
-
-#~ msgid "Brightness:"
-#~ msgstr "Svetlost:"
-
-#~ msgid "Contrast:"
-#~ msgstr "Kontrast:"
-
-#~ msgctxt "universal access, contrast"
-#~ msgid "Color"
-#~ msgstr "Barva"
-
-#~ msgid "Wireless devices require extra power"
-#~ msgstr "Brezžične naprave zahtevajo dodatno napajanje"
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Bližnjica po meri"
 
 #~ msgid ""
-#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-#~ "devices"
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
 #~ msgstr ""
-#~ "Souporaba Bluetooth vam omogoča souporabo datotek z drugimi napravami z "
-#~ "omogočenim Bluetooth"
+#~ "Tipka za izmenjavo omogoča uporabo dodatnih znakov. Ti so pogosto "
+#~ "natisnjeni na tipkovnici kot tretja možnost."
 
-#~ msgid "Only Receive From Trusted Devices"
-#~ msgstr "Prejmi le od zaupljivih naprav"
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Leva izmenjalka (Alt)"
 
-#~ msgid "Save Received Files to Downloads Folder"
-#~ msgstr "Shrani prejete datoteke v mapo prejemov"
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Desna izmenjalka (Alt)"
 
-#~ msgid "Show help options"
-#~ msgstr "Pokaži možnosti pomoči"
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Leva tipka Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Desna tipka Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Tipka Meni"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Desna krmilka (Ctrl)"
 
 #~ msgid ""
-#~ "%s\n"
-#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
 #~ msgstr ""
-#~ "%s\n"
-#~ "Zaženite '%s --help' za pregled celotnega seznama možnosti ukazne "
-#~ "vrstice.\n"
+#~ "Sestavljalna tipka omogoča vnos velikega števila različnih znakov. Za "
+#~ "uporabo najprej pritisnite sestavljalno tipko, nato pa zaporedje drugih "
+#~ "znakov. Na primer; pritisnite sestavljalko, potem <b>C</b> in nato <b>o</"
+#~ "b>. Izpisal se bo znak <b>©</b>. Z zaporedjem sestavljalka, <b>a</b> in "
+#~ "nato <b>'</b> pa ustvari znak <b>á</b>."
 
-#~ msgid "When battery power is _critical"
-#~ msgstr "Ko je polnost baterije _kritično nizka"
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Zaklep črk"
 
-#~ msgid "United States"
-#~ msgstr "Združene države Amerike"
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Posnemi zaslon"
 
-#~ msgid "Germany"
-#~ msgstr "Nemčija"
-
-#~ msgid "Spain"
-#~ msgstr "Španija"
-
-#~ msgid "China"
-#~ msgstr "Kitajska"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Onemogoči med _tipkanjem"
-
-#~ msgid "The system network services are not compatible with this version."
-#~ msgstr "Sistemske omrežne storitve niso podprte s to različico."
-
-#~ msgctxt "notifications"
-#~ msgid "Show Popup Banners"
-#~ msgstr "Pokaži pojavna obvestila"
-
-#~ msgctxt "notifications"
-#~ msgid "View in Lock Screen"
-#~ msgstr "Pokaži na zaklenjenem zaslonu"
-
-#~ msgid "Show Pop Up Banners"
-#~ msgstr "Pokaži pojavna obvestila"
-
-#~ msgid "Turns off wireless devices"
-#~ msgstr "Izklopi brezžične naprave"
-
-#~ msgid "Enter address of a printer or a text to filter results"
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
 #~ msgstr ""
-#~ "Vpišite naslov tiskalnika ali pa besedilo za filtriranje zadetkov iskanja"
+#~ "Vhodni vir je mogoče preklopiti z uporabo tipkovne bližnjice %s.\n"
+#~ "Nastavitve je mogoče spremeniti med nastavitvami bližnjic tipkovnice."
 
-#~ msgid "Sorry"
-#~ msgstr "Oprostite"
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d spremenjenih"
+#~ msgstr[1] "%d spremenjena"
+#~ msgstr[2] "%d spremenjeni"
+#~ msgstr[3] "%d spremenjene"
 
-#~ msgid "Share Public Folder On This Network"
-#~ msgstr "Javno mapo pokaži v omrežju "
-
-#~ msgid "Share Media On This Network"
-#~ msgstr "Souporaba predstavne datoteke na omrežju"
-
-#~ msgid "Shared Folders"
-#~ msgstr "Mape v souporabi"
-
-#~ msgid "column"
-#~ msgstr "stolpec"
-
-#~ msgid "Remove Folder"
-#~ msgstr "Odstrani mapo"
-
-#~ msgid "Immediately"
-#~ msgstr "Takoj"
-
-#~ msgid "Install Updates"
-#~ msgstr "Namesti posodobitve"
-
-#~ msgid "System Up-To-Date"
-#~ msgstr "Sistem je posodobljen."
-
-#~ msgid "Search for network printers or filter result"
-#~ msgstr "Poišči omrežni tiskalnik ali pa filtriraj zadetke"
-
-#~ msgid "_Default"
-#~ msgstr "_Privzeto"
-
-#~ msgid "Approve All Connections"
-#~ msgstr "Odobri vse povezave"
-
-#~ msgid "Set Up New Device"
-#~ msgstr "Nastavi novo napravo"
-
-#~ msgid "Paired"
-#~ msgstr "Seznanjeno"
-
-#~ msgid "Mouse & Touchpad Settings"
-#~ msgstr "Nastavitve miške in sledilne ploščice"
-
-#~ msgid "Keyboard Settings"
-#~ msgstr "Nastavitve tipkovnice"
-
-#~ msgid "Send Files…"
-#~ msgstr "Pošlji datoteke ..."
-
-#~ msgid "Visibility of “%s”"
-#~ msgstr "Vidnost “%s”"
-
-#~ msgid "Remove '%s' from the list of devices?"
-#~ msgstr "Ali naj se naprava '%s' odstrani s seznama?"
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Ali želite ponastaviti vse tipkovne bližnjice?"
 
 #~ msgid ""
-#~ "If you remove the device, you will have to set it up again before next "
-#~ "use."
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
 #~ msgstr ""
-#~ "V primeru, da napravo odstranite, jo bo treba pred naslednjo uporabo, "
-#~ "ponovno nastaviti."
+#~ "Ponastavljanje tipkovnih bližnjic lahko vpliva na tiste po meri. Dejanja "
+#~ "ni mogoče povrniti."
 
-#~ msgid "Share Public Folder"
-#~ msgstr "Souporaba mape"
+#~ msgid "Reset All"
+#~ msgstr "Ponastavi vse"
 
-#~ msgid "Only share with Trusted Devices"
-#~ msgstr "V souporabi le z varnimi napravami"
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s je že uporabljen za %s. Če ga zamenjate, bo %s onemogočen."
 
-#~ msgid "Device type:"
-#~ msgstr "Vrsta naprave:"
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Vpišite novo tipkovno bližnjico"
 
-#~ msgid "Manufacturer:"
-#~ msgstr "Proizvajalec:"
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Nastavi bližnjico po meri"
 
-#~ msgid "Model:"
-#~ msgstr "Model:"
+#~ msgid "Set Shortcut"
+#~ msgstr "Nastavi tipkovno bližnjico"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Vpišite novo tipkovno bližnjico za zamenjavo %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Dodaj bližnjico po meri"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Dvo-_prstno drsenje"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Pet klikov za GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dvojni klik, osnovni gumb"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Enojni klik, osnovni gumb"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dvojni klik, srednji gumb"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Enojni klik, srednji gumb"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dvojni klik, drugi gumb"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Enojni klik, drugi gumb"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Program NetworkManager mora biti zagnan."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Ne-varno omrežje (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Varno omrežje (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Varno omrežje (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Varno omrežje (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Varno omrežje"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Ob priklopu vroče točke se onemogoči povezava z omrežjem %s, zato dostop "
+#~ "po Wi-Fi ne bo več mogoč."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Vsebovati mora najmanj 8 znakov"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr ""
+#~ "Ali naj se zaustavi vroča vstopna točka in se prekine povezava vseh "
+#~ "uporabnikov?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Zaustavi vročo vstopno točko"
+
+#~ msgid "Preserve"
+#~ msgstr "Ohrani"
+
+#~ msgid "Permanent"
+#~ msgstr "Trajno"
+
+#~ msgid "Random"
+#~ msgstr "Naključno"
+
+#~ msgid "Stable"
+#~ msgstr "Stabilo"
 
 #~ msgid ""
-#~ "Image files can be dragged on this window to auto-complete the above "
-#~ "fields."
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
 #~ msgstr ""
-#~ "Slikovne datoteke je mogoče povleči v to okno za samodejno dopolnjevanje "
-#~ "vnosnih polj."
+#~ "Naslov MAC, vpisan na tem mestu, bo uporabljen kot strojni naslov za "
+#~ "omrežno napravo, ki ustvarja povezavo. Zmožnost je poznana kot kloniranje "
+#~ "naslova MAC oziroma lažno predstavljanje. Primer: 00:11:22:33:44:55"
 
-#~ msgid "Show your primary display on this screen also"
-#~ msgstr "Osnovni zaslon prikaži tudi na tem zaslonu"
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
 
-#~ msgid "Combine"
-#~ msgstr "Združi"
+#~ msgid "WEP"
+#~ msgstr "WEP"
 
-#~ msgid "Join with the primary display to create an extra space"
-#~ msgstr "Združi z osnovnim zaslonom za omogočanje dodatnega prostora"
+#~ msgid "WPA"
+#~ msgstr "WPA"
 
-#~ msgid "Don't use the display"
-#~ msgstr "Ne uporabi zaslona"
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
 
-#~ msgid "Mouse Preferences"
-#~ msgstr "Možnosti miške"
+#~ msgid "Enhanced Open"
+#~ msgstr "Napredno odpiranje"
 
-#~ msgid "Select the interface to use for the new service"
-#~ msgstr "Izbor vmesnika za novo storitev"
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
 
-#~ msgid "C_reate…"
-#~ msgstr "_Ustvari ..."
+#~ msgid "Enterprise"
+#~ msgstr "Podjetniški"
 
-#~ msgid "_Interface"
-#~ msgstr "_Vmesnik"
-
-#~ msgctxt "Language"
+#~ msgctxt "Wifi security"
 #~ msgid "None"
 #~ msgstr "Brez"
 
-#~ msgid "Changing photo for:"
-#~ msgstr "Spremeni sliko za:"
+#~ msgid "Never"
+#~ msgstr "Nikoli"
 
-#~ msgid ""
-#~ "Choose a picture that will be shown at the login screen for this account."
-#~ msgstr "Izbor slike, ki bo prikazana na prijavnem zaslonu tega računa."
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
 
-#~ msgid "Gallery"
-#~ msgstr "Galerija"
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
 
-#~ msgid "Take a photograph"
-#~ msgstr "Zajemi fotografijo"
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
 
-#~ msgid "Browse"
-#~ msgstr "Prebrskaj"
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
 
-#~ msgid "Photograph"
-#~ msgstr "Fotografija"
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
 
-#~ msgid "Switch between AM and PM."
-#~ msgstr "Preklop med dopoldanskim in popoldanskim prikazom."
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Brez"
 
-#~ msgid "Estimated battery capacity: %s"
-#~ msgstr "Ocenjeno trajanje baterije: %s"
-
-#~ msgid "_Region:"
-#~ msgstr "_Območje:"
-
-#~ msgid "_City:"
-#~ msgstr "_Mesto:"
-
-#~ msgid "Set the time one hour ahead."
-#~ msgstr "Nastavi čas za eno uro naprej."
-
-#~ msgid "Set the time one hour back."
-#~ msgstr "Nastavi čas za eno uro nazaj."
-
-#~ msgid "Set the time one minute ahead."
-#~ msgstr "Nastavi čas za eno minuto naprej."
-
-#~ msgid "Set the time one minute back."
-#~ msgstr "Nastavi čas za eno minuto nazaj."
-
-#~ msgid "AM/PM"
-#~ msgstr "dop./pop."
-
-#~ msgctxt "display panel, rotation"
-#~ msgid "Normal"
-#~ msgstr "Običajno"
-
-#~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "V smeri urinega kazalca"
-
-#~ msgctxt "display panel, rotation"
-#~ msgid "180 Degrees"
-#~ msgstr "180 stopinj"
-
-#~ msgid ""
-#~ "Select a monitor to change its properties; drag it to rearrange its "
-#~ "placement."
-#~ msgstr ""
-#~ "Z izborom zaslona je mogoče spreminjati lastnosti, s klikom in potegom pa "
-#~ "njihov položaj."
-
-#~ msgid "%a %R"
-#~ msgstr "%a %R"
-
-#~ msgid "_Resolution"
-#~ msgstr "_Ločljivost"
-
-#~ msgid "R_otation"
-#~ msgstr "_Vrtenje"
-
-#~ msgid "_Mirror displays"
-#~ msgstr "_Zrcali zaslone"
-
-#~ msgid "Note: may limit resolution options"
-#~ msgstr "Opomba: lahko omeji možnosti ločljivosti"
-
-#, fuzzy
-#~ msgid "Show Status When _Inactive"
-#~ msgstr "Pošlji v pripravljenost ob nedejavnosti:"
-
-#~ msgid "Could not save the monitor configuration"
-#~ msgstr "Ni mogoče shraniti nastavitev zaslona"
-
-#~ msgid "Hidden"
-#~ msgstr "Skrito"
-
-#~ msgid "Visible"
-#~ msgstr "Vidno"
-
-#~ msgid "Name & Visibility"
-#~ msgstr "Ime in vidnost"
-
-#~ msgid "Control how you appear on the screen and the network."
-#~ msgstr "Nadzirajte kako ste videti na zaslonu in omrežju."
-
-#~ msgid "Display _full name in top bar"
-#~ msgstr "Prikaži _polno ime v vrhnji vrstici"
-
-#~ msgid "Display full name in _lock screen"
-#~ msgstr "Prikaži _polno ime na zaklenjenem  zaslonu"
-
-#~ msgid "_Stealth Mode"
-#~ msgstr "_Prikriti način"
-
-#~ msgid "C_ontent sticks to fingers"
-#~ msgstr "V_sebina se prilepi na prste"
-
-#~ msgctxt "universal access, contrast"
-#~ msgid "Normal"
-#~ msgstr "Običajen"
-
-#~ msgctxt "universal access, contrast"
-#~ msgid "High/Inverse"
-#~ msgstr "Obrnjen visok kontrast"
-
-#~ msgid "On screen keyboard"
-#~ msgstr "Zaslonska tipkovnica"
-
-#~ msgid "OnBoard"
-#~ msgstr "OnBoard"
-
-#~ msgid "75%"
-#~ msgstr "75%"
-
-#~ msgid "100%"
-#~ msgstr "100%"
-
-#~ msgctxt "universal access, text size"
-#~ msgid "Normal"
-#~ msgstr "Običajno"
-
-#~ msgid "125%"
-#~ msgstr "125%"
-
-#~ msgid "150%"
-#~ msgstr "150%"
-
-#~ msgid "Beep on Caps and Num Lock"
-#~ msgstr "Zapiskaj ob pritisku tipk zaklepa številčnice in velikih črk"
-
-#~ msgid "Turn on or off:"
-#~ msgstr "Vključi ali izključi:"
-
-#~ msgctxt "universal access, zoom"
-#~ msgid "Zoom"
-#~ msgstr "Približanje"
-
-#~ msgid "Zoom in:"
-#~ msgstr "Približaj:"
-
-#~ msgid "Zoom out:"
-#~ msgstr "Oddalji:"
-
-#~ msgid "Closed Captioning"
-#~ msgstr "Zaprt naslov"
-
-#~ msgid "Display a textual description of speech and sounds"
-#~ msgstr "Prikaže besedni opis govora in zvokov"
-
-#~ msgctxt "universal access, delay"
-#~ msgid "Short"
-#~ msgstr "Kratek"
-
-#~ msgctxt "universal access, delay"
-#~ msgid "Long"
-#~ msgstr "Dolg"
-
-#~ msgid "Beep when a key is"
-#~ msgstr "Zapiskaj, kadar je tipka"
-
-#~ msgid "pressed"
-#~ msgstr "pritisnjeno"
-
-#~ msgid "accepted"
-#~ msgstr "sprejeto"
-
-#~ msgid "rejected"
-#~ msgstr "zavrnjeno"
-
-#~ msgid "Acc_eptance delay:"
-#~ msgstr "Pretek na_tančnosti:"
-
-#~ msgid "Control the pointer using the keypad"
-#~ msgstr "Kazalnik je mogoče upravljati s številčno tipkovnico"
-
-#~ msgid "Video Mouse"
-#~ msgstr "Video miška"
-
-#~ msgid "Control the pointer using the video camera."
-#~ msgstr "Nadzor kazalnika z uporabo video kamere."
-
-#~ msgctxt "universal access, threshold"
-#~ msgid "Small"
-#~ msgstr "Majhen"
-
-#~ msgctxt "universal access, threshold"
-#~ msgid "Large"
-#~ msgstr "Velik"
-
-#~ msgid "Mouse Settings"
-#~ msgstr "Nastavitve miške"
-
-#~ msgid "_Local Account"
-#~ msgstr "_Krajevni račun"
-
-#~ msgid "_Login Name"
-#~ msgstr "_Prijavno ime"
-
-#~ msgid "Tip: Enterprise domain or realm name"
-#~ msgstr "Namig: Prijava v poslovno domeno ali ime območja"
-
-#~ msgid "C_ontinue"
-#~ msgstr "_Nadaljuj"
-
-#~ msgid "Next Week"
-#~ msgstr "Naslednji teden"
-
-#~ msgid "Next week"
-#~ msgstr "Naslednji teden"
-
-#~ msgid "Log in without a password"
-#~ msgstr "Prijava brez gesla"
-
-#~ msgid "Disable this account"
-#~ msgstr "Onemogoči ta račun"
-
-#~ msgid "Enable this account"
-#~ msgstr "Omogoči ta račun"
-
-#~ msgid "_Action"
-#~ msgstr "_Dejanje"
-
-#~ msgid "_Show password"
-#~ msgstr "_Pokaži geslo"
-
-#~ msgid "How to choose a strong password"
-#~ msgstr "Kako izbrati dobro geslo"
-
-#~ msgctxt "Password strength"
-#~ msgid "Too short"
-#~ msgstr "Prekratko"
-
-#~ msgctxt "Password strength"
-#~ msgid "Not good enough"
-#~ msgstr "Ni dovolj dobro"
-
-#~ msgctxt "Password strength"
+#~ msgctxt "Signal strength"
 #~ msgid "Weak"
 #~ msgstr "Šibko"
 
-#~ msgctxt "Password strength"
-#~ msgid "Fair"
-#~ msgstr "Zadovoljivo"
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "V redu"
 
-#~ msgctxt "Password strength"
+#~ msgctxt "Signal strength"
 #~ msgid "Good"
 #~ msgstr "Dobro"
 
-#~ msgctxt "Password strength"
-#~ msgid "Strong"
-#~ msgstr "Močno"
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Odlično"
 
-#~ msgid "_Generate a password"
-#~ msgstr "Ustvari _geslo"
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
 
-#~ msgid "You need to enter a new password"
-#~ msgstr "Vnesti je treba novo geslo"
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
 
-#~ msgid "The new password is not strong enough"
-#~ msgstr "Novo geslo ne vsebuje dovolj različnih znakov"
+#~ msgid "Forget Connection"
+#~ msgstr "Pozabi povezavo"
 
-#~ msgid "You need to confirm the password"
-#~ msgstr "Geslo je treba potrditi"
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Odstrani profil povezave"
 
-#~ msgid "You need to enter your current password"
-#~ msgstr "Vnesti je treba trenutno geslo."
+#~ msgid "Remove VPN"
+#~ msgstr "Odstrani VPN"
 
-#~ msgid "The current password is not correct"
-#~ msgstr "Trenutno geslo ni pravo"
+#~ msgid "Details"
+#~ msgstr "Podrobnosti"
 
-#~ msgid "Switch Modes"
-#~ msgstr "Preklopi način"
+#~ msgid "automatic"
+#~ msgstr "samodejno"
 
-#~ msgid "Action"
-#~ msgstr "Dejanje"
+#~ msgid "Identity"
+#~ msgstr "Istovetnost"
 
-#~ msgid "Left Shift"
-#~ msgstr "Leva dvigalka (Shift)"
+#~ msgid "Delete Address"
+#~ msgstr "Izbriši naslov"
 
-#~ msgid "Right Shift"
-#~ msgstr "Desna dvigalka (Shift)"
+#~ msgid "Delete Route"
+#~ msgstr "Izbriši smer"
 
-#~ msgid "Left Alt+Shift"
-#~ msgstr "Leva izmenjalka (Alt)+ dvigalka (Shift)"
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
 
-#~ msgid "Right Alt+Shift"
-#~ msgstr "Desna izmenjalka (Alt)+ dvigalka (Shift)"
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
 
-#~ msgid "Left Ctrl+Shift"
-#~ msgstr "Leva krmilka (Ctrl)+ dvigalka (Shift)"
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "↓Brez"
 
-#~ msgid "Right Ctrl+Shift"
-#~ msgstr "Desna krmilka (Ctrl) + dvigalka (Shift)"
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "↓Ključ WEP 40/128-bit (Šestnajstiški ali ASCII)"
 
-#~ msgid "Left+Right Shift"
-#~ msgstr "Leva + desna dvigalka"
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "↓128-bitno šifrirno geslo WEP"
 
-#~ msgid "Left+Right Ctrl"
-#~ msgstr "Leva + desna krmilka (Ctrl)"
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "↓Dinamični WEP (802.1x)"
 
-#~ msgid "Alt+Shift"
-#~ msgstr "Izmenjalka (Alt)+dvigalka (Shift)"
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "↓Osebni WPA in WPA2"
 
-#~ msgid "Ctrl+Shift"
-#~ msgstr "Krmilka (Ctrl)+dvigalka (Shift)"
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "↓Podjetniški WPA in WPA2"
 
-#~ msgid "Alt+Ctrl"
-#~ msgstr "Izmenjalka (Alt)+krmilka (Ctrl)"
+#~ msgid "WPA3 Personal"
+#~ msgstr "Osebni WPA3"
 
-#~ msgid "Shift+Caps"
-#~ msgstr "Dvigalka (Shift)+ tipka zaklepnica črk"
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Ni mogoče odpreti urejevalnika povezav"
 
-#~ msgid "Alt+Caps"
-#~ msgstr "Izmenjalka (Alt)+ tipka zaklepnica črk"
+#~ msgid "New Profile"
+#~ msgstr "Nov profil"
 
-#~ msgid "Ctrl+Caps"
-#~ msgstr "Krmilka (Ctrl) + tipka zaklepnica črk"
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Neveljavna nastavitev %s: %s"
 
-#~ msgid "Export"
-#~ msgstr "Izvozi"
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Neveljavna nastavitev %s"
 
-#~ msgctxt "mouse, speed"
-#~ msgid "Slow"
-#~ msgstr "Počasi"
+#~ msgid "Import from file…"
+#~ msgstr "Uvozi iz datoteke …"
 
-#~ msgctxt "mouse, speed"
-#~ msgid "Fast"
-#~ msgstr "Hitro"
+#~ msgid "Add VPN"
+#~ msgstr "Dodaj VPN"
 
-#~ msgid "_Options…"
-#~ msgstr "_Možnosti ..."
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Povezave VPN ni mogoče uvoziti "
 
-#~ msgid "blablabla"
-#~ msgstr "blablabla"
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Datoteke »%s« ni mogoče prebrati ali pa ta ne vsebuje prepoznanih "
+#~ "podatkov o povezavi VPN\n"
+#~ "\n"
+#~ "Napaka: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Izbor datoteke za uvoz"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Datoteka z imenom »%s« že obstaja."
+
+#~ msgid "_Replace"
+#~ msgstr "_Zamenjaj"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "Ali želite zamenjati povezavo %s z nastavitvami povezave VPN, ki jih "
+#~ "shranjujete?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Ni mogoče izvoziti povezave VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Povezave VPN »%s« ni mogoče izvoziti v %s.\n"
+#~ "\n"
+#~ "Napaka: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Izvoz povezavo VPN"
+
+#~ msgid "never"
+#~ msgstr "nikoli"
+
+#~ msgid "today"
+#~ msgstr "danes"
+
+#~ msgid "yesterday"
+#~ msgstr "včeraj"
+
+#~ msgid "Last used"
+#~ msgstr "Nazadnje uporabljeno"
+
+#~ msgid "Add new connection"
+#~ msgstr "Dodaj novo povezavo"
 
 #~ msgid ""
-#~ "Address\n"
-#~ "section\n"
-#~ "goes\n"
-#~ "here"
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
 #~ msgstr ""
-#~ "To je polje\n"
-#~ "odseka\n"
-#~ "naslova"
+#~ "Omrežne podrobnosti o izbranem omrežju z nastavitvami po meri in "
+#~ "pripadajočimi gesli bodo izgubljene."
+
+#~ msgid "_Forget"
+#~ msgstr "_Izbriši"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Znana omrežja Wi-Fi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Izbriši"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Sistemska pravila onemogočajo uporabo vročih točk"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Brezžična naprava ne podpira načina vročih točk"
 
 #~ msgid ""
-#~ "DNS\n"
-#~ "section\n"
-#~ "goes\n"
-#~ "here"
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
 #~ msgstr ""
-#~ "To je polje\n"
-#~ "odseka\n"
-#~ "podatkov\n"
-#~ "DNS"
+#~ "Samodejno odkrivanje posredniškega strežnika je uporabljena, kadar "
+#~ "nastavitveni naslov URL ni naveden."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Možnost ni priporočljiva za nezavarovana javna omrežja."
+
+#~ msgid "Status unknown"
+#~ msgstr "Neznano stanje"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Neupravljano"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nedostopno"
+
+#~ msgid "Connecting"
+#~ msgstr "V povezovanju"
+
+#~ msgid "Authentication required"
+#~ msgstr "Zahtevana je overitev"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Prekinjanje povezave"
+
+#~ msgid "Connection failed"
+#~ msgstr "Povezovanje je spodletelo"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Stanje baterije ni znano (manjka)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Nastavitev je spodletela"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Nastavljanje IP je spodletelo"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Nastavitev IP je časovno poteklo"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Zahtevana so bila ustrezna gesla, ki pa niso bila podana"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Prosilnik 802.1X je odklopljen"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Nastavitev prosilnika 802.1X je spodletela"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Prosilnik 802.1X je spodletel"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Prosilnik 802.1X je potreboval preveč časa za overjanje"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Storitev PPP ni uspešno zagnana"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Storitev PPP je prekinjena"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP je spodletel"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Začenjanje odjemalca DHCP je spodletelo"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Napaka odjemalca DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Odjemalec DHCP je spodletel"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Začenjanje storitve souporabe povezave je spodletelo."
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Storitev souporabe povezave je spodletela."
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Začenjanje storitve AutoIP je spodletelo."
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Napaka storitve AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Storitev AutoIP je spodletela"
+
+#~ msgid "Line busy"
+#~ msgstr "Povezava je zasedena"
+
+#~ msgid "No dial tone"
+#~ msgstr "Ni klicnega signala"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Ni mogoče vzpostaviti signala povezave"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Zahteva klicanja je časovno potekla"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Poskus klicanja je spodletel"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Začenjanje modema je spodletelo"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Izbor določenega APN je spodletel"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Iskanje omrežij ni dejavno"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Vpis omrežja je zavrnjen"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Čas za vpis omrežja je potekel"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Vpis v zahtevano omrežju je spodletela"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Preverjanje PIN je spodletelo"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Napravi morda manjka zahtevana strojna programska oprema"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Dejavna povezava je izginila"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Predviden je bila obstoječa povezava"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modema ni mogoče najti"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Povezava Bluetooth je spodletela"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Kartica SIM ni vstavljena"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Zahtevana je šifra SIM PIN"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Zahtevana je šifra SIM PUK"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Kartica SIM je neustrezna"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Odvisnost povezave je spodletela"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Manjka strojna programska oprema"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabel ni priklopljen"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "nedoločena napaka varnostnega protokola 802.1x (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "ni izbrane datoteke"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "nedoločena napaka overjenja datoteke eap-method"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Zasebni ključi DER, PEM, PGP ali PKCS#12"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Potrdila DER ali PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "manjka datoteka EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Datoteke PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "manjka uporabniško ime EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "manjka geslo EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "neveljavno potrdilo EAP-PEAP CA: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "neveljavno potrdilo EAP-PEAP CA: potrdilo ni določeno"
+
+#~ msgid "missing EAP username"
+#~ msgstr "manjka uporabniško ime EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "manjka geslo EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "manjka istovetnost EAP"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "neveljavno potrdilo EAP-TLS CA: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "neveljavno potrdilo EAP-TLS CA: potrdilo ni določeno"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "neveljaven zasebni ključ EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "neveljavno uporabniško potrdilo EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Nešifrirani zasebni ključi niso varni"
 
 #~ msgid ""
-#~ "Routes\n"
-#~ "section\n"
-#~ "goes\n"
-#~ "here"
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
 #~ msgstr ""
-#~ "To je polje\n"
-#~ "odseka\n"
-#~ "prehodov"
+#~ "Videti je, da izbrani zasebni ključi niso zaščiteni z geslom. To bi lahko "
+#~ "ogrozilo varnost podatkov. Izberite z geslom zaščiten zasebni ključ.\n"
+#~ "\n"
+#~ "(Zasebne ključe lahko zaščitite z geslom z OpenSSL.)"
 
-#~ msgid "00:24:16:31:8G:7A"
-#~ msgstr "00:24:16:31:8G:7A"
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Izbor osebnega potrdila"
 
-#~ msgctxt "Input source"
+#~ msgid "Choose your private key"
+#~ msgstr "Izbor osebnega ključa"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "neveljavno potrdilo EAP-TTLS CA: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "neveljavno potrdilo EAP-TTLS CA: potrdilo ni določeno"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Prišlo je do neznane napake overjanja varnosti 802.1x."
+
+#~ msgid "Select a file"
+#~ msgstr "Izbor datoteke"
+
+#~ msgid "missing leap-username"
+#~ msgstr "manjka uporabniško ime za leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "manjka geslo leap"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Ni vpisanega gesla za Wi-Fi"
+
+#~ msgid "missing wep-key"
+#~ msgstr "manjka ključ wep"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "neveljavni podatki wpa-psk: ključ dolžine %zu mora vsebovati le števila v "
+#~ "šestnajstiškem sistemu"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "neveljavni podatki wpa-psk: ključ dolžine %zu mora vsebovati le znake "
+#~ "ASCII"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "neveljavni podatki wpa-psk: napačna dolžina ključa %zu. Biti mora biti "
+#~ "ali 5/13 (ASCII) oziroma 10/26 (šestnajstiško)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "neveljavni podatki wpa-psk: šifrirna koda mora biti vpisana"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr ""
+#~ "neveljavni podatki wpa-psk: šifrirna koda mura biti krajša od 64 znakov"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "neveljavni podatki wpa-psk: neustrezna dolžina ključa %zu. Biti mora "
+#~ "[8,63] bajtov oziroma 64 števil v šestnajstiškem sistemu"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "neveljavni podatki wpa-psk: ni mogoče tolmačiti 64-bitnega ključa v "
+#~ "šestnajstiškem sistemu"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Drugi"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "Račun %s je odstranjen."
+
+#~ msgid "Error removing account"
+#~ msgstr "Napaka med odstranjevanjem računa"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Račun %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Odstrani račun"
+
+#~ msgid "Unknown time"
+#~ msgstr "Neznan čas"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "Še %s do polne napolnjenosti"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Opozorilo: na voljo je še %s delovanja"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Še %s do konca delovanja"
+
+#~ msgid "Fully charged"
+#~ msgstr "Polna napolnjenost"
+
+#~ msgid "Not charging"
+#~ msgstr "Naprava se ne polni"
+
+#~ msgid "Empty"
+#~ msgstr "Prazno"
+
+#~ msgid "Charging"
+#~ msgstr "Polnjenje"
+
+#~ msgid "Discharging"
+#~ msgstr "Praznjenje"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Brezžična miška"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Brezžična tipkovnica"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Neprekinjen oskrba z napetostjo"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Digitalni pomočnik"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobilni telefon"
+
+#~ msgid "Media player"
+#~ msgstr "Predvajalnik predstavnih datotek"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablični računalnik"
+
+#~ msgid "Computer"
+#~ msgstr "Računalnik"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Igralniška vhodna naprava"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Glavno"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Dodatno"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterije"
+
+#~ msgid "When _idle"
+#~ msgstr "Ob _nedejavnosti"
+
+#~ msgid "Suspend"
+#~ msgstr "Zaustavi"
+
+#~ msgid "Power Off"
+#~ msgstr "Izklop"
+
+#~ msgid "Hibernate"
+#~ msgstr "Preidi v mirovanje"
+
+#~ msgid "Nothing"
+#~ msgstr "Ničesar"
+
+#~ msgid "When on battery power"
+#~ msgstr "Med delovanjem na bateriji"
+
+#~ msgid "When plugged in"
+#~ msgstr "Ob priklopu"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Nikoli"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Samodejen prehod v pripravljenost"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Zmogljivostni način delovanja je začasno onemogočen zaradi visoke delovne "
+#~ "temperature."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Sprememba delovanja: zmogljivostni način začasno ni na voljo. Za ponovno "
+#~ "vzpostavitev je treba napravo premakniti na stabilno površino."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Zmogljivostni način je začasno onemogočen."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Nizko stanje baterije: omogočen je varčevalni način delovanja. Predhodno "
+#~ "uporabljeni način bo obnovljen, ko bo baterija dovolj napolnjena."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Varčevalni način delovanja je sprožil program »%s«."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Zmogljivostni način delovanja je sprožil program »%s«."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Zmogljivost"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Visoka zmogljivost delovanja in velika poraba energije."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Uravnoteženo"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Običajna zmogljivost delovanja in zmerna poraba energije."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Varčno"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Zmanjšana zmogljivost delovanja in majhna poraba energije."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Tiskalnik »%s« je bil izbrisan."
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Dodajanje novega tiskalnika je spodletelo."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Ni mogoče naložiti uporabniškega vmesnika: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Odklenite za dodajanje tiskalnikov in spreminjanje nastavitev"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Podrobnosti %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Ni mogoče najti ustreznega gonilnika"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Izbor datoteke PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Datoteke opisa tiskalnika PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Tiskalnik JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Tiskalnik LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Enostransko"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Dolga stranica (standardno)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kratka stranica (zrcaljeno)"
+
+#~ msgid "Portrait"
+#~ msgstr "Pokončno"
+
+#~ msgid "Landscape"
+#~ msgstr "Ležeče"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Obrnjeno ležeče"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Obrnjeno pokončno"
+
+#~ msgid "Resume"
+#~ msgstr "Nadaljuj"
+
+#~ msgid "Pause"
+#~ msgstr "Premor"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "V čakanju"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Premor"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Zahtevana je overitev"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Izvajanje"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Zaustavljeno"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Preklicano"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Prekinjeno"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Zaključeno"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Premakni opravilo na vrh vrste"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s – dejavni posli"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Vpišite poverila za tiskanje na %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Odkleni strežnik tiskanja"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Odkleni %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Vnesite uporabniško ime in geslo za ogled tiskalnikov na %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Poteka iskanje tiskalnikov"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Zaporedna vrata"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Vzporedna vrata"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Mesto: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Naslov: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Strežnik zahteva overitev"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dvostransko"
+
+#~ msgid "Paper Type"
+#~ msgstr "Vrsta papirja"
+
+#~ msgid "Paper Source"
+#~ msgstr "Vir papirja"
+
+#~ msgid "Output Tray"
+#~ msgstr "Pladenj za papir"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Ločljivost"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Predhodno filtriranje GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Strani na stran"
+
+#~ msgid "Orientation"
+#~ msgstr "Usmerjenost"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Splošno"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Nastavitev strani"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Namestitvene možnosti"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Posel"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Kakovost slike"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Barvni profili"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Zaključevanje"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Napredno"
+
+#~ msgid "Test page"
+#~ msgstr "Preizkusna stran"
+
+#~ msgid "Auto Select"
+#~ msgstr "Samodejno izberi"
+
+#~ msgid "Printer Default"
+#~ msgstr "Privzeto za tiskalnik"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Vstavi samo pisave GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Pretvori v PS ravni 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Pretvori v PS ravni 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Brez predhodnega filtriranja"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Počisti glave tiskalnika"
+
+#~ msgid "Out of toner"
+#~ msgstr "Zmanjkalo je tonerja"
+
+#~ msgid "Low on developer"
+#~ msgstr "Razvijalca je malo"
+
+#~ msgid "Out of developer"
+#~ msgstr "Zmanjkalo je razvijalca"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Zaloge označevalnika je malo"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Zaloge označevalnika je zmanjkalo"
+
+#~ msgid "Open cover"
+#~ msgstr "Odprt pokrov"
+
+#~ msgid "Open door"
+#~ msgstr "Odprta vrata"
+
+#~ msgid "Low on paper"
+#~ msgstr "Malo papirja"
+
+#~ msgid "Out of paper"
+#~ msgstr "Ni papirja"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Nepovezano"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Zaustavljeno"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Zbiralnik odpadkov je skoraj poln"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Zbiralnik odpadkov je poln"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Optični foto prevodnik ne bo več dolgo deloval"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Optični foto prevodnik ne deluje več"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Pripravljen"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Ne sprejema poslov"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Obdelovanje"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperialni"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrični"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Vprašaj, kaj storiti"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ne naredi ničesar"
+
+#~ msgid "Open folder"
+#~ msgstr "Odpri mapo"
+
+#~ msgid "Other Media"
+#~ msgstr "Drugi nosilci"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Izbor programa za zvočne CD-je"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Izberite program za video DVD-je"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Izberite kateri program naj se zažene, ko je predvajalnik glasbe povezan"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Izberite program, ki naj teče, ko je povezan fotoaparat"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Izbor programa za programske CD-je"
+
+#~ msgid "audio DVD"
+#~ msgstr "zvočni DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "prazen Blu-Ray disk"
+
+#~ msgid "blank CD disc"
+#~ msgstr "prazen CD disk"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "prazen DVD disk"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "Prazen disk HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video disk"
+
+#~ msgid "e-book reader"
+#~ msgstr "Bralnik e-knjig"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video disk"
+
+#~ msgid "Picture CD"
+#~ msgstr "Slikovni CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Zaslon se izklopi"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekund"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuta"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuti"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minute"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minut"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minut"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 ura"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 minuta"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 minuti"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 minute"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Nikoli"
+
+#~ msgid "Select Location"
+#~ msgstr "Izbor mesta"
+
+#~ msgid "_OK"
+#~ msgstr "_V redu"
+
+#~ msgid "No applications found"
+#~ msgstr "Ni najdenih programov"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Ni izbranega omrežja za souporabo"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Omogočeno"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Onemogočeno"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Omogočeno"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Dejavno"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Izbor mape"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Omogoči souporabo predstavnih datotek"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Možnost souporabe datotek omogoča drugim uporabnikom  na trenutnem "
+#~ "omrežju dostop do Javne mape s protokolom: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Oddaljenim uporabnikom dovoli povezavo z ukazom Secure Shell, če je "
+#~ "oddaljena prijava omogočena:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Omogoči osebno souporabo datotek"
+
+#~ msgid "Device name copied"
+#~ msgstr "Naslov naprave je kopiran"
+
+#~ msgid "Device address copied"
+#~ msgstr "Naslov naprave je kopiran"
+
+#~ msgid "Username copied"
+#~ msgstr "Uporabniško ime je kopirano"
+
+#~ msgid "Password copied"
+#~ msgstr "Geslo je kopirano"
+
+#~ msgid "Custom"
+#~ msgstr "Po meri"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Preizkušanje %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100 %"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Prekinjena povezava"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "V povezovanju"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Povezano"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Napaka overitve"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Poteka overjanje"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Zmanjšana zmogljivost"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Povezano in overjeno"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Neznano"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Naprava je bila overjena ob:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Povezava je bila vzpostavljena ob:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Naprava je bila vpisana ob:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Overjanje naprave je spodletelo: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Pozabljanje naprave je spodletelo: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Napaka"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Overjeno"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Podsistem Thunderbolt (boltd) ni nameščen oziroma je neustrezno "
+#~ "nastavljen."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr ""
+#~ "Naprave je mogoče pripeti le z uporabo priklopa USB oziroma zaslonskega "
+#~ "priklopa."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Sistema Thunderbolt ni mogoče zaznati.\n"
+#~ "Podpora sistemu morda ni na voljo, sistem je v zaganjalniku BIOS "
+#~ "onemogočen, ali pa je nastavljen na nepodprto varnostno raven."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Podpora Thunderbolt je onemogočena med nastavitvami BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Varnostne ravni Thunderbolt ni mogoče določiti."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Napaka preklapljanja neposrednega načina: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "privzeta"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "srednja"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "velika"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "zelo velika"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "največja"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d točk"
+#~ msgstr[1] "%d točka"
+#~ msgstr[2] "%d točki"
+#~ msgstr[3] "%d točke"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kratko"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ zaslona"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ zaslona"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ zaslona"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Dolgo"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 ura"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 dan"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dni"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dni"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Ali naj se izbrišejo vsi predmeti iz smeti?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Vsi predmeti v smeteh bodo trajno izbrisani."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Izprazni _smeti"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Ali naj se izbrišejo vse začasne datoteke?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Vse začasne datoteke bodo trajno izbrisane."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Počisti začasne datoteke"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 dan"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 dni"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dni"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Trajno"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Vpis mora biti skladen s spletnim naslovom ponudnika prijave."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Dodajanje računa je spodletelo"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Vpis računa je spodletel"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Ni podprtega načina za overitev s to domeno"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Pridružitev v domeno je spodletela"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Prijavno ime ne deluje.\n"
+#~ "Poskusite vpisati drugo ime."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Prijavno geslo je napačno.\n"
+#~ "Poskusite vpisati drugo geslo."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Prijava v domeno je spodletela"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Domene ni mogoče najti. Morda je vpisana napačno."
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Brskanje med več slikami"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr ""
+#~ "pred izvajanjem tega opravila mora biti vzpostavljena povezava z napravo"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "naprava je že v uporabi v drugem opravilu"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "ni ustreznih dovoljenj za izvajanje tega dejanja"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "ni poslanih opravil za tiskanje"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Povezovanje z napravo med vpisovanjem je spodletelo."
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Povezovanje s čitalcem prstnih odtisov je spodletelo."
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr ""
+#~ "Povezovanje z ozadnjim programom čitalca prstnih odtisov je spodletelo."
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Prikaz prstnih odtisov je spodletel: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Brisanje prstnih odtisov je spodletelo: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Levi palec"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Levi sredinec"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Levi kazalec"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Levi prstanec"
+
+#~ msgid "Left little finger"
+#~ msgstr "Levi mezinec"
+
+#~ msgid "Right thumb"
+#~ msgstr "Desni palec"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Desni sredinec"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Desni kazalec"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Desni prstanec"
+
+#~ msgid "Right little finger"
+#~ msgstr "Desni mezinec"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Neznan prst"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Končano"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Naprava za prijavo s prstnim odtisom ni priklopljena"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Shramba naprave za branje prstnega odtisa je polna"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Odčitavanje novega prstnega odtisa je spodletelo."
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Začenjanje odčitavanja je spodletelo: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Odčitavanje novega prstnega odtisa je spodletelo."
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Zaustavljanje odčitavanja je spodletelo: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Ponavljajoče dvignite in položite prst na bralnik za odčitavanje prstnega "
+#~ "odtisa"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Ponovno odčitaj ta prst …"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Odčitaj nov prstni odtis"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Sproščanje naprave za branje prstnega odtisa %s je spodletelo: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Napaka branja naprave"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Povezovanje naprave za branje prstnega odtisa %s je spodletelo: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Pridobivanje naprav za prstni odtis je spodletelo: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Ta teden"
+
+#~ msgid "Last Week"
+#~ msgstr "Predhodni teden"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s – %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Seja je končana"
+
+#~ msgid "Session Started"
+#~ msgstr "Seja je začeta"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s – dejavnost računa"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Izberite drugo geslo."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Znova vnesite trenutno geslo."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Gesla ni mogoče spremeniti."
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Ni mogoče samodejno pridružiti tej vrsti domene"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Ni mogoče najti take domene ali takega področja"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Ni se mogoče prijaviti kot %s v domeno %s."
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Napačno geslo, poskusite znova."
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Z domeno %s povezava ni mogoča: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Napaka med brisanjem uporabnika"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Preklic oddaljeno vodenega uporabnika je spodletel"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Ni mogoče izbrisati lastnega računa."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s je še vedno prijavljen"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Izbris uporabnika, ki je trenutno prijavljen, lahko vpliva na delovanje "
+#~ "sistema."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Ali želite obdržati datoteke uporabnika %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Mogoče je ohraniti domačo mapo, vrstilno mapo pošte in začasne datoteke "
+#~ "tudi med brisanjem uporabniškega računa."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Izbriši datoteke"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Ohrani datoteke"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Ali ste prepričani, da želite preklicati oddaljeno voden račun uporabnika "
+#~ "%s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Izbriši"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Račun je onemogočen"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Nastavljeno bo ob naslednji prijavi"
+
+#~ msgctxt "Password mode"
 #~ msgid "None"
 #~ msgstr "Brez"
 
-#~ msgid "Expired credentials. Please log in again."
-#~ msgstr ""
-#~ "Poverilo je pretečeno. Za nadaljevanje se je treba znova prijaviti. "
+#~ msgid "Logged in"
+#~ msgstr "Trenutno dejavna prijava"
 
-#~ msgid "_Log In"
-#~ msgstr "_Prijava"
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Napaka med povezovanjem s storitvijo računov"
 
-#~ msgctxt "Power"
-#~ msgid "Bluetooth"
-#~ msgstr "Bluetooth"
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Prepričajte se, da je paket AccoutnService nameščen in omogočen."
 
-#~ msgid "Color management settings"
-#~ msgstr "Nastavitve upravljanja barv"
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Okno je treba za spreminjanje nastavitev najprej odkleniti"
 
-#~ msgid "British English"
-#~ msgstr "britansko angleško"
-
-#~ msgid "Spanish"
-#~ msgstr "špansko"
-
-#~ msgid "Chinese (simplified)"
-#~ msgstr "kitajsko poenostavljeno"
-
-#~ msgid "Select a region"
-#~ msgstr "Izbor območja"
-
-#~ msgid "Date and Time preferences panel"
-#~ msgstr "Pult možnosti nastavitev datuma in časa"
-
-#~ msgid "Set your mouse and touchpad preferences"
-#~ msgstr "Nastavite svoje možnosti miške in sledilne ploščice"
-
-#~ msgid "Mesh"
-#~ msgstr "Mreža"
-
-#~ msgid "Carrier/link changed"
-#~ msgstr "Signal/Povezava se je spremenila"
-
-#~ msgid "Manage online accounts"
-#~ msgstr "Upravljanje spletnih računov"
-
-#~ msgid "_Mark As Inactive After"
-#~ msgstr "_Označi kot nedejavno po"
-
-#~ msgid "Power management settings"
-#~ msgstr "Nastavitve upravljanja napajanja"
-
-#~ msgid "Manufacturers"
-#~ msgstr "Proizvajalci"
-
-#~ msgid "Drivers"
-#~ msgstr "Gonilniki"
-
-#~ msgid "Don't retain history"
-#~ msgstr "Ne ohranjaj zgodovine"
-
-#~ msgid "Change your region and language settings"
-#~ msgstr "Spremenite svoje področne in jezikovne nastavitve"
+#~ msgid "Delete the selected user account"
+#~ msgstr "Izbriši izbran uporabniški račun"
 
 #~ msgid ""
-#~ "The login screen, system accounts and new user accounts use the system-"
-#~ "wide Region and Language settings."
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
 #~ msgstr ""
-#~ "Prijavni zaslon, sistemski računi in novi uporabniški računi uporabljajo "
-#~ "sistemske nastavitve področij in jezika."
+#~ "Za izbris izbranega uporabniškega\n"
+#~ "računa, kliknite na ikono *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Odklenite za spreminjanje nastavitev in uporabnikov"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Novo geslo mora biti drugačno od starega."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Zamenjajte nekaj črk in številk."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Poskusite še malo spremeniti geslo."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Geslo brez uporabniškega imena bi bilo bolj varno."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Nikoli ne uporabite imena za geslo."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Poskusite se izogniti nekaterim besedam, ki so del geslu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Izogibajte se uporabi pogostih besed."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Izogibajte se zgolj zamenjavi razvrstitve obstoječih besed."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Dodajte več številk."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Dodajte več velikih črk."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Dodajte več malih črk."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Uporabite posebne znake, kot so na primer ločila."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Priporočljivo je uporabiti različne črke številke in posebne znake."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Poskusite se izogniti ponavljanju znakov."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Poskusite se izogniti ponavljanju znakov. Priporočljivo je uporabiti "
+#~ "različne črke številke in posebne znake."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Izognite se zaporedjem, kot sta 1234 in abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Geslo mora biti daljše. Poskusite dodati črke, številke in druge znake."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Priporočeno je uporabiti male in velike črke, vmes pa dodati tudi kakšno "
+#~ "številko."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "Dodajanje črk, številk in ločil poveča moč gesla."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Overitev je spodletela"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Novo geslo je prekratko"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Novo geslo je preveč enostavno"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Novo geslo je preveč podobno staremu"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Novo geslo je bilo nedavno že uporabljeno."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Novo geslo mora vsebovati številke ali posebne znake"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Novo geslo je enako staremu"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Vaše geslo je bilo spremenjeno od začetne overitve!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Novo geslo ne vsebuje dovolj različnih znakov"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Neznana napaka"
 
 #~ msgid ""
-#~ "The login screen, system accounts and new user accounts use the system-"
-#~ "wide Region and Language settings. You may change the system settings to "
-#~ "match yours."
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
 #~ msgstr ""
-#~ "Prijavni zaslon, sistemski računi in novi uporabniški računi uporabljajo "
-#~ "sistemske nastavitve področij in jezika. Te je mogoče kasneje prilagoditi "
-#~ "vsakemu računu posebej."
+#~ "Uporabniško ime je lahko sestavljeno iz malih črk angleške abecede, "
+#~ "številk in posebnih znakov » - _ «."
 
-#~ msgid "Copy Settings"
-#~ msgstr "Nastavitve kopiranja"
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Uporabniško ime ni na voljo! Izberite drugo ime."
 
-#~ msgid "Copy Settings…"
-#~ msgstr "Kopiraj nastavitve ..."
+#~ msgid "The username is too long."
+#~ msgstr "Uporabniško ime je predolgo."
 
-#~ msgid "Region and Language"
-#~ msgstr "Področje in jezik"
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Gumb %d"
 
-#~ msgid "Add Language"
-#~ msgstr "Dodaj jezik"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Določeno programi"
 
-#~ msgid "Select a region (change will be applied the next time you log in)"
-#~ msgstr "Izbor področja (sprememba bo uporabljena ob naslednji prijavi)"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Pošlji kode tipk"
 
-#~ msgid "Add Region"
-#~ msgstr "Dodaj področje"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Preklop zaslona"
 
-#~ msgid "Remove Region"
-#~ msgstr "Odstrani področje"
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Pokaži zaslonsko pomoč"
 
-#~ msgid "Currency"
-#~ msgstr "Valuta"
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Na prenosnik je priklopljena tablica"
 
-#~ msgid "Examples"
-#~ msgstr "Primeri"
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Na zunanji zaslon je priklopljena tablica"
 
-#~ msgid "Ctrl+Alt+Space"
-#~ msgstr "Ctrl+Alt+Preslednica"
+#~ msgid "External tablet device"
+#~ msgstr "Zunanja tablična naprava"
 
-#~ msgid "Shortcut Settings"
-#~ msgstr "Nastavitve tipkovnih bližnjic"
+#~ msgid "All Displays"
+#~ msgstr "Vsi zasloni"
 
-#~ msgid "Input source:"
-#~ msgstr "Vir vhoda:"
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Običajno pisalo, občutljivo na moč in vgrajeni drsnik"
 
-#~ msgid "Format:"
-#~ msgstr "Oblika:"
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Običajno pisalo, občutljivo na moč, kot in vrtljivi pritisk"
 
-#~ msgid "Your settings"
-#~ msgstr "Osebne nastavitve"
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Običajno pisalo, občutljivo na moč in kot pritiska"
 
-#~ msgid "System settings"
-#~ msgstr "Sistemske nastavitve"
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Običajno pisalo, občutljivo na moč pritiska"
 
-#~ msgid "Universal Access Preferences"
-#~ msgstr "možnosti splošnega dostopa"
+#~ msgid "New shortcut…"
+#~ msgstr "Nova bližnjica …"
 
-#~ msgid "_Hint"
-#~ msgstr "_Namig"
+#~ msgid "Operation Cancelled"
+#~ msgstr "Opravilo je preklicano"
 
-#~ msgid ""
-#~ "This hint may be displayed at the login screen.  It will be visible to "
-#~ "all users of this system.  Do <b>not</b> include the password here."
-#~ msgstr ""
-#~ "Namig se izpiše na prijavnem zaslonu. Viden bo vsem uporabnikom sistema, "
-#~ "zato <b>ni</b> varno vpisati gesla ali drugih zasebnih podatkov"
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Napakar:</b> dostop do spreminjanja nastavitev je onemogočen"
 
-#~ msgid "Fair"
-#~ msgstr "Zadovoljivo"
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Napaka:</b> Napaka mobilne naprave"
 
-#~ msgid "Set your Wacom tablet preferences"
-#~ msgstr "Nastavitve možnosti tablice Wacom"
+#~ msgid "Not Registered"
+#~ msgstr "Ni registrirano"
 
-#~ msgid "Out of range"
-#~ msgstr "Izven dosega"
+#~ msgid "Registered"
+#~ msgstr "Registrirano"
 
-#~ msgid "_Disconnect"
-#~ msgstr "_Prekini povezavo"
+#~ msgid "Roaming"
+#~ msgstr "Gostovanje"
 
-#~ msgid "_Connect"
-#~ msgstr "_Poveži"
+#~ msgid "Searching"
+#~ msgstr "Poteka iskanje …"
 
-#~ msgid "_Settings…"
-#~ msgstr "_Nastavitve ..."
+#~ msgid "Denied"
+#~ msgstr "Zavrnjeno"
 
-#~ msgid "Browse Files..."
-#~ msgstr "Brskanje datotek ..."
+#~ msgid "2G Only"
+#~ msgstr "Le G2"
 
-#~ msgid "Create virtual device"
-#~ msgstr "Ustvari navidezno napravo"
+#~ msgid "3G Only"
+#~ msgstr "Le G3"
 
-#~ msgid "Available Profiles for Displays"
-#~ msgstr "Razpoložljivi profili za  zaslone"
+#~ msgid "4G Only"
+#~ msgstr "Le G4"
 
-#~ msgid "Available Profiles for Scanners"
-#~ msgstr "Razpoložljivi profili za optične bralnike"
+#~ msgid "5G Only"
+#~ msgstr "Le 5G"
 
-#~ msgid "Available Profiles for Printers"
-#~ msgstr "Razpoložljivi profili za tiskalnike"
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (prednostno)"
 
-#~ msgid "Available Profiles for Cameras"
-#~ msgstr "Razpoložljivi profili za fotoaparate"
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (prednostno), 5G"
 
-#~ msgid "Available Profiles for Webcams"
-#~ msgstr "Razpoložljivi profili za spletne kamere"
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (prednostno), 4G, 5G"
 
-#~ msgid "%i year"
-#~ msgid_plural "%i years"
-#~ msgstr[0] "%i let"
-#~ msgstr[1] "%i leto"
-#~ msgstr[2] "%i leti"
-#~ msgstr[3] "%i leta"
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (prednostno), 3G, 4G, 5G"
 
-#~ msgid "%i month"
-#~ msgid_plural "%i months"
-#~ msgstr[0] "%i mesecev"
-#~ msgstr[1] "%i mesec"
-#~ msgstr[2] "%i meseca"
-#~ msgstr[3] "%i meseci"
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
 
-#~ msgid "%i week"
-#~ msgid_plural "%i weeks"
-#~ msgstr[0] "%i tednov"
-#~ msgstr[1] "%i teden"
-#~ msgstr[2] "%i tedna"
-#~ msgstr[3] "%i tedni"
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (prednostno)"
 
-#~ msgid "Less than 1 week"
-#~ msgstr "Manj kot en teden"
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (prednostno), 4G"
 
-#~ msgid "This device is not color managed."
-#~ msgstr "Naprava ni nastavljena za upravljanje barv."
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (prednostno), 3G, 4G"
 
-#~ msgid "This device is using manufacturing calibrated data."
-#~ msgstr "Naprava uporablja proizvodno umerjene podatke."
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
 
-#~ msgid ""
-#~ "This device does not have a profile suitable for whole-screen color "
-#~ "correction."
-#~ msgstr ""
-#~ "Naprava nima določenega ustreznega profila za uravnavanje barv celega "
-#~ "zaslona."
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (prednostno)"
 
-#~ msgid "Not specified"
-#~ msgstr "Ni določeno"
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (prednostno), 5G"
 
-#~ msgid "No devices supporting color management detected"
-#~ msgstr "Ni zaznanih naprav s podporo za upravljanje barv."
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (prednostno), 4G, 5G"
 
-#~ msgid "Add device"
-#~ msgstr "Dodaj napravo"
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
 
-#~ msgid "Add a virtual device"
-#~ msgstr "Dodaj navidezno napravo"
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (prednostno)"
 
-#~ msgid "English"
-#~ msgstr "angleško"
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (prednostno), 5G"
 
-#~ msgid "French"
-#~ msgstr "francosko"
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (prednostno), 4G, 5G"
 
-#~ msgid "Russian"
-#~ msgstr "rusko"
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
 
-#~ msgid "Arabic"
-#~ msgstr "arabsko"
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (prednostno)"
 
-#~ msgid "%d x %d"
-#~ msgstr "%d x %d"
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (prednostno), 5G"
 
-#~ msgid "VESA: %s"
-#~ msgstr "VESA: %s"
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (prednostno), 3G, 5G"
 
-#~ msgid "Unknown model"
-#~ msgstr "Neznan model"
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
 
-#~ msgid "The next login will attempt to use the standard experience."
-#~ msgstr "Ob naslednji prijavi bo uporabljena običajna izkušnja."
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (prednostno)"
 
-#~ msgid ""
-#~ "The next login will use the fallback mode intended for unsupported "
-#~ "graphics hardware."
-#~ msgstr ""
-#~ "Ob naslednji prijavi bo uporabljen zasilni način, ki je namenjen za "
-#~ "nepodprto grafično strojno opremo "
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (prednostno), 4G"
 
-#~ msgctxt "Experience"
-#~ msgid "Fallback"
-#~ msgstr "Povratno"
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
 
-#~ msgid "_Other Media..."
-#~ msgstr "_Drug nosilec ..."
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (prednostno)"
 
-#~ msgid "Experience"
-#~ msgstr "Izkušnja"
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (prednostno), 4G"
 
-#~ msgid "Forced _Fallback Mode"
-#~ msgstr "Vsiljen _povrnitveni način"
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
 
-#~ msgid "_Options..."
-#~ msgstr "_Možnosti ..."
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (prednostno)"
 
-#~ msgid "C_reate..."
-#~ msgstr "Ustva_ri ..."
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (prednostno), 3G"
 
-#~ msgid "_Settings..."
-#~ msgstr "_Nastavitve ..."
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
 
-#~ msgid "Caution low battery, %s remaining"
-#~ msgstr "Napetost UPS je kritično nizka - še %s"
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (prednostno)"
 
-#~ msgid "Using battery power - %s remaining"
-#~ msgstr "Napajanje iz baterije - še %s"
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (prednostno), 5G"
 
-#~ msgid "Using battery power"
-#~ msgstr "Napajanje iz baterije"
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
 
-#~ msgid "Charging - fully charged"
-#~ msgstr "Polnjenje - polna napolnjenost"
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (prednostno)"
 
-#~ msgid "Using UPS power - %s remaining"
-#~ msgstr "Uporaba napetosti varovala UPS - še %s"
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (prednostno), 5G"
 
-#~ msgid "Caution low UPS"
-#~ msgstr "Napetost UPS je kritično nizka"
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
 
-#~ msgid "Using UPS power"
-#~ msgstr "Uporaba napetosti varovala UPS"
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (prednostno)"
 
-#~ msgid "Your secondary battery is fully charged"
-#~ msgstr "Druga baterija je povsem napolnjena"
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (prednostno), 5G"
 
-#~ msgid "Your secondary battery is empty"
-#~ msgstr "Druga baterija je prazna"
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
 
-#~ msgctxt "Battery power"
-#~ msgid "Charging - fully charged"
-#~ msgstr "Polnjenje - polna napolnjenost"
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Neznano"
 
-#~ msgid ""
-#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
-#~ "used"
-#~ msgstr "Opomba: <a href=\"screen\">svetlost zaslona</a> vpliva na porabo"
+#~ msgid "Unlock SIM card"
+#~ msgstr "Odkleni kartico SIM"
 
-#~ msgid "Don't suspend"
-#~ msgstr "Ne pošlji v pripravljenost"
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Vpisati je treba kodo PIN za kartico SIM %d"
 
-#~ msgctxt "printer state"
-#~ msgid "Paused"
-#~ msgstr "V premoru"
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Vpišite kodo PIN za odklepanje kartice SIM"
 
-#~ msgid "_Show"
-#~ msgstr "_Pokaži"
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Vpisati je treba kodo PUK za kartico SIM %d"
 
-#~ msgid "Copy Settings..."
-#~ msgstr "Nastavitve kopiranja ..."
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Vpišite kodo PUK za odklepanje kartice SIM"
 
-#~ msgid ""
-#~ "Select a display language (change will be applied next time you log in)"
-#~ msgstr ""
-#~ "Izbor jezika namizja (sprememba bo uporabljena ob naslednji prijavi)"
+#~ msgid "Wrong password entered."
+#~ msgstr "Vpisano je napačno geslo"
 
-#~ msgid "Install languages..."
-#~ msgstr "Namesti jezike ..."
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Koda PUK mora biti 8-znakovna vrednost"
 
-#~ msgid "Brightness & Lock"
-#~ msgstr "Zaklepanje in svetlost"
+#~ msgid "Enter New PIN"
+#~ msgstr "Vpiši novo kodo PIN"
 
-#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
-#~ msgstr "Svetlost;Zakleni;Zatemnjevanje;Črn;Zaslon;"
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Koda PIN mora biti dolžine 4–8 znakov"
 
-#~ msgid "_Dim screen to save power"
-#~ msgstr "_Zatemni zaslon za zmanjšanje porabe"
+#~ msgid "Unlocking…"
+#~ msgstr "Poteka odklepanje …"
 
-#~ msgid "_Turn screen off when inactive for:"
-#~ msgstr "Ugasni zaslon ob nedejavnosti:"
+#~ msgid "Phone failure"
+#~ msgstr "Delovanje telefona je spodletelo"
 
-#~ msgid "Don't lock when at home"
-#~ msgstr "Ne zakleni, ko sem doma"
+#~ msgid "No connection to phone"
+#~ msgstr "NI vzpostavljene povezave s telefonom"
 
-#~ msgid "Locations..."
-#~ msgstr "Mesta ..."
+#~ msgid "Operation not allowed"
+#~ msgstr "Opravilo ni dovoljeno!"
 
-#~ msgid "Enable debugging code"
-#~ msgstr "Omogoči razhroščevanje kode"
+#~ msgid "Operation not supported"
+#~ msgstr "Opravilo ni podprto"
 
-#~ msgid " — GNOME Volume Control Applet"
-#~ msgstr " — GNOME aplet nadzora glasnosti"
+#~ msgid "SIM not inserted"
+#~ msgstr "Kartica SIM ni vstavljena"
 
-#~ msgid "Show desktop volume control"
-#~ msgstr "Pokaži namizni nadzornik zvoka"
+#~ msgid "SIM PIN required"
+#~ msgstr "Zahtevana je koda PIN za kartico SIM"
 
-#~ msgid "Sound Output Volume"
-#~ msgstr "Izhodna glasnost zvoka"
+#~ msgid "SIM PUK required"
+#~ msgstr "Zahtevana je koda PUK za kartico SIM"
 
-#~ msgid "_Sound Preferences"
-#~ msgstr "_Nastavitve zvoka"
+#~ msgid "SIM failure"
+#~ msgstr "Kartica SIM je nedostopna"
 
-#~ msgid "Muted"
-#~ msgstr "Utišaj"
+#~ msgid "SIM busy"
+#~ msgstr "Kartica SIM je zasedena"
 
-#~ msgid "Options..."
-#~ msgstr "Možnosti ..."
+#~ msgid "Incorrect password"
+#~ msgstr "Neveljavno geslo"
 
-#~ msgid "User Accounts"
-#~ msgstr "Uporabniški računi"
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Zahtevana je koda PIN2 za kartico SIM"
 
-#~ msgid "Browse for more pictures..."
-#~ msgstr "Brskanje med več slikami ..."
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Zahtevana je koda PIN2 za kartico SIM"
 
-#~ msgid "No user with the name '%s' exists."
-#~ msgstr "Uporabnik z imenom '%s' ne obstaja."
+#~ msgid "Not found"
+#~ msgstr "Predmeta ni mogoče najti"
 
-#~ msgid "This user does not exist."
-#~ msgstr "Uporabnik ne obstaja."
+#~ msgid "No network service"
+#~ msgstr "Ni dostopnih omrežnih storitev"
 
-#~ msgid "Map Buttons..."
-#~ msgstr "Prilagajanje gumbov"
+#~ msgid "Network timeout"
+#~ msgstr "Zakasnitev omrežja"
 
-#~ msgid "Calibrate..."
-#~ msgstr "Umeri ..."
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Uporaba storitve GPRS ni dovoljena"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Gostovanje na tem območju ni dovoljeno"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Nedoločena napaka GPRS"
+
+#~ msgid "No Error"
+#~ msgstr "Brez napake"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Dejanje je preklicano"
+
+#~ msgid "Access denied"
+#~ msgstr "Dostop je zavrnjen"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Neznana napaka"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Pokaži različico"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Omogoči podrobni način"
+
+#~ msgid "Search for the string"
+#~ msgstr "Poišči niz"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Izpiši možna imena pultov in končaj"
+
+#~ msgid "Panel to display"
+#~ msgstr "Pult za prikaz"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PULT][ARGUMENT …]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Razpoložljivi pulti:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sistemski zvoki"

--- a/po/sl.po~
+++ b/po/sl.po~
@@ -1,0 +1,9639 @@
+# Slovenian translations for gnome-control-center.
+# Copyright (C) 2009 gnome-control-center COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Andraž Tori <andraz.tori1@guest.arnes.si>, 2004.
+# Matjaž Horvat <m@owca.info>, 2005–2006.
+# Matic Žgur <mr.zgur@gmail.com>, 2006–2007.
+# Matej Urbančič <mateju@src.gnome.org>, + 2007–2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-19 21:25+0000\n"
+"PO-Revision-Date: 2022-09-20 22:11+0200\n"
+"Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
+"Language-Team: Slovenian GNOME Translation Team <gnome-si@googlegroups.com>\n"
+"Language: sl_SI\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n"
+"%100==4 ? 3 : 0);\n"
+"X-Poedit-SourceCharset: utf-8\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Sistemsko vodilo"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Poln dostop"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Vodilo seje"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Naprave"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Poln dostop do mape /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Omrežje"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Ima dostop do omrežja"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Domača mapa"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Le za branje"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Datotečni sistem"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Nastavitve"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Dovoljeno spreminjati nastavitve"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"Program %s ima že vgrajena nekatera dovoljenja in teh ni mogoče spreminjati. "
+"V kolikor vas dovoljenja skrbijo, razmislite o odstranitvi oziroma zamenjavi "
+"programa."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "Datoteka in vrste povezav %u, ki so odprte s programom."
+msgstr[1] "Datoteka in vrsta povezave %u, ki je odprta s programom."
+msgstr[2] "Datoteka in vrste povezav %u, ki so odprte s programom."
+msgstr[3] "Datoteka in vrste povezav %u, ki so odprte s programom."
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "Program <b>%s</b> omogoča odpiranje navedenih datotek in povezav."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "Uporabljenega je %s prostora na disku."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Programi"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Ni najdenih programov"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Namesti …"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Odpri"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Pogled podrobnosti"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Iskanje ~"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Prejmi sistemska iskanja in pošlji zadetke."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Onemogočeno"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Obvestila"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Prikaz sistemskih obvestil."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Zaženi v ozadju"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Dovoli dejavnost, kot je program zaprt."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Zajemanje zaslona"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Zajemanje zaslonskih slik v vsakem trenutku."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Spremeni sliko ozadja"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Spremeni sliko ozadja namizja."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Zvoki"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Omogoči predvajanje zvokov."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Onemogoči tipkovne bližnjice"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Onemogoči običajne sistemske tipkovne bližnjice."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Zajemanje slik s kamero."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Omogoči zajemanje zvoka z mikrofonom."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Storitve določanja položaja"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Omogoči dostop do geolokacijskih podatkov naprave."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Vgrajena dovoljenja"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Sistemska dovoljenja, ki jih zahteva program"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Datotečne vezi in povezave"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Shramba"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Ni najdenih zadetkov"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Poskusite z drugačnim iskalnim nizom"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Datotečne vezi in povezave"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Vrste datotek"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Vrste povezav"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "↓Ponastavi"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Podatki o velikosti prostora, ki ga program uporablja s podatki in "
+"predpomnilnikom."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Program"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Podatki"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Predpomnilnik"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Skupaj</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Počisti predpomnilnik …"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Nadzor nad dovoljenji in nastavitvami številnih programov"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "program;flatpak;dovoljenja;nastavitve;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Izbor slike"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Prekliči"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Odpri"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "različne velikosti"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Ni ozadja namizja"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Trenutno ozadje"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Slog"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Privzeto"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Temno"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Ozadje"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Dodaj sliko …"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Videz"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Spremeni sliko ozadja aku barve vmesnika"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"ozadje;slika ozadja;zaslon;Namizje;Stil;Slog;Temna;Svetla;tema;videz;oblika;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Omogoči"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Ni navzočih naprav Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Vstavite ključek BT za omogočanje vmesnika Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Vmesnik Bluetooth je izklopljen!"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Omogoča povezovanje naprav za izmenjavo datotek."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Omogočen je letalski način"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Ko je omogočen letalski način, je naprava Bluetooth izklopljena."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Onemogoči letalski način"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Omogočen je strojni letalski način"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Za uporabo vmesnika Bluetooth je treba izklopiti letalski način."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Vklopite in izklopite Bluetooth in povežite naprave"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "souporaba;izmenjava;obex;bluetooth;povezovanje;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera je izklopljena"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Ni določenih programov za zajem slik in videoposnetkov."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Uporaba kamere omogoča programom zajem slike in videa. Onemogočena naprava "
+"lahko povzroči napačno delovanje nekaterih programov.\n"
+"\n"
+"Dovoli navedenim programom uporabo kamere."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Ni programov, ki bi zahtevali dostop do kamere"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Zaščita slik in fotografij"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;kamera;slike;video;spletna "
+"kamera;zasebnost;posnetek;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Postavite napravo za umerjanje na označen kvadrat in pritisnite tipko za "
+"začetek."
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Premaknite napravo za umerjanje na mesto za umerjanje in pritisnite tipko za "
+"nadaljevanje."
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Premaknite napravo za umerjanje na površino in pritisnite tipko za "
+"nadaljevanje."
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Zapri pokrov prenosnika"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Prišlo je do notranje napake, ki ne ni mogoče razrešiti."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Orodja, zahtevana za umerjanje, niso nameščena."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Profila ni mogoče ustvariti."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Ciljne bele točke ni bilo mogoče pridobiti."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Dokončano!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Umerjanje je spodletelo!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Napravo za umerjanje je dovoljeno odstraniti."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ne motite umeritvene naprave med merjenjem"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Umerjanje zaslona"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Zaženi"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "Na_daljuj"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Končano"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Zaslon prenosnika"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Vgrajena spletna kamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Zaslon %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Optični bralnik %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Kamera %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Tiskalnik %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Spletna kamera %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Omogoči upravljanje barv za %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Pokaži barvne profile za %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Ni umerjeno"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Privzeto: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Barvni prostor: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Preizkusni profil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Izbor datoteke profila ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Uvozi"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Podprti profili ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Vse datoteke"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Zaslon"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Shrani profil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Shrani"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Ustvari barvni profil za izbrane naprave"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Merilne naprave ni mogoče zaznati. Preverite ali je priklopljena in povezana "
+"na ustrezen način."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Merilna naprava ne podpira profiliranja tiskalnika."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Vrsta naprave trenutno ni podprta."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Umerjanje zaslona"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kakovost umerjanja"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Umerjanje bo proizvedlo profil, ki ga lahko uporabite za upravljanje barve "
+"zaslona. Dlje časa kot porabite za umerjanje, boljša bo kakovost barvnega "
+"profila."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Med umerjanjem računalnika ne boste mogli uporabljati."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kakovost"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Predviden čas"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Naprava za umerjanje"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Izberite napravo tipala, ki jo želite uporabiti za umerjanje."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Vrsta zaslona"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Izberite vrsto povezanega zaslona."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Bela točka profila"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Izberite belo točko cilja zaslona. Večino zaslonov je treba umeriti na "
+"osvetlitev D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Svetlost zaslona"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Nastavite zaslon na svetlost, ki jo običajno uporabljate. Upravljanje barv "
+"bo najbolj natančno za to raven svetlosti."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Namesto tega lahko uporabite raven svetlosti, ki se uporablja z enim od "
+"drugih profilov za to napravo."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Ime profila"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Barvne profile je mogoče uporabiti na različnih napravah, ustvariti pa je "
+"mogoče tudi profile za različne svetlobne razmere."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Ime profila:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Povzetek"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil je uspešno ustvarjen"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopiraj profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Zahteva dostop do zapisljivega nosilca"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Morda bodo navodila o tem, kako uporabiti profil na sistemih <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> in <a href=\"windows"
+"\">Microsoft Windows</a> uporabna."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Dodaj profil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Zaznane so bile težave. Profil morda ne bo deloval pravilno. <a href="
+"\"\">Pokaži podrobnosti.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Uvozi datoteko …"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Dodaj"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Vsaka naprava zahteva posodobljen barvni profil za ustrezno barvno "
+"upravljanje."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Več podrobnosti"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Več podrobnosti o upravljanju barv"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Nastavi za vse uporabnike"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Nastavi profil za vse uporabnike tega računalnika"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Omogoči"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Dodaj profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Umeri …"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Umeri napravo"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Odstrani profil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Pogled podrobnosti"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Ni mogoče zaznati naprav za katere je mogoče upravljati barvo"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plazma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (osvetlitev ozadja CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (osvetlitev ozadja RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (bela osvetlitev ozadja LED)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Zaslon LCD s širokim barvnim obsegom (osvetlitev ozadja CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Zaslon LCD s širokim barvnim obsegom (osvetlitev ozadja RGB LED)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Visoka"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minut"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Srednja"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minut"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Nizka"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minut"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Lastno zaslonu"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (tisk in založništvo)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografija in grafika)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standardni barvni prostor"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Preizkusni profil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Samodejno"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Nizka kakovost"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Srednja kakovost"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Visoka kakovost"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Privzeta barva RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Privzeta barva CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Privzeta sivina"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Tovarniški umeritveni podatki, ki jih zagotavlja proizvajalec"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Celozaslonsko popravilo zaslona s tem profilom ni mogoče."
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Ta profil morda ni več natančen."
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Barva"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Umerite barvo svojih naprav kot so zasloni, fotoaparati ali tiskalniki"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Barva;ICC;Profil;Umerjanje;Tiskalnik;Zaslon;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Drugo …"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Izbor jezika"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Izberi"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Ni najdenih jezikov"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Več …"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Odklenite za spreminjanje nastavitev"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+"Nekatere nastavitve je treba najprej odkleniti, preden jih je mogoče "
+"spreminjati."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Odkleni …"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Povečanje ure"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Povečanje minute"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Čas"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Zmanjšanje ure"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Zmanjšanje minute"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Danes"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Včeraj"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d ur"
+msgstr[1] "%d ura"
+msgstr[2] "%d uri"
+msgstr[3] "%d ure"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minut"
+msgstr[1] "%d minuta"
+msgstr[2] "%d minuti"
+msgstr[3] "%d minute"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekund"
+msgstr[1] "%d sekunda"
+msgstr[2] "%d sekundi"
+msgstr[3] "%d sekunde"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekund"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Vroča točka"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-urni"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "12-urni"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Datum in čas"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Leto"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mesec"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "januar"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "februar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "marec"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "april"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "maj"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "junij"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "julij"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "avgust"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "september"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "november"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "december"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dan"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Časovni pas"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Iskanje mesta"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Samodejna _datum in čas"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Zahteva dostop do omrežja"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Datum in _čas"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Samodejni izbor _časovnega pasu"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Zahteva dostop do omrežja in omogočene geolokacijske storitve"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Omogočeno"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "_Časovni pas"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Oblika _izpisa časa"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Spreminjanje sistemskega časa, datuma in časovnega območja"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Ura;Časovni pas;Mesto;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Spremenite sistemski čas in datum"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Za spreminjanje nastavitev časa in datuma so zahtevana skrbniška dovoljenja."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Splet"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "Elektronska _pošta"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Koledar"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Glasba"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotografije"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Privzeti programi"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Nastavitev privzetih programov"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"privzeto;program;prednostno;priljubljeno;media;predstavnost;sistem;"
+"podrobnosti;info;informacije;različica;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Pošiljanje poročil o tehničnih napakah omogoča izboljšave distribucije %s. "
+"Poročila so poslana brezimno in brez kakršnihkoli osebnih podatkov. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Prijavljanje napak"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Samodejno prijavljanje napak"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostika napak"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Pošiljajte poročila o težavah"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostika;spori;napake;sesutje;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Omogočeno"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Onemogočeno"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Ali naj se uveljavijo spremembe?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Sprememb ni mogoče uveljaviti"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "To je lahko zaradi strojnih omejitev."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Uveljavi"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Nazaj"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Nastavitve zaslona so onemogočene"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Več zaslonov"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Združi"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Zrcali"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Vključuje vrhnjo vrstico in pojavno okno dejavnosti"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Prvi zaslon"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Nočna osvetlitev"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Ležeče"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Pokončno desno"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Pokončno levo"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Ležeče (obrnjeno)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Usmerjenost"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Ločljivost"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Hitrost osveževanja"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Prilagodi za televizijski zaslon"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Prilagodi velikost"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nočna osvetlitev ni na voljo"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"To je lahko posledica uporabljenega grafičnega gonilnika ali namizja, ki se "
+"uporablja na daljavo."
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Začasno onemogoči do jutri"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Filter ponovnega zagona"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Nočna osvetlitev se kaže v toplejših barvah. S tem preprečujemo naprezanje "
+"oči in zaspanost."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Urnik"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "od mraka do zore"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Ročno načrtovanje"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Čas"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Od"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Ure"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minute"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Za"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Temperatura barve"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Zasloni"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Izbor načina uporabe povezanih zaslonov in projektorjev"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"pult;panel;projektor;xrandr;zaslon;ločljivost;osveževanje;monitor;noč;"
+"svetloba;svetlost;modra;rdeči zamik;zora;mrak;barve;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Varen zagon je omogočen"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Varen zagon preprečuje nalaganje zlonamerne programske opreme ob zagonu "
+"naprave. Trenutno je vklopljena in deluje pravilno."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Zaznane so težave v delovanju varnega zagons"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Varen zagon preprečuje nalaganje zlonamerne programske opreme ob zagonu "
+"naprave. Trenutno je vklopljen, a ne deluje zaradi neveljavnega ključa."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Težave z varnim zagonom je mogoče pogosto odpraviti s prilagajanjem "
+"nastavitev strojne programske opreme UEFI (BIOS) računalnika, proizvajalec "
+"strojne opreme pa lahko zagotovi informacije o tem, kako to storiti."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Za pomoč stopite v stik s ponudnikom strojne programske opreme ali podporno "
+"službo."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Varni zagon je izklopljen"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Varen zagon preprečuje nalaganje zlonamerne programske opreme ob zagonu "
+"naprave. Trenutno je možnost izklopljena."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Varen zagon lahko omogočite v nastavitvah vdelane programske opreme UEFI "
+"(BIOS) računalnika. Za pomoč se obrnite na proizvajalca strojne opreme ali "
+"ponudnika skrbniške podpore."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Varen zagon preprečuje nalaganje zlonamerne programske opreme ob zagonu "
+"naprave.\n"
+"\n"
+"Za več podrobnosti se obrnite na proizvajalca strojne opreme ali podporo."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Uspešno končano"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Spodletelo"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Naprava podpira raven varnosti HSI %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Varnostna raven 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Naprava nima ustrezne zaščite pred strojnimi varnostnimi težavami. Vzrok so "
+"lahko nastavitve strojne ali programske opreme. Priporočljivo se je obrniti "
+"na podporo."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Varnostna raven 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Naprava ima le najmanjšo zaščito pred strojnimi varnostnimi težavamiNajnižja "
+"raven zagotavlja le zaščito pred preprostimi varnostnimi grožnjami."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Varnostna raven 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Naprava ima osnovno zaščito pred strojnimi varnostnimi težavami. Zagotavlja "
+"zaščito pred običajnimi varnostnimi grožnjami.\\"
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Varnostna raven 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Ta naprava ima razširjeno zaščito pred težavami s strojno varnostjo. To je "
+"najvišja varnostna raven naprave in zagotavlja zaščito pred naprednimi "
+"varnostnimi grožnjami."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Varnostna raven"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Za to napravo ravni varnosti niso na voljo"
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Za pomoč pri varnostnih posodobitvah stopite v stik s ponudnikom strojne."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"To težavo lahko odpravite v nastavitvah strojne programske opreme UEFI "
+"naprave ali s strani podpornega tehnika."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"To težavo lahko odpravite v nastavitvah strojne programske opreme naprave "
+"UEFI."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "To težavo lahko reši podporni tehnik."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Raven 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Raven 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Raven 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Zaščiteno pred zlonamerno programsko opremo, ko se naprava zažene."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Zaznane so težave v delovanju varnega zagons"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Osnovna zaščita, ko je naprava zagnana."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Varni zagon je izklopljen"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Ni zaščite, ko je naprava zagnana."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"To težavo bi lahko povzročila sprememba nastavitev strojne programske opreme "
+"UEFI, sprememba prilagoditve operacijskega sistema ali zlonamerna programska "
+"oprema v tem sistemu."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"To težavo bi lahko povzročila sprememba nastavitev strojne programske opreme "
+"UEFI ali zlonamerne programske opreme v tem sistemu."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"To težavo bi lahko povzročila sprememba prilagoditve operacijskega sistema "
+"ali zlonamerna programska oprema v tem sistemu."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Izpostavljeno resnim varnostnim tveganjem."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Omejena zaščita pred preprostimi varnostnimi grožnjami."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Zaščiten pred splošnimi varnostnimi grožnjami."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Zaščiteno pred široko paleto varnostnih groženj."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Celovita zaščita"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Ni dogodkov"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Strojna programska zaščita pisanja"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Zaklep strojne programske zaščite pisanja"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Območje strojne programske opreme BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Opisnik strojne programske opreme BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Zaščita pred zagonom DMA"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Preverjen zagon Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Zaščiten Intel BootGuard ACM"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Pravilnik o napakah za Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Varovalka Intel Boot Guard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Omogočena podpora Intel CET"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Podpora Intel CET je dejavna"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Šifriran RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Zaščita IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Zaklep jedra Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Overjanje jedra Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Izmenjevalni razdelek Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Premakni v pripravljenost s pomnilnikom RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Premakni v stanje nedejavnosti seje"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Ključ okolja UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Varni zagon UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Prilagoditev platforme TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Obnova TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Proizvajalski način upravljalskega okolja Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Prepis upravljalskega okolja Intel"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Različica upravljalskega okolja Intel"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Posodobitve strojne programske opreme"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Atest strojne programske opreme"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Preverjanje posodobitve strojne programske opreme"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Razhroščevanje okolja"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Varnostni pregledi procesorja"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Zaščita pred povratom AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Zaščita za ponovno predvajanje strojne programske opreme AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Strojna programska zaščita pisanja AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Okolje Fused"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Veljavno"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Ni veljavno"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Ni onemogočeno"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Zaklenjeno"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Ni zaklenjeno"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Šifrirano"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Ni šifrirano"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Okvarjeno"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Neokvarjeno"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Najdeno"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Ni najdeno"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Podprto"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Nepodprto"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Varnost naprave"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Varnostno stanje vdelane programske opreme gostitelja"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"zaslon;zaklep;diagnostika;crash;sesutje;zasebnost;hrošči;nedavno;začasno;tmp;"
+"index;ime;network;omrežje;istovetnost;identiteta;podatki;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Neznano"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bitni sistem"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bitni sistem"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Neznano"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Ni na voljo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Ime naprave"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Strojni model"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Pomnilnik"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Zmogljivost diska"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Poteka preračunavanje …"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Naziv OS"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ID Izgradnje sistema"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Vrsta OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Različica GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Poteka nalaganje …"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Sistem izrisovanja oken"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Ustvarjanje navideznih naprav"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Posodobitve programske opreme"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Preimenuj napravo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Ime naprave se uporablja za določitev naprave, kadar je ta prikazana v "
+"omrežju oziroma ob povezovanju naprav Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Ime naprave"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Preimenuj"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "O programu"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Pregled podrobnosti sistema"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"naprava;sistem;podrobnosti;pomnilnik;procesor;različica;privzeto;program;"
+"povrnjeno:prednostno;cd;dvd;usb;zvok;slika;video;disk;odstrani;predstavnost;"
+"samodejni zagon;nastavitve;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Zvok in nosilci"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Utišanje / Priklop zvoka"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Zmanjšaj glasnost"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Povečaj glasnost"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Utišanje / Priklop mikrofona"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Zagon predvajalnika predstavnih datotek"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Predvajanje (ali predvajanje/premor)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Premor predvajanja"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Zaustavi predvajanje"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Predhodna skladba"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Naslednja skladba"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Izvrzi"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Tipkanje"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Preklopi na naslednji vhodni vir"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Preklopi na predhodni vhodni vir"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Zaganjalniki"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Zagon brskalnika pomoči"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Zagon računala"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Zagon odjemalca e-pošte"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Zagon spletnega brskalnika"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Domača mapa"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Iskanje"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistem"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Odjava"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Zakleni zaslon"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Dostopnost"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Omogoči ali onemogoči približanje"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Približaj"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Oddalji"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Omogoči ali onemogoči zaslonski bralnik"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Omogoči ali onemogoči zaslonsko tipkovnico"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Povečaj velikost pisave"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Zmanjšaj velikost pisave"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Omogoči ali onemogoči visok kontrast slike"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Ni najdenih vhodnih virov"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Drugo"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Dodaj vhodni vir"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Vhodni načini na prijavnem oknu ne delujejo"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Vhodni vir ni izbran"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Možnosti"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Premakni navzgor"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Premakni navzdol"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Možnosti"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Pokaži razporeditev tipkovnice"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Odstrani"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Bližnjica po meri"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Drugotna tipka"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Tipka za izmenjavo omogoča uporabo dodatnih znakov. Ti so pogosto natisnjeni "
+"na tipkovnici kot tretja možnost."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Leva izmenjalka (Alt)"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Desna izmenjalka (Alt)"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Leva tipka Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Desna tipka Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Tipka Meni"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Desna krmilka (Ctrl)"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Sestavljalna tipka"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Sestavljalna tipka omogoča vnos velikega števila različnih znakov. Za "
+"uporabo najprej pritisnite sestavljalno tipko, nato pa zaporedje drugih "
+"znakov. Na primer; pritisnite sestavljalko, potem <b>C</b> in nato <b>o</b>. "
+"Izpisal se bo znak <b>©</b>. Z zaporedjem sestavljalka, <b>a</b> in nato "
+"<b>'</b> pa ustvari znak <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Zaklep črk"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Zaklep drsnika"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Posnemi zaslon"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Vhodni vir je mogoče preklopiti z uporabo tipkovne bližnjice %s.\n"
+"Nastavitve je mogoče spremeniti med nastavitvami bližnjic tipkovnice."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Vhodni viri – tipkovnica"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Izbor razporeditve tipkovnice oziroma drugega vhodnega vira."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Preklapljanje vhodnega vira"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Uporabi _enak vir v vseh oknih"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Preklopi vhodni vir za vsako okno _posebej"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Vnos posebnih znakov"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Načini vpisovanja simbolov in različic črk z uporabo tipkovnice."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Tipkovne bližnjice"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Pregled in prilagoditev bližnjic"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d spremenjenih"
+msgstr[1] "%d spremenjena"
+msgstr[2] "%d spremenjeni"
+msgstr[3] "%d spremenjene"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Ali želite ponastaviti vse tipkovne bližnjice?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Ponastavljanje tipkovnih bližnjic lahko vpliva na tiste po meri. Dejanja ni "
+"mogoče povrniti."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Prekliči"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Ponastavi vse"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Počisti vse …"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Ponastavi vse tipkovne bližnjice na privzete vrednosti"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Odsek"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Tipkovne bližnjice"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Dodaj tipkovno bližnjico"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Dodaj bližnjice po meri"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Nastavi tipkovne bližnjice po meri za zaganjanje programov, izvajanje "
+"skriptov in drugih opravil."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Dodaj tipkovno bližnjico"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Ni določene tipkovne bližnjice"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s je že uporabljen za %s. Če ga zamenjate, bo %s onemogočen."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Vpišite novo tipkovno bližnjico"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Nastavi bližnjico po meri"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Nastavi tipkovno bližnjico"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Vpišite novo tipkovno bližnjico za zamenjavo %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Dodaj bližnjico po meri"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Odstrani"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Zamenjaj"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Nastavi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Pritisnite tipko Esc za preklic ali pa povratno tipko za ponastavitev "
+"tipkovne bližnjice."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Ime"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Ukaz"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Bližnjica"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Nastavi tipkovno bližnjico …"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Brez"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Ponastavi tipkovno bližnjico na privzeto vrednost"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tipkovnica"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Prilagajanje tipkovnih bližnjic, nastavite možnosti tipkanja, razporeditve "
+"in vhodni viri"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"tipkovna bližnjica;delovna površina;okno;prilagoditev;velikost;kontrast;"
+"približanje;vir;zaklep;glasnost;jakost;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Storitve določanja trenutnega mesta so onemogočene"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Ni programov, ki bi zahtevali dostop do geolokacijskih podrobnosti."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Storitve določanja trenutnega mesta omogočajo programom podatke za uporabo. "
+"Povezava v omrežje Wi-Fi in mobilna omrežja poveča natančnost določanja.\n"
+"\n"
+"Program uporablja storitve določanja trenutnega mesta skladno s <a "
+"href='https://location.services.mozilla.com/privacy'>pravili zasebnosti</a>\n"
+"\n"
+"Navedenim programom bodo podatki na voljo."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Ni programov, ki bi zahtevali dostop do geolokacijskih podatkov"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Zaščitite podrobnosti o trenutnem mestu"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;lokacija;mesto;zasebnost;osebno;satelit;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofon je izklopljen"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Ni najdenih programov za zajem zvoka."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Uporaba mikrofona omogoča programom zajem zvoka. Onemogočena naprava lahko "
+"povzroči napačno delovanje nekaterih programov.\n"
+"\n"
+"Navedenim programom dovoli dostop do mikrofona."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Ni programov, ki bi zahtevali dostop do mikrofona"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Zaščita pogovorov"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofon;snemanje;aplikacija;zasebnost;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Preizkus uporabljenih _nastavitev"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Splošno"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Osnovni gumb"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Nastavi vrstni red gumbov na miški in sledilnih ploščicah."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Leva"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Desna"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Miška"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Hitrost kazalke miške"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Naravno drsenje"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Drsenje premika vsebino in ne pogleda."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Sledilna ploščica"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Hitrost kazalke sledilne ploščice"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Udarjanje za klik"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Udarjanje za klik"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Dvo-_prstno drsenje"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Robni drsnik"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Poskusite klikniti, dvojno klikniti in drseti"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Pet klikov za GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dvojni klik, osnovni gumb"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Enojni klik, osnovni gumb"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dvojni klik, srednji gumb"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Enojni klik, srednji gumb"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dvojni klik, drugi gumb"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Enojni klik, drugi gumb"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Miška in Sledilna ploščica"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Spremenite občutljivost svoje miške ali drsne ploščice in izberite desno ali "
+"levo ročnost"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Sledilna ploščica;Kazalnik;Klik;Udarjanje;Dvojni;Gumb;Sledilna kroglica;"
+"Drsnik;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Vroči kot"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Dotik levega zgornjega kota odpre pregled dejavnosti."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Dejavni robovi zaslona"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Dotik okna z zgornjim, levim ali desnim robom sproži dejanje prilagajanja "
+"velikosti okna."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Delovne površine"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dinamične delovne površine"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Samodejno odstrani prazne delovne površine"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Določeno število delovnih površin"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Število števila prikazanih delovnih površin"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Število delovnih površin"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Podpora več monitorjem"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Delovne površine le na _osnovnem zaslonu"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "_Delovne površine naj bodo na vseh zaslonih"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Preklapljanje programov"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Vključi programe _vseh delovnih površin"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Vključi le programe s _trenutne delovne površine"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Večopravilnost"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Upravljanje nastavitev za učinkovito delo in večopravilnost"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Namizje;Večopravilnost;"
+"Učinkovitost;Prilagajanje;Delo;delovne površine;vroči kot;kot;namizja;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ojoj, prišlo je do napake. Stopite v stik s ponudnikom programske opreme."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Program NetworkManager mora biti zagnan."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Druge naprave"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Dodaj povezavo"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Ni nastavljeno"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Ne-varno omrežje (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Varno omrežje (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Varno omrežje (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Varno omrežje (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Varno omrežje"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Povezano"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Možnosti …"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Ob priklopu vroče točke se onemogoči povezava z omrežjem %s, zato dostop po "
+"Wi-Fi ne bo več mogoč."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Vsebovati mora najmanj 8 znakov"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Vsebovati mora največ %d znakov"
+msgstr[1] "Vsebovati mora največ %d znak"
+msgstr[2] "Vsebovati mora največ %d znaka"
+msgstr[3] "Vsebovati mora največ %d znake"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Ali želite omogočiti vročo točko Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Vroča točka Wi-Fi omogoča drugim souporabo povezave z internetom. Uporabniki "
+"se lahko povežejo v ustvarjeno omrežje Wi-Fi. Za to možnost mora biti na "
+"voljo povezava mimo običajne Wi-Fi povezave."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Ime omrežja"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Geslo"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Ustvari naključno geslo"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Samodejno ustvari geslo"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Vklopi"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Omrežje Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+"Ali naj se zaustavi vroča vstopna točka in se prekine povezava vseh "
+"uporabnikov?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Zaustavi vročo vstopno točko"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Letalski način"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Onemogoči Wi-Fi, bluetooth in širokopasovna omrežja"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Ni najdenega vmesnika Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Prepričajte se, da je vmesnik Wi-Fi priklopljen in omogočen."
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Letalski način je omogočen"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Izklopi za uporabo Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Dejavna vroča točka Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobilne naprave lahko preberejo kodo QR za povezovanje."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Omogoči vročo točko …"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Vidna omrežja"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Program NetworkManager mora biti zagnan."
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "Varnost 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Varnost"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Ohrani"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Trajno"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Naključno"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabilo"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Naslov MAC, vpisan na tem mestu, bo uporabljen kot strojni naslov za omrežno "
+"napravo, ki ustvarja povezavo. Zmožnost je poznana kot kloniranje naslova "
+"MAC oziroma lažno predstavljanje. Primer: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Napredno odpiranje"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Podjetniški"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Brez"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Nikoli"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "pred %i dnevi"
+msgstr[1] "pred %i dnem"
+msgstr[2] "pred %i dnevoma"
+msgstr[3] "pred %i dnevi"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Brez"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Šibko"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "V redu"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Dobro"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Odlično"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Naslov IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Naslov IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP naslov"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Pozabi povezavo"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Odstrani profil povezave"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Odstrani VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Podrobnosti"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "samodejno"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Istovetnost"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Izbriši naslov"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Izbriši smer"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "↓Brez"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "↓Ključ WEP 40/128-bit (Šestnajstiški ali ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "↓128-bitno šifrirno geslo WEP"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "↓LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "↓Dinamični WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "↓Osebni WPA in WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "↓Podjetniški WPA in WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "Osebni WPA3"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Moč signala"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Hitrost povezave"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Strojni naslov"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Podprte frekvence"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Privzeta smer"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Nazadnje uporabljeno"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "_Samodejna povezava"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Na voljo tudi _drugim uporabnikom"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"_Merjena povezava: obstajajo podatkovne omejitve oziroma dodatni stroški"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Posodobitve programske opreme in drugi večji prejemi ne bodo zagnani "
+"samodejno."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Ime"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_Naslov MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Kloniran naslov"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bajtov"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Način IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Samodejno (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Poveži le krajevno"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Ročno"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Onemogoči"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Souporaba z ostalimi računalniki"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Naslovi"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Naslov"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Omrežna maska"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Prehod"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Samodejno"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Samodejni DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Naslovi strežnika DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Naslovi IP morajo biti ločeni z vejicami"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Usmerjevanje"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "_Samodejne smeri"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrični"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Uporabi _povezavo le za sredstva na lastnem omrežju"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Način IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Samodejno, le DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Predpona"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Ni mogoče odpreti urejevalnika povezav"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Nov profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Neveljavna nastavitev %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Neveljavna nastavitev %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Uvozi iz datoteke …"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Dodaj VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_Varnost"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Povezave VPN ni mogoče uvoziti "
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Datoteke »%s« ni mogoče prebrati ali pa ta ne vsebuje prepoznanih podatkov o "
+"povezavi VPN\n"
+"\n"
+"Napaka: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Izbor datoteke za uvoz"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Datoteka z imenom »%s« že obstaja."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Zamenjaj"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+"Ali želite zamenjati povezavo %s z nastavitvami povezave VPN, ki jih "
+"shranjujete?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Ni mogoče izvoziti povezave VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Povezave VPN »%s« ni mogoče izvoziti v %s.\n"
+"\n"
+"Napaka: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Izvoz povezavo VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Napaka: ni mogoče naložiti urejevalnika povezav VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Nadzor nad načini povezovanja v internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"omrežje;brezžično;Wi-Fi;Wifi;IP;LAN;Proxy;Posredniški;širokopasovno;modem;"
+"bluetooth;vpn;vlan;most;vez;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Nadzor nad načini povezovanja v omrežja Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"omrežje;brezžično;Wi-Fi;Wifi;IP;LAN;Proxy;Posredniški;širokopasovno;modem;"
+"bluetooth;vpn;vlan;most;vez;DNS;vroča točka;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "nikoli"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "danes"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "včeraj"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Nazadnje uporabljeno"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Žično"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Dodaj novo povezavo"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Omrežne podrobnosti o izbranem omrežju z nastavitvami po meri in "
+"pripadajočimi gesli bodo izgubljene."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Izbriši"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Znana omrežja Wi-Fi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Izbriši"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Sistemska pravila onemogočajo uporabo vročih točk"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Brezžična naprava ne podpira načina vročih točk"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Samodejno odkrivanje posredniškega strežnika je uporabljena, kadar "
+"nastavitveni naslov URL ni naveden."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Možnost ni priporočljiva za nezavarovana javna omrežja."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Izklopi napravo"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Dejavno"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Ponudnik"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Omrežni posredniški strežnik"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Posredniški strežnik _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Posredniški strežnik H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Posredniški strežnik _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Gostitelj vtičev"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Prezri gostitelji"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Vrata posredniškega strežnika HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Vrata posredniškega strežnika HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Vrata posredniškega strežnika FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Vrata posredniškega strežnika SOCKS"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Nastavitveni naslov URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Onemogoči povezavo VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Naziv omrežja"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Varnostna vrsta"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Geslo"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Onemogoči Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Več možnosti ..."
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Poveži v skrito omrežje …"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Omogoči vročo točko Wi-Fi …"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Znana omrežja Wi-Fi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Neznano stanje"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Neupravljano"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Nedostopno"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "V povezovanju"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Zahtevana je overitev"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Prekinjanje povezave"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Povezovanje je spodletelo"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Stanje baterije ni znano (manjka)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Nastavitev je spodletela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Nastavljanje IP je spodletelo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Nastavitev IP je časovno poteklo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Zahtevana so bila ustrezna gesla, ki pa niso bila podana"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Prosilnik 802.1X je odklopljen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Nastavitev prosilnika 802.1X je spodletela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Prosilnik 802.1X je spodletel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Prosilnik 802.1X je potreboval preveč časa za overjanje"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Storitev PPP ni uspešno zagnana"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Storitev PPP je prekinjena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP je spodletel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Začenjanje odjemalca DHCP je spodletelo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Napaka odjemalca DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Odjemalec DHCP je spodletel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Začenjanje storitve souporabe povezave je spodletelo."
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Storitev souporabe povezave je spodletela."
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Začenjanje storitve AutoIP je spodletelo."
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Napaka storitve AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Storitev AutoIP je spodletela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Povezava je zasedena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Ni klicnega signala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Ni mogoče vzpostaviti signala povezave"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Zahteva klicanja je časovno potekla"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Poskus klicanja je spodletel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Začenjanje modema je spodletelo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Izbor določenega APN je spodletel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Iskanje omrežij ni dejavno"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Vpis omrežja je zavrnjen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Čas za vpis omrežja je potekel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Vpis v zahtevano omrežju je spodletela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Preverjanje PIN je spodletelo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Napravi morda manjka zahtevana strojna programska oprema"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Dejavna povezava je izginila"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Predviden je bila obstoječa povezava"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modema ni mogoče najti"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Povezava Bluetooth je spodletela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Kartica SIM ni vstavljena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Zahtevana je šifra SIM PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Zahtevana je šifra SIM PUK"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Kartica SIM je neustrezna"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Odvisnost povezave je spodletela"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Manjka strojna programska oprema"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabel ni priklopljen"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "nedoločena napaka varnostnega protokola 802.1x (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "ni izbrane datoteke"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "nedoločena napaka overjenja datoteke eap-method"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Zasebni ključi DER, PEM, PGP ali PKCS#12"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Potrdila DER ali PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "manjka datoteka EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Datoteke PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Brezimno"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Overjeno"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Oba"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_Brezimna istovetnost"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "Datoteka _PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Izbor datoteke PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Notranja overitev"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Dovoli samodejno _odbiro PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "manjka uporabniško ime EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "manjka geslo EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Uporabniško ime"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Geslo"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Pokaži _geslo"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "neveljavno potrdilo EAP-PEAP CA: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "neveljavno potrdilo EAP-PEAP CA: potrdilo ni določeno"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Različica 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "↓Različica 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Potrdilo _CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Izbor potrdila pooblastitelja"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Ni zahtevanega dovoljenja _CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Različica PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "manjka uporabniško ime EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "manjka geslo EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "manjka istovetnost EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "neveljavno potrdilo EAP-TLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "neveljavno potrdilo EAP-TLS CA: potrdilo ni določeno"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "neveljaven zasebni ključ EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "neveljavno uporabniško potrdilo EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Nešifrirani zasebni ključi niso varni"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Videti je, da izbrani zasebni ključi niso zaščiteni z geslom. To bi lahko "
+"ogrozilo varnost podatkov. Izberite z geslom zaščiten zasebni ključ.\n"
+"\n"
+"(Zasebne ključe lahko zaščitite z geslom z OpenSSL.)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Izbor osebnega potrdila"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Izbor osebnega ključa"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Istovetnost"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Uporabniško potrdilo"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Osebni _ključ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Geslo _zasebnega ključa"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "neveljavno potrdilo EAP-TTLS CA: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "neveljavno potrdilo EAP-TTLS CA: potrdilo ni določeno"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (brez EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domena"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Prišlo je do neznane napake overjanja varnosti 802.1x."
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "GESLO"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tuneliran TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Varovani EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Overitev"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Izbor datoteke"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "manjka uporabniško ime za leap"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "manjka geslo leap"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Ni vpisanega gesla za Wi-Fi"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Vrsta"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "manjka ključ wep"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"neveljavni podatki wpa-psk: ključ dolžine %zu mora vsebovati le števila v "
+"šestnajstiškem sistemu"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"neveljavni podatki wpa-psk: ključ dolžine %zu mora vsebovati le znake ASCII"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"neveljavni podatki wpa-psk: napačna dolžina ključa %zu. Biti mora biti ali "
+"5/13 (ASCII) oziroma 10/26 (šestnajstiško)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "neveljavni podatki wpa-psk: šifrirna koda mora biti vpisana"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+"neveljavni podatki wpa-psk: šifrirna koda mura biti krajša od 64 znakov"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (privzeto)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Odpri sistem"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Objavljen ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Pokaži ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "Določilo _WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"neveljavni podatki wpa-psk: neustrezna dolžina ključa %zu. Biti mora [8,63] "
+"bajtov oziroma 64 števil v šestnajstiškem sistemu"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"neveljavni podatki wpa-psk: ni mogoče tolmačiti 64-bitnega ključa v "
+"šestnajstiškem sistemu"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Obvestila"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "_Zvočna opozorila"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Pojavna _obvestila"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Obvestila se bodo pojavljala na seznamu obvestil, ko bodo pojavna okna "
+"onemogočena."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Pokaži vsebino _sporočila v pojavnih oknih"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Pokaži obvestila na zaklenjenem zaslonu"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Pokaži _sporočila tudi na zaklenjenem zaslonu"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Ne moti s prikazovanjem obvestil"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Pokaži _obvestila na zaklenjenem zaslonu"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Nadzirajte katera obvestila so prikazana in kaj prikazujejo"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Obvestila;sporočila;pojavna sporočila;opozorila;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Drugi"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "Račun %s je odstranjen."
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Napaka med odstranjevanjem računa"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Razveljavi"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Zapri obvestilo"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Povezovanje s podatki v oblaku"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Ni povezave z internetom – povezava je zahtevana za uporabljanje novih "
+"spletnih računov"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Dodaj račun"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Račun %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Odstrani račun"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Spletni računi"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Nadzirajte svoje spletne račune in se odločite za kaj jih boste uporabili"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Splet;Klepet;Koledar;Elektronska pošta;Stiki;"
+"Računi;ownCloud;oblak;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Neznan čas"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minut"
+msgstr[1] "%i minuta"
+msgstr[2] "%i minuti"
+msgstr[3] "%i minute"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ur"
+msgstr[1] "%i ura"
+msgstr[2] "%i uri"
+msgstr[3] "%i ure"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ur"
+msgstr[1] "ura"
+msgstr[2] "uri"
+msgstr[3] "ure"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minuta"
+msgstr[2] "minuti"
+msgstr[3] "minute"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "Še %s do polne napolnjenosti"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Opozorilo: na voljo je še %s delovanja"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Še %s do konca delovanja"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Polna napolnjenost"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Naprava se ne polni"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Prazno"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Polnjenje"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Praznjenje"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Brezžična miška"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Brezžična tipkovnica"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Neprekinjen oskrba z napetostjo"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Digitalni pomočnik"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobilni telefon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Predvajalnik predstavnih datotek"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablični računalnik"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Računalnik"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Igralniška vhodna naprava"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Baterija"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Glavno"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Dodatno"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Baterije"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Ob _nedejavnosti"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Zaustavi"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Izklop"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Preidi v mirovanje"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ničesar"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Med delovanjem na bateriji"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Ob priklopu"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Nikoli"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Samodejen prehod v pripravljenost"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Zmogljivostni način delovanja je začasno onemogočen zaradi visoke delovne "
+"temperature."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Sprememba delovanja: zmogljivostni način začasno ni na voljo. Za ponovno "
+"vzpostavitev je treba napravo premakniti na stabilno površino."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Zmogljivostni način je začasno onemogočen."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Nizko stanje baterije: omogočen je varčevalni način delovanja. Predhodno "
+"uporabljeni način bo obnovljen, ko bo baterija dovolj napolnjena."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Varčevalni način delovanja je sprožil program »%s«."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Zmogljivostni način delovanja je sprožil program »%s«."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 ura"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minut"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 uri"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Način delovanja"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Vpliva na zmogljivost delovanja in porabo energije."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Možnosti varčevanja z energijo"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Samodejno prilagajanje svetlosti"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Nastavitev svetlosti zaslona se prilagaja osvetljenosti okolja."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Zamegljen zaslon"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Zmanjša svetlost zaslona, ko ni zaznane dejavnosti naprave."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Prazen zaslon"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Izklopi zaslon po določenem času nedejavnosti."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Samodejno ohranjevanje energije"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Omogoči varčni način delovanja, ko je baterija skoraj prazna."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Samodejen prehod v pripravljenost"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Preide v način pripravljenosti po določenem času nedejavnosti."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Delovanje gumba za _priklop"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Pokaži _napolnjenost baterije"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Samodejen prehod v pripravljenost"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Napajanje iz _omrežja"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Napajanje iz _baterije"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Časovni zamik"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Zmogljivost"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Visoka zmogljivost delovanja in velika poraba energije."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Uravnoteženo"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Običajna zmogljivost delovanja in zmerna poraba energije."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Varčno"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Zmanjšana zmogljivost delovanja in majhna poraba energije."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Napajanje"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Oglejte si stanje baterije in spremenite nastavitve varčevanje z energijo"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"v delovanju;v pripravljenosti;hiberniranje;v mirovanju;baterija;zaslon;DPMS;"
+"nedejavnost;svetlost;energija;poraba;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Tiskalnik »%s« je bil izbrisan."
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Dodajanje novega tiskalnika je spodletelo."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Ni mogoče naložiti uporabniškega vmesnika: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Odklenite za dodajanje tiskalnikov in spreminjanje nastavitev"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Tiskalniki"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Dodajte tiskalnike, oglejte si posle tiskalnika in se odločite, kako želite "
+"tiskati"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Tiskalnik;Vrsta;Tiskanje;Papir;Črnilo;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Dodaj tiskalnik"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Odkleni"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Ni najdenih tiskalnikov"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Vpis omrežnega naslova oziroma niz za iskanje tiskalnika"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Zahtevana je overitev"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Vnesite uporabniško ime in geslo za ogled tiskalnikov na strežniku tiskanja."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Uporabniško ime"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Podrobnosti %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Ni mogoče najti ustreznega gonilnika"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Izbor datoteke PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Datoteke opisa tiskalnika PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+"Imena tiskalnika ne smejo vsebovati presledka, tabulatorja, lojtre (#) ali "
+"poševnice (/)."
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Mesto"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Gonilnik"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Iskanje prednostnih gonilnikov …"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Poišči gonilnike"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Izbor iz podatkovne zbirke …"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Namesti datoteko PPD …"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Izbor gonilnik tiskalnika"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Poteka nalaganje zbirke gonilnikov …"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Izberi"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Tiskalnik JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Tiskalnik LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Enostransko"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Dolga stranica (standardno)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Kratka stranica (zrcaljeno)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Pokončno"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Ležeče"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Obrnjeno ležeče"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Obrnjeno pokončno"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Nadaljuj"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Premor"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "V čakanju"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Premor"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Zahtevana je overitev"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Izvajanje"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Zaustavljeno"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Preklicano"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Prekinjeno"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Zaključeno"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Premakni opravilo na vrh vrste"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u opravil tiskalnika zahteva overitev"
+msgstr[1] "%u opravilo tiskalnika zahteva overitev"
+msgstr[2] "%u opravili tiskalnika zahtevata overitev"
+msgstr[3] "%u opravila tiskalnika zahtevajo overitev"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s – dejavni posli"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Vpišite poverila za tiskanje na %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domena"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Overi"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Počisti vse"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Overi"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Ni dejavnih poslov tiskalnika"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Odkleni strežnik tiskanja"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Odkleni %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Vnesite uporabniško ime in geslo za ogled tiskalnikov na %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Poteka iskanje tiskalnikov"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Zaporedna vrata"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Vzporedna vrata"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Mesto: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Naslov: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Strežnik zahteva overitev"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dvostransko"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Vrsta papirja"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Vir papirja"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Pladenj za papir"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Ločljivost"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Predhodno filtriranje GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Strani na stran"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dvostransko"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Usmerjenost"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Splošno"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Nastavitev strani"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Namestitvene možnosti"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Posel"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Kakovost slike"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Barvni profili"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Zaključevanje"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Napredno"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Preizkusna stran"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Preizkusna stran"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Samodejno izberi"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Privzeto za tiskalnik"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Vstavi samo pisave GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Pretvori v PS ravni 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Pretvori v PS ravni 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Brez predhodnega filtriranja"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Proizvajalec"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Ni dejavnih poslov"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u poslov"
+msgstr[1] "%u posel"
+msgstr[2] "%u posla"
+msgstr[3] "%u posli"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Počisti glave tiskalnika"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Tonerja je malo"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Zmanjkalo je tonerja"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Razvijalca je malo"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Zmanjkalo je razvijalca"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Zaloge označevalnika je malo"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Zaloge označevalnika je zmanjkalo"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Odprt pokrov"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Odprta vrata"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Malo papirja"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Ni papirja"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Nepovezano"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Zaustavljeno"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Zbiralnik odpadkov je skoraj poln"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Zbiralnik odpadkov je poln"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Optični foto prevodnik ne bo več dolgo deloval"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Optični foto prevodnik ne deluje več"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Pripravljen"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Ne sprejema poslov"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Obdelovanje"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Možnosti tiskanja"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Podrobnosti tiskalnika"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Privzeto uporabi tiskalnik"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Počisti glave tiskalnika"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Odstrani tiskalnik"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Raven črnila"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Program ponovno zaženite, ko bo težava odpravljena."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Ponoven zagon"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Dodaj tiskalnik …"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Ni nastavljenih tiskalnikov"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Kaže, da sistemska storitev\n"
+"za tiskanje trenutno ni na voljo."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Jezikovna določila"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Preišči jezikovne nabore …"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Pogoste vrste"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Vse vrste"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Ni najdenih zadetkov"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Iskati je mogoče države ali jezike."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Predogled"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperialni"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrični"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datumi"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Datum in čas"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Števila"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Merski sistem"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papir"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Jezikovne nastavitve bodo uveljavljene pri naslednji prijavi"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Odjava …"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Jezikovne nastavitve določajo jezik besedila vmesnika in spletnih strani. "
+"Uporabijo se zapisi števil, datumov in denarnih enot."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Račun"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Jezik"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Jezikovna določila"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Prijavni zaslon"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Področje in Jezik"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Izbor jezika za zapisov"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "jezik,razporeditev;tipkovnica;vnos;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Vprašaj, kaj storiti"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Ne naredi ničesar"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Odpri mapo"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Drugi nosilci"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Izbor programa za zvočne CD-je"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Izberite program za video DVD-je"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Izberite kateri program naj se zažene, ko je predvajalnik glasbe povezan"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Izberite program, ki naj teče, ko je povezan fotoaparat"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Izbor programa za programske CD-je"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "zvočni DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "prazen Blu-Ray disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "prazen CD disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "prazen DVD disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "Prazen disk HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "Bralnik e-knjig"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD video disk"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Slikovni CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Programska oprema za okolje Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Izbor načina upravljanja z nosilci"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Zvočni CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_Video DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Predvajalnik glasbe"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Programska oprema"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Drugi nosilci …"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Nikoli ne pozovi ali zaženi programov ob vstavitvi nosilca"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Izberite kako upravljati z drugimi vrstami nosilcev"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Dejanje:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "Vrs_ta:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Odstranljivi nosilci"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Nastavitve odstranljivih nosilcev"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"naprava;sistem;podrobnosti;pomnilnik;procesor;različica;privzeto;program;"
+"povrnjeno:prednostno;cd;dvd;usb;zvok;slika;video;disk;odstrani;predstavnost;"
+"samodejni zagon;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Zaslon se izklopi"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekund"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 minuta"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 minuti"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 minute"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 minut"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minut"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 ura"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 minuta"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 minuti"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 minute"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 minute"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Nikoli"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Zaklep zaslona"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Samodejno zaklepanje zaslona onemogoči nepovabljenim dostop do računalnika, "
+"ko vas ni v bližini."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Zamik zatemnitve zaslona"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Čas nedejavnosti, po katerem se zaslon ugasne."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Samodejno zakleni zaslon"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Zamik samodejnega zaklepanja zaslona"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Čas po katerem se po ugasnjenem zaslonu ta tudi samodejno zaklene."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Pokaži _obvestila na zaklenjenem"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Prepovej nove naprave _USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Prepreči novi napravam USB povezovanje v sistem, ko je zaslon zaklenjen"
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Zasebnost zaslona"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Omeji kot pogleda"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Nastavitve zaslona"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;zaslon;zaklep;zasebno;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Izbor mesta"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_V redu"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Preišči mesta"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Mape, ki so vključene kot mesta iskanja sistemskih programov, kot so "
+"Datoteke, Slike in Video"
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Mesta"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Zaznamki"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Drugi"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Dodaj mesto"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Ni najdenih programov"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Iskanje programov"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Vključi zadetke iskanja drugih programov"
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Mape, ki jih pregledujejo sistemski programi."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Ni najdenih zadetkov"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Rezultati so prikazani glede na seznam razvrščanja."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Nadzirajte, kateri programi v pregledu dejavnosti prikazujejo rezultate "
+"iskanja"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "iskanje;išči;najdi;kazalo;skrij;zasebnost;zadetki;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Ni izbranega omrežja za souporabo"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Omrežja"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Omogočeno"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Onemogočeno"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Omogočeno"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Dejavno"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Izbor mape"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Dodaj"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Omogoči souporabo predstavnih datotek"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Možnost souporabe datotek omogoča drugim uporabnikom  na trenutnem omrežju "
+"dostop do Javne mape s protokolom: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Oddaljenim uporabnikom dovoli povezavo z ukazom Secure Shell, če je "
+"oddaljena prijava omogočena:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Omogoči osebno souporabo datotek"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Naslov naprave je kopiran"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Naslov naprave je kopiran"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Uporabniško ime je kopirano"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Geslo je kopirano"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Souporaba"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Ime računalnika"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Souporaba _datotek"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "_Oddaljeno namizje"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Souporaba predstavnih datotek"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Oddaljena prijava"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Skupna raba datotek"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Zahtevaj geslo"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Oddaljena prijava"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Oddaljeno namizje"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Oddaljeno namizje omogoča ogled in upravljanje namizja iz drugega "
+"računalnika."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Omogoči ali onemogoči napravi povezovanje z oddaljenimi namizji"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Daljinski upravljalnik"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Omogoča daljinsko upravljanje zaslona"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Kako vzpostaviti povezavo"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Povežite se s tem računalnikom z imenom naprave ali naslovom oddaljenega "
+"namizja."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Naslov oddaljenega namizja"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Overitev"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "Uporabniško ime in geslo sta potrebna za povezavo s tem računalnikom."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Uporabniško ime"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Overi šifriranje"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Prstni odtis šifriranja"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Šifrirni prstni odtis je viden v programih, ki omogočajo povezovanje, in "
+"mora biti povsod enak."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Souporaba predstavnih datotek"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Souporaba glasbe, fotografij in videov na omrežju."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Mape"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Nadzor nad souporabo podatkov in datotek z drugimi uporabniki"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"souporaba;izmenjava;ssh;gostitelj;ime;oddaljeno;namizje;bluetooth;obex;"
+"predstavnost;zvok;audio;slika;video;fotografije;filmi;strežnik;izrisovanje;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Omogoči ali onemogoči oddaljene prijave"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Za spremembo možnosti oddaljenega prijavljanja je zahtevana overitev"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Po meri"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klik"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Niz znakov"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Nihanje"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Brnenje"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Uravnoteženo"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Pojemanje"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Zadaj"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Spredaj"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Preizkušanje %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Kliknite zvočnik za preizkus"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Sistemska glasnost"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Glavna glasnost"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Ravni glasnosti"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Izhod"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Odvodna naprava"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Preizkus"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Nastavitve"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Nizkotonski zvočnik"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Vhod"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Vhodna naprava"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Glasnost"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Zvok opozoril"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100 %"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Nemo"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Zvok"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"Spreminjanje zvokovnih naprav, glasnosti zvoka in povezljivost z dogodki"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kartica;Mikrofon;Glasnost;Pojemanje;Uravnavanje;Bluetooth;Naglavne slušalke;"
+"Zvok;Dovod;Odvod;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Prekinjena povezava"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "V povezovanju"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Povezano"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Napaka overitve"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Poteka overjanje"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Zmanjšana zmogljivost"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Povezano in overjeno"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Neznano"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Naprava je bila overjena ob:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Povezava je bila vzpostavljena ob:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Naprava je bila vpisana ob:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Overjanje naprave je spodletelo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Pozabljanje naprave je spodletelo: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Odvisnosti so povezane s %u drugimi napravami"
+msgstr[1] "Odvisnosti so povezane s %u drugo napravo"
+msgstr[2] "Odvisnosti so povezane s %u drugima napravama"
+msgstr[3] "Odvisnosti so povezane s %u drugimi napravami"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Zapri obvestilo"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Ime:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Stanje:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Overi in poveži"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Pozabi napravo"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Napaka"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Overjeno"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Podsistem Thunderbolt (boltd) ni nameščen oziroma je neustrezno nastavljen."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "Dovoli neposreden dostop do naprav, kot so sidrišča in zunanje GPE."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+"Naprave je mogoče pripeti le z uporabo priklopa USB oziroma zaslonskega "
+"priklopa."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Sistema Thunderbolt ni mogoče zaznati.\n"
+"Podpora sistemu morda ni na voljo, sistem je v zaganjalniku BIOS onemogočen, "
+"ali pa je nastavljen na nepodprto varnostno raven."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Podpora Thunderbolt je onemogočena med nastavitvami BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Varnostne ravni Thunderbolt ni mogoče določiti."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Napaka preklapljanja neposrednega načina: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Ni podpore za naprave Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Povezava s podsistemom Thunderbolt ni mogoča."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Neposredni dostop"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Naprave na čakanju"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Ni priklopljenih naprav"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Upravljanje naprav Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;zasebnost;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Utripanje kazalke"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Kazalka v besedilnih poljih utripa."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Hitrost"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Hitrost utripanja kazalke"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Velikost kazalke"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Velikost kazalke je lahko za lažje vodenje prilagojena ravni približanja."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Pomočnik za klikanje"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulirani drugi klik"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Sproži drugotni klik s tiščanjem osnovnega gumba"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Pretek _natančnosti:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kratek"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Časovni zamik drugotnega klika"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Dolg"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Klik ob _prehodu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Sproži klik ob prehodu kazalnika nad točko"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Premor:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kratek"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Dolg"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Prag premikanja:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Majhen"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Velik"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Ponavljajoče tipke"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Ponovi izpis znakov tipke, ko je tipka pritisnjena zadržano."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Zamik ponavljanja tipke"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Hitrost ponovitve tipk"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Pomočnik tipkanja"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Lepljive tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Zaporedje spremenilnih tipk obravnava kot kombinacijo tipk"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Onemogoči, če sta sočasno pritisnjeni dve tipki"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Zapiskaj, ko je pritisnjena _spremenilna tipka"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Počasne tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Nastavi zamik med pritiskom in sprejemom tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kratek"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Časovni zamik počasnih tipk"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Dolg"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Zapiskaj, kadar je tipka _pritisnjena"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Zapiskaj, kadar je tipka _sprejeta"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Zapiskaj, kadar je tipka zav_rnjena"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Odskočne tipke"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Prezre hitre podvojene pritiske tipk"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kratek"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Časovni zamik podvojenih pritiskov tipk"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Dolg"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Omogoči s tipkovnico"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Vklopi ali izklopi zmožnosti dostopnosti s tipkovnico"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "privzeta"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "srednja"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "velika"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "zelo velika"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "največja"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d točk"
+msgstr[1] "%d točka"
+msgstr[2] "%d točki"
+msgstr[3] "%d točke"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Vedno pokaži meni dostopnosti"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Izrisovanje"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Visok kontrast prikaza"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Povečano besedilo"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Omogoči _animacije"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Zaslonski _bralnik"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Zaslonski bralnik prebere besedilo, ki je v žarišču pod kazalko."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "O_zvočene tipke"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Zapiska, kadar je pritisnjena tipka za zaklep številčnice ali velikih črk."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Velikost _kazalke"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Povečevalno polje"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Izrisovanje zvočnih obvestil"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Vidna _opozorila"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Zaslonska _tipkovnica"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Ponavljajoče tipke"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Utripanje kazalke"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Pomočnik tipkanja (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Kazanje in klikanje"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Miškine tipke"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Zaznaj tiskalnik"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Pomočnik za klikanje"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Časovni zamik dvojnega klika"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Časovni zamik dvojnega klika"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Vidna opozorila"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Preizkusni _blisk"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Zvok opozorila spremlja blisk."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Zabliskaj _celoten zaslon"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Zabliskaj _celotno okno"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kratko"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ zaslona"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ zaslona"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ zaslona"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Dolgo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Celozaslonski način"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Zgornja polovica"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Spodnja polovica"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Leva polovica"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Desna polovica"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Možnosti približanja"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Približevanje:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Položaj približevalnika:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Sledi kazalki miške"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Del zaslona:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Približevalnik deluje tudi _izven zaslona"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Ohrani kazalko približevalnika na sredini"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Kazalka približevalnika _odriva vsebino"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Kazalka približevalnika se _premika z vsebino"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Povečevalo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Merki:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Prekrivanje kazalke miške"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Debelina:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tanek"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Debel"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Dolžina:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Ba_rva:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Merki"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Barvni učinki:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Črno na belem:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Svetlost:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Ba_rva"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Brez"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Polna"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Nizka"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Visoka"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Nizek"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Visok"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Barvni učinki"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Naj bo enostavnejše videti, slišati, tipkati, kazati in klikati"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"tipkovnica;miška;a11y;splošno;dostopnost;kontrast;približanje;zaslon;bralnik;"
+"besedilo;pisava;velikost;AccessX;lepljive;počasne;odskočne;tipke;zamik;"
+"odskočne;dvojne;klik;ponovitev;zvok;tipkanje;tipkovnica,nastavitve;sluh;"
+"kontrast;zvok;približanje;zoom;zaslon;velikost;prilagoditve;prikrojitve;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 ura"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 dan"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dni"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dni"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Ali naj se izbrišejo vsi predmeti iz smeti?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Vsi predmeti v smeteh bodo trajno izbrisani."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Izprazni _smeti"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Ali naj se izbrišejo vse začasne datoteke?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Vse začasne datoteke bodo trajno izbrisane."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Počisti začasne datoteke"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 dan"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 dni"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dni"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Trajno"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Zgodovina datoteke"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Zgodovina datotek vključuje tudi zapise uporabe datotek. Te podrobnosti so "
+"lahko na voljo različnim programom, kar omogoča enostavnejše iskanje."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Zgodovina _datoteke"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Trajanje zgodovine datoteke"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Počisti _zgodovino …"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Smeti in začasne datoteke"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"V smeteh in v začasnih datoteka so včasih lahko osebni oziroma občutljivi "
+"podatki. Samodejno brisanje lahko zagotavlja večjo zasebnost."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Samodejno sprazni vsebino _smeti"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Samodejno počisti _začasne datoteke"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Samodejno izbriši _obdobje"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Izprazni _smeti …"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Počisti začasne datoteke …"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Zgodovina datoteke in smeti"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Ne puščaj sledi"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"uporaba;nedavno;zgodovina;datoteke;začasno;zasebno;osebno;smeti;brisanje;"
+"povrnitev;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Vpis mora biti skladen s spletnim naslovom ponudnika prijave."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Dodajanje računa je spodletelo"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Gesli se ne skladata."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Vpis računa je spodletel"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Ni podprtega načina za overitev s to domeno"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Pridružitev v domeno je spodletela"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Prijavno ime ne deluje.\n"
+"Poskusite vpisati drugo ime."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Prijavno geslo je napačno.\n"
+"Poskusite vpisati drugo geslo."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Prijava v domeno je spodletela"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Domene ni mogoče najti. Morda je vpisana napačno."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Dodaj uporabnika"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Skrbnik"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Skrbniki lahko dodajo in odstranijo druge uporabnike in vsem spreminjajo "
+"nastavitve. Starševski nadzor skrbnikom ni na voljo."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Uporabnik si nastavi geslo ob prvi prijavi"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Nastavi geslo"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Potrdi"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Prijava v poslovno domeno"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Uporabniški računi, ki jih upravlja podjetje ali ustanova."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Povezava ni vzpostavljena"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Poslovna prijava omogoča prijavo na to napravo z obstoječim poslovnim "
+"uporabniškim računom. Ta račun je mogoče uporabiti tudi za dostop do "
+"poslovnih virov na internetu."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Brskanje med več slikami"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Izbor datoteke …"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Upravljalnik prstnega odtisa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Prstni odtis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Ne"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Da"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Ali želite izbrisati obstoječe prstne odtise in onemogočiti tak način "
+"prijave?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Ni naprave za branje prstnega odtisa"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Ni naprave za branje prstnega odtisa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Zagotovite, da je naprava pravilno povezana."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Naprava za branje prstnega odtisa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Izberite napravo za branje prstnega odtisa, ki jo želite nastaviti"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Prijava s prstnim odtisom"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Prijava s prstnim odtisom omogoča prijavo oziroma odklepanje sistema s prstom"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Izbriši prstne odtise"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Prijava s prstnim odtisom"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr ""
+"pred izvajanjem tega opravila mora biti vzpostavljena povezava z napravo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "naprava je že v uporabi v drugem opravilu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "ni ustreznih dovoljenj za izvajanje tega dejanja"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "ni poslanih opravil za tiskanje"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Povezovanje z napravo med vpisovanjem je spodletelo."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Povezovanje s čitalcem prstnih odtisov je spodletelo."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr ""
+"Povezovanje z ozadnjim programom čitalca prstnih odtisov je spodletelo."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Prikaz prstnih odtisov je spodletel: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Brisanje prstnih odtisov je spodletelo: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Levi palec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Levi sredinec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Levi kazalec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Levi prstanec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Levi mezinec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Desni palec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Desni sredinec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Desni kazalec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Desni prstanec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Desni mezinec"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Neznan prst"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Končano"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Naprava za prijavo s prstnim odtisom ni priklopljena"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Shramba naprave za branje prstnega odtisa je polna"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Odčitavanje novega prstnega odtisa je spodletelo."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Začenjanje odčitavanja je spodletelo: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Odčitavanje novega prstnega odtisa je spodletelo."
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Zaustavljanje odčitavanja je spodletelo: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Ponavljajoče dvignite in položite prst na bralnik za odčitavanje prstnega "
+"odtisa"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Ponovno odčitaj ta prst …"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Odčitaj nov prstni odtis"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Sproščanje naprave za branje prstnega odtisa %s je spodletelo: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Napaka branja naprave"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Povezovanje naprave za branje prstnega odtisa %s je spodletelo: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Pridobivanje naprav za prstni odtis je spodletelo: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Ta teden"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Predhodni teden"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s – %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Seja je končana"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Seja je začeta"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s – dejavnost računa"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Predhodno"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Naslednje"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Izberite drugo geslo."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Znova vnesite trenutno geslo."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Gesla ni mogoče spremeniti."
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Spremeni geslo"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_Spremeni"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Trenutno geslo"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Novo geslo"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Potrdi geslo"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Dovoli uporabniku nastavljanje gesla ob naslednji prijavi."
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Nastavi geslo"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Ni mogoče samodejno pridružiti tej vrsti domene"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Ni mogoče najti take domene ali takega področja"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Ni se mogoče prijaviti kot %s v domeno %s."
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Napačno geslo, poskusite znova."
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Z domeno %s povezava ni mogoča: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Napaka med brisanjem uporabnika"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Preklic oddaljeno vodenega uporabnika je spodletel"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Ni mogoče izbrisati lastnega računa."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s je še vedno prijavljen"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Izbris uporabnika, ki je trenutno prijavljen, lahko vpliva na delovanje "
+"sistema."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Ali želite obdržati datoteke uporabnika %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Mogoče je ohraniti domačo mapo, vrstilno mapo pošte in začasne datoteke tudi "
+"med brisanjem uporabniškega računa."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Izbriši datoteke"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Ohrani datoteke"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Ali ste prepričani, da želite preklicati oddaljeno voden račun uporabnika %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Izbriši"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Račun je onemogočen"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Nastavljeno bo ob naslednji prijavi"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Brez"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Trenutno dejavna prijava"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Napaka med povezovanjem s storitvijo računov"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Prepričajte se, da je paket AccoutnService nameščen in omogočen."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Okno je treba za spreminjanje nastavitev najprej odkleniti"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Izbriši izbran uporabniški račun"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Za izbris izbranega uporabniškega\n"
+"računa, kliknite na ikono *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Odklenite za spreminjanje nastavitev in uporabnikov"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Uporabniki"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Za uveljavitev sprememb se je treba v sejo ponovno prijaviti"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Ponoven zagon"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Zapri"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Uredi podobo"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Polno Ime"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Uredi"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Prijava s _prstnimi odtisi"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Samodejna prijava"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Dejavnost računa"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Skrbnik"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Skrbniki lahko dodajo in odstranijo druge uporabnike in vsem spreminjajo "
+"nastavitve."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Starševski nadzor"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Odpri nadrejen nastavitveni program"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Odstrani uporabnika …"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Drugi uporabniki"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Dodaj uporabnika …"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Ni najdenih uporabnikov"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Odklenite za dodajanje uporabniškega računa."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Upravljanje uporabnikov in spreminjanje gesel"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Prijava;Ime;Prstni odtis;Podoba;Avatar;Logo;Obraz;Geslo;Starševski "
+"nadzor;Zaslonski čas;Omejitev;Zaklepanje programov;Uporaba;Omejitev uporabe;"
+"Otroci;Otrok;Mladostniki;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Prijava v domeno"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Skrbniška prijava v domeno"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Pred uporabo prijave v poslovno okolje mora biti računalnik\n"
+"prijavljen v domeno. Za dostop do domene so zahtevana\n"
+"skrbniška strežniška dovoljenja."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Ime _skrbnika"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Skrbniško geslo"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Upravljanje uporabniških računov"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Za spremembo podatkov uporabnika je zahtevana overitev"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Novo geslo mora biti drugačno od starega."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Zamenjajte nekaj črk in številk."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Poskusite še malo spremeniti geslo."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Geslo brez uporabniškega imena bi bilo bolj varno."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Nikoli ne uporabite imena za geslo."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Poskusite se izogniti nekaterim besedam, ki so del geslu."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Izogibajte se uporabi pogostih besed."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Izogibajte se zgolj zamenjavi razvrstitve obstoječih besed."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Dodajte več številk."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Dodajte več velikih črk."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Dodajte več malih črk."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Uporabite posebne znake, kot so na primer ločila."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Priporočljivo je uporabiti različne črke številke in posebne znake."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Poskusite se izogniti ponavljanju znakov."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Poskusite se izogniti ponavljanju znakov. Priporočljivo je uporabiti "
+"različne črke številke in posebne znake."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Izognite se zaporedjem, kot sta 1234 in abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Geslo mora biti daljše. Poskusite dodati črke, številke in druge znake."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Priporočeno je uporabiti male in velike črke, vmes pa dodati tudi kakšno "
+"številko."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Dodajanje črk, številk in ločil poveča moč gesla."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Overitev je spodletela"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Novo geslo je prekratko"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Novo geslo je preveč enostavno"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Novo geslo je preveč podobno staremu"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Novo geslo je bilo nedavno že uporabljeno."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Novo geslo mora vsebovati številke ali posebne znake"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Novo geslo je enako staremu"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Vaše geslo je bilo spremenjeno od začetne overitve!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Novo geslo ne vsebuje dovolj različnih znakov"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Neznana napaka"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Uporabniško ime je lahko sestavljeno iz malih črk angleške abecede, številk "
+"in posebnih znakov » - _ «."
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Uporabniško ime ni na voljo! Izberite drugo ime."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Uporabniško ime je predolgo."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Preslikava gumbov"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Preslikaj gumbe v opravila"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Za urejanje bližnjice je treba izbrati možnost »Pošlji kodo tipke«, nato "
+"pritisniti gumb bližnjice tipkovnice in zadržati ustrezne želene tipke za "
+"vnos nove. S povratno tipko se izbriše trenutna nastavitev."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Zapri"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "Z udarjanjem na ciljna mest se umeri zaslon zaslona na dotik."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Zaznan je napačen klik, opravilo bo znova začeto …"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Gumb %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Določeno programi"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Pošlji kode tipk"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Preklop zaslona"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Pokaži zaslonsko pomoč"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Na prenosnik je priklopljena tablica"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Na zunanji zaslon je priklopljena tablica"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Zunanja tablična naprava"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Zunanja tablična naprava"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Vsi zasloni"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Tablični način"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Uporabi absolutno prilagajanje za pisalo"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Levoročna usmerjenost"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tablične in Hitre tipke so obrnjene za levoročno uporabo"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Preslikaj na zaslon"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Ohrani razmerje velikosti"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Uporabi le del površine tablice za ohranjanje skladnosti z velikostjo "
+"monitorja"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Umeri"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Ni zaznane tablice"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Priklopite in prižgite tablico Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Občutek pritiska konice"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Mehko"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Pritisk konice pisala"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Čvrsto"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Gumb 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Gumb 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Gumb 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Občutek pritiska radirke"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Pritisk radirke"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Klik srednjega gumba miške"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Klik desnega gumba miške"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Posreduj"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Običajno pisalo, občutljivo na moč in vgrajeni drsnik"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Običajno pisalo, občutljivo na moč, kot in vrtljivi pritisk"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Običajno pisalo, občutljivo na moč in kot pritiska"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Običajno pisalo, občutljivo na moč pritiska"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Tablica Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Nastavitev preslikave gumbov in prilagoditev občutljivosti paličice grafične "
+"tablice"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablica;Wacom;Stylus;Radirka;Eraser;Miška;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Nova bližnjica …"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Dostopne točke"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Opravilo je preklicano"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Napakar:</b> dostop do spreminjanja nastavitev je onemogočen"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Napaka:</b> Napaka mobilne naprave"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Ni registrirano"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registrirano"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Gostovanje"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Poteka iskanje …"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Zavrnjeno"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Podrobnosti modema"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Stanje modema"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Ponudnik signala"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Vrsta omrežja"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Stanje omrežja"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Lastna številka"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Podrobnosti naprave"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Različica strojne programske opreme"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Le G2"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Le G3"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Le G4"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Le 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (prednostno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (prednostno), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (prednostno), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (prednostno), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (prednostno), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (prednostno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (prednostno), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (prednostno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (prednostno), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (prednostno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (prednostno), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (prednostno), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (prednostno), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (prednostno), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (prednostno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (prednostno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (prednostno)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (prednostno), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Neznano"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Odkleni kartico SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Odkleni"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Vpisati je treba kodo PIN za kartico SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Vpišite kodo PIN za odklepanje kartice SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Vpisati je treba kodo PUK za kartico SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Vpišite kodo PUK za odklepanje kartice SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Vpisano je napačno geslo. Na voljo imate še %u poskusov."
+msgstr[1] "Vpisano je napačno geslo. Na voljo imate še %u poskus."
+msgstr[2] "Vpisano je napačno geslo. Na voljo imate še %u poskusa."
+msgstr[3] "Vpisano je napačno geslo. Na voljo imate še %u poskuse."
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Na voljo imate še %u poskusov."
+msgstr[1] "Na voljo imate še %u poskus."
+msgstr[2] "Na voljo imate še %u poskusa"
+msgstr[3] "Na voljo imate še %u poskuse."
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Vpisano je napačno geslo"
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Koda PUK mora biti 8-znakovna vrednost"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Vpiši novo kodo PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Koda PIN mora biti dolžine 4–8 znakov"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Poteka odklepanje …"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Ni vstavljene kartice SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Za uporabo modema je treba vstaviti kartico PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "Kartica SIM je zaklenjena"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobilni podatki"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Dostop do podatkov z uporabo mobilnega omrežja"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Podatkovno gostovanje"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Med gostovanjem uporabljaj mobilne podatke"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Omrežni _način"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Omrežje"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Napredno"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Imena _dostopnih točk"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Zaklep kartice _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Zakleni kartico SIM s kodo PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Podrobnosti _modema"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Delovanje telefona je spodletelo"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "NI vzpostavljene povezave s telefonom"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Opravilo ni dovoljeno!"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Opravilo ni podprto"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Kartica SIM ni vstavljena"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Zahtevana je koda PIN za kartico SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Zahtevana je koda PUK za kartico SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Kartica SIM je nedostopna"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "Kartica SIM je zasedena"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Neveljavno geslo"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Zahtevana je koda PIN2 za kartico SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Zahtevana je koda PIN2 za kartico SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Predmeta ni mogoče najti"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Ni dostopnih omrežnih storitev"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Zakasnitev omrežja"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Uporaba storitve GPRS ni dovoljena"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Gostovanje na tem območju ni dovoljeno"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Nedoločena napaka GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Brez napake"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Dejanje je preklicano"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Dostop je zavrnjen"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Neznana napaka"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Način omrežja"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Samodejno"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Izbor omrežja"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Osveži omrežne ponudnike"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Omogoči mobilno omrežje"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Ni najdenega vmesnika WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Prepričajte se, da naprava podpira brezžični protokol WAN/Cellular"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Brezžično omrežje Wan je onemogočeno, kadar je omogočen letalski način"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "_Onemogoči letalski način"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Podatkovna povezava"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "Kartica SIM za dostop do interneta"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Zaklep kartice SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Naprej"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Zakleni kartico SIM s kodo PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Spremeni kodo PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Vpišite kodo PIN za spreminjanje nastavitev zaklepanja kartice SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobilno omrežje"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Nastavitve telefonije in mobilnih podatkovnih povezav"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;wwan;telephony;telefon;kartica;klicanje;mobilno;sim;mobile;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Orodje za nastavljanje namizja GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Program je osnovni vmesnik za prilagajanje nastavitev sistema."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Projekt GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Pokaži različico"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Omogoči podrobni način"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Poišči niz"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Izpiši možna imena pultov in končaj"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Pult za prikaz"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PULT][ARGUMENT …]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Kategorije nastavitev"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Zasebnost"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Razpoložljivi pulti:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Vse nastavitve"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Osnovni meni"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Opozorilo: razvojna različica"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Trenutna različica programa je namenjena izključno preizkušanju razvojnih "
+"možnosti. Pojavijo se lahko napake, nepravilno delovanje, izguba podatkov in "
+"druge nepričakovane nevšečnosti. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Pomoč"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Splošno"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Konča program"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Iskanje"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Pulti"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Pokaže predhodni pult"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Prekliče iskanje"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Možnosti;Nastavitve;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Določilnik za odpiranje zadnjega pulta Nastavitev."
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Določilnik za odpiranje zadnjega pulta Nastavitev. Neprepoznane vrednosti so "
+"prezrte, za prikaz pa je izbran prvi pult seznama."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Pokaži opozorilo med zagonom razvojne različice programa"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Ali naj se pokaže opozorilo, kadar je program zagnan v razvojnem načinu."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Začetno stanje okna"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Niz s shranjenimi podatki višine, širine in razpetega stanja okna programa."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u izhodov"
+msgstr[1] "%u izhod"
+msgstr[2] "%u izhoda"
+msgstr[3] "%u izhodi"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u vhodov"
+msgstr[1] "%u vhod"
+msgstr[2] "%u vhoda"
+msgstr[3] "%u vhodi"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sistemski zvoki"

--- a/po/sq.po
+++ b/po/sq.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center HEAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-09-15 05:35+0000\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2008-09-20 11:58+0200\n"
 "Last-Translator: Laurent Dhima <laurenti@alblinux.net>\n"
 "Language-Team: albanian <gnome-albanian-perkthyesit@lists.sourceforge.net>\n"
@@ -18,909 +18,5857 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "Bordi i figurës/etiketës"
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr ""
-"Gjerësia e kornizës rreth etiketës dhe figurës në dialogun e paralajmërimit"
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr "Lloji i paralajmërimit"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "Lloji i paralajmërimit"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "Butonët e paralajmërimit"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "Butonët e shfaqur në dialogun e paralajmërimit"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "Shfaq më shumë _detaje"
-
-#: ../capplets/about-me/gnome-about-me.c:739
-msgid "Select Image"
-msgstr "Zgjidh figurën"
-
-#: ../capplets/about-me/gnome-about-me.c:741
-msgid "No Image"
-msgstr "Asnjë figurë"
-
-#: ../capplets/about-me/gnome-about-me.c:769
-#: ../capplets/appearance/appearance-desktop.c:661
-msgid "Images"
-msgstr "Figura"
-
-#: ../capplets/about-me/gnome-about-me.c:773
-#: ../capplets/appearance/theme-installer.c:696
-msgid "All Files"
-msgstr "Të gjithë file"
-
-#: ../capplets/about-me/gnome-about-me.c:911
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-"U ndesh një gabim gjatë përpjekjes për marrje informacione mbi rubrikën\n"
-"Evolution Data Server nuk mund të trajtojë protokollin"
-
-#: ../capplets/about-me/gnome-about-me.c:932
-msgid "Unable to open address book"
-msgstr "E pamundur hapja e rubrikës"
-
-#: ../capplets/about-me/gnome-about-me.c:946
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-"ID i panjohur hyrje, baza me të dhënat e përdoruesve mund të jetë korruptuar"
-
-#: ../capplets/about-me/gnome-about-me.c:976
-#: ../capplets/about-me/gnome-about-me.c:978
-#, c-format
-msgid "About %s"
-msgstr "Informacione mbi %s"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "About Me"
-msgstr "Informacione përdoruesi"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "Përcakton të dhënat vetiake personale"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-msgid "<b>Email</b>"
-msgstr "<b>Email</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-msgid "<b>Home</b>"
-msgstr "<b>Shtëpi</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Mesazhe të menjëhershëm</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Job</b>"
-msgstr "<b>Punë</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Telephone</b>"
-msgstr "<b>Telefoni</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Web</b>"
-msgstr "<b>Web</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Work</b>"
-msgstr "<b>Punë</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
-msgstr ""
-"<span size=\"larger\" weight=\"bold\">Ndryshimi i fjalëkalimit personal</"
-"span>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "A_ddress:"
-msgstr "A_dresa:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_ssistant:"
-msgstr "A_sistenti:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "Address"
-msgstr "Adresa"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "C_ity:"
-msgstr "Qytet_i:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "C_ompany:"
-msgstr "K_ompania:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "Cale_ndar:"
-msgstr "Kale_ndari:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "Change Passwo_rd..."
-msgstr "Ndrysho fjalëka_limin..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Change pa_ssword"
-msgstr "Ndrysho f_jalëkalimin"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change password"
-msgstr "Ndrysho fjalëkalimin"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Ci_ty:"
-msgstr "Qy_teti:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Co_untry:"
-msgstr "Sh_teti:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Contact"
-msgstr "Kontakti"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Cou_ntry:"
-msgstr "Shte_ti:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Current _password:"
-msgstr "_Fjalëkalimi aktual:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr "Emri dhe mbiemri"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Hom_e:"
-msgstr "Shtë_pi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "P.O. _box:"
-msgstr "Kutia e po_stës:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P._O. box:"
-msgstr "Kutia e p_ostës:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "Personal Info"
-msgstr "Të dhëna personale"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-#: ../capplets/about-me/gnome-about-me-password.c:938
-msgid ""
-"Please type your password again in the <b>Retype new password</b> field."
-msgstr "Rishkruaj fjalëkalimin në fushën e <b>Rishkruaj fjalëkalimin e ri</b>."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "Select your photo"
-msgstr "Zgjidh fotografinë"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-msgid "State/Pro_vince:"
-msgstr "Shteti/Rre_thi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid ""
-"To change your password, enter your current password in the field below and "
-"click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for "
-"verification and click <b>Change password</b>."
-msgstr ""
-"Për të ndryshuar fjalëkalimin, shkruaj fjalëkalimin aktual në fushën e "
-"mëposhtme dhe kliko tek <b>Autentikimi</b>.\n"
-"Mbas autentikimit, shkruaj fjalëkalimin e ri, rishkruaje për verifikim dhe "
-"kliko tek <b>Ndrysho fjalëkalimin</b>."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid "User name:"
-msgstr "Emri i përdoruesit:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Web _log:"
-msgstr "Di_tari në web:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "Wor_k:"
-msgstr "Pun_a:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "Work _fax:"
-msgstr "_Fax në punë:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "Zip/_Postal code:"
-msgstr "Zip/Kodi i _postës:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "_Address:"
-msgstr "_Adresa:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "_Authenticate"
-msgstr "_Autentikimi"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Department:"
-msgstr "_Dipartimenti:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Groupwise:"
-msgstr "_Groupwise:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Home page:"
-msgstr "Faqja në w_eb:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_Home:"
-msgstr "_Shtëpia:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Jabber:"
-msgstr "_Jabber:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Manager:"
-msgstr "_Manageri:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_Mobile:"
-msgstr "_Celulari:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_New password:"
-msgstr "Fjalëkalimi i _ri:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Profession:"
-msgstr "_Profesioni:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Retype new password:"
-msgstr "_Rishkruaj fjalëkalimin e ri:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_State/Province:"
-msgstr "_Shteti/Rrethi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:55
-msgid "_Title:"
-msgstr "_Titulli:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:56
-msgid "_Work:"
-msgstr "_Puna:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:57
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:58
-msgid "_Zip/Postal code:"
-msgstr "_Zip/Kodi i postës:"
-
-#: ../capplets/about-me/gnome-about-me-password.c:162
-msgid "Child exited unexpectedly"
-msgstr "Biri doli në menyrë të papritur"
-
-#: ../capplets/about-me/gnome-about-me-password.c:297
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr "I pamundur ndalimi i kanalit të IO backend_stdin: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:310
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr "I pamundur ndalimi i kanalit të IO backend_stdout: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:409
-msgid "Authenticated!"
-msgstr "Autentikuar!"
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:475
-#: ../capplets/about-me/gnome-about-me-password.c:551
-msgid ""
-"Your password has been changed since you initially authenticated! Please re-"
-"authenticate."
-msgstr ""
-"Fjalëkalimi është ndryshuar që nga autentikimi fillestar. Kryej përsëri "
-"autentikimin."
-
-#: ../capplets/about-me/gnome-about-me-password.c:477
-msgid "That password was incorrect."
-msgstr "Fjalëkalimi nuk ishte i vlefshëm."
-
-#: ../capplets/about-me/gnome-about-me-password.c:524
-msgid "Your password has been changed."
-msgstr "Fjalëkalimi juaj është ndryshuar."
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:534
-#, c-format
-msgid "System error: %s."
-msgstr "Gabim sistemi: %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:537
-msgid "The password is too short."
-msgstr "Fjalëkalimi është tepër i shkurtër."
-
-#: ../capplets/about-me/gnome-about-me-password.c:540
-msgid "The password is too simple."
-msgstr "Fjalëkalimi është tepër i thjeshtë."
-
-#: ../capplets/about-me/gnome-about-me-password.c:543
-msgid "The old and new passwords are too similar."
-msgstr "Fjalëkalimi i ri është tepër i ngjashëm me të vjetrin."
-
-#: ../capplets/about-me/gnome-about-me-password.c:545
-msgid "The new password must contain numeric or special character(s)."
-msgstr "Fjalëkalimi i ri mund të përmbajë simbole numerikë ose specialë."
-
-#: ../capplets/about-me/gnome-about-me-password.c:548
-msgid "The old and new passwords are the same."
-msgstr "Fjalëkalimi i ri është njësoj me fjalëkalimin e vjetër."
-
-#. translators: Unable to launch <program>: <error message>
-#: ../capplets/about-me/gnome-about-me-password.c:820
-#, c-format
-msgid "Unable to launch %s: %s"
-msgstr "E pamundur nisja e %s: %s"
-
-#: ../capplets/about-me/gnome-about-me-password.c:824
-msgid "Unable to launch backend"
-msgstr "E pamundur nisja e backend"
-
-#: ../capplets/about-me/gnome-about-me-password.c:825
-msgid "A system error has occurred"
-msgstr "U ndesh një gabim sistemi"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:845
-msgid "Checking password..."
-msgstr "Kontrolli i fjalëkalimit..."
-
-#: ../capplets/about-me/gnome-about-me-password.c:932
-msgid "Click <b>Change password</b> to change your password."
-msgstr "Kliko tek <b>Ndrysho fjalëkalimin</b> për të ndryshuar fjalëkalimin."
-
-#: ../capplets/about-me/gnome-about-me-password.c:935
-msgid "Please type your password in the <b>New password</b> field."
-msgstr "Shkruaj fjalëkalimin tek fusha e <b>Fjalëkalimi i ri</b>."
-
-#: ../capplets/about-me/gnome-about-me-password.c:941
-msgid "The two passwords are not equal."
-msgstr "Dy fjalëkalimet nuk përputhen."
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Assistive Technologies</b>"
-msgstr "<b>Teknollogjitë asistuese</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Preferences</b>"
-msgstr "<b>Preferimet</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid "Accessible Lo_gin"
-msgstr "Hy_rje e përshtatshme"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technologies Preferences"
-msgstr "Preferimet e teknollogjive asistuese"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid ""
-"Changes to enable assistive technologies will not take effect until your "
-"next log in."
-msgstr ""
-"Nryshimet për aktivizimin e teknollogjive asistuese nuk do të kenë efekt "
-"deri në hyrjen e ardhshme."
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Close and _Log Out"
-msgstr "Mbyll dhe di_l jashtë"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "Jump to Preferred Applications dialog"
-msgstr "Shkon tek dialogu Aplikativët e preferuar"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "Jump to the Accessible Login dialog"
-msgstr "Shkon tek dialogu Hyrje e përshtatshme"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "Jump to the Keyboard Accessibility dialog"
-msgstr "Shkon tek dialogu Përshtatshmëria e tastierës"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "Jump to the Mouse Accessibility dialog"
-msgstr "Shkon tek dialogu Përshtatshmëria e mouse"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
-msgid "_Enable assistive technologies"
-msgstr "_Aktivizo teknologjitë asistuese"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
-msgid "_Keyboard Accessibility"
-msgstr "Përshtatshmëria e _tastierës"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
-msgid "_Mouse Accessibility"
-msgstr "Përshtatshmëria e _mouse"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
-msgid "_Preferred Applications"
-msgstr "Aplikativë të _preferuar"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technologies"
-msgstr "Teknollogjitë asistuese"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Choose which accessibility features to enable when you log in"
-msgstr "Zgjidh çfarë karakteristika përshtatshmërie të akivizohen në hyrje"
-
-#: ../capplets/appearance/appearance-desktop.c:629
-msgid "Add Wallpaper"
-msgstr "Shto sfond ekrani"
-
-#: ../capplets/appearance/appearance-desktop.c:665
-msgid "All files"
-msgstr "Të gjithë file"
-
-#: ../capplets/appearance/appearance-font.c:494
-msgid "Font may be too large"
-msgstr "Shkronja mund të jetë tepër e madhe"
-
-#: ../capplets/appearance/appearance-font.c:498
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
-"përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një madhësie më të "
-"vogël se %d."
-msgstr[1] ""
-"Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
-"përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një madhësie më të "
-"vogël se %d."
-
-#: ../capplets/appearance/appearance-font.c:511
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
-"përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një gërme me "
-"madhësi më të vogël."
-msgstr[1] ""
-"Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
-"përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një gërme me "
-"madhësi më të vogël."
-
-#: ../capplets/appearance/appearance-font.c:533
-msgid "Use previous font"
-msgstr "Përdor gërmën paraardhëse"
-
-#: ../capplets/appearance/appearance-font.c:535
-msgid "Use selected font"
-msgstr "Përdor gërmën e zgjedhur"
-
-#: ../capplets/appearance/appearance-main.c:107
-msgid "Specify the filename of a theme to install"
-msgstr "Specifiko emrin e file të një teme për tu instaluar"
-
-#: ../capplets/appearance/appearance-main.c:108
-msgid "filename"
-msgstr "EMRI_FILE"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/appearance/appearance-main.c:115
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
-msgstr ""
-"Specifiko emrin e faqes për tu shfaqur (theme|background|fonts|interface)"
-
-#: ../capplets/appearance/appearance-main.c:116
-#: ../capplets/default-applications/gnome-da-capplet.c:880
-#: ../capplets/mouse/gnome-mouse-properties.c:444
-msgid "page"
-msgstr "faqe"
-
-#: ../capplets/appearance/appearance-main.c:123
-msgid "[WALLPAPER...]"
-msgstr "[SFOND EKRANI...]"
-
-#: ../capplets/appearance/appearance-style.c:167
-#: ../capplets/common/gnome-theme-info.c:442
-#: ../capplets/common/gnome-theme-info.c:634
-msgid "Default Pointer"
-msgstr "Kursori i paracaktuar"
-
-#: ../capplets/appearance/appearance-style.c:229
-#: ../capplets/appearance/appearance-themes.c:686
-msgid "Install"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
+msgstr "Gërmat për _aplikativët:"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Aplikativë të preferuar"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
 msgstr "Instalo"
 
-#: ../capplets/appearance/appearance-style.c:249
-#: ../capplets/common/gnome-theme-info.c:1644
-#, c-format
-msgid ""
-"This theme will not look as intended because the required GTK+ theme engine "
-"'%s' is not installed."
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Hap"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_Detaje"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Kërko"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
-"Tema nuk do të shfaqet sikurse parashikuar pasi nuk është instaluar motori i "
-"nevojshëm GTK+ i temës '%s'."
 
-#: ../capplets/appearance/appearance-themes.c:674
-msgid "Apply Background"
-msgstr "Apliko sfondin"
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Çaktivizuar"
 
-#: ../capplets/appearance/appearance-themes.c:678
-msgid "Apply Font"
-msgstr "Apliko gërmën"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "Rr_otullimi"
 
-#: ../capplets/appearance/appearance-themes.c:682
-msgid "Revert Font"
-msgstr "Rikthe gërmën"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Shfaq opcionet e ndihmës"
 
-#: ../capplets/appearance/appearance-themes.c:712
-msgid ""
-"The current theme suggests a background and a font. Also, the last applied "
-"font suggestion can be reverted."
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Sfondi"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
 msgstr ""
-"Tema e tanishme propozon një sfond dhe një lloj gërmash. Është gjithashtu i "
-"mundur rikthimi i llojit të fundit të gërmave të propozuar të aplikuar."
 
-#: ../capplets/appearance/appearance-themes.c:714
-msgid ""
-"The current theme suggests a background. Also, the last applied font "
-"suggestion can be reverted."
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Përmasat e ekranit"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
 msgstr ""
-"Tema e tanishme propozon një sfond. Është gjithashtu i mundur rikthimi i "
-"llojit të fundit të gërmave të propozuar të aplikuar."
 
-#: ../capplets/appearance/appearance-themes.c:716
-msgid "The current theme suggests a background and a font."
-msgstr "Tema aktuale propozon një sfond dhe një lloj gërme."
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Asnjë sfond ekrani"
 
-#: ../capplets/appearance/appearance-themes.c:718
-msgid ""
-"The current theme suggests a font. Also, the last applied font suggestion "
-"can be reverted."
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
 msgstr ""
-"Tema e tanishme propozon një lloj gërmash. Është gjithashtu i mundur "
-"rikthimi i llojit të fundit të gërmave të propozuar të aplikuar."
 
-#: ../capplets/appearance/appearance-themes.c:720
-msgid "The current theme suggests a background."
-msgstr "Tema aktuale propozon një sfond."
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Tingujt"
 
-#: ../capplets/appearance/appearance-themes.c:722
-msgid "The last applied font suggestion can be reverted."
-msgstr "Aplikimi i llojit të fundit të gërmës së propozuar mund të anullohet."
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: ../capplets/appearance/appearance-themes.c:724
-msgid "The current theme suggests a font."
-msgstr "Tema aktuale propozon një lloj gërme."
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Përshpejtime të personalizuara"
 
-#: ../capplets/appearance/appearance-themes.c:1045
-#: ../capplets/default-applications/gnome-da-capplet.c:630
-#: ../capplets/sound/sound-properties-capplet.c:262
-#: ../capplets/sound/sound-theme.c:648 ../capplets/sound/sound-theme.c:720
-msgid "Custom"
-msgstr "E personalizuar"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Kombinime përshpejtuese nga tastiera"
 
-#: ../capplets/appearance/data/appearance.glade.h:1
-msgid "<b>C_olors</b>"
-msgstr "<b>N_gjyrat</b>"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
 
-# Nuk e di sa është i përshtatshëm, por tani për tani
-# nuk arrij të gjej asgjë më të saktë... provojmë.
-#. font hinting
-#: ../capplets/appearance/data/appearance.glade.h:3
-msgid "<b>Hinting</b>"
-msgstr "<b>Theksimi (hinting)</b>"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:4
-msgid "<b>Menus and Toolbars</b>"
-msgstr "<b>Panelët e menuve dhe instrumentëve</b>"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:5
-msgid "<b>Preview</b>"
-msgstr "<b>Pamja e parë</b>"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:6
-msgid "<b>Rendering</b>"
-msgstr "<b>Paraqitja në ekran</b>"
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
 
-# Nuk është aspak termi më i përshtatshëm...
-#: ../capplets/appearance/data/appearance.glade.h:7
-msgid "<b>Smoothing</b>"
-msgstr "<b>Lëmimi (smoothing)</b>"
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:8
-msgid "<b>Subpixel Order</b>"
-msgstr "<b>Renditja subpixel</b>"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:9
-msgid "<b>_Wallpaper</b>"
-msgstr "<b>_Sfondi i ekranit</b>"
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:10
-msgid "Appearance Preferences"
-msgstr "Preferimet e paraqitjes"
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:11
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Tingull prove"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Lloji i paralajmërimit"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Gërmat për _aplikativët:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Email</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "_Stili:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "E paracaktuar"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Sfondi"
 
-#: ../capplets/appearance/data/appearance.glade.h:12
-msgid "Best _shapes"
-msgstr "Optimizo _formën"
-
-#: ../capplets/appearance/data/appearance.glade.h:13
-msgid "Best co_ntrast"
-msgstr "Optimizo ko_ntrastin"
-
-#: ../capplets/appearance/data/appearance.glade.h:14
-msgid "C_ustomize..."
-msgstr "P_ersonalizo..."
-
-#: ../capplets/appearance/data/appearance.glade.h:15
-msgid "C_ut"
-msgstr "P_reje"
-
-#: ../capplets/appearance/data/appearance.glade.h:16
-msgid "Changing your cursor theme takes effect the next time you log in."
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
 msgstr ""
-"Ndryshimet në temën tuaj të kursorit do të kenë efekt në hyrjen e ardhshme."
 
-#: ../capplets/appearance/data/appearance.glade.h:17
-msgid "Colors"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Paraqitja"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Përmasat e ekranit"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Kursor i bardhë i madh"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "EMRI_FILE"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "EMRI_FILE"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Kopjimi i file"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Të gjithë file"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Shto..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "Hiq nga të preferuarit"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Detaje"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "minuta"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "_Mesatar"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "minuta"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "minuta"
+
+#: panels/color/cc-color-panel.ui:663
+#, fuzzy
+msgid "Native to display"
+msgstr "_Zbulo ekranet"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
 msgstr "Ngjyrat"
 
-#: ../capplets/appearance/data/appearance.glade.h:18
-msgid "Controls"
-msgstr "Kontrollet"
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:19
-msgid "Customize Theme"
-msgstr "Personalizo temën"
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:20
-msgid "D_etails..."
-msgstr "D_etaje..."
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Zgjidh figurën"
 
-#: ../capplets/appearance/data/appearance.glade.h:21
-msgid "Des_ktop font:"
-msgstr "Gërmat për h_apësirën e punës:"
+# #-#-#-#-#  glade3.HEAD.sq.po (glade3 HEAD)  #-#-#-#-#
+# (pofilter) accelerators: accelerator _ is missing from translation
+# #-#-#-#-#  glade3.gnome-2-22.sq.po (glade3 gnome-2-22)  #-#-#-#-#
+# (pofilter) accelerators: accelerator _ is missing from translation
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Zgjidh"
 
-#: ../capplets/appearance/data/appearance.glade.h:22
-msgid "Edit"
-msgstr "Ndrysho"
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Sipas _gjuhës"
 
-#: ../capplets/appearance/data/appearance.glade.h:23
-msgid "Font Rendering Details"
-msgstr "Detaje në lidhje me shfaqjen e shkronjave"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:24
-msgid "Fonts"
-msgstr "Llojet e gërmave"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:25
-msgid "Gra_yscale"
-msgstr "Shkallë e ngjyrës _gri"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:26
-msgid "Icons"
-msgstr "Ikonat"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:27
-msgid "Interface"
-msgstr "Interfaqja"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:28
-msgid "Large"
-msgstr "E madhe"
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_Koha në dispozicion:"
 
-#: ../capplets/appearance/data/appearance.glade.h:29
-msgid "N_one"
-msgstr "M_os përdor"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:30
-msgid "New File"
-msgstr "File i ri"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:31
-msgid "Open File"
-msgstr "Hap file"
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:32
-msgid "Open a dialog to specify the color"
-msgstr "Hap një dialog për të përcaktuar ngjyrën"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:33
-msgid "Pointer"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Kërko"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "Von_esa:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Çaktivizuar"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "sekonda"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Kale_ndari:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Kale_ndari:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Hap me aplikativin e paracaktuar"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Hap me aplikativin e paracaktuar"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Apliko gërmën"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "_Zbulo ekranet"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+#, fuzzy
+msgid "Mirror"
+msgstr "Gabim"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<b>Orientimi i mouse</b>"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Përmasat"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Intervali i ri_freskimit:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Përqindja e plotësuar"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Filtri"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Nga URI"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "minuta"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+#, fuzzy
+msgid "Displays"
+msgstr "_Zbulo ekranet"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Dispozitivët"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Emri dhe mbiemri"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Terminali i GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Dritarja në minimum"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Dispozitivët"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Dispozitivët"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Riemërto..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Informacione"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:16
+#, fuzzy
+msgid "Pause playback"
+msgstr "Riprodhimi i zë_rit:"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Riprodhimi i zë_rit:"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "Pushim gjatë shkrimit"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+# Hiqet web browser pasi rezulton
+# në listën e web browser
+#: panels/keyboard/01-launchers.xml.in:12
+#, fuzzy
+msgid "Launch web browser"
+msgstr "Epiphany"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Kërko"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Sistemi"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:6
+#, fuzzy
+msgid "Lock screen"
+msgstr "Blloko ekranin"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Përdorshmëria"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+#, fuzzy
+msgid "Options"
+msgstr "Veprimi"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+#, fuzzy
+msgid "Move Down"
+msgstr "Lëviz poshtë"
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Preferime"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Opsionet e planimetrisë së tastierës"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "Kutitë e _input:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "_Përdor të njëjtin host për të gjithë protokollet"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Mouse nga tastiera"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Kombinime përshpejtuese nga tastiera"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Përshpejtime të personalizuara"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Veprimi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Kombinimi përshpejtues"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Kombinimi përshpejtues"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Përshpejtime të personalizuara"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Kombinimi përshpejtues"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Kombinime përshpejtuese nga tastiera"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "_Emri:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "K_omanda:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Kombinimi përshpejtues"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Kombinimi përshpejtues"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Asgjë"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_Rikthe vlerat e paracaktuara"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastiera"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Përcakton të dhënat vetiake personale"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Të përgjithshme"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Majtas"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Djathtas"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
 msgstr "Kursori"
 
-#: ../capplets/appearance/data/appearance.glade.h:34
-msgid "R_esolution:"
-msgstr "D_allueshmëria:"
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:35
-msgid "Save File"
-msgstr "Ruaj file"
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Mouse"
 
-#: ../capplets/appearance/data/appearance.glade.h:36
-msgid "Save Theme As..."
-msgstr "Ruaj temën si..."
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Mouse nga tastiera"
 
-#: ../capplets/appearance/data/appearance.glade.h:37
-msgid "Save _As..."
-msgstr "Ru_aj si..."
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:38
-msgid "Save _background image"
-msgstr "Ruaj figurën e s_fondit"
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:39
-msgid "Show _icons in menus"
-msgstr "Shfaq _ikonat në menu"
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:40
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Përshpejtimi:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Buton i klikuar"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Përshpejtimi:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Gërmat për _aplikativët:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Dispozitivët"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Veprimi"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "I palidhur"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Server rrjeti"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Fjalëkalimi:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "_Fjalëkalimi aktual:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Mënyra përshpejt"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+#, fuzzy
+msgid "Link speed"
+msgstr "Shpejtësia e pulsimit të kursorit"
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Adresa"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Adresa"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Adresa"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Kursori i paracaktuar"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Emri:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Adresa:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Adresa:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Çaktivizuar"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Adresa"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adresa"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "Zbulim automatik"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "minuta"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Proxy i rrjetit"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Veprimi"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "Adresa"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy i rrjetit"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "Proxy H_TTP:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "Proxy H_TTP:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Host S_ocks:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "Host-et e shpërfillur"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "Proxy H_TTP:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "Proxy H_TTP:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "Proxy _FTP:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "_URL e autokonfigurimit:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Server rrjeti"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Fjalëkalimi:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Shfaq opcionet e ndihmës"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "Autentikuar!"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "Të gjithë file"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Përdor autentikim</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "Përdorue_si:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Fjalëkalimi:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "Fjalëkalimi i _ri:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_Autentikimi"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Rishkruaj fjalëkalimin e ri:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_Autentikimi"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "E paracaktuar"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "File i sistemit"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Rr_otullimi"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "File audio"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Përdor autentikim</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "minuta"
+msgstr[1] "minuta"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minuta"
+msgstr[1] "minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "minuta"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+#, fuzzy
+msgid "Battery"
+msgstr "Paralajmërim nga bateria"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Dispozitivët"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Mënyra përshpejt"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Pasqyra e ekranit"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Përmasat e ekranit"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+#, fuzzy
+msgid "On _Battery Power"
+msgstr "Paralajmërim nga bateria"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Vonesa:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "Kursori"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#, fuzzy
+msgid "Add Printer"
+msgstr "Kursori"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Autentikuar!"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "Përdorue_si:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Veprimi"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+# #-#-#-#-#  glade3.HEAD.sq.po (glade3 HEAD)  #-#-#-#-#
+# (pofilter) accelerators: accelerator _ is missing from translation
+# #-#-#-#-#  glade3.gnome-2-22.sq.po (glade3 gnome-2-22)  #-#-#-#-#
+# (pofilter) accelerators: accelerator _ is missing from translation
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Zgjidh"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_Autentikimi"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autentikimi"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Provë"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Detaje në lidhje me shfaqjen e shkronjave"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "_Rikthe vlerat e paracaktuara"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+#, fuzzy
+msgid "Remove Printer"
+msgstr "Hiq nga të preferuarit"
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Modele"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Sigurohu që mini-aplikativi të jetë instaluar sikurse duhet"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "_Ekzekuto në nisje"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "Kursori"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "Normal"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Aktivitete të përbashkët"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Të gjithë file"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Pamja e parë:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "_Dipartimenti:"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "Përfundimi i seancës"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+#, fuzzy
+msgid "_Language"
+msgstr "_Gjuha:"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Blloko ekranin"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+# Hiqet music player
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "Muine"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Veprimi"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Blloko ekranin"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+#, fuzzy
+msgid "Screen"
+msgstr "Blloko ekranin"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Përmasat e ekranit"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Të tjerë"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Veprimi"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Gërmat për _aplikativët:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Kërko"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Server rrjeti"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Hapësira e punës"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Fjalëkalimi:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Hapësira e punës"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Kontrolli UI"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "I palidhur"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Kopjo"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Autentikimi"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Emri i përdoruesit:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Sistemi"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Dispozitivët"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Provë"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Konfigurimi i proxy"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Dispozitivët"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Paralajmërim sonor"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+# #-#-#-#-#  gnome-icon-theme.HEAD.sq.po (gnome-icon-theme.HEAD)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# #-#-#-#-#  gnome-icon-theme.gnome-2-22.sq.po (gnome-icon-theme.HEAD)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Zëri"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Emri:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Dispozitivët"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Dispozitivët"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>Pulsimi i kursorit</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Kursor pulsues në fushat me tekst"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Shpejtësia:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Shpejtësia e pulsimit të kursorit"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Shpejtësia e pulsimit të kursorit"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
+msgstr "<b>Klik dytësor i simuluar</b>"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+#, fuzzy
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "_Nis klikimin dytësor duke mbajtur shtypur pulsantin kryesor"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kombinimi përshpejtues"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+#, fuzzy
+msgid "Secondary click delay"
+msgstr "Klik dytësor:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "D_opio klik:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+#, fuzzy
+msgid "Trigger a click when the pointer hovers"
+msgstr "F_illo klikimin kur ndalon lëvizja e kursorit"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "Von_esa:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kombinimi përshpejtues"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "Kufiri i lë_vizjes:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "E vogël"
 
-#: ../capplets/appearance/data/appearance.glade.h:41
-msgid ""
-"Solid color\n"
-"Horizontal gradient\n"
-"Vertical gradient"
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "E madhe"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Përsëritja e pulsantëve</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Pë_rsërit gërmën përderisa pulsanti mbahet i shtypur"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Shpejtësia e përsëritjes së pulsantëve"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Shpejtësia e përsëritjes së pulsantëve"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "Kontrolli i shkrimit"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "<b>Qëndrimi i pulsantëve</b>"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
 msgstr ""
-"Ngjyrë e njëtrajtshme\n"
-"Gradient horizontal\n"
-"Gradient vertikal"
 
-#: ../capplets/appearance/data/appearance.glade.h:44
-msgid "Sub_pixel (LCDs)"
-msgstr "Sub_pixel (LCD)"
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Çaktivizo qëndrimin e pulsantëve nëse shtypen dy pulsantë së bashku"
 
-#: ../capplets/appearance/data/appearance.glade.h:45
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "Lëmim i sub_pixel (LCD)"
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Sinjal akustik kur shtypet një _ndryshues"
 
-#: ../capplets/appearance/data/appearance.glade.h:46
-msgid "Text"
-msgstr "Tekst"
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "<b>Ngadalsimi i pulsantëve</b>"
 
-#: ../capplets/appearance/data/appearance.glade.h:47
-msgid ""
-"Text below items\n"
-"Text beside items\n"
-"Icons only\n"
-"Text only"
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
 msgstr ""
-"Teksti poshtë elementëve\n"
-"Teksti anash elementëve\n"
-"Vetëm ikonat\n"
-"Vetëm teksti"
 
-#: ../capplets/appearance/data/appearance.glade.h:51
-msgid "The current controls theme does not support color schemes."
-msgstr "Tema aktuale e kontrolleve nuk suporton skemat e ngjyrave."
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kombinimi përshpejtues"
 
-#: ../capplets/appearance/data/appearance.glade.h:52
-msgid "Theme"
-msgstr "Tema"
-
-#: ../capplets/appearance/data/appearance.glade.h:53
-msgid ""
-"Tiled\n"
-"Zoom\n"
-"Centered\n"
-"Scaled\n"
-"Fill screen"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
 msgstr ""
-"Figurë e përsëritur\n"
-"E zmadhuar\n"
-"Në qendër\n"
-"E shkallëzuar\n"
-"Përshtatur sipas ekranit"
 
-#: ../capplets/appearance/data/appearance.glade.h:58
-msgid "Toolbar _button labels:"
-msgstr "Etiketat e _butonëve të panelit të instrumentëve:"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
 
-#. vertical hinting, pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:60
-msgid "VB_GR"
-msgstr "VB_GR"
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Sinjal akustik kur shtyp_et një pulsant"
 
-#: ../capplets/appearance/data/appearance.glade.h:61
-msgid "Window Border"
-msgstr "Bordi i dritares"
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Sinjal akustik kur pr_anohet një pulsant"
 
-#: ../capplets/appearance/data/appearance.glade.h:62
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
-msgid "_Add..."
-msgstr "_Shto..."
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Sinjal akustik kur refu_zohet një pulsant"
 
-#: ../capplets/appearance/data/appearance.glade.h:63
-msgid "_Application font:"
-msgstr "Gërmat për _aplikativët:"
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "<b>Shtypja e përafërt e pulsantëve</b>"
 
-#. pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:65
-msgid "_BGR"
-msgstr "_BGR"
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Shpërf_ill shtypje të shpejta të njëpasnjëshme pulsantësh"
 
-#: ../capplets/appearance/data/appearance.glade.h:66
-msgid "_Copy"
-msgstr "_Kopjo"
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kombinimi përshpejtues"
 
-#: ../capplets/appearance/data/appearance.glade.h:67
-msgid "_Description:"
-msgstr "_Përshkrimi:"
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:68
-msgid "_Document font:"
-msgstr "Gërmat për _dokumentet:"
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:69
-msgid "_Editable menu shortcut keys"
-msgstr "Kombinimi i tasteve për menutë e ndryshu_eshme"
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+#, fuzzy
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Funksionet e _açesibilitetit mund të aktivizohen/çaktivizohen me kombinime "
+"përshpejtuese nga tastiera"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "Përshtatshmëria e _tastierës"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "E madhe"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+# Emri i vetë aplikativit
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Linux Screen Reader"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "File audio"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Sinjal akustik kur aktivizohen apo çaktivizohen funksionet e _açesibilitetit"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "Paralajmërim vizual"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Tastierë në ekran e GNOME"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Përsëritja e pulsantëve</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Pulsimi i kursorit</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Mouse nga tastiera"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Kursor i madh"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "<b>Koha në dispozicion për dopio klik</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "D_opio klik:"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+#, fuzzy
+msgid "Visual Alerts"
+msgstr "Paralajmërim vizual"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Ndriço të gjithë ekranin"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Ndriço dritaren"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Ndriço të gjithë ekranin"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+#, fuzzy
+msgid "Left Half"
+msgstr "Majtas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+#, fuzzy
+msgid "Right Half"
+msgstr "Djathtas"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "_Opsionet e planimetrisë..."
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "Orca me zmadhues"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "Ngjyrat"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Kontakti"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Asgjë"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "I _plotë"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "Ngjyrat"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "File i sistemit"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "Zbrazje koshi"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "Lëviz në kosh"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "Terminator"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Fjalëkalimi i _ri:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Zgjidh file e tingullit"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Mos pë_rdor"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Pamja e parë:"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Ndrysho fjalëkalimin"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Bashkësi ndryshimesh"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "_Fjalëkalimi aktual:"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "Fjalëkalimi i _ri:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Ndrysho fjalëkalimin"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Fjalëkalimi është tepër i shkurtër."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "Fjalëkalimi i _ri:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Emri dhe mbiemri"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Ndrysho"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Kontrollet"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Hap me aplikativin e paracaktuar"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Të tjerë"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Butonët e paralajmërimit"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Për të ndryshuar një pulsant përshpejtimi, kliko në rreshtin përkatës dhe "
+"shkruaj kombinimin e ri, ose shtyp «Backspace» për ta fshirë."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Kontrolli i shkrimit"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Buton i klikuar"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Buton i klikuar"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Buton i klikuar"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Planimetria"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Dritarja prind"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Klik dytësor:"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Dritaret"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Kliko OK për të mbaruar."
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Klik dytësor:"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Dritaret"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Hy_rje e përshtatshme"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Adresa"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Ruaj"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Detaje"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Proxy i rrjetit"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Server rrjeti"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Dispozitivët"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Celulari:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Proxy i rrjetit"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Proxy i rrjetit"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Detaje"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Proxy i rrjetit"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_Autentikimi"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "Server rrjeti"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Bashkësi ndryshimesh"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr ""
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Ndihmë"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Të përgjithshme"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Dalja"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Kërko"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Preferime"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgid "Image/label border"
+#~ msgstr "Bordi i figurës/etiketës"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr ""
+#~ "Gjerësia e kornizës rreth etiketës dhe figurës në dialogun e "
+#~ "paralajmërimit"
+
+#~ msgid "The type of alert"
+#~ msgstr "Lloji i paralajmërimit"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Butonët e shfaqur në dialogun e paralajmërimit"
+
+#~ msgid "Show more _details"
+#~ msgstr "Shfaq më shumë _detaje"
+
+#~ msgid "No Image"
+#~ msgstr "Asnjë figurë"
+
+#~ msgid "Images"
+#~ msgstr "Figura"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "U ndesh një gabim gjatë përpjekjes për marrje informacione mbi rubrikën\n"
+#~ "Evolution Data Server nuk mund të trajtojë protokollin"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "E pamundur hapja e rubrikës"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr ""
+#~ "ID i panjohur hyrje, baza me të dhënat e përdoruesve mund të jetë "
+#~ "korruptuar"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "Informacione mbi %s"
+
+#~ msgid "About Me"
+#~ msgstr "Informacione përdoruesi"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Shtëpi</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Mesazhe të menjëhershëm</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Punë</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Telefoni</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Web</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Punë</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr ""
+#~ "<span size=\"larger\" weight=\"bold\">Ndryshimi i fjalëkalimit personal</"
+#~ "span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "A_dresa:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "A_sistenti:"
+
+#~ msgid "C_ity:"
+#~ msgstr "Qytet_i:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "K_ompania:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Ndrysho fjalëka_limin..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "Ndrysho f_jalëkalimin"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Qy_teti:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "Sh_teti:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "Shte_ti:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "Shtë_pi:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "Kutia e po_stës:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "Kutia e p_ostës:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Të dhëna personale"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "Rishkruaj fjalëkalimin në fushën e <b>Rishkruaj fjalëkalimin e ri</b>."
+
+#~ msgid "Select your photo"
+#~ msgstr "Zgjidh fotografinë"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "Shteti/Rre_thi:"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "Për të ndryshuar fjalëkalimin, shkruaj fjalëkalimin aktual në fushën e "
+#~ "mëposhtme dhe kliko tek <b>Autentikimi</b>.\n"
+#~ "Mbas autentikimit, shkruaj fjalëkalimin e ri, rishkruaje për verifikim "
+#~ "dhe kliko tek <b>Ndrysho fjalëkalimin</b>."
+
+#~ msgid "Web _log:"
+#~ msgstr "Di_tari në web:"
+
+#~ msgid "Wor_k:"
+#~ msgstr "Pun_a:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "_Fax në punë:"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "Zip/Kodi i _postës:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "Faqja në w_eb:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Shtëpia:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Manageri:"
+
+#~ msgid "_Profession:"
+#~ msgstr "_Profesioni:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_Shteti/Rrethi:"
+
+#~ msgid "_Title:"
+#~ msgstr "_Titulli:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Puna:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "_Zip/Kodi i postës:"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "Biri doli në menyrë të papritur"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "I pamundur ndalimi i kanalit të IO backend_stdin: %s"
+
+#, c-format
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "I pamundur ndalimi i kanalit të IO backend_stdout: %s"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr ""
+#~ "Fjalëkalimi është ndryshuar që nga autentikimi fillestar. Kryej përsëri "
+#~ "autentikimin."
+
+#~ msgid "That password was incorrect."
+#~ msgstr "Fjalëkalimi nuk ishte i vlefshëm."
+
+#~ msgid "Your password has been changed."
+#~ msgstr "Fjalëkalimi juaj është ndryshuar."
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "Gabim sistemi: %s."
+
+#~ msgid "The password is too simple."
+#~ msgstr "Fjalëkalimi është tepër i thjeshtë."
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "Fjalëkalimi i ri është tepër i ngjashëm me të vjetrin."
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "Fjalëkalimi i ri mund të përmbajë simbole numerikë ose specialë."
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "Fjalëkalimi i ri është njësoj me fjalëkalimin e vjetër."
+
+#, c-format
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "E pamundur nisja e %s: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "E pamundur nisja e backend"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "U ndesh një gabim sistemi"
+
+#~ msgid "Checking password..."
+#~ msgstr "Kontrolli i fjalëkalimit..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr ""
+#~ "Kliko tek <b>Ndrysho fjalëkalimin</b> për të ndryshuar fjalëkalimin."
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "Shkruaj fjalëkalimin tek fusha e <b>Fjalëkalimi i ri</b>."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "Dy fjalëkalimet nuk përputhen."
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>Teknollogjitë asistuese</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>Preferimet</b>"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "Preferimet e teknollogjive asistuese"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "Nryshimet për aktivizimin e teknollogjive asistuese nuk do të kenë efekt "
+#~ "deri në hyrjen e ardhshme."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Mbyll dhe di_l jashtë"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "Shkon tek dialogu Aplikativët e preferuar"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "Shkon tek dialogu Hyrje e përshtatshme"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "Shkon tek dialogu Përshtatshmëria e tastierës"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "Shkon tek dialogu Përshtatshmëria e mouse"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Aktivizo teknologjitë asistuese"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "Përshtatshmëria e _mouse"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "Aplikativë të _preferuar"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "Teknollogjitë asistuese"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "Zgjidh çfarë karakteristika përshtatshmërie të akivizohen në hyrje"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Shto sfond ekrani"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Shkronja mund të jetë tepër e madhe"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
+#~ "përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një madhësie më "
+#~ "të vogël se %d."
+#~ msgstr[1] ""
+#~ "Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
+#~ "përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një madhësie më "
+#~ "të vogël se %d."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
+#~ "përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një gërme me "
+#~ "madhësi më të vogël."
+#~ msgstr[1] ""
+#~ "Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
+#~ "përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një gërme me "
+#~ "madhësi më të vogël."
+
+#~ msgid "Use previous font"
+#~ msgstr "Përdor gërmën paraardhëse"
+
+#~ msgid "Use selected font"
+#~ msgstr "Përdor gërmën e zgjedhur"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Specifiko emrin e file të një teme për tu instaluar"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "Specifiko emrin e faqes për tu shfaqur (theme|background|fonts|interface)"
+
+#~ msgid "page"
+#~ msgstr "faqe"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[SFOND EKRANI...]"
+
+#, c-format
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "Tema nuk do të shfaqet sikurse parashikuar pasi nuk është instaluar "
+#~ "motori i nevojshëm GTK+ i temës '%s'."
+
+#~ msgid "Apply Background"
+#~ msgstr "Apliko sfondin"
+
+#~ msgid "Revert Font"
+#~ msgstr "Rikthe gërmën"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "Tema e tanishme propozon një sfond dhe një lloj gërmash. Është gjithashtu "
+#~ "i mundur rikthimi i llojit të fundit të gërmave të propozuar të aplikuar."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "Tema e tanishme propozon një sfond. Është gjithashtu i mundur rikthimi i "
+#~ "llojit të fundit të gërmave të propozuar të aplikuar."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "Tema aktuale propozon një sfond dhe një lloj gërme."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "Tema e tanishme propozon një lloj gërmash. Është gjithashtu i mundur "
+#~ "rikthimi i llojit të fundit të gërmave të propozuar të aplikuar."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "Tema aktuale propozon një sfond."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "Aplikimi i llojit të fundit të gërmës së propozuar mund të anullohet."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "Tema aktuale propozon një lloj gërme."
+
+#~ msgid "Custom"
+#~ msgstr "E personalizuar"
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>N_gjyrat</b>"
+
+# Nuk e di sa është i përshtatshëm, por tani për tani
+# nuk arrij të gjej asgjë më të saktë... provojmë.
+#~ msgid "<b>Hinting</b>"
+#~ msgstr "<b>Theksimi (hinting)</b>"
+
+#~ msgid "<b>Menus and Toolbars</b>"
+#~ msgstr "<b>Panelët e menuve dhe instrumentëve</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Pamja e parë</b>"
+
+#~ msgid "<b>Rendering</b>"
+#~ msgstr "<b>Paraqitja në ekran</b>"
+
+# Nuk është aspak termi më i përshtatshëm...
+#~ msgid "<b>Smoothing</b>"
+#~ msgstr "<b>Lëmimi (smoothing)</b>"
+
+#~ msgid "<b>Subpixel Order</b>"
+#~ msgstr "<b>Renditja subpixel</b>"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>_Sfondi i ekranit</b>"
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "Preferimet e paraqitjes"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Optimizo _formën"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Optimizo ko_ntrastin"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "P_ersonalizo..."
+
+#~ msgid "C_ut"
+#~ msgstr "P_reje"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr ""
+#~ "Ndryshimet në temën tuaj të kursorit do të kenë efekt në hyrjen e "
+#~ "ardhshme."
+
+#~ msgid "Customize Theme"
+#~ msgstr "Personalizo temën"
+
+#~ msgid "D_etails..."
+#~ msgstr "D_etaje..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Gërmat për h_apësirën e punës:"
+
+#~ msgid "Fonts"
+#~ msgstr "Llojet e gërmave"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Shkallë e ngjyrës _gri"
+
+#~ msgid "Icons"
+#~ msgstr "Ikonat"
+
+#~ msgid "Interface"
+#~ msgstr "Interfaqja"
+
+#~ msgid "N_one"
+#~ msgstr "M_os përdor"
+
+#~ msgid "New File"
+#~ msgstr "File i ri"
+
+#~ msgid "Open File"
+#~ msgstr "Hap file"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Hap një dialog për të përcaktuar ngjyrën"
+
+#~ msgid "R_esolution:"
+#~ msgstr "D_allueshmëria:"
+
+#~ msgid "Save File"
+#~ msgstr "Ruaj file"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "Ruaj temën si..."
+
+#~ msgid "Save _As..."
+#~ msgstr "Ru_aj si..."
+
+#~ msgid "Save _background image"
+#~ msgstr "Ruaj figurën e s_fondit"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Shfaq _ikonat në menu"
+
+#~ msgid ""
+#~ "Solid color\n"
+#~ "Horizontal gradient\n"
+#~ "Vertical gradient"
+#~ msgstr ""
+#~ "Ngjyrë e njëtrajtshme\n"
+#~ "Gradient horizontal\n"
+#~ "Gradient vertikal"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Sub_pixel (LCD)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Lëmim i sub_pixel (LCD)"
+
+#~ msgid "Text"
+#~ msgstr "Tekst"
+
+#~ msgid ""
+#~ "Text below items\n"
+#~ "Text beside items\n"
+#~ "Icons only\n"
+#~ "Text only"
+#~ msgstr ""
+#~ "Teksti poshtë elementëve\n"
+#~ "Teksti anash elementëve\n"
+#~ "Vetëm ikonat\n"
+#~ "Vetëm teksti"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "Tema aktuale e kontrolleve nuk suporton skemat e ngjyrave."
+
+#~ msgid "Theme"
+#~ msgstr "Tema"
+
+#~ msgid ""
+#~ "Tiled\n"
+#~ "Zoom\n"
+#~ "Centered\n"
+#~ "Scaled\n"
+#~ "Fill screen"
+#~ msgstr ""
+#~ "Figurë e përsëritur\n"
+#~ "E zmadhuar\n"
+#~ "Në qendër\n"
+#~ "E shkallëzuar\n"
+#~ "Përshtatur sipas ekranit"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Etiketat e _butonëve të panelit të instrumentëve:"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "Window Border"
+#~ msgstr "Bordi i dritares"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "_Përshkrimi:"
+
+#~ msgid "_Document font:"
+#~ msgstr "Gërmat për _dokumentet:"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "Kombinimi i tasteve për menutë e ndryshu_eshme"
 
 # #-#-#-#-#  dia.HEAD.sq.po (dia HEAD)  #-#-#-#-#
 #
@@ -944,653 +5892,430 @@ msgstr "Kombinimi i tasteve për menutë e ndryshu_eshme"
 # (pofilter) unchanged: please translate
 # #-#-#-#-#  gnome-terminal.gnome-2-22.sq.po (gnome-terminal.gnome-2-22)  #-#-#-#-#
 # (pofilter) unchanged: please translate
-#: ../capplets/appearance/data/appearance.glade.h:70
-msgid "_File"
-msgstr "_File"
+#~ msgid "_File"
+#~ msgstr "_File"
 
-#: ../capplets/appearance/data/appearance.glade.h:71
-msgid "_Fixed width font:"
-msgstr "Gërma me gjerësi _fikse:"
+#~ msgid "_Fixed width font:"
+#~ msgstr "Gërma me gjerësi _fikse:"
 
-#: ../capplets/appearance/data/appearance.glade.h:72
-msgid "_Full"
-msgstr "I _plotë"
+#~ msgid "_Install..."
+#~ msgstr "_Instalo..."
 
-#: ../capplets/appearance/data/appearance.glade.h:73
-msgid "_Input boxes:"
-msgstr "Kutitë e _input:"
+#~ msgid "_Monochrome"
+#~ msgstr "_Monokromatik"
 
-#: ../capplets/appearance/data/appearance.glade.h:74
-msgid "_Install..."
-msgstr "_Instalo..."
+#~ msgid "_New"
+#~ msgstr "I _ri"
 
-#: ../capplets/appearance/data/appearance.glade.h:75
-msgid "_Medium"
-msgstr "_Mesatar"
+#~ msgid "_Paste"
+#~ msgstr "_Ngjit"
 
-#: ../capplets/appearance/data/appearance.glade.h:76
-msgid "_Monochrome"
-msgstr "_Monokromatik"
+#~ msgid "_Print"
+#~ msgstr "_Printo"
 
-#: ../capplets/appearance/data/appearance.glade.h:77
-msgid "_Name:"
-msgstr "_Emri:"
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
 
-#: ../capplets/appearance/data/appearance.glade.h:78
-msgid "_New"
-msgstr "I _ri"
+#~ msgid "_Selected items:"
+#~ msgstr "Elementët e _zgjedhur:"
 
-#: ../capplets/appearance/data/appearance.glade.h:79
-msgid "_None"
-msgstr "Mos pë_rdor"
+#~ msgid "_Size:"
+#~ msgstr "Madhë_sia:"
 
-#: ../capplets/appearance/data/appearance.glade.h:80
-msgid "_Open"
-msgstr "_Hap"
+#~ msgid "_Slight"
+#~ msgstr "I _lehtë"
 
-#: ../capplets/appearance/data/appearance.glade.h:81
-msgid "_Paste"
-msgstr "_Ngjit"
+#~ msgid "_Tooltips:"
+#~ msgstr "_Propozime:"
 
-#: ../capplets/appearance/data/appearance.glade.h:82
-msgid "_Print"
-msgstr "_Printo"
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
 
-#: ../capplets/appearance/data/appearance.glade.h:83
-msgid "_Quit"
-msgstr "_Dalja"
+#~ msgid "_Window title font:"
+#~ msgstr "Shkronjat për titullin e _dritareve:"
 
-#. pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:85
-msgid "_RGB"
-msgstr "_RGB"
+#~ msgid "_Windows:"
+#~ msgstr "_Dritaret:"
 
-#: ../capplets/appearance/data/appearance.glade.h:86
-msgid "_Reset to Defaults"
-msgstr "_Rikthe vlerat e paracaktuara"
+#~ msgid "dots per inch"
+#~ msgstr "pika për inç"
 
-#: ../capplets/appearance/data/appearance.glade.h:87
-msgid "_Save"
-msgstr "_Ruaj"
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "Personalizon paraqitjen e ambjentit grafik"
 
-#: ../capplets/appearance/data/appearance.glade.h:88
-msgid "_Selected items:"
-msgstr "Elementët e _zgjedhur:"
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "Instalon paketat e temave për pjesë të ndryshme të «desktop»"
 
-#: ../capplets/appearance/data/appearance.glade.h:89
-msgid "_Size:"
-msgstr "Madhë_sia:"
+#~ msgid "Theme Installer"
+#~ msgstr "Instaluesi i temave"
 
-#: ../capplets/appearance/data/appearance.glade.h:90
-msgid "_Slight"
-msgstr "I _lehtë"
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Paketa «Tema e Gnome»"
 
-#: ../capplets/appearance/data/appearance.glade.h:91
-msgid "_Style:"
-msgstr "_Stili:"
+#~ msgid "Slide Show"
+#~ msgstr "Diapozitivë"
 
-#: ../capplets/appearance/data/appearance.glade.h:92
-msgid "_Tooltips:"
-msgstr "_Propozime:"
-
-#. vertical hinting, pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:94
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:95
-msgid "_Window title font:"
-msgstr "Shkronjat për titullin e _dritareve:"
-
-#: ../capplets/appearance/data/appearance.glade.h:96
-msgid "_Windows:"
-msgstr "_Dritaret:"
-
-#: ../capplets/appearance/data/appearance.glade.h:97
-msgid "dots per inch"
-msgstr "pika për inç"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr "Paraqitja"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr "Personalizon paraqitjen e ambjentit grafik"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr "Instalon paketat e temave për pjesë të ndryshme të «desktop»"
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr "Instaluesi i temave"
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr "Paketa «Tema e Gnome»"
-
-#: ../capplets/appearance/gnome-wp-info.c:50
-msgid "No Wallpaper"
-msgstr "Asnjë sfond ekrani"
-
-#: ../capplets/appearance/gnome-wp-item.c:209
-msgid "Slide Show"
-msgstr "Diapozitivë"
-
-#. translators: <b>wallpaper name</b>
-#. * mime type, x pixel(s) by y pixel(s)
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:217
 #, c-format
-msgid ""
-"<b>%s</b>\n"
-"%s, %d %s by %d %s\n"
-"Folder: %s"
-msgstr ""
-"<b>%s</b>\n"
-"%s, %d %s nga %d %s\n"
-"Kartela: %s"
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s by %d %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %d %s nga %d %s\n"
+#~ "Kartela: %s"
 
-#: ../capplets/appearance/gnome-wp-item.c:223
-#: ../capplets/appearance/gnome-wp-item.c:225
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "pixel"
-msgstr[1] "pixel"
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "pixel"
+#~ msgstr[1] "pixel"
 
-#: ../capplets/appearance/theme-installer.c:172
-#: ../capplets/appearance/theme-installer.c:222
-msgid "Cannot install theme"
-msgstr "I pamundur instalimi i temës"
+#~ msgid "Cannot install theme"
+#~ msgstr "I pamundur instalimi i temës"
 
-#: ../capplets/appearance/theme-installer.c:174
 #, c-format
-msgid "The %s utility is not installed."
-msgstr "Programi ndihmues %s nuk është i instaluar."
+#~ msgid "The %s utility is not installed."
+#~ msgstr "Programi ndihmues %s nuk është i instaluar."
 
-#: ../capplets/appearance/theme-installer.c:224
-msgid "There was a problem while extracting the theme."
-msgstr "Është ndeshur një problem gjatë nxjerrjes së temës."
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "Është ndeshur një problem gjatë nxjerrjes së temës."
 
-#: ../capplets/appearance/theme-installer.c:247
-msgid "There was an error installing the selected file"
-msgstr "U ndesh një gabim gjatë instalimit të file të zgjedhur"
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "U ndesh një gabim gjatë instalimit të file të zgjedhur"
 
-#: ../capplets/appearance/theme-installer.c:248
 #, c-format
-msgid "\"%s\" does not appear to be a valid theme."
-msgstr "Mesa duket «%s» nuk është një temë e vlefshme."
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "Mesa duket «%s» nuk është një temë e vlefshme."
 
-#: ../capplets/appearance/theme-installer.c:249
 #, c-format
-msgid ""
-"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
-"you need to compile."
-msgstr ""
-"Mesa duket «%s» nuk është një temë e vlefshme. Mund të jetë një motor teme "
-"që duhet kompiluar paraprakisht."
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "Mesa duket «%s» nuk është një temë e vlefshme. Mund të jetë një motor "
+#~ "teme që duhet kompiluar paraprakisht."
 
-#: ../capplets/appearance/theme-installer.c:288
 #, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "Tema «%s» për GNOME u instalua korrektësisht"
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "Tema «%s» për GNOME u instalua korrektësisht"
 
-#: ../capplets/appearance/theme-installer.c:355
 #, c-format
-msgid "Installation for theme \"%s\" failed."
-msgstr "Instalimi i temës «%s» dështoi."
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "Instalimi i temës «%s» dështoi."
 
-#: ../capplets/appearance/theme-installer.c:393
 #, c-format
-msgid "The theme \"%s\" has been installed."
-msgstr "Tema «%s» u instalua."
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "Tema «%s» u instalua."
 
-#: ../capplets/appearance/theme-installer.c:399
-msgid "Would you like to apply it now, or keep your current theme?"
-msgstr "Mbahet tema aktuale apo aplikohet tema e sapo instaluar?"
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "Mbahet tema aktuale apo aplikohet tema e sapo instaluar?"
 
-#: ../capplets/appearance/theme-installer.c:401
-msgid "Keep Current Theme"
-msgstr "Mbaj temën aktuale"
+#~ msgid "Keep Current Theme"
+#~ msgstr "Mbaj temën aktuale"
 
-#: ../capplets/appearance/theme-installer.c:403
-msgid "Apply New Theme"
-msgstr "Apliko temën e re"
+#~ msgid "Apply New Theme"
+#~ msgstr "Apliko temën e re"
 
-#: ../capplets/appearance/theme-installer.c:506
-msgid "Failed to create temporary directory"
-msgstr "Krijimi i kartelës së përkohshme dështoi"
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Krijimi i kartelës së përkohshme dështoi"
 
-#: ../capplets/appearance/theme-installer.c:569
-msgid "New themes have been successfully installed."
-msgstr "Temat e reja u instaluan me sukses."
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "Temat e reja u instaluan me sukses."
 
-#: ../capplets/appearance/theme-installer.c:594
-msgid "No theme file location specified to install"
-msgstr "Nuk është dhënë pozicioni i file të temës për tu instaluar"
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Nuk është dhënë pozicioni i file të temës për tu instaluar"
 
-#: ../capplets/appearance/theme-installer.c:615
 #, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"Të drejta të pamjaftueshme për të instaluar temën në:\n"
-"%s"
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Të drejta të pamjaftueshme për të instaluar temën në:\n"
+#~ "%s"
 
-#: ../capplets/appearance/theme-installer.c:685
-msgid "Select Theme"
-msgstr "Zgjidh temën"
+#~ msgid "Select Theme"
+#~ msgstr "Zgjidh temën"
 
-#: ../capplets/appearance/theme-installer.c:689
-msgid "Theme Packages"
-msgstr "Paketa teme"
+#~ msgid "Theme Packages"
+#~ msgstr "Paketa teme"
 
-#: ../capplets/appearance/theme-save.c:91
 #, c-format
-msgid "Theme name must be present"
-msgstr "Duhet të jepet emri i temës"
+#~ msgid "Theme name must be present"
+#~ msgstr "Duhet të jepet emri i temës"
 
-#: ../capplets/appearance/theme-save.c:154
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Tema ekziston rregullisht. Vazhdon me zëvendësimin?"
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Tema ekziston rregullisht. Vazhdon me zëvendësimin?"
 
-#: ../capplets/appearance/theme-save.c:155
-#: ../capplets/common/file-transfer-dialog.c:450
-msgid "_Overwrite"
-msgstr "M_bishkruaj"
+#~ msgid "_Overwrite"
+#~ msgstr "M_bishkruaj"
 
-#: ../capplets/appearance/theme-util.c:74
-msgid "Would you like to delete this theme?"
-msgstr "Eleminon këtë temë?"
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Eleminon këtë temë?"
 
-#: ../capplets/appearance/theme-util.c:124
-msgid "Theme cannot be deleted"
-msgstr "Eleminimi i temës nuk është i mundur"
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "Eleminimi i temës nuk është i mundur"
 
-#: ../capplets/appearance/theme-util.c:251
-msgid "Could not install theme engine"
-msgstr "I pamundur instalimi i motorit të temës"
+#~ msgid "Could not install theme engine"
+#~ msgstr "I pamundur instalimi i motorit të temës"
 
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"E pamundur nisja e menazhuesit të rregullimeve 'gnome-settings-daemon'.\n"
-"Nëse menazhuesi i rregullimeve të GNOME nuk është duke punuar, disa nga "
-"zgjedhjet mund të mos kenë efekt. Kjo situatë tregon një problem të mundshëm "
-"Bonobo, ose që një menazhues rregullimesh tjetër jo i GNOME (p.sh. i KDE) "
-"është në ekzekutim duke krijuar konflikte me menazhuesin e rregullimeve të "
-"GNOME."
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "E pamundur nisja e menazhuesit të rregullimeve 'gnome-settings-daemon'.\n"
+#~ "Nëse menazhuesi i rregullimeve të GNOME nuk është duke punuar, disa nga "
+#~ "zgjedhjet mund të mos kenë efekt. Kjo situatë tregon një problem të "
+#~ "mundshëm Bonobo, ose që një menazhues rregullimesh tjetër jo i GNOME (p."
+#~ "sh. i KDE) është në ekzekutim duke krijuar konflikte me menazhuesin e "
+#~ "rregullimeve të GNOME."
 
-#: ../capplets/common/capplet-stock-icons.c:67
 #, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr "I pamundur ngarkimi i ikonës së stock «%s»\n"
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "I pamundur ngarkimi i ikonës së stock «%s»\n"
 
-#: ../capplets/common/capplet-util.c:80
 #, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Gabim gjatë shfaqjes së ndihmës: %s"
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Gabim gjatë shfaqjes së ndihmës: %s"
 
-#: ../capplets/common/file-transfer-dialog.c:98
 #, c-format
-msgid "Copying file: %u of %u"
-msgstr "Kopjimi i file: %u në %u"
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Kopjimi i file: %u në %u"
 
-#: ../capplets/common/file-transfer-dialog.c:145
 #, c-format
-msgid "Copying '%s'"
-msgstr "Kopjimi i «%s»"
+#~ msgid "Copying '%s'"
+#~ msgstr "Kopjimi i «%s»"
 
-#: ../capplets/common/file-transfer-dialog.c:185
-#: ../capplets/common/file-transfer-dialog.c:312
-msgid "Copying files"
-msgstr "Kopjimi i file"
+#~ msgid "Parent window of the dialog"
+#~ msgstr "Dritarja prind e dritares së dialogut"
 
-#: ../capplets/common/file-transfer-dialog.c:224
-msgid "Parent Window"
-msgstr "Dritarja prind"
+#~ msgid "URI currently transferring from"
+#~ msgstr "URI nga ku po transferohet aktualisht"
 
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Parent window of the dialog"
-msgstr "Dritarja prind e dritares së dialogut"
+#~ msgid "To URI"
+#~ msgstr "Tek URI"
 
-#: ../capplets/common/file-transfer-dialog.c:231
-msgid "From URI"
-msgstr "Nga URI"
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI drejt së cilës po transferohet aktualisht"
 
-#: ../capplets/common/file-transfer-dialog.c:232
-msgid "URI currently transferring from"
-msgstr "URI nga ku po transferohet aktualisht"
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Përqindja e transferimit plotësuar për momentin"
 
-#: ../capplets/common/file-transfer-dialog.c:239
-msgid "To URI"
-msgstr "Tek URI"
+#~ msgid "Current URI index"
+#~ msgstr "Indeksi i URI të tanishëm"
 
-#: ../capplets/common/file-transfer-dialog.c:240
-msgid "URI currently transferring to"
-msgstr "URI drejt së cilës po transferohet aktualisht"
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Indeksi i URI të tanishëm - fillon nga 1"
 
-#: ../capplets/common/file-transfer-dialog.c:247
-msgid "Fraction completed"
-msgstr "Përqindja e plotësuar"
+#~ msgid "Total URIs"
+#~ msgstr "URI gjithsej"
 
-#: ../capplets/common/file-transfer-dialog.c:248
-msgid "Fraction of transfer currently completed"
-msgstr "Përqindja e transferimit plotësuar për momentin"
+#~ msgid "Total number of URIs"
+#~ msgstr "Numri i përgjithshëm i URI"
 
-#: ../capplets/common/file-transfer-dialog.c:255
-msgid "Current URI index"
-msgstr "Indeksi i URI të tanishëm"
-
-#: ../capplets/common/file-transfer-dialog.c:256
-msgid "Current URI index - starts from 1"
-msgstr "Indeksi i URI të tanishëm - fillon nga 1"
-
-#: ../capplets/common/file-transfer-dialog.c:263
-msgid "Total URIs"
-msgstr "URI gjithsej"
-
-#: ../capplets/common/file-transfer-dialog.c:264
-msgid "Total number of URIs"
-msgstr "Numri i përgjithshëm i URI"
-
-#: ../capplets/common/file-transfer-dialog.c:444
 #, c-format
-msgid "File '%s' already exists. Do you want to overwrite it?"
-msgstr "File «%s» ekziston rregullisht. Vazhdon me mbishkrimin e tij?"
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "File «%s» ekziston rregullisht. Vazhdon me mbishkrimin e tij?"
 
-#: ../capplets/common/file-transfer-dialog.c:447
-msgid "_Skip"
-msgstr "_Kapërce"
+#~ msgid "_Skip"
+#~ msgstr "_Kapërce"
 
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Overwrite _All"
-msgstr "Mbishkruaj gjithçk_a"
+#~ msgid "Overwrite _All"
+#~ msgstr "Mbishkruaj gjithçk_a"
 
-#: ../capplets/common/gconf-property-editor.c:133
-msgid "Key"
-msgstr "Kyçi"
+#~ msgid "Key"
+#~ msgstr "Kyçi"
 
-#: ../capplets/common/gconf-property-editor.c:134
-msgid "GConf key to which this property editor is attached"
-msgstr "Kyçi GConf me të cilin ky editor pronësish është i lidhur"
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Kyçi GConf me të cilin ky editor pronësish është i lidhur"
 
-#: ../capplets/common/gconf-property-editor.c:140
-msgid "Callback"
-msgstr "Callback"
+#~ msgid "Callback"
+#~ msgstr "Callback"
 
-#: ../capplets/common/gconf-property-editor.c:141
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr "Kryen këtë callback kur vlera e shoqëruar me kyçin ndryshohet"
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "Kryen këtë callback kur vlera e shoqëruar me kyçin ndryshohet"
 
-#: ../capplets/common/gconf-property-editor.c:146
-msgid "Change set"
-msgstr "Bashkësi ndryshimesh"
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Bashkësi e ndryshimeve të GConf me të dhënat për t'ju dërguar klientit "
+#~ "gconf kur aplikohen ndryshimet"
 
-#: ../capplets/common/gconf-property-editor.c:147
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"Bashkësi e ndryshimeve të GConf me të dhënat për t'ju dërguar klientit gconf "
-"kur aplikohen ndryshimet"
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Callback konvertimi drejt widget"
 
-#: ../capplets/common/gconf-property-editor.c:152
-msgid "Conversion to widget callback"
-msgstr "Callback konvertimi drejt widget"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Callback për tu kryer kur nevoitet konvertimi i të dhënave nga GConf tek "
+#~ "widget"
 
-#: ../capplets/common/gconf-property-editor.c:153
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-"Callback për tu kryer kur nevoitet konvertimi i të dhënave nga GConf tek "
-"widget"
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Callback konvertimi nga widget"
 
-#: ../capplets/common/gconf-property-editor.c:158
-msgid "Conversion from widget callback"
-msgstr "Callback konvertimi nga widget"
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Callback për tu kryer kur nevoitet konvertimi i të dhënave nga widget në "
+#~ "GConf"
 
-#: ../capplets/common/gconf-property-editor.c:159
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"Callback për tu kryer kur nevoitet konvertimi i të dhënave nga widget në "
-"GConf"
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Objekt që kontrollon pronësinë (zakonisht një widget)"
 
-#: ../capplets/common/gconf-property-editor.c:164
-msgid "UI Control"
-msgstr "Kontrolli UI"
+#~ msgid "Property editor object data"
+#~ msgstr "Të dhënat e objektit për editorin e pronësive"
 
-#: ../capplets/common/gconf-property-editor.c:165
-msgid "Object that controls the property (normally a widget)"
-msgstr "Objekt që kontrollon pronësinë (zakonisht një widget)"
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Të dhëna specifike të kërkuara nga editori specifik i pronësive"
 
-#: ../capplets/common/gconf-property-editor.c:180
-msgid "Property editor object data"
-msgstr "Të dhënat e objektit për editorin e pronësive"
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Callback i lëshimit të së dhënave për editorin e pronësive"
 
-#: ../capplets/common/gconf-property-editor.c:181
-msgid "Custom data required by the specific property editor"
-msgstr "Të dhëna specifike të kërkuara nga editori specifik i pronësive"
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Callback e kryer kur duhet liruar kujtesa e të dhënave të objektit editor "
+#~ "i pronësive"
 
-#: ../capplets/common/gconf-property-editor.c:187
-msgid "Property editor data freeing callback"
-msgstr "Callback i lëshimit të së dhënave për editorin e pronësive"
-
-#: ../capplets/common/gconf-property-editor.c:188
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Callback e kryer kur duhet liruar kujtesa e të dhënave të objektit editor i "
-"pronësive"
-
-#: ../capplets/common/gconf-property-editor.c:1429
 #, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"E pamundur gjetja e file '%s'.\n"
-"\n"
-"Sigurohu që ekziston dhe provo përsëri, ose zgjidh një figurë tjetër sfondi."
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "E pamundur gjetja e file '%s'.\n"
+#~ "\n"
+#~ "Sigurohu që ekziston dhe provo përsëri, ose zgjidh një figurë tjetër "
+#~ "sfondi."
 
-#: ../capplets/common/gconf-property-editor.c:1437
 #, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"E pamundur njohja e formatit të file '%s'.\n"
-"Ndoshta është një lloj figure akoma i pasuportuar.\n"
-"\n"
-"Zgjidh një figurë tjetër."
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "E pamundur njohja e formatit të file '%s'.\n"
+#~ "Ndoshta është një lloj figure akoma i pasuportuar.\n"
+#~ "\n"
+#~ "Zgjidh një figurë tjetër."
 
-#: ../capplets/common/gconf-property-editor.c:1556
-msgid "Please select an image."
-msgstr "Zgjidh një figurë."
+#~ msgid "Please select an image."
+#~ msgstr "Zgjidh një figurë."
 
-# #-#-#-#-#  glade3.HEAD.sq.po (glade3 HEAD)  #-#-#-#-#
-# (pofilter) accelerators: accelerator _ is missing from translation
-# #-#-#-#-#  glade3.gnome-2-22.sq.po (glade3 gnome-2-22)  #-#-#-#-#
-# (pofilter) accelerators: accelerator _ is missing from translation
-#: ../capplets/common/gconf-property-editor.c:1561
-msgid "_Select"
-msgstr "_Zgjidh"
+#~ msgid "Default Pointer - Current"
+#~ msgstr "Kursori i paracaktuar - në përdorim"
 
-#: ../capplets/common/gnome-theme-info.c:635
-msgid "Default Pointer - Current"
-msgstr "Kursori i paracaktuar - në përdorim"
+#~ msgid "White Pointer"
+#~ msgstr "Kursor i bardhë"
 
-#: ../capplets/common/gnome-theme-info.c:639
-msgid "White Pointer"
-msgstr "Kursor i bardhë"
+#~ msgid "White Pointer - Current"
+#~ msgstr "Kursor i bardhë - në përdorim"
 
-#: ../capplets/common/gnome-theme-info.c:640
-msgid "White Pointer - Current"
-msgstr "Kursor i bardhë - në përdorim"
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Kursor i madh - në përdorim"
 
-#: ../capplets/common/gnome-theme-info.c:644
-msgid "Large Pointer"
-msgstr "Kursor i madh"
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Kursor i bardhë i madh - në përdorim"
 
-#: ../capplets/common/gnome-theme-info.c:645
-msgid "Large Pointer - Current"
-msgstr "Kursor i madh - në përdorim"
-
-#: ../capplets/common/gnome-theme-info.c:649
-msgid "Large White Pointer - Current"
-msgstr "Kursor i bardhë i madh - në përdorim"
-
-#: ../capplets/common/gnome-theme-info.c:650
-msgid "Large White Pointer"
-msgstr "Kursor i bardhë i madh"
-
-#: ../capplets/common/gnome-theme-info.c:1620
 #, c-format
-msgid ""
-"This theme will not look as intended because the required GTK+ theme '%s' is "
-"not installed."
-msgstr ""
-"Tema nuk do të shfaqet sikurse parashikuar pasi tema e kërkuar GTK+ '%s' nuk "
-"është instaluar."
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Tema nuk do të shfaqet sikurse parashikuar pasi tema e kërkuar GTK+ '%s' "
+#~ "nuk është instaluar."
 
-#: ../capplets/common/gnome-theme-info.c:1628
 #, c-format
-msgid ""
-"This theme will not look as intended because the required window manager "
-"theme '%s' is not installed."
-msgstr ""
-"Tema nuk do të shfaqet sikurse parashikuar pasi tema e kërkuar e menazhuesit "
-"të dritareve '%s' nuk është instaluar."
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "Tema nuk do të shfaqet sikurse parashikuar pasi tema e kërkuar e "
+#~ "menazhuesit të dritareve '%s' nuk është instaluar."
 
-#: ../capplets/common/gnome-theme-info.c:1635
 #, c-format
-msgid ""
-"This theme will not look as intended because the required icon theme '%s' is "
-"not installed."
-msgstr ""
-"Tema nuk do të shfaqet sikurse parashikuar pasi tema e kërkuar e ikonave "
-"'%s' nuk është instaluar."
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "Tema nuk do të shfaqet sikurse parashikuar pasi tema e kërkuar e ikonave "
+#~ "'%s' nuk është instaluar."
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Preferred Applications"
-msgstr "Aplikativë të preferuar"
+#~ msgid "Select your default applications"
+#~ msgstr "Zgjidh apliaktivët e paracaktuar"
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Zgjidh apliaktivët e paracaktuar"
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "Nis teknollogjinë asistuese të preferuar për shikimin"
 
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Start the preferred visual assistive technology"
-msgstr "Nis teknollogjinë asistuese të preferuar për shikimin"
+#~ msgid "Visual Assistance"
+#~ msgstr "Asistenca vizive"
 
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr "Asistenca vizive"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:94
-#: ../capplets/default-applications/gnome-da-capplet.c:345
-#: ../capplets/default-applications/gnome-da-capplet.c:366
 #, c-format
-msgid "Error saving configuration: %s"
-msgstr "Gabim gjatë ruajtjes së konfigurimit: %s"
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Gabim gjatë ruajtjes së konfigurimit: %s"
 
-#: ../capplets/default-applications/gnome-da-capplet.c:650
-msgid "Could not load the main interface"
-msgstr "I pamundur ngarkimi i interfaqes kryesore"
+#~ msgid "Could not load the main interface"
+#~ msgstr "I pamundur ngarkimi i interfaqes kryesore"
 
-#: ../capplets/default-applications/gnome-da-capplet.c:652
-msgid "Please make sure that the applet is properly installed"
-msgstr "Sigurohu që mini-aplikativi të jetë instaluar sikurse duhet"
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "Specifiko emrin e faqes për tu shfaqur (internet|multimedia|system|a11y)"
 
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/default-applications/gnome-da-capplet.c:879
-msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
-msgstr ""
-"Specifiko emrin e faqes për tu shfaqur (internet|multimedia|system|a11y)"
+#~ msgid "<b>Image Viewer</b>"
+#~ msgstr "<b>Shfaqës figurash</b>"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Image Viewer</b>"
-msgstr "<b>Shfaqës figurash</b>"
+#~ msgid "<b>Instant Messenger</b>"
+#~ msgstr "<b>Mesazhe të menjëhershëm</b>"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Instant Messenger</b>"
-msgstr "<b>Mesazhe të menjëhershëm</b>"
+#~ msgid "<b>Mail Reader</b>"
+#~ msgstr "<b>Klient i postës elektronike</b>"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Mail Reader</b>"
-msgstr "<b>Klient i postës elektronike</b>"
+#~ msgid "<b>Mobility</b>"
+#~ msgstr "<b>Lëvizshmëri</b>"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mobility</b>"
-msgstr "<b>Lëvizshmëri</b>"
+#~ msgid "<b>Multimedia Player</b>"
+#~ msgstr "<b>Riprodhues multimedial</b>"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Multimedia Player</b>"
-msgstr "<b>Riprodhues multimedial</b>"
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Emulator terminali</b>"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>Emulator terminali</b>"
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Editor teksti</b>"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Text Editor</b>"
-msgstr "<b>Editor teksti</b>"
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Riprodhues video</b>"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Video Player</b>"
-msgstr "<b>Riprodhues video</b>"
+#~ msgid "<b>Visual</b>"
+#~ msgstr "<b>Shikimi</b>"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "<b>Visual</b>"
-msgstr "<b>Shikimi</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "<b>Web Browser</b>"
-msgstr "<b>Shfletues web</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
-msgid "Accessibility"
-msgstr "Përdorshmëria"
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Shfletues web</b>"
 
 # Thjesht sensi.
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
 #, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr "Vlera %s zëvendësohet me lidhjen"
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "Vlera %s zëvendësohet me lidhjen"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "C_ommand:"
-msgstr "K_omanda:"
+#~ msgid "Co_mmand:"
+#~ msgstr "Ko_manda:"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Co_mmand:"
-msgstr "Ko_manda:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "E_xecute flag:"
-msgstr "Flag i e_kzekutimit:"
+#~ msgid "E_xecute flag:"
+#~ msgstr "Flag i e_kzekutimit:"
 
 # #-#-#-#-#  gnome-menus.HEAD.sq.po (gnome-menus gnome-2-22)  #-#-#-#-#
 # (pofilter) unchanged: please translate
 # #-#-#-#-#  gnome-menus.gnome-2-22.sq.po (gnome-menus gnome-2-22)  #-#-#-#-#
 # (pofilter) unchanged: please translate
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Internet"
-msgstr "Internet"
+#~ msgid "Internet"
+#~ msgstr "Internet"
 
 # #-#-#-#-#  gnome-icon-theme.HEAD.sq.po (gnome-icon-theme.HEAD)  #-#-#-#-#
 # 48x48/emblems/emblem-multimedia.icon.in.h:1
@@ -1602,1830 +6327,960 @@ msgstr "Internet"
 # 48x48/emblems/emblem-multimedia.icon.in.h:1
 # 48x48/emblems/emblem-multimedia.icon.in.h:1
 # (pofilter) unchanged: please translate
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Multimedia"
-msgstr "Multimedia"
+#~ msgid "Multimedia"
+#~ msgstr "Multimedia"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Open link in new _tab"
-msgstr "Hap lidhjet në një skedë _të re"
+#~ msgid "Open link in new _tab"
+#~ msgstr "Hap lidhjet në një skedë _të re"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "Open link in new _window"
-msgstr "Hap lidhjet në një _dritare të re"
+#~ msgid "Open link in new _window"
+#~ msgstr "Hap lidhjet në një _dritare të re"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid "Open link with web browser _default"
-msgstr "Hap lidhjet sipas _rregullimeve të shfletuesit web"
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Hap lidhjet sipas _rregullimeve të shfletuesit web"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Run at st_art"
-msgstr "Ekzekuto në _nisje"
+#~ msgid "Run at st_art"
+#~ msgstr "Ekzekuto në _nisje"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Run in t_erminal"
-msgstr "Ekzekuto në t_erminal"
+#~ msgid "Run in t_erminal"
+#~ msgstr "Ekzekuto në t_erminal"
 
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "System"
-msgstr "Sistemi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "_Run at start"
-msgstr "_Ekzekuto në nisje"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Balsa"
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
 
 # Hiqet Music Player pasi shfaqet
 # në listën e music player
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr "Banshee"
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr "Claws Mail"
+#~ msgid "Claws Mail"
+#~ msgstr "Claws Mail"
 
 # (pofilter) unchanged: please translate
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr "Dasher"
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr "Shfletues i përshtatshëm për Debian"
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Shfletues i përshtatshëm për Debian"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr "Emulator terminali Debian"
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Emulator terminali Debian"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr "ETerm"
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr "Encompass"
-
-# Hiqet web browser pasi rezulton
-# në listën e web browser
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr "Epiphany"
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
 
 # Hiqet mail reader pasi rezulton
 # në listën e klientëve mail
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr "Evolution"
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr "Firebird"
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Firefox"
-msgstr "Firefox"
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr "Zmadhuesi i GNOME pa lexues ekrani"
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "Zmadhuesi i GNOME pa lexues ekrani"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr "Tastierë në ekran e GNOME"
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr "Terminali i GNOME"
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Galeon"
-msgstr "Galeon"
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "Gnopernicus me zmadhues"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Gnopernicus"
-msgstr "Gnopernicus"
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Gnopernicus with Magnifier"
-msgstr "Gnopernicus me zmadhues"
+#~ msgid "Iceape Mail"
+#~ msgstr "Posta Iceape"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Iceape"
-msgstr "Iceape"
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Iceape Mail"
-msgstr "Posta Iceape"
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Icedove"
-msgstr "Icedove"
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "Zmadhuesi i KDE pa lexues ekrani"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Iceweasel"
-msgstr "Iceweasel"
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr "Zmadhuesi i KDE pa lexues ekrani"
+#~ msgid "Konsole"
+#~ msgstr "Konsole"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr "KMail"
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "Linux Screen Reader me zmadhues"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr "Konqueror"
+#~ msgid "Midori"
+#~ msgstr "Midori"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Konsole"
-msgstr "Konsole"
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
 
-# Emri i vetë aplikativit
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr "Linux Screen Reader"
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr "Linux Screen Reader me zmadhues"
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Midori"
-msgstr "Midori"
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Mozilla"
-msgstr "Mozilla"
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Mozilla Mail"
-msgstr "Mozilla Mail"
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
 
 # Hiqet music player
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Muine Music Player"
-msgstr "Muine"
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Mutt"
-msgstr "Mutt"
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "NXterm"
-msgstr "NXterm"
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "Posta SeaMonkey"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-msgid "Netscape Communicator"
-msgstr "Netscape Communicator"
+#~ msgid "Standard XTerminal"
+#~ msgstr "Terminal X standard"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Opera"
-msgstr "Opera"
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Orca"
-msgstr "Orca"
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca with Magnifier"
-msgstr "Orca me zmadhues"
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem"
 
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "RXVT"
-msgstr "RXVT"
+#~ msgid "aterm"
+#~ msgstr "aterm"
 
-# Hiqet music player
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-msgid "Rhythmbox Music Player"
-msgstr "Rhythmbox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-msgid "SeaMonkey Mail"
-msgstr "Posta SeaMonkey"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-msgid "Standard XTerminal"
-msgstr "Terminal X standard"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Sylpheed"
-msgstr "Sylpheed"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-msgid "Terminator"
-msgstr "Terminator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Totem Movie Player"
-msgstr "Totem"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/display/display-capplet.glade.h:1
-msgid "Include _Panel"
-msgstr "Përfshi _panelin"
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../capplets/display/display-capplet.glade.h:2
-#: ../capplets/display/xrandr-capplet.c:1319
-msgid "Mirror Screens"
-msgstr "Pasqyra e ekranit"
+#~ msgid "Include _Panel"
+#~ msgstr "Përfshi _panelin"
 
 # Përmasa???
-#: ../capplets/display/display-capplet.glade.h:3
-msgid "Monitor Resolution Settings"
-msgstr "Rregullimet e përmasave të ekranit"
+#~ msgid "Monitor Resolution Settings"
+#~ msgstr "Rregullimet e përmasave të ekranit"
 
-#: ../capplets/display/display-capplet.glade.h:4
-msgid ""
-"Normal\n"
-"Left\n"
-"Right\n"
-"Upside-down\n"
-msgstr ""
-"Normal\n"
-"Majtas\n"
-"Djathtas\n"
-"Lart-poshtë\n"
+#~ msgid ""
+#~ "Normal\n"
+#~ "Left\n"
+#~ "Right\n"
+#~ "Upside-down\n"
+#~ msgstr ""
+#~ "Normal\n"
+#~ "Majtas\n"
+#~ "Djathtas\n"
+#~ "Lart-poshtë\n"
 
-#: ../capplets/display/display-capplet.glade.h:9
-msgid "R_otation"
-msgstr "Rr_otullimi"
+#~ msgid "_Show Displays in Panel"
+#~ msgstr "_Shfaq ekranet në panel"
 
-#: ../capplets/display/display-capplet.glade.h:10
-msgid "Re_fresh Rate:"
-msgstr "Intervali i ri_freskimit:"
+#~ msgid "Change screen resolution"
+#~ msgstr "Ndrysho përmasat e ekranit"
 
-#: ../capplets/display/display-capplet.glade.h:11
-msgid "_Detect Displays"
-msgstr "_Zbulo ekranet"
+#~ msgid "Upside Down"
+#~ msgstr "Sipër poshtë"
 
-#: ../capplets/display/display-capplet.glade.h:12
-msgid "_Resolution"
-msgstr "_Përmasat"
-
-#: ../capplets/display/display-capplet.glade.h:13
-msgid "_Show Displays in Panel"
-msgstr "_Shfaq ekranet në panel"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Ndrysho përmasat e ekranit"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Përmasat e ekranit"
-
-#: ../capplets/display/xrandr-capplet.c:412
-#: ../capplets/display/xrandr-capplet.c:450
-msgid "Normal"
-msgstr "Normal"
-
-#: ../capplets/display/xrandr-capplet.c:413
-msgid "Left"
-msgstr "Majtas"
-
-#: ../capplets/display/xrandr-capplet.c:414
-msgid "Right"
-msgstr "Djathtas"
-
-#: ../capplets/display/xrandr-capplet.c:415
-msgid "Upside Down"
-msgstr "Sipër poshtë"
-
-#: ../capplets/display/xrandr-capplet.c:488
-#: ../capplets/display/xrandr-capplet.c:496
-#: ../capplets/display/xrandr-capplet.c:497
 #, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
 
-#: ../capplets/display/xrandr-capplet.c:549
-#: ../capplets/display/xrandr-capplet.c:568
-#: ../capplets/display/xrandr-capplet.c:578
 #, c-format
-msgid "%d x %d"
-msgstr "%d x %d"
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
 
-#: ../capplets/display/xrandr-capplet.c:560
-msgid "Off"
-msgstr "Çaktivizuar"
+#~ msgid "Off"
+#~ msgstr "Çaktivizuar"
 
-# #-#-#-#-#  gnome-icon-theme.HEAD.sq.po (gnome-icon-theme.HEAD)  #-#-#-#-#
-# 48x48/emblems/emblem-sound.icon.in.h:1
-# 48x48/emblems/emblem-sound.icon.in.h:1
-# 48x48/emblems/emblem-sound.icon.in.h:1
-# #-#-#-#-#  gnome-icon-theme.gnome-2-22.sq.po (gnome-icon-theme.HEAD)  #-#-#-#-#
-# 48x48/emblems/emblem-sound.icon.in.h:1
-# 48x48/emblems/emblem-sound.icon.in.h:1
-# 48x48/emblems/emblem-sound.icon.in.h:1
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
-msgstr "Zëri"
+#~ msgid "New shortcut..."
+#~ msgstr "Përshpejtim i ri..."
 
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-#: ../libslab/bookmark-agent.c:1154
-msgid "Desktop"
-msgstr "Hapësira e punës"
+#~ msgid "Accelerator key"
+#~ msgstr "Pulsant përshpejtues"
 
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr "Përshpejtim i ri..."
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Ndryshues të përshpejtuesëve"
 
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Pulsant përshpejtues"
+#~ msgid "Accelerator keycode"
+#~ msgstr "Kodi pulsantit përshpejtues"
 
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Ndryshues të përshpejtuesëve"
+#~ msgid "The type of accelerator."
+#~ msgstr "Lloji i përshpejtuesit."
 
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Kodi pulsantit përshpejtues"
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Aksion i panjohur>"
 
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Mënyra përshpejt"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Lloji i përshpejtuesit."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:90
-#: ../capplets/sound/sound-theme.c:415 ../capplets/sound/sound-theme.c:433
-#: ../capplets/sound/sound-theme.c:543 ../capplets/sound/sound-theme.c:559
-#: ../typing-break/drwright.c:480
-msgid "Disabled"
-msgstr "Çaktivizuar"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:171
-msgid "<Unknown Action>"
-msgstr "<Aksion i panjohur>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:804
-msgid "Custom Shortcuts"
-msgstr "Përshpejtime të personalizuara"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:938
 #, c-format
-msgid "Error saving the new shortcut: %s"
-msgstr "Gabim në ruajtjen e përshpejtuesit të ri: %s"
+#~ msgid "Error saving the new shortcut: %s"
+#~ msgstr "Gabim në ruajtjen e përshpejtuesit të ri: %s"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1016
 #, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-"Është i pamundur përdorimi i «%s» si kombinim përshpejtues, pasi pengon "
-"shkrimin normal.\n"
-"Provo të përdorësh në kombinim njëkohësisht një pulsant si Ctrl, Alt apo "
-"Shift."
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Është i pamundur përdorimi i «%s» si kombinim përshpejtues, pasi pengon "
+#~ "shkrimin normal.\n"
+#~ "Provo të përdorësh në kombinim njëkohësisht një pulsant si Ctrl, Alt apo "
+#~ "Shift."
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1046
 #, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-"Përshpejtimi «%s» përdoret rregullisht për\n"
-"«%s»"
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Përshpejtimi «%s» përdoret rregullisht për\n"
+#~ "«%s»"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1052
 #, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-"Nëse i ricaktohet përshpejtimi «%s», përshpejtimi «%s» do të çaktivizohet."
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Nëse i ricaktohet përshpejtimi «%s», përshpejtimi «%s» do të çaktivizohet."
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1060
-msgid "_Reassign"
-msgstr "_Ricakto"
+#~ msgid "_Reassign"
+#~ msgstr "_Ricakto"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1180
 #, c-format
-msgid "Error unsetting accelerator in configuration database: %s"
-msgstr ""
-"Gabim gjatë heqjes së përshpejtuesit në bazën e të dhënave të konfigurimit: "
-"%s"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1362
-msgid "Action"
-msgstr "Veprimi"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1384
-msgid "Shortcut"
-msgstr "Kombinimi përshpejtues"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Kombinime përshpejtuese nga tastiera"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new key "
-"combination, or press backspace to clear."
-msgstr ""
-"Për të ndryshuar një pulsant përshpejtimi, kliko në rreshtin përkatës dhe "
-"shkruaj kombinimin e ri, ose shtyp «Backspace» për ta fshirë."
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Cakton pulsante përshpejtues komandave"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:248
-#: ../capplets/keyboard/gnome-keyboard-properties.c:253
-#: ../capplets/sound/sound-properties-capplet.c:1185
-#: ../capplets/sound/sound-properties-capplet.c:1187
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-"Aplikon rregullimet dhe del (vetëm kompatibilitet; tashmë kontrollohet nga "
-"demon)"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:256
-#: ../capplets/sound/sound-properties-capplet.c:1189
-msgid "Retrieve and store legacy settings"
-msgstr "Rikuperon dhe rivendos rregullimet legacy"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:260
-msgid "Start the page with the typing break settings showing"
-msgstr ""
-"Nis duke shfaqur faqen e pronësive të rregullimeve për pushimet gjatë "
-"shkrimit"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:265
-msgid "Start the page with the accessibility settings showing"
-msgstr "Nis duke shfaqur faqen e pronësive të rregullimeve të açesibilitetit"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:274
-msgid "- GNOME Keyboard Preferences"
-msgstr "- Preferimet e tastierës së GNOME"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-msgid "<b>Bounce Keys</b>"
-msgstr "<b>Shtypja e përafërt e pulsantëve</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>Pulsimi i kursorit</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "<b>General</b>"
-msgstr "<b>Të përgjithshme</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Përsëritja e pulsantëve</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Slow Keys</b>"
-msgstr "<b>Ngadalsimi i pulsantëve</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>Sticky Keys</b>"
-msgstr "<b>Qëndrimi i pulsantëve</b>"
-
-#. fast acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Shpejt</i></small>"
-
-#. long delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>E gjatë</i></small>"
-
-#. short delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>E shkurtër</i></small>"
-
-#. slow acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Ngadalë</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_cceleration:"
-msgstr "P_ërshpejtimi:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "All_ow postponing of breaks"
-msgstr "Lej_o shtyrjen e pushimeve"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "Audio _Feedback..."
-msgstr "_Feedback audio..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Beep when _accessibility features are turned on or off"
-msgstr ""
-"Sinjal akustik kur aktivizohen apo çaktivizohen funksionet e _açesibilitetit"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Beep when a _modifier key is pressed"
-msgstr "Sinjal akustik kur shtypet një _ndryshues"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Beep when a _toggle key is pressed"
-msgstr "Sinjal akustik kur shtypet një pulsant _shkëmbyes"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Beep when a key is pr_essed"
-msgstr "Sinjal akustik kur shtyp_et një pulsant"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Beep when a key is reje_cted"
-msgstr "Sinjal akustik kur refu_zohet një pulsant"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Beep when key is _accepted"
-msgstr "Sinjal akustik kur pr_anohet një pulsant"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Beep when key is _rejected"
-msgstr "Sinjal akustik kur pulsanti _refuzohet"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "By _country"
-msgstr "Sipas sh_tetit"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "By _language"
-msgstr "Sipas _gjuhës"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Kontrollon nëse lejohet shtyrja e pushimeve"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Choose a Keyboard Model"
-msgstr "Zgjedhja e një modeli tastiere"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Choose a Layout"
-msgstr "Zgjedhja e një planimetrie"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Cursor _blinks in text fields"
-msgstr "Kursor pulsues në fushat me tekst"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
-msgid "Cursor blinks speed"
-msgstr "Shpejtësia e pulsimit të kursorit"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
-msgid "D_elay:"
-msgstr "Von_esa:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Disa_ble sticky keys if two keys are pressed together"
-msgstr "Çaktivizo qëndrimin e pulsantëve nëse shtypen dy pulsantë së bashku"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Duration of the break when typing is disallowed"
-msgstr "Kohëzgjatja e pushimit gjatë së cilës ndalohet shkrimi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Duration of work before forcing a break"
-msgstr "Kohëzgjatja e punës para se të detyrohet kryerja e një pushimi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
-msgid "General"
-msgstr "Të përgjithshme"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "Key presses _repeat when key is held down"
-msgstr "Pë_rsërit gërmën përderisa pulsanti mbahet i shtypur"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "Keyboard Accessibility Audio Feedback"
-msgstr "Feedback audio i açesibilitetit të tastierës"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "Keyboard Layout Options"
-msgstr "Opsionet e planimetrisë së tastierës"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "Keyboard Preferences"
-msgstr "Preferimet e tastierës"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "Keyboard _model:"
-msgstr "_Modeli i tastierës:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "Layout _Options..."
-msgstr "_Opsionet e planimetrisë..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "Layouts"
-msgstr "Planimetritë"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-"Mbas një intervali te caktuar kohe blloko ekranin për të parandaluar dëmet e "
-"shkaktuara nga përdorimi i gjatë i tastierës"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "Mouse Keys"
-msgstr "Mouse nga tastiera"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "Preview:"
-msgstr "Pamja e parë:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
-msgid "Repeat keys speed"
-msgstr "Shpejtësia e përsëritjes së pulsantëve"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
-msgid "Reset to De_faults"
-msgstr "Rivendos vlerat e para_caktuara"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
-msgid "S_peed:"
-msgstr "Sh_pejtësia:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
-msgid "Separate _layout for each window"
-msgstr "P_lanimetri e veçantë për çdo dritare"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
-msgid "Typing Break"
-msgstr "Pushim gjatë shkrimit"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
-msgid "_Accessibility features can be toggled with keyboard shortcuts"
-msgstr ""
-"Funksionet e _açesibilitetit mund të aktivizohen/çaktivizohen me kombinime "
-"përshpejtuese nga tastiera"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
-msgid "_Break interval lasts:"
-msgstr "Kohëzgjatja e _pushimit:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
-msgid "_Country:"
-msgstr "_Shteti:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
-msgid "_Delay:"
-msgstr "_Vonesa:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
-msgid "_Ignore fast duplicate keypresses"
-msgstr "Shpërf_ill shtypje të shpejta të njëpasnjëshme pulsantësh"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
-msgid "_Language:"
-msgstr "_Gjuha:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
-msgid "_Lock screen to enforce typing break"
-msgstr "B_lloko ekranin për të detyruar kryrjen e një pushimi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
-msgid "_Models:"
-msgstr "_Modele:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
-msgid "_Only accept long keypresses"
-msgstr "Prano ve_tëm shtypje pulsanti me kohëzgjatje të gjatë"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
-msgid "_Pointer can be controlled using the keypad"
-msgstr "_Kursori mund të kontrollohet duke përdorur tastierën"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
-msgid "_Selected layouts:"
-msgstr "Planimetritë e _zgjedhura:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
-msgid "_Simulate simultaneous keypresses"
-msgstr "_Simulo shtypje të njëkohshme pulsantësh"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
-msgid "_Speed:"
-msgstr "_Shpejtësia:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
-msgid "_Type to test settings:"
-msgstr "_Shkruaj këtu për të verifikuar rregullimet:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
-msgid "_Variants:"
-msgstr "_Variante:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
-msgid "_Vendors:"
-msgstr "_Prodhues:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
-msgid "_Work interval lasts:"
-msgstr "Intervali i _punës:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
-msgid "minutes"
-msgstr "minuta"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:81
-msgid "Unknown"
-msgstr "Nuk njihet"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:305
-msgid "Layout"
-msgstr "Planimetria"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:311
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:211
-#: ../capplets/sound/sound-theme.c:419 ../capplets/sound/sound-theme.c:539
-msgid "Default"
-msgstr "E paracaktuar"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
-msgid "Vendors"
-msgstr "Prodhues"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
-msgid "Models"
-msgstr "Modele"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Tastiera"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Përcakton preferimet e tastierës"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:89
-msgid "gesture|Move left"
-msgstr "Lëviz në të majtë"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:94
-msgid "gesture|Move right"
-msgstr "Lëviz në të djathtë"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:99
-msgid "gesture|Move up"
-msgstr "Lëviz sipër"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:104
-msgid "gesture|Move down"
-msgstr "Lëviz poshtë"
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:109
-msgid "gesture|Disabled"
-msgstr "Çaktivizuar"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/mouse/gnome-mouse-properties.c:443
-msgid "Specify the name of the page to show (general|accessibility)"
-msgstr "Specifiko emrin e faqes për tu shfaqur (general|accessibility)"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:452
-msgid "- GNOME Mouse Preferences"
-msgstr "- Preferimet e mouse për GNOME"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-msgid "<b>Double-Click Timeout</b>"
-msgstr "<b>Koha në dispozicion për dopio klik</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Zvarritja</b>"
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Dwell Click</b>"
-msgstr "<b>Klikim automatik</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Gjetja e kursorit</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>Orientimi i mouse</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<b>Pointer Speed</b>"
-msgstr "<b>Shpejtësia e kursorit</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<b>Simulated Secondary Click</b>"
-msgstr "<b>Klik dytësor i simuluar</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid ""
-"<i>To test your double-click settings, try to double-click on the light bulb."
-"</i>"
-msgstr ""
-"<i>Për të kontrolluar rregullimet personale të klikimit dopio, provo të bësh "
-"dopio klik tek llampa.</i>"
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid ""
-"<i>You can also use the Dwell Click panel applet to choose the click type.</"
-"i>"
-msgstr ""
-"<i>Mund gjithashtu të përdoret applet i panelit «Klikim automatik» për të "
-"zgjedhur llojin e klikimit.</i>"
-
-#. high sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "<small><i>High</i></small>"
-msgstr "<small><i>E lartë</i></small>"
-
-#. large threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "<small><i>Large</i></small>"
-msgstr "<small><i>I madh</i></small>"
-
-#. low sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "<small><i>Low</i></small>"
-msgstr "<small><i>E ulët</i></small>"
-
-#. small threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "<small><i>Small</i></small>"
-msgstr "<small><i>I vogël</i></small>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
-msgid "Choose type of click _beforehand"
-msgstr "Zgjidh llojin e klikimit të _parakohshëm"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
-msgid "Choose type of click with mo_use gestures"
-msgstr "Zgjidh llojin e klik me gjeste të mo_use"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
-msgid "D_ouble click:"
-msgstr "D_opio klik:"
-
-#. click to initiate drag-and-drop (like normally click and hold)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
-msgid "D_rag click:"
-msgstr "Klik zva_rritje:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
-msgid "Mouse Preferences"
-msgstr "Preferimet e mouse"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
-msgid "Seco_ndary click:"
-msgstr "Klik dytësor:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr "Sh_faq pozicionin e kursorit kur shtypet pulsanti Control"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
-msgid "Show click type _window"
-msgstr "Shfaq _dritaren për llojin e klikimit"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
-msgid "Thr_eshold:"
-msgstr "Kuf_iri:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
-msgid "_Acceleration:"
-msgstr "_Përshpejtimi:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
-msgid "_Initiate click when stopping pointer movement"
-msgstr "F_illo klikimin kur ndalon lëvizja e kursorit"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
-msgid "_Left-handed"
-msgstr "Për dorën e _majtë"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
-msgid "_Motion threshold:"
-msgstr "Kufiri i lë_vizjes:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
-msgid "_Right-handed"
-msgstr "Për dorën e _djathtë"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
-msgid "_Sensitivity:"
-msgstr "_Ndjeshmëria:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
-msgid "_Single click:"
-msgstr "Klik i ve_tëm:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
-msgid "_Timeout:"
-msgstr "_Koha në dispozicion:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr "_Nis klikimin dytësor duke mbajtur shtypur pulsantin kryesor"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Mouse"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Përcakton preferimet e mouse"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Proxy i rrjetit"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr "Përcakton preferimet e proxy të rrjetit"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>Lidhje di_rekte në internet</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>Ignore Host List</b>"
-msgstr "<b>Lista me host për tu shpërfillur</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>_Konfigurim automaktik i proxy</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>_Konfigurim manual i proxy</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Përdor autentikim</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "Autoconfiguration _URL:"
-msgstr "_URL e autokonfigurimit:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "HTTP Proxy Details"
-msgstr "Detaje Proxy HTTP"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "H_TTP proxy:"
-msgstr "Proxy H_TTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "Ignored Hosts"
-msgstr "Host-et e shpërfillur"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "Network Proxy Preferences"
-msgstr "Preferimet e proxy të rrjetit"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Port:"
-msgstr "Porta:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Proxy Configuration"
-msgstr "Konfigurimi i proxy"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "S_ocks host:"
-msgstr "Host S_ocks:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "U_sername:"
-msgstr "Përdorue_si:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "_Details"
-msgstr "_Detaje"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_FTP proxy:"
-msgstr "Proxy _FTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_Password:"
-msgstr "_Fjalëkalimi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Secure HTTP proxy:"
-msgstr "Proxy HTTP i _Sigurtë:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Use the same proxy for all protocols"
-msgstr "_Përdor të njëjtin host për të gjithë protokollet"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Aktivizoo tingujt dhe shoqëro me tinguj eventet"
-
-#: ../capplets/sound/mixer-support.c:79
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr ""
+#~ "Gabim gjatë heqjes së përshpejtuesit në bazën e të dhënave të "
+#~ "konfigurimit: %s"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Cakton pulsante përshpejtues komandave"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Aplikon rregullimet dhe del (vetëm kompatibilitet; tashmë kontrollohet "
+#~ "nga demon)"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Rikuperon dhe rivendos rregullimet legacy"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr ""
+#~ "Nis duke shfaqur faqen e pronësive të rregullimeve për pushimet gjatë "
+#~ "shkrimit"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr ""
+#~ "Nis duke shfaqur faqen e pronësive të rregullimeve të açesibilitetit"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- Preferimet e tastierës së GNOME"
+
+#~ msgid "<b>General</b>"
+#~ msgstr "<b>Të përgjithshme</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Shpejt</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>E gjatë</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>E shkurtër</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Ngadalë</i></small>"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "P_ërshpejtimi:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Lej_o shtyrjen e pushimeve"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "_Feedback audio..."
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "Sinjal akustik kur shtypet një pulsant _shkëmbyes"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "Sinjal akustik kur pulsanti _refuzohet"
+
+#~ msgid "By _country"
+#~ msgstr "Sipas sh_tetit"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Kontrollon nëse lejohet shtyrja e pushimeve"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Zgjedhja e një modeli tastiere"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Zgjedhja e një planimetrie"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Kohëzgjatja e pushimit gjatë së cilës ndalohet shkrimi"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Kohëzgjatja e punës para se të detyrohet kryerja e një pushimi"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "Feedback audio i açesibilitetit të tastierës"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Preferimet e tastierës"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "_Modeli i tastierës:"
+
+#~ msgid "Layouts"
+#~ msgstr "Planimetritë"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Mbas një intervali te caktuar kohe blloko ekranin për të parandaluar "
+#~ "dëmet e shkaktuara nga përdorimi i gjatë i tastierës"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "Rivendos vlerat e para_caktuara"
+
+#~ msgid "S_peed:"
+#~ msgstr "Sh_pejtësia:"
+
+#~ msgid "Separate _layout for each window"
+#~ msgstr "P_lanimetri e veçantë për çdo dritare"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "Kohëzgjatja e _pushimit:"
+
+#~ msgid "_Country:"
+#~ msgstr "_Shteti:"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "B_lloko ekranin për të detyruar kryrjen e një pushimi"
+
+#~ msgid "_Models:"
+#~ msgstr "_Modele:"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "Prano ve_tëm shtypje pulsanti me kohëzgjatje të gjatë"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "_Kursori mund të kontrollohet duke përdorur tastierën"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "Planimetritë e _zgjedhura:"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "_Simulo shtypje të njëkohshme pulsantësh"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Shkruaj këtu për të verifikuar rregullimet:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variante:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_Prodhues:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "Intervali i _punës:"
+
+#~ msgid "Unknown"
+#~ msgstr "Nuk njihet"
+
+#~ msgid "Vendors"
+#~ msgstr "Prodhues"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Përcakton preferimet e tastierës"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "Lëviz në të majtë"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "Lëviz në të djathtë"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "Lëviz sipër"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "Çaktivizuar"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "Specifiko emrin e faqes për tu shfaqur (general|accessibility)"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "- Preferimet e mouse për GNOME"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Zvarritja</b>"
+
+#~ msgid "<b>Dwell Click</b>"
+#~ msgstr "<b>Klikim automatik</b>"
+
+#~ msgid "<b>Locate Pointer</b>"
+#~ msgstr "<b>Gjetja e kursorit</b>"
+
+#~ msgid "<b>Pointer Speed</b>"
+#~ msgstr "<b>Shpejtësia e kursorit</b>"
+
+#~ msgid ""
+#~ "<i>To test your double-click settings, try to double-click on the light "
+#~ "bulb.</i>"
+#~ msgstr ""
+#~ "<i>Për të kontrolluar rregullimet personale të klikimit dopio, provo të "
+#~ "bësh dopio klik tek llampa.</i>"
+
+#~ msgid ""
+#~ "<i>You can also use the Dwell Click panel applet to choose the click type."
+#~ "</i>"
+#~ msgstr ""
+#~ "<i>Mund gjithashtu të përdoret applet i panelit «Klikim automatik» për të "
+#~ "zgjedhur llojin e klikimit.</i>"
+
+#~ msgid "<small><i>High</i></small>"
+#~ msgstr "<small><i>E lartë</i></small>"
+
+#~ msgid "<small><i>Large</i></small>"
+#~ msgstr "<small><i>I madh</i></small>"
+
+#~ msgid "<small><i>Low</i></small>"
+#~ msgstr "<small><i>E ulët</i></small>"
+
+#~ msgid "<small><i>Small</i></small>"
+#~ msgstr "<small><i>I vogël</i></small>"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "Zgjidh llojin e klikimit të _parakohshëm"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "Zgjidh llojin e klik me gjeste të mo_use"
+
+#~ msgid "D_rag click:"
+#~ msgstr "Klik zva_rritje:"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Preferimet e mouse"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Sh_faq pozicionin e kursorit kur shtypet pulsanti Control"
+
+#~ msgid "Show click type _window"
+#~ msgstr "Shfaq _dritaren për llojin e klikimit"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "Kuf_iri:"
+
+#~ msgid "_Left-handed"
+#~ msgstr "Për dorën e _majtë"
+
+#~ msgid "_Right-handed"
+#~ msgstr "Për dorën e _djathtë"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Ndjeshmëria:"
+
+#~ msgid "_Single click:"
+#~ msgstr "Klik i ve_tëm:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Përcakton preferimet e mouse"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Përcakton preferimet e proxy të rrjetit"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Lidhje di_rekte në internet</b>"
+
+#~ msgid "<b>Ignore Host List</b>"
+#~ msgstr "<b>Lista me host për tu shpërfillur</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>_Konfigurim automaktik i proxy</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_Konfigurim manual i proxy</b>"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Detaje Proxy HTTP"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Preferimet e proxy të rrjetit"
+
+#~ msgid "Port:"
+#~ msgstr "Porta:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "Proxy HTTP i _Sigurtë:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Aktivizoo tingujt dhe shoqëro me tinguj eventet"
+
 #, c-format
-msgid "Unknown Volume Control %d"
-msgstr "Kontroll volumi %d i panjohur"
+#~ msgid "Unknown Volume Control %d"
+#~ msgstr "Kontroll volumi %d i panjohur"
 
-#: ../capplets/sound/pipeline-tests.c:84
 #, c-format
-msgid "Failed to construct test pipeline for '%s'"
-msgstr "Dështoi ndërtimi i pipeline i provës për «%s»"
-
-#: ../capplets/sound/sound-properties-capplet.c:260
-#: ../capplets/sound/sound-properties-capplet.c:381
-msgid "Not connected"
-msgstr "I palidhur"
-
-#: ../capplets/sound/sound-properties-capplet.c:829
-msgid "Autodetect"
-msgstr "Zbulim automatik"
-
-#: ../capplets/sound/sound-properties-capplet.c:834
-#: ../capplets/sound/sound-properties-capplet.c:835
-msgid "ALSA - Advanced Linux Sound Architecture"
-msgstr "ALSA - Advanced Linux Sound Architecture"
-
-#: ../capplets/sound/sound-properties-capplet.c:836
-msgid "Artsd - ART Sound Daemon"
-msgstr "Artsd - ART Sound Daemon"
-
-#: ../capplets/sound/sound-properties-capplet.c:837
-#: ../capplets/sound/sound-properties-capplet.c:838
-msgid "ESD - Enlightened Sound Daemon"
-msgstr "ESD - Enlightened Sound Daemon"
-
-#: ../capplets/sound/sound-properties-capplet.c:841
-#: ../capplets/sound/sound-properties-capplet.c:844
-msgid "OSS - Open Sound System"
-msgstr "OSS - Open Sound System"
-
-#: ../capplets/sound/sound-properties-capplet.c:846
-#: ../capplets/sound/sound-properties-capplet.c:847
-msgid "PulseAudio Sound Server"
-msgstr "Server audio PulseAudio"
-
-#: ../capplets/sound/sound-properties-capplet.c:848
-msgid "Test Sound"
-msgstr "Tingull prove"
-
-#: ../capplets/sound/sound-properties-capplet.c:849
-msgid "Silence"
-msgstr "Heshtje"
-
-#: ../capplets/sound/sound-properties-capplet.c:1202
-msgid "- GNOME Sound Preferences"
-msgstr "- Preferimet audo të GNOME"
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "<b>Alerts and Sound Effects</b>"
-msgstr "<b>Alarme dhe efekte sonorë</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "<b>Audio Conferencing</b>"
-msgstr "<b>Konferenca audio</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "<b>Default Mixer Tracks</b>"
-msgstr "<b>Pistat e paracaktuara të mixer</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "<b>Music and Movies</b>"
-msgstr "<b>Muzikë dhe filma</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "<b>Sound Events</b>"
-msgstr "<b>Evente sonorë</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "<b>Sound Theme</b>"
-msgstr "<b>Tema sonore</b>"
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
-msgstr "<span weight=\"bold\" size=\"x-large\">Verifikimi...</span>"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "Click OK to finish."
-msgstr "Kliko OK për të mbaruar."
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "Devices"
-msgstr "Dispozitivët"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "Play _alert sound"
-msgstr "Riprodho tinguj p_aralajmërues"
-
-#: ../capplets/sound/sound-properties.glade.h:11
-msgid "Play _sound effects when buttons are clicked"
-msgstr "Riprodho efekte _sonorë kur klikohen butonët"
-
-#: ../capplets/sound/sound-properties.glade.h:12
-msgid "S_ound playback:"
-msgstr "Riprodhimi i zë_rit:"
-
-#: ../capplets/sound/sound-properties.glade.h:13
-msgid ""
-"Select the device and tracks to control with the keyboard. Use the Shift and "
-"Control keys to select multiple tracks if required."
-msgstr ""
-"Zgjidh dispozitivin dhe kanalet për tu kontrolluar nga tastiera. Përdor "
-"pulsantët «Shift» dhe «Control» nëse duhen zgjedhur disa pista."
-
-#: ../capplets/sound/sound-properties.glade.h:14
-msgid "So_und playback:"
-msgstr "Riprodhimi i zë_rit:"
-
-#: ../capplets/sound/sound-properties.glade.h:15
-msgid "Sou_nd capture:"
-msgstr "Regjistrimi i zër_it:"
-
-#: ../capplets/sound/sound-properties.glade.h:16
-#: ../capplets/sound/sound-theme.c:461 ../capplets/sound/sound-theme.c:1016
-msgid "Sound Preferences"
-msgstr "Preferimet e zërit"
-
-#: ../capplets/sound/sound-properties.glade.h:17
-msgid "Sounds"
-msgstr "Tingujt"
-
-#: ../capplets/sound/sound-properties.glade.h:18
-msgid "Test"
-msgstr "Provë"
-
-#: ../capplets/sound/sound-properties.glade.h:19
-msgid "Testing Pipeline"
-msgstr "Verifikimi i pipeline"
-
-#: ../capplets/sound/sound-properties.glade.h:20
-msgid "_Device:"
-msgstr "_Dispozitivi:"
-
-#: ../capplets/sound/sound-properties.glade.h:21
-msgid "_Play alerts and sound effects"
-msgstr "Ri_prodho paralajmërime dhe efekte sonorë"
-
-#: ../capplets/sound/sound-properties.glade.h:22
-msgid "_Sound playback:"
-msgstr "Riprodhimi i _zërit:"
-
-#. Bell
-#: ../capplets/sound/sound-theme-definition.h:46
-msgctxt "Sound event"
-msgid "Alert sound"
-msgstr "Paralajmërim sonor"
-
-#: ../capplets/sound/sound-theme-definition.h:47
-msgctxt "Sound event"
-msgid "Visual alert"
-msgstr "Paralajmërim vizual"
-
-#. Windows and buttons
-#: ../capplets/sound/sound-theme-definition.h:49
-msgctxt "Sound event"
-msgid "Windows and Buttons"
-msgstr "Dritaret dhe butonët"
-
-#: ../capplets/sound/sound-theme-definition.h:50
-msgctxt "Sound event"
-msgid "Button clicked"
-msgstr "Buton i klikuar"
-
-#: ../capplets/sound/sound-theme-definition.h:51
-msgctxt "Sound event"
-msgid "Toggle button clicked"
-msgstr "Buton me dy gjëndje i klikuar"
-
-#: ../capplets/sound/sound-theme-definition.h:52
-msgctxt "Sound event"
-msgid "Window maximized"
-msgstr "Dritarja në maksimum"
-
-#: ../capplets/sound/sound-theme-definition.h:53
-msgctxt "Sound event"
-msgid "Window unmaximized"
-msgstr "Dritarja çmaksimizuar"
-
-#: ../capplets/sound/sound-theme-definition.h:54
-msgctxt "Sound event"
-msgid "Window minimised"
-msgstr "Dritarja në minimum"
-
-#. Desktop
-#: ../capplets/sound/sound-theme-definition.h:56
-msgctxt "Sound event"
-msgid "Desktop"
-msgstr "Hapësira e punës"
-
-#: ../capplets/sound/sound-theme-definition.h:57
-msgctxt "Sound event"
-msgid "Login"
-msgstr "Hyrja"
-
-#: ../capplets/sound/sound-theme-definition.h:58
-msgctxt "Sound event"
-msgid "Logout"
-msgstr "Përfundimi i seancës"
-
-#: ../capplets/sound/sound-theme-definition.h:59
-msgctxt "Sound event"
-msgid "New e-mail"
-msgstr "Mesazh i ri poste"
-
-#: ../capplets/sound/sound-theme-definition.h:60
-msgctxt "Sound event"
-msgid "Empty trash"
-msgstr "Zbrazje koshi"
-
-#: ../capplets/sound/sound-theme-definition.h:61
-msgctxt "Sound event"
-msgid "Long action completed (download, CD burning, etc.)"
-msgstr "Përfundimi një veprimi të gjatë (shkarkime, masterizim CD, etj.)"
-
-#. Alerts?
-#: ../capplets/sound/sound-theme-definition.h:63
-msgctxt "Sound event"
-msgid "Alerts"
-msgstr "Sinjalizime"
-
-#: ../capplets/sound/sound-theme-definition.h:64
-msgctxt "Sound event"
-msgid "Information or question"
-msgstr "Informacione ose pyetje"
-
-#: ../capplets/sound/sound-theme-definition.h:65
-msgctxt "Sound event"
-msgid "Warning"
-msgstr "Kujdes"
-
-#: ../capplets/sound/sound-theme-definition.h:66
-msgctxt "Sound event"
-msgid "Error"
-msgstr "Gabim"
-
-#: ../capplets/sound/sound-theme-definition.h:67
-msgctxt "Sound event"
-msgid "Battery warning"
-msgstr "Paralajmërim nga bateria"
-
-#: ../capplets/sound/sound-theme.c:437 ../capplets/sound/sound-theme.c:563
-msgid "Flash screen"
-msgstr "Ndriço të gjithë ekranin"
-
-#: ../capplets/sound/sound-theme.c:441 ../capplets/sound/sound-theme.c:567
-msgid "Flash window"
-msgstr "Ndriço dritaren"
-
-#: ../capplets/sound/sound-theme.c:463 ../capplets/sound/sound-theme.c:1018
-msgid "Testing event sound"
-msgstr "Tingulli verifikues i eventeve"
-
-#: ../capplets/sound/sound-theme.c:482
-msgid "Select Sound File"
-msgstr "Zgjidh file e tingullit"
-
-#: ../capplets/sound/sound-theme.c:493
-msgid "Sound files"
-msgstr "File audio"
-
-#: ../capplets/sound/sound-theme.c:547
-msgid "Custom..."
-msgstr "Personalizimi..."
-
-#: ../capplets/windows/gnome-window-properties.c:344
-msgid "Cannot start the preferences application for your window manager"
-msgstr ""
-"E pamundur nisja e aplikativit për preferimet e menazhuesit të dritareve"
-
-#. translators: this is the Control key
-#: ../capplets/windows/gnome-window-properties.c:602
-msgid "C_ontrol"
-msgstr "C_ontrol"
-
-#: ../capplets/windows/gnome-window-properties.c:607
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:613
-msgid "H_yper"
-msgstr "H_yper"
-
-#: ../capplets/windows/gnome-window-properties.c:620
-msgid "S_uper (or \"Windows logo\")"
-msgstr "S_uper (ose «Stema e Windows»)"
-
-#: ../capplets/windows/gnome-window-properties.c:627
-msgid "_Meta"
-msgstr "_Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Pulsanti i lëvizjes</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>Veprimi për shtyllën e titullit</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Zgjedhja e dritares</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr ""
-"Për të lëvizur një dritare, shtyp-dhe-mbaj këtë tast pastaj kap dritaren:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Preferimet e dritareve"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_Dopjo-klikim mbi titullin për të kryer këtë veprim:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "_Intervali përpara ngritjes në plan të parë:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_Sill në plan të parë dritaret e zgjedhura mbas një intervali"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Zgjidh dritaret kur mouse kalon sipër tyre"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "sekonda"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "Përcakton pronësitë e dritareve"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "Dritaret"
-
-#. make start action
-#: ../libslab/application-tile.c:372
+#~ msgid "Failed to construct test pipeline for '%s'"
+#~ msgstr "Dështoi ndërtimi i pipeline i provës për «%s»"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - Advanced Linux Sound Architecture"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART Sound Daemon"
+
+#~ msgid "ESD - Enlightened Sound Daemon"
+#~ msgstr "ESD - Enlightened Sound Daemon"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - Open Sound System"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "Server audio PulseAudio"
+
+#~ msgid "Silence"
+#~ msgstr "Heshtje"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "- Preferimet audo të GNOME"
+
+#~ msgid "<b>Alerts and Sound Effects</b>"
+#~ msgstr "<b>Alarme dhe efekte sonorë</b>"
+
+#~ msgid "<b>Audio Conferencing</b>"
+#~ msgstr "<b>Konferenca audio</b>"
+
+#~ msgid "<b>Default Mixer Tracks</b>"
+#~ msgstr "<b>Pistat e paracaktuara të mixer</b>"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Muzikë dhe filma</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>Evente sonorë</b>"
+
+#~ msgid "<b>Sound Theme</b>"
+#~ msgstr "<b>Tema sonore</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">Verifikimi...</span>"
+
+#~ msgid "Play _alert sound"
+#~ msgstr "Riprodho tinguj p_aralajmërues"
+
+#~ msgid "Play _sound effects when buttons are clicked"
+#~ msgstr "Riprodho efekte _sonorë kur klikohen butonët"
+
+#~ msgid ""
+#~ "Select the device and tracks to control with the keyboard. Use the Shift "
+#~ "and Control keys to select multiple tracks if required."
+#~ msgstr ""
+#~ "Zgjidh dispozitivin dhe kanalet për tu kontrolluar nga tastiera. Përdor "
+#~ "pulsantët «Shift» dhe «Control» nëse duhen zgjedhur disa pista."
+
+#~ msgid "So_und playback:"
+#~ msgstr "Riprodhimi i zë_rit:"
+
+#~ msgid "Sou_nd capture:"
+#~ msgstr "Regjistrimi i zër_it:"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferimet e zërit"
+
+#~ msgid "Testing Pipeline"
+#~ msgstr "Verifikimi i pipeline"
+
+#~ msgid "_Device:"
+#~ msgstr "_Dispozitivi:"
+
+#~ msgid "_Play alerts and sound effects"
+#~ msgstr "Ri_prodho paralajmërime dhe efekte sonorë"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "Riprodhimi i _zërit:"
+
+#~ msgctxt "Sound event"
+#~ msgid "Windows and Buttons"
+#~ msgstr "Dritaret dhe butonët"
+
+#~ msgctxt "Sound event"
+#~ msgid "Toggle button clicked"
+#~ msgstr "Buton me dy gjëndje i klikuar"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window maximized"
+#~ msgstr "Dritarja në maksimum"
+
+#~ msgctxt "Sound event"
+#~ msgid "Window unmaximized"
+#~ msgstr "Dritarja çmaksimizuar"
+
+#~ msgctxt "Sound event"
+#~ msgid "Desktop"
+#~ msgstr "Hapësira e punës"
+
+#~ msgctxt "Sound event"
+#~ msgid "Login"
+#~ msgstr "Hyrja"
+
+#~ msgctxt "Sound event"
+#~ msgid "Logout"
+#~ msgstr "Përfundimi i seancës"
+
+#~ msgctxt "Sound event"
+#~ msgid "New e-mail"
+#~ msgstr "Mesazh i ri poste"
+
+#~ msgctxt "Sound event"
+#~ msgid "Long action completed (download, CD burning, etc.)"
+#~ msgstr "Përfundimi një veprimi të gjatë (shkarkime, masterizim CD, etj.)"
+
+#~ msgctxt "Sound event"
+#~ msgid "Alerts"
+#~ msgstr "Sinjalizime"
+
+#~ msgctxt "Sound event"
+#~ msgid "Information or question"
+#~ msgstr "Informacione ose pyetje"
+
+#~ msgctxt "Sound event"
+#~ msgid "Warning"
+#~ msgstr "Kujdes"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Tingulli verifikues i eventeve"
+
+#~ msgid "Custom..."
+#~ msgstr "Personalizimi..."
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr ""
+#~ "E pamundur nisja e aplikativit për preferimet e menazhuesit të dritareve"
+
+#~ msgid "C_ontrol"
+#~ msgstr "C_ontrol"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "H_yper"
+#~ msgstr "H_yper"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "S_uper (ose «Stema e Windows»)"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Pulsanti i lëvizjes</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Veprimi për shtyllën e titullit</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Zgjedhja e dritares</b>"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Për të lëvizur një dritare, shtyp-dhe-mbaj këtë tast pastaj kap dritaren:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Preferimet e dritareve"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Dopjo-klikim mbi titullin për të kryer këtë veprim:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Intervali përpara ngritjes në plan të parë:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Sill në plan të parë dritaret e zgjedhura mbas një intervali"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Zgjidh dritaret kur mouse kalon sipër tyre"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Përcakton pronësitë e dritareve"
+
 #, c-format
-msgid "<b>Start %s</b>"
-msgstr "<b>Nis %s</b>"
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>Nis %s</b>"
 
-#: ../libslab/application-tile.c:391 ../libslab/bookmark-agent.c:1056
-msgid "Help"
-msgstr "Ndihmë"
+#~ msgid "Upgrade"
+#~ msgstr "Përditësimi"
 
-#: ../libslab/application-tile.c:438
-msgid "Upgrade"
-msgstr "Përditësimi"
+#~ msgid "Uninstall"
+#~ msgstr "Çinstalimi"
 
-#: ../libslab/application-tile.c:453
-msgid "Uninstall"
-msgstr "Çinstalimi"
+#~ msgid "Add to Favorites"
+#~ msgstr "Shto tek të preferuarit"
 
-#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
-msgid "Remove from Favorites"
-msgstr "Hiq nga të preferuarit"
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "Hiq nga programet në nisje"
 
-#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
-msgid "Add to Favorites"
-msgstr "Shto tek të preferuarit"
+#~ msgid "Add to Startup Programs"
+#~ msgstr "Shto tek programet në nisje"
 
-#: ../libslab/application-tile.c:867
-msgid "Remove from Startup Programs"
-msgstr "Hiq nga programet në nisje"
-
-#: ../libslab/application-tile.c:869
-msgid "Add to Startup Programs"
-msgstr "Shto tek programet në nisje"
-
-#: ../libslab/app-shell.c:750
 #, c-format
-msgid ""
-"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
-"\n"
-" Your filter \"<b>%s</b>\" does not match any items.</span>"
-msgstr ""
-"<span size=\"large\"><b>Nuk u gjet asnjë korrespondues.</b> </span><span>\n"
-"\n"
-" Filtri \"<b>%s</b>\" nuk zgjedh asnjë element.</span>"
+#~ msgid ""
+#~ "<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+#~ "\n"
+#~ " Your filter \"<b>%s</b>\" does not match any items.</span>"
+#~ msgstr ""
+#~ "<span size=\"large\"><b>Nuk u gjet asnjë korrespondues.</b> </"
+#~ "span><span>\n"
+#~ "\n"
+#~ " Filtri \"<b>%s</b>\" nuk zgjedh asnjë element.</span>"
 
-#: ../libslab/app-shell.c:900
-msgid "Other"
-msgstr "Të tjerë"
+#~ msgid "Shutdown"
+#~ msgstr "Shuaj"
 
-#: ../libslab/bookmark-agent.c:1058
-msgid "Lock Screen"
-msgstr "Blloko ekranin"
+#~ msgid "New Spreadsheet"
+#~ msgstr "Fletë e re llogaritje"
 
-#: ../libslab/bookmark-agent.c:1060
-msgid "Logout"
-msgstr "Përfundimi i seancës"
+#~ msgid "New Document"
+#~ msgstr "Dokument i ri"
 
-#: ../libslab/bookmark-agent.c:1062
-msgid "Shutdown"
-msgstr "Shuaj"
+#~ msgid "Home"
+#~ msgstr "Shtëpia"
 
-#: ../libslab/bookmark-agent.c:1087
-msgid "New Spreadsheet"
-msgstr "Fletë e re llogaritje"
+#~ msgid "Documents"
+#~ msgstr "Dokumente"
 
-#: ../libslab/bookmark-agent.c:1092
-msgid "New Document"
-msgstr "Dokument i ri"
-
-#: ../libslab/bookmark-agent.c:1143
-msgid "Home"
-msgstr "Shtëpia"
-
-#: ../libslab/bookmark-agent.c:1148
-msgid "Documents"
-msgstr "Dokumente"
-
-#: ../libslab/bookmark-agent.c:1161
-msgid "File System"
-msgstr "File i sistemit"
-
-#: ../libslab/bookmark-agent.c:1165
-msgid "Network Servers"
-msgstr "Server rrjeti"
-
-#: ../libslab/bookmark-agent.c:1194
-msgid "Search"
-msgstr "Kërko"
-
-#. make open with default action
-#: ../libslab/directory-tile.c:171
 #, c-format
-msgid "<b>Open</b>"
-msgstr "<b>Hap</b>"
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Hap</b>"
 
-#. make rename action
-#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:235
-msgid "Rename..."
-msgstr "Riemërto..."
+#~ msgid "Send To..."
+#~ msgstr "Dërgo tek..."
 
-#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
-#: ../libslab/document-tile.c:249 ../libslab/document-tile.c:258
-msgid "Send To..."
-msgstr "Dërgo tek..."
+#~ msgid "Delete"
+#~ msgstr "Elemino"
 
-#. make move to trash action
-#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:284
-msgid "Move to Trash"
-msgstr "Lëviz në kosh"
-
-#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:456
-#: ../libslab/document-tile.c:294 ../libslab/document-tile.c:831
-msgid "Delete"
-msgstr "Elemino"
-
-#: ../libslab/directory-tile.c:532 ../libslab/document-tile.c:979
 #, c-format
-msgid "Are you sure you want to permanently delete \"%s\"?"
-msgstr "Eleminon përgjithmonë «%s»?"
+#~ msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgstr "Eleminon përgjithmonë «%s»?"
 
-#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:980
-msgid "If you delete an item, it is permanently lost."
-msgstr "Një element i eleminuar do të humbasë përgjithmonë."
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "Një element i eleminuar do të humbasë përgjithmonë."
 
-#: ../libslab/document-tile.c:196
 #, c-format
-msgid "<b>Open with \"%s\"</b>"
-msgstr "<b>Hap me «%s»</b>"
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>Hap me «%s»</b>"
 
-#: ../libslab/document-tile.c:208
-msgid "Open with Default Application"
-msgstr "Hap me aplikativin e paracaktuar"
+#~ msgid "Open in File Manager"
+#~ msgstr "Hap në «file manager»"
 
-#: ../libslab/document-tile.c:219
-msgid "Open in File Manager"
-msgstr "Hap në «file manager»"
+#~ msgid "?"
+#~ msgstr "?"
 
-#: ../libslab/document-tile.c:611
-msgid "?"
-msgstr "?"
+#~ msgid "%l:%M %p"
+#~ msgstr "%k.%M"
 
-#: ../libslab/document-tile.c:618
-msgid "%l:%M %p"
-msgstr "%k.%M"
+#~ msgid "Today %l:%M %p"
+#~ msgstr "Sot në orën %k.%M"
 
-#: ../libslab/document-tile.c:626
-msgid "Today %l:%M %p"
-msgstr "Sot në orën %k.%M"
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "Dje në orën %k.%M"
 
-#: ../libslab/document-tile.c:636
-msgid "Yesterday %l:%M %p"
-msgstr "Dje në orën %k.%M"
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a në orën %k.%M"
 
-#: ../libslab/document-tile.c:648
-msgid "%a %l:%M %p"
-msgstr "%a në orën %k.%M"
+#~ msgid "%b %d %l:%M %p"
+#~ msgstr "%d %b në orën %k.%M"
 
-#: ../libslab/document-tile.c:656
-msgid "%b %d %l:%M %p"
-msgstr "%d %b në orën %k.%M"
+#~ msgid "%b %d %Y"
+#~ msgstr "%d %b %Y"
 
-#: ../libslab/document-tile.c:658
-msgid "%b %d %Y"
-msgstr "%d %b %Y"
+#~ msgid "Find Now"
+#~ msgstr "Kërko tani"
 
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
-msgstr "Kërko tani"
-
-#: ../libslab/system-tile.c:128
 #, c-format
-msgid "<b>Open %s</b>"
-msgstr "<b>Hap %s</b>"
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>Hap %s</b>"
 
-#: ../libslab/system-tile.c:141
 #, c-format
-msgid "Remove from System Items"
-msgstr "Hiq nga zërat e sistemit"
+#~ msgid "Remove from System Items"
+#~ msgstr "Hiq nga zërat e sistemit"
 
-#: ../libwindow-settings/gnome-wm-manager.c:318
 #, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr ""
-"Menazhuesi i dritareve «%s» nuk ka një instrument konfigurimi të "
-"regjistruar\n"
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "Menazhuesi i dritareve «%s» nuk ka një instrument konfigurimi të "
+#~ "regjistruar\n"
 
-#: ../libwindow-settings/metacity-window-manager.c:402
-msgid "Maximize"
-msgstr "Maksimizo"
+#~ msgid "Maximize"
+#~ msgstr "Maksimizo"
 
-#: ../libwindow-settings/metacity-window-manager.c:403
-msgid "Maximize Vertically"
-msgstr "Maksimizo vertikalisht"
+#~ msgid "Maximize Vertically"
+#~ msgstr "Maksimizo vertikalisht"
 
-#: ../libwindow-settings/metacity-window-manager.c:404
-msgid "Maximize Horizontally"
-msgstr "Maksimizo horizontalisht"
+#~ msgid "Maximize Horizontally"
+#~ msgstr "Maksimizo horizontalisht"
 
-#: ../libwindow-settings/metacity-window-manager.c:405
-msgid "Minimize"
-msgstr "Minimizo"
+#~ msgid "Minimize"
+#~ msgstr "Minimizo"
 
-#: ../libwindow-settings/metacity-window-manager.c:406
-msgid "Roll up"
-msgstr "Palos"
+#~ msgid "Roll up"
+#~ msgstr "Palos"
 
-#: ../libwindow-settings/metacity-window-manager.c:407
-msgid "None"
-msgstr "Asgjë"
-
-#: ../shell/control-center.c:62
 #, c-format
-msgid "key not found [%s]\n"
-msgstr "pulsanti nuk u gjet [%s]\n"
+#~ msgid "key not found [%s]\n"
+#~ msgstr "pulsanti nuk u gjet [%s]\n"
 
-#: ../shell/control-center.c:159
-msgid "Filter"
-msgstr "Filtri"
+#~ msgid "Groups"
+#~ msgstr "Grupe"
 
-#: ../shell/control-center.c:159
-msgid "Groups"
-msgstr "Grupe"
+#~ msgid "Control Center"
+#~ msgstr "Qendra e kontrollit"
 
-#: ../shell/control-center.c:159
-msgid "Common Tasks"
-msgstr "Aktivitete të përbashkët"
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "Mbyll qendrën e kontrollit kur aktivizohet një aktivitet"
 
-#: ../shell/control-center.c:163 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Qendra e kontrollit"
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "Del nga terminali nëse kryhet një veprim shtimi apo heqje"
 
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr "Mbyll qendrën e kontrollit kur aktivizohet një aktivitet"
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "Del nga terminali nëse kryhet një veprim ndihme"
 
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr "Del nga terminali nëse kryhet një veprim shtimi apo heqje"
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "Del nga terminali nëse kryhet një veprim nisje"
 
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr "Del nga terminali nëse kryhet një veprim ndihme"
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "Del nga terminali nëse kryhet një veprim përditësimi apo çinstalimi"
 
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr "Del nga terminali nëse kryhet një veprim nisje"
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "Tregon nëse duhet mbyllur terminali kur kryhet një veprim ndihme."
 
-#: ../shell/control-center.schemas.in.h:5
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr "Del nga terminali nëse kryhet një veprim përditësimi apo çinstalimi"
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "Tregon nëse duhet mbyllur terminali kur kryhet një veprim nisje."
 
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed."
-msgstr "Tregon nëse duhet mbyllur terminali kur kryhet një veprim ndihme."
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr ""
+#~ "Tregon nëse duhet mbyllur terminali kur kryhet një veprim shtimi apo "
+#~ "heqje."
 
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed."
-msgstr "Tregon nëse duhet mbyllur terminali kur kryhet një veprim nisje."
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr ""
+#~ "Tregon nëse duhet mbyllur terminali kur kryhet një veprim përditësimi apo "
+#~ "çinstalimi."
 
-#: ../shell/control-center.schemas.in.h:8
-msgid ""
-"Indicates whether to close the shell when an add or remove action is "
-"performed."
-msgstr ""
-"Tregon nëse duhet mbyllur terminali kur kryhet një veprim shtimi apo heqje."
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "Emri i aktivitetit dhe file .desktop përkatës"
 
-#: ../shell/control-center.schemas.in.h:9
-msgid ""
-"Indicates whether to close the shell when an upgrade or uninstall action is "
-"performed."
-msgstr ""
-"Tregon nëse duhet mbyllur terminali kur kryhet një veprim përditësimi apo "
-"çinstalimi."
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "Emri i aktivitetit për tu shfaqur në qendrën e kontrollit ndjekur nga \";"
+#~ "\" si ndarës dhe nga emri i .desktop përkatës për nisjen e aktivitetit."
 
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr "Emri i aktivitetit dhe file .desktop përkatës"
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[Ndrysho temën;gtk-theme-selector.desktop,Përcakto aplikativët e "
+#~ "preferuar;default-applications.desktop,Shto printues;gnome-cups-manager."
+#~ "desktop]"
 
-#: ../shell/control-center.schemas.in.h:11
-msgid ""
-"The task name to be displayed in the control-center followed by a \";\" "
-"separator then the filename of an associated .desktop file to launch for "
-"that task."
-msgstr ""
-"Emri i aktivitetit për tu shfaqur në qendrën e kontrollit ndjekur nga \";\" "
-"si ndarës dhe nga emri i .desktop përkatës për nisjen e aktivitetit."
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr ""
+#~ "Nëse E VËRTETË, qendra e kontrollit do të mbyllet në aktivizimin e një "
+#~ "«aktiviteti të përbashkët»."
 
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
-msgid ""
-"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
-"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
-msgstr ""
-"[Ndrysho temën;gtk-theme-selector.desktop,Përcakto aplikativët e preferuar;"
-"default-applications.desktop,Shto printues;gnome-cups-manager.desktop]"
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Instrument konfigurimi për GNOME"
 
-#: ../shell/control-center.schemas.in.h:14
-msgid ""
-"if true, the control-center will close when a \"Common Task\" is activated."
-msgstr ""
-"Nëse E VËRTETË, qendra e kontrollit do të mbyllet në aktivizimin e një "
-"«aktiviteti të përbashkët»."
+#~ msgid "_Postpone Break"
+#~ msgstr "_Shty për më vonë pushimin"
 
-#: ../shell/gnomecc.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "Instrument konfigurimi për GNOME"
+#~ msgid "Take a break!"
+#~ msgstr "Pusho pak!"
 
-#: ../typing-break/drw-break-window.c:189
-msgid "_Postpone Break"
-msgstr "_Shty për më vonë pushimin"
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Pusho pak"
 
-#: ../typing-break/drw-break-window.c:245
-msgid "Take a break!"
-msgstr "Pusho pak!"
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#. translators: keep the initial "/"
-#: ../typing-break/drwright.c:130
-msgid "/_Preferences"
-msgstr "/_Preferime"
-
-#: ../typing-break/drwright.c:131
-msgid "/_About"
-msgstr "/_Informacione"
-
-#: ../typing-break/drwright.c:133
-msgid "/_Take a Break"
-msgstr "/_Pusho pak"
-
-#: ../typing-break/drwright.c:489
 #, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "Mungon %d minutë deri në pushimin tjetër"
-msgstr[1] "Mungojnë %d minuta deri në pushimin tjetër"
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "Mungon %d minutë deri në pushimin tjetër"
+#~ msgstr[1] "Mungojnë %d minuta deri në pushimin tjetër"
 
-#: ../typing-break/drwright.c:493
 #, c-format
-msgid "Less than one minute until the next break"
-msgstr "Mungon më pak se një minutë deri në pushimin tjetër"
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Mungon më pak se një minutë deri në pushimin tjetër"
 
-#: ../typing-break/drwright.c:580
 #, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
-msgstr ""
-"E pamundur hapja e dritares së dialogut të pronësive të pushimit për shkak "
-"të gabimit në vijim: %s"
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "E pamundur hapja e dritares së dialogut të pronësive të pushimit për "
+#~ "shkak të gabimit në vijim: %s"
 
-#: ../typing-break/drwright.c:599
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "Shkruar nga Richard Hult <richard@imendio.com>"
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Shkruar nga Richard Hult <richard@imendio.com>"
 
-#: ../typing-break/drwright.c:600
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Eye candy shtuar nga Anders Carlsson"
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Eye candy shtuar nga Anders Carlsson"
 
-#: ../typing-break/drwright.c:609
-msgid "A computer break reminder."
-msgstr "Një program për t'ju kujtuar për të pushuar gjatë punës në kompjuter."
+#~ msgid "A computer break reminder."
+#~ msgstr ""
+#~ "Një program për t'ju kujtuar për të pushuar gjatë punës në kompjuter."
 
-#: ../typing-break/drwright.c:611
-msgid "translator-credits"
-msgstr ""
-"Elian Myftiu <elian@alblinux.net>, 2003-2006\n"
-"Laurent Dhima <laurenti@alblinux.net>, 2008"
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "Elian Myftiu <elian@alblinux.net>, 2003-2006\n"
+#~ "Laurent Dhima <laurenti@alblinux.net>, 2008"
 
-#: ../typing-break/main.c:61
-msgid "Enable debugging code"
-msgstr "Aktivizoo kodin e debug"
+#~ msgid "Enable debugging code"
+#~ msgstr "Aktivizoo kodin e debug"
 
-#: ../typing-break/main.c:63
-msgid "Don't check whether the notification area exists"
-msgstr "Mos kontrollo praninë e zonës së njoftimeve"
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "Mos kontrollo praninë e zonës së njoftimeve"
 
-#: ../typing-break/main.c:89
-msgid "Typing Monitor"
-msgstr "Kontrolli i shkrimit"
-
-#: ../typing-break/main.c:105
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
-msgstr ""
-"Programi për kontrollin e shkrimit përdor zonën e njoftimeve për të shfaqur "
-"informacionet. Mesa duket ju nuk keni asnjë zonë njoftimi tek paneli juaj. "
-"Mund ta shtoni me një klikim të djathtë tek paneli juaj e duke zgjedhur "
-"\"Shto në panel\" , gjeni \"Zona e njoftimit\" e klikoni mbi pulsantin "
-"«Shto»."
-
-msgid "Show help options"
-msgstr "Shfaq opcionet e ndihmës"
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Programi për kontrollin e shkrimit përdor zonën e njoftimeve për të "
+#~ "shfaqur informacionet. Mesa duket ju nuk keni asnjë zonë njoftimi tek "
+#~ "paneli juaj. Mund ta shtoni me një klikim të djathtë tek paneli juaj e "
+#~ "duke zgjedhur \"Shto në panel\" , gjeni \"Zona e njoftimit\" e klikoni "
+#~ "mbi pulsantin «Shto»."

--- a/po/sq.po~
+++ b/po/sq.po~
@@ -1,0 +1,3431 @@
+# Përkthimi i gnome-control-center në shqip.
+# Copyright (C) 2003-2006, 2008 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Elian Myftiu <elian@alblinux.net>, 2003-2006.
+# Laurent Dhima <laurenti@alblinux.net>, 2008.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center HEAD\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2008-09-15 05:35+0000\n"
+"PO-Revision-Date: 2008-09-20 11:58+0200\n"
+"Last-Translator: Laurent Dhima <laurenti@alblinux.net>\n"
+"Language-Team: albanian <gnome-albanian-perkthyesit@lists.sourceforge.net>\n"
+"Language: sq\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "Bordi i figurës/etiketës"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+"Gjerësia e kornizës rreth etiketës dhe figurës në dialogun e paralajmërimit"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "Lloji i paralajmërimit"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "Lloji i paralajmërimit"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "Butonët e paralajmërimit"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "Butonët e shfaqur në dialogun e paralajmërimit"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "Shfaq më shumë _detaje"
+
+#: ../capplets/about-me/gnome-about-me.c:739
+msgid "Select Image"
+msgstr "Zgjidh figurën"
+
+#: ../capplets/about-me/gnome-about-me.c:741
+msgid "No Image"
+msgstr "Asnjë figurë"
+
+#: ../capplets/about-me/gnome-about-me.c:769
+#: ../capplets/appearance/appearance-desktop.c:661
+msgid "Images"
+msgstr "Figura"
+
+#: ../capplets/about-me/gnome-about-me.c:773
+#: ../capplets/appearance/theme-installer.c:696
+msgid "All Files"
+msgstr "Të gjithë file"
+
+#: ../capplets/about-me/gnome-about-me.c:911
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"U ndesh një gabim gjatë përpjekjes për marrje informacione mbi rubrikën\n"
+"Evolution Data Server nuk mund të trajtojë protokollin"
+
+#: ../capplets/about-me/gnome-about-me.c:932
+msgid "Unable to open address book"
+msgstr "E pamundur hapja e rubrikës"
+
+#: ../capplets/about-me/gnome-about-me.c:946
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+"ID i panjohur hyrje, baza me të dhënat e përdoruesve mund të jetë korruptuar"
+
+#: ../capplets/about-me/gnome-about-me.c:976
+#: ../capplets/about-me/gnome-about-me.c:978
+#, c-format
+msgid "About %s"
+msgstr "Informacione mbi %s"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "About Me"
+msgstr "Informacione përdoruesi"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "Përcakton të dhënat vetiake personale"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+msgid "<b>Email</b>"
+msgstr "<b>Email</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+msgid "<b>Home</b>"
+msgstr "<b>Shtëpi</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Mesazhe të menjëhershëm</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Job</b>"
+msgstr "<b>Punë</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Telephone</b>"
+msgstr "<b>Telefoni</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Web</b>"
+msgstr "<b>Web</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Work</b>"
+msgstr "<b>Punë</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+msgstr ""
+"<span size=\"larger\" weight=\"bold\">Ndryshimi i fjalëkalimit personal</"
+"span>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "A_ddress:"
+msgstr "A_dresa:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_ssistant:"
+msgstr "A_sistenti:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "Address"
+msgstr "Adresa"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "C_ity:"
+msgstr "Qytet_i:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "C_ompany:"
+msgstr "K_ompania:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "Cale_ndar:"
+msgstr "Kale_ndari:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "Change Passwo_rd..."
+msgstr "Ndrysho fjalëka_limin..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Change pa_ssword"
+msgstr "Ndrysho f_jalëkalimin"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change password"
+msgstr "Ndrysho fjalëkalimin"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Ci_ty:"
+msgstr "Qy_teti:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Co_untry:"
+msgstr "Sh_teti:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Contact"
+msgstr "Kontakti"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Cou_ntry:"
+msgstr "Shte_ti:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Current _password:"
+msgstr "_Fjalëkalimi aktual:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr "Emri dhe mbiemri"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Hom_e:"
+msgstr "Shtë_pi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "P.O. _box:"
+msgstr "Kutia e po_stës:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P._O. box:"
+msgstr "Kutia e p_ostës:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "Personal Info"
+msgstr "Të dhëna personale"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+#: ../capplets/about-me/gnome-about-me-password.c:938
+msgid ""
+"Please type your password again in the <b>Retype new password</b> field."
+msgstr "Rishkruaj fjalëkalimin në fushën e <b>Rishkruaj fjalëkalimin e ri</b>."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "Select your photo"
+msgstr "Zgjidh fotografinë"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+msgid "State/Pro_vince:"
+msgstr "Shteti/Rre_thi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid ""
+"To change your password, enter your current password in the field below and "
+"click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for "
+"verification and click <b>Change password</b>."
+msgstr ""
+"Për të ndryshuar fjalëkalimin, shkruaj fjalëkalimin aktual në fushën e "
+"mëposhtme dhe kliko tek <b>Autentikimi</b>.\n"
+"Mbas autentikimit, shkruaj fjalëkalimin e ri, rishkruaje për verifikim dhe "
+"kliko tek <b>Ndrysho fjalëkalimin</b>."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid "User name:"
+msgstr "Emri i përdoruesit:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Web _log:"
+msgstr "Di_tari në web:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "Wor_k:"
+msgstr "Pun_a:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "Work _fax:"
+msgstr "_Fax në punë:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "Zip/_Postal code:"
+msgstr "Zip/Kodi i _postës:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "_Address:"
+msgstr "_Adresa:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "_Authenticate"
+msgstr "_Autentikimi"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Department:"
+msgstr "_Dipartimenti:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Groupwise:"
+msgstr "_Groupwise:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Home page:"
+msgstr "Faqja në w_eb:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_Home:"
+msgstr "_Shtëpia:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Jabber:"
+msgstr "_Jabber:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Manager:"
+msgstr "_Manageri:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_Mobile:"
+msgstr "_Celulari:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_New password:"
+msgstr "Fjalëkalimi i _ri:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Profession:"
+msgstr "_Profesioni:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Retype new password:"
+msgstr "_Rishkruaj fjalëkalimin e ri:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_State/Province:"
+msgstr "_Shteti/Rrethi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:55
+msgid "_Title:"
+msgstr "_Titulli:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:56
+msgid "_Work:"
+msgstr "_Puna:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:57
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:58
+msgid "_Zip/Postal code:"
+msgstr "_Zip/Kodi i postës:"
+
+#: ../capplets/about-me/gnome-about-me-password.c:162
+msgid "Child exited unexpectedly"
+msgstr "Biri doli në menyrë të papritur"
+
+#: ../capplets/about-me/gnome-about-me-password.c:297
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr "I pamundur ndalimi i kanalit të IO backend_stdin: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:310
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr "I pamundur ndalimi i kanalit të IO backend_stdout: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:409
+msgid "Authenticated!"
+msgstr "Autentikuar!"
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:475
+#: ../capplets/about-me/gnome-about-me-password.c:551
+msgid ""
+"Your password has been changed since you initially authenticated! Please re-"
+"authenticate."
+msgstr ""
+"Fjalëkalimi është ndryshuar që nga autentikimi fillestar. Kryej përsëri "
+"autentikimin."
+
+#: ../capplets/about-me/gnome-about-me-password.c:477
+msgid "That password was incorrect."
+msgstr "Fjalëkalimi nuk ishte i vlefshëm."
+
+#: ../capplets/about-me/gnome-about-me-password.c:524
+msgid "Your password has been changed."
+msgstr "Fjalëkalimi juaj është ndryshuar."
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:534
+#, c-format
+msgid "System error: %s."
+msgstr "Gabim sistemi: %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:537
+msgid "The password is too short."
+msgstr "Fjalëkalimi është tepër i shkurtër."
+
+#: ../capplets/about-me/gnome-about-me-password.c:540
+msgid "The password is too simple."
+msgstr "Fjalëkalimi është tepër i thjeshtë."
+
+#: ../capplets/about-me/gnome-about-me-password.c:543
+msgid "The old and new passwords are too similar."
+msgstr "Fjalëkalimi i ri është tepër i ngjashëm me të vjetrin."
+
+#: ../capplets/about-me/gnome-about-me-password.c:545
+msgid "The new password must contain numeric or special character(s)."
+msgstr "Fjalëkalimi i ri mund të përmbajë simbole numerikë ose specialë."
+
+#: ../capplets/about-me/gnome-about-me-password.c:548
+msgid "The old and new passwords are the same."
+msgstr "Fjalëkalimi i ri është njësoj me fjalëkalimin e vjetër."
+
+#. translators: Unable to launch <program>: <error message>
+#: ../capplets/about-me/gnome-about-me-password.c:820
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr "E pamundur nisja e %s: %s"
+
+#: ../capplets/about-me/gnome-about-me-password.c:824
+msgid "Unable to launch backend"
+msgstr "E pamundur nisja e backend"
+
+#: ../capplets/about-me/gnome-about-me-password.c:825
+msgid "A system error has occurred"
+msgstr "U ndesh një gabim sistemi"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:845
+msgid "Checking password..."
+msgstr "Kontrolli i fjalëkalimit..."
+
+#: ../capplets/about-me/gnome-about-me-password.c:932
+msgid "Click <b>Change password</b> to change your password."
+msgstr "Kliko tek <b>Ndrysho fjalëkalimin</b> për të ndryshuar fjalëkalimin."
+
+#: ../capplets/about-me/gnome-about-me-password.c:935
+msgid "Please type your password in the <b>New password</b> field."
+msgstr "Shkruaj fjalëkalimin tek fusha e <b>Fjalëkalimi i ri</b>."
+
+#: ../capplets/about-me/gnome-about-me-password.c:941
+msgid "The two passwords are not equal."
+msgstr "Dy fjalëkalimet nuk përputhen."
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Assistive Technologies</b>"
+msgstr "<b>Teknollogjitë asistuese</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Preferences</b>"
+msgstr "<b>Preferimet</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid "Accessible Lo_gin"
+msgstr "Hy_rje e përshtatshme"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technologies Preferences"
+msgstr "Preferimet e teknollogjive asistuese"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid ""
+"Changes to enable assistive technologies will not take effect until your "
+"next log in."
+msgstr ""
+"Nryshimet për aktivizimin e teknollogjive asistuese nuk do të kenë efekt "
+"deri në hyrjen e ardhshme."
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Close and _Log Out"
+msgstr "Mbyll dhe di_l jashtë"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "Jump to Preferred Applications dialog"
+msgstr "Shkon tek dialogu Aplikativët e preferuar"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "Jump to the Accessible Login dialog"
+msgstr "Shkon tek dialogu Hyrje e përshtatshme"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr "Shkon tek dialogu Përshtatshmëria e tastierës"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "Jump to the Mouse Accessibility dialog"
+msgstr "Shkon tek dialogu Përshtatshmëria e mouse"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
+msgid "_Enable assistive technologies"
+msgstr "_Aktivizo teknologjitë asistuese"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
+msgid "_Keyboard Accessibility"
+msgstr "Përshtatshmëria e _tastierës"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
+msgid "_Mouse Accessibility"
+msgstr "Përshtatshmëria e _mouse"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
+msgid "_Preferred Applications"
+msgstr "Aplikativë të _preferuar"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technologies"
+msgstr "Teknollogjitë asistuese"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Choose which accessibility features to enable when you log in"
+msgstr "Zgjidh çfarë karakteristika përshtatshmërie të akivizohen në hyrje"
+
+#: ../capplets/appearance/appearance-desktop.c:629
+msgid "Add Wallpaper"
+msgstr "Shto sfond ekrani"
+
+#: ../capplets/appearance/appearance-desktop.c:665
+msgid "All files"
+msgstr "Të gjithë file"
+
+#: ../capplets/appearance/appearance-font.c:494
+msgid "Font may be too large"
+msgstr "Shkronja mund të jetë tepër e madhe"
+
+#: ../capplets/appearance/appearance-font.c:498
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
+"përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një madhësie më të "
+"vogël se %d."
+msgstr[1] ""
+"Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
+"përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një madhësie më të "
+"vogël se %d."
+
+#: ../capplets/appearance/appearance-font.c:511
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
+"përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një gërme me "
+"madhësi më të vogël."
+msgstr[1] ""
+"Gërma e zgjedhur është e gjërë %d pikë dhe mund të bëjë të vështirë "
+"përdorimin efikas të kompjuterit. Këshillohet zgjedhja e një gërme me "
+"madhësi më të vogël."
+
+#: ../capplets/appearance/appearance-font.c:533
+msgid "Use previous font"
+msgstr "Përdor gërmën paraardhëse"
+
+#: ../capplets/appearance/appearance-font.c:535
+msgid "Use selected font"
+msgstr "Përdor gërmën e zgjedhur"
+
+#: ../capplets/appearance/appearance-main.c:107
+msgid "Specify the filename of a theme to install"
+msgstr "Specifiko emrin e file të një teme për tu instaluar"
+
+#: ../capplets/appearance/appearance-main.c:108
+msgid "filename"
+msgstr "EMRI_FILE"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/appearance/appearance-main.c:115
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr ""
+"Specifiko emrin e faqes për tu shfaqur (theme|background|fonts|interface)"
+
+#: ../capplets/appearance/appearance-main.c:116
+#: ../capplets/default-applications/gnome-da-capplet.c:880
+#: ../capplets/mouse/gnome-mouse-properties.c:444
+msgid "page"
+msgstr "faqe"
+
+#: ../capplets/appearance/appearance-main.c:123
+msgid "[WALLPAPER...]"
+msgstr "[SFOND EKRANI...]"
+
+#: ../capplets/appearance/appearance-style.c:167
+#: ../capplets/common/gnome-theme-info.c:442
+#: ../capplets/common/gnome-theme-info.c:634
+msgid "Default Pointer"
+msgstr "Kursori i paracaktuar"
+
+#: ../capplets/appearance/appearance-style.c:229
+#: ../capplets/appearance/appearance-themes.c:686
+msgid "Install"
+msgstr "Instalo"
+
+#: ../capplets/appearance/appearance-style.c:249
+#: ../capplets/common/gnome-theme-info.c:1644
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme engine "
+"'%s' is not installed."
+msgstr ""
+"Tema nuk do të shfaqet sikurse parashikuar pasi nuk është instaluar motori i "
+"nevojshëm GTK+ i temës '%s'."
+
+#: ../capplets/appearance/appearance-themes.c:674
+msgid "Apply Background"
+msgstr "Apliko sfondin"
+
+#: ../capplets/appearance/appearance-themes.c:678
+msgid "Apply Font"
+msgstr "Apliko gërmën"
+
+#: ../capplets/appearance/appearance-themes.c:682
+msgid "Revert Font"
+msgstr "Rikthe gërmën"
+
+#: ../capplets/appearance/appearance-themes.c:712
+msgid ""
+"The current theme suggests a background and a font. Also, the last applied "
+"font suggestion can be reverted."
+msgstr ""
+"Tema e tanishme propozon një sfond dhe një lloj gërmash. Është gjithashtu i "
+"mundur rikthimi i llojit të fundit të gërmave të propozuar të aplikuar."
+
+#: ../capplets/appearance/appearance-themes.c:714
+msgid ""
+"The current theme suggests a background. Also, the last applied font "
+"suggestion can be reverted."
+msgstr ""
+"Tema e tanishme propozon një sfond. Është gjithashtu i mundur rikthimi i "
+"llojit të fundit të gërmave të propozuar të aplikuar."
+
+#: ../capplets/appearance/appearance-themes.c:716
+msgid "The current theme suggests a background and a font."
+msgstr "Tema aktuale propozon një sfond dhe një lloj gërme."
+
+#: ../capplets/appearance/appearance-themes.c:718
+msgid ""
+"The current theme suggests a font. Also, the last applied font suggestion "
+"can be reverted."
+msgstr ""
+"Tema e tanishme propozon një lloj gërmash. Është gjithashtu i mundur "
+"rikthimi i llojit të fundit të gërmave të propozuar të aplikuar."
+
+#: ../capplets/appearance/appearance-themes.c:720
+msgid "The current theme suggests a background."
+msgstr "Tema aktuale propozon një sfond."
+
+#: ../capplets/appearance/appearance-themes.c:722
+msgid "The last applied font suggestion can be reverted."
+msgstr "Aplikimi i llojit të fundit të gërmës së propozuar mund të anullohet."
+
+#: ../capplets/appearance/appearance-themes.c:724
+msgid "The current theme suggests a font."
+msgstr "Tema aktuale propozon një lloj gërme."
+
+#: ../capplets/appearance/appearance-themes.c:1045
+#: ../capplets/default-applications/gnome-da-capplet.c:630
+#: ../capplets/sound/sound-properties-capplet.c:262
+#: ../capplets/sound/sound-theme.c:648 ../capplets/sound/sound-theme.c:720
+msgid "Custom"
+msgstr "E personalizuar"
+
+#: ../capplets/appearance/data/appearance.glade.h:1
+msgid "<b>C_olors</b>"
+msgstr "<b>N_gjyrat</b>"
+
+# Nuk e di sa është i përshtatshëm, por tani për tani
+# nuk arrij të gjej asgjë më të saktë... provojmë.
+#. font hinting
+#: ../capplets/appearance/data/appearance.glade.h:3
+msgid "<b>Hinting</b>"
+msgstr "<b>Theksimi (hinting)</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:4
+msgid "<b>Menus and Toolbars</b>"
+msgstr "<b>Panelët e menuve dhe instrumentëve</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:5
+msgid "<b>Preview</b>"
+msgstr "<b>Pamja e parë</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:6
+msgid "<b>Rendering</b>"
+msgstr "<b>Paraqitja në ekran</b>"
+
+# Nuk është aspak termi më i përshtatshëm...
+#: ../capplets/appearance/data/appearance.glade.h:7
+msgid "<b>Smoothing</b>"
+msgstr "<b>Lëmimi (smoothing)</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:8
+msgid "<b>Subpixel Order</b>"
+msgstr "<b>Renditja subpixel</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:9
+msgid "<b>_Wallpaper</b>"
+msgstr "<b>_Sfondi i ekranit</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:10
+msgid "Appearance Preferences"
+msgstr "Preferimet e paraqitjes"
+
+#: ../capplets/appearance/data/appearance.glade.h:11
+msgid "Background"
+msgstr "Sfondi"
+
+#: ../capplets/appearance/data/appearance.glade.h:12
+msgid "Best _shapes"
+msgstr "Optimizo _formën"
+
+#: ../capplets/appearance/data/appearance.glade.h:13
+msgid "Best co_ntrast"
+msgstr "Optimizo ko_ntrastin"
+
+#: ../capplets/appearance/data/appearance.glade.h:14
+msgid "C_ustomize..."
+msgstr "P_ersonalizo..."
+
+#: ../capplets/appearance/data/appearance.glade.h:15
+msgid "C_ut"
+msgstr "P_reje"
+
+#: ../capplets/appearance/data/appearance.glade.h:16
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr ""
+"Ndryshimet në temën tuaj të kursorit do të kenë efekt në hyrjen e ardhshme."
+
+#: ../capplets/appearance/data/appearance.glade.h:17
+msgid "Colors"
+msgstr "Ngjyrat"
+
+#: ../capplets/appearance/data/appearance.glade.h:18
+msgid "Controls"
+msgstr "Kontrollet"
+
+#: ../capplets/appearance/data/appearance.glade.h:19
+msgid "Customize Theme"
+msgstr "Personalizo temën"
+
+#: ../capplets/appearance/data/appearance.glade.h:20
+msgid "D_etails..."
+msgstr "D_etaje..."
+
+#: ../capplets/appearance/data/appearance.glade.h:21
+msgid "Des_ktop font:"
+msgstr "Gërmat për h_apësirën e punës:"
+
+#: ../capplets/appearance/data/appearance.glade.h:22
+msgid "Edit"
+msgstr "Ndrysho"
+
+#: ../capplets/appearance/data/appearance.glade.h:23
+msgid "Font Rendering Details"
+msgstr "Detaje në lidhje me shfaqjen e shkronjave"
+
+#: ../capplets/appearance/data/appearance.glade.h:24
+msgid "Fonts"
+msgstr "Llojet e gërmave"
+
+#: ../capplets/appearance/data/appearance.glade.h:25
+msgid "Gra_yscale"
+msgstr "Shkallë e ngjyrës _gri"
+
+#: ../capplets/appearance/data/appearance.glade.h:26
+msgid "Icons"
+msgstr "Ikonat"
+
+#: ../capplets/appearance/data/appearance.glade.h:27
+msgid "Interface"
+msgstr "Interfaqja"
+
+#: ../capplets/appearance/data/appearance.glade.h:28
+msgid "Large"
+msgstr "E madhe"
+
+#: ../capplets/appearance/data/appearance.glade.h:29
+msgid "N_one"
+msgstr "M_os përdor"
+
+#: ../capplets/appearance/data/appearance.glade.h:30
+msgid "New File"
+msgstr "File i ri"
+
+#: ../capplets/appearance/data/appearance.glade.h:31
+msgid "Open File"
+msgstr "Hap file"
+
+#: ../capplets/appearance/data/appearance.glade.h:32
+msgid "Open a dialog to specify the color"
+msgstr "Hap një dialog për të përcaktuar ngjyrën"
+
+#: ../capplets/appearance/data/appearance.glade.h:33
+msgid "Pointer"
+msgstr "Kursori"
+
+#: ../capplets/appearance/data/appearance.glade.h:34
+msgid "R_esolution:"
+msgstr "D_allueshmëria:"
+
+#: ../capplets/appearance/data/appearance.glade.h:35
+msgid "Save File"
+msgstr "Ruaj file"
+
+#: ../capplets/appearance/data/appearance.glade.h:36
+msgid "Save Theme As..."
+msgstr "Ruaj temën si..."
+
+#: ../capplets/appearance/data/appearance.glade.h:37
+msgid "Save _As..."
+msgstr "Ru_aj si..."
+
+#: ../capplets/appearance/data/appearance.glade.h:38
+msgid "Save _background image"
+msgstr "Ruaj figurën e s_fondit"
+
+#: ../capplets/appearance/data/appearance.glade.h:39
+msgid "Show _icons in menus"
+msgstr "Shfaq _ikonat në menu"
+
+#: ../capplets/appearance/data/appearance.glade.h:40
+msgid "Small"
+msgstr "E vogël"
+
+#: ../capplets/appearance/data/appearance.glade.h:41
+msgid ""
+"Solid color\n"
+"Horizontal gradient\n"
+"Vertical gradient"
+msgstr ""
+"Ngjyrë e njëtrajtshme\n"
+"Gradient horizontal\n"
+"Gradient vertikal"
+
+#: ../capplets/appearance/data/appearance.glade.h:44
+msgid "Sub_pixel (LCDs)"
+msgstr "Sub_pixel (LCD)"
+
+#: ../capplets/appearance/data/appearance.glade.h:45
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "Lëmim i sub_pixel (LCD)"
+
+#: ../capplets/appearance/data/appearance.glade.h:46
+msgid "Text"
+msgstr "Tekst"
+
+#: ../capplets/appearance/data/appearance.glade.h:47
+msgid ""
+"Text below items\n"
+"Text beside items\n"
+"Icons only\n"
+"Text only"
+msgstr ""
+"Teksti poshtë elementëve\n"
+"Teksti anash elementëve\n"
+"Vetëm ikonat\n"
+"Vetëm teksti"
+
+#: ../capplets/appearance/data/appearance.glade.h:51
+msgid "The current controls theme does not support color schemes."
+msgstr "Tema aktuale e kontrolleve nuk suporton skemat e ngjyrave."
+
+#: ../capplets/appearance/data/appearance.glade.h:52
+msgid "Theme"
+msgstr "Tema"
+
+#: ../capplets/appearance/data/appearance.glade.h:53
+msgid ""
+"Tiled\n"
+"Zoom\n"
+"Centered\n"
+"Scaled\n"
+"Fill screen"
+msgstr ""
+"Figurë e përsëritur\n"
+"E zmadhuar\n"
+"Në qendër\n"
+"E shkallëzuar\n"
+"Përshtatur sipas ekranit"
+
+#: ../capplets/appearance/data/appearance.glade.h:58
+msgid "Toolbar _button labels:"
+msgstr "Etiketat e _butonëve të panelit të instrumentëve:"
+
+#. vertical hinting, pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:60
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/appearance/data/appearance.glade.h:61
+msgid "Window Border"
+msgstr "Bordi i dritares"
+
+#: ../capplets/appearance/data/appearance.glade.h:62
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
+msgid "_Add..."
+msgstr "_Shto..."
+
+#: ../capplets/appearance/data/appearance.glade.h:63
+msgid "_Application font:"
+msgstr "Gërmat për _aplikativët:"
+
+#. pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:65
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/appearance/data/appearance.glade.h:66
+msgid "_Copy"
+msgstr "_Kopjo"
+
+#: ../capplets/appearance/data/appearance.glade.h:67
+msgid "_Description:"
+msgstr "_Përshkrimi:"
+
+#: ../capplets/appearance/data/appearance.glade.h:68
+msgid "_Document font:"
+msgstr "Gërmat për _dokumentet:"
+
+#: ../capplets/appearance/data/appearance.glade.h:69
+msgid "_Editable menu shortcut keys"
+msgstr "Kombinimi i tasteve për menutë e ndryshu_eshme"
+
+# #-#-#-#-#  dia.HEAD.sq.po (dia HEAD)  #-#-#-#-#
+#
+# #-#-#-#-#  libbonoboui.HEAD.sq.po (libbonoboui HEAD)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  libgnomeui.HEAD.sq.po (libgnomeui HEAD)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  dasher.HEAD.sq.po (dasher HEAD)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  gucharmap.HEAD.sq.po (gucharmap gnome-2-22)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  gnome-terminal.HEAD.sq.po (gnome-terminal.gnome-2-22)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  ekiga.gnome-2-22.sq.po (ekiga gnome-2-22)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  gucharmap.gnome-2-22.sq.po (gucharmap gnome-2-22)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  libgnomeui.gnome-2-22.sq.po (libgnomeui HEAD)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  dasher.gnome-2-22.sq.po (dasher.HEAD)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  gnome-terminal.gnome-2-22.sq.po (gnome-terminal.gnome-2-22)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+#: ../capplets/appearance/data/appearance.glade.h:70
+msgid "_File"
+msgstr "_File"
+
+#: ../capplets/appearance/data/appearance.glade.h:71
+msgid "_Fixed width font:"
+msgstr "Gërma me gjerësi _fikse:"
+
+#: ../capplets/appearance/data/appearance.glade.h:72
+msgid "_Full"
+msgstr "I _plotë"
+
+#: ../capplets/appearance/data/appearance.glade.h:73
+msgid "_Input boxes:"
+msgstr "Kutitë e _input:"
+
+#: ../capplets/appearance/data/appearance.glade.h:74
+msgid "_Install..."
+msgstr "_Instalo..."
+
+#: ../capplets/appearance/data/appearance.glade.h:75
+msgid "_Medium"
+msgstr "_Mesatar"
+
+#: ../capplets/appearance/data/appearance.glade.h:76
+msgid "_Monochrome"
+msgstr "_Monokromatik"
+
+#: ../capplets/appearance/data/appearance.glade.h:77
+msgid "_Name:"
+msgstr "_Emri:"
+
+#: ../capplets/appearance/data/appearance.glade.h:78
+msgid "_New"
+msgstr "I _ri"
+
+#: ../capplets/appearance/data/appearance.glade.h:79
+msgid "_None"
+msgstr "Mos pë_rdor"
+
+#: ../capplets/appearance/data/appearance.glade.h:80
+msgid "_Open"
+msgstr "_Hap"
+
+#: ../capplets/appearance/data/appearance.glade.h:81
+msgid "_Paste"
+msgstr "_Ngjit"
+
+#: ../capplets/appearance/data/appearance.glade.h:82
+msgid "_Print"
+msgstr "_Printo"
+
+#: ../capplets/appearance/data/appearance.glade.h:83
+msgid "_Quit"
+msgstr "_Dalja"
+
+#. pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:85
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:86
+msgid "_Reset to Defaults"
+msgstr "_Rikthe vlerat e paracaktuara"
+
+#: ../capplets/appearance/data/appearance.glade.h:87
+msgid "_Save"
+msgstr "_Ruaj"
+
+#: ../capplets/appearance/data/appearance.glade.h:88
+msgid "_Selected items:"
+msgstr "Elementët e _zgjedhur:"
+
+#: ../capplets/appearance/data/appearance.glade.h:89
+msgid "_Size:"
+msgstr "Madhë_sia:"
+
+#: ../capplets/appearance/data/appearance.glade.h:90
+msgid "_Slight"
+msgstr "I _lehtë"
+
+#: ../capplets/appearance/data/appearance.glade.h:91
+msgid "_Style:"
+msgstr "_Stili:"
+
+#: ../capplets/appearance/data/appearance.glade.h:92
+msgid "_Tooltips:"
+msgstr "_Propozime:"
+
+#. vertical hinting, pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:94
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:95
+msgid "_Window title font:"
+msgstr "Shkronjat për titullin e _dritareve:"
+
+#: ../capplets/appearance/data/appearance.glade.h:96
+msgid "_Windows:"
+msgstr "_Dritaret:"
+
+#: ../capplets/appearance/data/appearance.glade.h:97
+msgid "dots per inch"
+msgstr "pika për inç"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr "Paraqitja"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr "Personalizon paraqitjen e ambjentit grafik"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr "Instalon paketat e temave për pjesë të ndryshme të «desktop»"
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr "Instaluesi i temave"
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr "Paketa «Tema e Gnome»"
+
+#: ../capplets/appearance/gnome-wp-info.c:50
+msgid "No Wallpaper"
+msgstr "Asnjë sfond ekrani"
+
+#: ../capplets/appearance/gnome-wp-item.c:209
+msgid "Slide Show"
+msgstr "Diapozitivë"
+
+#. translators: <b>wallpaper name</b>
+#. * mime type, x pixel(s) by y pixel(s)
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:217
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %d %s by %d %s\n"
+"Folder: %s"
+msgstr ""
+"<b>%s</b>\n"
+"%s, %d %s nga %d %s\n"
+"Kartela: %s"
+
+#: ../capplets/appearance/gnome-wp-item.c:223
+#: ../capplets/appearance/gnome-wp-item.c:225
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "pixel"
+msgstr[1] "pixel"
+
+#: ../capplets/appearance/theme-installer.c:172
+#: ../capplets/appearance/theme-installer.c:222
+msgid "Cannot install theme"
+msgstr "I pamundur instalimi i temës"
+
+#: ../capplets/appearance/theme-installer.c:174
+#, c-format
+msgid "The %s utility is not installed."
+msgstr "Programi ndihmues %s nuk është i instaluar."
+
+#: ../capplets/appearance/theme-installer.c:224
+msgid "There was a problem while extracting the theme."
+msgstr "Është ndeshur një problem gjatë nxjerrjes së temës."
+
+#: ../capplets/appearance/theme-installer.c:247
+msgid "There was an error installing the selected file"
+msgstr "U ndesh një gabim gjatë instalimit të file të zgjedhur"
+
+#: ../capplets/appearance/theme-installer.c:248
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme."
+msgstr "Mesa duket «%s» nuk është një temë e vlefshme."
+
+#: ../capplets/appearance/theme-installer.c:249
+#, c-format
+msgid ""
+"\"%s\" does not appear to be a valid theme. It may be a theme engine which "
+"you need to compile."
+msgstr ""
+"Mesa duket «%s» nuk është një temë e vlefshme. Mund të jetë një motor teme "
+"që duhet kompiluar paraprakisht."
+
+#: ../capplets/appearance/theme-installer.c:288
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "Tema «%s» për GNOME u instalua korrektësisht"
+
+#: ../capplets/appearance/theme-installer.c:355
+#, c-format
+msgid "Installation for theme \"%s\" failed."
+msgstr "Instalimi i temës «%s» dështoi."
+
+#: ../capplets/appearance/theme-installer.c:393
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr "Tema «%s» u instalua."
+
+#: ../capplets/appearance/theme-installer.c:399
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr "Mbahet tema aktuale apo aplikohet tema e sapo instaluar?"
+
+#: ../capplets/appearance/theme-installer.c:401
+msgid "Keep Current Theme"
+msgstr "Mbaj temën aktuale"
+
+#: ../capplets/appearance/theme-installer.c:403
+msgid "Apply New Theme"
+msgstr "Apliko temën e re"
+
+#: ../capplets/appearance/theme-installer.c:506
+msgid "Failed to create temporary directory"
+msgstr "Krijimi i kartelës së përkohshme dështoi"
+
+#: ../capplets/appearance/theme-installer.c:569
+msgid "New themes have been successfully installed."
+msgstr "Temat e reja u instaluan me sukses."
+
+#: ../capplets/appearance/theme-installer.c:594
+msgid "No theme file location specified to install"
+msgstr "Nuk është dhënë pozicioni i file të temës për tu instaluar"
+
+#: ../capplets/appearance/theme-installer.c:615
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"Të drejta të pamjaftueshme për të instaluar temën në:\n"
+"%s"
+
+#: ../capplets/appearance/theme-installer.c:685
+msgid "Select Theme"
+msgstr "Zgjidh temën"
+
+#: ../capplets/appearance/theme-installer.c:689
+msgid "Theme Packages"
+msgstr "Paketa teme"
+
+#: ../capplets/appearance/theme-save.c:91
+#, c-format
+msgid "Theme name must be present"
+msgstr "Duhet të jepet emri i temës"
+
+#: ../capplets/appearance/theme-save.c:154
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Tema ekziston rregullisht. Vazhdon me zëvendësimin?"
+
+#: ../capplets/appearance/theme-save.c:155
+#: ../capplets/common/file-transfer-dialog.c:450
+msgid "_Overwrite"
+msgstr "M_bishkruaj"
+
+#: ../capplets/appearance/theme-util.c:74
+msgid "Would you like to delete this theme?"
+msgstr "Eleminon këtë temë?"
+
+#: ../capplets/appearance/theme-util.c:124
+msgid "Theme cannot be deleted"
+msgstr "Eleminimi i temës nuk është i mundur"
+
+#: ../capplets/appearance/theme-util.c:251
+msgid "Could not install theme engine"
+msgstr "I pamundur instalimi i motorit të temës"
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"E pamundur nisja e menazhuesit të rregullimeve 'gnome-settings-daemon'.\n"
+"Nëse menazhuesi i rregullimeve të GNOME nuk është duke punuar, disa nga "
+"zgjedhjet mund të mos kenë efekt. Kjo situatë tregon një problem të mundshëm "
+"Bonobo, ose që një menazhues rregullimesh tjetër jo i GNOME (p.sh. i KDE) "
+"është në ekzekutim duke krijuar konflikte me menazhuesin e rregullimeve të "
+"GNOME."
+
+#: ../capplets/common/capplet-stock-icons.c:67
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr "I pamundur ngarkimi i ikonës së stock «%s»\n"
+
+#: ../capplets/common/capplet-util.c:80
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Gabim gjatë shfaqjes së ndihmës: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:98
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "Kopjimi i file: %u në %u"
+
+#: ../capplets/common/file-transfer-dialog.c:145
+#, c-format
+msgid "Copying '%s'"
+msgstr "Kopjimi i «%s»"
+
+#: ../capplets/common/file-transfer-dialog.c:185
+#: ../capplets/common/file-transfer-dialog.c:312
+msgid "Copying files"
+msgstr "Kopjimi i file"
+
+#: ../capplets/common/file-transfer-dialog.c:224
+msgid "Parent Window"
+msgstr "Dritarja prind"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Parent window of the dialog"
+msgstr "Dritarja prind e dritares së dialogut"
+
+#: ../capplets/common/file-transfer-dialog.c:231
+msgid "From URI"
+msgstr "Nga URI"
+
+#: ../capplets/common/file-transfer-dialog.c:232
+msgid "URI currently transferring from"
+msgstr "URI nga ku po transferohet aktualisht"
+
+#: ../capplets/common/file-transfer-dialog.c:239
+msgid "To URI"
+msgstr "Tek URI"
+
+#: ../capplets/common/file-transfer-dialog.c:240
+msgid "URI currently transferring to"
+msgstr "URI drejt së cilës po transferohet aktualisht"
+
+#: ../capplets/common/file-transfer-dialog.c:247
+msgid "Fraction completed"
+msgstr "Përqindja e plotësuar"
+
+#: ../capplets/common/file-transfer-dialog.c:248
+msgid "Fraction of transfer currently completed"
+msgstr "Përqindja e transferimit plotësuar për momentin"
+
+#: ../capplets/common/file-transfer-dialog.c:255
+msgid "Current URI index"
+msgstr "Indeksi i URI të tanishëm"
+
+#: ../capplets/common/file-transfer-dialog.c:256
+msgid "Current URI index - starts from 1"
+msgstr "Indeksi i URI të tanishëm - fillon nga 1"
+
+#: ../capplets/common/file-transfer-dialog.c:263
+msgid "Total URIs"
+msgstr "URI gjithsej"
+
+#: ../capplets/common/file-transfer-dialog.c:264
+msgid "Total number of URIs"
+msgstr "Numri i përgjithshëm i URI"
+
+#: ../capplets/common/file-transfer-dialog.c:444
+#, c-format
+msgid "File '%s' already exists. Do you want to overwrite it?"
+msgstr "File «%s» ekziston rregullisht. Vazhdon me mbishkrimin e tij?"
+
+#: ../capplets/common/file-transfer-dialog.c:447
+msgid "_Skip"
+msgstr "_Kapërce"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Overwrite _All"
+msgstr "Mbishkruaj gjithçk_a"
+
+#: ../capplets/common/gconf-property-editor.c:133
+msgid "Key"
+msgstr "Kyçi"
+
+#: ../capplets/common/gconf-property-editor.c:134
+msgid "GConf key to which this property editor is attached"
+msgstr "Kyçi GConf me të cilin ky editor pronësish është i lidhur"
+
+#: ../capplets/common/gconf-property-editor.c:140
+msgid "Callback"
+msgstr "Callback"
+
+#: ../capplets/common/gconf-property-editor.c:141
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr "Kryen këtë callback kur vlera e shoqëruar me kyçin ndryshohet"
+
+#: ../capplets/common/gconf-property-editor.c:146
+msgid "Change set"
+msgstr "Bashkësi ndryshimesh"
+
+#: ../capplets/common/gconf-property-editor.c:147
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"Bashkësi e ndryshimeve të GConf me të dhënat për t'ju dërguar klientit gconf "
+"kur aplikohen ndryshimet"
+
+#: ../capplets/common/gconf-property-editor.c:152
+msgid "Conversion to widget callback"
+msgstr "Callback konvertimi drejt widget"
+
+#: ../capplets/common/gconf-property-editor.c:153
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+"Callback për tu kryer kur nevoitet konvertimi i të dhënave nga GConf tek "
+"widget"
+
+#: ../capplets/common/gconf-property-editor.c:158
+msgid "Conversion from widget callback"
+msgstr "Callback konvertimi nga widget"
+
+#: ../capplets/common/gconf-property-editor.c:159
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"Callback për tu kryer kur nevoitet konvertimi i të dhënave nga widget në "
+"GConf"
+
+#: ../capplets/common/gconf-property-editor.c:164
+msgid "UI Control"
+msgstr "Kontrolli UI"
+
+#: ../capplets/common/gconf-property-editor.c:165
+msgid "Object that controls the property (normally a widget)"
+msgstr "Objekt që kontrollon pronësinë (zakonisht një widget)"
+
+#: ../capplets/common/gconf-property-editor.c:180
+msgid "Property editor object data"
+msgstr "Të dhënat e objektit për editorin e pronësive"
+
+#: ../capplets/common/gconf-property-editor.c:181
+msgid "Custom data required by the specific property editor"
+msgstr "Të dhëna specifike të kërkuara nga editori specifik i pronësive"
+
+#: ../capplets/common/gconf-property-editor.c:187
+msgid "Property editor data freeing callback"
+msgstr "Callback i lëshimit të së dhënave për editorin e pronësive"
+
+#: ../capplets/common/gconf-property-editor.c:188
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Callback e kryer kur duhet liruar kujtesa e të dhënave të objektit editor i "
+"pronësive"
+
+#: ../capplets/common/gconf-property-editor.c:1429
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"E pamundur gjetja e file '%s'.\n"
+"\n"
+"Sigurohu që ekziston dhe provo përsëri, ose zgjidh një figurë tjetër sfondi."
+
+#: ../capplets/common/gconf-property-editor.c:1437
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"E pamundur njohja e formatit të file '%s'.\n"
+"Ndoshta është një lloj figure akoma i pasuportuar.\n"
+"\n"
+"Zgjidh një figurë tjetër."
+
+#: ../capplets/common/gconf-property-editor.c:1556
+msgid "Please select an image."
+msgstr "Zgjidh një figurë."
+
+# #-#-#-#-#  glade3.HEAD.sq.po (glade3 HEAD)  #-#-#-#-#
+# (pofilter) accelerators: accelerator _ is missing from translation
+# #-#-#-#-#  glade3.gnome-2-22.sq.po (glade3 gnome-2-22)  #-#-#-#-#
+# (pofilter) accelerators: accelerator _ is missing from translation
+#: ../capplets/common/gconf-property-editor.c:1561
+msgid "_Select"
+msgstr "_Zgjidh"
+
+#: ../capplets/common/gnome-theme-info.c:635
+msgid "Default Pointer - Current"
+msgstr "Kursori i paracaktuar - në përdorim"
+
+#: ../capplets/common/gnome-theme-info.c:639
+msgid "White Pointer"
+msgstr "Kursor i bardhë"
+
+#: ../capplets/common/gnome-theme-info.c:640
+msgid "White Pointer - Current"
+msgstr "Kursor i bardhë - në përdorim"
+
+#: ../capplets/common/gnome-theme-info.c:644
+msgid "Large Pointer"
+msgstr "Kursor i madh"
+
+#: ../capplets/common/gnome-theme-info.c:645
+msgid "Large Pointer - Current"
+msgstr "Kursor i madh - në përdorim"
+
+#: ../capplets/common/gnome-theme-info.c:649
+msgid "Large White Pointer - Current"
+msgstr "Kursor i bardhë i madh - në përdorim"
+
+#: ../capplets/common/gnome-theme-info.c:650
+msgid "Large White Pointer"
+msgstr "Kursor i bardhë i madh"
+
+#: ../capplets/common/gnome-theme-info.c:1620
+#, c-format
+msgid ""
+"This theme will not look as intended because the required GTK+ theme '%s' is "
+"not installed."
+msgstr ""
+"Tema nuk do të shfaqet sikurse parashikuar pasi tema e kërkuar GTK+ '%s' nuk "
+"është instaluar."
+
+#: ../capplets/common/gnome-theme-info.c:1628
+#, c-format
+msgid ""
+"This theme will not look as intended because the required window manager "
+"theme '%s' is not installed."
+msgstr ""
+"Tema nuk do të shfaqet sikurse parashikuar pasi tema e kërkuar e menazhuesit "
+"të dritareve '%s' nuk është instaluar."
+
+#: ../capplets/common/gnome-theme-info.c:1635
+#, c-format
+msgid ""
+"This theme will not look as intended because the required icon theme '%s' is "
+"not installed."
+msgstr ""
+"Tema nuk do të shfaqet sikurse parashikuar pasi tema e kërkuar e ikonave "
+"'%s' nuk është instaluar."
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Preferred Applications"
+msgstr "Aplikativë të preferuar"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Zgjidh apliaktivët e paracaktuar"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Start the preferred visual assistive technology"
+msgstr "Nis teknollogjinë asistuese të preferuar për shikimin"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr "Asistenca vizive"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:94
+#: ../capplets/default-applications/gnome-da-capplet.c:345
+#: ../capplets/default-applications/gnome-da-capplet.c:366
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "Gabim gjatë ruajtjes së konfigurimit: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:650
+msgid "Could not load the main interface"
+msgstr "I pamundur ngarkimi i interfaqes kryesore"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:652
+msgid "Please make sure that the applet is properly installed"
+msgstr "Sigurohu që mini-aplikativi të jetë instaluar sikurse duhet"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/default-applications/gnome-da-capplet.c:879
+msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+msgstr ""
+"Specifiko emrin e faqes për tu shfaqur (internet|multimedia|system|a11y)"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Image Viewer</b>"
+msgstr "<b>Shfaqës figurash</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Instant Messenger</b>"
+msgstr "<b>Mesazhe të menjëhershëm</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Mail Reader</b>"
+msgstr "<b>Klient i postës elektronike</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mobility</b>"
+msgstr "<b>Lëvizshmëri</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Multimedia Player</b>"
+msgstr "<b>Riprodhues multimedial</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>Emulator terminali</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Text Editor</b>"
+msgstr "<b>Editor teksti</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Video Player</b>"
+msgstr "<b>Riprodhues video</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "<b>Visual</b>"
+msgstr "<b>Shikimi</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "<b>Web Browser</b>"
+msgstr "<b>Shfletues web</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
+msgid "Accessibility"
+msgstr "Përdorshmëria"
+
+# Thjesht sensi.
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr "Vlera %s zëvendësohet me lidhjen"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "C_ommand:"
+msgstr "K_omanda:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Co_mmand:"
+msgstr "Ko_manda:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "E_xecute flag:"
+msgstr "Flag i e_kzekutimit:"
+
+# #-#-#-#-#  gnome-menus.HEAD.sq.po (gnome-menus gnome-2-22)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  gnome-menus.gnome-2-22.sq.po (gnome-menus gnome-2-22)  #-#-#-#-#
+# (pofilter) unchanged: please translate
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Internet"
+msgstr "Internet"
+
+# #-#-#-#-#  gnome-icon-theme.HEAD.sq.po (gnome-icon-theme.HEAD)  #-#-#-#-#
+# 48x48/emblems/emblem-multimedia.icon.in.h:1
+# 48x48/emblems/emblem-multimedia.icon.in.h:1
+# 48x48/emblems/emblem-multimedia.icon.in.h:1
+# (pofilter) unchanged: please translate
+# #-#-#-#-#  gnome-icon-theme.gnome-2-22.sq.po (gnome-icon-theme.HEAD)  #-#-#-#-#
+# 48x48/emblems/emblem-multimedia.icon.in.h:1
+# 48x48/emblems/emblem-multimedia.icon.in.h:1
+# 48x48/emblems/emblem-multimedia.icon.in.h:1
+# (pofilter) unchanged: please translate
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Multimedia"
+msgstr "Multimedia"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Open link in new _tab"
+msgstr "Hap lidhjet në një skedë _të re"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "Open link in new _window"
+msgstr "Hap lidhjet në një _dritare të re"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid "Open link with web browser _default"
+msgstr "Hap lidhjet sipas _rregullimeve të shfletuesit web"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Run at st_art"
+msgstr "Ekzekuto në _nisje"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Run in t_erminal"
+msgstr "Ekzekuto në t_erminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "System"
+msgstr "Sistemi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "_Run at start"
+msgstr "_Ekzekuto në nisje"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Balsa"
+
+# Hiqet Music Player pasi shfaqet
+# në listën e music player
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr "Banshee"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr "Claws Mail"
+
+# (pofilter) unchanged: please translate
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr "Dasher"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr "Shfletues i përshtatshëm për Debian"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr "Emulator terminali Debian"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr "Encompass"
+
+# Hiqet web browser pasi rezulton
+# në listën e web browser
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr "Epiphany"
+
+# Hiqet mail reader pasi rezulton
+# në listën e klientëve mail
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr "Evolution"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr "Zmadhuesi i GNOME pa lexues ekrani"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr "Tastierë në ekran e GNOME"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr "Terminali i GNOME"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Gnopernicus"
+msgstr "Gnopernicus"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Gnopernicus with Magnifier"
+msgstr "Gnopernicus me zmadhues"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Iceape"
+msgstr "Iceape"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Iceape Mail"
+msgstr "Posta Iceape"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Icedove"
+msgstr "Icedove"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Iceweasel"
+msgstr "Iceweasel"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr "Zmadhuesi i KDE pa lexues ekrani"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Konsole"
+msgstr "Konsole"
+
+# Emri i vetë aplikativit
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr "Linux Screen Reader"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr "Linux Screen Reader me zmadhues"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Midori"
+msgstr "Midori"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Mozilla Mail"
+msgstr "Mozilla Mail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+# Hiqet music player
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Muine Music Player"
+msgstr "Muine"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+msgid "Netscape Communicator"
+msgstr "Netscape Communicator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Opera"
+msgstr "Opera"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Orca"
+msgstr "Orca"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca with Magnifier"
+msgstr "Orca me zmadhues"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "RXVT"
+msgstr "RXVT"
+
+# Hiqet music player
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+msgid "Rhythmbox Music Player"
+msgstr "Rhythmbox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+msgid "SeaMonkey Mail"
+msgstr "Posta SeaMonkey"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+msgid "Standard XTerminal"
+msgstr "Terminal X standard"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Sylpheed"
+msgstr "Sylpheed"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+msgid "Terminator"
+msgstr "Terminator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Totem Movie Player"
+msgstr "Totem"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/display/display-capplet.glade.h:1
+msgid "Include _Panel"
+msgstr "Përfshi _panelin"
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../capplets/display/display-capplet.glade.h:2
+#: ../capplets/display/xrandr-capplet.c:1319
+msgid "Mirror Screens"
+msgstr "Pasqyra e ekranit"
+
+# Përmasa???
+#: ../capplets/display/display-capplet.glade.h:3
+msgid "Monitor Resolution Settings"
+msgstr "Rregullimet e përmasave të ekranit"
+
+#: ../capplets/display/display-capplet.glade.h:4
+msgid ""
+"Normal\n"
+"Left\n"
+"Right\n"
+"Upside-down\n"
+msgstr ""
+"Normal\n"
+"Majtas\n"
+"Djathtas\n"
+"Lart-poshtë\n"
+
+#: ../capplets/display/display-capplet.glade.h:9
+msgid "R_otation"
+msgstr "Rr_otullimi"
+
+#: ../capplets/display/display-capplet.glade.h:10
+msgid "Re_fresh Rate:"
+msgstr "Intervali i ri_freskimit:"
+
+#: ../capplets/display/display-capplet.glade.h:11
+msgid "_Detect Displays"
+msgstr "_Zbulo ekranet"
+
+#: ../capplets/display/display-capplet.glade.h:12
+msgid "_Resolution"
+msgstr "_Përmasat"
+
+#: ../capplets/display/display-capplet.glade.h:13
+msgid "_Show Displays in Panel"
+msgstr "_Shfaq ekranet në panel"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Ndrysho përmasat e ekranit"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Përmasat e ekranit"
+
+#: ../capplets/display/xrandr-capplet.c:412
+#: ../capplets/display/xrandr-capplet.c:450
+msgid "Normal"
+msgstr "Normal"
+
+#: ../capplets/display/xrandr-capplet.c:413
+msgid "Left"
+msgstr "Majtas"
+
+#: ../capplets/display/xrandr-capplet.c:414
+msgid "Right"
+msgstr "Djathtas"
+
+#: ../capplets/display/xrandr-capplet.c:415
+msgid "Upside Down"
+msgstr "Sipër poshtë"
+
+#: ../capplets/display/xrandr-capplet.c:488
+#: ../capplets/display/xrandr-capplet.c:496
+#: ../capplets/display/xrandr-capplet.c:497
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/xrandr-capplet.c:549
+#: ../capplets/display/xrandr-capplet.c:568
+#: ../capplets/display/xrandr-capplet.c:578
+#, c-format
+msgid "%d x %d"
+msgstr "%d x %d"
+
+#: ../capplets/display/xrandr-capplet.c:560
+msgid "Off"
+msgstr "Çaktivizuar"
+
+# #-#-#-#-#  gnome-icon-theme.HEAD.sq.po (gnome-icon-theme.HEAD)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# #-#-#-#-#  gnome-icon-theme.gnome-2-22.sq.po (gnome-icon-theme.HEAD)  #-#-#-#-#
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+# 48x48/emblems/emblem-sound.icon.in.h:1
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Zëri"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+#: ../libslab/bookmark-agent.c:1154
+msgid "Desktop"
+msgstr "Hapësira e punës"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr "Përshpejtim i ri..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Pulsant përshpejtues"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Ndryshues të përshpejtuesëve"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Kodi pulsantit përshpejtues"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Mënyra përshpejt"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Lloji i përshpejtuesit."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:90
+#: ../capplets/sound/sound-theme.c:415 ../capplets/sound/sound-theme.c:433
+#: ../capplets/sound/sound-theme.c:543 ../capplets/sound/sound-theme.c:559
+#: ../typing-break/drwright.c:480
+msgid "Disabled"
+msgstr "Çaktivizuar"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:171
+msgid "<Unknown Action>"
+msgstr "<Aksion i panjohur>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:804
+msgid "Custom Shortcuts"
+msgstr "Përshpejtime të personalizuara"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:938
+#, c-format
+msgid "Error saving the new shortcut: %s"
+msgstr "Gabim në ruajtjen e përshpejtuesit të ri: %s"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1016
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"Është i pamundur përdorimi i «%s» si kombinim përshpejtues, pasi pengon "
+"shkrimin normal.\n"
+"Provo të përdorësh në kombinim njëkohësisht një pulsant si Ctrl, Alt apo "
+"Shift."
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1046
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"Përshpejtimi «%s» përdoret rregullisht për\n"
+"«%s»"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1052
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"Nëse i ricaktohet përshpejtimi «%s», përshpejtimi «%s» do të çaktivizohet."
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1060
+msgid "_Reassign"
+msgstr "_Ricakto"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1180
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr ""
+"Gabim gjatë heqjes së përshpejtuesit në bazën e të dhënave të konfigurimit: "
+"%s"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1362
+msgid "Action"
+msgstr "Veprimi"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1384
+msgid "Shortcut"
+msgstr "Kombinimi përshpejtues"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Kombinime përshpejtuese nga tastiera"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new key "
+"combination, or press backspace to clear."
+msgstr ""
+"Për të ndryshuar një pulsant përshpejtimi, kliko në rreshtin përkatës dhe "
+"shkruaj kombinimin e ri, ose shtyp «Backspace» për ta fshirë."
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Cakton pulsante përshpejtues komandave"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:248
+#: ../capplets/keyboard/gnome-keyboard-properties.c:253
+#: ../capplets/sound/sound-properties-capplet.c:1185
+#: ../capplets/sound/sound-properties-capplet.c:1187
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+"Aplikon rregullimet dhe del (vetëm kompatibilitet; tashmë kontrollohet nga "
+"demon)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:256
+#: ../capplets/sound/sound-properties-capplet.c:1189
+msgid "Retrieve and store legacy settings"
+msgstr "Rikuperon dhe rivendos rregullimet legacy"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:260
+msgid "Start the page with the typing break settings showing"
+msgstr ""
+"Nis duke shfaqur faqen e pronësive të rregullimeve për pushimet gjatë "
+"shkrimit"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:265
+msgid "Start the page with the accessibility settings showing"
+msgstr "Nis duke shfaqur faqen e pronësive të rregullimeve të açesibilitetit"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:274
+msgid "- GNOME Keyboard Preferences"
+msgstr "- Preferimet e tastierës së GNOME"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+msgid "<b>Bounce Keys</b>"
+msgstr "<b>Shtypja e përafërt e pulsantëve</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Pulsimi i kursorit</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "<b>General</b>"
+msgstr "<b>Të përgjithshme</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Përsëritja e pulsantëve</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Slow Keys</b>"
+msgstr "<b>Ngadalsimi i pulsantëve</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>Sticky Keys</b>"
+msgstr "<b>Qëndrimi i pulsantëve</b>"
+
+#. fast acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Shpejt</i></small>"
+
+#. long delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>E gjatë</i></small>"
+
+#. short delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>E shkurtër</i></small>"
+
+#. slow acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Ngadalë</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_cceleration:"
+msgstr "P_ërshpejtimi:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "All_ow postponing of breaks"
+msgstr "Lej_o shtyrjen e pushimeve"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "Audio _Feedback..."
+msgstr "_Feedback audio..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Beep when _accessibility features are turned on or off"
+msgstr ""
+"Sinjal akustik kur aktivizohen apo çaktivizohen funksionet e _açesibilitetit"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Beep when a _modifier key is pressed"
+msgstr "Sinjal akustik kur shtypet një _ndryshues"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Beep when a _toggle key is pressed"
+msgstr "Sinjal akustik kur shtypet një pulsant _shkëmbyes"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Beep when a key is pr_essed"
+msgstr "Sinjal akustik kur shtyp_et një pulsant"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Beep when a key is reje_cted"
+msgstr "Sinjal akustik kur refu_zohet një pulsant"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Beep when key is _accepted"
+msgstr "Sinjal akustik kur pr_anohet një pulsant"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Beep when key is _rejected"
+msgstr "Sinjal akustik kur pulsanti _refuzohet"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "By _country"
+msgstr "Sipas sh_tetit"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "By _language"
+msgstr "Sipas _gjuhës"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Kontrollon nëse lejohet shtyrja e pushimeve"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Choose a Keyboard Model"
+msgstr "Zgjedhja e një modeli tastiere"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Choose a Layout"
+msgstr "Zgjedhja e një planimetrie"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Cursor _blinks in text fields"
+msgstr "Kursor pulsues në fushat me tekst"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
+msgid "Cursor blinks speed"
+msgstr "Shpejtësia e pulsimit të kursorit"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
+msgid "D_elay:"
+msgstr "Von_esa:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr "Çaktivizo qëndrimin e pulsantëve nëse shtypen dy pulsantë së bashku"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Duration of the break when typing is disallowed"
+msgstr "Kohëzgjatja e pushimit gjatë së cilës ndalohet shkrimi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Duration of work before forcing a break"
+msgstr "Kohëzgjatja e punës para se të detyrohet kryerja e një pushimi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
+msgid "General"
+msgstr "Të përgjithshme"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "Key presses _repeat when key is held down"
+msgstr "Pë_rsërit gërmën përderisa pulsanti mbahet i shtypur"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "Keyboard Accessibility Audio Feedback"
+msgstr "Feedback audio i açesibilitetit të tastierës"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "Keyboard Layout Options"
+msgstr "Opsionet e planimetrisë së tastierës"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "Keyboard Preferences"
+msgstr "Preferimet e tastierës"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "Keyboard _model:"
+msgstr "_Modeli i tastierës:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "Layout _Options..."
+msgstr "_Opsionet e planimetrisë..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "Layouts"
+msgstr "Planimetritë"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Mbas një intervali te caktuar kohe blloko ekranin për të parandaluar dëmet e "
+"shkaktuara nga përdorimi i gjatë i tastierës"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "Mouse Keys"
+msgstr "Mouse nga tastiera"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "Preview:"
+msgstr "Pamja e parë:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
+msgid "Repeat keys speed"
+msgstr "Shpejtësia e përsëritjes së pulsantëve"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
+msgid "Reset to De_faults"
+msgstr "Rivendos vlerat e para_caktuara"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
+msgid "S_peed:"
+msgstr "Sh_pejtësia:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
+msgid "Separate _layout for each window"
+msgstr "P_lanimetri e veçantë për çdo dritare"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
+msgid "Typing Break"
+msgstr "Pushim gjatë shkrimit"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
+msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgstr ""
+"Funksionet e _açesibilitetit mund të aktivizohen/çaktivizohen me kombinime "
+"përshpejtuese nga tastiera"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
+msgid "_Break interval lasts:"
+msgstr "Kohëzgjatja e _pushimit:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
+msgid "_Country:"
+msgstr "_Shteti:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
+msgid "_Delay:"
+msgstr "_Vonesa:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
+msgid "_Ignore fast duplicate keypresses"
+msgstr "Shpërf_ill shtypje të shpejta të njëpasnjëshme pulsantësh"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
+msgid "_Language:"
+msgstr "_Gjuha:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
+msgid "_Lock screen to enforce typing break"
+msgstr "B_lloko ekranin për të detyruar kryrjen e një pushimi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
+msgid "_Models:"
+msgstr "_Modele:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
+msgid "_Only accept long keypresses"
+msgstr "Prano ve_tëm shtypje pulsanti me kohëzgjatje të gjatë"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
+msgid "_Pointer can be controlled using the keypad"
+msgstr "_Kursori mund të kontrollohet duke përdorur tastierën"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
+msgid "_Selected layouts:"
+msgstr "Planimetritë e _zgjedhura:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
+msgid "_Simulate simultaneous keypresses"
+msgstr "_Simulo shtypje të njëkohshme pulsantësh"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
+msgid "_Speed:"
+msgstr "_Shpejtësia:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
+msgid "_Type to test settings:"
+msgstr "_Shkruaj këtu për të verifikuar rregullimet:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
+msgid "_Variants:"
+msgstr "_Variante:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
+msgid "_Vendors:"
+msgstr "_Prodhues:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
+msgid "_Work interval lasts:"
+msgstr "Intervali i _punës:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
+msgid "minutes"
+msgstr "minuta"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:81
+msgid "Unknown"
+msgstr "Nuk njihet"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:305
+msgid "Layout"
+msgstr "Planimetria"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:311
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:211
+#: ../capplets/sound/sound-theme.c:419 ../capplets/sound/sound-theme.c:539
+msgid "Default"
+msgstr "E paracaktuar"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
+msgid "Vendors"
+msgstr "Prodhues"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
+msgid "Models"
+msgstr "Modele"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Tastiera"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Përcakton preferimet e tastierës"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:89
+msgid "gesture|Move left"
+msgstr "Lëviz në të majtë"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:94
+msgid "gesture|Move right"
+msgstr "Lëviz në të djathtë"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:99
+msgid "gesture|Move up"
+msgstr "Lëviz sipër"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:104
+msgid "gesture|Move down"
+msgstr "Lëviz poshtë"
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:109
+msgid "gesture|Disabled"
+msgstr "Çaktivizuar"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/mouse/gnome-mouse-properties.c:443
+msgid "Specify the name of the page to show (general|accessibility)"
+msgstr "Specifiko emrin e faqes për tu shfaqur (general|accessibility)"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:452
+msgid "- GNOME Mouse Preferences"
+msgstr "- Preferimet e mouse për GNOME"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+msgid "<b>Double-Click Timeout</b>"
+msgstr "<b>Koha në dispozicion për dopio klik</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Zvarritja</b>"
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Dwell Click</b>"
+msgstr "<b>Klikim automatik</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Gjetja e kursorit</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>Orientimi i mouse</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<b>Pointer Speed</b>"
+msgstr "<b>Shpejtësia e kursorit</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<b>Simulated Secondary Click</b>"
+msgstr "<b>Klik dytësor i simuluar</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid ""
+"<i>To test your double-click settings, try to double-click on the light bulb."
+"</i>"
+msgstr ""
+"<i>Për të kontrolluar rregullimet personale të klikimit dopio, provo të bësh "
+"dopio klik tek llampa.</i>"
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid ""
+"<i>You can also use the Dwell Click panel applet to choose the click type.</"
+"i>"
+msgstr ""
+"<i>Mund gjithashtu të përdoret applet i panelit «Klikim automatik» për të "
+"zgjedhur llojin e klikimit.</i>"
+
+#. high sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "<small><i>High</i></small>"
+msgstr "<small><i>E lartë</i></small>"
+
+#. large threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "<small><i>Large</i></small>"
+msgstr "<small><i>I madh</i></small>"
+
+#. low sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "<small><i>Low</i></small>"
+msgstr "<small><i>E ulët</i></small>"
+
+#. small threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "<small><i>Small</i></small>"
+msgstr "<small><i>I vogël</i></small>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
+msgid "Choose type of click _beforehand"
+msgstr "Zgjidh llojin e klikimit të _parakohshëm"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
+msgid "Choose type of click with mo_use gestures"
+msgstr "Zgjidh llojin e klik me gjeste të mo_use"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
+msgid "D_ouble click:"
+msgstr "D_opio klik:"
+
+#. click to initiate drag-and-drop (like normally click and hold)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
+msgid "D_rag click:"
+msgstr "Klik zva_rritje:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
+msgid "Mouse Preferences"
+msgstr "Preferimet e mouse"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
+msgid "Seco_ndary click:"
+msgstr "Klik dytësor:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr "Sh_faq pozicionin e kursorit kur shtypet pulsanti Control"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
+msgid "Show click type _window"
+msgstr "Shfaq _dritaren për llojin e klikimit"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
+msgid "Thr_eshold:"
+msgstr "Kuf_iri:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
+msgid "_Acceleration:"
+msgstr "_Përshpejtimi:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
+msgid "_Initiate click when stopping pointer movement"
+msgstr "F_illo klikimin kur ndalon lëvizja e kursorit"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
+msgid "_Left-handed"
+msgstr "Për dorën e _majtë"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
+msgid "_Motion threshold:"
+msgstr "Kufiri i lë_vizjes:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
+msgid "_Right-handed"
+msgstr "Për dorën e _djathtë"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
+msgid "_Sensitivity:"
+msgstr "_Ndjeshmëria:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
+msgid "_Single click:"
+msgstr "Klik i ve_tëm:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
+msgid "_Timeout:"
+msgstr "_Koha në dispozicion:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr "_Nis klikimin dytësor duke mbajtur shtypur pulsantin kryesor"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Mouse"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Përcakton preferimet e mouse"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Proxy i rrjetit"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr "Përcakton preferimet e proxy të rrjetit"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>Lidhje di_rekte në internet</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>Ignore Host List</b>"
+msgstr "<b>Lista me host për tu shpërfillur</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>_Konfigurim automaktik i proxy</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>_Konfigurim manual i proxy</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Përdor autentikim</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "Autoconfiguration _URL:"
+msgstr "_URL e autokonfigurimit:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "HTTP Proxy Details"
+msgstr "Detaje Proxy HTTP"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "H_TTP proxy:"
+msgstr "Proxy H_TTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "Ignored Hosts"
+msgstr "Host-et e shpërfillur"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "Network Proxy Preferences"
+msgstr "Preferimet e proxy të rrjetit"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Port:"
+msgstr "Porta:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Proxy Configuration"
+msgstr "Konfigurimi i proxy"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "S_ocks host:"
+msgstr "Host S_ocks:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "U_sername:"
+msgstr "Përdorue_si:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "_Details"
+msgstr "_Detaje"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_FTP proxy:"
+msgstr "Proxy _FTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_Password:"
+msgstr "_Fjalëkalimi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Secure HTTP proxy:"
+msgstr "Proxy HTTP i _Sigurtë:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Use the same proxy for all protocols"
+msgstr "_Përdor të njëjtin host për të gjithë protokollet"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Aktivizoo tingujt dhe shoqëro me tinguj eventet"
+
+#: ../capplets/sound/mixer-support.c:79
+#, c-format
+msgid "Unknown Volume Control %d"
+msgstr "Kontroll volumi %d i panjohur"
+
+#: ../capplets/sound/pipeline-tests.c:84
+#, c-format
+msgid "Failed to construct test pipeline for '%s'"
+msgstr "Dështoi ndërtimi i pipeline i provës për «%s»"
+
+#: ../capplets/sound/sound-properties-capplet.c:260
+#: ../capplets/sound/sound-properties-capplet.c:381
+msgid "Not connected"
+msgstr "I palidhur"
+
+#: ../capplets/sound/sound-properties-capplet.c:829
+msgid "Autodetect"
+msgstr "Zbulim automatik"
+
+#: ../capplets/sound/sound-properties-capplet.c:834
+#: ../capplets/sound/sound-properties-capplet.c:835
+msgid "ALSA - Advanced Linux Sound Architecture"
+msgstr "ALSA - Advanced Linux Sound Architecture"
+
+#: ../capplets/sound/sound-properties-capplet.c:836
+msgid "Artsd - ART Sound Daemon"
+msgstr "Artsd - ART Sound Daemon"
+
+#: ../capplets/sound/sound-properties-capplet.c:837
+#: ../capplets/sound/sound-properties-capplet.c:838
+msgid "ESD - Enlightened Sound Daemon"
+msgstr "ESD - Enlightened Sound Daemon"
+
+#: ../capplets/sound/sound-properties-capplet.c:841
+#: ../capplets/sound/sound-properties-capplet.c:844
+msgid "OSS - Open Sound System"
+msgstr "OSS - Open Sound System"
+
+#: ../capplets/sound/sound-properties-capplet.c:846
+#: ../capplets/sound/sound-properties-capplet.c:847
+msgid "PulseAudio Sound Server"
+msgstr "Server audio PulseAudio"
+
+#: ../capplets/sound/sound-properties-capplet.c:848
+msgid "Test Sound"
+msgstr "Tingull prove"
+
+#: ../capplets/sound/sound-properties-capplet.c:849
+msgid "Silence"
+msgstr "Heshtje"
+
+#: ../capplets/sound/sound-properties-capplet.c:1202
+msgid "- GNOME Sound Preferences"
+msgstr "- Preferimet audo të GNOME"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "<b>Alerts and Sound Effects</b>"
+msgstr "<b>Alarme dhe efekte sonorë</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "<b>Audio Conferencing</b>"
+msgstr "<b>Konferenca audio</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "<b>Default Mixer Tracks</b>"
+msgstr "<b>Pistat e paracaktuara të mixer</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "<b>Music and Movies</b>"
+msgstr "<b>Muzikë dhe filma</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "<b>Sound Events</b>"
+msgstr "<b>Evente sonorë</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "<b>Sound Theme</b>"
+msgstr "<b>Tema sonore</b>"
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+msgstr "<span weight=\"bold\" size=\"x-large\">Verifikimi...</span>"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "Click OK to finish."
+msgstr "Kliko OK për të mbaruar."
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "Devices"
+msgstr "Dispozitivët"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "Play _alert sound"
+msgstr "Riprodho tinguj p_aralajmërues"
+
+#: ../capplets/sound/sound-properties.glade.h:11
+msgid "Play _sound effects when buttons are clicked"
+msgstr "Riprodho efekte _sonorë kur klikohen butonët"
+
+#: ../capplets/sound/sound-properties.glade.h:12
+msgid "S_ound playback:"
+msgstr "Riprodhimi i zë_rit:"
+
+#: ../capplets/sound/sound-properties.glade.h:13
+msgid ""
+"Select the device and tracks to control with the keyboard. Use the Shift and "
+"Control keys to select multiple tracks if required."
+msgstr ""
+"Zgjidh dispozitivin dhe kanalet për tu kontrolluar nga tastiera. Përdor "
+"pulsantët «Shift» dhe «Control» nëse duhen zgjedhur disa pista."
+
+#: ../capplets/sound/sound-properties.glade.h:14
+msgid "So_und playback:"
+msgstr "Riprodhimi i zë_rit:"
+
+#: ../capplets/sound/sound-properties.glade.h:15
+msgid "Sou_nd capture:"
+msgstr "Regjistrimi i zër_it:"
+
+#: ../capplets/sound/sound-properties.glade.h:16
+#: ../capplets/sound/sound-theme.c:461 ../capplets/sound/sound-theme.c:1016
+msgid "Sound Preferences"
+msgstr "Preferimet e zërit"
+
+#: ../capplets/sound/sound-properties.glade.h:17
+msgid "Sounds"
+msgstr "Tingujt"
+
+#: ../capplets/sound/sound-properties.glade.h:18
+msgid "Test"
+msgstr "Provë"
+
+#: ../capplets/sound/sound-properties.glade.h:19
+msgid "Testing Pipeline"
+msgstr "Verifikimi i pipeline"
+
+#: ../capplets/sound/sound-properties.glade.h:20
+msgid "_Device:"
+msgstr "_Dispozitivi:"
+
+#: ../capplets/sound/sound-properties.glade.h:21
+msgid "_Play alerts and sound effects"
+msgstr "Ri_prodho paralajmërime dhe efekte sonorë"
+
+#: ../capplets/sound/sound-properties.glade.h:22
+msgid "_Sound playback:"
+msgstr "Riprodhimi i _zërit:"
+
+#. Bell
+#: ../capplets/sound/sound-theme-definition.h:46
+msgctxt "Sound event"
+msgid "Alert sound"
+msgstr "Paralajmërim sonor"
+
+#: ../capplets/sound/sound-theme-definition.h:47
+msgctxt "Sound event"
+msgid "Visual alert"
+msgstr "Paralajmërim vizual"
+
+#. Windows and buttons
+#: ../capplets/sound/sound-theme-definition.h:49
+msgctxt "Sound event"
+msgid "Windows and Buttons"
+msgstr "Dritaret dhe butonët"
+
+#: ../capplets/sound/sound-theme-definition.h:50
+msgctxt "Sound event"
+msgid "Button clicked"
+msgstr "Buton i klikuar"
+
+#: ../capplets/sound/sound-theme-definition.h:51
+msgctxt "Sound event"
+msgid "Toggle button clicked"
+msgstr "Buton me dy gjëndje i klikuar"
+
+#: ../capplets/sound/sound-theme-definition.h:52
+msgctxt "Sound event"
+msgid "Window maximized"
+msgstr "Dritarja në maksimum"
+
+#: ../capplets/sound/sound-theme-definition.h:53
+msgctxt "Sound event"
+msgid "Window unmaximized"
+msgstr "Dritarja çmaksimizuar"
+
+#: ../capplets/sound/sound-theme-definition.h:54
+msgctxt "Sound event"
+msgid "Window minimised"
+msgstr "Dritarja në minimum"
+
+#. Desktop
+#: ../capplets/sound/sound-theme-definition.h:56
+msgctxt "Sound event"
+msgid "Desktop"
+msgstr "Hapësira e punës"
+
+#: ../capplets/sound/sound-theme-definition.h:57
+msgctxt "Sound event"
+msgid "Login"
+msgstr "Hyrja"
+
+#: ../capplets/sound/sound-theme-definition.h:58
+msgctxt "Sound event"
+msgid "Logout"
+msgstr "Përfundimi i seancës"
+
+#: ../capplets/sound/sound-theme-definition.h:59
+msgctxt "Sound event"
+msgid "New e-mail"
+msgstr "Mesazh i ri poste"
+
+#: ../capplets/sound/sound-theme-definition.h:60
+msgctxt "Sound event"
+msgid "Empty trash"
+msgstr "Zbrazje koshi"
+
+#: ../capplets/sound/sound-theme-definition.h:61
+msgctxt "Sound event"
+msgid "Long action completed (download, CD burning, etc.)"
+msgstr "Përfundimi një veprimi të gjatë (shkarkime, masterizim CD, etj.)"
+
+#. Alerts?
+#: ../capplets/sound/sound-theme-definition.h:63
+msgctxt "Sound event"
+msgid "Alerts"
+msgstr "Sinjalizime"
+
+#: ../capplets/sound/sound-theme-definition.h:64
+msgctxt "Sound event"
+msgid "Information or question"
+msgstr "Informacione ose pyetje"
+
+#: ../capplets/sound/sound-theme-definition.h:65
+msgctxt "Sound event"
+msgid "Warning"
+msgstr "Kujdes"
+
+#: ../capplets/sound/sound-theme-definition.h:66
+msgctxt "Sound event"
+msgid "Error"
+msgstr "Gabim"
+
+#: ../capplets/sound/sound-theme-definition.h:67
+msgctxt "Sound event"
+msgid "Battery warning"
+msgstr "Paralajmërim nga bateria"
+
+#: ../capplets/sound/sound-theme.c:437 ../capplets/sound/sound-theme.c:563
+msgid "Flash screen"
+msgstr "Ndriço të gjithë ekranin"
+
+#: ../capplets/sound/sound-theme.c:441 ../capplets/sound/sound-theme.c:567
+msgid "Flash window"
+msgstr "Ndriço dritaren"
+
+#: ../capplets/sound/sound-theme.c:463 ../capplets/sound/sound-theme.c:1018
+msgid "Testing event sound"
+msgstr "Tingulli verifikues i eventeve"
+
+#: ../capplets/sound/sound-theme.c:482
+msgid "Select Sound File"
+msgstr "Zgjidh file e tingullit"
+
+#: ../capplets/sound/sound-theme.c:493
+msgid "Sound files"
+msgstr "File audio"
+
+#: ../capplets/sound/sound-theme.c:547
+msgid "Custom..."
+msgstr "Personalizimi..."
+
+#: ../capplets/windows/gnome-window-properties.c:344
+msgid "Cannot start the preferences application for your window manager"
+msgstr ""
+"E pamundur nisja e aplikativit për preferimet e menazhuesit të dritareve"
+
+#. translators: this is the Control key
+#: ../capplets/windows/gnome-window-properties.c:602
+msgid "C_ontrol"
+msgstr "C_ontrol"
+
+#: ../capplets/windows/gnome-window-properties.c:607
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:613
+msgid "H_yper"
+msgstr "H_yper"
+
+#: ../capplets/windows/gnome-window-properties.c:620
+msgid "S_uper (or \"Windows logo\")"
+msgstr "S_uper (ose «Stema e Windows»)"
+
+#: ../capplets/windows/gnome-window-properties.c:627
+msgid "_Meta"
+msgstr "_Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Pulsanti i lëvizjes</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>Veprimi për shtyllën e titullit</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Zgjedhja e dritares</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr ""
+"Për të lëvizur një dritare, shtyp-dhe-mbaj këtë tast pastaj kap dritaren:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Preferimet e dritareve"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_Dopjo-klikim mbi titullin për të kryer këtë veprim:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "_Intervali përpara ngritjes në plan të parë:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_Sill në plan të parë dritaret e zgjedhura mbas një intervali"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Zgjidh dritaret kur mouse kalon sipër tyre"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "sekonda"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "Përcakton pronësitë e dritareve"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Dritaret"
+
+#. make start action
+#: ../libslab/application-tile.c:372
+#, c-format
+msgid "<b>Start %s</b>"
+msgstr "<b>Nis %s</b>"
+
+#: ../libslab/application-tile.c:391 ../libslab/bookmark-agent.c:1056
+msgid "Help"
+msgstr "Ndihmë"
+
+#: ../libslab/application-tile.c:438
+msgid "Upgrade"
+msgstr "Përditësimi"
+
+#: ../libslab/application-tile.c:453
+msgid "Uninstall"
+msgstr "Çinstalimi"
+
+#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
+msgid "Remove from Favorites"
+msgstr "Hiq nga të preferuarit"
+
+#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
+msgid "Add to Favorites"
+msgstr "Shto tek të preferuarit"
+
+#: ../libslab/application-tile.c:867
+msgid "Remove from Startup Programs"
+msgstr "Hiq nga programet në nisje"
+
+#: ../libslab/application-tile.c:869
+msgid "Add to Startup Programs"
+msgstr "Shto tek programet në nisje"
+
+#: ../libslab/app-shell.c:750
+#, c-format
+msgid ""
+"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+"\n"
+" Your filter \"<b>%s</b>\" does not match any items.</span>"
+msgstr ""
+"<span size=\"large\"><b>Nuk u gjet asnjë korrespondues.</b> </span><span>\n"
+"\n"
+" Filtri \"<b>%s</b>\" nuk zgjedh asnjë element.</span>"
+
+#: ../libslab/app-shell.c:900
+msgid "Other"
+msgstr "Të tjerë"
+
+#: ../libslab/bookmark-agent.c:1058
+msgid "Lock Screen"
+msgstr "Blloko ekranin"
+
+#: ../libslab/bookmark-agent.c:1060
+msgid "Logout"
+msgstr "Përfundimi i seancës"
+
+#: ../libslab/bookmark-agent.c:1062
+msgid "Shutdown"
+msgstr "Shuaj"
+
+#: ../libslab/bookmark-agent.c:1087
+msgid "New Spreadsheet"
+msgstr "Fletë e re llogaritje"
+
+#: ../libslab/bookmark-agent.c:1092
+msgid "New Document"
+msgstr "Dokument i ri"
+
+#: ../libslab/bookmark-agent.c:1143
+msgid "Home"
+msgstr "Shtëpia"
+
+#: ../libslab/bookmark-agent.c:1148
+msgid "Documents"
+msgstr "Dokumente"
+
+#: ../libslab/bookmark-agent.c:1161
+msgid "File System"
+msgstr "File i sistemit"
+
+#: ../libslab/bookmark-agent.c:1165
+msgid "Network Servers"
+msgstr "Server rrjeti"
+
+#: ../libslab/bookmark-agent.c:1194
+msgid "Search"
+msgstr "Kërko"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:171
+#, c-format
+msgid "<b>Open</b>"
+msgstr "<b>Hap</b>"
+
+#. make rename action
+#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:235
+msgid "Rename..."
+msgstr "Riemërto..."
+
+#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
+#: ../libslab/document-tile.c:249 ../libslab/document-tile.c:258
+msgid "Send To..."
+msgstr "Dërgo tek..."
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:284
+msgid "Move to Trash"
+msgstr "Lëviz në kosh"
+
+#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:456
+#: ../libslab/document-tile.c:294 ../libslab/document-tile.c:831
+msgid "Delete"
+msgstr "Elemino"
+
+#: ../libslab/directory-tile.c:532 ../libslab/document-tile.c:979
+#, c-format
+msgid "Are you sure you want to permanently delete \"%s\"?"
+msgstr "Eleminon përgjithmonë «%s»?"
+
+#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:980
+msgid "If you delete an item, it is permanently lost."
+msgstr "Një element i eleminuar do të humbasë përgjithmonë."
+
+#: ../libslab/document-tile.c:196
+#, c-format
+msgid "<b>Open with \"%s\"</b>"
+msgstr "<b>Hap me «%s»</b>"
+
+#: ../libslab/document-tile.c:208
+msgid "Open with Default Application"
+msgstr "Hap me aplikativin e paracaktuar"
+
+#: ../libslab/document-tile.c:219
+msgid "Open in File Manager"
+msgstr "Hap në «file manager»"
+
+#: ../libslab/document-tile.c:611
+msgid "?"
+msgstr "?"
+
+#: ../libslab/document-tile.c:618
+msgid "%l:%M %p"
+msgstr "%k.%M"
+
+#: ../libslab/document-tile.c:626
+msgid "Today %l:%M %p"
+msgstr "Sot në orën %k.%M"
+
+#: ../libslab/document-tile.c:636
+msgid "Yesterday %l:%M %p"
+msgstr "Dje në orën %k.%M"
+
+#: ../libslab/document-tile.c:648
+msgid "%a %l:%M %p"
+msgstr "%a në orën %k.%M"
+
+#: ../libslab/document-tile.c:656
+msgid "%b %d %l:%M %p"
+msgstr "%d %b në orën %k.%M"
+
+#: ../libslab/document-tile.c:658
+msgid "%b %d %Y"
+msgstr "%d %b %Y"
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr "Kërko tani"
+
+#: ../libslab/system-tile.c:128
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr "<b>Hap %s</b>"
+
+#: ../libslab/system-tile.c:141
+#, c-format
+msgid "Remove from System Items"
+msgstr "Hiq nga zërat e sistemit"
+
+#: ../libwindow-settings/gnome-wm-manager.c:318
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+"Menazhuesi i dritareve «%s» nuk ka një instrument konfigurimi të "
+"regjistruar\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:402
+msgid "Maximize"
+msgstr "Maksimizo"
+
+#: ../libwindow-settings/metacity-window-manager.c:403
+msgid "Maximize Vertically"
+msgstr "Maksimizo vertikalisht"
+
+#: ../libwindow-settings/metacity-window-manager.c:404
+msgid "Maximize Horizontally"
+msgstr "Maksimizo horizontalisht"
+
+#: ../libwindow-settings/metacity-window-manager.c:405
+msgid "Minimize"
+msgstr "Minimizo"
+
+#: ../libwindow-settings/metacity-window-manager.c:406
+msgid "Roll up"
+msgstr "Palos"
+
+#: ../libwindow-settings/metacity-window-manager.c:407
+msgid "None"
+msgstr "Asgjë"
+
+#: ../shell/control-center.c:62
+#, c-format
+msgid "key not found [%s]\n"
+msgstr "pulsanti nuk u gjet [%s]\n"
+
+#: ../shell/control-center.c:159
+msgid "Filter"
+msgstr "Filtri"
+
+#: ../shell/control-center.c:159
+msgid "Groups"
+msgstr "Grupe"
+
+#: ../shell/control-center.c:159
+msgid "Common Tasks"
+msgstr "Aktivitete të përbashkët"
+
+#: ../shell/control-center.c:163 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Qendra e kontrollit"
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr "Mbyll qendrën e kontrollit kur aktivizohet një aktivitet"
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr "Del nga terminali nëse kryhet një veprim shtimi apo heqje"
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr "Del nga terminali nëse kryhet një veprim ndihme"
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr "Del nga terminali nëse kryhet një veprim nisje"
+
+#: ../shell/control-center.schemas.in.h:5
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr "Del nga terminali nëse kryhet një veprim përditësimi apo çinstalimi"
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed."
+msgstr "Tregon nëse duhet mbyllur terminali kur kryhet një veprim ndihme."
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed."
+msgstr "Tregon nëse duhet mbyllur terminali kur kryhet një veprim nisje."
+
+#: ../shell/control-center.schemas.in.h:8
+msgid ""
+"Indicates whether to close the shell when an add or remove action is "
+"performed."
+msgstr ""
+"Tregon nëse duhet mbyllur terminali kur kryhet një veprim shtimi apo heqje."
+
+#: ../shell/control-center.schemas.in.h:9
+msgid ""
+"Indicates whether to close the shell when an upgrade or uninstall action is "
+"performed."
+msgstr ""
+"Tregon nëse duhet mbyllur terminali kur kryhet një veprim përditësimi apo "
+"çinstalimi."
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr "Emri i aktivitetit dhe file .desktop përkatës"
+
+#: ../shell/control-center.schemas.in.h:11
+msgid ""
+"The task name to be displayed in the control-center followed by a \";\" "
+"separator then the filename of an associated .desktop file to launch for "
+"that task."
+msgstr ""
+"Emri i aktivitetit për tu shfaqur në qendrën e kontrollit ndjekur nga \";\" "
+"si ndarës dhe nga emri i .desktop përkatës për nisjen e aktivitetit."
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+msgid ""
+"[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-"
+"applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+msgstr ""
+"[Ndrysho temën;gtk-theme-selector.desktop,Përcakto aplikativët e preferuar;"
+"default-applications.desktop,Shto printues;gnome-cups-manager.desktop]"
+
+#: ../shell/control-center.schemas.in.h:14
+msgid ""
+"if true, the control-center will close when a \"Common Task\" is activated."
+msgstr ""
+"Nëse E VËRTETË, qendra e kontrollit do të mbyllet në aktivizimin e një "
+"«aktiviteti të përbashkët»."
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "Instrument konfigurimi për GNOME"
+
+#: ../typing-break/drw-break-window.c:189
+msgid "_Postpone Break"
+msgstr "_Shty për më vonë pushimin"
+
+#: ../typing-break/drw-break-window.c:245
+msgid "Take a break!"
+msgstr "Pusho pak!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#. translators: keep the initial "/"
+#: ../typing-break/drwright.c:130
+msgid "/_Preferences"
+msgstr "/_Preferime"
+
+#: ../typing-break/drwright.c:131
+msgid "/_About"
+msgstr "/_Informacione"
+
+#: ../typing-break/drwright.c:133
+msgid "/_Take a Break"
+msgstr "/_Pusho pak"
+
+#: ../typing-break/drwright.c:489
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "Mungon %d minutë deri në pushimin tjetër"
+msgstr[1] "Mungojnë %d minuta deri në pushimin tjetër"
+
+#: ../typing-break/drwright.c:493
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr "Mungon më pak se një minutë deri në pushimin tjetër"
+
+#: ../typing-break/drwright.c:580
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"E pamundur hapja e dritares së dialogut të pronësive të pushimit për shkak "
+"të gabimit në vijim: %s"
+
+#: ../typing-break/drwright.c:599
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "Shkruar nga Richard Hult <richard@imendio.com>"
+
+#: ../typing-break/drwright.c:600
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Eye candy shtuar nga Anders Carlsson"
+
+#: ../typing-break/drwright.c:609
+msgid "A computer break reminder."
+msgstr "Një program për t'ju kujtuar për të pushuar gjatë punës në kompjuter."
+
+#: ../typing-break/drwright.c:611
+msgid "translator-credits"
+msgstr ""
+"Elian Myftiu <elian@alblinux.net>, 2003-2006\n"
+"Laurent Dhima <laurenti@alblinux.net>, 2008"
+
+#: ../typing-break/main.c:61
+msgid "Enable debugging code"
+msgstr "Aktivizoo kodin e debug"
+
+#: ../typing-break/main.c:63
+msgid "Don't check whether the notification area exists"
+msgstr "Mos kontrollo praninë e zonës së njoftimeve"
+
+#: ../typing-break/main.c:89
+msgid "Typing Monitor"
+msgstr "Kontrolli i shkrimit"
+
+#: ../typing-break/main.c:105
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Programi për kontrollin e shkrimit përdor zonën e njoftimeve për të shfaqur "
+"informacionet. Mesa duket ju nuk keni asnjë zonë njoftimi tek paneli juaj. "
+"Mund ta shtoni me një klikim të djathtë tek paneli juaj e duke zgjedhur "
+"\"Shto në panel\" , gjeni \"Zona e njoftimit\" e klikoni mbi pulsantin "
+"«Shto»."
+
+msgid "Show help options"
+msgstr "Shfaq opcionet e ndihmës"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,122 +7,26 @@
 # Милош Поповић <gpopac@gmail.com>, 2010, 2011.
 # Марко М. Костић <marko.m.kostic@gmail.com>, 2016.
 # Борисав Живановић <borisavzivanovic@gmail.com>, 2017-2018.
-# Мирослав Николић <miroslavnikolić@rocketmail.com>, 2011–2022.
+# Мирослав Николић <miroslavnikolic@rocketmail.com>, 2011–2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-07 19:57+0000\n"
-"PO-Revision-Date: 2022-09-08 02:18+0200\n"
-"Last-Translator: Марко М. Костић <marko.m.kostic@gmail.com>\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-10-26 11:48+0200\n"
+"Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: Serbian <српски <gnome-sr@googlegroups.org>>\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n==1? 3 : n%10==1 && n%100!=11 ? 0 : n"
-"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=4; plural=n==1? 3 : n%10==1 && n%100!=11 ? 0 : "
+"n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2\n"
 "X-Project-Style: gnome\n"
-"X-Generator: Poedit 3.1.1\n"
-
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Системска сабирница"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Пун приступ"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Сабирница сесије"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Уређаји"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Пун приступ фасцикли /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Мрежа"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Има приступ мрежи"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Личнo"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Само за читање"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Систем датотека"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Подешавања"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Може променити подешавања"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"Програм „%s“ садржи следећа уграђена овлашћења. Она не могу бити промењена. "
-"Уколико сте забринути због ових овлашћења, размислите о уклањању овог "
-"програма."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u датотека и врста везе које отвара програм"
-msgstr[1] "%u датотеке и врсте везе које отвара програм"
-msgstr[2] "%u датотека и врста везе које отвара програм"
-msgstr[3] "Једна датотека и врста везе коју отвара програм"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> се користи за отварање следећих врста датотека и веза."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s простора на диску заузето."
+"X-Generator: Gtranslator 3.36.0\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -138,7 +42,6 @@ msgid "Install some…"
 msgstr "Инсталирајте неке…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Отвори"
 
@@ -162,24 +65,13 @@ msgstr "Претрага"
 msgid "Receive system searches and send results."
 msgstr "Примање системских претрага и слање исхода."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Искључено"
 
@@ -343,7 +235,6 @@ msgstr "Очисти кеш…"
 msgid "Control various application permissions and settings"
 msgstr "Управља разним овлашћењима и подешавањима програма"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
@@ -351,75 +242,16 @@ msgstr ""
 "флатпек;овлашћење;пермисија;подешавање;aplikacija;program;flatpak;fletpek;"
 "flatpek;ovlašćenje;permisija;podešavanje;ovlascenje;podesavanje;"
 
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Изаберите слику"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Откажи"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Отвори"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "више величина"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Нема позадине за радну површ"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Тренутна позадина"
-
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Стил"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Основно"
 
@@ -443,7 +275,6 @@ msgstr "Изглед"
 msgid "Change your background image or the UI colors"
 msgstr "Промените слику позадине или боје интерфејса"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -496,9 +327,7 @@ msgstr "Хардверски авионски режим рада је укљу�
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Искључите авионски режим рада бисте укључили блутут."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Блутут"
 
@@ -506,7 +335,6 @@ msgstr "Блутут"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Укључите или искључите блутут и повежите ваше уређаје"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr ""
@@ -541,93 +369,35 @@ msgstr "Ниједан програм није затражио приступ �
 msgid "Protect your pictures"
 msgstr "Заштитите ваше слике"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "camera;photos;video;webcam;lock;private;privacy;камера;фотографије;видео;"
 "вебкам;закључавање;приватност;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Поставите уређај за калибрацију преко квадрата и притисните „Почни“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Померите уређај за калибрацију на положај калибрације и притисните „Настави“"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Померите уређај за калибрацију на положај површине и притисните „Настави“"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Заклопите преносни рачунар"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Дошло је до унутрашње грешке која не може бити опорављена."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Алати потребни за калибрацију нису инсталирани."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Профил не може бити направљен."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Бела тачка мете се не може добавити."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Завршено!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Калибрација није успела!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Можете да уклоните уређај за калибрацију."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Не ометајте уређај за калибрацију док је у раду"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Прикажи калибрацију"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Откажи"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -644,140 +414,6 @@ msgstr "_Настави"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Готово"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Екран преносног рачунара"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Уграђена веб камерица"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s монитор"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s скенер"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s фотоапарат"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s штампач"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s веб камерица"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Укључи управљање бојом за „%s“"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Прикажи профиле боја за „%s“"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Није калибрисано"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Основно: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Простор боја: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Пробни профил: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Изабери датотеку ИЦЦ профила"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Увези"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Подржани ИЦЦ профили"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Све датотеке"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Екран"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Сачувај профил"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Сачувај"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Направите профил боје за изабрани уређај"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Није откривен инструмент за мерење. Проверите да ли је укључен и да ли је "
-"исправно прикључен."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Инструмент за мерење не подржава профилисање штампача."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Тип уређаја тренутно није подржан."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -894,13 +530,13 @@ msgstr "Захтева уписив диск"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"Можете увидети да су упутнице о коришћењу профила на системима <a href="
-"\"linux\">ГНУ/Линукса</a>, <a href=\"osx\">Ејпол ОС Икс-а</a> и <a href="
-"\"windows\">Мајкрософт Виндоуза</a> корисне."
+"Можете увидети да су упутнице о коришћењу профила на системима <a "
+"href=\"linux\">ГНУ/Линукса</a>, <a href=\"osx\">Ејпол ОС Икс-а</a> и <a "
+"href=\"windows\">Мајкрософт Виндоуза</a> корисне."
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -920,7 +556,6 @@ msgstr "_Увези датотеку…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -931,9 +566,7 @@ msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Сваком уређају је потребан освежени профил боје да би био управљан бојом."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Сазнајте више"
 
@@ -1066,82 +699,6 @@ msgstr "Д65 (Фотографија и графика)"
 msgid "D75"
 msgstr "Д75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Уобичајени простор"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Испробај профил"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Самостални"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Низак квалитет"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Осредњи квалитет"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Висок квалитет"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Основна РГБ"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Основна ЦМУК"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Основна сива"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Продавац је доставио податке фабричке калибрације"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Исправка приказа преко целог екрана није могућа са овим профилом"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Овај профил више не може бити тачан"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Боја"
@@ -1152,16 +709,11 @@ msgid ""
 msgstr ""
 "Калибрирајте боје ваших уређаја, као што су екрани, фото-апарати или штампачи"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Color;ICC;Profile;Calibrate;Printer;Display;боја;ицц;профил;калибрирај;"
 "штампач;екран;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Други…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1176,13 +728,8 @@ msgid "No languages found"
 msgstr "Нисам пронашао језике"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Још…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Откључај за промену подешавања"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1211,157 +758,6 @@ msgstr "Смањи сат"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Смањи минут"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Данас"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Јуче"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y."
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d сат"
-msgstr[1] "%d сата"
-msgstr[2] "%d сати"
-msgstr[3] "Један сат"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d минут"
-msgstr[1] "%d минута"
-msgstr[2] "%d минута"
-msgstr[3] "Један минут"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d секунда"
-msgstr[1] "%d секунде"
-msgstr[2] "%d секунди"
-msgstr[3] "Једна секунда"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 секунди"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Врућа тачка"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-часовно"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "ПрП/ПоП"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%A, %e.%m.%Y. %l:%M %P"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e. %B %Y. %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "КУВ%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %P"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1456,17 +852,11 @@ msgstr "Аутоматска временска _зона"
 msgid "Requires location services enabled and internet access"
 msgstr "Захтева омогућену услугу места и приступ интернету"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Омогућено"
 
@@ -1474,15 +864,42 @@ msgstr "Омогућено"
 msgid "Time Z_one"
 msgstr "Временска з_она"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Откључај"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Запис _времена"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Датуми"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 секунди"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Календар"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Бројеви"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Измените датум и време, укључујући временску зону"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;сат;временска зона;место;"
@@ -1529,20 +946,9 @@ msgstr "Подразумевани програми"
 msgid "Configure Default Applications"
 msgstr "Подесите основне програме"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "основни;програм;омиљени;медиј;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Слање извештаја о техничким проблемима нам помаже да побољшамо дистрибуцију "
-"„%s“. Извештаји се шаљу безимено и очишћени су од личних података. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1560,44 +966,9 @@ msgstr "Дијагностика"
 msgid "Report your problems"
 msgstr "Пријавите ваше проблеме"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostics;crash;дијагностика;пад;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Укљ."
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Искљ."
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Да применим измене?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Не могу да применим измене"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Ово је можда због ограничења хардвера."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1647,31 +1018,6 @@ msgstr "Главни екран"
 msgid "Night Light"
 msgstr "Ноћно светло"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Положено"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Усправно десно"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Усправно лево"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Положено (изврнуто)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1695,6 +1041,17 @@ msgstr "Дотеривање за ТВ"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Размера"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Природно клизање"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1791,7 +1148,6 @@ msgstr "Екрани"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Изаберите како ћете користити повезане екране и пројекторе"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1803,65 +1159,6 @@ msgstr ""
 "projektor;iks-randr;ekran;rezolucija;osvežavanje;monitor;noć;svetlo;plavo;"
 "redšift;boja;svitanje;sumrak;"
 
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Безбедно подизање је покренуто"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Безбедно подизање има проблема"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Безбедно подизање је искључено"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
 "Secure boot prevents malicious software from being loaded when the device "
@@ -1869,116 +1166,14 @@ msgid ""
 "\n"
 "For more information, contact the hardware manufacturer or IT support."
 msgstr ""
+"Безбедно подизање спречава учитавање злонамерног софтвера за време покретања "
+"уређаја.\n"
+"\n"
+"За више информација, обратите се произвођачу хардвера или ИТ подршци."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Успешно"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Неуспешно"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Безбедносни ниво 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Безбедносни ниво 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Безбедносни ниво 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Безбедносни ниво 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Безбедносни ниво"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr ""
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -1992,331 +1187,9 @@ msgstr "Ниво 2"
 msgid "Level 3"
 msgstr "Ниво 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Безбедно подизање има проблема"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Безбедно подизање је искључено"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr ""
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr ""
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr ""
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Нема догађаја"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Заштита уписа фирмвера"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Катанац заштите уписа фирмвера"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Област БИОС фирмвера"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Описник БИОС фирмвера"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr ""
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr ""
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr ""
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr ""
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Шифровани РАМ"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "ИОММУ заштита"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Закључавање Линукс кернела"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Потврђивање Линукс кернела"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Линуксова разменска"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Обустава у РАМ"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Обустава у мировање"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Платформски УЕФИ кључ"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "УЕФИ безбедно подизање"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Подешавање ТПМ платформе"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "ТПМ реконструкција"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "ТПМ издања 2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr ""
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr ""
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Ажурирања фирмвера"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Атест фирмвера"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Потврђивање ажурирања фирмвера"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Платформско поправљање грешака"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Безбедносне провере процесора"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr ""
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Риплеј заштита АМД фирмвера"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Заштита уписа АМД фирмвера"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr ""
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Исправно"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Није исправно"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Није омогућено"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Закључано"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Откључано"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Шифровано"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Нешифровано"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Укаљано"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Неукаљано"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Уочено"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Неуочено"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Подржано"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Неподржано"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2326,7 +1199,6 @@ msgstr "Безбедност уређаја"
 msgid "Host firmware security status"
 msgstr "Безбедносно стање фирмвера домаћина"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2335,49 +1207,6 @@ msgstr ""
 "екран;закључај;дијагноза;пад;урушавање;лично;скорашње;недавно;привремен;тмп;"
 "попис;назив;мрежа;идентитет;приватност;screen;lock;diagnostics;crash;private;"
 "recent;temporary;tmp;index;name;network;identity;privacy;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Непознато"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-бита"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-бита"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "Икс-11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Вејленд"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Непознато"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Није доступно"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Лого система"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2471,11 +1300,6 @@ msgstr "Системски подаци"
 msgid "View information about your system"
 msgstr "Погледајте податке о вашем систему"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2558,6 +1382,12 @@ msgstr "Покретачи"
 msgid "Launch help browser"
 msgstr "Покреће прегледач помоћи"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Подешавања"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Покреће калкулатор"
@@ -2579,7 +1409,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Претрага"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Систем"
 
@@ -2628,15 +1458,6 @@ msgstr "Смањи величину текста"
 msgid "High contrast on or off"
 msgstr "Укључи/искључи велики контраст"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Нисам пронашао изворе улаза"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Друго"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Додајте извор улаза"
@@ -2669,106 +1490,9 @@ msgstr "Поставке"
 msgid "View Keyboard Layout"
 msgstr "Прикажи распоред тастатуре"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Уклони"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Произвољне пречице"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Тастери заменских знакова"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Тастер заменских карактера се може користити за унос додатних знакова. "
-"Некада су одштампани као трећа могућност на вашој тастатури."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Леви алт"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Десни алт"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Леви супер"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Десни супер"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Тастер изборника"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Десни Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Саставни тастер"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Саставни тастер омогућава унос широког спектра знаков. Да га користите, "
-"притисните саставни тастер затим низ знакова.  На пример, саставни тастер за "
-"којим следи <b>C</b> и <b>o</b> уписаће <b>©</b>, <b>a</b> за којим следи "
-"<b>'</b> уписаће <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Закључавање слова"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Закључавање померања"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Штампај екран"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Извор уноса се може променити преко %s пречице на тастатури.\n"
-"Пречица се може променити у подешавањима пречица тастатуре."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2798,47 +1522,21 @@ msgstr "Унос посебних знакова"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Начини за унос симбола и различитих слова преко тастатуре."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Тастери заменских знакова"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Саставни тастер"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Пречице тастатуре"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Преглед и прилагођавање пречица"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d ставка је измењена"
-msgstr[1] "%d ставки је измењено"
-msgstr[2] "%d ставки је измењено"
-msgstr[3] "Једна ставка је измењена"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Да вратим све пречице?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Поновно враћање пречица може утицати на ваше произвољне пречице. Ово се не "
-"може опозвати."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Откажи"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Врати све"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2878,35 +1576,6 @@ msgstr "Додај пречицу"
 msgid "No keyboard shortcut found"
 msgstr "Нисам нашао речицу тастатуре"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"„%s“ се већ користи за пречицу „%s“. Ако замените, пречица „%s“ биће "
-"онемогућена"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Унесите нову пречицу"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Постави произвољну пречицу"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Постави пречицу"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Унесите нову пречицу за „%s“."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Додајте произвољну пречицу"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Уклони"
@@ -2918,7 +1587,6 @@ msgstr "_Замени"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Постави"
 
@@ -2956,6 +1624,11 @@ msgstr "Ништа"
 msgid "Reset the shortcut to its default value"
 msgstr "Врати пречицу на њену основну вредност"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Коришћење ваше камере"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Тастатура"
@@ -2968,7 +1641,6 @@ msgstr ""
 "Промените пречице тастатуре и подесите ваше поставке куцања, распореде "
 "тастатуре и изворе улаза"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3011,10 +1683,10 @@ msgstr "Ниједан програм није затражио податке �
 msgid "Protect your location information"
 msgstr "Заштитите ваше податке о месту становања"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr ""
+"место;локација;џпс;гпс;приватно;приватност;location;gps;private;privacy;"
 
 #: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
@@ -3046,10 +1718,11 @@ msgstr "Ниједан програм није затражио приступ �
 msgid "Protect your conversations"
 msgstr "Заштитите ваше разговоре"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
+"микрофон;снимање;програм;апликација;приватност;microphone;recording;"
+"application;privacy;"
 
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
@@ -3076,81 +1749,140 @@ msgstr "Лево"
 msgid "Right"
 msgstr "Десно"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Места претраге"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Миш"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Брзина миша"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Природно клизање"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Клизај на доле"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Клизање помера садржај, не преглед."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Клизање помера садржај, не преглед."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Покренуто"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Додирна табла"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Брзина додирне табле"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Лупни за клик"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Лупни за клик"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Премицање са два прста"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Искључи док _куцам"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Додирна табла (релативно)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Клизање по страни"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Клизај на доле"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Двострано"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Испробајте кликање, двоструко кликање, клизање"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Пет клика, ГЕГЛ време!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Двоструки клик, главно дугме"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Један клик, главно дугме"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Двоструки клик, средње дугме"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Један клик, средње дугме"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Двоструки клик, помоћно дугме"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Један клик, помоћно дугме"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3163,7 +1895,6 @@ msgstr ""
 "Промените осетљивост миша или додирне табле и изаберите леворукост или "
 "деснорукост"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3245,7 +1976,6 @@ msgstr "Упоредни рад"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Управљајте поставкама продуктивности и упоредног рада"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3255,20 +1985,11 @@ msgstr ""
 "Врући угао;Радни простори;Uporedni rad;Višestruki rad;Produktivnost;"
 "Prilagodi;Desktop;Radna površ;Vruci ugao;Radni prostori;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Упс, нешто је пошло наопако. Обратите се вашем продавцу софтвера."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Управљач мрежом треба бити покренут."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Други уређаји"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "ВПН"
 
@@ -3280,59 +2001,16 @@ msgstr "Додај везу"
 msgid "Not set up"
 msgstr "Није подешено"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (Назив мреже: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Небезбедна мрежа (ВЕП)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Безбедна мрежа (ВПА2)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Безбедна мрежа (ВПА2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Безбедна мрежа (ВПА3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Безбедна мрежа"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Повезани сте"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Могућности…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Укључивање вруће тачке ће вас откачити са мреже %s и неће бити могућ приступ "
-"интернету преко бежичне картице."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Мора садржати најмање осам знакова"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3385,20 +2063,6 @@ msgstr "Самостално направи лозинку"
 msgid "_Turn On"
 msgstr "_Укључи"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Бежична"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Да зауставим врућу тачку и да искључим све кориснике?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Заустави врућу тачку"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Режим у авиону"
@@ -3443,89 +2107,13 @@ msgstr "Видљиве мреже"
 msgid "NetworkManager needs to be running"
 msgstr "Управљач мрежом треба бити покренут"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Упс, нешто је пошло наопако. Обратите се вашем продавцу софтвера."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Безбедност 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Безбедност"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Задржи"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Трајно"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Насумично"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Стабилно"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"МАК адреса коју унесете овде биће коришћена као хардверска адреса мрежног "
-"уређаја на којем се покрене ова веза. Ова могућност је познатија као "
-"клонирање или лажирање МАК адресе. На пример: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Профил „%d“"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "ВЕП"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "ВПА"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "ВПА3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Побољшано отварање"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "ВПА2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Ентерпрајз"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ништа"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Никад"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3537,183 +2125,6 @@ msgstr[1] "Пре %i дана"
 msgstr[2] "Пре %i дана"
 msgstr[3] "Пре једног дана"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Нема сигнала"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Слаб сигнал"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Добар сигнал"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Одличан сигнал"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Изврстан сигнал"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "ИПв4 адреса"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "ИПв6 адреса"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "ИП адреса"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "ДНС4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "ДНС6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "ДНС"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Заборави везу"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Уклони профил везе"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Уклони ВПН"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Појединости"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "самостално"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Идентитет"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Обриши адресу"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Обриши руту"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "ИПв4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "ИПв6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ништа"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "ВЕП 40/128-битни кључ (Хекса или АСКРИ)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "ВЕП 128-битна лозинка"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "ЛЕАП"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Динамички ВЕП (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "Лични ВПА & ВПА2"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "Пословни ВПА & ВПА2"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "ВПА3 лично"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3723,8 +2134,20 @@ msgstr "Јачина сигнала"
 msgid "Link speed"
 msgstr "Брзина везе"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Безбедност"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "ИПв4 адреса"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "ИПв6 адреса"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Хардверска адреса"
 
@@ -3733,12 +2156,17 @@ msgid "Supported Frequencies"
 msgstr "Подржане фреквенције"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Подразумевана рута"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "ДНС"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3803,7 +2231,7 @@ msgstr "Само вежи-локално"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Ручно"
 
@@ -3847,9 +2275,8 @@ msgstr "Мрежни пролаз"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Самостално"
 
@@ -3902,89 +2329,9 @@ msgstr "Самостално, само ДХЦП"
 msgid "Prefix"
 msgstr "Префикс"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Не могу да отворим уређивача везе"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Нови профил"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Неисправно подешавање %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Неисправно подешавање %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Увези из датотеке…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Додај ВПН"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Б_езбедност"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Не могу да увезем ВПН везу"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Не могу да прочитам датотеку „%s“ или она не садржи познате ВПН податке о "
-"вези\n"
-"\n"
-"Грешка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Изаберите датотеку за увоз"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Датотека под називом „%s“ већ постоји."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Замени"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Да ли желите да замените „%s“ ВПН везом коју сада чувате?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Не могу да извезем ВПН везу"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Не могу да извезем ВПН везу „%s“ у %s.\n"
-"\n"
-"Грешка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Извези ВПН везу"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3998,11 +2345,16 @@ msgstr "_ССИД"
 msgid "_BSSID"
 msgstr "_БССИД"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Мрежа"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Управљајте вашим повезивањем на Интернет"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
@@ -4011,11 +2363,15 @@ msgstr ""
 "LAN;proksi;posrednik;VAN;broadbend;širokopojasni;modem;blutut;mreza;"
 "sirokopojasni;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Бежична"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Управљајте повезивањем на бежичне мреже"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
@@ -4023,81 +2379,9 @@ msgstr ""
 "бежична;вај-фај;ип;лан;широкопојасна;ДНС;хотспот;mreža;bežična;vaj-faj;ip;"
 "lan;širokopojasna;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "никад"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "данас"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "јуче"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Коришћена"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Жичана"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Додајте нову везу"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Детаљи мреже за изабране мреже, укључујући лозинку и сва произвољна "
-"подешавања ће бити изгубљени."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Заборави"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Познате бежичне мреже"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Заборави"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Политика система забрањује употребу као вруће тачке"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Бежични уређај не подржава режим вруће тачке"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Аутоматско налажење веб посредника се користи када није дата адреса за "
-"подешавање."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Ово није препоручљиво за небезбедне, јавне мреже."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4116,6 +2400,10 @@ msgstr "ИМЕИ"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Достављач"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "ИП адреса"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4200,289 +2488,6 @@ msgstr "_Укључи бежичну врућу тачку…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Познате бежичне мреже"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Непознато стање"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Неуправљан"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Недоступно"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Повезујем се"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Потребно је потврђивање идентитета"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Искључујем"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Повезивање није успело"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Стање је непознато (недостаје)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Није успело подешавање"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Није успело подешавање ИП-а"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Истекло је подешавање ИП-а"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Затражене су тајне, али нису достављене"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Прекинута је веза са 802.1x молиоцем"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Није успело подешавање 802.1x молиоца"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x молилац није успео"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Потврђивање идентитета 802.1x молиоца је трајало предуго"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "ППП услуга није успела да се покрене"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "ППП услуга је искључена"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "ППП није успело"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "ДХЦП клијент није успео да е покрене"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Грешка ДХЦП клијента"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "ДХЦП клијент није успео"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Услуга дељене везе није успела да се покрене"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Услуга дељене везе није успела"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Услуга самосталног ИП-а није успела да се покрене"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Грешка услуге самосталног ИП-а"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Услуга самосталног ИП-а није успела"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Линија је заузета"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Нема тона позивања"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Ниједан оператер не може бити пронађен"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Истекло је време захтева позивања"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Покушај позивања није успео"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Није успело покретање модема"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Нисам успео да изаберем наведени НТП"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Не тражим мреже"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Завођење мреже је одбијено"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Истекло је време за завођење мреже"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Нисам успео да заведем са захтеваном мрежом"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Провера ПИН-а није успела"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Можда недостаје фирмвер за уређај"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Веза је нестала"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Постојећа веза биће присвојена"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Није пронађен модем"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Веза блутута није успела"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "СИМ картица није убачена"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Потребан је СИМ ПИН"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Потребан је СИМ ПУК"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Погрешна СИМ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Није успела зависност везе"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Недостаје фирмвер"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Кабал је искључен"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "неодређена грешка у 802.1X безбедности (впа-еап)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "није изабрана датотека"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "неодређена грешка потврђивања датотеке еап-метода"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "ДЕР, ПЕМ, ПКЦС#12, или ПГП приватни кључеви"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "ДЕР или ПЕМ уверења"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "недостаје датотека ЕАП-ФАСТ ПАЦ"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "ПАЦ датотеке (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4531,14 +2536,6 @@ msgstr "_Унутрашња пријава"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Дозволи аутоматско ПАЦ _снабдевање"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "недостаје ЕАП-ЛЕАП корисничко име"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "недостаје ЕАП-ЛЕАП лозинка"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4564,16 +2561,6 @@ msgstr "_Лозинка"
 msgid "Sho_w password"
 msgstr "По_кажи лозинку"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "неисправно ЕАП-ПЕАП уверење издавача уверења: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-"неисправно ЕАП-ПЕАП уверење издавача уверења: није наведено никакво уверење"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4595,7 +2582,6 @@ msgid "C_A certificate"
 msgstr "ЦА _уверење"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4610,63 +2596,6 @@ msgstr "Није потребно _уверење издавача уверењ�
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "ПЕАП _издање"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "недостаје ЕАП корисничко име"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "недостаје ЕАП лозинка"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "недостаје ЕАП-ТЛС идентитет"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "неисправно ЕАП-ТЛС уверење издавача уверења: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-"неисправно ЕАП-ТЛС уверење издавача уверења: није наведено никакво уверење"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "неисправан ЕАП-ТЛС приватни кључ: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "неисправно ЕАП-ТЛС уверење корисника: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Нешифровани приватни кључеви нису сигурни"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Изгледа да изабрани приватни кључ није заштићен лозинком. Ово може угрозити "
-"ваше сигурносне податке. Изаберите приватни кључ који зе заштићен лозинком.\n"
-"\n"
-"(Можете заштитити приватне кључеве користећи „openssl“)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Изаберите ваше лично уверење"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Изаберите лични кључ"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4683,16 +2612,6 @@ msgstr "Лични _кључ"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Лозинка личног кључа"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "неисправно ЕАП-ТТЛС уверење издавача уверења: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-"неисправно ЕАП-ТТЛС уверење издавача уверења: није наведено никакво уверење"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4715,14 +2634,15 @@ msgstr "ЦХАП"
 msgid "_Domain"
 msgstr "_Домен"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Непозната грешка потврђивања 802.1X безбедности"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "ТЛС"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "ЛЕАП"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4750,59 +2670,10 @@ msgstr "Заштићени ЕАП (ПЕАП)"
 msgid "Au_thentication"
 msgstr "Потврђивање _идентитета"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Изаберите датотеку"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "недостаје леап корисничко име"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "недостаје леап лозинка"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Недостаје лозинка бежичне мреже."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Врста"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "недостаје веп кључ"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"неисправан веп кључ: кључ дужине %zu мора да садржи само хексадецималне цифре"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "неисправан веп кључ: кључ дужине %zu мора да садржи само аскри знакове"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"неисправан веп кључ: погрешна дужина кључа %zu. Кључ мора бити дужине 5/13 "
-"(аскри) или 10/26 (хекса)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "неисправан веп кључ: пропусна реч не сме бити празна"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "неисправан веп кључ: пропусна реч мора бити краћа од 64 знакова"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4827,20 +2698,6 @@ msgstr "П_рикажи кључ"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "ВЕП и_ндекс"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"неисправан впа-пск: неисправна дужина кључа %zu. Мора бити [8,63] бајта или "
-"64 хексадецималних цифара"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"неисправан впа-пск: не могу да растумачим кључ са 64 бајта као хексадецимални"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4895,29 +2752,11 @@ msgstr "_Обавештења на екрану закључавања"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Управљајте приказаним обавештењима и њиховим садржајем"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Notifications;Banner;Message;Tray;Popup;обавештења;врпца;порука;фиока;"
 "искочко;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Друго"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "Корисник „%s“ је уклоњен"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Грешка у уклањању налога"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4941,17 +2780,6 @@ msgstr "Нема интернет везе — повежите се да под
 msgid "Add an account"
 msgstr "Додајте налог"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "„%s“ налог"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Уклони налог"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Налози на мрежи"
@@ -4961,10 +2789,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Повежите се на ваше налоге на мрежи и одлучите за шта ћете их користити"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4974,10 +2798,6 @@ msgstr ""
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;гугл;фејсбук;твитер;јаху;веб;мрежа;"
 "ћаскање;календар;пошта;контакт;лични_облак;керберос;имап;смтп;покет;"
 "прочитајкасније;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Непознато време"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4997,13 +2817,6 @@ msgstr[1] "%i сата"
 msgstr[2] "%i сати"
 msgstr[3] "Један сат"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%d %s %d %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5020,188 +2833,6 @@ msgstr[0] "минут"
 msgstr[1] "минута"
 msgstr[2] "минута"
 msgstr[3] "минут"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s до потпуне напуњености"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Пажња: преостаје још %s рада"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Преостало време: %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Потпуно пуна"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Не пуни се"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Празна"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Пуни се"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Празни се"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Бежични миш"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Бежична тастатура"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Непрекидив извор напајања"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Лични дигитални помоћник"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Мобилни телефон"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Музички уређај"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Таблица"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Рачунар"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Улазни уређај за игре"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Батерија"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Главна"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Додатна"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Батерије"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Када _мирује"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Обустави"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Искључи"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Замрзни"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Ништа"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Када се напаја са батерије"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Када је укључен"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Никада"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Самостална обустава уређаја"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "Најбржи режим рада онемогућен због високе радне температуре."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Уочен рад на крилу: најбржи режим тренутно није доступан. Померите уређај на "
-"неку стабилну површину за омогућавање најбржег рада."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Режим учинковитости је тренутно искључен."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Батерија је скоро празна: штедиша енергије је укључен. Претходни режим биће "
-"враћен када се батерија довољно напуни."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Режим штедише напајања је укључио „%s“."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Режим учинковитости је покренуо „%s“."
 
 # bug(danilo): plural-forms
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
@@ -5266,6 +2897,15 @@ msgstr "100 минута"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 сата"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батерија"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Уређаји"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5344,33 +2984,6 @@ msgstr "Када се напаја са _батерије"
 msgid "Delay"
 msgstr "Застој"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Најбрже"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Велика брзина и коришћење напајања."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Уравнотеженост"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Уобичајена брзина и коришћење напајања."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Уштеда батерије"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Умањена брзина и коришћење напајања."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Напајање"
@@ -5379,7 +2992,6 @@ msgstr "Напајање"
 msgid "View your battery status and change power saving settings"
 msgstr "Погледајте стање ваше батерије и измените подешавања уштеде напајања"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5389,27 +3001,6 @@ msgstr ""
 "Energy;напајање;спавање;обустава;замрзавање;батерија;осветљај;затамњење;"
 "монитор;ДПМС;мировање;Енергија;napajanje;spavanje;obustava;zamrzavanje;"
 "baterija;osvetljaj;mirovanje;Energija;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Штампач „%s“ је обрисан"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Нисам успео да додам нови штампач."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Не могу да учитам сучеље: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Откључај за додавање штампача и промену подешавања"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5421,7 +3012,6 @@ msgstr ""
 "Додајте штампаче, погледајте послове штампања и одлучите као желите да "
 "штампате"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -5430,8 +3020,6 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Додај штампач"
 
@@ -5471,29 +3059,6 @@ msgstr ""
 msgid "Username"
 msgstr "Корисничко име"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Појединости за „%s“"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Нису пронађени одговарајући управљачки програми"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Изаберите ППД датотеку"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Датотеке описа Пост скрипт штампача (*.ppd,*.PPD, *.ppd.gz, *PPD.gz, *.PPD."
-"GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Назив штампача не може садржати размак, табулатор, # или /"
@@ -5502,9 +3067,7 @@ msgstr "Назив штампача не може садржати размак,
 msgid "Location"
 msgstr "Место"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Управљачки програм"
 
@@ -5532,121 +3095,14 @@ msgstr "Изаберите управљачки програм штампача"
 msgid "Loading drivers database…"
 msgstr "Учитавам базу података управљачких програма…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Откажи"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Изабери"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Штампач са непосредним млазом"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "ЛПД штампач"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Једнострано"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "По дужој страни (стандардно)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "По краћој страни (окренуто)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Усправно"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Положено"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Обрнуто положено"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Обрнуто усправно"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Настави"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Заустави"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "На чекању"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Заустављен"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Потребно је потврђивање идентитета"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Обрађујем"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Заустављен"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Отказан"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Поништен"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Завршен"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Пребаци овај посао на почетак реда"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5655,19 +3111,6 @@ msgstr[0] "%u посао захтева потврђивање идентите�
 msgstr[1] "%u посла захтевају потврђивање идентитета"
 msgstr[2] "%u послова захтева потврђивање идентитета"
 msgstr[3] "Један посао захтева потврђивање идентитета"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — покренути послови"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Унесите пуномоћства да бисте штампали са штампача „%s“."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5695,206 +3138,11 @@ msgstr "Потврди идентитет"
 msgid "No Active Printer Jobs"
 msgstr "Нема покренутих послова на штампачу"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Откључај сервер штампача"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Откључај „%s“."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Унесите корисничко име и лозинку да видите штампаче на „%s“."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Тражим штампаче"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "УСБ"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Серијски прикључник"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Паралелни прикључник"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Место: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Адреса: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Сервер захтева потврђивање идентитета"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Двострано"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Тип папира"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Извор папира"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Излазна трака"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Резолуција"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Гост скрипт предфилтер"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Страница по листу"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Двострано"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Усмерење"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Опште"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Подешавање странице"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Инстаљиве опције"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Посао"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Квалитет слике"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Боја"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Завршавање"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Напредно"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Пробна страница"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Пробна страница"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Сам одреди"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Подразумевано"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Само угњеждени Гост скрипт фонтови"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Преведи у 1° ниво постскрипта"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Преведи у 2° ниво постскрипта"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Без предфилтрирања"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Произвођач"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Нема активних послова"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5903,115 +3151,6 @@ msgstr[0] "%u посао"
 msgstr[1] "%u посла"
 msgstr[2] "%u послова"
 msgstr[3] "један посао"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Очистите главе штампача"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Понестаје тонера"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Нема више тонера"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Понестаје развијача"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Нема више развијача"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Понестаје маркера"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Нема више мастила"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Отворен поклопац"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Отворена вратанца"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Понестаје папира"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Нема више папира"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Искључен"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Заустављен"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Посуда за отпад је скоро пуна"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Посуда за отпад је пуна"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Оптички проводник фотографија је при крају живота"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Оптички проводник фотографија више не функционише"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Спреман"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Не прихвата послове"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Обрађује"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6035,6 +3174,10 @@ msgstr "Очисти главе штампача"
 msgid "Remove Printer"
 msgstr "Уклони штампач"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Нема активних послова"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6055,16 +3198,21 @@ msgid "Restart"
 msgstr "Поново покрени"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Додај штампач…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Додај штампач…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Нема штампача"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6072,7 +3220,6 @@ msgstr ""
 "Изгледа да није доступан позадински\n"
 "    програм за штампу."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Облици"
@@ -6100,16 +3247,6 @@ msgstr "Можете тражити земље или језике."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Преглед"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Империјални"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Метрички"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6147,20 +3284,24 @@ msgstr ""
 "Подешавање језика које се користи за приказ текста и веб страница. Формати "
 "се користе за бројеве, датуме и валуте."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Ваш налог"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Језик"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Формати"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Екран за пријављивање"
 
@@ -6172,99 +3313,9 @@ msgstr "Регион и језик"
 msgid "Select your display language and formats"
 msgstr "Изаберите ваш приказни језик и формате"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;језик;распоред;тастатура;унос;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Питај шта да радиш"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Не ради ништа"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Отвори фасциклу"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Остали носачи података"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Изаберите програм за аудио дискове (ЦД)"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Изаберите програм за видео дискове (ДВД)"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Изаберите програм за покретање када је прикључен музички плејер"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Изаберите програм за покретање када је прикључена камера"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Изаберите програм за дискове са софтвером"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "аудио ДВД"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "празан Блу-реј диск"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "празан ЦД диск"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "празан ДВД диск"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "празан ХД ДВД диск"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Блу-реј видео диск"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "читач ел. књига"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "ХД ДВД видео диск"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "ЦД са сликама"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Супер видео ЦД"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Видео ЦД"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Виндоуз програми"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6315,7 +3366,6 @@ msgstr "Преносни носачи"
 msgid "Configure Removable Media settings"
 msgstr "Подесите преносне медије"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6326,123 +3376,6 @@ msgstr ""
 "usb;zvuk;snimak;disk;uklonjivi;medijum;nosač;samopokretanje;device;system;"
 "default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;"
 "autorun;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Екран се искључује"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 секунди"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 минут"
-
-# bug(danilo): plural-forms
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 минута"
-
-# bug(danilo): plural-forms
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 минута"
-
-# bug(danilo): plural-forms
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 минута"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 минута"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 сат"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 минут"
-
-# bug(danilo): plural-forms
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 минута"
-
-# bug(danilo): plural-forms
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 минута"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 минута"
-
-# bug(danilo): plural-forms
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 минута"
-
-# bug(danilo): plural-forms
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 минута"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 минута"
-
-# bug(danilo): plural-forms
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 минута"
-
-# bug(danilo): plural-forms
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 минута"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Никада"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6480,40 +3413,40 @@ msgstr "Период када треба самостално закључати
 msgid "Show _Notifications on Lock Screen"
 msgstr "Прикажи обавештења _на закључаном екрану"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "_Обавештења на екрану закључавања"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Забрани нове _УСБ уређаје"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr "Спречава нове УСБ уређаје да раде на систему док је екран закључан."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Приватност екрана"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Ограничи угао гледања"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Екран"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Подешавања екрана"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "screen;lock;private;privacy;екран;закључавање;приватност;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Изабери место"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "У _реду"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6544,10 +3477,6 @@ msgstr "Друго"
 msgid "Add Location"
 msgstr "Додај место"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Нисам пронашао програме"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Претрага програма"
@@ -6575,95 +3504,15 @@ msgstr ""
 "Одлучите који програми ће приказивати резултате претраге у прегледу "
 "активности"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Search;Find;Index;Hide;Privacy;Results;нађи;тражи;пронађи;потражи;попис;"
 "индекс;сакриј;приватност;резултати;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Нису изабране мреже за дељење"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Мреже"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Укљ."
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Искљ."
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Укључено"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Радна"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Изаберите фасциклу"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Додај"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Омогући дељење медија"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Дељење датотека вам омогућава да делите вашу јавну фасциклу са другима на "
-"вашој тренутној мрежи користећи: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Када је укључено удаљено пријављивање, удаљени корисници могу да се повежу "
-"користећи наредбу безбедне шкољке:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Омогући дељење личних датотека"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Назив уређаја копиран"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Адреса уређаја копирана"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Корисничко име копирано"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Лозинка копирана"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6792,7 +3641,6 @@ msgstr "Фасцикле"
 msgid "Control what you want to share with others"
 msgstr "Одлучите шта желите да делите с другима"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6814,10 +3662,6 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Потребно је потврђивање идентитета за укључивање или искључивање удаљеног "
 "пријављивања"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Произвољно"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6850,11 +3694,6 @@ msgstr "Иза"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Испред"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Испробавам ставку %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6908,11 +3747,6 @@ msgstr "Јачина звука"
 msgid "Alert Sound"
 msgstr "Звук упозорења"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Утишај"
@@ -6925,7 +3759,6 @@ msgstr "Звук"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Измените нивое звука, улазе, излазе и звуке упозорења"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6934,76 +3767,6 @@ msgstr ""
 "картица;микрофон;јачина звука;ишчезавање;баланс;равнотежа;блутут;слушалице;"
 "звук;излаз;улаз;kartica;mikrofon;jačina zvuka;iščezavanje;balans;ravnoteža;"
 "blutut;slušalice;zvuk;izlaz;ulaz;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Неповезан"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Повезујем"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Повезан"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Грешка у овлашћивању"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Овлашћујем"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Смањена употребљивост"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Повезани и овлашћени"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Непознато"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Овлашћен у:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Повезан у:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Уписан у:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Нисам успео да овластим уређај: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Нисам успео да заборавим уређај: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7039,55 +3802,6 @@ msgstr "Овласти и повежи"
 msgid "Forget Device"
 msgstr "Заборави уређај"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Грeшкa"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Овлашћен"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Тандерболт подсистем (boltd) није инсталиран или није подешен исправно."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Дозволи директни приступ уређајима као што су докови или спољне графичке."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Могу се качити само УСБ и Дисплеј порт уређаји."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Нема уоченог Тандерболт хардвера.\n"
-"Или систем нема подршку за Тандерболт, или је онемогућен у БИОС-у, или је "
-"постављен на неподржани ниво безбедности у БИОС-у."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Подршка за Тандерболт је искључена у БИОС-у."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Безбедносни ниво Тандерболта се не може утврдити."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Грешка при промени директног режима: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Без подршке за Тандерболт"
@@ -7099,6 +3813,11 @@ msgstr "Не могу да се повежем на тандерболт под�
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Директни приступ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Дозволи директни приступ уређајима као што су докови или спољне графичке."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7116,7 +3835,6 @@ msgstr "Тандерболт"
 msgid "Manage Thunderbolt devices"
 msgstr "Управљај Тандерболт уређајима"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;Тандерболт;Тхундерболт;Tanderbolt;приватност;privatnost;"
@@ -7318,42 +4036,6 @@ msgstr "_Укључи тастатуром"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Укључите/искључите функције приступачности користећи тастатуру"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Основно"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Средњи"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Велики"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Већи"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Највећи"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d пиксел"
-msgstr[1] "%d пиксела"
-msgstr[2] "%d пиксела"
-msgstr[3] "један пиксел"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Увек прикажи изборник приступачности"
@@ -7468,31 +4150,6 @@ msgstr "Бљесни целим _екраном"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Бљесни целим п_розором"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Кратко"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "1/4 екрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "1/2 екрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "3/4 екрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Велико"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7649,7 +4306,6 @@ msgstr "Дејства боје"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Олакшајте посматрање, слушање, куцање, указивање и кликање"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7667,114 +4323,6 @@ msgstr ""
 "slova;veličina;Iks_pristup;lepljivi;tasteri;spori;odskočni;miš;dvostruki;"
 "klik;zastoj;ponovi;trepni;vizuelno;univerzalni pristup;sluh;audio;zvuk;"
 "kucanje;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 сат"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 дан"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 дана"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 дана"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 дана"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 дана"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 дана"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 дана"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 дана"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 дана"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Да избацим све ставке из смећа?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Све ставке из смећа ће бити трајно уклоњене."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Избаци Смеће"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Да обришем све привремене датотеке?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Све привремене датотеке ће бити трајно обрисане."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Прочисти привремене датотеке"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 дан"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 дана"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 дана"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Заувек"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7842,7 +4390,6 @@ msgstr "Историјат датотека и смеће"
 msgid "Don't leave traces"
 msgstr "Не остављај трагове"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
@@ -7851,57 +4398,6 @@ msgstr ""
 "коришћење;недавно;историјат;датотеке;привремено;тмп;приватност;смеће;чишћење;"
 "задржавање;korišćenje;nedavno;istorijat;datoteke;privremeno;privatnost;smeće;"
 "čišćenje;zadržavanje;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Треба да подудари веб адресу вашег достављача пријављивања."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Нисам успео да додам налог"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Лозинке се не подударају."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Нисам успео да упишем налог"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Нема подржаног начина за потврђивање идентитета са овим доменом"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Нисам успео да приступим домену"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Неисправно име за пријављивање.\n"
-"Покушајте поново."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Неисправна лозинка за пријављивање.\n"
-"Покушајте поново."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Нисам успео да се пријавим на домен"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Не могу да пронађем домен. Можда сте га погрешно написали?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7954,10 +4450,6 @@ msgstr ""
 "Пословно пријављивање омогућава постојећем централно управљаном корисничком "
 "налогу да се користи на овом уређају. Такође можете да користите овај налог "
 "да приступите ресурсима предузећа на интернету."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Потражите још слика"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8028,222 +4520,6 @@ msgstr "_Обриши отиске прста"
 msgid "Fingerprint Enroll"
 msgstr "Уписивање отиска прста"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "треба бити затражено од уређаја да обави ову радњу"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "уређај је већ затражен другим процесом"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "немате овлашћење да обавите ову радњу"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "никакви исписи нису уписани"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Нисам успео да комуницирам са урђајем за време уписа"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Нисам успео да комуницирам са читачем отисака"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Нисам успео да комуницирам са демоном отисака"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Неуспех при листању отисака прстију: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Неуспех при брисању сачуваних отисака прстију: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Леви палац"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Средњи, леви прст"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Леви кажипрст"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Домали, леви прст"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Мали, леви прст"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Десни палац"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Десни, средњи прст"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Десни кажипрст"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Десни, домали прсти"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Десни, мали прст"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Непознат прст"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Завршено"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Читач отиска прста није прикључен"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Складиште на читачу отиска прста је пуно"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Неуспех при упису новог отиска прста"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Неуспех при покретању уписа: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Нисам успео да додам нови отисак прста"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Неуспех при заустављању уписа: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Непрестано подижите и спуштајте ваш прст на читач да бисте уписали ваш "
-"отисак прста"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Поно_во упиши овај прст…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Скенирај нови отисак прста"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Нисам успео да отпустим читач отиска прста %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Проблем приликом читања уређаја"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Нисам успео да затражим читач отиска прста %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Нисам успео да добавим читаче отиска прста: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Ове седмице"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Прошле седмице"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Крај сесије"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Почетак сесије"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Активност налога"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Претходно"
@@ -8251,18 +4527,6 @@ msgstr "Претходно"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Следеће"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Изаберите другу лозинку."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Унесите вашу тренутну лозинку поново."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Лозинка не може бити промењена"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8284,6 +4548,10 @@ msgstr "Нова лозинка"
 msgid "Confirm Password"
 msgstr "Потврди лозинку"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Лозинке се не подударају."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Дозволи кориснику да измени лозинку приликом следећег пријављивања"
@@ -8291,135 +4559,6 @@ msgstr "Дозволи кориснику да измени лозинку пр�
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Постави лозинку сада"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Не могу сам да приступим овој врсти домена"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Није пронађен такав домен или подручје"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Не могу да се пријавим као „%s“ на домену %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Неисправна лозинка, покушајте поново"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Не могу да се повежем на домен „%s“: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Нисам успео да избришем корисника"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Нисам успео да опозовем даљински управљаног корисника"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Не можете обрисати ваш лични налог."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "„%s“ је и даље пријављен"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Брисање корисника док су пријављени може да остави систем у неусклађеном "
-"стању."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Да ли желите да сачувате датотеке корисника „%s“?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Могуће је задржати личну фасциклу, складишта поште и привремене датотеке "
-"приликом брисања корисничког налога."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Обриши датотеке"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Задржи датотеке"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Да ли сигурно желите да опозовете даљински управљани налог корисника „%s“?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Обриши"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Налог је искључен"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "За подешавање приликом наредног пријављивања"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ништа"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Пријављен сам"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Нисам успео да контактирам услугу налога"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Молим проверите да ли је Услуга налога инсталирана и укључена."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Ова површ мора бити откључана пре промене овог подешавања"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Обришите изабрани кориснички налог"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Да обришете изабрани кориснички налог,\n"
-"кликните прво на иконицу *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Откључај за додавање корисника и промену поставки"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8447,7 +4586,6 @@ msgid "Full name"
 msgstr "Име и презиме"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Уреди"
 
@@ -8509,7 +4647,6 @@ msgstr "Откључајте да бисте додали кориснички �
 msgid "Add or remove users and change your password"
 msgstr "Додајте или уклоните кориснике и измените вашу лозинку"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8555,177 +4692,6 @@ msgstr "Управљајте корисничким налозима"
 msgid "Authentication is required to change user data"
 msgstr "Потребно је потврђивање идентитета за промену корисничких података"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Нова лозинка треба да се разликује од старе."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Пробајте да измените нека слова и бројеве."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Пробајте још само мало да измените лозинку."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Лозинка без вашег корисничког имена ће бити јача."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Покушајте да избегнете ваше име у лозинки."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Покушајте да избегнете неке од речи употребљених у лозинки."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Покушајте да избегнете уобичајене речи."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Покушајте да избегнете преуређивање постојећих речи."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Покушајте да користите више бројева."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Покушајте да користите више великих слова."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Покушајте да користите више малих слова."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Покушајте да користите више посебних знакова, као тачка."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Покушајте да користите мешавину слова, бројева и тачака."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Покушајте да избегнете понављање истог знака."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Покушајте да избегнете понављање исте врсте знака: треба да мешате велика "
-"слова, бројеве и тачке."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Покушајте да избегнете низове 1234 или абвг."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Лозинка мора бити дужа. Покушајте да користите мешавину слова, бројева и "
-"тачака."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Мешајте велика и мала слова и пробајте да користите један или два броја."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Додавање још слова, бројева и тачке ће учинити лозинку још јачом."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Потврђивање идентитета није успело"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Нова лозинка је превише кратка"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Нова лозинка је превише једноставна"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Стара и нова лозинка су сувише сличне"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Нова лозинка је већ употребљавана у скорије време."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Нова лозинка мора да садржи нумеричке или специјалне знакове"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Стара и нова лозинка су исте"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Ваша лозинка је измењена од када сте на почетку потврдили идентитет!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Нова лозинка не садржи довољно различитих знакова"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Непозната грешка"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Корисничко име треба да садржи само велика и мала слова латинског алфабета "
-"од а-z, цифре и следеће знакове: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Корисничко име није доступно. Пробајте неко друго."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Корисничко име је предуго."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8760,52 +4726,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Откривен је лош клик, почињем из почетка…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Дугме %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Програм је дефинисан"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Пошаљи откуцај тастера"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Промени монитор"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Прикажи помоћ на екрану"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Таблица закачена на лаптоп"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Таблица закачена на спољни екран"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Спољна таблица"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Спољни пад уређај"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Сви екрани"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8901,22 +4825,6 @@ msgstr "Клик десног дугмета миша"
 msgid "Forward"
 msgstr "Напред"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Ербраш оловка са притиском, нагибом и уграђеним клизачем"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Ербраш оловка са притиском, нагибом и окретањем"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Стандарнда оловка са притиском и нагибом"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Стандардна оловка са притиском"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Ваком таблица"
@@ -8925,54 +4833,96 @@ msgstr "Ваком таблица"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Подеси мапирање дугмета и подесите осетљивост оловке графичких таблица"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;таблица;ваком;пенкало;брисач;миш;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Нова пречица…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Симулирани секундарни клик"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Виндоуз програми"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Понестаје тонера"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Споредни"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Виндоуз програми"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Управљајте поставкама продуктивности и упоредног рада"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Приступне тачке"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Додај"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Сачувај"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "АПН"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Радња је отказана"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Грешка:</b> Приступ забрањује промену подешавања"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Грешка:</b> Грешка мобилне опреме"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Нерегистрован"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Регистрован"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Роминг"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Претражујем"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Забрањено"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9002,212 +4952,13 @@ msgstr "Сопствени број"
 msgid "Device Details"
 msgstr "Појединости уређаја"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Произвођач"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Издање фирмвера"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Само 2Г"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Само 3Г"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Само 4Г"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Само 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2Г, 3Г, 4Г, 5Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2Г, 3Г, 4Г (пожељно), 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2Г, 3Г (пожељно), 4Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2Г (пожељно), 3Г, 4Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2Г, 3Г, 4Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2Г, 3Г, 4Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2Г, 3Г (пожељно), 4Г"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2Г (пожељно), 3Г, 4Г"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2Г, 3Г, 4Г"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3Г, 4Г, 5Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3Г, 4Г (пожељно), 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3Г (пожељно), 4Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3Г, 4Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2Г, 4Г, 5Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2Г, 4Г (пожељно), 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2Г (пожељно), 4Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2Г, 4Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2Г, 3Г, 5Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2Г, 3Г (пожељно), 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2Г (пожељно), 3Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2Г, 3Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3Г, 4Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3Г (пожељно), 4Г"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3Г, 4Г"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2Г, 4Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2Г (пожељно), 4Г"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2Г, 4Г"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2Г, 3Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2Г (пожељно), 3Г"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2Г, 3Г"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2Г, 5Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2Г (пожељно), 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3Г, 5Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3Г (пожељно), 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4Г, 5Г (пожељно)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4Г (пожељно), 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4Г, 5Г"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Непознато"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Откључај СИМ картицу"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Откључај"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Доставите ПИН код за СИМ %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Упишите ПИН да откључате вашу СИМ картицу"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Доставите ПУК код за СИМ %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Упишите ПУК да откључате вашу СИМ картицу"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9226,26 +4977,6 @@ msgstr[0] "Остао вам је %u покушај"
 msgstr[1] "Остала су вам %u покушаја"
 msgstr[2] "Остало вам је %u покушаја"
 msgstr[3] "Остао вам је један покушај"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Уписали сте погрешну лозинку."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "ПУК код треба бити број од 8 цифара"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Упишите нови ПИН"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "ПИН код треба бити број од 4-8 цифара"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Откључавам…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9303,94 +5034,6 @@ msgstr "Закључајте СИМ ПИН-ом"
 msgid "M_odem Details"
 msgstr "П_ојединости модема"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Неуспех у телефону"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Нема везе са телефоном"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Радња није допуштена"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Радња није подржана"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "СИМ није убачен"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Потребан је СИМ ПИН"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Потребан је СИМ ПУК"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Неуспех СИМ-а"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "СИМ је заузета"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Нетачна лозинка"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Потребан је СИМ ПИН2"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Потребан је СИМ ПУК2"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Није пронађено"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Нема мрежне услуге"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Мрежа је истекла"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "ГПРС услуге нису дозвољене"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Ромин није дозвољен у овој области"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Неодређена ГПРС грешка"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Нема грешака"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Радња је отказана"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Приступ одбијен"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Непозната грешка"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Мрежни режим"
@@ -9406,11 +5049,6 @@ msgstr "Изабери мрежу"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Освежите достављаче мреже"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "СИМ %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9468,7 +5106,6 @@ msgstr "Мобилна мрежа"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Подесите везе мобилних података и телефоније"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "целулар;телефонија;сим;мобилна;cellular;wwan;telephony;sim;mobile;"
@@ -9485,41 +5122,13 @@ msgstr "Подешавања су главно средство за подеш�
 msgid "The GNOME Project"
 msgstr "Гном пројекат"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Број издања приказа"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Укључује режим исписивања"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Тражи ниску"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Исписује могуће називе површи и излази"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Површ за приказ"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[ПОВРШ] [АРГУМЕНТ…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Категорије подешавања"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Приватност"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Доступне површи:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9577,7 +5186,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Откажи претрагу"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;Settings;поставке;подешавања;"
@@ -9617,8 +5225,6 @@ msgstr ""
 "Торка која садржи почетну висину и ширину прозора програма и стање "
 "увећаности."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9628,8 +5234,6 @@ msgstr[1] "%u излаза"
 msgstr[2] "%u излаза"
 msgstr[3] "Један излаз"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9639,15 +5243,3153 @@ msgstr[1] "%u улаза"
 msgstr[2] "%u улаза"
 msgstr[3] "Један улаз"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Системски звуци"
+#~ msgid "System Bus"
+#~ msgstr "Системска сабирница"
+
+#~ msgid "Full access"
+#~ msgstr "Пун приступ"
+
+#~ msgid "Session Bus"
+#~ msgstr "Сабирница сесије"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Пун приступ фасцикли /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Има приступ мрежи"
+
+#~ msgid "Home"
+#~ msgstr "Личнo"
+
+#~ msgid "Read-only"
+#~ msgstr "Само за читање"
+
+#~ msgid "File System"
+#~ msgstr "Систем датотека"
+
+#~ msgid "Can change settings"
+#~ msgstr "Може променити подешавања"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "Програм „%s“ садржи следећа уграђена овлашћења. Она не могу бити "
+#~ "промењена. Уколико сте забринути због ових овлашћења, размислите о "
+#~ "уклањању овог програма."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u датотека и врста везе које отвара програм"
+#~ msgstr[1] "%u датотеке и врсте везе које отвара програм"
+#~ msgstr[2] "%u датотека и врста везе које отвара програм"
+#~ msgstr[3] "Једна датотека и врста везе коју отвара програм"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> се користи за отварање следећих врста датотека и веза."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s простора на диску заузето."
+
+#~ msgid "Select a picture"
+#~ msgstr "Изаберите слику"
+
+#~ msgid "_Open"
+#~ msgstr "_Отвори"
+
+#~ msgid "multiple sizes"
+#~ msgstr "више величина"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Нема позадине за радну површ"
+
+#~ msgid "Current background"
+#~ msgstr "Тренутна позадина"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Поставите уређај за калибрацију преко квадрата и притисните „Почни“"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Померите уређај за калибрацију на положај калибрације и притисните "
+#~ "„Настави“"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Померите уређај за калибрацију на положај површине и притисните „Настави“"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Заклопите преносни рачунар"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Дошло је до унутрашње грешке која не може бити опорављена."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Алати потребни за калибрацију нису инсталирани."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Профил не може бити направљен."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Бела тачка мете се не може добавити."
+
+#~ msgid "Complete!"
+#~ msgstr "Завршено!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Калибрација није успела!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Можете да уклоните уређај за калибрацију."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Не ометајте уређај за калибрацију док је у раду"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Екран преносног рачунара"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Уграђена веб камерица"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s монитор"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s скенер"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s фотоапарат"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s штампач"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s веб камерица"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Укључи управљање бојом за „%s“"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Прикажи профиле боја за „%s“"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Није калибрисано"
+
+#~ msgid "Default: "
+#~ msgstr "Основно: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Простор боја: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Пробни профил: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Изабери датотеку ИЦЦ профила"
+
+#~ msgid "_Import"
+#~ msgstr "_Увези"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Подржани ИЦЦ профили"
+
+#~ msgid "All files"
+#~ msgstr "Све датотеке"
+
+#~ msgid "Save Profile"
+#~ msgstr "Сачувај профил"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Направите профил боје за изабрани уређај"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Није откривен инструмент за мерење. Проверите да ли је укључен и да ли је "
+#~ "исправно прикључен."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Инструмент за мерење не подржава профилисање штампача."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Тип уређаја тренутно није подржан."
+
+#~ msgid "Standard Space"
+#~ msgstr "Уобичајени простор"
+
+#~ msgid "Test Profile"
+#~ msgstr "Испробај профил"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Самостални"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Низак квалитет"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Осредњи квалитет"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Висок квалитет"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Основна РГБ"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Основна ЦМУК"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Основна сива"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Продавац је доставио податке фабричке калибрације"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Исправка приказа преко целог екрана није могућа са овим профилом"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Овај профил више не може бити тачан"
+
+#~ msgid "Other…"
+#~ msgstr "Други…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Откључај за промену подешавања"
+
+#~ msgid "Today"
+#~ msgstr "Данас"
+
+#~ msgid "Yesterday"
+#~ msgstr "Јуче"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y."
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d сат"
+#~ msgstr[1] "%d сата"
+#~ msgstr[2] "%d сати"
+#~ msgstr[3] "Један сат"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d минут"
+#~ msgstr[1] "%d минута"
+#~ msgstr[2] "%d минута"
+#~ msgstr[3] "Један минут"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d секунда"
+#~ msgstr[1] "%d секунде"
+#~ msgstr[2] "%d секунди"
+#~ msgstr[3] "Једна секунда"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Врућа тачка"
+
+#~ msgid "24-hour"
+#~ msgstr "24-часовно"
+
+#~ msgid "AM / PM"
+#~ msgstr "ПрП/ПоП"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%A, %e.%m.%Y. %l:%M %P"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e. %B %Y. %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "КУВ%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %P"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Слање извештаја о техничким проблемима нам помаже да побољшамо "
+#~ "дистрибуцију „%s“. Извештаји се шаљу безимено и очишћени су од личних "
+#~ "података. %s"
+
+#~ msgid "On"
+#~ msgstr "Укљ."
+
+#~ msgid "Off"
+#~ msgstr "Искљ."
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Да применим измене?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Не могу да применим измене"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Ово је можда због ограничења хардвера."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Положено"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Усправно десно"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Усправно лево"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Положено (изврнуто)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Безбедно подизање је покренуто"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Безбедно подизање спречава учитавање злонамерног софтвера за време "
+#~ "покретања уређаја. Тренутно је укључено и ради без грешке."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Безбедно подизање има проблема"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Безбедно подизање спречава учитавање злонамерног софтвера за време "
+#~ "покретања уређаја. Тренутно је укључено, али неће радити зато што има "
+#~ "један неисправан кључ."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Проблеми безбедног подизања могу се често решити из поставки уграђеног "
+#~ "програма УЕФИ-а вашег рачунара (БИОС) а произвођач вашег хардвера може да "
+#~ "обезбеди информације како то да урадите."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "За помоћ, обратите се произвођачу вашег хардвера или достављачу ИТ "
+#~ "подршке."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Безбедно подизање је искључено"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Безбедно подизање спречава учитавање злонамерног софтвера за време "
+#~ "покретања уређаја. Тренутно је искључено."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Безбедно подизање се може често укључити из поставки уграђеног програма "
+#~ "УЕФИ-а вашег рачунара (БИОС). За помоћ, обратите се произвођачу вашег "
+#~ "хардвера или достављачу ИТ подршке."
+
+#~ msgid "Passed"
+#~ msgstr "Успешно"
+
+#~ msgid "Failed"
+#~ msgstr "Неуспешно"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Уређај је у складу са „HSI“ ниво %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Безбедносни ниво 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Овај уређај нема заштиту од проблема безбедности хардвера. Ово може бити "
+#~ "услед хардверских или проблема подешавања уграђеног програма. Препоручује "
+#~ "вам се да се обратите вашем достављачу ИТ подршке."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Безбедносни ниво 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Овај уређај има најмању заштиту од проблема безбедности хардвера. Ово је "
+#~ "најнижи ниво безбедности уређаја и обезбеђује заштиту само од "
+#~ "једноставних безбедносних претњи."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Безбедносни ниво 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Овај уређај има основну заштиту од проблема безбедности хардвера. Ово "
+#~ "обезбеђује заштиту од неких општих безбедносних претњи."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Безбедносни ниво 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Овај уређај има прођирену заштиту од проблема безбедности хардвера. Ово "
+#~ "је највиши ниво безбедности уређаја и обезбеђује заштиту од напредних "
+#~ "безбедносних претњи."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Нивои безбедности нису доступни за овај уређај."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Обратите се вашем произвођачу хардвера за помоћ са безбедносним "
+#~ "освежењима."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Може бити могуће решити овај проблем у поставкама уграђеног програма УЕФИ-"
+#~ "а уређаја, или са техничарем подршке."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Може бити могуће решити овај проблем у поставкама уграђеног програма УЕФИ-"
+#~ "а уређаја."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Може бити могуће да техничар подршке реши овај проблем (ако је добре "
+#~ "воље)."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Заштићени сте од злонамерног софтвера приликом покретања уређаја."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Безбедно подизање има проблема"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Имате некакву заштиту приликом покретања уређаја."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Безбедно подизање је искључено"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Немате никакву заштиту приликом покретања уређаја."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Овај проблем је можда изазван изменом у поставкама уграђеног програма "
+#~ "УЕФИ-а, изменом у подешавањима оперативног система или услед злонамерног "
+#~ "софтвера на овом систему."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Овај проблем је можда изазван изменом у поставкама уграђеног програма "
+#~ "УЕФИ-а, или услед злонамерног софтвера на овом систему."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Овај проблем је можда изазван изменом у подешавањима оперативног система "
+#~ "или услед злонамерног софтвера на овом систему."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Изложен озбиљним безбедносним претњама."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Ограничена заштита од једноставних безбедносних претњи."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Заштићен од уобичајених безбедносних претњи."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Заштићен од великог опсега безбедносних претњи."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Разумљива заштита"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Заштита уписа фирмвера"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Катанац заштите уписа фирмвера"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Област БИОС фирмвера"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Описник БИОС фирмвера"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Предподизна ДМА заштита"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard проверено подизање"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM заштита"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard политика грешке"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard стопљено"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET је укључено"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET је активно"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Шифровани РАМ"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "ИОММУ заштита"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Закључавање Линукс кернела"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Потврђивање Линукс кернела"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Линуксова разменска"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Обустава у РАМ"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Обустава у мировање"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Платформски УЕФИ кључ"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "УЕФИ безбедно подизање"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Подешавање ТПМ платформе"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "ТПМ реконструкција"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "ТПМ издања 2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine режим производње"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine пресклопка"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine издање"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Ажурирања фирмвера"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Атест фирмвера"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Потврђивање ажурирања фирмвера"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Платформско поправљање грешака"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Безбедносне провере процесора"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "АМД резервна заштита"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Риплеј заштита АМД фирмвера"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Заштита уписа АМД фирмвера"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Притопљена платформа"
+
+#~ msgid "Valid"
+#~ msgstr "Исправно"
+
+#~ msgid "Not Valid"
+#~ msgstr "Није исправно"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Није омогућено"
+
+#~ msgid "Locked"
+#~ msgstr "Закључано"
+
+#~ msgid "Not Locked"
+#~ msgstr "Откључано"
+
+#~ msgid "Encrypted"
+#~ msgstr "Шифровано"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Нешифровано"
+
+#~ msgid "Tainted"
+#~ msgstr "Укаљано"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Неукаљано"
+
+#~ msgid "Found"
+#~ msgstr "Уочено"
+
+#~ msgid "Not Found"
+#~ msgstr "Неуочено"
+
+#~ msgid "Supported"
+#~ msgstr "Подржано"
+
+#~ msgid "Not Supported"
+#~ msgstr "Неподржано"
+
+#~ msgid "Unknown"
+#~ msgstr "Непознато"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-бита"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-бита"
+
+#~ msgid "X11"
+#~ msgstr "Икс-11"
+
+#~ msgid "Wayland"
+#~ msgstr "Вејленд"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Непознато"
+
+#~ msgid "Not Available"
+#~ msgstr "Није доступно"
+
+#~ msgid "System Logo"
+#~ msgstr "Лого система"
+
+#~ msgid "No input sources found"
+#~ msgstr "Нисам пронашао изворе улаза"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Друго"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Произвољне пречице"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Тастер заменских карактера се може користити за унос додатних знакова. "
+#~ "Некада су одштампани као трећа могућност на вашој тастатури."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Леви алт"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Десни алт"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Леви супер"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Десни супер"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Тастер изборника"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Десни Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Саставни тастер омогућава унос широког спектра знаков. Да га користите, "
+#~ "притисните саставни тастер затим низ знакова.  На пример, саставни тастер "
+#~ "за којим следи <b>C</b> и <b>o</b> уписаће <b>©</b>, <b>a</b> за којим "
+#~ "следи <b>'</b> уписаће <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Закључавање слова"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Закључавање померања"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Штампај екран"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Извор уноса се може променити преко %s пречице на тастатури.\n"
+#~ "Пречица се може променити у подешавањима пречица тастатуре."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d ставка је измењена"
+#~ msgstr[1] "%d ставки је измењено"
+#~ msgstr[2] "%d ставки је измењено"
+#~ msgstr[3] "Једна ставка је измењена"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Да вратим све пречице?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Поновно враћање пречица може утицати на ваше произвољне пречице. Ово се "
+#~ "не може опозвати."
+
+#~ msgid "Reset All"
+#~ msgstr "Врати све"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "„%s“ се већ користи за пречицу „%s“. Ако замените, пречица „%s“ биће "
+#~ "онемогућена"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Унесите нову пречицу"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Постави произвољну пречицу"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Постави пречицу"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Унесите нову пречицу за „%s“."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Додајте произвољну пречицу"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Премицање са два прста"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Пет клика, ГЕГЛ време!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Двоструки клик, главно дугме"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Један клик, главно дугме"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Двоструки клик, средње дугме"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Један клик, средње дугме"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Двоструки клик, помоћно дугме"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Један клик, помоћно дугме"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Управљач мрежом треба бити покренут."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (Назив мреже: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Небезбедна мрежа (ВЕП)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Безбедна мрежа (ВПА2)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Безбедна мрежа (ВПА2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Безбедна мрежа (ВПА3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Безбедна мрежа"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Укључивање вруће тачке ће вас откачити са мреже %s и неће бити могућ "
+#~ "приступ интернету преко бежичне картице."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Мора садржати најмање осам знакова"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Да зауставим врућу тачку и да искључим све кориснике?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Заустави врућу тачку"
+
+#~ msgid "Preserve"
+#~ msgstr "Задржи"
+
+#~ msgid "Permanent"
+#~ msgstr "Трајно"
+
+#~ msgid "Random"
+#~ msgstr "Насумично"
+
+#~ msgid "Stable"
+#~ msgstr "Стабилно"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "МАК адреса коју унесете овде биће коришћена као хардверска адреса мрежног "
+#~ "уређаја на којем се покрене ова веза. Ова могућност је познатија као "
+#~ "клонирање или лажирање МАК адресе. На пример: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Профил „%d“"
+
+#~ msgid "WEP"
+#~ msgstr "ВЕП"
+
+#~ msgid "WPA"
+#~ msgstr "ВПА"
+
+#~ msgid "WPA3"
+#~ msgstr "ВПА3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Побољшано отварање"
+
+#~ msgid "WPA2"
+#~ msgstr "ВПА2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Ентерпрајз"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ништа"
+
+#~ msgid "Never"
+#~ msgstr "Никад"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Нема сигнала"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Слаб сигнал"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Добар сигнал"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Одличан сигнал"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Изврстан сигнал"
+
+#~ msgid "DNS4"
+#~ msgstr "ДНС4"
+
+#~ msgid "DNS6"
+#~ msgstr "ДНС6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Заборави везу"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Уклони профил везе"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Уклони ВПН"
+
+#~ msgid "Details"
+#~ msgstr "Појединости"
+
+#~ msgid "automatic"
+#~ msgstr "самостално"
+
+#~ msgid "Identity"
+#~ msgstr "Идентитет"
+
+#~ msgid "Delete Address"
+#~ msgstr "Обриши адресу"
+
+#~ msgid "Delete Route"
+#~ msgstr "Обриши руту"
+
+#~ msgid "IPv4"
+#~ msgstr "ИПв4"
+
+#~ msgid "IPv6"
+#~ msgstr "ИПв6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ништа"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "ВЕП 40/128-битни кључ (Хекса или АСКРИ)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "ВЕП 128-битна лозинка"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Динамички ВЕП (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "Лични ВПА & ВПА2"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Пословни ВПА & ВПА2"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "ВПА3 лично"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Не могу да отворим уређивача везе"
+
+#~ msgid "New Profile"
+#~ msgstr "Нови профил"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Неисправно подешавање %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Неисправно подешавање %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Увези из датотеке…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Додај ВПН"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Не могу да увезем ВПН везу"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Не могу да прочитам датотеку „%s“ или она не садржи познате ВПН податке о "
+#~ "вези\n"
+#~ "\n"
+#~ "Грешка: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Изаберите датотеку за увоз"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Датотека под називом „%s“ већ постоји."
+
+#~ msgid "_Replace"
+#~ msgstr "_Замени"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Да ли желите да замените „%s“ ВПН везом коју сада чувате?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Не могу да извезем ВПН везу"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Не могу да извезем ВПН везу „%s“ у %s.\n"
+#~ "\n"
+#~ "Грешка: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Извези ВПН везу"
+
+#~ msgid "never"
+#~ msgstr "никад"
+
+#~ msgid "today"
+#~ msgstr "данас"
+
+#~ msgid "yesterday"
+#~ msgstr "јуче"
+
+#~ msgid "Last used"
+#~ msgstr "Коришћена"
+
+#~ msgid "Add new connection"
+#~ msgstr "Додајте нову везу"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Детаљи мреже за изабране мреже, укључујући лозинку и сва произвољна "
+#~ "подешавања ће бити изгубљени."
+
+#~ msgid "_Forget"
+#~ msgstr "_Заборави"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Познате бежичне мреже"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Заборави"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Политика система забрањује употребу као вруће тачке"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Бежични уређај не подржава режим вруће тачке"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Аутоматско налажење веб посредника се користи када није дата адреса за "
+#~ "подешавање."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Ово није препоручљиво за небезбедне, јавне мреже."
+
+#~ msgid "Status unknown"
+#~ msgstr "Непознато стање"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Неуправљан"
+
+#~ msgid "Unavailable"
+#~ msgstr "Недоступно"
+
+#~ msgid "Connecting"
+#~ msgstr "Повезујем се"
+
+#~ msgid "Authentication required"
+#~ msgstr "Потребно је потврђивање идентитета"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Искључујем"
+
+#~ msgid "Connection failed"
+#~ msgstr "Повезивање није успело"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Стање је непознато (недостаје)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Није успело подешавање"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Није успело подешавање ИП-а"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Истекло је подешавање ИП-а"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Затражене су тајне, али нису достављене"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Прекинута је веза са 802.1x молиоцем"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Није успело подешавање 802.1x молиоца"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x молилац није успео"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Потврђивање идентитета 802.1x молиоца је трајало предуго"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "ППП услуга није успела да се покрене"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "ППП услуга је искључена"
+
+#~ msgid "PPP failed"
+#~ msgstr "ППП није успело"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "ДХЦП клијент није успео да е покрене"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Грешка ДХЦП клијента"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "ДХЦП клијент није успео"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Услуга дељене везе није успела да се покрене"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Услуга дељене везе није успела"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Услуга самосталног ИП-а није успела да се покрене"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Грешка услуге самосталног ИП-а"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Услуга самосталног ИП-а није успела"
+
+#~ msgid "Line busy"
+#~ msgstr "Линија је заузета"
+
+#~ msgid "No dial tone"
+#~ msgstr "Нема тона позивања"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Ниједан оператер не може бити пронађен"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Истекло је време захтева позивања"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Покушај позивања није успео"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Није успело покретање модема"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Нисам успео да изаберем наведени НТП"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Не тражим мреже"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Завођење мреже је одбијено"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Истекло је време за завођење мреже"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Нисам успео да заведем са захтеваном мрежом"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Провера ПИН-а није успела"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Можда недостаје фирмвер за уређај"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Веза је нестала"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Постојећа веза биће присвојена"
+
+#~ msgid "Modem not found"
+#~ msgstr "Није пронађен модем"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Веза блутута није успела"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "СИМ картица није убачена"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Потребан је СИМ ПИН"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Потребан је СИМ ПУК"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Погрешна СИМ"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Није успела зависност везе"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Недостаје фирмвер"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Кабал је искључен"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "неодређена грешка у 802.1X безбедности (впа-еап)"
+
+#~ msgid "no file selected"
+#~ msgstr "није изабрана датотека"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "неодређена грешка потврђивања датотеке еап-метода"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "ДЕР, ПЕМ, ПКЦС#12, или ПГП приватни кључеви"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "ДЕР или ПЕМ уверења"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "недостаје датотека ЕАП-ФАСТ ПАЦ"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "ПАЦ датотеке (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "недостаје ЕАП-ЛЕАП корисничко име"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "недостаје ЕАП-ЛЕАП лозинка"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "неисправно ЕАП-ПЕАП уверење издавача уверења: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "неисправно ЕАП-ПЕАП уверење издавача уверења: није наведено никакво "
+#~ "уверење"
+
+#~ msgid "missing EAP username"
+#~ msgstr "недостаје ЕАП корисничко име"
+
+#~ msgid "missing EAP password"
+#~ msgstr "недостаје ЕАП лозинка"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "недостаје ЕАП-ТЛС идентитет"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "неисправно ЕАП-ТЛС уверење издавача уверења: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "неисправно ЕАП-ТЛС уверење издавача уверења: није наведено никакво уверење"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "неисправан ЕАП-ТЛС приватни кључ: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "неисправно ЕАП-ТЛС уверење корисника: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Нешифровани приватни кључеви нису сигурни"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Изгледа да изабрани приватни кључ није заштићен лозинком. Ово може "
+#~ "угрозити ваше сигурносне податке. Изаберите приватни кључ који зе "
+#~ "заштићен лозинком.\n"
+#~ "\n"
+#~ "(Можете заштитити приватне кључеве користећи „openssl“)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Изаберите ваше лично уверење"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Изаберите лични кључ"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "неисправно ЕАП-ТТЛС уверење издавача уверења: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "неисправно ЕАП-ТТЛС уверење издавача уверења: није наведено никакво "
+#~ "уверење"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Непозната грешка потврђивања 802.1X безбедности"
+
+#~ msgid "Select a file"
+#~ msgstr "Изаберите датотеку"
+
+#~ msgid "missing leap-username"
+#~ msgstr "недостаје леап корисничко име"
+
+#~ msgid "missing leap-password"
+#~ msgstr "недостаје леап лозинка"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Недостаје лозинка бежичне мреже."
+
+#~ msgid "missing wep-key"
+#~ msgstr "недостаје веп кључ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "неисправан веп кључ: кључ дужине %zu мора да садржи само хексадецималне "
+#~ "цифре"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "неисправан веп кључ: кључ дужине %zu мора да садржи само аскри знакове"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "неисправан веп кључ: погрешна дужина кључа %zu. Кључ мора бити дужине "
+#~ "5/13 (аскри) или 10/26 (хекса)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "неисправан веп кључ: пропусна реч не сме бити празна"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "неисправан веп кључ: пропусна реч мора бити краћа од 64 знакова"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "неисправан впа-пск: неисправна дужина кључа %zu. Мора бити [8,63] бајта "
+#~ "или 64 хексадецималних цифара"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "неисправан впа-пск: не могу да растумачим кључ са 64 бајта као "
+#~ "хексадецимални"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Друго"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "Корисник „%s“ је уклоњен"
+
+#~ msgid "Error removing account"
+#~ msgstr "Грешка у уклањању налога"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "„%s“ налог"
+
+#~ msgid "Remove Account"
+#~ msgstr "Уклони налог"
+
+#~ msgid "Unknown time"
+#~ msgstr "Непознато време"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%d %s %d %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s до потпуне напуњености"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Пажња: преостаје још %s рада"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Преостало време: %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Потпуно пуна"
+
+#~ msgid "Not charging"
+#~ msgstr "Не пуни се"
+
+#~ msgid "Empty"
+#~ msgstr "Празна"
+
+#~ msgid "Charging"
+#~ msgstr "Пуни се"
+
+#~ msgid "Discharging"
+#~ msgstr "Празни се"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Бежични миш"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Бежична тастатура"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Непрекидив извор напајања"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Лични дигитални помоћник"
+
+#~ msgid "Cellphone"
+#~ msgstr "Мобилни телефон"
+
+#~ msgid "Media player"
+#~ msgstr "Музички уређај"
+
+#~ msgid "Tablet"
+#~ msgstr "Таблица"
+
+#~ msgid "Computer"
+#~ msgstr "Рачунар"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Улазни уређај за игре"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Главна"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Додатна"
+
+#~ msgid "Batteries"
+#~ msgstr "Батерије"
+
+#~ msgid "When _idle"
+#~ msgstr "Када _мирује"
+
+#~ msgid "Suspend"
+#~ msgstr "Обустави"
+
+#~ msgid "Power Off"
+#~ msgstr "Искључи"
+
+#~ msgid "Hibernate"
+#~ msgstr "Замрзни"
+
+#~ msgid "Nothing"
+#~ msgstr "Ништа"
+
+#~ msgid "When on battery power"
+#~ msgstr "Када се напаја са батерије"
+
+#~ msgid "When plugged in"
+#~ msgstr "Када је укључен"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Никада"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Самостална обустава уређаја"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "Најбржи режим рада онемогућен због високе радне температуре."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Уочен рад на крилу: најбржи режим тренутно није доступан. Померите уређај "
+#~ "на неку стабилну површину за омогућавање најбржег рада."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Режим учинковитости је тренутно искључен."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Батерија је скоро празна: штедиша енергије је укључен. Претходни режим "
+#~ "биће враћен када се батерија довољно напуни."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Режим штедише напајања је укључио „%s“."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Режим учинковитости је покренуо „%s“."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Најбрже"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Велика брзина и коришћење напајања."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Уравнотеженост"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Уобичајена брзина и коришћење напајања."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Уштеда батерије"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Умањена брзина и коришћење напајања."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Штампач „%s“ је обрисан"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Нисам успео да додам нови штампач."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Не могу да учитам сучеље: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Откључај за додавање штампача и промену подешавања"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Појединости за „%s“"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Нису пронађени одговарајући управљачки програми"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Изаберите ППД датотеку"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Датотеке описа Пост скрипт штампача (*.ppd,*.PPD, *.ppd.gz, *PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Штампач са непосредним млазом"
+
+#~ msgid "LPD Printer"
+#~ msgstr "ЛПД штампач"
+
+#~ msgid "One Sided"
+#~ msgstr "Једнострано"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "По дужој страни (стандардно)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "По краћој страни (окренуто)"
+
+#~ msgid "Portrait"
+#~ msgstr "Усправно"
+
+#~ msgid "Landscape"
+#~ msgstr "Положено"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Обрнуто положено"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Обрнуто усправно"
+
+#~ msgid "Resume"
+#~ msgstr "Настави"
+
+#~ msgid "Pause"
+#~ msgstr "Заустави"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "На чекању"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Заустављен"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Потребно је потврђивање идентитета"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Обрађујем"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Заустављен"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Отказан"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Поништен"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Завршен"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Пребаци овај посао на почетак реда"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — покренути послови"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Унесите пуномоћства да бисте штампали са штампача „%s“."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Откључај сервер штампача"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Откључај „%s“."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Унесите корисничко име и лозинку да видите штампаче на „%s“."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Тражим штампаче"
+
+#~ msgid "USB"
+#~ msgstr "УСБ"
+
+#~ msgid "Serial Port"
+#~ msgstr "Серијски прикључник"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Паралелни прикључник"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Место: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Адреса: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Сервер захтева потврђивање идентитета"
+
+#~ msgid "Two Sided"
+#~ msgstr "Двострано"
+
+#~ msgid "Paper Type"
+#~ msgstr "Тип папира"
+
+#~ msgid "Paper Source"
+#~ msgstr "Извор папира"
+
+#~ msgid "Output Tray"
+#~ msgstr "Излазна трака"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Резолуција"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Гост скрипт предфилтер"
+
+#~ msgid "Pages per side"
+#~ msgstr "Страница по листу"
+
+#~ msgid "Orientation"
+#~ msgstr "Усмерење"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Опште"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Подешавање странице"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Инстаљиве опције"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Посао"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Квалитет слике"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Боја"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Завршавање"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Напредно"
+
+#~ msgid "Test page"
+#~ msgstr "Пробна страница"
+
+#~ msgid "Auto Select"
+#~ msgstr "Сам одреди"
+
+#~ msgid "Printer Default"
+#~ msgstr "Подразумевано"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Само угњеждени Гост скрипт фонтови"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Преведи у 1° ниво постскрипта"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Преведи у 2° ниво постскрипта"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Без предфилтрирања"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Очистите главе штампача"
+
+#~ msgid "Out of toner"
+#~ msgstr "Нема више тонера"
+
+#~ msgid "Low on developer"
+#~ msgstr "Понестаје развијача"
+
+#~ msgid "Out of developer"
+#~ msgstr "Нема више развијача"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Понестаје маркера"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Нема више мастила"
+
+#~ msgid "Open cover"
+#~ msgstr "Отворен поклопац"
+
+#~ msgid "Open door"
+#~ msgstr "Отворена вратанца"
+
+#~ msgid "Low on paper"
+#~ msgstr "Понестаје папира"
+
+#~ msgid "Out of paper"
+#~ msgstr "Нема више папира"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Искључен"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Заустављен"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Посуда за отпад је скоро пуна"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Посуда за отпад је пуна"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Оптички проводник фотографија је при крају живота"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Оптички проводник фотографија више не функционише"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Спреман"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Не прихвата послове"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Обрађује"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Империјални"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Метрички"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Питај шта да радиш"
+
+#~ msgid "Do nothing"
+#~ msgstr "Не ради ништа"
+
+#~ msgid "Open folder"
+#~ msgstr "Отвори фасциклу"
+
+#~ msgid "Other Media"
+#~ msgstr "Остали носачи података"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Изаберите програм за аудио дискове (ЦД)"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Изаберите програм за видео дискове (ДВД)"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Изаберите програм за покретање када је прикључен музички плејер"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Изаберите програм за покретање када је прикључена камера"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Изаберите програм за дискове са софтвером"
+
+#~ msgid "audio DVD"
+#~ msgstr "аудио ДВД"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "празан Блу-реј диск"
+
+#~ msgid "blank CD disc"
+#~ msgstr "празан ЦД диск"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "празан ДВД диск"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "празан ХД ДВД диск"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Блу-реј видео диск"
+
+#~ msgid "e-book reader"
+#~ msgstr "читач ел. књига"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "ХД ДВД видео диск"
+
+#~ msgid "Picture CD"
+#~ msgstr "ЦД са сликама"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Супер видео ЦД"
+
+#~ msgid "Video CD"
+#~ msgstr "Видео ЦД"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Екран се искључује"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 секунди"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 минут"
+
+# bug(danilo): plural-forms
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 минута"
+
+# bug(danilo): plural-forms
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 минута"
+
+# bug(danilo): plural-forms
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 минута"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 минута"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 сат"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 минут"
+
+# bug(danilo): plural-forms
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 минута"
+
+# bug(danilo): plural-forms
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 минута"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 минута"
+
+# bug(danilo): plural-forms
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 минута"
+
+# bug(danilo): plural-forms
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 минута"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 минута"
+
+# bug(danilo): plural-forms
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 минута"
+
+# bug(danilo): plural-forms
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 минута"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Никада"
+
+#~ msgid "Select Location"
+#~ msgstr "Изабери место"
+
+#~ msgid "_OK"
+#~ msgstr "У _реду"
+
+#~ msgid "No applications found"
+#~ msgstr "Нисам пронашао програме"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Нису изабране мреже за дељење"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Укљ."
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Искљ."
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Укључено"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Радна"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Изаберите фасциклу"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Омогући дељење медија"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Дељење датотека вам омогућава да делите вашу јавну фасциклу са другима на "
+#~ "вашој тренутној мрежи користећи: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Када је укључено удаљено пријављивање, удаљени корисници могу да се "
+#~ "повежу користећи наредбу безбедне шкољке:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Омогући дељење личних датотека"
+
+#~ msgid "Device name copied"
+#~ msgstr "Назив уређаја копиран"
+
+#~ msgid "Device address copied"
+#~ msgstr "Адреса уређаја копирана"
+
+#~ msgid "Username copied"
+#~ msgstr "Корисничко име копирано"
+
+#~ msgid "Password copied"
+#~ msgstr "Лозинка копирана"
+
+#~ msgid "Custom"
+#~ msgstr "Произвољно"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Испробавам ставку %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Неповезан"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Повезујем"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Повезан"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Грешка у овлашћивању"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Овлашћујем"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Смањена употребљивост"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Повезани и овлашћени"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Непознато"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Овлашћен у:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Повезан у:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Уписан у:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Нисам успео да овластим уређај: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Нисам успео да заборавим уређај: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Грeшкa"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Овлашћен"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Тандерболт подсистем (boltd) није инсталиран или није подешен исправно."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Могу се качити само УСБ и Дисплеј порт уређаји."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Нема уоченог Тандерболт хардвера.\n"
+#~ "Или систем нема подршку за Тандерболт, или је онемогућен у БИОС-у, или је "
+#~ "постављен на неподржани ниво безбедности у БИОС-у."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Подршка за Тандерболт је искључена у БИОС-у."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Безбедносни ниво Тандерболта се не може утврдити."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Грешка при промени директног режима: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Основно"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Средњи"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Велики"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Већи"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Највећи"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d пиксел"
+#~ msgstr[1] "%d пиксела"
+#~ msgstr[2] "%d пиксела"
+#~ msgstr[3] "један пиксел"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Кратко"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "1/4 екрана"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "1/2 екрана"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "3/4 екрана"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Велико"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 сат"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 дан"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 дана"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 дана"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 дана"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 дана"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 дана"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 дана"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 дана"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 дана"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Да избацим све ставке из смећа?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Све ставке из смећа ће бити трајно уклоњене."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Избаци Смеће"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Да обришем све привремене датотеке?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Све привремене датотеке ће бити трајно обрисане."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Прочисти привремене датотеке"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 дан"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 дана"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 дана"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Заувек"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Треба да подудари веб адресу вашег достављача пријављивања."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Нисам успео да додам налог"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Нисам успео да упишем налог"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Нема подржаног начина за потврђивање идентитета са овим доменом"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Нисам успео да приступим домену"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Неисправно име за пријављивање.\n"
+#~ "Покушајте поново."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Неисправна лозинка за пријављивање.\n"
+#~ "Покушајте поново."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Нисам успео да се пријавим на домен"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Не могу да пронађем домен. Можда сте га погрешно написали?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Потражите још слика"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "треба бити затражено од уређаја да обави ову радњу"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "уређај је већ затражен другим процесом"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "немате овлашћење да обавите ову радњу"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "никакви исписи нису уписани"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Нисам успео да комуницирам са урђајем за време уписа"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Нисам успео да комуницирам са читачем отисака"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Нисам успео да комуницирам са демоном отисака"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Неуспех при листању отисака прстију: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Неуспех при брисању сачуваних отисака прстију: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Леви палац"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Средњи, леви прст"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Леви кажипрст"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Домали, леви прст"
+
+#~ msgid "Left little finger"
+#~ msgstr "Мали, леви прст"
+
+#~ msgid "Right thumb"
+#~ msgstr "Десни палац"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Десни, средњи прст"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Десни кажипрст"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Десни, домали прсти"
+
+#~ msgid "Right little finger"
+#~ msgstr "Десни, мали прст"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Непознат прст"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Завршено"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Читач отиска прста није прикључен"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Складиште на читачу отиска прста је пуно"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Неуспех при упису новог отиска прста"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Неуспех при покретању уписа: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Нисам успео да додам нови отисак прста"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Неуспех при заустављању уписа: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Непрестано подижите и спуштајте ваш прст на читач да бисте уписали ваш "
+#~ "отисак прста"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Поно_во упиши овај прст…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Скенирај нови отисак прста"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Нисам успео да отпустим читач отиска прста %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Проблем приликом читања уређаја"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Нисам успео да затражим читач отиска прста %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Нисам успео да добавим читаче отиска прста: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Ове седмице"
+
+#~ msgid "Last Week"
+#~ msgstr "Прошле седмице"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Крај сесије"
+
+#~ msgid "Session Started"
+#~ msgstr "Почетак сесије"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Активност налога"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Изаберите другу лозинку."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Унесите вашу тренутну лозинку поново."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Лозинка не може бити промењена"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Не могу сам да приступим овој врсти домена"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Није пронађен такав домен или подручје"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Не могу да се пријавим као „%s“ на домену %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Неисправна лозинка, покушајте поново"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Не могу да се повежем на домен „%s“: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Нисам успео да избришем корисника"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Нисам успео да опозовем даљински управљаног корисника"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Не можете обрисати ваш лични налог."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "„%s“ је и даље пријављен"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Брисање корисника док су пријављени може да остави систем у неусклађеном "
+#~ "стању."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Да ли желите да сачувате датотеке корисника „%s“?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Могуће је задржати личну фасциклу, складишта поште и привремене датотеке "
+#~ "приликом брисања корисничког налога."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Обриши датотеке"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Задржи датотеке"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Да ли сигурно желите да опозовете даљински управљани налог корисника „%s“?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Обриши"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Налог је искључен"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "За подешавање приликом наредног пријављивања"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ништа"
+
+#~ msgid "Logged in"
+#~ msgstr "Пријављен сам"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Нисам успео да контактирам услугу налога"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Молим проверите да ли је Услуга налога инсталирана и укључена."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Ова површ мора бити откључана пре промене овог подешавања"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Обришите изабрани кориснички налог"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Да обришете изабрани кориснички налог,\n"
+#~ "кликните прво на иконицу *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Откључај за додавање корисника и промену поставки"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Нова лозинка треба да се разликује од старе."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Пробајте да измените нека слова и бројеве."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Пробајте још само мало да измените лозинку."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Лозинка без вашег корисничког имена ће бити јача."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Покушајте да избегнете ваше име у лозинки."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Покушајте да избегнете неке од речи употребљених у лозинки."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Покушајте да избегнете уобичајене речи."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Покушајте да избегнете преуређивање постојећих речи."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Покушајте да користите више бројева."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Покушајте да користите више великих слова."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Покушајте да користите више малих слова."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Покушајте да користите више посебних знакова, као тачка."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Покушајте да користите мешавину слова, бројева и тачака."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Покушајте да избегнете понављање истог знака."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Покушајте да избегнете понављање исте врсте знака: треба да мешате велика "
+#~ "слова, бројеве и тачке."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Покушајте да избегнете низове 1234 или абвг."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Лозинка мора бити дужа. Покушајте да користите мешавину слова, бројева и "
+#~ "тачака."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Мешајте велика и мала слова и пробајте да користите један или два броја."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "Додавање још слова, бројева и тачке ће учинити лозинку још јачом."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Потврђивање идентитета није успело"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Нова лозинка је превише кратка"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Нова лозинка је превише једноставна"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Стара и нова лозинка су сувише сличне"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Нова лозинка је већ употребљавана у скорије време."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Нова лозинка мора да садржи нумеричке или специјалне знакове"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Стара и нова лозинка су исте"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Ваша лозинка је измењена од када сте на почетку потврдили идентитет!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Нова лозинка не садржи довољно различитих знакова"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Непозната грешка"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Корисничко име треба да садржи само велика и мала слова латинског "
+#~ "алфабета од а-z, цифре и следеће знакове: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Корисничко име није доступно. Пробајте неко друго."
+
+#~ msgid "The username is too long."
+#~ msgstr "Корисничко име је предуго."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Дугме %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Програм је дефинисан"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Пошаљи откуцај тастера"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Промени монитор"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Прикажи помоћ на екрану"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Таблица закачена на лаптоп"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Таблица закачена на спољни екран"
+
+#~ msgid "External tablet device"
+#~ msgstr "Спољна таблица"
+
+#~ msgid "All Displays"
+#~ msgstr "Сви екрани"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Ербраш оловка са притиском, нагибом и уграђеним клизачем"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Ербраш оловка са притиском, нагибом и окретањем"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Стандарнда оловка са притиском и нагибом"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Стандардна оловка са притиском"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Нова пречица…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Радња је отказана"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Грешка:</b> Приступ забрањује промену подешавања"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Грешка:</b> Грешка мобилне опреме"
+
+#~ msgid "Not Registered"
+#~ msgstr "Нерегистрован"
+
+#~ msgid "Registered"
+#~ msgstr "Регистрован"
+
+#~ msgid "Roaming"
+#~ msgstr "Роминг"
+
+#~ msgid "Searching"
+#~ msgstr "Претражујем"
+
+#~ msgid "Denied"
+#~ msgstr "Забрањено"
+
+#~ msgid "2G Only"
+#~ msgstr "Само 2Г"
+
+#~ msgid "3G Only"
+#~ msgstr "Само 3Г"
+
+#~ msgid "4G Only"
+#~ msgstr "Само 4Г"
+
+#~ msgid "5G Only"
+#~ msgstr "Само 5Г"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2Г, 3Г, 4Г, 5Г (пожељно)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2Г, 3Г, 4Г (пожељно), 5Г"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2Г, 3Г (пожељно), 4Г, 5Г"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2Г (пожељно), 3Г, 4Г, 5Г"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2Г, 3Г, 4Г, 5Г"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2Г, 3Г, 4Г (пожељно)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2Г, 3Г (пожељно), 4Г"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2Г (пожељно), 3Г, 4Г"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2Г, 3Г, 4Г"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3Г, 4Г, 5Г (пожељно)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3Г, 4Г (пожељно), 5Г"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3Г (пожељно), 4Г, 5Г"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3Г, 4Г, 5Г"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2Г, 4Г, 5Г (пожељно)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2Г, 4Г (пожељно), 5Г"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2Г (пожељно), 4Г, 5Г"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2Г, 4Г, 5Г"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2Г, 3Г, 5Г (пожељно)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2Г, 3Г (пожељно), 5Г"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2Г (пожељно), 3Г, 5Г"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2Г, 3Г, 5Г"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3Г, 4Г (пожељно)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3Г (пожељно), 4Г"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3Г, 4Г"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2Г, 4Г (пожељно)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2Г (пожељно), 4Г"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2Г, 4Г"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2Г, 3Г (пожељно)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2Г (пожељно), 3Г"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2Г, 3Г"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2Г, 5Г (пожељно)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2Г (пожељно), 5Г"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2Г, 5Г"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3Г, 5Г (пожељно)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3Г (пожељно), 5Г"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3Г, 5Г"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4Г, 5Г (пожељно)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4Г (пожељно), 5Г"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4Г, 5Г"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Непознато"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Откључај СИМ картицу"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Доставите ПИН код за СИМ %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Упишите ПИН да откључате вашу СИМ картицу"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Доставите ПУК код за СИМ %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Упишите ПУК да откључате вашу СИМ картицу"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Уписали сте погрешну лозинку."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "ПУК код треба бити број од 8 цифара"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Упишите нови ПИН"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "ПИН код треба бити број од 4-8 цифара"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Откључавам…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Неуспех у телефону"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Нема везе са телефоном"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Радња није допуштена"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Радња није подржана"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "СИМ није убачен"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Потребан је СИМ ПИН"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Потребан је СИМ ПУК"
+
+#~ msgid "SIM failure"
+#~ msgstr "Неуспех СИМ-а"
+
+#~ msgid "SIM busy"
+#~ msgstr "СИМ је заузета"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Нетачна лозинка"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Потребан је СИМ ПИН2"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Потребан је СИМ ПУК2"
+
+#~ msgid "Not found"
+#~ msgstr "Није пронађено"
+
+#~ msgid "No network service"
+#~ msgstr "Нема мрежне услуге"
+
+#~ msgid "Network timeout"
+#~ msgstr "Мрежа је истекла"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "ГПРС услуге нису дозвољене"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Ромин није дозвољен у овој области"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Неодређена ГПРС грешка"
+
+#~ msgid "No Error"
+#~ msgstr "Нема грешака"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Радња је отказана"
+
+#~ msgid "Access denied"
+#~ msgstr "Приступ одбијен"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Непозната грешка"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "СИМ %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Број издања приказа"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Укључује режим исписивања"
+
+#~ msgid "Search for the string"
+#~ msgstr "Тражи ниску"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Исписује могуће називе површи и излази"
+
+#~ msgid "Panel to display"
+#~ msgstr "Површ за приказ"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[ПОВРШ] [АРГУМЕНТ…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Доступне површи:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Системски звуци"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "ДЕР или ПЕМ уверења (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Додај штампач…"
 
 #~ msgid "Light"
 #~ msgstr "Светли"
@@ -9744,11 +8486,11 @@ msgstr "Системски звуци"
 #~ msgstr "Непромењиво"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "Појединачна овлашћења програма се могу погледати у одељку <a href="
-#~ "\"privacy\">Приватност</a>, у Подешавањима."
+#~ "Појединачна овлашћења програма се могу погледати у одељку <a "
+#~ "href=\"privacy\">Приватност</a>, у Подешавањима."
 
 #~ msgid "Integration"
 #~ msgstr "Уграђивање"
@@ -10031,9 +8773,6 @@ msgstr "Системски звуци"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Таблица (апсолутно)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Додирна табла (релативно)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Поставке таблице"
 
@@ -10202,9 +8941,6 @@ msgstr "Системски звуци"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Непосредан приступ блутут хардверу"
-
-#~ msgid "Use your camera"
-#~ msgstr "Коришћење ваше камере"
 
 #~ msgid "Print documents"
 #~ msgstr "Штампа документа"
@@ -11044,9 +9780,6 @@ msgstr "Системски звуци"
 #~ msgid "Mirrored"
 #~ msgstr "Пресликано"
 
-#~ msgid "Secondary"
-#~ msgstr "Споредни"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Распоредите обједињене приказе"
 
@@ -11232,9 +9965,6 @@ msgstr "Системски звуци"
 #~ msgid "Mail"
 #~ msgstr "Ел. пошта"
 
-#~ msgid "Calendar"
-#~ msgstr "Календар"
-
 #~ msgid "Contacts"
 #~ msgstr "Контакти"
 
@@ -11380,9 +10110,6 @@ msgstr "Системски звуци"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Клизај на горе"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Клизај на доле"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Клизај десно"
@@ -11674,9 +10401,6 @@ msgstr "Системски звуци"
 
 #~ msgid "China"
 #~ msgstr "Кина"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Искључи док _куцам"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "Мрежни сервис на систему није подржан у овој верзији."

--- a/po/sr.po~
+++ b/po/sr.po~
@@ -1,0 +1,12184 @@
+# Serbian translation of gnome-control-center
+# Courtesy of Prevod.org team (http://prevod.org/) -- 2003–2022.
+# This file is distributed under the same license as the gnome-control-center package.
+# Вељко М. Станојевић <veljko@vms.homelinux.net>
+# Данило Шеган <danilo@gnome.org>, 2005.
+# Слободан Д. Средојевић <slobo@akrep.be>, 2006.
+# Милош Поповић <gpopac@gmail.com>, 2010, 2011.
+# Марко М. Костић <marko.m.kostic@gmail.com>, 2016.
+# Борисав Живановић <borisavzivanovic@gmail.com>, 2017-2018.
+# Мирослав Николић <miroslavnikolic@rocketmail.com>, 2011–2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-10-18 08:13+0000\n"
+"PO-Revision-Date: 2022-10-26 11:48+0200\n"
+"Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
+"Language-Team: Serbian <српски <gnome-sr@googlegroups.org>>\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2\n"
+"X-Project-Style: gnome\n"
+"X-Generator: Gtranslator 3.36.0\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Системска сабирница"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Пун приступ"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Сабирница сесије"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Уређаји"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Пун приступ фасцикли /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Мрежа"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Има приступ мрежи"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Личнo"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Само за читање"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Систем датотека"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Подешавања"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Може променити подешавања"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"Програм „%s“ садржи следећа уграђена овлашћења. Она не могу бити промењена. "
+"Уколико сте забринути због ових овлашћења, размислите о уклањању овог "
+"програма."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u датотека и врста везе које отвара програм"
+msgstr[1] "%u датотеке и врсте везе које отвара програм"
+msgstr[2] "%u датотека и врста везе које отвара програм"
+msgstr[3] "Једна датотека и врста везе коју отвара програм"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> се користи за отварање следећих врста датотека и веза."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s простора на диску заузето."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Програми"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Нема програма"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Инсталирајте неке…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Отвори"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Прикажи детаље"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Претрага"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Примање системских претрага и слање исхода."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Искључено"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Обавештења"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Приказивање системских обавештења."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Ради у позадини"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Дозвољен рад када је програм затворен."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Снимци екрана"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Хвата снимке екрана у било ком тренутку."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Промени позадину"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Промени позадину радне површине."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Звукови"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Пуштање звукова."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Спречи пречице"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Блокира уобичајене пречице тастатуре."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Камера"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Снимање слика преко камере."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Микрофон"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Снимање звука преко микрофона."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Услуге места"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Приступи подацима о локацији уређаја."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Уграђена овлашћења"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Системски приступ који захтева програм"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Подешавања датотека и веза"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Складиште"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Нисам нашао резултате"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Пробајте другачију претрагу"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Подешавања датотека и веза"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Врсте датотека"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Врсте везе"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Поново постави"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "Колико простора на диску овај програм заузима својим кешом и подацима."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Програм"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Подаци"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Кеш"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Укупно</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Очисти кеш…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Управља разним овлашћењима и подешавањима програма"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"application;flatpak;permission;setting;апликација;програм;флатпак;флетпек;"
+"флатпек;овлашћење;пермисија;подешавање;aplikacija;program;flatpak;fletpek;"
+"flatpek;ovlašćenje;permisija;podešavanje;ovlascenje;podesavanje;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Изаберите слику"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Откажи"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Отвори"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "више величина"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Нема позадине за радну површ"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Тренутна позадина"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Стил"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Основно"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Тамни"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Позадина"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Додај слику…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Изглед"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Промените слику позадине или боје интерфејса"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;позадина;екран;радна "
+"површ;стил;тамна;светла;pozadina;ekran;radna;povrs;površ;stil;tamna;svetla;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Омогући"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Није пронађен блутут"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Убаците УСБ блутут уређај за коришћење блутута."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Блутут је угашен"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Укључите за повезивање уређаја и остваривање преноса датотека."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Авионски режим рада је укључен"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Блутут је искључен када је авионски режим рада укључен."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Искључи авионски режим рада"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Хардверски авионски режим рада је укључен"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Искључите авионски режим рада бисте укључили блутут."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Блутут"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Укључите или искључите блутут и повежите ваше уређаје"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+"дељење;блутут;обекс;deljenje;blutut;obeks;share;sharing;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Камера је искључена"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Ниједан програм може снимати фотографије или видео записе."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Коришћење камере омогућава програмима снимање слика и видео записа. "
+"Онемогућавање приступа камери може узроковати проблеме у раду неким "
+"програмима.\n"
+"\n"
+"Дозвољава програмима испод коришћење ваше камере."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Ниједан програм није затражио приступ камери"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Заштитите ваше слике"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;камера;фотографије;видео;"
+"вебкам;закључавање;приватност;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Поставите уређај за калибрацију преко квадрата и притисните „Почни“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Померите уређај за калибрацију на положај калибрације и притисните „Настави“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Померите уређај за калибрацију на положај површине и притисните „Настави“"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Заклопите преносни рачунар"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Дошло је до унутрашње грешке која не може бити опорављена."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Алати потребни за калибрацију нису инсталирани."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Профил не може бити направљен."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Бела тачка мете се не може добавити."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Завршено!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Калибрација није успела!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Можете да уклоните уређај за калибрацију."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Не ометајте уређај за калибрацију док је у раду"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Прикажи калибрацију"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Покрени"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Настави"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Готово"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Екран преносног рачунара"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Уграђена веб камерица"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s монитор"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s скенер"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s фотоапарат"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s штампач"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s веб камерица"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Укључи управљање бојом за „%s“"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Прикажи профиле боја за „%s“"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Није калибрисано"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Основно: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Простор боја: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Пробни профил: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Изабери датотеку ИЦЦ профила"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Увези"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Подржани ИЦЦ профили"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Све датотеке"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Екран"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Сачувај профил"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Сачувај"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Направите профил боје за изабрани уређај"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Није откривен инструмент за мерење. Проверите да ли је укључен и да ли је "
+"исправно прикључен."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Инструмент за мерење не подржава профилисање штампача."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Тип уређаја тренутно није подржан."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Калибрација екрана"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Квалитет калибрације"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Калибрација ће произвести профил који можете да користите да управљате бојом "
+"вашег екрана. Што дуже буде трајала калибрација, то ће бити бољи квалитет "
+"профила боје."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Нећете моћи да користите рачунар за време калибрације."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Квалитет"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Приближно време"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Уређај калибрације"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Изаберите уређај сензора који желите да користите за калибрацију."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Врста екрана"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Изаберите врсту екрана који је повезан."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Бела тачка профила"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Изаберите белу тачку мете екрана. Већина екрана треба да буде калибрисана на "
+"Д65 осветљење."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Осветљај екрана"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Молим подесите екран на осветљај који вам највише одговара. Управљање бојом "
+"ће бити најтачније на том нивоу осветљаја."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Или другачије, можете да користите ниво осветљаја коришћен са једним од "
+"других профила за овај уређај."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Назив профила"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Можете да користите профил боје на различитим рачунарима, или чак да "
+"направите профиле за различите услове осветљења."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Назив профила:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Сажетак"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Профил је успешно направљен!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Умножите профил"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Захтева уписив диск"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Можете увидети да су упутнице о коришћењу профила на системима <a href="
+"\"linux\">ГНУ/Линукса</a>, <a href=\"osx\">Ејпол ОС Икс-а</a> и <a href="
+"\"windows\">Мајкрософт Виндоуза</a> корисне."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Додај профил"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Откривен је проблем. Профил не може да ради исправно. <a href=\"\">Прикажи "
+"појединости.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Увези датотеку…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Додај"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Сваком уређају је потребан освежени профил боје да би био управљан бојом."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Сазнајте више"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Сазнајте више о управљању бојама"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Поде_си за све кориснике"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Подесите овај профил за све кориснике на овом рачунару"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Омогући"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Додај профил"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "Ис_калибриши…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Подесите уређај"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Уклони профил"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Прикажи детаље"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Не могу да откријем ни један уређај који може бити управљан бојом"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "ЛЦД"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "ЛЕД"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "ЦРТ"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Пројектор"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Плазма"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "ЛЦД (ЦЦФЛ позадинско осветљење)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "ЛЦД (РГБ ЛЕД позадинско осветљење)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "ЛЦД (бело ЛЕД позадинско осветљење)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "ЛЦД широког гамута (ЦЦФЛ позадинско осветљење)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "ЛЦД широког гамута (РГБ ЛЕД позадинско осветљење)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Висок"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 минута"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Средњи"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 минута"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Низак"
+
+# bug(danilo): plural-forms
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 минута"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Изворно на екран"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "Д50 (Штампање и објављивање)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "Д55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "Д65 (Фотографија и графика)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "Д75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Уобичајени простор"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Испробај профил"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Самостални"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Низак квалитет"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Осредњи квалитет"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Висок квалитет"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Основна РГБ"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Основна ЦМУК"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Основна сива"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Продавац је доставио податке фабричке калибрације"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Исправка приказа преко целог екрана није могућа са овим профилом"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Овај профил више не може бити тачан"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Боја"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Калибрирајте боје ваших уређаја, као што су екрани, фото-апарати или штампачи"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Color;ICC;Profile;Calibrate;Printer;Display;боја;ицц;профил;калибрирај;"
+"штампач;екран;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Други…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Изабери језик"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "И_забери"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Нисам пронашао језике"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Још…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Откључај за промену подешавања"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Нека подешавања морају бити откључана пре промене."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Откључај…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Повећај сат"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Повећај минут"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Време"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Смањи сат"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Смањи минут"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Данас"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Јуче"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y."
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d сат"
+msgstr[1] "%d сата"
+msgstr[2] "%d сати"
+msgstr[3] "Један сат"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d минут"
+msgstr[1] "%d минута"
+msgstr[2] "%d минута"
+msgstr[3] "Један минут"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d секунда"
+msgstr[1] "%d секунде"
+msgstr[2] "%d секунди"
+msgstr[3] "Једна секунда"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 секунди"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Врућа тачка"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-часовно"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "ПрП/ПоП"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%A, %e.%m.%Y. %l:%M %P"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e. %B %Y. %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "КУВ%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %P"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Датум и време"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Година"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Месец"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Јануар"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Фебруар"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Март"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Април"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Мај"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Јун"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Јул"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Август"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Септембар"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Октобар"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Новембар"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Децембар"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Дан"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Временска зона"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Потражите град"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Аутоматско време и _датум"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Захтева приступ интернету"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Датум и _време"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Аутоматска временска _зона"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Захтева омогућену услугу места и приступ интернету"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Омогућено"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Временска з_она"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Запис _времена"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Измените датум и време, укључујући временску зону"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;сат;временска зона;место;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Измените подешавања времена и датума на систему"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Да измените подешавања времена и датума, морате да потврдите идентитет."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Веб"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Пошта"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Календар"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Музика"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Видео"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Фотографије"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Подразумевани програми"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Подесите основне програме"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "основни;програм;омиљени;медиј;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Слање извештаја о техничким проблемима нам помаже да побољшамо дистрибуцију "
+"„%s“. Извештаји се шаљу безимено и очишћени су од личних података. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Извештавање о проблему"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Самостално извести о проблему"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Дијагностика"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Пријавите ваше проблеме"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;дијагностика;пад;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Укљ."
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Искљ."
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Да применим измене?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Не могу да применим измене"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Ово је можда због ограничења хардвера."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Примени"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Назад"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Подешавања екрана онемогућена"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Више екрана"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Споји"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Пресликано"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Садржи горњу траку и Активности"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Главни екран"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Ноћно светло"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Положено"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Усправно десно"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Усправно лево"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Положено (изврнуто)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Усмерење"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Резолуција"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Стопа освежавања"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Дотеривање за ТВ"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Размера"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Ноћно светло недоступно"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Ово се може догодити због тренутно коришћеног графичког драјвера или се "
+"можда радна површ користи удаљено"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Привремено је искључено до сутра"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Поново покрени филтер"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Ноћно светло чини боје екрана топлијим. Може помоћи у спречавању напрезања "
+"очију и несанице."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Закажи"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Од заласка до изласка сунца"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Ручно закажи"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Времена"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Од"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Сат"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+# bug(danilo): plural-forms
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Минут"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "ПрП"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "ПоП"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "До"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Температура боје"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Екрани"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Изаберите како ћете користити повезане екране и пројекторе"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;панел;пројектор;икс-рандр;екран;резолуција;"
+"освежавање;монитор;ноћ;светло;плаво;редшифт;боја;свитање;сумрак;panel;"
+"projektor;iks-randr;ekran;rezolucija;osvežavanje;monitor;noć;svetlo;plavo;"
+"redšift;boja;svitanje;sumrak;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Безбедно подизање је покренуто"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Безбедно подизање спречава учитавање злонамерног софтвера за време покретања "
+"уређаја. Тренутно је укључено и ради без грешке."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Безбедно подизање има проблема"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Безбедно подизање спречава учитавање злонамерног софтвера за време покретања "
+"уређаја. Тренутно је укључено, али неће радити зато што има један неисправан "
+"кључ."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Проблеми безбедног подизања могу се често решити из поставки уграђеног "
+"програма УЕФИ-а вашег рачунара (БИОС) а произвођач вашег хардвера може да "
+"обезбеди информације како то да урадите."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"За помоћ, обратите се произвођачу вашег хардвера или достављачу ИТ подршке."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Безбедно подизање је искључено"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Безбедно подизање спречава учитавање злонамерног софтвера за време покретања "
+"уређаја. Тренутно је искључено."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Безбедно подизање се може често укључити из поставки уграђеног програма УЕФИ-"
+"а вашег рачунара (БИОС). За помоћ, обратите се произвођачу вашег хардвера "
+"или достављачу ИТ подршке."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Безбедно подизање спречава учитавање злонамерног софтвера за време покретања "
+"уређаја.\n"
+"\n"
+"За више информација, обратите се произвођачу хардвера или ИТ подршци."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Успешно"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Неуспешно"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Уређај је у складу са „HSI“ ниво %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Безбедносни ниво 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Овај уређај нема заштиту од проблема безбедности хардвера. Ово може бити "
+"услед хардверских или проблема подешавања уграђеног програма. Препоручује "
+"вам се да се обратите вашем достављачу ИТ подршке."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Безбедносни ниво 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Овај уређај има најмању заштиту од проблема безбедности хардвера. Ово је "
+"најнижи ниво безбедности уређаја и обезбеђује заштиту само од једноставних "
+"безбедносних претњи."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Безбедносни ниво 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Овај уређај има основну заштиту од проблема безбедности хардвера. Ово "
+"обезбеђује заштиту од неких општих безбедносних претњи."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Безбедносни ниво 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Овај уређај има прођирену заштиту од проблема безбедности хардвера. Ово је "
+"највиши ниво безбедности уређаја и обезбеђује заштиту од напредних "
+"безбедносних претњи."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Безбедносни ниво"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Нивои безбедности нису доступни за овај уређај."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Обратите се вашем произвођачу хардвера за помоћ са безбедносним освежењима."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Може бити могуће решити овај проблем у поставкама уграђеног програма УЕФИ-а "
+"уређаја, или са техничарем подршке."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Може бити могуће решити овај проблем у поставкама уграђеног програма УЕФИ-а "
+"уређаја."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+"Може бити могуће да техничар подршке реши овај проблем (ако је добре воље)."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Ниво 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Ниво 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Ниво 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Заштићени сте од злонамерног софтвера приликом покретања уређаја."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Безбедно подизање има проблема"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Имате некакву заштиту приликом покретања уређаја."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Безбедно подизање је искључено"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Немате никакву заштиту приликом покретања уређаја."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Овај проблем је можда изазван изменом у поставкама уграђеног програма УЕФИ-"
+"а, изменом у подешавањима оперативног система или услед злонамерног софтвера "
+"на овом систему."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Овај проблем је можда изазван изменом у поставкама уграђеног програма УЕФИ-"
+"а, или услед злонамерног софтвера на овом систему."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Овај проблем је можда изазван изменом у подешавањима оперативног система или "
+"услед злонамерног софтвера на овом систему."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Изложен озбиљним безбедносним претњама."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Ограничена заштита од једноставних безбедносних претњи."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Заштићен од уобичајених безбедносних претњи."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Заштићен од великог опсега безбедносних претњи."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Разумљива заштита"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Нема догађаја"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Заштита уписа фирмвера"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Катанац заштите уписа фирмвера"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Област БИОС фирмвера"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Описник БИОС фирмвера"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Предподизна ДМА заштита"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard проверено подизање"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM заштита"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard политика грешке"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard стопљено"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET је укључено"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET је активно"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Шифровани РАМ"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "ИОММУ заштита"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Закључавање Линукс кернела"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Потврђивање Линукс кернела"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Линуксова разменска"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Обустава у РАМ"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Обустава у мировање"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Платформски УЕФИ кључ"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "УЕФИ безбедно подизање"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Подешавање ТПМ платформе"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "ТПМ реконструкција"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "ТПМ издања 2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine режим производње"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine пресклопка"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine издање"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Ажурирања фирмвера"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Атест фирмвера"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Потврђивање ажурирања фирмвера"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Платформско поправљање грешака"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Безбедносне провере процесора"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "АМД резервна заштита"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Риплеј заштита АМД фирмвера"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Заштита уписа АМД фирмвера"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Притопљена платформа"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Исправно"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Није исправно"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Није омогућено"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Закључано"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Откључано"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Шифровано"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Нешифровано"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Укаљано"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Неукаљано"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Уочено"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Неуочено"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Подржано"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Неподржано"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Безбедност уређаја"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Безбедносно стање фирмвера домаћина"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"екран;закључај;дијагноза;пад;урушавање;лично;скорашње;недавно;привремен;тмп;"
+"попис;назив;мрежа;идентитет;приватност;screen;lock;diagnostics;crash;private;"
+"recent;temporary;tmp;index;name;network;identity;privacy;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Непознато"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-бита"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-бита"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "Икс-11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Вејленд"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Непознато"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Није доступно"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Лого система"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Назив уређаја"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Модел хардвера"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Меморија"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Процесор"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Графика"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Капацитет диска"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Израчунавам…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Назив ОС-а"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "ИБ изградње ОС-а"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Врста ОС-а"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Издање Гнома"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Учитавам…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Прозорски систем"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Виртуелизација"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Ажурирања програма"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Преименуј уређај"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Назив уређаја се користи за идентификовање овог уређаја на мрежи или "
+"приликом упаривања Блутут уређаја."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Назив уређаја"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "П_реименуј"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Системски подаци"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Погледајте податке о вашем систему"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"уређај;систем;информације;меморија;домаћин;хост;процесор;издање;основно;"
+"програм;омиљено;цд;двд;усб;звук;снимак;диск;уклоњиви;медијум;носач;"
+"самопокретање;uređaj;sistem;informacije;memorija;procesor;izdanje;osnovno;"
+"program;omiljeno;cd;dvd;usb;zvuk;snimak;disk;uklonjivi;medijum;nosač;domacin;"
+"host;samopokretanje;device;system;information;memory;processor;version;"
+"default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;"
+"autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Звук и медији"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Утишавање и појачавање звука"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Смањује јачину звука"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Појачава јачину звука"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Утишавање и појачавање микрофона"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Покреће медијски програм"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Пушта (или пушта/паузира)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Паузира пуштање"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Зауставља пуштање"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Претходна нумера"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Следећа нумера"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Избаци"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Куцање"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Пребаците се на следећи извор улаза"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Пребаците се на претходни извор улаза"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Покретачи"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Покреће прегледач помоћи"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Покреће калкулатор"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Покреће програм за ел. пошту"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Покреће веб прегледник"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Лична фасцикла"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Претрага"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Систем"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Одјави ме"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Закључај екран"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Приступачност"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Укључује/искључује увећање"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Увећава"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Умањује"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Укључи/искључи читач екрана"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Укључи/искључи екранску тастатуру"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Повећај величину текста"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Смањи величину текста"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Укључи/искључи велики контраст"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Нисам пронашао изворе улаза"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Друго"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Додајте извор улаза"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Начини уноса не могу бити коришћени у екрану пријављивања"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Није изабран извор улаза"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Могућности"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Помери горе"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Помери доле"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Поставке"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Прикажи распоред тастатуре"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Уклони"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Произвољне пречице"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Тастери заменских знакова"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Тастер заменских карактера се може користити за унос додатних знакова. "
+"Некада су одштампани као трећа могућност на вашој тастатури."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Леви алт"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Десни алт"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Леви супер"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Десни супер"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Тастер изборника"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Десни Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Саставни тастер"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Саставни тастер омогућава унос широког спектра знаков. Да га користите, "
+"притисните саставни тастер затим низ знакова.  На пример, саставни тастер за "
+"којим следи <b>C</b> и <b>o</b> уписаће <b>©</b>, <b>a</b> за којим следи "
+"<b>'</b> уписаће <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Закључавање слова"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Закључавање померања"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Штампај екран"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Извор уноса се може променити преко %s пречице на тастатури.\n"
+"Пречица се може променити у подешавањима пречица тастатуре."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Извори улаза"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Укључује распореде тастатуре или начине уноса."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Промена извора улаза"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Користи _исти извор за све прозоре"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Засебан _извор улаза за сваки прозор"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Унос посебних знакова"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Начини за унос симбола и различитих слова преко тастатуре."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Пречице тастатуре"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Преглед и прилагођавање пречица"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d ставка је измењена"
+msgstr[1] "%d ставки је измењено"
+msgstr[2] "%d ставки је измењено"
+msgstr[3] "Једна ставка је измењена"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Да вратим све пречице?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Поновно враћање пречица може утицати на ваше произвољне пречице. Ово се не "
+"може опозвати."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Откажи"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Врати све"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Врати све…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Вратите све пречице на њене основне вредности"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Одељак"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Пречице"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Додај пречицу"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Додајте произвољне пречице"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Поставите произвољне пречице за покретање програма, извршавање скрипти и још "
+"тога."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Додај пречицу"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Нисам нашао речицу тастатуре"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"„%s“ се већ користи за пречицу „%s“. Ако замените, пречица „%s“ биће "
+"онемогућена"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Унесите нову пречицу"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Постави произвољну пречицу"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Постави пречицу"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Унесите нову пречицу за „%s“."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Додајте произвољну пречицу"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Уклони"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Замени"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Постави"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Притисните „Esc“ да откажете или „Backspace“ да онемогућите пречицу "
+"тастатуре."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Назив"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Наредба"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Пречица"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Постави пречицу…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ништа"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Врати пречицу на њену основну вредност"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Тастатура"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Промените пречице тастатуре и подесите ваше поставке куцања, распореде "
+"тастатуре и изворе улаза"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+"пречица;радни простор;прозор;промени величину;зум;контраст;улаз;извор;"
+"закључај;волумен;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Услуге места су искључене"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Ниједан програм не може прикупити податке о месту."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Услуге места говоре програмима вашу локацију. Коришћење бежичних и мобилних "
+"мрежа повећава тачност.\n"
+"\n"
+"Користи се Мозилина услуга локације: <a href='https://location.services."
+"mozilla.com/privacy'>политика приватности</a>\n"
+"\n"
+"Дозвољава програмима испод да знају вашу локацију."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Ниједан програм није затражио податке о месту"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Заштитите ваше податке о месту становања"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+"место;локација;џпс;гпс;приватно;приватност;location;gps;private;privacy;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Микрофон је искључен"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Ниједан програм не може снимати звук."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Коришћење микрофона омогућава програмима снимање и слушање звукова. "
+"Онемогућавање приступа микрофону може узроковати проблеме у раду неким "
+"програмима.\n"
+"\n"
+"Дозвољава програмима испод употребу вашег микрофона."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Ниједан програм није затражио приступ микрофону"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Заштитите ваше разговоре"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"микрофон;снимање;програм;апликација;приватност;microphone;recording;"
+"application;privacy;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Испробај _подешавања"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Опште"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Главно дугме"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Подешава редослед физичких тастера на мишевима и додирним таблицама."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Лево"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Десно"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Миш"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Брзина миша"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Природно клизање"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Клизање помера садржај, не преглед."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Додирна табла"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Брзина додирне табле"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Лупни за клик"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Лупни за клик"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Премицање са два прста"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Клизање по страни"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Испробајте кликање, двоструко кликање, клизање"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Пет клика, ГЕГЛ време!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Двоструки клик, главно дугме"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Један клик, главно дугме"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Двоструки клик, средње дугме"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Један клик, средње дугме"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Двоструки клик, помоћно дугме"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Један клик, помоћно дугме"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Миш и додирна табла"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Промените осетљивост миша или додирне табле и изаберите леворукост или "
+"деснорукост"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;плоча;показивач;"
+"клик;додир;дупло;дугме;куглица;клизање;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "Врући у_гао"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Досегните горњи леви угао да бисте отворили преглед активности."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "Укључене ивице екран_а"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Повуците прозоре ка горњој, левој и десној ивици екрана да бисте променили "
+"величину."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Радни простори"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Динамички радни простори"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Самостално брише празне радне просторе."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Трајни радни простори"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Наведите број трајних радних простора."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Број радних простора"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Више екрана"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Радни _простори само на главном екрану"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Ра_дни простори на свим екранима"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Пребацивање програма"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Прикажи програме са свих _радних простора"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Прикажи програме _само са тренутног радног простора"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Упоредни рад"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Управљајте поставкама продуктивности и упоредног рада"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"Упоредни рад;Вишеструки рад;Продуктивност;Прилагоди;Десктоп;Радна површ;"
+"Врући угао;Радни простори;Uporedni rad;Višestruki rad;Produktivnost;"
+"Prilagodi;Desktop;Radna površ;Vruci ugao;Radni prostori;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Упс, нешто је пошло наопако. Обратите се вашем продавцу софтвера."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Управљач мрежом треба бити покренут."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Други уређаји"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "ВПН"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Додај везу"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Није подешено"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (Назив мреже: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Небезбедна мрежа (ВЕП)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Безбедна мрежа (ВПА2)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Безбедна мрежа (ВПА2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Безбедна мрежа (ВПА3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Безбедна мрежа"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Повезани сте"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Могућности…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Укључивање вруће тачке ће вас откачити са мреже %s и неће бити могућ приступ "
+"интернету преко бежичне картице."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Мора садржати најмање осам знакова"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Мора садржати највише %d знак"
+msgstr[1] "Мора садржати највише %d знака"
+msgstr[2] "Мора садржати највише %d знакова"
+msgstr[3] "Мора садржати највише %d знак"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Да укључим бежичну врућу тачку?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Врућа тачка бежичне мреже омогућава да поделите вашу интернет везу са "
+"другима тако што се направи бежична мрежа на коју се могу повезати. Да бисте "
+"ово урадили, морате имати интернет везу преко извора који није бежична "
+"картица."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Назив мреже"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Лозинка"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Направи насумичну лозинку"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Самостално направи лозинку"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Укључи"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Бежична"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Да зауставим врућу тачку и да искључим све кориснике?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Заустави врућу тачку"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Режим у авиону"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Искључите бежичну, блутут и широкопојасну мрежу"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Нисам нашао бежични адаптер"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Проверите да ли сте прикључили и упалили бежични адаптер"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Авио режим укључен"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Искључите да бисте користили бежичну картицу"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Бежична врућа тачка покренута"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Мобилни уређаји могу скенирати QR код за повезивање."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Искључи врућу тачку…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Видљиве мреже"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Управљач мрежом треба бити покренут"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Безбедност 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Безбедност"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Задржи"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Трајно"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Насумично"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Стабилно"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"МАК адреса коју унесете овде биће коришћена као хардверска адреса мрежног "
+"уређаја на којем се покрене ова веза. Ова могућност је познатија као "
+"клонирање или лажирање МАК адресе. На пример: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Профил „%d“"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "ВЕП"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "ВПА"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "ВПА3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Побољшано отварање"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "ВПА2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Ентерпрајз"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ништа"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Никад"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "Пре %i дан"
+msgstr[1] "Пре %i дана"
+msgstr[2] "Пре %i дана"
+msgstr[3] "Пре једног дана"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Нема сигнала"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Слаб сигнал"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Добар сигнал"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Одличан сигнал"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Изврстан сигнал"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "ИПв4 адреса"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "ИПв6 адреса"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "ИП адреса"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "ДНС4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "ДНС6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "ДНС"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Заборави везу"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Уклони профил везе"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Уклони ВПН"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Појединости"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "самостално"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Идентитет"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Обриши адресу"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Обриши руту"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "ИПв4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "ИПв6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ништа"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "ВЕП 40/128-битни кључ (Хекса или АСКРИ)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "ВЕП 128-битна лозинка"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "ЛЕАП"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Динамички ВЕП (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "Лични ВПА & ВПА2"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "Пословни ВПА & ВПА2"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "ВПА3 лично"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Јачина сигнала"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Брзина везе"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Хардверска адреса"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Подржане фреквенције"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Подразумевана рута"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Коришћена"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "_Сам се повежи"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Учини доступно _другим корисницима"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"О_граничена веза: постоје ограничења за податке или могу настати додатни "
+"трошкови"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Неће бити покретања самосталних ажурирања програма или других великих "
+"преузимања."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Назив"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_МАЦ адреса"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "М_ТУ"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Клонирана адреса"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "бајта"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "ИПв_4 Начин"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Самостално (ДХЦП)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Само вежи-локално"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Ручно"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Искључи"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Дељено ка осталим рачунарима"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Адресе"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Адреса"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Мрежна маска"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Мрежни пролаз"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Самостално"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Самостални ДНС"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Адресе ДНС сервера"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Раздвојте ИП адресе зарезима"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Руте"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Самосталне руте"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Метрички"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Користи ову везу _само за изворе на сопственој мрежи"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "ИПв_6 Начин"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Самостално, само ДХЦП"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Префикс"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Не могу да отворим уређивача везе"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Нови профил"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Неисправно подешавање %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Неисправно подешавање %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Увези из датотеке…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Додај ВПН"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Б_езбедност"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Не могу да увезем ВПН везу"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Не могу да прочитам датотеку „%s“ или она не садржи познате ВПН податке о "
+"вези\n"
+"\n"
+"Грешка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Изаберите датотеку за увоз"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Датотека под називом „%s“ већ постоји."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Замени"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Да ли желите да замените „%s“ ВПН везом коју сада чувате?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Не могу да извезем ВПН везу"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Не могу да извезем ВПН везу „%s“ у %s.\n"
+"\n"
+"Грешка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Извези ВПН везу"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Грешка: не могу да учитам уређивача ВПН везе)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_ССИД"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_БССИД"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Управљајте вашим повезивањем на Интернет"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;мрежа;ИП;ЛАН;"
+"прокси;посредник;ВАН;броадбенд;широкопојасни;модем;блутут;впн;ДНС;mreža;IP;"
+"LAN;proksi;posrednik;VAN;broadbend;širokopojasni;modem;blutut;mreza;"
+"sirokopojasni;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Управљајте повезивањем на бежичне мреже"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+";Network;Wireless;mreza;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;мрежа;"
+"бежична;вај-фај;ип;лан;широкопојасна;ДНС;хотспот;mreža;bežična;vaj-faj;ip;"
+"lan;širokopojasna;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "никад"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "данас"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "јуче"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Коришћена"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Жичана"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Додајте нову везу"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Детаљи мреже за изабране мреже, укључујући лозинку и сва произвољна "
+"подешавања ће бити изгубљени."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Заборави"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Познате бежичне мреже"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Заборави"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Политика система забрањује употребу као вруће тачке"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Бежични уређај не подржава режим вруће тачке"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Аутоматско налажење веб посредника се користи када није дата адреса за "
+"подешавање."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Ово није препоручљиво за небезбедне, јавне мреже."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Искључи уређај"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Покренуто"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "ИМЕИ"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Достављач"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Мрежни посредник"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_ХТТП посредник"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "_ХТТПС посредник"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_ФТП посредник"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Прикључци домаћина"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Занемари домаћине"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Прикључник ХТТП посредника"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Прикључник ХТТПС посредника"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Прикључник ФТП посредника"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Прикључник соцкс посредника"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Адреса подешавања"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Искључи ВПН везу"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Назив мреже"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Врста безбедности"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Лозинка"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Искључи бежичну"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Више опција…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Повежи се на скривену бежичну мрежу…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Укључи бежичну врућу тачку…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Познате бежичне мреже"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Непознато стање"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Неуправљан"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Недоступно"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Повезујем се"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Потребно је потврђивање идентитета"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Искључујем"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Повезивање није успело"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Стање је непознато (недостаје)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Није успело подешавање"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Није успело подешавање ИП-а"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Истекло је подешавање ИП-а"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Затражене су тајне, али нису достављене"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Прекинута је веза са 802.1x молиоцем"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Није успело подешавање 802.1x молиоца"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x молилац није успео"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Потврђивање идентитета 802.1x молиоца је трајало предуго"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "ППП услуга није успела да се покрене"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "ППП услуга је искључена"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "ППП није успело"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "ДХЦП клијент није успео да е покрене"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Грешка ДХЦП клијента"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "ДХЦП клијент није успео"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Услуга дељене везе није успела да се покрене"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Услуга дељене везе није успела"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Услуга самосталног ИП-а није успела да се покрене"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Грешка услуге самосталног ИП-а"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Услуга самосталног ИП-а није успела"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Линија је заузета"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Нема тона позивања"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Ниједан оператер не може бити пронађен"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Истекло је време захтева позивања"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Покушај позивања није успео"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Није успело покретање модема"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Нисам успео да изаберем наведени НТП"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Не тражим мреже"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Завођење мреже је одбијено"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Истекло је време за завођење мреже"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Нисам успео да заведем са захтеваном мрежом"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Провера ПИН-а није успела"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Можда недостаје фирмвер за уређај"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Веза је нестала"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Постојећа веза биће присвојена"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Није пронађен модем"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Веза блутута није успела"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "СИМ картица није убачена"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Потребан је СИМ ПИН"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Потребан је СИМ ПУК"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Погрешна СИМ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Није успела зависност везе"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Недостаје фирмвер"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Кабал је искључен"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "неодређена грешка у 802.1X безбедности (впа-еап)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "није изабрана датотека"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "неодређена грешка потврђивања датотеке еап-метода"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "ДЕР, ПЕМ, ПКЦС#12, или ПГП приватни кључеви"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "ДЕР или ПЕМ уверења"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "недостаје датотека ЕАП-ФАСТ ПАЦ"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "ПАЦ датотеке (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "ГТЦ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "МСЦХАПв2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Анонимно"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Потврђеним идентитетом"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Оба"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Анонимни _идентитет"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "ПАЦ _датотека"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Изабери ПАЦ датотеку"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Унутрашња пријава"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Дозволи аутоматско ПАЦ _снабдевање"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "недостаје ЕАП-ЛЕАП корисничко име"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "недостаје ЕАП-ЛЕАП лозинка"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Корисник"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Лозинка"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "По_кажи лозинку"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "неисправно ЕАП-ПЕАП уверење издавача уверења: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+"неисправно ЕАП-ПЕАП уверење издавача уверења: није наведено никакво уверење"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "МД5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Издање 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Издање 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "ЦА _уверење"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Изаберите уверење издавача овлашћења"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Није потребно _уверење издавача уверења"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "ПЕАП _издање"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "недостаје ЕАП корисничко име"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "недостаје ЕАП лозинка"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "недостаје ЕАП-ТЛС идентитет"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "неисправно ЕАП-ТЛС уверење издавача уверења: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+"неисправно ЕАП-ТЛС уверење издавача уверења: није наведено никакво уверење"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "неисправан ЕАП-ТЛС приватни кључ: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "неисправно ЕАП-ТЛС уверење корисника: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Нешифровани приватни кључеви нису сигурни"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Изгледа да изабрани приватни кључ није заштићен лозинком. Ово може угрозити "
+"ваше сигурносне податке. Изаберите приватни кључ који зе заштићен лозинком.\n"
+"\n"
+"(Можете заштитити приватне кључеве користећи „openssl“)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Изаберите ваше лично уверење"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Изаберите лични кључ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Идентитет"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Уверење _корисника"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Лични _кључ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "_Лозинка личног кључа"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "неисправно ЕАП-ТТЛС уверење издавача уверења: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+"неисправно ЕАП-ТТЛС уверење издавача уверења: није наведено никакво уверење"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "ПАП"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "МСЦХАП"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "МСЦХАПв2 (без ЕАП-а)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "ЦХАП"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Домен"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Непозната грешка потврђивања 802.1X безбедности"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "ТЛС"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "ЛЗН"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "ФАСТ"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "ТЛС кроз тунел"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Заштићени ЕАП (ПЕАП)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Потврђивање _идентитета"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Изаберите датотеку"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "недостаје леап корисничко име"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "недостаје леап лозинка"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Недостаје лозинка бежичне мреже."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Врста"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "недостаје веп кључ"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"неисправан веп кључ: кључ дужине %zu мора да садржи само хексадецималне цифре"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "неисправан веп кључ: кључ дужине %zu мора да садржи само аскри знакове"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"неисправан веп кључ: погрешна дужина кључа %zu. Кључ мора бити дужине 5/13 "
+"(аскри) или 10/26 (хекса)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "неисправан веп кључ: пропусна реч не сме бити празна"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "неисправан веп кључ: пропусна реч мора бити краћа од 64 знакова"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Основно)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Отворени систем"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Дељени кључ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Кључ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "П_рикажи кључ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "ВЕП и_ндекс"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"неисправан впа-пск: неисправна дужина кључа %zu. Мора бити [8,63] бајта или "
+"64 хексадецималних цифара"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"неисправан впа-пск: не могу да растумачим кључ са 64 бајта као хексадецимални"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "О_бавештења"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Звучне _узбуне"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Облачићи обавештења"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Обавештења ће наставити да се појављују на списку обавештења приликом "
+"приказивања облачића."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Прикажи садржај _поруке у облачићима"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Обавештења на екрану закључавања"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Прикажи садржај п_оруке на екрану закључавања"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Не узнемиравај"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Обавештења на екрану закључавања"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Управљајте приказаним обавештењима и њиховим садржајем"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;Banner;Message;Tray;Popup;обавештења;врпца;порука;фиока;"
+"искочко;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Друго"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "Корисник „%s“ је уклоњен"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Грешка у уклањању налога"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Поништи"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Затвори обавештење"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Повежите се на ваше податке у облаку"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Нема интернет везе — повежите се да подесите нове налоге на мрежи"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Додајте налог"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "„%s“ налог"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Уклони налог"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Налози на мрежи"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Повежите се на ваше налоге на мрежи и одлучите за шта ћете их користити"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;гугл;фејсбук;твитер;јаху;веб;мрежа;"
+"ћаскање;календар;пошта;контакт;лични_облак;керберос;имап;смтп;покет;"
+"прочитајкасније;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Непознато време"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i минут"
+msgstr[1] "%i минута"
+msgstr[2] "%i минута"
+msgstr[3] "Један минут"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i сат"
+msgstr[1] "%i сата"
+msgstr[2] "%i сати"
+msgstr[3] "Један сат"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%d %s %d %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "сат"
+msgstr[1] "сата"
+msgstr[2] "сати"
+msgstr[3] "сат"
+
+# bug(danilo): plural-forms
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "минут"
+msgstr[1] "минута"
+msgstr[2] "минута"
+msgstr[3] "минут"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s до потпуне напуњености"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Пажња: преостаје још %s рада"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Преостало време: %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Потпуно пуна"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Не пуни се"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Празна"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Пуни се"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Празни се"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Бежични миш"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Бежична тастатура"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Непрекидив извор напајања"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Лични дигитални помоћник"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Мобилни телефон"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Музички уређај"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Таблица"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Рачунар"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Улазни уређај за игре"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батерија"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Главна"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Додатна"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Батерије"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Када _мирује"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Обустави"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Искључи"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Замрзни"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ништа"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Када се напаја са батерије"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Када је укључен"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Никада"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Самостална обустава уређаја"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "Најбржи режим рада онемогућен због високе радне температуре."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Уочен рад на крилу: најбржи режим тренутно није доступан. Померите уређај на "
+"неку стабилну површину за омогућавање најбржег рада."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Режим учинковитости је тренутно искључен."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Батерија је скоро празна: штедиша енергије је укључен. Претходни режим биће "
+"враћен када се батерија довољно напуни."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Режим штедише напајања је укључио „%s“."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Режим учинковитости је покренуо „%s“."
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 минута"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 минута"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 сат"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 минута"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 минута"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 минута"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 сата"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Режим напајања"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Утиче на брзину система и коришћење напајања."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Опције уштеде напајања"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Самостално осветљење екрана"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Осветљеност екрана се подешава на светлост окружења."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Затамни екран"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Смањује осветљеност екрана када је рачунар неактиван."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Искљ_учи екран"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Искључује екран након одређеног мировања."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Самостална уштеда напајања"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Укључује режим штедише напајања када је батерија скоро празна."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "С_амостално обустави"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Обуставља рачунар након одређеног мировања."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Радња ду_гмета за напајање"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Прикажи _проценат батерије"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Сам обустави"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Када је _укључен"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Када се напаја са _батерије"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Застој"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Најбрже"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Велика брзина и коришћење напајања."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Уравнотеженост"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Уобичајена брзина и коришћење напајања."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Уштеда батерије"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Умањена брзина и коришћење напајања."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Напајање"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Погледајте стање ваше батерије и измените подешавања уштеде напајања"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;напајање;спавање;обустава;замрзавање;батерија;осветљај;затамњење;"
+"монитор;ДПМС;мировање;Енергија;napajanje;spavanje;obustava;zamrzavanje;"
+"baterija;osvetljaj;mirovanje;Energija;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Штампач „%s“ је обрисан"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Нисам успео да додам нови штампач."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Не могу да учитам сучеље: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Откључај за додавање штампача и промену подешавања"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Штампачи"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Додајте штампаче, погледајте послове штампања и одлучите као желите да "
+"штампате"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"Printer;Queue;Print;Paper;Ink;Toner;штампач;ред;штампа;папир;мастило;тонер;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Додај штампач"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Откључај"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Нисам нашао штампаче"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Унесите адресу мреже или потражите штампач"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Потребно је потврђивање идентитета"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Унесите корисничко име и лозинку да видите штампаче на серверу штампања."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Корисничко име"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Појединости за „%s“"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Нису пронађени одговарајући управљачки програми"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Изаберите ППД датотеку"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Датотеке описа Пост скрипт штампача (*.ppd,*.PPD, *.ppd.gz, *PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Назив штампача не може садржати размак, табулатор, # или /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Место"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Управљачки програм"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Тражим подесне управљачке програме…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Потражите управљачке програме"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Изабери из базе података…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Инсталирај ППД датотеку…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Изаберите управљачки програм штампача"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Учитавам базу података управљачких програма…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Изабери"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Штампач са непосредним млазом"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "ЛПД штампач"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Једнострано"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "По дужој страни (стандардно)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "По краћој страни (окренуто)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Усправно"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Положено"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Обрнуто положено"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Обрнуто усправно"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Настави"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Заустави"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "На чекању"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Заустављен"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Потребно је потврђивање идентитета"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Обрађујем"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Заустављен"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Отказан"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Поништен"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Завршен"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Пребаци овај посао на почетак реда"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u посао захтева потврђивање идентитета"
+msgstr[1] "%u посла захтевају потврђивање идентитета"
+msgstr[2] "%u послова захтева потврђивање идентитета"
+msgstr[3] "Један посао захтева потврђивање идентитета"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — покренути послови"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Унесите пуномоћства да бисте штампали са штампача „%s“."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Домен"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "Потврди _идентитет"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Очисти све"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "Потврди идентитет"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Нема покренутих послова на штампачу"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Откључај сервер штампача"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Откључај „%s“."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Унесите корисничко име и лозинку да видите штампаче на „%s“."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Тражим штампаче"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "УСБ"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Серијски прикључник"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Паралелни прикључник"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Место: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Адреса: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Сервер захтева потврђивање идентитета"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Двострано"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Тип папира"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Извор папира"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Излазна трака"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Резолуција"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Гост скрипт предфилтер"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Страница по листу"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Двострано"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Усмерење"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Опште"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Подешавање странице"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Инстаљиве опције"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Посао"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Квалитет слике"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Боја"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Завршавање"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Напредно"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Пробна страница"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Пробна страница"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Сам одреди"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Подразумевано"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Само угњеждени Гост скрипт фонтови"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Преведи у 1° ниво постскрипта"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Преведи у 2° ниво постскрипта"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Без предфилтрирања"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Произвођач"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Нема активних послова"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u посао"
+msgstr[1] "%u посла"
+msgstr[2] "%u послова"
+msgstr[3] "један посао"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Очистите главе штампача"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Понестаје тонера"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Нема више тонера"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Понестаје развијача"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Нема више развијача"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Понестаје маркера"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Нема више мастила"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Отворен поклопац"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Отворена вратанца"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Понестаје папира"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Нема више папира"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Искључен"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Заустављен"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Посуда за отпад је скоро пуна"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Посуда за отпад је пуна"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Оптички проводник фотографија је при крају живота"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Оптички проводник фотографија више не функционише"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Спреман"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Не прихвата послове"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Обрађује"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Опције штампања"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Појединости штампача"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Подразумевано користи штампач"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Очисти главе штампача"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Уклони штампач"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Мустра"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Нивоа мастила"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Поново покрените када проблем буде решен."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Поново покрени"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Додај штампач…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Нема штампача"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Изгледа да није доступан позадински\n"
+"    програм за штампу."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Облици"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Претражи језике…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Чести формати"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Сви формати"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Нема резултата претраге"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Можете тражити земље или језике."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Преглед"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Империјални"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Метрички"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Датуми"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Датуми и времена"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Бројеви"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Мерење"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Папир"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Језик и формат биће промењени приликом следеће пријаве на систем"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Одјава…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Подешавање језика које се користи за приказ текста и веб страница. Формати "
+"се користе за бројеве, датуме и валуте."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Ваш налог"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Језик"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Формати"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Екран за пријављивање"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Регион и језик"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Изаберите ваш приказни језик и формате"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;језик;распоред;тастатура;унос;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Питај шта да радиш"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Не ради ништа"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Отвори фасциклу"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Остали носачи података"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Изаберите програм за аудио дискове (ЦД)"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Изаберите програм за видео дискове (ДВД)"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Изаберите програм за покретање када је прикључен музички плејер"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Изаберите програм за покретање када је прикључена камера"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Изаберите програм за дискове са софтвером"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "аудио ДВД"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "празан Блу-реј диск"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "празан ЦД диск"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "празан ДВД диск"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "празан ХД ДВД диск"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Блу-реј видео диск"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "читач ел. књига"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "ХД ДВД видео диск"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "ЦД са сликама"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Супер видео ЦД"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Видео ЦД"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Виндоуз програми"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Изаберите како треба да се рукује са носачима података"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "ЦД _аудио"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_ДВД видео"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Музички програм"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Софтвер"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Остали носачи података…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Никада не питај или не покрећи програме након убацивања носача података"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Изаберите како треба да се рукује осталим носачима података"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Радња:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Врста:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Преносни носачи"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Подесите преносне медије"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"уређај;систем;основно;програм;омиљено;цд;двд;усб;звук;снимак;диск;уклоњиви;"
+"медијум;носач;самопокретање;uređaj;sistem;osnovno;program;omiljeno;cd;dvd;"
+"usb;zvuk;snimak;disk;uklonjivi;medijum;nosač;samopokretanje;device;system;"
+"default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;"
+"autorun;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Екран се искључује"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 секунди"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 минут"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 минута"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 минута"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 сат"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 минут"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 минута"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 минута"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 минута"
+
+# bug(danilo): plural-forms
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 минута"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Никада"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Закључавање екрана"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Самостално закључавање екрана спречава неовлашћени приступ рачунару када сте "
+"одсутни."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Застој гашења екрана"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Период мировања након којег ће се екран угасити."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Самостално _закључавање екрана"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Застој _самосталног закључавања екрана"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Период када треба самостално закључати екран, након гашења истог."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Прикажи обавештења _на закључаном екрану"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Забрани нове _УСБ уређаје"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "Спречава нове УСБ уређаје да раде на систему док је екран закључан."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Приватност екрана"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Ограничи угао гледања"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Подешавања екрана"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;екран;закључавање;приватност;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Изабери место"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "У _реду"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Места претраге"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Фасцикле које се претражују унутар системских програма као што су Датотеке, "
+"Фотографије и Видео."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Места"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Обележивачи"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Друго"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Додај место"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Нисам пронашао програме"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Претрага програма"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Укључи и резултате претраге из програма."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Фасцикле које се претражују унутар системских програма."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Резултати претраге"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Резултати су приказани на основу редоследа у списку."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Одлучите који програми ће приказивати резултате претраге у прегледу "
+"активности"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Find;Index;Hide;Privacy;Results;нађи;тражи;пронађи;потражи;попис;"
+"индекс;сакриј;приватност;резултати;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Нису изабране мреже за дељење"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Мреже"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Укљ."
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Искљ."
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Укључено"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Радна"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Изаберите фасциклу"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Додај"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Омогући дељење медија"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Дељење датотека вам омогућава да делите вашу јавну фасциклу са другима на "
+"вашој тренутној мрежи користећи: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Када је укључено удаљено пријављивање, удаљени корисници могу да се повежу "
+"користећи наредбу безбедне шкољке:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Омогући дељење личних датотека"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Назив уређаја копиран"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Адреса уређаја копирана"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Корисничко име копирано"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Лозинка копирана"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Дељење"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Назив рачунара"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Дељење датотека"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Удаљена ра_дна површ"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Дељење _медија"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Удаљено п_ријављивање"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Дељење датотека"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Захтева лозинку"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Удаљено пријављивање"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Удаљена радна површ"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Удаљена радна површ омогућава прегледање и управљање вашег рачунара са "
+"другог уређаја."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Укључите или искључите удаљено пријављивање на овај рачунар."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Даљинско управљање"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Дозволите удаљеним везама управљање вашим екраном."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Како се повезати"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Повежите се на овај рачунар користећи назив уређаја или адресу удаљене радне "
+"површи."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Умножавање"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Адреса удаљене радне површи"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Идентификовање"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "Потребни су корисничко име и лозинка за повезивање на овај рачунар."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Корисничко име"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Потврди шифровање"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Отисак шифровања"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr "Отисак шифровања је видљив долазним клијентима и треба бити исти."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Дељење медија"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Делите музику, фотографије и снимке на мрежи."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Фасцикле"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Одлучите шта желите да делите с другима"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"дели;дељење;ссх;безбедна шкољка;домаћин;назив;удаљено;радна површ;блутут;"
+"обекс;медија;звук;аудио;снимак;видео;слике;фотографије;филмови;сервер;"
+"исцртавач;deli;deljenje;ssh;bezbedna školjka;domaćin;naziv;udaljeno;radna "
+"površ;blutut;obeks;medija;zvuk;audio;snimak;video;slike;fotografije;filmovi;"
+"server;iscrtavač;share;sharing;ssh;host;name;remote;desktop;media;audio;"
+"video;pictures;photos;movies;server;renderer;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Укључите или искључите удаљено пријављивање"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Потребно је потврђивање идентитета за укључивање или искључивање удаљеног "
+"пријављивања"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Произвољно"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Клик"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Ниска"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Замах"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Шум"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Уравнотеженост"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Ишчезавање"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Иза"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Испред"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Испробавам ставку %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Кликни на звучник за пробу"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Системска јачина звука"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Јачина главног звука"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Нивои јачине звука"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Излаз"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Излазни уређај"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Провери"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Подешавање"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Сабвуфер"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Улаз"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Улазни уређај"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Јачина звука"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Звук упозорења"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Утишај"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Звук"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Измените нивое звука, улазе, излазе и звуке упозорења"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+"картица;микрофон;јачина звука;ишчезавање;баланс;равнотежа;блутут;слушалице;"
+"звук;излаз;улаз;kartica;mikrofon;jačina zvuka;iščezavanje;balans;ravnoteža;"
+"blutut;slušalice;zvuk;izlaz;ulaz;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Неповезан"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Повезујем"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Повезан"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Грешка у овлашћивању"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Овлашћујем"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Смањена употребљивост"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Повезани и овлашћени"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Непознато"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Овлашћен у:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Повезан у:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Уписан у:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Нисам успео да овластим уређај: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Нисам успео да заборавим уређај: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Зависи од %u другог уређаја"
+msgstr[1] "Зависи од %u друга уређаја"
+msgstr[2] "Зависи од %u других уређаја"
+msgstr[3] "Зависи од %u другог уређаја"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Затвори обавештење"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Назив:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Стање:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "ЈУИБ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Овласти и повежи"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Заборави уређај"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Грeшкa"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Овлашћен"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Тандерболт подсистем (boltd) није инсталиран или није подешен исправно."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Дозволи директни приступ уређајима као што су докови или спољне графичке."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Могу се качити само УСБ и Дисплеј порт уређаји."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Нема уоченог Тандерболт хардвера.\n"
+"Или систем нема подршку за Тандерболт, или је онемогућен у БИОС-у, или је "
+"постављен на неподржани ниво безбедности у БИОС-у."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Подршка за Тандерболт је искључена у БИОС-у."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Безбедносни ниво Тандерболта се не може утврдити."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Грешка при промени директног режима: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Без подршке за Тандерболт"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Не могу да се повежем на тандерболт подсистем."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Директни приступ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Уређаји на чекању"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Нема закачених уређаја"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Тандерболт"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Управљај Тандерболт уређајима"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;Тандерболт;Тхундерболт;Tanderbolt;приватност;privatnost;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Трепћући показивач"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Показивач трепће унутар текстуалних поља."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Брзина"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Брзина трептања показивача"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Величина показивача"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Величина показивача се може комбиновати са зумом како би показивач био "
+"уочљивији."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Помоћ при клику"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Симулирани секундарни клик"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Укључи/искључи секундарни клик држећи притиснут примарни тастер"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Кашњење прихватања:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Кратак"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Застој секундарног клика"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Велики"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Клик _лебдења"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Укључи/искључи клик када показивач лебди"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Застој:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Кратак"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Велики"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Осетљивост на покрет:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Мали"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Велики"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Понављање тастера"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Притисци тастера се понављају када се тастер држи притиснутим."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Застој понављања тастера"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Брзина понављања тастера"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Помоћ куцања"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Лепљиви тастери"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Схвата низ тастера модификатора као комбинацију тастера"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Искључи ако су два тастера притиснута истовремено"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Запишти када је притиснут _измењивач"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Спори тастери"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Убацује кашњење између притиска тастера и његовог прихватања"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Кратак"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Застој куцања спорих тастера"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Велики"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Запишти када је притиснут _тастер"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Запишти када је тастер _прихваћен"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Запишти када тастер није п_рихваћен"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Одскочни тастери"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Занемарује узастопне двоструке притиске на тастер"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Кратак"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Застој куцања одскочних тастера"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Велики"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Укључи тастатуром"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Укључите/искључите функције приступачности користећи тастатуру"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Основно"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Средњи"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Велики"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Већи"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Највећи"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d пиксел"
+msgstr[1] "%d пиксела"
+msgstr[2] "%d пиксела"
+msgstr[3] "један пиксел"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Увек прикажи изборник приступачности"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Видност"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Велики контраст"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Велики текст"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Омогући а_нимације"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Читач _екрана"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Читач екрана чита приказани текст како померате први план."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Тастери _звука"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Запишти када је закључавање бројева или великих слова укључено или искључено."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Величина _показивача"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Повећај"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Чујност"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Визуелна упозорења"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Тастатура на екрану"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Понављањ_е тастера"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Трептање показивача"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Помоћ при куцању (Икс приступ)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Показивање и кликтање"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Тастери _миша"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Пронађи по_казивач"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Помоћ при _клику"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Застој _дуплог клика"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Застој дуплог клика"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Визуелна упозорења"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Пробни _бљесак"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Користи видно указивање када се деси звук упозорења."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Бљесни целим _екраном"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Бљесни целим п_розором"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Кратко"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "1/4 екрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "1/2 екрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "3/4 екрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Велико"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Цео екран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Горња половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Доња половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Лева половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Десна половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Опције увећања"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Увећавање:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Положај лупе:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "Прати по_казивач миша"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Део _екрана:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Лупа се простире изван _екрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Држи по_казивач лупе по средини"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Показивач лу_пе гура садржаје унаоколо"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Показивач лупе се помера са сад_ржајима"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Лупа"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "У_крштање:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Преклапа п_оказивач миша"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Дебљина:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Танко"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Дебело"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "Тра_јање:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Бо_ја:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Укрштање"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Дејства боје:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Бела на црној:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "Осв_етљење:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Контраст:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Боја"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ништа"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Пун"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Низак"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Висок"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Низак"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Висок"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Дејства боје"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Олакшајте посматрање, слушање, куцање, указивање и кликање"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;тастатура;миш;a11y;приступачност;контраст;"
+"универзални приступ;зум;читач;екран;текст;слова;величина;Икс_приступ;лепљиви;"
+"тастери;спори;одскочни;миш;двоструки;клик;застој;понови;трепни;визуелно;слух;"
+"аудио;звук;куцање;tastatura;miš;pristupačnost;kontrast;zum;čitač;ekran;tekst;"
+"slova;veličina;Iks_pristup;lepljivi;tasteri;spori;odskočni;miš;dvostruki;"
+"klik;zastoj;ponovi;trepni;vizuelno;univerzalni pristup;sluh;audio;zvuk;"
+"kucanje;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 сат"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 дан"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 дана"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 дана"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 дана"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 дана"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 дана"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 дана"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 дана"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 дана"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Да избацим све ставке из смећа?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Све ставке из смећа ће бити трајно уклоњене."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Избаци Смеће"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Да обришем све привремене датотеке?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Све привремене датотеке ће бити трајно обрисане."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Прочисти привремене датотеке"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 дан"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 дана"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 дана"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Заувек"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Историјат датотека"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Историјат датотека садржи записник свих коришћених датотека. Ови подаци се "
+"деле међу програмима и они олакшавају тражење датотека које вам могу бити од "
+"користи."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "_Историјат датотека"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Задржавање историјата датотека"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Очис_ти историјат…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Смеће и привремене датотеке"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Смеће и привремене датотеке некада могу садржати личне или осетљиве податке. "
+"Самосталним брисањем штитите вашу приватност."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Самос_тално бриши садржај смећа"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Самостално бриши при_времене датотеке"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Период самосталног брисања"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Избаци Смеће…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Обриши привремене _датотеке…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Историјат датотека и смеће"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Не остављај трагове"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"коришћење;недавно;историјат;датотеке;привремено;тмп;приватност;смеће;чишћење;"
+"задржавање;korišćenje;nedavno;istorijat;datoteke;privremeno;privatnost;smeće;"
+"čišćenje;zadržavanje;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Треба да подудари веб адресу вашег достављача пријављивања."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Нисам успео да додам налог"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Лозинке се не подударају."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Нисам успео да упишем налог"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Нема подржаног начина за потврђивање идентитета са овим доменом"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Нисам успео да приступим домену"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Неисправно име за пријављивање.\n"
+"Покушајте поново."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Неисправна лозинка за пријављивање.\n"
+"Покушајте поново."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Нисам успео да се пријавим на домен"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Не могу да пронађем домен. Можда сте га погрешно написали?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Додајте корисника"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Администратор"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Администратори могу додавати и уклањати друге кориснике и могу мењати "
+"подешавања свих корисника. Родитељске контроле не могу бити примењене над "
+"администраторима."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Корисник поставља лозинку приликом прве пријаве"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Постави лозинку сада"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Потврди"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Пословна пријава"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Кориснички налози којима управља фирма или организација."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Ван мреже сте"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Пословно пријављивање омогућава постојећем централно управљаном корисничком "
+"налогу да се користи на овом уређају. Такође можете да користите овај налог "
+"да приступите ресурсима предузећа на интернету."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Потражите још слика"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Изаберите датотеку…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Управник отисцима прстију"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Отисак прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Не"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Да"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Да ли желите да обришете забележене отиске прста како би онемогућили "
+"пријављивање путем отиска прста?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Нема читача отиска прста"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Нема читача отиска прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Проверите да ли је уређај исправно прикључен."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Читач отиска прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Изаберите читач отиска прста којег желите подесити"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Пријављивање отиском прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Пријава преко отиска прста вам омогућава да откључате и пријавите се на ваш "
+"рачунар преко прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Обриши отиске прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Уписивање отиска прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "треба бити затражено од уређаја да обави ову радњу"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "уређај је већ затражен другим процесом"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "немате овлашћење да обавите ову радњу"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "никакви исписи нису уписани"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Нисам успео да комуницирам са урђајем за време уписа"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Нисам успео да комуницирам са читачем отисака"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Нисам успео да комуницирам са демоном отисака"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Неуспех при листању отисака прстију: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Неуспех при брисању сачуваних отисака прстију: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Леви палац"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Средњи, леви прст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "_Леви кажипрст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Домали, леви прст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Мали, леви прст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Десни палац"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Десни, средњи прст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "_Десни кажипрст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Десни, домали прсти"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Десни, мали прст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Непознат прст"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Завршено"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Читач отиска прста није прикључен"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Складиште на читачу отиска прста је пуно"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Неуспех при упису новог отиска прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Неуспех при покретању уписа: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Нисам успео да додам нови отисак прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Неуспех при заустављању уписа: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Непрестано подижите и спуштајте ваш прст на читач да бисте уписали ваш "
+"отисак прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "Поно_во упиши овај прст…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Скенирај нови отисак прста"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Нисам успео да отпустим читач отиска прста %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Проблем приликом читања уређаја"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Нисам успео да затражим читач отиска прста %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Нисам успео да добавим читаче отиска прста: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Ове седмице"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Прошле седмице"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Крај сесије"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Почетак сесије"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Активност налога"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Претходно"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Следеће"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Изаберите другу лозинку."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Унесите вашу тренутну лозинку поново."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Лозинка не може бити промењена"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Измените лозинку"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "П_ромени"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Тренутна лозинка"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Нова лозинка"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Потврди лозинку"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Дозволи кориснику да измени лозинку приликом следећег пријављивања"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Постави лозинку сада"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Не могу сам да приступим овој врсти домена"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Није пронађен такав домен или подручје"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Не могу да се пријавим као „%s“ на домену %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Неисправна лозинка, покушајте поново"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Не могу да се повежем на домен „%s“: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Нисам успео да избришем корисника"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Нисам успео да опозовем даљински управљаног корисника"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Не можете обрисати ваш лични налог."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "„%s“ је и даље пријављен"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Брисање корисника док су пријављени може да остави систем у неусклађеном "
+"стању."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Да ли желите да сачувате датотеке корисника „%s“?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Могуће је задржати личну фасциклу, складишта поште и привремене датотеке "
+"приликом брисања корисничког налога."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Обриши датотеке"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Задржи датотеке"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Да ли сигурно желите да опозовете даљински управљани налог корисника „%s“?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Обриши"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Налог је искључен"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "За подешавање приликом наредног пријављивања"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ништа"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Пријављен сам"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Нисам успео да контактирам услугу налога"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Молим проверите да ли је Услуга налога инсталирана и укључена."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Ова површ мора бити откључана пре промене овог подешавања"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Обришите изабрани кориснички налог"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Да обришете изабрани кориснички налог,\n"
+"кликните прво на иконицу *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Откључај за додавање корисника и промену поставки"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Корисници"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Морате поново да покренете сесију како би измене ступиле у дејство"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Поново покрени сада"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Затвори"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Уреди аватар"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Име и презиме"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Уреди"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Пријављивање _отиском прста"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Аутоматско _пријављивање"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Активност налога"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Администратор"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Администратори могу додавати и уклањати друге кориснике и могу мењати "
+"подешавања свих корисника."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "Родитељско у_прављање"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Отворите програм родитељског надзора."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Уклони корисника…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Други корисници"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Додај корисника…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Нисам нашао кориснике"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Откључајте да бисте додали кориснички налог."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Додајте или уклоните кориснике и измените вашу лозинку"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;пријава;"
+"име;назив;отисак;аватар;лого;лице;лозинка;родитељска контрола;време екрана;"
+"ограничени програми;ограничења веба;коришћење;ограничење коришћења;дете;деца;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Упиши"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Пријављивање администратора домена"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Да бисте користили пословна пријављивања, овај рачунар треба да буде\n"
+"уписан у домену. Нека администратор ваше мреже овде упише лозинку\n"
+"њихових домена."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Име _администратора"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Лозинка администратора"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Управљајте корисничким налозима"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Потребно је потврђивање идентитета за промену корисничких података"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Нова лозинка треба да се разликује од старе."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Пробајте да измените нека слова и бројеве."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Пробајте још само мало да измените лозинку."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Лозинка без вашег корисничког имена ће бити јача."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Покушајте да избегнете ваше име у лозинки."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Покушајте да избегнете неке од речи употребљених у лозинки."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Покушајте да избегнете уобичајене речи."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Покушајте да избегнете преуређивање постојећих речи."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Покушајте да користите више бројева."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Покушајте да користите више великих слова."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Покушајте да користите више малих слова."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Покушајте да користите више посебних знакова, као тачка."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Покушајте да користите мешавину слова, бројева и тачака."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Покушајте да избегнете понављање истог знака."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Покушајте да избегнете понављање исте врсте знака: треба да мешате велика "
+"слова, бројеве и тачке."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Покушајте да избегнете низове 1234 или абвг."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Лозинка мора бити дужа. Покушајте да користите мешавину слова, бројева и "
+"тачака."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Мешајте велика и мала слова и пробајте да користите један или два броја."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Додавање још слова, бројева и тачке ће учинити лозинку још јачом."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Потврђивање идентитета није успело"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Нова лозинка је превише кратка"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Нова лозинка је превише једноставна"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Стара и нова лозинка су сувише сличне"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Нова лозинка је већ употребљавана у скорије време."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Нова лозинка мора да садржи нумеричке или специјалне знакове"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Стара и нова лозинка су исте"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Ваша лозинка је измењена од када сте на почетку потврдили идентитет!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Нова лозинка не садржи довољно различитих знакова"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Непозната грешка"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Корисничко име треба да садржи само велика и мала слова латинског алфабета "
+"од а-z, цифре и следеће знакове: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Корисничко име није доступно. Пробајте неко друго."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Корисничко име је предуго."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Мапирај дугмад"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Мапирајте дугмад према функцијама"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Да измените пречицу, изаберите радњу „Пошаљи откуцај тастера“, притисните "
+"дугме пречице тастатуре и држите притиснутим нове тастере или притисните "
+"„Повратницу“ да обришете пречицу."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Затвори"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Молим лупните знаке мете који ће се појавити на екрану да калибришете "
+"таблицу."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Откривен је лош клик, почињем из почетка…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Дугме %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Програм је дефинисан"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Пошаљи откуцај тастера"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Промени монитор"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Прикажи помоћ на екрану"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Таблица закачена на лаптоп"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Таблица закачена на спољни екран"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Спољна таблица"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Спољни пад уређај"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Сви екрани"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Режим таблице"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Користи апсолутно позиционирање за оловку"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Леворуко усмерење"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Таблица и експресни кључеви су обрнути за леворуке"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Мапирај на монитор"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Задржи размеру"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "Користи само део површине таблице због задржавања размере екрана"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Калибриши"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Таблица није откривена"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Повежите или укључите вашу Ваком таблицу."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Осећај притиска савета"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Умекшан"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Притисак типа оловке"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Стојеће"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Button 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Дугме 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Дугме 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Осећај притиска брисача"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Притисак брисача"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Клик средњег дугмета миша"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Клик десног дугмета миша"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Напред"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Ербраш оловка са притиском, нагибом и уграђеним клизачем"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Ербраш оловка са притиском, нагибом и окретањем"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Стандарнда оловка са притиском и нагибом"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Стандардна оловка са притиском"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Ваком таблица"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Подеси мапирање дугмета и подесите осетљивост оловке графичких таблица"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;таблица;ваком;пенкало;брисач;миш;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Нова пречица…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Приступне тачке"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "АПН"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Радња је отказана"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Грешка:</b> Приступ забрањује промену подешавања"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Грешка:</b> Грешка мобилне опреме"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Нерегистрован"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Регистрован"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Роминг"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Претражујем"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Забрањено"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Појединости модема"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Стање модема"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Оператер"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Врста мреже"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Стање мреже"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Сопствени број"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Појединости уређаја"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Издање фирмвера"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Само 2Г"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Само 3Г"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Само 4Г"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Само 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2Г, 3Г, 4Г, 5Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2Г, 3Г, 4Г (пожељно), 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2Г, 3Г (пожељно), 4Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2Г (пожељно), 3Г, 4Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2Г, 3Г, 4Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2Г, 3Г, 4Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2Г, 3Г (пожељно), 4Г"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2Г (пожељно), 3Г, 4Г"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2Г, 3Г, 4Г"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3Г, 4Г, 5Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3Г, 4Г (пожељно), 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3Г (пожељно), 4Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3Г, 4Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2Г, 4Г, 5Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2Г, 4Г (пожељно), 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2Г (пожељно), 4Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2Г, 4Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2Г, 3Г, 5Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2Г, 3Г (пожељно), 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2Г (пожељно), 3Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2Г, 3Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3Г, 4Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3Г (пожељно), 4Г"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3Г, 4Г"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2Г, 4Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2Г (пожељно), 4Г"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2Г, 4Г"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2Г, 3Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2Г (пожељно), 3Г"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2Г, 3Г"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2Г, 5Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2Г (пожељно), 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3Г, 5Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3Г (пожељно), 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4Г, 5Г (пожељно)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4Г (пожељно), 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4Г, 5Г"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Непознато"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Откључај СИМ картицу"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Откључај"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Доставите ПИН код за СИМ %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Упишите ПИН да откључате вашу СИМ картицу"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Доставите ПУК код за СИМ %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Упишите ПУК да откључате вашу СИМ картицу"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Уписана је погрешна лозинка. Остао вам је %1$u покушај"
+msgstr[1] "Уписана је погрешна лозинка. Остала су вам %1$u покушаја"
+msgstr[2] "Уписана је погрешна лозинка. Остало вам је %1$u покушаја"
+msgstr[3] "Уписана је погрешна лозинка. Остао вам је један покушај"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Остао вам је %u покушај"
+msgstr[1] "Остала су вам %u покушаја"
+msgstr[2] "Остало вам је %u покушаја"
+msgstr[3] "Остао вам је један покушај"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Уписали сте погрешну лозинку."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "ПУК код треба бити број од 8 цифара"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Упишите нови ПИН"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "ПИН код треба бити број од 4-8 цифара"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Откључавам…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Нема СИМ-а"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Уметните СИМ картицу да бисте користили овај модем"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "СИМ је закључана"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Мобилни подаци"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Приступите подацима користећи мобилну мрежу"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Роминг података"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Користите мобилне податке када сте у ромингу"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Мреж_ни режим"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "Мр_ежа"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Напредно"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Називи приступне тачке"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Закључај _СИМ"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Закључајте СИМ ПИН-ом"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "П_ојединости модема"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Неуспех у телефону"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Нема везе са телефоном"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Радња није допуштена"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Радња није подржана"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "СИМ није убачен"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Потребан је СИМ ПИН"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Потребан је СИМ ПУК"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Неуспех СИМ-а"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "СИМ је заузета"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Нетачна лозинка"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Потребан је СИМ ПИН2"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Потребан је СИМ ПУК2"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Није пронађено"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Нема мрежне услуге"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Мрежа је истекла"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "ГПРС услуге нису дозвољене"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Ромин није дозвољен у овој области"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Неодређена ГПРС грешка"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Нема грешака"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Радња је отказана"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Приступ одбијен"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Непозната грешка"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Мрежни режим"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Самостално"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Изабери мрежу"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Освежите достављаче мреже"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "СИМ %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Омогући мобилну мрежу"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Нисам нашао мобилни адаптер"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Проверите да ли сте прикључили и упалили мобилни адаптер"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Мобилна мрежа је искључена када је авионски режим рада укључен"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Искључи авионс_ки режим рада"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Податковна веза"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "СИМ картица за интернет"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "СИМ закључавање"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Следеће"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Закључај СИМ ПИН-ом"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Промени ПИН"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Упишите текући ПИН да измените поставке закључавања СИМ-а"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Мобилна мрежа"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Подесите везе мобилних података и телефоније"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "целулар;телефонија;сим;мобилна;cellular;wwan;telephony;sim;mobile;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Алатка за подешавање Гномовог радног окружења"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Подешавања су главно средство за подешавање вашег система."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Гном пројекат"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Број издања приказа"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Укључује режим исписивања"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Тражи ниску"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Исписује могуће називе површи и излази"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Површ за приказ"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[ПОВРШ] [АРГУМЕНТ…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Категорије подешавања"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Приватност"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Доступне површи:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Сва подешавања"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Главни изборник"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Упозорење: развојно издање"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Ово издање Подешавања се треба користити само у пробне сврхе. Можете "
+"искусити неисправно понашање система, губитак података и друге непредвиђене "
+"проблеме. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Помоћ"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Опште"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Излазак"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Претрага"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Површи"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Иди на претходну површ"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Откажи претрагу"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;поставке;подешавања;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Одредник последње отворене површи Подешавања"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Одредник последње отворене површи Подешавања. Вредности које нису препознате "
+"ће бити прескочене и прва површ из списка биће одабрана."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Прикажи упозорење када је покренуто развојно издање Подешавања"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Да ли Подешавања треба да приказују упозорење ако је покренуто развојно "
+"издање."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Почетно стање прозора"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Торка која садржи почетну висину и ширину прозора програма и стање "
+"увећаности."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u излаз"
+msgstr[1] "%u излаза"
+msgstr[2] "%u излаза"
+msgstr[3] "Један излаз"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u улаз"
+msgstr[1] "%u улаза"
+msgstr[2] "%u улаза"
+msgstr[3] "Један улаз"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Системски звуци"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "ДЕР или ПЕМ уверења (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Додај штампач…"
+
+#~ msgid "Light"
+#~ msgstr "Светли"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "екран;закључај;дијагноза;пад;урушавање;лично;скорашње;недавно;привремен;"
+#~ "прв;попис;назив;мрежа;идентитет;"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Ређање екрана"
+
+#~ msgid "Set"
+#~ msgstr "Постави"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Закључајте ваш екран"
+
+#~ msgid "Bark"
+#~ msgstr "Лавеж"
+
+#~ msgid "Drip"
+#~ msgstr "Капање"
+
+#~ msgid "Glass"
+#~ msgstr "Стакло"
+
+#~ msgid "Sonar"
+#~ msgstr "Сонар"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Површ звука Гномових Подешавања"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Површ Гномових Подешавања за миш и додирну таблу"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Површ позадине Гномових Подешавања"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Површ тастатуре Гномових Подешавања"
+
+#~ msgid "Web Links"
+#~ msgstr "Веб везе"
+
+#~ msgid "Git Links"
+#~ msgstr "Гит везе"
+
+#~ msgid "%s Links"
+#~ msgstr "%s везе"
+
+#~ msgid "Unset"
+#~ msgstr "Расподеси"
+
+#~ msgid "Links"
+#~ msgstr "Везе"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Хипертекстуалне датотеке"
+
+#~ msgid "Text Files"
+#~ msgstr "Текстуалне датотеке"
+
+#~ msgid "Image Files"
+#~ msgstr "Слике"
+
+#~ msgid "Font Files"
+#~ msgstr "Фонтови"
+
+#~ msgid "Archive Files"
+#~ msgstr "Архивирање датотека"
+
+#~ msgid "Package Files"
+#~ msgstr "Паковање датотека"
+
+#~ msgid "Audio Files"
+#~ msgstr "Звучни записи"
+
+#~ msgid "Video Files"
+#~ msgstr "Видео записи"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Овлашћења и приступ"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Подаци и услуге које је затражио овај програм и његова потребна овлашћења."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Непромењиво"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Појединачна овлашћења програма се могу погледати у одељку <a href="
+#~ "\"privacy\">Приватност</a>, у Подешавањима."
+
+#~ msgid "Integration"
+#~ msgstr "Уграђивање"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Подеси радну позадину"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Подразумевани управљачи"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Врсте датотека и веза које овај програм отвара."
+
+#~ msgid "Usage"
+#~ msgstr "Употреба"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Колико ресурса овај програм користи."
+
+#~ msgid "Open in Software"
+#~ msgstr "Отвори у Програмима"
+
+#~ msgid "Activities"
+#~ msgstr "Активности"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Дозвољава програмима испод да користе вашу камеру."
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Нисам успео да отпремим датотеку: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Профил је отпремљен у:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Запишите ову адресу."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Поново покрените овај рачунар и учитајте ваш уобичајени оперативни систем."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Упишите адресу у ваш прегледник да преузмете и да инсталирате профил."
+
+#~ msgid "Upload profile"
+#~ msgstr "Отпремите профил"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Захтева Интернет везу"
+
+#~ msgid "_Copy"
+#~ msgstr "_Умножи"
+
+#~ msgid "Select _All"
+#~ msgstr "Изабери _све"
+
+#~ msgid "Single Display"
+#~ msgstr "Један екран"
+
+#~ msgid "Join Displays"
+#~ msgstr "Спојени екрани"
+
+#~ msgid "Display Mode"
+#~ msgstr "Режим екрана"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Превуците екране да одговарају вашем физичком распореду екрана. Изаберите "
+#~ "екран за измену његових подешавања."
+
+#~ msgid "Active Display"
+#~ msgstr "Радни екран"
+
+#~ msgid "More Warm"
+#~ msgstr "Више топло"
+
+#~ msgid "Less Warm"
+#~ msgstr "Мање топло"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Чува снимак у фасциклу „$PICTURES“"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Чува снимак прозора у фасциклу „$PICTURES“"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Чува снимак области у фасциклу „$PICTURES“"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Умножава снимак у бележницу"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Умножава снимак прозора у бележницу"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Умножава снимак области у бележницу"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Снимите кратак радни ток екрана"
+
+#~ msgid "Move up"
+#~ msgstr "Помери горе"
+
+#~ msgid "Move down"
+#~ msgstr "Помери доле"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Услуге места омогућавају програмима да знају вашу локацију. Тачност је "
+#~ "повећана укључивањем бежичне картице и мобилне широкопојасне мреже."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Користи Мозилину услугу локације: <a href='https://location.services."
+#~ "mozilla.com/privacy'>политика приватности</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Дозвољава програмима испод да утврде ваше место становања."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Дозвољава програмима испод да користе ваш микрофон."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Време за дупли клик"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s ВПН"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Дугме за гашење и обуставу"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Уочен је рад на крилу: најбржи режим није доступан"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Висока температура хардвера: најбржи режим није доступан"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Најбржи режим није доступан"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Потврди идентитет"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Изаберите формат бројева, датума и валута. Промене ће бити примењене при "
+#~ "следећем пријављивању."
+
+#~ msgid "My Account"
+#~ msgstr "Мој налог"
+
+#~ msgid "Language"
+#~ msgstr "Језик"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Језик коришћен за текст у прозорима и веб страницама."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Поново покрените сесију како би измене ступиле у дејство"
+
+#~ msgid "Restart…"
+#~ msgstr "Поново покрени…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Подешавања пријављивања користе сви корисници када се пријављују на систем"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Управља приказом резултата претраге у прегледу активности. Редослед "
+#~ "резултата претраге се може променити померањем редова у списку."
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Дељење екрана омогућава удаљеним корисницима да виде или да управљају "
+#~ "вашим екраном тако што ће се повезати на %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Дељење е_крана"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Неке услуге су искључене јер нема приступа на мрежу."
+
+#~ msgid "_Password:"
+#~ msgstr "_Лозинка:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Прикажи лозинку"
+
+#~ msgid "Access Options"
+#~ msgstr "Могућности приступа"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Нове везе морају затражити приступ"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Захтевај лозинку"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Тастери звука"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Читач екрана"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Читач екрана"
+
+#~ msgid "Standard"
+#~ msgstr "Стандардни"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Врста налога"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Дозволи кориснику да подеси _лозинку приликом следећег пријављивања"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Постави лозинку са_да"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Морате бити на мрежи да бисте додали пословне кориснике."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Снимите слику…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Да направите измене,\n"
+#~ "кликните прво на иконицу *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Направите кориснички налог"
+
+#~ msgid "User Icon"
+#~ msgstr "Иконица корисника"
+
+#~ msgid "Account Settings"
+#~ msgstr "Подешавања налога"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Потврђивање идентитета и пријава"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Биће коришћено за именовање ваше личне фасцикле и не може бити измењено."
+
+#~ msgid "Output:"
+#~ msgstr "Излаз:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Задржи однос размере (црне траке):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Мапирај на једном монитору"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d од %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Приказује мапирање"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Таблица (апсолутно)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Додирна табла (релативно)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Поставке таблице"
+
+#~ msgid "_Help"
+#~ msgstr "По_моћ"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Подешавања Блутута"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Режим праћења"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Мапирај дугмад…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Дотерајте подешавања миша"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Подесите резолуцију приказа"
+
+#~ msgid "No stylus found"
+#~ msgstr "Нисам нашао оловку"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Приближите вашу оловку табличном уређају да га подесите"
+
+#~ msgid "Top Button"
+#~ msgstr "Горње дугме"
+
+#~ msgid "Lower Button"
+#~ msgstr "Доње дугме"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Најниже дугме"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Откључавам..."
+
+#~| msgid "Keyboard Shortcuts"
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Пречице тастатуре"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Ово можете изменити у „Прилагоди пречице“"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Држите тастер притиснутим и куцајте за унос других знакова"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Осветљај _екрана"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Осветљај _тастатуре"
+
+#~| msgid "_Dim Screen When Inactive"
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Затамни екран када је нерадан"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Празан екран"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Бежична"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Искључите бежичну картицу да бисте уштедели батерију."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Искључите мобилни интернет (3Г, 4Г, ЛТЕ, итд.) да бисте уштедели батерију."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Блутут"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Искључите блутут да бисте уштедели батерију."
+
+#~| msgid "Balance"
+#~ msgid "Balanced Power"
+#~ msgstr "Уравнотежено напајање"
+
+#~ msgid "Add…"
+#~ msgstr "Додај…"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "пријављивање;име;отисак прстију;аватар;лого;лице;лозинка;Login;Name;"
+#~ "Fingerprint;Avatar;Logo;Face;Password;"
+
+#~ msgid "Left Alt"
+#~ msgstr "Леви алт"
+
+#~ msgid "Right Alt"
+#~ msgstr "Десни алт"
+
+#~ msgid "Left Super"
+#~ msgstr "Леви супер"
+
+#~ msgid "Right Super"
+#~ msgstr "Десни супер"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Десни ктрл"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Тастери заменских знакова"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Измењивачи само пребацују на следећи извор"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Тастер изборника"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Пуни се"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Упозорење"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Скоро празна"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Пуна"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Потпуно пуна"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Празна"
+
+#~ msgid "Previous source"
+#~ msgstr "Претходни извор"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Супер+Shift+Размак"
+
+#~ msgid "Next source"
+#~ msgstr "Следећи извор"
+
+#~ msgid "Super+Space"
+#~ msgstr "Супер+Размак"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Леви+десни Alt"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Додајте кориснике и мењајте лозинке"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Пуштање и снимање звука"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr ""
+#~ "Уочавање мрежних уређаја преко мДНС/ДНС-СД протокола (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Непосредан приступ блутут хардверу"
+
+#~ msgid "Use your camera"
+#~ msgstr "Коришћење ваше камере"
+
+#~ msgid "Print documents"
+#~ msgstr "Штампа документа"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Коришћење било ког повезаног џојстика"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Дозволи повезивање на услугу Докер"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Подешава мрежни заштитни зид"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Подешавање и коришћење повлашћених ФУСЕ система датотека"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Ажурира фирмвер на овом уређају"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Приступа подацима о хардверу"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Достављање ентропије хардверском генератору насумичних бројева"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Коришћење хардверски генерисаних насумичних бројева"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Приступ датотекама у личној фасцикли"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Приступ услузи либвирт"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Мења језик система и подешавања региона"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Промена подешавања и достављача локације"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Читање системских и програмских записника"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "приступ media-hub услузи"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Коришћење и подешавање модема"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Читање података о системским закаченим уређајима и квотама дискова"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Управљање музичким и видео пуштачима (плејерима)"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Мења подешавања мреже на нижем нивоу"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Приступ услузи Управник Мрежа за читање и промену мрежних подешавања"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Читање мрежних подешавања"
+
+#~ msgid "Change network settings"
+#~ msgstr "Мења подешавања мреже"
+
+#~ msgid "Read network settings"
+#~ msgstr "Чита подешавања мреже"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Приступ услузи офоно за читање и промену мрежних подешавања мобилне "
+#~ "телефоније"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Управљање хардвером Open vSwitch"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Читање са ЦД/ДВД носача"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Читање, додавање, промена или уклањање сачуваних лозинки"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Приступ уређајима pppd и ppp за подешавање веза које користе од тачке до "
+#~ "тачке протокол"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Паузирање или окончавање било ког процеса на систему"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Непосредан приступ УСБ хардверу"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Читање и писање на преносним уређајима за складиштење података"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Спречавање закључавања и успављивања екрана"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Приступ хардверу са серијским прикључком"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Поновно покретање или гашење уређаја"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Инсталирање, уклањање и подешавање софтвера"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Приступ радном оквиру за складиштење"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Читање података о процесима и систему"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Надгледање и управљање било којим покренутим програмом"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Мења време и датум"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Мења подешавања мрежног времена"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Мења временску зону"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr "Приступ услузи UDisks2 за управљање дисковима и преносним уређајима"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Читање или промена дељених календарских догађаја у Убунту Јунити 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Читање или промена дељених контаката у Убунту Јунити 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Приступ подацима о потрошњи енергије"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Отворен приступ за читање или писање У2Ф уређаја"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Универзални приступ"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Искључите да се повежете на бежичну мрежу"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Лозинка"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Да направите кориснички налог,\n"
+#~ "кликните прво на иконицу *"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Омогући пријављивање отиском прста"
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Остали прсти:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Ваш отисак прста је успешно сачуван. Сада се можете пријавити на систем "
+#~ "преко читача отисака прстију."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Немате дозволе за приступ овом уређају. Контактирајте вашег "
+#~ "администратора система."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Дошло је до грешке унутар програма."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Да обришем забележене отиске прста?"
+
+#~ msgid "Done!"
+#~ msgstr "Готово!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Не могу да приступим уређају „%s“"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Не могу да ухватим отисак прста са уређаја „%s“"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Не могу да приступим ниједном читачу отисака прстију"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Јавите се администратору система за помоћ."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Морате сачувати један од ваших отисака прста са уређаја „%s“, како би "
+#~ "омогућили пријаву на систем отиском прста."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Бирам прст"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Подеси позадину и екран закључавања"
+
+#~ msgid "Set Background"
+#~ msgstr "Подеси позадину"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Подеси екран закључавања"
+
+#~ msgid "Remove Background"
+#~ msgstr "Уклони позадину"
+
+#~ msgid "Version %s"
+#~ msgstr "Издање %s"
+
+#~ msgid "OS name"
+#~ msgstr "Назив ОС-а"
+
+#~ msgid "OS type"
+#~ msgstr "Врста ОС-а"
+
+#~ msgid "Disk"
+#~ msgstr "Диск"
+
+#~ msgid "Check for updates"
+#~ msgstr "Проверавам ажурирања"
+
+#~ msgid "Network proxy"
+#~ msgstr "Мрежни посредник"
+
+#~ msgid "page 1"
+#~ msgstr "страна 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Унутрашња _пријава"
+
+#~ msgid "page 2"
+#~ msgstr "страна 2"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "Ограничи позадинску употре_бу података"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Прикладно за везе које имају ограничење података или се наплаћују."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Уплетени пар (ТП)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Сучеље јединице прикачињања (АУИ)"
+
+#~ msgid "BNC"
+#~ msgstr "БНЦ"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Сучеље независног медија (МИИ)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 MB/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 MB/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 GB/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 GB/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Укључивањем бежичне вруће тачке прекинућете везу са <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Није могуће приступити Интернету преко ваше бежичне док је укључена врућа "
+#~ "тачка."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Бежичне вруће тачке се обично користе за дељење додатне интернет везе "
+#~ "бежичним путем."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Самостално _повежи"
+
+#~ msgid "details"
+#~ msgstr "појединости"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Прикажи _лозинку"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Учини доступно другим корисницима"
+
+#~ msgid "identity"
+#~ msgstr "идентитет"
+
+#~ msgid "IPv_4"
+#~ msgstr "ИПв_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Адреса"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Само самосталне (ДХЦП) адресе"
+
+#~ msgid "Link-local only"
+#~ msgstr "Само вежи-локално"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Занемари аутоматски добијене руте"
+
+#~ msgid "ipv4"
+#~ msgstr "ипв4"
+
+#~ msgid "IPv_6"
+#~ msgstr "ИПв_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ипв6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Клонирана МАЦ адреса"
+
+#~ msgid "_Reset"
+#~ msgstr "_Поново постави"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Поново ће поставити подешавања ове везе на њихова основна, али ће је "
+#~ "упамтити као жељену везу."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Уклониће све податке који се односе на ову мрежу и неће покушати да се "
+#~ "сам повеже на њу."
+
+#~ msgid "Hardware"
+#~ msgstr "Уређаји"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Поново постави"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Прикључени уређаји"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ад-хок"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Инфраструктурно"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Облачићи _обавештења"
+
+#~ msgid "In use"
+#~ msgstr "Користи се"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Укљ."
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Искљ."
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Искљ."
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Укљ."
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Искљ."
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Укљ."
+
+#~ msgid "Usage & History"
+#~ msgstr "Употреба и историјат"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Политика приватности"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Памћење историјата олакшава поновно проналажење неких ствари. Те ставке "
+#~ "се никада не деле преко мреже."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Скоро коришћено"
+
+#~ msgid "Retain _History"
+#~ msgstr "Задржи _историјат"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Закључавање екрана штити вашу приватност када сте одсутни."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "_Закључај екран након затамњења од"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "_Обавештења на екрану закључавања"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Самостално ће прочистити смеће и привремене датотеке да би вам помогао да "
+#~ "одржите рачунар слободним од непотребних осетљивих података."
+
+#~ msgid "Purge _After"
+#~ msgstr "Прочисти _након"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Слањем података о софтверу који користите ви нам помажете да вам "
+#~ "доставимо тачније препоруке. Такође нам помажете да побољшамо наш "
+#~ "софтвер.\n"
+#~ "\n"
+#~ "Прикупљање свих података се ради у тајности, и никада ваше податке нећемо "
+#~ "делити са трећим лицима."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Пошаљи податке о коришћењу софтвера"
+
+#~ msgid "_Camera"
+#~ msgstr "_Камера"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Микрофон"
+
+#~ msgid "_Location Services"
+#~ msgstr "Услуге _места"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Заштитите ваше личне податке и одлучите шта други могу да виде"
+
+#~ msgid "No regions found"
+#~ msgstr "Нисам пронашао подручја"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Бљесни насловом _прозора"
+
+#~ msgid "Last Login"
+#~ msgstr "Последње пријављивање"
+
+#~ msgid "_Background"
+#~ msgstr "_Позадина"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Мења се током целог дана"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Поплочано"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Увећано"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Центрирано"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Сразмерно"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Попуњено"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Распрострто"
+
+#~ msgid "Colors"
+#~ msgstr "Боје"
+
+#~ msgid "Pictures"
+#~ msgstr "Слике"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Нисам пронашао слике"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Можете да додате слике у вашу фасциклу %s и оне ће бити приказане овде"
+
+#~ msgid "_Off"
+#~ msgstr "_Иск."
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Веза/назив мреже"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Сам обустави"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Када је дугме за напајање притиснуто"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Корисничко име не може почети са „-“."
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Ноћно светло"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Не могу да добијем податке о екрану"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Пребаците се на претходни извор"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Пребаците се на следећи извор"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Заменски прелазак на следећи извор"
+
+#~ msgid "_Options"
+#~ msgstr "_Опције"
+
+#~ msgid "Add input source"
+#~ msgstr "Додај извор улаза"
+
+#~ msgid "Remove input source"
+#~ msgstr "Уклони изворе улаза"
+
+#~ msgid "Move input source up"
+#~ msgstr "Премести извор улаза горе"
+
+#~ msgid "Move input source down"
+#~ msgstr "Премести извор улаза доле"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Прикажи распоред тастатуре извора улаза"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Лево"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Десно"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Најмање"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Највише"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Сабвуфер:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Профил:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Провери звучнике"
+
+#~ msgid "Peak detect"
+#~ msgstr "Откривање врхунца"
+
+#~ msgid "Device"
+#~ msgstr "Уређај"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Провера звучника за „%s“"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Изаберите уређај као звучни и_злаз:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Подешавања за изабрани уређај:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Јачина _улазног звука:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Изаберите уређај као звучни у_лаз:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Звучни ефекти"
+
+#~ msgid "Built-in"
+#~ msgstr "Уграђен"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Поставке звука"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Провера звучног сигнала"
+
+#~ msgid "From theme"
+#~ msgstr "Из теме"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Изаберите звук за _упозорење:"
+
+#~ msgid "Stop"
+#~ msgstr "Заустави"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Стандардни"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Администратор"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Гномов Управљачки Центар"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Управљачки центар је главно Гномово сучеље за подешавање различитих "
+#~ "делова вашег система."
+
+#~ msgid "Quit"
+#~ msgstr "Изађи"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "hardware"
+#~ msgstr "уређаји"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Енглески (Велика Британија)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Велика Британија"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Потврди нову лозинку"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Лозинке се не подударају."
+
+#~ msgid "page 3"
+#~ msgstr "страна 3"
+
+#~ msgid "Show the overview"
+#~ msgstr "Приказује преглед"
+
+#~ msgid "Back­ground"
+#~ msgstr "Позадина"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Блутут"
+
+#~ msgid "Co­lor"
+#~ msgstr "Боја"
+
+#~ msgid "Overview"
+#~ msgstr "Преглед"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Основни програми"
+
+#~ msgid "Ab­out"
+#~ msgstr "Опис"
+
+#~ msgid "De­tails"
+#~ msgstr "Појединости"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Преносни медији"
+
+#~ msgid "Net­work"
+#~ msgstr "Мрежа"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Обавештења"
+
+#~ msgid "Po­wer"
+#~ msgstr "Напајање"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Приватност"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Дељење"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Универзални приступ"
+
+#~ msgid "Disable image"
+#~ msgstr "Искључи слику"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Потражите још слика…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Користи је „%s“"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Ваком таблица"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Уређаји"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Систем"
+
+#~| msgid "_Apply"
+#~ msgid "Apply"
+#~ msgstr "Примени"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Спуштен поклопац"
+
+#~ msgid "Mirrored"
+#~ msgstr "Пресликано"
+
+#~ msgid "Secondary"
+#~ msgstr "Споредни"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Распоредите обједињене приказе"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Превуците приказе да их прераспоредите"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d херца (НТСЦ)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d херца"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Супротно смеру казаљке на сату за 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Заокрени за 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "У смеру казаљке на сату за 90°"
+
+#~ msgid "Size"
+#~ msgstr "Величина"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Прикажи горњу траку и преглед активности на овом приказу"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Придружите овај приказ са другим да направите додатни радни простор"
+
+#~ msgid "Presentation"
+#~ msgstr "Излагање"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Прикажите само покретне приказе и медије"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Прикажите ваш постојећи преглед на оба приказа"
+
+#~ msgid "Turn Off"
+#~ msgstr "Искључи"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Не користи овај приказ"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Распореди обједињене приказе"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-бита (ИБ изградње: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d бита"
+
+#~ msgid "Base system"
+#~ msgstr "Основни систем"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "пречица;понови;трепни;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Притисни Есц да откажете."
+
+#~ msgid "Server"
+#~ msgstr "Сервер"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Обриши ДНС сервер"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Учини доступно другим _корисницима"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Област _мрежне баријере"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Основно"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Област одређује ниво поверења везе"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Поново постави подешавања за ову мрежу, укључујући лозинке, али је "
+#~ "запамти као жељену мрежу"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Уклони све податке који се односе на ову мрежу и немој покушати да се сам "
+#~ "повежеш"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Ако имате неку другу везу на Интернет осим бежичне, можете да подесите "
+#~ "бежичну врућу тачку да делите везу са другима."
+
+#~ msgid "Proxy"
+#~ msgstr "Посредник"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Додај профил…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Ништа"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Ручно"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Аутоматски"
+
+#~ msgid "VPN Type"
+#~ msgstr "ВПН врста"
+
+#~ msgid "Group Name"
+#~ msgstr "Назив групе"
+
+#~ msgid "Group Password"
+#~ msgstr "Лозинка групе"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Користи као врућу тачку…"
+
+#~ msgid "_History"
+#~ msgstr "_Историјат"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Покушајте да додате још слова, бројева и симбола."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Јачина: слаба"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Јачина: солидна"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Јачина: осредња"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Јачина: добра"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Јачина: одлична"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Ваш налог</small>"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Врпце обавештења"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Врпце о_бавештења"
+
+#~ msgid "Add Account"
+#~ msgstr "Додај налог"
+
+#~ msgid "Mail"
+#~ msgstr "Ел. пошта"
+
+#~ msgid "Calendar"
+#~ msgstr "Календар"
+
+#~ msgid "Contacts"
+#~ msgstr "Контакти"
+
+#~ msgid "Chat"
+#~ msgstr "Ћаскање"
+
+#~ msgid "Error creating account"
+#~ msgstr "Грешка у стварању налога"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Да ли сте сигурни да желите да уклоните налог?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Ово неће уклонити налог на серверу."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Нису подешени налози на мрежи"
+
+#~ msgid "Add an online account"
+#~ msgstr "Додајте налог на мрежи"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Додавање налога омогућава вашим апликацијама да му приступе због "
+#~ "докумената, поште, контаката, календара, ћаскања и других ствари."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Подешавам"
+
+#~ msgid "Toner Level"
+#~ msgstr "Ниво тонера"
+
+#~ msgid "Supply Level"
+#~ msgstr "Ниво залиха"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Инсталирам"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u покренут"
+#~ msgstr[1] "%u покренута"
+#~ msgstr[2] "%u покренутих"
+#~ msgstr[3] "Један покренут"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Додај нови штампач"
+
+#~ msgid "No printers detected."
+#~ msgstr "Нема откривених штампача."
+
+#~ msgid "Supply"
+#~ msgstr "Залихе"
+
+#~ msgid "Jobs"
+#~ msgstr "Послови"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Прикажи _послове"
+
+#~ msgid "label"
+#~ msgstr "натпис"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Одштампај _пробну страницу"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s — %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Остали налози"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Горе"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Доле"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Ништа"
+
+#~ msgid "Left Ring"
+#~ msgstr "Леви прстен"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Режим левог прстена #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Режим десног прстена #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Лева додирна трака"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Режим леве додирне траке #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Десна додирна трака"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Режим десне додирне траке #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Режим прекидача левог додирног прстена"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Режим прекидача десног додирног прстена"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Режим прекидача леве додирне траке"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Режим прекидача десне додирне траке"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Режим прекидача #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Лево дугме #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Десно дугме #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Горње дугме #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Доње дугме #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Без радње"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Клик левог дугмета миша"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Клизај на горе"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Клизај на доле"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Клизај десно"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr "Пречица тастатуре за <b>%s</b>. Унесите нову пречицу да иземните."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Да измените пречицу, кликните на одговарајући ред и укуцајте нову "
+#~ "комбинацију тастера или притисните „Backspace“ да обришете пречицу."
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Уклони пречицу"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Непозната радња>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Пречица „%s“ не може бити коришћена јер ће бити немогуће куцати користећи "
+#~ "овај тастер.\n"
+#~ "Пробајте да придодате тастер као што је „Цтрл, Алт или Шифт“."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Пречица „%s“ се већ користи за\n"
+#~ "„%s“"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "Уколико доделите пречицу за „%s“, пречица „%s“ ће бити искључена."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Поново додели"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "„%s“ пречица има придружену „%s“ пречицу. Да ли желите да је самостално "
+#~ "подесите на „%s“?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "„%s“ је тренутно придружена са „%s“, ова пречица ће бити искључена ако "
+#~ "наставите."
+
+#~ msgid "_Assign"
+#~ msgstr "_Додели"
+
+#~ msgid "Bond"
+#~ msgstr "Веза"
+
+#~ msgid "Team"
+#~ msgstr "Екипа"
+
+#~ msgid "Bridge"
+#~ msgstr "Мост"
+
+#~ msgid "VLAN"
+#~ msgstr "ВЛАН"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Не могу да учитам ВПН прикључке"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Додавање мрежне везе"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Поданици свезе"
+
+#~ msgid "(none)"
+#~ msgstr "(ништа)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Поданици моста"
+
+#~ msgid "Team slaves"
+#~ msgstr "Поданици тима"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "Инфинибанд уређаји не подржавају повезани режим"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Није изабрано уверење издавача овлашћења"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Уколико не изаберете уверење издавача овлашћења (ЦА) ваша бежична веза "
+#~ "може бити несигурна или лажна.  Да ли желите да изаберете уверење?"
+
+#~ msgid "Ignore"
+#~ msgstr "Занемари"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Изаберите ЦА уверење"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Увек затражи _лозинку"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Не _упозоравај ме више"
+
+#~ msgid "Yes"
+#~ msgstr "Да"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Грешка пријављивања на налог"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Пуномоћства су истекла."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Учланите се да укључи овај налог."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Учлани ме"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Друго"
+
+#~ msgid "_Verify"
+#~ msgstr "_Потврди"
+
+#~ msgid "Login History"
+#~ msgstr "Историјат пријављивања"
+
+#~ msgid "Add User Account"
+#~ msgstr "Додај кориснички налог"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Корисник са корисничким именом „%s“ већ постоји."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Користи се за одређивање вашег географског положаја"
+
+#~ msgid "Done"
+#~ msgstr "Обављено"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Временска _зона"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Настави штампање"
+
+# раније је било „савети“, али можда је боље „хинтови“
+#~ msgid "Pause Printing"
+#~ msgstr "Паузирај штампање"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Задржан"
+
+#~ msgid "Job Title"
+#~ msgstr "Назив посла"
+
+#~ msgid "Job State"
+#~ msgstr "Стање посла"
+
+#~ msgid "Password:"
+#~ msgstr "Лозинка:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "По_нављање тастера"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "Тр_ептање показивача"
+
+#~ msgid "Zoom"
+#~ msgstr "Увећано"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Боја"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Застој:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Кратак"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Мала"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Велики"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Велика"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Брзина:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Испробајте ваша подешавања"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Мала"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Велика"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Лево"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Десно"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Брзина показивача"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Мала"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Велика"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Мала"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Велика"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Додај нови штампач"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Бежични уређаји захтевају додатно напајање"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Кад је напајање батерије _критично"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Дељење блутута вам омогућава да делите датотеке са другим укљученим "
+#~ "блутут уређајима"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Само примај са поверљивих уређаја"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Сачувај примљене датотеке у фасциклу преузимања"
+
+#~ msgid "Show help options"
+#~ msgstr "Приказује опције за помоћ"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Покрените „%s --help“ да ​​видите потпун списак доступних опција линије "
+#~ "наредби.\n"
+
+#~ msgid "United States"
+#~ msgstr "Сједињене Америчке Државе"
+
+#~ msgid "Spain"
+#~ msgstr "Шпанија"
+
+#~ msgid "China"
+#~ msgstr "Кина"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Искључи док _куцам"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Мрежни сервис на систему није подржан у овој верзији."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Прикажи искачуће врпце"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Прегледај у екрану закључавања"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Прикажи искачуће врпце"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Искључите бежичне уређаје"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Потражите штампаче на мрежи или издвојте резултате"
+
+#~ msgid "Sorry"
+#~ msgstr "Извините"
+
+#~ msgid "Immediately"
+#~ msgstr "Одмах"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Дели медије на овој мрежи"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Дељене фасцикле"
+
+#~ msgid "column"
+#~ msgstr "колона"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Уклони фасциклу"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Дели јавну фасциклу на овој мрежи"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Подеси нови уређај"
+
+#~ msgid "Paired"
+#~ msgstr "Упарен"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Подешавања миша и додирне табле"
+
+#~ msgid "Send Files…"
+#~ msgstr "Пошаљи датотеке…"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Видљивост за „%s“"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Да уклоним „%s“ са списка уређаја?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Уколико уклоните уређај, мораћете поново да га подесите пре следећег "
+#~ "коришћења."
+
+#~ msgid "Export"
+#~ msgstr "Извези"
+
+#~ msgid "Device type:"
+#~ msgstr "Врста уређаја:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Произвођач:"
+
+#~ msgid "Model:"
+#~ msgstr "Модел:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Датотеке слика могу бити превучене на овај прозор да аутоматски допуне "
+#~ "одговарајућа поља."
+
+#~ msgid "Left Shift"
+#~ msgstr "Леви шифт"
+
+#~ msgid "Right Shift"
+#~ msgstr "Десни шифт"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Леви алт+шифт"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Леви ктрл+шифт"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Десни ктрл+шифт"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Алт+шифт"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ктрл+шифт"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Алт+ктрл"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Шифт+велика/мала слова"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Алт+велика/мала слова"
+
+#~ msgid "_Region:"
+#~ msgstr "_Регион:"
+
+#~ msgid "_City:"
+#~ msgstr "_Град:"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Подеси време један сат унапред."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Подеси време један сат уназад."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Подеси време један минут унапред."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Подеси време један минут уназад."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Пребаци између ПрП и ПоП."
+
+#~ msgid "AM/PM"
+#~ msgstr "ПрП/ПоП"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Нормално"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "У смеру казаљке на сату"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 степени"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Изаберите екран да измените подешавања; превуците екране да им промените "
+#~ "редослед."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Не могу да сачувам подешавања за екран"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "Не могу да нађем екране"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Резолуција"
+
+#~ msgid "R_otation"
+#~ msgstr "_Окренутост"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Клонирај екране"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Напомена: може да ограничи опције резолуције"
+
+#~ msgid "Install Updates"
+#~ msgstr "Инсталирај ажурирања"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Ажурирања система"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Подешавања миша"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "Мала"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "Велика"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "Садржај се _лепи за прсте"
+
+#~ msgid "_Options…"
+#~ msgstr "_Опције…"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Изаберите сучеље за нови сервис"
+
+#~ msgid "C_reate…"
+#~ msgstr "_Направи…"
+
+#~ msgid "_Interface"
+#~ msgstr "Су_чеље"
+
+#~ msgid "_Default"
+#~ msgstr "_Подразумевано"
+
+#~ msgid "Hidden"
+#~ msgstr "Скривен"
+
+#~ msgid "Visible"
+#~ msgstr "Видљив"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "Назив и видљивост"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "Управљајте тиме како изгледате на екрану и на мрежи."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "Прикажи _пуно име на горњој траци"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "Прикажи пуно име у екрану _закључавања"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "_Потајни режим"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Ништа"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Дели јавну фасциклу"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Само дели са поверљивим уређајима"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Одобри све везе"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Нормалан"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Висок/Обрнут"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Тастатура на екрану"
+
+#~ msgid "OnBoard"
+#~ msgstr "ОнБоард"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Нормалан"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Запишти при закључавању великих слова и бројева"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "Укључи/искључи:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Увећање"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Увећај:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Умањи:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "Затворено хватање"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Прикажи текстуални опис говора и звукова"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "Кратак"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "Дуг"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Запишти када је тастер"
+
+#~ msgid "pressed"
+#~ msgstr "притиснут"
+
+#~ msgid "accepted"
+#~ msgstr "прихваћен"
+
+#~ msgid "rejected"
+#~ msgstr "одбијен"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "Застој _прихватања:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Контролиши показивач користећи тастатуру"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Видео миш"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Контролиши показивач користећи видео камеру."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "Мала"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "Велика"
+
+#~ msgid "_Local Account"
+#~ msgstr "_Месни налог"
+
+#~ msgid "_Login Name"
+#~ msgstr "_Пријавно име"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "Савет: Пословни домен или назив подручја"
+
+#~ msgid "C_ontinue"
+#~ msgstr "_Настави"
+
+#~ msgid "Next Week"
+#~ msgstr "Следећа седмица"
+
+#~ msgid "Next week"
+#~ msgstr "Следећа седмица"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Пријави се без лозинке"
+
+#~ msgid "Disable this account"
+#~ msgstr "Искључи овај налог"
+
+#~ msgid "Enable this account"
+#~ msgstr "Укључи овај налог"
+
+#~ msgid "_Action"
+#~ msgstr "_Радња"
+
+#~ msgid "_Show password"
+#~ msgstr "Пр_икажи лозинку"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Како изабрати јаку лозинку"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Мењам фотографију за:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Изаберите слику која ће бити приказана на екрану за пријављивање за овај "
+#~ "налог."
+
+#~ msgid "Gallery"
+#~ msgstr "Збирка"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Снимите фотографију"
+
+#~ msgid "Browse"
+#~ msgstr "Разгледај"
+
+#~ msgid "Photograph"
+#~ msgstr "Фотографија"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Прекратка"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "Није довољно добра"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Слаба"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Солидна"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Добра"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Јака"
+
+#~ msgid "_Generate a password"
+#~ msgstr "Створи _лозинку"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "Морате да унесете нову лозинку"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "Нова лозинка није довољно јака"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "Морате да потврдите лозинку"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "Морате да унесете вашу тренутну лозинку"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "Тренутна лозинка није тачна"
+
+#~ msgid "Switch Modes"
+#~ msgstr "Режими пребацивања"
+
+#~ msgid "Action"
+#~ msgstr "Радња"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Десни алт+шифт"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Леви+десни шифт"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Леви+десни ктрл"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ктрл+велика/мала слова"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "Процењени капацитет батерије: %s"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -11,9 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2018-02-24 17:48+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2018-02-25 08:19+0100\n"
 "Last-Translator: Marko M. Kostić <marko.m.kostic@gmail.com>\n"
 "Language-Team: srpski <gnome-sr@googlegroups.org>\n"
@@ -21,200 +20,331 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n==1? 3 : n%10==1 && n%100!=11 ? 0 : n"
-"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=4; plural=n==1? 3 : n%10==1 && n%100!=11 ? 0 : "
+"n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Project-Style: gnome\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: panels/background/background.ui:49
-msgid "_Background"
-msgstr "_Pozadina"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Programi"
 
-#. This refers to a slideshow background
-#: panels/background/background.ui:99 panels/background/background.ui:212
-msgid "Changes throughout the day"
-msgstr "Menja se tokom celog dana"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Nisam pronašao programe"
 
-#. To translators: This is a noun, not a verb
-#: panels/background/background.ui:162
-msgid "_Lock Screen"
-msgstr "Zaključavanje _ekrana"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "Instaliraj PPD datoteku…"
 
-#: panels/background/background.ui:268
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Popločano"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Otvori"
 
-#: panels/background/background.ui:272
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Uvećano"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "_Prikaži detalje"
 
-#: panels/background/background.ui:276
-msgctxt "background, style"
-msgid "Center"
-msgstr "Centrirano"
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Pretraga"
 
-#: panels/background/background.ui:280
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Srazmerno"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
 
-#: panels/background/background.ui:284
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Popunjeno"
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Isključeno"
 
-#: panels/background/background.ui:288
-msgctxt "background, style"
-msgid "Span"
-msgstr "Rasprostrto"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Obaveštenja"
 
-#: panels/background/cc-background-chooser-dialog.c:424
-msgid "Wallpapers"
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Prikaži _obaveštenja"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Pozadina"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Snimci ekrana"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
 msgstr "Pozadine"
 
-#: panels/background/cc-background-chooser-dialog.c:433
-msgid "Colors"
-msgstr "Boje"
+#: panels/applications/cc-applications-panel.ui:148
+#, fuzzy
+msgid "Change the desktop wallpaper."
+msgstr "preferences-desktop-wallpaper"
 
-#. translators: This is the title of the wallpaper chooser dialog.
-#: panels/background/cc-background-chooser-dialog.c:468
-msgid "Select Background"
-msgstr "Izaberite pozadinu"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Zvuk"
 
-#: panels/background/cc-background-chooser-dialog.c:496
-msgid "Pictures"
-msgstr "Slike"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#. translators: No pictures were found
-#: panels/background/cc-background-chooser-dialog.c:528
-msgid "No Pictures Found"
-msgstr "Nisam pronašao slike"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Postavi prečicu"
 
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: panels/background/cc-background-chooser-dialog.c:545
-#: panels/search/cc-search-locations-dialog.c:302
-msgid "Home"
-msgstr "Lično"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Nisam našao rečicu tastature"
 
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: panels/background/cc-background-chooser-dialog.c:555
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "Možete da dodate slike u vašu fasciklu %s i one će biti prikazane ovde"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s fotoaparat"
 
-#: panels/background/cc-background-chooser-dialog.c:560
-#: panels/color/cc-color-panel.c:225 panels/color/cc-color-panel.c:963
-#: panels/color/color-calibrate.ui:25 panels/color/color.ui:657
-#: panels/common/language-chooser.ui:23 panels/display/cc-display-panel.c:2594
-#: panels/network/connection-editor/connection-editor.ui:15
-#: panels/network/connection-editor/vpn-helpers.c:181
-#: panels/network/connection-editor/vpn-helpers.c:310
-#: panels/network/net-device-wifi.c:1411 panels/network/net-device-wifi.c:1491
-#: panels/network/net-device-wifi.c:1736 panels/network/network-wifi.ui:24
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:331
-#: panels/privacy/cc-privacy-panel.c:1053 panels/region/format-chooser.ui:25
-#: panels/region/input-chooser.ui:13
-#: panels/search/cc-search-locations-dialog.c:642
-#: panels/sharing/cc-sharing-panel.c:384
-#: panels/user-accounts/data/account-dialog.ui:28
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/user-accounts/data/password-dialog.ui:21
-#: panels/user-accounts/um-fingerprint-dialog.c:261
-#: panels/user-accounts/um-photo-dialog.c:102
-#: panels/user-accounts/um-photo-dialog.c:229
-#: panels/user-accounts/um-user-panel.c:635
-#: panels/user-accounts/um-user-panel.c:653
-msgid "_Cancel"
-msgstr "_Otkaži"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: panels/background/cc-background-chooser-dialog.c:561
-msgid "_Select"
-msgstr "I_zaberi"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
 
-#: panels/background/cc-background-item.c:192
-msgid "multiple sizes"
-msgstr "više veličina"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:196
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Usluge mesta"
 
-#: panels/background/cc-background-item.c:321
-msgid "No Desktop Background"
-msgstr "Nema pozadine za radnu površ"
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
 
-#: panels/background/cc-background-panel.c:291
-msgid "Current background"
-msgstr "Trenutna pozadina"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Ugrađena veb kamerica"
 
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Nisam našao rezultate"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Probajte drugačiju pretragu"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Vrsta ekrana"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Brzina veze"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Ponovo postavi"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Programi"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Penkalo"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Osnovno"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Pozadina"
 
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "Dodaj štampač…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "Francuska"
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Izmenite sliku pozadine na tapet ili fotografiju"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/background/gnome-background-panel.desktop.in.in:7
-msgid "preferences-desktop-wallpaper"
-msgstr "preferences-desktop-wallpaper"
-
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
-"pozadina;ekran;radna površ;Wallpaper;Screen;Desktop;pozadina;ekran;radna;"
-"povrs;površ;"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:265
-msgid "Turn Off Airplane Mode"
-msgstr "Isključi avionski režim rada"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "_Omogući"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:330
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Nije pronađen blutut"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:330
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Ubacite USB blutut uređaj za korišćenje blututa."
 
-#: panels/bluetooth/cc-bluetooth-panel.c:331
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Blutut je ugašen"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:331
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Uključite za povezivanje uređaja i ostvarivanje prenosa datoteka."
 
-#: panels/bluetooth/cc-bluetooth-panel.c:332
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "Avionski režim rada je uključen"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:332
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Blutut je isključen kada je avionski režim rada uključen."
 
-#: panels/bluetooth/cc-bluetooth-panel.c:333
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Isključi avionski režim rada"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
 msgstr "Hardverski avionski režim rada je uključen"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:333
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Isključite avionski režim rada biste uključili blutut."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/network/network.ui:101 panels/printers/pp-new-printer-dialog.c:1816
 msgid "Bluetooth"
 msgstr "Blutut"
 
@@ -222,402 +352,136 @@ msgstr "Blutut"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Uključite ili isključite blutut i povežite vaše uređaje"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:6
-msgid "bluetooth"
-msgstr "bluetooth"
-
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 "deljenje;blutut;obeks;deljenje;blutut;obeks;share;sharing;bluetooth;obex;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Postavite uređaj za kalibraciju preko kvadrata i pritisnite „Počni“"
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "Blutut je ugašen"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "Nijedan program trenutno ne reprodukuje ili snima zvuk."
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"Pomerite uređaj za kalibraciju na položaj kalibracije i pritisnite „Nastavi“"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-"Pomerite uređaj za kalibraciju na položaj površine i pritisnite „Nastavi“"
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "Zaklopite prenosni računar"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "Potražite još slika"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "Došlo je do unutrašnje greške koja ne može biti oporavljena."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "Alati potrebni za kalibraciju nisu instalirani."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "Profil ne može biti napravljen."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "Bela tačka mete se ne može dobaviti."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "Završeno!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "Kalibracija nije uspela!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "Možete da uklonite uređaj za kalibraciju."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Ne ometajte uređaj za kalibraciju dok je u radu"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Ekran prenosnog računara"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Ugrađena veb kamerica"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s monitor"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s skener"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s fotoaparat"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s štampač"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s veb kamerica"
-
-#: panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Uključi upravljanje bojom za „%s“"
-
-#: panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Prikaži profile boja za „%s“"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:323
-msgid "Not calibrated"
-msgstr "Nije kalibrisano"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:141
-msgid "Default: "
-msgstr "Osnovno: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:149
-msgid "Colorspace: "
-msgstr "Prostor boja: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:156
-msgid "Test profile: "
-msgstr "Probni profil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:223
-msgid "Select ICC Profile File"
-msgstr "Izaberi datoteku ICC profila"
-
-#: panels/color/cc-color-panel.c:226
-msgid "_Import"
-msgstr "_Uvezi"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:237
-msgid "Supported ICC profiles"
-msgstr "Podržani ICC profili"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:244
-#: panels/network/wireless-security/eap-method-fast.c:417
-msgid "All files"
-msgstr "Sve datoteke"
-
-#: panels/color/cc-color-panel.c:583
-msgid "Screen"
-msgstr "Ekran"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:908
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Nisam uspeo da otpremim datoteku: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:922
-msgid "The profile has been uploaded to:"
-msgstr "Profil je otpremljen u:"
-
-#: panels/color/cc-color-panel.c:924
-msgid "Write down this URL."
-msgstr "Zapišite ovu adresu."
-
-#: panels/color/cc-color-panel.c:925
-msgid "Restart this computer and boot your normal operating system."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"Ponovo pokrenite ovaj računar i učitajte vaš uobičajeni operativni sistem."
 
-#: panels/color/cc-color-panel.c:926
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "Upišite adresu u vaš preglednik da preuzmete i da instalirate profil."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:960
-msgid "Save Profile"
-msgstr "Sačuvaj profil"
-
-#: panels/color/cc-color-panel.c:964
-#: panels/network/connection-editor/vpn-helpers.c:311
-msgid "_Save"
-msgstr "_Sačuvaj"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1325
-msgid "Create a color profile for the selected device"
-msgstr "Napravite profil boje za izabrani uređaj"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1340 panels/color/cc-color-panel.c:1364
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Nije otkriven instrument za merenje. Proverite da li je uključen i da li je "
-"ispravno priključen."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1374
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Instrument za merenje ne podržava profilisanje štampača."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1385
-msgid "The device type is not currently supported."
-msgstr "Tip uređaja trenutno nije podržan."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "Uobičajeni prostor"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "Isprobaj profil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Samostalni"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Nizak kvalitet"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Osrednji kvalitet"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Visok kvalitet"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Osnovna RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Osnovna CMUK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Osnovna siva"
-
-#: panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "Prodavac je dostavio podatke fabričke kalibracije"
-
-#: panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Ispravka prikaza preko celog ekrana nije moguća sa ovim profilom"
-
-#: panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "Ovaj profil više ne može biti tačan"
-
-#: panels/color/color-calibrate.ui:7
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Prikaži kalibraciju"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Otkaži"
+
 #. This starts the calibration process
-#: panels/color/color-calibrate.ui:40
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "_Pokreni"
 
 #. This resumes the calibration process
-#: panels/color/color-calibrate.ui:54
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "_Nastavi"
 
 #. This button returns the user back to the color control panel
-#: panels/color/color-calibrate.ui:67 panels/common/language-chooser.ui:12
-#: panels/region/format-chooser.ui:14
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Urađeno"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: panels/color/color.ui:6 panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Kalibracija ekrana"
 
-#: panels/color/color.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kvalitet kalibracije"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"Kalibracija će proizvesti profil koji možete da koristite da upravljate bojom "
-"vašeg ekrana. Što duže bude trajala kalibracija, to će biti bolji kvalitet "
-"profila boje."
+"Kalibracija će proizvesti profil koji možete da koristite da upravljate "
+"bojom vašeg ekrana. Što duže bude trajala kalibracija, to će biti bolji "
+"kvalitet profila boje."
 
-#: panels/color/color.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "Nećete moći da koristite računar za vreme kalibracije."
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/color.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Kvalitet"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/color.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Približno vreme"
 
-#: panels/color/color.ui:121
-msgid "Calibration Quality"
-msgstr "Kvalitet kalibracije"
-
-#: panels/color/color.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Izaberite uređaj senzora koji želite da koristite za kalibraciju."
-
-#: panels/color/color.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Uređaj kalibracije"
 
-#: panels/color/color.ui:189
-msgid "Select the type of display that is connected."
-msgstr "Izaberite vrstu ekrana koji je povezan."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Izaberite uređaj senzora koji želite da koristite za kalibraciju."
 
-#: panels/color/color.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Vrsta ekrana"
 
-#: panels/color/color.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Izaberite vrstu ekrana koji je povezan."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Bela tačka profila"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -625,19 +489,19 @@ msgstr ""
 "Izaberite belu tačku mete ekrana. Većina ekrana treba da bude kalibrisana na "
 "D65 osvetljenje."
 
-#: panels/color/color.ui:278
-msgid "Profile Whitepoint"
-msgstr "Bela tačka profila"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Osvetljaj ekrana"
 
-#: panels/color/color.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"Molim podesite ekran na osvetljaj koji vam najviše odgovara. Upravljanje bojom "
-"će biti najtačnije na tom nivou osvetljaja."
+"Molim podesite ekran na osvetljaj koji vam najviše odgovara. Upravljanje "
+"bojom će biti najtačnije na tom nivou osvetljaja."
 
-#: panels/color/color.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -645,11 +509,11 @@ msgstr ""
 "Ili drugačije, možete da koristite nivo osvetljaja korišćen sa jednim od "
 "drugih profila za ovaj uređaj."
 
-#: panels/color/color.ui:318
-msgid "Display Brightness"
-msgstr "Osvetljaj ekrana"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Naziv profila"
 
-#: panels/color/color.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -657,64 +521,41 @@ msgstr ""
 "Možete da koristite profil boje na različitim računarima, ili čak da "
 "napravite profile za različite uslove osvetljenja."
 
-#: panels/color/color.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Naziv profila:"
 
-#: panels/color/color.ui:377
-msgid "Profile Name"
-msgstr "Naziv profila"
-
-#: panels/color/color.ui:392
-msgid "Profile successfully created!"
-msgstr "Profil je uspešno napravljen!"
-
-#: panels/color/color.ui:443
-msgid "Copy profile"
-msgstr "Umnožite profil"
-
-#: panels/color/color.ui:456
-msgid "Requires writable media"
-msgstr "Zahteva upisiv disk"
-
-#: panels/color/color.ui:519
-msgid "Upload profile"
-msgstr "Otpremite profil"
-
-#: panels/color/color.ui:532
-msgid "Requires Internet connection"
-msgstr "Zahteva Internet vezu"
-
-#: panels/color/color.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"Možete uvideti da su uputnice o korišćenju profila na sistemima <a href="
-"\"linux\">GNU/Linuksa</a>, <a href=\"osx\">Ejpol OS Iks-a</a> i <a href="
-"\"windows\">Majkrosoft Vindouza</a> korisne."
-
-#: panels/color/color.ui:607 panels/user-accounts/um-fingerprint-dialog.c:720
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Sažetak"
 
-#: panels/color/color.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil je uspešno napravljen!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Umnožite profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Zahteva upisiv disk"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Možete uvideti da su uputnice o korišćenju profila na sistemima <a "
+"href=\"linux\">GNU/Linuksa</a>, <a href=\"osx\">Ejpol OS Iks-a</a> i <a "
+"href=\"windows\">Majkrosoft Vindouza</a> korisne."
+
+#: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
 msgstr "Dodaj profil"
 
-#: panels/color/color.ui:643
-msgid "_Import File…"
-msgstr "_Uvezi datoteku…"
-
-#: panels/color/color.ui:672
-#: panels/network/connection-editor/net-connection-editor.c:519
-#: panels/printers/new-printer-dialog.ui:80 panels/region/input-chooser.ui:22
-#: panels/user-accounts/data/account-dialog.ui:47
-msgid "_Add"
-msgstr "_Dodaj"
-
-#: panels/color/color.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
@@ -722,142 +563,152 @@ msgstr ""
 "Otkriven je problem. Profil ne može da radi ispravno. <a href=\"\">Prikaži "
 "pojedinosti.</a>"
 
-#: panels/color/color.ui:807
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Uvezi datoteku…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Dodaj"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Svakom uređaju je potreban osveženi profil boje da bi bio upravljan bojom."
 
-#: panels/color/color.ui:829
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Saznajte više"
 
-#: panels/color/color.ui:834
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Saznajte više o upravljanju bojama"
 
-#: panels/color/color.ui:882
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "Pode_si za sve korisnike"
 
-#: panels/color/color.ui:886 panels/color/color.ui:901
-#: panels/color/color.ui:902
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Podesite ovaj profil za sve korisnike na ovom računaru"
 
-#: panels/color/color.ui:897
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "_Omogući"
 
-#: panels/color/color.ui:928
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "_Dodaj profil"
 
-#: panels/color/color.ui:941
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "Is_kalibriši…"
 
-#: panels/color/color.ui:945
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Podesite uređaj"
 
-#: panels/color/color.ui:956
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "_Ukloni profil"
 
-#: panels/color/color.ui:969
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "_Prikaži detalje"
 
-#: panels/color/color.ui:1005
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "Ne mogu da otkrijem ni jedan uređaj koji može biti upravljan bojom"
 
-#: panels/color/color.ui:1047
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/color.ui:1052
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/color.ui:1057
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: panels/color/color.ui:1062
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Projektor"
 
-#: panels/color/color.ui:1067
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Plazma"
 
-#: panels/color/color.ui:1072
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL pozadinsko osvetljenje)"
 
-#: panels/color/color.ui:1077
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED pozadinsko osvetljenje)"
 
-#: panels/color/color.ui:1082
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (belo LED pozadinsko osvetljenje)"
 
-#: panels/color/color.ui:1087
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "LCD širokog gamuta (CCFL pozadinsko osvetljenje)"
 
-#: panels/color/color.ui:1092
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "LCD širokog gamuta (RGB LED pozadinsko osvetljenje)"
 
-#: panels/color/color.ui:1109
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Visok"
 
-#: panels/color/color.ui:1110
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 minuta"
 
-#: panels/color/color.ui:1114
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Srednji"
 
-#: panels/color/color.ui:1115 panels/power/power.ui:25
-#: panels/privacy/privacy.ui:38
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 minuta"
 
-#: panels/color/color.ui:1119
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Nizak"
 
 # bug(danilo): plural-forms
-#: panels/color/color.ui:1120 panels/power/power.ui:13 panels/power/power.ui:95
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 minuta"
 
-#: panels/color/color.ui:1142
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Izvorno na ekran"
 
-#: panels/color/color.ui:1146
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Štampanje i objavljivanje)"
 
-#: panels/color/color.ui:1150
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/color.ui:1154
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Fotografija i grafika)"
 
-#: panels/color/color.ui:1158
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
@@ -871,234 +722,200 @@ msgid ""
 msgstr ""
 "Kalibrirajte boje vaših uređaja, kao što su ekrani, foto-aparati ili štampači"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/color/gnome-color-panel.desktop.in.in:7
-msgid "preferences-color"
-msgstr "preferences-color"
-
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "boja;icc;profil;kalibriraj;štampač;ekran;"
 
-#: panels/common/cc-common-language.c:323
-msgid "Other…"
-msgstr "Drugi…"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Jezik"
 
-#: panels/common/cc-language-chooser.c:124
-#: panels/region/cc-format-chooser.c:269 panels/region/cc-input-chooser.c:169
-msgid "More…"
-msgstr "Još…"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "I_zaberi"
 
-#: panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "Nisam pronašao jezike"
 
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:106
-msgid "Today"
-msgstr "Danas"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Još…"
 
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "Yesterday"
-msgstr "Juče"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e. %b"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "_Otključaj"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y."
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: panels/common/language-chooser.ui:5
-msgid "Language"
-msgstr "Jezik"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
-#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
-msgid "Day"
-msgstr "Dan"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Vreme"
 
-#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
-#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
-msgid "Month"
-msgstr "Mesec"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
-#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
-msgid "Year"
-msgstr "Godina"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:333
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%A, %e.%m.%Y. %l:%M %P"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:338
-msgid "%e %B %Y, %R"
-msgstr "%e. %B %Y. %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:503
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:530
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:537
-msgid "UTC%:::z"
-msgstr "KUV%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:542
-msgid "%l:%M %p"
-msgstr "%l:%M %P"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:547
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:552
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/datetime.ui:22
-msgid "January"
-msgstr "Januar"
-
-#: panels/datetime/datetime.ui:25
-msgid "February"
-msgstr "Februar"
-
-#: panels/datetime/datetime.ui:28
-msgid "March"
-msgstr "Mart"
-
-#: panels/datetime/datetime.ui:31
-msgid "April"
-msgstr "April"
-
-#: panels/datetime/datetime.ui:34
-msgid "May"
-msgstr "Maj"
-
-#: panels/datetime/datetime.ui:37
-msgid "June"
-msgstr "Jun"
-
-#: panels/datetime/datetime.ui:40
-msgid "July"
-msgstr "Jul"
-
-#: panels/datetime/datetime.ui:43
-msgid "August"
-msgstr "Avgust"
-
-#: panels/datetime/datetime.ui:46
-msgid "September"
-msgstr "Septembar"
-
-#: panels/datetime/datetime.ui:49
-msgid "October"
-msgstr "Oktobar"
-
-#: panels/datetime/datetime.ui:52
-msgid "November"
-msgstr "Novembar"
-
-#: panels/datetime/datetime.ui:55
-msgid "December"
-msgstr "Decembar"
-
-#: panels/datetime/datetime.ui:61
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Datum i vreme"
 
-#: panels/datetime/datetime.ui:106
-msgid "Hour"
-msgstr "Sat"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Godina"
 
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: panels/datetime/datetime.ui:121
-msgid "∶"
-msgstr "∶"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Mesec"
 
-# bug(danilo): plural-forms
-#: panels/datetime/datetime.ui:143
-msgid "Minute"
-msgstr "Minut"
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januar"
 
-#: panels/datetime/datetime.ui:208
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februar"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Mart"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maj"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Jun"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Jul"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Avgust"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Septembar"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktobar"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Novembar"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Decembar"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dan"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "Vremenska zona"
 
-#: panels/datetime/datetime.ui:228
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Potražite grad"
 
-#: panels/datetime/datetime.ui:304
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "Automatsko vreme i _datum"
 
-#: panels/datetime/datetime.ui:319 panels/datetime/datetime.ui:397
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Zahteva pristup internetu"
 
-#: panels/datetime/datetime.ui:382
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Datum i _vreme"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "Automatska vremenska _zona"
 
-#: panels/datetime/datetime.ui:454
-msgid "Date & _Time"
-msgstr "Datum i _vreme"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "Zahteva pristup internetu"
 
-#: panels/datetime/datetime.ui:502
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Vremenska z_ona"
 
-#: panels/datetime/datetime.ui:570
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "U smeru kazaljke na satu"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Zapis _vremena"
 
-#: panels/datetime/datetime.ui:588
-msgid "24-hour"
-msgstr "24-časovno"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/datetime.ui:589
-msgid "AM / PM"
-msgstr "PrP/PoP"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datumi"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "Sporedni"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Kalendar"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Brojevi"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Izmenite datum i vreme, uključujući vremensku zonu"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/datetime/gnome-datetime-panel.desktop.in.in:7
-msgid "preferences-system-time"
-msgstr "preferences-system-time"
-
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "sat;vremenska zona;mesto;"
@@ -1112,144 +929,173 @@ msgid "To change time or date settings, you need to authenticate."
 msgstr ""
 "Da izmenite podešavanja vremena i datuma, morate da potvrdite identitet."
 
-#: panels/display/cc-display-panel.c:729
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Položeno"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Veb"
 
-#: panels/display/cc-display-panel.c:732
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Uspravno desno"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Pošta"
 
-#: panels/display/cc-display-panel.c:735
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Uspravno levo"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalendar"
 
-#: panels/display/cc-display-panel.c:738
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Položeno (izvrnuto)"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Muzika"
 
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/display/cc-display-panel.c:805
-#: panels/printers/pp-options-dialog.c:558
-msgid "Orientation"
-msgstr "Usmerenje"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
 
-#: panels/display/cc-display-panel.c:870 panels/display/cc-display-panel.c:1673
-#: panels/printers/pp-options-dialog.c:87
-msgid "Resolution"
-msgstr "Rezolucija"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotografije"
 
-#: panels/display/cc-display-panel.c:958
-msgid "Refresh Rate"
-msgstr "Stopa osvežavanja"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Podrazumevani programi"
 
-#: panels/display/cc-display-panel.c:1095
-msgid "Scale"
-msgstr "Srazmerno"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Podesite osnovne programe"
 
-#: panels/display/cc-display-panel.c:1148
-msgid "Adjust for TV"
-msgstr "Doterivanje za TV"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "osnovni;program;omiljeni;medij;"
 
-#: panels/display/cc-display-panel.c:1410
-msgid "Primary Display"
-msgstr "Glavni ekran"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Izveštavanje o problemu"
 
-#: panels/display/cc-display-panel.c:1439
-msgid "Display Arrangement"
-msgstr "Ređanje ekrana"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Samostalno izvesti o problemu"
 
-#: panels/display/cc-display-panel.c:1440
-msgid ""
-"Drag displays to match your setup. The top bar is placed on the primary "
-"display."
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
 msgstr ""
-"Prevucite ekrane da odgovaraju vašem podešavanju. Gornja traka se prikazuje na "
-"glavnom ekranu."
 
-#: panels/display/cc-display-panel.c:1863
-msgid "Display Mode"
-msgstr "Režim ekrana"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: panels/display/cc-display-panel.c:1879
-msgid "Join Displays"
-msgstr "Spojeni ekrani"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
 
-#: panels/display/cc-display-panel.c:1882
-msgid "Mirror"
-msgstr "Preslikano"
-
-#: panels/display/cc-display-panel.c:1885
-msgid "Single Display"
-msgstr "Jedan ekran"
-
-#: panels/display/cc-display-panel.c:2590
-msgid "Apply Changes?"
-msgstr "Da primenim izmene?"
-
-#: panels/display/cc-display-panel.c:2604
-#: panels/network/connection-editor/connection-editor.ui:24
-#: panels/network/network-wifi.ui:38
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Primeni"
 
-#: panels/display/cc-display-panel.c:2979
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Nazad"
 
-#. TRANSLATORS: the state of the night light setting
-#: panels/display/cc-display-panel.c:3195
-#: panels/notifications/cc-notifications-panel.c:292
-#: panels/power/cc-power-panel.c:1991 panels/power/cc-power-panel.c:1998
-#: panels/privacy/cc-privacy-panel.c:190 panels/privacy/cc-privacy-panel.c:257
-#: panels/universal-access/cc-ua-panel.c:333
-#: panels/universal-access/cc-ua-panel.c:714
-#: panels/universal-access/cc-ua-panel.c:727
-#: panels/universal-access/cc-ua-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:910
-msgid "On"
-msgstr "Uklj."
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "Blutut je isključen"
 
-#: panels/display/cc-display-panel.c:3195 panels/network/net-proxy.c:54
-#: panels/notifications/cc-notifications-panel.c:292
-#: panels/power/cc-power-panel.c:1985 panels/power/cc-power-panel.c:1996
-#: panels/privacy/cc-privacy-panel.c:190 panels/privacy/cc-privacy-panel.c:257
-#: panels/universal-access/cc-ua-panel.c:333
-#: panels/universal-access/cc-ua-panel.c:714
-#: panels/universal-access/cc-ua-panel.c:727
-#: panels/universal-access/cc-ua-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:910 panels/universal-access/uap.ui:334
-#: panels/universal-access/uap.ui:380 panels/universal-access/uap.ui:426
-#: panels/universal-access/uap.ui:532 panels/universal-access/uap.ui:685
-#: panels/universal-access/uap.ui:731 panels/universal-access/uap.ui:777
-#: panels/universal-access/uap.ui:929
-msgid "Off"
-msgstr "Isklj."
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Jedan ekran"
 
-#: panels/display/cc-display-panel.c:3216
-msgid "_Night Light"
-msgstr "_Noćno svetlo"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
 
-#: panels/display/cc-display-panel.c:3281
-msgid "Could not get screen information"
-msgstr "Ne mogu da dobijem podatke o ekranu"
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Preslikano"
 
-#. This cancels the redshift inhibit.
-#: panels/display/display.ui:71
-msgid "Restart Filter"
-msgstr "Ponovo pokreni filter"
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Glavni ekran"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Noćno svetlo"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Usmerenje"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Stopa osvežavanja"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Doterivanje za TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Srazmerno"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Prirodno klizanje"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Noćno svetlo"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/display.ui:103
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Privremeno je isključeno do sutra"
 
-#: panels/display/display.ui:144
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Ponovo pokreni filter"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1257,49 +1103,63 @@ msgstr ""
 "Noćno svetlo čini boje ekrana toplijim. Može pomoći u sprečavanju naprezanja "
 "očiju i nesanice."
 
-#. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/display.ui:171 panels/display/display.ui:567
-msgid "Night Light"
-msgstr "Noćno svetlo"
-
-#: panels/display/display.ui:187
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Zakaži"
 
-#: panels/display/display.ui:215
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Od zalaska do izlaska sunca"
 
-#: panels/display/display.ui:229
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:56 panels/network/network-proxy.ui:113
-#: panels/network/network-wifi.ui:777 panels/network/network-wifi.ui:1054
-#: panels/privacy/cc-privacy-panel.c:217
-msgid "Manual"
-msgstr "Ručno"
+#: panels/display/cc-night-light-page.ui:141
+#, fuzzy
+msgid "Manual Schedule"
+msgstr "Zakaži"
 
-#: panels/display/display.ui:268
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Vremena"
+
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Od"
 
-#: panels/display/display.ui:309 panels/display/display.ui:430
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Sat"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
+# bug(danilo): plural-forms
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minut"
+
 #. This is the short form for the time period in the morning
-#: panels/display/display.ui:343 panels/display/display.ui:464
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "PrP"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/display.ui:359 panels/display/display.ui:480
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "PoP"
 
-#: panels/display/display.ui:528
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Do"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
 
 #: panels/display/gnome-display-panel.desktop.in.in:3
 msgid "Displays"
@@ -1309,184 +1169,173 @@ msgstr "Ekrani"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Izaberite kako ćete koristiti povezane ekrane i projektore"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/display/gnome-display-panel.desktop.in.in:7
-msgid "preferences-desktop-display"
-msgstr "preferences-desktop-display"
-
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
 msgstr ""
 "panel;projektor;iks-randr;ekran;rezolucija;osvežavanje;monitor;noć;svetlo;"
-"plavo;redšift;boja;svitanje;sumrak;panel;projektor;iks-randr;ekran;rezolucija;"
-"osvežavanje;monitor;noć;svetlo;plavo;redšift;boja;svitanje;sumrak;Panel;"
-"Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;"
-"color;sunset;sunrise;"
+"plavo;redšift;boja;svitanje;sumrak;panel;projektor;iks-randr;ekran;"
+"rezolucija;osvežavanje;monitor;noć;svetlo;plavo;redšift;boja;svitanje;sumrak;"
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
 
-#. TRANSLATORS: AP type
-#: panels/info/cc-info-overview-panel.c:374
-#: panels/info/cc-info-overview-panel.c:457 panels/network/panel-common.c:123
-msgid "Unknown"
-msgstr "Nepoznato"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info/cc-info-overview-panel.c:465
-#, c-format
-msgid "%s; Build ID: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Ključ bezbednosti"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Nivoa mastila"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Nivoa mastila"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Nivoa mastila"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Bezbednost"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ekran;zaključaj;dijagnoza;pad;urušavanje;lično;skorašnje;nedavno;privremen;"
+"prv;popis;naziv;mreža;identitet;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Naziv uređaja"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Hardverska adresa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Memorija"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Procesor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafika"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Izračunavam…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Naziv"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
 msgstr "%s; IB izgradnje: %s"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info/cc-info-overview-panel.c:482
-#, c-format
-msgid "64-bit"
-msgstr "64-bita"
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Vrsta"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info/cc-info-overview-panel.c:485
-#, c-format
-msgid "32-bit"
-msgstr "32-bita"
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Izdanje 0"
 
-#: panels/info/cc-info-overview-panel.c:775
-#, c-format
-msgid "Version %s"
-msgstr "Izdanje %s"
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Učitavam opcije…"
 
-#: panels/info/cc-info-removable-media-panel.c:298
-msgid "Ask what to do"
-msgstr "Pitaj šta da radiš"
-
-#: panels/info/cc-info-removable-media-panel.c:302
-msgid "Do nothing"
-msgstr "Ne radi ništa"
-
-#: panels/info/cc-info-removable-media-panel.c:306
-msgid "Open folder"
-msgstr "Otvori fasciklu"
-
-#: panels/info/cc-info-removable-media-panel.c:391
-msgid "Other Media"
-msgstr "Ostali nosači podataka"
-
-#: panels/info/cc-info-removable-media-panel.c:424
-msgid "Select an application for audio CDs"
-msgstr "Izaberite program za audio diskove (CD)"
-
-#: panels/info/cc-info-removable-media-panel.c:425
-msgid "Select an application for video DVDs"
-msgstr "Izaberite program za video diskove (DVD)"
-
-#: panels/info/cc-info-removable-media-panel.c:426
-msgid "Select an application to run when a music player is connected"
-msgstr "Izaberite program za pokretanje kada je priključen muzički plejer"
-
-#: panels/info/cc-info-removable-media-panel.c:427
-msgid "Select an application to run when a camera is connected"
-msgstr "Izaberite program za pokretanje kada je priključena kamera"
-
-#: panels/info/cc-info-removable-media-panel.c:428
-msgid "Select an application for software CDs"
-msgstr "Izaberite program za diskove sa softverom"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/info/cc-info-removable-media-panel.c:440
-msgid "audio DVD"
-msgstr "audio DVD"
-
-#: panels/info/cc-info-removable-media-panel.c:441
-msgid "blank Blu-ray disc"
-msgstr "prazan Blu-rej disk"
-
-#: panels/info/cc-info-removable-media-panel.c:442
-msgid "blank CD disc"
-msgstr "prazan CD disk"
-
-#: panels/info/cc-info-removable-media-panel.c:443
-msgid "blank DVD disc"
-msgstr "prazan DVD disk"
-
-#: panels/info/cc-info-removable-media-panel.c:444
-msgid "blank HD DVD disc"
-msgstr "prazan HD DVD disk"
-
-#: panels/info/cc-info-removable-media-panel.c:445
-msgid "Blu-ray video disc"
-msgstr "Blu-rej video disk"
-
-#: panels/info/cc-info-removable-media-panel.c:446
-msgid "e-book reader"
-msgstr "čitač el. knjiga"
-
-#: panels/info/cc-info-removable-media-panel.c:447
-msgid "HD DVD video disc"
-msgstr "HD DVD video disk"
-
-#: panels/info/cc-info-removable-media-panel.c:448
-msgid "Picture CD"
-msgstr "CD sa slikama"
-
-#: panels/info/cc-info-removable-media-panel.c:449
-msgid "Super Video CD"
-msgstr "Super video CD"
-
-#: panels/info/cc-info-removable-media-panel.c:450
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/info/cc-info-removable-media-panel.c:451
-msgid "Windows software"
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
 msgstr "Vindouz programi"
 
-#: panels/info/gnome-default-apps-panel.desktop.in.in:3
-msgid "Default Applications"
-msgstr "Podrazumevani programi"
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtuelizacija"
 
-#: panels/info/gnome-default-apps-panel.desktop.in.in:4
-msgid "Configure Default Applications"
-msgstr "Podesite osnovne programe"
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "Upotreba softvera"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info/gnome-default-apps-panel.desktop.in.in:7
-msgid "starred"
-msgstr "starred"
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Ukloni uređaj"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/info/gnome-default-apps-panel.desktop.in.in:19
-msgid "default;application;preferred;media;"
-msgstr "osnovni;program;omiljeni;medij;"
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
 
-#: panels/info/gnome-info-overview-panel.desktop.in.in:3
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Naziv uređaja"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_Korisnik"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
 msgid "About"
 msgstr "O programu"
 
-#: panels/info/gnome-info-overview-panel.desktop.in.in:4
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr "Pogledajte podatke o vašem sistemu"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info/gnome-info-overview-panel.desktop.in.in:7
-msgid "help-about"
-msgstr "help-about"
-
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
-#: panels/info/gnome-info-overview-panel.desktop.in.in:23
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "uređaj;sistem;informacije;memorija;procesor;izdanje;osnovno;program;omiljeno;"
 "cd;dvd;usb;zvuk;snimak;disk;uklonjivi;medijum;nosač;samopokretanje;uređaj;"
@@ -1495,144 +1344,13 @@ msgstr ""
 "information;memory;processor;version;default;application;preferred;cd;dvd;"
 "usb;audio;video;disc;removable;media;autorun;"
 
-#: panels/info/gnome-removable-media-panel.desktop.in.in:3
-msgid "Removable Media"
-msgstr "Prenosni nosači"
-
-#: panels/info/gnome-removable-media-panel.desktop.in.in:4
-msgid "Configure Removable Media settings"
-msgstr "Podesite prenosne medije"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/info/gnome-removable-media-panel.desktop.in.in:7
-msgid "media-removable"
-msgstr "media-removable"
-
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/info/gnome-removable-media-panel.desktop.in.in:19
-msgid ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
-"removable;media;autorun;"
-msgstr ""
-"uređaj;sistem;osnovno;program;omiljeno;cd;dvd;usb;zvuk;snimak;disk;uklonjivi;"
-"medijum;nosač;samopokretanje;uređaj;sistem;osnovno;program;omiljeno;cd;dvd;"
-"usb;zvuk;snimak;disk;uklonjivi;medijum;nosač;samopokretanje;device;system;"
-"default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;"
-"autorun;"
-
-#: panels/info/info-default-apps.ui:31
-msgid "_Web"
-msgstr "_Veb"
-
-#: panels/info/info-default-apps.ui:43
-msgid "_Mail"
-msgstr "_Pošta"
-
-#: panels/info/info-default-apps.ui:59
-msgid "_Calendar"
-msgstr "_Kalendar"
-
-#: panels/info/info-default-apps.ui:75
-msgid "M_usic"
-msgstr "_Muzika"
-
-#: panels/info/info-default-apps.ui:91
-msgid "_Video"
-msgstr "_Video"
-
-#: panels/info/info-default-apps.ui:162 panels/info/info-removable-media.ui:161
-msgid "_Photos"
-msgstr "_Fotografije"
-
-#: panels/info/info-overview.ui:58
-msgid "Device name"
-msgstr "Naziv uređaja"
-
-#: panels/info/info-overview.ui:74
-msgid "Memory"
-msgstr "Memorija"
-
-#: panels/info/info-overview.ui:90
-msgid "Processor"
-msgstr "Procesor"
-
-#: panels/info/info-overview.ui:106
-msgid "Graphics"
-msgstr "Grafika"
-
-#. To translators: this field contains the distro name and version
-#: panels/info/info-overview.ui:121
-msgid "OS name"
-msgstr "Naziv OS-a"
-
-#. To translators: this field contains the distro type
-#: panels/info/info-overview.ui:137
-msgid "OS type"
-msgstr "Vrsta OS-a"
-
-#: panels/info/info-overview.ui:153
-msgid "Virtualization"
-msgstr "Virtuelizacija"
-
-#: panels/info/info-overview.ui:169
-msgid "Disk"
-msgstr "Disk"
-
-#: panels/info/info-overview.ui:274
-msgid "Calculating…"
-msgstr "Izračunavam…"
-
-#: panels/info/info-overview.ui:314
-msgid "Check for updates"
-msgstr "Proveravam ažuriranja"
-
-#: panels/info/info-removable-media.ui:43
-msgid "Select how media should be handled"
-msgstr "Izaberite kako treba da se rukuje sa nosačima podataka"
-
-#: panels/info/info-removable-media.ui:74
-msgid "CD _audio"
-msgstr "CD _audio"
-
-#: panels/info/info-removable-media.ui:91
-msgid "_DVD video"
-msgstr "_DVD video"
-
-#: panels/info/info-removable-media.ui:132
-msgid "_Music player"
-msgstr "_Muzički program"
-
-#: panels/info/info-removable-media.ui:190
-msgid "_Software"
-msgstr "_Softver"
-
-#: panels/info/info-removable-media.ui:228
-msgid "_Other Media…"
-msgstr "_Ostali nosači podataka…"
-
-#: panels/info/info-removable-media.ui:272
-msgid "_Never prompt or start programs on media insertion"
-msgstr ""
-"_Nikada ne pitaj ili ne pokreći programe nakon ubacivanja nosača podataka"
-
-#: panels/info/info-removable-media.ui:331
-msgid "Select how other media should be handled"
-msgstr "Izaberite kako treba da se rukuje ostalim nosačima podataka"
-
-#: panels/info/info-removable-media.ui:370
-msgid "_Action:"
-msgstr "_Radnja:"
-
-#: panels/info/info-removable-media.ui:393
-msgid "_Type:"
-msgstr "_Vrsta:"
-
 #: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "Zvuk i mediji"
 
 #: panels/keyboard/00-multimedia.xml.in:4
-msgid "Volume mute"
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Isključuje jačinu zvuka"
 
 #: panels/keyboard/00-multimedia.xml.in:6
@@ -1644,34 +1362,39 @@ msgid "Volume up"
 msgstr "Pojačava jačinu zvuka"
 
 #: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Pokreće medijski program"
 
-#: panels/keyboard/00-multimedia.xml.in:12
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Pušta (ili pušta/pauzira)"
 
-#: panels/keyboard/00-multimedia.xml.in:14
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Pauzira puštanje"
 
-#: panels/keyboard/00-multimedia.xml.in:16
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Zaustavlja puštanje"
 
-#: panels/keyboard/00-multimedia.xml.in:18
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Prethodna numera"
 
-#: panels/keyboard/00-multimedia.xml.in:20
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Sledeća numera"
 
-#: panels/keyboard/00-multimedia.xml.in:22
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Izbaci"
 
-#: panels/keyboard/01-input-sources.xml.in:4 panels/universal-access/uap.ui:576
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Kucanje"
 
@@ -1691,9 +1414,9 @@ msgstr "Pokretači"
 msgid "Launch help browser"
 msgstr "Pokreće pregledač pomoći"
 
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:223
-#: shell/cc-window.c:761 shell/gnome-control-center.desktop.in.in:3
-#: shell/window.ui:125
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "Podešavanja"
 
@@ -1714,43 +1437,11 @@ msgid "Home folder"
 msgstr "Lična fascikla"
 
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/window.ui:157
+msgctxt "keybinding"
 msgid "Search"
 msgstr "Pretraga"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "Snimci ekrana"
-
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "Čuva snimak u fasciklu „$PICTURES“"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Čuva snimak prozora u fasciklu „$PICTURES“"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Čuva snimak oblasti u fasciklu „$PICTURES“"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "Umnožava snimak u beležnicu"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Umnožava snimak prozora u beležnicu"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Umnožava snimak oblasti u beležnicu"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "Snimite kratak radni tok ekrana"
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistem"
 
@@ -1764,8 +1455,9 @@ msgstr "Zaključaj ekran"
 
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
-msgid "Universal Access"
-msgstr "Univerzalni pristup"
+#, fuzzy
+msgid "Accessibility"
+msgstr "Vidljivost"
 
 #: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
@@ -1799,114 +1491,196 @@ msgstr "Smanji veličinu teksta"
 msgid "High contrast on or off"
 msgstr "Uključi/isključi veliki kontrast"
 
-#: panels/keyboard/cc-keyboard-manager.c:506
-#: panels/keyboard/cc-keyboard-manager.c:514
-#: panels/keyboard/cc-keyboard-manager.c:822
-msgid "Custom Shortcuts"
-msgstr "Proizvoljne prečice"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Dodajte izvor ulaza"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: panels/keyboard/cc-keyboard-option.c:263
-#: panels/keyboard/cc-keyboard-option.c:382
-#: panels/keyboard/keyboard-shortcuts.c:435
-#: panels/keyboard/shortcut-editor.ui:96 panels/network/network-proxy.ui:123
-#: panels/network/network-wifi.ui:782 panels/network/network-wifi.ui:1059
-#: panels/user-accounts/um-fingerprint-dialog.c:211
-#: subprojects/gvc/gvc-mixer-control.c:1866
-msgid "Disabled"
-msgstr "Isključeno"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Načini unosa ne mogu biti korišćeni u ekranu prijavljivanja"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: panels/keyboard/cc-keyboard-option.c:341
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Nije izabran izvor ulaza"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Mogućnosti"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Pomeri gore"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Pomeri dole"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Postavke"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Prečice tastature"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr "Ukloni"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Izvori ulaza"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Izbori izvora ulaza"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Koristi _isti izvor za sve prozore"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "Dopusti _različite izvore za svaki prozor"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "Tasteri zamenskih znakova"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: panels/keyboard/cc-keyboard-option.c:350
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "Sastavni taster"
 
-#: panels/keyboard/cc-keyboard-option.c:355
-msgid "Modifiers-only switch to next source"
-msgstr "Izmenjivači samo prebacuju na sledeći izvor"
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Prečice tastature"
 
-#: panels/keyboard/cc-keyboard-panel.c:181
-msgid "Reset All Shortcuts?"
-msgstr "Da vratim sve prečice?"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Proizvoljne prečice"
 
-#: panels/keyboard/cc-keyboard-panel.c:184
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Vrati sve…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Vratite sve prečice na njene osnovne vrednosti"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Odeljak"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Prečica"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Dodaj prečicu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Dodajte proizvoljnu prečicu"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"Ponovno vraćanje prečica može uticati na vaše proizvoljne prečice. Ovo se ne "
-"može opozvati."
 
-#: panels/keyboard/cc-keyboard-panel.c:188
-#: panels/keyboard/shortcut-editor.ui:346
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-msgid "Cancel"
-msgstr "Otkaži"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Dodaj prečicu"
 
-#: panels/keyboard/cc-keyboard-panel.c:189
-msgid "Reset All"
-msgstr "Vrati sve"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Nisam našao rečicu tastature"
 
-#: panels/keyboard/cc-keyboard-panel.c:281
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Ukloni"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "Zameni"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+#, fuzzy
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Pritisnite „Esc“ da otkažete ili povratnicu da vratite prečicu tastature."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Naziv"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Naredba"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Prečica"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Postavi prečicu…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ništa"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Vrati prečicu na njenu osnovnu vrednost"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:413
-#, c-format
-msgid ""
-"%s is already being used for <b>%s</b>. If you replace it, %s will be "
-"disabled"
-msgstr "„%s“ se već koristi za <b>%s</b>. Ako zamenite, „%s“ biće isključeno"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:583
-msgid "Set Custom Shortcut"
-msgstr "Postavi proizvoljnu prečicu"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:583
-msgid "Set Shortcut"
-msgstr "Postavi prečicu"
-
-#. Setup the top label
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:592
-#, c-format
-msgid "Enter new shortcut to change <b>%s</b>."
-msgstr "Unesite novu prečicu da izmenite <b>%s</b>."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:1019
-msgid "Add Custom Shortcut"
-msgstr "Dodajte proizvoljnu prečicu"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Podrazumevano koristi štampač"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Tastatura"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
 "Pogledajte i izmenite prečice tastature i podesite vaše postavke kucanja"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:7
-msgid "input-keyboard"
-msgstr "input-keyboard"
-
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -1914,77 +1688,230 @@ msgstr ""
 "prečica;radni prostor;prozor;promeni veličinu;zum;kontrast;ulaz;izvor;"
 "zaključaj;volumen;"
 
-#: panels/keyboard/gnome-keyboard-panel.ui:67 panels/region/input-options.ui:68
-#: shell/cc-application.c:255
-msgid "Keyboard Shortcuts"
-msgstr "Prečice tastature"
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "Usluge mesta"
 
-#: panels/keyboard/gnome-keyboard-panel.ui:77
-msgid "Reset All…"
-msgstr "Vrati sve…"
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Nijedan program trenutno ne reprodukuje ili snima zvuk."
 
-#: panels/keyboard/gnome-keyboard-panel.ui:78
-msgid "Reset all shortcuts to their default keybindings"
-msgstr "Vratite sve prečice na njene osnovne vrednosti"
-
-#: panels/keyboard/gnome-keyboard-panel.ui:164
-msgid "No keyboard shortcut found"
-msgstr "Nisam našao rečicu tastature"
-
-#: panels/keyboard/gnome-keyboard-panel.ui:175 shell/panel-list.ui:206
-msgid "Try a different search"
-msgstr "Probajte drugačiju pretragu"
-
-#: panels/keyboard/shortcut-editor.ui:68 panels/keyboard/shortcut-editor.ui:318
-msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
-"Pritisnite „Esc“ da otkažete ili povratnicu da vratite prečicu tastature."
 
-#: panels/keyboard/shortcut-editor.ui:156 panels/printers/details-dialog.ui:38
-#: panels/sound/gvc-mixer-dialog.c:1480
-#: panels/sound/gvc-sound-theme-chooser.c:554
-msgid "Name"
-msgstr "Naziv"
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:168
-msgid "Command"
-msgstr "Naredba"
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:180
-msgid "Shortcut"
-msgstr "Prečica"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:259
-msgid "Set Shortcut…"
-msgstr "Postavi prečicu…"
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "Ekran se isključuje"
 
-#: panels/keyboard/shortcut-editor.ui:272 panels/network/network-wifi.ui:594
-msgid "None"
-msgstr "Ništa"
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "Nisam pronašao programe"
 
-#: panels/keyboard/shortcut-editor.ui:303
-msgid "Enter the new shortcut"
-msgstr "Unesite novu prečicu"
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:357
-msgid "Remove"
-msgstr "Ukloni"
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:367
-msgid "Add"
-msgstr "Dodaj"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:382
-msgid "Replace"
-msgstr "Zameni"
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:395
-msgid "Set"
-msgstr "Postavi"
-
-#: panels/mouse/cc-mouse-panel.c:82 panels/wacom/cc-wacom-panel.c:402
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Isprobaj _podešavanja"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Opšte"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Glavno dugme"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Podešava redosled fizičkih tastera na miševima i dodirnim tablicama."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Levo"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Desno"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Mesta pretrage"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Miš"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "Brzina miša"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Klizaj na dole"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "Klizanje pomera sadržaj, ne pregled."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Klizanje pomera sadržaj, ne pregled."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Radna"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Dodirna tabla"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "Brzina dodirne table"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "Lupni za klik"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Lupni za klik"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Isključi dok _kucam"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Dodirna tabla (relativno)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Klizanje po strani"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Klizaj levo"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dvostrano"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Isprobajte klikanje, dvostruko klikanje, klizanje"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -1997,227 +1924,229 @@ msgstr ""
 "Promenite osetljivost miša ili dodirne table i izaberite levorukost ili "
 "desnorukost"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/mouse/gnome-mouse-panel.desktop.in.in:7
-msgid "input-mouse"
-msgstr "input-mouse"
-
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "ploča;pokazivač;klik;dodir;duplo;dugme;kuglica;klizanje;"
 
-#: panels/mouse/gnome-mouse-properties.ui:45
-msgid "General"
-msgstr "Opšte"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:83
-msgid "Primary Button"
-msgstr "Glavno dugme"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:102
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "Podešava redosled fizičkih tastera na miševima i dodirnim tablicama."
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:131
-msgid "Left"
-msgstr "Levo"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:141
-msgid "Right"
-msgstr "Desno"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "Prostor boja: "
 
-#: panels/mouse/gnome-mouse-properties.ui:177
-msgid "Mouse"
-msgstr "Miš"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:216
-msgid "Mouse Speed"
-msgstr "Brzina miša"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "Sam izbaci _smeće"
 
-#: panels/mouse/gnome-mouse-properties.ui:238
-#: panels/mouse/gnome-mouse-properties.ui:543
-msgid "Double-click timeout"
-msgstr "Vreme za dupli klik"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/gnome-mouse-properties.ui:275
-#: panels/mouse/gnome-mouse-properties.ui:451
-msgid "Natural Scrolling"
-msgstr "Prirodno klizanje"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:291
-#: panels/mouse/gnome-mouse-properties.ui:467
-msgid "Scrolling moves the content, not the view."
-msgstr "Klizanje pomera sadržaj, ne pregled."
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:341
-#: panels/mouse/gnome-mouse-properties.ui:386
-msgid "Touchpad"
-msgstr "Dodirna tabla"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "Ekran"
 
-#: panels/mouse/gnome-mouse-properties.ui:522
-msgid "Touchpad Speed"
-msgstr "Brzina dodirne table"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "Prevucite da promenite primarnu prikaz."
 
-#: panels/mouse/gnome-mouse-properties.ui:581
-msgid "Tap to Click"
-msgstr "Lupni za klik"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:634
-msgid "Two-finger Scrolling"
-msgstr "Premicanje sa dva prsta"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Program je definisan"
 
-#: panels/mouse/gnome-mouse-properties.ui:687
-msgid "Edge Scrolling"
-msgstr "Klizanje po strani"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:130 panels/mouse/gnome-mouse-test.ui:23
-msgid "Try clicking, double clicking, scrolling"
-msgstr "Isprobajte klikanje, dvostruko klikanje, klizanje"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "Pet klika, GEGL vreme!"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "Dvostruki klik, glavno dugme"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "Jedan klik, glavno dugme"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "Dvostruki klik, srednje dugme"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Uređaji"
 
-#: panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "Jedan klik, srednje dugme"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "Dvostruki klik, pomoćno dugme"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Dodajte novu vezu"
 
-#: panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "Jedan klik, pomoćno dugme"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Nije podešeno"
 
-#. add proxy to device list
-#: panels/network/cc-network-panel.c:579
-msgid "Network proxy"
-msgstr "Mrežni posrednik"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Povezani ste"
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/cc-network-panel.c:715 panels/network/net-vpn.c:192
-#: panels/network/net-vpn.c:321
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Mogućnosti…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
 
-#: panels/network/cc-network-panel.c:779 panels/network/wifi.ui:282
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Da uključim bežičnu vruću tačku?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Naziv mreže"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Lozinka"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Stvorite lozinku"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Stvorite lozinku"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Uključi"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Režim u avionu"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Isključite bežičnu, blutut i širokopojasnu mrežu"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nisam našao bežični adapter"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Proverite da li ste priključili i upalili bežični adapter"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Režim u avionu"
+
+#: panels/network/cc-wifi-panel.ui:165
+#, fuzzy
+msgid "Turn off to use Wi-Fi"
+msgstr "Isključite bežičnu karticu da biste uštedeli bateriju."
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Bežična vruća tačka"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Uključi bežičnu vruću tačku…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Vidljive mreže"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Upravljač mrežom treba biti pokrenut"
+
+#: panels/network/cc-wifi-panel.ui:303
 msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr "Ups, nešto je pošlo naopako. Obratite se vašem prodavcu softvera."
 
-#: panels/network/cc-network-panel.c:785
-msgid "NetworkManager needs to be running."
-msgstr "Upravljač mrežom treba biti pokrenut."
-
-#: panels/network/cc-wifi-panel.c:213
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:1766
-msgid "Wi-Fi"
-msgstr "Bežična"
-
-#: panels/network/connection-editor/8021x-security-page.ui:26
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Bezbednost 802.1x"
 
-#: panels/network/connection-editor/8021x-security-page.ui:73
-#: panels/network/connection-editor/security-page.ui:72
-#: panels/wacom/wacom-stylus-page.ui:108
-msgid "page 1"
-msgstr "strana 1"
-
-#: panels/network/connection-editor/8021x-security-page.ui:224
-#: panels/network/connection-editor/security-page.ui:223
-#: panels/network/wireless-security/eap-method-fast.ui:50
-#: panels/network/wireless-security/eap-method-peap.ui:48
-#: panels/network/wireless-security/eap-method-ttls.ui:31
-msgid "Anony_mous identity"
-msgstr "Anonimni _identitet"
-
-#: panels/network/connection-editor/8021x-security-page.ui:238
-#: panels/network/connection-editor/security-page.ui:237
-msgid "Inner _authentication"
-msgstr "Unutrašnja _prijava"
-
-#: panels/network/connection-editor/8021x-security-page.ui:281
-#: panels/network/connection-editor/security-page.ui:280
-#: panels/wacom/wacom-stylus-page.ui:426
-msgid "page 2"
-msgstr "strana 2"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:101
-#: panels/network/connection-editor/ce-page-security.c:445
-#: panels/network/connection-editor/details-page.ui:86
-#: panels/network/network-wifi.ui:239
-msgid "Security"
-msgstr "Bezbednost"
-
-#: panels/network/connection-editor/ce-page.c:481
-msgid "automatic"
-msgstr "samostalno"
-
-#: panels/network/connection-editor/ce-page.c:521
-#, c-format
-msgid "Profile %d"
-msgstr "Profil „%d“"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:56
-#: panels/network/net-device-wifi.c:235 panels/network/net-device-wifi.c:468
-msgid "WEP"
-msgstr "VEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:60
-#: panels/network/net-device-wifi.c:239 panels/network/net-device-wifi.c:473
-#: panels/network/network-wifi.ui:593
-msgid "WPA"
-msgstr "VPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:64
-#: panels/network/net-device-wifi.c:243
-msgid "WPA2"
-msgstr "VPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:69
-#: panels/network/net-device-wifi.c:248
-msgid "Enterprise"
-msgstr "Enterprajz"
-
-#: panels/network/connection-editor/ce-page-details.c:74
-#: panels/network/net-device-wifi.c:253 panels/network/net-device-wifi.c:458
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ništa"
-
-#: panels/network/connection-editor/ce-page-details.c:95
-#: panels/power/power.ui:99
-msgid "Never"
-msgstr "Nikad"
-
-#: panels/network/connection-editor/ce-page-details.c:110
-#: panels/network/net-device-ethernet.c:121
-#: panels/network/net-device-wifi.c:567
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
@@ -2226,449 +2155,227 @@ msgstr[1] "Pre %i dana"
 msgstr[2] "Pre %i dana"
 msgstr[3] "Pre jednog dana"
 
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:225
-#: panels/network/net-device-ethernet.c:50 panels/network/net-device-wifi.c:646
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:251
-#: panels/network/net-device-wifi.c:675
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Nema signala"
-
-#: panels/network/connection-editor/ce-page-details.c:253
-#: panels/network/net-device-wifi.c:677
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Slab signal"
-
-#: panels/network/connection-editor/ce-page-details.c:255
-#: panels/network/net-device-wifi.c:679
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Dobar signal"
-
-#: panels/network/connection-editor/ce-page-details.c:257
-#: panels/network/net-device-wifi.c:681
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Odličan signal"
-
-#: panels/network/connection-editor/ce-page-details.c:259
-#: panels/network/net-device-wifi.c:683
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Izvrstan signal"
-
-#: panels/network/connection-editor/ce-page-details.c:302
-msgid "Forget Connection"
-msgstr "Zaboravi vezu"
-
-#: panels/network/connection-editor/ce-page-details.c:304
-msgid "Remove Connection Profile"
-msgstr "Ukloni profil veze"
-
-#: panels/network/connection-editor/ce-page-details.c:306
-msgid "Remove VPN"
-msgstr "Ukloni VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-#: panels/network/network-wifi.ui:1456 shell/cc-window.c:215
-#: shell/panel-list.ui:103
-msgid "Details"
-msgstr "Pojedinosti"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:174
-#: panels/network/connection-editor/ce-page-vpn.c:188
-#: panels/network/connection-editor/ce-page-wifi.c:194
-#: panels/network/network-wifi.ui:1460
-msgid "Identity"
-msgstr "Identitet"
-
-#: panels/network/connection-editor/ce-page-ip4.c:251
-#: panels/network/connection-editor/ce-page-ip6.c:230
-msgid "Delete Address"
-msgstr "Obriši adresu"
-
-#: panels/network/connection-editor/ce-page-ip4.c:422
-#: panels/network/connection-editor/ce-page-ip6.c:390
-msgid "Delete Route"
-msgstr "Obriši rutu"
-
-#: panels/network/connection-editor/ce-page-ip4.c:896
-#: panels/network/network-wifi.ui:1464
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:828
-#: panels/network/network-wifi.ui:1468
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:245
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ništa"
-
-#: panels/network/connection-editor/ce-page-security.c:268
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "VEP 40/128-bitni ključ (Heksa ili ASKRI)"
-
-#: panels/network/connection-editor/ce-page-security.c:278
-msgid "WEP 128-bit Passphrase"
-msgstr "VEP 128-bitna lozinka"
-
-#: panels/network/connection-editor/ce-page-security.c:291
-#: panels/network/wireless-security/wireless-security.c:465
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:304
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dinamički VEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:318
-msgid "WPA & WPA2 Personal"
-msgstr "Lični VPA & VPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:332
-msgid "WPA & WPA2 Enterprise"
-msgstr "Poslovni VPA & VPA2"
-
-#: panels/network/connection-editor/details-page.ui:18
-#: panels/network/network-wifi.ui:174
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Jačina signala"
 
-#: panels/network/connection-editor/details-page.ui:52
-#: panels/network/network-wifi.ui:207
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Brzina veze"
 
-#: panels/network/connection-editor/details-page.ui:104
-#: panels/network/net-device-ethernet.c:154 panels/network/network-wifi.ui:256
-#: panels/network/panel-common.c:644
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Bezbednost"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 adresa"
 
-#: panels/network/connection-editor/details-page.ui:122
-#: panels/network/net-device-ethernet.c:155
-#: panels/network/net-device-ethernet.c:159
-#: panels/network/network-mobile.ui:189 panels/network/network-wifi.ui:273
-#: panels/network/panel-common.c:645
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 adresa"
 
-#: panels/network/connection-editor/details-page.ui:140
-#: panels/network/net-device-ethernet.c:162 panels/network/network-wifi.ui:290
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Hardverska adresa"
 
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Podržani ICC profili"
+
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/network-mobile.ui:206 panels/network/network-wifi.ui:307
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Podrazumevana ruta"
 
-#: panels/network/connection-editor/details-page.ui:177
-#: panels/network/connection-editor/ip4-page.ui:197
-#: panels/network/connection-editor/ip6-page.ui:211
-#: panels/network/net-device-ethernet.c:168
-#: panels/network/network-mobile.ui:224 panels/network/network-wifi.ui:325
-#: panels/network/network-wifi.ui:832 panels/network/network-wifi.ui:1109
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: panels/network/connection-editor/details-page.ui:195
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Korišćena"
 
-#: panels/network/connection-editor/details-page.ui:324
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "_Sam se poveži"
 
-#: panels/network/connection-editor/details-page.ui:343
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Učini dostupno _drugim korisnicima"
 
-#: panels/network/connection-editor/details-page.ui:376
-msgid "Restrict background data usage"
-msgstr "Ograniči pozadinsku upotrebu podataka"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:386
-msgid "Appropriate for connections that have data charges or limits."
-msgstr "Prikladno za veze koje imaju ograničenje podataka ili se naplaćuju."
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:16
-#: panels/network/connection-editor/ethernet-page.ui:39
-#: panels/network/connection-editor/ip4-page.ui:209
-#: panels/network/connection-editor/ip4-page.ui:277
-#: panels/network/connection-editor/ip6-page.ui:42
-#: panels/network/connection-editor/ip6-page.ui:223
-#: panels/network/connection-editor/ip6-page.ui:291
-#: panels/network/net-proxy.c:58 panels/network/network-proxy.ui:103
-#: panels/network/wireless-security/eap-method-peap.ui:22
-#: panels/privacy/cc-privacy-panel.c:217
-msgid "Automatic"
-msgstr "Samostalno"
-
-#: panels/network/connection-editor/ethernet-page.ui:19
-msgid "Twisted Pair (TP)"
-msgstr "Upleteni par (TP)"
-
-#: panels/network/connection-editor/ethernet-page.ui:22
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Sučelje jedinice prikačinjanja (AUI)"
-
-#: panels/network/connection-editor/ethernet-page.ui:25
-msgid "BNC"
-msgstr "BNC"
-
-#: panels/network/connection-editor/ethernet-page.ui:28
-msgid "Media Independent Interface (MII)"
-msgstr "Sučelje nezavisnog medija (MII)"
-
-#: panels/network/connection-editor/ethernet-page.ui:42
-msgid "10 Mb/s"
-msgstr "10 MB/s"
-
-#: panels/network/connection-editor/ethernet-page.ui:45
-msgid "100 Mb/s"
-msgstr "100 MB/s"
-
-#: panels/network/connection-editor/ethernet-page.ui:48
-msgid "1 Gb/s"
-msgstr "1 GB/s"
-
-#: panels/network/connection-editor/ethernet-page.ui:51
-msgid "10 Gb/s"
-msgstr "10 GB/s"
-
-#: panels/network/connection-editor/ethernet-page.ui:71
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Naziv"
 
-#: panels/network/connection-editor/ethernet-page.ui:100
-#: panels/network/connection-editor/wifi-page.ui:68
-#: panels/network/network-wifi.ui:1261
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "_MAC adresa"
 
-#: panels/network/connection-editor/ethernet-page.ui:146
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: panels/network/connection-editor/ethernet-page.ui:163
-#: panels/network/connection-editor/wifi-page.ui:98
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "_Klonirana adresa"
 
-#: panels/network/connection-editor/ethernet-page.ui:178
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "bajta"
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 msgid "IPv_4 Method"
 msgstr "IPv_4 Način"
 
-#: panels/network/connection-editor/ip4-page.ui:42
-#: panels/network/network-wifi.ui:778 panels/network/network-wifi.ui:1055
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "Samostalno (DHCP)"
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "Samo veži-lokalno"
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Ručno"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 msgid "Disable"
 msgstr "Isključi"
 
-#: panels/network/connection-editor/ip4-page.ui:111
-#: panels/network/connection-editor/ip6-page.ui:125
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "Deljeno sa ostalim računarima"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
 msgid "Addresses"
 msgstr "Adrese"
 
-#: panels/network/connection-editor/ip4-page.ui:129
-#: panels/network/connection-editor/ip4-page.ui:313
-#: panels/network/connection-editor/ip6-page.ui:143
-#: panels/network/connection-editor/ip6-page.ui:327
-#: panels/printers/details-dialog.ui:87
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Adresa"
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Mrežna maska"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Mrežni prolaz"
 
-#: panels/network/connection-editor/ip4-page.ui:220
-#: panels/network/connection-editor/ip6-page.ui:234
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Samostalno"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "Samostalni DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:244
-#: panels/network/connection-editor/ip6-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Razdvojte IP adrese zarezima"
 
-#: panels/network/connection-editor/ip4-page.ui:265
-#: panels/network/connection-editor/ip6-page.ui:279
-#: panels/network/network-wifi.ui:877 panels/network/network-wifi.ui:1154
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Rute"
 
-#: panels/network/connection-editor/ip4-page.ui:288
-#: panels/network/connection-editor/ip6-page.ui:302
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Samostalne rute"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:354
-#: panels/network/connection-editor/ip6-page.ui:368
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metrički"
 
-#: panels/network/connection-editor/ip4-page.ui:384
-#: panels/network/connection-editor/ip6-page.ui:398
-#: panels/network/network-wifi.ui:933 panels/network/network-wifi.ui:1210
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Koristi ovu vezu _samo za izvore na sopstvenoj mreži"
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
 msgstr "IPv_6 Način"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "Samostalno, samo DHCP"
 
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Prefiks"
 
-#: panels/network/connection-editor/net-connection-editor.c:273
-msgid "Unable to open connection editor"
-msgstr "Ne mogu da otvorim uređivača veze"
-
-#: panels/network/connection-editor/net-connection-editor.c:291
-msgid "New Profile"
-msgstr "Novi profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:603
-#: panels/network/network.ui:142
-msgid "VPN"
-msgstr "VPN"
-
-#: panels/network/connection-editor/net-connection-editor.c:751
-msgid "Import from file…"
-msgstr "Uvezi iz datoteke…"
-
-#: panels/network/connection-editor/net-connection-editor.c:785
-msgid "Add VPN"
-msgstr "Dodaj VPN"
-
-#: panels/network/connection-editor/security-page.ui:26
-#: panels/network/network-wifi.ui:529
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "B_ezbednost"
 
-#: panels/network/connection-editor/vpn-helpers.c:141
-msgid "Cannot import VPN connection"
-msgstr "Ne mogu da uvezem VPN vezu"
-
-#: panels/network/connection-editor/vpn-helpers.c:143
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Ne mogu da pročitam datoteku „%s“ ili ona ne sadrži poznate VPN podatke o "
-"vezi\n"
-"\n"
-"Greška: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:178
-msgid "Select file to import"
-msgstr "Izaberite datoteku za uvoz"
-
-#: panels/network/connection-editor/vpn-helpers.c:182
-#: panels/printers/pp-details-dialog.c:332
-#: panels/sharing/cc-sharing-panel.c:385
-#: panels/user-accounts/um-photo-dialog.c:230
-msgid "_Open"
-msgstr "_Otvori"
-
-#: panels/network/connection-editor/vpn-helpers.c:230
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Datoteka pod nazivom „%s“ već postoji."
-
-#: panels/network/connection-editor/vpn-helpers.c:232
-msgid "_Replace"
-msgstr "_Zameni"
-
-#: panels/network/connection-editor/vpn-helpers.c:234
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Da li želite da zamenite „%s“ VPN vezom koju sada čuvate?"
-
-#: panels/network/connection-editor/vpn-helpers.c:270
-msgid "Cannot export VPN connection"
-msgstr "Ne mogu da izvezem VPN vezu"
-
-#: panels/network/connection-editor/vpn-helpers.c:272
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Ne mogu da izvezem VPN vezu „%s“ u %s.\n"
-"\n"
-"Greška: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:307
-msgid "Export VPN connection"
-msgstr "Izvezi VPN vezu"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(Greška: ne mogu da učitam uređivača VPN veze)"
 
-#: panels/network/connection-editor/wifi-page.ui:20
-#: panels/network/network-wifi.ui:497
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
-#: panels/network/network-wifi.ui:513
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
 
-#: panels/network/connection-editor/wifi-page.ui:53
-#: panels/network/network-wifi.ui:562
-msgid "My Home Network"
-msgstr "Moja kućna mreža"
-
 #: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:241
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "Mreža"
 
@@ -2676,991 +2383,327 @@ msgstr "Mreža"
 msgid "Control how you connect to the Internet"
 msgstr "Upravljajte vašim povezivanjem na Internet"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/network/gnome-network-panel.desktop.in.in:7
-msgid "network-workgroup"
-msgstr "network-workgroup"
-
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"DNS;"
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "mreža;bežična;vaj-faj;ip;lan;posrednik;van;širokopojasna;modem;blutut;vpn;"
 "DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Bežična"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Upravljajte povezivanjem na bežične mreže"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/network/gnome-wifi-panel.desktop.in.in:7
-msgid "network-wireless"
-msgstr "network-wireless"
-
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
-msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "mreža;bežična;vaj-faj;ip;lan;širokopojasna;DNS;"
 
-#: panels/network/net-device-ethernet.c:107
-#: panels/network/net-device-wifi.c:553
-msgid "never"
-msgstr "nikad"
-
-#: panels/network/net-device-ethernet.c:117
-#: panels/network/net-device-wifi.c:563
-msgid "today"
-msgstr "danas"
-
-#: panels/network/net-device-ethernet.c:119
-#: panels/network/net-device-wifi.c:565
-msgid "yesterday"
-msgstr "juče"
-
-#: panels/network/net-device-ethernet.c:157
-#: panels/network/network-mobile.ui:172 panels/network/panel-common.c:647
-#: panels/network/panel-common.c:649
-msgid "IP Address"
-msgstr "IP adresa"
-
-#: panels/network/net-device-ethernet.c:173 panels/network/network-wifi.ui:342
-msgid "Last used"
-msgstr "Korišćena"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:276
-#: panels/network/network-ethernet.ui:19 panels/network/network-simple.ui:39
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Žičana"
 
-#: panels/network/net-device-ethernet.c:344
-#: panels/network/net-device-wifi.c:1895 panels/network/network-ethernet.ui:120
-#: panels/network/network-mobile.ui:394 panels/network/network-simple.ui:75
-#: panels/network/network-vpn.ui:79
-msgid "Options…"
-msgstr "Mogućnosti…"
-
-#: panels/network/net-device-mobile.c:238
-msgid "Add new connection"
-msgstr "Dodajte novu vezu"
-
-#: panels/network/net-device-wifi.c:1368
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "Uključivanjem bežične vruće tačke prekinućete vezu sa <b>%s</b>."
-
-#: panels/network/net-device-wifi.c:1372
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"Nije moguće pristupiti Internetu preko vaše bežične dok je uključena vruća "
-"tačka."
-
-#: panels/network/net-device-wifi.c:1379
-msgid "Turn On Wi-Fi Hotspot?"
-msgstr "Da uključim bežičnu vruću tačku?"
-
-#: panels/network/net-device-wifi.c:1401
-msgid ""
-"Wi-Fi hotspots are usually used to share an additional Internet connection "
-"over Wi-Fi."
-msgstr ""
-"Bežične vruće tačke se obično koriste za deljenje dodatne internet veze "
-"bežičnim putem."
-
-#: panels/network/net-device-wifi.c:1412
-msgid "_Turn On"
-msgstr "_Uključi"
-
-#: panels/network/net-device-wifi.c:1489
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Da zaustavim vruću tačku i da isključim sve korisnike?"
-
-#: panels/network/net-device-wifi.c:1492
-msgid "_Stop Hotspot"
-msgstr "_Zaustavi vruću tačku"
-
-#: panels/network/net-device-wifi.c:1592
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Politika sistema zabranjuje upotrebu kao vruće tačke"
-
-#: panels/network/net-device-wifi.c:1595
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Bežični uređaj ne podržava režim vruće tačke"
-
-#: panels/network/net-device-wifi.c:1733
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Detalji mreže za izabrane mreže, uključujući lozinku i sva proizvoljna "
-"podešavanja će biti izgubljeni."
-
-#: panels/network/net-device-wifi.c:1737 panels/network/network-wifi.ui:1362
-msgid "_Forget"
-msgstr "_Zaboravi"
-
-#: panels/network/net-device-wifi.c:2046 panels/network/net-device-wifi.c:2053
-msgid "Known Wi-Fi Networks"
-msgstr "Poznate bežične mreže"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:2086
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Zaboravi"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:102
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Automatsko nalaženje veb posrednika se koristi kada nije data adresa za "
-"podešavanje."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:110
-msgid "This is not recommended for untrusted public networks."
-msgstr "Ovo nije preporučljivo za nebezbedne, javne mreže."
-
-#: panels/network/network-mobile.ui:30
-msgid "IMEI"
-msgstr "IMEI"
-
-#: panels/network/network-mobile.ui:48
-msgid "Provider"
-msgstr "Dostavljač"
-
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:92
-msgid "Network Proxy"
-msgstr "Mrežni posrednik"
-
-#: panels/network/network-proxy.ui:173
-msgid "_HTTP Proxy"
-msgstr "_HTTP posrednik"
-
-#: panels/network/network-proxy.ui:192
-msgid "H_TTPS Proxy"
-msgstr "_HTTPS posrednik"
-
-#: panels/network/network-proxy.ui:211
-msgid "_FTP Proxy"
-msgstr "_FTP posrednik"
-
-#: panels/network/network-proxy.ui:230
-msgid "_Socks Host"
-msgstr "_Priključci domaćina"
-
-#: panels/network/network-proxy.ui:249
-msgid "_Ignore Hosts"
-msgstr "_Zanemari domaćine"
-
-#: panels/network/network-proxy.ui:287
-msgid "HTTP proxy port"
-msgstr "Priključnik HTTP posrednika"
-
-#: panels/network/network-proxy.ui:364
-msgid "HTTPS proxy port"
-msgstr "Priključnik HTTPS posrednika"
-
-#: panels/network/network-proxy.ui:385
-msgid "FTP proxy port"
-msgstr "Priključnik FTP posrednika"
-
-#: panels/network/network-proxy.ui:406
-msgid "Socks proxy port"
-msgstr "Priključnik socks posrednika"
-
-#: panels/network/network-proxy.ui:435
-msgid "_Configuration URL"
-msgstr "_Adresa podešavanja"
-
-#: panels/network/network-simple.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Isključi uređaj"
 
-#: panels/network/network.ui:194
-msgid "Not set up"
-msgstr "Nije podešeno"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Radna"
 
-#: panels/network/network-vpn.ui:56
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Dostavljač"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP adresa"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Mrežni posrednik"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP posrednik"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "_HTTPS posrednik"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP posrednik"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Priključci domaćina"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Zanemari domaćine"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Priključnik HTTP posrednika"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Priključnik HTTPS posrednika"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Priključnik FTP posrednika"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Priključnik socks posrednika"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Adresa podešavanja"
+
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "Isključi VPN vezu"
 
-#: panels/network/network-wifi.ui:127
-msgid "Automatic _Connect"
-msgstr "Samostalno _poveži"
-
-#: panels/network/network-wifi.ui:474
-msgid "details"
-msgstr "pojedinosti"
-
-#: panels/network/network-wifi.ui:545
-#: panels/network/wireless-security/eap-method-leap.ui:40
-#: panels/network/wireless-security/eap-method-simple.ui:40
-#: panels/network/wireless-security/ws-leap.ui:40
-#: panels/network/wireless-security/ws-wpa-psk.ui:22
-#: panels/sharing/sharing.ui:351
-#: panels/user-accounts/data/account-dialog.ui:300
-#: panels/user-accounts/data/account-dialog.ui:525
-#: panels/user-accounts/data/user-accounts-dialog.ui:205
-msgid "_Password"
-msgstr "_Lozinka"
-
-#: panels/network/network-wifi.ui:622
-msgid "Show P_assword"
-msgstr "Prikaži _lozinku"
-
-#: panels/network/network-wifi.ui:652
-msgid "Make available to other users"
-msgstr "Učini dostupno drugim korisnicima"
-
-#: panels/network/network-wifi.ui:680
-msgid "identity"
-msgstr "identitet"
-
-#: panels/network/network-wifi.ui:714
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: panels/network/network-wifi.ui:755 panels/network/network-wifi.ui:1032
-msgid "_Addresses"
-msgstr "_Adresa"
-
-#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
-msgid "Automatic (DHCP) addresses only"
-msgstr "Samo samostalne (DHCP) adrese"
-
-#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
-msgid "Link-local only"
-msgstr "Samo veži-lokalno"
-
-#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
-msgid "Shared with other computers"
-msgstr "Deljeno sa ostalim računarima"
-
-#: panels/network/network-wifi.ui:917 panels/network/network-wifi.ui:1194
-msgid "_Ignore automatically obtained routes"
-msgstr "_Zanemari automatski dobijene rute"
-
-#: panels/network/network-wifi.ui:960
-msgid "ipv4"
-msgstr "ipv4"
-
-#: panels/network/network-wifi.ui:991
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: panels/network/network-wifi.ui:1237
-msgid "ipv6"
-msgstr "ipv6"
-
-#: panels/network/network-wifi.ui:1277
-msgid "_Cloned MAC Address"
-msgstr "_Klonirana MAC adresa"
-
-#: panels/network/network-wifi.ui:1327
-msgid "hardware"
-msgstr "uređaji"
-
-#: panels/network/network-wifi.ui:1346
-msgid "_Reset"
-msgstr "_Ponovo postavi"
-
-#: panels/network/network-wifi.ui:1382
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"Ponovo će postaviti podešavanja ove veze na njihova osnovna, ali će je "
-"upamtiti kao željenu vezu."
-
-#: panels/network/network-wifi.ui:1399
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"Ukloniće sve podatke koji se odnose na ovu mrežu i neće pokušati da se sam "
-"poveže na nju."
-
-#: panels/network/network-wifi.ui:1419
-msgid "reset"
-msgstr "ponovo postavi"
-
-#: panels/network/network-wifi.ui:1472
-msgid "Hardware"
-msgstr "Uređaji"
-
-#: panels/network/network-wifi.ui:1476
-msgctxt "tab"
-msgid "Reset"
-msgstr "Ponovo postavi"
-
-#: panels/network/network-wifi.ui:1537
-msgid "Wi-Fi Hotspot"
-msgstr "Bežična vruća tačka"
-
-#: panels/network/network-wifi.ui:1554
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Isključite da se povežete na bežičnu mrežu"
-
-#: panels/network/network-wifi.ui:1603
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Naziv mreže"
 
-#: panels/network/network-wifi.ui:1621
-msgid "Connected Devices"
-msgstr "Priključeni uređaji"
-
-#: panels/network/network-wifi.ui:1639
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Vrsta bezbednosti"
 
-#: panels/network/network-wifi.ui:1702
-msgctxt "Wi-Fi passkey"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Lozinka"
 
-#: panels/network/network-wifi.ui:1796
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Isključi bežičnu"
 
-#: panels/network/network-wifi.ui:1828
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Učitavam opcije…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Poveži se na skrivenu bežičnu mrežu…"
 
-#: panels/network/network-wifi.ui:1838
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Uključi bežičnu vruću tačku…"
 
-#: panels/network/network-wifi.ui:1848
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "_Poznate bežične mreže"
 
-#: panels/network/wifi.ui:40
-msgid "No Wi-Fi Adapter Found"
-msgstr "Nisam našao bežični adapter"
-
-#: panels/network/wifi.ui:52
-msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
-msgstr "Proverite da li ste priključili i upalili bežični adapter"
-
-#: panels/network/wifi.ui:127
-msgid "Airplane Mode"
-msgstr "Režim u avionu"
-
-#: panels/network/wifi.ui:142
-msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
-msgstr "Isključite bežičnu, blutut i širokopojasnu mrežu"
-
-#: panels/network/wifi.ui:192
-msgid "Visible Networks"
-msgstr "Vidljive mreže"
-
-#: panels/network/wifi.ui:271
-msgid "NetworkManager needs to be running"
-msgstr "Upravljač mrežom treba biti pokrenut"
-
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:127
-msgid "Ad-hoc"
-msgstr "Ad-hok"
-
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:131
-msgid "Infrastructure"
-msgstr "Infrastrukturno"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:147 panels/network/panel-common.c:201
-msgid "Status unknown"
-msgstr "Nepoznato stanje"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:151
-msgid "Unmanaged"
-msgstr "Neupravljan"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:155
-msgid "Unavailable"
-msgstr "Nedostupno"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:165 panels/network/panel-common.c:207
-msgid "Connecting"
-msgstr "Povezujem se"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:169 panels/network/panel-common.c:211
-msgid "Authentication required"
-msgstr "Potrebno je potvrđivanje identiteta"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:173 panels/network/panel-common.c:215
-msgid "Connected"
-msgstr "Povezani ste"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:177
-msgid "Disconnecting"
-msgstr "Isključujem"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:181 panels/network/panel-common.c:219
-msgid "Connection failed"
-msgstr "Povezivanje nije uspelo"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:185 panels/network/panel-common.c:227
-msgid "Status unknown (missing)"
-msgstr "Stanje je nepoznato (nedostaje)"
-
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:223
-msgid "Not connected"
-msgstr "Niste povezani"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "Configuration failed"
-msgstr "Nije uspelo podešavanje"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252
-msgid "IP configuration failed"
-msgstr "Nije uspelo podešavanje IP-a"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "IP configuration expired"
-msgstr "Isteklo je podešavanje IP-a"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:260
-msgid "Secrets were required, but not provided"
-msgstr "Zatražene su tajne, ali nisu dostavljene"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:264
-msgid "802.1x supplicant disconnected"
-msgstr "Prekinuta je veza sa 802.1x moliocem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:268
-msgid "802.1x supplicant configuration failed"
-msgstr "Nije uspelo podešavanje 802.1x molioca"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:272
-msgid "802.1x supplicant failed"
-msgstr "802.1x molilac nije uspeo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:276
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Potvrđivanje identiteta 802.1x molioca je trajalo predugo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:280
-msgid "PPP service failed to start"
-msgstr "PPP usluga nije uspela da se pokrene"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:284
-msgid "PPP service disconnected"
-msgstr "PPP usluga je isključena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:288
-msgid "PPP failed"
-msgstr "PPP nije uspelo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:292
-msgid "DHCP client failed to start"
-msgstr "DHCP klijent nije uspeo da e pokrene"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:296
-msgid "DHCP client error"
-msgstr "Greška DHCP klijenta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:300
-msgid "DHCP client failed"
-msgstr "DHCP klijent nije uspeo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:304
-msgid "Shared connection service failed to start"
-msgstr "Usluga deljene veze nije uspela da se pokrene"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:308
-msgid "Shared connection service failed"
-msgstr "Usluga deljene veze nije uspela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:312
-msgid "AutoIP service failed to start"
-msgstr "Usluga samostalnog IP-a nije uspela da se pokrene"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:316
-msgid "AutoIP service error"
-msgstr "Greška usluge samostalnog IP-a"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:320
-msgid "AutoIP service failed"
-msgstr "Usluga samostalnog IP-a nije uspela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:324
-msgid "Line busy"
-msgstr "Linija je zauzeta"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:328
-msgid "No dial tone"
-msgstr "Nema tona pozivanja"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:332
-msgid "No carrier could be established"
-msgstr "Nijedan nosač ne može biti uspostavljen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:336
-msgid "Dialing request timed out"
-msgstr "Isteklo je vreme zahteva pozivanja"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:340
-msgid "Dialing attempt failed"
-msgstr "Pokušaj pozivanja nije uspeo"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:344
-msgid "Modem initialization failed"
-msgstr "Nije uspelo pokretanje modema"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:348
-msgid "Failed to select the specified APN"
-msgstr "Nisam uspeo da izaberem navedeni NTP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:352
-msgid "Not searching for networks"
-msgstr "Ne tražim mreže"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:356
-msgid "Network registration denied"
-msgstr "Zavođenje mreže je odbijeno"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:360
-msgid "Network registration timed out"
-msgstr "Isteklo je vreme za zavođenje mreže"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:364
-msgid "Failed to register with the requested network"
-msgstr "Nisam uspeo da zavedem sa zahtevanom mrežom"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:368
-msgid "PIN check failed"
-msgstr "Provera PIN-a nije uspela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:372
-msgid "Firmware for the device may be missing"
-msgstr "Možda nedostaje firmver za uređaj"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:376
-msgid "Connection disappeared"
-msgstr "Veza je nestala"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:380
-msgid "Existing connection was assumed"
-msgstr "Postojeća veza biće prisvojena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:384
-msgid "Modem not found"
-msgstr "Nije pronađen modem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:388
-msgid "Bluetooth connection failed"
-msgstr "Veza blututa nije uspela"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:392
-msgid "SIM Card not inserted"
-msgstr "SIM kartica nije ubačena"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:396
-msgid "SIM Pin required"
-msgstr "Potreban je SIM PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:400
-msgid "SIM Puk required"
-msgstr "Potreban je SIM PUK"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:404
-msgid "SIM wrong"
-msgstr "Pogrešna SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:408
-msgid "Connection dependency failed"
-msgstr "Nije uspela zavisnost veze"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:433
-msgid "Firmware missing"
-msgstr "Nedostaje firmver"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:437
-msgid "Cable unplugged"
-msgstr "Kabal je isključen"
-
-#: panels/network/wireless-security/eap-method.c:57
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "neodređena greška u 802.1X bezbednosti (vpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:233
-msgid "no file selected"
-msgstr "Nije izabrana datoteka"
-
-#: panels/network/wireless-security/eap-method.c:264
-msgid "unspecified error validating eap-method file"
-msgstr "neodređena greška potvrđivanja datoteke eap-metoda"
-
-#: panels/network/wireless-security/eap-method.c:439
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, ili PKCS#12 lični ključevi (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:442
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER ili PEM uverenja (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:72
-msgid "missing EAP-FAST PAC file"
-msgstr "nedostaje datoteka EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:268
-#: panels/network/wireless-security/eap-method-peap.c:302
-#: panels/network/wireless-security/eap-method-ttls.c:351
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: panels/network/wireless-security/eap-method-fast.c:283
-#: panels/network/wireless-security/eap-method-peap.c:272
-#: panels/network/wireless-security/eap-method-ttls.c:289
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: panels/network/wireless-security/eap-method-fast.c:406
-msgid "Choose a PAC file"
-msgstr "Izaberi PAC datoteku"
-
-#: panels/network/wireless-security/eap-method-fast.c:413
-msgid "PAC files (*.pac)"
-msgstr "PAC datoteke (*.pac)"
-
-#: panels/network/wireless-security/eap-method-fast.ui:22
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "Anonimno"
 
-#: panels/network/wireless-security/eap-method-fast.ui:25
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "Potvrđenim identitetom"
 
-#: panels/network/wireless-security/eap-method-fast.ui:28
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "Oba"
 
-#: panels/network/wireless-security/eap-method-fast.ui:76
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anonimni _identitet"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "PAC _datoteka"
 
-#: panels/network/wireless-security/eap-method-fast.ui:122
-#: panels/network/wireless-security/eap-method-peap.ui:146
-#: panels/network/wireless-security/eap-method-ttls.ui:97
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Izaberi PAC datoteku"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "_Unutrašnja prijava"
 
-#: panels/network/wireless-security/eap-method-fast.ui:156
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Dozvoli automatsko PAC _snabdevanje"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "nedostaje EAP-LEAP korisničko ime"
-
-#: panels/network/wireless-security/eap-method-leap.c:74
-msgid "missing EAP-LEAP password"
-msgstr "nedostaje EAP-LEAP lozinka"
-
-#: panels/network/wireless-security/eap-method-leap.ui:26
-#: panels/network/wireless-security/eap-method-simple.ui:26
-#: panels/network/wireless-security/ws-leap.ui:26
-#: panels/user-accounts/data/account-dialog.ui:142
-#: panels/user-accounts/data/account-dialog.ui:505
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_Korisnik"
 
-#: panels/network/wireless-security/eap-method-leap.ui:68
-#: panels/network/wireless-security/eap-method-simple.ui:85
-#: panels/network/wireless-security/eap-method-tls.ui:164
-#: panels/network/wireless-security/ws-leap.ui:68
-#: panels/network/wireless-security/ws-wpa-psk.ui:76
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Lozinka"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "Po_kaži lozinku"
 
-#: panels/network/wireless-security/eap-method-peap.c:63
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "neispravno EAP-PEAP uverenje izdavača uverenja: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:68
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-"neispravno EAP-PEAP uverenje izdavača uverenja: nije navedeno nikakvo uverenje"
-
-#: panels/network/wireless-security/eap-method-peap.c:287
-#: panels/network/wireless-security/eap-method-ttls.c:336
-#: panels/network/wireless-security/wireless-security.c:441
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: panels/network/wireless-security/eap-method-peap.c:381
-#: panels/network/wireless-security/eap-method-tls.c:492
-#: panels/network/wireless-security/eap-method-ttls.c:430
-msgid "Choose a Certificate Authority certificate"
-msgstr "Izaberite uverenje izdavača ovlašćenja"
-
-#: panels/network/wireless-security/eap-method-peap.ui:25
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "Izdanje 0"
 
-#: panels/network/wireless-security/eap-method-peap.ui:28
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "Izdanje 1"
 
-#: panels/network/wireless-security/eap-method-peap.ui:74
-#: panels/network/wireless-security/eap-method-tls.ui:75
-#: panels/network/wireless-security/eap-method-ttls.ui:57
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "CA _uverenje"
 
-#: panels/network/wireless-security/eap-method-peap.ui:96
-#: panels/network/wireless-security/eap-method-tls.ui:97
-#: panels/network/wireless-security/eap-method-ttls.ui:79
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Izaberite uverenje izdavača ovlašćenja"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "Nije potrebno _uverenje izdavača uverenja"
 
-#: panels/network/wireless-security/eap-method-peap.ui:114
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _izdanje"
 
-#: panels/network/wireless-security/eap-method-simple.c:74
-msgid "missing EAP username"
-msgstr "nedostaje EAP korisničko ime"
-
-#: panels/network/wireless-security/eap-method-simple.c:87
-msgid "missing EAP password"
-msgstr "nedostaje EAP lozinka"
-
-#: panels/network/wireless-security/eap-method-tls.c:68
-msgid "missing EAP-TLS identity"
-msgstr "nedostaje EAP-TLS identitet"
-
-#: panels/network/wireless-security/eap-method-tls.c:77
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "neispravno EAP-TLS uverenje izdavača uverenja: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:84
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-"neispravno EAP-TLS uverenje izdavača uverenja: nije navedeno nikakvo uverenje"
-
-#: panels/network/wireless-security/eap-method-tls.c:100
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "neispravan EAP-TLS privatni ključ: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:110
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "neispravno EAP-TLS uverenje korisnika: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:307
-msgid "Unencrypted private keys are insecure"
-msgstr "Nešifrovani privatni ključevi nisu sigurni"
-
-#: panels/network/wireless-security/eap-method-tls.c:310
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Izgleda da izabrani privatni ključ nije zaštićen lozinkom. Ovo može ugroziti "
-"vaše sigurnosne podatke. Izaberite privatni ključ koji ze zaštićen lozinkom.\n"
-"\n"
-"(Možete zaštititi privatne ključeve koristeći „openssl“)"
-
-#: panels/network/wireless-security/eap-method-tls.c:486
-msgid "Choose your personal certificate"
-msgstr "Izaberite vaše lično uverenje"
-
-#: panels/network/wireless-security/eap-method-tls.c:498
-msgid "Choose your private key"
-msgstr "Izaberite lični ključ"
-
-#: panels/network/wireless-security/eap-method-tls.ui:24
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "_Identitet"
 
-#: panels/network/wireless-security/eap-method-tls.ui:50
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "Uverenje _korisnika"
 
-#: panels/network/wireless-security/eap-method-tls.ui:115
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "Lični _ključ"
 
-#: panels/network/wireless-security/eap-method-tls.ui:140
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Lozinka ličnog ključa"
 
-#: panels/network/wireless-security/eap-method-ttls.c:63
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "neispravno EAP-TTLS uverenje izdavača uverenja: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:68
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-"neispravno EAP-TTLS uverenje izdavača uverenja: nije navedeno nikakvo uverenje"
-
-#: panels/network/wireless-security/eap-method-ttls.c:259
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: panels/network/wireless-security/eap-method-ttls.c:274
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.c:305
+#: panels/network/wireless-security/eap-method-ttls.ui:25
 msgid "MSCHAPv2 (no EAP)"
 msgstr "MSCHAPv2 (bez EAP-a)"
 
-#: panels/network/wireless-security/eap-method-ttls.c:321
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/wireless-security.c:87
-msgid "Unknown error validating 802.1X security"
-msgstr "Nepoznata greška potvrđivanja 802.1X bezbednosti"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domen"
 
-#: panels/network/wireless-security/wireless-security.c:453
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: panels/network/wireless-security/wireless-security.c:477
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
 msgid "PWD"
 msgstr "LZN"
 
-#: panels/network/wireless-security/wireless-security.c:488
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: panels/network/wireless-security/wireless-security.c:499
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "TLS kroz tunel"
 
-#: panels/network/wireless-security/wireless-security.c:510
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "Zaštićeni EAP (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:39
-#: panels/network/wireless-security/ws-wep-key.ui:115
-#: panels/network/wireless-security/ws-wpa-eap.ui:33
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "Potvrđivanje _identiteta"
 
-#: panels/network/wireless-security/ws-leap.c:63
-msgid "missing leap-username"
-msgstr "nedostaje leap korisničko ime"
-
-#: panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr "nedostaje leap lozinka"
-
-#: panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr "nedostaje vep ključ"
-
-#: panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"neispravan vep ključ: ključ dužine %zu mora da sadrži samo heksadecimalne cifre"
-
-#: panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "neispravan vep ključ: ključ dužine %zu mora da sadrži samo askri znakove"
-
-#: panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"neispravan vep ključ: pogrešna dužina ključa %zu. Ključ mora biti dužine 5/13 "
-"(askri) ili 10/26 (heksa)"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "neispravan vep ključ: propusna reč ne sme biti prazna"
-
-#: panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "neispravan vep ključ: propusna reč mora biti kraća od 64 znakova"
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Vrsta"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -3674,54 +2717,36 @@ msgstr "Otvoreni sistem"
 msgid "Shared Key"
 msgstr "Deljeni ključ"
 
-#: panels/network/wireless-security/ws-wep-key.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "_Ključ"
 
-#: panels/network/wireless-security/ws-wep-key.ui:94
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "P_rikaži ključ"
 
-#: panels/network/wireless-security/ws-wep-key.ui:152
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "VEP i_ndeks"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"neispravan vpa-psk: neispravna dužina ključa %zu. Mora biti [8,63] bajta ili "
-"64 heksadecimalnih cifara"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"neispravan vpa-psk: ne mogu da rastumačim ključ sa 64 bajta kao heksadecimalni"
-
-#: panels/network/wireless-security/ws-wpa-psk.ui:50
-msgid "_Type"
-msgstr "_Vrsta"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/edit-dialog.ui:64
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "O_baveštenja"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/edit-dialog.ui:116
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "Zvučne _uzbune"
 
-#: panels/notifications/edit-dialog.ui:172
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "_Oblačići obaveštenja"
 
-#: panels/notifications/edit-dialog.ui:188
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
@@ -3730,76 +2755,59 @@ msgstr ""
 "prikazivanja oblačića."
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/edit-dialog.ui:253
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "Prikaži sadržaj _poruke u oblačićima"
 
-#: panels/notifications/edit-dialog.ui:304
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "_Obaveštenja na ekranu zaključavanja"
 
-#: panels/notifications/edit-dialog.ui:355
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "Prikaži sadržaj p_oruke na ekranu zaključavanja"
 
-#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
-msgid "Notifications"
-msgstr "Obaveštenja"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "_Obaveštenja na ekranu zaključavanja"
 
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "Upravljajte prikazanim obaveštenjima i njihovim sadržajem"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/notifications/gnome-notifications-panel.desktop.in.in:7
-msgid "preferences-system-notifications"
-msgstr "preferences-system-notifications"
-
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "obaveštenja;vrpca;poruka;fioka;iskočko;"
 
-#: panels/notifications/notifications.ui:84
-msgid "Notification _Popups"
-msgstr "Oblačići _obaveštenja"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Poništi"
 
-#: panels/notifications/notifications.ui:134
-msgid "_Lock Screen Notifications"
-msgstr "_Obaveštenja na ekranu zaključavanja"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Unutrašnja _prijava"
 
-#. List of applications.
-#: panels/notifications/notifications.ui:180 panels/privacy/privacy.ui:875
-#: panels/sound/gvc-mixer-dialog.c:1768
-msgid "Applications"
-msgstr "Programi"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Povežite se na vaše podatke u oblaku"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:148
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Drugo"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Nema internet veze — povežite se da podesite nove naloge na mreži"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:551
-#, c-format
-msgid "%s Account"
-msgstr "„%s“ nalog"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:843
-msgid "Error removing account"
-msgstr "Greška u uklanjanju naloga"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:908
-#, c-format
-msgid "<b>%s</b> removed"
-msgstr "<b>%s</b> je uklonjen"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Dodajte nalog"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -3810,15 +2818,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Povežite se na vaše naloge na mreži i odlučite za šta ćete ih koristiti"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:7
-msgid "goa-panel"
-msgstr "goa-panel"
-
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -3827,32 +2826,7 @@ msgstr ""
 "gugl;fejsbuk;tviter;jahu;veb;mreža;ćaskanje;kalendar;pošta;kontakt;"
 "lični_oblak;kerberos;imap;smtp;poket;pročitajkasnije;"
 
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
-msgid "Undo"
-msgstr "Poništi"
-
-#: panels/online-accounts/online-accounts.ui:125
-msgid "Connect to your data in the cloud"
-msgstr "Povežite se na vaše podatke u oblaku"
-
-#: panels/online-accounts/online-accounts.ui:137
-msgid "No internet connection — connect to set up new online accounts"
-msgstr "Nema internet veze — povežite se da podesite nove naloge na mreži"
-
-#: panels/online-accounts/online-accounts.ui:159
-msgid "Add an account"
-msgstr "Dodajte nalog"
-
-#: panels/online-accounts/online-accounts.ui:264
-msgid "Remove Account"
-msgstr "Ukloni nalog"
-
-#: panels/power/cc-power-panel.c:253
-msgid "Unknown time"
-msgstr "Nepoznato vreme"
-
-#: panels/power/cc-power-panel.c:259
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
@@ -3861,7 +2835,7 @@ msgstr[1] "%i minuta"
 msgstr[2] "%i minuta"
 msgstr[3] "Jedan minut"
 
-#: panels/power/cc-power-panel.c:271
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
@@ -3870,14 +2844,7 @@ msgstr[1] "%i sata"
 msgstr[2] "%i sati"
 msgstr[3] "Jedan sat"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-power-panel.c:279
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%d %s %d %s"
-
-#: panels/power/cc-power-panel.c:280
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "sat"
@@ -3886,7 +2853,7 @@ msgstr[2] "sati"
 msgstr[3] "sat"
 
 # bug(danilo): plural-forms
-#: panels/power/cc-power-panel.c:281
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
@@ -3894,243 +2861,173 @@ msgstr[1] "minuta"
 msgstr[2] "minuta"
 msgstr[3] "minut"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:300
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s do potpune napunjenosti"
+# bug(danilo): plural-forms
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minuta"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:307
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Pažnja: preostaje još %s rada"
+# bug(danilo): plural-forms
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minuta"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:312
-#, c-format
-msgid "%s remaining"
-msgstr "Preostalo vreme: %s"
+# bug(danilo): plural-forms
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minuta"
 
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:317 panels/power/cc-power-panel.c:345
-msgid "Fully charged"
-msgstr "Potpuno puna"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minuta"
 
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:321 panels/power/cc-power-panel.c:349
-msgid "Empty"
-msgstr "Prazna"
+# bug(danilo): plural-forms
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minuta"
 
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:336
-msgid "Charging"
-msgstr "Puni se"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 sat"
 
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:341
-msgid "Discharging"
-msgstr "Prazni se"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minuta"
 
-#: panels/power/cc-power-panel.c:464
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Glavna"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minuta"
 
-#: panels/power/cc-power-panel.c:466
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Dodatna"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minuta"
 
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:537
-msgid "Wireless mouse"
-msgstr "Bežični miš"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 sata"
 
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:540
-msgid "Wireless keyboard"
-msgstr "Bežična tastatura"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:543
-msgid "Uninterruptible power supply"
-msgstr "Neprekidiv izvor napajanja"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:546
-msgid "Personal digital assistant"
-msgstr "Lični digitalni pomoćnik"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:549
-msgid "Cellphone"
-msgstr "Mobilni telefon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:552
-msgid "Media player"
-msgstr "Muzički uređaj"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:555 panels/wacom/cc-wacom-panel.c:793
-msgid "Tablet"
-msgstr "Tablica"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:558
-msgid "Computer"
-msgstr "Računar"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:561
-msgid "Gaming input device"
-msgstr "Ulazni uređaj za igre"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-power-panel.c:564 panels/power/cc-power-panel.c:804
-#: panels/power/cc-power-panel.c:2377
+#: panels/power/cc-power-panel.ui:58
 msgid "Battery"
 msgstr "Baterija"
 
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:618
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Puni se"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:625
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Upozorenje"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:630
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Skoro prazna"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:635
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Puna"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:640
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Potpuno puna"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:644
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Prazna"
-
-#: panels/power/cc-power-panel.c:802
-msgid "Batteries"
-msgstr "Baterije"
-
-#: panels/power/cc-power-panel.c:1239
-msgid "When _idle"
-msgstr "Kada _miruje"
-
-#: panels/power/cc-power-panel.c:1693
-msgid "Power Saving"
-msgstr "Ušteda napajanja"
-
-#: panels/power/cc-power-panel.c:1724
-msgid "_Screen brightness"
-msgstr "Osvetljaj _ekrana"
-
-#: panels/power/cc-power-panel.c:1743
-msgid "Automatic brightness"
-msgstr "Samostalno podešavanje osvetljenja"
-
-#: panels/power/cc-power-panel.c:1763
-msgid "_Keyboard brightness"
-msgstr "Osvetljaj _tastature"
-
-#: panels/power/cc-power-panel.c:1773
-msgid "_Dim screen when inactive"
-msgstr "_Zatamni ekran kada je neradan"
-
-#: panels/power/cc-power-panel.c:1798
-msgid "_Blank screen"
-msgstr "_Prazan ekran"
-
-#: panels/power/cc-power-panel.c:1835
-msgid "_Wi-Fi"
-msgstr "_Bežična"
-
-#: panels/power/cc-power-panel.c:1840
-msgid "Turn off Wi-Fi to save power."
-msgstr "Isključite bežičnu karticu da biste uštedeli bateriju."
-
-#: panels/power/cc-power-panel.c:1865
-msgid "_Mobile broadband"
-msgstr "_Mobilna širokopojasna"
-
-#: panels/power/cc-power-panel.c:1870
-msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
-msgstr ""
-"Isključite mobilni internet (3G, 4G, LTE, itd.) da biste uštedeli bateriju."
-
-#: panels/power/cc-power-panel.c:1923
-msgid "_Bluetooth"
-msgstr "_Blutut"
-
-#: panels/power/cc-power-panel.c:1928
-msgid "Turn off Bluetooth to save power."
-msgstr "Isključite blutut da biste uštedeli bateriju."
-
-#: panels/power/cc-power-panel.c:1987
-msgid "When on battery power"
-msgstr "Kada se napaja sa baterije"
-
-#: panels/power/cc-power-panel.c:1989
-msgid "When plugged in"
-msgstr "Kada je uključen"
-
-#: panels/power/cc-power-panel.c:2084
-msgid "Suspend"
-msgstr "Obustavi"
-
-#: panels/power/cc-power-panel.c:2085
-msgid "Power Off"
-msgstr "Isključi"
-
-#: panels/power/cc-power-panel.c:2086
-msgid "Hibernate"
-msgstr "Zamrzni"
-
-#: panels/power/cc-power-panel.c:2087
-msgid "Nothing"
-msgstr "Ništa"
-
-#. Frame header
-#: panels/power/cc-power-panel.c:2201
-msgid "Suspend & Power Button"
-msgstr "Dugme za gašenje i obustavu"
-
-#: panels/power/cc-power-panel.c:2240
-msgid "_Automatic suspend"
-msgstr "_Sam obustavi"
-
-#: panels/power/cc-power-panel.c:2241
-msgid "Automatic suspend"
-msgstr "Samostalna obustava uređaja"
-
-#: panels/power/cc-power-panel.c:2308
-msgid "_When the Power Button is pressed"
-msgstr "_Kada je dugme za napajanje pritisnuto"
-
-#: panels/power/cc-power-panel.c:2427 shell/cc-window.c:219
-#: shell/panel-list.ui:45
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
 msgid "Devices"
 msgstr "Uređaji"
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Isključi"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "Ušteda napajanja"
+
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "Samostalno podešavanje osvetljenja"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Ekran"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Čitač _ekrana"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "_Samostalno izvesti o problemu"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "Sam obustavi"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "Donje dugme"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Sam obustavi"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "Kada je _uključen"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Kada se napaja sa _baterije"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Zastoj"
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4138,179 +3035,17 @@ msgstr "Napajanje"
 
 #: panels/power/gnome-power-panel.desktop.in.in:4
 msgid "View your battery status and change power saving settings"
-msgstr "Pogledajte stanje vaše baterije i izmenite podešavanja uštede napajanja"
+msgstr ""
+"Pogledajte stanje vaše baterije i izmenite podešavanja uštede napajanja"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/power/gnome-power-panel.desktop.in.in:7
-msgid "gnome-power-manager"
-msgstr "gnome-power-manager"
-
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
-"napajanje;spavanje;obustava;zamrzavanje;baterija;osvetljaj;zatamnjenje;monitor;"
-"DPMS;mirovanje;"
-
-# bug(danilo): plural-forms
-#: panels/power/power.ui:17
-msgid "20 minutes"
-msgstr "20 minuta"
-
-# bug(danilo): plural-forms
-#: panels/power/power.ui:21
-msgid "25 minutes"
-msgstr "25 minuta"
-
-# bug(danilo): plural-forms
-#: panels/power/power.ui:29
-msgid "45 minutes"
-msgstr "45 minuta"
-
-#: panels/power/power.ui:33 panels/privacy/privacy.ui:42
-#: panels/privacy/privacy.ui:56
-msgid "1 hour"
-msgstr "1 sat"
-
-#: panels/power/power.ui:37
-msgid "80 minutes"
-msgstr "80 minuta"
-
-#: panels/power/power.ui:41
-msgid "90 minutes"
-msgstr "90 minuta"
-
-#: panels/power/power.ui:45
-msgid "100 minutes"
-msgstr "100 minuta"
-
-#: panels/power/power.ui:49
-msgid "2 hours"
-msgstr "2 sata"
-
-#: panels/power/power.ui:63 panels/privacy/privacy.ui:22
-msgid "1 minute"
-msgstr "1 minut"
-
-# bug(danilo): plural-forms
-#: panels/power/power.ui:67 panels/privacy/privacy.ui:26
-msgid "2 minutes"
-msgstr "2 minuta"
-
-# bug(danilo): plural-forms
-#: panels/power/power.ui:71 panels/privacy/privacy.ui:30
-msgid "3 minutes"
-msgstr "3 minuta"
-
-#: panels/power/power.ui:75
-msgid "4 minutes"
-msgstr "4 minuta"
-
-# bug(danilo): plural-forms
-#: panels/power/power.ui:79 panels/privacy/privacy.ui:34
-msgid "5 minutes"
-msgstr "5 minuta"
-
-# bug(danilo): plural-forms
-#: panels/power/power.ui:83
-msgid "8 minutes"
-msgstr "8 minuta"
-
-#: panels/power/power.ui:87
-msgid "10 minutes"
-msgstr "10 minuta"
-
-# bug(danilo): plural-forms
-#: panels/power/power.ui:91
-msgid "12 minutes"
-msgstr "12 minuta"
-
-#: panels/power/power.ui:155
-msgid "Automatic Suspend"
-msgstr "Sam obustavi"
-
-#: panels/power/power.ui:180
-msgid "_Plugged In"
-msgstr "Kada je _uključen"
-
-#: panels/power/power.ui:196
-msgid "On _Battery Power"
-msgstr "Kada se napaja sa _baterije"
-
-#: panels/power/power.ui:241 panels/power/power.ui:301
-#: panels/universal-access/uap.ui:1501
-msgid "Delay"
-msgstr "Zastoj"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "Potvrdi identitet"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:361
-msgid "Username"
-msgstr "Korisničko ime"
-
-#. Translators: This is a password needed for printing.
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:382
-#: panels/user-accounts/data/account-dialog.ui:240
-msgid "Password"
-msgstr "Lozinka"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:336
-msgid "Authentication Required"
-msgstr "Potrebno je potvrđivanje identiteta"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:791
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Štampač „%s“ je obrisan"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:1036
-msgid "Failed to add new printer."
-msgstr "Nisam uspeo da dodam novi štampač."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1371
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Ne mogu da učitam sučelje: %s"
-
-#: panels/printers/details-dialog.ui:63 panels/printers/printer-entry.ui:223
-msgid "Location"
-msgstr "Mesto"
-
-#. Translators: Name of column showing printer drivers
-#: panels/printers/details-dialog.ui:111
-#: panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "Upravljački program"
-
-#: panels/printers/details-dialog.ui:147
-msgid "Searching for preferred drivers…"
-msgstr "Tražim podesne upravljačke programe…"
-
-#: panels/printers/details-dialog.ui:169
-msgid "Search for Drivers"
-msgstr "Potražite upravljačke programe"
-
-#: panels/printers/details-dialog.ui:177
-msgid "Select from Database…"
-msgstr "Izaberi iz baze podataka…"
-
-#: panels/printers/details-dialog.ui:185
-msgid "Install PPD File…"
-msgstr "Instaliraj PPD datoteku…"
+"napajanje;spavanje;obustava;zamrzavanje;baterija;osvetljaj;zatamnjenje;"
+"monitor;DPMS;mirovanje;"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4322,210 +3057,97 @@ msgstr ""
 "Dodajte štampače, pogledajte poslove štampanja i odlučite kao želite da "
 "štampate"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/printers/gnome-printers-panel.desktop.in.in:7
-msgid "printer"
-msgstr "printer"
-
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "štampač;red;štampa;papir;mastilo;toner;"
 
-#. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/jobs-dialog.ui:44
-msgid "Domain"
-msgstr "Domen"
-
-#. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/jobs-dialog.ui:123
-msgid "A_uthenticate"
-msgstr "Potvrdi _identitet"
-
-#. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/jobs-dialog.ui:163
-msgid "Clear All"
-msgstr "Očisti sve"
-
-#. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/jobs-dialog.ui:225
-msgid "_Authenticate"
-msgstr "Potvrdi identitet"
-
-#. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/jobs-dialog.ui:354
-msgid "No Active Printer Jobs"
-msgstr "Nema pokrenutih poslova na štampaču"
-
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:384
-#: panels/printers/pp-new-printer-dialog.c:456
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Dodaj štampač"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Otključaj"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:210
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Nisam našao štampače"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:283
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Unesite adresu mreže ili potražite štampač"
 
-#: panels/printers/new-printer-dialog.ui:352
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Potrebno je potvrđivanje identiteta"
+
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Unesite korisničko ime i lozinku da vidite štampače na serveru štampanja."
 
-#. Translators: This button triggers the printing of a test page.
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/options-dialog.ui:22 panels/printers/pp-options-dialog.c:893
-msgid "Test Page"
-msgstr "Probna stranica"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Korisničko ime"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:135
-#: panels/printers/pp-details-dialog.c:435
-#, c-format
-msgid "%s Details"
-msgstr "Pojedinosti za „%s“"
-
-#: panels/printers/pp-details-dialog.c:184
-msgid "No suitable driver found"
-msgstr "Nisu pronađeni odgovarajući upravljački programi"
-
-#: panels/printers/pp-details-dialog.c:328
-msgid "Select PPD File"
-msgstr "Izaberite PPD datoteku"
-
-#: panels/printers/pp-details-dialog.c:337
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"Datoteke opisa Post skript štampača (*.ppd,*.PPD, *.ppd.gz, *PPD.gz, *.PPD."
-"GZ)"
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Mesto"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Upravljački program"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Tražim podesne upravljačke programe…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Potražite upravljačke programe"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Izaberi iz baze podataka…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Instaliraj PPD datoteku…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "Izaberite upravljački program štampača"
 
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/um-photo-dialog.c:104
-msgid "Select"
-msgstr "Izaberi"
-
-#: panels/printers/ppd-selection-dialog.ui:73
+#: panels/printers/ppd-selection-dialog.ui:75
 msgid "Loading drivers database…"
 msgstr "Učitavam bazu podataka upravljačkih programa…"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:539
-msgid "JetDirect Printer"
-msgstr "Štampač sa neposrednim mlazom"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Otkaži"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:795
-msgid "LPD Printer"
-msgstr "LPD štampač"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Izaberi"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "Jednostrano"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "Po dužoj strani (standardno)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:70
-#: panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "Po kraćoj strani (okrenuto)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "Uspravno"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "Položeno"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "Obrnuto položeno"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "Obrnuto uspravno"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-jobs-dialog.c:243
-msgctxt "print job"
-msgid "Pending"
-msgstr "Na čekanju"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-jobs-dialog.c:249
-msgctxt "print job"
-msgid "Paused"
-msgstr "Zaustavljen"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-jobs-dialog.c:254
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Potrebno je potvrđivanje identiteta"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-jobs-dialog.c:259
-msgctxt "print job"
-msgid "Processing"
-msgstr "Obrađujem"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-jobs-dialog.c:263
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Zaustavljen"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-jobs-dialog.c:267
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Otkazan"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-jobs-dialog.c:271
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Poništen"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-jobs-dialog.c:275
-msgctxt "print job"
-msgid "Completed"
-msgstr "Završen"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:399
+#: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
@@ -4534,202 +3156,38 @@ msgstr[1] "%u posla zahtevaju potvrđivanje identiteta"
 msgstr[2] "%u poslova zahteva potvrđivanje identiteta"
 msgstr[3] "Jedan posao zahteva potvrđivanje identiteta"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:617
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — pokrenuti poslovi"
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domen"
 
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:622
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Unesite punomoćstva da biste štampali sa štampača „%s“."
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "Potvrdi _identitet"
 
-#: panels/printers/pp-new-printer-dialog.c:402
-msgid "Unlock Print Server"
-msgstr "Otključaj server štampača"
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Očisti sve"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:406
-#, c-format
-msgid "Unlock %s."
-msgstr "Otključaj „%s“."
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "Potvrdi identitet"
 
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:411
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Unesite korisničko ime i lozinku da vidite štampače na „%s“."
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Nema pokrenutih poslova na štampaču"
 
-#: panels/printers/pp-new-printer-dialog.c:876
-msgid "Searching for Printers"
-msgstr "Tražim štampače"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1799
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1804
-msgid "Serial Port"
-msgstr "Serijski priključnik"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1811
-msgid "Parallel Port"
-msgstr "Paralelni priključnik"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1853
-#, c-format
-msgid "Location: %s"
-msgstr "Mesto: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1858
-#, c-format
-msgid "Address: %s"
-msgstr "Adresa: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1887
-msgid "Server requires authentication"
-msgstr "Server zahteva potvrđivanje identiteta"
-
-#: panels/printers/pp-options-dialog.c:83
-msgid "Two Sided"
-msgstr "Dvostrano"
-
-#: panels/printers/pp-options-dialog.c:84
-msgid "Paper Type"
-msgstr "Tip papira"
-
-#: panels/printers/pp-options-dialog.c:85
-msgid "Paper Source"
-msgstr "Izvor papira"
-
-#: panels/printers/pp-options-dialog.c:86
-msgid "Output Tray"
-msgstr "Izlazna traka"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "GhostScript pre-filtering"
-msgstr "Gost skript predfilter"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:534
-msgid "Pages per side"
-msgstr "Stranica po listu"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:546
-msgid "Two-sided"
-msgstr "Dvostrano"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Opšte"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Podešavanje stranice"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Instaljive opcije"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Posao"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Kvalitet slike"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Boja"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Završavanje"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:676
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Napredno"
-
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:908
-msgid "Test page"
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
 msgstr "Probna stranica"
 
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:76
-#: panels/printers/pp-ppd-option-widget.c:78
-#: panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "Sam odredi"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:80
-#: panels/printers/pp-ppd-option-widget.c:82
-#: panels/printers/pp-ppd-option-widget.c:84
-#: panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "Podrazumevano"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "Samo ugnježdeni Gost skript fontovi"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "Prevedi u 1° nivo postskripta"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "Prevedi u 2° nivo postskripta"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "Bez predfiltriranja"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "Proizvođač"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:598 panels/printers/printer-entry.ui:166
-msgid "No Active Jobs"
-msgstr "Nema aktivnih poslova"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:603
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
@@ -4738,636 +3196,363 @@ msgstr[1] "%u posla"
 msgstr[2] "%u poslova"
 msgstr[3] "jedan posao"
 
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:766
-msgid "Low on toner"
-msgstr "Ponestaje tonera"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:768
-msgid "Out of toner"
-msgstr "Nema više tonera"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:771
-msgid "Low on developer"
-msgstr "Ponestaje razvijača"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:774
-msgid "Out of developer"
-msgstr "Nema više razvijača"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:776
-msgid "Low on a marker supply"
-msgstr "Ponestaje markera"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:778
-msgid "Out of a marker supply"
-msgstr "Nema više mastila"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:780
-msgid "Open cover"
-msgstr "Otvoren poklopac"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:782
-msgid "Open door"
-msgstr "Otvorena vratanca"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:784
-msgid "Low on paper"
-msgstr "Ponestaje papira"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:786
-msgid "Out of paper"
-msgstr "Nema više papira"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:788
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Isključen"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:790
-#: panels/printers/pp-printer-entry.c:920
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Zaustavljen"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:792
-msgid "Waste receptacle almost full"
-msgstr "Posuda za otpad je skoro puna"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:794
-msgid "Waste receptacle full"
-msgstr "Posuda za otpad je puna"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:796
-msgid "The optical photo conductor is near end of life"
-msgstr "Optički provodnik fotografija je pri kraju života"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:798
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Optički provodnik fotografija više ne funkcioniše"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:906
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Spreman"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:911
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Ne prihvata poslove"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:916
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Obrađuje"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:940
-msgid "Clean print heads"
-msgstr "Očistite glave štampača"
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "Opcije štampanja"
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "Pojedinosti štampača"
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
 msgstr "Podrazumevano koristi štampač"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 msgid "Clean Print Heads"
 msgstr "Očisti glave štampača"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Ukloni štampač"
 
-#: panels/printers/printer-entry.ui:193
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Nema aktivnih poslova"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Mustra"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Nivoa mastila"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:312
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Ponovo pokrenite kada problem bude rešen."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:319
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Ponovo pokreni"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:20
-msgid "Add…"
-msgstr "Dodaj…"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Dodaj štampač…"
 
-#: panels/printers/printers.ui:186
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Dodaj štampač…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Nema štampača"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:200
-msgid "Add a Printer…"
-msgstr "Dodaj štampač…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:232
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Izgleda da nije dostupan pozadinski\n"
 "program za štampu."
 
-#: panels/privacy/cc-privacy-panel.c:387 panels/privacy/privacy.ui:280
-msgid "Screen Lock"
-msgstr "Zaključavanje ekrana"
-
-#: panels/privacy/cc-privacy-panel.c:438
-msgid "In use"
-msgstr "Koristi se"
-
-#: panels/privacy/cc-privacy-panel.c:443
-msgctxt "Location services status"
-msgid "On"
-msgstr "Uklj."
-
-#: panels/privacy/cc-privacy-panel.c:444
-msgctxt "Location services status"
-msgid "Off"
-msgstr "Isklj."
-
-#: panels/privacy/cc-privacy-panel.c:823 panels/privacy/privacy.ui:745
-msgid "Location Services"
-msgstr "Usluge mesta"
-
-#: panels/privacy/cc-privacy-panel.c:946 panels/privacy/privacy.ui:127
-msgid "Usage & History"
-msgstr "Upotreba i istorijat"
-
-#: panels/privacy/cc-privacy-panel.c:1075
-msgid "Empty all items from Trash?"
-msgstr "Da izbacim sve stavke iz smeća?"
-
-#: panels/privacy/cc-privacy-panel.c:1076
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Sve stavke iz smeća će biti trajno uklonjene."
-
-#: panels/privacy/cc-privacy-panel.c:1077
-msgid "_Empty Trash"
-msgstr "_Izbaci Smeće"
-
-#: panels/privacy/cc-privacy-panel.c:1100
-msgid "Delete all the temporary files?"
-msgstr "Da obrišem sve privremene datoteke?"
-
-#: panels/privacy/cc-privacy-panel.c:1101
-msgid "All the temporary files will be permanently deleted."
-msgstr "Sve privremene datoteke će biti trajno obrisane."
-
-#: panels/privacy/cc-privacy-panel.c:1102
-msgid "_Purge Temporary Files"
-msgstr "_Pročisti privremene datoteke"
-
-#: panels/privacy/cc-privacy-panel.c:1124 panels/privacy/privacy.ui:432
-msgid "Purge Trash & Temporary Files"
-msgstr "Očisti smeće i privremene datoteke"
-
-#: panels/privacy/cc-privacy-panel.c:1164 panels/privacy/privacy.ui:637
-msgid "Software Usage"
-msgstr "Upotreba softvera"
-
-#: panels/privacy/cc-privacy-panel.c:1205 panels/privacy/privacy.ui:959
-msgid "Problem Reporting"
-msgstr "Izveštavanje o problemu"
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: panels/privacy/cc-privacy-panel.c:1219
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-"Slanje izveštaja o tehničkim problemima nam pomaže da poboljšamo „%s“. "
-"Izveštaji se šalju bezimeno i očišćeni su od ličnih podataka."
-
-#: panels/privacy/cc-privacy-panel.c:1231 panels/privacy/privacy.ui:719
-msgid "Privacy Policy"
-msgstr "Politika privatnosti"
-
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:3
-msgid "Privacy"
-msgstr "Privatnost"
-
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
-msgid "Protect your personal information and control what others might see"
-msgstr "Zaštitite vaše lične podatke i odlučite šta drugi mogu da vide"
-
-#. FIXME
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:8
-msgid "preferences-system-privacy"
-msgstr "preferences-system-privacy"
-
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"ekran;zaključaj;dijagnoza;pad;urušavanje;lično;skorašnje;nedavno;privremen;prv;"
-"popis;naziv;mreža;identitet;"
-
-#: panels/privacy/privacy.ui:14
-msgid "Screen Turns Off"
-msgstr "Ekran se isključuje"
-
-#: panels/privacy/privacy.ui:18
-msgid "30 seconds"
-msgstr "30 sekundi"
-
-#: panels/privacy/privacy.ui:60 panels/privacy/privacy.ui:106
-msgid "1 day"
-msgstr "1 dan"
-
-#: panels/privacy/privacy.ui:64
-msgid "2 days"
-msgstr "2 dana"
-
-#: panels/privacy/privacy.ui:68
-msgid "3 days"
-msgstr "3 dana"
-
-#: panels/privacy/privacy.ui:72
-msgid "4 days"
-msgstr "4 dana"
-
-#: panels/privacy/privacy.ui:76
-msgid "5 days"
-msgstr "5 dana"
-
-#: panels/privacy/privacy.ui:80
-msgid "6 days"
-msgstr "6 dana"
-
-#: panels/privacy/privacy.ui:84 panels/privacy/privacy.ui:110
-msgid "7 days"
-msgstr "7 dana"
-
-#: panels/privacy/privacy.ui:88
-msgid "14 days"
-msgstr "14 dana"
-
-#: panels/privacy/privacy.ui:92 panels/privacy/privacy.ui:114
-msgid "30 days"
-msgstr "30 dana"
-
-#: panels/privacy/privacy.ui:118
-msgid "Forever"
-msgstr "Zauvek"
-
-#: panels/privacy/privacy.ui:148
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"Pamćenje istorijata olakšava ponovno pronalaženje nekih stvari. Te stavke se "
-"nikada ne dele preko mreže."
-
-#: panels/privacy/privacy.ui:176
-msgid "_Recently Used"
-msgstr "_Skoro korišćeno"
-
-#: panels/privacy/privacy.ui:207
-msgid "Retain _History"
-msgstr "Zadrži _istorijat"
-
-#: panels/privacy/privacy.ui:247
-msgid "Cl_ear Recent History"
-msgstr "Očisti _skorašnji istorijat"
-
-#: panels/privacy/privacy.ui:301
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "Zaključavanje ekrana štiti vašu privatnost kada ste odsutni."
-
-#: panels/privacy/privacy.ui:328
-msgid "Automatic Screen _Lock"
-msgstr "Samostalno _zaključavanje ekrana"
-
-#: panels/privacy/privacy.ui:362
-msgid "Lock screen _after blank for"
-msgstr "_Zaključaj ekran nakon zatamnjenja od"
-
-#: panels/privacy/privacy.ui:394
-msgid "Show _Notifications"
-msgstr "Prikaži _obaveštenja"
-
-#: panels/privacy/privacy.ui:454
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"Samostalno će pročistiti smeće i privremene datoteke da bi vam pomogao da "
-"održite računar slobodnim od nepotrebnih osetljivih podataka."
-
-#: panels/privacy/privacy.ui:483
-msgid "Automatically empty _Trash"
-msgstr "Sam izbaci _smeće"
-
-#: panels/privacy/privacy.ui:515
-msgid "Automatically purge Temporary _Files"
-msgstr "Sam pročisti privremene _datoteke"
-
-#: panels/privacy/privacy.ui:546
-msgid "Purge _After"
-msgstr "Pročisti _nakon"
-
-#: panels/privacy/privacy.ui:590
-msgid "_Empty Trash…"
-msgstr "_Izbaci Smeće…"
-
-#: panels/privacy/privacy.ui:606
-msgid "_Purge Temporary Files…"
-msgstr "_Pročisti privremene datoteke…"
-
-#: panels/privacy/privacy.ui:654
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"Slanjem podataka o softveru koji koristite vi nam pomažete da vam dostavimo "
-"tačnije preporuke. Takođe nam pomažete da poboljšamo naš softver.\n"
-"\n"
-"Prikupljanje svih podataka se radi u tajnosti, i nikada vaše podatke nećemo "
-"deliti sa trećim licima."
-
-#: panels/privacy/privacy.ui:681
-msgid "_Send software usage statistics"
-msgstr "_Pošalji podatke o korišćenju softvera"
-
-#: panels/privacy/privacy.ui:764
-msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"Usluge mesta omogućavaju programima da znaju vašu lokaciju. Tačnost je "
-"povećana uključivanjem bežične kartice i mobilne širokopojasne mreže."
-
-#: panels/privacy/privacy.ui:778
-msgid ""
-"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
-msgstr ""
-"Koristi Mozilinu uslugu lokacije: <a href='https://location.services.mozilla."
-"com/privacy'>politika privatnosti</a>"
-
-#: panels/privacy/privacy.ui:828
-msgid "_Location Services"
-msgstr "Usluge _mesta"
-
-#: panels/privacy/privacy.ui:1026
-msgid "_Automatic Problem Reporting"
-msgstr "_Samostalno izvesti o problemu"
-
-#: panels/region/cc-format-chooser.c:118
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperijalni"
-
-#: panels/region/cc-format-chooser.c:120
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrički"
-
-#: panels/region/cc-format-chooser.c:285
-msgid "No regions found"
-msgstr "Nisam pronašao područja"
-
-#: panels/region/cc-input-chooser.c:182
-msgid "No input sources found"
-msgstr "Nisam pronašao izvore ulaza"
-
-#: panels/region/cc-input-chooser.c:1012
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Drugo"
-
-#: panels/region/cc-region-panel.c:881
-msgid "No input source selected"
-msgstr "Nije izabran izvor ulaza"
-
-#: panels/region/cc-region-panel.c:1773
-msgid "Login _Screen"
-msgstr "Ekran _za prijavljivanje"
-
-#: panels/region/format-chooser.ui:7
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Oblici"
 
-#: panels/region/format-chooser.ui:120
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Mesta pretrage"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Oblici"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Oblici"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "Nisam našao rezultate"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Pregled"
 
-#: panels/region/format-chooser.ui:137
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Datumi"
 
-#: panels/region/format-chooser.ui:168
-msgid "Times"
-msgstr "Vremena"
-
-#: panels/region/format-chooser.ui:199
+#: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
 msgstr "Datumi i vremena"
 
-#: panels/region/format-chooser.ui:230
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Brojevi"
 
-#: panels/region/format-chooser.ui:247
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Merenje"
 
-#: panels/region/format-chooser.ui:264
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Papir"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "Vaš nalog"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Jezik"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr "_Formati"
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Ekran _za prijavljivanje"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Region i jezik"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr ""
 "Izaberite vaš prikazani jezik, zapise, rasporede tastature i izvore ulaza"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/region/gnome-region-panel.desktop.in.in:7
-msgid "preferences-desktop-locale"
-msgstr "preferences-desktop-locale"
-
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "jezik;raspored;tastatura;unos;"
 
-#: panels/region/input-chooser.ui:5
-msgid "Add an Input Source"
-msgstr "Dodajte izvor ulaza"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Izaberite kako treba da se rukuje sa nosačima podataka"
 
-#: panels/region/input-chooser.ui:76
-msgid "Input methods can’t be used on the login screen"
-msgstr "Načini unosa ne mogu biti korišćeni u ekranu prijavljivanja"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _audio"
 
-#: panels/region/input-options.ui:7
-msgid "Input Source Options"
-msgstr "Izbori izvora ulaza"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD video"
 
-#: panels/region/input-options.ui:27
-msgid "Use the _same source for all windows"
-msgstr "Koristi _isti izvor za sve prozore"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Muzički program"
 
-#: panels/region/input-options.ui:45
-msgid "Allow _different sources for each window"
-msgstr "Dopusti _različite izvore za svaki prozor"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Softver"
 
-#: panels/region/input-options.ui:85
-msgid "Switch to previous source"
-msgstr "Prebacite se na prethodni izvor"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Ostali nosači podataka…"
 
-#: panels/region/input-options.ui:102
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Razmak"
-
-#: panels/region/input-options.ui:116
-msgid "Switch to next source"
-msgstr "Prebacite se na sledeći izvor"
-
-#: panels/region/input-options.ui:133
-msgid "Super+Space"
-msgstr "Super+Razmak"
-
-#: panels/region/input-options.ui:147
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "Možete da promenite ove prečice u podešavanjima tastature"
-
-#: panels/region/input-options.ui:164
-msgid "Alternative switch to next source"
-msgstr "Zamenski prelazak na sledeći izvor"
-
-#: panels/region/input-options.ui:181
-msgid "Left+Right Alt"
-msgstr "Levi+desni Alt"
-
-#: panels/region/region.ui:67
-#: panels/user-accounts/data/user-accounts-dialog.ui:348
-msgid "_Language"
-msgstr "_Jezik"
-
-#: panels/region/region.ui:85
-msgid "English (United Kingdom)"
-msgstr "Engleski (Velika Britanija)"
-
-#: panels/region/region.ui:112
-msgid "Restart the session for changes to take effect"
-msgstr "Ponovo pokrenite sesiju kako bi izmene stupile u dejstvo"
-
-#: panels/region/region.ui:134
-msgid "Restart…"
-msgstr "Ponovo pokreni…"
-
-#: panels/region/region.ui:169
-msgid "_Formats"
-msgstr "_Formati"
-
-#: panels/region/region.ui:187
-msgid "United Kingdom"
-msgstr "Velika Britanija"
-
-#: panels/region/region.ui:229
-msgid "Input Sources"
-msgstr "Izvori ulaza"
-
-#: panels/region/region.ui:245
-msgid "_Options"
-msgstr "_Opcije"
-
-#: panels/region/region.ui:311
-msgid "Add input source"
-msgstr "Dodaj izvor ulaza"
-
-#: panels/region/region.ui:336
-msgid "Remove input source"
-msgstr "Ukloni izvore ulaza"
-
-#: panels/region/region.ui:386
-msgid "Move input source up"
-msgstr "Premesti izvor ulaza gore"
-
-#: panels/region/region.ui:411
-msgid "Move input source down"
-msgstr "Premesti izvor ulaza dole"
-
-#: panels/region/region.ui:461
-msgid "Configure input source"
-msgstr "Podesi izvor ulaza"
-
-#: panels/region/region.ui:486
-msgid "Show input source keyboard layout"
-msgstr "Prikaži raspored tastature izvora ulaza"
-
-#: panels/region/region.ui:530
-msgid "Login settings are used by all users when logging into the system"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
 msgstr ""
-"Podešavanja prijavljivanja koriste svi korisnici kada se prijavljuju na sistem"
+"_Nikada ne pitaj ili ne pokreći programe nakon ubacivanja nosača podataka"
 
-#: panels/search/cc-search-locations-dialog.c:639
-msgid "Select Location"
-msgstr "Izaberi mesto"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Izaberite kako treba da se rukuje ostalim nosačima podataka"
 
-#: panels/search/cc-search-locations-dialog.c:643
-msgid "_OK"
-msgstr "U _redu"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Radnja:"
 
-#: panels/search/cc-search-panel.c:178
-msgid "No applications found"
-msgstr "Nisam pronašao programe"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Vrsta:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Prenosni nosači"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Podesite prenosne medije"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"uređaj;sistem;osnovno;program;omiljeno;cd;dvd;usb;zvuk;snimak;disk;uklonjivi;"
+"medijum;nosač;samopokretanje;uređaj;sistem;osnovno;program;omiljeno;cd;dvd;"
+"usb;zvuk;snimak;disk;uklonjivi;medijum;nosač;samopokretanje;device;system;"
+"default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;"
+"autorun;"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Zaključavanje ekrana"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "_Prazan ekran"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Samostalno _zaključavanje ekrana"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "Samostalno _zaključavanje ekrana"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "Prikaži _obaveštenja"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Zaključavanje _ekrana"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Privatnost"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Podešavanja zvuka"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Mesta pretrage"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Mesta"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Obeleživači"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Drugo"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Mesto"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Programi"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Mesta pretrage"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
@@ -5376,121 +3561,147 @@ msgstr ""
 "Odlučite koji programi će prikazivati rezultate pretrage u pregledu "
 "aktivnosti"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/search/gnome-search-panel.desktop.in.in:7
-msgid "preferences-system-search"
-msgstr "preferences-system-search"
-
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "nađi;traži;pronađi;potraži;popis;indeks;sakrij;privatnost;rezultati;"
 
-#: panels/search/search-locations-dialog.ui:9
-msgid "Search Locations"
-msgstr "Mesta pretrage"
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Mreže"
 
-#: panels/search/search-locations-dialog.ui:43
-msgid "Places"
-msgstr "Mesta"
-
-#: panels/search/search-locations-dialog.ui:73
-msgid "Bookmarks"
-msgstr "Obeleživači"
-
-#: panels/search/search-locations-dialog.ui:130
-msgid "Other"
-msgstr "Drugo"
-
-#: panels/search/search.ui:66
-msgid "Move Up"
-msgstr "Pomeri gore"
-
-#: panels/search/search.ui:83
-msgid "Move Down"
-msgstr "Pomeri dole"
-
-#: panels/search/search.ui:119
-msgid "Preferences"
-msgstr "Postavke"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:305
-msgid "No networks selected for sharing"
-msgstr "Nisu izabrane mreže za deljenje"
-
-#: panels/sharing/cc-sharing-panel.c:275
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Uklj."
-
-#: panels/sharing/cc-sharing-panel.c:277 panels/sharing/cc-sharing-panel.c:304
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Isklj."
-
-#: panels/sharing/cc-sharing-panel.c:307
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Uključeno"
-
-#: panels/sharing/cc-sharing-panel.c:310
-msgctxt "service is active"
-msgid "Active"
-msgstr "Radna"
-
-#: panels/sharing/cc-sharing-panel.c:381
-msgid "Choose a Folder"
-msgstr "Izaberite fasciklu"
-
-#: panels/sharing/cc-sharing-panel.c:693
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr ""
-"Deljenje datoteka vam omogućava da delite vašu javnu fasciklu sa drugima na "
-"vašoj tekućoj mreži koristeći: <a href=\"dav://%s\">dav://%s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:695
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"Kada je uključeno udaljeno prijavljivanje, udaljeni korisnici mogu da se povežu "
-"koristeći naredbu bezbedne školjke:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:697
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"Deljenje ekrana omogućava udaljenim korisnicima da vide ili da upravljaju vašim "
-"ekranom tako što će se povezati na <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:809
-msgid "Copy"
-msgstr "Umnožavanje"
-
-#: panels/sharing/cc-sharing-panel.c:1236
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Deljenje"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Naziv računara"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Deljenje datoteka"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Udaljeni pregled"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Deljenje _medija"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Udaljeno p_rijavljivanje"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Deljenje datoteka"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Zahteva lozinku"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Udaljeno prijavljivanje"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Udaljeni pregled"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Uključite ili isključite udaljeno prijavljivanje"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Dozvoli ud_aljeno upravljanje"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
+msgstr "_Dozvoli vezama da kontrolišu ekran"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "Niste povezani"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Umnožavanje"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "Obriši adresu"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "Potvrđivanje _identiteta"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Korisničko ime"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Upisujem otiske prstiju"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Deljenje medija"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Delite muziku, fotografije i snimke na mreži."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Fascikle"
 
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
 msgstr "Odlučite šta želite da delite s drugima"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/sharing/gnome-sharing-panel.desktop.in.in:7
-msgid "preferences-system-sharing"
-msgstr "preferences-system-sharing"
-
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -5503,10 +3714,6 @@ msgstr ""
 "server;iscrtavač;share;sharing;ssh;host;name;remote;desktop;media;audio;"
 "video;pictures;photos;movies;server;renderer;"
 
-#: panels/sharing/networks.ui:19
-msgid "Networks"
-msgstr "Mreže"
-
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
 msgstr "Uključite ili isključite udaljeno prijavljivanje"
@@ -5514,990 +3721,1040 @@ msgstr "Uključite ili isključite udaljeno prijavljivanje"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr ""
-"Potrebno je potvrđivanje identiteta za uključivanje ili isključivanje udaljenog "
-"prijavljivanja"
+"Potrebno je potvrđivanje identiteta za uključivanje ili isključivanje "
+"udaljenog prijavljivanja"
 
-#: panels/sharing/sharing.ui:46
-msgid "_Computer Name"
-msgstr "_Naziv računara"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flikr"
 
-#: panels/sharing/sharing.ui:104
-msgid "_File Sharing"
-msgstr "_Deljenje datoteka"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "Deljenje"
 
-#: panels/sharing/sharing.ui:147
-msgid "_Screen Sharing"
-msgstr "Deljenje e_krana"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: panels/sharing/sharing.ui:190
-msgid "_Media Sharing"
-msgstr "Deljenje _medija"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: panels/sharing/sharing.ui:233
-msgid "_Remote Login"
-msgstr "Udaljeno p_rijavljivanje"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_Uravnoteženost:"
 
-#: panels/sharing/sharing.ui:272
-msgid "Some services are disabled because of no network access."
-msgstr "Neke usluge su isključene jer nema pristupa na mrežu."
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_Iščezavanje:"
 
-#: panels/sharing/sharing.ui:286 panels/sharing/sharing.ui:413
-msgid "File Sharing"
-msgstr "Deljenje datoteka"
-
-#: panels/sharing/sharing.ui:333
-msgid "_Require Password"
-msgstr "_Zahteva lozinku"
-
-#: panels/sharing/sharing.ui:424 panels/sharing/sharing.ui:496
-msgid "Remote Login"
-msgstr "Udaljeno prijavljivanje"
-
-#: panels/sharing/sharing.ui:519 panels/sharing/sharing.ui:765
-msgid "Screen Sharing"
-msgstr "Deljenje ekrana"
-
-#: panels/sharing/sharing.ui:577
-msgid "_Allow connections to control the screen"
-msgstr "_Dozvoli vezama da kontrolišu ekran"
-
-#: panels/sharing/sharing.ui:622
-msgid "_Password:"
-msgstr "_Lozinka:"
-
-#: panels/sharing/sharing.ui:652
-msgid "_Show Password"
-msgstr "_Prikaži lozinku"
-
-#: panels/sharing/sharing.ui:683
-msgid "Access Options"
-msgstr "Mogućnosti pristupa"
-
-#: panels/sharing/sharing.ui:697
-msgid "_New connections must ask for access"
-msgstr "_Nove veze moraju zatražiti pristup"
-
-#: panels/sharing/sharing.ui:715
-msgid "_Require a password"
-msgstr "_Zahtevaj lozinku"
-
-#: panels/sharing/sharing.ui:776 panels/sharing/sharing.ui:870
-msgid "Media Sharing"
-msgstr "Deljenje medija"
-
-#: panels/sharing/sharing.ui:809
-msgid "Share music, photos and videos over the network."
-msgstr "Delite muziku, fotografije i snimke na mreži."
-
-#: panels/sharing/sharing.ui:824
-msgid "Folders"
-msgstr "Fascikle"
-
-#: panels/sound/data/gnome-sound-panel.desktop.in.in:3
-msgid "Sound"
-msgstr "Zvuk"
-
-#: panels/sound/data/gnome-sound-panel.desktop.in.in:4
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "Izmenite nivoe zvuka, ulaze, izlaze i zvuke upozorenja"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/sound/data/gnome-sound-panel.desktop.in.in:7
-msgid "multimedia-volume-control"
-msgstr "multimedia-volume-control"
-
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/sound/data/gnome-sound-panel.desktop.in.in:20
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "kartica;mikrofon;jačina zvuka;iščezavanje;balans;blutut;slušalice;zvuk;"
-
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:6
-msgid "Bark"
-msgstr "Lavež"
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:12
-msgid "Drip"
-msgstr "Kapanje"
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:18
-msgid "Glass"
-msgstr "Staklo"
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:24
-msgid "Sonar"
-msgstr "Sonar"
-
-#: panels/sound/gvc-balance-bar.c:104
-msgctxt "balance"
-msgid "Left"
-msgstr "Levo"
-
-#: panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Right"
-msgstr "Desno"
-
-#: panels/sound/gvc-balance-bar.c:108
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "Iza"
 
-#: panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "Ispred"
 
-#: panels/sound/gvc-balance-bar.c:112
-msgctxt "balance"
-msgid "Minimum"
-msgstr "Najmanje"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Maximum"
-msgstr "Najviše"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Sistemski zvuci"
 
-#: panels/sound/gvc-balance-bar.c:288
-msgid "_Balance:"
-msgstr "_Uravnoteženost:"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Jačina zvuka _upozorenja:"
 
-#: panels/sound/gvc-balance-bar.c:291
-msgid "_Fade:"
-msgstr "_Iščezavanje:"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Isključuje jačinu zvuka"
 
-#: panels/sound/gvc-balance-bar.c:294
-msgid "_Subwoofer:"
-msgstr "_Sabvufer:"
-
-#: panels/sound/gvc-channel-bar.c:610 panels/sound/gvc-channel-bar.c:619
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: panels/sound/gvc-channel-bar.c:614
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "Bez pojačanja"
-
-#: panels/sound/gvc-combo-box.c:166 panels/sound/gvc-mixer-dialog.c:253
-#: panels/sound/gvc-mixer-dialog.c:520
-msgid "_Profile:"
-msgstr "_Profil:"
-
-#: panels/sound/gvc-mixer-dialog.c:255
-msgid "_Test Speakers"
-msgstr "_Proveri zvučnike"
-
-#: panels/sound/gvc-mixer-dialog.c:424
-msgid "Peak detect"
-msgstr "Otkrivanje vrhunca"
-
-#: panels/sound/gvc-mixer-dialog.c:1499
-msgid "Device"
-msgstr "Uređaj"
-
-#: panels/sound/gvc-mixer-dialog.c:1562
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "Provera zvučnika za „%s“"
-
-#: panels/sound/gvc-mixer-dialog.c:1617
-msgid "_Output volume:"
-msgstr "Jačina _izlaznog zvuka:"
-
-#: panels/sound/gvc-mixer-dialog.c:1631
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Izlaz"
 
-#: panels/sound/gvc-mixer-dialog.c:1636
-msgid "C_hoose a device for sound output:"
-msgstr "Izaberite uređaj kao zvučni i_zlaz:"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Jačina _izlaznog zvuka:"
 
-#: panels/sound/gvc-mixer-dialog.c:1658
-msgid "Settings for the selected device:"
-msgstr "Podešavanja za izabrani uređaj:"
-
-#: panels/sound/gvc-mixer-dialog.c:1669
-msgid "Input"
-msgstr "Ulaz"
-
-#: panels/sound/gvc-mixer-dialog.c:1676
-msgid "_Input volume:"
-msgstr "Jačina _ulaznog zvuka:"
-
-#: panels/sound/gvc-mixer-dialog.c:1697
-msgid "Input level:"
-msgstr "Nivo ulaza:"
-
-#: panels/sound/gvc-mixer-dialog.c:1723
-msgid "C_hoose a device for sound input:"
-msgstr "Izaberite uređaj kao zvučni u_laz:"
-
-#: panels/sound/gvc-mixer-dialog.c:1747
-msgid "Sound Effects"
-msgstr "Zvučni efekti"
-
-#: panels/sound/gvc-mixer-dialog.c:1754
-msgid "_Alert volume:"
-msgstr "Jačina zvuka _upozorenja:"
-
-#: panels/sound/gvc-mixer-dialog.c:1775
-msgid "No application is currently playing or recording audio."
-msgstr "Nijedan program trenutno ne reprodukuje ili snima zvuk."
-
-#: panels/sound/gvc-sound-theme-chooser.c:187
-msgid "Built-in"
-msgstr "Ugrađen"
-
-#: panels/sound/gvc-sound-theme-chooser.c:446
-#: panels/sound/gvc-sound-theme-chooser.c:458
-#: panels/sound/gvc-sound-theme-chooser.c:470
-msgid "Sound Preferences"
-msgstr "Postavke zvuka"
-
-#: panels/sound/gvc-sound-theme-chooser.c:449
-#: panels/sound/gvc-sound-theme-chooser.c:460
-#: panels/sound/gvc-sound-theme-chooser.c:472
-msgid "Testing event sound"
-msgstr "Provera zvučnog signala"
-
-#: panels/sound/gvc-sound-theme-chooser.c:544
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "Osnovno"
-
-#: panels/sound/gvc-sound-theme-chooser.c:545
-msgid "From theme"
-msgstr "Iz teme"
-
-#: panels/sound/gvc-sound-theme-chooser.c:720
-msgid "C_hoose an alert sound:"
-msgstr "Izaberite zvuk za _upozorenje:"
-
-#: panels/sound/gvc-speaker-test.c:229
-msgid "Stop"
-msgstr "Zaustavi"
-
-#: panels/sound/gvc-speaker-test.c:229 panels/sound/gvc-speaker-test.c:341
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Proveri"
 
-#: panels/sound/gvc-speaker-test.c:237
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "_Adresa podešavanja"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Sabvufer"
 
-#: panels/sound/sound-theme-file-utils.c:288
-msgid "Custom"
-msgstr "Proizvoljno"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Ulaz"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:353
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Osnovno"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Nivo ulaza:"
 
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Srednji"
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "Pojačava jačinu zvuka"
 
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Veliki"
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Jačina zvuka _upozorenja:"
 
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Veći"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Najveći"
-
-#: panels/universal-access/cc-ua-panel.c:369
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d piksel"
-msgstr[1] "%d piksela"
-msgstr[2] "%d piksela"
-msgstr[3] "jedan piksel"
-
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "Olakšajte posmatranje, slušanje, kucanje, ukazivanje i klikanje"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:7
-msgid "preferences-desktop-accessibility"
-msgstr "preferences-desktop-accessibility"
-
-#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
-msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
 msgstr ""
-"tastatura;miš;a11y;pristupačnost;kontrast;zum;čitač;ekran;tekst;slova;"
-"veličina;Iks_pristup;lepljivi;tasteri;spori;odskočni;miš;dvostruki;klik;"
-"zastoj;ponovi;trepni;"
 
-#: panels/universal-access/uap.ui:89
-msgid "_Always Show Universal Access Menu"
-msgstr "_Uvek prikaži izbornik univerzalnog pristupa"
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Zvuk"
 
-#: panels/universal-access/uap.ui:131
-msgid "Seeing"
-msgstr "Vidnost"
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Izmenite nivoe zvuka, ulaze, izlaze i zvuke upozorenja"
 
-#: panels/universal-access/uap.ui:177
-msgid "_High Contrast"
-msgstr "_Veliki kontrast"
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"kartica;mikrofon;jačina zvuka;iščezavanje;balans;blutut;slušalice;zvuk;"
 
-#: panels/universal-access/uap.ui:224
-msgid "_Large Text"
-msgstr "_Veliki tekst"
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
 
-#: panels/universal-access/uap.ui:269
-msgid "C_ursor Size"
-msgstr "Veličina _pokazivača"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Obaveštenja"
 
-#: panels/universal-access/uap.ui:316
-#: panels/universal-access/zoom-options.ui:98
-msgid "_Zoom"
-msgstr "_Povećaj"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_Naziv:"
 
-#: panels/universal-access/uap.ui:362
-msgid "Screen _Reader"
-msgstr "Čitač _ekrana"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: panels/universal-access/uap.ui:408 panels/universal-access/uap.ui:1237
-msgid "_Sound Keys"
-msgstr "Tasteri _zvuka"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: panels/universal-access/uap.ui:470
-msgid "Hearing"
-msgstr "Čujnost"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "Samostalno _poveži"
 
-#: panels/universal-access/uap.ui:514 panels/universal-access/uap.ui:1340
-msgid "_Visual Alerts"
-msgstr "_Vizuelna upozorenja"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Ukloni uređaj"
 
-#: panels/universal-access/uap.ui:622
-msgid "Screen _Keyboard"
-msgstr "_Tastatura na ekranu"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: panels/universal-access/uap.ui:667
-msgid "R_epeat Keys"
-msgstr "Ponavljanj_e tastera"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Ne mogu da se povežem na domen „%s“: %s"
 
-#: panels/universal-access/uap.ui:713
-msgid "Cursor _Blinking"
-msgstr "_Treptanje pokazivača"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "Univerzalni pristup"
 
-#: panels/universal-access/uap.ui:759
-msgid "_Typing Assist (AccessX)"
-msgstr "_Pomoć pri kucanju (Iks pristup)"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: panels/universal-access/uap.ui:820
-msgid "Pointing & Clicking"
-msgstr "Ukazivanje i klikanje"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Dodaj uređaj"
 
-#: panels/universal-access/uap.ui:866
-msgid "_Mouse Keys"
-msgstr "Tasteri _miša"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: panels/universal-access/uap.ui:911
-msgid "_Click Assist"
-msgstr "Pomoć pri _kliku"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: panels/universal-access/uap.ui:957
-msgid "_Double-Click Delay"
-msgstr "Zastoj _duplog klika"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: panels/universal-access/uap.ui:977
-msgid "Double-Click Delay"
-msgstr "Zastoj duplog klika"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: panels/universal-access/uap.ui:1042
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Trepćući pokazivač"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Pokazivač trepće unutar tekstualnih polja."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Brzina"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Brzina treptanja pokazivača"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
 msgstr "Veličina pokazivača"
 
-#: panels/universal-access/uap.ui:1069
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 "Veličina pokazivača se može kombinovati sa zumom kako bi pokazivač bio "
 "uočljiviji."
 
-#: panels/universal-access/uap.ui:1105
-msgid "Screen Reader"
-msgstr "Čitač ekrana"
-
-#: panels/universal-access/uap.ui:1122
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "Čitač ekrana čita prikazani tekst kako pomerate prvi plan."
-
-#: panels/universal-access/uap.ui:1155
-msgid "_Screen Reader"
-msgstr "_Čitač ekrana"
-
-#: panels/universal-access/uap.ui:1194
-msgid "Sound Keys"
-msgstr "Tasteri zvuka"
-
-#: panels/universal-access/uap.ui:1212
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr ""
-"Zapišti kada je zaključavanje brojeva ili velikih slova uključeno ili isključeno."
-
-#: panels/universal-access/uap.ui:1282
-msgid "Visual Alerts"
-msgstr "Vizuelna upozorenja"
-
-#: panels/universal-access/uap.ui:1286
-msgid "_Test flash"
-msgstr "Probni _bljesak"
-
-#: panels/universal-access/uap.ui:1315
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "Koristi vidno ukazivanje kada se desi zvuk upozorenja."
-
-#: panels/universal-access/uap.ui:1366
-msgid "Flash the _window title"
-msgstr "Bljesni naslovom _prozora"
-
-#: panels/universal-access/uap.ui:1384
-msgid "Flash the entire _screen"
-msgstr "Bljesni celim _ekranom"
-
-#: panels/universal-access/uap.ui:1429
-msgid "Repeat Keys"
-msgstr "Ponavljanje tastera"
-
-#: panels/universal-access/uap.ui:1459
-msgid "Key presses repeat when key is held down."
-msgstr "Pritisci tastera se ponavljaju kada se taster drži pritisnutim."
-
-#: panels/universal-access/uap.ui:1538
-msgid "Repeat keys delay"
-msgstr "Zastoj ponavljanja tastera"
-
-#: panels/universal-access/uap.ui:1586 panels/universal-access/uap.ui:1719
-msgid "Speed"
-msgstr "Brzina"
-
-#: panels/universal-access/uap.ui:1623
-msgid "Repeat keys speed"
-msgstr "Brzina ponavljanja tastera"
-
-#: panels/universal-access/uap.ui:1647
-msgid "Cursor Blinking"
-msgstr "Trepćući pokazivač"
-
-#: panels/universal-access/uap.ui:1677
-msgid "Cursor blinks in text fields."
-msgstr "Pokazivač trepće unutar tekstualnih polja."
-
-#: panels/universal-access/uap.ui:1756
-msgid "Cursor blinking speed"
-msgstr "Brzina treptanja pokazivača"
-
-#: panels/universal-access/uap.ui:1792
-msgid "Typing Assist"
-msgstr "Pomoć kucanja"
-
-#: panels/universal-access/uap.ui:1831
-msgid "_Sticky Keys"
-msgstr "_Lepljivi tasteri"
-
-#: panels/universal-access/uap.ui:1848
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "Shvata niz tastera modifikatora kao kombinaciju tastera"
-
-#: panels/universal-access/uap.ui:1872
-msgid "_Disable if two keys are pressed together"
-msgstr "_Isključi ako su dva tastera pritisnuta istovremeno"
-
-#: panels/universal-access/uap.ui:1890
-msgid "Beep when a _modifier key is pressed"
-msgstr "Zapišti kada je pritisnut _izmenjivač"
-
-#: panels/universal-access/uap.ui:1938
-msgid "S_low Keys"
-msgstr "_Spori tasteri"
-
-#: panels/universal-access/uap.ui:1955
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "Ubacuje kašnjenje između pritiska tastera i njegovog prihvatanja"
-
-#: panels/universal-access/uap.ui:1988 panels/universal-access/uap.ui:2201
-#: panels/universal-access/uap.ui:2538
-msgid "A_cceptance delay:"
-msgstr "_Kašnjenje prihvatanja:"
-
-#: panels/universal-access/uap.ui:2010
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Kratak"
-
-#: panels/universal-access/uap.ui:2029
-msgid "Slow keys typing delay"
-msgstr "Zastoj kucanja sporih tastera"
-
-#: panels/universal-access/uap.ui:2044
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Veliki"
-
-#: panels/universal-access/uap.ui:2071
-msgid "Beep when a key is pr_essed"
-msgstr "Zapišti kada je pritisnut _taster"
-
-#: panels/universal-access/uap.ui:2088
-msgid "Beep when a key is _accepted"
-msgstr "Zapišti kada je taster _prihvaćen"
-
-#: panels/universal-access/uap.ui:2105 panels/universal-access/uap.ui:2284
-msgid "Beep when a key is _rejected"
-msgstr "Zapišti kada taster nije p_rihvaćen"
-
-#: panels/universal-access/uap.ui:2151
-msgid "_Bounce Keys"
-msgstr "_Odskočni tasteri"
-
-#: panels/universal-access/uap.ui:2168
-msgid "Ignores fast duplicate keypresses"
-msgstr "Zanemaruje uzastopne dvostruke pritiske na taster"
-
-#: panels/universal-access/uap.ui:2223
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Kratak"
-
-#: panels/universal-access/uap.ui:2242
-msgid "Bounce keys typing delay"
-msgstr "Zastoj kucanja odskočnih tastera"
-
-#: panels/universal-access/uap.ui:2257
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Veliki"
-
-#: panels/universal-access/uap.ui:2370
-msgid "_Enable by Keyboard"
-msgstr "_Uključi tastaturom"
-
-#: panels/universal-access/uap.ui:2387
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "Uključite/isključite funkcije pristupačnosti koristeći tastaturu"
-
-#: panels/universal-access/uap.ui:2451
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "Pomoć pri kliku"
 
-#: panels/universal-access/uap.ui:2487
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "_Simulirani sekundarni klik"
 
-#: panels/universal-access/uap.ui:2505
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "Uključi/isključi sekundarni klik držeći pritisnut primarni taster"
 
-#: panels/universal-access/uap.ui:2559
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Kašnjenje prihvatanja:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Kratak"
 
-#: panels/universal-access/uap.ui:2578
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "Zastoj sekundarnog klika"
 
-#: panels/universal-access/uap.ui:2593
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Veliki"
 
-#: panels/universal-access/uap.ui:2650
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "Klik _lebdenja"
 
-#: panels/universal-access/uap.ui:2668
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "Uključi/isključi klik kada pokazivač lebdi"
 
-#: panels/universal-access/uap.ui:2701
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "_Zastoj:"
 
-#: panels/universal-access/uap.ui:2723
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Kratak"
 
-#: panels/universal-access/uap.ui:2754
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Veliki"
 
-#: panels/universal-access/uap.ui:2790
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "_Osetljivost na pokret:"
 
-#: panels/universal-access/uap.ui:2812
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Mali"
 
-#: panels/universal-access/uap.ui:2843
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Veliki"
 
-#: panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Ponavljanje tastera"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Pritisci tastera se ponavljaju kada se taster drži pritisnutim."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Zastoj ponavljanja tastera"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Brzina ponavljanja tastera"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Pomoć kucanja"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Lepljivi tasteri"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Shvata niz tastera modifikatora kao kombinaciju tastera"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Isključi ako su dva tastera pritisnuta istovremeno"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Zapišti kada je pritisnut _izmenjivač"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Spori tasteri"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Ubacuje kašnjenje između pritiska tastera i njegovog prihvatanja"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
-msgstr "Kratko"
+msgstr "Kratak"
 
-#: panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "1/4 ekrana"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Zastoj kucanja sporih tastera"
 
-#: panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "1/2 ekrana"
-
-#: panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "3/4 ekrana"
-
-#: panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
-msgstr "Veliko"
+msgstr "Veliki"
 
-#: panels/universal-access/zoom-options.ui:48
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Zapišti kada je pritisnut _taster"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Zapišti kada je taster _prihvaćen"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Zapišti kada taster nije p_rihvaćen"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Odskočni tasteri"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Zanemaruje uzastopne dvostruke pritiske na taster"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kratak"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Zastoj kucanja odskočnih tastera"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Veliki"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Uključi tastaturom"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Uključite/isključite funkcije pristupačnosti koristeći tastaturu"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Uvek prikaži izbornik univerzalnog pristupa"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Vidnost"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Veliki kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Veliki tekst"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Čitač _ekrana"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Čitač ekrana čita prikazani tekst kako pomerate prvi plan."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Tasteri _zvuka"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Zapišti kada je zaključavanje brojeva ili velikih slova uključeno ili "
+"isključeno."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Veličina _pokazivača"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Povećaj"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Čujnost"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Vizuelna upozorenja"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "_Tastatura na ekranu"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Ponavljanj_e tastera"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Treptanje pokazivača"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Pomoć pri kucanju (Iks pristup)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Ukazivanje i klikanje"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Tasteri _miša"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Ukloni štampač"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Pomoć pri _kliku"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Zastoj _duplog klika"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Zastoj duplog klika"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Vizuelna upozorenja"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Probni _bljesak"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Koristi vidno ukazivanje kada se desi zvuk upozorenja."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Bljesni celim _ekranom"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Bljesni celim _ekranom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "Ceo ekran"
 
-#: panels/universal-access/zoom-options.ui:53
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "Gornja polovina"
 
-#: panels/universal-access/zoom-options.ui:58
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "Donja polovina"
 
-#: panels/universal-access/zoom-options.ui:63
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "Leva polovina"
 
-#: panels/universal-access/zoom-options.ui:68
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "Desna polovina"
 
-#: panels/universal-access/zoom-options.ui:77
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "Opcije uvećanja"
 
-#: panels/universal-access/zoom-options.ui:186
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
 msgstr "_Uvećavanje:"
 
-#: panels/universal-access/zoom-options.ui:250
-msgid "_Follow mouse cursor"
-msgstr "Prati po_kazivač miša"
-
-#: panels/universal-access/zoom-options.ui:270
-msgid "_Screen part:"
-msgstr "Deo _ekrana:"
-
-#: panels/universal-access/zoom-options.ui:332
-msgid "Magnifier _extends outside of screen"
-msgstr "Lupa se prostire izvan _ekrana"
-
-#: panels/universal-access/zoom-options.ui:351
-msgid "_Keep magnifier cursor centered"
-msgstr "Drži po_kazivač lupe po sredini"
-
-#: panels/universal-access/zoom-options.ui:370
-msgid "Magnifier cursor _pushes contents around"
-msgstr "Pokazivač lu_pe gura sadržaje unaokolo"
-
-#: panels/universal-access/zoom-options.ui:389
-msgid "Magnifier cursor moves with _contents"
-msgstr "Pokazivač lupe se pomera sa sad_ržajima"
-
-#: panels/universal-access/zoom-options.ui:423
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "Položaj lupe:"
 
-#: panels/universal-access/zoom-options.ui:444
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "Prati po_kazivač miša"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Deo _ekrana:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Lupa se prostire izvan _ekrana"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "Drži po_kazivač lupe po sredini"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Pokazivač lu_pe gura sadržaje unaokolo"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Pokazivač lupe se pomera sa sad_ržajima"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: panels/universal-access/zoom-options.ui:490
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "U_krštanje:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Preklapa p_okazivač miša"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
 msgstr "_Debljina:"
 
-#: panels/universal-access/zoom-options.ui:516
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "Tanko"
 
-#: panels/universal-access/zoom-options.ui:548
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "Debelo"
 
-#: panels/universal-access/zoom-options.ui:574
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
 msgstr "Tra_janje:"
 
 #. The color of the accessibility crosshair
-#: panels/universal-access/zoom-options.ui:626
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
 msgstr "Bo_ja:"
 
-#: panels/universal-access/zoom-options.ui:690
-msgid "_Crosshairs:"
-msgstr "U_krštanje:"
-
-#: panels/universal-access/zoom-options.ui:741
-msgid "_Overlaps mouse cursor"
-msgstr "Preklapa p_okazivač miša"
-
-#: panels/universal-access/zoom-options.ui:779
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "Ukrštanje"
 
-#: panels/universal-access/zoom-options.ui:827
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Dejstva boje:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
 msgstr "_Bela na crnoj:"
 
-#: panels/universal-access/zoom-options.ui:850
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
 msgstr "Osv_etljenje:"
 
-#: panels/universal-access/zoom-options.ui:874
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
 msgstr "_Kontrast:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/zoom-options.ui:897
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
 msgid "Co_lor"
 msgstr "_Boja"
 
-#: panels/universal-access/zoom-options.ui:925
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "Ništa"
 
-#: panels/universal-access/zoom-options.ui:957
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "Pun"
 
-#: panels/universal-access/zoom-options.ui:1023
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "Nizak"
 
-#: panels/universal-access/zoom-options.ui:1056
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "Visok"
 
-#: panels/universal-access/zoom-options.ui:1087
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "Nizak"
 
-#: panels/universal-access/zoom-options.ui:1120
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "Visok"
 
-#: panels/universal-access/zoom-options.ui:1156
-msgid "Color Effects:"
-msgstr "Dejstva boje:"
-
-#: panels/universal-access/zoom-options.ui:1181
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "Dejstva boje"
 
-#: panels/user-accounts/data/account-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Olakšajte posmatranje, slušanje, kucanje, ukazivanje i klikanje"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"tastatura;miš;a11y;pristupačnost;kontrast;zum;čitač;ekran;tekst;slova;"
+"veličina;Iks_pristup;lepljivi;tasteri;spori;odskočni;miš;dvostruki;klik;"
+"zastoj;ponovi;trepni;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Istorijat"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "Istorijat"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "Očisti _skorašnji istorijat"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "Očisti smeće i privremene datoteke"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "Sam izbaci _smeće"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Sam pročisti privremene _datoteke"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "Sam izbaci _smeće"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Izbaci Smeće…"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Pročisti privremene datoteke…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Dodajte korisnika"
 
-#: panels/user-accounts/data/account-dialog.ui:171
-msgid "_Full Name"
-msgstr "_Ime i prezime"
-
-#: panels/user-accounts/data/account-dialog.ui:197
-#: panels/user-accounts/data/user-accounts-dialog.ui:146
-msgid "Standard"
-msgstr "Standardni"
-
-#: panels/user-accounts/data/account-dialog.ui:207
-#: panels/user-accounts/data/user-accounts-dialog.ui:155
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "Administrator"
 
-#: panels/user-accounts/data/account-dialog.ui:223
-#: panels/user-accounts/data/user-accounts-dialog.ui:173
-msgid "Account _Type"
-msgstr "_Vrsta naloga"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: panels/user-accounts/data/account-dialog.ui:260
-msgid "Allow user to set a password when they next _login"
-msgstr "Dozvoli korisniku da podesi _lozinku prilikom sledećeg prijavljivanja"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "Dozvoli korisniku da izmeni lozinku prilikom sledećeg prijavljivanja"
 
-#: panels/user-accounts/data/account-dialog.ui:274
-msgid "Set a password _now"
-msgstr "Postavi lozinku sa_da"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "Postavi lozinku sada"
 
-#: panels/user-accounts/data/account-dialog.ui:387
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "_Potvrdi"
 
-#: panels/user-accounts/data/account-dialog.ui:463
-#: panels/user-accounts/data/account-dialog.ui:667
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_Poslovno prijavljivanje"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Van mreže ste"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
 "resources on the internet."
 msgstr ""
-"Poslovno prijavljivanje omogućava postojećem centralno upravljanom korisničkom "
-"nalogu da se koristi na ovom uređaju. Takođe možete da koristite ovaj nalog "
-"da pristupite resursima preduzeća na internetu."
+"Poslovno prijavljivanje omogućava postojećem centralno upravljanom "
+"korisničkom nalogu da se koristi na ovom uređaju. Takođe možete da koristite "
+"ovaj nalog da pristupite resursima preduzeća na internetu."
 
-#: panels/user-accounts/data/account-dialog.ui:485
-#: panels/user-accounts/data/join-dialog.ui:116
-msgid "_Domain"
-msgstr "_Domen"
-
-#: panels/user-accounts/data/account-dialog.ui:707
-msgid "You are Offline"
-msgstr "Van mreže ste"
-
-#: panels/user-accounts/data/account-dialog.ui:726
-msgid "You must be online in order to add enterprise users."
-msgstr "Morate biti na mreži da biste dodali poslovne korisnike."
-
-#: panels/user-accounts/data/account-dialog.ui:760
-msgid "_Enterprise Login"
-msgstr "_Poslovno prijavljivanje"
-
-#: panels/user-accounts/data/account-fingerprint.ui:12
-msgid "Left thumb"
-msgstr "Levi palac"
-
-#: panels/user-accounts/data/account-fingerprint.ui:15
-msgid "Left middle finger"
-msgstr "Srednji, levi prst"
-
-#: panels/user-accounts/data/account-fingerprint.ui:18
-msgid "Left ring finger"
-msgstr "Domali, levi prst"
-
-#: panels/user-accounts/data/account-fingerprint.ui:21
-msgid "Left little finger"
-msgstr "Mali, levi prst"
-
-#: panels/user-accounts/data/account-fingerprint.ui:24
-msgid "Right thumb"
-msgstr "Desni palac"
-
-#: panels/user-accounts/data/account-fingerprint.ui:27
-msgid "Right middle finger"
-msgstr "Desni, srednji prst"
-
-#: panels/user-accounts/data/account-fingerprint.ui:30
-msgid "Right ring finger"
-msgstr "Desni, domali prsti"
-
-#: panels/user-accounts/data/account-fingerprint.ui:33
-msgid "Right little finger"
-msgstr "Desni, mali prst"
-
-#: panels/user-accounts/data/account-fingerprint.ui:39
-#: panels/user-accounts/um-fingerprint-dialog.c:677
-msgid "Enable Fingerprint Login"
-msgstr "Omogući prijavljivanje otiskom prsta"
-
-#: panels/user-accounts/data/account-fingerprint.ui:89
-msgid "_Right index finger"
-msgstr "_Desni kažiprst"
-
-#: panels/user-accounts/data/account-fingerprint.ui:105
-msgid "_Left index finger"
-msgstr "_Levi kažiprst"
-
-#: panels/user-accounts/data/account-fingerprint.ui:126
-msgid "_Other finger:"
-msgstr "_Ostali prsti:"
-
-#: panels/user-accounts/data/account-fingerprint.ui:262
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"Vaš otisak prsta je uspešno sačuvan. Sada se možete prijaviti na sistem "
-"preko čitača otisaka prstiju."
-
-#: panels/user-accounts/data/avatar-chooser.ui:27
-msgid "Take a Picture…"
-msgstr "Snimite sliku…"
-
-#: panels/user-accounts/data/avatar-chooser.ui:34
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
 msgstr "Izaberite datoteku…"
 
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Ne"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Da li želite da obrišete zabeležene otiske prsta kako bi onemogućili "
+"prijavljivanje putem otiska prsta?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Ulazni uređaj za igre"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Obriši otiske prsta"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Prethodna sedmica"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "Sledeća sedmica"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Izmenite lozinku"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "P_romeni"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Trenutna _lozinka"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Nova lozinka"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "P_otvrdi lozinku"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lozinke se ne podudaraju."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Dozvoli korisniku da izmeni lozinku prilikom sledećeg prijavljivanja"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Postavi lozinku sada"
+
+#: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Korisnici"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Morate ponovo da pokrenete sesiju kako bi izmene stupile u dejstvo"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Ponovo pokreni sada"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Zatvori"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Ime i prezime"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Uredi"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "Automatsko _prijavljivanje"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "%s — Aktivnost naloga"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Ukloni korisnika…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Ostali prsti:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "_Dodaj korisnika…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Nisam našao korisnike"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Otključajte da biste dodali korisnički nalog."
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "Dodajte ili uklonite korisnike i izmenite vašu lozinku"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:7
-msgid "system-users"
-msgstr "system-users"
-
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "prijavljivanje;ime;otisak prstiju;avatar;logo;lice;lozinka;"
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Upiši"
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Prijavljivanje administratora domena"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6507,83 +4764,13 @@ msgstr ""
 "upisan u domenu. Neka administrator vaše mreže ovde upiše lozinku\n"
 "njihovih domena."
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "Ime _administratora"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Lozinka administratora"
-
-#: panels/user-accounts/data/password-dialog.ui:7
-msgid "Change Password"
-msgstr "Izmenite lozinku"
-
-#: panels/user-accounts/data/password-dialog.ui:38
-msgid "Ch_ange"
-msgstr "P_romeni"
-
-#: panels/user-accounts/data/password-dialog.ui:142
-msgid "_Verify New Password"
-msgstr "_Potvrdi novu lozinku"
-
-#: panels/user-accounts/data/password-dialog.ui:159
-msgid "_New Password"
-msgstr "_Nova lozinka"
-
-#: panels/user-accounts/data/password-dialog.ui:208
-msgid "Current _Password"
-msgstr "Trenutna _lozinka"
-
-#: panels/user-accounts/data/password-dialog.ui:243
-msgid "Allow user to change their password on next login"
-msgstr "Dozvoli korisniku da izmeni lozinku prilikom sledećeg prijavljivanja"
-
-#: panels/user-accounts/data/password-dialog.ui:256
-msgid "Set a password now"
-msgstr "Postavi lozinku sada"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:20
-msgid "_Add User…"
-msgstr "_Dodaj korisnika…"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:69
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "Morate ponovo da pokrenete sesiju kako bi izmene stupile u dejstvo"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:77
-msgid "Restart Now"
-msgstr "Ponovo pokreni sada"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:244
-msgid "A_utomatic Login"
-msgstr "Automatsko _prijavljivanje"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:285
-msgid "_Fingerprint Login"
-msgstr "Prijavljivanje _otiskom prsta"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:311
-#: panels/user-accounts/data/user-accounts-dialog.ui:324
-msgid "User Icon"
-msgstr "Ikonica korisnika"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:387
-msgid "Last Login"
-msgstr "Poslednje prijavljivanje"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:434
-msgid "Remove User…"
-msgstr "Ukloni korisnika…"
-
-#. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/data/user-accounts-dialog.ui:466
-msgid "No Users Found"
-msgstr "Nisam našao korisnike"
-
-#: panels/user-accounts/data/user-accounts-dialog.ui:476
-msgid "Unlock to add a user account."
-msgstr "Otključajte da biste dodali korisnički nalog."
 
 #: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
@@ -6593,582 +4780,16 @@ msgstr "Upravljajte korisničkim nalozima"
 msgid "Authentication is required to change user data"
 msgstr "Potrebno je potvrđivanje identiteta za promenu korisničkih podataka"
 
-#: panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Nova lozinka treba da se razlikuje od stare."
-
-#: panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Probajte da izmenite neka slova i brojeve."
-
-#: panels/user-accounts/pw-utils.c:85 panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Probajte još samo malo da izmenite lozinku."
-
-#: panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Lozinka bez vašeg korisničkog imena će biti jača."
-
-#: panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Pokušajte da izbegnete vaše ime u lozinki."
-
-#: panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Pokušajte da izbegnete neke od reči upotrebljenih u lozinki."
-
-#: panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Pokušajte da izbegnete uobičajene reči."
-
-#: panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Pokušajte da izbegnete preuređivanje postojećih reči."
-
-#: panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Pokušajte da koristite više brojeva."
-
-#: panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Pokušajte da koristite više velikih slova."
-
-#: panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Pokušajte da koristite više malih slova."
-
-#: panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Pokušajte da koristite više posebnih znakova, kao tačka."
-
-#: panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Pokušajte da koristite mešavinu slova, brojeva i tačaka."
-
-#: panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Pokušajte da izbegnete ponavljanje istog znaka."
-
-#: panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Pokušajte da izbegnete ponavljanje iste vrste znaka: treba da mešate velika "
-"slova, brojeve i tačke."
-
-#: panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Pokušajte da izbegnete nizove 1234 ili abvg."
-
-#: panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Lozinka mora biti duža. Pokušajte da koristite mešavinu slova, brojeva i "
-"tačaka."
-
-#: panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Mešajte velika i mala slova i probajte da koristite jedan ili dva broja."
-
-#: panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Dodavanje još slova, brojeva i tačke će učiniti lozinku još jačom."
-
-#: panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "Potvrđivanje identiteta nije uspelo"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "Nova lozinka je previše kratka"
-
-#: panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "Nova lozinka je previše jednostavna"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Stara i nova lozinka su suviše slične"
-
-#: panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Nova lozinka je već upotrebljavana u skorije vreme."
-
-#: panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Nova lozinka mora da sadrži numeričke ili specijalne znakove"
-
-#: panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Stara i nova lozinka su iste"
-
-#: panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Vaša lozinka je izmenjena od kada ste na početku potvrdili identitet!"
-
-#: panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Nova lozinka ne sadrži dovoljno različitih znakova"
-
-#: panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "Nepoznata greška"
-
-#: panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "Treba da podudari veb adresu vašeg dostavljača prijavljivanja."
-
-#: panels/user-accounts/um-account-dialog.c:229
-msgid "Failed to add account"
-msgstr "Nisam uspeo da dodam nalog"
-
-#: panels/user-accounts/um-account-dialog.c:462
-msgid "Passwords do not match."
-msgstr "Lozinke se ne podudaraju."
-
-#: panels/user-accounts/um-account-dialog.c:717
-#: panels/user-accounts/um-account-dialog.c:763
-#: panels/user-accounts/um-account-dialog.c:784
-msgid "Failed to register account"
-msgstr "Nisam uspeo da upišem nalog"
-
-#: panels/user-accounts/um-account-dialog.c:907
-msgid "No supported way to authenticate with this domain"
-msgstr "Nema podržanog načina za potvrđivanje identiteta sa ovim domenom"
-
-#: panels/user-accounts/um-account-dialog.c:980
-msgid "Failed to join domain"
-msgstr "Nisam uspeo da pristupim domenu"
-
-#: panels/user-accounts/um-account-dialog.c:1041
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Neispravno ime za prijavljivanje.\n"
-"Pokušajte ponovo."
-
-#: panels/user-accounts/um-account-dialog.c:1048
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Neispravna lozinka za prijavljivanje.\n"
-"Pokušajte ponovo."
-
-#: panels/user-accounts/um-account-dialog.c:1056
-msgid "Failed to log into domain"
-msgstr "Nisam uspeo da se prijavim na domen"
-
-#: panels/user-accounts/um-account-dialog.c:1114
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Ne mogu da pronađem domen. Možda ste ga pogrešno napisali?"
-
-#: panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "Standardni"
-
-#: panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "Administrator"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"Nemate dozvole za pristup ovom uređaju. Kontaktirajte vašeg administratora "
-"sistema."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "Uređaj je već u upotrebi."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr "Došlo je do greške unutar programa."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Enabled"
-msgstr "Omogućeno"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:260
-msgid "Delete registered fingerprints?"
-msgstr "Da obrišem zabeležene otiske prsta?"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:264
-msgid "_Delete Fingerprints"
-msgstr "_Obriši otiske prsta"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:270
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"Da li želite da obrišete zabeležene otiske prsta kako bi onemogućili "
-"prijavljivanje putem otiska prsta?"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:440
-msgid "Done!"
-msgstr "Urađeno!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:501
-#: panels/user-accounts/um-fingerprint-dialog.c:543
-#, c-format
-msgid "Could not access “%s” device"
-msgstr "Ne mogu da pristupim uređaju „%s“"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:584
-#, c-format
-msgid "Could not start finger capture on “%s” device"
-msgstr "Ne mogu da uhvatim otisak prsta sa uređaja „%s“"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:628
-msgid "Could not access any fingerprint readers"
-msgstr "Ne mogu da pristupim nijednom čitaču otisaka prstiju"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:629
-msgid "Please contact your system administrator for help."
-msgstr "Javite se administratoru sistema za pomoć."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: panels/user-accounts/um-fingerprint-dialog.c:711
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the “%s” device."
-msgstr ""
-"Morate sačuvati jedan od vaših otisaka prsta sa uređaja „%s“, kako bi "
-"omogućili prijavu na sistem otiskom prsta."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:718
-msgid "Selecting finger"
-msgstr "Biram prst"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:719
-msgid "Enrolling fingerprints"
-msgstr "Upisujem otiske prstiju"
-
-#: panels/user-accounts/um-history-dialog.c:70
-msgid "This Week"
-msgstr "Ove sedmice"
-
-#: panels/user-accounts/um-history-dialog.c:73
-msgid "Last Week"
-msgstr "Prošle sedmice"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/um-history-dialog.c:79
-#: panels/user-accounts/um-history-dialog.c:83
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e. %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/um-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e. %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/um-history-dialog.c:93
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/um-history-dialog.c:177
-#: panels/user-accounts/um-user-panel.c:767
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/um-history-dialog.c:180
-#: panels/user-accounts/um-user-panel.c:771
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/um-history-dialog.c:250
-msgid "Session Ended"
-msgstr "Kraj sesije"
-
-#: panels/user-accounts/um-history-dialog.c:256
-msgid "Session Started"
-msgstr "Početak sesije"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/um-history-dialog.c:299
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Aktivnost naloga"
-
-#: panels/user-accounts/um-password-dialog.c:144
-msgid "Please choose another password."
-msgstr "Izaberite drugu lozinku."
-
-#: panels/user-accounts/um-password-dialog.c:153
-msgid "Please type your current password again."
-msgstr "Unesite vašu trenutnu lozinku ponovo."
-
-#: panels/user-accounts/um-password-dialog.c:159
-msgid "Password could not be changed"
-msgstr "Lozinka ne može biti promenjena"
-
-#: panels/user-accounts/um-password-dialog.c:285
-msgid "The passwords do not match."
-msgstr "Lozinke se ne podudaraju."
-
-#: panels/user-accounts/um-photo-dialog.c:226
-msgid "Browse for more pictures"
-msgstr "Potražite još slika"
-
-#: panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "Ne mogu sam da pristupim ovoj vrsti domena"
-
-#: panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "Nije pronađen takav domen ili područje"
-
-#: panels/user-accounts/um-realm-manager.c:815
-#: panels/user-accounts/um-realm-manager.c:829
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Ne mogu da se prijavim kao „%s“ na domenu %s"
-
-#: panels/user-accounts/um-realm-manager.c:821
-msgid "Invalid password, please try again"
-msgstr "Neispravna lozinka, pokušajte ponovo"
-
-#: panels/user-accounts/um-realm-manager.c:834
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Ne mogu da se povežem na domen „%s“: %s"
-
-#: panels/user-accounts/um-user-panel.c:201
-msgid "Your account"
-msgstr "Vaš nalog"
-
-#: panels/user-accounts/um-user-panel.c:381
-msgid "Failed to delete user"
-msgstr "Nisam uspeo da izbrišem korisnika"
-
-#: panels/user-accounts/um-user-panel.c:439
-#: panels/user-accounts/um-user-panel.c:498
-#: panels/user-accounts/um-user-panel.c:550
-msgid "Failed to revoke remotely managed user"
-msgstr "Nisam uspeo da opozovem daljinski upravljanog korisnika"
-
-#: panels/user-accounts/um-user-panel.c:604
-msgid "You cannot delete your own account."
-msgstr "Ne možete obrisati vaš lični nalog."
-
-#: panels/user-accounts/um-user-panel.c:613
-#, c-format
-msgid "%s is still logged in"
-msgstr "„%s“ je i dalje prijavljen"
-
-#: panels/user-accounts/um-user-panel.c:617
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Brisanje korisnika dok su prijavljeni može da ostavi sistem u neusklađenom "
-"stanju."
-
-#: panels/user-accounts/um-user-panel.c:626
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Da li želite da sačuvate datoteke korisnika „%s“?"
-
-#: panels/user-accounts/um-user-panel.c:630
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Moguće je zadržati ličnu fasciklu, skladišta pošte i privremene datoteke "
-"prilikom brisanja korisničkog naloga."
-
-#: panels/user-accounts/um-user-panel.c:633
-msgid "_Delete Files"
-msgstr "_Obriši datoteke"
-
-#: panels/user-accounts/um-user-panel.c:634
-msgid "_Keep Files"
-msgstr "_Zadrži datoteke"
-
-#: panels/user-accounts/um-user-panel.c:648
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Da li sigurno želite da opozovete daljinski upravljani nalog korisnika „%s“?"
-
-#: panels/user-accounts/um-user-panel.c:652
-msgid "_Delete"
-msgstr "_Obriši"
-
-#: panels/user-accounts/um-user-panel.c:702
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Nalog je isključen"
-
-#: panels/user-accounts/um-user-panel.c:710
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Za podešavanje prilikom narednog prijavljivanja"
-
-#: panels/user-accounts/um-user-panel.c:713
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ništa"
-
-#: panels/user-accounts/um-user-panel.c:760
-msgid "Logged in"
-msgstr "Prijavljen sam"
-
-#: panels/user-accounts/um-user-panel.c:1107
-msgid "Failed to contact the accounts service"
-msgstr "Nisam uspeo da kontaktiram uslugu naloga"
-
-#: panels/user-accounts/um-user-panel.c:1109
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Molim proverite da li je Usluga naloga instalirana i uključena."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/um-user-panel.c:1141
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Da napravite izmene,\n"
-"kliknite prvo na ikonicu *"
-
-#: panels/user-accounts/um-user-panel.c:1181
-msgid "Create a user account"
-msgstr "Napravite korisnički nalog"
-
-#: panels/user-accounts/um-user-panel.c:1192
-#: panels/user-accounts/um-user-panel.c:1371
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Da napravite korisnički nalog,\n"
-"kliknite prvo na ikonicu *"
-
-#: panels/user-accounts/um-user-panel.c:1202
-msgid "Delete the selected user account"
-msgstr "Obrišite izabrani korisnički nalog"
-
-#: panels/user-accounts/um-user-panel.c:1214
-#: panels/user-accounts/um-user-panel.c:1376
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Da obrišete izabrani korisnički nalog,\n"
-"kliknite prvo na ikonicu *"
-
-#: panels/user-accounts/um-utils.c:496
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Izvinite, ali to korisničko ime nije dostupno. Probajte neko drugo."
-
-#: panels/user-accounts/um-utils.c:499
-#, c-format
-msgid "The username is too long."
-msgstr "Korisničko ime je predugo."
-
-#: panels/user-accounts/um-utils.c:502
-msgid "The username cannot start with a “-”."
-msgstr "Korisničko ime ne može početi sa „-“."
-
-#: panels/user-accounts/um-utils.c:505
-msgid ""
-"The username should only consist of upper and lower case letters from a-z, "
-"digits and the following characters: . - _"
-msgstr ""
-"Korisničko ime treba da sadrži samo velika i mala slova latinskog alfabeta "
-"od a-z, cifre i sledeće znakove: . - _"
-
-#: panels/user-accounts/um-utils.c:509
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr ""
-"Biće korišćeno za imenovanje vaše lične fascikle i ne može biti izmenjeno."
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Mapiraj dugmad"
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:547
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "_Zatvori"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Mapirajte dugmad prema funkcijama"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -7177,7 +4798,11 @@ msgstr ""
 "dugme prečice tastature i držite pritisnutim nove tastere ili pritisnite "
 "„Povratnicu“ da obrišete prečicu."
 
-#: panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Zatvori"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -7185,68 +4810,120 @@ msgstr ""
 "Molim lupnite znake mete koji će se pojaviti na ekranu da kalibrišete "
 "tablicu."
 
-#: panels/wacom/calibrator/calibrator-gui.c:87
+#: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
 msgstr "Otkriven je loš klik, počinjem iz početka…"
 
-#: panels/wacom/cc-wacom-button-row.c:266
-#, c-format
-msgid "Button %d"
-msgstr "Dugme %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:53
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Program je definisan"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Tablica"
 
-#: panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Pošalji otkucaj tastera"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Promeni monitor"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Levoruko usmerenje"
 
-#: panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Prikaži pomoć na ekranu"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:260
-msgid "Output:"
-msgstr "Izlaz:"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mapiraj monitor…"
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:272
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Zadrži odnos razmere (crne trake):"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Razmera"
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:283
-msgid "Map to single monitor"
-msgstr "Mapiraj na jednom monitoru"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:86
-#, c-format
-msgid "%d of %d"
-msgstr "%d od %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Podesi…"
 
-#: panels/wacom/cc-wacom-page.c:544
-msgid "Display Mapping"
-msgstr "Prikazuje mapiranje"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Tablica nije otkrivena"
 
-#: panels/wacom/cc-wacom-panel.c:790 panels/wacom/wacom-stylus-page.ui:127
-msgid "Stylus"
-msgstr "Penkalo"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Molim priključite ili upalite vašu Vakom tablicu"
 
-#: panels/wacom/cc-wacom-stylus-page.c:362
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Osećaj pritiska saveta"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Umekšan"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Stojeće"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Dugme"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Dugme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Dugme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Osećaj pritiska brisača"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Osećaj pritiska brisača"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Klik srednjeg dugmeta miša"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Klik desnog dugmeta miša"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Napred"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:198
 msgid "Wacom Tablet"
 msgstr "Vakom tablica"
 
@@ -7255,197 +4932,356 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "podesite mapiranje dugmeta i podesite osetljivost olovke grafičkih tablica"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: panels/wacom/gnome-wacom-panel.desktop.in.in:7
-msgid "input-tablet"
-msgstr "input-tablet"
-
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "tablica;vakom;penkalo;brisač;miš;"
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "Tablica (apsolutno)"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
-msgstr "Dodirna tabla (relativno)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "Postavke tablice"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "Po_moć"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:123
-msgid "No tablet detected"
-msgstr "Tablica nije otkrivena"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:139
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Molim priključite ili upalite vašu Vakom tablicu"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:159
-msgid "Bluetooth Settings"
-msgstr "Podešavanja Blututa"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:231
-msgid "Map to Monitor…"
-msgstr "Mapiraj monitor…"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:247
-msgid "Map Buttons…"
-msgstr "Mapiraj dugmad…"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulirani sekundarni klik"
 
-#: panels/wacom/gnome-wacom-properties.ui:263
-msgid "Calibrate…"
-msgstr "Podesi…"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Vindouz programi"
 
-#: panels/wacom/gnome-wacom-properties.ui:284
-msgid "Adjust display resolution"
-msgstr "Podesite rezoluciju prikaza"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#: panels/wacom/gnome-wacom-properties.ui:300
-msgid "Adjust mouse settings"
-msgstr "Doterajte podešavanja miša"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Ponestaje tonera"
 
-#: panels/wacom/gnome-wacom-properties.ui:328
-msgid "Tracking Mode"
-msgstr "Režim praćenja"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Sporedni"
 
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Left-Handed Orientation"
-msgstr "Levoruko usmerenje"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Vindouz programi"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "Nova prečica…"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "Klik srednjeg dugmeta miša"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "Klik desnog dugmeta miša"
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Mogućnosti pristupa"
 
-#: panels/wacom/wacom-stylus-page.ui:37
-msgid "Back"
-msgstr "Nazad"
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Dodaj"
 
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "Napred"
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Sačuvaj"
 
-#: panels/wacom/wacom-stylus-page.ui:77
-msgid "No stylus found"
-msgstr "Nisam našao olovku"
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
 
-#: panels/wacom/wacom-stylus-page.ui:91
-msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr "Približite vašu olovku tabličnom uređaju da ga podesite"
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Pojedinosti"
 
-#: panels/wacom/wacom-stylus-page.ui:167
-msgid "Eraser Pressure Feel"
-msgstr "Osećaj pritiska brisača"
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:188 panels/wacom/wacom-stylus-page.ui:348
-msgid "Soft"
-msgstr "Umekšan"
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:218 panels/wacom/wacom-stylus-page.ui:378
-msgid "Firm"
-msgstr "Stojeće"
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_Mrežno vreme"
 
-#: panels/wacom/wacom-stylus-page.ui:241
-msgid "Top Button"
-msgstr "Gornje dugme"
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Mreže"
 
-#: panels/wacom/wacom-stylus-page.ui:270
-msgid "Lower Button"
-msgstr "Donje dugme"
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Brojevi"
 
-#: panels/wacom/wacom-stylus-page.ui:299
-msgid "Lowest Button"
-msgstr "Najniže dugme"
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Pojedinosti štampača"
 
-#: panels/wacom/wacom-stylus-page.ui:328
-msgid "Tip Pressure Feel"
-msgstr "Osećaj pritiska saveta"
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Proizvođač"
 
-#: panels/wacom/wacom-stylus-page.ui:440
-msgid "page 3"
-msgstr "strana 3"
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Nedostaje firmver"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
-msgid "GNOME Control Center"
-msgstr "Gnomov Upravljački Centar"
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
-msgid "Utilities to configure the GNOME desktop"
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Mobilna širokopojasna"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_Mrežno vreme"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Mreža"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Napredno"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Mogućnosti pristupa"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Zaključavanje ekrana"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Pojedinosti za „%s“"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Naziv mreže"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Samostalno"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Moja kućna mreža"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Moja kućna mreža"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Nisam našao bežični adapter"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+#, fuzzy
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Proverite da li ste priključili i upalili bežični adapter"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Blutut je isključen kada je avionski režim rada uključen."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Isključi avionski režim rada"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Zaboravi vezu"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM kartica nije ubačena"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Zaključavanje ekrana"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "P_romeni"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Moja kućna mreža"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "Podesite prenosne medije"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+#, fuzzy
+msgid "Utility to configure the GNOME desktop"
 msgstr "Alatke za podešavanje Gnom radnog okruženja"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
-msgid ""
-"The control center is GNOME’s main interface for configuration of various "
-"aspects of your desktop."
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
 msgstr ""
-"Upravljački centar je glavno Gnomovo sučelje za podešavanje različitih delova "
-"vašeg sistema."
 
-#: shell/cc-application.c:47
-msgid "Display version number"
-msgstr "Broj izdanja prikaza"
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
 
-#: shell/cc-application.c:48
-msgid "Enable verbose mode"
-msgstr "Uključuje režim ispisivanja"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "Podešavam novi upravljački program…"
 
-#: shell/cc-application.c:49
-msgid "Show the overview"
-msgstr "Prikazuje pregled"
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "Privatnost"
 
-#: shell/cc-application.c:50
-msgid "Search for the string"
-msgstr "Traži nisku"
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Sva podešavanja"
 
-#: shell/cc-application.c:51
-msgid "List possible panel names and exit"
-msgstr "Ispisuje moguće nazive panela i izlazi"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "Glavni"
 
-#: shell/cc-application.c:52
-msgid "Panel to display"
-msgstr "Panel za prikaz"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: shell/cc-application.c:52
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: shell/cc-application.c:117
-msgid "Available panels:"
-msgstr "Dostupni paneli:"
-
-#: shell/cc-application.c:256
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Pomoć"
-
-#: shell/cc-application.c:257
-msgid "Quit"
-msgstr "Izađi"
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: shell/gnome-control-center.desktop.in.in:5
-msgid "gnome-control-center"
-msgstr "gnome-control-center"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "postavke;podešavanja;"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -7457,7 +5293,7 @@ msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Izlazak"
 
-#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "Pretraga"
@@ -7467,21 +5303,20 @@ msgctxt "shortcut window"
 msgid "Panels"
 msgstr "Površi"
 
-#: shell/help-overlay.ui:40
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
 msgctxt "shortcut window"
-msgid "Go back to the overview"
+msgid "Go back to previous panel"
 msgstr "Idi nazad na pregled"
 
-#: shell/help-overlay.ui:53
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Otkaži pretragu"
 
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: shell/hostname-helper.c:189
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Vruća tačka"
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "postavke;podešavanja;"
 
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
@@ -7495,17 +5330,26 @@ msgstr ""
 "Identifikator poslednjeg otvorenog panela Podešavanja. Vrednosti koje nisu "
 "prepoznate će biti prekočene i prvi panel iz spiska će biti odabran."
 
-#: shell/panel-list.ui:195
-msgid "No results found"
-msgstr "Nisam našao rezultate"
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
 
-#: shell/window.ui:141
-msgid "All Settings"
-msgstr "Sva podešavanja"
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1873
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
@@ -7514,9 +5358,7 @@ msgstr[1] "%u izlaza"
 msgstr[2] "%u izlaza"
 msgstr[3] "Jedan izlaz"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1883
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
@@ -7525,9 +5367,2706 @@ msgstr[1] "%u ulaza"
 msgstr[2] "%u ulaza"
 msgstr[3] "Jedan ulaz"
 
-#: subprojects/gvc/gvc-mixer-control.c:2738
-msgid "System Sounds"
-msgstr "Sistemski zvuci"
+#~ msgid "_Background"
+#~ msgstr "_Pozadina"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Menja se tokom celog dana"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Popločano"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Uvećano"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrirano"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Srazmerno"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Popunjeno"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Rasprostrto"
+
+#~ msgid "Colors"
+#~ msgstr "Boje"
+
+#~ msgid "Select Background"
+#~ msgstr "Izaberite pozadinu"
+
+#~ msgid "Pictures"
+#~ msgstr "Slike"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Nisam pronašao slike"
+
+#~ msgid "Home"
+#~ msgstr "Lično"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Možete da dodate slike u vašu fasciklu %s i one će biti prikazane ovde"
+
+#~ msgid "multiple sizes"
+#~ msgstr "više veličina"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Nema pozadine za radnu površ"
+
+#~ msgid "Current background"
+#~ msgstr "Trenutna pozadina"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr ""
+#~ "pozadina;ekran;radna površ;Wallpaper;Screen;Desktop;pozadina;ekran;radna;"
+#~ "povrs;površ;"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Postavite uređaj za kalibraciju preko kvadrata i pritisnite „Počni“"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Pomerite uređaj za kalibraciju na položaj kalibracije i pritisnite "
+#~ "„Nastavi“"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Pomerite uređaj za kalibraciju na položaj površine i pritisnite „Nastavi“"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Zaklopite prenosni računar"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Došlo je do unutrašnje greške koja ne može biti oporavljena."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Alati potrebni za kalibraciju nisu instalirani."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profil ne može biti napravljen."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Bela tačka mete se ne može dobaviti."
+
+#~ msgid "Complete!"
+#~ msgstr "Završeno!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibracija nije uspela!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Možete da uklonite uređaj za kalibraciju."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Ne ometajte uređaj za kalibraciju dok je u radu"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Ekran prenosnog računara"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s monitor"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s skener"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s štampač"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s veb kamerica"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Uključi upravljanje bojom za „%s“"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Prikaži profile boja za „%s“"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Nije kalibrisano"
+
+#~ msgid "Default: "
+#~ msgstr "Osnovno: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Probni profil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Izaberi datoteku ICC profila"
+
+#~ msgid "_Import"
+#~ msgstr "_Uvezi"
+
+#~ msgid "All files"
+#~ msgstr "Sve datoteke"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Nisam uspeo da otpremim datoteku: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profil je otpremljen u:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Zapišite ovu adresu."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Ponovo pokrenite ovaj računar i učitajte vaš uobičajeni operativni sistem."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Upišite adresu u vaš preglednik da preuzmete i da instalirate profil."
+
+#~ msgid "Save Profile"
+#~ msgstr "Sačuvaj profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Napravite profil boje za izabrani uređaj"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Nije otkriven instrument za merenje. Proverite da li je uključen i da li "
+#~ "je ispravno priključen."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Instrument za merenje ne podržava profilisanje štampača."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Tip uređaja trenutno nije podržan."
+
+#~ msgid "Standard Space"
+#~ msgstr "Uobičajeni prostor"
+
+#~ msgid "Test Profile"
+#~ msgstr "Isprobaj profil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Samostalni"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Nizak kvalitet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Osrednji kvalitet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Visok kvalitet"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Osnovna RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Osnovna CMUK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Osnovna siva"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Prodavac je dostavio podatke fabričke kalibracije"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Ispravka prikaza preko celog ekrana nije moguća sa ovim profilom"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Ovaj profil više ne može biti tačan"
+
+#~ msgid "Upload profile"
+#~ msgstr "Otpremite profil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Zahteva Internet vezu"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "Other…"
+#~ msgstr "Drugi…"
+
+#~ msgid "Today"
+#~ msgstr "Danas"
+
+#~ msgid "Yesterday"
+#~ msgstr "Juče"
+
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y."
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%A, %e.%m.%Y. %l:%M %P"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e. %B %Y. %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "KUV%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %P"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "24-hour"
+#~ msgstr "24-časovno"
+
+#~ msgid "AM / PM"
+#~ msgstr "PrP/PoP"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Položeno"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Uspravno desno"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Uspravno levo"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Položeno (izvrnuto)"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Ređanje ekrana"
+
+#~ msgid ""
+#~ "Drag displays to match your setup. The top bar is placed on the primary "
+#~ "display."
+#~ msgstr ""
+#~ "Prevucite ekrane da odgovaraju vašem podešavanju. Gornja traka se "
+#~ "prikazuje na glavnom ekranu."
+
+#~ msgid "Display Mode"
+#~ msgstr "Režim ekrana"
+
+#~ msgid "Join Displays"
+#~ msgstr "Spojeni ekrani"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Da primenim izmene?"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "On"
+#~ msgstr "Uklj."
+
+#~ msgid "Off"
+#~ msgstr "Isklj."
+
+#~ msgid "_Night Light"
+#~ msgstr "_Noćno svetlo"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Ne mogu da dobijem podatke o ekranu"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "Unknown"
+#~ msgstr "Nepoznato"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bita"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bita"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "Izdanje %s"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Pitaj šta da radiš"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ne radi ništa"
+
+#~ msgid "Open folder"
+#~ msgstr "Otvori fasciklu"
+
+#~ msgid "Other Media"
+#~ msgstr "Ostali nosači podataka"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Izaberite program za audio diskove (CD)"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Izaberite program za video diskove (DVD)"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Izaberite program za pokretanje kada je priključen muzički plejer"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Izaberite program za pokretanje kada je priključena kamera"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Izaberite program za diskove sa softverom"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "prazan Blu-rej disk"
+
+#~ msgid "blank CD disc"
+#~ msgstr "prazan CD disk"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "prazan DVD disk"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "prazan HD DVD disk"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-rej video disk"
+
+#~ msgid "e-book reader"
+#~ msgstr "čitač el. knjiga"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video disk"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD sa slikama"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "OS name"
+#~ msgstr "Naziv OS-a"
+
+#~ msgid "OS type"
+#~ msgstr "Vrsta OS-a"
+
+#~ msgid "Disk"
+#~ msgstr "Disk"
+
+#~ msgid "Check for updates"
+#~ msgstr "Proveravam ažuriranja"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Čuva snimak u fasciklu „$PICTURES“"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Čuva snimak prozora u fasciklu „$PICTURES“"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Čuva snimak oblasti u fasciklu „$PICTURES“"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Umnožava snimak u beležnicu"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Umnožava snimak prozora u beležnicu"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Umnožava snimak oblasti u beležnicu"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Snimite kratak radni tok ekrana"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Izmenjivači samo prebacuju na sledeći izvor"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Da vratim sve prečice?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Ponovno vraćanje prečica može uticati na vaše proizvoljne prečice. Ovo se "
+#~ "ne može opozvati."
+
+#~ msgid "Reset All"
+#~ msgstr "Vrati sve"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for <b>%s</b>. If you replace it, %s will be "
+#~ "disabled"
+#~ msgstr ""
+#~ "„%s“ se već koristi za <b>%s</b>. Ako zamenite, „%s“ biće isključeno"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Postavi proizvoljnu prečicu"
+
+#, c-format
+#~ msgid "Enter new shortcut to change <b>%s</b>."
+#~ msgstr "Unesite novu prečicu da izmenite <b>%s</b>."
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Unesite novu prečicu"
+
+#~ msgid "Set"
+#~ msgstr "Postavi"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Vreme za dupli klik"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Premicanje sa dva prsta"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Pet klika, GEGL vreme!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dvostruki klik, glavno dugme"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Jedan klik, glavno dugme"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dvostruki klik, srednje dugme"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Jedan klik, srednje dugme"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dvostruki klik, pomoćno dugme"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Jedan klik, pomoćno dugme"
+
+#~ msgid "Network proxy"
+#~ msgstr "Mrežni posrednik"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Upravljač mrežom treba biti pokrenut."
+
+#~ msgid "page 1"
+#~ msgstr "strana 1"
+
+#~ msgid "page 2"
+#~ msgstr "strana 2"
+
+#~ msgid "automatic"
+#~ msgstr "samostalno"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil „%d“"
+
+#~ msgid "WEP"
+#~ msgstr "VEP"
+
+#~ msgid "WPA"
+#~ msgstr "VPA"
+
+#~ msgid "WPA2"
+#~ msgstr "VPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprajz"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ništa"
+
+#~ msgid "Never"
+#~ msgstr "Nikad"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Nema signala"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Slab signal"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Dobar signal"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Odličan signal"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Izvrstan signal"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Ukloni profil veze"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Ukloni VPN"
+
+#~ msgid "Identity"
+#~ msgstr "Identitet"
+
+#~ msgid "Delete Route"
+#~ msgstr "Obriši rutu"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ništa"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "VEP 40/128-bitni ključ (Heksa ili ASKRI)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "VEP 128-bitna lozinka"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dinamički VEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "Lični VPA & VPA2"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Poslovni VPA & VPA2"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "Ograniči pozadinsku upotrebu podataka"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Prikladno za veze koje imaju ograničenje podataka ili se naplaćuju."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Upleteni par (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Sučelje jedinice prikačinjanja (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Sučelje nezavisnog medija (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 MB/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 MB/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 GB/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 GB/s"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Ne mogu da otvorim uređivača veze"
+
+#~ msgid "New Profile"
+#~ msgstr "Novi profil"
+
+#~ msgid "Import from file…"
+#~ msgstr "Uvezi iz datoteke…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Dodaj VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Ne mogu da uvezem VPN vezu"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Ne mogu da pročitam datoteku „%s“ ili ona ne sadrži poznate VPN podatke o "
+#~ "vezi\n"
+#~ "\n"
+#~ "Greška: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Izaberite datoteku za uvoz"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Datoteka pod nazivom „%s“ već postoji."
+
+#~ msgid "_Replace"
+#~ msgstr "_Zameni"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Da li želite da zamenite „%s“ VPN vezom koju sada čuvate?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Ne mogu da izvezem VPN vezu"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Ne mogu da izvezem VPN vezu „%s“ u %s.\n"
+#~ "\n"
+#~ "Greška: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Izvezi VPN vezu"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "never"
+#~ msgstr "nikad"
+
+#~ msgid "today"
+#~ msgstr "danas"
+
+#~ msgid "yesterday"
+#~ msgstr "juče"
+
+#~ msgid "Last used"
+#~ msgstr "Korišćena"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Uključivanjem bežične vruće tačke prekinućete vezu sa <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Nije moguće pristupiti Internetu preko vaše bežične dok je uključena "
+#~ "vruća tačka."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Bežične vruće tačke se obično koriste za deljenje dodatne internet veze "
+#~ "bežičnim putem."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Da zaustavim vruću tačku i da isključim sve korisnike?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Zaustavi vruću tačku"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Politika sistema zabranjuje upotrebu kao vruće tačke"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Bežični uređaj ne podržava režim vruće tačke"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Detalji mreže za izabrane mreže, uključujući lozinku i sva proizvoljna "
+#~ "podešavanja će biti izgubljeni."
+
+#~ msgid "_Forget"
+#~ msgstr "_Zaboravi"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Poznate bežične mreže"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Zaboravi"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Automatsko nalaženje veb posrednika se koristi kada nije data adresa za "
+#~ "podešavanje."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Ovo nije preporučljivo za nebezbedne, javne mreže."
+
+#~ msgid "details"
+#~ msgstr "pojedinosti"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Prikaži _lozinku"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Učini dostupno drugim korisnicima"
+
+#~ msgid "identity"
+#~ msgstr "identitet"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adresa"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Samo samostalne (DHCP) adrese"
+
+#~ msgid "Link-local only"
+#~ msgstr "Samo veži-lokalno"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Zanemari automatski dobijene rute"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Klonirana MAC adresa"
+
+#~ msgid "hardware"
+#~ msgstr "uređaji"
+
+#~ msgid "_Reset"
+#~ msgstr "_Ponovo postavi"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Ponovo će postaviti podešavanja ove veze na njihova osnovna, ali će je "
+#~ "upamtiti kao željenu vezu."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Ukloniće sve podatke koji se odnose na ovu mrežu i neće pokušati da se "
+#~ "sam poveže na nju."
+
+#~ msgid "reset"
+#~ msgstr "ponovo postavi"
+
+#~ msgid "Hardware"
+#~ msgstr "Uređaji"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Ponovo postavi"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Isključite da se povežete na bežičnu mrežu"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Priključeni uređaji"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Lozinka"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hok"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastrukturno"
+
+#~ msgid "Status unknown"
+#~ msgstr "Nepoznato stanje"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Neupravljan"
+
+#~ msgid "Unavailable"
+#~ msgstr "Nedostupno"
+
+#~ msgid "Connecting"
+#~ msgstr "Povezujem se"
+
+#~ msgid "Authentication required"
+#~ msgstr "Potrebno je potvrđivanje identiteta"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Isključujem"
+
+#~ msgid "Connection failed"
+#~ msgstr "Povezivanje nije uspelo"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Stanje je nepoznato (nedostaje)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Nije uspelo podešavanje"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Nije uspelo podešavanje IP-a"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Isteklo je podešavanje IP-a"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Zatražene su tajne, ali nisu dostavljene"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Prekinuta je veza sa 802.1x moliocem"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Nije uspelo podešavanje 802.1x molioca"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x molilac nije uspeo"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Potvrđivanje identiteta 802.1x molioca je trajalo predugo"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP usluga nije uspela da se pokrene"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP usluga je isključena"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP nije uspelo"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP klijent nije uspeo da e pokrene"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Greška DHCP klijenta"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP klijent nije uspeo"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Usluga deljene veze nije uspela da se pokrene"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Usluga deljene veze nije uspela"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Usluga samostalnog IP-a nije uspela da se pokrene"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Greška usluge samostalnog IP-a"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Usluga samostalnog IP-a nije uspela"
+
+#~ msgid "Line busy"
+#~ msgstr "Linija je zauzeta"
+
+#~ msgid "No dial tone"
+#~ msgstr "Nema tona pozivanja"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Nijedan nosač ne može biti uspostavljen"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Isteklo je vreme zahteva pozivanja"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Pokušaj pozivanja nije uspeo"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Nije uspelo pokretanje modema"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Nisam uspeo da izaberem navedeni NTP"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Ne tražim mreže"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Zavođenje mreže je odbijeno"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Isteklo je vreme za zavođenje mreže"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Nisam uspeo da zavedem sa zahtevanom mrežom"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Provera PIN-a nije uspela"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Možda nedostaje firmver za uređaj"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Veza je nestala"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Postojeća veza biće prisvojena"
+
+#~ msgid "Modem not found"
+#~ msgstr "Nije pronađen modem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Veza blututa nije uspela"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Potreban je SIM PIN"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Potreban je SIM PUK"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Pogrešna SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Nije uspela zavisnost veze"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabal je isključen"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "neodređena greška u 802.1X bezbednosti (vpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "Nije izabrana datoteka"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "neodređena greška potvrđivanja datoteke eap-metoda"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "DER, PEM, ili PKCS#12 lični ključevi (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER ili PEM uverenja (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "nedostaje datoteka EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC datoteke (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "nedostaje EAP-LEAP korisničko ime"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "nedostaje EAP-LEAP lozinka"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "neispravno EAP-PEAP uverenje izdavača uverenja: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "neispravno EAP-PEAP uverenje izdavača uverenja: nije navedeno nikakvo "
+#~ "uverenje"
+
+#~ msgid "missing EAP username"
+#~ msgstr "nedostaje EAP korisničko ime"
+
+#~ msgid "missing EAP password"
+#~ msgstr "nedostaje EAP lozinka"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "nedostaje EAP-TLS identitet"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "neispravno EAP-TLS uverenje izdavača uverenja: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "neispravno EAP-TLS uverenje izdavača uverenja: nije navedeno nikakvo "
+#~ "uverenje"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "neispravan EAP-TLS privatni ključ: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "neispravno EAP-TLS uverenje korisnika: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Nešifrovani privatni ključevi nisu sigurni"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Izgleda da izabrani privatni ključ nije zaštićen lozinkom. Ovo može "
+#~ "ugroziti vaše sigurnosne podatke. Izaberite privatni ključ koji ze "
+#~ "zaštićen lozinkom.\n"
+#~ "\n"
+#~ "(Možete zaštititi privatne ključeve koristeći „openssl“)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Izaberite vaše lično uverenje"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Izaberite lični ključ"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "neispravno EAP-TTLS uverenje izdavača uverenja: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "neispravno EAP-TTLS uverenje izdavača uverenja: nije navedeno nikakvo "
+#~ "uverenje"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Nepoznata greška potvrđivanja 802.1X bezbednosti"
+
+#~ msgid "missing leap-username"
+#~ msgstr "nedostaje leap korisničko ime"
+
+#~ msgid "missing leap-password"
+#~ msgstr "nedostaje leap lozinka"
+
+#~ msgid "missing wep-key"
+#~ msgstr "nedostaje vep ključ"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "neispravan vep ključ: ključ dužine %zu mora da sadrži samo heksadecimalne "
+#~ "cifre"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "neispravan vep ključ: ključ dužine %zu mora da sadrži samo askri znakove"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "neispravan vep ključ: pogrešna dužina ključa %zu. Ključ mora biti dužine "
+#~ "5/13 (askri) ili 10/26 (heksa)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "neispravan vep ključ: propusna reč ne sme biti prazna"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "neispravan vep ključ: propusna reč mora biti kraća od 64 znakova"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "neispravan vpa-psk: neispravna dužina ključa %zu. Mora biti [8,63] bajta "
+#~ "ili 64 heksadecimalnih cifara"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "neispravan vpa-psk: ne mogu da rastumačim ključ sa 64 bajta kao "
+#~ "heksadecimalni"
+
+#~ msgid "preferences-system-notifications"
+#~ msgstr "preferences-system-notifications"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Oblačići _obaveštenja"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Drugo"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "„%s“ nalog"
+
+#~ msgid "Error removing account"
+#~ msgstr "Greška u uklanjanju naloga"
+
+#, c-format
+#~ msgid "<b>%s</b> removed"
+#~ msgstr "<b>%s</b> je uklonjen"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "Remove Account"
+#~ msgstr "Ukloni nalog"
+
+#~ msgid "Unknown time"
+#~ msgstr "Nepoznato vreme"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%d %s %d %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s do potpune napunjenosti"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Pažnja: preostaje još %s rada"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Preostalo vreme: %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Potpuno puna"
+
+#~ msgid "Empty"
+#~ msgstr "Prazna"
+
+#~ msgid "Charging"
+#~ msgstr "Puni se"
+
+#~ msgid "Discharging"
+#~ msgstr "Prazni se"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Glavna"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Dodatna"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Bežični miš"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Bežična tastatura"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Neprekidiv izvor napajanja"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Lični digitalni pomoćnik"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobilni telefon"
+
+#~ msgid "Media player"
+#~ msgstr "Muzički uređaj"
+
+#~ msgid "Computer"
+#~ msgstr "Računar"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Puni se"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Upozorenje"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Skoro prazna"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Puna"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Potpuno puna"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Prazna"
+
+#~ msgid "Batteries"
+#~ msgstr "Baterije"
+
+#~ msgid "When _idle"
+#~ msgstr "Kada _miruje"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "Osvetljaj _ekrana"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "Osvetljaj _tastature"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "_Zatamni ekran kada je neradan"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Bežična"
+
+#~ msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+#~ msgstr ""
+#~ "Isključite mobilni internet (3G, 4G, LTE, itd.) da biste uštedeli "
+#~ "bateriju."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Blutut"
+
+#~ msgid "Turn off Bluetooth to save power."
+#~ msgstr "Isključite blutut da biste uštedeli bateriju."
+
+#~ msgid "When on battery power"
+#~ msgstr "Kada se napaja sa baterije"
+
+#~ msgid "When plugged in"
+#~ msgstr "Kada je uključen"
+
+#~ msgid "Suspend"
+#~ msgstr "Obustavi"
+
+#~ msgid "Power Off"
+#~ msgstr "Isključi"
+
+#~ msgid "Hibernate"
+#~ msgstr "Zamrzni"
+
+#~ msgid "Nothing"
+#~ msgstr "Ništa"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Dugme za gašenje i obustavu"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Sam obustavi"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Samostalna obustava uređaja"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Kada je dugme za napajanje pritisnuto"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "1 minute"
+#~ msgstr "1 minut"
+
+# bug(danilo): plural-forms
+#~ msgid "2 minutes"
+#~ msgstr "2 minuta"
+
+# bug(danilo): plural-forms
+#~ msgid "3 minutes"
+#~ msgstr "3 minuta"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 minuta"
+
+# bug(danilo): plural-forms
+#~ msgid "5 minutes"
+#~ msgstr "5 minuta"
+
+# bug(danilo): plural-forms
+#~ msgid "8 minutes"
+#~ msgstr "8 minuta"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 minuta"
+
+# bug(danilo): plural-forms
+#~ msgid "12 minutes"
+#~ msgstr "12 minuta"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Potvrdi identitet"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Štampač „%s“ je obrisan"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Nisam uspeo da dodam novi štampač."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Ne mogu da učitam sučelje: %s"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Nisu pronađeni odgovarajući upravljački programi"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Izaberite PPD datoteku"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Datoteke opisa Post skript štampača (*.ppd,*.PPD, *.ppd.gz, *PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Štampač sa neposrednim mlazom"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD štampač"
+
+#~ msgid "One Sided"
+#~ msgstr "Jednostrano"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Po dužoj strani (standardno)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Po kraćoj strani (okrenuto)"
+
+#~ msgid "Portrait"
+#~ msgstr "Uspravno"
+
+#~ msgid "Landscape"
+#~ msgstr "Položeno"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Obrnuto položeno"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Obrnuto uspravno"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Na čekanju"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Zaustavljen"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Potrebno je potvrđivanje identiteta"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Obrađujem"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Zaustavljen"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Otkazan"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Poništen"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Završen"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — pokrenuti poslovi"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Unesite punomoćstva da biste štampali sa štampača „%s“."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Otključaj server štampača"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Otključaj „%s“."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Unesite korisničko ime i lozinku da vidite štampače na „%s“."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Tražim štampače"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Serijski priključnik"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralelni priključnik"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Mesto: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adresa: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Server zahteva potvrđivanje identiteta"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dvostrano"
+
+#~ msgid "Paper Type"
+#~ msgstr "Tip papira"
+
+#~ msgid "Paper Source"
+#~ msgstr "Izvor papira"
+
+#~ msgid "Output Tray"
+#~ msgstr "Izlazna traka"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Gost skript predfilter"
+
+#~ msgid "Pages per side"
+#~ msgstr "Stranica po listu"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Opšte"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Podešavanje stranice"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Instaljive opcije"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Posao"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Kvalitet slike"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Boja"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Završavanje"
+
+#~ msgid "Test page"
+#~ msgstr "Probna stranica"
+
+#~ msgid "Auto Select"
+#~ msgstr "Sam odredi"
+
+#~ msgid "Printer Default"
+#~ msgstr "Podrazumevano"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Samo ugnježdeni Gost skript fontovi"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Prevedi u 1° nivo postskripta"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Prevedi u 2° nivo postskripta"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Bez predfiltriranja"
+
+#~ msgid "Out of toner"
+#~ msgstr "Nema više tonera"
+
+#~ msgid "Low on developer"
+#~ msgstr "Ponestaje razvijača"
+
+#~ msgid "Out of developer"
+#~ msgstr "Nema više razvijača"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Ponestaje markera"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Nema više mastila"
+
+#~ msgid "Open cover"
+#~ msgstr "Otvoren poklopac"
+
+#~ msgid "Open door"
+#~ msgstr "Otvorena vratanca"
+
+#~ msgid "Low on paper"
+#~ msgstr "Ponestaje papira"
+
+#~ msgid "Out of paper"
+#~ msgstr "Nema više papira"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Isključen"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Zaustavljen"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Posuda za otpad je skoro puna"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Posuda za otpad je puna"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Optički provodnik fotografija je pri kraju života"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Optički provodnik fotografija više ne funkcioniše"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Spreman"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Ne prihvata poslove"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Obrađuje"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Očistite glave štampača"
+
+#~ msgid "Add…"
+#~ msgstr "Dodaj…"
+
+#~ msgid "In use"
+#~ msgstr "Koristi se"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Uklj."
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Isklj."
+
+#~ msgid "Usage & History"
+#~ msgstr "Upotreba i istorijat"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Da izbacim sve stavke iz smeća?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Sve stavke iz smeća će biti trajno uklonjene."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Izbaci Smeće"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Da obrišem sve privremene datoteke?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Sve privremene datoteke će biti trajno obrisane."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Pročisti privremene datoteke"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Slanje izveštaja o tehničkim problemima nam pomaže da poboljšamo „%s“. "
+#~ "Izveštaji se šalju bezimeno i očišćeni su od ličnih podataka."
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Politika privatnosti"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Zaštitite vaše lične podatke i odlučite šta drugi mogu da vide"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 sekundi"
+
+#~ msgid "1 day"
+#~ msgstr "1 dan"
+
+#~ msgid "2 days"
+#~ msgstr "2 dana"
+
+#~ msgid "3 days"
+#~ msgstr "3 dana"
+
+#~ msgid "4 days"
+#~ msgstr "4 dana"
+
+#~ msgid "5 days"
+#~ msgstr "5 dana"
+
+#~ msgid "6 days"
+#~ msgstr "6 dana"
+
+#~ msgid "7 days"
+#~ msgstr "7 dana"
+
+#~ msgid "14 days"
+#~ msgstr "14 dana"
+
+#~ msgid "30 days"
+#~ msgstr "30 dana"
+
+#~ msgid "Forever"
+#~ msgstr "Zauvek"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Pamćenje istorijata olakšava ponovno pronalaženje nekih stvari. Te stavke "
+#~ "se nikada ne dele preko mreže."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Skoro korišćeno"
+
+#~ msgid "Retain _History"
+#~ msgstr "Zadrži _istorijat"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Zaključavanje ekrana štiti vašu privatnost kada ste odsutni."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "_Zaključaj ekran nakon zatamnjenja od"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Samostalno će pročistiti smeće i privremene datoteke da bi vam pomogao da "
+#~ "održite računar slobodnim od nepotrebnih osetljivih podataka."
+
+#~ msgid "Purge _After"
+#~ msgstr "Pročisti _nakon"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Slanjem podataka o softveru koji koristite vi nam pomažete da vam "
+#~ "dostavimo tačnije preporuke. Takođe nam pomažete da poboljšamo naš "
+#~ "softver.\n"
+#~ "\n"
+#~ "Prikupljanje svih podataka se radi u tajnosti, i nikada vaše podatke "
+#~ "nećemo deliti sa trećim licima."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Pošalji podatke o korišćenju softvera"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Usluge mesta omogućavaju programima da znaju vašu lokaciju. Tačnost je "
+#~ "povećana uključivanjem bežične kartice i mobilne širokopojasne mreže."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Koristi Mozilinu uslugu lokacije: <a href='https://location.services."
+#~ "mozilla.com/privacy'>politika privatnosti</a>"
+
+#~ msgid "_Location Services"
+#~ msgstr "Usluge _mesta"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperijalni"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrički"
+
+#~ msgid "No regions found"
+#~ msgstr "Nisam pronašao područja"
+
+#~ msgid "No input sources found"
+#~ msgstr "Nisam pronašao izvore ulaza"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Drugo"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Prebacite se na prethodni izvor"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Razmak"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Prebacite se na sledeći izvor"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Razmak"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "Možete da promenite ove prečice u podešavanjima tastature"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Zamenski prelazak na sledeći izvor"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Levi+desni Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Engleski (Velika Britanija)"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Ponovo pokrenite sesiju kako bi izmene stupile u dejstvo"
+
+#~ msgid "Restart…"
+#~ msgstr "Ponovo pokreni…"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Velika Britanija"
+
+#~ msgid "_Options"
+#~ msgstr "_Opcije"
+
+#~ msgid "Add input source"
+#~ msgstr "Dodaj izvor ulaza"
+
+#~ msgid "Remove input source"
+#~ msgstr "Ukloni izvore ulaza"
+
+#~ msgid "Move input source up"
+#~ msgstr "Premesti izvor ulaza gore"
+
+#~ msgid "Move input source down"
+#~ msgstr "Premesti izvor ulaza dole"
+
+#~ msgid "Configure input source"
+#~ msgstr "Podesi izvor ulaza"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Prikaži raspored tastature izvora ulaza"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Podešavanja prijavljivanja koriste svi korisnici kada se prijavljuju na "
+#~ "sistem"
+
+#~ msgid "Select Location"
+#~ msgstr "Izaberi mesto"
+
+#~ msgid "_OK"
+#~ msgstr "U _redu"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Nisu izabrane mreže za deljenje"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Uklj."
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Isklj."
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Uključeno"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Izaberite fasciklu"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "Deljenje datoteka vam omogućava da delite vašu javnu fasciklu sa drugima "
+#~ "na vašoj tekućoj mreži koristeći: <a href=\"dav://%s\">dav://%s</a>"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "Kada je uključeno udaljeno prijavljivanje, udaljeni korisnici mogu da se "
+#~ "povežu koristeći naredbu bezbedne školjke:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "Deljenje ekrana omogućava udaljenim korisnicima da vide ili da upravljaju "
+#~ "vašim ekranom tako što će se povezati na <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Deljenje e_krana"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Neke usluge su isključene jer nema pristupa na mrežu."
+
+#~ msgid "Screen Sharing"
+#~ msgstr "Deljenje ekrana"
+
+#~ msgid "_Password:"
+#~ msgstr "_Lozinka:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Prikaži lozinku"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Nove veze moraju zatražiti pristup"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Zahtevaj lozinku"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "Bark"
+#~ msgstr "Lavež"
+
+#~ msgid "Drip"
+#~ msgstr "Kapanje"
+
+#~ msgid "Glass"
+#~ msgstr "Staklo"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Levo"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Desno"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Najmanje"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Najviše"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Sabvufer:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Bez pojačanja"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Proveri zvučnike"
+
+#~ msgid "Peak detect"
+#~ msgstr "Otkrivanje vrhunca"
+
+#~ msgid "Device"
+#~ msgstr "Uređaj"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Provera zvučnika za „%s“"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Izaberite uređaj kao zvučni i_zlaz:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Podešavanja za izabrani uređaj:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Jačina _ulaznog zvuka:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Izaberite uređaj kao zvučni u_laz:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Zvučni efekti"
+
+#~ msgid "Built-in"
+#~ msgstr "Ugrađen"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Postavke zvuka"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Provera zvučnog signala"
+
+#~ msgid "From theme"
+#~ msgstr "Iz teme"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Izaberite zvuk za _upozorenje:"
+
+#~ msgid "Stop"
+#~ msgstr "Zaustavi"
+
+#~ msgid "Custom"
+#~ msgstr "Proizvoljno"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Osnovno"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Srednji"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Veliki"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Veći"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Najveći"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d piksel"
+#~ msgstr[1] "%d piksela"
+#~ msgstr[2] "%d piksela"
+#~ msgstr[3] "jedan piksel"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Čitač ekrana"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Čitač ekrana"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Tasteri zvuka"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Bljesni naslovom _prozora"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kratko"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "1/4 ekrana"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "1/2 ekrana"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "3/4 ekrana"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Veliko"
+
+#~ msgid "Standard"
+#~ msgstr "Standardni"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Vrsta naloga"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Dozvoli korisniku da podesi _lozinku prilikom sledećeg prijavljivanja"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Postavi lozinku sa_da"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Morate biti na mreži da biste dodali poslovne korisnike."
+
+#~ msgid "Left thumb"
+#~ msgstr "Levi palac"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Srednji, levi prst"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Domali, levi prst"
+
+#~ msgid "Left little finger"
+#~ msgstr "Mali, levi prst"
+
+#~ msgid "Right thumb"
+#~ msgstr "Desni palac"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Desni, srednji prst"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Desni, domali prsti"
+
+#~ msgid "Right little finger"
+#~ msgstr "Desni, mali prst"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Omogući prijavljivanje otiskom prsta"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Desni kažiprst"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Levi kažiprst"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Vaš otisak prsta je uspešno sačuvan. Sada se možete prijaviti na sistem "
+#~ "preko čitača otisaka prstiju."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Snimite sliku…"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "prijavljivanje;ime;otisak prstiju;avatar;logo;lice;lozinka;"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Potvrdi novu lozinku"
+
+#~ msgid "User Icon"
+#~ msgstr "Ikonica korisnika"
+
+#~ msgid "Last Login"
+#~ msgstr "Poslednje prijavljivanje"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Nova lozinka treba da se razlikuje od stare."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Probajte da izmenite neka slova i brojeve."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Probajte još samo malo da izmenite lozinku."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Lozinka bez vašeg korisničkog imena će biti jača."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Pokušajte da izbegnete vaše ime u lozinki."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Pokušajte da izbegnete neke od reči upotrebljenih u lozinki."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Pokušajte da izbegnete uobičajene reči."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Pokušajte da izbegnete preuređivanje postojećih reči."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Pokušajte da koristite više brojeva."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Pokušajte da koristite više velikih slova."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Pokušajte da koristite više malih slova."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Pokušajte da koristite više posebnih znakova, kao tačka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Pokušajte da koristite mešavinu slova, brojeva i tačaka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Pokušajte da izbegnete ponavljanje istog znaka."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Pokušajte da izbegnete ponavljanje iste vrste znaka: treba da mešate "
+#~ "velika slova, brojeve i tačke."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Pokušajte da izbegnete nizove 1234 ili abvg."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Lozinka mora biti duža. Pokušajte da koristite mešavinu slova, brojeva i "
+#~ "tačaka."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Mešajte velika i mala slova i probajte da koristite jedan ili dva broja."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "Dodavanje još slova, brojeva i tačke će učiniti lozinku još jačom."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Potvrđivanje identiteta nije uspelo"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Nova lozinka je previše kratka"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Nova lozinka je previše jednostavna"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Stara i nova lozinka su suviše slične"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Nova lozinka je već upotrebljavana u skorije vreme."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Nova lozinka mora da sadrži numeričke ili specijalne znakove"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Stara i nova lozinka su iste"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "Vaša lozinka je izmenjena od kada ste na početku potvrdili identitet!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Nova lozinka ne sadrži dovoljno različitih znakova"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Nepoznata greška"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Treba da podudari veb adresu vašeg dostavljača prijavljivanja."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Nisam uspeo da dodam nalog"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Lozinke se ne podudaraju."
+
+#~ msgid "Failed to register account"
+#~ msgstr "Nisam uspeo da upišem nalog"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Nema podržanog načina za potvrđivanje identiteta sa ovim domenom"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Nisam uspeo da pristupim domenu"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Neispravno ime za prijavljivanje.\n"
+#~ "Pokušajte ponovo."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Neispravna lozinka za prijavljivanje.\n"
+#~ "Pokušajte ponovo."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Nisam uspeo da se prijavim na domen"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Ne mogu da pronađem domen. Možda ste ga pogrešno napisali?"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standardni"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administrator"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Nemate dozvole za pristup ovom uređaju. Kontaktirajte vašeg "
+#~ "administratora sistema."
+
+#~ msgid "The device is already in use."
+#~ msgstr "Uređaj je već u upotrebi."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Došlo je do greške unutar programa."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Da obrišem zabeležene otiske prsta?"
+
+#~ msgid "Done!"
+#~ msgstr "Urađeno!"
+
+#, c-format
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Ne mogu da pristupim uređaju „%s“"
+
+#, c-format
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Ne mogu da uhvatim otisak prsta sa uređaja „%s“"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Ne mogu da pristupim nijednom čitaču otisaka prstiju"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Javite se administratoru sistema za pomoć."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Morate sačuvati jedan od vaših otisaka prsta sa uređaja „%s“, kako bi "
+#~ "omogućili prijavu na sistem otiskom prsta."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Biram prst"
+
+#~ msgid "This Week"
+#~ msgstr "Ove sedmice"
+
+#~ msgid "Last Week"
+#~ msgstr "Prošle sedmice"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e. %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e. %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Kraj sesije"
+
+#~ msgid "Session Started"
+#~ msgstr "Početak sesije"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Izaberite drugu lozinku."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Unesite vašu trenutnu lozinku ponovo."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Lozinka ne može biti promenjena"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Ne mogu sam da pristupim ovoj vrsti domena"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "Nije pronađen takav domen ili područje"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Ne mogu da se prijavim kao „%s“ na domenu %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Neispravna lozinka, pokušajte ponovo"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Nisam uspeo da izbrišem korisnika"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Nisam uspeo da opozovem daljinski upravljanog korisnika"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Ne možete obrisati vaš lični nalog."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "„%s“ je i dalje prijavljen"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Brisanje korisnika dok su prijavljeni može da ostavi sistem u "
+#~ "neusklađenom stanju."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Da li želite da sačuvate datoteke korisnika „%s“?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Moguće je zadržati ličnu fasciklu, skladišta pošte i privremene datoteke "
+#~ "prilikom brisanja korisničkog naloga."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Obriši datoteke"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Zadrži datoteke"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Da li sigurno želite da opozovete daljinski upravljani nalog korisnika "
+#~ "„%s“?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Obriši"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Nalog je isključen"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Za podešavanje prilikom narednog prijavljivanja"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ništa"
+
+#~ msgid "Logged in"
+#~ msgstr "Prijavljen sam"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Nisam uspeo da kontaktiram uslugu naloga"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Molim proverite da li je Usluga naloga instalirana i uključena."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Da napravite izmene,\n"
+#~ "kliknite prvo na ikonicu *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Napravite korisnički nalog"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Da napravite korisnički nalog,\n"
+#~ "kliknite prvo na ikonicu *"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Obrišite izabrani korisnički nalog"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Da obrišete izabrani korisnički nalog,\n"
+#~ "kliknite prvo na ikonicu *"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Izvinite, ali to korisničko ime nije dostupno. Probajte neko drugo."
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "Korisničko ime je predugo."
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Korisničko ime ne može početi sa „-“."
+
+#~ msgid ""
+#~ "The username should only consist of upper and lower case letters from a-"
+#~ "z, digits and the following characters: . - _"
+#~ msgstr ""
+#~ "Korisničko ime treba da sadrži samo velika i mala slova latinskog "
+#~ "alfabeta od a-z, cifre i sledeće znakove: . - _"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Biće korišćeno za imenovanje vaše lične fascikle i ne može biti izmenjeno."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Dugme %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Pošalji otkucaj tastera"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Promeni monitor"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Prikaži pomoć na ekranu"
+
+#~ msgid "Output:"
+#~ msgstr "Izlaz:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Zadrži odnos razmere (crne trake):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Mapiraj na jednom monitoru"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d od %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Prikazuje mapiranje"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablica (apsolutno)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Postavke tablice"
+
+#~ msgid "_Help"
+#~ msgstr "Po_moć"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Podešavanja Blututa"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Mapiraj dugmad…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Podesite rezoluciju prikaza"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Doterajte podešavanja miša"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Režim praćenja"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nova prečica…"
+
+#~ msgid "No stylus found"
+#~ msgstr "Nisam našao olovku"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Približite vašu olovku tabličnom uređaju da ga podesite"
+
+#~ msgid "Top Button"
+#~ msgstr "Gornje dugme"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Najniže dugme"
+
+#~ msgid "page 3"
+#~ msgstr "strana 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Gnomov Upravljački Centar"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Upravljački centar je glavno Gnomovo sučelje za podešavanje različitih "
+#~ "delova vašeg sistema."
+
+#~ msgid "Display version number"
+#~ msgstr "Broj izdanja prikaza"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Uključuje režim ispisivanja"
+
+#~ msgid "Show the overview"
+#~ msgstr "Prikazuje pregled"
+
+#~ msgid "Search for the string"
+#~ msgstr "Traži nisku"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Ispisuje moguće nazive panela i izlazi"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel za prikaz"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Dostupni paneli:"
+
+#~ msgid "Quit"
+#~ msgstr "Izađi"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Vruća tačka"
 
 #~ msgid "Back­ground"
 #~ msgstr "Pozadina"
@@ -7537,9 +8076,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "Co­lor"
 #~ msgstr "Boja"
-
-#~ msgid "Section"
-#~ msgstr "Odeljak"
 
 #~ msgid "Overview"
 #~ msgstr "Pregled"
@@ -7555,10 +8091,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "Remo­vable Media"
 #~ msgstr "Prenosni mediji"
-
-#~ msgctxt "keybinding"
-#~ msgid "Search"
-#~ msgstr "Pretraga"
 
 #~ msgid "Net­work"
 #~ msgstr "Mreža"
@@ -7615,12 +8147,6 @@ msgstr "Sistemski zvuci"
 #~ msgid "Mirrored"
 #~ msgstr "Preslikano"
 
-#~ msgid "Primary"
-#~ msgstr "Glavni"
-
-#~ msgid "Secondary"
-#~ msgstr "Sporedni"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Rasporedite objedinjene prikaze"
 
@@ -7644,9 +8170,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "Size"
 #~ msgstr "Veličina"
-
-#~ msgid "Aspect Ratio"
-#~ msgstr "Razmera"
 
 #~ msgid "Show the top bar and Activities Overview on this display"
 #~ msgstr "Prikaži gornju traku i pregled aktivnosti na ovom prikazu"
@@ -7693,9 +8216,6 @@ msgstr "Sistemski zvuci"
 #~ msgid "Delete DNS Server"
 #~ msgstr "Obriši DNS server"
 
-#~ msgid "Reset"
-#~ msgstr "Ponovo postavi"
-
 #~ msgid "Make available to other _users"
 #~ msgstr "Učini dostupno drugim _korisnicima"
 
@@ -7730,9 +8250,6 @@ msgstr "Sistemski zvuci"
 #~ "Ako imate neku drugu vezu na Internet osim bežične, možete da podesite "
 #~ "bežičnu vruću tačku da delite vezu sa drugima."
 
-#~ msgid "History"
-#~ msgstr "Istorijat"
-
 #~ msgid "Proxy"
 #~ msgstr "Posrednik"
 
@@ -7750,12 +8267,6 @@ msgstr "Sistemski zvuci"
 #~ msgctxt "proxy method"
 #~ msgid "Automatic"
 #~ msgstr "Automatski"
-
-#~ msgid "Add Device"
-#~ msgstr "Dodaj uređaj"
-
-#~ msgid "Remove Device"
-#~ msgstr "Ukloni uređaj"
 
 #~ msgid "VPN Type"
 #~ msgstr "VPN vrsta"
@@ -7780,9 +8291,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "4"
 #~ msgstr "4"
-
-#~ msgid "Loading options…"
-#~ msgstr "Učitavam opcije…"
 
 #~ msgctxt "Password hint"
 #~ msgid "Try to add more letters, numbers and symbols."
@@ -7814,9 +8322,6 @@ msgstr "Sistemski zvuci"
 #~ msgid "Wayland"
 #~ msgstr "Vejland"
 
-#~ msgid "Edit"
-#~ msgstr "Uredi"
-
 #~ msgctxt "notifications"
 #~ msgid "Notification _Banners"
 #~ msgstr "_Vrpce obaveštenja"
@@ -7829,9 +8334,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "Mail"
 #~ msgstr "El. pošta"
-
-#~ msgid "Calendar"
-#~ msgstr "Kalendar"
 
 #~ msgid "Contacts"
 #~ msgstr "Kontakti"
@@ -7850,9 +8352,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "Ovo neće ukloniti nalog na serveru."
-
-#~ msgid "_Remove"
-#~ msgstr "_Ukloni"
 
 #~ msgid "No online accounts configured"
 #~ msgstr "Nisu podešeni nalozi na mreži"
@@ -7908,9 +8407,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "label"
 #~ msgstr "natpis"
-
-#~ msgid "Setting new driver…"
-#~ msgstr "Podešavam novi upravljački program…"
 
 #~ msgid "Print _Test Page"
 #~ msgstr "Odštampaj _probnu stranicu"
@@ -7991,12 +8487,6 @@ msgstr "Sistemski zvuci"
 #~ msgid "Scroll Up"
 #~ msgstr "Klizaj na gore"
 
-#~ msgid "Scroll Down"
-#~ msgstr "Klizaj na dole"
-
-#~ msgid "Scroll Left"
-#~ msgstr "Klizaj levo"
-
 #~ msgid "Scroll Right"
 #~ msgstr "Klizaj desno"
 
@@ -8009,12 +8499,6 @@ msgstr "Sistemski zvuci"
 #~ msgstr ""
 #~ "Da izmenite prečicu, kliknite na odgovarajući red i ukucajte novu "
 #~ "kombinaciju tastera ili pritisnite „Backspace“ da obrišete prečicu."
-
-#~ msgid "_Name:"
-#~ msgstr "_Naziv:"
-
-#~ msgid "Add Shortcut"
-#~ msgstr "Dodaj prečicu"
 
 #~ msgid "Remove Shortcut"
 #~ msgstr "Ukloni prečicu"
@@ -8119,9 +8603,6 @@ msgstr "Sistemski zvuci"
 #~ msgid "Don't _warn me again"
 #~ msgstr "Ne _upozoravaj me više"
 
-#~ msgid "No"
-#~ msgstr "Ne"
-
 #~ msgid "Yes"
 #~ msgstr "Da"
 
@@ -8144,9 +8625,6 @@ msgstr "Sistemski zvuci"
 #~ msgid "Personal File Sharing"
 #~ msgstr "Deljenje ličnih datoteka"
 
-#~ msgid "_Allow Remote Control"
-#~ msgstr "Dozvoli ud_aljeno upravljanje"
-
 #~ msgid "_Verify"
 #~ msgstr "_Potvrdi"
 
@@ -8168,9 +8646,6 @@ msgstr "Sistemski zvuci"
 #~ msgid "Time _Zone"
 #~ msgstr "Vremenska _zona"
 
-#~ msgid "Close"
-#~ msgstr "Zatvori"
-
 #~ msgid "Resume Printing"
 #~ msgstr "Nastavi štampanje"
 
@@ -8187,12 +8662,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "Job State"
 #~ msgstr "Stanje posla"
-
-#~ msgid "Time"
-#~ msgstr "Vreme"
-
-#~ msgid "Options"
-#~ msgstr "Mogućnosti"
 
 #~ msgid "Password:"
 #~ msgstr "Lozinka:"
@@ -8276,20 +8745,11 @@ msgstr "Sistemski zvuci"
 #~ msgid "Add New Printer"
 #~ msgstr "Dodaj novi štampač"
 
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "Blutut je isključen"
-
-#~ msgid "Security key"
-#~ msgstr "Ključ bezbednosti"
-
 #~ msgid "Wireless devices require extra power"
 #~ msgstr "Bežični uređaji zahtevaju dodatno napajanje"
 
 #~ msgid "When battery power is _critical"
 #~ msgstr "Kad je napajanje baterije _kritično"
-
-#~ msgid "Power off"
-#~ msgstr "Isključi"
 
 #~ msgid ""
 #~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
@@ -8324,17 +8784,11 @@ msgstr "Sistemski zvuci"
 #~ msgid "Germany"
 #~ msgstr "Nemačka"
 
-#~ msgid "France"
-#~ msgstr "Francuska"
-
 #~ msgid "Spain"
 #~ msgstr "Španija"
 
 #~ msgid "China"
 #~ msgstr "Kina"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Isključi dok _kucam"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "Mrežni servis na sistemu nije podržan u ovoj verziji."
@@ -8380,29 +8834,17 @@ msgstr "Sistemski zvuci"
 #~ msgid "Share Public Folder On This Network"
 #~ msgstr "Deli javnu fasciklu na ovoj mreži"
 
-#~ msgid "Flickr"
-#~ msgstr "Flikr"
-
 #~ msgid "Set Up New Device"
 #~ msgstr "Podesi novi uređaj"
 
 #~ msgid "Paired"
 #~ msgstr "Uparen"
 
-#~ msgid "Type"
-#~ msgstr "Vrsta"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "Podešavanja miša i dodirne table"
 
-#~ msgid "Sound Settings"
-#~ msgstr "Podešavanja zvuka"
-
 #~ msgid "Send Files…"
 #~ msgstr "Pošalji datoteke…"
-
-#~ msgid "Visibility"
-#~ msgstr "Vidljivost"
 
 #~ msgid "Visibility of “%s”"
 #~ msgstr "Vidljivost za „%s“"
@@ -8487,9 +8929,6 @@ msgstr "Sistemski zvuci"
 #~ msgid "_City:"
 #~ msgstr "_Grad:"
 
-#~ msgid "_Network Time"
-#~ msgstr "_Mrežno vreme"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "Podesi vreme jedan sat unapred."
 
@@ -8513,18 +8952,8 @@ msgstr "Sistemski zvuci"
 #~ msgstr "Normalno"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "U smeru kazaljke na satu"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 stepeni"
-
-#~ msgid "Monitor"
-#~ msgstr "Ekran"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "Prevucite da promenite primarnu prikaz."
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -8622,9 +9051,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "Only share with Trusted Devices"
 #~ msgstr "Samo deli sa poverljivim uređajima"
-
-#~ msgid "Remote View"
-#~ msgstr "Udaljeni pregled"
 
 #~ msgid "Approve All Connections"
 #~ msgstr "Odobri sve veze"
@@ -8733,12 +9159,6 @@ msgstr "Sistemski zvuci"
 #~ msgid "C_ontinue"
 #~ msgstr "_Nastavi"
 
-#~ msgid "Previous Week"
-#~ msgstr "Prethodna sedmica"
-
-#~ msgid "Next Week"
-#~ msgstr "Sledeća sedmica"
-
 #~ msgid "Next week"
 #~ msgstr "Sledeća sedmica"
 
@@ -8750,12 +9170,6 @@ msgstr "Sistemski zvuci"
 
 #~ msgid "Enable this account"
 #~ msgstr "Uključi ovaj nalog"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "P_otvrdi lozinku"
-
-#~ msgid "Generate a password"
-#~ msgstr "Stvorite lozinku"
 
 #~ msgid "_Action"
 #~ msgstr "_Radnja"
@@ -8772,8 +9186,8 @@ msgstr "Sistemski zvuci"
 #~ msgid ""
 #~ "Choose a picture that will be shown at the login screen for this account."
 #~ msgstr ""
-#~ "Izaberite sliku koja će biti prikazana na ekranu za prijavljivanje za ovaj "
-#~ "nalog."
+#~ "Izaberite sliku koja će biti prikazana na ekranu za prijavljivanje za "
+#~ "ovaj nalog."
 
 #~ msgid "Gallery"
 #~ msgstr "Zbirka"

--- a/po/sr@latin.po~
+++ b/po/sr@latin.po~
@@ -1,0 +1,8854 @@
+# Serbian translation of gnome-control-center
+# Courtesy of Prevod.org team (http://prevod.org/) -- 2003—2017.
+# This file is distributed under the same license as the gnome-control-center package.
+# Veljko M. Stanojević <veljko@vms.homelinux.net>
+# Danilo Šegan <danilo@gnome.org>, 2005.
+# Slobodan D. Sredojević <slobo@akrep.be>, 2006.
+# Miloš Popović <gpopac@gmail.com>, 2010, 2011.
+# Miroslav Nikolić <miroslavnikolic@rocketmail.com>, 2011—2017.
+# Marko M. Kostić <marko.m.kostic@gmail.com>, 2016.
+# Borisav Živanović <borisavzivanovic@gmail.com>, 2017-2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2018-02-24 17:48+0000\n"
+"PO-Revision-Date: 2018-02-25 08:19+0100\n"
+"Last-Translator: Marko M. Kostić <marko.m.kostic@gmail.com>\n"
+"Language-Team: srpski <gnome-sr@googlegroups.org>\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Project-Style: gnome\n"
+"X-Generator: Poedit 2.0.6\n"
+
+#: panels/background/background.ui:49
+msgid "_Background"
+msgstr "_Pozadina"
+
+#. This refers to a slideshow background
+#: panels/background/background.ui:99 panels/background/background.ui:212
+msgid "Changes throughout the day"
+msgstr "Menja se tokom celog dana"
+
+#. To translators: This is a noun, not a verb
+#: panels/background/background.ui:162
+msgid "_Lock Screen"
+msgstr "Zaključavanje _ekrana"
+
+#: panels/background/background.ui:268
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Popločano"
+
+#: panels/background/background.ui:272
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Uvećano"
+
+#: panels/background/background.ui:276
+msgctxt "background, style"
+msgid "Center"
+msgstr "Centrirano"
+
+#: panels/background/background.ui:280
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Srazmerno"
+
+#: panels/background/background.ui:284
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Popunjeno"
+
+#: panels/background/background.ui:288
+msgctxt "background, style"
+msgid "Span"
+msgstr "Rasprostrto"
+
+#: panels/background/cc-background-chooser-dialog.c:424
+msgid "Wallpapers"
+msgstr "Pozadine"
+
+#: panels/background/cc-background-chooser-dialog.c:433
+msgid "Colors"
+msgstr "Boje"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: panels/background/cc-background-chooser-dialog.c:468
+msgid "Select Background"
+msgstr "Izaberite pozadinu"
+
+#: panels/background/cc-background-chooser-dialog.c:496
+msgid "Pictures"
+msgstr "Slike"
+
+#. translators: No pictures were found
+#: panels/background/cc-background-chooser-dialog.c:528
+msgid "No Pictures Found"
+msgstr "Nisam pronašao slike"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: panels/background/cc-background-chooser-dialog.c:545
+#: panels/search/cc-search-locations-dialog.c:302
+msgid "Home"
+msgstr "Lično"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: panels/background/cc-background-chooser-dialog.c:555
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "Možete da dodate slike u vašu fasciklu %s i one će biti prikazane ovde"
+
+#: panels/background/cc-background-chooser-dialog.c:560
+#: panels/color/cc-color-panel.c:225 panels/color/cc-color-panel.c:963
+#: panels/color/color-calibrate.ui:25 panels/color/color.ui:657
+#: panels/common/language-chooser.ui:23 panels/display/cc-display-panel.c:2594
+#: panels/network/connection-editor/connection-editor.ui:15
+#: panels/network/connection-editor/vpn-helpers.c:181
+#: panels/network/connection-editor/vpn-helpers.c:310
+#: panels/network/net-device-wifi.c:1411 panels/network/net-device-wifi.c:1491
+#: panels/network/net-device-wifi.c:1736 panels/network/network-wifi.ui:24
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:331
+#: panels/privacy/cc-privacy-panel.c:1053 panels/region/format-chooser.ui:25
+#: panels/region/input-chooser.ui:13
+#: panels/search/cc-search-locations-dialog.c:642
+#: panels/sharing/cc-sharing-panel.c:384
+#: panels/user-accounts/data/account-dialog.ui:28
+#: panels/user-accounts/data/join-dialog.ui:20
+#: panels/user-accounts/data/password-dialog.ui:21
+#: panels/user-accounts/um-fingerprint-dialog.c:261
+#: panels/user-accounts/um-photo-dialog.c:102
+#: panels/user-accounts/um-photo-dialog.c:229
+#: panels/user-accounts/um-user-panel.c:635
+#: panels/user-accounts/um-user-panel.c:653
+msgid "_Cancel"
+msgstr "_Otkaži"
+
+#: panels/background/cc-background-chooser-dialog.c:561
+msgid "_Select"
+msgstr "I_zaberi"
+
+#: panels/background/cc-background-item.c:192
+msgid "multiple sizes"
+msgstr "više veličina"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:196
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:321
+msgid "No Desktop Background"
+msgstr "Nema pozadine za radnu površ"
+
+#: panels/background/cc-background-panel.c:291
+msgid "Current background"
+msgstr "Trenutna pozadina"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "Pozadina"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Izmenite sliku pozadine na tapet ili fotografiju"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/background/gnome-background-panel.desktop.in.in:7
+msgid "preferences-desktop-wallpaper"
+msgstr "preferences-desktop-wallpaper"
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr ""
+"pozadina;ekran;radna površ;Wallpaper;Screen;Desktop;pozadina;ekran;radna;"
+"povrs;površ;"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:265
+msgid "Turn Off Airplane Mode"
+msgstr "Isključi avionski režim rada"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:330
+msgid "No Bluetooth Found"
+msgstr "Nije pronađen blutut"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:330
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Ubacite USB blutut uređaj za korišćenje blututa."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:331
+msgid "Bluetooth Turned Off"
+msgstr "Blutut je ugašen"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:331
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Uključite za povezivanje uređaja i ostvarivanje prenosa datoteka."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:332
+msgid "Airplane Mode is on"
+msgstr "Avionski režim rada je uključen"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:332
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Blutut je isključen kada je avionski režim rada uključen."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:333
+msgid "Hardware Airplane Mode is on"
+msgstr "Hardverski avionski režim rada je uključen"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:333
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Isključite avionski režim rada biste uključili blutut."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/network/network.ui:101 panels/printers/pp-new-printer-dialog.c:1816
+msgid "Bluetooth"
+msgstr "Blutut"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Uključite ili isključite blutut i povežite vaše uređaje"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:6
+msgid "bluetooth"
+msgstr "bluetooth"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+"deljenje;blutut;obeks;deljenje;blutut;obeks;share;sharing;bluetooth;obex;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Postavite uređaj za kalibraciju preko kvadrata i pritisnite „Počni“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Pomerite uređaj za kalibraciju na položaj kalibracije i pritisnite „Nastavi“"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Pomerite uređaj za kalibraciju na položaj površine i pritisnite „Nastavi“"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "Zaklopite prenosni računar"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "Došlo je do unutrašnje greške koja ne može biti oporavljena."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "Alati potrebni za kalibraciju nisu instalirani."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "Profil ne može biti napravljen."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "Bela tačka mete se ne može dobaviti."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "Završeno!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "Kalibracija nije uspela!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "Možete da uklonite uređaj za kalibraciju."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Ne ometajte uređaj za kalibraciju dok je u radu"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Ekran prenosnog računara"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Ugrađena veb kamerica"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s monitor"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s skener"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s fotoaparat"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s štampač"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s veb kamerica"
+
+#: panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Uključi upravljanje bojom za „%s“"
+
+#: panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Prikaži profile boja za „%s“"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:323
+msgid "Not calibrated"
+msgstr "Nije kalibrisano"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:141
+msgid "Default: "
+msgstr "Osnovno: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:149
+msgid "Colorspace: "
+msgstr "Prostor boja: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:156
+msgid "Test profile: "
+msgstr "Probni profil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:223
+msgid "Select ICC Profile File"
+msgstr "Izaberi datoteku ICC profila"
+
+#: panels/color/cc-color-panel.c:226
+msgid "_Import"
+msgstr "_Uvezi"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:237
+msgid "Supported ICC profiles"
+msgstr "Podržani ICC profili"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:244
+#: panels/network/wireless-security/eap-method-fast.c:417
+msgid "All files"
+msgstr "Sve datoteke"
+
+#: panels/color/cc-color-panel.c:583
+msgid "Screen"
+msgstr "Ekran"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:908
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Nisam uspeo da otpremim datoteku: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:922
+msgid "The profile has been uploaded to:"
+msgstr "Profil je otpremljen u:"
+
+#: panels/color/cc-color-panel.c:924
+msgid "Write down this URL."
+msgstr "Zapišite ovu adresu."
+
+#: panels/color/cc-color-panel.c:925
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+"Ponovo pokrenite ovaj računar i učitajte vaš uobičajeni operativni sistem."
+
+#: panels/color/cc-color-panel.c:926
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "Upišite adresu u vaš preglednik da preuzmete i da instalirate profil."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:960
+msgid "Save Profile"
+msgstr "Sačuvaj profil"
+
+#: panels/color/cc-color-panel.c:964
+#: panels/network/connection-editor/vpn-helpers.c:311
+msgid "_Save"
+msgstr "_Sačuvaj"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1325
+msgid "Create a color profile for the selected device"
+msgstr "Napravite profil boje za izabrani uređaj"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1340 panels/color/cc-color-panel.c:1364
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Nije otkriven instrument za merenje. Proverite da li je uključen i da li je "
+"ispravno priključen."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1374
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Instrument za merenje ne podržava profilisanje štampača."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1385
+msgid "The device type is not currently supported."
+msgstr "Tip uređaja trenutno nije podržan."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "Uobičajeni prostor"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "Isprobaj profil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Samostalni"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Nizak kvalitet"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Osrednji kvalitet"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Visok kvalitet"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Osnovna RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Osnovna CMUK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Osnovna siva"
+
+#: panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "Prodavac je dostavio podatke fabričke kalibracije"
+
+#: panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Ispravka prikaza preko celog ekrana nije moguća sa ovim profilom"
+
+#: panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "Ovaj profil više ne može biti tačan"
+
+#: panels/color/color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr "Prikaži kalibraciju"
+
+#. This starts the calibration process
+#: panels/color/color-calibrate.ui:40
+msgid "_Start"
+msgstr "_Pokreni"
+
+#. This resumes the calibration process
+#: panels/color/color-calibrate.ui:54
+msgid "_Resume"
+msgstr "_Nastavi"
+
+#. This button returns the user back to the color control panel
+#: panels/color/color-calibrate.ui:67 panels/common/language-chooser.ui:12
+#: panels/region/format-chooser.ui:14
+msgid "_Done"
+msgstr "_Urađeno"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: panels/color/color.ui:6 panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "Kalibracija ekrana"
+
+#: panels/color/color.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibracija će proizvesti profil koji možete da koristite da upravljate bojom "
+"vašeg ekrana. Što duže bude trajala kalibracija, to će biti bolji kvalitet "
+"profila boje."
+
+#: panels/color/color.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Nećete moći da koristite računar za vreme kalibracije."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/color.ui:58
+msgid "Quality"
+msgstr "Kvalitet"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/color.ui:75
+msgid "Approximate Time"
+msgstr "Približno vreme"
+
+#: panels/color/color.ui:121
+msgid "Calibration Quality"
+msgstr "Kvalitet kalibracije"
+
+#: panels/color/color.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Izaberite uređaj senzora koji želite da koristite za kalibraciju."
+
+#: panels/color/color.ui:174
+msgid "Calibration Device"
+msgstr "Uređaj kalibracije"
+
+#: panels/color/color.ui:189
+msgid "Select the type of display that is connected."
+msgstr "Izaberite vrstu ekrana koji je povezan."
+
+#: panels/color/color.ui:226
+msgid "Display Type"
+msgstr "Vrsta ekrana"
+
+#: panels/color/color.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Izaberite belu tačku mete ekrana. Većina ekrana treba da bude kalibrisana na "
+"D65 osvetljenje."
+
+#: panels/color/color.ui:278
+msgid "Profile Whitepoint"
+msgstr "Bela tačka profila"
+
+#: panels/color/color.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Molim podesite ekran na osvetljaj koji vam najviše odgovara. Upravljanje bojom "
+"će biti najtačnije na tom nivou osvetljaja."
+
+#: panels/color/color.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Ili drugačije, možete da koristite nivo osvetljaja korišćen sa jednim od "
+"drugih profila za ovaj uređaj."
+
+#: panels/color/color.ui:318
+msgid "Display Brightness"
+msgstr "Osvetljaj ekrana"
+
+#: panels/color/color.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Možete da koristite profil boje na različitim računarima, ili čak da "
+"napravite profile za različite uslove osvetljenja."
+
+#: panels/color/color.ui:348
+msgid "Profile Name:"
+msgstr "Naziv profila:"
+
+#: panels/color/color.ui:377
+msgid "Profile Name"
+msgstr "Naziv profila"
+
+#: panels/color/color.ui:392
+msgid "Profile successfully created!"
+msgstr "Profil je uspešno napravljen!"
+
+#: panels/color/color.ui:443
+msgid "Copy profile"
+msgstr "Umnožite profil"
+
+#: panels/color/color.ui:456
+msgid "Requires writable media"
+msgstr "Zahteva upisiv disk"
+
+#: panels/color/color.ui:519
+msgid "Upload profile"
+msgstr "Otpremite profil"
+
+#: panels/color/color.ui:532
+msgid "Requires Internet connection"
+msgstr "Zahteva Internet vezu"
+
+#: panels/color/color.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Možete uvideti da su uputnice o korišćenju profila na sistemima <a href="
+"\"linux\">GNU/Linuksa</a>, <a href=\"osx\">Ejpol OS Iks-a</a> i <a href="
+"\"windows\">Majkrosoft Vindouza</a> korisne."
+
+#: panels/color/color.ui:607 panels/user-accounts/um-fingerprint-dialog.c:720
+msgid "Summary"
+msgstr "Sažetak"
+
+#: panels/color/color.ui:621
+msgid "Add Profile"
+msgstr "Dodaj profil"
+
+#: panels/color/color.ui:643
+msgid "_Import File…"
+msgstr "_Uvezi datoteku…"
+
+#: panels/color/color.ui:672
+#: panels/network/connection-editor/net-connection-editor.c:519
+#: panels/printers/new-printer-dialog.ui:80 panels/region/input-chooser.ui:22
+#: panels/user-accounts/data/account-dialog.ui:47
+msgid "_Add"
+msgstr "_Dodaj"
+
+#: panels/color/color.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Otkriven je problem. Profil ne može da radi ispravno. <a href=\"\">Prikaži "
+"pojedinosti.</a>"
+
+#: panels/color/color.ui:807
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Svakom uređaju je potreban osveženi profil boje da bi bio upravljan bojom."
+
+#: panels/color/color.ui:829
+msgid "Learn more"
+msgstr "Saznajte više"
+
+#: panels/color/color.ui:834
+msgid "Learn more about color management"
+msgstr "Saznajte više o upravljanju bojama"
+
+#: panels/color/color.ui:882
+msgid "_Set for all users"
+msgstr "Pode_si za sve korisnike"
+
+#: panels/color/color.ui:886 panels/color/color.ui:901
+#: panels/color/color.ui:902
+msgid "Set this profile for all users on this computer"
+msgstr "Podesite ovaj profil za sve korisnike na ovom računaru"
+
+#: panels/color/color.ui:897
+msgid "_Enable"
+msgstr "_Omogući"
+
+#: panels/color/color.ui:928
+msgid "_Add profile"
+msgstr "_Dodaj profil"
+
+#: panels/color/color.ui:941
+msgid "_Calibrate…"
+msgstr "Is_kalibriši…"
+
+#: panels/color/color.ui:945
+msgid "Calibrate the device"
+msgstr "Podesite uređaj"
+
+#: panels/color/color.ui:956
+msgid "_Remove profile"
+msgstr "_Ukloni profil"
+
+#: panels/color/color.ui:969
+msgid "_View details"
+msgstr "_Prikaži detalje"
+
+#: panels/color/color.ui:1005
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Ne mogu da otkrijem ni jedan uređaj koji može biti upravljan bojom"
+
+#: panels/color/color.ui:1047
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/color.ui:1052
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/color.ui:1057
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/color.ui:1062
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/color.ui:1067
+msgid "Plasma"
+msgstr "Plazma"
+
+#: panels/color/color.ui:1072
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL pozadinsko osvetljenje)"
+
+#: panels/color/color.ui:1077
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED pozadinsko osvetljenje)"
+
+#: panels/color/color.ui:1082
+msgid "LCD (white LED backlight)"
+msgstr "LCD (belo LED pozadinsko osvetljenje)"
+
+#: panels/color/color.ui:1087
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD širokog gamuta (CCFL pozadinsko osvetljenje)"
+
+#: panels/color/color.ui:1092
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD širokog gamuta (RGB LED pozadinsko osvetljenje)"
+
+#: panels/color/color.ui:1109
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Visok"
+
+#: panels/color/color.ui:1110
+msgid "40 minutes"
+msgstr "40 minuta"
+
+#: panels/color/color.ui:1114
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Srednji"
+
+#: panels/color/color.ui:1115 panels/power/power.ui:25
+#: panels/privacy/privacy.ui:38
+msgid "30 minutes"
+msgstr "30 minuta"
+
+#: panels/color/color.ui:1119
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Nizak"
+
+# bug(danilo): plural-forms
+#: panels/color/color.ui:1120 panels/power/power.ui:13 panels/power/power.ui:95
+msgid "15 minutes"
+msgstr "15 minuta"
+
+#: panels/color/color.ui:1142
+msgid "Native to display"
+msgstr "Izvorno na ekran"
+
+#: panels/color/color.ui:1146
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Štampanje i objavljivanje)"
+
+#: panels/color/color.ui:1150
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/color.ui:1154
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotografija i grafika)"
+
+#: panels/color/color.ui:1158
+msgid "D75"
+msgstr "D75"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Boja"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Kalibrirajte boje vaših uređaja, kao što su ekrani, foto-aparati ili štampači"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/color/gnome-color-panel.desktop.in.in:7
+msgid "preferences-color"
+msgstr "preferences-color"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "boja;icc;profil;kalibriraj;štampač;ekran;"
+
+#: panels/common/cc-common-language.c:323
+msgid "Other…"
+msgstr "Drugi…"
+
+#: panels/common/cc-language-chooser.c:124
+#: panels/region/cc-format-chooser.c:269 panels/region/cc-input-chooser.c:169
+msgid "More…"
+msgstr "Još…"
+
+#: panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "Nisam pronašao jezike"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:106
+msgid "Today"
+msgstr "Danas"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "Yesterday"
+msgstr "Juče"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y."
+
+#: panels/common/language-chooser.ui:5
+msgid "Language"
+msgstr "Jezik"
+
+#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
+#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
+msgid "Day"
+msgstr "Dan"
+
+#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
+#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
+msgid "Month"
+msgstr "Mesec"
+
+#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
+#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
+msgid "Year"
+msgstr "Godina"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:333
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%A, %e.%m.%Y. %l:%M %P"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:338
+msgid "%e %B %Y, %R"
+msgstr "%e. %B %Y. %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:503
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:530
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:537
+msgid "UTC%:::z"
+msgstr "KUV%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:542
+msgid "%l:%M %p"
+msgstr "%l:%M %P"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:547
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:552
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/datetime.ui:22
+msgid "January"
+msgstr "Januar"
+
+#: panels/datetime/datetime.ui:25
+msgid "February"
+msgstr "Februar"
+
+#: panels/datetime/datetime.ui:28
+msgid "March"
+msgstr "Mart"
+
+#: panels/datetime/datetime.ui:31
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/datetime.ui:34
+msgid "May"
+msgstr "Maj"
+
+#: panels/datetime/datetime.ui:37
+msgid "June"
+msgstr "Jun"
+
+#: panels/datetime/datetime.ui:40
+msgid "July"
+msgstr "Jul"
+
+#: panels/datetime/datetime.ui:43
+msgid "August"
+msgstr "Avgust"
+
+#: panels/datetime/datetime.ui:46
+msgid "September"
+msgstr "Septembar"
+
+#: panels/datetime/datetime.ui:49
+msgid "October"
+msgstr "Oktobar"
+
+#: panels/datetime/datetime.ui:52
+msgid "November"
+msgstr "Novembar"
+
+#: panels/datetime/datetime.ui:55
+msgid "December"
+msgstr "Decembar"
+
+#: panels/datetime/datetime.ui:61
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Datum i vreme"
+
+#: panels/datetime/datetime.ui:106
+msgid "Hour"
+msgstr "Sat"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: panels/datetime/datetime.ui:121
+msgid "∶"
+msgstr "∶"
+
+# bug(danilo): plural-forms
+#: panels/datetime/datetime.ui:143
+msgid "Minute"
+msgstr "Minut"
+
+#: panels/datetime/datetime.ui:208
+msgid "Time Zone"
+msgstr "Vremenska zona"
+
+#: panels/datetime/datetime.ui:228
+msgid "Search for a city"
+msgstr "Potražite grad"
+
+#: panels/datetime/datetime.ui:304
+msgid "Automatic _Date & Time"
+msgstr "Automatsko vreme i _datum"
+
+#: panels/datetime/datetime.ui:319 panels/datetime/datetime.ui:397
+msgid "Requires internet access"
+msgstr "Zahteva pristup internetu"
+
+#: panels/datetime/datetime.ui:382
+msgid "Automatic Time _Zone"
+msgstr "Automatska vremenska _zona"
+
+#: panels/datetime/datetime.ui:454
+msgid "Date & _Time"
+msgstr "Datum i _vreme"
+
+#: panels/datetime/datetime.ui:502
+msgid "Time Z_one"
+msgstr "Vremenska z_ona"
+
+#: panels/datetime/datetime.ui:570
+msgid "Time _Format"
+msgstr "Zapis _vremena"
+
+#: panels/datetime/datetime.ui:588
+msgid "24-hour"
+msgstr "24-časovno"
+
+#: panels/datetime/datetime.ui:589
+msgid "AM / PM"
+msgstr "PrP/PoP"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Izmenite datum i vreme, uključujući vremensku zonu"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:7
+msgid "preferences-system-time"
+msgstr "preferences-system-time"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "sat;vremenska zona;mesto;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Izmenite podešavanja vremena i datuma na sistemu"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Da izmenite podešavanja vremena i datuma, morate da potvrdite identitet."
+
+#: panels/display/cc-display-panel.c:729
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Položeno"
+
+#: panels/display/cc-display-panel.c:732
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Uspravno desno"
+
+#: panels/display/cc-display-panel.c:735
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Uspravno levo"
+
+#: panels/display/cc-display-panel.c:738
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Položeno (izvrnuto)"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/display/cc-display-panel.c:805
+#: panels/printers/pp-options-dialog.c:558
+msgid "Orientation"
+msgstr "Usmerenje"
+
+#: panels/display/cc-display-panel.c:870 panels/display/cc-display-panel.c:1673
+#: panels/printers/pp-options-dialog.c:87
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: panels/display/cc-display-panel.c:958
+msgid "Refresh Rate"
+msgstr "Stopa osvežavanja"
+
+#: panels/display/cc-display-panel.c:1095
+msgid "Scale"
+msgstr "Srazmerno"
+
+#: panels/display/cc-display-panel.c:1148
+msgid "Adjust for TV"
+msgstr "Doterivanje za TV"
+
+#: panels/display/cc-display-panel.c:1410
+msgid "Primary Display"
+msgstr "Glavni ekran"
+
+#: panels/display/cc-display-panel.c:1439
+msgid "Display Arrangement"
+msgstr "Ređanje ekrana"
+
+#: panels/display/cc-display-panel.c:1440
+msgid ""
+"Drag displays to match your setup. The top bar is placed on the primary "
+"display."
+msgstr ""
+"Prevucite ekrane da odgovaraju vašem podešavanju. Gornja traka se prikazuje na "
+"glavnom ekranu."
+
+#: panels/display/cc-display-panel.c:1863
+msgid "Display Mode"
+msgstr "Režim ekrana"
+
+#: panels/display/cc-display-panel.c:1879
+msgid "Join Displays"
+msgstr "Spojeni ekrani"
+
+#: panels/display/cc-display-panel.c:1882
+msgid "Mirror"
+msgstr "Preslikano"
+
+#: panels/display/cc-display-panel.c:1885
+msgid "Single Display"
+msgstr "Jedan ekran"
+
+#: panels/display/cc-display-panel.c:2590
+msgid "Apply Changes?"
+msgstr "Da primenim izmene?"
+
+#: panels/display/cc-display-panel.c:2604
+#: panels/network/connection-editor/connection-editor.ui:24
+#: panels/network/network-wifi.ui:38
+msgid "_Apply"
+msgstr "_Primeni"
+
+#: panels/display/cc-display-panel.c:2979
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#. TRANSLATORS: the state of the night light setting
+#: panels/display/cc-display-panel.c:3195
+#: panels/notifications/cc-notifications-panel.c:292
+#: panels/power/cc-power-panel.c:1991 panels/power/cc-power-panel.c:1998
+#: panels/privacy/cc-privacy-panel.c:190 panels/privacy/cc-privacy-panel.c:257
+#: panels/universal-access/cc-ua-panel.c:333
+#: panels/universal-access/cc-ua-panel.c:714
+#: panels/universal-access/cc-ua-panel.c:727
+#: panels/universal-access/cc-ua-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:910
+msgid "On"
+msgstr "Uklj."
+
+#: panels/display/cc-display-panel.c:3195 panels/network/net-proxy.c:54
+#: panels/notifications/cc-notifications-panel.c:292
+#: panels/power/cc-power-panel.c:1985 panels/power/cc-power-panel.c:1996
+#: panels/privacy/cc-privacy-panel.c:190 panels/privacy/cc-privacy-panel.c:257
+#: panels/universal-access/cc-ua-panel.c:333
+#: panels/universal-access/cc-ua-panel.c:714
+#: panels/universal-access/cc-ua-panel.c:727
+#: panels/universal-access/cc-ua-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:910 panels/universal-access/uap.ui:334
+#: panels/universal-access/uap.ui:380 panels/universal-access/uap.ui:426
+#: panels/universal-access/uap.ui:532 panels/universal-access/uap.ui:685
+#: panels/universal-access/uap.ui:731 panels/universal-access/uap.ui:777
+#: panels/universal-access/uap.ui:929
+msgid "Off"
+msgstr "Isklj."
+
+#: panels/display/cc-display-panel.c:3216
+msgid "_Night Light"
+msgstr "_Noćno svetlo"
+
+#: panels/display/cc-display-panel.c:3281
+msgid "Could not get screen information"
+msgstr "Ne mogu da dobijem podatke o ekranu"
+
+#. This cancels the redshift inhibit.
+#: panels/display/display.ui:71
+msgid "Restart Filter"
+msgstr "Ponovo pokreni filter"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/display.ui:103
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Privremeno je isključeno do sutra"
+
+#: panels/display/display.ui:144
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Noćno svetlo čini boje ekrana toplijim. Može pomoći u sprečavanju naprezanja "
+"očiju i nesanice."
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/display.ui:171 panels/display/display.ui:567
+msgid "Night Light"
+msgstr "Noćno svetlo"
+
+#: panels/display/display.ui:187
+msgid "Schedule"
+msgstr "Zakaži"
+
+#: panels/display/display.ui:215
+msgid "Sunset to Sunrise"
+msgstr "Od zalaska do izlaska sunca"
+
+#: panels/display/display.ui:229
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:56 panels/network/network-proxy.ui:113
+#: panels/network/network-wifi.ui:777 panels/network/network-wifi.ui:1054
+#: panels/privacy/cc-privacy-panel.c:217
+msgid "Manual"
+msgstr "Ručno"
+
+#: panels/display/display.ui:268
+msgid "From"
+msgstr "Od"
+
+#: panels/display/display.ui:309 panels/display/display.ui:430
+msgid ":"
+msgstr ":"
+
+#. This is the short form for the time period in the morning
+#: panels/display/display.ui:343 panels/display/display.ui:464
+msgid "AM"
+msgstr "PrP"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/display.ui:359 panels/display/display.ui:480
+msgid "PM"
+msgstr "PoP"
+
+#: panels/display/display.ui:528
+msgid "To"
+msgstr "Do"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ekrani"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Izaberite kako ćete koristiti povezane ekrane i projektore"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/display/gnome-display-panel.desktop.in.in:7
+msgid "preferences-desktop-display"
+msgstr "preferences-desktop-display"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"panel;projektor;iks-randr;ekran;rezolucija;osvežavanje;monitor;noć;svetlo;"
+"plavo;redšift;boja;svitanje;sumrak;panel;projektor;iks-randr;ekran;rezolucija;"
+"osvežavanje;monitor;noć;svetlo;plavo;redšift;boja;svitanje;sumrak;Panel;"
+"Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;redshift;"
+"color;sunset;sunrise;"
+
+#. TRANSLATORS: AP type
+#: panels/info/cc-info-overview-panel.c:374
+#: panels/info/cc-info-overview-panel.c:457 panels/network/panel-common.c:123
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info/cc-info-overview-panel.c:465
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; IB izgradnje: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info/cc-info-overview-panel.c:482
+#, c-format
+msgid "64-bit"
+msgstr "64-bita"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info/cc-info-overview-panel.c:485
+#, c-format
+msgid "32-bit"
+msgstr "32-bita"
+
+#: panels/info/cc-info-overview-panel.c:775
+#, c-format
+msgid "Version %s"
+msgstr "Izdanje %s"
+
+#: panels/info/cc-info-removable-media-panel.c:298
+msgid "Ask what to do"
+msgstr "Pitaj šta da radiš"
+
+#: panels/info/cc-info-removable-media-panel.c:302
+msgid "Do nothing"
+msgstr "Ne radi ništa"
+
+#: panels/info/cc-info-removable-media-panel.c:306
+msgid "Open folder"
+msgstr "Otvori fasciklu"
+
+#: panels/info/cc-info-removable-media-panel.c:391
+msgid "Other Media"
+msgstr "Ostali nosači podataka"
+
+#: panels/info/cc-info-removable-media-panel.c:424
+msgid "Select an application for audio CDs"
+msgstr "Izaberite program za audio diskove (CD)"
+
+#: panels/info/cc-info-removable-media-panel.c:425
+msgid "Select an application for video DVDs"
+msgstr "Izaberite program za video diskove (DVD)"
+
+#: panels/info/cc-info-removable-media-panel.c:426
+msgid "Select an application to run when a music player is connected"
+msgstr "Izaberite program za pokretanje kada je priključen muzički plejer"
+
+#: panels/info/cc-info-removable-media-panel.c:427
+msgid "Select an application to run when a camera is connected"
+msgstr "Izaberite program za pokretanje kada je priključena kamera"
+
+#: panels/info/cc-info-removable-media-panel.c:428
+msgid "Select an application for software CDs"
+msgstr "Izaberite program za diskove sa softverom"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/info/cc-info-removable-media-panel.c:440
+msgid "audio DVD"
+msgstr "audio DVD"
+
+#: panels/info/cc-info-removable-media-panel.c:441
+msgid "blank Blu-ray disc"
+msgstr "prazan Blu-rej disk"
+
+#: panels/info/cc-info-removable-media-panel.c:442
+msgid "blank CD disc"
+msgstr "prazan CD disk"
+
+#: panels/info/cc-info-removable-media-panel.c:443
+msgid "blank DVD disc"
+msgstr "prazan DVD disk"
+
+#: panels/info/cc-info-removable-media-panel.c:444
+msgid "blank HD DVD disc"
+msgstr "prazan HD DVD disk"
+
+#: panels/info/cc-info-removable-media-panel.c:445
+msgid "Blu-ray video disc"
+msgstr "Blu-rej video disk"
+
+#: panels/info/cc-info-removable-media-panel.c:446
+msgid "e-book reader"
+msgstr "čitač el. knjiga"
+
+#: panels/info/cc-info-removable-media-panel.c:447
+msgid "HD DVD video disc"
+msgstr "HD DVD video disk"
+
+#: panels/info/cc-info-removable-media-panel.c:448
+msgid "Picture CD"
+msgstr "CD sa slikama"
+
+#: panels/info/cc-info-removable-media-panel.c:449
+msgid "Super Video CD"
+msgstr "Super video CD"
+
+#: panels/info/cc-info-removable-media-panel.c:450
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/info/cc-info-removable-media-panel.c:451
+msgid "Windows software"
+msgstr "Vindouz programi"
+
+#: panels/info/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Podrazumevani programi"
+
+#: panels/info/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Podesite osnovne programe"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info/gnome-default-apps-panel.desktop.in.in:7
+msgid "starred"
+msgstr "starred"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/info/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "osnovni;program;omiljeni;medij;"
+
+#: panels/info/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "O programu"
+
+#: panels/info/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Pogledajte podatke o vašem sistemu"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info/gnome-info-overview-panel.desktop.in.in:7
+msgid "help-about"
+msgstr "help-about"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"uređaj;sistem;informacije;memorija;procesor;izdanje;osnovno;program;omiljeno;"
+"cd;dvd;usb;zvuk;snimak;disk;uklonjivi;medijum;nosač;samopokretanje;uređaj;"
+"sistem;informacije;memorija;procesor;izdanje;osnovno;program;omiljeno;cd;dvd;"
+"usb;zvuk;snimak;disk;uklonjivi;medijum;nosač;samopokretanje;device;system;"
+"information;memory;processor;version;default;application;preferred;cd;dvd;"
+"usb;audio;video;disc;removable;media;autorun;"
+
+#: panels/info/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Prenosni nosači"
+
+#: panels/info/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Podesite prenosne medije"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/info/gnome-removable-media-panel.desktop.in.in:7
+msgid "media-removable"
+msgstr "media-removable"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/info/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"uređaj;sistem;osnovno;program;omiljeno;cd;dvd;usb;zvuk;snimak;disk;uklonjivi;"
+"medijum;nosač;samopokretanje;uređaj;sistem;osnovno;program;omiljeno;cd;dvd;"
+"usb;zvuk;snimak;disk;uklonjivi;medijum;nosač;samopokretanje;device;system;"
+"default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;"
+"autorun;"
+
+#: panels/info/info-default-apps.ui:31
+msgid "_Web"
+msgstr "_Veb"
+
+#: panels/info/info-default-apps.ui:43
+msgid "_Mail"
+msgstr "_Pošta"
+
+#: panels/info/info-default-apps.ui:59
+msgid "_Calendar"
+msgstr "_Kalendar"
+
+#: panels/info/info-default-apps.ui:75
+msgid "M_usic"
+msgstr "_Muzika"
+
+#: panels/info/info-default-apps.ui:91
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/info/info-default-apps.ui:162 panels/info/info-removable-media.ui:161
+msgid "_Photos"
+msgstr "_Fotografije"
+
+#: panels/info/info-overview.ui:58
+msgid "Device name"
+msgstr "Naziv uređaja"
+
+#: panels/info/info-overview.ui:74
+msgid "Memory"
+msgstr "Memorija"
+
+#: panels/info/info-overview.ui:90
+msgid "Processor"
+msgstr "Procesor"
+
+#: panels/info/info-overview.ui:106
+msgid "Graphics"
+msgstr "Grafika"
+
+#. To translators: this field contains the distro name and version
+#: panels/info/info-overview.ui:121
+msgid "OS name"
+msgstr "Naziv OS-a"
+
+#. To translators: this field contains the distro type
+#: panels/info/info-overview.ui:137
+msgid "OS type"
+msgstr "Vrsta OS-a"
+
+#: panels/info/info-overview.ui:153
+msgid "Virtualization"
+msgstr "Virtuelizacija"
+
+#: panels/info/info-overview.ui:169
+msgid "Disk"
+msgstr "Disk"
+
+#: panels/info/info-overview.ui:274
+msgid "Calculating…"
+msgstr "Izračunavam…"
+
+#: panels/info/info-overview.ui:314
+msgid "Check for updates"
+msgstr "Proveravam ažuriranja"
+
+#: panels/info/info-removable-media.ui:43
+msgid "Select how media should be handled"
+msgstr "Izaberite kako treba da se rukuje sa nosačima podataka"
+
+#: panels/info/info-removable-media.ui:74
+msgid "CD _audio"
+msgstr "CD _audio"
+
+#: panels/info/info-removable-media.ui:91
+msgid "_DVD video"
+msgstr "_DVD video"
+
+#: panels/info/info-removable-media.ui:132
+msgid "_Music player"
+msgstr "_Muzički program"
+
+#: panels/info/info-removable-media.ui:190
+msgid "_Software"
+msgstr "_Softver"
+
+#: panels/info/info-removable-media.ui:228
+msgid "_Other Media…"
+msgstr "_Ostali nosači podataka…"
+
+#: panels/info/info-removable-media.ui:272
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Nikada ne pitaj ili ne pokreći programe nakon ubacivanja nosača podataka"
+
+#: panels/info/info-removable-media.ui:331
+msgid "Select how other media should be handled"
+msgstr "Izaberite kako treba da se rukuje ostalim nosačima podataka"
+
+#: panels/info/info-removable-media.ui:370
+msgid "_Action:"
+msgstr "_Radnja:"
+
+#: panels/info/info-removable-media.ui:393
+msgid "_Type:"
+msgstr "_Vrsta:"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Zvuk i mediji"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute"
+msgstr "Isključuje jačinu zvuka"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Smanjuje jačinu zvuka"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Pojačava jačinu zvuka"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Launch media player"
+msgstr "Pokreće medijski program"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Play (or play/pause)"
+msgstr "Pušta (ili pušta/pauzira)"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Pause playback"
+msgstr "Pauzira puštanje"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Stop playback"
+msgstr "Zaustavlja puštanje"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Previous track"
+msgstr "Prethodna numera"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Next track"
+msgstr "Sledeća numera"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Eject"
+msgstr "Izbaci"
+
+#: panels/keyboard/01-input-sources.xml.in:4 panels/universal-access/uap.ui:576
+msgid "Typing"
+msgstr "Kucanje"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Prebacite se na sledeći izvor ulaza"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Prebacite se na prethodni izvor ulaza"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Pokretači"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Pokreće pregledač pomoći"
+
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:223
+#: shell/cc-window.c:761 shell/gnome-control-center.desktop.in.in:3
+#: shell/window.ui:125
+msgid "Settings"
+msgstr "Podešavanja"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Pokreće kalkulator"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Pokreće program za el. poštu"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Pokreće veb preglednik"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Lična fascikla"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/window.ui:157
+msgid "Search"
+msgstr "Pretraga"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "Snimci ekrana"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr "Čuva snimak u fasciklu „$PICTURES“"
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Čuva snimak prozora u fasciklu „$PICTURES“"
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Čuva snimak oblasti u fasciklu „$PICTURES“"
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "Umnožava snimak u beležnicu"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Umnožava snimak prozora u beležnicu"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Umnožava snimak oblasti u beležnicu"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr "Snimite kratak radni tok ekrana"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistem"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Odjavi me"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Zaključaj ekran"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Universal Access"
+msgstr "Univerzalni pristup"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Uključuje/isključuje uvećanje"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Uvećava"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Umanjuje"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Uključi/isključi čitač ekrana"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Uključi/isključi ekransku tastaturu"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Povećaj veličinu teksta"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Smanji veličinu teksta"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Uključi/isključi veliki kontrast"
+
+#: panels/keyboard/cc-keyboard-manager.c:506
+#: panels/keyboard/cc-keyboard-manager.c:514
+#: panels/keyboard/cc-keyboard-manager.c:822
+msgid "Custom Shortcuts"
+msgstr "Proizvoljne prečice"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: panels/keyboard/cc-keyboard-option.c:263
+#: panels/keyboard/cc-keyboard-option.c:382
+#: panels/keyboard/keyboard-shortcuts.c:435
+#: panels/keyboard/shortcut-editor.ui:96 panels/network/network-proxy.ui:123
+#: panels/network/network-wifi.ui:782 panels/network/network-wifi.ui:1059
+#: panels/user-accounts/um-fingerprint-dialog.c:211
+#: subprojects/gvc/gvc-mixer-control.c:1866
+msgid "Disabled"
+msgstr "Isključeno"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: panels/keyboard/cc-keyboard-option.c:341
+msgid "Alternative Characters Key"
+msgstr "Tasteri zamenskih znakova"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: panels/keyboard/cc-keyboard-option.c:350
+msgid "Compose Key"
+msgstr "Sastavni taster"
+
+#: panels/keyboard/cc-keyboard-option.c:355
+msgid "Modifiers-only switch to next source"
+msgstr "Izmenjivači samo prebacuju na sledeći izvor"
+
+#: panels/keyboard/cc-keyboard-panel.c:181
+msgid "Reset All Shortcuts?"
+msgstr "Da vratim sve prečice?"
+
+#: panels/keyboard/cc-keyboard-panel.c:184
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Ponovno vraćanje prečica može uticati na vaše proizvoljne prečice. Ovo se ne "
+"može opozvati."
+
+#: panels/keyboard/cc-keyboard-panel.c:188
+#: panels/keyboard/shortcut-editor.ui:346
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+msgid "Cancel"
+msgstr "Otkaži"
+
+#: panels/keyboard/cc-keyboard-panel.c:189
+msgid "Reset All"
+msgstr "Vrati sve"
+
+#: panels/keyboard/cc-keyboard-panel.c:281
+msgid "Reset the shortcut to its default value"
+msgstr "Vrati prečicu na njenu osnovnu vrednost"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:413
+#, c-format
+msgid ""
+"%s is already being used for <b>%s</b>. If you replace it, %s will be "
+"disabled"
+msgstr "„%s“ se već koristi za <b>%s</b>. Ako zamenite, „%s“ biće isključeno"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:583
+msgid "Set Custom Shortcut"
+msgstr "Postavi proizvoljnu prečicu"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:583
+msgid "Set Shortcut"
+msgstr "Postavi prečicu"
+
+#. Setup the top label
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:592
+#, c-format
+msgid "Enter new shortcut to change <b>%s</b>."
+msgstr "Unesite novu prečicu da izmenite <b>%s</b>."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:1019
+msgid "Add Custom Shortcut"
+msgstr "Dodajte proizvoljnu prečicu"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tastatura"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"Pogledajte i izmenite prečice tastature i podesite vaše postavke kucanja"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:7
+msgid "input-keyboard"
+msgstr "input-keyboard"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"prečica;radni prostor;prozor;promeni veličinu;zum;kontrast;ulaz;izvor;"
+"zaključaj;volumen;"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:67 panels/region/input-options.ui:68
+#: shell/cc-application.c:255
+msgid "Keyboard Shortcuts"
+msgstr "Prečice tastature"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:77
+msgid "Reset All…"
+msgstr "Vrati sve…"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:78
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Vratite sve prečice na njene osnovne vrednosti"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:164
+msgid "No keyboard shortcut found"
+msgstr "Nisam našao rečicu tastature"
+
+#: panels/keyboard/gnome-keyboard-panel.ui:175 shell/panel-list.ui:206
+msgid "Try a different search"
+msgstr "Probajte drugačiju pretragu"
+
+#: panels/keyboard/shortcut-editor.ui:68 panels/keyboard/shortcut-editor.ui:318
+msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
+msgstr ""
+"Pritisnite „Esc“ da otkažete ili povratnicu da vratite prečicu tastature."
+
+#: panels/keyboard/shortcut-editor.ui:156 panels/printers/details-dialog.ui:38
+#: panels/sound/gvc-mixer-dialog.c:1480
+#: panels/sound/gvc-sound-theme-chooser.c:554
+msgid "Name"
+msgstr "Naziv"
+
+#: panels/keyboard/shortcut-editor.ui:168
+msgid "Command"
+msgstr "Naredba"
+
+#: panels/keyboard/shortcut-editor.ui:180
+msgid "Shortcut"
+msgstr "Prečica"
+
+#: panels/keyboard/shortcut-editor.ui:259
+msgid "Set Shortcut…"
+msgstr "Postavi prečicu…"
+
+#: panels/keyboard/shortcut-editor.ui:272 panels/network/network-wifi.ui:594
+msgid "None"
+msgstr "Ništa"
+
+#: panels/keyboard/shortcut-editor.ui:303
+msgid "Enter the new shortcut"
+msgstr "Unesite novu prečicu"
+
+#: panels/keyboard/shortcut-editor.ui:357
+msgid "Remove"
+msgstr "Ukloni"
+
+#: panels/keyboard/shortcut-editor.ui:367
+msgid "Add"
+msgstr "Dodaj"
+
+#: panels/keyboard/shortcut-editor.ui:382
+msgid "Replace"
+msgstr "Zameni"
+
+#: panels/keyboard/shortcut-editor.ui:395
+msgid "Set"
+msgstr "Postavi"
+
+#: panels/mouse/cc-mouse-panel.c:82 panels/wacom/cc-wacom-panel.c:402
+msgid "Test Your _Settings"
+msgstr "Isprobaj _podešavanja"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Miš i dodirna tabla"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Promenite osetljivost miša ili dodirne table i izaberite levorukost ili "
+"desnorukost"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:7
+msgid "input-mouse"
+msgstr "input-mouse"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ploča;pokazivač;klik;dodir;duplo;dugme;kuglica;klizanje;"
+
+#: panels/mouse/gnome-mouse-properties.ui:45
+msgid "General"
+msgstr "Opšte"
+
+#: panels/mouse/gnome-mouse-properties.ui:83
+msgid "Primary Button"
+msgstr "Glavno dugme"
+
+#: panels/mouse/gnome-mouse-properties.ui:102
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Podešava redosled fizičkih tastera na miševima i dodirnim tablicama."
+
+#: panels/mouse/gnome-mouse-properties.ui:131
+msgid "Left"
+msgstr "Levo"
+
+#: panels/mouse/gnome-mouse-properties.ui:141
+msgid "Right"
+msgstr "Desno"
+
+#: panels/mouse/gnome-mouse-properties.ui:177
+msgid "Mouse"
+msgstr "Miš"
+
+#: panels/mouse/gnome-mouse-properties.ui:216
+msgid "Mouse Speed"
+msgstr "Brzina miša"
+
+#: panels/mouse/gnome-mouse-properties.ui:238
+#: panels/mouse/gnome-mouse-properties.ui:543
+msgid "Double-click timeout"
+msgstr "Vreme za dupli klik"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/gnome-mouse-properties.ui:275
+#: panels/mouse/gnome-mouse-properties.ui:451
+msgid "Natural Scrolling"
+msgstr "Prirodno klizanje"
+
+#: panels/mouse/gnome-mouse-properties.ui:291
+#: panels/mouse/gnome-mouse-properties.ui:467
+msgid "Scrolling moves the content, not the view."
+msgstr "Klizanje pomera sadržaj, ne pregled."
+
+#: panels/mouse/gnome-mouse-properties.ui:341
+#: panels/mouse/gnome-mouse-properties.ui:386
+msgid "Touchpad"
+msgstr "Dodirna tabla"
+
+#: panels/mouse/gnome-mouse-properties.ui:522
+msgid "Touchpad Speed"
+msgstr "Brzina dodirne table"
+
+#: panels/mouse/gnome-mouse-properties.ui:581
+msgid "Tap to Click"
+msgstr "Lupni za klik"
+
+#: panels/mouse/gnome-mouse-properties.ui:634
+msgid "Two-finger Scrolling"
+msgstr "Premicanje sa dva prsta"
+
+#: panels/mouse/gnome-mouse-properties.ui:687
+msgid "Edge Scrolling"
+msgstr "Klizanje po strani"
+
+#: panels/mouse/gnome-mouse-test.c:130 panels/mouse/gnome-mouse-test.ui:23
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Isprobajte klikanje, dvostruko klikanje, klizanje"
+
+#: panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "Pet klika, GEGL vreme!"
+
+#: panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "Dvostruki klik, glavno dugme"
+
+#: panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "Jedan klik, glavno dugme"
+
+#: panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "Dvostruki klik, srednje dugme"
+
+#: panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "Jedan klik, srednje dugme"
+
+#: panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "Dvostruki klik, pomoćno dugme"
+
+#: panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "Jedan klik, pomoćno dugme"
+
+#. add proxy to device list
+#: panels/network/cc-network-panel.c:579
+msgid "Network proxy"
+msgstr "Mrežni posrednik"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/cc-network-panel.c:715 panels/network/net-vpn.c:192
+#: panels/network/net-vpn.c:321
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#: panels/network/cc-network-panel.c:779 panels/network/wifi.ui:282
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Ups, nešto je pošlo naopako. Obratite se vašem prodavcu softvera."
+
+#: panels/network/cc-network-panel.c:785
+msgid "NetworkManager needs to be running."
+msgstr "Upravljač mrežom treba biti pokrenut."
+
+#: panels/network/cc-wifi-panel.c:213
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:1766
+msgid "Wi-Fi"
+msgstr "Bežična"
+
+#: panels/network/connection-editor/8021x-security-page.ui:26
+msgid "802.1x _Security"
+msgstr "_Bezbednost 802.1x"
+
+#: panels/network/connection-editor/8021x-security-page.ui:73
+#: panels/network/connection-editor/security-page.ui:72
+#: panels/wacom/wacom-stylus-page.ui:108
+msgid "page 1"
+msgstr "strana 1"
+
+#: panels/network/connection-editor/8021x-security-page.ui:224
+#: panels/network/connection-editor/security-page.ui:223
+#: panels/network/wireless-security/eap-method-fast.ui:50
+#: panels/network/wireless-security/eap-method-peap.ui:48
+#: panels/network/wireless-security/eap-method-ttls.ui:31
+msgid "Anony_mous identity"
+msgstr "Anonimni _identitet"
+
+#: panels/network/connection-editor/8021x-security-page.ui:238
+#: panels/network/connection-editor/security-page.ui:237
+msgid "Inner _authentication"
+msgstr "Unutrašnja _prijava"
+
+#: panels/network/connection-editor/8021x-security-page.ui:281
+#: panels/network/connection-editor/security-page.ui:280
+#: panels/wacom/wacom-stylus-page.ui:426
+msgid "page 2"
+msgstr "strana 2"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:101
+#: panels/network/connection-editor/ce-page-security.c:445
+#: panels/network/connection-editor/details-page.ui:86
+#: panels/network/network-wifi.ui:239
+msgid "Security"
+msgstr "Bezbednost"
+
+#: panels/network/connection-editor/ce-page.c:481
+msgid "automatic"
+msgstr "samostalno"
+
+#: panels/network/connection-editor/ce-page.c:521
+#, c-format
+msgid "Profile %d"
+msgstr "Profil „%d“"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:56
+#: panels/network/net-device-wifi.c:235 panels/network/net-device-wifi.c:468
+msgid "WEP"
+msgstr "VEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:60
+#: panels/network/net-device-wifi.c:239 panels/network/net-device-wifi.c:473
+#: panels/network/network-wifi.ui:593
+msgid "WPA"
+msgstr "VPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:64
+#: panels/network/net-device-wifi.c:243
+msgid "WPA2"
+msgstr "VPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:69
+#: panels/network/net-device-wifi.c:248
+msgid "Enterprise"
+msgstr "Enterprajz"
+
+#: panels/network/connection-editor/ce-page-details.c:74
+#: panels/network/net-device-wifi.c:253 panels/network/net-device-wifi.c:458
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ništa"
+
+#: panels/network/connection-editor/ce-page-details.c:95
+#: panels/power/power.ui:99
+msgid "Never"
+msgstr "Nikad"
+
+#: panels/network/connection-editor/ce-page-details.c:110
+#: panels/network/net-device-ethernet.c:121
+#: panels/network/net-device-wifi.c:567
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "Pre %i dan"
+msgstr[1] "Pre %i dana"
+msgstr[2] "Pre %i dana"
+msgstr[3] "Pre jednog dana"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:225
+#: panels/network/net-device-ethernet.c:50 panels/network/net-device-wifi.c:646
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:251
+#: panels/network/net-device-wifi.c:675
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Nema signala"
+
+#: panels/network/connection-editor/ce-page-details.c:253
+#: panels/network/net-device-wifi.c:677
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Slab signal"
+
+#: panels/network/connection-editor/ce-page-details.c:255
+#: panels/network/net-device-wifi.c:679
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Dobar signal"
+
+#: panels/network/connection-editor/ce-page-details.c:257
+#: panels/network/net-device-wifi.c:681
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Odličan signal"
+
+#: panels/network/connection-editor/ce-page-details.c:259
+#: panels/network/net-device-wifi.c:683
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Izvrstan signal"
+
+#: panels/network/connection-editor/ce-page-details.c:302
+msgid "Forget Connection"
+msgstr "Zaboravi vezu"
+
+#: panels/network/connection-editor/ce-page-details.c:304
+msgid "Remove Connection Profile"
+msgstr "Ukloni profil veze"
+
+#: panels/network/connection-editor/ce-page-details.c:306
+msgid "Remove VPN"
+msgstr "Ukloni VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+#: panels/network/network-wifi.ui:1456 shell/cc-window.c:215
+#: shell/panel-list.ui:103
+msgid "Details"
+msgstr "Pojedinosti"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:174
+#: panels/network/connection-editor/ce-page-vpn.c:188
+#: panels/network/connection-editor/ce-page-wifi.c:194
+#: panels/network/network-wifi.ui:1460
+msgid "Identity"
+msgstr "Identitet"
+
+#: panels/network/connection-editor/ce-page-ip4.c:251
+#: panels/network/connection-editor/ce-page-ip6.c:230
+msgid "Delete Address"
+msgstr "Obriši adresu"
+
+#: panels/network/connection-editor/ce-page-ip4.c:422
+#: panels/network/connection-editor/ce-page-ip6.c:390
+msgid "Delete Route"
+msgstr "Obriši rutu"
+
+#: panels/network/connection-editor/ce-page-ip4.c:896
+#: panels/network/network-wifi.ui:1464
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:828
+#: panels/network/network-wifi.ui:1468
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:245
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ništa"
+
+#: panels/network/connection-editor/ce-page-security.c:268
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "VEP 40/128-bitni ključ (Heksa ili ASKRI)"
+
+#: panels/network/connection-editor/ce-page-security.c:278
+msgid "WEP 128-bit Passphrase"
+msgstr "VEP 128-bitna lozinka"
+
+#: panels/network/connection-editor/ce-page-security.c:291
+#: panels/network/wireless-security/wireless-security.c:465
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:304
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dinamički VEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:318
+msgid "WPA & WPA2 Personal"
+msgstr "Lični VPA & VPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:332
+msgid "WPA & WPA2 Enterprise"
+msgstr "Poslovni VPA & VPA2"
+
+#: panels/network/connection-editor/details-page.ui:18
+#: panels/network/network-wifi.ui:174
+msgid "Signal Strength"
+msgstr "Jačina signala"
+
+#: panels/network/connection-editor/details-page.ui:52
+#: panels/network/network-wifi.ui:207
+msgid "Link speed"
+msgstr "Brzina veze"
+
+#: panels/network/connection-editor/details-page.ui:104
+#: panels/network/net-device-ethernet.c:154 panels/network/network-wifi.ui:256
+#: panels/network/panel-common.c:644
+msgid "IPv4 Address"
+msgstr "IPv4 adresa"
+
+#: panels/network/connection-editor/details-page.ui:122
+#: panels/network/net-device-ethernet.c:155
+#: panels/network/net-device-ethernet.c:159
+#: panels/network/network-mobile.ui:189 panels/network/network-wifi.ui:273
+#: panels/network/panel-common.c:645
+msgid "IPv6 Address"
+msgstr "IPv6 adresa"
+
+#: panels/network/connection-editor/details-page.ui:140
+#: panels/network/net-device-ethernet.c:162 panels/network/network-wifi.ui:290
+msgid "Hardware Address"
+msgstr "Hardverska adresa"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/network-mobile.ui:206 panels/network/network-wifi.ui:307
+msgid "Default Route"
+msgstr "Podrazumevana ruta"
+
+#: panels/network/connection-editor/details-page.ui:177
+#: panels/network/connection-editor/ip4-page.ui:197
+#: panels/network/connection-editor/ip6-page.ui:211
+#: panels/network/net-device-ethernet.c:168
+#: panels/network/network-mobile.ui:224 panels/network/network-wifi.ui:325
+#: panels/network/network-wifi.ui:832 panels/network/network-wifi.ui:1109
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:195
+msgid "Last Used"
+msgstr "Korišćena"
+
+#: panels/network/connection-editor/details-page.ui:324
+msgid "Connect _automatically"
+msgstr "_Sam se poveži"
+
+#: panels/network/connection-editor/details-page.ui:343
+msgid "Make available to _other users"
+msgstr "Učini dostupno _drugim korisnicima"
+
+#: panels/network/connection-editor/details-page.ui:376
+msgid "Restrict background data usage"
+msgstr "Ograniči pozadinsku upotrebu podataka"
+
+#: panels/network/connection-editor/details-page.ui:386
+msgid "Appropriate for connections that have data charges or limits."
+msgstr "Prikladno za veze koje imaju ograničenje podataka ili se naplaćuju."
+
+#: panels/network/connection-editor/ethernet-page.ui:16
+#: panels/network/connection-editor/ethernet-page.ui:39
+#: panels/network/connection-editor/ip4-page.ui:209
+#: panels/network/connection-editor/ip4-page.ui:277
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:291
+#: panels/network/net-proxy.c:58 panels/network/network-proxy.ui:103
+#: panels/network/wireless-security/eap-method-peap.ui:22
+#: panels/privacy/cc-privacy-panel.c:217
+msgid "Automatic"
+msgstr "Samostalno"
+
+#: panels/network/connection-editor/ethernet-page.ui:19
+msgid "Twisted Pair (TP)"
+msgstr "Upleteni par (TP)"
+
+#: panels/network/connection-editor/ethernet-page.ui:22
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Sučelje jedinice prikačinjanja (AUI)"
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+msgid "BNC"
+msgstr "BNC"
+
+#: panels/network/connection-editor/ethernet-page.ui:28
+msgid "Media Independent Interface (MII)"
+msgstr "Sučelje nezavisnog medija (MII)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+msgid "10 Mb/s"
+msgstr "10 MB/s"
+
+#: panels/network/connection-editor/ethernet-page.ui:45
+msgid "100 Mb/s"
+msgstr "100 MB/s"
+
+#: panels/network/connection-editor/ethernet-page.ui:48
+msgid "1 Gb/s"
+msgstr "1 GB/s"
+
+#: panels/network/connection-editor/ethernet-page.ui:51
+msgid "10 Gb/s"
+msgstr "10 GB/s"
+
+#: panels/network/connection-editor/ethernet-page.ui:71
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "_Naziv"
+
+#: panels/network/connection-editor/ethernet-page.ui:100
+#: panels/network/connection-editor/wifi-page.ui:68
+#: panels/network/network-wifi.ui:1261
+msgid "_MAC Address"
+msgstr "_MAC adresa"
+
+#: panels/network/connection-editor/ethernet-page.ui:146
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:163
+#: panels/network/connection-editor/wifi-page.ui:98
+msgid "_Cloned Address"
+msgstr "_Klonirana adresa"
+
+#: panels/network/connection-editor/ethernet-page.ui:178
+msgid "bytes"
+msgstr "bajta"
+
+#: panels/network/connection-editor/ip4-page.ui:27
+msgid "IPv_4 Method"
+msgstr "IPv_4 Način"
+
+#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/network-wifi.ui:778 panels/network/network-wifi.ui:1055
+msgid "Automatic (DHCP)"
+msgstr "Samostalno (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr "Samo veži-lokalno"
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+msgid "Disable"
+msgstr "Isključi"
+
+#: panels/network/connection-editor/ip4-page.ui:111
+#: panels/network/connection-editor/ip6-page.ui:125
+msgid "Addresses"
+msgstr "Adrese"
+
+#: panels/network/connection-editor/ip4-page.ui:129
+#: panels/network/connection-editor/ip4-page.ui:313
+#: panels/network/connection-editor/ip6-page.ui:143
+#: panels/network/connection-editor/ip6-page.ui:327
+#: panels/printers/details-dialog.ui:87
+msgid "Address"
+msgstr "Adresa"
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+msgid "Netmask"
+msgstr "Mrežna maska"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Gateway"
+msgstr "Mrežni prolaz"
+
+#: panels/network/connection-editor/ip4-page.ui:220
+#: panels/network/connection-editor/ip6-page.ui:234
+msgid "Automatic DNS"
+msgstr "Samostalni DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:244
+#: panels/network/connection-editor/ip6-page.ui:258
+msgid "Separate IP addresses with commas"
+msgstr "Razdvojte IP adrese zarezima"
+
+#: panels/network/connection-editor/ip4-page.ui:265
+#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/network-wifi.ui:877 panels/network/network-wifi.ui:1154
+msgid "Routes"
+msgstr "Rute"
+
+#: panels/network/connection-editor/ip4-page.ui:288
+#: panels/network/connection-editor/ip6-page.ui:302
+msgid "Automatic Routes"
+msgstr "Samostalne rute"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:354
+#: panels/network/connection-editor/ip6-page.ui:368
+msgid "Metric"
+msgstr "Metrički"
+
+#: panels/network/connection-editor/ip4-page.ui:384
+#: panels/network/connection-editor/ip6-page.ui:398
+#: panels/network/network-wifi.ui:933 panels/network/network-wifi.ui:1210
+msgid "Use this connection _only for resources on its network"
+msgstr "Koristi ovu vezu _samo za izvore na sopstvenoj mreži"
+
+#: panels/network/connection-editor/ip6-page.ui:27
+msgid "IPv_6 Method"
+msgstr "IPv_6 Način"
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr "Samostalno, samo DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+msgid "Prefix"
+msgstr "Prefiks"
+
+#: panels/network/connection-editor/net-connection-editor.c:273
+msgid "Unable to open connection editor"
+msgstr "Ne mogu da otvorim uređivača veze"
+
+#: panels/network/connection-editor/net-connection-editor.c:291
+msgid "New Profile"
+msgstr "Novi profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:603
+#: panels/network/network.ui:142
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/connection-editor/net-connection-editor.c:751
+msgid "Import from file…"
+msgstr "Uvezi iz datoteke…"
+
+#: panels/network/connection-editor/net-connection-editor.c:785
+msgid "Add VPN"
+msgstr "Dodaj VPN"
+
+#: panels/network/connection-editor/security-page.ui:26
+#: panels/network/network-wifi.ui:529
+msgid "S_ecurity"
+msgstr "B_ezbednost"
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+msgid "Cannot import VPN connection"
+msgstr "Ne mogu da uvezem VPN vezu"
+
+#: panels/network/connection-editor/vpn-helpers.c:143
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Ne mogu da pročitam datoteku „%s“ ili ona ne sadrži poznate VPN podatke o "
+"vezi\n"
+"\n"
+"Greška: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:178
+msgid "Select file to import"
+msgstr "Izaberite datoteku za uvoz"
+
+#: panels/network/connection-editor/vpn-helpers.c:182
+#: panels/printers/pp-details-dialog.c:332
+#: panels/sharing/cc-sharing-panel.c:385
+#: panels/user-accounts/um-photo-dialog.c:230
+msgid "_Open"
+msgstr "_Otvori"
+
+#: panels/network/connection-editor/vpn-helpers.c:230
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Datoteka pod nazivom „%s“ već postoji."
+
+#: panels/network/connection-editor/vpn-helpers.c:232
+msgid "_Replace"
+msgstr "_Zameni"
+
+#: panels/network/connection-editor/vpn-helpers.c:234
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Da li želite da zamenite „%s“ VPN vezom koju sada čuvate?"
+
+#: panels/network/connection-editor/vpn-helpers.c:270
+msgid "Cannot export VPN connection"
+msgstr "Ne mogu da izvezem VPN vezu"
+
+#: panels/network/connection-editor/vpn-helpers.c:272
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Ne mogu da izvezem VPN vezu „%s“ u %s.\n"
+"\n"
+"Greška: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:307
+msgid "Export VPN connection"
+msgstr "Izvezi VPN vezu"
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Greška: ne mogu da učitam uređivača VPN veze)"
+
+#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/network-wifi.ui:497
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/network-wifi.ui:513
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/connection-editor/wifi-page.ui:53
+#: panels/network/network-wifi.ui:562
+msgid "My Home Network"
+msgstr "Moja kućna mreža"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:241
+msgid "Network"
+msgstr "Mreža"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Upravljajte vašim povezivanjem na Internet"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/network/gnome-network-panel.desktop.in.in:7
+msgid "network-workgroup"
+msgstr "network-workgroup"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;"
+msgstr ""
+"mreža;bežična;vaj-faj;ip;lan;posrednik;van;širokopojasna;modem;blutut;vpn;"
+"DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Upravljajte povezivanjem na bežične mreže"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/network/gnome-wifi-panel.desktop.in.in:7
+msgid "network-wireless"
+msgstr "network-wireless"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+msgstr "mreža;bežična;vaj-faj;ip;lan;širokopojasna;DNS;"
+
+#: panels/network/net-device-ethernet.c:107
+#: panels/network/net-device-wifi.c:553
+msgid "never"
+msgstr "nikad"
+
+#: panels/network/net-device-ethernet.c:117
+#: panels/network/net-device-wifi.c:563
+msgid "today"
+msgstr "danas"
+
+#: panels/network/net-device-ethernet.c:119
+#: panels/network/net-device-wifi.c:565
+msgid "yesterday"
+msgstr "juče"
+
+#: panels/network/net-device-ethernet.c:157
+#: panels/network/network-mobile.ui:172 panels/network/panel-common.c:647
+#: panels/network/panel-common.c:649
+msgid "IP Address"
+msgstr "IP adresa"
+
+#: panels/network/net-device-ethernet.c:173 panels/network/network-wifi.ui:342
+msgid "Last used"
+msgstr "Korišćena"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:276
+#: panels/network/network-ethernet.ui:19 panels/network/network-simple.ui:39
+msgid "Wired"
+msgstr "Žičana"
+
+#: panels/network/net-device-ethernet.c:344
+#: panels/network/net-device-wifi.c:1895 panels/network/network-ethernet.ui:120
+#: panels/network/network-mobile.ui:394 panels/network/network-simple.ui:75
+#: panels/network/network-vpn.ui:79
+msgid "Options…"
+msgstr "Mogućnosti…"
+
+#: panels/network/net-device-mobile.c:238
+msgid "Add new connection"
+msgstr "Dodajte novu vezu"
+
+#: panels/network/net-device-wifi.c:1368
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "Uključivanjem bežične vruće tačke prekinućete vezu sa <b>%s</b>."
+
+#: panels/network/net-device-wifi.c:1372
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"Nije moguće pristupiti Internetu preko vaše bežične dok je uključena vruća "
+"tačka."
+
+#: panels/network/net-device-wifi.c:1379
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Da uključim bežičnu vruću tačku?"
+
+#: panels/network/net-device-wifi.c:1401
+msgid ""
+"Wi-Fi hotspots are usually used to share an additional Internet connection "
+"over Wi-Fi."
+msgstr ""
+"Bežične vruće tačke se obično koriste za deljenje dodatne internet veze "
+"bežičnim putem."
+
+#: panels/network/net-device-wifi.c:1412
+msgid "_Turn On"
+msgstr "_Uključi"
+
+#: panels/network/net-device-wifi.c:1489
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Da zaustavim vruću tačku i da isključim sve korisnike?"
+
+#: panels/network/net-device-wifi.c:1492
+msgid "_Stop Hotspot"
+msgstr "_Zaustavi vruću tačku"
+
+#: panels/network/net-device-wifi.c:1592
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Politika sistema zabranjuje upotrebu kao vruće tačke"
+
+#: panels/network/net-device-wifi.c:1595
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Bežični uređaj ne podržava režim vruće tačke"
+
+#: panels/network/net-device-wifi.c:1733
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Detalji mreže za izabrane mreže, uključujući lozinku i sva proizvoljna "
+"podešavanja će biti izgubljeni."
+
+#: panels/network/net-device-wifi.c:1737 panels/network/network-wifi.ui:1362
+msgid "_Forget"
+msgstr "_Zaboravi"
+
+#: panels/network/net-device-wifi.c:2046 panels/network/net-device-wifi.c:2053
+msgid "Known Wi-Fi Networks"
+msgstr "Poznate bežične mreže"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:2086
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Zaboravi"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:102
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Automatsko nalaženje veb posrednika se koristi kada nije data adresa za "
+"podešavanje."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:110
+msgid "This is not recommended for untrusted public networks."
+msgstr "Ovo nije preporučljivo za nebezbedne, javne mreže."
+
+#: panels/network/network-mobile.ui:30
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:48
+msgid "Provider"
+msgstr "Dostavljač"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:92
+msgid "Network Proxy"
+msgstr "Mrežni posrednik"
+
+#: panels/network/network-proxy.ui:173
+msgid "_HTTP Proxy"
+msgstr "_HTTP posrednik"
+
+#: panels/network/network-proxy.ui:192
+msgid "H_TTPS Proxy"
+msgstr "_HTTPS posrednik"
+
+#: panels/network/network-proxy.ui:211
+msgid "_FTP Proxy"
+msgstr "_FTP posrednik"
+
+#: panels/network/network-proxy.ui:230
+msgid "_Socks Host"
+msgstr "_Priključci domaćina"
+
+#: panels/network/network-proxy.ui:249
+msgid "_Ignore Hosts"
+msgstr "_Zanemari domaćine"
+
+#: panels/network/network-proxy.ui:287
+msgid "HTTP proxy port"
+msgstr "Priključnik HTTP posrednika"
+
+#: panels/network/network-proxy.ui:364
+msgid "HTTPS proxy port"
+msgstr "Priključnik HTTPS posrednika"
+
+#: panels/network/network-proxy.ui:385
+msgid "FTP proxy port"
+msgstr "Priključnik FTP posrednika"
+
+#: panels/network/network-proxy.ui:406
+msgid "Socks proxy port"
+msgstr "Priključnik socks posrednika"
+
+#: panels/network/network-proxy.ui:435
+msgid "_Configuration URL"
+msgstr "_Adresa podešavanja"
+
+#: panels/network/network-simple.ui:50
+msgid "Turn device off"
+msgstr "Isključi uređaj"
+
+#: panels/network/network.ui:194
+msgid "Not set up"
+msgstr "Nije podešeno"
+
+#: panels/network/network-vpn.ui:56
+msgid "Turn VPN connection off"
+msgstr "Isključi VPN vezu"
+
+#: panels/network/network-wifi.ui:127
+msgid "Automatic _Connect"
+msgstr "Samostalno _poveži"
+
+#: panels/network/network-wifi.ui:474
+msgid "details"
+msgstr "pojedinosti"
+
+#: panels/network/network-wifi.ui:545
+#: panels/network/wireless-security/eap-method-leap.ui:40
+#: panels/network/wireless-security/eap-method-simple.ui:40
+#: panels/network/wireless-security/ws-leap.ui:40
+#: panels/network/wireless-security/ws-wpa-psk.ui:22
+#: panels/sharing/sharing.ui:351
+#: panels/user-accounts/data/account-dialog.ui:300
+#: panels/user-accounts/data/account-dialog.ui:525
+#: panels/user-accounts/data/user-accounts-dialog.ui:205
+msgid "_Password"
+msgstr "_Lozinka"
+
+#: panels/network/network-wifi.ui:622
+msgid "Show P_assword"
+msgstr "Prikaži _lozinku"
+
+#: panels/network/network-wifi.ui:652
+msgid "Make available to other users"
+msgstr "Učini dostupno drugim korisnicima"
+
+#: panels/network/network-wifi.ui:680
+msgid "identity"
+msgstr "identitet"
+
+#: panels/network/network-wifi.ui:714
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: panels/network/network-wifi.ui:755 panels/network/network-wifi.ui:1032
+msgid "_Addresses"
+msgstr "_Adresa"
+
+#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
+msgid "Automatic (DHCP) addresses only"
+msgstr "Samo samostalne (DHCP) adrese"
+
+#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
+msgid "Link-local only"
+msgstr "Samo veži-lokalno"
+
+#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
+msgid "Shared with other computers"
+msgstr "Deljeno sa ostalim računarima"
+
+#: panels/network/network-wifi.ui:917 panels/network/network-wifi.ui:1194
+msgid "_Ignore automatically obtained routes"
+msgstr "_Zanemari automatski dobijene rute"
+
+#: panels/network/network-wifi.ui:960
+msgid "ipv4"
+msgstr "ipv4"
+
+#: panels/network/network-wifi.ui:991
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: panels/network/network-wifi.ui:1237
+msgid "ipv6"
+msgstr "ipv6"
+
+#: panels/network/network-wifi.ui:1277
+msgid "_Cloned MAC Address"
+msgstr "_Klonirana MAC adresa"
+
+#: panels/network/network-wifi.ui:1327
+msgid "hardware"
+msgstr "uređaji"
+
+#: panels/network/network-wifi.ui:1346
+msgid "_Reset"
+msgstr "_Ponovo postavi"
+
+#: panels/network/network-wifi.ui:1382
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"Ponovo će postaviti podešavanja ove veze na njihova osnovna, ali će je "
+"upamtiti kao željenu vezu."
+
+#: panels/network/network-wifi.ui:1399
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"Ukloniće sve podatke koji se odnose na ovu mrežu i neće pokušati da se sam "
+"poveže na nju."
+
+#: panels/network/network-wifi.ui:1419
+msgid "reset"
+msgstr "ponovo postavi"
+
+#: panels/network/network-wifi.ui:1472
+msgid "Hardware"
+msgstr "Uređaji"
+
+#: panels/network/network-wifi.ui:1476
+msgctxt "tab"
+msgid "Reset"
+msgstr "Ponovo postavi"
+
+#: panels/network/network-wifi.ui:1537
+msgid "Wi-Fi Hotspot"
+msgstr "Bežična vruća tačka"
+
+#: panels/network/network-wifi.ui:1554
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Isključite da se povežete na bežičnu mrežu"
+
+#: panels/network/network-wifi.ui:1603
+msgid "Network Name"
+msgstr "Naziv mreže"
+
+#: panels/network/network-wifi.ui:1621
+msgid "Connected Devices"
+msgstr "Priključeni uređaji"
+
+#: panels/network/network-wifi.ui:1639
+msgid "Security type"
+msgstr "Vrsta bezbednosti"
+
+#: panels/network/network-wifi.ui:1702
+msgctxt "Wi-Fi passkey"
+msgid "Password"
+msgstr "Lozinka"
+
+#: panels/network/network-wifi.ui:1796
+msgid "Turn Wi-Fi off"
+msgstr "Isključi bežičnu"
+
+#: panels/network/network-wifi.ui:1828
+msgid "_Connect to Hidden Network…"
+msgstr "_Poveži se na skrivenu bežičnu mrežu…"
+
+#: panels/network/network-wifi.ui:1838
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Uključi bežičnu vruću tačku…"
+
+#: panels/network/network-wifi.ui:1848
+msgid "_Known Wi-Fi Networks"
+msgstr "_Poznate bežične mreže"
+
+#: panels/network/wifi.ui:40
+msgid "No Wi-Fi Adapter Found"
+msgstr "Nisam našao bežični adapter"
+
+#: panels/network/wifi.ui:52
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Proverite da li ste priključili i upalili bežični adapter"
+
+#: panels/network/wifi.ui:127
+msgid "Airplane Mode"
+msgstr "Režim u avionu"
+
+#: panels/network/wifi.ui:142
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Isključite bežičnu, blutut i širokopojasnu mrežu"
+
+#: panels/network/wifi.ui:192
+msgid "Visible Networks"
+msgstr "Vidljive mreže"
+
+#: panels/network/wifi.ui:271
+msgid "NetworkManager needs to be running"
+msgstr "Upravljač mrežom treba biti pokrenut"
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:127
+msgid "Ad-hoc"
+msgstr "Ad-hok"
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:131
+msgid "Infrastructure"
+msgstr "Infrastrukturno"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:147 panels/network/panel-common.c:201
+msgid "Status unknown"
+msgstr "Nepoznato stanje"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:151
+msgid "Unmanaged"
+msgstr "Neupravljan"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:155
+msgid "Unavailable"
+msgstr "Nedostupno"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:165 panels/network/panel-common.c:207
+msgid "Connecting"
+msgstr "Povezujem se"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:169 panels/network/panel-common.c:211
+msgid "Authentication required"
+msgstr "Potrebno je potvrđivanje identiteta"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:173 panels/network/panel-common.c:215
+msgid "Connected"
+msgstr "Povezani ste"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:177
+msgid "Disconnecting"
+msgstr "Isključujem"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:181 panels/network/panel-common.c:219
+msgid "Connection failed"
+msgstr "Povezivanje nije uspelo"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:185 panels/network/panel-common.c:227
+msgid "Status unknown (missing)"
+msgstr "Stanje je nepoznato (nedostaje)"
+
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:223
+msgid "Not connected"
+msgstr "Niste povezani"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "Configuration failed"
+msgstr "Nije uspelo podešavanje"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252
+msgid "IP configuration failed"
+msgstr "Nije uspelo podešavanje IP-a"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "IP configuration expired"
+msgstr "Isteklo je podešavanje IP-a"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:260
+msgid "Secrets were required, but not provided"
+msgstr "Zatražene su tajne, ali nisu dostavljene"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:264
+msgid "802.1x supplicant disconnected"
+msgstr "Prekinuta je veza sa 802.1x moliocem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:268
+msgid "802.1x supplicant configuration failed"
+msgstr "Nije uspelo podešavanje 802.1x molioca"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:272
+msgid "802.1x supplicant failed"
+msgstr "802.1x molilac nije uspeo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:276
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Potvrđivanje identiteta 802.1x molioca je trajalo predugo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:280
+msgid "PPP service failed to start"
+msgstr "PPP usluga nije uspela da se pokrene"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:284
+msgid "PPP service disconnected"
+msgstr "PPP usluga je isključena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:288
+msgid "PPP failed"
+msgstr "PPP nije uspelo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:292
+msgid "DHCP client failed to start"
+msgstr "DHCP klijent nije uspeo da e pokrene"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:296
+msgid "DHCP client error"
+msgstr "Greška DHCP klijenta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:300
+msgid "DHCP client failed"
+msgstr "DHCP klijent nije uspeo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:304
+msgid "Shared connection service failed to start"
+msgstr "Usluga deljene veze nije uspela da se pokrene"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:308
+msgid "Shared connection service failed"
+msgstr "Usluga deljene veze nije uspela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:312
+msgid "AutoIP service failed to start"
+msgstr "Usluga samostalnog IP-a nije uspela da se pokrene"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:316
+msgid "AutoIP service error"
+msgstr "Greška usluge samostalnog IP-a"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:320
+msgid "AutoIP service failed"
+msgstr "Usluga samostalnog IP-a nije uspela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:324
+msgid "Line busy"
+msgstr "Linija je zauzeta"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:328
+msgid "No dial tone"
+msgstr "Nema tona pozivanja"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:332
+msgid "No carrier could be established"
+msgstr "Nijedan nosač ne može biti uspostavljen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:336
+msgid "Dialing request timed out"
+msgstr "Isteklo je vreme zahteva pozivanja"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:340
+msgid "Dialing attempt failed"
+msgstr "Pokušaj pozivanja nije uspeo"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:344
+msgid "Modem initialization failed"
+msgstr "Nije uspelo pokretanje modema"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:348
+msgid "Failed to select the specified APN"
+msgstr "Nisam uspeo da izaberem navedeni NTP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:352
+msgid "Not searching for networks"
+msgstr "Ne tražim mreže"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:356
+msgid "Network registration denied"
+msgstr "Zavođenje mreže je odbijeno"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:360
+msgid "Network registration timed out"
+msgstr "Isteklo je vreme za zavođenje mreže"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:364
+msgid "Failed to register with the requested network"
+msgstr "Nisam uspeo da zavedem sa zahtevanom mrežom"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:368
+msgid "PIN check failed"
+msgstr "Provera PIN-a nije uspela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:372
+msgid "Firmware for the device may be missing"
+msgstr "Možda nedostaje firmver za uređaj"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:376
+msgid "Connection disappeared"
+msgstr "Veza je nestala"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:380
+msgid "Existing connection was assumed"
+msgstr "Postojeća veza biće prisvojena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:384
+msgid "Modem not found"
+msgstr "Nije pronađen modem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:388
+msgid "Bluetooth connection failed"
+msgstr "Veza blututa nije uspela"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:392
+msgid "SIM Card not inserted"
+msgstr "SIM kartica nije ubačena"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:396
+msgid "SIM Pin required"
+msgstr "Potreban je SIM PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:400
+msgid "SIM Puk required"
+msgstr "Potreban je SIM PUK"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:404
+msgid "SIM wrong"
+msgstr "Pogrešna SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:408
+msgid "Connection dependency failed"
+msgstr "Nije uspela zavisnost veze"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:433
+msgid "Firmware missing"
+msgstr "Nedostaje firmver"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:437
+msgid "Cable unplugged"
+msgstr "Kabal je isključen"
+
+#: panels/network/wireless-security/eap-method.c:57
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "neodređena greška u 802.1X bezbednosti (vpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:233
+msgid "no file selected"
+msgstr "Nije izabrana datoteka"
+
+#: panels/network/wireless-security/eap-method.c:264
+msgid "unspecified error validating eap-method file"
+msgstr "neodređena greška potvrđivanja datoteke eap-metoda"
+
+#: panels/network/wireless-security/eap-method.c:439
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "DER, PEM, ili PKCS#12 lični ključevi (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:442
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER ili PEM uverenja (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:72
+msgid "missing EAP-FAST PAC file"
+msgstr "nedostaje datoteka EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:268
+#: panels/network/wireless-security/eap-method-peap.c:302
+#: panels/network/wireless-security/eap-method-ttls.c:351
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.c:283
+#: panels/network/wireless-security/eap-method-peap.c:272
+#: panels/network/wireless-security/eap-method-ttls.c:289
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.c:406
+msgid "Choose a PAC file"
+msgstr "Izaberi PAC datoteku"
+
+#: panels/network/wireless-security/eap-method-fast.c:413
+msgid "PAC files (*.pac)"
+msgstr "PAC datoteke (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:22
+msgid "Anonymous"
+msgstr "Anonimno"
+
+#: panels/network/wireless-security/eap-method-fast.ui:25
+msgid "Authenticated"
+msgstr "Potvrđenim identitetom"
+
+#: panels/network/wireless-security/eap-method-fast.ui:28
+msgid "Both"
+msgstr "Oba"
+
+#: panels/network/wireless-security/eap-method-fast.ui:76
+msgid "PAC _file"
+msgstr "PAC _datoteka"
+
+#: panels/network/wireless-security/eap-method-fast.ui:122
+#: panels/network/wireless-security/eap-method-peap.ui:146
+#: panels/network/wireless-security/eap-method-ttls.ui:97
+msgid "_Inner authentication"
+msgstr "_Unutrašnja prijava"
+
+#: panels/network/wireless-security/eap-method-fast.ui:156
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Dozvoli automatsko PAC _snabdevanje"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "nedostaje EAP-LEAP korisničko ime"
+
+#: panels/network/wireless-security/eap-method-leap.c:74
+msgid "missing EAP-LEAP password"
+msgstr "nedostaje EAP-LEAP lozinka"
+
+#: panels/network/wireless-security/eap-method-leap.ui:26
+#: panels/network/wireless-security/eap-method-simple.ui:26
+#: panels/network/wireless-security/ws-leap.ui:26
+#: panels/user-accounts/data/account-dialog.ui:142
+#: panels/user-accounts/data/account-dialog.ui:505
+msgid "_Username"
+msgstr "_Korisnik"
+
+#: panels/network/wireless-security/eap-method-leap.ui:68
+#: panels/network/wireless-security/eap-method-simple.ui:85
+#: panels/network/wireless-security/eap-method-tls.ui:164
+#: panels/network/wireless-security/ws-leap.ui:68
+#: panels/network/wireless-security/ws-wpa-psk.ui:76
+msgid "Sho_w password"
+msgstr "Po_kaži lozinku"
+
+#: panels/network/wireless-security/eap-method-peap.c:63
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "neispravno EAP-PEAP uverenje izdavača uverenja: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:68
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+"neispravno EAP-PEAP uverenje izdavača uverenja: nije navedeno nikakvo uverenje"
+
+#: panels/network/wireless-security/eap-method-peap.c:287
+#: panels/network/wireless-security/eap-method-ttls.c:336
+#: panels/network/wireless-security/wireless-security.c:441
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.c:381
+#: panels/network/wireless-security/eap-method-tls.c:492
+#: panels/network/wireless-security/eap-method-ttls.c:430
+msgid "Choose a Certificate Authority certificate"
+msgstr "Izaberite uverenje izdavača ovlašćenja"
+
+#: panels/network/wireless-security/eap-method-peap.ui:25
+msgid "Version 0"
+msgstr "Izdanje 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:28
+msgid "Version 1"
+msgstr "Izdanje 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:74
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:57
+msgid "C_A certificate"
+msgstr "CA _uverenje"
+
+#: panels/network/wireless-security/eap-method-peap.ui:96
+#: panels/network/wireless-security/eap-method-tls.ui:97
+#: panels/network/wireless-security/eap-method-ttls.ui:79
+msgid "No CA certificate is _required"
+msgstr "Nije potrebno _uverenje izdavača uverenja"
+
+#: panels/network/wireless-security/eap-method-peap.ui:114
+msgid "PEAP _version"
+msgstr "PEAP _izdanje"
+
+#: panels/network/wireless-security/eap-method-simple.c:74
+msgid "missing EAP username"
+msgstr "nedostaje EAP korisničko ime"
+
+#: panels/network/wireless-security/eap-method-simple.c:87
+msgid "missing EAP password"
+msgstr "nedostaje EAP lozinka"
+
+#: panels/network/wireless-security/eap-method-tls.c:68
+msgid "missing EAP-TLS identity"
+msgstr "nedostaje EAP-TLS identitet"
+
+#: panels/network/wireless-security/eap-method-tls.c:77
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "neispravno EAP-TLS uverenje izdavača uverenja: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:84
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+"neispravno EAP-TLS uverenje izdavača uverenja: nije navedeno nikakvo uverenje"
+
+#: panels/network/wireless-security/eap-method-tls.c:100
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "neispravan EAP-TLS privatni ključ: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:110
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "neispravno EAP-TLS uverenje korisnika: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:307
+msgid "Unencrypted private keys are insecure"
+msgstr "Nešifrovani privatni ključevi nisu sigurni"
+
+#: panels/network/wireless-security/eap-method-tls.c:310
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Izgleda da izabrani privatni ključ nije zaštićen lozinkom. Ovo može ugroziti "
+"vaše sigurnosne podatke. Izaberite privatni ključ koji ze zaštićen lozinkom.\n"
+"\n"
+"(Možete zaštititi privatne ključeve koristeći „openssl“)"
+
+#: panels/network/wireless-security/eap-method-tls.c:486
+msgid "Choose your personal certificate"
+msgstr "Izaberite vaše lično uverenje"
+
+#: panels/network/wireless-security/eap-method-tls.c:498
+msgid "Choose your private key"
+msgstr "Izaberite lični ključ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:24
+msgid "I_dentity"
+msgstr "_Identitet"
+
+#: panels/network/wireless-security/eap-method-tls.ui:50
+msgid "_User certificate"
+msgstr "Uverenje _korisnika"
+
+#: panels/network/wireless-security/eap-method-tls.ui:115
+msgid "Private _key"
+msgstr "Lični _ključ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:140
+msgid "_Private key password"
+msgstr "_Lozinka ličnog ključa"
+
+#: panels/network/wireless-security/eap-method-ttls.c:63
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "neispravno EAP-TTLS uverenje izdavača uverenja: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:68
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+"neispravno EAP-TTLS uverenje izdavača uverenja: nije navedeno nikakvo uverenje"
+
+#: panels/network/wireless-security/eap-method-ttls.c:259
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.c:274
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.c:305
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (bez EAP-a)"
+
+#: panels/network/wireless-security/eap-method-ttls.c:321
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/wireless-security.c:87
+msgid "Unknown error validating 802.1X security"
+msgstr "Nepoznata greška potvrđivanja 802.1X bezbednosti"
+
+#: panels/network/wireless-security/wireless-security.c:453
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/wireless-security.c:477
+msgid "PWD"
+msgstr "LZN"
+
+#: panels/network/wireless-security/wireless-security.c:488
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/wireless-security.c:499
+msgid "Tunneled TLS"
+msgstr "TLS kroz tunel"
+
+#: panels/network/wireless-security/wireless-security.c:510
+msgid "Protected EAP (PEAP)"
+msgstr "Zaštićeni EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:39
+#: panels/network/wireless-security/ws-wep-key.ui:115
+#: panels/network/wireless-security/ws-wpa-eap.ui:33
+msgid "Au_thentication"
+msgstr "Potvrđivanje _identiteta"
+
+#: panels/network/wireless-security/ws-leap.c:63
+msgid "missing leap-username"
+msgstr "nedostaje leap korisničko ime"
+
+#: panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr "nedostaje leap lozinka"
+
+#: panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr "nedostaje vep ključ"
+
+#: panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"neispravan vep ključ: ključ dužine %zu mora da sadrži samo heksadecimalne cifre"
+
+#: panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "neispravan vep ključ: ključ dužine %zu mora da sadrži samo askri znakove"
+
+#: panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"neispravan vep ključ: pogrešna dužina ključa %zu. Ključ mora biti dužine 5/13 "
+"(askri) ili 10/26 (heksa)"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "neispravan vep ključ: propusna reč ne sme biti prazna"
+
+#: panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "neispravan vep ključ: propusna reč mora biti kraća od 64 znakova"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Osnovno)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Otvoreni sistem"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Deljeni ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:56
+msgid "_Key"
+msgstr "_Ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:94
+msgid "Sho_w key"
+msgstr "P_rikaži ključ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:152
+msgid "WEP inde_x"
+msgstr "VEP i_ndeks"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"neispravan vpa-psk: neispravna dužina ključa %zu. Mora biti [8,63] bajta ili "
+"64 heksadecimalnih cifara"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"neispravan vpa-psk: ne mogu da rastumačim ključ sa 64 bajta kao heksadecimalni"
+
+#: panels/network/wireless-security/ws-wpa-psk.ui:50
+msgid "_Type"
+msgstr "_Vrsta"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/edit-dialog.ui:64
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "O_baveštenja"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/edit-dialog.ui:116
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Zvučne _uzbune"
+
+#: panels/notifications/edit-dialog.ui:172
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Oblačići obaveštenja"
+
+#: panels/notifications/edit-dialog.ui:188
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Obaveštenja će nastaviti da se pojavljuju na spisku obaveštenja prilikom "
+"prikazivanja oblačića."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/edit-dialog.ui:253
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Prikaži sadržaj _poruke u oblačićima"
+
+#: panels/notifications/edit-dialog.ui:304
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "_Obaveštenja na ekranu zaključavanja"
+
+#: panels/notifications/edit-dialog.ui:355
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Prikaži sadržaj p_oruke na ekranu zaključavanja"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Obaveštenja"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Upravljajte prikazanim obaveštenjima i njihovim sadržajem"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:7
+msgid "preferences-system-notifications"
+msgstr "preferences-system-notifications"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "obaveštenja;vrpca;poruka;fioka;iskočko;"
+
+#: panels/notifications/notifications.ui:84
+msgid "Notification _Popups"
+msgstr "Oblačići _obaveštenja"
+
+#: panels/notifications/notifications.ui:134
+msgid "_Lock Screen Notifications"
+msgstr "_Obaveštenja na ekranu zaključavanja"
+
+#. List of applications.
+#: panels/notifications/notifications.ui:180 panels/privacy/privacy.ui:875
+#: panels/sound/gvc-mixer-dialog.c:1768
+msgid "Applications"
+msgstr "Programi"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:148
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Drugo"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:551
+#, c-format
+msgid "%s Account"
+msgstr "„%s“ nalog"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:843
+msgid "Error removing account"
+msgstr "Greška u uklanjanju naloga"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:908
+#, c-format
+msgid "<b>%s</b> removed"
+msgstr "<b>%s</b> je uklonjen"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Nalozi na mreži"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Povežite se na vaše naloge na mreži i odlučite za šta ćete ih koristiti"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:7
+msgid "goa-panel"
+msgstr "goa-panel"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"gugl;fejsbuk;tviter;jahu;veb;mreža;ćaskanje;kalendar;pošta;kontakt;"
+"lični_oblak;kerberos;imap;smtp;poket;pročitajkasnije;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
+msgid "Undo"
+msgstr "Poništi"
+
+#: panels/online-accounts/online-accounts.ui:125
+msgid "Connect to your data in the cloud"
+msgstr "Povežite se na vaše podatke u oblaku"
+
+#: panels/online-accounts/online-accounts.ui:137
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Nema internet veze — povežite se da podesite nove naloge na mreži"
+
+#: panels/online-accounts/online-accounts.ui:159
+msgid "Add an account"
+msgstr "Dodajte nalog"
+
+#: panels/online-accounts/online-accounts.ui:264
+msgid "Remove Account"
+msgstr "Ukloni nalog"
+
+#: panels/power/cc-power-panel.c:253
+msgid "Unknown time"
+msgstr "Nepoznato vreme"
+
+#: panels/power/cc-power-panel.c:259
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minut"
+msgstr[1] "%i minuta"
+msgstr[2] "%i minuta"
+msgstr[3] "Jedan minut"
+
+#: panels/power/cc-power-panel.c:271
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i sat"
+msgstr[1] "%i sata"
+msgstr[2] "%i sati"
+msgstr[3] "Jedan sat"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-power-panel.c:279
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%d %s %d %s"
+
+#: panels/power/cc-power-panel.c:280
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "sat"
+msgstr[1] "sata"
+msgstr[2] "sati"
+msgstr[3] "sat"
+
+# bug(danilo): plural-forms
+#: panels/power/cc-power-panel.c:281
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minuta"
+msgstr[2] "minuta"
+msgstr[3] "minut"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:300
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s do potpune napunjenosti"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:307
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Pažnja: preostaje još %s rada"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:312
+#, c-format
+msgid "%s remaining"
+msgstr "Preostalo vreme: %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:317 panels/power/cc-power-panel.c:345
+msgid "Fully charged"
+msgstr "Potpuno puna"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:321 panels/power/cc-power-panel.c:349
+msgid "Empty"
+msgstr "Prazna"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:336
+msgid "Charging"
+msgstr "Puni se"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:341
+msgid "Discharging"
+msgstr "Prazni se"
+
+#: panels/power/cc-power-panel.c:464
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Glavna"
+
+#: panels/power/cc-power-panel.c:466
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Dodatna"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:537
+msgid "Wireless mouse"
+msgstr "Bežični miš"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:540
+msgid "Wireless keyboard"
+msgstr "Bežična tastatura"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:543
+msgid "Uninterruptible power supply"
+msgstr "Neprekidiv izvor napajanja"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:546
+msgid "Personal digital assistant"
+msgstr "Lični digitalni pomoćnik"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:549
+msgid "Cellphone"
+msgstr "Mobilni telefon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:552
+msgid "Media player"
+msgstr "Muzički uređaj"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:555 panels/wacom/cc-wacom-panel.c:793
+msgid "Tablet"
+msgstr "Tablica"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:558
+msgid "Computer"
+msgstr "Računar"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:561
+msgid "Gaming input device"
+msgstr "Ulazni uređaj za igre"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-power-panel.c:564 panels/power/cc-power-panel.c:804
+#: panels/power/cc-power-panel.c:2377
+msgid "Battery"
+msgstr "Baterija"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:618
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Puni se"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:625
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Upozorenje"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:630
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Skoro prazna"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:635
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Puna"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:640
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Potpuno puna"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:644
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Prazna"
+
+#: panels/power/cc-power-panel.c:802
+msgid "Batteries"
+msgstr "Baterije"
+
+#: panels/power/cc-power-panel.c:1239
+msgid "When _idle"
+msgstr "Kada _miruje"
+
+#: panels/power/cc-power-panel.c:1693
+msgid "Power Saving"
+msgstr "Ušteda napajanja"
+
+#: panels/power/cc-power-panel.c:1724
+msgid "_Screen brightness"
+msgstr "Osvetljaj _ekrana"
+
+#: panels/power/cc-power-panel.c:1743
+msgid "Automatic brightness"
+msgstr "Samostalno podešavanje osvetljenja"
+
+#: panels/power/cc-power-panel.c:1763
+msgid "_Keyboard brightness"
+msgstr "Osvetljaj _tastature"
+
+#: panels/power/cc-power-panel.c:1773
+msgid "_Dim screen when inactive"
+msgstr "_Zatamni ekran kada je neradan"
+
+#: panels/power/cc-power-panel.c:1798
+msgid "_Blank screen"
+msgstr "_Prazan ekran"
+
+#: panels/power/cc-power-panel.c:1835
+msgid "_Wi-Fi"
+msgstr "_Bežična"
+
+#: panels/power/cc-power-panel.c:1840
+msgid "Turn off Wi-Fi to save power."
+msgstr "Isključite bežičnu karticu da biste uštedeli bateriju."
+
+#: panels/power/cc-power-panel.c:1865
+msgid "_Mobile broadband"
+msgstr "_Mobilna širokopojasna"
+
+#: panels/power/cc-power-panel.c:1870
+msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+msgstr ""
+"Isključite mobilni internet (3G, 4G, LTE, itd.) da biste uštedeli bateriju."
+
+#: panels/power/cc-power-panel.c:1923
+msgid "_Bluetooth"
+msgstr "_Blutut"
+
+#: panels/power/cc-power-panel.c:1928
+msgid "Turn off Bluetooth to save power."
+msgstr "Isključite blutut da biste uštedeli bateriju."
+
+#: panels/power/cc-power-panel.c:1987
+msgid "When on battery power"
+msgstr "Kada se napaja sa baterije"
+
+#: panels/power/cc-power-panel.c:1989
+msgid "When plugged in"
+msgstr "Kada je uključen"
+
+#: panels/power/cc-power-panel.c:2084
+msgid "Suspend"
+msgstr "Obustavi"
+
+#: panels/power/cc-power-panel.c:2085
+msgid "Power Off"
+msgstr "Isključi"
+
+#: panels/power/cc-power-panel.c:2086
+msgid "Hibernate"
+msgstr "Zamrzni"
+
+#: panels/power/cc-power-panel.c:2087
+msgid "Nothing"
+msgstr "Ništa"
+
+#. Frame header
+#: panels/power/cc-power-panel.c:2201
+msgid "Suspend & Power Button"
+msgstr "Dugme za gašenje i obustavu"
+
+#: panels/power/cc-power-panel.c:2240
+msgid "_Automatic suspend"
+msgstr "_Sam obustavi"
+
+#: panels/power/cc-power-panel.c:2241
+msgid "Automatic suspend"
+msgstr "Samostalna obustava uređaja"
+
+#: panels/power/cc-power-panel.c:2308
+msgid "_When the Power Button is pressed"
+msgstr "_Kada je dugme za napajanje pritisnuto"
+
+#: panels/power/cc-power-panel.c:2427 shell/cc-window.c:219
+#: shell/panel-list.ui:45
+msgid "Devices"
+msgstr "Uređaji"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Napajanje"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Pogledajte stanje vaše baterije i izmenite podešavanja uštede napajanja"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/power/gnome-power-panel.desktop.in.in:7
+msgid "gnome-power-manager"
+msgstr "gnome-power-manager"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"napajanje;spavanje;obustava;zamrzavanje;baterija;osvetljaj;zatamnjenje;monitor;"
+"DPMS;mirovanje;"
+
+# bug(danilo): plural-forms
+#: panels/power/power.ui:17
+msgid "20 minutes"
+msgstr "20 minuta"
+
+# bug(danilo): plural-forms
+#: panels/power/power.ui:21
+msgid "25 minutes"
+msgstr "25 minuta"
+
+# bug(danilo): plural-forms
+#: panels/power/power.ui:29
+msgid "45 minutes"
+msgstr "45 minuta"
+
+#: panels/power/power.ui:33 panels/privacy/privacy.ui:42
+#: panels/privacy/privacy.ui:56
+msgid "1 hour"
+msgstr "1 sat"
+
+#: panels/power/power.ui:37
+msgid "80 minutes"
+msgstr "80 minuta"
+
+#: panels/power/power.ui:41
+msgid "90 minutes"
+msgstr "90 minuta"
+
+#: panels/power/power.ui:45
+msgid "100 minutes"
+msgstr "100 minuta"
+
+#: panels/power/power.ui:49
+msgid "2 hours"
+msgstr "2 sata"
+
+#: panels/power/power.ui:63 panels/privacy/privacy.ui:22
+msgid "1 minute"
+msgstr "1 minut"
+
+# bug(danilo): plural-forms
+#: panels/power/power.ui:67 panels/privacy/privacy.ui:26
+msgid "2 minutes"
+msgstr "2 minuta"
+
+# bug(danilo): plural-forms
+#: panels/power/power.ui:71 panels/privacy/privacy.ui:30
+msgid "3 minutes"
+msgstr "3 minuta"
+
+#: panels/power/power.ui:75
+msgid "4 minutes"
+msgstr "4 minuta"
+
+# bug(danilo): plural-forms
+#: panels/power/power.ui:79 panels/privacy/privacy.ui:34
+msgid "5 minutes"
+msgstr "5 minuta"
+
+# bug(danilo): plural-forms
+#: panels/power/power.ui:83
+msgid "8 minutes"
+msgstr "8 minuta"
+
+#: panels/power/power.ui:87
+msgid "10 minutes"
+msgstr "10 minuta"
+
+# bug(danilo): plural-forms
+#: panels/power/power.ui:91
+msgid "12 minutes"
+msgstr "12 minuta"
+
+#: panels/power/power.ui:155
+msgid "Automatic Suspend"
+msgstr "Sam obustavi"
+
+#: panels/power/power.ui:180
+msgid "_Plugged In"
+msgstr "Kada je _uključen"
+
+#: panels/power/power.ui:196
+msgid "On _Battery Power"
+msgstr "Kada se napaja sa _baterije"
+
+#: panels/power/power.ui:241 panels/power/power.ui:301
+#: panels/universal-access/uap.ui:1501
+msgid "Delay"
+msgstr "Zastoj"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "Potvrdi identitet"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:361
+msgid "Username"
+msgstr "Korisničko ime"
+
+#. Translators: This is a password needed for printing.
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:382
+#: panels/user-accounts/data/account-dialog.ui:240
+msgid "Password"
+msgstr "Lozinka"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:336
+msgid "Authentication Required"
+msgstr "Potrebno je potvrđivanje identiteta"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:791
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Štampač „%s“ je obrisan"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:1036
+msgid "Failed to add new printer."
+msgstr "Nisam uspeo da dodam novi štampač."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1371
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Ne mogu da učitam sučelje: %s"
+
+#: panels/printers/details-dialog.ui:63 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "Mesto"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/details-dialog.ui:111
+#: panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Upravljački program"
+
+#: panels/printers/details-dialog.ui:147
+msgid "Searching for preferred drivers…"
+msgstr "Tražim podesne upravljačke programe…"
+
+#: panels/printers/details-dialog.ui:169
+msgid "Search for Drivers"
+msgstr "Potražite upravljačke programe"
+
+#: panels/printers/details-dialog.ui:177
+msgid "Select from Database…"
+msgstr "Izaberi iz baze podataka…"
+
+#: panels/printers/details-dialog.ui:185
+msgid "Install PPD File…"
+msgstr "Instaliraj PPD datoteku…"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Štampači"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Dodajte štampače, pogledajte poslove štampanja i odlučite kao želite da "
+"štampate"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/printers/gnome-printers-panel.desktop.in.in:7
+msgid "printer"
+msgstr "printer"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "štampač;red;štampa;papir;mastilo;toner;"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/jobs-dialog.ui:44
+msgid "Domain"
+msgstr "Domen"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/jobs-dialog.ui:123
+msgid "A_uthenticate"
+msgstr "Potvrdi _identitet"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/jobs-dialog.ui:163
+msgid "Clear All"
+msgstr "Očisti sve"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/jobs-dialog.ui:225
+msgid "_Authenticate"
+msgstr "Potvrdi identitet"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/jobs-dialog.ui:354
+msgid "No Active Printer Jobs"
+msgstr "Nema pokrenutih poslova na štampaču"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:384
+#: panels/printers/pp-new-printer-dialog.c:456
+msgid "Add Printer"
+msgstr "Dodaj štampač"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+msgid "_Unlock"
+msgstr "_Otključaj"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:210
+msgid "No Printers Found"
+msgstr "Nisam našao štampače"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:283
+msgid "Enter a network address or search for a printer"
+msgstr "Unesite adresu mreže ili potražite štampač"
+
+#: panels/printers/new-printer-dialog.ui:352
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Unesite korisničko ime i lozinku da vidite štampače na serveru štampanja."
+
+#. Translators: This button triggers the printing of a test page.
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/options-dialog.ui:22 panels/printers/pp-options-dialog.c:893
+msgid "Test Page"
+msgstr "Probna stranica"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:135
+#: panels/printers/pp-details-dialog.c:435
+#, c-format
+msgid "%s Details"
+msgstr "Pojedinosti za „%s“"
+
+#: panels/printers/pp-details-dialog.c:184
+msgid "No suitable driver found"
+msgstr "Nisu pronađeni odgovarajući upravljački programi"
+
+#: panels/printers/pp-details-dialog.c:328
+msgid "Select PPD File"
+msgstr "Izaberite PPD datoteku"
+
+#: panels/printers/pp-details-dialog.c:337
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Datoteke opisa Post skript štampača (*.ppd,*.PPD, *.ppd.gz, *PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr "Izaberite upravljački program štampača"
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/um-photo-dialog.c:104
+msgid "Select"
+msgstr "Izaberi"
+
+#: panels/printers/ppd-selection-dialog.ui:73
+msgid "Loading drivers database…"
+msgstr "Učitavam bazu podataka upravljačkih programa…"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:539
+msgid "JetDirect Printer"
+msgstr "Štampač sa neposrednim mlazom"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:795
+msgid "LPD Printer"
+msgstr "LPD štampač"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "Jednostrano"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "Po dužoj strani (standardno)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:70
+#: panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "Po kraćoj strani (okrenuto)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "Uspravno"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "Položeno"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "Obrnuto položeno"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "Obrnuto uspravno"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-jobs-dialog.c:243
+msgctxt "print job"
+msgid "Pending"
+msgstr "Na čekanju"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-jobs-dialog.c:249
+msgctxt "print job"
+msgid "Paused"
+msgstr "Zaustavljen"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-jobs-dialog.c:254
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Potrebno je potvrđivanje identiteta"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-jobs-dialog.c:259
+msgctxt "print job"
+msgid "Processing"
+msgstr "Obrađujem"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-jobs-dialog.c:263
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Zaustavljen"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-jobs-dialog.c:267
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Otkazan"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-jobs-dialog.c:271
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Poništen"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-jobs-dialog.c:275
+msgctxt "print job"
+msgid "Completed"
+msgstr "Završen"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:399
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u posao zahteva potvrđivanje identiteta"
+msgstr[1] "%u posla zahtevaju potvrđivanje identiteta"
+msgstr[2] "%u poslova zahteva potvrđivanje identiteta"
+msgstr[3] "Jedan posao zahteva potvrđivanje identiteta"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:617
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — pokrenuti poslovi"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:622
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Unesite punomoćstva da biste štampali sa štampača „%s“."
+
+#: panels/printers/pp-new-printer-dialog.c:402
+msgid "Unlock Print Server"
+msgstr "Otključaj server štampača"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:406
+#, c-format
+msgid "Unlock %s."
+msgstr "Otključaj „%s“."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:411
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Unesite korisničko ime i lozinku da vidite štampače na „%s“."
+
+#: panels/printers/pp-new-printer-dialog.c:876
+msgid "Searching for Printers"
+msgstr "Tražim štampače"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1799
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1804
+msgid "Serial Port"
+msgstr "Serijski priključnik"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1811
+msgid "Parallel Port"
+msgstr "Paralelni priključnik"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1853
+#, c-format
+msgid "Location: %s"
+msgstr "Mesto: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1858
+#, c-format
+msgid "Address: %s"
+msgstr "Adresa: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1887
+msgid "Server requires authentication"
+msgstr "Server zahteva potvrđivanje identiteta"
+
+#: panels/printers/pp-options-dialog.c:83
+msgid "Two Sided"
+msgstr "Dvostrano"
+
+#: panels/printers/pp-options-dialog.c:84
+msgid "Paper Type"
+msgstr "Tip papira"
+
+#: panels/printers/pp-options-dialog.c:85
+msgid "Paper Source"
+msgstr "Izvor papira"
+
+#: panels/printers/pp-options-dialog.c:86
+msgid "Output Tray"
+msgstr "Izlazna traka"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "GhostScript pre-filtering"
+msgstr "Gost skript predfilter"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:534
+msgid "Pages per side"
+msgstr "Stranica po listu"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:546
+msgid "Two-sided"
+msgstr "Dvostrano"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Opšte"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Podešavanje stranice"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Instaljive opcije"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Posao"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Kvalitet slike"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Boja"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Završavanje"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:676
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Napredno"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:908
+msgid "Test page"
+msgstr "Probna stranica"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:76
+#: panels/printers/pp-ppd-option-widget.c:78
+#: panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "Sam odredi"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:80
+#: panels/printers/pp-ppd-option-widget.c:82
+#: panels/printers/pp-ppd-option-widget.c:84
+#: panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "Podrazumevano"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "Samo ugnježdeni Gost skript fontovi"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "Prevedi u 1° nivo postskripta"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "Prevedi u 2° nivo postskripta"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "Bez predfiltriranja"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "Proizvođač"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:598 panels/printers/printer-entry.ui:166
+msgid "No Active Jobs"
+msgstr "Nema aktivnih poslova"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:603
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u posao"
+msgstr[1] "%u posla"
+msgstr[2] "%u poslova"
+msgstr[3] "jedan posao"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:766
+msgid "Low on toner"
+msgstr "Ponestaje tonera"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:768
+msgid "Out of toner"
+msgstr "Nema više tonera"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:771
+msgid "Low on developer"
+msgstr "Ponestaje razvijača"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:774
+msgid "Out of developer"
+msgstr "Nema više razvijača"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:776
+msgid "Low on a marker supply"
+msgstr "Ponestaje markera"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:778
+msgid "Out of a marker supply"
+msgstr "Nema više mastila"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:780
+msgid "Open cover"
+msgstr "Otvoren poklopac"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:782
+msgid "Open door"
+msgstr "Otvorena vratanca"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:784
+msgid "Low on paper"
+msgstr "Ponestaje papira"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:786
+msgid "Out of paper"
+msgstr "Nema više papira"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:788
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Isključen"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:790
+#: panels/printers/pp-printer-entry.c:920
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Zaustavljen"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:792
+msgid "Waste receptacle almost full"
+msgstr "Posuda za otpad je skoro puna"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:794
+msgid "Waste receptacle full"
+msgstr "Posuda za otpad je puna"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:796
+msgid "The optical photo conductor is near end of life"
+msgstr "Optički provodnik fotografija je pri kraju života"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:798
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Optički provodnik fotografija više ne funkcioniše"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:906
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Spreman"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:911
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Ne prihvata poslove"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:916
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Obrađuje"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:940
+msgid "Clean print heads"
+msgstr "Očistite glave štampača"
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr "Opcije štampanja"
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr "Pojedinosti štampača"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+msgid "Use Printer by Default"
+msgstr "Podrazumevano koristi štampač"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+msgid "Clean Print Heads"
+msgstr "Očisti glave štampača"
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "Ukloni štampač"
+
+#: panels/printers/printer-entry.ui:193
+msgid "Model"
+msgstr "Mustra"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr "Nivoa mastila"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:312
+msgid "Please restart when the problem is resolved."
+msgstr "Ponovo pokrenite kada problem bude rešen."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:319
+msgid "Restart"
+msgstr "Ponovo pokreni"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:20
+msgid "Add…"
+msgstr "Dodaj…"
+
+#: panels/printers/printers.ui:186
+msgid "No printers"
+msgstr "Nema štampača"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:200
+msgid "Add a Printer…"
+msgstr "Dodaj štampač…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:232
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"Izgleda da nije dostupan pozadinski\n"
+"program za štampu."
+
+#: panels/privacy/cc-privacy-panel.c:387 panels/privacy/privacy.ui:280
+msgid "Screen Lock"
+msgstr "Zaključavanje ekrana"
+
+#: panels/privacy/cc-privacy-panel.c:438
+msgid "In use"
+msgstr "Koristi se"
+
+#: panels/privacy/cc-privacy-panel.c:443
+msgctxt "Location services status"
+msgid "On"
+msgstr "Uklj."
+
+#: panels/privacy/cc-privacy-panel.c:444
+msgctxt "Location services status"
+msgid "Off"
+msgstr "Isklj."
+
+#: panels/privacy/cc-privacy-panel.c:823 panels/privacy/privacy.ui:745
+msgid "Location Services"
+msgstr "Usluge mesta"
+
+#: panels/privacy/cc-privacy-panel.c:946 panels/privacy/privacy.ui:127
+msgid "Usage & History"
+msgstr "Upotreba i istorijat"
+
+#: panels/privacy/cc-privacy-panel.c:1075
+msgid "Empty all items from Trash?"
+msgstr "Da izbacim sve stavke iz smeća?"
+
+#: panels/privacy/cc-privacy-panel.c:1076
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Sve stavke iz smeća će biti trajno uklonjene."
+
+#: panels/privacy/cc-privacy-panel.c:1077
+msgid "_Empty Trash"
+msgstr "_Izbaci Smeće"
+
+#: panels/privacy/cc-privacy-panel.c:1100
+msgid "Delete all the temporary files?"
+msgstr "Da obrišem sve privremene datoteke?"
+
+#: panels/privacy/cc-privacy-panel.c:1101
+msgid "All the temporary files will be permanently deleted."
+msgstr "Sve privremene datoteke će biti trajno obrisane."
+
+#: panels/privacy/cc-privacy-panel.c:1102
+msgid "_Purge Temporary Files"
+msgstr "_Pročisti privremene datoteke"
+
+#: panels/privacy/cc-privacy-panel.c:1124 panels/privacy/privacy.ui:432
+msgid "Purge Trash & Temporary Files"
+msgstr "Očisti smeće i privremene datoteke"
+
+#: panels/privacy/cc-privacy-panel.c:1164 panels/privacy/privacy.ui:637
+msgid "Software Usage"
+msgstr "Upotreba softvera"
+
+#: panels/privacy/cc-privacy-panel.c:1205 panels/privacy/privacy.ui:959
+msgid "Problem Reporting"
+msgstr "Izveštavanje o problemu"
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: panels/privacy/cc-privacy-panel.c:1219
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+"Slanje izveštaja o tehničkim problemima nam pomaže da poboljšamo „%s“. "
+"Izveštaji se šalju bezimeno i očišćeni su od ličnih podataka."
+
+#: panels/privacy/cc-privacy-panel.c:1231 panels/privacy/privacy.ui:719
+msgid "Privacy Policy"
+msgstr "Politika privatnosti"
+
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:3
+msgid "Privacy"
+msgstr "Privatnost"
+
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
+msgid "Protect your personal information and control what others might see"
+msgstr "Zaštitite vaše lične podatke i odlučite šta drugi mogu da vide"
+
+#. FIXME
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:8
+msgid "preferences-system-privacy"
+msgstr "preferences-system-privacy"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"ekran;zaključaj;dijagnoza;pad;urušavanje;lično;skorašnje;nedavno;privremen;prv;"
+"popis;naziv;mreža;identitet;"
+
+#: panels/privacy/privacy.ui:14
+msgid "Screen Turns Off"
+msgstr "Ekran se isključuje"
+
+#: panels/privacy/privacy.ui:18
+msgid "30 seconds"
+msgstr "30 sekundi"
+
+#: panels/privacy/privacy.ui:60 panels/privacy/privacy.ui:106
+msgid "1 day"
+msgstr "1 dan"
+
+#: panels/privacy/privacy.ui:64
+msgid "2 days"
+msgstr "2 dana"
+
+#: panels/privacy/privacy.ui:68
+msgid "3 days"
+msgstr "3 dana"
+
+#: panels/privacy/privacy.ui:72
+msgid "4 days"
+msgstr "4 dana"
+
+#: panels/privacy/privacy.ui:76
+msgid "5 days"
+msgstr "5 dana"
+
+#: panels/privacy/privacy.ui:80
+msgid "6 days"
+msgstr "6 dana"
+
+#: panels/privacy/privacy.ui:84 panels/privacy/privacy.ui:110
+msgid "7 days"
+msgstr "7 dana"
+
+#: panels/privacy/privacy.ui:88
+msgid "14 days"
+msgstr "14 dana"
+
+#: panels/privacy/privacy.ui:92 panels/privacy/privacy.ui:114
+msgid "30 days"
+msgstr "30 dana"
+
+#: panels/privacy/privacy.ui:118
+msgid "Forever"
+msgstr "Zauvek"
+
+#: panels/privacy/privacy.ui:148
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"Pamćenje istorijata olakšava ponovno pronalaženje nekih stvari. Te stavke se "
+"nikada ne dele preko mreže."
+
+#: panels/privacy/privacy.ui:176
+msgid "_Recently Used"
+msgstr "_Skoro korišćeno"
+
+#: panels/privacy/privacy.ui:207
+msgid "Retain _History"
+msgstr "Zadrži _istorijat"
+
+#: panels/privacy/privacy.ui:247
+msgid "Cl_ear Recent History"
+msgstr "Očisti _skorašnji istorijat"
+
+#: panels/privacy/privacy.ui:301
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "Zaključavanje ekrana štiti vašu privatnost kada ste odsutni."
+
+#: panels/privacy/privacy.ui:328
+msgid "Automatic Screen _Lock"
+msgstr "Samostalno _zaključavanje ekrana"
+
+#: panels/privacy/privacy.ui:362
+msgid "Lock screen _after blank for"
+msgstr "_Zaključaj ekran nakon zatamnjenja od"
+
+#: panels/privacy/privacy.ui:394
+msgid "Show _Notifications"
+msgstr "Prikaži _obaveštenja"
+
+#: panels/privacy/privacy.ui:454
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"Samostalno će pročistiti smeće i privremene datoteke da bi vam pomogao da "
+"održite računar slobodnim od nepotrebnih osetljivih podataka."
+
+#: panels/privacy/privacy.ui:483
+msgid "Automatically empty _Trash"
+msgstr "Sam izbaci _smeće"
+
+#: panels/privacy/privacy.ui:515
+msgid "Automatically purge Temporary _Files"
+msgstr "Sam pročisti privremene _datoteke"
+
+#: panels/privacy/privacy.ui:546
+msgid "Purge _After"
+msgstr "Pročisti _nakon"
+
+#: panels/privacy/privacy.ui:590
+msgid "_Empty Trash…"
+msgstr "_Izbaci Smeće…"
+
+#: panels/privacy/privacy.ui:606
+msgid "_Purge Temporary Files…"
+msgstr "_Pročisti privremene datoteke…"
+
+#: panels/privacy/privacy.ui:654
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"Slanjem podataka o softveru koji koristite vi nam pomažete da vam dostavimo "
+"tačnije preporuke. Takođe nam pomažete da poboljšamo naš softver.\n"
+"\n"
+"Prikupljanje svih podataka se radi u tajnosti, i nikada vaše podatke nećemo "
+"deliti sa trećim licima."
+
+#: panels/privacy/privacy.ui:681
+msgid "_Send software usage statistics"
+msgstr "_Pošalji podatke o korišćenju softvera"
+
+#: panels/privacy/privacy.ui:764
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"Usluge mesta omogućavaju programima da znaju vašu lokaciju. Tačnost je "
+"povećana uključivanjem bežične kartice i mobilne širokopojasne mreže."
+
+#: panels/privacy/privacy.ui:778
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+"Koristi Mozilinu uslugu lokacije: <a href='https://location.services.mozilla."
+"com/privacy'>politika privatnosti</a>"
+
+#: panels/privacy/privacy.ui:828
+msgid "_Location Services"
+msgstr "Usluge _mesta"
+
+#: panels/privacy/privacy.ui:1026
+msgid "_Automatic Problem Reporting"
+msgstr "_Samostalno izvesti o problemu"
+
+#: panels/region/cc-format-chooser.c:118
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperijalni"
+
+#: panels/region/cc-format-chooser.c:120
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrički"
+
+#: panels/region/cc-format-chooser.c:285
+msgid "No regions found"
+msgstr "Nisam pronašao područja"
+
+#: panels/region/cc-input-chooser.c:182
+msgid "No input sources found"
+msgstr "Nisam pronašao izvore ulaza"
+
+#: panels/region/cc-input-chooser.c:1012
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Drugo"
+
+#: panels/region/cc-region-panel.c:881
+msgid "No input source selected"
+msgstr "Nije izabran izvor ulaza"
+
+#: panels/region/cc-region-panel.c:1773
+msgid "Login _Screen"
+msgstr "Ekran _za prijavljivanje"
+
+#: panels/region/format-chooser.ui:7
+msgid "Formats"
+msgstr "Oblici"
+
+#: panels/region/format-chooser.ui:120
+msgid "Preview"
+msgstr "Pregled"
+
+#: panels/region/format-chooser.ui:137
+msgid "Dates"
+msgstr "Datumi"
+
+#: panels/region/format-chooser.ui:168
+msgid "Times"
+msgstr "Vremena"
+
+#: panels/region/format-chooser.ui:199
+msgid "Dates & Times"
+msgstr "Datumi i vremena"
+
+#: panels/region/format-chooser.ui:230
+msgid "Numbers"
+msgstr "Brojevi"
+
+#: panels/region/format-chooser.ui:247
+msgid "Measurement"
+msgstr "Merenje"
+
+#: panels/region/format-chooser.ui:264
+msgid "Paper"
+msgstr "Papir"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Region i jezik"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"Izaberite vaš prikazani jezik, zapise, rasporede tastature i izvore ulaza"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/region/gnome-region-panel.desktop.in.in:7
+msgid "preferences-desktop-locale"
+msgstr "preferences-desktop-locale"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "jezik;raspored;tastatura;unos;"
+
+#: panels/region/input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Dodajte izvor ulaza"
+
+#: panels/region/input-chooser.ui:76
+msgid "Input methods can’t be used on the login screen"
+msgstr "Načini unosa ne mogu biti korišćeni u ekranu prijavljivanja"
+
+#: panels/region/input-options.ui:7
+msgid "Input Source Options"
+msgstr "Izbori izvora ulaza"
+
+#: panels/region/input-options.ui:27
+msgid "Use the _same source for all windows"
+msgstr "Koristi _isti izvor za sve prozore"
+
+#: panels/region/input-options.ui:45
+msgid "Allow _different sources for each window"
+msgstr "Dopusti _različite izvore za svaki prozor"
+
+#: panels/region/input-options.ui:85
+msgid "Switch to previous source"
+msgstr "Prebacite se na prethodni izvor"
+
+#: panels/region/input-options.ui:102
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Razmak"
+
+#: panels/region/input-options.ui:116
+msgid "Switch to next source"
+msgstr "Prebacite se na sledeći izvor"
+
+#: panels/region/input-options.ui:133
+msgid "Super+Space"
+msgstr "Super+Razmak"
+
+#: panels/region/input-options.ui:147
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "Možete da promenite ove prečice u podešavanjima tastature"
+
+#: panels/region/input-options.ui:164
+msgid "Alternative switch to next source"
+msgstr "Zamenski prelazak na sledeći izvor"
+
+#: panels/region/input-options.ui:181
+msgid "Left+Right Alt"
+msgstr "Levi+desni Alt"
+
+#: panels/region/region.ui:67
+#: panels/user-accounts/data/user-accounts-dialog.ui:348
+msgid "_Language"
+msgstr "_Jezik"
+
+#: panels/region/region.ui:85
+msgid "English (United Kingdom)"
+msgstr "Engleski (Velika Britanija)"
+
+#: panels/region/region.ui:112
+msgid "Restart the session for changes to take effect"
+msgstr "Ponovo pokrenite sesiju kako bi izmene stupile u dejstvo"
+
+#: panels/region/region.ui:134
+msgid "Restart…"
+msgstr "Ponovo pokreni…"
+
+#: panels/region/region.ui:169
+msgid "_Formats"
+msgstr "_Formati"
+
+#: panels/region/region.ui:187
+msgid "United Kingdom"
+msgstr "Velika Britanija"
+
+#: panels/region/region.ui:229
+msgid "Input Sources"
+msgstr "Izvori ulaza"
+
+#: panels/region/region.ui:245
+msgid "_Options"
+msgstr "_Opcije"
+
+#: panels/region/region.ui:311
+msgid "Add input source"
+msgstr "Dodaj izvor ulaza"
+
+#: panels/region/region.ui:336
+msgid "Remove input source"
+msgstr "Ukloni izvore ulaza"
+
+#: panels/region/region.ui:386
+msgid "Move input source up"
+msgstr "Premesti izvor ulaza gore"
+
+#: panels/region/region.ui:411
+msgid "Move input source down"
+msgstr "Premesti izvor ulaza dole"
+
+#: panels/region/region.ui:461
+msgid "Configure input source"
+msgstr "Podesi izvor ulaza"
+
+#: panels/region/region.ui:486
+msgid "Show input source keyboard layout"
+msgstr "Prikaži raspored tastature izvora ulaza"
+
+#: panels/region/region.ui:530
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"Podešavanja prijavljivanja koriste svi korisnici kada se prijavljuju na sistem"
+
+#: panels/search/cc-search-locations-dialog.c:639
+msgid "Select Location"
+msgstr "Izaberi mesto"
+
+#: panels/search/cc-search-locations-dialog.c:643
+msgid "_OK"
+msgstr "U _redu"
+
+#: panels/search/cc-search-panel.c:178
+msgid "No applications found"
+msgstr "Nisam pronašao programe"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Odlučite koji programi će prikazivati rezultate pretrage u pregledu "
+"aktivnosti"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/search/gnome-search-panel.desktop.in.in:7
+msgid "preferences-system-search"
+msgstr "preferences-system-search"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "nađi;traži;pronađi;potraži;popis;indeks;sakrij;privatnost;rezultati;"
+
+#: panels/search/search-locations-dialog.ui:9
+msgid "Search Locations"
+msgstr "Mesta pretrage"
+
+#: panels/search/search-locations-dialog.ui:43
+msgid "Places"
+msgstr "Mesta"
+
+#: panels/search/search-locations-dialog.ui:73
+msgid "Bookmarks"
+msgstr "Obeleživači"
+
+#: panels/search/search-locations-dialog.ui:130
+msgid "Other"
+msgstr "Drugo"
+
+#: panels/search/search.ui:66
+msgid "Move Up"
+msgstr "Pomeri gore"
+
+#: panels/search/search.ui:83
+msgid "Move Down"
+msgstr "Pomeri dole"
+
+#: panels/search/search.ui:119
+msgid "Preferences"
+msgstr "Postavke"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:305
+msgid "No networks selected for sharing"
+msgstr "Nisu izabrane mreže za deljenje"
+
+#: panels/sharing/cc-sharing-panel.c:275
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Uklj."
+
+#: panels/sharing/cc-sharing-panel.c:277 panels/sharing/cc-sharing-panel.c:304
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Isklj."
+
+#: panels/sharing/cc-sharing-panel.c:307
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Uključeno"
+
+#: panels/sharing/cc-sharing-panel.c:310
+msgctxt "service is active"
+msgid "Active"
+msgstr "Radna"
+
+#: panels/sharing/cc-sharing-panel.c:381
+msgid "Choose a Folder"
+msgstr "Izaberite fasciklu"
+
+#: panels/sharing/cc-sharing-panel.c:693
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"Deljenje datoteka vam omogućava da delite vašu javnu fasciklu sa drugima na "
+"vašoj tekućoj mreži koristeći: <a href=\"dav://%s\">dav://%s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:695
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"Kada je uključeno udaljeno prijavljivanje, udaljeni korisnici mogu da se povežu "
+"koristeći naredbu bezbedne školjke:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:697
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"Deljenje ekrana omogućava udaljenim korisnicima da vide ili da upravljaju vašim "
+"ekranom tako što će se povezati na <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:809
+msgid "Copy"
+msgstr "Umnožavanje"
+
+#: panels/sharing/cc-sharing-panel.c:1236
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Deljenje"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Odlučite šta želite da delite s drugima"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:7
+msgid "preferences-system-sharing"
+msgstr "preferences-system-sharing"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"deli;deljenje;ssh;bezbedna školjka;domaćin;naziv;udaljeno;radna površ;blutut;"
+"obeks;medija;zvuk;audio;snimak;video;slike;fotografije;filmovi;server;"
+"iscrtavač;deli;deljenje;ssh;bezbedna školjka;domaćin;naziv;udaljeno;radna "
+"površ;blutut;obeks;medija;zvuk;audio;snimak;video;slike;fotografije;filmovi;"
+"server;iscrtavač;share;sharing;ssh;host;name;remote;desktop;media;audio;"
+"video;pictures;photos;movies;server;renderer;"
+
+#: panels/sharing/networks.ui:19
+msgid "Networks"
+msgstr "Mreže"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Uključite ili isključite udaljeno prijavljivanje"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Potrebno je potvrđivanje identiteta za uključivanje ili isključivanje udaljenog "
+"prijavljivanja"
+
+#: panels/sharing/sharing.ui:46
+msgid "_Computer Name"
+msgstr "_Naziv računara"
+
+#: panels/sharing/sharing.ui:104
+msgid "_File Sharing"
+msgstr "_Deljenje datoteka"
+
+#: panels/sharing/sharing.ui:147
+msgid "_Screen Sharing"
+msgstr "Deljenje e_krana"
+
+#: panels/sharing/sharing.ui:190
+msgid "_Media Sharing"
+msgstr "Deljenje _medija"
+
+#: panels/sharing/sharing.ui:233
+msgid "_Remote Login"
+msgstr "Udaljeno p_rijavljivanje"
+
+#: panels/sharing/sharing.ui:272
+msgid "Some services are disabled because of no network access."
+msgstr "Neke usluge su isključene jer nema pristupa na mrežu."
+
+#: panels/sharing/sharing.ui:286 panels/sharing/sharing.ui:413
+msgid "File Sharing"
+msgstr "Deljenje datoteka"
+
+#: panels/sharing/sharing.ui:333
+msgid "_Require Password"
+msgstr "_Zahteva lozinku"
+
+#: panels/sharing/sharing.ui:424 panels/sharing/sharing.ui:496
+msgid "Remote Login"
+msgstr "Udaljeno prijavljivanje"
+
+#: panels/sharing/sharing.ui:519 panels/sharing/sharing.ui:765
+msgid "Screen Sharing"
+msgstr "Deljenje ekrana"
+
+#: panels/sharing/sharing.ui:577
+msgid "_Allow connections to control the screen"
+msgstr "_Dozvoli vezama da kontrolišu ekran"
+
+#: panels/sharing/sharing.ui:622
+msgid "_Password:"
+msgstr "_Lozinka:"
+
+#: panels/sharing/sharing.ui:652
+msgid "_Show Password"
+msgstr "_Prikaži lozinku"
+
+#: panels/sharing/sharing.ui:683
+msgid "Access Options"
+msgstr "Mogućnosti pristupa"
+
+#: panels/sharing/sharing.ui:697
+msgid "_New connections must ask for access"
+msgstr "_Nove veze moraju zatražiti pristup"
+
+#: panels/sharing/sharing.ui:715
+msgid "_Require a password"
+msgstr "_Zahtevaj lozinku"
+
+#: panels/sharing/sharing.ui:776 panels/sharing/sharing.ui:870
+msgid "Media Sharing"
+msgstr "Deljenje medija"
+
+#: panels/sharing/sharing.ui:809
+msgid "Share music, photos and videos over the network."
+msgstr "Delite muziku, fotografije i snimke na mreži."
+
+#: panels/sharing/sharing.ui:824
+msgid "Folders"
+msgstr "Fascikle"
+
+#: panels/sound/data/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Zvuk"
+
+#: panels/sound/data/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Izmenite nivoe zvuka, ulaze, izlaze i zvuke upozorenja"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/sound/data/gnome-sound-panel.desktop.in.in:7
+msgid "multimedia-volume-control"
+msgstr "multimedia-volume-control"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/data/gnome-sound-panel.desktop.in.in:20
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "kartica;mikrofon;jačina zvuka;iščezavanje;balans;blutut;slušalice;zvuk;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:6
+msgid "Bark"
+msgstr "Lavež"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:12
+msgid "Drip"
+msgstr "Kapanje"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:18
+msgid "Glass"
+msgstr "Staklo"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: panels/sound/data/sounds/gnome-sounds-default.xml.in.in:24
+msgid "Sonar"
+msgstr "Sonar"
+
+#: panels/sound/gvc-balance-bar.c:104
+msgctxt "balance"
+msgid "Left"
+msgstr "Levo"
+
+#: panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Right"
+msgstr "Desno"
+
+#: panels/sound/gvc-balance-bar.c:108
+msgctxt "balance"
+msgid "Rear"
+msgstr "Iza"
+
+#: panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Front"
+msgstr "Ispred"
+
+#: panels/sound/gvc-balance-bar.c:112
+msgctxt "balance"
+msgid "Minimum"
+msgstr "Najmanje"
+
+#: panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Maximum"
+msgstr "Najviše"
+
+#: panels/sound/gvc-balance-bar.c:288
+msgid "_Balance:"
+msgstr "_Uravnoteženost:"
+
+#: panels/sound/gvc-balance-bar.c:291
+msgid "_Fade:"
+msgstr "_Iščezavanje:"
+
+#: panels/sound/gvc-balance-bar.c:294
+msgid "_Subwoofer:"
+msgstr "_Sabvufer:"
+
+#: panels/sound/gvc-channel-bar.c:610 panels/sound/gvc-channel-bar.c:619
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gvc-channel-bar.c:614
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "Bez pojačanja"
+
+#: panels/sound/gvc-combo-box.c:166 panels/sound/gvc-mixer-dialog.c:253
+#: panels/sound/gvc-mixer-dialog.c:520
+msgid "_Profile:"
+msgstr "_Profil:"
+
+#: panels/sound/gvc-mixer-dialog.c:255
+msgid "_Test Speakers"
+msgstr "_Proveri zvučnike"
+
+#: panels/sound/gvc-mixer-dialog.c:424
+msgid "Peak detect"
+msgstr "Otkrivanje vrhunca"
+
+#: panels/sound/gvc-mixer-dialog.c:1499
+msgid "Device"
+msgstr "Uređaj"
+
+#: panels/sound/gvc-mixer-dialog.c:1562
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "Provera zvučnika za „%s“"
+
+#: panels/sound/gvc-mixer-dialog.c:1617
+msgid "_Output volume:"
+msgstr "Jačina _izlaznog zvuka:"
+
+#: panels/sound/gvc-mixer-dialog.c:1631
+msgid "Output"
+msgstr "Izlaz"
+
+#: panels/sound/gvc-mixer-dialog.c:1636
+msgid "C_hoose a device for sound output:"
+msgstr "Izaberite uređaj kao zvučni i_zlaz:"
+
+#: panels/sound/gvc-mixer-dialog.c:1658
+msgid "Settings for the selected device:"
+msgstr "Podešavanja za izabrani uređaj:"
+
+#: panels/sound/gvc-mixer-dialog.c:1669
+msgid "Input"
+msgstr "Ulaz"
+
+#: panels/sound/gvc-mixer-dialog.c:1676
+msgid "_Input volume:"
+msgstr "Jačina _ulaznog zvuka:"
+
+#: panels/sound/gvc-mixer-dialog.c:1697
+msgid "Input level:"
+msgstr "Nivo ulaza:"
+
+#: panels/sound/gvc-mixer-dialog.c:1723
+msgid "C_hoose a device for sound input:"
+msgstr "Izaberite uređaj kao zvučni u_laz:"
+
+#: panels/sound/gvc-mixer-dialog.c:1747
+msgid "Sound Effects"
+msgstr "Zvučni efekti"
+
+#: panels/sound/gvc-mixer-dialog.c:1754
+msgid "_Alert volume:"
+msgstr "Jačina zvuka _upozorenja:"
+
+#: panels/sound/gvc-mixer-dialog.c:1775
+msgid "No application is currently playing or recording audio."
+msgstr "Nijedan program trenutno ne reprodukuje ili snima zvuk."
+
+#: panels/sound/gvc-sound-theme-chooser.c:187
+msgid "Built-in"
+msgstr "Ugrađen"
+
+#: panels/sound/gvc-sound-theme-chooser.c:446
+#: panels/sound/gvc-sound-theme-chooser.c:458
+#: panels/sound/gvc-sound-theme-chooser.c:470
+msgid "Sound Preferences"
+msgstr "Postavke zvuka"
+
+#: panels/sound/gvc-sound-theme-chooser.c:449
+#: panels/sound/gvc-sound-theme-chooser.c:460
+#: panels/sound/gvc-sound-theme-chooser.c:472
+msgid "Testing event sound"
+msgstr "Provera zvučnog signala"
+
+#: panels/sound/gvc-sound-theme-chooser.c:544
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "Osnovno"
+
+#: panels/sound/gvc-sound-theme-chooser.c:545
+msgid "From theme"
+msgstr "Iz teme"
+
+#: panels/sound/gvc-sound-theme-chooser.c:720
+msgid "C_hoose an alert sound:"
+msgstr "Izaberite zvuk za _upozorenje:"
+
+#: panels/sound/gvc-speaker-test.c:229
+msgid "Stop"
+msgstr "Zaustavi"
+
+#: panels/sound/gvc-speaker-test.c:229 panels/sound/gvc-speaker-test.c:341
+msgid "Test"
+msgstr "Proveri"
+
+#: panels/sound/gvc-speaker-test.c:237
+msgid "Subwoofer"
+msgstr "Sabvufer"
+
+#: panels/sound/sound-theme-file-utils.c:288
+msgid "Custom"
+msgstr "Proizvoljno"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:353
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Osnovno"
+
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Srednji"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Veliki"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Veći"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Najveći"
+
+#: panels/universal-access/cc-ua-panel.c:369
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d piksel"
+msgstr[1] "%d piksela"
+msgstr[2] "%d piksela"
+msgstr[3] "jedan piksel"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Olakšajte posmatranje, slušanje, kucanje, ukazivanje i klikanje"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:7
+msgid "preferences-desktop-accessibility"
+msgstr "preferences-desktop-accessibility"
+
+#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;Repeat;Blink;"
+msgstr ""
+"tastatura;miš;a11y;pristupačnost;kontrast;zum;čitač;ekran;tekst;slova;"
+"veličina;Iks_pristup;lepljivi;tasteri;spori;odskočni;miš;dvostruki;klik;"
+"zastoj;ponovi;trepni;"
+
+#: panels/universal-access/uap.ui:89
+msgid "_Always Show Universal Access Menu"
+msgstr "_Uvek prikaži izbornik univerzalnog pristupa"
+
+#: panels/universal-access/uap.ui:131
+msgid "Seeing"
+msgstr "Vidnost"
+
+#: panels/universal-access/uap.ui:177
+msgid "_High Contrast"
+msgstr "_Veliki kontrast"
+
+#: panels/universal-access/uap.ui:224
+msgid "_Large Text"
+msgstr "_Veliki tekst"
+
+#: panels/universal-access/uap.ui:269
+msgid "C_ursor Size"
+msgstr "Veličina _pokazivača"
+
+#: panels/universal-access/uap.ui:316
+#: panels/universal-access/zoom-options.ui:98
+msgid "_Zoom"
+msgstr "_Povećaj"
+
+#: panels/universal-access/uap.ui:362
+msgid "Screen _Reader"
+msgstr "Čitač _ekrana"
+
+#: panels/universal-access/uap.ui:408 panels/universal-access/uap.ui:1237
+msgid "_Sound Keys"
+msgstr "Tasteri _zvuka"
+
+#: panels/universal-access/uap.ui:470
+msgid "Hearing"
+msgstr "Čujnost"
+
+#: panels/universal-access/uap.ui:514 panels/universal-access/uap.ui:1340
+msgid "_Visual Alerts"
+msgstr "_Vizuelna upozorenja"
+
+#: panels/universal-access/uap.ui:622
+msgid "Screen _Keyboard"
+msgstr "_Tastatura na ekranu"
+
+#: panels/universal-access/uap.ui:667
+msgid "R_epeat Keys"
+msgstr "Ponavljanj_e tastera"
+
+#: panels/universal-access/uap.ui:713
+msgid "Cursor _Blinking"
+msgstr "_Treptanje pokazivača"
+
+#: panels/universal-access/uap.ui:759
+msgid "_Typing Assist (AccessX)"
+msgstr "_Pomoć pri kucanju (Iks pristup)"
+
+#: panels/universal-access/uap.ui:820
+msgid "Pointing & Clicking"
+msgstr "Ukazivanje i klikanje"
+
+#: panels/universal-access/uap.ui:866
+msgid "_Mouse Keys"
+msgstr "Tasteri _miša"
+
+#: panels/universal-access/uap.ui:911
+msgid "_Click Assist"
+msgstr "Pomoć pri _kliku"
+
+#: panels/universal-access/uap.ui:957
+msgid "_Double-Click Delay"
+msgstr "Zastoj _duplog klika"
+
+#: panels/universal-access/uap.ui:977
+msgid "Double-Click Delay"
+msgstr "Zastoj duplog klika"
+
+#: panels/universal-access/uap.ui:1042
+msgid "Cursor Size"
+msgstr "Veličina pokazivača"
+
+#: panels/universal-access/uap.ui:1069
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Veličina pokazivača se može kombinovati sa zumom kako bi pokazivač bio "
+"uočljiviji."
+
+#: panels/universal-access/uap.ui:1105
+msgid "Screen Reader"
+msgstr "Čitač ekrana"
+
+#: panels/universal-access/uap.ui:1122
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Čitač ekrana čita prikazani tekst kako pomerate prvi plan."
+
+#: panels/universal-access/uap.ui:1155
+msgid "_Screen Reader"
+msgstr "_Čitač ekrana"
+
+#: panels/universal-access/uap.ui:1194
+msgid "Sound Keys"
+msgstr "Tasteri zvuka"
+
+#: panels/universal-access/uap.ui:1212
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+"Zapišti kada je zaključavanje brojeva ili velikih slova uključeno ili isključeno."
+
+#: panels/universal-access/uap.ui:1282
+msgid "Visual Alerts"
+msgstr "Vizuelna upozorenja"
+
+#: panels/universal-access/uap.ui:1286
+msgid "_Test flash"
+msgstr "Probni _bljesak"
+
+#: panels/universal-access/uap.ui:1315
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Koristi vidno ukazivanje kada se desi zvuk upozorenja."
+
+#: panels/universal-access/uap.ui:1366
+msgid "Flash the _window title"
+msgstr "Bljesni naslovom _prozora"
+
+#: panels/universal-access/uap.ui:1384
+msgid "Flash the entire _screen"
+msgstr "Bljesni celim _ekranom"
+
+#: panels/universal-access/uap.ui:1429
+msgid "Repeat Keys"
+msgstr "Ponavljanje tastera"
+
+#: panels/universal-access/uap.ui:1459
+msgid "Key presses repeat when key is held down."
+msgstr "Pritisci tastera se ponavljaju kada se taster drži pritisnutim."
+
+#: panels/universal-access/uap.ui:1538
+msgid "Repeat keys delay"
+msgstr "Zastoj ponavljanja tastera"
+
+#: panels/universal-access/uap.ui:1586 panels/universal-access/uap.ui:1719
+msgid "Speed"
+msgstr "Brzina"
+
+#: panels/universal-access/uap.ui:1623
+msgid "Repeat keys speed"
+msgstr "Brzina ponavljanja tastera"
+
+#: panels/universal-access/uap.ui:1647
+msgid "Cursor Blinking"
+msgstr "Trepćući pokazivač"
+
+#: panels/universal-access/uap.ui:1677
+msgid "Cursor blinks in text fields."
+msgstr "Pokazivač trepće unutar tekstualnih polja."
+
+#: panels/universal-access/uap.ui:1756
+msgid "Cursor blinking speed"
+msgstr "Brzina treptanja pokazivača"
+
+#: panels/universal-access/uap.ui:1792
+msgid "Typing Assist"
+msgstr "Pomoć kucanja"
+
+#: panels/universal-access/uap.ui:1831
+msgid "_Sticky Keys"
+msgstr "_Lepljivi tasteri"
+
+#: panels/universal-access/uap.ui:1848
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Shvata niz tastera modifikatora kao kombinaciju tastera"
+
+#: panels/universal-access/uap.ui:1872
+msgid "_Disable if two keys are pressed together"
+msgstr "_Isključi ako su dva tastera pritisnuta istovremeno"
+
+#: panels/universal-access/uap.ui:1890
+msgid "Beep when a _modifier key is pressed"
+msgstr "Zapišti kada je pritisnut _izmenjivač"
+
+#: panels/universal-access/uap.ui:1938
+msgid "S_low Keys"
+msgstr "_Spori tasteri"
+
+#: panels/universal-access/uap.ui:1955
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Ubacuje kašnjenje između pritiska tastera i njegovog prihvatanja"
+
+#: panels/universal-access/uap.ui:1988 panels/universal-access/uap.ui:2201
+#: panels/universal-access/uap.ui:2538
+msgid "A_cceptance delay:"
+msgstr "_Kašnjenje prihvatanja:"
+
+#: panels/universal-access/uap.ui:2010
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kratak"
+
+#: panels/universal-access/uap.ui:2029
+msgid "Slow keys typing delay"
+msgstr "Zastoj kucanja sporih tastera"
+
+#: panels/universal-access/uap.ui:2044
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Veliki"
+
+#: panels/universal-access/uap.ui:2071
+msgid "Beep when a key is pr_essed"
+msgstr "Zapišti kada je pritisnut _taster"
+
+#: panels/universal-access/uap.ui:2088
+msgid "Beep when a key is _accepted"
+msgstr "Zapišti kada je taster _prihvaćen"
+
+#: panels/universal-access/uap.ui:2105 panels/universal-access/uap.ui:2284
+msgid "Beep when a key is _rejected"
+msgstr "Zapišti kada taster nije p_rihvaćen"
+
+#: panels/universal-access/uap.ui:2151
+msgid "_Bounce Keys"
+msgstr "_Odskočni tasteri"
+
+#: panels/universal-access/uap.ui:2168
+msgid "Ignores fast duplicate keypresses"
+msgstr "Zanemaruje uzastopne dvostruke pritiske na taster"
+
+#: panels/universal-access/uap.ui:2223
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kratak"
+
+#: panels/universal-access/uap.ui:2242
+msgid "Bounce keys typing delay"
+msgstr "Zastoj kucanja odskočnih tastera"
+
+#: panels/universal-access/uap.ui:2257
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Veliki"
+
+#: panels/universal-access/uap.ui:2370
+msgid "_Enable by Keyboard"
+msgstr "_Uključi tastaturom"
+
+#: panels/universal-access/uap.ui:2387
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Uključite/isključite funkcije pristupačnosti koristeći tastaturu"
+
+#: panels/universal-access/uap.ui:2451
+msgid "Click Assist"
+msgstr "Pomoć pri kliku"
+
+#: panels/universal-access/uap.ui:2487
+msgid "_Simulated Secondary Click"
+msgstr "_Simulirani sekundarni klik"
+
+#: panels/universal-access/uap.ui:2505
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Uključi/isključi sekundarni klik držeći pritisnut primarni taster"
+
+#: panels/universal-access/uap.ui:2559
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kratak"
+
+#: panels/universal-access/uap.ui:2578
+msgid "Secondary click delay"
+msgstr "Zastoj sekundarnog klika"
+
+#: panels/universal-access/uap.ui:2593
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Veliki"
+
+#: panels/universal-access/uap.ui:2650
+msgid "_Hover Click"
+msgstr "Klik _lebdenja"
+
+#: panels/universal-access/uap.ui:2668
+msgid "Trigger a click when the pointer hovers"
+msgstr "Uključi/isključi klik kada pokazivač lebdi"
+
+#: panels/universal-access/uap.ui:2701
+msgid "D_elay:"
+msgstr "_Zastoj:"
+
+#: panels/universal-access/uap.ui:2723
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kratak"
+
+#: panels/universal-access/uap.ui:2754
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Veliki"
+
+#: panels/universal-access/uap.ui:2790
+msgid "Motion _threshold:"
+msgstr "_Osetljivost na pokret:"
+
+#: panels/universal-access/uap.ui:2812
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Mali"
+
+#: panels/universal-access/uap.ui:2843
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Veliki"
+
+#: panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kratko"
+
+#: panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "1/4 ekrana"
+
+#: panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "1/2 ekrana"
+
+#: panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "3/4 ekrana"
+
+#: panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "Veliko"
+
+#: panels/universal-access/zoom-options.ui:48
+msgid "Full Screen"
+msgstr "Ceo ekran"
+
+#: panels/universal-access/zoom-options.ui:53
+msgid "Top Half"
+msgstr "Gornja polovina"
+
+#: panels/universal-access/zoom-options.ui:58
+msgid "Bottom Half"
+msgstr "Donja polovina"
+
+#: panels/universal-access/zoom-options.ui:63
+msgid "Left Half"
+msgstr "Leva polovina"
+
+#: panels/universal-access/zoom-options.ui:68
+msgid "Right Half"
+msgstr "Desna polovina"
+
+#: panels/universal-access/zoom-options.ui:77
+msgid "Zoom Options"
+msgstr "Opcije uvećanja"
+
+#: panels/universal-access/zoom-options.ui:186
+msgid "_Magnification:"
+msgstr "_Uvećavanje:"
+
+#: panels/universal-access/zoom-options.ui:250
+msgid "_Follow mouse cursor"
+msgstr "Prati po_kazivač miša"
+
+#: panels/universal-access/zoom-options.ui:270
+msgid "_Screen part:"
+msgstr "Deo _ekrana:"
+
+#: panels/universal-access/zoom-options.ui:332
+msgid "Magnifier _extends outside of screen"
+msgstr "Lupa se prostire izvan _ekrana"
+
+#: panels/universal-access/zoom-options.ui:351
+msgid "_Keep magnifier cursor centered"
+msgstr "Drži po_kazivač lupe po sredini"
+
+#: panels/universal-access/zoom-options.ui:370
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Pokazivač lu_pe gura sadržaje unaokolo"
+
+#: panels/universal-access/zoom-options.ui:389
+msgid "Magnifier cursor moves with _contents"
+msgstr "Pokazivač lupe se pomera sa sad_ržajima"
+
+#: panels/universal-access/zoom-options.ui:423
+msgid "Magnifier Position:"
+msgstr "Položaj lupe:"
+
+#: panels/universal-access/zoom-options.ui:444
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: panels/universal-access/zoom-options.ui:490
+msgid "_Thickness:"
+msgstr "_Debljina:"
+
+#: panels/universal-access/zoom-options.ui:516
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tanko"
+
+#: panels/universal-access/zoom-options.ui:548
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Debelo"
+
+#: panels/universal-access/zoom-options.ui:574
+msgid "_Length:"
+msgstr "Tra_janje:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/zoom-options.ui:626
+msgid "Co_lor:"
+msgstr "Bo_ja:"
+
+#: panels/universal-access/zoom-options.ui:690
+msgid "_Crosshairs:"
+msgstr "U_krštanje:"
+
+#: panels/universal-access/zoom-options.ui:741
+msgid "_Overlaps mouse cursor"
+msgstr "Preklapa p_okazivač miša"
+
+#: panels/universal-access/zoom-options.ui:779
+msgid "Crosshairs"
+msgstr "Ukrštanje"
+
+#: panels/universal-access/zoom-options.ui:827
+msgid "_White on black:"
+msgstr "_Bela na crnoj:"
+
+#: panels/universal-access/zoom-options.ui:850
+msgid "_Brightness:"
+msgstr "Osv_etljenje:"
+
+#: panels/universal-access/zoom-options.ui:874
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/zoom-options.ui:897
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Boja"
+
+#: panels/universal-access/zoom-options.ui:925
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ništa"
+
+#: panels/universal-access/zoom-options.ui:957
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Pun"
+
+#: panels/universal-access/zoom-options.ui:1023
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Nizak"
+
+#: panels/universal-access/zoom-options.ui:1056
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Visok"
+
+#: panels/universal-access/zoom-options.ui:1087
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Nizak"
+
+#: panels/universal-access/zoom-options.ui:1120
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Visok"
+
+#: panels/universal-access/zoom-options.ui:1156
+msgid "Color Effects:"
+msgstr "Dejstva boje:"
+
+#: panels/universal-access/zoom-options.ui:1181
+msgid "Color Effects"
+msgstr "Dejstva boje"
+
+#: panels/user-accounts/data/account-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "Dodajte korisnika"
+
+#: panels/user-accounts/data/account-dialog.ui:171
+msgid "_Full Name"
+msgstr "_Ime i prezime"
+
+#: panels/user-accounts/data/account-dialog.ui:197
+#: panels/user-accounts/data/user-accounts-dialog.ui:146
+msgid "Standard"
+msgstr "Standardni"
+
+#: panels/user-accounts/data/account-dialog.ui:207
+#: panels/user-accounts/data/user-accounts-dialog.ui:155
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/data/account-dialog.ui:223
+#: panels/user-accounts/data/user-accounts-dialog.ui:173
+msgid "Account _Type"
+msgstr "_Vrsta naloga"
+
+#: panels/user-accounts/data/account-dialog.ui:260
+msgid "Allow user to set a password when they next _login"
+msgstr "Dozvoli korisniku da podesi _lozinku prilikom sledećeg prijavljivanja"
+
+#: panels/user-accounts/data/account-dialog.ui:274
+msgid "Set a password _now"
+msgstr "Postavi lozinku sa_da"
+
+#: panels/user-accounts/data/account-dialog.ui:387
+msgid "_Confirm"
+msgstr "_Potvrdi"
+
+#: panels/user-accounts/data/account-dialog.ui:463
+#: panels/user-accounts/data/account-dialog.ui:667
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Poslovno prijavljivanje omogućava postojećem centralno upravljanom korisničkom "
+"nalogu da se koristi na ovom uređaju. Takođe možete da koristite ovaj nalog "
+"da pristupite resursima preduzeća na internetu."
+
+#: panels/user-accounts/data/account-dialog.ui:485
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "_Domen"
+
+#: panels/user-accounts/data/account-dialog.ui:707
+msgid "You are Offline"
+msgstr "Van mreže ste"
+
+#: panels/user-accounts/data/account-dialog.ui:726
+msgid "You must be online in order to add enterprise users."
+msgstr "Morate biti na mreži da biste dodali poslovne korisnike."
+
+#: panels/user-accounts/data/account-dialog.ui:760
+msgid "_Enterprise Login"
+msgstr "_Poslovno prijavljivanje"
+
+#: panels/user-accounts/data/account-fingerprint.ui:12
+msgid "Left thumb"
+msgstr "Levi palac"
+
+#: panels/user-accounts/data/account-fingerprint.ui:15
+msgid "Left middle finger"
+msgstr "Srednji, levi prst"
+
+#: panels/user-accounts/data/account-fingerprint.ui:18
+msgid "Left ring finger"
+msgstr "Domali, levi prst"
+
+#: panels/user-accounts/data/account-fingerprint.ui:21
+msgid "Left little finger"
+msgstr "Mali, levi prst"
+
+#: panels/user-accounts/data/account-fingerprint.ui:24
+msgid "Right thumb"
+msgstr "Desni palac"
+
+#: panels/user-accounts/data/account-fingerprint.ui:27
+msgid "Right middle finger"
+msgstr "Desni, srednji prst"
+
+#: panels/user-accounts/data/account-fingerprint.ui:30
+msgid "Right ring finger"
+msgstr "Desni, domali prsti"
+
+#: panels/user-accounts/data/account-fingerprint.ui:33
+msgid "Right little finger"
+msgstr "Desni, mali prst"
+
+#: panels/user-accounts/data/account-fingerprint.ui:39
+#: panels/user-accounts/um-fingerprint-dialog.c:677
+msgid "Enable Fingerprint Login"
+msgstr "Omogući prijavljivanje otiskom prsta"
+
+#: panels/user-accounts/data/account-fingerprint.ui:89
+msgid "_Right index finger"
+msgstr "_Desni kažiprst"
+
+#: panels/user-accounts/data/account-fingerprint.ui:105
+msgid "_Left index finger"
+msgstr "_Levi kažiprst"
+
+#: panels/user-accounts/data/account-fingerprint.ui:126
+msgid "_Other finger:"
+msgstr "_Ostali prsti:"
+
+#: panels/user-accounts/data/account-fingerprint.ui:262
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"Vaš otisak prsta je uspešno sačuvan. Sada se možete prijaviti na sistem "
+"preko čitača otisaka prstiju."
+
+#: panels/user-accounts/data/avatar-chooser.ui:27
+msgid "Take a Picture…"
+msgstr "Snimite sliku…"
+
+#: panels/user-accounts/data/avatar-chooser.ui:34
+msgid "Select a File…"
+msgstr "Izaberite datoteku…"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Korisnici"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Dodajte ili uklonite korisnike i izmenite vašu lozinku"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:7
+msgid "system-users"
+msgstr "system-users"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "prijavljivanje;ime;otisak prstiju;avatar;logo;lice;lozinka;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr "_Upiši"
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "Prijavljivanje administratora domena"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Da biste koristili poslovna prijavljivanja, ovaj računar treba da bude\n"
+"upisan u domenu. Neka administrator vaše mreže ovde upiše lozinku\n"
+"njihovih domena."
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "Ime _administratora"
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "Lozinka administratora"
+
+#: panels/user-accounts/data/password-dialog.ui:7
+msgid "Change Password"
+msgstr "Izmenite lozinku"
+
+#: panels/user-accounts/data/password-dialog.ui:38
+msgid "Ch_ange"
+msgstr "P_romeni"
+
+#: panels/user-accounts/data/password-dialog.ui:142
+msgid "_Verify New Password"
+msgstr "_Potvrdi novu lozinku"
+
+#: panels/user-accounts/data/password-dialog.ui:159
+msgid "_New Password"
+msgstr "_Nova lozinka"
+
+#: panels/user-accounts/data/password-dialog.ui:208
+msgid "Current _Password"
+msgstr "Trenutna _lozinka"
+
+#: panels/user-accounts/data/password-dialog.ui:243
+msgid "Allow user to change their password on next login"
+msgstr "Dozvoli korisniku da izmeni lozinku prilikom sledećeg prijavljivanja"
+
+#: panels/user-accounts/data/password-dialog.ui:256
+msgid "Set a password now"
+msgstr "Postavi lozinku sada"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:20
+msgid "_Add User…"
+msgstr "_Dodaj korisnika…"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:69
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Morate ponovo da pokrenete sesiju kako bi izmene stupile u dejstvo"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:77
+msgid "Restart Now"
+msgstr "Ponovo pokreni sada"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:244
+msgid "A_utomatic Login"
+msgstr "Automatsko _prijavljivanje"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:285
+msgid "_Fingerprint Login"
+msgstr "Prijavljivanje _otiskom prsta"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:311
+#: panels/user-accounts/data/user-accounts-dialog.ui:324
+msgid "User Icon"
+msgstr "Ikonica korisnika"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:387
+msgid "Last Login"
+msgstr "Poslednje prijavljivanje"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:434
+msgid "Remove User…"
+msgstr "Ukloni korisnika…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/data/user-accounts-dialog.ui:466
+msgid "No Users Found"
+msgstr "Nisam našao korisnike"
+
+#: panels/user-accounts/data/user-accounts-dialog.ui:476
+msgid "Unlock to add a user account."
+msgstr "Otključajte da biste dodali korisnički nalog."
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Upravljajte korisničkim nalozima"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Potrebno je potvrđivanje identiteta za promenu korisničkih podataka"
+
+#: panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Nova lozinka treba da se razlikuje od stare."
+
+#: panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Probajte da izmenite neka slova i brojeve."
+
+#: panels/user-accounts/pw-utils.c:85 panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Probajte još samo malo da izmenite lozinku."
+
+#: panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Lozinka bez vašeg korisničkog imena će biti jača."
+
+#: panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Pokušajte da izbegnete vaše ime u lozinki."
+
+#: panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Pokušajte da izbegnete neke od reči upotrebljenih u lozinki."
+
+#: panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Pokušajte da izbegnete uobičajene reči."
+
+#: panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Pokušajte da izbegnete preuređivanje postojećih reči."
+
+#: panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Pokušajte da koristite više brojeva."
+
+#: panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Pokušajte da koristite više velikih slova."
+
+#: panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Pokušajte da koristite više malih slova."
+
+#: panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Pokušajte da koristite više posebnih znakova, kao tačka."
+
+#: panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Pokušajte da koristite mešavinu slova, brojeva i tačaka."
+
+#: panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Pokušajte da izbegnete ponavljanje istog znaka."
+
+#: panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Pokušajte da izbegnete ponavljanje iste vrste znaka: treba da mešate velika "
+"slova, brojeve i tačke."
+
+#: panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Pokušajte da izbegnete nizove 1234 ili abvg."
+
+#: panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Lozinka mora biti duža. Pokušajte da koristite mešavinu slova, brojeva i "
+"tačaka."
+
+#: panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Mešajte velika i mala slova i probajte da koristite jedan ili dva broja."
+
+#: panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Dodavanje još slova, brojeva i tačke će učiniti lozinku još jačom."
+
+#: panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "Potvrđivanje identiteta nije uspelo"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "Nova lozinka je previše kratka"
+
+#: panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "Nova lozinka je previše jednostavna"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Stara i nova lozinka su suviše slične"
+
+#: panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Nova lozinka je već upotrebljavana u skorije vreme."
+
+#: panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Nova lozinka mora da sadrži numeričke ili specijalne znakove"
+
+#: panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Stara i nova lozinka su iste"
+
+#: panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Vaša lozinka je izmenjena od kada ste na početku potvrdili identitet!"
+
+#: panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Nova lozinka ne sadrži dovoljno različitih znakova"
+
+#: panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "Nepoznata greška"
+
+#: panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "Treba da podudari veb adresu vašeg dostavljača prijavljivanja."
+
+#: panels/user-accounts/um-account-dialog.c:229
+msgid "Failed to add account"
+msgstr "Nisam uspeo da dodam nalog"
+
+#: panels/user-accounts/um-account-dialog.c:462
+msgid "Passwords do not match."
+msgstr "Lozinke se ne podudaraju."
+
+#: panels/user-accounts/um-account-dialog.c:717
+#: panels/user-accounts/um-account-dialog.c:763
+#: panels/user-accounts/um-account-dialog.c:784
+msgid "Failed to register account"
+msgstr "Nisam uspeo da upišem nalog"
+
+#: panels/user-accounts/um-account-dialog.c:907
+msgid "No supported way to authenticate with this domain"
+msgstr "Nema podržanog načina za potvrđivanje identiteta sa ovim domenom"
+
+#: panels/user-accounts/um-account-dialog.c:980
+msgid "Failed to join domain"
+msgstr "Nisam uspeo da pristupim domenu"
+
+#: panels/user-accounts/um-account-dialog.c:1041
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Neispravno ime za prijavljivanje.\n"
+"Pokušajte ponovo."
+
+#: panels/user-accounts/um-account-dialog.c:1048
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Neispravna lozinka za prijavljivanje.\n"
+"Pokušajte ponovo."
+
+#: panels/user-accounts/um-account-dialog.c:1056
+msgid "Failed to log into domain"
+msgstr "Nisam uspeo da se prijavim na domen"
+
+#: panels/user-accounts/um-account-dialog.c:1114
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Ne mogu da pronađem domen. Možda ste ga pogrešno napisali?"
+
+#: panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "Standardni"
+
+#: panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "Administrator"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"Nemate dozvole za pristup ovom uređaju. Kontaktirajte vašeg administratora "
+"sistema."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "Uređaj je već u upotrebi."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr "Došlo je do greške unutar programa."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:260
+msgid "Delete registered fingerprints?"
+msgstr "Da obrišem zabeležene otiske prsta?"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:264
+msgid "_Delete Fingerprints"
+msgstr "_Obriši otiske prsta"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:270
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Da li želite da obrišete zabeležene otiske prsta kako bi onemogućili "
+"prijavljivanje putem otiska prsta?"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:440
+msgid "Done!"
+msgstr "Urađeno!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:501
+#: panels/user-accounts/um-fingerprint-dialog.c:543
+#, c-format
+msgid "Could not access “%s” device"
+msgstr "Ne mogu da pristupim uređaju „%s“"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:584
+#, c-format
+msgid "Could not start finger capture on “%s” device"
+msgstr "Ne mogu da uhvatim otisak prsta sa uređaja „%s“"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:628
+msgid "Could not access any fingerprint readers"
+msgstr "Ne mogu da pristupim nijednom čitaču otisaka prstiju"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:629
+msgid "Please contact your system administrator for help."
+msgstr "Javite se administratoru sistema za pomoć."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: panels/user-accounts/um-fingerprint-dialog.c:711
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the “%s” device."
+msgstr ""
+"Morate sačuvati jedan od vaših otisaka prsta sa uređaja „%s“, kako bi "
+"omogućili prijavu na sistem otiskom prsta."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:718
+msgid "Selecting finger"
+msgstr "Biram prst"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:719
+msgid "Enrolling fingerprints"
+msgstr "Upisujem otiske prstiju"
+
+#: panels/user-accounts/um-history-dialog.c:70
+msgid "This Week"
+msgstr "Ove sedmice"
+
+#: panels/user-accounts/um-history-dialog.c:73
+msgid "Last Week"
+msgstr "Prošle sedmice"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/um-history-dialog.c:79
+#: panels/user-accounts/um-history-dialog.c:83
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e. %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/um-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e. %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/um-history-dialog.c:93
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/um-history-dialog.c:177
+#: panels/user-accounts/um-user-panel.c:767
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/um-history-dialog.c:180
+#: panels/user-accounts/um-user-panel.c:771
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/um-history-dialog.c:250
+msgid "Session Ended"
+msgstr "Kraj sesije"
+
+#: panels/user-accounts/um-history-dialog.c:256
+msgid "Session Started"
+msgstr "Početak sesije"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/um-history-dialog.c:299
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Aktivnost naloga"
+
+#: panels/user-accounts/um-password-dialog.c:144
+msgid "Please choose another password."
+msgstr "Izaberite drugu lozinku."
+
+#: panels/user-accounts/um-password-dialog.c:153
+msgid "Please type your current password again."
+msgstr "Unesite vašu trenutnu lozinku ponovo."
+
+#: panels/user-accounts/um-password-dialog.c:159
+msgid "Password could not be changed"
+msgstr "Lozinka ne može biti promenjena"
+
+#: panels/user-accounts/um-password-dialog.c:285
+msgid "The passwords do not match."
+msgstr "Lozinke se ne podudaraju."
+
+#: panels/user-accounts/um-photo-dialog.c:226
+msgid "Browse for more pictures"
+msgstr "Potražite još slika"
+
+#: panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "Ne mogu sam da pristupim ovoj vrsti domena"
+
+#: panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "Nije pronađen takav domen ili područje"
+
+#: panels/user-accounts/um-realm-manager.c:815
+#: panels/user-accounts/um-realm-manager.c:829
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Ne mogu da se prijavim kao „%s“ na domenu %s"
+
+#: panels/user-accounts/um-realm-manager.c:821
+msgid "Invalid password, please try again"
+msgstr "Neispravna lozinka, pokušajte ponovo"
+
+#: panels/user-accounts/um-realm-manager.c:834
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Ne mogu da se povežem na domen „%s“: %s"
+
+#: panels/user-accounts/um-user-panel.c:201
+msgid "Your account"
+msgstr "Vaš nalog"
+
+#: panels/user-accounts/um-user-panel.c:381
+msgid "Failed to delete user"
+msgstr "Nisam uspeo da izbrišem korisnika"
+
+#: panels/user-accounts/um-user-panel.c:439
+#: panels/user-accounts/um-user-panel.c:498
+#: panels/user-accounts/um-user-panel.c:550
+msgid "Failed to revoke remotely managed user"
+msgstr "Nisam uspeo da opozovem daljinski upravljanog korisnika"
+
+#: panels/user-accounts/um-user-panel.c:604
+msgid "You cannot delete your own account."
+msgstr "Ne možete obrisati vaš lični nalog."
+
+#: panels/user-accounts/um-user-panel.c:613
+#, c-format
+msgid "%s is still logged in"
+msgstr "„%s“ je i dalje prijavljen"
+
+#: panels/user-accounts/um-user-panel.c:617
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Brisanje korisnika dok su prijavljeni može da ostavi sistem u neusklađenom "
+"stanju."
+
+#: panels/user-accounts/um-user-panel.c:626
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Da li želite da sačuvate datoteke korisnika „%s“?"
+
+#: panels/user-accounts/um-user-panel.c:630
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Moguće je zadržati ličnu fasciklu, skladišta pošte i privremene datoteke "
+"prilikom brisanja korisničkog naloga."
+
+#: panels/user-accounts/um-user-panel.c:633
+msgid "_Delete Files"
+msgstr "_Obriši datoteke"
+
+#: panels/user-accounts/um-user-panel.c:634
+msgid "_Keep Files"
+msgstr "_Zadrži datoteke"
+
+#: panels/user-accounts/um-user-panel.c:648
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Da li sigurno želite da opozovete daljinski upravljani nalog korisnika „%s“?"
+
+#: panels/user-accounts/um-user-panel.c:652
+msgid "_Delete"
+msgstr "_Obriši"
+
+#: panels/user-accounts/um-user-panel.c:702
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Nalog je isključen"
+
+#: panels/user-accounts/um-user-panel.c:710
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Za podešavanje prilikom narednog prijavljivanja"
+
+#: panels/user-accounts/um-user-panel.c:713
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ništa"
+
+#: panels/user-accounts/um-user-panel.c:760
+msgid "Logged in"
+msgstr "Prijavljen sam"
+
+#: panels/user-accounts/um-user-panel.c:1107
+msgid "Failed to contact the accounts service"
+msgstr "Nisam uspeo da kontaktiram uslugu naloga"
+
+#: panels/user-accounts/um-user-panel.c:1109
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Molim proverite da li je Usluga naloga instalirana i uključena."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/um-user-panel.c:1141
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Da napravite izmene,\n"
+"kliknite prvo na ikonicu *"
+
+#: panels/user-accounts/um-user-panel.c:1181
+msgid "Create a user account"
+msgstr "Napravite korisnički nalog"
+
+#: panels/user-accounts/um-user-panel.c:1192
+#: panels/user-accounts/um-user-panel.c:1371
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Da napravite korisnički nalog,\n"
+"kliknite prvo na ikonicu *"
+
+#: panels/user-accounts/um-user-panel.c:1202
+msgid "Delete the selected user account"
+msgstr "Obrišite izabrani korisnički nalog"
+
+#: panels/user-accounts/um-user-panel.c:1214
+#: panels/user-accounts/um-user-panel.c:1376
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Da obrišete izabrani korisnički nalog,\n"
+"kliknite prvo na ikonicu *"
+
+#: panels/user-accounts/um-utils.c:496
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Izvinite, ali to korisničko ime nije dostupno. Probajte neko drugo."
+
+#: panels/user-accounts/um-utils.c:499
+#, c-format
+msgid "The username is too long."
+msgstr "Korisničko ime je predugo."
+
+#: panels/user-accounts/um-utils.c:502
+msgid "The username cannot start with a “-”."
+msgstr "Korisničko ime ne može početi sa „-“."
+
+#: panels/user-accounts/um-utils.c:505
+msgid ""
+"The username should only consist of upper and lower case letters from a-z, "
+"digits and the following characters: . - _"
+msgstr ""
+"Korisničko ime treba da sadrži samo velika i mala slova latinskog alfabeta "
+"od a-z, cifre i sledeće znakove: . - _"
+
+#: panels/user-accounts/um-utils.c:509
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr ""
+"Biće korišćeno za imenovanje vaše lične fascikle i ne može biti izmenjeno."
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr "Mapiraj dugmad"
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:547
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "_Zatvori"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr "Mapirajte dugmad prema funkcijama"
+
+#: panels/wacom/button-mapping.ui:119
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Da izmenite prečicu, izaberite radnju „Pošalji otkucaj tastera“, pritisnite "
+"dugme prečice tastature i držite pritisnutim nove tastere ili pritisnite "
+"„Povratnicu“ da obrišete prečicu."
+
+#: panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Molim lupnite znake mete koji će se pojaviti na ekranu da kalibrišete "
+"tablicu."
+
+#: panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting…"
+msgstr "Otkriven je loš klik, počinjem iz početka…"
+
+#: panels/wacom/cc-wacom-button-row.c:266
+#, c-format
+msgid "Button %d"
+msgstr "Dugme %d"
+
+#: panels/wacom/cc-wacom-button-row.h:53
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Program je definisan"
+
+#: panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Pošalji otkucaj tastera"
+
+#: panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Promeni monitor"
+
+#: panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Prikaži pomoć na ekranu"
+
+#: panels/wacom/cc-wacom-mapping-panel.c:260
+msgid "Output:"
+msgstr "Izlaz:"
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:272
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Zadrži odnos razmere (crne trake):"
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:283
+msgid "Map to single monitor"
+msgstr "Mapiraj na jednom monitoru"
+
+#: panels/wacom/cc-wacom-nav-button.c:86
+#, c-format
+msgid "%d of %d"
+msgstr "%d od %d"
+
+#: panels/wacom/cc-wacom-page.c:544
+msgid "Display Mapping"
+msgstr "Prikazuje mapiranje"
+
+#: panels/wacom/cc-wacom-panel.c:790 panels/wacom/wacom-stylus-page.ui:127
+msgid "Stylus"
+msgstr "Penkalo"
+
+#: panels/wacom/cc-wacom-stylus-page.c:362
+msgid "Button"
+msgstr "Dugme"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:198
+msgid "Wacom Tablet"
+msgstr "Vakom tablica"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"podesite mapiranje dugmeta i podesite osetljivost olovke grafičkih tablica"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:7
+msgid "input-tablet"
+msgstr "input-tablet"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "tablica;vakom;penkalo;brisač;miš;"
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr "Tablica (apsolutno)"
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr "Dodirna tabla (relativno)"
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr "Postavke tablice"
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "Po_moć"
+
+#: panels/wacom/gnome-wacom-properties.ui:123
+msgid "No tablet detected"
+msgstr "Tablica nije otkrivena"
+
+#: panels/wacom/gnome-wacom-properties.ui:139
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Molim priključite ili upalite vašu Vakom tablicu"
+
+#: panels/wacom/gnome-wacom-properties.ui:159
+msgid "Bluetooth Settings"
+msgstr "Podešavanja Blututa"
+
+#: panels/wacom/gnome-wacom-properties.ui:231
+msgid "Map to Monitor…"
+msgstr "Mapiraj monitor…"
+
+#: panels/wacom/gnome-wacom-properties.ui:247
+msgid "Map Buttons…"
+msgstr "Mapiraj dugmad…"
+
+#: panels/wacom/gnome-wacom-properties.ui:263
+msgid "Calibrate…"
+msgstr "Podesi…"
+
+#: panels/wacom/gnome-wacom-properties.ui:284
+msgid "Adjust display resolution"
+msgstr "Podesite rezoluciju prikaza"
+
+#: panels/wacom/gnome-wacom-properties.ui:300
+msgid "Adjust mouse settings"
+msgstr "Doterajte podešavanja miša"
+
+#: panels/wacom/gnome-wacom-properties.ui:328
+msgid "Tracking Mode"
+msgstr "Režim praćenja"
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Left-Handed Orientation"
+msgstr "Levoruko usmerenje"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "Nova prečica…"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr "Klik srednjeg dugmeta miša"
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr "Klik desnog dugmeta miša"
+
+#: panels/wacom/wacom-stylus-page.ui:37
+msgid "Back"
+msgstr "Nazad"
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "Napred"
+
+#: panels/wacom/wacom-stylus-page.ui:77
+msgid "No stylus found"
+msgstr "Nisam našao olovku"
+
+#: panels/wacom/wacom-stylus-page.ui:91
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr "Približite vašu olovku tabličnom uređaju da ga podesite"
+
+#: panels/wacom/wacom-stylus-page.ui:167
+msgid "Eraser Pressure Feel"
+msgstr "Osećaj pritiska brisača"
+
+#: panels/wacom/wacom-stylus-page.ui:188 panels/wacom/wacom-stylus-page.ui:348
+msgid "Soft"
+msgstr "Umekšan"
+
+#: panels/wacom/wacom-stylus-page.ui:218 panels/wacom/wacom-stylus-page.ui:378
+msgid "Firm"
+msgstr "Stojeće"
+
+#: panels/wacom/wacom-stylus-page.ui:241
+msgid "Top Button"
+msgstr "Gornje dugme"
+
+#: panels/wacom/wacom-stylus-page.ui:270
+msgid "Lower Button"
+msgstr "Donje dugme"
+
+#: panels/wacom/wacom-stylus-page.ui:299
+msgid "Lowest Button"
+msgstr "Najniže dugme"
+
+#: panels/wacom/wacom-stylus-page.ui:328
+msgid "Tip Pressure Feel"
+msgstr "Osećaj pritiska saveta"
+
+#: panels/wacom/wacom-stylus-page.ui:440
+msgid "page 3"
+msgstr "strana 3"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+msgid "GNOME Control Center"
+msgstr "Gnomov Upravljački Centar"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+msgid "Utilities to configure the GNOME desktop"
+msgstr "Alatke za podešavanje Gnom radnog okruženja"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid ""
+"The control center is GNOME’s main interface for configuration of various "
+"aspects of your desktop."
+msgstr ""
+"Upravljački centar je glavno Gnomovo sučelje za podešavanje različitih delova "
+"vašeg sistema."
+
+#: shell/cc-application.c:47
+msgid "Display version number"
+msgstr "Broj izdanja prikaza"
+
+#: shell/cc-application.c:48
+msgid "Enable verbose mode"
+msgstr "Uključuje režim ispisivanja"
+
+#: shell/cc-application.c:49
+msgid "Show the overview"
+msgstr "Prikazuje pregled"
+
+#: shell/cc-application.c:50
+msgid "Search for the string"
+msgstr "Traži nisku"
+
+#: shell/cc-application.c:51
+msgid "List possible panel names and exit"
+msgstr "Ispisuje moguće nazive panela i izlazi"
+
+#: shell/cc-application.c:52
+msgid "Panel to display"
+msgstr "Panel za prikaz"
+
+#: shell/cc-application.c:52
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-application.c:117
+msgid "Available panels:"
+msgstr "Dostupni paneli:"
+
+#: shell/cc-application.c:256
+msgid "Help"
+msgstr "Pomoć"
+
+#: shell/cc-application.c:257
+msgid "Quit"
+msgstr "Izađi"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: shell/gnome-control-center.desktop.in.in:5
+msgid "gnome-control-center"
+msgstr "gnome-control-center"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "postavke;podešavanja;"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Opšte"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Izlazak"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Pretraga"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Površi"
+
+#: shell/help-overlay.ui:40
+msgctxt "shortcut window"
+msgid "Go back to the overview"
+msgstr "Idi nazad na pregled"
+
+#: shell/help-overlay.ui:53
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Otkaži pretragu"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: shell/hostname-helper.c:189
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Vruća tačka"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Identifikator poslednjeg otvorenog panela Podešavanja "
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Identifikator poslednjeg otvorenog panela Podešavanja. Vrednosti koje nisu "
+"prepoznate će biti prekočene i prvi panel iz spiska će biti odabran."
+
+#: shell/panel-list.ui:195
+msgid "No results found"
+msgstr "Nisam našao rezultate"
+
+#: shell/window.ui:141
+msgid "All Settings"
+msgstr "Sva podešavanja"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1873
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u izlaz"
+msgstr[1] "%u izlaza"
+msgstr[2] "%u izlaza"
+msgstr[3] "Jedan izlaz"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1883
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ulaz"
+msgstr[1] "%u ulaza"
+msgstr[2] "%u ulaza"
+msgstr[3] "Jedan ulaz"
+
+#: subprojects/gvc/gvc-mixer-control.c:2738
+msgid "System Sounds"
+msgstr "Sistemski zvuci"
+
+#~ msgid "Back­ground"
+#~ msgstr "Pozadina"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blutut"
+
+#~ msgid "Co­lor"
+#~ msgstr "Boja"
+
+#~ msgid "Section"
+#~ msgstr "Odeljak"
+
+#~ msgid "Overview"
+#~ msgstr "Pregled"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Osnovni programi"
+
+#~ msgid "Ab­out"
+#~ msgstr "Opis"
+
+#~ msgid "De­tails"
+#~ msgstr "Pojedinosti"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Prenosni mediji"
+
+#~ msgctxt "keybinding"
+#~ msgid "Search"
+#~ msgstr "Pretraga"
+
+#~ msgid "Net­work"
+#~ msgstr "Mreža"
+
+#~ msgid "invalid EAP-TLS password: missing"
+#~ msgstr "neispravna EAP-TLS LOZINKA: nedostaje"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Obaveštenja"
+
+#~ msgid "Po­wer"
+#~ msgstr "Napajanje"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Privatnost"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Deljenje"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Univerzalni pristup"
+
+#~ msgid "Disable image"
+#~ msgstr "Isključi sliku"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Potražite još slika…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Koristi je „%s“"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Vakom tablica"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Lično"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Uređaji"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Sistem"
+
+#~| msgid "_Apply"
+#~ msgid "Apply"
+#~ msgstr "Primeni"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Spušten poklopac"
+
+#~ msgid "Mirrored"
+#~ msgstr "Preslikano"
+
+#~ msgid "Primary"
+#~ msgstr "Glavni"
+
+#~ msgid "Secondary"
+#~ msgstr "Sporedni"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Rasporedite objedinjene prikaze"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Prevucite prikaze da ih prerasporedite"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d herca (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d herca"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Suprotno smeru kazaljke na satu za 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Zaokreni za 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "U smeru kazaljke na satu za 90°"
+
+#~ msgid "Size"
+#~ msgstr "Veličina"
+
+#~ msgid "Aspect Ratio"
+#~ msgstr "Razmera"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Prikaži gornju traku i pregled aktivnosti na ovom prikazu"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Pridružite ovaj prikaz sa drugim da napravite dodatni radni prostor"
+
+#~ msgid "Presentation"
+#~ msgstr "Izlaganje"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Prikažite samo pokretne prikaze i medije"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Prikažite vaš postojeći pregled na oba prikaza"
+
+#~ msgid "Turn Off"
+#~ msgstr "Isključi"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Ne koristi ovaj prikaz"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Rasporedi objedinjene prikaze"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bita (IB izgradnje: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d bita"
+
+#~ msgid "Base system"
+#~ msgstr "Osnovni sistem"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "prečica;ponovi;trepni;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Pritisni Esc da otkažete."
+
+#~ msgid "Server"
+#~ msgstr "Server"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Obriši DNS server"
+
+#~ msgid "Reset"
+#~ msgstr "Ponovo postavi"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Učini dostupno drugim _korisnicima"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Oblast _mrežne barijere"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Osnovno"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Oblast određuje nivo poverenja veze"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Ponovo postavi podešavanja za ovu mrežu, uključujući lozinke, ali je "
+#~ "zapamti kao željenu mrežu"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Ukloni sve podatke koji se odnose na ovu mrežu i nemoj pokušati da se sam "
+#~ "povežeš"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Ako imate neku drugu vezu na Internet osim bežične, možete da podesite "
+#~ "bežičnu vruću tačku da delite vezu sa drugima."
+
+#~ msgid "History"
+#~ msgstr "Istorijat"
+
+#~ msgid "Proxy"
+#~ msgstr "Posrednik"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Dodaj profil…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Ništa"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Ručno"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatski"
+
+#~ msgid "Add Device"
+#~ msgstr "Dodaj uređaj"
+
+#~ msgid "Remove Device"
+#~ msgstr "Ukloni uređaj"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN vrsta"
+
+#~ msgid "Group Name"
+#~ msgstr "Naziv grupe"
+
+#~ msgid "Group Password"
+#~ msgstr "Lozinka grupe"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Koristi kao vruću tačku…"
+
+#~ msgid "_History"
+#~ msgstr "_Istorijat"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "Loading options…"
+#~ msgstr "Učitavam opcije…"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Pokušajte da dodate još slova, brojeva i simbola."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Jačina: slaba"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Jačina: solidna"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Jačina: osrednja"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Jačina: dobra"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Jačina: odlična"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Vaš nalog</small>"
+
+#~ msgid "Wayland"
+#~ msgstr "Vejland"
+
+#~ msgid "Edit"
+#~ msgstr "Uredi"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Vrpce obaveštenja"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Vrpce o_baveštenja"
+
+#~ msgid "Add Account"
+#~ msgstr "Dodaj nalog"
+
+#~ msgid "Mail"
+#~ msgstr "El. pošta"
+
+#~ msgid "Calendar"
+#~ msgstr "Kalendar"
+
+#~ msgid "Contacts"
+#~ msgstr "Kontakti"
+
+#~ msgid "Chat"
+#~ msgstr "Ćaskanje"
+
+#~ msgid "Resources"
+#~ msgstr "Izvorišta"
+
+#~ msgid "Error creating account"
+#~ msgstr "Greška u stvaranju naloga"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Da li ste sigurni da želite da uklonite nalog?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Ovo neće ukloniti nalog na serveru."
+
+#~ msgid "_Remove"
+#~ msgstr "_Ukloni"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Nisu podešeni nalozi na mreži"
+
+#~ msgid "Add an online account"
+#~ msgstr "Dodajte nalog na mreži"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Dodavanje naloga omogućava vašim aplikacijama da mu pristupe zbog "
+#~ "dokumenata, pošte, kontakata, kalendara, ćaskanja i drugih stvari."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Podešavam"
+
+#~ msgid "Toner Level"
+#~ msgstr "Nivo tonera"
+
+#~ msgid "Supply Level"
+#~ msgstr "Nivo zaliha"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Instaliram"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u pokrenut"
+#~ msgstr[1] "%u pokrenuta"
+#~ msgstr[2] "%u pokrenutih"
+#~ msgstr[3] "Jedan pokrenut"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Dodaj novi štampač"
+
+#~ msgid "No printers detected."
+#~ msgstr "Nema otkrivenih štampača."
+
+#~ msgid "Supply"
+#~ msgstr "Zalihe"
+
+#~ msgid "_Default printer"
+#~ msgstr "Osnovni _štampač"
+
+#~ msgid "Jobs"
+#~ msgstr "Poslovi"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Prikaži _poslove"
+
+#~ msgid "label"
+#~ msgstr "natpis"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "Podešavam novi upravljački program…"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Odštampaj _probnu stranicu"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s — %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Ostali nalozi"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Gore"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Dole"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Ništa"
+
+#~ msgid "Left Ring"
+#~ msgstr "Levi prsten"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Režim levog prstena #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Režim desnog prstena #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Leva dodirna traka"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Režim leve dodirne trake #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Desna dodirna traka"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Režim desne dodirne trake #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Režim prekidača levog dodirnog prstena"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Režim prekidača desnog dodirnog prstena"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Režim prekidača leve dodirne trake"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Režim prekidača desne dodirne trake"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Režim prekidača #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Levo dugme #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Desno dugme #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Gornje dugme #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Donje dugme #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Bez radnje"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Klik levog dugmeta miša"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Klizaj na gore"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Klizaj na dole"
+
+#~ msgid "Scroll Left"
+#~ msgstr "Klizaj levo"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Klizaj desno"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr "Prečica tastature za <b>%s</b>. Unesite novu prečicu da izemnite."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Da izmenite prečicu, kliknite na odgovarajući red i ukucajte novu "
+#~ "kombinaciju tastera ili pritisnite „Backspace“ da obrišete prečicu."
+
+#~ msgid "_Name:"
+#~ msgstr "_Naziv:"
+
+#~ msgid "Add Shortcut"
+#~ msgstr "Dodaj prečicu"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Ukloni prečicu"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Nepoznata radnja>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Prečica „%s“ ne može biti korišćena jer će biti nemoguće kucati koristeći "
+#~ "ovaj taster.\n"
+#~ "Probajte da pridodate taster kao što je „Ctrl, Alt ili Šift“."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Prečica „%s“ se već koristi za\n"
+#~ "„%s“"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "Ukoliko dodelite prečicu za „%s“, prečica „%s“ će biti isključena."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Ponovo dodeli"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "„%s“ prečica ima pridruženu „%s“ prečicu. Da li želite da je samostalno "
+#~ "podesite na „%s“?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "„%s“ je trenutno pridružena sa „%s“, ova prečica će biti isključena ako "
+#~ "nastavite."
+
+#~ msgid "_Assign"
+#~ msgstr "_Dodeli"
+
+#~ msgid "Bond"
+#~ msgstr "Veza"
+
+#~ msgid "Team"
+#~ msgstr "Ekipa"
+
+#~ msgid "Bridge"
+#~ msgstr "Most"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Ne mogu da učitam VPN priključke"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Dodavanje mrežne veze"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Podanici sveze"
+
+#~ msgid "(none)"
+#~ msgstr "(ništa)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Podanici mosta"
+
+#~ msgid "Team slaves"
+#~ msgstr "Podanici tima"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "Infiniband uređaji ne podržavaju povezani režim"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Nije izabrano uverenje izdavača ovlašćenja"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Ukoliko ne izaberete uverenje izdavača ovlašćenja (CA) vaša bežična veza "
+#~ "može biti nesigurna ili lažna.  Da li želite da izaberete uverenje?"
+
+#~ msgid "Ignore"
+#~ msgstr "Zanemari"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Izaberite CA uverenje"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Uvek zatraži _lozinku"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Ne _upozoravaj me više"
+
+#~ msgid "No"
+#~ msgstr "Ne"
+
+#~ msgid "Yes"
+#~ msgstr "Da"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Greška prijavljivanja na nalog"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Punomoćstva su istekla."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Učlanite se da uključi ovaj nalog."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Učlani me"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Drugo"
+
+#~ msgid "Personal File Sharing"
+#~ msgstr "Deljenje ličnih datoteka"
+
+#~ msgid "_Allow Remote Control"
+#~ msgstr "Dozvoli ud_aljeno upravljanje"
+
+#~ msgid "_Verify"
+#~ msgstr "_Potvrdi"
+
+#~ msgid "Login History"
+#~ msgstr "Istorijat prijavljivanja"
+
+#~ msgid "Add User Account"
+#~ msgstr "Dodaj korisnički nalog"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Korisnik sa korisničkim imenom „%s“ već postoji."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Koristi se za određivanje vašeg geografskog položaja"
+
+#~ msgid "Done"
+#~ msgstr "Obavljeno"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Vremenska _zona"
+
+#~ msgid "Close"
+#~ msgstr "Zatvori"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Nastavi štampanje"
+
+# ranije je bilo „saveti“, ali možda je bolje „hintovi“
+#~ msgid "Pause Printing"
+#~ msgstr "Pauziraj štampanje"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Zadržan"
+
+#~ msgid "Job Title"
+#~ msgstr "Naziv posla"
+
+#~ msgid "Job State"
+#~ msgstr "Stanje posla"
+
+#~ msgid "Time"
+#~ msgstr "Vreme"
+
+#~ msgid "Options"
+#~ msgstr "Mogućnosti"
+
+#~ msgid "Password:"
+#~ msgstr "Lozinka:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "Po_navljanje tastera"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "Tr_eptanje pokazivača"
+
+#~ msgid "Zoom"
+#~ msgstr "Uvećano"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Boja"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Zastoj:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Kratak"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Mala"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Veliki"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Velika"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Brzina:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Isprobajte vaša podešavanja"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Mala"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Velika"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Levo"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Desno"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Brzina pokazivača"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Mala"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Velika"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Mala"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Velika"
+
+#~ msgid "No printers available"
+#~ msgstr "Nema dostupnih štampača"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Dodaj novi štampač"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "Blutut je isključen"
+
+#~ msgid "Security key"
+#~ msgstr "Ključ bezbednosti"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Bežični uređaji zahtevaju dodatno napajanje"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Kad je napajanje baterije _kritično"
+
+#~ msgid "Power off"
+#~ msgstr "Isključi"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Deljenje blututa vam omogućava da delite datoteke sa drugim uključenim "
+#~ "blutut uređajima"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Samo primaj sa poverljivih uređaja"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Sačuvaj primljene datoteke u fasciklu preuzimanja"
+
+#~ msgid "Show help options"
+#~ msgstr "Prikazuje opcije za pomoć"
+
+#~ msgid "- Settings"
+#~ msgstr "— Podešavanja"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Pokrenite „%s --help“ da ​​vidite potpun spisak dostupnih opcija linije "
+#~ "naredbi.\n"
+
+#~ msgid "United States"
+#~ msgstr "Sjedinjene Američke Države"
+
+#~ msgid "Germany"
+#~ msgstr "Nemačka"
+
+#~ msgid "France"
+#~ msgstr "Francuska"
+
+#~ msgid "Spain"
+#~ msgstr "Španija"
+
+#~ msgid "China"
+#~ msgstr "Kina"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Isključi dok _kucam"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Mrežni servis na sistemu nije podržan u ovoj verziji."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Prikaži iskačuće vrpce"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Pregledaj u ekranu zaključavanja"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Prikaži iskačuće vrpce"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "Prikaži u ekranu zaključavanja"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Isključite bežične uređaje"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Potražite štampače na mreži ili izdvojte rezultate"
+
+#~ msgid "Sorry"
+#~ msgstr "Izvinite"
+
+#~ msgid "Immediately"
+#~ msgstr "Odmah"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Deli medije na ovoj mreži"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Deljene fascikle"
+
+#~ msgid "column"
+#~ msgstr "kolona"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Ukloni fasciklu"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Deli javnu fasciklu na ovoj mreži"
+
+#~ msgid "Flickr"
+#~ msgstr "Flikr"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Podesi novi uređaj"
+
+#~ msgid "Paired"
+#~ msgstr "Uparen"
+
+#~ msgid "Type"
+#~ msgstr "Vrsta"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Podešavanja miša i dodirne table"
+
+#~ msgid "Sound Settings"
+#~ msgstr "Podešavanja zvuka"
+
+#~ msgid "Send Files…"
+#~ msgstr "Pošalji datoteke…"
+
+#~ msgid "Visibility"
+#~ msgstr "Vidljivost"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Vidljivost za „%s“"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "Da uklonim „%s“ sa spiska uređaja?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Ukoliko uklonite uređaj, moraćete ponovo da ga podesite pre sledećeg "
+#~ "korišćenja."
+
+#~ msgid "Export"
+#~ msgstr "Izvezi"
+
+#~ msgid "Device type:"
+#~ msgstr "Vrsta uređaja:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Proizvođač:"
+
+#~ msgid "Model:"
+#~ msgstr "Model:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Datoteke slika mogu biti prevučene na ovaj prozor da automatski dopune "
+#~ "odgovarajuća polja."
+
+#~ msgid "Left Shift"
+#~ msgstr "Levi šift"
+
+#~ msgid "Left Alt"
+#~ msgstr "Levi alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "Levi ktrl"
+
+#~ msgid "Right Shift"
+#~ msgstr "Desni šift"
+
+#~ msgid "Right Alt"
+#~ msgstr "Desni alt"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Desni ktrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Levi alt+šift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Levi ktrl+šift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Desni ktrl+šift"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+šift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ktrl+šift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+ktrl"
+
+#~ msgid "Caps"
+#~ msgstr "Velika/mala slova"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Šift+velika/mala slova"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+velika/mala slova"
+
+#~ msgid "_Region:"
+#~ msgstr "_Region:"
+
+#~ msgid "_City:"
+#~ msgstr "_Grad:"
+
+#~ msgid "_Network Time"
+#~ msgstr "_Mrežno vreme"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Podesi vreme jedan sat unapred."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Podesi vreme jedan sat unazad."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Podesi vreme jedan minut unapred."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Podesi vreme jedan minut unazad."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Prebaci između PrP i PoP."
+
+#~ msgid "AM/PM"
+#~ msgstr "PrP/PoP"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Normalno"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "U smeru kazaljke na satu"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 stepeni"
+
+#~ msgid "Monitor"
+#~ msgstr "Ekran"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "Prevucite da promenite primarnu prikaz."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Izaberite ekran da izmenite podešavanja; prevucite ekrane da im promenite "
+#~ "redosled."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Ne mogu da sačuvam podešavanja za ekran"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "Ne mogu da nađem ekrane"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Rezolucija"
+
+#~ msgid "R_otation"
+#~ msgstr "_Okrenutost"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Kloniraj ekrane"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Napomena: može da ograniči opcije rezolucije"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "_Očitaj ekrane"
+
+#~ msgid "Install Updates"
+#~ msgstr "Instaliraj ažuriranja"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Ažuriranja sistema"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Podešavanja miša"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "Mala"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "Velika"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "Sadržaj se _lepi za prste"
+
+#~ msgid "_Options…"
+#~ msgstr "_Opcije…"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Izaberite sučelje za novi servis"
+
+#~ msgid "C_reate…"
+#~ msgstr "_Napravi…"
+
+#~ msgid "_Interface"
+#~ msgstr "Su_čelje"
+
+#~ msgid "_Default"
+#~ msgstr "_Podrazumevano"
+
+#~ msgid "Hidden"
+#~ msgstr "Skriven"
+
+#~ msgid "Visible"
+#~ msgstr "Vidljiv"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "Naziv i vidljivost"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "Upravljajte time kako izgledate na ekranu i na mreži."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "Prikaži _puno ime na gornjoj traci"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "Prikaži puno ime u ekranu _zaključavanja"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "_Potajni režim"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Ništa"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Deli javnu fasciklu"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Samo deli sa poverljivim uređajima"
+
+#~ msgid "Remote View"
+#~ msgstr "Udaljeni pregled"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Odobri sve veze"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Normalan"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Visok/Obrnut"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Tastatura na ekranu"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Normalan"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Zapišti pri zaključavanju velikih slova i brojeva"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "Uključi/isključi:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Uvećanje"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Uvećaj:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Umanji:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "Zatvoreno hvatanje"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Prikaži tekstualni opis govora i zvukova"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "Kratak"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "Dug"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Zapišti kada je taster"
+
+#~ msgid "pressed"
+#~ msgstr "pritisnut"
+
+#~ msgid "accepted"
+#~ msgstr "prihvaćen"
+
+#~ msgid "rejected"
+#~ msgstr "odbijen"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "Zastoj _prihvatanja:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Kontroliši pokazivač koristeći tastaturu"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Video miš"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Kontroliši pokazivač koristeći video kameru."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "Mala"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "Velika"
+
+#~ msgid "_Local Account"
+#~ msgstr "_Mesni nalog"
+
+#~ msgid "_Login Name"
+#~ msgstr "_Prijavno ime"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "Savet: Poslovni domen ili naziv područja"
+
+#~ msgid "C_ontinue"
+#~ msgstr "_Nastavi"
+
+#~ msgid "Previous Week"
+#~ msgstr "Prethodna sedmica"
+
+#~ msgid "Next Week"
+#~ msgstr "Sledeća sedmica"
+
+#~ msgid "Next week"
+#~ msgstr "Sledeća sedmica"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Prijavi se bez lozinke"
+
+#~ msgid "Disable this account"
+#~ msgstr "Isključi ovaj nalog"
+
+#~ msgid "Enable this account"
+#~ msgstr "Uključi ovaj nalog"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "P_otvrdi lozinku"
+
+#~ msgid "Generate a password"
+#~ msgstr "Stvorite lozinku"
+
+#~ msgid "_Action"
+#~ msgstr "_Radnja"
+
+#~ msgid "_Show password"
+#~ msgstr "Pr_ikaži lozinku"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Kako izabrati jaku lozinku"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Menjam fotografiju za:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Izaberite sliku koja će biti prikazana na ekranu za prijavljivanje za ovaj "
+#~ "nalog."
+
+#~ msgid "Gallery"
+#~ msgstr "Zbirka"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Snimite fotografiju"
+
+#~ msgid "Browse"
+#~ msgstr "Razgledaj"
+
+#~ msgid "Photograph"
+#~ msgstr "Fotografija"
+
+#~ msgid "Account Information"
+#~ msgstr "Podaci o nalogu"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Prekratka"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "Nije dovoljno dobra"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Slaba"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Solidna"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Dobra"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Jaka"
+
+#~ msgid "_Generate a password"
+#~ msgstr "Stvori _lozinku"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "Morate da unesete novu lozinku"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "Nova lozinka nije dovoljno jaka"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "Morate da potvrdite lozinku"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "Morate da unesete vašu trenutnu lozinku"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "Trenutna lozinka nije tačna"
+
+#~ msgid "Switch Modes"
+#~ msgstr "Režimi prebacivanja"
+
+#~ msgid "Action"
+#~ msgstr "Radnja"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Desni alt+šift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Levi+desni šift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Levi+desni ktrl"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ktrl+velika/mala slova"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "Procenjeni kapacitet baterije: %s"

--- a/po/sv.po
+++ b/po/sv.po
@@ -15,9 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-03 00:34+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-09-11 15:13+0200\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -28,99 +27,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Systembuss"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Fullständig åtkomst"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Sessionsbuss"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Enheter"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Fullständig åtkomst till /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Nätverk"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Har nätverksåtkomst"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Hem"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Skrivskyddat"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Filsystem"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Inställningar"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Kan ändra inställningar"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s har följande inbyggda behörigheter. Dessa kan inte ändras. Om du är "
-"bekymrad över dessa behörigheter bör du överväga att ta bort detta program."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u fil- och länktyp som öppnas av programmet"
-msgstr[1] "%u fil- och länktyper som öppnas av programmet"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> används för att öppna följande typer av filer och länkar."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s diskutrymme används."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -136,7 +43,6 @@ msgid "Install some…"
 msgstr "Installera några…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Öppna"
 
@@ -160,24 +66,13 @@ msgstr "Sök"
 msgid "Receive system searches and send results."
 msgstr "Ta emot systemsökningar och skicka resultat."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Inaktiverad"
 
@@ -342,80 +237,20 @@ msgstr "Töm cache…"
 msgid "Control various application permissions and settings"
 msgstr "Styr diverse behörigheter och inställningar för program"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "program;flatpak;rättighet;behörighet;inställning;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Välj en bild"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Avbryt"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Öppna"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "flera storlekar"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Ingen skrivbordsbakgrund"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Aktuell bakgrund"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Stil"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Standard"
 
@@ -439,7 +274,6 @@ msgstr "Utseende"
 msgid "Change your background image or the UI colors"
 msgstr "Ändra din bakgrundsbild eller användargränssnittsfärgerna"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -492,9 +326,7 @@ msgstr "Flygplansläge i hårdvaran är på"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Slå av växelknappen för flygplansläge för att aktivera Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -502,7 +334,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Slå på samt av Bluetooth och anslut dina enheter"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "dela;delning;share;blåtand;bluetooth;obex;"
@@ -535,90 +366,33 @@ msgstr "Inga program har bett om åtkomst till kameran"
 msgid "Protect your pictures"
 msgstr "Skydda dina bilder"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr "kamera;foton;video;webbkamera;lås;privat;sekretess;integritet;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Placera din kalibreringsenhet ovanpå kvadraten och tryck ”Starta”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Flytta din kalibreringsenhet till kalibreringspositionen och välj ”Fortsätt”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Flytta din kalibreringsenhet till ytpositionen och välj ”Fortsätt”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Stäng igen den bärbara datorns lock"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Kunde inte återhämta sig från ett internt fel som uppstod."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Verktyg som krävs för kalibrering är inte installerade."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Profilen kan inte genereras."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Målets vitpunkt kunde inte hämtas."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Färdig!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrering misslyckades!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Du kan ta bort kalibreringsenheten."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Stör inte kalibreringsenheten under pågående kalibrering"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Skärmkalibrering"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Avbryt"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -635,140 +409,6 @@ msgstr "_Fortsätt"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Färdig"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Skärm för bärbar dator"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Inbyggd webbkamera"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s-skärm"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s-bildläsare"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s-kamera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s-skrivare"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s-webbkamera"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Aktivera färghantering för %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Visa färgprofiler för %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Inte kalibrerad"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Standard: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Färgrymd: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Testprofil: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Välj ICC-profil"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Importera"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "ICC-profiler som stöds"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Alla filer"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Skärm"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Spara profil"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Spara"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Skapa en färgprofil för den valda enheten"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Kunde inte hitta mätinstrumentet. Kontrollera att det är påslaget och "
-"korrekt anslutet."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Mätinstrumentet saknar stöd för skrivarprofilering."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Enhetstypen stöds för närvarande inte."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -910,7 +550,6 @@ msgstr "_Importera fil…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -920,9 +559,7 @@ msgstr "_Lägg till"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "Varje enhet behöver en uppdaterad färgprofil för att färghanteras."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Läs mer"
 
@@ -1054,82 +691,6 @@ msgstr "D65 (fotografi och grafik)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standardrymd"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Testprofil"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Automatisk"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Låg kvalitet"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Mellankvalitet"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Hög kvalitet"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Standard RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Standard CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Standardgrå"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Kalibreringsdata tillhandahållen av tillverkare"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Fullskärmskorrigering inte möjlig med denna profil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Denna profil är kanske inte helt korrekt längre"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Färg"
@@ -1140,14 +701,9 @@ msgid ""
 msgstr ""
 "Kalibrera färgen för dina enheter såsom skärmar, kameror eller skrivare"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Färg;ICC;Profil;Kalibrera;Skrivare;Skärm;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Övriga…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1162,13 +718,8 @@ msgid "No languages found"
 msgstr "Hittade inga språk"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Mer…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Lås upp för att ändra inställningar"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1197,151 +748,6 @@ msgstr "Minska timme"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Minska minut"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "I dag"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "I går"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d timme"
-msgstr[1] "%d timmar"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d minut"
-msgstr[1] "%d minuter"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d sekund"
-msgstr[1] "%d sekunder"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 sekunder"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Surfzon"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-timmars"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %I:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%I:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1436,17 +842,11 @@ msgstr "A_utomatisk tidszon"
 msgid "Requires location services enabled and internet access"
 msgstr "Kräver platstjänster aktiverade och internetåtkomst"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Aktiverad"
 
@@ -1454,15 +854,42 @@ msgstr "Aktiverad"
 msgid "Time Z_one"
 msgstr "Tidsz_on"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Lås upp"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Tids_format"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Datum"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 sekunder"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Kalender"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Tal"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Ändra datum och tid, även tidszon"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Klocka;Tidszon;Plats;"
@@ -1509,20 +936,9 @@ msgstr "Standardprogram"
 msgid "Configure Default Applications"
 msgstr "Konfigurera standardprogram"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "standard;program;föredragen;media;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Att skicka in rapporter om tekniska problem hjälper oss att förbättra %s. "
-"Rapporter skickas anonymt och rensas på personliga data. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1540,44 +956,9 @@ msgstr "Diagnostik"
 msgid "Report your problems"
 msgstr "Rapportera dina problem"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostik;krasch;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "På"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Av"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Verkställ ändringar?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Ändringar kan inte verkställas"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Detta kan bero på hårdvarubegränsningar."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1627,31 +1008,6 @@ msgstr "Primär skärm"
 msgid "Night Light"
 msgstr "Nattbelysning"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Liggande"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Stående höger"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Stående vänster"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Liggande (omvänt)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1675,6 +1031,17 @@ msgstr "Justera för TV"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Skala"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Naturlig rullning"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1774,7 +1141,6 @@ msgstr "Skärm­ar"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Välj hur anslutna skärmar och projektorer ska användas"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1782,78 +1148,6 @@ msgid ""
 msgstr ""
 "Panel;Projektor;xrandr;Skärm;Upplösning;Uppdatering;Natt;Belysning;Blå;"
 "redshift;färg;solnedgång;soluppgång;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Säkerhetsstart är aktiv"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Säkerhetsstart förhindrar skadlig programvara från att läsas in när enheten "
-"startas. Det är för närvarande påslaget och fungerar korrekt."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Säkerhetsstart har problem"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Säkerhetsstart förhindrar skadlig programvara från att läsas in när enheten "
-"startas. Det är för närvarande påslaget, men kommer inte att fungera på "
-"grund av att det har en ogiltig nyckel."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Problem med säkerhetsstart kan ofta lösas från din dators fasta UEFI-"
-"programvaruinställningar (BIOS) och din hårdvarutillverkare kan ge "
-"information om hur du gör detta."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "Kontakta din hårdvarutillverkare eller IT-supportleverantör för hjälp."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Säkerhetsstart är avstängd"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Säkerhetsstart förhindrar skadlig programvara från att läsas in när enheten "
-"startas. Det är för närvarande avstängt."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Säkerhetsstart kan ofta aktiveras från din dators fasta UEFI-"
-"programvaruinställningar (BIOS). Kontakta din hårdvarutillverkare eller IT-"
-"supportleverantör för hjälp."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1867,128 +1161,9 @@ msgstr ""
 "\n"
 "Kontakta hårdvarutillverkaren eller IT-support för mer information."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Lyckades"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Misslyckades"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Enheten överensstämmer med HSI-nivå %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Säkerhetsnivå 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Den här enheten har inget skydd mot hårdvarusäkerhetsproblem. Detta kan bero "
-"på ett problem med konfigurationen av hårdvara eller fast programvara. Du "
-"rekommenderas kontakta din IT-supportleverantör."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Säkerhetsnivå 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Den här enheten har minimalt skydd mot hårdvarusäkerhetsproblem. Detta är "
-"den lägsta nivån av enhetssäkerhet och ger bara skydd mot enkla säkerhetshot."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Säkerhetsnivå 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Den här enheten har grundläggande skydd mot hårdvarusäkerhetsproblem. Detta "
-"ger skydd mot några vanliga säkerhetshot."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Säkerhetsnivå 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Den här enheten har utökat skydd mot hårdvarusäkerhetsproblem. Detta är den "
-"högsta nivån av enhetssäkerhet och ger skydd mot avancerade säkerhetshot."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Säkerhetsnivå"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Säkerhetsnivåer är inte tillgängliga för den här enheten."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr "Kontakta din hårdvarutillverkare för hjälp med säkerhetsuppdateringar."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Det kan vara möjligt att lösa det här problemet i enhetens fasta UEFI-"
-"programvaruinställningar eller av en supporttekniker."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Det kan vara möjligt att lösa det här problemet i enhetens fasta UEFI-"
-"programvaruinställningar."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Det kan vara möjligt för en supporttekniker att lösa problemet."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2002,338 +1177,9 @@ msgstr "Nivå 2"
 msgid "Level 3"
 msgstr "Nivå 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Skyddad mot skadlig programvara när enheten startar."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Säkerhetsstart har problem"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Visst skydd när enheten startas."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Säkerhetsstart är av"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Inget skydd när enheten startas."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Det här problemet kan ha orsakats av en ändring i fasta UEFI-"
-"programvaruinställningar, en ändring av operativsystemets konfiguration "
-"eller på grund av skadlig programvara på systemet."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Det här problemet kan ha orsakats av en ändring i de fasta UEFI-"
-"programvaruinställningarna eller på grund av skadlig programvara på systemet."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Det här problemet kan ha orsakats av en ändring av operativsystemets "
-"konfiguration eller på grund av skadlig programvara på systemet."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Utsatt för allvarliga säkerhetshot."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Begränsat skydd mot enkla säkerhetshot."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Skyddad mot vanliga säkerhetshot."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Skyddad mot ett brett utbud av säkerhetshot."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Omfattande skydd"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Inga händelser"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Skrivskydd för fast programvara"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Skrivskyddslås för fast programvara"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "BIOS-region för fast programvara"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "BIOS-beskrivare för fast programvara"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "DMA-skydd före uppstart"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard verifierad uppstart"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM-skyddad"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard-felpolicy"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard säkring"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET stöds"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET aktiv"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Krypterat RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU-skydd"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Lockdown för Linux-kärnan"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Verifiering av Linux-kärnan"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux-växlingsutrymme"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Gå till vänteläge i RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Gå till inaktivt läge"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI-plattformsnyckel"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI säkerhetsstart"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TPM-plattformskonfiguration"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM-rekonstruktion"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel Management Engine-tillverkningsläge"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Intel Management Engine-åsidosättning"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Intel Management Engine-version"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Uppdateringar för fast programvara"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Attestering av fast programvara"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Verifiering av uppdateraren av fast programvara"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Plattformsfelsökning"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Processorsäkerhetskontroller"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD-tillbakarullningsskydd"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Återuppspelningsskydd för AMD:s fasta programvara"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Skrivskydd för AMD:s fasta programvara"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Plattform med säkring"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Giltig"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Ogiltig"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Inaktiverad"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Låst"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Upplåst"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Krypterad"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Okrypterad"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Befläckad"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Obefläckad"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Hittad"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Hittades inte"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Stöds"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Stöds inte"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2343,7 +1189,6 @@ msgstr "Enhetssäkerhet"
 msgid "Host firmware security status"
 msgstr "Säkerhetsstatus för värdens fasta programvara"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2351,49 +1196,6 @@ msgid ""
 msgstr ""
 "skärm;lås;diagnostik;krasch;privat;nyligen;senaste;tillfällig;temporär;tmp;"
 "index;namn;nätverk;identitet;sekretess;integritet;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Okänd"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bitars"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bitars"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Okänt"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Inte tillgänglig"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Systemlogotyp"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2487,11 +1289,6 @@ msgstr "Om"
 msgid "View information about your system"
 msgstr "Visa information om ditt system"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2569,6 +1366,12 @@ msgstr "Programstartare"
 msgid "Launch help browser"
 msgstr "Starta hjälpläsare"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Inställningar"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Starta miniräknare"
@@ -2590,7 +1393,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Sök"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "System"
 
@@ -2639,15 +1442,6 @@ msgstr "Minska textstorleken"
 msgid "High contrast on or off"
 msgstr "Hög kontrast på eller av"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Inga inmatningskällor hittades"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Övriga"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Lägg till en inmatningskälla"
@@ -2680,106 +1474,9 @@ msgstr "Inställningar"
 msgid "View Keyboard Layout"
 msgstr "Visa tangentbordslayout"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Ta bort"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Anpassade kortkommandon"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Alternativa tecken-tangent"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Alternativa tecken-tangenten kan användas för att mata in ytterligare "
-"tecken. Dessa skrivs ibland som ett tredje alternativ på ditt tangentbord."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Vänster Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Höger Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Vänster super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Höger super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menytangent"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Höger Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Compose-tangent"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Compose-tangenten tillåter ett stort urval av tecken att matas in. För att "
-"använda den, tryck på Compose-tangenten och sedan en sekvens av tecken. Till "
-"exempel kommer Compose-tangenten följt av <b>C</b> och <b>o</b> att mata in "
-"<b>©</b>, <b>a</b> följt av <b>'</b> kommer att mata in <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Inmatningsskällor kan växlas genom att använda tangentbordsgenvägen %s.\n"
-"Denna kan ändras i inställningarna för tangentbordsgenvägar."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2810,45 +1507,21 @@ msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Metoder för att mata in symboler och bokstavsvarianter med tangentbordet."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternativa tecken-tangent"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose-tangent"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Tangentbordsgenvägar"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Visa och anpassa kortkommandon"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d ändrad"
-msgstr[1] "%d ändrade"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Återställ alla kortkommandon?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Att återställa kortkommandona kan påverka dina anpassade kortkommandon. "
-"Detta kan inte ångras."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Återställ alla"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2888,34 +1561,6 @@ msgstr "Lägg till kortkommando"
 msgid "No keyboard shortcut found"
 msgstr "Ingen tangentbordsgenväg hittades"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s används redan för %s. Om du vill ersätta det kommer %s att inaktiveras"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Mata in det nya kortkommandot"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Ställ in anpassat kortkommando"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Ställ in kortkommando"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Mata in nytt kortkommando för att ändra %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Lägg till anpassat kortkommando"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Ta bort"
@@ -2927,7 +1572,6 @@ msgstr "_Ersätt"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Ställ in"
 
@@ -2965,6 +1609,11 @@ msgstr "Ingen"
 msgid "Reset the shortcut to its default value"
 msgstr "Återställ kortkommandot till dess standardvärde"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Använd din kamera"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Tan­gent­bord"
@@ -2977,7 +1626,6 @@ msgstr ""
 "Ändra tangentbordsgenvägar och konfigurera dina skrivinställningar, "
 "tangentbordslayouter och inmatningskällor"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3019,7 +1667,6 @@ msgstr "Inga program har bett om platsåtkomst"
 msgid "Protect your location information"
 msgstr "Skydda din platsinformation"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "plats;gps;privat;sekretess;integritet;"
@@ -3054,7 +1701,6 @@ msgstr "Inga program har bett om åtkomst till mikrofonen"
 msgid "Protect your conversations"
 msgstr "Skydda dina konversationer"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofon;inspelning;program;sekretess;integritet;"
@@ -3084,81 +1730,140 @@ msgstr "Vänster"
 msgid "Right"
 msgstr "Höger"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Sökplatser"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Mus"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Mushastighet"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Naturlig rullning"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Rulla nedåt"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Rullning flyttar innehållet, inte vyn."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Rullning flyttar innehållet, inte vyn."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Aktiv"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Styrplatta"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Hastighet för styrplatta"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Knacka för att klicka"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Knacka för att klicka"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Tvåfingersrullning"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Inaktivera bild"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Styrplatta (relativ)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Kantrullning"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Rulla nedåt"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Dubbelsidig"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Prova att klicka, dubbelklicka och rulla"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Fem klick, dags för Gegl!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Dubbelklick med primär musknapp"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Enkelklick, primär knapp"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Dubbelklick med mellanmusknapp"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Enkelklick med mellanmusknappen"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Dubbelklick med sekundära musknappen"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Enkelklick med sekundära musknappen"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3170,7 +1875,6 @@ msgid ""
 msgstr ""
 "Ändra din mus- eller styrplattekänslighet och välj höger- eller vänsterhänt"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Styrplatta;Muspekare;Klick;Slå lätt;Dubbel;Knapp;Trackball;Rulla;"
@@ -3250,7 +1954,6 @@ msgstr "Multikörning"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Hantera inställningar för produktivitet och multikörning"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3258,20 +1961,11 @@ msgstr ""
 "Multitasking;Multitask;Multikörning;Produktivitet;Anpassa;Skrivbord;Hot "
 "Corner;Hett hörn;Arbetsytor;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Hoppsan, något gick fel. Kontakta din programvaruleverantör."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Nätverkshanteraren måste vara aktiv."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Andra enheter"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3283,59 +1977,16 @@ msgstr "Lägg till anslutning"
 msgid "Not set up"
 msgstr "Inte konfigurerat"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Osäkert nätverk (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Säkert nätverk (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Säkert nätverk (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Säkert nätverk (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Säkert nätverk"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Ansluten"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Alternativ…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Att slå på surfzonen kommer att koppla från %s, och det kommer inte vara "
-"möjligt att komma åt internet genom Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Måste bestå av minst 8 tecken"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3385,20 +2036,6 @@ msgstr "Generera lösenord automatiskt"
 msgid "_Turn On"
 msgstr "_Slå på"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Tråd­löst"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Stoppa surfzonen och koppla ifrån eventuella användare?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Stoppa surfzon"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Flygplansläge"
@@ -3443,89 +2080,13 @@ msgstr "Synliga nätverk"
 msgid "NetworkManager needs to be running"
 msgstr "Nätverkshanteraren måste vara aktiv"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Hoppsan, något gick fel. Kontakta din programvaruleverantör."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x-_säkerhet"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Säkerhet"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Bevara"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Permanent"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Slumpmässig"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Stabil"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"MAC-adressen som anges här kommer att användas som hårdvaruadress för "
-"nätverksenheten som denna anslutning är aktiverad på. Denna funktion är känd "
-"som MAC-kloning eller ”spoofing”. Exempel: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Aldrig"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3534,183 +2095,6 @@ msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i dag sedan"
 msgstr[1] "%i dagar sedan"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2,4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2,4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Svag"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Bra"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Utmärkt"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4-adress"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6-adress"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP-adress"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Glöm anslutning"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Ta bort anslutningsprofil"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Ta bort VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Detaljer"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "automatisk"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Identitet"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Ta bort adress"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Standardrutt"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bitars nyckel (Hex eller ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bitars lösenfras"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamisk WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Enterprise"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Personal"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3721,8 +2105,20 @@ msgstr "Signalstyrka"
 msgid "Link speed"
 msgstr "Länkhastighet"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Säkerhet"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4-adress"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-adress"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Hårdvaruadress"
 
@@ -3731,12 +2127,17 @@ msgid "Supported Frequencies"
 msgstr "Frekvenser som stöds"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Standardrutt"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3799,7 +2200,7 @@ msgstr "Endast lokal länk"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Manuell"
 
@@ -3843,9 +2244,8 @@ msgstr "Gateway"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Automatisk"
 
@@ -3898,89 +2298,9 @@ msgstr "Automatisk, endast DHCP"
 msgid "Prefix"
 msgstr "Prefix"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Kunde inte öppna anslutningsredigeraren"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Ny profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Ogiltig inställning %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Ogiltig inställning %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Importera från fil…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Lägg till VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Säk_erhet"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Kan inte importera VPN-anslutning"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Filen ”%s” kan inte läsas eller innehåller ej igenkänd VPN-"
-"anslutningsinformation\n"
-"\n"
-"Fel: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Välj fil att importera"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "En fil med namnet ”%s” finns redan."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "E_rsätt"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Vill du ersätta %s med VPN-anslutningen du sparar?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Kan inte exportera VPN-anslutning"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN-anslutningen ”%s” kunde inte exporteras till %s.\n"
-"\n"
-"Fel: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Exportera VPN-anslutning"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3994,99 +2314,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Nätverk"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Kontrollera hur du ansluter till internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Nätverk;IP;LAN;Proxy;WAN;Bredband;Modem;Bluetooth;Blåtand;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Tråd­löst"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Kontrollera hur du ansluter till trådlösa nätverk"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Nätverk;Trådlöst;Wi-Fi;Wifi;IP;LAN;Bredband;DNS;Hotspot;Surfzon;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "aldrig"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "i dag"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "i går"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Senast använd"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Trådbundet"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Lägg till ny anslutning"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Nätverksdetaljer för markerade nätverk, inklusive lösenord och anpassad "
-"konfiguration kommer att gå förlorade."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Glöm"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Kända trådlösa nätverk"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Glöm"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Systempolicyn tillåter ej användning som surfzon"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Den trådlösa enheten stöder inte användning av surfzoner"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Web Proxy Autodiscovery (WPAD) används när en konfigurations-URL inte "
-"tillhandahålls."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Detta rekommenderas inte för opålitliga publika nätverk."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4105,6 +2362,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Leverantör"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adress"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4189,289 +2450,6 @@ msgstr "Slå på _trådlös surfzon…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Kända trådlösa nätverk"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Okänd status"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Ohanterad"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Otillgänglig"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Ansluter"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Autentisering krävs"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Kopplar från"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Anslutningen misslyckades"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Okänd status (saknas)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Konfiguration misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP-konfiguration misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP-konfiguration passerade slutdatum"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Hemligheter krävdes, men tillhandahölls inte"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x-supplikanten kopplades från"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Konfiguration av 802.1x-supplikanten misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x-supplikanten misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x-supplikanten tog för lång tid på sig att autentisera"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Misslyckades med att starta PPP-tjänsten"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP-tjänsten kopplades från"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Misslyckades med att starta DHCP-klienten"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP-klient fel"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP-klienten misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Misslyckades med att starta tjänsten för delad anslutning"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Tjänsten för delad anslutning misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Kunde inte starta AutoIP-tjänsten"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Fel i AutoIP-tjänsten"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP-tjänsten misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Linjen är upptagen"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Ingen rington"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Bärvågen kunde inte etableras"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Tidsgränsen för uppringningen överskreds"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Uppringningen misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Initiering av modem misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Misslyckades med att välja angiven APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Söker inte efter nätverk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Nätverksregistrering nekades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Tidsgränsen för nätverksregistrering överstegs"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Misslyckades att registrera med begärt nätverk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Kontroll av PIN-kod misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Enheten kan sakna fast programvara"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Anslutningen försvann"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Befintlig anslutning antogs"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modemet kunde inte hittas"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth-anslutningen misslyckades"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM-kortet är inte isatt"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM-kortet kräver PIN-kod"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM-kortet kräver PUK-kod"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Fel på SIM-kortet"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Anslutningsberoende misslyckades"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Fast programvara saknas"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kabeln är frånkopplad"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "odefinierat fel i 802.1X-säkerhet (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "ingen fil vald"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "ospecificerat fel vid validering av eap-metodfil"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Privata DER-, PEM-, PKCS#12- eller PGP-nycklar"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER- eller PEM-certifikat"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "saknar PAC-fil för EAP-FAST"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC-filer (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4520,14 +2498,6 @@ msgstr "_Inre autentisering"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Tillåt automatisk PAC-pro_visionering"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "saknar EAP-LEAP-användarnamn"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "saknar EAP-LEAP-lösenord"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4553,15 +2523,6 @@ msgstr "_Lösenord"
 msgid "Sho_w password"
 msgstr "Visa lösen_ord"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "ogiltigt CA-certifikat för EAP-PEAP: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "ogiltigt CA-certifikat för EAP-PEAP: inget certifikat angivet"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4583,7 +2544,6 @@ msgid "C_A certificate"
 msgstr "C_A-certifikat"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4598,63 +2558,6 @@ msgstr "Inget CA-certifikat k_rävs"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _version"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "saknar EAP-användarnamn"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "saknar EAP-lösenord"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "saknar EAP-TLS-identitet"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "ogiltigt CA-certifikat för EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "ogiltigt CA-certifikat för EAP-TLS: inget certifikat angivet"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "ogiltig privat nyckel för EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "ogiltigt EAP-TLS-användarcertifikat: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Okrypterade privata nycklar är osäkra"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Den valda privata nyckeln verkar inte vara skyddad av ett lösenord. Det "
-"skulle kunna tillåta säkerhetsreferenser att bli komprometterade. Välj en "
-"lösenordsskyddad privat nyckel.\n"
-"\n"
-"(Du kan lösenordsskydda din privata nyckel med openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Välj ditt personliga certifikat"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Välj din privata nyckel"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4671,15 +2574,6 @@ msgstr "Privat nyc_kel"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Lösenord för _privat nyckel"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "ogiltigt CA-certifikat för EAP-TTLS: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "ogiltigt CA-certifikat för EAP-TTLS: inget certifikat angivet"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4702,14 +2596,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Domän"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Okänt fel vid validering av 802.1X-säkerhet"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4737,62 +2632,10 @@ msgstr "Skyddad EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "Au_tentisering"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Välj en fil"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "saknar leap-användarnamn"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "saknar leap-lösenord"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Wi-Fi-lösenord saknas."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Typ"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "saknar wep-nyckel"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"ogiltig wep-nyckel: nyckel med en längd på %zu får endast innehålla "
-"hexadecimala siffror"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"ogiltig wep-nyckel: nyckel med en längd på %zu får endast innehålla ascii-"
-"tecken"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"ogiltig wep-nyckel: felaktig nyckellängd %zu. En nyckel måste ha antingen "
-"längden 5/13 (ascii) eller 10/26 (hex)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "ogiltig wep-nyckel: lösenfras får inte vara tom"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "ogiltig wep-nyckel: lösenfras måste vara kortare än 64 tecken"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4817,19 +2660,6 @@ msgstr "_Visa nyckel"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP-inde_x"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"ogiltig wpa-psk: ogiltig nyckellängd %zu. Måste vara [8,63] byte eller 64 "
-"hexadecimala siffror"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "ogiltig wpa-psk: kan inte tolka nyckel med 64 byte som hexadecimal"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4883,27 +2713,9 @@ msgstr "Aviseringar på _låsskärm"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Kontrollera vilka aviseringar som visas samt vad de visar"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Aviseringar;Banderoll;Meddelande;Bricka;Popup;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Övriga"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s togs bort"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Fel vid borttagning av kontot"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4927,17 +2739,6 @@ msgstr "Ingen internetanslutning — anslut för att konfigurera nya nätkonton"
 msgid "Add an account"
 msgstr "Lägg till ett konto"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s-konto"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Ta bort konto"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Nät­kont­on"
@@ -4946,10 +2747,6 @@ msgstr "Nät­kont­on"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "Anslut till dina nätkonton och bestäm hur de ska användas"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4957,10 +2754,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Webb;Nätet;Chatt;Kalender;E-post;Kontakt;"
 "ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Okänd tid"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4976,13 +2769,6 @@ msgid_plural "%i hours"
 msgstr[0] "%i timme"
 msgstr[1] "%i timmar"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4994,189 +2780,6 @@ msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "minut"
 msgstr[1] "minuter"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s tills fullt uppladdad"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Varning: %s återstår"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s återstår"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Fullt uppladdad"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Laddar inte"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Tom"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Laddar upp"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Laddar ur"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Trådlös mus"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Trådlöst tangentbord"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Avbrottsfri kraftförsörjning (UPS)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Handdator"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Mobiltelefon"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Mediaspelare"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Ritplatta"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Dator"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Inmatningsenhet för spel"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Batteri"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Huvudsaklig"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Extra"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Batterier"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "När led_ig"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Försätt i vänteläge"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Stäng av"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Försätt i viloläge"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Ingenting"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "När på batteriström"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "När ansluten"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Aldrig"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Automatiskt vänteläge"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Prestandaläge tillfälligt inaktiverat på grund av hög arbetstemperatur."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Knä upptäckt: prestandaläge är otillgängligt för tillfället. Flytta enheten "
-"till en stabil yta för att återställa."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Prestandaläge är tillfälligt inaktiverat."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Låg batterinivå: strömsparare aktiverad. Tidigare läge kommer att "
-"återställas när batteriet har laddats tillräckligt."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Strömsparläge aktiverades av ”%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Prestandaläge aktiverades av ”%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5237,6 +2840,15 @@ msgstr "100 minuter"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "Två timmar"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batteri"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Enheter"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5315,33 +2927,6 @@ msgstr "På _batteriström"
 msgid "Delay"
 msgstr "Fördröjning"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Prestanda"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Hög prestanda och strömförbrukning."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Balanserad"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Standardprestanda och strömförbrukning."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Strömsparare"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Minskad prestanda och strömförbrukning."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Ström"
@@ -5350,7 +2935,6 @@ msgstr "Ström"
 msgid "View your battery status and change power saving settings"
 msgstr "Visa din batteristatus och ändra energisparinställningar"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5358,27 +2942,6 @@ msgid ""
 msgstr ""
 "Ström;Sova;Vänteläge;Viloläge;Batteri;Ljusstyrka;Dämpa;Blank;Skärm;DPMS;"
 "inaktiv;Energi;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Skrivaren ”%s” har tagits bort"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Misslyckades med att lägga till ny skrivare."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Det gick inte att läsa in användargränssnittet: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Lås upp för att lägga till skrivare och ändra inställningar"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5388,7 +2951,6 @@ msgstr "Skriv­ar­e"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Lägg till skrivare, visa skrivarjobb och besluta hur du vill skriva ut"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Skrivare;Kö;Skriv ut;Papper;Bläck;Toner;"
@@ -5396,8 +2958,6 @@ msgstr "Skrivare;Kö;Skriv ut;Papper;Bläck;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Lägg till skrivare"
 
@@ -5437,29 +2997,6 @@ msgstr ""
 msgid "Username"
 msgstr "Användarnamn"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Detaljer för %s"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Ingen lämplig drivrutin kunde hittas"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Välj PPD-fil"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript-skrivarbeskrivningsfiler (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Skrivarnamn kan inte innehålla BLANKSTEG, TABB, # eller /"
@@ -5468,9 +3005,7 @@ msgstr "Skrivarnamn kan inte innehålla BLANKSTEG, TABB, # eller /"
 msgid "Location"
 msgstr "Plats"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Drivrutin"
 
@@ -5498,141 +3033,20 @@ msgstr "Välj drivrutin för skrivare"
 msgid "Loading drivers database…"
 msgstr "Läser in drivrutinsdatabas…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Avbryt"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Välj"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect-skrivare"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD-skrivare"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Enkelsidig"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Långsida (standard)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Kortsida (vänd)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Porträtt"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Landskap"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Omvänt landskap"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Omvänt porträtt"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Fortsätt"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Pausa"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Väntar"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Pausad"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Autentisering krävs"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Behandlar"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Stoppad"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Avbruten"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Avbruten"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Färdig"
-
-# TODO: front of the queue?
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Flytta det här jobbet längst fram i kön"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u jobb begär autentisering"
 msgstr[1] "%u jobb begär autentisering"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — aktiva jobb"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Ange autentiseringsuppgifter för att skriva ut från %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5660,321 +3074,17 @@ msgstr "_Autentisera"
 msgid "No Active Printer Jobs"
 msgstr "Inga aktiva skrivarjobb"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Lås upp skrivarserver"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Lås upp %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Ange ditt användarnamn och lösenord för att se skrivare på %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Söker efter skrivare"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Seriellport"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Parallellport"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Plats: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adress: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Server begär autentisering"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Dubbelsidig"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Papperstyp"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Papperskälla"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Utskriftsfack"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Upplösning"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript-förfiltrering"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Sidor per blad"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Dubbelsidig"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Orientering"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Allmänt"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Sidinställningar"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Installerbara alternativ"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Jobb"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Bildkvalitet"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Färg"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Slutför"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Avancerat"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Testsida"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Testsida"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Välj automatiskt"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Skrivarens standardinställning"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Bädda enbart in GhostScript-typsnitt"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Konvertera till PS nivå 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Konvertera till PS nivå 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Ingen förfiltrering"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Tillverkare"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Inga aktiva jobb"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u jobb"
 msgstr[1] "%u jobb"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Rengör skrivarhuvuden"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Låg tonernivå"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Slut på toner"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Nästan slut på framkallningsvätska"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Slut på framkallningsvätska"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Nästan slut på färg"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Slut på färg"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Luckan är öppen"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Luckan är öppen"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Låg pappersnivå"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Slut på papper"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Frånkopplad"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Stoppad"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Skräpkorgen är nästan full"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Skräpkorgen är full"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Den optiska fototrumman är nära slutet på sin livstid"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Den optiska fototrumman är inte längre funktionsduglig"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Redo"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Accepterar inte jobb"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Behandlar"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5998,6 +3108,10 @@ msgstr "Rengör skrivarhuvuden"
 msgid "Remove Printer"
 msgstr "Ta bort skrivare"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Inga aktiva jobb"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6018,16 +3132,21 @@ msgid "Restart"
 msgstr "Starta om"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Lägg till skrivare…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Lägg till en skrivare…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Inga skrivare"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6035,7 +3154,6 @@ msgstr ""
 "Tyvärr! Systemets utskriftstjänst\n"
 "    verkar inte finnas tillgänglig."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Format"
@@ -6063,16 +3181,6 @@ msgstr "Sökningar kan vara efter länder eller språk."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Förhandsgranska"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Imperial"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrisk"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6110,20 +3218,24 @@ msgstr ""
 "Språkinställningen används för gränssnittstext och webbsidor. Format används "
 "för siffror, datum och valutor."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Ditt konto"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Språk"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Format"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Inloggningsskärm"
 
@@ -6135,99 +3247,9 @@ msgstr "Re­gion & språk"
 msgid "Select your display language and formats"
 msgstr "Välj ditt visningsspråk och dina format"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Språk;Layout;Tangentbord;Inmatning;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Fråga vad som ska göras"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Gör ingenting"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Öppna mapp"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Övriga media"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Välj ett program för ljud-cd-skivor"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Välj ett program för video-dvd-skivor"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Välj ett program att köra när en musikspelare ansluts"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Välj ett program att köra när en kamera ansluts"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Välj ett program för program-cd-skivor"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "ljud-dvd"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "tom Blu-ray-skiva"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "tom cd-skiva"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "tom dvd-skiva"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "tom HD DVD-skiva"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray-videoskiva"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "e-boksläsare"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD-videoskiva"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Bildcd"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video-cd"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Videocd"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Fönsterprogramvara"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6277,7 +3299,6 @@ msgstr "Flyttbara media"
 msgid "Configure Removable Media settings"
 msgstr "Konfigurera inställningar för flyttbara media"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6285,114 +3306,6 @@ msgid ""
 msgstr ""
 "enhet;system;standard;program;föredragen;cd;dvd;usb;ljud;video;skiva;"
 "flyttbar;media;automatisk körning;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Skärmen stängs av"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 sekunder"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "En minut"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "Två minuter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "Tre minuter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "Fem minuter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 minuter"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "En timme"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "En minut"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "Två minuter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "Tre minuter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "Fyra minuter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "Fem minuter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "Åtta minuter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "Tio minuter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "Tolv minuter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 minuter"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Aldrig"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6430,11 +3343,16 @@ msgstr "Tid efter att skärmen släckts då skärmen kommer att låsas automatis
 msgid "Show _Notifications on Lock Screen"
 msgstr "Visa _aviseringar på låsskärmen"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Aviseringar på _låsskärm"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Förbjud nya _USB-enheter"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6442,30 +3360,25 @@ msgstr ""
 "Förhindra nya USB-enheter från att interagera med systemet då skärmen är "
 "låst."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Skärmsekretess"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Begränsa betraktningsvinkeln"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skärm"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Skärminställningar"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "skärm;lås;privat;sekretess;integritet;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Välj plats"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_OK"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6495,10 +3408,6 @@ msgstr "Övriga"
 msgid "Add Location"
 msgstr "Lägg till plats"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Inga program hittades"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Programsökning"
@@ -6524,93 +3433,13 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "Kontrollera vilka program som visar sökresultat i Aktivitetsöversikten"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Sök;Hitta;Index;Göm;Sekretess;Resultat;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Inga nätverk markerade för delning"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Nätverk"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "På"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Av"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Aktiverad"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Aktiv"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Välj en mapp"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Lägg till"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Aktivera mediadelning"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Fildelning låter dig dela din publika mapp med andra på det nätverk du "
-"använder för tillfället: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Då fjärrinloggning är aktiverad kan fjärranvändare ansluta med det säkra "
-"skalkommandot:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Aktivera personlig mediadelning"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Enhetsnamn kopierat"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Enhetsadress kopierad"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Användarnamn kopierat"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Lösenord kopierat"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6741,7 +3570,6 @@ msgstr "Mappar"
 msgid "Control what you want to share with others"
 msgstr "Kontrollera vad du vill dela med andra"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6757,10 +3585,6 @@ msgstr "Aktivera eller inaktivera fjärrinloggning"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Autentisering krävs för att aktivera eller inaktivera fjärrinloggning"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Anpassat"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6795,11 +3619,6 @@ msgstr "Bakre"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Främre"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Testar %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6853,11 +3672,6 @@ msgstr "Volym"
 msgid "Alert Sound"
 msgstr "Larmljud"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Tyst"
@@ -6870,81 +3684,10 @@ msgstr "Ljud"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Ändra ljudvolym, ingångar, utgångar och ljudhändelser"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr "Kort;Mikrofon;Volym;Tona;Balans;Bluetooth;Headset;Ljud;Utgång;Ingång;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Frånkopplad"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Ansluter"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Ansluten"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Auktorisering krävs"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Auktoriserar"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Reducerad funktionalitet"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Ansluten och auktoriserad"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Okänd"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Auktoriserades:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Anslöts:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Registrerades:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Misslyckades med att auktorisera enhet: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Misslyckades med att glömma enheten: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6978,57 +3721,6 @@ msgstr "Auktorisera och anslut"
 msgid "Forget Device"
 msgstr "Glöm enhet"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Fel"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Auktoriserad"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Thunderbolt-undersystemet (boltd) är inte installerat eller inte korrekt "
-"konfigurerat."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Tillåt direktåtkomst för enheter såsom dockor och externa grafikprocessorer."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Endast USB- och Display Port-enheter kan kopplas in."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt kunde inte detekteras.\n"
-"Antingen saknar systemet stöd för Thunderbolt, eller så har det inaktiverats "
-"i BIOS, eller så har det ställts in till en säkerhetsnivå som inte stöds i "
-"BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Stöd för Thunderbolt har inaktiverats i BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Säkerhetsnivå för Thunderbolt kunde inte avgöras."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Fel vid växling av direktläge: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Inget Thunderbolt-stöd"
@@ -7040,6 +3732,11 @@ msgstr "Det gick inte att ansluta till thunderbolt-undersystemet."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Direktåtkomst"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Tillåt direktåtkomst för enheter såsom dockor och externa grafikprocessorer."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7057,7 +3754,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Hantera Thunderbolt-enheter"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;sekretess;"
@@ -7260,40 +3956,6 @@ msgstr "Aktivera med tang_entbord"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Slå på och av hjälpmedelsfunktioner från tangentbordet"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Standard"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Mellan"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Stor"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Större"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Störst"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d bildpunkt"
-msgstr[1] "%d bildpunkter"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "Visa _alltid meny för hjälpmedel"
@@ -7407,31 +4069,6 @@ msgstr "Blinka hela _skärmen"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Blinka hela _fönstret"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Kort"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ skärm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ skärm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ skärm"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Lång"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7588,7 +4225,6 @@ msgstr "Färgeffekter"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Gör det enklare att se, höra, skriva, peka och klicka"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7600,114 +4236,6 @@ msgstr ""
 "Skärmläsare;stor;hög;text;typsnitt;teckensnitt;storlek;AccessX;Klistriga;"
 "Tangenter;Tröga;Tangentstuds;Mustangenter;Dubbelklick;Fördröjning;Hastighet;"
 "Assistans;Upprepa;Blinka;visuell;hörsel;ljud;skrift;animationer;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "En timme"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "En dag"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "Två dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "Tre dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "Fyra dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "Fem dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "Sex dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "Sju dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 dagar"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 dagar"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Töm alla objekt i papperskorgen?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Alla objekt i papperskorgen kommer att tas bort permanent."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "_Töm papperskorgen"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Radera alla tillfälliga filer?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Alla tillfälliga filer kommer att raderas permanent."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Ta bort tillfälliga filer"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "En dag"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "Sju dagar"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 dagar"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "För alltid"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7776,64 +4304,12 @@ msgstr "Filhistorik & papperskorg"
 msgid "Don't leave traces"
 msgstr "Lämna inga spår"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "användning:senaste;historik;filer;tillfällig;temporär;tmp;privat;sekretess;"
 "integritet;skräp;rensa;behåll;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Ska matcha din inloggningsleverantörs webbadress."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Misslyckades med att lägga till konto"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Lösenorden stämmer inte överens."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Misslyckades med att registrera konto"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Inget stöd för att autentisera med denna domän"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Misslyckades med att ansluta till domänen"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Inloggningsnamnet fungerade inte.\n"
-"Prova igen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Inloggningslösenordet fungerade inte.\n"
-"Prova igen."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Misslyckades med att logga in på domänen"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Kunde inte hitta domänen. Kanske felstavade du den?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7886,10 +4362,6 @@ msgstr ""
 "Företagsinloggning tillåter att ett befintligt centralt hanterat "
 "användarkonto kan användas på denna enhet. Du kan också använda detta konto "
 "för att komma åt företagsresurser på internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Bläddra efter fler bilder"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7960,222 +4432,6 @@ msgstr "_Ta bort fingeravtryck"
 msgid "Fingerprint Enroll"
 msgstr "Fingeravtrycksregistrering"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "enheten behöver tas i anspråk för att utföra denna åtgärd"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "enheten har redan tagits i anspråk av en annan process"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "du har inte rättigheter att utföra åtgärden"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "inga avtryck har registrerats"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Misslyckades med att kommunicera med enheten under registrering"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Misslyckades med att kommunicera med fingeravtrycksläsaren"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Misslyckades med att kommunicera med fingeravtrycksdemonen"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Misslyckades med att lista fingeravtryck: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Misslyckades med att ta bort sparade fingeravtryck: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Vänster tumme"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Vänster långfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "_Vänster pekfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Vänster ringfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Vänster lillfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Höger tumme"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Höger långfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "_Höger pekfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Höger ringfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Höger lillfinger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Okänt finger"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Färdig"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Fingeravtrycksenheten kopplades från"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Fingeravtrycksenhetens utrymme är fullt"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Misslyckades med att registrera nytt fingeravtryck"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Misslyckades med att starta registrering: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Misslyckades med att registrera nytt fingeravtryck"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Misslyckades med att stoppa registrering: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Lyft och placera upprepat ditt finger på läsaren för att registrera ditt "
-"fingeravtryck"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "_Registrera detta finger på nytt…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Läs av nytt fingeravtryck"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Misslyckades med att släppa fingeravtrycksenheten %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Problem vid läsning av enhet"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Misslyckades med att begära fingeravtrycksenheten %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Misslyckades med att erhålla fingeravtrycksenheter: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Denna vecka"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Förra veckan"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Session avslutad"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Session påbörjad"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Kontoaktivitet"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Föregående"
@@ -8183,18 +4439,6 @@ msgstr "Föregående"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Nästa"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Välj ett annat lösenord."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Ange ditt aktuella lösenord igen."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Lösenordet kunde inte ändras"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8216,6 +4460,10 @@ msgstr "Nytt lösenord"
 msgid "Confirm Password"
 msgstr "Bekräfta nytt lösenord"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lösenorden stämmer inte överens."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Tillåt användare att ändra lösenord vid nästa inloggning"
@@ -8223,134 +4471,6 @@ msgstr "Tillåt användare att ändra lösenord vid nästa inloggning"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Ange ett lösenord nu"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Kan inte automatiskt gå med i denna typ av domän"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Ingen sådan domän eller sfär funnen"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Kan inte logga in som %s på %s-domänen"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Ogiltigt lösenord, försök igen"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Det gick inte att ansluta till %s-domänen: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Misslyckades med att ta bort användaren"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Misslyckades med att ta bort fjärrhanterad användare"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Du kan inte ta bort ditt egna konto."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s är fortfarande inloggad"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Att ta bort en användare när de är inloggade kan medföra att systemet hamnar "
-"i ett inkonsistent tillstånd."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Vill du behålla filer tillhörande %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Det är möjligt att behålla hemkatalogen, e-postkö och tillfälliga filer när "
-"ett användarkonto tas bort."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Ta bort filer"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "_Behåll filer"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Är du säker på att du vill ta bort fjärrhanterade kontot för %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Ta bort"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Kontot är inaktiverat"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Ska ställas in vid nästa inloggning"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ingen"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Inloggad"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Misslyckades med att kontakta kontotjänsten"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Försäkra dig om att kontotjänsten är installerad och aktiverad."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Den här panelen måste vara upplåst för att ändra denna inställning"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Ta bort markerat användarkonto"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Klicka först på *-ikonen för att\n"
-"ta bort markerat användarkonto"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Lås upp för att lägga till användare och ändra inställningar"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8378,7 +4498,6 @@ msgid "Full name"
 msgstr "Fullständigt namn"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Redigera"
 
@@ -8440,7 +4559,6 @@ msgstr "Lås upp för att lägga till ett användarkonto."
 msgid "Add or remove users and change your password"
 msgstr "Lägg till eller ta bort användare och ändra ditt lösenord"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8485,178 +4603,6 @@ msgstr "Hantera användarkonton"
 msgid "Authentication is required to change user data"
 msgstr "För att ändra användardata krävs autentisering"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Det nya lösenordet måste skilja sig åt från det gamla."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Ändra några bokstäver och siffror."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Försök att ändra lösenordet lite mer."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Ett lösenord utan ditt användarnamn skulle vara starkare."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Undvik att använda ditt namn i lösenordet."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Undvika några av orden som ingår i lösenordet."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Undvik vanliga ord."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Undvik att kasta om befintliga ord."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Använd fler siffror."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Använd fler versaler."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Använd fler gemener."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Använd fler specialtecken som till exempel skiljetecken."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Använd en blandning av bokstäver, siffror och skiljetecken."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Undvik att upprepa samma tecken."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Undvik att repetera samma typ av tecken: du behöver blanda bokstäver, "
-"siffror och skiljetecken."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Undvik sekvenser likt 1234 eller abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Lösenordet behöver vara längre. Försök att lägga till fler bokstäver, "
-"siffror och skiljetecken."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Blanda versaler och gemener och försök använda en eller flera siffror."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Att lägga till fler bokstäver, siffror och skiljetecken kommer göra "
-"lösenordet starkare."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Autentiseringen misslyckades"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Det nya lösenordet är för kort"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Det nya lösenordet är för enkelt"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Det gamla och det nya lösenordet är för lika"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Det nya lösenordet har används tidigare."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Det nya lösenordet måste innehålla numeriska- eller specialtecken"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Det gamla och det nya lösenordet är identiska"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Ditt lösenord har ändrats sedan du först autentiserades!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Det nya lösenordet innehåller inte tillräckligt många olika tecken"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Okänt fel"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Användarnamnet får vanligen endast innehålla små bokstäver från a-z, siffror "
-"och följande tecken: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Det användarnamnet är tyvärr inte tillgängligt. Försök med ett annat."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Användarnamnet är för långt."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8690,54 +4636,12 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Felaktigt klick upptäcktes, startar om…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Knapp %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Programdefinierad"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Skicka tangenttryckning"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Byt skärm"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Visa hjälp på skärmen"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Ritplatta monterad på skärm för bärbar dator"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Ritplatta monterad på extern skärm"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Extern ritplatteenhet"
-
 # Wacom Express Key Remote, andvänds tillsammans med en ritplatta.
 # https://estore.wacom.com/media/catalog/product/cache/fb4143a007ae6439deba9b18afd745f2/a/c/ack-411050_main_2.jpg
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Extern fjärrkontrollsenhet"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Alla skärm­ar"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8835,22 +4739,6 @@ msgstr "Högerklick med musknapp"
 msgid "Forward"
 msgstr "Framåt"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Airbrush-styluspenna med tryck, lutning och integrerat reglage"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Airbrush-styluspenna med tryck, lutning och rotation"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Standardstyluspenna med tryck och lutning"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Standardstyluspenna med tryck"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom-ritplatta"
@@ -8860,54 +4748,96 @@ msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr ""
 "Ställ in knappkopplingar och justera styluspennkänsligheten för ritplattor"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Ritplatta;Wacom;Styluspenna;Raderare;Mus;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Nytt kortkommando…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Simulerat sekundärklick"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Fönsterprogramvara"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Låg tonernivå"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Sekundär"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Fönsterprogramvara"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Hantera inställningar för produktivitet och multikörning"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Accesspunkter"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Lägg till"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Spara"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Operationen avbröts"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Fel:</b> Åtkomst nekad vid ändring av inställningar"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Fel:</b> Mobilutrustningsfel"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Inte registrerad"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Registrerad"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Roaming"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Söker"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Nekad"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8937,212 +4867,13 @@ msgstr "Eget nummer"
 msgid "Device Details"
 msgstr "Enhetsdetaljer"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Tillverkare"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Version av fast programvara"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Endast 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Endast 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Endast 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Endast 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (föredras), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (föredras), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (föredras), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (föredras), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (föredras), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (föredras), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (föredras), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (föredras), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (föredras), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (föredras), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (föredras), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (föredras), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (föredras), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (föredras), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (föredras), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (föredras), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (föredras)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (föredras), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Okänt"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Lås upp SIM-kort"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Lås upp"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Tillhandahåll PIN-koden för SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Ange PIN för att låsa upp ditt SIM-kort"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Tillhandahåll PUK-koden för SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Ange PUK för att låsa upp ditt SIM-kort"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9157,26 +4888,6 @@ msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Du har %u försök kvar"
 msgstr[1] "Du har %u försök kvar"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Fel lösenord matades in."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK-koden ska vara ett 8-siffrigt tal"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Ange ny PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN-koden ska vara ett tal med 4-8 siffror"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Låser upp…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9234,94 +4945,6 @@ msgstr "Lås SIM med PIN"
 msgid "M_odem Details"
 msgstr "M_odemdetaljer"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Telefonfel"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Ingen anslutning till telefon"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Operationen tillåts ej"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Operationen stöds ej"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM inte anslutet"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "PIN för SIM krävs"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "PUK för SIM krävs"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM-fel"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM upptaget"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Felaktigt lösenord"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "PIN2 för SIM krävs"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "PUK2 för SIM krävs"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Hittades inte"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Ingen nätverkstjänst"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Nätverkstidsgräns överskreds"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS-tjänster tillåts ej"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Roaming är inte tillåtet på området för denna plats"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Ospecificerat GPRS-fel"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Inget fel"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Åtgärden avbröts"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Åtkomst nekad"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Okänt fel"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Nätverksläge"
@@ -9337,11 +4960,6 @@ msgstr "Välj nätverk"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Uppdatera nätverksleverantörer"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9399,7 +5017,6 @@ msgstr "Mobilnätverk"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Konfigurera telefoni och mobildataanslutningar"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;mobilnätverk;wwan;telefoni;sim;mobil;"
@@ -9417,41 +5034,13 @@ msgstr ""
 msgid "The GNOME Project"
 msgstr "GNOME-projektet"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Visa versionsnummer"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Aktivera informativt läge"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Sök efter strängen"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Lista möjliga panelnamn och avsluta"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Panel att visa"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Inställningskategorier"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Sekretess"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Tillgängliga paneler:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9509,7 +5098,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Avbryt sökning"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Inställningar;"
@@ -9548,8 +5136,6 @@ msgstr ""
 "En tupel som innehåller programfönstrets initiala bredd, höjd och "
 "maximeringstillstånd."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9557,8 +5143,6 @@ msgid_plural "%u Outputs"
 msgstr[0] "%u utgång"
 msgstr[1] "%u utgångar"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9566,12 +5150,3123 @@ msgid_plural "%u Inputs"
 msgstr[0] "%u ingång"
 msgstr[1] "%u ingångar"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Systemljud"
+#~ msgid "System Bus"
+#~ msgstr "Systembuss"
 
-#~ msgid "Add a Printer…"
-#~ msgstr "Lägg till en skrivare…"
+#~ msgid "Full access"
+#~ msgstr "Fullständig åtkomst"
+
+#~ msgid "Session Bus"
+#~ msgstr "Sessionsbuss"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Fullständig åtkomst till /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Har nätverksåtkomst"
+
+#~ msgid "Home"
+#~ msgstr "Hem"
+
+#~ msgid "Read-only"
+#~ msgstr "Skrivskyddat"
+
+#~ msgid "File System"
+#~ msgstr "Filsystem"
+
+#~ msgid "Can change settings"
+#~ msgstr "Kan ändra inställningar"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s har följande inbyggda behörigheter. Dessa kan inte ändras. Om du är "
+#~ "bekymrad över dessa behörigheter bör du överväga att ta bort detta "
+#~ "program."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u fil- och länktyp som öppnas av programmet"
+#~ msgstr[1] "%u fil- och länktyper som öppnas av programmet"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> används för att öppna följande typer av filer och länkar."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s diskutrymme används."
+
+#~ msgid "Select a picture"
+#~ msgstr "Välj en bild"
+
+#~ msgid "_Open"
+#~ msgstr "_Öppna"
+
+#~ msgid "multiple sizes"
+#~ msgstr "flera storlekar"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Ingen skrivbordsbakgrund"
+
+#~ msgid "Current background"
+#~ msgstr "Aktuell bakgrund"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Placera din kalibreringsenhet ovanpå kvadraten och tryck ”Starta”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Flytta din kalibreringsenhet till kalibreringspositionen och välj "
+#~ "”Fortsätt”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "Flytta din kalibreringsenhet till ytpositionen och välj ”Fortsätt”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Stäng igen den bärbara datorns lock"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Kunde inte återhämta sig från ett internt fel som uppstod."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Verktyg som krävs för kalibrering är inte installerade."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profilen kan inte genereras."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Målets vitpunkt kunde inte hämtas."
+
+#~ msgid "Complete!"
+#~ msgstr "Färdig!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrering misslyckades!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Du kan ta bort kalibreringsenheten."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Stör inte kalibreringsenheten under pågående kalibrering"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Skärm för bärbar dator"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Inbyggd webbkamera"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s-skärm"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s-bildläsare"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s-kamera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s-skrivare"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s-webbkamera"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Aktivera färghantering för %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Visa färgprofiler för %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Inte kalibrerad"
+
+#~ msgid "Default: "
+#~ msgstr "Standard: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Färgrymd: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Testprofil: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Välj ICC-profil"
+
+#~ msgid "_Import"
+#~ msgstr "_Importera"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "ICC-profiler som stöds"
+
+#~ msgid "All files"
+#~ msgstr "Alla filer"
+
+#~ msgid "Save Profile"
+#~ msgstr "Spara profil"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Skapa en färgprofil för den valda enheten"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Kunde inte hitta mätinstrumentet. Kontrollera att det är påslaget och "
+#~ "korrekt anslutet."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Mätinstrumentet saknar stöd för skrivarprofilering."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Enhetstypen stöds för närvarande inte."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standardrymd"
+
+#~ msgid "Test Profile"
+#~ msgstr "Testprofil"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Automatisk"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Låg kvalitet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Mellankvalitet"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Hög kvalitet"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Standard RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Standard CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Standardgrå"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Kalibreringsdata tillhandahållen av tillverkare"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Fullskärmskorrigering inte möjlig med denna profil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Denna profil är kanske inte helt korrekt längre"
+
+#~ msgid "Other…"
+#~ msgstr "Övriga…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Lås upp för att ändra inställningar"
+
+#~ msgid "Today"
+#~ msgstr "I dag"
+
+#~ msgid "Yesterday"
+#~ msgstr "I går"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d timme"
+#~ msgstr[1] "%d timmar"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d minut"
+#~ msgstr[1] "%d minuter"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d sekund"
+#~ msgstr[1] "%d sekunder"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Surfzon"
+
+#~ msgid "24-hour"
+#~ msgstr "24-timmars"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %I:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%I:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Att skicka in rapporter om tekniska problem hjälper oss att förbättra %s. "
+#~ "Rapporter skickas anonymt och rensas på personliga data. %s"
+
+#~ msgid "On"
+#~ msgstr "På"
+
+#~ msgid "Off"
+#~ msgstr "Av"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Verkställ ändringar?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Ändringar kan inte verkställas"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Detta kan bero på hårdvarubegränsningar."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Liggande"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Stående höger"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Stående vänster"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Liggande (omvänt)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Säkerhetsstart är aktiv"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Säkerhetsstart förhindrar skadlig programvara från att läsas in när "
+#~ "enheten startas. Det är för närvarande påslaget och fungerar korrekt."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Säkerhetsstart har problem"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Säkerhetsstart förhindrar skadlig programvara från att läsas in när "
+#~ "enheten startas. Det är för närvarande påslaget, men kommer inte att "
+#~ "fungera på grund av att det har en ogiltig nyckel."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Problem med säkerhetsstart kan ofta lösas från din dators fasta UEFI-"
+#~ "programvaruinställningar (BIOS) och din hårdvarutillverkare kan ge "
+#~ "information om hur du gör detta."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Kontakta din hårdvarutillverkare eller IT-supportleverantör för hjälp."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Säkerhetsstart är avstängd"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Säkerhetsstart förhindrar skadlig programvara från att läsas in när "
+#~ "enheten startas. Det är för närvarande avstängt."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Säkerhetsstart kan ofta aktiveras från din dators fasta UEFI-"
+#~ "programvaruinställningar (BIOS). Kontakta din hårdvarutillverkare eller "
+#~ "IT-supportleverantör för hjälp."
+
+#~ msgid "Passed"
+#~ msgstr "Lyckades"
+
+#~ msgid "Failed"
+#~ msgstr "Misslyckades"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Enheten överensstämmer med HSI-nivå %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Säkerhetsnivå 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Den här enheten har inget skydd mot hårdvarusäkerhetsproblem. Detta kan "
+#~ "bero på ett problem med konfigurationen av hårdvara eller fast "
+#~ "programvara. Du rekommenderas kontakta din IT-supportleverantör."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Säkerhetsnivå 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Den här enheten har minimalt skydd mot hårdvarusäkerhetsproblem. Detta är "
+#~ "den lägsta nivån av enhetssäkerhet och ger bara skydd mot enkla "
+#~ "säkerhetshot."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Säkerhetsnivå 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Den här enheten har grundläggande skydd mot hårdvarusäkerhetsproblem. "
+#~ "Detta ger skydd mot några vanliga säkerhetshot."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Säkerhetsnivå 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Den här enheten har utökat skydd mot hårdvarusäkerhetsproblem. Detta är "
+#~ "den högsta nivån av enhetssäkerhet och ger skydd mot avancerade "
+#~ "säkerhetshot."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Säkerhetsnivåer är inte tillgängliga för den här enheten."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Kontakta din hårdvarutillverkare för hjälp med säkerhetsuppdateringar."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Det kan vara möjligt att lösa det här problemet i enhetens fasta UEFI-"
+#~ "programvaruinställningar eller av en supporttekniker."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Det kan vara möjligt att lösa det här problemet i enhetens fasta UEFI-"
+#~ "programvaruinställningar."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Det kan vara möjligt för en supporttekniker att lösa problemet."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Skyddad mot skadlig programvara när enheten startar."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Säkerhetsstart har problem"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Visst skydd när enheten startas."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Säkerhetsstart är av"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Inget skydd när enheten startas."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Det här problemet kan ha orsakats av en ändring i fasta UEFI-"
+#~ "programvaruinställningar, en ändring av operativsystemets konfiguration "
+#~ "eller på grund av skadlig programvara på systemet."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Det här problemet kan ha orsakats av en ändring i de fasta UEFI-"
+#~ "programvaruinställningarna eller på grund av skadlig programvara på "
+#~ "systemet."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Det här problemet kan ha orsakats av en ändring av operativsystemets "
+#~ "konfiguration eller på grund av skadlig programvara på systemet."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Utsatt för allvarliga säkerhetshot."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Begränsat skydd mot enkla säkerhetshot."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Skyddad mot vanliga säkerhetshot."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Skyddad mot ett brett utbud av säkerhetshot."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Omfattande skydd"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Skrivskydd för fast programvara"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Skrivskyddslås för fast programvara"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "BIOS-region för fast programvara"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "BIOS-beskrivare för fast programvara"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "DMA-skydd före uppstart"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard verifierad uppstart"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM-skyddad"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard-felpolicy"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard säkring"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET stöds"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET aktiv"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Krypterat RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU-skydd"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Lockdown för Linux-kärnan"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Verifiering av Linux-kärnan"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux-växlingsutrymme"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Gå till vänteläge i RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Gå till inaktivt läge"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI-plattformsnyckel"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI säkerhetsstart"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM-plattformskonfiguration"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM-rekonstruktion"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine-tillverkningsläge"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine-åsidosättning"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine-version"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Uppdateringar för fast programvara"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Attestering av fast programvara"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Verifiering av uppdateraren av fast programvara"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Plattformsfelsökning"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Processorsäkerhetskontroller"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD-tillbakarullningsskydd"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Återuppspelningsskydd för AMD:s fasta programvara"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Skrivskydd för AMD:s fasta programvara"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Plattform med säkring"
+
+#~ msgid "Valid"
+#~ msgstr "Giltig"
+
+#~ msgid "Not Valid"
+#~ msgstr "Ogiltig"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Inaktiverad"
+
+#~ msgid "Locked"
+#~ msgstr "Låst"
+
+#~ msgid "Not Locked"
+#~ msgstr "Upplåst"
+
+#~ msgid "Encrypted"
+#~ msgstr "Krypterad"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Okrypterad"
+
+#~ msgid "Tainted"
+#~ msgstr "Befläckad"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Obefläckad"
+
+#~ msgid "Found"
+#~ msgstr "Hittad"
+
+#~ msgid "Not Found"
+#~ msgstr "Hittades inte"
+
+#~ msgid "Supported"
+#~ msgstr "Stöds"
+
+#~ msgid "Not Supported"
+#~ msgstr "Stöds inte"
+
+#~ msgid "Unknown"
+#~ msgstr "Okänd"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bitars"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bitars"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Okänt"
+
+#~ msgid "Not Available"
+#~ msgstr "Inte tillgänglig"
+
+#~ msgid "System Logo"
+#~ msgstr "Systemlogotyp"
+
+#~ msgid "No input sources found"
+#~ msgstr "Inga inmatningskällor hittades"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Övriga"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Anpassade kortkommandon"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Alternativa tecken-tangenten kan användas för att mata in ytterligare "
+#~ "tecken. Dessa skrivs ibland som ett tredje alternativ på ditt tangentbord."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Vänster Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Höger Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Vänster super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Höger super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menytangent"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Höger Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Compose-tangenten tillåter ett stort urval av tecken att matas in. För "
+#~ "att använda den, tryck på Compose-tangenten och sedan en sekvens av "
+#~ "tecken. Till exempel kommer Compose-tangenten följt av <b>C</b> och <b>o</"
+#~ "b> att mata in <b>©</b>, <b>a</b> följt av <b>'</b> kommer att mata in "
+#~ "<b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Inmatningsskällor kan växlas genom att använda tangentbordsgenvägen %s.\n"
+#~ "Denna kan ändras i inställningarna för tangentbordsgenvägar."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d ändrad"
+#~ msgstr[1] "%d ändrade"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Återställ alla kortkommandon?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Att återställa kortkommandona kan påverka dina anpassade kortkommandon. "
+#~ "Detta kan inte ångras."
+
+#~ msgid "Reset All"
+#~ msgstr "Återställ alla"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s används redan för %s. Om du vill ersätta det kommer %s att inaktiveras"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Mata in det nya kortkommandot"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Ställ in anpassat kortkommando"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Ställ in kortkommando"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Mata in nytt kortkommando för att ändra %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Lägg till anpassat kortkommando"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Tvåfingersrullning"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Fem klick, dags för Gegl!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Dubbelklick med primär musknapp"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Enkelklick, primär knapp"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Dubbelklick med mellanmusknapp"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Enkelklick med mellanmusknappen"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Dubbelklick med sekundära musknappen"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Enkelklick med sekundära musknappen"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Nätverkshanteraren måste vara aktiv."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Osäkert nätverk (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Säkert nätverk (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Säkert nätverk (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Säkert nätverk (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Säkert nätverk"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Att slå på surfzonen kommer att koppla från %s, och det kommer inte vara "
+#~ "möjligt att komma åt internet genom Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Måste bestå av minst 8 tecken"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Stoppa surfzonen och koppla ifrån eventuella användare?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Stoppa surfzon"
+
+#~ msgid "Preserve"
+#~ msgstr "Bevara"
+
+#~ msgid "Permanent"
+#~ msgstr "Permanent"
+
+#~ msgid "Random"
+#~ msgstr "Slumpmässig"
+
+#~ msgid "Stable"
+#~ msgstr "Stabil"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "MAC-adressen som anges här kommer att användas som hårdvaruadress för "
+#~ "nätverksenheten som denna anslutning är aktiverad på. Denna funktion är "
+#~ "känd som MAC-kloning eller ”spoofing”. Exempel: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "Never"
+#~ msgstr "Aldrig"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2,4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2,4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Svag"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Bra"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Utmärkt"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Glöm anslutning"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Ta bort anslutningsprofil"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Ta bort VPN"
+
+#~ msgid "Details"
+#~ msgstr "Detaljer"
+
+#~ msgid "automatic"
+#~ msgstr "automatisk"
+
+#~ msgid "Identity"
+#~ msgstr "Identitet"
+
+#~ msgid "Delete Address"
+#~ msgstr "Ta bort adress"
+
+#~ msgid "Delete Route"
+#~ msgstr "Standardrutt"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bitars nyckel (Hex eller ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bitars lösenfras"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamisk WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Enterprise"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Personal"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Kunde inte öppna anslutningsredigeraren"
+
+#~ msgid "New Profile"
+#~ msgstr "Ny profil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Ogiltig inställning %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Ogiltig inställning %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Importera från fil…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Lägg till VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Kan inte importera VPN-anslutning"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Filen ”%s” kan inte läsas eller innehåller ej igenkänd VPN-"
+#~ "anslutningsinformation\n"
+#~ "\n"
+#~ "Fel: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Välj fil att importera"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "En fil med namnet ”%s” finns redan."
+
+#~ msgid "_Replace"
+#~ msgstr "E_rsätt"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Vill du ersätta %s med VPN-anslutningen du sparar?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Kan inte exportera VPN-anslutning"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN-anslutningen ”%s” kunde inte exporteras till %s.\n"
+#~ "\n"
+#~ "Fel: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Exportera VPN-anslutning"
+
+#~ msgid "never"
+#~ msgstr "aldrig"
+
+#~ msgid "today"
+#~ msgstr "i dag"
+
+#~ msgid "yesterday"
+#~ msgstr "i går"
+
+#~ msgid "Last used"
+#~ msgstr "Senast använd"
+
+#~ msgid "Add new connection"
+#~ msgstr "Lägg till ny anslutning"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Nätverksdetaljer för markerade nätverk, inklusive lösenord och anpassad "
+#~ "konfiguration kommer att gå förlorade."
+
+#~ msgid "_Forget"
+#~ msgstr "_Glöm"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Kända trådlösa nätverk"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Glöm"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Systempolicyn tillåter ej användning som surfzon"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Den trådlösa enheten stöder inte användning av surfzoner"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Web Proxy Autodiscovery (WPAD) används när en konfigurations-URL inte "
+#~ "tillhandahålls."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Detta rekommenderas inte för opålitliga publika nätverk."
+
+#~ msgid "Status unknown"
+#~ msgstr "Okänd status"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Ohanterad"
+
+#~ msgid "Unavailable"
+#~ msgstr "Otillgänglig"
+
+#~ msgid "Connecting"
+#~ msgstr "Ansluter"
+
+#~ msgid "Authentication required"
+#~ msgstr "Autentisering krävs"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Kopplar från"
+
+#~ msgid "Connection failed"
+#~ msgstr "Anslutningen misslyckades"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Okänd status (saknas)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Konfiguration misslyckades"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP-konfiguration misslyckades"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP-konfiguration passerade slutdatum"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Hemligheter krävdes, men tillhandahölls inte"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x-supplikanten kopplades från"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Konfiguration av 802.1x-supplikanten misslyckades"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x-supplikanten misslyckades"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x-supplikanten tog för lång tid på sig att autentisera"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Misslyckades med att starta PPP-tjänsten"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP-tjänsten kopplades från"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP misslyckades"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Misslyckades med att starta DHCP-klienten"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP-klient fel"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP-klienten misslyckades"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Misslyckades med att starta tjänsten för delad anslutning"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Tjänsten för delad anslutning misslyckades"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Kunde inte starta AutoIP-tjänsten"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Fel i AutoIP-tjänsten"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP-tjänsten misslyckades"
+
+#~ msgid "Line busy"
+#~ msgstr "Linjen är upptagen"
+
+#~ msgid "No dial tone"
+#~ msgstr "Ingen rington"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Bärvågen kunde inte etableras"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Tidsgränsen för uppringningen överskreds"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Uppringningen misslyckades"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Initiering av modem misslyckades"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Misslyckades med att välja angiven APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Söker inte efter nätverk"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Nätverksregistrering nekades"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Tidsgränsen för nätverksregistrering överstegs"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Misslyckades att registrera med begärt nätverk"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Kontroll av PIN-kod misslyckades"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Enheten kan sakna fast programvara"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Anslutningen försvann"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Befintlig anslutning antogs"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modemet kunde inte hittas"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth-anslutningen misslyckades"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM-kortet är inte isatt"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM-kortet kräver PIN-kod"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM-kortet kräver PUK-kod"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Fel på SIM-kortet"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Anslutningsberoende misslyckades"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Fast programvara saknas"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kabeln är frånkopplad"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "odefinierat fel i 802.1X-säkerhet (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "ingen fil vald"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "ospecificerat fel vid validering av eap-metodfil"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Privata DER-, PEM-, PKCS#12- eller PGP-nycklar"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER- eller PEM-certifikat"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "saknar PAC-fil för EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC-filer (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "saknar EAP-LEAP-användarnamn"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "saknar EAP-LEAP-lösenord"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "ogiltigt CA-certifikat för EAP-PEAP: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "ogiltigt CA-certifikat för EAP-PEAP: inget certifikat angivet"
+
+#~ msgid "missing EAP username"
+#~ msgstr "saknar EAP-användarnamn"
+
+#~ msgid "missing EAP password"
+#~ msgstr "saknar EAP-lösenord"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "saknar EAP-TLS-identitet"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "ogiltigt CA-certifikat för EAP-TLS: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "ogiltigt CA-certifikat för EAP-TLS: inget certifikat angivet"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "ogiltig privat nyckel för EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "ogiltigt EAP-TLS-användarcertifikat: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Okrypterade privata nycklar är osäkra"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Den valda privata nyckeln verkar inte vara skyddad av ett lösenord. Det "
+#~ "skulle kunna tillåta säkerhetsreferenser att bli komprometterade. Välj en "
+#~ "lösenordsskyddad privat nyckel.\n"
+#~ "\n"
+#~ "(Du kan lösenordsskydda din privata nyckel med openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Välj ditt personliga certifikat"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Välj din privata nyckel"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "ogiltigt CA-certifikat för EAP-TTLS: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "ogiltigt CA-certifikat för EAP-TTLS: inget certifikat angivet"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Okänt fel vid validering av 802.1X-säkerhet"
+
+#~ msgid "Select a file"
+#~ msgstr "Välj en fil"
+
+#~ msgid "missing leap-username"
+#~ msgstr "saknar leap-användarnamn"
+
+#~ msgid "missing leap-password"
+#~ msgstr "saknar leap-lösenord"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Wi-Fi-lösenord saknas."
+
+#~ msgid "missing wep-key"
+#~ msgstr "saknar wep-nyckel"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "ogiltig wep-nyckel: nyckel med en längd på %zu får endast innehålla "
+#~ "hexadecimala siffror"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "ogiltig wep-nyckel: nyckel med en längd på %zu får endast innehålla ascii-"
+#~ "tecken"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "ogiltig wep-nyckel: felaktig nyckellängd %zu. En nyckel måste ha antingen "
+#~ "längden 5/13 (ascii) eller 10/26 (hex)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "ogiltig wep-nyckel: lösenfras får inte vara tom"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "ogiltig wep-nyckel: lösenfras måste vara kortare än 64 tecken"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "ogiltig wpa-psk: ogiltig nyckellängd %zu. Måste vara [8,63] byte eller 64 "
+#~ "hexadecimala siffror"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "ogiltig wpa-psk: kan inte tolka nyckel med 64 byte som hexadecimal"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Övriga"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s togs bort"
+
+#~ msgid "Error removing account"
+#~ msgstr "Fel vid borttagning av kontot"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s-konto"
+
+#~ msgid "Remove Account"
+#~ msgstr "Ta bort konto"
+
+#~ msgid "Unknown time"
+#~ msgstr "Okänd tid"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s tills fullt uppladdad"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Varning: %s återstår"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s återstår"
+
+#~ msgid "Fully charged"
+#~ msgstr "Fullt uppladdad"
+
+#~ msgid "Not charging"
+#~ msgstr "Laddar inte"
+
+#~ msgid "Empty"
+#~ msgstr "Tom"
+
+#~ msgid "Charging"
+#~ msgstr "Laddar upp"
+
+#~ msgid "Discharging"
+#~ msgstr "Laddar ur"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Trådlös mus"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Trådlöst tangentbord"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Avbrottsfri kraftförsörjning (UPS)"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Handdator"
+
+#~ msgid "Cellphone"
+#~ msgstr "Mobiltelefon"
+
+#~ msgid "Media player"
+#~ msgstr "Mediaspelare"
+
+#~ msgid "Tablet"
+#~ msgstr "Ritplatta"
+
+#~ msgid "Computer"
+#~ msgstr "Dator"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Inmatningsenhet för spel"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Huvudsaklig"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Extra"
+
+#~ msgid "Batteries"
+#~ msgstr "Batterier"
+
+#~ msgid "When _idle"
+#~ msgstr "När led_ig"
+
+#~ msgid "Suspend"
+#~ msgstr "Försätt i vänteläge"
+
+#~ msgid "Power Off"
+#~ msgstr "Stäng av"
+
+#~ msgid "Hibernate"
+#~ msgstr "Försätt i viloläge"
+
+#~ msgid "Nothing"
+#~ msgstr "Ingenting"
+
+#~ msgid "When on battery power"
+#~ msgstr "När på batteriström"
+
+#~ msgid "When plugged in"
+#~ msgstr "När ansluten"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Aldrig"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Automatiskt vänteläge"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Prestandaläge tillfälligt inaktiverat på grund av hög arbetstemperatur."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Knä upptäckt: prestandaläge är otillgängligt för tillfället. Flytta "
+#~ "enheten till en stabil yta för att återställa."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Prestandaläge är tillfälligt inaktiverat."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Låg batterinivå: strömsparare aktiverad. Tidigare läge kommer att "
+#~ "återställas när batteriet har laddats tillräckligt."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Strömsparläge aktiverades av ”%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Prestandaläge aktiverades av ”%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Prestanda"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Hög prestanda och strömförbrukning."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Balanserad"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Standardprestanda och strömförbrukning."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Strömsparare"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Minskad prestanda och strömförbrukning."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Skrivaren ”%s” har tagits bort"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Misslyckades med att lägga till ny skrivare."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Det gick inte att läsa in användargränssnittet: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Lås upp för att lägga till skrivare och ändra inställningar"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Detaljer för %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Ingen lämplig drivrutin kunde hittas"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Välj PPD-fil"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript-skrivarbeskrivningsfiler (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect-skrivare"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD-skrivare"
+
+#~ msgid "One Sided"
+#~ msgstr "Enkelsidig"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Långsida (standard)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kortsida (vänd)"
+
+#~ msgid "Portrait"
+#~ msgstr "Porträtt"
+
+#~ msgid "Landscape"
+#~ msgstr "Landskap"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Omvänt landskap"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Omvänt porträtt"
+
+#~ msgid "Resume"
+#~ msgstr "Fortsätt"
+
+#~ msgid "Pause"
+#~ msgstr "Pausa"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Väntar"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Pausad"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Autentisering krävs"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Behandlar"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Stoppad"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Avbruten"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Avbruten"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Färdig"
+
+# TODO: front of the queue?
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Flytta det här jobbet längst fram i kön"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — aktiva jobb"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Ange autentiseringsuppgifter för att skriva ut från %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Lås upp skrivarserver"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Lås upp %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Ange ditt användarnamn och lösenord för att se skrivare på %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Söker efter skrivare"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Seriellport"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Parallellport"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Plats: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adress: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Server begär autentisering"
+
+#~ msgid "Two Sided"
+#~ msgstr "Dubbelsidig"
+
+#~ msgid "Paper Type"
+#~ msgstr "Papperstyp"
+
+#~ msgid "Paper Source"
+#~ msgstr "Papperskälla"
+
+#~ msgid "Output Tray"
+#~ msgstr "Utskriftsfack"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Upplösning"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript-förfiltrering"
+
+#~ msgid "Pages per side"
+#~ msgstr "Sidor per blad"
+
+#~ msgid "Orientation"
+#~ msgstr "Orientering"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Allmänt"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Sidinställningar"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Installerbara alternativ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Jobb"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Bildkvalitet"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Färg"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Slutför"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Avancerat"
+
+#~ msgid "Test page"
+#~ msgstr "Testsida"
+
+#~ msgid "Auto Select"
+#~ msgstr "Välj automatiskt"
+
+#~ msgid "Printer Default"
+#~ msgstr "Skrivarens standardinställning"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Bädda enbart in GhostScript-typsnitt"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Konvertera till PS nivå 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Konvertera till PS nivå 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Ingen förfiltrering"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Rengör skrivarhuvuden"
+
+#~ msgid "Out of toner"
+#~ msgstr "Slut på toner"
+
+#~ msgid "Low on developer"
+#~ msgstr "Nästan slut på framkallningsvätska"
+
+#~ msgid "Out of developer"
+#~ msgstr "Slut på framkallningsvätska"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Nästan slut på färg"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Slut på färg"
+
+#~ msgid "Open cover"
+#~ msgstr "Luckan är öppen"
+
+#~ msgid "Open door"
+#~ msgstr "Luckan är öppen"
+
+#~ msgid "Low on paper"
+#~ msgstr "Låg pappersnivå"
+
+#~ msgid "Out of paper"
+#~ msgstr "Slut på papper"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Frånkopplad"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Stoppad"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Skräpkorgen är nästan full"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Skräpkorgen är full"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Den optiska fototrumman är nära slutet på sin livstid"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Den optiska fototrumman är inte längre funktionsduglig"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Redo"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Accepterar inte jobb"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Behandlar"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Imperial"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrisk"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Fråga vad som ska göras"
+
+#~ msgid "Do nothing"
+#~ msgstr "Gör ingenting"
+
+#~ msgid "Open folder"
+#~ msgstr "Öppna mapp"
+
+#~ msgid "Other Media"
+#~ msgstr "Övriga media"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Välj ett program för ljud-cd-skivor"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Välj ett program för video-dvd-skivor"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Välj ett program att köra när en musikspelare ansluts"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Välj ett program att köra när en kamera ansluts"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Välj ett program för program-cd-skivor"
+
+#~ msgid "audio DVD"
+#~ msgstr "ljud-dvd"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "tom Blu-ray-skiva"
+
+#~ msgid "blank CD disc"
+#~ msgstr "tom cd-skiva"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "tom dvd-skiva"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "tom HD DVD-skiva"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray-videoskiva"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-boksläsare"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD-videoskiva"
+
+#~ msgid "Picture CD"
+#~ msgstr "Bildcd"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video-cd"
+
+#~ msgid "Video CD"
+#~ msgstr "Videocd"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Skärmen stängs av"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 sekunder"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "En minut"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "Två minuter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "Tre minuter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "Fem minuter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 minuter"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "En timme"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "En minut"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "Två minuter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "Tre minuter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "Fyra minuter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "Fem minuter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "Åtta minuter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "Tio minuter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "Tolv minuter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 minuter"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Aldrig"
+
+#~ msgid "Select Location"
+#~ msgstr "Välj plats"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No applications found"
+#~ msgstr "Inga program hittades"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Inga nätverk markerade för delning"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "På"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Av"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Aktiverad"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Aktiv"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Välj en mapp"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Aktivera mediadelning"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Fildelning låter dig dela din publika mapp med andra på det nätverk du "
+#~ "använder för tillfället: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Då fjärrinloggning är aktiverad kan fjärranvändare ansluta med det säkra "
+#~ "skalkommandot:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Aktivera personlig mediadelning"
+
+#~ msgid "Device name copied"
+#~ msgstr "Enhetsnamn kopierat"
+
+#~ msgid "Device address copied"
+#~ msgstr "Enhetsadress kopierad"
+
+#~ msgid "Username copied"
+#~ msgstr "Användarnamn kopierat"
+
+#~ msgid "Password copied"
+#~ msgstr "Lösenord kopierat"
+
+#~ msgid "Custom"
+#~ msgstr "Anpassat"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Testar %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Frånkopplad"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Ansluter"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Ansluten"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Auktorisering krävs"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Auktoriserar"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Reducerad funktionalitet"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Ansluten och auktoriserad"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Okänd"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Auktoriserades:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Anslöts:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Registrerades:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Misslyckades med att auktorisera enhet: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Misslyckades med att glömma enheten: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Fel"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Auktoriserad"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt-undersystemet (boltd) är inte installerat eller inte korrekt "
+#~ "konfigurerat."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Endast USB- och Display Port-enheter kan kopplas in."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt kunde inte detekteras.\n"
+#~ "Antingen saknar systemet stöd för Thunderbolt, eller så har det "
+#~ "inaktiverats i BIOS, eller så har det ställts in till en säkerhetsnivå "
+#~ "som inte stöds i BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Stöd för Thunderbolt har inaktiverats i BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Säkerhetsnivå för Thunderbolt kunde inte avgöras."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Fel vid växling av direktläge: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Standard"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Mellan"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Stor"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Större"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Störst"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d bildpunkt"
+#~ msgstr[1] "%d bildpunkter"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kort"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ skärm"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ skärm"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ skärm"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Lång"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "En timme"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "En dag"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "Två dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "Tre dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "Fyra dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "Fem dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "Sex dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "Sju dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 dagar"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 dagar"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Töm alla objekt i papperskorgen?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Alla objekt i papperskorgen kommer att tas bort permanent."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Töm papperskorgen"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Radera alla tillfälliga filer?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Alla tillfälliga filer kommer att raderas permanent."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Ta bort tillfälliga filer"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "En dag"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "Sju dagar"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 dagar"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "För alltid"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Ska matcha din inloggningsleverantörs webbadress."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Misslyckades med att lägga till konto"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Misslyckades med att registrera konto"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Inget stöd för att autentisera med denna domän"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Misslyckades med att ansluta till domänen"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Inloggningsnamnet fungerade inte.\n"
+#~ "Prova igen."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Inloggningslösenordet fungerade inte.\n"
+#~ "Prova igen."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Misslyckades med att logga in på domänen"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Kunde inte hitta domänen. Kanske felstavade du den?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Bläddra efter fler bilder"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "enheten behöver tas i anspråk för att utföra denna åtgärd"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "enheten har redan tagits i anspråk av en annan process"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "du har inte rättigheter att utföra åtgärden"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "inga avtryck har registrerats"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Misslyckades med att kommunicera med enheten under registrering"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Misslyckades med att kommunicera med fingeravtrycksläsaren"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Misslyckades med att kommunicera med fingeravtrycksdemonen"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Misslyckades med att lista fingeravtryck: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Misslyckades med att ta bort sparade fingeravtryck: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Vänster tumme"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Vänster långfinger"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Vänster pekfinger"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Vänster ringfinger"
+
+#~ msgid "Left little finger"
+#~ msgstr "Vänster lillfinger"
+
+#~ msgid "Right thumb"
+#~ msgstr "Höger tumme"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Höger långfinger"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Höger pekfinger"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Höger ringfinger"
+
+#~ msgid "Right little finger"
+#~ msgstr "Höger lillfinger"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Okänt finger"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Färdig"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Fingeravtrycksenheten kopplades från"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Fingeravtrycksenhetens utrymme är fullt"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Misslyckades med att registrera nytt fingeravtryck"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Misslyckades med att starta registrering: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Misslyckades med att registrera nytt fingeravtryck"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Misslyckades med att stoppa registrering: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Lyft och placera upprepat ditt finger på läsaren för att registrera ditt "
+#~ "fingeravtryck"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "_Registrera detta finger på nytt…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Läs av nytt fingeravtryck"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Misslyckades med att släppa fingeravtrycksenheten %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Problem vid läsning av enhet"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Misslyckades med att begära fingeravtrycksenheten %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Misslyckades med att erhålla fingeravtrycksenheter: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Denna vecka"
+
+#~ msgid "Last Week"
+#~ msgstr "Förra veckan"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Session avslutad"
+
+#~ msgid "Session Started"
+#~ msgstr "Session påbörjad"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Kontoaktivitet"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Välj ett annat lösenord."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Ange ditt aktuella lösenord igen."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Lösenordet kunde inte ändras"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Kan inte automatiskt gå med i denna typ av domän"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Ingen sådan domän eller sfär funnen"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Kan inte logga in som %s på %s-domänen"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Ogiltigt lösenord, försök igen"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Det gick inte att ansluta till %s-domänen: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Misslyckades med att ta bort användaren"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Misslyckades med att ta bort fjärrhanterad användare"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Du kan inte ta bort ditt egna konto."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s är fortfarande inloggad"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Att ta bort en användare när de är inloggade kan medföra att systemet "
+#~ "hamnar i ett inkonsistent tillstånd."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Vill du behålla filer tillhörande %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Det är möjligt att behålla hemkatalogen, e-postkö och tillfälliga filer "
+#~ "när ett användarkonto tas bort."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Ta bort filer"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Behåll filer"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "Är du säker på att du vill ta bort fjärrhanterade kontot för %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Ta bort"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Kontot är inaktiverat"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Ska ställas in vid nästa inloggning"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "Logged in"
+#~ msgstr "Inloggad"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Misslyckades med att kontakta kontotjänsten"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Försäkra dig om att kontotjänsten är installerad och aktiverad."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Den här panelen måste vara upplåst för att ändra denna inställning"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Ta bort markerat användarkonto"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klicka först på *-ikonen för att\n"
+#~ "ta bort markerat användarkonto"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Lås upp för att lägga till användare och ändra inställningar"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Det nya lösenordet måste skilja sig åt från det gamla."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Ändra några bokstäver och siffror."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Försök att ändra lösenordet lite mer."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Ett lösenord utan ditt användarnamn skulle vara starkare."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Undvik att använda ditt namn i lösenordet."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Undvika några av orden som ingår i lösenordet."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Undvik vanliga ord."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Undvik att kasta om befintliga ord."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Använd fler siffror."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Använd fler versaler."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Använd fler gemener."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Använd fler specialtecken som till exempel skiljetecken."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Använd en blandning av bokstäver, siffror och skiljetecken."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Undvik att upprepa samma tecken."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Undvik att repetera samma typ av tecken: du behöver blanda bokstäver, "
+#~ "siffror och skiljetecken."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Undvik sekvenser likt 1234 eller abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Lösenordet behöver vara längre. Försök att lägga till fler bokstäver, "
+#~ "siffror och skiljetecken."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Blanda versaler och gemener och försök använda en eller flera siffror."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Att lägga till fler bokstäver, siffror och skiljetecken kommer göra "
+#~ "lösenordet starkare."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Autentiseringen misslyckades"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Det nya lösenordet är för kort"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Det nya lösenordet är för enkelt"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Det gamla och det nya lösenordet är för lika"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Det nya lösenordet har används tidigare."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Det nya lösenordet måste innehålla numeriska- eller specialtecken"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Det gamla och det nya lösenordet är identiska"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Ditt lösenord har ändrats sedan du först autentiserades!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Det nya lösenordet innehåller inte tillräckligt många olika tecken"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Okänt fel"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Användarnamnet får vanligen endast innehålla små bokstäver från a-z, "
+#~ "siffror och följande tecken: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr ""
+#~ "Det användarnamnet är tyvärr inte tillgängligt. Försök med ett annat."
+
+#~ msgid "The username is too long."
+#~ msgstr "Användarnamnet är för långt."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Knapp %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Programdefinierad"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Skicka tangenttryckning"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Byt skärm"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Visa hjälp på skärmen"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Ritplatta monterad på skärm för bärbar dator"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Ritplatta monterad på extern skärm"
+
+#~ msgid "External tablet device"
+#~ msgstr "Extern ritplatteenhet"
+
+#~ msgid "All Displays"
+#~ msgstr "Alla skärm­ar"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Airbrush-styluspenna med tryck, lutning och integrerat reglage"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Airbrush-styluspenna med tryck, lutning och rotation"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Standardstyluspenna med tryck och lutning"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Standardstyluspenna med tryck"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Nytt kortkommando…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Operationen avbröts"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Fel:</b> Åtkomst nekad vid ändring av inställningar"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Fel:</b> Mobilutrustningsfel"
+
+#~ msgid "Not Registered"
+#~ msgstr "Inte registrerad"
+
+#~ msgid "Registered"
+#~ msgstr "Registrerad"
+
+#~ msgid "Roaming"
+#~ msgstr "Roaming"
+
+#~ msgid "Searching"
+#~ msgstr "Söker"
+
+#~ msgid "Denied"
+#~ msgstr "Nekad"
+
+#~ msgid "2G Only"
+#~ msgstr "Endast 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Endast 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Endast 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Endast 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (föredras)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (föredras), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (föredras), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (föredras), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (föredras)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (föredras), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (föredras), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (föredras)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (föredras), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (föredras), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (föredras)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (föredras), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (föredras), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (föredras)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (föredras), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (föredras), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (föredras)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (föredras), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (föredras)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (föredras), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (föredras)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (föredras), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (föredras)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (föredras), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (föredras)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (föredras), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (föredras)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (föredras), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Okänt"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Lås upp SIM-kort"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Tillhandahåll PIN-koden för SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Ange PIN för att låsa upp ditt SIM-kort"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Tillhandahåll PUK-koden för SIM %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Ange PUK för att låsa upp ditt SIM-kort"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Fel lösenord matades in."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK-koden ska vara ett 8-siffrigt tal"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Ange ny PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN-koden ska vara ett tal med 4-8 siffror"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Låser upp…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Telefonfel"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Ingen anslutning till telefon"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Operationen tillåts ej"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Operationen stöds ej"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM inte anslutet"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "PIN för SIM krävs"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "PUK för SIM krävs"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM-fel"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM upptaget"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Felaktigt lösenord"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "PIN2 för SIM krävs"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "PUK2 för SIM krävs"
+
+#~ msgid "Not found"
+#~ msgstr "Hittades inte"
+
+#~ msgid "No network service"
+#~ msgstr "Ingen nätverkstjänst"
+
+#~ msgid "Network timeout"
+#~ msgstr "Nätverkstidsgräns överskreds"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS-tjänster tillåts ej"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Roaming är inte tillåtet på området för denna plats"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Ospecificerat GPRS-fel"
+
+#~ msgid "No Error"
+#~ msgstr "Inget fel"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Åtgärden avbröts"
+
+#~ msgid "Access denied"
+#~ msgstr "Åtkomst nekad"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Okänt fel"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Visa versionsnummer"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Aktivera informativt läge"
+
+#~ msgid "Search for the string"
+#~ msgstr "Sök efter strängen"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Lista möjliga panelnamn och avsluta"
+
+#~ msgid "Panel to display"
+#~ msgstr "Panel att visa"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Tillgängliga paneler:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Systemljud"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER eller PEM-certifikat (*.der, *.pem, *.crt, *.cer)"
@@ -9766,9 +8461,6 @@ msgstr "Systemljud"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Ritplatta (absolut)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Styrplatta (relativ)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Inställningar för ritplatta"
@@ -10140,9 +8832,6 @@ msgstr "Systemljud"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "Kom direkt åt bluetooth-hårdvara"
-
-#~ msgid "Use your camera"
-#~ msgstr "Använd din kamera"
 
 #~ msgid "Print documents"
 #~ msgstr "Skriv ut dokument"
@@ -11004,9 +9693,6 @@ msgstr "Systemljud"
 #~ msgid "Remove your finger, and try swiping your finger again"
 #~ msgstr "Ta bort ditt finger och prova att dra ditt finger igen"
 
-#~ msgid "Disable image"
-#~ msgstr "Inaktivera bild"
-
 #~ msgid "Browse for more pictures…"
 #~ msgstr "Bläddra efter fler bilder…"
 
@@ -11071,9 +9757,6 @@ msgstr "Systemljud"
 
 #~ msgid "Mirrored"
 #~ msgstr "Speglad"
-
-#~ msgid "Secondary"
-#~ msgstr "Sekundär"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Arrangera kombinerade skärmar"
@@ -11232,9 +9915,6 @@ msgstr "Systemljud"
 #~ msgid "Mail"
 #~ msgstr "E-post"
 
-#~ msgid "Calendar"
-#~ msgstr "Kalender"
-
 #~ msgid "Contacts"
 #~ msgstr "Kontakter"
 
@@ -11386,9 +10066,6 @@ msgstr "Systemljud"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Rulla uppåt"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Rulla nedåt"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Rulla åt höger"

--- a/po/sv.po~
+++ b/po/sv.po~
@@ -1,0 +1,11678 @@
+# Swedish messages for gnome-control-center.
+# Copyright © 1998-2022 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Martin Wahlen <mva@sbbs.se>, 1998, 1999.
+# Christian Rose <menthos@menthos.com>, 2000, 2001, 2002, 2003, 2004, 2005.
+# Daniel Nylander <po@danielnylander.se>, 2006, 2007, 2008, 2009, 2010, 2011, 2012.
+# Josef Andersson <josef.andersson@fripost.org>, 2014.
+# Åke Engelbrektson <eson57@gmail.com>, 2014.
+# Anders Jonsson <anders.jonsson@norsjovallen.se>, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022.
+# Mattias Eriksson <snaggen@gmail.com>, 2015.
+# Sebastian Rasmussen <sebras@gmail.com>, 2015, 2016.
+# Luna Jernberg <droidbittin@gmail.com>, 2020, 2021, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-03 00:34+0000\n"
+"PO-Revision-Date: 2022-09-11 15:13+0200\n"
+"Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
+"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Systembuss"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Fullständig åtkomst"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Sessionsbuss"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Enheter"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Fullständig åtkomst till /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Nätverk"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Har nätverksåtkomst"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Hem"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Skrivskyddat"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Filsystem"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Inställningar"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Kan ändra inställningar"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s har följande inbyggda behörigheter. Dessa kan inte ändras. Om du är "
+"bekymrad över dessa behörigheter bör du överväga att ta bort detta program."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u fil- och länktyp som öppnas av programmet"
+msgstr[1] "%u fil- och länktyper som öppnas av programmet"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> används för att öppna följande typer av filer och länkar."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s diskutrymme används."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Program"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Inga program"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Installera några…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Öppna"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Visa detaljer"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Sök"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Ta emot systemsökningar och skicka resultat."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Inaktiverad"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Aviseringar"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Visa systemaviseringar."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Kör i bakgrunden"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Tillåt aktivitet när programmet är stängt."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Skärmbilder"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Ta skärmbilder när som helst."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Ändra bakgrundsbild"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Ändra skrivbordets bakgrundsbild."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Ljud"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Återge ljud."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Hindra kortkommandon"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Blockera standardtangentbordsgenvägar."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Ta bilder med kameran."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Spela in ljud med mikrofonen."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Platstjänster"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Få åtkomst till platsdata för enhet."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Inbyggda behörigheter"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Systemfunktioner som krävs av programmet"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Fil- &amp; länkassociationer"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Lagring"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Inga resultat hittades"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Försök med en annan sökning"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Fil- & länkassociationer"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Filtyper"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Länktyper"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Återställ"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Hur mycket diskutrymme detta program tar upp för programdata och cachar."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Program"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Data"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Cache"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Totalt</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Töm cache…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Styr diverse behörigheter och inställningar för program"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "program;flatpak;rättighet;behörighet;inställning;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Välj en bild"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Avbryt"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Öppna"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "flera storlekar"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Ingen skrivbordsbakgrund"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Aktuell bakgrund"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Stil"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Standard"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Mörk"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Bakgrund"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Lägg till bild…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Utseende"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Ändra din bakgrundsbild eller användargränssnittsfärgerna"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Bakgrundsbild;Wallpaper;Skrivbordsbakgrund;Skärm;Skrivbord;Stil;Ljus;Mörk;"
+"Utseende;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Aktivera"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Inget Bluetooth hittades"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Anslut en adapter för att använda Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth är avstängt"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Slå på för att ansluta enheter och ta emot filöverföringar."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Flygplansläge är på"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth är inaktiverat när flygplansläge är på."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Stäng av flygplansläge"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Flygplansläge i hårdvaran är på"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Slå av växelknappen för flygplansläge för att aktivera Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Slå på samt av Bluetooth och anslut dina enheter"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "dela;delning;share;blåtand;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kameran är avstängd"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Inget program kan ta foton eller spela in video."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Användning av kameran låter program fånga bilder och video. Att inaktivera "
+"kameran kan få vissa program att inte fungera som det är tänkt.\n"
+"\n"
+"Tillåt programmen nedan att använda din kamera."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Inga program har bett om åtkomst till kameran"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Skydda dina bilder"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr "kamera;foton;video;webbkamera;lås;privat;sekretess;integritet;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Placera din kalibreringsenhet ovanpå kvadraten och tryck ”Starta”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Flytta din kalibreringsenhet till kalibreringspositionen och välj ”Fortsätt”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Flytta din kalibreringsenhet till ytpositionen och välj ”Fortsätt”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Stäng igen den bärbara datorns lock"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Kunde inte återhämta sig från ett internt fel som uppstod."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Verktyg som krävs för kalibrering är inte installerade."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Profilen kan inte genereras."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Målets vitpunkt kunde inte hämtas."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Färdig!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrering misslyckades!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Du kan ta bort kalibreringsenheten."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Stör inte kalibreringsenheten under pågående kalibrering"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Skärmkalibrering"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Starta"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Fortsätt"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Färdig"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Skärm för bärbar dator"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Inbyggd webbkamera"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s-skärm"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s-bildläsare"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s-kamera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s-skrivare"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s-webbkamera"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Aktivera färghantering för %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Visa färgprofiler för %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Inte kalibrerad"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Standard: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Färgrymd: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Testprofil: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Välj ICC-profil"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Importera"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "ICC-profiler som stöds"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Alla filer"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Skärm"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Spara profil"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Spara"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Skapa en färgprofil för den valda enheten"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Kunde inte hitta mätinstrumentet. Kontrollera att det är påslaget och "
+"korrekt anslutet."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Mätinstrumentet saknar stöd för skrivarprofilering."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Enhetstypen stöds för närvarande inte."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Skärmkalibrering"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibreringskvalitet"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrering kommer att skapa en profil du kan använda för att färghantera "
+"din skärm. Ju längre du kalibrerar, desto bättre blir färgprofilens kvalitet."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Du kommer inte att kunna använda din dator medan kalibrering sker."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Kvalitet"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Ungefärlig tid"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibreringsenhet"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Välj sensorenhet du vill använda för kalibrering."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Skärmtyp"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Välj vilken skärmtyp som är ansluten."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profilvitpunkt"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Välj vitpunkt för skärmmål. De flesta skärmar ska kalibreras till D65-"
+"ljuskälla."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Skärmljusstyrka"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Vänligen ställ in skärmens ljusstyrka till den som är typisk för dig. "
+"Färghantering kommer att vara som mest korrekt vid denna ljusstyrkenivå."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternativt så kan du använda ljusstyrkenivån som en av de andra profilerna "
+"för denna enhet använder."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profilnamn"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Du kan använda en färgprofil på olika datorer eller till och med skapa "
+"profiler för olika belysningsförutsättningar."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profilnamn:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Sammandrag"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil skapad!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Kopiera profil"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Kräver skrivbar media"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Du kanske finner dessa instruktioner om hur man använder profilen på <a "
+"href=\"linux\">GNU/Linux-</a>, <a href=\"osx\">Apple OS X-</a> och <a "
+"href=\"windows\">Microsoft Windows</a> system användbara."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Lägg till profil"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Upptäckte problem. Profilen kanske inte fungerar korrekt. <a href=\"\">Visa "
+"detaljer.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Importera fil…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Lägg till"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "Varje enhet behöver en uppdaterad färgprofil för att färghanteras."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Läs mer"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Läs mer om färghantering"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Ställ in för alla användare"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Ställ in denna profil för alla användare på denna dator"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Aktivera"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Lägg till profil"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrera…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Kalibrera enheten"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Ta bort profil"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Visa detaljer"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Kunde inte upptäcka några enheter som kan färghanteras"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektor"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL bakgrundsbelysning)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED bakgrundsbelysning)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (vit LED-bakgrundsbelysning)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Brett färgomfång LCD (CCFL-bakgrundsbelysning)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Brett färgomfång LCD (RGB LED-bakgrundsbelysning)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Hög"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 minuter"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Mellan"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 minuter"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Låg"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 minuter"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Skärmspecifika"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (utskrifter och publicering)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (fotografi och grafik)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standardrymd"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Testprofil"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Automatisk"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Låg kvalitet"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Mellankvalitet"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Hög kvalitet"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Standard RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Standard CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Standardgrå"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Kalibreringsdata tillhandahållen av tillverkare"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Fullskärmskorrigering inte möjlig med denna profil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Denna profil är kanske inte helt korrekt längre"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Färg"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Kalibrera färgen för dina enheter såsom skärmar, kameror eller skrivare"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Färg;ICC;Profil;Kalibrera;Skrivare;Skärm;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Övriga…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Välj språk"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Välj"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Hittade inga språk"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Mer…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Lås upp för att ändra inställningar"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Några inställningar måste låsas upp innan de kan ändras."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Lås upp…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Öka timme"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Öka minut"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Tid"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Minska timme"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Minska minut"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "I dag"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "I går"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d timme"
+msgstr[1] "%d timmar"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minut"
+msgstr[1] "%d minuter"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekund"
+msgstr[1] "%d sekunder"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 sekunder"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Surfzon"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-timmars"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %I:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%I:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Dat­um & tid"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "År"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Månad"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Januari"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Februari"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Mars"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "April"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Maj"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Juni"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Juli"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Augusti"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "September"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Oktober"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "November"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "December"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Dag"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Tidszon"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Sök efter en stad"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Automatisk _datum &amp; tid"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Kräver internetåtkomst"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Datum &amp; _tid"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "A_utomatisk tidszon"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Kräver platstjänster aktiverade och internetåtkomst"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Aktiverad"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Tidsz_on"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Tids_format"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Ändra datum och tid, även tidszon"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Klocka;Tidszon;Plats;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Ändra systeminställningar för tid och datum"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Du måste autentisera dig för att ändra inställningar för tid eller datum."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Webb"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_E-post"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Kalender"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_usik"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Film"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Foton"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Standardprogram"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Konfigurera standardprogram"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "standard;program;föredragen;media;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Att skicka in rapporter om tekniska problem hjälper oss att förbättra %s. "
+"Rapporter skickas anonymt och rensas på personliga data. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Problemrapportering"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Automatisk problemrapportering"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Diagnostik"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Rapportera dina problem"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostik;krasch;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "På"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Av"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Verkställ ändringar?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Ändringar kan inte verkställas"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Detta kan bero på hårdvarubegränsningar."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Verkställ"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Bakåt"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Skärminställningar inaktiverade"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Flera skärmar"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Anslut"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Spegling"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Innehåller systemrad och Aktiviteter"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Primär skärm"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Nattbelysning"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Liggande"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Stående höger"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Stående vänster"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Liggande (omvänt)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Orientering"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Upplösning"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Uppdateringfrekvens"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Justera för TV"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Skala"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Nattbelysning otillgänglig"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Detta kan vara resultatet av grafikdrivrutinen som används eller att "
+"skrivbordet används på distans"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Tillfälligt inaktiverad till i morgon"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Starta om filter"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Nattbelysning gör skärmens färg varmare. Detta kan underlätta att förhindra "
+"trötthet i ögonen och sömnlöshet."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Schema"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Solnedgång till soluppgång"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Manuellt schema"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Tid"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Från"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Timme"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Minut"
+
+# Enligt ICU-locale: https://www.localeplanet.com/icu/sv/index.html
+# Glibc är i stället tom: https://lh.2xlibre.net/locale/sv_SE/
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "fm"
+
+# Enligt ICU-locale: https://www.localeplanet.com/icu/sv/index.html
+# Glibc är i stället tom: https://lh.2xlibre.net/locale/sv_SE/
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "em"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Till"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Färgtemperatur"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Skärm­ar"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Välj hur anslutna skärmar och projektorer ska användas"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projektor;xrandr;Skärm;Upplösning;Uppdatering;Natt;Belysning;Blå;"
+"redshift;färg;solnedgång;soluppgång;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Säkerhetsstart är aktiv"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Säkerhetsstart förhindrar skadlig programvara från att läsas in när enheten "
+"startas. Det är för närvarande påslaget och fungerar korrekt."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Säkerhetsstart har problem"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Säkerhetsstart förhindrar skadlig programvara från att läsas in när enheten "
+"startas. Det är för närvarande påslaget, men kommer inte att fungera på "
+"grund av att det har en ogiltig nyckel."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Problem med säkerhetsstart kan ofta lösas från din dators fasta UEFI-"
+"programvaruinställningar (BIOS) och din hårdvarutillverkare kan ge "
+"information om hur du gör detta."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "Kontakta din hårdvarutillverkare eller IT-supportleverantör för hjälp."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Säkerhetsstart är avstängd"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Säkerhetsstart förhindrar skadlig programvara från att läsas in när enheten "
+"startas. Det är för närvarande avstängt."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Säkerhetsstart kan ofta aktiveras från din dators fasta UEFI-"
+"programvaruinställningar (BIOS). Kontakta din hårdvarutillverkare eller IT-"
+"supportleverantör för hjälp."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Säkerhetsstart förhindrar skadlig programvara från att läsas in när enheten "
+"startas.\n"
+"\n"
+"Kontakta hårdvarutillverkaren eller IT-support för mer information."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Lyckades"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Misslyckades"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Enheten överensstämmer med HSI-nivå %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Säkerhetsnivå 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Den här enheten har inget skydd mot hårdvarusäkerhetsproblem. Detta kan bero "
+"på ett problem med konfigurationen av hårdvara eller fast programvara. Du "
+"rekommenderas kontakta din IT-supportleverantör."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Säkerhetsnivå 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Den här enheten har minimalt skydd mot hårdvarusäkerhetsproblem. Detta är "
+"den lägsta nivån av enhetssäkerhet och ger bara skydd mot enkla säkerhetshot."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Säkerhetsnivå 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Den här enheten har grundläggande skydd mot hårdvarusäkerhetsproblem. Detta "
+"ger skydd mot några vanliga säkerhetshot."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Säkerhetsnivå 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Den här enheten har utökat skydd mot hårdvarusäkerhetsproblem. Detta är den "
+"högsta nivån av enhetssäkerhet och ger skydd mot avancerade säkerhetshot."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Säkerhetsnivå"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Säkerhetsnivåer är inte tillgängliga för den här enheten."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr "Kontakta din hårdvarutillverkare för hjälp med säkerhetsuppdateringar."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Det kan vara möjligt att lösa det här problemet i enhetens fasta UEFI-"
+"programvaruinställningar eller av en supporttekniker."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Det kan vara möjligt att lösa det här problemet i enhetens fasta UEFI-"
+"programvaruinställningar."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Det kan vara möjligt för en supporttekniker att lösa problemet."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Nivå 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Nivå 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Nivå 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Skyddad mot skadlig programvara när enheten startar."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Säkerhetsstart har problem"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Visst skydd när enheten startas."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Säkerhetsstart är av"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Inget skydd när enheten startas."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Det här problemet kan ha orsakats av en ändring i fasta UEFI-"
+"programvaruinställningar, en ändring av operativsystemets konfiguration "
+"eller på grund av skadlig programvara på systemet."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Det här problemet kan ha orsakats av en ändring i de fasta UEFI-"
+"programvaruinställningarna eller på grund av skadlig programvara på systemet."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Det här problemet kan ha orsakats av en ändring av operativsystemets "
+"konfiguration eller på grund av skadlig programvara på systemet."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Utsatt för allvarliga säkerhetshot."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Begränsat skydd mot enkla säkerhetshot."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Skyddad mot vanliga säkerhetshot."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Skyddad mot ett brett utbud av säkerhetshot."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Omfattande skydd"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Inga händelser"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Skrivskydd för fast programvara"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Skrivskyddslås för fast programvara"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "BIOS-region för fast programvara"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "BIOS-beskrivare för fast programvara"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "DMA-skydd före uppstart"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard verifierad uppstart"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM-skyddad"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard-felpolicy"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard säkring"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET stöds"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET aktiv"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Krypterat RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU-skydd"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Lockdown för Linux-kärnan"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Verifiering av Linux-kärnan"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux-växlingsutrymme"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Gå till vänteläge i RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Gå till inaktivt läge"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI-plattformsnyckel"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI säkerhetsstart"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM-plattformskonfiguration"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM-rekonstruktion"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine-tillverkningsläge"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine-åsidosättning"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine-version"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Uppdateringar för fast programvara"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Attestering av fast programvara"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Verifiering av uppdateraren av fast programvara"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Plattformsfelsökning"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Processorsäkerhetskontroller"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD-tillbakarullningsskydd"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Återuppspelningsskydd för AMD:s fasta programvara"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Skrivskydd för AMD:s fasta programvara"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Plattform med säkring"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Giltig"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Ogiltig"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Inaktiverad"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Låst"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Upplåst"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Krypterad"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Okrypterad"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Befläckad"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Obefläckad"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Hittad"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Hittades inte"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Stöds"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Stöds inte"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Enhetssäkerhet"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Säkerhetsstatus för värdens fasta programvara"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"skärm;lås;diagnostik;krasch;privat;nyligen;senaste;tillfällig;temporär;tmp;"
+"index;namn;nätverk;identitet;sekretess;integritet;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Okänd"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bitars"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bitars"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Okänt"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Inte tillgänglig"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Systemlogotyp"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Enhetsnamn"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Hårdvarumodell"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Minne"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Processor"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafik"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Diskkapacitet"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Beräknar…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "OS-namn"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Bygg-ID för OS"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "OS-typ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME-version"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Läser in…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Fönstersystem"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Virtualisering"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Programvaruuppdateringar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Byt namn på enhet"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Enhetsnamnet används för att identifiera denna enhet när den visas över "
+"nätverket, eller vid ihopparning med Bluetooth-enheter."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Enhetsnamn"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "_Byt namn"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Om"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Visa information om ditt system"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"enhet;system;information;värdnamn;minne;processor;version;standard;program;"
+"föredragen;cd;dvd;usb;ljud;video;skiva;flyttbar;media;automatisk körning;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Ljud och media"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Tysta/aktivera volym"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Sänk volymen"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Höj volymen"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Tysta/aktivera mikrofon"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Starta mediaspelare"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Spela (eller spela/gör paus)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Pausa uppspelning"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Stoppa uppspelning"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Föregående spår"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Nästa spår"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Mata ut"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Skriva"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Byt till nästa inmatningskälla"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Byt till föregående inmatningskälla"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Programstartare"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Starta hjälpläsare"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Starta miniräknare"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Starta e-postklient"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Starta webbläsare"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Hemmapp"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Sök"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "System"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Logga ut"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Lås skärmen"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Hjälpmedel"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Aktivera eller inaktivera zoom"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Zooma in"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Zooma ut"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Aktivera eller inaktivera skärmläsare"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Aktivera eller inaktivera skärmtangentbord"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Öka textstorleken"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Minska textstorleken"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Hög kontrast på eller av"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Inga inmatningskällor hittades"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Övriga"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Lägg till en inmatningskälla"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Inmatningsmetoder kan inte användas på inloggningsskärmen"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Ingen inmatningskälla vald"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Alternativ"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Flytta upp"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Flytta ned"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Inställningar"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Visa tangentbordslayout"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Ta bort"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Anpassade kortkommandon"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Alternativa tecken-tangent"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Alternativa tecken-tangenten kan användas för att mata in ytterligare "
+"tecken. Dessa skrivs ibland som ett tredje alternativ på ditt tangentbord."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Vänster Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Höger Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Vänster super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Höger super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menytangent"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Höger Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose-tangent"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Compose-tangenten tillåter ett stort urval av tecken att matas in. För att "
+"använda den, tryck på Compose-tangenten och sedan en sekvens av tecken. Till "
+"exempel kommer Compose-tangenten följt av <b>C</b> och <b>o</b> att mata in "
+"<b>©</b>, <b>a</b> följt av <b>'</b> kommer att mata in <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Inmatningsskällor kan växlas genom att använda tangentbordsgenvägen %s.\n"
+"Denna kan ändras i inställningarna för tangentbordsgenvägar."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Inmatningskällor"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Inkluderar tangentbordslayouter och inmatningsmetoder."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Växling av inmatningskälla"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Använd _samma källa för alla fönster"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Växla inmatningskällor _individuellt för varje fönster"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Inmatning av specialtecken"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Metoder för att mata in symboler och bokstavsvarianter med tangentbordet."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Tangentbordsgenvägar"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Visa och anpassa kortkommandon"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d ändrad"
+msgstr[1] "%d ändrade"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Återställ alla kortkommandon?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Att återställa kortkommandona kan påverka dina anpassade kortkommandon. "
+"Detta kan inte ångras."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Återställ alla"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Återställ alla…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Återställ alla kortkommandon till sina standardtangentbindningar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Sektion"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Kortkommandon"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Lägg till ett kortkommando"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Lägg till anpassade kortkommandon"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Konfigurera anpassade kortkommandon för att starta program, köra skript med "
+"mera."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Lägg till kortkommando"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Ingen tangentbordsgenväg hittades"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s används redan för %s. Om du vill ersätta det kommer %s att inaktiveras"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Mata in det nya kortkommandot"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Ställ in anpassat kortkommando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Ställ in kortkommando"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Mata in nytt kortkommando för att ändra %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Lägg till anpassat kortkommando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Ta bort"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "_Ersätt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Ställ in"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Tryck ned Esc för att avbryta eller backsteg för att inaktivera "
+"tangentbordsgenvägen."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Namn"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Kommando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Kortkommando"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Ställ in kortkommando…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ingen"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Återställ kortkommandot till dess standardvärde"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Tan­gent­bord"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Ändra tangentbordsgenvägar och konfigurera dina skrivinställningar, "
+"tangentbordslayouter och inmatningskällor"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Genväg;Arbetsyta;Fönster;Storleksändring;Zoom;Kontrast;Inmatning;Källa;Lås;"
+"Volym;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Platstjänster är avstängda"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Inga program kan erhålla platsinformation."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Platstjänster låter program få veta din position. Att använda Wi-Fi och "
+"mobilt bredband ökar noggrannheten.\n"
+"\n"
+"Använder Mozilla Location Service: <a href='https://location.services."
+"mozilla.com/privacy'>Sekretesspolicy</a>\n"
+"\n"
+"Tillåt programmen nedan att fastställa din plats."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Inga program har bett om platsåtkomst"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Skydda din platsinformation"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "plats;gps;privat;sekretess;integritet;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofonen är avstängd"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Inga program kan spela in ljud."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Användning av mikrofonen låter program spela in och lyssna på ljud. Att "
+"inaktivera mikrofonen kan få vissa program att inte fungera som det är "
+"tänkt.\n"
+"\n"
+"Tillåt programmen nedan att använda din mikrofon."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Inga program har bett om åtkomst till mikrofonen"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Skydda dina konversationer"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofon;inspelning;program;sekretess;integritet;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Prova dina in_ställningar"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Allmänt"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Primärknapp"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Ställer in ordningen för de fysiska knapparna på möss och styrplattor."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Vänster"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Höger"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Mus"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Mushastighet"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Naturlig rullning"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Rullning flyttar innehållet, inte vyn."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Styrplatta"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Hastighet för styrplatta"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Knacka för att klicka"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Knacka för att klicka"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Tvåfingersrullning"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Kantrullning"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Prova att klicka, dubbelklicka och rulla"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Fem klick, dags för Gegl!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Dubbelklick med primär musknapp"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Enkelklick, primär knapp"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Dubbelklick med mellanmusknapp"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Enkelklick med mellanmusknappen"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Dubbelklick med sekundära musknappen"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Enkelklick med sekundära musknappen"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Mus & styr­platt­a"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Ändra din mus- eller styrplattekänslighet och välj höger- eller vänsterhänt"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Styrplatta;Muspekare;Klick;Slå lätt;Dubbel;Knapp;Trackball;Rulla;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Hett hörn"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Rör det övre vänstra hörnet för att öppna översiktsvyn Aktiviteter."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Aktiva skärmkanter"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Dra fönster mot de övre, vänstra och högra skärmkanterna för att ändra "
+"storlek på dem."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Arbetsytor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dynamiska arbetsytor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Ta automatiskt bort tomma arbetsytor."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Fast antal arbetsytor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Ange ett antal permanenta arbetsytor."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "A_ntal arbetsytor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Flera skärmar"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Arbetsytor bara på den _primära skärmen"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Arbetsytor på a_lla skärmar"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Programväxling"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Inkludera program från alla a_rbetsytor"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Inkludera endast program från den a_ktuella arbetsytan"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Multikörning"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Hantera inställningar för produktivitet och multikörning"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Multikörning;Produktivitet;Anpassa;Skrivbord;Hot "
+"Corner;Hett hörn;Arbetsytor;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Hoppsan, något gick fel. Kontakta din programvaruleverantör."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Nätverkshanteraren måste vara aktiv."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Andra enheter"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Lägg till anslutning"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Inte konfigurerat"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Osäkert nätverk (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Säkert nätverk (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Säkert nätverk (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Säkert nätverk (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Säkert nätverk"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Ansluten"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Alternativ…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Att slå på surfzonen kommer att koppla från %s, och det kommer inte vara "
+"möjligt att komma åt internet genom Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Måste bestå av minst 8 tecken"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Måste bestå av högst %d tecken"
+msgstr[1] "Måste bestå av högst %d tecken"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Slå på trådlös surfzon?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Trådlös surfzon låter andra dela din internetanslutning, genom att skapa ett "
+"Wi-Fi-nätverk som de kan ansluta till. För att göra detta behöver du ha en "
+"internetanslutning genom en annan källa än Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Nätverksnamn"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Lösenord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Generera slumpmässigt lösenord"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Generera lösenord automatiskt"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Slå på"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Tråd­löst"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Stoppa surfzonen och koppla ifrån eventuella användare?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Stoppa surfzon"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Flygplansläge"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Inaktiverar trådlöst nätverk, Bluetooth och mobilt bredband"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Ingen Wi-Fi-adapter hittades"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Säkerställ att du har en Wi-Fi-adapter inkopplad och påslagen"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Flygplansläge på"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Slå av för att använda trådlöst nätverk"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Trådlös surfzon aktiv"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobilenheter kan läsa av QR-koden för att ansluta."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Slå av surfzon…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Synliga nätverk"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Nätverkshanteraren måste vara aktiv"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x-_säkerhet"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Säkerhet"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Bevara"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Permanent"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Slumpmässig"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Stabil"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"MAC-adressen som anges här kommer att användas som hårdvaruadress för "
+"nätverksenheten som denna anslutning är aktiverad på. Denna funktion är känd "
+"som MAC-kloning eller ”spoofing”. Exempel: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Aldrig"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i dag sedan"
+msgstr[1] "%i dagar sedan"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2,4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2,4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Svag"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Bra"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Utmärkt"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4-adress"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6-adress"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP-adress"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Glöm anslutning"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Ta bort anslutningsprofil"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "Ta bort VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Detaljer"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "automatisk"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Identitet"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Ta bort adress"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Standardrutt"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bitars nyckel (Hex eller ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bitars lösenfras"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamisk WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Enterprise"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Personal"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Signalstyrka"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Länkhastighet"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Hårdvaruadress"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Frekvenser som stöds"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Standardrutt"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Senast använd"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Anslut _automatiskt"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Gör _tillgänglig för andra användare"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "Anslutning med _datakvot: har datagränser eller kan medföra kostnader"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Programvaruuppdateringar och andra stora hämtningar kommer inte att startas "
+"automatiskt."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Namn"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC-adress"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonad adress"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "byte"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4-metod"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Automatiskt (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Endast lokal länk"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Manuell"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Inaktivera"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Delad med andra datorer"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresser"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adress"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Nätmask"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Gateway"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Automatisk"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Automatisk DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS-serveradress(er)"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "Separera IP-adresser med kommatecken"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rutter"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Automatiska rutter"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Använd en_dast denna anslutning för resurser på dess nätverk"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6-metod"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Automatisk, endast DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefix"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Kunde inte öppna anslutningsredigeraren"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Ny profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Ogiltig inställning %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Ogiltig inställning %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Importera från fil…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Lägg till VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Säk_erhet"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Kan inte importera VPN-anslutning"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Filen ”%s” kan inte läsas eller innehåller ej igenkänd VPN-"
+"anslutningsinformation\n"
+"\n"
+"Fel: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Välj fil att importera"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "En fil med namnet ”%s” finns redan."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "E_rsätt"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Vill du ersätta %s med VPN-anslutningen du sparar?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Kan inte exportera VPN-anslutning"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN-anslutningen ”%s” kunde inte exporteras till %s.\n"
+"\n"
+"Fel: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Exportera VPN-anslutning"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Fel: kan inte läsa in VPN-anslutningsredigerare)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Kontrollera hur du ansluter till internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Nätverk;IP;LAN;Proxy;WAN;Bredband;Modem;Bluetooth;Blåtand;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Kontrollera hur du ansluter till trådlösa nätverk"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Nätverk;Trådlöst;Wi-Fi;Wifi;IP;LAN;Bredband;DNS;Hotspot;Surfzon;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "aldrig"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "i dag"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "i går"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Senast använd"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Trådbundet"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Lägg till ny anslutning"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Nätverksdetaljer för markerade nätverk, inklusive lösenord och anpassad "
+"konfiguration kommer att gå förlorade."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Glöm"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Kända trådlösa nätverk"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Glöm"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Systempolicyn tillåter ej användning som surfzon"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Den trådlösa enheten stöder inte användning av surfzoner"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Web Proxy Autodiscovery (WPAD) används när en konfigurations-URL inte "
+"tillhandahålls."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Detta rekommenderas inte för opålitliga publika nätverk."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Stäng av enhet"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Aktiv"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Leverantör"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Nätverksproxy"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP-proxy"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTP_S-proxy"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP-proxy"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "So_cks-värd"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Ignorera värdar"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP-proxyport"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS-proxyport"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP-proxyport"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks-proxyport"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_URL för konfiguration"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Stäng av VPN-anslutning"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Nätverksnamn"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Säkerhetstyp"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Lösenord"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Stäng av trådlöst nätverk"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Fler alternativ…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_Anslut till dolt nätverk…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Slå på _trådlös surfzon…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Kända trådlösa nätverk"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Okänd status"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Ohanterad"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Otillgänglig"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Ansluter"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Autentisering krävs"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Kopplar från"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Anslutningen misslyckades"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Okänd status (saknas)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Konfiguration misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP-konfiguration misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP-konfiguration passerade slutdatum"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Hemligheter krävdes, men tillhandahölls inte"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x-supplikanten kopplades från"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Konfiguration av 802.1x-supplikanten misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x-supplikanten misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x-supplikanten tog för lång tid på sig att autentisera"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Misslyckades med att starta PPP-tjänsten"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP-tjänsten kopplades från"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Misslyckades med att starta DHCP-klienten"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP-klient fel"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP-klienten misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Misslyckades med att starta tjänsten för delad anslutning"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Tjänsten för delad anslutning misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Kunde inte starta AutoIP-tjänsten"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Fel i AutoIP-tjänsten"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP-tjänsten misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Linjen är upptagen"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Ingen rington"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Bärvågen kunde inte etableras"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Tidsgränsen för uppringningen överskreds"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Uppringningen misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Initiering av modem misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Misslyckades med att välja angiven APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Söker inte efter nätverk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Nätverksregistrering nekades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Tidsgränsen för nätverksregistrering överstegs"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Misslyckades att registrera med begärt nätverk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Kontroll av PIN-kod misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Enheten kan sakna fast programvara"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Anslutningen försvann"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Befintlig anslutning antogs"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modemet kunde inte hittas"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth-anslutningen misslyckades"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM-kortet är inte isatt"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM-kortet kräver PIN-kod"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM-kortet kräver PUK-kod"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Fel på SIM-kortet"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Anslutningsberoende misslyckades"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Fast programvara saknas"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kabeln är frånkopplad"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "odefinierat fel i 802.1X-säkerhet (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "ingen fil vald"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "ospecificerat fel vid validering av eap-metodfil"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Privata DER-, PEM-, PKCS#12- eller PGP-nycklar"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER- eller PEM-certifikat"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "saknar PAC-fil för EAP-FAST"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC-filer (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonym"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Autentiserad"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Båda"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anony_m identitet"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC-_fil"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Välj en PAC-fil"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "_Inre autentisering"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Tillåt automatisk PAC-pro_visionering"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "saknar EAP-LEAP-användarnamn"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "saknar EAP-LEAP-lösenord"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "An_vändarnamn"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Lösenord"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Visa lösen_ord"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "ogiltigt CA-certifikat för EAP-PEAP: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "ogiltigt CA-certifikat för EAP-PEAP: inget certifikat angivet"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Version 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Version 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A-certifikat"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Välj ett certifikat för certifikatsutfärdare"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Inget CA-certifikat k_rävs"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP _version"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "saknar EAP-användarnamn"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "saknar EAP-lösenord"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "saknar EAP-TLS-identitet"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "ogiltigt CA-certifikat för EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "ogiltigt CA-certifikat för EAP-TLS: inget certifikat angivet"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "ogiltig privat nyckel för EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "ogiltigt EAP-TLS-användarcertifikat: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Okrypterade privata nycklar är osäkra"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Den valda privata nyckeln verkar inte vara skyddad av ett lösenord. Det "
+"skulle kunna tillåta säkerhetsreferenser att bli komprometterade. Välj en "
+"lösenordsskyddad privat nyckel.\n"
+"\n"
+"(Du kan lösenordsskydda din privata nyckel med openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Välj ditt personliga certifikat"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Välj din privata nyckel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "I_dentitet"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Användarcertifikat"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Privat nyc_kel"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Lösenord för _privat nyckel"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "ogiltigt CA-certifikat för EAP-TTLS: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "ogiltigt CA-certifikat för EAP-TTLS: inget certifikat angivet"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (ingen EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Domän"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Okänt fel vid validering av 802.1X-säkerhet"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tunnlad TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Skyddad EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Au_tentisering"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Välj en fil"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "saknar leap-användarnamn"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "saknar leap-lösenord"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Wi-Fi-lösenord saknas."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Typ"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "saknar wep-nyckel"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"ogiltig wep-nyckel: nyckel med en längd på %zu får endast innehålla "
+"hexadecimala siffror"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"ogiltig wep-nyckel: nyckel med en längd på %zu får endast innehålla ascii-"
+"tecken"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"ogiltig wep-nyckel: felaktig nyckellängd %zu. En nyckel måste ha antingen "
+"längden 5/13 (ascii) eller 10/26 (hex)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "ogiltig wep-nyckel: lösenfras får inte vara tom"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "ogiltig wep-nyckel: lösenfras måste vara kortare än 64 tecken"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Standard)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Öppna system"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Delad nyckel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "Nyc_kel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Visa nyckel"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP-inde_x"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"ogiltig wpa-psk: ogiltig nyckellängd %zu. Måste vara [8,63] byte eller 64 "
+"hexadecimala siffror"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "ogiltig wpa-psk: kan inte tolka nyckel med 64 byte som hexadecimal"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Aviseringar"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Ljud_alarm"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Aviserings_poppupper"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Aviseringar kommer att dyka upp i aviseringslistan då poppupper inaktiveras."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Visa meddelande_innehåll i poppupper"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Aviseringar på _låsskärm"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Visa meddelandei_nnehåll på låsskärm"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Stör _ej"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Aviseringar på _låsskärm"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Kontrollera vilka aviseringar som visas samt vad de visar"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Aviseringar;Banderoll;Meddelande;Bricka;Popup;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Övriga"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s togs bort"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Fel vid borttagning av kontot"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Ångra"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Stäng aviseringen"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Anslut till dina data i molnet"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "Ingen internetanslutning — anslut för att konfigurera nya nätkonton"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Lägg till ett konto"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s-konto"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Ta bort konto"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Nät­kont­on"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "Anslut till dina nätkonton och bestäm hur de ska användas"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Webb;Nätet;Chatt;Kalender;E-post;Kontakt;"
+"ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Okänd tid"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i minut"
+msgstr[1] "%i minuter"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i timme"
+msgstr[1] "%i timmar"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "timme"
+msgstr[1] "timmar"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "minut"
+msgstr[1] "minuter"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s tills fullt uppladdad"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Varning: %s återstår"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s återstår"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Fullt uppladdad"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Laddar inte"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Tom"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Laddar upp"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Laddar ur"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Trådlös mus"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Trådlöst tangentbord"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Avbrottsfri kraftförsörjning (UPS)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Handdator"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Mobiltelefon"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Mediaspelare"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Ritplatta"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Dator"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Inmatningsenhet för spel"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Batteri"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Huvudsaklig"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Extra"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Batterier"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "När led_ig"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Försätt i vänteläge"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Stäng av"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Försätt i viloläge"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Ingenting"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "När på batteriström"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "När ansluten"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Aldrig"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Automatiskt vänteläge"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Prestandaläge tillfälligt inaktiverat på grund av hög arbetstemperatur."
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Knä upptäckt: prestandaläge är otillgängligt för tillfället. Flytta enheten "
+"till en stabil yta för att återställa."
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "Prestandaläge är tillfälligt inaktiverat."
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Låg batterinivå: strömsparare aktiverad. Tidigare läge kommer att "
+"återställas när batteriet har laddats tillräckligt."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Strömsparläge aktiverades av ”%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Prestandaläge aktiverades av ”%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 minuter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 minuter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 minuter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 minuter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 minuter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "En timme"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 minuter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 minuter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 minuter"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "Två timmar"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Strömläge"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Påverkar systemets prestanda och strömförbrukning."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Strömsparalternativ"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Automatisk skärmljusstyrka"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Skärmljusstyrka justeras efter omgivande ljus."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Dämpa skärm"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Reducerar skärmens ljusstyrka när datorn är inaktiv."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "_Töm skärm"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Slår av skärmen efter en period av inaktivitet."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Automatisk strömsparare"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Aktiverar strömsparläge när batterinivån är låg."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Automatiskt vänteläge"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Pausar datorn efter en period av inaktivitet."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Strö_mknappsbeteende"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Visa batteri_procent"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Automatiskt vänteläge"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Ansluten"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "På _batteriström"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Fördröjning"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Prestanda"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Hög prestanda och strömförbrukning."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Balanserad"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Standardprestanda och strömförbrukning."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Strömsparare"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Minskad prestanda och strömförbrukning."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Ström"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Visa din batteristatus och ändra energisparinställningar"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Ström;Sova;Vänteläge;Viloläge;Batteri;Ljusstyrka;Dämpa;Blank;Skärm;DPMS;"
+"inaktiv;Energi;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Skrivaren ”%s” har tagits bort"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Misslyckades med att lägga till ny skrivare."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Det gick inte att läsa in användargränssnittet: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Lås upp för att lägga till skrivare och ändra inställningar"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Skriv­ar­e"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Lägg till skrivare, visa skrivarjobb och besluta hur du vill skriva ut"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Skrivare;Kö;Skriv ut;Papper;Bläck;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Lägg till skrivare"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "Lås _upp"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Inga skrivare hittades"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Ange en nätverksadress eller sök efter en skrivare"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Autentisering krävs"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Ange ditt användarnamn och lösenord för att se skrivare på skrivarserver."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Användarnamn"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Detaljer för %s"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Ingen lämplig drivrutin kunde hittas"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Välj PPD-fil"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript-skrivarbeskrivningsfiler (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Skrivarnamn kan inte innehålla BLANKSTEG, TABB, # eller /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Plats"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Drivrutin"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Söker efter lämpliga drivrutiner…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Sök efter drivrutiner"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Välj från databas…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Installera PPD-fil…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Välj drivrutin för skrivare"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Läser in drivrutinsdatabas…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Välj"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect-skrivare"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD-skrivare"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Enkelsidig"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Långsida (standard)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Kortsida (vänd)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Porträtt"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Landskap"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Omvänt landskap"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Omvänt porträtt"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Fortsätt"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Pausa"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Väntar"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Pausad"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Autentisering krävs"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Behandlar"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Stoppad"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Avbruten"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Avbruten"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Färdig"
+
+# TODO: front of the queue?
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Flytta det här jobbet längst fram i kön"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u jobb begär autentisering"
+msgstr[1] "%u jobb begär autentisering"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — aktiva jobb"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Ange autentiseringsuppgifter för att skriva ut från %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Domän"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "A_utentisera"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Töm alla"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Autentisera"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "Inga aktiva skrivarjobb"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Lås upp skrivarserver"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Lås upp %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Ange ditt användarnamn och lösenord för att se skrivare på %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Söker efter skrivare"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Seriellport"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Parallellport"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Plats: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adress: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Server begär autentisering"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Dubbelsidig"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Papperstyp"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Papperskälla"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Utskriftsfack"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Upplösning"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript-förfiltrering"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Sidor per blad"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Dubbelsidig"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Orientering"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Allmänt"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Sidinställningar"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Installerbara alternativ"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Jobb"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Bildkvalitet"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Färg"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Slutför"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Avancerat"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Testsida"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Testsida"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Välj automatiskt"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Skrivarens standardinställning"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Bädda enbart in GhostScript-typsnitt"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Konvertera till PS nivå 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Konvertera till PS nivå 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Ingen förfiltrering"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Tillverkare"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Inga aktiva jobb"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u jobb"
+msgstr[1] "%u jobb"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Rengör skrivarhuvuden"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Låg tonernivå"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Slut på toner"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Nästan slut på framkallningsvätska"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Slut på framkallningsvätska"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Nästan slut på färg"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Slut på färg"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Luckan är öppen"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Luckan är öppen"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Låg pappersnivå"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Slut på papper"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Frånkopplad"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Stoppad"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Skräpkorgen är nästan full"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Skräpkorgen är full"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Den optiska fototrumman är nära slutet på sin livstid"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Den optiska fototrumman är inte längre funktionsduglig"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Redo"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Accepterar inte jobb"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Behandlar"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Utskriftsalternativ"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Skrivardetaljer"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Använd skrivare som standard"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Rengör skrivarhuvuden"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Ta bort skrivare"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Modell"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Bläcknivå"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Starta om då problemet har lösts."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Starta om"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Lägg till skrivare…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Inga skrivare"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Tyvärr! Systemets utskriftstjänst\n"
+"    verkar inte finnas tillgänglig."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Format"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Sök lokaler…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Vanliga format"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Alla format"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Inga sökresultat"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Sökningar kan vara efter länder eller språk."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Förhandsgranska"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Imperial"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrisk"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Datum"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Dat­um & tider"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Tal"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Mätning"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Papper"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Språk och format kommer att ändras efter nästa inloggning"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Logga ut…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Språkinställningen används för gränssnittstext och webbsidor. Format används "
+"för siffror, datum och valutor."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Ditt konto"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Språk"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Format"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Inloggningsskärm"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Re­gion & språk"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Välj ditt visningsspråk och dina format"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Språk;Layout;Tangentbord;Inmatning;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Fråga vad som ska göras"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Gör ingenting"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Öppna mapp"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Övriga media"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Välj ett program för ljud-cd-skivor"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Välj ett program för video-dvd-skivor"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Välj ett program att köra när en musikspelare ansluts"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Välj ett program att köra när en kamera ansluts"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Välj ett program för program-cd-skivor"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "ljud-dvd"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "tom Blu-ray-skiva"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "tom cd-skiva"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "tom dvd-skiva"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "tom HD DVD-skiva"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray-videoskiva"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "e-boksläsare"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD-videoskiva"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Bildcd"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video-cd"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Videocd"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Fönsterprogramvara"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Välj hur media ska hanteras"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "Cd-_ljud"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_Dvd-video"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Musikspelare"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "Pro_gramvara"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Övriga media…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Fråga aldrig eller starta program när media matas in"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Välj hur övriga media ska hanteras"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Åtgärd:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Typ:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Flyttbara media"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Konfigurera inställningar för flyttbara media"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"enhet;system;standard;program;föredragen;cd;dvd;usb;ljud;video;skiva;"
+"flyttbar;media;automatisk körning;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Skärmen stängs av"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 sekunder"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "En minut"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "Två minuter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "Tre minuter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "Fem minuter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 minuter"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "En timme"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "En minut"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "Två minuter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "Tre minuter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "Fyra minuter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "Fem minuter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "Åtta minuter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "Tio minuter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "Tolv minuter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 minuter"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Aldrig"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Skärmlås"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Att automatiskt låsa skärmen förhindrar andra från att komma åt datorn medan "
+"du är borta."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Fördröjning för tömning av skärm"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Inaktivitetsperiod innan skärmen kommer att släckas."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Automatiskt skärm_lås"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Fördröjning för automatiskt _skärmlås"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Tid efter att skärmen släckts då skärmen kommer att låsas automatiskt."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Visa _aviseringar på låsskärmen"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Förbjud nya _USB-enheter"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Förhindra nya USB-enheter från att interagera med systemet då skärmen är "
+"låst."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Skärmsekretess"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Begränsa betraktningsvinkeln"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Skärminställningar"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "skärm;lås;privat;sekretess;integritet;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Välj plats"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Sökplatser"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Mappar som genomsöks av systemprogram såsom Filer, Foton och Videoklipp."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Platser"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Bokmärken"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Övriga"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Lägg till plats"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Inga program hittades"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Programsökning"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Inkludera sökresultat som tillhandahålls av program."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Mappar som genomsöks av systemprogram."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Sökresultat"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Resultat visas enligt listordningen."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "Kontrollera vilka program som visar sökresultat i Aktivitetsöversikten"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Sök;Hitta;Index;Göm;Sekretess;Resultat;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Inga nätverk markerade för delning"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Nätverk"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "På"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Av"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Aktiverad"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Aktiv"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Välj en mapp"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Lägg till"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Aktivera mediadelning"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Fildelning låter dig dela din publika mapp med andra på det nätverk du "
+"använder för tillfället: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Då fjärrinloggning är aktiverad kan fjärranvändare ansluta med det säkra "
+"skalkommandot:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Aktivera personlig mediadelning"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Enhetsnamn kopierat"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Enhetsadress kopierad"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Användarnamn kopierat"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Lösenord kopierat"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Dela"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Datornamn"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Fildelning"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Fjärr_skrivbord"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Mediadelning"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Fjärrinloggning"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Fildelning"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Begär lösenord"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Fjärrinloggning"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Fjärrskrivbord"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Fjärrskrivbord låter dig se och styra ditt skrivbord från en annan dator."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Aktivera eller inaktivera fjärrskrivbordsanslutningar till den här datorn."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Fjärrkontroll"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Tillåter fjärranslutningar att styra skärmen."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Hur du ansluter"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Anslut till den här datorn med enhetens namn eller fjärrskrivbordsadress."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopiera"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Fjärrskrivbordsadress"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Autentisering"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Användarnamnet och lösenordet krävs för att ansluta till den här datorn."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Användarnamn"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Verifiera kryptering"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Krypteringsfingeravtryck"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Krypteringsfingeravtrycket kan ses i anslutande klienter och bör vara "
+"identiskt."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Mediadelning"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Dela musik, foton och filmer över nätverket."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Mappar"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Kontrollera vad du vill dela med andra"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"dela;delning;share;ssh;värd;namn;fjärr;skrivbord;media;audio;ljud;video;"
+"bilder;foton;filmer;server;renderare;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Aktivera eller inaktivera fjärrinloggning"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Autentisering krävs för att aktivera eller inaktivera fjärrinloggning"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Anpassat"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Klick"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Sträng"
+
+# Ljudet av golfsving eller liknande
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Sving"
+
+# Hummande ljud
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Hum"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Balans"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Toning"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Bakre"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Främre"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Testar %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Klicka på en högtalare för att testa"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Systemvolym"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Huvudvolym"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Volymnivåer"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Utgång"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Utgångsenhet"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Testa"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Konfiguration"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Ingång"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Ingångsenhet"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Volym"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Larmljud"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Tyst"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Ljud"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Ändra ljudvolym, ingångar, utgångar och ljudhändelser"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "Kort;Mikrofon;Volym;Tona;Balans;Bluetooth;Headset;Ljud;Utgång;Ingång;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Frånkopplad"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Ansluter"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Ansluten"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Auktorisering krävs"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Auktoriserar"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Reducerad funktionalitet"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Ansluten och auktoriserad"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Okänd"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Auktoriserades:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Anslöts:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Registrerades:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Misslyckades med att auktorisera enhet: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Misslyckades med att glömma enheten: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Beror på %u annan enhet"
+msgstr[1] "Beror på %u andra enheter"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Stäng avisering"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Namn:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Status:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Auktorisera och anslut"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Glöm enhet"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Fel"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Auktoriserad"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Thunderbolt-undersystemet (boltd) är inte installerat eller inte korrekt "
+"konfigurerat."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Tillåt direktåtkomst för enheter såsom dockor och externa grafikprocessorer."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Endast USB- och Display Port-enheter kan kopplas in."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt kunde inte detekteras.\n"
+"Antingen saknar systemet stöd för Thunderbolt, eller så har det inaktiverats "
+"i BIOS, eller så har det ställts in till en säkerhetsnivå som inte stöds i "
+"BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Stöd för Thunderbolt har inaktiverats i BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Säkerhetsnivå för Thunderbolt kunde inte avgöras."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Fel vid växling av direktläge: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Inget Thunderbolt-stöd"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Det gick inte att ansluta till thunderbolt-undersystemet."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Direktåtkomst"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Väntande enheter"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Inga enheter inkopplade"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Hantera Thunderbolt-enheter"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;sekretess;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Markörblinkning"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Markören blinkar i textfält."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Hastighet"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Hastighet för markörblinkning"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Markörstorlek"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Markörstorlek kan kombineras med zoom för att göra det lättare att se "
+"markören."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Klickhjälp"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Simulerat sekundärklick"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Initiera ett sekundärklick genom att hålla ned primärknappen"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Acc_eptansfördröjning:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Fördröjning för sekundärklick"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lång"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Uppehållsklick"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Initiera ett klick när muspekaren svävar"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "_Fördröjning:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Lång"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Tröskelvärde för _rörelse:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Liten"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Stor"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Upprepningstangenter"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Tangenttryckningar upprepas då tangent hålls ned."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Tangentupprepningsfördröjning"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Tangentupprepningshastighet"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Skrivassistent"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Klistriga tangenter"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Behandlar en sekvens av modifierartangenter som en tangentkombination"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Inaktivera om två tangenter trycks samtidigt"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Pip när en _modifierartangent trycks ned"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "T_röga tangenter"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Lägger till en fördröjning mellan en tangenttryckning tills den accepteras"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Skrivfördröjning för tröga tangenter"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Lång"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Pip när en tangent tr_ycks ned"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Pip när tangent a_ccepteras"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Pip _när en tangent förkastas"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Tangentstuds"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ignorera snabba duplicerade tangenttryckningar"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Skrivfördröjning för tangentstuds"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lång"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Aktivera med tang_entbord"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Slå på och av hjälpmedelsfunktioner från tangentbordet"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Standard"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Mellan"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Stor"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Större"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Störst"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d bildpunkt"
+msgstr[1] "%d bildpunkter"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "Visa _alltid meny för hjälpmedel"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Se"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Hög kontrast"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Stor text"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Aktivera a_nimeringar"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Skärmläsa_re"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Skärmläsaren läser visad text allteftersom du flyttar fokus."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Ljudtangenter"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Pip när Num Lock eller Caps Lock slås på eller av."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "_Markörstorlek"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Zooma"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Höra"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Visuella larm"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "S_kärmtangentbord"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Uppr_epningstangenter"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Markör_blinkning"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Skrivassis_tent (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Peka &amp; klicka"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Mustangenter"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Hitta muspekare"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Klickhjälp"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "D_ubbelklicksfördröjning"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Dubbelklicksfördröjning"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Visuella larm"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Test_blinkning"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Använd en visuell indikation när ett larmljud inträffar."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Blinka hela _skärmen"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Blinka hela _fönstret"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kort"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ skärm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ skärm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ skärm"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Lång"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Helskärm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Övre halva"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Nedre halva"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Vänster halva"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Höger halva"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Alternativ för zoom"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Förstoring:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Förstorarens position:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Följ muspekare"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Del av _skärmen:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Förstoraren _sträcker sig utanför skärmen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Håll förstorarens markör centrerad"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Förstorarens markör _flyttar på innehåll"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Förstorarens markör flyttas med _innehållet"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Förstorare"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Hårkors:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Överlappar muspekare"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Tjocklek:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Tunn"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Tjock"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Längd:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Färg:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Hårkors"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Färgeffekter:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Vitt på svart:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Ljusstyrka:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Kontrast:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "F_ärg"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Fullständig"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Låg"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Hög"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Låg"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Hög"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Färgeffekter"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Gör det enklare att se, höra, skriva, peka och klicka"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Tangentbord;Mus;a11y;Hjälpmedel;Tillgänglighet;Kontrast;Markör;Zoom;"
+"Skärmläsare;stor;hög;text;typsnitt;teckensnitt;storlek;AccessX;Klistriga;"
+"Tangenter;Tröga;Tangentstuds;Mustangenter;Dubbelklick;Fördröjning;Hastighet;"
+"Assistans;Upprepa;Blinka;visuell;hörsel;ljud;skrift;animationer;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "En timme"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "En dag"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "Två dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "Tre dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "Fyra dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "Fem dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "Sex dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "Sju dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 dagar"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 dagar"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Töm alla objekt i papperskorgen?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Alla objekt i papperskorgen kommer att tas bort permanent."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "_Töm papperskorgen"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Radera alla tillfälliga filer?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Alla tillfälliga filer kommer att raderas permanent."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Ta bort tillfälliga filer"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "En dag"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "Sju dagar"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 dagar"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "För alltid"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Filhistorik"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Filhistorik behåller ett register över filer som du har använt. Denna "
+"information delas mellan program, och gör det enklare att hitta filer som du "
+"kan vilja använda."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Filh_istorik"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Varaktighet för fil_historik"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Töm historik…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Papperskorg &amp; tillfälliga filer"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Papperskorgen och temporära filer kan ibland innehålla personlig eller "
+"känslig information. Att automatiskt ta bort dem kan hjälpa till att värna "
+"din integritet."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Ta automatiskt bort _papperskorgens innehåll"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Ta automatiskt bort tillfälliga _filer"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Period för _automatisk borttagning"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "_Töm papperskorgen…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Ta _bort tillfälliga filer…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Filhistorik & papperskorg"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Lämna inga spår"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"användning:senaste;historik;filer;tillfällig;temporär;tmp;privat;sekretess;"
+"integritet;skräp;rensa;behåll;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Ska matcha din inloggningsleverantörs webbadress."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Misslyckades med att lägga till konto"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Lösenorden stämmer inte överens."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Misslyckades med att registrera konto"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Inget stöd för att autentisera med denna domän"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Misslyckades med att ansluta till domänen"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Inloggningsnamnet fungerade inte.\n"
+"Prova igen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Inloggningslösenordet fungerade inte.\n"
+"Prova igen."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Misslyckades med att logga in på domänen"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Kunde inte hitta domänen. Kanske felstavade du den?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Lägg till användare"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Administratör"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Administratörer kan lägga till och ta bort andra användare och kan ändra "
+"inställningar för alla användare. Föräldrakontroll kan inte tillämpas på "
+"administratörer."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Användaren anger lösenord vid första inloggning"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Ange ett lösenord nu"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Bekräfta"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Företagsinloggning"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Användarkonton som hanteras av ett företag eller en organisation."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Du är frånkopplad"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Företagsinloggning tillåter att ett befintligt centralt hanterat "
+"användarkonto kan användas på denna enhet. Du kan också använda detta konto "
+"för att komma åt företagsresurser på internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Bläddra efter fler bilder"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Välj en fil…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Fingeravtryckshanterare"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Fingeravtryck"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Nej"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Ja"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Vill du ta bort dina registrerade fingeravtryck så att "
+"fingeravtrycksinloggning inaktiveras?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Ingen fingeravtrycksenhet"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Ingen fingeravtrycksenhet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Säkerställ att enheten är korrekt ansluten."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Fingeravtrycksenhet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Välj fingeravtrycksenheten som du vill konfigurera"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Fingeravtrycksinloggning"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Fingeravtrycksinloggning låter dig låsa upp och logga in på din dator med "
+"ditt finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Ta bort fingeravtryck"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Fingeravtrycksregistrering"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "enheten behöver tas i anspråk för att utföra denna åtgärd"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "enheten har redan tagits i anspråk av en annan process"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "du har inte rättigheter att utföra åtgärden"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "inga avtryck har registrerats"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Misslyckades med att kommunicera med enheten under registrering"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Misslyckades med att kommunicera med fingeravtrycksläsaren"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Misslyckades med att kommunicera med fingeravtrycksdemonen"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Misslyckades med att lista fingeravtryck: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Misslyckades med att ta bort sparade fingeravtryck: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Vänster tumme"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Vänster långfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "_Vänster pekfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Vänster ringfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Vänster lillfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Höger tumme"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Höger långfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "_Höger pekfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Höger ringfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Höger lillfinger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Okänt finger"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Färdig"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Fingeravtrycksenheten kopplades från"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Fingeravtrycksenhetens utrymme är fullt"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Misslyckades med att registrera nytt fingeravtryck"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Misslyckades med att starta registrering: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Misslyckades med att registrera nytt fingeravtryck"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Misslyckades med att stoppa registrering: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Lyft och placera upprepat ditt finger på läsaren för att registrera ditt "
+"fingeravtryck"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "_Registrera detta finger på nytt…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Läs av nytt fingeravtryck"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Misslyckades med att släppa fingeravtrycksenheten %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Problem vid läsning av enhet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Misslyckades med att begära fingeravtrycksenheten %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Misslyckades med att erhålla fingeravtrycksenheter: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Denna vecka"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Förra veckan"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Session avslutad"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Session påbörjad"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Kontoaktivitet"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Föregående"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Nästa"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Välj ett annat lösenord."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Ange ditt aktuella lösenord igen."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Lösenordet kunde inte ändras"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Byt lösenord"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "Än_dra"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Aktuellt lösenord"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Nytt lösenord"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Bekräfta nytt lösenord"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Tillåt användare att ändra lösenord vid nästa inloggning"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Ange ett lösenord nu"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Kan inte automatiskt gå med i denna typ av domän"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Ingen sådan domän eller sfär funnen"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Kan inte logga in som %s på %s-domänen"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Ogiltigt lösenord, försök igen"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Det gick inte att ansluta till %s-domänen: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Misslyckades med att ta bort användaren"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Misslyckades med att ta bort fjärrhanterad användare"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Du kan inte ta bort ditt egna konto."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s är fortfarande inloggad"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Att ta bort en användare när de är inloggade kan medföra att systemet hamnar "
+"i ett inkonsistent tillstånd."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Vill du behålla filer tillhörande %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Det är möjligt att behålla hemkatalogen, e-postkö och tillfälliga filer när "
+"ett användarkonto tas bort."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Ta bort filer"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "_Behåll filer"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Är du säker på att du vill ta bort fjärrhanterade kontot för %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Ta bort"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Kontot är inaktiverat"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Ska ställas in vid nästa inloggning"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ingen"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Inloggad"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Misslyckades med att kontakta kontotjänsten"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Försäkra dig om att kontotjänsten är installerad och aktiverad."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Den här panelen måste vara upplåst för att ändra denna inställning"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Ta bort markerat användarkonto"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Klicka först på *-ikonen för att\n"
+"ta bort markerat användarkonto"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Lås upp för att lägga till användare och ändra inställningar"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Användare"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Din session behöver startas om för att ändringar ska genomföras"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Starta om nu"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Stäng"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Redigera profilbild"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Fullständigt namn"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Redigera"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Fingeravtrycksinloggning"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "A_utomatisk inloggning"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Kontoaktivitet"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Administratör"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Administratörer kan lägga till och ta bort andra användare, och kan ändra "
+"inställningar för alla användare."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Föräldrakontroller"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Öppna programmet Föräldrakontroller."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Ta bort användare…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Andra användare"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Lägg till användare…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Inga användare hittades"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Lås upp för att lägga till ett användarkonto."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Lägg till eller ta bort användare och ändra ditt lösenord"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Inloggning;Namn;Fingeravtryck;Avatar;Logotyp;Ansikte;Lösenord;"
+"Föräldrakontroller;Skärmtid;Programbegränsningar;Webbegränsningar;Användning;"
+"Användningsgräns;Unge;Ungar;Barn;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Registrera"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Inloggning för domänadministratör"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"För att använda företagsinloggning, måste datorn vara\n"
+"ansluten till domänen. Låt nätverksadministratören fylla i\n"
+"sitt lösenord här."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Administratörs_namn"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Administratörslösenord"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Hantera användarkonton"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "För att ändra användardata krävs autentisering"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Det nya lösenordet måste skilja sig åt från det gamla."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Ändra några bokstäver och siffror."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Försök att ändra lösenordet lite mer."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Ett lösenord utan ditt användarnamn skulle vara starkare."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Undvik att använda ditt namn i lösenordet."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Undvika några av orden som ingår i lösenordet."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Undvik vanliga ord."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Undvik att kasta om befintliga ord."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Använd fler siffror."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Använd fler versaler."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Använd fler gemener."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Använd fler specialtecken som till exempel skiljetecken."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Använd en blandning av bokstäver, siffror och skiljetecken."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Undvik att upprepa samma tecken."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Undvik att repetera samma typ av tecken: du behöver blanda bokstäver, "
+"siffror och skiljetecken."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Undvik sekvenser likt 1234 eller abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Lösenordet behöver vara längre. Försök att lägga till fler bokstäver, "
+"siffror och skiljetecken."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Blanda versaler och gemener och försök använda en eller flera siffror."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Att lägga till fler bokstäver, siffror och skiljetecken kommer göra "
+"lösenordet starkare."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Autentiseringen misslyckades"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Det nya lösenordet är för kort"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Det nya lösenordet är för enkelt"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Det gamla och det nya lösenordet är för lika"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Det nya lösenordet har används tidigare."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Det nya lösenordet måste innehålla numeriska- eller specialtecken"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Det gamla och det nya lösenordet är identiska"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Ditt lösenord har ändrats sedan du först autentiserades!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Det nya lösenordet innehåller inte tillräckligt många olika tecken"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Okänt fel"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Användarnamnet får vanligen endast innehålla små bokstäver från a-z, siffror "
+"och följande tecken: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Det användarnamnet är tyvärr inte tillgängligt. Försök med ett annat."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Användarnamnet är för långt."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Koppla knappar"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Koppla knappar till funktioner"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"För att redigera ett kortkommando, välj ”Skicka tangenttryckning”-åtgärden, "
+"tryck tangentbordsgenvägen och håll nere de nya tangenterna eller tryck "
+"backsteg för att rensa."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Stäng"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Tryck på målmarkörerna när de visas på skärmen för att kalibrera ritplattan."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Felaktigt klick upptäcktes, startar om…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Knapp %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Programdefinierad"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Skicka tangenttryckning"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Byt skärm"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Visa hjälp på skärmen"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Ritplatta monterad på skärm för bärbar dator"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Ritplatta monterad på extern skärm"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Extern ritplatteenhet"
+
+# Wacom Express Key Remote, andvänds tillsammans med en ritplatta.
+# https://estore.wacom.com/media/catalog/product/cache/fb4143a007ae6439deba9b18afd745f2/a/c/ack-411050_main_2.jpg
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Extern fjärrkontrollsenhet"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Alla skärm­ar"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Ritplatteläge"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Använd absolut positionering för pennan"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Vänsterhänt orientering"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Ritplatteknappar och ExpressKeys™ roteras för vänsterhänt användning"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Mappa till skärm"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Behåll bildförhållande"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Använd endast en del av ritplattans yta för att behålla skärmens "
+"bildförhållande"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibrera"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Ingen ritplatta hittades"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Anslut eller slå på din Wacom-ritplatta."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Tryckkänsla för spets"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Mjuk"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Spetstryck för styluspenna"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Fast"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Knapp 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Knapp 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Knapp 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Tryckkänsla för raderare"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Tryck för raderare"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Mittenklick med musknapp"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Högerklick med musknapp"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Framåt"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Airbrush-styluspenna med tryck, lutning och integrerat reglage"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Airbrush-styluspenna med tryck, lutning och rotation"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Standardstyluspenna med tryck och lutning"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Standardstyluspenna med tryck"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom-ritplatta"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Ställ in knappkopplingar och justera styluspennkänsligheten för ritplattor"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Ritplatta;Wacom;Styluspenna;Raderare;Mus;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Nytt kortkommando…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Accesspunkter"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Operationen avbröts"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Fel:</b> Åtkomst nekad vid ändring av inställningar"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Fel:</b> Mobilutrustningsfel"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Inte registrerad"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Registrerad"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Roaming"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Söker"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Nekad"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modemdetaljer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modemstatus"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Operatör"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Nätverkstyp"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Nätverksstatus"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Eget nummer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Enhetsdetaljer"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Version av fast programvara"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Endast 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Endast 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Endast 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Endast 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (föredras), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (föredras), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (föredras), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (föredras), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (föredras), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (föredras), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (föredras), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (föredras), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (föredras), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (föredras), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (föredras), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (föredras), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (föredras), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (föredras), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (föredras), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (föredras), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (föredras)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (föredras), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Okänt"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Lås upp SIM-kort"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Lås upp"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Tillhandahåll PIN-koden för SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Ange PIN för att låsa upp ditt SIM-kort"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Tillhandahåll PUK-koden för SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Ange PUK för att låsa upp ditt SIM-kort"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Fel lösenord matades in. Du har %1$u försök kvar"
+msgstr[1] "Fel lösenord matades in. Du har %1$u försök kvar"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Du har %u försök kvar"
+msgstr[1] "Du har %u försök kvar"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Fel lösenord matades in."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK-koden ska vara ett 8-siffrigt tal"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Ange ny PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN-koden ska vara ett tal med 4-8 siffror"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Låser upp…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Inget SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Sätt i ett SIM-kort för att använda detta modem"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM låst"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobildata"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Kom åt data genom mobilnätverk"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Data-roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Använd mobildata vid roaming"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Nätverksläge"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "Nä_tverk"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Avancerat"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Accesspunktnamn"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM-lås"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Lås SIM med PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "M_odemdetaljer"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Telefonfel"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Ingen anslutning till telefon"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Operationen tillåts ej"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Operationen stöds ej"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM inte anslutet"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "PIN för SIM krävs"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "PUK för SIM krävs"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM-fel"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM upptaget"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Felaktigt lösenord"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "PIN2 för SIM krävs"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "PUK2 för SIM krävs"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Hittades inte"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Ingen nätverkstjänst"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Nätverkstidsgräns överskreds"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS-tjänster tillåts ej"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Roaming är inte tillåtet på området för denna plats"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Ospecificerat GPRS-fel"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Inget fel"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Åtgärden avbröts"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Åtkomst nekad"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Okänt fel"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Nätverksläge"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Automatiskt"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Välj nätverk"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Uppdatera nätverksleverantörer"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Aktivera mobilnätverk"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Ingen WWAN-adapter hittades"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Säkerställ att du har en WWAN-enhet/mobilenhet"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "WWAN är inaktiverat när flygplansläge är på"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "S_täng av flygplansläge"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Dataanslutning"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM-kort används för internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM-lås"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Nästa"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "_Lås SIM med PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Ändra PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Ange aktuell PIN för att ändra låsinställningar för SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobilnätverk"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Konfigurera telefoni och mobildataanslutningar"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;mobilnätverk;wwan;telefoni;sim;mobil;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Verktyg för att konfigurera GNOME-skrivbordet"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+"Inställningar är det primära gränssnittet för att konfigurera ditt system."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME-projektet"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Visa versionsnummer"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Aktivera informativt läge"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Sök efter strängen"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Lista möjliga panelnamn och avsluta"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Panel att visa"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Inställningskategorier"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Sekretess"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Tillgängliga paneler:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Alla inställningar"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Primär meny"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Varning: Utvecklingsversion"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Denna version av Inställningar bör endast användas i utvecklingssyfte. Du "
+"kan råka ut för felaktigt beteende hos systemet, dataförlust och andra "
+"oväntade problem. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Hjälp"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Allmänt"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Avsluta"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Sök"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneler"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Gå tillbaka till föregående panel"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Avbryt sökning"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Inställningar;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Identifieraren för den sista inställningspanelen som öppnades"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Identifieraren för den sista inställningspanelen som öppnades. Okända värden "
+"kommer att ignoreras och den första panelen i listan väljs."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Visa en varning då en utvecklingsversion av Inställningar körs"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Huruvida Inställningar ska visa en varning då en utvecklingsversion körs."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Initialt fönstertillstånd"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"En tupel som innehåller programfönstrets initiala bredd, höjd och "
+"maximeringstillstånd."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u utgång"
+msgstr[1] "%u utgångar"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ingång"
+msgstr[1] "%u ingångar"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Systemljud"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Lägg till en skrivare…"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER eller PEM-certifikat (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Drip"
+#~ msgstr "Droppe"
+
+#~ msgid "Glass"
+#~ msgstr "Glas"
+
+#~ msgid "Sonar"
+#~ msgstr "Sonar"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Skärmuppställning"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Lås din skärm"
+
+#~ msgid "Light"
+#~ msgstr "Ljus"
+
+#~ msgid "Set"
+#~ msgstr "Ställ in"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "skärm;lås;diagnostik;krasch;sekretess;nyligen;tillfällig;tmp;index;namn;"
+#~ "nätverk;identitet;"
+
+#~ msgid "Bark"
+#~ msgstr "Skall"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Ljudpanelen i GNOME Inställningar"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Mus &amp; styrplatta-panelen i GNOME Inställningar"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Bakgrundspanelen i GNOME Inställningar"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Tangentbordspanelen i GNOME Inställningar"
+
+#~ msgid "More Warm"
+#~ msgstr "Varmare"
+
+#~ msgid "Less Warm"
+#~ msgstr "Mindre varm"
+
+#~ msgid "Move up"
+#~ msgstr "Flytta upp"
+
+#~ msgid "Move down"
+#~ msgstr "Flytta ned"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s-VPN"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Autentisera"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Skärmdelning tillåter fjärranvändare att se eller styra din skärm genom "
+#~ "att ansluta till %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "_Skärmdelning"
+
+#~ msgid "_Password:"
+#~ msgstr "_Lösenord:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Visa lösenord"
+
+#~ msgid "Access Options"
+#~ msgstr "Åtkomstalternativ"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Nya anslutningar måste fråga efter åtkomst"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Begär ett lösenord"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Ta en skärmbild"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "Spara en skärmbild av ett fönster"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Tillåt programmen nedan att använda din mikrofon."
+
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgid "Account _Type"
+#~ msgstr "Konto_typ"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Låt användare välja lösenord vid nästa _inloggning"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Ange ett lösenord _nu"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "Du måste vara ansluten till nätet för att lägga till företagsanvändare."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Ta en bild…"
+
+#~ msgid "Your account"
+#~ msgstr "Ditt konto"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klicka först på *-ikonen\n"
+#~ "för att göra ändringar"
+
+#~ msgid "Create a user account"
+#~ msgstr "Skapa ett användarkonto"
+
+#~ msgid "User Icon"
+#~ msgstr "Användarikon"
+
+#~ msgid "Account Settings"
+#~ msgstr "Kontoinställningar"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Autentisering & inloggning"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Det här kommer att användas för att namnge din hemmapp och kan inte "
+#~ "ändras."
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Välj formatet för tal, datum och valutor. Ändringar börjar gälla vid "
+#~ "nästa inloggning."
+
+#~ msgid "My Account"
+#~ msgstr "Mitt konto"
+
+#~ msgid "Language"
+#~ msgstr "Språk"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Språket som används för text i fönster och webbsidor."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Starta om sessionen för att ändringar ska genomföras"
+
+#~ msgid "Restart…"
+#~ msgstr "Starta om…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Inloggningsinställningar används av alla användare när inloggad i systemet"
+
+#~ msgid "Output:"
+#~ msgstr "Utmatning:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Behåll bildförhållande (brevlådeformat):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Koppla till ensam skärm"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d av %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Skärmkoppling"
+
+#~ msgid "Stylus"
+#~ msgstr "Styluspenna"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Ritplatta (absolut)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Styrplatta (relativ)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Inställningar för ritplatta"
+
+#~ msgid "_Help"
+#~ msgstr "_Hjälp"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Bluetooth-inställningar"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Spårningsläge"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Koppla knappar…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Ställ in musinställningar"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Justera skärmupplösning"
+
+#~ msgid "Decouple Display"
+#~ msgstr "Frikoppla skärm"
+
+#~ msgid "No stylus found"
+#~ msgstr "Inga styluspenna hittades"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "Förflytta din styluspenna nära ritplattan för att konfigurera den"
+
+#~ msgid "Top Button"
+#~ msgstr "Övre knapp"
+
+#~ msgid "Lower Button"
+#~ msgstr "Nedre knapp"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Nedersta knappen"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Spara en skärmbild till $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Spara en skärmbild på ett område till $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Kopiera en skärmbild till urklipp"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Kopiera en skärmbild av ett fönster till urklipp"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Kopiera en skärmbild av ett område till urklipp"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Spela in en kort skärminspelning"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Styr vilka sökresultat som visas i översiktsvyn Aktiviteter. Ordningen på "
+#~ "sökresultat kan också ändras genom att flytta rader i listan."
+
+#~ msgid "Web Links"
+#~ msgstr "Webblänkar"
+
+#~ msgid "Git Links"
+#~ msgstr "Git-länkar"
+
+#~ msgid "%s Links"
+#~ msgstr "%s-länkar"
+
+#~ msgid "Unset"
+#~ msgstr "Ej inställd"
+
+#~ msgid "Links"
+#~ msgstr "Länkar"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Hypertextfiler"
+
+#~ msgid "Text Files"
+#~ msgstr "Textfiler"
+
+#~ msgid "Image Files"
+#~ msgstr "Bildfiler"
+
+#~ msgid "Font Files"
+#~ msgstr "Typsnittsfiler"
+
+#~ msgid "Archive Files"
+#~ msgstr "Arkivfiler"
+
+#~ msgid "Package Files"
+#~ msgstr "Paketfiler"
+
+#~ msgid "Audio Files"
+#~ msgstr "Ljudfiler"
+
+#~ msgid "Video Files"
+#~ msgstr "Videofiler"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Behörigheter och åtkomst"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Data och tjänster som detta program har begärt åtkomst till och "
+#~ "behörigheter som det kräver."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Kan inte ändras"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Individuella behörigheter för program kan granskas i <a "
+#~ "href=\"privacy\">Sekretess</a>-inställningarna."
+
+#~ msgid "Integration"
+#~ msgstr "Integration"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Ställ in skrivbordsbakgrund"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Standardhanterare"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Typer av filer och länkar som detta program öppnar."
+
+#~ msgid "Usage"
+#~ msgstr "Användning"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Hur mycket resurser detta program använder."
+
+#~ msgid "Open in Software"
+#~ msgstr "Öppna i Programvara"
+
+#~ msgid "Display Mode"
+#~ msgstr "Skärmläge"
+
+#~ msgid "Join Displays"
+#~ msgstr "Sammanfoga skärm­ar"
+
+#~ msgid "Single Display"
+#~ msgstr "Ensam skärm"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Dra skärmar så de överensstämmer med din fysiska skärmuppställning. Välj "
+#~ "en skärm för att ändra dess inställningar."
+
+#~ msgid "Active Display"
+#~ msgstr "Aktiv skärm"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Tillåt programmen nedan att använda din kamera."
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Platstjänster låter program få veta din position. Att aktivera Wi-Fi och "
+#~ "mobilt bredband ökar noggrannheten."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Använder Mozilla Location Service: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Sekretesspolicy</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Tillåt programmen nedan att se din plats."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Knä upptäckt: prestandaläge är inte tillgängligt"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Hög hårdvarutemperatur: prestandaläge är inte tillgängligt"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Prestandaläge är inte tillgängligt"
+
+#~ msgid "Activities"
+#~ msgstr "Aktiviteter"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Ljudtangenter"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Skärmläsare"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "_Skärmläsare"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Misslyckades med att skicka filen: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Profilen har skickats till:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Skriv ner denna URL."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Starta om den här datorn och läs in ditt vanliga operativsystem."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Skriv in URL:en i din webbläsare för att hämta och installera profilen."
+
+#~ msgid "Upload profile"
+#~ msgstr "Skicka upp profil"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Kräver anslutning till Internet"
+
+#~ msgid "_Copy"
+#~ msgstr "_Kopiera"
+
+#~ msgid "Select _All"
+#~ msgstr "Markera _allt"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Tidsgräns för dubbelklick"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Vänteläges- & avstängningsknapp"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Vissa tjänster är inaktiverade på grund av ingen nätverksåtkomst."
+
+#~ msgid "Unlocking..."
+#~ msgstr "Låser upp…"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Inloggning;Namn;Fingeravtryck;Avatar;Logotyp;Ansikte;Lösenord;"
+
+#~ msgid "PDP authentication failure"
+#~ msgstr "PDP-autentiseringsfel"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Skärmljusstyrka"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Tangentbordljusstyrka"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Dämpa skärmen när inaktiv"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Töm skärm"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "Trådlöst _nätverk"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Trådlöst nätverk kan stängas av för att spara ström."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Mobilt bredband (LTE, 4G, 3G med mera) kan stängas av för att spara ström."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth kan stängas av för att spara ström."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Balanserad strömförbrukning"
+
+#~ msgid "Add…"
+#~ msgstr "Lägg till…"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Tangentbordsgenväg"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Detta kan ändras i Anpassa kortkommandon"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Håll nere och skriv för att mata in olika tecken"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Alternativa tecken-tangenten"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Byt till nästa källa enbart med modifierare"
+
+#~ msgid "Previous source"
+#~ msgstr "Föregående källa"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+skift+blanksteg"
+
+#~ msgid "Next source"
+#~ msgstr "Nästa källa"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+blanksteg"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Vänster + höger Alt"
+
+#~ msgid "Left Alt"
+#~ msgstr "Vänster Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Höger Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Vänster super"
+
+#~ msgid "Right Super"
+#~ msgstr "Höger super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Höger Ctrl"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Menytangent"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Laddar"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Varning"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Låg"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Bra"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Uppladdad"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Tom"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "Lägg till användarkonton och ändra lösenord"
+
+#~ msgid "Play and record sound"
+#~ msgstr "Spela och spela in ljud"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "Upptäck nätverksenheter med mDNS/DNS-SD (Bonjour/zeroconf)"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "Kom direkt åt bluetooth-hårdvara"
+
+#~ msgid "Use your camera"
+#~ msgstr "Använd din kamera"
+
+#~ msgid "Print documents"
+#~ msgstr "Skriv ut dokument"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "Använd en ansluten styrspak"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "Tillåt anslutning till Docker-tjänsten"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "Konfigurera nätverksbrandvägg"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "Konfigurera och använd privilegierade FUSE-filsystem"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "Uppdatera fast programvara på denna enhet"
+
+#~ msgid "Access hardware information"
+#~ msgstr "Kom åt hårdvaruinformation"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "Tillhandahåll entropi åt hårdvaruslumptalsgenerator"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "Använd hårdvarugenererade slumptal"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "Kom åt filer i din hemmapp"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "Kom åt libvirt-tjänst"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "Ändra systemspråk och regionsinställningar"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "Ändra inställningar och leverantörer för plats"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "Läs system- och programloggar"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "kom åt tjänsten media-hub"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "Använd och konfigurera modem"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "Läs systemets monteringsinformation och diskkvoter"
+
+#~ msgid "Control music and video players"
+#~ msgstr "Styr musik- och videospelare"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "Ändra nätverksinställningar på låg nivå"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr ""
+#~ "Kom åt tjänsten Nätverkshanteraren för att läsa och ändra "
+#~ "nätverksinställningar"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "Läsåtkomst till nätverksinställningar"
+
+#~ msgid "Change network settings"
+#~ msgstr "Ändra nätverksinställningar"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr ""
+#~ "Kom åt ofono-tjänsten för att läsa och ändra nätverksinställningar för "
+#~ "mobiltelefoni"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "Styr Open vSwitch-hårdvara"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "Läs från cd/dvd"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "Läs, lägg till, ändra eller ta bort sparade lösenord"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr ""
+#~ "Kom åt pppd- och ppp-enheter för konfiguration av Point-to-Point Protocol-"
+#~ "anslutningar"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "Pausa eller avsluta valfri process på systemet"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "Kom åt USB-hårdvara direkt"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "Läs/skriv filer på flyttbara lagringsenheter"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "Förhindra skärmen från att gå i viloläge/låsas"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "Kom åt hårdvara via serieport"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "Starta om eller stäng av enheten"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "Installera, ta bort och konfigurera programvara"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "Kom åt tjänst för lagringsramverk"
+
+#~ msgid "Read process and system information"
+#~ msgstr "Läs process- och systeminformation"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "Övervaka och styr körande program"
+
+#~ msgid "Change the date and time"
+#~ msgstr "Ändra datum och tid"
+
+#~ msgid "Change time server settings"
+#~ msgstr "Ändra tidsserverinställningar"
+
+#~ msgid "Change the time zone"
+#~ msgstr "Ändra tidszonen"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr ""
+#~ "Kom åt UDisks2-tjänsten för konfiguration av diskar och flyttbara media"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "Läs/ändra delade kalenderevenemang i Ubuntu Unity 8"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "Läs/ändra delade kontakter i Ubuntu Unity 8"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "Kom åt energianvändningsdata"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "Läs/skrivåtkomst till exponerade U2F-enheter"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "Hjälpmedel"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Slå av för att ansluta till ett trådlöst nätverk"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Lösenord"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Klicka först på *-ikonen för\n"
+#~ "att skapa ett användarkonto"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Aktivera fingeravtrycksinloggning"
+
+#~ msgid "_Other finger:"
+#~ msgstr "A_nnat finger:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Ditt fingeravtryck sparades. Du ska nu kunna logga in med hjälp av din "
+#~ "fingeravtrycksläsare."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "Du tillåts inte komma åt enheten. Kontakta din systemadministratör."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Ett internt fel har inträffat."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Ta bort registrerade fingeravtryck?"
+
+#~ msgid "Done!"
+#~ msgstr "Färdig!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Kunde inte komma åt enheten ”%s”"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Kunde inte starta fingeravläsning på enheten ”%s”"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Kunde inte komma åt några fingeravtrycksläsare"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Kontakta din systemadministratör för hjälp."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Du behöver spara ett av dina fingeravtryck med hjälp av enheten ”%s” för "
+#~ "att aktivera fingeravtrycksinloggning."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Välj finger"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "Ställ in bakgrund och låsskärm"
+
+#~ msgid "Set Background"
+#~ msgstr "Ställ in bakgrund"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "Ställ in låsskärm"
+
+#~ msgid "Remove Background"
+#~ msgstr "Ta bort bakgrund"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "Rapporter skickas anonymt och rensas på personliga data."
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr ""
+#~ "Att skicka in rapporter om tekniska problem hjälper oss att förbättra "
+#~ "detta operativsystem."
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Aviserings_poppupper"
+
+#~ msgid "Last Login"
+#~ msgstr "Senast inloggad"
+
+#~ msgid "Version %s"
+#~ msgstr "Version %s"
+
+#~ msgid "OS name"
+#~ msgstr "OS-namn"
+
+#~ msgid "OS type"
+#~ msgstr "OS-typ"
+
+#~ msgid "Disk"
+#~ msgstr "Disk"
+
+#~ msgid "Check for updates"
+#~ msgstr "Sök uppdateringar"
+
+#~ msgid "Network proxy"
+#~ msgstr "Nätverksproxy"
+
+#~ msgid "page 1"
+#~ msgstr "sida 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "Inre _autentisering"
+
+#~ msgid "page 2"
+#~ msgstr "sida 2"
+
+#~ msgid "Restrict _background data usage"
+#~ msgstr "_Begränsa dataanvändning i bakgrunden"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr ""
+#~ "Lämpligt för anslutningar som har datakostnader eller begränsad datamängd."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Aktivering av den trådlösa surfzonen kommer att koppla bort dig från "
+#~ "<b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Det är inte möjligt att ansluta trådlöst till internet så länge surfzonen "
+#~ "är aktiv."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Trådlösa surfzoner används vanligen för att dela en ytterligare "
+#~ "internetanslutning över Wi-Fi."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "A_utomatisk anslutning"
+
+#~ msgid "details"
+#~ msgstr "detaljer"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Visa _lösenord"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Gör tillgänglig för alla användare"
+
+#~ msgid "identity"
+#~ msgstr "identitet"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Adresser"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Endast automatiska (DHCP)-adresser"
+
+#~ msgid "Link-local only"
+#~ msgstr "Endast lokal länk"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Ignorera automatiskt erhållna rutter"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_Klonad MAC-adress"
+
+#~ msgid "_Reset"
+#~ msgstr "_Återställ"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Återställ standardinställningarna för denna anslutning, men kom ihåg som "
+#~ "en anslutning att helst använda."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Ta bort alla detaljer rörande detta nätverk och försök inte att ansluta "
+#~ "till det automatiskt."
+
+#~ msgid "Hardware"
+#~ msgstr "Hårdvara"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Återställ"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Anslutna enheter"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastruktur"
+
+#~ msgid "In use"
+#~ msgstr "I bruk"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "På"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Av"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Av"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "På"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Av"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "På"
+
+#~ msgid "Usage & History"
+#~ msgstr "Användning & historik"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Sekretesspolicy"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Att komma ihåg din historik gör att det blir enklare att hitta saker "
+#~ "igen. Dessa objekt delas aldrig via nätverket."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Nyligen använda"
+
+#~ msgid "Retain _History"
+#~ msgstr "Behåll _historik"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "Skärmlåset skyddar ditt privatliv när du inte är närvarande."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Lås s_kärmen om tom efter"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "Aviseri_ngar på låsskärm"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Rensa automatiskt papperskorgen och tillfälliga filer för att hålla din "
+#~ "dator ren från onödig känslig information."
+
+#~ msgid "Purge _After"
+#~ msgstr "Rens_a efter"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Att skicka oss information om vilken programvara du använder hjälper oss "
+#~ "att ge dig mer korrekta rekommendationer. Det hjälper oss också att "
+#~ "förbättra vår programvara.\n"
+#~ "\n"
+#~ "All information vi samlar in anonymiseras, och vi kommer aldrig att dela "
+#~ "dina data med tredje part."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Skicka statistik över programvaruanvändning"
+
+#~ msgid "_Camera"
+#~ msgstr "_Kamera"
+
+#~ msgid "_Microphone"
+#~ msgstr "_Mikrofon"
+
+#~ msgid "_Location Services"
+#~ msgstr "P_latstjänster"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "Skydda din personliga information och kontrollera vad andra kan se"
+
+#~ msgid "No regions found"
+#~ msgstr "Inga regioner hittades"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Blinka _fönstrets namnlist"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Användarnamnet får inte börja med ett ”-”."
+
+#~ msgid "_Background"
+#~ msgstr "_Bakgrund"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Ändrar sig under dagen"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Sida vid sida"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Zooma"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Centrera"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Skala"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Fyll"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Omfång"
+
+#~ msgid "Colors"
+#~ msgstr "Färger"
+
+#~ msgid "Pictures"
+#~ msgstr "Bilder"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Inga bilder hittades"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Du kan lägga till bilder till mapp för %s så kommer de att visas här"
+
+#~ msgid "_Off"
+#~ msgstr "_Av"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "Anslutning/SSID"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Automatiskt vänteläge"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_När avstängningsknappen trycks ned"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "_Night Light"
+#~ msgstr "_Nattbelysning"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Kunde inte hämta skärminformation"
+
+#~ msgid "Add input source"
+#~ msgstr "Lägg till inmatningskälla"
+
+#~ msgid "Remove input source"
+#~ msgstr "Ta bort inmatningskälla"
+
+#~ msgid "Move input source up"
+#~ msgstr "Flytta upp inmatningskälla"
+
+#~ msgid "Move input source down"
+#~ msgstr "Flytta ner inmatningskälla"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Visa tangentbordslayout för inmatningskälla"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Vänster"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Höger"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Minimum"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Maximum"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Subwoofer:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Profil:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "Testa _högtalare"
+
+#~ msgid "Peak detect"
+#~ msgstr "Upptäck toppar"
+
+#~ msgid "Device"
+#~ msgstr "Enhet"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Högtalartest för %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Välj _en enhet som ljudutgång:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Inställningar för den valda enheten:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Ingångsvolym:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "Välj _en enhet som ljudingång:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Ljudeffekter"
+
+#~ msgid "Built-in"
+#~ msgstr "Inbyggd"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Ljudinställningar"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Testar händelseljud"
+
+#~ msgid "From theme"
+#~ msgstr "Från tema"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "Välj ett lar_mljud:"
+
+#~ msgid "Stop"
+#~ msgstr "Stoppa"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME Kontrollpanel"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Kontrollpanelen är GNOME:s huvudsakliga gränssnitt för inställning av "
+#~ "olika aspekter för ditt skrivbord."
+
+#~ msgid "hardware"
+#~ msgstr "hårdvara"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Byt till föregående källa"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Byt till nästa källa"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Alternativt byte till nästa källa"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Engelska (Storbritannien)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Storbritannien"
+
+#~ msgid "_Options"
+#~ msgstr "A_lternativ"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Standard"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Administratör"
+
+#~ msgid "page 3"
+#~ msgstr "sida 3"
+
+#~ msgid "Quit"
+#~ msgstr "Avsluta"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Verifiera nytt lösenord"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Lösenorden stämmer inte överens."
+
+#~ msgid "Show the overview"
+#~ msgstr "Visa översikten"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "Placera din vänstra tumme på %s"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "Dra din vänstra tumme på %s"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "Placera ditt vänstra pekfinger på %s"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "Dra ditt vänstra pekfinger på %s"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "Placera ditt vänstra långfinger på %s"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "Dra ditt vänstra långfinger på %s"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "Placera ditt vänstra ringfinger på %s"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "Dra ditt vänstra ringfinger på %s"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "Placera ditt vänstra lillfinger på %s"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "Dra ditt vänstra lillfinger på %s"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "Placera din högra tumme på %s"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "Dra din högra tumme på %s"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "Placera ditt högra pekfinger på %s"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "Dra ditt högra pekfinger på %s"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "Placera ditt högra långfinger på %s"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "Dra ditt högra långfinger på %s"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "Placera ditt högra ringfinger på %s"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "Dra ditt högra ringfinger på %s"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "Placera ditt högra lillfinger på %s"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "Dra ditt högra lillfinger på %s"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "Placera ditt finger på läsaren igen"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "Dra ditt finger igen"
+
+#~ msgid "Swipe was too short; try again"
+#~ msgstr "Dragningen var för kort, försök igen"
+
+#~ msgid "Your finger was not centered; try swiping your finger again"
+#~ msgstr "Ditt finger var inte centrerat. Prova att dra ditt finger igen"
+
+#~ msgid "Remove your finger and try swiping it again"
+#~ msgstr "Ta bort ditt finger och prova att dra det igen"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "Dragningen var för kort, försök igen"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "Ditt finger var inte centrerat. Prova att dra ditt finger igen"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "Ta bort ditt finger och prova att dra ditt finger igen"
+
+#~ msgid "Disable image"
+#~ msgstr "Inaktivera bild"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Bläddra efter fler bilder…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Används av %s"
+
+#~ msgid "Back­ground"
+#~ msgstr "Bak­grund"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blue­tooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Färg"
+
+#~ msgid "Overview"
+#~ msgstr "Översikt"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Standard­prog­ram"
+
+#~ msgid "Ab­out"
+#~ msgstr "Om"
+
+#~ msgid "De­tails"
+#~ msgstr "De­talj­er"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Flytt­bara media"
+
+#~ msgid "Net­work"
+#~ msgstr "Nät­verk"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "A­vi­ser­ing­ar"
+
+#~ msgid "Po­wer"
+#~ msgstr "Ström"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Sekr­et­ess"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Del­a"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Hjälp­med­el"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wa­com-rit­platt­a"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Hårdvara"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "System"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Lock stängt"
+
+#~ msgid "Mirrored"
+#~ msgstr "Speglad"
+
+#~ msgid "Secondary"
+#~ msgstr "Sekundär"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Arrangera kombinerade skärmar"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Dra skärmar för att arrangera om dem"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Size"
+#~ msgstr "Storlek"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Visa systemraden och Aktivitetsöversikten på denna skärm"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Sammanfoga denna skärm med en annan för att skapa en extra arbetsyta"
+
+#~ msgid "Presentation"
+#~ msgstr "Presentation"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Visa endast bildspel och media"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Visa din befintliga vy på båda skärmarna"
+
+#~ msgid "Turn Off"
+#~ msgstr "Stäng av"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Använd inte denna skärm"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Arrangera kombinerade skärmar"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (Bygg-ID: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bitars"
+
+#~ msgid "Base system"
+#~ msgstr "Grundsystem"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Kortkommando;Genväg;Repetera;Blinka;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Tryck Esc för att avbryta."
+
+#~ msgid "Server"
+#~ msgstr "Server"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Radera DNS-server"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Gör tillgänglig för andra _användare"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Brandväggs_zon"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Standard"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Zonen anger anslutningens tillitsnivå"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Återställ inställningarna för detta nätverk, inklusive lösenord, men kom "
+#~ "ihåg det som ett önskat nätverk"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Ta bort alla detaljer som tillhör detta nätverk och försök inte att "
+#~ "ansluta automatiskt"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Lägg till profil…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Manuell"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Automatiskt"
+
+#~ msgid "Group Name"
+#~ msgstr "Gruppnamn"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "A_nvänd som surfzon…"
+
+#~ msgid "_History"
+#~ msgstr "_Historik"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Lägg till fler bokstäver, siffror och symboler."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Styrka: svag"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Styrka: låg"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Styrka: medel"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Styrka: bra"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Styrka: hög"
+
+#~ msgid "0"
+#~ msgstr "0"
+
+#~ msgid "Add Account"
+#~ msgstr "Lägg till konto"
+
+#~ msgid "Mail"
+#~ msgstr "E-post"
+
+#~ msgid "Calendar"
+#~ msgstr "Kalender"
+
+#~ msgid "Contacts"
+#~ msgstr "Kontakter"
+
+#~ msgid "Chat"
+#~ msgstr "Chatt"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Konfigurerar"
+
+#~ msgid "Toner Level"
+#~ msgstr "Tonernivå"
+
+#~ msgid "Supply Level"
+#~ msgstr "Förbrukningsmaterial"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Installerar"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u aktiv"
+#~ msgstr[1] "%u aktiva"
+
+#~ msgctxt "button"
+#~ msgid "Add"
+#~ msgstr "Lägg till"
+
+#~ msgid "Supply"
+#~ msgstr "Förbrukningsmaterial"
+
+#~ msgid "Jobs"
+#~ msgstr "Jobb"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Visa _jobb"
+
+#~ msgid "label"
+#~ msgstr "etikett"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Skriv ut _testsida"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>Ditt konto</small>"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "Aviserings_banderoller"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Aviserings_banderoller"
+
+#~ msgid "Error creating account"
+#~ msgstr "Fel vid skapande av kontot"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Är du säker på att du vill ta bort kontot?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Detta kommer inte att ta bort kontot på servern."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Inga nätkonton konfigurerade"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Att lägga till ett konto medför att dina program kan komma åt det för "
+#~ "dokument, e-post, kontakter, kalender, chatt och mer."
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Lägg till en ny skrivare"
+
+#~ msgid "No printers detected."
+#~ msgstr "Inga skrivare hittades."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Övriga konton"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Upp"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Ned"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#~ msgid "Left Ring"
+#~ msgstr "Vänster ring"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Vänster ringläge #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Höger ringläge #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Vänster Touchstrip"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Vänster Touchstrip-läge #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Höger Touchstrip"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Höger Touchstrip-läge #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Lägesväxel för vänster Touchring"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Lägesväxel för höger Touchring"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Lägesväxel för vänster Touchstrip"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Lägesväxel för höger Touchstrip"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Lägesväxlare #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Vänsterknapp #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Högerknapp #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Överknapp #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Nederknapp #%d"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Vänsterklick med musknapp"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Rulla uppåt"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Rulla nedåt"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Rulla åt höger"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr "Tangentbordsgenväg för <b>%s</b>. Mata in ny genväg för att ändra."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "För att redigera en genväg så klickar du på raden och håller ner de nya "
+#~ "tangenterna, eller trycker på backsteg för att tömma."
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Ta bort genväg"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Okänd åtgärd>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Genvägen ”%s” kan inte användas på grund av att den kommer att bli "
+#~ "omöjlig att ange med\n"
+#~ "den här tangenten. Prova med en tangent såsom Control, Alt eller Skift på "
+#~ "samma gång."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Genvägen ”%s” används redan för\n"
+#~ " ”%s”"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Om du omtilldelar genvägen till ”%s” kommer genvägen ”%s” att inaktiveras."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Omtilldela"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Genvägen ”%s” har en associerad genväg ”%s”. Vill du automatiskt sätta "
+#~ "den till ”%s”?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "”%s” är för tillfället associerad med ”%s”, denna genväg kommer att "
+#~ "inaktiveras om du fortsätter."
+
+#~ msgid "_Assign"
+#~ msgstr "Tilldel_a"
+
+#~ msgid "Bond"
+#~ msgstr "Bindning"
+
+#~ msgid "Team"
+#~ msgstr "Grupp"
+
+#~ msgid "Bridge"
+#~ msgstr "Brygga"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Kunde inte läsa in VPN-insticksmoduler"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Lägg till nätverksanslutning"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Bindningsslavar"
+
+#~ msgid "(none)"
+#~ msgstr "(ingen)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Bryggslavar"
+
+#~ msgid "Team slaves"
+#~ msgstr "Gruppslavar"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand-enheten saknar stöd för anslutet läge"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Inget certifikat för certifikatsutfärdare valt"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Att inte använda ett certifikat för certifikatsutfärdare (CA) kan "
+#~ "resultera i osäkra anslutningar till falska trådlösa nätverk. Vill du "
+#~ "välja ett certifikat för certifikatsutfärdare?"
+
+#~ msgid "Ignore"
+#~ msgstr "Ignorera"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Välj CA-certifikat"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Efte_rfråga detta lösenord var gång"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "_Varna mig inte igen"
+
+#~ msgid "Yes"
+#~ msgstr "Ja"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Fel vid inloggning med kontot"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Autentiseringsuppgifterna har gått ut."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Logga in för att aktivera detta konto."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Logga in"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Övrigt"
+
+#~ msgid "_Verify"
+#~ msgstr "_Verifiera"
+
+#~ msgid "Login History"
+#~ msgstr "Inloggningshistorik"
+
+#~ msgid "Add User Account"
+#~ msgstr "Lägg till användarkonto"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "En användare med användarnamnet ”%s” finns redan."
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Används för att fastställa din geografiska position"
+
+#~ msgid "Done"
+#~ msgstr "Färdig"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Tids_zon"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Återuppta utskrift"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Gör paus i utskrift"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Hålls kvar"
+
+#~ msgid "Job Title"
+#~ msgstr "Jobbtitel"
+
+#~ msgid "Job State"
+#~ msgstr "Jobbtillstånd"
+
+#~ msgid "Password:"
+#~ msgstr "Lösenord:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "_Upprepningstangenter"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "_Markörblinkning"
+
+#~ msgid "Zoom"
+#~ msgstr "Zooma"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Färg"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Fördröjning:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Kort"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Långsam"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Lång"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Snabb"
+
+#~ msgid "S_peed:"
+#~ msgstr "Hasti_ghet:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Prova dina inställningar"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Långsam"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Snabb"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Vänster"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Höger"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Pekarhastighet"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Långsam"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Snabb"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Långsam"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Snabb"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Lägg till ny skrivare"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Trådlösa enheter kräver extra ström"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Bluetooth-delning låter dig dela filer med andra Bluetooth-aktiverade "
+#~ "enheter"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Ta endast emot från betrodda enheter"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Spara mottagna filer till mappen för hämtningar"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "När batteriström är _kritiskt låg"
+
+#~ msgid "Show help options"
+#~ msgstr "Visa hjälpflaggor"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Kör \"%s --help\" för att se en komplett lista över tillgängliga "
+#~ "kommandoradsflaggor.\n"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Slå av trådlösa enheter"

--- a/po/ta.po
+++ b/po/ta.po
@@ -14,9 +14,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.master.ta\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-09-15 06:30+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-09-15 16:27+0630\n"
 "Last-Translator: Shantha kumar <shkumar@redhat.com>\n"
 "Language-Team: American English <kde-i18n-doc@kde.org>\n"
@@ -25,8 +24,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Lokalize 1.5\n"
-"Plural-Forms: nplurals=2; plural=(n!=1);\\n"
-"\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\\n\n"
 "\n"
 "\n"
 "\n"
@@ -39,578 +37,470 @@ msgstr ""
 "\n"
 "\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "பயன்பாடுகள்"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "பயன்பாடு எதுவும் இல்லை"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "நிறுவப்பட்டது"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "திற (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "விவரங்களை காண்"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "தேடு"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "முடக்கப்பட்டது"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "அறிவிப்புகள்"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "அறிவிப்புகளைக் காண்பி (_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "பின்னணி"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "திரை வெட்டுக்கள்"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "சுவர்-காகிதங்கள்"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "ஒலி"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+#, fuzzy
+msgid "Reproduce sounds."
+msgstr "ஒலிகள் இல்லை"
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "குறுக்கு வழிகள்"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "விசைப்பலகை குறுக்கு வழிகள்"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s கேமரா"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "ஒலி வாங்கி அளவு"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "இருப்பிடச் சேவைகள் (_L)"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "உள்ளமைந்த வெப்கேம்"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "பகுதி காணப்படவில்லை"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "காட்சி வகை"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "இணைப்பு வேகம்"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "மீட்டமை"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "பயன்பாடுகள்"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>திற</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "எழுத்தாணி"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "முன்னிருப்பு"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "பின்னணி"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "நாள் முழுதும் மாறும்"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "சுயவிவரம் சேர் (_A)…"
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "Lock Screen"
-msgstr "திரையை பூட்டு"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "கருப்பொருள்  விருப்பஙகள்"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "ஓடுகளாக்க பரப்பு"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "அணுகிப்பார்"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "மையம்"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "அளவாக்கம்"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "நிரப்பு"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "வீச்சு"
-
-#: ../panels/background/cc-background-chooser-dialog.c:438
-msgid "Wallpapers"
-msgstr "சுவர்-காகிதங்கள்"
-
-#: ../panels/background/cc-background-chooser-dialog.c:447
-msgid "Colors"
-msgstr "வண்ணங்கள்"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:485
-msgid "Select Background"
-msgstr "பின்னணியை தேர்ந்தெடு"
-
-#: ../panels/background/cc-background-chooser-dialog.c:514
-msgid "Pictures"
-msgstr "படங்கள் "
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:546
-msgid "No Pictures Found"
-msgstr "படங்கள் இல்லை"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:564
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "இல்லம்"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:576
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr ""
-"உங்கள் %s கோப்புறையில் நீங்கள் படங்களைச் சேர்க்கலாம், அவை இங்கு "
-"காண்பிக்கப்படும்"
-
-#: ../panels/background/cc-background-chooser-dialog.c:583
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1537
-#: ../panels/display/cc-display-panel.c:1976
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1247
-#: ../panels/network/net-device-wifi.c:1440
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/cc-printers-panel.c:1947
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-#: ../panels/user-accounts/um-photo-dialog.c:95
-#: ../panels/user-accounts/um-photo-dialog.c:222
-#: ../panels/user-accounts/um-user-panel.c:513
-msgid "_Cancel"
-msgstr "_C நீக்கு"
-
-#: ../panels/background/cc-background-chooser-dialog.c:584
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:97
-msgid "Select"
-msgstr "தேர்வு செய்க "
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "பல அளவுகள்"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "பணிமேடை பின்னணி எதுவுமில்லை"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "நடப்பு பின்னணி"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "உங்கள் பின்புலப் படத்தை வால்பேப்பர் அல்லது புகைப்படமாக மாற்றவும்"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "சுவர்-காகிதங்கள் ;திரை;மேல்மேசை;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "ப்ளூடூத் செயல்நீக்கப்பட்டது"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "செயல்படுத்து"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "ப்ளூடூத் தகைவிகள் ஏதும் காணப்படவில்லை"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth பகிர்வு"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "_p விமானப்பாங்கு"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "ப்ளூடூத் வன்பொருள் மாற்றியால் செயல் நீக்கப்பட்டது"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1688
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "_p விமானப்பாங்கு"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "_p விமானப்பாங்கு"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "ப்ளூடூத்"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
-msgstr ""
-"Bluetooth ஐ ஆன் மற்றும் ஆஃப் செய்யவும் மற்றும் உங்கள் சாதனங்களை இணைக்கவும்"
+msgstr "Bluetooth ஐ ஆன் மற்றும் ஆஃப் செய்யவும் மற்றும் உங்கள் சாதனங்களை இணைக்கவும்"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
-"உங்கள் அளவைவகுத்தல் சாதனத்தை சதுரத்தின் மீது வைத்து 'தொடங்கு' என்பதை "
-"அழுத்தவும்"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "நடப்பில் எந்த பயன்பாடும் ஒலியை இயக்கவோ பதியவோ இல்லை"
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"உங்கள் அளவைவகுத்தல் சாதனத்தை அளவைவகுத்தல் இடநிலைக்கு நகர்த்தி 'தொடரு' என்பதை "
-"அழுத்தவும்"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
-"உங்கள் அளவைவகுத்தல் சாதனத்தை மேற்பரப்பு இடநிலைக்கு நகர்த்தி 'தொடரு' என்பதை "
-"அழுத்தவும்"
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "மடிக்கணினி மூடியை மூடவும்"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "அதிக படங்களுக்கு உலாவி காண்க"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "சரிசெய்ய முடியாத ஒரு உள்ளமை பிழை நேர்ந்தது."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "அளவைவகுத்தலைச் செய்வதற்குத் தேவையான கருவிகள் நிறுவப்படவில்லை."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "சுயவிவரத்தை உருவாக்க முடியவில்லை."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "இலக்கு வெண்புள்ளி அடையக்கூடியதாக இல்லை."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "முடிந்தது!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "அளவைவகுத்தல் தோல்வி!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "அளவைவகுத்தல் சாதனத்தை அகற்றலாம்."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "செயலில் இருக்கும் போது அளவைவகுத்தல் சாதனத்தைத் தொந்தரவு செய்ய வேண்டாம்"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "மடிக்கணினி திரை"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "உள்ளமைந்த வெப்கேம்"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s மானிட்டர்"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s ஸ்கேனர்"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s கேமரா"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s அச்சுப்பொறி"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s வெப்கேம்"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s க்கு நிற மேலாண்மையை செயல்படுத்தவும்"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s க்கு நிற சுயவிவரங்களைக் காண்பி"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-msgid "Not calibrated"
-msgstr "அளவைவகுக்கப்படவில்லை"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "முன்னிருப்பு:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "நிறவெளி:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "சோதனை வரிவுரு:"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "ஐசிசி வரிவுரு கோப்பை  தேர்ந்தெடு."
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "இறக்குமதி (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "ஆதரவுள்ள ஐசிசி வரிவுருக்கள்"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "எல்லா கோப்புகள்"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "திரை"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "கோப்பைப் பதிவேற்றுவதில் தோல்வியடைந்தது: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "சுயவிவரம் இங்கு பதிவேற்றப்பட்டது:"
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "இந்த URL ஐ எழுதிக்கொள்ளவும்."
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"இந்த கணினியை மறுதொடக்கம் செய்து உங்கள் வழக்கமான இயக்க முறைமையை பூட் செய்யவும்."
 
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-"சுயவிவரத்தைப் பதிவிறக்க இந்த URL ஐ உங்கள் உலாவியில் தட்டச்சு செய்து, "
-"சுயவிவரத்தை "
-"நிறுவவும்."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "சுயவிவரத்தைச் சேமி"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "சேமி (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "தேர்ந்தெடுக்கப்பட்ட சாதனத்திற்கு வண்ன வரியுரு அமை:"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"அளவீட்டு கருவி காணவில்லை. அது இயக்கப்பட்டுள்ளது, சரியாக பொருத்தப்பட்டுள்ளது "
-"என உறுதி "
-"செய்து கொள்க."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "அளவீட்டு கருவி அச்சுப்பொறி வருவுருவாக்கத்தை ஆதரிக்கவில்லை."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "இந்த சாதன வகைக்கு இப்போது ஆதரவில்லை."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "தரநிலையான இடம்"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "சோதனை சுயவிவரம்:"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "தானியங்கு"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "குறைந்த தரம்"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "நடுநிலைத் தரம்"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "உயர் தரம்"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "முன்னிருப்பு ஆர்ஜிபி"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "முன்னிருப்பு சிஎம்ஒய்கே"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "முன்னிருப்பு சாம்பல்"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "விற்பனையாளர் வழங்கிய தொழிற்சாலை அளவைவகுத்தல் தரவு"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "இந்த சுயவிவரத்தில் முழுத்திரை காட்சி திருத்தம் செய்ய முடியாது"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "இந்த சுயவிவரம் இப்போது துல்லியமாக இல்லாமால் இருக்கலாம்"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "காட்சி அளவைவகுத்தல்"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr "ரத்து செய்"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_C நீக்கு"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "தொடங்கு"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "மீண்டும் தொடர்"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "முடிந்தது"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "முடிந்தது (_D)"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "திரை அளவீடு"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "அளவைவகுத்தல் தரம்"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"அளவைவகுத்தல் செய்தால், ஒரு சுஉயவிவரம் உருவாக்கப்படும், அதைக் கொண்டு நீங்கள் "
-"உங்கள் திரையின் "
-"நிறங்களை மேலாண்மை செய்யலாம். அளவைவகுத்தலில் அதிக நேரம் செலவழித்தால் உங்கள் "
-"நிற சுயவிவரம் "
+"அளவைவகுத்தல் செய்தால், ஒரு சுஉயவிவரம் உருவாக்கப்படும், அதைக் கொண்டு நீங்கள் உங்கள் திரையின் "
+"நிறங்களை மேலாண்மை செய்யலாம். அளவைவகுத்தலில் அதிக நேரம் செலவழித்தால் உங்கள் நிற சுயவிவரம் "
 "தரமாக இருக்கும்."
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "அளவைவகுத்தல் நிகழும் போது கணினியைப் பயன்படுத்த முடியாது."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "தரம்"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "தோராயமான நேரம்"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "அளவைவகுத்தல் தரம்"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr ""
-"அளவைவகுத்தலுக்கு நீங்கள் பயன்படுத்த விரும்பும் சென்சார் சாதனத்தைத் "
-"தேர்ந்தெடுக்கவும்."
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "அளவைவகுத்தல் சாதனம்"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "இணைக்கப்பட்ட காட்சியின் வகையைத் தேர்ந்தெடுக்கவும்."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "அளவைவகுத்தலுக்கு நீங்கள் பயன்படுத்த விரும்பும் சென்சார் சாதனத்தைத் தேர்ந்தெடுக்கவும்."
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "காட்சி வகை"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "இணைக்கப்பட்ட காட்சியின் வகையைத் தேர்ந்தெடுக்கவும்."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "சுயவிவர வெண்புள்ளி"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -618,3148 +508,2370 @@ msgstr ""
 "ஒர் உதிரை இலக்கு வெண் புள்ளியைத் தேர்ந்தெடுக்கவும். பெரும்பாலான காட்சிகள் D65 "
 "இல்லுமினன்ட்டுக்கு அளவைவகுக்கப்பட வேண்டும்."
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "சுயவிவர வெண்புள்ளி"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "காட்சி ஒளிர்வு"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"காட்சியை உங்களுக்கு வழக்கமாக இருக்கும் ஒளிர்வில் அமைக்கவும். இந்த ஒளிர்வு "
-"அளவில் நிற "
+"காட்சியை உங்களுக்கு வழக்கமாக இருக்கும் ஒளிர்வில் அமைக்கவும். இந்த ஒளிர்வு அளவில் நிற "
 "மேலாண்மை மிகத் துல்லியமாக இருக்கும்."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
-"மாற்றாக இந்த சாதனத்திற்கு பயன்படுத்தப்படும் மற்ற சுயவிவரங்களில் ஒன்றில் "
-"பயன்படுத்தப்பட்டுள்ள "
+"மாற்றாக இந்த சாதனத்திற்கு பயன்படுத்தப்படும் மற்ற சுயவிவரங்களில் ஒன்றில் பயன்படுத்தப்பட்டுள்ள "
 "ஒளிர்வு அளவையும் நீங்கள் பயன்படுத்தலாம்."
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "காட்சி ஒளிர்வு"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "சுயவிவரப் பெயர்"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
-"நீங்கள் வெவ்வேறு கணினிகளில் ஒரு நிற சுயவிவரத்தைப் பயன்படுத்தலாம் அல்லது "
-"வெவ்வேறு ஒளி "
+"நீங்கள் வெவ்வேறு கணினிகளில் ஒரு நிற சுயவிவரத்தைப் பயன்படுத்தலாம் அல்லது வெவ்வேறு ஒளி "
 "நிலைகளுக்கு என சுயவிவரங்களை உருவாக்கிக்கொள்ளலாம்."
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "சுயவிவரப் பெயர்:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "சுயவிவரப் பெயர்"
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "சுருக்கம்"
 
-#: ../panels/color/color.ui.h:21
+#: panels/color/cc-color-panel.ui:259
 msgid "Profile successfully created!"
 msgstr "சுயவிவரம் வெற்றிகரமாக உருவாக்கப்பட்டது!"
 
-#: ../panels/color/color.ui.h:22
+#: panels/color/cc-color-panel.ui:290
 msgid "Copy profile"
 msgstr "சுயவிவரத்தை நகலெடு"
 
-#: ../panels/color/color.ui.h:23
+#: panels/color/cc-color-panel.ui:296
 msgid "Requires writable media"
 msgstr "எழுதத்தக்க ஊடகம் தேவை"
 
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "சுயவிவரத்தைப் பதிவேற்று"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "இணைய இணைப்பு தேவை"
-
-#: ../panels/color/color.ui.h:26
+#: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> மற்றும் <a "
 "href=\"windows\">Microsoft Windows</a> ஆகிய இயக்க முறைமைகளில் சுயவிவரத்தை "
 "எப்படிப் பயன்படுத்துவது என்பது பற்றிய இந்த வழிமுறைகள் உங்களுக்குப் பயன்படலாம்."
 
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:730
-msgid "Summary"
-msgstr "சுருக்கம்"
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "வரிவுரு சேர்"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "கோப்பை இறக்குமதி செய்…"
-
-#: ../panels/color/color.ui.h:30
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
-msgstr "சேர் (_A)"
-
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"சிக்கல்கள் உள்ளது. சுயவிவரம் சரியாக செயல்படாது போகலாம். <a href=\"\">"
-"விவரங்களைக் "
+"சிக்கல்கள் உள்ளது. சுயவிவரம் சரியாக செயல்படாது போகலாம். <a href=\"\">விவரங்களைக் "
 "காண்பி.</a>"
 
-#: ../panels/color/color.ui.h:32
-msgid "Each device needs an up to date color profile to be color managed."
-msgstr ""
-"வண்ண மேலாண்மைக்கு ஒவ்வொரு சாதனமும் வண்ண வரிவுருவை இற்றைப்படுத்த வேண்டியுள்ளது."
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "கோப்பை இறக்குமதி செய்…"
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "சேர் (_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "வண்ண மேலாண்மைக்கு ஒவ்வொரு சாதனமும் வண்ண வரிவுருவை இற்றைப்படுத்த வேண்டியுள்ளது."
+
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "மேலும் கற்க"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "நிற மேலாண்மை குறித்து மேலும் கற்க"
 
-#: ../panels/color/color.ui.h:35
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "எல்லாப்பயனருக்கும் அமை"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "இந்த வரியுருவை இந்த கணினியில் எல்லா பயனர்களுக்கும் அமை"
 
-#: ../panels/color/color.ui.h:37
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "செயல்படுத்து"
 
-#: ../panels/color/color.ui.h:38
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "வரிவுரு சேர்"
 
-#: ../panels/color/color.ui.h:39
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "அளவிடு..."
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "சாதனத்தை அளவிடு "
 
-#: ../panels/color/color.ui.h:41
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "வரிவுருவை நீக்கு"
 
-#: ../panels/color/color.ui.h:42
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "விவரங்களை காண்"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "நிற மேலாண்மை செய்யக்கூடிய சாதனங்கள் எதனையும் கண்டறிய முடியவில்லை"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "ஒளிப்படக்காட்டி"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "பிளாஸ்மா"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL பேக்லைட்)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED பேக்லைட்)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (வெள்ளை LED பேக்லைட்)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "அகல கேமட் LCD (CCFL பேக்லைட்)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "அகல கேமட் LCD (RGB LED பேக்லைட்)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "அதிகம்"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 நிமிடங்கள்"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "நடுத்தரம்"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 நிமிடங்கள்"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "குறைவு"
 
-#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 நிமிடங்கள்"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "காட்சிக்கு உரியது"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (அச்சு மற்றும் வெளியீடு)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (புகைப்படம் மற்றும் வரைபொருள்)"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "நிறம்"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
-"உங்கள் காட்சிகள், கேமராக்கள் அல்லது அச்சுப்பொறிகள் போன்ற சாதனங்களின் நிறத்தை "
-"அளவைவகுக்கவும்"
+"உங்கள் காட்சிகள், கேமராக்கள் அல்லது அச்சுப்பொறிகள் போன்ற சாதனங்களின் நிறத்தை அளவைவகுக்கவும்"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "நிறம்;ஐசிசி;வரிவுரு;அளவீடுசெய்;அச்சுப்பொறி;தோற்றம்;"
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:684
-msgid "United States"
-msgstr "யுனைடட் ஸ்டேட்ஸ் "
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "மொழியை தேர்ந்தெடு"
 
-#: ../panels/common/cc-common-language.c:685
-msgid "Germany"
-msgstr "ஜெர்மனி "
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "(_S) தேர்ந்தெடு"
 
-#: ../panels/common/cc-common-language.c:686
-msgid "France"
-msgstr "ப்ரான்ஸ்"
-
-#: ../panels/common/cc-common-language.c:687
-msgid "Spain"
-msgstr "ஸ்பெய்ன் "
-
-#: ../panels/common/cc-common-language.c:688
-msgid "China"
-msgstr "சைனா"
-
-#: ../panels/common/cc-common-language.c:758
-msgid "Other…"
-msgstr "மற்றவை…"
-
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr "மேலும்…"
-
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "மொழிகள் இல்லை"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "மொழி"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "மேலும்…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "முடிந்தது (_D)"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "பூட்டை திற"
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-#| msgctxt "login date-time"
-#| msgid "%s, %s"
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "அளவு ஐ அதிகமாக்குக:"
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "நேரம்"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "அளவை குறைவாக்குக:"
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "ஜனவரி"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "பெப்ரவரி"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "மார்ச்"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "ஏப்ரல்"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "மே"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "ஜூன்"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "ஜூலை"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "ஆகஸ்ட்"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "செப்டம்பர்"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "அக்டோபர்"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "நவம்பர்"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "திசம்பர்"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "தேதி மற்றும் நேரம்"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "மணி"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "நிமிடம்"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "நாள்"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "மாதம்"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "வருடம்"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "மாதம்"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "ஜனவரி"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "பெப்ரவரி"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "மார்ச்"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "ஏப்ரல்"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "மே"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "ஜூன்"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "ஜூலை"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "ஆகஸ்ட்"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "செப்டம்பர்"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "அக்டோபர்"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "நவம்பர்"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "திசம்பர்"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "நாள்"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "நேர மண்டலம்"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "நகரத்தைத் தேடு"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "தானியக்க தேதி மற்றும் நேரம் (_D)"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "இணைய அணுகல் தேவை"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "தேதி மற்றும் நேரம்"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "தானியங்கு நேர மண்டலம் (_Z)"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "Date & _Time"
-msgstr "தேதி மற்றும் நேரம்"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "இணைய அணுகல் தேவை"
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
-msgstr "நேர மண்டலம் (_Z)"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "செயலாக்கப்பட்டது"
 
-#: ../panels/datetime/datetime.ui.h:28
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "நேர மண்டலம்"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "பூட்டை திற"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "நேர வடிவமைப்பு (_F)"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24-மணி"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "தேதிகள்"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "இரண்டாம் நிலை"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "நாள்காட்டி (_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "எண்கள்"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "நேர மண்டலம் உட்பட தேதி மற்றூம் நேரத்தை மாற்றவும்"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "கடிகாரம்;நேரமண்டலம்;இடம்;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "கணினி நேரம் மற்றும் தேதி அமைவை மாற்றி அமைக்க"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
-msgstr ""
-"கணினி நேரம் மற்றும் தேதி அமைப்புகளை மாற்ற நீங்கள் உறுதிப்படுத்த வேண்டும்."
+msgstr "கணினி நேரம் மற்றும் தேதி அமைப்புகளை மாற்ற நீங்கள் உறுதிப்படுத்த வேண்டும்."
 
-#: ../panels/display/cc-display-panel.c:487
-msgid "Lid Closed"
-msgstr "மூடி மூடப்பட்டது"
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-msgid "Mirrored"
-msgstr "பிரதிபலிப்பு"
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2145
-msgid "Primary"
-msgstr "முதன்மை"
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "ஆஃப்"
-
-#: ../panels/display/cc-display-panel.c:497
-msgid "Secondary"
-msgstr "இரண்டாம் நிலை"
-
-#: ../panels/display/cc-display-panel.c:1533
-msgid "Arrange Combined Displays"
-msgstr "சேர்க்கை திரைகாட்டிகளை அடுக்கு"
-
-#: ../panels/display/cc-display-panel.c:1539
-#: ../panels/display/cc-display-panel.c:1979
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr "செயல்படுத்து (_A)"
-
-#: ../panels/display/cc-display-panel.c:1560
-msgid "Drag displays to rearrange them"
-msgstr "திரைகாட்டிகளின் வரிசையை மாற்ற அவற்றை இழுக்கவும்"
-
-#: ../panels/display/cc-display-panel.c:2081
-msgid "Size"
-msgstr "அளவு"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2094
-msgid "Aspect Ratio"
-msgstr "தோன்று விகிதம்"
-
-#: ../panels/display/cc-display-panel.c:2115
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "தெளிதிறன் "
-
-#: ../panels/display/cc-display-panel.c:2146
-msgid "Show the top bar and Activities Overview on this display"
-msgstr ""
-"இந்த திரைகாட்டியில் மேல் பட்டியையும் செயல்பாடுகள் மேலோட்டத்தையும் காண்பி"
-
-#: ../panels/display/cc-display-panel.c:2152
-msgid "Secondary Display"
-msgstr "இரண்டாம் நிலை திரைகாட்டி"
-
-#: ../panels/display/cc-display-panel.c:2153
-msgid "Join this display with another to create an extra workspace"
-msgstr ""
-"இந்தத் திரைகாட்டியை மற்றொன்றுடன் இணைத்து கூடுதல் பணியிடத்தை உருவாக்கலாம்"
-
-#: ../panels/display/cc-display-panel.c:2160
-msgid "Presentation"
-msgstr "விளக்கக்காட்சி"
-
-#: ../panels/display/cc-display-panel.c:2161
-msgid "Show slideshows and media only"
-msgstr "ஸ்லைடுகாட்சிகளையும் ஊடகங்களையும் மட்டும் காண்பி"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2166
-msgid "Mirror"
-msgstr "பிரதிபலிப்பு"
-
-#: ../panels/display/cc-display-panel.c:2167
-msgid "Show your existing view on both displays"
-msgstr "இரண்டு திரைகாட்டிகளிலும் தற்போதுள்ள உங்கள் காட்சிவகையைக் காண்பிக்கவும்"
-
-#: ../panels/display/cc-display-panel.c:2173
-msgid "Turn Off"
-msgstr "அணை"
-
-#: ../panels/display/cc-display-panel.c:2174
-msgid "Don't use this display"
-msgstr "இந்தத் திரைகாட்டியைப் பயன்படுத்த வேண்டாம்"
-
-#: ../panels/display/cc-display-panel.c:2383
-msgid "Could not get screen information"
-msgstr "திரை தகவலை பெற முடியவில்லை"
-
-#: ../panels/display/cc-display-panel.c:2414
-msgid "_Arrange Combined Displays"
-msgstr "சேர்க்கை திரைகாட்டிகளை அடுக்கு (_A)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "காட்டிகள்"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr ""
-"இணைக்கப்பட்ட திரைகளையும் ஒளிப்படக்காட்டிகளையும் எப்படிப் பயன்படுத்த வேண்டும் "
-"எனத் தேர்வு "
-"செய்யவும்"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "பலகம்;ஒளிப்படக்காட்டி;எக்ஸ்ரான்டர்;திரை;தெளிதிறன்;புதுப்பி;திரை"
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr "வேலேன்ட்"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "தெரியாத"
-
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-பிட்"
-
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr "%d-பிட்"
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr "என்ன செய்ய என்று கேள் "
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr "ஒன்றும் செய்யாதே"
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr "அடைவினை திற"
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr " மற்ற ஊடகம்"
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr "ஒலி குறுந்தட்டுகளுக்கு  நிரலைத் தெரிவுசெய்யவும்"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr "விடியோ டிவிடி களுக்கு நிரலைத் தெரிவுசெய்யவும்"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr "இசைப்பியை இணைத்தபோது துவக்க நிரலை தேர்ந்தெடுக்கவும்."
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr "காமிராவை இணைத்தபோது துவக்க நிரலை தேர்ந்தெடுக்கவும்."
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr "மென்பொருள் குறுந்தட்டுகளுக்கு நிரலைத் தெரிவுசெய்யவும்"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr "ஒலி டிவிடி"
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr "வெற்று ப்ளூ-ரே வட்டு"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr "வெற்று குறுந்தட்டு வட்டு"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr "வெற்று டிவிடி வட்டு"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr "வெற்று ஹெச்டி டிவிடி வட்டு"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr "ப்ளூ-ரே விடியோ வட்டு"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr "மின் புத்தக படிப்பி"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr "ஹெச்டி டிவிடி விடியோ வட்டு"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr "படங்கள் குறுந்தட்டு"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr "சூப்பர் விடியோ குறுந்தட்டு"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr "வீடியோ குறுவட்டு"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr "சாளர மென்பொருள்"
-
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1932
-msgid "Section"
-msgstr "பிரிவு"
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "மேலோட்டம்"
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr "முன்னிருப்பு பயன்பாடுகள்"
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "நீக்கப்படக்கூடிய சாதனங்கள் "
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr "பதிப்பு %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:46
-msgid "Details"
-msgstr "விவரங்கள்"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr "உங்கள் கணினி குறித்த தகவலைப் பார்க்க"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"சாதனம்;கணினி;தகவல்;நினைவகம்;செயலி;பதிப்பு;முன்னிருப்பு;நிரல்;பயன்பாடு; "
-"முன்னுரிமை;"
-"சிடி;டிவிடி;யூஎஸ்பி;ஒலி;விடியோ;வட்டு;வெளியேற்றக்கூடிய;ஊடகம்;தானியங்கிஇயக்கம்;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "மற்ற ஊடகத்தை எப்படி கையாள வேண்டுமென தேர்வு செய்க"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "செயல் (_A)"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "வகை_T :"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "சாதனம்  பெயர்"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "நினைவகம்"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "செயலகம்"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "அடிப்படைக் கணினி"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "வட்டு"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "கணக்கிடுகிறது…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "வரைகலைகள்"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "மெய்நிகராக்கம்"
-
-#: ../panels/info/info.ui.h:13
-#| msgid "Checking for Updates"
-msgid "Check for updates"
-msgstr "புதுப்பிப்புகள் உள்ளதா எனப் பார்"
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "_W இணையம்"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "(_M)மின்னஞ்சல்"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "நாள்காட்டி (_C)"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "_u இசை"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "_V வீடியோ"
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "_படங்கள்"
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "ஊடகத்தை எப்படி கையாள வேண்டுமென தேர்வு செய்க"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "முன்னிருப்பு பயன்பாடுகள்"
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "_a குறுந்தட்டு ஒலி"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "முன்னிருப்பு பயன்பாடுகள்"
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "_D டிவிடி விடியோ"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "_M இசை இயக்கி"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+#, fuzzy
+msgid "Problem Reporting"
+msgstr "சரிவிகிதமான"
 
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "_S மென்பொருள் "
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "மற்ற ஊடகம்… (_O)"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr "_N ஊடகம் உள்ளிட்டபோது தூண்டாதே அல்லது நிரல்களை துவக்காதே "
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "செயல்படுத்து (_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "பின்"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "ப்ளூடூத் செயல்நீக்கப்பட்டது"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "திரைகளை கண்டுபிடி"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "பிரதிபலிப்பு"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "இரண்டாம் நிலை திரைகாட்டி"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "வலது வளையம்"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "திசை"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "தெளிதிறன் "
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "புதுப்பிக்கும்  விகிதம் (_f):"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "அளவாக்கம்"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "முடிக்கப்பட்ட அளவு"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "அச்சுப்பொறி எதுவும் இல்லை "
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "இப்போது மறுதுவக்கு"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "நேரங்கள்"
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "URI இலிருந்து"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "மணி"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "நிமிடம்"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "காட்டிகள்"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+"இணைக்கப்பட்ட திரைகளையும் ஒளிப்படக்காட்டிகளையும் எப்படிப் பயன்படுத்த வேண்டும் எனத் தேர்வு "
+"செய்யவும்"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "பலகம்;ஒளிப்படக்காட்டி;எக்ஸ்ரான்டர்;திரை;தெளிதிறன்;புதுப்பி;திரை"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "பாதுகாப்பு விசை"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "மசி மட்டம்:"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "மசி மட்டம்:"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "மசி மட்டம்:"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "பாதுகாப்பு"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"திரை;பூட்டு;கண்டறிதல்கள்;செயலிழப்பு;தனிப்பட்ட;சமீபத்திய;தற்காலிக;tmp;அட்டவணை;பெயர்;"
+"பிணையம்;அடையாளம்;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "சாதனம்  பெயர்"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "வன்பொருள் முகவரி"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "நினைவகம்"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "செயலகம்"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "வரைகலைகள்"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "கணக்கிடுகிறது…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "பெயர்"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "வகை"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "க்னோம் முனையம்"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "விருப்பங்களை ஏற்றுகிறது..."
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "சாளர மென்பொருள்"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "மெய்நிகராக்கம்"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "மென்பொருள் பயன்பாடு"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "சாதனத்தை நீக்கு"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "சாதனம்  பெயர்"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "மறுபெயரிடு..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "%s பற்றி"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "உங்கள் கணினி குறித்த தகவலைப் பார்க்க"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"சாதனம்;கணினி;தகவல்;நினைவகம்;செயலி;பதிப்பு;முன்னிருப்பு;நிரல்;பயன்பாடு; முன்னுரிமை;"
+"சிடி;டிவிடி;யூஎஸ்பி;ஒலி;விடியோ;வட்டு;வெளியேற்றக்கூடிய;ஊடகம்;தானியங்கிஇயக்கம்;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "ஒலி மற்றும் ஊடகம்"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "ஒலியை நிறுத்து"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "ஒலி அளவை குறை"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "ஒலி அளவை உயர்த்து"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "ஒலி வாங்கி அளவு"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "ஊடக இயக்கியை துவக்கு."
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "துவக்கு (துவக்க/ தாமதிக்க)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "திருப்பி இசைத்தலை தாமதி."
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "திருப்பி இசைத்தலை நிறுத்து."
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "முந்தய தடம் ."
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "அடுத்த தடம் ."
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "வெளியேற்று"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "உள்ளிடல் "
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "அடுத்த உள்ளீட்டு மூலத்துக்கு மாற்றவும்"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "முந்தைய உள்ளீட்டு மூலத்துக்கு மாற்றவும்"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "துவக்கிகள் "
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "உதவி மேலோடியை துவக்கு"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "அமைவுகள்"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "கணக்கிடும் கருவியை துவக்கு"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "மின்னஞ்சல் சார்ந்தோனை துவக்கு"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "வலை மேலோடியை துவக்கு"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "இல்ல அடைவுக்குப் போகவும்."
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "தேடு"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "திரை வெட்டுக்கள்"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "ஒரு திரைவெட்டை $PICTURES க்கு சேமிக்கவும்"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "ஒரு சாரளத்தின்  திரைவெட்டினை $PICTURES க்கு சேமிக்கவும்"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "ஒரு பகுதியின் திரைவெட்டை $PICTURES க்கு சேமிக்கவும்"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "திரைவெட்டை ஒட்டுப்பலகைக்கு நகல் எடுக்கவும்."
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "ஒரு சாரளத்தின் திரைவெட்டை ஒட்டுப்பலகைக்கு நகல் எடுக்கவும்."
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "ஒரு இடத்தின் திரைவெட்டை ஒட்டுப்பலகைக்கு நகல் எடுக்கவும்."
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "ஒரு சிறிய திரைக்காட்சியைப் பதிவு செய்"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "கணினி"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "வெளியேறுக"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "திரையை பூட்டு"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "உலகளாவிய அணுகல்"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "(_M) சொடுக்கி அணுகல்"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "அணுகி பார்த்தல் செயலில் அல்லது செயல்நீங்கி"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "அணுகிப்பார்"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "விலகிப்பார்"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "திரை படிப்பி செயலில் அல்லது செயல்நீங்கி"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "திரை விசைப்பலகை செயலில் அல்லது செயல்நீங்கி"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "உரை அளவு ஐ அதிகமாக்குக"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "உரை அளவை குறைவாக்குக"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "உயர் மாறுபாடு செயலில் அல்லது செயல் நீங்கி"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1218
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-msgid "Disabled"
-msgstr "முடக்கப்பட்டது"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "ஒரு உள்ளீட்டு மூலத்தைச் சேர்"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "மாற்று எழுத்துருக்கள் விசை"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "புகுபதிவு திரையில் உள்ளீட்டு முறைகளைப் பயன்படுத்த முடியாது"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "உருவாக்க விசை"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "உள்ளீட்டு மூலம் தேர்ந்தெடுக்கப்படவில்லை"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "மாற்றிகள்-அடுத்த மூலத்திற்கு மட்டும் மாற்றவும்"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "தேர்வுகள்"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "விசைப்பலகை"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "மேலே நகர்த்து"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr ""
-"விசைப்பலகை குறூக்கு வழிகளைக் கண்டு மாற்றவும், அத்துடன் உங்கள் தட்டச்சு "
-"முன்னுரிமைகளை "
-"அமைக்கவும்"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "கீழே நகர்த்து"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "சுருக்குவழி;மீண்டும்நிகழ்த்து;கண்ணிமை;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "முன்னுரிமைகள்"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "தனிப்பயன் குறுக்குவழி"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "விசைப்பலகை இடவமைவை காட்டுக"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "(_N) பெயர்:"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "நீக்கு (_R)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "(_o) கட்டளை:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "மறுசெயல் விசைகள்"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "அமுக்கப்படும்போது விசை மறுபடியும் அச்சிடப்படும்."
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "(_D) தாமதம்:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "(_S) வேகம்:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "குறுகிய"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "மெதுவாக"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "தொடரும் விசைகளின் வேகம்"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "நீண்ட"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "வேகமான"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "நிலைக்காட்டி சிமிட்டும்"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "(_b) நிலைக்காட்டி உரை  உள்ளே சிமிட்டும்"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "(_p) வேகம்:"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "நிலைகாட்டி சிமிட்டும் வேகம்"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr " உள்ளீட்டு மூலங்கள்"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "குறுக்கு வழியை சேர்"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "குறுக்கு வழியை நீக்கு"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"குறுவழியை திருத்த பொருத்தமான வரியில் சொடுக்கு.  மற்றும் புதிய விசைகளை உள்ளிடு "
-"அல்லது  துப்புரவாக்க பின்னோக்கு  விசையை அழுத்துக ."
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "உள்ளீட்டு மூல விருப்பங்கள்"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "எல்லா  சாளரத்திற்கும் ஒரே மூலத்தைப் பயன்படுத்து (_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "ஒவ்வொரு சாளரத்திற்கும் வெவ்வேறு மூலங்களைப் பயன்படுத்து (_d)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "மாற்று எழுத்துருக்கள் விசை"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "உருவாக்க விசை"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "விசைப்பலகை குறுக்கு வழிகள்"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "தனிப்பயன் குறுக்குவழிகள் "
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "பிரிவு"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "குறுக்கு வழிகள்"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:635
-#: ../panels/keyboard/keyboard-shortcuts.c:643
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "குறுக்கு வழியை சேர்"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "தனிப்பயன் குறுக்குவழிகள் "
 
-#: ../panels/keyboard/keyboard-shortcuts.c:860
-msgid "<Unknown Action>"
-msgstr "<தெரியாத செயல்>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1357
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"புதிய குறுக்குவழி \"%s\" யை பயன்படுத்த முடியாது. ஏனெனில் இந்த விசையை "
-"வைத்துக்கொண்டு "
-"தட்டச்ச முடியாது.\n"
-"அதே நேரத்தில் கன்ட்ரோல், ஆல்ட் அல்லது ஷிப்ட் விசைகளை பயன்படுத்தி "
-"முயற்சிக்கவும்."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1387
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr "குறுவழி \"%s\"ஏற்கெனவே \"%s\"க்கு பயன்பட்டது "
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "குறுக்கு வழியை சேர்"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1392
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "விசைப்பலகை குறுக்கு வழிகள்"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "நீக்கு (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "மாற்று (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-" \"%s\" க்கு குறுவழியாக மாற்றி அமைத்தால்  \"%s\" குறுவழி  முடங்கிவிடும்."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1398
-msgid "_Reassign"
-msgstr "(_R) மறுஇருத்து "
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1439
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"\"%s\" குறுக்குவழியுடன் \"%s\" எனும் குறுக்குவழி இணைந்துள்ளது. "
-"அதை தானாகவே \"%s\" க்கு அமைக்க வேண்டுமா?"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1449
-#, c-format
-#| msgid ""
-#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
-#| "disabled."
-msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
-msgstr ""
-"தற்போது \"%s\" ஆனது \"%s\" உடன் இணைந்துள்ளது, நீங்கள் தொடர்ந்தால் இந்தக் "
-"குறுக்குவழி முடக்கப்படும்."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "பெயர்"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1456
-#| msgid "_Reassign"
-msgid "_Assign"
-msgstr "அமை (_A)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "(_o) கட்டளை:"
 
-#: ../panels/mouse/cc-mouse-panel.c:94
-msgid "Test Your _Settings"
-msgstr "உங்களுடைய அமைவுகளை சோதிக்கவும் (_S)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "குறுக்கு வழி"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-msgid "Test Your Settings"
-msgstr "உங்கள் அமைவுகளை சோதிக்கவும்"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "புதிய குறுவழி…"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse & Touchpad"
-msgstr "சொடுக்கி மற்றும் தொடுதிட்டு"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid ""
-"Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr ""
-"உங்கள் சொடுக்கி அல்லது தொடுதிட்டின் உணர்திறனை மாற்றவும், வலதுகைப் பழக்கமா "
-"இடதுகைப் "
-"பழக்கமா எனத் தேர்ந்தெடுக்கவும்"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "பொது"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "மெதுவாக"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "இரட்டை சொடுக்கு நேரம் முடிந்தது"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "வேகமாக"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "(_D) இரட்டிப்பு சொடுக்கு:"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "_b முதன்மை நிறம்"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "இடது (_L)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "வலது (_R)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "சொடுக்கி"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "_P இட சுட்டி வேகம்"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "மெதுவாக"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "வேகமாக"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "தொடுதிட்டு"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "மெதுவாக"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "வேகமாக"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
-msgstr "(_t) தட்டச்சும்போது செயல்நீக்கு"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
-msgstr "_c சொடுக்க தட்டவும்"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
-msgstr "(_f) இரு விரல்கள் உருளல்"
-
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "_Natural scrolling"
-msgstr "இயல்பான உருளல் (_N)"
-
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "சொடுக்கல். இரட்டை சொடுக்கல், உருளல் ஆகியவற்றை முயற்சிக்கவும்"
-
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "ஐந்து கிளிக்குகள், GEGL நேரம்!"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "இரட்டை சொடுக்கு, முதன்மை பொத்தான்"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "ஒற்றை சொடுக்கு, முதன்மை பொத்தான்"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "இரட்டை சொடுக்கு, நடு பொத்தான்"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "ஒற்றை சொடுக்கு, நடு பொத்தான்"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "இரட்டை சொடுக்கு, இரண்டாம் பொத்தான்"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "ஒற்றை சொடுக்கு, இரண்டாம் பொத்தான்"
-
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:366
-msgid "Air_plane Mode"
-msgstr "_p விமானப்பாங்கு"
-
-#: ../panels/network/cc-network-panel.c:974
-msgid "Network proxy"
-msgstr "வலையமைப்பு பிரதிநிதி."
-
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1153 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1298
-msgid "The system network services are not compatible with this version."
-msgstr "இந்த பதிப்புடன் கணினி வலைப்பின்னல் சேவைகள் இசையவில்லை"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
-msgid "802.1x _Security"
-msgstr "802.1x பாதுகாப்பு (_S)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "பக்கம் 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "அநாமதேய அடையாளம் (_m)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "அக அங்கீகரிப்பு (_a)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "பக்கம் 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "பாதுகாப்பு"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "தானியங்கு"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:218
-#: ../panels/network/net-device-wifi.c:382
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:222
-#: ../panels/network/net-device-wifi.c:387
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:226
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:231
-msgid "Enterprise"
-msgstr "என்டர்ப்ரைஸ்"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:236
-#: ../panels/network/net-device-wifi.c:372
-msgctxt "Wifi security"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "ஏதுமில்லை"
 
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "ஒரு போதும் இல்லை"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
 
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:819
-msgid "Today"
-msgstr "இன்று"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "(_R) முன்னிருப்புக்கு மீட்டமை"
 
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:822
-msgid "Yesterday"
-msgstr "நேற்று"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "விசைப்பலகை"
 
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:476
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"விசைப்பலகை குறூக்கு வழிகளைக் கண்டு மாற்றவும், அத்துடன் உங்கள் தட்டச்சு முன்னுரிமைகளை "
+"அமைக்கவும்"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "இருப்பிடச் சேவைகள் (_L)"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "நடப்பில் எந்த பயன்பாடும் ஒலியை இயக்கவோ பதியவோ இல்லை"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "ஒலி வாங்கி அளவு"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "பயன்பாடு எதுவும் இல்லை"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "உங்களுடைய அமைவுகளை சோதிக்கவும் (_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "பொது"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "_b முதன்மை நிறம்"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "இடது"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "வலது"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "இடங்களைத் தேடு"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "சொடுக்கி"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "சொடுக்கி அமைப்புகள்"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "கீழ் உருளல்"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+#, fuzzy
+msgid "Traditional"
+msgstr "சரிவிகிதமான"
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "பெரிதாக்கி நிலைக்காட்டி உள்ளடக்கங்களுடன் நகர்கிறது"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "(_A) ஆர்முடுகல்:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "செயலில் உள்ளது"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "தொடுதிட்டு"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "தொடுதிட்டு"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "முறை (_M):"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "_c சொடுக்க தட்டவும்"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "_c சொடுக்க தட்டவும்"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "(_t) தட்டச்சும்போது செயல்நீக்கு"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "தொடுதிட்டு (ரிலேடிவ்)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "உருளல்"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "இடது உருளல்"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "இரு பக்கம்"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "சொடுக்கல். இரட்டை சொடுக்கல், உருளல் ஆகியவற்றை முயற்சிக்கவும்"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "சொடுக்கி மற்றும் தொடுதிட்டு"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"உங்கள் சொடுக்கி அல்லது தொடுதிட்டின் உணர்திறனை மாற்றவும், வலதுகைப் பழக்கமா இடதுகைப் "
+"பழக்கமா எனத் தேர்ந்தெடுக்கவும்"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "நிறவெளி:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "குப்பைதொட்டியை தானாக காலி செய் (_T)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "மானிட்டர்"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "முதன்மை காட்சியை மாற்ற இழுக்கவும்"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "பயன்பாடுகள்"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "சாதனங்கள்"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "புதிய இணைப்பு சேர்"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "இணைக்கப்பட்டது"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "விருப்பங்கள்…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi ஹாட்ஸ்பாட்"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "பிணைய பெயர்"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "கடவுச்சொல்"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "ஒரு கடவுச்சொல்லை உருவாக்கு"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "ஒரு கடவுச்சொல்லை உருவாக்கு"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_T இயக்கு"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "_p விமானப்பாங்கு"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "படங்கள் இல்லை"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "_p விமானப்பாங்கு"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi ஹாட்ஸ்பாட்"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "ஹாட்ஸ்பாட்டாகப் பயன்படுத்தவும்… (_U)"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "பிணையங்கள்"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x பாதுகாப்பு (_S)"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i நாளைக்கு முன்"
 msgstr[1] "%i நாட்கள் முன்"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:533
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "None"
-msgstr "ஏதுமில்லை"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "வலுவற்றது"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "சரி"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:568
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "நன்று"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:570
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "மிக நன்று"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "அடையாளம்"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "முகவரி"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "நெட்மாஸ்க்"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "நுழைவாயில்"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "முகவரியை அழிக்கவும்"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "சேர்க்க"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "சேவையகம்"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "DNS சேவையகத்தை அழி"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "மெட்ரிக்"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "பாதையை அழிக்கவும்"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP)"
-msgstr "தானியங்கு (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Manual"
-msgstr "கைமுறை"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "இணைப்பு-உள்ளமை மட்டும்"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "முன்னொட்டு"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "தானியங்கு"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "தானியங்கு, DHCP மட்டும்"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:51
-msgid "Reset"
-msgstr "மீட்டமை"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "எதுவுமில்லை"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-பிட் விசை (ஹெக்ஸ் அல்லது ஆஸ்கி)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-பிட் கடவுச்சொல்"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "மாறும் WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 தனிப்பட்ட"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 கடவுச்சொல்"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "சமிக்ஞை வலிமை"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "இணைப்பு வேகம்"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "பாதுகாப்பு"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 முகவரி"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 முகவரி"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "வன்பொருள் முகவரி"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "ஆதரவுள்ள ஐசிசி வரிவுருக்கள்"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "முன்னிருப்பு வழி:"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "கடைசியாக பயன்படுத்தப்பட்டது"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "திருப்பிய ஜோடி (டிபி)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "இணைப்பு பொருள் இடைமுகம் (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "பிஎன்சி (BNC)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "ஊடக சார்பில்லா இடைமுகம் (எம்ஐஐ)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "_N பெயர் "
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
-msgid "_MAC Address"
-msgstr "MAC முகவரி (_M)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "M_TU"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "க்ளோன் செய்யப்பட்ட  முகவரி (_C)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "பைட்டுகள்"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "மற்ற பயனர்களுக்கும் கிடைக்கும்படி அமை (_u)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "நேரத்தை தானியங்கியாக அமை (_a)"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "ஃபயர்வால் மண்டலம் (_Z)"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "முன்னிருப்பு"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "மண்டலம் இணைப்பின் நம்பகத்தின் அளவை வரையறுக்கிறது"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
-msgstr "முகவரிகள் (_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "தானியங்கி DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Routes"
-msgstr "பாதைகள்"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "தானியங்கி பாதைகள்"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:34
-msgid "Use this connection _only for resources on its network"
-msgstr ""
-"இந்த இணைப்பை இந்த பிணையத்தில் உள்ளவர்களுக்கு மட்டும் பயன்படுத்தவும் (_o)"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "இணைப்புத் திருத்தியைத் திறக்க முடியவில்லை"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "புதிய சுயவிவரம்"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "பிணைப்பு"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "அணி"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "பிரிட்ஜ்"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "VPN செருகுநிரல்களை ஏற்ற முடியவில்லை"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "கோப்பிலிருந்து இறக்கவும்…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "பிணைய இணைப்பைச் சேர்"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "மீட்டமை (_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1441
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "மற (_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"இந்தப் பிணையத்திற்கான கடவுச்சொற்கள் உள்ளிட்ட அமைப்புகளை மீட்டமைக்கவும், ஆனால் "
-"இதை விரும்பும் "
-"பிணையமாக நினைவில் கொள்ளவும்"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"இந்தப் பிணையம் தொடர்பான அனைத்து விவரங்களையும் அகற்றவும், மேலும்  தானாக இணைக்க "
-"முயற்சிக்க "
-"வேண்டாம்"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
-msgid "S_ecurity"
-msgstr "பாதுகாப்பு (_e)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "VPN இணைப்பை இறக்க முடியவில்லை"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"கோப்பு '%s'ஐ வாசிக்க முடியவில்லை அல்லது அங்கீகரிக்கப்பட்ட VPN இணைப்புத் தகவலை "
-"பெற்றிருக்கவில்லை \n"
-"\n"
-"பிழை: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "இறக்க கோப்பை தேர்ந்தெடுக்கவும்"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1948
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:223
-msgid "_Open"
-msgstr "திற (_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "\"%s\" என பெயரிடப்பட்ட கோப்பு ஏற்கனவே உள்ளது."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "மாற்று (_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "VPN இணைப்புடன் %s ஐ இடமாற்ற நீங்கள் விரும்புகிறீர்களா?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "VPN இணைப்பை ஏற்ற முடியவல்லை"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN இணைப்பு '%s' ஆனது %sஐ ஏற்றுமதி செய்ய முடியாது.\n"
-"\n"
-"பிழை: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-#| msgid "Export VPN connection..."
-msgid "Export VPN connection"
-msgstr "VPN இணைப்பை ஏற்றுமதிசெய்"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(பிழை: VPN இணைப்புத் திருத்தியை ஏற்ற முடியவில்லை)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "_SSID"
-msgstr "_SSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
-msgid "_BSSID"
-msgstr "_BSSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "என் இல்ல பிணையம்"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "மற்ற பயனர்களுக்கு கிடைக்கும்படி அமை (_o)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "பிணையம்"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Control how you connect to the Internet"
-msgstr "நீங்கள் எப்படி இணையத்துடன் இணைகிறீர்கள் என்பதைக் கட்டுப்படுத்துங்கள்"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
-#| "vpn;vlan;bridge;bond;"
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "பிணைப்பு அடிமைகள்"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_N பெயர் "
 
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(எதுவுமில்லை)"
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC முகவரி (_M)"
 
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "பிரிட்ஜ் அடிமைகள்"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
 
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:462
-msgid "never"
-msgstr "ஒரு போதும் இல்லை"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "க்ளோன் செய்யப்பட்ட  முகவரி (_C)"
 
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:472
-msgid "today"
-msgstr "இன்று"
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "பைட்டுகள்"
 
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:474
-msgid "yesterday"
-msgstr "நேற்று"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "முறை (_M):"
 
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP முகவரி"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "தானியங்கு (DHCP)"
 
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "கடைசியில் பயன்படுத்தப்பட்டது"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "இணைப்பு-உள்ளமை மட்டும்"
 
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "ஒயர்டு"
-
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1596
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "விருப்பங்கள்…"
-
-#: ../panels/network/net-device-ethernet.c:474
-#, c-format
-msgid "Profile %d"
-msgstr "சுயவிவரம் %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "புதிய இணைப்பு சேர்"
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr "அணி அடிமைகள்"
-
-#: ../panels/network/net-device-wifi.c:1154
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-"உங்களிடம் வயர்லெஸ் அல்லாத ஒரு இணைய இணைப்பு இருந்தால், இணைப்பை மற்றவர்களிடம் "
-"பகிர்ந்துகொள்ள "
-"நீங்கள் ஒரு வயர்லெஸ் ஹாட்ஸ்பாட்டை அமைத்துப் பயன்படுத்தலாம்."
-
-#: ../panels/network/net-device-wifi.c:1158
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-"கம்பியில்லா வட்டத்துக்கு மாறுவது <b>%s</b> யிலிருந்ஹ்டு உங்களை துண்டிக்கும்."
-
-#: ../panels/network/net-device-wifi.c:1162
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"கம்பியில்லா வட்டம் செயலில் இருப்பின் உங்களது கம்பியில்லா இணைப்பு மூலம் "
-"நீங்கள் பிணையத்தை "
-"அணுக இயலாது."
-
-#: ../panels/network/net-device-wifi.c:1245
-msgid "Stop hotspot and disconnect any users?"
-msgstr "செயலிடத்தை நிறுத்தி பயனர்களை இணைப்பு நீக்கவா?"
-
-#: ../panels/network/net-device-wifi.c:1248
-msgid "_Stop Hotspot"
-msgstr "_S செயலிடத்தை நிறுத்து"
-
-#: ../panels/network/net-device-wifi.c:1305
-msgid "System policy prohibits use as a Hotspot"
-msgstr "ஹாட்ஸ்பாட்டாக பயன்படுத்துவதை கணினி கொள்கை தடைசெய்கிறது"
-
-#: ../panels/network/net-device-wifi.c:1308
-msgid "Wireless device does not support Hotspot mode"
-msgstr "வயர்லெஸ் சாதனம் ஹாட்ஸ்பாட் பயன்முறையை ஆதரிக்கவில்லை"
-
-#: ../panels/network/net-device-wifi.c:1437
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"தேர்ந்தெடுக்கப்பட்ட பிணையங்களின் கடவுச்சொற்கள் மற்றும் தனிப்பயன் "
-"அமைவாக்கங்கள் உட்பட அனைத்து "
-"விவரங்களும் இழக்கப்படும்."
-
-#: ../panels/network/net-device-wifi.c:1745
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "வரலாறு"
-
-#: ../panels/network/net-device-wifi.c:1749
-#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
-#: ../panels/wacom/cc-wacom-page.c:533
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Close"
-msgstr "மூடு (_C)"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1757
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "மற (_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"வலை பதிலாள் தானியங்கி காணல் வடிவமைப்பு, யூஆர்எல் இல்லாத போது பயன்படும்."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "நம்பகமில்லாத பொது வலைப்பின்னல்களுக்கு இதை பரிந்துரைக்கவில்லை"
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "பதிலாள்"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "சுயவிவரம் சேர் (_A)…"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "வழங்குபவர்"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "எதுவுமில்லை"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "கைமுறை"
 
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "தானியங்கி"
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "முடக்கப்பட்டது"
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
-msgstr "முறை (_M):"
-
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "(_C) வடிவமைப்பு URL:"
-
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "(_T) HTTP பிரதிநிதி ."
-
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "(_T) HTTP பிரதிநிதி ."
-
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "(_F) FTP பிரதிநிதி ."
-
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "_S சாக்ஸ்  புரவன்"
-
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "ஹோஸ்ட்டுகளைப் புறக்கணி (_I)"
-
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "HTTP ப்ராக்ஸி முனையம்"
-
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "HTTPS ப்ராக்ஸி முனையம்"
-
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "FTP ப்ராக்ஸி முனையம்"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "Socks ப்ராக்ஸி முனையம்"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "சாதனத்தை ஆஃப் செய்"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "சாதனத்தை சேர் "
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "சாதனத்தை நீக்கு"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "விபிஎன் வகை"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "குழு பெயர்"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "குழு கடவுச்சொல்"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "பயனர்பெயர்"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr "VPN இணைப்பை ஆஃப் செய்"
-
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "தானியங்கு இணைப்பு (_C)"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "விவரங்கள்"
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "கடவுச்சொல் (_P)"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "ஏதுமில்லை"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "கடவுச்சொல்லை காட்டு (_a)"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr "மற்ற பயனர்களுக்குக் கிடைக்கும்படி செய்"
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "அடையாளம்"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr "தானியக்கி (DHCP) முகவரிகள் மட்டுமே "
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr "இணைப்பு-உள்ளமை மட்டும்"
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
 msgstr "மற்ற கணினிகளுடன் பகிரப்பட்டது"
 
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr "தானாக பெற்ற பாதைகளைப் புறக்கணி (_I)"
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "முகவரிகள் (_A)"
 
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "ipv4"
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "முகவரி"
 
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "ipv6"
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "நெட்மாஸ்க்"
 
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr "க்ளோன் செய்யப்பட்ட MAC முகவரி (_C)"
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "நுழைவாயில்"
 
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr "வன்பொருள்"
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "தானியங்கு"
 
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "தானியங்கி DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
 msgstr ""
-"இந்த இணைப்புக்கான அமைவுகளை அவற்றின் முன்னிருப்பு அமைப்புக்கு மீட்டமை, ஆனால் "
-"இதை விரும்பும் "
-"இணைப்பாக நினைவில் கொள்."
 
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
 msgstr ""
-"இந்தப் பிணையம் தொடர்பான அனைத்து விவரங்களையும் அகற்றவும், மேலும்  தானாக இதற்கு "
-"இணைக்க "
-"முயற்சிக்க வேண்டாம்."
 
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "மீட்டமை"
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "பாதைகள்"
 
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "வன்பொருள்"
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "தானியங்கி பாதைகள்"
 
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi ஹாட்ஸ்பாட்"
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "மெட்ரிக்"
 
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Turn On"
-msgstr "_T இயக்கு"
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "இந்த இணைப்பை இந்த பிணையத்தில் உள்ளவர்களுக்கு மட்டும் பயன்படுத்தவும் (_o)"
 
-#: ../panels/network/network-wifi.ui.h:54
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "முறை (_M):"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "தானியங்கு, DHCP மட்டும்"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "முன்னொட்டு"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "பாதுகாப்பு (_e)"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(பிழை: VPN இணைப்புத் திருத்தியை ஏற்ற முடியவில்லை)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "பிணையம்"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "நீங்கள் எப்படி இணையத்துடன் இணைகிறீர்கள் என்பதைக் கட்டுப்படுத்துங்கள்"
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Turn Wi-Fi off"
-msgstr "Wi-Fi ஆஃப் செய்"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "நீங்கள் எப்படி இணையத்துடன் இணைகிறீர்கள் என்பதைக் கட்டுப்படுத்துங்கள்"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_Use as Hotspot…"
-msgstr "ஹாட்ஸ்பாட்டாகப் பயன்படுத்தவும்… (_U)"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "_Connect to Hidden Network…"
-msgstr "மறைக்கப்பட்ட பிணையத்துக்கு இணைக்கவும்...(_C)"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "ஒயர்டு"
 
-#: ../panels/network/network-wifi.ui.h:58
-msgid "_History"
-msgstr "வரலாறு (_H)"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "சாதனத்தை ஆஃப் செய்"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "வயர்லெஸ் பிணையத்துடன் இணைப்பதற்கு ஸ்விட்ச் ஆஃப் செய்யவும்"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "செயலில் உள்ளது"
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "வழங்குபவர்"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP முகவரி"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "வலையமைப்பு பிரதிநிதி."
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "(_T) HTTP பிரதிநிதி ."
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "(_T) HTTP பிரதிநிதி ."
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "(_F) FTP பிரதிநிதி ."
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_S சாக்ஸ்  புரவன்"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "ஹோஸ்ட்டுகளைப் புறக்கணி (_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP ப்ராக்ஸி முனையம்"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS ப்ராக்ஸி முனையம்"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP ப்ராக்ஸி முனையம்"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks ப்ராக்ஸி முனையம்"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "(_C) வடிவமைப்பு URL:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN இணைப்பை ஆஃப் செய்"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "பிணைய பெயர்"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Connected Devices"
-msgstr "இணைக்கப்பட்ட சாதனங்கள்"
-
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "பாதுகாப்பு வகை"
 
-#: ../panels/network/network-wifi.ui.h:63
-msgid "Security key"
-msgstr "பாதுகாப்பு விசை"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "கடவுச்சொல்"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "தற்காலிக"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi ஆஃப் செய்"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "கட்டுமானம்"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "விருப்பங்களை ஏற்றுகிறது..."
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "தெரியாத நிலை"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "மறைக்கப்பட்ட பிணையத்துக்கு இணைக்கவும்...(_C)"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "மேலாண்மை இல்லாத"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi ஹாட்ஸ்பாட்"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "இருப்பில் இல்லை"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "இணைக்கிறது..."
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "அனுமதி தேவை"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "இணைக்கப்பட்டது"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "துண்டிக்கப்படுகிறது..."
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "இணைப்பு தோல்வியுற்றது"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "நிலை தெரியவில்லை (காணவில்லை)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "இணைக்கப்படவில்லை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "வடிவமைப்பு தோல்வியுற்றது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "ஐபி வடிவமைப்பு தொல்வியுற்றது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "ஐபி வடிவமைப்பு காலாவதியாயிற்று"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "ரகசியங்கள் தேவையாயிருந்தன, ஆனால் தரப்படவில்லை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x சப்ளிகன்ட் துண்டிக்கபட்டது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x சப்ளிகன்ட் வடிவமைப்பு தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1x சப்ளிகன்ட் தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x சப்ளிகன்ட் உறுதிசெய்ய வெகு நேரம் எடுத்துக்கொண்டது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "பிபிபி சேவை துவக்கம் தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "பிபிபி சேவை துண்டிக்கபட்டது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "பிபிபி தோல்வியுற்றது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "டிஹெச்சிபி சார்ந்தோன் துவக்கம் தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "(டிஹெச்சிபி) DHCP சார்ந்தோன் பிழை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "(டிஹெச்சிபி) DHCP சார்ந்தோன் தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "பகிர்ந்த இணைப்பு சேவை துவக்க தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "பகிர்ந்த இணைப்பு சேவை தோல்வியுற்றது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "ஆட்டோஐபி சேவை துவக்கம் தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "ஆட்டோஐபி சேவை துவக்கம் பிழை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "ஆட்டோஐபி சேவை தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "தடம் பயன்பாட்டில்"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "டயல் ஒலி இல்லை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "கடத்தி ஏதும் செயலாக்க முடியவில்லை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "டயல் செய்யும் நேரம் கடந்தது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "டயல் செய்யும் முயற்சி தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "மோடம் துவக்கம் தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "குறிப்பிட்ட ஏபிஎன் ஐ தேர்ந்தெடுத்தல் தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "வலையமைப்புகளை தேடவில்லை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "வலையமைப்பு பதிவுசெய்தல் மறுக்கப்பட்டது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "வலையமைப்பு பதிவுசெய்தல் நேரம் கடந்தது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "வேண்டிய வலையமைப்பு பதிவுசெய்தல் தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "பின்(PIN) சோதனை தோல்வி"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "சாதனத்தின் வர்த்தக மென்பொருள் காணவில்லை போலும்"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "இணைப்பு காணாமல் போயிற்று"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "இருப்பிலுள்ள இணைப்பு இருப்பதாக கொள்ளப்பட்டது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "மோடம் காணப்படவில்லை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "ப்ளூடூத் இணைப்பு தோல்வியுற்றது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "சிம் கார்ட் சொருகப்படவில்லை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "சிம் பின் தேவை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "சிம் பியூகே தேவை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "சிம் தவறானது"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "இன்பினிபேன்ட் சாதனம் இணைப்பு பாங்கை ஆதரிக்கவில்லை"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "இணைப்பு  சார்பு தோல்வியுற்றது"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "தள நிரல் காணவில்லை"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "இணைப்பு துண்டிக்கப்பட்டது"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "அங்கீகார சான்றிதழ் தேர்ந்தெடுக்கப்படவில்லை"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-"ஓரு சான்றிதழ் அங்கீகார (CA) சான்றிதழைப் பயன்படுத்தாவிட்டால், Wi-Fi பிணையங்கள் "
-"பாதுகாப்பற்றதாகவும் நம்பகமற்றதாகவும் விளங்கலாம்.  ஓரு சான்றிதழ் அங்கீகார (CA) "
-"சான்றிதழைத் "
-"தேர்வு செய்ய வேண்டுமா?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "புறக்கணி"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "CA சான்றிதழை தேர்ந்தெடுக்கவும்"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, or PKCS#12 தனிப்பட்ட விசைகள் (*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER அல்லது PEM சான்றிதழ்கள் (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-#| msgid "Choose a PAC file..."
-msgid "Choose a PAC file"
-msgstr "ஒரு PAC கோப்பினைத் தேர்ந்தெடுக்கவும்"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC கோப்புகள் (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC கோப்பு (_f)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "அக அங்கீகாரம் (_I)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "PAC ப்ரோ விஷனிங் (_v)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "அநாமதேயர்"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "அங்கீகரிக்கப்பட்டது"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "இரண்டும்"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "அநாமதேய அடையாளம் (_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC கோப்பு (_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "ஒரு PAC கோப்பினைத் தேர்ந்தெடுக்கவும்"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "அக அங்கீகாரம் (_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC ப்ரோ விஷனிங் (_v)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "(_U) பயனர் பெயர்:"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "கடவுச்சொல் (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "கடவுச்சொல்லைக் காட்டு (_w)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-#| msgid "Choose a Certificate Authority certificate..."
-msgid "Choose a Certificate Authority certificate"
-msgstr "அங்கீகார அதிகாரச் சான்றிதழைத் தேர்ந்தெடுக்கவும்"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "பதிப்பு 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "பதிப்பு 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "CA சான்றிதழ் (_A)"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "அங்கீகார அதிகாரச் சான்றிதழைத் தேர்ந்தெடுக்கவும்"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "அனுமதி தேவை"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP பதிப்பு (_v)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "ஒவ்வொரு முறையும் இந்த கடவுச்சொல்லைக் கேட்கவும் (_k)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "மறைகுறியாக்கப்படாத தனிபட்ட விசைகள் பாதுகாப்பில்லாதது"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"தேர்ந்தெடுக்கப்பட்ட தனிப்பட்ட விசையானது கடவுச்சொல்லால் பாதுகாக்கப்படாதது எனத் "
-"தோன்றுகிறது.  இதனால் பாதுகாப்பு சான்றளிப்பு உத்தரவாதமானதாக இல்லாமல் "
-"போகக்கூடும்.  "
-"கடவுச்சொல்லால் பாதுகாக்கப்பட்ட ஒரு தனிப்பட்ட விசையைத் தேர்ந்தெடுக்கவும்.\n"
-"\n"
-"(openssl ஐக் கொண்டு நீங்கள் உங்கள் தனிப்பட்ட விசையை கடவுச்சொல்லால் "
-"பாதுகாக்கப்பட்டதாக "
-"மாற்றலாம்)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-#| msgid "Choose your personal certificate..."
-msgid "Choose your personal certificate"
-msgstr "உங்கள் தனிப்பட்ட சான்றிதழைத் தேர்ந்தெடுக்கவும்"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-#| msgid "Choose your private key..."
-msgid "Choose your private key"
-msgstr "உங்கள் தனிப்பட்ட விசையைத் தேர்ந்தெடுக்கவும்"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "அடையாளம் (_d)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "பயனர் சான்றிதழ் (_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "தனிப்பட்ட விசை ( _k)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "தனிப்பட்ட விசை கடவுச்சொல் (_P)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "மீண்டும் எச்சரிக்காதே (_w)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "(_D) களம்"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "இல்லை"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "ஆம்"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "டன்னல்டு TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "பாதுகாக்கப்பட்ட EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "அங்கீகாரம் (_t)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (முன்னிருப்பு)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "திறந்த முறைமை"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "பகிரப்பட்ட விசை"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "விசை (_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "விசையைக் காட்டு (_w)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP அட்டவணை (_x)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "வகை (_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (முன்னிருப்பு)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "திறந்த முறைமை"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "பகிரப்பட்ட விசை"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "விசை (_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "விசையைக் காட்டு (_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP அட்டவணை (_x)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "அறிவிப்புகள்"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "ஓலி விழிப்பூட்டல்கள்"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "மேலெழு பதாகைகளைக் காண்பி"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "பதாகைகளில் விவரங்களைக் காட்டு"
-
-#: ../panels/notifications/cc-edit-dialog.c:43
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "திரைப்பூட்டில் காண்பி"
-
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "திரைப்பூட்டில் விவரங்களைக் காண்பி"
-
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "ஆன்"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "அறிவிப்புகள்"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "அறிவிப்புகள்"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "திரைப்பூட்டில் விவரங்களைக் காண்பி"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "அறிவிப்புகள்"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr ""
-"எந்தெந்த அறிவிப்புகள் காண்பிக்கப்பட வேண்டும் என்பதையும் அவை எவற்றைக் "
-"காண்பிக்க வேண்டும் "
+"எந்தெந்த அறிவிப்புகள் காண்பிக்கப்பட வேண்டும் என்பதையும் அவை எவற்றைக் காண்பிக்க வேண்டும் "
 "என்பதையும் கட்டுப்படுத்தவும்"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "அறிவிப்புகள்;பதாகை;செய்தி;பலகம்;மேலெழு;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "மேலெழு பதாகைகளைக் காண்பி"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "திரைப்பூட்டில் காண்பி"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "அக அங்கீகரிப்பு (_a)"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-msgctxt "Online Account"
-msgid "Other"
-msgstr "மற்றவை"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
-msgstr "கணக்கு சேர்"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
-msgstr "மின்னஞ்சல்"
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "கணக்கை சேர்"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr "தொடர்புகள்"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "அரட்டை"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "வளங்கள்"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "கணக்குக்குள் நுழைவதில் பிழை"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "சான்றளிப்புகள் காலாவதியாகிவிட்டன."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr "இந்தக் கணக்கை செயல்படுத்த உள்நுழையவும்."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr "உள்நுழை (_S)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "கணக்கை உருவாக்குவதில் பிழை"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "கணக்கை நீக்குவதில் பிழை"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "கணக்கை அவசியம்  நீக்க உறுதியாக உள்ளீரா?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "இது சேவையகத்தில் கணக்கை நீக்காது."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "நீக்கு (_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "ஆன் லைன்  கணக்குகள்"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
-"உங்கள் ஆன்லைன் கணக்குகளில் இணைந்து அவற்றை எதற்கு பயன்படுத்த வேண்டும் என "
-"முடிவு செய்யவும்"
+"உங்கள் ஆன்லைன் கணக்குகளில் இணைந்து அவற்றை எதற்கு பயன்படுத்த வேண்டும் என முடிவு செய்யவும்"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -3767,2370 +2879,1974 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "ஆன் லைன் கணக்கு ஏதும் வடிவமைக்கப்படவில்லை"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "கணக்கு நீக்கு"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "ஒரு ஆன் லைன் கணக்கு சேர்"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"ஒரு கணக்கை சேர்ப்பது உங்கள் பயன்பாடுகளை அதன் ஆவணங்கள், மின்னஞ்சல், "
-"தொடர்புகள், நாட்காட்டி, "
-"அரட்டை மேலும் பலவற்றை அணுக அனுமதிக்கும்."
-
-#: ../panels/power/cc-power-panel.c:183
-msgid "Unknown time"
-msgstr "தெரியாத நேரம்"
-
-#: ../panels/power/cc-power-panel.c:189
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i நிமிடம்"
 msgstr[1] "%i நிமிடங்கள்"
 
-#: ../panels/power/cc-power-panel.c:201
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i மணிநேரம்"
 msgstr[1] "%i மணிநேரங்கள்"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:209
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "மணி"
 msgstr[1] "மணிகள்"
 
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "நிமிடம்"
 msgstr[1] "நிமிடங்கள்"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:230
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s முழுவதும் சார்ஜ் செய்யப்படும் வரை"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 நிமிடங்கள்"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:237
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "எச்சரிக்கை: %s மீதமுள்ளது"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 நிமிடங்கள்"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:242
-#, c-format
-msgid "%s remaining"
-msgstr "%s மீதமுள்ளது"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 நிமிடங்கள்"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
-msgid "Fully charged"
-msgstr "முழுதும் சார்ஜ் செய்யப்பட்டது"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 நிமிடங்கள்"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
-msgid "Empty"
-msgstr "வெற்று"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Charging"
-msgstr "மின் சக்தி ஏற்றம் ஆகிறது"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:271
-msgid "Discharging"
-msgstr "சக்தி இறங்குகிறது"
-
-#: ../panels/power/cc-power-panel.c:396
-msgctxt "Battery name"
-msgid "Main"
-msgstr "முதன்மை"
-
-#: ../panels/power/cc-power-panel.c:398
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "கூடுதல்"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:470
-msgid "Wireless mouse"
-msgstr "கம்பியில்லா சொடுக்கி"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:473
-msgid "Wireless keyboard"
-msgstr "கம்பியில்லா விசைப்பலகை"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:476
-msgid "Uninterruptible power supply"
-msgstr "தடையில்லா மின்சாரம்"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Personal digital assistant"
-msgstr "அந்தரங்க இரும உதவியாளர்"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Cellphone"
-msgstr "அலைபேசி"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Media player"
-msgstr "இசை இயக்கி"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Tablet"
-msgstr "தொடுபலகை"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Computer"
-msgstr "கணினி"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
-#: ../panels/power/cc-power-panel.c:2019
-msgid "Battery"
-msgstr "மின்கலம்"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "மின் சக்தி ஏற்றம் ஆகிறது"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "எச்சரிக்கை"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Low"
-msgstr "குறைவான"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Good"
-msgstr "நன்று"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "முழுதும் சார்ஜ் செய்யப்பட்டது"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "வெற்று"
-
-#: ../panels/power/cc-power-panel.c:715
-msgid "Batteries"
-msgstr "பேட்டரிகள்"
-
-#: ../panels/power/cc-power-panel.c:1117
-msgid "When _idle"
-msgstr "செயலின்றி இருக்கும் போது (_i)"
-
-#: ../panels/power/cc-power-panel.c:1445
-msgid "Power Saving"
-msgstr "மின்சக்தி சேமிப்பு"
-
-#: ../panels/power/cc-power-panel.c:1473
-msgid "_Screen brightness"
-msgstr "திரை பிரகாசம் (_S)"
-
-#: ../panels/power/cc-power-panel.c:1479
-msgid "_Keyboard brightness"
-msgstr "விசைப்பலகை பிரகாசம் (_K)"
-
-#: ../panels/power/cc-power-panel.c:1489
-msgid "_Dim screen when inactive"
-msgstr "செயலின்றி இருக்கையில் திரையை மங்கலாக்கு (_D)"
-
-#: ../panels/power/cc-power-panel.c:1514
-msgid "_Blank screen"
-msgstr "வெற்றுத் திரை (_B)"
-
-#: ../panels/power/cc-power-panel.c:1551
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: ../panels/power/cc-power-panel.c:1556
-msgid "Turns off wireless devices"
-msgstr "வயர்லெஸ் சாதனங்களை இயக்க நிறுத்தும்"
-
-#: ../panels/power/cc-power-panel.c:1581
-msgid "_Mobile broadband"
-msgstr "மொபைல் பிராட்பேண்டு (_M)"
-
-#: ../panels/power/cc-power-panel.c:1586
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "மொபைல் பிராட்பேன்ட் (3G, 4G, WiMax போன்ற) சாதனங்களை இயக்க நிறுத்தும்"
-
-#: ../panels/power/cc-power-panel.c:1635
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: ../panels/power/cc-power-panel.c:1686
-msgid "When on battery power"
-msgstr "பேட்டரி சக்தியில் இருக்கையில்"
-
-#: ../panels/power/cc-power-panel.c:1688
-msgid "When plugged in"
-msgstr "சொருகியுள்ள போது"
-
-#: ../panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Off"
-msgstr "இடைநிறுத்து & அணை"
-
-#: ../panels/power/cc-power-panel.c:1851
-msgid "_Automatic suspend"
-msgstr "தானியங்கு இடைநிறுத்தம் (_A)"
-
-#: ../panels/power/cc-power-panel.c:1875
-msgid "When battery power is _critical"
-msgstr "பேட்டரி மின்சாரம் மிகக் குறைவாகிப் போகையில் (_C)"
-
-#: ../panels/power/cc-power-panel.c:1930
-msgid "Power Off"
-msgstr "மின்சக்தி நிறுத்து"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Devices"
-msgstr "சாதனங்கள்"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "சக்தி"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr "பேட்டரி நிலையைக் கண்டு மின்சக்தி சேமிப்பு அமைவுகளை மாற்றவும்"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-"சக்தி;உறங்கு;இடைநிறுத்தம்;பேட்டரி;பிரகாசம்;மங்கல்;வெற்று;மானிட்டர்;DPMS;செயலின"
-"்றி;"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "இடை உறக்கம்"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "மின்சக்தி நிறுத்தம்"
-
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 நிமிடங்கள்"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 மணி"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 நிமிடங்கள்"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 நிமிடங்கள்"
 
-#: ../panels/power/power.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 நிமிடங்கள்"
 
-#: ../panels/power/power.ui.h:10
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 மணிகள்"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 நிமிடம்"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "மின்கலம்"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 நிமிடங்கள்"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "சாதனங்கள்"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 நிமிடங்கள்"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "மின்சக்தி நிறுத்தம்"
 
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "4 நிமிடங்கள்"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 நிமிடங்கள்"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "மின்சக்தி சேமிப்பு"
 
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "8 நிமிடங்கள்"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "திரை பிரகாசம் (_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 நிமிடங்கள்"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "திரை பிரகாசம் மற்றும் பூட்டு அமைப்பு"
 
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "12 நிமிடங்கள்"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "திரை"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "திரைபடிப்பான் (_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "தானியங்கி பாதைகள்"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "தானியங்கு இடைநிறுத்தம்"
+
+#: panels/power/cc-power-panel.ui:175
+#, fuzzy
+msgid "Pauses the computer after a period of inactivity."
+msgstr "இவ்வளவு நேரம் செயலற்று இருந்தால் கனினியை பணிநிறுத்தம் செய்க:"
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "கீழ் பொத்தான்"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "தானியங்கு இடைநிறுத்தம்"
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "செருகியுள்ள போது (_P)"
 
-#: ../panels/power/power.ui.h:22
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "பேட்டரி சக்தியில் இருக்கையில் (_B)"
 
-#: ../panels/power/power.ui.h:23
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "தாமதி"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "அங்கீகாரம்"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "சக்தி"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "கடவுச்சொல்"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "பேட்டரி நிலையைக் கண்டு மின்சக்தி சேமிப்பு அமைவுகளை மாற்றவும்"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "அனுமதி உறுதிபடுத்தல் வேண்டும்"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr "அச்சுப்பொடி குறைவாக உள்ளது"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr "அச்சு மைப்பொடி போதாது"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr "உருவாக்கி குறைவாக உள்ளது"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr "உருவாக்கி இல்லை"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr "குறியிடுவான் கொடை குறைவாக உள்ளது"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr "குறியிடுவான் கொடை இல்லை"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr "மூடியை திற"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr "கதவை திற"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr "காகிதம் குறைவாக உள்லது"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr "தாள் வெளியே உள்ளது"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr "இணைப்பு விலகி"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "நிறுத்தப்பட்டது"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr "குப்பைக்கூடை அனேகமாக நிறைந்தது"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr "குப்பைக்கூடை நிறைந்தது"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr "ஒளி கடத்தியின் வாழ்நாள் முடிவு நெருங்கிவிட்டது"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ஒளி கடத்தி இப்போது வேலை செய்யவில்லை"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "வடிவமைக்கிறது."
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr "தயார்"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "பணிகளை ஏற்க வேண்டாம்"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr "செயலாக்கம்..."
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Toner Level"
-msgstr "அச்சு மைப்பொடி மட்டம்"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Ink Level"
-msgstr "மசி மட்டம்:"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:928
-msgid "Supply Level"
-msgstr "கொடை மட்டம்"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:946
-msgctxt "printer state"
-msgid "Installing"
-msgstr "நிறுவப்படுகிறது"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1123
-msgid "No printers available"
-msgstr "அச்சுப்பொறி எதுவும் இல்லை "
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1433
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "செயலில் %u"
-msgstr[1] "செயலில் %u"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1777
-msgid "Failed to add new printer."
-msgstr "அச்சுப்பொறியை சேர்க்க முடியவில்லை"
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid "Select PPD File"
-msgstr "பிபிடி கோப்பை  தேர்ந்தெடு."
-
-#: ../panels/printers/cc-printers-panel.c:1953
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"போஸ்ட்ஸ்கிரிப்ட் அசுப்பொறி விவர கோப்புகள் (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
-"*.PPD."
-"GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "சக்தி;உறங்கு;இடைநிறுத்தம்;பேட்டரி;பிரகாசம்;மங்கல்;வெற்று;மானிட்டர்;DPMS;செயலின்றி;"
 
-#: ../panels/printers/cc-printers-panel.c:2258
-msgid "No suitable driver found"
-msgstr "தகுந்த இயக்கி எதுவும் காணப்படவில்லை "
-
-#: ../panels/printers/cc-printers-panel.c:2327
-msgid "Searching for preferred drivers…"
-msgstr "விரும்பப்படும் இயக்கிகளை தேடுகிறது…"
-
-#: ../panels/printers/cc-printers-panel.c:2342
-msgid "Select from database…"
-msgstr "தரவுத்தளத்திலிருந்து தேர்ந்தெடு…"
-
-#: ../panels/printers/cc-printers-panel.c:2351
-msgid "Provide PPD File…"
-msgstr "PPD கோப்பை வழங்கவும்…"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2502
-#: ../panels/printers/cc-printers-panel.c:2525
-msgid "Test page"
-msgstr "சோதனை பக்கம்"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2933
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "ui ஏற்ற முடியவில்லை: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "அச்சுப்பொறிகள்"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
-"அச்சுப்பொறிகளைச் சேர்க்கவும், அச்சுப்பொறி பணிகளைக் காணவும் மற்றும் அவை எப்படி "
-"அச்சிட "
+"அச்சுப்பொறிகளைச் சேர்க்கவும், அச்சுப்பொறி பணிகளைக் காணவும் மற்றும் அவை எப்படி அச்சிட "
 "வேண்டும் என முடிவு செய்யவும்"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "அச்சுப்பொறி;வரிசை;அச்சடி;காகிதம்;மசி;டோனர்;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "செயலில் உள்ள வேலைகள்"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "மூடு"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "அச்சிடுவதை தொடர்க"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "அச்சடித்தலை தாமதி"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "அச்சு வேலையை ரத்து செய் "
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "புதிய அச்சுப்பொறியை சேர்"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "A_uthenticate"
-msgstr "அங்கீகரி (_u)"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "அச்சுப்பொறிகள் எதுவும் கண்டுபிடிக்கப்படவில்லை ."
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-msgid "Enter address of a printer or a text to filter results"
-msgstr ""
-"முடிவுகளை வடிகட்ட ஒரு அச்சுப்பொறியின் முகவரி அல்லது உரை ஒன்றை உள்ளிடவும்"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "விருப்பங்களை ஏற்றுகிறது..."
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "அச்சுப்பொறி இயக்கியை தேர்ந்தெடு"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "இயக்கிகள் தரவுத்தளத்தை ஏற்றுகிறது..."
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-#| msgid "Remove Printer"
-msgid "JetDirect Printer"
-msgstr "JetDirect அச்சுப்பொறி"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-#| msgid "%s Printer"
-msgid "LPD Printer"
-msgstr "LPD அச்சுப்பொறி"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "ஒரு பக்க"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "நீள விளிம்புடைய (செந்தரம்)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "குறுகிய விளிம்புடைய (புரட்டு)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "செங்குத்து "
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "கிடைமட்டம்"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "பின்திருப்பிய கிடைமட்டம்"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "பின்திருப்பிய செங்குத்து"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "நிலுவையில்"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "கிடப்பில்"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "செயலாக்கமாகிறது"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "நிறுத்தப்பட்டது"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "ரத்து செய்யப்பட்டது"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "கைவிடப்பட்டது"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "முடிவுற்றது"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "வேலையின் தலைப்பு"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "வேலை நிலை"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "நேரம்"
-
-#: ../panels/printers/pp-jobs-dialog.c:495
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s செயலில் உள்ள வேலைகள்"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Serial Port"
-msgstr "வரிசை துறை"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1683
-msgid "Parallel Port"
-msgstr "இணையான துறை"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-#| msgid "Location"
-msgid "Location: %s"
-msgstr "இடம்: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1744
-#, c-format
-#| msgid "A_ddress:"
-msgid "Address: %s"
-msgstr "முகவரி: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1768
-msgid "Server requires authentication"
-msgstr "சேவையகத்திற்கு அங்கீகாரம் தேவைப்படுகிறது"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "இரு பக்க"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "காகித வகை"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "காகித மூலம்"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "வெளியீட்டு தட்டு"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "கோஸ்ட்ஸ்கிரிப்ட் முன் வடிகட்டல்"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:531
-msgid "Pages per side"
-msgstr "தாள்பக்கத்துக்கு பக்கங்கள்"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:543
-msgid "Two-sided"
-msgstr "இரு பக்கம்"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:555
-msgid "Orientation"
-msgstr "திசை"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:652
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "பொது"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "பக்க அமைவு"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "நிறுவக்கூடிய தேர்வுகள்"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "வேலை"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "பிம்ப தரம்"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "நிறம்"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "முடிக்கிறது"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "மேம்பட்ட"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "தானியங்கியாக தேர்வு செய்க "
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "அச்சுப்பொறி முன்னிருப்பு"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "கோஸ்ட் ஸ்க்ரிப்ட் எழுத்துருக்களை மட்டும் உள்ளமை"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "பிஎஸ் மட்டம் 1 க்கு மாற்று"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "பிஎஸ் மட்டம் 2 க்கு மாற்று"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "முன் வடிகட்டல் இல்லை"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "உற்பத்தியாளர்"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "இயக்கி"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-"%s இல் கிடைக்கும் அச்சுப்பொறிகளைக் காண உங்கள் பயனர் பெயர் மற்றும் "
-"கடவுச்சொல்லை உள்ளிடவும்."
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "அச்சுப்பொறியைச் சேர்"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "அச்சுப்பொறியை நீக்கு"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "பூட்டை திற"
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "வழங்கு"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "படங்கள் இல்லை"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "அனுமதி உறுதிபடுத்தல் வேண்டும்"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"%s இல் கிடைக்கும் அச்சுப்பொறிகளைக் காண உங்கள் பயனர் பெயர் மற்றும் கடவுச்சொல்லை உள்ளிடவும்."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "பயனர்பெயர்"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "இடம்"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-#| msgid "Default Route"
-msgid "_Default printer"
-msgstr "முன்னிருப்பு அச்சுப்பொறி (_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "இயக்கி"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "வேலைகள்"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "விரும்பப்படும் இயக்கிகளை தேடுகிறது…"
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "பணிகளைக் காண்பி Show _Jobs"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "நகரத்தைத் தேடு"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "தரவுத்தளத்திலிருந்து தேர்ந்தெடு…"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "PPD கோப்பை வழங்கவும்…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "அச்சுப்பொறி இயக்கியை தேர்ந்தெடு"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "இயக்கிகள் தரவுத்தளத்தை ஏற்றுகிறது..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "ரத்து செய்"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "தேர்வு செய்க "
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "சேவையகத்திற்கு அங்கீகாரம் தேவைப்படுகிறது"
+msgstr[1] "சேவையகத்திற்கு அங்கீகாரம் தேவைப்படுகிறது"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "(_D) களம்"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "அங்கீகரி (_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "அங்கீகாரம்"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s செயலில் உள்ள வேலைகள்"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "சோதனை பக்கம்"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "புகு பதிகை தேர்வுகள்"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "அச்சுப்பொறி முன்னிருப்பு"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "அச்சுப்பொறி முன்னிருப்பு"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "அச்சு வேலையை ரத்து செய் "
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "அச்சுப்பொறியை நீக்கு"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "செயலில் உள்ள வேலைகள்"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "மாதிரி"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "விளக்கச்சீட்டு"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "மசி மட்டம்:"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "புதிய இயக்கியை அமைக்கிறது..."
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "குறுநிரல் ஒழுங்காக நிறுவப்பட்டுள்ளதா என்பதை சரிபார்க்கவும்"
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "பக்கம் 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "_T சோதனை பக்கத்தை அச்சிடு"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "விருப்பங்கள் (_O)"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "இப்போது மறுதுவக்கு"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "புதிய அச்சுப்பொறியை சேர்"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "அச்சுப்பொறியைச் சேர்"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "அச்சடிப்பி அமைப்புகள் ஐ மாற்றுக"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "அச்சுப்பொறிகள்"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "மன்னிக்க! கணினியின் அச்சிடும் சேவை\n"
 " கிடைப்பதாக தெரியவில்லை"
 
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "திரைப்பூட்டு"
-
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "பயன்பாடு & வரலாறு"
-
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
-msgstr "குப்பைத் தொட்டியிலிருந்து அனைத்தையும் நீக்கி காலி செய்யவா?"
-
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
-msgstr "குப்பைத் தொட்டியில் உள்ளவை அனைத்தும் நிரந்தரமாக நீக்கப்படும்."
-
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "குப்பை தொட்டியை காலி செய் (_E)"
-
-#: ../panels/privacy/cc-privacy-panel.c:512
-msgid "Delete all the temporary files?"
-msgstr "தற்காலிகக் கோப்புகள் அனைத்தையும் அழிக்கவா?"
-
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
-msgstr "தற்காலிகக் கோப்புகள் அனைத்தும் நிரந்தரமாக அழிக்கப்படும்."
-
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "தற்காலிக கோப்புகளை அழி (_P)"
-
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "தேவையற்றதையும் தற்காலிகக் கோப்புகளையும் அழி"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-#| msgid "Software"
-msgid "Software Usage"
-msgstr "மென்பொருள் பயன்பாடு"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "தனியுரிமை"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-"உங்கள் தனிப்பட்ட தகவல்களைப் பாதுகாப்பாக வைத்திருந்து, மற்றவர்கள் எவற்றை "
-"மட்டும் காணக்கூடும் "
-"என்பதை நீங்களே கட்டுப்படுத்துங்கள்"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"திரை;பூட்டு;கண்டறிதல்கள்;செயலிழப்பு;தனிப்பட்ட;சமீபத்திய;தற்காலிக;tmp;அட்டவணை;ப"
-"ெயர்;"
-"பிணையம்;அடையாளம்;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "திரை அணைகிறது"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 நொடிகள்"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 நாள்"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 நாட்கள்"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 நாட்கள்"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 நாட்கள்"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 நாட்கள்"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 நாட்கள்"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 நாட்கள்"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 நாட்கள்"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 நாட்கள்"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "எப்போதும் "
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"உங்கள் வரலாற்றை நினைவில் கொள்வதால், வேண்டியவற்றை எளிதில் மீண்டும் "
-"கண்டுபிடிக்க முடியும். "
-"இவை பிணையத்தின் வழியாக எப்போதும் பகிரப்படாது."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "சமீபத்தில் பயன்படுத்தியது (_R)"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "வரலாற்றை வைத்திரு (_H)"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "சமீபத்திய வரலாற்றை அழி (_e)"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr ""
-"நீங்கள் கணினியை விட்டு விலகி இருக்கும் போது திரைப்பூட்டு உங்கள் தனியுரிமையைப் "
-"பாதுகாக்கிறது."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "தானியங்கி திரைப்பூட்டு (_L)"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "இவ்வளவு நேரம் வெறுமையாக இருந்த பிறகு திரையைப் பூட்டவும் (_a)"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "அறிவிப்புகளைக் காண்பி (_N)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"தேவையில்லாத முக்கியத் தகவல்கள் அடைத்துக்கொண்டு இல்லாமல் உங்கள் கணினி சிறப்பாக "
-"இருக்க, "
-"குப்பை தொட்டியையும் தற்காலிகக் கோப்புகளையும் தானாக அழிக்கவும்."
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "குப்பைதொட்டியை தானாக காலி செய் (_T)"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "தற்காலிகக் கோப்புகளை தானாக அழி (_F)"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "இத்தனை நாட்களுக்குப் பிறகு அழி (_A)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"நீங்கள் எந்த மென்பொருளைப் பயன்படுத்துகிறீர்கள் என்ற தகவலை எங்களுக்கு "
-"அனுப்பினால், உங்களுக்கு "
-"இன்னும் துல்லியமான பரிந்துரைகளை வழங்க எங்களுக்கு அது உதவியாக இருக்கும். அது "
-"எங்கள் மென்பொருளை "
-"மேம்படுத்தவும் உதவும்.\n"
-"\n"
-"நாங்கள் சேகரிக்கும் தகவல் அனைத்துமே பெயரிலாததாக்கப்படும், உங்கள் தரவை ஒரு "
-"போதும் மூன்றாம் தரப்பினரிடம் பகிர மாட்டோம்."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "மென்பொருள் பயன்பாடு விவரங்களை அனுப்பு (_S)"
-
-#: ../panels/privacy/privacy.ui.h:41
-#| msgid "Privacy"
-msgid "Privacy Policy"
-msgstr "தனியுரிமைக் கொள்கை"
-
-#: ../panels/privacy/privacy.ui.h:42
-#| msgid "_Location name:"
-msgid "_Location Services"
-msgstr "இருப்பிடச் சேவைகள் (_L)"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "உங்கள் இருப்பிடத்தைத் தீர்மானிக்க பயன்படுகிறது"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "இம்பீரியல்"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "மெட்ரிக்"
-
-#: ../panels/region/cc-format-chooser.c:284
-msgid "No regions found"
-msgstr "பகுதி காணப்படவில்லை"
-
-#: ../panels/region/cc-input-chooser.c:179
-msgid "No input sources found"
-msgstr "உள்ளீட்டு மூலங்கள் இல்லை"
-
-#: ../panels/region/cc-input-chooser.c:1076
-msgctxt "Input Source"
-msgid "Other"
-msgstr "மற்றவை"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:892
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "மாற்றங்கள் விளைவை ஏற்படுத்த உங்கள் அமர்வை மறுதொடக்கம் செய்ய வேண்டும்"
-
-#: ../panels/region/cc-region-panel.c:240
-#: ../panels/user-accounts/um-user-panel.c:893
-msgid "Restart Now"
-msgstr "இப்போது மறுதுவக்கு"
-
-#: ../panels/region/cc-region-panel.c:858
-msgid "No input source selected"
-msgstr "உள்ளீட்டு மூலம் தேர்ந்தெடுக்கப்படவில்லை"
-
-#: ../panels/region/cc-region-panel.c:1088
-msgid "Sorry"
-msgstr "மன்னிக்கவும்"
-
-#: ../panels/region/cc-region-panel.c:1090
-msgid "Input methods can't be used on the login screen"
-msgstr "புகுபதிவு திரையில் உள்ளீட்டு முறைகளைப் பயன்படுத்த முடியாது"
-
-#: ../panels/region/cc-region-panel.c:1727
-msgid "Login Screen"
-msgstr "புகுபதிவு திரை"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ஒழுங்குகள்"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "இடங்களைத் தேடு"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "பொது வேலைகள்"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "ஒழுங்குகள்"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "முன்பார்வை"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "தேதிகள்"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "நேரங்கள்"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "தேதி மற்றும் நேரம்"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "எண்கள்"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "அளவு "
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "காகிதம்"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "மொழிகள் நிறுவு... "
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "என் கணக்கு"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "(_L) மொழி"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "ஒழுங்குகள்"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "புகுபதிவு திரை"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr " வட்டாரம் மற்றும் மொழி "
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr ""
-"உங்கள் காட்சி மொழி, வடிவமைப்புகள், விசைப்பலகை தளவமைப்புகள் மற்றும் உள்ளீட்டு "
-"மூலங்களைத் "
+"உங்கள் காட்சி மொழி, வடிவமைப்புகள், விசைப்பலகை தளவமைப்புகள் மற்றும் உள்ளீட்டு மூலங்களைத் "
 "தேர்ந்தெடுக்கவும்"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "மொழி;இடஅமைவு;விசைப்பலகை;உள்ளீடு;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "ஒரு உள்ளீட்டு மூலத்தைச் சேர்"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "ஊடகத்தை எப்படி கையாள வேண்டுமென தேர்வு செய்க"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "உள்ளீட்டு மூல விருப்பங்கள்"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_a குறுந்தட்டு ஒலி"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Use the _same source for all windows"
-msgstr "எல்லா  சாளரத்திற்கும் ஒரே மூலத்தைப் பயன்படுத்து (_s)"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_D டிவிடி விடியோ"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Allow _different sources for each window"
-msgstr "ஒவ்வொரு சாளரத்திற்கும் வெவ்வேறு மூலங்களைப் பயன்படுத்து (_d)"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_M இசை இயக்கி"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Keyboard Shortcuts"
-msgstr "விசைப்பலகை குறுக்கு வழிகள்"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_S மென்பொருள் "
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Switch to previous source"
-msgstr "முந்தைய மூலத்துக்கு மாற்றவும்"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "மற்ற ஊடகம்… (_O)"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_N ஊடகம் உள்ளிட்டபோது தூண்டாதே அல்லது நிரல்களை துவக்காதே "
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Switch to next source"
-msgstr "அடுத்த மூலத்துக்கு மாற்றவும்"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "மற்ற ஊடகத்தை எப்படி கையாள வேண்டுமென தேர்வு செய்க"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "Super+Space"
-msgstr "Super+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "செயல் (_A)"
 
-#: ../panels/region/input-options.ui.h:10
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "இந்த குறுக்குவழிகளை நீங்கள் விசைப்பலகை அமைப்புகளில் மாற்றலாம்"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "வகை_T :"
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Alternative switch to next source"
-msgstr "அடுத்த மூலத்திற்கு மாற்று விசை"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "நீக்கப்படக்கூடிய சாதனங்கள் "
 
-#: ../panels/region/input-options.ui.h:12
-msgid "Left+Right Alt"
-msgstr "இடது+வலது Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "ப்ளூடூத் அமைப்புகளை வடிவமை"
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "ஆங்கிலம் (இங்கிலாந்து)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "யுனைட்டக் கிங்டம்"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "தேர்வுகள்"
-
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
-msgstr ""
-"புகுபதிவு அமைப்புகள் கணினியில் புகுபதிவு செய்யும் போது அனைத்து பயனர்களாலும் "
-"பயன்படுத்தப்படும்"
-
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
-msgid "Places"
-msgstr "இடங்கள்"
-
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
-msgid "Bookmarks"
-msgstr "புத்தகக்குறிகள்"
-
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
-msgstr "மற்றவை"
-
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "ஒரு இடத்தை தேர்ந்தெடுக்கவும்"
-
-#: ../panels/search/cc-search-locations-dialog.c:682
-msgid "_OK"
-msgstr "சரி (_O)"
-
-#: ../panels/search/cc-search-panel.c:176
-msgid "No applications found"
-msgstr "பயன்பாடு எதுவும் இல்லை"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "தேடு"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Control which applications show search results in the Activities Overview"
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"செயல்பாடுகளின் மேலோட்டப் பார்வையில், எந்த பயன்பாடுகள் தேடல் முடிவுகளைக் "
-"காண்பிக்க வேண்டும் "
-"என்பதைக் கட்டுப்படுத்தவும்"
+"சாதனம்;கணினி;தகவல்;நினைவகம்;செயலி;பதிப்பு;முன்னிருப்பு;நிரல்;பயன்பாடு; முன்னுரிமை;"
+"சிடி;டிவிடி;யூஎஸ்பி;ஒலி;விடியோ;வட்டு;வெளியேற்றக்கூடிய;ஊடகம்;தானியங்கிஇயக்கம்;"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
-msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "தேடு;கண்டறி;அட்டவணை;மறை;தனியுரிமை;முடிவுகள்;"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "திரைப்பூட்டு"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "வெற்றுத் திரை (_B)"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "தானியங்கி திரைப்பூட்டு (_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "தானியங்கி திரைப்பூட்டு (_L)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "திரைப்பூட்டில் விவரங்களைக் காண்பி"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "திரையை பூட்டு"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "தனியுரிமை"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "திரை"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "ஒலி அமைப்புகள்"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "இடங்களைத் தேடு"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "மேலே நகர்த்து"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "கீழே நகர்த்து"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "முன்னுரிமைகள்"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "ஆன்"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "ஆஃப்"
-
-#: ../panels/sharing/cc-sharing-panel.c:304
-#| msgid "Enabled"
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "செயல்படுத்தப்பட்டது"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-#| msgid "Active Jobs"
-msgctxt "service is active"
-msgid "Active"
-msgstr "செயலில் உள்ளது"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "ஒரு கோப்புறையைத் தேர்ந்தெடுக்கவும்"
-
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "நகலெடு"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-msgid "Sharing"
-msgstr "பகிர்வு"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr ""
-"நீங்கள் மற்றவர்களுடன் எவற்றைப் பகிர வேண்டும் என்பதைக் கட்டுப்படுத்தவும்"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
 msgstr ""
-"பகிர்;பகிர்தல்;ssh;ஹோஸ்ட்;பெயர்;தொலைநிலை;டெஸ்க்டாப்;bluetooth;obex;மீடியா;ஆடிய"
-"ோ;வீடியோ;"
-"படங்கள்;புகைப்படங்கள்;மூவிகள்;சேவையகம்;ரென்டெரர்;"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "தொலைநிலை புகுபதிவை செயல்படுத்து அல்லது முடக்கு"
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
+msgid "Places"
+msgstr "இடங்கள்"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "தொலைநிலை புகுபதிவை செயல்படுத்த அல்லது முடக்க அங்கீகாரம் தேவைப்படுகிறது"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
+msgid "Bookmarks"
+msgstr "புத்தகக்குறிகள்"
 
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:299
-#| msgid "List of keyboard layouts selected for usage"
-msgid "No networks selected for sharing"
-msgstr "பகிர்வதற்கு பிணையங்கள் எதுவும் தேர்ந்தெடுக்கப்படவில்லை"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "மற்றவை"
 
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
-#| msgid "Network"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "இடம்"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "பயன்பாடுகள்"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "_S முகவரியால் தேடு"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"செயல்பாடுகளின் மேலோட்டப் பார்வையில், எந்த பயன்பாடுகள் தேடல் முடிவுகளைக் காண்பிக்க வேண்டும் "
+"என்பதைக் கட்டுப்படுத்தவும்"
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "தேடு;கண்டறி;அட்டவணை;மறை;தனியுரிமை;முடிவுகள்;"
+
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "பிணையங்கள்"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "Bluetooth பகிர்வு"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "பகிர்வு"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-"Bluetooth பகிர்வைக் கொண்டு நீங்கள் Bluetooth செயல்படுத்தப்பட்ட மற்ற "
-"சாதனங்களுடன் "
-"கோப்புகளைப் பகிர்ந்து கொள்ளலாம்"
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "நம்பகமான சாதனங்களிடமிருந்து மட்டும் பெறவும்"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "பெறப்படும் கோப்புகளை பதிவிறக்கங்கள் கோப்புறையில் சேமிக்கவும்"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "கணினியின் பெயர்"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "தனிப்பட்ட கோப்பு பகிர்வு"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "திரை பகிர்வு"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "மேசைச்சூழல்"
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
 msgstr "மீடியா பகிர்வு"
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "தொலைநிலை புகுபதிவு"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "பகிர்வு"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "கடவுச்சொல் தேவை"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "தொலைநிலை புகுபதிவு"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "பிணைய அணுகல் இல்லாததால் சில சேவைகள் முடக்கப்பட்டுள்ளன."
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "மேசைச்சூழல்"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
-"தனிப்பட்ட கோப்புப் பகிர்வைக் கொண்டு நீங்கள் இதைப் பயன்படுத்தி உங்கள் தற்போதைய "
-"பிணையத்திலுள்ள "
-"மற்றவர்களுடன் உங்கள் பொதுக் கோப்புறையைப் பகிர்ந்துகொள்ள முடியும்: <a "
-"href=\"dav://%s"
-"\">dav://%s</a>"
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr "கடவுச்சொல் தேவை"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "தொலைநிலை புகுபதிவை செயல்படுத்து அல்லது முடக்கு"
 
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"Secure Shell கட்டளையைப் பயன்படுத்தி தொலைநிலை பயனர்கள் இணைவதற்கு "
-"அனுமதிக்கவும்:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"தொலைநிலை பயனர்கள் இதில் இணைவதன் மூலம் உங்கள் திரையை அணுகவும் "
-"கட்டுப்படுத்தவும் "
-"அனுமதிக்கவும்: <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:20
-#| msgid "Remote Control"
-msgid "Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "தொலைநிலைக் கட்டுப்பாட்டை அனுமதி"
 
-#: ../panels/sharing/sharing.ui.h:21
-#| msgid "Password"
-msgid "Password:"
-msgstr "கடவுச்சொல்:"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "கடவுச்சொல்லை காட்டு"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "இணைக்கப்படவில்லை"
 
-#: ../panels/sharing/sharing.ui.h:23
-#| msgid "%s Options"
-msgid "Access Options"
-msgstr "அணுகல் விருப்பங்கள்"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "புதிய இணைப்புகள் அணுகலைக் கோர வேண்டும்"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "நகலெடு"
 
-#: ../panels/sharing/sharing.ui.h:25
-#| msgid "Require Password"
-msgid "Require a password"
-msgstr "கடவுச்சொல் தேவை"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "முகவரியை அழிக்கவும்"
 
-#: ../panels/sharing/sharing.ui.h:26
-#| msgid "Share Music, Photos and Videos with others on the current network."
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "அங்கீகாரம் (_t)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "பயனர் பெயர்:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "விரல்ரேகை பதிவு செய்கிறது"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "மீடியா பகிர்வு"
+
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "பிணையத்தின் வழியாக இசை, புகைப்படங்கள் மற்றும் வீடியோக்களைப் பகிரலாம்."
 
-#: ../panels/sharing/sharing.ui.h:27
-#| msgid "Add Folder"
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "கோப்புறைகள்"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "ஒலி"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "நீங்கள் மற்றவர்களுடன் எவற்றைப் பகிர வேண்டும் என்பதைக் கட்டுப்படுத்தவும்"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 msgstr ""
-"ஒலி அளவுகள், உள்ளீடுகள், வெளியீடுகள் மற்றும் விழிப்பூட்டல் ஒலிகளை மாற்று"
+"பகிர்;பகிர்தல்;ssh;ஹோஸ்ட்;பெயர்;தொலைநிலை;டெஸ்க்டாப்;bluetooth;obex;மீடியா;ஆடியோ;வீடியோ;"
+"படங்கள்;புகைப்படங்கள்;மூவிகள்;சேவையகம்;ரென்டெரர்;"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "அட்டை;ஒலிவாங்கி;ஒலிஅளவு;மறைவுறு;சமனம்;ப்ளூடூத்;ஹெட்செட்;ஆடியோ;"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "தொலைநிலை புகுபதிவை செயல்படுத்து அல்லது முடக்கு"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "குரைப்பு"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "தொலைநிலை புகுபதிவை செயல்படுத்த அல்லது முடக்க அங்கீகாரம் தேவைப்படுகிறது"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "தண்ணீர் சொட்டு"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "மினுமினு"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "க்ளாஸ்"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "பகிர்வு"
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "சோனார்"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "இடது"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "வலது"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_B சமனம்:"
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "_F மறைவுறு:"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "பின்"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "முன்"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "குறைந்தபட்சம்"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "அதிக பட்சம்"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "_B சமனம்:"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "_F மறைவுறு:"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "_S சப்வூஃபர்:"
-
-#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:616
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "பெருக்காதது"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "_P விவரகுறிப்பு:"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u வெளிப்பாடு"
-msgstr[1] "%u வெளிப்பாடுகள்"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u உள்ளீடு"
-msgstr[1] "%u உள்ளீடுகள்"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "கணினி ஒலிகள்"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "_T ஒலி பெருக்கிகளை சோதி "
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "_A எச்சரிக்கை அளவு:"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "உச்சிகளை கண்டுபிடி"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "ஒலியை நிறுத்து"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1509
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "பெயர்"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1528
-msgid "Device"
-msgstr "சாதனம்"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1591
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s க்கு ஒலி பெருக்கி சோதனை"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1649
-msgid "_Output volume:"
-msgstr "_O வெளியீடு ஒலி அளவு: "
-
-#: ../panels/sound/gvc-mixer-dialog.c:1663
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "வெளிப்பாடு"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1668
-msgid "C_hoose a device for sound output:"
-msgstr "_h ஒலி வெளிப்பாடுக்கு சாதனத்தை தேர்ந்தெடு"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "_O வெளியீடு ஒலி அளவு: "
 
-#: ../panels/sound/gvc-mixer-dialog.c:1693
-msgid "Settings for the selected device:"
-msgstr "தேர்ந்தெடுக்கப்பட்ட சாதனத்திற்கு அமைப்பு:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "Input"
-msgstr "உள்ளீடு"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "_Input volume:"
-msgstr "(_I) உள்ளீட்டு ஒலி அளவு:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1734
-msgid "Input level:"
-msgstr "(_I) உள்ளீட்டு மட்டம்:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1762
-msgid "C_hoose a device for sound input:"
-msgstr "_h ஒலி உள்ளீட்டுக்கு சாதனம் தேர்ந்தெடு:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "Sound Effects"
-msgstr "ஒலி விளைவுகள்"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-msgid "_Alert volume:"
-msgstr "_A எச்சரிக்கை அளவு:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1809
-msgid "Applications"
-msgstr "பயன்பாடுகள்"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1813
-msgid "No application is currently playing or recording audio."
-msgstr "நடப்பில் எந்த பயன்பாடும் ஒலியை இயக்கவோ பதியவோ இல்லை"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "உட்பொதியப்பட்டது"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "ஒலி முன்னுரிமைகள்"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "ஒலி நிகழ்வை சோதிக்கிறது"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "முன்னிருப்பு"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "தீமிலிருந்து"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:769
-msgid "C_hoose an alert sound:"
-msgstr "ஒரு விழிப்பூட்டும் ஒலியை தேர்ந்தெடு: (_h)"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "நிறுத்து"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "சோதனை"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "(_C) வடிவமைப்பு URL:"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "சப்வூஃபர்"
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "தனிப்பயன்"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "உள்ளீடு"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr ""
-"பார்ப்பது, கேட்பது, தட்டச்சு செய்வது, சுட்டுவது மற்றும் சொடுக்குவது "
-"அனைத்தையும் "
-"எளிதாக்கவும்"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "(_I) உள்ளீட்டு மட்டம்:"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "ஒலி அளவை உயர்த்து"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "_A எச்சரிக்கை அளவு:"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "ஒலி நிறுத்தம்"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ஒலி"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ஒலி அளவுகள், உள்ளீடுகள், வெளியீடுகள் மற்றும் விழிப்பூட்டல் ஒலிகளை மாற்று"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "அட்டை;ஒலிவாங்கி;ஒலிஅளவு;மறைவுறு;சமனம்;ப்ளூடூத்;ஹெட்செட்;ஆடியோ;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "அறிவிப்புகள்"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "(_N) பெயர்:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "அனைவருக்குமான அணுகல் மெனுவை எப்போதும் காட்டு (_A)"
-
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "காணல் "
-
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "அதிக வேறுபாடு (_H)"
-
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "பெரிய உரை (_L)"
-
-#: ../panels/universal-access/uap.ui.h:5
-msgid "_Zoom"
-msgstr "பெரிதாக்கு (_Z)"
-
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr "திரைபடிப்பான் (_R)"
-
-#: ../panels/universal-access/uap.ui.h:8
-msgid "_Sound Keys"
-msgstr "ஒலி விசைகள் (_S)"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "கேட்டல் "
-
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
-msgstr "காட்சி எச்சரிக்கைகள் (_V)"
-
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Screen _Keyboard"
-msgstr "திரை விசைப்பலகை (_K)"
-
-#: ../panels/universal-access/uap.ui.h:13
-msgid "_Typing Assist (AccessX)"
-msgstr "தட்டச்சு உதவியாளர் (AccessX) (_T)"
-
-#: ../panels/universal-access/uap.ui.h:14
-#| msgid "Pointing and Clicking"
-msgid "Pointing & Clicking"
-msgstr "சுட்டி & சொடுக்கல்"
-
-#: ../panels/universal-access/uap.ui.h:15
-msgid "_Mouse Keys"
-msgstr "சொடுக்கி விசைகள் (_M)"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "சொடுக்க உதவி (_C)"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "திரைபடிப்பான்"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
 msgstr ""
-"திரைபடிப்பான் நீங்கள் திரை கவனப் பகுதியை நகர்த்தும் போது அதற்குரிய உரையை "
-"படித்துக் "
-"காட்டும்."
 
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Screen Reader"
-msgstr "திரைபடிப்பான் (_S)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "தானியங்கு இணைப்பு (_C)"
 
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Sound Keys"
-msgstr "ஒலி விசைகள்"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "சாதனத்தை நீக்கு"
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "Num Lock அல்லது Caps Lock இயக்கப்படும் போது பீப் ஒலி எழுப்பு."
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "காட்சி எச்சரிக்கைகள்"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "_T மின்ஒளியை சோதி "
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "எச்சரிக்கை ஒலி எழுப்பப்படும் போது காட்சி அடையாளத்தையும் காட்டு."
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Flash the _window title"
-msgstr "சாளர தலைப்புப்பட்டையை பளிச்சிடு (_W)"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Flash the entire _screen"
-msgstr "முழு திரையை பளிச்சிடு (_s)"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Typing Assist"
-msgstr "தட்டச்சு உதவியாளர்"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "_Sticky Keys"
-msgstr "ஒட்டு விசைகள் (_S)"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "மாற்றி விசைகளின் வரிசை ஒன்றை விசை தொகுப்பாக கொள்ளும்."
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "_D இரண்டு விசைகளை ஒரே நேரத்தில் அழுத்தினால் செயல் நீக்கவும்."
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifer key is pressed"
-msgstr "(_m) மாற்றி விசை  அழுத்தினால் பீப் ஒலி எழுப்புக"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "S_low Keys"
-msgstr "மெது விசைகள் (_L)"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
 msgstr ""
-"ஒரு விசை அழுத்தப்படுவதற்கும் அது ஒப்புக்கொள்ளப் படுவதற்கும் இடையே ஒரு "
-"இடைவெளியை அமை "
 
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "_c ஒப்புக்கொள்ளல் தாமதம்:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s களத்துடன் இணைக்க முடியவில்லை: %s"
 
-#: ../panels/universal-access/uap.ui.h:35
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "குறுகிய"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "உலகளாவிய அணுகல்"
 
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "மெது விசைகள் தட்டச்சு தாமதம்"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:37
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "நீண்ட"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "சாதனங்களை பெறுகிறது..."
 
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Beep when a key is pr_essed"
-msgstr "(_e) எந்த விசையும்  அழுத்தினால் பீப் ஒலி எழுப்புக"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Beep when a key is _accepted"
-msgstr "விசை ஏற்கப்பட்டால் பீப் ஒலி எழுப்புக (_a)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "தண்டர் பர்ட்"
 
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "_r விசை ஏற்கப்படவில்லையானால் பீப் ஒலி எழுப்புக"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:41
-msgid "_Bounce Keys"
-msgstr "பவுன்ஸ் விசைகள் (_B)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "வேக இரட்டிப்பு விசை அழுத்தங்களை உதாசீனம் செய்க"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "நிலைக்காட்டி சிமிட்டும்"
 
-#: ../panels/universal-access/uap.ui.h:43
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "குறுகிய"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "(_b) நிலைக்காட்டி உரை  உள்ளே சிமிட்டும்"
 
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "எதிரொலிப்பு விசைகள் தட்டச்சு தாமதம்"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "வேகம்"
 
-#: ../panels/universal-access/uap.ui.h:45
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "நீண்ட"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "நிலைகாட்டி சிமிட்டும் வேகம்"
 
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Enable by Keyboard"
-msgstr "விசைப்பலகையால் செய்யப்படும் வசதியை இயக்கு (_E)"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "நிலைகாட்டி சிமிட்டும் வேகம்"
 
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr " விசைப்பலகையில் இருந்து அணுகல் சிறப்பு இயல்புகளை இயக்கு/இயக்கம் நீக்கு"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "சொடுக்க உதவி"
 
-#: ../panels/universal-access/uap.ui.h:49
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "பாவிக்கப்பட்ட இரண்டாம் நிலை சொடுக்கம்"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "முதன்மை  பொத்தானை அழுத்தியதன் மூலம் இரண்டாம் சொடுக்கை இடரவும்"
 
-#: ../panels/universal-access/uap.ui.h:51
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_c ஒப்புக்கொள்ளல் தாமதம்:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "குறுகிய"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "இரண்டாம் சொடுக்கு தாமதிப்பு"
 
-#: ../panels/universal-access/uap.ui.h:53
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "நீண்ட"
 
-#: ../panels/universal-access/uap.ui.h:54
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "மேல் நகர்வு சொடுக்கம் (_H)"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "சுட்டி அசைவை நிறுத்தும்போது சொடுக்கை தூண்டு"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "_e தாமதம்:"
 
-#: ../panels/universal-access/uap.ui.h:57
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "குறுகிய"
 
-#: ../panels/universal-access/uap.ui.h:58
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "நீண்ட"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "(_t) நகர்வு மாறு நிலை :"
 
-#: ../panels/universal-access/uap.ui.h:60
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "சிறிய"
 
-#: ../panels/universal-access/uap.ui.h:61
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "பெரிய"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "மறுசெயல் விசைகள்"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "அமுக்கப்படும்போது விசை மறுபடியும் அச்சிடப்படும்."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "தொடரும் விசைகளின் வேகம்"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "தொடரும் விசைகளின் வேகம்"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "தட்டச்சு உதவியாளர்"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "ஒட்டு விசைகள் (_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "மாற்றி விசைகளின் வரிசை ஒன்றை விசை தொகுப்பாக கொள்ளும்."
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_D இரண்டு விசைகளை ஒரே நேரத்தில் அழுத்தினால் செயல் நீக்கவும்."
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "(_m) மாற்றி விசை  அழுத்தினால் பீப் ஒலி எழுப்புக"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "மெது விசைகள் (_L)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"ஒரு விசை அழுத்தப்படுவதற்கும் அது ஒப்புக்கொள்ளப் படுவதற்கும் இடையே ஒரு இடைவெளியை அமை "
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "குறுகிய"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "1/4 திரை"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "மெது விசைகள் தட்டச்சு தாமதம்"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "1/2 திரை"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "3/4 திரை"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
-msgstr "நீண்டது"
+msgstr "நீண்ட"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "(_e) எந்த விசையும்  அழுத்தினால் பீப் ஒலி எழுப்புக"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "விசை ஏற்கப்பட்டால் பீப் ஒலி எழுப்புக (_a)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "_r விசை ஏற்கப்படவில்லையானால் பீப் ஒலி எழுப்புக"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "பவுன்ஸ் விசைகள் (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "வேக இரட்டிப்பு விசை அழுத்தங்களை உதாசீனம் செய்க"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "குறுகிய"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "எதிரொலிப்பு விசைகள் தட்டச்சு தாமதம்"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "நீண்ட"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "விசைப்பலகையால் செய்யப்படும் வசதியை இயக்கு (_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr " விசைப்பலகையில் இருந்து அணுகல் சிறப்பு இயல்புகளை இயக்கு/இயக்கம் நீக்கு"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "அனைவருக்குமான அணுகல் மெனுவை எப்போதும் காட்டு (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "காணல் "
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "அதிக வேறுபாடு (_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "பெரிய உரை (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "திரைபடிப்பான் (_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"திரைபடிப்பான் நீங்கள் திரை கவனப் பகுதியை நகர்த்தும் போது அதற்குரிய உரையை படித்துக் "
+"காட்டும்."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "ஒலி விசைகள் (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num Lock அல்லது Caps Lock இயக்கப்படும் போது பீப் ஒலி எழுப்பு."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "நிலைகாட்டி சிமிட்டும் வேகம்"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "பெரிதாக்கு (_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "கேட்டல் "
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "காட்சி எச்சரிக்கைகள் (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "திரை விசைப்பலகை (_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "மறுசெயல் விசைகள்"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "நிலைக்காட்டி சிமிட்டும்"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "தட்டச்சு உதவியாளர் (AccessX) (_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "சுட்டி & சொடுக்கல்"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "சொடுக்கி விசைகள் (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "வெள்ளை சொடுக்கி"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "சொடுக்க உதவி (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "(_D) இரட்டிப்பு சொடுக்கு:"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "இரட்டை சொடுக்கு நேரம் முடிந்தது"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "காட்சி எச்சரிக்கைகள்"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_T மின்ஒளியை சோதி "
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "எச்சரிக்கை ஒலி எழுப்பப்படும் போது காட்சி அடையாளத்தையும் காட்டு."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "முழு திரையை பளிச்சிடு (_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "முழு திரையை பளிச்சிடு (_s)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "முழு-திரையிலும் காண்பி"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "மேல் பாதி"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "கீழ் பாதி"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "இடது  "
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "வலது பாதி"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "அணுகிக்காணல் தேர்வுகள்"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "அணுகிப்பார்"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "பெரிதாக்கம் :"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "சொடுக்கி நிலைகாட்டியை தொடர்"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "திரையின் பாகம்:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "பெரிதாக்கி திரைக்கு வெளியே நீள்கிறது"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "பெரிதாக்கி நிலைக்காட்டியை எப்போதும் மையத்தில் வைக்கவும்"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "பெரிதாக்கி நிலைக்காட்டி உள்ளடக்கத்தை இங்குமங்கும் தள்ளுகிறது"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "பெரிதாக்கி நிலைக்காட்டி உள்ளடக்கங்களுடன் நகர்கிறது"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "பெரிதாக்கி இடம்:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "சொடுக்கி நிலைகாட்டியை தொடர்"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "திரையின் பாகம்:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "பெரிதாக்கி திரைக்கு வெளியே நீள்கிறது"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "பெரிதாக்கி நிலைக்காட்டியை எப்போதும் மையத்தில் வைக்கவும்"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "பெரிதாக்கி நிலைக்காட்டி உள்ளடக்கத்தை இங்குமங்கும் தள்ளுகிறது"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "பெரிதாக்கி நிலைக்காட்டி உள்ளடக்கங்களுடன் நகர்கிறது"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "பெரிதாக்கி "
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "குறுக்கு இழைகள்:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "சொடுக்கி நிலைக்காட்டி மேல் பரவுகிறது"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "தடிமன்:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "மெல்லிய"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "தடிமனான"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "நீளம்:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "நிறம்:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "குறுக்கு இழைகள்:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "சொடுக்கி நிலைக்காட்டி மேல் பரவுகிறது"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "குறுக்கு இழைகள்"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "நிற விளைவுகள்:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "கறுப்பில் வெள்ளை:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "வெளிச்சம்:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "வேறுபாடு:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "நிறம்"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "எதுவுமில்லை"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "முழு"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "குறைவான"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "அதிகம்"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "குறைவாக"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "அதிக"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "நிற விளைவுகள்:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "நிற விளைவுகள்"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "செந்தரம்"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "நிர்வாகி"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Full Name"
-msgstr "முழுப் பெயர் (_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "_T கணக்கு வகை"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to set a password when they next login"
-msgstr "பயனர் அடுத்த புகுபதிவில் கடவுச்சொல்லை அமைக்க அனுமதிக்கவும்"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "கடவுச்சொல்லை இப்போது அமை"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "சரிபார் (_V)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
 msgstr ""
-"தொழில் ரீதியான புகுபதிவில், இந்த சாதனத்தில் மைய முறையில் நிர்வகிக்கப்படும் "
-"முன்பே உள்ள "
-"ஒரு பயனர் கணக்கைப் பயன்படுத்த முடிகிறது."
+"பார்ப்பது, கேட்பது, தட்டச்சு செய்வது, சுட்டுவது மற்றும் சொடுக்குவது அனைத்தையும் "
+"எளிதாக்கவும்"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "(_D) களம்"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"தொழில் ரீதியான கணக்குகளைச் சேர்க்க\n"
-"ஆன்லைனுக்குச் செல்லவும்."
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "_E என்டர்ப்ரைஸ் புகுபதிவு:"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "வரலாறு"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "வரலாறு"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "சமீபத்திய வரலாற்றை அழி (_e)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "தேவையற்றதையும் தற்காலிகக் கோப்புகளையும் அழி"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "குப்பைதொட்டியை தானாக காலி செய் (_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "தற்காலிகக் கோப்புகளை தானாக அழி (_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "குப்பைதொட்டியை தானாக காலி செய் (_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "குப்பை தொட்டியை காலி செய் (_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "தற்காலிக கோப்புகளை அழி (_P)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "குப்பைக்கு நகர்த்து"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "பயனர் சேர்"
 
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "நிர்வாகி"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "பயனர் அடுத்த புகுபதிவில் கடவுச்சொல்லை அமைக்க அனுமதிக்கவும்"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "கடவுச்சொல்லை இப்போது அமை"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "வடிவமைக்கிறது."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "_E என்டர்ப்ரைஸ் புகுபதிவு:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "இணைப்பு விலகி"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"தொழில் ரீதியான புகுபதிவில், இந்த சாதனத்தில் மைய முறையில் நிர்வகிக்கப்படும் முன்பே உள்ள "
+"ஒரு பயனர் கணக்கைப் பயன்படுத்த முடிகிறது."
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "பிபிடி கோப்பை  தேர்ந்தெடு."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "_F கைரேகை புகுபதிவு:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "_F கைரேகை புகுபதிவு:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "இல்லை"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"நீங்கள் பதிவு செய்யப்பட்ட கைரேகைகளை அழிக்க வேண்டுமா எனவே கைரேகை புகுபதிவு "
+"செயல்நீக்கப்படும்?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "அச்சுப்பொறிகள் எதுவும் கண்டுபிடிக்கப்படவில்லை ."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "_F கைரேகை புகுபதிவு:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "_F கைரேகை புகுபதிவு:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "_h வடிவமைக்க சாதனத்தை தேர்ந்தெடு"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "_F கைரேகை புகுபதிவு:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "கைரேகைகளை அழி (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "_F கைரேகை புகுபதிவு:"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "முந்தைய வாரம்"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "அடுத்த வாரம்"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "கடவுச்சொல்லை மாற்று"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "_a மாற்று"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "நடப்பு கடவுச்சொல் (_p)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "புதிய கடவுச் சொல் (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "_o கடவுச் சொல்லை உறுதி செய்க: "
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "கடவுச்சொற்கள் பொருந்தவில்லை."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "பயனர் அடுத்த புகுபதிவில் கடவுச்சொல்லை அமைக்க அனுமதிக்கவும்"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "கடவுச்சொல்லை இப்போது அமை"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "பயனர்கள்"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "மாற்றங்கள் விளைவை ஏற்படுத்த உங்கள் அமர்வை மறுதொடக்கம் செய்ய வேண்டும்"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "இப்போது மறுதுவக்கு"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "மூடு"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "முழுப் பெயர் (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_F கைரேகை புகுபதிவு:"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_u தானியங்கி உள்நுழைவு"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "_t கணக்கு வகை:"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "நிர்வாகி"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "கட்டுப்பாடுகள்"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "பயனர் கணக்கு நீக்கு"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_O மற்ற விரல்:"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "பயனர் சேர்"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "படங்கள் இல்லை"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "ஒரு பயனர் கணக்கை உருவாக்கு"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "பயனர்களைச் சேர்க்கவும் அல்லது நீக்கவும் மற்றும் உங்கள் கடவுச்சொல்லை மாற்றவும்"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "பதிவு செய்யவும் (_E)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "டொமெய்ன் நிர்வாகி உள்நுழைவு"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6140,1148 +4856,3375 @@ msgstr ""
 " பதிவாக வேண்டும். தயை செய்து  உங்கள் வலையமைப்பு நிர்வாகியை \n"
 "அவர்களது டொமெய்ன் கடவுச்சொல்லை இங்கே உள்ளிட வையுங்கள்."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "_N நிர்வாகி பெயர்"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "நிர்வாகி கடவுச்சொல்"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "இடது கட்டைவிரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "இடது நடு விரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "இடது மோதிர விரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "இடது சிறுவிரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "வலது கட்டைவிரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "வலது நடு விரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "வலது மோதிர விரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "வலது சிறு விரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:687
-msgid "Enable Fingerprint Login"
-msgstr "கைரேகை புகுபதிவை செயல்படுத்து"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "_R வலது சுட்டு விரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "_L இடது சுட்டுவிரல்"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "_O மற்ற விரல்:"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"உங்கள் கைரேகை வெற்றிகரமாக சேமிக்கப்பட்டது. இப்போது நீங்கள் கைரேகை வாசிப்பி "
-"மூலம் "
-"புகுபதிவு செய்ய முடியும்."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "பயனர்கள்"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr ""
-"பயனர்களைச் சேர்க்கவும் அல்லது நீக்கவும் மற்றும் உங்கள் கடவுச்சொல்லை மாற்றவும்"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "உள்புகுகை;பெயர்;விரல்ரேகை;அவதாரம்;லோகோ;முகம்;கடவுச்சொல்;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "புகுபதிவு வரலாறு"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-#| msgid "Change pa_ssword"
-msgid "Change Password"
-msgstr "கடவுச்சொல்லை மாற்று"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "_a மாற்று"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "புதிய கடவுச் சொல்லைச் சரிபார் (_V)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "புதிய கடவுச் சொல் (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "நடப்பு கடவுச்சொல் (_p)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "பயனர் கணக்கு சேர்"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "பயனர் கணக்கு நீக்கு"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "புகு பதிகை தேர்வுகள்"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "_u தானியங்கி உள்நுழைவு"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "_F கைரேகை புகுபதிவு:"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "பயனர் சின்னம்"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "(_L) மொழி"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "கடந்த புகுபதிவு"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "பயனர் கணக்குகளை மேலாள்"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "பயனர் தரவை மாற்ற அனுமதி தேவை"
 
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "புதிய கடவுச்சொல் பழையதிலிருந்து வேறுபட்டிருக்க வேண்டும்."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "சில எழுத்துகளையும் எண்களையும் மாற்றி முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "கடவுச்சொல்லை இன்னும் கொஞ்சம் மாற்ற முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "உங்கள் பயனர் பெயரைக் கொண்டில்லாத கடவுச்சொல் இன்னும் வலிமையானது."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr ""
-"கடவுச்சொல்லில் உங்கள் பயனர் பெயரைப் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr ""
-"சேர்க்கப்பட்டுள்ள சில சொற்களை கடவுச்சொல்லில் பயன்படுத்துவதைத் தவிர்க்க "
-"முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "பொதுவான சொற்களைத் தவிர்க்க முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "முன்பே உள்ள சொற்களை மறுவரிசைப்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "அதிக எண்களைப் பயன்படுத்த முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "அதிக பெரிய எழுத்துகளைப் பயன்படுத்த முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "அதிக சிறிய எழுத்துகளைப் பயன்படுத்த முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-"நிறுத்தக் குறிகள் போன்ற சிறப்பு எழுத்துகளை அதிகம் பயன்படுத்த முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
-"எண்கள், எழுத்துகள் மற்றும் நிறுத்தக்குறிகளைக் கலந்து பயன்படுத்த "
-"முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr ""
-"ஒரே எழுத்தை மீண்டும் மீண்டும் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"ஒரே வகை எழுத்தை மீண்டும் மீண்டும் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்: "
-"எண்கள், எழுத்துகள் "
-"மற்றும் நிறுத்தக்குறிகளைக் கலந்து பயன்படுத்த வேண்டும்."
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr ""
-"1234 அல்லது abcd போன்ற வரிசை எழுத்துகளைப் பயன்படுத்துவதைத் தவிர்க்க "
-"முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "அதிக எண்கள், எழுத்துகள், சின்னங்களைச் சேர்க்க முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr ""
-"பெரிய எழுத்துகள் மற்றும் சிறிய எழுத்துகளைக் கலந்து பயன்படுத்தி ஓரிரண்டு "
-"எண்களையும் "
-"பயன்படுத்தவும்."
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-"நல்ல கடவுச்சொல்! அதிக எண்களையும் எழுத்துகளையும் நிறுத்தக் குறிகளையும் "
-"சேர்த்தால் இன்னும் "
-"வலிமையாகும்."
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "வலிமை: வலிமையில்லை"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "வலிமை: குறைவு"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "வலிமை: நடுத்தரம்"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "வலிமை: நன்று"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "வலிமை: அதிகம்"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "அனுமதித்தல் தோல்வி"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "கடவுச்சொல் மிகவும் சிறயதாக உள்ளது."
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "கடவுச்சொல் மிக எளிமையாக உள்ளது."
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "பழைய கடவுச்சொல்லும் புதிய கடவுச்சொல்லும் ஒரே மாதிரி உள்ளன"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "புதிய கடவுச்சொல் ஏற்கனவே சமீபத்தில் பயன்படுத்தப்பட்டுள்ளது "
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "புதிய கடவுச்சொல்லில் எண்களும் சிறப்பு எழுத்துக்களூம் இருக்க வேண்டும்"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "பழைய மற்றும் கடவுச்சொற்கள் ஒரே மாதிரியாக உள்ளது."
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
-"ஆரம்ப அங்கீகாரத்திலிருந்து உங்கள் கடவுச்சொல் மாற்றப்பட்டுள்ளது! மீண்டும் "
-"அங்கீகரிக்கவும்."
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "புதிய கடவுச்சொல்லில் தேவையான அளவு மாறுபட்ட எழுத்துருக்கள் இல்லை"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "தெரியாத பிழை"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "உங்கள் கணக்கு வழங்குநரின் வலை முகவரிக்குப் பொருந்த வேண்டும்."
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "கணக்கை சேர்த்தல் தோல்வி"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-msgid "Passwords do not match."
-msgstr "கடவுச்சொற்கள் பொருந்தவில்லை"
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr "கணக்கை பதிவு செய்ய முடியவில்லை"
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr "இந்த களத்துடன் உறுதிப்படுத்த ஆதரவுள்ள வழி இல்லை"
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr "களத்தில் சேருதல் தோல்வி"
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"புகுபதிவு பெயர் பயனளிக்கவில்லை.\n"
-"மீண்டும் முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"புகுபதிவு கடவுச்சொல் பயனளிக்கவில்லை.\n"
-"மீண்டும் முயற்சிக்கவும்."
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr "களத்தில் உள்நுழைதல் தோல்வி"
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "டொமைனைக் கண்டறிய முடியவில்லை. எழுத்துக்கூட்டு தவறா?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:138
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr "நீங்கள் சாதனத்தை அணு அனுமதி இல்லை. கணினி நிர்வாகியை அணுகவும்."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:140
-msgid "The device is already in use."
-msgstr "சாதனம் பயன்படுத்த தயாராக உள்ளது."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid "An internal error occurred."
-msgstr "ஒரு உள்ளமை பிழை நேர்ந்தது."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Enabled"
-msgstr "செயலாக்கப்பட்டது"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:263
-msgid "Delete registered fingerprints?"
-msgstr "பதிவு செய்யப்பட்ட கைரேகைகளை அழிக்கவா?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-msgid "_Delete Fingerprints"
-msgstr "கைரேகைகளை அழி (_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:273
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"நீங்கள் பதிவு செய்யப்பட்ட கைரேகைகளை அழிக்க வேண்டுமா எனவே கைரேகை புகுபதிவு "
-"செயல்நீக்கப்படும்?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:444
-msgid "Done!"
-msgstr "முடிந்தது!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:505
-#: ../panels/user-accounts/um-fingerprint-dialog.c:547
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' சாதனத்தை அணுக முடியவில்லை"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:588
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "'%s' சாதனத்தில் விரலை பிடிக்க துவக்க முடியவில்லை"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:638
-msgid "Could not access any fingerprint readers"
-msgstr "கைரேகை வாசிப்பி எதையும் அணுக முடியவில்லை"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:639
-msgid "Please contact your system administrator for help."
-msgstr "உதவிக்கு உங்கள் கணினி நிர்வாகியை அணுகவும்"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:721
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"கைரேகை புகுபதிவை செயல்படுத்த உங்கள் கைரேகையை '%s' சாதனத்தை பயன்படுத்தி "
-"சேமிக்க "
-"வேண்டும்."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:728
-msgid "Selecting finger"
-msgstr "விரலை தேர்ந்தெடு"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:729
-msgid "Enrolling fingerprints"
-msgstr "விரல்ரேகை பதிவு செய்கிறது"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "இந்த வாரம்"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "கடந்த வாரம்"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:631
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:635
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "அமர்வு முடிந்தது"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "அமர்வு தொடங்கியது"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "தயவு செய்து வேறு கடவுச்சொல்லை தேர்ந்தெடுக்கவும்."
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "தயை செய்து நடப்பு கடவுச்சொல்லை மீண்டும் உள்ளிடவும்"
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "கடவுச்சொல்லை மாற்ற முடியாது."
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-msgid "The passwords do not match."
-msgstr "கடவுச்சொற்கள் பொருந்தவில்லை."
-
-#: ../panels/user-accounts/um-photo-dialog.c:219
-msgid "Browse for more pictures"
-msgstr "அதிக படங்களுக்கு உலாவி காண்க"
-
-#: ../panels/user-accounts/um-photo-dialog.c:453
-msgid "Disable image"
-msgstr "பிம்பத்தை முடக்கு"
-
-#: ../panels/user-accounts/um-photo-dialog.c:471
-msgid "Take a photo…"
-msgstr "ஒரு புகைப்படம் எடுக்கவும் …"
-
-#: ../panels/user-accounts/um-photo-dialog.c:489
-msgid "Browse for more pictures…"
-msgstr "அதிக படங்களுக்கு உலவுக…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:713
-#, c-format
-msgid "Used by %s"
-msgstr "%s ஆல் பயன்படுத்தப்ப்ட்டது"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "இந்த வகை டொமைனை தானாக சேர்க்க முடியாது"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "அது போன்ற களம் அல்லது ராஜ்யம் காணவில்லை"
-
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s ஆக %s களத்தில் உள்நுழைய இயலாது"
-
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
-msgstr "செல்லுபடியாகாத கடவுச்சொல், தயை செய்து மீண்டும் முயற்சி செய்க"
-
-#: ../panels/user-accounts/um-realm-manager.c:832
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "%s களத்துடன் இணைக்க முடியவில்லை: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:198
-msgid "Other Accounts"
-msgstr "மற்ற கணக்குகள்"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "Failed to delete user"
-msgstr "பயனரை நீக்க முடியவில்லை"
-
-#: ../panels/user-accounts/um-user-panel.c:482
-msgid "You cannot delete your own account."
-msgstr "நீங்கள் உங்கள் கணக்கையே நீக்க முடியாது"
-
-#: ../panels/user-accounts/um-user-panel.c:491
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s இன்னும் உள் நுழைந்து உள்ளார் "
-
-#: ../panels/user-accounts/um-user-panel.c:495
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"ஒரு பயனர் உள் நுழைந்து உள்லபோது அவர் கணக்கை நீக்குவது கணினியை "
-"நிலையற்றதாக்கும்."
-
-#: ../panels/user-accounts/um-user-panel.c:504
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "%s இன் கோப்புக்களை வைத்துக்கொள்ள வேண்டுமா?"
-
-#: ../panels/user-accounts/um-user-panel.c:508
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"ஒரு பயனரின் கணக்கை நீக்கும்போது இல்ல அடைவு, அஞ்சல் சுருள், தற்காலிக கோப்புகள் "
-"ஆகியவற்றை "
-"வைத்துக்கொள்ள முடியும்."
-
-#: ../panels/user-accounts/um-user-panel.c:511
-msgid "_Delete Files"
-msgstr "(_D) கோப்புக்களை நீக்கவும்"
-
-#: ../panels/user-accounts/um-user-panel.c:512
-msgid "_Keep Files"
-msgstr "_K கோப்புக்களை வைத்துக்கொள்ளவும்"
-
-#: ../panels/user-accounts/um-user-panel.c:564
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "கணக்கு முடக்கப்பட்டது"
-
-#: ../panels/user-accounts/um-user-panel.c:572
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "அடுத்த புகுபதிவில் அமைக்கப்படும்"
-
-#: ../panels/user-accounts/um-user-panel.c:575
-msgctxt "Password mode"
-msgid "None"
-msgstr "ஏதுமில்லை"
-
-#: ../panels/user-accounts/um-user-panel.c:624
-msgid "Logged in"
-msgstr "புகுபதிவு செய்துள்ளது"
-
-#: ../panels/user-accounts/um-user-panel.c:1067
-msgid "Failed to contact the accounts service"
-msgstr "கணக்கு சேவையை தொடர்பு கொள்வதில் தோல்வி"
-
-#: ../panels/user-accounts/um-user-panel.c:1069
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"கணக்கு சேவை  நிறுவப்பட்டுள்ளதா செயலாக்கப்பட்டுள்ளதா என்பதை சரிபார்க்கவும்"
-
-#: ../panels/user-accounts/um-user-panel.c:1110
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"மாற்றங்கள் செய்ய \n"
-"முதலில் * சின்னத்தை சொடுக்குக"
-
-#: ../panels/user-accounts/um-user-panel.c:1148
-msgid "Create a user account"
-msgstr "ஒரு பயனர் கணக்கை உருவாக்கு"
-
-#: ../panels/user-accounts/um-user-panel.c:1159
-#: ../panels/user-accounts/um-user-panel.c:1471
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"புதிய பயனர் கணக்கை உருவாக்க,\n"
-"முதலில் * சின்னத்தை சொடுக்குக"
-
-#: ../panels/user-accounts/um-user-panel.c:1169
-msgid "Delete the selected user account"
-msgstr "தேர்ந்தெடுத்த பயனர் கணக்கை நீக்கவும்"
-
-#: ../panels/user-accounts/um-user-panel.c:1181
-#: ../panels/user-accounts/um-user-panel.c:1476
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"தேர்ந்தெடுத்த பயனர் கணக்கை நீக்க,\n"
-"முதலில் * சின்னத்தை சொடுக்குக"
-
-#: ../panels/user-accounts/um-user-panel.c:1385
-msgid "My Account"
-msgstr "என் கணக்கு"
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-#| msgid "A user with the username '%s' already exists"
-msgid "A user with the username '%s' already exists."
-msgstr "'%s' என்ற பயனர் பெயரில் ஏற்கனவே ஒரு பயனர் உள்ளார்."
-
-#: ../panels/user-accounts/um-utils.c:571
-#, c-format
-#| msgid "The username is too long"
-msgid "The username is too long."
-msgstr "பயனர் பெயர் மிக நீளமாக உள்ளது."
-
-#: ../panels/user-accounts/um-utils.c:574
-#| msgid "The username cannot start with a '-'"
-msgid "The username cannot start with a '-'."
-msgstr "பயனர் பெயர் '-' ஐக் கொண்டு தொடங்கக்கூடாது."
-
-#: ../panels/user-accounts/um-utils.c:577
-#| msgid ""
-#| "The username should only consist of lower and upper case letters from a-"
-#| "z, digits and any of characters '.', '-' and '_'"
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"பயனர் பெயரில் a-z வரையிலான பெரிய மற்றும் சிறிய எழுத்துகள், எண்கள் மற்றும் "
-"'.', '-', "
-"'_' ஆகிய எழுத்துகள் மட்டுமே இருக்கலாம்."
-
-#: ../panels/user-accounts/um-utils.c:581
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-"இது உங்கள் இல்லக் கோப்புறைக்குப் பெயரிடப் பயன்படுத்தப்படும், இதை மாற்ற "
-"முடியாது."
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:831
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "வரைபட பொத்தான்கள்"
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "வரைபட பொத்தன்களிலிருந்து செயல்களுக்கு"
 
-#: ../panels/wacom/button-mapping.ui.h:4
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"ஒரு குறுக்குவழியைத் திருத்த, \"விசை அழுத்தலை அனுப்பு\" செயல்பாட்டைத் தேர்வு "
-"செய்து, "
-"விசைப்பலகை குறுக்குவழி பொத்தானை அழுத்தி, புதிய விசைகளை அழுத்திப் பிடிக்கவும் "
-"அல்லது "
+"ஒரு குறுக்குவழியைத் திருத்த, \"விசை அழுத்தலை அனுப்பு\" செயல்பாட்டைத் தேர்வு செய்து, "
+"விசைப்பலகை குறுக்குவழி பொத்தானை அழுத்தி, புதிய விசைகளை அழுத்திப் பிடிக்கவும் அல்லது "
 "அழிக்க பேக்ஸ்பேஸ் ஐ அழுத்தவும்."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "மூடு (_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
-msgstr ""
-"தொடு பல்கையை அளவிட திரையில் இலக்கு குறிகள் தோன்றுகையில் அவற்றை தொடவும்."
+msgstr "தொடு பல்கையை அளவிட திரையில் இலக்கு குறிகள் தோன்றுகையில் அவற்றை தொடவும்."
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "தவறான சொடுக்கல் கண்டுபிடிக்கப்பட்டது, மீள் துவக்கம்"
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "மேலே"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "மெய்நிகர் சாதனம் உருவாக்கு"
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "கீழே"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "தொடுபலகை"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "எதுவுமில்லை"
-
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "விசைதட்டலை அனுப்பு"
-
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "மானிட்டரை மாற்றுக"
-
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "திரையிலான உதவியைக் காண்பி"
-
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "வெளிப்பாடு:"
-
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr " காட்சி பாங்கு விகிதத்தை வைத்திரு (அஞ்சல்பெட்டி):"
-
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "வரை படத்திலிருந்து ஒற்றை திரைக்கு"
-
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d  %d இல் "
-
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "வரைபடத்தை காட்டு"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
-msgstr "பொத்தான்"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Wacom Tablet"
-msgstr "வாகாம் தொடுதட்டு"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
-"கிராஃபிக்ஸ் டாப்ளெட்டுகளுக்கு பொத்தான் இணைப்புகளை அமைத்து ஸ்டைலஸின் உணர்திறனை "
-"சரிசெய்யவும்"
 
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "தொடுதட்டு;வாகாம்;எழுத்தாணி;துடைப்பி;சொடுக்கி;"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "இடது கைவாகு திசைவி"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "தொடுதட்டு (அப்சொலூட்)"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "தொடுதிட்டு (ரிலேடிவ்)"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "திரைக்கு தொடர்பிணைக்கவும்"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "தொடுதட்டு முன்னுரிமைகள்"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "தோன்று விகிதம்"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "அளவிடு..."
+
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "தொடுபலகை ஏதும் கண்டுபிடிக்கப்படவில்லை"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "உங்கள் வாகாம் தொடுதட்டை சொருகவும் அல்லது சக்தியூட்டவும்."
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Bluetooth Settings"
-msgstr "ப்ளூடூத் அமைப்புகள்"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map to Monitor…"
-msgstr "திரைக்கு தொடர்பிணைக்கவும்"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map Buttons…"
-msgstr "பொத்தான்களை தொடர்பிணை…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust display resolution"
-msgstr "திரைக்காட்சி தெளிதிறனை சரிசெய்யவும்"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust mouse settings"
-msgstr "சொடுக்கி அமைப்புகளை சரிசெய்யவும்"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Tracking Mode"
-msgstr "நிலை தொடர்தல் பாங்கு"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Left-Handed Orientation"
-msgstr "இடது கைவாகு திசைவி"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-msgid "Left Ring"
-msgstr "இடது வளையம்"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "இடது வட்ட பாங்கு #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-msgid "Right Ring"
-msgstr "வலது வளையம்"
-
-#: ../panels/wacom/gsd-wacom-device.c:1104
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "வலது வட்ட பாங்கு #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-msgid "Left Touchstrip"
-msgstr "இடது தொடுபட்டை"
-
-#: ../panels/wacom/gsd-wacom-device.c:1157
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "இடது தொடுபட்டை பாங்கு #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-msgid "Right Touchstrip"
-msgstr "வலது தொடுபட்டை"
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "வலது தொடு பட்டை பாங்கு #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1214
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "இடது தொடு வட்ட பாங்கு மாற்றி "
-
-#: ../panels/wacom/gsd-wacom-device.c:1216
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "வலது தொடு வட்ட பாங்கு மாற்றி "
-
-#: ../panels/wacom/gsd-wacom-device.c:1219
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "இடது தொடு பட்டை பாங்கு மாற்றி "
-
-#: ../panels/wacom/gsd-wacom-device.c:1221
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "வலது தொடு பட்டை பாங்கு மாற்றி "
-
-#: ../panels/wacom/gsd-wacom-device.c:1226
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "பாங்கு மாற்றி #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1334
-#, c-format
-msgid "Left Button #%d"
-msgstr "இடது பொத்தான் #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1337
-#, c-format
-msgid "Right Button #%d"
-msgstr "வலது பொத்தான் #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1340
-#, c-format
-msgid "Top Button #%d"
-msgstr "மேல் பொத்தான் #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1343
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "கீழ் பொத்தான் #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "புதிய குறுவழி…"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "செயல் இல்லை"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "இடது சொடுக்கி பொத்தான் சொடுக்கு"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "நடு சொடுக்கி பொத்தான் சொடுக்கு"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "வலது சொடுக்கி பொத்தான் சொடுக்கு"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "மேல் உருளல்"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "கீழ் உருளல்"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "இடது உருளல்"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "வலது உருளல்"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "பின்"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "அனுப்பு"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "எழுத்தாணி"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "அழிப்பி அழுத்த உணர்வு"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "மென்மையான"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "உறுதியான"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "மேல் பொத்தான்"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "கீழ் பொத்தான்"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "நுனி அழுத்த உணர்வு"
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "வெர்போஸ் பாங்கை செயல்படுத்து"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "மென்மையான"
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "மேல்காணலை காட்டுக"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "சரத்தைத் தேடு"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "சாத்தியமுள்ள பலக பெயர்களைப் பட்டியலிட்டுவிட்டு வெளியேறு"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "உதவி விருப்பங்களை காட்டு"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "காட்ட பலகம்"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- அமைப்புகள்"
-
-#: ../shell/cc-application.c:163
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-"%s\n"
-"'%s --help´ ஒரு முழு பட்டியலில் இருக்கும் கட்டளை வரி விருப்பங்களை காண.\n"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "கிடைக்கும் பலகங்கள்:"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "உறுதியான"
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "உதவி"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "பொத்தான்"
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "வெளியேறு"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "பொத்தான்"
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "பொத்தான்"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "அழிப்பி அழுத்த உணர்வு"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "அழிப்பி அழுத்த உணர்வு"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "நடு சொடுக்கி பொத்தான் சொடுக்கு"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "வலது சொடுக்கி பொத்தான் சொடுக்கு"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "அனுப்பு"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "வாகாம் தொடுதட்டு"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"கிராஃபிக்ஸ் டாப்ளெட்டுகளுக்கு பொத்தான் இணைப்புகளை அமைத்து ஸ்டைலஸின் உணர்திறனை சரிசெய்யவும்"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "தொடுதட்டு;வாகாம்;எழுத்தாணி;துடைப்பி;சொடுக்கி;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "இட அமைவு"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "தாய் சாளரம்"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "பாவிக்கப்பட்ட இரண்டாம் நிலை சொடுக்கம்"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "சாளரங்கள்"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "அச்சுப்பொடி குறைவாக உள்ளது"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "இரண்டாம் நிலை"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "சாளரங்கள்"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "அணுகல் விருப்பங்கள்"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "சேர்க்க"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "சேமி (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "விவரங்கள்"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_N பிணைய நேரம்"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "பிணைய அமைவுகள்"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "எண்கள்"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "சாதன வகைகள்"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "உற்பத்தியாளர்"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "தள நிரல் காணவில்லை"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "பூட்டப்பட்டது"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "மொபைல் பிராட்பேண்டு (_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_N பிணைய நேரம்"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "பிணையம்"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "மேம்பட்ட"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "அணுகல் விருப்பங்கள்"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "பூட்டு"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "விவரங்கள்"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "பிணைய பெயர்"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "தானியங்கு"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "என் இல்ல பிணையம்"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "என் இல்ல பிணையம்"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "ப்ளூடூத் தகைவிகள் ஏதும் காணப்படவில்லை"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "_p விமானப்பாங்கு"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "இணைப்பு"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "சிம் கார்ட் சொருகப்படவில்லை"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "பூட்டு"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "_a மாற்று"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "என் இல்ல பிணையம்"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "புதிய இயக்கியை அமைக்கிறது..."
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "தனியுரிமை"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "எல்லா அமைப்புகளும்"
 
-#. Add categories
-#: ../shell/cc-window.c:876
-msgctxt "category"
-msgid "Personal"
-msgstr "தனிப்பட்டவை"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "முதன்மை"
 
-#: ../shell/cc-window.c:877
-msgctxt "category"
-msgid "Hardware"
-msgstr "வன்பொருள்"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:878
-msgctxt "category"
-msgid "System"
-msgstr "கணினி"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "உதவி"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "பொது"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "வெளியேறு"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "தேடு"
+
+#: shell/help-overlay.ui:35
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "பலக சின்னம்"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "முந்தைய மூலத்துக்கு மாற்றவும்"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "ரத்து செய்யப்பட்டது"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
-#~ msgid "Flickr"
-#~ msgstr "மினுமினு"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u வெளிப்பாடு"
+msgstr[1] "%u வெளிப்பாடுகள்"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u உள்ளீடு"
+msgstr[1] "%u உள்ளீடுகள்"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "நாள் முழுதும் மாறும்"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "ஓடுகளாக்க பரப்பு"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "அணுகிப்பார்"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "மையம்"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "நிரப்பு"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "வீச்சு"
+
+#~ msgid "Colors"
+#~ msgstr "வண்ணங்கள்"
+
+#~ msgid "Select Background"
+#~ msgstr "பின்னணியை தேர்ந்தெடு"
+
+#~ msgid "Pictures"
+#~ msgstr "படங்கள் "
+
+#~ msgid "Home"
+#~ msgstr "இல்லம்"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "உங்கள் %s கோப்புறையில் நீங்கள் படங்களைச் சேர்க்கலாம், அவை இங்கு காண்பிக்கப்படும்"
+
+#~ msgid "multiple sizes"
+#~ msgstr "பல அளவுகள்"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "பணிமேடை பின்னணி எதுவுமில்லை"
+
+#~ msgid "Current background"
+#~ msgstr "நடப்பு பின்னணி"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "சுவர்-காகிதங்கள் ;திரை;மேல்மேசை;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "உங்கள் அளவைவகுத்தல் சாதனத்தை சதுரத்தின் மீது வைத்து 'தொடங்கு' என்பதை அழுத்தவும்"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr ""
+#~ "உங்கள் அளவைவகுத்தல் சாதனத்தை அளவைவகுத்தல் இடநிலைக்கு நகர்த்தி 'தொடரு' என்பதை அழுத்தவும்"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr ""
+#~ "உங்கள் அளவைவகுத்தல் சாதனத்தை மேற்பரப்பு இடநிலைக்கு நகர்த்தி 'தொடரு' என்பதை அழுத்தவும்"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "மடிக்கணினி மூடியை மூடவும்"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "சரிசெய்ய முடியாத ஒரு உள்ளமை பிழை நேர்ந்தது."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "அளவைவகுத்தலைச் செய்வதற்குத் தேவையான கருவிகள் நிறுவப்படவில்லை."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "சுயவிவரத்தை உருவாக்க முடியவில்லை."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "இலக்கு வெண்புள்ளி அடையக்கூடியதாக இல்லை."
+
+#~ msgid "Complete!"
+#~ msgstr "முடிந்தது!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "அளவைவகுத்தல் தோல்வி!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "அளவைவகுத்தல் சாதனத்தை அகற்றலாம்."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "செயலில் இருக்கும் போது அளவைவகுத்தல் சாதனத்தைத் தொந்தரவு செய்ய வேண்டாம்"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "மடிக்கணினி திரை"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s மானிட்டர்"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s ஸ்கேனர்"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s அச்சுப்பொறி"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s வெப்கேம்"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s க்கு நிற மேலாண்மையை செயல்படுத்தவும்"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s க்கு நிற சுயவிவரங்களைக் காண்பி"
+
+#~ msgid "Not calibrated"
+#~ msgstr "அளவைவகுக்கப்படவில்லை"
+
+#~ msgid "Default: "
+#~ msgstr "முன்னிருப்பு:"
+
+#~ msgid "Test profile: "
+#~ msgstr "சோதனை வரிவுரு:"
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ஐசிசி வரிவுரு கோப்பை  தேர்ந்தெடு."
+
+#~ msgid "_Import"
+#~ msgstr "இறக்குமதி (_I)"
+
+#~ msgid "All files"
+#~ msgstr "எல்லா கோப்புகள்"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "கோப்பைப் பதிவேற்றுவதில் தோல்வியடைந்தது: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "சுயவிவரம் இங்கு பதிவேற்றப்பட்டது:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "இந்த URL ஐ எழுதிக்கொள்ளவும்."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "இந்த கணினியை மறுதொடக்கம் செய்து உங்கள் வழக்கமான இயக்க முறைமையை பூட் செய்யவும்."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "சுயவிவரத்தைப் பதிவிறக்க இந்த URL ஐ உங்கள் உலாவியில் தட்டச்சு செய்து, சுயவிவரத்தை "
+#~ "நிறுவவும்."
+
+#~ msgid "Save Profile"
+#~ msgstr "சுயவிவரத்தைச் சேமி"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "தேர்ந்தெடுக்கப்பட்ட சாதனத்திற்கு வண்ன வரியுரு அமை:"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "அளவீட்டு கருவி காணவில்லை. அது இயக்கப்பட்டுள்ளது, சரியாக பொருத்தப்பட்டுள்ளது என உறுதி "
+#~ "செய்து கொள்க."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "அளவீட்டு கருவி அச்சுப்பொறி வருவுருவாக்கத்தை ஆதரிக்கவில்லை."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "இந்த சாதன வகைக்கு இப்போது ஆதரவில்லை."
+
+#~ msgid "Standard Space"
+#~ msgstr "தரநிலையான இடம்"
+
+#~ msgid "Test Profile"
+#~ msgstr "சோதனை சுயவிவரம்:"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "தானியங்கு"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "குறைந்த தரம்"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "நடுநிலைத் தரம்"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "உயர் தரம்"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "முன்னிருப்பு ஆர்ஜிபி"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "முன்னிருப்பு சிஎம்ஒய்கே"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "முன்னிருப்பு சாம்பல்"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "விற்பனையாளர் வழங்கிய தொழிற்சாலை அளவைவகுத்தல் தரவு"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "இந்த சுயவிவரத்தில் முழுத்திரை காட்சி திருத்தம் செய்ய முடியாது"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "இந்த சுயவிவரம் இப்போது துல்லியமாக இல்லாமால் இருக்கலாம்"
+
+#~ msgid "Done"
+#~ msgstr "முடிந்தது"
+
+#~ msgid "Upload profile"
+#~ msgstr "சுயவிவரத்தைப் பதிவேற்று"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "இணைய இணைப்பு தேவை"
+
+#~ msgid "United States"
+#~ msgstr "யுனைடட் ஸ்டேட்ஸ் "
+
+#~ msgid "Germany"
+#~ msgstr "ஜெர்மனி "
+
+#~ msgid "France"
+#~ msgstr "ப்ரான்ஸ்"
+
+#~ msgid "Spain"
+#~ msgstr "ஸ்பெய்ன் "
+
+#~ msgid "China"
+#~ msgstr "சைனா"
+
+#~ msgid "Other…"
+#~ msgstr "மற்றவை…"
+
+#~ msgid "Language"
+#~ msgstr "மொழி"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~| msgctxt "login date-time"
+#~| msgid "%s, %s"
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "நேர மண்டலம் (_Z)"
+
+#~ msgid "24-hour"
+#~ msgstr "24-மணி"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "Lid Closed"
+#~ msgstr "மூடி மூடப்பட்டது"
+
+#~ msgid "Mirrored"
+#~ msgstr "பிரதிபலிப்பு"
+
+#~ msgid "Off"
+#~ msgstr "ஆஃப்"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "சேர்க்கை திரைகாட்டிகளை அடுக்கு"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "திரைகாட்டிகளின் வரிசையை மாற்ற அவற்றை இழுக்கவும்"
+
+#~ msgid "Size"
+#~ msgstr "அளவு"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "இந்த திரைகாட்டியில் மேல் பட்டியையும் செயல்பாடுகள் மேலோட்டத்தையும் காண்பி"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "இந்தத் திரைகாட்டியை மற்றொன்றுடன் இணைத்து கூடுதல் பணியிடத்தை உருவாக்கலாம்"
+
+#~ msgid "Presentation"
+#~ msgstr "விளக்கக்காட்சி"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "ஸ்லைடுகாட்சிகளையும் ஊடகங்களையும் மட்டும் காண்பி"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "இரண்டு திரைகாட்டிகளிலும் தற்போதுள்ள உங்கள் காட்சிவகையைக் காண்பிக்கவும்"
+
+#~ msgid "Turn Off"
+#~ msgstr "அணை"
+
+#~ msgid "Don't use this display"
+#~ msgstr "இந்தத் திரைகாட்டியைப் பயன்படுத்த வேண்டாம்"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "திரை தகவலை பெற முடியவில்லை"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "சேர்க்கை திரைகாட்டிகளை அடுக்கு (_A)"
+
+#~ msgid "Wayland"
+#~ msgstr "வேலேன்ட்"
+
+#~ msgid "Unknown"
+#~ msgstr "தெரியாத"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-பிட்"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-பிட்"
+
+#~ msgid "Ask what to do"
+#~ msgstr "என்ன செய்ய என்று கேள் "
+
+#~ msgid "Do nothing"
+#~ msgstr "ஒன்றும் செய்யாதே"
+
+#~ msgid "Open folder"
+#~ msgstr "அடைவினை திற"
+
+#~ msgid "Other Media"
+#~ msgstr " மற்ற ஊடகம்"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ஒலி குறுந்தட்டுகளுக்கு  நிரலைத் தெரிவுசெய்யவும்"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "விடியோ டிவிடி களுக்கு நிரலைத் தெரிவுசெய்யவும்"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "இசைப்பியை இணைத்தபோது துவக்க நிரலை தேர்ந்தெடுக்கவும்."
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "காமிராவை இணைத்தபோது துவக்க நிரலை தேர்ந்தெடுக்கவும்."
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "மென்பொருள் குறுந்தட்டுகளுக்கு நிரலைத் தெரிவுசெய்யவும்"
+
+#~ msgid "audio DVD"
+#~ msgstr "ஒலி டிவிடி"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "வெற்று ப்ளூ-ரே வட்டு"
+
+#~ msgid "blank CD disc"
+#~ msgstr "வெற்று குறுந்தட்டு வட்டு"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "வெற்று டிவிடி வட்டு"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "வெற்று ஹெச்டி டிவிடி வட்டு"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "ப்ளூ-ரே விடியோ வட்டு"
+
+#~ msgid "e-book reader"
+#~ msgstr "மின் புத்தக படிப்பி"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "ஹெச்டி டிவிடி விடியோ வட்டு"
+
+#~ msgid "Picture CD"
+#~ msgstr "படங்கள் குறுந்தட்டு"
+
+#~ msgid "Super Video CD"
+#~ msgstr "சூப்பர் விடியோ குறுந்தட்டு"
+
+#~ msgid "Video CD"
+#~ msgstr "வீடியோ குறுவட்டு"
+
+#~ msgid "Overview"
+#~ msgstr "மேலோட்டம்"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "பதிப்பு %s"
+
+#~ msgid "Base system"
+#~ msgstr "அடிப்படைக் கணினி"
+
+#~ msgid "Disk"
+#~ msgstr "வட்டு"
+
+#~| msgid "Checking for Updates"
+#~ msgid "Check for updates"
+#~ msgstr "புதுப்பிப்புகள் உள்ளதா எனப் பார்"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "ஒரு திரைவெட்டை $PICTURES க்கு சேமிக்கவும்"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "ஒரு சாரளத்தின்  திரைவெட்டினை $PICTURES க்கு சேமிக்கவும்"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "ஒரு பகுதியின் திரைவெட்டை $PICTURES க்கு சேமிக்கவும்"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "திரைவெட்டை ஒட்டுப்பலகைக்கு நகல் எடுக்கவும்."
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "ஒரு சாரளத்தின் திரைவெட்டை ஒட்டுப்பலகைக்கு நகல் எடுக்கவும்."
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "ஒரு இடத்தின் திரைவெட்டை ஒட்டுப்பலகைக்கு நகல் எடுக்கவும்."
+
+#~ msgid "Record a short screencast"
+#~ msgstr "ஒரு சிறிய திரைக்காட்சியைப் பதிவு செய்"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "மாற்றிகள்-அடுத்த மூலத்திற்கு மட்டும் மாற்றவும்"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "சுருக்குவழி;மீண்டும்நிகழ்த்து;கண்ணிமை;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "தனிப்பயன் குறுக்குவழி"
+
+#~ msgid "_Delay:"
+#~ msgstr "(_D) தாமதம்:"
+
+#~ msgid "_Speed:"
+#~ msgstr "(_S) வேகம்:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "குறுகிய"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "மெதுவாக"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "நீண்ட"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "வேகமான"
+
+#~ msgid "S_peed:"
+#~ msgstr "(_p) வேகம்:"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "குறுக்கு வழியை நீக்கு"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "குறுவழியை திருத்த பொருத்தமான வரியில் சொடுக்கு.  மற்றும் புதிய விசைகளை உள்ளிடு "
+#~ "அல்லது  துப்புரவாக்க பின்னோக்கு  விசையை அழுத்துக ."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<தெரியாத செயல்>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "புதிய குறுக்குவழி \"%s\" யை பயன்படுத்த முடியாது. ஏனெனில் இந்த விசையை "
+#~ "வைத்துக்கொண்டு தட்டச்ச முடியாது.\n"
+#~ "அதே நேரத்தில் கன்ட்ரோல், ஆல்ட் அல்லது ஷிப்ட் விசைகளை பயன்படுத்தி முயற்சிக்கவும்."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr "குறுவழி \"%s\"ஏற்கெனவே \"%s\"க்கு பயன்பட்டது "
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr " \"%s\" க்கு குறுவழியாக மாற்றி அமைத்தால்  \"%s\" குறுவழி  முடங்கிவிடும்."
+
+#~ msgid "_Reassign"
+#~ msgstr "(_R) மறுஇருத்து "
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" குறுக்குவழியுடன் \"%s\" எனும் குறுக்குவழி இணைந்துள்ளது. அதை தானாகவே "
+#~ "\"%s\" க்கு அமைக்க வேண்டுமா?"
+
+#, c-format
+#~| msgid ""
+#~| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~| "disabled."
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "தற்போது \"%s\" ஆனது \"%s\" உடன் இணைந்துள்ளது, நீங்கள் தொடர்ந்தால் இந்தக் குறுக்குவழி "
+#~ "முடக்கப்படும்."
+
+#~| msgid "_Reassign"
+#~ msgid "_Assign"
+#~ msgstr "அமை (_A)"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "உங்கள் அமைவுகளை சோதிக்கவும்"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "மெதுவாக"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "இரட்டை சொடுக்கு நேரம் முடிந்தது"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "வேகமாக"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "இடது (_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "வலது (_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_P இட சுட்டி வேகம்"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "மெதுவாக"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "வேகமாக"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "மெதுவாக"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "வேகமாக"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "(_f) இரு விரல்கள் உருளல்"
+
+#~ msgid "_Natural scrolling"
+#~ msgstr "இயல்பான உருளல் (_N)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "ஐந்து கிளிக்குகள், GEGL நேரம்!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "இரட்டை சொடுக்கு, முதன்மை பொத்தான்"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "ஒற்றை சொடுக்கு, முதன்மை பொத்தான்"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "இரட்டை சொடுக்கு, நடு பொத்தான்"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "ஒற்றை சொடுக்கு, நடு பொத்தான்"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "இரட்டை சொடுக்கு, இரண்டாம் பொத்தான்"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "ஒற்றை சொடுக்கு, இரண்டாம் பொத்தான்"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "இந்த பதிப்புடன் கணினி வலைப்பின்னல் சேவைகள் இசையவில்லை"
+
+#~ msgid "page 1"
+#~ msgstr "பக்கம் 1"
+
+#~ msgid "page 2"
+#~ msgstr "பக்கம் 2"
+
+#~ msgid "automatic"
+#~ msgstr "தானியங்கு"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "என்டர்ப்ரைஸ்"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "ஏதுமில்லை"
+
+#~ msgid "Never"
+#~ msgstr "ஒரு போதும் இல்லை"
+
+#~ msgid "Today"
+#~ msgstr "இன்று"
+
+#~ msgid "Yesterday"
+#~ msgstr "நேற்று"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "ஏதுமில்லை"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "வலுவற்றது"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "சரி"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "நன்று"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "மிக நன்று"
+
+#~ msgid "Identity"
+#~ msgstr "அடையாளம்"
+
+#~ msgid "Server"
+#~ msgstr "சேவையகம்"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS சேவையகத்தை அழி"
+
+#~ msgid "Delete Route"
+#~ msgstr "பாதையை அழிக்கவும்"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "எதுவுமில்லை"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-பிட் விசை (ஹெக்ஸ் அல்லது ஆஸ்கி)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-பிட் கடவுச்சொல்"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "மாறும் WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 தனிப்பட்ட"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 கடவுச்சொல்"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "திருப்பிய ஜோடி (டிபி)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "இணைப்பு பொருள் இடைமுகம் (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "பிஎன்சி (BNC)"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "ஊடக சார்பில்லா இடைமுகம் (எம்ஐஐ)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "மற்ற பயனர்களுக்கும் கிடைக்கும்படி அமை (_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "ஃபயர்வால் மண்டலம் (_Z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "முன்னிருப்பு"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "மண்டலம் இணைப்பின் நம்பகத்தின் அளவை வரையறுக்கிறது"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "இணைப்புத் திருத்தியைத் திறக்க முடியவில்லை"
+
+#~ msgid "New Profile"
+#~ msgstr "புதிய சுயவிவரம்"
+
+#~ msgid "Bond"
+#~ msgstr "பிணைப்பு"
+
+#~ msgid "Team"
+#~ msgstr "அணி"
+
+#~ msgid "Bridge"
+#~ msgstr "பிரிட்ஜ்"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN செருகுநிரல்களை ஏற்ற முடியவில்லை"
+
+#~ msgid "Import from file…"
+#~ msgstr "கோப்பிலிருந்து இறக்கவும்…"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "பிணைய இணைப்பைச் சேர்"
+
+#~ msgid "_Reset"
+#~ msgstr "மீட்டமை (_R)"
+
+#~ msgid "_Forget"
+#~ msgstr "மற (_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "இந்தப் பிணையத்திற்கான கடவுச்சொற்கள் உள்ளிட்ட அமைப்புகளை மீட்டமைக்கவும், ஆனால் இதை "
+#~ "விரும்பும் பிணையமாக நினைவில் கொள்ளவும்"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "இந்தப் பிணையம் தொடர்பான அனைத்து விவரங்களையும் அகற்றவும், மேலும்  தானாக இணைக்க "
+#~ "முயற்சிக்க வேண்டாம்"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN இணைப்பை இறக்க முடியவில்லை"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "கோப்பு '%s'ஐ வாசிக்க முடியவில்லை அல்லது அங்கீகரிக்கப்பட்ட VPN இணைப்புத் தகவலை "
+#~ "பெற்றிருக்கவில்லை \n"
+#~ "\n"
+#~ "பிழை: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "இறக்க கோப்பை தேர்ந்தெடுக்கவும்"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "\"%s\" என பெயரிடப்பட்ட கோப்பு ஏற்கனவே உள்ளது."
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "VPN இணைப்புடன் %s ஐ இடமாற்ற நீங்கள் விரும்புகிறீர்களா?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN இணைப்பை ஏற்ற முடியவல்லை"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN இணைப்பு '%s' ஆனது %sஐ ஏற்றுமதி செய்ய முடியாது.\n"
+#~ "\n"
+#~ "பிழை: %s."
+
+#~| msgid "Export VPN connection..."
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN இணைப்பை ஏற்றுமதிசெய்"
+
+#~ msgid "Bond slaves"
+#~ msgstr "பிணைப்பு அடிமைகள்"
+
+#~ msgid "(none)"
+#~ msgstr "(எதுவுமில்லை)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "பிரிட்ஜ் அடிமைகள்"
+
+#~ msgid "never"
+#~ msgstr "ஒரு போதும் இல்லை"
+
+#~ msgid "today"
+#~ msgstr "இன்று"
+
+#~ msgid "yesterday"
+#~ msgstr "நேற்று"
+
+#~ msgid "Last used"
+#~ msgstr "கடைசியில் பயன்படுத்தப்பட்டது"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "சுயவிவரம் %d"
+
+#~ msgid "Team slaves"
+#~ msgstr "அணி அடிமைகள்"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "உங்களிடம் வயர்லெஸ் அல்லாத ஒரு இணைய இணைப்பு இருந்தால், இணைப்பை மற்றவர்களிடம் "
+#~ "பகிர்ந்துகொள்ள நீங்கள் ஒரு வயர்லெஸ் ஹாட்ஸ்பாட்டை அமைத்துப் பயன்படுத்தலாம்."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "கம்பியில்லா வட்டத்துக்கு மாறுவது <b>%s</b> யிலிருந்ஹ்டு உங்களை துண்டிக்கும்."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "கம்பியில்லா வட்டம் செயலில் இருப்பின் உங்களது கம்பியில்லா இணைப்பு மூலம் நீங்கள் பிணையத்தை "
+#~ "அணுக இயலாது."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "செயலிடத்தை நிறுத்தி பயனர்களை இணைப்பு நீக்கவா?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_S செயலிடத்தை நிறுத்து"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "ஹாட்ஸ்பாட்டாக பயன்படுத்துவதை கணினி கொள்கை தடைசெய்கிறது"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "வயர்லெஸ் சாதனம் ஹாட்ஸ்பாட் பயன்முறையை ஆதரிக்கவில்லை"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "தேர்ந்தெடுக்கப்பட்ட பிணையங்களின் கடவுச்சொற்கள் மற்றும் தனிப்பயன் அமைவாக்கங்கள் உட்பட அனைத்து "
+#~ "விவரங்களும் இழக்கப்படும்."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "மற (_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "வலை பதிலாள் தானியங்கி காணல் வடிவமைப்பு, யூஆர்எல் இல்லாத போது பயன்படும்."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "நம்பகமில்லாத பொது வலைப்பின்னல்களுக்கு இதை பரிந்துரைக்கவில்லை"
+
+#~ msgid "Proxy"
+#~ msgstr "பதிலாள்"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "எதுவுமில்லை"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "கைமுறை"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "தானியங்கி"
+
+#~ msgid "Add Device"
+#~ msgstr "சாதனத்தை சேர் "
+
+#~ msgid "VPN Type"
+#~ msgstr "விபிஎன் வகை"
+
+#~ msgid "Group Name"
+#~ msgstr "குழு பெயர்"
+
+#~ msgid "Group Password"
+#~ msgstr "குழு கடவுச்சொல்"
+
+#~ msgid "details"
+#~ msgstr "விவரங்கள்"
+
+#~ msgid "Show P_assword"
+#~ msgstr "கடவுச்சொல்லை காட்டு (_a)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "மற்ற பயனர்களுக்குக் கிடைக்கும்படி செய்"
+
+#~ msgid "identity"
+#~ msgstr "அடையாளம்"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "தானியக்கி (DHCP) முகவரிகள் மட்டுமே "
+
+#~ msgid "Link-local only"
+#~ msgstr "இணைப்பு-உள்ளமை மட்டும்"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "தானாக பெற்ற பாதைகளைப் புறக்கணி (_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "க்ளோன் செய்யப்பட்ட MAC முகவரி (_C)"
+
+#~ msgid "hardware"
+#~ msgstr "வன்பொருள்"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "இந்த இணைப்புக்கான அமைவுகளை அவற்றின் முன்னிருப்பு அமைப்புக்கு மீட்டமை, ஆனால் இதை "
+#~ "விரும்பும் இணைப்பாக நினைவில் கொள்."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "இந்தப் பிணையம் தொடர்பான அனைத்து விவரங்களையும் அகற்றவும், மேலும்  தானாக இதற்கு இணைக்க "
+#~ "முயற்சிக்க வேண்டாம்."
+
+#~ msgid "reset"
+#~ msgstr "மீட்டமை"
+
+#~ msgid "Hardware"
+#~ msgstr "வன்பொருள்"
+
+#~ msgid "_History"
+#~ msgstr "வரலாறு (_H)"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "வயர்லெஸ் பிணையத்துடன் இணைப்பதற்கு ஸ்விட்ச் ஆஃப் செய்யவும்"
+
+#~ msgid "Connected Devices"
+#~ msgstr "இணைக்கப்பட்ட சாதனங்கள்"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "தற்காலிக"
+
+#~ msgid "Infrastructure"
+#~ msgstr "கட்டுமானம்"
+
+#~ msgid "Status unknown"
+#~ msgstr "தெரியாத நிலை"
+
+#~ msgid "Unmanaged"
+#~ msgstr "மேலாண்மை இல்லாத"
+
+#~ msgid "Unavailable"
+#~ msgstr "இருப்பில் இல்லை"
+
+#~ msgid "Connecting"
+#~ msgstr "இணைக்கிறது..."
+
+#~ msgid "Disconnecting"
+#~ msgstr "துண்டிக்கப்படுகிறது..."
+
+#~ msgid "Connection failed"
+#~ msgstr "இணைப்பு தோல்வியுற்றது"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "நிலை தெரியவில்லை (காணவில்லை)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "வடிவமைப்பு தோல்வியுற்றது"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "ஐபி வடிவமைப்பு தொல்வியுற்றது"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "ஐபி வடிவமைப்பு காலாவதியாயிற்று"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "ரகசியங்கள் தேவையாயிருந்தன, ஆனால் தரப்படவில்லை"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x சப்ளிகன்ட் துண்டிக்கபட்டது"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x சப்ளிகன்ட் வடிவமைப்பு தோல்வி"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x சப்ளிகன்ட் தோல்வி"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x சப்ளிகன்ட் உறுதிசெய்ய வெகு நேரம் எடுத்துக்கொண்டது"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "பிபிபி சேவை துவக்கம் தோல்வி"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "பிபிபி சேவை துண்டிக்கபட்டது"
+
+#~ msgid "PPP failed"
+#~ msgstr "பிபிபி தோல்வியுற்றது"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "டிஹெச்சிபி சார்ந்தோன் துவக்கம் தோல்வி"
+
+#~ msgid "DHCP client error"
+#~ msgstr "(டிஹெச்சிபி) DHCP சார்ந்தோன் பிழை"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "(டிஹெச்சிபி) DHCP சார்ந்தோன் தோல்வி"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "பகிர்ந்த இணைப்பு சேவை துவக்க தோல்வி"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "பகிர்ந்த இணைப்பு சேவை தோல்வியுற்றது"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "ஆட்டோஐபி சேவை துவக்கம் தோல்வி"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "ஆட்டோஐபி சேவை துவக்கம் பிழை"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "ஆட்டோஐபி சேவை தோல்வி"
+
+#~ msgid "Line busy"
+#~ msgstr "தடம் பயன்பாட்டில்"
+
+#~ msgid "No dial tone"
+#~ msgstr "டயல் ஒலி இல்லை"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "கடத்தி ஏதும் செயலாக்க முடியவில்லை"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "டயல் செய்யும் நேரம் கடந்தது"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "டயல் செய்யும் முயற்சி தோல்வி"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "மோடம் துவக்கம் தோல்வி"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "குறிப்பிட்ட ஏபிஎன் ஐ தேர்ந்தெடுத்தல் தோல்வி"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "வலையமைப்புகளை தேடவில்லை"
+
+#~ msgid "Network registration denied"
+#~ msgstr "வலையமைப்பு பதிவுசெய்தல் மறுக்கப்பட்டது"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "வலையமைப்பு பதிவுசெய்தல் நேரம் கடந்தது"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "வேண்டிய வலையமைப்பு பதிவுசெய்தல் தோல்வி"
+
+#~ msgid "PIN check failed"
+#~ msgstr "பின்(PIN) சோதனை தோல்வி"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "சாதனத்தின் வர்த்தக மென்பொருள் காணவில்லை போலும்"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "இணைப்பு காணாமல் போயிற்று"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "இருப்பிலுள்ள இணைப்பு இருப்பதாக கொள்ளப்பட்டது"
+
+#~ msgid "Modem not found"
+#~ msgstr "மோடம் காணப்படவில்லை"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "ப்ளூடூத் இணைப்பு தோல்வியுற்றது"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "சிம் பின் தேவை"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "சிம் பியூகே தேவை"
+
+#~ msgid "SIM wrong"
+#~ msgstr "சிம் தவறானது"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "இன்பினிபேன்ட் சாதனம் இணைப்பு பாங்கை ஆதரிக்கவில்லை"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "இணைப்பு  சார்பு தோல்வியுற்றது"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "இணைப்பு துண்டிக்கப்பட்டது"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "அங்கீகார சான்றிதழ் தேர்ந்தெடுக்கப்படவில்லை"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "ஓரு சான்றிதழ் அங்கீகார (CA) சான்றிதழைப் பயன்படுத்தாவிட்டால், Wi-Fi பிணையங்கள் "
+#~ "பாதுகாப்பற்றதாகவும் நம்பகமற்றதாகவும் விளங்கலாம்.  ஓரு சான்றிதழ் அங்கீகார (CA) "
+#~ "சான்றிதழைத் தேர்வு செய்ய வேண்டுமா?"
+
+#~ msgid "Ignore"
+#~ msgstr "புறக்கணி"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA சான்றிதழை தேர்ந்தெடுக்கவும்"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, or PKCS#12 தனிப்பட்ட விசைகள் (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER அல்லது PEM சான்றிதழ்கள் (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC கோப்புகள் (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "ஒவ்வொரு முறையும் இந்த கடவுச்சொல்லைக் கேட்கவும் (_k)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "மறைகுறியாக்கப்படாத தனிபட்ட விசைகள் பாதுகாப்பில்லாதது"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "தேர்ந்தெடுக்கப்பட்ட தனிப்பட்ட விசையானது கடவுச்சொல்லால் பாதுகாக்கப்படாதது எனத் "
+#~ "தோன்றுகிறது.  இதனால் பாதுகாப்பு சான்றளிப்பு உத்தரவாதமானதாக இல்லாமல் போகக்கூடும்.  "
+#~ "கடவுச்சொல்லால் பாதுகாக்கப்பட்ட ஒரு தனிப்பட்ட விசையைத் தேர்ந்தெடுக்கவும்.\n"
+#~ "\n"
+#~ "(openssl ஐக் கொண்டு நீங்கள் உங்கள் தனிப்பட்ட விசையை கடவுச்சொல்லால் பாதுகாக்கப்பட்டதாக "
+#~ "மாற்றலாம்)"
+
+#~| msgid "Choose your personal certificate..."
+#~ msgid "Choose your personal certificate"
+#~ msgstr "உங்கள் தனிப்பட்ட சான்றிதழைத் தேர்ந்தெடுக்கவும்"
+
+#~| msgid "Choose your private key..."
+#~ msgid "Choose your private key"
+#~ msgstr "உங்கள் தனிப்பட்ட விசையைத் தேர்ந்தெடுக்கவும்"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "மீண்டும் எச்சரிக்காதே (_w)"
+
+#~ msgid "Yes"
+#~ msgstr "ஆம்"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "மேலெழு பதாகைகளைக் காண்பி"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "பதாகைகளில் விவரங்களைக் காட்டு"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "திரைப்பூட்டில் காண்பி"
+
+#~ msgid "On"
+#~ msgstr "ஆன்"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "மேலெழு பதாகைகளைக் காண்பி"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "திரைப்பூட்டில் காண்பி"
+
+#~ msgid "Add Account"
+#~ msgstr "கணக்கு சேர்"
+
+#~ msgid "Mail"
+#~ msgstr "மின்னஞ்சல்"
+
+#~ msgid "Contacts"
+#~ msgstr "தொடர்புகள்"
+
+#~ msgid "Chat"
+#~ msgstr "அரட்டை"
+
+#~ msgid "Resources"
+#~ msgstr "வளங்கள்"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "கணக்குக்குள் நுழைவதில் பிழை"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "சான்றளிப்புகள் காலாவதியாகிவிட்டன."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "இந்தக் கணக்கை செயல்படுத்த உள்நுழையவும்."
+
+#~ msgid "_Sign In"
+#~ msgstr "உள்நுழை (_S)"
+
+#~ msgid "Error creating account"
+#~ msgstr "கணக்கை உருவாக்குவதில் பிழை"
+
+#~ msgid "Error removing account"
+#~ msgstr "கணக்கை நீக்குவதில் பிழை"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "கணக்கை அவசியம்  நீக்க உறுதியாக உள்ளீரா?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "இது சேவையகத்தில் கணக்கை நீக்காது."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "ஆன் லைன் கணக்கு ஏதும் வடிவமைக்கப்படவில்லை"
+
+#~ msgid "Remove Account"
+#~ msgstr "கணக்கு நீக்கு"
+
+#~ msgid "Add an online account"
+#~ msgstr "ஒரு ஆன் லைன் கணக்கு சேர்"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "ஒரு கணக்கை சேர்ப்பது உங்கள் பயன்பாடுகளை அதன் ஆவணங்கள், மின்னஞ்சல், தொடர்புகள், "
+#~ "நாட்காட்டி, அரட்டை மேலும் பலவற்றை அணுக அனுமதிக்கும்."
+
+#~ msgid "Unknown time"
+#~ msgstr "தெரியாத நேரம்"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s முழுவதும் சார்ஜ் செய்யப்படும் வரை"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "எச்சரிக்கை: %s மீதமுள்ளது"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s மீதமுள்ளது"
+
+#~ msgid "Fully charged"
+#~ msgstr "முழுதும் சார்ஜ் செய்யப்பட்டது"
+
+#~ msgid "Empty"
+#~ msgstr "வெற்று"
+
+#~ msgid "Charging"
+#~ msgstr "மின் சக்தி ஏற்றம் ஆகிறது"
+
+#~ msgid "Discharging"
+#~ msgstr "சக்தி இறங்குகிறது"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "முதன்மை"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "கூடுதல்"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "கம்பியில்லா சொடுக்கி"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "கம்பியில்லா விசைப்பலகை"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "தடையில்லா மின்சாரம்"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "அந்தரங்க இரும உதவியாளர்"
+
+#~ msgid "Cellphone"
+#~ msgstr "அலைபேசி"
+
+#~ msgid "Media player"
+#~ msgstr "இசை இயக்கி"
+
+#~ msgid "Computer"
+#~ msgstr "கணினி"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "மின் சக்தி ஏற்றம் ஆகிறது"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "எச்சரிக்கை"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "குறைவான"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "நன்று"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "முழுதும் சார்ஜ் செய்யப்பட்டது"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "வெற்று"
+
+#~ msgid "Batteries"
+#~ msgstr "பேட்டரிகள்"
+
+#~ msgid "When _idle"
+#~ msgstr "செயலின்றி இருக்கும் போது (_i)"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "விசைப்பலகை பிரகாசம் (_K)"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "செயலின்றி இருக்கையில் திரையை மங்கலாக்கு (_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "வயர்லெஸ் சாதனங்களை இயக்க நிறுத்தும்"
+
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "மொபைல் பிராட்பேன்ட் (3G, 4G, WiMax போன்ற) சாதனங்களை இயக்க நிறுத்தும்"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "When on battery power"
+#~ msgstr "பேட்டரி சக்தியில் இருக்கையில்"
+
+#~ msgid "When plugged in"
+#~ msgstr "சொருகியுள்ள போது"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "இடைநிறுத்து & அணை"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "தானியங்கு இடைநிறுத்தம் (_A)"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "பேட்டரி மின்சாரம் மிகக் குறைவாகிப் போகையில் (_C)"
+
+#~ msgid "Power Off"
+#~ msgstr "மின்சக்தி நிறுத்து"
+
+#~ msgid "Hibernate"
+#~ msgstr "இடை உறக்கம்"
+
+#~ msgid "1 minute"
+#~ msgstr "1 நிமிடம்"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 நிமிடங்கள்"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 நிமிடங்கள்"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 நிமிடங்கள்"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 நிமிடங்கள்"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 நிமிடங்கள்"
+
+#~ msgid "Out of toner"
+#~ msgstr "அச்சு மைப்பொடி போதாது"
+
+#~ msgid "Low on developer"
+#~ msgstr "உருவாக்கி குறைவாக உள்ளது"
+
+#~ msgid "Out of developer"
+#~ msgstr "உருவாக்கி இல்லை"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "குறியிடுவான் கொடை குறைவாக உள்ளது"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "குறியிடுவான் கொடை இல்லை"
+
+#~ msgid "Open cover"
+#~ msgstr "மூடியை திற"
+
+#~ msgid "Open door"
+#~ msgstr "கதவை திற"
+
+#~ msgid "Low on paper"
+#~ msgstr "காகிதம் குறைவாக உள்லது"
+
+#~ msgid "Out of paper"
+#~ msgstr "தாள் வெளியே உள்ளது"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "நிறுத்தப்பட்டது"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "குப்பைக்கூடை அனேகமாக நிறைந்தது"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "குப்பைக்கூடை நிறைந்தது"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ஒளி கடத்தியின் வாழ்நாள் முடிவு நெருங்கிவிட்டது"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ஒளி கடத்தி இப்போது வேலை செய்யவில்லை"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "தயார்"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "பணிகளை ஏற்க வேண்டாம்"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "செயலாக்கம்..."
+
+#~ msgid "Toner Level"
+#~ msgstr "அச்சு மைப்பொடி மட்டம்"
+
+#~ msgid "Supply Level"
+#~ msgstr "கொடை மட்டம்"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "நிறுவப்படுகிறது"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "செயலில் %u"
+#~ msgstr[1] "செயலில் %u"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "அச்சுப்பொறியை சேர்க்க முடியவில்லை"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "போஸ்ட்ஸ்கிரிப்ட் அசுப்பொறி விவர கோப்புகள் (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "தகுந்த இயக்கி எதுவும் காணப்படவில்லை "
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "ui ஏற்ற முடியவில்லை: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "அச்சிடுவதை தொடர்க"
+
+#~ msgid "Pause Printing"
+#~ msgstr "அச்சடித்தலை தாமதி"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "புதிய அச்சுப்பொறியை சேர்"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "முடிவுகளை வடிகட்ட ஒரு அச்சுப்பொறியின் முகவரி அல்லது உரை ஒன்றை உள்ளிடவும்"
+
+#~| msgid "Remove Printer"
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect அச்சுப்பொறி"
+
+#~| msgid "%s Printer"
+#~ msgid "LPD Printer"
+#~ msgstr "LPD அச்சுப்பொறி"
+
+#~ msgid "One Sided"
+#~ msgstr "ஒரு பக்க"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "நீள விளிம்புடைய (செந்தரம்)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "குறுகிய விளிம்புடைய (புரட்டு)"
+
+#~ msgid "Portrait"
+#~ msgstr "செங்குத்து "
+
+#~ msgid "Landscape"
+#~ msgstr "கிடைமட்டம்"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "பின்திருப்பிய கிடைமட்டம்"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "பின்திருப்பிய செங்குத்து"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "நிலுவையில்"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "கிடப்பில்"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "செயலாக்கமாகிறது"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "நிறுத்தப்பட்டது"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "கைவிடப்பட்டது"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "முடிவுற்றது"
+
+#~ msgid "Job Title"
+#~ msgstr "வேலையின் தலைப்பு"
+
+#~ msgid "Job State"
+#~ msgstr "வேலை நிலை"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "வரிசை துறை"
+
+#~ msgid "Parallel Port"
+#~ msgstr "இணையான துறை"
+
+#, c-format
+#~| msgid "Location"
+#~ msgid "Location: %s"
+#~ msgstr "இடம்: %s"
+
+#, c-format
+#~| msgid "A_ddress:"
+#~ msgid "Address: %s"
+#~ msgstr "முகவரி: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "இரு பக்க"
+
+#~ msgid "Paper Type"
+#~ msgstr "காகித வகை"
+
+#~ msgid "Paper Source"
+#~ msgstr "காகித மூலம்"
+
+#~ msgid "Output Tray"
+#~ msgstr "வெளியீட்டு தட்டு"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "கோஸ்ட்ஸ்கிரிப்ட் முன் வடிகட்டல்"
+
+#~ msgid "Pages per side"
+#~ msgstr "தாள்பக்கத்துக்கு பக்கங்கள்"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "பொது"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "பக்க அமைவு"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "நிறுவக்கூடிய தேர்வுகள்"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "வேலை"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "பிம்ப தரம்"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "நிறம்"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "முடிக்கிறது"
+
+#~ msgid "Auto Select"
+#~ msgstr "தானியங்கியாக தேர்வு செய்க "
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "கோஸ்ட் ஸ்க்ரிப்ட் எழுத்துருக்களை மட்டும் உள்ளமை"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "பிஎஸ் மட்டம் 1 க்கு மாற்று"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "பிஎஸ் மட்டம் 2 க்கு மாற்று"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "முன் வடிகட்டல் இல்லை"
+
+#~ msgid "Supply"
+#~ msgstr "வழங்கு"
+
+#~| msgid "Default Route"
+#~ msgid "_Default printer"
+#~ msgstr "முன்னிருப்பு அச்சுப்பொறி (_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "வேலைகள்"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "பணிகளைக் காண்பி Show _Jobs"
+
+#~ msgid "label"
+#~ msgstr "விளக்கச்சீட்டு"
+
+#~ msgid "page 3"
+#~ msgstr "பக்கம் 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "_T சோதனை பக்கத்தை அச்சிடு"
+
+#~ msgid "_Options"
+#~ msgstr "விருப்பங்கள் (_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "புதிய அச்சுப்பொறியை சேர்"
+
+#~ msgid "Usage & History"
+#~ msgstr "பயன்பாடு & வரலாறு"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "குப்பைத் தொட்டியிலிருந்து அனைத்தையும் நீக்கி காலி செய்யவா?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "குப்பைத் தொட்டியில் உள்ளவை அனைத்தும் நிரந்தரமாக நீக்கப்படும்."
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "தற்காலிகக் கோப்புகள் அனைத்தையும் அழிக்கவா?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "தற்காலிகக் கோப்புகள் அனைத்தும் நிரந்தரமாக அழிக்கப்படும்."
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "உங்கள் தனிப்பட்ட தகவல்களைப் பாதுகாப்பாக வைத்திருந்து, மற்றவர்கள் எவற்றை மட்டும் "
+#~ "காணக்கூடும் என்பதை நீங்களே கட்டுப்படுத்துங்கள்"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "திரை அணைகிறது"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 நொடிகள்"
+
+#~ msgid "1 day"
+#~ msgstr "1 நாள்"
+
+#~ msgid "2 days"
+#~ msgstr "2 நாட்கள்"
+
+#~ msgid "3 days"
+#~ msgstr "3 நாட்கள்"
+
+#~ msgid "4 days"
+#~ msgstr "4 நாட்கள்"
+
+#~ msgid "5 days"
+#~ msgstr "5 நாட்கள்"
+
+#~ msgid "6 days"
+#~ msgstr "6 நாட்கள்"
+
+#~ msgid "7 days"
+#~ msgstr "7 நாட்கள்"
+
+#~ msgid "14 days"
+#~ msgstr "14 நாட்கள்"
+
+#~ msgid "30 days"
+#~ msgstr "30 நாட்கள்"
+
+#~ msgid "Forever"
+#~ msgstr "எப்போதும் "
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "உங்கள் வரலாற்றை நினைவில் கொள்வதால், வேண்டியவற்றை எளிதில் மீண்டும் கண்டுபிடிக்க முடியும். "
+#~ "இவை பிணையத்தின் வழியாக எப்போதும் பகிரப்படாது."
+
+#~ msgid "_Recently Used"
+#~ msgstr "சமீபத்தில் பயன்படுத்தியது (_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "வரலாற்றை வைத்திரு (_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "நீங்கள் கணினியை விட்டு விலகி இருக்கும் போது திரைப்பூட்டு உங்கள் தனியுரிமையைப் "
+#~ "பாதுகாக்கிறது."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "இவ்வளவு நேரம் வெறுமையாக இருந்த பிறகு திரையைப் பூட்டவும் (_a)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "தேவையில்லாத முக்கியத் தகவல்கள் அடைத்துக்கொண்டு இல்லாமல் உங்கள் கணினி சிறப்பாக இருக்க, "
+#~ "குப்பை தொட்டியையும் தற்காலிகக் கோப்புகளையும் தானாக அழிக்கவும்."
+
+#~ msgid "Purge _After"
+#~ msgstr "இத்தனை நாட்களுக்குப் பிறகு அழி (_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "நீங்கள் எந்த மென்பொருளைப் பயன்படுத்துகிறீர்கள் என்ற தகவலை எங்களுக்கு அனுப்பினால், "
+#~ "உங்களுக்கு இன்னும் துல்லியமான பரிந்துரைகளை வழங்க எங்களுக்கு அது உதவியாக இருக்கும். "
+#~ "அது எங்கள் மென்பொருளை மேம்படுத்தவும் உதவும்.\n"
+#~ "\n"
+#~ "நாங்கள் சேகரிக்கும் தகவல் அனைத்துமே பெயரிலாததாக்கப்படும், உங்கள் தரவை ஒரு போதும் "
+#~ "மூன்றாம் தரப்பினரிடம் பகிர மாட்டோம்."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "மென்பொருள் பயன்பாடு விவரங்களை அனுப்பு (_S)"
+
+#~| msgid "Privacy"
+#~ msgid "Privacy Policy"
+#~ msgstr "தனியுரிமைக் கொள்கை"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "உங்கள் இருப்பிடத்தைத் தீர்மானிக்க பயன்படுகிறது"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "இம்பீரியல்"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "மெட்ரிக்"
+
+#~ msgid "No input sources found"
+#~ msgstr "உள்ளீட்டு மூலங்கள் இல்லை"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "மற்றவை"
+
+#~ msgid "Sorry"
+#~ msgstr "மன்னிக்கவும்"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "அடுத்த மூலத்துக்கு மாற்றவும்"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "இந்த குறுக்குவழிகளை நீங்கள் விசைப்பலகை அமைப்புகளில் மாற்றலாம்"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "அடுத்த மூலத்திற்கு மாற்று விசை"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "இடது+வலது Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "ஆங்கிலம் (இங்கிலாந்து)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "யுனைட்டக் கிங்டம்"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "புகுபதிவு அமைப்புகள் கணினியில் புகுபதிவு செய்யும் போது அனைத்து பயனர்களாலும் "
+#~ "பயன்படுத்தப்படும்"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "மற்றவை"
+
+#~ msgid "Select Location"
+#~ msgstr "ஒரு இடத்தை தேர்ந்தெடுக்கவும்"
+
+#~ msgid "_OK"
+#~ msgstr "சரி (_O)"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "ஆன்"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "ஆஃப்"
+
+#~| msgid "Enabled"
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "செயல்படுத்தப்பட்டது"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "ஒரு கோப்புறையைத் தேர்ந்தெடுக்கவும்"
+
+#~| msgid "List of keyboard layouts selected for usage"
+#~ msgid "No networks selected for sharing"
+#~ msgstr "பகிர்வதற்கு பிணையங்கள் எதுவும் தேர்ந்தெடுக்கப்படவில்லை"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Bluetooth பகிர்வைக் கொண்டு நீங்கள் Bluetooth செயல்படுத்தப்பட்ட மற்ற சாதனங்களுடன் "
+#~ "கோப்புகளைப் பகிர்ந்து கொள்ளலாம்"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "நம்பகமான சாதனங்களிடமிருந்து மட்டும் பெறவும்"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "பெறப்படும் கோப்புகளை பதிவிறக்கங்கள் கோப்புறையில் சேமிக்கவும்"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "திரை பகிர்வு"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "பிணைய அணுகல் இல்லாததால் சில சேவைகள் முடக்கப்பட்டுள்ளன."
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "தனிப்பட்ட கோப்புப் பகிர்வைக் கொண்டு நீங்கள் இதைப் பயன்படுத்தி உங்கள் தற்போதைய "
+#~ "பிணையத்திலுள்ள மற்றவர்களுடன் உங்கள் பொதுக் கோப்புறையைப் பகிர்ந்துகொள்ள முடியும்: <a "
+#~ "href=\"dav://%s\">dav://%s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "Secure Shell கட்டளையைப் பயன்படுத்தி தொலைநிலை பயனர்கள் இணைவதற்கு அனுமதிக்கவும்:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "தொலைநிலை பயனர்கள் இதில் இணைவதன் மூலம் உங்கள் திரையை அணுகவும் கட்டுப்படுத்தவும் "
+#~ "அனுமதிக்கவும்: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~| msgid "Password"
+#~ msgid "Password:"
+#~ msgstr "கடவுச்சொல்:"
+
+#~ msgid "Show Password"
+#~ msgstr "கடவுச்சொல்லை காட்டு"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "புதிய இணைப்புகள் அணுகலைக் கோர வேண்டும்"
+
+#~| msgid "Require Password"
+#~ msgid "Require a password"
+#~ msgstr "கடவுச்சொல் தேவை"
+
+#~ msgid "Bark"
+#~ msgstr "குரைப்பு"
+
+#~ msgid "Drip"
+#~ msgstr "தண்ணீர் சொட்டு"
+
+#~ msgid "Glass"
+#~ msgstr "க்ளாஸ்"
+
+#~ msgid "Sonar"
+#~ msgstr "சோனார்"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "குறைந்தபட்சம்"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "அதிக பட்சம்"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_S சப்வூஃபர்:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "பெருக்காதது"
+
+#~ msgid "_Profile:"
+#~ msgstr "_P விவரகுறிப்பு:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_T ஒலி பெருக்கிகளை சோதி "
+
+#~ msgid "Peak detect"
+#~ msgstr "உச்சிகளை கண்டுபிடி"
+
+#~ msgid "Device"
+#~ msgstr "சாதனம்"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s க்கு ஒலி பெருக்கி சோதனை"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_h ஒலி வெளிப்பாடுக்கு சாதனத்தை தேர்ந்தெடு"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "தேர்ந்தெடுக்கப்பட்ட சாதனத்திற்கு அமைப்பு:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "(_I) உள்ளீட்டு ஒலி அளவு:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_h ஒலி உள்ளீட்டுக்கு சாதனம் தேர்ந்தெடு:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "ஒலி விளைவுகள்"
+
+#~ msgid "Built-in"
+#~ msgstr "உட்பொதியப்பட்டது"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ஒலி முன்னுரிமைகள்"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ஒலி நிகழ்வை சோதிக்கிறது"
+
+#~ msgid "From theme"
+#~ msgstr "தீமிலிருந்து"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "ஒரு விழிப்பூட்டும் ஒலியை தேர்ந்தெடு: (_h)"
+
+#~ msgid "Stop"
+#~ msgstr "நிறுத்து"
+
+#~ msgid "Custom"
+#~ msgstr "தனிப்பயன்"
+
+#~ msgid "Screen Reader"
+#~ msgstr "திரைபடிப்பான்"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "திரைபடிப்பான் (_S)"
+
+#~ msgid "Sound Keys"
+#~ msgstr "ஒலி விசைகள்"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "சாளர தலைப்புப்பட்டையை பளிச்சிடு (_W)"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "குறுகிய"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "1/4 திரை"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "1/2 திரை"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "3/4 திரை"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "நீண்டது"
+
+#~ msgid "Zoom"
+#~ msgstr "அணுகிப்பார்"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "நிறம்"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "செந்தரம்"
+
+#~ msgid "Account _Type"
+#~ msgstr "_T கணக்கு வகை"
+
+#~ msgid "_Verify"
+#~ msgstr "சரிபார் (_V)"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "தொழில் ரீதியான கணக்குகளைச் சேர்க்க\n"
+#~ "ஆன்லைனுக்குச் செல்லவும்."
+
+#~ msgid "Left thumb"
+#~ msgstr "இடது கட்டைவிரல்"
+
+#~ msgid "Left middle finger"
+#~ msgstr "இடது நடு விரல்"
+
+#~ msgid "Left ring finger"
+#~ msgstr "இடது மோதிர விரல்"
+
+#~ msgid "Left little finger"
+#~ msgstr "இடது சிறுவிரல்"
+
+#~ msgid "Right thumb"
+#~ msgstr "வலது கட்டைவிரல்"
+
+#~ msgid "Right middle finger"
+#~ msgstr "வலது நடு விரல்"
+
+#~ msgid "Right ring finger"
+#~ msgstr "வலது மோதிர விரல்"
+
+#~ msgid "Right little finger"
+#~ msgstr "வலது சிறு விரல்"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "கைரேகை புகுபதிவை செயல்படுத்து"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_R வலது சுட்டு விரல்"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_L இடது சுட்டுவிரல்"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "உங்கள் கைரேகை வெற்றிகரமாக சேமிக்கப்பட்டது. இப்போது நீங்கள் கைரேகை வாசிப்பி மூலம் "
+#~ "புகுபதிவு செய்ய முடியும்."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "உள்புகுகை;பெயர்;விரல்ரேகை;அவதாரம்;லோகோ;முகம்;கடவுச்சொல்;"
+
+#~ msgid "Login History"
+#~ msgstr "புகுபதிவு வரலாறு"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "புதிய கடவுச் சொல்லைச் சரிபார் (_V)"
+
+#~ msgid "Add User Account"
+#~ msgstr "பயனர் கணக்கு சேர்"
+
+#~ msgid "User Icon"
+#~ msgstr "பயனர் சின்னம்"
+
+#~ msgid "Last Login"
+#~ msgstr "கடந்த புகுபதிவு"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "புதிய கடவுச்சொல் பழையதிலிருந்து வேறுபட்டிருக்க வேண்டும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "சில எழுத்துகளையும் எண்களையும் மாற்றி முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "கடவுச்சொல்லை இன்னும் கொஞ்சம் மாற்ற முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "உங்கள் பயனர் பெயரைக் கொண்டில்லாத கடவுச்சொல் இன்னும் வலிமையானது."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "கடவுச்சொல்லில் உங்கள் பயனர் பெயரைப் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr ""
+#~ "சேர்க்கப்பட்டுள்ள சில சொற்களை கடவுச்சொல்லில் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "பொதுவான சொற்களைத் தவிர்க்க முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "முன்பே உள்ள சொற்களை மறுவரிசைப்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "அதிக எண்களைப் பயன்படுத்த முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "அதிக பெரிய எழுத்துகளைப் பயன்படுத்த முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "அதிக சிறிய எழுத்துகளைப் பயன்படுத்த முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "நிறுத்தக் குறிகள் போன்ற சிறப்பு எழுத்துகளை அதிகம் பயன்படுத்த முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "எண்கள், எழுத்துகள் மற்றும் நிறுத்தக்குறிகளைக் கலந்து பயன்படுத்த முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "ஒரே எழுத்தை மீண்டும் மீண்டும் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "ஒரே வகை எழுத்தை மீண்டும் மீண்டும் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்: எண்கள், "
+#~ "எழுத்துகள் மற்றும் நிறுத்தக்குறிகளைக் கலந்து பயன்படுத்த வேண்டும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr ""
+#~ "1234 அல்லது abcd போன்ற வரிசை எழுத்துகளைப் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "அதிக எண்கள், எழுத்துகள், சின்னங்களைச் சேர்க்க முயற்சிக்கவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr ""
+#~ "பெரிய எழுத்துகள் மற்றும் சிறிய எழுத்துகளைக் கலந்து பயன்படுத்தி ஓரிரண்டு எண்களையும் "
+#~ "பயன்படுத்தவும்."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr ""
+#~ "நல்ல கடவுச்சொல்! அதிக எண்களையும் எழுத்துகளையும் நிறுத்தக் குறிகளையும் சேர்த்தால் இன்னும் "
+#~ "வலிமையாகும்."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "வலிமை: வலிமையில்லை"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "வலிமை: குறைவு"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "வலிமை: நடுத்தரம்"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "வலிமை: நன்று"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "வலிமை: அதிகம்"
+
+#~ msgid "Authentication failed"
+#~ msgstr "அனுமதித்தல் தோல்வி"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "கடவுச்சொல் மிகவும் சிறயதாக உள்ளது."
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "கடவுச்சொல் மிக எளிமையாக உள்ளது."
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "பழைய கடவுச்சொல்லும் புதிய கடவுச்சொல்லும் ஒரே மாதிரி உள்ளன"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "புதிய கடவுச்சொல் ஏற்கனவே சமீபத்தில் பயன்படுத்தப்பட்டுள்ளது "
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "புதிய கடவுச்சொல்லில் எண்களும் சிறப்பு எழுத்துக்களூம் இருக்க வேண்டும்"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "பழைய மற்றும் கடவுச்சொற்கள் ஒரே மாதிரியாக உள்ளது."
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr ""
+#~ "ஆரம்ப அங்கீகாரத்திலிருந்து உங்கள் கடவுச்சொல் மாற்றப்பட்டுள்ளது! மீண்டும் அங்கீகரிக்கவும்."
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "புதிய கடவுச்சொல்லில் தேவையான அளவு மாறுபட்ட எழுத்துருக்கள் இல்லை"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "தெரியாத பிழை"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "உங்கள் கணக்கு வழங்குநரின் வலை முகவரிக்குப் பொருந்த வேண்டும்."
+
+#~ msgid "Failed to add account"
+#~ msgstr "கணக்கை சேர்த்தல் தோல்வி"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "கடவுச்சொற்கள் பொருந்தவில்லை"
+
+#~ msgid "Failed to register account"
+#~ msgstr "கணக்கை பதிவு செய்ய முடியவில்லை"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "இந்த களத்துடன் உறுதிப்படுத்த ஆதரவுள்ள வழி இல்லை"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "களத்தில் சேருதல் தோல்வி"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "புகுபதிவு பெயர் பயனளிக்கவில்லை.\n"
+#~ "மீண்டும் முயற்சிக்கவும்."
+
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "புகுபதிவு கடவுச்சொல் பயனளிக்கவில்லை.\n"
+#~ "மீண்டும் முயற்சிக்கவும்."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "களத்தில் உள்நுழைதல் தோல்வி"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "டொமைனைக் கண்டறிய முடியவில்லை. எழுத்துக்கூட்டு தவறா?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "நீங்கள் சாதனத்தை அணு அனுமதி இல்லை. கணினி நிர்வாகியை அணுகவும்."
+
+#~ msgid "The device is already in use."
+#~ msgstr "சாதனம் பயன்படுத்த தயாராக உள்ளது."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "ஒரு உள்ளமை பிழை நேர்ந்தது."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "பதிவு செய்யப்பட்ட கைரேகைகளை அழிக்கவா?"
+
+#~ msgid "Done!"
+#~ msgstr "முடிந்தது!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' சாதனத்தை அணுக முடியவில்லை"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' சாதனத்தில் விரலை பிடிக்க துவக்க முடியவில்லை"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "கைரேகை வாசிப்பி எதையும் அணுக முடியவில்லை"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "உதவிக்கு உங்கள் கணினி நிர்வாகியை அணுகவும்"
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "கைரேகை புகுபதிவை செயல்படுத்த உங்கள் கைரேகையை '%s' சாதனத்தை பயன்படுத்தி சேமிக்க "
+#~ "வேண்டும்."
+
+#~ msgid "Selecting finger"
+#~ msgstr "விரலை தேர்ந்தெடு"
+
+#~ msgid "This Week"
+#~ msgstr "இந்த வாரம்"
+
+#~ msgid "Last Week"
+#~ msgstr "கடந்த வாரம்"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "அமர்வு முடிந்தது"
+
+#~ msgid "Session Started"
+#~ msgstr "அமர்வு தொடங்கியது"
+
+#~ msgid "Please choose another password."
+#~ msgstr "தயவு செய்து வேறு கடவுச்சொல்லை தேர்ந்தெடுக்கவும்."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "தயை செய்து நடப்பு கடவுச்சொல்லை மீண்டும் உள்ளிடவும்"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "கடவுச்சொல்லை மாற்ற முடியாது."
+
+#~ msgid "Disable image"
+#~ msgstr "பிம்பத்தை முடக்கு"
+
+#~ msgid "Take a photo…"
+#~ msgstr "ஒரு புகைப்படம் எடுக்கவும் …"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "அதிக படங்களுக்கு உலவுக…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s ஆல் பயன்படுத்தப்ப்ட்டது"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "இந்த வகை டொமைனை தானாக சேர்க்க முடியாது"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "அது போன்ற களம் அல்லது ராஜ்யம் காணவில்லை"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s ஆக %s களத்தில் உள்நுழைய இயலாது"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "செல்லுபடியாகாத கடவுச்சொல், தயை செய்து மீண்டும் முயற்சி செய்க"
+
+#~ msgid "Other Accounts"
+#~ msgstr "மற்ற கணக்குகள்"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "பயனரை நீக்க முடியவில்லை"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "நீங்கள் உங்கள் கணக்கையே நீக்க முடியாது"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s இன்னும் உள் நுழைந்து உள்ளார் "
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "ஒரு பயனர் உள் நுழைந்து உள்லபோது அவர் கணக்கை நீக்குவது கணினியை நிலையற்றதாக்கும்."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "%s இன் கோப்புக்களை வைத்துக்கொள்ள வேண்டுமா?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ஒரு பயனரின் கணக்கை நீக்கும்போது இல்ல அடைவு, அஞ்சல் சுருள், தற்காலிக கோப்புகள் "
+#~ "ஆகியவற்றை வைத்துக்கொள்ள முடியும்."
+
+#~ msgid "_Delete Files"
+#~ msgstr "(_D) கோப்புக்களை நீக்கவும்"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_K கோப்புக்களை வைத்துக்கொள்ளவும்"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "கணக்கு முடக்கப்பட்டது"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "அடுத்த புகுபதிவில் அமைக்கப்படும்"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "ஏதுமில்லை"
+
+#~ msgid "Logged in"
+#~ msgstr "புகுபதிவு செய்துள்ளது"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "கணக்கு சேவையை தொடர்பு கொள்வதில் தோல்வி"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "கணக்கு சேவை  நிறுவப்பட்டுள்ளதா செயலாக்கப்பட்டுள்ளதா என்பதை சரிபார்க்கவும்"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "மாற்றங்கள் செய்ய \n"
+#~ "முதலில் * சின்னத்தை சொடுக்குக"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "புதிய பயனர் கணக்கை உருவாக்க,\n"
+#~ "முதலில் * சின்னத்தை சொடுக்குக"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "தேர்ந்தெடுத்த பயனர் கணக்கை நீக்கவும்"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "தேர்ந்தெடுத்த பயனர் கணக்கை நீக்க,\n"
+#~ "முதலில் * சின்னத்தை சொடுக்குக"
+
+#, c-format
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "'%s' என்ற பயனர் பெயரில் ஏற்கனவே ஒரு பயனர் உள்ளார்."
+
+#, c-format
+#~| msgid "The username is too long"
+#~ msgid "The username is too long."
+#~ msgstr "பயனர் பெயர் மிக நீளமாக உள்ளது."
+
+#~| msgid "The username cannot start with a '-'"
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "பயனர் பெயர் '-' ஐக் கொண்டு தொடங்கக்கூடாது."
+
+#~| msgid ""
+#~| "The username should only consist of lower and upper case letters from a-"
+#~| "z, digits and any of characters '.', '-' and '_'"
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "பயனர் பெயரில் a-z வரையிலான பெரிய மற்றும் சிறிய எழுத்துகள், எண்கள் மற்றும் '.', '-', "
+#~ "'_' ஆகிய எழுத்துகள் மட்டுமே இருக்கலாம்."
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr "இது உங்கள் இல்லக் கோப்புறைக்குப் பெயரிடப் பயன்படுத்தப்படும், இதை மாற்ற முடியாது."
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "மேலே"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "கீழே"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "எதுவுமில்லை"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "விசைதட்டலை அனுப்பு"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "மானிட்டரை மாற்றுக"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "திரையிலான உதவியைக் காண்பி"
+
+#~ msgid "Output:"
+#~ msgstr "வெளிப்பாடு:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr " காட்சி பாங்கு விகிதத்தை வைத்திரு (அஞ்சல்பெட்டி):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "வரை படத்திலிருந்து ஒற்றை திரைக்கு"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d  %d இல் "
+
+#~ msgid "Display Mapping"
+#~ msgstr "வரைபடத்தை காட்டு"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "தொடுதட்டு (அப்சொலூட்)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "தொடுதட்டு முன்னுரிமைகள்"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ப்ளூடூத் அமைப்புகள்"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "பொத்தான்களை தொடர்பிணை…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "திரைக்காட்சி தெளிதிறனை சரிசெய்யவும்"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "சொடுக்கி அமைப்புகளை சரிசெய்யவும்"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "நிலை தொடர்தல் பாங்கு"
+
+#~ msgid "Left Ring"
+#~ msgstr "இடது வளையம்"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "இடது வட்ட பாங்கு #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "வலது வட்ட பாங்கு #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "இடது தொடுபட்டை"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "இடது தொடுபட்டை பாங்கு #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "வலது தொடுபட்டை"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "வலது தொடு பட்டை பாங்கு #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "இடது தொடு வட்ட பாங்கு மாற்றி "
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "வலது தொடு வட்ட பாங்கு மாற்றி "
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "இடது தொடு பட்டை பாங்கு மாற்றி "
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "வலது தொடு பட்டை பாங்கு மாற்றி "
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "பாங்கு மாற்றி #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "இடது பொத்தான் #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "வலது பொத்தான் #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "மேல் பொத்தான் #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "கீழ் பொத்தான் #%d"
+
+#~ msgid "No Action"
+#~ msgstr "செயல் இல்லை"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "இடது சொடுக்கி பொத்தான் சொடுக்கு"
+
+#~ msgid "Scroll Up"
+#~ msgstr "மேல் உருளல்"
+
+#~ msgid "Scroll Right"
+#~ msgstr "வலது உருளல்"
+
+#~ msgid "Top Button"
+#~ msgstr "மேல் பொத்தான்"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "வெர்போஸ் பாங்கை செயல்படுத்து"
+
+#~ msgid "Show the overview"
+#~ msgstr "மேல்காணலை காட்டுக"
+
+#~ msgid "Search for the string"
+#~ msgstr "சரத்தைத் தேடு"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "சாத்தியமுள்ள பலக பெயர்களைப் பட்டியலிட்டுவிட்டு வெளியேறு"
+
+#~ msgid "Show help options"
+#~ msgstr "உதவி விருப்பங்களை காட்டு"
+
+#~ msgid "Panel to display"
+#~ msgstr "காட்ட பலகம்"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- அமைப்புகள்"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "'%s --help´ ஒரு முழு பட்டியலில் இருக்கும் கட்டளை வரி விருப்பங்களை காண.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "கிடைக்கும் பலகங்கள்:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "தனிப்பட்டவை"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "வன்பொருள்"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "கணினி"
 
 #~ msgid "Install Updates"
 #~ msgstr "மேம்படுத்தல்களை நிறுவு"
@@ -7322,20 +8265,11 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Set Up New Device"
 #~ msgstr "புதிய சாதனத்தை அமைக்கவும்"
 
-#~ msgid "Connection"
-#~ msgstr "இணைப்பு"
-
 #~ msgid "Paired"
 #~ msgstr "ஜோடிசேர்த்த"
 
-#~ msgid "Type"
-#~ msgstr "வகை"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "சொடுக்கி மற்றும் தொடுதிட்டு அமைப்புகள்"
-
-#~ msgid "Sound Settings"
-#~ msgstr "ஒலி அமைப்புகள்"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "விசைப்பலகை அமைப்புகள்"
@@ -7436,12 +8370,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "_City:"
 #~ msgstr "நகரம் (_C):"
 
-#~ msgid "_Network Time"
-#~ msgstr "_N பிணைய நேரம்"
-
-#~ msgid ":"
-#~ msgstr ":"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "நேரத்தை ஒரு மனி முன்னே அமை."
 
@@ -7476,12 +8404,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "180 Degrees"
 #~ msgstr "180 பாகைகள்"
 
-#~ msgid "Monitor"
-#~ msgstr "மானிட்டர்"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "முதன்மை காட்சியை மாற்ற இழுக்கவும்"
-
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
 #~ "placement."
@@ -7514,9 +8436,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "குறிப்பு: தெளிதிறன் தேர்வுகளை கட்டுப்படுத்தலாம்"
-
-#~ msgid "_Detect Displays"
-#~ msgstr "திரைகளை கண்டுபிடி"
 
 #~ msgid "Mouse Preferences"
 #~ msgstr "சொடுக்கி பண்புகள்"
@@ -7670,12 +8589,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Large"
 #~ msgstr "பெரிய"
 
-#~ msgid "Mouse Settings"
-#~ msgstr "சொடுக்கி அமைப்புகள்"
-
-#~ msgid "Add account"
-#~ msgstr "கணக்கை சேர்"
-
 #~ msgid "_Local Account"
 #~ msgstr "_L உள்ளமை கணக்கு"
 
@@ -7688,12 +8601,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "C_ontinue"
 #~ msgstr "_o தொடர்"
 
-#~ msgid "Previous Week"
-#~ msgstr "முந்தைய வாரம்"
-
-#~ msgid "Next Week"
-#~ msgstr "அடுத்த வாரம்"
-
 #~ msgid "Next week"
 #~ msgstr "அடுத்த வாரம்"
 
@@ -7705,12 +8612,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Enable this account"
 #~ msgstr "இந்த கணக்கை செயலாக்கு"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "_o கடவுச் சொல்லை உறுதி செய்க: "
-
-#~ msgid "Generate a password"
-#~ msgstr "ஒரு கடவுச்சொல்லை உருவாக்கு"
 
 #~ msgid "_Action"
 #~ msgstr "செயல் (_A)"
@@ -7850,18 +8751,12 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Change the background"
 #~ msgstr "பின்னணி படத்தை மாற்று"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "ப்ளூடூத் அமைப்புகளை வடிவமை"
-
 #~ msgid "Browse Files..."
 #~ msgstr "கோப்புகளை உலாவு..."
 
 #~ msgctxt "Power"
 #~ msgid "Bluetooth"
 #~ msgstr "ப்ளூடூத்"
-
-#~ msgid "Create virtual device"
-#~ msgstr "மெய்நிகர் சாதனம் உருவாக்கு"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "காட்சிகருவிகளுக்கு இருக்கும் வரிவுருக்கள்"
@@ -7956,12 +8851,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Unspecified"
 #~ msgstr "குறிப்பிடப்படாத"
 
-#~ msgid "Select a language"
-#~ msgstr "மொழியை தேர்ந்தெடு"
-
-#~ msgid "_Select"
-#~ msgstr "(_S) தேர்ந்தெடு"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "நாள் நேரம் விருப்பங்கள் பலகம்"
 
@@ -8014,9 +8903,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Set your mouse and touchpad preferences"
 #~ msgstr "உங்கள் சொடுக்கி மற்றும் தொடுதிட்டின் விருப்ப தேர்வுகளை அமைக்கவும்"
-
-#~ msgid "Network settings"
-#~ msgstr "பிணைய அமைவுகள்"
 
 #~ msgid "Network;Wireless;IP;LAN;Proxy;"
 #~ msgstr "பிணையம்;ஒயர்லெஸ்;ஐபி;லான்;ப்ராக்ஸி;"
@@ -8114,9 +9000,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Paused"
 #~ msgstr "தாமதிக்கப்பட்டுள்ளது"
 
-#~ msgid "Change printer settings"
-#~ msgstr "அச்சடிப்பி அமைப்புகள் ஐ மாற்றுக"
-
 #~ msgid "Manufacturers"
 #~ msgstr "உருவாக்கியோர்"
 
@@ -8180,9 +9063,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Input source:"
 #~ msgstr " உள்ளீட்டு மூலம்:"
 
-#~ msgid "Install languages..."
-#~ msgstr "மொழிகள் நிறுவு... "
-
 #~ msgid "Move Input Source Up"
 #~ msgstr " உள்ளீட்டு மூலத்தை மேலே நகர்த்து"
 
@@ -8212,9 +9092,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Shortcut Settings"
 #~ msgstr "குறுக்கு வழி  அமைப்புகள்"
 
-#~ msgid "Show Keyboard Layout"
-#~ msgstr "விசைப்பலகை இடவமைவை காட்டுக"
-
 #~ msgid "System settings"
 #~ msgstr "கணினி அமைப்புகள்"
 
@@ -8227,17 +9104,11 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "பிரகாசம்;பூட்டு;மங்கல்;வெற்று;திரை;"
 
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "திரை பிரகாசம் மற்றும் பூட்டு அமைப்பு"
-
 #~ msgid "Don't lock when at home"
 #~ msgstr "வீட்டில் உள்ளபோது பூட்டாதே"
 
 #~ msgid "Locations..."
 #~ msgstr "இருப்பிடங்கள்..."
-
-#~ msgid "Lock"
-#~ msgstr "பூட்டு"
 
 #~ msgid "_Dim screen to save power"
 #~ msgstr "_D சக்தியை சேமிக்க திரையை மங்கலாக்கு"
@@ -8256,9 +9127,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Sound Output Volume"
 #~ msgstr "ஒலி வெளிப்பாடு அளவு"
-
-#~ msgid "Microphone Volume"
-#~ msgstr "ஒலி வாங்கி அளவு"
 
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "ஒலி விருப்பத்தேர்வுகளை துவக்குவதில் தோல்வி: %s"
@@ -8335,12 +9203,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Subnet Mask"
 #~ msgstr "துணை இணைய மறைப்பு"
 
-#~ msgid "_Search by Address"
-#~ msgstr "_S முகவரியால் தேடு"
-
-#~ msgid "Getting devices..."
-#~ msgstr "சாதனங்களை பெறுகிறது..."
-
 #~ msgid ""
 #~ "FirewallD is not running. Network printer detection needs services mdns, "
 #~ "ipp, ipp-client and samba-client enabled on firewall."
@@ -8355,9 +9217,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgctxt "printer type"
 #~ msgid "Network"
 #~ msgstr "பிணையம்"
-
-#~ msgid "Device types"
-#~ msgstr "சாதன வகைகள்"
 
 #~ msgid "Automatic configuration"
 #~ msgstr "தானியங்கி கட்டமைப்பு"
@@ -8398,14 +9257,8 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Take a screenshot"
 #~ msgstr "ஒரு திரைவெட்டினை எடுக்கவும்"
 
-#~ msgid "Shortcut"
-#~ msgstr "குறுக்கு வழி"
-
 #~ msgid "A_cceleration:"
 #~ msgstr "(_c) ஊக்கி:"
-
-#~ msgid "Double-Click Timeout"
-#~ msgstr "இரட்டை சொடுக்கு நேரம் முடிந்தது"
 
 #~ msgid "Drag Threshold"
 #~ msgstr "இழுப்பு விளிம்பு"
@@ -8415,9 +9268,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "(_m) தொடுதிட்டால் சொடுக்கி சொடுக்கலை செயல்படுத்து"
-
-#~ msgid "Scrolling"
-#~ msgstr "உருளல்"
 
 #~ msgid "Sh_ow position of pointer when the Control key is pressed"
 #~ msgstr "(_o) கன்ட்ரோல் விசையை அழுத்தினால் சுட்டியின் இடத்தை காட்டு"
@@ -8526,12 +9376,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "View and edit keyboard layout options"
 #~ msgstr "விசைப்பலகை இட அமைவு தேர்வுகளை பார்த்து திருத்துக"
 
-#~ msgid "Layout"
-#~ msgstr "இட அமைவு"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "_h வடிவமைக்க சாதனத்தை தேர்ந்தெடு"
-
 #~ msgid "Caribou"
 #~ msgstr "காரிபௌ"
 
@@ -8540,12 +9384,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Dasher"
 #~ msgstr "டேஷர்"
-
-#~ msgid "Decrease size:"
-#~ msgstr "அளவை குறைவாக்குக:"
-
-#~ msgid "Increase size:"
-#~ msgstr "அளவு ஐ அதிகமாக்குக:"
 
 #~ msgid "Nomon"
 #~ msgstr "நோமோன் (மானிட்டர் ஏதுமில்லை)"
@@ -8582,17 +9420,11 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Choose a generated password"
 #~ msgstr "உருவாக்கிய கடவுச்சொல்லை தேர்ந்தெடு"
 
-#~ msgid "Account _type"
-#~ msgstr "_t கணக்கு வகை:"
-
 #~ msgid "More choices..."
 #~ msgstr "மேலும் தேர்வுகள்..."
 
 #~ msgid "Wacom Graphics Tablet"
 #~ msgstr "வாகாம் வரைகலை தொடுதட்டு"
-
-#~ msgid "Unlock"
-#~ msgstr "பூட்டை திற"
 
 #~ msgid "Battery charging"
 #~ msgstr "மின்கல சக்தி ஏற்றம் ஆகிறது"
@@ -8647,9 +9479,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Too many custom shortcuts"
 #~ msgstr "அதிகமான தனிப்பயன் குறுக்குவழிகள் "
-
-#~ msgid "Speed"
-#~ msgstr "வேகம்"
 
 #~ msgid "Ask me"
 #~ msgstr "என்னை கேள்"
@@ -8771,9 +9600,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Position of magnified view on screen"
 #~ msgstr "திரையில் பெரிதாக்கப்பட்ட காட்சியின் இடம்"
 
-#~ msgid "Proportional"
-#~ msgstr "சரிவிகிதமான"
-
 #~ msgid "Push"
 #~ msgstr "தள்ளு"
 
@@ -8807,9 +9633,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "_Turn off after:"
 #~ msgstr "_T இவ்வளவுக்குப்பின் நிறுத்து:"
 
-#~ msgid "Mute"
-#~ msgstr "ஒலி நிறுத்தம்"
-
 #~ msgid "Chinese"
 #~ msgstr "சைனீஸ் "
 
@@ -8821,9 +9644,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "On AC _power:"
 #~ msgstr "_p ஏசி மின்சாரத்தில்:"
-
-#~ msgid "Put the computer to sleep when inactive:"
-#~ msgstr "இவ்வளவு நேரம் செயலற்று இருந்தால் கனினியை பணிநிறுத்தம் செய்க:"
 
 #~ msgid "When the _sleep button is pressed:"
 #~ msgstr "_s உறக்க பொத்தான் அழுத்தப்படும் போது:"
@@ -8881,9 +9701,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgstr ""
 #~ "எங்கு பணிமேடை தீம்களை பெறுவதற்கான URL. ஒரு வெற்று சரமாக அமைத்தால் இணைப்பு தோன்றாது."
 
-#~ msgid "Locked"
-#~ msgstr "பூட்டப்பட்டது"
-
 #~ msgid ""
 #~ "Dialog is unlocked.\n"
 #~ "Click to prevent further changes"
@@ -8919,9 +9736,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Use previous window's layout in new windows"
 #~ msgstr "புதிய சாளரங்களில் முந்தைய சாளரத்தின் இடவமைவை தேர்ந்தெடு"
-
-#~ msgid "_Acceleration:"
-#~ msgstr "(_A) ஆர்முடுகல்:"
 
 #~ msgid "<span size=\"x-large\">High/Inverse</span>"
 #~ msgstr "<span size=\"x-large\">மாறுபாடு /எதிர்மறை</span>"
@@ -9018,9 +9832,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Could not load the main interface"
 #~ msgstr "முதன்மை இடைமுகத்தை ஏற்ற முடியவில்லை"
 
-#~ msgid "Please make sure that the applet is properly installed"
-#~ msgstr "குறுநிரல் ஒழுங்காக நிறுவப்பட்டுள்ளதா என்பதை சரிபார்க்கவும்"
-
 #~ msgid "All %s occurrences will be replaced with actual link"
 #~ msgstr "அனைத்து %s நிகழ்வுகளும் உண்மையான இணைப்புகளால் மாற்றப்படும்"
 
@@ -9078,9 +9889,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "GNOME OnScreen Keyboard"
 #~ msgstr "க்னோமின் திரை விசைப்பலகை"
 
-#~ msgid "GNOME Terminal"
-#~ msgstr "க்னோம் முனையம்"
-
 #~ msgid "Gnopernicus"
 #~ msgstr "க்னோபர்நிக்கஸ்"
 
@@ -9137,9 +9945,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Upside Down"
 #~ msgstr "தலை கீழ்"
-
-#~ msgid "Desktop"
-#~ msgstr "மேசைச்சூழல்"
 
 #~ msgid "Error unsetting accelerator in configuration database: %s"
 #~ msgstr "வடிவமைப்பு தரவுத்தளத்தில் ஊக்கியை மாற்றி அமைப்பதில்  பிழை: %s"
@@ -9250,9 +10055,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "_Use the same proxy for all protocols"
 #~ msgstr "(_U) எல்லா நெறிமுறைகளுக்கும் அதே பதிலாள் ஐ பயன்படுத்துவும். "
-
-#~ msgid "No sounds"
-#~ msgstr "ஒலிகள் இல்லை"
 
 #~ msgid "Sound _theme:"
 #~ msgstr "ஒலித் தீம்: (_t)"
@@ -9421,17 +10223,8 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Sylpheed-Claws"
 #~ msgstr "ஸில்ஃபீட்-க்ளாஸ் "
 
-#~ msgid "Thunderbird"
-#~ msgstr "தண்டர் பர்ட்"
-
 #~ msgid "Include _panel"
 #~ msgstr "பலகத்தை சேர் (_p)"
-
-#~ msgid "Panel icon"
-#~ msgstr "பலக சின்னம்"
-
-#~ msgid "Re_fresh rate:"
-#~ msgstr "புதுப்பிக்கும்  விகிதம் (_f):"
 
 #~ msgid "Sa_me image in all monitors"
 #~ msgstr "_m  எல்லா  திரையகங்களிலும் அதே  பிம்பம்."
@@ -9787,9 +10580,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Copyright:"
 #~ msgstr "காப்புரிமை:"
 
-#~ msgid "Installed"
-#~ msgstr "நிறுவப்பட்டது"
-
 #~ msgid "usage: %s fontfile\n"
 #~ msgstr "பயன்பாடு : %s fontfile\n"
 
@@ -9920,9 +10710,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Unable to open address book"
 #~ msgstr "முகவரி புத்தகத்தை திறக்க முடியவில்லை"
 
-#~ msgid "About %s"
-#~ msgstr "%s பற்றி"
-
 #~ msgid "A_IM/iChat:"
 #~ msgstr "A_IM/iChat:"
 
@@ -9973,9 +10760,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "State/Pro_vince:"
 #~ msgstr "மாநிலம்/மாகாணம்: (_v)"
-
-#~ msgid "User name:"
-#~ msgstr "பயனர் பெயர்:"
 
 #~ msgid "Web _log:"
 #~ msgstr "இணைய பதிவு: (_l)"
@@ -10173,9 +10957,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "The current theme suggests a font."
 #~ msgstr "இப்போதைய கருப்பொருள் ஒரு எழுத்துருவை குறிப்பிடுகிறது."
 
-#~ msgid "Appearance Preferences"
-#~ msgstr "கருப்பொருள்  விருப்பஙகள்"
-
 #~ msgid "Best _shapes"
 #~ msgstr "(_s) சிறந்த வடிவங்கள்"
 
@@ -10185,9 +10966,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Changing your cursor theme takes effect the next time you log in."
 #~ msgstr ""
 #~ "உங்கள் சொடுக்கி கருப்பொருள் நீங்கள் அடுத்த முறை உள்நுழையும் போது செயலுக்கு வரும்."
-
-#~ msgid "Controls"
-#~ msgstr "கட்டுப்பாடுகள்"
 
 #~ msgid "Customize Theme"
 #~ msgstr "சூழலை தனிபயன் ஆக்குக"
@@ -10284,9 +11062,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "_RGB"
 #~ msgstr "_RGB"
-
-#~ msgid "_Reset to Defaults"
-#~ msgstr "(_R) முன்னிருப்புக்கு மீட்டமை"
 
 #~ msgid "_Selected items:"
 #~ msgstr "(_S) தேர்வுசெய்த _உருப்படிகள்:"
@@ -10419,14 +11194,8 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Copying '%s'"
 #~ msgstr "'%s' ஐ நகலெடுக்கிறது"
 
-#~ msgid "Parent Window"
-#~ msgstr "தாய் சாளரம்"
-
 #~ msgid "Parent window of the dialog"
 #~ msgstr "உரையாடலின் தாய் சாளரம்"
-
-#~ msgid "From URI"
-#~ msgstr "URI இலிருந்து"
 
 #~ msgid "URI currently transferring from"
 #~ msgstr "இதனைப் பெறும் URI முகவரி"
@@ -10436,9 +11205,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "URI currently transferring to"
 #~ msgstr "இதனை அனுப்பும் URI முகவரி"
-
-#~ msgid "Fraction completed"
-#~ msgstr "முடிக்கப்பட்ட அளவு"
 
 #~ msgid "Fraction of transfer currently completed"
 #~ msgstr "இதுவரை முடிக்கப்பட்ட அனுப்புகையின் பகுதி"
@@ -10466,9 +11232,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Default Pointer - Current"
 #~ msgstr "முன்னிருப்பு சொடுக்கி - இப்போதைய"
-
-#~ msgid "White Pointer"
-#~ msgstr "வெள்ளை சொடுக்கி"
 
 #~ msgid "White Pointer - Current"
 #~ msgstr "வெள்ளை சொடுக்கி - இப்போதைய"
@@ -10546,9 +11309,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "_Enable assistive technologies"
 #~ msgstr "(_E) உதவி தொழில்நுட்பங்களை செயல்படுத்தவும"
 
-#~ msgid "_Mouse Accessibility"
-#~ msgstr "(_M) சொடுக்கி அணுகல்"
-
 #~ msgid "_Preferred Applications"
 #~ msgstr "விருப்பமான நிரல்கள்"
 
@@ -10624,17 +11384,11 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 #~ msgid "Set your window properties"
 #~ msgstr "உங்கள் சாளர பண்புகளை அமைக்கவும்"
 
-#~ msgid "Windows"
-#~ msgstr "சாளரங்கள்"
-
 #~ msgid "Hide on start (useful to preload the shell)"
 #~ msgstr "துவக்கத்தில் மறை (ஷெல்லை முன் ஏற்றும் போது பயனுள்ளது)"
 
 #~ msgid "Filter"
 #~ msgstr "வடிகட்டி"
-
-#~ msgid "Common Tasks"
-#~ msgstr "பொது வேலைகள்"
 
 #~ msgid "Your filter \"%s\" does not match any items."
 #~ msgstr "உங்கள் வடிப்பி \"%s\" எந்த உருப்படிகளுக்கும் பொருந்தவில்லை."
@@ -10662,15 +11416,6 @@ msgstr "விருப்பங்கள்;அமைப்புகள்;"
 
 #~ msgid "Documents"
 #~ msgstr "ஆவணங்கள்"
-
-#~ msgid "<b>Open</b>"
-#~ msgstr "<b>திற</b>"
-
-#~ msgid "Rename..."
-#~ msgstr "மறுபெயரிடு..."
-
-#~ msgid "Move to Trash"
-#~ msgstr "குப்பைக்கு நகர்த்து"
 
 #~ msgid "Delete"
 #~ msgstr "நீக்கு"

--- a/po/ta.po~
+++ b/po/ta.po~
@@ -1,0 +1,10736 @@
+# translation of gnome-control-center.master.ta.po to Tamil
+# Tamil translation of gnome-control-center
+# Copyright (C) 2002
+# This file is distributed under the same license as the gnome-control-center.
+#
+# Dinesh Nadarajah <dinesh_list@sbcglobal.net>, 2002, 2004.
+# Ma SivaKumar <tamil@leatherlink.net>, 2004.
+# Jayaradha N <jaya@pune.redhat.com>, 2004.
+# Felix <ifelix@redhat.com>, 2006.
+# Dr.T.Vasudevan <agnihot3@gmail.com>, 2007, 2008, 2009, 2010, 2011, 2012.
+# I. Felix <ifelix@redhat.com>, 2009.
+# Dr,T,Vasudevan <agnihot3@gmail.com>, 2010, 2011.
+# Shantha kumar <shkumar@redhat.com>, 2012, 2013, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.master.ta\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-09-15 06:30+0000\n"
+"PO-Revision-Date: 2014-09-15 16:27+0630\n"
+"Last-Translator: Shantha kumar <shkumar@redhat.com>\n"
+"Language-Team: American English <kde-i18n-doc@kde.org>\n"
+"Language: ta\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 1.5\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "பின்னணி"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "நாள் முழுதும் மாறும்"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "Lock Screen"
+msgstr "திரையை பூட்டு"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "ஓடுகளாக்க பரப்பு"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "அணுகிப்பார்"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "மையம்"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "அளவாக்கம்"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "நிரப்பு"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "வீச்சு"
+
+#: ../panels/background/cc-background-chooser-dialog.c:438
+msgid "Wallpapers"
+msgstr "சுவர்-காகிதங்கள்"
+
+#: ../panels/background/cc-background-chooser-dialog.c:447
+msgid "Colors"
+msgstr "வண்ணங்கள்"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:485
+msgid "Select Background"
+msgstr "பின்னணியை தேர்ந்தெடு"
+
+#: ../panels/background/cc-background-chooser-dialog.c:514
+msgid "Pictures"
+msgstr "படங்கள் "
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:546
+msgid "No Pictures Found"
+msgstr "படங்கள் இல்லை"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:564
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "இல்லம்"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:576
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr ""
+"உங்கள் %s கோப்புறையில் நீங்கள் படங்களைச் சேர்க்கலாம், அவை இங்கு "
+"காண்பிக்கப்படும்"
+
+#: ../panels/background/cc-background-chooser-dialog.c:583
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/color/color.ui.h:29 ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1537
+#: ../panels/display/cc-display-panel.c:1976
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1247
+#: ../panels/network/net-device-wifi.c:1440
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/cc-printers-panel.c:1947
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+#: ../panels/user-accounts/um-photo-dialog.c:95
+#: ../panels/user-accounts/um-photo-dialog.c:222
+#: ../panels/user-accounts/um-user-panel.c:513
+msgid "_Cancel"
+msgstr "_C நீக்கு"
+
+#: ../panels/background/cc-background-chooser-dialog.c:584
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:97
+msgid "Select"
+msgstr "தேர்வு செய்க "
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "பல அளவுகள்"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "பணிமேடை பின்னணி எதுவுமில்லை"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "நடப்பு பின்னணி"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "உங்கள் பின்புலப் படத்தை வால்பேப்பர் அல்லது புகைப்படமாக மாற்றவும்"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "சுவர்-காகிதங்கள் ;திரை;மேல்மேசை;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "ப்ளூடூத் செயல்நீக்கப்பட்டது"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "ப்ளூடூத் தகைவிகள் ஏதும் காணப்படவில்லை"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "ப்ளூடூத் வன்பொருள் மாற்றியால் செயல் நீக்கப்பட்டது"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+msgid "Bluetooth"
+msgstr "ப்ளூடூத்"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+"Bluetooth ஐ ஆன் மற்றும் ஆஃப் செய்யவும் மற்றும் உங்கள் சாதனங்களை இணைக்கவும்"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr ""
+"உங்கள் அளவைவகுத்தல் சாதனத்தை சதுரத்தின் மீது வைத்து 'தொடங்கு' என்பதை "
+"அழுத்தவும்"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+"உங்கள் அளவைவகுத்தல் சாதனத்தை அளவைவகுத்தல் இடநிலைக்கு நகர்த்தி 'தொடரு' என்பதை "
+"அழுத்தவும்"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr ""
+"உங்கள் அளவைவகுத்தல் சாதனத்தை மேற்பரப்பு இடநிலைக்கு நகர்த்தி 'தொடரு' என்பதை "
+"அழுத்தவும்"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "மடிக்கணினி மூடியை மூடவும்"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "சரிசெய்ய முடியாத ஒரு உள்ளமை பிழை நேர்ந்தது."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "அளவைவகுத்தலைச் செய்வதற்குத் தேவையான கருவிகள் நிறுவப்படவில்லை."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "சுயவிவரத்தை உருவாக்க முடியவில்லை."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "இலக்கு வெண்புள்ளி அடையக்கூடியதாக இல்லை."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "முடிந்தது!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "அளவைவகுத்தல் தோல்வி!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "அளவைவகுத்தல் சாதனத்தை அகற்றலாம்."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "செயலில் இருக்கும் போது அளவைவகுத்தல் சாதனத்தைத் தொந்தரவு செய்ய வேண்டாம்"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "மடிக்கணினி திரை"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "உள்ளமைந்த வெப்கேம்"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s மானிட்டர்"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s ஸ்கேனர்"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s கேமரா"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s அச்சுப்பொறி"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s வெப்கேம்"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s க்கு நிற மேலாண்மையை செயல்படுத்தவும்"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s க்கு நிற சுயவிவரங்களைக் காண்பி"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+msgid "Not calibrated"
+msgstr "அளவைவகுக்கப்படவில்லை"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "முன்னிருப்பு:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "நிறவெளி:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "சோதனை வரிவுரு:"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "ஐசிசி வரிவுரு கோப்பை  தேர்ந்தெடு."
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "இறக்குமதி (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "ஆதரவுள்ள ஐசிசி வரிவுருக்கள்"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "எல்லா கோப்புகள்"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "திரை"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "கோப்பைப் பதிவேற்றுவதில் தோல்வியடைந்தது: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "சுயவிவரம் இங்கு பதிவேற்றப்பட்டது:"
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "இந்த URL ஐ எழுதிக்கொள்ளவும்."
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+"இந்த கணினியை மறுதொடக்கம் செய்து உங்கள் வழக்கமான இயக்க முறைமையை பூட் செய்யவும்."
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+"சுயவிவரத்தைப் பதிவிறக்க இந்த URL ஐ உங்கள் உலாவியில் தட்டச்சு செய்து, "
+"சுயவிவரத்தை "
+"நிறுவவும்."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "சுயவிவரத்தைச் சேமி"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "சேமி (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "தேர்ந்தெடுக்கப்பட்ட சாதனத்திற்கு வண்ன வரியுரு அமை:"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"அளவீட்டு கருவி காணவில்லை. அது இயக்கப்பட்டுள்ளது, சரியாக பொருத்தப்பட்டுள்ளது "
+"என உறுதி "
+"செய்து கொள்க."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "அளவீட்டு கருவி அச்சுப்பொறி வருவுருவாக்கத்தை ஆதரிக்கவில்லை."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "இந்த சாதன வகைக்கு இப்போது ஆதரவில்லை."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "தரநிலையான இடம்"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "சோதனை சுயவிவரம்:"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "தானியங்கு"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "குறைந்த தரம்"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "நடுநிலைத் தரம்"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "உயர் தரம்"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "முன்னிருப்பு ஆர்ஜிபி"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "முன்னிருப்பு சிஎம்ஒய்கே"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "முன்னிருப்பு சாம்பல்"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "விற்பனையாளர் வழங்கிய தொழிற்சாலை அளவைவகுத்தல் தரவு"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "இந்த சுயவிவரத்தில் முழுத்திரை காட்சி திருத்தம் செய்ய முடியாது"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "இந்த சுயவிவரம் இப்போது துல்லியமாக இல்லாமால் இருக்கலாம்"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "காட்சி அளவைவகுத்தல்"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr "ரத்து செய்"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "தொடங்கு"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "மீண்டும் தொடர்"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "முடிந்தது"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "திரை அளவீடு"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"அளவைவகுத்தல் செய்தால், ஒரு சுஉயவிவரம் உருவாக்கப்படும், அதைக் கொண்டு நீங்கள் "
+"உங்கள் திரையின் "
+"நிறங்களை மேலாண்மை செய்யலாம். அளவைவகுத்தலில் அதிக நேரம் செலவழித்தால் உங்கள் "
+"நிற சுயவிவரம் "
+"தரமாக இருக்கும்."
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "அளவைவகுத்தல் நிகழும் போது கணினியைப் பயன்படுத்த முடியாது."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "தரம்"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "தோராயமான நேரம்"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "அளவைவகுத்தல் தரம்"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+"அளவைவகுத்தலுக்கு நீங்கள் பயன்படுத்த விரும்பும் சென்சார் சாதனத்தைத் "
+"தேர்ந்தெடுக்கவும்."
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "அளவைவகுத்தல் சாதனம்"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "இணைக்கப்பட்ட காட்சியின் வகையைத் தேர்ந்தெடுக்கவும்."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "காட்சி வகை"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"ஒர் உதிரை இலக்கு வெண் புள்ளியைத் தேர்ந்தெடுக்கவும். பெரும்பாலான காட்சிகள் D65 "
+"இல்லுமினன்ட்டுக்கு அளவைவகுக்கப்பட வேண்டும்."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "சுயவிவர வெண்புள்ளி"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"காட்சியை உங்களுக்கு வழக்கமாக இருக்கும் ஒளிர்வில் அமைக்கவும். இந்த ஒளிர்வு "
+"அளவில் நிற "
+"மேலாண்மை மிகத் துல்லியமாக இருக்கும்."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"மாற்றாக இந்த சாதனத்திற்கு பயன்படுத்தப்படும் மற்ற சுயவிவரங்களில் ஒன்றில் "
+"பயன்படுத்தப்பட்டுள்ள "
+"ஒளிர்வு அளவையும் நீங்கள் பயன்படுத்தலாம்."
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "காட்சி ஒளிர்வு"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"நீங்கள் வெவ்வேறு கணினிகளில் ஒரு நிற சுயவிவரத்தைப் பயன்படுத்தலாம் அல்லது "
+"வெவ்வேறு ஒளி "
+"நிலைகளுக்கு என சுயவிவரங்களை உருவாக்கிக்கொள்ளலாம்."
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "சுயவிவரப் பெயர்:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "சுயவிவரப் பெயர்"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "சுயவிவரம் வெற்றிகரமாக உருவாக்கப்பட்டது!"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "சுயவிவரத்தை நகலெடு"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "எழுதத்தக்க ஊடகம் தேவை"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "சுயவிவரத்தைப் பதிவேற்று"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "இணைய இணைப்பு தேவை"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> மற்றும் <a "
+"href=\"windows\">Microsoft Windows</a> ஆகிய இயக்க முறைமைகளில் சுயவிவரத்தை "
+"எப்படிப் பயன்படுத்துவது என்பது பற்றிய இந்த வழிமுறைகள் உங்களுக்குப் பயன்படலாம்."
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+msgid "Summary"
+msgstr "சுருக்கம்"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "கோப்பை இறக்குமதி செய்…"
+
+#: ../panels/color/color.ui.h:30
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr "சேர் (_A)"
+
+#: ../panels/color/color.ui.h:31
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"சிக்கல்கள் உள்ளது. சுயவிவரம் சரியாக செயல்படாது போகலாம். <a href=\"\">"
+"விவரங்களைக் "
+"காண்பி.</a>"
+
+#: ../panels/color/color.ui.h:32
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"வண்ண மேலாண்மைக்கு ஒவ்வொரு சாதனமும் வண்ண வரிவுருவை இற்றைப்படுத்த வேண்டியுள்ளது."
+
+#: ../panels/color/color.ui.h:33
+msgid "Learn more"
+msgstr "மேலும் கற்க"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more about color management"
+msgstr "நிற மேலாண்மை குறித்து மேலும் கற்க"
+
+#: ../panels/color/color.ui.h:35
+msgid "Set for all users"
+msgstr "எல்லாப்பயனருக்கும் அமை"
+
+#: ../panels/color/color.ui.h:36
+msgid "Set this profile for all users on this computer"
+msgstr "இந்த வரியுருவை இந்த கணினியில் எல்லா பயனர்களுக்கும் அமை"
+
+#: ../panels/color/color.ui.h:37
+msgid "Enable"
+msgstr "செயல்படுத்து"
+
+#: ../panels/color/color.ui.h:38
+msgid "Add profile"
+msgstr "வரிவுரு சேர்"
+
+#: ../panels/color/color.ui.h:39
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Calibrate…"
+msgstr "அளவிடு..."
+
+#: ../panels/color/color.ui.h:40
+msgid "Calibrate the device"
+msgstr "சாதனத்தை அளவிடு "
+
+#: ../panels/color/color.ui.h:41
+msgid "Remove profile"
+msgstr "வரிவுருவை நீக்கு"
+
+#: ../panels/color/color.ui.h:42
+msgid "View details"
+msgstr "விவரங்களை காண்"
+
+#: ../panels/color/color.ui.h:43
+msgid "Unable to detect any devices that can be color managed"
+msgstr "நிற மேலாண்மை செய்யக்கூடிய சாதனங்கள் எதனையும் கண்டறிய முடியவில்லை"
+
+#: ../panels/color/color.ui.h:44
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:45
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:46
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:47
+msgid "Projector"
+msgstr "ஒளிப்படக்காட்டி"
+
+#: ../panels/color/color.ui.h:48
+msgid "Plasma"
+msgstr "பிளாஸ்மா"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL பேக்லைட்)"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED பேக்லைட்)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (white LED backlight)"
+msgstr "LCD (வெள்ளை LED பேக்லைட்)"
+
+#: ../panels/color/color.ui.h:52
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "அகல கேமட் LCD (CCFL பேக்லைட்)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "அகல கேமட் LCD (RGB LED பேக்லைட்)"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "அதிகம்"
+
+#: ../panels/color/color.ui.h:55
+msgid "40 minutes"
+msgstr "40 நிமிடங்கள்"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "நடுத்தரம்"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 நிமிடங்கள்"
+
+#: ../panels/color/color.ui.h:58
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "குறைவு"
+
+#: ../panels/color/color.ui.h:59 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 நிமிடங்கள்"
+
+#: ../panels/color/color.ui.h:60
+msgid "Native to display"
+msgstr "காட்சிக்கு உரியது"
+
+#: ../panels/color/color.ui.h:61
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (அச்சு மற்றும் வெளியீடு)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:63
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (புகைப்படம் மற்றும் வரைபொருள்)"
+
+#: ../panels/color/color.ui.h:64
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "நிறம்"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"உங்கள் காட்சிகள், கேமராக்கள் அல்லது அச்சுப்பொறிகள் போன்ற சாதனங்களின் நிறத்தை "
+"அளவைவகுக்கவும்"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "நிறம்;ஐசிசி;வரிவுரு;அளவீடுசெய்;அச்சுப்பொறி;தோற்றம்;"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:684
+msgid "United States"
+msgstr "யுனைடட் ஸ்டேட்ஸ் "
+
+#: ../panels/common/cc-common-language.c:685
+msgid "Germany"
+msgstr "ஜெர்மனி "
+
+#: ../panels/common/cc-common-language.c:686
+msgid "France"
+msgstr "ப்ரான்ஸ்"
+
+#: ../panels/common/cc-common-language.c:687
+msgid "Spain"
+msgstr "ஸ்பெய்ன் "
+
+#: ../panels/common/cc-common-language.c:688
+msgid "China"
+msgstr "சைனா"
+
+#: ../panels/common/cc-common-language.c:758
+msgid "Other…"
+msgstr "மற்றவை…"
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr "மேலும்…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "மொழிகள் இல்லை"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "மொழி"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "முடிந்தது (_D)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+#| msgctxt "login date-time"
+#| msgid "%s, %s"
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "ஜனவரி"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "பெப்ரவரி"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "மார்ச்"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "ஏப்ரல்"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "மே"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "ஜூன்"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "ஜூலை"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "ஆகஸ்ட்"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "செப்டம்பர்"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "அக்டோபர்"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "நவம்பர்"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "திசம்பர்"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "தேதி மற்றும் நேரம்"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "மணி"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "நிமிடம்"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "நாள்"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "மாதம்"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "வருடம்"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Time Zone"
+msgstr "நேர மண்டலம்"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Search for a city"
+msgstr "நகரத்தைத் தேடு"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Automatic _Date & Time"
+msgstr "தானியக்க தேதி மற்றும் நேரம் (_D)"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr "இணைய அணுகல் தேவை"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Automatic Time _Zone"
+msgstr "தானியங்கு நேர மண்டலம் (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "Date & _Time"
+msgstr "தேதி மற்றும் நேரம்"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr "நேர மண்டலம் (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:28
+msgid "Time _Format"
+msgstr "நேர வடிவமைப்பு (_F)"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24-மணி"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "நேர மண்டலம் உட்பட தேதி மற்றூம் நேரத்தை மாற்றவும்"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "கடிகாரம்;நேரமண்டலம்;இடம்;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "கணினி நேரம் மற்றும் தேதி அமைவை மாற்றி அமைக்க"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"கணினி நேரம் மற்றும் தேதி அமைப்புகளை மாற்ற நீங்கள் உறுதிப்படுத்த வேண்டும்."
+
+#: ../panels/display/cc-display-panel.c:487
+msgid "Lid Closed"
+msgstr "மூடி மூடப்பட்டது"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+msgid "Mirrored"
+msgstr "பிரதிபலிப்பு"
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2145
+msgid "Primary"
+msgstr "முதன்மை"
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "ஆஃப்"
+
+#: ../panels/display/cc-display-panel.c:497
+msgid "Secondary"
+msgstr "இரண்டாம் நிலை"
+
+#: ../panels/display/cc-display-panel.c:1533
+msgid "Arrange Combined Displays"
+msgstr "சேர்க்கை திரைகாட்டிகளை அடுக்கு"
+
+#: ../panels/display/cc-display-panel.c:1539
+#: ../panels/display/cc-display-panel.c:1979
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "செயல்படுத்து (_A)"
+
+#: ../panels/display/cc-display-panel.c:1560
+msgid "Drag displays to rearrange them"
+msgstr "திரைகாட்டிகளின் வரிசையை மாற்ற அவற்றை இழுக்கவும்"
+
+#: ../panels/display/cc-display-panel.c:2081
+msgid "Size"
+msgstr "அளவு"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2094
+msgid "Aspect Ratio"
+msgstr "தோன்று விகிதம்"
+
+#: ../panels/display/cc-display-panel.c:2115
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "தெளிதிறன் "
+
+#: ../panels/display/cc-display-panel.c:2146
+msgid "Show the top bar and Activities Overview on this display"
+msgstr ""
+"இந்த திரைகாட்டியில் மேல் பட்டியையும் செயல்பாடுகள் மேலோட்டத்தையும் காண்பி"
+
+#: ../panels/display/cc-display-panel.c:2152
+msgid "Secondary Display"
+msgstr "இரண்டாம் நிலை திரைகாட்டி"
+
+#: ../panels/display/cc-display-panel.c:2153
+msgid "Join this display with another to create an extra workspace"
+msgstr ""
+"இந்தத் திரைகாட்டியை மற்றொன்றுடன் இணைத்து கூடுதல் பணியிடத்தை உருவாக்கலாம்"
+
+#: ../panels/display/cc-display-panel.c:2160
+msgid "Presentation"
+msgstr "விளக்கக்காட்சி"
+
+#: ../panels/display/cc-display-panel.c:2161
+msgid "Show slideshows and media only"
+msgstr "ஸ்லைடுகாட்சிகளையும் ஊடகங்களையும் மட்டும் காண்பி"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2166
+msgid "Mirror"
+msgstr "பிரதிபலிப்பு"
+
+#: ../panels/display/cc-display-panel.c:2167
+msgid "Show your existing view on both displays"
+msgstr "இரண்டு திரைகாட்டிகளிலும் தற்போதுள்ள உங்கள் காட்சிவகையைக் காண்பிக்கவும்"
+
+#: ../panels/display/cc-display-panel.c:2173
+msgid "Turn Off"
+msgstr "அணை"
+
+#: ../panels/display/cc-display-panel.c:2174
+msgid "Don't use this display"
+msgstr "இந்தத் திரைகாட்டியைப் பயன்படுத்த வேண்டாம்"
+
+#: ../panels/display/cc-display-panel.c:2383
+msgid "Could not get screen information"
+msgstr "திரை தகவலை பெற முடியவில்லை"
+
+#: ../panels/display/cc-display-panel.c:2414
+msgid "_Arrange Combined Displays"
+msgstr "சேர்க்கை திரைகாட்டிகளை அடுக்கு (_A)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "காட்டிகள்"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+"இணைக்கப்பட்ட திரைகளையும் ஒளிப்படக்காட்டிகளையும் எப்படிப் பயன்படுத்த வேண்டும் "
+"எனத் தேர்வு "
+"செய்யவும்"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "பலகம்;ஒளிப்படக்காட்டி;எக்ஸ்ரான்டர்;திரை;தெளிதிறன்;புதுப்பி;திரை"
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr "வேலேன்ட்"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "தெரியாத"
+
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-பிட்"
+
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr "%d-பிட்"
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr "என்ன செய்ய என்று கேள் "
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr "ஒன்றும் செய்யாதே"
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr "அடைவினை திற"
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr " மற்ற ஊடகம்"
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr "ஒலி குறுந்தட்டுகளுக்கு  நிரலைத் தெரிவுசெய்யவும்"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr "விடியோ டிவிடி களுக்கு நிரலைத் தெரிவுசெய்யவும்"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr "இசைப்பியை இணைத்தபோது துவக்க நிரலை தேர்ந்தெடுக்கவும்."
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr "காமிராவை இணைத்தபோது துவக்க நிரலை தேர்ந்தெடுக்கவும்."
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr "மென்பொருள் குறுந்தட்டுகளுக்கு நிரலைத் தெரிவுசெய்யவும்"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr "ஒலி டிவிடி"
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr "வெற்று ப்ளூ-ரே வட்டு"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr "வெற்று குறுந்தட்டு வட்டு"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr "வெற்று டிவிடி வட்டு"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr "வெற்று ஹெச்டி டிவிடி வட்டு"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr "ப்ளூ-ரே விடியோ வட்டு"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr "மின் புத்தக படிப்பி"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr "ஹெச்டி டிவிடி விடியோ வட்டு"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr "படங்கள் குறுந்தட்டு"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr "சூப்பர் விடியோ குறுந்தட்டு"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr "வீடியோ குறுவட்டு"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr "சாளர மென்பொருள்"
+
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1932
+msgid "Section"
+msgstr "பிரிவு"
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "மேலோட்டம்"
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "முன்னிருப்பு பயன்பாடுகள்"
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "நீக்கப்படக்கூடிய சாதனங்கள் "
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr "பதிப்பு %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:46
+msgid "Details"
+msgstr "விவரங்கள்"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "உங்கள் கணினி குறித்த தகவலைப் பார்க்க"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"சாதனம்;கணினி;தகவல்;நினைவகம்;செயலி;பதிப்பு;முன்னிருப்பு;நிரல்;பயன்பாடு; "
+"முன்னுரிமை;"
+"சிடி;டிவிடி;யூஎஸ்பி;ஒலி;விடியோ;வட்டு;வெளியேற்றக்கூடிய;ஊடகம்;தானியங்கிஇயக்கம்;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "மற்ற ஊடகத்தை எப்படி கையாள வேண்டுமென தேர்வு செய்க"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "செயல் (_A)"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "வகை_T :"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "சாதனம்  பெயர்"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "நினைவகம்"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "செயலகம்"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "அடிப்படைக் கணினி"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "வட்டு"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "கணக்கிடுகிறது…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "வரைகலைகள்"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "மெய்நிகராக்கம்"
+
+#: ../panels/info/info.ui.h:13
+#| msgid "Checking for Updates"
+msgid "Check for updates"
+msgstr "புதுப்பிப்புகள் உள்ளதா எனப் பார்"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "_W இணையம்"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "(_M)மின்னஞ்சல்"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "நாள்காட்டி (_C)"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "_u இசை"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "_V வீடியோ"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "_படங்கள்"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "ஊடகத்தை எப்படி கையாள வேண்டுமென தேர்வு செய்க"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "_a குறுந்தட்டு ஒலி"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "_D டிவிடி விடியோ"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "_M இசை இயக்கி"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "_S மென்பொருள் "
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "மற்ற ஊடகம்… (_O)"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_N ஊடகம் உள்ளிட்டபோது தூண்டாதே அல்லது நிரல்களை துவக்காதே "
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "ஒலி மற்றும் ஊடகம்"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "ஒலியை நிறுத்து"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "ஒலி அளவை குறை"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "ஒலி அளவை உயர்த்து"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "ஊடக இயக்கியை துவக்கு."
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "துவக்கு (துவக்க/ தாமதிக்க)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "திருப்பி இசைத்தலை தாமதி."
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "திருப்பி இசைத்தலை நிறுத்து."
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "முந்தய தடம் ."
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "அடுத்த தடம் ."
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "வெளியேற்று"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "உள்ளிடல் "
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "அடுத்த உள்ளீட்டு மூலத்துக்கு மாற்றவும்"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "முந்தைய உள்ளீட்டு மூலத்துக்கு மாற்றவும்"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "துவக்கிகள் "
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "உதவி மேலோடியை துவக்கு"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "அமைவுகள்"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "கணக்கிடும் கருவியை துவக்கு"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "மின்னஞ்சல் சார்ந்தோனை துவக்கு"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "வலை மேலோடியை துவக்கு"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "இல்ல அடைவுக்குப் போகவும்."
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "தேடு"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "திரை வெட்டுக்கள்"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "ஒரு திரைவெட்டை $PICTURES க்கு சேமிக்கவும்"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "ஒரு சாரளத்தின்  திரைவெட்டினை $PICTURES க்கு சேமிக்கவும்"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "ஒரு பகுதியின் திரைவெட்டை $PICTURES க்கு சேமிக்கவும்"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "திரைவெட்டை ஒட்டுப்பலகைக்கு நகல் எடுக்கவும்."
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "ஒரு சாரளத்தின் திரைவெட்டை ஒட்டுப்பலகைக்கு நகல் எடுக்கவும்."
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "ஒரு இடத்தின் திரைவெட்டை ஒட்டுப்பலகைக்கு நகல் எடுக்கவும்."
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "ஒரு சிறிய திரைக்காட்சியைப் பதிவு செய்"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "கணினி"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "வெளியேறுக"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "திரையை பூட்டு"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "உலகளாவிய அணுகல்"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "அணுகி பார்த்தல் செயலில் அல்லது செயல்நீங்கி"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "அணுகிப்பார்"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "விலகிப்பார்"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "திரை படிப்பி செயலில் அல்லது செயல்நீங்கி"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "திரை விசைப்பலகை செயலில் அல்லது செயல்நீங்கி"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "உரை அளவு ஐ அதிகமாக்குக"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "உரை அளவை குறைவாக்குக"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "உயர் மாறுபாடு செயலில் அல்லது செயல் நீங்கி"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1218
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+msgid "Disabled"
+msgstr "முடக்கப்பட்டது"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "மாற்று எழுத்துருக்கள் விசை"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "உருவாக்க விசை"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "மாற்றிகள்-அடுத்த மூலத்திற்கு மட்டும் மாற்றவும்"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "விசைப்பலகை"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"விசைப்பலகை குறூக்கு வழிகளைக் கண்டு மாற்றவும், அத்துடன் உங்கள் தட்டச்சு "
+"முன்னுரிமைகளை "
+"அமைக்கவும்"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "சுருக்குவழி;மீண்டும்நிகழ்த்து;கண்ணிமை;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "தனிப்பயன் குறுக்குவழி"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "(_N) பெயர்:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "(_o) கட்டளை:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "மறுசெயல் விசைகள்"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "அமுக்கப்படும்போது விசை மறுபடியும் அச்சிடப்படும்."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "(_D) தாமதம்:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "(_S) வேகம்:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "குறுகிய"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "மெதுவாக"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "தொடரும் விசைகளின் வேகம்"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "நீண்ட"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "வேகமான"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "நிலைக்காட்டி சிமிட்டும்"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "(_b) நிலைக்காட்டி உரை  உள்ளே சிமிட்டும்"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "(_p) வேகம்:"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "நிலைகாட்டி சிமிட்டும் வேகம்"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr " உள்ளீட்டு மூலங்கள்"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "குறுக்கு வழியை சேர்"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "குறுக்கு வழியை நீக்கு"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"குறுவழியை திருத்த பொருத்தமான வரியில் சொடுக்கு.  மற்றும் புதிய விசைகளை உள்ளிடு "
+"அல்லது  துப்புரவாக்க பின்னோக்கு  விசையை அழுத்துக ."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "குறுக்கு வழிகள்"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:635
+#: ../panels/keyboard/keyboard-shortcuts.c:643
+msgid "Custom Shortcuts"
+msgstr "தனிப்பயன் குறுக்குவழிகள் "
+
+#: ../panels/keyboard/keyboard-shortcuts.c:860
+msgid "<Unknown Action>"
+msgstr "<தெரியாத செயல்>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1357
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"புதிய குறுக்குவழி \"%s\" யை பயன்படுத்த முடியாது. ஏனெனில் இந்த விசையை "
+"வைத்துக்கொண்டு "
+"தட்டச்ச முடியாது.\n"
+"அதே நேரத்தில் கன்ட்ரோல், ஆல்ட் அல்லது ஷிப்ட் விசைகளை பயன்படுத்தி "
+"முயற்சிக்கவும்."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1387
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr "குறுவழி \"%s\"ஏற்கெனவே \"%s\"க்கு பயன்பட்டது "
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1392
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+" \"%s\" க்கு குறுவழியாக மாற்றி அமைத்தால்  \"%s\" குறுவழி  முடங்கிவிடும்."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1398
+msgid "_Reassign"
+msgstr "(_R) மறுஇருத்து "
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1439
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"\"%s\" குறுக்குவழியுடன் \"%s\" எனும் குறுக்குவழி இணைந்துள்ளது. "
+"அதை தானாகவே \"%s\" க்கு அமைக்க வேண்டுமா?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1449
+#, c-format
+#| msgid ""
+#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#| "disabled."
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"தற்போது \"%s\" ஆனது \"%s\" உடன் இணைந்துள்ளது, நீங்கள் தொடர்ந்தால் இந்தக் "
+"குறுக்குவழி முடக்கப்படும்."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1456
+#| msgid "_Reassign"
+msgid "_Assign"
+msgstr "அமை (_A)"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "உங்களுடைய அமைவுகளை சோதிக்கவும் (_S)"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+msgid "Test Your Settings"
+msgstr "உங்கள் அமைவுகளை சோதிக்கவும்"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "சொடுக்கி மற்றும் தொடுதிட்டு"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"உங்கள் சொடுக்கி அல்லது தொடுதிட்டின் உணர்திறனை மாற்றவும், வலதுகைப் பழக்கமா "
+"இடதுகைப் "
+"பழக்கமா எனத் தேர்ந்தெடுக்கவும்"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "பொது"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "மெதுவாக"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "இரட்டை சொடுக்கு நேரம் முடிந்தது"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "வேகமாக"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "(_D) இரட்டிப்பு சொடுக்கு:"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "_b முதன்மை நிறம்"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "இடது (_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "வலது (_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "சொடுக்கி"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "_P இட சுட்டி வேகம்"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "மெதுவாக"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "வேகமாக"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "தொடுதிட்டு"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "மெதுவாக"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "வேகமாக"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr "(_t) தட்டச்சும்போது செயல்நீக்கு"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr "_c சொடுக்க தட்டவும்"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr "(_f) இரு விரல்கள் உருளல்"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "_Natural scrolling"
+msgstr "இயல்பான உருளல் (_N)"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "சொடுக்கல். இரட்டை சொடுக்கல், உருளல் ஆகியவற்றை முயற்சிக்கவும்"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "ஐந்து கிளிக்குகள், GEGL நேரம்!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "இரட்டை சொடுக்கு, முதன்மை பொத்தான்"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "ஒற்றை சொடுக்கு, முதன்மை பொத்தான்"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "இரட்டை சொடுக்கு, நடு பொத்தான்"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "ஒற்றை சொடுக்கு, நடு பொத்தான்"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "இரட்டை சொடுக்கு, இரண்டாம் பொத்தான்"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "ஒற்றை சொடுக்கு, இரண்டாம் பொத்தான்"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:366
+msgid "Air_plane Mode"
+msgstr "_p விமானப்பாங்கு"
+
+#: ../panels/network/cc-network-panel.c:974
+msgid "Network proxy"
+msgstr "வலையமைப்பு பிரதிநிதி."
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1153 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1298
+msgid "The system network services are not compatible with this version."
+msgstr "இந்த பதிப்புடன் கணினி வலைப்பின்னல் சேவைகள் இசையவில்லை"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x பாதுகாப்பு (_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "பக்கம் 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "அநாமதேய அடையாளம் (_m)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "அக அங்கீகரிப்பு (_a)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "பக்கம் 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "பாதுகாப்பு"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "தானியங்கு"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:218
+#: ../panels/network/net-device-wifi.c:382
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:222
+#: ../panels/network/net-device-wifi.c:387
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:226
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:231
+msgid "Enterprise"
+msgstr "என்டர்ப்ரைஸ்"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:236
+#: ../panels/network/net-device-wifi.c:372
+msgctxt "Wifi security"
+msgid "None"
+msgstr "ஏதுமில்லை"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "ஒரு போதும் இல்லை"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:819
+msgid "Today"
+msgstr "இன்று"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:822
+msgid "Yesterday"
+msgstr "நேற்று"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:476
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i நாளைக்கு முன்"
+msgstr[1] "%i நாட்கள் முன்"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:533
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "None"
+msgstr "ஏதுமில்லை"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "வலுவற்றது"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "சரி"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:568
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "நன்று"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:570
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "மிக நன்று"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "அடையாளம்"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "முகவரி"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "நெட்மாஸ்க்"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "நுழைவாயில்"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "முகவரியை அழிக்கவும்"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "சேர்க்க"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "சேவையகம்"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "DNS சேவையகத்தை அழி"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "மெட்ரிக்"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "பாதையை அழிக்கவும்"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "தானியங்கு (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Manual"
+msgstr "கைமுறை"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "இணைப்பு-உள்ளமை மட்டும்"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "முன்னொட்டு"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "தானியங்கு"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "தானியங்கு, DHCP மட்டும்"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:51
+msgid "Reset"
+msgstr "மீட்டமை"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "எதுவுமில்லை"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-பிட் விசை (ஹெக்ஸ் அல்லது ஆஸ்கி)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-பிட் கடவுச்சொல்"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "மாறும் WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 தனிப்பட்ட"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 கடவுச்சொல்"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr "சமிக்ஞை வலிமை"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "இணைப்பு வேகம்"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 முகவரி"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 முகவரி"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "வன்பொருள் முகவரி"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "முன்னிருப்பு வழி:"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "கடைசியாக பயன்படுத்தப்பட்டது"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "திருப்பிய ஜோடி (டிபி)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "இணைப்பு பொருள் இடைமுகம் (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "பிஎன்சி (BNC)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "ஊடக சார்பில்லா இடைமுகம் (எம்ஐஐ)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "_N பெயர் "
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "MAC முகவரி (_M)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "க்ளோன் செய்யப்பட்ட  முகவரி (_C)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "பைட்டுகள்"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "மற்ற பயனர்களுக்கும் கிடைக்கும்படி அமை (_u)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "நேரத்தை தானியங்கியாக அமை (_a)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "ஃபயர்வால் மண்டலம் (_Z)"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "முன்னிருப்பு"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "மண்டலம் இணைப்பின் நம்பகத்தின் அளவை வரையறுக்கிறது"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "முகவரிகள் (_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "தானியங்கி DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "பாதைகள்"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "தானியங்கி பாதைகள்"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+"இந்த இணைப்பை இந்த பிணையத்தில் உள்ளவர்களுக்கு மட்டும் பயன்படுத்தவும் (_o)"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "இணைப்புத் திருத்தியைத் திறக்க முடியவில்லை"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "புதிய சுயவிவரம்"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "பிணைப்பு"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "அணி"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "பிரிட்ஜ்"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "VPN செருகுநிரல்களை ஏற்ற முடியவில்லை"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "கோப்பிலிருந்து இறக்கவும்…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "பிணைய இணைப்பைச் சேர்"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "மீட்டமை (_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1441
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "மற (_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"இந்தப் பிணையத்திற்கான கடவுச்சொற்கள் உள்ளிட்ட அமைப்புகளை மீட்டமைக்கவும், ஆனால் "
+"இதை விரும்பும் "
+"பிணையமாக நினைவில் கொள்ளவும்"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"இந்தப் பிணையம் தொடர்பான அனைத்து விவரங்களையும் அகற்றவும், மேலும்  தானாக இணைக்க "
+"முயற்சிக்க "
+"வேண்டாம்"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "பாதுகாப்பு (_e)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "VPN இணைப்பை இறக்க முடியவில்லை"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"கோப்பு '%s'ஐ வாசிக்க முடியவில்லை அல்லது அங்கீகரிக்கப்பட்ட VPN இணைப்புத் தகவலை "
+"பெற்றிருக்கவில்லை \n"
+"\n"
+"பிழை: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "இறக்க கோப்பை தேர்ந்தெடுக்கவும்"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1948
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:223
+msgid "_Open"
+msgstr "திற (_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "\"%s\" என பெயரிடப்பட்ட கோப்பு ஏற்கனவே உள்ளது."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "மாற்று (_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "VPN இணைப்புடன் %s ஐ இடமாற்ற நீங்கள் விரும்புகிறீர்களா?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "VPN இணைப்பை ஏற்ற முடியவல்லை"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN இணைப்பு '%s' ஆனது %sஐ ஏற்றுமதி செய்ய முடியாது.\n"
+"\n"
+"பிழை: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+#| msgid "Export VPN connection..."
+msgid "Export VPN connection"
+msgstr "VPN இணைப்பை ஏற்றுமதிசெய்"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(பிழை: VPN இணைப்புத் திருத்தியை ஏற்ற முடியவில்லை)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "என் இல்ல பிணையம்"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "மற்ற பயனர்களுக்கு கிடைக்கும்படி அமை (_o)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "பிணையம்"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "நீங்கள் எப்படி இணையத்துடன் இணைகிறீர்கள் என்பதைக் கட்டுப்படுத்துங்கள்"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
+#| "vpn;vlan;bridge;bond;"
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "பிணைப்பு அடிமைகள்"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(எதுவுமில்லை)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "பிரிட்ஜ் அடிமைகள்"
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:462
+msgid "never"
+msgstr "ஒரு போதும் இல்லை"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:472
+msgid "today"
+msgstr "இன்று"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:474
+msgid "yesterday"
+msgstr "நேற்று"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP முகவரி"
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "கடைசியில் பயன்படுத்தப்பட்டது"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "ஒயர்டு"
+
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1596
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "விருப்பங்கள்…"
+
+#: ../panels/network/net-device-ethernet.c:474
+#, c-format
+msgid "Profile %d"
+msgstr "சுயவிவரம் %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "புதிய இணைப்பு சேர்"
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr "அணி அடிமைகள்"
+
+#: ../panels/network/net-device-wifi.c:1154
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"உங்களிடம் வயர்லெஸ் அல்லாத ஒரு இணைய இணைப்பு இருந்தால், இணைப்பை மற்றவர்களிடம் "
+"பகிர்ந்துகொள்ள "
+"நீங்கள் ஒரு வயர்லெஸ் ஹாட்ஸ்பாட்டை அமைத்துப் பயன்படுத்தலாம்."
+
+#: ../panels/network/net-device-wifi.c:1158
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+"கம்பியில்லா வட்டத்துக்கு மாறுவது <b>%s</b> யிலிருந்ஹ்டு உங்களை துண்டிக்கும்."
+
+#: ../panels/network/net-device-wifi.c:1162
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"கம்பியில்லா வட்டம் செயலில் இருப்பின் உங்களது கம்பியில்லா இணைப்பு மூலம் "
+"நீங்கள் பிணையத்தை "
+"அணுக இயலாது."
+
+#: ../panels/network/net-device-wifi.c:1245
+msgid "Stop hotspot and disconnect any users?"
+msgstr "செயலிடத்தை நிறுத்தி பயனர்களை இணைப்பு நீக்கவா?"
+
+#: ../panels/network/net-device-wifi.c:1248
+msgid "_Stop Hotspot"
+msgstr "_S செயலிடத்தை நிறுத்து"
+
+#: ../panels/network/net-device-wifi.c:1305
+msgid "System policy prohibits use as a Hotspot"
+msgstr "ஹாட்ஸ்பாட்டாக பயன்படுத்துவதை கணினி கொள்கை தடைசெய்கிறது"
+
+#: ../panels/network/net-device-wifi.c:1308
+msgid "Wireless device does not support Hotspot mode"
+msgstr "வயர்லெஸ் சாதனம் ஹாட்ஸ்பாட் பயன்முறையை ஆதரிக்கவில்லை"
+
+#: ../panels/network/net-device-wifi.c:1437
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"தேர்ந்தெடுக்கப்பட்ட பிணையங்களின் கடவுச்சொற்கள் மற்றும் தனிப்பயன் "
+"அமைவாக்கங்கள் உட்பட அனைத்து "
+"விவரங்களும் இழக்கப்படும்."
+
+#: ../panels/network/net-device-wifi.c:1745
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "வரலாறு"
+
+#: ../panels/network/net-device-wifi.c:1749
+#: ../panels/region/input-options.ui.h:2 ../panels/wacom/button-mapping.ui.h:2
+#: ../panels/wacom/cc-wacom-page.c:533
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Close"
+msgstr "மூடு (_C)"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1757
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "மற (_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"வலை பதிலாள் தானியங்கி காணல் வடிவமைப்பு, யூஆர்எல் இல்லாத போது பயன்படும்."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "நம்பகமில்லாத பொது வலைப்பின்னல்களுக்கு இதை பரிந்துரைக்கவில்லை"
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "பதிலாள்"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "சுயவிவரம் சேர் (_A)…"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "வழங்குபவர்"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "எதுவுமில்லை"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "கைமுறை"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "தானியங்கி"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "முறை (_M):"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "(_C) வடிவமைப்பு URL:"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "(_T) HTTP பிரதிநிதி ."
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "(_T) HTTP பிரதிநிதி ."
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "(_F) FTP பிரதிநிதி ."
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "_S சாக்ஸ்  புரவன்"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "ஹோஸ்ட்டுகளைப் புறக்கணி (_I)"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "HTTP ப்ராக்ஸி முனையம்"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "HTTPS ப்ராக்ஸி முனையம்"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "FTP ப்ராக்ஸி முனையம்"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "Socks ப்ராக்ஸி முனையம்"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "சாதனத்தை ஆஃப் செய்"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "சாதனத்தை சேர் "
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "சாதனத்தை நீக்கு"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "விபிஎன் வகை"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "குழு பெயர்"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "குழு கடவுச்சொல்"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "பயனர்பெயர்"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "VPN இணைப்பை ஆஃப் செய்"
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "தானியங்கு இணைப்பு (_C)"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "விவரங்கள்"
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "கடவுச்சொல் (_P)"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "ஏதுமில்லை"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "கடவுச்சொல்லை காட்டு (_a)"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr "மற்ற பயனர்களுக்குக் கிடைக்கும்படி செய்"
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "அடையாளம்"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr "தானியக்கி (DHCP) முகவரிகள் மட்டுமே "
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr "இணைப்பு-உள்ளமை மட்டும்"
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr "மற்ற கணினிகளுடன் பகிரப்பட்டது"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr "தானாக பெற்ற பாதைகளைப் புறக்கணி (_I)"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr "க்ளோன் செய்யப்பட்ட MAC முகவரி (_C)"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr "வன்பொருள்"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"இந்த இணைப்புக்கான அமைவுகளை அவற்றின் முன்னிருப்பு அமைப்புக்கு மீட்டமை, ஆனால் "
+"இதை விரும்பும் "
+"இணைப்பாக நினைவில் கொள்."
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"இந்தப் பிணையம் தொடர்பான அனைத்து விவரங்களையும் அகற்றவும், மேலும்  தானாக இதற்கு "
+"இணைக்க "
+"முயற்சிக்க வேண்டாம்."
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "மீட்டமை"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "வன்பொருள்"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi ஹாட்ஸ்பாட்"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Turn On"
+msgstr "_T இயக்கு"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi ஆஃப் செய்"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_Use as Hotspot…"
+msgstr "ஹாட்ஸ்பாட்டாகப் பயன்படுத்தவும்… (_U)"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "_Connect to Hidden Network…"
+msgstr "மறைக்கப்பட்ட பிணையத்துக்கு இணைக்கவும்...(_C)"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "_History"
+msgstr "வரலாறு (_H)"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "வயர்லெஸ் பிணையத்துடன் இணைப்பதற்கு ஸ்விட்ச் ஆஃப் செய்யவும்"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Network Name"
+msgstr "பிணைய பெயர்"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Connected Devices"
+msgstr "இணைக்கப்பட்ட சாதனங்கள்"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "Security type"
+msgstr "பாதுகாப்பு வகை"
+
+#: ../panels/network/network-wifi.ui.h:63
+msgid "Security key"
+msgstr "பாதுகாப்பு விசை"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "தற்காலிக"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "கட்டுமானம்"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "தெரியாத நிலை"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "மேலாண்மை இல்லாத"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "இருப்பில் இல்லை"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "இணைக்கிறது..."
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "அனுமதி தேவை"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "இணைக்கப்பட்டது"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "துண்டிக்கப்படுகிறது..."
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "இணைப்பு தோல்வியுற்றது"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "நிலை தெரியவில்லை (காணவில்லை)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "இணைக்கப்படவில்லை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "வடிவமைப்பு தோல்வியுற்றது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "ஐபி வடிவமைப்பு தொல்வியுற்றது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "ஐபி வடிவமைப்பு காலாவதியாயிற்று"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "ரகசியங்கள் தேவையாயிருந்தன, ஆனால் தரப்படவில்லை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x சப்ளிகன்ட் துண்டிக்கபட்டது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x சப்ளிகன்ட் வடிவமைப்பு தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1x சப்ளிகன்ட் தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x சப்ளிகன்ட் உறுதிசெய்ய வெகு நேரம் எடுத்துக்கொண்டது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "பிபிபி சேவை துவக்கம் தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "பிபிபி சேவை துண்டிக்கபட்டது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "பிபிபி தோல்வியுற்றது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "டிஹெச்சிபி சார்ந்தோன் துவக்கம் தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "(டிஹெச்சிபி) DHCP சார்ந்தோன் பிழை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "(டிஹெச்சிபி) DHCP சார்ந்தோன் தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "பகிர்ந்த இணைப்பு சேவை துவக்க தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "பகிர்ந்த இணைப்பு சேவை தோல்வியுற்றது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "ஆட்டோஐபி சேவை துவக்கம் தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "ஆட்டோஐபி சேவை துவக்கம் பிழை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "ஆட்டோஐபி சேவை தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "தடம் பயன்பாட்டில்"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "டயல் ஒலி இல்லை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "கடத்தி ஏதும் செயலாக்க முடியவில்லை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "டயல் செய்யும் நேரம் கடந்தது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "டயல் செய்யும் முயற்சி தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "மோடம் துவக்கம் தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "குறிப்பிட்ட ஏபிஎன் ஐ தேர்ந்தெடுத்தல் தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "வலையமைப்புகளை தேடவில்லை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "வலையமைப்பு பதிவுசெய்தல் மறுக்கப்பட்டது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "வலையமைப்பு பதிவுசெய்தல் நேரம் கடந்தது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "வேண்டிய வலையமைப்பு பதிவுசெய்தல் தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "பின்(PIN) சோதனை தோல்வி"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "சாதனத்தின் வர்த்தக மென்பொருள் காணவில்லை போலும்"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "இணைப்பு காணாமல் போயிற்று"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "இருப்பிலுள்ள இணைப்பு இருப்பதாக கொள்ளப்பட்டது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "மோடம் காணப்படவில்லை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "ப்ளூடூத் இணைப்பு தோல்வியுற்றது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "சிம் கார்ட் சொருகப்படவில்லை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "சிம் பின் தேவை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "சிம் பியூகே தேவை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "சிம் தவறானது"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "இன்பினிபேன்ட் சாதனம் இணைப்பு பாங்கை ஆதரிக்கவில்லை"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "இணைப்பு  சார்பு தோல்வியுற்றது"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "தள நிரல் காணவில்லை"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "இணைப்பு துண்டிக்கப்பட்டது"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "அங்கீகார சான்றிதழ் தேர்ந்தெடுக்கப்படவில்லை"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+"ஓரு சான்றிதழ் அங்கீகார (CA) சான்றிதழைப் பயன்படுத்தாவிட்டால், Wi-Fi பிணையங்கள் "
+"பாதுகாப்பற்றதாகவும் நம்பகமற்றதாகவும் விளங்கலாம்.  ஓரு சான்றிதழ் அங்கீகார (CA) "
+"சான்றிதழைத் "
+"தேர்வு செய்ய வேண்டுமா?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "புறக்கணி"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "CA சான்றிதழை தேர்ந்தெடுக்கவும்"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, or PKCS#12 தனிப்பட்ட விசைகள் (*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER அல்லது PEM சான்றிதழ்கள் (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+#| msgid "Choose a PAC file..."
+msgid "Choose a PAC file"
+msgstr "ஒரு PAC கோப்பினைத் தேர்ந்தெடுக்கவும்"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC கோப்புகள் (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC கோப்பு (_f)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "அக அங்கீகாரம் (_I)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "PAC ப்ரோ விஷனிங் (_v)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "அநாமதேயர்"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "அங்கீகரிக்கப்பட்டது"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "இரண்டும்"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "(_U) பயனர் பெயர்:"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "கடவுச்சொல்லைக் காட்டு (_w)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+#| msgid "Choose a Certificate Authority certificate..."
+msgid "Choose a Certificate Authority certificate"
+msgstr "அங்கீகார அதிகாரச் சான்றிதழைத் தேர்ந்தெடுக்கவும்"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "பதிப்பு 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "பதிப்பு 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "CA சான்றிதழ் (_A)"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP பதிப்பு (_v)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "ஒவ்வொரு முறையும் இந்த கடவுச்சொல்லைக் கேட்கவும் (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "மறைகுறியாக்கப்படாத தனிபட்ட விசைகள் பாதுகாப்பில்லாதது"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"தேர்ந்தெடுக்கப்பட்ட தனிப்பட்ட விசையானது கடவுச்சொல்லால் பாதுகாக்கப்படாதது எனத் "
+"தோன்றுகிறது.  இதனால் பாதுகாப்பு சான்றளிப்பு உத்தரவாதமானதாக இல்லாமல் "
+"போகக்கூடும்.  "
+"கடவுச்சொல்லால் பாதுகாக்கப்பட்ட ஒரு தனிப்பட்ட விசையைத் தேர்ந்தெடுக்கவும்.\n"
+"\n"
+"(openssl ஐக் கொண்டு நீங்கள் உங்கள் தனிப்பட்ட விசையை கடவுச்சொல்லால் "
+"பாதுகாக்கப்பட்டதாக "
+"மாற்றலாம்)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+#| msgid "Choose your personal certificate..."
+msgid "Choose your personal certificate"
+msgstr "உங்கள் தனிப்பட்ட சான்றிதழைத் தேர்ந்தெடுக்கவும்"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+#| msgid "Choose your private key..."
+msgid "Choose your private key"
+msgstr "உங்கள் தனிப்பட்ட விசையைத் தேர்ந்தெடுக்கவும்"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "அடையாளம் (_d)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "பயனர் சான்றிதழ் (_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "தனிப்பட்ட விசை ( _k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "தனிப்பட்ட விசை கடவுச்சொல் (_P)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "மீண்டும் எச்சரிக்காதே (_w)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "இல்லை"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "ஆம்"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "டன்னல்டு TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "பாதுகாக்கப்பட்ட EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "அங்கீகாரம் (_t)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (முன்னிருப்பு)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "திறந்த முறைமை"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "பகிரப்பட்ட விசை"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "விசை (_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "விசையைக் காட்டு (_w)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP அட்டவணை (_x)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "வகை (_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "அறிவிப்புகள்"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "ஓலி விழிப்பூட்டல்கள்"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "மேலெழு பதாகைகளைக் காண்பி"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "பதாகைகளில் விவரங்களைக் காட்டு"
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "திரைப்பூட்டில் காண்பி"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "திரைப்பூட்டில் விவரங்களைக் காண்பி"
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "ஆன்"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "அறிவிப்புகள்"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+"எந்தெந்த அறிவிப்புகள் காண்பிக்கப்பட வேண்டும் என்பதையும் அவை எவற்றைக் "
+"காண்பிக்க வேண்டும் "
+"என்பதையும் கட்டுப்படுத்தவும்"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "அறிவிப்புகள்;பதாகை;செய்தி;பலகம்;மேலெழு;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "மேலெழு பதாகைகளைக் காண்பி"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "திரைப்பூட்டில் காண்பி"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+msgctxt "Online Account"
+msgid "Other"
+msgstr "மற்றவை"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "கணக்கு சேர்"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr "மின்னஞ்சல்"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr "தொடர்புகள்"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "அரட்டை"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "வளங்கள்"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "கணக்குக்குள் நுழைவதில் பிழை"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "சான்றளிப்புகள் காலாவதியாகிவிட்டன."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr "இந்தக் கணக்கை செயல்படுத்த உள்நுழையவும்."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr "உள்நுழை (_S)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "கணக்கை உருவாக்குவதில் பிழை"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "கணக்கை நீக்குவதில் பிழை"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "கணக்கை அவசியம்  நீக்க உறுதியாக உள்ளீரா?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "இது சேவையகத்தில் கணக்கை நீக்காது."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "நீக்கு (_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "ஆன் லைன்  கணக்குகள்"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"உங்கள் ஆன்லைன் கணக்குகளில் இணைந்து அவற்றை எதற்கு பயன்படுத்த வேண்டும் என "
+"முடிவு செய்யவும்"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "ஆன் லைன் கணக்கு ஏதும் வடிவமைக்கப்படவில்லை"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "கணக்கு நீக்கு"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "ஒரு ஆன் லைன் கணக்கு சேர்"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"ஒரு கணக்கை சேர்ப்பது உங்கள் பயன்பாடுகளை அதன் ஆவணங்கள், மின்னஞ்சல், "
+"தொடர்புகள், நாட்காட்டி, "
+"அரட்டை மேலும் பலவற்றை அணுக அனுமதிக்கும்."
+
+#: ../panels/power/cc-power-panel.c:183
+msgid "Unknown time"
+msgstr "தெரியாத நேரம்"
+
+#: ../panels/power/cc-power-panel.c:189
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i நிமிடம்"
+msgstr[1] "%i நிமிடங்கள்"
+
+#: ../panels/power/cc-power-panel.c:201
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i மணிநேரம்"
+msgstr[1] "%i மணிநேரங்கள்"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:209
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:210
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "மணி"
+msgstr[1] "மணிகள்"
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "நிமிடம்"
+msgstr[1] "நிமிடங்கள்"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:230
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s முழுவதும் சார்ஜ் செய்யப்படும் வரை"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:237
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "எச்சரிக்கை: %s மீதமுள்ளது"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:242
+#, c-format
+msgid "%s remaining"
+msgstr "%s மீதமுள்ளது"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
+msgid "Fully charged"
+msgstr "முழுதும் சார்ஜ் செய்யப்பட்டது"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
+msgid "Empty"
+msgstr "வெற்று"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Charging"
+msgstr "மின் சக்தி ஏற்றம் ஆகிறது"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:271
+msgid "Discharging"
+msgstr "சக்தி இறங்குகிறது"
+
+#: ../panels/power/cc-power-panel.c:396
+msgctxt "Battery name"
+msgid "Main"
+msgstr "முதன்மை"
+
+#: ../panels/power/cc-power-panel.c:398
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "கூடுதல்"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:470
+msgid "Wireless mouse"
+msgstr "கம்பியில்லா சொடுக்கி"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:473
+msgid "Wireless keyboard"
+msgstr "கம்பியில்லா விசைப்பலகை"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:476
+msgid "Uninterruptible power supply"
+msgstr "தடையில்லா மின்சாரம்"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Personal digital assistant"
+msgstr "அந்தரங்க இரும உதவியாளர்"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Cellphone"
+msgstr "அலைபேசி"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Media player"
+msgstr "இசை இயக்கி"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Tablet"
+msgstr "தொடுபலகை"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Computer"
+msgstr "கணினி"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
+#: ../panels/power/cc-power-panel.c:2019
+msgid "Battery"
+msgstr "மின்கலம்"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "மின் சக்தி ஏற்றம் ஆகிறது"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "எச்சரிக்கை"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Low"
+msgstr "குறைவான"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Good"
+msgstr "நன்று"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "முழுதும் சார்ஜ் செய்யப்பட்டது"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "வெற்று"
+
+#: ../panels/power/cc-power-panel.c:715
+msgid "Batteries"
+msgstr "பேட்டரிகள்"
+
+#: ../panels/power/cc-power-panel.c:1117
+msgid "When _idle"
+msgstr "செயலின்றி இருக்கும் போது (_i)"
+
+#: ../panels/power/cc-power-panel.c:1445
+msgid "Power Saving"
+msgstr "மின்சக்தி சேமிப்பு"
+
+#: ../panels/power/cc-power-panel.c:1473
+msgid "_Screen brightness"
+msgstr "திரை பிரகாசம் (_S)"
+
+#: ../panels/power/cc-power-panel.c:1479
+msgid "_Keyboard brightness"
+msgstr "விசைப்பலகை பிரகாசம் (_K)"
+
+#: ../panels/power/cc-power-panel.c:1489
+msgid "_Dim screen when inactive"
+msgstr "செயலின்றி இருக்கையில் திரையை மங்கலாக்கு (_D)"
+
+#: ../panels/power/cc-power-panel.c:1514
+msgid "_Blank screen"
+msgstr "வெற்றுத் திரை (_B)"
+
+#: ../panels/power/cc-power-panel.c:1551
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: ../panels/power/cc-power-panel.c:1556
+msgid "Turns off wireless devices"
+msgstr "வயர்லெஸ் சாதனங்களை இயக்க நிறுத்தும்"
+
+#: ../panels/power/cc-power-panel.c:1581
+msgid "_Mobile broadband"
+msgstr "மொபைல் பிராட்பேண்டு (_M)"
+
+#: ../panels/power/cc-power-panel.c:1586
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "மொபைல் பிராட்பேன்ட் (3G, 4G, WiMax போன்ற) சாதனங்களை இயக்க நிறுத்தும்"
+
+#: ../panels/power/cc-power-panel.c:1635
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: ../panels/power/cc-power-panel.c:1686
+msgid "When on battery power"
+msgstr "பேட்டரி சக்தியில் இருக்கையில்"
+
+#: ../panels/power/cc-power-panel.c:1688
+msgid "When plugged in"
+msgstr "சொருகியுள்ள போது"
+
+#: ../panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Off"
+msgstr "இடைநிறுத்து & அணை"
+
+#: ../panels/power/cc-power-panel.c:1851
+msgid "_Automatic suspend"
+msgstr "தானியங்கு இடைநிறுத்தம் (_A)"
+
+#: ../panels/power/cc-power-panel.c:1875
+msgid "When battery power is _critical"
+msgstr "பேட்டரி மின்சாரம் மிகக் குறைவாகிப் போகையில் (_C)"
+
+#: ../panels/power/cc-power-panel.c:1930
+msgid "Power Off"
+msgstr "மின்சக்தி நிறுத்து"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Devices"
+msgstr "சாதனங்கள்"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "சக்தி"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr "பேட்டரி நிலையைக் கண்டு மின்சக்தி சேமிப்பு அமைவுகளை மாற்றவும்"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"சக்தி;உறங்கு;இடைநிறுத்தம்;பேட்டரி;பிரகாசம்;மங்கல்;வெற்று;மானிட்டர்;DPMS;செயலின"
+"்றி;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "இடை உறக்கம்"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "மின்சக்தி நிறுத்தம்"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "45 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 மணி"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "80 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "90 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "100 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "2 மணிகள்"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 நிமிடம்"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "4 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "8 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "12 நிமிடங்கள்"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "தானியங்கு இடைநிறுத்தம்"
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr "செருகியுள்ள போது (_P)"
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr "பேட்டரி சக்தியில் இருக்கையில் (_B)"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "தாமதி"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "அங்கீகாரம்"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "கடவுச்சொல்"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "அனுமதி உறுதிபடுத்தல் வேண்டும்"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr "அச்சுப்பொடி குறைவாக உள்ளது"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr "அச்சு மைப்பொடி போதாது"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr "உருவாக்கி குறைவாக உள்ளது"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr "உருவாக்கி இல்லை"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr "குறியிடுவான் கொடை குறைவாக உள்ளது"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr "குறியிடுவான் கொடை இல்லை"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr "மூடியை திற"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr "கதவை திற"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr "காகிதம் குறைவாக உள்லது"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr "தாள் வெளியே உள்ளது"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr "இணைப்பு விலகி"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "நிறுத்தப்பட்டது"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr "குப்பைக்கூடை அனேகமாக நிறைந்தது"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr "குப்பைக்கூடை நிறைந்தது"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr "ஒளி கடத்தியின் வாழ்நாள் முடிவு நெருங்கிவிட்டது"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ஒளி கடத்தி இப்போது வேலை செய்யவில்லை"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "வடிவமைக்கிறது."
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr "தயார்"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "பணிகளை ஏற்க வேண்டாம்"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr "செயலாக்கம்..."
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Toner Level"
+msgstr "அச்சு மைப்பொடி மட்டம்"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Ink Level"
+msgstr "மசி மட்டம்:"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:928
+msgid "Supply Level"
+msgstr "கொடை மட்டம்"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:946
+msgctxt "printer state"
+msgid "Installing"
+msgstr "நிறுவப்படுகிறது"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1123
+msgid "No printers available"
+msgstr "அச்சுப்பொறி எதுவும் இல்லை "
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1433
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "செயலில் %u"
+msgstr[1] "செயலில் %u"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1777
+msgid "Failed to add new printer."
+msgstr "அச்சுப்பொறியை சேர்க்க முடியவில்லை"
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid "Select PPD File"
+msgstr "பிபிடி கோப்பை  தேர்ந்தெடு."
+
+#: ../panels/printers/cc-printers-panel.c:1953
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"போஸ்ட்ஸ்கிரிப்ட் அசுப்பொறி விவர கோப்புகள் (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+"*.PPD."
+"GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2258
+msgid "No suitable driver found"
+msgstr "தகுந்த இயக்கி எதுவும் காணப்படவில்லை "
+
+#: ../panels/printers/cc-printers-panel.c:2327
+msgid "Searching for preferred drivers…"
+msgstr "விரும்பப்படும் இயக்கிகளை தேடுகிறது…"
+
+#: ../panels/printers/cc-printers-panel.c:2342
+msgid "Select from database…"
+msgstr "தரவுத்தளத்திலிருந்து தேர்ந்தெடு…"
+
+#: ../panels/printers/cc-printers-panel.c:2351
+msgid "Provide PPD File…"
+msgstr "PPD கோப்பை வழங்கவும்…"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2502
+#: ../panels/printers/cc-printers-panel.c:2525
+msgid "Test page"
+msgstr "சோதனை பக்கம்"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2933
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "ui ஏற்ற முடியவில்லை: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "அச்சுப்பொறிகள்"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"அச்சுப்பொறிகளைச் சேர்க்கவும், அச்சுப்பொறி பணிகளைக் காணவும் மற்றும் அவை எப்படி "
+"அச்சிட "
+"வேண்டும் என முடிவு செய்யவும்"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "அச்சுப்பொறி;வரிசை;அச்சடி;காகிதம்;மசி;டோனர்;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "செயலில் உள்ள வேலைகள்"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "மூடு"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "அச்சிடுவதை தொடர்க"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "அச்சடித்தலை தாமதி"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "அச்சு வேலையை ரத்து செய் "
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "புதிய அச்சுப்பொறியை சேர்"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "A_uthenticate"
+msgstr "அங்கீகரி (_u)"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "அச்சுப்பொறிகள் எதுவும் கண்டுபிடிக்கப்படவில்லை ."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter address of a printer or a text to filter results"
+msgstr ""
+"முடிவுகளை வடிகட்ட ஒரு அச்சுப்பொறியின் முகவரி அல்லது உரை ஒன்றை உள்ளிடவும்"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "விருப்பங்களை ஏற்றுகிறது..."
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "அச்சுப்பொறி இயக்கியை தேர்ந்தெடு"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "இயக்கிகள் தரவுத்தளத்தை ஏற்றுகிறது..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+#| msgid "Remove Printer"
+msgid "JetDirect Printer"
+msgstr "JetDirect அச்சுப்பொறி"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+#| msgid "%s Printer"
+msgid "LPD Printer"
+msgstr "LPD அச்சுப்பொறி"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "ஒரு பக்க"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "நீள விளிம்புடைய (செந்தரம்)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "குறுகிய விளிம்புடைய (புரட்டு)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "செங்குத்து "
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "கிடைமட்டம்"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "பின்திருப்பிய கிடைமட்டம்"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "பின்திருப்பிய செங்குத்து"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "நிலுவையில்"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "கிடப்பில்"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "செயலாக்கமாகிறது"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "நிறுத்தப்பட்டது"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "ரத்து செய்யப்பட்டது"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "கைவிடப்பட்டது"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "முடிவுற்றது"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "வேலையின் தலைப்பு"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "வேலை நிலை"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "நேரம்"
+
+#: ../panels/printers/pp-jobs-dialog.c:495
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s செயலில் உள்ள வேலைகள்"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Serial Port"
+msgstr "வரிசை துறை"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1683
+msgid "Parallel Port"
+msgstr "இணையான துறை"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+#| msgid "Location"
+msgid "Location: %s"
+msgstr "இடம்: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1744
+#, c-format
+#| msgid "A_ddress:"
+msgid "Address: %s"
+msgstr "முகவரி: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1768
+msgid "Server requires authentication"
+msgstr "சேவையகத்திற்கு அங்கீகாரம் தேவைப்படுகிறது"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "இரு பக்க"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "காகித வகை"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "காகித மூலம்"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "வெளியீட்டு தட்டு"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "கோஸ்ட்ஸ்கிரிப்ட் முன் வடிகட்டல்"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:531
+msgid "Pages per side"
+msgstr "தாள்பக்கத்துக்கு பக்கங்கள்"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:543
+msgid "Two-sided"
+msgstr "இரு பக்கம்"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:555
+msgid "Orientation"
+msgstr "திசை"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:652
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "பொது"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "பக்க அமைவு"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "நிறுவக்கூடிய தேர்வுகள்"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "வேலை"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "பிம்ப தரம்"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "நிறம்"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "முடிக்கிறது"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "மேம்பட்ட"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "தானியங்கியாக தேர்வு செய்க "
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "அச்சுப்பொறி முன்னிருப்பு"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "கோஸ்ட் ஸ்க்ரிப்ட் எழுத்துருக்களை மட்டும் உள்ளமை"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "பிஎஸ் மட்டம் 1 க்கு மாற்று"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "பிஎஸ் மட்டம் 2 க்கு மாற்று"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "முன் வடிகட்டல் இல்லை"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "உற்பத்தியாளர்"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "இயக்கி"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"%s இல் கிடைக்கும் அச்சுப்பொறிகளைக் காண உங்கள் பயனர் பெயர் மற்றும் "
+"கடவுச்சொல்லை உள்ளிடவும்."
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "அச்சுப்பொறியைச் சேர்"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "அச்சுப்பொறியை நீக்கு"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "வழங்கு"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "இடம்"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+#| msgid "Default Route"
+msgid "_Default printer"
+msgstr "முன்னிருப்பு அச்சுப்பொறி (_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "வேலைகள்"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "பணிகளைக் காண்பி Show _Jobs"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "மாதிரி"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "விளக்கச்சீட்டு"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "புதிய இயக்கியை அமைக்கிறது..."
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "பக்கம் 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "_T சோதனை பக்கத்தை அச்சிடு"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "விருப்பங்கள் (_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "புதிய அச்சுப்பொறியை சேர்"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"மன்னிக்க! கணினியின் அச்சிடும் சேவை\n"
+" கிடைப்பதாக தெரியவில்லை"
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "திரைப்பூட்டு"
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "பயன்பாடு & வரலாறு"
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr "குப்பைத் தொட்டியிலிருந்து அனைத்தையும் நீக்கி காலி செய்யவா?"
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr "குப்பைத் தொட்டியில் உள்ளவை அனைத்தும் நிரந்தரமாக நீக்கப்படும்."
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "குப்பை தொட்டியை காலி செய் (_E)"
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+msgid "Delete all the temporary files?"
+msgstr "தற்காலிகக் கோப்புகள் அனைத்தையும் அழிக்கவா?"
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr "தற்காலிகக் கோப்புகள் அனைத்தும் நிரந்தரமாக அழிக்கப்படும்."
+
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "தற்காலிக கோப்புகளை அழி (_P)"
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "தேவையற்றதையும் தற்காலிகக் கோப்புகளையும் அழி"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+#| msgid "Software"
+msgid "Software Usage"
+msgstr "மென்பொருள் பயன்பாடு"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "தனியுரிமை"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+"உங்கள் தனிப்பட்ட தகவல்களைப் பாதுகாப்பாக வைத்திருந்து, மற்றவர்கள் எவற்றை "
+"மட்டும் காணக்கூடும் "
+"என்பதை நீங்களே கட்டுப்படுத்துங்கள்"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"திரை;பூட்டு;கண்டறிதல்கள்;செயலிழப்பு;தனிப்பட்ட;சமீபத்திய;தற்காலிக;tmp;அட்டவணை;ப"
+"ெயர்;"
+"பிணையம்;அடையாளம்;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "திரை அணைகிறது"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 நொடிகள்"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 நாள்"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 நாட்கள்"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 நாட்கள்"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 நாட்கள்"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 நாட்கள்"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 நாட்கள்"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 நாட்கள்"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 நாட்கள்"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 நாட்கள்"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "எப்போதும் "
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"உங்கள் வரலாற்றை நினைவில் கொள்வதால், வேண்டியவற்றை எளிதில் மீண்டும் "
+"கண்டுபிடிக்க முடியும். "
+"இவை பிணையத்தின் வழியாக எப்போதும் பகிரப்படாது."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "சமீபத்தில் பயன்படுத்தியது (_R)"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "வரலாற்றை வைத்திரு (_H)"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "சமீபத்திய வரலாற்றை அழி (_e)"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr ""
+"நீங்கள் கணினியை விட்டு விலகி இருக்கும் போது திரைப்பூட்டு உங்கள் தனியுரிமையைப் "
+"பாதுகாக்கிறது."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "தானியங்கி திரைப்பூட்டு (_L)"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "இவ்வளவு நேரம் வெறுமையாக இருந்த பிறகு திரையைப் பூட்டவும் (_a)"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "அறிவிப்புகளைக் காண்பி (_N)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"தேவையில்லாத முக்கியத் தகவல்கள் அடைத்துக்கொண்டு இல்லாமல் உங்கள் கணினி சிறப்பாக "
+"இருக்க, "
+"குப்பை தொட்டியையும் தற்காலிகக் கோப்புகளையும் தானாக அழிக்கவும்."
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "குப்பைதொட்டியை தானாக காலி செய் (_T)"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "தற்காலிகக் கோப்புகளை தானாக அழி (_F)"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "இத்தனை நாட்களுக்குப் பிறகு அழி (_A)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"நீங்கள் எந்த மென்பொருளைப் பயன்படுத்துகிறீர்கள் என்ற தகவலை எங்களுக்கு "
+"அனுப்பினால், உங்களுக்கு "
+"இன்னும் துல்லியமான பரிந்துரைகளை வழங்க எங்களுக்கு அது உதவியாக இருக்கும். அது "
+"எங்கள் மென்பொருளை "
+"மேம்படுத்தவும் உதவும்.\n"
+"\n"
+"நாங்கள் சேகரிக்கும் தகவல் அனைத்துமே பெயரிலாததாக்கப்படும், உங்கள் தரவை ஒரு "
+"போதும் மூன்றாம் தரப்பினரிடம் பகிர மாட்டோம்."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "மென்பொருள் பயன்பாடு விவரங்களை அனுப்பு (_S)"
+
+#: ../panels/privacy/privacy.ui.h:41
+#| msgid "Privacy"
+msgid "Privacy Policy"
+msgstr "தனியுரிமைக் கொள்கை"
+
+#: ../panels/privacy/privacy.ui.h:42
+#| msgid "_Location name:"
+msgid "_Location Services"
+msgstr "இருப்பிடச் சேவைகள் (_L)"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "உங்கள் இருப்பிடத்தைத் தீர்மானிக்க பயன்படுகிறது"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "இம்பீரியல்"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "மெட்ரிக்"
+
+#: ../panels/region/cc-format-chooser.c:284
+msgid "No regions found"
+msgstr "பகுதி காணப்படவில்லை"
+
+#: ../panels/region/cc-input-chooser.c:179
+msgid "No input sources found"
+msgstr "உள்ளீட்டு மூலங்கள் இல்லை"
+
+#: ../panels/region/cc-input-chooser.c:1076
+msgctxt "Input Source"
+msgid "Other"
+msgstr "மற்றவை"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:892
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "மாற்றங்கள் விளைவை ஏற்படுத்த உங்கள் அமர்வை மறுதொடக்கம் செய்ய வேண்டும்"
+
+#: ../panels/region/cc-region-panel.c:240
+#: ../panels/user-accounts/um-user-panel.c:893
+msgid "Restart Now"
+msgstr "இப்போது மறுதுவக்கு"
+
+#: ../panels/region/cc-region-panel.c:858
+msgid "No input source selected"
+msgstr "உள்ளீட்டு மூலம் தேர்ந்தெடுக்கப்படவில்லை"
+
+#: ../panels/region/cc-region-panel.c:1088
+msgid "Sorry"
+msgstr "மன்னிக்கவும்"
+
+#: ../panels/region/cc-region-panel.c:1090
+msgid "Input methods can't be used on the login screen"
+msgstr "புகுபதிவு திரையில் உள்ளீட்டு முறைகளைப் பயன்படுத்த முடியாது"
+
+#: ../panels/region/cc-region-panel.c:1727
+msgid "Login Screen"
+msgstr "புகுபதிவு திரை"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "ஒழுங்குகள்"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "முன்பார்வை"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "தேதிகள்"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "நேரங்கள்"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "எண்கள்"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "அளவு "
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "காகிதம்"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr " வட்டாரம் மற்றும் மொழி "
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"உங்கள் காட்சி மொழி, வடிவமைப்புகள், விசைப்பலகை தளவமைப்புகள் மற்றும் உள்ளீட்டு "
+"மூலங்களைத் "
+"தேர்ந்தெடுக்கவும்"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "மொழி;இடஅமைவு;விசைப்பலகை;உள்ளீடு;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "ஒரு உள்ளீட்டு மூலத்தைச் சேர்"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "உள்ளீட்டு மூல விருப்பங்கள்"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Use the _same source for all windows"
+msgstr "எல்லா  சாளரத்திற்கும் ஒரே மூலத்தைப் பயன்படுத்து (_s)"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Allow _different sources for each window"
+msgstr "ஒவ்வொரு சாளரத்திற்கும் வெவ்வேறு மூலங்களைப் பயன்படுத்து (_d)"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Keyboard Shortcuts"
+msgstr "விசைப்பலகை குறுக்கு வழிகள்"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Switch to previous source"
+msgstr "முந்தைய மூலத்துக்கு மாற்றவும்"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Switch to next source"
+msgstr "அடுத்த மூலத்துக்கு மாற்றவும்"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "இந்த குறுக்குவழிகளை நீங்கள் விசைப்பலகை அமைப்புகளில் மாற்றலாம்"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Alternative switch to next source"
+msgstr "அடுத்த மூலத்திற்கு மாற்று விசை"
+
+#: ../panels/region/input-options.ui.h:12
+msgid "Left+Right Alt"
+msgstr "இடது+வலது Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "ஆங்கிலம் (இங்கிலாந்து)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "யுனைட்டக் கிங்டம்"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "தேர்வுகள்"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"புகுபதிவு அமைப்புகள் கணினியில் புகுபதிவு செய்யும் போது அனைத்து பயனர்களாலும் "
+"பயன்படுத்தப்படும்"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr "இடங்கள்"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "புத்தகக்குறிகள்"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr "மற்றவை"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "ஒரு இடத்தை தேர்ந்தெடுக்கவும்"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+msgid "_OK"
+msgstr "சரி (_O)"
+
+#: ../panels/search/cc-search-panel.c:176
+msgid "No applications found"
+msgstr "பயன்பாடு எதுவும் இல்லை"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "தேடு"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"செயல்பாடுகளின் மேலோட்டப் பார்வையில், எந்த பயன்பாடுகள் தேடல் முடிவுகளைக் "
+"காண்பிக்க வேண்டும் "
+"என்பதைக் கட்டுப்படுத்தவும்"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "தேடு;கண்டறி;அட்டவணை;மறை;தனியுரிமை;முடிவுகள்;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "இடங்களைத் தேடு"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "மேலே நகர்த்து"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "கீழே நகர்த்து"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "முன்னுரிமைகள்"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "ஆன்"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "ஆஃப்"
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+#| msgid "Enabled"
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "செயல்படுத்தப்பட்டது"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+#| msgid "Active Jobs"
+msgctxt "service is active"
+msgid "Active"
+msgstr "செயலில் உள்ளது"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "ஒரு கோப்புறையைத் தேர்ந்தெடுக்கவும்"
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "நகலெடு"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "பகிர்வு"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr ""
+"நீங்கள் மற்றவர்களுடன் எவற்றைப் பகிர வேண்டும் என்பதைக் கட்டுப்படுத்தவும்"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"பகிர்;பகிர்தல்;ssh;ஹோஸ்ட்;பெயர்;தொலைநிலை;டெஸ்க்டாப்;bluetooth;obex;மீடியா;ஆடிய"
+"ோ;வீடியோ;"
+"படங்கள்;புகைப்படங்கள்;மூவிகள்;சேவையகம்;ரென்டெரர்;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "தொலைநிலை புகுபதிவை செயல்படுத்து அல்லது முடக்கு"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "தொலைநிலை புகுபதிவை செயல்படுத்த அல்லது முடக்க அங்கீகாரம் தேவைப்படுகிறது"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:299
+#| msgid "List of keyboard layouts selected for usage"
+msgid "No networks selected for sharing"
+msgstr "பகிர்வதற்கு பிணையங்கள் எதுவும் தேர்ந்தெடுக்கப்படவில்லை"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+#| msgid "Network"
+msgid "Networks"
+msgstr "பிணையங்கள்"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "Bluetooth பகிர்வு"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"Bluetooth பகிர்வைக் கொண்டு நீங்கள் Bluetooth செயல்படுத்தப்பட்ட மற்ற "
+"சாதனங்களுடன் "
+"கோப்புகளைப் பகிர்ந்து கொள்ளலாம்"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "நம்பகமான சாதனங்களிடமிருந்து மட்டும் பெறவும்"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "பெறப்படும் கோப்புகளை பதிவிறக்கங்கள் கோப்புறையில் சேமிக்கவும்"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "கணினியின் பெயர்"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "தனிப்பட்ட கோப்பு பகிர்வு"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "திரை பகிர்வு"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "மீடியா பகிர்வு"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "தொலைநிலை புகுபதிவு"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "பிணைய அணுகல் இல்லாததால் சில சேவைகள் முடக்கப்பட்டுள்ளன."
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"தனிப்பட்ட கோப்புப் பகிர்வைக் கொண்டு நீங்கள் இதைப் பயன்படுத்தி உங்கள் தற்போதைய "
+"பிணையத்திலுள்ள "
+"மற்றவர்களுடன் உங்கள் பொதுக் கோப்புறையைப் பகிர்ந்துகொள்ள முடியும்: <a "
+"href=\"dav://%s"
+"\">dav://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr "கடவுச்சொல் தேவை"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"Secure Shell கட்டளையைப் பயன்படுத்தி தொலைநிலை பயனர்கள் இணைவதற்கு "
+"அனுமதிக்கவும்:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"தொலைநிலை பயனர்கள் இதில் இணைவதன் மூலம் உங்கள் திரையை அணுகவும் "
+"கட்டுப்படுத்தவும் "
+"அனுமதிக்கவும்: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:20
+#| msgid "Remote Control"
+msgid "Allow Remote Control"
+msgstr "தொலைநிலைக் கட்டுப்பாட்டை அனுமதி"
+
+#: ../panels/sharing/sharing.ui.h:21
+#| msgid "Password"
+msgid "Password:"
+msgstr "கடவுச்சொல்:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "கடவுச்சொல்லை காட்டு"
+
+#: ../panels/sharing/sharing.ui.h:23
+#| msgid "%s Options"
+msgid "Access Options"
+msgstr "அணுகல் விருப்பங்கள்"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "புதிய இணைப்புகள் அணுகலைக் கோர வேண்டும்"
+
+#: ../panels/sharing/sharing.ui.h:25
+#| msgid "Require Password"
+msgid "Require a password"
+msgstr "கடவுச்சொல் தேவை"
+
+#: ../panels/sharing/sharing.ui.h:26
+#| msgid "Share Music, Photos and Videos with others on the current network."
+msgid "Share music, photos and videos over the network."
+msgstr "பிணையத்தின் வழியாக இசை, புகைப்படங்கள் மற்றும் வீடியோக்களைப் பகிரலாம்."
+
+#: ../panels/sharing/sharing.ui.h:27
+#| msgid "Add Folder"
+msgid "Folders"
+msgstr "கோப்புறைகள்"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "ஒலி"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"ஒலி அளவுகள், உள்ளீடுகள், வெளியீடுகள் மற்றும் விழிப்பூட்டல் ஒலிகளை மாற்று"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "அட்டை;ஒலிவாங்கி;ஒலிஅளவு;மறைவுறு;சமனம்;ப்ளூடூத்;ஹெட்செட்;ஆடியோ;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "குரைப்பு"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "தண்ணீர் சொட்டு"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "க்ளாஸ்"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "சோனார்"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "இடது"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "வலது"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "பின்"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "முன்"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "குறைந்தபட்சம்"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "அதிக பட்சம்"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "_B சமனம்:"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "_F மறைவுறு:"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "_S சப்வூஃபர்:"
+
+#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:616
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "பெருக்காதது"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "_P விவரகுறிப்பு:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u வெளிப்பாடு"
+msgstr[1] "%u வெளிப்பாடுகள்"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u உள்ளீடு"
+msgstr[1] "%u உள்ளீடுகள்"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "கணினி ஒலிகள்"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "_T ஒலி பெருக்கிகளை சோதி "
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "உச்சிகளை கண்டுபிடி"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1509
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "பெயர்"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1528
+msgid "Device"
+msgstr "சாதனம்"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1591
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s க்கு ஒலி பெருக்கி சோதனை"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1649
+msgid "_Output volume:"
+msgstr "_O வெளியீடு ஒலி அளவு: "
+
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "Output"
+msgstr "வெளிப்பாடு"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1668
+msgid "C_hoose a device for sound output:"
+msgstr "_h ஒலி வெளிப்பாடுக்கு சாதனத்தை தேர்ந்தெடு"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1693
+msgid "Settings for the selected device:"
+msgstr "தேர்ந்தெடுக்கப்பட்ட சாதனத்திற்கு அமைப்பு:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "Input"
+msgstr "உள்ளீடு"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "_Input volume:"
+msgstr "(_I) உள்ளீட்டு ஒலி அளவு:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1734
+msgid "Input level:"
+msgstr "(_I) உள்ளீட்டு மட்டம்:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1762
+msgid "C_hoose a device for sound input:"
+msgstr "_h ஒலி உள்ளீட்டுக்கு சாதனம் தேர்ந்தெடு:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "Sound Effects"
+msgstr "ஒலி விளைவுகள்"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+msgid "_Alert volume:"
+msgstr "_A எச்சரிக்கை அளவு:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1809
+msgid "Applications"
+msgstr "பயன்பாடுகள்"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1813
+msgid "No application is currently playing or recording audio."
+msgstr "நடப்பில் எந்த பயன்பாடும் ஒலியை இயக்கவோ பதியவோ இல்லை"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "உட்பொதியப்பட்டது"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "ஒலி முன்னுரிமைகள்"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "ஒலி நிகழ்வை சோதிக்கிறது"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "முன்னிருப்பு"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "தீமிலிருந்து"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:769
+msgid "C_hoose an alert sound:"
+msgstr "ஒரு விழிப்பூட்டும் ஒலியை தேர்ந்தெடு: (_h)"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "நிறுத்து"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "சோதனை"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "சப்வூஃபர்"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "தனிப்பயன்"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"பார்ப்பது, கேட்பது, தட்டச்சு செய்வது, சுட்டுவது மற்றும் சொடுக்குவது "
+"அனைத்தையும் "
+"எளிதாக்கவும்"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "அனைவருக்குமான அணுகல் மெனுவை எப்போதும் காட்டு (_A)"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "காணல் "
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "அதிக வேறுபாடு (_H)"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "பெரிய உரை (_L)"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "_Zoom"
+msgstr "பெரிதாக்கு (_Z)"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr "திரைபடிப்பான் (_R)"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "_Sound Keys"
+msgstr "ஒலி விசைகள் (_S)"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "கேட்டல் "
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr "காட்சி எச்சரிக்கைகள் (_V)"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Screen _Keyboard"
+msgstr "திரை விசைப்பலகை (_K)"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "_Typing Assist (AccessX)"
+msgstr "தட்டச்சு உதவியாளர் (AccessX) (_T)"
+
+#: ../panels/universal-access/uap.ui.h:14
+#| msgid "Pointing and Clicking"
+msgid "Pointing & Clicking"
+msgstr "சுட்டி & சொடுக்கல்"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "_Mouse Keys"
+msgstr "சொடுக்கி விசைகள் (_M)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "சொடுக்க உதவி (_C)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "திரைபடிப்பான்"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"திரைபடிப்பான் நீங்கள் திரை கவனப் பகுதியை நகர்த்தும் போது அதற்குரிய உரையை "
+"படித்துக் "
+"காட்டும்."
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Screen Reader"
+msgstr "திரைபடிப்பான் (_S)"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Sound Keys"
+msgstr "ஒலி விசைகள்"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "Num Lock அல்லது Caps Lock இயக்கப்படும் போது பீப் ஒலி எழுப்பு."
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "காட்சி எச்சரிக்கைகள்"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "_T மின்ஒளியை சோதி "
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "எச்சரிக்கை ஒலி எழுப்பப்படும் போது காட்சி அடையாளத்தையும் காட்டு."
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Flash the _window title"
+msgstr "சாளர தலைப்புப்பட்டையை பளிச்சிடு (_W)"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Flash the entire _screen"
+msgstr "முழு திரையை பளிச்சிடு (_s)"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Typing Assist"
+msgstr "தட்டச்சு உதவியாளர்"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "_Sticky Keys"
+msgstr "ஒட்டு விசைகள் (_S)"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "மாற்றி விசைகளின் வரிசை ஒன்றை விசை தொகுப்பாக கொள்ளும்."
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "_D இரண்டு விசைகளை ஒரே நேரத்தில் அழுத்தினால் செயல் நீக்கவும்."
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifer key is pressed"
+msgstr "(_m) மாற்றி விசை  அழுத்தினால் பீப் ஒலி எழுப்புக"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "S_low Keys"
+msgstr "மெது விசைகள் (_L)"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"ஒரு விசை அழுத்தப்படுவதற்கும் அது ஒப்புக்கொள்ளப் படுவதற்கும் இடையே ஒரு "
+"இடைவெளியை அமை "
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "_c ஒப்புக்கொள்ளல் தாமதம்:"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "குறுகிய"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "மெது விசைகள் தட்டச்சு தாமதம்"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "நீண்ட"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Beep when a key is pr_essed"
+msgstr "(_e) எந்த விசையும்  அழுத்தினால் பீப் ஒலி எழுப்புக"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Beep when a key is _accepted"
+msgstr "விசை ஏற்கப்பட்டால் பீப் ஒலி எழுப்புக (_a)"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "_r விசை ஏற்கப்படவில்லையானால் பீப் ஒலி எழுப்புக"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "_Bounce Keys"
+msgstr "பவுன்ஸ் விசைகள் (_B)"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "வேக இரட்டிப்பு விசை அழுத்தங்களை உதாசீனம் செய்க"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "குறுகிய"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "எதிரொலிப்பு விசைகள் தட்டச்சு தாமதம்"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "நீண்ட"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Enable by Keyboard"
+msgstr "விசைப்பலகையால் செய்யப்படும் வசதியை இயக்கு (_E)"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr " விசைப்பலகையில் இருந்து அணுகல் சிறப்பு இயல்புகளை இயக்கு/இயக்கம் நீக்கு"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "சொடுக்க உதவி"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "_Simulated Secondary Click"
+msgstr "பாவிக்கப்பட்ட இரண்டாம் நிலை சொடுக்கம்"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "முதன்மை  பொத்தானை அழுத்தியதன் மூலம் இரண்டாம் சொடுக்கை இடரவும்"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "secondary click"
+msgid "Short"
+msgstr "குறுகிய"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "இரண்டாம் சொடுக்கு தாமதிப்பு"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "நீண்ட"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "_Hover Click"
+msgstr "மேல் நகர்வு சொடுக்கம் (_H)"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "சுட்டி அசைவை நிறுத்தும்போது சொடுக்கை தூண்டு"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "_e தாமதம்:"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "குறுகிய"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "நீண்ட"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "(_t) நகர்வு மாறு நிலை :"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "சிறிய"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "பெரிய"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "குறுகிய"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "1/4 திரை"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "1/2 திரை"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "3/4 திரை"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "நீண்டது"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "முழு-திரையிலும் காண்பி"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "மேல் பாதி"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "கீழ் பாதி"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "இடது  "
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "வலது பாதி"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "அணுகிக்காணல் தேர்வுகள்"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "அணுகிப்பார்"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "பெரிதாக்கம் :"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "சொடுக்கி நிலைகாட்டியை தொடர்"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "திரையின் பாகம்:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "பெரிதாக்கி திரைக்கு வெளியே நீள்கிறது"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "பெரிதாக்கி நிலைக்காட்டியை எப்போதும் மையத்தில் வைக்கவும்"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "பெரிதாக்கி நிலைக்காட்டி உள்ளடக்கத்தை இங்குமங்கும் தள்ளுகிறது"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "பெரிதாக்கி நிலைக்காட்டி உள்ளடக்கங்களுடன் நகர்கிறது"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "பெரிதாக்கி இடம்:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "பெரிதாக்கி "
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "தடிமன்:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "மெல்லிய"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "தடிமனான"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "நீளம்:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "நிறம்:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "குறுக்கு இழைகள்:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "சொடுக்கி நிலைக்காட்டி மேல் பரவுகிறது"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "குறுக்கு இழைகள்"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "கறுப்பில் வெள்ளை:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "வெளிச்சம்:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "வேறுபாடு:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "நிறம்"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "எதுவுமில்லை"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "முழு"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "குறைவான"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "அதிகம்"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "குறைவாக"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "அதிக"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "நிற விளைவுகள்:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "நிற விளைவுகள்"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "செந்தரம்"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "நிர்வாகி"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Full Name"
+msgstr "முழுப் பெயர் (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "_T கணக்கு வகை"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to set a password when they next login"
+msgstr "பயனர் அடுத்த புகுபதிவில் கடவுச்சொல்லை அமைக்க அனுமதிக்கவும்"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "கடவுச்சொல்லை இப்போது அமை"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "சரிபார் (_V)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"தொழில் ரீதியான புகுபதிவில், இந்த சாதனத்தில் மைய முறையில் நிர்வகிக்கப்படும் "
+"முன்பே உள்ள "
+"ஒரு பயனர் கணக்கைப் பயன்படுத்த முடிகிறது."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "(_D) களம்"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"தொழில் ரீதியான கணக்குகளைச் சேர்க்க\n"
+"ஆன்லைனுக்குச் செல்லவும்."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "_E என்டர்ப்ரைஸ் புகுபதிவு:"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "பயனர் சேர்"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "பதிவு செய்யவும் (_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "டொமெய்ன் நிர்வாகி உள்நுழைவு"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"ஊக்க உள்நுழைவை பயன்படுத்த, இந்த கணினி இந்த டொமெய்னில்\n"
+" பதிவாக வேண்டும். தயை செய்து  உங்கள் வலையமைப்பு நிர்வாகியை \n"
+"அவர்களது டொமெய்ன் கடவுச்சொல்லை இங்கே உள்ளிட வையுங்கள்."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "_N நிர்வாகி பெயர்"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "நிர்வாகி கடவுச்சொல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "இடது கட்டைவிரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "இடது நடு விரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "இடது மோதிர விரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "இடது சிறுவிரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "வலது கட்டைவிரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "வலது நடு விரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "வலது மோதிர விரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "வலது சிறு விரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:687
+msgid "Enable Fingerprint Login"
+msgstr "கைரேகை புகுபதிவை செயல்படுத்து"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "_R வலது சுட்டு விரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "_L இடது சுட்டுவிரல்"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "_O மற்ற விரல்:"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"உங்கள் கைரேகை வெற்றிகரமாக சேமிக்கப்பட்டது. இப்போது நீங்கள் கைரேகை வாசிப்பி "
+"மூலம் "
+"புகுபதிவு செய்ய முடியும்."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "பயனர்கள்"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr ""
+"பயனர்களைச் சேர்க்கவும் அல்லது நீக்கவும் மற்றும் உங்கள் கடவுச்சொல்லை மாற்றவும்"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "உள்புகுகை;பெயர்;விரல்ரேகை;அவதாரம்;லோகோ;முகம்;கடவுச்சொல்;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "புகுபதிவு வரலாறு"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#| msgid "Change pa_ssword"
+msgid "Change Password"
+msgstr "கடவுச்சொல்லை மாற்று"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "_a மாற்று"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "புதிய கடவுச் சொல்லைச் சரிபார் (_V)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "புதிய கடவுச் சொல் (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "நடப்பு கடவுச்சொல் (_p)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "பயனர் கணக்கு சேர்"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "பயனர் கணக்கு நீக்கு"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "புகு பதிகை தேர்வுகள்"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "_u தானியங்கி உள்நுழைவு"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "_F கைரேகை புகுபதிவு:"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "பயனர் சின்னம்"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "(_L) மொழி"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "கடந்த புகுபதிவு"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "பயனர் கணக்குகளை மேலாள்"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "பயனர் தரவை மாற்ற அனுமதி தேவை"
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "புதிய கடவுச்சொல் பழையதிலிருந்து வேறுபட்டிருக்க வேண்டும்."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "சில எழுத்துகளையும் எண்களையும் மாற்றி முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "கடவுச்சொல்லை இன்னும் கொஞ்சம் மாற்ற முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "உங்கள் பயனர் பெயரைக் கொண்டில்லாத கடவுச்சொல் இன்னும் வலிமையானது."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr ""
+"கடவுச்சொல்லில் உங்கள் பயனர் பெயரைப் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr ""
+"சேர்க்கப்பட்டுள்ள சில சொற்களை கடவுச்சொல்லில் பயன்படுத்துவதைத் தவிர்க்க "
+"முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "பொதுவான சொற்களைத் தவிர்க்க முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "முன்பே உள்ள சொற்களை மறுவரிசைப்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "அதிக எண்களைப் பயன்படுத்த முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "அதிக பெரிய எழுத்துகளைப் பயன்படுத்த முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "அதிக சிறிய எழுத்துகளைப் பயன்படுத்த முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+"நிறுத்தக் குறிகள் போன்ற சிறப்பு எழுத்துகளை அதிகம் பயன்படுத்த முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr ""
+"எண்கள், எழுத்துகள் மற்றும் நிறுத்தக்குறிகளைக் கலந்து பயன்படுத்த "
+"முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr ""
+"ஒரே எழுத்தை மீண்டும் மீண்டும் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"ஒரே வகை எழுத்தை மீண்டும் மீண்டும் பயன்படுத்துவதைத் தவிர்க்க முயற்சிக்கவும்: "
+"எண்கள், எழுத்துகள் "
+"மற்றும் நிறுத்தக்குறிகளைக் கலந்து பயன்படுத்த வேண்டும்."
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr ""
+"1234 அல்லது abcd போன்ற வரிசை எழுத்துகளைப் பயன்படுத்துவதைத் தவிர்க்க "
+"முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "அதிக எண்கள், எழுத்துகள், சின்னங்களைச் சேர்க்க முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr ""
+"பெரிய எழுத்துகள் மற்றும் சிறிய எழுத்துகளைக் கலந்து பயன்படுத்தி ஓரிரண்டு "
+"எண்களையும் "
+"பயன்படுத்தவும்."
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+"நல்ல கடவுச்சொல்! அதிக எண்களையும் எழுத்துகளையும் நிறுத்தக் குறிகளையும் "
+"சேர்த்தால் இன்னும் "
+"வலிமையாகும்."
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "வலிமை: வலிமையில்லை"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "வலிமை: குறைவு"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "வலிமை: நடுத்தரம்"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "வலிமை: நன்று"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "வலிமை: அதிகம்"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "அனுமதித்தல் தோல்வி"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "கடவுச்சொல் மிகவும் சிறயதாக உள்ளது."
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "கடவுச்சொல் மிக எளிமையாக உள்ளது."
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "பழைய கடவுச்சொல்லும் புதிய கடவுச்சொல்லும் ஒரே மாதிரி உள்ளன"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "புதிய கடவுச்சொல் ஏற்கனவே சமீபத்தில் பயன்படுத்தப்பட்டுள்ளது "
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "புதிய கடவுச்சொல்லில் எண்களும் சிறப்பு எழுத்துக்களூம் இருக்க வேண்டும்"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "பழைய மற்றும் கடவுச்சொற்கள் ஒரே மாதிரியாக உள்ளது."
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr ""
+"ஆரம்ப அங்கீகாரத்திலிருந்து உங்கள் கடவுச்சொல் மாற்றப்பட்டுள்ளது! மீண்டும் "
+"அங்கீகரிக்கவும்."
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "புதிய கடவுச்சொல்லில் தேவையான அளவு மாறுபட்ட எழுத்துருக்கள் இல்லை"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "தெரியாத பிழை"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "உங்கள் கணக்கு வழங்குநரின் வலை முகவரிக்குப் பொருந்த வேண்டும்."
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "கணக்கை சேர்த்தல் தோல்வி"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+msgid "Passwords do not match."
+msgstr "கடவுச்சொற்கள் பொருந்தவில்லை"
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr "கணக்கை பதிவு செய்ய முடியவில்லை"
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr "இந்த களத்துடன் உறுதிப்படுத்த ஆதரவுள்ள வழி இல்லை"
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr "களத்தில் சேருதல் தோல்வி"
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"புகுபதிவு பெயர் பயனளிக்கவில்லை.\n"
+"மீண்டும் முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"புகுபதிவு கடவுச்சொல் பயனளிக்கவில்லை.\n"
+"மீண்டும் முயற்சிக்கவும்."
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr "களத்தில் உள்நுழைதல் தோல்வி"
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "டொமைனைக் கண்டறிய முடியவில்லை. எழுத்துக்கூட்டு தவறா?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:138
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr "நீங்கள் சாதனத்தை அணு அனுமதி இல்லை. கணினி நிர்வாகியை அணுகவும்."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:140
+msgid "The device is already in use."
+msgstr "சாதனம் பயன்படுத்த தயாராக உள்ளது."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid "An internal error occurred."
+msgstr "ஒரு உள்ளமை பிழை நேர்ந்தது."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Enabled"
+msgstr "செயலாக்கப்பட்டது"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:263
+msgid "Delete registered fingerprints?"
+msgstr "பதிவு செய்யப்பட்ட கைரேகைகளை அழிக்கவா?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+msgid "_Delete Fingerprints"
+msgstr "கைரேகைகளை அழி (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:273
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"நீங்கள் பதிவு செய்யப்பட்ட கைரேகைகளை அழிக்க வேண்டுமா எனவே கைரேகை புகுபதிவு "
+"செயல்நீக்கப்படும்?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:444
+msgid "Done!"
+msgstr "முடிந்தது!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:505
+#: ../panels/user-accounts/um-fingerprint-dialog.c:547
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' சாதனத்தை அணுக முடியவில்லை"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:588
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "'%s' சாதனத்தில் விரலை பிடிக்க துவக்க முடியவில்லை"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:638
+msgid "Could not access any fingerprint readers"
+msgstr "கைரேகை வாசிப்பி எதையும் அணுக முடியவில்லை"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:639
+msgid "Please contact your system administrator for help."
+msgstr "உதவிக்கு உங்கள் கணினி நிர்வாகியை அணுகவும்"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:721
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"கைரேகை புகுபதிவை செயல்படுத்த உங்கள் கைரேகையை '%s' சாதனத்தை பயன்படுத்தி "
+"சேமிக்க "
+"வேண்டும்."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:728
+msgid "Selecting finger"
+msgstr "விரலை தேர்ந்தெடு"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:729
+msgid "Enrolling fingerprints"
+msgstr "விரல்ரேகை பதிவு செய்கிறது"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "இந்த வாரம்"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "கடந்த வாரம்"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:631
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "அமர்வு முடிந்தது"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "அமர்வு தொடங்கியது"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "தயவு செய்து வேறு கடவுச்சொல்லை தேர்ந்தெடுக்கவும்."
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "தயை செய்து நடப்பு கடவுச்சொல்லை மீண்டும் உள்ளிடவும்"
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "கடவுச்சொல்லை மாற்ற முடியாது."
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "The passwords do not match."
+msgstr "கடவுச்சொற்கள் பொருந்தவில்லை."
+
+#: ../panels/user-accounts/um-photo-dialog.c:219
+msgid "Browse for more pictures"
+msgstr "அதிக படங்களுக்கு உலாவி காண்க"
+
+#: ../panels/user-accounts/um-photo-dialog.c:453
+msgid "Disable image"
+msgstr "பிம்பத்தை முடக்கு"
+
+#: ../panels/user-accounts/um-photo-dialog.c:471
+msgid "Take a photo…"
+msgstr "ஒரு புகைப்படம் எடுக்கவும் …"
+
+#: ../panels/user-accounts/um-photo-dialog.c:489
+msgid "Browse for more pictures…"
+msgstr "அதிக படங்களுக்கு உலவுக…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:713
+#, c-format
+msgid "Used by %s"
+msgstr "%s ஆல் பயன்படுத்தப்ப்ட்டது"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "இந்த வகை டொமைனை தானாக சேர்க்க முடியாது"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "அது போன்ற களம் அல்லது ராஜ்யம் காணவில்லை"
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s ஆக %s களத்தில் உள்நுழைய இயலாது"
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr "செல்லுபடியாகாத கடவுச்சொல், தயை செய்து மீண்டும் முயற்சி செய்க"
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "%s களத்துடன் இணைக்க முடியவில்லை: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:198
+msgid "Other Accounts"
+msgstr "மற்ற கணக்குகள்"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "Failed to delete user"
+msgstr "பயனரை நீக்க முடியவில்லை"
+
+#: ../panels/user-accounts/um-user-panel.c:482
+msgid "You cannot delete your own account."
+msgstr "நீங்கள் உங்கள் கணக்கையே நீக்க முடியாது"
+
+#: ../panels/user-accounts/um-user-panel.c:491
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s இன்னும் உள் நுழைந்து உள்ளார் "
+
+#: ../panels/user-accounts/um-user-panel.c:495
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"ஒரு பயனர் உள் நுழைந்து உள்லபோது அவர் கணக்கை நீக்குவது கணினியை "
+"நிலையற்றதாக்கும்."
+
+#: ../panels/user-accounts/um-user-panel.c:504
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "%s இன் கோப்புக்களை வைத்துக்கொள்ள வேண்டுமா?"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"ஒரு பயனரின் கணக்கை நீக்கும்போது இல்ல அடைவு, அஞ்சல் சுருள், தற்காலிக கோப்புகள் "
+"ஆகியவற்றை "
+"வைத்துக்கொள்ள முடியும்."
+
+#: ../panels/user-accounts/um-user-panel.c:511
+msgid "_Delete Files"
+msgstr "(_D) கோப்புக்களை நீக்கவும்"
+
+#: ../panels/user-accounts/um-user-panel.c:512
+msgid "_Keep Files"
+msgstr "_K கோப்புக்களை வைத்துக்கொள்ளவும்"
+
+#: ../panels/user-accounts/um-user-panel.c:564
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "கணக்கு முடக்கப்பட்டது"
+
+#: ../panels/user-accounts/um-user-panel.c:572
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "அடுத்த புகுபதிவில் அமைக்கப்படும்"
+
+#: ../panels/user-accounts/um-user-panel.c:575
+msgctxt "Password mode"
+msgid "None"
+msgstr "ஏதுமில்லை"
+
+#: ../panels/user-accounts/um-user-panel.c:624
+msgid "Logged in"
+msgstr "புகுபதிவு செய்துள்ளது"
+
+#: ../panels/user-accounts/um-user-panel.c:1067
+msgid "Failed to contact the accounts service"
+msgstr "கணக்கு சேவையை தொடர்பு கொள்வதில் தோல்வி"
+
+#: ../panels/user-accounts/um-user-panel.c:1069
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"கணக்கு சேவை  நிறுவப்பட்டுள்ளதா செயலாக்கப்பட்டுள்ளதா என்பதை சரிபார்க்கவும்"
+
+#: ../panels/user-accounts/um-user-panel.c:1110
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"மாற்றங்கள் செய்ய \n"
+"முதலில் * சின்னத்தை சொடுக்குக"
+
+#: ../panels/user-accounts/um-user-panel.c:1148
+msgid "Create a user account"
+msgstr "ஒரு பயனர் கணக்கை உருவாக்கு"
+
+#: ../panels/user-accounts/um-user-panel.c:1159
+#: ../panels/user-accounts/um-user-panel.c:1471
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"புதிய பயனர் கணக்கை உருவாக்க,\n"
+"முதலில் * சின்னத்தை சொடுக்குக"
+
+#: ../panels/user-accounts/um-user-panel.c:1169
+msgid "Delete the selected user account"
+msgstr "தேர்ந்தெடுத்த பயனர் கணக்கை நீக்கவும்"
+
+#: ../panels/user-accounts/um-user-panel.c:1181
+#: ../panels/user-accounts/um-user-panel.c:1476
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"தேர்ந்தெடுத்த பயனர் கணக்கை நீக்க,\n"
+"முதலில் * சின்னத்தை சொடுக்குக"
+
+#: ../panels/user-accounts/um-user-panel.c:1385
+msgid "My Account"
+msgstr "என் கணக்கு"
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+#| msgid "A user with the username '%s' already exists"
+msgid "A user with the username '%s' already exists."
+msgstr "'%s' என்ற பயனர் பெயரில் ஏற்கனவே ஒரு பயனர் உள்ளார்."
+
+#: ../panels/user-accounts/um-utils.c:571
+#, c-format
+#| msgid "The username is too long"
+msgid "The username is too long."
+msgstr "பயனர் பெயர் மிக நீளமாக உள்ளது."
+
+#: ../panels/user-accounts/um-utils.c:574
+#| msgid "The username cannot start with a '-'"
+msgid "The username cannot start with a '-'."
+msgstr "பயனர் பெயர் '-' ஐக் கொண்டு தொடங்கக்கூடாது."
+
+#: ../panels/user-accounts/um-utils.c:577
+#| msgid ""
+#| "The username should only consist of lower and upper case letters from a-"
+#| "z, digits and any of characters '.', '-' and '_'"
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"பயனர் பெயரில் a-z வரையிலான பெரிய மற்றும் சிறிய எழுத்துகள், எண்கள் மற்றும் "
+"'.', '-', "
+"'_' ஆகிய எழுத்துகள் மட்டுமே இருக்கலாம்."
+
+#: ../panels/user-accounts/um-utils.c:581
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+"இது உங்கள் இல்லக் கோப்புறைக்குப் பெயரிடப் பயன்படுத்தப்படும், இதை மாற்ற "
+"முடியாது."
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:831
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "வரைபட பொத்தான்கள்"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr "வரைபட பொத்தன்களிலிருந்து செயல்களுக்கு"
+
+#: ../panels/wacom/button-mapping.ui.h:4
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ஒரு குறுக்குவழியைத் திருத்த, \"விசை அழுத்தலை அனுப்பு\" செயல்பாட்டைத் தேர்வு "
+"செய்து, "
+"விசைப்பலகை குறுக்குவழி பொத்தானை அழுத்தி, புதிய விசைகளை அழுத்திப் பிடிக்கவும் "
+"அல்லது "
+"அழிக்க பேக்ஸ்பேஸ் ஐ அழுத்தவும்."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"தொடு பல்கையை அளவிட திரையில் இலக்கு குறிகள் தோன்றுகையில் அவற்றை தொடவும்."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "தவறான சொடுக்கல் கண்டுபிடிக்கப்பட்டது, மீள் துவக்கம்"
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "மேலே"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "கீழே"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "எதுவுமில்லை"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "விசைதட்டலை அனுப்பு"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "மானிட்டரை மாற்றுக"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "திரையிலான உதவியைக் காண்பி"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "வெளிப்பாடு:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr " காட்சி பாங்கு விகிதத்தை வைத்திரு (அஞ்சல்பெட்டி):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "வரை படத்திலிருந்து ஒற்றை திரைக்கு"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d  %d இல் "
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "வரைபடத்தை காட்டு"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "பொத்தான்"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Wacom Tablet"
+msgstr "வாகாம் தொடுதட்டு"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"கிராஃபிக்ஸ் டாப்ளெட்டுகளுக்கு பொத்தான் இணைப்புகளை அமைத்து ஸ்டைலஸின் உணர்திறனை "
+"சரிசெய்யவும்"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "தொடுதட்டு;வாகாம்;எழுத்தாணி;துடைப்பி;சொடுக்கி;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "தொடுதட்டு (அப்சொலூட்)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "தொடுதிட்டு (ரிலேடிவ்)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "தொடுதட்டு முன்னுரிமைகள்"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "No tablet detected"
+msgstr "தொடுபலகை ஏதும் கண்டுபிடிக்கப்படவில்லை"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "உங்கள் வாகாம் தொடுதட்டை சொருகவும் அல்லது சக்தியூட்டவும்."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Bluetooth Settings"
+msgstr "ப்ளூடூத் அமைப்புகள்"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map to Monitor…"
+msgstr "திரைக்கு தொடர்பிணைக்கவும்"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map Buttons…"
+msgstr "பொத்தான்களை தொடர்பிணை…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust display resolution"
+msgstr "திரைக்காட்சி தெளிதிறனை சரிசெய்யவும்"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust mouse settings"
+msgstr "சொடுக்கி அமைப்புகளை சரிசெய்யவும்"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Tracking Mode"
+msgstr "நிலை தொடர்தல் பாங்கு"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Left-Handed Orientation"
+msgstr "இடது கைவாகு திசைவி"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+msgid "Left Ring"
+msgstr "இடது வளையம்"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "இடது வட்ட பாங்கு #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+msgid "Right Ring"
+msgstr "வலது வளையம்"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "வலது வட்ட பாங்கு #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+msgid "Left Touchstrip"
+msgstr "இடது தொடுபட்டை"
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "இடது தொடுபட்டை பாங்கு #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+msgid "Right Touchstrip"
+msgstr "வலது தொடுபட்டை"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "வலது தொடு பட்டை பாங்கு #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "இடது தொடு வட்ட பாங்கு மாற்றி "
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "வலது தொடு வட்ட பாங்கு மாற்றி "
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "இடது தொடு பட்டை பாங்கு மாற்றி "
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "வலது தொடு பட்டை பாங்கு மாற்றி "
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "பாங்கு மாற்றி #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr "இடது பொத்தான் #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr "வலது பொத்தான் #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr "மேல் பொத்தான் #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "கீழ் பொத்தான் #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "புதிய குறுவழி…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "செயல் இல்லை"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "இடது சொடுக்கி பொத்தான் சொடுக்கு"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "நடு சொடுக்கி பொத்தான் சொடுக்கு"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "வலது சொடுக்கி பொத்தான் சொடுக்கு"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "மேல் உருளல்"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "கீழ் உருளல்"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "இடது உருளல்"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "வலது உருளல்"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "பின்"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "அனுப்பு"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "எழுத்தாணி"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "அழிப்பி அழுத்த உணர்வு"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "மென்மையான"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "உறுதியான"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "மேல் பொத்தான்"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "கீழ் பொத்தான்"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "நுனி அழுத்த உணர்வு"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "வெர்போஸ் பாங்கை செயல்படுத்து"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "மேல்காணலை காட்டுக"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "சரத்தைத் தேடு"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "சாத்தியமுள்ள பலக பெயர்களைப் பட்டியலிட்டுவிட்டு வெளியேறு"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "உதவி விருப்பங்களை காட்டு"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "காட்ட பலகம்"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- அமைப்புகள்"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"'%s --help´ ஒரு முழு பட்டியலில் இருக்கும் கட்டளை வரி விருப்பங்களை காண.\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "கிடைக்கும் பலகங்கள்:"
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "உதவி"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "வெளியேறு"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+msgid "All Settings"
+msgstr "எல்லா அமைப்புகளும்"
+
+#. Add categories
+#: ../shell/cc-window.c:876
+msgctxt "category"
+msgid "Personal"
+msgstr "தனிப்பட்டவை"
+
+#: ../shell/cc-window.c:877
+msgctxt "category"
+msgid "Hardware"
+msgstr "வன்பொருள்"
+
+#: ../shell/cc-window.c:878
+msgctxt "category"
+msgid "System"
+msgstr "கணினி"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "விருப்பங்கள்;அமைப்புகள்;"
+
+#~ msgid "Flickr"
+#~ msgstr "மினுமினு"
+
+#~ msgid "Install Updates"
+#~ msgstr "மேம்படுத்தல்களை நிறுவு"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "கணிணி தற்காலப்படுத்தப்பட்டது"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "வலைப்பின்னல் அச்சுப்பொறியை தேடவும்  அல்லது விடையை வடிக்கவும்"
+
+#~ msgid "_Default"
+#~ msgstr "_D முன்னிருப்பு"
+
+#~ msgid "Immediately"
+#~ msgstr "உடனடியாக"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "இந்தப் பிணையத்தில் மீடியாவைப் பகிரவும்"
+
+#~ msgid "Shared Folders"
+#~ msgstr "பகிரப்பட்ட கோப்புறைகள்"
+
+#~ msgid "column"
+#~ msgstr "நிரல்"
+
+#~ msgid "Remove Folder"
+#~ msgstr "கோப்புறையை நீக்கு"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "இந்தப் பிணையத்தில் பொதுக் கோப்புறையைப் பகிரவும்"
+
+#~ msgid "Remote View"
+#~ msgstr "தொலைநிலை பார்வை"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "அனைத்து இணைப்புகளையும் அங்கீகரி"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "புதிய சாதனத்தை அமைக்கவும்"
+
+#~ msgid "Connection"
+#~ msgstr "இணைப்பு"
+
+#~ msgid "Paired"
+#~ msgstr "ஜோடிசேர்த்த"
+
+#~ msgid "Type"
+#~ msgstr "வகை"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "சொடுக்கி மற்றும் தொடுதிட்டு அமைப்புகள்"
+
+#~ msgid "Sound Settings"
+#~ msgstr "ஒலி அமைப்புகள்"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "விசைப்பலகை அமைப்புகள்"
+
+#~ msgid "Send Files…"
+#~ msgstr "கோப்புகளை அனுப்பவும்..."
+
+#~ msgid "Visibility"
+#~ msgstr "காண் தகைவு"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "%s இன் காண்தகைவு"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "'%s' ஐ சாதனங்கள் பட்டியலிலிருந்து நீக்கலாமா?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr "சாதனத்தை நீங்கள் நீக்கினால் அடுத்த பயனுக்கு முன் மீண்டும் வடிவமைக்க வேண்டும்."
+
+#~ msgid "Device type:"
+#~ msgstr "சாதன வகை:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "உருவாக்கியவர்: "
+
+#~ msgid "Model:"
+#~ msgstr "மாதிரி:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "மேல் காணும் புலங்களை தானியங்கியாக பூர்த்தி செய்ய பிம்ப கோப்புக்களை இந்த சாளரத்தில் "
+#~ "இழுத்துவிடலாம்."
+
+#~ msgid "Left Shift"
+#~ msgstr "இடது Shift"
+
+#~ msgid "Left Alt"
+#~ msgstr "இடது Alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "இடது Ctrl"
+
+#~ msgid "Right Shift"
+#~ msgstr "வலது Shift"
+
+#~ msgid "Right Alt"
+#~ msgstr "வலது Alt"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "வலது Ctrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "இடது Alt+Shift"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "வலது Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "இடது Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "வலது Ctrl+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "இடது+வலது Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "இடது+வலது Ctrl"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "Caps"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "_Region:"
+#~ msgstr "_R வட்டாரம்:"
+
+#~ msgid "_City:"
+#~ msgstr "நகரம் (_C):"
+
+#~ msgid "_Network Time"
+#~ msgstr "_N பிணைய நேரம்"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "நேரத்தை ஒரு மனி முன்னே அமை."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "நேரத்தை ஒரு மனி பின்னே அமை."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "நேரத்தை ஒரு நிமிடம்  முன்னே அமை."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "நேரத்தை ஒரு நிமிடம் பின்னே அமை."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "முற்பகல் பிற்பகலுக்குள் மாறு"
+
+#~ msgid "AM/PM"
+#~ msgstr "முப/பிப"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "இயல்பான"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "இடம்புரியாக "
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "வலம்புரியாக "
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 பாகைகள்"
+
+#~ msgid "Monitor"
+#~ msgstr "மானிட்டர்"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "முதன்மை காட்சியை மாற்ற இழுக்கவும்"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "பண்புகளை  மாற்ற ஒரு திரையகத்தை   தேர்வு செய்க; அதன் இடத்தை  மாற்ற அதை  இழுக்கவும்."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%b %d %l:%M %p"
+
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "வடிவமைப்பினை செயலாக்குவதில் பிழை: %s"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "மானிட்டர் கட்டமைப்பை சேமிக்க முடியவில்லை"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "காட்சிகளை கண்டறிய முடியவில்லை"
+
+#~ msgid "_Resolution"
+#~ msgstr "தெளிவுத்திறன் (_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "சுழற்சி (_o):"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "பிரதிபலிக்கும்  திரைகள் (_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "குறிப்பு: தெளிதிறன் தேர்வுகளை கட்டுப்படுத்தலாம்"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "திரைகளை கண்டுபிடி"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "சொடுக்கி பண்புகள்"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "_o உள்ளடக்கம் விரலுக்கு ஒட்டும்"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "புதிய சேவைக்கு இடைமுகத்தை தேர்ந்தெடு"
+
+#~ msgid "C_reate…"
+#~ msgstr "உருவாக்கு... (_r)"
+
+#~ msgid "_Interface"
+#~ msgstr "_I இடைமுகம்"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "கணக்கிடப்பட்ட பேட்டரி திறன்: %s"
+
+#~ msgid "Hidden"
+#~ msgstr "மறைக்கப்பட்டது"
+
+#~ msgid "Visible"
+#~ msgstr "புலப்படும்"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "பெயர் & புலப்படுதன்மை"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr ""
+#~ "திரையிலும் பிணையத்திலும் நீங்கள் எப்படி காண்பிக்கப்படுவீர்கள் என்பதைக் கட்டுப்படுத்தவும்."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "மேல் பட்டியில் முழுப் பெயரைக் காண்பி (_f)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "திரைப்பூட்டில் முழுப் பெயரைக் காண்பி (_l)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "பதுங்கல் பயன்முறை (_S)"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "எதுவுமில்லை"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "பொதுக் கோப்புறையைப் பகிரவும்"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "நம்பகமான சாதனங்களிடம் மட்டும் பகிரவும்"
+
+#~ msgid "No shortcut set"
+#~ msgstr "சுருக்கு வழி அமைக்கவில்லை"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "இயல்பாக"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "உயர் மாறுபாடு /எதிர்மறை"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "திரை விசைப்பலகை"
+
+#~ msgid "OnBoard"
+#~ msgstr "உள்ளே"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "இயல்பான"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "இன்னும் பெரிய"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "தலைப்பெழுத்து மற்றும் எண் ஆகியன பூட்டப்படும்போது பீப் ஒலி எழுப்புக."
+
+#~ msgid "Turn on or off:"
+#~ msgstr "இயக்கு அல்லது நிறுத்து:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "அணுகிப்பார்"
+
+#~ msgid "Zoom in:"
+#~ msgstr "அணுகிப்பார்:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "விலகிப்பார்:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "தலைப்பிடுதலை நிறுத்து"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "பேச்சு ஒலி ஆகியவற்றின் உரை விவரணத்தை காட்டுக."
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "திரை விசைப்பலகை"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "குறுகிய"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "நீண்ட"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "எந்த விசையும்  அழுத்தினால் பீப் ஒலி எழுப்புக"
+
+#~ msgid "pressed"
+#~ msgstr "அழுத்தியது"
+
+#~ msgid "accepted"
+#~ msgstr "ஏற்கப்பட்டது"
+
+#~ msgid "rejected"
+#~ msgstr "நிராகரிக்கப்பட்டது "
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "_e ஒப்புக்கொள்ளல் தாமதம்:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "சுட்டியை விசைபலகத்தால் கட்டுப்படுத்துக."
+
+#~ msgid "Video Mouse"
+#~ msgstr "வீடியோ சொடுக்கி"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "விடியோ காமிராவை வைத்து சுட்டியை கட்டுப்படுத்துக."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "சிறிய"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "பெரிய"
+
+#~ msgid "Mouse Settings"
+#~ msgstr "சொடுக்கி அமைப்புகள்"
+
+#~ msgid "Add account"
+#~ msgstr "கணக்கை சேர்"
+
+#~ msgid "_Local Account"
+#~ msgstr "_L உள்ளமை கணக்கு"
+
+#~ msgid "_Login Name"
+#~ msgstr "உள் நுழை பெயர் (_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "குறிப்பு: என்டர்ப்ரைஸ் களப்பெயர் அல்லது ஆட்சி பெயர்"
+
+#~ msgid "C_ontinue"
+#~ msgstr "_o தொடர்"
+
+#~ msgid "Previous Week"
+#~ msgstr "முந்தைய வாரம்"
+
+#~ msgid "Next Week"
+#~ msgstr "அடுத்த வாரம்"
+
+#~ msgid "Next week"
+#~ msgstr "அடுத்த வாரம்"
+
+#~ msgid "Log in without a password"
+#~ msgstr "கடவுச்சொல் இன்றி உள்நுழை"
+
+#~ msgid "Disable this account"
+#~ msgstr "இந்த கணக்கை முடக்கு"
+
+#~ msgid "Enable this account"
+#~ msgstr "இந்த கணக்கை செயலாக்கு"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "_o கடவுச் சொல்லை உறுதி செய்க: "
+
+#~ msgid "Generate a password"
+#~ msgstr "ஒரு கடவுச்சொல்லை உருவாக்கு"
+
+#~ msgid "_Action"
+#~ msgstr "செயல் (_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "_S கடவுச்சொல்லை காட்டு"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "வலிமையான கடவுச்சொல்லை தேர்ந்தெடுப்பது எப்படி"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "இவருக்கு படத்தை மாற்றுகிறது:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "இந்த கணக்குக்கு உள்புகுகை திரையில் காட்ட ஒரு படத்தை தேர்ந்தெடு."
+
+#~ msgid "Gallery"
+#~ msgstr "பிம்ப சேகரிப்பு "
+
+#~ msgid "Take a photograph"
+#~ msgstr "ஒரு போட்டோ எடுக்கவும் "
+
+#~ msgid "Browse"
+#~ msgstr "உலாவு"
+
+#~ msgid "Photograph"
+#~ msgstr "புகைப்படம்"
+
+#~ msgid "Account Information"
+#~ msgstr "கணக்கு தகவல்"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "மிகச் சிறியது"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "போதிய அளவு நன்றாக இல்லை"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "பலகீனமானது"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "மிதமான"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "நன்று"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "பலமானது"
+
+#~ msgid "_Generate a password"
+#~ msgstr "_G ஒரு கடவுச்சொல்லை உருவாக்கு"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "நீங்கள் புதிய கடவுச்சொல்லை உள்ளிட வேண்டும்"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "புதிய கடவுச்சொல் போதுமான அளவு வலிமையாக இல்லை"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "கடவுச்சொல் ஐ உறுதி செய்ய வேண்டும்."
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "நீங்கள் நடப்பு கடவுச்சொல்லை உள்ளிட வேண்டும் "
+
+#~ msgid "The current password is not correct"
+#~ msgstr "நடப்பு கடவுச்சொல் தவறானது"
+
+#~ msgid "Wrong password"
+#~ msgstr "தவறான கடவுச்சொல்"
+
+#~ msgid "Switch Modes"
+#~ msgstr "மாற்றி பாங்குகள்"
+
+#~ msgid "Action"
+#~ msgstr "செயல்"
+
+#~ msgid "Export"
+#~ msgstr "ஏற்றுமதி"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "மெதுவாக"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "வேகமான"
+
+#~ msgid "blablabla"
+#~ msgstr "blablabla"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "முகவரி\n"
+#~ "பிரிவு\n"
+#~ "இங்கு\n"
+#~ "இடம்பெறும்"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "பிரிவு\n"
+#~ "இங்கு\n"
+#~ "இடம்பெறும்"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "பாதைகள்\n"
+#~ "பிரிவு\n"
+#~ "இங்கு\n"
+#~ "இடம்பெறும்"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "_Options…"
+#~ msgstr "விருப்பங்கள் (_O)…"
+
+#~ msgid "Change the background"
+#~ msgstr "பின்னணி படத்தை மாற்று"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "ப்ளூடூத் அமைப்புகளை வடிவமை"
+
+#~ msgid "Browse Files..."
+#~ msgstr "கோப்புகளை உலாவு..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "ப்ளூடூத்"
+
+#~ msgid "Create virtual device"
+#~ msgstr "மெய்நிகர் சாதனம் உருவாக்கு"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "காட்சிகருவிகளுக்கு இருக்கும் வரிவுருக்கள்"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "வருடிகளுக்கு இருக்கும் வரிவுருக்கள்"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "அச்சுப்பொறிக்களுக்கு இருக்கும் வரிவுருக்கள்"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "காமிராக்களுக்கு இருக்கும் வரிவுருக்கள்"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "வலை காமிராக்களுக்கு இருக்கும் வரிவுருக்கள்"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i வருடம்"
+#~ msgstr[1] "%i வருடங்கள்"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i மாதம்"
+#~ msgstr[1] "%i மாதங்கள்"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i வாரம்"
+#~ msgstr[1] "%i வாரங்கள்"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "1 வாரத்தைவிட குறை"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "சாதனம் வண்ண மேலாண்மை செய்யப்படாதது."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "இந்த சாதனம் உருவாக்கியபோது அள்விட்ட தரவை பயன்படுத்துகிறது."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "இந்த சாதனம் முழு திரையையும் வண்ணத்திருத்தம் செய்ய பொருந்தும் வரிவுரு கொண்டில்லை."
+
+#~ msgid "Not specified"
+#~ msgstr "குறிப்பிடப்படாத"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "வண்ண மேலாண்மை செய்ய சாதனம் ஏதுமில்லை "
+
+#~ msgid "Add a virtual device"
+#~ msgstr "மெய்நிகர் சாதனத்தை சேர்"
+
+#~ msgid "Add device"
+#~ msgstr "சாதனத்தை சேர் "
+
+#~ msgid "Remove a device"
+#~ msgstr "ஒரு சாதனத்தை நீக்கு"
+
+#~ msgid "Color management settings"
+#~ msgstr "நிற மேலாண்மை அமைப்பு"
+
+#~ msgid "English"
+#~ msgstr "ஆங்கிலம்"
+
+#~ msgid "British English"
+#~ msgstr "ப்ரிட்டிஷ் ஆங்கிலம்"
+
+#~ msgid "German"
+#~ msgstr "ஜெர்மன் "
+
+#~ msgid "French"
+#~ msgstr "ப்ரெஞ்ச் "
+
+#~ msgid "Spanish"
+#~ msgstr "ஸ்பானிஷ் "
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "எளிதாக்கிய சைனிஸ்)"
+
+#~ msgid "Russian"
+#~ msgstr "ரஷ்யன்"
+
+#~ msgid "Arabic"
+#~ msgstr "அராபிக்"
+
+#~ msgid "Select a region"
+#~ msgstr "மண்டலத்தை தேர்ந்தெடுக்கவும்"
+
+#~ msgid "Unspecified"
+#~ msgstr "குறிப்பிடப்படாத"
+
+#~ msgid "Select a language"
+#~ msgstr "மொழியை தேர்ந்தெடு"
+
+#~ msgid "_Select"
+#~ msgstr "(_S) தேர்ந்தெடு"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "நாள் நேரம் விருப்பங்கள் பலகம்"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "தெரியாத மாதிரி"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "அடுத்த உள்நுழைவு செந்தர முறையை பயன்படுத்தும்"
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "அடுத்த உள்நுழைவு ஆதரவில்லாத வரைகலை வன்பொருளுக்கான பின்சார்பு முறையை பயன்படுத்தும்"
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "பின்சார்தல்"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "செந்தரம்"
+
+#~ msgid "System Information"
+#~ msgstr "கணினி தகவல்"
+
+#~ msgid "Experience"
+#~ msgstr "அனுபவம்"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "_F வலுக்கட்டாய பின்சார்பு பாங்கு"
+
+#~ msgid "OS type"
+#~ msgstr "ஓஎஸ் வகை"
+
+#~ msgid "_Other Media..."
+#~ msgstr "_O மற்ற ஊடகம்..."
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "விசைப்பலகை அமைப்புகள் ஐ மாற்றுக"
+
+#~ msgid "Layout Settings"
+#~ msgstr "இடவமைப்பு அமைப்புகள்"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "உங்கள் சொடுக்கி மற்றும் தொடுதிட்டின் விருப்ப தேர்வுகளை அமைக்கவும்"
+
+#~ msgid "Network settings"
+#~ msgstr "பிணைய அமைவுகள்"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "பிணையம்;ஒயர்லெஸ்;ஐபி;லான்;ப்ராக்ஸி;"
+
+#~ msgid "Out of range"
+#~ msgstr "வரையறை தாண்டியுள்ளது"
+
+#~ msgid "_Options..."
+#~ msgstr "(_O) தேர்வுகள்..."
+
+#~ msgid "C_reate..."
+#~ msgstr "உருவாக்கு (_r)..."
+
+#~ msgid "_Configure..."
+#~ msgstr "_C வடிவமை..."
+
+#~ msgid "Wireless"
+#~ msgstr "கம்பியில்லா"
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "கம்பியில்லா இணைப்பு வட்டம்"
+
+#~ msgid "_Connect"
+#~ msgstr "_C இணை"
+
+#~ msgid "_Disconnect"
+#~ msgstr "_D துண்டி"
+
+#~ msgid "Mesh"
+#~ msgstr "கம்பிவலை"
+
+#~ msgid "Disconnected"
+#~ msgstr "துண்டிக்கபட்டது"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "கடத்தி/ இணைப்பு மாறிவிட்டது"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr " அறிமுக ஆவணம் காலாவதியானது. மீண்டும் உள் நுழைக."
+
+#~ msgid "_Log In"
+#~ msgstr "_L உள்நுழை"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "ஆன் லைன் கணக்குகளை மேலாள்"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "எச்சரிக்கை மின்கல சக்தி குறைவு, %s மீதம்"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "மின்கல மின்சாரத்தில் - %s மீதம்"
+
+#~ msgid "Using battery power"
+#~ msgstr "மின்கல மின்சாரத்தை பயன்படுத்துகிறது:"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "மின் சக்தி ஏற்றம் - முழுமையானது"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "யூபிஎஸ் மின்சக்தியில்  - %s  மீதமுள்ளது"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "எச்சரிக்கை. யூபிஎஸ் சக்தி குறைவு."
+
+#~ msgid "Using UPS power"
+#~ msgstr "யூபிஎஸ் சக்தி பயனாகிறது"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "உங்கள் இரண்டாம்  மின்கலம் முழுமையாக மின்னேற்றப்பட்டது"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "உங்கள் இரண்டாம்  மின்கலம் காலியாக உள்ளது"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "மின் சக்தி ஏற்றம் - முழுமையானது"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "குறிப்பு: <a href=\"screen\">திரை வெளிச்சம்</a> எவ்வளவு சக்தி பயனாகிறது என்பதை "
+#~ "பாதிக்கும்."
+
+#~ msgid "Power management settings"
+#~ msgstr "சக்தி மேலாண்மை அமைப்பு"
+
+#~ msgid "Don't suspend"
+#~ msgstr "இடைநிறுத்தம் செய்யாதே"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "இவ்வளவு நேரம் செயலற்று இருந்தால் பணிநிறுத்தம் செய்க"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "தாமதிக்கப்பட்டுள்ளது"
+
+#~ msgid "Change printer settings"
+#~ msgstr "அச்சடிப்பி அமைப்புகள் ஐ மாற்றுக"
+
+#~ msgid "Manufacturers"
+#~ msgstr "உருவாக்கியோர்"
+
+#~ msgid "Drivers"
+#~ msgstr "இயக்கிகள்"
+
+#~ msgid "_Show"
+#~ msgstr "_S காட்டுக"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "உங்கள் வட்டாரத்தையும் மொழி அமைவையும் மாற்றி அமைக்க"
+
+#~ msgid "Choose an input source"
+#~ msgstr "உள்ளீட்டு மூலத்தை தேர்ந்தெடு"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "உள்ளீட்டு மூலத்தை சேர்க்க தேர்ந்தெடு"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "உள் நுழைவு திரை, கணினி கணக்குகள் மற்றும் புதிய பயனர் கணக்குகள் கணினியின் இடம் மற்றும் "
+#~ "மொழி அமைப்புகளை பயன்படுத்துகின்றன."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "உள் நுழைவு திரை, கணினி கணக்குகள் மற்றும் புதிய பயனர் கணக்குகள் கணினியின் இடம் மற்றும் "
+#~ "மொழி அமைப்புகளை பயன்படுத்துகின்றன. உங்களுடையதுடன் பொருந்தும் படி அவற்றை மாற்றலாம். ."
+
+#~ msgid "Copy Settings"
+#~ msgstr "அமைப்புகளை பிரதி எடு"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "அமைப்புகளை பிரதி எடு..."
+
+#~ msgid "Add Language"
+#~ msgstr "மொழியை சேர்"
+
+#~ msgid "Add Region"
+#~ msgstr "வட்டாரத்தை சேர்"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "கன்ட்ரோல்+ஆல்ட்+ஸ்பேஸ்"
+
+#~ msgid "Currency"
+#~ msgstr "பணம்"
+
+#~ msgid "Display language:"
+#~ msgstr "மொழியை காட்டு:"
+
+#~ msgid "Examples"
+#~ msgstr "உதாரணங்கள்"
+
+#~ msgid "Format:"
+#~ msgstr "வடிவம்:"
+
+#~ msgid "Input source:"
+#~ msgstr " உள்ளீட்டு மூலம்:"
+
+#~ msgid "Install languages..."
+#~ msgstr "மொழிகள் நிறுவு... "
+
+#~ msgid "Move Input Source Up"
+#~ msgstr " உள்ளீட்டு மூலத்தை மேலே நகர்த்து"
+
+#~ msgid "Region and Language"
+#~ msgstr " வட்டாரம் மற்றும் மொழி "
+
+#~ msgid "Remove Input Source"
+#~ msgstr " உள்ளீட்டு மூலத்தை நீக்கு"
+
+#~ msgid "Remove Language"
+#~ msgstr "மொழி  நீக்கு"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "காட்டுவதற்கு மொழியைத் தேர்ந்தெடுக்கவும் (மாற்றங்கள் அடுத்த முறை நீங்கள் உள் நுழையும்போது "
+#~ "செயலாகும்)"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr ""
+#~ "காட்டுவதற்கு மண்டலத்தை தேர்ந்தெடுக்கவும் (மாற்றங்கள் அடுத்த முறை நீங்கள் உள் நுழையும்போது "
+#~ "செயலாகும்)"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "விசைப்பலகைகள் அல்லது மற்ற உள்ளீட்டு மூலங்களை தேர்ந்தெடு"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "குறுக்கு வழி  அமைப்புகள்"
+
+#~ msgid "Show Keyboard Layout"
+#~ msgstr "விசைப்பலகை இடவமைவை காட்டுக"
+
+#~ msgid "System settings"
+#~ msgstr "கணினி அமைப்புகள்"
+
+#~ msgid "Your settings"
+#~ msgstr "உங்களுடைய அமைவுகள்"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "வெளிச்சம் மற்றும் பூட்டு"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "பிரகாசம்;பூட்டு;மங்கல்;வெற்று;திரை;"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "திரை பிரகாசம் மற்றும் பூட்டு அமைப்பு"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "வீட்டில் உள்ளபோது பூட்டாதே"
+
+#~ msgid "Locations..."
+#~ msgstr "இருப்பிடங்கள்..."
+
+#~ msgid "Lock"
+#~ msgstr "பூட்டு"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "_D சக்தியை சேமிக்க திரையை மங்கலாக்கு"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "பிழைத்திருத்த குறியீட்டை செயல்படுத்து"
+
+#~ msgid "Version of this application"
+#~ msgstr "இந்த பயன்பாட்டின் பதிப்பு "
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr "—GNOME ஒலிவளவு கட்டுப்பாடு குறுநிரல்"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "பணிமேடை ஒலிவளவு கட்டுப்பாட்டை காட்டு"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "ஒலி வெளிப்பாடு அளவு"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "ஒலி வாங்கி அளவு"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "ஒலி விருப்பத்தேர்வுகளை துவக்குவதில் தோல்வி: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "_M ஒலியை முடக்கு"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "_S ஒலி விருப்பத்தேர்வுகள்"
+
+#~ msgid "Muted"
+#~ msgstr "ஒலி நிறுத்தப்பட்டது"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "உலகளாவிய அணுகல் தேர்வுகள்"
+
+#~ msgid "Options..."
+#~ msgstr "தேர்வுகள்..."
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "நிறம்"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "எதுவுமில்லை"
+
+#~ msgid "User Accounts"
+#~ msgstr "பயனர் கணக்குகள்"
+
+#~ msgid "Fair"
+#~ msgstr "மிதமான"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "இந்த குறிப்பு உள்புகுகை திரையில் காட்டப்படலாம். இந்த கணினியை பயன்படுத்துவோர் அனைவரும் "
+#~ "இதை காணலாம்.  <b>சேர்க்காதீர்</b>இங்கே கடவுச்சொல்லை."
+
+#~ msgid "_Hint"
+#~ msgstr "_உதவி குறிப்பு"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "அதிக படங்களுக்கு உலாவுக..."
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "'%s' பயனர் பெயரில் யாரும் இல்லை"
+
+#~ msgid "This user does not exist."
+#~ msgstr "இந்த பயனர் இருப்பில் இல்லை"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "உங்கள் வாகாம் தொடுதட்டு விருப்பங்களை அமைக்கவும்"
+
+#~ msgid "Calibrate..."
+#~ msgstr "அளவிடு..."
+
+#~ msgid "Map Buttons..."
+#~ msgstr "வரைபட பொத்தான்கள்..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- கணினி அமைப்புகள்"
+
+#~ msgid "Control Center"
+#~ msgstr "கட்டுப்பாட்டு மையம்"
+
+#~ msgid "System Settings"
+#~ msgstr "கணினி அமைப்புகள்"
+
+#~ msgid "Security Key"
+#~ msgstr "பாதுகாப்பு விசை"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "துணை இணைய மறைப்பு"
+
+#~ msgid "_Search by Address"
+#~ msgstr "_S முகவரியால் தேடு"
+
+#~ msgid "Getting devices..."
+#~ msgstr "சாதனங்களை பெறுகிறது..."
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "பயர்வால்டீமன் இயங்கவில்லை. வலைப்பின்னல் அச்சுப்பொறி இயங்க பயர்வாலில் எம்டிஎன்எஸ், ஐபிபி,"
+#~ "ஐபிபி-க்லையன்ட், சாம்பா -க்லையன்ட் ஆகியவை செயலனுமதி இருக்க வேண்டும்."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "உள்ளமை"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "பிணையம்"
+
+#~ msgid "Device types"
+#~ msgstr "சாதன வகைகள்"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "தானியங்கி கட்டமைப்பு"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "எம்டிஎன்எஸ் இணைப்புகளுக்கு பயர்வாலை திறத்தல்"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "சாம்பா இணைப்புகளுக்கு பயர்வாலை திறத்தல்"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "ஐபிபி இணைப்புகளுக்கு பயர்வாலை திறத்தல்"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "சுவர்-காகிதம் சேர்"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "சுவர்-காகிதங்கள் நீக்கு"
+
+#~ msgid "Swap colors"
+#~ msgstr "நிறங்களை இட மாற்றுக"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "கிடைமட்ட சீர் நிற மாற்றங்கள்"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "செங்குத்து சீர் நிற மாற்றங்கள்"
+
+#~ msgid "Solid Color"
+#~ msgstr "பரு நிறம்"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "நிறங்கள் & நிறசீர் மாற்றங்கள்"
+
+#~ msgid "Acti_on:"
+#~ msgstr "(_o) செயல்:"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "ஒரு திரைவெட்டினை எடுக்கவும்"
+
+#~ msgid "Shortcut"
+#~ msgstr "குறுக்கு வழி"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "(_c) ஊக்கி:"
+
+#~ msgid "Double-Click Timeout"
+#~ msgstr "இரட்டை சொடுக்கு நேரம் முடிந்தது"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "இழுப்பு விளிம்பு"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "இழுத்துப் போடுதல்"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "(_m) தொடுதிட்டால் சொடுக்கி சொடுக்கலை செயல்படுத்து"
+
+#~ msgid "Scrolling"
+#~ msgstr "உருளல்"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "(_o) கன்ட்ரோல் விசையை அழுத்தினால் சுட்டியின் இடத்தை காட்டு"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "(_e) மாறு நிலை:"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "உங்கள் அமைப்பை சோதிக்க  முகத்தின் மீது இரட்டை சொடுக்கு செய்க"
+
+#~ msgid "_Disabled"
+#~ msgstr "_D முடக்கப்பட்டது"
+
+#~ msgid "_Left-handed"
+#~ msgstr "(_L) இடதுகைவாகு"
+
+#~ msgid "_Right-handed"
+#~ msgstr "(_R) வலதுகைவாகு"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "(_S) உணர்திறன்:"
+
+#~ msgid "_Timeout:"
+#~ msgstr "வெளியேற்ற நேரம்:"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "மற்றவை..."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "எப்படியும் செயலிடத்தை உருவாக்கவா?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "%s இலிருந்து இணைப்பு நீங்கி புதிய செயலிடத்தை உருவாக்கவா?அமெரிக்கா"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "பிணையத்துக்கு இதுவே ஒரே ஒரு இணைப்பு"
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "_H செயலிடத்தை உருவாக்கு"
+
+#~ msgid "Disable VPN"
+#~ msgstr "விபிஎன் முடக்கப்பட்டது"
+
+#~ msgid "FTP Port"
+#~ msgstr "FTP துறை"
+
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP துறை"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "HTTPS துறை"
+
+#~ msgid "_Network Name"
+#~ msgstr "பிணைய பெயர் (_N):"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "_S செயலிடத்தை நிறுத்து..."
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "ஒரு புதிய கணக்கை சேர்க்க முதலில் கணக்கின் வகையை தேர்ந்தெடு "
+
+#~ msgid "_Add..."
+#~ msgstr "சேர் (_A)..."
+
+#~ msgid "Tip:"
+#~ msgstr "உதவிக்குறிப்பு"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "எவ்வளவு மின் சக்தி பயன்படுத்தப்படும் என பாதிக்கிறது"
+
+#~ msgid "Allowed users"
+#~ msgstr "அனுமதிக்கப்பட்ட பயனர்கள்"
+
+#~ msgid "_Back"
+#~ msgstr "_B பின்"
+
+#~ msgid "Add Layout"
+#~ msgstr "இட அமைவை சேர்"
+
+#~ msgid "Layouts"
+#~ msgstr "இடஅமைவுகள்"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr " புதிய சாளரங்கள் நடப்பு முன்னிருப்பு  இட அமைவை பயன்படுத்தும்"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "புதிய சாளரங்கள் நடப்பு சாளர இட அமைவை பயன்படுத்தும்"
+
+#~ msgid "Preview Layout"
+#~ msgstr "முன்பார்வை இடஅமைவு:"
+
+#~ msgid "Remove Layout"
+#~ msgstr "இட அமைவு நீக்கு"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "நடப்பு விசைப்பலகை அமைப்பை முன்னிருப்பு\n"
+#~ "அமைப்பால் மாற்றுக."
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "(_f) முன்னிருப்புக்கு மறுஅமை"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "விசைப்பலகை இட அமைவு தேர்வுகளை பார்த்து திருத்துக"
+
+#~ msgid "Layout"
+#~ msgstr "இட அமைவு"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "_h வடிவமைக்க சாதனத்தை தேர்ந்தெடு"
+
+#~ msgid "Caribou"
+#~ msgstr "காரிபௌ"
+
+#~ msgid "Change contrast:"
+#~ msgstr "வேறுபாட்டை மாற்று :"
+
+#~ msgid "Dasher"
+#~ msgstr "டேஷர்"
+
+#~ msgid "Decrease size:"
+#~ msgstr "அளவை குறைவாக்குக:"
+
+#~ msgid "Increase size:"
+#~ msgstr "அளவு ஐ அதிகமாக்குக:"
+
+#~ msgid "Nomon"
+#~ msgstr "நோமோன் (மானிட்டர் ஏதுமில்லை)"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "அமைப்புகளை சோதிக்க இங்கு உள்ளிடவும்:"
+
+#~ msgid "_Text size:"
+#~ msgstr "_T உரை அளவு:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "காட்சி"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "அணுகிப்பார்"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 திரை"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 திரை"
+
+#~ msgid "Cr_eate"
+#~ msgstr "உருவாக்கு (_r)"
+
+#~ msgid "Create new account"
+#~ msgstr "புதிய கணக்கை உருவாக்கு"
+
+#~ msgid "_Account Type"
+#~ msgstr "_A கணக்கு வகை"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "உருவாக்கிய கடவுச்சொல்லை தேர்ந்தெடு"
+
+#~ msgid "Account _type"
+#~ msgstr "_t கணக்கு வகை:"
+
+#~ msgid "More choices..."
+#~ msgstr "மேலும் தேர்வுகள்..."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "வாகாம் வரைகலை தொடுதட்டு"
+
+#~ msgid "Unlock"
+#~ msgstr "பூட்டை திற"
+
+#~ msgid "Battery charging"
+#~ msgstr "மின்கல சக்தி ஏற்றம் ஆகிறது"
+
+#~ msgid "Battery discharging"
+#~ msgstr "மின்கல சக்தி இறங்குகிறது"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr " %s மின் ஏற்றும் வரை(%.0lf%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s  காலியாகும் வரை  (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% மின்னேற்றப்பட்டது"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "காட்சி கட்டமைப்பை செயல்படுத்தும் போது அமர்வு பஸ்ஸை பெற முடியவில்லை"
+
+#~ msgid "System Info"
+#~ msgstr "கணினி தகவல்"
+
+#~ msgid "_Photos:"
+#~ msgstr "_படங்கள்:"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "மாறுதன்மையை நிலை மாற்று"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "பெரிதாக்கியை மாற்று"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "திரைபடிப்பானை மாற்று"
+
+#~ msgid "Accelerator key"
+#~ msgstr "முடுக்கல் விசை"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "முடுக்கல் மாற்றிகள்"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "முடுக்கல் விசை"
+
+#~ msgid "Accel Mode"
+#~ msgstr "முடுக்கல் முறைமை"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "முடுக்கல் வகையினம்:"
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "புதிய குறுக்குவழியை சேமிப்பதில் பிழை"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "அதிகமான தனிப்பயன் குறுக்குவழிகள் "
+
+#~ msgid "Speed"
+#~ msgstr "வேகம்"
+
+#~ msgid "Ask me"
+#~ msgstr "என்னை கேள்"
+
+#~ msgid "Shutdown"
+#~ msgstr "பணிநிறுத்தம்"
+
+#~ msgid "Suspend"
+#~ msgstr "இடைநிறுத்தம்"
+
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr "இந்த சாதனத்துடன் பொருந்தும் வரிவுருக்கள் மட்டுமே மேலே பட்டியலிடப்பட்டன."
+
+#~ msgid "Key"
+#~ msgstr "விசை"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "இந்த பண்பு திருத்தி இணைக்கப்பட்டுள்ள Gஅமைப்பு விசை"
+
+#~ msgid "Callback"
+#~ msgstr "திரும்ப அழை"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "மாற்றப்பட்ட விசையுடன் மதிப்பு தொடற்புறும்போது மீண்டும் அழைப்பு வழங்கப்படும்"
+
+#~ msgid "Change set"
+#~ msgstr "கணத்தை மாற்று"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf  மாற்று அமைப்பு கொண்டுள்ள அமைப்பு gconf  கிளயண்ட் பயன்படுத்தினவுடட் "
+#~ "முன்னோக்கப்பட்டது"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "குறுபயன்பாடு அழைப்புக்கு மாற்றுதல்"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "தரவுகள் GConf லிருந்து விட்ஜெட்டுக்கு மாற்றம் செய்யும்போது பின்னுக்குகூப்பிடு "
+#~ "வழங்கப்படவேண்டும்"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "குறுபயன்பாடு மறுஅழைப்பிலிருந்து மாற்றுதல்"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "தரவுகள் விட்ஜெட்டிலிருந்து GConfக்கு மாற்றம் செய்யப்படும்போது பின்னுக்குகூப்பிடு "
+#~ "வழங்கப்படவேண்டும்"
+
+#~ msgid "UI Control"
+#~ msgstr "UI கட்டுப்பாடு"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "தன்மையை கட்டுப்படுத்தும் பொருள்"
+
+#~ msgid "Property editor object data"
+#~ msgstr "பண்பு மாற்றி பொருள் விவரம்"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "குறிப்பிட்ட பண்பு மாற்றிக்கு தேவைப்படும் தனிவகை தகவல்"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "மறுஅழைப்பை விட்டுவிடும் பண்பு மாற்றி தகவல்"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "குணங்கள் தொகுப்பி பொருள் தரவு சுதந்திரமாகும்போது பின்னுக்குகூப்பிடு வழங்கப்படவேண்டும்"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "'%s'கோப்பையை கண்டறிய இயலவில்லை.\n"
+#~ "\n"
+#~ "இக்கோப்பை உள்ளதா என கண்டறியவும்,அல்லது வேரொரு பின்னணியை தேர்வு செய்யவும்"
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' கோப்பு எப்பதி திறக்க வேண்டுமென்று எனக்கு தெரியவில்லை.\n"
+#~ "மற்றும் இது ஒரு விதமான பட்ம் அத்ற்க்கு ஆதரவலிக்கவில்லை.\n"
+#~ "\n"
+#~ "பதிலாக தயவுசெய்து வேறு படத்தை தேர்ந்தெடுக்கவும்."
+
+#~ msgid "Please select an image."
+#~ msgstr "ஓர் படத்தை தெரிவு செய்யவும்."
+
+#~ msgid "Always"
+#~ msgstr "எப்போதும்"
+
+#~ msgid "Centered"
+#~ msgstr "மையப்படுத்தப்பட்ட "
+
+#~ msgid "Color and Opacity"
+#~ msgstr "நிறம் மற்றூம் ஒளிபுகாத்தன்மை"
+
+#~ msgid "Image moves with the mouse pointer"
+#~ msgstr "பிம்பம் சொடுக்கி நிலைகாட்டியுடன் நகர்கிறது"
+
+#~ msgid "Image scrolls at screen edges"
+#~ msgstr "பிம்பம் திரையின் விளிம்புகளில் உருளுகிறது"
+
+#~ msgid "Moveable lens - magnified view follows mouse movements"
+#~ msgstr "நகர்த்தக்கூடிய குவிஆடி - சொடுக்கியை பெரிதாக்கப்பட்ட காட்சி தொடர்கிறது"
+
+#~ msgid "Position of magnified view on screen"
+#~ msgstr "திரையில் பெரிதாக்கப்பட்ட காட்சியின் இடம்"
+
+#~ msgid "Proportional"
+#~ msgstr "சரிவிகிதமான"
+
+#~ msgid "Push"
+#~ msgstr "தள்ளு"
+
+#~ msgid "Show"
+#~ msgstr "காட்டுக"
+
+#~ msgid "Show crosshairs intersection"
+#~ msgstr "குறூக்கு இழை வெட்டுமிடம் காட்டு"
+
+#~ msgid "To keep the pointer centered"
+#~ msgstr "நிலைக்காட்டியை மையமாக வைத்தல்"
+
+#~ msgid "To keep the pointer visible"
+#~ msgstr "நிலைக்காட்டியை காணுமாறு வைத்தல்"
+
+#~ msgid "Create a user"
+#~ msgstr "ஒரு பயனரை உருவாக்கு"
+
+#~ msgid "Upside-down"
+#~ msgstr "தலை கீழ்"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "ஊடகம் மற்றும் தானியக்கம்"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "ஊடகத்தை வடிவமை மற்றும் தானியங்கி  விருப்ப தேர்வுகளை அமைக்கவும்"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "சிடி;டிவிடி;ஒலி;விடியோ;வட்டு"
+
+#~ msgid "_Turn off after:"
+#~ msgstr "_T இவ்வளவுக்குப்பின் நிறுத்து:"
+
+#~ msgid "Mute"
+#~ msgstr "ஒலி நிறுத்தம்"
+
+#~ msgid "Chinese"
+#~ msgstr "சைனீஸ் "
+
+#~ msgid "24-_Hour Time"
+#~ msgstr "_H 24- மணிநேர வடிவம்"
+
+#~ msgid "Updates Available"
+#~ msgstr "மேம்படுத்தல்கள் உள்ளன"
+
+#~ msgid "On AC _power:"
+#~ msgstr "_p ஏசி மின்சாரத்தில்:"
+
+#~ msgid "Put the computer to sleep when inactive:"
+#~ msgstr "இவ்வளவு நேரம் செயலற்று இருந்தால் கனினியை பணிநிறுத்தம் செய்க:"
+
+#~ msgid "When the _sleep button is pressed:"
+#~ msgstr "_s உறக்க பொத்தான் அழுத்தப்படும் போது:"
+
+#~ msgid "When the p_ower button is pressed:"
+#~ msgstr "_o மின்சக்தி பொத்தான் அழுத்தப்படும் போது:"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "விசைப்பலகை;சொடுக்கி;a11y;அணுகல்;"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f KB"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f MB"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f GB"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TB"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PB"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EB"
+
+#~ msgid "Current network location"
+#~ msgstr "நடப்பு பிணைய இடம்"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "கூடுதல் பின்னணிகள் இணைய முகவரி"
+
+#~ msgid "More themes URL"
+#~ msgstr "கூடுதல் தீம்கள் URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "உங்கள் நடப்பு இட பெயருக்கு இதனை அமை. இது தொடர்புடைய பிணைய ப்ராக்ஸி கட்டமைப்பை "
+#~ "வரையறுக்க பயன்படுகிறது."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "எங்கு பணிமேடை பின்னணிகளை பெறுவதற்கான URL. ஒரு வெற்று சரமாக அமைத்தால் இணைப்பு "
+#~ "தோன்றாது."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "எங்கு பணிமேடை தீம்களை பெறுவதற்கான URL. ஒரு வெற்று சரமாக அமைத்தால் இணைப்பு தோன்றாது."
+
+#~ msgid "Locked"
+#~ msgstr "பூட்டப்பட்டது"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "உரையாடல் பூட்டு திறக்கப்பட்டது \n"
+#~ "மேலும் மாற்றங்களை தவிர்க்க சொடுக்கவும் "
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "உரையாடல் பூட்டப்பட்டது \n"
+#~ "மேலும் மாற்றங்களை செய்ய சொடுக்கவும் "
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "கணினி நடைமுறைகள் மாற்றங்களை தடுக்கிறது \n"
+#~ "உங்கள் கணினி நிர்வாகியை அணுகவும் "
+
+#~ msgid "Photos"
+#~ msgstr "புகைப்படங்கள்"
+
+#~ msgid "Web"
+#~ msgstr "இணையம்"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "ஒவ்வொரு புதிய சாளரத்திற்கும் முன்னிருப்பு  இட அமைவு"
+
+#~ msgid "Use previous window's layout in new windows"
+#~ msgstr "புதிய சாளரங்களில் முந்தைய சாளரத்தின் இடவமைவை தேர்ந்தெடு"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "(_A) ஆர்முடுகல்:"
+
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">மாறுபாடு /எதிர்மறை</span>"
+
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">அதிகமான</span>"
+
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"\"x-large\"\">குறைவான</span>"
+
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">இயல்பான</span>"
+
+#~ msgid "Beep when a modifer key is pressed"
+#~ msgstr "மாற்றி விசை  அழுத்தினால் பீப் ஒலி எழுப்புக"
+
+#~ msgid "Orange"
+#~ msgstr "ஆரஞ்சு"
+
+#~ msgid "Chocolate"
+#~ msgstr "சாக்லேட்"
+
+#~ msgid "Chameleon"
+#~ msgstr "காமிலியன்"
+
+#~ msgid "Plum"
+#~ msgstr "ப்ளம்"
+
+#~ msgid "Aluminium"
+#~ msgstr "அலுமினியம்"
+
+#~ msgid "Gray"
+#~ msgstr "சாம்பல்"
+
+#~ msgid "Slide Show"
+#~ msgstr "ஸ்லைடு காட்சி "
+
+#~ msgid "Image"
+#~ msgstr "படம்"
+
+#~ msgid "%d %s by %d %s"
+#~ msgstr "%d %s கீழ் %d %s"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "பிக்ஸல்"
+#~ msgstr[1] "பிக்ஸல்கள்"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s, %s\n"
+#~ "அடைவு: %s"
+
+#~ msgid ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "Folder: %s"
+#~ msgstr ""
+#~ "<b>%s</b>\n"
+#~ "%s\n"
+#~ "அடைவு: %s"
+
+#~ msgid "12 hour format"
+#~ msgstr "12 மணி வடிவமைப்பு"
+
+#~ msgid "16"
+#~ msgstr "16"
+
+#~ msgid "2010"
+#~ msgstr "2010"
+
+#~ msgid "24 hour format"
+#~ msgstr "24 மணி வடிவமைப்பு"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "விருப்பமான நிரல்கள்"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "தேர்ந்தெடுத்த பார்வை உதவி தொழில்நுட்பத்தை துவக்கு"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "காட்சி உதவி"
+
+#~ msgid "Error setting default browser: %s"
+#~ msgstr "மின்னிருப்பு உலாவியை அமைக்கையில் பிழை: %s"
+
+#~ msgid "Error setting default mailer: %s"
+#~ msgstr "மின்னிருப்பு அஞ்சல் நிரல் அமைக்கையில் பிழை: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "முதன்மை இடைமுகத்தை ஏற்ற முடியவில்லை"
+
+#~ msgid "Please make sure that the applet is properly installed"
+#~ msgstr "குறுநிரல் ஒழுங்காக நிறுவப்பட்டுள்ளதா என்பதை சரிபார்க்கவும்"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "அனைத்து %s நிகழ்வுகளும் உண்மையான இணைப்புகளால் மாற்றப்படும்"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "(_m) கட்டளை:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "கொடியை இயக்கு: (_x)"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "உடனடி செய்தியாளர்"
+
+#~ msgid "Internet"
+#~ msgstr "இணையம்"
+
+#~ msgid "Mail Reader"
+#~ msgstr "அஞ்சல் படிப்பி"
+
+#~ msgid "Mobility"
+#~ msgstr "நகருதல்"
+
+#~ msgid "Run at st_art"
+#~ msgstr "(_a) துவக்கத்தில் இயக்குக"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "முனையத்தில் இயக்கு (_e)"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "முனைய எமுலேட்டர்"
+
+#~ msgid "Text Editor"
+#~ msgstr "உரை தொகுப்பி"
+
+#~ msgid "Visual"
+#~ msgstr "காட்சி"
+
+#~ msgid "Web Browser"
+#~ msgstr "இணைய உலாவி"
+
+#~ msgid "_Run at start"
+#~ msgstr "(_R) துவக்கத்தில்  இயக்கு "
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "பான்ஷீ இசைப்பி"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "டெபியன் முனைய எமுலேட்டர்"
+
+#~ msgid "ETerm"
+#~ msgstr "Eமுனையம்"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "க்னோம் திரை படிப்பி இல்லாத பெரிதாக்கி"
+
+#~ msgid "GNOME OnScreen Keyboard"
+#~ msgstr "க்னோமின் திரை விசைப்பலகை"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "க்னோம் முனையம்"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "க்னோபர்நிக்கஸ்"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "க்னோபர்நிகஸ் பெரிதாக்கியுடன்"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "கேடீஇ திரை படிப்பி இல்லாத பெரிதாக்கி"
+
+#~ msgid "Konsole"
+#~ msgstr "கான்சோல்"
+
+#~ msgid "Linux Screen Reader"
+#~ msgstr "லினக்ஸ் திரைபடிப்பான்"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "லினக்ஸ் திரைபடிப்பான் பெரிதாக்கியுடன்"
+
+#~ msgid "Listen"
+#~ msgstr "கேள்"
+
+#~ msgid "NXterm"
+#~ msgstr "NXமுனையம்"
+
+#~ msgid "Orca"
+#~ msgstr "ஆர்கா"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "பெரிதாக்கி உடன் ஆர்கா"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "ரிதம்பாக்ஸ் இசை இயக்கி"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "வழக்கமான Xமுனையம்"
+
+#~ msgid "Terminator"
+#~ msgstr "முடித்துவைப்பவர்"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "டோடம் திரைப்பட இயக்கி"
+
+#~ msgid "aterm"
+#~ msgstr "எடெர்ம்"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "மானிட்டர்களை கண்டுபிடி (_D)"
+
+#~ msgid "_Mirror Screens"
+#~ msgstr "_M பிரதிபலிக்கும்  திரைகள்"
+
+#~ msgid "Upside Down"
+#~ msgstr "தலை கீழ்"
+
+#~ msgid "Desktop"
+#~ msgstr "மேசைச்சூழல்"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "வடிவமைப்பு தரவுத்தளத்தில் ஊக்கியை மாற்றி அமைப்பதில்  பிழை: %s"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "(_m) விசைப்பலகை வகை"
+
+#~ msgid "Move the selected keyboard layout down in the list"
+#~ msgstr "தேர்ந்தெடுக்கப்பட்ட விசைப்பலகை அமைப்பை பட்டியலில் கீழே நகர்த்துக"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "தேர்ந்தெடுக்கப்பட்ட விசைப்பலகை அமைப்பை பட்டியலில் மேலே நகர்த்துக"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "தேர்வு செய்யப்பட்ட விசைப்பலகை அமைப்பை அச்சிடுக"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "தேர்ந்தெடுக்கப்பட்ட விசைப்பலகை அமைப்பை பட்டியலில் இருந்து நீக்குக."
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "பட்டியலில் சேர்க்க வேண்டிய விசைப்பலகை அமைப்பினை தேர்ந்தெடு"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "(_P) சுட்டி விசைபலகத்தால் கட்டுப்படுத்த இயலும்."
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "(_T) அமைப்புகளை சோதிக்க உள்ளிடவும்:"
+
+#~ msgid "By _country"
+#~ msgstr "நாட்டால்: (_c)"
+
+#~ msgid "Preview:"
+#~ msgstr "முன்பார்வை:"
+
+#~ msgid "_Country:"
+#~ msgstr "நாடு: (_C)"
+
+#~ msgid "_Variants:"
+#~ msgstr "(_V) மாறுபட்ட வடிவங்கள்:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "ஒரு விசைப்பலகை மாதிரியை தேர்வு செய்யவும்"
+
+#~ msgid "_Models:"
+#~ msgstr "மாதிரிகள்: (_M)"
+
+#~ msgid "_Vendors:"
+#~ msgstr "(_V) விற்பனையாளர்கள்:"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "(_b)சொடுக்கு வகையை முன் கூட்டியே   தேர்வு செய்க"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "(_u) சொடுக்கு வகையை  சொடுக்கி அசைவால்  தேர்வு செய்க"
+
+#~ msgid "D_rag click:"
+#~ msgstr "(_r) இழுவை சொடுக்கு:"
+
+#~ msgid "Dwell Click"
+#~ msgstr "ட்வெல்(Dwell) சொடுக்கு"
+
+#~ msgid "Show click type _window"
+#~ msgstr "(_w) சொடுக்கு வகை சாளரத்தை காட்டு"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr ""
+#~ "சொடுக்கு வகையை தேர்ந்தெடுக்க நிலை சொடுக்கு பலக குறுநிரலைக்கூட பயன்படுத்தலாம்."
+
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "(_I)சுட்டி அசைவை நிறுத்தும்போது சொடுக்கை துவக்கு"
+
+#~ msgid "_Single click:"
+#~ msgstr "(_S) ஒற்றை சொடுக்கு:"
+
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr "(_T) முதன்மை  பொத்தானை அழுத்திய படி இரண்டாம் சொடுக்கை இடரவும்"
+
+#~ msgid "Location already exists"
+#~ msgstr "இடம் ஏற்கனவே உள்ளது"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "உங்கள் பிணைய பதிலாள் முன்னுரிமைகளை அமை"
+
+#~ msgid "Web;Location;"
+#~ msgstr "வலை;இடம்;"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>(_M) கையேடு உள்ளமைக்கபட்ட கோலி</b>"
+
+#~ msgid "Create New Location"
+#~ msgstr "புதிய இடத்தை உருவாக்கு"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP பதிவாணை விவரங்கள்"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "புரவலன் பட்டியலை தவிர்"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "பிணைய பதிலாள் முன்னுரிமைகள்"
+
+#~ msgid "The location already exists."
+#~ msgstr "இந்த இடம் ஏற்கனவே உள்ளது."
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "(_S) HTTP பிரதிநிதி பழங்கவும்."
+
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "(_U) எல்லா நெறிமுறைகளுக்கும் அதே பதிலாள் ஐ பயன்படுத்துவும். "
+
+#~ msgid "No sounds"
+#~ msgstr "ஒலிகள் இல்லை"
+
+#~ msgid "Sound _theme:"
+#~ msgstr "ஒலித் தீம்: (_t)"
+
+#~ msgid "Enable _window and button sounds"
+#~ msgstr "சாளரம் மற்றும் பொத்தான் ஒலிகளை செயல்படுத்து ( _w)"
+
+#~ msgid "Ctrl+Alt+0"
+#~ msgstr "கன்ட்ரோல்+ஆல்ட்+0"
+
+#~ msgid "Ctrl+Alt+4"
+#~ msgstr "கன்ட்ரோல்+ஆல்ட்+4"
+
+#~ msgid "Ctrl+Alt+8"
+#~ msgstr "கன்ட்ரோல்+ஆல்ட்+8"
+
+#~ msgid "Ctrl+Alt+="
+#~ msgstr "கன்ட்ரோல்+ஆல்ட்+="
+
+#~ msgid "I need assistance with:"
+#~ msgstr "இதற்கு உதவி தேவை:"
+
+#~ msgid "LowContrast"
+#~ msgstr "குறைந்த வேறுபாடு"
+
+#~ msgid "Shift+Ctrl+Alt+-"
+#~ msgstr "ஷிப்ட்+கன்ட்ரோல்+ஆல்ட்+-"
+
+#~ msgid "Shift+Ctrl+Alt+="
+#~ msgstr "ஷிப்ட்+கன்ட்ரோல்+ஆல்ட்+="
+
+#~ msgid "Use an alternative form of text input"
+#~ msgstr "மாற்று உள்ளீடு வகையை பயன்படுத்துக "
+
+#~ msgctxt "Account type"
+#~ msgid "Supervised"
+#~ msgstr "மேற்பார்வையிடப்பட்டது"
+
+#~ msgid ""
+#~ "A guest account will allow anyone to temporarily log in to this computer "
+#~ "without a password.  For security, remote logins to this account are not "
+#~ "allowed.\n"
+#~ "\n"
+#~ "<b>When the guest user logs out, all files and data associated with the "
+#~ "account will be deleted.</b>"
+#~ msgstr ""
+#~ "இந்த கணினி கடவுச்சொல் இல்லாமல் ஒரு விருந்தினர் தற்காலிகமாக உள்நுழைய அனுமதிக்கும். "
+#~ "பாதுகாப்பிற்காக தொலை உள்புகுகைகள் இந்த கணக்குக்கு கிடையாது.\n"
+#~ "\n"
+#~ "<b>பயனர் வெளிச்செல்லும்போது அவருடைய கோப்புகள் தரவுகள் அனைத்தும் அழிக்கப்படும்.</b>"
+
+#~ msgid "Accounts"
+#~ msgstr "கணக்குகள்"
+
+#~ msgid "Address Book Card:"
+#~ msgstr "முகவரி  புத்தக அட்டை:"
+
+#~ msgid "Allow guests to log in to this computer"
+#~ msgstr "இந்த கணினிக்கு விருந்தினரை அனுமதி"
+
+#~ msgid "E-mail address:"
+#~ msgstr "மின்னஞ்சல் முகவரி:"
+
+#~ msgid "Restrictions:"
+#~ msgstr "ஆவண தடைகள்:"
+
+#~ msgid "Show Shutdown, Suspend and Restart actions"
+#~ msgstr "கணினி நிறுத்தம், செயல் நிறுத்தம், மீள்துவக்கம் ஆகிய செயல்களை காட்டு"
+
+#~ msgid "Show list of users"
+#~ msgstr "பயனர் பட்டியல் ஐ காட்டு"
+
+#~ msgid "Show password hints"
+#~ msgstr "கடவுச்சொல் உதவிக் குறிப்புகளை காட்டு"
+
+#~ msgid "Example preferences panel"
+#~ msgstr "உதாரண விருப்பங்கள் பலகம்"
+
+#~ msgid "Foo;Bar;Baz;"
+#~ msgstr "ஃபூ;பார்;பஃஸ்;"
+
+#~ msgid "Image Viewer"
+#~ msgstr "படம் காட்டி"
+
+#~ msgid "Multimedia"
+#~ msgstr "பல்ஊடகம்"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "புதிய தத்தலில் இணைப்பினை திறக்கவும் (_t)"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "புதிய சாளரத்தில் இணைப்பினை திறக்கவும் (_w)"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "முன்னிருப்பாக இணைய உலாவியில் இணைப்பினை திறக்கவும் (_d)"
+
+#~ msgid "Video Player"
+#~ msgstr "வீடியோ இயக்கி"
+
+#~ msgid "Balsa"
+#~ msgstr "பல்சா"
+
+#~ msgid "Claws Mail"
+#~ msgstr "க்ளாஸ் அஞ்சல்"
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Debian அறிவார்ந்த உலாவி"
+
+#~ msgid "Encompass"
+#~ msgstr "என்காம்பஸ்துகொள்"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "எவலூஷன் அஞ்சல் காட்டி"
+
+#~ msgid "Firefox"
+#~ msgstr "பயர்பாக்ஃஸ்"
+
+#~ msgid "Iceape"
+#~ msgstr "ஐஸ்ஏப்"
+
+#~ msgid "Iceape Mail"
+#~ msgstr "ஐஸ்ஏப் அஞ்சல்"
+
+#~ msgid "Icedove"
+#~ msgstr "ஐஸ்டோவ்"
+
+#~ msgid "Iceweasel"
+#~ msgstr "ஐஸ்வீஸல்"
+
+#~ msgid "Konqueror"
+#~ msgstr "கான்கொரர்"
+
+#~ msgid "Midori"
+#~ msgstr "மிடோரி"
+
+#~ msgid "Mozilla"
+#~ msgstr "மோசில்லா"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "மோசில்லா 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "மொசில்லா அஞ்சல்"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "மோசில்லா தண்டர் பர்ட்"
+
+#~ msgid "Mutt"
+#~ msgstr "மட்"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "நெட்ஸ்கேப்"
+
+#~ msgid "Opera"
+#~ msgstr "ஒபெரா"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "ஸீமங்கி"
+
+#~ msgid "SeaMonkey Mail"
+#~ msgstr "ஸீமங்கி அஞ்சல்"
+
+#~ msgid "Sylpheed"
+#~ msgstr "ஸில்ஃபீட்"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "ஸில்ஃபீட்-க்ளாஸ் "
+
+#~ msgid "Thunderbird"
+#~ msgstr "தண்டர் பர்ட்"
+
+#~ msgid "Include _panel"
+#~ msgstr "பலகத்தை சேர் (_p)"
+
+#~ msgid "Panel icon"
+#~ msgstr "பலக சின்னம்"
+
+#~ msgid "Re_fresh rate:"
+#~ msgstr "புதுப்பிக்கும்  விகிதம் (_f):"
+
+#~ msgid "Sa_me image in all monitors"
+#~ msgstr "_m  எல்லா  திரையகங்களிலும் அதே  பிம்பம்."
+
+#~ msgid "Monitors"
+#~ msgstr "திரைகள்"
+
+#~ msgid ""
+#~ "Usage: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "This program installs a RANDR profile for multi-monitor setups into\n"
+#~ "a systemwide location.  The resulting profile will get used when\n"
+#~ "the RANDR plug-in gets run in gnome-settings-daemon.\n"
+#~ "\n"
+#~ "SOURCE_FILE - a full pathname, typically /home/username/.config/monitors."
+#~ "xml\n"
+#~ "\n"
+#~ "DEST_NAME - relative name for the installed file.  This will get put in\n"
+#~ "            the systemwide directory for RANDR configurations,\n"
+#~ "            so the result will typically be %s/DEST_NAME\n"
+#~ msgstr ""
+#~ "பயன்பாடு: %s SOURCE_FILE DEST_NAME\n"
+#~ "\n"
+#~ "இந்த நிரல் ஒரு பல்திரை அமைப்புக்கான RANDR வரிவுருவை \n"
+#~ "கணினி அளாவிய இடத்தில் வைக்கிறது. இப்படி உருவான வரிவுரு \n"
+#~ "RANDR சொருகி க்னோம் அமைப்பு டீமனால் இயக்கப்படும் போது பயனாகிறது.\n"
+#~ "\n"
+#~ "SOURCE_FILE - ஒரு முழு பாதையின் பெயர், வழக்கமாக /home/username/.config/"
+#~ "monitors.xml\n"
+#~ "\n"
+#~ "DEST_NAME - நிறுவிய கோப்பின் பெயர். இது கணினி அளாவிய அடைவில் \n"
+#~ "            RANDR அமைப்புக்காக வைக்கப்படும்\n"
+#~ "            ஆகவே விடை வழக்கமாக %s/DEST_NAME என்றிருக்கும்.\n"
+
+#~ msgid "This program can only be used by the root user"
+#~ msgstr "ரூட் பயனர் மட்டுமே இந்த நிரலை இயக்கலாம்."
+
+#~ msgid "The source filename must be absolute"
+#~ msgstr "மூல கோப்புப் பெயர் முழுமையாக இருக்க வேண்டும்"
+
+#~ msgid "Could not get information for %s: %s\n"
+#~ msgstr " %s க்கு தகவலை பெற முடியவில்லை: %s\n"
+
+#~ msgid "%s must be a regular file\n"
+#~ msgstr "%s வழக்கமான கோப்பாக இருக்க வேண்டும் \n"
+
+#~ msgid "This program must only be run through pkexec(1)"
+#~ msgstr "இந்த நிரல் pkexec(1) ஆல் மட்டுமே இயக்கப்பட வேண்டும்"
+
+#~ msgid "PKEXEC_UID must be set to an integer value"
+#~ msgstr "PKEXEC_UID ஒரு முழு எண் மதிப்புக்கு அமைக்கப்பட வேண்டும்."
+
+#~ msgid "%s must be owned by you\n"
+#~ msgstr "%s உங்களுடையதாக இருக்க வேண்டும்\n"
+
+#~ msgid "%s must not have any directory components\n"
+#~ msgstr "%s இல் அடைவு கூறுகள் ஏதும் இருக்கக்கூடாது\n"
+
+#~ msgid "%s must be a directory\n"
+#~ msgstr "%s ஒரு அடைவாக இருக்க வேண்டும்\n"
+
+#~ msgid "Could not open %s/%s: %s\n"
+#~ msgstr "%s/%s ஐ திறக்க  முடியவில்லை: %s\n"
+
+#~ msgid "Could not rename %s to %s: %s\n"
+#~ msgstr "%s லிருந்து %sக்கு மறுபெயரிட முடியவில்லை: %s\n"
+
+#~ msgid ""
+#~ "Authentication is required to install multi-monitor settings for all users"
+#~ msgstr "எல்லாப் பயனர்களுக்கு பல்திரை அமைக்க அங்கீகாரம் தேவைப்படுகிறது"
+
+#~ msgid "Install multi-monitor settings for the whole system"
+#~ msgstr "முழு கணினிக்கும் பல திரை அமைப்பை நிறுவுக"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Monitor: %s"
+#~ msgstr "மானிட்டர்: %s"
+
+#~ msgid "The monitor configuration has been saved"
+#~ msgstr "மானிட்டர் கட்டமைப்பு சேமிக்கப்பட்டது"
+
+#~ msgid "This configuration will be used the next time someone logs in."
+#~ msgstr "இந்த அமைப்பு அடுத்து யாரும் உள் நுழையும் போது பயன்படுத்தப்படும்."
+
+#~ msgid "Could not set the default configuration for monitors"
+#~ msgstr "மானிட்டர்களுக்கு முன்னிருப்பு கட்டமைப்பை அமைக்க முடியவில்லை"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "கட்டளைகளுக்கான குறுக்கு வழி விசைகளை ஒப்படை"
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "(_t) முன் பின் மாற்று விசை  அழுத்தினால் பீப் ஒலி எழுப்புக"
+
+#~ msgid "Beep when a key is reje_cted"
+#~ msgstr "(_c) விசை ஏற்கப்படவில்லையானால் பீப் ஒலி எழுப்புக"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "(_r) விசை ஏற்கப்படவில்லையானால் பீப் ஒலி எழுப்புக"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "சாளரம் தலைப்புப்பட்டையை பளிச்சிடு (_w)"
+
+#~ msgid "Flash entire _screen"
+#~ msgstr "முழு திரையை பளிச்சிடு (_s)"
+
+#~ msgid "Keyboard Accessibility Audio Feedback"
+#~ msgstr "விசைப்பலகை அணுகல்-  ஒலி மீட்பொலி "
+
+#~ msgid "Show _visual feedback for the alert sound"
+#~ msgstr "எச்சரிக்கை ஒலியின் விஷுவல் பின்னூட்டத்தை காட்டு (_v)"
+
+#~ msgid "Visual cues for sounds"
+#~ msgstr "ஒலிகளுக்கான விஷுவல் cues"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "இடை முறிவுகளை தள்ளிப்போட அனுமதி (_o)"
+
+#~ msgid "Audio _Feedback..."
+#~ msgstr "(_F) ஒலி மீட்பொலி..."
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "முறிவுகள்  தள்ளிப்போட அனுமதி உள்ளதா என சோதிக்கவும்"
+
+#~ msgid "Disa_ble sticky keys if two keys are pressed together"
+#~ msgstr "(_b) இரண்டு விசைகளை ஒரே நேஎரத்தில் அழுத்தினால்  ஒட்டு விசையை செயல் நீக்கவும்."
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "உள்ளிடல் செயலிழக்கப்பட்டபோது இடைவேளையின்வின் காலஅளவு"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "இவ்வளவு வேலைக்குப் பிறகு இடைவேளையை கட்டாயமாக்கு"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "வி விசைப்ப விபத்து ஏற்படாமல் தடுக்கலை  குறிப்பிட்ட கால இடைவெளிக்குப்பிறகு "
+#~ "திரையைப்பூட்டவும்"
+
+#~ msgid "Typing Break"
+#~ msgstr "உள்ளிடல் இடைவெளி"
+
+#~ msgid "_Accessibility features can be toggled with keyboard shortcuts"
+#~ msgstr ""
+#~ "(_A) அணுகல் சிறப்பு இயல்புகள் விசைப்பலகை குறுக்குவழிகளுடன் முன் பின் மாற் ற முடியும்."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "(_B) இடைவெளி நீள நேரம்:"
+
+#~ msgid "_Ignore fast duplicate keypresses"
+#~ msgstr "(_I) வேக இரட்டிப்பு விசை அழுத்தங்களை தவிர்"
+
+#~ msgid "_Lock screen to enforce typing break"
+#~ msgstr "(_L) தட்டச்சு முறிவை கட்டாயப்படுத்த திரையை பூட்டு "
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "(_O) நீண்ட விசை அழுத்தத்தை மட்டும் ஏற்றுக்கொள்க"
+
+#~ msgid "_Simulate simultaneous keypresses"
+#~ msgstr "(_S) ஒரே நேர விசை அழுத்தலை பாவிக்க"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "(_W) வேலை இடைவெளி  நேரம்"
+
+#~ msgid "Unable to load stock icon '%s'\n"
+#~ msgstr "இருப்பு சின்னத்தை ஏற்ற முடியவில்லை '%s'\n"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "இடது பக்கம் நகர்த்து"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "வலது பக்கம் நகர்த்து "
+
+#~ msgid "gesture|Move up"
+#~ msgstr "மேலே நகர்த்து"
+
+#~ msgid "gesture|Move down"
+#~ msgstr "கீழே நகர்த்து"
+
+#~ msgid "gesture|Disabled"
+#~ msgstr "முடக்கப்பட்ட"
+
+#~ msgid ""
+#~ "Accessibility features can be turned on or off with keyboard shortcuts"
+#~ msgstr ""
+#~ "(_A) அணுகல் சிறப்பு இயல்புகள் விசைப்பலகை குறுக்குவழிகளுடன் முன் பின் மாற்ற முடியும்."
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "ஒரு வேலை முடிந்ததும் கட்டுப்பாட்டு மையத்தை மூடு"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "சேர் நீக்கு செயல் முடிந்தவுடன் ஷெல் இலிருந்து வெளியேறு"
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "உதவி செயல் முடிந்தவுடன் ஷெல் இலிருந்து வெளியேறு"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "துவக்கு செயல் முடிந்தவுடன் ஷெல் இலிருந்து வெளியேறு"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "மேம்படுத்து அல்லது நிறுவல் நீக்கு செயல் முடிந்தவுடன் ஷெல் இலிருந்து வெளியேறு"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "உதவி செயல் முடிந்தால் ஷெல் ஐ மூடுவதா என காட்டுகிறது"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "துவக்க செயல் நடந்தால் ஷெல் ஐ மூடுவதா என காட்டுகிறது"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr "சேர் அல்லது நீக்கு செயல் முடிந்தால் ஷெல் ஐ மூடுவதா என காட்டுகிறது."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr "மேம்பாடு அல்லது நிறுவல் நீக்கம் செயல் நடந்தால் ஷெல் ஐ மூடுவதா என காட்டுகிறது."
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "வேலைகளின் பெயர்கள் மற்றும் தொடர்புள்ள desktop கோப்புகள்"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "பணி பெயர் கட்டுப்பாடு மையத்தில் காட்டப்படும். இதன் பின்னே \";\" ஆல் பிரிக்கப்பட்டு , "
+#~ "அந்த செயலை செய்ய அதன் தொடர்பான .desktop கோப்பின் பெயர் காட்டப்படும் ."
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr "உண்மை எனில் கட்டுப்பாட்டு மையம்  \"Common Task\" செயலானதும் மூடப்படும்."
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "கனோம் அமைவடிவு கருவி"
+
+#~ msgid "_Postpone Break"
+#~ msgstr "(_P) ஒத்திவத்தல் முறிப்பு"
+
+#~ msgid "_Take a Break"
+#~ msgstr "ஒரு ஓய்வு எடு (_T)"
+
+#~ msgid "Take a break now (next in %dm)"
+#~ msgstr "இடைவேளை எடுக்கவும் (அடுத்தது %dm இல்)"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d நிமிடத்திற்கு குறைவான அடுத்த இடைவெளி வரை"
+#~ msgstr[1] "%d நிமிடங்களுக்கு குறைவான அடுத்த இடைவெளி வரை"
+
+#~ msgid "Take a break now (next in less than one minute)"
+#~ msgstr "இடைவேளை எடுக்கவும் (அடுத்தது ஒரு நிமிடத்திற்கு குறைவான இடைவெளியில்)"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "ஒரு நிமிடத்திற்கு குறைவான அடுத்த இடைவெளி வரை"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr "அச்சிடும் உடை குணங்கள் உரையாட பின்வரும் பிழையுடன் மேலே கொண்டுவர முடியாது:%s"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "எழுதியது ரிச்சர்ட் ஹுல்ட் <richard@imendio.com>"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "ஆண்டிராஸ் கார்ல்சன் ஐய் காண்டியை சேர்த்தார்"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "கணினி புறிவின் நினைவுகுறிப்பு."
+
+#~ msgid "translator-credits"
+#~ msgstr "I. Felix <ifelix@redhat.com>. Dr. T. Vasudevan <agnihot3@gmail.com>"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "அறிவிப்பு இடம் உள்ளதா என ஆராய வேண்டாம்."
+
+#~ msgid "Typing Monitor"
+#~ msgstr "அச்சிடும் திரையகம்"
+
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "தட்டச்சு திரை தகவலை காட்ட தனி இடத்தை பயன்படுத்தும். உங்கள் பலகத்தில் திருத்த தனி இடம் "
+#~ "இருக்க வேண்டிய அவசியம் இல்லை. உங்கள் பலகத்தின் மேல் வலது சொடுக்கி பலகத்திற்குள் சேர் -> "
+#~ "பயன்பாடுகள் -> தகவல் பரப்பு பயன்படுத்தி சேர்க்கலாம்."
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "உண்மையெனில், OpenType எழுத்துருக்கள் சிறுபடமாக்கப்படும்."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "உண்மையெனில், PCF எழுத்துருக்கள் சிறுபடமாக்கப்படும்."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "உண்மையெனில், TrueType எழுத்துருக்கள் சிறுபடமாக்கப்படும்."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "உண்மையெனில், Type1 எழுத்துருக்கள் சிறுபடமாக்கப்படும்."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr "OpenType எழுத்துருக்களுக்கு சிறுபடம் உருவாக்க இந்த விசையை கட்டளையாக அமை"
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "PCF எழுத்துருக்களுக்கு சிறுபடம் உருவாக்க இந்த விசையை கட்டளையாக அமை."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr "TrueType எழுத்துருக்களுக்கு சிறுபடம் உருவாக்க இந்த விசையை கட்டளையாக அமை."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "Type1 எழுத்துருக்களுக்கு சிறுபடம் உருவாக்க இந்த விசையை கட்டளையாக அமை."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "OpenType எழுத்துருக்களுக்கான சிறுபட கட்டளை"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "PCF எழுத்துருக்களுக்கான சிறுபட கட்டளை"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "TrueType எழுத்துருக்களுக்கான சிறுபட கட்டளை"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Type1 எழுத்துருக்களுக்கான சிறுபட கட்டளை"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "OpenType எழுத்துருக்களை சிறுபடமாக்க வேண்டுமா"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCF எழுத்துருக்களை சிறுபடமாக்க வேண்டுமா"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "TrueType எழுத்துருக்களை சிறுபடமாக்க வேண்டுமா"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Type1 எழுத்துருக்களை சிறுபடமாக்க வேண்டுமா"
+
+#~ msgid "Copyright:"
+#~ msgstr "காப்புரிமை:"
+
+#~ msgid "Installed"
+#~ msgstr "நிறுவப்பட்டது"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "பயன்பாடு : %s fontfile\n"
+
+#~ msgid "I_nstall Font"
+#~ msgstr "_n எழுத்துருக்களை நிறுவு"
+
+#~ msgid "Font Viewer"
+#~ msgstr "எழுத்துரு காட்டி"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "உரையிலிருந்து சிறுபடம் (முன்னிருப்பு: Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "TEXT"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "எழுத்துரு அளவு (முன்னிருப்பு: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "SIZE"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "Image/label border"
+#~ msgstr "படம்/பெயர் எல்லை"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "எச்சரிக்கை உரையாடலில் பெயர் மற்றும் உருவை சுற்றிலும் உள்ள எல்லை அகலம்"
+
+#~ msgid "The type of alert"
+#~ msgstr "எச்சரிக்கையின் வகை"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "எச்சரிக்கை உரையாடலில் காட்டப்பட்ட பொத்தான்கள்"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "%sஇல் உங்கள் இடது கட்டைவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "%sஇல் உங்கள் இடது கட்டைவிரலை தேய்க்கவும்"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "%sஇல் உங்கள் இடது சுட்டுவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "%sஇல் உங்கள் இடது சுட்டுவிரலை தேய்க்கவும்"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "%sஇல் உங்கள் இடது நடுவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "%sஇல் உங்கள் இடது நடுவிரலை தேய்க்கவும்"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "%sஇல் உங்கள் இடது மோதிரவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "%sஇல் உங்கள் இடது மோதிர விரலை தேய்க்கவும்"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "%sஇல் உங்கள் இடது சிறுவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "%sஇல் உங்கள் இடது சிறு விரலை தேய்க்கவும்"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "%sஇல் உங்கள் வலது கட்டைவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "%sஇல் உங்கள் வலது கட்டைவிரலை தேய்க்கவும்"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "%sஇல் உங்கள் வலது சுட்டுவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "%sஇல் உங்கள் வலது சுட்டு விரலை தேய்க்கவும்"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "%sஇல் உங்கள் வலது நடுவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "%sஇல் உங்கள் வலது நடு விரலை தேய்க்கவும்"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "%sஇல் உங்கள் வலது மோதிரவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "%sஇல் உங்கள் வலது மோதிர விரலை தேய்க்கவும்"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "%sஇல் உங்கள் வலது சிறுவிரலை வைக்கவும்"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "%sஇல் உங்கள் வலது சிறு விரலை தேய்க்கவும்"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "வாசிப்பியில் உங்கள் விரலை மீண்டும் வைக்கவும்"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "விரலை மீண்டும் தேய்க்கவும்"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "தேய்த்தல் மிகவும் குறைவாக உள்ளது, மீண்டும் முயற்சிக்கவும்"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "உங்கள் விரல் மையமாக இல்லை, மீண்டும் விரலை தேய்க்க முயற்சிக்கவும்"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "விரலை எடுத்து மீண்டும் உங்கள் விரலை தேய்க்கவும்"
+
+#~ msgid "No Image"
+#~ msgstr "படம் இல்லை"
+
+#~ msgid "Images"
+#~ msgstr "படங்கள்"
+
+#~ msgid "All Files"
+#~ msgstr "அனைத்து கோப்புகள்"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "முகவரி புத்தகத்தை எடுக்க முயற்சிக்கும் போது பிழை\n"
+#~ "Evolution தரவு சேவையகம் நெறிமுறையை கையாள முடியவில்லை"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "முகவரி புத்தகத்தை திறக்க முடியவில்லை"
+
+#~ msgid "About %s"
+#~ msgstr "%s பற்றி"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "உதவியாளர்: (_s)"
+
+#~ msgid "C_ompany:"
+#~ msgstr "நிறுவனம்: (_o)"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "கடவுச்சொல்லை மாற்று... (_r)"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "நகரம்: (_t)"
+
+#~ msgid "Co_untry:"
+#~ msgstr "நாடு: (_u)"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "நாடு: (_n)"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "கைரேகை புகுபதிவை செயல்நீக்கு (_F)..."
+
+#~ msgid "Email"
+#~ msgstr "மின்னஞ்சல்"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "கைரேகை புகுபதிவை செயல்படுத்து (_F)..."
+
+#~ msgid "Hom_e:"
+#~ msgstr "முதன்மை: (_e)"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "Instant Messaging"
+#~ msgstr "உடனடி செய்தி"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _box:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. box:"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "மாநிலம்/மாகாணம்: (_v)"
+
+#~ msgid "User name:"
+#~ msgstr "பயனர் பெயர்:"
+
+#~ msgid "Web _log:"
+#~ msgstr "இணைய பதிவு: (_l)"
+
+#~ msgid "Wor_k:"
+#~ msgstr "வேலை: (_k)"
+
+#~ msgid "Work"
+#~ msgstr "வேலை"
+
+#~ msgid "Work _fax:"
+#~ msgstr "வேலை தொலைநகலி: (_f)"
+
+#~ msgid "ZIP/_Postal code:"
+#~ msgstr "ஃஜிப்/பின் அஞ்சல் குறியீடு: (_P)"
+
+#~ msgid "_GroupWise:"
+#~ msgstr "குழுவாரியாக: (_G)"
+
+#~ msgid "_Home page:"
+#~ msgstr "முதன்மை பக்கம்: (_H)"
+
+#~ msgid "_Home:"
+#~ msgstr "முதன்மை: (_H)"
+
+#~ msgid "_Manager:"
+#~ msgstr "மேலாளர்: (_M)"
+
+#~ msgid "_State/Province:"
+#~ msgstr "மாநிலம்/மாகாணம்: (_S)"
+
+#~ msgid "_Work:"
+#~ msgstr "பணி: (_W)"
+
+#~ msgid "_XMPP:"
+#~ msgstr "_XMPP:"
+
+#~ msgid "_ZIP/Postal code:"
+#~ msgstr "ஃஜிப்/ அஞ்சல் குறியீடு: (_P)"
+
+#~ msgid "Swipe finger on reader"
+#~ msgstr "வாசிப்பியில் விரலை தேய்க்கவும்"
+
+#~ msgid "Place finger on reader"
+#~ msgstr "வாசிப்பியில் விரலை வைக்கவும்"
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "எதிர்பாராத விதமாக சேய் வெளியேறியது"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO தடத்தை பணிநிறுத்தம் செய்ய முடியவில்லை: %s"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO தடத்தை பணிநிறுத்தம் செய்ய முடியவில்லை: %s"
+
+#~ msgid "System error: %s."
+#~ msgstr "கணினி பிழை: %s."
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "இதை துவக்க முடியவில்லை %s: %s"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "பின்தளத்தை ஏற்ற முடியவில்லை"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "ஒரு கணினி பிழை ஏற்பட்டுள்ளது"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "<b>கடவுச்சொல்லை மாற்று</b> என்பதை சொடுக்கி உங்கள் கடவுச்சொல்லை மாற்றவும்."
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr ""
+#~ "உங்கள் கடவுச்சொல்லை மீண்டும் <b>மீண்டும் புதிய கடவுச்சொல் தட்டச்சு செய்யவும்</b> புலத்தில் "
+#~ "தட்டச்சு செய்யவும்."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "இரண்டு கடவுச்சொற்களும் ஒன்றாக இல்லை."
+
+#~ msgid "Change your password"
+#~ msgstr "உங்கள் கடவுச்சொல்லை மாற்றவும்"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "உங்கள் கடவுச்சொல்லை மாற்ற கீழுள்ள புலத்தில் உங்கள் தற்போதைய கடவுச்சொல்லை உள்ளிட்டு  "
+#~ "<b>உறுதிப்படுத்து</b> ஐ சொடுக்கவும்.\n"
+#~ "உறுதிபடுத்தியதும் உங்கள் புதிய கடவுச்சொல்லை உள்ளிட்டு அதை சரி பார்க்க மீண்டும் "
+#~ "உள்ளிடுக. பின் <b>கடவுச்சொல் மாற்று</b> ஐ சொடுக்கவும்."
+
+#~ msgid "Font may be too large"
+#~ msgstr "எழுத்துரு மிகப்பெரிதாக இருக்கலாம்"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "நீங்கள் தேர்வு செய்த எழுத்துரு %d அளவு பெரிதாக உள்ளது மேலும் முழுமையாக "
+#~ "கணிப்பொறியில் பயன்படுத்துவது கடினம். சிறிய அளவை பயன்படுத்தவும் %d."
+#~ msgstr[1] ""
+#~ "நீங்கள் தேர்வு செய்த எழுத்துரு %d அளவு பெரிதாக உள்ளது மேலும் முழுமையாக "
+#~ "கணிப்பொறியில் பயன்படுத்துவது கடினம். சிறிய அளவை பயன்படுத்தவும் %d."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "நீங்கள் தேர்வு செய்த எழுத்துரு %d அளவு பெரிதாக உள்ளது மேலும் முழுமையாக "
+#~ "கணிப்பொறியில் பயன்படுத்துவது கடினம். சிறிய அளவை பயன்படுத்தவும்"
+#~ msgstr[1] ""
+#~ "நீங்கள் தேர்வு செய்த எழுத்துரு %d அளவு பெரிதாக உள்ளது மேலும் முழுமையாக "
+#~ "கணிப்பொறியில் பயன்படுத்துவது கடினம். சிறிய அளவை பயன்படுத்தவும்."
+
+#~ msgid "Use previous font"
+#~ msgstr "முந்தைய எழுத்துருவை பயன்படுத்தவும்"
+
+#~ msgid "Use selected font"
+#~ msgstr "தேர்ந்தெடுத்த எழுத்துருவை பயன்படுத்துக"
+
+#~ msgid "Could not load user interface file: %s"
+#~ msgstr "பயனர் இடைமுக கோப்பை ஏற்ற முடியவில்லை: %s"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "நிறுவ வேண்டிய கருத்துக் கோப்பின் பெயரை குறிப்பிடவும்"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr ""
+#~ "காட்ட வேண்டிய பக்கத்தின் பெயரை குறிப்பிடுக(கருத்து|பின்னணி|எழுத்துரு|இடைமுகம்)"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[WALLPAPER...]"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme "
+#~ "engine '%s' is not installed."
+#~ msgstr ""
+#~ "தேவையான ஜிடிகே கருப்பொருள் இயந்திரம் '%s' நிறுவாததால் இந்த கருப்பொருள் "
+#~ "எதிர்பார்த்தாற்போல் அமையாது."
+
+#~ msgid "Apply Background"
+#~ msgstr "பின்னணி வண்ணங்களை அமை."
+
+#~ msgid "Apply Font"
+#~ msgstr "எழுத்துருவை பயன்படுத்து."
+
+#~ msgid "Revert Font"
+#~ msgstr "எழுத்துருவை மீட்டெடு"
+
+#~ msgid ""
+#~ "The current theme suggests a background and a font. Also, the last "
+#~ "applied font suggestion can be reverted."
+#~ msgstr ""
+#~ "இப்போதைய கருப்பொருள் ஒரு பிண்ணனியையும் ஒரு எழுத்துருவையும்   பரிந்து காட்டுகிறது. "
+#~ "மேலும் கடைசியாக செயலாக்கிய எழுத்துரு பரிந்துரையை  நீக்கி விடலாம்.."
+
+#~ msgid ""
+#~ "The current theme suggests a background. Also, the last applied font "
+#~ "suggestion can be reverted."
+#~ msgstr ""
+#~ "இப்போதைய கருப்பொருள் ஒரு பிண்ணனியை   பரிந்து காட்டுகிறது. மேலும் கடைசியாக "
+#~ "செயலாக்கிய எழுத்துரு பரிந்துரையை  நீக்கி விடலாம்.."
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr ""
+#~ "இப்போதைய கருப்பொருள் ஒரு கணினிமேசை பின்னணி மற்றும் ஒரு எழுத்துருவை "
+#~ "குறிப்பிடுகிறது."
+
+#~ msgid ""
+#~ "The current theme suggests a font. Also, the last applied font suggestion "
+#~ "can be reverted."
+#~ msgstr ""
+#~ "இப்போதைய கருப்பொருள்  ஒரு எழுத்துருவை   பரிந்து காட்டுகிறது. மேலும் கடைசியாக "
+#~ "செயலாக்கிய எழுத்துரு பரிந்துரையை  நீக்கி விடலாம்.."
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "இப்போதைய கருப்பொருள் ஒரு கணினிமேசை பின்னணியை குறிப்பிடுகிறது."
+
+#~ msgid "The last applied font suggestion can be reverted."
+#~ msgstr "கடைசியாக செயலாக்கிய எழுத்துரு பரிந்துரையை  நீக்கி விடலாம்."
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "இப்போதைய கருப்பொருள் ஒரு எழுத்துருவை குறிப்பிடுகிறது."
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "கருப்பொருள்  விருப்பஙகள்"
+
+#~ msgid "Best _shapes"
+#~ msgstr "(_s) சிறந்த வடிவங்கள்"
+
+#~ msgid "C_ustomize..."
+#~ msgstr "(_u)தனிப்பயன்..."
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr ""
+#~ "உங்கள் சொடுக்கி கருப்பொருள் நீங்கள் அடுத்த முறை உள்நுழையும் போது செயலுக்கு வரும்."
+
+#~ msgid "Controls"
+#~ msgstr "கட்டுப்பாடுகள்"
+
+#~ msgid "Customize Theme"
+#~ msgstr "சூழலை தனிபயன் ஆக்குக"
+
+#~ msgid "D_etails..."
+#~ msgstr "(_e) விவரங்கள்.."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "பணிமேடை எழுத்துரு: (_k)"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "எழுத்துரு விவரண விவரங்கள்"
+
+#~ msgid "Fonts"
+#~ msgstr "எழுத்துருக்கள்"
+
+#~ msgid "Get more backgrounds online"
+#~ msgstr "மேலும் ஆன்லைன் பின்னணிகளை பெறு"
+
+#~ msgid "Get more themes online"
+#~ msgstr "கூடுதல் ஆன்லைன் தீம்களை பெறு"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "(_y)கறுப்புவெள்ளை."
+
+#~ msgid "Icons"
+#~ msgstr "குறும்படங்கள் மட்டும்."
+
+#~ msgid "Icons only"
+#~ msgstr "சின்னங்கள் மட்டும்."
+
+#~ msgid "N_one"
+#~ msgstr "(_o) ஏதுமில்லைற்று"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "நிறத்தை குறிப்பிட உரையாடலை திறக்கவும்"
+
+#~ msgid "R_esolution:"
+#~ msgstr "(_e) நுணுக்கம்:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "கருப்பொருளை இப்படி சேமி..."
+
+#~ msgid "Save _As..."
+#~ msgstr "(_A) இப்படி சேமி"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "(_p) உள்பிக்சல் (LCDs)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "(_p) உள்பிக்சல் மழுப்பாக்கல் (LCDs)"
+
+#~ msgid "Subpixel Order"
+#~ msgstr "உள்பிக்சல் வரிசை"
+
+#~ msgid "Text"
+#~ msgstr "உரை"
+
+#~ msgid "Text below items"
+#~ msgstr "உருப்படிகள் கீழே உரை"
+
+#~ msgid "Text beside items"
+#~ msgstr "உருப்படிகள் பக்கத்தில் உரை"
+
+#~ msgid "Text only"
+#~ msgstr "உரை மட்டும்"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "இப்போதைய கட்டுபாடுகள் கருப்பொருள் வண்ண திட்டங்களை ஆதரிக்கவில்லை"
+
+#~ msgid "Theme"
+#~ msgstr "கருப்பொருள்"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "விளக்கம்: (_D)"
+
+#~ msgid "_Document font:"
+#~ msgstr "ஆவண எழுத்துரு: (_D)"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "நிலையான எழுத்துரு அகலம்: (_F)"
+
+#~ msgid "_Monochrome"
+#~ msgstr "(_M) ஒற்றைநிறம்"
+
+#~ msgid "_None"
+#~ msgstr "(_N) வெற்று"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "(_R) முன்னிருப்புக்கு மீட்டமை"
+
+#~ msgid "_Selected items:"
+#~ msgstr "(_S) தேர்வுசெய்த _உருப்படிகள்:"
+
+#~ msgid "_Size:"
+#~ msgstr "(_S) அளவு:"
+
+#~ msgid "_Slight"
+#~ msgstr "(_S) சிறிதளவு"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "(_T) உதவிக்குறிப்புகள்:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "(_W) சாளரம் தலைப்பு எழுத்துரு:"
+
+#~ msgid "_Windows:"
+#~ msgstr "(_W) சாளரங்கள்:"
+
+#~ msgid "dots per inch"
+#~ msgstr "அங்குலத்துக்கு புள்ளிகள்"
+
+#~ msgid "Customize the look of the desktop"
+#~ msgstr "கணிமேசைக்கான காட்சியை தனிப்பயனாக்குக"
+
+#~ msgid "Installs themes packages for various parts of the desktop"
+#~ msgstr "கணினிமேசையின் பல பகுதிகளுக்கு கருப்பொருள்  பொதிகளை நிறுவுகிறது"
+
+#~ msgid "Theme Installer"
+#~ msgstr "கருப்பொருள் நிறுவி"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "க்னோம் கருப்பொருள் பொதி"
+
+#~ msgid "Cannot install theme"
+#~ msgstr "கருப்பொருளை நிறுவ முடியவில்லை  "
+
+# c-format
+#~ msgid "The %s utility is not installed."
+#~ msgstr " %s பயன்பாடு நிறுவப்படவில்லை."
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "கருப்பொருளை பிரித்தெடுப்பதில் பிரச்சினை."
+
+#~ msgid "There was an error installing the selected file"
+#~ msgstr "தேர்ந்தெடுக்கப்பட்ட கோப்பை நிறுவுவதில் தவறு"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" செல்லுபடியாகும் கருப்பொருளாக தெரியவில்லை."
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr ""
+#~ "\"%s\" செல்லுபடியாகும் கருப்பொருளாக தெரியவில்லை. அது நீங்கள் தொகுக்க வேண்டிய "
+#~ "கருப்பொருள் இயந்திரமாக இருக்கலாம்."
+
+# c-format
+#~ msgid "Installation for theme \"%s\" failed."
+#~ msgstr "\"%s\" கருப்பொருளுக்கு நிறுவல் தோல்வி அடைந்தது"
+
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "கருத்து\"%s\" நிறுவப்பட்டது"
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr ""
+#~ "அதை இப்போது செயலாக்க வேண்டுமா அல்லது உங்களது இப்போதைய கருத்தை வைத்துக் கொள்ளவா?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "நடப்பு சூழலை வைக்கவும்"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "புதிய சூழலை செயல்படுத்து"
+
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "GNOME சூழல் %s தற்போது நிறுவப்பட்டுள்ளது"
+
+#~ msgid "New themes have been successfully installed."
+#~ msgstr "புதிய கருப்பொருள் வெற்றிகரமாக நிறுவப்பட்டது."
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "நிறுவும் போது பொருள் குறிப்பிடபடாத கோப்பின் இடத்தை குறிப்பிடவும்"
+
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "சூழலை நிறுவுவதில் போதிய அனுமதிகள் இல்லை :\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "கருப்பொருள் ஐ தேர்ந்தெடு"
+
+#~ msgid "Theme Packages"
+#~ msgstr "கருப்பொருள் பொதிகள்"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "கருப்பொருள் பெயர் இருக்க வேண்டும்"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "கருப்பொருள் ஏற்கெனவே உள்ளது. மாற்ற விருப்பமா?"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "இந்த கருத்தை நீக்க வேண்டுமா?"
+
+#~ msgid "Could not install theme engine"
+#~ msgstr "கருப்பொருள்  இயந்திரத்தை நிறுவ முடியவில்லை"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with DBus, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "'gnome-settings-daemon' அமைப்பு மேலாளரை துவங்க முடியவில்லை.\n"
+#~ "க்னோம் அமைப்பு மேலாளர் இல்லாமல் சில விருப்பங்களை நிறைவு செய்ய முடியாது. இதனால் "
+#~ "போனபோவில் பிழை நேரலாம் அல்லது க்னோம் அல்லாத பயன்பாடு (உதாரணம் கேடியி) அமைப்பு "
+#~ "மேலாளர் ஏற்கெனவெ செயல்பாட்டில் இருக்கலாம் அல்லது க்னோமோடு சிக்கல் நிகழ்ந்திருக்கலாம்"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "உதவியை காட்டும்போது பிழை ஏற்பட்டது: %s"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "கோப்புகளை நகலெடுக்கிறது: %u ல் %uஐ"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' ஐ நகலெடுக்கிறது"
+
+#~ msgid "Parent Window"
+#~ msgstr "தாய் சாளரம்"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "உரையாடலின் தாய் சாளரம்"
+
+#~ msgid "From URI"
+#~ msgstr "URI இலிருந்து"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "இதனைப் பெறும் URI முகவரி"
+
+#~ msgid "To URI"
+#~ msgstr "URI சேருமிடம்"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "இதனை அனுப்பும் URI முகவரி"
+
+#~ msgid "Fraction completed"
+#~ msgstr "முடிக்கப்பட்ட அளவு"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "இதுவரை முடிக்கப்பட்ட அனுப்புகையின் பகுதி"
+
+#~ msgid "Current URI index"
+#~ msgstr "இந்த URI அட்டிகை"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "இந்த URI அட்டிகை - 1லிருந்து தொடங்கி"
+
+#~ msgid "Total URIs"
+#~ msgstr "மொத்த URIகள்"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "URIகளின் மொத்த எண்ணிக்கை"
+
+#~ msgid "File '%s' already exists. Do you want to overwrite it?"
+#~ msgstr "கோப்பு '%s' ஏற்கெனவே  உள்ளது. அதை மேலெழுத வேண்டுமா?"
+
+#~ msgid "_Skip"
+#~ msgstr "(_S) தவிர்"
+
+#~ msgid "Overwrite _All"
+#~ msgstr "(_A) அனைத்தும் மேலெழுது "
+
+#~ msgid "Default Pointer - Current"
+#~ msgstr "முன்னிருப்பு சொடுக்கி - இப்போதைய"
+
+#~ msgid "White Pointer"
+#~ msgstr "வெள்ளை சொடுக்கி"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "வெள்ளை சொடுக்கி - இப்போதைய"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "பெரிய சொடுக்கி - இப்போதைய"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "பெரிய வெள்ளை சொடுக்கி - இப்போதைய"
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required GTK+ theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "தேவையான ஜிடிகே கருப்பொருள் இயந்திரம் '%s' நிறுவாததால் இந்த கருப்பொருள் "
+#~ "எதிர்பார்த்தாற்போல் அமையாது."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required window manager "
+#~ "theme '%s' is not installed."
+#~ msgstr ""
+#~ "தேவையான சாளர மேலாண்மை கருப்பொருள்  '%s' நிறுவாததால் இந்த கருப்பொருள் "
+#~ "எதிர்பார்த்தாற்போல் அமையாது."
+
+#~ msgid ""
+#~ "This theme will not look as intended because the required icon theme '%s' "
+#~ "is not installed."
+#~ msgstr ""
+#~ "தேவையான சின்னம் கருப்பொருள்  '%s' நிறுவாததால் இந்த கருப்பொருள் எதிர்பார்த்தாற்போல் "
+#~ "அமையாது.."
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "சாளர மேலாளர்\"%s\" உள்ளமைப்பு  கருவியை பதிவாக்கவில்லை\n"
+
+#~ msgid "Maximize Vertically"
+#~ msgstr "செங்குத்தாக பெரிதாக்கு"
+
+#~ msgid "Maximize Horizontally"
+#~ msgstr "கிடை மட்டத்தில்  பெரிதாக்கு"
+
+#~ msgid "_Jabber:"
+#~ msgstr "ஜாபர்: (_J)"
+
+#~ msgid "Accessible Lo_gin"
+#~ msgstr "(_g) அணுகக்கூடிய உள்நுழைவு"
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "உதவி தொழில்நுட்பங்கள்"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "உதவி தொழில் நுட்ப விருப்பங்கள்"
+
+#~ msgid ""
+#~ "Changes to enable assistive technologies will not take effect until your "
+#~ "next log in."
+#~ msgstr ""
+#~ "நீங்கள் அடுத்த முறை நுழையும் வரை உதவி தொழில்நுட்ப அமைப்பில் ஏற்படுத்தும் மாற்றங்கள் "
+#~ "செயல்படா."
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "(_L) மூடி விட்டு வெளியேறவும்"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "விருப்பமான நிரல்கள் உரையாடலுக்கு செல்லவும்"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "அணுகக்கூடிய உள்நுழைவு உரையாடலுக்கு செல்க"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "அணுகக்கூடிய விசைப்பலகை உரையாடலுக்கு செல்க"
+
+#~ msgid "Jump to the Mouse Accessibility dialog"
+#~ msgstr "சொடுக்கி அணுகல் உரையாடலுக்கு தாவு"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "(_E) உதவி தொழில்நுட்பங்களை செயல்படுத்தவும"
+
+#~ msgid "_Mouse Accessibility"
+#~ msgstr "(_M) சொடுக்கி அணுகல்"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "விருப்பமான நிரல்கள்"
+
+#~ msgid "Choose which accessibility features to enable when you log in"
+#~ msgstr "தேர்வு செய்க:  உள் நுழையும்போது எந்த அணுகல் சிறப்பியல்பை செயல் ஆக்க வேண்டும் "
+
+#~ msgid ""
+#~ "Specify the name of the page to show (internet|multimedia|system|a11y)"
+#~ msgstr ""
+#~ "காட்ட வேன்டிய  பக்கத்தின்  பெயரை குறிப்பிடு  (இணையம் | பல்லூடகம் | கணினி | நண்பன்)"
+
+#~ msgid "Monitor Preferences"
+#~ msgstr "கணினி திரையக முன்னுரிமைகள்"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "அமைவுகளை சேமித்து வெளிச்செல்லவும்"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "உள்ளிடல் முறிவு அமைப்புகளை காட்டி, பக்கத்தை திறக்கவும்"
+
+#~ msgid "Start the page with the accessibility settings showing"
+#~ msgstr "அணுகல் அமைப்புகளை காட்டி, பக்கத்தை திறக்கவும்"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- க்னோம் விசைப்பலகை விருப்பங்கள்"
+
+#~ msgid "Specify the name of the page to show (general|accessibility)"
+#~ msgstr "காட்ட வேண்டிய  பக்கத்தின் பெயர் குறிப்பிடு"
+
+#~ msgid "- GNOME Mouse Preferences"
+#~ msgstr "GNOME சொடுக்கி விருப்பங்கள்"
+
+#~ msgid "Cannot start the preferences application for your window manager"
+#~ msgstr "உங்கள் சாளர மேலாளருக்கு விருப்ப பயன்பாடுகள் துவங்க முடியாது"
+
+#~ msgid "_Alt"
+#~ msgstr "(_A) ஆல்ட்"
+
+#~ msgid "H_yper"
+#~ msgstr "(_y) ஹைப்பர்"
+
+#~ msgid "S_uper (or \"Windows logo\")"
+#~ msgstr "(_u) சூப்பர்  (அல்ல \"Windows logo\")"
+
+#~ msgid "Movement Key"
+#~ msgstr "நகரும் விசைகள்"
+
+#~ msgid "Titlebar Action"
+#~ msgstr "தலைப்புப்பட்டி செயல்"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "சாளரத்தை நகர்த்த, இந்த விசையை அழுத்தி சாளரத்தை இழுக்கவும்:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "சாளரம்த்தின் விருப்பங்கள்"
+
+#~ msgid "Window Selection"
+#~ msgstr "சாளரத்தேர்வு"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "(_D)இந்த செயலை செயல்படுத்த தலைப்புபட்டையில் இரட்டை சொடுக்கு செய்யவும்:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "(_I) எழுவதற்க்கு முன் இடைவேளை :"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "(_R) இடைவேளைக்கு பிறகு உயரும் தேர்வுசெய்யபட்ட சாளரம்"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "(_S) சொடுக்கி சாளரங்கள்மேல் நகர்த்தும்போது அவைகளை தெரிவுசெய்க."
+
+#~ msgid "Set your window properties"
+#~ msgstr "உங்கள் சாளர பண்புகளை அமைக்கவும்"
+
+#~ msgid "Windows"
+#~ msgstr "சாளரங்கள்"
+
+#~ msgid "Hide on start (useful to preload the shell)"
+#~ msgstr "துவக்கத்தில் மறை (ஷெல்லை முன் ஏற்றும் போது பயனுள்ளது)"
+
+#~ msgid "Filter"
+#~ msgstr "வடிகட்டி"
+
+#~ msgid "Common Tasks"
+#~ msgstr "பொது வேலைகள்"
+
+#~ msgid "Your filter \"%s\" does not match any items."
+#~ msgstr "உங்கள் வடிப்பி \"%s\" எந்த உருப்படிகளுக்கும் பொருந்தவில்லை."
+
+#~ msgid "Upgrade"
+#~ msgstr "நிலைஉயர்த்து"
+
+#~ msgid "Uninstall"
+#~ msgstr "நிறுவல் நீக்கு"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "விருப்பத்திற்கு சேர்"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "துவக்க நிரல்களிலிருந்து நீக்கு"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "தொடங்கல் நிரல்களில் சேர்"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "புதிய விரிதாள்"
+
+#~ msgid "New Document"
+#~ msgstr "புதிய ஆவணம்"
+
+#~ msgid "Documents"
+#~ msgstr "ஆவணங்கள்"
+
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>திற</b>"
+
+#~ msgid "Rename..."
+#~ msgstr "மறுபெயரிடு..."
+
+#~ msgid "Move to Trash"
+#~ msgstr "குப்பைக்கு நகர்த்து"
+
+#~ msgid "Delete"
+#~ msgstr "நீக்கு"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "உருப்படியை நீக்கினால் அதை  நிரந்தரமாக இழக்க நேரும்"
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "இதனால் திற \"%s\""
+
+#~ msgid "Open in File Manager"
+#~ msgstr "கோப்பு மேலாளரில் திற"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "இன்று %l:%M %p"
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "நேற்று %b %d %l:%M %p"
+
+#~ msgid "Find Now"
+#~ msgstr "இப்போது கண்டறி"
+
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>திற %s</b>"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "கணினி அமைப்பு உருப்படிகளில் இருந்து நீக்கு"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "திரை நுணுக்கத்தை மாற்றவும்"
+
+#~ msgid "Display Preferences"
+#~ msgstr "காட்சி முன்னுரிமைகள்"
+
+#~ msgid "Drag the monitors to set their place"
+#~ msgstr "அதன் இடத்தை அமைக்க மானிட்டர்களை இழுக்கவும்"
+
+#~ msgid "Menus and Toolbars"
+#~ msgstr "கருவிப்பட்டைகளும் பட்டிப்பட்டைகளும்"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "(_i)பட்டிகளில் குறும்படங்களை காட்டுக"
+
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "கருவிப்பட்டை பொத்தான் பெயர்கள்: (_b)"
+
+#~ msgid "_Editable menu shortcut keys"
+#~ msgstr "திருத்தக்கூடிய பட்டி குறுக்கு விசைகள் (_E)"
+
+#~ msgid "New windows get layout \"foobar\""
+#~ msgstr "புதிய சாளரங்களுக்கு இட அமைவு  \"foobar\""
+
+#~ msgid "Selected _layouts:"
+#~ msgstr "(_l) தேர்வுசெய்த இடஅமைவுகள்:"
+
+#~ msgid "C_ontrol"
+#~ msgstr "கன்ட்ரோல் (_o)"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "The quick brown fox jumps over the lazy dog. 0123456789"

--- a/po/te.po
+++ b/po/te.po
@@ -18,9 +18,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center.master.te\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-08-22 06:31+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-09-03 20:11+0630\n"
 "Last-Translator: Krishnababu Krothapalli <kkrothap@redhat.com>\n"
 "Language-Team: Telugu <Fedora-trans-te@redhat.com>\n"
@@ -32,3718 +31,2822 @@ msgstr ""
 "X-Launchpad-Export-Date: 2011-09-24 09:12+0000\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "అనువర్తనాలు"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "ఏ అనువర్తనములు కనబడలేదు"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "నవీకరణలను స్థాపించు"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "తెరువు (_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "వివరాలను చూడు"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "శోధించు"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "అచేతనపరచివుంది"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "ప్రకటనలు"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "ప్రకటనలను చూపు (_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "నేపథ్యం"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "తెరపట్టులు"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "నేపథ్యచిత్రాలు"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "శబ్దము"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "అడ్డదారులు"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "కీబోర్డు లఘువులు"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s కెమేరా"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "మైక్రోఫోన్ శబ్దస్థాయి"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "స్థానం సేవలు (_L)"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "బుల్ట్-యిన్ వెబ్‌కామ్"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "ఏ ప్రాంతములు కనబడలేదు"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "ప్రదర్శన రకం"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "లంకె వేగం"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "తిరిగివుంచు"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "అనువర్తనాలు"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>థీమ్</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "శైలి:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "అప్రమేయం"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "నేపథ్యం"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "రోజు మొత్తంమీద మార్పులు"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "ప్రొఫైల్ జతచేయి... (_A)"
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-#| msgid "Lock screen"
-msgid "Lock Screen"
-msgstr "తెరకు తాళంవేయి"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "కనిపించువిధం"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "పలక"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "జూమ్"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "మధ్య"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "స్కేల్"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "నింపు"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "అవధి"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:442
-msgid "Select Background"
-msgstr "నేపథ్యాన్ని ఎంచుకోండి"
-
-#: ../panels/background/cc-background-chooser-dialog.c:463
-msgid "Wallpapers"
-msgstr "నేపథ్యచిత్రాలు"
-
-#: ../panels/background/cc-background-chooser-dialog.c:472
-msgid "Pictures"
-msgstr "చిత్రాలు"
-
-#: ../panels/background/cc-background-chooser-dialog.c:481
-msgid "Colors"
-msgstr "రంగులు"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:540
-#| msgid "No input sources found"
-msgid "No Pictures Found"
-msgstr "ఏ చిత్రాలు కనబడలేదు"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:558
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "నివాసం"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:570
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "మీరు చిత్రాలను మీ %s ఫోల్డర్‌కు జతచేయవచ్చు మరియు అవి ఇక్కడ చూపబడును"
-
-#: ../panels/background/cc-background-chooser-dialog.c:592
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1537
-#: ../panels/display/cc-display-panel.c:1976
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1240
-#: ../panels/network/net-device-wifi.c:1448
-#: ../panels/printers/cc-printers-panel.c:1947
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-#: ../panels/user-accounts/um-photo-dialog.c:95
-#: ../panels/user-accounts/um-photo-dialog.c:222
-#: ../panels/user-accounts/um-user-panel.c:513
-msgid "_Cancel"
-msgstr "రద్దుచేయి (_C)"
-
-#: ../panels/background/cc-background-chooser-dialog.c:593
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:97
-msgid "Select"
-msgstr "ఎంచుకోండి"
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "బహుళ పరిమాణములు"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "డెస్క్‍టాప్ నేపథ్యంలేదు"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "ప్రస్తుత నేపథ్యం"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "మీ బ్యాక్‌గ్రౌండ్ చిత్రమును వాల్‌పేపర్ లేదా చిత్రమునకు మార్చండి"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "నేపథ్యచిత్రం;తెర;డెస్క్​టాప్;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "బ్లూటూత్ అచేతనపరచబడింది"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "చేతనం"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "ఎటువంటి బ్లూటూత్ ఎడాప్టర్లు కనపడలేదు"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "బ్లూటూత్ భాగస్వామ్యం"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "విమానం రీతి (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "బ్లూటూత్ హార్డ్‍వేర్ స్విచ్‌తో అచేతనపరచబడింది"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1688
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "విమానం రీతి (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "విమానం రీతి (_p)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "బ్లూటూత్"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "బ్లూటూత్ ఆఫ్ మరియు ఆన్ చేసి మీ పరికరాలను అనుసంధానించండి"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "మీ కాలిబరేషన్ పరికరంను చతురస్త్రంపై వుంచి 'ప్రారంభించు' వత్తండి"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
-msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
 msgstr ""
-"మీ కాలిబరేషన్ పరికరంను కాలిబరేట్ స్థానమునకు కదల్చి అప్పడు 'కొనసాగించు' వత్తండి"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
 msgstr ""
-"మీ కాలిబరేషన్ పరికరంను ఉపరితల స్థానమునకు కదల్చి అప్పడు 'కొనసాగించు' వత్తండి"
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "లాప్‌టాప్ లిడ్ మూయి"
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "ఏ అనువర్తనము ప్రస్తుతం ఆడియోను నడుపుటలేదు లేదా రికర్డు చేయుటలేదు."
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "ఒక అంతర్గత దోషం సంభవించినది అది రికవర్ కాలేదు."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "కాలిబరేషన్ కొరకు అవసరమైన సాధనములు సంస్థాపించబడలేదు."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "ప్రొఫైల్ జనియింప చేయలేక పోయింది"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "లక్ష్యపు వైట్‌పాయింట్ పొందలేదు."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "పూర్తయినది!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "కాలిబరేషన్ విఫలమైంది!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "మీరు కాలిబరేషన్ పరికరం తీసివేయవచ్చు"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "పురోగతినందు వున్నప్పుడు కాలిబరేషన్ పరికరంను విజ్ఞ పరచవద్దు"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "లాప్‌టాప్ తెర"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "బుల్ట్-యిన్ వెబ్‌కామ్"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s మానిటర్"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s స్కానర్"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s కెమేరా"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s ముద్రకం"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s వెబ్‌క్యామ్"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s కొరకు రంగు నిర్వాహణ చేతనం చేయండి"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s కొరకు రంగు ప్రొఫైల్స్ చూపు"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-msgid "Not calibrated"
-msgstr "కాలిబరేట్ చేయలేదు"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "అప్రమేయం: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "రంగులఅంతరం: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "పరీక్షా ప్రవర: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "ICC ప్రవర దస్త్రమును ఎంచుకొనుము"
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "దిగుమతిచేయి (_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "సహకార ICC ప్రవరలు"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "అన్ని దస్త్రాలు"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "తెర"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "ఫైలు యెక్కించుటలో విఫలమైంది: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "ప్రొఫైల్ దీనికి అప్‌లోడ్ అయింది:"
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "ఈ URL వ్రాయి."
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
-msgstr "ఈ కంప్యూటర్ పునఃప్రారంభించి మీ సాధారణ ఆపరేటింగ్ సిస్టమ్ బూట్ చేయి."
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "ప్రొఫైల్ సంస్థాపించుటకు URL ను మీ బ్రౌజర్ నందు టైపు చేసి దించుకోండి."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "ప్రొఫైల్ దాయి"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "భద్రపరచు (_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "ఎంచుకున్న పరికరమునకు రంగు ప్రవరను సృష్టించు"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
-"కొలుస్తున్న సాధనము కనుగొనబడలేదు. దయచేసి ఆన్ ఉందా మరియు సరిగ్గా అనుసంధానమయి "
-"ఉందా చాచుకొనుము."
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "కొలుస్తున్న సాధనము ప్రింటర్ ప్రొఫైలింగును సహకరించుటలేదు"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "పరికరపు రకము ప్రస్తుతము సహకరించుటలేదు."
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "మరిన్ని చిత్రముల కొరకు అన్వేషించు"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "ప్రామాణిక జాగా"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "పరీక్షా ప్రొఫైల్"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "స్వయంచాలక"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "తక్కువ నాణ్యత"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "మధ్యమ నాణ్యత"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "అధిక నాణ్యత"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB అప్రమేయం"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK అప్రమేయం"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "అప్రమేయ గ్రే"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "అమ్మకందారు అందించిన ఫాక్టరీ కాలిబరేషన్ దత్తాంశం"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "ఈ ప్రొఫైల్‌తో పూర్తి-తెర ప్రదర్శన దిద్దుబాటు సాధ్యం కాదు"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "ఈ ప్రోఫైల్ యిక ఖచ్చితంగా వుండకపోవచ్చు"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "క్యాలిబ్రేషన్ ప్రదర్శించు"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr "రద్దుచేయి"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "రద్దుచేయి (_C)"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "మొదలు"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "తిరిగికొనసాగించు"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "అయినది"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "అయినది (_D)"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "తెర సామర్థ్యం"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "క్యాలిబ్రేషన్ నాణ్యత"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"మీ తెర రంగు నిర్వహణ కొరకు వుపయోగించుకొనుటకు కాలిబరేషన్ వొక ప్రొఫైల్ "
-"అందించును. మీరు యెంతసేపు "
+"మీ తెర రంగు నిర్వహణ కొరకు వుపయోగించుకొనుటకు కాలిబరేషన్ వొక ప్రొఫైల్ అందించును. మీరు యెంతసేపు "
 "కాలిబరేషన్‌పై గడిపితే, రంగు ప్రొఫైల్ యొక్క నాణ్యత వుత్తమంగా వుంటుంది."
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "కాలిబరేషన్ జరుగునప్పుడు మీరు మీ కంప్యూటర్‌ను వుపయోగించలేరు."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "నాణ్యత"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "షుమారు సమయం"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "క్యాలిబ్రేషన్ నాణ్యత"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr ""
-"కాలిబరేషన్ కొరకు వుపయోగించాలని అనుకొనుచున్న సెన్సార్ పరికరం యెంపికచేయి."
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "క్యాలిబ్రేషన్ పరికరం"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "అనుసంధానించిన ప్రదర్శన రకంను యెంపికచేయి."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "కాలిబరేషన్ కొరకు వుపయోగించాలని అనుకొనుచున్న సెన్సార్ పరికరం యెంపికచేయి."
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "ప్రదర్శన రకం"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "అనుసంధానించిన ప్రదర్శన రకంను యెంపికచేయి."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "ప్రొఫైల్ వైట్‌పాయింట్"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
-"ప్రదర్శన లక్ష్యం వైట్ పాయింట్ యెంపికచేయి. చాలా ప్రదర్శనలు D65 "
-"యిల్యుమినెంట్‌కు కాలిబరేట్ అయివుండును."
+"ప్రదర్శన లక్ష్యం వైట్ పాయింట్ యెంపికచేయి. చాలా ప్రదర్శనలు D65 యిల్యుమినెంట్‌కు కాలిబరేట్ అయివుండును."
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "ప్రొఫైల్ వైట్‌పాయింట్"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "ప్రకాశత ప్రదర్శన"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"మీకు తగిన కాంతిప్రకాశంకు పదర్శనను అమర్చండి. ఈ కాంతిప్రకాశ స్థాయినందు రంగు "
-"నిర్వహణ చాలా ఖచ్చితంగా "
+"మీకు తగిన కాంతిప్రకాశంకు పదర్శనను అమర్చండి. ఈ కాంతిప్రకాశ స్థాయినందు రంగు నిర్వహణ చాలా ఖచ్చితంగా "
 "వుండును."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
-"ప్రత్యామ్నాయంగా, ఈ పరికరం కొరకు యితర ప్రొఫైల్సులో వొక దానినందు వుపయోగించిన "
-"కాంతిప్రకాశం స్థాయిను మీరు "
+"ప్రత్యామ్నాయంగా, ఈ పరికరం కొరకు యితర ప్రొఫైల్సులో వొక దానినందు వుపయోగించిన కాంతిప్రకాశం స్థాయిను మీరు "
 "వుపయోగించవచ్చు."
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "ప్రకాశత ప్రదర్శన"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "ప్రొఫైల్ పేరు"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
-"రంగు ప్రొఫైల్సును మీరు విభిన్న కంప్యూటర్లపై వుపయోగించవచ్చు, లేదా విభిన్న "
-"లైటింగ్ నిభందనల కొరకు ప్రొఫైల్స్ "
+"రంగు ప్రొఫైల్సును మీరు విభిన్న కంప్యూటర్లపై వుపయోగించవచ్చు, లేదా విభిన్న లైటింగ్ నిభందనల కొరకు ప్రొఫైల్స్ "
 "సృష్టించవచ్చు."
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "ప్రొఫైల్ పేరు:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "ప్రొఫైల్ పేరు"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "ప్రొఫైల్ సఫలవంతంగా సృష్టించబడెను!"
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "ప్రొఫైల్ నకలుతీయి"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "వ్రాయదగ్గ మాధ్యమం కావాలి"
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "ప్రొఫైల్ యెక్కించు"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "ఇంటర్నెట్ అనుసంధానం కావాలి"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> మరియు <a href="
-"\"windows\">Microsoft Windows</a> వ్యవస్థలపై ప్రొఫైల్ యేలా వుపయోగించాలి "
-"అనేదానికొరకు మీకు యీ "
-"సూచనలు వుపయోగకరంగా వుంటాయి."
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "సారాంశం"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "ఫైల్ ను దిగుమతి చేయి…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "ప్రొఫైల్ సఫలవంతంగా సృష్టించబడెను!"
 
-#: ../panels/color/color.ui.h:29
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "ప్రొఫైల్ నకలుతీయి"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "వ్రాయదగ్గ మాధ్యమం కావాలి"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> మరియు <a "
+"href=\"windows\">Microsoft Windows</a> వ్యవస్థలపై ప్రొఫైల్ యేలా వుపయోగించాలి అనేదానికొరకు మీకు "
+"యీ సూచనలు వుపయోగకరంగా వుంటాయి."
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "ప్రవర జతచేయి"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
-msgstr ""
-"సమస్యలు గుర్తించబడెను. ప్రొఫైల్ సరిగా పనిచేయకపోవచ్చు.<a href=\"\">వివరాలు "
-"చూడండి.</a>"
+msgstr "సమస్యలు గుర్తించబడెను. ప్రొఫైల్ సరిగా పనిచేయకపోవచ్చు.<a href=\"\">వివరాలు చూడండి.</a>"
 
-#: ../panels/color/color.ui.h:30
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "ఫైల్ ను దిగుమతి చేయి…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "జతచేయి (_A)"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "ప్రతి పరికరము రంగు నిర్వహనమగుటకు రంగు ప్రవరను తాజాపరుచు."
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "మరింత తెలుసుకోండి"
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "వర్ణ నిర్వాహణ గురించి మరింత నేర్చుకోండి"
 
-#: ../panels/color/color.ui.h:33
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "వాడుకరులందరికీ అమర్చు"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "ఈ కంప్యూటరును వాడే వాడుకరులందరికీ ఈ ప్రవరని అమర్చు"
 
-#: ../panels/color/color.ui.h:35
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "చేతనం"
 
-#: ../panels/color/color.ui.h:36
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "ప్రవర జతచేయి"
 
-#: ../panels/color/color.ui.h:37
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "క్రమాంకనం చేయి..."
 
-#: ../panels/color/color.ui.h:38
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "పరికరాన్ని క్రమాంకనంచేయి"
 
-#: ../panels/color/color.ui.h:39
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "ప్రవర తీసివేయి"
 
-#: ../panels/color/color.ui.h:40
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "వివరాలను చూడు"
 
-#: ../panels/color/color.ui.h:41
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "రంగు నిర్వహణతో వున్న యే పరికరాలను గుర్తించలేక పోయింది"
 
-#: ../panels/color/color.ui.h:42
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "ప్రోజెక్టర్"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "ప్లాస్మా"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL బాక్‌లైట్)"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED బాక్‌లైట్)"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (వైట్ LED బాక్‌లైట్)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Wide gamut LCD (CCFL బాక్‌లైట్)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Wide gamut LCD (RGB LED బాక్‌లైట్)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "అదిక"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 నిమిషాలు"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "మాధ్యమం(_M)"
 
-#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 నిమిషాలు"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "తక్కువ"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 నిమిషాలు"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "ప్రదర్శనకు స్వభావం"
 
-#: ../panels/color/color.ui.h:59
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (ముద్రమ మరియు ప్రచురణ)"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (ఛాయాగ్రహణం మరియు గ్రాఫిక్స్)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "రంగు"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
-msgstr ""
-"మీ పరికరముల యొక్క రంగును కాలిబరేట్ చేయండి, ప్రదర్శనలు, కేమెరాలు లేదా "
-"ముద్రికలు వలె"
+msgstr "మీ పరికరముల యొక్క రంగును కాలిబరేట్ చేయండి, ప్రదర్శనలు, కేమెరాలు లేదా ముద్రికలు వలె"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "వర్ణం;ICC;ప్రవర;కాలిబ్రేట్;ముద్రకం;ప్రదర్శకం;"
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:684
-msgid "United States"
-msgstr "యునైటెడ్ స్టేట్స్"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "ఒక భాషను ఎంచుకోండి"
 
-#: ../panels/common/cc-common-language.c:685
-msgid "Germany"
-msgstr "జర్మనీ"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "ఎంచుకొను (_S)"
 
-#: ../panels/common/cc-common-language.c:686
-msgid "France"
-msgstr "ఫ్రాన్స్"
-
-#: ../panels/common/cc-common-language.c:687
-msgid "Spain"
-msgstr "స్పెయిన్"
-
-#: ../panels/common/cc-common-language.c:688
-msgid "China"
-msgstr "చైనా"
-
-#: ../panels/common/cc-common-language.c:758
-msgid "Other…"
-msgstr "ఇతర ..."
-
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr "మరిన్ని…"
-
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "ఏ భాషలు కనుగొనలేదు"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "భాష"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "మరిన్ని…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "అయినది (_D)"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-#| msgid "%b %d %l:%M %p"
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "అన్‌లాక్"
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "పరిమాణం పెంచు:"
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "సమయం"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "పరిమాణం తగ్గించు:"
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-#| msgid "%d x %d (%s)"
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "జనవరి"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "ఫిబ్రవరి"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "మార్చి"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "ఏప్రిల్"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "మే"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "జూన్"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "జులై"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "ఆగస్టు"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "సెప్టెంబర్"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "అక్టోబర్"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "నవంబర్"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "డిసెంబర్"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "తేది మరియు సమయం"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "గంట"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-#| msgid "minute"
-#| msgid_plural "minutes"
-msgid "Minute"
-msgstr "నిమిషం"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "రోజు"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "నెల"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "సంవత్సరం"
 
-#: ../panels/datetime/datetime.ui.h:21
-#| msgid "Time"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "నెల"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "జనవరి"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ఫిబ్రవరి"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "మార్చి"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "ఏప్రిల్"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "మే"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "జూన్"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "జులై"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "ఆగస్టు"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "సెప్టెంబర్"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "అక్టోబర్"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "నవంబర్"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "డిసెంబర్"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "రోజు"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "సమయ క్షేత్రం"
 
-#: ../panels/datetime/datetime.ui.h:22
-#| msgid "Search for the string"
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "పట్టణం కొరకు వెతుకు"
 
-#: ../panels/datetime/datetime.ui.h:23
-#| msgid "Date & Time"
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "స్వయంచాలక తేది మరియు సమయం (_D)"
 
-#: ../panels/datetime/datetime.ui.h:24
-#| msgid "Requires Internet connection"
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "ఇంటర్నెట్ అనుసంధానం కావాలి"
 
-#: ../panels/datetime/datetime.ui.h:25
-#| msgid "Automatic _Connect"
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "తేది మరియు సమయం (_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "స్వయంచాలక సమయ క్షేత్రం (_Z)"
 
-#: ../panels/datetime/datetime.ui.h:26
-#| msgid "Date & Time"
-msgid "Date & _Time"
-msgstr "తేది మరియు సమయం (_T)"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "ఇంటర్నెట్ అనుసంధానం కావాలి"
 
-#: ../panels/datetime/datetime.ui.h:27
-#| msgid "Firewall _Zone"
-msgid "Time _Zone"
-msgstr "సమయ క్షేత్రం (_Z)"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "చేతనపరిచివుంది"
 
-#: ../panels/datetime/datetime.ui.h:28
-#| msgid "Formats"
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "సమయ క్షేత్రం"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "అన్‌లాక్"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "సమయ ఫార్మేట్ (_F)"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24-గంటలు"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "తొలి / మలి"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "తేదీలు"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "సెకనులు"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "క్యాలెండర్ (_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "సంఖ్యలు"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "తేదీ మరియు సమయం మార్చు, సమయ క్షేత్రంతో సహా"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "గడియారం;సమయక్షేత్రం;ప్రదేశం;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "వ్యవస్థ సమయం మరియు తేదీ అమరికలను మార్చు"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "సమయం లేదా తేదీ అమరికలను మార్చుటకు, మీరు ధృవీకరించాలి."
 
-#: ../panels/display/cc-display-panel.c:487
-#| msgid "Close"
-msgid "Lid Closed"
-msgstr "లిడ్ మూసివేయి"
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-#| msgid "Mirrored Displays"
-msgid "Mirrored"
-msgstr "మిర్రర్డ్"
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2145
-#| msgid "Primary _button"
-msgid "Primary"
-msgstr "ప్రాథమిక"
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "ఆఫ్"
-
-#: ../panels/display/cc-display-panel.c:497
-#| msgid "Secondary color"
-msgid "Secondary"
-msgstr "రెండవ"
-
-#: ../panels/display/cc-display-panel.c:1533
-#| msgid "Mirrored Displays"
-msgid "Arrange Combined Displays"
-msgstr "కలగలిపిన ప్రదర్శనలు అమర్చు"
-
-#: ../panels/display/cc-display-panel.c:1539
-#: ../panels/display/cc-display-panel.c:1979
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-msgid "_Apply"
-msgstr "వర్తించు (_A)"
-
-#: ../panels/display/cc-display-panel.c:1560
-msgid "Drag displays to rearrange them"
-msgstr "ప్రదర్శనలను పట్టిలాగుతూ వాటిని తిరిగిసర్దవచ్చు"
-
-#: ../panels/display/cc-display-panel.c:2081
-#| msgid "Size:"
-msgid "Size"
-msgstr "పరిమాణము"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2094
-msgid "Aspect Ratio"
-msgstr "ఏస్పెక్ట్ రేషియో"
-
-#: ../panels/display/cc-display-panel.c:2115
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "విభాజకత"
-
-#: ../panels/display/cc-display-panel.c:2146
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "ఈ ప్రదర్శనపై కార్యకలాపాల అవలోకనం మరియు పై పట్టీ చూపుము"
-
-#: ../panels/display/cc-display-panel.c:2152
-#| msgid "Secondary click delay"
-msgid "Secondary Display"
-msgstr "రెండవ ప్రదర్శన"
-
-#: ../panels/display/cc-display-panel.c:2153
-msgid "Join this display with another to create an extra workspace"
-msgstr "అదనపు పనిస్థలం సృష్టించుటకు ఈ ప్రదర్శనను వేరొక దానితో కలుపుము"
-
-#: ../panels/display/cc-display-panel.c:2160
-#| msgid "Orientation"
-msgid "Presentation"
-msgstr "సమర్పణ"
-
-#: ../panels/display/cc-display-panel.c:2161
-msgid "Show slideshows and media only"
-msgstr "స్లైడ్‌షో మరియు మాధ్యమం మాత్రమే చూపుము"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2166
-msgid "Mirror"
-msgstr "మిర్రర్"
-
-#: ../panels/display/cc-display-panel.c:2167
-msgid "Show your existing view on both displays"
-msgstr "రెండు ప్రదర్శనలపై మీరు దర్శించునది చూపుము"
-
-#: ../panels/display/cc-display-panel.c:2173
-#| msgid "_Turn On"
-msgid "Turn Off"
-msgstr "ఆఫ్ చేయి"
-
-#: ../panels/display/cc-display-panel.c:2174
-#| msgid "Panel to display"
-msgid "Don't use this display"
-msgstr "ఈ ప్రదర్శనను ఉపయోగించవద్దు"
-
-#: ../panels/display/cc-display-panel.c:2383
-msgid "Could not get screen information"
-msgstr "తెర సమాచారమును పొందలేక పోయింది"
-
-#: ../panels/display/cc-display-panel.c:2414
-#| msgid "Mirrored Displays"
-msgid "_Arrange Combined Displays"
-msgstr "కలగలిపిన ప్రదర్శనలు అమర్చు (_A)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "ప్రదర్శనలు"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr "అనుసంధానిత మానిటర్స్ మరియు ప్రొజెక్టర్స్ యెలా వుపయోగించాలో యెంచుకొనుము"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "పానల్;ప్రొజెక్టర్;xrandr;తెర;రిజొల్యూషన్;రీఫ్రెష్;మానిటర్;"
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr "వేలాండ్"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "తెలియని"
-
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-బిట్"
-
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr "%d-బిట్"
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr "ఏమి చేయాలో అడుగు"
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr "ఏమి చేయవద్దు"
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr "సంచయం తెరువు"
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr "ఇతర మాధ్యమం"
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr "ఆడియో సీడీల కొరకు ఒక అనువర్తనాన్ని ఎంచుకోండి"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr "వీడియో డీవీడీల కొరకు ఒక అనువర్తనాన్ని ఎంచుకోండి"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr "సంగీత ఆటకం అనుసంధానమైనప్పుడు నడుపుటకు ఒక అనువర్తనం ఎంచుకోండి"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr "కెమేరా అనుసంధానమైనప్పుడు నడుపుటకు ఒక అనువర్తనము ఎంచుకోండి"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr "సాఫ్ట్‍వేర్ సీడీల కొరకు ఒక అనువర్తనాన్ని ఎంచుకోండి"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr "ఆడియో DVD"
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr "ఖాళీ బ్లూ-రే డిస్కు"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr "ఖాళీ CD డిస్కు"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr "ఖాళీ DVD డిస్కు"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr "ఖాళీ HD DVD డిస్కు"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr "బ్లూ-రే వీడియో డిస్కు"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr "ఈ-పుస్తకం చదువరి"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr "HD DVD వీడియో డిస్కు"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr "చిత్రల సీడీ"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr "సూపర్ వీడియో సీడీ"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr "వీడియో సీడీ"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr "విండోస్ సాఫ్ట్‍వేర్"
-
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1917
-msgid "Section"
-msgstr "విభాగం"
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "అవలోకనం"
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr "అప్రమేయ అనువర్తనాలు"
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "తీసివేయదగిన మాధ్యమం"
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr "రూపాంతరం %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:44
-msgid "Details"
-msgstr "వివరాలు"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr "మీ వ్యవస్థ గురించి సమాచారం దర్శించు"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"పరికరం;వ్యవస్థ;సమాచారం;మెమోరీ;ప్రోసెసర్;రూపాంతరం;అప్రమేయం;అనువర్తనం;ప్రాధాన్యమ"
-"ిచ్చేవి;సీడీ;డీవీడీ;యూఎస్‌బీ;"
-"ఆడియో;వీడియో;డిస్క్;తీసివేయదగిన;మాధ్యమం;స్వయంగానడుచు;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "ఇతర మాధ్యమం యెలా సంభాలించబడాలో యెంపికచేయి"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "చర్య (_A):"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "రకం (_T):"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "పరికరం పేరు"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "మెమొరీ"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "ప్రోసెసర్"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "ప్రాధమిక వ్యవస్థ"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "డిస్కు"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "లెక్కిస్తోంది..."
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "రేఖాచిత్రాలు"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "వర్చ్యులైజేషన్"
-
-#: ../panels/info/info.ui.h:13
-#| msgid "Checking for Updates"
-msgid "Check for updates"
-msgstr "నవీకరణల కొరకు పరిశీలించుము"
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "జాలం (_W)"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "మెయిల్ (_M)"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "క్యాలెండర్ (_C)"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "సంగీతం (_u)"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "వీడియో (_V)"
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "ఫోటోలు (_P)"
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "మాధ్యమం యెలా సంభాలించబడాలో యెంపికచేయి"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "అప్రమేయ అనువర్తనాలు"
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "సీడీ ఆడియో (_a)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "అప్రమేయ అనువర్తనాలు"
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "డీవీడీ వీడియో (_D)"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "సంగీత ప్రదర్శకం (_M)"
-
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "సాఫ్ట్‍వేర్ (_S)"
-
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "ఇతర మాధ్యమం... (_O)"
-
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
 msgstr ""
-"మాధ్యమ ప్రవేశమప్పుడు యెప్పుడూ ప్రోగ్రామ్సు ప్రారంభించవద్దు అడుగవద్దు (_N)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "వర్తించు (_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "వెనుకకు"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "బ్లూటూత్ అచేతనపరచబడింది"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "ప్రదర్శకాలను కనిపెట్టు (_D)"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "మిర్రర్"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "రెండవ ప్రదర్శన"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "కుడి  వలయం"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "సర్దుబాటు"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "విభాజకత"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "పునర్వికాసం రేటు(_f):"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "స్కేల్"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "పూర్తయిన భిన్నం"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "ఏ ముద్రకాలు అందుబాటులోలేవు"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "ఇప్పుడు పునఃప్రారంభించు"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "కాలములు"
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "యుఆర్ఎల్ నుండి"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "గంట"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "నిమిషం"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "ప్రదర్శనలు"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "అనుసంధానిత మానిటర్స్ మరియు ప్రొజెక్టర్స్ యెలా వుపయోగించాలో యెంచుకొనుము"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "పానల్;ప్రొజెక్టర్;xrandr;తెర;రిజొల్యూషన్;రీఫ్రెష్;మానిటర్;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "భద్రత కీ"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "సిరా స్థాయి"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "సిరా స్థాయి"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "సిరా స్థాయి"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "రక్షణ"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "పరికరం పేరు"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "హార్డ్‍వేర్ చిరునామా"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "మెమొరీ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "ప్రోసెసర్"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "రేఖాచిత్రాలు"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "లెక్కిస్తోంది..."
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "పేరు"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "రకం"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME టెర్మినల్"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "ఐచ్ఛికాలు నింపుతోంది..."
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "విండోస్ సాఫ్ట్‍వేర్"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "వర్చ్యులైజేషన్"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "సాఫ్ట్‌వేర్ వాడుక"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "పరికరాన్ని తీసివేయి"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "పరికరం పేరు"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "పునఃనామకరణం..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "%s గురించి"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "మీ వ్యవస్థ గురించి సమాచారం దర్శించు"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"పరికరం;వ్యవస్థ;సమాచారం;మెమోరీ;ప్రోసెసర్;రూపాంతరం;అప్రమేయం;అనువర్తనం;ప్రాధాన్యమిచ్చేవి;సీడీ;డీవీడీ;యూఎస్‌బీ;"
+"ఆడియో;వీడియో;డిస్క్;తీసివేయదగిన;మాధ్యమం;స్వయంగానడుచు;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "శబ్దము మరియు మాధ్యమం"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "నిశబ్దం"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "శబ్దము తగ్గించు"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "శబ్దాన్ని పెంచు"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "మైక్రోఫోన్ శబ్దస్థాయి"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "మాధ్యమ ఆటకాన్ని ప్రారంభించు"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "నడుపు (లేదా నడుపు/నిలిపివుంచు)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "ప్లేబాక్ నిలుపివుంచు"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "ప్లేబ్యాక్ ఆపు"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "క్రితం ట్రాక్"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "తరువాతి ట్రాక్"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "బయటకునెట్టు"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "టైపింగు"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "తరువాతి యిన్పుట్ మూలానికి మారు"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "మునుపటి యిన్పుట్ మూలానికి మారు"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "ప్రారంభకాలు"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "సహాయ విహరిణి దించు"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "అమరికలు"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "గణనపరికరాన్ని ప్రారంభించు"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "ఈమెయిల్ కక్షిదారు ప్రారంభించు"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "జాల విహారకాన్ని ప్రారంభించు"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "నివాస సంచయం"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "అన్వేషించు"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "తెరపట్టులు"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "స్క్రీన్‌షాట్‌ను $PICTURES కు దాయి"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "విండో యొక్క స్క్రీన్‌షాట్‌ను $PICTURES కు దాయి"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "ప్రాంతము యొక్క స్క్రీన్‌షాట్‌ను $PICTURES కు దాయి"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "తెరపట్టును క్లిప్‌బోర్డునకు నకలుచేయి"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "క్లిప్ బోర్డు ఒక విండో యొక్క ఒక తెర ఛాయాచిత్రం నకలు"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "క్లిప్ బోర్డు అనేది ఒక ప్రాంతం యొక్క తెర ఛాయాచిత్రం నకలు"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "పొట్టి తెరపట్టును రికార్డ్ చేయి"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "వ్యవస్థ"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "నిష్క్రమించు"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "తెరకు తాళంవేయి"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "సార్వత్రిక ప్రాప్తి"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "దృగ్గోచరత"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "జూమ్‌ను ఆన్ లేదా ఆఫ్ చేయి"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "అతిరూపించండి"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "అవరూపించండి"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "తెర చదువకాన్ని ఆన్ లేదా ఆఫ్ చేయి"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "తెర-పై కీబోర్డును ఆన్ లేక ఆఫ్ చేయి"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "పాఠము పరిమాణము పెంచు"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "పాఠము పరిమాణం తగ్గించు"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "అధిక వ్యత్యాసాన్ని ఆన్‌చేయి లేక ఆపు"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1217
-#: ../panels/network/network-wifi.ui.h:29
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-#: ../panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Disabled"
-msgstr "అచేతనపరచివుంది"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "ఇన్‌పుట్ వనరుని జతచేయి"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "ప్రత్యామ్నాయ అక్షరాల మీట"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "లాగిన్ తెర నందు యిన్పుట్ పద్దతులు వుపయోగించలేము"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "రచన మీట"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "ఏ యిన్పుట్ మూలం యెంపికకాలేదు"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "సవరణిలు-మాత్రమే తరువాతి మూలానికి మారు"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "ఐచ్ఛికాలు"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "కీబోర్డు"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "పైకి జరపండి"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr "కీబోర్డు లఘువులను దర్శించి మార్చు మరియు మీ టైపింగ్ అభీష్టాలను అమర్చు"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "క్రిందకు జరుపు"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "అడ్డదారి;పునరావృతం;బ్లింక్;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "అభీష్టాలు"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "అనురూపిత అడ్డదారి"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "కీబోర్డు లేయవుటు చూపించు"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
-msgstr "జతచేయి (_A)"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "తీసివేయి (_R)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "పేరు (_N):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "ఆదేశం(_o):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "పునరావృత కీలు"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "కీ నొక్కివుంచినప్పుడు కీ వత్తులు పునరావృతం కావాలి (_r)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "ఆలస్యం(_D):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "వేగం(_S):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "పొట్టి"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "నెమ్మది"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "పునరావృత కీల వేగం"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "పొడవు"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "వేగము"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "కర్సర్ బ్లింకవుచున్నది"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "పాఠ్య క్షేత్రములందు కర్సర్ బ్లింక్‌అవాలి (_b)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "వేగం (_p):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "కర్సర్ రెప్పపాటు వేగం"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "ఇన్‌పుట్ వనరులు"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "అడ్డదారిని జతచేయి"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "అడ్డదారిని తీసివేయి"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
 msgstr ""
-"ఒక షార్ట్ కట్ ని సరిచేయుటకు,రో పై క్లిక్ చేసి మరియు కొత్త కీలను నొక్కుము లేదా "
-"బ్యాక్ స్పేస్  నొక్కుము "
-"చెరుపుటకు"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "ఇన్‌పుట్ వనరు ఐచ్చికాలు"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "అన్ని విండోల కొరకు అదే వనరును వుపయోగించు (_s)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "ప్రతి విండో కొరకు విభిన్న మూలాలను అనుమతించు (_d)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "ప్రత్యామ్నాయ అక్షరాల మీట"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "రచన మీట"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "కీబోర్డు లఘువులు"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "అనురూపిత అడ్డదారులు"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "విభాగం"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "అడ్డదారులు"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:634
-#: ../panels/keyboard/keyboard-shortcuts.c:642
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "అడ్డదారిని జతచేయి"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "అనురూపిత అడ్డదారులు"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:859
-msgid "<Unknown Action>"
-msgstr "<తెలియని చర్య>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1356
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"అడ్డదారి \"%s\" ఉపయోగించబడదు ఎంచేతంటే ఈ కీ ఉపయోగించి దీనిని టైపుచేయుట అసాధ్యం "
-"అవుతుంది.\n"
-"Control,Alt లేదా అదే సమయంలో Shift వంటి కీలతో దయచేసి ప్రయత్నించండి."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1386
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "అడ్డదారిని జతచేయి"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "కీబోర్డు లఘువులు"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "తీసివేయి (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "పునఃస్థాపించు (_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"\"%s\" అను అడ్డదారి ఇప్పటికే\n"
-" \"%s\"కొరకు వినియోగంలో వుంది"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1391
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr ""
-"మీరు అడ్డదారిని \"%s\"కు తిరిగిఅప్పగిస్తే, \"%s\" అడ్డదారి అచేతనము "
-"చేయబడుతుంది."
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1397
-msgid "_Reassign"
-msgstr "తిరిగిఅప్పగించు (_R)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "పేరు"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1429
-#, c-format
-msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
-msgstr ""
-"\"%s\" లఘువు అనునది \"%s\" లఘువుతో కలిసివుంది. మీరు దానిని స్వయంచాలకంగా \"%"
-"s\" కు అమర్చాలని అనుకుంటున్నారా?"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "ఆదేశం(_o):"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1435
-#, c-format
-#| msgid ""
-#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
-#| "disabled."
-msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
-msgstr ""
-"\"%s\" ప్రస్తుతం ఇప్పుడు \"%s\" తో కలిసివుంది, మీరు ముందుకు కదిలితే ఈ లఘువు "
-"అచేతనం చేయబడును."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "అడ్డదారి"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1441
-#| msgid "_Reassign"
-msgid "_Assign"
-msgstr "అప్పగించు (_A)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "కొత్త లఘువు…"
 
-#: ../panels/mouse/cc-mouse-panel.c:94
-msgid "Test Your _Settings"
-msgstr "మీ అమరికలను పరీక్షించండి (_S)"
-
-#: ../panels/mouse/cc-mouse-panel.c:107
-#| msgid "Test Your _Settings"
-msgid "Test Your Settings"
-msgstr "మీ అమరికలను పరీక్షించండి"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse & Touchpad"
-msgstr "మౌసు మరియు టచ్‌ప్యాడ్"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid ""
-"Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr ""
-"మీ మౌస్ లేదా టచ్‌పాడ్ సెన్సిటివిటిని మార్చు మరియు కుడి లేదా ఎడమచేతి-వాటం "
-"యెంపికచేయండి"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-#| msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-msgstr "ట్రాక్‌పాడ్;సూచకి;నొక్కు;టాప్;డబుల్;బటన్;ట్రాక్‌బాల్;స్క్రాల్;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "సాధారణ"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "నెమ్మది"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "రెండు-నొక్కుల కాలము"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "వేగము"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "రెండు నొక్కులు(_D)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "ప్రాథమిక బటన్ (_b)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "ఎడమ (_L)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "కుడి (_R)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "మౌస్"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "సూచిక వేగం (_P)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "నెమ్మది"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "వేగము"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "టచ్‌ప్యాడ్"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "నెమ్మది"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "వేగము"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
-msgstr "టంకిస్తున్నప్పుడు అచేతనించు (_t)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
-msgstr "నొక్కుటకు తాకండి (_c)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
-msgstr "రెండు-వేళ్ళ జరుపుట (_f)"
-
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-#| msgid "_Edge scrolling"
-msgid "_Natural scrolling"
-msgstr "సాధారణ స్క్రాలింగ్ (_N)"
-
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "నొక్కుటను, రెండుమార్లు నొక్కుటను, జురుపుటను ప్రయత్నించండి"
-
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "ఐదు నొక్కులు, GEGL సమయం!"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "రెండు నొక్కులు, ప్రాథమిక బటన్"
-
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "ఒక నొక్కు, ప్రాధమిక బటన్"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "రెండు నొక్కులు, మధ్య బటన్"
-
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "ఒక నొక్కు, మధ్య బటన్"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "రెండు-నొక్కులు, రెండవ బటన్"
-
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "ఒక నొక్కు, రెండవ బటన్"
-
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:366
-msgid "Air_plane Mode"
-msgstr "విమానం రీతి (_p)"
-
-#: ../panels/network/cc-network-panel.c:965
-msgid "Network proxy"
-msgstr "నెట్‌వర్క్ ప్రోక్సీ"
-
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1289
-msgid "The system network services are not compatible with this version."
-msgstr "ఈ రూపాంతరంతో సిస్టమ్ నెట్వర్కు సేవలు సారూప్యతను కలిగిలేవు."
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
-msgid "802.1x _Security"
-msgstr "802.1x రక్షణ (_S)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "పుట 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "ఎనానిమస్ గుర్తింపు (_m)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "అంతర ధృవీకరణ (_a)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "పుట 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:4
-msgid "Security"
-msgstr "రక్షణ"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "స్వయంచాలక"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:217
-#: ../panels/network/net-device-wifi.c:378
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:221
-#: ../panels/network/net-device-wifi.c:383
-#: ../panels/network/network-wifi.ui.h:17
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:225
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:230
-msgid "Enterprise"
-msgstr "ఎంటర్‌ప్రైజ్"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:235
-#: ../panels/network/net-device-wifi.c:368
-msgctxt "Wifi security"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "ఏదీకాదు"
 
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "ఎన్నటికీకాదు"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
 
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:819
-msgid "Today"
-msgstr "నేడు"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "అప్రమేయాలకు తిరిగిఉంచు(_R)"
 
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:822
-msgid "Yesterday"
-msgstr "నిన్న"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "కీబోర్డు"
 
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:472
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "కీబోర్డు లఘువులను దర్శించి మార్చు మరియు మీ టైపింగ్ అభీష్టాలను అమర్చు"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "స్థానం సేవలు (_L)"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "ఏ అనువర్తనము ప్రస్తుతం ఆడియోను నడుపుటలేదు లేదా రికర్డు చేయుటలేదు."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "మైక్రోఫోన్ శబ్దస్థాయి"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "ఏ అనువర్తనములు కనబడలేదు"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "మీ అమరికలను పరీక్షించండి (_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "సాధారణ"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "ప్రాథమిక బటన్ (_b)"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "ఎడమ"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "కుడి"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "ముద్రకం ఐచ్ఛికాలు"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "మౌస్"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "మౌస్ అమరికలు"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "కిందకి జరుపు"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "విషయాలను బూతద్దం సూచకితో కదలికలు"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "త్వరుణం(_A):"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "క్రియాశీల"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "టచ్‌ప్యాడ్"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "టచ్‌ప్యాడ్"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "పద్ధతి (_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "నొక్కుటకు తాకండి (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "నొక్కుటకు తాకండి (_c)"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "టంకిస్తున్నప్పుడు అచేతనించు (_t)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "టచ్‌ప్యాడ్ (సాపేక్షమైనది)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "జరుపుట"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "ఎడమవైపు జరుపు"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "రెండు-వైపులా"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "నొక్కుటను, రెండుమార్లు నొక్కుటను, జురుపుటను ప్రయత్నించండి"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "మౌసు మరియు టచ్‌ప్యాడ్"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "మీ మౌస్ లేదా టచ్‌పాడ్ సెన్సిటివిటిని మార్చు మరియు కుడి లేదా ఎడమచేతి-వాటం యెంపికచేయండి"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ట్రాక్‌పాడ్;సూచకి;నొక్కు;టాప్;డబుల్;బటన్;ట్రాక్‌బాల్;స్క్రాల్;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "రంగులఅంతరం: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "చెత్తను స్వయంచాలకంగా ఖాళీచేయి (_T)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "మానిటర్"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "ప్రాధమిక ప్రదర్శనను మార్చుటకు లాగుము."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "అనువర్తనాలు"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "పరికరాలు"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "కొత్త అనుసంధానాన్ని జతచేయి"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "అనుసంధానమైంది"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "ఐచ్ఛికాలు..."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi హాట్‌స్పాట్"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "నెట్‌వర్క్ పేరు"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "సంకేతపదం"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "సంకేతపదాన్ని ఉత్పత్తించు"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "సంకేతపదాన్ని ఉత్పత్తించు"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "చేతనించు (_T)"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "విమానం రీతి (_p)"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "ఏ చిత్రాలు కనబడలేదు"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "విమానం రీతి (_p)"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi హాట్‌స్పాట్"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "హాట్‌స్పాట్ వుపయోగించు... (_U)"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "నెట్‌వర్కులు"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x రక్షణ (_S)"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i రోజు క్రితం"
 msgstr[1] "%i రోజుల క్రితం"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:529
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:558
-msgctxt "Signal strength"
-msgid "None"
-msgstr "ఏదీకాదు"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:560
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "బలహీనం"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "సరే"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "మంచిది"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "బాగుంది"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:45
-msgid "Identity"
-msgstr "గుర్తింపు"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "చిరునామా"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "నెట్‌మాస్క్"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "సింహద్వారం"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "చిరునామా తొలగించు"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "జతచేయి"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "సేవిక"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "DNS సేవికను తొలగించు"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "మెట్రిక్"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "రౌట్ తొలగించు"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:25
-msgid "Automatic (DHCP)"
-msgstr "స్వయంచాలక (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:24
-msgid "Manual"
-msgstr "మానవీయ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "లింక్-లోకల్ మాత్రమే"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:46
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "ప్రిఫిక్స్"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "స్వయంచాలక"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "స్వయంచాలక, DHCP మాత్రమే"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:47
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:49
-msgid "Reset"
-msgstr "తిరిగివుంచు"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "ఏదీకాదు"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit Key (Hex or ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit Passphrase"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dynamic WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Personal"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA మరియు WPA2 ఎంటర్‌ప్రైజ్"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:2
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "సంకేతం బలం"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:3
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "లంకె వేగం"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "రక్షణ"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 చిరునామా"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 చిరునామా"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:7
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "హార్డ్‍వేర్ చిరునామా"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:8
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "సహకార ICC ప్రవరలు"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "అప్రమేయ మార్గం"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "చివరిగా వాడినది"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "ట్విస్టెడ్ పెయిర్ (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "ఎటాచ్‌మెంట్ యూనిట్ యింటర్ఫేస్ (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "మాధ్యమం యిండిపెండెంట్ యింటర్ఫేస్ (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "పేరు (_N)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:36
-msgid "_MAC Address"
-msgstr "_MSC చిరునామా"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "M_TU"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "క్లోన్‌డ్ చిరునామా (_C)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "బైట్లు"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "యితర వాడుకరులకు అందుబాటులో వుంచు (_u)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "స్వయంచాలకంగా అనుసంధానించు (_a)"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "ఫైర్‌వాల్ క్షేత్రం (_Z)"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "అప్రమేయం"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "క్షేత్రము అనుసంధానము యొక్క విశ్వాస స్థాయిను నిర్వచించును"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:22
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:23
-msgid "_Addresses"
-msgstr "చిరునామా (_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "స్వయంచాలక DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Routes"
-msgstr "రౌట్స్"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "స్వయంచాలక రౌట్స్"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Use this connection _only for resources on its network"
-msgstr "దాని నెట్వర్కుపైని వనరుల కొరకు మాత్రమే యీ అనుసంధానం వుపయోగించు (_o)"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:34
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "అనుసంధానం కూర్పరి తెరువలేక పోయింది"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "కొత్త ప్రొఫైల్"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "బాండ్"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "జట్టు"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "బ్రిడ్జ్"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "VPN ప్లగిన్స్ లోడు చేయలేక పోయింది"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "ఫైలునుండి దిగుమతిచేయి..."
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "నెట్వర్కు అనుసంధానం జతచేయి"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Reset"
-msgstr "తిరిగివుంచు (_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1449
-#: ../panels/network/network-wifi.ui.h:40
-msgid "_Forget"
-msgstr "మరచిపో (_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr ""
-"ఈ నెట్వర్కుకు అమరికలను తిరిగివుంచు, సంకేతపదములతో సహా, అయితే దీనిని అబీష్ట "
-"నెట్వర్కు వలె గుర్తించు"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr ""
-"ఈ నెట్వర్కునకు సంభందించిన అన్ని వివరాలను తీసివేయి మరియు స్వయంచాలకంగా "
-"అనుసంధానించుటకు ప్రయత్నించవద్దు"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "S_ecurity"
-msgstr "రక్షణ (_e)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "VPN అనుసంధానంను దిగుమతి చేయలేదు"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"ఫైలు '%s' చదువబడలేదు లేదా గుర్తించిన VPN అనుసంధాన సమాచారం కలిగిలేదు\n"
-"\n"
-"దోషం: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "దిగుమతి చేయుటకు ఫైలును యెంపికచేయి"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1948
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:223
-msgid "_Open"
-msgstr "తెరువు (_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "\"%s\" పేరుతో ఫైలు యిప్పటికే వుంది."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "పునఃస్థాపించు (_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "మీరు దాయుచున్న VPN అనుసంధానంతో %s ను పునఃస్థాపించాలని అనుకొనుచున్నారా?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "VPN అనుసంధానం ఎగుమతి చేయలేదు"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN అనుసంధానం '%s' అనునది %sకు యెగుమతి కాలేదు.\n"
-"\n"
-"దోషం: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-#| msgid "Export VPN connection..."
-msgid "Export VPN connection"
-msgstr "VPN అనుసంధానం ఎగుమతిచేయి"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(దోషం: VPN అనుసంధానం సరికూర్పరిని లోడు చేయలేక పోతోంది)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:12
-msgid "_SSID"
-msgstr "_SSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:13
-msgid "_BSSID"
-msgstr "_BSSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:16
-msgid "My Home Network"
-msgstr "నా హోమ్ నెట్వర్కు"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "ఇతర వాడుకరులకు అందుబాటులో వుంచు (_o)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "పేరు (_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MSC చిరునామా"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "క్లోన్‌డ్ చిరునామా (_C)"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "బైట్లు"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "పద్ధతి (_M)"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "స్వయంచాలక (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "లింక్-లోకల్ మాత్రమే"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "మానవీయ"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "అచేతనపరచివుంది"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "ఇతర కంప్యూటర్లతో భాగస్వామ్యమైను"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "చిరునామా (_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "చిరునామా"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "నెట్‌మాస్క్"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "సింహద్వారం"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "స్వయంచాలక"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "స్వయంచాలక DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "రౌట్స్"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "స్వయంచాలక రౌట్స్"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "మెట్రిక్"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "దాని నెట్వర్కుపైని వనరుల కొరకు మాత్రమే యీ అనుసంధానం వుపయోగించు (_o)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
+msgstr "పద్ధతి (_M)"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "స్వయంచాలక, DHCP మాత్రమే"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "ప్రిఫిక్స్"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "రక్షణ (_e)"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(దోషం: VPN అనుసంధానం సరికూర్పరిని లోడు చేయలేక పోతోంది)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 msgid "Network"
 msgstr "నెట్‌వర్క్"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+#: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "మీరు యింటర్నెట్‌కు యెలా అనుసంధానం కావాలో నియంత్రించు"
 
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
-#| "vpn;vlan;bridge;bond;"
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
 "vlan;bridge;bond;DNS;"
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "బాండ్ స్లేవ్స్"
-
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(ఏదీకాదు)"
-
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "బ్రిడ్జ్ స్లేవ్స్"
-
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:458
-msgid "never"
-msgstr "ఎన్నటికీకాదు"
-
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:468
-msgid "today"
-msgstr "నేడు"
-
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:470
-msgid "yesterday"
-msgstr "నిన్న"
-
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP చిరునామా"
-
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:10
-msgid "Last used"
-msgstr "చివరిగా వాడినది"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "వయర్డ్"
-
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1604
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "ఐచ్ఛికాలు..."
-
-#: ../panels/network/net-device-ethernet.c:474
-#, c-format
-msgid "Profile %d"
-msgstr "ప్రొఫైల్ %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "కొత్త అనుసంధానాన్ని జతచేయి"
-
-#: ../panels/network/net-device-team.c:77
-#| msgid "Bridge slaves"
-msgid "Team slaves"
-msgstr "టీమ్ స్లేవ్స్"
-
-#: ../panels/network/net-device-wifi.c:1153
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr ""
-"మీరు వైర్‌లెస్ కాక యింకా వేరే యింటర్నెట్ అనుసంధానం కలిగివుంటే, మీరు మీ "
-"యింటర్నెట్ అనుసంధానం పంచుకొనుటకు "
-"వైర్‌లెస్ హాట్‌స్పాట్ అమర్చవచ్చు."
-
-#: ../panels/network/net-device-wifi.c:1157
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-"వైర్‌లెస్ హాట్‌స్పాట్ల మధ్యన మారుట అనునది మీ అనుసంధానమును <b>%s</b> నుండి "
-"తెంచును."
-
-#: ../panels/network/net-device-wifi.c:1161
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"హాట్‌స్పాట్ క్రియాశీలముగా వున్నప్పుడు మీ వైర్‌లెస్ ద్వారా యింటర్నెట్‌ను "
-"యాక్సెస్ చేయుట సాధ్యంకాదు."
-
-#: ../panels/network/net-device-wifi.c:1238
-msgid "Stop hotspot and disconnect any users?"
-msgstr "హాట్ స్పాట్‌ను ఆపి ఏ వినియోగదారుడినైనా తెంచవచ్చునా?"
-
-#: ../panels/network/net-device-wifi.c:1241
-msgid "_Stop Hotspot"
-msgstr "హాట్ స్పాట్‌ను ఆపివేయి (_S)"
-
-#: ../panels/network/net-device-wifi.c:1313
-msgid "System policy prohibits use as a Hotspot"
-msgstr "హాట్‌స్పాట్ వలె వుపయోగించుటకు వ్యవస్థ విధానం నిషేధించును"
-
-#: ../panels/network/net-device-wifi.c:1316
-msgid "Wireless device does not support Hotspot mode"
-msgstr "హాట్‌స్పాట్ రీతికి వైర్‌లెస్ పరికరం తోడ్పాటునిచ్చుటలేదు"
-
-# c-format
-#: ../panels/network/net-device-wifi.c:1445
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"ఎంపికచేసిన నెట్వర్కు కొరకు నెట్వర్కు వివరాలు, సంకేతపదములతో సహా మలచుకొనిన "
-"ఆకృతీకరణ కోల్పోవును."
-
-#: ../panels/network/net-device-wifi.c:1753
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "చరిత్ర"
-
-#: ../panels/network/net-device-wifi.c:1757
-#: ../panels/wacom/cc-wacom-page.c:533
-msgid "_Close"
-msgstr "మూసివేయి (_C)"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1765
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "మరచిపో (_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "ఆకృతీకరణ URL అందివ్వనప్పుడు వెబ్ ప్రోక్సీ ఆటోడిస్కవరీ వుపయోగించబడును."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "నమ్మదగని పబ్లిక్ నెట్వర్కులకు దీనిని సిఫార్సు చేయడంలేదు."
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "ప్రోక్సీ"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "ప్రొఫైల్ జతచేయి... (_A)"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "సరఫరాదారు"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "ఏదీకాదు"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
-msgid "Manual"
-msgstr "మానవీయం"
-
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
-msgid "Automatic"
-msgstr "స్వయంచాలకం"
-
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
-msgstr "పద్ధతి (_M)"
-
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "URL ను రూపకరించు (_C)"
-
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "HTTP ప్రోక్సీ (_H)"
-
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "HTTPS ప్రోక్సీ (_T)"
-
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "FTP ప్రోక్సీ (_F)"
-
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "సాక్స్ హోస్ట్(_S)"
-
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "అతిధేయాలను విస్మరించు (_I)"
-
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "HTTP ప్రోక్సీ పోర్ట్"
-
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "HTTPS ప్రోక్సీ పోర్ట్"
-
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "FTP ప్రోక్సీ పోర్ట్"
-
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "సాక్స్ ప్రోక్సీ పోర్టు"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "పరికరాన్ని ఆపు"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "పరికరాన్ని జతచేయండి"
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "పరికరాన్ని తీసివేయి"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN రకం"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "గుంపు పేరు"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "గుంపు సంకేతపదం"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "వాడుకరిపేరు"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr "VPN అనుసంధానం ఆపు"
-
-#: ../panels/network/network-wifi.ui.h:1
-msgid "Automatic _Connect"
-msgstr "స్వయంచాలక ప్రవేశం (_C)"
-
-#: ../panels/network/network-wifi.ui.h:11
-msgid "details"
-msgstr "వివరాలు"
-
-#: ../panels/network/network-wifi.ui.h:15
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "సంకేతపదం (_P)"
-
-#: ../panels/network/network-wifi.ui.h:18
-msgid "None"
-msgstr "ఏదీకాదు"
-
-#: ../panels/network/network-wifi.ui.h:19
-msgid "Show P_assword"
-msgstr "సంకేతపదాన్ని చూపించు (_a)"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "Make available to other users"
-msgstr "ఇతర వాడుకరులకు అందుబాటులో వుంచు"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "identity"
-msgstr "గుర్తింపు"
-
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Automatic (DHCP) addresses only"
-msgstr "స్వయంచాలక (DHCP) చిరునామాలు మాత్రమే"
-
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Link-local only"
-msgstr "లింక్-లోకల్ మాత్రమే"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Shared with other computers"
-msgstr "ఇతర కంప్యూటర్లతో భాగస్వామ్యమైను"
-
-#: ../panels/network/network-wifi.ui.h:31
-msgid "_Ignore automatically obtained routes"
-msgstr "పొందిన రౌట్లను స్వయంచాలకంగా విస్మరించు (_I)"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "_Cloned MAC Address"
-msgstr "క్లోన్డ్ MAC చిరునామా (_C)"
-
-#: ../panels/network/network-wifi.ui.h:38
-msgid "hardware"
-msgstr "హార్డువేర్"
-
-#: ../panels/network/network-wifi.ui.h:41
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"ఈ అనుసంధానం కొరకు అమరికలను వాటి అప్రమేయాలకు వుంచండి, అయితే అభీష్ట అనుసంధానంగా "
-"గుర్తుంచుకో."
-
-#: ../panels/network/network-wifi.ui.h:42
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"ఈ నెట్వర్కునకు సంభందించిన అన్ని వివరాలను తీసివేయి మరియు స్వయంచాలకంగా దానికి "
-"అనుసంధానించుటకు "
-"ప్రయత్నించవద్దు."
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid "reset"
-msgstr "తిరిగివుంచు"
-
-#: ../panels/network/network-wifi.ui.h:48
-msgid "Hardware"
-msgstr "హార్డ్‍వేర్"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi హాట్‌స్పాట్"
-
-#: ../panels/network/network-wifi.ui.h:51
-msgid "_Turn On"
-msgstr "చేతనించు (_T)"
-
-#: ../panels/network/network-wifi.ui.h:52
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:53
-msgid "Turn Wi-Fi off"
-msgstr "Wi-Fi ఆఫ్ చేయి"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "మీరు యింటర్నెట్‌కు యెలా అనుసంధానం కావాలో నియంత్రించు"
 
-#: ../panels/network/network-wifi.ui.h:54
-msgid "_Use as Hotspot…"
-msgstr "హాట్‌స్పాట్ వుపయోగించు... (_U)"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "_Connect to Hidden Network…"
-msgstr "మరుగునవున్న నెట్వర్కునకు అనుసంధానమవ్వు... (_C)"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "వయర్డ్"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_History"
-msgstr "చరిత్ర (_H)"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "పరికరాన్ని ఆపు"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Wi-Fi నెట్వర్కునకు అనుసంధానమగుటను స్విచ్ ఆఫ్ చేయి"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "క్రియాశీల"
 
-#: ../panels/network/network-wifi.ui.h:58
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "సరఫరాదారు"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP చిరునామా"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "నెట్వర్కు ప్రాక్సీ"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "HTTP ప్రోక్సీ (_H)"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTPS ప్రోక్సీ (_T)"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "FTP ప్రోక్సీ (_F)"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "సాక్స్ హోస్ట్(_S)"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "అతిధేయాలను విస్మరించు (_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP ప్రోక్సీ పోర్ట్"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS ప్రోక్సీ పోర్ట్"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP ప్రోక్సీ పోర్ట్"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "సాక్స్ ప్రోక్సీ పోర్టు"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL ను రూపకరించు (_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN అనుసంధానం ఆపు"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "నెట్‌వర్క్ పేరు"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Connected Devices"
-msgstr "అనుసంధానమైవున్న పరికరాలు"
-
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "భద్రత రకం"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Security key"
-msgstr "భద్రత కీ"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "సంకేతపదం"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "ఎడ్-హాక్"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi ఆఫ్ చేయి"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "ఆకృతి"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "ఐచ్ఛికాలు నింపుతోంది..."
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "స్థితి తెలియదు"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "మరుగునవున్న నెట్వర్కునకు అనుసంధానమవ్వు... (_C)"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "అస్థవ్యస్థ"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi హాట్‌స్పాట్"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "అందుబాటులోలేదు"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "అనుసంధానిస్తోంది"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "ధృవీకరణ అవసరం"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "అనుసంధానమైంది"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "అననుసంధానిస్తున్నది"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "అనుసంధానం విఫలమైంది"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "స్థితి తెలియదు (జాడలేదు)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "అనుసంధానించబడి లేదు"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "స్వరూపణం విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "ఐపీ స్వరూపణం విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "ఐపీ స్వరూపణం కాలంచెల్లినది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "రహస్యాలు అవసరమైనవి, అయితే అందించబడలేదు"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1X సప్లికెంట్ అనుసంధానంపోయింది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1X సప్లికెంట్ ఆకృతీకరణ విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1X సప్లికెంట్ విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "ధృవీకరణకు 802.1X సప్లికెంట్ చాలా సమయం తీసుకొంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "ప్రారంభమవుటకు PPP సేవ విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "పిపిపి సేవ అననుసంధానించబడింది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "ప్రారంభమగుటకు DHCP క్లైంట్ విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP కక్షిదారు దోషం"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP కక్షిదారు విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "ప్రారంభమగుటకు భాగస్వామ్య అనుసంధానం విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "భాగస్వామ్య అనుసంధాన సేవ విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "ప్రారంభమగుటకు AutoIP సేవ విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "స్వయంఐపీ సేవ దోషం"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "స్వయంఐపీ సేవ విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "లైన్ రద్దీగా వుంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "డైల్ టోన్ లేదు"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "ఏ వాహకం ఏర్పరచలేక పోయింది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "డయిలింగ్ అభ్యర్ధన కాలం మించినది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "డయిలింగ్ యత్నం విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "మోడెమ్ ఆరంభించుటలో విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "తెలిపిన APNను యెంపికచేయుటకు విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "నెట్వర్కుల కొరకు అన్వేషించుటలేదు"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "నెట్‌వర్క్ నమోదు తిరస్కరించబడింది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "నెట్వర్కు నమోదీకరణ సమయం మించినది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "అభ్యర్ధించిన నెట్వర్కుతో నమోదగుటకు విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "పిన్ పరిశీలన విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "పరికరంకు ఫర్మువేర్ బహుశా దొరకట్లేదు"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "అనుసంధానం అదృశ్యమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "ఇప్పటికే వున్న అనుసంధానం పరిగణించడమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "మోడెమ్ కనపడలేదు"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "బ్లూటూత్ అనుసంధానం విఫలమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "సిమ్ కార్డు పెట్టలేదు"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "సిమ్ పిన్ అవసరం"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "SIM Puk అవసరమైంది"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "సిమ్ తప్పు"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "అనుసంధానించిన రీతిని యిన్ఫీబాండ్ పరికరం తోడ్పాటునీయటులేదు"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "అనుసంధానం ఆధారం విఫలమైంది"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "ఫిర్మ్‍వేర్ తప్పిపోయినది"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "కేబుల్ తీసివేయబడింది"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "ధృవీకరణపత్ర అధికారికం ధృవీకరణపత్రం యెంచుకోబడలేదు"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
 msgstr ""
-" ధృ‌వీకరణపత్ర ఆధికారిక (CA) ధృవీకరణపత్రం వుపయోగించుట లేదు సురక్షితం కాని "
-"అనుసంధానములనందు, రోగ్ "
-"Wi-Fi నెట్వర్కులకు కారణమగును. మీరు ధృవీకరణపత్ర అధికారిక ధృవీకరణపత్రం "
-"యెంచుకోవాలని "
-"అనుకొనుచున్నారా?"
 
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "విస్మరించు"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "CA ధృవీకరణపత్రం యెంపికచేయి"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, లేదా PKCS#12 వ్యక్తిగత కీలు (*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER లేదా PEM ధృవీకరణపత్రాలు (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-#| msgid "Choose a PAC file..."
-msgid "Choose a PAC file"
-msgstr "PAC ఫైలు యెంపికచేయి"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC ఫైళ్ళు (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC ఫైలు (_f)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "అంతర ధృవీకరణ (_I)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "PAC ప్రొవిజనింగ్ (_v)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "పేరులేని"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "దృవీకరించబడిన"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "రెండూ"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "ఎనానిమస్ గుర్తింపు (_m)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC ఫైలు (_f)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PAC ఫైలు యెంపికచేయి"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "అంతర ధృవీకరణ (_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "PAC ప్రొవిజనింగ్ (_v)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "వాడుకరిపేరు (_U)"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "సంకేతపదం (_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "సంకేతపదాన్ని చూపించు (_w)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-#| msgid "Choose a Certificate Authority certificate..."
-msgid "Choose a Certificate Authority certificate"
-msgstr "ధృవీకరణపత్ర అధికార ధృవీకరణపత్రం యెంపికచేయి"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "వర్షన్ 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "వర్షన్ 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "C_A ధృవీకరణపత్రం"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "ధృవీకరణపత్ర అధికార ధృవీకరణపత్రం యెంపికచేయి"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "ధృవీకరణ అవసరం"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP వర్షన్ (_v)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "ఈ సంకేతపదం కొరకు ప్రతిసారి అడుగు (_k)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "ఎన్క్రిప్టుకాని వ్యక్తిగత కీలు సురిక్షితంకావు"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"ఎంపికచేసిన వ్యక్తిగత కీ సంకేతపదంచే రక్షించబడుతున్నట్లు అనిపించుటలేదు. దీని "
-"వలన మీ రక్షణ ఆనవాళ్ళు "
-"రాజీపడవచ్చు. దయచేసి సంకేతపదంతో-రక్షితమగు వ్యక్తిగత కీ యెంపికచేయండి.\n"
-"\n"
-"(మీరు మీ వ్యక్తిగత కీను openssl తో సంకేతపద-రక్షితం చేయవచ్చు)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-#| msgid "Choose your personal certificate..."
-msgid "Choose your personal certificate"
-msgstr "మీ వ్యక్తిగత ధృవీకరణపత్రం యెంపికచేయి"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-#| msgid "Choose your private key..."
-msgid "Choose your private key"
-msgstr "మీ వ్యక్తిగత కీ యెంపికచేయి"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "గుర్తింపు (_d)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "వాడుకరి ధృవీకరణపత్రం (_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "వ్యక్తిగత కీ (_k)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "వ్యక్తిగత కీ సంకేతపదం (_P)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "నన్ను మరలా వారించ వద్దు (_w)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "డొమైన్ (_D)"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "కాదు"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "అవును"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "టన్నెల్డ్ TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "రక్షిత EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "ధృవీకరణ (_t)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (అప్రమేయం)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "ఓపెన్ వ్యవస్థ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "భాగస్వామ్య కీ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "కీ (_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "కీ చూపు (_w)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP విషయసూచి (_x)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "రకం (_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (అప్రమేయం)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "ఓపెన్ వ్యవస్థ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "భాగస్వామ్య కీ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "కీ (_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "కీ చూపు (_w)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP విషయసూచి (_x)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "ప్రకటనలు"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "శబ్ద హెచ్చరికలు"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "పాపప్ బానర్స్ చూపు"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "బానర్స్ నందు వివరాలు చూపు"
-
-#: ../panels/notifications/cc-edit-dialog.c:43
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "లాక్ తెరనందు దర్శించు"
-
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "లాక్ తెర నందు వివరాలు చూపు"
-
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "ఆన్"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "ప్రకటనలు"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "ప్రకటనలు"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "లాక్ తెర నందు వివరాలు చూపు"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "ప్రకటనలు"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "ఏ ప్రకటనలు ప్రదర్శించాలి మరియు అవి యేమి చూపాలో నియంత్రించు"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "ప్రకటనలు;బానర్;సందేశం;ట్రే;పాపప్;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "పాప్ అప్ బానర్స్ చూపు"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "లాక్ తెర నందు చూపు"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "అంతర ధృవీకరణ (_a)"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-#| msgid "Other"
-msgctxt "Online Account"
-msgid "Other"
-msgstr "ఇతర"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "ఖాతాను జతచేయండి"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
-msgstr "మెయిల్"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr "పరిచయాలు"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "సంభాషణ"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "వనరులు"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "ఖాతాలోనికి ప్రవేశించుటలో దోషం"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "ఆనవాళ్ళ గడువు తీరెను."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr "ఈ ఖాతాను చేతనపరచుటకు ప్రవేశించు."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr "సైన్ యిన్ (_S)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "ఖాతాను సృష్టించుటలో దోషం"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "ఖాతాను తీసివేయుటలో దోషం"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "మీరు ఖచ్ఛితంగా ఖాతాను తీసివేయాలనుకుంటున్నారా?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "ఇది ఖాతాను సేవకము నందు తీసివేయదు."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "తీసివేయి (_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "ఆన్‌లైన్ ఖాతాలు"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
-msgstr ""
-"మీ ఆన్‌లైన్ ఖాతాలకు  అనుసంధానమై మరియు వాటిని దేని కొరకు వుపయోగించాలో "
-"నిర్ణయించు"
+msgstr "మీ ఆన్‌లైన్ ఖాతాలకు  అనుసంధానమై మరియు వాటిని దేని కొరకు వుపయోగించాలో నిర్ణయించు"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
-#| "ownCloud;"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -3751,3587 +2854,5371 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "ఎటువంటి ఆన్‌లైన్ ఖాతాలు స్వరూపించబడలేదు"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "ఖాతాను తీసివేయండి"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "ఒక ఆన్‌లైన్ ఖాతాను జతచేయి"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"ఒక ఖాతాను జతచేయుట ద్వారా మీ అనువర్తనములు దాని పత్రములను, మెయిల్, పరిచయాలను, "
-"క్యాలెండర్‌ను, "
-"సంభాషణను మరియు మరిన్నింటిని యాక్సెస్ చేసుకొనుటకు అనుమతించును."
-
-#: ../panels/power/cc-power-panel.c:183
-msgid "Unknown time"
-msgstr "సమయం తెలియదు"
-
-#: ../panels/power/cc-power-panel.c:189
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i నిమిషం"
 msgstr[1] "%i నిమిషాలు"
 
-#: ../panels/power/cc-power-panel.c:201
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i గంట"
 msgstr[1] "%i గంటలు"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:209
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "గంట"
 msgstr[1] "గంటలు"
 
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "నిమిషం"
 msgstr[1] "నిమిషాలు"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:230
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s పూర్తిగా ఛార్జగు వరకు"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 నిమిషాలు"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:237
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "హెచ్చరిక: %s మిగిలివుంది"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 నిమిషాలు"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:242
-#, c-format
-msgid "%s remaining"
-msgstr "%s మిగిలివుంది"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 నిమిషాలు"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
-msgid "Fully charged"
-msgstr "పూర్తిగా చార్జైనది"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 నిమిషాలు"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
-msgid "Empty"
-msgstr "ఖాళీ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Charging"
-msgstr "చార్జవుతోంది"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:271
-msgid "Discharging"
-msgstr "చార్జుపోతోంది"
-
-#: ../panels/power/cc-power-panel.c:396
-msgctxt "Battery name"
-msgid "Main"
-msgstr "ముఖ్య"
-
-#: ../panels/power/cc-power-panel.c:398
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "అదనపు"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:470
-msgid "Wireless mouse"
-msgstr "వైర్‌లెస్ మౌస్"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:473
-msgid "Wireless keyboard"
-msgstr "వైరులేని కీబోర్డు"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:476
-msgid "Uninterruptible power supply"
-msgstr "అంతరాయంకలిగించని విద్యుత్ సరఫరా"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Personal digital assistant"
-msgstr "వ్యక్తిగత డిజిటల్ సహాయకం"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Cellphone"
-msgstr "సెల్‌ఫోను"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Media player"
-msgstr "మాధ్యమ ప్రదర్శకం"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Tablet"
-msgstr "టాబ్లెట్"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Computer"
-msgstr "కంప్యూటర్"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
-#: ../panels/power/cc-power-panel.c:2019
-msgid "Battery"
-msgstr "బ్యాటరీ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "చార్జవుతోంది"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "జాగ్రత్త"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Low"
-msgstr "తక్కువ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Good"
-msgstr "బాగుంది"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "పూర్తిగా చార్జైనది"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "ఖాళీ"
-
-#: ../panels/power/cc-power-panel.c:715
-msgid "Batteries"
-msgstr "బ్యాటరీలు"
-
-#: ../panels/power/cc-power-panel.c:1117
-msgid "When _idle"
-msgstr "నిష్క్రియగా వున్నప్పుడు (_i)"
-
-#: ../panels/power/cc-power-panel.c:1445
-msgid "Power Saving"
-msgstr "విద్యుత్ ఆదా"
-
-#: ../panels/power/cc-power-panel.c:1473
-#| msgid "_Screen Brightness"
-msgid "_Screen brightness"
-msgstr "తెర ప్రకాశత (_S)"
-
-#: ../panels/power/cc-power-panel.c:1479
-#| msgid "Keyboard Preferences"
-msgid "_Keyboard brightness"
-msgstr "కీబోర్డు ప్రకాశత (_K)"
-
-#: ../panels/power/cc-power-panel.c:1489
-#| msgid "_Dim Screen when Inactive"
-msgid "_Dim screen when inactive"
-msgstr "క్రియాహీనంగా ఉంటే తెర ప్రకాశత తగ్గించు (_D)"
-
-#: ../panels/power/cc-power-panel.c:1514
-#| msgid "_Blank Screen"
-msgid "_Blank screen"
-msgstr "శూన్య తెర (_B)"
-
-#: ../panels/power/cc-power-panel.c:1551
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: ../panels/power/cc-power-panel.c:1556
-msgid "Turns off wireless devices"
-msgstr "వైర్‌లెస్ పరికరాలను ఆఫ్ చేయును"
-
-#: ../panels/power/cc-power-panel.c:1581
-#| msgid "_Mobile Broadband"
-msgid "_Mobile broadband"
-msgstr "మొబైల్ బ్రాడ్‌బాండ్ (_M)"
-
-#: ../panels/power/cc-power-panel.c:1586
-#| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "మొబైల్ బ్రాడ్‌బ్యాండ్ (3G, 4G, WiMax, మొద.) పరికరాలను ఆఫ్ చేయును"
-
-#: ../panels/power/cc-power-panel.c:1635
-msgid "_Bluetooth"
-msgstr "బ్లూటూత్ (_B)"
-
-#: ../panels/power/cc-power-panel.c:1686
-msgid "When on battery power"
-msgstr "బ్యాటరీ విద్యుత్ పై వున్నప్పుడు"
-
-#: ../panels/power/cc-power-panel.c:1688
-msgid "When plugged in"
-msgstr "అనుసంధానించినపుడు"
-
-#: ../panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Off"
-msgstr "నిలిపివేయి మరియు విద్యుత్ ఆపు"
-
-#: ../panels/power/cc-power-panel.c:1851
-#| msgid "_Automatic Suspend"
-msgid "_Automatic suspend"
-msgstr "స్వయంచాలక నిలుపుదల (_A)"
-
-#: ../panels/power/cc-power-panel.c:1875
-#| msgid "When Battery Power is _Critical"
-msgid "When battery power is _critical"
-msgstr "బ్యాటరీ విద్యుత్ క్లిష్టస్థితిలో ఉన్నప్పుడు (_C)"
-
-#: ../panels/power/cc-power-panel.c:1930
-msgid "Power Off"
-msgstr "విద్యుత్ ఆపండి"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Devices"
-msgstr "పరికరాలు"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "విద్యుత్"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr "మీ బ్యాటరీ స్థితి దర్శించి మరియు విద్యుత్ ఆదా అమరికలను మార్చు"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-"విద్యుత్;నిద్రావస్థ;నిలిపివేయి;సుప్తావస్థ;బ్యాటరీ;ప్రకాశత;డిమ్;శూన్యం;మానిటర్;"
-"DPMS;నిష్క్రియ;"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "సుప్తావస్థ"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "విద్యుత్ ఆపండి"
-
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 నిమిషాలు"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 గంట"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 నిమిషాలు"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 నిమిషాలు"
 
-#: ../panels/power/power.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 నిమిషాలు"
 
-#: ../panels/power/power.ui.h:10
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 గంటలు"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 నిమిషం"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "బ్యాటరీ"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 నిమిషాలు"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "పరికరాలు"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 నిమిషాలు"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "విద్యుత్ ఆపండి"
 
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "4 నిమిషాలు"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 నిమిషాలు"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "విద్యుత్ ఆదా"
 
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "8 నిమిషాలు"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "తెర ప్రకాశత (_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 నిమిషాలు"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "తెర ప్రకాశత మరియు తాళం అమరికలు"
 
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "12 నిమిషాలు"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "తెర"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "తెర చదువరి (_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "స్వయంచాలక రౌట్స్"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "స్వయంచాలక నిలుపుదల"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "క్రింది బటన్"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "స్వయంచాలక నిలుపుదల"
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "చొప్పించిన (_P)"
 
-#: ../panels/power/power.ui.h:22
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "బ్యాటరీ విద్యుత్ పైన (_B)"
 
-#: ../panels/power/power.ui.h:23
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "ఆలస్యం"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "దృవీకరించు"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "విద్యుత్"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "సంకేతపదం"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "మీ బ్యాటరీ స్థితి దర్శించి మరియు విద్యుత్ ఆదా అమరికలను మార్చు"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "ధృవీకరణ అవసరమైంది"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr "టోనర్ తక్కువగా ఉంది"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr "టోనర్ అయిపోయింది"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr "అభివృద్దికారి దిగువ"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr "అభివృద్దికారి బయట"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr "మార్కర్ పంపిణీ దిగువ"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr "మార్కర్ పంపిణీ బయట"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr "తెరుచు కవర్"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr "ద్వారమును తెరువు"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr "కాగితం దిగువ"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr "కాగితం బయట"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ఆఫ్‌లైన్"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "నిలిపివేయబడింది"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr "వ్యర్థం వుండేచోటు దాదాపు నిండింది"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr "వ్యర్థం వుండేచోటు నిండింది"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr "ఆప్టికల్ ఫోటో కండక్టర్ అంత్యదశకు చేరుతోంది"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ఆప్టికల్ ఫోటో కండక్టర్ పనిచేయుట లేదు"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "స్వరూపిస్తోంది"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr "సిద్దం"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "పనులను ఆమోదించదు"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr "క్రమగతి"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Toner Level"
-msgstr "టోనర్ స్థాయి"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Ink Level"
-msgstr "సిరా స్థాయి"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:928
-msgid "Supply Level"
-msgstr "పంపిణీ స్థాయి"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:946
-msgctxt "printer state"
-msgid "Installing"
-msgstr "స్థాపిస్తోంది"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1123
-msgid "No printers available"
-msgstr "ఏ ముద్రకాలు అందుబాటులోలేవు"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1433
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u క్రియాశీలత"
-msgstr[1] "%u క్రియాశీలత"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1777
-msgid "Failed to add new printer."
-msgstr "కొత్త ముద్రకాన్ని జతచేయుటలో విఫలమైంది."
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid "Select PPD File"
-msgstr "PDD దస్త్రాన్ని ఎంచుకోండి"
-
-#: ../panels/printers/cc-printers-panel.c:1953
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"పోస్టుస్క్రిప్ట్ ప్రింటర్ డిస్క్రిప్షన్ ఫైళ్ళు (*.ppd, *.PPD, *.ppd.gz, "
-"*.PPD.gz, *.PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr "విద్యుత్;నిద్రావస్థ;నిలిపివేయి;సుప్తావస్థ;బ్యాటరీ;ప్రకాశత;డిమ్;శూన్యం;మానిటర్;DPMS;నిష్క్రియ;"
 
-#: ../panels/printers/cc-printers-panel.c:2258
-msgid "No suitable driver found"
-msgstr "సరిపోయే చోదకం ఏమీ కనపడలేదు"
-
-#: ../panels/printers/cc-printers-panel.c:2327
-msgid "Searching for preferred drivers…"
-msgstr "అభీష్ట చోదకంల కొరకు అన్వేషిస్తోంది..."
-
-#: ../panels/printers/cc-printers-panel.c:2342
-msgid "Select from database…"
-msgstr "డేటాబేసు నుండి ఎంచుకోండి..."
-
-#: ../panels/printers/cc-printers-panel.c:2351
-msgid "Provide PPD File…"
-msgstr "PPD ఫైల్ అందించు..."
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2502
-#: ../panels/printers/cc-printers-panel.c:2525
-msgid "Test page"
-msgstr "పరీక్ష పేజీ"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2933
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "అంతరవర్తి నింపలేకుంది: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "ముద్రకాలు"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
-msgstr ""
-"ముద్రికలను జతచేయి, ముద్రణ పనులను దర్శించి మరియు యెలా ముద్రించాలో నిర్ణయించు"
+msgstr "ముద్రికలను జతచేయి, ముద్రణ పనులను దర్శించి మరియు యెలా ముద్రించాలో నిర్ణయించు"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "ముద్రకం;వరుస;ముద్రించు;కాగితం;సిరా;టోనర్;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "క్రియాశీల కార్యాలు"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "మూసివేయి"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "ముద్రణను తిరిగి కొనసాగించు"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "ముద్రణను నిలిపివేయి"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "ముద్రణా కార్యాన్ని రద్దుచేయి"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "ఒక కొత్త ముద్రకాన్ని జతచేయి"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-#| msgid "Authenticate"
-msgid "A_uthenticate"
-msgstr "దృవీకరించు (_u)"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "ఏ ముద్రకాలు కనిపెట్టబడలేదు."
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-#| msgid "Search for network printers or filter result"
-msgid "Enter address of a printer or a text to filter results"
-msgstr "ఫలితాలను వడపోయుటకు ముద్రకం లేదా పాఠం చిరునామా ప్రవేశపెట్టండి"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "ఐచ్ఛికాలు నింపుతోంది..."
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "ముద్రకం చోదకాన్ని ఎంచుకోండి"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "చోదకంల డాటాబేస్ లోడుచేస్తోంది..."
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-#| msgid "Remove Printer"
-msgid "JetDirect Printer"
-msgstr "JetDirect ముద్రకం"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-#| msgid "%s Printer"
-msgid "LPD Printer"
-msgstr "LPD ముద్రకం"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "ఒక వైపు"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "లాంగ్ యెడ్జ్ (ప్రామాణికమైంది)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "షార్ట్ యెడ్జ్ (ఫ్లిప్)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "అడ్డచిత్రం"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "అడ్డచిత్రం"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "అపసవ్య లాండ్‌స్కేప్"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "అపసవ్య పొర్ట్రైట్"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "పెండింగు"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "నిలిపివేయబడినది"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "క్రమగతి"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "ఆపివేయబడింది"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "రద్దుచేయబడింది"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "మధ్యలో రద్దుచేయబడింది"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "పూర్తయినది"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "కార్య శీర్షిక"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "కార్య స్థితి"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "సమయం"
-
-#: ../panels/printers/pp-jobs-dialog.c:495
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s క్రియాశీల కార్యాలు"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Serial Port"
-msgstr "వరుస పోర్ట్"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1683
-msgid "Parallel Port"
-msgstr "సమాంతర పోర్ట్"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-#| msgid "Location"
-msgid "Location: %s"
-msgstr "స్థానము: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1744
-#, c-format
-#| msgid "A_ddress:"
-msgid "Address: %s"
-msgstr "చిరునామా: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1768
-#| msgid "_Inner authentication"
-msgid "Server requires authentication"
-msgstr "సేవికకు ధృవీకరణ అవసరం"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "రెండు వైపులా"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "కాగితపు రకం"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "కాగితపు మూలం"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "అవుట్‌పుట్ పళ్లెం"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "గోస్టుస్క్రిప్ట్ ప్రి-ఫిల్టరింగ్"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:531
-msgid "Pages per side"
-msgstr "ఒకవైపుకి పుటలు"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:543
-msgid "Two-sided"
-msgstr "రెండు-వైపులా"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:555
-msgid "Orientation"
-msgstr "సర్దుబాటు"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:652
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "సాధారణం"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "పుట అమరిక"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "స్థాపించదగిన ఐచ్ఛికాలు"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "కార్యము"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "బొమ్మ నాణ్యత"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "రంగు"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "పూర్తిచేస్తోంది"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "ఉన్నతం"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "స్వయం ఎంచు"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "ముద్రకము అప్రమేయం"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "ఎంబడెడ్ గోస్టుస్క్రిప్ట్ ఫాంట్లు మాత్రమే"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "PS స్థాయి 1 కు మార్చు"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "PS స్థాయి 2 కు మార్చు"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "ప్రి-ఫిల్టరింగ్ లేదు"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "తయారీదారు"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "చోదకం"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr ""
-"%s పైన అందుబాటులోని ముద్రకాలను దర్శించుటకు మీ వాడుకరిపేరు మరియు సంకేతపదం "
-"ప్రవేశపెట్టండి."
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "ముద్రకాన్ని జతచేయండి"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "ముద్రకాన్ని తీసివేయి"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "అన్‌లాక్"
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "పంపిణీ"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "ఏ చిత్రాలు కనబడలేదు"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "ధృవీకరణ అవసరమైంది"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr "%s పైన అందుబాటులోని ముద్రకాలను దర్శించుటకు మీ వాడుకరిపేరు మరియు సంకేతపదం ప్రవేశపెట్టండి."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "వాడుకరిపేరు"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "స్థానము"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-#| msgid "Default Route"
-msgid "_Default printer"
-msgstr "అప్రమేయ ముద్రకం (_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "చోదకం"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "కార్యాలు"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "అభీష్ట చోదకంల కొరకు అన్వేషిస్తోంది..."
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "పనులను చూపు (_J)"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "పట్టణం కొరకు వెతుకు"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "డేటాబేసు నుండి ఎంచుకోండి..."
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "PPD ఫైల్ అందించు..."
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "ముద్రకం చోదకాన్ని ఎంచుకోండి"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "చోదకంల డాటాబేస్ లోడుచేస్తోంది..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "రద్దుచేయి"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "ఎంచుకోండి"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "సేవికకు ధృవీకరణ అవసరం"
+msgstr[1] "సేవికకు ధృవీకరణ అవసరం"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "డొమైన్ (_D)"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "దృవీకరించు (_u)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "దృవీకరించు"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s క్రియాశీల కార్యాలు"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "పరీక్ష పేజీ"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "ముద్రకం ఐచ్ఛికాలు"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "ముద్రకము అప్రమేయం"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "ముద్రకము అప్రమేయం"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "ముద్రణా కార్యాన్ని రద్దుచేయి"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "ముద్రకాన్ని తీసివేయి"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "క్రియాశీల కార్యాలు"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "మోడల్"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "నామాంకం"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "సిరా స్థాయి"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "కొత్త చోదకం అమర్చుతోంది..."
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "పుట 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "పరిశీలనా పేజీని ముద్రించు (_T)"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "ఐచ్ఛికాలు (_O)"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "ఇప్పుడు పునఃప్రారంభించు"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "కొత్త ముద్రకాన్ని జతచేయి"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "ముద్రకాన్ని జతచేయండి"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "ముద్రకం అమరికలను మార్చు"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "ముద్రకాలు"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "క్షమించండి! వ్యవస్థ యొక్క ముద్రణా సేవ\n"
 "అందుబాటులో వున్నట్లు లేదు."
 
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "తెర లాక్"
-
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "వాడుక మరియు చరిత్ర"
-
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
-msgstr "చెత్తబూట్ట నుండి అన్ని అంశాలను ఖాళీచేయాలా?"
-
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
-msgstr "చెత్తబుట్ట నందలి అన్ని అంశాలు శాశ్వతంగా తొలగించబడును."
-
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "చెత్త ఖాళీచేయి (_E)"
-
-#: ../panels/privacy/cc-privacy-panel.c:512
-#| msgid "Purge Trash & Temporary Files"
-msgid "Delete all the temporary files?"
-msgstr "అన్ని తాత్కాలిక ఫైళ్ళను తొలగించాలా?"
-
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
-msgstr "అన్ని తాత్కాలిక దస్త్రములు శాశ్వతంగా తొలగించబడును."
-
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "తాత్కాలిక ఫైళ్ళను శుద్దంచేయి (_P)"
-
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "చెత్త మరియు తాత్కాలిక ఫైళ్ళు శుద్దంచేయి"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-#| msgid "Software"
-msgid "Software Usage"
-msgstr "సాఫ్ట్‌వేర్ వాడుక"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "గోప్యత"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-"మీ వ్యక్తిగత సమాచారం రక్షించును మరియు యితరులు యేమి చూడాలో నియంత్రించును"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "తెర మూయబడెను"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 సెకన్లు"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 రోజు"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 రోజులు"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 రోజులు"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 రోజులు"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 రోజులు"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 రోజులు"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 రోజులు"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 రోజులు"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 రోజులు"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "ఎప్పటికీ"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"మీ చరిత్రను గుర్తుంచుకొనుట వలన విషయాలను మరలా కనుగొనుటకు శులభతరం అగును. ఈ "
-"అంశములు "
-"నెట్వర్కు నందు యెప్పుడూ భాగస్వామ్యపరచ బడవు."
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "ఇటీవల వుపయోగించిన (_R)"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "చరిత్ర వుంచు (_H)"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "ఇటీవలి చరిత్ర శుబ్రంచేయి (_e)"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "మీరు దూరంగా వున్నప్పుడు తెర లాక్ మీ గోప్యతను రక్షించును."
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "స్వయంచాలక తెర లాక్ (_L)"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "శూన్యం తరువాత తెర లాక్ చేయి (_a)"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "ప్రకటనలను చూపు (_N)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"మీ కంప్యూటర్‌ను అక్కరలేని సున్నితమైన సమాచారం లేకుండా వుంచుటకు తాత్కాలిక "
-"ఫైళ్ళను మరియు చెత్తను "
-"స్వయంచాలకంగా శుద్దపరచును."
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "చెత్తను స్వయంచాలకంగా ఖాళీచేయి (_T)"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "తాత్కాలిక ఫైళ్ళను స్వయంచాలకంగా శుద్దంచేయి (_F)"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "తరువాత శుద్దపరచు (_A)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"మీరు ఏ సాఫ్టువేర్లు ఉపయోగిస్తున్నారు అనే సమాచారం మాకు పంపితే మీకు సరిపోయే "
-"సిఫార్సులను చేయడంలో మాకు దోహదపడును.  "
-"అది మా సాఫ్టువేర్‌ను మెరుగుపరచుడానికి కూడా సహాయకంగా ఉంటుంది.\n"
-"\n"
-"మేము సేకరించే సమాచారం అంతా అజ్ఞాతంగా ఉంచబడును, మరియు మేము ఎప్పటికీ మూడో "
-"వ్యక్తులతో అది పంచుకోము."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "సాఫ్టువేర్ వినియోగపు గణాంకాలు పంపుము (_S)"
-
-#: ../panels/privacy/privacy.ui.h:41
-#| msgid "Privacy"
-msgid "Privacy Policy"
-msgstr "గోప్యతా విధానం"
-
-#: ../panels/privacy/privacy.ui.h:42
-#| msgid "Location"
-msgid "_Location Services"
-msgstr "స్థానం సేవలు (_L)"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "మీ భౌగోళిక స్థానం నిర్ణయించుటలో ఉపయోగపడును"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ఉన్నతమైన"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "మెట్రిక్"
-
-#: ../panels/region/cc-format-chooser.c:284
-msgid "No regions found"
-msgstr "ఏ ప్రాంతములు కనబడలేదు"
-
-#: ../panels/region/cc-input-chooser.c:179
-msgid "No input sources found"
-msgstr "ఏ యిన్పుట్ మూలాలు కనబడలేదు"
-
-#: ../panels/region/cc-input-chooser.c:1076
-#| msgid "Other"
-msgctxt "Input Source"
-msgid "Other"
-msgstr "ఇతర"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:896
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "మార్పులు ప్రభావితం కావుటకు మీ సెషన్ పునఃప్రారంభించబడాలి"
-
-#: ../panels/region/cc-region-panel.c:240
-#: ../panels/user-accounts/um-user-panel.c:897
-msgid "Restart Now"
-msgstr "ఇప్పుడు పునఃప్రారంభించు"
-
-#: ../panels/region/cc-region-panel.c:858
-msgid "No input source selected"
-msgstr "ఏ యిన్పుట్ మూలం యెంపికకాలేదు"
-
-#: ../panels/region/cc-region-panel.c:1088
-msgid "Sorry"
-msgstr "క్షమించండి"
-
-#: ../panels/region/cc-region-panel.c:1090
-msgid "Input methods can't be used on the login screen"
-msgstr "లాగిన్ తెర నందు యిన్పుట్ పద్దతులు వుపయోగించలేము"
-
-#: ../panels/region/cc-region-panel.c:1727
-msgid "Login Screen"
-msgstr "లాగిన్ తెర"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "ఫార్మేట్లు"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "అన్వేషణ స్థానములు"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "ఉమ్మడి కర్తవ్యాలు"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "ఫార్మేట్లు"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "మునుజూపు"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "తేదీలు"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "కాలములు"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "తేది మరియు సమయం"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "సంఖ్యలు"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "కొలమానం"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "కాగితం"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "భాషలను స్థాపించు..."
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "నా ఖాతా"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "భాష  (_L)"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "ఫార్మేట్లు"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "లాగిన్ తెర"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "ప్రాంతము & భాష"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
-msgstr ""
-"మీ ప్రదర్శన భాషను, ఫార్మాట్లను, కీబోర్డు లేఅవుట్లను మరియు యిన్పుట్ మూలాలను "
-"యెంపికచేయండి"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "మీ ప్రదర్శన భాషను, ఫార్మాట్లను, కీబోర్డు లేఅవుట్లను మరియు యిన్పుట్ మూలాలను యెంపికచేయండి"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "భాష;నమూనా;కీబోర్డు;యిన్పుట్;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "ఇన్‌పుట్ వనరుని జతచేయి"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "మాధ్యమం యెలా సంభాలించబడాలో యెంపికచేయి"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "ఇన్‌పుట్ వనరు ఐచ్చికాలు"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "సీడీ ఆడియో (_a)"
 
-#: ../panels/region/input-options.ui.h:2
-msgid "Use the _same source for all windows"
-msgstr "అన్ని విండోల కొరకు అదే వనరును వుపయోగించు (_s)"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "డీవీడీ వీడియో (_D)"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Allow _different sources for each window"
-msgstr "ప్రతి విండో కొరకు విభిన్న మూలాలను అనుమతించు (_d)"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "సంగీత ప్రదర్శకం (_M)"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Keyboard Shortcuts"
-msgstr "కీబోర్డు లఘువులు"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "సాఫ్ట్‍వేర్ (_S)"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Switch to previous source"
-msgstr "మునుపటి మూలానికి మారు"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "ఇతర మాధ్యమం... (_O)"
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "మాధ్యమ ప్రవేశమప్పుడు యెప్పుడూ ప్రోగ్రామ్సు ప్రారంభించవద్దు అడుగవద్దు (_N)"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Switch to next source"
-msgstr "తరువాతి మూలానికి మారు"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "ఇతర మాధ్యమం యెలా సంభాలించబడాలో యెంపికచేయి"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Super+Space"
-msgstr "Super+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "చర్య (_A):"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "కీబోర్డు అమరికలనందు మీరు యీ లఘువులను మార్చగలరు"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "రకం (_T):"
 
-#: ../panels/region/input-options.ui.h:10
-msgid "Alternative switch to next source"
-msgstr "తరువాతి మూలమునకు ప్రత్యామ్నాయ స్విచ్"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "తీసివేయదగిన మాధ్యమం"
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Left+Right Alt"
-msgstr "ఎడమ+కుడి Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "బ్లూటూత్ అమరికలను స్వరూపించు"
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "ఇంగ్లిష్ (యునైటెడ్ కింగ్డమ్)"
-
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "యునైటెడ్ కింగ్డమ్"
-
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "ఐచ్ఛికాలు"
-
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
-msgstr ""
-"వ్యవస్థనకు లాగిన్ అగునప్పుడు లాగన్ అమరికలు అందరి వాడుకరుల చేత వుపయోగించబడును"
-
-#: ../panels/search/cc-search-locations-dialog.c:476
-#| msgid "Places"
-msgctxt "Search Location"
-msgid "Places"
-msgstr "స్థానములు"
-
-#: ../panels/search/cc-search-locations-dialog.c:478
-#| msgid "Bookmarks"
-msgctxt "Search Location"
-msgid "Bookmarks"
-msgstr "ఇష్టాంశాలు"
-
-#: ../panels/search/cc-search-locations-dialog.c:480
-#| msgid "Other"
-msgctxt "Search Location"
-msgid "Other"
-msgstr "ఇతర"
-
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "స్థానము యెంపికచేయి"
-
-#: ../panels/search/cc-search-locations-dialog.c:682
-#| msgid "GOK"
-msgid "_OK"
-msgstr "సరే (_O)"
-
-#: ../panels/search/cc-search-panel.c:176
-msgid "No applications found"
-msgstr "ఏ అనువర్తనములు కనబడలేదు"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "శోధించు"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Control which applications show search results in the Activities Overview"
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
 msgstr ""
-"క్రియాశీలతల వోవర్‌వ్యూ నందు యే అనువర్తనములు శోధన ఫలితాలను చూపాలో నియంత్రించును"
+"పరికరం;వ్యవస్థ;సమాచారం;మెమోరీ;ప్రోసెసర్;రూపాంతరం;అప్రమేయం;అనువర్తనం;ప్రాధాన్యమిచ్చేవి;సీడీ;డీవీడీ;యూఎస్‌బీ;"
+"ఆడియో;వీడియో;డిస్క్;తీసివేయదగిన;మాధ్యమం;స్వయంగానడుచు;"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
-msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "అన్వేషించు;కనుగొను;విషయసూచి;మరగునవుంచు;గోప్యత;ఫలితాలు;"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "తెర లాక్"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "శూన్య తెర (_B)"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "స్వయంచాలక తెర లాక్ (_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "స్వయంచాలక తెర లాక్ (_L)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "లాక్ తెర నందు వివరాలు చూపు"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "తెరకు తాళంవేయి"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "గోప్యత"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "తెర"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "శబ్ద అమరికలు"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "అన్వేషణ స్థానములు"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "పైకి జరపండి"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "క్రిందకు జరుపు"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "అభీష్టాలు"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "ఆన్"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "ఆఫ్"
-
-#: ../panels/sharing/cc-sharing-panel.c:304
-#| msgid "Enabled"
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "చేతనమైంది"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-#| msgid "Active Jobs"
-msgctxt "service is active"
-msgid "Active"
-msgstr "క్రియాశీల"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "ఫోల్డర్ యెంపికచేయి"
-
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "నకలుతీయు"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-msgid "Sharing"
-msgstr "పంచుకొనుచున్నది"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr "మీరు యితరులతో యేమి పంచుకోవాలని అనుకొనుచున్నారో నియంత్రించు"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+#: panels/search/cc-search-locations-dialog.ui:13
 msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
 msgstr ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "రిమోట్ లాగిన్ చేతనం లేదా అచేతనం చేయి"
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
+msgid "Places"
+msgstr "స్థానములు"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "రిమోట్ లాగిన్ చేతనం లేదా అచేతనం చేయుటకు ధృవీకరమ అవసరమైంది"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
+msgid "Bookmarks"
+msgstr "ఇష్టాంశాలు"
 
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:299
-msgid "No networks selected for sharing"
-msgstr "పంచుకొనుటకు ఏ నెట్వర్కులు ఎంపికకాలేదు"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "ఇతర"
 
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
-#| msgid "Network"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "స్థానము"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "అనువర్తనాలు"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "చిరునామాని బట్టి వెతుకు (_S)"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "క్రియాశీలతల వోవర్‌వ్యూ నందు యే అనువర్తనములు శోధన ఫలితాలను చూపాలో నియంత్రించును"
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "అన్వేషించు;కనుగొను;విషయసూచి;మరగునవుంచు;గోప్యత;ఫలితాలు;"
+
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "నెట్‌వర్కులు"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "బ్లూటూత్ భాగస్వామ్యం"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "పంచుకొనుచున్నది"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr ""
-"బ్లూటూట్ భాగస్వామ్యం అనునది వేరే బ్లూట్ చేతన పరికరాలతో ఫైళ్ళను పంచుకొనుటకు "
-"అనుమతించును"
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "నమ్మకమైన పరికరాలనుండి మాత్రమే స్వీకరించు"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "స్వీకరించిన ఫైళ్ళను డౌనులోడ్స్ ఫోల్డర్‌కు దాయి"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "కంప్యూటర్ పేరు"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "వ్యక్తిగత ఫైల్ భాగస్వామ్యం"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "తెర భాగస్వామ్యం"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "రిమోట్ దర్శనం"
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
 msgstr "మాధ్యమ భాగస్వామ్యం"
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "రిమోట్ లాగిన్"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "పంచుకొనుచున్నది"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "సంకేతపదం అవసరం"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "రిమోట్ లాగిన్"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "ఏ నెట్వర్కు యాక్సెస్ లేని కారణంగా కొన్ని సేవలు అచేతనపరచబడెను."
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "రిమోట్ దర్శనం"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
-"వ్యక్తిగత ఫైల్ భాగస్వామ్యం అనునది మిమ్ములను ప్రస్తుత నెట్వర్కునందు యితరులతో "
-"మీ పబ్లిక్ ఫోల్డర్‌ను "
-"పంచుకొనుటకు అనుమతించును: <a href=\"dav://%s\">dav://%s</a> వుపయోగించి"
 
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr "సంకేతపదం అవసరం"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "రిమోట్ లాగిన్ చేతనం లేదా అచేతనం చేయి"
 
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"సెక్యూర్ షెల్ కమాండ్ వుపయోగించి రిమోట్ వాడుకరులను అనుసంధానించుటకు "
-"అనుమతించుము:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"దీనికి అనుసంధానమగుట ద్వారా రిమోట్ వాడుకరులను మీ తెరను దర్శించుటకు లేదా "
-"నియంత్రించుటకు "
-"అనుమతించుము: <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:20
-#| msgid "Remote Control"
-msgid "Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "రిమోట్ నియంత్రణ అనుమతించు"
 
-#: ../panels/sharing/sharing.ui.h:21
-#| msgid "_Password:"
-msgid "Password:"
-msgstr "సంకేతపదం:"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "సంకేతపదమును చూపుము"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "అనుసంధానించబడి లేదు"
 
-#: ../panels/sharing/sharing.ui.h:23
-#| msgid "%s Options"
-msgid "Access Options"
-msgstr "ఏక్సెస్ ఐచ్ఛికాలు"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "ఏక్సెస్ కొరకు కొత్త అనుసంధానాలు తప్పక అడగాలి"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "నకలుతీయు"
 
-#: ../panels/sharing/sharing.ui.h:25
-#| msgid "Require Password"
-msgid "Require a password"
-msgstr "సంకేతపదం అవసరం"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "చిరునామా తొలగించు"
 
-#: ../panels/sharing/sharing.ui.h:26
-#| msgid "Share Music, Photos and Videos with others on the current network."
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "ధృవీకరణ (_t)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "వాడుకరి పేరు:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "వేలిముద్రలను నమోదుచేస్తున్నది"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "మాధ్యమ భాగస్వామ్యం"
+
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "నెట్వర్కునందు సంగీతం, చిత్రాలు మరియు వీడియోలు పంచుకొనుము."
 
-#: ../panels/sharing/sharing.ui.h:27
-#| msgid "Add Folder"
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "సంచయాలు"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "శబ్దము"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "మీరు యితరులతో యేమి పంచుకోవాలని అనుకొనుచున్నారో నియంత్రించు"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
 msgstr ""
-"శబ్ద స్థాయిలను, యిన్పుట్లను, అవుట్పుట్లను, మరియు హెచ్చరిక శబ్దములను మార్చు"
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "కార్డు;మైక్రోఫోన్;శబ్దం;ఫేడ్;సమతుల్యం;బ్లూటూత్;హెడ్‌సెట్;శ్రవ్యకం;"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "రిమోట్ లాగిన్ చేతనం లేదా అచేతనం చేయి"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "మొరుగు"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "రిమోట్ లాగిన్ చేతనం లేదా అచేతనం చేయుటకు ధృవీకరమ అవసరమైంది"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "నీటిచుక్క"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "ఫ్లికర్"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "గాజు"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "పంచుకొనుచున్నది"
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "సోనార్"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "ఎడమ"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "కుడి"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "సమతుల్యం (_B):"
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "వాడిపోవు:(_F)"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "వెనుక"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "ముందు"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "కనిష్టం"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "గరిష్టం"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "వ్యవస్థ శబ్దములు"
 
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "సమతుల్యం (_B):"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "హెచ్చరిక శబ్దం (_A):"
 
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "వాడిపోవు:(_F)"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "నిశబ్దం"
 
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "సబ్‌వూఫర్ (_S):"
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "అవుట్‌పుట్"
 
-#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "అవుట్‌పుట్ శబ్దం (_O):"
 
-#: ../panels/sound/gvc-channel-bar.c:616
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "అన్‌యాంప్లిఫైడ్"
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "పరీక్షించు"
 
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "ప్రవర (_P):"
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "URL ను రూపకరించు (_C)"
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "సబ్‌వూఫర్"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "ఇన్‌పుట్"
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "ఇన్‌పుట్ స్థాయి:"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "శబ్దాన్ని పెంచు"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "సంకేతం బటన్లు"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "నిశబ్దం"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "శబ్దము"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "శబ్ద స్థాయిలను, యిన్పుట్లను, అవుట్పుట్లను, మరియు హెచ్చరిక శబ్దములను మార్చు"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "కార్డు;మైక్రోఫోన్;శబ్దం;ఫేడ్;సమతుల్యం;బ్లూటూత్;హెడ్‌సెట్;శ్రవ్యకం;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "ప్రకటనలు"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "నామము:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "స్వయంచాలక ప్రవేశం (_C)"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "పరికరాన్ని తీసివేయి"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "%s డొమైన్‌కు అనుసంధానం కాలేకపోయింది: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "సార్వత్రిక ప్రాప్తి"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "పరికరాలను పొందుట..."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "కర్సర్ బ్లింకవుచున్నది"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "పాఠ్య క్షేత్రములందు కర్సర్ బ్లింక్‌అవాలి (_b)"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "వేగం"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "కర్సర్ రెప్పపాటు వేగం"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "కర్సర్ రెప్పపాటు వేగం"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "సహాయకి నొక్కండి"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "సిమ్యులేటెడ్ రెండవ నొక్కు (_S)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "ప్రధమ బట్టన్ ను నొక్కుతూ ద్వితీయ క్లిక్ ను మొదలెట్టు"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "అంగీకరించు జాప్యం:(_c)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "పొట్టి"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "రెండవ నొక్కు ఆలస్యం"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "పొడవు"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "హోవర్ క్లిక్ (_H)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "పాయింటరు హోవర్ అయినప్పుడు క్లిక్ ను మొదలెట్టు"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "ఆలస్యం (_e):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "పొట్టి"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "పొడవు"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "గతి ఉపక్రమణ:(_t)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "చిన్న"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "పెద్ద"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "పునరావృత కీలు"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "కీ నొక్కివుంచినప్పుడు కీ వత్తులు పునరావృతం కావాలి (_r)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "పునరావృత కీల వేగం"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "పునరావృత కీల వేగం"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "టైపింగు సహాయకం"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "అంటివుండే కీలు (_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "ఒక వరుస మార్పు చేయు కీ లను కీ కలయిక లా భావించును "
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "ఒకవేళ రెండు కీలు ఒకేసారి నొక్కితే అచేతనపరుచు (_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "సవరణి కీ వత్తినప్పుడు బీప్ చేయుము(_m)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "నెమ్మది కీలు (_l"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr " కీ నొక్కిన మరియు కీ అంగీకరించబడ్డ మధ్యలో జాప్యమును ఉంచును "
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "పొట్టి"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "నెమ్మది మీటల టైపింగు ఆలస్యం"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "పొడవు"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "కీ వత్తినప్పుడు బీప్‌చేయుము(_e)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "కీ ఆమోదించినప్పుడు బీప్ చేయుము (_a)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "బీప్ ఎపుడైతే ఒక కీ ని తిరస్కిరించినపుడు(_r) "
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "బౌన్సు కీలు (_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "వేగ నకలీ కీప్రెస్ ను పట్టించుకోదు"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "పొట్టి"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "బౌన్స్ మీటల టైపింగు ఆలస్యం"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "పొడవు"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "కీబోర్డుతో చేతనించు (_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "కీబోర్డ్ ఉపయోగించి ప్రవేశయోగ్య విశిష్టతలను చేతనం లేదా అచేతనం చేయి"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "సార్వత్రిక ఏక్సెస్ మెనూ ఎల్లప్పుడూ చూపుము (_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "చూస్తున్న"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "అధిక కాంట్రాస్ట్ (_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "అతిపెద్ద పాఠం (_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "తెర చదువరి (_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "మీరు ఫోకస్‌ను కదల్చగానే ప్రదర్శించబడుతున్న పాఠంను తెరచదువరి దాన్ని చదువును."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "శబ్ద కీలు (_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "నమ్ లాక్ లేదా కాప్స్ లాక్ ఆన్ చేయగానే బీప్ చేయును."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "కర్సర్ రెప్పపాటు వేగం"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "జూమ్ (_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "వినుట"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "దృశ్య హెచ్చరికలు (_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "తెర కీబోర్డు (_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "పునరావృత కీలు"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "కర్సర్ బ్లింకవుచున్నది"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "టైపింగు సహాయకం (AccessX) (_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "ఎత్తిచూపు మరియు క్లిక్ చేయు"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "మౌస్ కీలు (_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "సూచిక"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "సహాయకి నొక్కండి (_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "రెండు నొక్కులు(_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "రెండు-నొక్కలు కాలముమించినది"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "దృశ్యమాన హెచ్చరికలు"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "ఫ్లాష్ పరీక్షించు (_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "హెచ్చరిక శబ్దము కలిగినపుడు  దృశ్య సూచిని ఉపయోగించు."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "పూర్తి తెరను ఫ్లాష్ చేయు (_s)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "పూర్తి తెరను ఫ్లాష్ చేయు (_s)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "పూర్తి తెర"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "పైన సగం"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "క్రింది సగం"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "ఎడమ సగభాగం"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "కుడి సగభాగం"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "జూమ్ ఐచ్చికాలు"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "మాగ్నిఫికేషన్:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "బూతద్ద స్థానము:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "మౌస్ కర్సరును అనుసరించు"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "తెర భాగం:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "బూతద్దపు తెర వెలుపల విస్తరించింది"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "బూతద్దం ములుకు కేంద్రీకృతమై ఉంచండి"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "బూతద్దం ములుకు చుట్టూ ఉన్న విషయాలను నెట్టివేసింది"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "విషయాలను బూతద్దం సూచకితో కదలికలు"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "బూతద్దము"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "కేశలు అడ్డంగా:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "సమన్వయం ఎలుక ములుకు"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
+msgstr "మందం:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "సన్నం"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "మందం"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
+msgstr "పొడవు:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
+msgstr "రంగు:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "క్రాస్‌హెయిర్స్"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "రంగుల ప్రభావాలు:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
+msgstr "నలుపుపై తెలుపు:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "ప్రకాశత:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "వ్యత్యాసం:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "ఏదీకాదు"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "పూర్తి"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "తక్కువ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "ఎక్కువ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "తక్కువ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "అధికం"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "రంగుల ప్రభావాలు"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "చూడుటకు, వినుటకు, టైపునకు, సూచించుటకు మరియు నొక్కుటకు దీనిని సులభతరం చేయి"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "చరిత్ర"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "చరిత్ర"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "ఇటీవలి చరిత్ర శుబ్రంచేయి (_e)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "చెత్త మరియు తాత్కాలిక ఫైళ్ళు శుద్దంచేయి"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "చెత్తను స్వయంచాలకంగా ఖాళీచేయి (_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "తాత్కాలిక ఫైళ్ళను స్వయంచాలకంగా శుద్దంచేయి (_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "చెత్తను స్వయంచాలకంగా ఖాళీచేయి (_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "చెత్త ఖాళీచేయి (_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "తాత్కాలిక ఫైళ్ళను శుద్దంచేయి (_P)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "చెత్తకుండికి కదుపుము"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "వాడుకరిని జతచేయండి"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "నిర్వాహకుడు"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "తరువాత ప్రవేశంలో సంకేతపదాన్ని ఎన్నుకొనుటకు వాడుకరిని అనుమతించు"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "ఒక కొత్త సంకేతపదాన్ని అమర్చు"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "స్వరూపిస్తోంది"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "ఆఫ్‌లైన్"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"మనుగడలోవున్న కేంద్రీకృత నిర్వాహిత వాడుకరి ఖాతాను ఈ పరికరంపై ఉపయోగించుటకు ఎంటర్‌ప్రైజ్ లాగిన్ "
+"అనుమతించును."
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PDD దస్త్రాన్ని ఎంచుకోండి"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "కాదు"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "వేలిముద్ర లాగిన్ అచేతనపరిచే నమోదైన వేలిముద్రల తొలగింపును మారు చేద్దామనుకొనుచున్నారా?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "ఏ ముద్రకాలు కనిపెట్టబడలేదు."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "స్వరూపించుటకు ఒక పరికరం ఎంచుకోండి (_h):"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "వేలిముద్రలను తొలగించు (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "క్రితం వార్"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "తరువాతి వారం"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "సంకేతపదమును మార్చు"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "మార్చు (_a)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "ప్రస్తుత సంకేతపదం (_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "కొత్త సంకేతపదం (_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "సంకేతపదాన్ని నిర్ధారించండి (_o)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "సంకేతపదాలు సరిపోలలేదు."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "తరువాత ప్రవేశంలో సంకేతపదాన్ని ఎన్నుకొనుటకు వాడుకరిని అనుమతించు"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "ఒక కొత్త సంకేతపదాన్ని అమర్చు"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "వాడుకరులు"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "మార్పులు ప్రభావితం కావుటకు మీ సెషన్ పునఃప్రారంభించబడాలి"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "ఇప్పుడు పునఃప్రారంభించు"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "మూసివేయి"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "పూర్తి పేరు (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "స్వయంచాలక ప్రవేశం (_u)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "ఖాతా రకం (_t)"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "నిర్వాహకుడు"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "నియంత్రణలు"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "అప్రమేయ అనువర్తనంతో తెరువుము"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "వాడుకరి ఖాతాను తీసివేయి"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "ఇతర వేలు (_O):"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "వాడుకరిని జతచేయండి"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "ఏ చిత్రాలు కనబడలేదు"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "వాడుకరిని ఖాతాను సృష్టించు"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "వాడుకరులను జతచేయి లేదా తీసివేయి మరియు మీ సంకేతపదం మార్చు"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "నమోదుచేయి(_E)"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "డొమైన్ నిర్వాహకుని ప్రవేశం"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"ఎంటర్‌ప్రైజ్ లాగిన్స్ వుపయోగించుటకు, ఈ కంప్యూటర్ డొమైన్ నందు ఎన్‌రోల్ కావలసివుంటుంది\n"
+"మీ నెట్వర్కు నిర్వహణాధికారి వారి డొమైన్ సంకేతపదంను యిక్కడ టైపు చేయవలెను."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "నిర్వాహకుని పేరు (_N)"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "నిర్వాహకుని సంకేతపదం"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "వాడుకరి ఖాతాలను నిర్వహించు"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "వాడుకరి సమాచారాన్ని మార్చాలంటే ధృవీకరణ అవసరం"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "మ్యాప్ బటన్లు"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr " కార్యాలను పటం మీటలు"
+
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ఒక షార్ట్ కట్ ని సరిచేయుటకు, \"కీస్ట్రోక్ పంపు\" చర్య ఎంచుకొని, కీబోర్డ్ లఘువు బటన్ వత్తండి మరియు "
+"కొత్త కీలను పట్టివుంచండి లేదా శుబ్రంచేయుటకు బ్యాక్‌స్పేస్ వత్తండి."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "మూసివేయి (_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "తాము మాత్ర బలాన్ని నిర్ణయించు కు తెరపైన కనిపించే విధంగా లక్ష్యాన్ని గుర్తులను పొందేల చెయ్యండి."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
+msgstr "MIS-క్లిక్ పునఃప్రారంభించి, కనుగొనబడింది ..."
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "వర్చువల్ పరికరమును సృష్టించు"
+
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "టాబ్లెట్"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "ఎడమ-చేతివైపు సర్దుబాటు"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "మానిటర్‌కు మాప్ చేయి ..."
+
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "ఏస్పెక్ట్ రేషియో"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "క్రమాంకనం చేయి..."
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "ఏ టాబ్లెట్ కనిపెట్టబడలేదు"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "మీ వాకం ట్యాబ్లెట్ ను దయచేసి ప్లగిన్ లేదా ఆన్ చేయుము "
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "ప్రెషరు స్పర్శ టిప్"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "సున్నితమైన"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "ఫిర్మ్"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "బటన్"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "బటన్"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "బటన్"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "ప్రెషరు స్పర్శను చెరుపుము"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "ప్రెషరు స్పర్శను చెరుపుము"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "మధ్య మౌస్ బటన్ నొక్కు"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "కుడి మౌస్ బటన్ నొక్కు"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "ముందుకు"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "వ్యాకం టాబ్లెట్"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "గ్రాఫిక్స్ టాబ్లెట్ల కొరకు బటన్ మాపింగ్ మరియు స్టైలస్ సున్నితత్వం సర్దుబాటు చేయును"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "ట్యాబ్లెట్;వాకం;శ్టైలస్;ఇరేసర్;మౌజ్;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "నమూనా"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "మాత్రుక విండో"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "సిమ్యులేటెడ్ రెండవ నొక్కు (_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "విండోలు"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "టోనర్ తక్కువగా ఉంది"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "రెండవ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "విండోలు"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "ఏక్సెస్ ఐచ్ఛికాలు"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "జతచేయి"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "భద్రపరచు (_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "వివరాలు"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "నెట్‌వర్క్ సమయం (_N)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "నెట్‌వర్క్ అమరికలు"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "సంఖ్యలు"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "పరికరం రకాలు"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "తయారీదారు"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "ఫిర్మ్‍వేర్ తప్పిపోయినది"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "మొబైల్(_M):"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "నెట్‌వర్క్ సమయం (_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "నెట్‌వర్క్"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "ఉన్నతం"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "ఏక్సెస్ ఐచ్ఛికాలు"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "తాళంవేయి"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "వివరాలు"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "నెట్‌వర్క్ పేరు"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "స్వయంచాలక"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "నా హోమ్ నెట్వర్కు"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "నా హోమ్ నెట్వర్కు"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "ఎటువంటి బ్లూటూత్ ఎడాప్టర్లు కనపడలేదు"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "విమానం రీతి (_p)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "అనుసంధానము"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "సిమ్ కార్డు పెట్టలేదు"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "తాళంవేయి"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "మార్చు (_a)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "నా హోమ్ నెట్వర్కు"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "కొత్త చోదకం అమర్చుతోంది..."
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "గోప్యత"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "అన్ని అమరికలు"
+
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "ప్రాథమిక"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "సహాయం"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "సాధారణ"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "నిష్క్రమించు"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "శోధించు"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "మునుపటి మూలానికి మారు"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "రద్దుచేయబడింది"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "ప్రాధాన్యతలు;అమరికలు;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u అవుట్‌పుట్"
 msgstr[1] "%u అవుట్‌పుట్లు"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u ఇన్‌పుట్"
 msgstr[1] "%u ఇన్‌పుట్లు"
 
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
-msgstr "వ్యవస్థ శబ్దములు"
+#~ msgid "Changes throughout the day"
+#~ msgstr "రోజు మొత్తంమీద మార్పులు"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "స్పీకర్లను పరీక్షించు (_T)"
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "పలక"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "పీక్ గుర్తింపు"
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "జూమ్"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1509
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "పేరు"
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "మధ్య"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1528
-msgid "Device"
-msgstr "పరికరం"
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "నింపు"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1591
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "అవధి"
+
+#~ msgid "Select Background"
+#~ msgstr "నేపథ్యాన్ని ఎంచుకోండి"
+
+#~ msgid "Pictures"
+#~ msgstr "చిత్రాలు"
+
+#~ msgid "Colors"
+#~ msgstr "రంగులు"
+
+#~ msgid "Home"
+#~ msgstr "నివాసం"
+
 #, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s కొరకు స్పీకర్ పరీక్ష"
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "మీరు చిత్రాలను మీ %s ఫోల్డర్‌కు జతచేయవచ్చు మరియు అవి ఇక్కడ చూపబడును"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1649
-msgid "_Output volume:"
-msgstr "అవుట్‌పుట్ శబ్దం (_O):"
+#~ msgid "multiple sizes"
+#~ msgstr "బహుళ పరిమాణములు"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1663
-msgid "Output"
-msgstr "అవుట్‌పుట్"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1668
-msgid "C_hoose a device for sound output:"
-msgstr "శబ్ద అవుట్‌పుట్ కొరకు ఒక పరికరమును ఎంచుకోండి (_h):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1693
-msgid "Settings for the selected device:"
-msgstr "ఎంపికచేసిన పరికరము కొరకు అమరికలు:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "Input"
-msgstr "ఇన్‌పుట్"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "_Input volume:"
-msgstr "ఇన్‌పుట్ శబ్దం (_I):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1734
-msgid "Input level:"
-msgstr "ఇన్‌పుట్ స్థాయి:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1762
-msgid "C_hoose a device for sound input:"
-msgstr "శబ్ద ఇన్‌పుట్ కొరకు ఒక పరికరమును ఎంచుకోండి (_h):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "Sound Effects"
-msgstr "శబ్ద ప్రభావాలు"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-msgid "_Alert volume:"
-msgstr "హెచ్చరిక శబ్దం (_A):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1809
-msgid "Applications"
-msgstr "అనువర్తనాలు"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1813
-msgid "No application is currently playing or recording audio."
-msgstr "ఏ అనువర్తనము ప్రస్తుతం ఆడియోను నడుపుటలేదు లేదా రికర్డు చేయుటలేదు."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "బుల్ట్-యిన్"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "శబ్ద ప్రాధాన్యతలు"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "పరీక్షణ ఘటన శబ్ధము"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "అప్రమేయం"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "థీమ్ నుండి"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:769
-msgid "C_hoose an alert sound:"
-msgstr "హెచ్చరిక శబ్దమును ఎంచుకోండి (_h):"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "ఆపు"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
-msgid "Test"
-msgstr "పరీక్షించు"
-
-#: ../panels/sound/gvc-speaker-test.c:227
-msgid "Subwoofer"
-msgstr "సబ్‌వూఫర్"
-
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "అనురూపితం"
-
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr ""
-"చూడుటకు, వినుటకు, టైపునకు, సూచించుటకు మరియు నొక్కుటకు దీనిని సులభతరం చేయి"
-
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
-#| msgid ""
-#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;"
-#| "size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
-msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
-msgstr ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
-
-#: ../panels/universal-access/uap.ui.h:1
-#| msgid "Universal Access"
-msgid "_Always Show Universal Access Menu"
-msgstr "సార్వత్రిక ఏక్సెస్ మెనూ ఎల్లప్పుడూ చూపుము (_A)"
-
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "చూస్తున్న"
-
-#: ../panels/universal-access/uap.ui.h:3
-#| msgid "High Contrast"
-msgid "_High Contrast"
-msgstr "అధిక కాంట్రాస్ట్ (_H)"
-
-#: ../panels/universal-access/uap.ui.h:4
-#| msgid "Large Text"
-msgid "_Large Text"
-msgstr "అతిపెద్ద పాఠం (_L)"
-
-#: ../panels/universal-access/uap.ui.h:5
-#| msgid "Zoom"
-msgid "_Zoom"
-msgstr "జూమ్ (_Z)"
-
-#: ../panels/universal-access/uap.ui.h:7
-#| msgid "Screen Reader"
-msgid "Screen _Reader"
-msgstr "తెర చదువరి (_R)"
-
-#: ../panels/universal-access/uap.ui.h:8
-#| msgid "Bounce Keys"
-msgid "_Sound Keys"
-msgstr "శబ్ద కీలు (_S)"
-
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "వినుట"
-
-#: ../panels/universal-access/uap.ui.h:10
-#| msgid "Visual Alerts"
-msgid "_Visual Alerts"
-msgstr "దృశ్య హెచ్చరికలు (_V)"
-
-#: ../panels/universal-access/uap.ui.h:12
-#| msgid "Screen keyboard"
-msgid "Screen _Keyboard"
-msgstr "తెర కీబోర్డు (_K)"
-
-#: ../panels/universal-access/uap.ui.h:13
-#| msgid "Typing Assistant"
-msgid "_Typing Assist (AccessX)"
-msgstr "టైపింగు సహాయకం (AccessX) (_T)"
-
-#: ../panels/universal-access/uap.ui.h:14
-#| msgid "Pointing and Clicking"
-msgid "Pointing & Clicking"
-msgstr "ఎత్తిచూపు మరియు క్లిక్ చేయు"
-
-#: ../panels/universal-access/uap.ui.h:15
-#| msgid "Mouse Keys"
-msgid "_Mouse Keys"
-msgstr "మౌస్ కీలు (_M)"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "సహాయకి నొక్కండి (_C)"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "తెర చదువకం"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr ""
-"మీరు ఫోకస్‌ను కదల్చగానే ప్రదర్శించబడుతున్న పాఠంను తెరచదువరి దాన్ని చదువును."
-
-#: ../panels/universal-access/uap.ui.h:19
-#| msgid "Screen Reader"
-msgid "_Screen Reader"
-msgstr "తెర చదువరి (_S)"
-
-#: ../panels/universal-access/uap.ui.h:20
-#| msgid "Bounce Keys"
-msgid "Sound Keys"
-msgstr "శబ్ద కీలు"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "నమ్ లాక్ లేదా కాప్స్ లాక్ ఆన్ చేయగానే బీప్ చేయును."
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "దృశ్యమాన హెచ్చరికలు"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "ఫ్లాష్ పరీక్షించు (_T)"
-
-#: ../panels/universal-access/uap.ui.h:24
-#| msgid "Use a visual indication when an alert sound occurs"
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "హెచ్చరిక శబ్దము కలిగినపుడు  దృశ్య సూచిని ఉపయోగించు."
-
-#: ../panels/universal-access/uap.ui.h:25
-#| msgid "Flash the window title"
-msgid "Flash the _window title"
-msgstr "విండో శీర్షికను ఫ్లాష్ చేయు (_w)"
-
-#: ../panels/universal-access/uap.ui.h:26
-#| msgid "Flash the entire screen"
-msgid "Flash the entire _screen"
-msgstr "పూర్తి తెరను ఫ్లాష్ చేయు (_s)"
-
-#: ../panels/universal-access/uap.ui.h:27
-#| msgid "Typing Assistant"
-msgid "Typing Assist"
-msgstr "టైపింగు సహాయకం"
-
-#: ../panels/universal-access/uap.ui.h:28
-#| msgid "Sticky Keys"
-msgid "_Sticky Keys"
-msgstr "అంటివుండే కీలు (_S)"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "ఒక వరుస మార్పు చేయు కీ లను కీ కలయిక లా భావించును "
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "ఒకవేళ రెండు కీలు ఒకేసారి నొక్కితే అచేతనపరుచు (_D)"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifer key is pressed"
-msgstr "బీప్ ఎపుడైతే ఒక మార్పుచేయనున్న కీ ని ప్రెస్ చేసినపుడు(_m)"
-
-#: ../panels/universal-access/uap.ui.h:32
-#| msgid "Slow Keys"
-msgid "S_low Keys"
-msgstr "నెమ్మది కీలు (_l"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr " కీ నొక్కిన మరియు కీ అంగీకరించబడ్డ మధ్యలో జాప్యమును ఉంచును "
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "అంగీకరించు జాప్యం:(_c)"
-
-#: ../panels/universal-access/uap.ui.h:35
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "పొట్టి"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "నెమ్మది మీటల టైపింగు ఆలస్యం"
-
-#: ../panels/universal-access/uap.ui.h:37
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "పొడవు"
-
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Beep when a key is pr_essed"
-msgstr "కీ వత్తినప్పుడు బీప్‌చేయుము(_e)"
-
-#: ../panels/universal-access/uap.ui.h:39
-#| msgid "Beep when key is _accepted"
-msgid "Beep when a key is _accepted"
-msgstr "కీ ఆమోదించినప్పుడు బీప్ చేయుము (_a)"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "బీప్ ఎపుడైతే ఒక కీ ని తిరస్కిరించినపుడు(_r) "
-
-#: ../panels/universal-access/uap.ui.h:41
-#| msgid "Bounce Keys"
-msgid "_Bounce Keys"
-msgstr "బౌన్సు కీలు (_B)"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "వేగ నకలీ కీప్రెస్ ను పట్టించుకోదు"
-
-#: ../panels/universal-access/uap.ui.h:43
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "పొట్టి"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "బౌన్స్ మీటల టైపింగు ఆలస్యం"
-
-#: ../panels/universal-access/uap.ui.h:45
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "పొడవు"
-
-#: ../panels/universal-access/uap.ui.h:46
-#| msgid "Enable by Keyboard"
-msgid "_Enable by Keyboard"
-msgstr "కీబోర్డుతో చేతనించు (_E)"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "కీబోర్డ్ ఉపయోగించి ప్రవేశయోగ్య విశిష్టతలను చేతనం లేదా అచేతనం చేయి"
-
-#: ../panels/universal-access/uap.ui.h:48
-msgid "Click Assist"
-msgstr "సహాయకి నొక్కండి"
-
-#: ../panels/universal-access/uap.ui.h:49
-#| msgid "Simulated Secondary Click"
-msgid "_Simulated Secondary Click"
-msgstr "సిమ్యులేటెడ్ రెండవ నొక్కు (_S)"
-
-#: ../panels/universal-access/uap.ui.h:50
-msgid "Trigger a secondary click by holding down the primary button"
-msgstr "ప్రధమ బట్టన్ ను నొక్కుతూ ద్వితీయ క్లిక్ ను మొదలెట్టు"
-
-#: ../panels/universal-access/uap.ui.h:51
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
-msgctxt "secondary click"
-msgid "Short"
-msgstr "పొట్టి"
-
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Secondary click delay"
-msgstr "రెండవ నొక్కు ఆలస్యం"
-
-#: ../panels/universal-access/uap.ui.h:53
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
-msgctxt "secondary click delay"
-msgid "Long"
-msgstr "పొడవు"
-
-#: ../panels/universal-access/uap.ui.h:54
-#| msgid "Hover Click"
-msgid "_Hover Click"
-msgstr "హోవర్ క్లిక్ (_H)"
-
-#: ../panels/universal-access/uap.ui.h:55
-msgid "Trigger a click when the pointer hovers"
-msgstr "పాయింటరు హోవర్ అయినప్పుడు క్లిక్ ను మొదలెట్టు"
-
-#: ../panels/universal-access/uap.ui.h:56
-msgid "D_elay:"
-msgstr "ఆలస్యం (_e):"
-
-#: ../panels/universal-access/uap.ui.h:57
-#| msgctxt "keyboard, delay"
-#| msgid "Short"
-msgctxt "dwell click delay"
-msgid "Short"
-msgstr "పొట్టి"
-
-#: ../panels/universal-access/uap.ui.h:58
-#| msgctxt "keyboard, delay"
-#| msgid "Long"
-msgctxt "dwell click delay"
-msgid "Long"
-msgstr "పొడవు"
-
-#: ../panels/universal-access/uap.ui.h:59
-msgid "Motion _threshold:"
-msgstr "గతి ఉపక్రమణ:(_t)"
-
-#: ../panels/universal-access/uap.ui.h:60
-#| msgctxt "universal access, text size"
-#| msgid "Small"
-msgctxt "dwell click threshold"
-msgid "Small"
-msgstr "చిన్న"
-
-#: ../panels/universal-access/uap.ui.h:61
-#| msgctxt "universal access, text size"
-#| msgid "Large"
-msgctxt "dwell click threshold"
-msgid "Large"
-msgstr "పెద్ద"
-
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
-msgid "Short"
-msgstr "లఘువు"
-
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ తెర"
-
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ తెర"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ తెర"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
-msgid "Long"
-msgstr "పొడవు"
-
-#: ../panels/universal-access/zoom-options.ui.h:1
-msgid "Full Screen"
-msgstr "పూర్తి తెర"
-
-#: ../panels/universal-access/zoom-options.ui.h:2
-msgid "Top Half"
-msgstr "పైన సగం"
-
-#: ../panels/universal-access/zoom-options.ui.h:3
-msgid "Bottom Half"
-msgstr "క్రింది సగం"
-
-#: ../panels/universal-access/zoom-options.ui.h:4
-msgid "Left Half"
-msgstr "ఎడమ సగభాగం"
-
-#: ../panels/universal-access/zoom-options.ui.h:5
-msgid "Right Half"
-msgstr "కుడి సగభాగం"
-
-#: ../panels/universal-access/zoom-options.ui.h:6
-msgid "Zoom Options"
-msgstr "జూమ్ ఐచ్చికాలు"
-
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "జూమ్"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
-msgstr "మాగ్నిఫికేషన్:"
-
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "మౌస్ కర్సరును అనుసరించు"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "తెర భాగం:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "బూతద్దపు తెర వెలుపల విస్తరించింది"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "బూతద్దం ములుకు కేంద్రీకృతమై ఉంచండి"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "బూతద్దం ములుకు చుట్టూ ఉన్న విషయాలను నెట్టివేసింది"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "విషయాలను బూతద్దం సూచకితో కదలికలు"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
-msgid "Magnifier Position:"
-msgstr "బూతద్ద స్థానము:"
-
-#: ../panels/universal-access/zoom-options.ui.h:16
-msgid "Magnifier"
-msgstr "బూతద్దము"
-
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
-msgstr "మందం:"
-
-#: ../panels/universal-access/zoom-options.ui.h:18
-msgctxt "universal access, thickness"
-msgid "Thin"
-msgstr "సన్నం"
-
-#: ../panels/universal-access/zoom-options.ui.h:19
-msgctxt "universal access, thickness"
-msgid "Thick"
-msgstr "మందం"
-
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
-msgstr "పొడవు:"
-
-#. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
-msgstr "రంగు:"
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "కేశలు అడ్డంగా:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "సమన్వయం ఎలుక ములుకు"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
-msgid "Crosshairs"
-msgstr "క్రాస్‌హెయిర్స్"
-
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
-msgstr "నలుపుపై తెలుపు:"
-
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
-msgstr "ప్రకాశత:"
-
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
-msgstr "వ్యత్యాసం:"
-
-#. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
-msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "రంగు"
-
-#: ../panels/universal-access/zoom-options.ui.h:31
-msgctxt "universal access, color"
-msgid "None"
-msgstr "ఏదీకాదు"
-
-#: ../panels/universal-access/zoom-options.ui.h:32
-msgctxt "universal access, color"
-msgid "Full"
-msgstr "పూర్తి"
-
-#: ../panels/universal-access/zoom-options.ui.h:33
-msgctxt "universal access, brightness"
-msgid "Low"
-msgstr "తక్కువ"
-
-#: ../panels/universal-access/zoom-options.ui.h:34
-msgctxt "universal access, brightness"
-msgid "High"
-msgstr "ఎక్కువ"
-
-#: ../panels/universal-access/zoom-options.ui.h:35
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "తక్కువ"
-
-#: ../panels/universal-access/zoom-options.ui.h:36
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "అధికం"
-
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "రంగుల ప్రభావాలు:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
-msgid "Color Effects"
-msgstr "రంగుల ప్రభావాలు"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "ప్రామాణికం"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "నిర్వాహకుడు"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-#| msgid "Full Name"
-msgid "_Full Name"
-msgstr "పూర్తి నామము (_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "ఖాతా రకం (_T)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-#| msgid "Choose password at next login"
-msgid "Allow user to set a password when they next login"
-msgstr "తరువాత ప్రవేశంలో సంకేతపదాన్ని ఎన్నుకొనుటకు వాడుకరిని అనుమతించు"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "ఒక కొత్త సంకేతపదాన్ని అమర్చు"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "నిర్ధారించు (_V)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
-msgstr ""
-"మనుగడలోవున్న కేంద్రీకృత నిర్వాహిత వాడుకరి ఖాతాను ఈ పరికరంపై ఉపయోగించుటకు "
-"ఎంటర్‌ప్రైజ్ లాగిన్ అనుమతించును."
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "డొమైన్ (_D)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid ""
-"Go online to add\n"
-"enterprise login accounts."
-msgstr ""
-"ఎంటర్‌ప్రైజ్ లాగిన్ ఖాతాలను\n"
-"జతచేయుటకు ఆన్‌లైన్‌కు వెళ్ళండి."
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "వేలిముద్ర ప్రవేశం (_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
-msgid "Add User"
-msgstr "వాడుకరిని జతచేయండి"
-
-#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
-msgid "_Enroll"
-msgstr "నమోదుచేయి(_E)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
-msgid "Domain Administrator Login"
-msgstr "డొమైన్ నిర్వాహకుని ప్రవేశం"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
-msgid ""
-"In order to use enterprise logins, this computer needs to be\n"
-"enrolled in the domain. Please have your network administrator\n"
-"type their domain password here."
-msgstr ""
-"ఎంటర్‌ప్రైజ్ లాగిన్స్ వుపయోగించుటకు, ఈ కంప్యూటర్ డొమైన్ నందు ఎన్‌రోల్ "
-"కావలసివుంటుంది\n"
-"మీ నెట్వర్కు నిర్వహణాధికారి వారి డొమైన్ సంకేతపదంను యిక్కడ టైపు చేయవలెను."
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
-msgid "Administrator _Name"
-msgstr "నిర్వాహకుని పేరు (_N)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
-msgid "Administrator Password"
-msgstr "నిర్వాహకుని సంకేతపదం"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "ఎడమ బ్రొటన వ్రేలు"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "ఎడమ మధ్య వ్రేలు"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "ఎడమ ఉంగరపు వ్రేలు"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "ఎడమ చిటికెన వ్రేలు"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "కుడి బ్రొటన వ్రేలు"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "కుడి మధ్య వ్రేలు"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "కుడి ఉంగరపు వ్రేలు"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "కుడి చిటికెన వ్రేలు"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:697
-msgid "Enable Fingerprint Login"
-msgstr "వేలిముద్ర ప్రవేశాన్ని చేతనపరుచు"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "కుడి చూపుడు వ్రేలు (_R)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "ఎడమ చూపుడు వ్రేలు (_L)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "ఇతర వేలు (_O):"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"మీ వేలిముద్ర విజయవంతంగా భద్రపరుచబడింది. మీరు ఇప్పుడు మీ వేలిముద్ర "
-"చదువరి(రీడర్) ఉపయోగించి "
-"ప్రవేశించగలుగుతారు."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "వాడుకరులు"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr "వాడుకరులను జతచేయి లేదా తీసివేయి మరియు మీ సంకేతపదం మార్చు"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "ప్రవేశించు;పేరు;వేలిముద్ర;అవతారం;చిహ్నం;ముఖం;సంకేతపదం;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "లాగిన్ చరిత్ర"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-#| msgid "Changing password for"
-msgid "Change Password"
-msgstr "సంకేతపదమును మార్చు"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "మార్చు (_a)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-#| msgid "_New password"
-msgid "_Verify New Password"
-msgstr "కొత్త సంకేతపదం నిర్ధారించు (_V)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-#| msgid "_New password"
-msgid "_New Password"
-msgstr "కొత్త సంకేతపదం (_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-#| msgid "Current _password"
-msgid "Current _Password"
-msgstr "ప్రస్తుత సంకేతపదం (_P)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "వాడుకరి ఖాతాను జతచేయి"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "వాడుకరి ఖాతాను తీసివేయి"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "ప్రవేశ ఐచ్ఛికాలు"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "స్వయంచాలక ప్రవేశం (_u)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "వేలిముద్ర ప్రవేశం (_F)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "వాడుకరి ప్రతీక"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "భాష  (_L)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "చివరి ప్రవేశం"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
-msgid "Manage user accounts"
-msgstr "వాడుకరి ఖాతాలను నిర్వహించు"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
-msgid "Authentication is required to change user data"
-msgstr "వాడుకరి సమాచారాన్ని మార్చాలంటే ధృవీకరణ అవసరం"
-
-#: ../panels/user-accounts/pw-utils.c:81
-#| msgid "The new password does not contain enough different characters"
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "కొత్త సంకేతపదం పాత సకేతపదానికి వేరుగా ఉండాలి."
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "కొన్ని అక్షరాలు మరియు సంఖ్యలు మార్చుటకు ప్రయత్నించు."
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-#| msgid "Changing password for"
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "సంకేతపదం ఇంకొంచం మార్చడానికి ప్రయత్నించండి."
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "మీ వాడుకరి పేరు లేకుండా సంకేతపదంవుంటే ధృడంగావుంటుంది."
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "సంకేతపదంనందు మీ వాడుకరిపేరు లేకుండా చూసుకోండి."
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "సంకేతపదంనందు కొన్ని పదాలను వాడుకుండా చూసుకోండి."
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "సాధారణ పదాలను వాడుకుండా చూసుకోండి."
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "మనుగడలోవున్న పదాలను రీకార్డ్ చేయుకుండా చూసుకోండి."
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "మరిన్ని సంఖ్యలను ఉపయోగించుటకు ప్రయత్నించండి."
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "మరిన్ని పెద్దబడి అక్షరాలను ఉపయోగించుటకు ప్రయత్నించండి."
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "మరిన్ని చిన్నబడి అక్షరాలను ఉపయోగించుటకు ప్రయత్నించండి."
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "విరామచిహ్మాలు వంటి, ప్రత్యేక అక్షరాలు మరిన్ని ఉండునట్లు చూసుకోండి."
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "అక్షరాలు, సంఖ్యలు మరియు విరామచిహ్నాల సమ్మేళనంగా ఉండునట్లు చూసుకోండి."
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "ఒకే అక్షరాన్ని తిరిగి వాడకుండా చూసుకోండి."
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"ఒకే రకమైన అక్షరం తిరిగి వాడకుండా చూసుకోండి: మీరు అక్షరాలు, సంఖ్యలు మరియు "
-"విరామచిహ్నాలు కలిపివాడాలి."
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 లేదా abcd వంటి వరుసలను వాడకుండా చూసుకోండి."
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "మరిన్ని అక్షరాలు, సంఖ్యలు మరియు చిహ్నాలు జతచేయుటకు చూడండి."
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr "పెద్దబడి మరియు చిన్నబడి మరియు ఒకటి లేదా రెండు సంఖ్యలను కలపండి."
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr ""
-"మంచి సంకేతపదం! మరిన్ని అక్షరాలు, సంఖ్యలు మరియు విరామచిహ్నాలు జతచేస్తే మరింత "
-"దృఢమౌతుంది."
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "పటిష్టత: బలహీనం"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-#| msgid "Length:"
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "పటిష్టత: తక్కువ"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "పటిష్టత: మధ్యమం"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "పటిష్టత: మంచిది"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "పటిష్టత: ధృడమైనది"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "ధృవీకరణ విఫలమైంది"
-
-#: ../panels/user-accounts/run-passwd.c:502
 #, c-format
-msgid "The new password is too short"
-msgstr "కొత్త సంకేతపదం మరీ చిన్నగా ఉంది"
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
 
-#: ../panels/user-accounts/run-passwd.c:508
+#~ msgid "No Desktop Background"
+#~ msgstr "డెస్క్‍టాప్ నేపథ్యంలేదు"
+
+#~ msgid "Current background"
+#~ msgstr "ప్రస్తుత నేపథ్యం"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "నేపథ్యచిత్రం;తెర;డెస్క్​టాప్;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "మీ కాలిబరేషన్ పరికరంను చతురస్త్రంపై వుంచి 'ప్రారంభించు' వత్తండి"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "మీ కాలిబరేషన్ పరికరంను కాలిబరేట్ స్థానమునకు కదల్చి అప్పడు 'కొనసాగించు' వత్తండి"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "మీ కాలిబరేషన్ పరికరంను ఉపరితల స్థానమునకు కదల్చి అప్పడు 'కొనసాగించు' వత్తండి"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "లాప్‌టాప్ లిడ్ మూయి"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "ఒక అంతర్గత దోషం సంభవించినది అది రికవర్ కాలేదు."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "కాలిబరేషన్ కొరకు అవసరమైన సాధనములు సంస్థాపించబడలేదు."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "ప్రొఫైల్ జనియింప చేయలేక పోయింది"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "లక్ష్యపు వైట్‌పాయింట్ పొందలేదు."
+
+#~ msgid "Complete!"
+#~ msgstr "పూర్తయినది!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "కాలిబరేషన్ విఫలమైంది!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "మీరు కాలిబరేషన్ పరికరం తీసివేయవచ్చు"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "పురోగతినందు వున్నప్పుడు కాలిబరేషన్ పరికరంను విజ్ఞ పరచవద్దు"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "లాప్‌టాప్ తెర"
+
 #, c-format
-msgid "The new password is too simple"
-msgstr "కొత్త సంకేతపదం చాలా సరళంగా ఉంది"
+#~ msgid "%s Monitor"
+#~ msgstr "%s మానిటర్"
 
-#: ../panels/user-accounts/run-passwd.c:514
 #, c-format
-msgid "The old and new passwords are too similar"
-msgstr "పాత మరియు కొత్త సంకేతపదాలు చాలా దగ్గరగా ఉన్నాయి"
+#~ msgid "%s Scanner"
+#~ msgstr "%s స్కానర్"
 
-#: ../panels/user-accounts/run-passwd.c:517
 #, c-format
-msgid "The new password has already been used recently."
-msgstr "కొత్త సంకేతపదం ఈ మధ్యనే వాడబడింది."
+#~ msgid "%s Printer"
+#~ msgstr "%s ముద్రకం"
 
-#: ../panels/user-accounts/run-passwd.c:520
 #, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "కొత్త సంకేతపదం తప్పనిసరిగా సంఖ్యలు లేక ప్రత్యేక అక్షరాలను కలిగివుండాలి"
+#~ msgid "%s Webcam"
+#~ msgstr "%s వెబ్‌క్యామ్"
 
-#: ../panels/user-accounts/run-passwd.c:524
 #, c-format
-msgid "The old and new passwords are the same"
-msgstr "పాత మరయు కొత్త సంకేతపదాలు ఒకేవిధంగా ఉన్నాయి"
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s కొరకు రంగు నిర్వాహణ చేతనం చేయండి"
 
-#: ../panels/user-accounts/run-passwd.c:528
 #, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "మీరు మొదట ధృవీకరణమైనప్పట్టినుంచి మీ రహస్యపదము మారినది"
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s కొరకు రంగు ప్రొఫైల్స్ చూపు"
 
-#: ../panels/user-accounts/run-passwd.c:532
+#~ msgid "Not calibrated"
+#~ msgstr "కాలిబరేట్ చేయలేదు"
+
+#~ msgid "Default: "
+#~ msgstr "అప్రమేయం: "
+
+#~ msgid "Test profile: "
+#~ msgstr "పరీక్షా ప్రవర: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC ప్రవర దస్త్రమును ఎంచుకొనుము"
+
+#~ msgid "_Import"
+#~ msgstr "దిగుమతిచేయి (_I)"
+
+#~ msgid "All files"
+#~ msgstr "అన్ని దస్త్రాలు"
+
 #, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "కొత్త సంకేతపదం సరిపడినన్ని వైవిధ్య అక్షరాలను కలిగిలేదు"
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "ఫైలు యెక్కించుటలో విఫలమైంది: %s"
 
-#: ../panels/user-accounts/run-passwd.c:536
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "ప్రొఫైల్ దీనికి అప్‌లోడ్ అయింది:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "ఈ URL వ్రాయి."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "ఈ కంప్యూటర్ పునఃప్రారంభించి మీ సాధారణ ఆపరేటింగ్ సిస్టమ్ బూట్ చేయి."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "ప్రొఫైల్ సంస్థాపించుటకు URL ను మీ బ్రౌజర్ నందు టైపు చేసి దించుకోండి."
+
+#~ msgid "Save Profile"
+#~ msgstr "ప్రొఫైల్ దాయి"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "ఎంచుకున్న పరికరమునకు రంగు ప్రవరను సృష్టించు"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "కొలుస్తున్న సాధనము కనుగొనబడలేదు. దయచేసి ఆన్ ఉందా మరియు సరిగ్గా అనుసంధానమయి ఉందా చాచుకొనుము."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "కొలుస్తున్న సాధనము ప్రింటర్ ప్రొఫైలింగును సహకరించుటలేదు"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "పరికరపు రకము ప్రస్తుతము సహకరించుటలేదు."
+
+#~ msgid "Standard Space"
+#~ msgstr "ప్రామాణిక జాగా"
+
+#~ msgid "Test Profile"
+#~ msgstr "పరీక్షా ప్రొఫైల్"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "స్వయంచాలక"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "తక్కువ నాణ్యత"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "మధ్యమ నాణ్యత"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "అధిక నాణ్యత"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB అప్రమేయం"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK అప్రమేయం"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "అప్రమేయ గ్రే"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "అమ్మకందారు అందించిన ఫాక్టరీ కాలిబరేషన్ దత్తాంశం"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "ఈ ప్రొఫైల్‌తో పూర్తి-తెర ప్రదర్శన దిద్దుబాటు సాధ్యం కాదు"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "ఈ ప్రోఫైల్ యిక ఖచ్చితంగా వుండకపోవచ్చు"
+
+#~ msgid "Done"
+#~ msgstr "అయినది"
+
+#~ msgid "Upload profile"
+#~ msgstr "ప్రొఫైల్ యెక్కించు"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "ఇంటర్నెట్ అనుసంధానం కావాలి"
+
+#~ msgid "United States"
+#~ msgstr "యునైటెడ్ స్టేట్స్"
+
+#~ msgid "Germany"
+#~ msgstr "జర్మనీ"
+
+#~ msgid "France"
+#~ msgstr "ఫ్రాన్స్"
+
+#~ msgid "Spain"
+#~ msgstr "స్పెయిన్"
+
+#~ msgid "China"
+#~ msgstr "చైనా"
+
+#~ msgid "Other…"
+#~ msgstr "ఇతర ..."
+
+#~ msgid "Language"
+#~ msgstr "భాష"
+
+#~| msgid "%b %d %l:%M %p"
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
 #, c-format
-msgid "Unknown error"
-msgstr "తెలియని దోషం"
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
 
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "మీ ఖాతా అందించువారి వెబ్ చిరునామాతో సరిపోలాలి."
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "ఖాతాను జతచేయుటలో విఫలమైంది"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-#| msgid "Passwords do not match"
-msgid "Passwords do not match."
-msgstr "సంకేతపదాలు సరిపోలటం లేదు."
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr "ఖాతాని నమోదించుటలో విఫలమైంది"
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr "ఈ డొమైన్‌తో ధృవీకరించుటకు తోడ్పాటునిచ్చు మార్గంలేదు"
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr "డొమైన్ నందు జేరుటకు విఫలమైంది"
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"ఆ లాగిన్ పేరు పనిచేయలేదు.\n"
-"దయచేసి తిరిగి ప్రయత్నించండి."
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-#| msgid "Invalid password, please try again"
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"ఆ లాగిన్ సంకేతపదం పనిచేయలేదు.\n"
-"దయచేసి మరలా ప్రయత్నించండి."
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr "డొమైన్ నందు లాగిన్ అగుటకు విఫలమైంది"
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr ""
-"డొమైన్ కనుగొనలేక పోయింది. బహుశా మీరు దానిని సరిగా టైప్ చేసివుండకపోవచ్చు?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:137
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"పరికరమును యాక్సిస్ చేయుటకు మీరు అనుమతిలేదు. మీ సిస్టమ్ నిర్వహణాధికారిని "
-"సంప్రదించండి."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
-msgid "The device is already in use."
-msgstr "పరికరము ఇప్పటికే వినియోగంలో వుంది."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "An internal error occurred."
-msgstr "ఒక అంతర్గత దోషం సంభవించినది."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:217
-#: ../panels/user-accounts/um-fingerprint-dialog.c:218
-msgid "Enabled"
-msgstr "చేతనపరిచివుంది"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:266
-msgid "Delete registered fingerprints?"
-msgstr "నమోదైన వేలిముద్రలను తొలగించాలా?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:270
-msgid "_Delete Fingerprints"
-msgstr "వేలిముద్రలను తొలగించు (_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:276
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"వేలిముద్ర లాగిన్ అచేతనపరిచే నమోదైన వేలిముద్రల తొలగింపును మారు "
-"చేద్దామనుకొనుచున్నారా?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:452
-msgid "Done!"
-msgstr "అయినది!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:513
-#: ../panels/user-accounts/um-fingerprint-dialog.c:555
 #, c-format
-msgid "Could not access '%s' device"
-msgstr "'%s' పరికరాన్ని యాక్సిస్ చేయలేకపోయింది"
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:596
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
 #, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "'%s' పరికరముపైన వేలి కాప్చరును ప్రారంభించలేక పోయింది"
+#~| msgid "%d x %d (%s)"
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:647
-msgid "Could not access any fingerprint readers"
-msgstr "ఎటువంటి వేలిముద్ర చదువరులను యాక్సెస్ చేయలేకపోతుంది"
+#~ msgid "∶"
+#~ msgstr "∶"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:648
-msgid "Please contact your system administrator for help."
-msgstr "సహాయము కొరకు దయచేసి మీ వ్యవస్థ నిర్వాహకుడిని సంప్రదించండి."
+#~| msgid "Firewall _Zone"
+#~ msgid "Time _Zone"
+#~ msgstr "సమయ క్షేత్రం (_Z)"
 
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:731
+#~ msgid "24-hour"
+#~ msgstr "24-గంటలు"
+
+#~ msgid "AM / PM"
+#~ msgstr "తొలి / మలి"
+
+#~| msgid "Close"
+#~ msgid "Lid Closed"
+#~ msgstr "లిడ్ మూసివేయి"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Mirrored"
+#~ msgstr "మిర్రర్డ్"
+
+#~ msgid "Off"
+#~ msgstr "ఆఫ్"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "కలగలిపిన ప్రదర్శనలు అమర్చు"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "ప్రదర్శనలను పట్టిలాగుతూ వాటిని తిరిగిసర్దవచ్చు"
+
+#~| msgid "Size:"
+#~ msgid "Size"
+#~ msgstr "పరిమాణము"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "ఈ ప్రదర్శనపై కార్యకలాపాల అవలోకనం మరియు పై పట్టీ చూపుము"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "అదనపు పనిస్థలం సృష్టించుటకు ఈ ప్రదర్శనను వేరొక దానితో కలుపుము"
+
+#~| msgid "Orientation"
+#~ msgid "Presentation"
+#~ msgstr "సమర్పణ"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "స్లైడ్‌షో మరియు మాధ్యమం మాత్రమే చూపుము"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "రెండు ప్రదర్శనలపై మీరు దర్శించునది చూపుము"
+
+#~| msgid "_Turn On"
+#~ msgid "Turn Off"
+#~ msgstr "ఆఫ్ చేయి"
+
+#~| msgid "Panel to display"
+#~ msgid "Don't use this display"
+#~ msgstr "ఈ ప్రదర్శనను ఉపయోగించవద్దు"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "తెర సమాచారమును పొందలేక పోయింది"
+
+#~| msgid "Mirrored Displays"
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "కలగలిపిన ప్రదర్శనలు అమర్చు (_A)"
+
+#~ msgid "Wayland"
+#~ msgstr "వేలాండ్"
+
+#~ msgid "Unknown"
+#~ msgstr "తెలియని"
+
 #, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"వేలిముద్ర ప్రవేశాన్ని చేతనపరచుటకు, '%s' పరికరము ఉపయోగించి మీ వేలిముద్రలలో "
-"ఒకటి "
-"భద్రపరుచవలసివుంటుంది."
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-బిట్"
 
-#: ../panels/user-accounts/um-fingerprint-dialog.c:738
-msgid "Selecting finger"
-msgstr "ఎంచుకొనుతున్న వేలు"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:739
-msgid "Enrolling fingerprints"
-msgstr "వేలిముద్రలను నమోదుచేస్తున్నది"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "ఈ వారం"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "ఆఖరి వారం"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-#| msgid "%b %d %Y"
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-#| msgid "%b %d %Y"
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
 #, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
+#~ msgid "%d-bit"
+#~ msgstr "%d-బిట్"
 
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:631
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
+#~ msgid "Ask what to do"
+#~ msgstr "ఏమి చేయాలో అడుగు"
 
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:635
+#~ msgid "Do nothing"
+#~ msgstr "ఏమి చేయవద్దు"
+
+#~ msgid "Open folder"
+#~ msgstr "సంచయం తెరువు"
+
+#~ msgid "Other Media"
+#~ msgstr "ఇతర మాధ్యమం"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ఆడియో సీడీల కొరకు ఒక అనువర్తనాన్ని ఎంచుకోండి"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "వీడియో డీవీడీల కొరకు ఒక అనువర్తనాన్ని ఎంచుకోండి"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "సంగీత ఆటకం అనుసంధానమైనప్పుడు నడుపుటకు ఒక అనువర్తనం ఎంచుకోండి"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "కెమేరా అనుసంధానమైనప్పుడు నడుపుటకు ఒక అనువర్తనము ఎంచుకోండి"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "సాఫ్ట్‍వేర్ సీడీల కొరకు ఒక అనువర్తనాన్ని ఎంచుకోండి"
+
+#~ msgid "audio DVD"
+#~ msgstr "ఆడియో DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "ఖాళీ బ్లూ-రే డిస్కు"
+
+#~ msgid "blank CD disc"
+#~ msgstr "ఖాళీ CD డిస్కు"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "ఖాళీ DVD డిస్కు"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "ఖాళీ HD DVD డిస్కు"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "బ్లూ-రే వీడియో డిస్కు"
+
+#~ msgid "e-book reader"
+#~ msgstr "ఈ-పుస్తకం చదువరి"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD వీడియో డిస్కు"
+
+#~ msgid "Picture CD"
+#~ msgstr "చిత్రల సీడీ"
+
+#~ msgid "Super Video CD"
+#~ msgstr "సూపర్ వీడియో సీడీ"
+
+#~ msgid "Video CD"
+#~ msgstr "వీడియో సీడీ"
+
+#~ msgid "Overview"
+#~ msgstr "అవలోకనం"
+
 #, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
+#~ msgid "Version %s"
+#~ msgstr "రూపాంతరం %s"
 
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "సెషన్ చేతనమైంది"
+#~ msgid "Base system"
+#~ msgstr "ప్రాధమిక వ్యవస్థ"
 
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "సెషన్ ప్రారంభించబడింది"
+#~ msgid "Disk"
+#~ msgstr "డిస్కు"
 
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "దయచేసి వేరొక సంకేతపదాన్ని ఎన్నుకోండి."
+#~| msgid "Checking for Updates"
+#~ msgid "Check for updates"
+#~ msgstr "నవీకరణల కొరకు పరిశీలించుము"
 
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "దయచేసి మీ ప్రస్తుత సంకేతపదాన్ని మరలా టైపు చేయండి."
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "స్క్రీన్‌షాట్‌ను $PICTURES కు దాయి"
 
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "సంకేతపదం మార్చబడదు"
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "విండో యొక్క స్క్రీన్‌షాట్‌ను $PICTURES కు దాయి"
 
-#: ../panels/user-accounts/um-password-dialog.c:286
-#| msgid "The passwords do not match"
-msgid "The passwords do not match."
-msgstr "సంకేతపదాలు సరిపోలలేదు."
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "ప్రాంతము యొక్క స్క్రీన్‌షాట్‌ను $PICTURES కు దాయి"
 
-#: ../panels/user-accounts/um-photo-dialog.c:219
-msgid "Browse for more pictures"
-msgstr "మరిన్ని చిత్రముల కొరకు అన్వేషించు"
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "తెరపట్టును క్లిప్‌బోర్డునకు నకలుచేయి"
 
-#: ../panels/user-accounts/um-photo-dialog.c:453
-msgid "Disable image"
-msgstr "బొమ్మని అచేతనపరుచు"
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "క్లిప్ బోర్డు ఒక విండో యొక్క ఒక తెర ఛాయాచిత్రం నకలు"
 
-#: ../panels/user-accounts/um-photo-dialog.c:471
-msgid "Take a photo…"
-msgstr "ఒక ఫొటో తీయండి…"
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "క్లిప్ బోర్డు అనేది ఒక ప్రాంతం యొక్క తెర ఛాయాచిత్రం నకలు"
 
-#: ../panels/user-accounts/um-photo-dialog.c:489
-msgid "Browse for more pictures…"
-msgstr "మరిన్ని చిత్రముల కొరకు అన్వేషించు..."
+#~ msgid "Record a short screencast"
+#~ msgstr "పొట్టి తెరపట్టును రికార్డ్ చేయి"
 
-#: ../panels/user-accounts/um-photo-dialog.c:713
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "సవరణిలు-మాత్రమే తరువాతి మూలానికి మారు"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "అడ్డదారి;పునరావృతం;బ్లింక్;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "అనురూపిత అడ్డదారి"
+
+#~ msgid "_Name:"
+#~ msgstr "పేరు (_N):"
+
+#~ msgid "_Delay:"
+#~ msgstr "ఆలస్యం(_D):"
+
+#~ msgid "_Speed:"
+#~ msgstr "వేగం(_S):"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "పొట్టి"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "నెమ్మది"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "పొడవు"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "వేగము"
+
+#~ msgid "S_peed:"
+#~ msgstr "వేగం (_p):"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "అడ్డదారిని తీసివేయి"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "ఒక షార్ట్ కట్ ని సరిచేయుటకు,రో పై క్లిక్ చేసి మరియు కొత్త కీలను నొక్కుము లేదా బ్యాక్ స్పేస్  నొక్కుము "
+#~ "చెరుపుటకు"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<తెలియని చర్య>"
+
 #, c-format
-msgid "Used by %s"
-msgstr "%s చేత వాడబడింది"
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "అడ్డదారి \"%s\" ఉపయోగించబడదు ఎంచేతంటే ఈ కీ ఉపయోగించి దీనిని టైపుచేయుట అసాధ్యం అవుతుంది.\n"
+#~ "Control,Alt లేదా అదే సమయంలో Shift వంటి కీలతో దయచేసి ప్రయత్నించండి."
 
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "ఈ రకమైన డొమైన్‌కు స్వయంచాలకంగా జేరలేము"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
 #, c-format
-msgid "No such domain or realm found"
-msgstr "అటువంటి డొమైన్ లేదా రియాల్మ్ కనుగొనబడలేదు"
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "\"%s\" అను అడ్డదారి ఇప్పటికే\n"
+#~ " \"%s\"కొరకు వినియోగంలో వుంది"
 
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
 #, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s వలె %s డొమైన్ వద్ద లాగిన్ కాలేకపోయింది"
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "మీరు అడ్డదారిని \"%s\"కు తిరిగిఅప్పగిస్తే, \"%s\" అడ్డదారి అచేతనము చేయబడుతుంది."
 
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
-msgstr "సంకేతపదం తప్పు, మరలా ప్రయత్నించండి"
+#~ msgid "_Reassign"
+#~ msgstr "తిరిగిఅప్పగించు (_R)"
 
-#: ../panels/user-accounts/um-realm-manager.c:832
 #, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "%s డొమైన్‌కు అనుసంధానం కాలేకపోయింది: %s"
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "\"%s\" లఘువు అనునది \"%s\" లఘువుతో కలిసివుంది. మీరు దానిని స్వయంచాలకంగా \"%s\" కు "
+#~ "అమర్చాలని అనుకుంటున్నారా?"
 
-#: ../panels/user-accounts/um-user-panel.c:198
-msgid "Other Accounts"
-msgstr "ఇతర ఖాతాలు"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "Failed to delete user"
-msgstr "వాడుకరిని తొలగించుటలో విఫలమైంది"
-
-#: ../panels/user-accounts/um-user-panel.c:482
-msgid "You cannot delete your own account."
-msgstr "మీరు మీ స్వంత ఖాతాను తొలగించలేరు."
-
-#: ../panels/user-accounts/um-user-panel.c:491
 #, c-format
-msgid "%s is still logged in"
-msgstr "%s ఇంకా ప్రవేశించేవున్నారు"
+#~| msgid ""
+#~| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~| "disabled."
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" ప్రస్తుతం ఇప్పుడు \"%s\" తో కలిసివుంది, మీరు ముందుకు కదిలితే ఈ లఘువు అచేతనం "
+#~ "చేయబడును."
 
-#: ../panels/user-accounts/um-user-panel.c:495
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"ప్రవేశించివున్న వాడుకరిని తొలగించినచో వ్యవస్థను అస్థిరస్థితిలో "
-"వదిలివేయబడవచ్చు."
+#~| msgid "_Reassign"
+#~ msgid "_Assign"
+#~ msgstr "అప్పగించు (_A)"
 
-#: ../panels/user-accounts/um-user-panel.c:504
+#~| msgid "Test Your _Settings"
+#~ msgid "Test Your Settings"
+#~ msgstr "మీ అమరికలను పరీక్షించండి"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "నెమ్మది"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "రెండు-నొక్కుల కాలము"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "వేగము"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "ఎడమ (_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "కుడి (_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "సూచిక వేగం (_P)"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "నెమ్మది"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "వేగము"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "నెమ్మది"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "వేగము"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "రెండు-వేళ్ళ జరుపుట (_f)"
+
+#~| msgid "_Edge scrolling"
+#~ msgid "_Natural scrolling"
+#~ msgstr "సాధారణ స్క్రాలింగ్ (_N)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "ఐదు నొక్కులు, GEGL సమయం!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "రెండు నొక్కులు, ప్రాథమిక బటన్"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "ఒక నొక్కు, ప్రాధమిక బటన్"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "రెండు నొక్కులు, మధ్య బటన్"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "ఒక నొక్కు, మధ్య బటన్"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "రెండు-నొక్కులు, రెండవ బటన్"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "ఒక నొక్కు, రెండవ బటన్"
+
+#~ msgid "Network proxy"
+#~ msgstr "నెట్‌వర్క్ ప్రోక్సీ"
+
 #, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "%s యొక్క దస్త్రాలను ఉంచాలనుకుంటున్నారా?"
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
 
-#: ../panels/user-accounts/um-user-panel.c:508
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"వాడుకరి ఖాతాను తొలగించునపుడు నివాస సంచయం,మెయిల్ స్పూల్ మరియు తాత్కాలిక "
-"దస్త్రాలను ఉంచడం కుదురుతుంది"
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "ఈ రూపాంతరంతో సిస్టమ్ నెట్వర్కు సేవలు సారూప్యతను కలిగిలేవు."
 
-#: ../panels/user-accounts/um-user-panel.c:511
-msgid "_Delete Files"
-msgstr "దస్త్రాలను తొలగించు (_D)"
+#~ msgid "page 1"
+#~ msgstr "పుట 1"
 
-#: ../panels/user-accounts/um-user-panel.c:512
-msgid "_Keep Files"
-msgstr "దస్త్రాలను ఉంచు (_K)"
+#~ msgid "page 2"
+#~ msgstr "పుట 2"
 
-#: ../panels/user-accounts/um-user-panel.c:564
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "ఖాతా అచేతనమైవుంది"
+#~ msgid "automatic"
+#~ msgstr "స్వయంచాలక"
 
-#: ../panels/user-accounts/um-user-panel.c:572
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "తరువాతి ప్రవేశంలో అమర్చబడుతుంది"
+#~ msgid "WEP"
+#~ msgstr "WEP"
 
-#: ../panels/user-accounts/um-user-panel.c:575
-msgctxt "Password mode"
-msgid "None"
-msgstr "ఏదీకాదు"
+#~ msgid "WPA"
+#~ msgstr "WPA"
 
-#: ../panels/user-accounts/um-user-panel.c:624
-msgid "Logged in"
-msgstr "లాగిన్ అయెను"
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
 
-#: ../panels/user-accounts/um-user-panel.c:1072
-msgid "Failed to contact the accounts service"
-msgstr "ఖాతాల సేవను సంప్రదించుటలో విఫలమైంది"
+#~ msgid "Enterprise"
+#~ msgstr "ఎంటర్‌ప్రైజ్"
 
-#: ../panels/user-accounts/um-user-panel.c:1074
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "దయచేసి ఖాతాసేవ స్థాపించబడి మరియు చేతనపరచివుండునట్లు చూసుకోండి."
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "ఏదీకాదు"
 
-#: ../panels/user-accounts/um-user-panel.c:1115
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"మార్పులు చేయడానికి,\n"
-"మొదటగా * ప్రతీకను నొక్కండి"
+#~ msgid "Never"
+#~ msgstr "ఎన్నటికీకాదు"
 
-#: ../panels/user-accounts/um-user-panel.c:1153
-msgid "Create a user account"
-msgstr "వాడుకరిని ఖాతాను సృష్టించు"
+#~ msgid "Today"
+#~ msgstr "నేడు"
 
-#: ../panels/user-accounts/um-user-panel.c:1164
-#: ../panels/user-accounts/um-user-panel.c:1453
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"ఒక వాడుకరిని సృష్టించుటకు,\n"
-"ముందుగా * ప్రతీకను నొక్కండి"
+#~ msgid "Yesterday"
+#~ msgstr "నిన్న"
 
-#: ../panels/user-accounts/um-user-panel.c:1174
-msgid "Delete the selected user account"
-msgstr "ఎంపికచేసిన వాడుకరి ఖాతాను తొలగించు"
-
-#: ../panels/user-accounts/um-user-panel.c:1186
-#: ../panels/user-accounts/um-user-panel.c:1458
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"ఎంచుకున్న వాడుకరిని తొలగించుటకు,\n"
-"ముందుగా * ప్రతీకను నొక్కండి"
-
-#: ../panels/user-accounts/um-user-panel.c:1368
-msgid "My Account"
-msgstr "నా ఖాతా"
-
-#: ../panels/user-accounts/um-utils.c:567
 #, c-format
-#| msgid "A user with the username '%s' already exists"
-msgid "A user with the username '%s' already exists."
-msgstr "'%s' వాడుకరిపేరుతో ఒక వాడుకరి ఇదివరకే ఉన్నారు."
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
 
-#: ../panels/user-accounts/um-utils.c:571
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "ఏదీకాదు"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "బలహీనం"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "సరే"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "మంచిది"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "బాగుంది"
+
+#~ msgid "Identity"
+#~ msgstr "గుర్తింపు"
+
+#~ msgid "Server"
+#~ msgstr "సేవిక"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS సేవికను తొలగించు"
+
+#~ msgid "Delete Route"
+#~ msgstr "రౌట్ తొలగించు"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "ఏదీకాదు"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit Passphrase"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dynamic WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Personal"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA మరియు WPA2 ఎంటర్‌ప్రైజ్"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "ట్విస్టెడ్ పెయిర్ (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "ఎటాచ్‌మెంట్ యూనిట్ యింటర్ఫేస్ (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "మాధ్యమం యిండిపెండెంట్ యింటర్ఫేస్ (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "యితర వాడుకరులకు అందుబాటులో వుంచు (_u)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "ఫైర్‌వాల్ క్షేత్రం (_Z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "అప్రమేయం"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "క్షేత్రము అనుసంధానము యొక్క విశ్వాస స్థాయిను నిర్వచించును"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "అనుసంధానం కూర్పరి తెరువలేక పోయింది"
+
+#~ msgid "New Profile"
+#~ msgstr "కొత్త ప్రొఫైల్"
+
+#~ msgid "Bond"
+#~ msgstr "బాండ్"
+
+#~ msgid "Team"
+#~ msgstr "జట్టు"
+
+#~ msgid "Bridge"
+#~ msgstr "బ్రిడ్జ్"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "VPN ప్లగిన్స్ లోడు చేయలేక పోయింది"
+
+#~ msgid "Import from file…"
+#~ msgstr "ఫైలునుండి దిగుమతిచేయి..."
+
+#~ msgid "Add Network Connection"
+#~ msgstr "నెట్వర్కు అనుసంధానం జతచేయి"
+
+#~ msgid "_Reset"
+#~ msgstr "తిరిగివుంచు (_R)"
+
+#~ msgid "_Forget"
+#~ msgstr "మరచిపో (_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "ఈ నెట్వర్కుకు అమరికలను తిరిగివుంచు, సంకేతపదములతో సహా, అయితే దీనిని అబీష్ట నెట్వర్కు వలె గుర్తించు"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "ఈ నెట్వర్కునకు సంభందించిన అన్ని వివరాలను తీసివేయి మరియు స్వయంచాలకంగా అనుసంధానించుటకు "
+#~ "ప్రయత్నించవద్దు"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN అనుసంధానంను దిగుమతి చేయలేదు"
+
 #, c-format
-#| msgid "The username is too long"
-msgid "The username is too long."
-msgstr "వాడుకరిపేరు మరీ పెద్దగా ఉంది."
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "ఫైలు '%s' చదువబడలేదు లేదా గుర్తించిన VPN అనుసంధాన సమాచారం కలిగిలేదు\n"
+#~ "\n"
+#~ "దోషం: %s."
 
-#: ../panels/user-accounts/um-utils.c:574
-#| msgid "The username cannot start with a '-'"
-msgid "The username cannot start with a '-'."
-msgstr "వాడుకరిపేరు '-' తో మొదలవ్వకూడదు."
+#~ msgid "Select file to import"
+#~ msgstr "దిగుమతి చేయుటకు ఫైలును యెంపికచేయి"
 
-#: ../panels/user-accounts/um-utils.c:577
-#| msgid ""
-#| "The username must only consist of:\n"
-#| " ➣ letters from the English alphabet\n"
-#| " ➣ digits\n"
-#| " ➣ any of the characters '.', '-' and '_'"
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr ""
-"వాడుకరిపేరు చిన్న మరియు పెద్దబడి అక్షరాలను a-z వరకు, అంకెలు మరియు '.', '-', "
-"'_' వీటిలో ఏదైనా కలిగివుండవచ్చు."
-
-#: ../panels/user-accounts/um-utils.c:581
-msgid "This will be used to name your home folder and can't be changed."
-msgstr ""
-"మీ నివాస సంచయం పేరు పెట్టుటకు యిది వుపయోగించబడును మరియు దీనిని మార్చలేము."
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:827
-#| msgid "%b %d %Y"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:831
-#| msgid "%b %d %Y"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#: ../panels/wacom/button-mapping.ui.h:1
-msgid "Map Buttons"
-msgstr "మ్యాప్ బటన్లు"
-
-#: ../panels/wacom/button-mapping.ui.h:2
-msgid "Map buttons to functions"
-msgstr " కార్యాలను పటం మీటలు"
-
-#: ../panels/wacom/button-mapping.ui.h:3
-#| msgid ""
-#| "To edit a shortcut, click the row and hold down the new keys or press "
-#| "Backspace to clear."
-msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
-"shortcut button and hold down the new keys or press Backspace to clear."
-msgstr ""
-"ఒక షార్ట్ కట్ ని సరిచేయుటకు, \"కీస్ట్రోక్ పంపు\" చర్య ఎంచుకొని, కీబోర్డ్ "
-"లఘువు బటన్ వత్తండి మరియు కొత్త కీలను పట్టివుంచండి లేదా శుబ్రంచేయుటకు "
-"బ్యాక్‌స్పేస్ వత్తండి."
-
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
-msgid ""
-"Please tap the target markers as they appear on screen to calibrate the "
-"tablet."
-msgstr ""
-"తాము మాత్ర బలాన్ని నిర్ణయించు కు తెరపైన కనిపించే విధంగా లక్ష్యాన్ని "
-"గుర్తులను పొందేల చెయ్యండి."
-
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
-msgstr "MIS-క్లిక్ పునఃప్రారంభించి, కనుగొనబడింది ..."
-
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "పైకి"
-
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "క్రిందికి"
-
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "ఏదీకాదు"
-
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "కీస్ట్రోక్ పంపు"
-
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "మానిటర్ మార్చు"
-
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "తెర-పై సహాయం చూపు"
-
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "అవుట్‌పుట్:"
-
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "రూప నిష్పత్తి ఉంచు (letterbox):"
-
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "ఒంటరి మానిటర్‌కు మాప్‌చేయి"
-
-#: ../panels/wacom/cc-wacom-nav-button.c:88
 #, c-format
-msgid "%d of %d"
-msgstr "%d యొక్క%d"
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "\"%s\" పేరుతో ఫైలు యిప్పటికే వుంది."
 
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "మ్యాపింగును ప్రదర్శించు"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
-msgstr "బటన్"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr "వ్యాకం టాబ్లెట్"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr ""
-"గ్రాఫిక్స్ టాబ్లెట్ల కొరకు బటన్ మాపింగ్ మరియు స్టైలస్ సున్నితత్వం సర్దుబాటు "
-"చేయును"
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "ట్యాబ్లెట్;వాకం;శ్టైలస్;ఇరేసర్;మౌజ్;"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "టాబ్లెట్ (ఖచ్ఛితం)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "టచ్‌ప్యాడ్ (సాపేక్షమైనది)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "టాబ్లెట్ ప్రాధాన్యతలు"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "No tablet detected"
-msgstr "ఏ టాబ్లెట్ కనిపెట్టబడలేదు"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "మీ వాకం ట్యాబ్లెట్ ను దయచేసి ప్లగిన్ లేదా ఆన్ చేయుము "
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr "బ్లూటూత్ అమరికలు"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Map to Monitor…"
-msgstr "మానిటర్‌కు మాప్ చేయి ..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map Buttons…"
-msgstr "మ్యాప్ బటన్లు..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr "ప్రదర్శన విభాజకతను సవరించండి"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust mouse settings"
-msgstr "మౌస్ అమరికలు సర్దుబాటుచేయి"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Tracking Mode"
-msgstr "ట్రాకింగ్ మోడ్"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Left-Handed Orientation"
-msgstr "ఎడమ-చేతివైపు సర్దుబాటు"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-msgid "Left Ring"
-msgstr "ఎడమ వలయం"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
 #, c-format
-msgid "Left Ring Mode #%d"
-msgstr "ఎడమ వలయం రీతి #%d"
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "మీరు దాయుచున్న VPN అనుసంధానంతో %s ను పునఃస్థాపించాలని అనుకొనుచున్నారా?"
 
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-msgid "Right Ring"
-msgstr "కుడి  వలయం"
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN అనుసంధానం ఎగుమతి చేయలేదు"
 
-#: ../panels/wacom/gsd-wacom-device.c:1104
 #, c-format
-msgid "Right Ring Mode #%d"
-msgstr "కుడి  వలయం రీతి #%d"
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN అనుసంధానం '%s' అనునది %sకు యెగుమతి కాలేదు.\n"
+#~ "\n"
+#~ "దోషం: %s."
 
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-msgid "Left Touchstrip"
-msgstr "ఎడమ టచ్‌స్ట్రిప్"
+#~| msgid "Export VPN connection..."
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN అనుసంధానం ఎగుమతిచేయి"
 
-#: ../panels/wacom/gsd-wacom-device.c:1157
+#~ msgid "Bond slaves"
+#~ msgstr "బాండ్ స్లేవ్స్"
+
+#~ msgid "(none)"
+#~ msgstr "(ఏదీకాదు)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "బ్రిడ్జ్ స్లేవ్స్"
+
+#~ msgid "never"
+#~ msgstr "ఎన్నటికీకాదు"
+
+#~ msgid "today"
+#~ msgstr "నేడు"
+
+#~ msgid "yesterday"
+#~ msgstr "నిన్న"
+
+#~ msgid "Last used"
+#~ msgstr "చివరిగా వాడినది"
+
 #, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "ఎడమ టచ్ స్ట్రిప్ రీతి #%d"
+#~ msgid "Profile %d"
+#~ msgstr "ప్రొఫైల్ %d"
 
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-msgid "Right Touchstrip"
-msgstr "కుడి టచ్‌స్ట్రిప్"
+#~| msgid "Bridge slaves"
+#~ msgid "Team slaves"
+#~ msgstr "టీమ్ స్లేవ్స్"
 
-#: ../panels/wacom/gsd-wacom-device.c:1188
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "మీరు వైర్‌లెస్ కాక యింకా వేరే యింటర్నెట్ అనుసంధానం కలిగివుంటే, మీరు మీ యింటర్నెట్ అనుసంధానం "
+#~ "పంచుకొనుటకు వైర్‌లెస్ హాట్‌స్పాట్ అమర్చవచ్చు."
+
 #, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "కుడి టచ్ స్ట్రిప్ రీతి #%d"
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "వైర్‌లెస్ హాట్‌స్పాట్ల మధ్యన మారుట అనునది మీ అనుసంధానమును <b>%s</b> నుండి తెంచును."
 
-#: ../panels/wacom/gsd-wacom-device.c:1214
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "హాట్‌స్పాట్ క్రియాశీలముగా వున్నప్పుడు మీ వైర్‌లెస్ ద్వారా యింటర్నెట్‌ను యాక్సెస్ చేయుట సాధ్యంకాదు."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "హాట్ స్పాట్‌ను ఆపి ఏ వినియోగదారుడినైనా తెంచవచ్చునా?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "హాట్ స్పాట్‌ను ఆపివేయి (_S)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "హాట్‌స్పాట్ వలె వుపయోగించుటకు వ్యవస్థ విధానం నిషేధించును"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "హాట్‌స్పాట్ రీతికి వైర్‌లెస్ పరికరం తోడ్పాటునిచ్చుటలేదు"
+
+# c-format
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "ఎంపికచేసిన నెట్వర్కు కొరకు నెట్వర్కు వివరాలు, సంకేతపదములతో సహా మలచుకొనిన ఆకృతీకరణ కోల్పోవును."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "మరచిపో (_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "ఆకృతీకరణ URL అందివ్వనప్పుడు వెబ్ ప్రోక్సీ ఆటోడిస్కవరీ వుపయోగించబడును."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "నమ్మదగని పబ్లిక్ నెట్వర్కులకు దీనిని సిఫార్సు చేయడంలేదు."
+
+#~ msgid "Proxy"
+#~ msgstr "ప్రోక్సీ"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "ఏదీకాదు"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "మానవీయం"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "స్వయంచాలకం"
+
+#~ msgid "Add Device"
+#~ msgstr "పరికరాన్ని జతచేయండి"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN రకం"
+
+#~ msgid "Group Name"
+#~ msgstr "గుంపు పేరు"
+
+#~ msgid "Group Password"
+#~ msgstr "గుంపు సంకేతపదం"
+
+#~ msgid "details"
+#~ msgstr "వివరాలు"
+
+#~ msgid "Show P_assword"
+#~ msgstr "సంకేతపదాన్ని చూపించు (_a)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "ఇతర వాడుకరులకు అందుబాటులో వుంచు"
+
+#~ msgid "identity"
+#~ msgstr "గుర్తింపు"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "స్వయంచాలక (DHCP) చిరునామాలు మాత్రమే"
+
+#~ msgid "Link-local only"
+#~ msgstr "లింక్-లోకల్ మాత్రమే"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "పొందిన రౌట్లను స్వయంచాలకంగా విస్మరించు (_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "క్లోన్డ్ MAC చిరునామా (_C)"
+
+#~ msgid "hardware"
+#~ msgstr "హార్డువేర్"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "ఈ అనుసంధానం కొరకు అమరికలను వాటి అప్రమేయాలకు వుంచండి, అయితే అభీష్ట అనుసంధానంగా గుర్తుంచుకో."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "ఈ నెట్వర్కునకు సంభందించిన అన్ని వివరాలను తీసివేయి మరియు స్వయంచాలకంగా దానికి అనుసంధానించుటకు "
+#~ "ప్రయత్నించవద్దు."
+
+#~ msgid "reset"
+#~ msgstr "తిరిగివుంచు"
+
+#~ msgid "Hardware"
+#~ msgstr "హార్డ్‍వేర్"
+
+#~ msgid "_History"
+#~ msgstr "చరిత్ర (_H)"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Wi-Fi నెట్వర్కునకు అనుసంధానమగుటను స్విచ్ ఆఫ్ చేయి"
+
+#~ msgid "Connected Devices"
+#~ msgstr "అనుసంధానమైవున్న పరికరాలు"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "ఎడ్-హాక్"
+
+#~ msgid "Infrastructure"
+#~ msgstr "ఆకృతి"
+
+#~ msgid "Status unknown"
+#~ msgstr "స్థితి తెలియదు"
+
+#~ msgid "Unmanaged"
+#~ msgstr "అస్థవ్యస్థ"
+
+#~ msgid "Unavailable"
+#~ msgstr "అందుబాటులోలేదు"
+
+#~ msgid "Connecting"
+#~ msgstr "అనుసంధానిస్తోంది"
+
+#~ msgid "Disconnecting"
+#~ msgstr "అననుసంధానిస్తున్నది"
+
+#~ msgid "Connection failed"
+#~ msgstr "అనుసంధానం విఫలమైంది"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "స్థితి తెలియదు (జాడలేదు)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "స్వరూపణం విఫలమైంది"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "ఐపీ స్వరూపణం విఫలమైంది"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "ఐపీ స్వరూపణం కాలంచెల్లినది"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "రహస్యాలు అవసరమైనవి, అయితే అందించబడలేదు"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1X సప్లికెంట్ అనుసంధానంపోయింది"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1X సప్లికెంట్ ఆకృతీకరణ విఫలమైంది"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1X సప్లికెంట్ విఫలమైంది"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "ధృవీకరణకు 802.1X సప్లికెంట్ చాలా సమయం తీసుకొంది"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "ప్రారంభమవుటకు PPP సేవ విఫలమైంది"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "పిపిపి సేవ అననుసంధానించబడింది"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP విఫలమైంది"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "ప్రారంభమగుటకు DHCP క్లైంట్ విఫలమైంది"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP కక్షిదారు దోషం"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP కక్షిదారు విఫలమైంది"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "ప్రారంభమగుటకు భాగస్వామ్య అనుసంధానం విఫలమైంది"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "భాగస్వామ్య అనుసంధాన సేవ విఫలమైంది"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "ప్రారంభమగుటకు AutoIP సేవ విఫలమైంది"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "స్వయంఐపీ సేవ దోషం"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "స్వయంఐపీ సేవ విఫలమైంది"
+
+#~ msgid "Line busy"
+#~ msgstr "లైన్ రద్దీగా వుంది"
+
+#~ msgid "No dial tone"
+#~ msgstr "డైల్ టోన్ లేదు"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "ఏ వాహకం ఏర్పరచలేక పోయింది"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "డయిలింగ్ అభ్యర్ధన కాలం మించినది"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "డయిలింగ్ యత్నం విఫలమైంది"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "మోడెమ్ ఆరంభించుటలో విఫలమైంది"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "తెలిపిన APNను యెంపికచేయుటకు విఫలమైంది"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "నెట్వర్కుల కొరకు అన్వేషించుటలేదు"
+
+#~ msgid "Network registration denied"
+#~ msgstr "నెట్‌వర్క్ నమోదు తిరస్కరించబడింది"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "నెట్వర్కు నమోదీకరణ సమయం మించినది"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "అభ్యర్ధించిన నెట్వర్కుతో నమోదగుటకు విఫలమైంది"
+
+#~ msgid "PIN check failed"
+#~ msgstr "పిన్ పరిశీలన విఫలమైంది"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "పరికరంకు ఫర్మువేర్ బహుశా దొరకట్లేదు"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "అనుసంధానం అదృశ్యమైంది"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "ఇప్పటికే వున్న అనుసంధానం పరిగణించడమైంది"
+
+#~ msgid "Modem not found"
+#~ msgstr "మోడెమ్ కనపడలేదు"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "బ్లూటూత్ అనుసంధానం విఫలమైంది"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "సిమ్ పిన్ అవసరం"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk అవసరమైంది"
+
+#~ msgid "SIM wrong"
+#~ msgstr "సిమ్ తప్పు"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "అనుసంధానించిన రీతిని యిన్ఫీబాండ్ పరికరం తోడ్పాటునీయటులేదు"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "అనుసంధానం ఆధారం విఫలమైంది"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "కేబుల్ తీసివేయబడింది"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "ధృవీకరణపత్ర అధికారికం ధృవీకరణపత్రం యెంచుకోబడలేదు"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ " ధృ‌వీకరణపత్ర ఆధికారిక (CA) ధృవీకరణపత్రం వుపయోగించుట లేదు సురక్షితం కాని అనుసంధానములనందు, "
+#~ "రోగ్ Wi-Fi నెట్వర్కులకు కారణమగును. మీరు ధృవీకరణపత్ర అధికారిక ధృవీకరణపత్రం యెంచుకోవాలని "
+#~ "అనుకొనుచున్నారా?"
+
+#~ msgid "Ignore"
+#~ msgstr "విస్మరించు"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA ధృవీకరణపత్రం యెంపికచేయి"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, లేదా PKCS#12 వ్యక్తిగత కీలు (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER లేదా PEM ధృవీకరణపత్రాలు (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ఫైళ్ళు (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "ఈ సంకేతపదం కొరకు ప్రతిసారి అడుగు (_k)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "ఎన్క్రిప్టుకాని వ్యక్తిగత కీలు సురిక్షితంకావు"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "ఎంపికచేసిన వ్యక్తిగత కీ సంకేతపదంచే రక్షించబడుతున్నట్లు అనిపించుటలేదు. దీని వలన మీ రక్షణ "
+#~ "ఆనవాళ్ళు రాజీపడవచ్చు. దయచేసి సంకేతపదంతో-రక్షితమగు వ్యక్తిగత కీ యెంపికచేయండి.\n"
+#~ "\n"
+#~ "(మీరు మీ వ్యక్తిగత కీను openssl తో సంకేతపద-రక్షితం చేయవచ్చు)"
+
+#~| msgid "Choose your personal certificate..."
+#~ msgid "Choose your personal certificate"
+#~ msgstr "మీ వ్యక్తిగత ధృవీకరణపత్రం యెంపికచేయి"
+
+#~| msgid "Choose your private key..."
+#~ msgid "Choose your private key"
+#~ msgstr "మీ వ్యక్తిగత కీ యెంపికచేయి"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "నన్ను మరలా వారించ వద్దు (_w)"
+
+#~ msgid "Yes"
+#~ msgstr "అవును"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "పాపప్ బానర్స్ చూపు"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "బానర్స్ నందు వివరాలు చూపు"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "లాక్ తెరనందు దర్శించు"
+
+#~ msgid "On"
+#~ msgstr "ఆన్"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "పాప్ అప్ బానర్స్ చూపు"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "లాక్ తెర నందు చూపు"
+
+#~ msgid "Add Account"
+#~ msgstr "ఖాతాను జతచేయండి"
+
+#~ msgid "Mail"
+#~ msgstr "మెయిల్"
+
+#~ msgid "Contacts"
+#~ msgstr "పరిచయాలు"
+
+#~ msgid "Chat"
+#~ msgstr "సంభాషణ"
+
+#~ msgid "Resources"
+#~ msgstr "వనరులు"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "ఖాతాలోనికి ప్రవేశించుటలో దోషం"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "ఆనవాళ్ళ గడువు తీరెను."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "ఈ ఖాతాను చేతనపరచుటకు ప్రవేశించు."
+
+#~ msgid "_Sign In"
+#~ msgstr "సైన్ యిన్ (_S)"
+
+#~ msgid "Error creating account"
+#~ msgstr "ఖాతాను సృష్టించుటలో దోషం"
+
+#~ msgid "Error removing account"
+#~ msgstr "ఖాతాను తీసివేయుటలో దోషం"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "మీరు ఖచ్ఛితంగా ఖాతాను తీసివేయాలనుకుంటున్నారా?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "ఇది ఖాతాను సేవకము నందు తీసివేయదు."
+
+#~ msgid "No online accounts configured"
+#~ msgstr "ఎటువంటి ఆన్‌లైన్ ఖాతాలు స్వరూపించబడలేదు"
+
+#~ msgid "Remove Account"
+#~ msgstr "ఖాతాను తీసివేయండి"
+
+#~ msgid "Add an online account"
+#~ msgstr "ఒక ఆన్‌లైన్ ఖాతాను జతచేయి"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "ఒక ఖాతాను జతచేయుట ద్వారా మీ అనువర్తనములు దాని పత్రములను, మెయిల్, పరిచయాలను, క్యాలెండర్‌ను, "
+#~ "సంభాషణను మరియు మరిన్నింటిని యాక్సెస్ చేసుకొనుటకు అనుమతించును."
+
+#~ msgid "Unknown time"
+#~ msgstr "సమయం తెలియదు"
+
 #, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "ఎడమ స్పర్శవలయం రీతి స్విచ్"
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
 
-#: ../panels/wacom/gsd-wacom-device.c:1216
 #, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "కుడి స్పర్శవలయం రీతి స్విచ్"
+#~ msgid "%s until fully charged"
+#~ msgstr "%s పూర్తిగా ఛార్జగు వరకు"
 
-#: ../panels/wacom/gsd-wacom-device.c:1219
 #, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "ఎడమ టచ్ స్ట్రిప్ రీతి స్విచ్"
+#~ msgid "Caution: %s remaining"
+#~ msgstr "హెచ్చరిక: %s మిగిలివుంది"
 
-#: ../panels/wacom/gsd-wacom-device.c:1221
 #, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "కుడి టచ్ స్ట్రిప్ రీతి స్విచ్"
+#~ msgid "%s remaining"
+#~ msgstr "%s మిగిలివుంది"
 
-#: ../panels/wacom/gsd-wacom-device.c:1226
+#~ msgid "Fully charged"
+#~ msgstr "పూర్తిగా చార్జైనది"
+
+#~ msgid "Empty"
+#~ msgstr "ఖాళీ"
+
+#~ msgid "Charging"
+#~ msgstr "చార్జవుతోంది"
+
+#~ msgid "Discharging"
+#~ msgstr "చార్జుపోతోంది"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "ముఖ్య"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "అదనపు"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "వైర్‌లెస్ మౌస్"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "వైరులేని కీబోర్డు"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "అంతరాయంకలిగించని విద్యుత్ సరఫరా"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "వ్యక్తిగత డిజిటల్ సహాయకం"
+
+#~ msgid "Cellphone"
+#~ msgstr "సెల్‌ఫోను"
+
+#~ msgid "Media player"
+#~ msgstr "మాధ్యమ ప్రదర్శకం"
+
+#~ msgid "Computer"
+#~ msgstr "కంప్యూటర్"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "చార్జవుతోంది"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "జాగ్రత్త"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "తక్కువ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "బాగుంది"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "పూర్తిగా చార్జైనది"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "ఖాళీ"
+
+#~ msgid "Batteries"
+#~ msgstr "బ్యాటరీలు"
+
+#~ msgid "When _idle"
+#~ msgstr "నిష్క్రియగా వున్నప్పుడు (_i)"
+
+#~| msgid "Keyboard Preferences"
+#~ msgid "_Keyboard brightness"
+#~ msgstr "కీబోర్డు ప్రకాశత (_K)"
+
+#~| msgid "_Dim Screen when Inactive"
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "క్రియాహీనంగా ఉంటే తెర ప్రకాశత తగ్గించు (_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "వైర్‌లెస్ పరికరాలను ఆఫ్ చేయును"
+
+#~| msgid "_Mobile Broadband"
+#~ msgid "_Mobile broadband"
+#~ msgstr "మొబైల్ బ్రాడ్‌బాండ్ (_M)"
+
+#~| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "మొబైల్ బ్రాడ్‌బ్యాండ్ (3G, 4G, WiMax, మొద.) పరికరాలను ఆఫ్ చేయును"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "బ్లూటూత్ (_B)"
+
+#~ msgid "When on battery power"
+#~ msgstr "బ్యాటరీ విద్యుత్ పై వున్నప్పుడు"
+
+#~ msgid "When plugged in"
+#~ msgstr "అనుసంధానించినపుడు"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "నిలిపివేయి మరియు విద్యుత్ ఆపు"
+
+#~| msgid "_Automatic Suspend"
+#~ msgid "_Automatic suspend"
+#~ msgstr "స్వయంచాలక నిలుపుదల (_A)"
+
+#~| msgid "When Battery Power is _Critical"
+#~ msgid "When battery power is _critical"
+#~ msgstr "బ్యాటరీ విద్యుత్ క్లిష్టస్థితిలో ఉన్నప్పుడు (_C)"
+
+#~ msgid "Power Off"
+#~ msgstr "విద్యుత్ ఆపండి"
+
+#~ msgid "Hibernate"
+#~ msgstr "సుప్తావస్థ"
+
+#~ msgid "1 minute"
+#~ msgstr "1 నిమిషం"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 నిమిషాలు"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 నిమిషాలు"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 నిమిషాలు"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 నిమిషాలు"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 నిమిషాలు"
+
+#~ msgid "Out of toner"
+#~ msgstr "టోనర్ అయిపోయింది"
+
+#~ msgid "Low on developer"
+#~ msgstr "అభివృద్దికారి దిగువ"
+
+#~ msgid "Out of developer"
+#~ msgstr "అభివృద్దికారి బయట"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "మార్కర్ పంపిణీ దిగువ"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "మార్కర్ పంపిణీ బయట"
+
+#~ msgid "Open cover"
+#~ msgstr "తెరుచు కవర్"
+
+#~ msgid "Open door"
+#~ msgstr "ద్వారమును తెరువు"
+
+#~ msgid "Low on paper"
+#~ msgstr "కాగితం దిగువ"
+
+#~ msgid "Out of paper"
+#~ msgstr "కాగితం బయట"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "నిలిపివేయబడింది"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "వ్యర్థం వుండేచోటు దాదాపు నిండింది"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "వ్యర్థం వుండేచోటు నిండింది"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ఆప్టికల్ ఫోటో కండక్టర్ అంత్యదశకు చేరుతోంది"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ఆప్టికల్ ఫోటో కండక్టర్ పనిచేయుట లేదు"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "సిద్దం"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "పనులను ఆమోదించదు"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "క్రమగతి"
+
+#~ msgid "Toner Level"
+#~ msgstr "టోనర్ స్థాయి"
+
+#~ msgid "Supply Level"
+#~ msgstr "పంపిణీ స్థాయి"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "స్థాపిస్తోంది"
+
 #, c-format
-msgid "Mode Switch #%d"
-msgstr "స్విచ్  రీతి #%d"
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u క్రియాశీలత"
+#~ msgstr[1] "%u క్రియాశీలత"
 
-#: ../panels/wacom/gsd-wacom-device.c:1334
+#~ msgid "Failed to add new printer."
+#~ msgstr "కొత్త ముద్రకాన్ని జతచేయుటలో విఫలమైంది."
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "పోస్టుస్క్రిప్ట్ ప్రింటర్ డిస్క్రిప్షన్ ఫైళ్ళు (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "సరిపోయే చోదకం ఏమీ కనపడలేదు"
+
 #, c-format
-msgid "Left Button #%d"
-msgstr "ఎడమ బటన్ #%d"
+#~ msgid "Could not load ui: %s"
+#~ msgstr "అంతరవర్తి నింపలేకుంది: %s"
 
-#: ../panels/wacom/gsd-wacom-device.c:1337
+#~ msgid "Resume Printing"
+#~ msgstr "ముద్రణను తిరిగి కొనసాగించు"
+
+#~ msgid "Pause Printing"
+#~ msgstr "ముద్రణను నిలిపివేయి"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "ఒక కొత్త ముద్రకాన్ని జతచేయి"
+
+#~| msgid "Search for network printers or filter result"
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "ఫలితాలను వడపోయుటకు ముద్రకం లేదా పాఠం చిరునామా ప్రవేశపెట్టండి"
+
+#~| msgid "Remove Printer"
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect ముద్రకం"
+
+#~| msgid "%s Printer"
+#~ msgid "LPD Printer"
+#~ msgstr "LPD ముద్రకం"
+
+#~ msgid "One Sided"
+#~ msgstr "ఒక వైపు"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "లాంగ్ యెడ్జ్ (ప్రామాణికమైంది)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "షార్ట్ యెడ్జ్ (ఫ్లిప్)"
+
+#~ msgid "Portrait"
+#~ msgstr "అడ్డచిత్రం"
+
+#~ msgid "Landscape"
+#~ msgstr "అడ్డచిత్రం"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "అపసవ్య లాండ్‌స్కేప్"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "అపసవ్య పొర్ట్రైట్"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "పెండింగు"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "నిలిపివేయబడినది"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "క్రమగతి"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "ఆపివేయబడింది"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "మధ్యలో రద్దుచేయబడింది"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "పూర్తయినది"
+
+#~ msgid "Job Title"
+#~ msgstr "కార్య శీర్షిక"
+
+#~ msgid "Job State"
+#~ msgstr "కార్య స్థితి"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "వరుస పోర్ట్"
+
+#~ msgid "Parallel Port"
+#~ msgstr "సమాంతర పోర్ట్"
+
 #, c-format
-msgid "Right Button #%d"
-msgstr "కుడి బటన్ #%d"
+#~| msgid "Location"
+#~ msgid "Location: %s"
+#~ msgstr "స్థానము: %s"
 
-#: ../panels/wacom/gsd-wacom-device.c:1340
 #, c-format
-msgid "Top Button #%d"
-msgstr "పైన బటన్ #%d"
+#~| msgid "A_ddress:"
+#~ msgid "Address: %s"
+#~ msgstr "చిరునామా: %s"
 
-#: ../panels/wacom/gsd-wacom-device.c:1343
+#~ msgid "Two Sided"
+#~ msgstr "రెండు వైపులా"
+
+#~ msgid "Paper Type"
+#~ msgstr "కాగితపు రకం"
+
+#~ msgid "Paper Source"
+#~ msgstr "కాగితపు మూలం"
+
+#~ msgid "Output Tray"
+#~ msgstr "అవుట్‌పుట్ పళ్లెం"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "గోస్టుస్క్రిప్ట్ ప్రి-ఫిల్టరింగ్"
+
+#~ msgid "Pages per side"
+#~ msgstr "ఒకవైపుకి పుటలు"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "సాధారణం"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "పుట అమరిక"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "స్థాపించదగిన ఐచ్ఛికాలు"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "కార్యము"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "బొమ్మ నాణ్యత"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "రంగు"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "పూర్తిచేస్తోంది"
+
+#~ msgid "Auto Select"
+#~ msgstr "స్వయం ఎంచు"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "ఎంబడెడ్ గోస్టుస్క్రిప్ట్ ఫాంట్లు మాత్రమే"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS స్థాయి 1 కు మార్చు"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS స్థాయి 2 కు మార్చు"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "ప్రి-ఫిల్టరింగ్ లేదు"
+
+#~ msgid "Supply"
+#~ msgstr "పంపిణీ"
+
+#~| msgid "Default Route"
+#~ msgid "_Default printer"
+#~ msgstr "అప్రమేయ ముద్రకం (_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "కార్యాలు"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "పనులను చూపు (_J)"
+
+#~ msgid "label"
+#~ msgstr "నామాంకం"
+
+#~ msgid "page 3"
+#~ msgstr "పుట 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "పరిశీలనా పేజీని ముద్రించు (_T)"
+
+#~ msgid "_Options"
+#~ msgstr "ఐచ్ఛికాలు (_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "కొత్త ముద్రకాన్ని జతచేయి"
+
+#~ msgid "Usage & History"
+#~ msgstr "వాడుక మరియు చరిత్ర"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "చెత్తబూట్ట నుండి అన్ని అంశాలను ఖాళీచేయాలా?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "చెత్తబుట్ట నందలి అన్ని అంశాలు శాశ్వతంగా తొలగించబడును."
+
+#~| msgid "Purge Trash & Temporary Files"
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "అన్ని తాత్కాలిక ఫైళ్ళను తొలగించాలా?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "అన్ని తాత్కాలిక దస్త్రములు శాశ్వతంగా తొలగించబడును."
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "మీ వ్యక్తిగత సమాచారం రక్షించును మరియు యితరులు యేమి చూడాలో నియంత్రించును"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "తెర మూయబడెను"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 సెకన్లు"
+
+#~ msgid "1 day"
+#~ msgstr "1 రోజు"
+
+#~ msgid "2 days"
+#~ msgstr "2 రోజులు"
+
+#~ msgid "3 days"
+#~ msgstr "3 రోజులు"
+
+#~ msgid "4 days"
+#~ msgstr "4 రోజులు"
+
+#~ msgid "5 days"
+#~ msgstr "5 రోజులు"
+
+#~ msgid "6 days"
+#~ msgstr "6 రోజులు"
+
+#~ msgid "7 days"
+#~ msgstr "7 రోజులు"
+
+#~ msgid "14 days"
+#~ msgstr "14 రోజులు"
+
+#~ msgid "30 days"
+#~ msgstr "30 రోజులు"
+
+#~ msgid "Forever"
+#~ msgstr "ఎప్పటికీ"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "మీ చరిత్రను గుర్తుంచుకొనుట వలన విషయాలను మరలా కనుగొనుటకు శులభతరం అగును. ఈ అంశములు "
+#~ "నెట్వర్కు నందు యెప్పుడూ భాగస్వామ్యపరచ బడవు."
+
+#~ msgid "_Recently Used"
+#~ msgstr "ఇటీవల వుపయోగించిన (_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "చరిత్ర వుంచు (_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "మీరు దూరంగా వున్నప్పుడు తెర లాక్ మీ గోప్యతను రక్షించును."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "శూన్యం తరువాత తెర లాక్ చేయి (_a)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "మీ కంప్యూటర్‌ను అక్కరలేని సున్నితమైన సమాచారం లేకుండా వుంచుటకు తాత్కాలిక ఫైళ్ళను మరియు చెత్తను "
+#~ "స్వయంచాలకంగా శుద్దపరచును."
+
+#~ msgid "Purge _After"
+#~ msgstr "తరువాత శుద్దపరచు (_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "మీరు ఏ సాఫ్టువేర్లు ఉపయోగిస్తున్నారు అనే సమాచారం మాకు పంపితే మీకు సరిపోయే సిఫార్సులను చేయడంలో మాకు "
+#~ "దోహదపడును.  అది మా సాఫ్టువేర్‌ను మెరుగుపరచుడానికి కూడా సహాయకంగా ఉంటుంది.\n"
+#~ "\n"
+#~ "మేము సేకరించే సమాచారం అంతా అజ్ఞాతంగా ఉంచబడును, మరియు మేము ఎప్పటికీ మూడో వ్యక్తులతో అది "
+#~ "పంచుకోము."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "సాఫ్టువేర్ వినియోగపు గణాంకాలు పంపుము (_S)"
+
+#~| msgid "Privacy"
+#~ msgid "Privacy Policy"
+#~ msgstr "గోప్యతా విధానం"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "మీ భౌగోళిక స్థానం నిర్ణయించుటలో ఉపయోగపడును"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ఉన్నతమైన"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "మెట్రిక్"
+
+#~ msgid "No input sources found"
+#~ msgstr "ఏ యిన్పుట్ మూలాలు కనబడలేదు"
+
+#~| msgid "Other"
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "ఇతర"
+
+#~ msgid "Sorry"
+#~ msgstr "క్షమించండి"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "తరువాతి మూలానికి మారు"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "కీబోర్డు అమరికలనందు మీరు యీ లఘువులను మార్చగలరు"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "తరువాతి మూలమునకు ప్రత్యామ్నాయ స్విచ్"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "ఎడమ+కుడి Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "ఇంగ్లిష్ (యునైటెడ్ కింగ్డమ్)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "యునైటెడ్ కింగ్డమ్"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "వ్యవస్థనకు లాగిన్ అగునప్పుడు లాగన్ అమరికలు అందరి వాడుకరుల చేత వుపయోగించబడును"
+
+#~| msgid "Other"
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "ఇతర"
+
+#~ msgid "Select Location"
+#~ msgstr "స్థానము యెంపికచేయి"
+
+#~| msgid "GOK"
+#~ msgid "_OK"
+#~ msgstr "సరే (_O)"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "ఆన్"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "ఆఫ్"
+
+#~| msgid "Enabled"
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "చేతనమైంది"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "ఫోల్డర్ యెంపికచేయి"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "పంచుకొనుటకు ఏ నెట్వర్కులు ఎంపికకాలేదు"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr "బ్లూటూట్ భాగస్వామ్యం అనునది వేరే బ్లూట్ చేతన పరికరాలతో ఫైళ్ళను పంచుకొనుటకు అనుమతించును"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "నమ్మకమైన పరికరాలనుండి మాత్రమే స్వీకరించు"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "స్వీకరించిన ఫైళ్ళను డౌనులోడ్స్ ఫోల్డర్‌కు దాయి"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "తెర భాగస్వామ్యం"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "ఏ నెట్వర్కు యాక్సెస్ లేని కారణంగా కొన్ని సేవలు అచేతనపరచబడెను."
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "వ్యక్తిగత ఫైల్ భాగస్వామ్యం అనునది మిమ్ములను ప్రస్తుత నెట్వర్కునందు యితరులతో మీ పబ్లిక్ ఫోల్డర్‌ను "
+#~ "పంచుకొనుటకు అనుమతించును: <a href=\"dav://%s\">dav://%s</a> వుపయోగించి"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "సెక్యూర్ షెల్ కమాండ్ వుపయోగించి రిమోట్ వాడుకరులను అనుసంధానించుటకు అనుమతించుము:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "దీనికి అనుసంధానమగుట ద్వారా రిమోట్ వాడుకరులను మీ తెరను దర్శించుటకు లేదా నియంత్రించుటకు "
+#~ "అనుమతించుము: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#~| msgid "_Password:"
+#~ msgid "Password:"
+#~ msgstr "సంకేతపదం:"
+
+#~ msgid "Show Password"
+#~ msgstr "సంకేతపదమును చూపుము"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "ఏక్సెస్ కొరకు కొత్త అనుసంధానాలు తప్పక అడగాలి"
+
+#~| msgid "Require Password"
+#~ msgid "Require a password"
+#~ msgstr "సంకేతపదం అవసరం"
+
+#~ msgid "Bark"
+#~ msgstr "మొరుగు"
+
+#~ msgid "Drip"
+#~ msgstr "నీటిచుక్క"
+
+#~ msgid "Glass"
+#~ msgstr "గాజు"
+
+#~ msgid "Sonar"
+#~ msgstr "సోనార్"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "కనిష్టం"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "గరిష్టం"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "సబ్‌వూఫర్ (_S):"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "అన్‌యాంప్లిఫైడ్"
+
+#~ msgid "_Profile:"
+#~ msgstr "ప్రవర (_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "స్పీకర్లను పరీక్షించు (_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "పీక్ గుర్తింపు"
+
+#~ msgid "Device"
+#~ msgstr "పరికరం"
+
 #, c-format
-msgid "Bottom Button #%d"
-msgstr "దిగువ మీట #%d"
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s కొరకు స్పీకర్ పరీక్ష"
 
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-#| msgid "New shortcut..."
-msgid "New shortcut…"
-msgstr "కొత్త లఘువు…"
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "శబ్ద అవుట్‌పుట్ కొరకు ఒక పరికరమును ఎంచుకోండి (_h):"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "ఏ చర్యలేదు"
+#~ msgid "Settings for the selected device:"
+#~ msgstr "ఎంపికచేసిన పరికరము కొరకు అమరికలు:"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "ఎడమ మౌస్ బటన్ నొక్కు"
+#~ msgid "_Input volume:"
+#~ msgstr "ఇన్‌పుట్ శబ్దం (_I):"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "మధ్య మౌస్ బటన్ నొక్కు"
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "శబ్ద ఇన్‌పుట్ కొరకు ఒక పరికరమును ఎంచుకోండి (_h):"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "కుడి మౌస్ బటన్ నొక్కు"
+#~ msgid "Sound Effects"
+#~ msgstr "శబ్ద ప్రభావాలు"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "పైకి జరుపు"
+#~ msgid "Built-in"
+#~ msgstr "బుల్ట్-యిన్"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "కిందకి జరుపు"
+#~ msgid "Sound Preferences"
+#~ msgstr "శబ్ద ప్రాధాన్యతలు"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "ఎడమవైపు జరుపు"
+#~ msgid "Testing event sound"
+#~ msgstr "పరీక్షణ ఘటన శబ్ధము"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "కుడివైపు జరుపు"
+#~ msgid "From theme"
+#~ msgstr "థీమ్ నుండి"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "వెనుకకు"
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "హెచ్చరిక శబ్దమును ఎంచుకోండి (_h):"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "ముందుకు"
+#~ msgid "Stop"
+#~ msgstr "ఆపు"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "స్టైలస్"
+#~ msgid "Custom"
+#~ msgstr "అనురూపితం"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "ప్రెషరు స్పర్శను చెరుపుము"
+#~ msgid "Screen Reader"
+#~ msgstr "తెర చదువకం"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "సున్నితమైన"
+#~| msgid "Screen Reader"
+#~ msgid "_Screen Reader"
+#~ msgstr "తెర చదువరి (_S)"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "ఫిర్మ్"
+#~| msgid "Bounce Keys"
+#~ msgid "Sound Keys"
+#~ msgstr "శబ్ద కీలు"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "పైన బటన్"
+#~| msgid "Flash the window title"
+#~ msgid "Flash the _window title"
+#~ msgstr "విండో శీర్షికను ఫ్లాష్ చేయు (_w)"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "క్రింది బటన్"
+#~ msgid "Beep when a _modifer key is pressed"
+#~ msgstr "బీప్ ఎపుడైతే ఒక మార్పుచేయనున్న కీ ని ప్రెస్ చేసినపుడు(_m)"
 
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
-msgid "Tip Pressure Feel"
-msgstr "ప్రెషరు స్పర్శ టిప్"
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "లఘువు"
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "వెర్బోస్ విధాన్ని చేతనపరుచు"
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ తెర"
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "అవలోకనం చూపించు"
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ తెర"
 
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "స్ట్రింగ్ కొరకు అన్వేషించు"
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ తెర"
 
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "సాధ్యమగు పానల్ పేర్లను జాబితా చేసి మరియు నిష్క్రమించు"
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "పొడవు"
 
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "సహాయ ఐచ్ఛికాలను చూపించు"
+#~ msgid "Zoom"
+#~ msgstr "జూమ్"
 
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "ప్రదర్శించవలసిన ప్యానల్"
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "రంగు"
 
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "ప్రామాణికం"
 
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- అమరికలు"
+#~| msgid "Full Name"
+#~ msgid "_Full Name"
+#~ msgstr "పూర్తి నామము (_F)"
 
-#: ../shell/cc-application.c:163
+#~ msgid "Account _Type"
+#~ msgstr "ఖాతా రకం (_T)"
+
+#~ msgid "_Verify"
+#~ msgstr "నిర్ధారించు (_V)"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "ఎంటర్‌ప్రైజ్ లాగిన్ ఖాతాలను\n"
+#~ "జతచేయుటకు ఆన్‌లైన్‌కు వెళ్ళండి."
+
+#~ msgid "Left thumb"
+#~ msgstr "ఎడమ బ్రొటన వ్రేలు"
+
+#~ msgid "Left middle finger"
+#~ msgstr "ఎడమ మధ్య వ్రేలు"
+
+#~ msgid "Left ring finger"
+#~ msgstr "ఎడమ ఉంగరపు వ్రేలు"
+
+#~ msgid "Left little finger"
+#~ msgstr "ఎడమ చిటికెన వ్రేలు"
+
+#~ msgid "Right thumb"
+#~ msgstr "కుడి బ్రొటన వ్రేలు"
+
+#~ msgid "Right middle finger"
+#~ msgstr "కుడి మధ్య వ్రేలు"
+
+#~ msgid "Right ring finger"
+#~ msgstr "కుడి ఉంగరపు వ్రేలు"
+
+#~ msgid "Right little finger"
+#~ msgstr "కుడి చిటికెన వ్రేలు"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "వేలిముద్ర ప్రవేశాన్ని చేతనపరుచు"
+
+#~ msgid "_Right index finger"
+#~ msgstr "కుడి చూపుడు వ్రేలు (_R)"
+
+#~ msgid "_Left index finger"
+#~ msgstr "ఎడమ చూపుడు వ్రేలు (_L)"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "మీ వేలిముద్ర విజయవంతంగా భద్రపరుచబడింది. మీరు ఇప్పుడు మీ వేలిముద్ర చదువరి(రీడర్) ఉపయోగించి "
+#~ "ప్రవేశించగలుగుతారు."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "ప్రవేశించు;పేరు;వేలిముద్ర;అవతారం;చిహ్నం;ముఖం;సంకేతపదం;"
+
+#~ msgid "Login History"
+#~ msgstr "లాగిన్ చరిత్ర"
+
+#~| msgid "_New password"
+#~ msgid "_Verify New Password"
+#~ msgstr "కొత్త సంకేతపదం నిర్ధారించు (_V)"
+
+#~ msgid "Add User Account"
+#~ msgstr "వాడుకరి ఖాతాను జతచేయి"
+
+#~ msgid "Login Options"
+#~ msgstr "ప్రవేశ ఐచ్ఛికాలు"
+
+#~ msgid "User Icon"
+#~ msgstr "వాడుకరి ప్రతీక"
+
+#~ msgid "Last Login"
+#~ msgstr "చివరి ప్రవేశం"
+
+#~| msgid "The new password does not contain enough different characters"
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "కొత్త సంకేతపదం పాత సకేతపదానికి వేరుగా ఉండాలి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "కొన్ని అక్షరాలు మరియు సంఖ్యలు మార్చుటకు ప్రయత్నించు."
+
+#~| msgid "Changing password for"
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "సంకేతపదం ఇంకొంచం మార్చడానికి ప్రయత్నించండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "మీ వాడుకరి పేరు లేకుండా సంకేతపదంవుంటే ధృడంగావుంటుంది."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "సంకేతపదంనందు మీ వాడుకరిపేరు లేకుండా చూసుకోండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "సంకేతపదంనందు కొన్ని పదాలను వాడుకుండా చూసుకోండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "సాధారణ పదాలను వాడుకుండా చూసుకోండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "మనుగడలోవున్న పదాలను రీకార్డ్ చేయుకుండా చూసుకోండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "మరిన్ని సంఖ్యలను ఉపయోగించుటకు ప్రయత్నించండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "మరిన్ని పెద్దబడి అక్షరాలను ఉపయోగించుటకు ప్రయత్నించండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "మరిన్ని చిన్నబడి అక్షరాలను ఉపయోగించుటకు ప్రయత్నించండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "విరామచిహ్మాలు వంటి, ప్రత్యేక అక్షరాలు మరిన్ని ఉండునట్లు చూసుకోండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "అక్షరాలు, సంఖ్యలు మరియు విరామచిహ్నాల సమ్మేళనంగా ఉండునట్లు చూసుకోండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "ఒకే అక్షరాన్ని తిరిగి వాడకుండా చూసుకోండి."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "ఒకే రకమైన అక్షరం తిరిగి వాడకుండా చూసుకోండి: మీరు అక్షరాలు, సంఖ్యలు మరియు విరామచిహ్నాలు కలిపివాడాలి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 లేదా abcd వంటి వరుసలను వాడకుండా చూసుకోండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "మరిన్ని అక్షరాలు, సంఖ్యలు మరియు చిహ్నాలు జతచేయుటకు చూడండి."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr "పెద్దబడి మరియు చిన్నబడి మరియు ఒకటి లేదా రెండు సంఖ్యలను కలపండి."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr "మంచి సంకేతపదం! మరిన్ని అక్షరాలు, సంఖ్యలు మరియు విరామచిహ్నాలు జతచేస్తే మరింత దృఢమౌతుంది."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "పటిష్టత: బలహీనం"
+
+#~| msgid "Length:"
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "పటిష్టత: తక్కువ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "పటిష్టత: మధ్యమం"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "పటిష్టత: మంచిది"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "పటిష్టత: ధృడమైనది"
+
+#~ msgid "Authentication failed"
+#~ msgstr "ధృవీకరణ విఫలమైంది"
+
 #, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
-msgstr ""
-"%s\n"
-"అందుబాటులో వున్న ఆదేశ వరుస ఐచ్చికముల పూర్తి జాబితా కొరకు '%s --help' "
-"నడుపండి.\n"
+#~ msgid "The new password is too short"
+#~ msgstr "కొత్త సంకేతపదం మరీ చిన్నగా ఉంది"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "అందుబాటులోని పానల్స్:"
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "కొత్త సంకేతపదం చాలా సరళంగా ఉంది"
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "సహాయం"
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "పాత మరియు కొత్త సంకేతపదాలు చాలా దగ్గరగా ఉన్నాయి"
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "నిష్క్రమించు"
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "కొత్త సంకేతపదం ఈ మధ్యనే వాడబడింది."
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
-msgid "All Settings"
-msgstr "అన్ని అమరికలు"
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "కొత్త సంకేతపదం తప్పనిసరిగా సంఖ్యలు లేక ప్రత్యేక అక్షరాలను కలిగివుండాలి"
 
-#. Add categories
-#: ../shell/cc-window.c:876
-msgctxt "category"
-msgid "Personal"
-msgstr "వ్యక్తిగత"
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "పాత మరయు కొత్త సంకేతపదాలు ఒకేవిధంగా ఉన్నాయి"
 
-#: ../shell/cc-window.c:877
-msgctxt "category"
-msgid "Hardware"
-msgstr "హార్డ్‍వేర్"
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "మీరు మొదట ధృవీకరణమైనప్పట్టినుంచి మీ రహస్యపదము మారినది"
 
-#: ../shell/cc-window.c:878
-msgctxt "category"
-msgid "System"
-msgstr "వ్యవస్థ"
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "కొత్త సంకేతపదం సరిపడినన్ని వైవిధ్య అక్షరాలను కలిగిలేదు"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
-msgid "Preferences;Settings;"
-msgstr "ప్రాధాన్యతలు;అమరికలు;"
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "తెలియని దోషం"
 
-#~ msgid "Flickr"
-#~ msgstr "ఫ్లికర్"
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "మీ ఖాతా అందించువారి వెబ్ చిరునామాతో సరిపోలాలి."
+
+#~ msgid "Failed to add account"
+#~ msgstr "ఖాతాను జతచేయుటలో విఫలమైంది"
+
+#~| msgid "Passwords do not match"
+#~ msgid "Passwords do not match."
+#~ msgstr "సంకేతపదాలు సరిపోలటం లేదు."
+
+#~ msgid "Failed to register account"
+#~ msgstr "ఖాతాని నమోదించుటలో విఫలమైంది"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "ఈ డొమైన్‌తో ధృవీకరించుటకు తోడ్పాటునిచ్చు మార్గంలేదు"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "డొమైన్ నందు జేరుటకు విఫలమైంది"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ఆ లాగిన్ పేరు పనిచేయలేదు.\n"
+#~ "దయచేసి తిరిగి ప్రయత్నించండి."
+
+#~| msgid "Invalid password, please try again"
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ఆ లాగిన్ సంకేతపదం పనిచేయలేదు.\n"
+#~ "దయచేసి మరలా ప్రయత్నించండి."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "డొమైన్ నందు లాగిన్ అగుటకు విఫలమైంది"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "డొమైన్ కనుగొనలేక పోయింది. బహుశా మీరు దానిని సరిగా టైప్ చేసివుండకపోవచ్చు?"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "పరికరమును యాక్సిస్ చేయుటకు మీరు అనుమతిలేదు. మీ సిస్టమ్ నిర్వహణాధికారిని సంప్రదించండి."
+
+#~ msgid "The device is already in use."
+#~ msgstr "పరికరము ఇప్పటికే వినియోగంలో వుంది."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "ఒక అంతర్గత దోషం సంభవించినది."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "నమోదైన వేలిముద్రలను తొలగించాలా?"
+
+#~ msgid "Done!"
+#~ msgstr "అయినది!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "'%s' పరికరాన్ని యాక్సిస్ చేయలేకపోయింది"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "'%s' పరికరముపైన వేలి కాప్చరును ప్రారంభించలేక పోయింది"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "ఎటువంటి వేలిముద్ర చదువరులను యాక్సెస్ చేయలేకపోతుంది"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "సహాయము కొరకు దయచేసి మీ వ్యవస్థ నిర్వాహకుడిని సంప్రదించండి."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "వేలిముద్ర ప్రవేశాన్ని చేతనపరచుటకు, '%s' పరికరము ఉపయోగించి మీ వేలిముద్రలలో ఒకటి "
+#~ "భద్రపరుచవలసివుంటుంది."
+
+#~ msgid "Selecting finger"
+#~ msgstr "ఎంచుకొనుతున్న వేలు"
+
+#~ msgid "This Week"
+#~ msgstr "ఈ వారం"
+
+#~ msgid "Last Week"
+#~ msgstr "ఆఖరి వారం"
+
+#~| msgid "%b %d %Y"
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~| msgid "%b %d %Y"
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "సెషన్ చేతనమైంది"
+
+#~ msgid "Session Started"
+#~ msgstr "సెషన్ ప్రారంభించబడింది"
+
+#~ msgid "Please choose another password."
+#~ msgstr "దయచేసి వేరొక సంకేతపదాన్ని ఎన్నుకోండి."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "దయచేసి మీ ప్రస్తుత సంకేతపదాన్ని మరలా టైపు చేయండి."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "సంకేతపదం మార్చబడదు"
+
+#~ msgid "Disable image"
+#~ msgstr "బొమ్మని అచేతనపరుచు"
+
+#~ msgid "Take a photo…"
+#~ msgstr "ఒక ఫొటో తీయండి…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "మరిన్ని చిత్రముల కొరకు అన్వేషించు..."
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s చేత వాడబడింది"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "ఈ రకమైన డొమైన్‌కు స్వయంచాలకంగా జేరలేము"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "అటువంటి డొమైన్ లేదా రియాల్మ్ కనుగొనబడలేదు"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s వలె %s డొమైన్ వద్ద లాగిన్ కాలేకపోయింది"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "సంకేతపదం తప్పు, మరలా ప్రయత్నించండి"
+
+#~ msgid "Other Accounts"
+#~ msgstr "ఇతర ఖాతాలు"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "వాడుకరిని తొలగించుటలో విఫలమైంది"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "మీరు మీ స్వంత ఖాతాను తొలగించలేరు."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ఇంకా ప్రవేశించేవున్నారు"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "ప్రవేశించివున్న వాడుకరిని తొలగించినచో వ్యవస్థను అస్థిరస్థితిలో వదిలివేయబడవచ్చు."
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "%s యొక్క దస్త్రాలను ఉంచాలనుకుంటున్నారా?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "వాడుకరి ఖాతాను తొలగించునపుడు నివాస సంచయం,మెయిల్ స్పూల్ మరియు తాత్కాలిక దస్త్రాలను ఉంచడం "
+#~ "కుదురుతుంది"
+
+#~ msgid "_Delete Files"
+#~ msgstr "దస్త్రాలను తొలగించు (_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "దస్త్రాలను ఉంచు (_K)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "ఖాతా అచేతనమైవుంది"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "తరువాతి ప్రవేశంలో అమర్చబడుతుంది"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "ఏదీకాదు"
+
+#~ msgid "Logged in"
+#~ msgstr "లాగిన్ అయెను"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "ఖాతాల సేవను సంప్రదించుటలో విఫలమైంది"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "దయచేసి ఖాతాసేవ స్థాపించబడి మరియు చేతనపరచివుండునట్లు చూసుకోండి."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "మార్పులు చేయడానికి,\n"
+#~ "మొదటగా * ప్రతీకను నొక్కండి"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ఒక వాడుకరిని సృష్టించుటకు,\n"
+#~ "ముందుగా * ప్రతీకను నొక్కండి"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "ఎంపికచేసిన వాడుకరి ఖాతాను తొలగించు"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ఎంచుకున్న వాడుకరిని తొలగించుటకు,\n"
+#~ "ముందుగా * ప్రతీకను నొక్కండి"
+
+#, c-format
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "'%s' వాడుకరిపేరుతో ఒక వాడుకరి ఇదివరకే ఉన్నారు."
+
+#, c-format
+#~| msgid "The username is too long"
+#~ msgid "The username is too long."
+#~ msgstr "వాడుకరిపేరు మరీ పెద్దగా ఉంది."
+
+#~| msgid "The username cannot start with a '-'"
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "వాడుకరిపేరు '-' తో మొదలవ్వకూడదు."
+
+#~| msgid ""
+#~| "The username must only consist of:\n"
+#~| " ➣ letters from the English alphabet\n"
+#~| " ➣ digits\n"
+#~| " ➣ any of the characters '.', '-' and '_'"
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "వాడుకరిపేరు చిన్న మరియు పెద్దబడి అక్షరాలను a-z వరకు, అంకెలు మరియు '.', '-', '_' వీటిలో "
+#~ "ఏదైనా కలిగివుండవచ్చు."
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr "మీ నివాస సంచయం పేరు పెట్టుటకు యిది వుపయోగించబడును మరియు దీనిని మార్చలేము."
+
+#~| msgid "%b %d %Y"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~| msgid "%b %d %Y"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "పైకి"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "క్రిందికి"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "ఏదీకాదు"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "కీస్ట్రోక్ పంపు"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "మానిటర్ మార్చు"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "తెర-పై సహాయం చూపు"
+
+#~ msgid "Output:"
+#~ msgstr "అవుట్‌పుట్:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "రూప నిష్పత్తి ఉంచు (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "ఒంటరి మానిటర్‌కు మాప్‌చేయి"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d యొక్క%d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "మ్యాపింగును ప్రదర్శించు"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "టాబ్లెట్ (ఖచ్ఛితం)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "టాబ్లెట్ ప్రాధాన్యతలు"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "బ్లూటూత్ అమరికలు"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "మ్యాప్ బటన్లు..."
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "ప్రదర్శన విభాజకతను సవరించండి"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "మౌస్ అమరికలు సర్దుబాటుచేయి"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ట్రాకింగ్ మోడ్"
+
+#~ msgid "Left Ring"
+#~ msgstr "ఎడమ వలయం"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "ఎడమ వలయం రీతి #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "కుడి  వలయం రీతి #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "ఎడమ టచ్‌స్ట్రిప్"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "ఎడమ టచ్ స్ట్రిప్ రీతి #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "కుడి టచ్‌స్ట్రిప్"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "కుడి టచ్ స్ట్రిప్ రీతి #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "ఎడమ స్పర్శవలయం రీతి స్విచ్"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "కుడి స్పర్శవలయం రీతి స్విచ్"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "ఎడమ టచ్ స్ట్రిప్ రీతి స్విచ్"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "కుడి టచ్ స్ట్రిప్ రీతి స్విచ్"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "స్విచ్  రీతి #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "ఎడమ బటన్ #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "కుడి బటన్ #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "పైన బటన్ #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "దిగువ మీట #%d"
+
+#~ msgid "No Action"
+#~ msgstr "ఏ చర్యలేదు"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "ఎడమ మౌస్ బటన్ నొక్కు"
+
+#~ msgid "Scroll Up"
+#~ msgstr "పైకి జరుపు"
+
+#~ msgid "Scroll Right"
+#~ msgstr "కుడివైపు జరుపు"
+
+#~ msgid "Stylus"
+#~ msgstr "స్టైలస్"
+
+#~ msgid "Top Button"
+#~ msgstr "పైన బటన్"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "వెర్బోస్ విధాన్ని చేతనపరుచు"
+
+#~ msgid "Show the overview"
+#~ msgstr "అవలోకనం చూపించు"
+
+#~ msgid "Search for the string"
+#~ msgstr "స్ట్రింగ్ కొరకు అన్వేషించు"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "సాధ్యమగు పానల్ పేర్లను జాబితా చేసి మరియు నిష్క్రమించు"
+
+#~ msgid "Show help options"
+#~ msgstr "సహాయ ఐచ్ఛికాలను చూపించు"
+
+#~ msgid "Panel to display"
+#~ msgstr "ప్రదర్శించవలసిన ప్యానల్"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- అమరికలు"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "అందుబాటులో వున్న ఆదేశ వరుస ఐచ్చికముల పూర్తి జాబితా కొరకు '%s --help' నడుపండి.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "అందుబాటులోని పానల్స్:"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "వ్యక్తిగత"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "హార్డ్‍వేర్"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "వ్యవస్థ"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "కొత్త పరికరాన్ని అమర్చు"
 
-#~ msgid "Connection"
-#~ msgstr "అనుసంధానము"
-
 #~ msgid "Paired"
 #~ msgstr "జతపరిచినవి"
 
-#~ msgid "Type"
-#~ msgstr "రకం"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "మౌస్ మరియు టచ్‌ప్యాడ్ అమరికలు"
-
-#~ msgid "Sound Settings"
-#~ msgstr "శబ్ద అమరికలు"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "కీబోర్డు అమరికలు"
 
 #~ msgid "Send Files…"
 #~ msgstr "దస్త్రాలను పంపండి..."
-
-#~ msgid "Visibility"
-#~ msgstr "దృగ్గోచరత"
 
 #~ msgid "Visibility of “%s”"
 #~ msgstr "“%s” యొక్క దృగ్గోచరత"
@@ -7423,12 +8310,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "_City:"
 #~ msgstr "నగరం (_C):"
 
-#~ msgid "_Network Time"
-#~ msgstr "నెట్‌వర్క్ సమయం (_N)"
-
-#~ msgid ":"
-#~ msgstr ":"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "సమయాన్ని ఒక గంట ముందుకి అమర్చు."
 
@@ -7463,12 +8344,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "180 Degrees"
 #~ msgstr "180 డిగ్రీలు"
 
-#~ msgid "Monitor"
-#~ msgstr "మానిటర్"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "ప్రాధమిక ప్రదర్శనను మార్చుటకు లాగుము."
-
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
 #~ "placement."
@@ -7500,12 +8375,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "గమనిక: విభాజకత ఐచ్చికాలను పరిమితం చేయవచ్చు"
-
-#~ msgid "_Detect Displays"
-#~ msgstr "ప్రదర్శకాలను కనిపెట్టు (_D)"
-
-#~ msgid "Install Updates"
-#~ msgstr "నవీకరణలను స్థాపించు"
 
 #~ msgid "System Up-To-Date"
 #~ msgstr "వ్యవస్థ నేటి వరకూ నవీకరించబడివుంది"
@@ -7579,9 +8448,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Share Public Folder On This Network"
 #~ msgstr "ఈ నెట్వర్కు నందు పబ్లిక్ ఫోల్డర్ పంచుకొనుము"
-
-#~ msgid "Remote View"
-#~ msgstr "రిమోట్ దర్శనం"
 
 #~ msgid "Approve All Connections"
 #~ msgstr "అన్ని అనుసంధానాలను ఆమోదించు"
@@ -7688,17 +8554,8 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Large"
 #~ msgstr "పెద్ద"
 
-#~ msgid "Mouse Settings"
-#~ msgstr "మౌస్ అమరికలు"
-
-#~ msgid "Add account"
-#~ msgstr "ఖాతాను జతచేయండి"
-
 #~ msgid "_Local Account"
 #~ msgstr "స్థానిక ఖాతా (_L)"
-
-#~ msgid "_Full name"
-#~ msgstr "పూర్తి పేరు (_F)"
 
 #~ msgid "_Login Name"
 #~ msgstr "ప్రవేశ నామం (_L)"
@@ -7708,12 +8565,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "C_ontinue"
 #~ msgstr "కొనసాగండి (_o)"
-
-#~ msgid "Previous Week"
-#~ msgstr "క్రితం వార్"
-
-#~ msgid "Next Week"
-#~ msgstr "తరువాతి వారం"
 
 #~ msgid "Next week"
 #~ msgstr "తరువాతి వారం"
@@ -7726,12 +8577,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Enable this account"
 #~ msgstr "ఈ ఖాతాను చేతనపరుచు"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "సంకేతపదాన్ని నిర్ధారించండి (_o)"
-
-#~ msgid "Generate a password"
-#~ msgstr "సంకేతపదాన్ని ఉత్పత్తించు"
 
 #~ msgid "_Action"
 #~ msgstr "చర్య (_A)"
@@ -7818,18 +8663,12 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Change the background"
 #~ msgstr "నేపథ్యమును మార్చు"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "బ్లూటూత్ అమరికలను స్వరూపించు"
-
 #~ msgid "Browse Files..."
 #~ msgstr "దస్త్రాలను విహరించండి..."
 
 #~ msgctxt "Power"
 #~ msgid "Bluetooth"
 #~ msgstr "బ్లూటూత్"
-
-#~ msgid "Create virtual device"
-#~ msgstr "వర్చువల్ పరికరమును సృష్టించు"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "తెరల కొరకు అందుబాటులోవున్న ప్రవరలు"
@@ -7920,12 +8759,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Unspecified"
 #~ msgstr "తెలుపని"
 
-#~ msgid "Select a language"
-#~ msgstr "ఒక భాషను ఎంచుకోండి"
-
-#~ msgid "_Select"
-#~ msgstr "ఎంచుకొను (_S)"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "తేది మరియు సమయం ప్రాధాన్యతల ప్యానల్"
 
@@ -7973,9 +8806,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Set your mouse and touchpad preferences"
 #~ msgstr "మీ మౌస్ మరియు టచ్‌ప్యాడ్ ప్రాధాన్యతలను అమర్చు"
-
-#~ msgid "Network settings"
-#~ msgstr "నెట్‌వర్క్ అమరికలు"
 
 #~ msgid "Network;Wireless;IP;LAN;Proxy;"
 #~ msgstr "నెట్‌వర్కు;వైర్‌లెస్;IP;LAN;ప్రాక్సీ;"
@@ -8063,9 +8893,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Paused"
 #~ msgstr "నిలిపివుంచిన"
 
-#~ msgid "Change printer settings"
-#~ msgstr "ముద్రకం అమరికలను మార్చు"
-
 #~ msgid "Manufacturers"
 #~ msgstr "తయారీదారులు"
 
@@ -8118,9 +8945,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Remove Language"
 #~ msgstr "భాషను తీసివేయి"
 
-#~ msgid "Install languages..."
-#~ msgstr "భాషలను స్థాపించు..."
-
 #~ msgid "Select a region (change will be applied the next time you log in)"
 #~ msgstr "ఒక ప్రాంతాన్ని ఎంచుకొను (మీ తరువాయి ప్రవేశంలో మార్పులు అనువర్తించబడతాయి)"
 
@@ -8141,9 +8965,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Move Input Source Up"
 #~ msgstr "ఇన్‌పుట్ వనరుని పైకి కదుపు"
-
-#~ msgid "Show Keyboard Layout"
-#~ msgstr "కీబోర్డు లేయవుటు చూపించు"
 
 #~ msgid "Ctrl+Alt+Space"
 #~ msgstr "Ctrl+Alt+Space"
@@ -8169,9 +8990,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Brightness & Lock"
 #~ msgstr "ప్రకాశత మరియు తాళం"
 
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "తెర ప్రకాశత మరియు తాళం అమరికలు"
-
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "ప్రకాశత;తాళం;తక్కువకాంతి;బ్లాంక్;మానిటర్;"
 
@@ -8183,9 +9001,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Locations..."
 #~ msgstr "ప్రదేశాలు..."
-
-#~ msgid "Lock"
-#~ msgstr "తాళంవేయి"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "డీబగ్గింగ్ సంహిత ను చేతనంచేయి"
@@ -8201,9 +9016,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Sound Output Volume"
 #~ msgstr "శబ్ద అవుట్‌పుట్ స్థాయి"
-
-#~ msgid "Microphone Volume"
-#~ msgstr "మైక్రోఫోన్ శబ్దస్థాయి"
 
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "శబ్ధ అభీష్టాలను ప్రారంభించుటకు విఫలమైంది: %s"
@@ -8301,9 +9113,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Take a screenshot"
 #~ msgstr "ఒక తెరపట్టును తీయండి"
 
-#~ msgid "Shortcut"
-#~ msgstr "అడ్డదారి"
-
 #~ msgid "_Right-handed"
 #~ msgstr "కుడి-చేతి (_R)"
 
@@ -8328,9 +9137,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Drag Threshold"
 #~ msgstr "త్రెష్‌హోల్డును లాగుము"
 
-#~ msgid "Double-Click Timeout"
-#~ msgstr "రెండు-నొక్కలు కాలముమించినది"
-
 #~ msgid "_Timeout:"
 #~ msgstr "సమయం మించినది(_T):"
 
@@ -8339,9 +9145,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "టచ్‌ప్యాడ్‌తో మౌస్ నొక్కులను చేతనపరుచు (_m)"
-
-#~ msgid "Scrolling"
-#~ msgstr "జరుపుట"
 
 #~ msgid "_Disabled"
 #~ msgstr "అచేతనపరిచివుంది (_D)"
@@ -8371,12 +9174,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Subnet Mask"
 #~ msgstr "సబ్‌నెట్ మాస్క్"
 
-#~ msgid "_Search by Address"
-#~ msgstr "చిరునామాని బట్టి వెతుకు (_S)"
-
-#~ msgid "Getting devices..."
-#~ msgstr "పరికరాలను పొందుట..."
-
 #~ msgid ""
 #~ "FirewallD is not running. Network printer detection needs services mdns, "
 #~ "ipp, ipp-client and samba-client enabled on firewall."
@@ -8391,9 +9188,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgctxt "printer type"
 #~ msgid "Network"
 #~ msgstr "నెట్‌వర్క్"
-
-#~ msgid "Device types"
-#~ msgstr "పరికరం రకాలు"
 
 #~ msgid "Automatic configuration"
 #~ msgstr "స్వయంచాలక స్వరూపణం"
@@ -8410,14 +9204,8 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "_Back"
 #~ msgstr "వెనుకకు (_B)"
 
-#~ msgid "Printer Options"
-#~ msgstr "ముద్రకం ఐచ్ఛికాలు"
-
 #~ msgid "Allowed users"
 #~ msgstr "అనుమతించిన వాడుకరులు"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "స్వరూపించుటకు ఒక పరికరం ఎంచుకోండి (_h):"
 
 #~ msgid "Dasher"
 #~ msgstr "డాషర్"
@@ -8427,9 +9215,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Caribou"
 #~ msgstr "కారిబౌ"
-
-#~ msgid "Account _type"
-#~ msgstr "ఖాతా రకం (_t)"
 
 #~ msgid "Disable VPN"
 #~ msgstr "VPN అచేతనపరుచు"
@@ -8487,20 +9272,11 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Layouts"
 #~ msgstr "నమూనాలు"
 
-#~ msgid "Layout"
-#~ msgstr "నమూనా"
-
 #~ msgid "Change contrast:"
 #~ msgstr "వ్యత్యాసాన్ని మార్చు:"
 
 #~ msgid "_Text size:"
 #~ msgstr "పాఠ్య పరిమాణం (_T):"
-
-#~ msgid "Increase size:"
-#~ msgstr "పరిమాణం పెంచు:"
-
-#~ msgid "Decrease size:"
-#~ msgstr "పరిమాణం తగ్గించు:"
 
 #~ msgctxt "universal access, seeing"
 #~ msgid "Display"
@@ -8575,12 +9351,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Too many custom shortcuts"
 #~ msgstr "మరీ ఎక్కువ అనురూపిత అడ్డదారులు"
-
-#~ msgid "Speed"
-#~ msgstr "వేగం"
-
-#~ msgid "Unlock"
-#~ msgstr "అన్‌లాక్"
 
 #~ msgid "Battery discharging"
 #~ msgstr "బ్యాటరీ చార్జుపోతోంది"
@@ -8709,17 +9479,8 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "_Turn off after:"
 #~ msgstr "ఇంతసేపటి తరువాత ఆపివేయి (_T):"
 
-#~ msgid "Mute"
-#~ msgstr "నిశబ్దం"
-
-#~ msgid "Appearance"
-#~ msgstr "కనిపించువిధం"
-
 #~ msgid "<b>Background</b>"
 #~ msgstr "<b>నేపథ్యం</b>"
-
-#~ msgid "<b>Theme</b>"
-#~ msgstr "<b>థీమ్</b>"
 
 #~ msgid "Apply system wide"
 #~ msgstr "వ్యవస్థ అంతటికీ అనువర్తించు"
@@ -8752,9 +9513,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ "\";\" విభజని తో నియంత్రణ-కేద్రం లో కర్తవ్యం నామము ప్రదర్శించబడాలి అప్పుడు సంభందిత .desktop "
 #~ "దస్త్రం ఆ కర్తవ్యంను దించుటకు ప్రదర్శించబడాలి."
 
-#~ msgid "User name:"
-#~ msgstr "వాడుకరి పేరు:"
-
 #~ msgid "Save Theme As..."
 #~ msgstr "థీమ్ ను ఇలాదాయి..."
 
@@ -8764,26 +9522,17 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "_Home page:"
 #~ msgstr "నివాస పేజి(_H):"
 
-#~ msgid "Fraction completed"
-#~ msgstr "పూర్తయిన భిన్నం"
-
 #~ msgid ""
 #~ "Your password has been changed since you initially authenticated! Please "
 #~ "re-authenticate."
 #~ msgstr ""
 #~ "మీరు ప్రధమంలో దృవీకరించబడి నందువల్ల మీ సంకేతపదం మార్చబడింది! దయచేసి తిరిగి-దృవీకరించబడండి."
 
-#~ msgid "Pointer"
-#~ msgstr "సూచిక"
-
 #~ msgid "Parent window of the dialog"
 #~ msgstr "డైలాగ్‌యొక్క మాత్రుక విండో"
 
 #~ msgid "Unable to launch backend"
 #~ msgstr "బ్యాక్ఎండ్ ను దించలేము"
-
-#~ msgid "Open with Default Application"
-#~ msgstr "అప్రమేయ అనువర్తనంతో తెరువుము"
 
 #~ msgid "Current URI index"
 #~ msgstr "ప్రస్తుత యుఆర్ఎల్ సూచి"
@@ -8851,12 +9600,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Could not shutdown backend_stdin IO channel: %s"
 #~ msgstr "backend_stdin IO ప్రసారమార్గం ను మూయలేక పోయింది: %s"
 
-#~ msgid "_Reset to Defaults"
-#~ msgstr "అప్రమేయాలకు తిరిగిఉంచు(_R)"
-
-#~ msgid "From URI"
-#~ msgstr "యుఆర్ఎల్ నుండి"
-
 #~ msgid "Assign shortcut keys to commands"
 #~ msgstr "ఆదేశాలకు లఘువులను జతచేయుము"
 
@@ -8871,9 +9614,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Eye candy added by Anders Carlsson"
 #~ msgstr "ఏండర్స్ కార్ల్సన్  చే ఐ క్యాండీ జత చేయబడినది"
-
-#~ msgid "Beep when a _modifier key is pressed"
-#~ msgstr "సవరణి కీ వత్తినప్పుడు బీప్ చేయుము(_m)"
 
 #~ msgid "?"
 #~ msgstr "?"
@@ -8939,9 +9679,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "P.O. _box:"
 #~ msgstr "P.O. _box:"
 
-#~ msgid "GNOME Terminal"
-#~ msgstr "GNOME టెర్మినల్"
-
 #~ msgid "Gnome Theme Package"
 #~ msgstr "గ్నోమ్ థీమ్ నిర్వాహకి"
 
@@ -8980,9 +9717,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgstr[1] ""
 #~ "ఎంపిక చేసిన అక్షరశైలి %d పాలు పెద్దది, దీన్ని కంప్యూటర్ వినియోగించటం కష్టతరం.మీరు పరిమాణం చిన్నదిగా "
 #~ "ఉన్న అక్షరశైలిని ఎంపిక చేసుకోవాలని సలహా"
-
-#~ msgid "Controls"
-#~ msgstr "నియంత్రణలు"
 
 #~ msgid "_Slight"
 #~ msgstr "స్వల్పం(_S)"
@@ -9085,17 +9819,11 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ "ఎంపిక చేసిన అక్షరశైలి %d పాలు పెద్దది, దీన్ని కంప్యూటర్ వినియోగించటం కష్టతరం.మీరు %dపాలు కన్నా "
 #~ "చిన్నది ఎంపిక చేసుకోవాలని సలహా"
 
-#~ msgid "Parent Window"
-#~ msgstr "మాత్రుక విండో"
-
 #~ msgid "Models"
 #~ msgstr "నమూనాలు"
 
 #~ msgid "All Files"
 #~ msgstr "అన్ని ఫైళ్ళు"
-
-#~ msgid "Windows"
-#~ msgstr "విండోలు"
 
 #~ msgid "Set your network proxy preferences"
 #~ msgstr "మీ నెట్వర్కు ప్రాక్సీ అభీష్టాలను అమర్చుము"
@@ -9135,9 +9863,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Copying '%s'"
 #~ msgstr "'%s' నకలుతీయుచున్నది"
-
-#~ msgid "_Acceleration:"
-#~ msgstr "త్వరుణం(_A):"
 
 #~ msgid ""
 #~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
@@ -9224,9 +9949,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "The current controls theme does not support color schemes."
 #~ msgstr "ప్రస్తుత నియంత్రికల థీమ్ వర్ణపు పధకాలకు మద్దతీయుటలేదు."
 
-#~ msgid "seconds"
-#~ msgstr "సెకనులు"
-
 #~ msgid "Select your default applications"
 #~ msgstr "మీ అప్రమేయ అనువర్తనంలను ఎంపికచేయుము"
 
@@ -9250,12 +9972,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Please type your password in the <b>New password</b> field."
 #~ msgstr "దయచేసి మీ సంకేతపదాన్ని <b>కొత్త సంకేతపదం</b> క్షేత్రమునందు టైపుచేయండి."
-
-#~ msgid "_Mobile:"
-#~ msgstr "మొబైల్(_M):"
-
-#~ msgid "About %s"
-#~ msgstr "%s గురించి"
 
 #~ msgid "Maximize"
 #~ msgstr "పెద్దది చేయు"
@@ -9338,9 +10054,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Run at st_art"
 #~ msgstr "ప్రారంభంవద్ద నడుపుము(_a)"
 
-#~ msgid "Alert Buttons"
-#~ msgstr "సంకేతం బటన్లు"
-
 #~ msgid "M_SN:"
 #~ msgstr "M_SN:"
 
@@ -9368,9 +10081,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "_Tooltips:"
 #~ msgstr "చిట్కాలు(_T):"
-
-#~ msgid "Network Proxy"
-#~ msgstr "నెట్వర్కు ప్రాక్సీ"
 
 #~ msgid "Preview:"
 #~ msgstr "ఉపదర్శనం:"
@@ -9411,14 +10121,8 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "Disa_ble sticky keys if two keys are pressed together"
 #~ msgstr "ఒకేసారి రెండుకీలు కలిపి వత్తబడితే చెందివుండు కీలను అచేతనంచేయుము(_b)"
 
-#~ msgid "Common Tasks"
-#~ msgstr "ఉమ్మడి కర్తవ్యాలు"
-
 #~ msgid "Vendors"
 #~ msgstr "అమ్మకందార్లు"
-
-#~ msgid "Rename..."
-#~ msgstr "పునఃనామకరణం..."
 
 #~ msgid "Standard XTerminal"
 #~ msgstr "ప్రామాణిక Xఅగ్రం"
@@ -9448,9 +10152,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Open a dialog to specify the color"
 #~ msgstr "వర్ణమును తెలుపుటకు డైలాగ్ ను తెరువుము"
-
-#~ msgid "Move to Trash"
-#~ msgstr "చెత్తకుండికి కదుపుము"
 
 #~ msgid "_Yahoo:"
 #~ msgstr "యాహూ(_Y):"
@@ -9608,9 +10309,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 #~ msgid "No theme file location specified to install"
 #~ msgstr "నెలకొల్పుటకు వైవిద్యాంశ దస్త్ర స్థానాన్ని పేర్కొనలేదు"
 
-#~ msgid "Re_fresh rate:"
-#~ msgstr "పునర్వికాసం రేటు(_f):"
-
 #~ msgid "Flash _window titlebar"
 #~ msgstr "విండో శీర్షికపట్టీని ప్రకాశించుము(_w)"
 
@@ -9664,12 +10362,6 @@ msgstr "ప్రాధాన్యతలు;అమరికలు;"
 
 #~ msgid "Whether to thumbnail Type1 fonts"
 #~ msgstr "టైప్1 ఫాంట్లను థంబ్‌నైల్ చేయాలా"
-
-#~ msgid "Name:"
-#~ msgstr "నామము:"
-
-#~ msgid "Style:"
-#~ msgstr "శైలి:"
 
 #~ msgid "Version:"
 #~ msgstr "వర్షన్:"

--- a/po/te.po~
+++ b/po/te.po~
@@ -1,0 +1,9785 @@
+# translation of gnome-control-center.master.te.po to Telugu
+# Telugu translation of control-center
+# Copyright (C) 2011 Gnome Telugu Contributors.
+# Copyright (C) 2005, 2011,2012 Swecha Telugu Localisation Team <localization@swecha.net>.
+# This file is distributed under the same license as the control-center package.
+#
+#
+#
+# Prajasakti Localisation Team <localisation@prajasakti.com>, 2005.
+# Krishna Babu K <kkrothap@redhat.com>, 2008, 2009.
+# Krishnababu Krothapalli <kkrothap@redhat.com>, 2011, 2012, 2013, 2014.
+# Hari Krishna <hari@swecha.net>, 2011.
+# Sasi Bhushan Boddepalli <sasi@swecha.net>, 2012.
+# GVS.Giri (swecha team)<gvs.giri947@gmail.com>,2012.
+# Naveen kandimalla <naveen@swecha.net>,2012.
+# Praveen Illa <mail2ipn@gmail.com>, 2011, 2012.
+# Daniel Mustieles <daniel.mustieles@gmail.com>, 2013.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center.master.te\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-08-22 06:31+0000\n"
+"PO-Revision-Date: 2014-09-03 20:11+0630\n"
+"Last-Translator: Krishnababu Krothapalli <kkrothap@redhat.com>\n"
+"Language-Team: Telugu <Fedora-trans-te@redhat.com>\n"
+"Language: te\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Launchpad-Export-Date: 2011-09-24 09:12+0000\n"
+"X-Generator: Lokalize 1.5\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "నేపథ్యం"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "రోజు మొత్తంమీద మార్పులు"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+#| msgid "Lock screen"
+msgid "Lock Screen"
+msgstr "తెరకు తాళంవేయి"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "పలక"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "జూమ్"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "మధ్య"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "స్కేల్"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "నింపు"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "అవధి"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:442
+msgid "Select Background"
+msgstr "నేపథ్యాన్ని ఎంచుకోండి"
+
+#: ../panels/background/cc-background-chooser-dialog.c:463
+msgid "Wallpapers"
+msgstr "నేపథ్యచిత్రాలు"
+
+#: ../panels/background/cc-background-chooser-dialog.c:472
+msgid "Pictures"
+msgstr "చిత్రాలు"
+
+#: ../panels/background/cc-background-chooser-dialog.c:481
+msgid "Colors"
+msgstr "రంగులు"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:540
+#| msgid "No input sources found"
+msgid "No Pictures Found"
+msgstr "ఏ చిత్రాలు కనబడలేదు"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:558
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "నివాసం"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:570
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "మీరు చిత్రాలను మీ %s ఫోల్డర్‌కు జతచేయవచ్చు మరియు అవి ఇక్కడ చూపబడును"
+
+#: ../panels/background/cc-background-chooser-dialog.c:592
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1537
+#: ../panels/display/cc-display-panel.c:1976
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1240
+#: ../panels/network/net-device-wifi.c:1448
+#: ../panels/printers/cc-printers-panel.c:1947
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+#: ../panels/user-accounts/um-photo-dialog.c:95
+#: ../panels/user-accounts/um-photo-dialog.c:222
+#: ../panels/user-accounts/um-user-panel.c:513
+msgid "_Cancel"
+msgstr "రద్దుచేయి (_C)"
+
+#: ../panels/background/cc-background-chooser-dialog.c:593
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:97
+msgid "Select"
+msgstr "ఎంచుకోండి"
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "బహుళ పరిమాణములు"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "డెస్క్‍టాప్ నేపథ్యంలేదు"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "ప్రస్తుత నేపథ్యం"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "మీ బ్యాక్‌గ్రౌండ్ చిత్రమును వాల్‌పేపర్ లేదా చిత్రమునకు మార్చండి"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "నేపథ్యచిత్రం;తెర;డెస్క్​టాప్;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "బ్లూటూత్ అచేతనపరచబడింది"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "ఎటువంటి బ్లూటూత్ ఎడాప్టర్లు కనపడలేదు"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "బ్లూటూత్ హార్డ్‍వేర్ స్విచ్‌తో అచేతనపరచబడింది"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+msgid "Bluetooth"
+msgstr "బ్లూటూత్"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "బ్లూటూత్ ఆఫ్ మరియు ఆన్ చేసి మీ పరికరాలను అనుసంధానించండి"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "మీ కాలిబరేషన్ పరికరంను చతురస్త్రంపై వుంచి 'ప్రారంభించు' వత్తండి"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr ""
+"మీ కాలిబరేషన్ పరికరంను కాలిబరేట్ స్థానమునకు కదల్చి అప్పడు 'కొనసాగించు' వత్తండి"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr ""
+"మీ కాలిబరేషన్ పరికరంను ఉపరితల స్థానమునకు కదల్చి అప్పడు 'కొనసాగించు' వత్తండి"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "లాప్‌టాప్ లిడ్ మూయి"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "ఒక అంతర్గత దోషం సంభవించినది అది రికవర్ కాలేదు."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "కాలిబరేషన్ కొరకు అవసరమైన సాధనములు సంస్థాపించబడలేదు."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "ప్రొఫైల్ జనియింప చేయలేక పోయింది"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "లక్ష్యపు వైట్‌పాయింట్ పొందలేదు."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "పూర్తయినది!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "కాలిబరేషన్ విఫలమైంది!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "మీరు కాలిబరేషన్ పరికరం తీసివేయవచ్చు"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "పురోగతినందు వున్నప్పుడు కాలిబరేషన్ పరికరంను విజ్ఞ పరచవద్దు"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "లాప్‌టాప్ తెర"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "బుల్ట్-యిన్ వెబ్‌కామ్"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s మానిటర్"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s స్కానర్"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s కెమేరా"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s ముద్రకం"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s వెబ్‌క్యామ్"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s కొరకు రంగు నిర్వాహణ చేతనం చేయండి"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s కొరకు రంగు ప్రొఫైల్స్ చూపు"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+msgid "Not calibrated"
+msgstr "కాలిబరేట్ చేయలేదు"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "అప్రమేయం: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "రంగులఅంతరం: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "పరీక్షా ప్రవర: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "ICC ప్రవర దస్త్రమును ఎంచుకొనుము"
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "దిగుమతిచేయి (_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "సహకార ICC ప్రవరలు"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "అన్ని దస్త్రాలు"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "తెర"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "ఫైలు యెక్కించుటలో విఫలమైంది: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "ప్రొఫైల్ దీనికి అప్‌లోడ్ అయింది:"
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "ఈ URL వ్రాయి."
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr "ఈ కంప్యూటర్ పునఃప్రారంభించి మీ సాధారణ ఆపరేటింగ్ సిస్టమ్ బూట్ చేయి."
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "ప్రొఫైల్ సంస్థాపించుటకు URL ను మీ బ్రౌజర్ నందు టైపు చేసి దించుకోండి."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "ప్రొఫైల్ దాయి"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "భద్రపరచు (_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "ఎంచుకున్న పరికరమునకు రంగు ప్రవరను సృష్టించు"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"కొలుస్తున్న సాధనము కనుగొనబడలేదు. దయచేసి ఆన్ ఉందా మరియు సరిగ్గా అనుసంధానమయి "
+"ఉందా చాచుకొనుము."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "కొలుస్తున్న సాధనము ప్రింటర్ ప్రొఫైలింగును సహకరించుటలేదు"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "పరికరపు రకము ప్రస్తుతము సహకరించుటలేదు."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "ప్రామాణిక జాగా"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "పరీక్షా ప్రొఫైల్"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "స్వయంచాలక"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "తక్కువ నాణ్యత"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "మధ్యమ నాణ్యత"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "అధిక నాణ్యత"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB అప్రమేయం"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK అప్రమేయం"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "అప్రమేయ గ్రే"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "అమ్మకందారు అందించిన ఫాక్టరీ కాలిబరేషన్ దత్తాంశం"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "ఈ ప్రొఫైల్‌తో పూర్తి-తెర ప్రదర్శన దిద్దుబాటు సాధ్యం కాదు"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "ఈ ప్రోఫైల్ యిక ఖచ్చితంగా వుండకపోవచ్చు"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "క్యాలిబ్రేషన్ ప్రదర్శించు"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr "రద్దుచేయి"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "మొదలు"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "తిరిగికొనసాగించు"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "అయినది"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "తెర సామర్థ్యం"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"మీ తెర రంగు నిర్వహణ కొరకు వుపయోగించుకొనుటకు కాలిబరేషన్ వొక ప్రొఫైల్ "
+"అందించును. మీరు యెంతసేపు "
+"కాలిబరేషన్‌పై గడిపితే, రంగు ప్రొఫైల్ యొక్క నాణ్యత వుత్తమంగా వుంటుంది."
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "కాలిబరేషన్ జరుగునప్పుడు మీరు మీ కంప్యూటర్‌ను వుపయోగించలేరు."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "నాణ్యత"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "షుమారు సమయం"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "క్యాలిబ్రేషన్ నాణ్యత"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+"కాలిబరేషన్ కొరకు వుపయోగించాలని అనుకొనుచున్న సెన్సార్ పరికరం యెంపికచేయి."
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "క్యాలిబ్రేషన్ పరికరం"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "అనుసంధానించిన ప్రదర్శన రకంను యెంపికచేయి."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "ప్రదర్శన రకం"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"ప్రదర్శన లక్ష్యం వైట్ పాయింట్ యెంపికచేయి. చాలా ప్రదర్శనలు D65 "
+"యిల్యుమినెంట్‌కు కాలిబరేట్ అయివుండును."
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "ప్రొఫైల్ వైట్‌పాయింట్"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"మీకు తగిన కాంతిప్రకాశంకు పదర్శనను అమర్చండి. ఈ కాంతిప్రకాశ స్థాయినందు రంగు "
+"నిర్వహణ చాలా ఖచ్చితంగా "
+"వుండును."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"ప్రత్యామ్నాయంగా, ఈ పరికరం కొరకు యితర ప్రొఫైల్సులో వొక దానినందు వుపయోగించిన "
+"కాంతిప్రకాశం స్థాయిను మీరు "
+"వుపయోగించవచ్చు."
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "ప్రకాశత ప్రదర్శన"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"రంగు ప్రొఫైల్సును మీరు విభిన్న కంప్యూటర్లపై వుపయోగించవచ్చు, లేదా విభిన్న "
+"లైటింగ్ నిభందనల కొరకు ప్రొఫైల్స్ "
+"సృష్టించవచ్చు."
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "ప్రొఫైల్ పేరు:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "ప్రొఫైల్ పేరు"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "ప్రొఫైల్ సఫలవంతంగా సృష్టించబడెను!"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "ప్రొఫైల్ నకలుతీయి"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "వ్రాయదగ్గ మాధ్యమం కావాలి"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "ప్రొఫైల్ యెక్కించు"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "ఇంటర్నెట్ అనుసంధానం కావాలి"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"<a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> మరియు <a href="
+"\"windows\">Microsoft Windows</a> వ్యవస్థలపై ప్రొఫైల్ యేలా వుపయోగించాలి "
+"అనేదానికొరకు మీకు యీ "
+"సూచనలు వుపయోగకరంగా వుంటాయి."
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+msgid "Summary"
+msgstr "సారాంశం"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "ఫైల్ ను దిగుమతి చేయి…"
+
+#: ../panels/color/color.ui.h:29
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"సమస్యలు గుర్తించబడెను. ప్రొఫైల్ సరిగా పనిచేయకపోవచ్చు.<a href=\"\">వివరాలు "
+"చూడండి.</a>"
+
+#: ../panels/color/color.ui.h:30
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "ప్రతి పరికరము రంగు నిర్వహనమగుటకు రంగు ప్రవరను తాజాపరుచు."
+
+#: ../panels/color/color.ui.h:31
+msgid "Learn more"
+msgstr "మరింత తెలుసుకోండి"
+
+#: ../panels/color/color.ui.h:32
+msgid "Learn more about color management"
+msgstr "వర్ణ నిర్వాహణ గురించి మరింత నేర్చుకోండి"
+
+#: ../panels/color/color.ui.h:33
+msgid "Set for all users"
+msgstr "వాడుకరులందరికీ అమర్చు"
+
+#: ../panels/color/color.ui.h:34
+msgid "Set this profile for all users on this computer"
+msgstr "ఈ కంప్యూటరును వాడే వాడుకరులందరికీ ఈ ప్రవరని అమర్చు"
+
+#: ../panels/color/color.ui.h:35
+msgid "Enable"
+msgstr "చేతనం"
+
+#: ../panels/color/color.ui.h:36
+msgid "Add profile"
+msgstr "ప్రవర జతచేయి"
+
+#: ../panels/color/color.ui.h:37
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate…"
+msgstr "క్రమాంకనం చేయి..."
+
+#: ../panels/color/color.ui.h:38
+msgid "Calibrate the device"
+msgstr "పరికరాన్ని క్రమాంకనంచేయి"
+
+#: ../panels/color/color.ui.h:39
+msgid "Remove profile"
+msgstr "ప్రవర తీసివేయి"
+
+#: ../panels/color/color.ui.h:40
+msgid "View details"
+msgstr "వివరాలను చూడు"
+
+#: ../panels/color/color.ui.h:41
+msgid "Unable to detect any devices that can be color managed"
+msgstr "రంగు నిర్వహణతో వున్న యే పరికరాలను గుర్తించలేక పోయింది"
+
+#: ../panels/color/color.ui.h:42
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:43
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:44
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:45
+msgid "Projector"
+msgstr "ప్రోజెక్టర్"
+
+#: ../panels/color/color.ui.h:46
+msgid "Plasma"
+msgstr "ప్లాస్మా"
+
+#: ../panels/color/color.ui.h:47
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL బాక్‌లైట్)"
+
+#: ../panels/color/color.ui.h:48
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED బాక్‌లైట్)"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (white LED backlight)"
+msgstr "LCD (వైట్ LED బాక్‌లైట్)"
+
+#: ../panels/color/color.ui.h:50
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Wide gamut LCD (CCFL బాక్‌లైట్)"
+
+#: ../panels/color/color.ui.h:51
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Wide gamut LCD (RGB LED బాక్‌లైట్)"
+
+#: ../panels/color/color.ui.h:52
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "అదిక"
+
+#: ../panels/color/color.ui.h:53
+msgid "40 minutes"
+msgstr "40 నిమిషాలు"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "మాధ్యమం(_M)"
+
+#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 నిమిషాలు"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "తక్కువ"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 నిమిషాలు"
+
+#: ../panels/color/color.ui.h:58
+msgid "Native to display"
+msgstr "ప్రదర్శనకు స్వభావం"
+
+#: ../panels/color/color.ui.h:59
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (ముద్రమ మరియు ప్రచురణ)"
+
+#: ../panels/color/color.ui.h:60
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:61
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (ఛాయాగ్రహణం మరియు గ్రాఫిక్స్)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "రంగు"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"మీ పరికరముల యొక్క రంగును కాలిబరేట్ చేయండి, ప్రదర్శనలు, కేమెరాలు లేదా "
+"ముద్రికలు వలె"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "వర్ణం;ICC;ప్రవర;కాలిబ్రేట్;ముద్రకం;ప్రదర్శకం;"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:684
+msgid "United States"
+msgstr "యునైటెడ్ స్టేట్స్"
+
+#: ../panels/common/cc-common-language.c:685
+msgid "Germany"
+msgstr "జర్మనీ"
+
+#: ../panels/common/cc-common-language.c:686
+msgid "France"
+msgstr "ఫ్రాన్స్"
+
+#: ../panels/common/cc-common-language.c:687
+msgid "Spain"
+msgstr "స్పెయిన్"
+
+#: ../panels/common/cc-common-language.c:688
+msgid "China"
+msgstr "చైనా"
+
+#: ../panels/common/cc-common-language.c:758
+msgid "Other…"
+msgstr "ఇతర ..."
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr "మరిన్ని…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "ఏ భాషలు కనుగొనలేదు"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "భాష"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "అయినది (_D)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+#| msgid "%b %d %l:%M %p"
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+#| msgid "%d x %d (%s)"
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "జనవరి"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "ఫిబ్రవరి"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "మార్చి"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "ఏప్రిల్"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "మే"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "జూన్"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "జులై"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "ఆగస్టు"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "సెప్టెంబర్"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "అక్టోబర్"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "నవంబర్"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "డిసెంబర్"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "తేది మరియు సమయం"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "గంట"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+#| msgid "minute"
+#| msgid_plural "minutes"
+msgid "Minute"
+msgstr "నిమిషం"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "రోజు"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "నెల"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "సంవత్సరం"
+
+#: ../panels/datetime/datetime.ui.h:21
+#| msgid "Time"
+msgid "Time Zone"
+msgstr "సమయ క్షేత్రం"
+
+#: ../panels/datetime/datetime.ui.h:22
+#| msgid "Search for the string"
+msgid "Search for a city"
+msgstr "పట్టణం కొరకు వెతుకు"
+
+#: ../panels/datetime/datetime.ui.h:23
+#| msgid "Date & Time"
+msgid "Automatic _Date & Time"
+msgstr "స్వయంచాలక తేది మరియు సమయం (_D)"
+
+#: ../panels/datetime/datetime.ui.h:24
+#| msgid "Requires Internet connection"
+msgid "Requires internet access"
+msgstr "ఇంటర్నెట్ అనుసంధానం కావాలి"
+
+#: ../panels/datetime/datetime.ui.h:25
+#| msgid "Automatic _Connect"
+msgid "Automatic Time _Zone"
+msgstr "స్వయంచాలక సమయ క్షేత్రం (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:26
+#| msgid "Date & Time"
+msgid "Date & _Time"
+msgstr "తేది మరియు సమయం (_T)"
+
+#: ../panels/datetime/datetime.ui.h:27
+#| msgid "Firewall _Zone"
+msgid "Time _Zone"
+msgstr "సమయ క్షేత్రం (_Z)"
+
+#: ../panels/datetime/datetime.ui.h:28
+#| msgid "Formats"
+msgid "Time _Format"
+msgstr "సమయ ఫార్మేట్ (_F)"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24-గంటలు"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "తొలి / మలి"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "తేదీ మరియు సమయం మార్చు, సమయ క్షేత్రంతో సహా"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "గడియారం;సమయక్షేత్రం;ప్రదేశం;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "వ్యవస్థ సమయం మరియు తేదీ అమరికలను మార్చు"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "సమయం లేదా తేదీ అమరికలను మార్చుటకు, మీరు ధృవీకరించాలి."
+
+#: ../panels/display/cc-display-panel.c:487
+#| msgid "Close"
+msgid "Lid Closed"
+msgstr "లిడ్ మూసివేయి"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+#| msgid "Mirrored Displays"
+msgid "Mirrored"
+msgstr "మిర్రర్డ్"
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2145
+#| msgid "Primary _button"
+msgid "Primary"
+msgstr "ప్రాథమిక"
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "ఆఫ్"
+
+#: ../panels/display/cc-display-panel.c:497
+#| msgid "Secondary color"
+msgid "Secondary"
+msgstr "రెండవ"
+
+#: ../panels/display/cc-display-panel.c:1533
+#| msgid "Mirrored Displays"
+msgid "Arrange Combined Displays"
+msgstr "కలగలిపిన ప్రదర్శనలు అమర్చు"
+
+#: ../panels/display/cc-display-panel.c:1539
+#: ../panels/display/cc-display-panel.c:1979
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+msgid "_Apply"
+msgstr "వర్తించు (_A)"
+
+#: ../panels/display/cc-display-panel.c:1560
+msgid "Drag displays to rearrange them"
+msgstr "ప్రదర్శనలను పట్టిలాగుతూ వాటిని తిరిగిసర్దవచ్చు"
+
+#: ../panels/display/cc-display-panel.c:2081
+#| msgid "Size:"
+msgid "Size"
+msgstr "పరిమాణము"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2094
+msgid "Aspect Ratio"
+msgstr "ఏస్పెక్ట్ రేషియో"
+
+#: ../panels/display/cc-display-panel.c:2115
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "విభాజకత"
+
+#: ../panels/display/cc-display-panel.c:2146
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "ఈ ప్రదర్శనపై కార్యకలాపాల అవలోకనం మరియు పై పట్టీ చూపుము"
+
+#: ../panels/display/cc-display-panel.c:2152
+#| msgid "Secondary click delay"
+msgid "Secondary Display"
+msgstr "రెండవ ప్రదర్శన"
+
+#: ../panels/display/cc-display-panel.c:2153
+msgid "Join this display with another to create an extra workspace"
+msgstr "అదనపు పనిస్థలం సృష్టించుటకు ఈ ప్రదర్శనను వేరొక దానితో కలుపుము"
+
+#: ../panels/display/cc-display-panel.c:2160
+#| msgid "Orientation"
+msgid "Presentation"
+msgstr "సమర్పణ"
+
+#: ../panels/display/cc-display-panel.c:2161
+msgid "Show slideshows and media only"
+msgstr "స్లైడ్‌షో మరియు మాధ్యమం మాత్రమే చూపుము"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2166
+msgid "Mirror"
+msgstr "మిర్రర్"
+
+#: ../panels/display/cc-display-panel.c:2167
+msgid "Show your existing view on both displays"
+msgstr "రెండు ప్రదర్శనలపై మీరు దర్శించునది చూపుము"
+
+#: ../panels/display/cc-display-panel.c:2173
+#| msgid "_Turn On"
+msgid "Turn Off"
+msgstr "ఆఫ్ చేయి"
+
+#: ../panels/display/cc-display-panel.c:2174
+#| msgid "Panel to display"
+msgid "Don't use this display"
+msgstr "ఈ ప్రదర్శనను ఉపయోగించవద్దు"
+
+#: ../panels/display/cc-display-panel.c:2383
+msgid "Could not get screen information"
+msgstr "తెర సమాచారమును పొందలేక పోయింది"
+
+#: ../panels/display/cc-display-panel.c:2414
+#| msgid "Mirrored Displays"
+msgid "_Arrange Combined Displays"
+msgstr "కలగలిపిన ప్రదర్శనలు అమర్చు (_A)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "ప్రదర్శనలు"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr "అనుసంధానిత మానిటర్స్ మరియు ప్రొజెక్టర్స్ యెలా వుపయోగించాలో యెంచుకొనుము"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "పానల్;ప్రొజెక్టర్;xrandr;తెర;రిజొల్యూషన్;రీఫ్రెష్;మానిటర్;"
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr "వేలాండ్"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "తెలియని"
+
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-బిట్"
+
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr "%d-బిట్"
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr "ఏమి చేయాలో అడుగు"
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr "ఏమి చేయవద్దు"
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr "సంచయం తెరువు"
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr "ఇతర మాధ్యమం"
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr "ఆడియో సీడీల కొరకు ఒక అనువర్తనాన్ని ఎంచుకోండి"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr "వీడియో డీవీడీల కొరకు ఒక అనువర్తనాన్ని ఎంచుకోండి"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr "సంగీత ఆటకం అనుసంధానమైనప్పుడు నడుపుటకు ఒక అనువర్తనం ఎంచుకోండి"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr "కెమేరా అనుసంధానమైనప్పుడు నడుపుటకు ఒక అనువర్తనము ఎంచుకోండి"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr "సాఫ్ట్‍వేర్ సీడీల కొరకు ఒక అనువర్తనాన్ని ఎంచుకోండి"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr "ఆడియో DVD"
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr "ఖాళీ బ్లూ-రే డిస్కు"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr "ఖాళీ CD డిస్కు"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr "ఖాళీ DVD డిస్కు"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr "ఖాళీ HD DVD డిస్కు"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr "బ్లూ-రే వీడియో డిస్కు"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr "ఈ-పుస్తకం చదువరి"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr "HD DVD వీడియో డిస్కు"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr "చిత్రల సీడీ"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr "సూపర్ వీడియో సీడీ"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr "వీడియో సీడీ"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr "విండోస్ సాఫ్ట్‍వేర్"
+
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1917
+msgid "Section"
+msgstr "విభాగం"
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "అవలోకనం"
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "అప్రమేయ అనువర్తనాలు"
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "తీసివేయదగిన మాధ్యమం"
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr "రూపాంతరం %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:44
+msgid "Details"
+msgstr "వివరాలు"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "మీ వ్యవస్థ గురించి సమాచారం దర్శించు"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"పరికరం;వ్యవస్థ;సమాచారం;మెమోరీ;ప్రోసెసర్;రూపాంతరం;అప్రమేయం;అనువర్తనం;ప్రాధాన్యమ"
+"ిచ్చేవి;సీడీ;డీవీడీ;యూఎస్‌బీ;"
+"ఆడియో;వీడియో;డిస్క్;తీసివేయదగిన;మాధ్యమం;స్వయంగానడుచు;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "ఇతర మాధ్యమం యెలా సంభాలించబడాలో యెంపికచేయి"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "చర్య (_A):"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "రకం (_T):"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "పరికరం పేరు"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "మెమొరీ"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "ప్రోసెసర్"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "ప్రాధమిక వ్యవస్థ"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "డిస్కు"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "లెక్కిస్తోంది..."
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "రేఖాచిత్రాలు"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "వర్చ్యులైజేషన్"
+
+#: ../panels/info/info.ui.h:13
+#| msgid "Checking for Updates"
+msgid "Check for updates"
+msgstr "నవీకరణల కొరకు పరిశీలించుము"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "జాలం (_W)"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "మెయిల్ (_M)"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "క్యాలెండర్ (_C)"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "సంగీతం (_u)"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "వీడియో (_V)"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "ఫోటోలు (_P)"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "మాధ్యమం యెలా సంభాలించబడాలో యెంపికచేయి"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "సీడీ ఆడియో (_a)"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "డీవీడీ వీడియో (_D)"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "సంగీత ప్రదర్శకం (_M)"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "సాఫ్ట్‍వేర్ (_S)"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "ఇతర మాధ్యమం... (_O)"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"మాధ్యమ ప్రవేశమప్పుడు యెప్పుడూ ప్రోగ్రామ్సు ప్రారంభించవద్దు అడుగవద్దు (_N)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "శబ్దము మరియు మాధ్యమం"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "నిశబ్దం"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "శబ్దము తగ్గించు"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "శబ్దాన్ని పెంచు"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "మాధ్యమ ఆటకాన్ని ప్రారంభించు"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "నడుపు (లేదా నడుపు/నిలిపివుంచు)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "ప్లేబాక్ నిలుపివుంచు"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "ప్లేబ్యాక్ ఆపు"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "క్రితం ట్రాక్"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "తరువాతి ట్రాక్"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "బయటకునెట్టు"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "టైపింగు"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "తరువాతి యిన్పుట్ మూలానికి మారు"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "మునుపటి యిన్పుట్ మూలానికి మారు"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "ప్రారంభకాలు"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "సహాయ విహరిణి దించు"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "అమరికలు"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "గణనపరికరాన్ని ప్రారంభించు"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "ఈమెయిల్ కక్షిదారు ప్రారంభించు"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "జాల విహారకాన్ని ప్రారంభించు"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "నివాస సంచయం"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "అన్వేషించు"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "తెరపట్టులు"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "స్క్రీన్‌షాట్‌ను $PICTURES కు దాయి"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "విండో యొక్క స్క్రీన్‌షాట్‌ను $PICTURES కు దాయి"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "ప్రాంతము యొక్క స్క్రీన్‌షాట్‌ను $PICTURES కు దాయి"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "తెరపట్టును క్లిప్‌బోర్డునకు నకలుచేయి"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "క్లిప్ బోర్డు ఒక విండో యొక్క ఒక తెర ఛాయాచిత్రం నకలు"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "క్లిప్ బోర్డు అనేది ఒక ప్రాంతం యొక్క తెర ఛాయాచిత్రం నకలు"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "పొట్టి తెరపట్టును రికార్డ్ చేయి"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "వ్యవస్థ"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "నిష్క్రమించు"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "తెరకు తాళంవేయి"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "సార్వత్రిక ప్రాప్తి"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "జూమ్‌ను ఆన్ లేదా ఆఫ్ చేయి"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "అతిరూపించండి"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "అవరూపించండి"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "తెర చదువకాన్ని ఆన్ లేదా ఆఫ్ చేయి"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "తెర-పై కీబోర్డును ఆన్ లేక ఆఫ్ చేయి"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "పాఠము పరిమాణము పెంచు"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "పాఠము పరిమాణం తగ్గించు"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "అధిక వ్యత్యాసాన్ని ఆన్‌చేయి లేక ఆపు"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1217
+#: ../panels/network/network-wifi.ui.h:29
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+#: ../panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Disabled"
+msgstr "అచేతనపరచివుంది"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "ప్రత్యామ్నాయ అక్షరాల మీట"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "రచన మీట"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "సవరణిలు-మాత్రమే తరువాతి మూలానికి మారు"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "కీబోర్డు"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "కీబోర్డు లఘువులను దర్శించి మార్చు మరియు మీ టైపింగ్ అభీష్టాలను అమర్చు"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "అడ్డదారి;పునరావృతం;బ్లింక్;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "అనురూపిత అడ్డదారి"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr "జతచేయి (_A)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "పేరు (_N):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "ఆదేశం(_o):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "పునరావృత కీలు"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "కీ నొక్కివుంచినప్పుడు కీ వత్తులు పునరావృతం కావాలి (_r)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "ఆలస్యం(_D):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "వేగం(_S):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "పొట్టి"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "నెమ్మది"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "పునరావృత కీల వేగం"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "పొడవు"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "వేగము"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "కర్సర్ బ్లింకవుచున్నది"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "పాఠ్య క్షేత్రములందు కర్సర్ బ్లింక్‌అవాలి (_b)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "వేగం (_p):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "కర్సర్ రెప్పపాటు వేగం"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "ఇన్‌పుట్ వనరులు"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "అడ్డదారిని జతచేయి"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "అడ్డదారిని తీసివేయి"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr ""
+"ఒక షార్ట్ కట్ ని సరిచేయుటకు,రో పై క్లిక్ చేసి మరియు కొత్త కీలను నొక్కుము లేదా "
+"బ్యాక్ స్పేస్  నొక్కుము "
+"చెరుపుటకు"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "అడ్డదారులు"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:634
+#: ../panels/keyboard/keyboard-shortcuts.c:642
+msgid "Custom Shortcuts"
+msgstr "అనురూపిత అడ్డదారులు"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:859
+msgid "<Unknown Action>"
+msgstr "<తెలియని చర్య>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1356
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"అడ్డదారి \"%s\" ఉపయోగించబడదు ఎంచేతంటే ఈ కీ ఉపయోగించి దీనిని టైపుచేయుట అసాధ్యం "
+"అవుతుంది.\n"
+"Control,Alt లేదా అదే సమయంలో Shift వంటి కీలతో దయచేసి ప్రయత్నించండి."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1386
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"\"%s\" అను అడ్డదారి ఇప్పటికే\n"
+" \"%s\"కొరకు వినియోగంలో వుంది"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1391
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+"మీరు అడ్డదారిని \"%s\"కు తిరిగిఅప్పగిస్తే, \"%s\" అడ్డదారి అచేతనము "
+"చేయబడుతుంది."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1397
+msgid "_Reassign"
+msgstr "తిరిగిఅప్పగించు (_R)"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1429
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr ""
+"\"%s\" లఘువు అనునది \"%s\" లఘువుతో కలిసివుంది. మీరు దానిని స్వయంచాలకంగా \"%"
+"s\" కు అమర్చాలని అనుకుంటున్నారా?"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1435
+#, c-format
+#| msgid ""
+#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#| "disabled."
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr ""
+"\"%s\" ప్రస్తుతం ఇప్పుడు \"%s\" తో కలిసివుంది, మీరు ముందుకు కదిలితే ఈ లఘువు "
+"అచేతనం చేయబడును."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1441
+#| msgid "_Reassign"
+msgid "_Assign"
+msgstr "అప్పగించు (_A)"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "మీ అమరికలను పరీక్షించండి (_S)"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+#| msgid "Test Your _Settings"
+msgid "Test Your Settings"
+msgstr "మీ అమరికలను పరీక్షించండి"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "మౌసు మరియు టచ్‌ప్యాడ్"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"మీ మౌస్ లేదా టచ్‌పాడ్ సెన్సిటివిటిని మార్చు మరియు కుడి లేదా ఎడమచేతి-వాటం "
+"యెంపికచేయండి"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#| msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ట్రాక్‌పాడ్;సూచకి;నొక్కు;టాప్;డబుల్;బటన్;ట్రాక్‌బాల్;స్క్రాల్;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "సాధారణ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "నెమ్మది"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "రెండు-నొక్కుల కాలము"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "వేగము"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "రెండు నొక్కులు(_D)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "ప్రాథమిక బటన్ (_b)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "ఎడమ (_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "కుడి (_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "మౌస్"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "సూచిక వేగం (_P)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "నెమ్మది"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "వేగము"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "టచ్‌ప్యాడ్"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "నెమ్మది"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "వేగము"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr "టంకిస్తున్నప్పుడు అచేతనించు (_t)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr "నొక్కుటకు తాకండి (_c)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr "రెండు-వేళ్ళ జరుపుట (_f)"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+#| msgid "_Edge scrolling"
+msgid "_Natural scrolling"
+msgstr "సాధారణ స్క్రాలింగ్ (_N)"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "నొక్కుటను, రెండుమార్లు నొక్కుటను, జురుపుటను ప్రయత్నించండి"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "ఐదు నొక్కులు, GEGL సమయం!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "రెండు నొక్కులు, ప్రాథమిక బటన్"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "ఒక నొక్కు, ప్రాధమిక బటన్"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "రెండు నొక్కులు, మధ్య బటన్"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "ఒక నొక్కు, మధ్య బటన్"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "రెండు-నొక్కులు, రెండవ బటన్"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "ఒక నొక్కు, రెండవ బటన్"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:366
+msgid "Air_plane Mode"
+msgstr "విమానం రీతి (_p)"
+
+#: ../panels/network/cc-network-panel.c:965
+msgid "Network proxy"
+msgstr "నెట్‌వర్క్ ప్రోక్సీ"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1289
+msgid "The system network services are not compatible with this version."
+msgstr "ఈ రూపాంతరంతో సిస్టమ్ నెట్వర్కు సేవలు సారూప్యతను కలిగిలేవు."
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x రక్షణ (_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "పుట 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "ఎనానిమస్ గుర్తింపు (_m)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "అంతర ధృవీకరణ (_a)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "పుట 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Security"
+msgstr "రక్షణ"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "స్వయంచాలక"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:217
+#: ../panels/network/net-device-wifi.c:378
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:221
+#: ../panels/network/net-device-wifi.c:383
+#: ../panels/network/network-wifi.ui.h:17
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:225
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:230
+msgid "Enterprise"
+msgstr "ఎంటర్‌ప్రైజ్"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:235
+#: ../panels/network/net-device-wifi.c:368
+msgctxt "Wifi security"
+msgid "None"
+msgstr "ఏదీకాదు"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "ఎన్నటికీకాదు"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:819
+msgid "Today"
+msgstr "నేడు"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:822
+msgid "Yesterday"
+msgstr "నిన్న"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:472
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i రోజు క్రితం"
+msgstr[1] "%i రోజుల క్రితం"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:529
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:558
+msgctxt "Signal strength"
+msgid "None"
+msgstr "ఏదీకాదు"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:560
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "బలహీనం"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "సరే"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "మంచిది"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "బాగుంది"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:45
+msgid "Identity"
+msgstr "గుర్తింపు"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "చిరునామా"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "నెట్‌మాస్క్"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "సింహద్వారం"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "చిరునామా తొలగించు"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "జతచేయి"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "సేవిక"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "DNS సేవికను తొలగించు"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "మెట్రిక్"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "రౌట్ తొలగించు"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:25
+msgid "Automatic (DHCP)"
+msgstr "స్వయంచాలక (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:24
+msgid "Manual"
+msgstr "మానవీయ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "లింక్-లోకల్ మాత్రమే"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:46
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "ప్రిఫిక్స్"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "స్వయంచాలక"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "స్వయంచాలక, DHCP మాత్రమే"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:47
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:49
+msgid "Reset"
+msgstr "తిరిగివుంచు"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "ఏదీకాదు"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit Key (Hex or ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit Passphrase"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dynamic WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Personal"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA మరియు WPA2 ఎంటర్‌ప్రైజ్"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:2
+msgid "Signal Strength"
+msgstr "సంకేతం బలం"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Link speed"
+msgstr "లంకె వేగం"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 చిరునామా"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 చిరునామా"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:7
+msgid "Hardware Address"
+msgstr "హార్డ్‍వేర్ చిరునామా"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:8
+msgid "Default Route"
+msgstr "అప్రమేయ మార్గం"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:9
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "చివరిగా వాడినది"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "ట్విస్టెడ్ పెయిర్ (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "ఎటాచ్‌మెంట్ యూనిట్ యింటర్ఫేస్ (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "మాధ్యమం యిండిపెండెంట్ యింటర్ఫేస్ (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "పేరు (_N)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:36
+msgid "_MAC Address"
+msgstr "_MSC చిరునామా"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "క్లోన్‌డ్ చిరునామా (_C)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "బైట్లు"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "యితర వాడుకరులకు అందుబాటులో వుంచు (_u)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "స్వయంచాలకంగా అనుసంధానించు (_a)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "ఫైర్‌వాల్ క్షేత్రం (_Z)"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "అప్రమేయం"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "క్షేత్రము అనుసంధానము యొక్క విశ్వాస స్థాయిను నిర్వచించును"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:22
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:23
+msgid "_Addresses"
+msgstr "చిరునామా (_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "స్వయంచాలక DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Routes"
+msgstr "రౌట్స్"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "స్వయంచాలక రౌట్స్"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Use this connection _only for resources on its network"
+msgstr "దాని నెట్వర్కుపైని వనరుల కొరకు మాత్రమే యీ అనుసంధానం వుపయోగించు (_o)"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:34
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "అనుసంధానం కూర్పరి తెరువలేక పోయింది"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "కొత్త ప్రొఫైల్"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "బాండ్"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "జట్టు"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "బ్రిడ్జ్"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "VPN ప్లగిన్స్ లోడు చేయలేక పోయింది"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "ఫైలునుండి దిగుమతిచేయి..."
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "నెట్వర్కు అనుసంధానం జతచేయి"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Reset"
+msgstr "తిరిగివుంచు (_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1449
+#: ../panels/network/network-wifi.ui.h:40
+msgid "_Forget"
+msgstr "మరచిపో (_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr ""
+"ఈ నెట్వర్కుకు అమరికలను తిరిగివుంచు, సంకేతపదములతో సహా, అయితే దీనిని అబీష్ట "
+"నెట్వర్కు వలె గుర్తించు"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr ""
+"ఈ నెట్వర్కునకు సంభందించిన అన్ని వివరాలను తీసివేయి మరియు స్వయంచాలకంగా "
+"అనుసంధానించుటకు ప్రయత్నించవద్దు"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "S_ecurity"
+msgstr "రక్షణ (_e)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "VPN అనుసంధానంను దిగుమతి చేయలేదు"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"ఫైలు '%s' చదువబడలేదు లేదా గుర్తించిన VPN అనుసంధాన సమాచారం కలిగిలేదు\n"
+"\n"
+"దోషం: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "దిగుమతి చేయుటకు ఫైలును యెంపికచేయి"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1948
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:223
+msgid "_Open"
+msgstr "తెరువు (_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "\"%s\" పేరుతో ఫైలు యిప్పటికే వుంది."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "పునఃస్థాపించు (_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "మీరు దాయుచున్న VPN అనుసంధానంతో %s ను పునఃస్థాపించాలని అనుకొనుచున్నారా?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "VPN అనుసంధానం ఎగుమతి చేయలేదు"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN అనుసంధానం '%s' అనునది %sకు యెగుమతి కాలేదు.\n"
+"\n"
+"దోషం: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+#| msgid "Export VPN connection..."
+msgid "Export VPN connection"
+msgstr "VPN అనుసంధానం ఎగుమతిచేయి"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(దోషం: VPN అనుసంధానం సరికూర్పరిని లోడు చేయలేక పోతోంది)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:12
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:13
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:16
+msgid "My Home Network"
+msgstr "నా హోమ్ నెట్వర్కు"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "ఇతర వాడుకరులకు అందుబాటులో వుంచు (_o)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "నెట్‌వర్క్"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "మీరు యింటర్నెట్‌కు యెలా అనుసంధానం కావాలో నియంత్రించు"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
+#| "vpn;vlan;bridge;bond;"
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "బాండ్ స్లేవ్స్"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(ఏదీకాదు)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "బ్రిడ్జ్ స్లేవ్స్"
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:458
+msgid "never"
+msgstr "ఎన్నటికీకాదు"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:468
+msgid "today"
+msgstr "నేడు"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:470
+msgid "yesterday"
+msgstr "నిన్న"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP చిరునామా"
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Last used"
+msgstr "చివరిగా వాడినది"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "వయర్డ్"
+
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1604
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "ఐచ్ఛికాలు..."
+
+#: ../panels/network/net-device-ethernet.c:474
+#, c-format
+msgid "Profile %d"
+msgstr "ప్రొఫైల్ %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "కొత్త అనుసంధానాన్ని జతచేయి"
+
+#: ../panels/network/net-device-team.c:77
+#| msgid "Bridge slaves"
+msgid "Team slaves"
+msgstr "టీమ్ స్లేవ్స్"
+
+#: ../panels/network/net-device-wifi.c:1153
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"మీరు వైర్‌లెస్ కాక యింకా వేరే యింటర్నెట్ అనుసంధానం కలిగివుంటే, మీరు మీ "
+"యింటర్నెట్ అనుసంధానం పంచుకొనుటకు "
+"వైర్‌లెస్ హాట్‌స్పాట్ అమర్చవచ్చు."
+
+#: ../panels/network/net-device-wifi.c:1157
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+"వైర్‌లెస్ హాట్‌స్పాట్ల మధ్యన మారుట అనునది మీ అనుసంధానమును <b>%s</b> నుండి "
+"తెంచును."
+
+#: ../panels/network/net-device-wifi.c:1161
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"హాట్‌స్పాట్ క్రియాశీలముగా వున్నప్పుడు మీ వైర్‌లెస్ ద్వారా యింటర్నెట్‌ను "
+"యాక్సెస్ చేయుట సాధ్యంకాదు."
+
+#: ../panels/network/net-device-wifi.c:1238
+msgid "Stop hotspot and disconnect any users?"
+msgstr "హాట్ స్పాట్‌ను ఆపి ఏ వినియోగదారుడినైనా తెంచవచ్చునా?"
+
+#: ../panels/network/net-device-wifi.c:1241
+msgid "_Stop Hotspot"
+msgstr "హాట్ స్పాట్‌ను ఆపివేయి (_S)"
+
+#: ../panels/network/net-device-wifi.c:1313
+msgid "System policy prohibits use as a Hotspot"
+msgstr "హాట్‌స్పాట్ వలె వుపయోగించుటకు వ్యవస్థ విధానం నిషేధించును"
+
+#: ../panels/network/net-device-wifi.c:1316
+msgid "Wireless device does not support Hotspot mode"
+msgstr "హాట్‌స్పాట్ రీతికి వైర్‌లెస్ పరికరం తోడ్పాటునిచ్చుటలేదు"
+
+# c-format
+#: ../panels/network/net-device-wifi.c:1445
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"ఎంపికచేసిన నెట్వర్కు కొరకు నెట్వర్కు వివరాలు, సంకేతపదములతో సహా మలచుకొనిన "
+"ఆకృతీకరణ కోల్పోవును."
+
+#: ../panels/network/net-device-wifi.c:1753
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "చరిత్ర"
+
+#: ../panels/network/net-device-wifi.c:1757
+#: ../panels/wacom/cc-wacom-page.c:533
+msgid "_Close"
+msgstr "మూసివేయి (_C)"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1765
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "మరచిపో (_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "ఆకృతీకరణ URL అందివ్వనప్పుడు వెబ్ ప్రోక్సీ ఆటోడిస్కవరీ వుపయోగించబడును."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "నమ్మదగని పబ్లిక్ నెట్వర్కులకు దీనిని సిఫార్సు చేయడంలేదు."
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "ప్రోక్సీ"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "ప్రొఫైల్ జతచేయి... (_A)"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "సరఫరాదారు"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "ఏదీకాదు"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "మానవీయం"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "స్వయంచాలకం"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "పద్ధతి (_M)"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "URL ను రూపకరించు (_C)"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "HTTP ప్రోక్సీ (_H)"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "HTTPS ప్రోక్సీ (_T)"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "FTP ప్రోక్సీ (_F)"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "సాక్స్ హోస్ట్(_S)"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "అతిధేయాలను విస్మరించు (_I)"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "HTTP ప్రోక్సీ పోర్ట్"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "HTTPS ప్రోక్సీ పోర్ట్"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "FTP ప్రోక్సీ పోర్ట్"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "సాక్స్ ప్రోక్సీ పోర్టు"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "పరికరాన్ని ఆపు"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "పరికరాన్ని జతచేయండి"
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "పరికరాన్ని తీసివేయి"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN రకం"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "గుంపు పేరు"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "గుంపు సంకేతపదం"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "వాడుకరిపేరు"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "VPN అనుసంధానం ఆపు"
+
+#: ../panels/network/network-wifi.ui.h:1
+msgid "Automatic _Connect"
+msgstr "స్వయంచాలక ప్రవేశం (_C)"
+
+#: ../panels/network/network-wifi.ui.h:11
+msgid "details"
+msgstr "వివరాలు"
+
+#: ../panels/network/network-wifi.ui.h:15
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "సంకేతపదం (_P)"
+
+#: ../panels/network/network-wifi.ui.h:18
+msgid "None"
+msgstr "ఏదీకాదు"
+
+#: ../panels/network/network-wifi.ui.h:19
+msgid "Show P_assword"
+msgstr "సంకేతపదాన్ని చూపించు (_a)"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "Make available to other users"
+msgstr "ఇతర వాడుకరులకు అందుబాటులో వుంచు"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "identity"
+msgstr "గుర్తింపు"
+
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Automatic (DHCP) addresses only"
+msgstr "స్వయంచాలక (DHCP) చిరునామాలు మాత్రమే"
+
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Link-local only"
+msgstr "లింక్-లోకల్ మాత్రమే"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Shared with other computers"
+msgstr "ఇతర కంప్యూటర్లతో భాగస్వామ్యమైను"
+
+#: ../panels/network/network-wifi.ui.h:31
+msgid "_Ignore automatically obtained routes"
+msgstr "పొందిన రౌట్లను స్వయంచాలకంగా విస్మరించు (_I)"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "_Cloned MAC Address"
+msgstr "క్లోన్డ్ MAC చిరునామా (_C)"
+
+#: ../panels/network/network-wifi.ui.h:38
+msgid "hardware"
+msgstr "హార్డువేర్"
+
+#: ../panels/network/network-wifi.ui.h:41
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"ఈ అనుసంధానం కొరకు అమరికలను వాటి అప్రమేయాలకు వుంచండి, అయితే అభీష్ట అనుసంధానంగా "
+"గుర్తుంచుకో."
+
+#: ../panels/network/network-wifi.ui.h:42
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"ఈ నెట్వర్కునకు సంభందించిన అన్ని వివరాలను తీసివేయి మరియు స్వయంచాలకంగా దానికి "
+"అనుసంధానించుటకు "
+"ప్రయత్నించవద్దు."
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid "reset"
+msgstr "తిరిగివుంచు"
+
+#: ../panels/network/network-wifi.ui.h:48
+msgid "Hardware"
+msgstr "హార్డ్‍వేర్"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi హాట్‌స్పాట్"
+
+#: ../panels/network/network-wifi.ui.h:51
+msgid "_Turn On"
+msgstr "చేతనించు (_T)"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi ఆఫ్ చేయి"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "_Use as Hotspot…"
+msgstr "హాట్‌స్పాట్ వుపయోగించు... (_U)"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "_Connect to Hidden Network…"
+msgstr "మరుగునవున్న నెట్వర్కునకు అనుసంధానమవ్వు... (_C)"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_History"
+msgstr "చరిత్ర (_H)"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Wi-Fi నెట్వర్కునకు అనుసంధానమగుటను స్విచ్ ఆఫ్ చేయి"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "Network Name"
+msgstr "నెట్‌వర్క్ పేరు"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Connected Devices"
+msgstr "అనుసంధానమైవున్న పరికరాలు"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Security type"
+msgstr "భద్రత రకం"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Security key"
+msgstr "భద్రత కీ"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "ఎడ్-హాక్"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "ఆకృతి"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "స్థితి తెలియదు"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "అస్థవ్యస్థ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "అందుబాటులోలేదు"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "అనుసంధానిస్తోంది"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "ధృవీకరణ అవసరం"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "అనుసంధానమైంది"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "అననుసంధానిస్తున్నది"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "అనుసంధానం విఫలమైంది"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "స్థితి తెలియదు (జాడలేదు)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "అనుసంధానించబడి లేదు"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "స్వరూపణం విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "ఐపీ స్వరూపణం విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "ఐపీ స్వరూపణం కాలంచెల్లినది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "రహస్యాలు అవసరమైనవి, అయితే అందించబడలేదు"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1X సప్లికెంట్ అనుసంధానంపోయింది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1X సప్లికెంట్ ఆకృతీకరణ విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1X సప్లికెంట్ విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "ధృవీకరణకు 802.1X సప్లికెంట్ చాలా సమయం తీసుకొంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "ప్రారంభమవుటకు PPP సేవ విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "పిపిపి సేవ అననుసంధానించబడింది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "ప్రారంభమగుటకు DHCP క్లైంట్ విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP కక్షిదారు దోషం"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP కక్షిదారు విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "ప్రారంభమగుటకు భాగస్వామ్య అనుసంధానం విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "భాగస్వామ్య అనుసంధాన సేవ విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "ప్రారంభమగుటకు AutoIP సేవ విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "స్వయంఐపీ సేవ దోషం"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "స్వయంఐపీ సేవ విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "లైన్ రద్దీగా వుంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "డైల్ టోన్ లేదు"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "ఏ వాహకం ఏర్పరచలేక పోయింది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "డయిలింగ్ అభ్యర్ధన కాలం మించినది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "డయిలింగ్ యత్నం విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "మోడెమ్ ఆరంభించుటలో విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "తెలిపిన APNను యెంపికచేయుటకు విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "నెట్వర్కుల కొరకు అన్వేషించుటలేదు"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "నెట్‌వర్క్ నమోదు తిరస్కరించబడింది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "నెట్వర్కు నమోదీకరణ సమయం మించినది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "అభ్యర్ధించిన నెట్వర్కుతో నమోదగుటకు విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "పిన్ పరిశీలన విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "పరికరంకు ఫర్మువేర్ బహుశా దొరకట్లేదు"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "అనుసంధానం అదృశ్యమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "ఇప్పటికే వున్న అనుసంధానం పరిగణించడమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "మోడెమ్ కనపడలేదు"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "బ్లూటూత్ అనుసంధానం విఫలమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "సిమ్ కార్డు పెట్టలేదు"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "సిమ్ పిన్ అవసరం"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "SIM Puk అవసరమైంది"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "సిమ్ తప్పు"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "అనుసంధానించిన రీతిని యిన్ఫీబాండ్ పరికరం తోడ్పాటునీయటులేదు"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "అనుసంధానం ఆధారం విఫలమైంది"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "ఫిర్మ్‍వేర్ తప్పిపోయినది"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "కేబుల్ తీసివేయబడింది"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "ధృవీకరణపత్ర అధికారికం ధృవీకరణపత్రం యెంచుకోబడలేదు"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr ""
+" ధృ‌వీకరణపత్ర ఆధికారిక (CA) ధృవీకరణపత్రం వుపయోగించుట లేదు సురక్షితం కాని "
+"అనుసంధానములనందు, రోగ్ "
+"Wi-Fi నెట్వర్కులకు కారణమగును. మీరు ధృవీకరణపత్ర అధికారిక ధృవీకరణపత్రం "
+"యెంచుకోవాలని "
+"అనుకొనుచున్నారా?"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "విస్మరించు"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "CA ధృవీకరణపత్రం యెంపికచేయి"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, లేదా PKCS#12 వ్యక్తిగత కీలు (*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER లేదా PEM ధృవీకరణపత్రాలు (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+#| msgid "Choose a PAC file..."
+msgid "Choose a PAC file"
+msgstr "PAC ఫైలు యెంపికచేయి"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC ఫైళ్ళు (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC ఫైలు (_f)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "అంతర ధృవీకరణ (_I)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "PAC ప్రొవిజనింగ్ (_v)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "పేరులేని"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "దృవీకరించబడిన"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "రెండూ"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "వాడుకరిపేరు (_U)"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "సంకేతపదాన్ని చూపించు (_w)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+#| msgid "Choose a Certificate Authority certificate..."
+msgid "Choose a Certificate Authority certificate"
+msgstr "ధృవీకరణపత్ర అధికార ధృవీకరణపత్రం యెంపికచేయి"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "వర్షన్ 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "వర్షన్ 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "C_A ధృవీకరణపత్రం"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP వర్షన్ (_v)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "ఈ సంకేతపదం కొరకు ప్రతిసారి అడుగు (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "ఎన్క్రిప్టుకాని వ్యక్తిగత కీలు సురిక్షితంకావు"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"ఎంపికచేసిన వ్యక్తిగత కీ సంకేతపదంచే రక్షించబడుతున్నట్లు అనిపించుటలేదు. దీని "
+"వలన మీ రక్షణ ఆనవాళ్ళు "
+"రాజీపడవచ్చు. దయచేసి సంకేతపదంతో-రక్షితమగు వ్యక్తిగత కీ యెంపికచేయండి.\n"
+"\n"
+"(మీరు మీ వ్యక్తిగత కీను openssl తో సంకేతపద-రక్షితం చేయవచ్చు)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+#| msgid "Choose your personal certificate..."
+msgid "Choose your personal certificate"
+msgstr "మీ వ్యక్తిగత ధృవీకరణపత్రం యెంపికచేయి"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+#| msgid "Choose your private key..."
+msgid "Choose your private key"
+msgstr "మీ వ్యక్తిగత కీ యెంపికచేయి"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "గుర్తింపు (_d)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "వాడుకరి ధృవీకరణపత్రం (_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "వ్యక్తిగత కీ (_k)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "వ్యక్తిగత కీ సంకేతపదం (_P)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "నన్ను మరలా వారించ వద్దు (_w)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "కాదు"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "అవును"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "టన్నెల్డ్ TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "రక్షిత EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "ధృవీకరణ (_t)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (అప్రమేయం)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "ఓపెన్ వ్యవస్థ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "భాగస్వామ్య కీ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "కీ (_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "కీ చూపు (_w)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP విషయసూచి (_x)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "రకం (_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "ప్రకటనలు"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "శబ్ద హెచ్చరికలు"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "పాపప్ బానర్స్ చూపు"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "బానర్స్ నందు వివరాలు చూపు"
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "లాక్ తెరనందు దర్శించు"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "లాక్ తెర నందు వివరాలు చూపు"
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "ఆన్"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "ప్రకటనలు"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr "ఏ ప్రకటనలు ప్రదర్శించాలి మరియు అవి యేమి చూపాలో నియంత్రించు"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "ప్రకటనలు;బానర్;సందేశం;ట్రే;పాపప్;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "పాప్ అప్ బానర్స్ చూపు"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "లాక్ తెర నందు చూపు"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+#| msgid "Other"
+msgctxt "Online Account"
+msgid "Other"
+msgstr "ఇతర"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "ఖాతాను జతచేయండి"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr "మెయిల్"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr "పరిచయాలు"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "సంభాషణ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "వనరులు"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "ఖాతాలోనికి ప్రవేశించుటలో దోషం"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "ఆనవాళ్ళ గడువు తీరెను."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr "ఈ ఖాతాను చేతనపరచుటకు ప్రవేశించు."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr "సైన్ యిన్ (_S)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "ఖాతాను సృష్టించుటలో దోషం"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "ఖాతాను తీసివేయుటలో దోషం"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "మీరు ఖచ్ఛితంగా ఖాతాను తీసివేయాలనుకుంటున్నారా?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "ఇది ఖాతాను సేవకము నందు తీసివేయదు."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "తీసివేయి (_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "ఆన్‌లైన్ ఖాతాలు"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"మీ ఆన్‌లైన్ ఖాతాలకు  అనుసంధానమై మరియు వాటిని దేని కొరకు వుపయోగించాలో "
+"నిర్ణయించు"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+#| "ownCloud;"
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "ఎటువంటి ఆన్‌లైన్ ఖాతాలు స్వరూపించబడలేదు"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "ఖాతాను తీసివేయండి"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "ఒక ఆన్‌లైన్ ఖాతాను జతచేయి"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"ఒక ఖాతాను జతచేయుట ద్వారా మీ అనువర్తనములు దాని పత్రములను, మెయిల్, పరిచయాలను, "
+"క్యాలెండర్‌ను, "
+"సంభాషణను మరియు మరిన్నింటిని యాక్సెస్ చేసుకొనుటకు అనుమతించును."
+
+#: ../panels/power/cc-power-panel.c:183
+msgid "Unknown time"
+msgstr "సమయం తెలియదు"
+
+#: ../panels/power/cc-power-panel.c:189
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i నిమిషం"
+msgstr[1] "%i నిమిషాలు"
+
+#: ../panels/power/cc-power-panel.c:201
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i గంట"
+msgstr[1] "%i గంటలు"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:209
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:210
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "గంట"
+msgstr[1] "గంటలు"
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "నిమిషం"
+msgstr[1] "నిమిషాలు"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:230
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s పూర్తిగా ఛార్జగు వరకు"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:237
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "హెచ్చరిక: %s మిగిలివుంది"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:242
+#, c-format
+msgid "%s remaining"
+msgstr "%s మిగిలివుంది"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
+msgid "Fully charged"
+msgstr "పూర్తిగా చార్జైనది"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
+msgid "Empty"
+msgstr "ఖాళీ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Charging"
+msgstr "చార్జవుతోంది"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:271
+msgid "Discharging"
+msgstr "చార్జుపోతోంది"
+
+#: ../panels/power/cc-power-panel.c:396
+msgctxt "Battery name"
+msgid "Main"
+msgstr "ముఖ్య"
+
+#: ../panels/power/cc-power-panel.c:398
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "అదనపు"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:470
+msgid "Wireless mouse"
+msgstr "వైర్‌లెస్ మౌస్"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:473
+msgid "Wireless keyboard"
+msgstr "వైరులేని కీబోర్డు"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:476
+msgid "Uninterruptible power supply"
+msgstr "అంతరాయంకలిగించని విద్యుత్ సరఫరా"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Personal digital assistant"
+msgstr "వ్యక్తిగత డిజిటల్ సహాయకం"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Cellphone"
+msgstr "సెల్‌ఫోను"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Media player"
+msgstr "మాధ్యమ ప్రదర్శకం"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Tablet"
+msgstr "టాబ్లెట్"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Computer"
+msgstr "కంప్యూటర్"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
+#: ../panels/power/cc-power-panel.c:2019
+msgid "Battery"
+msgstr "బ్యాటరీ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "చార్జవుతోంది"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "జాగ్రత్త"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Low"
+msgstr "తక్కువ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Good"
+msgstr "బాగుంది"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "పూర్తిగా చార్జైనది"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "ఖాళీ"
+
+#: ../panels/power/cc-power-panel.c:715
+msgid "Batteries"
+msgstr "బ్యాటరీలు"
+
+#: ../panels/power/cc-power-panel.c:1117
+msgid "When _idle"
+msgstr "నిష్క్రియగా వున్నప్పుడు (_i)"
+
+#: ../panels/power/cc-power-panel.c:1445
+msgid "Power Saving"
+msgstr "విద్యుత్ ఆదా"
+
+#: ../panels/power/cc-power-panel.c:1473
+#| msgid "_Screen Brightness"
+msgid "_Screen brightness"
+msgstr "తెర ప్రకాశత (_S)"
+
+#: ../panels/power/cc-power-panel.c:1479
+#| msgid "Keyboard Preferences"
+msgid "_Keyboard brightness"
+msgstr "కీబోర్డు ప్రకాశత (_K)"
+
+#: ../panels/power/cc-power-panel.c:1489
+#| msgid "_Dim Screen when Inactive"
+msgid "_Dim screen when inactive"
+msgstr "క్రియాహీనంగా ఉంటే తెర ప్రకాశత తగ్గించు (_D)"
+
+#: ../panels/power/cc-power-panel.c:1514
+#| msgid "_Blank Screen"
+msgid "_Blank screen"
+msgstr "శూన్య తెర (_B)"
+
+#: ../panels/power/cc-power-panel.c:1551
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: ../panels/power/cc-power-panel.c:1556
+msgid "Turns off wireless devices"
+msgstr "వైర్‌లెస్ పరికరాలను ఆఫ్ చేయును"
+
+#: ../panels/power/cc-power-panel.c:1581
+#| msgid "_Mobile Broadband"
+msgid "_Mobile broadband"
+msgstr "మొబైల్ బ్రాడ్‌బాండ్ (_M)"
+
+#: ../panels/power/cc-power-panel.c:1586
+#| msgid "Turns off Mobile Broadband (3G, 4G, WiMax, etc.) devices"
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "మొబైల్ బ్రాడ్‌బ్యాండ్ (3G, 4G, WiMax, మొద.) పరికరాలను ఆఫ్ చేయును"
+
+#: ../panels/power/cc-power-panel.c:1635
+msgid "_Bluetooth"
+msgstr "బ్లూటూత్ (_B)"
+
+#: ../panels/power/cc-power-panel.c:1686
+msgid "When on battery power"
+msgstr "బ్యాటరీ విద్యుత్ పై వున్నప్పుడు"
+
+#: ../panels/power/cc-power-panel.c:1688
+msgid "When plugged in"
+msgstr "అనుసంధానించినపుడు"
+
+#: ../panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Off"
+msgstr "నిలిపివేయి మరియు విద్యుత్ ఆపు"
+
+#: ../panels/power/cc-power-panel.c:1851
+#| msgid "_Automatic Suspend"
+msgid "_Automatic suspend"
+msgstr "స్వయంచాలక నిలుపుదల (_A)"
+
+#: ../panels/power/cc-power-panel.c:1875
+#| msgid "When Battery Power is _Critical"
+msgid "When battery power is _critical"
+msgstr "బ్యాటరీ విద్యుత్ క్లిష్టస్థితిలో ఉన్నప్పుడు (_C)"
+
+#: ../panels/power/cc-power-panel.c:1930
+msgid "Power Off"
+msgstr "విద్యుత్ ఆపండి"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Devices"
+msgstr "పరికరాలు"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "విద్యుత్"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr "మీ బ్యాటరీ స్థితి దర్శించి మరియు విద్యుత్ ఆదా అమరికలను మార్చు"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"విద్యుత్;నిద్రావస్థ;నిలిపివేయి;సుప్తావస్థ;బ్యాటరీ;ప్రకాశత;డిమ్;శూన్యం;మానిటర్;"
+"DPMS;నిష్క్రియ;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "సుప్తావస్థ"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "విద్యుత్ ఆపండి"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "45 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 గంట"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "80 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "90 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "100 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "2 గంటలు"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 నిమిషం"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "4 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "8 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "12 నిమిషాలు"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "స్వయంచాలక నిలుపుదల"
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr "చొప్పించిన (_P)"
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr "బ్యాటరీ విద్యుత్ పైన (_B)"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "ఆలస్యం"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "దృవీకరించు"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "సంకేతపదం"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "ధృవీకరణ అవసరమైంది"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr "టోనర్ తక్కువగా ఉంది"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr "టోనర్ అయిపోయింది"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr "అభివృద్దికారి దిగువ"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr "అభివృద్దికారి బయట"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr "మార్కర్ పంపిణీ దిగువ"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr "మార్కర్ పంపిణీ బయట"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr "తెరుచు కవర్"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr "ద్వారమును తెరువు"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr "కాగితం దిగువ"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr "కాగితం బయట"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ఆఫ్‌లైన్"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "నిలిపివేయబడింది"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr "వ్యర్థం వుండేచోటు దాదాపు నిండింది"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr "వ్యర్థం వుండేచోటు నిండింది"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr "ఆప్టికల్ ఫోటో కండక్టర్ అంత్యదశకు చేరుతోంది"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ఆప్టికల్ ఫోటో కండక్టర్ పనిచేయుట లేదు"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "స్వరూపిస్తోంది"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr "సిద్దం"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "పనులను ఆమోదించదు"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr "క్రమగతి"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Toner Level"
+msgstr "టోనర్ స్థాయి"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Ink Level"
+msgstr "సిరా స్థాయి"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:928
+msgid "Supply Level"
+msgstr "పంపిణీ స్థాయి"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:946
+msgctxt "printer state"
+msgid "Installing"
+msgstr "స్థాపిస్తోంది"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1123
+msgid "No printers available"
+msgstr "ఏ ముద్రకాలు అందుబాటులోలేవు"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1433
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u క్రియాశీలత"
+msgstr[1] "%u క్రియాశీలత"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1777
+msgid "Failed to add new printer."
+msgstr "కొత్త ముద్రకాన్ని జతచేయుటలో విఫలమైంది."
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid "Select PPD File"
+msgstr "PDD దస్త్రాన్ని ఎంచుకోండి"
+
+#: ../panels/printers/cc-printers-panel.c:1953
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"పోస్టుస్క్రిప్ట్ ప్రింటర్ డిస్క్రిప్షన్ ఫైళ్ళు (*.ppd, *.PPD, *.ppd.gz, "
+"*.PPD.gz, *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2258
+msgid "No suitable driver found"
+msgstr "సరిపోయే చోదకం ఏమీ కనపడలేదు"
+
+#: ../panels/printers/cc-printers-panel.c:2327
+msgid "Searching for preferred drivers…"
+msgstr "అభీష్ట చోదకంల కొరకు అన్వేషిస్తోంది..."
+
+#: ../panels/printers/cc-printers-panel.c:2342
+msgid "Select from database…"
+msgstr "డేటాబేసు నుండి ఎంచుకోండి..."
+
+#: ../panels/printers/cc-printers-panel.c:2351
+msgid "Provide PPD File…"
+msgstr "PPD ఫైల్ అందించు..."
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2502
+#: ../panels/printers/cc-printers-panel.c:2525
+msgid "Test page"
+msgstr "పరీక్ష పేజీ"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2933
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "అంతరవర్తి నింపలేకుంది: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "ముద్రకాలు"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"ముద్రికలను జతచేయి, ముద్రణ పనులను దర్శించి మరియు యెలా ముద్రించాలో నిర్ణయించు"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "ముద్రకం;వరుస;ముద్రించు;కాగితం;సిరా;టోనర్;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "క్రియాశీల కార్యాలు"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "మూసివేయి"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "ముద్రణను తిరిగి కొనసాగించు"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "ముద్రణను నిలిపివేయి"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "ముద్రణా కార్యాన్ని రద్దుచేయి"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "ఒక కొత్త ముద్రకాన్ని జతచేయి"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+#| msgid "Authenticate"
+msgid "A_uthenticate"
+msgstr "దృవీకరించు (_u)"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "ఏ ముద్రకాలు కనిపెట్టబడలేదు."
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+#| msgid "Search for network printers or filter result"
+msgid "Enter address of a printer or a text to filter results"
+msgstr "ఫలితాలను వడపోయుటకు ముద్రకం లేదా పాఠం చిరునామా ప్రవేశపెట్టండి"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "ఐచ్ఛికాలు నింపుతోంది..."
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "ముద్రకం చోదకాన్ని ఎంచుకోండి"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "చోదకంల డాటాబేస్ లోడుచేస్తోంది..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+#| msgid "Remove Printer"
+msgid "JetDirect Printer"
+msgstr "JetDirect ముద్రకం"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+#| msgid "%s Printer"
+msgid "LPD Printer"
+msgstr "LPD ముద్రకం"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "ఒక వైపు"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "లాంగ్ యెడ్జ్ (ప్రామాణికమైంది)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "షార్ట్ యెడ్జ్ (ఫ్లిప్)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "అడ్డచిత్రం"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "అడ్డచిత్రం"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "అపసవ్య లాండ్‌స్కేప్"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "అపసవ్య పొర్ట్రైట్"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "పెండింగు"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "నిలిపివేయబడినది"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "క్రమగతి"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "ఆపివేయబడింది"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "రద్దుచేయబడింది"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "మధ్యలో రద్దుచేయబడింది"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "పూర్తయినది"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "కార్య శీర్షిక"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "కార్య స్థితి"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "సమయం"
+
+#: ../panels/printers/pp-jobs-dialog.c:495
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s క్రియాశీల కార్యాలు"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Serial Port"
+msgstr "వరుస పోర్ట్"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1683
+msgid "Parallel Port"
+msgstr "సమాంతర పోర్ట్"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+#| msgid "Location"
+msgid "Location: %s"
+msgstr "స్థానము: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1744
+#, c-format
+#| msgid "A_ddress:"
+msgid "Address: %s"
+msgstr "చిరునామా: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1768
+#| msgid "_Inner authentication"
+msgid "Server requires authentication"
+msgstr "సేవికకు ధృవీకరణ అవసరం"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "రెండు వైపులా"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "కాగితపు రకం"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "కాగితపు మూలం"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "అవుట్‌పుట్ పళ్లెం"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "గోస్టుస్క్రిప్ట్ ప్రి-ఫిల్టరింగ్"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:531
+msgid "Pages per side"
+msgstr "ఒకవైపుకి పుటలు"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:543
+msgid "Two-sided"
+msgstr "రెండు-వైపులా"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:555
+msgid "Orientation"
+msgstr "సర్దుబాటు"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:652
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "సాధారణం"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "పుట అమరిక"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "స్థాపించదగిన ఐచ్ఛికాలు"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "కార్యము"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "బొమ్మ నాణ్యత"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "రంగు"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "పూర్తిచేస్తోంది"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "ఉన్నతం"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "స్వయం ఎంచు"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "ముద్రకము అప్రమేయం"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "ఎంబడెడ్ గోస్టుస్క్రిప్ట్ ఫాంట్లు మాత్రమే"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "PS స్థాయి 1 కు మార్చు"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "PS స్థాయి 2 కు మార్చు"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "ప్రి-ఫిల్టరింగ్ లేదు"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "తయారీదారు"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "చోదకం"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr ""
+"%s పైన అందుబాటులోని ముద్రకాలను దర్శించుటకు మీ వాడుకరిపేరు మరియు సంకేతపదం "
+"ప్రవేశపెట్టండి."
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "ముద్రకాన్ని జతచేయండి"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "ముద్రకాన్ని తీసివేయి"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "పంపిణీ"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "స్థానము"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+#| msgid "Default Route"
+msgid "_Default printer"
+msgstr "అప్రమేయ ముద్రకం (_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "కార్యాలు"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "పనులను చూపు (_J)"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "మోడల్"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "నామాంకం"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "కొత్త చోదకం అమర్చుతోంది..."
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "పుట 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "పరిశీలనా పేజీని ముద్రించు (_T)"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "ఐచ్ఛికాలు (_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "కొత్త ముద్రకాన్ని జతచేయి"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"క్షమించండి! వ్యవస్థ యొక్క ముద్రణా సేవ\n"
+"అందుబాటులో వున్నట్లు లేదు."
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "తెర లాక్"
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "వాడుక మరియు చరిత్ర"
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr "చెత్తబూట్ట నుండి అన్ని అంశాలను ఖాళీచేయాలా?"
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr "చెత్తబుట్ట నందలి అన్ని అంశాలు శాశ్వతంగా తొలగించబడును."
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "చెత్త ఖాళీచేయి (_E)"
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+#| msgid "Purge Trash & Temporary Files"
+msgid "Delete all the temporary files?"
+msgstr "అన్ని తాత్కాలిక ఫైళ్ళను తొలగించాలా?"
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr "అన్ని తాత్కాలిక దస్త్రములు శాశ్వతంగా తొలగించబడును."
+
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "తాత్కాలిక ఫైళ్ళను శుద్దంచేయి (_P)"
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "చెత్త మరియు తాత్కాలిక ఫైళ్ళు శుద్దంచేయి"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+#| msgid "Software"
+msgid "Software Usage"
+msgstr "సాఫ్ట్‌వేర్ వాడుక"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "గోప్యత"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+"మీ వ్యక్తిగత సమాచారం రక్షించును మరియు యితరులు యేమి చూడాలో నియంత్రించును"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "తెర మూయబడెను"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 సెకన్లు"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 రోజు"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 రోజులు"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 రోజులు"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 రోజులు"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 రోజులు"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 రోజులు"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 రోజులు"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 రోజులు"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 రోజులు"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "ఎప్పటికీ"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"మీ చరిత్రను గుర్తుంచుకొనుట వలన విషయాలను మరలా కనుగొనుటకు శులభతరం అగును. ఈ "
+"అంశములు "
+"నెట్వర్కు నందు యెప్పుడూ భాగస్వామ్యపరచ బడవు."
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "ఇటీవల వుపయోగించిన (_R)"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "చరిత్ర వుంచు (_H)"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "ఇటీవలి చరిత్ర శుబ్రంచేయి (_e)"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "మీరు దూరంగా వున్నప్పుడు తెర లాక్ మీ గోప్యతను రక్షించును."
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "స్వయంచాలక తెర లాక్ (_L)"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "శూన్యం తరువాత తెర లాక్ చేయి (_a)"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "ప్రకటనలను చూపు (_N)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"మీ కంప్యూటర్‌ను అక్కరలేని సున్నితమైన సమాచారం లేకుండా వుంచుటకు తాత్కాలిక "
+"ఫైళ్ళను మరియు చెత్తను "
+"స్వయంచాలకంగా శుద్దపరచును."
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "చెత్తను స్వయంచాలకంగా ఖాళీచేయి (_T)"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "తాత్కాలిక ఫైళ్ళను స్వయంచాలకంగా శుద్దంచేయి (_F)"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "తరువాత శుద్దపరచు (_A)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"మీరు ఏ సాఫ్టువేర్లు ఉపయోగిస్తున్నారు అనే సమాచారం మాకు పంపితే మీకు సరిపోయే "
+"సిఫార్సులను చేయడంలో మాకు దోహదపడును.  "
+"అది మా సాఫ్టువేర్‌ను మెరుగుపరచుడానికి కూడా సహాయకంగా ఉంటుంది.\n"
+"\n"
+"మేము సేకరించే సమాచారం అంతా అజ్ఞాతంగా ఉంచబడును, మరియు మేము ఎప్పటికీ మూడో "
+"వ్యక్తులతో అది పంచుకోము."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "సాఫ్టువేర్ వినియోగపు గణాంకాలు పంపుము (_S)"
+
+#: ../panels/privacy/privacy.ui.h:41
+#| msgid "Privacy"
+msgid "Privacy Policy"
+msgstr "గోప్యతా విధానం"
+
+#: ../panels/privacy/privacy.ui.h:42
+#| msgid "Location"
+msgid "_Location Services"
+msgstr "స్థానం సేవలు (_L)"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "మీ భౌగోళిక స్థానం నిర్ణయించుటలో ఉపయోగపడును"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ఉన్నతమైన"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "మెట్రిక్"
+
+#: ../panels/region/cc-format-chooser.c:284
+msgid "No regions found"
+msgstr "ఏ ప్రాంతములు కనబడలేదు"
+
+#: ../panels/region/cc-input-chooser.c:179
+msgid "No input sources found"
+msgstr "ఏ యిన్పుట్ మూలాలు కనబడలేదు"
+
+#: ../panels/region/cc-input-chooser.c:1076
+#| msgid "Other"
+msgctxt "Input Source"
+msgid "Other"
+msgstr "ఇతర"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:896
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "మార్పులు ప్రభావితం కావుటకు మీ సెషన్ పునఃప్రారంభించబడాలి"
+
+#: ../panels/region/cc-region-panel.c:240
+#: ../panels/user-accounts/um-user-panel.c:897
+msgid "Restart Now"
+msgstr "ఇప్పుడు పునఃప్రారంభించు"
+
+#: ../panels/region/cc-region-panel.c:858
+msgid "No input source selected"
+msgstr "ఏ యిన్పుట్ మూలం యెంపికకాలేదు"
+
+#: ../panels/region/cc-region-panel.c:1088
+msgid "Sorry"
+msgstr "క్షమించండి"
+
+#: ../panels/region/cc-region-panel.c:1090
+msgid "Input methods can't be used on the login screen"
+msgstr "లాగిన్ తెర నందు యిన్పుట్ పద్దతులు వుపయోగించలేము"
+
+#: ../panels/region/cc-region-panel.c:1727
+msgid "Login Screen"
+msgstr "లాగిన్ తెర"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "ఫార్మేట్లు"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "మునుజూపు"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "తేదీలు"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "కాలములు"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "సంఖ్యలు"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "కొలమానం"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "కాగితం"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "ప్రాంతము & భాష"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"మీ ప్రదర్శన భాషను, ఫార్మాట్లను, కీబోర్డు లేఅవుట్లను మరియు యిన్పుట్ మూలాలను "
+"యెంపికచేయండి"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "భాష;నమూనా;కీబోర్డు;యిన్పుట్;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "ఇన్‌పుట్ వనరుని జతచేయి"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "ఇన్‌పుట్ వనరు ఐచ్చికాలు"
+
+#: ../panels/region/input-options.ui.h:2
+msgid "Use the _same source for all windows"
+msgstr "అన్ని విండోల కొరకు అదే వనరును వుపయోగించు (_s)"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Allow _different sources for each window"
+msgstr "ప్రతి విండో కొరకు విభిన్న మూలాలను అనుమతించు (_d)"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Keyboard Shortcuts"
+msgstr "కీబోర్డు లఘువులు"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Switch to previous source"
+msgstr "మునుపటి మూలానికి మారు"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Switch to next source"
+msgstr "తరువాతి మూలానికి మారు"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "కీబోర్డు అమరికలనందు మీరు యీ లఘువులను మార్చగలరు"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "Alternative switch to next source"
+msgstr "తరువాతి మూలమునకు ప్రత్యామ్నాయ స్విచ్"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Left+Right Alt"
+msgstr "ఎడమ+కుడి Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "ఇంగ్లిష్ (యునైటెడ్ కింగ్డమ్)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "యునైటెడ్ కింగ్డమ్"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "ఐచ్ఛికాలు"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"వ్యవస్థనకు లాగిన్ అగునప్పుడు లాగన్ అమరికలు అందరి వాడుకరుల చేత వుపయోగించబడును"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+#| msgid "Places"
+msgctxt "Search Location"
+msgid "Places"
+msgstr "స్థానములు"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+#| msgid "Bookmarks"
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "ఇష్టాంశాలు"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+#| msgid "Other"
+msgctxt "Search Location"
+msgid "Other"
+msgstr "ఇతర"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "స్థానము యెంపికచేయి"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+#| msgid "GOK"
+msgid "_OK"
+msgstr "సరే (_O)"
+
+#: ../panels/search/cc-search-panel.c:176
+msgid "No applications found"
+msgstr "ఏ అనువర్తనములు కనబడలేదు"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "శోధించు"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"క్రియాశీలతల వోవర్‌వ్యూ నందు యే అనువర్తనములు శోధన ఫలితాలను చూపాలో నియంత్రించును"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "అన్వేషించు;కనుగొను;విషయసూచి;మరగునవుంచు;గోప్యత;ఫలితాలు;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "అన్వేషణ స్థానములు"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "పైకి జరపండి"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "క్రిందకు జరుపు"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "అభీష్టాలు"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "ఆన్"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "ఆఫ్"
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+#| msgid "Enabled"
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "చేతనమైంది"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+#| msgid "Active Jobs"
+msgctxt "service is active"
+msgid "Active"
+msgstr "క్రియాశీల"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "ఫోల్డర్ యెంపికచేయి"
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "నకలుతీయు"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "పంచుకొనుచున్నది"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "మీరు యితరులతో యేమి పంచుకోవాలని అనుకొనుచున్నారో నియంత్రించు"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "రిమోట్ లాగిన్ చేతనం లేదా అచేతనం చేయి"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "రిమోట్ లాగిన్ చేతనం లేదా అచేతనం చేయుటకు ధృవీకరమ అవసరమైంది"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:299
+msgid "No networks selected for sharing"
+msgstr "పంచుకొనుటకు ఏ నెట్వర్కులు ఎంపికకాలేదు"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+#| msgid "Network"
+msgid "Networks"
+msgstr "నెట్‌వర్కులు"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "బ్లూటూత్ భాగస్వామ్యం"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr ""
+"బ్లూటూట్ భాగస్వామ్యం అనునది వేరే బ్లూట్ చేతన పరికరాలతో ఫైళ్ళను పంచుకొనుటకు "
+"అనుమతించును"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "నమ్మకమైన పరికరాలనుండి మాత్రమే స్వీకరించు"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "స్వీకరించిన ఫైళ్ళను డౌనులోడ్స్ ఫోల్డర్‌కు దాయి"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "కంప్యూటర్ పేరు"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "వ్యక్తిగత ఫైల్ భాగస్వామ్యం"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "తెర భాగస్వామ్యం"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "మాధ్యమ భాగస్వామ్యం"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "రిమోట్ లాగిన్"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "ఏ నెట్వర్కు యాక్సెస్ లేని కారణంగా కొన్ని సేవలు అచేతనపరచబడెను."
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"వ్యక్తిగత ఫైల్ భాగస్వామ్యం అనునది మిమ్ములను ప్రస్తుత నెట్వర్కునందు యితరులతో "
+"మీ పబ్లిక్ ఫోల్డర్‌ను "
+"పంచుకొనుటకు అనుమతించును: <a href=\"dav://%s\">dav://%s</a> వుపయోగించి"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr "సంకేతపదం అవసరం"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"సెక్యూర్ షెల్ కమాండ్ వుపయోగించి రిమోట్ వాడుకరులను అనుసంధానించుటకు "
+"అనుమతించుము:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"దీనికి అనుసంధానమగుట ద్వారా రిమోట్ వాడుకరులను మీ తెరను దర్శించుటకు లేదా "
+"నియంత్రించుటకు "
+"అనుమతించుము: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:20
+#| msgid "Remote Control"
+msgid "Allow Remote Control"
+msgstr "రిమోట్ నియంత్రణ అనుమతించు"
+
+#: ../panels/sharing/sharing.ui.h:21
+#| msgid "_Password:"
+msgid "Password:"
+msgstr "సంకేతపదం:"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "సంకేతపదమును చూపుము"
+
+#: ../panels/sharing/sharing.ui.h:23
+#| msgid "%s Options"
+msgid "Access Options"
+msgstr "ఏక్సెస్ ఐచ్ఛికాలు"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "ఏక్సెస్ కొరకు కొత్త అనుసంధానాలు తప్పక అడగాలి"
+
+#: ../panels/sharing/sharing.ui.h:25
+#| msgid "Require Password"
+msgid "Require a password"
+msgstr "సంకేతపదం అవసరం"
+
+#: ../panels/sharing/sharing.ui.h:26
+#| msgid "Share Music, Photos and Videos with others on the current network."
+msgid "Share music, photos and videos over the network."
+msgstr "నెట్వర్కునందు సంగీతం, చిత్రాలు మరియు వీడియోలు పంచుకొనుము."
+
+#: ../panels/sharing/sharing.ui.h:27
+#| msgid "Add Folder"
+msgid "Folders"
+msgstr "సంచయాలు"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "శబ్దము"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+"శబ్ద స్థాయిలను, యిన్పుట్లను, అవుట్పుట్లను, మరియు హెచ్చరిక శబ్దములను మార్చు"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "కార్డు;మైక్రోఫోన్;శబ్దం;ఫేడ్;సమతుల్యం;బ్లూటూత్;హెడ్‌సెట్;శ్రవ్యకం;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "మొరుగు"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "నీటిచుక్క"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "గాజు"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "సోనార్"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "ఎడమ"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "కుడి"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "వెనుక"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "ముందు"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "కనిష్టం"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "గరిష్టం"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "సమతుల్యం (_B):"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "వాడిపోవు:(_F)"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "సబ్‌వూఫర్ (_S):"
+
+#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:616
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "అన్‌యాంప్లిఫైడ్"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "ప్రవర (_P):"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u అవుట్‌పుట్"
+msgstr[1] "%u అవుట్‌పుట్లు"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u ఇన్‌పుట్"
+msgstr[1] "%u ఇన్‌పుట్లు"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "వ్యవస్థ శబ్దములు"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "స్పీకర్లను పరీక్షించు (_T)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "పీక్ గుర్తింపు"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1509
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "పేరు"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1528
+msgid "Device"
+msgstr "పరికరం"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1591
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s కొరకు స్పీకర్ పరీక్ష"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1649
+msgid "_Output volume:"
+msgstr "అవుట్‌పుట్ శబ్దం (_O):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "Output"
+msgstr "అవుట్‌పుట్"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1668
+msgid "C_hoose a device for sound output:"
+msgstr "శబ్ద అవుట్‌పుట్ కొరకు ఒక పరికరమును ఎంచుకోండి (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1693
+msgid "Settings for the selected device:"
+msgstr "ఎంపికచేసిన పరికరము కొరకు అమరికలు:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "Input"
+msgstr "ఇన్‌పుట్"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "_Input volume:"
+msgstr "ఇన్‌పుట్ శబ్దం (_I):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1734
+msgid "Input level:"
+msgstr "ఇన్‌పుట్ స్థాయి:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1762
+msgid "C_hoose a device for sound input:"
+msgstr "శబ్ద ఇన్‌పుట్ కొరకు ఒక పరికరమును ఎంచుకోండి (_h):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "Sound Effects"
+msgstr "శబ్ద ప్రభావాలు"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+msgid "_Alert volume:"
+msgstr "హెచ్చరిక శబ్దం (_A):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1809
+msgid "Applications"
+msgstr "అనువర్తనాలు"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1813
+msgid "No application is currently playing or recording audio."
+msgstr "ఏ అనువర్తనము ప్రస్తుతం ఆడియోను నడుపుటలేదు లేదా రికర్డు చేయుటలేదు."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "బుల్ట్-యిన్"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "శబ్ద ప్రాధాన్యతలు"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "పరీక్షణ ఘటన శబ్ధము"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "అప్రమేయం"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "థీమ్ నుండి"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:769
+msgid "C_hoose an alert sound:"
+msgstr "హెచ్చరిక శబ్దమును ఎంచుకోండి (_h):"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "ఆపు"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "పరీక్షించు"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "సబ్‌వూఫర్"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "అనురూపితం"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+"చూడుటకు, వినుటకు, టైపునకు, సూచించుటకు మరియు నొక్కుటకు దీనిని సులభతరం చేయి"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#| msgid ""
+#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;"
+#| "size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+
+#: ../panels/universal-access/uap.ui.h:1
+#| msgid "Universal Access"
+msgid "_Always Show Universal Access Menu"
+msgstr "సార్వత్రిక ఏక్సెస్ మెనూ ఎల్లప్పుడూ చూపుము (_A)"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "చూస్తున్న"
+
+#: ../panels/universal-access/uap.ui.h:3
+#| msgid "High Contrast"
+msgid "_High Contrast"
+msgstr "అధిక కాంట్రాస్ట్ (_H)"
+
+#: ../panels/universal-access/uap.ui.h:4
+#| msgid "Large Text"
+msgid "_Large Text"
+msgstr "అతిపెద్ద పాఠం (_L)"
+
+#: ../panels/universal-access/uap.ui.h:5
+#| msgid "Zoom"
+msgid "_Zoom"
+msgstr "జూమ్ (_Z)"
+
+#: ../panels/universal-access/uap.ui.h:7
+#| msgid "Screen Reader"
+msgid "Screen _Reader"
+msgstr "తెర చదువరి (_R)"
+
+#: ../panels/universal-access/uap.ui.h:8
+#| msgid "Bounce Keys"
+msgid "_Sound Keys"
+msgstr "శబ్ద కీలు (_S)"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "వినుట"
+
+#: ../panels/universal-access/uap.ui.h:10
+#| msgid "Visual Alerts"
+msgid "_Visual Alerts"
+msgstr "దృశ్య హెచ్చరికలు (_V)"
+
+#: ../panels/universal-access/uap.ui.h:12
+#| msgid "Screen keyboard"
+msgid "Screen _Keyboard"
+msgstr "తెర కీబోర్డు (_K)"
+
+#: ../panels/universal-access/uap.ui.h:13
+#| msgid "Typing Assistant"
+msgid "_Typing Assist (AccessX)"
+msgstr "టైపింగు సహాయకం (AccessX) (_T)"
+
+#: ../panels/universal-access/uap.ui.h:14
+#| msgid "Pointing and Clicking"
+msgid "Pointing & Clicking"
+msgstr "ఎత్తిచూపు మరియు క్లిక్ చేయు"
+
+#: ../panels/universal-access/uap.ui.h:15
+#| msgid "Mouse Keys"
+msgid "_Mouse Keys"
+msgstr "మౌస్ కీలు (_M)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "సహాయకి నొక్కండి (_C)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "తెర చదువకం"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+"మీరు ఫోకస్‌ను కదల్చగానే ప్రదర్శించబడుతున్న పాఠంను తెరచదువరి దాన్ని చదువును."
+
+#: ../panels/universal-access/uap.ui.h:19
+#| msgid "Screen Reader"
+msgid "_Screen Reader"
+msgstr "తెర చదువరి (_S)"
+
+#: ../panels/universal-access/uap.ui.h:20
+#| msgid "Bounce Keys"
+msgid "Sound Keys"
+msgstr "శబ్ద కీలు"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "నమ్ లాక్ లేదా కాప్స్ లాక్ ఆన్ చేయగానే బీప్ చేయును."
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "దృశ్యమాన హెచ్చరికలు"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "ఫ్లాష్ పరీక్షించు (_T)"
+
+#: ../panels/universal-access/uap.ui.h:24
+#| msgid "Use a visual indication when an alert sound occurs"
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "హెచ్చరిక శబ్దము కలిగినపుడు  దృశ్య సూచిని ఉపయోగించు."
+
+#: ../panels/universal-access/uap.ui.h:25
+#| msgid "Flash the window title"
+msgid "Flash the _window title"
+msgstr "విండో శీర్షికను ఫ్లాష్ చేయు (_w)"
+
+#: ../panels/universal-access/uap.ui.h:26
+#| msgid "Flash the entire screen"
+msgid "Flash the entire _screen"
+msgstr "పూర్తి తెరను ఫ్లాష్ చేయు (_s)"
+
+#: ../panels/universal-access/uap.ui.h:27
+#| msgid "Typing Assistant"
+msgid "Typing Assist"
+msgstr "టైపింగు సహాయకం"
+
+#: ../panels/universal-access/uap.ui.h:28
+#| msgid "Sticky Keys"
+msgid "_Sticky Keys"
+msgstr "అంటివుండే కీలు (_S)"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "ఒక వరుస మార్పు చేయు కీ లను కీ కలయిక లా భావించును "
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "ఒకవేళ రెండు కీలు ఒకేసారి నొక్కితే అచేతనపరుచు (_D)"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifer key is pressed"
+msgstr "బీప్ ఎపుడైతే ఒక మార్పుచేయనున్న కీ ని ప్రెస్ చేసినపుడు(_m)"
+
+#: ../panels/universal-access/uap.ui.h:32
+#| msgid "Slow Keys"
+msgid "S_low Keys"
+msgstr "నెమ్మది కీలు (_l"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr " కీ నొక్కిన మరియు కీ అంగీకరించబడ్డ మధ్యలో జాప్యమును ఉంచును "
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "అంగీకరించు జాప్యం:(_c)"
+
+#: ../panels/universal-access/uap.ui.h:35
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "పొట్టి"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "నెమ్మది మీటల టైపింగు ఆలస్యం"
+
+#: ../panels/universal-access/uap.ui.h:37
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "పొడవు"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Beep when a key is pr_essed"
+msgstr "కీ వత్తినప్పుడు బీప్‌చేయుము(_e)"
+
+#: ../panels/universal-access/uap.ui.h:39
+#| msgid "Beep when key is _accepted"
+msgid "Beep when a key is _accepted"
+msgstr "కీ ఆమోదించినప్పుడు బీప్ చేయుము (_a)"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "బీప్ ఎపుడైతే ఒక కీ ని తిరస్కిరించినపుడు(_r) "
+
+#: ../panels/universal-access/uap.ui.h:41
+#| msgid "Bounce Keys"
+msgid "_Bounce Keys"
+msgstr "బౌన్సు కీలు (_B)"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "వేగ నకలీ కీప్రెస్ ను పట్టించుకోదు"
+
+#: ../panels/universal-access/uap.ui.h:43
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "పొట్టి"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "బౌన్స్ మీటల టైపింగు ఆలస్యం"
+
+#: ../panels/universal-access/uap.ui.h:45
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "పొడవు"
+
+#: ../panels/universal-access/uap.ui.h:46
+#| msgid "Enable by Keyboard"
+msgid "_Enable by Keyboard"
+msgstr "కీబోర్డుతో చేతనించు (_E)"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "కీబోర్డ్ ఉపయోగించి ప్రవేశయోగ్య విశిష్టతలను చేతనం లేదా అచేతనం చేయి"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "సహాయకి నొక్కండి"
+
+#: ../panels/universal-access/uap.ui.h:49
+#| msgid "Simulated Secondary Click"
+msgid "_Simulated Secondary Click"
+msgstr "సిమ్యులేటెడ్ రెండవ నొక్కు (_S)"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "ప్రధమ బట్టన్ ను నొక్కుతూ ద్వితీయ క్లిక్ ను మొదలెట్టు"
+
+#: ../panels/universal-access/uap.ui.h:51
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "secondary click"
+msgid "Short"
+msgstr "పొట్టి"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "రెండవ నొక్కు ఆలస్యం"
+
+#: ../panels/universal-access/uap.ui.h:53
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "పొడవు"
+
+#: ../panels/universal-access/uap.ui.h:54
+#| msgid "Hover Click"
+msgid "_Hover Click"
+msgstr "హోవర్ క్లిక్ (_H)"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "పాయింటరు హోవర్ అయినప్పుడు క్లిక్ ను మొదలెట్టు"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "ఆలస్యం (_e):"
+
+#: ../panels/universal-access/uap.ui.h:57
+#| msgctxt "keyboard, delay"
+#| msgid "Short"
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "పొట్టి"
+
+#: ../panels/universal-access/uap.ui.h:58
+#| msgctxt "keyboard, delay"
+#| msgid "Long"
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "పొడవు"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "గతి ఉపక్రమణ:(_t)"
+
+#: ../panels/universal-access/uap.ui.h:60
+#| msgctxt "universal access, text size"
+#| msgid "Small"
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "చిన్న"
+
+#: ../panels/universal-access/uap.ui.h:61
+#| msgctxt "universal access, text size"
+#| msgid "Large"
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "పెద్ద"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "లఘువు"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ తెర"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ తెర"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ తెర"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "పొడవు"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "పూర్తి తెర"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "పైన సగం"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "క్రింది సగం"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "ఎడమ సగభాగం"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "కుడి సగభాగం"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "జూమ్ ఐచ్చికాలు"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "జూమ్"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "మాగ్నిఫికేషన్:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "మౌస్ కర్సరును అనుసరించు"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "తెర భాగం:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "బూతద్దపు తెర వెలుపల విస్తరించింది"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "బూతద్దం ములుకు కేంద్రీకృతమై ఉంచండి"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "బూతద్దం ములుకు చుట్టూ ఉన్న విషయాలను నెట్టివేసింది"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "విషయాలను బూతద్దం సూచకితో కదలికలు"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "బూతద్ద స్థానము:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "బూతద్దము"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "మందం:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "సన్నం"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "మందం"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "పొడవు:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "రంగు:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "కేశలు అడ్డంగా:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "సమన్వయం ఎలుక ములుకు"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "క్రాస్‌హెయిర్స్"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "నలుపుపై తెలుపు:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "ప్రకాశత:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "వ్యత్యాసం:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "రంగు"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "ఏదీకాదు"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "పూర్తి"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "తక్కువ"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "ఎక్కువ"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "తక్కువ"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "అధికం"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "రంగుల ప్రభావాలు:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "రంగుల ప్రభావాలు"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "ప్రామాణికం"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "నిర్వాహకుడు"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+#| msgid "Full Name"
+msgid "_Full Name"
+msgstr "పూర్తి నామము (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "ఖాతా రకం (_T)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+#| msgid "Choose password at next login"
+msgid "Allow user to set a password when they next login"
+msgstr "తరువాత ప్రవేశంలో సంకేతపదాన్ని ఎన్నుకొనుటకు వాడుకరిని అనుమతించు"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "ఒక కొత్త సంకేతపదాన్ని అమర్చు"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "నిర్ధారించు (_V)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr ""
+"మనుగడలోవున్న కేంద్రీకృత నిర్వాహిత వాడుకరి ఖాతాను ఈ పరికరంపై ఉపయోగించుటకు "
+"ఎంటర్‌ప్రైజ్ లాగిన్ అనుమతించును."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "డొమైన్ (_D)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"ఎంటర్‌ప్రైజ్ లాగిన్ ఖాతాలను\n"
+"జతచేయుటకు ఆన్‌లైన్‌కు వెళ్ళండి."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "వాడుకరిని జతచేయండి"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "నమోదుచేయి(_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "డొమైన్ నిర్వాహకుని ప్రవేశం"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"ఎంటర్‌ప్రైజ్ లాగిన్స్ వుపయోగించుటకు, ఈ కంప్యూటర్ డొమైన్ నందు ఎన్‌రోల్ "
+"కావలసివుంటుంది\n"
+"మీ నెట్వర్కు నిర్వహణాధికారి వారి డొమైన్ సంకేతపదంను యిక్కడ టైపు చేయవలెను."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "నిర్వాహకుని పేరు (_N)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "నిర్వాహకుని సంకేతపదం"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "ఎడమ బ్రొటన వ్రేలు"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "ఎడమ మధ్య వ్రేలు"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "ఎడమ ఉంగరపు వ్రేలు"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "ఎడమ చిటికెన వ్రేలు"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "కుడి బ్రొటన వ్రేలు"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "కుడి మధ్య వ్రేలు"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "కుడి ఉంగరపు వ్రేలు"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "కుడి చిటికెన వ్రేలు"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:697
+msgid "Enable Fingerprint Login"
+msgstr "వేలిముద్ర ప్రవేశాన్ని చేతనపరుచు"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "కుడి చూపుడు వ్రేలు (_R)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "ఎడమ చూపుడు వ్రేలు (_L)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "ఇతర వేలు (_O):"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"మీ వేలిముద్ర విజయవంతంగా భద్రపరుచబడింది. మీరు ఇప్పుడు మీ వేలిముద్ర "
+"చదువరి(రీడర్) ఉపయోగించి "
+"ప్రవేశించగలుగుతారు."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "వాడుకరులు"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "వాడుకరులను జతచేయి లేదా తీసివేయి మరియు మీ సంకేతపదం మార్చు"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "ప్రవేశించు;పేరు;వేలిముద్ర;అవతారం;చిహ్నం;ముఖం;సంకేతపదం;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "లాగిన్ చరిత్ర"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+#| msgid "Changing password for"
+msgid "Change Password"
+msgstr "సంకేతపదమును మార్చు"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "మార్చు (_a)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+#| msgid "_New password"
+msgid "_Verify New Password"
+msgstr "కొత్త సంకేతపదం నిర్ధారించు (_V)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+#| msgid "_New password"
+msgid "_New Password"
+msgstr "కొత్త సంకేతపదం (_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+#| msgid "Current _password"
+msgid "Current _Password"
+msgstr "ప్రస్తుత సంకేతపదం (_P)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "వాడుకరి ఖాతాను జతచేయి"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "వాడుకరి ఖాతాను తీసివేయి"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "ప్రవేశ ఐచ్ఛికాలు"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "స్వయంచాలక ప్రవేశం (_u)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "వేలిముద్ర ప్రవేశం (_F)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "వాడుకరి ప్రతీక"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "భాష  (_L)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "చివరి ప్రవేశం"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "వాడుకరి ఖాతాలను నిర్వహించు"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "వాడుకరి సమాచారాన్ని మార్చాలంటే ధృవీకరణ అవసరం"
+
+#: ../panels/user-accounts/pw-utils.c:81
+#| msgid "The new password does not contain enough different characters"
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "కొత్త సంకేతపదం పాత సకేతపదానికి వేరుగా ఉండాలి."
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "కొన్ని అక్షరాలు మరియు సంఖ్యలు మార్చుటకు ప్రయత్నించు."
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+#| msgid "Changing password for"
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "సంకేతపదం ఇంకొంచం మార్చడానికి ప్రయత్నించండి."
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "మీ వాడుకరి పేరు లేకుండా సంకేతపదంవుంటే ధృడంగావుంటుంది."
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "సంకేతపదంనందు మీ వాడుకరిపేరు లేకుండా చూసుకోండి."
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "సంకేతపదంనందు కొన్ని పదాలను వాడుకుండా చూసుకోండి."
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "సాధారణ పదాలను వాడుకుండా చూసుకోండి."
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "మనుగడలోవున్న పదాలను రీకార్డ్ చేయుకుండా చూసుకోండి."
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "మరిన్ని సంఖ్యలను ఉపయోగించుటకు ప్రయత్నించండి."
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "మరిన్ని పెద్దబడి అక్షరాలను ఉపయోగించుటకు ప్రయత్నించండి."
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "మరిన్ని చిన్నబడి అక్షరాలను ఉపయోగించుటకు ప్రయత్నించండి."
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "విరామచిహ్మాలు వంటి, ప్రత్యేక అక్షరాలు మరిన్ని ఉండునట్లు చూసుకోండి."
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "అక్షరాలు, సంఖ్యలు మరియు విరామచిహ్నాల సమ్మేళనంగా ఉండునట్లు చూసుకోండి."
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "ఒకే అక్షరాన్ని తిరిగి వాడకుండా చూసుకోండి."
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"ఒకే రకమైన అక్షరం తిరిగి వాడకుండా చూసుకోండి: మీరు అక్షరాలు, సంఖ్యలు మరియు "
+"విరామచిహ్నాలు కలిపివాడాలి."
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 లేదా abcd వంటి వరుసలను వాడకుండా చూసుకోండి."
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "మరిన్ని అక్షరాలు, సంఖ్యలు మరియు చిహ్నాలు జతచేయుటకు చూడండి."
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr "పెద్దబడి మరియు చిన్నబడి మరియు ఒకటి లేదా రెండు సంఖ్యలను కలపండి."
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr ""
+"మంచి సంకేతపదం! మరిన్ని అక్షరాలు, సంఖ్యలు మరియు విరామచిహ్నాలు జతచేస్తే మరింత "
+"దృఢమౌతుంది."
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "పటిష్టత: బలహీనం"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+#| msgid "Length:"
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "పటిష్టత: తక్కువ"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "పటిష్టత: మధ్యమం"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "పటిష్టత: మంచిది"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "పటిష్టత: ధృడమైనది"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "ధృవీకరణ విఫలమైంది"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "కొత్త సంకేతపదం మరీ చిన్నగా ఉంది"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "కొత్త సంకేతపదం చాలా సరళంగా ఉంది"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "పాత మరియు కొత్త సంకేతపదాలు చాలా దగ్గరగా ఉన్నాయి"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "కొత్త సంకేతపదం ఈ మధ్యనే వాడబడింది."
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "కొత్త సంకేతపదం తప్పనిసరిగా సంఖ్యలు లేక ప్రత్యేక అక్షరాలను కలిగివుండాలి"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "పాత మరయు కొత్త సంకేతపదాలు ఒకేవిధంగా ఉన్నాయి"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "మీరు మొదట ధృవీకరణమైనప్పట్టినుంచి మీ రహస్యపదము మారినది"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "కొత్త సంకేతపదం సరిపడినన్ని వైవిధ్య అక్షరాలను కలిగిలేదు"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "తెలియని దోషం"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "మీ ఖాతా అందించువారి వెబ్ చిరునామాతో సరిపోలాలి."
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "ఖాతాను జతచేయుటలో విఫలమైంది"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+#| msgid "Passwords do not match"
+msgid "Passwords do not match."
+msgstr "సంకేతపదాలు సరిపోలటం లేదు."
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr "ఖాతాని నమోదించుటలో విఫలమైంది"
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr "ఈ డొమైన్‌తో ధృవీకరించుటకు తోడ్పాటునిచ్చు మార్గంలేదు"
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr "డొమైన్ నందు జేరుటకు విఫలమైంది"
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"ఆ లాగిన్ పేరు పనిచేయలేదు.\n"
+"దయచేసి తిరిగి ప్రయత్నించండి."
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+#| msgid "Invalid password, please try again"
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"ఆ లాగిన్ సంకేతపదం పనిచేయలేదు.\n"
+"దయచేసి మరలా ప్రయత్నించండి."
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr "డొమైన్ నందు లాగిన్ అగుటకు విఫలమైంది"
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr ""
+"డొమైన్ కనుగొనలేక పోయింది. బహుశా మీరు దానిని సరిగా టైప్ చేసివుండకపోవచ్చు?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:137
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"పరికరమును యాక్సిస్ చేయుటకు మీరు అనుమతిలేదు. మీ సిస్టమ్ నిర్వహణాధికారిని "
+"సంప్రదించండి."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid "The device is already in use."
+msgstr "పరికరము ఇప్పటికే వినియోగంలో వుంది."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "An internal error occurred."
+msgstr "ఒక అంతర్గత దోషం సంభవించినది."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:217
+#: ../panels/user-accounts/um-fingerprint-dialog.c:218
+msgid "Enabled"
+msgstr "చేతనపరిచివుంది"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:266
+msgid "Delete registered fingerprints?"
+msgstr "నమోదైన వేలిముద్రలను తొలగించాలా?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:270
+msgid "_Delete Fingerprints"
+msgstr "వేలిముద్రలను తొలగించు (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:276
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"వేలిముద్ర లాగిన్ అచేతనపరిచే నమోదైన వేలిముద్రల తొలగింపును మారు "
+"చేద్దామనుకొనుచున్నారా?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:452
+msgid "Done!"
+msgstr "అయినది!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:513
+#: ../panels/user-accounts/um-fingerprint-dialog.c:555
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "'%s' పరికరాన్ని యాక్సిస్ చేయలేకపోయింది"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:596
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "'%s' పరికరముపైన వేలి కాప్చరును ప్రారంభించలేక పోయింది"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:647
+msgid "Could not access any fingerprint readers"
+msgstr "ఎటువంటి వేలిముద్ర చదువరులను యాక్సెస్ చేయలేకపోతుంది"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:648
+msgid "Please contact your system administrator for help."
+msgstr "సహాయము కొరకు దయచేసి మీ వ్యవస్థ నిర్వాహకుడిని సంప్రదించండి."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:731
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"వేలిముద్ర ప్రవేశాన్ని చేతనపరచుటకు, '%s' పరికరము ఉపయోగించి మీ వేలిముద్రలలో "
+"ఒకటి "
+"భద్రపరుచవలసివుంటుంది."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:738
+msgid "Selecting finger"
+msgstr "ఎంచుకొనుతున్న వేలు"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:739
+msgid "Enrolling fingerprints"
+msgstr "వేలిముద్రలను నమోదుచేస్తున్నది"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "ఈ వారం"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "ఆఖరి వారం"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+#| msgid "%b %d %Y"
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+#| msgid "%b %d %Y"
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:631
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "సెషన్ చేతనమైంది"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "సెషన్ ప్రారంభించబడింది"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "దయచేసి వేరొక సంకేతపదాన్ని ఎన్నుకోండి."
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "దయచేసి మీ ప్రస్తుత సంకేతపదాన్ని మరలా టైపు చేయండి."
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "సంకేతపదం మార్చబడదు"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+#| msgid "The passwords do not match"
+msgid "The passwords do not match."
+msgstr "సంకేతపదాలు సరిపోలలేదు."
+
+#: ../panels/user-accounts/um-photo-dialog.c:219
+msgid "Browse for more pictures"
+msgstr "మరిన్ని చిత్రముల కొరకు అన్వేషించు"
+
+#: ../panels/user-accounts/um-photo-dialog.c:453
+msgid "Disable image"
+msgstr "బొమ్మని అచేతనపరుచు"
+
+#: ../panels/user-accounts/um-photo-dialog.c:471
+msgid "Take a photo…"
+msgstr "ఒక ఫొటో తీయండి…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:489
+msgid "Browse for more pictures…"
+msgstr "మరిన్ని చిత్రముల కొరకు అన్వేషించు..."
+
+#: ../panels/user-accounts/um-photo-dialog.c:713
+#, c-format
+msgid "Used by %s"
+msgstr "%s చేత వాడబడింది"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "ఈ రకమైన డొమైన్‌కు స్వయంచాలకంగా జేరలేము"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "అటువంటి డొమైన్ లేదా రియాల్మ్ కనుగొనబడలేదు"
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s వలె %s డొమైన్ వద్ద లాగిన్ కాలేకపోయింది"
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr "సంకేతపదం తప్పు, మరలా ప్రయత్నించండి"
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "%s డొమైన్‌కు అనుసంధానం కాలేకపోయింది: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:198
+msgid "Other Accounts"
+msgstr "ఇతర ఖాతాలు"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "Failed to delete user"
+msgstr "వాడుకరిని తొలగించుటలో విఫలమైంది"
+
+#: ../panels/user-accounts/um-user-panel.c:482
+msgid "You cannot delete your own account."
+msgstr "మీరు మీ స్వంత ఖాతాను తొలగించలేరు."
+
+#: ../panels/user-accounts/um-user-panel.c:491
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ఇంకా ప్రవేశించేవున్నారు"
+
+#: ../panels/user-accounts/um-user-panel.c:495
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"ప్రవేశించివున్న వాడుకరిని తొలగించినచో వ్యవస్థను అస్థిరస్థితిలో "
+"వదిలివేయబడవచ్చు."
+
+#: ../panels/user-accounts/um-user-panel.c:504
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "%s యొక్క దస్త్రాలను ఉంచాలనుకుంటున్నారా?"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"వాడుకరి ఖాతాను తొలగించునపుడు నివాస సంచయం,మెయిల్ స్పూల్ మరియు తాత్కాలిక "
+"దస్త్రాలను ఉంచడం కుదురుతుంది"
+
+#: ../panels/user-accounts/um-user-panel.c:511
+msgid "_Delete Files"
+msgstr "దస్త్రాలను తొలగించు (_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:512
+msgid "_Keep Files"
+msgstr "దస్త్రాలను ఉంచు (_K)"
+
+#: ../panels/user-accounts/um-user-panel.c:564
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "ఖాతా అచేతనమైవుంది"
+
+#: ../panels/user-accounts/um-user-panel.c:572
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "తరువాతి ప్రవేశంలో అమర్చబడుతుంది"
+
+#: ../panels/user-accounts/um-user-panel.c:575
+msgctxt "Password mode"
+msgid "None"
+msgstr "ఏదీకాదు"
+
+#: ../panels/user-accounts/um-user-panel.c:624
+msgid "Logged in"
+msgstr "లాగిన్ అయెను"
+
+#: ../panels/user-accounts/um-user-panel.c:1072
+msgid "Failed to contact the accounts service"
+msgstr "ఖాతాల సేవను సంప్రదించుటలో విఫలమైంది"
+
+#: ../panels/user-accounts/um-user-panel.c:1074
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "దయచేసి ఖాతాసేవ స్థాపించబడి మరియు చేతనపరచివుండునట్లు చూసుకోండి."
+
+#: ../panels/user-accounts/um-user-panel.c:1115
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"మార్పులు చేయడానికి,\n"
+"మొదటగా * ప్రతీకను నొక్కండి"
+
+#: ../panels/user-accounts/um-user-panel.c:1153
+msgid "Create a user account"
+msgstr "వాడుకరిని ఖాతాను సృష్టించు"
+
+#: ../panels/user-accounts/um-user-panel.c:1164
+#: ../panels/user-accounts/um-user-panel.c:1453
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"ఒక వాడుకరిని సృష్టించుటకు,\n"
+"ముందుగా * ప్రతీకను నొక్కండి"
+
+#: ../panels/user-accounts/um-user-panel.c:1174
+msgid "Delete the selected user account"
+msgstr "ఎంపికచేసిన వాడుకరి ఖాతాను తొలగించు"
+
+#: ../panels/user-accounts/um-user-panel.c:1186
+#: ../panels/user-accounts/um-user-panel.c:1458
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"ఎంచుకున్న వాడుకరిని తొలగించుటకు,\n"
+"ముందుగా * ప్రతీకను నొక్కండి"
+
+#: ../panels/user-accounts/um-user-panel.c:1368
+msgid "My Account"
+msgstr "నా ఖాతా"
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+#| msgid "A user with the username '%s' already exists"
+msgid "A user with the username '%s' already exists."
+msgstr "'%s' వాడుకరిపేరుతో ఒక వాడుకరి ఇదివరకే ఉన్నారు."
+
+#: ../panels/user-accounts/um-utils.c:571
+#, c-format
+#| msgid "The username is too long"
+msgid "The username is too long."
+msgstr "వాడుకరిపేరు మరీ పెద్దగా ఉంది."
+
+#: ../panels/user-accounts/um-utils.c:574
+#| msgid "The username cannot start with a '-'"
+msgid "The username cannot start with a '-'."
+msgstr "వాడుకరిపేరు '-' తో మొదలవ్వకూడదు."
+
+#: ../panels/user-accounts/um-utils.c:577
+#| msgid ""
+#| "The username must only consist of:\n"
+#| " ➣ letters from the English alphabet\n"
+#| " ➣ digits\n"
+#| " ➣ any of the characters '.', '-' and '_'"
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr ""
+"వాడుకరిపేరు చిన్న మరియు పెద్దబడి అక్షరాలను a-z వరకు, అంకెలు మరియు '.', '-', "
+"'_' వీటిలో ఏదైనా కలిగివుండవచ్చు."
+
+#: ../panels/user-accounts/um-utils.c:581
+msgid "This will be used to name your home folder and can't be changed."
+msgstr ""
+"మీ నివాస సంచయం పేరు పెట్టుటకు యిది వుపయోగించబడును మరియు దీనిని మార్చలేము."
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:827
+#| msgid "%b %d %Y"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:831
+#| msgid "%b %d %Y"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "మ్యాప్ బటన్లు"
+
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr " కార్యాలను పటం మీటలు"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+#| msgid ""
+#| "To edit a shortcut, click the row and hold down the new keys or press "
+#| "Backspace to clear."
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ఒక షార్ట్ కట్ ని సరిచేయుటకు, \"కీస్ట్రోక్ పంపు\" చర్య ఎంచుకొని, కీబోర్డ్ "
+"లఘువు బటన్ వత్తండి మరియు కొత్త కీలను పట్టివుంచండి లేదా శుబ్రంచేయుటకు "
+"బ్యాక్‌స్పేస్ వత్తండి."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"తాము మాత్ర బలాన్ని నిర్ణయించు కు తెరపైన కనిపించే విధంగా లక్ష్యాన్ని "
+"గుర్తులను పొందేల చెయ్యండి."
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "MIS-క్లిక్ పునఃప్రారంభించి, కనుగొనబడింది ..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "పైకి"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "క్రిందికి"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "ఏదీకాదు"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "కీస్ట్రోక్ పంపు"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "మానిటర్ మార్చు"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "తెర-పై సహాయం చూపు"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "అవుట్‌పుట్:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "రూప నిష్పత్తి ఉంచు (letterbox):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "ఒంటరి మానిటర్‌కు మాప్‌చేయి"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d యొక్క%d"
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "మ్యాపింగును ప్రదర్శించు"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "బటన్"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr "వ్యాకం టాబ్లెట్"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"గ్రాఫిక్స్ టాబ్లెట్ల కొరకు బటన్ మాపింగ్ మరియు స్టైలస్ సున్నితత్వం సర్దుబాటు "
+"చేయును"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "ట్యాబ్లెట్;వాకం;శ్టైలస్;ఇరేసర్;మౌజ్;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "టాబ్లెట్ (ఖచ్ఛితం)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "టచ్‌ప్యాడ్ (సాపేక్షమైనది)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "టాబ్లెట్ ప్రాధాన్యతలు"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr "ఏ టాబ్లెట్ కనిపెట్టబడలేదు"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "మీ వాకం ట్యాబ్లెట్ ను దయచేసి ప్లగిన్ లేదా ఆన్ చేయుము "
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr "బ్లూటూత్ అమరికలు"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Map to Monitor…"
+msgstr "మానిటర్‌కు మాప్ చేయి ..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map Buttons…"
+msgstr "మ్యాప్ బటన్లు..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr "ప్రదర్శన విభాజకతను సవరించండి"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust mouse settings"
+msgstr "మౌస్ అమరికలు సర్దుబాటుచేయి"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Tracking Mode"
+msgstr "ట్రాకింగ్ మోడ్"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Left-Handed Orientation"
+msgstr "ఎడమ-చేతివైపు సర్దుబాటు"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+msgid "Left Ring"
+msgstr "ఎడమ వలయం"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "ఎడమ వలయం రీతి #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+msgid "Right Ring"
+msgstr "కుడి  వలయం"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "కుడి  వలయం రీతి #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+msgid "Left Touchstrip"
+msgstr "ఎడమ టచ్‌స్ట్రిప్"
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "ఎడమ టచ్ స్ట్రిప్ రీతి #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+msgid "Right Touchstrip"
+msgstr "కుడి టచ్‌స్ట్రిప్"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "కుడి టచ్ స్ట్రిప్ రీతి #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "ఎడమ స్పర్శవలయం రీతి స్విచ్"
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "కుడి స్పర్శవలయం రీతి స్విచ్"
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "ఎడమ టచ్ స్ట్రిప్ రీతి స్విచ్"
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "కుడి టచ్ స్ట్రిప్ రీతి స్విచ్"
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "స్విచ్  రీతి #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr "ఎడమ బటన్ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr "కుడి బటన్ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr "పైన బటన్ #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "దిగువ మీట #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+#| msgid "New shortcut..."
+msgid "New shortcut…"
+msgstr "కొత్త లఘువు…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "ఏ చర్యలేదు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "ఎడమ మౌస్ బటన్ నొక్కు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "మధ్య మౌస్ బటన్ నొక్కు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "కుడి మౌస్ బటన్ నొక్కు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "పైకి జరుపు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "కిందకి జరుపు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "ఎడమవైపు జరుపు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "కుడివైపు జరుపు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "వెనుకకు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "ముందుకు"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "స్టైలస్"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "ప్రెషరు స్పర్శను చెరుపుము"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "సున్నితమైన"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "ఫిర్మ్"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "పైన బటన్"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "క్రింది బటన్"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "ప్రెషరు స్పర్శ టిప్"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "వెర్బోస్ విధాన్ని చేతనపరుచు"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "అవలోకనం చూపించు"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "స్ట్రింగ్ కొరకు అన్వేషించు"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "సాధ్యమగు పానల్ పేర్లను జాబితా చేసి మరియు నిష్క్రమించు"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "సహాయ ఐచ్ఛికాలను చూపించు"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "ప్రదర్శించవలసిన ప్యానల్"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- అమరికలు"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"అందుబాటులో వున్న ఆదేశ వరుస ఐచ్చికముల పూర్తి జాబితా కొరకు '%s --help' "
+"నడుపండి.\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "అందుబాటులోని పానల్స్:"
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "సహాయం"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "నిష్క్రమించు"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+msgid "All Settings"
+msgstr "అన్ని అమరికలు"
+
+#. Add categories
+#: ../shell/cc-window.c:876
+msgctxt "category"
+msgid "Personal"
+msgstr "వ్యక్తిగత"
+
+#: ../shell/cc-window.c:877
+msgctxt "category"
+msgid "Hardware"
+msgstr "హార్డ్‍వేర్"
+
+#: ../shell/cc-window.c:878
+msgctxt "category"
+msgid "System"
+msgstr "వ్యవస్థ"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "ప్రాధాన్యతలు;అమరికలు;"
+
+#~ msgid "Flickr"
+#~ msgstr "ఫ్లికర్"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "కొత్త పరికరాన్ని అమర్చు"
+
+#~ msgid "Connection"
+#~ msgstr "అనుసంధానము"
+
+#~ msgid "Paired"
+#~ msgstr "జతపరిచినవి"
+
+#~ msgid "Type"
+#~ msgstr "రకం"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "మౌస్ మరియు టచ్‌ప్యాడ్ అమరికలు"
+
+#~ msgid "Sound Settings"
+#~ msgstr "శబ్ద అమరికలు"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "కీబోర్డు అమరికలు"
+
+#~ msgid "Send Files…"
+#~ msgstr "దస్త్రాలను పంపండి..."
+
+#~ msgid "Visibility"
+#~ msgstr "దృగ్గోచరత"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "“%s” యొక్క దృగ్గోచరత"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "పరికరముల జాబితా నుండి '%s'ను తీసివేయాలా?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "ఒకవేళ మీరు పరికరమును తీసివేసినట్లయితే, మీరు తరువాత మళ్ళీ వాడాలంటే ముందుగా దీనిని మరలా "
+#~ "అమర్చవలసివుంటుంది."
+
+#~ msgid "Device type:"
+#~ msgstr "పరికరం రకము:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "తయారీదారుడు:"
+
+#~ msgid "Model:"
+#~ msgstr "మోడల్:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "పైనున్న క్షేత్రముల స్వయం -పూర్తి  చేయుటకు చిత్ర దస్త్రములను ఈ విండోకు లాగవచ్చును"
+
+#~ msgid "Left Shift"
+#~ msgstr "ఎడమ Shift"
+
+#~ msgid "Left Alt"
+#~ msgstr "ఎడమ Alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "ఎడమ Ctrl"
+
+#~ msgid "Right Shift"
+#~ msgstr "కుడి Shift"
+
+#~ msgid "Right Alt"
+#~ msgstr "కుడి Alt"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "కుడి Ctrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "ఎడమ Alt+Shift"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "కుడి Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "ఎడమ Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "కుడి Ctrl+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "ఎడమ+కుడి Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "ఎడమ+కుడి Ctrl"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "Caps"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "_Region:"
+#~ msgstr "ప్రాంతం (_R):"
+
+#~ msgid "_City:"
+#~ msgstr "నగరం (_C):"
+
+#~ msgid "_Network Time"
+#~ msgstr "నెట్‌వర్క్ సమయం (_N)"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "సమయాన్ని ఒక గంట ముందుకి అమర్చు."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "సమయాన్ని ఒక గంట వెనక్కి పెట్టు"
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "సమయాన్ని ఒక నిమిషం ముందుకు పెట్టు"
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "సమయాన్ని ఒక నిమిషం వెనక్కి పెట్టు"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "పూర్వాహ్నం మరియు అపరాహ్నం మద్య మారు"
+
+#~ msgid "AM/PM"
+#~ msgstr "పూర్వాహ్నం/అపరాహ్నం"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "సాధారణం"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "అపసవ్య-దిశ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "సవ్యదిశ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 డిగ్రీలు"
+
+#~ msgid "Monitor"
+#~ msgstr "మానిటర్"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "ప్రాధమిక ప్రదర్శనను మార్చుటకు లాగుము."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "మానిటర్ లక్షణాలని మార్చుటకు ఎంచుకో.  దాని స్థానాన్ని మార్చటానికి, పట్టి కదపండి"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "స్వరూపణం అనువర్తించుటలో విఫలమైంది: %s"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "మానిటర్ ఆకృతీకరణను దాయలేక పోయింది"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "ప్రదర్శనలను గుర్తించలేకపోయింది"
+
+#~ msgid "_Resolution"
+#~ msgstr "విభాజకత (_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "భ్రమణం (_o)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "మిర్రర్ ప్రదర్శనలు (_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "గమనిక: విభాజకత ఐచ్చికాలను పరిమితం చేయవచ్చు"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "ప్రదర్శకాలను కనిపెట్టు (_D)"
+
+#~ msgid "Install Updates"
+#~ msgstr "నవీకరణలను స్థాపించు"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "వ్యవస్థ నేటి వరకూ నవీకరించబడివుంది"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "మౌస్ ప్రాధాన్యతలు"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "విషయాలు వ్రేలుకు అద్దుకొనును (_o)"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "కొత్త సేవ కొరకు వుపయోగించుటకు యింటర్ఫేస్ యెంపికచేయి"
+
+#~ msgid "C_reate…"
+#~ msgstr "సృష్టించుము... (_r)"
+
+#~ msgid "_Interface"
+#~ msgstr "అంతరవర్తి (_I)"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "అంచనావేసిన బ్యాటరీ సామర్ధ్యం: %s"
+
+#~ msgid "_Default"
+#~ msgstr "అప్రమేయం (_D)"
+
+#~ msgid "Hidden"
+#~ msgstr "మరుగునవున్న"
+
+#~ msgid "Visible"
+#~ msgstr "కనిపించు"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "పేరు మరియు దర్శనీయత"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "తెర మరియు నెట్వర్కు నందు మీరు యెలా కనిపించాలో నియంత్రించును."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "టాప్ పట్టీనందు పూర్తిపేరు ప్రదర్శించు (_f)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "లాక్ తెరనందు పూర్తి పేరు ప్రదర్శించు (_l)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "స్టీల్త్ రీతి (_S)"
+
+#~ msgid "Immediately"
+#~ msgstr "తక్షణమే"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "ఏదీకాదు"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "పబ్లిక్ ఫోల్టర్ పంచుకో"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "నమ్మకమైన పరికరాలతో మాత్రమే పంచుకో"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "ఈ నెట్వర్కు పైన మాధ్యమం పంచుకొనుము"
+
+#~ msgid "Shared Folders"
+#~ msgstr "భాగస్వామ్యపు ఫోల్డర్లు"
+
+#~ msgid "column"
+#~ msgstr "నిలువువరుస"
+
+#~ msgid "Remove Folder"
+#~ msgstr "సంచయం తీసివేయి"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "ఈ నెట్వర్కు నందు పబ్లిక్ ఫోల్డర్ పంచుకొనుము"
+
+#~ msgid "Remote View"
+#~ msgstr "రిమోట్ దర్శనం"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "అన్ని అనుసంధానాలను ఆమోదించు"
+
+#~ msgid "No shortcut set"
+#~ msgstr "ఏ అడ్డదారి అమర్చలేదు"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "సాధారణం"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "అధిక/విలోమమైన"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "తెరపై కీబోర్డు"
+
+#~ msgid "OnBoard"
+#~ msgstr "ఆంబోర్డ్"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "సాధారణ"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "చాలా పెద్ద"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Caps మరియు Num Lock లను చేతనించినపుడు బీప్మనిపించు"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "ఆన్ లేదా ఆఫ్ చేయి"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "జూమ్"
+
+#~ msgid "Zoom in:"
+#~ msgstr "అతిరూపించు:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "అవరూపించు:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "క్యాప్షానైజింగ్ మూసినపుడు"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "మాటా మరియు శబ్దముల  పాఠ్య వివరణను ప్రదర్శించు "
+
+#~ msgid "On Screen Keyboard"
+#~ msgstr "తెరపై కీబోర్డు"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "పొట్టి"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "పొడవు"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "బీప్ ఎపుడైతే ఒక కీ"
+
+#~ msgid "pressed"
+#~ msgstr "వొత్తబడింది"
+
+#~ msgid "accepted"
+#~ msgstr "అంగీకరించబడింది"
+
+#~ msgid "rejected"
+#~ msgstr "తిరస్కరించబడింది"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "అంగీకరించు జాప్యం:(_e)"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "కీప్యాడ్‌ని వాడి పాయింటరుని నియంత్రించు."
+
+#~ msgid "Video Mouse"
+#~ msgstr "వీడియో మౌస్"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "వీడియో కెమేరాని వాడి పాయింటరుని నియంత్రించు."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "చిన్న"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "పెద్ద"
+
+#~ msgid "Mouse Settings"
+#~ msgstr "మౌస్ అమరికలు"
+
+#~ msgid "Add account"
+#~ msgstr "ఖాతాను జతచేయండి"
+
+#~ msgid "_Local Account"
+#~ msgstr "స్థానిక ఖాతా (_L)"
+
+#~ msgid "_Full name"
+#~ msgstr "పూర్తి పేరు (_F)"
+
+#~ msgid "_Login Name"
+#~ msgstr "ప్రవేశ నామం (_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "చిట్కా: ఎంటర్‌ప్రైజ్ డొమైన్ లేదా రియాల్మ్ పేరు"
+
+#~ msgid "C_ontinue"
+#~ msgstr "కొనసాగండి (_o)"
+
+#~ msgid "Previous Week"
+#~ msgstr "క్రితం వార్"
+
+#~ msgid "Next Week"
+#~ msgstr "తరువాతి వారం"
+
+#~ msgid "Next week"
+#~ msgstr "తరువాతి వారం"
+
+#~ msgid "Log in without a password"
+#~ msgstr "సంకేతపదం లేకుండా ప్రవేశించు"
+
+#~ msgid "Disable this account"
+#~ msgstr "ఈ ఖాతాను అచేతనపరుచు"
+
+#~ msgid "Enable this account"
+#~ msgstr "ఈ ఖాతాను చేతనపరుచు"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "సంకేతపదాన్ని నిర్ధారించండి (_o)"
+
+#~ msgid "Generate a password"
+#~ msgstr "సంకేతపదాన్ని ఉత్పత్తించు"
+
+#~ msgid "_Action"
+#~ msgstr "చర్య (_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "సంకేతపదాన్ని చూపించు (_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "ఒక బలమైన సంకేతపదాన్ని ఎన్నుకోవడం ఎలా"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "దీనికి ఫొటోను మార్చు:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "ఈ ఖాతాకు ప్రవేశ తెర వద్ద చూపించుటకు ఒక చిత్రాన్ని ఎంచుకోండి."
+
+#~ msgid "Gallery"
+#~ msgstr "చిత్రశాల"
+
+#~ msgid "Take a photograph"
+#~ msgstr "ఒక ఫోటోగ్రాఫ్‌ను తీసుకొను"
+
+#~ msgid "Browse"
+#~ msgstr "విహరించు"
+
+#~ msgid "Photograph"
+#~ msgstr "ఫోటోగ్రాఫ్"
+
+#~ msgid "Account Information"
+#~ msgstr "ఖాతా సమాచారము"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "మరీ చిన్నది"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "తగినంత లేదు"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "బలహీనం"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "బాగుంది"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "మంచిది"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "బలంగావుంది"
+
+#~ msgid "_Generate a password"
+#~ msgstr "ఒక సంకేతపదాన్ని ఉత్పత్తించు (_G)"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "మీరు ఒక కొత్త సంకేతపదాన్ని ప్రవేశపెట్టాలి"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "కొత్త సంకేతపదం దృఢంగా లేదు"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "మీరు సంకేతపదాన్ని నిర్ధారించవలసివుంది"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "మీ ప్రస్తుత సంకేతపదాన్ని ప్రవేశపెట్టాలి"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "ప్రస్తుత సంకేతపదం తప్పు"
+
+#~ msgid "Wrong password"
+#~ msgstr "సంకేతపదం తప్పు"
+
+#~ msgid "Switch Modes"
+#~ msgstr "మార్చు విధములు"
+
+#~ msgid "Action"
+#~ msgstr "చర్య"
+
+#~ msgid "Change the background"
+#~ msgstr "నేపథ్యమును మార్చు"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "బ్లూటూత్ అమరికలను స్వరూపించు"
+
+#~ msgid "Browse Files..."
+#~ msgstr "దస్త్రాలను విహరించండి..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "బ్లూటూత్"
+
+#~ msgid "Create virtual device"
+#~ msgstr "వర్చువల్ పరికరమును సృష్టించు"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "తెరల కొరకు అందుబాటులోవున్న ప్రవరలు"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "స్కానర్ల కొరకు అందుబాటులోవున్న ప్రవరలు"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "ముద్రాపకాల కొరకు అందుబాటులోవున్న ప్రవరలు"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "కెమేరాల కొరకు అందుబాటులోవున్న ప్రవరలు"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "వెబ్‌క్యామ్‌ల కొరకు అందుబాటులోవున్న ప్రవరలు"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i సంవత్సరం"
+#~ msgstr[1] "%i సంవత్సరాలు"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i నెల"
+#~ msgstr[1] "%i నెలలు"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i వారం"
+#~ msgstr[1] "%i వారాలు"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "1 వారం కంటే తక్కువ"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "ఈ పరికరం వర్ణం నిర్వహించుటలేదు"
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "ఉత్పాదమవనున్న కాలిబరేటడ్ దత్తంశం ని ఈ పరికరము ఉపయోగంచుతున్నది."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "పూర్తి-తెర రంగు సరిచేయుటకు సరి అయిన ప్రవర ఈ పరికరమునకు లేదు"
+
+#~ msgid "Not specified"
+#~ msgstr "తెలుపబడలేదు"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "ఏ పరికరములు గుర్తించిన రంగు నిర్వాహన  సహకరించుటలేదు  "
+
+#~ msgid "Add device"
+#~ msgstr "పరికరాన్ని జతచేయి"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "వర్చువల్ పరికరాన్ని జతచేయి"
+
+#~ msgid "Remove a device"
+#~ msgstr "ఒక పరికరాన్ని తీసివేయ"
+
+#~ msgid "Color management settings"
+#~ msgstr "రంగు నిర్వహణ అమరికలు"
+
+#~ msgid "English"
+#~ msgstr "ఇంగ్లీషు"
+
+#~ msgid "British English"
+#~ msgstr "బ్రిటిష్ ఇంగ్లీష్"
+
+#~ msgid "German"
+#~ msgstr "జర్మన్"
+
+#~ msgid "French"
+#~ msgstr "ఫ్రెంచ్"
+
+#~ msgid "Spanish"
+#~ msgstr "స్పానిష్"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "చైనీస్ (సరళమైనది)"
+
+#~ msgid "Russian"
+#~ msgstr "రష్యన్"
+
+#~ msgid "Arabic"
+#~ msgstr "అరబిక్"
+
+#~ msgid "Unspecified"
+#~ msgstr "తెలుపని"
+
+#~ msgid "Select a language"
+#~ msgstr "ఒక భాషను ఎంచుకోండి"
+
+#~ msgid "_Select"
+#~ msgstr "ఎంచుకొను (_S)"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "తేది మరియు సమయం ప్రాధాన్యతల ప్యానల్"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "తెలియని మోడల్"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "తరువాతి లాగిన్ ప్రామాణిక అనుభవాన్ని వుపయోగించుటకు యత్నించును."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr "తోడ్పాటులేని చిత్రరూపాల హార్డువేర్‌కు వుద్దేశించిన ఫాల్‌బాక్ రీతిని తరువాతి లాగిన్ వుపయోగించును."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "పాల్‌బ్యాక్"
+
+#~ msgid "System Information"
+#~ msgstr "వ్యవస్థ సమాచారం"
+
+#~ msgid "OS type"
+#~ msgstr "ఒయస్ రకం"
+
+#~ msgid "_Other Media..."
+#~ msgstr "ఇతర మాధ్యమం... (_O)"
+
+#~ msgid "Experience"
+#~ msgstr "అనుభవం"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "బలమైన ఫాల్ బ్యాక్ మోడ్(_F)"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "కీబోర్డు అమరికలను మార్చు"
+
+#~ msgid "Layout Settings"
+#~ msgstr "నమూనా అమరికలు"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "మీ మౌస్ మరియు టచ్‌ప్యాడ్ ప్రాధాన్యతలను అమర్చు"
+
+#~ msgid "Network settings"
+#~ msgstr "నెట్‌వర్క్ అమరికలు"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "నెట్‌వర్కు;వైర్‌లెస్;IP;LAN;ప్రాక్సీ;"
+
+#~ msgid "Out of range"
+#~ msgstr "పరిధి దాటిపోయింది"
+
+#~ msgid "_Options..."
+#~ msgstr "ఐచ్ఛికాలు...(_O)"
+
+#~ msgid "C_reate..."
+#~ msgstr "సృష్టించు...(_r)"
+
+#~ msgid "_Configure..."
+#~ msgstr "స్వరూపించు...(_C)"
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "వైర్‌లెస్ హాట్‌స్పాట్"
+
+#~ msgid "Wireless"
+#~ msgstr "వైర్‌లెస్"
+
+#~ msgid "_Disconnect"
+#~ msgstr "అననుసంధానించు (_D)"
+
+#~ msgid "_Connect"
+#~ msgstr "అనుసంధానించు (_C)"
+
+#~ msgid "Mesh"
+#~ msgstr "మెష్"
+
+#~ msgid "Disconnected"
+#~ msgstr "అననుసంధానమైంది"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "యోగ్యతాపత్రముల కాలం చెల్లినది. దయచేసి మరలా ప్రవేశించండి."
+
+#~ msgid "_Log In"
+#~ msgstr "ప్రవేశించు (_L)"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "ఆన్‌లైన్ ఖాతాలను నిర్వహించు"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "జాగ్రత్త తక్కువ బ్యాటరీ,%s మిగిలి ఉన్నాయి"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "బ్యాటరీ విద్యుత్తును వాడుతోంది - %s మిగిలివున్నది"
+
+#~ msgid "Using battery power"
+#~ msgstr "బ్యాటరీ విద్యుత్తును వాడుతున్నది"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "చార్జవుతోంది - పూర్తిగా చార్జయింది"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "%s మిగిలిన - UPS శక్తి ఉపయోగించడం"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "జాగ్రత్త UPS తక్కువగా ఉంది"
+
+#~ msgid "Using UPS power"
+#~ msgstr "యూపియస్ విద్యుత్తును వాడుతోంది"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "మీ రెండవ బ్యాటరీ పూర్తిగా ఛార్జి అయినది"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "మీ రెండవ బ్యాటరీ ఖాళీగా ఉంది"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "చార్జవుతోంది - పూర్తిగా చార్జయింది"
+
+#~ msgid "Power management settings"
+#~ msgstr "పవర్ నిర్వహణ అమరికలు"
+
+#~ msgid "Don't suspend"
+#~ msgstr "తాత్కాలికంగా నిలిపివేయవద్దు"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "ఇంతసేపు క్రియాహీనముగా ఉంటే తాత్కాలికంగా నిలిపివేయి"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "నిలిపివుంచిన"
+
+#~ msgid "Change printer settings"
+#~ msgstr "ముద్రకం అమరికలను మార్చు"
+
+#~ msgid "Manufacturers"
+#~ msgstr "తయారీదారులు"
+
+#~ msgid "Drivers"
+#~ msgstr "చోదకాలు"
+
+#~ msgid "_Show"
+#~ msgstr "చూపించు (_S)"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "మీ ప్రాంతం మరియు భాషా అమరికలను మార్చు"
+
+#~ msgid "Choose an input source"
+#~ msgstr "ఒక ఇన్‌పుట్ మూలాన్ని ఎంచుకోండి"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "జతచేయుటకు ఇన్‌పుట్ మూలాన్ని ఎంచుకోండి"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "ప్రవేశ తెర, వ్యవస్థ ఖాతాలు మరియు కొత్త వాడుకరుల ఖాతాలు వ్యవస్థ-వ్యాప్తంగా ప్రాంతం మరియు భాష "
+#~ "అమరికలు ఉపయోగిస్తాయి."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "ప్రవేశ తెర, వ్యవస్థ ఖాతాలు మరియు కొత్త వాడుకరుల ఖాతాలు వ్యవస్థ-వ్యాప్యంగా ప్రాంతం మరియు భాష "
+#~ "అమరికలు ఉపయోగిస్తాయి.మీ అమరికలు ఉపమించుటకు మీరు మీ సిస్టం అమరికలు మార్చుకొనవచ్చును"
+
+#~ msgid "Copy Settings"
+#~ msgstr "అమరికలను నకలుచేయి"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "అమరికలను నకలుచేయి..."
+
+#~ msgid "Region and Language"
+#~ msgstr "ప్రాంతం మరియు భాష"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr "ప్రదర్శనా భాషను యెంపికచేయి (మార్పు అనునది మీరు తరువాత సారి లాగిన్ అయినప్పుడు వర్తించును)"
+
+#~ msgid "Add Language"
+#~ msgstr "భాషను జతచేయి"
+
+#~ msgid "Remove Language"
+#~ msgstr "భాషను తీసివేయి"
+
+#~ msgid "Install languages..."
+#~ msgstr "భాషలను స్థాపించు..."
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "ఒక ప్రాంతాన్ని ఎంచుకొను (మీ తరువాయి ప్రవేశంలో మార్పులు అనువర్తించబడతాయి)"
+
+#~ msgid "Add Region"
+#~ msgstr "ప్రాంతాన్ని జతచేయి"
+
+#~ msgid "Currency"
+#~ msgstr "ద్రవ్యం"
+
+#~ msgid "Examples"
+#~ msgstr "ఉదాహరణలు"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "కీబోర్డులను లేదా ఇతర ఇన్‌పుట్ మూలాలను ఎంచుకోండి"
+
+#~ msgid "Remove Input Source"
+#~ msgstr "ఇన్‌పుట్ వనరుని తీసివేయి"
+
+#~ msgid "Move Input Source Up"
+#~ msgstr "ఇన్‌పుట్ వనరుని పైకి కదుపు"
+
+#~ msgid "Show Keyboard Layout"
+#~ msgstr "కీబోర్డు లేయవుటు చూపించు"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "అడ్డదారుల అమరికలు"
+
+#~ msgid "Display language:"
+#~ msgstr "ప్రదర్శనా భాష:"
+
+#~ msgid "Input source:"
+#~ msgstr "ఇన్‌పుట్ వనరు:"
+
+#~ msgid "Format:"
+#~ msgstr "ఆకృతి:"
+
+#~ msgid "Your settings"
+#~ msgstr "మీ అమరికలు"
+
+#~ msgid "System settings"
+#~ msgstr "వ్యవస్థ అమరికలు"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "ప్రకాశత మరియు తాళం"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "తెర ప్రకాశత మరియు తాళం అమరికలు"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "ప్రకాశత;తాళం;తక్కువకాంతి;బ్లాంక్;మానిటర్;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "విద్యుత్ ఆదాచేయుటకు తెర ప్రకాశతను తగ్గించు (_D)"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "నివాసం వద్ద వున్నప్పుడు లాక్ చేయవద్దు"
+
+#~ msgid "Locations..."
+#~ msgstr "ప్రదేశాలు..."
+
+#~ msgid "Lock"
+#~ msgstr "తాళంవేయి"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "డీబగ్గింగ్ సంహిత ను చేతనంచేయి"
+
+#~ msgid "Version of this application"
+#~ msgstr "ఈ అనువర్తనం యొక్క రూపాంతరం"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — గ్నోమ్ వాల్యూమ్ కంట్రోల్ ఆప్లెట్"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "డెస్క్‍టాప్ శబ్దస్థాయి నియంత్రణను చూపించు"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "శబ్ద అవుట్‌పుట్ స్థాయి"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "మైక్రోఫోన్ శబ్దస్థాయి"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "శబ్ధ అభీష్టాలను ప్రారంభించుటకు విఫలమైంది: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "నిశబ్దం (_M)"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "శబ్ద ప్రాధాన్యతలు (_S)"
+
+#~ msgid "Muted"
+#~ msgstr "నిశబ్దించబడింది"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "సార్వత్రిక ప్రాప్తి ప్రాధాన్యతలు"
+
+#~ msgid "Options..."
+#~ msgstr "ఐచ్ఛికాలు..."
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "రంగు"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "ఏదీకాదు"
+
+#~ msgid "User Accounts"
+#~ msgstr "వాడుకరి ఖాతాలు"
+
+#~ msgid "_Hint"
+#~ msgstr "సూచన (_H)"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "ఈ సూచన ప్రవేశ తెర వద్ద ప్రదర్శించబడుతుంది.  ఇది ఈ వ్యవస్థ యొక్క వాడుకరులందరికీ కనిపిస్తుంది.  "
+#~ "ఇక్కడ సంకేతపదాన్ని చేర్చ <b>వద్దు</b>."
+
+#~ msgid "Fair"
+#~ msgstr "బాగుంది"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "మరిన్ని చిత్రాల కోసం విహరించండి..."
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "'%s' వాడుకరిపేరుతో ఎటువంటి వాడుకరి లేరు."
+
+#~ msgid "This user does not exist."
+#~ msgstr "వాడుకరి అసలు లేనేలేడు."
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "వ్యాకం ట్యాబ్లెట్ అభీష్టాలను సమకూర్చు"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "మ్యాప్ బటన్స్..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "క్యాలిబరేట్..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- వ్యవస్థ అమరికలు"
+
+#~ msgid "Control Center"
+#~ msgstr "నియంత్రణా కేంద్రం"
+
+#~ msgid "System Settings"
+#~ msgstr "వ్యవస్థ అమరికలు"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "నేపథ్యచిత్రాన్ని జతచేయి"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "నేపథ్యచిత్రాన్ని తీసివేయి"
+
+#~ msgid "Swap colors"
+#~ msgstr "స్వాప్ రంగులు"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "సమాంతర గ్రేడియంట్"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "నిలువు గ్రేడియంట్"
+
+#~ msgid "Solid Color"
+#~ msgstr "ఘన వర్ణం"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "రంగులు & గ్రేడియంట్స్"
+
+#~ msgid "Acti_on:"
+#~ msgstr "చర్య (_o):"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "ఒక తెరపట్టును తీయండి"
+
+#~ msgid "Shortcut"
+#~ msgstr "అడ్డదారి"
+
+#~ msgid "_Right-handed"
+#~ msgstr "కుడి-చేతి (_R)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "ఎడమ-చేతి (_L)"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "నియంత్రిక కీ వత్తినప్పుడు సూచిక చూపించబడు స్థానము(_o)"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "త్వరణం (_c):"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "సున్నితత్వం (_S):"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "లాగుట మరియు వదులుట"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "త్రెష్‌హోల్డు (_e):"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "త్రెష్‌హోల్డును లాగుము"
+
+#~ msgid "Double-Click Timeout"
+#~ msgstr "రెండు-నొక్కలు కాలముమించినది"
+
+#~ msgid "_Timeout:"
+#~ msgstr "సమయం మించినది(_T):"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "మీ అమరికలను పరీక్షించుటకు, ముఖముపై రెండుసార్లు నొక్కి ప్రయత్నించండి."
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "టచ్‌ప్యాడ్‌తో మౌస్ నొక్కులను చేతనపరుచు (_m)"
+
+#~ msgid "Scrolling"
+#~ msgstr "జరుపుట"
+
+#~ msgid "_Disabled"
+#~ msgstr "అచేతనపరిచివుంది (_D)"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "ఇతర..."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "ఎలాగైనా హాట్ స్పాట్ ని సృష్టించవచ్చా?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "%s నుంచి తెంచుకొని కొత్త హాట్ స్పాట్ ని సృష్టించాలా?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "అంతర్జాలానికి కేవలం ఇది ఒక్కటే అనుసంధానం."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "హాట్ స్పాట్ (_H)"
+
+#~ msgid "_Network Name"
+#~ msgstr "నెట్‌వర్క్ పేరు (_N)"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "హాట్ స్పాట్ ను ఆపు(_S)"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "సబ్‌నెట్ మాస్క్"
+
+#~ msgid "_Search by Address"
+#~ msgstr "చిరునామాని బట్టి వెతుకు (_S)"
+
+#~ msgid "Getting devices..."
+#~ msgstr "పరికరాలను పొందుట..."
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD నడువుటలేదు. ఫయర్ వాల్ ను చేతనపరుచుటకు నెట్వర్కు ప్రింటర్ డిటెక్షన్ కి mdns, "
+#~ "ipp, ipp-clientమరియు samba-clientకావలెను"
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "స్థానికం"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "నెట్‌వర్క్"
+
+#~ msgid "Device types"
+#~ msgstr "పరికరం రకాలు"
+
+#~ msgid "Automatic configuration"
+#~ msgstr "స్వయంచాలక స్వరూపణం"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "mDNS అనుసంధానములకు ఫైర్ వాల్ తెరవబదుచున్నది"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Samba అనుసంధానములకు ఫైర్ వాల్ తెరవబదుచున్నది"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "IPP అనుసంధానములకు ఫైర్ వాల్ తెరవబదుచున్నది"
+
+#~ msgid "_Back"
+#~ msgstr "వెనుకకు (_B)"
+
+#~ msgid "Printer Options"
+#~ msgstr "ముద్రకం ఐచ్ఛికాలు"
+
+#~ msgid "Allowed users"
+#~ msgstr "అనుమతించిన వాడుకరులు"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "స్వరూపించుటకు ఒక పరికరం ఎంచుకోండి (_h):"
+
+#~ msgid "Dasher"
+#~ msgstr "డాషర్"
+
+#~ msgid "Nomon"
+#~ msgstr "నొమాన్"
+
+#~ msgid "Caribou"
+#~ msgstr "కారిబౌ"
+
+#~ msgid "Account _type"
+#~ msgstr "ఖాతా రకం (_t)"
+
+#~ msgid "Disable VPN"
+#~ msgstr "VPN అచేతనపరుచు"
+
+#~ msgid "HTTP Port"
+#~ msgstr "HTTP పోర్టు"
+
+#~ msgid "HTTPS Port"
+#~ msgstr "HTTPS పోర్టు"
+
+#~ msgid "FTP Port"
+#~ msgstr "FTP పోర్టు"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "ఒక కొత్త ఖాతాను జతచేయుటకు, మొదటగా ఖాతా రకాన్ని ఎంచుకొను"
+
+#~ msgid "_Add..."
+#~ msgstr "జతచేయి...(_A)"
+
+#~ msgid "Tip:"
+#~ msgstr "చిట్కా:"
+
+#~ msgid "Brightness Settings"
+#~ msgstr "ప్రకాశత అమరికలు"
+
+#~ msgid "affect how much power is used"
+#~ msgstr "పవర్ ఎంత వరకు  ప్రభావితం   ఉపయోగిస్తారు "
+
+#~ msgid "Add Layout"
+#~ msgstr "నమూనాని జతచేయి"
+
+#~ msgid "Remove Layout"
+#~ msgstr "నమూనాను తీసివేయి"
+
+#~ msgid "Preview Layout"
+#~ msgstr "నమూనా మునుజూపు"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "కొత్త కిటికీలకు అప్రమేయ నమూనాను వాడు"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "కొత్త కిటికీలకు మునుపటి కిటికీల నమూనాను వాడు"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "కీ బోర్డు అమరిక ఐచ్ఛికాలను చూడు మరియు మార్చు"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "అప్రమేయాలకు తిరగిఉంచుము(_f)"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr "ప్రస్తుత కీ బోర్డు అమరిక  లక్షణాలను తొలగించి అప్రమేయ లక్షణాలు ప్రవేశపెట్టుము."
+
+#~ msgid "Layouts"
+#~ msgstr "నమూనాలు"
+
+#~ msgid "Layout"
+#~ msgstr "నమూనా"
+
+#~ msgid "Change contrast:"
+#~ msgstr "వ్యత్యాసాన్ని మార్చు:"
+
+#~ msgid "_Text size:"
+#~ msgstr "పాఠ్య పరిమాణం (_T):"
+
+#~ msgid "Increase size:"
+#~ msgstr "పరిమాణం పెంచు:"
+
+#~ msgid "Decrease size:"
+#~ msgstr "పరిమాణం తగ్గించు:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "ప్రదర్శన"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "జూమ్"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "అమరికలను పరీక్షించుటకు ఇక్కడ టైపు చేయండి"
+
+#~ msgid "1/2 Screen"
+#~ msgstr "1/2 తెర"
+
+#~ msgid "3/4 Screen"
+#~ msgstr "3/4 తెర"
+
+#~ msgid "Create new account"
+#~ msgstr "కొత్త ఖాతాను సృష్టించు"
+
+#~ msgid "_Account Type"
+#~ msgstr "ఖాతా రకం (_A)"
+
+#~ msgid "Cr_eate"
+#~ msgstr "సృష్టించు (_e)"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "ఉత్పన్నమయిన సంకేతపదాన్ని ఎన్నుకొను"
+
+#~ msgid "More choices..."
+#~ msgstr "మరిన్ని ఎంపికలు..."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "వ్యాకం గ్రాఫిక్స్  ట్యాబ్లెట్"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "ప్రదర్శన ఆకృతీకరణను ఆపాదించునప్పుడు సెషన్ బస్‌ను పొందలేక పోయింది"
+
+#~ msgid "System Info"
+#~ msgstr "వ్యవస్థ సమాచారం"
+
+#~ msgid "_Photos:"
+#~ msgstr "ఫొటోలు (_P):"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "ఘాడత మార్చు"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "మాగ్నిఫైర్ మార్చు"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "తెర చదువరిని మార్చు"
+
+#~ msgid "Accelerator key"
+#~ msgstr "ఏక్సలరేటర్ కీ"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "ఏక్సలరేటర్ సవరింపులు"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "ఏక్సెలరేటర్ కీకొడ్"
+
+#~ msgid "Accel Mode"
+#~ msgstr "త్వరణసాధన విధం"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "ఏక్సలరేటర్ రకం."
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "కొత్త అడ్డదారిని భద్రపరుచుటలో దోషము"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "మరీ ఎక్కువ అనురూపిత అడ్డదారులు"
+
+#~ msgid "Speed"
+#~ msgstr "వేగం"
+
+#~ msgid "Unlock"
+#~ msgstr "అన్‌లాక్"
+
+#~ msgid "Battery discharging"
+#~ msgstr "బ్యాటరీ చార్జుపోతోంది"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "%s చార్జ్ అగునంతవరకు (%.0lf%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "%s ఖాళీ అగునంతవరకు (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% చార్జైనది"
+
+#~ msgid "Key"
+#~ msgstr "కీ"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "లక్షణాలను సరిచేయుదానికి అనుబంధంగా వున్న GConf మీట"
+
+#~ msgid "Callback"
+#~ msgstr "వెనక్కి పిలుపు"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "మీటకు అనుబంధంగా వున్న విలువ మారినప్పుడు తిరిగి వెనక్కి పిలుపు"
+
+#~ msgid "Change set"
+#~ msgstr "అమరిక మార్పు"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr "క్లయింటుకు చేర్చవలసిన GConf మార్పు అమరికలు వున్న దత్తాంశం"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "widget వెనక్కి పిలుపుకు మార్పు"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "దత్తాంశం GConfనుండి widgetకు మార్చునప్పుడు జారీ చేయవలసిన వెనక్కి పిలుపు"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "widget నుండి వెనక్కి పిలుపు మార్పు"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "దత్తాంశం widgetనుండి GConf నకు మార్చునప్పుడు  జారీ చేయవలసిన వెనక్కి పిలుపు"
+
+#~ msgid "UI Control"
+#~ msgstr "యుఐ నియంత్రణ"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "లక్షణాలను నియంత్రించే తాత్పర్యం (సహజంగా ఒక widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "లక్షణాలను సరిచేయుదాని దత్తాంశం తాత్పర్యం"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "నిర్దేశిత లక్షణాల సరిచేయుదానికవసరమయ్యే మలచిన దత్తాంశం"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "లక్షణాలను సరిచేయుదాని దత్తాంశాన్ని ఖాళీచేయు వెనక్కిపిలుపు"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "లక్షణాలను సరిచేయుదాని తాత్పర్య దత్తాంశాన్ని ఖాళీచేయుటకు జారీ చేయవలసిన వెనక్కిపిలుపు"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "'%s'దస్త్రము దొరకలేదు.\n"
+#~ "\n"
+#~ "దయచేసిన వుందోలేదో సరిచూసుకొని మళ్ళీ ప్రయత్నించండి, లేక  వేరొక బ్యాక్‌గ్రౌండ్ దృశ్యాన్ని ఎంపిక చేసుకోండి"
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s'దస్త్రమును ఎలా తెరవాలో తెలియదు.\n"
+#~ "బహుశా, ఈ రకమైన దృశ్యానికి సహకారంలేదు.\n"
+#~ "\n"
+#~ "దీనికి బదులుగా వేరొక దృశ్యాన్ని ఎంపిక చేసుకోండి."
+
+#~ msgid "Please select an image."
+#~ msgstr "దయచేసి ఒక చిత్రాన్ని ఎంపిక చేసుకోండి."
+
+#, fuzzy
+#~ msgid "Centered"
+#~ msgstr "మధ్య"
+
+#, fuzzy
+#~ msgid "Show"
+#~ msgstr "చూపించు (_S)"
+
+#~ msgid "Create a user"
+#~ msgstr "ఒక వాడుకరిని సృష్టించు"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "మాధ్యమం మరియు స్వయంనడుపుదల"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "మాధ్యమం మరియు స్వయంగానడుచు ప్రాధాన్యతలను స్వరూపించు"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "cd;dvd;usb;ఆడియో;వీడియో;డిస్కు;"
+
+#~ msgid "Ask me"
+#~ msgstr "నన్ను అడుగు"
+
+#~ msgid "Shutdown"
+#~ msgstr "మూసివేయి"
+
+#~ msgid "Suspend"
+#~ msgstr "తాత్కాలికంగా నిలిపివేయి"
+
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr "పరికరముకు అనుసంధానమైన ప్రొఫైళ్ళు మాత్రమే పైన జతపడబడతాయి."
+
+#~ msgid "_Turn off after:"
+#~ msgstr "ఇంతసేపటి తరువాత ఆపివేయి (_T):"
+
+#~ msgid "Mute"
+#~ msgstr "నిశబ్దం"
+
+#~ msgid "Appearance"
+#~ msgstr "కనిపించువిధం"
+
+#~ msgid "<b>Background</b>"
+#~ msgstr "<b>నేపథ్యం</b>"
+
+#~ msgid "<b>Theme</b>"
+#~ msgstr "<b>థీమ్</b>"
+
+#~ msgid "Apply system wide"
+#~ msgstr "వ్యవస్థ అంతటికీ అనువర్తించు"
+
+#~ msgid "Show click type _window"
+#~ msgstr "నొక్కు రకం విండోను చూపుము(_w)"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "నగరం(_t):"
+
+#~ msgid "Could not shutdown backend_stdout IO channel: %s"
+#~ msgstr "backend_stdout IO ప్రసారమార్గం ను మూయలేక పోయింది: %s"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an upgrade or uninstall action "
+#~ "is performed."
+#~ msgstr "నవీకరించు లేదా నిర్మూలించు చర్య జరుగగానే షెల్ మూయాలేమో సూచించుము."
+
+#~ msgid "Open in File Manager"
+#~ msgstr "దస్త్ర నిర్వాహకినందు తెరువుము"
+
+#~ msgid "Web _log:"
+#~ msgstr "వెబ్ లాగ్(_l):"
+
+#~ msgid ""
+#~ "The task name to be displayed in the control-center followed by a \";\" "
+#~ "separator then the filename of an associated .desktop file to launch for "
+#~ "that task."
+#~ msgstr ""
+#~ "\";\" విభజని తో నియంత్రణ-కేద్రం లో కర్తవ్యం నామము ప్రదర్శించబడాలి అప్పుడు సంభందిత .desktop "
+#~ "దస్త్రం ఆ కర్తవ్యంను దించుటకు ప్రదర్శించబడాలి."
+
+#~ msgid "User name:"
+#~ msgstr "వాడుకరి పేరు:"
+
+#~ msgid "Save Theme As..."
+#~ msgstr "థీమ్ ను ఇలాదాయి..."
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "అమరికలను పరీక్షించుటకు టైపుచేయుము(_T):"
+
+#~ msgid "_Home page:"
+#~ msgstr "నివాస పేజి(_H):"
+
+#~ msgid "Fraction completed"
+#~ msgstr "పూర్తయిన భిన్నం"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr ""
+#~ "మీరు ప్రధమంలో దృవీకరించబడి నందువల్ల మీ సంకేతపదం మార్చబడింది! దయచేసి తిరిగి-దృవీకరించబడండి."
+
+#~ msgid "Pointer"
+#~ msgstr "సూచిక"
+
+#~ msgid "Parent window of the dialog"
+#~ msgstr "డైలాగ్‌యొక్క మాత్రుక విండో"
+
+#~ msgid "Unable to launch backend"
+#~ msgstr "బ్యాక్ఎండ్ ను దించలేము"
+
+#~ msgid "Open with Default Application"
+#~ msgstr "అప్రమేయ అనువర్తనంతో తెరువుము"
+
+#~ msgid "Current URI index"
+#~ msgstr "ప్రస్తుత యుఆర్ఎల్ సూచి"
+
+#~ msgid "Are you sure you want to permanently delete \"%s\"?"
+#~ msgstr "మీరు \"%s\" ని శాశ్వతంగా తొలగించుదామని అనుకుంటున్నారా?"
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "పాత మరియు కొత్త సంకేతపదాలు మరీ పోలికగాఉన్నాయి."
+
+#~ msgid "Today %l:%M %p"
+#~ msgstr "ఈరోజు %l:%M %p"
+
+#~ msgid "Multimedia"
+#~ msgstr "బహుళమాద్యమం"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "మీ కర్సర్ థీమ్‌ను మార్చుట తర్వాత సారి మీరు లాగిన్ అయినప్పుడు ప్రభావితంఅవుతుంది."
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>స్వయంచాలక ప్రాక్సీ అకృతీకరణ(_A)</b>"
+
+#~ msgid "Window Preferences"
+#~ msgstr "విండో అభీష్టాలు"
+
+#~ msgid "Jump to the Accessible Login dialog"
+#~ msgstr "అందుబాటు లాగిన్ డైలాగ్‌కు దూకుము"
+
+#~ msgid "Exit shell on add or remove action performed"
+#~ msgstr "జతచేయు లేదా తీసివేయు చర్య జరుపబడగానే షెల్ నుండి బయటకురమ్ము"
+
+#~ msgid "Font Rendering Details"
+#~ msgstr "ఫాంటు ప్రస్పుటీకరణ వివరములు"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "టైపింగ్ విరామ అమరికలను చూపుతూ పుటను ప్రారంభించు"
+
+#~ msgid "gesture|Move right"
+#~ msgstr "కుడికి కదుపుము"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "టర్మినల్లో నడుపు(_e)"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "టొటెమ్ మూవీ ప్లేయర్"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "తెర చదువునది లేకుండా KDE వృద్దీకరణి"
+
+#~ msgid "The password is too short."
+#~ msgstr "ఆ సంకేతపదం మరీ పొట్టిగాఉంది."
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "యుఆర్ఎల్ ప్రస్తుతం ఇక్కడకు బదలాయించబడుతుంది"
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "రెండు సంకేతపదాలు సరిపోలలెదు."
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "ప్రస్తుత యుఆర్ఎల్ సూచి -1నుండి ప్రారంభం"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "వృద్దీకరణి తో లినక్స్  తెర చదువునది"
+
+#~ msgid "Could not shutdown backend_stdin IO channel: %s"
+#~ msgstr "backend_stdin IO ప్రసారమార్గం ను మూయలేక పోయింది: %s"
+
+#~ msgid "_Reset to Defaults"
+#~ msgstr "అప్రమేయాలకు తిరిగిఉంచు(_R)"
+
+#~ msgid "From URI"
+#~ msgstr "యుఆర్ఎల్ నుండి"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "ఆదేశాలకు లఘువులను జతచేయుము"
+
+#~ msgid "C_ompany:"
+#~ msgstr "కంపెని(_o):"
+
+#~ msgid "There was a problem while extracting the theme."
+#~ msgstr "థీమ్‌ను వేలికితీస్తున్నప్పుడు అక్కడ ఒక దోషం ఉంది."
+
+#~ msgid "Assistive Technologies"
+#~ msgstr "సహాయక సాంకేతికతలు"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "ఏండర్స్ కార్ల్సన్  చే ఐ క్యాండీ జత చేయబడినది"
+
+#~ msgid "Beep when a _modifier key is pressed"
+#~ msgstr "సవరణి కీ వత్తినప్పుడు బీప్ చేయుము(_m)"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "Linux Screen Reader"
+#~ msgstr "లినక్స్  తెర చదువునది"
+
+#~ msgid "_Home:"
+#~ msgstr "నివాసం(_H):"
+
+#~ msgid "Beep when a _toggle key is pressed"
+#~ msgstr "మార్పు కీ వత్తినప్పుడు బీప్‌చేయుము(_t)"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "కంప్యూటర్ విరామం జ్ఞాపకం చేయునది."
+
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr "Window manager \"%s\" గవాక్ష అభికర్త రూపకరణ పనిముట్టును నమోదు చేసుకోలేదు\n"
+
+#~ msgid "gesture|Move left"
+#~ msgstr "ఎడమకు కదుపుము"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "టైపింగు అనుతించబడనప్పుడు విరామం యొక్క కాలపరిమాణం"
+
+#~ msgid "dots per inch"
+#~ msgstr "అంగుళంకు చుక్కులు"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "Muine సంగీత ప్లేయర్"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "నెట్వర్కు ప్రాక్సీ అభీష్టాలు"
+
+#~ msgid ""
+#~ "Specify the name of the page to show (theme|background|fonts|interface)"
+#~ msgstr "చూపుటకు పేజియొక్క నామమును తెలుపుము (theme|background|fonts|interface)"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "రక్షిత HTTP ప్రాక్సీ(_S):"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "రంగాలంకరణ పటాన్ని జతచేయు"
+
+#~ msgid "Remove from Startup Programs"
+#~ msgstr "ప్రారంభ ప్రోగ్రామ్సు నుండి తీసివేయుము"
+
+#~ msgid "_Motion threshold:"
+#~ msgstr "కదలిక త్రెష్‌హోల్డ్(_M):"
+
+#~ msgid "_Fixed width font:"
+#~ msgstr "నిర్దేశిత వెడల్పు ఫాంటు(_F):"
+
+#~ msgid "Find Now"
+#~ msgstr "ఇప్పుడు కనుగొనుము"
+
+#~ msgid "P._O. box:"
+#~ msgstr "P._O. box:"
+
+#~ msgid "Autoconfiguration _URL:"
+#~ msgstr "స్వయంచాలకఆకృతీకరణ _URL:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "P.O. _box:"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "GNOME టెర్మినల్"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "గ్నోమ్ థీమ్ నిర్వాహకి"
+
+#~ msgid "Terminator"
+#~ msgstr "టెర్మినేటర్"
+
+#~ msgid "Hom_e:"
+#~ msgstr "నివాసం(_e):"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "చిరునామాపుస్తకాన్ని తెరువలేదు"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "కీబోర్డు రీతి(_m):"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "వాయిదావేయబడునట్లు విరామాలు అనుమతించబడినవేమో పరిశీలించుము"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "మౌస్ గెస్ట్రస్ తో నొక్కురకాన్ని ఎంచుకొనుము(_u)"
+
+#~ msgid "If you delete an item, it is permanently lost."
+#~ msgstr "మీరు ఒక అంశము ను తొలగించినచో, అది శాశ్వతంగా పోతుంది."
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "ఎంపిక చేసిన అక్షరశైలి %d పాలు పెద్దది, దీన్ని కంప్యూటర్ వినియోగించటం కష్టతరం.మీరు పరిమాణం చిన్నదిగా "
+#~ "ఉన్న అక్షరశైలిని ఎంపిక చేసుకోవాలని సలహా"
+#~ msgstr[1] ""
+#~ "ఎంపిక చేసిన అక్షరశైలి %d పాలు పెద్దది, దీన్ని కంప్యూటర్ వినియోగించటం కష్టతరం.మీరు పరిమాణం చిన్నదిగా "
+#~ "ఉన్న అక్షరశైలిని ఎంపిక చేసుకోవాలని సలహా"
+
+#~ msgid "Controls"
+#~ msgstr "నియంత్రణలు"
+
+#~ msgid "_Slight"
+#~ msgstr "స్వల్పం(_S)"
+
+#~ msgid "Task names and associated .desktop files"
+#~ msgstr "కర్తవ్యం నామములు మరియు సంభందిత .desktop దస్త్రములు"
+
+#~ msgid "gesture|Move up"
+#~ msgstr "పైకి కదుపుము"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "అన్ని %s సంభవాలు వాస్తవ లింకుతో పునఃస్థాపితం అవుతాయి"
+
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d నిముషం తర్వాత విరామం"
+#~ msgstr[1] "%d నిముషం తర్వాత విరామం"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "విరామం కొరకు బలవంతపెట్టుటకు మునుపు పని యొక్క కాలపరిమాణం"
+
+#~ msgid "The password is too simple."
+#~ msgstr "ఆ సంకేతపదం మరీ సాదారణంగా ఉంది."
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "రిచర్డ్ హల్ట్  చే వ్రాయబడింది <richard@imendio.com>"
+
+#~ msgid "Font may be too large"
+#~ msgstr "అక్షరశైలి చాలా పెద్దదిగా ఉన్నట్లుంది"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "వైవిద్యాంశ ఇప్పటికే వుంది. దీన్ని పునఃస్థాపించాలా?"
+
+#~ msgid "Jump to Preferred Applications dialog"
+#~ msgstr "అభీష్ట అనువర్తనాల డైలాగ్‌కు దూకుము"
+
+#~ msgid "Groups"
+#~ msgstr "సమూహాలు"
+
+#~ msgid "Add to Favorites"
+#~ msgstr "ఇష్టంశములకు జతచేయుము"
+
+#~ msgid "Image/label border"
+#~ msgstr "చిత్రము/లేబుల్ సరిహద్దు"
+
+#~ msgid ""
+#~ "\"%s\" does not appear to be a valid theme. It may be a theme engine "
+#~ "which you need to compile."
+#~ msgstr "\"%s\" విలువైన థీమ్‌లా అనిపించుటలేదు. అది మీరు కంపైల్ చేయవలిసిఉన్న థీమ్‌ఇంజన్ అయ్యుండొచ్చు."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when an add or remove action is "
+#~ "performed."
+#~ msgstr "జతచేయి లేదా తీసివేయి చర్య జరుగగానే షెల్ మూయాలేమో సూచించుము."
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "కీబోర్డు రీతిని ఎంపికచేయుము"
+
+#~ msgid ""
+#~ "To change your password, enter your current password in the field below "
+#~ "and click <b>Authenticate</b>.\n"
+#~ "After you have authenticated, enter your new password, retype it for "
+#~ "verification and click <b>Change password</b>."
+#~ msgstr ""
+#~ "మీ సంకేతపదాన్ని మార్చుటకు, మీ ప్రస్తుత సంకేతపదాన్ని ఈ క్రింది క్షేత్రమునందు ప్రవేశపెట్టి మరియు "
+#~ "<b>దృవీకరించు</b> బటన్ నొక్కండి.\n"
+#~ "మీరు దృవీకరించబడిన తర్వాత, మీ కొత్త సంకేతపదాన్ని ప్రవేశపెట్టండి, నిర్ధారణ కొరకు దాన్ని మరలాటైపుచేయండి "
+#~ "మరియు <b>సంకేతపదాన్ని మార్చుము</b> నొక్కండి."
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "GNOME OnScreen Keyboard"
+#~ msgstr "GNOME తెరపైని కీబోర్డు"
+
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "సూచిక కదలిక ఆగంగానే నొక్కును సిద్దంచేయుము(_I)"
+
+#~ msgid "S_ocks host:"
+#~ msgstr "సాక్స్ అతిధేయ(_o):"
+
+#~ msgid "_Run at start"
+#~ msgstr "ప్రారంభం వద్ద నడుపుము(_R)"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "యుఆర్ఎల్ ప్రస్తుతం ఇక్కడ నుండి బదలాయించబడుతుంది"
+
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "ఎంపిక చేసిన అక్షరశైలి %d పాలు పెద్దది, దీన్ని కంప్యూటర్ వినియోగించటం కష్టతరం.మీరు %dపాలు కన్నా "
+#~ "చిన్నది ఎంపిక చేసుకోవాలని సలహా"
+#~ msgstr[1] ""
+#~ "ఎంపిక చేసిన అక్షరశైలి %d పాలు పెద్దది, దీన్ని కంప్యూటర్ వినియోగించటం కష్టతరం.మీరు %dపాలు కన్నా "
+#~ "చిన్నది ఎంపిక చేసుకోవాలని సలహా"
+
+#~ msgid "Parent Window"
+#~ msgstr "మాత్రుక విండో"
+
+#~ msgid "Models"
+#~ msgstr "నమూనాలు"
+
+#~ msgid "All Files"
+#~ msgstr "అన్ని ఫైళ్ళు"
+
+#~ msgid "Windows"
+#~ msgstr "విండోలు"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "మీ నెట్వర్కు ప్రాక్సీ అభీష్టాలను అమర్చుము"
+
+#~ msgid "_State/Province:"
+#~ msgstr "రాష్త్రం/మండలము(_S):"
+
+#~ msgid "_Document font:"
+#~ msgstr "పత్రము ఫాంటు(_D):"
+
+#~ msgid "_None"
+#~ msgstr "ఏదికాదు(_N)"
+
+#~ msgid "D_rag click:"
+#~ msgstr "లాగి నొక్కు(_r):"
+
+#~ msgid "_New password:"
+#~ msgstr "కొత్త సంకేతపదం(_N):"
+
+#~ msgid "Unable to launch %s: %s"
+#~ msgstr "దించ లేము %s: %s"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "విరామం తర్వాత ఎంపికచేసిన విండోలను లేవనెత్తుము(_R)"
+
+#~ msgid "Close the control-center when a task is activated"
+#~ msgstr "కర్తవ్యం క్రీయాశీలం కాగానే నియంత్రణా-కేంద్రంను మూయుము"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "ముందుగానే నొక్కు రకాన్ని ఎంచుకొనుము(_b)"
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "కొత్త మరియు పాత సంకేతపదాలు ఒకేపోలికతో ఉన్నాయి."
+
+#~ msgid "Slide Show"
+#~ msgstr "స్లైడ్ షో"
+
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' నకలుతీయుచున్నది"
+
+#~ msgid "_Acceleration:"
+#~ msgstr "త్వరుణం(_A):"
+
+#~ msgid ""
+#~ "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;"
+#~ "default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+#~ msgstr ""
+#~ "[థీమ్ ను మార్చుము;gtk-theme-selector.desktop,అభీష్ట అనువర్తనంలను అమర్చుము; "
+#~ "default-applications.desktop,ముద్రణాయంత్రంను జతచేయుము;gnome-cups-manager."
+#~ "desktop]"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "వృద్దీకరణి తో ఒర్కా"
+
+#~ msgid "Upgrade"
+#~ msgstr "మెరుగుదల"
+
+#~ msgid "ETerm"
+#~ msgstr "Eఅగ్రం"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "HTTP ప్రాక్సీ వివరములు"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME ఆకృతీకరణ సాధనం"
+
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr "పేర్కొన్న దోషంతో పాటు టైపింగు విరామ లక్షణాల సంభాషణను వెలికి తీసుకు రాలేకసోయింది: %s"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "పునరావృత కీబోర్డు ఉపయోగిత నష్టాల నిరోదనకు సహాయపడుటకు కొంత కాలపరిమాణం తరువాత తెరను లాక్‌చేయుము"
+
+#~ msgid "Remove from Favorites"
+#~ msgstr "ఇష్టాంశముల నుండి తీసివేయుము"
+
+#~ msgid "C_ity:"
+#~ msgstr "పట్టణం(_i):"
+
+#~ msgid "Add to Startup Programs"
+#~ msgstr "ప్రారంభ ప్రోగ్రామ్స్ కు జతచేయుము"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[వాల్‌పేపర్...]"
+
+#~ msgid "Cale_ndar:"
+#~ msgstr "క్యాలెండర్(_n):"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox సంగీత ప్లేయర్"
+
+#~ msgid "NXterm"
+#~ msgstr "NXఅగ్రం"
+
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "అన్ని నియమాలకు ఒకే ప్రాక్సీని ఉపయోగించుము(_U)"
+
+#~ msgid "Text"
+#~ msgstr "పాఠ్యము"
+
+#~ msgid "_Monochrome"
+#~ msgstr "మోనోక్రోమ్(_M)"
+
+#~ msgid "_Preferred Applications"
+#~ msgstr "అభీష్ట అనువర్తనంలు(_P)"
+
+#~ msgid "Wor_k:"
+#~ msgstr "పని(_k):"
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr "మీ సంకేతపదాన్ని మార్చుటకు <b>సంకేతపదాన్ని మార్చు</b> నొక్కండి."
+
+#~ msgid "Child exited unexpectedly"
+#~ msgstr "అనుకోకుండా శిశువు ఉత్తేజితం అయింది"
+
+#~ msgid "Don't check whether the notification area exists"
+#~ msgstr "ప్రకటన ప్రదేశం ఉందేమో పరిశీలించవద్దు"
+
+#~ msgid "The current controls theme does not support color schemes."
+#~ msgstr "ప్రస్తుత నియంత్రికల థీమ్ వర్ణపు పధకాలకు మద్దతీయుటలేదు."
+
+#~ msgid "seconds"
+#~ msgstr "సెకనులు"
+
+#~ msgid "Select your default applications"
+#~ msgstr "మీ అప్రమేయ అనువర్తనంలను ఎంపికచేయుము"
+
+#~ msgid "Theme"
+#~ msgstr "థీమ్"
+
+#~ msgid "Assistive Technologies Preferences"
+#~ msgstr "సహాయక సాంకేతికతల అభీష్టాలు"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>మానవీయ ప్రాక్సీ ఆకృతీకరణ(_M)</b>"
+
+#~ msgid "Beep when _accessibility features are turned on or off"
+#~ msgstr "అందుబాటు సౌలభ్యాలు ఆన్ లేదా ఆఫ్ అయినప్పుడు బీప్‌చేయుము(_a)"
+
+#~ msgid "_Input boxes:"
+#~ msgstr "ఇన్‌పుట్ పెట్టెలు(_I):"
+
+#~ msgid "_Window title font:"
+#~ msgstr "విండో శీర్షిక ఫాంటు(_W):"
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "దయచేసి మీ సంకేతపదాన్ని <b>కొత్త సంకేతపదం</b> క్షేత్రమునందు టైపుచేయండి."
+
+#~ msgid "_Mobile:"
+#~ msgstr "మొబైల్(_M):"
+
+#~ msgid "About %s"
+#~ msgstr "%s గురించి"
+
+#~ msgid "Maximize"
+#~ msgstr "పెద్దది చేయు"
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "విరామ చివరలను విడగొట్టుము(_B)"
+
+#~ msgid "Theme name must be present"
+#~ msgstr "వైవిద్యాంశం తప్పనిసరిగా వుండాలి"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "మౌస్ వాటిపైకి కదలగానే విండోను ఎంపికచేయుము(_S)"
+
+#~ msgid "The current theme suggests a background and a font."
+#~ msgstr "ప్రస్తుత థీమ్ ఒక బ్యాక్‌గ్రౌండ్‌ను మరియు ఫాంటును సూచిస్తోంది."
+
+#~ msgid "Exit shell on help action performed"
+#~ msgstr "సహాయం చర్య జరుపబడగానే షెల్ నుండి బయటకురమ్ము"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Use selected font"
+#~ msgstr "ఎంపికచేసిన ఫాంటును వాడుము"
+
+#~ msgid "U_sername:"
+#~ msgstr "వినియోగదారునినామము(_s):"
+
+#~ msgid "Roll up"
+#~ msgstr "ఎగువకు మడువు"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "గ్నోపర్నికస్"
+
+#~ msgid "Beep when key is _rejected"
+#~ msgstr "కీ తిరస్కరించినప్పుడు బీప్ చేయుము(_r)"
+
+#~ msgid "System error: %s."
+#~ msgstr "సిస్టమ్ దోషం: %s."
+
+#~ msgid "Your password has been changed."
+#~ msgstr "మీ సంకేతపదం మార్చబడింది."
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "సహాయక సాంకేతికతలను చేతనంచేయుము(_E)"
+
+#~ msgid "_Vendors:"
+#~ msgstr "అమ్మకందారులు(_V):"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "అభీష్ట దృశ్యసంభంద సాంకేతికతను ప్రారంభించుము"
+
+#~ msgid "Jump to the Keyboard Accessibility dialog"
+#~ msgstr "కీబోర్డు అందుబాటు డైలాగ్‌కు దూకుము"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "మీ మౌస్ అభీష్టాలను అమర్చుము"
+
+#~ msgid "State/Pro_vince:"
+#~ msgstr "రాష్ట్రం/ప్రాంతము(_v):"
+
+#~ msgid "Copying files"
+#~ msgstr "దస్త్రములను నకలుతీయుచున్నది"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "ఆదేశం(_m):"
+
+#~ msgid "The current theme suggests a font."
+#~ msgstr "ప్రస్తుత థీమ్ ఒక ఫాంట్‌ను సూచిస్తోంది."
+
+#~ msgid "A_ssistant:"
+#~ msgstr "సహాయకి(_s):"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "మీ కీబోర్డు అభీష్టాలను అమర్చుము"
+
+#~ msgid "Konsole"
+#~ msgstr "కన్సోల్"
+
+#~ msgid "Run at st_art"
+#~ msgstr "ప్రారంభంవద్ద నడుపుము(_a)"
+
+#~ msgid "Alert Buttons"
+#~ msgstr "సంకేతం బటన్లు"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "సంకేత డైలాగ్ లోని లేబుల్ మరియు చిత్రము చుట్టూ ఉన్న సరిహద్దు యొక్క వెడల్పు"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "ఉత్తమ ఘాడత(_n)"
+
+#~ msgid "That password was incorrect."
+#~ msgstr "ఆ సంకేతపదం సరైనదికాదు."
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "చిరునామాపుస్తకం సమాచారాన్ని పొందుటకు ప్రయత్నిస్తున్నప్పుడు అక్కడొక దోషంఉంది\n"
+#~ "ఎవాల్యూషన్ డాటా సేవిక నియమాన్ని సంభాలించలేదు"
+
+#~ msgid "To URI"
+#~ msgstr "యుఆర్ఎల్ కు"
+
+#~ msgid "_Ignore fast duplicate keypresses"
+#~ msgstr "వేగ నకిలీ కీవత్తులను వదిలివేయుము(_I)"
+
+#~ msgid "_Tooltips:"
+#~ msgstr "చిట్కాలు(_T):"
+
+#~ msgid "Network Proxy"
+#~ msgstr "నెట్వర్కు ప్రాక్సీ"
+
+#~ msgid "Preview:"
+#~ msgstr "ఉపదర్శనం:"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "ఈ చర్యను జరుపుటకు శీర్షికపట్టీని రెండు-నొక్కులు నొక్కుము(_D):"
+
+#~ msgid "The current theme suggests a background."
+#~ msgstr "ప్రస్తుత థీమ్ ఒక బ్యాక్‌గ్రౌండ్‌ను సూచిస్తోంది."
+
+#~ msgid "Beep when a key is reje_cted"
+#~ msgstr "కీ తిరస్కరించబడినప్పుడు బీప్‌చేయుము(_c)"
+
+#~ msgid "Orca"
+#~ msgstr "ఒర్కా"
+
+#~ msgid "\"%s\" does not appear to be a valid theme."
+#~ msgstr "\"%s\" విలువైన థీమ్‌లా అనిపించుటలేదు."
+
+#~ msgid "_Single click:"
+#~ msgstr "ఏక నొక్కు(_S):"
+
+#~ msgid "Exit shell on upgrade or uninstall action performed"
+#~ msgstr "నవీకరణ లేదా నిర్మూలన చర్య జరుపబడగానే షెల్ నుండి బయటకురమ్ము"
+
+#~ msgid "Best _shapes"
+#~ msgstr "ఉత్తమ రూపాలు(_S)"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "విరామాల యొక్క వాయిదాలను అనుమతించుము(_o)"
+
+#~ msgid "_Windows:"
+#~ msgstr "విండోలు(_W):"
+
+#~ msgid "_Work:"
+#~ msgstr "పని(_W):"
+
+#~ msgid "Disa_ble sticky keys if two keys are pressed together"
+#~ msgstr "ఒకేసారి రెండుకీలు కలిపి వత్తబడితే చెందివుండు కీలను అచేతనంచేయుము(_b)"
+
+#~ msgid "Common Tasks"
+#~ msgstr "ఉమ్మడి కర్తవ్యాలు"
+
+#~ msgid "Vendors"
+#~ msgstr "అమ్మకందార్లు"
+
+#~ msgid "Rename..."
+#~ msgstr "పునఃనామకరణం..."
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "ప్రామాణిక Xఅగ్రం"
+
+#~ msgid "Set your window properties"
+#~ msgstr "మీ విండో లక్షణాలను అమర్చుము"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "పని విరామాల చివరలు(_W):"
+
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr "ప్రాధమిక బటన్ నొక్కిఉంచుట ద్వారా ద్వితీయ నొక్కును ప్రయోగించుము(_T):"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "తెర చదువునది లేకుండా GNOME వృద్దీకరణి"
+
+#~ msgid ""
+#~ "if true, the control-center will close when a \"Common Task\" is "
+#~ "activated."
+#~ msgstr "నిజమైతే, \"ఉమ్మడి కర్తవ్యం\" క్రియాశీలం అవ్వగానే నియంత్రణ-కేంద్రం మూయబడుతుంది."
+
+#~ msgid "Save _As..."
+#~ msgstr "ఇలా దాయుము(_A)..."
+
+#~ msgid "Visual Assistance"
+#~ msgstr "దృశ్యసంభంధ సహాయకి"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "వర్ణమును తెలుపుటకు డైలాగ్ ను తెరువుము"
+
+#~ msgid "Move to Trash"
+#~ msgstr "చెత్తకుండికి కదుపుము"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "యాహూ(_Y):"
+
+#~ msgid "Take a break!"
+#~ msgstr "విరామం తీసుకొ!"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "ఉత్తేజితంకు ముందు విరామం(_I):"
+
+#~ msgid "Work _fax:"
+#~ msgstr "పని ఫాక్స్(_f):"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "ముఖ్య అంతర్ముఖిని నింపలేకపోతోంది"
+
+#~ msgid "_Models:"
+#~ msgstr "రీతులు(_M):"
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "కొత్త సంకేతపదం అంకెలు లేదా ప్రత్యేక అక్షరము(ల)ను తప్పక కలిగిఉండవలెను."
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a help action is performed."
+#~ msgstr "సహాయం చర్య జరుగగానే షెల్ మూయాలేమో సూచించుము."
+
+#~ msgid "New Document"
+#~ msgstr "కొత్త పత్రము"
+
+#~ msgid "The %s utility is not installed."
+#~ msgstr "%s సౌలభ్యం సంస్థాపించబడలేదు."
+
+#~ msgid "Yesterday %l:%M %p"
+#~ msgstr "నిన్న %l:%M %p"
+
+#~ msgid "_Only accept long keypresses"
+#~ msgstr "ఎక్కువసేపు కీవత్తులను మాత్రమే ఆమోదించు(_O)"
+
+#~ msgid "Apply Background"
+#~ msgstr "బ్యాక్‌గ్రౌండ్‌ను ఆపాదించుము"
+
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "దస్త్రమును నకలుతీయలేము: %2$u యొక్క %1$u"
+
+#~ msgid "A system error has occurred"
+#~ msgstr "ఒక సిస్టమ్ దోషం ఎదురైంది"
+
+#~ msgid "N_one"
+#~ msgstr "ఏదీకాదు(_o)"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "తాత్కాలిక సంచయం సృష్టించుటలో విఫలమైంది"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "ఫ్లాగ్‌ను నిర్వర్తించు(_x):"
+
+#~ msgid "Delete"
+#~ msgstr "తొలగించు"
+
+#~ msgid "Fonts"
+#~ msgstr "ఫాంట్లు"
+
+#~ msgid "D_etails..."
+#~ msgstr "వివరములు(_e)..."
+
+#~ msgid "_Retype new password:"
+#~ msgstr "కొత్త సంకేతపదాన్ని తిరిగిటైపుచేయండి(_R):"
+
+#~ msgid "_Manager:"
+#~ msgstr "అభికర్త(_M):"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "తర్వాత విరామానికి ఒక నిమిషం కన్నా తక్కువ సమయం"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "గ్రేస్కేలు(_y)"
+
+#~ msgid "Remove from System Items"
+#~ msgstr "సిస్టమ్ అంశములనుండి తొలగించుము"
+
+#~ msgid "Apply Font"
+#~ msgstr "ఫాంటును ఆపాదించుము"
+
+#~ msgid "Filter"
+#~ msgstr "వడపోత"
+
+#~ msgid "To move a window, press-and-hold this key then grab the window:"
+#~ msgstr "విండోకు కదులుటకు, ఈ కీను వత్తుము-మరియు-పట్టిఉంచుము అప్పుడు విండో పట్టుము:"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "మీరు ఈ థీమ్‌ను తొలగించుదామని అనుకుంటున్నారా?"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "సంకేతం డైలాగ్ నందు చూపించబడిన బటన్లు"
+
+#~ msgid ""
+#~ "Indicates whether to close the shell when a start action is performed."
+#~ msgstr "ప్రారంభం చర్య జరుగగానే షెల్ మూయాలేమో సూచించుము."
+
+#~ msgid "_Department:"
+#~ msgstr "శాఖ(_D):"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "మొత్తం యుఆర్ఎల్ ల సంఖ్య"
+
+#~ msgid "_Meta"
+#~ msgstr "మెటా(_M)"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "కేవలం అమరికలను అమలు చేసి త్యజించు(అనుసంధానం మాత్రమే, ప్రస్తుతం సూత్రధారులతో మాత్రమే "
+#~ "నడుపబడుతుంది)"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "ఇప్పటివరకూ పూర్తయిన బదలాయింపు భిన్నం"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "మూయి మరియు లాగ్అవుట్ అవ్వు(_L)"
+
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "సహాయం ప్రదర్శించుటలో దోషం: %s"
+
+#~ msgid "Typing Break"
+#~ msgstr "టైపింగ్ విరామం"
+
+#~ msgid "Exit shell on start action performed"
+#~ msgstr "ప్రారంభం చర్య జరుపబడగానే షెల్ నుండి బయటకురమ్ము"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "కొత్త స్ప్రెడ్‌షీట్"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- GNOME కీబోర్డు అభీష్టాలు"
+
+#~ msgid "Total URIs"
+#~ msgstr "మొత్తం యుఆర్ఎల్ లు"
+
+#~ msgid "Gnopernicus with Magnifier"
+#~ msgstr "వృద్దీకరణి తో గ్నోపర్నికస్"
+
+#~ msgid "_Variants:"
+#~ msgstr "తేడాలు(_V):"
+
+#~ msgid ""
+#~ "Please type your password again in the <b>Retype new password</b> field."
+#~ msgstr "దయచేసి మీ సంకేతపదాన్ని <b>కొత్త సంకేతపదాన్ని మరలాటైపుచేయి</b> క్షేత్రమునందు టైపుచేయండి."
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "నెలకొల్పుటకు వైవిద్యాంశ దస్త్ర స్థానాన్ని పేర్కొనలేదు"
+
+#~ msgid "Re_fresh rate:"
+#~ msgstr "పునర్వికాసం రేటు(_f):"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "విండో శీర్షికపట్టీని ప్రకాశించుము(_w)"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr "నిజంకు అమర్చితే, అప్పుడు ఓపెన్‌టైప్ ఫాంట్లు థంబ్‌నెయిల్ అవుతాయి."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "నిజంకు అమర్చితే, అప్పుడు PCF ఫాంట్లు థంబ్‌నెయిల్ అవుతాయి."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr "నిజంకు అమర్చితే, అప్పుడు ట్రూటైప్ ఫాంట్లు థంబ్‌నెయిల్ అవుతాయి."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "నిజంకు అమర్చితే, అప్పుడు టైపు1 ఫాంట్లు థంబ్‌నెయిల్ అవుతాయి."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr "ఓపెన్‌టైప్ ఫాంట్ల కొరకు థంబ్‌నెయిల్సును సృష్టించుటకు ఉపయోగించు ఆదేశంకు ఈ కీని అమర్చుము."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr "PCF ఫాంట్ల కొరకు థంబ్‌నెయిల్సును సృష్టించుటకు ఉపయోగించు ఆదేశంకు ఈ కీని అమర్చుము."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr "ట్రూటైప్ ఫాంట్ల కొరకు థంబ్‌నెయిల్సును సృష్టించుటకు ఉపయోగించు ఆదేశంకు ఈ కీని అమర్చుము."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr "టైప్ 1 ఫాంట్ల కొరకు థంబ్‌నెయిల్సును సృష్టించుటకు ఉపయోగించు ఆదేశంకు ఈ కీని అమర్చుము."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "ఓపెన్‌టైప్ ఫాంట్ల కొరకు థంబ్‌నైల్ ఆదేశం"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "PCF ఫాంట్ల కొరకు థంబ్‌నైల్ ఆదేశం"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "ట్రూటైప్ ఫాంట్ల కొరకు థంబ్‌నైల్ ఆదేశం"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "టైప్1 ఫాంట్ల కొరకు థంబ్‌నైల్ ఆదేశం"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "ఓపెన్‌టైప్ ఫాంట్లను థంబ్‌నైల్ చేయాలా"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "PCF ఫాంట్లను థంబ్‌నైల్ చేయాలా"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "ట్రూటైప్ ఫాంట్లను థంబ్‌నైల్ చేయాలా"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "టైప్1 ఫాంట్లను థంబ్‌నైల్ చేయాలా"
+
+#~ msgid "Name:"
+#~ msgstr "నామము:"
+
+#~ msgid "Style:"
+#~ msgstr "శైలి:"
+
+#~ msgid "Version:"
+#~ msgstr "వర్షన్:"
+
+#~ msgid "Copyright:"
+#~ msgstr "కాపీరైట్:"
+
+#~ msgid "Description:"
+#~ msgstr "వివరణ:"
+
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "వినిమయం: %s అక్షరశైలిదస్త్రం\n"
+
+#~ msgid "Text to thumbnail (default: Aa)"
+#~ msgstr "థంబ్‌నైల్ కు పాఠ్యము (అప్రమేయం:Aa)"
+
+#~ msgid "TEXT"
+#~ msgstr "పాఠ్యము"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "ఫాంటు పరిమాణం (అప్రమేయం: 64)"
+
+#~ msgid "SIZE"
+#~ msgstr "పరిమాణం"
+
+#~ msgid "FONT-FILE OUTPUT-FILE"
+#~ msgstr "FONT-FILE OUTPUT-FILE"
+
+#~ msgid "Error parsing arguments: %s\n"
+#~ msgstr "ఆర్గుమెంట్లను పార్శ్ చేయుటలో దోషం: %s\n"
+
+#~ msgid "The type of alert"
+#~ msgstr "హెచ్చరిక యొక్క రకము"
+
+#~ msgid "Select Image"
+#~ msgstr "ప్రతిబింబమును యెంపికచేయుము"
+
+#~ msgid "No Image"
+#~ msgstr "ప్రతిబింబము లేదు"
+
+#~ msgid "Images"
+#~ msgstr "ప్రతిబింబములు"
+
+#~ msgid "Enable _Fingerprint Login..."
+#~ msgstr "వేలిముద్ర లాగిన్ చేతనముచేయుము... (_F)"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "వేలిముద్ర లాగిన్ అచేతనముచేయుము... (_F)"
+
+#~ msgid "About Me"
+#~ msgstr "నా గురించి"
+
+#~ msgid "Export"
+#~ msgstr "ఎగుమతి"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "నెమ్మది"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "వేగము"
+
+#~ msgid "_Options…"
+#~ msgstr "ఐచ్ఛికాలు... (_O)"
+
+#~ msgid "blablabla"
+#~ msgstr "blablabla"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "చిరునామా\n"
+#~ "విభాగము\n"
+#~ "యిచట\n"
+#~ "వచ్చును"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "విభాగము\n"
+#~ "యిచట\n"
+#~ "వచ్చును"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "రౌట్స్\n"
+#~ "విభాగము\n"
+#~ "యిచట\n"
+#~ "వచ్చును"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "వాహకం/లంకె మార్చబడింది"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "చిట్కా: <a href=\"screen\">తెర కాంతిప్రకాశం</a> యెంత పవర్ వుపయోగించబడెనో ప్రభావితం చేయును"

--- a/po/tg.po
+++ b/po/tg.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2020-09-18 17:24+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2020-09-18 22:50+0500\n"
 "Last-Translator: Victor Ibragimov <victor.ibragimov@gmail.com>\n"
 "Language-Team: Tajik <tg@li.org>\n"
@@ -20,354 +19,224 @@ msgstr ""
 "X-Generator: Poedit 2.2.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: panels/applications/cc-applications-panel.c:561
-#, fuzzy
-#| msgid "System Sounds"
-msgid "System Bus"
-msgstr "Овозҳои низом"
-
-#: panels/applications/cc-applications-panel.c:561
-#: panels/applications/cc-applications-panel.c:563
-#: panels/applications/cc-applications-panel.c:579
-#: panels/applications/cc-applications-panel.c:584
-#, fuzzy
-#| msgid "_Full Name"
-msgid "Full access"
-msgstr "_Номи пурра"
-
-#: panels/applications/cc-applications-panel.c:563
-#, fuzzy
-#| msgid "Session Ended"
-msgid "Session Bus"
-msgstr "Ҷаласа хотима ёфт"
-
-#: panels/applications/cc-applications-panel.c:568
-#: panels/power/cc-power-panel.c:2453 panels/thunderbolt/cc-bolt-panel.ui:466
-#: panels/thunderbolt/cc-bolt-panel.ui:525 shell/cc-panel-list.ui:45
-#: shell/cc-window.c:268
-msgid "Devices"
-msgstr "Дастгоҳҳо"
-
-#: panels/applications/cc-applications-panel.c:568
-msgid "Full access to /dev"
-msgstr "Дастрасии пурра ба /dev"
-
-#: panels/applications/cc-applications-panel.c:573
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:241
-msgid "Network"
-msgstr "Шабака"
-
-#: panels/applications/cc-applications-panel.c:573
-#, fuzzy
-#| msgid "Network Name"
-msgid "Has network access"
-msgstr "Номи шабака"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: panels/applications/cc-applications-panel.c:579
-#: panels/applications/cc-applications-panel.c:581
-#: panels/background/cc-background-chooser-dialog.c:536
-#: panels/search/cc-search-locations-dialog.c:286
-msgid "Home"
-msgstr "Асосӣ"
-
-#: panels/applications/cc-applications-panel.c:581
-#: panels/applications/cc-applications-panel.c:586
-#, fuzzy
-#| msgctxt "printer state"
-#| msgid "Ready"
-msgid "Read-only"
-msgstr "Тайёр"
-
-#: panels/applications/cc-applications-panel.c:584
-#: panels/applications/cc-applications-panel.c:586
-#, fuzzy
-#| msgid "Open System"
-msgid "File System"
-msgstr "Системаи кушода"
-
-#: panels/applications/cc-applications-panel.c:591
-#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:272
-#: shell/cc-window.c:935 shell/cc-window.ui:131
-#: shell/gnome-control-center.desktop.in.in:3
-msgid "Settings"
-msgstr "Танзимот"
-
-#: panels/applications/cc-applications-panel.c:591
-msgid "Can change settings"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:596
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:738
-msgid "Web Links"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:748
-msgid "Git Links"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:754
-#, c-format
-msgid "%s Links"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:762
-#: panels/applications/cc-applications-panel.c:798
-msgid "Unset"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:853
-#, fuzzy
-#| msgid "Link speed"
-msgid "Links"
-msgstr "Суръати пайванд"
-
-#: panels/applications/cc-applications-panel.c:861
-#, fuzzy
-#| msgid "_Delete Files"
-msgid "Hypertext Files"
-msgstr "_Нест кардани файлҳо"
-
-#: panels/applications/cc-applications-panel.c:875
-#, fuzzy
-#| msgid "_Delete Files"
-msgid "Text Files"
-msgstr "_Нест кардани файлҳо"
-
-#: panels/applications/cc-applications-panel.c:889
-#, fuzzy
-#| msgid "_Keep Files"
-msgid "Image Files"
-msgstr "_Нигоҳ доштани файлҳо"
-
-#: panels/applications/cc-applications-panel.c:905
-#, fuzzy
-#| msgid "_Delete Files"
-msgid "Font Files"
-msgstr "_Нест кардани файлҳо"
-
-#: panels/applications/cc-applications-panel.c:966
-msgid "Archive Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:986
-msgid "Package Files"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.c:1009
-#, fuzzy
-#| msgid "All files"
-msgid "Audio Files"
-msgstr "Ҳамаи файлҳо"
-
-#: panels/applications/cc-applications-panel.c:1026
-#, fuzzy
-#| msgid "_Keep Files"
-msgid "Video Files"
-msgstr "_Нигоҳ доштани файлҳо"
-
-#: panels/applications/cc-applications-panel.c:1034
-#, fuzzy
-#| msgid "_Delete Files"
-msgid "Other Files"
-msgstr "_Нест кардани файлҳо"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1376
-#: panels/applications/cc-applications-panel.ui:406
+#: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
-#: panels/notifications/cc-notifications-panel.ui:167
-#: panels/privacy/cc-privacy-panel.ui:1085
+#: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
 msgstr "Барномаҳо"
 
-#: panels/applications/cc-applications-panel.ui:45
+#: panels/applications/cc-applications-panel.ui:31
 #, fuzzy
-#| msgid "No applications found"
 msgid "No applications"
 msgstr "Ягон барнома ёфт нашуд"
 
-#: panels/applications/cc-applications-panel.ui:59
+#: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr "Насб кардани баъзеи…"
 
-#: panels/applications/cc-applications-panel.ui:99
-msgid "Permissions & Access"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:111
-msgid ""
-"Data and services that this app has asked for access to and permissions that "
-"it requires."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:126
-#: panels/applications/cc-applications-panel.ui:132
-#: panels/privacy/cc-privacy-panel.c:908 panels/privacy/cc-privacy-panel.ui:745
+#: panels/applications/cc-applications-panel.ui:84
 #, fuzzy
-#| msgid "%s Camera"
-msgid "Camera"
-msgstr "Камераи %s"
+msgid "Open"
+msgstr "_Кушодан"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: panels/applications/cc-applications-panel.ui:133
-#: panels/applications/cc-applications-panel.ui:145
-#: panels/applications/cc-applications-panel.ui:157
-#: panels/applications/cc-applications-panel.ui:237
-#: panels/applications/cc-applications-panel.ui:255
-#: panels/keyboard/cc-keyboard-option.c:259
-#: panels/keyboard/cc-keyboard-option.c:378
-#: panels/keyboard/keyboard-shortcuts.c:425
-#: panels/keyboard/shortcut-editor.ui:96 panels/network/network-proxy.ui:123
-#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
-#: panels/user-accounts/um-fingerprint-dialog.c:211
-#: subprojects/gvc/gvc-mixer-control.c:1864
-msgid "Disabled"
-msgstr "Ғайрифаъол"
-
-#: panels/applications/cc-applications-panel.ui:138
-#: panels/applications/cc-applications-panel.ui:144
-#: panels/privacy/cc-privacy-panel.c:941 panels/privacy/cc-privacy-panel.ui:850
-msgid "Microphone"
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:150
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/privacy/cc-privacy-panel.c:850 panels/privacy/cc-privacy-panel.ui:955
+#: panels/applications/cc-applications-panel.ui:94
 #, fuzzy
-#| msgid "_Location Services"
-msgid "Location Services"
-msgstr "_Хидматҳои ҷойгиршавӣ"
+msgid "View Details"
+msgstr "Тафсилотро намоиш додан"
 
-#: panels/applications/cc-applications-panel.ui:162
-#: panels/applications/cc-applications-panel.ui:489
-#, fuzzy
-#| msgid "Built-in Webcam"
-msgid "Built-in Permissions"
-msgstr "Вебкамераи дарунсохт"
-
-#: panels/applications/cc-applications-panel.ui:163
-#, fuzzy
-#| msgid "Password could not be changed"
-msgid "Cannot be changed"
-msgstr "Ниҳонвожа тағйир дода намешавад"
-
-#: panels/applications/cc-applications-panel.ui:180
-msgid ""
-"Individual permissions for applications can be reviewed in the <a href="
-"\"privacy\">Privacy</a> Settings."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:204
-#, fuzzy
-#| msgid "Orientation"
-msgid "Integration"
-msgstr "Самт"
-
-#: panels/applications/cc-applications-panel.ui:216
-msgid "System features used by this application."
-msgstr ""
-
-#: panels/applications/cc-applications-panel.ui:230
-#: panels/applications/cc-applications-panel.ui:236
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
-#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:161
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Ҷустуҷӯ"
 
-#: panels/applications/cc-applications-panel.ui:242
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Ғайрифаъол"
+
+#: panels/applications/cc-applications-panel.ui:126
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:3
 msgid "Notifications"
 msgstr "Огоҳиҳо"
 
-#: panels/applications/cc-applications-panel.ui:248
-#: panels/applications/cc-applications-panel.ui:254
+#: panels/applications/cc-applications-panel.ui:127
 #, fuzzy
-#| msgid "Sound"
+msgid "Show system notifications."
+msgstr "_Намоиш додани огоҳиҳо"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Пасзамина"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Суратҳои экран"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Тасвирҳои экран"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
 msgid "Sounds"
 msgstr "Садо"
 
-#: panels/applications/cc-applications-panel.ui:287
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
 #, fuzzy
-#| msgid "_Default printer"
-msgid "Default Handlers"
-msgstr "_Принтери пешфарз"
+msgid "Inhibit Shortcuts"
+msgstr "Миёнбурҳо"
 
-#: panels/applications/cc-applications-panel.ui:299
-msgid "Types of files and links that this application opens."
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Миёнбурҳои клавиатура"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "Камераи %s"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:315
-msgid "Reset"
-msgstr "Бозсозӣ"
-
-#: panels/applications/cc-applications-panel.ui:351
-msgid "Usage"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:363
-msgid "How much resources this application is using."
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:378
-#: panels/applications/cc-applications-panel.ui:525
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "_Хидматҳои ҷойгиршавӣ"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "Вебкамераи дарунсохт"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 #, fuzzy
-#| msgid "_Software"
-msgid "Open in Software"
-msgstr "_Нармафзор"
-
-#: panels/applications/cc-applications-panel.ui:463 shell/cc-panel-list.ui:190
-#, fuzzy
-#| msgid "No regions found"
 msgid "No results found"
 msgstr "Ягон минтақа ёфт нашуд"
 
-#: panels/applications/cc-applications-panel.ui:474
-#: panels/keyboard/cc-keyboard-panel.ui:175 shell/cc-panel-list.ui:201
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:542
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Системаи кушода"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "Суръати пайванд"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Бозсозӣ"
+
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:551
+#: panels/applications/cc-applications-panel.ui:420
 #, fuzzy
-#| msgid "Applications"
 msgid "Application"
 msgstr "Барномаҳо"
 
-#: panels/applications/cc-applications-panel.ui:557
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:563
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:569
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr ""
 
-#: panels/applications/cc-applications-panel.ui:586
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr ""
 
@@ -375,210 +244,106 @@ msgstr ""
 msgid "Control various application permissions and settings"
 msgstr ""
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 
-#: panels/background/background.ui:49
+#: panels/background/cc-background-panel.ui:9
 #, fuzzy
-#| msgid "Background"
-msgid "_Background"
-msgstr "Пасзамина"
+msgid "Style"
+msgstr "Қалам"
 
-#. This refers to a slideshow background
-#: panels/background/background.ui:99 panels/background/background.ui:212
-msgid "Changes throughout the day"
-msgstr "Тағйироти рӯз"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Пешфарз"
 
-#. To translators: This is a noun, not a verb
-#: panels/background/background.ui:162
-#, fuzzy
-#| msgid "Lock Screen"
-msgid "_Lock Screen"
-msgstr "Экрани қулф"
-
-#: panels/background/background.ui:268
-msgctxt "background, style"
-msgid "Tile"
-msgstr "Сафолпӯш"
-
-#: panels/background/background.ui:272
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "Танзими андоза"
-
-#: panels/background/background.ui:276
-msgctxt "background, style"
-msgid "Center"
-msgstr "Ба марказ кӯчонидан"
-
-#: panels/background/background.ui:280
-msgctxt "background, style"
-msgid "Scale"
-msgstr "Миқиёсбандӣ"
-
-#: panels/background/background.ui:284
-msgctxt "background, style"
-msgid "Fill"
-msgstr "Пуркунӣ"
-
-#: panels/background/background.ui:288
-msgctxt "background, style"
-msgid "Span"
-msgstr "Ваҷаб"
-
-#: panels/background/cc-background-chooser-dialog.c:412
-msgid "Wallpapers"
-msgstr "Тасвирҳои экран"
-
-#: panels/background/cc-background-chooser-dialog.c:423
-msgid "Colors"
-msgstr "Рангҳо"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: panels/background/cc-background-chooser-dialog.c:455
-msgid "Select Background"
-msgstr "Интихоби пасзамина"
-
-#: panels/background/cc-background-chooser-dialog.c:484
-msgid "Pictures"
-msgstr "Тасвирҳо"
-
-#. translators: No pictures were found
-#: panels/background/cc-background-chooser-dialog.c:519
-msgid "No Pictures Found"
-msgstr "Ягон тасвир ёфт нашудааст"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: panels/background/cc-background-chooser-dialog.c:546
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
-"Шумо метавонед тасвирҳоро ба ҷузвдони %s илова кунед ва онҳо дар ин ҷо "
-"намоиш дода мешаванд"
 
-#: panels/background/cc-background-chooser-dialog.c:550
-#: panels/color/cc-color-panel.c:241 panels/color/cc-color-panel.c:894
-#: panels/color/cc-color-panel.ui:657 panels/color/color-calibrate.ui:25
-#: panels/common/cc-language-chooser.ui:24
-#: panels/display/cc-display-panel.c:916
-#: panels/network/connection-editor/connection-editor.ui:17
-#: panels/network/connection-editor/vpn-helpers.c:181
-#: panels/network/connection-editor/vpn-helpers.c:310
-#: panels/network/net-device-wifi.c:1200 panels/network/net-device-wifi.c:1280
-#: panels/network/net-device-wifi.c:1474 panels/network/network-wifi.ui:24
-#: panels/printers/new-printer-dialog.ui:45
-#: panels/printers/pp-details-dialog.c:313
-#: panels/privacy/cc-privacy-panel.c:1137 panels/region/cc-format-chooser.ui:24
-#: panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:607
-#: panels/sharing/cc-sharing-panel.c:427
-#: panels/user-accounts/cc-add-user-dialog.ui:28
-#: panels/user-accounts/cc-avatar-chooser.c:106
-#: panels/user-accounts/cc-avatar-chooser.c:234
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:640
-#: panels/user-accounts/cc-user-panel.c:658
-#: panels/user-accounts/data/join-dialog.ui:20
-#: panels/user-accounts/um-fingerprint-dialog.c:261
-msgid "_Cancel"
-msgstr "_Бекор кардан"
-
-#: panels/background/cc-background-chooser-dialog.c:551
-#: panels/common/cc-language-chooser.ui:12
-#, fuzzy
-#| msgid "Select"
-msgid "_Select"
-msgstr "Интихоб кардан"
-
-#: panels/background/cc-background-item.c:191
-msgid "multiple sizes"
-msgstr "якчанд андоза"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:195
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:320
-msgid "No Desktop Background"
-msgstr "Бе пасзаминаи мизи корӣ"
-
-#: panels/background/cc-background-panel.c:291
-msgid "Current background"
-msgstr "Пасзаминаи ҷорӣ"
-
-#: panels/background/gnome-background-panel.desktop.in.in:3
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Пасзамина"
 
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "Илова кардани принтер…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "Фаронса"
+
 #: panels/background/gnome-background-panel.desktop.in.in:4
-msgid "Change your background image to a wallpaper or photo"
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "Тағйир додани тасвири пасзамина ба тасвири экран ё сурат"
 
-#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Тасвири экран;Экран;Мизи корӣ;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.c:309
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
 #, fuzzy
-#| msgid "No Bluetooth adapters found"
+msgid "Enable"
+msgstr "Фаъол кардан"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
 msgid "No Bluetooth Found"
 msgstr "Ягон адаптери Bluetooth ёфт нашуд"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:310
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.c:313
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 #, fuzzy
-#| msgid "Bluetooth Sharing"
 msgid "Bluetooth Turned Off"
 msgstr "Дастрасии муштараки Bluetooth"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:314
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr ""
 
-#: panels/bluetooth/cc-bluetooth-panel.c:317
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 #, fuzzy
-#| msgid "Air_plane Mode"
-msgid "Airplane Mode is on"
+msgid "Airplane Mode is On"
 msgstr "Ҳ_олати ҳавопаймо"
 
-#: panels/bluetooth/cc-bluetooth-panel.c:318
-#| msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr ""
 "Вақте ки ҳолати ҳавопаймо фаъол аст, Bluetooth дар ҳолати ғайрифаъол қарор "
 "мегирад."
 
-#: panels/bluetooth/cc-bluetooth-panel.c:321
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 #, fuzzy
-#| msgid "Air_plane Mode"
-msgid "Hardware Airplane Mode is on"
-msgstr "Ҳ_олати ҳавопаймо"
-
-#: panels/bluetooth/cc-bluetooth-panel.c:322
-msgid "Turn off the Airplane mode switch to enable Bluetooth."
-msgstr ""
-
-#: panels/bluetooth/cc-bluetooth-panel.c:324
-#, fuzzy
-#| msgid "Air_plane Mode"
 msgid "Turn Off Airplane Mode"
 msgstr "Ҳ_олати ҳавопаймо"
 
-#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "Ҳ_олати ҳавопаймо"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/network/cc-network-panel.ui:101
-#: panels/printers/pp-new-printer-dialog.c:1697
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -586,265 +351,92 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Фаъол ва хомӯш кардани Bluetooth ва пайваст кардани дастгоҳҳо"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr ""
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:348
+#: panels/camera/cc-camera-panel.ui:24
 #, fuzzy
-#| msgid "Place your calibration device over the square and press 'Start'"
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Дастгоҳи санҷишии худро ба чоркунҷа гузошта, \"Оғоз\"-ро зер кунед"
+msgid "Camera is Turned Off"
+msgstr "Дастрасии муштараки Bluetooth"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:354
+#: panels/camera/cc-camera-panel.ui:25
 #, fuzzy
-#| msgid ""
-#| "Move your calibration device to the calibrate position and press "
-#| "'Continue'"
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Дастгоҳи санҷишии худро ба ҷойгиршавии санҷиш гузошта, \"Идома додан\"-ро "
-"пахш кунед"
+msgid "No applications can capture photos or video."
+msgstr "Ягон барнома дар айни ҳол аудиоро пахш ё сабт накарда истодааст."
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:360
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
 #, fuzzy
-#| msgid ""
-#| "Move your calibration device to the surface position and press 'Continue'"
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
+msgid "Protect your pictures"
+msgstr "Тамошо кардани тасвирҳои дигар"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"Дастгоҳи санҷишии худро ба ҷойгиршавии сатҳ гузошта, \"Идома додан\"-ро пахш "
-"кунед"
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:366
-msgid "Shut the laptop lid"
-msgstr "Пӯшидани сарпӯши лэптоп"
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Санҷиши дисплей"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:397
-msgid "An internal error occurred that could not be recovered."
-msgstr "Хатои дарунии ҳалнашаванда ба вуҷуд омад."
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Бекор кардан"
 
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:402
-msgid "Tools required for calibration are not installed."
-msgstr "Абзорҳои лозимии санҷиши насб нашудаанд."
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
+msgstr "Оғоз кардан"
 
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:408
-msgid "The profile could not be generated."
-msgstr "Профил эҷод карда нашуд."
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
+msgstr "Давом додан"
 
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:414
-msgid "The target whitepoint was not obtainable."
-msgstr "Нуқтаи сафеди таъинотӣ ба даст оварда нашуд."
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Тайёр"
 
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:453
-msgid "Complete!"
-msgstr "Ба анҷом расид!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:461
-msgid "Calibration failed!"
-msgstr "Санҷиш қатъ шудааст!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:468
-msgid "You can remove the calibration device."
-msgstr "Шумо метавонед дастгоҳи санҷиширо тоза кунед."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:537
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Дастгоҳи санҷиширо дар ҳолати иҷро қатъ накунед"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Экрани лэптоп"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Вебкамераи дарунсохт"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Монитори %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Сканери %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Камераи %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Принтери %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Веб-камераи %s"
-
-#: panels/color/cc-color-device.c:91
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Фаъол кардани идоракунии рангҳо барои %s"
-
-#: panels/color/cc-color-device.c:94
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Намоиш додани профилҳои ранг барои %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:303
-msgid "Not calibrated"
-msgstr "Санҷиш нашудааст"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:170
-msgid "Default: "
-msgstr "Пешфарз:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:178
-msgid "Colorspace: "
-msgstr "Фазои рангин:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:185
-msgid "Test profile: "
-msgstr "Санҷиши профил:"
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:239
-msgid "Select ICC Profile File"
-msgstr "Интихоби файли профили ICC"
-
-#: panels/color/cc-color-panel.c:242
-msgid "_Import"
-msgstr "_Ворид кардан"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:253
-msgid "Supported ICC profiles"
-msgstr "Профилҳои дастгиришудаи ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:260
-#: panels/network/wireless-security/eap-method-fast.c:417
-msgid "All files"
-msgstr "Ҳамаи файлҳо"
-
-#: panels/color/cc-color-panel.c:555
-msgid "Screen"
-msgstr "Экран"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: panels/color/cc-color-panel.c:847
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "Боркунии файл қатъ шуд: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: panels/color/cc-color-panel.c:859
-msgid "The profile has been uploaded to:"
-msgstr "Профил ба макони зерин бор шудааст:"
-
-#: panels/color/cc-color-panel.c:861
-msgid "Write down this URL."
-msgstr "Ин суроғаи URL-ро нависед."
-
-#: panels/color/cc-color-panel.c:862
-msgid "Restart this computer and boot your normal operating system."
-msgstr ""
-"Бозоғозидани ин компютер ва роҳандозӣ кардани низоми амалиётии муқаррарии "
-"шумо"
-
-#: panels/color/cc-color-panel.c:863
-msgid "Type the URL into your browser to download and install the profile."
-msgstr ""
-"Суроғаи URL-ро ба браузери худ ворид кунед, то ин ки профилро боргирӣ ва "
-"насб кунед."
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:891
-msgid "Save Profile"
-msgstr "Захира кардани профил"
-
-#: panels/color/cc-color-panel.c:895
-#: panels/network/connection-editor/vpn-helpers.c:311
-msgid "_Save"
-msgstr "_Захира кардан"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1209
-msgid "Create a color profile for the selected device"
-msgstr "Эҷод кардани профили рангин барои дастгоҳи интихобшуда"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1224 panels/color/cc-color-panel.c:1248
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Абзори ченкунӣ ёфт нашуд. Лутфан, санҷед, ки он фаъол мебошад, ва ба таври "
-"дуруст пайваст шудаанд."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1258
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Абзори ченкунӣ профилҳои принтерро дастгирӣ намекунад."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1269
-msgid "The device type is not currently supported."
-msgstr "Намуди дастгоҳ дар айни ҳол дастгирӣ намешавад."
-
-#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:47
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "Санҷиши экран"
 
-#: panels/color/cc-color-panel.ui:23
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Сифати санҷиш"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -854,7 +446,7 @@ msgstr ""
 "рангҳои экран истифода баред. Чӣ қадар вақти санҷиширо сарф кунед, ҳамон "
 "қадар сифати профили ранг беҳтар мегардад."
 
-#: panels/color/cc-color-panel.ui:38
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr ""
@@ -862,36 +454,36 @@ msgstr ""
 "баред."
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:58
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "Сифат"
 
 #. This is the approximate time it takes to calibrate the display.
-#: panels/color/cc-color-panel.ui:75
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "Вақти тахминӣ"
 
-#: panels/color/cc-color-panel.ui:121
-msgid "Calibration Quality"
-msgstr "Сифати санҷиш"
-
-#: panels/color/cc-color-panel.ui:137
-msgid "Select the sensor device you want to use for calibration."
-msgstr "Интихоби дастгоҳи ламсӣ барои истифода дар санҷиш"
-
-#: panels/color/cc-color-panel.ui:174
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "Дастгоҳи санҷишӣ"
 
-#: panels/color/cc-color-panel.ui:189
-msgid "Select the type of display that is connected."
-msgstr "Интихоби намуди дисплейи пайвастшуда."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Интихоби дастгоҳи ламсӣ барои истифода дар санҷиш"
 
-#: panels/color/cc-color-panel.ui:226
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "Намуди дисплей"
 
-#: panels/color/cc-color-panel.ui:241
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Интихоби намуди дисплейи пайвастшуда."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Профили \"Whitepoint\""
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
@@ -899,11 +491,11 @@ msgstr ""
 "Нуқтаи ҳадафии сафеди дисплейро интихоб кунед. Қисми зиёди дисплейҳо бояд ба "
 "манбаи равшании D65 санҷида шаванд."
 
-#: panels/color/cc-color-panel.ui:278
-msgid "Profile Whitepoint"
-msgstr "Профили \"Whitepoint\""
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Равшании дисплей"
 
-#: panels/color/cc-color-panel.ui:293
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
@@ -911,7 +503,7 @@ msgstr ""
 "Лутфан, дисплейро ба равшание, ки ба шумо мувофиқ аст, таъин кунед. "
 "Идоракунии рангҳо дар ин сатҳи равшанӣ саҳеҳтарин мегардад."
 
-#: panels/color/cc-color-panel.ui:307
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
@@ -919,11 +511,11 @@ msgstr ""
 "Ба тарзи илова, шумо метавонед сатҳи дурахшониеро, ки бо яке аз профилҳои "
 "дигар барои ин дастгоҳ истифода мебаред, истифода баред."
 
-#: panels/color/cc-color-panel.ui:318
-msgid "Display Brightness"
-msgstr "Равшании дисплей"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Номи профил"
 
-#: panels/color/cc-color-panel.ui:333
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
@@ -931,323 +523,202 @@ msgstr ""
 "Шумо метавонед профили рангро дар компютерҳои гуногун истифода баред, ё ки "
 "ҳатто профилҳоро барои шароитҳои гуногуни равшанӣ эҷод кунед."
 
-#: panels/color/cc-color-panel.ui:348
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "Номи профил:"
 
-#: panels/color/cc-color-panel.ui:377
-msgid "Profile Name"
-msgstr "Номи профил"
-
-#: panels/color/cc-color-panel.ui:392
-msgid "Profile successfully created!"
-msgstr "Профил бо муваффақият эҷод шудааст!"
-
-#: panels/color/cc-color-panel.ui:443
-msgid "Copy profile"
-msgstr "Нусха бардоштани профил"
-
-#: panels/color/cc-color-panel.ui:456
-msgid "Requires writable media"
-msgstr "Медиаи сабтшаванда лозим аст"
-
-#: panels/color/cc-color-panel.ui:519
-msgid "Upload profile"
-msgstr "Бор кардани профил"
-
-#: panels/color/cc-color-panel.ui:532
-msgid "Requires Internet connection"
-msgstr "Пайвасти интернет лозим аст"
-
-#: panels/color/cc-color-panel.ui:591
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"Ин дастурҳои оиди тарзи истифодабарии ин профил дар низомҳои <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> ва <a href=\"windows"
-"\">Microsoft Windows</a> метавонанд ба шумо кумак кунанд."
-
-#: panels/color/cc-color-panel.ui:607
-#: panels/user-accounts/um-fingerprint-dialog.c:720
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "Хулоса"
 
-#: panels/color/cc-color-panel.ui:621
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Профил бо муваффақият эҷод шудааст!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Нусха бардоштани профил"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Медиаи сабтшаванда лозим аст"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Ин дастурҳои оиди тарзи истифодабарии ин профил дар низомҳои <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> ва <a "
+"href=\"windows\">Microsoft Windows</a> метавонанд ба шумо кумак кунанд."
+
+#: panels/color/cc-color-panel.ui:335
 #, fuzzy
-#| msgid "Add profile"
 msgid "Add Profile"
 msgstr "Илова кардани профил"
 
-#: panels/color/cc-color-panel.ui:643
-#, fuzzy
-#| msgid "Import File…"
-msgid "_Import File…"
-msgstr "Ворид кардани файл…"
-
-#: panels/color/cc-color-panel.ui:672
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:80
-#: panels/region/cc-input-chooser.ui:20
-#: panels/user-accounts/cc-add-user-dialog.ui:47
-msgid "_Add"
-msgstr "_Илова кардан"
-
-#: panels/color/cc-color-panel.ui:732
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Мушкилӣ ба вуҷуд омад. Эҳтимол аст, ки профил дуруст кор намекунад. <a href="
-"\"\">Намоиш додани тафсилот.</a>"
+"Мушкилӣ ба вуҷуд омад. Эҳтимол аст, ки профил дуруст кор намекунад. <a "
+"href=\"\">Намоиш додани тафсилот.</a>"
 
-#: panels/color/cc-color-panel.ui:790
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "Ворид кардани файл…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Илова кардан"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Ҳар як дастгоҳ барои идоракунии ранг бояд дорои профили ранги навшуда бошад."
 
-#: panels/color/cc-color-panel.ui:812
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "Маълумоти муфассал"
 
-#: panels/color/cc-color-panel.ui:817
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "Маълумоти бештар дар бораи идоракунии рангҳо"
 
-#: panels/color/cc-color-panel.ui:865
+#: panels/color/cc-color-panel.ui:473
 #, fuzzy
-#| msgid "Set for all users"
 msgid "_Set for all users"
 msgstr "Таъин кардан ба ҳамаи корбарон"
 
-#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
-#: panels/color/cc-color-panel.ui:885
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "Таъин кардани ин профил ба ҳамаи корбарони ин компютер"
 
-#: panels/color/cc-color-panel.ui:880
+#: panels/color/cc-color-panel.ui:481
 #, fuzzy
-#| msgid "Enable"
 msgid "_Enable"
 msgstr "Фаъол кардан"
 
-#: panels/color/cc-color-panel.ui:911
+#: panels/color/cc-color-panel.ui:497
 #, fuzzy
-#| msgid "Add profile"
 msgid "_Add profile"
 msgstr "Илова кардани профил"
 
-#: panels/color/cc-color-panel.ui:924
-#| msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "_Андозагароӣ…"
 
-#: panels/color/cc-color-panel.ui:928
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "Санҷиши дастгоҳ"
 
-#: panels/color/cc-color-panel.ui:939
+#: panels/color/cc-color-panel.ui:511
 #, fuzzy
-#| msgid "Remove profile"
 msgid "_Remove profile"
 msgstr "Тоза кардани профил"
 
-#: panels/color/cc-color-panel.ui:952
+#: panels/color/cc-color-panel.ui:517
 #, fuzzy
-#| msgid "View details"
 msgid "_View details"
 msgstr "Тафсилотро намоиш додан"
 
-#: panels/color/cc-color-panel.ui:988
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "Ягон дастгоҳи қобили идоракунии рангҳо ташхис нашуд"
 
-#: panels/color/cc-color-panel.ui:1032
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: panels/color/cc-color-panel.ui:1037
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: panels/color/cc-color-panel.ui:1042
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: panels/color/cc-color-panel.ui:1047
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "Проектор"
 
-#: panels/color/cc-color-panel.ui:1052
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "Плазма"
 
-#: panels/color/cc-color-panel.ui:1057
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (равшансозии CCFL)"
 
-#: panels/color/cc-color-panel.ui:1062
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (равшансозии RGB LED)"
 
-#: panels/color/cc-color-panel.ui:1067
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (равшансозии LED-и сафед)"
 
-#: panels/color/cc-color-panel.ui:1072
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "Гаммаи васеъи LCD (равшансозии CCFL)"
 
-#: panels/color/cc-color-panel.ui:1077
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "Гаммаи васеъи LCD (равшансозии RGB LED)"
 
-#: panels/color/cc-color-panel.ui:1094
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "Баланд"
 
-#: panels/color/cc-color-panel.ui:1095
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 дақиқа"
 
-#: panels/color/cc-color-panel.ui:1099
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "Миёна"
 
-#: panels/color/cc-color-panel.ui:1100
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 дақиқа"
 
-#: panels/color/cc-color-panel.ui:1104
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "Паст"
 
-#: panels/color/cc-color-panel.ui:1105
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 дақиқа"
 
-#: panels/color/cc-color-panel.ui:1127
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "Аслӣ барои дисплей"
 
-#: panels/color/cc-color-panel.ui:1131
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (Чопкунӣ ва нашркунӣ)"
 
-#: panels/color/cc-color-panel.ui:1135
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: panels/color/cc-color-panel.ui:1139
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (Суратҳо ва графикаҳо)"
 
-#: panels/color/cc-color-panel.ui:1143
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:100
-msgid "Standard Space"
-msgstr "Фазои стандартӣ"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:106
-msgid "Test Profile"
-msgstr "Санҷиши профил"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:114
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Худкор"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:124
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Сифати паст"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:129
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Сифати миёна"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:136
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Сифати баланд"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:153
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB-и пешфарз"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:160
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK-и пешфарз"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:167
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Хокистариранги пешфарз"
-
-#: panels/color/cc-color-profile.c:190
-msgid "Vendor supplied factory calibration data"
-msgstr "Иттилооти санҷиши заводии бо фурӯшанда таъминшуда"
-
-#: panels/color/cc-color-profile.c:199
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Ислоҳкунии экрани пурраи дисплей бо ин профил имконнопазир аст"
-
-#: panels/color/cc-color-profile.c:221
-msgid "This profile may no longer be accurate"
-msgstr "Эҳтимол аст, ки ин профил дигар саҳеҳ намебошад"
-
-#: panels/color/color-calibrate.ui:7
-msgid "Display Calibration"
-msgstr "Санҷиши дисплей"
-
-#. This starts the calibration process
-#: panels/color/color-calibrate.ui:40
-#, fuzzy
-#| msgid "Start"
-msgid "_Start"
-msgstr "Оғоз кардан"
-
-#. This resumes the calibration process
-#: panels/color/color-calibrate.ui:54
-#, fuzzy
-#| msgid "Resume"
-msgid "_Resume"
-msgstr "Давом додан"
-
-#. This button returns the user back to the color control panel
-#: panels/color/color-calibrate.ui:67 panels/region/cc-format-chooser.ui:13
-msgid "_Done"
-msgstr "_Тайёр"
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1258,245 +729,202 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Санҷиши ранги дастгоҳҳо, монанди дисплейҳо, камераҳо ё принтерҳо"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Ранг;ICC;Профил;Танзими андоза;Принтер;Дисплей;"
 
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Дигар…"
-
-#: panels/common/cc-language-chooser.c:125
-#: panels/region/cc-format-chooser.c:268 panels/region/cc-input-chooser.c:178
-msgid "More…"
-msgstr "Бештар…"
-
-#: panels/common/cc-language-chooser.c:142
-msgid "No languages found"
-msgstr "Ягон забон ёфт нашудааст"
-
 #: panels/common/cc-language-chooser.ui:5
 #, fuzzy
-#| msgid "Language"
 msgid "Select Language"
 msgstr "Забон"
 
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:106
-msgid "Today"
-msgstr "Имрӯз"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "Yesterday"
-msgstr "Дирӯз"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
+#: panels/common/cc-language-chooser.ui:13
 #, fuzzy
-#| msgid "_Stop Hotspot"
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "_Қатъ кардани \"ХОТ-СПОТ\""
+msgid "_Select"
+msgstr "Интихоб кардан"
 
-#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
-#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
-msgid "Day"
-msgstr "Рӯз"
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Ягон забон ёфт нашудааст"
 
-#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
-#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
-msgid "Month"
-msgstr "Моҳ"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "Бештар…"
 
-#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
-#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
-msgid "Year"
-msgstr "Сол"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:332
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:337
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:502
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:529
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Вақт"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:536
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:541
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:546
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:551
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: panels/datetime/cc-datetime-panel.ui:26
-msgid "January"
-msgstr "Январ"
-
-#: panels/datetime/cc-datetime-panel.ui:29
-msgid "February"
-msgstr "Феврал"
-
-#: panels/datetime/cc-datetime-panel.ui:32
-msgid "March"
-msgstr "Март"
-
-#: panels/datetime/cc-datetime-panel.ui:35
-msgid "April"
-msgstr "Апрел"
-
-#: panels/datetime/cc-datetime-panel.ui:38
-msgid "May"
-msgstr "Май"
-
-#: panels/datetime/cc-datetime-panel.ui:41
-msgid "June"
-msgstr "Июн"
-
-#: panels/datetime/cc-datetime-panel.ui:44
-msgid "July"
-msgstr "Июл"
-
-#: panels/datetime/cc-datetime-panel.ui:47
-msgid "August"
-msgstr "Август"
-
-#: panels/datetime/cc-datetime-panel.ui:50
-msgid "September"
-msgstr "Сентябр"
-
-#: panels/datetime/cc-datetime-panel.ui:53
-msgid "October"
-msgstr "Октябр"
-
-#: panels/datetime/cc-datetime-panel.ui:56
-msgid "November"
-msgstr "Ноябр"
-
-#: panels/datetime/cc-datetime-panel.ui:59
-msgid "December"
-msgstr "Декабр"
-
-#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "Сана ва Вақт"
 
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Сол"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Моҳ"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Январ"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Феврал"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Март"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Апрел"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Май"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Июн"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Июл"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Август"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Сентябр"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Октябр"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Ноябр"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Декабр"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Рӯз"
+
 #: panels/datetime/cc-datetime-panel.ui:113
-#: panels/display/cc-night-light-dialog.ui:245
-#: panels/display/cc-night-light-dialog.ui:352
-msgid "Hour"
-msgstr "Соат"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: panels/datetime/cc-datetime-panel.ui:128
-msgid "∶"
-msgstr "∶"
-
-#: panels/datetime/cc-datetime-panel.ui:152
-#: panels/display/cc-night-light-dialog.ui:273
-#: panels/display/cc-night-light-dialog.ui:380
-msgid "Minute"
-msgstr "Дақиқа"
-
-#: panels/datetime/cc-datetime-panel.ui:219
 msgid "Time Zone"
 msgstr "Минтақаи вақт"
 
-#: panels/datetime/cc-datetime-panel.ui:240
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "Ҷустуҷӯи шаҳр"
 
-#: panels/datetime/cc-datetime-panel.ui:313
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "_Сана ва вақти худкор"
 
-#: panels/datetime/cc-datetime-panel.ui:314
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "Дастрасии интернет лозим аст"
 
-#: panels/datetime/cc-datetime-panel.ui:334
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "Сана ва _вақт"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "_Минтақаи вақти худкор"
 
-#: panels/datetime/cc-datetime-panel.ui:335
+#: panels/datetime/cc-datetime-panel.ui:205
 #, fuzzy
-#| msgid "Requires internet access"
 msgid "Requires location services enabled and internet access"
 msgstr "Дастрасии интернет лозим аст"
 
-#: panels/datetime/cc-datetime-panel.ui:350
-msgid "Date & _Time"
-msgstr "Сана ва _вақт"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Фаъол"
 
-#: panels/datetime/cc-datetime-panel.ui:366
+#: panels/datetime/cc-datetime-panel.ui:220
 #, fuzzy
-#| msgid "Time Zone"
 msgid "Time Z_one"
 msgstr "Минтақаи вақт"
 
-#: panels/datetime/cc-datetime-panel.ui:405
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Самти ҳаракати соат"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Формати _вақт"
 
-#: panels/datetime/cc-datetime-panel.ui:414
-msgid "24-hour"
-msgstr "24-соат"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: panels/datetime/cc-datetime-panel.ui:415
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Санаҳо"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "30 сония"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Тақвим"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Рақамҳо"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Тағйир додани вақт ва сана, аз ҷумла минтақаи вақт"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Соат;Минтақаи вақт;Ҷойгиршавӣ;"
@@ -1509,243 +937,235 @@ msgstr "Тағйир додани танзимоти вақт ва санаи н
 msgid "To change time or date settings, you need to authenticate."
 msgstr "Барои тағйир додани танзимоти вақт ё сана, шумо бояд ворид шавед."
 
-#: panels/display/cc-display-panel.c:927
-#: panels/network/connection-editor/connection-editor.ui:27
-#: panels/network/network-wifi.ui:38
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Веб"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Почта"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Тақвим"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Мусиқӣ"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Видео"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Суратҳо"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Барномаҳои пешфарз"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Барномаҳои пешфарз"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Гузориш дар бораи мушкилиҳо"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Гузоришдиҳии худкор оид ба мушкилиҳо"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "_Татбиқ кардан"
 
-#: panels/display/cc-display-panel.c:948
-msgid "Apply Changes?"
-msgstr ""
-
-#: panels/display/cc-display-panel.c:953
-msgid "Changes Cannot be Applied"
-msgstr ""
-
-#: panels/display/cc-display-panel.c:954
-msgid "This could be due to hardware limitations."
-msgstr ""
-
-#. TRANSLATORS: the state of the night light setting
-#: panels/display/cc-display-panel.c:1127
-#: panels/notifications/cc-notifications-panel.c:270
-#: panels/power/cc-power-panel.c:2056 panels/power/cc-power-panel.c:2063
-#: panels/privacy/cc-privacy-panel.c:212 panels/privacy/cc-privacy-panel.c:289
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:841
-#: panels/universal-access/cc-ua-panel.c:854
-#: panels/universal-access/cc-ua-panel.c:866
-#: panels/universal-access/cc-ua-panel.c:1031
-msgid "On"
-msgstr "Фаъол"
-
-#: panels/display/cc-display-panel.c:1127 panels/network/net-proxy.c:54
-#: panels/notifications/cc-notifications-panel.c:270
-#: panels/power/cc-power-panel.c:2050 panels/power/cc-power-panel.c:2061
-#: panels/privacy/cc-privacy-panel.c:212 panels/privacy/cc-privacy-panel.c:289
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:841
-#: panels/universal-access/cc-ua-panel.c:854
-#: panels/universal-access/cc-ua-panel.c:866
-#: panels/universal-access/cc-ua-panel.c:1031
-#: panels/universal-access/cc-ua-panel.ui:338
-#: panels/universal-access/cc-ua-panel.ui:384
-#: panels/universal-access/cc-ua-panel.ui:430
-#: panels/universal-access/cc-ua-panel.ui:536
-#: panels/universal-access/cc-ua-panel.ui:689
-#: panels/universal-access/cc-ua-panel.ui:735
-#: panels/universal-access/cc-ua-panel.ui:781
-#: panels/universal-access/cc-ua-panel.ui:933
-msgid "Off"
-msgstr "Хомӯш"
-
-#: panels/display/cc-display-panel.ui:81
-#, fuzzy
-#| msgid "Secondary Display"
-msgid "Single Display"
-msgstr "Дисплейи дуюм"
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Бозгашт"
 
 #: panels/display/cc-display-panel.ui:100
-#: panels/display/cc-display-panel.ui:305
 #, fuzzy
-#| msgid "Displays"
-msgid "Join Displays"
-msgstr "Дисплейҳо"
+msgid "Display Settings Disabled"
+msgstr "Bluetooth ғайрифаъол аст"
 
-#: panels/display/cc-display-panel.ui:118
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "Дисплейи дуюм"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Оина"
 
-#: panels/display/cc-display-panel.ui:143
-#, fuzzy
-#| msgid "Display Type"
-msgid "Display Mode"
-msgstr "Намуди дисплей"
-
-#: panels/display/cc-display-panel.ui:235
-msgid ""
-"Drag displays to match your physical display setup. Select a display to "
-"change its settings."
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
 msgstr ""
 
-#: panels/display/cc-display-panel.ui:242
+#: panels/display/cc-display-panel.ui:156
 #, fuzzy
-#| msgid "Display Mapping"
-msgid "Display Arrangement"
-msgstr "Нақшабандии дисплей"
-
-#: panels/display/cc-display-panel.ui:424
-#, fuzzy
-#| msgid "Display Calibration"
-msgid "Display Configuration"
-msgstr "Санҷиши дисплей"
+msgid "Primary Display"
+msgstr "Дисплейҳо"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:451
-#: panels/display/cc-display-panel.ui:469
-#: panels/display/cc-night-light-dialog.ui:505
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 #, fuzzy
-#| msgid "Right Ring"
 msgid "Night Light"
 msgstr "Ҳалқаи рост"
 
-#: panels/display/cc-display-settings.c:108
+#: panels/display/cc-display-settings.ui:43
 #, fuzzy
-#| msgid "Landscape"
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Уфуқӣ"
-
-#: panels/display/cc-display-settings.c:111
-#, fuzzy
-#| msgid "Portrait"
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Амудӣ"
-
-#: panels/display/cc-display-settings.c:114
-#, fuzzy
-#| msgid "Portrait"
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Амудӣ"
-
-#: panels/display/cc-display-settings.c:117
-#, fuzzy
-#| msgid "Landscape"
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Уфуқӣ"
-
-#: panels/display/cc-display-settings.c:191
-#, c-format
-msgid "%.2lf Hz"
-msgstr ""
-
-#: panels/display/cc-display-settings.ui:15
-#, fuzzy
-#| msgid "Orientation"
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Самт"
 
-#: panels/display/cc-display-settings.ui:24
+#: panels/display/cc-display-settings.ui:50
 #, fuzzy
-#| msgid "Resolution"
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Возеҳӣ"
 
-#: panels/display/cc-display-settings.ui:33
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Суръати навсозӣ"
 
-#: panels/display/cc-display-settings.ui:42
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr ""
 
-#: panels/display/cc-display-settings.ui:59
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 #, fuzzy
-#| msgctxt "background, style"
-#| msgid "Scale"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Миқиёсбандӣ"
 
-#: panels/display/cc-night-light-dialog.c:647
-msgid "More Warm"
-msgstr ""
-
-#: panels/display/cc-night-light-dialog.c:659
-msgid "Less Warm"
-msgstr ""
-
-#. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-dialog.ui:46
+#: panels/display/cc-display-settings.ui:101
 #, fuzzy
-#| msgid "Restart Now"
-msgid "Restart Filter"
-msgstr "Ҳозир бозоғозӣ кардан"
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "_Ҳаракаткунии одатӣ"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Ҳалқаи рост"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
 
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-dialog.ui:79
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr ""
 
-#: panels/display/cc-night-light-dialog.ui:106
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Ҳозир бозоғозӣ кардан"
+
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
 msgstr ""
 
-#: panels/display/cc-night-light-dialog.ui:127
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr ""
 
-#: panels/display/cc-night-light-dialog.ui:148
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr ""
 
-#: panels/display/cc-night-light-dialog.ui:164
-#: panels/network/connection-editor/ip4-page.ui:69
-#: panels/network/connection-editor/ip6-page.ui:83
-#: panels/network/net-proxy.c:56 panels/network/network-proxy.ui:113
-#: panels/network/network-wifi.ui:776 panels/network/network-wifi.ui:1053
-#: panels/privacy/cc-privacy-panel.c:239
-msgid "Manual"
-msgstr "Дастӣ"
-
-#: panels/display/cc-night-light-dialog.ui:180
-msgid "_Off"
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
 msgstr ""
 
-#: panels/display/cc-night-light-dialog.ui:216
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Вақтҳо"
+
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr ""
 
-#: panels/display/cc-night-light-dialog.ui:254
-#: panels/display/cc-night-light-dialog.ui:361
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Соат"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Дақиқа"
+
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-dialog.ui:284
-#: panels/display/cc-night-light-dialog.ui:391
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr ""
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-dialog.ui:300
-#: panels/display/cc-night-light-dialog.ui:407
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr ""
 
-#: panels/display/cc-night-light-dialog.ui:449
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr ""
 
-#: panels/display/cc-night-light-dialog.ui:470
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr ""
 
@@ -1757,308 +1177,168 @@ msgstr "Дисплейҳо"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Интихоб кардани тарзи истифодаи мониторҳо ва проекторҳои пайвастшуда"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 #, fuzzy
-#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;"
 msgstr "Панел;Проектор;xrandr;Экран;Возеҳӣ;Навсозӣ;Монитор;"
 
-#: panels/info/cc-info-default-apps-panel.ui:31
-msgid "_Web"
-msgstr "_Веб"
-
-#: panels/info/cc-info-default-apps-panel.ui:43
-msgid "_Mail"
-msgstr "_Почта"
-
-#: panels/info/cc-info-default-apps-panel.ui:59
-msgid "_Calendar"
-msgstr "_Тақвим"
-
-#: panels/info/cc-info-default-apps-panel.ui:75
-msgid "M_usic"
-msgstr "_Мусиқӣ"
-
-#: panels/info/cc-info-default-apps-panel.ui:91
-msgid "_Video"
-msgstr "_Видео"
-
-#: panels/info/cc-info-default-apps-panel.ui:162
-#: panels/info/cc-info-removable-media-panel.ui:161
-msgid "_Photos"
-msgstr "_Суратҳо"
-
-#. TRANSLATORS: AP type
-#: panels/info/cc-info-overview-panel.c:369
-#: panels/info/cc-info-overview-panel.c:452
-#: panels/info/cc-info-overview-panel.c:497
-#: panels/info/cc-info-overview-panel.c:527 panels/network/panel-common.c:123
-msgid "Unknown"
-msgstr "Номаълум"
-
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info/cc-info-overview-panel.c:460
-#, c-format
-msgid "%s; Build ID: %s"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
 msgstr ""
 
-#. translators: This is the type of architecture for the OS
-#: panels/info/cc-info-overview-panel.c:477
-#, fuzzy, c-format
-#| msgid "%d-bit"
-msgid "64-bit"
-msgstr "%d-бит"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Калиди амният"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info/cc-info-overview-panel.c:480
-#, fuzzy, c-format
-#| msgid "%d-bit"
-msgid "32-bit"
-msgstr "%d-бит"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Сатҳи ранг"
 
-#: panels/info/cc-info-overview-panel.c:710
-#, c-format
-msgid "Version %s"
-msgstr "Версияи %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Сатҳи ранг"
 
-#: panels/info/cc-info-overview-panel.ui:70
-msgid "Device name"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Сатҳи ранг"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "Амният"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"экран;қулф;ташхис;вайронӣ;махфӣ;қаблӣ;муваққатӣ;tmp;индекс;ном;шабака;"
+"шахсият;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
 msgstr "Номи дастгоҳ"
 
-#: panels/info/cc-info-overview-panel.ui:86
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "Суроғаи сахтафзор"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
 msgid "Memory"
 msgstr "Ҳофиза"
 
-#: panels/info/cc-info-overview-panel.ui:102
+#: panels/info-overview/cc-info-overview-panel.ui:66
 msgid "Processor"
 msgstr "Просессор"
 
-#: panels/info/cc-info-overview-panel.ui:118
+#: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
 msgstr "Графика"
 
-#. To translators: this field contains the distro name and version
-#: panels/info/cc-info-overview-panel.ui:133
-msgid "OS name"
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
 msgstr ""
 
-#. To translators: this field contains the distro type
-#: panels/info/cc-info-overview-panel.ui:149
-#, fuzzy
-#| msgid "Security type"
-msgid "OS type"
-msgstr "Навъи амният"
-
-#: panels/info/cc-info-overview-panel.ui:165
-msgid "Virtualization"
-msgstr "Виртуализатсия"
-
-#: panels/info/cc-info-overview-panel.ui:181
-msgid "Disk"
-msgstr "Диск"
-
-#: panels/info/cc-info-overview-panel.ui:293
+#: panels/info-overview/cc-info-overview-panel.ui:83
 msgid "Calculating…"
 msgstr "Ҳисоб шуда истодааст…"
 
-#: panels/info/cc-info-overview-panel.ui:333
-msgid "Check for updates"
-msgstr "Санҷиши навсозиҳо"
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Ном"
 
-#: panels/info/cc-info-removable-media-panel.c:296
-msgid "Ask what to do"
-msgstr "Чӣ бояд кард"
-
-#: panels/info/cc-info-removable-media-panel.c:300
-msgid "Do nothing"
-msgstr "Амалиёт лозим нест"
-
-#: panels/info/cc-info-removable-media-panel.c:304
-msgid "Open folder"
-msgstr "Кушодани ҷузвдон"
-
-#: panels/info/cc-info-removable-media-panel.c:389
-msgid "Other Media"
-msgstr "Мултимедиаи дигар"
-
-#: panels/info/cc-info-removable-media-panel.c:422
-msgid "Select an application for audio CDs"
-msgstr "Интихоби барнома барои аудио дар дискҳои CD"
-
-#: panels/info/cc-info-removable-media-panel.c:423
-msgid "Select an application for video DVDs"
-msgstr "Интихоби барнома барои видео дар дискҳои DVD"
-
-#: panels/info/cc-info-removable-media-panel.c:424
-msgid "Select an application to run when a music player is connected"
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
 msgstr ""
-"Барномаеро барои иҷро шудан ҳангоми пайваст шудани плеери мусиқӣ интихоб "
-"кунед"
 
-#: panels/info/cc-info-removable-media-panel.c:425
-msgid "Select an application to run when a camera is connected"
-msgstr ""
-"Барномаеро барои иҷро шудан ҳангоми пайваст шудани камера интихоб кунед"
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Навъ"
 
-#: panels/info/cc-info-removable-media-panel.c:426
-msgid "Select an application for software CDs"
-msgstr "Интихоби барнома барои нармафзор дан дискҳои CD"
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "- Танзимот"
 
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/info/cc-info-removable-media-panel.c:438
-msgid "audio DVD"
-msgstr "Диски аудиои DVD"
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Боркунии имконот..."
 
-#: panels/info/cc-info-removable-media-panel.c:439
-msgid "blank Blu-ray disc"
-msgstr "диски холии Blu-ray"
-
-#: panels/info/cc-info-removable-media-panel.c:440
-msgid "blank CD disc"
-msgstr "диски холии CD"
-
-#: panels/info/cc-info-removable-media-panel.c:441
-msgid "blank DVD disc"
-msgstr "диски холии DVD"
-
-#: panels/info/cc-info-removable-media-panel.c:442
-msgid "blank HD DVD disc"
-msgstr "диски холии HD DVD"
-
-#: panels/info/cc-info-removable-media-panel.c:443
-msgid "Blu-ray video disc"
-msgstr "Диски видеои Blu-ray"
-
-#: panels/info/cc-info-removable-media-panel.c:444
-msgid "e-book reader"
-msgstr "хонандаи китобхои электронӣ"
-
-#: panels/info/cc-info-removable-media-panel.c:445
-msgid "HD DVD video disc"
-msgstr "Диски видеои HD DVD"
-
-#: panels/info/cc-info-removable-media-panel.c:446
-msgid "Picture CD"
-msgstr "Суратҳо дар CD"
-
-#: panels/info/cc-info-removable-media-panel.c:447
-msgid "Super Video CD"
-msgstr "Супервидеои CD"
-
-#: panels/info/cc-info-removable-media-panel.c:448
-msgid "Video CD"
-msgstr "Видеои CD"
-
-#: panels/info/cc-info-removable-media-panel.c:449
-msgid "Windows software"
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
 msgstr "Нармафзори Windows"
 
-#: panels/info/cc-info-removable-media-panel.ui:43
-msgid "Select how media should be handled"
-msgstr "Интихоби тарзи истифодаи медиа"
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Виртуализатсия"
 
-#: panels/info/cc-info-removable-media-panel.ui:74
-msgid "CD _audio"
-msgstr "Аудиои _CD"
-
-#: panels/info/cc-info-removable-media-panel.ui:91
-msgid "_DVD video"
-msgstr "Видеои _DVD"
-
-#: panels/info/cc-info-removable-media-panel.ui:132
-msgid "_Music player"
-msgstr "_Плеери мусиқӣ"
-
-#: panels/info/cc-info-removable-media-panel.ui:190
-msgid "_Software"
-msgstr "_Нармафзор"
-
-#: panels/info/cc-info-removable-media-panel.ui:228
-msgid "_Other Media…"
-msgstr "_Мултимедиаи дигар…"
-
-#: panels/info/cc-info-removable-media-panel.ui:272
-msgid "_Never prompt or start programs on media insertion"
-msgstr ""
-"_Ҳеҷ гоҳ огоҳ надодан ва оғоз накардани барномаҳо ҳангоми дарҷкунии медиа"
-
-#: panels/info/cc-info-removable-media-panel.ui:331
-msgid "Select how other media should be handled"
-msgstr "Интихоби тарзи истифодаи медиаи дигар"
-
-#: panels/info/cc-info-removable-media-panel.ui:370
-msgid "_Action:"
-msgstr "_Амал:"
-
-#: panels/info/cc-info-removable-media-panel.ui:393
-msgid "_Type:"
-msgstr "_Навъ:"
-
-#: panels/info/gnome-default-apps-panel.desktop.in.in:3
-msgid "Default Applications"
-msgstr "Барномаҳои пешфарз"
-
-#: panels/info/gnome-default-apps-panel.desktop.in.in:4
+#: panels/info-overview/cc-info-overview-panel.ui:150
 #, fuzzy
-#| msgid "Default Applications"
-msgid "Configure Default Applications"
-msgstr "Барномаҳои пешфарз"
+msgid "Software Updates"
+msgstr "Истифодаи нармафзор"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/info/gnome-default-apps-panel.desktop.in.in:19
-msgid "default;application;preferred;media;"
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Илова кардани дастгоҳ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
 msgstr ""
 
-#: panels/info/gnome-info-overview-panel.desktop.in.in:3
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Номи дастгоҳ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "_Номи корбар"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
 msgid "About"
 msgstr ""
 
-#: panels/info/gnome-info-overview-panel.desktop.in.in:4
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr "Намоиш додани иттилоот дар бораи низом"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
-#: panels/info/gnome-info-overview-panel.desktop.in.in:23
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr ""
-"дастгоҳ;низом;иттилоот;ҳофиза;просессор;версия;пешфарз;барнома;пазируфта;cd;"
-"dvd;usb;аудио;видео;диск;ҷқдошаванда;медиа;иҷрои худкор;"
-
-#: panels/info/gnome-removable-media-panel.desktop.in.in:3
-msgid "Removable Media"
-msgstr "Медиаи ҷудошаванда"
-
-#: panels/info/gnome-removable-media-panel.desktop.in.in:4
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 #, fuzzy
-#| msgid "Removable Media"
-msgid "Configure Removable Media settings"
-msgstr "Медиаи ҷудошаванда"
-
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/info/gnome-removable-media-panel.desktop.in.in:19
-#, fuzzy
-#| msgid ""
-#| "device;system;information;memory;processor;version;default;application;"
-#| "preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgid ""
-"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
-"removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "дастгоҳ;низом;иттилоот;ҳофиза;просессор;версия;пешфарз;барнома;пазируфта;cd;"
 "dvd;usb;аудио;видео;диск;ҷқдошаванда;медиа;иҷрои худкор;"
@@ -2068,7 +1348,8 @@ msgid "Sound and Media"
 msgstr "Садо ва мултимедиа"
 
 #: panels/keyboard/00-multimedia.xml.in:4
-msgid "Volume mute"
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "Бесадо кардан"
 
 #: panels/keyboard/00-multimedia.xml.in:6
@@ -2080,35 +1361,39 @@ msgid "Volume up"
 msgstr "Баланд кардан"
 
 #: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "Оғоз кардани плеери мултимедиа"
 
-#: panels/keyboard/00-multimedia.xml.in:12
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "Пахш кардан (ё пахш/таваққуф)"
 
-#: panels/keyboard/00-multimedia.xml.in:14
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "Таваққуф кардани иҷро"
 
-#: panels/keyboard/00-multimedia.xml.in:16
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "Қатъ кардани иҷро"
 
-#: panels/keyboard/00-multimedia.xml.in:18
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "Пайгирии қаблӣ"
 
-#: panels/keyboard/00-multimedia.xml.in:20
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "Пайгирии навбатӣ"
 
-#: panels/keyboard/00-multimedia.xml.in:22
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "Баровардан"
 
 #: panels/keyboard/01-input-sources.xml.in:4
-#: panels/universal-access/cc-ua-panel.ui:580
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "Вуруд"
 
@@ -2128,6 +1413,12 @@ msgstr "Оғозкунандагон"
 msgid "Launch help browser"
 msgstr "Оғоз кардани кумаки браузер"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Танзимот"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Оғоз кардани калкулятор"
@@ -2144,39 +1435,12 @@ msgstr "Оғоз кардани браузери веб"
 msgid "Home folder"
 msgstr "Ҷузвдони асосӣ"
 
-#: panels/keyboard/01-screenshot.xml.in:2
-msgid "Screenshots"
-msgstr "Суратҳои экран"
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Ҷустуҷӯ"
 
-#: panels/keyboard/01-screenshot.xml.in:6
-msgid "Save a screenshot to $PICTURES"
-msgstr "Захира кардани сурати экран ба $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:10
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "Захира кардани сурати равзана ба $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:14
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "Захира кардани сурати ноҳия ба $PICTURES"
-
-#: panels/keyboard/01-screenshot.xml.in:17
-msgid "Copy a screenshot to clipboard"
-msgstr "Нусха бардоштани сурати экран ба ҳофизаи муваққатӣ"
-
-#: panels/keyboard/01-screenshot.xml.in:20
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "Нусха бардоштани сурати равзана ба ҳофизаи муваққатӣ"
-
-#: panels/keyboard/01-screenshot.xml.in:23
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "Нусха бардоштани сурати ноҳия ба ҳофизаи муваққатӣ"
-
-#: panels/keyboard/01-screenshot.xml.in:26
-msgid "Record a short screencast"
-msgstr "Сабт кардани видеои экрании кӯтоҳ"
-
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Система"
 
@@ -2190,8 +1454,9 @@ msgstr "Экрани қулф"
 
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
-msgid "Universal Access"
-msgstr "Дастрасии умумӣ"
+#, fuzzy
+msgid "Accessibility"
+msgstr "Қобилияти намоиш"
 
 #: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
@@ -2225,180 +1490,435 @@ msgstr "Хурд кардани андозаи матн"
 msgid "High contrast on or off"
 msgstr "Фаъол ё хомӯш кардани контрасти баланд"
 
-#: panels/keyboard/cc-keyboard-manager.c:501
-#: panels/keyboard/cc-keyboard-manager.c:509
-#: panels/keyboard/cc-keyboard-manager.c:809
-msgid "Custom Shortcuts"
-msgstr "Миёнбурҳои шахсӣ"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Илова кардани манбаи вуруд"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: panels/keyboard/cc-keyboard-option.c:337
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "Усулҳои вуруд наметавонанд дар экрани воридшавӣ истифода шаванд"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Ягон манбаи вуруд интихоб нашудааст"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Имконот"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Ба боло"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Ба поён"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Хусусиятҳо"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Миёнбурҳои клавиатура"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Тоза кардан"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Манбаҳои вуруд"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "Имконоти манбаи вуруд"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Истифода бурдани манбаи _якхела барои ҳамаи равзанаҳо"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "Иҷозат додани _манбаҳои гуногун барои ҳар як равзана"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "Тугмаҳои аломатдори иловагӣ"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: panels/keyboard/cc-keyboard-option.c:346
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "Тугмаи эҷодкунӣ"
 
-#: panels/keyboard/cc-keyboard-option.c:351
-msgid "Modifiers-only switch to next source"
-msgstr "Табдилдиҳандагон-танҳо гузариш ба манбаи навбатӣ"
-
-#: panels/keyboard/cc-keyboard-panel.c:179
-msgid "Reset All Shortcuts?"
-msgstr "Ҳамаи миёнбурҳоро тоза мекунед?"
-
-#: panels/keyboard/cc-keyboard-panel.c:182
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.c:186
-#: panels/keyboard/shortcut-editor.ui:346
-#: panels/printers/authentication-dialog.ui:29
-#: panels/printers/ppd-selection-dialog.ui:27
-msgid "Cancel"
-msgstr "Бекор кардан"
-
-#: panels/keyboard/cc-keyboard-panel.c:187
-#, fuzzy
-#| msgid "Reset"
-msgid "Reset All"
-msgstr "Бозсозӣ"
-
-#: panels/keyboard/cc-keyboard-panel.c:283
-msgid "Reset the shortcut to its default value"
-msgstr ""
-
-#: panels/keyboard/cc-keyboard-panel.ui:67 panels/region/cc-region-panel.ui:395
-#: shell/cc-window.ui:334
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Миёнбурҳои клавиатура"
 
-#: panels/keyboard/cc-keyboard-panel.ui:77
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "Миёнбурҳои шахсӣ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:78
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
 msgid "Reset all shortcuts to their default keybindings"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-panel.ui:164
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Қисмат"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
+msgid "Shortcuts"
+msgstr "Миёнбурҳо"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Илова кардани миёнбур"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "Миёнбури шахсӣ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Илова кардани миёнбур"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
 msgid "No keyboard shortcut found"
 msgstr "Миёнбурҳои клавиатура"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:411
-#, c-format
-msgid ""
-"%s is already being used for <b>%s</b>. If you replace it, %s will be "
-"disabled"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+#, fuzzy
+msgid "_Remove"
+msgstr "_Тоза кардан"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "Ҷойгузин _кардан"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
-#, fuzzy
-#| msgid "Custom Shortcut"
-msgid "Set Custom Shortcut"
-msgstr "Миёнбури шахсӣ"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Ном"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Фармон"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 #, fuzzy
-#| msgid "Shortcuts"
-msgid "Set Shortcut"
+msgid "Shortcut"
 msgstr "Миёнбурҳо"
 
-#. Setup the top label
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:590
-#, c-format
-msgid "Enter new shortcut to change <b>%s</b>."
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Танзими миёнбур…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Ҳеҷ"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
 msgstr ""
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:1017
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
 #, fuzzy
-#| msgid "Custom Shortcut"
-msgid "Add Custom Shortcut"
-msgstr "Миёнбури шахсӣ"
+msgid "Use layout default"
+msgstr "Принтери пешфарз"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Клавиатура"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
-msgid "View and change keyboard shortcuts and set your typing preferences"
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
 "Миёнбурҳои клавиатураро намоиш диҳед ва тағйир диҳед, ва бартариҳои чопкунии "
 "худро таъин кунед"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:68 panels/keyboard/shortcut-editor.ui:318
-msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "_Хидматҳои ҷойгиршавӣ"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "Ягон барнома дар айни ҳол аудиоро пахш ё сабт накарда истодааст."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
 msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:156 panels/printers/details-dialog.ui:38
-msgid "Name"
-msgstr "Ном"
-
-#: panels/keyboard/shortcut-editor.ui:168
-msgid "Command"
-msgstr "Фармон"
-
-#: panels/keyboard/shortcut-editor.ui:180
-#, fuzzy
-#| msgid "Shortcuts"
-msgid "Shortcut"
-msgstr "Миёнбурҳо"
-
-#: panels/keyboard/shortcut-editor.ui:259
-msgid "Set Shortcut…"
-msgstr "Танзими миёнбур…"
-
-#: panels/keyboard/shortcut-editor.ui:272 panels/network/network-wifi.ui:593
-msgid "None"
-msgstr "Ҳеҷ"
-
-#: panels/keyboard/shortcut-editor.ui:303
-msgid "Enter the new shortcut"
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
 msgstr ""
 
-#: panels/keyboard/shortcut-editor.ui:357
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
 #, fuzzy
-#| msgid "_Remove"
-msgid "Remove"
-msgstr "_Тоза кардан"
+msgid "Microphone Turned Off"
+msgstr "Экран хомӯш мешавад"
 
-#: panels/keyboard/shortcut-editor.ui:367
-msgid "Add"
-msgstr "Илова кардан"
-
-#: panels/keyboard/shortcut-editor.ui:382
+#: panels/microphone/cc-microphone-panel.ui:24
 #, fuzzy
-#| msgid "_Replace"
-msgid "Replace"
-msgstr "Ҷойгузин _кардан"
+msgid "No applications can record sound."
+msgstr "Ягон барнома ёфт нашуд"
 
-#: panels/keyboard/shortcut-editor.ui:395
-#, fuzzy
-#| msgid "Select"
-msgid "Set"
-msgstr "Интихоб кардан"
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.c:80 panels/wacom/cc-wacom-panel.c:463
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "Санҷиши _танзимот"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Умумӣ"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "Тугмаи _асосӣ"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "Чап"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "Рост"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Ҷустуҷӯи ҷойгиршавӣ"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Муш"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Танзимоти муш"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Ба поён ҳаракат кардан"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "Ин ҳисобро аз сервер тоза намекунад."
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Ин ҳисобро аз сервер тоза намекунад."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Фаъол"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "Панели ламсӣ"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "Панели ламсӣ"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "Барои зеркунӣ _зарба занед"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Барои зеркунӣ _зарба занед"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "Ғайрифаъол кардан ҳангоми чопкунӣ"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Панели ламсӣ (нисбӣ)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "Ба рост ҳаракат кардан"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Ба чап ҳаракат кардан"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Дутарафа"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Зеркунӣ, зеркунии дубора, ҳаракатдиҳиро кӯшиш кунед"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2411,1744 +1931,801 @@ msgstr ""
 "Тағйир додани ҳассосияти муш ё панели ламсӣ ва имконоти истифодаи дасти рост "
 "ё чап"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 ":Панели пайгирӣ;Нишондиҳанда;Зер кардан;Зарба задан;Дубора;Тугма;Трекбол;"
 "Ҳаракат;"
 
-#: panels/mouse/gnome-mouse-properties.ui:50
-msgid "General"
-msgstr "Умумӣ"
-
-#: panels/mouse/gnome-mouse-properties.ui:88
-#, fuzzy
-#| msgid "Primary _button"
-msgid "Primary Button"
-msgstr "Тугмаи _асосӣ"
-
-#: panels/mouse/gnome-mouse-properties.ui:107
-msgid "Sets the order of physical buttons on mice and touchpads."
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
 msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:136
-#: panels/sound/cc-balance-slider.ui:13
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
 #, fuzzy
-#| msgctxt "balance"
-#| msgid "Left"
-msgid "Left"
-msgstr "Чап"
+msgid "Workspaces"
+msgstr "Фазои рангин:"
 
-#: panels/mouse/gnome-mouse-properties.ui:146
-#: panels/sound/cc-balance-slider.ui:15
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
 #, fuzzy
-#| msgctxt "balance"
-#| msgid "Right"
-msgid "Right"
-msgstr "Рост"
+msgid "Automatically removes empty workspaces."
+msgstr "Холӣ кардани сабад _ба таври худкор"
 
-#: panels/mouse/gnome-mouse-properties.ui:182
-msgid "Mouse"
-msgstr "Муш"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:221
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
 #, fuzzy
-#| msgid "Mouse Settings"
-msgid "Mouse Speed"
-msgstr "Танзимоти муш"
+msgid "Multi-Monitor"
+msgstr "Монитор"
 
-#: panels/mouse/gnome-mouse-properties.ui:243
-#: panels/mouse/gnome-mouse-properties.ui:535
-msgid "Double-click timeout"
-msgstr "Анҷоми вақти зеркуни дубора"
-
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/gnome-mouse-properties.ui:280
-#: panels/mouse/gnome-mouse-properties.ui:443
+#: panels/multitasking/cc-multitasking-panel.ui:130
 #, fuzzy
-#| msgid "_Natural scrolling"
-msgid "Natural Scrolling"
-msgstr "_Ҳаракаткунии одатӣ"
+msgid "Workspaces on _primary display only"
+msgstr "Барои тағйир додани дисплейи асосӣ кашед."
 
-#: panels/mouse/gnome-mouse-properties.ui:296
-#: panels/mouse/gnome-mouse-properties.ui:459
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
 #, fuzzy
-#| msgid "This will not remove the account on the server."
-msgid "Scrolling moves the content, not the view."
-msgstr "Ин ҳисобро аз сервер тоза намекунад."
+msgid "Application Switching"
+msgstr "Барномаи муайяншуда"
 
-#: panels/mouse/gnome-mouse-properties.ui:346
-#: panels/mouse/gnome-mouse-properties.ui:391
-msgid "Touchpad"
-msgstr "Панели ламсӣ"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:514
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 #, fuzzy
-#| msgid "Touchpad"
-msgid "Touchpad Speed"
-msgstr "Панели ламсӣ"
+msgid "Other Devices"
+msgstr "_Нест кардани файлҳо"
 
-#: panels/mouse/gnome-mouse-properties.ui:573
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
 #, fuzzy
-#| msgid "Tap to _click"
-msgid "Tap to Click"
-msgstr "Барои зеркунӣ _зарба занед"
+msgid "Add connection"
+msgstr "Илова кардани пайвасти нав"
 
-#: panels/mouse/gnome-mouse-properties.ui:625
-#, fuzzy
-#| msgid "Two _finger scroll"
-msgid "Two-finger Scrolling"
-msgstr "Ҳаракатдиҳии _дуангушта"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#: panels/mouse/gnome-mouse-properties.ui:678
-#, fuzzy
-#| msgid "Scroll Right"
-msgid "Edge Scrolling"
-msgstr "Ба рост ҳаракат кардан"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "Пайвастшуда"
 
-#: panels/mouse/gnome-mouse-test.c:132 panels/mouse/gnome-mouse-test.ui:25
-msgid "Try clicking, double clicking, scrolling"
-msgstr "Зеркунӣ, зеркунии дубора, ҳаракатдиҳиро кӯшиш кунед"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Имконот…"
 
-#: panels/mouse/gnome-mouse-test.c:137
-msgid "Five clicks, GEGL time!"
-msgstr "Панҷ зеркунӣ, вақти GEGL!"
-
-#: panels/mouse/gnome-mouse-test.c:142
-msgid "Double click, primary button"
-msgstr "Зеркунии дубора, тугмаи асосӣ"
-
-#: panels/mouse/gnome-mouse-test.c:142
-msgid "Single click, primary button"
-msgstr "Зеркунии якбора, тугмаи асосӣ"
-
-#: panels/mouse/gnome-mouse-test.c:145
-msgid "Double click, middle button"
-msgstr "Зеркунии дубора, тугмаи миёна"
-
-#: panels/mouse/gnome-mouse-test.c:145
-msgid "Single click, middle button"
-msgstr "Зеркунии якбора, тугмаи миёна"
-
-#: panels/mouse/gnome-mouse-test.c:148
-msgid "Double click, secondary button"
-msgstr "Зеркунии дубора, тугмаи иловагӣ"
-
-#: panels/mouse/gnome-mouse-test.c:148
-msgid "Single click, secondary button"
-msgstr "Зеркунии якбора, тугмаи иловагӣ"
-
-#. add proxy to device list
-#: panels/network/cc-network-panel.c:590
-msgid "Network proxy"
-msgstr "Прокси шабака"
-
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: panels/network/cc-network-panel.c:726 panels/network/net-vpn.c:167
-#: panels/network/net-vpn.c:295
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%s VPN"
-msgstr "VPN-и %s"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
 
-#: panels/network/cc-network-panel.c:790 panels/network/cc-wifi-panel.ui:304
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Нуқтаи дастрасии Wi-Fi-ро фаъол мекунед?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Номи шабака"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Ниҳонвожа"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "Эҷод кардани ниҳонвожа"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Эҷод кардани ниҳонвожа"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Хомӯш кардан"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Ҳ_олати ҳавопаймо"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "Ягон тасвир ёфт нашудааст"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "Ҳ_олати ҳавопаймо"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Нуқтаи дастрасии Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "_Фаъол кардани нуқтаи дастрасии Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "Шабакаҳо"
+
+#: panels/network/cc-wifi-panel.ui:297
+#, fuzzy
+msgid "NetworkManager needs to be running"
+msgstr "Мудири шабака бояд иҷро карда шавад"
+
+#: panels/network/cc-wifi-panel.ui:303
 msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr ""
 "Оҳ, чизе нодуруст ба амал омад. Лутфан, бо фурӯшандаи нармафзор дар тамос "
 "шавед."
 
-#: panels/network/cc-network-panel.c:796
-msgid "NetworkManager needs to be running."
-msgstr "Мудири шабака бояд иҷро карда шавад."
-
-#: panels/network/cc-network-panel.ui:142
-#: panels/network/connection-editor/net-connection-editor.c:581
-msgid "VPN"
-msgstr "VPN"
-
-#: panels/network/cc-network-panel.ui:194
-msgid "Not set up"
-msgstr ""
-
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:189
-#, fuzzy, c-format
-#| msgctxt "timezone desc"
-#| msgid "%s (%s)"
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (%s)"
-
-#: panels/network/cc-wifi-connection-row.ui:73
-#: panels/network/net-device-ethernet.c:359
-#: panels/network/network-ethernet.ui:120 panels/network/network-mobile.ui:394
-#: panels/network/network-simple.ui:75 panels/network/network-vpn.ui:79
-msgid "Options…"
-msgstr "Имконот…"
-
-#: panels/network/cc-wifi-panel.c:281
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:1738
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.ui:56
-#, fuzzy
-#| msgid "Air_plane Mode"
-msgid "Airplane Mode"
-msgstr "Ҳ_олати ҳавопаймо"
-
-#: panels/network/cc-wifi-panel.ui:72
-msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
-msgstr ""
-
-#: panels/network/cc-wifi-panel.ui:141
-#, fuzzy
-#| msgid "No Pictures Found"
-msgid "No Wi-Fi Adapter Found"
-msgstr "Ягон тасвир ёфт нашудааст"
-
-#: panels/network/cc-wifi-panel.ui:153
-msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
-msgstr ""
-
-#: panels/network/cc-wifi-panel.ui:188
-#, fuzzy
-#| msgid "Air_plane Mode"
-msgid "Airplane Mode On"
-msgstr "Ҳ_олати ҳавопаймо"
-
-#: panels/network/cc-wifi-panel.ui:200
-msgid "Turn off to use Wi-Fi"
-msgstr ""
-
-#: panels/network/cc-wifi-panel.ui:226
-#, fuzzy
-#| msgid "Networks"
-msgid "Visible Networks"
-msgstr "Шабакаҳо"
-
-#: panels/network/cc-wifi-panel.ui:293
-#, fuzzy
-#| msgid "NetworkManager needs to be running."
-msgid "NetworkManager needs to be running"
-msgstr "Мудири шабака бояд иҷро карда шавад"
-
-#: panels/network/connection-editor/8021x-security-page.ui:26
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Амнияти 802.1x"
 
-#: panels/network/connection-editor/8021x-security-page.ui:73
-#: panels/network/connection-editor/security-page.ui:72
-msgid "page 1"
-msgstr "саҳифаи 1"
-
-#: panels/network/connection-editor/8021x-security-page.ui:224
-#: panels/network/connection-editor/security-page.ui:223
-#: panels/network/wireless-security/eap-method-fast.ui:50
-#: panels/network/wireless-security/eap-method-peap.ui:48
-#: panels/network/wireless-security/eap-method-ttls.ui:31
-msgid "Anony_mous identity"
-msgstr "Шахсияти _махфӣ"
-
-#: panels/network/connection-editor/8021x-security-page.ui:238
-#: panels/network/connection-editor/security-page.ui:237
-msgid "Inner _authentication"
-msgstr "Санҷиши _ҳаққонияти дохилӣ"
-
-#: panels/network/connection-editor/8021x-security-page.ui:281
-#: panels/network/connection-editor/security-page.ui:280
-msgid "page 2"
-msgstr "саҳифаи 2"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:101
-#: panels/network/connection-editor/ce-page-security.c:445
-#: panels/network/connection-editor/details-page.ui:86
-#: panels/network/network-wifi.ui:239
-msgid "Security"
-msgstr "Амният"
-
-#: panels/network/connection-editor/ce-page.c:481
-msgid "automatic"
-msgstr "худкор"
-
-#: panels/network/connection-editor/ce-page.c:521
-#, c-format
-msgid "Profile %d"
-msgstr "Профили %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:56
-#: panels/network/net-device-wifi.c:123 panels/network/net-device-wifi.c:299
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:60
-#: panels/network/net-device-wifi.c:127 panels/network/net-device-wifi.c:304
-#: panels/network/network-wifi.ui:592
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:64
-#: panels/network/net-device-wifi.c:131
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:69
-#: panels/network/net-device-wifi.c:136
-msgid "Enterprise"
-msgstr "Корхонавӣ"
-
-#: panels/network/connection-editor/ce-page-details.c:74
-#: panels/network/net-device-wifi.c:141 panels/network/net-device-wifi.c:289
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Ҳеҷ"
-
-#: panels/network/connection-editor/ce-page-details.c:95
-msgid "Never"
-msgstr "Ҳеҷ гоҳ"
-
-#: panels/network/connection-editor/ce-page-details.c:110
-#: panels/network/net-device-ethernet.c:137
-#: panels/network/net-device-wifi.c:398
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i day ago"
 msgstr[1] "%i рӯз пеш"
 
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:228
-#: panels/network/net-device-ethernet.c:66 panels/network/net-device-wifi.c:476
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d МБ/с"
-
-#: panels/network/connection-editor/ce-page-details.c:249
-#: panels/network/net-device-wifi.c:505
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Ҳеҷ"
-
-#: panels/network/connection-editor/ce-page-details.c:251
-#: panels/network/net-device-wifi.c:507
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Паст"
-
-#: panels/network/connection-editor/ce-page-details.c:253
-#: panels/network/net-device-wifi.c:509
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Хуб"
-
-#: panels/network/connection-editor/ce-page-details.c:255
-#: panels/network/net-device-wifi.c:511
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Хуб"
-
-#: panels/network/connection-editor/ce-page-details.c:257
-#: panels/network/net-device-wifi.c:513
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Аъло"
-
-#: panels/network/connection-editor/ce-page-details.c:300
-#, fuzzy
-#| msgid "Connection"
-msgid "Forget Connection"
-msgstr "Пайвастшавӣ"
-
-#: panels/network/connection-editor/ce-page-details.c:302
-#, fuzzy
-#| msgid "Connection failed"
-msgid "Remove Connection Profile"
-msgstr "Пайваст қатъ шудааст"
-
-#: panels/network/connection-editor/ce-page-details.c:304
-#, fuzzy
-#| msgid "_Remove"
-msgid "Remove VPN"
-msgstr "_Тоза кардан"
-
-#: panels/network/connection-editor/ce-page-details.c:332
-#: panels/network/network-wifi.ui:1433 shell/cc-panel-list.ui:103
-#: shell/cc-window.c:264
-msgid "Details"
-msgstr "Тафсилот"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:174
-#: panels/network/connection-editor/ce-page-vpn.c:188
-#: panels/network/connection-editor/ce-page-wifi.c:194
-#: panels/network/network-wifi.ui:1437
-msgid "Identity"
-msgstr "Шахсият"
-
-#: panels/network/connection-editor/ce-page-ip4.c:251
-#: panels/network/connection-editor/ce-page-ip6.c:230
-msgid "Delete Address"
-msgstr "Нест кардани суроға"
-
-#: panels/network/connection-editor/ce-page-ip4.c:422
-#: panels/network/connection-editor/ce-page-ip6.c:390
-msgid "Delete Route"
-msgstr "Нест кардани масир"
-
-#: panels/network/connection-editor/ce-page-ip4.c:896
-#: panels/network/network-wifi.ui:1441
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:828
-#: panels/network/network-wifi.ui:1445
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:245
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Ҳеҷ"
-
-#: panels/network/connection-editor/ce-page-security.c:268
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Калиди 40/128-бити WEP (Hex ё ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:278
-msgid "WEP 128-bit Passphrase"
-msgstr "Гузарвожаи WEP 128-бит"
-
-#: panels/network/connection-editor/ce-page-security.c:291
-#: panels/network/wireless-security/wireless-security.c:465
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:304
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP-и динамикӣ (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:318
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Шахсӣ"
-
-#: panels/network/connection-editor/ce-page-security.c:332
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Корхонавӣ"
-
-#: panels/network/connection-editor/details-page.ui:18
-#: panels/network/network-wifi.ui:174
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "Тавоноии сигнал"
 
-#: panels/network/connection-editor/details-page.ui:52
-#: panels/network/network-wifi.ui:207
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "Суръати пайванд"
 
-#: panels/network/connection-editor/details-page.ui:104
-#: panels/network/net-device-ethernet.c:170 panels/network/network-wifi.ui:256
-#: panels/network/panel-common.c:644
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Амният"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "Суроғаи IPv4"
 
-#: panels/network/connection-editor/details-page.ui:122
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-ethernet.c:175
-#: panels/network/network-mobile.ui:189 panels/network/network-wifi.ui:273
-#: panels/network/panel-common.c:645
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "Суроғаи IPv6"
 
-#: panels/network/connection-editor/details-page.ui:140
-#: panels/network/net-device-ethernet.c:178 panels/network/network-wifi.ui:290
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "Суроғаи сахтафзор"
 
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "Профилҳои дастгиришудаи ICC"
+
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:182
-#: panels/network/network-mobile.ui:206 panels/network/network-wifi.ui:307
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Масири пешфарз"
 
-#: panels/network/connection-editor/details-page.ui:177
-#: panels/network/connection-editor/ip4-page.ui:197
-#: panels/network/connection-editor/ip6-page.ui:211
-#: panels/network/net-device-ethernet.c:184
-#: panels/network/network-mobile.ui:224 panels/network/network-wifi.ui:325
-#: panels/network/network-wifi.ui:831 panels/network/network-wifi.ui:1108
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: panels/network/connection-editor/details-page.ui:195
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "Истифодашудаи охирин"
 
-#: panels/network/connection-editor/details-page.ui:324
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "_Пайваст шудан ба таври худкор"
 
-#: panels/network/connection-editor/details-page.ui:343
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "Дастрас кардан ба _корбарони дигар"
 
-#: panels/network/connection-editor/details-page.ui:376
-msgid "Restrict background data usage"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: panels/network/connection-editor/details-page.ui:386
-msgid "Appropriate for connections that have data charges or limits."
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: panels/network/connection-editor/ethernet-page.ui:16
-#: panels/network/connection-editor/ethernet-page.ui:39
-#: panels/network/connection-editor/ip4-page.ui:209
-#: panels/network/connection-editor/ip4-page.ui:277
-#: panels/network/connection-editor/ip6-page.ui:42
-#: panels/network/connection-editor/ip6-page.ui:223
-#: panels/network/connection-editor/ip6-page.ui:291
-#: panels/network/net-proxy.c:58 panels/network/network-proxy.ui:103
-#: panels/network/wireless-security/eap-method-peap.ui:22
-#: panels/privacy/cc-privacy-panel.c:239
-msgid "Automatic"
-msgstr "Худкор"
-
-#: panels/network/connection-editor/ethernet-page.ui:19
-msgid "Twisted Pair (TP)"
-msgstr "Ҷуфти тобдор (TP)"
-
-#: panels/network/connection-editor/ethernet-page.ui:22
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Интерфейси воҳиди замима (AUI)"
-
-#: panels/network/connection-editor/ethernet-page.ui:25
-msgid "BNC"
-msgstr "BNC"
-
-#: panels/network/connection-editor/ethernet-page.ui:28
-msgid "Media Independent Interface (MII)"
-msgstr "Интерфейси мустақили медиа (MII)"
-
-#: panels/network/connection-editor/ethernet-page.ui:42
-msgid "10 Mb/s"
-msgstr "10 МБ/с"
-
-#: panels/network/connection-editor/ethernet-page.ui:45
-msgid "100 Mb/s"
-msgstr "100 МБ/с"
-
-#: panels/network/connection-editor/ethernet-page.ui:48
-msgid "1 Gb/s"
-msgstr "1 ГБ/с"
-
-#: panels/network/connection-editor/ethernet-page.ui:51
-msgid "10 Gb/s"
-msgstr "10 ГБ/с"
-
-#: panels/network/connection-editor/ethernet-page.ui:71
-#: panels/network/connection-editor/vpn-page.ui:23
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
 msgid "_Name"
 msgstr "_Ном"
 
-#: panels/network/connection-editor/ethernet-page.ui:100
-#: panels/network/connection-editor/wifi-page.ui:67
-#: panels/network/network-wifi.ui:1260
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
 msgid "_MAC Address"
 msgstr "Суроғаи _MAC"
 
-#: panels/network/connection-editor/ethernet-page.ui:146
+#: panels/network/connection-editor/ethernet-page.ui:80
 msgid "M_TU"
 msgstr "M_TU"
 
-#: panels/network/connection-editor/ethernet-page.ui:163
-#: panels/network/connection-editor/wifi-page.ui:97
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
 msgid "_Cloned Address"
 msgstr "_Суроғаи нусхабардошта"
 
-#: panels/network/connection-editor/ethernet-page.ui:178
+#: panels/network/connection-editor/ethernet-page.ui:104
 msgid "bytes"
 msgstr "байт"
 
-#: panels/network/connection-editor/ip4-page.ui:27
+#: panels/network/connection-editor/ip4-page.ui:21
 #, fuzzy
-#| msgid "_Method"
 msgid "IPv_4 Method"
 msgstr "_Усул"
 
-#: panels/network/connection-editor/ip4-page.ui:42
-#: panels/network/network-wifi.ui:777 panels/network/network-wifi.ui:1054
+#: panels/network/connection-editor/ip4-page.ui:36
 msgid "Automatic (DHCP)"
 msgstr "Худкор (DHCP)"
 
-#: panels/network/connection-editor/ip4-page.ui:55
-#: panels/network/connection-editor/ip6-page.ui:69
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
 msgid "Link-Local Only"
 msgstr "Танҳо пайванди маҳаллӣ"
 
-#: panels/network/connection-editor/ip4-page.ui:83
-#: panels/network/connection-editor/ip6-page.ui:97
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Дастӣ"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
 #, fuzzy
-#| msgid "Disabled"
 msgid "Disable"
 msgstr "Ғайрифаъол"
 
-#: panels/network/connection-editor/ip4-page.ui:111
-#: panels/network/connection-editor/ip6-page.ui:125
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
 #, fuzzy
-#| msgid "_Addresses"
+msgid "Shared to other computers"
+msgstr "Бо компютери дигар мубодилашуда"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
 msgid "Addresses"
 msgstr "_Суроғаҳо"
 
-#: panels/network/connection-editor/ip4-page.ui:129
-#: panels/network/connection-editor/ip4-page.ui:313
-#: panels/network/connection-editor/ip6-page.ui:143
-#: panels/network/connection-editor/ip6-page.ui:327
-#: panels/printers/details-dialog.ui:89
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Суроға"
 
-#: panels/network/connection-editor/ip4-page.ui:143
-#: panels/network/connection-editor/ip4-page.ui:327
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Маскаи шабака"
 
-#: panels/network/connection-editor/ip4-page.ui:157
-#: panels/network/connection-editor/ip4-page.ui:341
-#: panels/network/connection-editor/ip6-page.ui:171
-#: panels/network/connection-editor/ip6-page.ui:355
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Шлюз"
 
-#: panels/network/connection-editor/ip4-page.ui:220
-#: panels/network/connection-editor/ip6-page.ui:234
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr "Худкор"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
 msgid "Automatic DNS"
 msgstr "DNS-и худкор"
 
-#: panels/network/connection-editor/ip4-page.ui:244
-#: panels/network/connection-editor/ip6-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr ""
 
-#: panels/network/connection-editor/ip4-page.ui:265
-#: panels/network/connection-editor/ip6-page.ui:279
-#: panels/network/network-wifi.ui:876 panels/network/network-wifi.ui:1153
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Масирҳо"
 
-#: panels/network/connection-editor/ip4-page.ui:288
-#: panels/network/connection-editor/ip6-page.ui:302
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Масирҳои худкор"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:354
-#: panels/network/connection-editor/ip6-page.ui:368
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 #, fuzzy
-#| msgctxt "network parameters"
-#| msgid "Metric"
 msgid "Metric"
 msgstr "Метрӣ"
 
-#: panels/network/connection-editor/ip4-page.ui:384
-#: panels/network/connection-editor/ip6-page.ui:398
-#: panels/network/network-wifi.ui:932 panels/network/network-wifi.ui:1209
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Истифода бурдани ин пайваст _танҳо барои сарчашмаҳои ин шабака"
 
-#: panels/network/connection-editor/ip6-page.ui:27
+#: panels/network/connection-editor/ip6-page.ui:21
 #, fuzzy
-#| msgid "_Method"
 msgid "IPv_6 Method"
 msgstr "_Усул"
 
-#: panels/network/connection-editor/ip6-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:45
 msgid "Automatic, DHCP only"
 msgstr "Худкорона, танҳо DHCP"
 
-#: panels/network/connection-editor/ip6-page.ui:157
-#: panels/network/connection-editor/ip6-page.ui:341
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Пешванд"
 
-#: panels/network/connection-editor/net-connection-editor.c:261
-msgid "Unable to open connection editor"
-msgstr "Муҳаррири пайвастҳо кушода нашуд"
-
-#: panels/network/connection-editor/net-connection-editor.c:279
-msgid "New Profile"
-msgstr "Профили нав"
-
-#: panels/network/connection-editor/net-connection-editor.c:727
-msgid "Import from file…"
-msgstr "Ворид кардан аз файл…"
-
-#: panels/network/connection-editor/net-connection-editor.c:759
-#, fuzzy
-#| msgid "%s VPN"
-msgid "Add VPN"
-msgstr "VPN-и %s"
-
-#: panels/network/connection-editor/security-page.ui:26
-#: panels/network/network-wifi.ui:529
+#: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Амният"
 
-#: panels/network/connection-editor/vpn-helpers.c:141
-msgid "Cannot import VPN connection"
-msgstr "Пайвасти VPN ворид намешавад"
-
-#: panels/network/connection-editor/vpn-helpers.c:143
-#, fuzzy, c-format
-#| msgid ""
-#| "The file '%s' could not be read or does not contain recognized VPN "
-#| "connection information\n"
-#| "\n"
-#| "Error: %s."
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Файли \"%s\" наметавонад хонда шавад, ё ки маълумоти муайяншудаи пайвасти "
-"VPN-ро надорад\n"
-"\n"
-"Хатогӣ: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:178
-msgid "Select file to import"
-msgstr "Интихоби файл барои воридот"
-
-#: panels/network/connection-editor/vpn-helpers.c:182
-#: panels/printers/pp-details-dialog.c:314
-#: panels/sharing/cc-sharing-panel.c:428
-#: panels/user-accounts/cc-avatar-chooser.c:235
-msgid "_Open"
-msgstr "_Кушодан"
-
-#: panels/network/connection-editor/vpn-helpers.c:230
-#, fuzzy, c-format
-#| msgid "A file named \"%s\" already exists."
-msgid "A file named “%s” already exists."
-msgstr "Номи файли \"%s\" аллакай мавҷуд аст."
-
-#: panels/network/connection-editor/vpn-helpers.c:232
-msgid "_Replace"
-msgstr "Ҷойгузин _кардан"
-
-#: panels/network/connection-editor/vpn-helpers.c:234
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Шумо мехоҳед, ки %s-ро бо пайвасти VPN-и захирашуда ҷойгузин кунед?"
-
-#: panels/network/connection-editor/vpn-helpers.c:270
-msgid "Cannot export VPN connection"
-msgstr "Пайвасти VPN содир намешавад"
-
-#: panels/network/connection-editor/vpn-helpers.c:272
-#, fuzzy, c-format
-#| msgid ""
-#| "The VPN connection '%s' could not be exported to %s.\n"
-#| "\n"
-#| "Error: %s."
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Пайвасти VPN-и \"%s\" ба %s содир карда нашуд.\n"
-"\n"
-"Хатогӣ: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:307
-msgid "Export VPN connection"
-msgstr "Содир кардани пайвасти VPN"
-
-#: panels/network/connection-editor/vpn-page.ui:58
+#: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
 msgstr "(Хато: муҳаррири пайвасти VPN кушода нашуд)"
 
-#: panels/network/connection-editor/wifi-page.ui:20
-#: panels/network/network-wifi.ui:497
+#: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
 msgstr "_SSID"
 
-#: panels/network/connection-editor/wifi-page.ui:36
-#: panels/network/network-wifi.ui:513
+#: panels/network/connection-editor/wifi-page.ui:28
 msgid "_BSSID"
 msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Шабака"
 
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Идора кунед, ки шумо чӣ тавр ба Интернет пайваст мешавед"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 #, fuzzy
-#| msgid ""
-#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
-#| "vpn;vlan;bridge;bond;DNS;"
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"DNS;"
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Шабака;Бесим;Wi-Fi;Wifi;IP;LAN;Прокси;WAN;Пайвасти паҳннавор;Модем;Bluetooth;"
 "vpn;vlan;bridge;bond;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 #, fuzzy
-#| msgid "Control how you connect to the Internet"
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Идора кунед, ки шумо чӣ тавр ба Интернет пайваст мешавед"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 #, fuzzy
-#| msgid ""
-#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
-#| "vpn;vlan;bridge;bond;DNS;"
-msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Шабака;Бесим;Wi-Fi;Wifi;IP;LAN;Прокси;WAN;Пайвасти паҳннавор;Модем;Bluetooth;"
 "vpn;vlan;bridge;bond;DNS;"
 
-#: panels/network/net-device-ethernet.c:123
-#: panels/network/net-device-wifi.c:384
-msgid "never"
-msgstr "ҳеҷ гоҳ"
-
-#: panels/network/net-device-ethernet.c:133
-#: panels/network/net-device-wifi.c:394
-msgid "today"
-msgstr "имрӯз"
-
-#: panels/network/net-device-ethernet.c:135
-#: panels/network/net-device-wifi.c:396
-msgid "yesterday"
-msgstr "дирӯз"
-
-#: panels/network/net-device-ethernet.c:173
-#: panels/network/network-mobile.ui:172 panels/network/panel-common.c:647
-#: panels/network/panel-common.c:649
-msgid "IP Address"
-msgstr "Суроғаи IP"
-
-#: panels/network/net-device-ethernet.c:189 panels/network/network-wifi.ui:342
-msgid "Last used"
-msgstr "Истифодашудаи охирин"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:291
-#: panels/network/network-ethernet.ui:19 panels/network/network-simple.ui:39
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Симӣ"
 
-#: panels/network/net-device-mobile.c:236
-msgid "Add new connection"
-msgstr "Илова кардани пайвасти нав"
-
-#: panels/network/net-device-wifi.c:1157
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr ""
-"Гузариш ба хот-споти бесим пайвасти шуморо аз <b>%s</b> қатъ мегардонад."
-
-#: panels/network/net-device-wifi.c:1161
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr ""
-"Ҳангоми фаъол будани хот-спот шумо наметавонед тавассути пайвасти бесими худ "
-"ба Интернет пайваст шавед."
-
-#: panels/network/net-device-wifi.c:1168
-msgid "Turn On Wi-Fi Hotspot?"
-msgstr "Нуқтаи дастрасии Wi-Fi-ро фаъол мекунед?"
-
-#: panels/network/net-device-wifi.c:1190
-msgid ""
-"Wi-Fi hotspots are usually used to share an additional Internet connection "
-"over Wi-Fi."
-msgstr ""
-
-#: panels/network/net-device-wifi.c:1201
-msgid "_Turn On"
-msgstr "_Хомӯш кардан"
-
-#: panels/network/net-device-wifi.c:1278
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Пайвасти \"ХОТ-СПОТ\" ва ҳамаи корбаронро қатъ мекунед?"
-
-#: panels/network/net-device-wifi.c:1281
-msgid "_Stop Hotspot"
-msgstr "_Қатъ кардани \"ХОТ-СПОТ\""
-
-#: panels/network/net-device-wifi.c:1337
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Сиёсати низом истифодаи минтақаи дастрасиро манъ мекунад"
-
-#: panels/network/net-device-wifi.c:1340
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Дастгоҳи бесим ҳолати \"ХОТ-СПОТ\"-ро дастгирӣ намекунад"
-
-#: panels/network/net-device-wifi.c:1471
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Тафсилоти шабака барои шабакаҳои интихобшуда, аз он ҷумла ниҳонвожаҳо ва "
-"ягон конфигуратсияи фармоишӣ, гум карда мешавад."
-
-#: panels/network/net-device-wifi.c:1475 panels/network/network-wifi.ui:1350
-msgid "_Forget"
-msgstr "_Фаромӯш кардан"
-
-#: panels/network/net-device-wifi.c:1638 panels/network/net-device-wifi.c:1645
-msgid "Known Wi-Fi Networks"
-msgstr ""
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1682
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "__Фаромӯш кардан"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:102
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Ҳангоми пешҳниҳод нашудани суроғаи URL-и конфигуратсия ташхиси худкори "
-"проксии веб истифода мешавад."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:110
-msgid "This is not recommended for untrusted public networks."
-msgstr "Ин барои шабакаҳои беэътимоди оммавӣ тавсия намешавад."
-
-#: panels/network/network-mobile.ui:30
-msgid "IMEI"
-msgstr "IMEI"
-
-#: panels/network/network-mobile.ui:48
-msgid "Provider"
-msgstr "Провайдер"
-
-#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:92
-#, fuzzy
-#| msgid "Network proxy"
-msgid "Network Proxy"
-msgstr "Прокси шабака"
-
-#: panels/network/network-proxy.ui:173
-msgid "_HTTP Proxy"
-msgstr "Прокси _HTTP"
-
-#: panels/network/network-proxy.ui:192
-msgid "H_TTPS Proxy"
-msgstr "Прокси H_TTPS"
-
-#: panels/network/network-proxy.ui:211
-msgid "_FTP Proxy"
-msgstr "Прокси _FTP"
-
-#: panels/network/network-proxy.ui:230
-msgid "_Socks Host"
-msgstr "_Мизбони socks"
-
-#: panels/network/network-proxy.ui:249
-msgid "_Ignore Hosts"
-msgstr "_Нодида гирифтани мизбонҳо"
-
-#: panels/network/network-proxy.ui:287
-msgid "HTTP proxy port"
-msgstr "Порти прокси HTTP"
-
-#: panels/network/network-proxy.ui:364
-msgid "HTTPS proxy port"
-msgstr "Порти прокси HTTPS"
-
-#: panels/network/network-proxy.ui:385
-msgid "FTP proxy port"
-msgstr "Порти прокси FTP"
-
-#: panels/network/network-proxy.ui:406
-msgid "Socks proxy port"
-msgstr "Порти проксии socks"
-
-#: panels/network/network-proxy.ui:435
-msgid "_Configuration URL"
-msgstr "_Танзимоти суроғаи URL"
-
-#: panels/network/network-simple.ui:50
+#: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Хомӯш кардани дастгоҳ"
 
-#: panels/network/network-vpn.ui:56
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Фаъол"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Провайдер"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Суроғаи IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Прокси шабака"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "Прокси _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "Прокси H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Прокси _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Мизбони socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Нодида гирифтани мизбонҳо"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Порти прокси HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Порти прокси HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Порти прокси FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Порти проксии socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Танзимоти суроғаи URL"
+
+#: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
 msgstr "Хомӯш кардани пайвасти VPN"
 
-#: panels/network/network-wifi.ui:127
-msgid "Automatic _Connect"
-msgstr "Паёвасти _худкор"
-
-#: panels/network/network-wifi.ui:474
-msgid "details"
-msgstr "тафсилот"
-
-#: panels/network/network-wifi.ui:545
-#: panels/network/wireless-security/eap-method-leap.ui:40
-#: panels/network/wireless-security/eap-method-simple.ui:40
-#: panels/network/wireless-security/ws-leap.ui:40
-#: panels/network/wireless-security/ws-wpa-psk.ui:22
-#: panels/sharing/cc-sharing-panel.ui:351
-#: panels/user-accounts/cc-add-user-dialog.ui:310
-#: panels/user-accounts/cc-add-user-dialog.ui:547
-#: panels/user-accounts/cc-user-panel.ui:214
-msgid "_Password"
-msgstr "_Ниҳонвожа"
-
-#: panels/network/network-wifi.ui:621
-msgid "Show P_assword"
-msgstr "Намоиш додани п_арол"
-
-#: panels/network/network-wifi.ui:651
-msgid "Make available to other users"
-msgstr "Дастрас кардан ба корбарони дигар"
-
-#: panels/network/network-wifi.ui:679
-msgid "identity"
-msgstr "шахсият"
-
-#: panels/network/network-wifi.ui:713
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: panels/network/network-wifi.ui:754 panels/network/network-wifi.ui:1031
-msgid "_Addresses"
-msgstr "_Суроғаҳо"
-
-#: panels/network/network-wifi.ui:778 panels/network/network-wifi.ui:1055
-msgid "Automatic (DHCP) addresses only"
-msgstr "Танҳо суроғаҳои худкор (DHCP)"
-
-#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
-msgid "Link-local only"
-msgstr "Танҳо пайванди маҳаллӣ"
-
-#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
-msgid "Shared with other computers"
-msgstr "Бо компютери дигар мубодилашуда"
-
-#: panels/network/network-wifi.ui:916 panels/network/network-wifi.ui:1193
-msgid "_Ignore automatically obtained routes"
-msgstr "_Нодида гирифтани масирҳои ба таври худкор бадастовардашуда"
-
-#: panels/network/network-wifi.ui:959
-msgid "ipv4"
-msgstr "ipv4"
-
-#: panels/network/network-wifi.ui:990
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: panels/network/network-wifi.ui:1236
-msgid "ipv6"
-msgstr "ipv6"
-
-#: panels/network/network-wifi.ui:1276
-msgid "_Cloned MAC Address"
-msgstr "С_уроғаи MAC-и нусхабардошта"
-
-#: panels/network/network-wifi.ui:1334
-msgid "_Reset"
-msgstr "_Бозсозӣ"
-
-#: panels/network/network-wifi.ui:1370
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr ""
-"Танзими дубораи танзимоти ин пайваст ба пешфарзҳои онҳо, аммо дар ёд доштан "
-"ҳамчун пайвасти пазируфта."
-
-#: panels/network/network-wifi.ui:1387
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr ""
-"Тоза кардани ҳамаи тафсилоти ин шабака ва пайваст нашудани худкор ба он."
-
-#: panels/network/network-wifi.ui:1449
-msgid "Hardware"
-msgstr "Сахтафзор"
-
-#: panels/network/network-wifi.ui:1453
+#: panels/network/network-wifi.ui:34
 #, fuzzy
-#| msgid "Reset"
-msgctxt "tab"
-msgid "Reset"
-msgstr "Бозсозӣ"
-
-#: panels/network/network-wifi.ui:1505
-msgid "Wi-Fi Hotspot"
-msgstr "Нуқтаи дастрасии Wi-Fi"
-
-#: panels/network/network-wifi.ui:1523
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "Барои пайваст шудан ба шабакаи Wi-Fi, ҷодо сзед"
-
-#: panels/network/network-wifi.ui:1572
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "Номи шабака"
 
-#: panels/network/network-wifi.ui:1590
-msgid "Connected Devices"
-msgstr "Дастгоҳҳои пайвастшуда"
-
-#: panels/network/network-wifi.ui:1608
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "Навъи амният"
 
-#: panels/network/network-wifi.ui:1671
+#: panels/network/network-wifi.ui:46
 #, fuzzy
-#| msgid "Password"
-msgctxt "Wi-Fi passkey"
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "Ниҳонвожа"
 
-#: panels/network/network-wifi.ui:1768
+#: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
 msgstr "Хомӯш кардани пайвасти Wi-Fi"
 
-#: panels/network/network-wifi.ui:1800
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Боркунии имконот..."
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Пайваст шудан ба шабакаи пинҳоншуда…"
 
-#: panels/network/network-wifi.ui:1810
-#| msgid "Wi-Fi Hotspot"
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Фаъол кардани нуқтаи дастрасии Wi-Fi…"
 
-#: panels/network/network-wifi.ui:1820
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr ""
 
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:127
-msgid "Ad-hoc"
-msgstr "Махсус"
-
-#. TRANSLATORS: AP type
-#: panels/network/panel-common.c:131
-msgid "Infrastructure"
-msgstr "Инфрасохтор"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:147 panels/network/panel-common.c:201
-msgid "Status unknown"
-msgstr "Вазъияти номаълум"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:151
-msgid "Unmanaged"
-msgstr "Идоранушуда"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:155
-msgid "Unavailable"
-msgstr "Дастнорас"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:165 panels/network/panel-common.c:207
-msgid "Connecting"
-msgstr "Пайваст шуда истодааст"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:169 panels/network/panel-common.c:211
-msgid "Authentication required"
-msgstr "Санҷиши ҳаққоният лозим аст"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:173 panels/network/panel-common.c:215
-msgid "Connected"
-msgstr "Пайвастшуда"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:177
-msgid "Disconnecting"
-msgstr "Пайваст қатъ шуда истодааст"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:181 panels/network/panel-common.c:219
-msgid "Connection failed"
-msgstr "Пайваст қатъ шудааст"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:185 panels/network/panel-common.c:227
-msgid "Status unknown (missing)"
-msgstr "Вазъияти номаълум (намерасидагӣ)"
-
-#. TRANSLATORS: VPN status
-#: panels/network/panel-common.c:223
-msgid "Not connected"
-msgstr "Пайваст нашудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "Configuration failed"
-msgstr "Танзимот қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252
-msgid "IP configuration failed"
-msgstr "Танзимоти IP қатъ шуд"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "IP configuration expired"
-msgstr "Танзимоти IP аз мӯҳлаташ гузашт"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:260
-msgid "Secrets were required, but not provided"
-msgstr "Сирҳо лозим мебошанд, аммо пешниҳод нашуданд"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:264
-msgid "802.1x supplicant disconnected"
-msgstr "Пайвасти дархосткунандаи 802.1x қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:268
-msgid "802.1x supplicant configuration failed"
-msgstr "Конфигуратсияи дархосткунандаи 802.1x қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:272
-msgid "802.1x supplicant failed"
-msgstr "Дархосткунандаи 802.1x қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:276
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Дархосткунандаи 802.1x барои санҷиши ҳаққоният вақти зиёдро гирифт"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:280
-msgid "PPP service failed to start"
-msgstr "Оғози хидмати PPP қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:284
-msgid "PPP service disconnected"
-msgstr "Пайвасти хидмати PPP қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:288
-msgid "PPP failed"
-msgstr "PPP қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:292
-msgid "DHCP client failed to start"
-msgstr "Оғози муштарии DHCP бо нокомӣ дучор шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:296
-msgid "DHCP client error"
-msgstr "Хатогии муштарии DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:300
-msgid "DHCP client failed"
-msgstr "Муштарии DHCP бо нокомӣ дучор шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:304
-msgid "Shared connection service failed to start"
-msgstr "Оғози хидмати пайвасти мубодилашуда қатъ шуд"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:308
-msgid "Shared connection service failed"
-msgstr "Хидмати пайвасти мубодилашуда қатъ шуд"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:312
-msgid "AutoIP service failed to start"
-msgstr "Оғози хидмати AutoIP қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:316
-msgid "AutoIP service error"
-msgstr "Хатои хидмати AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:320
-msgid "AutoIP service failed"
-msgstr "Хидмати AutoIP қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:324
-msgid "Line busy"
-msgstr "Хат машғул аст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:328
-msgid "No dial tone"
-msgstr "Бе оҳанги занг"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:332
-msgid "No carrier could be established"
-msgstr "Ягон ҳомил пайваст нашудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:336
-msgid "Dialing request timed out"
-msgstr "Вақти шуморагирӣ ба анҷом расид"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:340
-msgid "Dialing attempt failed"
-msgstr "Шуморагирӣ қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:344
-msgid "Modem initialization failed"
-msgstr "Оғоздиҳии модем ба анҷом нарасид"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:348
-msgid "Failed to select the specified APN"
-msgstr "Интихоби APN-и муайяншуда қатъ шуд"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:352
-msgid "Not searching for networks"
-msgstr "Шабакаҳоро ҷустуҷӯ намекунад"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:356
-msgid "Network registration denied"
-msgstr "Қайдкунии шабака қатъ шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:360
-msgid "Network registration timed out"
-msgstr "Вақти қайдкунии шабака ба анҷом расид"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:364
-msgid "Failed to register with the requested network"
-msgstr "Қайдкунӣ бо шабакаи дархостшуда қатъ шуд"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:368
-msgid "PIN check failed"
-msgstr "Санҷиши PIN қатъ шуд"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:372
-msgid "Firmware for the device may be missing"
-msgstr "Эҳтимол аст, ки дастгоҳ нармафзори дарунсохт надорад"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:376
-msgid "Connection disappeared"
-msgstr "Пайваст гум шудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:380
-msgid "Existing connection was assumed"
-msgstr "Пайвасти мавҷудбуда мунтазир буд"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:384
-msgid "Modem not found"
-msgstr "Модем ёфт нашуд"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:388
-msgid "Bluetooth connection failed"
-msgstr "Пайвастшавии Bluetooth ба анҷом нарасид"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:392
-msgid "SIM Card not inserted"
-msgstr "Корти SIM ворид нашудааст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:396
-msgid "SIM Pin required"
-msgstr "SIM Pin лозим аст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:400
-msgid "SIM Puk required"
-msgstr "SIM Puk лозим аст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:404
-msgid "SIM wrong"
-msgstr "SIM нодуруст аст"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:408
-msgid "Connection dependency failed"
-msgstr "Вобастагии пайваст қатъ шуд"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:433
-msgid "Firmware missing"
-msgstr "Нармафзори дарунсохт вуҷуд надорад"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:437
-msgid "Cable unplugged"
-msgstr "Сим ҷудо шудааст"
-
-#: panels/network/wireless-security/eap-method.c:69
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:245
-msgid "no file selected"
-msgstr "ягон файл интихоб нашуд"
-
-#: panels/network/wireless-security/eap-method.c:276
-msgid "unspecified error validating eap-method file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method.c:451
-#, fuzzy
-#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "Калидҳои шахсии DER, PEM, ё PKCS#12 (*.der, *.pem, *.p12)"
-
-#: panels/network/wireless-security/eap-method.c:454
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Гувоҳиномаҳои DER ё PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:72
-msgid "missing EAP-FAST PAC file"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-fast.c:268
-#: panels/network/wireless-security/eap-method-peap.c:302
-#: panels/network/wireless-security/eap-method-ttls.c:351
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: panels/network/wireless-security/eap-method-fast.c:283
-#: panels/network/wireless-security/eap-method-peap.c:272
-#: panels/network/wireless-security/eap-method-ttls.c:289
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: panels/network/wireless-security/eap-method-fast.c:406
-msgid "Choose a PAC file"
-msgstr "Интихоб кардани файли PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:413
-msgid "PAC files (*.pac)"
-msgstr "Файли PAC (*.pac)"
-
-#: panels/network/wireless-security/eap-method-fast.ui:22
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "Ношинос"
 
-#: panels/network/wireless-security/eap-method-fast.ui:25
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "Ҳаққоният санҷида шуд"
 
-#: panels/network/wireless-security/eap-method-fast.ui:28
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "Ҳар ду"
 
-#: panels/network/wireless-security/eap-method-fast.ui:76
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Шахсияти _махфӣ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "Файли _PAC"
 
-#: panels/network/wireless-security/eap-method-fast.ui:122
-#: panels/network/wireless-security/eap-method-peap.ui:146
-#: panels/network/wireless-security/eap-method-ttls.ui:97
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Интихоб кардани файли PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "_Санҷиши ҳаққонияти дохилӣ"
 
-#: panels/network/wireless-security/eap-method-fast.ui:156
+#: panels/network/wireless-security/eap-method-fast.ui:126
 #, fuzzy
-#| msgid "PAC pro_visioning"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "_Таъминоти PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.c:74
-msgid "missing EAP-LEAP password"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-leap.ui:26
-#: panels/network/wireless-security/eap-method-simple.ui:26
-#: panels/network/wireless-security/ws-leap.ui:26
-#: panels/user-accounts/cc-add-user-dialog.ui:146
-#: panels/user-accounts/cc-add-user-dialog.ui:527
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "_Номи корбар"
 
-#: panels/network/wireless-security/eap-method-leap.ui:68
-#: panels/network/wireless-security/eap-method-simple.ui:85
-#: panels/network/wireless-security/eap-method-tls.ui:164
-#: panels/network/wireless-security/ws-leap.ui:68
-#: panels/network/wireless-security/ws-wpa-psk.ui:76
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Ниҳонвожа"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Намоиш додани ниҳонвожа"
 
-#: panels/network/wireless-security/eap-method-peap.c:63
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:68
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-peap.c:287
-#: panels/network/wireless-security/eap-method-ttls.c:336
-#: panels/network/wireless-security/wireless-security.c:441
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: panels/network/wireless-security/eap-method-peap.c:381
-#: panels/network/wireless-security/eap-method-tls.c:492
-#: panels/network/wireless-security/eap-method-ttls.c:430
-msgid "Choose a Certificate Authority certificate"
-msgstr "Интихоб кардани гувоҳиномаи мақомоти гувоҳиномаҳо"
-
-#: panels/network/wireless-security/eap-method-peap.ui:25
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "Версияи 0"
 
-#: panels/network/wireless-security/eap-method-peap.ui:28
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "Версияи 1"
 
-#: panels/network/wireless-security/eap-method-peap.ui:74
-#: panels/network/wireless-security/eap-method-tls.ui:75
-#: panels/network/wireless-security/eap-method-ttls.ui:57
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "Гувоҳиномаи C_A"
 
-#: panels/network/wireless-security/eap-method-peap.ui:96
-#: panels/network/wireless-security/eap-method-tls.ui:97
-#: panels/network/wireless-security/eap-method-ttls.ui:79
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Интихоб кардани гувоҳиномаи мақомоти гувоҳиномаҳо"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 #, fuzzy
-#| msgid "Authentication required"
 msgid "No CA certificate is _required"
 msgstr "Санҷиши ҳаққоният лозим аст"
 
-#: panels/network/wireless-security/eap-method-peap.ui:114
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Версияи PEAP"
 
-#: panels/network/wireless-security/eap-method-simple.c:74
-msgid "missing EAP username"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-simple.c:87
-msgid "missing EAP password"
-msgstr "ниҳонвожаи EAP ворид нашуд"
-
-#: panels/network/wireless-security/eap-method-tls.c:68
-msgid "missing EAP-TLS identity"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:77
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:84
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:100
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:110
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-tls.c:307
-msgid "Unencrypted private keys are insecure"
-msgstr "Калидҳои махфии берамз хатарнок мебошанд"
-
-#: panels/network/wireless-security/eap-method-tls.c:310
-#, fuzzy
-#| msgid ""
-#| "The selected private key does not appear to be protected by a password.  "
-#| "This could allow your security credentials to be compromised.  Please "
-#| "select a password-protected private key.\n"
-#| "\n"
-#| "(You can password-protect your private key with openssl)"
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Калиди махфии интихобшуда бо ниҳонвожа ҳифз нашудааст.  Ин метавонад сабаби "
-"бадном кардани маълумоти корбари амниятии шумо гардад.  Лутфан, калиди "
-"махфии бо ниҳонвожа ҳифзшударо интихоб кунед.\n"
-"\n"
-"(Шумо метавонед калиди махфии худро тавассути openssl бо ниҳонвожа муҳофизат "
-"кунед)"
-
-#: panels/network/wireless-security/eap-method-tls.c:486
-msgid "Choose your personal certificate"
-msgstr "Интихоб кардани гувоҳиномаи шахсӣ"
-
-#: panels/network/wireless-security/eap-method-tls.c:498
-msgid "Choose your private key"
-msgstr "Интихоб кардани калиди шахсӣ"
-
-#: panels/network/wireless-security/eap-method-tls.ui:24
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "Ш_ахсият"
 
-#: panels/network/wireless-security/eap-method-tls.ui:50
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "_Гувоҳиномаи корбар"
 
-#: panels/network/wireless-security/eap-method-tls.ui:115
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "_Калиди шахсӣ"
 
-#: panels/network/wireless-security/eap-method-tls.ui:140
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_Ниҳонвожаи калиди шахсӣ"
 
-#: panels/network/wireless-security/eap-method-ttls.c:63
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:68
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-
-#: panels/network/wireless-security/eap-method-ttls.c:259
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: panels/network/wireless-security/eap-method-ttls.c:274
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: panels/network/wireless-security/eap-method-ttls.c:305
+#: panels/network/wireless-security/eap-method-ttls.ui:25
 #, fuzzy
-#| msgid "MSCHAPv2"
 msgid "MSCHAPv2 (no EAP)"
 msgstr "MSCHAPv2"
 
-#: panels/network/wireless-security/eap-method-ttls.c:321
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: panels/network/wireless-security/wireless-security.c:87
-msgid "Unknown error validating 802.1X security"
-msgstr ""
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Домен"
 
-#: panels/network/wireless-security/wireless-security.c:453
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: panels/network/wireless-security/wireless-security.c:477
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
 msgid "PWD"
 msgstr ""
 
-#: panels/network/wireless-security/wireless-security.c:488
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "ТЕЗ"
 
-#: panels/network/wireless-security/wireless-security.c:499
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "TLS-и нақбӣ"
 
-#: panels/network/wireless-security/wireless-security.c:510
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "EAP-и муҳофизатшуда (PEAP)"
 
-#: panels/network/wireless-security/ws-dynamic-wep.ui:39
-#: panels/network/wireless-security/ws-wep-key.ui:115
-#: panels/network/wireless-security/ws-wpa-eap.ui:33
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "_Санҷиши ҳаққоният"
 
-#: panels/network/wireless-security/ws-leap.c:63
-msgid "missing leap-username"
-msgstr ""
-
-#: panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr "ниҳонвожаи мамониат ворид нашуд"
-
-#: panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr ""
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Навъ"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4162,99 +2739,69 @@ msgstr "Системаи кушода"
 msgid "Shared Key"
 msgstr "Калиди мубодилашуда"
 
-#: panels/network/wireless-security/ws-wep-key.ui:56
+#: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
 msgstr "_Тугма"
 
-#: panels/network/wireless-security/ws-wep-key.ui:94
+#: panels/network/wireless-security/ws-wep-key.ui:75
 msgid "Sho_w key"
 msgstr "Намоиш додани _калид"
 
-#: panels/network/wireless-security/ws-wep-key.ui:152
+#: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "_Индекси WEP"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-
-#: panels/network/wireless-security/ws-wpa-psk.ui:50
-msgid "_Type"
-msgstr "_Навъ"
-
 #. This is the per application switch for message tray usage.
-#: panels/notifications/cc-app-notifications-dialog.ui:61
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 #, fuzzy
-#| msgctxt "notifications"
-#| msgid "Notifications"
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "Огоҳиҳо"
 
 #. This is the setting to configure sounds associated with notifications.
-#: panels/notifications/cc-app-notifications-dialog.ui:113
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 #, fuzzy
-#| msgctxt "notifications"
-#| msgid "Sound Alerts"
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "Огоҳиҳои овоздор"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:169
+#: panels/notifications/cc-app-notifications-dialog.ui:42
 #, fuzzy
-#| msgctxt "notifications"
-#| msgid "Notifications"
 msgctxt "notifications"
 msgid "Notification _Popups"
 msgstr "Огоҳиҳо"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:185
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
 msgstr ""
 
 #. Popups here refers to message tray notifications in the middle of the screen.
-#: panels/notifications/cc-app-notifications-dialog.ui:250
+#: panels/notifications/cc-app-notifications-dialog.ui:56
 #, fuzzy
-#| msgctxt "notifications"
-#| msgid "Show Message Content in Banners"
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
 msgstr "Намоиш додани муҳтаво дар баннерҳо"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:301
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 #, fuzzy
-#| msgctxt "notifications"
-#| msgid "Lock Screen Notifications"
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "Огоҳиҳои экрани қулф"
 
-#: panels/notifications/cc-app-notifications-dialog.ui:352
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 #, fuzzy
-#| msgctxt "notifications"
-#| msgid "Show Message Content on Lock Screen"
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "Намоиш додани муҳтаво дар экрани қулф"
 
-#: panels/notifications/cc-notifications-panel.ui:70
-#, fuzzy
-#| msgid "Notifications"
-msgid "Notification _Popups"
-msgstr "Огоҳиҳо"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
 
-#: panels/notifications/cc-notifications-panel.ui:121
+#: panels/notifications/cc-notifications-panel.ui:17
 #, fuzzy
-#| msgid "Lock Screen Notifications"
 msgid "_Lock Screen Notifications"
 msgstr "Огоҳиҳои экрани қулф"
 
@@ -4263,35 +2810,33 @@ msgid "Control which notifications are displayed and what they show"
 msgstr ""
 "Идора кунед, ки кадом огоҳиҳо намоиш дода мешаванд ва чиро намоиш медиҳанд"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Огоҳиҳо;Баннер;Паём;Қуттӣ;Зоҳиршаванда;"
 
-#: panels/online-accounts/cc-online-accounts-panel.c:150
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Дигар"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/cc-online-accounts-panel.c:626
-#, fuzzy, c-format
-#| msgid "My Account"
-msgid "%s Account"
-msgstr "Ҳисоби ман"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:923
-msgid "Error removing account"
-msgstr "Ҳангоми тозакунии ҳисоб хатогӣ ба вуҷуд омад"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:988
-#, c-format
-msgid "<b>%s</b> removed"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
 msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Санҷиши _ҳаққонияти дохилӣ"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "Илова кардани ҳисоб"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4303,10 +2848,6 @@ msgstr ""
 "Ба ҳисобҳои онлайни худ пайваст шавед ва интихоб кунед, ки онҳоро барои чӣ "
 "истифода мебаред"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4315,538 +2856,193 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Онлайн;Чат;Тақвим;Почта;Тамос;ownCloud;"
 "Kerberos;IMAP;SMTP;Баста;Баъдтар;"
 
-#. Translators: This is the button which allows undoing the removal of the printer.
-#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
-msgid "Undo"
-msgstr ""
-
-#: panels/online-accounts/online-accounts.ui:96
-msgid "Connect to your data in the cloud"
-msgstr ""
-
-#: panels/online-accounts/online-accounts.ui:111
-msgid "No internet connection — connect to set up new online accounts"
-msgstr ""
-
-#: panels/online-accounts/online-accounts.ui:136
-#, fuzzy
-#| msgid "Add account"
-msgid "Add an account"
-msgstr "Илова кардани ҳисоб"
-
-#: panels/online-accounts/online-accounts.ui:243
-msgid "Remove Account"
-msgstr "Тоза кардани ҳисоб"
-
-#: panels/power/cc-power-panel.c:318
-msgid "Unknown time"
-msgstr "Вақти номаълум"
-
-#: panels/power/cc-power-panel.c:324
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i дақиқа"
 msgstr[1] "%i дақиқа"
 
-#: panels/power/cc-power-panel.c:336
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i соат"
 msgstr[1] "%i соат"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-power-panel.c:344
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: panels/power/cc-power-panel.c:345
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "соат"
 msgstr[1] "соат"
 
-#: panels/power/cc-power-panel.c:346
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "дақиқа"
 msgstr[1] "дақиқа"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:364
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s то анҷоми пуркунии батарея"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:371
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Диққат: %s боқимонда"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-power-panel.c:376
-#, c-format
-msgid "%s remaining"
-msgstr "%s боқимонда"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:381 panels/power/cc-power-panel.c:411
-msgid "Fully charged"
-msgstr "Комилан пур аст"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:385 panels/power/cc-power-panel.c:415
-#, fuzzy
-#| msgid "Charging"
-msgid "Not charging"
-msgstr "Пуркунии барқ"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:389 panels/power/cc-power-panel.c:419
-msgid "Empty"
-msgstr "Холӣ кардан"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:402
-msgid "Charging"
-msgstr "Пуркунии барқ"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:407
-msgid "Discharging"
-msgstr "Тамомшавии барқ"
-
-#: panels/power/cc-power-panel.c:540
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Асосӣ"
-
-#: panels/power/cc-power-panel.c:542
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Иловагӣ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:611
-msgid "Wireless mouse"
-msgstr "Муши бесим"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:614
-msgid "Wireless keyboard"
-msgstr "Клавиатураи бесим"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:617
-msgid "Uninterruptible power supply"
-msgstr "Таъминоти қатънашавандаи барқ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:620
-msgid "Personal digital assistant"
-msgstr "Ёрдамчии рақамии шахсӣ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:623
-msgid "Cellphone"
-msgstr "Телефони мобилӣ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:626
-msgid "Media player"
-msgstr "Плеери мултимедиа"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:629 panels/wacom/cc-wacom-panel.c:848
-msgid "Tablet"
-msgstr "Планшет"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:632
-msgid "Computer"
-msgstr "Компютер"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:635
-msgid "Gaming input device"
-msgstr ""
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-power-panel.c:638 panels/power/cc-power-panel.c:891
-#: panels/power/cc-power-panel.c:2406
-msgid "Battery"
-msgstr "Батарея"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:699
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "Пуркунии барқ"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:706
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "Диққат"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:711
-msgctxt "Battery power"
-msgid "Low"
-msgstr "Паст"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-power-panel.c:716
-msgctxt "Battery power"
-msgid "Good"
-msgstr "Хуб"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:721
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "Комилан пур аст"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-power-panel.c:725
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "Холӣ"
-
-#: panels/power/cc-power-panel.c:889
-msgid "Batteries"
-msgstr "Батареяҳо"
-
-#: panels/power/cc-power-panel.c:1250
-#, fuzzy, c-format
-#| msgid "%i hour"
-#| msgid_plural "%i hours"
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%i соат"
-msgstr[1] "%i соат"
-
-#: panels/power/cc-power-panel.c:1252
-#, fuzzy, c-format
-#| msgid "%i minute"
-#| msgid_plural "%i minutes"
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%i дақиқа"
-msgstr[1] "%i дақиқа"
-
-#: panels/power/cc-power-panel.c:1255
-#, fuzzy, c-format
-#| msgid "30 seconds"
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "30 сония"
-msgstr[1] "30 сония"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/power/cc-power-panel.c:1260
-#, fuzzy, c-format
-#| msgid "%i %s %i %s"
-msgctxt "time"
-msgid "%s %s %s"
-msgstr "%i %s %i %s"
-
-#. 2 minutes 12 seconds
-#: panels/power/cc-power-panel.c:1263
-#, fuzzy, c-format
-#| msgid "%i %s %i %s"
-msgctxt "time"
-msgid "%s %s"
-msgstr "%i %s %i %s"
-
-#. 0 seconds
-#: panels/power/cc-power-panel.c:1269
-#, fuzzy
-#| msgid "30 seconds"
-msgid "0 seconds"
-msgstr "30 сония"
-
-#: panels/power/cc-power-panel.c:1366
-msgid "When _idle"
-msgstr "Вақте ки беҳаракат аст"
-
-#: panels/power/cc-power-panel.c:1811
-msgid "Power Saving"
-msgstr "Захиракунии барқ"
-
-#: panels/power/cc-power-panel.c:1845
-msgid "_Screen brightness"
-msgstr "_Равшании экран"
-
-#: panels/power/cc-power-panel.c:1866
-msgid "Automatic brightness"
-msgstr "Дурахшонии худкор"
-
-#: panels/power/cc-power-panel.c:1879
-msgid "_Keyboard brightness"
-msgstr "_Дурахшонии экран"
-
-#: panels/power/cc-power-panel.c:1890
-msgid "_Dim screen when inactive"
-msgstr "_Камнур кардани экран дар ҳолати ғайрифаъол"
-
-#: panels/power/cc-power-panel.c:1908
-msgid "_Blank screen"
-msgstr "_Экрани холӣ"
-
-#: panels/power/cc-power-panel.c:1931
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: panels/power/cc-power-panel.c:1932
-msgid "Wi-Fi can be turned off to save power."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:1948
-msgid "_Mobile broadband"
-msgstr "_Паҳннавори мобилӣ"
-
-#: panels/power/cc-power-panel.c:1949
-#, fuzzy
-#| msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
-msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
-msgstr ""
-"Дастгоҳҳои паҳннавори мобилӣ (3G, 4G, WiMax ва ғайра) барқи иловагиро талаб "
-"мекунад"
-
-#: panels/power/cc-power-panel.c:1999
-msgid "_Bluetooth"
-msgstr "_Bluetooth"
-
-#: panels/power/cc-power-panel.c:2000
-msgid "Bluetooth can be turned off to save power."
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2052
-msgid "When on battery power"
-msgstr "Вақте ки аз батарея кор мекунад"
-
-#: panels/power/cc-power-panel.c:2054
-msgid "When plugged in"
-msgstr "Вақте ки аз манбаъ барқ кор мекунад"
-
-#: panels/power/cc-power-panel.c:2148
-msgid "Suspend"
-msgstr ""
-
-#: panels/power/cc-power-panel.c:2149
-msgid "Power Off"
-msgstr "Анҷоми кор"
-
-#: panels/power/cc-power-panel.c:2150
-msgid "Hibernate"
-msgstr "Гибернатсия"
-
-#: panels/power/cc-power-panel.c:2151
-#, fuzzy
-#| msgid "Do nothing"
-msgid "Nothing"
-msgstr "Амалиёт лозим нест"
-
-#. Frame header
-#: panels/power/cc-power-panel.c:2251
-#, fuzzy
-#| msgid "Suspend & Power Off"
-msgid "Suspend & Power Button"
-msgstr "Таваққуф ва анҷоми кор"
-
-#: panels/power/cc-power-panel.c:2292
-msgid "_Automatic suspend"
-msgstr "_Таваққуфи худкор"
-
-#: panels/power/cc-power-panel.c:2293
-#, fuzzy
-#| msgid "_Automatic suspend"
-msgid "Automatic suspend"
-msgstr "_Таваққуфи худкор"
-
-#: panels/power/cc-power-panel.c:2350
-msgid "_When the Power Button is pressed"
-msgstr ""
-
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:13
+#: panels/power/cc-power-panel.ui:12
 #, fuzzy
-#| msgid "15 minutes"
 msgctxt "automatic_suspend"
 msgid "15 minutes"
 msgstr "15 дақиқа"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:17
+#: panels/power/cc-power-panel.ui:16
 #, fuzzy
-#| msgid "2 minutes"
 msgctxt "automatic_suspend"
 msgid "20 minutes"
 msgstr "2 дақиқа"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:21
+#: panels/power/cc-power-panel.ui:20
 #, fuzzy
-#| msgid "5 minutes"
 msgctxt "automatic_suspend"
 msgid "25 minutes"
 msgstr "5 дақиқа"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:25
+#: panels/power/cc-power-panel.ui:24
 #, fuzzy
-#| msgid "30 minutes"
 msgctxt "automatic_suspend"
 msgid "30 minutes"
 msgstr "30 дақиқа"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:29
+#: panels/power/cc-power-panel.ui:28
 #, fuzzy
-#| msgid "45 minutes"
 msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 дақиқа"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:33
+#: panels/power/cc-power-panel.ui:32
 #, fuzzy
-#| msgid "1 hour"
 msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 соат"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:37
+#: panels/power/cc-power-panel.ui:36
 #, fuzzy
-#| msgid "80 minutes"
 msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 дақиқа"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:41
+#: panels/power/cc-power-panel.ui:40
 #, fuzzy
-#| msgid "90 minutes"
 msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 дақиқа"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:45
+#: panels/power/cc-power-panel.ui:44
 #, fuzzy
-#| msgid "100 minutes"
 msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 дақиқа"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
-#: panels/power/cc-power-panel.ui:49
+#: panels/power/cc-power-panel.ui:48
 #, fuzzy
-#| msgid "2 hours"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 соат"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:63
-#, fuzzy
-#| msgid "1 minute"
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 дақиқа"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батарея"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:67
-#, fuzzy
-#| msgid "2 minutes"
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 дақиқа"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Дастгоҳҳо"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:71
+#: panels/power/cc-power-panel.ui:93
 #, fuzzy
-#| msgid "3 minutes"
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 дақиқа"
+msgid "Power Mode"
+msgstr "Анҷоми кор"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:75
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
 #, fuzzy
-#| msgid "4 minutes"
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 дақиқа"
+msgid "Power Saving Options"
+msgstr "Захиракунии барқ"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:79
+#: panels/power/cc-power-panel.ui:126
 #, fuzzy
-#| msgid "5 minutes"
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 дақиқа"
+msgid "Automatic Screen Brightness"
+msgstr "Дурахшонии худкор"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:83
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
 #, fuzzy
-#| msgid "8 minutes"
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 дақиқа"
+msgid "Dim Screen"
+msgstr "Экран"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:87
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
 #, fuzzy
-#| msgid "10 minutes"
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 дақиқа"
+msgid "Screen _Blank"
+msgstr "Хонандаи _экранӣ"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:91
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
 #, fuzzy
-#| msgid "12 minutes"
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 дақиқа"
+msgid "Automatic Power Saver"
+msgstr "_Гузоришдиҳии худкор оид ба мушкилиҳо"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:95
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
 #, fuzzy
-#| msgid "15 minutes"
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 дақиқа"
+msgid "_Automatic Suspend"
+msgstr "Таваққуфи худкор"
 
-#. Translators: Option for "Blank screen" in "Power" panel.
-#: panels/power/cc-power-panel.ui:99
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
 #, fuzzy
-#| msgid "Never"
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Ҳеҷ гоҳ"
+msgid "Po_wer Button Behavior"
+msgstr "Тугмаи пасткунӣ"
 
-#: panels/power/cc-power-panel.ui:147
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Таваққуфи худкор"
 
-#: panels/power/cc-power-panel.ui:172
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "_Васлшуда"
 
-#: panels/power/cc-power-panel.ui:188
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Аз _батарея кор мекунад"
 
-#: panels/power/cc-power-panel.ui:233 panels/power/cc-power-panel.ui:293
-#: panels/universal-access/cc-ua-panel.ui:1507
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Таъхир"
 
@@ -4859,88 +3055,14 @@ msgid "View your battery status and change power saving settings"
 msgstr ""
 "Намоиш додани вазъияти батарея ва тағйир додани танзимоти захиракунии барқ"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 "Барқ;Хоб;Таваққуф;Гибернатсия;Батарея;Дурахшонӣ;Камнур;Холӣ;Монитор;DPMS;"
 "Беҳаракат;"
-
-#: panels/printers/authentication-dialog.ui:11
-msgid " "
-msgstr " "
-
-#: panels/printers/authentication-dialog.ui:42
-msgid "Authenticate"
-msgstr "Санҷиши ҳаққоният"
-
-#. Translators: This is a username on a print server.
-#: panels/printers/authentication-dialog.ui:80
-#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:362
-msgid "Username"
-msgstr "Номи корбар"
-
-#. Translators: This is a password needed for printing.
-#: panels/printers/authentication-dialog.ui:96
-#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:383
-#: panels/user-accounts/cc-add-user-dialog.ui:249
-msgid "Password"
-msgstr "Ниҳонвожа"
-
-#: panels/printers/authentication-dialog.ui:139
-#: panels/printers/new-printer-dialog.ui:337
-msgid "Authentication Required"
-msgstr "Санҷиши ҳаққоният лозим аст"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:715
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr ""
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:938
-msgid "Failed to add new printer."
-msgstr "Иловакунии принтери нав қатъ шуд."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1242
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Интерфейси корбар бор нашуд: %s"
-
-#: panels/printers/details-dialog.ui:64 panels/printers/printer-entry.ui:223
-msgid "Location"
-msgstr "Ҷойгиршавӣ"
-
-#. Translators: Name of column showing printer drivers
-#: panels/printers/details-dialog.ui:114
-#: panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "Драйвер"
-
-#: panels/printers/details-dialog.ui:152
-msgid "Searching for preferred drivers…"
-msgstr "Ҷустуҷӯи драйверҳои мувофиқ…"
-
-#: panels/printers/details-dialog.ui:174
-#, fuzzy
-#| msgid "Search for a city"
-msgid "Search for Drivers"
-msgstr "Ҷустуҷӯи шаҳр"
-
-#: panels/printers/details-dialog.ui:182
-#, fuzzy
-#| msgid "Select from database…"
-msgid "Select from Database…"
-msgstr "Интихоб кардан аз пойгоҳи иттилоотӣ…"
-
-#: panels/printers/details-dialog.ui:190
-#, fuzzy
-#| msgid "Provide PPD File…"
-msgid "Install PPD File…"
-msgstr "Таъмини файли PPD…"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4950,1271 +3072,516 @@ msgstr "Принтерҳо"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "Илова кардани принтерҳо, намоиши вазифаҳои чоп ва тарзи чопкунӣ"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Принтер;Навбат;Чоп кардан;Қоғаз;Ранг;Тюнер;"
 
-#. Translators: This is a windows domain used with SMB protocol.
-#: panels/printers/jobs-dialog.ui:44
-#, fuzzy
-#| msgid "_Domain"
-msgid "Domain"
-msgstr "_Домен"
-
-#. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/jobs-dialog.ui:123
-msgid "A_uthenticate"
-msgstr "_Санҷиши ҳаққоният"
-
-#. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/jobs-dialog.ui:163
-msgid "Clear All"
-msgstr ""
-
-#. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/jobs-dialog.ui:225
-#, fuzzy
-#| msgid "Authenticate"
-msgid "_Authenticate"
-msgstr "Санҷиши ҳаққоният"
-
-#. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/jobs-dialog.ui:354
-#, fuzzy
-#| msgid "%s Active Jobs"
-msgid "No Active Printer Jobs"
-msgstr "%s вазифаи фаъол"
-
 #. Translators: This is the title presented at top of the dialog.
-#: panels/printers/new-printer-dialog.ui:29
-#: panels/printers/pp-new-printer-dialog.c:363
-#: panels/printers/pp-new-printer-dialog.c:427
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "Илова кардани принтер"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:96
-#: panels/printers/new-printer-dialog.ui:111
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr ""
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:211
+#: panels/printers/new-printer-dialog.ui:197
 #, fuzzy
-#| msgid "No Pictures Found"
 msgid "No Printers Found"
 msgstr "Ягон тасвир ёфт нашудааст"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:284
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Суроғаи шабакавиро ворид кунед ё принтерро ҷустуҷӯ кунед"
 
-#: panels/printers/new-printer-dialog.ui:353
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Санҷиши ҳаққоният лозим аст"
+
+#: panels/printers/new-printer-dialog.ui:308
 #, fuzzy
-#| msgid "Enter your username and password to view printers available on %s."
 msgid "Enter username and password to view printers on Print Server."
 msgstr ""
 "Барои намоиш додани принтерҳои дастрас дар %s, шумо бояд номи корбар ва "
 "ниҳонвожаро ворид кунед."
 
-#. Translators: This button triggers the printing of a test page.
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/options-dialog.ui:22 panels/printers/pp-options-dialog.c:907
-#, fuzzy
-#| msgid "Test page"
-msgid "Test Page"
-msgstr "Саҳифаи санҷишӣ"
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Номи корбар"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:133
-#: panels/printers/pp-details-dialog.c:417
-#, fuzzy, c-format
-#| msgid "Details"
-msgid "%s Details"
-msgstr "Тафсилот"
-
-#: panels/printers/pp-details-dialog.c:180
-msgid "No suitable driver found"
-msgstr "Ягон драйвери мувофиқ ёфт нашудааст"
-
-#: panels/printers/pp-details-dialog.c:310
-msgid "Select PPD File"
-msgstr "Интихоби файли PPD"
-
-#: panels/printers/pp-details-dialog.c:319
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"Файлҳои тавсифи принтери PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
-"GZ)"
 
-#: panels/printers/ppd-selection-dialog.ui:10
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Ҷойгиршавӣ"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "Драйвер"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Ҷустуҷӯи драйверҳои мувофиқ…"
+
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "Ҷустуҷӯи шаҳр"
+
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "Интихоб кардан аз пойгоҳи иттилоотӣ…"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Таъмини файли PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
 msgid "Select Printer Driver"
 msgstr "Интихоби драйвери принтер"
 
-#: panels/printers/ppd-selection-dialog.ui:40
-#: panels/user-accounts/cc-avatar-chooser.c:108
-msgid "Select"
-msgstr "Интихоб кардан"
-
-#: panels/printers/ppd-selection-dialog.ui:73
+#: panels/printers/ppd-selection-dialog.ui:75
 #, fuzzy
-#| msgid "Loading drivers database..."
 msgid "Loading drivers database…"
 msgstr "Боркунии пойгоҳи иттилоотии драйверҳо..."
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:472
-msgid "JetDirect Printer"
-msgstr "Принтери JetDirect"
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Бекор кардан"
 
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:707
-msgid "LPD Printer"
-msgstr "Принтери LPD"
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "Интихоб кардан"
 
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:65
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Яктарафа"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:67
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Канори дароз (стандартӣ)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:69
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Канори кӯтоҳ (акскунӣ)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:71
-msgid "Portrait"
-msgstr "Амудӣ"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:73
-msgid "Landscape"
-msgstr "Уфуқӣ"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:75
-msgid "Reverse landscape"
-msgstr "Баръакси уфуқӣ"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:77
-msgid "Reverse portrait"
-msgstr "Баръакси амуди"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-jobs-dialog.c:234
-msgctxt "print job"
-msgid "Pending"
-msgstr "Мунтазир"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-jobs-dialog.c:240
-#, fuzzy
-#| msgid "Last used"
-msgctxt "print job"
-msgid "Paused"
-msgstr "Истифодашудаи охирин"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-jobs-dialog.c:245
-#, fuzzy
-#| msgid "Authentication required"
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Санҷиши ҳаққоният лозим аст"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-jobs-dialog.c:250
-msgctxt "print job"
-msgid "Processing"
-msgstr "Коркард"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-jobs-dialog.c:254
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Манъ шуд"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-jobs-dialog.c:258
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Бекор карда шуд"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-jobs-dialog.c:262
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Қатъшуда"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-jobs-dialog.c:266
-msgctxt "print job"
-msgid "Completed"
-msgstr "Ба анҷом расид"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
-#: panels/printers/pp-jobs-dialog.c:390
+#: panels/printers/pp-jobs-dialog.c:318
 #, fuzzy, c-format
-#| msgid "Server requires authentication"
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "_Сервер санҷиши ҳаққониятро талаб мекунад"
 msgstr[1] "_Сервер санҷиши ҳаққониятро талаб мекунад"
 
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:613
-#, fuzzy, c-format
-#| msgid "%s Active Jobs"
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "_Домен"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "_Санҷиши ҳаққоният"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "Санҷиши ҳаққоният"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
 msgstr "%s вазифаи фаъол"
 
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:617
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr ""
-
-#: panels/printers/pp-new-printer-dialog.c:380
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
 #, fuzzy
-#| msgid "Select Printer Driver"
-msgid "Unlock Print Server"
-msgstr "Интихоби драйвери принтер"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:384
-#, c-format
-msgid "Unlock %s."
-msgstr ""
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:388
-#, fuzzy, c-format
-#| msgid "Enter your username and password to view printers available on %s."
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Барои намоиш додани принтерҳои дастрас дар %s, шумо бояд номи корбар ва "
-"ниҳонвожаро ворид кунед."
-
-#: panels/printers/pp-new-printer-dialog.c:838
-#, fuzzy
-#| msgid "Not searching for networks"
-msgid "Searching for Printers"
-msgstr "Шабакаҳоро ҷустуҷӯ намекунад"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1680
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1685
-msgid "Serial Port"
-msgstr "Порти силсилавӣ"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1692
-msgid "Parallel Port"
-msgstr "Порти мувозӣ"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1734
-#, c-format
-msgid "Location: %s"
-msgstr "Ҷойгиршавӣ: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-msgid "Address: %s"
-msgstr "Суроға: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1766
-msgid "Server requires authentication"
-msgstr "_Сервер санҷиши ҳаққониятро талаб мекунад"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Two Sided"
-msgstr "Дутарафа"
-
-#: panels/printers/pp-options-dialog.c:91
-msgid "Paper Type"
-msgstr "Навъи қоғаз"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "Paper Source"
-msgstr "Манбаи қоғаз"
-
-#: panels/printers/pp-options-dialog.c:93
-msgid "Output Tray"
-msgstr "Қуттии барориш"
-
-#: panels/printers/pp-options-dialog.c:94
-#, fuzzy
-#| msgid "Resolution"
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Возеҳӣ"
-
-#: panels/printers/pp-options-dialog.c:95
-msgid "GhostScript pre-filtering"
-msgstr "Филтркунии пешакии GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:548
-msgid "Pages per side"
-msgstr "Саҳифаҳо дар як тараф"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:560
-msgid "Two-sided"
-msgstr "Дутарафа"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:572
-msgid "Orientation"
-msgstr "Самт"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Умумӣ"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Танзими саҳифа"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:675
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Имконоти насбшаванда"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:678
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Вазифа"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:681
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Сифати тасвир"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:684
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Ранг"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:687
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Ба анҷом расида истоддаст"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:690
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Иловагӣ"
-
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:920
-msgid "Test page"
+msgid "Test Page"
 msgstr "Саҳифаи санҷишӣ"
 
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Интихоб ба таври худкор"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Принтери пешфарз"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Илова кардани танҳо шрифтҳои GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Табдил додан ба сатҳи 1 PS"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Табдил додан ба сатҳи 2 PS"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Ягон филтри пешакӣ нест"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "Истеҳсолкунанда"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:606 panels/printers/printer-entry.ui:166
-#, fuzzy
-#| msgid "Active Jobs"
-msgid "No Active Jobs"
-msgstr "Вазифаҳои фаъол"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:611
+#: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:766
-msgid "Low on toner"
-msgstr "Миқдори тонер паст аст"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:768
-msgid "Out of toner"
-msgstr "Тонер тамом шуд"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:771
-msgid "Low on developer"
-msgstr "Таҳиягар паст аст"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:774
-msgid "Out of developer"
-msgstr "Таҳиягар ба анҷом расид"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:776
-msgid "Low on a marker supply"
-msgstr "Миқдори таъминоти маркер паст аст"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:778
-msgid "Out of a marker supply"
-msgstr "Таъминоти маркер ба анҷом расид"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:780
-msgid "Open cover"
-msgstr "Кушодани сарпӯш"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:782
-msgid "Open door"
-msgstr "Дари кушода"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:784
-msgid "Low on paper"
-msgstr "Миқдори қоғаз паст аст"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:786
-msgid "Out of paper"
-msgstr "Қоғаз тамом шуд"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:788
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Офлайн"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:790
-#: panels/printers/pp-printer-entry.c:918
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Манъ шуд"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:792
-msgid "Waste receptacle almost full"
-msgstr "Махзани партов тақрибан пур аст"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:794
-msgid "Waste receptacle full"
-msgstr "Махзани партов пур аст"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:796
-msgid "The optical photo conductor is near end of life"
-msgstr "Ҳодии оптикии сурат дар вақти наздик аз кор мебарояд"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:798
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Ҳодии оптикии сурат дигар кор намекунад"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:904
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Тайёр"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:909
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Корҳоро қабул намекунад"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:914
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Коркард"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:938
-msgid "Clean print heads"
-msgstr ""
-
-#: panels/printers/printer-entry.ui:14
+#: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
 msgstr "Имконоти чопкунӣ"
 
-#: panels/printers/printer-entry.ui:26
+#: panels/printers/printer-entry.ui:29
 msgid "Printer Details"
 msgstr "Тафсилоти принтер"
 
 #. Set this printer as default
-#: panels/printers/printer-entry.ui:38
+#: panels/printers/printer-entry.ui:40
 #, fuzzy
-#| msgid "Printer Default"
 msgid "Use Printer by Default"
 msgstr "Принтери пешфарз"
 
 #. Translators: This button executes command which cleans print heads of the printer.
-#: panels/printers/printer-entry.ui:50
+#: panels/printers/printer-entry.ui:52
 #, fuzzy
-#| msgid "Cancel Print Job"
 msgid "Clean Print Heads"
 msgstr "Бекор кардани кори принтер"
 
-#: panels/printers/printer-entry.ui:61
+#: panels/printers/printer-entry.ui:62
 msgid "Remove Printer"
 msgstr "Тоза кардани принтер"
 
-#: panels/printers/printer-entry.ui:193
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "Вазифаҳои фаъол"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Намуна"
 
-#: panels/printers/printer-entry.ui:251
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Сатҳи ранг"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:312
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr ""
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:319
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Бозоғозӣ кардан"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:20
-msgid "Add…"
-msgstr ""
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "Илова кардани принтер…"
 
-#: panels/printers/printers.ui:186
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Илова кардани принтер…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Ягон принтер нест"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:200
-msgid "Add a Printer…"
-msgstr "Илова кардани принтер…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:232
+#: panels/printers/printers.ui:209
 #, fuzzy
-#| msgid ""
-#| "Sorry! The system printing service\n"
-#| "doesn't seem to be available."
 msgid ""
 "Sorry! The system printing service\n"
-"doesn’t seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "Мутаассифона, хидмати низоми чоп\n"
 "дар айни ҳол дастнорас аст."
 
-#: panels/privacy/cc-privacy-panel.c:423 panels/privacy/cc-privacy-panel.ui:280
-msgid "Screen Lock"
-msgstr "Экрани қулф"
-
-#: panels/privacy/cc-privacy-panel.c:467
-msgid "In use"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.c:472
-#, fuzzy
-#| msgid "On"
-msgctxt "Location services status"
-msgid "On"
-msgstr "Фаъол"
-
-#: panels/privacy/cc-privacy-panel.c:473
-#, fuzzy
-#| msgid "Off"
-msgctxt "Location services status"
-msgid "Off"
-msgstr "Хомӯш"
-
-#: panels/privacy/cc-privacy-panel.c:895
-#, fuzzy
-#| msgid "Off"
-msgctxt "Camera status"
-msgid "Off"
-msgstr "Хомӯш"
-
-#: panels/privacy/cc-privacy-panel.c:897
-#, fuzzy
-#| msgid "On"
-msgctxt "Camera status"
-msgid "On"
-msgstr "Фаъол"
-
-#: panels/privacy/cc-privacy-panel.c:928
-#, fuzzy
-#| msgid "Off"
-msgctxt "Microphone status"
-msgid "Off"
-msgstr "Хомӯш"
-
-#: panels/privacy/cc-privacy-panel.c:930
-#, fuzzy
-#| msgid "On"
-msgctxt "Microphone status"
-msgid "On"
-msgstr "Фаъол"
-
-#: panels/privacy/cc-privacy-panel.c:1036
-#: panels/privacy/cc-privacy-panel.ui:127
-msgid "Usage & History"
-msgstr "Истифодабарӣ ва таърих"
-
-#: panels/privacy/cc-privacy-panel.c:1157
-msgid "Empty all items from Trash?"
-msgstr "Ҳамаи объектҳои сабадро бебозгашт нест мекунед?"
-
-#: panels/privacy/cc-privacy-panel.c:1158
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Ҳамаи объектҳои сабад бебозгашт нест карда мешаванд."
-
-#: panels/privacy/cc-privacy-panel.c:1159
-msgid "_Empty Trash"
-msgstr "_Холӣ кардани сабад"
-
-#: panels/privacy/cc-privacy-panel.c:1180
-msgid "Delete all the temporary files?"
-msgstr "Ҳамаи файлҳои муваққатиро нест мекунед?"
-
-#: panels/privacy/cc-privacy-panel.c:1181
-msgid "All the temporary files will be permanently deleted."
-msgstr "Ҳамаи файлҳои муваққатӣ бебозгашт нест карда мешаванд."
-
-#: panels/privacy/cc-privacy-panel.c:1182
-msgid "_Purge Temporary Files"
-msgstr "_Пок кардани файлҳои муваққатӣ"
-
-#: panels/privacy/cc-privacy-panel.c:1204
-#: panels/privacy/cc-privacy-panel.ui:432
-msgid "Purge Trash & Temporary Files"
-msgstr "Пок кардани сабад ва файлҳои муваққатӣ"
-
-#: panels/privacy/cc-privacy-panel.c:1237
-#: panels/privacy/cc-privacy-panel.ui:637
-msgid "Software Usage"
-msgstr "Истифодаи нармафзор"
-
-#: panels/privacy/cc-privacy-panel.c:1276
-#: panels/privacy/cc-privacy-panel.ui:1169
-msgid "Problem Reporting"
-msgstr "Гузориш дар бораи мушкилиҳо"
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: panels/privacy/cc-privacy-panel.c:1288
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-"Фиристодани гузоришҳо дар бораи мушкилиҳои техникӣ барои кумаки такмилдиҳии "
-"%s. Гузоришҳо ба тавримахфӣ фиристода мешаванд ва маълумоти шахсиро дар бар "
-"намегиранд."
-
-#: panels/privacy/cc-privacy-panel.c:1300
-#: panels/privacy/cc-privacy-panel.ui:719
-msgid "Privacy Policy"
-msgstr "Сиёсати махфият"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:14
-#, fuzzy
-#| msgid "Screen Turns Off"
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Экран хомӯш мешавад"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:18
-#, fuzzy
-#| msgid "30 seconds"
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 сония"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:22
-#, fuzzy
-#| msgid "1 minute"
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 дақиқа"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:26
-#, fuzzy
-#| msgid "2 minutes"
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 дақиқа"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:30
-#, fuzzy
-#| msgid "3 minutes"
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 дақиқа"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:34
-#, fuzzy
-#| msgid "5 minutes"
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 дақиқа"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:38
-#, fuzzy
-#| msgid "30 minutes"
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 дақиқа"
-
-#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
-#: panels/privacy/cc-privacy-panel.ui:42
-#, fuzzy
-#| msgid "1 hour"
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 соат"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:56
-#, fuzzy
-#| msgid "1 hour"
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 соат"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:60
-#, fuzzy
-#| msgid "1 day"
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 рӯз"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:64
-#, fuzzy
-#| msgid "2 days"
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 рӯз"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:68
-#, fuzzy
-#| msgid "3 days"
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 рӯз"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:72
-#, fuzzy
-#| msgid "4 days"
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 рӯз"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:76
-#, fuzzy
-#| msgid "5 days"
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 рӯз"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:80
-#, fuzzy
-#| msgid "6 days"
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 рӯз"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:84
-#, fuzzy
-#| msgid "7 days"
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 рӯз"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:88
-#, fuzzy
-#| msgid "14 days"
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 рӯз"
-
-#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
-#: panels/privacy/cc-privacy-panel.ui:92
-#, fuzzy
-#| msgid "30 days"
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 рӯз"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/privacy/cc-privacy-panel.ui:106
-#, fuzzy
-#| msgid "1 day"
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 рӯз"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/privacy/cc-privacy-panel.ui:110
-#, fuzzy
-#| msgid "7 days"
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 рӯз"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/privacy/cc-privacy-panel.ui:114
-#, fuzzy
-#| msgid "30 days"
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 рӯз"
-
-#. Translators: Option for "Retain History" in "Usage & History" dialog.
-#: panels/privacy/cc-privacy-panel.ui:118
-#, fuzzy
-#| msgid "Forever"
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Ҳамеша"
-
-#: panels/privacy/cc-privacy-panel.ui:148
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"Дар ёд доштани таърихи шумо ёфтани дубораи чизҳоро осон мегардонад. Ин "
-"объектҳо ягон вақт дар шабака мубодила намешаванд."
-
-#: panels/privacy/cc-privacy-panel.ui:176
-msgid "_Recently Used"
-msgstr "_Истифодашудаи охирин"
-
-#: panels/privacy/cc-privacy-panel.ui:207
-msgid "Retain _History"
-msgstr "Нигоҳ доштани _таърих"
-
-#: panels/privacy/cc-privacy-panel.ui:247
-msgid "Cl_ear Recent History"
-msgstr "_Пок кардани таърихи қаблӣ"
-
-#: panels/privacy/cc-privacy-panel.ui:301
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr ""
-"Қулфи экран ҳангоми мавҷуд набудани шумо махфияти шуморо муҳофизат мекунад."
-
-#: panels/privacy/cc-privacy-panel.ui:328
-msgid "Automatic Screen _Lock"
-msgstr "Қулфи экрани _худкор"
-
-#: panels/privacy/cc-privacy-panel.ui:362
-msgid "Lock screen _after blank for"
-msgstr "Қулф кардани экран _баъд аз холӣ дар давоми"
-
-#: panels/privacy/cc-privacy-panel.ui:394
-#, fuzzy
-#| msgid "Lock Screen Notifications"
-msgid "Lock Screen _Notifications"
-msgstr "Огоҳиҳои экрани қулф"
-
-#: panels/privacy/cc-privacy-panel.ui:454
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"Тоза кардани сабад ва файлҳои муваққатӣ ба таври худкор барои нигоҳ доштани "
-"компютер бе иттилооти нодаркор."
-
-#: panels/privacy/cc-privacy-panel.ui:483
-msgid "Automatically empty _Trash"
-msgstr "Холӣ кардани сабад _ба таври худкор"
-
-#: panels/privacy/cc-privacy-panel.ui:515
-msgid "Automatically purge Temporary _Files"
-msgstr "Холӣ кардани файлҳои _муваққатӣ ба таври худкор"
-
-#: panels/privacy/cc-privacy-panel.ui:546
-msgid "Purge _After"
-msgstr "Пок кардан _баъд аз"
-
-#: panels/privacy/cc-privacy-panel.ui:590
-#, fuzzy
-#| msgid "_Empty Trash"
-msgid "_Empty Trash…"
-msgstr "_Холӣ кардани сабад"
-
-#: panels/privacy/cc-privacy-panel.ui:606
-#, fuzzy
-#| msgid "_Purge Temporary Files"
-msgid "_Purge Temporary Files…"
-msgstr "_Пок кардани файлҳои муваққатӣ"
-
-#: panels/privacy/cc-privacy-panel.ui:654
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"Бо ирсолкунии иттилоот дар бораи истифодаи нармафзор шумо ба мо кумак "
-"мерасонед, то ки мо тавонем ба шумо тавсияҳои дақиқро таъмин намоем. "
-"Иттилооти ирсолшуда инчунин барои беҳтаркунии нармафзори мо кумак "
-"мерасонад.\n"
-"\n"
-"Ҳамаи иттилооти ҷамъшуда маълумоти шахсии шуморо дар бар намегирад ва бо "
-"тарафҳои сеюм ҳеҷ гоҳ мубодила намешавад."
-
-#: panels/privacy/cc-privacy-panel.ui:681
-msgid "_Send software usage statistics"
-msgstr "_Фиристодани омори истифодаи нармафзор"
-
-#: panels/privacy/cc-privacy-panel.ui:764
-msgid ""
-"Use of the camera allows applications to capture photos and video. Disabling "
-"the camera may cause some applications to not function properly."
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.ui:812
-#, fuzzy
-#| msgid "%s Camera"
-msgid "_Camera"
-msgstr "Камераи %s"
-
-#: panels/privacy/cc-privacy-panel.ui:869
-msgid ""
-"Use of the microphone allows applications to capture sounds. Disabling the "
-"microphone may cause some applications to not function properly."
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.ui:917
-msgid "_Microphone"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.ui:974
-msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.ui:988
-msgid ""
-"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
-"com/privacy'>Privacy Policy</a>"
-msgstr ""
-
-#: panels/privacy/cc-privacy-panel.ui:1038
-msgid "_Location Services"
-msgstr "_Хидматҳои ҷойгиршавӣ"
-
-#: panels/privacy/cc-privacy-panel.ui:1236
-msgid "_Automatic Problem Reporting"
-msgstr "_Гузоришдиҳии худкор оид ба мушкилиҳо"
-
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:3
-msgid "Privacy"
-msgstr "Махфият"
-
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
-msgid "Protect your personal information and control what others might see"
-msgstr ""
-"Иттилооти шахсиро муҳофизат кунед ва идора кунед, ки дигарон чиро дида "
-"метавонанд"
-
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: panels/privacy/gnome-privacy-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr ""
-"экран;қулф;ташхис;вайронӣ;махфӣ;қаблӣ;муваққатӣ;tmp;индекс;ном;шабака;"
-"шахсият;"
-
-#: panels/region/cc-format-chooser.c:114
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Империягӣ"
-
-#: panels/region/cc-format-chooser.c:116
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Метрӣ"
-
-#: panels/region/cc-format-chooser.c:286
-msgid "No regions found"
-msgstr "Ягон минтақа ёфт нашуд"
-
-#: panels/region/cc-format-chooser.ui:7
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Форматҳо"
 
-#: panels/region/cc-format-chooser.ui:106
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "Ҷустуҷӯи ҷойгиршавӣ"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "Форматҳо"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Форматҳо"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "Ягон минтақа ёфт нашуд"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Пешнамоиш"
 
-#: panels/region/cc-format-chooser.ui:123
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "Санаҳо"
 
-#: panels/region/cc-format-chooser.ui:154
-msgid "Times"
-msgstr "Вақтҳо"
-
-#: panels/region/cc-format-chooser.ui:185
+#: panels/region/cc-format-preview.ui:53
 #, fuzzy
-#| msgid "Date & Time"
 msgid "Dates & Times"
 msgstr "Сана ва Вақт"
 
-#: panels/region/cc-format-chooser.ui:216
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "Рақамҳо"
 
-#: panels/region/cc-format-chooser.ui:233
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "Ченак"
 
-#: panels/region/cc-format-chooser.ui:250
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "Қоғаз"
 
-#: panels/region/cc-input-chooser.c:193
-msgid "No input sources found"
-msgstr "Ягон манбаи вуруд ёфт нашудааст"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#: panels/region/cc-input-chooser.c:948
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Дигар"
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
 
-#: panels/region/cc-input-chooser.ui:5
-msgid "Add an Input Source"
-msgstr "Илова кардани манбаи вуруд"
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#: panels/region/cc-input-chooser.ui:77
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 #, fuzzy
-#| msgid "Input methods can't be used on the login screen"
-msgid "Input methods can’t be used on the login screen"
-msgstr "Усулҳои вуруд наметавонанд дар экрани воридшавӣ истифода шаванд"
+msgid "Your Account"
+msgstr "Ҳисоби шумо"
 
-#: panels/region/cc-region-panel.c:1503
-#, fuzzy
-#| msgid "Login Screen"
-msgid "Login _Screen"
-msgstr "Экрани воридшавӣ"
-
-#: panels/region/cc-region-panel.ui:64
-#: panels/user-accounts/cc-user-panel.ui:362
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Забон"
 
-#: panels/region/cc-region-panel.ui:99
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 #, fuzzy
-#| msgid "Your session needs to be restarted for changes to take effect"
-msgid "Restart the session for changes to take effect"
-msgstr "Барои татбиқ кардани тағйирот шумо бояд низомро бозоғозӣ кунед"
-
-#: panels/region/cc-region-panel.ui:114
-#, fuzzy
-#| msgid "Restart Now"
-msgid "Restart…"
-msgstr "Ҳозир бозоғозӣ кардан"
-
-#: panels/region/cc-region-panel.ui:147
-#, fuzzy
-#| msgid "Formats"
 msgid "_Formats"
 msgstr "Форматҳо"
 
-#: panels/region/cc-region-panel.ui:195
-msgid "Input Sources"
-msgstr "Манбаҳои вуруд"
-
-#: panels/region/cc-region-panel.ui:209
-msgid "Choose keyboard layouts or input methods."
-msgstr ""
-
-#: panels/region/cc-region-panel.ui:266
-msgid "No input source selected"
-msgstr "Ягон манбаи вуруд интихоб нашудааст"
-
-#: panels/region/cc-region-panel.ui:300
-msgid "Login settings are used by all users when logging into the system"
-msgstr ""
-"Танзимоти воридшавӣ бо ҳамаи корбарон ҳангоми воридшавӣ ба низом истифода "
-"мешаванд"
-
-#: panels/region/cc-region-panel.ui:338
-msgid "Input Source Options"
-msgstr "Имконоти манбаи вуруд"
-
-#: panels/region/cc-region-panel.ui:353
-msgid "Use the _same source for all windows"
-msgstr "Истифода бурдани манбаи _якхела барои ҳамаи равзанаҳо"
-
-#: panels/region/cc-region-panel.ui:371
-msgid "Allow _different sources for each window"
-msgstr "Иҷозат додани _манбаҳои гуногун барои ҳар як равзана"
-
-#: panels/region/cc-region-panel.ui:413
+#: panels/region/cc-region-panel.ui:113
 #, fuzzy
-#| msgid "Previous track"
-msgid "Previous source"
-msgstr "Пайгирии қаблӣ"
-
-#: panels/region/cc-region-panel.ui:431
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Фосила"
-
-#: panels/region/cc-region-panel.ui:446
-#, fuzzy
-#| msgid "Resources"
-msgid "Next source"
-msgstr "Захираҳо"
-
-#: panels/region/cc-region-panel.ui:464
-msgid "Super+Space"
-msgstr "Super+Фосила"
-
-#: panels/region/cc-region-panel.ui:479
-msgid "Left+Right Alt"
-msgstr "Alt-и рост + чап"
-
-#: panels/region/cc-region-panel.ui:495
-#, fuzzy
-#| msgid "You can change these shortcuts in the keyboard settings"
-msgid "These keyboard shortcuts can be changed in the keyboard settings"
-msgstr "Шумо метавонед ин миёнбурҳоро дар танзимоти клавиатура тағйир диҳед"
+msgid "Login Screen"
+msgstr "Экрани воридшавӣ"
 
 #: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "Забон ва минтақа"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
+#, fuzzy
+msgid "Select your display language and formats"
 msgstr ""
 "Интихоби забони интерфейс, форматҳо, тарҳбандии клавиатураҳо ва манбаҳои "
 "вуруд"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Забон;Тарҳбандӣ;Клавиатура;Вуруд;"
 
-#: panels/search/cc-search-locations-dialog.c:604
-msgid "Select Location"
-msgstr "Интихоби ҷойгиршавӣ"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Интихоби тарзи истифодаи медиа"
 
-#: panels/search/cc-search-locations-dialog.c:608
-msgid "_OK"
-msgstr "_OK"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "Аудиои _CD"
 
-#: panels/search/cc-search-panel.c:175
-msgid "No applications found"
-msgstr "Ягон барнома ёфт нашуд"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "Видеои _DVD"
 
-#: panels/search/cc-search-panel.ui:52
-msgid "Move Up"
-msgstr "Ба боло"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Плеери мусиқӣ"
 
-#: panels/search/cc-search-panel.ui:69
-msgid "Move Down"
-msgstr "Ба поён"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Нармафзор"
 
-#: panels/search/cc-search-panel.ui:105
-msgid "Preferences"
-msgstr "Хусусиятҳо"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Мултимедиаи дигар…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Ҳеҷ гоҳ огоҳ надодан ва оғоз накардани барномаҳо ҳангоми дарҷкунии медиа"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Интихоби тарзи истифодаи медиаи дигар"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Амал:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Навъ:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Медиаи ҷудошаванда"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "Медиаи ҷудошаванда"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"дастгоҳ;низом;иттилоот;ҳофиза;просессор;версия;пешфарз;барнома;пазируфта;cd;"
+"dvd;usb;аудио;видео;диск;ҷқдошаванда;медиа;иҷрои худкор;"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Экрани қулф"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "_Экрани холӣ"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Қулфи экрани _худкор"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "Қулфи экрани _худкор"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Намоиш додани огоҳиҳо"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Экрани қулф"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Махфият"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Экран"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Танзимоти садо"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Ҷустуҷӯи ҷойгиршавӣ"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
+msgid "Places"
+msgstr "Ҷойҳо"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
+msgid "Bookmarks"
+msgstr "Хатбаракҳо"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Дигар"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Ҷойгиршавӣ"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Барномаҳо"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Ҷустуҷӯи ҷойгиршавӣ"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
 
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
@@ -6223,220 +3590,148 @@ msgstr ""
 "Идора кунед, ки кадом барномаҳо натиҷаҳои ҷустуҷӯро дар хулосаи фаъолият "
 "намоиш медиҳанд"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Ҷустуҷӯ;Ёфтан;Индекс;Пинҳон кардан;Махфият;Натиҷаҳо;"
 
-#: panels/search/search-locations-dialog.ui:9
-msgid "Search Locations"
-msgstr "Ҷустуҷӯи ҷойгиршавӣ"
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Шабакаҳо"
 
-#: panels/search/search-locations-dialog.ui:43
-#, fuzzy
-#| msgctxt "Search Location"
-#| msgid "Places"
-msgid "Places"
-msgstr "Ҷойҳо"
-
-#: panels/search/search-locations-dialog.ui:73
-#, fuzzy
-#| msgctxt "Search Location"
-#| msgid "Bookmarks"
-msgid "Bookmarks"
-msgstr "Хатбаракҳо"
-
-#: panels/search/search-locations-dialog.ui:130
-#, fuzzy
-#| msgctxt "Online Account"
-#| msgid "Other"
-msgid "Other"
-msgstr "Дигар"
-
-#. Label
-#: panels/sharing/cc-sharing-networks.c:307
-msgid "No networks selected for sharing"
-msgstr "Барои мубодила ягон шабака интихоб карда нашуд"
-
-#: panels/sharing/cc-sharing-panel.c:319
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Фаъол"
-
-#: panels/sharing/cc-sharing-panel.c:321 panels/sharing/cc-sharing-panel.c:348
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Хомӯш"
-
-#: panels/sharing/cc-sharing-panel.c:351
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Фаъолшуда"
-
-#: panels/sharing/cc-sharing-panel.c:354
-msgctxt "service is active"
-msgid "Active"
-msgstr "Фаъол"
-
-#: panels/sharing/cc-sharing-panel.c:424
-msgid "Choose a Folder"
-msgstr "Интихоб кардани ҷузвдон"
-
-#: panels/sharing/cc-sharing-panel.c:724
-#, fuzzy, c-format
-#| msgid ""
-#| "Personal File Sharing allows you to share your Public folder with others "
-#| "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr ""
-"Дастрасии муштараки файлҳои шахсӣ ба шумо имкон медиҳад, ки ҷузвдони \"Оммавӣ"
-"\"-и худро бо дигарон дар шабакаи ҷории худ тавассути зерин мебодила кунед: "
-"<a href=\"dav://%s\">dav://%s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:726
-#, fuzzy, c-format
-#| msgid ""
-#| "Allow remote users to connect using the Secure Shell command:\n"
-#| "<a href=\"ssh %s\">ssh %s</a>"
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"Ба корбарони дурдаст иҷозат диҳед, ки тавонанд барои пайваст шудан фармони "
-"Secure Shell-ро истифода баранд:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:728
-#, fuzzy, c-format
-#| msgid ""
-#| "Allow remote users to view or control your screen by connecting to: <a "
-#| "href=\"vnc://%s\">vnc://%s</a>"
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"Ба корбарони дурдаст иҷозат диҳед, ки тавонанд экрани шуморо бинанд ё идора "
-"кунанд (тавассути): <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: panels/sharing/cc-sharing-panel.c:832
-msgid "Copy"
-msgstr "Нусха бардоштан"
-
-#: panels/sharing/cc-sharing-panel.c:1285
+#: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "Дастрасии муштарак"
 
-#: panels/sharing/cc-sharing-panel.ui:34
+#: panels/sharing/cc-sharing-panel.ui:31
 #, fuzzy
-#| msgid "Computer Name"
 msgid "_Computer Name"
 msgstr "Номи компютер"
 
-#: panels/sharing/cc-sharing-panel.ui:94
+#: panels/sharing/cc-sharing-panel.ui:58
 #, fuzzy
-#| msgid "Personal File Sharing"
 msgid "_File Sharing"
 msgstr "Мубодилаи файлҳои шахсӣ"
 
-#: panels/sharing/cc-sharing-panel.ui:139
+#: panels/sharing/cc-sharing-panel.ui:65
 #, fuzzy
-#| msgid "Screen Sharing"
-msgid "_Screen Sharing"
-msgstr "Мубодилаи экран"
+msgid "Remote _Desktop"
+msgstr "Намоиши дурдаст"
 
-#: panels/sharing/cc-sharing-panel.ui:184
+#: panels/sharing/cc-sharing-panel.ui:72
 #, fuzzy
-#| msgid "Media Sharing"
 msgid "_Media Sharing"
 msgstr "Мубодилакунии медиа"
 
-#: panels/sharing/cc-sharing-panel.ui:229
+#: panels/sharing/cc-sharing-panel.ui:79
 #, fuzzy
-#| msgid "Remote Login"
 msgid "_Remote Login"
 msgstr "Воридшавии дурдаст"
 
-#: panels/sharing/cc-sharing-panel.ui:268
-msgid "Some services are disabled because of no network access."
-msgstr ""
-"Аз сабаби мавҷуд набудани дастрасии шабакавӣ, баъзе хидматҳо ғайрифаъол "
-"карда шудаанд."
-
-#: panels/sharing/cc-sharing-panel.ui:286
-#: panels/sharing/cc-sharing-panel.ui:413
+#: panels/sharing/cc-sharing-panel.ui:92
 #, fuzzy
-#| msgid "Sharing"
 msgid "File Sharing"
 msgstr "Дастрасии муштарак"
 
-#: panels/sharing/cc-sharing-panel.ui:333
+#: panels/sharing/cc-sharing-panel.ui:138
 #, fuzzy
-#| msgid "Require Password"
 msgid "_Require Password"
 msgstr "Ниҳонвожа ҳатмист"
 
-#: panels/sharing/cc-sharing-panel.ui:424
-#: panels/sharing/cc-sharing-panel.ui:496
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "Воридшавии дурдаст"
 
-#: panels/sharing/cc-sharing-panel.ui:519
-#: panels/sharing/cc-sharing-panel.ui:765
-msgid "Screen Sharing"
-msgstr "Мубодилаи экран"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Намоиши дурдаст"
 
-#: panels/sharing/cc-sharing-panel.ui:577
-msgid "_Allow connections to control the screen"
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:622
+#: panels/sharing/cc-sharing-panel.ui:271
 #, fuzzy
-#| msgid "_Password"
-msgid "_Password:"
-msgstr "_Ниҳонвожа"
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Фаъол ё ғайрифаъол кардани воридшавии дурдаст"
 
-#: panels/sharing/cc-sharing-panel.ui:652
+#: panels/sharing/cc-sharing-panel.ui:284
 #, fuzzy
-#| msgid "Show Password"
-msgid "_Show Password"
-msgstr "Намоиш додани ниҳонвожа"
+msgid "Remote Control"
+msgstr "Иҷозати идоракунии дурдаст"
 
-#: panels/sharing/cc-sharing-panel.ui:683
-msgid "Access Options"
-msgstr "Имконоти дастрсӣ"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: panels/sharing/cc-sharing-panel.ui:697
+#: panels/sharing/cc-sharing-panel.ui:299
 #, fuzzy
-#| msgid "New connections must ask for access"
-msgid "_New connections must ask for access"
-msgstr "Пайвастҳои нав бояд барои дастрасӣ иҷозатро дархост кунанд"
+msgid "How to Connect"
+msgstr "Пайваст нашудааст"
 
-#: panels/sharing/cc-sharing-panel.ui:715
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Нусха бардоштан"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 #, fuzzy
-#| msgid "Require a password"
-msgid "_Require a password"
-msgstr "Ниҳонвожа лозим аст"
+msgid "Remote Desktop Address"
+msgstr "Нест кардани суроға"
 
-#: panels/sharing/cc-sharing-panel.ui:776
-#: panels/sharing/cc-sharing-panel.ui:870
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Санҷиши ҳаққоният"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Номи корбар"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "Қайдкунии нақши ангуштон"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
 msgstr "Мубодилакунии медиа"
 
-#: panels/sharing/cc-sharing-panel.ui:809
+#: panels/sharing/cc-sharing-panel.ui:489
 #, fuzzy
-#| msgid ""
-#| "Media sharing allows you to share music, photos and videos over the "
-#| "network."
 msgid "Share music, photos and videos over the network."
 msgstr ""
 "Мубодилаи медиа ба шумо барои мубодила кардани мусиқӣ, суратҳо ва видеоҳо "
 "тавассути шабака имкон медиҳад."
 
-#: panels/sharing/cc-sharing-panel.ui:824
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "Ҷузвдонҳо"
 
@@ -6444,22 +3739,14 @@ msgstr "Ҷузвдонҳо"
 msgid "Control what you want to share with others"
 msgstr "Идора кунед, ки шумо бо дигарон чиро мубодила мекунед"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 #, fuzzy
-#| msgid ""
-#| "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;"
-#| "video;pictures;photos;movies;server;renderer;"
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
 "movies;server;renderer;"
 msgstr ""
 "мубодила кардан;дастрасии муштарак;ssh;мизбон;ном;дурдаст;мизи корӣ;"
 "bluetooth;obex;медиа;аудио;видео;тасвирҳо;суратҳо;филмҳо;сервер;пардозанда;"
-
-#: panels/sharing/networks.ui:19
-msgid "Networks"
-msgstr "Шабакаҳо"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
@@ -6470,122 +3757,106 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Барои фаъол ё ғайрифаъол кардани вуруди дурдаст, санҷиши ҳаққоният лозим аст"
 
-#: panels/sound/cc-alert-chooser.c:151
-msgid "Custom"
-msgstr "Иловагӣ"
-
-#: panels/sound/cc-alert-chooser.ui:12 panels/sound/cc-alert-selector.ui:9
-msgid "Bark"
-msgstr "Ав-ав"
-
-#: panels/sound/cc-alert-chooser.ui:19 panels/sound/cc-alert-selector.ui:15
-msgid "Drip"
-msgstr "Қатра"
-
-#: panels/sound/cc-alert-chooser.ui:26 panels/sound/cc-alert-selector.ui:21
-msgid "Glass"
-msgstr "Шиша"
-
-#: panels/sound/cc-alert-chooser.ui:33 panels/sound/cc-alert-selector.ui:27
-msgid "Sonar"
-msgstr "Садоӣ"
-
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-alert-chooser.ui:12
 #, fuzzy
-#| msgctxt "balance"
-#| msgid "Rear"
-msgid "Rear"
-msgstr "Пушт"
+msgid "Click"
+msgstr "Flickr"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-alert-chooser.ui:20
 #, fuzzy
-#| msgctxt "balance"
-#| msgid "Front"
-msgid "Front"
-msgstr "Пеш"
+msgid "String"
+msgstr "Дастрасии муштарак"
 
-#: panels/sound/cc-output-test-dialog.c:134
-#, fuzzy, c-format
-#| msgid "Settings"
-msgid "Testing %s"
-msgstr "Танзимот"
-
-#: panels/sound/cc-output-test-dialog.ui:127
-msgid "Click a speaker to test"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
 msgstr ""
 
-#: panels/sound/cc-sound-panel.ui:29
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
 #, fuzzy
-#| msgid "System Sounds"
-msgid "System Volume"
-msgstr "Овозҳои низом"
-
-#: panels/sound/cc-sound-panel.ui:45
-#, fuzzy
-#| msgid "Volume mute"
-msgid "Volume Levels"
-msgstr "Бесадо кардан"
-
-#: panels/sound/cc-sound-panel.ui:67
-msgid "Output"
-msgstr "Барориш"
-
-#: panels/sound/cc-sound-panel.ui:94
-#, fuzzy
-#| msgid "_Output volume:"
-msgid "Output Device"
-msgstr "_Баландии садои барориш:"
-
-#: panels/sound/cc-sound-panel.ui:117
-msgid "Test"
-msgstr "Санҷиш"
-
-#: panels/sound/cc-sound-panel.ui:148 panels/sound/cc-sound-panel.ui:325
-msgid "Configuration"
-msgstr "Танзимот"
-
-#: panels/sound/cc-sound-panel.ui:181
-#, fuzzy
-#| msgid "_Balance:"
 msgid "Balance"
 msgstr "_Мувозина:"
 
-#: panels/sound/cc-sound-panel.ui:208
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
 #, fuzzy
-#| msgid "_Fade:"
 msgid "Fade"
 msgstr "_Шаффофӣ:"
 
-#: panels/sound/cc-sound-panel.ui:235
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
+msgid "Rear"
+msgstr "Пушт"
+
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
+msgid "Front"
+msgstr "Пеш"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Овозҳои низом"
+
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Овозҳои низом"
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Бесадо кардан"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Барориш"
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "_Баландии садои барориш:"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Санҷиш"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Танзимот"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Динамики паст-басомадӣ"
 
-#: panels/sound/cc-sound-panel.ui:257
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Вуруд"
 
-#: panels/sound/cc-sound-panel.ui:284
+#: panels/sound/cc-sound-panel.ui:235
 #, fuzzy
-#| msgid "Input level:"
 msgid "Input Device"
 msgstr "Сатҳи вуруд:"
 
-#: panels/sound/cc-sound-panel.ui:358
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 #, fuzzy
-#| msgid "Volume up"
 msgid "Volume"
 msgstr "Баланд кардан"
 
-#: panels/sound/cc-sound-panel.ui:380
+#: panels/sound/cc-sound-panel.ui:327
 #, fuzzy
-#| msgid "_Alert volume:"
 msgid "Alert Sound"
 msgstr "_Баландии садои огоҳӣ:"
 
-#: panels/sound/cc-volume-slider.c:178
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6595,196 +3866,70 @@ msgstr "Садо"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Тағйир додани сатҳи садо, вурудҳо, бароришҳо ва садоҳои огоҳӣ"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+#, fuzzy
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr "Корт;Микрофон;Ҳаҷм;Шаффофӣ;Баланс;Bluetooth;Гӯшмонак;Аудио;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:94
-#: panels/thunderbolt/cc-bolt-device-entry.c:125
-#, fuzzy
-#| msgid "Disconnecting"
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Пайваст қатъ шуда истодааст"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:97
-#: panels/thunderbolt/cc-bolt-device-entry.c:128
-#, fuzzy
-#| msgid "Connecting"
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Пайваст шуда истодааст"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:100
-#: panels/thunderbolt/cc-bolt-device-entry.c:132
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-#, fuzzy
-#| msgid "Connected"
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Пайвастшуда"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:103
-#, fuzzy
-#| msgid "Authentication required"
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Санҷиши ҳаққоният лозим аст"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:106
-#: panels/thunderbolt/cc-bolt-device-entry.c:138
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:115
-#, fuzzy
-#| msgid "Connected Devices"
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Дастгоҳҳои пайвастшуда"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:121
-#: panels/thunderbolt/cc-bolt-device-entry.c:152
-#, fuzzy
-#| msgid "Unknown"
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Номаълум"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:177
-msgid "Authorized at:"
-msgstr ""
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:183
-#, fuzzy
-#| msgid "Connected"
-msgid "Connected at:"
-msgstr "Пайвастшуда"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:190
-#, fuzzy
-#| msgid "_Enroll"
-msgid "Enrolled at:"
-msgstr "_Илова кардан"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:264
-#, fuzzy
-#| msgid "Failed to upload file: %s"
-msgid "Failed to authorize device: "
-msgstr "Боркунии файл қатъ шуд: %s"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:333
-#, fuzzy
-#| msgid "Failed to upload file: %s"
-msgid "Failed to forget device: "
-msgstr "Боркунии файл қатъ шуд: %s"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Огоҳиҳо"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Ном:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Вазъият:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 #, fuzzy
-#| msgid "Automatic _Connect"
 msgid "Authorize and Connect"
 msgstr "Паёвасти _худкор"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Дастгоҳро аз руйхат комилан тоза намоед"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:135
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
 #, fuzzy
-#| msgid "Mirror"
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Оина"
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Ба домени %s пайваст нашуд: %s"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:146
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 #, fuzzy
-#| msgid "Authenticated"
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Ҳаққоният санҷида шуд"
-
-#: panels/thunderbolt/cc-bolt-panel.c:176
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:469
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:513
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.c:517
-#, fuzzy
-#| msgid "The profile could not be generated."
-msgid "Thunderbolt security level could not be determined."
-msgstr "Профил эҷод карда нашуд."
-
-#: panels/thunderbolt/cc-bolt-panel.c:622
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:143
-msgid "No Thunderbolt support"
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:246
-#, fuzzy
-#| msgid "Universal Access"
 msgid "Direct Access"
 msgstr "Дастрасии умумӣ"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:269
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 
-#: panels/thunderbolt/cc-bolt-panel.ui:289
-msgid "Only USB and Display Port devices can attach."
-msgstr ""
-
-#: panels/thunderbolt/cc-bolt-panel.ui:397
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 #, fuzzy
-#| msgid "Add Device"
 msgid "Pending Devices"
 msgstr "Илова кардани дастгоҳ"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:535
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr ""
 
@@ -6796,742 +3941,641 @@ msgstr ""
 msgid "Manage Thunderbolt devices"
 msgstr ""
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
-msgid "Thunderbolt;"
+msgid "Thunderbolt;privacy;"
 msgstr ""
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:498
-#, fuzzy
-#| msgid "Default"
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Пешфарз"
-
-#: panels/universal-access/cc-ua-panel.c:501
-#, fuzzy
-#| msgctxt "Calibration quality"
-#| msgid "Medium"
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Миёна"
-
-#: panels/universal-access/cc-ua-panel.c:504
-#, fuzzy
-#| msgctxt "dwell click threshold"
-#| msgid "Large"
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Бузург"
-
-#: panels/universal-access/cc-ua-panel.c:507
-#, fuzzy
-#| msgctxt "universal access, text size"
-#| msgid "Larger"
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Калонтар"
-
-#: panels/universal-access/cc-ua-panel.c:510
-#, fuzzy
-#| msgctxt "dwell click threshold"
-#| msgid "Large"
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Бузург"
-
-#: panels/universal-access/cc-ua-panel.c:514
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] ""
-msgstr[1] ""
-
-#: panels/universal-access/cc-ua-panel.ui:93
-msgid "_Always Show Universal Access Menu"
-msgstr "_Ҳамеша намоиш додани менюи дастрасии умумӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:135
-msgid "Seeing"
-msgstr "Дидан"
-
-#: panels/universal-access/cc-ua-panel.ui:181
-msgid "_High Contrast"
-msgstr "_Контрасти баланд"
-
-#: panels/universal-access/cc-ua-panel.ui:228
-msgid "_Large Text"
-msgstr "_Матни бузург"
-
-#: panels/universal-access/cc-ua-panel.ui:273
-msgid "C_ursor Size"
-msgstr "Андозаи курсор"
-
-#: panels/universal-access/cc-ua-panel.ui:320
-#: panels/universal-access/zoom-options.ui:99
-msgid "_Zoom"
-msgstr "_Танзими андоза"
-
-#: panels/universal-access/cc-ua-panel.ui:366
-msgid "Screen _Reader"
-msgstr "Хонандаи _экранӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:412
-#: panels/universal-access/cc-ua-panel.ui:1243
-msgid "_Sound Keys"
-msgstr "_Тугмаҳои садо"
-
-#: panels/universal-access/cc-ua-panel.ui:474
-msgid "Hearing"
-msgstr "Шунавоӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:518
-#: panels/universal-access/cc-ua-panel.ui:1346
-msgid "_Visual Alerts"
-msgstr "_Огоҳиҳои намоён"
-
-#: panels/universal-access/cc-ua-panel.ui:626
-msgid "Screen _Keyboard"
-msgstr "Клавиатураи _экранӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:671
-#, fuzzy
-#| msgid "Repeat Keys"
-msgid "R_epeat Keys"
-msgstr "Тугмаҳои такрорӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:717
-#, fuzzy
-#| msgid "Cursor Blinking"
-msgid "Cursor _Blinking"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
 msgstr "Мижазании курсор"
 
-#: panels/universal-access/cc-ua-panel.ui:763
-msgid "_Typing Assist (AccessX)"
-msgstr "_Ёвари вуруд (AccessX)"
-
-#: panels/universal-access/cc-ua-panel.ui:824
-msgid "Pointing & Clicking"
-msgstr "Нишондиҳӣ ва зеркунӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:870
-msgid "_Mouse Keys"
-msgstr "_Тугмаҳои муш"
-
-#: panels/universal-access/cc-ua-panel.ui:915
-msgid "_Click Assist"
-msgstr "_Ёвари зеркунӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:961
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 #, fuzzy
-#| msgid "_Double-click"
-msgid "_Double-Click Delay"
-msgstr "_Дубора зер кардан"
+msgid "Cursor blinks in text fields."
+msgstr "Мижазании курсор дар _майдонҳои матнӣ"
 
-#: panels/universal-access/cc-ua-panel.ui:981
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 #, fuzzy
-#| msgid "_Double-click"
-msgid "Double-Click Delay"
-msgstr "_Дубора зер кардан"
+msgid "Speed"
+msgstr "_Суръат:"
 
-#: panels/universal-access/cc-ua-panel.ui:1048
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 #, fuzzy
-#| msgid "Cursor blink speed"
+msgid "Cursor blinking speed"
+msgstr "Суръати мижазании курсор"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
 msgid "Cursor Size"
 msgstr "Суръати мижазании курсор"
 
-#: panels/universal-access/cc-ua-panel.ui:1075
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 
-#: panels/universal-access/cc-ua-panel.ui:1111
-msgid "Screen Reader"
-msgstr "Хонандаи экранӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:1128
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "Хонандаи экранӣ матни нишоншударо аз рӯи фокус мехонад."
-
-#: panels/universal-access/cc-ua-panel.ui:1161
-msgid "_Screen Reader"
-msgstr "Хонандаи _экранӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:1200
-msgid "Sound Keys"
-msgstr "Тугмаҳои садо"
-
-#: panels/universal-access/cc-ua-panel.ui:1218
-#, fuzzy
-#| msgid "Beep when Num Lock or Caps Lock are turned on."
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "Сигнали бип ҳангоми фаъол кардани Num Lock ё Caps Lock."
-
-#: panels/universal-access/cc-ua-panel.ui:1288
-msgid "Visual Alerts"
-msgstr "Огоҳиҳои намоён"
-
-#: panels/universal-access/cc-ua-panel.ui:1292
-msgid "_Test flash"
-msgstr "_Санҷидани мижазанӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:1321
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "Истифода бурдани огоҳии визуалӣ ҳангоми пайдо шудани садои ҳушдор."
-
-#: panels/universal-access/cc-ua-panel.ui:1372
-msgid "Flash the _window title"
-msgstr "Мижазании _сарлавҳаи равзана"
-
-#: panels/universal-access/cc-ua-panel.ui:1390
-msgid "Flash the entire _screen"
-msgstr "Мижазании _экран"
-
-#: panels/universal-access/cc-ua-panel.ui:1435
-msgid "Repeat Keys"
-msgstr "Тугмаҳои такрорӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:1465
-#, fuzzy
-#| msgid "Key presses _repeat when key is held down"
-msgid "Key presses repeat when key is held down."
-msgstr "Пахшкуниҳои тугмаҳо ҳангоми пахш кардани тугма _такрор мешаванд"
-
-#: panels/universal-access/cc-ua-panel.ui:1545
-#, fuzzy
-#| msgid "Repeat keys speed"
-msgid "Repeat keys delay"
-msgstr "Суръати тугмаҳои такрорӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:1593
-#: panels/universal-access/cc-ua-panel.ui:1728
-#, fuzzy
-#| msgid "_Speed:"
-msgid "Speed"
-msgstr "_Суръат:"
-
-#: panels/universal-access/cc-ua-panel.ui:1632
-msgid "Repeat keys speed"
-msgstr "Суръати тугмаҳои такрорӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:1656
-msgid "Cursor Blinking"
-msgstr "Мижазании курсор"
-
-#: panels/universal-access/cc-ua-panel.ui:1686
-#, fuzzy
-#| msgid "Cursor _blinks in text fields"
-msgid "Cursor blinks in text fields."
-msgstr "Мижазании курсор дар _майдонҳои матнӣ"
-
-#: panels/universal-access/cc-ua-panel.ui:1765
-#, fuzzy
-#| msgid "Cursor blink speed"
-msgid "Cursor blinking speed"
-msgstr "Суръати мижазании курсор"
-
-#: panels/universal-access/cc-ua-panel.ui:1801
-msgid "Typing Assist"
-msgstr "Ёвари вуруд"
-
-#: panels/universal-access/cc-ua-panel.ui:1840
-msgid "_Sticky Keys"
-msgstr "_Тугмаҳои часпак"
-
-#: panels/universal-access/cc-ua-panel.ui:1857
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "Пайдарпайии тугмаҳои табдилдиҳандаро ҳамчун маҷмӯи тугмаҳо меҳисобад"
-
-#: panels/universal-access/cc-ua-panel.ui:1881
-msgid "_Disable if two keys are pressed together"
-msgstr "_Ғайрифаъол кунед, агар ду тугма якҷоя зер шаванд"
-
-#: panels/universal-access/cc-ua-panel.ui:1899
-msgid "Beep when a _modifier key is pressed"
-msgstr "_Сигнали бип ҳангоми пахш кардани тугмаи табдилдиҳанда"
-
-#: panels/universal-access/cc-ua-panel.ui:1947
-msgid "S_low Keys"
-msgstr "Тугмаҳои _суст"
-
-#: panels/universal-access/cc-ua-panel.ui:1964
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
-"Таъин кардани таъхир дар байни зеркунии тугма ва қабулкунии тугмаи зершуда"
-
-#: panels/universal-access/cc-ua-panel.ui:1997
-#: panels/universal-access/cc-ua-panel.ui:2210
-#: panels/universal-access/cc-ua-panel.ui:2547
-msgid "A_cceptance delay:"
-msgstr "Таъхири қ_абулкунӣ:"
-
-#: panels/universal-access/cc-ua-panel.ui:2019
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "Кӯтоҳ"
-
-#: panels/universal-access/cc-ua-panel.ui:2038
-msgid "Slow keys typing delay"
-msgstr "Таъхири тугмаҳои суст"
-
-#: panels/universal-access/cc-ua-panel.ui:2053
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "Дароз"
-
-#: panels/universal-access/cc-ua-panel.ui:2080
-msgid "Beep when a key is pr_essed"
-msgstr "_Сигнали бип барои тугмаи _зершуда"
-
-#: panels/universal-access/cc-ua-panel.ui:2097
-msgid "Beep when a key is _accepted"
-msgstr "Сигнали бип барои тугмаи _қабулшуда"
-
-#: panels/universal-access/cc-ua-panel.ui:2114
-#: panels/universal-access/cc-ua-panel.ui:2293
-msgid "Beep when a key is _rejected"
-msgstr "Сигнали бип барои тугмаи _радшуда"
-
-#: panels/universal-access/cc-ua-panel.ui:2160
-msgid "_Bounce Keys"
-msgstr "_Тугмаҳои ҷаҳида"
-
-#: panels/universal-access/cc-ua-panel.ui:2177
-msgid "Ignores fast duplicate keypresses"
-msgstr "Пахшкуниҳои зуди такрориро нодида мегузаронад"
-
-#: panels/universal-access/cc-ua-panel.ui:2232
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "Кӯтоҳ"
-
-#: panels/universal-access/cc-ua-panel.ui:2251
-msgid "Bounce keys typing delay"
-msgstr "Таъхири чопи тугмаҳои ҷаҳида"
-
-#: panels/universal-access/cc-ua-panel.ui:2266
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "Дароз"
-
-#: panels/universal-access/cc-ua-panel.ui:2379
-msgid "_Enable by Keyboard"
-msgstr "_Фаъол кардан бо клавиатура"
-
-#: panels/universal-access/cc-ua-panel.ui:2396
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr ""
-"Хусусиятҳои қобилияти дастрасиро ба воситаи клавиатура фаъол ва хомӯш мекунад"
-
-#: panels/universal-access/cc-ua-panel.ui:2460
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "Ёвари зеркунӣ"
 
-#: panels/universal-access/cc-ua-panel.ui:2496
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "_Шабеҳсозии зеркунии иловагӣ"
 
-#: panels/universal-access/cc-ua-panel.ui:2514
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "Ба ҷо овардани зеркунии иловагӣ бо нигоҳ доштани тугмаи асосӣ"
 
-#: panels/universal-access/cc-ua-panel.ui:2568
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Таъхири қ_абулкунӣ:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "Кӯтоҳ"
 
-#: panels/universal-access/cc-ua-panel.ui:2587
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "Таъхири зеркунии дуюм"
 
-#: panels/universal-access/cc-ua-panel.ui:2602
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "Дароз"
 
-#: panels/universal-access/cc-ua-panel.ui:2659
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "_Зеркунӣ дар боло"
 
-#: panels/universal-access/cc-ua-panel.ui:2677
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "Ба ҷо овардани зеркунӣ ҳангоми боло нигаҳ доштани нишондиҳанда"
 
-#: panels/universal-access/cc-ua-panel.ui:2710
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "_Таъхир:"
 
-#: panels/universal-access/cc-ua-panel.ui:2732
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "Кӯтоҳ"
 
-#: panels/universal-access/cc-ua-panel.ui:2763
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "Дароз"
 
-#: panels/universal-access/cc-ua-panel.ui:2799
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "Остонаи ҳ_аракат:"
 
-#: panels/universal-access/cc-ua-panel.ui:2821
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "Хурд"
 
-#: panels/universal-access/cc-ua-panel.ui:2852
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "Бузург"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Тугмаҳои такрорӣ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Пахшкуниҳои тугмаҳо ҳангоми пахш кардани тугма _такрор мешаванд"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "Суръати тугмаҳои такрорӣ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Суръати тугмаҳои такрорӣ"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Ёвари вуруд"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Тугмаҳои часпак"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Пайдарпайии тугмаҳои табдилдиҳандаро ҳамчун маҷмӯи тугмаҳо меҳисобад"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Ғайрифаъол кунед, агар ду тугма якҷоя зер шаванд"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "_Сигнали бип ҳангоми пахш кардани тугмаи табдилдиҳанда"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Тугмаҳои _суст"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Таъин кардани таъхир дар байни зеркунии тугма ва қабулкунии тугмаи зершуда"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Кӯтоҳ"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Таъхири тугмаҳои суст"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Дароз"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "_Сигнали бип барои тугмаи _зершуда"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Сигнали бип барои тугмаи _қабулшуда"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Сигнали бип барои тугмаи _радшуда"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Тугмаҳои ҷаҳида"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Пахшкуниҳои зуди такрориро нодида мегузаронад"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Кӯтоҳ"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Таъхири чопи тугмаҳои ҷаҳида"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Дароз"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Фаъол кардан бо клавиатура"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Хусусиятҳои қобилияти дастрасиро ба воситаи клавиатура фаъол ва хомӯш мекунад"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Ҳамеша намоиш додани менюи дастрасии умумӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Дидан"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Контрасти баланд"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Матни бузург"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Хонандаи _экранӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Хонандаи экранӣ матни нишоншударо аз рӯи фокус мехонад."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "_Тугмаҳои садо"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Сигнали бип ҳангоми фаъол кардани Num Lock ё Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Андозаи курсор"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Танзими андоза"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Шунавоӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Огоҳиҳои намоён"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Клавиатураи _экранӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "Тугмаҳои такрорӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Мижазании курсор"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Ёвари вуруд (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "Нишондиҳӣ ва зеркунӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Тугмаҳои муш"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Тоза кардани принтер"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Ёвари зеркунӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "_Дубора зер кардан"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "_Дубора зер кардан"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Огоҳиҳои намоён"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_Санҷидани мижазанӣ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Истифода бурдани огоҳии визуалӣ ҳангоми пайдо шудани садои ҳушдор."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Мижазании _экран"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Мижазании _экран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Экрани пурра"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Ними боло"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Ними поён"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Ними чап"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Ними рост"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Имконоти танзими андоза"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "Бузургнамоӣ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Ҷойгиршавии бузургнамо:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "Пайгирӣ кардани курсори муш"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Қисми экран:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "Бузургнамо берун аз экран густариш меёбад"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "Нигоҳ доштани курсори бузургнамо дар марказ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Курсори бузургнамо муҳтаворо идора мекунад"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "Курсори бузургнамо якҷоя бо муҳтаво интиқол меёбад"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Бузургнамо"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "Нишонгирӣ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "Курсори мушро ҳампӯшонӣ мекунад"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
+msgstr "Ғафсӣ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Тунук"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Ғафс"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
+msgstr "Давомнокӣ:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
+msgstr "Ранг:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Нишонгирӣ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Таъсирҳои ранг:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
+msgstr "Сафеду сиёҳ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Равшанӣ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Контраст:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ҳеҷ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Пурра"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Паст"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Баланд"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Паст"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Баланд"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Таъсирҳои ранг"
 
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Осон кардани дидан, шунидан, нуқта гузоштан ва зер кардан"
 
-#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 #, fuzzy
-#| msgid ""
-#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;"
-#| "size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
-"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
-"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
 "Клавиатура;Муш;a11y;Қобилияти дастрасӣ;Контраст;Танзими андоза;Хонанда;Экран;"
 "матн;шрифт;андоза;AccessX;Тугмаҳои часпак;Тугмаҳои суст;Тугмаҳои ҷаҳиш;"
 "Тугмаҳои муш;"
 
-#: panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "Short"
-msgstr "Кӯтоҳ"
-
-#: panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "Экрани ¼"
-
-#: panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "Экрани ½"
-
-#: panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "Экрани ¾"
-
-#: panels/universal-access/zoom-options.c:338
-msgctxt "Distance"
-msgid "Long"
-msgstr "Дароз"
-
-#: panels/universal-access/zoom-options.ui:48
-msgid "Full Screen"
-msgstr "Экрани пурра"
-
-#: panels/universal-access/zoom-options.ui:53
-msgid "Top Half"
-msgstr "Ними боло"
-
-#: panels/universal-access/zoom-options.ui:58
-msgid "Bottom Half"
-msgstr "Ними поён"
-
-#: panels/universal-access/zoom-options.ui:63
-msgid "Left Half"
-msgstr "Ними чап"
-
-#: panels/universal-access/zoom-options.ui:68
-msgid "Right Half"
-msgstr "Ними рост"
-
-#: panels/universal-access/zoom-options.ui:78
-msgid "Zoom Options"
-msgstr "Имконоти танзими андоза"
-
-#: panels/universal-access/zoom-options.ui:185
+#: panels/usage/cc-usage-panel.ui:9
 #, fuzzy
-#| msgid "Magnification:"
-msgid "_Magnification:"
-msgstr "Бузургнамоӣ:"
+msgid "File History"
+msgstr "Таърих"
 
-#: panels/universal-access/zoom-options.ui:249
-#, fuzzy
-#| msgid "Follow mouse cursor"
-msgid "_Follow mouse cursor"
-msgstr "Пайгирӣ кардани курсори муш"
-
-#: panels/universal-access/zoom-options.ui:269
-#, fuzzy
-#| msgid "Screen part:"
-msgid "_Screen part:"
-msgstr "Қисми экран:"
-
-#: panels/universal-access/zoom-options.ui:331
-#, fuzzy
-#| msgid "Magnifier extends outside of screen"
-msgid "Magnifier _extends outside of screen"
-msgstr "Бузургнамо берун аз экран густариш меёбад"
-
-#: panels/universal-access/zoom-options.ui:350
-#, fuzzy
-#| msgid "Keep magnifier cursor centered"
-msgid "_Keep magnifier cursor centered"
-msgstr "Нигоҳ доштани курсори бузургнамо дар марказ"
-
-#: panels/universal-access/zoom-options.ui:369
-#, fuzzy
-#| msgid "Magnifier cursor pushes contents around"
-msgid "Magnifier cursor _pushes contents around"
-msgstr "Курсори бузургнамо муҳтаворо идора мекунад"
-
-#: panels/universal-access/zoom-options.ui:388
-#, fuzzy
-#| msgid "Magnifier cursor moves with contents"
-msgid "Magnifier cursor moves with _contents"
-msgstr "Курсори бузургнамо якҷоя бо муҳтаво интиқол меёбад"
-
-#: panels/universal-access/zoom-options.ui:422
-msgid "Magnifier Position:"
-msgstr "Ҷойгиршавии бузургнамо:"
-
-#: panels/universal-access/zoom-options.ui:443
-msgid "Magnifier"
-msgstr "Бузургнамо"
-
-#: panels/universal-access/zoom-options.ui:490
-#, fuzzy
-#| msgid "Thickness:"
-msgid "_Thickness:"
-msgstr "Ғафсӣ:"
-
-#: panels/universal-access/zoom-options.ui:516
-msgctxt "universal access, thickness"
-msgid "Thin"
-msgstr "Тунук"
-
-#: panels/universal-access/zoom-options.ui:548
-msgctxt "universal access, thickness"
-msgid "Thick"
-msgstr "Ғафс"
-
-#: panels/universal-access/zoom-options.ui:574
-#, fuzzy
-#| msgid "Length:"
-msgid "_Length:"
-msgstr "Давомнокӣ:"
-
-#. The color of the accessibility crosshair
-#: panels/universal-access/zoom-options.ui:623
-#, fuzzy
-#| msgid "Color:"
-msgid "Co_lor:"
-msgstr "Ранг:"
-
-#: panels/universal-access/zoom-options.ui:687
-#, fuzzy
-#| msgid "Crosshairs:"
-msgid "_Crosshairs:"
-msgstr "Нишонгирӣ:"
-
-#: panels/universal-access/zoom-options.ui:735
-#, fuzzy
-#| msgid "Overlaps mouse cursor"
-msgid "_Overlaps mouse cursor"
-msgstr "Курсори мушро ҳампӯшонӣ мекунад"
-
-#: panels/universal-access/zoom-options.ui:773
-msgid "Crosshairs"
-msgstr "Нишонгирӣ"
-
-#: panels/universal-access/zoom-options.ui:822
-#, fuzzy
-#| msgid "White on black:"
-msgid "_White on black:"
-msgstr "Сафеду сиёҳ:"
-
-#: panels/universal-access/zoom-options.ui:842
-#, fuzzy
-#| msgid "Brightness:"
-msgid "_Brightness:"
-msgstr "Равшанӣ:"
-
-#: panels/universal-access/zoom-options.ui:863
-#, fuzzy
-#| msgid "Contrast:"
-msgid "_Contrast:"
-msgstr "Контраст:"
-
-#. The contrast scale goes from Color to None (grayscale)
-#: panels/universal-access/zoom-options.ui:883
-msgctxt "universal access, contrast"
-msgid "Co_lor"
-msgstr ""
-
-#: panels/universal-access/zoom-options.ui:908
-msgctxt "universal access, color"
-msgid "None"
-msgstr "Ҳеҷ"
-
-#: panels/universal-access/zoom-options.ui:940
-msgctxt "universal access, color"
-msgid "Full"
-msgstr "Пурра"
-
-#: panels/universal-access/zoom-options.ui:1003
-msgctxt "universal access, brightness"
-msgid "Low"
-msgstr "Паст"
-
-#: panels/universal-access/zoom-options.ui:1036
-msgctxt "universal access, brightness"
-msgid "High"
-msgstr "Баланд"
-
-#: panels/universal-access/zoom-options.ui:1067
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "Паст"
-
-#: panels/universal-access/zoom-options.ui:1100
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "Баланд"
-
-#: panels/universal-access/zoom-options.ui:1136
-msgid "Color Effects:"
-msgstr "Таъсирҳои ранг:"
-
-#: panels/universal-access/zoom-options.ui:1161
-msgid "Color Effects"
-msgstr "Таъсирҳои ранг"
-
-#: panels/user-accounts/cc-add-user-dialog.c:34
-#, fuzzy
-#| msgid "Should match the web address of your account provider."
-msgid "Should match the web address of your login provider."
-msgstr "Бояд ба суроғаи веби ҳисоби провайдери шумо мувофиқ бошад."
-
-#: panels/user-accounts/cc-add-user-dialog.c:204
-msgid "Failed to add account"
-msgstr "Иловакунии ҳисоб қатъ шуд"
-
-#: panels/user-accounts/cc-add-user-dialog.c:652
-#: panels/user-accounts/cc-password-dialog.c:261
-msgid "The passwords do not match."
-msgstr "Ниҳонвожаҳо мувофиқат намекунанд."
-
-#: panels/user-accounts/cc-add-user-dialog.c:874
-#: panels/user-accounts/cc-add-user-dialog.c:920
-#: panels/user-accounts/cc-add-user-dialog.c:941
-msgid "Failed to register account"
-msgstr "Қайдкунии ҳисоб қатъ шуд"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1064
-msgid "No supported way to authenticate with this domain"
-msgstr ""
-"Ягон имконияти дастгирӣ барои санҷиши ҳаққоният бо ин домен вуҷуд надорад"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1137
-msgid "Failed to join domain"
-msgstr "Ҳамроҳ шудан ба домен қатъ шуд"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1198
-#, fuzzy
-#| msgid ""
-#| "That login name didn't work.\n"
-#| "Please try again."
+#: panels/usage/cc-usage-panel.ui:10
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
 msgstr ""
-"Номи вуруд нодуруст аст.\n"
-"Лутфан амалро такрор кунед."
 
-#: panels/user-accounts/cc-add-user-dialog.c:1205
+#: panels/usage/cc-usage-panel.ui:13
 #, fuzzy
-#| msgid ""
-#| "That login password didn't work.\n"
-#| "Please try again."
+msgid "File H_istory"
+msgstr "Таърих"
+
+#: panels/usage/cc-usage-panel.ui:25
+#, fuzzy
+msgid "File _History Duration"
+msgstr "Татбиқи танзимот қатъ шудааст"
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "_Пок кардани таърихи қаблӣ"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "Пок кардани сабад ва файлҳои муваққатӣ"
+
+#: panels/usage/cc-usage-panel.ui:64
 msgid ""
-"That login password didn’t work.\n"
-"Please try again."
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
 msgstr ""
-"Ниҳонвожаи вуруд нодуруст аст.\n"
-"Лутфан амалро такрор кунед."
 
-#: panels/user-accounts/cc-add-user-dialog.c:1213
-msgid "Failed to log into domain"
-msgstr "Ворид шудан ба домен қатъ шуд"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1271
+#: panels/usage/cc-usage-panel.ui:67
 #, fuzzy
-#| msgid "Unable find the domain. Maybe you misspelled it?"
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Домен ёфт нашуд. Эҳтимол аст, ки шумо онро хатогӣ ворид кардед?"
+msgid "Automatically Delete _Trash Content"
+msgstr "Холӣ кардани сабад _ба таври худкор"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:18
-#: panels/user-accounts/data/join-dialog.ui:11
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "Холӣ кардани файлҳои _муваққатӣ ба таври худкор"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "Холӣ кардани сабад _ба таври худкор"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "_Холӣ кардани сабад"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_Пок кардани файлҳои муваққатӣ"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "Илова кардани корбар"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:180
-msgid "_Full Name"
-msgstr "_Номи пурра"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:206
-#: panels/user-accounts/cc-user-panel.ui:151
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 #, fuzzy
-#| msgctxt "Account type"
-#| msgid "Standard"
-msgid "Standard"
-msgstr "Стандартӣ"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:216
-#: panels/user-accounts/cc-user-panel.ui:161
-#, fuzzy
-#| msgctxt "Account type"
-#| msgid "Administrator"
 msgid "Administrator"
 msgstr "Маъмур"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:232
-#: panels/user-accounts/cc-user-panel.ui:179
-msgid "Account _Type"
-msgstr "_Намуди ҳисоб"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:269
-#, fuzzy
-#| msgid "Allow user to set a password when they next login"
-msgid "Allow user to set a password when they next _login"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"Ба корбар иҷозат диҳед, ки ҳангоми воридшавии навбатӣ ниҳонвожаеро барпо "
-"кунад"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:283
+#: panels/user-accounts/cc-add-user-dialog.ui:149
 #, fuzzy
-#| msgid "Set a password now"
-msgid "Set a password _now"
+msgid "User sets password on first login"
+msgstr "Интихоб кардани ниҳонвожа барои воридшавии навбатӣ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
 msgstr "Ниҳонвожаро ҳозир таъин кунед"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:405
+#: panels/user-accounts/cc-add-user-dialog.ui:224
 #, fuzzy
-#| msgid "_Confirm Password"
-msgid "_Confirm"
+msgid "Confirm"
 msgstr "_Тасдиқ кардани ниҳонвожа"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:485
-#: panels/user-accounts/cc-add-user-dialog.ui:692
+#: panels/user-accounts/cc-add-user-dialog.ui:278
 #, fuzzy
-#| msgid ""
-#| "Enterprise login allows an existing centrally managed user account to be "
-#| "used on this device."
+msgid "Enterprise Login"
+msgstr "_Воридшавии корӣ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "Офлайн"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7540,439 +4584,238 @@ msgstr ""
 "Вуруди Enterprise иҷозат медиҳад, ки тавонед ҳисоби корбари идорашавандаи "
 "марказии мавҷудбударо дар ин дастгоҳ истифода баред."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:507
-#: panels/user-accounts/data/join-dialog.ui:116
-msgid "_Domain"
-msgstr "_Домен"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:732
+#: panels/user-accounts/cc-avatar-chooser.ui:32
 #, fuzzy
-#| msgctxt "printer state"
-#| msgid "Offline"
-msgid "You are Offline"
-msgstr "Офлайн"
-
-#: panels/user-accounts/cc-add-user-dialog.ui:751
-#, fuzzy
-#| msgid ""
-#| "Go online to add\n"
-#| "enterprise login accounts."
-msgid "You must be online in order to add enterprise users."
-msgstr ""
-"Барои илова кардани ҳисобҳои\n"
-"Enterprise ба онлайн гузаред."
-
-#: panels/user-accounts/cc-add-user-dialog.ui:782
-msgid "_Enterprise Login"
-msgstr "_Воридшавии корӣ"
-
-#: panels/user-accounts/cc-avatar-chooser.c:231
-msgid "Browse for more pictures"
-msgstr "Тамошо кардани тасвирҳои дигар"
-
-#: panels/user-accounts/cc-avatar-chooser.ui:27
-#, fuzzy
-#| msgid "Take a photo…"
-msgid "Take a Picture…"
-msgstr "Гирифтани сурат..."
-
-#: panels/user-accounts/cc-avatar-chooser.ui:34
-#, fuzzy
-#| msgid "Select PPD File"
 msgid "Select a File…"
 msgstr "Интихоби файли PPD"
 
-#: panels/user-accounts/cc-login-history-dialog.c:69
-msgid "This Week"
-msgstr "Ҳафтаи ҷорӣ"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "_Воридшавӣ бо нақши ангушт"
 
-#: panels/user-accounts/cc-login-history-dialog.c:72
-msgid "Last Week"
-msgstr "Ҳафтаи гузашта"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "_Воридшавӣ бо нақши ангушт"
 
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:82
-#: panels/user-accounts/cc-login-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "Не"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:91
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%b %e, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:96
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
 msgstr ""
 
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:173
-#: panels/user-accounts/cc-user-panel.c:770
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Шумо мехоҳед, ки барои ғайрифаъол кардани воридшавӣ тавассути нақши ангушт, "
+"нақшҳои ангуштони қайдшударо нест кунед?"
 
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:176
-#: panels/user-accounts/cc-user-panel.c:774
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "Ягон принтер муайян нашуд."
 
-#: panels/user-accounts/cc-login-history-dialog.c:243
-msgid "Session Ended"
-msgstr "Ҷаласа хотима ёфт"
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "_Воридшавӣ бо нақши ангушт"
 
-#: panels/user-accounts/cc-login-history-dialog.c:249
-msgid "Session Started"
-msgstr "Ҷаласа оғоз ёфт"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
 
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:343
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Фаъолияти ҳисоб"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "_Воридшавӣ бо нақши ангушт"
 
-#: panels/user-accounts/cc-password-dialog.c:125
-msgid "Please choose another password."
-msgstr "Лутфан, ниҳонвожаи дигареро интихоб кунед."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.c:134
-msgid "Please type your current password again."
-msgstr "Лутфан, ниҳонвожаи ҷории худро ворид кунед."
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "_Воридшавӣ бо нақши ангушт"
 
-#: panels/user-accounts/cc-password-dialog.c:140
-msgid "Password could not be changed"
-msgstr "Ниҳонвожа тағйир дода намешавад"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
 
-#: panels/user-accounts/cc-password-dialog.ui:7
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_Нест кардани нақши ангуштон"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "_Воридшавӣ бо нақши ангушт"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Ҳафтаи қаблӣ"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "Ҳафтаи навбатӣ"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Тағйир додани ниҳонвожа"
 
-#: panels/user-accounts/cc-password-dialog.ui:37
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "_Тағйир додан"
 
-#: panels/user-accounts/cc-password-dialog.ui:145
-msgid "_Confirm New Password"
-msgstr "_Тасдиқ кардани ниҳонвожаи нав"
-
-#: panels/user-accounts/cc-password-dialog.ui:162
-msgid "_New Password"
-msgstr "_Ниҳонвожаи нав"
-
-#: panels/user-accounts/cc-password-dialog.ui:216
-msgid "Current _Password"
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
 msgstr "_Ниҳонвожаи ҷорӣ"
 
-#: panels/user-accounts/cc-password-dialog.ui:254
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Ниҳонвожаи нав"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "_Тасдиқ кардани ниҳонвожа"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Ниҳонвожаҳо мувофиқат намекунанд."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr ""
 "Ба корбар иҷозат диҳед, ки ҳангоми воридшавии навбатӣ ниҳонвожаеро иваз "
 "намояд"
 
-#: panels/user-accounts/cc-password-dialog.ui:267
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Ниҳонвожаро ҳозир таъин кунед"
 
-#: panels/user-accounts/cc-realm-manager.c:307
-msgid "Cannot automatically join this type of domain"
-msgstr "Ба ин намуди домен ба таври худкор пайваст намешавад"
-
-#: panels/user-accounts/cc-realm-manager.c:310
-msgid "No such domain or realm found"
-msgstr "Ягон домен ё соҳиб ёфт нашудааст"
-
-#: panels/user-accounts/cc-realm-manager.c:732
-#: panels/user-accounts/cc-realm-manager.c:746
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Ҳамчун %s ба домени %s пайваст намешавад"
-
-#: panels/user-accounts/cc-realm-manager.c:738
-msgid "Invalid password, please try again"
-msgstr "Ниҳонвожаи нодуруст, лутфан амалро такрор кунед"
-
-#: panels/user-accounts/cc-realm-manager.c:751
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Ба домени %s пайваст нашуд: %s"
-
-#: panels/user-accounts/cc-user-panel.c:213
-msgid "Your account"
-msgstr "Ҳисоби шумо"
-
-#: panels/user-accounts/cc-user-panel.c:388
-msgid "Failed to delete user"
-msgstr "Несткунии корбар қатъ шуд"
-
-#: panels/user-accounts/cc-user-panel.c:446
-#: panels/user-accounts/cc-user-panel.c:505
-#: panels/user-accounts/cc-user-panel.c:557
-msgid "Failed to revoke remotely managed user"
-msgstr "Бекоркунии корбари идорашавандаи дурдаст иҷро нашуд"
-
-#: panels/user-accounts/cc-user-panel.c:609
-msgid "You cannot delete your own account."
-msgstr "Шумо наметавонед ҳисоби худро нест кунед."
-
-#: panels/user-accounts/cc-user-panel.c:618
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s то ҳол воридшуда мебошад"
-
-#: panels/user-accounts/cc-user-panel.c:622
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Несткунии корбари воридшуда метавонад низомро ба ҳолати номунтаззам дарорад."
-
-#: panels/user-accounts/cc-user-panel.c:631
-#, fuzzy, c-format
-#| msgid "Do you want to keep %s's files?"
-msgid "Do you want to keep %s’s files?"
-msgstr "Шумо мехоҳед, ки файлҳои %s-ро нигоҳ доред?"
-
-#: panels/user-accounts/cc-user-panel.c:635
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Ҳангоми нест кардани ҳисоби корбар шумо метавонед директорияи аслӣ, файлҳои "
-"навбати почта ва файлҳои муваққатиро нигоҳ доред."
-
-#: panels/user-accounts/cc-user-panel.c:638
-msgid "_Delete Files"
-msgstr "_Нест кардани файлҳо"
-
-#: panels/user-accounts/cc-user-panel.c:639
-msgid "_Keep Files"
-msgstr "_Нигоҳ доштани файлҳо"
-
-#: panels/user-accounts/cc-user-panel.c:653
-#, fuzzy, c-format
-#| msgid "Are you sure you want to revoke remotely managed %s's account?"
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Шумо мутмаин ҳастед, ки мехоҳед ҳисоби корбари идорашавандаи дурдасти %s "
-"бекор кунед?"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgid "_Delete"
-msgstr "_Нест кардан"
-
-#: panels/user-accounts/cc-user-panel.c:707
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Ҳисоб ғайрифаъол аст"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Ҳангоми воридшавии навбатӣ таъин карда мешавад"
-
-#: panels/user-accounts/cc-user-panel.c:718
-msgctxt "Password mode"
-msgid "None"
-msgstr "Ҳеҷ"
-
-#: panels/user-accounts/cc-user-panel.c:763
-msgid "Logged in"
-msgstr "Ворид шудааст"
-
-#: panels/user-accounts/cc-user-panel.c:1093
-msgid "Failed to contact the accounts service"
-msgstr "Тамосгирӣ бо хадамоти ҳисобҳо қатъ шуд"
-
-#: panels/user-accounts/cc-user-panel.c:1095
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Лутфан, мутмаин шавед, ки AccountService насб шудааст ва дар ҳоли иҷро "
-"мебошад."
-
-#. Translator comments:
-#. * We split the line in 2 here to "make it look good", as there's
-#. * no good way to do this in GTK+ for tooltips. See:
-#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
-#: panels/user-accounts/cc-user-panel.c:1127
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"Барои даровардани тағйирот,\n"
-"аввал нишонаи \"*\"-ро зер кунед"
-
-#: panels/user-accounts/cc-user-panel.c:1200
-msgid "Create a user account"
-msgstr "Эҷод кардани ҳисоби корбар"
-
-#: panels/user-accounts/cc-user-panel.c:1211
-#: panels/user-accounts/cc-user-panel.c:1339
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"Барои эҷод кардани ҳисоби корбар,\n"
-"пеш аз ҳама нишонаи * -ро зер кунед"
-
-#: panels/user-accounts/cc-user-panel.c:1220
-msgid "Delete the selected user account"
-msgstr "Нест кардани ҳисоби корбари интихобшуда"
-
-#: panels/user-accounts/cc-user-panel.c:1232
-#: panels/user-accounts/cc-user-panel.c:1343
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Барои нест кардани ҳисоби корбари интихобшуда,\n"
-"пеш аз ҳама нишонаи * -ро зер кунед"
-
-#: panels/user-accounts/cc-user-panel.ui:18
-#, fuzzy
-#| msgid "Add User"
-msgid "_Add User…"
-msgstr "Илова кардани корбар"
-
-#: panels/user-accounts/cc-user-panel.ui:70
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "Барои татбиқ кардани тағйирот шумо бояд низомро бозоғозӣ кунед"
-
-#: panels/user-accounts/cc-user-panel.ui:78
-msgid "Restart Now"
-msgstr "Ҳозир бозоғозӣ кардан"
-
-#: panels/user-accounts/cc-user-panel.ui:254
-msgid "A_utomatic Login"
-msgstr "_Воридшавии худкор"
-
-#: panels/user-accounts/cc-user-panel.ui:296
-msgid "_Fingerprint Login"
-msgstr "_Воридшавӣ бо нақши ангушт"
-
-#: panels/user-accounts/cc-user-panel.ui:322
-#: panels/user-accounts/cc-user-panel.ui:338
-msgid "User Icon"
-msgstr "Нишонаи корбар"
-
-#: panels/user-accounts/cc-user-panel.ui:402
-msgid "Last Login"
-msgstr "Воридшавии охирин"
-
-#: panels/user-accounts/cc-user-panel.ui:451
-#, fuzzy
-#| msgid "Remove User Account"
-msgid "Remove User…"
-msgstr "Тоза кардани ҳисоби корбар"
-
-#. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:484
-#, fuzzy
-#| msgid "No Pictures Found"
-msgid "No Users Found"
-msgstr "Ягон тасвир ёфт нашудааст"
-
-#: panels/user-accounts/cc-user-panel.ui:494
-#, fuzzy
-#| msgid "Create a user account"
-msgid "Unlock to add a user account."
-msgstr "Эҷод кардани ҳисоби корбар"
-
-#: panels/user-accounts/data/account-fingerprint.ui:12
-msgid "Left thumb"
-msgstr "Сарангушти чап"
-
-#: panels/user-accounts/data/account-fingerprint.ui:15
-msgid "Left middle finger"
-msgstr "Ангушти миёнаи чап"
-
-#: panels/user-accounts/data/account-fingerprint.ui:18
-msgid "Left ring finger"
-msgstr "Ангушти ҳалқаи чап"
-
-#: panels/user-accounts/data/account-fingerprint.ui:21
-msgid "Left little finger"
-msgstr "Ангушти хурди чап"
-
-#: panels/user-accounts/data/account-fingerprint.ui:24
-msgid "Right thumb"
-msgstr "Сарангушти рост"
-
-#: panels/user-accounts/data/account-fingerprint.ui:27
-msgid "Right middle finger"
-msgstr "Ангушти миёнаи рост"
-
-#: panels/user-accounts/data/account-fingerprint.ui:30
-msgid "Right ring finger"
-msgstr "Ангушти ҳалқаи рост"
-
-#: panels/user-accounts/data/account-fingerprint.ui:33
-msgid "Right little finger"
-msgstr "Ангушти хурди рост"
-
-#: panels/user-accounts/data/account-fingerprint.ui:39
-#: panels/user-accounts/um-fingerprint-dialog.c:677
-msgid "Enable Fingerprint Login"
-msgstr "Фаъол кардани воридшавӣ бо нақши ангушт"
-
-#: panels/user-accounts/data/account-fingerprint.ui:89
-msgid "_Right index finger"
-msgstr "_Ангушти ишорати рост"
-
-#: panels/user-accounts/data/account-fingerprint.ui:105
-msgid "_Left index finger"
-msgstr "_Ангушти ишорати чап "
-
-#: panels/user-accounts/data/account-fingerprint.ui:126
-msgid "_Other finger:"
-msgstr "_Ангушти дигар:"
-
-#: panels/user-accounts/data/account-fingerprint.ui:262
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr ""
-"Нақши ангушти шумо бо муваффақият захира шудааст. Акнун шумо метавонед "
-"тавассути хонандаи нақши ангуштон ворид шавед."
-
+#: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Корбарон"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Барои татбиқ кардани тағйирот шумо бояд низомро бозоғозӣ кунед"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Ҳозир бозоғозӣ кардан"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Пӯшидан"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Номи пурра"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Воридшавӣ бо нақши ангушт"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Воридшавии худкор"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "%s — Фаъолияти ҳисоб"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "Маъмур"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "Тоза кардани ҳисоби корбар"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "_Нест кардани файлҳо"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "Илова кардани корбар"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Ягон тасвир ёфт нашудааст"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "Эҷод кардани ҳисоби корбар"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "Илова ё тоза кардани корбарон ва тағйир додани ниҳонвожаи худ"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Воридшавӣ;Ном;Нақши ангушт;Аватар;Тамға;Рӯй;Ниҳонвожа;"
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: panels/user-accounts/data/join-dialog.ui:39
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_Илова кардан"
 
-#: panels/user-accounts/data/join-dialog.ui:75
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "Воридшавии маъмури домен"
 
-#: panels/user-accounts/data/join-dialog.ui:93
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -7982,11 +4825,11 @@ msgstr ""
 "ба домен дохил шуда бошад. Лутфан, аз маъмури шабакаи худ пурсед, ки\n"
 "ниҳонвожаи домени худро дар ин ҷо ворид намояд."
 
-#: panels/user-accounts/data/join-dialog.ui:150
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "Номи _маъмур"
 
-#: panels/user-accounts/data/join-dialog.ui:185
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "Ниҳонвожаи маъмур"
 
@@ -7998,316 +4841,17 @@ msgstr "Идоракунии ҳисобҳои корбар"
 msgid "Authentication is required to change user data"
 msgstr "Барои тағйир додани маълумоти корбар, санҷиши ҳаққоният лозим аст"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Ниҳонвожаи нав бояд аз ниҳонвожаи кӯҳна фарқ кунад."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Баъзе ҳарфҳо ва рақамҳоро тағйир диҳед."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Ниҳонвожаи худро каме мураккаб кунед."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Ниҳонвожа бе номи корбар қавитар мешавад."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Номи худро дар ниҳонвожа истифода набаред."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Баъзе калимаҳоро аз ниҳонвожа истисно кунед."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Калимаҳои оддиро истифода набаред."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Тартиби калимаҳои мавҷудбударо иваз накунед."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Бештар рақамҳоро истифода баред."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Бештар ҳарфҳои калонро истифода баред."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Бештар ҳарфҳои хурдро истифода баред."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Бештар аломатҳои маҳсусро, монанди нуқтагузорӣ, истифода баред."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Аралаши калимаҳо, рақамҳо ва нуқтагузориро истифода баред."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Аломатҳои такрориро истифода набаред."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Аломатҳои такрориро истифода набаред: шумо бояд ҳарфҳо, рақамҳо ва "
-"нуқтагузориро аралаш кунед."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Мунтазамии рақамҳоро монанди 1234 ё abcd истифода набаред."
-
-#: panels/user-accounts/pw-utils.c:128
-#, fuzzy
-#| msgctxt "Password hint"
-#| msgid "Try to use a mixture of letters, numbers and punctuation."
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr "Аралаши калимаҳо, рақамҳо ва нуқтагузориро истифода баред."
-
-#: panels/user-accounts/pw-utils.c:130
-#, fuzzy
-#| msgctxt "Password hint"
-#| msgid "Mix uppercase and lowercase and use a number or two."
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr ""
-"Ҳарфҳои хурду калонро аралаш кунед ва як ё якчанд рақамро истифода баред."
-
-#: panels/user-accounts/pw-utils.c:132
-#, fuzzy
-#| msgctxt "Password hint"
-#| msgid ""
-#| "Good password! Adding more letters, numbers and punctuation will make it "
-#| "stronger."
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Ниҳонвожаи хуб! Агар бештар калимаҳо, рақамҳо ва нуқтагузориро илова кунед, "
-"ниҳонвожаро қавитар мекунед."
-
-#: panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "Санҷиши ҳаққоният қатъ шудааст"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "Ниҳонвожаи нав хеле кӯтоҳ аст"
-
-#: panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "Ниҳонвожаи нав хеле осон аст"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Ниҳонвожаи нав ва кӯҳна хеле монанданд"
-
-#: panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Ниҳонвожаи нав аллакай истифода шуда буд."
-
-#: panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Ниҳонвожаи нав бояд аломатҳои рақамӣ ва махсусро дар бар гирад"
-
-#: panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Ниҳонвожаи нав ва кӯҳна мувофиқат мекунанд"
-
-#: panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Баъд аз воридшавии вақти аввалин ниҳонвожаи шумо тағйир ёфт!"
-
-#: panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Ниҳонвожаи нав аломатҳои дигаргунро дар бар намегирад"
-
-#: panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "Хатогии номаълум"
-
-#: panels/user-accounts/user-utils.c:430
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr ""
-
-#: panels/user-accounts/user-utils.c:433
-#, c-format
-msgid "The username is too long."
-msgstr "Номи корбар хеле дароз аст."
-
-#: panels/user-accounts/user-utils.c:436
-#, fuzzy
-#| msgid "The username cannot start with a '-'."
-msgid "The username cannot start with a “-”."
-msgstr "Номи корбар бояд бо '-' сар нашавад."
-
-#: panels/user-accounts/user-utils.c:439
-#, fuzzy
-#| msgid ""
-#| "The username should only consist of lower and upper case letters from a-"
-#| "z, digits and any of characters '.', '-' and '_'."
-msgid ""
-"The username should only consist of upper and lower case letters from a-z, "
-"digits and the following characters: . - _"
-msgstr ""
-"Номи корбар бояд аз ҳарфҳои хурду калон (аз a то z), рақамҳо ва аз аломатҳои "
-"'.', '-' ва '_' иборат шавад."
-
-#: panels/user-accounts/user-utils.c:443
-#, fuzzy
-#| msgid "This will be used to name your home folder and can't be changed."
-msgid "This will be used to name your home folder and can’t be changed."
-msgstr ""
-"Ин барои номи ҷузвдони асосӣ истифода мешавад ва тағйир дода намешавад."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-"Шумо барои истифодаи ин дастгоҳ иҷозат надоред. Бо маъмури низоми худ дар "
-"тамос шавед."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "Дастгоҳ аллакай истифода шудааст."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr "Хатои дарунӣ ба вуҷуд омад."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Enabled"
-msgstr "Фаъол"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:260
-msgid "Delete registered fingerprints?"
-msgstr "Нақши ангуштони қайдшударо нест мекунед?"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:264
-msgid "_Delete Fingerprints"
-msgstr "_Нест кардани нақши ангуштон"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:270
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr ""
-"Шумо мехоҳед, ки барои ғайрифаъол кардани воридшавӣ тавассути нақши ангушт, "
-"нақшҳои ангуштони қайдшударо нест кунед?"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:440
-msgid "Done!"
-msgstr "Тайёр!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:501
-#: panels/user-accounts/um-fingerprint-dialog.c:543
-#, fuzzy, c-format
-#| msgid "Could not access '%s' device"
-msgid "Could not access “%s” device"
-msgstr "Дастгоҳи '%s' кушода нашуд"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: panels/user-accounts/um-fingerprint-dialog.c:584
-#, fuzzy, c-format
-#| msgid "Could not start finger capture on '%s' device"
-msgid "Could not start finger capture on “%s” device"
-msgstr "Муайянкунии ангушт дар дастгоҳи '%s' оғоз нашуд"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:628
-msgid "Could not access any fingerprint readers"
-msgstr "Ягон хонандаи нақши ангушт дастрас нест"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:629
-msgid "Please contact your system administrator for help."
-msgstr ""
-"Лутфан, барои гирифтани дастгирӣ ба маъмури низоми худ муроҷиат намоед."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: panels/user-accounts/um-fingerprint-dialog.c:711
-#, fuzzy, c-format
-#| msgid ""
-#| "To enable fingerprint login, you need to save one of your fingerprints, "
-#| "using the '%s' device."
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the “%s” device."
-msgstr ""
-"Барои фаъол кардани воридшавӣ тавассути нақши ангушт, шумо бояд тавассути "
-"дастгоҳи \"%s\" яке аз нақшҳои ангушти худро захира кунед."
-
-#: panels/user-accounts/um-fingerprint-dialog.c:718
-msgid "Selecting finger"
-msgstr "Интихоби ангушт"
-
-#: panels/user-accounts/um-fingerprint-dialog.c:719
-msgid "Enrolling fingerprints"
-msgstr "Қайдкунии нақши ангуштон"
-
-#: panels/wacom/button-mapping.ui:9
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Нишона гузоштани тугмаҳо"
 
-#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:533
-#: panels/wacom/gnome-wacom-properties.ui:60
-msgid "_Close"
-msgstr "_Пӯшидан"
-
-#: panels/wacom/button-mapping.ui:71
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "Нишона гузоштани тугмаҳо ба функсияҳо"
 
-#: panels/wacom/button-mapping.ui:119
+#: panels/wacom/button-mapping.ui:51
 #, fuzzy
-#| msgid ""
-#| "To edit a shortcut, choose the \"Send Keystroke\" action, press the "
-#| "keyboard shortcut button and hold down the new keys or press Backspace to "
-#| "clear."
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
@@ -8316,7 +4860,11 @@ msgstr ""
 "кунед, тугмаи миёнбурро дар клавиатура зер кунед ва тугмаҳои навро таъин "
 "кунед, ё ки барои пок кардан тугмаи Backspace-ро пахш кунед."
 
-#: panels/wacom/calibrator/calibrator.ui:60
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Пӯшидан"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
@@ -8324,70 +4872,121 @@ msgstr ""
 "Лутфан, барои санҷидани планшет маркерҳои ҳадафиро ҳангоми пайдо шудани "
 "онгҳо зарба занед."
 
-#: panels/wacom/calibrator/calibrator.ui:77
+#: panels/wacom/calibrator/calibrator.ui:63
 #, fuzzy
-#| msgid "Mis-click detected, restarting..."
 msgid "Mis-click detected, restarting…"
 msgstr "Зеркунии нодуруст ташхис карда шуд, бозоғозӣ шуда истодааст..."
 
-#: panels/wacom/cc-wacom-button-row.c:253
-#, c-format
-msgid "Button %d"
-msgstr "Тугмаи %d"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Барномаи муайяншуда"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "Планшет"
 
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Фиристодани пахши тугмаҳо"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Қатъу васл кардани монитор"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "Самти чап"
 
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Намоиш додани кумаки экранӣ"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: panels/wacom/cc-wacom-mapping-panel.c:256
-msgid "Output:"
-msgstr "Барориш:"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Нишона гузоштан ба монитор..."
 
-#. Keep ratio switch
-#: panels/wacom/cc-wacom-mapping-panel.c:268
-msgid "Keep aspect ratio (letterbox):"
-msgstr "Нигоҳ доштани таносуб (қуттии почта):"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "Таносуб"
 
-#. Whole-desktop checkbox
-#: panels/wacom/cc-wacom-mapping-panel.c:279
-msgid "Map to single monitor"
-msgstr "Нишона гузоштан ба монитори ягона"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: panels/wacom/cc-wacom-nav-button.c:84
-#, c-format
-msgid "%d of %d"
-msgstr "%d аз %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "Санҷидан..."
 
-#: panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "Нақшабандии дисплей"
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Ягон планшет муайян нашуд"
 
-#: panels/wacom/cc-wacom-panel.c:845 panels/wacom/wacom-stylus-page.ui:119
-msgid "Stylus"
-msgstr "Қалам"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Лутфан, планшети Wacom-ро васл кунед ва фаъол созед"
 
-#: panels/wacom/cc-wacom-stylus-page.c:355
-msgid "Button"
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Ҳассосияти фишори нӯг"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Нарм"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Ҷиддӣ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
 msgstr "Тугма"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Тугма"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Тугма"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Ҳассосияти зеркунии тозакунак"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "Ҳассосияти зеркунии тозакунак"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Зеркунии тугмаи миёнаи муш"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Зеркунии тугмаи рости муш"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Ба пеш"
+
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
-#: panels/wacom/gnome-wacom-properties.ui:200
 msgid "Wacom Tablet"
 msgstr "Планшети Wacom"
 
@@ -8397,208 +4996,353 @@ msgstr ""
 "Таъин кардани нақшабандиҳои тугмаҳо ва танзим кардани ҳассосияти қалам барои "
 "планшетҳои графикӣ"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Планшет;Wacom;Қалам;Тозакунак;Муш;"
 
-#: panels/wacom/gnome-wacom-properties.ui:15
-msgid "Tablet (absolute)"
-msgstr "Планшет (матлақ)"
-
-#: panels/wacom/gnome-wacom-properties.ui:19
-msgid "Touchpad (relative)"
-msgstr "Панели ламсӣ (нисбӣ)"
-
-#: panels/wacom/gnome-wacom-properties.ui:27
-msgid "Tablet Preferences"
-msgstr "Хусусиятҳои планшет"
-
-#: panels/wacom/gnome-wacom-properties.ui:44
-msgid "_Help"
-msgstr "_Кумак"
-
-#: panels/wacom/gnome-wacom-properties.ui:125
-msgid "No tablet detected"
-msgstr "Ягон планшет муайян нашуд"
-
-#: panels/wacom/gnome-wacom-properties.ui:141
-msgid "Please plug in or turn on your Wacom tablet"
-msgstr "Лутфан, планшети Wacom-ро васл кунед ва фаъол созед"
-
-#: panels/wacom/gnome-wacom-properties.ui:161
-msgid "Bluetooth Settings"
-msgstr "Танзимоти Bluetooth"
-
-#: panels/wacom/gnome-wacom-properties.ui:238
-msgid "Tracking Mode"
-msgstr "Ҳолати пайгирӣ"
-
-#: panels/wacom/gnome-wacom-properties.ui:266
-msgid "Left-Handed Orientation"
-msgstr "Самти чап"
-
-#: panels/wacom/gnome-wacom-properties.ui:296
-msgid "Map to Monitor…"
-msgstr "Нишона гузоштан ба монитор..."
-
-#: panels/wacom/gnome-wacom-properties.ui:309
-msgid "Map Buttons…"
-msgstr "Нишона гузоштани тугмаҳо..."
-
-#: panels/wacom/gnome-wacom-properties.ui:322
-msgid "Calibrate…"
-msgstr "Санҷидан..."
-
-#: panels/wacom/gnome-wacom-properties.ui:340
-msgid "Adjust mouse settings"
-msgstr "Танзими хусусиятҳои муш"
-
-#: panels/wacom/gnome-wacom-properties.ui:356
-msgid "Adjust display resolution"
-msgstr "Танзими возеҳии дисплей"
-
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
-msgid "New shortcut…"
-msgstr "Миёнбури нав"
-
-#: panels/wacom/wacom-stylus-page.ui:25
-msgid "Default"
-msgstr "Пешфарз"
-
-#: panels/wacom/wacom-stylus-page.ui:29
-msgid "Middle Mouse Button Click"
-msgstr "Зеркунии тугмаи миёнаи муш"
-
-#: panels/wacom/wacom-stylus-page.ui:33
-msgid "Right Mouse Button Click"
-msgstr "Зеркунии тугмаи рости муш"
-
-#: panels/wacom/wacom-stylus-page.ui:37 shell/cc-window.ui:242
-msgid "Back"
-msgstr "Бозгашт"
-
-#: panels/wacom/wacom-stylus-page.ui:41
-msgid "Forward"
-msgstr "Ба пеш"
-
-#: panels/wacom/wacom-stylus-page.ui:79
-msgid "No stylus found"
-msgstr "Ягон қалам (стилус) ёфт нашуд"
-
-#: panels/wacom/wacom-stylus-page.ui:93
-msgid "Please move your stylus to the proximity of the tablet to configure it"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
 msgstr ""
-"Лутфан, барои танзим кардани қалам (стилус) онро дар сатҳи лавҳа ҳаракат "
-"намоед"
 
-#: panels/wacom/wacom-stylus-page.ui:159
-msgid "Eraser Pressure Feel"
-msgstr "Ҳассосияти зеркунии тозакунак"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:340
-msgid "Soft"
-msgstr "Нарм"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:210 panels/wacom/wacom-stylus-page.ui:370
-msgid "Firm"
-msgstr "Ҷиддӣ"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:233
-msgid "Top Button"
-msgstr "Поёни боло"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:262
-msgid "Lower Button"
-msgstr "Тугмаи пасткунӣ"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: panels/wacom/wacom-stylus-page.ui:291
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
 #, fuzzy
-#| msgid "Lower Button"
-msgid "Lowest Button"
-msgstr "Тугмаи пасткунӣ"
+msgid "Resize with Secondary Click"
+msgstr "_Шабеҳсозии зеркунии иловагӣ"
 
-#: panels/wacom/wacom-stylus-page.ui:320
-msgid "Tip Pressure Feel"
-msgstr "Ҳассосияти фишори нӯг"
-
-#: shell/appdata/gnome-control-center.appdata.xml.in:7
+#: panels/windows/cc-windows-panel.ui:89
 #, fuzzy
-#| msgid "- Settings"
-msgid "GNOME Settings"
-msgstr "- Танзимот"
+msgid "Windows Focus"
+msgstr "Нармафзори Windows"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
 #, fuzzy
-#| msgid "Utilities to configure the GNOME desktop"
+msgid "Focus on Hover"
+msgstr "Миқдори тонер паст аст"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Дуюм"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Нармафзори Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Имконоти дастрсӣ"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Илова кардан"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Захира кардан"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Тафсилот"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+#, fuzzy
+msgid "Modem Status"
+msgstr "Вазъият:"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "_Вақти шабака"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Шабакаҳо"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "Рақамҳо"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Тафсилоти принтер"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Истеҳсолкунанда"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "Нармафзори дарунсохт вуҷуд надорад"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Паҳннавори мобилӣ"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "_Вақти шабака"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Шабака"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "Иловагӣ"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "Имконоти дастрсӣ"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "Экрани қулф"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Тафсилот"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Номи шабака"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "Худкор"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "Шабакаи хонагии ман"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Шабакаи хонагии ман"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "Ягон тасвир ёфт нашудааст"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+"Вақте ки ҳолати ҳавопаймо фаъол аст, Bluetooth дар ҳолати ғайрифаъол қарор "
+"мегирад."
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "Ҳ_олати ҳавопаймо"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Пайвастшавӣ"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "Корти SIM ворид нашудааст"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "Экрани қулф"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "_Тағйир додан"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "Шабакаи хонагии ман"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Telephony and mobile data connections"
+msgstr "Медиаи ҷудошаванда"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+#, fuzzy
 msgid "Utility to configure the GNOME desktop"
 msgstr "Барномаҳои пуштибонӣ барои танзими мизи кории GNOME"
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:10
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
 msgstr ""
 
-#: shell/appdata/gnome-control-center.appdata.xml.in:20
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
 msgid "The GNOME Project"
 msgstr ""
 
-#: shell/cc-application.c:58
+#: shell/cc-panel-list.ui:18
 #, fuzzy
-#| msgid "Display Brightness"
-msgid "Display version number"
-msgstr "Равшании дисплей"
+msgid "Settings categories"
+msgstr "Танзимкунии драйвери нав..."
 
-#: shell/cc-application.c:59
-msgid "Enable verbose mode"
-msgstr "Фаъол кардани ҳолати ботафсил"
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "Махфият"
 
-#: shell/cc-application.c:60
-msgid "Search for the string"
-msgstr "Ҷустуҷӯи сатр"
-
-#: shell/cc-application.c:61
-msgid "List possible panel names and exit"
-msgstr "Пайванд гузоштани номҳои эҳтимолии наворҳо ва баромад"
-
-#: shell/cc-application.c:62
-msgid "Panel to display"
-msgstr "Панел барои намоиш"
-
-#: shell/cc-application.c:62
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
-
-#: shell/cc-panel-loader.c:279
-msgid "Available panels:"
-msgstr "Лавҳаҳои дастрас:"
-
-#: shell/cc-window.ui:146
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "Ҳамаи танзимот"
 
-#: shell/cc-window.ui:184
+#: shell/cc-window.ui:54
 msgid "Primary Menu"
 msgstr "Феҳристи асосӣ"
 
-#: shell/cc-window.ui:326
+#: shell/cc-window.ui:152
 msgid "Warning: Development Version"
 msgstr ""
 
-#: shell/cc-window.ui:327
+#: shell/cc-window.ui:153
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
 "issues. "
 msgstr ""
 
-#: shell/cc-window.ui:338
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "Кумак"
-
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: shell/gnome-control-center.desktop.in.in:17
-msgid "Preferences;Settings;"
-msgstr "Хусусиятҳо;Танзимот;"
 
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
@@ -8610,7 +5354,7 @@ msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Баромад"
 
-#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "Ҷустуҷӯ"
@@ -8620,15 +5364,19 @@ msgctxt "shortcut window"
 msgid "Panels"
 msgstr "Лавҳаҳо"
 
-#: shell/help-overlay.ui:40
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
 msgstr "Гузариш ба лавҳаи қаблӣ"
 
-#: shell/help-overlay.ui:53
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Бекор кардани ҷустуҷӯ"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Хусусиятҳо;Танзимот;"
 
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
@@ -8649,30 +5397,2901 @@ msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr ""
 
-#. translators:
-#. * The number of sound outputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1871
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u барориш"
 msgstr[1] "%u барориш"
 
-#. translators:
-#. * The number of sound inputs on a particular device
-#: subprojects/gvc/gvc-mixer-control.c:1881
+#: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u вуруд"
 msgstr[1] "%u вуруд"
 
-#: subprojects/gvc/gvc-mixer-control.c:2736
-msgid "System Sounds"
-msgstr "Овозҳои низом"
+#, fuzzy
+#~| msgid "System Sounds"
+#~ msgid "System Bus"
+#~ msgstr "Овозҳои низом"
 
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "Bluetooth ғайрифаъол аст"
+#, fuzzy
+#~| msgid "_Full Name"
+#~ msgid "Full access"
+#~ msgstr "_Номи пурра"
+
+#, fuzzy
+#~| msgid "Session Ended"
+#~ msgid "Session Bus"
+#~ msgstr "Ҷаласа хотима ёфт"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Дастрасии пурра ба /dev"
+
+#, fuzzy
+#~| msgid "Network Name"
+#~ msgid "Has network access"
+#~ msgstr "Номи шабака"
+
+#~ msgid "Home"
+#~ msgstr "Асосӣ"
+
+#, fuzzy
+#~| msgctxt "printer state"
+#~| msgid "Ready"
+#~ msgid "Read-only"
+#~ msgstr "Тайёр"
+
+#, fuzzy
+#~| msgid "Link speed"
+#~ msgid "Links"
+#~ msgstr "Суръати пайванд"
+
+#, fuzzy
+#~| msgid "_Delete Files"
+#~ msgid "Hypertext Files"
+#~ msgstr "_Нест кардани файлҳо"
+
+#, fuzzy
+#~| msgid "_Delete Files"
+#~ msgid "Text Files"
+#~ msgstr "_Нест кардани файлҳо"
+
+#, fuzzy
+#~| msgid "_Keep Files"
+#~ msgid "Image Files"
+#~ msgstr "_Нигоҳ доштани файлҳо"
+
+#, fuzzy
+#~| msgid "_Delete Files"
+#~ msgid "Font Files"
+#~ msgstr "_Нест кардани файлҳо"
+
+#, fuzzy
+#~| msgid "All files"
+#~ msgid "Audio Files"
+#~ msgstr "Ҳамаи файлҳо"
+
+#, fuzzy
+#~| msgid "_Keep Files"
+#~ msgid "Video Files"
+#~ msgstr "_Нигоҳ доштани файлҳо"
+
+#, fuzzy
+#~| msgid "Password could not be changed"
+#~ msgid "Cannot be changed"
+#~ msgstr "Ниҳонвожа тағйир дода намешавад"
+
+#, fuzzy
+#~| msgid "Orientation"
+#~ msgid "Integration"
+#~ msgstr "Самт"
+
+#, fuzzy
+#~| msgid "_Default printer"
+#~ msgid "Default Handlers"
+#~ msgstr "_Принтери пешфарз"
+
+#, fuzzy
+#~| msgid "_Software"
+#~ msgid "Open in Software"
+#~ msgstr "_Нармафзор"
+
+#, fuzzy
+#~| msgid "Background"
+#~ msgid "_Background"
+#~ msgstr "Пасзамина"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Тағйироти рӯз"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Сафолпӯш"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Танзими андоза"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Ба марказ кӯчонидан"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Миқиёсбандӣ"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Пуркунӣ"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Ваҷаб"
+
+#~ msgid "Colors"
+#~ msgstr "Рангҳо"
+
+#~ msgid "Select Background"
+#~ msgstr "Интихоби пасзамина"
+
+#~ msgid "Pictures"
+#~ msgstr "Тасвирҳо"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Ягон тасвир ёфт нашудааст"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Шумо метавонед тасвирҳоро ба ҷузвдони %s илова кунед ва онҳо дар ин ҷо "
+#~ "намоиш дода мешаванд"
+
+#~ msgid "multiple sizes"
+#~ msgstr "якчанд андоза"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Бе пасзаминаи мизи корӣ"
+
+#~ msgid "Current background"
+#~ msgstr "Пасзаминаи ҷорӣ"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Тасвири экран;Экран;Мизи корӣ;"
+
+#, fuzzy
+#~| msgid "Place your calibration device over the square and press 'Start'"
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "Дастгоҳи санҷишии худро ба чоркунҷа гузошта, \"Оғоз\"-ро зер кунед"
+
+#, fuzzy
+#~| msgid ""
+#~| "Move your calibration device to the calibrate position and press "
+#~| "'Continue'"
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Дастгоҳи санҷишии худро ба ҷойгиршавии санҷиш гузошта, \"Идома додан\"-ро "
+#~ "пахш кунед"
+
+#, fuzzy
+#~| msgid ""
+#~| "Move your calibration device to the surface position and press 'Continue'"
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Дастгоҳи санҷишии худро ба ҷойгиршавии сатҳ гузошта, \"Идома додан\"-ро "
+#~ "пахш кунед"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Пӯшидани сарпӯши лэптоп"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Хатои дарунии ҳалнашаванда ба вуҷуд омад."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Абзорҳои лозимии санҷиши насб нашудаанд."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Профил эҷод карда нашуд."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Нуқтаи сафеди таъинотӣ ба даст оварда нашуд."
+
+#~ msgid "Complete!"
+#~ msgstr "Ба анҷом расид!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Санҷиш қатъ шудааст!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Шумо метавонед дастгоҳи санҷиширо тоза кунед."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Дастгоҳи санҷиширо дар ҳолати иҷро қатъ накунед"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Экрани лэптоп"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Вебкамераи дарунсохт"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Монитори %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Сканери %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Камераи %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Принтери %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Веб-камераи %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Фаъол кардани идоракунии рангҳо барои %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Намоиш додани профилҳои ранг барои %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Санҷиш нашудааст"
+
+#~ msgid "Default: "
+#~ msgstr "Пешфарз:"
+
+#~ msgid "Test profile: "
+#~ msgstr "Санҷиши профил:"
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Интихоби файли профили ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Ворид кардан"
+
+#~ msgid "All files"
+#~ msgstr "Ҳамаи файлҳо"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Боркунии файл қатъ шуд: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Профил ба макони зерин бор шудааст:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Ин суроғаи URL-ро нависед."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Бозоғозидани ин компютер ва роҳандозӣ кардани низоми амалиётии муқаррарии "
+#~ "шумо"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Суроғаи URL-ро ба браузери худ ворид кунед, то ин ки профилро боргирӣ ва "
+#~ "насб кунед."
+
+#~ msgid "Save Profile"
+#~ msgstr "Захира кардани профил"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Эҷод кардани профили рангин барои дастгоҳи интихобшуда"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Абзори ченкунӣ ёфт нашуд. Лутфан, санҷед, ки он фаъол мебошад, ва ба "
+#~ "таври дуруст пайваст шудаанд."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Абзори ченкунӣ профилҳои принтерро дастгирӣ намекунад."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Намуди дастгоҳ дар айни ҳол дастгирӣ намешавад."
+
+#~ msgid "Upload profile"
+#~ msgstr "Бор кардани профил"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Пайвасти интернет лозим аст"
+
+#~ msgid "Standard Space"
+#~ msgstr "Фазои стандартӣ"
+
+#~ msgid "Test Profile"
+#~ msgstr "Санҷиши профил"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Худкор"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Сифати паст"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Сифати миёна"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Сифати баланд"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB-и пешфарз"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK-и пешфарз"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Хокистариранги пешфарз"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Иттилооти санҷиши заводии бо фурӯшанда таъминшуда"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Ислоҳкунии экрани пурраи дисплей бо ин профил имконнопазир аст"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Эҳтимол аст, ки ин профил дигар саҳеҳ намебошад"
+
+#~ msgid "Other…"
+#~ msgstr "Дигар…"
+
+#~ msgid "Today"
+#~ msgstr "Имрӯз"
+
+#~ msgid "Yesterday"
+#~ msgstr "Дирӯз"
+
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#, fuzzy
+#~| msgid "_Stop Hotspot"
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "_Қатъ кардани \"ХОТ-СПОТ\""
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "24-hour"
+#~ msgstr "24-соат"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "On"
+#~ msgstr "Фаъол"
+
+#~ msgid "Off"
+#~ msgstr "Хомӯш"
+
+#, fuzzy
+#~| msgid "Display Type"
+#~ msgid "Display Mode"
+#~ msgstr "Намуди дисплей"
+
+#, fuzzy
+#~| msgid "Display Mapping"
+#~ msgid "Display Arrangement"
+#~ msgstr "Нақшабандии дисплей"
+
+#, fuzzy
+#~| msgid "Display Calibration"
+#~ msgid "Display Configuration"
+#~ msgstr "Санҷиши дисплей"
+
+#, fuzzy
+#~| msgid "Landscape"
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Уфуқӣ"
+
+#, fuzzy
+#~| msgid "Portrait"
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Амудӣ"
+
+#, fuzzy
+#~| msgid "Portrait"
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Амудӣ"
+
+#, fuzzy
+#~| msgid "Landscape"
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Уфуқӣ"
+
+#~ msgid "Unknown"
+#~ msgstr "Номаълум"
+
+#, fuzzy, c-format
+#~| msgid "%d-bit"
+#~ msgid "64-bit"
+#~ msgstr "%d-бит"
+
+#, fuzzy, c-format
+#~| msgid "%d-bit"
+#~ msgid "32-bit"
+#~ msgstr "%d-бит"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "Версияи %s"
+
+#, fuzzy
+#~| msgid "Security type"
+#~ msgid "OS type"
+#~ msgstr "Навъи амният"
+
+#~ msgid "Disk"
+#~ msgstr "Диск"
+
+#~ msgid "Check for updates"
+#~ msgstr "Санҷиши навсозиҳо"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Чӣ бояд кард"
+
+#~ msgid "Do nothing"
+#~ msgstr "Амалиёт лозим нест"
+
+#~ msgid "Open folder"
+#~ msgstr "Кушодани ҷузвдон"
+
+#~ msgid "Other Media"
+#~ msgstr "Мултимедиаи дигар"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Интихоби барнома барои аудио дар дискҳои CD"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Интихоби барнома барои видео дар дискҳои DVD"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr ""
+#~ "Барномаеро барои иҷро шудан ҳангоми пайваст шудани плеери мусиқӣ интихоб "
+#~ "кунед"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr ""
+#~ "Барномаеро барои иҷро шудан ҳангоми пайваст шудани камера интихоб кунед"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Интихоби барнома барои нармафзор дан дискҳои CD"
+
+#~ msgid "audio DVD"
+#~ msgstr "Диски аудиои DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "диски холии Blu-ray"
+
+#~ msgid "blank CD disc"
+#~ msgstr "диски холии CD"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "диски холии DVD"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "диски холии HD DVD"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Диски видеои Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "хонандаи китобхои электронӣ"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Диски видеои HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "Суратҳо дар CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Супервидеои CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Видеои CD"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Захира кардани сурати экран ба $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Захира кардани сурати равзана ба $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Захира кардани сурати ноҳия ба $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Нусха бардоштани сурати экран ба ҳофизаи муваққатӣ"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Нусха бардоштани сурати равзана ба ҳофизаи муваққатӣ"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Нусха бардоштани сурати ноҳия ба ҳофизаи муваққатӣ"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Сабт кардани видеои экрании кӯтоҳ"
+
+#~ msgid "Universal Access"
+#~ msgstr "Дастрасии умумӣ"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Табдилдиҳандагон-танҳо гузариш ба манбаи навбатӣ"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Ҳамаи миёнбурҳоро тоза мекунед?"
+
+#, fuzzy
+#~| msgid "Reset"
+#~ msgid "Reset All"
+#~ msgstr "Бозсозӣ"
+
+#, fuzzy
+#~| msgid "Custom Shortcut"
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Миёнбури шахсӣ"
+
+#, fuzzy
+#~| msgid "Select"
+#~ msgid "Set"
+#~ msgstr "Интихоб кардан"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Анҷоми вақти зеркуни дубора"
+
+#, fuzzy
+#~| msgid "Two _finger scroll"
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Ҳаракатдиҳии _дуангушта"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Панҷ зеркунӣ, вақти GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Зеркунии дубора, тугмаи асосӣ"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Зеркунии якбора, тугмаи асосӣ"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Зеркунии дубора, тугмаи миёна"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Зеркунии якбора, тугмаи миёна"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Зеркунии дубора, тугмаи иловагӣ"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Зеркунии якбора, тугмаи иловагӣ"
+
+#~ msgid "Network proxy"
+#~ msgstr "Прокси шабака"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "VPN-и %s"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Мудири шабака бояд иҷро карда шавад."
+
+#, fuzzy, c-format
+#~| msgctxt "timezone desc"
+#~| msgid "%s (%s)"
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "page 1"
+#~ msgstr "саҳифаи 1"
+
+#~ msgid "page 2"
+#~ msgstr "саҳифаи 2"
+
+#~ msgid "automatic"
+#~ msgstr "худкор"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Профили %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Корхонавӣ"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Ҳеҷ"
+
+#~ msgid "Never"
+#~ msgstr "Ҳеҷ гоҳ"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d МБ/с"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Ҳеҷ"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Паст"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Хуб"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Хуб"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Аъло"
+
+#, fuzzy
+#~| msgid "Connection failed"
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Пайваст қатъ шудааст"
+
+#, fuzzy
+#~| msgid "_Remove"
+#~ msgid "Remove VPN"
+#~ msgstr "_Тоза кардан"
+
+#~ msgid "Identity"
+#~ msgstr "Шахсият"
+
+#~ msgid "Delete Route"
+#~ msgstr "Нест кардани масир"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Ҳеҷ"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Калиди 40/128-бити WEP (Hex ё ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Гузарвожаи WEP 128-бит"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP-и динамикӣ (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Шахсӣ"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Корхонавӣ"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Ҷуфти тобдор (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Интерфейси воҳиди замима (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Интерфейси мустақили медиа (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 МБ/с"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 МБ/с"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 ГБ/с"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 ГБ/с"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Муҳаррири пайвастҳо кушода нашуд"
+
+#~ msgid "New Profile"
+#~ msgstr "Профили нав"
+
+#~ msgid "Import from file…"
+#~ msgstr "Ворид кардан аз файл…"
+
+#, fuzzy
+#~| msgid "%s VPN"
+#~ msgid "Add VPN"
+#~ msgstr "VPN-и %s"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Пайвасти VPN ворид намешавад"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "The file '%s' could not be read or does not contain recognized VPN "
+#~| "connection information\n"
+#~| "\n"
+#~| "Error: %s."
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Файли \"%s\" наметавонад хонда шавад, ё ки маълумоти муайяншудаи пайвасти "
+#~ "VPN-ро надорад\n"
+#~ "\n"
+#~ "Хатогӣ: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Интихоби файл барои воридот"
+
+#, fuzzy, c-format
+#~| msgid "A file named \"%s\" already exists."
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Номи файли \"%s\" аллакай мавҷуд аст."
+
+#~ msgid "_Replace"
+#~ msgstr "Ҷойгузин _кардан"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Шумо мехоҳед, ки %s-ро бо пайвасти VPN-и захирашуда ҷойгузин кунед?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Пайвасти VPN содир намешавад"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "The VPN connection '%s' could not be exported to %s.\n"
+#~| "\n"
+#~| "Error: %s."
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Пайвасти VPN-и \"%s\" ба %s содир карда нашуд.\n"
+#~ "\n"
+#~ "Хатогӣ: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Содир кардани пайвасти VPN"
+
+#~ msgid "never"
+#~ msgstr "ҳеҷ гоҳ"
+
+#~ msgid "today"
+#~ msgstr "имрӯз"
+
+#~ msgid "yesterday"
+#~ msgstr "дирӯз"
+
+#~ msgid "Last used"
+#~ msgstr "Истифодашудаи охирин"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "Гузариш ба хот-споти бесим пайвасти шуморо аз <b>%s</b> қатъ мегардонад."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Ҳангоми фаъол будани хот-спот шумо наметавонед тавассути пайвасти бесими "
+#~ "худ ба Интернет пайваст шавед."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Пайвасти \"ХОТ-СПОТ\" ва ҳамаи корбаронро қатъ мекунед?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Қатъ кардани \"ХОТ-СПОТ\""
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Сиёсати низом истифодаи минтақаи дастрасиро манъ мекунад"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Дастгоҳи бесим ҳолати \"ХОТ-СПОТ\"-ро дастгирӣ намекунад"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Тафсилоти шабака барои шабакаҳои интихобшуда, аз он ҷумла ниҳонвожаҳо ва "
+#~ "ягон конфигуратсияи фармоишӣ, гум карда мешавад."
+
+#~ msgid "_Forget"
+#~ msgstr "_Фаромӯш кардан"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "__Фаромӯш кардан"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Ҳангоми пешҳниҳод нашудани суроғаи URL-и конфигуратсия ташхиси худкори "
+#~ "проксии веб истифода мешавад."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Ин барои шабакаҳои беэътимоди оммавӣ тавсия намешавад."
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "Паёвасти _худкор"
+
+#~ msgid "details"
+#~ msgstr "тафсилот"
+
+#~ msgid "Show P_assword"
+#~ msgstr "Намоиш додани п_арол"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Дастрас кардан ба корбарони дигар"
+
+#~ msgid "identity"
+#~ msgstr "шахсият"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "_Суроғаҳо"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Танҳо суроғаҳои худкор (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Танҳо пайванди маҳаллӣ"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Нодида гирифтани масирҳои ба таври худкор бадастовардашуда"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "С_уроғаи MAC-и нусхабардошта"
+
+#~ msgid "_Reset"
+#~ msgstr "_Бозсозӣ"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Танзими дубораи танзимоти ин пайваст ба пешфарзҳои онҳо, аммо дар ёд "
+#~ "доштан ҳамчун пайвасти пазируфта."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Тоза кардани ҳамаи тафсилоти ин шабака ва пайваст нашудани худкор ба он."
+
+#~ msgid "Hardware"
+#~ msgstr "Сахтафзор"
+
+#, fuzzy
+#~| msgid "Reset"
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Бозсозӣ"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Барои пайваст шудан ба шабакаи Wi-Fi, ҷодо сзед"
+
+#~ msgid "Connected Devices"
+#~ msgstr "Дастгоҳҳои пайвастшуда"
+
+#, fuzzy
+#~| msgid "Password"
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Ниҳонвожа"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Махсус"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Инфрасохтор"
+
+#~ msgid "Status unknown"
+#~ msgstr "Вазъияти номаълум"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Идоранушуда"
+
+#~ msgid "Unavailable"
+#~ msgstr "Дастнорас"
+
+#~ msgid "Connecting"
+#~ msgstr "Пайваст шуда истодааст"
+
+#~ msgid "Authentication required"
+#~ msgstr "Санҷиши ҳаққоният лозим аст"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Пайваст қатъ шуда истодааст"
+
+#~ msgid "Connection failed"
+#~ msgstr "Пайваст қатъ шудааст"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Вазъияти номаълум (намерасидагӣ)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Танзимот қатъ шудааст"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Танзимоти IP қатъ шуд"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Танзимоти IP аз мӯҳлаташ гузашт"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Сирҳо лозим мебошанд, аммо пешниҳод нашуданд"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Пайвасти дархосткунандаи 802.1x қатъ шудааст"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Конфигуратсияи дархосткунандаи 802.1x қатъ шудааст"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Дархосткунандаи 802.1x қатъ шудааст"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Дархосткунандаи 802.1x барои санҷиши ҳаққоният вақти зиёдро гирифт"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Оғози хидмати PPP қатъ шудааст"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Пайвасти хидмати PPP қатъ шудааст"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP қатъ шудааст"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Оғози муштарии DHCP бо нокомӣ дучор шудааст"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Хатогии муштарии DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Муштарии DHCP бо нокомӣ дучор шудааст"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Оғози хидмати пайвасти мубодилашуда қатъ шуд"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Хидмати пайвасти мубодилашуда қатъ шуд"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Оғози хидмати AutoIP қатъ шудааст"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Хатои хидмати AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Хидмати AutoIP қатъ шудааст"
+
+#~ msgid "Line busy"
+#~ msgstr "Хат машғул аст"
+
+#~ msgid "No dial tone"
+#~ msgstr "Бе оҳанги занг"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Ягон ҳомил пайваст нашудааст"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Вақти шуморагирӣ ба анҷом расид"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Шуморагирӣ қатъ шудааст"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Оғоздиҳии модем ба анҷом нарасид"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Интихоби APN-и муайяншуда қатъ шуд"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Шабакаҳоро ҷустуҷӯ намекунад"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Қайдкунии шабака қатъ шудааст"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Вақти қайдкунии шабака ба анҷом расид"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Қайдкунӣ бо шабакаи дархостшуда қатъ шуд"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Санҷиши PIN қатъ шуд"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Эҳтимол аст, ки дастгоҳ нармафзори дарунсохт надорад"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Пайваст гум шудааст"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Пайвасти мавҷудбуда мунтазир буд"
+
+#~ msgid "Modem not found"
+#~ msgstr "Модем ёфт нашуд"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Пайвастшавии Bluetooth ба анҷом нарасид"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM Pin лозим аст"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk лозим аст"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM нодуруст аст"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Вобастагии пайваст қатъ шуд"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Сим ҷудо шудааст"
+
+#~ msgid "no file selected"
+#~ msgstr "ягон файл интихоб нашуд"
+
+#, fuzzy
+#~| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "Калидҳои шахсии DER, PEM, ё PKCS#12 (*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Гувоҳиномаҳои DER ё PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Файли PAC (*.pac)"
+
+#~ msgid "missing EAP password"
+#~ msgstr "ниҳонвожаи EAP ворид нашуд"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Калидҳои махфии берамз хатарнок мебошанд"
+
+#, fuzzy
+#~| msgid ""
+#~| "The selected private key does not appear to be protected by a password.  "
+#~| "This could allow your security credentials to be compromised.  Please "
+#~| "select a password-protected private key.\n"
+#~| "\n"
+#~| "(You can password-protect your private key with openssl)"
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Калиди махфии интихобшуда бо ниҳонвожа ҳифз нашудааст.  Ин метавонад "
+#~ "сабаби бадном кардани маълумоти корбари амниятии шумо гардад.  Лутфан, "
+#~ "калиди махфии бо ниҳонвожа ҳифзшударо интихоб кунед.\n"
+#~ "\n"
+#~ "(Шумо метавонед калиди махфии худро тавассути openssl бо ниҳонвожа "
+#~ "муҳофизат кунед)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Интихоб кардани гувоҳиномаи шахсӣ"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Интихоб кардани калиди шахсӣ"
+
+#~ msgid "missing leap-password"
+#~ msgstr "ниҳонвожаи мамониат ворид нашуд"
+
+#, fuzzy
+#~| msgid "Notifications"
+#~ msgid "Notification _Popups"
+#~ msgstr "Огоҳиҳо"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Дигар"
+
+#, fuzzy, c-format
+#~| msgid "My Account"
+#~ msgid "%s Account"
+#~ msgstr "Ҳисоби ман"
+
+#~ msgid "Error removing account"
+#~ msgstr "Ҳангоми тозакунии ҳисоб хатогӣ ба вуҷуд омад"
+
+#~ msgid "Remove Account"
+#~ msgstr "Тоза кардани ҳисоб"
+
+#~ msgid "Unknown time"
+#~ msgstr "Вақти номаълум"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s то анҷоми пуркунии батарея"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Диққат: %s боқимонда"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s боқимонда"
+
+#~ msgid "Fully charged"
+#~ msgstr "Комилан пур аст"
+
+#, fuzzy
+#~| msgid "Charging"
+#~ msgid "Not charging"
+#~ msgstr "Пуркунии барқ"
+
+#~ msgid "Empty"
+#~ msgstr "Холӣ кардан"
+
+#~ msgid "Charging"
+#~ msgstr "Пуркунии барқ"
+
+#~ msgid "Discharging"
+#~ msgstr "Тамомшавии барқ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Асосӣ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Иловагӣ"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Муши бесим"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Клавиатураи бесим"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Таъминоти қатънашавандаи барқ"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Ёрдамчии рақамии шахсӣ"
+
+#~ msgid "Cellphone"
+#~ msgstr "Телефони мобилӣ"
+
+#~ msgid "Media player"
+#~ msgstr "Плеери мултимедиа"
+
+#~ msgid "Computer"
+#~ msgstr "Компютер"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Пуркунии барқ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Диққат"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Паст"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Хуб"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Комилан пур аст"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Холӣ"
+
+#~ msgid "Batteries"
+#~ msgstr "Батареяҳо"
+
+#, fuzzy, c-format
+#~| msgid "%i hour"
+#~| msgid_plural "%i hours"
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%i соат"
+#~ msgstr[1] "%i соат"
+
+#, fuzzy, c-format
+#~| msgid "%i minute"
+#~| msgid_plural "%i minutes"
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%i дақиқа"
+#~ msgstr[1] "%i дақиқа"
+
+#, fuzzy, c-format
+#~| msgid "30 seconds"
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "30 сония"
+#~ msgstr[1] "30 сония"
+
+#, fuzzy, c-format
+#~| msgid "%i %s %i %s"
+#~ msgctxt "time"
+#~ msgid "%s %s %s"
+#~ msgstr "%i %s %i %s"
+
+#, fuzzy, c-format
+#~| msgid "%i %s %i %s"
+#~ msgctxt "time"
+#~ msgid "%s %s"
+#~ msgstr "%i %s %i %s"
+
+#~ msgid "When _idle"
+#~ msgstr "Вақте ки беҳаракат аст"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "_Равшании экран"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "_Дурахшонии экран"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "_Камнур кардани экран дар ҳолати ғайрифаъол"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#, fuzzy
+#~| msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Дастгоҳҳои паҳннавори мобилӣ (3G, 4G, WiMax ва ғайра) барқи иловагиро "
+#~ "талаб мекунад"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "When on battery power"
+#~ msgstr "Вақте ки аз батарея кор мекунад"
+
+#~ msgid "When plugged in"
+#~ msgstr "Вақте ки аз манбаъ барқ кор мекунад"
+
+#~ msgid "Power Off"
+#~ msgstr "Анҷоми кор"
+
+#~ msgid "Hibernate"
+#~ msgstr "Гибернатсия"
+
+#, fuzzy
+#~| msgid "Do nothing"
+#~ msgid "Nothing"
+#~ msgstr "Амалиёт лозим нест"
+
+#, fuzzy
+#~| msgid "Suspend & Power Off"
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Таваққуф ва анҷоми кор"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Таваққуфи худкор"
+
+#, fuzzy
+#~| msgid "_Automatic suspend"
+#~ msgid "Automatic suspend"
+#~ msgstr "_Таваққуфи худкор"
+
+#, fuzzy
+#~| msgid "1 minute"
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 дақиқа"
+
+#, fuzzy
+#~| msgid "2 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 дақиқа"
+
+#, fuzzy
+#~| msgid "3 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 дақиқа"
+
+#, fuzzy
+#~| msgid "4 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 дақиқа"
+
+#, fuzzy
+#~| msgid "5 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 дақиқа"
+
+#, fuzzy
+#~| msgid "8 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 дақиқа"
+
+#, fuzzy
+#~| msgid "10 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 дақиқа"
+
+#, fuzzy
+#~| msgid "12 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 дақиқа"
+
+#, fuzzy
+#~| msgid "15 minutes"
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 дақиқа"
+
+#, fuzzy
+#~| msgid "Never"
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Ҳеҷ гоҳ"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Санҷиши ҳаққоният"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Иловакунии принтери нав қатъ шуд."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Интерфейси корбар бор нашуд: %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Ягон драйвери мувофиқ ёфт нашудааст"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Интихоби файли PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Файлҳои тавсифи принтери PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Принтери JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Принтери LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Яктарафа"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Канори дароз (стандартӣ)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Канори кӯтоҳ (акскунӣ)"
+
+#~ msgid "Portrait"
+#~ msgstr "Амудӣ"
+
+#~ msgid "Landscape"
+#~ msgstr "Уфуқӣ"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Баръакси уфуқӣ"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Баръакси амуди"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Мунтазир"
+
+#, fuzzy
+#~| msgid "Last used"
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Истифодашудаи охирин"
+
+#, fuzzy
+#~| msgid "Authentication required"
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Санҷиши ҳаққоният лозим аст"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Коркард"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Манъ шуд"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Бекор карда шуд"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Қатъшуда"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Ба анҷом расид"
+
+#, fuzzy, c-format
+#~| msgid "%s Active Jobs"
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s вазифаи фаъол"
+
+#, fuzzy
+#~| msgid "Select Printer Driver"
+#~ msgid "Unlock Print Server"
+#~ msgstr "Интихоби драйвери принтер"
+
+#, fuzzy, c-format
+#~| msgid "Enter your username and password to view printers available on %s."
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Барои намоиш додани принтерҳои дастрас дар %s, шумо бояд номи корбар ва "
+#~ "ниҳонвожаро ворид кунед."
+
+#, fuzzy
+#~| msgid "Not searching for networks"
+#~ msgid "Searching for Printers"
+#~ msgstr "Шабакаҳоро ҷустуҷӯ намекунад"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Порти силсилавӣ"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Порти мувозӣ"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Ҷойгиршавӣ: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Суроға: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "_Сервер санҷиши ҳаққониятро талаб мекунад"
+
+#~ msgid "Two Sided"
+#~ msgstr "Дутарафа"
+
+#~ msgid "Paper Type"
+#~ msgstr "Навъи қоғаз"
+
+#~ msgid "Paper Source"
+#~ msgstr "Манбаи қоғаз"
+
+#~ msgid "Output Tray"
+#~ msgstr "Қуттии барориш"
+
+#, fuzzy
+#~| msgid "Resolution"
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Возеҳӣ"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Филтркунии пешакии GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Саҳифаҳо дар як тараф"
+
+#~ msgid "Orientation"
+#~ msgstr "Самт"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Умумӣ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Танзими саҳифа"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Имконоти насбшаванда"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Вазифа"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Сифати тасвир"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Ранг"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Ба анҷом расида истоддаст"
+
+#~ msgid "Test page"
+#~ msgstr "Саҳифаи санҷишӣ"
+
+#~ msgid "Auto Select"
+#~ msgstr "Интихоб ба таври худкор"
+
+#~ msgid "Printer Default"
+#~ msgstr "Принтери пешфарз"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Илова кардани танҳо шрифтҳои GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Табдил додан ба сатҳи 1 PS"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Табдил додан ба сатҳи 2 PS"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Ягон филтри пешакӣ нест"
+
+#~ msgid "Out of toner"
+#~ msgstr "Тонер тамом шуд"
+
+#~ msgid "Low on developer"
+#~ msgstr "Таҳиягар паст аст"
+
+#~ msgid "Out of developer"
+#~ msgstr "Таҳиягар ба анҷом расид"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Миқдори таъминоти маркер паст аст"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Таъминоти маркер ба анҷом расид"
+
+#~ msgid "Open cover"
+#~ msgstr "Кушодани сарпӯш"
+
+#~ msgid "Open door"
+#~ msgstr "Дари кушода"
+
+#~ msgid "Low on paper"
+#~ msgstr "Миқдори қоғаз паст аст"
+
+#~ msgid "Out of paper"
+#~ msgstr "Қоғаз тамом шуд"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Офлайн"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Манъ шуд"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Махзани партов тақрибан пур аст"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Махзани партов пур аст"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Ҳодии оптикии сурат дар вақти наздик аз кор мебарояд"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Ҳодии оптикии сурат дигар кор намекунад"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Тайёр"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Корҳоро қабул намекунад"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Коркард"
+
+#, fuzzy
+#~| msgid "On"
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Фаъол"
+
+#, fuzzy
+#~| msgid "Off"
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Хомӯш"
+
+#, fuzzy
+#~| msgid "Off"
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "Хомӯш"
+
+#, fuzzy
+#~| msgid "On"
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "Фаъол"
+
+#, fuzzy
+#~| msgid "Off"
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "Хомӯш"
+
+#, fuzzy
+#~| msgid "On"
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "Фаъол"
+
+#~ msgid "Usage & History"
+#~ msgstr "Истифодабарӣ ва таърих"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Ҳамаи объектҳои сабадро бебозгашт нест мекунед?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Ҳамаи объектҳои сабад бебозгашт нест карда мешаванд."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "_Холӣ кардани сабад"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Ҳамаи файлҳои муваққатиро нест мекунед?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Ҳамаи файлҳои муваққатӣ бебозгашт нест карда мешаванд."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Пок кардани файлҳои муваққатӣ"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "Фиристодани гузоришҳо дар бораи мушкилиҳои техникӣ барои кумаки "
+#~ "такмилдиҳии %s. Гузоришҳо ба тавримахфӣ фиристода мешаванд ва маълумоти "
+#~ "шахсиро дар бар намегиранд."
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Сиёсати махфият"
+
+#, fuzzy
+#~| msgid "30 seconds"
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 сония"
+
+#, fuzzy
+#~| msgid "1 minute"
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 дақиқа"
+
+#, fuzzy
+#~| msgid "2 minutes"
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 дақиқа"
+
+#, fuzzy
+#~| msgid "3 minutes"
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 дақиқа"
+
+#, fuzzy
+#~| msgid "5 minutes"
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 дақиқа"
+
+#, fuzzy
+#~| msgid "30 minutes"
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 дақиқа"
+
+#, fuzzy
+#~| msgid "1 hour"
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 соат"
+
+#, fuzzy
+#~| msgid "1 hour"
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 соат"
+
+#, fuzzy
+#~| msgid "1 day"
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 рӯз"
+
+#, fuzzy
+#~| msgid "2 days"
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 рӯз"
+
+#, fuzzy
+#~| msgid "3 days"
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 рӯз"
+
+#, fuzzy
+#~| msgid "4 days"
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 рӯз"
+
+#, fuzzy
+#~| msgid "5 days"
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 рӯз"
+
+#, fuzzy
+#~| msgid "6 days"
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 рӯз"
+
+#, fuzzy
+#~| msgid "7 days"
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 рӯз"
+
+#, fuzzy
+#~| msgid "14 days"
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 рӯз"
+
+#, fuzzy
+#~| msgid "30 days"
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 рӯз"
+
+#, fuzzy
+#~| msgid "1 day"
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 рӯз"
+
+#, fuzzy
+#~| msgid "7 days"
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 рӯз"
+
+#, fuzzy
+#~| msgid "30 days"
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 рӯз"
+
+#, fuzzy
+#~| msgid "Forever"
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Ҳамеша"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Дар ёд доштани таърихи шумо ёфтани дубораи чизҳоро осон мегардонад. Ин "
+#~ "объектҳо ягон вақт дар шабака мубодила намешаванд."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Истифодашудаи охирин"
+
+#~ msgid "Retain _History"
+#~ msgstr "Нигоҳ доштани _таърих"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Қулфи экран ҳангоми мавҷуд набудани шумо махфияти шуморо муҳофизат "
+#~ "мекунад."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Қулф кардани экран _баъд аз холӣ дар давоми"
+
+#, fuzzy
+#~| msgid "Lock Screen Notifications"
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "Огоҳиҳои экрани қулф"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Тоза кардани сабад ва файлҳои муваққатӣ ба таври худкор барои нигоҳ "
+#~ "доштани компютер бе иттилооти нодаркор."
+
+#~ msgid "Purge _After"
+#~ msgstr "Пок кардан _баъд аз"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Бо ирсолкунии иттилоот дар бораи истифодаи нармафзор шумо ба мо кумак "
+#~ "мерасонед, то ки мо тавонем ба шумо тавсияҳои дақиқро таъмин намоем. "
+#~ "Иттилооти ирсолшуда инчунин барои беҳтаркунии нармафзори мо кумак "
+#~ "мерасонад.\n"
+#~ "\n"
+#~ "Ҳамаи иттилооти ҷамъшуда маълумоти шахсии шуморо дар бар намегирад ва бо "
+#~ "тарафҳои сеюм ҳеҷ гоҳ мубодила намешавад."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Фиристодани омори истифодаи нармафзор"
+
+#, fuzzy
+#~| msgid "%s Camera"
+#~ msgid "_Camera"
+#~ msgstr "Камераи %s"
+
+#~ msgid "_Location Services"
+#~ msgstr "_Хидматҳои ҷойгиршавӣ"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Иттилооти шахсиро муҳофизат кунед ва идора кунед, ки дигарон чиро дида "
+#~ "метавонанд"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Империягӣ"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Метрӣ"
+
+#~ msgid "No regions found"
+#~ msgstr "Ягон минтақа ёфт нашуд"
+
+#~ msgid "No input sources found"
+#~ msgstr "Ягон манбаи вуруд ёфт нашудааст"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Дигар"
+
+#, fuzzy
+#~| msgid "Your session needs to be restarted for changes to take effect"
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Барои татбиқ кардани тағйирот шумо бояд низомро бозоғозӣ кунед"
+
+#, fuzzy
+#~| msgid "Restart Now"
+#~ msgid "Restart…"
+#~ msgstr "Ҳозир бозоғозӣ кардан"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Танзимоти воридшавӣ бо ҳамаи корбарон ҳангоми воридшавӣ ба низом истифода "
+#~ "мешаванд"
+
+#, fuzzy
+#~| msgid "Previous track"
+#~ msgid "Previous source"
+#~ msgstr "Пайгирии қаблӣ"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Фосила"
+
+#, fuzzy
+#~| msgid "Resources"
+#~ msgid "Next source"
+#~ msgstr "Захираҳо"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Фосила"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt-и рост + чап"
+
+#, fuzzy
+#~| msgid "You can change these shortcuts in the keyboard settings"
+#~ msgid "These keyboard shortcuts can be changed in the keyboard settings"
+#~ msgstr "Шумо метавонед ин миёнбурҳоро дар танзимоти клавиатура тағйир диҳед"
+
+#~ msgid "Select Location"
+#~ msgstr "Интихоби ҷойгиршавӣ"
+
+#~ msgid "_OK"
+#~ msgstr "_OK"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Барои мубодила ягон шабака интихоб карда нашуд"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Фаъол"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Хомӯш"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Фаъолшуда"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Интихоб кардани ҷузвдон"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "Personal File Sharing allows you to share your Public folder with others "
+#~| "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "Дастрасии муштараки файлҳои шахсӣ ба шумо имкон медиҳад, ки ҷузвдони "
+#~ "\"Оммавӣ\"-и худро бо дигарон дар шабакаи ҷории худ тавассути зерин "
+#~ "мебодила кунед: <a href=\"dav://%s\">dav://%s</a>"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "Allow remote users to connect using the Secure Shell command:\n"
+#~| "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "Ба корбарони дурдаст иҷозат диҳед, ки тавонанд барои пайваст шудан "
+#~ "фармони Secure Shell-ро истифода баранд:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "Allow remote users to view or control your screen by connecting to: <a "
+#~| "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "Ба корбарони дурдаст иҷозат диҳед, ки тавонанд экрани шуморо бинанд ё "
+#~ "идора кунанд (тавассути): <a href=\"vnc://%s\">vnc://%s</a>"
+
+#, fuzzy
+#~| msgid "Screen Sharing"
+#~ msgid "_Screen Sharing"
+#~ msgstr "Мубодилаи экран"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr ""
+#~ "Аз сабаби мавҷуд набудани дастрасии шабакавӣ, баъзе хидматҳо ғайрифаъол "
+#~ "карда шудаанд."
+
+#~ msgid "Screen Sharing"
+#~ msgstr "Мубодилаи экран"
+
+#, fuzzy
+#~| msgid "_Password"
+#~ msgid "_Password:"
+#~ msgstr "_Ниҳонвожа"
+
+#, fuzzy
+#~| msgid "Show Password"
+#~ msgid "_Show Password"
+#~ msgstr "Намоиш додани ниҳонвожа"
+
+#, fuzzy
+#~| msgid "New connections must ask for access"
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Пайвастҳои нав бояд барои дастрасӣ иҷозатро дархост кунанд"
+
+#, fuzzy
+#~| msgid "Require a password"
+#~ msgid "_Require a password"
+#~ msgstr "Ниҳонвожа лозим аст"
+
+#~ msgid "Custom"
+#~ msgstr "Иловагӣ"
+
+#~ msgid "Bark"
+#~ msgstr "Ав-ав"
+
+#~ msgid "Drip"
+#~ msgstr "Қатра"
+
+#~ msgid "Glass"
+#~ msgstr "Шиша"
+
+#~ msgid "Sonar"
+#~ msgstr "Садоӣ"
+
+#, fuzzy, c-format
+#~| msgid "Settings"
+#~ msgid "Testing %s"
+#~ msgstr "Танзимот"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#, fuzzy
+#~| msgid "Disconnecting"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Пайваст қатъ шуда истодааст"
+
+#, fuzzy
+#~| msgid "Connecting"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Пайваст шуда истодааст"
+
+#, fuzzy
+#~| msgid "Connected"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Пайвастшуда"
+
+#, fuzzy
+#~| msgid "Authentication required"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Санҷиши ҳаққоният лозим аст"
+
+#, fuzzy
+#~| msgid "Connected Devices"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Дастгоҳҳои пайвастшуда"
+
+#, fuzzy
+#~| msgid "Unknown"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Номаълум"
+
+#, fuzzy
+#~| msgid "Connected"
+#~ msgid "Connected at:"
+#~ msgstr "Пайвастшуда"
+
+#, fuzzy
+#~| msgid "_Enroll"
+#~ msgid "Enrolled at:"
+#~ msgstr "_Илова кардан"
+
+#, fuzzy
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Боркунии файл қатъ шуд: %s"
+
+#, fuzzy
+#~| msgid "Failed to upload file: %s"
+#~ msgid "Failed to forget device: "
+#~ msgstr "Боркунии файл қатъ шуд: %s"
+
+#, fuzzy
+#~| msgid "Mirror"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Оина"
+
+#, fuzzy
+#~| msgid "Authenticated"
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Ҳаққоният санҷида шуд"
+
+#, fuzzy
+#~| msgid "The profile could not be generated."
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Профил эҷод карда нашуд."
+
+#, fuzzy
+#~| msgid "Default"
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Пешфарз"
+
+#, fuzzy
+#~| msgctxt "Calibration quality"
+#~| msgid "Medium"
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Миёна"
+
+#, fuzzy
+#~| msgctxt "dwell click threshold"
+#~| msgid "Large"
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Бузург"
+
+#, fuzzy
+#~| msgctxt "universal access, text size"
+#~| msgid "Larger"
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Калонтар"
+
+#, fuzzy
+#~| msgctxt "dwell click threshold"
+#~| msgid "Large"
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Бузург"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Хонандаи экранӣ"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Хонандаи _экранӣ"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Тугмаҳои садо"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Мижазании _сарлавҳаи равзана"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Кӯтоҳ"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "Экрани ¼"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "Экрани ½"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "Экрани ¾"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Дароз"
+
+#, fuzzy
+#~| msgid "Should match the web address of your account provider."
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Бояд ба суроғаи веби ҳисоби провайдери шумо мувофиқ бошад."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Иловакунии ҳисоб қатъ шуд"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Қайдкунии ҳисоб қатъ шуд"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr ""
+#~ "Ягон имконияти дастгирӣ барои санҷиши ҳаққоният бо ин домен вуҷуд надорад"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Ҳамроҳ шудан ба домен қатъ шуд"
+
+#, fuzzy
+#~| msgid ""
+#~| "That login name didn't work.\n"
+#~| "Please try again."
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Номи вуруд нодуруст аст.\n"
+#~ "Лутфан амалро такрор кунед."
+
+#, fuzzy
+#~| msgid ""
+#~| "That login password didn't work.\n"
+#~| "Please try again."
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Ниҳонвожаи вуруд нодуруст аст.\n"
+#~ "Лутфан амалро такрор кунед."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Ворид шудан ба домен қатъ шуд"
+
+#, fuzzy
+#~| msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Домен ёфт нашуд. Эҳтимол аст, ки шумо онро хатогӣ ворид кардед?"
+
+#, fuzzy
+#~| msgctxt "Account type"
+#~| msgid "Standard"
+#~ msgid "Standard"
+#~ msgstr "Стандартӣ"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Намуди ҳисоб"
+
+#, fuzzy
+#~| msgid "Allow user to set a password when they next login"
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Ба корбар иҷозат диҳед, ки ҳангоми воридшавии навбатӣ ниҳонвожаеро барпо "
+#~ "кунад"
+
+#, fuzzy
+#~| msgid "Set a password now"
+#~ msgid "Set a password _now"
+#~ msgstr "Ниҳонвожаро ҳозир таъин кунед"
+
+#, fuzzy
+#~| msgid ""
+#~| "Go online to add\n"
+#~| "enterprise login accounts."
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "Барои илова кардани ҳисобҳои\n"
+#~ "Enterprise ба онлайн гузаред."
+
+#, fuzzy
+#~| msgid "Take a photo…"
+#~ msgid "Take a Picture…"
+#~ msgstr "Гирифтани сурат..."
+
+#~ msgid "This Week"
+#~ msgstr "Ҳафтаи ҷорӣ"
+
+#~ msgid "Last Week"
+#~ msgstr "Ҳафтаи гузашта"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%b %e, %Y"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Ҷаласа хотима ёфт"
+
+#~ msgid "Session Started"
+#~ msgstr "Ҷаласа оғоз ёфт"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Лутфан, ниҳонвожаи дигареро интихоб кунед."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Лутфан, ниҳонвожаи ҷории худро ворид кунед."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Ниҳонвожа тағйир дода намешавад"
+
+#~ msgid "_Confirm New Password"
+#~ msgstr "_Тасдиқ кардани ниҳонвожаи нав"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Ба ин намуди домен ба таври худкор пайваст намешавад"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Ягон домен ё соҳиб ёфт нашудааст"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Ҳамчун %s ба домени %s пайваст намешавад"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Ниҳонвожаи нодуруст, лутфан амалро такрор кунед"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Несткунии корбар қатъ шуд"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Бекоркунии корбари идорашавандаи дурдаст иҷро нашуд"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Шумо наметавонед ҳисоби худро нест кунед."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s то ҳол воридшуда мебошад"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Несткунии корбари воридшуда метавонад низомро ба ҳолати номунтаззам "
+#~ "дарорад."
+
+#, fuzzy, c-format
+#~| msgid "Do you want to keep %s's files?"
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Шумо мехоҳед, ки файлҳои %s-ро нигоҳ доред?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Ҳангоми нест кардани ҳисоби корбар шумо метавонед директорияи аслӣ, "
+#~ "файлҳои навбати почта ва файлҳои муваққатиро нигоҳ доред."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Нест кардани файлҳо"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Нигоҳ доштани файлҳо"
+
+#, fuzzy, c-format
+#~| msgid "Are you sure you want to revoke remotely managed %s's account?"
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Шумо мутмаин ҳастед, ки мехоҳед ҳисоби корбари идорашавандаи дурдасти %s "
+#~ "бекор кунед?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Нест кардан"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Ҳисоб ғайрифаъол аст"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Ҳангоми воридшавии навбатӣ таъин карда мешавад"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Ҳеҷ"
+
+#~ msgid "Logged in"
+#~ msgstr "Ворид шудааст"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Тамосгирӣ бо хадамоти ҳисобҳо қатъ шуд"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Лутфан, мутмаин шавед, ки AccountService насб шудааст ва дар ҳоли иҷро "
+#~ "мебошад."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Барои даровардани тағйирот,\n"
+#~ "аввал нишонаи \"*\"-ро зер кунед"
+
+#~ msgid "Create a user account"
+#~ msgstr "Эҷод кардани ҳисоби корбар"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Барои эҷод кардани ҳисоби корбар,\n"
+#~ "пеш аз ҳама нишонаи * -ро зер кунед"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Нест кардани ҳисоби корбари интихобшуда"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Барои нест кардани ҳисоби корбари интихобшуда,\n"
+#~ "пеш аз ҳама нишонаи * -ро зер кунед"
+
+#~ msgid "User Icon"
+#~ msgstr "Нишонаи корбар"
+
+#~ msgid "Last Login"
+#~ msgstr "Воридшавии охирин"
+
+#~ msgid "Left thumb"
+#~ msgstr "Сарангушти чап"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Ангушти миёнаи чап"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Ангушти ҳалқаи чап"
+
+#~ msgid "Left little finger"
+#~ msgstr "Ангушти хурди чап"
+
+#~ msgid "Right thumb"
+#~ msgstr "Сарангушти рост"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Ангушти миёнаи рост"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Ангушти ҳалқаи рост"
+
+#~ msgid "Right little finger"
+#~ msgstr "Ангушти хурди рост"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Фаъол кардани воридшавӣ бо нақши ангушт"
+
+#~ msgid "_Right index finger"
+#~ msgstr "_Ангушти ишорати рост"
+
+#~ msgid "_Left index finger"
+#~ msgstr "_Ангушти ишорати чап "
+
+#~ msgid "_Other finger:"
+#~ msgstr "_Ангушти дигар:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Нақши ангушти шумо бо муваффақият захира шудааст. Акнун шумо метавонед "
+#~ "тавассути хонандаи нақши ангуштон ворид шавед."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Воридшавӣ;Ном;Нақши ангушт;Аватар;Тамға;Рӯй;Ниҳонвожа;"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Ниҳонвожаи нав бояд аз ниҳонвожаи кӯҳна фарқ кунад."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Баъзе ҳарфҳо ва рақамҳоро тағйир диҳед."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Ниҳонвожаи худро каме мураккаб кунед."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Ниҳонвожа бе номи корбар қавитар мешавад."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Номи худро дар ниҳонвожа истифода набаред."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Баъзе калимаҳоро аз ниҳонвожа истисно кунед."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Калимаҳои оддиро истифода набаред."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Тартиби калимаҳои мавҷудбударо иваз накунед."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Бештар рақамҳоро истифода баред."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Бештар ҳарфҳои калонро истифода баред."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Бештар ҳарфҳои хурдро истифода баред."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Бештар аломатҳои маҳсусро, монанди нуқтагузорӣ, истифода баред."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Аралаши калимаҳо, рақамҳо ва нуқтагузориро истифода баред."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Аломатҳои такрориро истифода набаред."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Аломатҳои такрориро истифода набаред: шумо бояд ҳарфҳо, рақамҳо ва "
+#~ "нуқтагузориро аралаш кунед."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Мунтазамии рақамҳоро монанди 1234 ё abcd истифода набаред."
+
+#, fuzzy
+#~| msgctxt "Password hint"
+#~| msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr "Аралаши калимаҳо, рақамҳо ва нуқтагузориро истифода баред."
+
+#, fuzzy
+#~| msgctxt "Password hint"
+#~| msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr ""
+#~ "Ҳарфҳои хурду калонро аралаш кунед ва як ё якчанд рақамро истифода баред."
+
+#, fuzzy
+#~| msgctxt "Password hint"
+#~| msgid ""
+#~| "Good password! Adding more letters, numbers and punctuation will make it "
+#~| "stronger."
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Ниҳонвожаи хуб! Агар бештар калимаҳо, рақамҳо ва нуқтагузориро илова "
+#~ "кунед, ниҳонвожаро қавитар мекунед."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Санҷиши ҳаққоният қатъ шудааст"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Ниҳонвожаи нав хеле кӯтоҳ аст"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Ниҳонвожаи нав хеле осон аст"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Ниҳонвожаи нав ва кӯҳна хеле монанданд"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Ниҳонвожаи нав аллакай истифода шуда буд."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Ниҳонвожаи нав бояд аломатҳои рақамӣ ва махсусро дар бар гирад"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Ниҳонвожаи нав ва кӯҳна мувофиқат мекунанд"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Баъд аз воридшавии вақти аввалин ниҳонвожаи шумо тағйир ёфт!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Ниҳонвожаи нав аломатҳои дигаргунро дар бар намегирад"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Хатогии номаълум"
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "Номи корбар хеле дароз аст."
+
+#, fuzzy
+#~| msgid "The username cannot start with a '-'."
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Номи корбар бояд бо '-' сар нашавад."
+
+#, fuzzy
+#~| msgid ""
+#~| "The username should only consist of lower and upper case letters from a-"
+#~| "z, digits and any of characters '.', '-' and '_'."
+#~ msgid ""
+#~ "The username should only consist of upper and lower case letters from a-"
+#~ "z, digits and the following characters: . - _"
+#~ msgstr ""
+#~ "Номи корбар бояд аз ҳарфҳои хурду калон (аз a то z), рақамҳо ва аз "
+#~ "аломатҳои '.', '-' ва '_' иборат шавад."
+
+#, fuzzy
+#~| msgid "This will be used to name your home folder and can't be changed."
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Ин барои номи ҷузвдони асосӣ истифода мешавад ва тағйир дода намешавад."
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Шумо барои истифодаи ин дастгоҳ иҷозат надоред. Бо маъмури низоми худ дар "
+#~ "тамос шавед."
+
+#~ msgid "The device is already in use."
+#~ msgstr "Дастгоҳ аллакай истифода шудааст."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Хатои дарунӣ ба вуҷуд омад."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Нақши ангуштони қайдшударо нест мекунед?"
+
+#~ msgid "Done!"
+#~ msgstr "Тайёр!"
+
+#, fuzzy, c-format
+#~| msgid "Could not access '%s' device"
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Дастгоҳи '%s' кушода нашуд"
+
+#, fuzzy, c-format
+#~| msgid "Could not start finger capture on '%s' device"
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Муайянкунии ангушт дар дастгоҳи '%s' оғоз нашуд"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "Ягон хонандаи нақши ангушт дастрас нест"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr ""
+#~ "Лутфан, барои гирифтани дастгирӣ ба маъмури низоми худ муроҷиат намоед."
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "To enable fingerprint login, you need to save one of your fingerprints, "
+#~| "using the '%s' device."
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Барои фаъол кардани воридшавӣ тавассути нақши ангушт, шумо бояд тавассути "
+#~ "дастгоҳи \"%s\" яке аз нақшҳои ангушти худро захира кунед."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Интихоби ангушт"
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Тугмаи %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Фиристодани пахши тугмаҳо"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Қатъу васл кардани монитор"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Намоиш додани кумаки экранӣ"
+
+#~ msgid "Output:"
+#~ msgstr "Барориш:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Нигоҳ доштани таносуб (қуттии почта):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Нишона гузоштан ба монитори ягона"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d аз %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Нақшабандии дисплей"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Планшет (матлақ)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Хусусиятҳои планшет"
+
+#~ msgid "_Help"
+#~ msgstr "_Кумак"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Танзимоти Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Ҳолати пайгирӣ"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Нишона гузоштани тугмаҳо..."
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Танзими хусусиятҳои муш"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Танзими возеҳии дисплей"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Миёнбури нав"
+
+#~ msgid "No stylus found"
+#~ msgstr "Ягон қалам (стилус) ёфт нашуд"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Лутфан, барои танзим кардани қалам (стилус) онро дар сатҳи лавҳа ҳаракат "
+#~ "намоед"
+
+#~ msgid "Top Button"
+#~ msgstr "Поёни боло"
+
+#, fuzzy
+#~| msgid "Lower Button"
+#~ msgid "Lowest Button"
+#~ msgstr "Тугмаи пасткунӣ"
+
+#, fuzzy
+#~| msgid "Display Brightness"
+#~ msgid "Display version number"
+#~ msgstr "Равшании дисплей"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Фаъол кардани ҳолати ботафсил"
+
+#~ msgid "Search for the string"
+#~ msgstr "Ҷустуҷӯи сатр"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Пайванд гузоштани номҳои эҳтимолии наворҳо ва баромад"
+
+#~ msgid "Panel to display"
+#~ msgstr "Панел барои намоиш"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Лавҳаҳои дастрас:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Овозҳои низом"
 
 #~ msgid "Done"
 #~ msgstr "Тайёр"
@@ -8685,9 +8304,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "Mirrored"
 #~ msgstr "Мунъакис"
-
-#~ msgid "Secondary"
-#~ msgstr "Дуюм"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Мураттабсозии дисплейҳои ҳамҷояшуда"
@@ -8706,9 +8322,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "Size"
 #~ msgstr "Андоза"
-
-#~ msgid "Aspect Ratio"
-#~ msgstr "Таносуб"
 
 #~ msgid "Show the top bar and Activities Overview on this display"
 #~ msgstr "Намоиш додани навори болоӣ ва хулосаи фаъолият дар ин дисплей"
@@ -8745,18 +8358,11 @@ msgstr "Овозҳои низом"
 #~ msgid "%s %d-bit"
 #~ msgstr "%s %d-бит"
 
-#~ msgid "Section"
-#~ msgstr "Қисмат"
-
 #~ msgid "Overview"
 #~ msgstr "Хулоса"
 
 #~ msgid "Base system"
 #~ msgstr "Системаи асосӣ"
-
-#~ msgctxt "keybinding"
-#~ msgid "Search"
-#~ msgstr "Ҷустуҷӯ"
 
 #~ msgid "Shortcut;Repeat;Blink;"
 #~ msgstr "Миёнбур;Такрор;Мижазанӣ;"
@@ -8782,9 +8388,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "S_peed:"
 #~ msgstr "С_уръат:"
-
-#~ msgid "Add Shortcut"
-#~ msgstr "Илова кардани миёнбур"
 
 #~ msgid ""
 #~ "To edit a shortcut, click the row and hold down the new keys or press "
@@ -8928,9 +8531,6 @@ msgstr "Овозҳои низом"
 #~ "Тоза кардани ҳамаи тафсилоти ин шабака ва кӯшиш накардани пайвастшавии "
 #~ "худкор"
 
-#~ msgid "My Home Network"
-#~ msgstr "Шабакаи хонагии ман"
-
 #~ msgid "Bond slaves"
 #~ msgstr "Пайвасти фармонбарон"
 
@@ -8950,9 +8550,6 @@ msgstr "Овозҳои низом"
 #~ "Агар пайвасти Интернети шумо аз пайвасти бесим фарқ кунад, шумо метавонед "
 #~ "хот-споти бесимро танзим кунед, то ин ки пайвастро бо дигарон мубодила "
 #~ "кунед."
-
-#~ msgid "History"
-#~ msgstr "Таърих"
 
 #~ msgid "Proxy"
 #~ msgstr "Прокси"
@@ -8993,9 +8590,6 @@ msgstr "Овозҳои низом"
 #~ msgid "_History"
 #~ msgstr "_Таърих"
 
-#~ msgid "Security key"
-#~ msgstr "Калиди амният"
-
 #~ msgid "InfiniBand device does not support connected mode"
 #~ msgstr "Дастгоҳи InfiniBand ҳолати пайвастшударо дастгирӣ намекунад"
 
@@ -9022,9 +8616,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "Don't _warn me again"
 #~ msgstr "_Маро дигар огоҳ накунед"
-
-#~ msgid "No"
-#~ msgstr "Не"
 
 #~ msgid "Yes"
 #~ msgstr "Ҳа"
@@ -9114,9 +8705,6 @@ msgstr "Овозҳои низом"
 #~ msgstr[0] "%u фаъол"
 #~ msgstr[1] "%u фаъол"
 
-#~ msgid "Close"
-#~ msgstr "Пӯшидан"
-
 #~ msgid "Resume Printing"
 #~ msgstr "Давом додани чоп"
 
@@ -9125,12 +8713,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "Add a New Printer"
 #~ msgstr "Илова кардани принтери нав"
-
-#~ msgid "No printers detected."
-#~ msgstr "Ягон принтер муайян нашуд."
-
-#~ msgid "Loading options…"
-#~ msgstr "Боркунии имконот..."
 
 #~ msgctxt "print job"
 #~ msgid "Held"
@@ -9141,9 +8723,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "Job State"
 #~ msgstr "Вазъияти вазифа"
-
-#~ msgid "Time"
-#~ msgstr "Вақт"
 
 #~ msgid "Supply"
 #~ msgstr "Таъминот"
@@ -9157,9 +8736,6 @@ msgstr "Овозҳои низом"
 #~ msgid "label"
 #~ msgstr "барчасп"
 
-#~ msgid "Setting new driver…"
-#~ msgstr "Танзимкунии драйвери нав..."
-
 #~ msgid "page 3"
 #~ msgstr "саҳифаи 3"
 
@@ -9171,9 +8747,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "Add New Printer"
 #~ msgstr "Илова кардани принтери нав"
-
-#~ msgid "Show _Notifications"
-#~ msgstr "_Намоиш додани огоҳиҳо"
 
 #~ msgid "Used to determine your geographical location"
 #~ msgstr "Барои муайян кардани ҷойгиршавии ҷуғрофии шумо истифода мешавад"
@@ -9189,9 +8762,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "United Kingdom"
 #~ msgstr "Британияи Кабир"
-
-#~ msgid "Options"
-#~ msgstr "Имконот"
 
 #~ msgid "Add input source"
 #~ msgstr "Илова кардани манбаи вуруд"
@@ -9227,9 +8797,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "Save Received Files to Downloads Folder"
 #~ msgstr "Захира кардани файлҳои захирашуда ба ҷузвдони боргириҳо"
-
-#~ msgid "Allow Remote Control"
-#~ msgstr "Иҷозати идоракунии дурдаст"
 
 #~ msgid "Password:"
 #~ msgstr "Ниҳонвожа:"
@@ -9278,9 +8845,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "Sound Effects"
 #~ msgstr "Таъсири садо"
-
-#~ msgid "No application is currently playing or recording audio."
-#~ msgstr "Ягон барнома дар айни ҳол аудиоро пахш ё сабт накарда истодааст."
 
 #~ msgid "Built-in"
 #~ msgstr "Дарунсохт"
@@ -9435,12 +8999,6 @@ msgstr "Овозҳои низом"
 #~ msgid "Scroll Up"
 #~ msgstr "Ба боло ҳаракат кардан"
 
-#~ msgid "Scroll Down"
-#~ msgstr "Ба поён ҳаракат кардан"
-
-#~ msgid "Scroll Left"
-#~ msgstr "Ба чап ҳаракат кардан"
-
 #~ msgid "GNOME Control Center"
 #~ msgstr "Маркази идоракунии GNOME"
 
@@ -9480,12 +9038,6 @@ msgstr "Овозҳои низом"
 #~ msgid "When battery power is _critical"
 #~ msgstr "_Вақте ки барқи батарея қариб ба анҷом расид"
 
-#~ msgid "Power off"
-#~ msgstr "Анҷоми кор"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "Ғайрифаъол кардан ҳангоми чопкунӣ"
-
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "Хидматҳои шабакавии система бо ин версия мутобиқат намекунанд."
 
@@ -9516,9 +9068,6 @@ msgstr "Овозҳои низом"
 #~ msgid "Germany"
 #~ msgstr "Олмон"
 
-#~ msgid "France"
-#~ msgstr "Фаронса"
-
 #~ msgid "Spain"
 #~ msgstr "Испания"
 
@@ -9546,17 +9095,11 @@ msgstr "Овозҳои низом"
 #~ msgid "Share Public Folder On This Network"
 #~ msgstr "Мубодила кардани ҷузвдони оммавӣ дар ин шабака"
 
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
-
 #~ msgid "System Up-To-Date"
 #~ msgstr "Системаи шумо нав мебошад"
 
 #~ msgid "Search for network printers or filter result"
 #~ msgstr "Ҷустуҷӯи принтерҳои шабакавӣ ё нтиҷаи филтр"
-
-#~ msgid "Remote View"
-#~ msgstr "Намоиши дурдаст"
 
 #~ msgid "Approve All Connections"
 #~ msgstr "Тасдиқ кардани ҳамаи пайвастҳо"
@@ -9570,23 +9113,14 @@ msgstr "Овозҳои низом"
 #~ msgid "Paired"
 #~ msgstr "Ҷуфтдор"
 
-#~ msgid "Type"
-#~ msgstr "Навъ"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "Танзимоти муш ва панели ламсӣ"
-
-#~ msgid "Sound Settings"
-#~ msgstr "Танзимоти садо"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "Танзимоти клавиатура"
 
 #~ msgid "Send Files…"
 #~ msgstr "Фиристодани файлҳо…"
-
-#~ msgid "Visibility"
-#~ msgstr "Қобилияти намоиш"
 
 #~ msgid "Visibility of “%s”"
 #~ msgstr "Намоённокии “%s”"
@@ -9688,18 +9222,8 @@ msgstr "Овозҳои низом"
 #~ msgstr "Оддӣ"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "Самти ҳаракати соат"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 дараҷа"
-
-#~ msgid "Monitor"
-#~ msgstr "Монитор"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "Барои тағйир додани дисплейи асосӣ кашед."
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -9713,9 +9237,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "%a %l:%M %p"
 #~ msgstr "%a %l:%M %p"
-
-#~ msgid "Failed to apply configuration"
-#~ msgstr "Татбиқи танзимот қатъ шудааст"
 
 #~ msgid "_Resolution"
 #~ msgstr "_Возеҳӣ"
@@ -9737,9 +9258,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "_City:"
 #~ msgstr "_Шаҳр:"
-
-#~ msgid "_Network Time"
-#~ msgstr "_Вақти шабака"
 
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "Соатро ба як соат пеш гузаронед."
@@ -9904,20 +9422,11 @@ msgstr "Овозҳои низом"
 #~ msgid "Large"
 #~ msgstr "Калон"
 
-#~ msgid "Previous Week"
-#~ msgstr "Ҳафтаи қаблӣ"
-
-#~ msgid "Next Week"
-#~ msgstr "Ҳафтаи навбатӣ"
-
 #~ msgid "Next week"
 #~ msgstr "Ҳафтаи навбатӣ"
 
 #~ msgid "C_ontent sticks to fingers"
 #~ msgstr "_Муҳтаво ба ангушт мечаспад"
-
-#~ msgid "Choose password at next login"
-#~ msgstr "Интихоб кардани ниҳонвожа барои воридшавии навбатӣ"
 
 #~ msgid "Log in without a password"
 #~ msgstr "Бе ниҳонвожа ворид шудан"
@@ -9927,12 +9436,6 @@ msgstr "Овозҳои низом"
 
 #~ msgid "Enable this account"
 #~ msgstr "Фаъол кардани ин ҳисоб"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "_Тасдиқ кардани ниҳонвожа"
-
-#~ msgid "Generate a password"
-#~ msgstr "Эҷод кардани ниҳонвожа"
 
 #~ msgid "_Action"
 #~ msgstr "_Амал"

--- a/po/tg.po~
+++ b/po/tg.po~
@@ -1,0 +1,10052 @@
+# Tajik translation for gnome-control-center.
+# Copyright (C) 2013 gnome-control-center's COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center package.
+# Victor Ibragimov <victor.ibragimov@gmail.com>, 2013, 2014, 2015, 2019б 2020
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2020-09-18 17:24+0000\n"
+"PO-Revision-Date: 2020-09-18 22:50+0500\n"
+"Last-Translator: Victor Ibragimov <victor.ibragimov@gmail.com>\n"
+"Language-Team: Tajik <tg@li.org>\n"
+"Language: tg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.2.1\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#: panels/applications/cc-applications-panel.c:561
+#, fuzzy
+#| msgid "System Sounds"
+msgid "System Bus"
+msgstr "Овозҳои низом"
+
+#: panels/applications/cc-applications-panel.c:561
+#: panels/applications/cc-applications-panel.c:563
+#: panels/applications/cc-applications-panel.c:579
+#: panels/applications/cc-applications-panel.c:584
+#, fuzzy
+#| msgid "_Full Name"
+msgid "Full access"
+msgstr "_Номи пурра"
+
+#: panels/applications/cc-applications-panel.c:563
+#, fuzzy
+#| msgid "Session Ended"
+msgid "Session Bus"
+msgstr "Ҷаласа хотима ёфт"
+
+#: panels/applications/cc-applications-panel.c:568
+#: panels/power/cc-power-panel.c:2453 panels/thunderbolt/cc-bolt-panel.ui:466
+#: panels/thunderbolt/cc-bolt-panel.ui:525 shell/cc-panel-list.ui:45
+#: shell/cc-window.c:268
+msgid "Devices"
+msgstr "Дастгоҳҳо"
+
+#: panels/applications/cc-applications-panel.c:568
+msgid "Full access to /dev"
+msgstr "Дастрасии пурра ба /dev"
+
+#: panels/applications/cc-applications-panel.c:573
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:241
+msgid "Network"
+msgstr "Шабака"
+
+#: panels/applications/cc-applications-panel.c:573
+#, fuzzy
+#| msgid "Network Name"
+msgid "Has network access"
+msgstr "Номи шабака"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: panels/applications/cc-applications-panel.c:579
+#: panels/applications/cc-applications-panel.c:581
+#: panels/background/cc-background-chooser-dialog.c:536
+#: panels/search/cc-search-locations-dialog.c:286
+msgid "Home"
+msgstr "Асосӣ"
+
+#: panels/applications/cc-applications-panel.c:581
+#: panels/applications/cc-applications-panel.c:586
+#, fuzzy
+#| msgctxt "printer state"
+#| msgid "Ready"
+msgid "Read-only"
+msgstr "Тайёр"
+
+#: panels/applications/cc-applications-panel.c:584
+#: panels/applications/cc-applications-panel.c:586
+#, fuzzy
+#| msgid "Open System"
+msgid "File System"
+msgstr "Системаи кушода"
+
+#: panels/applications/cc-applications-panel.c:591
+#: panels/keyboard/01-launchers.xml.in:6 shell/cc-window.c:272
+#: shell/cc-window.c:935 shell/cc-window.ui:131
+#: shell/gnome-control-center.desktop.in.in:3
+msgid "Settings"
+msgstr "Танзимот"
+
+#: panels/applications/cc-applications-panel.c:591
+msgid "Can change settings"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:596
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:738
+msgid "Web Links"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:748
+msgid "Git Links"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:754
+#, c-format
+msgid "%s Links"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:762
+#: panels/applications/cc-applications-panel.c:798
+msgid "Unset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:853
+#, fuzzy
+#| msgid "Link speed"
+msgid "Links"
+msgstr "Суръати пайванд"
+
+#: panels/applications/cc-applications-panel.c:861
+#, fuzzy
+#| msgid "_Delete Files"
+msgid "Hypertext Files"
+msgstr "_Нест кардани файлҳо"
+
+#: panels/applications/cc-applications-panel.c:875
+#, fuzzy
+#| msgid "_Delete Files"
+msgid "Text Files"
+msgstr "_Нест кардани файлҳо"
+
+#: panels/applications/cc-applications-panel.c:889
+#, fuzzy
+#| msgid "_Keep Files"
+msgid "Image Files"
+msgstr "_Нигоҳ доштани файлҳо"
+
+#: panels/applications/cc-applications-panel.c:905
+#, fuzzy
+#| msgid "_Delete Files"
+msgid "Font Files"
+msgstr "_Нест кардани файлҳо"
+
+#: panels/applications/cc-applications-panel.c:966
+msgid "Archive Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:986
+msgid "Package Files"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.c:1009
+#, fuzzy
+#| msgid "All files"
+msgid "Audio Files"
+msgstr "Ҳамаи файлҳо"
+
+#: panels/applications/cc-applications-panel.c:1026
+#, fuzzy
+#| msgid "_Keep Files"
+msgid "Video Files"
+msgstr "_Нигоҳ доштани файлҳо"
+
+#: panels/applications/cc-applications-panel.c:1034
+#, fuzzy
+#| msgid "_Delete Files"
+msgid "Other Files"
+msgstr "_Нест кардани файлҳо"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1376
+#: panels/applications/cc-applications-panel.ui:406
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:167
+#: panels/privacy/cc-privacy-panel.ui:1085
+msgid "Applications"
+msgstr "Барномаҳо"
+
+#: panels/applications/cc-applications-panel.ui:45
+#, fuzzy
+#| msgid "No applications found"
+msgid "No applications"
+msgstr "Ягон барнома ёфт нашуд"
+
+#: panels/applications/cc-applications-panel.ui:59
+msgid "Install some…"
+msgstr "Насб кардани баъзеи…"
+
+#: panels/applications/cc-applications-panel.ui:99
+msgid "Permissions & Access"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:111
+msgid ""
+"Data and services that this app has asked for access to and permissions that "
+"it requires."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/applications/cc-applications-panel.ui:132
+#: panels/privacy/cc-privacy-panel.c:908 panels/privacy/cc-privacy-panel.ui:745
+#, fuzzy
+#| msgid "%s Camera"
+msgid "Camera"
+msgstr "Камераи %s"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:133
+#: panels/applications/cc-applications-panel.ui:145
+#: panels/applications/cc-applications-panel.ui:157
+#: panels/applications/cc-applications-panel.ui:237
+#: panels/applications/cc-applications-panel.ui:255
+#: panels/keyboard/cc-keyboard-option.c:259
+#: panels/keyboard/cc-keyboard-option.c:378
+#: panels/keyboard/keyboard-shortcuts.c:425
+#: panels/keyboard/shortcut-editor.ui:96 panels/network/network-proxy.ui:123
+#: panels/network/network-wifi.ui:781 panels/network/network-wifi.ui:1058
+#: panels/user-accounts/um-fingerprint-dialog.c:211
+#: subprojects/gvc/gvc-mixer-control.c:1864
+msgid "Disabled"
+msgstr "Ғайрифаъол"
+
+#: panels/applications/cc-applications-panel.ui:138
+#: panels/applications/cc-applications-panel.ui:144
+#: panels/privacy/cc-privacy-panel.c:941 panels/privacy/cc-privacy-panel.ui:850
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:150
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/privacy/cc-privacy-panel.c:850 panels/privacy/cc-privacy-panel.ui:955
+#, fuzzy
+#| msgid "_Location Services"
+msgid "Location Services"
+msgstr "_Хидматҳои ҷойгиршавӣ"
+
+#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:489
+#, fuzzy
+#| msgid "Built-in Webcam"
+msgid "Built-in Permissions"
+msgstr "Вебкамераи дарунсохт"
+
+#: panels/applications/cc-applications-panel.ui:163
+#, fuzzy
+#| msgid "Password could not be changed"
+msgid "Cannot be changed"
+msgstr "Ниҳонвожа тағйир дода намешавад"
+
+#: panels/applications/cc-applications-panel.ui:180
+msgid ""
+"Individual permissions for applications can be reviewed in the <a href="
+"\"privacy\">Privacy</a> Settings."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#, fuzzy
+#| msgid "Orientation"
+msgid "Integration"
+msgstr "Самт"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System features used by this application."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:230
+#: panels/applications/cc-applications-panel.ui:236
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:161
+msgid "Search"
+msgstr "Ҷустуҷӯ"
+
+#: panels/applications/cc-applications-panel.ui:242
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Огоҳиҳо"
+
+#: panels/applications/cc-applications-panel.ui:248
+#: panels/applications/cc-applications-panel.ui:254
+#, fuzzy
+#| msgid "Sound"
+msgid "Sounds"
+msgstr "Садо"
+
+#: panels/applications/cc-applications-panel.ui:287
+#, fuzzy
+#| msgid "_Default printer"
+msgid "Default Handlers"
+msgstr "_Принтери пешфарз"
+
+#: panels/applications/cc-applications-panel.ui:299
+msgid "Types of files and links that this application opens."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:315
+msgid "Reset"
+msgstr "Бозсозӣ"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "Usage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:363
+msgid "How much resources this application is using."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:378
+#: panels/applications/cc-applications-panel.ui:525
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:413
+#, fuzzy
+#| msgid "_Software"
+msgid "Open in Software"
+msgstr "_Нармафзор"
+
+#: panels/applications/cc-applications-panel.ui:463 shell/cc-panel-list.ui:190
+#, fuzzy
+#| msgid "No regions found"
+msgid "No results found"
+msgstr "Ягон минтақа ёфт нашуд"
+
+#: panels/applications/cc-applications-panel.ui:474
+#: panels/keyboard/cc-keyboard-panel.ui:175 shell/cc-panel-list.ui:201
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:542
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:551
+#, fuzzy
+#| msgid "Applications"
+msgid "Application"
+msgstr "Барномаҳо"
+
+#: panels/applications/cc-applications-panel.ui:557
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:563
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:569
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:586
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/background.ui:49
+#, fuzzy
+#| msgid "Background"
+msgid "_Background"
+msgstr "Пасзамина"
+
+#. This refers to a slideshow background
+#: panels/background/background.ui:99 panels/background/background.ui:212
+msgid "Changes throughout the day"
+msgstr "Тағйироти рӯз"
+
+#. To translators: This is a noun, not a verb
+#: panels/background/background.ui:162
+#, fuzzy
+#| msgid "Lock Screen"
+msgid "_Lock Screen"
+msgstr "Экрани қулф"
+
+#: panels/background/background.ui:268
+msgctxt "background, style"
+msgid "Tile"
+msgstr "Сафолпӯш"
+
+#: panels/background/background.ui:272
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "Танзими андоза"
+
+#: panels/background/background.ui:276
+msgctxt "background, style"
+msgid "Center"
+msgstr "Ба марказ кӯчонидан"
+
+#: panels/background/background.ui:280
+msgctxt "background, style"
+msgid "Scale"
+msgstr "Миқиёсбандӣ"
+
+#: panels/background/background.ui:284
+msgctxt "background, style"
+msgid "Fill"
+msgstr "Пуркунӣ"
+
+#: panels/background/background.ui:288
+msgctxt "background, style"
+msgid "Span"
+msgstr "Ваҷаб"
+
+#: panels/background/cc-background-chooser-dialog.c:412
+msgid "Wallpapers"
+msgstr "Тасвирҳои экран"
+
+#: panels/background/cc-background-chooser-dialog.c:423
+msgid "Colors"
+msgstr "Рангҳо"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: panels/background/cc-background-chooser-dialog.c:455
+msgid "Select Background"
+msgstr "Интихоби пасзамина"
+
+#: panels/background/cc-background-chooser-dialog.c:484
+msgid "Pictures"
+msgstr "Тасвирҳо"
+
+#. translators: No pictures were found
+#: panels/background/cc-background-chooser-dialog.c:519
+msgid "No Pictures Found"
+msgstr "Ягон тасвир ёфт нашудааст"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: panels/background/cc-background-chooser-dialog.c:546
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr ""
+"Шумо метавонед тасвирҳоро ба ҷузвдони %s илова кунед ва онҳо дар ин ҷо "
+"намоиш дода мешаванд"
+
+#: panels/background/cc-background-chooser-dialog.c:550
+#: panels/color/cc-color-panel.c:241 panels/color/cc-color-panel.c:894
+#: panels/color/cc-color-panel.ui:657 panels/color/color-calibrate.ui:25
+#: panels/common/cc-language-chooser.ui:24
+#: panels/display/cc-display-panel.c:916
+#: panels/network/connection-editor/connection-editor.ui:17
+#: panels/network/connection-editor/vpn-helpers.c:181
+#: panels/network/connection-editor/vpn-helpers.c:310
+#: panels/network/net-device-wifi.c:1200 panels/network/net-device-wifi.c:1280
+#: panels/network/net-device-wifi.c:1474 panels/network/network-wifi.ui:24
+#: panels/printers/new-printer-dialog.ui:45
+#: panels/printers/pp-details-dialog.c:313
+#: panels/privacy/cc-privacy-panel.c:1137 panels/region/cc-format-chooser.ui:24
+#: panels/region/cc-input-chooser.ui:11
+#: panels/search/cc-search-locations-dialog.c:607
+#: panels/sharing/cc-sharing-panel.c:427
+#: panels/user-accounts/cc-add-user-dialog.ui:28
+#: panels/user-accounts/cc-avatar-chooser.c:106
+#: panels/user-accounts/cc-avatar-chooser.c:234
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:640
+#: panels/user-accounts/cc-user-panel.c:658
+#: panels/user-accounts/data/join-dialog.ui:20
+#: panels/user-accounts/um-fingerprint-dialog.c:261
+msgid "_Cancel"
+msgstr "_Бекор кардан"
+
+#: panels/background/cc-background-chooser-dialog.c:551
+#: panels/common/cc-language-chooser.ui:12
+#, fuzzy
+#| msgid "Select"
+msgid "_Select"
+msgstr "Интихоб кардан"
+
+#: panels/background/cc-background-item.c:191
+msgid "multiple sizes"
+msgstr "якчанд андоза"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:195
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:320
+msgid "No Desktop Background"
+msgstr "Бе пасзаминаи мизи корӣ"
+
+#: panels/background/cc-background-panel.c:291
+msgid "Current background"
+msgstr "Пасзаминаи ҷорӣ"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Background"
+msgstr "Пасзамина"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image to a wallpaper or photo"
+msgstr "Тағйир додани тасвири пасзамина ба тасвири экран ё сурат"
+
+#. Translators: Search terms to find the Background panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Тасвири экран;Экран;Мизи корӣ;"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:309
+#, fuzzy
+#| msgid "No Bluetooth adapters found"
+msgid "No Bluetooth Found"
+msgstr "Ягон адаптери Bluetooth ёфт нашуд"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:310
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.c:313
+#, fuzzy
+#| msgid "Bluetooth Sharing"
+msgid "Bluetooth Turned Off"
+msgstr "Дастрасии муштараки Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:314
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.c:317
+#, fuzzy
+#| msgid "Air_plane Mode"
+msgid "Airplane Mode is on"
+msgstr "Ҳ_олати ҳавопаймо"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:318
+#| msgid "Bluetooth is disabled by hardware switch"
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+"Вақте ки ҳолати ҳавопаймо фаъол аст, Bluetooth дар ҳолати ғайрифаъол қарор "
+"мегирад."
+
+#: panels/bluetooth/cc-bluetooth-panel.c:321
+#, fuzzy
+#| msgid "Air_plane Mode"
+msgid "Hardware Airplane Mode is on"
+msgstr "Ҳ_олати ҳавопаймо"
+
+#: panels/bluetooth/cc-bluetooth-panel.c:322
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.c:324
+#, fuzzy
+#| msgid "Air_plane Mode"
+msgid "Turn Off Airplane Mode"
+msgstr "Ҳ_олати ҳавопаймо"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/network/cc-network-panel.ui:101
+#: panels/printers/pp-new-printer-dialog.c:1697
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Фаъол ва хомӯш кардани Bluetooth ва пайваст кардани дастгоҳҳо"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:348
+#, fuzzy
+#| msgid "Place your calibration device over the square and press 'Start'"
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Дастгоҳи санҷишии худро ба чоркунҷа гузошта, \"Оғоз\"-ро зер кунед"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:354
+#, fuzzy
+#| msgid ""
+#| "Move your calibration device to the calibrate position and press "
+#| "'Continue'"
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Дастгоҳи санҷишии худро ба ҷойгиршавии санҷиш гузошта, \"Идома додан\"-ро "
+"пахш кунед"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:360
+#, fuzzy
+#| msgid ""
+#| "Move your calibration device to the surface position and press 'Continue'"
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Дастгоҳи санҷишии худро ба ҷойгиршавии сатҳ гузошта, \"Идома додан\"-ро пахш "
+"кунед"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:366
+msgid "Shut the laptop lid"
+msgstr "Пӯшидани сарпӯши лэптоп"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:397
+msgid "An internal error occurred that could not be recovered."
+msgstr "Хатои дарунии ҳалнашаванда ба вуҷуд омад."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:402
+msgid "Tools required for calibration are not installed."
+msgstr "Абзорҳои лозимии санҷиши насб нашудаанд."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:408
+msgid "The profile could not be generated."
+msgstr "Профил эҷод карда нашуд."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:414
+msgid "The target whitepoint was not obtainable."
+msgstr "Нуқтаи сафеди таъинотӣ ба даст оварда нашуд."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:453
+msgid "Complete!"
+msgstr "Ба анҷом расид!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:461
+msgid "Calibration failed!"
+msgstr "Санҷиш қатъ шудааст!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:468
+msgid "You can remove the calibration device."
+msgstr "Шумо метавонед дастгоҳи санҷиширо тоза кунед."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:537
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Дастгоҳи санҷиширо дар ҳолати иҷро қатъ накунед"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Экрани лэптоп"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Вебкамераи дарунсохт"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Монитори %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Сканери %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Камераи %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Принтери %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Веб-камераи %s"
+
+#: panels/color/cc-color-device.c:91
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Фаъол кардани идоракунии рангҳо барои %s"
+
+#: panels/color/cc-color-device.c:94
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Намоиш додани профилҳои ранг барои %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:303
+msgid "Not calibrated"
+msgstr "Санҷиш нашудааст"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:170
+msgid "Default: "
+msgstr "Пешфарз:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:178
+msgid "Colorspace: "
+msgstr "Фазои рангин:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:185
+msgid "Test profile: "
+msgstr "Санҷиши профил:"
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:239
+msgid "Select ICC Profile File"
+msgstr "Интихоби файли профили ICC"
+
+#: panels/color/cc-color-panel.c:242
+msgid "_Import"
+msgstr "_Ворид кардан"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:253
+msgid "Supported ICC profiles"
+msgstr "Профилҳои дастгиришудаи ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:260
+#: panels/network/wireless-security/eap-method-fast.c:417
+msgid "All files"
+msgstr "Ҳамаи файлҳо"
+
+#: panels/color/cc-color-panel.c:555
+msgid "Screen"
+msgstr "Экран"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: panels/color/cc-color-panel.c:847
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "Боркунии файл қатъ шуд: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: panels/color/cc-color-panel.c:859
+msgid "The profile has been uploaded to:"
+msgstr "Профил ба макони зерин бор шудааст:"
+
+#: panels/color/cc-color-panel.c:861
+msgid "Write down this URL."
+msgstr "Ин суроғаи URL-ро нависед."
+
+#: panels/color/cc-color-panel.c:862
+msgid "Restart this computer and boot your normal operating system."
+msgstr ""
+"Бозоғозидани ин компютер ва роҳандозӣ кардани низоми амалиётии муқаррарии "
+"шумо"
+
+#: panels/color/cc-color-panel.c:863
+msgid "Type the URL into your browser to download and install the profile."
+msgstr ""
+"Суроғаи URL-ро ба браузери худ ворид кунед, то ин ки профилро боргирӣ ва "
+"насб кунед."
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:891
+msgid "Save Profile"
+msgstr "Захира кардани профил"
+
+#: panels/color/cc-color-panel.c:895
+#: panels/network/connection-editor/vpn-helpers.c:311
+msgid "_Save"
+msgstr "_Захира кардан"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1209
+msgid "Create a color profile for the selected device"
+msgstr "Эҷод кардани профили рангин барои дастгоҳи интихобшуда"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1224 panels/color/cc-color-panel.c:1248
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Абзори ченкунӣ ёфт нашуд. Лутфан, санҷед, ки он фаъол мебошад, ва ба таври "
+"дуруст пайваст шудаанд."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1258
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Абзори ченкунӣ профилҳои принтерро дастгирӣ намекунад."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1269
+msgid "The device type is not currently supported."
+msgstr "Намуди дастгоҳ дар айни ҳол дастгирӣ намешавад."
+
+#: panels/color/cc-color-panel.ui:6 panels/wacom/calibrator/calibrator.ui:47
+msgid "Screen Calibration"
+msgstr "Санҷиши экран"
+
+#: panels/color/cc-color-panel.ui:23
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Санҷиш профилеро эҷод мекунад, то ин ки шумо тавонед онро барои идоракунии "
+"рангҳои экран истифода баред. Чӣ қадар вақти санҷиширо сарф кунед, ҳамон "
+"қадар сифати профили ранг беҳтар мегардад."
+
+#: panels/color/cc-color-panel.ui:38
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Ҳангоми истифодаи ҳолати санҷиши шумо наметавонед компютери худро истифода "
+"баред."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:58
+msgid "Quality"
+msgstr "Сифат"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:75
+msgid "Approximate Time"
+msgstr "Вақти тахминӣ"
+
+#: panels/color/cc-color-panel.ui:121
+msgid "Calibration Quality"
+msgstr "Сифати санҷиш"
+
+#: panels/color/cc-color-panel.ui:137
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Интихоби дастгоҳи ламсӣ барои истифода дар санҷиш"
+
+#: panels/color/cc-color-panel.ui:174
+msgid "Calibration Device"
+msgstr "Дастгоҳи санҷишӣ"
+
+#: panels/color/cc-color-panel.ui:189
+msgid "Select the type of display that is connected."
+msgstr "Интихоби намуди дисплейи пайвастшуда."
+
+#: panels/color/cc-color-panel.ui:226
+msgid "Display Type"
+msgstr "Намуди дисплей"
+
+#: panels/color/cc-color-panel.ui:241
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Нуқтаи ҳадафии сафеди дисплейро интихоб кунед. Қисми зиёди дисплейҳо бояд ба "
+"манбаи равшании D65 санҷида шаванд."
+
+#: panels/color/cc-color-panel.ui:278
+msgid "Profile Whitepoint"
+msgstr "Профили \"Whitepoint\""
+
+#: panels/color/cc-color-panel.ui:293
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Лутфан, дисплейро ба равшание, ки ба шумо мувофиқ аст, таъин кунед. "
+"Идоракунии рангҳо дар ин сатҳи равшанӣ саҳеҳтарин мегардад."
+
+#: panels/color/cc-color-panel.ui:307
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Ба тарзи илова, шумо метавонед сатҳи дурахшониеро, ки бо яке аз профилҳои "
+"дигар барои ин дастгоҳ истифода мебаред, истифода баред."
+
+#: panels/color/cc-color-panel.ui:318
+msgid "Display Brightness"
+msgstr "Равшании дисплей"
+
+#: panels/color/cc-color-panel.ui:333
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Шумо метавонед профили рангро дар компютерҳои гуногун истифода баред, ё ки "
+"ҳатто профилҳоро барои шароитҳои гуногуни равшанӣ эҷод кунед."
+
+#: panels/color/cc-color-panel.ui:348
+msgid "Profile Name:"
+msgstr "Номи профил:"
+
+#: panels/color/cc-color-panel.ui:377
+msgid "Profile Name"
+msgstr "Номи профил"
+
+#: panels/color/cc-color-panel.ui:392
+msgid "Profile successfully created!"
+msgstr "Профил бо муваффақият эҷод шудааст!"
+
+#: panels/color/cc-color-panel.ui:443
+msgid "Copy profile"
+msgstr "Нусха бардоштани профил"
+
+#: panels/color/cc-color-panel.ui:456
+msgid "Requires writable media"
+msgstr "Медиаи сабтшаванда лозим аст"
+
+#: panels/color/cc-color-panel.ui:519
+msgid "Upload profile"
+msgstr "Бор кардани профил"
+
+#: panels/color/cc-color-panel.ui:532
+msgid "Requires Internet connection"
+msgstr "Пайвасти интернет лозим аст"
+
+#: panels/color/cc-color-panel.ui:591
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Ин дастурҳои оиди тарзи истифодабарии ин профил дар низомҳои <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> ва <a href=\"windows"
+"\">Microsoft Windows</a> метавонанд ба шумо кумак кунанд."
+
+#: panels/color/cc-color-panel.ui:607
+#: panels/user-accounts/um-fingerprint-dialog.c:720
+msgid "Summary"
+msgstr "Хулоса"
+
+#: panels/color/cc-color-panel.ui:621
+#, fuzzy
+#| msgid "Add profile"
+msgid "Add Profile"
+msgstr "Илова кардани профил"
+
+#: panels/color/cc-color-panel.ui:643
+#, fuzzy
+#| msgid "Import File…"
+msgid "_Import File…"
+msgstr "Ворид кардани файл…"
+
+#: panels/color/cc-color-panel.ui:672
+#: panels/network/connection-editor/net-connection-editor.c:497
+#: panels/printers/new-printer-dialog.ui:80
+#: panels/region/cc-input-chooser.ui:20
+#: panels/user-accounts/cc-add-user-dialog.ui:47
+msgid "_Add"
+msgstr "_Илова кардан"
+
+#: panels/color/cc-color-panel.ui:732
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Мушкилӣ ба вуҷуд омад. Эҳтимол аст, ки профил дуруст кор намекунад. <a href="
+"\"\">Намоиш додани тафсилот.</a>"
+
+#: panels/color/cc-color-panel.ui:790
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Ҳар як дастгоҳ барои идоракунии ранг бояд дорои профили ранги навшуда бошад."
+
+#: panels/color/cc-color-panel.ui:812
+msgid "Learn more"
+msgstr "Маълумоти муфассал"
+
+#: panels/color/cc-color-panel.ui:817
+msgid "Learn more about color management"
+msgstr "Маълумоти бештар дар бораи идоракунии рангҳо"
+
+#: panels/color/cc-color-panel.ui:865
+#, fuzzy
+#| msgid "Set for all users"
+msgid "_Set for all users"
+msgstr "Таъин кардан ба ҳамаи корбарон"
+
+#: panels/color/cc-color-panel.ui:869 panels/color/cc-color-panel.ui:884
+#: panels/color/cc-color-panel.ui:885
+msgid "Set this profile for all users on this computer"
+msgstr "Таъин кардани ин профил ба ҳамаи корбарони ин компютер"
+
+#: panels/color/cc-color-panel.ui:880
+#, fuzzy
+#| msgid "Enable"
+msgid "_Enable"
+msgstr "Фаъол кардан"
+
+#: panels/color/cc-color-panel.ui:911
+#, fuzzy
+#| msgid "Add profile"
+msgid "_Add profile"
+msgstr "Илова кардани профил"
+
+#: panels/color/cc-color-panel.ui:924
+#| msgid "Calibrate…"
+msgid "_Calibrate…"
+msgstr "_Андозагароӣ…"
+
+#: panels/color/cc-color-panel.ui:928
+msgid "Calibrate the device"
+msgstr "Санҷиши дастгоҳ"
+
+#: panels/color/cc-color-panel.ui:939
+#, fuzzy
+#| msgid "Remove profile"
+msgid "_Remove profile"
+msgstr "Тоза кардани профил"
+
+#: panels/color/cc-color-panel.ui:952
+#, fuzzy
+#| msgid "View details"
+msgid "_View details"
+msgstr "Тафсилотро намоиш додан"
+
+#: panels/color/cc-color-panel.ui:988
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Ягон дастгоҳи қобили идоракунии рангҳо ташхис нашуд"
+
+#: panels/color/cc-color-panel.ui:1032
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:1037
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:1042
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:1047
+msgid "Projector"
+msgstr "Проектор"
+
+#: panels/color/cc-color-panel.ui:1052
+msgid "Plasma"
+msgstr "Плазма"
+
+#: panels/color/cc-color-panel.ui:1057
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (равшансозии CCFL)"
+
+#: panels/color/cc-color-panel.ui:1062
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (равшансозии RGB LED)"
+
+#: panels/color/cc-color-panel.ui:1067
+msgid "LCD (white LED backlight)"
+msgstr "LCD (равшансозии LED-и сафед)"
+
+#: panels/color/cc-color-panel.ui:1072
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Гаммаи васеъи LCD (равшансозии CCFL)"
+
+#: panels/color/cc-color-panel.ui:1077
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Гаммаи васеъи LCD (равшансозии RGB LED)"
+
+#: panels/color/cc-color-panel.ui:1094
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Баланд"
+
+#: panels/color/cc-color-panel.ui:1095
+msgid "40 minutes"
+msgstr "40 дақиқа"
+
+#: panels/color/cc-color-panel.ui:1099
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Миёна"
+
+#: panels/color/cc-color-panel.ui:1100
+msgid "30 minutes"
+msgstr "30 дақиқа"
+
+#: panels/color/cc-color-panel.ui:1104
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Паст"
+
+#: panels/color/cc-color-panel.ui:1105
+msgid "15 minutes"
+msgstr "15 дақиқа"
+
+#: panels/color/cc-color-panel.ui:1127
+msgid "Native to display"
+msgstr "Аслӣ барои дисплей"
+
+#: panels/color/cc-color-panel.ui:1131
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Чопкунӣ ва нашркунӣ)"
+
+#: panels/color/cc-color-panel.ui:1135
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:1139
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Суратҳо ва графикаҳо)"
+
+#: panels/color/cc-color-panel.ui:1143
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:100
+msgid "Standard Space"
+msgstr "Фазои стандартӣ"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:106
+msgid "Test Profile"
+msgstr "Санҷиши профил"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:114
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Худкор"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:124
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Сифати паст"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:129
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Сифати миёна"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:136
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Сифати баланд"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:153
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB-и пешфарз"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:160
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK-и пешфарз"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:167
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Хокистариранги пешфарз"
+
+#: panels/color/cc-color-profile.c:190
+msgid "Vendor supplied factory calibration data"
+msgstr "Иттилооти санҷиши заводии бо фурӯшанда таъминшуда"
+
+#: panels/color/cc-color-profile.c:199
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Ислоҳкунии экрани пурраи дисплей бо ин профил имконнопазир аст"
+
+#: panels/color/cc-color-profile.c:221
+msgid "This profile may no longer be accurate"
+msgstr "Эҳтимол аст, ки ин профил дигар саҳеҳ намебошад"
+
+#: panels/color/color-calibrate.ui:7
+msgid "Display Calibration"
+msgstr "Санҷиши дисплей"
+
+#. This starts the calibration process
+#: panels/color/color-calibrate.ui:40
+#, fuzzy
+#| msgid "Start"
+msgid "_Start"
+msgstr "Оғоз кардан"
+
+#. This resumes the calibration process
+#: panels/color/color-calibrate.ui:54
+#, fuzzy
+#| msgid "Resume"
+msgid "_Resume"
+msgstr "Давом додан"
+
+#. This button returns the user back to the color control panel
+#: panels/color/color-calibrate.ui:67 panels/region/cc-format-chooser.ui:13
+msgid "_Done"
+msgstr "_Тайёр"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Ранг"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Санҷиши ранги дастгоҳҳо, монанди дисплейҳо, камераҳо ё принтерҳо"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Ранг;ICC;Профил;Танзими андоза;Принтер;Дисплей;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Дигар…"
+
+#: panels/common/cc-language-chooser.c:125
+#: panels/region/cc-format-chooser.c:268 panels/region/cc-input-chooser.c:178
+msgid "More…"
+msgstr "Бештар…"
+
+#: panels/common/cc-language-chooser.c:142
+msgid "No languages found"
+msgstr "Ягон забон ёфт нашудааст"
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+#| msgid "Language"
+msgid "Select Language"
+msgstr "Забон"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:106
+msgid "Today"
+msgstr "Имрӯз"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "Yesterday"
+msgstr "Дирӯз"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+#, fuzzy
+#| msgid "_Stop Hotspot"
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "_Қатъ кардани \"ХОТ-СПОТ\""
+
+#: panels/datetime/big.ui:16 panels/datetime/little.ui:16
+#: panels/datetime/middle.ui:16 panels/datetime/ydm.ui:16
+msgid "Day"
+msgstr "Рӯз"
+
+#: panels/datetime/big.ui:32 panels/datetime/little.ui:32
+#: panels/datetime/middle.ui:32 panels/datetime/ydm.ui:32
+msgid "Month"
+msgstr "Моҳ"
+
+#: panels/datetime/big.ui:48 panels/datetime/little.ui:48
+#: panels/datetime/middle.ui:48 panels/datetime/ydm.ui:48
+msgid "Year"
+msgstr "Сол"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:332
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:337
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:502
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:529
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:536
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:541
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:546
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:551
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:26
+msgid "January"
+msgstr "Январ"
+
+#: panels/datetime/cc-datetime-panel.ui:29
+msgid "February"
+msgstr "Феврал"
+
+#: panels/datetime/cc-datetime-panel.ui:32
+msgid "March"
+msgstr "Март"
+
+#: panels/datetime/cc-datetime-panel.ui:35
+msgid "April"
+msgstr "Апрел"
+
+#: panels/datetime/cc-datetime-panel.ui:38
+msgid "May"
+msgstr "Май"
+
+#: panels/datetime/cc-datetime-panel.ui:41
+msgid "June"
+msgstr "Июн"
+
+#: panels/datetime/cc-datetime-panel.ui:44
+msgid "July"
+msgstr "Июл"
+
+#: panels/datetime/cc-datetime-panel.ui:47
+msgid "August"
+msgstr "Август"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "September"
+msgstr "Сентябр"
+
+#: panels/datetime/cc-datetime-panel.ui:53
+msgid "October"
+msgstr "Октябр"
+
+#: panels/datetime/cc-datetime-panel.ui:56
+msgid "November"
+msgstr "Ноябр"
+
+#: panels/datetime/cc-datetime-panel.ui:59
+msgid "December"
+msgstr "Декабр"
+
+#: panels/datetime/cc-datetime-panel.ui:65
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Сана ва Вақт"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#: panels/display/cc-night-light-dialog.ui:245
+#: panels/display/cc-night-light-dialog.ui:352
+msgid "Hour"
+msgstr "Соат"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: panels/datetime/cc-datetime-panel.ui:128
+msgid "∶"
+msgstr "∶"
+
+#: panels/datetime/cc-datetime-panel.ui:152
+#: panels/display/cc-night-light-dialog.ui:273
+#: panels/display/cc-night-light-dialog.ui:380
+msgid "Minute"
+msgstr "Дақиқа"
+
+#: panels/datetime/cc-datetime-panel.ui:219
+msgid "Time Zone"
+msgstr "Минтақаи вақт"
+
+#: panels/datetime/cc-datetime-panel.ui:240
+msgid "Search for a city"
+msgstr "Ҷустуҷӯи шаҳр"
+
+#: panels/datetime/cc-datetime-panel.ui:313
+msgid "Automatic _Date & Time"
+msgstr "_Сана ва вақти худкор"
+
+#: panels/datetime/cc-datetime-panel.ui:314
+msgid "Requires internet access"
+msgstr "Дастрасии интернет лозим аст"
+
+#: panels/datetime/cc-datetime-panel.ui:334
+msgid "Automatic Time _Zone"
+msgstr "_Минтақаи вақти худкор"
+
+#: panels/datetime/cc-datetime-panel.ui:335
+#, fuzzy
+#| msgid "Requires internet access"
+msgid "Requires location services enabled and internet access"
+msgstr "Дастрасии интернет лозим аст"
+
+#: panels/datetime/cc-datetime-panel.ui:350
+msgid "Date & _Time"
+msgstr "Сана ва _вақт"
+
+#: panels/datetime/cc-datetime-panel.ui:366
+#, fuzzy
+#| msgid "Time Zone"
+msgid "Time Z_one"
+msgstr "Минтақаи вақт"
+
+#: panels/datetime/cc-datetime-panel.ui:405
+msgid "Time _Format"
+msgstr "Формати _вақт"
+
+#: panels/datetime/cc-datetime-panel.ui:414
+msgid "24-hour"
+msgstr "24-соат"
+
+#: panels/datetime/cc-datetime-panel.ui:415
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Тағйир додани вақт ва сана, аз ҷумла минтақаи вақт"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Соат;Минтақаи вақт;Ҷойгиршавӣ;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Тағйир додани танзимоти вақт ва санаи низом"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Барои тағйир додани танзимоти вақт ё сана, шумо бояд ворид шавед."
+
+#: panels/display/cc-display-panel.c:927
+#: panels/network/connection-editor/connection-editor.ui:27
+#: panels/network/network-wifi.ui:38
+msgid "_Apply"
+msgstr "_Татбиқ кардан"
+
+#: panels/display/cc-display-panel.c:948
+msgid "Apply Changes?"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:953
+msgid "Changes Cannot be Applied"
+msgstr ""
+
+#: panels/display/cc-display-panel.c:954
+msgid "This could be due to hardware limitations."
+msgstr ""
+
+#. TRANSLATORS: the state of the night light setting
+#: panels/display/cc-display-panel.c:1127
+#: panels/notifications/cc-notifications-panel.c:270
+#: panels/power/cc-power-panel.c:2056 panels/power/cc-power-panel.c:2063
+#: panels/privacy/cc-privacy-panel.c:212 panels/privacy/cc-privacy-panel.c:289
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:841
+#: panels/universal-access/cc-ua-panel.c:854
+#: panels/universal-access/cc-ua-panel.c:866
+#: panels/universal-access/cc-ua-panel.c:1031
+msgid "On"
+msgstr "Фаъол"
+
+#: panels/display/cc-display-panel.c:1127 panels/network/net-proxy.c:54
+#: panels/notifications/cc-notifications-panel.c:270
+#: panels/power/cc-power-panel.c:2050 panels/power/cc-power-panel.c:2061
+#: panels/privacy/cc-privacy-panel.c:212 panels/privacy/cc-privacy-panel.c:289
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:841
+#: panels/universal-access/cc-ua-panel.c:854
+#: panels/universal-access/cc-ua-panel.c:866
+#: panels/universal-access/cc-ua-panel.c:1031
+#: panels/universal-access/cc-ua-panel.ui:338
+#: panels/universal-access/cc-ua-panel.ui:384
+#: panels/universal-access/cc-ua-panel.ui:430
+#: panels/universal-access/cc-ua-panel.ui:536
+#: panels/universal-access/cc-ua-panel.ui:689
+#: panels/universal-access/cc-ua-panel.ui:735
+#: panels/universal-access/cc-ua-panel.ui:781
+#: panels/universal-access/cc-ua-panel.ui:933
+msgid "Off"
+msgstr "Хомӯш"
+
+#: panels/display/cc-display-panel.ui:81
+#, fuzzy
+#| msgid "Secondary Display"
+msgid "Single Display"
+msgstr "Дисплейи дуюм"
+
+#: panels/display/cc-display-panel.ui:100
+#: panels/display/cc-display-panel.ui:305
+#, fuzzy
+#| msgid "Displays"
+msgid "Join Displays"
+msgstr "Дисплейҳо"
+
+#: panels/display/cc-display-panel.ui:118
+msgid "Mirror"
+msgstr "Оина"
+
+#: panels/display/cc-display-panel.ui:143
+#, fuzzy
+#| msgid "Display Type"
+msgid "Display Mode"
+msgstr "Намуди дисплей"
+
+#: panels/display/cc-display-panel.ui:235
+msgid ""
+"Drag displays to match your physical display setup. Select a display to "
+"change its settings."
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:242
+#, fuzzy
+#| msgid "Display Mapping"
+msgid "Display Arrangement"
+msgstr "Нақшабандии дисплей"
+
+#: panels/display/cc-display-panel.ui:424
+#, fuzzy
+#| msgid "Display Calibration"
+msgid "Display Configuration"
+msgstr "Санҷиши дисплей"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:451
+#: panels/display/cc-display-panel.ui:469
+#: panels/display/cc-night-light-dialog.ui:505
+#, fuzzy
+#| msgid "Right Ring"
+msgid "Night Light"
+msgstr "Ҳалқаи рост"
+
+#: panels/display/cc-display-settings.c:108
+#, fuzzy
+#| msgid "Landscape"
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Уфуқӣ"
+
+#: panels/display/cc-display-settings.c:111
+#, fuzzy
+#| msgid "Portrait"
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Амудӣ"
+
+#: panels/display/cc-display-settings.c:114
+#, fuzzy
+#| msgid "Portrait"
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Амудӣ"
+
+#: panels/display/cc-display-settings.c:117
+#, fuzzy
+#| msgid "Landscape"
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Уфуқӣ"
+
+#: panels/display/cc-display-settings.c:191
+#, c-format
+msgid "%.2lf Hz"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:15
+#, fuzzy
+#| msgid "Orientation"
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Самт"
+
+#: panels/display/cc-display-settings.ui:24
+#, fuzzy
+#| msgid "Resolution"
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Возеҳӣ"
+
+#: panels/display/cc-display-settings.ui:33
+msgid "Refresh Rate"
+msgstr "Суръати навсозӣ"
+
+#: panels/display/cc-display-settings.ui:42
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:59
+#, fuzzy
+#| msgctxt "background, style"
+#| msgid "Scale"
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Миқиёсбандӣ"
+
+#: panels/display/cc-night-light-dialog.c:647
+msgid "More Warm"
+msgstr ""
+
+#: panels/display/cc-night-light-dialog.c:659
+msgid "Less Warm"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-dialog.ui:46
+#, fuzzy
+#| msgid "Restart Now"
+msgid "Restart Filter"
+msgstr "Ҳозир бозоғозӣ кардан"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-dialog.ui:79
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#: panels/display/cc-night-light-dialog.ui:106
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-dialog.ui:127
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-dialog.ui:148
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-dialog.ui:164
+#: panels/network/connection-editor/ip4-page.ui:69
+#: panels/network/connection-editor/ip6-page.ui:83
+#: panels/network/net-proxy.c:56 panels/network/network-proxy.ui:113
+#: panels/network/network-wifi.ui:776 panels/network/network-wifi.ui:1053
+#: panels/privacy/cc-privacy-panel.c:239
+msgid "Manual"
+msgstr "Дастӣ"
+
+#: panels/display/cc-night-light-dialog.ui:180
+msgid "_Off"
+msgstr ""
+
+#: panels/display/cc-night-light-dialog.ui:216
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-dialog.ui:254
+#: panels/display/cc-night-light-dialog.ui:361
+msgid ":"
+msgstr ":"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-dialog.ui:284
+#: panels/display/cc-night-light-dialog.ui:391
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-dialog.ui:300
+#: panels/display/cc-night-light-dialog.ui:407
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-dialog.ui:449
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-dialog.ui:470
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Дисплейҳо"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Интихоб кардани тарзи истифодаи мониторҳо ва проекторҳои пайвастшуда"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+#| msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "Панел;Проектор;xrandr;Экран;Возеҳӣ;Навсозӣ;Монитор;"
+
+#: panels/info/cc-info-default-apps-panel.ui:31
+msgid "_Web"
+msgstr "_Веб"
+
+#: panels/info/cc-info-default-apps-panel.ui:43
+msgid "_Mail"
+msgstr "_Почта"
+
+#: panels/info/cc-info-default-apps-panel.ui:59
+msgid "_Calendar"
+msgstr "_Тақвим"
+
+#: panels/info/cc-info-default-apps-panel.ui:75
+msgid "M_usic"
+msgstr "_Мусиқӣ"
+
+#: panels/info/cc-info-default-apps-panel.ui:91
+msgid "_Video"
+msgstr "_Видео"
+
+#: panels/info/cc-info-default-apps-panel.ui:162
+#: panels/info/cc-info-removable-media-panel.ui:161
+msgid "_Photos"
+msgstr "_Суратҳо"
+
+#. TRANSLATORS: AP type
+#: panels/info/cc-info-overview-panel.c:369
+#: panels/info/cc-info-overview-panel.c:452
+#: panels/info/cc-info-overview-panel.c:497
+#: panels/info/cc-info-overview-panel.c:527 panels/network/panel-common.c:123
+msgid "Unknown"
+msgstr "Номаълум"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info/cc-info-overview-panel.c:460
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr ""
+
+#. translators: This is the type of architecture for the OS
+#: panels/info/cc-info-overview-panel.c:477
+#, fuzzy, c-format
+#| msgid "%d-bit"
+msgid "64-bit"
+msgstr "%d-бит"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info/cc-info-overview-panel.c:480
+#, fuzzy, c-format
+#| msgid "%d-bit"
+msgid "32-bit"
+msgstr "%d-бит"
+
+#: panels/info/cc-info-overview-panel.c:710
+#, c-format
+msgid "Version %s"
+msgstr "Версияи %s"
+
+#: panels/info/cc-info-overview-panel.ui:70
+msgid "Device name"
+msgstr "Номи дастгоҳ"
+
+#: panels/info/cc-info-overview-panel.ui:86
+msgid "Memory"
+msgstr "Ҳофиза"
+
+#: panels/info/cc-info-overview-panel.ui:102
+msgid "Processor"
+msgstr "Просессор"
+
+#: panels/info/cc-info-overview-panel.ui:118
+msgid "Graphics"
+msgstr "Графика"
+
+#. To translators: this field contains the distro name and version
+#: panels/info/cc-info-overview-panel.ui:133
+msgid "OS name"
+msgstr ""
+
+#. To translators: this field contains the distro type
+#: panels/info/cc-info-overview-panel.ui:149
+#, fuzzy
+#| msgid "Security type"
+msgid "OS type"
+msgstr "Навъи амният"
+
+#: panels/info/cc-info-overview-panel.ui:165
+msgid "Virtualization"
+msgstr "Виртуализатсия"
+
+#: panels/info/cc-info-overview-panel.ui:181
+msgid "Disk"
+msgstr "Диск"
+
+#: panels/info/cc-info-overview-panel.ui:293
+msgid "Calculating…"
+msgstr "Ҳисоб шуда истодааст…"
+
+#: panels/info/cc-info-overview-panel.ui:333
+msgid "Check for updates"
+msgstr "Санҷиши навсозиҳо"
+
+#: panels/info/cc-info-removable-media-panel.c:296
+msgid "Ask what to do"
+msgstr "Чӣ бояд кард"
+
+#: panels/info/cc-info-removable-media-panel.c:300
+msgid "Do nothing"
+msgstr "Амалиёт лозим нест"
+
+#: panels/info/cc-info-removable-media-panel.c:304
+msgid "Open folder"
+msgstr "Кушодани ҷузвдон"
+
+#: panels/info/cc-info-removable-media-panel.c:389
+msgid "Other Media"
+msgstr "Мултимедиаи дигар"
+
+#: panels/info/cc-info-removable-media-panel.c:422
+msgid "Select an application for audio CDs"
+msgstr "Интихоби барнома барои аудио дар дискҳои CD"
+
+#: panels/info/cc-info-removable-media-panel.c:423
+msgid "Select an application for video DVDs"
+msgstr "Интихоби барнома барои видео дар дискҳои DVD"
+
+#: panels/info/cc-info-removable-media-panel.c:424
+msgid "Select an application to run when a music player is connected"
+msgstr ""
+"Барномаеро барои иҷро шудан ҳангоми пайваст шудани плеери мусиқӣ интихоб "
+"кунед"
+
+#: panels/info/cc-info-removable-media-panel.c:425
+msgid "Select an application to run when a camera is connected"
+msgstr ""
+"Барномаеро барои иҷро шудан ҳангоми пайваст шудани камера интихоб кунед"
+
+#: panels/info/cc-info-removable-media-panel.c:426
+msgid "Select an application for software CDs"
+msgstr "Интихоби барнома барои нармафзор дан дискҳои CD"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/info/cc-info-removable-media-panel.c:438
+msgid "audio DVD"
+msgstr "Диски аудиои DVD"
+
+#: panels/info/cc-info-removable-media-panel.c:439
+msgid "blank Blu-ray disc"
+msgstr "диски холии Blu-ray"
+
+#: panels/info/cc-info-removable-media-panel.c:440
+msgid "blank CD disc"
+msgstr "диски холии CD"
+
+#: panels/info/cc-info-removable-media-panel.c:441
+msgid "blank DVD disc"
+msgstr "диски холии DVD"
+
+#: panels/info/cc-info-removable-media-panel.c:442
+msgid "blank HD DVD disc"
+msgstr "диски холии HD DVD"
+
+#: panels/info/cc-info-removable-media-panel.c:443
+msgid "Blu-ray video disc"
+msgstr "Диски видеои Blu-ray"
+
+#: panels/info/cc-info-removable-media-panel.c:444
+msgid "e-book reader"
+msgstr "хонандаи китобхои электронӣ"
+
+#: panels/info/cc-info-removable-media-panel.c:445
+msgid "HD DVD video disc"
+msgstr "Диски видеои HD DVD"
+
+#: panels/info/cc-info-removable-media-panel.c:446
+msgid "Picture CD"
+msgstr "Суратҳо дар CD"
+
+#: panels/info/cc-info-removable-media-panel.c:447
+msgid "Super Video CD"
+msgstr "Супервидеои CD"
+
+#: panels/info/cc-info-removable-media-panel.c:448
+msgid "Video CD"
+msgstr "Видеои CD"
+
+#: panels/info/cc-info-removable-media-panel.c:449
+msgid "Windows software"
+msgstr "Нармафзори Windows"
+
+#: panels/info/cc-info-removable-media-panel.ui:43
+msgid "Select how media should be handled"
+msgstr "Интихоби тарзи истифодаи медиа"
+
+#: panels/info/cc-info-removable-media-panel.ui:74
+msgid "CD _audio"
+msgstr "Аудиои _CD"
+
+#: panels/info/cc-info-removable-media-panel.ui:91
+msgid "_DVD video"
+msgstr "Видеои _DVD"
+
+#: panels/info/cc-info-removable-media-panel.ui:132
+msgid "_Music player"
+msgstr "_Плеери мусиқӣ"
+
+#: panels/info/cc-info-removable-media-panel.ui:190
+msgid "_Software"
+msgstr "_Нармафзор"
+
+#: panels/info/cc-info-removable-media-panel.ui:228
+msgid "_Other Media…"
+msgstr "_Мултимедиаи дигар…"
+
+#: panels/info/cc-info-removable-media-panel.ui:272
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Ҳеҷ гоҳ огоҳ надодан ва оғоз накардани барномаҳо ҳангоми дарҷкунии медиа"
+
+#: panels/info/cc-info-removable-media-panel.ui:331
+msgid "Select how other media should be handled"
+msgstr "Интихоби тарзи истифодаи медиаи дигар"
+
+#: panels/info/cc-info-removable-media-panel.ui:370
+msgid "_Action:"
+msgstr "_Амал:"
+
+#: panels/info/cc-info-removable-media-panel.ui:393
+msgid "_Type:"
+msgstr "_Навъ:"
+
+#: panels/info/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Барномаҳои пешфарз"
+
+#: panels/info/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Default Applications"
+msgid "Configure Default Applications"
+msgstr "Барномаҳои пешфарз"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/info/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/info/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Намоиш додани иттилоот дар бораи низом"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"дастгоҳ;низом;иттилоот;ҳофиза;просессор;версия;пешфарз;барнома;пазируфта;cd;"
+"dvd;usb;аудио;видео;диск;ҷқдошаванда;медиа;иҷрои худкор;"
+
+#: panels/info/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Медиаи ҷудошаванда"
+
+#: panels/info/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Removable Media"
+msgid "Configure Removable Media settings"
+msgstr "Медиаи ҷудошаванда"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/info/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "device;system;information;memory;processor;version;default;application;"
+#| "preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"дастгоҳ;низом;иттилоот;ҳофиза;просессор;версия;пешфарз;барнома;пазируфта;cd;"
+"dvd;usb;аудио;видео;диск;ҷқдошаванда;медиа;иҷрои худкор;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Садо ва мултимедиа"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute"
+msgstr "Бесадо кардан"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Паст кардан"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Баланд кардан"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Launch media player"
+msgstr "Оғоз кардани плеери мултимедиа"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Play (or play/pause)"
+msgstr "Пахш кардан (ё пахш/таваққуф)"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Pause playback"
+msgstr "Таваққуф кардани иҷро"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Stop playback"
+msgstr "Қатъ кардани иҷро"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Previous track"
+msgstr "Пайгирии қаблӣ"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Next track"
+msgstr "Пайгирии навбатӣ"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Eject"
+msgstr "Баровардан"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:580
+msgid "Typing"
+msgstr "Вуруд"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Гузариш ба манбаи вуруди навбатӣ"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Гузариш ба манбаи вуруди қаблӣ"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Оғозкунандагон"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Оғоз кардани кумаки браузер"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Оғоз кардани калкулятор"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Оғоз кардани барномаи почтаи электронӣ"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Оғоз кардани браузери веб"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Ҷузвдони асосӣ"
+
+#: panels/keyboard/01-screenshot.xml.in:2
+msgid "Screenshots"
+msgstr "Суратҳои экран"
+
+#: panels/keyboard/01-screenshot.xml.in:6
+msgid "Save a screenshot to $PICTURES"
+msgstr "Захира кардани сурати экран ба $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:10
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "Захира кардани сурати равзана ба $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:14
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "Захира кардани сурати ноҳия ба $PICTURES"
+
+#: panels/keyboard/01-screenshot.xml.in:17
+msgid "Copy a screenshot to clipboard"
+msgstr "Нусха бардоштани сурати экран ба ҳофизаи муваққатӣ"
+
+#: panels/keyboard/01-screenshot.xml.in:20
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "Нусха бардоштани сурати равзана ба ҳофизаи муваққатӣ"
+
+#: panels/keyboard/01-screenshot.xml.in:23
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "Нусха бардоштани сурати ноҳия ба ҳофизаи муваққатӣ"
+
+#: panels/keyboard/01-screenshot.xml.in:26
+msgid "Record a short screencast"
+msgstr "Сабт кардани видеои экрании кӯтоҳ"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Система"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Баромад"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Экрани қулф"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Universal Access"
+msgstr "Дастрасии умумӣ"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Хомӯш ё фаъол кардани танзими андоза"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Бузург кардани андоза"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Хурд кардани андоза"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Хомӯш ё фаъол кардани хонандаи экранӣ"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Хомӯш ё фаъол кардани клавиатураи экранӣ"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Калон кардани андозаи матн"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Хурд кардани андозаи матн"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Фаъол ё хомӯш кардани контрасти баланд"
+
+#: panels/keyboard/cc-keyboard-manager.c:501
+#: panels/keyboard/cc-keyboard-manager.c:509
+#: panels/keyboard/cc-keyboard-manager.c:809
+msgid "Custom Shortcuts"
+msgstr "Миёнбурҳои шахсӣ"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: panels/keyboard/cc-keyboard-option.c:337
+msgid "Alternative Characters Key"
+msgstr "Тугмаҳои аломатдори иловагӣ"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: panels/keyboard/cc-keyboard-option.c:346
+msgid "Compose Key"
+msgstr "Тугмаи эҷодкунӣ"
+
+#: panels/keyboard/cc-keyboard-option.c:351
+msgid "Modifiers-only switch to next source"
+msgstr "Табдилдиҳандагон-танҳо гузариш ба манбаи навбатӣ"
+
+#: panels/keyboard/cc-keyboard-panel.c:179
+msgid "Reset All Shortcuts?"
+msgstr "Ҳамаи миёнбурҳоро тоза мекунед?"
+
+#: panels/keyboard/cc-keyboard-panel.c:182
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.c:186
+#: panels/keyboard/shortcut-editor.ui:346
+#: panels/printers/authentication-dialog.ui:29
+#: panels/printers/ppd-selection-dialog.ui:27
+msgid "Cancel"
+msgstr "Бекор кардан"
+
+#: panels/keyboard/cc-keyboard-panel.c:187
+#, fuzzy
+#| msgid "Reset"
+msgid "Reset All"
+msgstr "Бозсозӣ"
+
+#: panels/keyboard/cc-keyboard-panel.c:283
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:67 panels/region/cc-region-panel.ui:395
+#: shell/cc-window.ui:334
+msgid "Keyboard Shortcuts"
+msgstr "Миёнбурҳои клавиатура"
+
+#: panels/keyboard/cc-keyboard-panel.ui:77
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:78
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:164
+#, fuzzy
+#| msgid "Keyboard Shortcuts"
+msgid "No keyboard shortcut found"
+msgstr "Миёнбурҳои клавиатура"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:411
+#, c-format
+msgid ""
+"%s is already being used for <b>%s</b>. If you replace it, %s will be "
+"disabled"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+#, fuzzy
+#| msgid "Custom Shortcut"
+msgid "Set Custom Shortcut"
+msgstr "Миёнбури шахсӣ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:581
+#, fuzzy
+#| msgid "Shortcuts"
+msgid "Set Shortcut"
+msgstr "Миёнбурҳо"
+
+#. Setup the top label
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:590
+#, c-format
+msgid "Enter new shortcut to change <b>%s</b>."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:1017
+#, fuzzy
+#| msgid "Custom Shortcut"
+msgid "Add Custom Shortcut"
+msgstr "Миёнбури шахсӣ"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Клавиатура"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr ""
+"Миёнбурҳои клавиатураро намоиш диҳед ва тағйир диҳед, ва бартариҳои чопкунии "
+"худро таъин кунед"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/keyboard/shortcut-editor.ui:68 panels/keyboard/shortcut-editor.ui:318
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/shortcut-editor.ui:156 panels/printers/details-dialog.ui:38
+msgid "Name"
+msgstr "Ном"
+
+#: panels/keyboard/shortcut-editor.ui:168
+msgid "Command"
+msgstr "Фармон"
+
+#: panels/keyboard/shortcut-editor.ui:180
+#, fuzzy
+#| msgid "Shortcuts"
+msgid "Shortcut"
+msgstr "Миёнбурҳо"
+
+#: panels/keyboard/shortcut-editor.ui:259
+msgid "Set Shortcut…"
+msgstr "Танзими миёнбур…"
+
+#: panels/keyboard/shortcut-editor.ui:272 panels/network/network-wifi.ui:593
+msgid "None"
+msgstr "Ҳеҷ"
+
+#: panels/keyboard/shortcut-editor.ui:303
+msgid "Enter the new shortcut"
+msgstr ""
+
+#: panels/keyboard/shortcut-editor.ui:357
+#, fuzzy
+#| msgid "_Remove"
+msgid "Remove"
+msgstr "_Тоза кардан"
+
+#: panels/keyboard/shortcut-editor.ui:367
+msgid "Add"
+msgstr "Илова кардан"
+
+#: panels/keyboard/shortcut-editor.ui:382
+#, fuzzy
+#| msgid "_Replace"
+msgid "Replace"
+msgstr "Ҷойгузин _кардан"
+
+#: panels/keyboard/shortcut-editor.ui:395
+#, fuzzy
+#| msgid "Select"
+msgid "Set"
+msgstr "Интихоб кардан"
+
+#: panels/mouse/cc-mouse-panel.c:80 panels/wacom/cc-wacom-panel.c:463
+msgid "Test Your _Settings"
+msgstr "Санҷиши _танзимот"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Муш ва панели ламсӣ"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Тағйир додани ҳассосияти муш ё панели ламсӣ ва имконоти истифодаи дасти рост "
+"ё чап"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+":Панели пайгирӣ;Нишондиҳанда;Зер кардан;Зарба задан;Дубора;Тугма;Трекбол;"
+"Ҳаракат;"
+
+#: panels/mouse/gnome-mouse-properties.ui:50
+msgid "General"
+msgstr "Умумӣ"
+
+#: panels/mouse/gnome-mouse-properties.ui:88
+#, fuzzy
+#| msgid "Primary _button"
+msgid "Primary Button"
+msgstr "Тугмаи _асосӣ"
+
+#: panels/mouse/gnome-mouse-properties.ui:107
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/gnome-mouse-properties.ui:136
+#: panels/sound/cc-balance-slider.ui:13
+#, fuzzy
+#| msgctxt "balance"
+#| msgid "Left"
+msgid "Left"
+msgstr "Чап"
+
+#: panels/mouse/gnome-mouse-properties.ui:146
+#: panels/sound/cc-balance-slider.ui:15
+#, fuzzy
+#| msgctxt "balance"
+#| msgid "Right"
+msgid "Right"
+msgstr "Рост"
+
+#: panels/mouse/gnome-mouse-properties.ui:182
+msgid "Mouse"
+msgstr "Муш"
+
+#: panels/mouse/gnome-mouse-properties.ui:221
+#, fuzzy
+#| msgid "Mouse Settings"
+msgid "Mouse Speed"
+msgstr "Танзимоти муш"
+
+#: panels/mouse/gnome-mouse-properties.ui:243
+#: panels/mouse/gnome-mouse-properties.ui:535
+msgid "Double-click timeout"
+msgstr "Анҷоми вақти зеркуни дубора"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/gnome-mouse-properties.ui:280
+#: panels/mouse/gnome-mouse-properties.ui:443
+#, fuzzy
+#| msgid "_Natural scrolling"
+msgid "Natural Scrolling"
+msgstr "_Ҳаракаткунии одатӣ"
+
+#: panels/mouse/gnome-mouse-properties.ui:296
+#: panels/mouse/gnome-mouse-properties.ui:459
+#, fuzzy
+#| msgid "This will not remove the account on the server."
+msgid "Scrolling moves the content, not the view."
+msgstr "Ин ҳисобро аз сервер тоза намекунад."
+
+#: panels/mouse/gnome-mouse-properties.ui:346
+#: panels/mouse/gnome-mouse-properties.ui:391
+msgid "Touchpad"
+msgstr "Панели ламсӣ"
+
+#: panels/mouse/gnome-mouse-properties.ui:514
+#, fuzzy
+#| msgid "Touchpad"
+msgid "Touchpad Speed"
+msgstr "Панели ламсӣ"
+
+#: panels/mouse/gnome-mouse-properties.ui:573
+#, fuzzy
+#| msgid "Tap to _click"
+msgid "Tap to Click"
+msgstr "Барои зеркунӣ _зарба занед"
+
+#: panels/mouse/gnome-mouse-properties.ui:625
+#, fuzzy
+#| msgid "Two _finger scroll"
+msgid "Two-finger Scrolling"
+msgstr "Ҳаракатдиҳии _дуангушта"
+
+#: panels/mouse/gnome-mouse-properties.ui:678
+#, fuzzy
+#| msgid "Scroll Right"
+msgid "Edge Scrolling"
+msgstr "Ба рост ҳаракат кардан"
+
+#: panels/mouse/gnome-mouse-test.c:132 panels/mouse/gnome-mouse-test.ui:25
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Зеркунӣ, зеркунии дубора, ҳаракатдиҳиро кӯшиш кунед"
+
+#: panels/mouse/gnome-mouse-test.c:137
+msgid "Five clicks, GEGL time!"
+msgstr "Панҷ зеркунӣ, вақти GEGL!"
+
+#: panels/mouse/gnome-mouse-test.c:142
+msgid "Double click, primary button"
+msgstr "Зеркунии дубора, тугмаи асосӣ"
+
+#: panels/mouse/gnome-mouse-test.c:142
+msgid "Single click, primary button"
+msgstr "Зеркунии якбора, тугмаи асосӣ"
+
+#: panels/mouse/gnome-mouse-test.c:145
+msgid "Double click, middle button"
+msgstr "Зеркунии дубора, тугмаи миёна"
+
+#: panels/mouse/gnome-mouse-test.c:145
+msgid "Single click, middle button"
+msgstr "Зеркунии якбора, тугмаи миёна"
+
+#: panels/mouse/gnome-mouse-test.c:148
+msgid "Double click, secondary button"
+msgstr "Зеркунии дубора, тугмаи иловагӣ"
+
+#: panels/mouse/gnome-mouse-test.c:148
+msgid "Single click, secondary button"
+msgstr "Зеркунии якбора, тугмаи иловагӣ"
+
+#. add proxy to device list
+#: panels/network/cc-network-panel.c:590
+msgid "Network proxy"
+msgstr "Прокси шабака"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: panels/network/cc-network-panel.c:726 panels/network/net-vpn.c:167
+#: panels/network/net-vpn.c:295
+#, c-format
+msgid "%s VPN"
+msgstr "VPN-и %s"
+
+#: panels/network/cc-network-panel.c:790 panels/network/cc-wifi-panel.ui:304
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Оҳ, чизе нодуруст ба амал омад. Лутфан, бо фурӯшандаи нармафзор дар тамос "
+"шавед."
+
+#: panels/network/cc-network-panel.c:796
+msgid "NetworkManager needs to be running."
+msgstr "Мудири шабака бояд иҷро карда шавад."
+
+#: panels/network/cc-network-panel.ui:142
+#: panels/network/connection-editor/net-connection-editor.c:581
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:194
+msgid "Not set up"
+msgstr ""
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:189
+#, fuzzy, c-format
+#| msgctxt "timezone desc"
+#| msgid "%s (%s)"
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (%s)"
+
+#: panels/network/cc-wifi-connection-row.ui:73
+#: panels/network/net-device-ethernet.c:359
+#: panels/network/network-ethernet.ui:120 panels/network/network-mobile.ui:394
+#: panels/network/network-simple.ui:75 panels/network/network-vpn.ui:79
+msgid "Options…"
+msgstr "Имконот…"
+
+#: panels/network/cc-wifi-panel.c:281
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:1738
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:56
+#, fuzzy
+#| msgid "Air_plane Mode"
+msgid "Airplane Mode"
+msgstr "Ҳ_олати ҳавопаймо"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:141
+#, fuzzy
+#| msgid "No Pictures Found"
+msgid "No Wi-Fi Adapter Found"
+msgstr "Ягон тасвир ёфт нашудааст"
+
+#: panels/network/cc-wifi-panel.ui:153
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:188
+#, fuzzy
+#| msgid "Air_plane Mode"
+msgid "Airplane Mode On"
+msgstr "Ҳ_олати ҳавопаймо"
+
+#: panels/network/cc-wifi-panel.ui:200
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:226
+#, fuzzy
+#| msgid "Networks"
+msgid "Visible Networks"
+msgstr "Шабакаҳо"
+
+#: panels/network/cc-wifi-panel.ui:293
+#, fuzzy
+#| msgid "NetworkManager needs to be running."
+msgid "NetworkManager needs to be running"
+msgstr "Мудири шабака бояд иҷро карда шавад"
+
+#: panels/network/connection-editor/8021x-security-page.ui:26
+msgid "802.1x _Security"
+msgstr "_Амнияти 802.1x"
+
+#: panels/network/connection-editor/8021x-security-page.ui:73
+#: panels/network/connection-editor/security-page.ui:72
+msgid "page 1"
+msgstr "саҳифаи 1"
+
+#: panels/network/connection-editor/8021x-security-page.ui:224
+#: panels/network/connection-editor/security-page.ui:223
+#: panels/network/wireless-security/eap-method-fast.ui:50
+#: panels/network/wireless-security/eap-method-peap.ui:48
+#: panels/network/wireless-security/eap-method-ttls.ui:31
+msgid "Anony_mous identity"
+msgstr "Шахсияти _махфӣ"
+
+#: panels/network/connection-editor/8021x-security-page.ui:238
+#: panels/network/connection-editor/security-page.ui:237
+msgid "Inner _authentication"
+msgstr "Санҷиши _ҳаққонияти дохилӣ"
+
+#: panels/network/connection-editor/8021x-security-page.ui:281
+#: panels/network/connection-editor/security-page.ui:280
+msgid "page 2"
+msgstr "саҳифаи 2"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:101
+#: panels/network/connection-editor/ce-page-security.c:445
+#: panels/network/connection-editor/details-page.ui:86
+#: panels/network/network-wifi.ui:239
+msgid "Security"
+msgstr "Амният"
+
+#: panels/network/connection-editor/ce-page.c:481
+msgid "automatic"
+msgstr "худкор"
+
+#: panels/network/connection-editor/ce-page.c:521
+#, c-format
+msgid "Profile %d"
+msgstr "Профили %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:56
+#: panels/network/net-device-wifi.c:123 panels/network/net-device-wifi.c:299
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:60
+#: panels/network/net-device-wifi.c:127 panels/network/net-device-wifi.c:304
+#: panels/network/network-wifi.ui:592
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:64
+#: panels/network/net-device-wifi.c:131
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:69
+#: panels/network/net-device-wifi.c:136
+msgid "Enterprise"
+msgstr "Корхонавӣ"
+
+#: panels/network/connection-editor/ce-page-details.c:74
+#: panels/network/net-device-wifi.c:141 panels/network/net-device-wifi.c:289
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Ҳеҷ"
+
+#: panels/network/connection-editor/ce-page-details.c:95
+msgid "Never"
+msgstr "Ҳеҷ гоҳ"
+
+#: panels/network/connection-editor/ce-page-details.c:110
+#: panels/network/net-device-ethernet.c:137
+#: panels/network/net-device-wifi.c:398
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i day ago"
+msgstr[1] "%i рӯз пеш"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:228
+#: panels/network/net-device-ethernet.c:66 panels/network/net-device-wifi.c:476
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d МБ/с"
+
+#: panels/network/connection-editor/ce-page-details.c:249
+#: panels/network/net-device-wifi.c:505
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Ҳеҷ"
+
+#: panels/network/connection-editor/ce-page-details.c:251
+#: panels/network/net-device-wifi.c:507
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Паст"
+
+#: panels/network/connection-editor/ce-page-details.c:253
+#: panels/network/net-device-wifi.c:509
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Хуб"
+
+#: panels/network/connection-editor/ce-page-details.c:255
+#: panels/network/net-device-wifi.c:511
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Хуб"
+
+#: panels/network/connection-editor/ce-page-details.c:257
+#: panels/network/net-device-wifi.c:513
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Аъло"
+
+#: panels/network/connection-editor/ce-page-details.c:300
+#, fuzzy
+#| msgid "Connection"
+msgid "Forget Connection"
+msgstr "Пайвастшавӣ"
+
+#: panels/network/connection-editor/ce-page-details.c:302
+#, fuzzy
+#| msgid "Connection failed"
+msgid "Remove Connection Profile"
+msgstr "Пайваст қатъ шудааст"
+
+#: panels/network/connection-editor/ce-page-details.c:304
+#, fuzzy
+#| msgid "_Remove"
+msgid "Remove VPN"
+msgstr "_Тоза кардан"
+
+#: panels/network/connection-editor/ce-page-details.c:332
+#: panels/network/network-wifi.ui:1433 shell/cc-panel-list.ui:103
+#: shell/cc-window.c:264
+msgid "Details"
+msgstr "Тафсилот"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:174
+#: panels/network/connection-editor/ce-page-vpn.c:188
+#: panels/network/connection-editor/ce-page-wifi.c:194
+#: panels/network/network-wifi.ui:1437
+msgid "Identity"
+msgstr "Шахсият"
+
+#: panels/network/connection-editor/ce-page-ip4.c:251
+#: panels/network/connection-editor/ce-page-ip6.c:230
+msgid "Delete Address"
+msgstr "Нест кардани суроға"
+
+#: panels/network/connection-editor/ce-page-ip4.c:422
+#: panels/network/connection-editor/ce-page-ip6.c:390
+msgid "Delete Route"
+msgstr "Нест кардани масир"
+
+#: panels/network/connection-editor/ce-page-ip4.c:896
+#: panels/network/network-wifi.ui:1441
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:828
+#: panels/network/network-wifi.ui:1445
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:245
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Ҳеҷ"
+
+#: panels/network/connection-editor/ce-page-security.c:268
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Калиди 40/128-бити WEP (Hex ё ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:278
+msgid "WEP 128-bit Passphrase"
+msgstr "Гузарвожаи WEP 128-бит"
+
+#: panels/network/connection-editor/ce-page-security.c:291
+#: panels/network/wireless-security/wireless-security.c:465
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:304
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP-и динамикӣ (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:318
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Шахсӣ"
+
+#: panels/network/connection-editor/ce-page-security.c:332
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Корхонавӣ"
+
+#: panels/network/connection-editor/details-page.ui:18
+#: panels/network/network-wifi.ui:174
+msgid "Signal Strength"
+msgstr "Тавоноии сигнал"
+
+#: panels/network/connection-editor/details-page.ui:52
+#: panels/network/network-wifi.ui:207
+msgid "Link speed"
+msgstr "Суръати пайванд"
+
+#: panels/network/connection-editor/details-page.ui:104
+#: panels/network/net-device-ethernet.c:170 panels/network/network-wifi.ui:256
+#: panels/network/panel-common.c:644
+msgid "IPv4 Address"
+msgstr "Суроғаи IPv4"
+
+#: panels/network/connection-editor/details-page.ui:122
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-ethernet.c:175
+#: panels/network/network-mobile.ui:189 panels/network/network-wifi.ui:273
+#: panels/network/panel-common.c:645
+msgid "IPv6 Address"
+msgstr "Суроғаи IPv6"
+
+#: panels/network/connection-editor/details-page.ui:140
+#: panels/network/net-device-ethernet.c:178 panels/network/network-wifi.ui:290
+msgid "Hardware Address"
+msgstr "Суроғаи сахтафзор"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:182
+#: panels/network/network-mobile.ui:206 panels/network/network-wifi.ui:307
+msgid "Default Route"
+msgstr "Масири пешфарз"
+
+#: panels/network/connection-editor/details-page.ui:177
+#: panels/network/connection-editor/ip4-page.ui:197
+#: panels/network/connection-editor/ip6-page.ui:211
+#: panels/network/net-device-ethernet.c:184
+#: panels/network/network-mobile.ui:224 panels/network/network-wifi.ui:325
+#: panels/network/network-wifi.ui:831 panels/network/network-wifi.ui:1108
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/details-page.ui:195
+msgid "Last Used"
+msgstr "Истифодашудаи охирин"
+
+#: panels/network/connection-editor/details-page.ui:324
+msgid "Connect _automatically"
+msgstr "_Пайваст шудан ба таври худкор"
+
+#: panels/network/connection-editor/details-page.ui:343
+msgid "Make available to _other users"
+msgstr "Дастрас кардан ба _корбарони дигар"
+
+#: panels/network/connection-editor/details-page.ui:376
+msgid "Restrict background data usage"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:386
+msgid "Appropriate for connections that have data charges or limits."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:16
+#: panels/network/connection-editor/ethernet-page.ui:39
+#: panels/network/connection-editor/ip4-page.ui:209
+#: panels/network/connection-editor/ip4-page.ui:277
+#: panels/network/connection-editor/ip6-page.ui:42
+#: panels/network/connection-editor/ip6-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:291
+#: panels/network/net-proxy.c:58 panels/network/network-proxy.ui:103
+#: panels/network/wireless-security/eap-method-peap.ui:22
+#: panels/privacy/cc-privacy-panel.c:239
+msgid "Automatic"
+msgstr "Худкор"
+
+#: panels/network/connection-editor/ethernet-page.ui:19
+msgid "Twisted Pair (TP)"
+msgstr "Ҷуфти тобдор (TP)"
+
+#: panels/network/connection-editor/ethernet-page.ui:22
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Интерфейси воҳиди замима (AUI)"
+
+#: panels/network/connection-editor/ethernet-page.ui:25
+msgid "BNC"
+msgstr "BNC"
+
+#: panels/network/connection-editor/ethernet-page.ui:28
+msgid "Media Independent Interface (MII)"
+msgstr "Интерфейси мустақили медиа (MII)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+msgid "10 Mb/s"
+msgstr "10 МБ/с"
+
+#: panels/network/connection-editor/ethernet-page.ui:45
+msgid "100 Mb/s"
+msgstr "100 МБ/с"
+
+#: panels/network/connection-editor/ethernet-page.ui:48
+msgid "1 Gb/s"
+msgstr "1 ГБ/с"
+
+#: panels/network/connection-editor/ethernet-page.ui:51
+msgid "10 Gb/s"
+msgstr "10 ГБ/с"
+
+#: panels/network/connection-editor/ethernet-page.ui:71
+#: panels/network/connection-editor/vpn-page.ui:23
+msgid "_Name"
+msgstr "_Ном"
+
+#: panels/network/connection-editor/ethernet-page.ui:100
+#: panels/network/connection-editor/wifi-page.ui:67
+#: panels/network/network-wifi.ui:1260
+msgid "_MAC Address"
+msgstr "Суроғаи _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:146
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:163
+#: panels/network/connection-editor/wifi-page.ui:97
+msgid "_Cloned Address"
+msgstr "_Суроғаи нусхабардошта"
+
+#: panels/network/connection-editor/ethernet-page.ui:178
+msgid "bytes"
+msgstr "байт"
+
+#: panels/network/connection-editor/ip4-page.ui:27
+#, fuzzy
+#| msgid "_Method"
+msgid "IPv_4 Method"
+msgstr "_Усул"
+
+#: panels/network/connection-editor/ip4-page.ui:42
+#: panels/network/network-wifi.ui:777 panels/network/network-wifi.ui:1054
+msgid "Automatic (DHCP)"
+msgstr "Худкор (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:69
+msgid "Link-Local Only"
+msgstr "Танҳо пайванди маҳаллӣ"
+
+#: panels/network/connection-editor/ip4-page.ui:83
+#: panels/network/connection-editor/ip6-page.ui:97
+#, fuzzy
+#| msgid "Disabled"
+msgid "Disable"
+msgstr "Ғайрифаъол"
+
+#: panels/network/connection-editor/ip4-page.ui:111
+#: panels/network/connection-editor/ip6-page.ui:125
+#, fuzzy
+#| msgid "_Addresses"
+msgid "Addresses"
+msgstr "_Суроғаҳо"
+
+#: panels/network/connection-editor/ip4-page.ui:129
+#: panels/network/connection-editor/ip4-page.ui:313
+#: panels/network/connection-editor/ip6-page.ui:143
+#: panels/network/connection-editor/ip6-page.ui:327
+#: panels/printers/details-dialog.ui:89
+msgid "Address"
+msgstr "Суроға"
+
+#: panels/network/connection-editor/ip4-page.ui:143
+#: panels/network/connection-editor/ip4-page.ui:327
+msgid "Netmask"
+msgstr "Маскаи шабака"
+
+#: panels/network/connection-editor/ip4-page.ui:157
+#: panels/network/connection-editor/ip4-page.ui:341
+#: panels/network/connection-editor/ip6-page.ui:171
+#: panels/network/connection-editor/ip6-page.ui:355
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: panels/network/connection-editor/ip4-page.ui:220
+#: panels/network/connection-editor/ip6-page.ui:234
+msgid "Automatic DNS"
+msgstr "DNS-и худкор"
+
+#: panels/network/connection-editor/ip4-page.ui:244
+#: panels/network/connection-editor/ip6-page.ui:258
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:265
+#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/network-wifi.ui:876 panels/network/network-wifi.ui:1153
+msgid "Routes"
+msgstr "Масирҳо"
+
+#: panels/network/connection-editor/ip4-page.ui:288
+#: panels/network/connection-editor/ip6-page.ui:302
+msgid "Automatic Routes"
+msgstr "Масирҳои худкор"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:354
+#: panels/network/connection-editor/ip6-page.ui:368
+#, fuzzy
+#| msgctxt "network parameters"
+#| msgid "Metric"
+msgid "Metric"
+msgstr "Метрӣ"
+
+#: panels/network/connection-editor/ip4-page.ui:384
+#: panels/network/connection-editor/ip6-page.ui:398
+#: panels/network/network-wifi.ui:932 panels/network/network-wifi.ui:1209
+msgid "Use this connection _only for resources on its network"
+msgstr "Истифода бурдани ин пайваст _танҳо барои сарчашмаҳои ин шабака"
+
+#: panels/network/connection-editor/ip6-page.ui:27
+#, fuzzy
+#| msgid "_Method"
+msgid "IPv_6 Method"
+msgstr "_Усул"
+
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Automatic, DHCP only"
+msgstr "Худкорона, танҳо DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:157
+#: panels/network/connection-editor/ip6-page.ui:341
+msgid "Prefix"
+msgstr "Пешванд"
+
+#: panels/network/connection-editor/net-connection-editor.c:261
+msgid "Unable to open connection editor"
+msgstr "Муҳаррири пайвастҳо кушода нашуд"
+
+#: panels/network/connection-editor/net-connection-editor.c:279
+msgid "New Profile"
+msgstr "Профили нав"
+
+#: panels/network/connection-editor/net-connection-editor.c:727
+msgid "Import from file…"
+msgstr "Ворид кардан аз файл…"
+
+#: panels/network/connection-editor/net-connection-editor.c:759
+#, fuzzy
+#| msgid "%s VPN"
+msgid "Add VPN"
+msgstr "VPN-и %s"
+
+#: panels/network/connection-editor/security-page.ui:26
+#: panels/network/network-wifi.ui:529
+msgid "S_ecurity"
+msgstr "_Амният"
+
+#: panels/network/connection-editor/vpn-helpers.c:141
+msgid "Cannot import VPN connection"
+msgstr "Пайвасти VPN ворид намешавад"
+
+#: panels/network/connection-editor/vpn-helpers.c:143
+#, fuzzy, c-format
+#| msgid ""
+#| "The file '%s' could not be read or does not contain recognized VPN "
+#| "connection information\n"
+#| "\n"
+#| "Error: %s."
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Файли \"%s\" наметавонад хонда шавад, ё ки маълумоти муайяншудаи пайвасти "
+"VPN-ро надорад\n"
+"\n"
+"Хатогӣ: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:178
+msgid "Select file to import"
+msgstr "Интихоби файл барои воридот"
+
+#: panels/network/connection-editor/vpn-helpers.c:182
+#: panels/printers/pp-details-dialog.c:314
+#: panels/sharing/cc-sharing-panel.c:428
+#: panels/user-accounts/cc-avatar-chooser.c:235
+msgid "_Open"
+msgstr "_Кушодан"
+
+#: panels/network/connection-editor/vpn-helpers.c:230
+#, fuzzy, c-format
+#| msgid "A file named \"%s\" already exists."
+msgid "A file named “%s” already exists."
+msgstr "Номи файли \"%s\" аллакай мавҷуд аст."
+
+#: panels/network/connection-editor/vpn-helpers.c:232
+msgid "_Replace"
+msgstr "Ҷойгузин _кардан"
+
+#: panels/network/connection-editor/vpn-helpers.c:234
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Шумо мехоҳед, ки %s-ро бо пайвасти VPN-и захирашуда ҷойгузин кунед?"
+
+#: panels/network/connection-editor/vpn-helpers.c:270
+msgid "Cannot export VPN connection"
+msgstr "Пайвасти VPN содир намешавад"
+
+#: panels/network/connection-editor/vpn-helpers.c:272
+#, fuzzy, c-format
+#| msgid ""
+#| "The VPN connection '%s' could not be exported to %s.\n"
+#| "\n"
+#| "Error: %s."
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Пайвасти VPN-и \"%s\" ба %s содир карда нашуд.\n"
+"\n"
+"Хатогӣ: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:307
+msgid "Export VPN connection"
+msgstr "Содир кардани пайвасти VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:58
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Хато: муҳаррири пайвасти VPN кушода нашуд)"
+
+#: panels/network/connection-editor/wifi-page.ui:20
+#: panels/network/network-wifi.ui:497
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:36
+#: panels/network/network-wifi.ui:513
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Идора кунед, ки шумо чӣ тавр ба Интернет пайваст мешавед"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
+#| "vpn;vlan;bridge;bond;DNS;"
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;"
+msgstr ""
+"Шабака;Бесим;Wi-Fi;Wifi;IP;LAN;Прокси;WAN;Пайвасти паҳннавор;Модем;Bluetooth;"
+"vpn;vlan;bridge;bond;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+#| msgid "Control how you connect to the Internet"
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Идора кунед, ки шумо чӣ тавр ба Интернет пайваст мешавед"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
+#| "vpn;vlan;bridge;bond;DNS;"
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;"
+msgstr ""
+"Шабака;Бесим;Wi-Fi;Wifi;IP;LAN;Прокси;WAN;Пайвасти паҳннавор;Модем;Bluetooth;"
+"vpn;vlan;bridge;bond;DNS;"
+
+#: panels/network/net-device-ethernet.c:123
+#: panels/network/net-device-wifi.c:384
+msgid "never"
+msgstr "ҳеҷ гоҳ"
+
+#: panels/network/net-device-ethernet.c:133
+#: panels/network/net-device-wifi.c:394
+msgid "today"
+msgstr "имрӯз"
+
+#: panels/network/net-device-ethernet.c:135
+#: panels/network/net-device-wifi.c:396
+msgid "yesterday"
+msgstr "дирӯз"
+
+#: panels/network/net-device-ethernet.c:173
+#: panels/network/network-mobile.ui:172 panels/network/panel-common.c:647
+#: panels/network/panel-common.c:649
+msgid "IP Address"
+msgstr "Суроғаи IP"
+
+#: panels/network/net-device-ethernet.c:189 panels/network/network-wifi.ui:342
+msgid "Last used"
+msgstr "Истифодашудаи охирин"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:291
+#: panels/network/network-ethernet.ui:19 panels/network/network-simple.ui:39
+msgid "Wired"
+msgstr "Симӣ"
+
+#: panels/network/net-device-mobile.c:236
+msgid "Add new connection"
+msgstr "Илова кардани пайвасти нав"
+
+#: panels/network/net-device-wifi.c:1157
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr ""
+"Гузариш ба хот-споти бесим пайвасти шуморо аз <b>%s</b> қатъ мегардонад."
+
+#: panels/network/net-device-wifi.c:1161
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr ""
+"Ҳангоми фаъол будани хот-спот шумо наметавонед тавассути пайвасти бесими худ "
+"ба Интернет пайваст шавед."
+
+#: panels/network/net-device-wifi.c:1168
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Нуқтаи дастрасии Wi-Fi-ро фаъол мекунед?"
+
+#: panels/network/net-device-wifi.c:1190
+msgid ""
+"Wi-Fi hotspots are usually used to share an additional Internet connection "
+"over Wi-Fi."
+msgstr ""
+
+#: panels/network/net-device-wifi.c:1201
+msgid "_Turn On"
+msgstr "_Хомӯш кардан"
+
+#: panels/network/net-device-wifi.c:1278
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Пайвасти \"ХОТ-СПОТ\" ва ҳамаи корбаронро қатъ мекунед?"
+
+#: panels/network/net-device-wifi.c:1281
+msgid "_Stop Hotspot"
+msgstr "_Қатъ кардани \"ХОТ-СПОТ\""
+
+#: panels/network/net-device-wifi.c:1337
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Сиёсати низом истифодаи минтақаи дастрасиро манъ мекунад"
+
+#: panels/network/net-device-wifi.c:1340
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Дастгоҳи бесим ҳолати \"ХОТ-СПОТ\"-ро дастгирӣ намекунад"
+
+#: panels/network/net-device-wifi.c:1471
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Тафсилоти шабака барои шабакаҳои интихобшуда, аз он ҷумла ниҳонвожаҳо ва "
+"ягон конфигуратсияи фармоишӣ, гум карда мешавад."
+
+#: panels/network/net-device-wifi.c:1475 panels/network/network-wifi.ui:1350
+msgid "_Forget"
+msgstr "_Фаромӯш кардан"
+
+#: panels/network/net-device-wifi.c:1638 panels/network/net-device-wifi.c:1645
+msgid "Known Wi-Fi Networks"
+msgstr ""
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1682
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "__Фаромӯш кардан"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:102
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Ҳангоми пешҳниҳод нашудани суроғаи URL-и конфигуратсия ташхиси худкори "
+"проксии веб истифода мешавад."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:110
+msgid "This is not recommended for untrusted public networks."
+msgstr "Ин барои шабакаҳои беэътимоди оммавӣ тавсия намешавад."
+
+#: panels/network/network-mobile.ui:30
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:48
+msgid "Provider"
+msgstr "Провайдер"
+
+#: panels/network/network-proxy.ui:47 panels/network/network-proxy.ui:92
+#, fuzzy
+#| msgid "Network proxy"
+msgid "Network Proxy"
+msgstr "Прокси шабака"
+
+#: panels/network/network-proxy.ui:173
+msgid "_HTTP Proxy"
+msgstr "Прокси _HTTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "H_TTPS Proxy"
+msgstr "Прокси H_TTPS"
+
+#: panels/network/network-proxy.ui:211
+msgid "_FTP Proxy"
+msgstr "Прокси _FTP"
+
+#: panels/network/network-proxy.ui:230
+msgid "_Socks Host"
+msgstr "_Мизбони socks"
+
+#: panels/network/network-proxy.ui:249
+msgid "_Ignore Hosts"
+msgstr "_Нодида гирифтани мизбонҳо"
+
+#: panels/network/network-proxy.ui:287
+msgid "HTTP proxy port"
+msgstr "Порти прокси HTTP"
+
+#: panels/network/network-proxy.ui:364
+msgid "HTTPS proxy port"
+msgstr "Порти прокси HTTPS"
+
+#: panels/network/network-proxy.ui:385
+msgid "FTP proxy port"
+msgstr "Порти прокси FTP"
+
+#: panels/network/network-proxy.ui:406
+msgid "Socks proxy port"
+msgstr "Порти проксии socks"
+
+#: panels/network/network-proxy.ui:435
+msgid "_Configuration URL"
+msgstr "_Танзимоти суроғаи URL"
+
+#: panels/network/network-simple.ui:50
+msgid "Turn device off"
+msgstr "Хомӯш кардани дастгоҳ"
+
+#: panels/network/network-vpn.ui:56
+msgid "Turn VPN connection off"
+msgstr "Хомӯш кардани пайвасти VPN"
+
+#: panels/network/network-wifi.ui:127
+msgid "Automatic _Connect"
+msgstr "Паёвасти _худкор"
+
+#: panels/network/network-wifi.ui:474
+msgid "details"
+msgstr "тафсилот"
+
+#: panels/network/network-wifi.ui:545
+#: panels/network/wireless-security/eap-method-leap.ui:40
+#: panels/network/wireless-security/eap-method-simple.ui:40
+#: panels/network/wireless-security/ws-leap.ui:40
+#: panels/network/wireless-security/ws-wpa-psk.ui:22
+#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/user-accounts/cc-add-user-dialog.ui:310
+#: panels/user-accounts/cc-add-user-dialog.ui:547
+#: panels/user-accounts/cc-user-panel.ui:214
+msgid "_Password"
+msgstr "_Ниҳонвожа"
+
+#: panels/network/network-wifi.ui:621
+msgid "Show P_assword"
+msgstr "Намоиш додани п_арол"
+
+#: panels/network/network-wifi.ui:651
+msgid "Make available to other users"
+msgstr "Дастрас кардан ба корбарони дигар"
+
+#: panels/network/network-wifi.ui:679
+msgid "identity"
+msgstr "шахсият"
+
+#: panels/network/network-wifi.ui:713
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: panels/network/network-wifi.ui:754 panels/network/network-wifi.ui:1031
+msgid "_Addresses"
+msgstr "_Суроғаҳо"
+
+#: panels/network/network-wifi.ui:778 panels/network/network-wifi.ui:1055
+msgid "Automatic (DHCP) addresses only"
+msgstr "Танҳо суроғаҳои худкор (DHCP)"
+
+#: panels/network/network-wifi.ui:779 panels/network/network-wifi.ui:1056
+msgid "Link-local only"
+msgstr "Танҳо пайванди маҳаллӣ"
+
+#: panels/network/network-wifi.ui:780 panels/network/network-wifi.ui:1057
+msgid "Shared with other computers"
+msgstr "Бо компютери дигар мубодилашуда"
+
+#: panels/network/network-wifi.ui:916 panels/network/network-wifi.ui:1193
+msgid "_Ignore automatically obtained routes"
+msgstr "_Нодида гирифтани масирҳои ба таври худкор бадастовардашуда"
+
+#: panels/network/network-wifi.ui:959
+msgid "ipv4"
+msgstr "ipv4"
+
+#: panels/network/network-wifi.ui:990
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: panels/network/network-wifi.ui:1236
+msgid "ipv6"
+msgstr "ipv6"
+
+#: panels/network/network-wifi.ui:1276
+msgid "_Cloned MAC Address"
+msgstr "С_уроғаи MAC-и нусхабардошта"
+
+#: panels/network/network-wifi.ui:1334
+msgid "_Reset"
+msgstr "_Бозсозӣ"
+
+#: panels/network/network-wifi.ui:1370
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr ""
+"Танзими дубораи танзимоти ин пайваст ба пешфарзҳои онҳо, аммо дар ёд доштан "
+"ҳамчун пайвасти пазируфта."
+
+#: panels/network/network-wifi.ui:1387
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr ""
+"Тоза кардани ҳамаи тафсилоти ин шабака ва пайваст нашудани худкор ба он."
+
+#: panels/network/network-wifi.ui:1449
+msgid "Hardware"
+msgstr "Сахтафзор"
+
+#: panels/network/network-wifi.ui:1453
+#, fuzzy
+#| msgid "Reset"
+msgctxt "tab"
+msgid "Reset"
+msgstr "Бозсозӣ"
+
+#: panels/network/network-wifi.ui:1505
+msgid "Wi-Fi Hotspot"
+msgstr "Нуқтаи дастрасии Wi-Fi"
+
+#: panels/network/network-wifi.ui:1523
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Барои пайваст шудан ба шабакаи Wi-Fi, ҷодо сзед"
+
+#: panels/network/network-wifi.ui:1572
+msgid "Network Name"
+msgstr "Номи шабака"
+
+#: panels/network/network-wifi.ui:1590
+msgid "Connected Devices"
+msgstr "Дастгоҳҳои пайвастшуда"
+
+#: panels/network/network-wifi.ui:1608
+msgid "Security type"
+msgstr "Навъи амният"
+
+#: panels/network/network-wifi.ui:1671
+#, fuzzy
+#| msgid "Password"
+msgctxt "Wi-Fi passkey"
+msgid "Password"
+msgstr "Ниҳонвожа"
+
+#: panels/network/network-wifi.ui:1768
+msgid "Turn Wi-Fi off"
+msgstr "Хомӯш кардани пайвасти Wi-Fi"
+
+#: panels/network/network-wifi.ui:1800
+msgid "_Connect to Hidden Network…"
+msgstr "_Пайваст шудан ба шабакаи пинҳоншуда…"
+
+#: panels/network/network-wifi.ui:1810
+#| msgid "Wi-Fi Hotspot"
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Фаъол кардани нуқтаи дастрасии Wi-Fi…"
+
+#: panels/network/network-wifi.ui:1820
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:127
+msgid "Ad-hoc"
+msgstr "Махсус"
+
+#. TRANSLATORS: AP type
+#: panels/network/panel-common.c:131
+msgid "Infrastructure"
+msgstr "Инфрасохтор"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:147 panels/network/panel-common.c:201
+msgid "Status unknown"
+msgstr "Вазъияти номаълум"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:151
+msgid "Unmanaged"
+msgstr "Идоранушуда"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:155
+msgid "Unavailable"
+msgstr "Дастнорас"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:165 panels/network/panel-common.c:207
+msgid "Connecting"
+msgstr "Пайваст шуда истодааст"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:169 panels/network/panel-common.c:211
+msgid "Authentication required"
+msgstr "Санҷиши ҳаққоният лозим аст"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:173 panels/network/panel-common.c:215
+msgid "Connected"
+msgstr "Пайвастшуда"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:177
+msgid "Disconnecting"
+msgstr "Пайваст қатъ шуда истодааст"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:181 panels/network/panel-common.c:219
+msgid "Connection failed"
+msgstr "Пайваст қатъ шудааст"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:185 panels/network/panel-common.c:227
+msgid "Status unknown (missing)"
+msgstr "Вазъияти номаълум (намерасидагӣ)"
+
+#. TRANSLATORS: VPN status
+#: panels/network/panel-common.c:223
+msgid "Not connected"
+msgstr "Пайваст нашудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "Configuration failed"
+msgstr "Танзимот қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252
+msgid "IP configuration failed"
+msgstr "Танзимоти IP қатъ шуд"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "IP configuration expired"
+msgstr "Танзимоти IP аз мӯҳлаташ гузашт"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:260
+msgid "Secrets were required, but not provided"
+msgstr "Сирҳо лозим мебошанд, аммо пешниҳод нашуданд"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:264
+msgid "802.1x supplicant disconnected"
+msgstr "Пайвасти дархосткунандаи 802.1x қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:268
+msgid "802.1x supplicant configuration failed"
+msgstr "Конфигуратсияи дархосткунандаи 802.1x қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:272
+msgid "802.1x supplicant failed"
+msgstr "Дархосткунандаи 802.1x қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:276
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Дархосткунандаи 802.1x барои санҷиши ҳаққоният вақти зиёдро гирифт"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:280
+msgid "PPP service failed to start"
+msgstr "Оғози хидмати PPP қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:284
+msgid "PPP service disconnected"
+msgstr "Пайвасти хидмати PPP қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:288
+msgid "PPP failed"
+msgstr "PPP қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:292
+msgid "DHCP client failed to start"
+msgstr "Оғози муштарии DHCP бо нокомӣ дучор шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:296
+msgid "DHCP client error"
+msgstr "Хатогии муштарии DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:300
+msgid "DHCP client failed"
+msgstr "Муштарии DHCP бо нокомӣ дучор шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:304
+msgid "Shared connection service failed to start"
+msgstr "Оғози хидмати пайвасти мубодилашуда қатъ шуд"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:308
+msgid "Shared connection service failed"
+msgstr "Хидмати пайвасти мубодилашуда қатъ шуд"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:312
+msgid "AutoIP service failed to start"
+msgstr "Оғози хидмати AutoIP қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:316
+msgid "AutoIP service error"
+msgstr "Хатои хидмати AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:320
+msgid "AutoIP service failed"
+msgstr "Хидмати AutoIP қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:324
+msgid "Line busy"
+msgstr "Хат машғул аст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:328
+msgid "No dial tone"
+msgstr "Бе оҳанги занг"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:332
+msgid "No carrier could be established"
+msgstr "Ягон ҳомил пайваст нашудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:336
+msgid "Dialing request timed out"
+msgstr "Вақти шуморагирӣ ба анҷом расид"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:340
+msgid "Dialing attempt failed"
+msgstr "Шуморагирӣ қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:344
+msgid "Modem initialization failed"
+msgstr "Оғоздиҳии модем ба анҷом нарасид"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:348
+msgid "Failed to select the specified APN"
+msgstr "Интихоби APN-и муайяншуда қатъ шуд"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:352
+msgid "Not searching for networks"
+msgstr "Шабакаҳоро ҷустуҷӯ намекунад"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:356
+msgid "Network registration denied"
+msgstr "Қайдкунии шабака қатъ шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:360
+msgid "Network registration timed out"
+msgstr "Вақти қайдкунии шабака ба анҷом расид"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:364
+msgid "Failed to register with the requested network"
+msgstr "Қайдкунӣ бо шабакаи дархостшуда қатъ шуд"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:368
+msgid "PIN check failed"
+msgstr "Санҷиши PIN қатъ шуд"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:372
+msgid "Firmware for the device may be missing"
+msgstr "Эҳтимол аст, ки дастгоҳ нармафзори дарунсохт надорад"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:376
+msgid "Connection disappeared"
+msgstr "Пайваст гум шудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:380
+msgid "Existing connection was assumed"
+msgstr "Пайвасти мавҷудбуда мунтазир буд"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:384
+msgid "Modem not found"
+msgstr "Модем ёфт нашуд"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:388
+msgid "Bluetooth connection failed"
+msgstr "Пайвастшавии Bluetooth ба анҷом нарасид"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:392
+msgid "SIM Card not inserted"
+msgstr "Корти SIM ворид нашудааст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:396
+msgid "SIM Pin required"
+msgstr "SIM Pin лозим аст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:400
+msgid "SIM Puk required"
+msgstr "SIM Puk лозим аст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:404
+msgid "SIM wrong"
+msgstr "SIM нодуруст аст"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:408
+msgid "Connection dependency failed"
+msgstr "Вобастагии пайваст қатъ шуд"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:433
+msgid "Firmware missing"
+msgstr "Нармафзори дарунсохт вуҷуд надорад"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:437
+msgid "Cable unplugged"
+msgstr "Сим ҷудо шудааст"
+
+#: panels/network/wireless-security/eap-method.c:69
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:245
+msgid "no file selected"
+msgstr "ягон файл интихоб нашуд"
+
+#: panels/network/wireless-security/eap-method.c:276
+msgid "unspecified error validating eap-method file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method.c:451
+#, fuzzy
+#| msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "Калидҳои шахсии DER, PEM, ё PKCS#12 (*.der, *.pem, *.p12)"
+
+#: panels/network/wireless-security/eap-method.c:454
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "Гувоҳиномаҳои DER ё PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:72
+msgid "missing EAP-FAST PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.c:268
+#: panels/network/wireless-security/eap-method-peap.c:302
+#: panels/network/wireless-security/eap-method-ttls.c:351
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.c:283
+#: panels/network/wireless-security/eap-method-peap.c:272
+#: panels/network/wireless-security/eap-method-ttls.c:289
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.c:406
+msgid "Choose a PAC file"
+msgstr "Интихоб кардани файли PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:413
+msgid "PAC files (*.pac)"
+msgstr "Файли PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:22
+msgid "Anonymous"
+msgstr "Ношинос"
+
+#: panels/network/wireless-security/eap-method-fast.ui:25
+msgid "Authenticated"
+msgstr "Ҳаққоният санҷида шуд"
+
+#: panels/network/wireless-security/eap-method-fast.ui:28
+msgid "Both"
+msgstr "Ҳар ду"
+
+#: panels/network/wireless-security/eap-method-fast.ui:76
+msgid "PAC _file"
+msgstr "Файли _PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:122
+#: panels/network/wireless-security/eap-method-peap.ui:146
+#: panels/network/wireless-security/eap-method-ttls.ui:97
+msgid "_Inner authentication"
+msgstr "_Санҷиши ҳаққонияти дохилӣ"
+
+#: panels/network/wireless-security/eap-method-fast.ui:156
+#, fuzzy
+#| msgid "PAC pro_visioning"
+msgid "Allow automatic PAC pro_visioning"
+msgstr "_Таъминоти PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.c:74
+msgid "missing EAP-LEAP password"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:26
+#: panels/network/wireless-security/eap-method-simple.ui:26
+#: panels/network/wireless-security/ws-leap.ui:26
+#: panels/user-accounts/cc-add-user-dialog.ui:146
+#: panels/user-accounts/cc-add-user-dialog.ui:527
+msgid "_Username"
+msgstr "_Номи корбар"
+
+#: panels/network/wireless-security/eap-method-leap.ui:68
+#: panels/network/wireless-security/eap-method-simple.ui:85
+#: panels/network/wireless-security/eap-method-tls.ui:164
+#: panels/network/wireless-security/ws-leap.ui:68
+#: panels/network/wireless-security/ws-wpa-psk.ui:76
+msgid "Sho_w password"
+msgstr "_Намоиш додани ниҳонвожа"
+
+#: panels/network/wireless-security/eap-method-peap.c:63
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:68
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.c:287
+#: panels/network/wireless-security/eap-method-ttls.c:336
+#: panels/network/wireless-security/wireless-security.c:441
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.c:381
+#: panels/network/wireless-security/eap-method-tls.c:492
+#: panels/network/wireless-security/eap-method-ttls.c:430
+msgid "Choose a Certificate Authority certificate"
+msgstr "Интихоб кардани гувоҳиномаи мақомоти гувоҳиномаҳо"
+
+#: panels/network/wireless-security/eap-method-peap.ui:25
+msgid "Version 0"
+msgstr "Версияи 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:28
+msgid "Version 1"
+msgstr "Версияи 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:74
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:57
+msgid "C_A certificate"
+msgstr "Гувоҳиномаи C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:96
+#: panels/network/wireless-security/eap-method-tls.ui:97
+#: panels/network/wireless-security/eap-method-ttls.ui:79
+#, fuzzy
+#| msgid "Authentication required"
+msgid "No CA certificate is _required"
+msgstr "Санҷиши ҳаққоният лозим аст"
+
+#: panels/network/wireless-security/eap-method-peap.ui:114
+msgid "PEAP _version"
+msgstr "_Версияи PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:74
+msgid "missing EAP username"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-simple.c:87
+msgid "missing EAP password"
+msgstr "ниҳонвожаи EAP ворид нашуд"
+
+#: panels/network/wireless-security/eap-method-tls.c:68
+msgid "missing EAP-TLS identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:77
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:84
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:100
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:110
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.c:307
+msgid "Unencrypted private keys are insecure"
+msgstr "Калидҳои махфии берамз хатарнок мебошанд"
+
+#: panels/network/wireless-security/eap-method-tls.c:310
+#, fuzzy
+#| msgid ""
+#| "The selected private key does not appear to be protected by a password.  "
+#| "This could allow your security credentials to be compromised.  Please "
+#| "select a password-protected private key.\n"
+#| "\n"
+#| "(You can password-protect your private key with openssl)"
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Калиди махфии интихобшуда бо ниҳонвожа ҳифз нашудааст.  Ин метавонад сабаби "
+"бадном кардани маълумоти корбари амниятии шумо гардад.  Лутфан, калиди "
+"махфии бо ниҳонвожа ҳифзшударо интихоб кунед.\n"
+"\n"
+"(Шумо метавонед калиди махфии худро тавассути openssl бо ниҳонвожа муҳофизат "
+"кунед)"
+
+#: panels/network/wireless-security/eap-method-tls.c:486
+msgid "Choose your personal certificate"
+msgstr "Интихоб кардани гувоҳиномаи шахсӣ"
+
+#: panels/network/wireless-security/eap-method-tls.c:498
+msgid "Choose your private key"
+msgstr "Интихоб кардани калиди шахсӣ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:24
+msgid "I_dentity"
+msgstr "Ш_ахсият"
+
+#: panels/network/wireless-security/eap-method-tls.ui:50
+msgid "_User certificate"
+msgstr "_Гувоҳиномаи корбар"
+
+#: panels/network/wireless-security/eap-method-tls.ui:115
+msgid "Private _key"
+msgstr "_Калиди шахсӣ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:140
+msgid "_Private key password"
+msgstr "_Ниҳонвожаи калиди шахсӣ"
+
+#: panels/network/wireless-security/eap-method-ttls.c:63
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:68
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.c:259
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.c:274
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.c:305
+#, fuzzy
+#| msgid "MSCHAPv2"
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.c:321
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/wireless-security.c:87
+msgid "Unknown error validating 802.1X security"
+msgstr ""
+
+#: panels/network/wireless-security/wireless-security.c:453
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/wireless-security.c:477
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/wireless-security.c:488
+msgid "FAST"
+msgstr "ТЕЗ"
+
+#: panels/network/wireless-security/wireless-security.c:499
+msgid "Tunneled TLS"
+msgstr "TLS-и нақбӣ"
+
+#: panels/network/wireless-security/wireless-security.c:510
+msgid "Protected EAP (PEAP)"
+msgstr "EAP-и муҳофизатшуда (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:39
+#: panels/network/wireless-security/ws-wep-key.ui:115
+#: panels/network/wireless-security/ws-wpa-eap.ui:33
+msgid "Au_thentication"
+msgstr "_Санҷиши ҳаққоният"
+
+#: panels/network/wireless-security/ws-leap.c:63
+msgid "missing leap-username"
+msgstr ""
+
+#: panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr "ниҳонвожаи мамониат ворид нашуд"
+
+#: panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Пешфарз)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Системаи кушода"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Калиди мубодилашуда"
+
+#: panels/network/wireless-security/ws-wep-key.ui:56
+msgid "_Key"
+msgstr "_Тугма"
+
+#: panels/network/wireless-security/ws-wep-key.ui:94
+msgid "Sho_w key"
+msgstr "Намоиш додани _калид"
+
+#: panels/network/wireless-security/ws-wep-key.ui:152
+msgid "WEP inde_x"
+msgstr "_Индекси WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wpa-psk.ui:50
+msgid "_Type"
+msgstr "_Навъ"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:61
+#, fuzzy
+#| msgctxt "notifications"
+#| msgid "Notifications"
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Огоҳиҳо"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:113
+#, fuzzy
+#| msgctxt "notifications"
+#| msgid "Sound Alerts"
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Огоҳиҳои овоздор"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:169
+#, fuzzy
+#| msgctxt "notifications"
+#| msgid "Notifications"
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Огоҳиҳо"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:185
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:250
+#, fuzzy
+#| msgctxt "notifications"
+#| msgid "Show Message Content in Banners"
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Намоиш додани муҳтаво дар баннерҳо"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:301
+#, fuzzy
+#| msgctxt "notifications"
+#| msgid "Lock Screen Notifications"
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Огоҳиҳои экрани қулф"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:352
+#, fuzzy
+#| msgctxt "notifications"
+#| msgid "Show Message Content on Lock Screen"
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Намоиш додани муҳтаво дар экрани қулф"
+
+#: panels/notifications/cc-notifications-panel.ui:70
+#, fuzzy
+#| msgid "Notifications"
+msgid "Notification _Popups"
+msgstr "Огоҳиҳо"
+
+#: panels/notifications/cc-notifications-panel.ui:121
+#, fuzzy
+#| msgid "Lock Screen Notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Огоҳиҳои экрани қулф"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+"Идора кунед, ки кадом огоҳиҳо намоиш дода мешаванд ва чиро намоиш медиҳанд"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Огоҳиҳо;Баннер;Паём;Қуттӣ;Зоҳиршаванда;"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:150
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Дигар"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/cc-online-accounts-panel.c:626
+#, fuzzy, c-format
+#| msgid "My Account"
+msgid "%s Account"
+msgstr "Ҳисоби ман"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:923
+msgid "Error removing account"
+msgstr "Ҳангоми тозакунии ҳисоб хатогӣ ба вуҷуд омад"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:988
+#, c-format
+msgid "<b>%s</b> removed"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Ҳисобҳои онлайн"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Ба ҳисобҳои онлайни худ пайваст шавед ва интихоб кунед, ки онҳоро барои чӣ "
+"истифода мебаред"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Онлайн;Чат;Тақвим;Почта;Тамос;ownCloud;"
+"Kerberos;IMAP;SMTP;Баста;Баъдтар;"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/online-accounts.ui:38 panels/printers/printers.ui:71
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/online-accounts.ui:96
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/online-accounts.ui:111
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/online-accounts.ui:136
+#, fuzzy
+#| msgid "Add account"
+msgid "Add an account"
+msgstr "Илова кардани ҳисоб"
+
+#: panels/online-accounts/online-accounts.ui:243
+msgid "Remove Account"
+msgstr "Тоза кардани ҳисоб"
+
+#: panels/power/cc-power-panel.c:318
+msgid "Unknown time"
+msgstr "Вақти номаълум"
+
+#: panels/power/cc-power-panel.c:324
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i дақиқа"
+msgstr[1] "%i дақиқа"
+
+#: panels/power/cc-power-panel.c:336
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i соат"
+msgstr[1] "%i соат"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-power-panel.c:344
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-power-panel.c:345
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "соат"
+msgstr[1] "соат"
+
+#: panels/power/cc-power-panel.c:346
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "дақиқа"
+msgstr[1] "дақиқа"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:364
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s то анҷоми пуркунии батарея"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:371
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Диққат: %s боқимонда"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-power-panel.c:376
+#, c-format
+msgid "%s remaining"
+msgstr "%s боқимонда"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:381 panels/power/cc-power-panel.c:411
+msgid "Fully charged"
+msgstr "Комилан пур аст"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:385 panels/power/cc-power-panel.c:415
+#, fuzzy
+#| msgid "Charging"
+msgid "Not charging"
+msgstr "Пуркунии барқ"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:389 panels/power/cc-power-panel.c:419
+msgid "Empty"
+msgstr "Холӣ кардан"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:402
+msgid "Charging"
+msgstr "Пуркунии барқ"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:407
+msgid "Discharging"
+msgstr "Тамомшавии барқ"
+
+#: panels/power/cc-power-panel.c:540
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Асосӣ"
+
+#: panels/power/cc-power-panel.c:542
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Иловагӣ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:611
+msgid "Wireless mouse"
+msgstr "Муши бесим"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:614
+msgid "Wireless keyboard"
+msgstr "Клавиатураи бесим"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:617
+msgid "Uninterruptible power supply"
+msgstr "Таъминоти қатънашавандаи барқ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:620
+msgid "Personal digital assistant"
+msgstr "Ёрдамчии рақамии шахсӣ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:623
+msgid "Cellphone"
+msgstr "Телефони мобилӣ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:626
+msgid "Media player"
+msgstr "Плеери мултимедиа"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:629 panels/wacom/cc-wacom-panel.c:848
+msgid "Tablet"
+msgstr "Планшет"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:632
+msgid "Computer"
+msgstr "Компютер"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:635
+msgid "Gaming input device"
+msgstr ""
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-power-panel.c:638 panels/power/cc-power-panel.c:891
+#: panels/power/cc-power-panel.c:2406
+msgid "Battery"
+msgstr "Батарея"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:699
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "Пуркунии барқ"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:706
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "Диққат"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:711
+msgctxt "Battery power"
+msgid "Low"
+msgstr "Паст"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-power-panel.c:716
+msgctxt "Battery power"
+msgid "Good"
+msgstr "Хуб"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:721
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "Комилан пур аст"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-power-panel.c:725
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "Холӣ"
+
+#: panels/power/cc-power-panel.c:889
+msgid "Batteries"
+msgstr "Батареяҳо"
+
+#: panels/power/cc-power-panel.c:1250
+#, fuzzy, c-format
+#| msgid "%i hour"
+#| msgid_plural "%i hours"
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%i соат"
+msgstr[1] "%i соат"
+
+#: panels/power/cc-power-panel.c:1252
+#, fuzzy, c-format
+#| msgid "%i minute"
+#| msgid_plural "%i minutes"
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%i дақиқа"
+msgstr[1] "%i дақиқа"
+
+#: panels/power/cc-power-panel.c:1255
+#, fuzzy, c-format
+#| msgid "30 seconds"
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "30 сония"
+msgstr[1] "30 сония"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/power/cc-power-panel.c:1260
+#, fuzzy, c-format
+#| msgid "%i %s %i %s"
+msgctxt "time"
+msgid "%s %s %s"
+msgstr "%i %s %i %s"
+
+#. 2 minutes 12 seconds
+#: panels/power/cc-power-panel.c:1263
+#, fuzzy, c-format
+#| msgid "%i %s %i %s"
+msgctxt "time"
+msgid "%s %s"
+msgstr "%i %s %i %s"
+
+#. 0 seconds
+#: panels/power/cc-power-panel.c:1269
+#, fuzzy
+#| msgid "30 seconds"
+msgid "0 seconds"
+msgstr "30 сония"
+
+#: panels/power/cc-power-panel.c:1366
+msgid "When _idle"
+msgstr "Вақте ки беҳаракат аст"
+
+#: panels/power/cc-power-panel.c:1811
+msgid "Power Saving"
+msgstr "Захиракунии барқ"
+
+#: panels/power/cc-power-panel.c:1845
+msgid "_Screen brightness"
+msgstr "_Равшании экран"
+
+#: panels/power/cc-power-panel.c:1866
+msgid "Automatic brightness"
+msgstr "Дурахшонии худкор"
+
+#: panels/power/cc-power-panel.c:1879
+msgid "_Keyboard brightness"
+msgstr "_Дурахшонии экран"
+
+#: panels/power/cc-power-panel.c:1890
+msgid "_Dim screen when inactive"
+msgstr "_Камнур кардани экран дар ҳолати ғайрифаъол"
+
+#: panels/power/cc-power-panel.c:1908
+msgid "_Blank screen"
+msgstr "_Экрани холӣ"
+
+#: panels/power/cc-power-panel.c:1931
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: panels/power/cc-power-panel.c:1932
+msgid "Wi-Fi can be turned off to save power."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:1948
+msgid "_Mobile broadband"
+msgstr "_Паҳннавори мобилӣ"
+
+#: panels/power/cc-power-panel.c:1949
+#, fuzzy
+#| msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
+msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+msgstr ""
+"Дастгоҳҳои паҳннавори мобилӣ (3G, 4G, WiMax ва ғайра) барқи иловагиро талаб "
+"мекунад"
+
+#: panels/power/cc-power-panel.c:1999
+msgid "_Bluetooth"
+msgstr "_Bluetooth"
+
+#: panels/power/cc-power-panel.c:2000
+msgid "Bluetooth can be turned off to save power."
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2052
+msgid "When on battery power"
+msgstr "Вақте ки аз батарея кор мекунад"
+
+#: panels/power/cc-power-panel.c:2054
+msgid "When plugged in"
+msgstr "Вақте ки аз манбаъ барқ кор мекунад"
+
+#: panels/power/cc-power-panel.c:2148
+msgid "Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.c:2149
+msgid "Power Off"
+msgstr "Анҷоми кор"
+
+#: panels/power/cc-power-panel.c:2150
+msgid "Hibernate"
+msgstr "Гибернатсия"
+
+#: panels/power/cc-power-panel.c:2151
+#, fuzzy
+#| msgid "Do nothing"
+msgid "Nothing"
+msgstr "Амалиёт лозим нест"
+
+#. Frame header
+#: panels/power/cc-power-panel.c:2251
+#, fuzzy
+#| msgid "Suspend & Power Off"
+msgid "Suspend & Power Button"
+msgstr "Таваққуф ва анҷоми кор"
+
+#: panels/power/cc-power-panel.c:2292
+msgid "_Automatic suspend"
+msgstr "_Таваққуфи худкор"
+
+#: panels/power/cc-power-panel.c:2293
+#, fuzzy
+#| msgid "_Automatic suspend"
+msgid "Automatic suspend"
+msgstr "_Таваққуфи худкор"
+
+#: panels/power/cc-power-panel.c:2350
+msgid "_When the Power Button is pressed"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:13
+#, fuzzy
+#| msgid "15 minutes"
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:17
+#, fuzzy
+#| msgid "2 minutes"
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:21
+#, fuzzy
+#| msgid "5 minutes"
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:25
+#, fuzzy
+#| msgid "30 minutes"
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:29
+#, fuzzy
+#| msgid "45 minutes"
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:33
+#, fuzzy
+#| msgid "1 hour"
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 соат"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:37
+#, fuzzy
+#| msgid "80 minutes"
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:41
+#, fuzzy
+#| msgid "90 minutes"
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:45
+#, fuzzy
+#| msgid "100 minutes"
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:49
+#, fuzzy
+#| msgid "2 hours"
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 соат"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:63
+#, fuzzy
+#| msgid "1 minute"
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 дақиқа"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:67
+#, fuzzy
+#| msgid "2 minutes"
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 дақиқа"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:71
+#, fuzzy
+#| msgid "3 minutes"
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 дақиқа"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:75
+#, fuzzy
+#| msgid "4 minutes"
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 дақиқа"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:79
+#, fuzzy
+#| msgid "5 minutes"
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 дақиқа"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:83
+#, fuzzy
+#| msgid "8 minutes"
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 дақиқа"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:87
+#, fuzzy
+#| msgid "10 minutes"
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 дақиқа"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:91
+#, fuzzy
+#| msgid "12 minutes"
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 дақиқа"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:95
+#, fuzzy
+#| msgid "15 minutes"
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 дақиқа"
+
+#. Translators: Option for "Blank screen" in "Power" panel.
+#: panels/power/cc-power-panel.ui:99
+#, fuzzy
+#| msgid "Never"
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Ҳеҷ гоҳ"
+
+#: panels/power/cc-power-panel.ui:147
+msgid "Automatic Suspend"
+msgstr "Таваққуфи худкор"
+
+#: panels/power/cc-power-panel.ui:172
+msgid "_Plugged In"
+msgstr "_Васлшуда"
+
+#: panels/power/cc-power-panel.ui:188
+msgid "On _Battery Power"
+msgstr "Аз _батарея кор мекунад"
+
+#: panels/power/cc-power-panel.ui:233 panels/power/cc-power-panel.ui:293
+#: panels/universal-access/cc-ua-panel.ui:1507
+msgid "Delay"
+msgstr "Таъхир"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Барқ"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+"Намоиш додани вазъияти батарея ва тағйир додани танзимоти захиракунии барқ"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"Барқ;Хоб;Таваққуф;Гибернатсия;Батарея;Дурахшонӣ;Камнур;Холӣ;Монитор;DPMS;"
+"Беҳаракат;"
+
+#: panels/printers/authentication-dialog.ui:11
+msgid " "
+msgstr " "
+
+#: panels/printers/authentication-dialog.ui:42
+msgid "Authenticate"
+msgstr "Санҷиши ҳаққоният"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/authentication-dialog.ui:80
+#: panels/printers/jobs-dialog.ui:57 panels/printers/new-printer-dialog.ui:362
+msgid "Username"
+msgstr "Номи корбар"
+
+#. Translators: This is a password needed for printing.
+#: panels/printers/authentication-dialog.ui:96
+#: panels/printers/jobs-dialog.ui:70 panels/printers/new-printer-dialog.ui:383
+#: panels/user-accounts/cc-add-user-dialog.ui:249
+msgid "Password"
+msgstr "Ниҳонвожа"
+
+#: panels/printers/authentication-dialog.ui:139
+#: panels/printers/new-printer-dialog.ui:337
+msgid "Authentication Required"
+msgstr "Санҷиши ҳаққоният лозим аст"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:715
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr ""
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:938
+msgid "Failed to add new printer."
+msgstr "Иловакунии принтери нав қатъ шуд."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1242
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Интерфейси корбар бор нашуд: %s"
+
+#: panels/printers/details-dialog.ui:64 panels/printers/printer-entry.ui:223
+msgid "Location"
+msgstr "Ҷойгиршавӣ"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/details-dialog.ui:114
+#: panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "Драйвер"
+
+#: panels/printers/details-dialog.ui:152
+msgid "Searching for preferred drivers…"
+msgstr "Ҷустуҷӯи драйверҳои мувофиқ…"
+
+#: panels/printers/details-dialog.ui:174
+#, fuzzy
+#| msgid "Search for a city"
+msgid "Search for Drivers"
+msgstr "Ҷустуҷӯи шаҳр"
+
+#: panels/printers/details-dialog.ui:182
+#, fuzzy
+#| msgid "Select from database…"
+msgid "Select from Database…"
+msgstr "Интихоб кардан аз пойгоҳи иттилоотӣ…"
+
+#: panels/printers/details-dialog.ui:190
+#, fuzzy
+#| msgid "Provide PPD File…"
+msgid "Install PPD File…"
+msgstr "Таъмини файли PPD…"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Принтерҳо"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "Илова кардани принтерҳо, намоиши вазифаҳои чоп ва тарзи чопкунӣ"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Принтер;Навбат;Чоп кардан;Қоғаз;Ранг;Тюнер;"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/jobs-dialog.ui:44
+#, fuzzy
+#| msgid "_Domain"
+msgid "Domain"
+msgstr "_Домен"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/jobs-dialog.ui:123
+msgid "A_uthenticate"
+msgstr "_Санҷиши ҳаққоният"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/jobs-dialog.ui:163
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/jobs-dialog.ui:225
+#, fuzzy
+#| msgid "Authenticate"
+msgid "_Authenticate"
+msgstr "Санҷиши ҳаққоният"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/jobs-dialog.ui:354
+#, fuzzy
+#| msgid "%s Active Jobs"
+msgid "No Active Printer Jobs"
+msgstr "%s вазифаи фаъол"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:29
+#: panels/printers/pp-new-printer-dialog.c:363
+#: panels/printers/pp-new-printer-dialog.c:427
+msgid "Add Printer"
+msgstr "Илова кардани принтер"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:96
+#: panels/printers/new-printer-dialog.ui:111
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:211
+#, fuzzy
+#| msgid "No Pictures Found"
+msgid "No Printers Found"
+msgstr "Ягон тасвир ёфт нашудааст"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:284
+msgid "Enter a network address or search for a printer"
+msgstr "Суроғаи шабакавиро ворид кунед ё принтерро ҷустуҷӯ кунед"
+
+#: panels/printers/new-printer-dialog.ui:353
+#, fuzzy
+#| msgid "Enter your username and password to view printers available on %s."
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Барои намоиш додани принтерҳои дастрас дар %s, шумо бояд номи корбар ва "
+"ниҳонвожаро ворид кунед."
+
+#. Translators: This button triggers the printing of a test page.
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/options-dialog.ui:22 panels/printers/pp-options-dialog.c:907
+#, fuzzy
+#| msgid "Test page"
+msgid "Test Page"
+msgstr "Саҳифаи санҷишӣ"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:133
+#: panels/printers/pp-details-dialog.c:417
+#, fuzzy, c-format
+#| msgid "Details"
+msgid "%s Details"
+msgstr "Тафсилот"
+
+#: panels/printers/pp-details-dialog.c:180
+msgid "No suitable driver found"
+msgstr "Ягон драйвери мувофиқ ёфт нашудааст"
+
+#: panels/printers/pp-details-dialog.c:310
+msgid "Select PPD File"
+msgstr "Интихоби файли PPD"
+
+#: panels/printers/pp-details-dialog.c:319
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Файлҳои тавсифи принтери PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+"GZ)"
+
+#: panels/printers/ppd-selection-dialog.ui:10
+msgid "Select Printer Driver"
+msgstr "Интихоби драйвери принтер"
+
+#: panels/printers/ppd-selection-dialog.ui:40
+#: panels/user-accounts/cc-avatar-chooser.c:108
+msgid "Select"
+msgstr "Интихоб кардан"
+
+#: panels/printers/ppd-selection-dialog.ui:73
+#, fuzzy
+#| msgid "Loading drivers database..."
+msgid "Loading drivers database…"
+msgstr "Боркунии пойгоҳи иттилоотии драйверҳо..."
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:472
+msgid "JetDirect Printer"
+msgstr "Принтери JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:707
+msgid "LPD Printer"
+msgstr "Принтери LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:65
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Яктарафа"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:67
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Канори дароз (стандартӣ)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:69
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Канори кӯтоҳ (акскунӣ)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:71
+msgid "Portrait"
+msgstr "Амудӣ"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:73
+msgid "Landscape"
+msgstr "Уфуқӣ"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:75
+msgid "Reverse landscape"
+msgstr "Баръакси уфуқӣ"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:77
+msgid "Reverse portrait"
+msgstr "Баръакси амуди"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-jobs-dialog.c:234
+msgctxt "print job"
+msgid "Pending"
+msgstr "Мунтазир"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-jobs-dialog.c:240
+#, fuzzy
+#| msgid "Last used"
+msgctxt "print job"
+msgid "Paused"
+msgstr "Истифодашудаи охирин"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-jobs-dialog.c:245
+#, fuzzy
+#| msgid "Authentication required"
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Санҷиши ҳаққоният лозим аст"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-jobs-dialog.c:250
+msgctxt "print job"
+msgid "Processing"
+msgstr "Коркард"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-jobs-dialog.c:254
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Манъ шуд"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-jobs-dialog.c:258
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Бекор карда шуд"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-jobs-dialog.c:262
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Қатъшуда"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-jobs-dialog.c:266
+msgctxt "print job"
+msgid "Completed"
+msgstr "Ба анҷом расид"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:390
+#, fuzzy, c-format
+#| msgid "Server requires authentication"
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "_Сервер санҷиши ҳаққониятро талаб мекунад"
+msgstr[1] "_Сервер санҷиши ҳаққониятро талаб мекунад"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:613
+#, fuzzy, c-format
+#| msgid "%s Active Jobs"
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s вазифаи фаъол"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:617
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr ""
+
+#: panels/printers/pp-new-printer-dialog.c:380
+#, fuzzy
+#| msgid "Select Printer Driver"
+msgid "Unlock Print Server"
+msgstr "Интихоби драйвери принтер"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:384
+#, c-format
+msgid "Unlock %s."
+msgstr ""
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:388
+#, fuzzy, c-format
+#| msgid "Enter your username and password to view printers available on %s."
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Барои намоиш додани принтерҳои дастрас дар %s, шумо бояд номи корбар ва "
+"ниҳонвожаро ворид кунед."
+
+#: panels/printers/pp-new-printer-dialog.c:838
+#, fuzzy
+#| msgid "Not searching for networks"
+msgid "Searching for Printers"
+msgstr "Шабакаҳоро ҷустуҷӯ намекунад"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1680
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1685
+msgid "Serial Port"
+msgstr "Порти силсилавӣ"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1692
+msgid "Parallel Port"
+msgstr "Порти мувозӣ"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1734
+#, c-format
+msgid "Location: %s"
+msgstr "Ҷойгиршавӣ: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+msgid "Address: %s"
+msgstr "Суроға: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1766
+msgid "Server requires authentication"
+msgstr "_Сервер санҷиши ҳаққониятро талаб мекунад"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Two Sided"
+msgstr "Дутарафа"
+
+#: panels/printers/pp-options-dialog.c:91
+msgid "Paper Type"
+msgstr "Навъи қоғаз"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "Paper Source"
+msgstr "Манбаи қоғаз"
+
+#: panels/printers/pp-options-dialog.c:93
+msgid "Output Tray"
+msgstr "Қуттии барориш"
+
+#: panels/printers/pp-options-dialog.c:94
+#, fuzzy
+#| msgid "Resolution"
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Возеҳӣ"
+
+#: panels/printers/pp-options-dialog.c:95
+msgid "GhostScript pre-filtering"
+msgstr "Филтркунии пешакии GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:548
+msgid "Pages per side"
+msgstr "Саҳифаҳо дар як тараф"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:560
+msgid "Two-sided"
+msgstr "Дутарафа"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:572
+msgid "Orientation"
+msgstr "Самт"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Умумӣ"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Танзими саҳифа"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:675
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Имконоти насбшаванда"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:678
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Вазифа"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:681
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Сифати тасвир"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:684
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Ранг"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:687
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Ба анҷом расида истоддаст"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:690
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Иловагӣ"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:920
+msgid "Test page"
+msgstr "Саҳифаи санҷишӣ"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Интихоб ба таври худкор"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Принтери пешфарз"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Илова кардани танҳо шрифтҳои GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Табдил додан ба сатҳи 1 PS"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Табдил додан ба сатҳи 2 PS"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Ягон филтри пешакӣ нест"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "Истеҳсолкунанда"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:606 panels/printers/printer-entry.ui:166
+#, fuzzy
+#| msgid "Active Jobs"
+msgid "No Active Jobs"
+msgstr "Вазифаҳои фаъол"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:611
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:766
+msgid "Low on toner"
+msgstr "Миқдори тонер паст аст"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:768
+msgid "Out of toner"
+msgstr "Тонер тамом шуд"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:771
+msgid "Low on developer"
+msgstr "Таҳиягар паст аст"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:774
+msgid "Out of developer"
+msgstr "Таҳиягар ба анҷом расид"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:776
+msgid "Low on a marker supply"
+msgstr "Миқдори таъминоти маркер паст аст"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:778
+msgid "Out of a marker supply"
+msgstr "Таъминоти маркер ба анҷом расид"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:780
+msgid "Open cover"
+msgstr "Кушодани сарпӯш"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:782
+msgid "Open door"
+msgstr "Дари кушода"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:784
+msgid "Low on paper"
+msgstr "Миқдори қоғаз паст аст"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:786
+msgid "Out of paper"
+msgstr "Қоғаз тамом шуд"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:788
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Офлайн"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:790
+#: panels/printers/pp-printer-entry.c:918
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Манъ шуд"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:792
+msgid "Waste receptacle almost full"
+msgstr "Махзани партов тақрибан пур аст"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:794
+msgid "Waste receptacle full"
+msgstr "Махзани партов пур аст"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:796
+msgid "The optical photo conductor is near end of life"
+msgstr "Ҳодии оптикии сурат дар вақти наздик аз кор мебарояд"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:798
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Ҳодии оптикии сурат дигар кор намекунад"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:904
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Тайёр"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:909
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Корҳоро қабул намекунад"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:914
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Коркард"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:938
+msgid "Clean print heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:14
+msgid "Printing Options"
+msgstr "Имконоти чопкунӣ"
+
+#: panels/printers/printer-entry.ui:26
+msgid "Printer Details"
+msgstr "Тафсилоти принтер"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:38
+#, fuzzy
+#| msgid "Printer Default"
+msgid "Use Printer by Default"
+msgstr "Принтери пешфарз"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:50
+#, fuzzy
+#| msgid "Cancel Print Job"
+msgid "Clean Print Heads"
+msgstr "Бекор кардани кори принтер"
+
+#: panels/printers/printer-entry.ui:61
+msgid "Remove Printer"
+msgstr "Тоза кардани принтер"
+
+#: panels/printers/printer-entry.ui:193
+msgid "Model"
+msgstr "Намуна"
+
+#: panels/printers/printer-entry.ui:251
+msgid "Ink Level"
+msgstr "Сатҳи ранг"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:312
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:319
+msgid "Restart"
+msgstr "Бозоғозӣ кардан"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:20
+msgid "Add…"
+msgstr ""
+
+#: panels/printers/printers.ui:186
+msgid "No printers"
+msgstr "Ягон принтер нест"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:200
+msgid "Add a Printer…"
+msgstr "Илова кардани принтер…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:232
+#, fuzzy
+#| msgid ""
+#| "Sorry! The system printing service\n"
+#| "doesn't seem to be available."
+msgid ""
+"Sorry! The system printing service\n"
+"doesn’t seem to be available."
+msgstr ""
+"Мутаассифона, хидмати низоми чоп\n"
+"дар айни ҳол дастнорас аст."
+
+#: panels/privacy/cc-privacy-panel.c:423 panels/privacy/cc-privacy-panel.ui:280
+msgid "Screen Lock"
+msgstr "Экрани қулф"
+
+#: panels/privacy/cc-privacy-panel.c:467
+msgid "In use"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.c:472
+#, fuzzy
+#| msgid "On"
+msgctxt "Location services status"
+msgid "On"
+msgstr "Фаъол"
+
+#: panels/privacy/cc-privacy-panel.c:473
+#, fuzzy
+#| msgid "Off"
+msgctxt "Location services status"
+msgid "Off"
+msgstr "Хомӯш"
+
+#: panels/privacy/cc-privacy-panel.c:895
+#, fuzzy
+#| msgid "Off"
+msgctxt "Camera status"
+msgid "Off"
+msgstr "Хомӯш"
+
+#: panels/privacy/cc-privacy-panel.c:897
+#, fuzzy
+#| msgid "On"
+msgctxt "Camera status"
+msgid "On"
+msgstr "Фаъол"
+
+#: panels/privacy/cc-privacy-panel.c:928
+#, fuzzy
+#| msgid "Off"
+msgctxt "Microphone status"
+msgid "Off"
+msgstr "Хомӯш"
+
+#: panels/privacy/cc-privacy-panel.c:930
+#, fuzzy
+#| msgid "On"
+msgctxt "Microphone status"
+msgid "On"
+msgstr "Фаъол"
+
+#: panels/privacy/cc-privacy-panel.c:1036
+#: panels/privacy/cc-privacy-panel.ui:127
+msgid "Usage & History"
+msgstr "Истифодабарӣ ва таърих"
+
+#: panels/privacy/cc-privacy-panel.c:1157
+msgid "Empty all items from Trash?"
+msgstr "Ҳамаи объектҳои сабадро бебозгашт нест мекунед?"
+
+#: panels/privacy/cc-privacy-panel.c:1158
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Ҳамаи объектҳои сабад бебозгашт нест карда мешаванд."
+
+#: panels/privacy/cc-privacy-panel.c:1159
+msgid "_Empty Trash"
+msgstr "_Холӣ кардани сабад"
+
+#: panels/privacy/cc-privacy-panel.c:1180
+msgid "Delete all the temporary files?"
+msgstr "Ҳамаи файлҳои муваққатиро нест мекунед?"
+
+#: panels/privacy/cc-privacy-panel.c:1181
+msgid "All the temporary files will be permanently deleted."
+msgstr "Ҳамаи файлҳои муваққатӣ бебозгашт нест карда мешаванд."
+
+#: panels/privacy/cc-privacy-panel.c:1182
+msgid "_Purge Temporary Files"
+msgstr "_Пок кардани файлҳои муваққатӣ"
+
+#: panels/privacy/cc-privacy-panel.c:1204
+#: panels/privacy/cc-privacy-panel.ui:432
+msgid "Purge Trash & Temporary Files"
+msgstr "Пок кардани сабад ва файлҳои муваққатӣ"
+
+#: panels/privacy/cc-privacy-panel.c:1237
+#: panels/privacy/cc-privacy-panel.ui:637
+msgid "Software Usage"
+msgstr "Истифодаи нармафзор"
+
+#: panels/privacy/cc-privacy-panel.c:1276
+#: panels/privacy/cc-privacy-panel.ui:1169
+msgid "Problem Reporting"
+msgstr "Гузориш дар бораи мушкилиҳо"
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: panels/privacy/cc-privacy-panel.c:1288
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+"Фиристодани гузоришҳо дар бораи мушкилиҳои техникӣ барои кумаки такмилдиҳии "
+"%s. Гузоришҳо ба тавримахфӣ фиристода мешаванд ва маълумоти шахсиро дар бар "
+"намегиранд."
+
+#: panels/privacy/cc-privacy-panel.c:1300
+#: panels/privacy/cc-privacy-panel.ui:719
+msgid "Privacy Policy"
+msgstr "Сиёсати махфият"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:14
+#, fuzzy
+#| msgid "Screen Turns Off"
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Экран хомӯш мешавад"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:18
+#, fuzzy
+#| msgid "30 seconds"
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 сония"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:22
+#, fuzzy
+#| msgid "1 minute"
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 дақиқа"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:26
+#, fuzzy
+#| msgid "2 minutes"
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 дақиқа"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:30
+#, fuzzy
+#| msgid "3 minutes"
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 дақиқа"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:34
+#, fuzzy
+#| msgid "5 minutes"
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 дақиқа"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:38
+#, fuzzy
+#| msgid "30 minutes"
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 дақиқа"
+
+#. Translators: Option for "Lock screen after blank for" in "Screen Lock" dialog.
+#: panels/privacy/cc-privacy-panel.ui:42
+#, fuzzy
+#| msgid "1 hour"
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 соат"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:56
+#, fuzzy
+#| msgid "1 hour"
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 соат"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:60
+#, fuzzy
+#| msgid "1 day"
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 рӯз"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:64
+#, fuzzy
+#| msgid "2 days"
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 рӯз"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:68
+#, fuzzy
+#| msgid "3 days"
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 рӯз"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:72
+#, fuzzy
+#| msgid "4 days"
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 рӯз"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:76
+#, fuzzy
+#| msgid "5 days"
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 рӯз"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:80
+#, fuzzy
+#| msgid "6 days"
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 рӯз"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:84
+#, fuzzy
+#| msgid "7 days"
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 рӯз"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:88
+#, fuzzy
+#| msgid "14 days"
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 рӯз"
+
+#. Translators: Option for "Purge After" in "Purge Trash & Temporary Files" dialog.
+#: panels/privacy/cc-privacy-panel.ui:92
+#, fuzzy
+#| msgid "30 days"
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 рӯз"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/privacy/cc-privacy-panel.ui:106
+#, fuzzy
+#| msgid "1 day"
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 рӯз"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/privacy/cc-privacy-panel.ui:110
+#, fuzzy
+#| msgid "7 days"
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 рӯз"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/privacy/cc-privacy-panel.ui:114
+#, fuzzy
+#| msgid "30 days"
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 рӯз"
+
+#. Translators: Option for "Retain History" in "Usage & History" dialog.
+#: panels/privacy/cc-privacy-panel.ui:118
+#, fuzzy
+#| msgid "Forever"
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Ҳамеша"
+
+#: panels/privacy/cc-privacy-panel.ui:148
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"Дар ёд доштани таърихи шумо ёфтани дубораи чизҳоро осон мегардонад. Ин "
+"объектҳо ягон вақт дар шабака мубодила намешаванд."
+
+#: panels/privacy/cc-privacy-panel.ui:176
+msgid "_Recently Used"
+msgstr "_Истифодашудаи охирин"
+
+#: panels/privacy/cc-privacy-panel.ui:207
+msgid "Retain _History"
+msgstr "Нигоҳ доштани _таърих"
+
+#: panels/privacy/cc-privacy-panel.ui:247
+msgid "Cl_ear Recent History"
+msgstr "_Пок кардани таърихи қаблӣ"
+
+#: panels/privacy/cc-privacy-panel.ui:301
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr ""
+"Қулфи экран ҳангоми мавҷуд набудани шумо махфияти шуморо муҳофизат мекунад."
+
+#: panels/privacy/cc-privacy-panel.ui:328
+msgid "Automatic Screen _Lock"
+msgstr "Қулфи экрани _худкор"
+
+#: panels/privacy/cc-privacy-panel.ui:362
+msgid "Lock screen _after blank for"
+msgstr "Қулф кардани экран _баъд аз холӣ дар давоми"
+
+#: panels/privacy/cc-privacy-panel.ui:394
+#, fuzzy
+#| msgid "Lock Screen Notifications"
+msgid "Lock Screen _Notifications"
+msgstr "Огоҳиҳои экрани қулф"
+
+#: panels/privacy/cc-privacy-panel.ui:454
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"Тоза кардани сабад ва файлҳои муваққатӣ ба таври худкор барои нигоҳ доштани "
+"компютер бе иттилооти нодаркор."
+
+#: panels/privacy/cc-privacy-panel.ui:483
+msgid "Automatically empty _Trash"
+msgstr "Холӣ кардани сабад _ба таври худкор"
+
+#: panels/privacy/cc-privacy-panel.ui:515
+msgid "Automatically purge Temporary _Files"
+msgstr "Холӣ кардани файлҳои _муваққатӣ ба таври худкор"
+
+#: panels/privacy/cc-privacy-panel.ui:546
+msgid "Purge _After"
+msgstr "Пок кардан _баъд аз"
+
+#: panels/privacy/cc-privacy-panel.ui:590
+#, fuzzy
+#| msgid "_Empty Trash"
+msgid "_Empty Trash…"
+msgstr "_Холӣ кардани сабад"
+
+#: panels/privacy/cc-privacy-panel.ui:606
+#, fuzzy
+#| msgid "_Purge Temporary Files"
+msgid "_Purge Temporary Files…"
+msgstr "_Пок кардани файлҳои муваққатӣ"
+
+#: panels/privacy/cc-privacy-panel.ui:654
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"Бо ирсолкунии иттилоот дар бораи истифодаи нармафзор шумо ба мо кумак "
+"мерасонед, то ки мо тавонем ба шумо тавсияҳои дақиқро таъмин намоем. "
+"Иттилооти ирсолшуда инчунин барои беҳтаркунии нармафзори мо кумак "
+"мерасонад.\n"
+"\n"
+"Ҳамаи иттилооти ҷамъшуда маълумоти шахсии шуморо дар бар намегирад ва бо "
+"тарафҳои сеюм ҳеҷ гоҳ мубодила намешавад."
+
+#: panels/privacy/cc-privacy-panel.ui:681
+msgid "_Send software usage statistics"
+msgstr "_Фиристодани омори истифодаи нармафзор"
+
+#: panels/privacy/cc-privacy-panel.ui:764
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly."
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.ui:812
+#, fuzzy
+#| msgid "%s Camera"
+msgid "_Camera"
+msgstr "Камераи %s"
+
+#: panels/privacy/cc-privacy-panel.ui:869
+msgid ""
+"Use of the microphone allows applications to capture sounds. Disabling the "
+"microphone may cause some applications to not function properly."
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.ui:917
+msgid "_Microphone"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.ui:974
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.ui:988
+msgid ""
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>"
+msgstr ""
+
+#: panels/privacy/cc-privacy-panel.ui:1038
+msgid "_Location Services"
+msgstr "_Хидматҳои ҷойгиршавӣ"
+
+#: panels/privacy/cc-privacy-panel.ui:1236
+msgid "_Automatic Problem Reporting"
+msgstr "_Гузоришдиҳии худкор оид ба мушкилиҳо"
+
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:3
+msgid "Privacy"
+msgstr "Махфият"
+
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:4
+msgid "Protect your personal information and control what others might see"
+msgstr ""
+"Иттилооти шахсиро муҳофизат кунед ва идора кунед, ки дигарон чиро дида "
+"метавонанд"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/privacy/gnome-privacy-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"экран;қулф;ташхис;вайронӣ;махфӣ;қаблӣ;муваққатӣ;tmp;индекс;ном;шабака;"
+"шахсият;"
+
+#: panels/region/cc-format-chooser.c:114
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Империягӣ"
+
+#: panels/region/cc-format-chooser.c:116
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Метрӣ"
+
+#: panels/region/cc-format-chooser.c:286
+msgid "No regions found"
+msgstr "Ягон минтақа ёфт нашуд"
+
+#: panels/region/cc-format-chooser.ui:7
+msgid "Formats"
+msgstr "Форматҳо"
+
+#: panels/region/cc-format-chooser.ui:106
+msgid "Preview"
+msgstr "Пешнамоиш"
+
+#: panels/region/cc-format-chooser.ui:123
+msgid "Dates"
+msgstr "Санаҳо"
+
+#: panels/region/cc-format-chooser.ui:154
+msgid "Times"
+msgstr "Вақтҳо"
+
+#: panels/region/cc-format-chooser.ui:185
+#, fuzzy
+#| msgid "Date & Time"
+msgid "Dates & Times"
+msgstr "Сана ва Вақт"
+
+#: panels/region/cc-format-chooser.ui:216
+msgid "Numbers"
+msgstr "Рақамҳо"
+
+#: panels/region/cc-format-chooser.ui:233
+msgid "Measurement"
+msgstr "Ченак"
+
+#: panels/region/cc-format-chooser.ui:250
+msgid "Paper"
+msgstr "Қоғаз"
+
+#: panels/region/cc-input-chooser.c:193
+msgid "No input sources found"
+msgstr "Ягон манбаи вуруд ёфт нашудааст"
+
+#: panels/region/cc-input-chooser.c:948
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Дигар"
+
+#: panels/region/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Илова кардани манбаи вуруд"
+
+#: panels/region/cc-input-chooser.ui:77
+#, fuzzy
+#| msgid "Input methods can't be used on the login screen"
+msgid "Input methods can’t be used on the login screen"
+msgstr "Усулҳои вуруд наметавонанд дар экрани воридшавӣ истифода шаванд"
+
+#: panels/region/cc-region-panel.c:1503
+#, fuzzy
+#| msgid "Login Screen"
+msgid "Login _Screen"
+msgstr "Экрани воридшавӣ"
+
+#: panels/region/cc-region-panel.ui:64
+#: panels/user-accounts/cc-user-panel.ui:362
+msgid "_Language"
+msgstr "_Забон"
+
+#: panels/region/cc-region-panel.ui:99
+#, fuzzy
+#| msgid "Your session needs to be restarted for changes to take effect"
+msgid "Restart the session for changes to take effect"
+msgstr "Барои татбиқ кардани тағйирот шумо бояд низомро бозоғозӣ кунед"
+
+#: panels/region/cc-region-panel.ui:114
+#, fuzzy
+#| msgid "Restart Now"
+msgid "Restart…"
+msgstr "Ҳозир бозоғозӣ кардан"
+
+#: panels/region/cc-region-panel.ui:147
+#, fuzzy
+#| msgid "Formats"
+msgid "_Formats"
+msgstr "Форматҳо"
+
+#: panels/region/cc-region-panel.ui:195
+msgid "Input Sources"
+msgstr "Манбаҳои вуруд"
+
+#: panels/region/cc-region-panel.ui:209
+msgid "Choose keyboard layouts or input methods."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:266
+msgid "No input source selected"
+msgstr "Ягон манбаи вуруд интихоб нашудааст"
+
+#: panels/region/cc-region-panel.ui:300
+msgid "Login settings are used by all users when logging into the system"
+msgstr ""
+"Танзимоти воридшавӣ бо ҳамаи корбарон ҳангоми воридшавӣ ба низом истифода "
+"мешаванд"
+
+#: panels/region/cc-region-panel.ui:338
+msgid "Input Source Options"
+msgstr "Имконоти манбаи вуруд"
+
+#: panels/region/cc-region-panel.ui:353
+msgid "Use the _same source for all windows"
+msgstr "Истифода бурдани манбаи _якхела барои ҳамаи равзанаҳо"
+
+#: panels/region/cc-region-panel.ui:371
+msgid "Allow _different sources for each window"
+msgstr "Иҷозат додани _манбаҳои гуногун барои ҳар як равзана"
+
+#: panels/region/cc-region-panel.ui:413
+#, fuzzy
+#| msgid "Previous track"
+msgid "Previous source"
+msgstr "Пайгирии қаблӣ"
+
+#: panels/region/cc-region-panel.ui:431
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Фосила"
+
+#: panels/region/cc-region-panel.ui:446
+#, fuzzy
+#| msgid "Resources"
+msgid "Next source"
+msgstr "Захираҳо"
+
+#: panels/region/cc-region-panel.ui:464
+msgid "Super+Space"
+msgstr "Super+Фосила"
+
+#: panels/region/cc-region-panel.ui:479
+msgid "Left+Right Alt"
+msgstr "Alt-и рост + чап"
+
+#: panels/region/cc-region-panel.ui:495
+#, fuzzy
+#| msgid "You can change these shortcuts in the keyboard settings"
+msgid "These keyboard shortcuts can be changed in the keyboard settings"
+msgstr "Шумо метавонед ин миёнбурҳоро дар танзимоти клавиатура тағйир диҳед"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Забон ва минтақа"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr ""
+"Интихоби забони интерфейс, форматҳо, тарҳбандии клавиатураҳо ва манбаҳои "
+"вуруд"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Забон;Тарҳбандӣ;Клавиатура;Вуруд;"
+
+#: panels/search/cc-search-locations-dialog.c:604
+msgid "Select Location"
+msgstr "Интихоби ҷойгиршавӣ"
+
+#: panels/search/cc-search-locations-dialog.c:608
+msgid "_OK"
+msgstr "_OK"
+
+#: panels/search/cc-search-panel.c:175
+msgid "No applications found"
+msgstr "Ягон барнома ёфт нашуд"
+
+#: panels/search/cc-search-panel.ui:52
+msgid "Move Up"
+msgstr "Ба боло"
+
+#: panels/search/cc-search-panel.ui:69
+msgid "Move Down"
+msgstr "Ба поён"
+
+#: panels/search/cc-search-panel.ui:105
+msgid "Preferences"
+msgstr "Хусусиятҳо"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Идора кунед, ки кадом барномаҳо натиҷаҳои ҷустуҷӯро дар хулосаи фаъолият "
+"намоиш медиҳанд"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Ҷустуҷӯ;Ёфтан;Индекс;Пинҳон кардан;Махфият;Натиҷаҳо;"
+
+#: panels/search/search-locations-dialog.ui:9
+msgid "Search Locations"
+msgstr "Ҷустуҷӯи ҷойгиршавӣ"
+
+#: panels/search/search-locations-dialog.ui:43
+#, fuzzy
+#| msgctxt "Search Location"
+#| msgid "Places"
+msgid "Places"
+msgstr "Ҷойҳо"
+
+#: panels/search/search-locations-dialog.ui:73
+#, fuzzy
+#| msgctxt "Search Location"
+#| msgid "Bookmarks"
+msgid "Bookmarks"
+msgstr "Хатбаракҳо"
+
+#: panels/search/search-locations-dialog.ui:130
+#, fuzzy
+#| msgctxt "Online Account"
+#| msgid "Other"
+msgid "Other"
+msgstr "Дигар"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:307
+msgid "No networks selected for sharing"
+msgstr "Барои мубодила ягон шабака интихоб карда нашуд"
+
+#: panels/sharing/cc-sharing-panel.c:319
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Фаъол"
+
+#: panels/sharing/cc-sharing-panel.c:321 panels/sharing/cc-sharing-panel.c:348
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Хомӯш"
+
+#: panels/sharing/cc-sharing-panel.c:351
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Фаъолшуда"
+
+#: panels/sharing/cc-sharing-panel.c:354
+msgctxt "service is active"
+msgid "Active"
+msgstr "Фаъол"
+
+#: panels/sharing/cc-sharing-panel.c:424
+msgid "Choose a Folder"
+msgstr "Интихоб кардани ҷузвдон"
+
+#: panels/sharing/cc-sharing-panel.c:724
+#, fuzzy, c-format
+#| msgid ""
+#| "Personal File Sharing allows you to share your Public folder with others "
+#| "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"Дастрасии муштараки файлҳои шахсӣ ба шумо имкон медиҳад, ки ҷузвдони \"Оммавӣ"
+"\"-и худро бо дигарон дар шабакаи ҷории худ тавассути зерин мебодила кунед: "
+"<a href=\"dav://%s\">dav://%s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:726
+#, fuzzy, c-format
+#| msgid ""
+#| "Allow remote users to connect using the Secure Shell command:\n"
+#| "<a href=\"ssh %s\">ssh %s</a>"
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"Ба корбарони дурдаст иҷозат диҳед, ки тавонанд барои пайваст шудан фармони "
+"Secure Shell-ро истифода баранд:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:728
+#, fuzzy, c-format
+#| msgid ""
+#| "Allow remote users to view or control your screen by connecting to: <a "
+#| "href=\"vnc://%s\">vnc://%s</a>"
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"Ба корбарони дурдаст иҷозат диҳед, ки тавонанд экрани шуморо бинанд ё идора "
+"кунанд (тавассути): <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: panels/sharing/cc-sharing-panel.c:832
+msgid "Copy"
+msgstr "Нусха бардоштан"
+
+#: panels/sharing/cc-sharing-panel.c:1285
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Дастрасии муштарак"
+
+#: panels/sharing/cc-sharing-panel.ui:34
+#, fuzzy
+#| msgid "Computer Name"
+msgid "_Computer Name"
+msgstr "Номи компютер"
+
+#: panels/sharing/cc-sharing-panel.ui:94
+#, fuzzy
+#| msgid "Personal File Sharing"
+msgid "_File Sharing"
+msgstr "Мубодилаи файлҳои шахсӣ"
+
+#: panels/sharing/cc-sharing-panel.ui:139
+#, fuzzy
+#| msgid "Screen Sharing"
+msgid "_Screen Sharing"
+msgstr "Мубодилаи экран"
+
+#: panels/sharing/cc-sharing-panel.ui:184
+#, fuzzy
+#| msgid "Media Sharing"
+msgid "_Media Sharing"
+msgstr "Мубодилакунии медиа"
+
+#: panels/sharing/cc-sharing-panel.ui:229
+#, fuzzy
+#| msgid "Remote Login"
+msgid "_Remote Login"
+msgstr "Воридшавии дурдаст"
+
+#: panels/sharing/cc-sharing-panel.ui:268
+msgid "Some services are disabled because of no network access."
+msgstr ""
+"Аз сабаби мавҷуд набудани дастрасии шабакавӣ, баъзе хидматҳо ғайрифаъол "
+"карда шудаанд."
+
+#: panels/sharing/cc-sharing-panel.ui:286
+#: panels/sharing/cc-sharing-panel.ui:413
+#, fuzzy
+#| msgid "Sharing"
+msgid "File Sharing"
+msgstr "Дастрасии муштарак"
+
+#: panels/sharing/cc-sharing-panel.ui:333
+#, fuzzy
+#| msgid "Require Password"
+msgid "_Require Password"
+msgstr "Ниҳонвожа ҳатмист"
+
+#: panels/sharing/cc-sharing-panel.ui:424
+#: panels/sharing/cc-sharing-panel.ui:496
+msgid "Remote Login"
+msgstr "Воридшавии дурдаст"
+
+#: panels/sharing/cc-sharing-panel.ui:519
+#: panels/sharing/cc-sharing-panel.ui:765
+msgid "Screen Sharing"
+msgstr "Мубодилаи экран"
+
+#: panels/sharing/cc-sharing-panel.ui:577
+msgid "_Allow connections to control the screen"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:622
+#, fuzzy
+#| msgid "_Password"
+msgid "_Password:"
+msgstr "_Ниҳонвожа"
+
+#: panels/sharing/cc-sharing-panel.ui:652
+#, fuzzy
+#| msgid "Show Password"
+msgid "_Show Password"
+msgstr "Намоиш додани ниҳонвожа"
+
+#: panels/sharing/cc-sharing-panel.ui:683
+msgid "Access Options"
+msgstr "Имконоти дастрсӣ"
+
+#: panels/sharing/cc-sharing-panel.ui:697
+#, fuzzy
+#| msgid "New connections must ask for access"
+msgid "_New connections must ask for access"
+msgstr "Пайвастҳои нав бояд барои дастрасӣ иҷозатро дархост кунанд"
+
+#: panels/sharing/cc-sharing-panel.ui:715
+#, fuzzy
+#| msgid "Require a password"
+msgid "_Require a password"
+msgstr "Ниҳонвожа лозим аст"
+
+#: panels/sharing/cc-sharing-panel.ui:776
+#: panels/sharing/cc-sharing-panel.ui:870
+msgid "Media Sharing"
+msgstr "Мубодилакунии медиа"
+
+#: panels/sharing/cc-sharing-panel.ui:809
+#, fuzzy
+#| msgid ""
+#| "Media sharing allows you to share music, photos and videos over the "
+#| "network."
+msgid "Share music, photos and videos over the network."
+msgstr ""
+"Мубодилаи медиа ба шумо барои мубодила кардани мусиқӣ, суратҳо ва видеоҳо "
+"тавассути шабака имкон медиҳад."
+
+#: panels/sharing/cc-sharing-panel.ui:824
+msgid "Folders"
+msgstr "Ҷузвдонҳо"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Идора кунед, ки шумо бо дигарон чиро мубодила мекунед"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+#| msgid ""
+#| "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;"
+#| "video;pictures;photos;movies;server;renderer;"
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"мубодила кардан;дастрасии муштарак;ssh;мизбон;ном;дурдаст;мизи корӣ;"
+"bluetooth;obex;медиа;аудио;видео;тасвирҳо;суратҳо;филмҳо;сервер;пардозанда;"
+
+#: panels/sharing/networks.ui:19
+msgid "Networks"
+msgstr "Шабакаҳо"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Фаъол ё ғайрифаъол кардани воридшавии дурдаст"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Барои фаъол ё ғайрифаъол кардани вуруди дурдаст, санҷиши ҳаққоният лозим аст"
+
+#: panels/sound/cc-alert-chooser.c:151
+msgid "Custom"
+msgstr "Иловагӣ"
+
+#: panels/sound/cc-alert-chooser.ui:12 panels/sound/cc-alert-selector.ui:9
+msgid "Bark"
+msgstr "Ав-ав"
+
+#: panels/sound/cc-alert-chooser.ui:19 panels/sound/cc-alert-selector.ui:15
+msgid "Drip"
+msgstr "Қатра"
+
+#: panels/sound/cc-alert-chooser.ui:26 panels/sound/cc-alert-selector.ui:21
+msgid "Glass"
+msgstr "Шиша"
+
+#: panels/sound/cc-alert-chooser.ui:33 panels/sound/cc-alert-selector.ui:27
+msgid "Sonar"
+msgstr "Садоӣ"
+
+#: panels/sound/cc-fade-slider.ui:13
+#, fuzzy
+#| msgctxt "balance"
+#| msgid "Rear"
+msgid "Rear"
+msgstr "Пушт"
+
+#: panels/sound/cc-fade-slider.ui:15
+#, fuzzy
+#| msgctxt "balance"
+#| msgid "Front"
+msgid "Front"
+msgstr "Пеш"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, fuzzy, c-format
+#| msgid "Settings"
+msgid "Testing %s"
+msgstr "Танзимот"
+
+#: panels/sound/cc-output-test-dialog.ui:127
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:29
+#, fuzzy
+#| msgid "System Sounds"
+msgid "System Volume"
+msgstr "Овозҳои низом"
+
+#: panels/sound/cc-sound-panel.ui:45
+#, fuzzy
+#| msgid "Volume mute"
+msgid "Volume Levels"
+msgstr "Бесадо кардан"
+
+#: panels/sound/cc-sound-panel.ui:67
+msgid "Output"
+msgstr "Барориш"
+
+#: panels/sound/cc-sound-panel.ui:94
+#, fuzzy
+#| msgid "_Output volume:"
+msgid "Output Device"
+msgstr "_Баландии садои барориш:"
+
+#: panels/sound/cc-sound-panel.ui:117
+msgid "Test"
+msgstr "Санҷиш"
+
+#: panels/sound/cc-sound-panel.ui:148 panels/sound/cc-sound-panel.ui:325
+msgid "Configuration"
+msgstr "Танзимот"
+
+#: panels/sound/cc-sound-panel.ui:181
+#, fuzzy
+#| msgid "_Balance:"
+msgid "Balance"
+msgstr "_Мувозина:"
+
+#: panels/sound/cc-sound-panel.ui:208
+#, fuzzy
+#| msgid "_Fade:"
+msgid "Fade"
+msgstr "_Шаффофӣ:"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Subwoofer"
+msgstr "Динамики паст-басомадӣ"
+
+#: panels/sound/cc-sound-panel.ui:257
+msgid "Input"
+msgstr "Вуруд"
+
+#: panels/sound/cc-sound-panel.ui:284
+#, fuzzy
+#| msgid "Input level:"
+msgid "Input Device"
+msgstr "Сатҳи вуруд:"
+
+#: panels/sound/cc-sound-panel.ui:358
+#, fuzzy
+#| msgid "Volume up"
+msgid "Volume"
+msgstr "Баланд кардан"
+
+#: panels/sound/cc-sound-panel.ui:380
+#, fuzzy
+#| msgid "_Alert volume:"
+msgid "Alert Sound"
+msgstr "_Баландии садои огоҳӣ:"
+
+#: panels/sound/cc-volume-slider.c:178
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Садо"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Тағйир додани сатҳи садо, вурудҳо, бароришҳо ва садоҳои огоҳӣ"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "Корт;Микрофон;Ҳаҷм;Шаффофӣ;Баланс;Bluetooth;Гӯшмонак;Аудио;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:94
+#: panels/thunderbolt/cc-bolt-device-entry.c:125
+#, fuzzy
+#| msgid "Disconnecting"
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Пайваст қатъ шуда истодааст"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:97
+#: panels/thunderbolt/cc-bolt-device-entry.c:128
+#, fuzzy
+#| msgid "Connecting"
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Пайваст шуда истодааст"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:100
+#: panels/thunderbolt/cc-bolt-device-entry.c:132
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+#, fuzzy
+#| msgid "Connected"
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Пайвастшуда"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:103
+#, fuzzy
+#| msgid "Authentication required"
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Санҷиши ҳаққоният лозим аст"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:106
+#: panels/thunderbolt/cc-bolt-device-entry.c:138
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:115
+#, fuzzy
+#| msgid "Connected Devices"
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Дастгоҳҳои пайвастшуда"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:121
+#: panels/thunderbolt/cc-bolt-device-entry.c:152
+#, fuzzy
+#| msgid "Unknown"
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Номаълум"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:177
+msgid "Authorized at:"
+msgstr ""
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:183
+#, fuzzy
+#| msgid "Connected"
+msgid "Connected at:"
+msgstr "Пайвастшуда"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:190
+#, fuzzy
+#| msgid "_Enroll"
+msgid "Enrolled at:"
+msgstr "_Илова кардан"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:264
+#, fuzzy
+#| msgid "Failed to upload file: %s"
+msgid "Failed to authorize device: "
+msgstr "Боркунии файл қатъ шуд: %s"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:333
+#, fuzzy
+#| msgid "Failed to upload file: %s"
+msgid "Failed to forget device: "
+msgstr "Боркунии файл қатъ шуд: %s"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:491
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:109
+msgid "Name:"
+msgstr "Ном:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "Status:"
+msgstr "Вазъият:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:174
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:324
+#, fuzzy
+#| msgid "Automatic _Connect"
+msgid "Authorize and Connect"
+msgstr "Паёвасти _худкор"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:346
+msgid "Forget Device"
+msgstr "Дастгоҳро аз руйхат комилан тоза намоед"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:135
+#, fuzzy
+#| msgid "Mirror"
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Оина"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:146
+#, fuzzy
+#| msgid "Authenticated"
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Ҳаққоният санҷида шуд"
+
+#: panels/thunderbolt/cc-bolt-panel.c:176
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:469
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:513
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.c:517
+#, fuzzy
+#| msgid "The profile could not be generated."
+msgid "Thunderbolt security level could not be determined."
+msgstr "Профил эҷод карда нашуд."
+
+#: panels/thunderbolt/cc-bolt-panel.c:622
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:143
+msgid "No Thunderbolt support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:246
+#, fuzzy
+#| msgid "Universal Access"
+msgid "Direct Access"
+msgstr "Дастрасии умумӣ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:269
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:289
+msgid "Only USB and Display Port devices can attach."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:397
+#, fuzzy
+#| msgid "Add Device"
+msgid "Pending Devices"
+msgstr "Илова кардани дастгоҳ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:535
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;"
+msgstr ""
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:498
+#, fuzzy
+#| msgid "Default"
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Пешфарз"
+
+#: panels/universal-access/cc-ua-panel.c:501
+#, fuzzy
+#| msgctxt "Calibration quality"
+#| msgid "Medium"
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Миёна"
+
+#: panels/universal-access/cc-ua-panel.c:504
+#, fuzzy
+#| msgctxt "dwell click threshold"
+#| msgid "Large"
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Бузург"
+
+#: panels/universal-access/cc-ua-panel.c:507
+#, fuzzy
+#| msgctxt "universal access, text size"
+#| msgid "Larger"
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Калонтар"
+
+#: panels/universal-access/cc-ua-panel.c:510
+#, fuzzy
+#| msgctxt "dwell click threshold"
+#| msgid "Large"
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Бузург"
+
+#: panels/universal-access/cc-ua-panel.c:514
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/universal-access/cc-ua-panel.ui:93
+msgid "_Always Show Universal Access Menu"
+msgstr "_Ҳамеша намоиш додани менюи дастрасии умумӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:135
+msgid "Seeing"
+msgstr "Дидан"
+
+#: panels/universal-access/cc-ua-panel.ui:181
+msgid "_High Contrast"
+msgstr "_Контрасти баланд"
+
+#: panels/universal-access/cc-ua-panel.ui:228
+msgid "_Large Text"
+msgstr "_Матни бузург"
+
+#: panels/universal-access/cc-ua-panel.ui:273
+msgid "C_ursor Size"
+msgstr "Андозаи курсор"
+
+#: panels/universal-access/cc-ua-panel.ui:320
+#: panels/universal-access/zoom-options.ui:99
+msgid "_Zoom"
+msgstr "_Танзими андоза"
+
+#: panels/universal-access/cc-ua-panel.ui:366
+msgid "Screen _Reader"
+msgstr "Хонандаи _экранӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:412
+#: panels/universal-access/cc-ua-panel.ui:1243
+msgid "_Sound Keys"
+msgstr "_Тугмаҳои садо"
+
+#: panels/universal-access/cc-ua-panel.ui:474
+msgid "Hearing"
+msgstr "Шунавоӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:518
+#: panels/universal-access/cc-ua-panel.ui:1346
+msgid "_Visual Alerts"
+msgstr "_Огоҳиҳои намоён"
+
+#: panels/universal-access/cc-ua-panel.ui:626
+msgid "Screen _Keyboard"
+msgstr "Клавиатураи _экранӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:671
+#, fuzzy
+#| msgid "Repeat Keys"
+msgid "R_epeat Keys"
+msgstr "Тугмаҳои такрорӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:717
+#, fuzzy
+#| msgid "Cursor Blinking"
+msgid "Cursor _Blinking"
+msgstr "Мижазании курсор"
+
+#: panels/universal-access/cc-ua-panel.ui:763
+msgid "_Typing Assist (AccessX)"
+msgstr "_Ёвари вуруд (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:824
+msgid "Pointing & Clicking"
+msgstr "Нишондиҳӣ ва зеркунӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:870
+msgid "_Mouse Keys"
+msgstr "_Тугмаҳои муш"
+
+#: panels/universal-access/cc-ua-panel.ui:915
+msgid "_Click Assist"
+msgstr "_Ёвари зеркунӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:961
+#, fuzzy
+#| msgid "_Double-click"
+msgid "_Double-Click Delay"
+msgstr "_Дубора зер кардан"
+
+#: panels/universal-access/cc-ua-panel.ui:981
+#, fuzzy
+#| msgid "_Double-click"
+msgid "Double-Click Delay"
+msgstr "_Дубора зер кардан"
+
+#: panels/universal-access/cc-ua-panel.ui:1048
+#, fuzzy
+#| msgid "Cursor blink speed"
+msgid "Cursor Size"
+msgstr "Суръати мижазании курсор"
+
+#: panels/universal-access/cc-ua-panel.ui:1075
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:1111
+msgid "Screen Reader"
+msgstr "Хонандаи экранӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:1128
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Хонандаи экранӣ матни нишоншударо аз рӯи фокус мехонад."
+
+#: panels/universal-access/cc-ua-panel.ui:1161
+msgid "_Screen Reader"
+msgstr "Хонандаи _экранӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:1200
+msgid "Sound Keys"
+msgstr "Тугмаҳои садо"
+
+#: panels/universal-access/cc-ua-panel.ui:1218
+#, fuzzy
+#| msgid "Beep when Num Lock or Caps Lock are turned on."
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Сигнали бип ҳангоми фаъол кардани Num Lock ё Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:1288
+msgid "Visual Alerts"
+msgstr "Огоҳиҳои намоён"
+
+#: panels/universal-access/cc-ua-panel.ui:1292
+msgid "_Test flash"
+msgstr "_Санҷидани мижазанӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:1321
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Истифода бурдани огоҳии визуалӣ ҳангоми пайдо шудани садои ҳушдор."
+
+#: panels/universal-access/cc-ua-panel.ui:1372
+msgid "Flash the _window title"
+msgstr "Мижазании _сарлавҳаи равзана"
+
+#: panels/universal-access/cc-ua-panel.ui:1390
+msgid "Flash the entire _screen"
+msgstr "Мижазании _экран"
+
+#: panels/universal-access/cc-ua-panel.ui:1435
+msgid "Repeat Keys"
+msgstr "Тугмаҳои такрорӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:1465
+#, fuzzy
+#| msgid "Key presses _repeat when key is held down"
+msgid "Key presses repeat when key is held down."
+msgstr "Пахшкуниҳои тугмаҳо ҳангоми пахш кардани тугма _такрор мешаванд"
+
+#: panels/universal-access/cc-ua-panel.ui:1545
+#, fuzzy
+#| msgid "Repeat keys speed"
+msgid "Repeat keys delay"
+msgstr "Суръати тугмаҳои такрорӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:1593
+#: panels/universal-access/cc-ua-panel.ui:1728
+#, fuzzy
+#| msgid "_Speed:"
+msgid "Speed"
+msgstr "_Суръат:"
+
+#: panels/universal-access/cc-ua-panel.ui:1632
+msgid "Repeat keys speed"
+msgstr "Суръати тугмаҳои такрорӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:1656
+msgid "Cursor Blinking"
+msgstr "Мижазании курсор"
+
+#: panels/universal-access/cc-ua-panel.ui:1686
+#, fuzzy
+#| msgid "Cursor _blinks in text fields"
+msgid "Cursor blinks in text fields."
+msgstr "Мижазании курсор дар _майдонҳои матнӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:1765
+#, fuzzy
+#| msgid "Cursor blink speed"
+msgid "Cursor blinking speed"
+msgstr "Суръати мижазании курсор"
+
+#: panels/universal-access/cc-ua-panel.ui:1801
+msgid "Typing Assist"
+msgstr "Ёвари вуруд"
+
+#: panels/universal-access/cc-ua-panel.ui:1840
+msgid "_Sticky Keys"
+msgstr "_Тугмаҳои часпак"
+
+#: panels/universal-access/cc-ua-panel.ui:1857
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Пайдарпайии тугмаҳои табдилдиҳандаро ҳамчун маҷмӯи тугмаҳо меҳисобад"
+
+#: panels/universal-access/cc-ua-panel.ui:1881
+msgid "_Disable if two keys are pressed together"
+msgstr "_Ғайрифаъол кунед, агар ду тугма якҷоя зер шаванд"
+
+#: panels/universal-access/cc-ua-panel.ui:1899
+msgid "Beep when a _modifier key is pressed"
+msgstr "_Сигнали бип ҳангоми пахш кардани тугмаи табдилдиҳанда"
+
+#: panels/universal-access/cc-ua-panel.ui:1947
+msgid "S_low Keys"
+msgstr "Тугмаҳои _суст"
+
+#: panels/universal-access/cc-ua-panel.ui:1964
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+"Таъин кардани таъхир дар байни зеркунии тугма ва қабулкунии тугмаи зершуда"
+
+#: panels/universal-access/cc-ua-panel.ui:1997
+#: panels/universal-access/cc-ua-panel.ui:2210
+#: panels/universal-access/cc-ua-panel.ui:2547
+msgid "A_cceptance delay:"
+msgstr "Таъхири қ_абулкунӣ:"
+
+#: panels/universal-access/cc-ua-panel.ui:2019
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Кӯтоҳ"
+
+#: panels/universal-access/cc-ua-panel.ui:2038
+msgid "Slow keys typing delay"
+msgstr "Таъхири тугмаҳои суст"
+
+#: panels/universal-access/cc-ua-panel.ui:2053
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Дароз"
+
+#: panels/universal-access/cc-ua-panel.ui:2080
+msgid "Beep when a key is pr_essed"
+msgstr "_Сигнали бип барои тугмаи _зершуда"
+
+#: panels/universal-access/cc-ua-panel.ui:2097
+msgid "Beep when a key is _accepted"
+msgstr "Сигнали бип барои тугмаи _қабулшуда"
+
+#: panels/universal-access/cc-ua-panel.ui:2114
+#: panels/universal-access/cc-ua-panel.ui:2293
+msgid "Beep when a key is _rejected"
+msgstr "Сигнали бип барои тугмаи _радшуда"
+
+#: panels/universal-access/cc-ua-panel.ui:2160
+msgid "_Bounce Keys"
+msgstr "_Тугмаҳои ҷаҳида"
+
+#: panels/universal-access/cc-ua-panel.ui:2177
+msgid "Ignores fast duplicate keypresses"
+msgstr "Пахшкуниҳои зуди такрориро нодида мегузаронад"
+
+#: panels/universal-access/cc-ua-panel.ui:2232
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Кӯтоҳ"
+
+#: panels/universal-access/cc-ua-panel.ui:2251
+msgid "Bounce keys typing delay"
+msgstr "Таъхири чопи тугмаҳои ҷаҳида"
+
+#: panels/universal-access/cc-ua-panel.ui:2266
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Дароз"
+
+#: panels/universal-access/cc-ua-panel.ui:2379
+msgid "_Enable by Keyboard"
+msgstr "_Фаъол кардан бо клавиатура"
+
+#: panels/universal-access/cc-ua-panel.ui:2396
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"Хусусиятҳои қобилияти дастрасиро ба воситаи клавиатура фаъол ва хомӯш мекунад"
+
+#: panels/universal-access/cc-ua-panel.ui:2460
+msgid "Click Assist"
+msgstr "Ёвари зеркунӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:2496
+msgid "_Simulated Secondary Click"
+msgstr "_Шабеҳсозии зеркунии иловагӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:2514
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Ба ҷо овардани зеркунии иловагӣ бо нигоҳ доштани тугмаи асосӣ"
+
+#: panels/universal-access/cc-ua-panel.ui:2568
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Кӯтоҳ"
+
+#: panels/universal-access/cc-ua-panel.ui:2587
+msgid "Secondary click delay"
+msgstr "Таъхири зеркунии дуюм"
+
+#: panels/universal-access/cc-ua-panel.ui:2602
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Дароз"
+
+#: panels/universal-access/cc-ua-panel.ui:2659
+msgid "_Hover Click"
+msgstr "_Зеркунӣ дар боло"
+
+#: panels/universal-access/cc-ua-panel.ui:2677
+msgid "Trigger a click when the pointer hovers"
+msgstr "Ба ҷо овардани зеркунӣ ҳангоми боло нигаҳ доштани нишондиҳанда"
+
+#: panels/universal-access/cc-ua-panel.ui:2710
+msgid "D_elay:"
+msgstr "_Таъхир:"
+
+#: panels/universal-access/cc-ua-panel.ui:2732
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Кӯтоҳ"
+
+#: panels/universal-access/cc-ua-panel.ui:2763
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Дароз"
+
+#: panels/universal-access/cc-ua-panel.ui:2799
+msgid "Motion _threshold:"
+msgstr "Остонаи ҳ_аракат:"
+
+#: panels/universal-access/cc-ua-panel.ui:2821
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Хурд"
+
+#: panels/universal-access/cc-ua-panel.ui:2852
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Бузург"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Осон кардани дидан, шунидан, нуқта гузоштан ва зер кардан"
+
+#. Translators: Search terms to find the Universal Access panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+#| msgid ""
+#| "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;"
+#| "size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;"
+"big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;"
+"click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
+msgstr ""
+"Клавиатура;Муш;a11y;Қобилияти дастрасӣ;Контраст;Танзими андоза;Хонанда;Экран;"
+"матн;шрифт;андоза;AccessX;Тугмаҳои часпак;Тугмаҳои суст;Тугмаҳои ҷаҳиш;"
+"Тугмаҳои муш;"
+
+#: panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "Short"
+msgstr "Кӯтоҳ"
+
+#: panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "Экрани ¼"
+
+#: panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "Экрани ½"
+
+#: panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "Экрани ¾"
+
+#: panels/universal-access/zoom-options.c:338
+msgctxt "Distance"
+msgid "Long"
+msgstr "Дароз"
+
+#: panels/universal-access/zoom-options.ui:48
+msgid "Full Screen"
+msgstr "Экрани пурра"
+
+#: panels/universal-access/zoom-options.ui:53
+msgid "Top Half"
+msgstr "Ними боло"
+
+#: panels/universal-access/zoom-options.ui:58
+msgid "Bottom Half"
+msgstr "Ними поён"
+
+#: panels/universal-access/zoom-options.ui:63
+msgid "Left Half"
+msgstr "Ними чап"
+
+#: panels/universal-access/zoom-options.ui:68
+msgid "Right Half"
+msgstr "Ними рост"
+
+#: panels/universal-access/zoom-options.ui:78
+msgid "Zoom Options"
+msgstr "Имконоти танзими андоза"
+
+#: panels/universal-access/zoom-options.ui:185
+#, fuzzy
+#| msgid "Magnification:"
+msgid "_Magnification:"
+msgstr "Бузургнамоӣ:"
+
+#: panels/universal-access/zoom-options.ui:249
+#, fuzzy
+#| msgid "Follow mouse cursor"
+msgid "_Follow mouse cursor"
+msgstr "Пайгирӣ кардани курсори муш"
+
+#: panels/universal-access/zoom-options.ui:269
+#, fuzzy
+#| msgid "Screen part:"
+msgid "_Screen part:"
+msgstr "Қисми экран:"
+
+#: panels/universal-access/zoom-options.ui:331
+#, fuzzy
+#| msgid "Magnifier extends outside of screen"
+msgid "Magnifier _extends outside of screen"
+msgstr "Бузургнамо берун аз экран густариш меёбад"
+
+#: panels/universal-access/zoom-options.ui:350
+#, fuzzy
+#| msgid "Keep magnifier cursor centered"
+msgid "_Keep magnifier cursor centered"
+msgstr "Нигоҳ доштани курсори бузургнамо дар марказ"
+
+#: panels/universal-access/zoom-options.ui:369
+#, fuzzy
+#| msgid "Magnifier cursor pushes contents around"
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Курсори бузургнамо муҳтаворо идора мекунад"
+
+#: panels/universal-access/zoom-options.ui:388
+#, fuzzy
+#| msgid "Magnifier cursor moves with contents"
+msgid "Magnifier cursor moves with _contents"
+msgstr "Курсори бузургнамо якҷоя бо муҳтаво интиқол меёбад"
+
+#: panels/universal-access/zoom-options.ui:422
+msgid "Magnifier Position:"
+msgstr "Ҷойгиршавии бузургнамо:"
+
+#: panels/universal-access/zoom-options.ui:443
+msgid "Magnifier"
+msgstr "Бузургнамо"
+
+#: panels/universal-access/zoom-options.ui:490
+#, fuzzy
+#| msgid "Thickness:"
+msgid "_Thickness:"
+msgstr "Ғафсӣ:"
+
+#: panels/universal-access/zoom-options.ui:516
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Тунук"
+
+#: panels/universal-access/zoom-options.ui:548
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Ғафс"
+
+#: panels/universal-access/zoom-options.ui:574
+#, fuzzy
+#| msgid "Length:"
+msgid "_Length:"
+msgstr "Давомнокӣ:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/zoom-options.ui:623
+#, fuzzy
+#| msgid "Color:"
+msgid "Co_lor:"
+msgstr "Ранг:"
+
+#: panels/universal-access/zoom-options.ui:687
+#, fuzzy
+#| msgid "Crosshairs:"
+msgid "_Crosshairs:"
+msgstr "Нишонгирӣ:"
+
+#: panels/universal-access/zoom-options.ui:735
+#, fuzzy
+#| msgid "Overlaps mouse cursor"
+msgid "_Overlaps mouse cursor"
+msgstr "Курсори мушро ҳампӯшонӣ мекунад"
+
+#: panels/universal-access/zoom-options.ui:773
+msgid "Crosshairs"
+msgstr "Нишонгирӣ"
+
+#: panels/universal-access/zoom-options.ui:822
+#, fuzzy
+#| msgid "White on black:"
+msgid "_White on black:"
+msgstr "Сафеду сиёҳ:"
+
+#: panels/universal-access/zoom-options.ui:842
+#, fuzzy
+#| msgid "Brightness:"
+msgid "_Brightness:"
+msgstr "Равшанӣ:"
+
+#: panels/universal-access/zoom-options.ui:863
+#, fuzzy
+#| msgid "Contrast:"
+msgid "_Contrast:"
+msgstr "Контраст:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/zoom-options.ui:883
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/zoom-options.ui:908
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Ҳеҷ"
+
+#: panels/universal-access/zoom-options.ui:940
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Пурра"
+
+#: panels/universal-access/zoom-options.ui:1003
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Паст"
+
+#: panels/universal-access/zoom-options.ui:1036
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Баланд"
+
+#: panels/universal-access/zoom-options.ui:1067
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Паст"
+
+#: panels/universal-access/zoom-options.ui:1100
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Баланд"
+
+#: panels/universal-access/zoom-options.ui:1136
+msgid "Color Effects:"
+msgstr "Таъсирҳои ранг:"
+
+#: panels/universal-access/zoom-options.ui:1161
+msgid "Color Effects"
+msgstr "Таъсирҳои ранг"
+
+#: panels/user-accounts/cc-add-user-dialog.c:34
+#, fuzzy
+#| msgid "Should match the web address of your account provider."
+msgid "Should match the web address of your login provider."
+msgstr "Бояд ба суроғаи веби ҳисоби провайдери шумо мувофиқ бошад."
+
+#: panels/user-accounts/cc-add-user-dialog.c:204
+msgid "Failed to add account"
+msgstr "Иловакунии ҳисоб қатъ шуд"
+
+#: panels/user-accounts/cc-add-user-dialog.c:652
+#: panels/user-accounts/cc-password-dialog.c:261
+msgid "The passwords do not match."
+msgstr "Ниҳонвожаҳо мувофиқат намекунанд."
+
+#: panels/user-accounts/cc-add-user-dialog.c:874
+#: panels/user-accounts/cc-add-user-dialog.c:920
+#: panels/user-accounts/cc-add-user-dialog.c:941
+msgid "Failed to register account"
+msgstr "Қайдкунии ҳисоб қатъ шуд"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1064
+msgid "No supported way to authenticate with this domain"
+msgstr ""
+"Ягон имконияти дастгирӣ барои санҷиши ҳаққоният бо ин домен вуҷуд надорад"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1137
+msgid "Failed to join domain"
+msgstr "Ҳамроҳ шудан ба домен қатъ шуд"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1198
+#, fuzzy
+#| msgid ""
+#| "That login name didn't work.\n"
+#| "Please try again."
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Номи вуруд нодуруст аст.\n"
+"Лутфан амалро такрор кунед."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1205
+#, fuzzy
+#| msgid ""
+#| "That login password didn't work.\n"
+#| "Please try again."
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Ниҳонвожаи вуруд нодуруст аст.\n"
+"Лутфан амалро такрор кунед."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1213
+msgid "Failed to log into domain"
+msgstr "Ворид шудан ба домен қатъ шуд"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1271
+#, fuzzy
+#| msgid "Unable find the domain. Maybe you misspelled it?"
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Домен ёфт нашуд. Эҳтимол аст, ки шумо онро хатогӣ ворид кардед?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:18
+#: panels/user-accounts/data/join-dialog.ui:11
+msgid "Add User"
+msgstr "Илова кардани корбар"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:180
+msgid "_Full Name"
+msgstr "_Номи пурра"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:206
+#: panels/user-accounts/cc-user-panel.ui:151
+#, fuzzy
+#| msgctxt "Account type"
+#| msgid "Standard"
+msgid "Standard"
+msgstr "Стандартӣ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:216
+#: panels/user-accounts/cc-user-panel.ui:161
+#, fuzzy
+#| msgctxt "Account type"
+#| msgid "Administrator"
+msgid "Administrator"
+msgstr "Маъмур"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:232
+#: panels/user-accounts/cc-user-panel.ui:179
+msgid "Account _Type"
+msgstr "_Намуди ҳисоб"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:269
+#, fuzzy
+#| msgid "Allow user to set a password when they next login"
+msgid "Allow user to set a password when they next _login"
+msgstr ""
+"Ба корбар иҷозат диҳед, ки ҳангоми воридшавии навбатӣ ниҳонвожаеро барпо "
+"кунад"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:283
+#, fuzzy
+#| msgid "Set a password now"
+msgid "Set a password _now"
+msgstr "Ниҳонвожаро ҳозир таъин кунед"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:405
+#, fuzzy
+#| msgid "_Confirm Password"
+msgid "_Confirm"
+msgstr "_Тасдиқ кардани ниҳонвожа"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:485
+#: panels/user-accounts/cc-add-user-dialog.ui:692
+#, fuzzy
+#| msgid ""
+#| "Enterprise login allows an existing centrally managed user account to be "
+#| "used on this device."
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Вуруди Enterprise иҷозат медиҳад, ки тавонед ҳисоби корбари идорашавандаи "
+"марказии мавҷудбударо дар ин дастгоҳ истифода баред."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:507
+#: panels/user-accounts/data/join-dialog.ui:116
+msgid "_Domain"
+msgstr "_Домен"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:732
+#, fuzzy
+#| msgctxt "printer state"
+#| msgid "Offline"
+msgid "You are Offline"
+msgstr "Офлайн"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:751
+#, fuzzy
+#| msgid ""
+#| "Go online to add\n"
+#| "enterprise login accounts."
+msgid "You must be online in order to add enterprise users."
+msgstr ""
+"Барои илова кардани ҳисобҳои\n"
+"Enterprise ба онлайн гузаред."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:782
+msgid "_Enterprise Login"
+msgstr "_Воридшавии корӣ"
+
+#: panels/user-accounts/cc-avatar-chooser.c:231
+msgid "Browse for more pictures"
+msgstr "Тамошо кардани тасвирҳои дигар"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:27
+#, fuzzy
+#| msgid "Take a photo…"
+msgid "Take a Picture…"
+msgstr "Гирифтани сурат..."
+
+#: panels/user-accounts/cc-avatar-chooser.ui:34
+#, fuzzy
+#| msgid "Select PPD File"
+msgid "Select a File…"
+msgstr "Интихоби файли PPD"
+
+#: panels/user-accounts/cc-login-history-dialog.c:69
+msgid "This Week"
+msgstr "Ҳафтаи ҷорӣ"
+
+#: panels/user-accounts/cc-login-history-dialog.c:72
+msgid "Last Week"
+msgstr "Ҳафтаи гузашта"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:82
+#: panels/user-accounts/cc-login-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:91
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%b %e, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:96
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr ""
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:173
+#: panels/user-accounts/cc-user-panel.c:770
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:176
+#: panels/user-accounts/cc-user-panel.c:774
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:243
+msgid "Session Ended"
+msgstr "Ҷаласа хотима ёфт"
+
+#: panels/user-accounts/cc-login-history-dialog.c:249
+msgid "Session Started"
+msgstr "Ҷаласа оғоз ёфт"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:343
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Фаъолияти ҳисоб"
+
+#: panels/user-accounts/cc-password-dialog.c:125
+msgid "Please choose another password."
+msgstr "Лутфан, ниҳонвожаи дигареро интихоб кунед."
+
+#: panels/user-accounts/cc-password-dialog.c:134
+msgid "Please type your current password again."
+msgstr "Лутфан, ниҳонвожаи ҷории худро ворид кунед."
+
+#: panels/user-accounts/cc-password-dialog.c:140
+msgid "Password could not be changed"
+msgstr "Ниҳонвожа тағйир дода намешавад"
+
+#: panels/user-accounts/cc-password-dialog.ui:7
+msgid "Change Password"
+msgstr "Тағйир додани ниҳонвожа"
+
+#: panels/user-accounts/cc-password-dialog.ui:37
+msgid "Ch_ange"
+msgstr "_Тағйир додан"
+
+#: panels/user-accounts/cc-password-dialog.ui:145
+msgid "_Confirm New Password"
+msgstr "_Тасдиқ кардани ниҳонвожаи нав"
+
+#: panels/user-accounts/cc-password-dialog.ui:162
+msgid "_New Password"
+msgstr "_Ниҳонвожаи нав"
+
+#: panels/user-accounts/cc-password-dialog.ui:216
+msgid "Current _Password"
+msgstr "_Ниҳонвожаи ҷорӣ"
+
+#: panels/user-accounts/cc-password-dialog.ui:254
+msgid "Allow user to change their password on next login"
+msgstr ""
+"Ба корбар иҷозат диҳед, ки ҳангоми воридшавии навбатӣ ниҳонвожаеро иваз "
+"намояд"
+
+#: panels/user-accounts/cc-password-dialog.ui:267
+msgid "Set a password now"
+msgstr "Ниҳонвожаро ҳозир таъин кунед"
+
+#: panels/user-accounts/cc-realm-manager.c:307
+msgid "Cannot automatically join this type of domain"
+msgstr "Ба ин намуди домен ба таври худкор пайваст намешавад"
+
+#: panels/user-accounts/cc-realm-manager.c:310
+msgid "No such domain or realm found"
+msgstr "Ягон домен ё соҳиб ёфт нашудааст"
+
+#: panels/user-accounts/cc-realm-manager.c:732
+#: panels/user-accounts/cc-realm-manager.c:746
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Ҳамчун %s ба домени %s пайваст намешавад"
+
+#: panels/user-accounts/cc-realm-manager.c:738
+msgid "Invalid password, please try again"
+msgstr "Ниҳонвожаи нодуруст, лутфан амалро такрор кунед"
+
+#: panels/user-accounts/cc-realm-manager.c:751
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Ба домени %s пайваст нашуд: %s"
+
+#: panels/user-accounts/cc-user-panel.c:213
+msgid "Your account"
+msgstr "Ҳисоби шумо"
+
+#: panels/user-accounts/cc-user-panel.c:388
+msgid "Failed to delete user"
+msgstr "Несткунии корбар қатъ шуд"
+
+#: panels/user-accounts/cc-user-panel.c:446
+#: panels/user-accounts/cc-user-panel.c:505
+#: panels/user-accounts/cc-user-panel.c:557
+msgid "Failed to revoke remotely managed user"
+msgstr "Бекоркунии корбари идорашавандаи дурдаст иҷро нашуд"
+
+#: panels/user-accounts/cc-user-panel.c:609
+msgid "You cannot delete your own account."
+msgstr "Шумо наметавонед ҳисоби худро нест кунед."
+
+#: panels/user-accounts/cc-user-panel.c:618
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s то ҳол воридшуда мебошад"
+
+#: panels/user-accounts/cc-user-panel.c:622
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Несткунии корбари воридшуда метавонад низомро ба ҳолати номунтаззам дарорад."
+
+#: panels/user-accounts/cc-user-panel.c:631
+#, fuzzy, c-format
+#| msgid "Do you want to keep %s's files?"
+msgid "Do you want to keep %s’s files?"
+msgstr "Шумо мехоҳед, ки файлҳои %s-ро нигоҳ доред?"
+
+#: panels/user-accounts/cc-user-panel.c:635
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Ҳангоми нест кардани ҳисоби корбар шумо метавонед директорияи аслӣ, файлҳои "
+"навбати почта ва файлҳои муваққатиро нигоҳ доред."
+
+#: panels/user-accounts/cc-user-panel.c:638
+msgid "_Delete Files"
+msgstr "_Нест кардани файлҳо"
+
+#: panels/user-accounts/cc-user-panel.c:639
+msgid "_Keep Files"
+msgstr "_Нигоҳ доштани файлҳо"
+
+#: panels/user-accounts/cc-user-panel.c:653
+#, fuzzy, c-format
+#| msgid "Are you sure you want to revoke remotely managed %s's account?"
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Шумо мутмаин ҳастед, ки мехоҳед ҳисоби корбари идорашавандаи дурдасти %s "
+"бекор кунед?"
+
+#: panels/user-accounts/cc-user-panel.c:657
+msgid "_Delete"
+msgstr "_Нест кардан"
+
+#: panels/user-accounts/cc-user-panel.c:707
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Ҳисоб ғайрифаъол аст"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Ҳангоми воридшавии навбатӣ таъин карда мешавад"
+
+#: panels/user-accounts/cc-user-panel.c:718
+msgctxt "Password mode"
+msgid "None"
+msgstr "Ҳеҷ"
+
+#: panels/user-accounts/cc-user-panel.c:763
+msgid "Logged in"
+msgstr "Ворид шудааст"
+
+#: panels/user-accounts/cc-user-panel.c:1093
+msgid "Failed to contact the accounts service"
+msgstr "Тамосгирӣ бо хадамоти ҳисобҳо қатъ шуд"
+
+#: panels/user-accounts/cc-user-panel.c:1095
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr ""
+"Лутфан, мутмаин шавед, ки AccountService насб шудааст ва дар ҳоли иҷро "
+"мебошад."
+
+#. Translator comments:
+#. * We split the line in 2 here to "make it look good", as there's
+#. * no good way to do this in GTK+ for tooltips. See:
+#. * https://bugzilla.gnome.org/show_bug.cgi?id=657168
+#: panels/user-accounts/cc-user-panel.c:1127
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"Барои даровардани тағйирот,\n"
+"аввал нишонаи \"*\"-ро зер кунед"
+
+#: panels/user-accounts/cc-user-panel.c:1200
+msgid "Create a user account"
+msgstr "Эҷод кардани ҳисоби корбар"
+
+#: panels/user-accounts/cc-user-panel.c:1211
+#: panels/user-accounts/cc-user-panel.c:1339
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"Барои эҷод кардани ҳисоби корбар,\n"
+"пеш аз ҳама нишонаи * -ро зер кунед"
+
+#: panels/user-accounts/cc-user-panel.c:1220
+msgid "Delete the selected user account"
+msgstr "Нест кардани ҳисоби корбари интихобшуда"
+
+#: panels/user-accounts/cc-user-panel.c:1232
+#: panels/user-accounts/cc-user-panel.c:1343
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Барои нест кардани ҳисоби корбари интихобшуда,\n"
+"пеш аз ҳама нишонаи * -ро зер кунед"
+
+#: panels/user-accounts/cc-user-panel.ui:18
+#, fuzzy
+#| msgid "Add User"
+msgid "_Add User…"
+msgstr "Илова кардани корбар"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Барои татбиқ кардани тағйирот шумо бояд низомро бозоғозӣ кунед"
+
+#: panels/user-accounts/cc-user-panel.ui:78
+msgid "Restart Now"
+msgstr "Ҳозир бозоғозӣ кардан"
+
+#: panels/user-accounts/cc-user-panel.ui:254
+msgid "A_utomatic Login"
+msgstr "_Воридшавии худкор"
+
+#: panels/user-accounts/cc-user-panel.ui:296
+msgid "_Fingerprint Login"
+msgstr "_Воридшавӣ бо нақши ангушт"
+
+#: panels/user-accounts/cc-user-panel.ui:322
+#: panels/user-accounts/cc-user-panel.ui:338
+msgid "User Icon"
+msgstr "Нишонаи корбар"
+
+#: panels/user-accounts/cc-user-panel.ui:402
+msgid "Last Login"
+msgstr "Воридшавии охирин"
+
+#: panels/user-accounts/cc-user-panel.ui:451
+#, fuzzy
+#| msgid "Remove User Account"
+msgid "Remove User…"
+msgstr "Тоза кардани ҳисоби корбар"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:484
+#, fuzzy
+#| msgid "No Pictures Found"
+msgid "No Users Found"
+msgstr "Ягон тасвир ёфт нашудааст"
+
+#: panels/user-accounts/cc-user-panel.ui:494
+#, fuzzy
+#| msgid "Create a user account"
+msgid "Unlock to add a user account."
+msgstr "Эҷод кардани ҳисоби корбар"
+
+#: panels/user-accounts/data/account-fingerprint.ui:12
+msgid "Left thumb"
+msgstr "Сарангушти чап"
+
+#: panels/user-accounts/data/account-fingerprint.ui:15
+msgid "Left middle finger"
+msgstr "Ангушти миёнаи чап"
+
+#: panels/user-accounts/data/account-fingerprint.ui:18
+msgid "Left ring finger"
+msgstr "Ангушти ҳалқаи чап"
+
+#: panels/user-accounts/data/account-fingerprint.ui:21
+msgid "Left little finger"
+msgstr "Ангушти хурди чап"
+
+#: panels/user-accounts/data/account-fingerprint.ui:24
+msgid "Right thumb"
+msgstr "Сарангушти рост"
+
+#: panels/user-accounts/data/account-fingerprint.ui:27
+msgid "Right middle finger"
+msgstr "Ангушти миёнаи рост"
+
+#: panels/user-accounts/data/account-fingerprint.ui:30
+msgid "Right ring finger"
+msgstr "Ангушти ҳалқаи рост"
+
+#: panels/user-accounts/data/account-fingerprint.ui:33
+msgid "Right little finger"
+msgstr "Ангушти хурди рост"
+
+#: panels/user-accounts/data/account-fingerprint.ui:39
+#: panels/user-accounts/um-fingerprint-dialog.c:677
+msgid "Enable Fingerprint Login"
+msgstr "Фаъол кардани воридшавӣ бо нақши ангушт"
+
+#: panels/user-accounts/data/account-fingerprint.ui:89
+msgid "_Right index finger"
+msgstr "_Ангушти ишорати рост"
+
+#: panels/user-accounts/data/account-fingerprint.ui:105
+msgid "_Left index finger"
+msgstr "_Ангушти ишорати чап "
+
+#: panels/user-accounts/data/account-fingerprint.ui:126
+msgid "_Other finger:"
+msgstr "_Ангушти дигар:"
+
+#: panels/user-accounts/data/account-fingerprint.ui:262
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr ""
+"Нақши ангушти шумо бо муваффақият захира шудааст. Акнун шумо метавонед "
+"тавассути хонандаи нақши ангуштон ворид шавед."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Корбарон"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Илова ё тоза кардани корбарон ва тағйир додани ниҳонвожаи худ"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Воридшавӣ;Ном;Нақши ангушт;Аватар;Тамға;Рӯй;Ниҳонвожа;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:39
+msgid "_Enroll"
+msgstr "_Илова кардан"
+
+#: panels/user-accounts/data/join-dialog.ui:75
+msgid "Domain Administrator Login"
+msgstr "Воридшавии маъмури домен"
+
+#: panels/user-accounts/data/join-dialog.ui:93
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Барои истифодаи воридшавиҳои корӣ, ин компютер бояд\n"
+"ба домен дохил шуда бошад. Лутфан, аз маъмури шабакаи худ пурсед, ки\n"
+"ниҳонвожаи домени худро дар ин ҷо ворид намояд."
+
+#: panels/user-accounts/data/join-dialog.ui:150
+msgid "Administrator _Name"
+msgstr "Номи _маъмур"
+
+#: panels/user-accounts/data/join-dialog.ui:185
+msgid "Administrator Password"
+msgstr "Ниҳонвожаи маъмур"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Идоракунии ҳисобҳои корбар"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Барои тағйир додани маълумоти корбар, санҷиши ҳаққоният лозим аст"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Ниҳонвожаи нав бояд аз ниҳонвожаи кӯҳна фарқ кунад."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Баъзе ҳарфҳо ва рақамҳоро тағйир диҳед."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Ниҳонвожаи худро каме мураккаб кунед."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Ниҳонвожа бе номи корбар қавитар мешавад."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Номи худро дар ниҳонвожа истифода набаред."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Баъзе калимаҳоро аз ниҳонвожа истисно кунед."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Калимаҳои оддиро истифода набаред."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Тартиби калимаҳои мавҷудбударо иваз накунед."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Бештар рақамҳоро истифода баред."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Бештар ҳарфҳои калонро истифода баред."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Бештар ҳарфҳои хурдро истифода баред."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Бештар аломатҳои маҳсусро, монанди нуқтагузорӣ, истифода баред."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Аралаши калимаҳо, рақамҳо ва нуқтагузориро истифода баред."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Аломатҳои такрориро истифода набаред."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Аломатҳои такрориро истифода набаред: шумо бояд ҳарфҳо, рақамҳо ва "
+"нуқтагузориро аралаш кунед."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Мунтазамии рақамҳоро монанди 1234 ё abcd истифода набаред."
+
+#: panels/user-accounts/pw-utils.c:128
+#, fuzzy
+#| msgctxt "Password hint"
+#| msgid "Try to use a mixture of letters, numbers and punctuation."
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr "Аралаши калимаҳо, рақамҳо ва нуқтагузориро истифода баред."
+
+#: panels/user-accounts/pw-utils.c:130
+#, fuzzy
+#| msgctxt "Password hint"
+#| msgid "Mix uppercase and lowercase and use a number or two."
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr ""
+"Ҳарфҳои хурду калонро аралаш кунед ва як ё якчанд рақамро истифода баред."
+
+#: panels/user-accounts/pw-utils.c:132
+#, fuzzy
+#| msgctxt "Password hint"
+#| msgid ""
+#| "Good password! Adding more letters, numbers and punctuation will make it "
+#| "stronger."
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Ниҳонвожаи хуб! Агар бештар калимаҳо, рақамҳо ва нуқтагузориро илова кунед, "
+"ниҳонвожаро қавитар мекунед."
+
+#: panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "Санҷиши ҳаққоният қатъ шудааст"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "Ниҳонвожаи нав хеле кӯтоҳ аст"
+
+#: panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "Ниҳонвожаи нав хеле осон аст"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Ниҳонвожаи нав ва кӯҳна хеле монанданд"
+
+#: panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Ниҳонвожаи нав аллакай истифода шуда буд."
+
+#: panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Ниҳонвожаи нав бояд аломатҳои рақамӣ ва махсусро дар бар гирад"
+
+#: panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Ниҳонвожаи нав ва кӯҳна мувофиқат мекунанд"
+
+#: panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Баъд аз воридшавии вақти аввалин ниҳонвожаи шумо тағйир ёфт!"
+
+#: panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Ниҳонвожаи нав аломатҳои дигаргунро дар бар намегирад"
+
+#: panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "Хатогии номаълум"
+
+#: panels/user-accounts/user-utils.c:430
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr ""
+
+#: panels/user-accounts/user-utils.c:433
+#, c-format
+msgid "The username is too long."
+msgstr "Номи корбар хеле дароз аст."
+
+#: panels/user-accounts/user-utils.c:436
+#, fuzzy
+#| msgid "The username cannot start with a '-'."
+msgid "The username cannot start with a “-”."
+msgstr "Номи корбар бояд бо '-' сар нашавад."
+
+#: panels/user-accounts/user-utils.c:439
+#, fuzzy
+#| msgid ""
+#| "The username should only consist of lower and upper case letters from a-"
+#| "z, digits and any of characters '.', '-' and '_'."
+msgid ""
+"The username should only consist of upper and lower case letters from a-z, "
+"digits and the following characters: . - _"
+msgstr ""
+"Номи корбар бояд аз ҳарфҳои хурду калон (аз a то z), рақамҳо ва аз аломатҳои "
+"'.', '-' ва '_' иборат шавад."
+
+#: panels/user-accounts/user-utils.c:443
+#, fuzzy
+#| msgid "This will be used to name your home folder and can't be changed."
+msgid "This will be used to name your home folder and can’t be changed."
+msgstr ""
+"Ин барои номи ҷузвдони асосӣ истифода мешавад ва тағйир дода намешавад."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+"Шумо барои истифодаи ин дастгоҳ иҷозат надоред. Бо маъмури низоми худ дар "
+"тамос шавед."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "Дастгоҳ аллакай истифода шудааст."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr "Хатои дарунӣ ба вуҷуд омад."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Enabled"
+msgstr "Фаъол"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:260
+msgid "Delete registered fingerprints?"
+msgstr "Нақши ангуштони қайдшударо нест мекунед?"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:264
+msgid "_Delete Fingerprints"
+msgstr "_Нест кардани нақши ангуштон"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:270
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Шумо мехоҳед, ки барои ғайрифаъол кардани воридшавӣ тавассути нақши ангушт, "
+"нақшҳои ангуштони қайдшударо нест кунед?"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:440
+msgid "Done!"
+msgstr "Тайёр!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:501
+#: panels/user-accounts/um-fingerprint-dialog.c:543
+#, fuzzy, c-format
+#| msgid "Could not access '%s' device"
+msgid "Could not access “%s” device"
+msgstr "Дастгоҳи '%s' кушода нашуд"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: panels/user-accounts/um-fingerprint-dialog.c:584
+#, fuzzy, c-format
+#| msgid "Could not start finger capture on '%s' device"
+msgid "Could not start finger capture on “%s” device"
+msgstr "Муайянкунии ангушт дар дастгоҳи '%s' оғоз нашуд"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:628
+msgid "Could not access any fingerprint readers"
+msgstr "Ягон хонандаи нақши ангушт дастрас нест"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:629
+msgid "Please contact your system administrator for help."
+msgstr ""
+"Лутфан, барои гирифтани дастгирӣ ба маъмури низоми худ муроҷиат намоед."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: panels/user-accounts/um-fingerprint-dialog.c:711
+#, fuzzy, c-format
+#| msgid ""
+#| "To enable fingerprint login, you need to save one of your fingerprints, "
+#| "using the '%s' device."
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the “%s” device."
+msgstr ""
+"Барои фаъол кардани воридшавӣ тавассути нақши ангушт, шумо бояд тавассути "
+"дастгоҳи \"%s\" яке аз нақшҳои ангушти худро захира кунед."
+
+#: panels/user-accounts/um-fingerprint-dialog.c:718
+msgid "Selecting finger"
+msgstr "Интихоби ангушт"
+
+#: panels/user-accounts/um-fingerprint-dialog.c:719
+msgid "Enrolling fingerprints"
+msgstr "Қайдкунии нақши ангуштон"
+
+#: panels/wacom/button-mapping.ui:9
+msgid "Map Buttons"
+msgstr "Нишона гузоштани тугмаҳо"
+
+#: panels/wacom/button-mapping.ui:37 panels/wacom/cc-wacom-page.c:533
+#: panels/wacom/gnome-wacom-properties.ui:60
+msgid "_Close"
+msgstr "_Пӯшидан"
+
+#: panels/wacom/button-mapping.ui:71
+msgid "Map buttons to functions"
+msgstr "Нишона гузоштани тугмаҳо ба функсияҳо"
+
+#: panels/wacom/button-mapping.ui:119
+#, fuzzy
+#| msgid ""
+#| "To edit a shortcut, choose the \"Send Keystroke\" action, press the "
+#| "keyboard shortcut button and hold down the new keys or press Backspace to "
+#| "clear."
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Барои таҳрир кардани миёнбур, амали \"Фиристодани пахши тугмаҳо\"-ро интихоб "
+"кунед, тугмаи миёнбурро дар клавиатура зер кунед ва тугмаҳои навро таъин "
+"кунед, ё ки барои пок кардан тугмаи Backspace-ро пахш кунед."
+
+#: panels/wacom/calibrator/calibrator.ui:60
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Лутфан, барои санҷидани планшет маркерҳои ҳадафиро ҳангоми пайдо шудани "
+"онгҳо зарба занед."
+
+#: panels/wacom/calibrator/calibrator.ui:77
+#, fuzzy
+#| msgid "Mis-click detected, restarting..."
+msgid "Mis-click detected, restarting…"
+msgstr "Зеркунии нодуруст ташхис карда шуд, бозоғозӣ шуда истодааст..."
+
+#: panels/wacom/cc-wacom-button-row.c:253
+#, c-format
+msgid "Button %d"
+msgstr "Тугмаи %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Барномаи муайяншуда"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Фиристодани пахши тугмаҳо"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Қатъу васл кардани монитор"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Намоиш додани кумаки экранӣ"
+
+#: panels/wacom/cc-wacom-mapping-panel.c:256
+msgid "Output:"
+msgstr "Барориш:"
+
+#. Keep ratio switch
+#: panels/wacom/cc-wacom-mapping-panel.c:268
+msgid "Keep aspect ratio (letterbox):"
+msgstr "Нигоҳ доштани таносуб (қуттии почта):"
+
+#. Whole-desktop checkbox
+#: panels/wacom/cc-wacom-mapping-panel.c:279
+msgid "Map to single monitor"
+msgstr "Нишона гузоштан ба монитори ягона"
+
+#: panels/wacom/cc-wacom-nav-button.c:84
+#, c-format
+msgid "%d of %d"
+msgstr "%d аз %d"
+
+#: panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "Нақшабандии дисплей"
+
+#: panels/wacom/cc-wacom-panel.c:845 panels/wacom/wacom-stylus-page.ui:119
+msgid "Stylus"
+msgstr "Қалам"
+
+#: panels/wacom/cc-wacom-stylus-page.c:355
+msgid "Button"
+msgstr "Тугма"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+#: panels/wacom/gnome-wacom-properties.ui:200
+msgid "Wacom Tablet"
+msgstr "Планшети Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Таъин кардани нақшабандиҳои тугмаҳо ва танзим кардани ҳассосияти қалам барои "
+"планшетҳои графикӣ"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Планшет;Wacom;Қалам;Тозакунак;Муш;"
+
+#: panels/wacom/gnome-wacom-properties.ui:15
+msgid "Tablet (absolute)"
+msgstr "Планшет (матлақ)"
+
+#: panels/wacom/gnome-wacom-properties.ui:19
+msgid "Touchpad (relative)"
+msgstr "Панели ламсӣ (нисбӣ)"
+
+#: panels/wacom/gnome-wacom-properties.ui:27
+msgid "Tablet Preferences"
+msgstr "Хусусиятҳои планшет"
+
+#: panels/wacom/gnome-wacom-properties.ui:44
+msgid "_Help"
+msgstr "_Кумак"
+
+#: panels/wacom/gnome-wacom-properties.ui:125
+msgid "No tablet detected"
+msgstr "Ягон планшет муайян нашуд"
+
+#: panels/wacom/gnome-wacom-properties.ui:141
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Лутфан, планшети Wacom-ро васл кунед ва фаъол созед"
+
+#: panels/wacom/gnome-wacom-properties.ui:161
+msgid "Bluetooth Settings"
+msgstr "Танзимоти Bluetooth"
+
+#: panels/wacom/gnome-wacom-properties.ui:238
+msgid "Tracking Mode"
+msgstr "Ҳолати пайгирӣ"
+
+#: panels/wacom/gnome-wacom-properties.ui:266
+msgid "Left-Handed Orientation"
+msgstr "Самти чап"
+
+#: panels/wacom/gnome-wacom-properties.ui:296
+msgid "Map to Monitor…"
+msgstr "Нишона гузоштан ба монитор..."
+
+#: panels/wacom/gnome-wacom-properties.ui:309
+msgid "Map Buttons…"
+msgstr "Нишона гузоштани тугмаҳо..."
+
+#: panels/wacom/gnome-wacom-properties.ui:322
+msgid "Calibrate…"
+msgstr "Санҷидан..."
+
+#: panels/wacom/gnome-wacom-properties.ui:340
+msgid "Adjust mouse settings"
+msgstr "Танзими хусусиятҳои муш"
+
+#: panels/wacom/gnome-wacom-properties.ui:356
+msgid "Adjust display resolution"
+msgstr "Танзими возеҳии дисплей"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:217
+msgid "New shortcut…"
+msgstr "Миёнбури нав"
+
+#: panels/wacom/wacom-stylus-page.ui:25
+msgid "Default"
+msgstr "Пешфарз"
+
+#: panels/wacom/wacom-stylus-page.ui:29
+msgid "Middle Mouse Button Click"
+msgstr "Зеркунии тугмаи миёнаи муш"
+
+#: panels/wacom/wacom-stylus-page.ui:33
+msgid "Right Mouse Button Click"
+msgstr "Зеркунии тугмаи рости муш"
+
+#: panels/wacom/wacom-stylus-page.ui:37 shell/cc-window.ui:242
+msgid "Back"
+msgstr "Бозгашт"
+
+#: panels/wacom/wacom-stylus-page.ui:41
+msgid "Forward"
+msgstr "Ба пеш"
+
+#: panels/wacom/wacom-stylus-page.ui:79
+msgid "No stylus found"
+msgstr "Ягон қалам (стилус) ёфт нашуд"
+
+#: panels/wacom/wacom-stylus-page.ui:93
+msgid "Please move your stylus to the proximity of the tablet to configure it"
+msgstr ""
+"Лутфан, барои танзим кардани қалам (стилус) онро дар сатҳи лавҳа ҳаракат "
+"намоед"
+
+#: panels/wacom/wacom-stylus-page.ui:159
+msgid "Eraser Pressure Feel"
+msgstr "Ҳассосияти зеркунии тозакунак"
+
+#: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:340
+msgid "Soft"
+msgstr "Нарм"
+
+#: panels/wacom/wacom-stylus-page.ui:210 panels/wacom/wacom-stylus-page.ui:370
+msgid "Firm"
+msgstr "Ҷиддӣ"
+
+#: panels/wacom/wacom-stylus-page.ui:233
+msgid "Top Button"
+msgstr "Поёни боло"
+
+#: panels/wacom/wacom-stylus-page.ui:262
+msgid "Lower Button"
+msgstr "Тугмаи пасткунӣ"
+
+#: panels/wacom/wacom-stylus-page.ui:291
+#, fuzzy
+#| msgid "Lower Button"
+msgid "Lowest Button"
+msgstr "Тугмаи пасткунӣ"
+
+#: panels/wacom/wacom-stylus-page.ui:320
+msgid "Tip Pressure Feel"
+msgstr "Ҳассосияти фишори нӯг"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:7
+#, fuzzy
+#| msgid "- Settings"
+msgid "GNOME Settings"
+msgstr "- Танзимот"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:8
+#, fuzzy
+#| msgid "Utilities to configure the GNOME desktop"
+msgid "Utility to configure the GNOME desktop"
+msgstr "Барномаҳои пуштибонӣ барои танзими мизи кории GNOME"
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/gnome-control-center.appdata.xml.in:20
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-application.c:58
+#, fuzzy
+#| msgid "Display Brightness"
+msgid "Display version number"
+msgstr "Равшании дисплей"
+
+#: shell/cc-application.c:59
+msgid "Enable verbose mode"
+msgstr "Фаъол кардани ҳолати ботафсил"
+
+#: shell/cc-application.c:60
+msgid "Search for the string"
+msgstr "Ҷустуҷӯи сатр"
+
+#: shell/cc-application.c:61
+msgid "List possible panel names and exit"
+msgstr "Пайванд гузоштани номҳои эҳтимолии наворҳо ва баромад"
+
+#: shell/cc-application.c:62
+msgid "Panel to display"
+msgstr "Панел барои намоиш"
+
+#: shell/cc-application.c:62
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: shell/cc-panel-loader.c:279
+msgid "Available panels:"
+msgstr "Лавҳаҳои дастрас:"
+
+#: shell/cc-window.ui:146
+msgid "All Settings"
+msgstr "Ҳамаи танзимот"
+
+#: shell/cc-window.ui:184
+msgid "Primary Menu"
+msgstr "Феҳристи асосӣ"
+
+#: shell/cc-window.ui:326
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:327
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:338
+msgid "Help"
+msgstr "Кумак"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/gnome-control-center.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Хусусиятҳо;Танзимот;"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Умумӣ"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Баромад"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:48
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Ҷустуҷӯ"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Лавҳаҳо"
+
+#: shell/help-overlay.ui:40
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Гузариш ба лавҳаи қаблӣ"
+
+#: shell/help-overlay.ui:53
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Бекор кардани ҷустуҷӯ"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1871
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u барориш"
+msgstr[1] "%u барориш"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1881
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u вуруд"
+msgstr[1] "%u вуруд"
+
+#: subprojects/gvc/gvc-mixer-control.c:2736
+msgid "System Sounds"
+msgstr "Овозҳои низом"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "Bluetooth ғайрифаъол аст"
+
+#~ msgid "Done"
+#~ msgstr "Тайёр"
+
+#~ msgid "Time _Zone"
+#~ msgstr "Минтақаи _вақт"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Сапрӯши пӯшида"
+
+#~ msgid "Mirrored"
+#~ msgstr "Мунъакис"
+
+#~ msgid "Secondary"
+#~ msgstr "Дуюм"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Мураттабсозии дисплейҳои ҳамҷояшуда"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Барои аз нав мураттабсозии дисплейҳо, онҳоро кашед"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Давр занондан зидди ақрабаки соат ба 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Давр занондан ба 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Давр занондан аз рӯи ақрабаки соат ба 90°"
+
+#~ msgid "Size"
+#~ msgstr "Андоза"
+
+#~ msgid "Aspect Ratio"
+#~ msgstr "Таносуб"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "Намоиш додани навори болоӣ ва хулосаи фаъолият дар ин дисплей"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr ""
+#~ "Муттаҳид кардани ин дисплей бо дисплейи дигар барои омода кардни фазои "
+#~ "кории иловагӣ"
+
+#~ msgid "Presentation"
+#~ msgstr "Тақдим"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Намоиш додани танҳо слайдҳо ва мултимедиа"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Намоиш додани намуди ҷорӣ дар ҳар дуи дисплей"
+
+#~ msgid "Turn Off"
+#~ msgstr "Хомӯш кардан"
+
+#~ msgid "Don't use this display"
+#~ msgstr "Истифода набурдани ин дисплей"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Иттилооти экран ёфт нашуд"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Мураттабсозии дисплейҳои ҳамҷояшуда"
+
+#~ msgid "Wayland"
+#~ msgstr "Вэуленд"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-бит"
+
+#~ msgid "Section"
+#~ msgstr "Қисмат"
+
+#~ msgid "Overview"
+#~ msgstr "Хулоса"
+
+#~ msgid "Base system"
+#~ msgstr "Системаи асосӣ"
+
+#~ msgctxt "keybinding"
+#~ msgid "Search"
+#~ msgstr "Ҷустуҷӯ"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Миёнбур;Такрор;Мижазанӣ;"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Таъхир:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Кӯтоҳ"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Суст"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Дароз"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Тез"
+
+#~ msgid "S_peed:"
+#~ msgstr "С_уръат:"
+
+#~ msgid "Add Shortcut"
+#~ msgstr "Илова кардани миёнбур"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Барои таҳрир кардани миёнбур, сатреро зер кунед, ва тугмаҳои навро пахш "
+#~ "кунед, ё ки барои пок кардан тугмаи \"Backspace\"-ро пахш кунед."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Амали номаълум>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Миёнбури \"%s\" наметавонад истифода шавад, чунки тавассути ин тугма чоп "
+#~ "кардан намешавад.\n"
+#~ "Лутфан, бо тугма ба монанди Control, Alt ё Shift дар якҷоягӣ кӯшиш кунед."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Миёнбури \"%s\" аллакай барои зерин истифода мешавад:\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr ""
+#~ "Агар шумо миёнбурро ба \"%s\" аз нав таъин кунед, миёнбури \"%s\" "
+#~ "ғайрифаъол карда мешавад."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Аз нав таъин кардан"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Миёнбури \"%s\" ба миёнбури \"%s\" тааллуқ дорад. Шумо мехоҳед, ки онро "
+#~ "ба \"%s\" ба таври худкор танзим кунед?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "Дар айни ҳол \"%s\" ба \"%s\" тааллуқ дорад ва ин миёнбур ғайрифаъол "
+#~ "карда мешавад, агар ба пеш интиқол диҳед."
+
+#~ msgid "_Assign"
+#~ msgstr "_Таъин кардан"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Санҷидани танзимоти худ"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Суст"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Тез"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "_Чап"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_Рост"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_Суръати нишондиҳанда"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Суст"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Тез"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Суст"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Тез"
+
+#~ msgid "Server"
+#~ msgstr "Сервер"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Нест кардани сервери DNS"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Дастрас кардан ба корбарони _дигар"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "Минтақаи _девори оташ"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Пешфарз"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Минтақа сатҳи эътимоднокии пайвастро муайян мекунад"
+
+#~ msgid "Bond"
+#~ msgstr "Пайваст"
+
+#~ msgid "Team"
+#~ msgstr "Даста"
+
+#~ msgid "Bridge"
+#~ msgstr "Кӯпрук"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Плагинҳои VPN бор намешаванд"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Илова кардани пайвасти шабака"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Танзими дубораи ин шабака, аз он ҷумла ниҳонвожаҳо, аммо дар ёд доштани "
+#~ "он ҳамчун пайвасти пазируфта"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Тоза кардани ҳамаи тафсилоти ин шабака ва кӯшиш накардани пайвастшавии "
+#~ "худкор"
+
+#~ msgid "My Home Network"
+#~ msgstr "Шабакаи хонагии ман"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Пайвасти фармонбарон"
+
+#~ msgid "(none)"
+#~ msgstr "(ҳеҷ)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Кӯпруки фармонбар"
+
+#~ msgid "Team slaves"
+#~ msgstr "Фармонбарони даста"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Агар пайвасти Интернети шумо аз пайвасти бесим фарқ кунад, шумо метавонед "
+#~ "хот-споти бесимро танзим кунед, то ин ки пайвастро бо дигарон мубодила "
+#~ "кунед."
+
+#~ msgid "History"
+#~ msgstr "Таърих"
+
+#~ msgid "Proxy"
+#~ msgstr "Прокси"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Илова кардани профил…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Ҳеҷ"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Дастӣ"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Худкор"
+
+#~ msgid "VPN Type"
+#~ msgstr "Навъи VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "Номи гурӯҳ"
+
+#~ msgid "Group Password"
+#~ msgstr "Ниҳонвожаи гурӯҳ"
+
+#~ msgid "hardware"
+#~ msgstr "сахтафзор"
+
+#~ msgid "reset"
+#~ msgstr "бозсозӣ"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Истифода бурдан ҳамчун нуқтаи дастрасӣ…"
+
+#~ msgid "_History"
+#~ msgstr "_Таърих"
+
+#~ msgid "Security key"
+#~ msgstr "Калиди амният"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "Дастгоҳи InfiniBand ҳолати пайвастшударо дастгирӣ намекунад"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Ягон гувоҳиномаи Мақомоти гувоҳиномаҳо интихоб нашудааст"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Агар шумо гувоҳиномаи Мақомоти гувоҳиномаҳоро (CA) истифода набаред, шумо "
+#~ "метавонед ба шабакаҳои беэътимод ва маккори Wi-Fi пайваст шавед.  Шумо "
+#~ "мехоҳед, ки гувоҳиномаи Мақомоти гувоҳиномаҳоро интихоб кунед?"
+
+#~ msgid "Ignore"
+#~ msgstr "Рад кардан"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Интихоб кардани гувоҳиномаи CA"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Ҳамеша ин ниҳонвожаро _дархост кардан"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "_Маро дигар огоҳ накунед"
+
+#~ msgid "No"
+#~ msgstr "Не"
+
+#~ msgid "Yes"
+#~ msgstr "Ҳа"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification Banners"
+#~ msgstr "Баннерҳои огоҳиҳо"
+
+#~ msgid "Notification Banners"
+#~ msgstr "Баннерҳои огоҳиҳо"
+
+#~ msgid "Add Account"
+#~ msgstr "Илова кардани ҳисоб"
+
+#~ msgid "Mail"
+#~ msgstr "Почта"
+
+#~ msgid "Contacts"
+#~ msgstr "Тамосҳо"
+
+#~ msgid "Chat"
+#~ msgstr "Чат"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Ҳангоми ворид шудан ба ҳисоб хатогӣ ба вуҷуд омад"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Маълумоти корбар аз мӯҳлаташ гузашт."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Барои фаъол кардани ин ҳисоб ворид шавед."
+
+#~ msgid "_Sign In"
+#~ msgstr "_Ворид шудан"
+
+#~ msgid "Error creating account"
+#~ msgstr "Ҳангоми эҷодкунии ҳисоб хатогӣ ба вуҷуд омад"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Шумо мутмаин ҳастед, ки мехоҳед ин ҳисобро тоза кунед?"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Ягон ҳисоби онлайн танзим нашудааст"
+
+#~ msgid "Add an online account"
+#~ msgstr "Илова кардани ҳисоби онлайн"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Иловакунии ҳисоб ба барномаҳо иҷозат медиҳад, ки онҳо тавонанд ба "
+#~ "ҳуҷҷатҳо, почта, тамосҳо, тақвимҳо, чат ва файлҳои дигар дастрасӣ пайдо "
+#~ "кунанд."
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Дастгоҳи бесим барқи иловагиро талаб мекунад"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Конфигуратсия"
+
+#~ msgid "Toner Level"
+#~ msgstr "Сатҳи тюнер"
+
+#~ msgid "Supply Level"
+#~ msgstr "Сатҳи таъминот"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Насб шуда истодааст"
+
+#~ msgid "No printers available"
+#~ msgstr "Ягон принтер дастрас нест"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u фаъол"
+#~ msgstr[1] "%u фаъол"
+
+#~ msgid "Close"
+#~ msgstr "Пӯшидан"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Давом додани чоп"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Таваққуф кардани чоп"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Илова кардани принтери нав"
+
+#~ msgid "No printers detected."
+#~ msgstr "Ягон принтер муайян нашуд."
+
+#~ msgid "Loading options…"
+#~ msgstr "Боркунии имконот..."
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Боздошта"
+
+#~ msgid "Job Title"
+#~ msgstr "Номи вазифа"
+
+#~ msgid "Job State"
+#~ msgstr "Вазъияти вазифа"
+
+#~ msgid "Time"
+#~ msgstr "Вақт"
+
+#~ msgid "Supply"
+#~ msgstr "Таъминот"
+
+#~ msgid "Jobs"
+#~ msgstr "Вазифаҳо"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Намоиш додани _вазифаҳо"
+
+#~ msgid "label"
+#~ msgstr "барчасп"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "Танзимкунии драйвери нав..."
+
+#~ msgid "page 3"
+#~ msgstr "саҳифаи 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "Чоп кардани _саҳифаи санҷишӣ"
+
+#~ msgid "_Options"
+#~ msgstr "_Имконот"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Илова кардани принтери нав"
+
+#~ msgid "Show _Notifications"
+#~ msgstr "_Намоиш додани огоҳиҳо"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Барои муайян кардани ҷойгиршавии ҷуғрофии шумо истифода мешавад"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Гузариш ба манбаи навбатӣ"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Қатъу васлкунии иловагӣ ба манбаи навбатӣ"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Англисӣ (Шоҳигарии Муттаҳида)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Британияи Кабир"
+
+#~ msgid "Options"
+#~ msgstr "Имконот"
+
+#~ msgid "Add input source"
+#~ msgstr "Илова кардани манбаи вуруд"
+
+#~ msgid "Remove input source"
+#~ msgstr "Тоза кардани манбаи вуруд"
+
+#~ msgid "Move input source up"
+#~ msgstr "Интиқол додани манбаи вуруд ба боло"
+
+#~ msgid "Move input source down"
+#~ msgstr "Интиқол додани манбаи вуруд ба поён"
+
+#~ msgid "Configure input source"
+#~ msgstr "Танзим кардани манбаи вуруд"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Намоиш додани тарҳбандии клавиатураи манбаи вуруд"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Дигар"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Дастрасии муштараки Bluetooth ба шумо имкон медиҳад, ки тавонед файлҳоро "
+#~ "бо дастгоҳҳои дигари Bluetooth-дор мубодила кунед"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Қабул кардан танҳо аз дастгоҳҳои боэътибор"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Захира кардани файлҳои захирашуда ба ҷузвдони боргириҳо"
+
+#~ msgid "Allow Remote Control"
+#~ msgstr "Иҷозати идоракунии дурдаст"
+
+#~ msgid "Password:"
+#~ msgstr "Ниҳонвожа:"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Ҳади аққал"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Ҳадди акcаp"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Динамики паст-басомадӣ:"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "Беқувват"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Профил:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_Санҷидани баландгӯякҳо"
+
+#~ msgid "Peak detect"
+#~ msgstr "Ташхиси баландтарин"
+
+#~ msgid "Device"
+#~ msgstr "Дастгоҳ"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Санҷиши баландгӯяк барои %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "Интихоб _кардани дастгоҳ барои барориши садо:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Танзимот барои дастгоҳҳои интихобшуда:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "_Баландии садои вуруд:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Интихоб кардани дастгоҳ барои вуруди садо:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Таъсири садо"
+
+#~ msgid "No application is currently playing or recording audio."
+#~ msgstr "Ягон барнома дар айни ҳол аудиоро пахш ё сабт накарда истодааст."
+
+#~ msgid "Built-in"
+#~ msgstr "Дарунсохт"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Хусусиятҳои садо"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Санҷиши садои рӯйдод"
+
+#~ msgid "From theme"
+#~ msgstr "Аз мавзӯъ"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Интихоб кардани садои огоҳӣ:"
+
+#~ msgid "Stop"
+#~ msgstr "Истодан"
+
+#~ msgid "Zoom"
+#~ msgstr "Танзими андоза"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Ранг"
+
+#~ msgid "_Verify"
+#~ msgstr "_Тайид кардан"
+
+#~ msgid "Login History"
+#~ msgstr "Таърихи воридшавӣ"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_Тайид кардани ниҳонвожаи нав"
+
+#~ msgid "Add User Account"
+#~ msgstr "Илова кардани ҳисоби корбар"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr ""
+#~ "Кӯшиш кунед, ки бештар калимаҳо, рақамҳо ва нуқтагузориро истифода баред."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Тавоноӣ: Паст"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Тавоноӣ: Паст"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Тавоноӣ: Миёна"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Тавоноӣ: Хуб"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Тавоноӣ: Баланд"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Ниҳонвожаҳо мувофиқат намекунанд."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Disable image"
+#~ msgstr "Ғайрифаъол кардани тасвир"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Тамошо кардани тасвирҳои дигар..."
+
+#~ msgid "Used by %s"
+#~ msgstr "Бо %s истифода шудааст"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Ҳисобҳои дигар"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Корбар бо номи '%s' аллакай мавҷуд аст."
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Ба боло"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Ба поён"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Ҳеҷ"
+
+#~ msgid "Left Ring"
+#~ msgstr "Ҳалқаи чап"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Ҳолати ҳалқаи чапи #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Ҳолати ҳалқаи рости #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Тасмаи ламсии чап"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Ҳолати тасмаи ламсии чапи #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Ҳолати тасмаи ламсии рост"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Ҳолати тасмаи ламсии #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Ивазкунии ҳолати ҳалқаи ламсии чап"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Ивазкунии ҳолати ҳалқаи ламсии рост"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Ивазкунии ҳолати тасмаи ламсии чап"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Ивазкунии ҳолати тасмаи ламсии рост"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Ивазкунии ҳолати #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Тугмаи чап #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Тугмаи рост #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Поёни боло #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Тугмаи поён #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Ягон амал нест"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Зеркунии тугмаи чапи муш"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Ба боло ҳаракат кардан"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Ба поён ҳаракат кардан"
+
+#~ msgid "Scroll Left"
+#~ msgstr "Ба чап ҳаракат кардан"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Маркази идоракунии GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME's main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Маркази идоракунии GNOME ин интерфейси асосӣ барои танзим кардани "
+#~ "унсурҳои гуногуни мизи кории шумо мебошад."
+
+#~ msgid "Show the overview"
+#~ msgstr "Намоиш додани хулоса"
+
+#~ msgid "Show help options"
+#~ msgstr "Намоиш додани имконоти кумак"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Барои дидани рӯйхати пурраи фармонҳои дастрас, фармони '%s --help' -ро "
+#~ "иҷро кунед.\n"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "Шахсӣ"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Сахтафзор"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Система"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "_Вақте ки барқи батарея қариб ба анҷом расид"
+
+#~ msgid "Power off"
+#~ msgstr "Анҷоми кор"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "Ғайрифаъол кардан ҳангоми чопкунӣ"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Хидматҳои шабакавии система бо ин версия мутобиқат намекунанд."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Намоиш додани баннерҳои пайдошаванда"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Намоиш додан дар экрани қулф"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Намоиш додани баннерҳои пайдошаванда"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "Намоиш додан дар экрани қулф"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Хомӯш кардани дастгоҳҳои бесим"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr ""
+#~ "Барои филтр кардани натиҷаҳо суроғаи принтер ё калидвожаеро ворид кунед"
+
+#~ msgid "United States"
+#~ msgstr "Иёлоти Муттаҳида"
+
+#~ msgid "Germany"
+#~ msgstr "Олмон"
+
+#~ msgid "France"
+#~ msgstr "Фаронса"
+
+#~ msgid "Spain"
+#~ msgstr "Испания"
+
+#~ msgid "China"
+#~ msgstr "Хитой"
+
+#~ msgid "Immediately"
+#~ msgstr "Фавран"
+
+#~ msgid "Sorry"
+#~ msgstr "Бубахшед"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "Мубодила кардани медиа дар ин шабака"
+
+#~ msgid "Shared Folders"
+#~ msgstr "Ҷузвдонҳои мубодилашуда"
+
+#~ msgid "column"
+#~ msgstr "сутун"
+
+#~ msgid "Remove Folder"
+#~ msgstr "Тоза кардани ҷузвдон"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "Мубодила кардани ҷузвдони оммавӣ дар ин шабака"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "Системаи шумо нав мебошад"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "Ҷустуҷӯи принтерҳои шабакавӣ ё нтиҷаи филтр"
+
+#~ msgid "Remote View"
+#~ msgstr "Намоиши дурдаст"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "Тасдиқ кардани ҳамаи пайвастҳо"
+
+#~ msgid "_Default"
+#~ msgstr "_Пешфарз"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Танзим кардани дастгоҳи нав"
+
+#~ msgid "Paired"
+#~ msgstr "Ҷуфтдор"
+
+#~ msgid "Type"
+#~ msgstr "Навъ"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "Танзимоти муш ва панели ламсӣ"
+
+#~ msgid "Sound Settings"
+#~ msgstr "Танзимоти садо"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "Танзимоти клавиатура"
+
+#~ msgid "Send Files…"
+#~ msgstr "Фиристодани файлҳо…"
+
+#~ msgid "Visibility"
+#~ msgstr "Қобилияти намоиш"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "Намоённокии “%s”"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "'%s'-ро аз рӯйхати дастгоҳҳо тоза мекунед?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "Агар шумо дастгоҳро тоза кунед, ба шумо лозим мешавад, ки пеш аз "
+#~ "истифодабарии навбатӣ онро аз нав танзим кунед."
+
+#~ msgid "Share Public Folder"
+#~ msgstr "Мубодила кардани ҷузвдони оммавӣ"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "Мубодила кардан танҳо бо дастгоҳҳои боэътибор"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "Ҳеҷ"
+
+#~ msgid "Device type:"
+#~ msgstr "Навъи дастгоҳ:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "Истеҳсолкунанда:"
+
+#~ msgid "Model:"
+#~ msgstr "Намуна:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "Файлҳои тасвирҳо метавонанд ба ин равзана кашида монда шаванд, то ин ки "
+#~ "майдонҳои боло ба таври худкор пур карда шаванд."
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "Намоиш додани дисплейи асосии худ дар ин экран"
+
+#~ msgid "Combine"
+#~ msgstr "Ҳамҷоя кардан"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr ""
+#~ "Муттаҳид кардани ин дисплей бо дисплейи асосӣ барои омода кардни фазои "
+#~ "кории иловагӣ"
+
+#~ msgid "Don't use the display"
+#~ msgstr "Истифода набурдани ин дисплей"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Бартариҳои муш"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "Интихоби интерфейс барои хидмати нав"
+
+#~ msgid "C_reate…"
+#~ msgstr "_Эҷод кардан…"
+
+#~ msgid "_Interface"
+#~ msgstr "_Интерфейс"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "Тағйирдиҳии сурат барои:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "Интихоб кардани тасвире, ки дар экрани воридшавӣ барои ин ҳисоб намоиш "
+#~ "дода мешавад."
+
+#~ msgid "Gallery"
+#~ msgstr "Галерея"
+
+#~ msgid "Take a photograph"
+#~ msgstr "Гирифтани сурат"
+
+#~ msgid "Browse"
+#~ msgstr "Тамошо кардан"
+
+#~ msgid "Photograph"
+#~ msgstr "Суратгирӣ"
+
+#~ msgid "Account Information"
+#~ msgstr "Иттилооти ҳисоб"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "Табдил додан дар байни AM ва PM."
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "Қобилияти тахминии батарея: %s"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "Оддӣ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "Самти ҳаракати соат"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 дараҷа"
+
+#~ msgid "Monitor"
+#~ msgstr "Монитор"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "Барои тағйир додани дисплейи асосӣ кашед."
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "Мониторро барои тағйир додани хусусиятҳои он интихоб кунед; барои аз нав "
+#~ "тартиб додани ҷойгиршавии он онро кашида баред."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%a %l:%M %p"
+
+#~ msgid "Failed to apply configuration"
+#~ msgstr "Татбиқи танзимот қатъ шудааст"
+
+#~ msgid "_Resolution"
+#~ msgstr "_Возеҳӣ"
+
+#~ msgid "R_otation"
+#~ msgstr "_Даврзанӣ"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "_Дисплейҳои оинавӣ"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "Тавзеҳ: метавонад имконоти возеҳиро маҳдуд кунад"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "_Пайдо кардани дисплейҳо"
+
+#~ msgid "_Region:"
+#~ msgstr "_Минтақа:"
+
+#~ msgid "_City:"
+#~ msgstr "_Шаҳр:"
+
+#~ msgid "_Network Time"
+#~ msgstr "_Вақти шабака"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "Соатро ба як соат пеш гузаронед."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "Соатро ба як соат қафо гузаронед."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "Соатро ба як дақиқа пеш гузаронед."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "Соатро ба як дақиқа қафо гузаронед."
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgid "Show Status When _Inactive"
+#~ msgstr "Намоиш додани вазъият ҳангоми _ғайрифаъол будан"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "Танзимоти монитор захира нашуд"
+
+#~ msgid "Hidden"
+#~ msgstr "Ноаён"
+
+#~ msgid "Visible"
+#~ msgstr "Аён"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "Ном ва қобили намоиш"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "Идора кунед, ки шумо чӣ тавр дар экран ва шабака зоҳир мешавед."
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "Намоиш додани номи пурра дар _навори боло"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "Намоиш додани номи пурра дар _экрани қулф"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "_Ҳолати пинҳонӣ"
+
+#~ msgid "_Login Name"
+#~ msgstr "_Номи вурудӣ"
+
+#~ msgid "Login _Password"
+#~ msgstr "_Ниҳонвожаи вуруд"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "Ниҳонвожаҳо мувофиқат намекунанд"
+
+#~ msgid ""
+#~ "Login not recognized.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Воридшавӣ муайян нашуд.\n"
+#~ "Лутфан, амалро такрор кунед."
+
+#~ msgid "Domain not found."
+#~ msgstr "Домен ёфт нашуд."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more characters."
+#~ msgstr "Аломатҳои бештарро илова кунед."
+
+#~ msgid "Switch Modes"
+#~ msgstr "Ҳолатҳои қатъу васл"
+
+#~ msgid "Action"
+#~ msgstr "Амал"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "Оддӣ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "Боло/Ворунашуда"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "Клавиатураи экранӣ"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "Оддӣ"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Сигнали бип барои тугмаҳои Caps ва Num Lock"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "Хомӯш ё фаъол кардани дастгоҳ:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "Танзими андоза"
+
+#~ msgid "Zoom in:"
+#~ msgstr "Бузург кардани андоза:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "Хурд кардани андоза:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "Аксгирии пӯшида"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "Намоиш додани тафсири матни барои талаффуз ва садоҳо"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "Кӯтоҳ"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "Дароз"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "Сигнали бип барои тугмаи"
+
+#~ msgid "pressed"
+#~ msgstr "зершуда"
+
+#~ msgid "accepted"
+#~ msgstr "қабулшуда"
+
+#~ msgid "rejected"
+#~ msgstr "радшуда"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "_Таъхири қабулкунӣ:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "Идора кардани нишондиҳандаи муш бо клавиатура"
+
+#~ msgid "Video Mouse"
+#~ msgstr "Муши видео"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "Идора кардани нишондиҳандаи муш бо веб камера"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "Хурд"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "Калон"
+
+#~ msgid "Previous Week"
+#~ msgstr "Ҳафтаи қаблӣ"
+
+#~ msgid "Next Week"
+#~ msgstr "Ҳафтаи навбатӣ"
+
+#~ msgid "Next week"
+#~ msgstr "Ҳафтаи навбатӣ"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "_Муҳтаво ба ангушт мечаспад"
+
+#~ msgid "Choose password at next login"
+#~ msgstr "Интихоб кардани ниҳонвожа барои воридшавии навбатӣ"
+
+#~ msgid "Log in without a password"
+#~ msgstr "Бе ниҳонвожа ворид шудан"
+
+#~ msgid "Disable this account"
+#~ msgstr "Ғайрифаъол кардани ин ҳисоб"
+
+#~ msgid "Enable this account"
+#~ msgstr "Фаъол кардани ин ҳисоб"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "_Тасдиқ кардани ниҳонвожа"
+
+#~ msgid "Generate a password"
+#~ msgstr "Эҷод кардани ниҳонвожа"
+
+#~ msgid "_Action"
+#~ msgstr "_Амал"
+
+#~ msgid "_Show password"
+#~ msgstr "Намоиш _додани ниҳонвожа"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "Тарзи интихоби ниҳонвожаи қавӣ"
+
+#~ msgid "_Generate a password"
+#~ msgstr "_Эҷод кардани ниҳонвожа"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "Шумо бояд ниҳонвожаи наверо ворид кунед"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "Ниҳонвожаи нав қафӣ нест"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "Шумо бояд ниҳонвожаро тасдиқ кунед"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "Шумо бояд ниҳонвожаи ҷориро ворид кунед"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "Ниҳонвожаи ҷорӣ нодуруст аст"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "Хеле кӯтоҳ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "Паст"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "Хуб"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "Хуб"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "Қавӣ"
+
+#~ msgid "_Local Account"
+#~ msgstr "_Ҳисоби маҳаллӣ"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "Маслиҳат: Домени тиҷорӣ ё номи соҳиб"
+
+#~ msgid "C_ontinue"
+#~ msgstr "_Идома додан"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "Хеле хуб нест"
+
+#~ msgid "Left Shift"
+#~ msgstr "Shift-и чап"
+
+#~ msgid "Left Alt"
+#~ msgstr "Alt-и чап"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "Ctrl-и чап"
+
+#~ msgid "Right Shift"
+#~ msgstr "Shift-и рост"
+
+#~ msgid "Right Alt"
+#~ msgstr "Alt-и рост"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl-и рост"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Alt-и чап + Shift"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Alt-и рост + Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Ctrl-и чап + Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Ctrl-и рост + Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Shift-и рост + чап"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Ctrl-и рост + чап"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "Caps"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"

--- a/po/th.po
+++ b/po/th.po
@@ -12,9 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2016-09-10 00:29+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2016-10-13 10:42+0700\n"
 "Last-Translator: Theppitak Karoonboonyanan <theppitak@gmail.com>\n"
 "Language-Team: Thai <thai-l10n@googlegroups.com>\n"
@@ -25,539 +24,419 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Gtranslator 2.91.6\n"
 
-#: ../panels/background/background.ui.h:1
-msgid "_Background"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "โปรแกรม"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "ไม่พบโปรแกรม"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "ติดตั้งรุ่นใหม่"
+
+#: panels/applications/cc-applications-panel.ui:84
+msgid "Open"
+msgstr "เปิด"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "ดู_รายละเอียด"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "ค้นหา"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "ไม่ใช้"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_การแจ้งเหตุ"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "แสดงการแ_จ้งเหตุ"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
 msgstr "_พื้นหลัง"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "เปลี่ยนแปลงตลอดวัน"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "_Lock Screen"
-msgstr "หน้าจอ_ล็อค"
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "ภาพหน้าจอ"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "เรียงกระเบื้อง"
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
 
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "ซูม"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "วางตรงกลาง"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "ขยายพอดีหน้าจอ"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "ยืดเต็มจอ"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "แสดงเต็มภาพ"
-
-#: ../panels/background/cc-background-chooser-dialog.c:437
-msgid "Wallpapers"
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
 msgstr "ภาพพื้นหลัง"
 
-#: ../panels/background/cc-background-chooser-dialog.c:446
-msgid "Colors"
-msgstr "สี"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:483
-msgid "Select Background"
-msgstr "เลือกพื้นหลัง"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "เสียง"
 
-#: ../panels/background/cc-background-chooser-dialog.c:511
-msgid "Pictures"
-msgstr "รูปภาพ"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:543
-msgid "No Pictures Found"
-msgstr "ไม่พบรูปภาพ"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "ปุ่มลัด"
 
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:561
-#: ../panels/search/cc-search-locations-dialog.c:302
-msgid "Home"
-msgstr "บ้าน"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "ไม่พบปุ่มลัด"
 
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:573
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "คุณสามารถเพิ่มรูปภาพลงในโฟลเดอร์ %s ของคุณ แล้วรูปภาพจะปรากฏที่นี่"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "กล้อง %s"
 
-#: ../panels/background/cc-background-chooser-dialog.c:580
-#: ../panels/color/cc-color-panel.c:225 ../panels/color/cc-color-panel.c:963
-#: ../panels/color/color-calibrate.ui.h:2 ../panels/color/color.ui.h:30
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1561
-#: ../panels/display/cc-display-panel.c:2206
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-#: ../panels/network/connection-editor/vpn-helpers.c:181
-#: ../panels/network/connection-editor/vpn-helpers.c:310
-#: ../panels/network/net-device-wifi.c:1298
-#: ../panels/network/net-device-wifi.c:1535
-#: ../panels/network/network-wifi.ui.h:1
-#: ../panels/printers/cc-printers-panel.c:2076
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:1048
-#: ../panels/region/format-chooser.ui.h:3 ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:637
-#: ../panels/sharing/cc-sharing-panel.c:372
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/join-dialog.ui.h:2
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:265
-#: ../panels/user-accounts/um-photo-dialog.c:94
-#: ../panels/user-accounts/um-photo-dialog.c:217
-#: ../panels/user-accounts/um-user-panel.c:705
-#: ../panels/user-accounts/um-user-panel.c:723
-msgid "_Cancel"
-msgstr "_ยกเลิก"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../panels/background/cc-background-chooser-dialog.c:581
-msgid "_Select"
-msgstr "เ_ลือก"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "ความดังของไมโครโฟน"
 
-#: ../panels/background/cc-background-item.c:203
-msgid "multiple sizes"
-msgstr "หลายขนาด"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:207
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "บริการตำแหน่งที่ตั้ง"
 
-#: ../panels/background/cc-background-item.c:333
-msgid "No Desktop Background"
-msgstr "ไม่ใช้ภาพพื้นหลังพื้นโต๊ะ"
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
 
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "พื้นหลังปัจจุบัน"
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "เว็บแคมในตัว"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Back­ground"
-msgstr "พื้น­หลัง"
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:3
-msgid "Change your background image to a wallpaper or photo"
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "ไม่พบภูมิภาค"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "ลองค้นหาด้วยคำอื่น"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "ชนิดจอแสดงผล"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "อัตราเร็วลิงก์"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "ล้างค่า"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "โปรแกรม"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "ปากกา"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "ปริยาย"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "_พื้นหลัง"
+
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "เ_พิ่มโพรไฟล์…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "ฝรั่งเศส"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "เปลี่ยนภาพพื้นหลังของคุณเป็นลวดลายหรือภาพถ่าย"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:5
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "ภาพพื้นหลัง;หน้าจอ;พื้นโต๊ะ;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Turn Off Airplane Mode"
-msgstr "ปิดโหมดเครื่องบิน"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "_เปิดใช้"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:330
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "ไม่พบบลูทูท"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:330
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "เสียบ dongle เพื่อใช้บลูทูท"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:331
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "บลูทูทถูกปิดอยู่"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:331
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "เปิดเพื่อเชื่อมต่ออุปกรณ์และรับการถ่ายโอนแฟ้ม"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:332
-msgid "Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
 msgstr "โหมดเครื่องบินเปิดอยู่"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:332
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "บลูทูทจะถูกปิดใช้งานเมื่อเปิดใช้โหมดเครื่องบิน"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:333
-msgid "Hardware Airplane Mode is on"
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "ปิดโหมดเครื่องบิน"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
 msgstr "โหมดเครื่องบินแบบฮาร์ดแวร์เปิดอยู่"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:333
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "ปิดสวิตช์โหมดเครื่องบินหากต้องการเปิดใช้งานบลูทูท"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
-msgid "Blue­tooth"
-msgstr "บลู­ทูท"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr "บลูทูท"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:3
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "เปิด-ปิดบูลทูท และเชื่อมต่ออุปกรณ์ของคุณ"
 
-#. Translators: those are keywords for the bluetooth control-center panel
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:5
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "แบ่งปัน;ใช้ร่วม;บลูทูท;obex;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "วางอุปกรณ์เทียบมาตรฐานของคุณบนสี่เหลี่ยม แล้วกด 'เริ่ม'"
+#: panels/camera/cc-camera-panel.ui:24
+#, fuzzy
+msgid "Camera is Turned Off"
+msgstr "บลูทูทถูกปิดอยู่"
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "ไม่มีโปรแกรมที่เล่นหรืออัดเสียงอยู่"
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
-msgstr "เลื่อนอุปกรณ์เทียบมาตรฐานของคุณไปยังตำแหน่งเทียบมาตรฐาน แล้วกด 'ทำต่อไป'"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr "เลื่อนอุปกรณ์เทียบมาตรฐานของคุณไปยังตำแหน่งผิวหน้า แล้วกด 'ทำต่อไป'"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "ปิดฝาพับของแล็ปท็อป"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "ท่องดูรูปภาพเพิ่มเติม"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "เกิดข้อผิดพลาดภายในที่ไม่สามารถกู้คืนได้"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "เครื่องมือที่ต้องใช้ในการเทียบมาตรฐานไม่ได้ติดตั้งไว้"
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "ไม่สามารถสร้างโพรไฟล์ได้"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "ไม่สามารถอ่านค่าจุดขาวเป้าหมายได้"
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "เสร็จสมบูรณ์!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "เทียบมาตรฐานไม่สำเร็จ!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "คุณสามารถถอดอุปกรณ์เทียบมาตรฐานออกได้"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "ห้ามรบกวนอุปกรณ์เทียบมาตรฐานขณะทำงาน"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "หน้าจอแล็ปท็อป"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "เว็บแคมในตัว"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "จอภาพ %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "สแกนเนอร์ %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "กล้อง %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "เครื่องพิมพ์ %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "เว็บแคม %s"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "เปิดใช้การจัดการสีสำหรับ %s"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "แสดงโพรไฟล์สีสำหรับ %s"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:323
-msgid "Not calibrated"
-msgstr "ยังไม่เทียบมาตรฐาน"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:141
-msgid "Default: "
-msgstr "ปริยาย: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:149
-msgid "Colorspace: "
-msgstr "สเปซสี: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:156
-msgid "Test profile: "
-msgstr "โพรไฟล์ทดสอบ: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:223
-msgid "Select ICC Profile File"
-msgstr "เลือกแฟ้มโพรไฟล์ ICC"
-
-#: ../panels/color/cc-color-panel.c:226
-msgid "_Import"
-msgstr "_นำเข้า"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:237
-msgid "Supported ICC profiles"
-msgstr "โพรไฟล์ ICC ที่รองรับ"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:244
-#: ../panels/network/wireless-security/eap-method-fast.c:417
-msgid "All files"
-msgstr "ทุกแฟ้ม"
-
-#: ../panels/color/cc-color-panel.c:583
-msgid "Screen"
-msgstr "หน้าจอ"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:908
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "อัปโหลดแฟ้มไม่สำเร็จ: %s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:922
-msgid "The profile has been uploaded to:"
-msgstr "ได้อัปโหลดโพรไฟล์ไปแล้วที่:"
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Write down this URL."
-msgstr "จด URL นี้ไว้"
-
-#: ../panels/color/cc-color-panel.c:925
-msgid "Restart this computer and boot your normal operating system."
-msgstr "เริ่มเปิดคอมพิวเตอร์ใหม่และบูตระบบปฏิบัติการปกติของคุณ"
-
-#: ../panels/color/cc-color-panel.c:926
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "ป้อน URL ดังกล่าวในเบราว์เซอร์ของคุณเพื่อดาวน์โหลดและติดตั้งโพรไฟล์นี้"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:960
-msgid "Save Profile"
-msgstr "บันทึกโพรไฟล์"
-
-#: ../panels/color/cc-color-panel.c:964
-#: ../panels/network/connection-editor/vpn-helpers.c:311
-msgid "_Save"
-msgstr "_บันทึก"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1324
-msgid "Create a color profile for the selected device"
-msgstr "สร้างโพรไฟล์สีสำหรับอุปกรณ์ที่เลือก"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "ตรวจไม่พบอุปกรณ์ตรวจวัด กรุณาตรวจสอบว่าได้เปิดอุปกรณ์หรือยัง และได้เชื่อมต่อถูกต้องหรือไม่"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1373
-msgid "The measuring instrument does not support printer profiling."
-msgstr "อุปกรณ์ตรวจวัดไม่รองรับการทำโพรไฟล์เครื่องพิมพ์"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1384
-msgid "The device type is not currently supported."
-msgstr "ยังไม่รองรับอุปกรณ์ตรวจวัดชนิดนี้"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "สเปซมาตรฐาน"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "โพรไฟล์ทดสอบ"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "อัตโนมัติ"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "คุณภาพต่ำ"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "คุณภาพปานกลาง"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "คุณภาพสูง"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB ปริยาย"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK ปริยาย"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "โทนสีเทาปริยาย"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "ข้อมูลสำหรับเทียบมาตรฐานจากโรงงานที่ผู้จำหน่ายให้มา"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "ไม่สามารถปรับแก้การแสดงผลแบบเต็มหน้าจอได้สำหรับโพรไฟล์นี้"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "โพรไฟล์นี้อาจไม่ถูกต้องแม่นยำอีกต่อไป"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "การเทียบมาตรฐานจอแสดงผล"
 
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_ยกเลิก"
+
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
+#: panels/color/cc-color-calibrate.ui:28
 msgid "_Start"
 msgstr "เ_ริ่ม"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
+#: panels/color/cc-color-calibrate.ui:34
 msgid "_Resume"
 msgstr "_ทำงานต่อ"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "เ_สร็จสิ้น"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "การปรับเทียบมาตรฐานหน้าจอ"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "คุณภาพการเทียบมาตรฐาน"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
@@ -566,3138 +445,2371 @@ msgstr ""
 "การเทียบมาตรฐานจะสร้างโพรไฟล์ที่คุณสามารถใช้จัดการการใช้สีบนหน้าจอของคุณ "
 "ยิ่งคุณใช้เวลาเทียบมาตรฐานนาน ก็จะยิ่งได้โพรไฟล์สีที่มีคุณภาพสูง"
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "คุณจะไม่สามารถใช้คอมพิวเตอร์ของคุณขณะที่เทียบมาตรฐานอยู่"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "คุณภาพ"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "เวลาโดยประมาณ"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "คุณภาพการเทียบมาตรฐาน"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "เลือกอุปกรณ์รับรู้ที่คุณต้องการใช้ในการเทียบมาตรฐาน"
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "อุปกรณ์เทียบมาตรฐาน"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "เลือกชนิดของจอแสดงผลที่เชื่อมต่ออยู่"
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "เลือกอุปกรณ์รับรู้ที่คุณต้องการใช้ในการเทียบมาตรฐาน"
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "ชนิดจอแสดงผล"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "เลือกชนิดของจอแสดงผลที่เชื่อมต่ออยู่"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "จุดขาวของโพรไฟล์"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
 "เลือกจุดขาวเป้าหมายของจอแสดงผล จอแสดงผลส่วนใหญ่ควรเทียบมาตรฐานกับแหล่งกำเนิดแสง D65"
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "จุดขาวของโพรไฟล์"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "ความสว่างจอแสดงผล"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
 "กรุณาปรับจอแสดงผลให้มีความสว่างเป็นปกติสำหรับคุณ การจัดการสีจะแม่นยำที่สุดที่ระดับความสว่างนี้"
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
 "หรือมิฉะนั้น คุณก็อาจใช้ระดับความสว่างที่ใช้กับโพรไฟล์อื่นๆ โพรไฟล์ใดโพรไฟล์หนึ่งสำหรับอุปกรณ์นี้"
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "ความสว่างจอแสดงผล"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "ชื่อโพรไฟล์"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
 "คุณสามารถใช้โพรไฟล์สีกับคอมพิวเตอร์อื่นได้ หรือแม้แต่สร้างโพรไฟล์ต่างๆ สำหรับสภาพแสงที่ต่างกันก็ได้"
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "ชื่อโพรไฟล์:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "ชื่อโพรไฟล์"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "สร้างโพร์ไฟล์สำเร็จแล้ว!"
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "คัดลอกโพรไฟล์"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "ต้องการสื่อที่สามารถเขียนได้"
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "อัปโหลดโพรไฟล์"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "ต้องการการเชื่อมต่ออินเทอร์เน็ต"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-"คำแนะนำเกี่ยวกับวิธีใช้โพรไฟล์สีบนระบบ <a href=\"linux\">GNU/Linux</a>, <a href=\"osx"
-"\">Apple OS X</a> และ <a href=\"windows\">Microsoft Windows</a> "
-"เหล่านี้อาจเป็นประโยชน์สำหรับคุณ"
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "สรุป"
 
-#: ../panels/color/color.ui.h:28
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "สร้างโพร์ไฟล์สำเร็จแล้ว!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "คัดลอกโพรไฟล์"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "ต้องการสื่อที่สามารถเขียนได้"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"คำแนะนำเกี่ยวกับวิธีใช้โพรไฟล์สีบนระบบ <a href=\"linux\">GNU/Linux</a>, <a "
+"href=\"osx\">Apple OS X</a> และ <a href=\"windows\">Microsoft Windows</a> "
+"เหล่านี้อาจเป็นประโยชน์สำหรับคุณ"
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
 msgstr "เพิ่มโพรไฟล์"
 
-#: ../panels/color/color.ui.h:29
-msgid "_Import File…"
-msgstr "_นำเข้าแฟ้ม…"
-
-#: ../panels/color/color.ui.h:31
-#: ../panels/network/connection-editor/net-connection-editor.c:546
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-msgid "_Add"
-msgstr "เ_พิ่ม"
-
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr "พบปัญหา โพรไฟล์นี้อาจทำงานไม่ถูกต้อง <a href=\"\">แสดงรายละเอียด</a>"
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_นำเข้าแฟ้ม…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "เ_พิ่ม"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "อุปกรณ์แต่ละชิ้นต้องมีโพรไฟล์สีที่เป็นค่าล่าสุดเพื่อที่จะจัดการสี"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "ศึกษาเพิ่มเติม"
 
-#: ../panels/color/color.ui.h:35
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "ศึกษาเพิ่มเติมเกี่ยวกับการจัดการสี"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:473
 msgid "_Set for all users"
 msgstr "_กำหนดสำหรับผู้ใช้ทุกคน"
 
-#: ../panels/color/color.ui.h:37
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "กำหนดโพรไฟล์นี้ให้ผู้ใช้ทุกคนในเครื่องนี้ใช้"
 
-#: ../panels/color/color.ui.h:38
+#: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
 msgstr "_เปิดใช้"
 
-#: ../panels/color/color.ui.h:39
+#: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
 msgstr "เ_พิ่มโพรไฟล์"
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
 msgstr "เ_ทียบมาตรฐาน…"
 
-#: ../panels/color/color.ui.h:41
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "เทียบมาตรฐานค่าอุปกรณ์"
 
-#: ../panels/color/color.ui.h:42
+#: panels/color/cc-color-panel.ui:511
 msgid "_Remove profile"
 msgstr "_ลบโพรไฟล์ออก"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:517
 msgid "_View details"
 msgstr "ดู_รายละเอียด"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "ตรวจไม่พบอุปกรณ์ใดที่สามารถจัดการสีได้"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "เครื่องฉาย"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "พลาสมา"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (แสงหลังแบบ CCFL)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (แสงหลังแบบ LED ชนิด RGB)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (แสงหลังแบบ LED ขาว)"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "LCD ย่านสีกว้าง (แสงหลังแบบ CCFL)"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "LCD ย่านสีกว้าง (แสงหลังแบบ LED ชนิด RGB)"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "สูง"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 นาที"
 
-#: ../panels/color/color.ui.h:57
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "ปานกลาง"
 
-#: ../panels/color/color.ui.h:58 ../panels/power/power.ui.h:2
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 นาที"
 
-#: ../panels/color/color.ui.h:59
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "ต่ำ"
 
-#: ../panels/color/color.ui.h:60 ../panels/power/power.ui.h:1
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 นาที"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "ตามธรรมชาติจอแสดงผล"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (การพิมพ์และการจัดพิมพ์)"
 
-#: ../panels/color/color.ui.h:63
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:64
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (การถ่ายภาพและกราฟิกส์)"
 
-#: ../panels/color/color.ui.h:65
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Co­lor"
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
 msgstr "สี"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:3
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "เทียบมาตรฐานสีอุปกรณ์ของคุณ เช่น จอภาพ กล้องถ่ายรูป หรือเครื่องพิมพ์"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:5
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "สี;ICC;โพรไฟล์;เทียบมาตรฐาน;เครื่องพิมพ์;จอภาพ;"
 
-#: ../panels/common/cc-common-language.c:323
-msgid "Other…"
-msgstr "อื่นๆ…"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "เลือกภาษา"
 
-#: ../panels/common/cc-language-chooser.c:124
-#: ../panels/region/cc-format-chooser.c:271
-#: ../panels/region/cc-input-chooser.c:169
-msgid "More…"
-msgstr "เพิ่มเติม…"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "เ_ลือก"
 
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "ไม่พบภาษา"
 
-#: ../panels/common/cc-util.c:127
-#: ../panels/network/connection-editor/ce-page-details.c:100
-msgid "Today"
-msgstr "วันนี้"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "เพิ่มเติม…"
 
-#: ../panels/common/cc-util.c:131
-#: ../panels/network/connection-editor/ce-page-details.c:102
-msgid "Yesterday"
-msgstr "เมื่อวาน"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "ปลดล็อค"
 
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b %Ey"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: ../panels/common/language-chooser.ui.h:1
-msgid "Language"
-msgstr "ภาษา"
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "เพิ่มขนาด:"
 
-#: ../panels/datetime/big.ui.h:1 ../panels/datetime/little.ui.h:1
-#: ../panels/datetime/middle.ui.h:1 ../panels/datetime/ydm.ui.h:1
-msgid "Day"
-msgstr "วันที่"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "เวลา"
 
-#: ../panels/datetime/big.ui.h:2 ../panels/datetime/little.ui.h:2
-#: ../panels/datetime/middle.ui.h:2 ../panels/datetime/ydm.ui.h:2
-msgid "Month"
-msgstr "เดือน"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../panels/datetime/big.ui.h:3 ../panels/datetime/little.ui.h:3
-#: ../panels/datetime/middle.ui.h:3 ../panels/datetime/ydm.ui.h:3
-msgid "Year"
-msgstr "ค.ศ."
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "ลดขนาด:"
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Ey, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Ey, %R"
-
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "มกราคม"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "กุมภาพันธ์"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "มีนาคม"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "เมษายน"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "พฤษภาคม"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "มิถุนายน"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "กรกฎาคม"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "สิงหาคม"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "กันยายน"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "ตุลาคม"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "พฤศจิกายน"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "ธันวาคม"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "วันที่ & เวลา"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "ชั่วโมง"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "ค.ศ."
 
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "เดือน"
 
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "นาที"
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "มกราคม"
 
-#: ../panels/datetime/datetime.ui.h:18
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "กุมภาพันธ์"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "มีนาคม"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "เมษายน"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "พฤษภาคม"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "มิถุนายน"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "กรกฎาคม"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "สิงหาคม"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "กันยายน"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ตุลาคม"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "พฤศจิกายน"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "ธันวาคม"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "วันที่"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "เขตเวลา"
 
-#: ../panels/datetime/datetime.ui.h:19
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "ค้นหาเมือง"
 
-#: ../panels/datetime/datetime.ui.h:20
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "_วันที่ & เวลาอัตโนมัติ"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "ต้องการการเข้าถึงอินเทอร์เน็ต"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "วันที่ & เ_วลา"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "เ_ขตเวลาอัตโนมัติ"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Date & _Time"
-msgstr "วันที่ & เ_วลา"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "ต้องการการเข้าถึงอินเทอร์เน็ต"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "เปิดใช้"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "เ_ขตเวลา"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "ปลดล็อค"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "รู_ปแบบเวลา"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "24-hour"
-msgstr "24 ชั่วโมง"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "วันที่"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "จอรอง"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "ปฏิทิน"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "ตัวเลข"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "ตั้งวันที่และเวลา รวมถึงเขตเวลา"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:5
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "นาฬิกา;เขตเวลา;ตำแหน่งที่ตั้ง;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "ตั้งเวลาระบบและตั้งค่าเกี่ยวกับวันที่"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "ในการตั้งเวลาหรือวันที่ คุณต้องยืนยันตัวบุคคลก่อน"
 
-#: ../panels/display/cc-display-panel.c:573
-msgid "Lid Closed"
-msgstr "ฝาแล็ปท็อปปิด"
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "เ_ว็บ"
 
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:576
-msgid "Mirrored"
-msgstr "แสดงเหมือนกัน"
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "เ_มล"
 
-#: ../panels/display/cc-display-panel.c:578
-#: ../panels/display/cc-display-panel.c:2429
-msgid "Primary"
-msgstr "จอหลัก"
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_ปฏิทิน"
 
-#: ../panels/display/cc-display-panel.c:580
-#: ../panels/notifications/cc-notifications-panel.c:257
-#: ../panels/power/cc-power-panel.c:1960 ../panels/power/cc-power-panel.c:1971
-#: ../panels/privacy/cc-privacy-panel.c:190
-#: ../panels/privacy/cc-privacy-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:269
-#: ../panels/universal-access/cc-ua-panel.c:590
-#: ../panels/universal-access/cc-ua-panel.c:603
-#: ../panels/universal-access/cc-ua-panel.c:615
-#: ../panels/universal-access/cc-ua-panel.c:786
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "ปิด"
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "เ_พลง"
 
-#: ../panels/display/cc-display-panel.c:583
-msgid "Secondary"
-msgstr "จอรอง"
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "วีดิ_ทัศน์"
 
-#. Title of displays dialog when multiple monitors are present.
-#: ../panels/display/cc-display-panel.c:1558
-msgid "Arrange Combined Displays"
-msgstr "จัดเรียงจอแสดงผลประกอบกัน"
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_ภาพถ่าย:"
 
-#: ../panels/display/cc-display-panel.c:1562
-#: ../panels/display/cc-display-panel.c:2207
-#: ../panels/network/connection-editor/connection-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:2
-msgid "_Apply"
-msgstr "เริ่มใ_ช้"
-
-#: ../panels/display/cc-display-panel.c:1586
-msgid "Drag displays to rearrange them"
-msgstr "ลากจอแสดงผลเพื่อจัดเรียง"
-
-#. translators: example string is "60 Hz (NTSC)"
-#. * NTSC is https://en.wikipedia.org/wiki/NTSC
-#: ../panels/display/cc-display-panel.c:1793
-#, c-format
-msgid "%d Hz (NTSC)"
-msgstr "%d Hz (NTSC)"
-
-#. translators: example string is "60 Hz"
-#: ../panels/display/cc-display-panel.c:1799
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../panels/display/cc-display-panel.c:2259
-msgid "Rotate counterclockwise by 90°"
-msgstr "หมุนทวนเข็มนาฬิกา 90°"
-
-#: ../panels/display/cc-display-panel.c:2277
-msgid "Rotate by 180°"
-msgstr "หมุน 180°"
-
-#: ../panels/display/cc-display-panel.c:2295
-msgid "Rotate clockwise by 90°"
-msgstr "หมุนตามเข็มนาฬิกา 90°"
-
-#: ../panels/display/cc-display-panel.c:2316
-msgid "Size"
-msgstr "ขนาด"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2331
-msgid "Aspect Ratio"
-msgstr "สัดส่วนจอภาพ"
-
-#: ../panels/display/cc-display-panel.c:2354
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "ความละเอียด"
-
-#: ../panels/display/cc-display-panel.c:2374
-msgid "Adjust for TV"
-msgstr "ปรับสำหรับโทรทัศน์"
-
-#: ../panels/display/cc-display-panel.c:2398
-msgid "Refresh Rate"
-msgstr "อัตราการรีเฟรช"
-
-#: ../panels/display/cc-display-panel.c:2430
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "แสดงแถบด้านบนและภาพรวมกิจกรรมในจอแสดงผลนี้"
-
-#: ../panels/display/cc-display-panel.c:2436
-msgid "Secondary Display"
-msgstr "จอแสดงผลรอง"
-
-#: ../panels/display/cc-display-panel.c:2437
-msgid "Join this display with another to create an extra workspace"
-msgstr "เชื่อมจอแสดงผลนี้กับจออื่นเพื่อสร้างพื้นที่ทำงานเพิ่มพิเศษ"
-
-#: ../panels/display/cc-display-panel.c:2444
-msgid "Presentation"
-msgstr "งานนำเสนอ"
-
-#: ../panels/display/cc-display-panel.c:2445
-msgid "Show slideshows and media only"
-msgstr "แสดงภาพสไลด์และสื่อเท่านั้น"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2450
-msgid "Mirror"
-msgstr "แสดงเหมือนกัน"
-
-#: ../panels/display/cc-display-panel.c:2451
-msgid "Show your existing view on both displays"
-msgstr "แสดงหน้าจอของคุณออกทางจอแสดงผลทั้งคู่"
-
-#: ../panels/display/cc-display-panel.c:2457
-msgid "Turn Off"
-msgstr "ปิด"
-
-#: ../panels/display/cc-display-panel.c:2458
-msgid "Don't use this display"
-msgstr "ไม่ใช้จอแสดงผลนี้"
-
-#: ../panels/display/cc-display-panel.c:2769
-msgid "Could not get screen information"
-msgstr "ไม่สามารถอ่านข้อมูลเกี่ยวกับหน้าจอ"
-
-#: ../panels/display/cc-display-panel.c:2800
-msgid "_Arrange Combined Displays"
-msgstr "_จัดเรียงจอแสดงผลประกอบกัน"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Dis­plays"
-msgstr "จอ­แสดง­ผล"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:3
-msgid "Choose how to use connected monitors and projectors"
-msgstr "เลือกวิธีใช้งานจอภาพและเครื่องฉายที่เชื่อมต่ออยู่"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:5
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "แผงควบคุม;เครื่องฉาย;xrandr;หน้าจอ;ความละเอียด;รีเฟรช;จอภาพ;"
-
-#: ../panels/info/cc-info-panel.c:345
-msgid "Wayland"
-msgstr "Wayland"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:348 ../panels/network/panel-common.c:123
-msgid "Unknown"
-msgstr "ไม่ทราบ"
-
-#: ../panels/info/cc-info-panel.c:481
-#, c-format
-msgid "%s %d-bit (Build ID: %s)"
-msgstr "%s %d บิต (ID ประกอบสร้าง: %s)"
-
-#: ../panels/info/cc-info-panel.c:483
-#, c-format
-msgid "%d-bit (Build ID: %s)"
-msgstr "%d บิต (ID ประกอบสร้าง: %s)"
-
-#: ../panels/info/cc-info-panel.c:491
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d บิต"
-
-#: ../panels/info/cc-info-panel.c:493
-#, c-format
-msgid "%d-bit"
-msgstr "%d บิต"
-
-#: ../panels/info/cc-info-panel.c:1174
-msgid "Ask what to do"
-msgstr "ถามว่าจะให้ทำอะไร"
-
-# probably wrong spelling
-#: ../panels/info/cc-info-panel.c:1178
-msgid "Do nothing"
-msgstr "ไม่ต้องทำอะไร"
-
-#: ../panels/info/cc-info-panel.c:1182
-msgid "Open folder"
-msgstr "เปิดโฟลเดอร์"
-
-#: ../panels/info/cc-info-panel.c:1273
-msgid "Other Media"
-msgstr "สื่ออื่นๆ"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "Select an application for audio CDs"
-msgstr "เลือกโปรแกรมสำหรับซีดีเพลง"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Select an application for video DVDs"
-msgstr "เลือกโปรแกรมสำหรับดีวีดีภาพยนตร์"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "Select an application to run when a music player is connected"
-msgstr "เลือกโปรแกรมที่จะเรียกเมื่อมีการเชื่อมต่อกับเครื่องเล่นเพลง"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "Select an application to run when a camera is connected"
-msgstr "เลือกโปรแกรมที่จะเรียกเมื่อมีการเชื่อมต่อกับกล้องถ่ายรูป"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Select an application for software CDs"
-msgstr "เลือกโปรแกรมสำหรับซีดีซอฟต์แวร์"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1320
-msgid "audio DVD"
-msgstr "ดีวีดีเพลง"
-
-#: ../panels/info/cc-info-panel.c:1321
-msgid "blank Blu-ray disc"
-msgstr "แผ่นบลูเรย์เปล่า"
-
-#: ../panels/info/cc-info-panel.c:1322
-msgid "blank CD disc"
-msgstr "แผ่นซีดีเปล่า"
-
-#: ../panels/info/cc-info-panel.c:1323
-msgid "blank DVD disc"
-msgstr "แผ่นดีวีดีเปล่า"
-
-#: ../panels/info/cc-info-panel.c:1324
-msgid "blank HD DVD disc"
-msgstr "แผ่นดีวีดีเปล่าความจุสูง"
-
-#: ../panels/info/cc-info-panel.c:1325
-msgid "Blu-ray video disc"
-msgstr "แผ่นภาพยนตร์บลูเรย์"
-
-#: ../panels/info/cc-info-panel.c:1326
-msgid "e-book reader"
-msgstr "เครื่องอ่านอีบุ๊ก"
-
-#: ../panels/info/cc-info-panel.c:1327
-msgid "HD DVD video disc"
-msgstr "แผ่นดีวีดีภาพยนตร์ความจุสูง"
-
-#: ../panels/info/cc-info-panel.c:1328
-msgid "Picture CD"
-msgstr "ซีดีรูปภาพ"
-
-#: ../panels/info/cc-info-panel.c:1329
-msgid "Super Video CD"
-msgstr "ซูเปอร์วิดีโอซีดี"
-
-#: ../panels/info/cc-info-panel.c:1330
-msgid "Video CD"
-msgstr "วิดีโอซีดี"
-
-#: ../panels/info/cc-info-panel.c:1331
-msgid "Windows software"
-msgstr "ซอฟต์แวร์สำหรับวินโดวส์"
-
-#: ../panels/info/cc-info-panel.c:1454
-msgid "Section"
-msgstr "หัวข้อ"
-
-#: ../panels/info/cc-info-panel.c:1463 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "ทั่วไป"
-
-#: ../panels/info/cc-info-panel.c:1469 ../panels/info/info.ui.h:21
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
 msgid "Default Applications"
 msgstr "โปรแกรมหลัก"
 
-#: ../panels/info/cc-info-panel.c:1474 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "สื่อถอดเสียบ"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "โปรแกรมหลัก"
 
-#: ../panels/info/cc-info-panel.c:1499
-#, c-format
-msgid "Version %s"
-msgstr "รุ่น %s"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "De­tails"
-msgstr "ราย­ละเอียด"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "การรายงานปัญหา"
 
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:3
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "การรายงานปัญหาโดย_อัตโนมัติ"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "เริ่มใ_ช้"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "ย้อนกลับ"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "บลูทูทถูกปิดใช้งาน"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "_ตรวจหาจอแสดงผล"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "แสดงเหมือนกัน"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "จอแสดงผลรอง"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "วงแหวนสัมผัสขวา"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "แนววาง"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "ความละเอียด"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "อัตราการรีเฟรช"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "ปรับสำหรับโทรทัศน์"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "ขยายพอดีหน้าจอ"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "เลื่อนหน้าจอแบบธรรมชาติ"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "ไม่มีเครื่องพิมพ์"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "ตั้งต้นใหม่เดี๋ยวนี้"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "เวลา"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "ชั่วโมง"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "นาที"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+#, fuzzy
+msgid "Displays"
+msgstr "การแสดงผล"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "เลือกวิธีใช้งานจอภาพและเครื่องฉายที่เชื่อมต่ออยู่"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "แผงควบคุม;เครื่องฉาย;xrandr;หน้าจอ;ความละเอียด;รีเฟรช;จอภาพ;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "กุญแจระบบรักษาความปลอดภัย"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "ระดับน้ำหมึก"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "ระดับน้ำหมึก"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "ระดับน้ำหมึก"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "การรักษาความปลอดภัย"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr "หน้าจอ;ล็อค;วินิจฉัย;พัง;ส่วนตัว;ล่าสุด;ชั่วคราว;tmp;ดัชนี;ชื่อ;เครือข่าย;เอกลักษณ์;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ชื่ออุปกรณ์"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "ที่อยู่ฮาร์ดแวร์"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "หน่วยความจำ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "ตัวประมวลผล"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "กราฟิกส์"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "กำลังคำนวณ…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "ชื่อ"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "ชนิด"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "เทอร์มินัลของ GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "กำลังโหลดตัวเลือก…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "ซอฟต์แวร์สำหรับวินโดวส์"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "การจำลองเครื่องเสมือน"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "การใช้ซอฟต์แวร์"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "ลบอุปกรณ์ออก"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ชื่ออุปกรณ์"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "ชื่อ_ผู้ใช้"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
 msgid "View information about your system"
 msgstr "ดูข้อมูลเกี่ยวกับระบบของคุณ"
 
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:5
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
 msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 "อุปกรณ์;ระบบ;ข้อมูล;หน่วยความจำ;ตัวประมวลผล;รุ่น;ปริยาย;โปรแกรม;โปรแกรมหลักๆ;ซีดี;ดีวีดี;"
 "usb;เสียง;วีดิทัศน์;ดิสก์;ถอดเสียบ;สื่อ;autorun;"
 
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "เลือกวิธีจัดการสื่ออื่นๆ"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "_การกระทำ:"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "_ชนิด:"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "ชื่ออุปกรณ์"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "หน่วยความจำ"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "ตัวประมวลผล"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "ระบบพื้นฐาน"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "ดิสก์"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "กำลังคำนวณ…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "กราฟิกส์"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "การจำลองเครื่องเสมือน"
-
-#: ../panels/info/info.ui.h:13
-msgid "Check for updates"
-msgstr "ตรวจสอบซอฟต์แวร์รุ่นใหม่"
-
-#: ../panels/info/info.ui.h:15
-msgid "_Web"
-msgstr "เ_ว็บ"
-
-#: ../panels/info/info.ui.h:16
-msgid "_Mail"
-msgstr "เ_มล"
-
-#: ../panels/info/info.ui.h:17
-msgid "_Calendar"
-msgstr "_ปฏิทิน"
-
-#: ../panels/info/info.ui.h:18
-msgid "M_usic"
-msgstr "เ_พลง"
-
-#: ../panels/info/info.ui.h:19
-msgid "_Video"
-msgstr "วีดิ_ทัศน์"
-
-#: ../panels/info/info.ui.h:20
-msgid "_Photos"
-msgstr "_ภาพถ่าย:"
-
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "เลือกวิธีจัดการสื่อ"
-
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "ซีดีเ_พลง"
-
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "_ดีวีดีภาพยนตร์"
-
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "เ_ครื่องเล่นเพลง"
-
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "ซอ_ฟต์แวร์"
-
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "_สื่ออื่นๆ…"
-
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr "ไ_ม่ต้องถามหรือเปิดโปรแกรมในสื่อเมื่อใส่เข้ามา"
-
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "เสียงและเพลง"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "ปิดเสียง"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "เบาเสียงลง"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "เร่งเสียงขึ้น"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "ความดังของไมโครโฟน"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "เรียกโปรแกรมเล่นสื่อ"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "เล่น (หรือ เล่น/พัก)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "พักเพลง"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "หยุดเล่นเพลง"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "เพลงก่อนหน้า"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "เพลงถัดไป"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "เอาสื่อออก"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "การพิมพ์"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "สลับไปยังช่องทางป้อนข้อความเข้าถัดไป"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "สลับไปยังช่องทางป้อนข้อความเข้าก่อนหน้า"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "ปุ่มเรียก"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "เรียกโปรแกรมแสดงวิธีใช้"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/alt/cc-window.c:274
-#: ../shell/alt/cc-window.c:829 ../shell/cc-window.c:1584
-#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/window.ui.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "ตั้งค่า"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "เรียกเครื่องคิดเลข"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "เรียกโปรแกรมอ่าน-เขียนเมล"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "เรียกเว็บเบราว์เซอร์"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "โฟลเดอร์บ้าน"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "ค้นหา"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "ภาพหน้าจอ"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "จับภาพหน้าจอไปเก็บไว้ที่โฟลเดอร์ $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "จับภาพหน้าต่างไปเก็บไว้ที่โฟลเดอร์ $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "จับภาพพื้นที่หน้าจอไปเก็บไว้ที่โฟลเดอร์ $PICTURES"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "จับภาพหน้าจอเข้าไปไว้ในคลิปบอร์ด"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "จับภาพหน้าต่างเข้าไปไว้ในคลิปบอร์ด"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "จับภาพพื้นที่หน้าจอเข้าไปไว้ในคลิปบอร์ด"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "บันทึกภาพถ่ายทอดหน้าจออย่างสั้น"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "ระบบ"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "ออกจากระบบ"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "ล็อคหน้าจอ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-msgid "Universal Access"
-msgstr "การเข้าถึงหลากหลาย"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "ความปรากฏเห็น"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "เปิดหรือปิดการซูม"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "ซูมเข้า"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "ซูมออก"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "เปิดหรือปิดการอ่านหน้าจอ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "เปิดหรือปิดแป้นพิมพ์บนจอ"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "เพิ่มขนาดตัวอักษร"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "ลดขนาดตัวอักษร"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "เปิดหรือปิดการแสดงสีตัดกัน"
 
-#: ../panels/keyboard/cc-keyboard-manager.c:514
-#: ../panels/keyboard/cc-keyboard-manager.c:522
-#: ../panels/keyboard/cc-keyboard-manager.c:830
-msgid "Custom Shortcuts"
-msgstr "ปุ่มลัดกำหนดเอง"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "เพิ่มช่องทางป้อนข้อความ"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:440
-#: ../panels/keyboard/shortcut-editor.ui.h:2
-#: ../panels/network/network-wifi.ui.h:31
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-msgid "Disabled"
-msgstr "ไม่ใช้"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "ไม่สามารถใช้วิธีป้อนข้อความในหน้าจอเข้าระบบได้"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "ปุ่มยกแคร่ระดับสาม"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "ไม่ได้เลือกช่องทางป้อนข้อความใด"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "ปุ่ม Compose"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "ตัวเลือก"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "ปุ่มสลับไปยังช่องทางถัดไปโดยใช้ปุ่มประกอบเท่านั้น"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "เลื่อนขึ้น"
 
-#: ../panels/keyboard/cc-keyboard-panel.c:215
-msgid "Reset the shortcut to its default value"
-msgstr "คืนค่าปุ่มลัดกลับเป็นค่าปริยาย"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "เลื่อนลง"
 
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:357
-#, c-format
-msgid ""
-"%s is already being used for <b>%s</b>. If you replace it, %s will be "
-"disabled"
-msgstr "%s ถูกใช้กับ <b>%s</b> ไปแล้ว ถ้าคุณกำหนดทับ %s ก็จะถูกปิดไม่ให้ใช้งาน"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "ปรับแต่ง"
 
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:514
-msgid "Set Custom Shortcut"
-msgstr "ตั้งค่าปุ่มลัดที่กำหนดเอง"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "แสดงและแก้ไขตัวเลือกสำหรับผังแป้นพิมพ์"
 
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:514
-#: ../panels/keyboard/shortcut-editor.ui.h:7
-msgid "Set Shortcut"
-msgstr "ตั้งค่าปุ่มลัด"
-
-#. Setup the top label
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:523
-#, c-format
-msgid "Enter new shortcut to change <b>%s</b>."
-msgstr "กดปุ่มลัดใหม่เพื่อเปลี่ยน <b>%s</b>"
-
-#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:937
-msgid "Add Custom Shortcut"
-msgstr "เพิ่มปุ่มลัดกำหนดเอง"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "Key­board"
-msgstr "แป้น­พิมพ์"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:3
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr "ดูและตั้งปุ่มลัดและปรับแต่งการป้อนข้อความของคุณ"
-
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:5
-msgid "Shortcut;Repeat;Blink;"
-msgstr "ปุ่มลัด;ซ้ำปุ่ม;กะพริบ;"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "No keyboard shortcut found"
-msgstr "ไม่พบปุ่มลัด"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "Try a different search"
-msgstr "ลองค้นหาด้วยคำอื่น"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:1
-msgid "Press Esc to cancel."
-msgstr "กด Esc เพื่อยกเลิก"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:3
-#: ../panels/sound/gvc-mixer-dialog.c:1493
-#: ../panels/sound/gvc-sound-theme-chooser.c:564
-msgid "Name"
-msgstr "ชื่อ"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:4
-msgid "Command"
-msgstr "คำสั่ง"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:5
-msgid "Shortcut"
-msgstr "ปุ่มลัด"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:6
-msgid "Edit"
-msgstr "แก้ไข"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:8
-#: ../panels/network/network-wifi.ui.h:20
-msgid "None"
-msgstr "ไม่ใช้"
-
-#: ../panels/keyboard/shortcut-editor.ui.h:9
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "ลบออก"
 
-#: ../panels/keyboard/shortcut-editor.ui.h:10
-msgid "Enter the new shortcut"
-msgstr "กดปุ่มลัดอันใหม่"
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "ช่องทางป้อนข้อความ"
 
-#: ../panels/keyboard/shortcut-editor.ui.h:11
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-msgid "Cancel"
-msgstr "ยกเลิก"
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
 
-#: ../panels/keyboard/shortcut-editor.ui.h:12
-#: ../panels/network/connection-editor/ce-page-ip4.c:276
-#: ../panels/network/connection-editor/ce-page-ip6.c:277
-msgid "Add"
-msgstr "เพิ่ม"
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "ตัวเลือกของช่องทางป้อนข้อความ"
 
-#: ../panels/keyboard/shortcut-editor.ui.h:13
-msgid "Replace"
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "ใช้ช่องทางป้อนข้อความเ_ดียวกันหมดทุกหน้าต่าง"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "ใช้ช่องทางป้อนข้อความ_ต่างกันสำหรับแต่ละหน้าต่าง"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "ปุ่มยกแคร่ระดับสาม"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "ปุ่ม Compose"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "ปุ่มลัด"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "ปุ่มลัดกำหนดเอง"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+#, fuzzy
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "คืนค่าปุ่มลัดกลับเป็นค่าปริยาย"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "หัวข้อ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "ปุ่มลัด"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "เพิ่มปุ่มลัด"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
+msgstr "เพิ่มปุ่มลัดกำหนดเอง"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "เพิ่มปุ่มลัด"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "ไม่พบปุ่มลัด"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_ลบออก"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
 msgstr "กำหนดทับ"
 
-#: ../panels/keyboard/shortcut-editor.ui.h:14
-msgid "Set"
-msgstr "กำหนดค่า"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
 
-#: ../panels/mouse/cc-mouse-panel.c:82
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "ชื่อ"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "คำสั่ง"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "ปุ่มลัด"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "ตั้งค่าปุ่มลัด"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "ไม่ใช้"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "คืนค่าปุ่มลัดกลับเป็นค่าปริยาย"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "_กลับไปใช้ค่าปริยาย"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+#, fuzzy
+msgid "Keyboard"
+msgstr "แป้น­พิมพ์"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "ดูและตั้งปุ่มลัดและปรับแต่งการป้อนข้อความของคุณ"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "บริการตำแหน่งที่ตั้ง"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "ไม่มีโปรแกรมที่เล่นหรืออัดเสียงอยู่"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "ความดังของไมโครโฟน"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "ไม่พบโปรแกรม"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "_ทดสอบค่าตั้งของคุณ"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Mouse & Touch­pad"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "ทั่วไป"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "ปุ่มหลัก"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "กำหนดลำดับของปุ่มจริงบนเมาส์และทัชแพด"
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "ซ้าย"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "ขวา"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "ค้นหาตำแหน่งที่ตั้ง"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "เมาส์"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+msgid "Mouse Speed"
+msgstr "ความเร็วเมาส์"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "เลื่อนหน้าจอลง"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "การเลื่อนจะเลื่อนเนื้อหา ไม่ใช่เลื่อนช่องมอง"
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "การเลื่อนจะเลื่อนเนื้อหา ไม่ใช่เลื่อนช่องมอง"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "ความเร่_ง:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "ทำงานอยู่"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "ทัชแพด"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr "ความเร็วทัชแพด"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_วิธีการ"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr "คลิกด้วยการแตะ"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "คลิกด้วยการแตะ"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "ปิดขณะ_พิมพ์แป้นพิมพ์"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "ทัชแพด (สัมพัทธ์)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "เลื่อนหน้าจอที่ขอบ"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "เลื่อนหน้าจอไปทางซ้าย"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "สองหน้า"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ทดลองคลิก ดับเบิลคลิก และเลื่อนหน้า"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mouse & Touchpad"
 msgstr "เมาส์ & ทัช­แพด"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:3
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "ตั้งความไวของเมาส์หรือทัชแพดของคุณ และเลือกใช้เมาส์มือขวาหรือมือซ้าย"
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:5
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "ทัชแพด;ตัวชี้;คลิก;แตะ;ดับเบิล;ปุ่ม;แทร็กบอล;เลื่อน;"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "ทั่วไป"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "Primary Button"
-msgstr "ปุ่มหลัก"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "กำหนดลำดับของปุ่มจริงบนเมาส์และทัชแพด"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Left"
-msgstr "ซ้าย"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "Right"
-msgstr "ขวา"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "สเปซสี: "
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Mouse"
-msgstr "เมาส์"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Mouse Speed"
-msgstr "ความเร็วเมาส์"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "เ_ทขยะโดยอัตโนมัติ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgid "Double-click timeout"
-msgstr "ความเร็วของดับเบิลคลิก"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "Natural Scrolling"
-msgstr "เลื่อนหน้าจอแบบธรรมชาติ"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgid "Scrolling moves the content, not the view."
-msgstr "การเลื่อนจะเลื่อนเนื้อหา ไม่ใช่เลื่อนช่องมอง"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgid "Touchpad"
-msgstr "ทัชแพด"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "จอภาพ"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad Speed"
-msgstr "ความเร็วทัชแพด"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "ลากเพื่อเปลี่ยนจอแสดงผลหลัก"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgid "Tap to Click"
-msgstr "คลิกด้วยการแตะ"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgid "Two-finger Scrolling"
-msgstr "เลื่อนหน้าจอด้วยสองนิ้ว"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "โปรแกรม"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Edge Scrolling"
-msgstr "เลื่อนหน้าจอที่ขอบ"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "ทดลองคลิก ดับเบิลคลิก และเลื่อนหน้า"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "ห้าคลิก ได้เวลา GEGL!"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "ดับเบิลคลิก ปุ่มหลัก"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "คลิกเดียว ปุ่มหลัก"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "ดับเบิลคลิก ปุ่มกลาง"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "อุปกรณ์"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "คลิกเดียว ปุ่มกลาง"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "ดับเบิลคลิก ปุ่มรอง"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "เพิ่มช่องเชื่อมต่อ"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "คลิกเดียว ปุ่มรอง"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:349
-msgid "Air_plane Mode"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "เชื่อมต่อแล้ว"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "ตัวเลือก…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "จุดแพร่สัญญาณ Wi-Fi"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "ชื่อเครือข่าย"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "รหัสผ่าน"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "สุ่มรหัสผ่าน"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "สุ่มรหัสผ่าน"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_เปิด"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
 msgstr "โหมดเ_ครื่องบิน"
 
-#: ../panels/network/cc-network-panel.c:953
-msgid "Network proxy"
-msgstr "พร็อกซีเครือข่าย"
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1129 ../panels/network/net-vpn.c:283
-#: ../panels/network/net-vpn.c:440
-#, c-format
-msgid "%s VPN"
-msgstr "VPN %s"
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "ไม่พบรูปภาพ"
 
-#: ../panels/network/cc-network-panel.c:1194
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "โหมดเ_ครื่องบิน"
+
+#: panels/network/cc-wifi-panel.ui:165
+#, fuzzy
+msgid "Turn off to use Wi-Fi"
+msgstr "ปิด Wi-Fi เพื่อประหยัดพลังงาน"
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "จุดแพร่สัญญาณ Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "ใช้เป็นจุดแ_พร่สัญญาณ…"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "เครือข่าย"
+
+#: panels/network/cc-wifi-panel.ui:297
+#, fuzzy
+msgid "NetworkManager needs to be running"
+msgstr "ต้องมี NetworkManager ทำงานอยู่"
+
+#: panels/network/cc-wifi-panel.ui:303
 msgid "Oops, something has gone wrong. Please contact your software vendor."
 msgstr "มีบางอย่างไม่ถูกต้อง กรุณาติดต่อผู้จำหน่ายซอฟต์แวร์ของคุณ"
 
-#: ../panels/network/cc-network-panel.c:1200
-msgid "NetworkManager needs to be running."
-msgstr "ต้องมี NetworkManager ทำงานอยู่"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "การรักษาความปลอดภัยของ 802.1x"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "หน้า 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "เอกลักษณ์แบบนิ_รนาม"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:5
-msgid "Inner _authentication"
-msgstr "การยืนยันตัวบุคคลชั้นใ_น"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:6
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "หน้า 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:101
-#: ../panels/network/connection-editor/ce-page-security.c:459
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6
-msgid "Security"
-msgstr "การรักษาความปลอดภัย"
-
-#: ../panels/network/connection-editor/ce-page.c:481
-msgid "automatic"
-msgstr "อัตโนมัติ"
-
-#: ../panels/network/connection-editor/ce-page.c:521
-#, c-format
-msgid "Profile %d"
-msgstr "โพรไฟล์ %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:50
-#: ../panels/network/net-device-wifi.c:214
-#: ../panels/network/net-device-wifi.c:390
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:54
-#: ../panels/network/net-device-wifi.c:218
-#: ../panels/network/net-device-wifi.c:395
-#: ../panels/network/network-wifi.ui.h:19
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:58
-#: ../panels/network/net-device-wifi.c:222
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:63
-#: ../panels/network/net-device-wifi.c:227
-msgid "Enterprise"
-msgstr "เอนเทอร์ไพรส์"
-
-#: ../panels/network/connection-editor/ce-page-details.c:68
-#: ../panels/network/net-device-wifi.c:232
-#: ../panels/network/net-device-wifi.c:380
-msgctxt "Wifi security"
-msgid "None"
-msgstr "ไม่มี"
-
-#: ../panels/network/connection-editor/ce-page-details.c:89
-#: ../panels/power/power.ui.h:17
-msgid "Never"
-msgstr "ไม่มี"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/network/net-device-ethernet.c:120
-#: ../panels/network/net-device-wifi.c:485
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i วันก่อน"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:153
-#: ../panels/network/net-device-ethernet.c:50
-#: ../panels/network/net-device-wifi.c:542
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:179
-#: ../panels/network/net-device-wifi.c:571
-msgctxt "Signal strength"
-msgid "None"
-msgstr "ไม่มี"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:573
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "อ่อน"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:575
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "พอใช้"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:577
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "ดี"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:579
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "ดีมาก"
-
-#: ../panels/network/connection-editor/ce-page-details.c:225
-#: ../panels/network/network-wifi.ui.h:46 ../shell/alt/cc-window.c:266
-msgid "Details"
-msgstr "รายละเอียด"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:215
-#: ../panels/network/connection-editor/ce-page-vpn.c:221
-#: ../panels/network/connection-editor/ce-page-wifi.c:227
-#: ../panels/network/network-wifi.ui.h:47
-msgid "Identity"
-msgstr "ชื่อ"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:178
-#: ../panels/network/connection-editor/ce-page-ip4.c:432
-#: ../panels/network/connection-editor/ce-page-ip6.c:180
-#: ../panels/network/connection-editor/ce-page-ip6.c:427
-msgid "Address"
-msgstr "ที่อยู่"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:191
-#: ../panels/network/connection-editor/ce-page-ip4.c:445
-msgid "Netmask"
-msgstr "เน็ตแมสก์"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:205
-#: ../panels/network/connection-editor/ce-page-ip4.c:458
-#: ../panels/network/connection-editor/ce-page-ip6.c:206
-#: ../panels/network/connection-editor/ce-page-ip6.c:453
-#: ../panels/network/network-vpn.ui.h:2
-msgid "Gateway"
-msgstr "เกตเวย์"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:222
-#: ../panels/network/connection-editor/ce-page-ip6.c:223
-msgid "Delete Address"
-msgstr "ลบที่อยู่"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:339
-#: ../panels/network/connection-editor/ce-page-ip6.c:334
-msgid "Server"
-msgstr "เซิร์ฟเวอร์"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:356
-#: ../panels/network/connection-editor/ce-page-ip6.c:351
-msgid "Delete DNS Server"
-msgstr "ลบเซิร์ฟเวอร์ DNS"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:472
-#: ../panels/network/connection-editor/ce-page-ip6.c:467
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "เมตริก"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:493
-#: ../panels/network/connection-editor/ce-page-ip6.c:484
-msgid "Delete Route"
-msgstr "ลบเส้นทาง"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:597
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP)"
-msgstr "อัตโนมัติ (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:601
-#: ../panels/network/connection-editor/ce-page-ip6.c:592
-#: ../panels/network/network-wifi.ui.h:26
-#: ../panels/privacy/cc-privacy-panel.c:217
-msgid "Manual"
-msgstr "กำหนดเอง"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:605
-#: ../panels/network/connection-editor/ce-page-ip6.c:596
-msgid "Link-Local Only"
-msgstr "เชื่อมต่อภายในเท่านั้น"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:935
-#: ../panels/network/network-wifi.ui.h:48
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:193
-#: ../panels/network/connection-editor/ce-page-ip6.c:440
-msgid "Prefix"
-msgstr "Prefix"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:584
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:217
-msgid "Automatic"
-msgstr "อัตโนมัติ"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:588
-msgid "Automatic, DHCP only"
-msgstr "อัตโนมัติ ใช้ DHCP เท่านั้น"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:898
-#: ../panels/network/network-wifi.ui.h:49
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:78
-#: ../panels/network/network-wifi.ui.h:51
-msgid "Reset"
-msgstr "ล้างค่า"
-
-#: ../panels/network/connection-editor/ce-page-security.c:248
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "ไม่ใช้"
-
-#: ../panels/network/connection-editor/ce-page-security.c:271
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/กุญแจ 128 บิต (ฐานสิบหกหรือ ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:281
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP วลีรหัสผ่าน 128 บิต"
-
-#: ../panels/network/connection-editor/ce-page-security.c:294
-#: ../panels/network/wireless-security/wireless-security.c:463
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:307
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP แบบผันแปร (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:321
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 ส่วนบุคคล"
-
-#: ../panels/network/connection-editor/ce-page-security.c:335
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 เอนเทอร์ไพรส์"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:4
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "ความแรงของสัญญาณ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "อัตราเร็วลิงก์"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:153
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:644
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "การรักษาความปลอดภัย"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "ที่อยู่ IPv4"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:154
-#: ../panels/network/net-device-ethernet.c:158
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:645
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "ที่อยู่ IPv6"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:161
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "ที่อยู่ฮาร์ดแวร์"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:165
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:10
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "โพรไฟล์ ICC ที่รองรับ"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "เส้นทางปริยาย"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:11
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "ใช้ครั้งล่าสุด"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "Twisted Pair (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "Attachment Unit Interface (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "Media Independent Interface (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "_ชื่อ"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:38
-msgid "_MAC Address"
-msgstr "ที่อยู่ _MAC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "M_TU"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "ที่อยู่ที่_ถอดแบบมา"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "ไบต์"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "เปิดให้ผู้ใ_ช้อื่นใช้ด้วย"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "เชื่อมต่อโดย_อัตโนมัติ"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-msgid "Firewall _Zone"
-msgstr "เ_ขตไฟร์วอลล์"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-#: ../panels/network/connection-editor/firewall-helpers.c:118
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "ปริยาย"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:50
-msgid "The zone defines the trust level of the connection"
-msgstr "เขตนี้จะกำหนดระดับความเชื่อถือของการเชื่อมต่อ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:24
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:25
-msgid "_Addresses"
-msgstr "_ที่อยู่"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "DNS อัตโนมัติ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Routes"
-msgstr "เส้นทาง"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "เส้นทางอัตโนมัติ"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:34
-msgid "Use this connection _only for resources on its network"
-msgstr "ใช้การเชื่อมต่อนี้สำหรับทรัพยากรในเครือข่ายของมันเ_ท่านั้น"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:36
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:296
-msgid "Unable to open connection editor"
-msgstr "ไม่สามารถเปิดเครื่องมือแก้ไขการเชื่อมต่อ"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:314
-msgid "New Profile"
-msgstr "โพรไฟล์ใหม่"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:635
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:783
-msgid "Import from file…"
-msgstr "นำเข้าจากแฟ้ม…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:817
-msgid "Add VPN"
-msgstr "เพิ่ม VPN"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:41
-msgid "_Reset"
-msgstr "_ล้างค่า"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1536
-#: ../panels/network/network-wifi.ui.h:42
-msgid "_Forget"
-msgstr "ล_บทิ้ง"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr "ล้างการตั้งค่าสำหรับเครือข่ายนี้ รวมถึงรหัสผ่าน แต่จำเครือข่ายไว้"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr "ลบรายละเอียดที่เกี่ยวข้องกับเครือข่ายนี้ทั้งหมด และไม่พยายามเชื่อมต่ออัตโนมัติ"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:16
-msgid "S_ecurity"
-msgstr "การ_รักษาความปลอดภัย"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:141
-msgid "Cannot import VPN connection"
-msgstr "ไม่สามารถนำเข้าการเชื่อมต่อ VPN"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:143
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"แฟ้ม '%s' ไม่สามารถอ่านได้ หรือไม่มีข้อมูลการเชื่อมต่อ VPN ที่รู้จัก\n"
-"\n"
-"ข้อผิดพลาด: %s"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:178
-msgid "Select file to import"
-msgstr "เลือกแฟ้มที่จะนำเข้า"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:182
-#: ../panels/printers/cc-printers-panel.c:2077
-#: ../panels/sharing/cc-sharing-panel.c:373
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "_Open"
-msgstr "_เปิด"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:230
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "มีแฟ้มชื่อ \"%s\" อยู่ก่อนแล้ว"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:232
-msgid "_Replace"
-msgstr "แ_ทนที่"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:234
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "คุณต้องการจะแทนที่ %s ด้วยการเชื่อมต่อ VPN ที่คุณกำลังจะบันทึกนี้หรือไม่?"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:270
-msgid "Cannot export VPN connection"
-msgstr "ไม่สามารถส่งออกการเชื่อมต่อ VPN"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:272
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"ไม่สามารถส่งออกการเชื่อมต่อ '%s' ออกยัง %s\n"
-"\n"
-"ข้อผิดพลาด: %s"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:307
-msgid "Export VPN connection"
-msgstr "ส่งออกการเชื่อมต่อ VPN"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(ข้อผิดพลาด: ไม่สามารถโหลดเครื่องมือแก้ไขการเชื่อมต่อ VPN)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "_SSID"
-msgstr "_SSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:15
-msgid "_BSSID"
-msgstr "_BSSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:18
-msgid "My Home Network"
-msgstr "เครือข่ายของบ้านฉัน"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "เปิดให้ผู้ใ_ช้อื่นใช้ด้วย"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Net­work"
-msgstr "เครือ­ข่าย"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:3
-msgid "Control how you connect to the Internet"
-msgstr "ควบคุมวิธีการเชื่อมต่อกับอินเทอร์เน็ตของคุณ"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:5
-msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"DNS;"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
-"เครือข่าย;ไร้สาย;Wi-Fi;Wifi;ไอพี;แลน;พร็อกซี;แวน;บรอดแบนด์;โมเด็ม;บลูทูท;vpn;DNS;"
 
-#: ../panels/network/net-device-ethernet.c:106
-#: ../panels/network/net-device-wifi.c:471
-msgid "never"
-msgstr "ยังไม่เคยใช้"
-
-#: ../panels/network/net-device-ethernet.c:116
-#: ../panels/network/net-device-wifi.c:481
-msgid "today"
-msgstr "วันนี้"
-
-#: ../panels/network/net-device-ethernet.c:118
-#: ../panels/network/net-device-wifi.c:483
-msgid "yesterday"
-msgstr "เมื่อวาน"
-
-#: ../panels/network/net-device-ethernet.c:156
-#: ../panels/network/network-mobile.ui.h:3 ../panels/network/panel-common.c:647
-#: ../panels/network/panel-common.c:649 ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "ที่อยู่ไอพี"
-
-#: ../panels/network/net-device-ethernet.c:172
-#: ../panels/network/network-wifi.ui.h:12
-msgid "Last used"
-msgstr "ใช้ครั้งล่าสุด"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:280
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "ใช้สาย"
-
-#: ../panels/network/net-device-ethernet.c:348
-#: ../panels/network/net-device-wifi.c:1694
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8 ../panels/network/network-vpn.ui.h:7
-msgid "Options…"
-msgstr "ตัวเลือก…"
-
-#: ../panels/network/net-device-mobile.c:223
-msgid "Add new connection"
-msgstr "เพิ่มช่องเชื่อมต่อ"
-
-#: ../panels/network/net-device-wifi.c:1205
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
-"ถ้าคุณมีการเชื่อมต่อไปยังอินเทอร์เน็ตทางอื่นนอกเหนือจากเครือข่ายไร้สาย "
-"คุณก็สามารถตั้งค่าจุดแพร่สัญญาณไร้สายเพื่อแบ่งปันการเชื่อมต่ออินเทอร์เน็ตให้ผู้อื่นใช้ได้"
 
-#: ../panels/network/net-device-wifi.c:1209
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "การเปิดใช้จุดแพร่สัญญาณไร้สายจะเป็นการตัดการเชื่อมต่อจาก <b>%s</b>"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_ชื่อ"
 
-#: ../panels/network/net-device-wifi.c:1213
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr "คุณจะไม่สามารถเข้าถึงอินเทอร์เน็ตผ่านเครือข่ายไร้สายได้ในระหว่างเปิดใช้จุดแพร่สัญญาณ"
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "ที่อยู่ _MAC"
 
-#: ../panels/network/net-device-wifi.c:1296
-msgid "Stop hotspot and disconnect any users?"
-msgstr "จะปิดจุดแพร่สัญญาณและตัดการเชื่อมต่อกับผู้ใช้ทั้งหมดหรือไม่?"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
 
-#: ../panels/network/net-device-wifi.c:1299
-msgid "_Stop Hotspot"
-msgstr "ปิ_ดจุดแพร่สัญญาณ"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "ที่อยู่ที่_ถอดแบบมา"
 
-#: ../panels/network/net-device-wifi.c:1397
-msgid "System policy prohibits use as a Hotspot"
-msgstr "นโยบายของระบบห้ามใช้เป็นจุดแพร่สัญญาณ"
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "ไบต์"
 
-#: ../panels/network/net-device-wifi.c:1400
-msgid "Wireless device does not support Hotspot mode"
-msgstr "อุปกรณ์ไร้สายไม่รองรับโหมดจุดแพร่สัญญาณ"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "_วิธีการ"
 
-#: ../panels/network/net-device-wifi.c:1532
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr "รายละเอียดของเครือข่ายที่เลือก รวมถึงรหัสผ่านและค่าปรับแต่งใดๆ จะถูกลบทิ้ง"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "อัตโนมัติ (DHCP)"
 
-#: ../panels/network/net-device-wifi.c:1842
-msgid "History"
-msgstr "ประวัติ"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "เชื่อมต่อภายในเท่านั้น"
 
-#: ../panels/network/net-device-wifi.c:1846
-#: ../panels/printers/options-dialog.ui.h:2
-#: ../panels/wacom/button-mapping.ui.h:2 ../panels/wacom/cc-wacom-page.c:525
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "_Close"
-msgstr "ปิ_ด"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1854
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_ลบทิ้ง"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "การตรวจหาเว็บพร็อกซีอัตโนมัติจะใช้เมื่อไม่มีการกำหนด URL สำหรับตั้งค่าไว้"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "ไม่แนะนำให้ใช้ในเครือข่ายสาธารณะที่ไม่น่าเชื่อถือ"
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "พร็อกซี"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "เ_พิ่มโพรไฟล์…"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "ผู้ให้บริการ"
-
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "เครือข่าย"
-
-#: ../panels/network/network-proxy.ui.h:1
-msgctxt "proxy method"
-msgid "None"
-msgstr "ไม่ใช้"
-
-#: ../panels/network/network-proxy.ui.h:2
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "กำหนดเอง"
 
-#: ../panels/network/network-proxy.ui.h:3
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "ไม่ใช้"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "แบ่งปันให้เครื่องอื่น"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_ที่อยู่"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ที่อยู่"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "เน็ตแมสก์"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "เกตเวย์"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "อัตโนมัติ"
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS อัตโนมัติ"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "เส้นทาง"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "เส้นทางอัตโนมัติ"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "เมตริก"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "ใช้การเชื่อมต่อนี้สำหรับทรัพยากรในเครือข่ายของมันเ_ท่านั้น"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
 msgstr "_วิธีการ"
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "URL สำหรับตั้ง_ค่า"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "อัตโนมัติ ใช้ DHCP เท่านั้น"
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "พร็อกซี _HTTP"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Prefix"
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "พร็อกซี H_TTPS"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "การ_รักษาความปลอดภัย"
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "พร็อกซี _FTP"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ข้อผิดพลาด: ไม่สามารถโหลดเครื่องมือแก้ไขการเชื่อมต่อ VPN)"
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "โฮสต์ _Socks"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "โฮสต์ที่ไ_ม่ผ่านพร็อกซี"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
 
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "พอร์ตพร็อกซี HTTP"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "เครือข่าย"
 
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "พอร์ตพร็อกซี HTTPS"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "ควบคุมวิธีการเชื่อมต่อกับอินเทอร์เน็ตของคุณ"
 
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "พอร์ตพร็อกซี FTP"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"เครือข่าย;ไร้สาย;Wi-Fi;Wifi;ไอพี;แลน;พร็อกซี;แวน;บรอดแบนด์;โมเด็ม;บลูทูท;vpn;DNS;"
 
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "พอร์ตพร็อกซี Socks"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "ปิดอุปกรณ์"
-
-#: ../panels/network/network.ui.h:1
-msgid "Add Device"
-msgstr "เพิ่มอุปกรณ์"
-
-#: ../panels/network/network.ui.h:2
-msgid "Remove Device"
-msgstr "ลบอุปกรณ์ออก"
-
-#: ../panels/network/network-vpn.ui.h:1
-msgid "VPN Type"
-msgstr "ชนิด VPN"
-
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Group Name"
-msgstr "ชื่อกลุ่ม"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Password"
-msgstr "รหัสผ่านกลุ่ม"
-
-#: ../panels/network/network-vpn.ui.h:5
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "ชื่อผู้ใช้"
-
-#: ../panels/network/network-vpn.ui.h:6
-msgid "Turn VPN connection off"
-msgstr "ปิดการเชื่อมต่อ VPN"
-
-#: ../panels/network/network-wifi.ui.h:3
-msgid "Automatic _Connect"
-msgstr "เชื่อม_ต่ออัตโนมัติ"
-
-#: ../panels/network/network-wifi.ui.h:13
-msgid "details"
-msgstr "รายละเอียด"
-
-#: ../panels/network/network-wifi.ui.h:17
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/sharing/sharing.ui.h:9
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "_Password"
-msgstr "_รหัสผ่าน"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Show P_assword"
-msgstr "แ_สดงรหัสผ่าน"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "Make available to other users"
-msgstr "เปิดให้ผู้ใช้อื่นใช้ด้วย"
-
-#: ../panels/network/network-wifi.ui.h:23
-msgid "identity"
-msgstr "ชื่อ"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Automatic (DHCP) addresses only"
-msgstr "อัตโนมัติ (DHCP) เฉพาะที่อยู่"
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Link-local only"
-msgstr "เชื่อมต่อภายในเท่านั้น"
-
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Shared with other computers"
-msgstr "แบ่งปันให้เครื่องอื่น"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "_Ignore automatically obtained routes"
-msgstr "ไ_ม่สนใจเส้นทางเครือข่ายที่ได้รับมาแบบอัตโนมัติ"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Cloned MAC Address"
-msgstr "_ถอดแบบที่อยู่ MAC"
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid "hardware"
-msgstr "ฮาร์ดแวร์"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr "ล้างการตั้งค่าสำหรับการเชื่อมต่อนี้ให้เป็นค่าปริยาย แต่จำการเชื่อมต่อไว้"
-
-#: ../panels/network/network-wifi.ui.h:44
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr "ลบรายละเอียดที่เกี่ยวข้องกับเครือข่ายนี้ทั้งหมด และไม่พยายามเชื่อมต่ออัตโนมัติกับเครือข่ายนี้"
-
-#: ../panels/network/network-wifi.ui.h:45
-msgid "reset"
-msgstr "ล้างค่า"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Hardware"
-msgstr "ฮาร์ดแวร์"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "Wi-Fi Hotspot"
-msgstr "จุดแพร่สัญญาณ Wi-Fi"
-
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Turn On"
-msgstr "_เปิด"
-
-#: ../panels/network/network-wifi.ui.h:54
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "Turn Wi-Fi off"
-msgstr "ปิด Wi-Fi"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "ควบคุมวิธีการเชื่อมต่อกับอินเทอร์เน็ตของคุณ"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_Use as Hotspot…"
-msgstr "ใช้เป็นจุดแ_พร่สัญญาณ…"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"เครือข่าย;ไร้สาย;Wi-Fi;Wifi;ไอพี;แลน;พร็อกซี;แวน;บรอดแบนด์;โมเด็ม;บลูทูท;vpn;DNS;"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "_Connect to Hidden Network…"
-msgstr "เ_ชื่อมต่อไปยังเครือข่ายที่ซ่อนตัวอยู่…"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "ใช้สาย"
 
-#: ../panels/network/network-wifi.ui.h:58
-msgid "_History"
-msgstr "_ประวัติ"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "ปิดอุปกรณ์"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "ปิดหากต้องการเชื่อมต่อไปยังเครือข่าย Wi-Fi"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "ทำงานอยู่"
 
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "ผู้ให้บริการ"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "ที่อยู่ไอพี"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "พร็อกซีเครือข่าย"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "พร็อกซี _HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "พร็อกซี H_TTPS"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "พร็อกซี _FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "โฮสต์ _Socks"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "โฮสต์ที่ไ_ม่ผ่านพร็อกซี"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "พอร์ตพร็อกซี HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "พอร์ตพร็อกซี HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "พอร์ตพร็อกซี FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "พอร์ตพร็อกซี Socks"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "URL สำหรับตั้ง_ค่า"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "ปิดการเชื่อมต่อ VPN"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "ชื่อเครือข่าย"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Connected Devices"
-msgstr "อุปกรณ์ที่เชื่อมต่อ"
-
-#: ../panels/network/network-wifi.ui.h:62
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "ระบบรักษาความปลอดภัย"
 
-#: ../panels/network/network-wifi.ui.h:63
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Password"
 msgstr "รหัสผ่าน"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:127
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "ปิด Wi-Fi"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Infrastructure"
-msgstr "Infrastructure"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "กำลังโหลดตัวเลือก…"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:147 ../panels/network/panel-common.c:201
-msgid "Status unknown"
-msgstr "ไม่ทราบสถานะ"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "เ_ชื่อมต่อไปยังเครือข่ายที่ซ่อนตัวอยู่…"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:151
-msgid "Unmanaged"
-msgstr "ไม่มีการจัดการ"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "จุดแพร่สัญญาณ Wi-Fi"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unavailable"
-msgstr "ใช้งานไม่ได้"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:165 ../panels/network/panel-common.c:207
-msgid "Connecting"
-msgstr "กำลังเชื่อมต่อ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Authentication required"
-msgstr "ต้องยืนยันตัวบุคคล"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Connected"
-msgstr "เชื่อมต่อแล้ว"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:177
-msgid "Disconnecting"
-msgstr "กำลังตัดการเชื่อมต่อ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:181 ../panels/network/panel-common.c:219
-msgid "Connection failed"
-msgstr "เชื่อมต่อไม่สำเร็จ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:227
-msgid "Status unknown (missing)"
-msgstr "ไม่ทราบสถานะ (ค่าหายไป)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:223
-msgid "Not connected"
-msgstr "ไม่ได้เชื่อมต่อ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:248
-msgid "Configuration failed"
-msgstr "ตั้งค่าไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "IP configuration failed"
-msgstr "ตั้งค่าไอพีไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration expired"
-msgstr "ค่าไอพีหมดอายุ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "Secrets were required, but not provided"
-msgstr "ต้องการข้อมูลลับ แต่ไม่ได้ป้อนไว้"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x supplicant ถูกตัดการเชื่อมต่อ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant configuration failed"
-msgstr "ตั้งค่า 802.1x supplicant ไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant failed"
-msgstr "802.1x supplicant ล้มเหลว"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant ใช้เวลายืนยันตัวบุคคลนานเกินไป"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "PPP service failed to start"
-msgstr "เปิดบริการ PPP ไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service disconnected"
-msgstr "บริการ PPP ถูกตัดการเชื่อมต่อ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP failed"
-msgstr "PPP ล้มเหลว"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "DHCP client failed to start"
-msgstr "เปิดใช้ลูกข่าย DHCP ไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client error"
-msgstr "เกิดข้อผิดพลาดที่ลูกข่าย DHCP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client failed"
-msgstr "ลูกข่าย DHCP ล้มเหลว"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "Shared connection service failed to start"
-msgstr "เปิดบริการแบ่งปันการเชื่อมต่อไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed"
-msgstr "บริการแบ่งปันการเชื่อมต่อล้มเหลว"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "AutoIP service failed to start"
-msgstr "เปิดบริการ AutoIP ไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service error"
-msgstr "เกิดข้อผิดพลาดที่บริการ AutoIP"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service failed"
-msgstr "บริการ AutoIP ล้มเหลว"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "Line busy"
-msgstr "สายไม่ว่าง"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "No dial tone"
-msgstr "ไม่มีสัญญาณหมุนเลขหมาย"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No carrier could be established"
-msgstr "ไม่สามารถเชื่อมต่อกับผู้ให้บริการ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "Dialing request timed out"
-msgstr "หมดเวลาคอยการหมุนเลขหมาย"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing attempt failed"
-msgstr "หมุนเลขหมายไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Modem initialization failed"
-msgstr "ตั้งค่าเริ่มต้นโมเด็มไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Failed to select the specified APN"
-msgstr "เลือก APN ที่กำหนดไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Not searching for networks"
-msgstr "ไม่ได้อยู่ระหว่างค้นหาเครือข่าย"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Network registration denied"
-msgstr "การลงทะเบียนเครือข่ายถูกปฏิเสธ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration timed out"
-msgstr "หมดเวลาคอยลงทะเบียนเครือข่าย"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Failed to register with the requested network"
-msgstr "ลงทะเบียนกับเครือข่ายที่ร้องขอไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "PIN check failed"
-msgstr "การตรวจสอบ PIN ล้มเหลว"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "Firmware for the device may be missing"
-msgstr "อาจขาดเฟิร์มแวร์สำหรับอุปกรณ์"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Connection disappeared"
-msgstr "การเชื่อมต่อหายไป"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Existing connection was assumed"
-msgstr "ถือว่ามีการเชื่อมต่ออยู่ก่อนแล้ว"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Modem not found"
-msgstr "ไม่พบโมเด็ม"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Bluetooth connection failed"
-msgstr "เชื่อมต่อบลูทูทไม่สำเร็จ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "SIM Card not inserted"
-msgstr "ไม่ได้ใส่ SIM card"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Pin required"
-msgstr "ต้องการรหัส PIN ของ SIM"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Puk required"
-msgstr "ต้องการรหัส PUK ของ SIM"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM wrong"
-msgstr "SIM ผิด"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "Connection dependency failed"
-msgstr "สิ่งที่ต้องใช้สำหรับการเชื่อมต่อล้มเหลว"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:433
-msgid "Firmware missing"
-msgstr "ขาดเฟิร์มแวร์"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:437
-msgid "Cable unplugged"
-msgstr "สายเคเบิลถูกถอดออก"
-
-#: ../panels/network/wireless-security/eap-method.c:69
-msgid "undefined error in 802.1x security (wpa-eap)"
-msgstr "เกิดข้อผิดพลาดที่ไม่ได้บัญญัติไว้ในความปลอดภัย 802.1x (wpa-eap)"
-
-#: ../panels/network/wireless-security/eap-method.c:245
-msgid "no file selected"
-msgstr "ไม่ได้เลือกแฟ้ม"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid "unspecified error validating eap-method file"
-msgstr "เกิดข้อผิดพลาดที่ไม่ได้บัญญัติไว้ขณะตรวจความถูกต้องของแฟ้ม eap-method"
-
-#: ../panels/network/wireless-security/eap-method.c:480
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "กุญแจส่วนตัวแบบ DER, PEM, หรือ PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: ../panels/network/wireless-security/eap-method.c:483
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "ใบรับรองแบบ DER หรือ PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:72
-msgid "missing EAP-FAST PAC file"
-msgstr "ไม่มีแฟ้ม PAC สำหรับ EAP-FAST"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:268
-#: ../panels/network/wireless-security/eap-method-peap.c:302
-#: ../panels/network/wireless-security/eap-method-ttls.c:333
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:283
-#: ../panels/network/wireless-security/eap-method-peap.c:272
-#: ../panels/network/wireless-security/eap-method-ttls.c:288
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:406
-msgid "Choose a PAC file"
-msgstr "เลือกแฟ้ม PAC"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:413
-msgid "PAC files (*.pac)"
-msgstr "แฟ้ม PAC (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "นิรนาม"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "ผ่านการยืนยันตัวบุคคล"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "ทั้งสองอย่าง"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "เอกลักษณ์แบบนิ_รนาม"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
 msgid "PAC _file"
 msgstr "แ_ฟ้ม PAC"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:5
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "เลือกแฟ้ม PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
 msgstr "การยืนยันตัวบุคคลชั้นใ_น"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
 msgstr "อนุญาตให้_จัดเตรียม PAC อัตโนมัติ"
 
-#: ../panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "ขาดชื่อผู้ใช้ EAP-LEAP"
-
-#: ../panels/network/wireless-security/eap-method-leap.c:74
-msgid "missing EAP-LEAP password"
-msgstr "ขาดรหัสผ่าน EAP-LEAP"
-
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "ชื่อ_ผู้ใช้"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:7
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_รหัสผ่าน"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "แ_สดงรหัสผ่าน"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:63
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "ใบรับรอง EAP-PEAP CA ไม่ถูกต้อง: %s"
-
-#: ../panels/network/wireless-security/eap-method-peap.c:68
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "ใบรับรอง EAP-PEAP CA ไม่ถูกต้อง: ไม่ได้ระบุใบรับรอง"
-
-#: ../panels/network/wireless-security/eap-method-peap.c:287
-#: ../panels/network/wireless-security/eap-method-ttls.c:318
-#: ../panels/network/wireless-security/wireless-security.c:439
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:381
-#: ../panels/network/wireless-security/eap-method-tls.c:501
-#: ../panels/network/wireless-security/eap-method-ttls.c:412
-msgid "Choose a Certificate Authority certificate"
-msgstr "เลือกใบรับรองจากองค์กรออกใบรับรอง"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "รุ่น 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "รุ่น 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "ใ_บรับรอง CA"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "เลือกใบรับรองจากองค์กรออกใบรับรอง"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
 msgid "No CA certificate is _required"
 msgstr "ไ_ม่ต้องใช้ใบรับรอง CA"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:9
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "รุ่_นของ PEAP"
 
-#: ../panels/network/wireless-security/eap-method-simple.c:74
-msgid "missing EAP username"
-msgstr "ขาดชื่อผู้ใช้ EAP"
-
-#: ../panels/network/wireless-security/eap-method-simple.c:87
-msgid "missing EAP password"
-msgstr "ขาดรหัสผ่าน EAP"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:68
-msgid "missing EAP-TLS identity"
-msgstr "ขาดเอกลักษณ์ EAP-TLS"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:77
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "ใบรับรอง EAP-TLS CA ไม่ถูกต้อง: %s"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:84
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "ใบรับรอง EAP-TLS CA ไม่ถูกต้อง: ไม่ได้ระบุใบรับรอง"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:95
-msgid "invalid EAP-TLS password: missing"
-msgstr "รหัสผ่าน EAP-TLS ไม่ถูกต้อง: ไม่มีรหัสผ่าน"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:109
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "กุญแจส่วนตัว EAP-TLS ไม่ถูกต้อง: %s"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:119
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "ใบรับรองผู้ใช้ EAP-TLS ไม่ถูกต้อง: %s"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:316
-msgid "Unencrypted private keys are insecure"
-msgstr "กุญแจส่วนตัวที่ไม่เข้ารหัสลับนั้นไม่มีความปลอดภัย"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:319
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"กุญแจส่วนตัวที่เลือกไม่มีการปกป้องด้วยรหัสผ่าน "
-"ซึ่งอาจทำให้ข้อมูลลับของระบบรักษาความปลอดภัยของคุณถูกขโมยใช้ได้ "
-"กรุณาเลือกกุญแจส่วนตัวที่มีการปกป้องด้วยรหัสผ่าน\n"
-"\n"
-"(คุณสามารถปกป้องกุญแจส่วนตัวของคุณด้วยรหัสผ่านได้ โดยใช้ openssl)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:495
-msgid "Choose your personal certificate"
-msgstr "เลือกใบรับรองส่วนตัวของคุณ"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:507
-msgid "Choose your private key"
-msgstr "เลือกกุญแจส่วนตัวของคุณ"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "_ชื่อ"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "ใ_บรับรองของผู้ใช้"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "กุญแจ_ส่วนตัว"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "_รหัสผ่านกุญแจส่วนตัว"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:63
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "ใบรับรอง EAP-TTLS CA ไม่ถูกต้อง: %s"
-
-#: ../panels/network/wireless-security/eap-method-ttls.c:68
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "ใบรับรอง EAP-TTLS CA ไม่ถูกต้อง: ไม่ได้ระบุใบรับรอง"
-
-#: ../panels/network/wireless-security/eap-method-ttls.c:258
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:273
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:303
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/wireless-security.c:87
-msgid "Unknown error validating 802.1x security"
-msgstr "เกิดข้อผิดพลาดไม่ทราบสาเหตุขณะตรวจสอบความปลอดภัย 802.1x"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "โ_ดเมน"
 
-#: ../panels/network/wireless-security/wireless-security.c:451
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:475
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
 msgid "PWD"
 msgstr "PWD"
 
-#: ../panels/network/wireless-security/wireless-security.c:486
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:497
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "TLS ผ่านทันเนล"
 
-#: ../panels/network/wireless-security/wireless-security.c:508
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "EAP ที่มีการปกป้อง (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "การ_ยืนยันตัวบุคคล"
 
-#: ../panels/network/wireless-security/ws-leap.c:63
-msgid "missing leap-username"
-msgstr "ขาดชื่อผู้ใช้ leap"
-
-#: ../panels/network/wireless-security/ws-leap.c:74
-msgid "missing leap-password"
-msgstr "ขาดรหัสผ่าน leap"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:107
-msgid "missing wep-key"
-msgstr "ขาด wep-key"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:116
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "wep-key ไม่ถูกต้อง: คีย์ความยาว %zu ต้องมีเฉพาะตัวเลขฐานสิบหกเท่านั้น"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:124
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "wep-key ไม่ถูกต้อง: คีย์ความยาว %zu ต้องมีเฉพาะอักขระแอสกี้เท่านั้น"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:130
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"wep-key ไม่ถูกต้อง: ความยาวคีย์ %zu ไม่ถูกต้อง คีย์ต้องยาว 5/13 (แอสกี) หรือ 10/26 "
-"(ฐานสิบหก) อย่างใดอย่างหนึ่ง"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:137
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "wep-key ไม่ถูกต้อง: วลีรหัสผ่านต้องไม่ว่างเปล่า"
-
-#: ../panels/network/wireless-security/ws-wep-key.c:139
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "wep-key ไม่ถูกต้อง: วลีรหัสผ่านต้องสั้นกว่า 64 อักขระ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (ปริยาย)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "ระบบเปิด"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "ใช้กุญแจร่วมกัน"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "กุญแ_จ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "แ_สดงกุญแจ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "_ดัชนี WEP"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.c:70
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk ไม่ถูกต้อง: ความยาวคีย์ %zu ไม่ถูกต้อง ต้องยาวตั้งแต่ 8 ถึง 63 ไบต์ "
-"หรือเป็นเลขฐานสิบหก 64 หลักเท่านั้น"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.c:79
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "wpa-psk ไม่ถูกต้อง: ไม่สามารถอ่านค่าคีย์ความยาว 64 ไบต์เป็นเลขฐานสิบหกได้"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_ชนิด"
 
-#: ../panels/notifications/cc-notifications-panel.c:257
-#: ../panels/power/cc-power-panel.c:1966 ../panels/power/cc-power-panel.c:1973
-#: ../panels/privacy/cc-privacy-panel.c:190
-#: ../panels/privacy/cc-privacy-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:269
-#: ../panels/universal-access/cc-ua-panel.c:590
-#: ../panels/universal-access/cc-ua-panel.c:603
-#: ../panels/universal-access/cc-ua-panel.c:615
-#: ../panels/universal-access/cc-ua-panel.c:786
-msgid "On"
-msgstr "เปิด"
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (ปริยาย)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "ระบบเปิด"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "ใช้กุญแจร่วมกัน"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "กุญแ_จ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "แ_สดงกุญแจ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "_ดัชนี WEP"
 
 #. This is the per application switch for message tray usage.
-#: ../panels/notifications/edit-dialog.ui.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
 msgstr "_การแจ้งเหตุ"
 
 #. This is the setting to configure sounds associated with notifications.
-#: ../panels/notifications/edit-dialog.ui.h:4
+#: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
 msgstr "เสียงแจ้งเ_ตือน"
 
-#: ../panels/notifications/edit-dialog.ui.h:5
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Notification _Banners"
-msgstr "_พาดหัวการแจ้งเหตุ"
+msgid "Notification _Popups"
+msgstr "_การแจ้งเหตุ"
 
-#. Banners here refers to message tray notifications in the middle of the screen.
-#: ../panels/notifications/edit-dialog.ui.h:7
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Message _Content in Banners"
+msgid "Show Message _Content in Popups"
 msgstr "แสดงเ_นื้อหาข้อความในพาดหัว"
 
-#: ../panels/notifications/edit-dialog.ui.h:8
+#: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
 msgstr "การแจ้งเหตุการ_ล็อคหน้าจอ"
 
-#: ../panels/notifications/edit-dialog.ui.h:9
+#: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
 msgstr "แสดงเนื้อ_หาข้อความในหน้าล็อคหน้าจอ"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
-msgid "No­ti­fi­ca­tions"
-msgstr "การ­แจ้ง­เหตุ"
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:3
-msgid "Control which notifications are displayed and what they show"
-msgstr "ควบคุมการแจ้งเหตุว่าจะแสดงรายการใดหรือสิ่งใดบ้าง"
-
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:5
-msgid "Notifications;Banner;Message;Tray;Popup;"
-msgstr "การแจ้งเหตุ;พาดหัว;ข้อความ;ถาด;กล่องผุดขึ้น;"
-
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Notification _Banners"
-msgstr "_พาดหัวการแจ้งเหตุ"
-
-#: ../panels/notifications/notifications.ui.h:2
+#: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
 msgstr "การแจ้งเหตุการ_ล็อคหน้าจอ"
 
-#. List of applications.
-#: ../panels/notifications/notifications.ui.h:4
-#: ../panels/privacy/privacy.ui.h:45 ../panels/sound/gvc-mixer-dialog.c:1781
-msgid "Applications"
-msgstr "โปรแกรม"
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "ควบคุมการแจ้งเหตุว่าจะแสดงรายการใดหรือสิ่งใดบ้าง"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:170
-msgctxt "Online Account"
-msgid "Other"
-msgstr "อื่นๆ"
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "การแจ้งเหตุ;พาดหัว;ข้อความ;ถาด;กล่องผุดขึ้น;"
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:291
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "การยืนยันตัวบุคคลชั้นใ_น"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "เพิ่มบัญชี"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Mail"
-msgstr "เมล"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Calendar"
-msgstr "ปฏิทิน"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Contacts"
-msgstr "ผู้ติดต่อ"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:346
-msgid "Chat"
-msgstr "สนทนา"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:352
-msgid "Resources"
-msgstr "ทรัพยากร"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:640
-msgid "Error creating account"
-msgstr "เกิดข้อผิดพลาดขณะสร้างบัญชี"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:700
-msgid "Error removing account"
-msgstr "เกิดข้อผิดพลาดขณะลบบัญชี"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:736
-msgid "Are you sure you want to remove the account?"
-msgstr "ยืนยันที่จะลบบัญชีหรือไม่?"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:738
-msgid "This will not remove the account on the server."
-msgstr "การลบนี้จะไม่มีการลบบัญชีที่เซิร์ฟเวอร์"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:739
-msgid "_Remove"
-msgstr "_ลบออก"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "On­line Accounts"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+#, fuzzy
+msgid "Online Accounts"
 msgstr "บัญชี­ออน­ไลน์"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "เชื่อมต่อไปยังบัญชีออนไลน์ของคุณและตัดสินใจว่าจะใช้เพื่อทำอะไร"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:5
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
@@ -3705,1513 +2817,872 @@ msgstr ""
 "กูเกิล;เฟซบุ๊ก;ทวิตเตอร์;ยาฮู;เว็บ;ออนไลน์;แช็ต;ปฏิทิน;เมล;ผู้ติดต่อ;ownCloud;Kerberos;IMAP;"
 "SMTP;พ็อกเก็ต;ReadItLater;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "ไม่ได้ตั้งค่าบัญชีออนไลน์ใดไว้"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "Remove Account"
-msgstr "ลบบัญชี"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "เพิ่มบัญชีออนไลน์"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr ""
-"การเพิ่มบัญชีจะช่วยให้โปรแกรมต่างๆ ของคุณสามารถเข้าถึงเอกสาร เมล ผู้ติดต่อ ปฏิทิน การสนทนา "
-"และอื่นๆ จากบัญชีนั้นๆ"
-
-#: ../panels/power/cc-power-panel.c:253
-msgid "Unknown time"
-msgstr "ไม่ทราบเวลา"
-
-#: ../panels/power/cc-power-panel.c:259
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i นาที"
 
-#: ../panels/power/cc-power-panel.c:271
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i ชั่วโมง"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:279
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:280
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "ชั่วโมง"
 
-#: ../panels/power/cc-power-panel.c:281
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "นาที"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:300
-#, c-format
-msgid "%s until fully charged"
-msgstr "อีก %s จะเต็ม"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 นาที"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:307
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "คำเตือน: อีก %s จะหมด"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 นาที"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:312
-#, c-format
-msgid "%s remaining"
-msgstr "อีก %s จะหมด"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 นาที"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:317 ../panels/power/cc-power-panel.c:345
-msgid "Fully charged"
-msgstr "ประจุไฟเต็มแล้ว"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 นาที"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:321 ../panels/power/cc-power-panel.c:349
-msgid "Empty"
-msgstr "ไม่มีประจุเหลืออยู่"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:336
-msgid "Charging"
-msgstr "กำลังประจุไฟ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:341
-msgid "Discharging"
-msgstr "กำลังจ่ายไฟ"
-
-#: ../panels/power/cc-power-panel.c:464
-msgctxt "Battery name"
-msgid "Main"
-msgstr "หลัก"
-
-#: ../panels/power/cc-power-panel.c:466
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "พิเศษ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:537
-msgid "Wireless mouse"
-msgstr "เมาส์ไร้สาย"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgid "Wireless keyboard"
-msgstr "แป้นพิมพ์ไร้สาย"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:543
-msgid "Uninterruptible power supply"
-msgstr "อุปกรณ์จ่ายไฟสำรอง"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:546
-msgid "Personal digital assistant"
-msgstr "เครื่องช่วยงานส่วนบุคคลแบบดิจิทัล"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:549
-msgid "Cellphone"
-msgstr "โทรศัพท์เคลื่อนที่"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgid "Media player"
-msgstr "เครื่องเล่นสื่อ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:555
-msgid "Tablet"
-msgstr "แท็บเล็ต"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:558
-msgid "Computer"
-msgstr "คอมพิวเตอร์"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:561 ../panels/power/cc-power-panel.c:801
-#: ../panels/power/cc-power-panel.c:2358
-msgid "Battery"
-msgstr "แบตเตอรี่"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:615
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "กำลังประจุไฟ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:622
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "ระวัง"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:627
-msgctxt "Battery power"
-msgid "Low"
-msgstr "ต่ำ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:632
-msgctxt "Battery power"
-msgid "Good"
-msgstr "ดี"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:637
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "ประจุไฟเต็มแล้ว"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:641
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "ไม่มีประจุเหลืออยู่"
-
-#: ../panels/power/cc-power-panel.c:799
-msgid "Batteries"
-msgstr "แบตเตอรี่"
-
-#: ../panels/power/cc-power-panel.c:1227
-msgid "When _idle"
-msgstr "เมื่อไ_ม่ใช้งาน"
-
-#: ../panels/power/cc-power-panel.c:1680
-msgid "Power Saving"
-msgstr "การประหยัดพลังงาน"
-
-#: ../panels/power/cc-power-panel.c:1715
-msgid "_Screen brightness"
-msgstr "ความ_สว่างหน้าจอ"
-
-#: ../panels/power/cc-power-panel.c:1734
-msgid "Automatic brightness"
-msgstr "ความสว่างอัตโนมัติ"
-
-#: ../panels/power/cc-power-panel.c:1754
-msgid "_Keyboard brightness"
-msgstr "ความสว่างแ_ป้นพิมพ์"
-
-#: ../panels/power/cc-power-panel.c:1764
-msgid "_Dim screen when inactive"
-msgstr "_หรี่หน้าจอเมื่อไม่มีการใช้งาน"
-
-#: ../panels/power/cc-power-panel.c:1789
-msgid "_Blank screen"
-msgstr "แสดงหน้าจอ_ว่าง"
-
-#: ../panels/power/cc-power-panel.c:1826
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: ../panels/power/cc-power-panel.c:1831
-msgid "Turn off Wi-Fi to save power."
-msgstr "ปิด Wi-Fi เพื่อประหยัดพลังงาน"
-
-#: ../panels/power/cc-power-panel.c:1856
-msgid "_Mobile broadband"
-msgstr "บรอดแบนด์_มือถือ"
-
-#: ../panels/power/cc-power-panel.c:1861
-msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
-msgstr "ปิดอุปกรณ์บรอดแบนด์มือถือ (3G, 4G, LTE ฯลฯ) เพื่อประหยัดพลังงาน"
-
-#: ../panels/power/cc-power-panel.c:1906
-msgid "_Bluetooth"
-msgstr "_บลูทูท"
-
-#: ../panels/power/cc-power-panel.c:1962
-msgid "When on battery power"
-msgstr "เมื่อใช้ไฟจากแบตเตอรี่"
-
-#: ../panels/power/cc-power-panel.c:1964
-msgid "When plugged in"
-msgstr "เมื่อเสียบปลั๊กไฟ"
-
-#: ../panels/power/cc-power-panel.c:2059
-msgid "Suspend"
-msgstr "พักเครื่อง"
-
-#: ../panels/power/cc-power-panel.c:2060
-msgid "Hibernate"
-msgstr "จำศีลเครื่อง"
-
-# probably wrong spelling
-#: ../panels/power/cc-power-panel.c:2061
-msgid "Nothing"
-msgstr "ไม่ต้องทำอะไร"
-
-#. Frame header
-#: ../panels/power/cc-power-panel.c:2175
-msgid "Suspend & Power Button"
-msgstr "ปุ่มพัก & เปิด/ปิดเครื่อง"
-
-#: ../panels/power/cc-power-panel.c:2218
-msgid "_Automatic suspend"
-msgstr "พักเครื่องโดย_อัตโนมัติ"
-
-#: ../panels/power/cc-power-panel.c:2219
-msgid "Automatic suspend"
-msgstr "พักเครื่องโดยอัตโนมัติ"
-
-#: ../panels/power/cc-power-panel.c:2286
-msgid "_When the Power Button is pressed"
-msgstr "เมื่อกดปุ่มเปิ_ด/ปิดเครื่อง"
-
-#: ../panels/power/cc-power-panel.c:2412 ../shell/alt/cc-window.c:270
-msgid "Devices"
-msgstr "อุปกรณ์"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Po­wer"
-msgstr "พลัง­งาน"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:3
-msgid "View your battery status and change power saving settings"
-msgstr "ดูสถานะแบตเตอรี่และตั้งค่าการประหยัดพลังงาน"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:5
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr ""
-"พลังงาน;หลับ;พักเครื่อง;จำศีลเครื่อง;แบตเตอรี่;ความสว่าง;หรี่;ว่าง;จอภาพ;DPMS;ไม่ใช้งาน;"
-
-#: ../panels/power/power.ui.h:3
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 นาที"
 
-#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 ชั่วโมง"
 
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 นาที"
 
-#: ../panels/power/power.ui.h:6
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 นาที"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 นาที"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 ชั่วโมง"
 
-#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 นาที"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "แบตเตอรี่"
 
-#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 นาที"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "อุปกรณ์"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 นาที"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "ปิดเครื่อง"
 
-#: ../panels/power/power.ui.h:12
-msgid "4 minutes"
-msgstr "4 นาที"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 นาที"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "การประหยัดพลังงาน"
 
-#: ../panels/power/power.ui.h:14
-msgid "8 minutes"
-msgstr "8 นาที"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "ความสว่างอัตโนมัติ"
 
-#: ../panels/power/power.ui.h:15
-msgid "10 minutes"
-msgstr "10 นาที"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "ตั้งค่าความสว่างและการล็อคหน้าจอ"
 
-#: ../panels/power/power.ui.h:16
-msgid "12 minutes"
-msgstr "12 นาที"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "หน้าจอ"
 
-#: ../panels/power/power.ui.h:18
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "การ_อ่านหน้าจอ"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "การรายงานปัญหาโดย_อัตโนมัติ"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "พักเครื่องอัตโนมัติ"
+
+#: panels/power/cc-power-panel.ui:175
+#, fuzzy
+msgid "Pauses the computer after a period of inactivity."
+msgstr "ให้เครื่องหลับเมื่อไม่มีการใช้งาน:"
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "ปุ่มล่าง"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "พักเครื่องอัตโนมัติ"
 
-#: ../panels/power/power.ui.h:19
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "เมื่อเสียบ_ปลั๊กไฟ"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "เมื่อใช้ไฟจากแ_บตเตอรี่"
 
-#: ../panels/power/power.ui.h:21 ../panels/universal-access/uap.ui.h:33
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "รอ"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "ยืนยันตัวบุคคล"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "พลังงาน"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "ต้องยืนยันตัวบุคคล"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "ดูสถานะแบตเตอรี่และตั้งค่าการประหยัดพลังงาน"
 
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:683
-msgid "Low on toner"
-msgstr "ผงหมึกใกล้หมด"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:685
-msgid "Out of toner"
-msgstr "ผงหมึกหมด"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:688
-msgid "Low on developer"
-msgstr "น้ำยาใกล้หมด"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:691
-msgid "Out of developer"
-msgstr "น้ำยาหมด"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:693
-msgid "Low on a marker supply"
-msgstr "ตลับสีหมึกใกล้หมด"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:695
-msgid "Out of a marker supply"
-msgstr "ตลับสีหมึกหมด"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:697
-msgid "Open cover"
-msgstr "ฝาครอบเปิด"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:699
-msgid "Open door"
-msgstr "ประตูเปิด"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:701
-msgid "Low on paper"
-msgstr "กระดาษใกล้หมด"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:703
-msgid "Out of paper"
-msgstr "กระดาษหมด"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:705
-msgctxt "printer state"
-msgid "Offline"
-msgstr "ออฟไลน์"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:707
-#: ../panels/printers/cc-printers-panel.c:897
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "หยุด"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:709
-msgid "Waste receptacle almost full"
-msgstr "ที่เก็บของเสียใกล้เต็ม"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:711
-msgid "Waste receptacle full"
-msgstr "ที่เก็บของเสียเต็ม"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:713
-msgid "The optical photo conductor is near end of life"
-msgstr "ลูกกลิ้งไวแสงใกล้หมดอายุ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:715
-msgid "The optical photo conductor is no longer functioning"
-msgstr "ลูกกลิ้งไวแสงไม่ทำงานแล้ว"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:824
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "กำลังตั้งค่า"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:883
-msgctxt "printer state"
-msgid "Ready"
-msgstr "พร้อม"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:888
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "ไม่รับงานพิมพ์"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:893
-msgctxt "printer state"
-msgid "Processing"
-msgstr "กำลังดำเนินการ"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:1013
-msgid "Toner Level"
-msgstr "ระดับผงหมึก"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:1016
-msgid "Ink Level"
-msgstr "ระดับน้ำหมึก"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:1019
-msgid "Supply Level"
-msgstr "ระดับแหล่งจ่าย"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:1037
-msgctxt "printer state"
-msgid "Installing"
-msgstr "กำลังติดตั้ง"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1551
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "ทำงานอยู่ %u"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1892
-msgid "Failed to add new printer."
-msgstr "เพิ่มเครื่องพิมพ์เครื่องใหม่ไม่สำเร็จ"
-
-#: ../panels/printers/cc-printers-panel.c:2073
-msgid "Select PPD File"
-msgstr "เลือกแฟ้ม PPD"
-
-#: ../panels/printers/cc-printers-panel.c:2082
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
-"แฟ้มบรรยายเครื่องพิมพ์โพสต์สคริปต์ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+"พลังงาน;หลับ;พักเครื่อง;จำศีลเครื่อง;แบตเตอรี่;ความสว่าง;หรี่;ว่าง;จอภาพ;DPMS;ไม่ใช้งาน;"
 
-#: ../panels/printers/cc-printers-panel.c:2389
-msgid "No suitable driver found"
-msgstr "ไม่พบไดรเวอร์ที่เหมาะสม"
-
-#: ../panels/printers/cc-printers-panel.c:2460
-msgid "Searching for preferred drivers…"
-msgstr "กำลังค้นหาไดรเวอร์สำหรับเครื่องพิมพ์…"
-
-#: ../panels/printers/cc-printers-panel.c:2481
-msgid "Select from database…"
-msgstr "เลือกจากฐานข้อมูล…"
-
-#: ../panels/printers/cc-printers-panel.c:2490
-msgid "Provide PPD File…"
-msgstr "ป้อนแฟ้ม PPD…"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2637
-#: ../panels/printers/cc-printers-panel.c:2660
-msgid "Test page"
-msgstr "หน้าทดสอบ"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:3115
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "อ่านส่วนติดต่อผู้ใช้ไม่สำเร็จ: %s"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
-msgid "Prin­ters"
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
 msgstr "เครื่อง­พิมพ์"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "เพิ่มเครื่องพิมพ์, ดูงานพิมพ์ที่เครื่องพิมพ์ และเลือกวิธีการพิมพ์"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:5
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "เครื่องพิมพ์;คิว;พิมพ์;กระดาษ;หมึก;ผงหมึก;"
 
-#. Translators: this action removes (purges) all the listed jobs from the list.
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Clear All"
-msgstr "ลบทั้งหมด"
-
-#. Translators: this label describes the dialog empty state, with no jobs listed.
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "No Active Printer Jobs"
-msgstr "ไม่มีงานพิมพ์ที่ดำเนินการอยู่"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "เพิ่มเครื่องพิมพ์เครื่องใหม่"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "A_uthenticate"
-msgstr "ยื_นยันตัวบุคคล"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "ไม่พบเครื่องพิมพ์"
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-msgid "Enter a network address or search for a printer"
-msgstr "ป้อนที่อยู่เครือข่ายหรือค้นหาเครื่องพิมพ์"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "กำลังโหลดตัวเลือก…"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "เลือกไดรเวอร์เครื่องพิมพ์"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:96
-msgid "Select"
-msgstr "เลือก"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "กำลังโหลดฐานข้อมูลไดรเวอร์..."
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:526
-msgid "JetDirect Printer"
-msgstr "เครื่องพิมพ์ JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:782
-msgid "LPD Printer"
-msgstr "เครื่องพิมพ์ LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "หน้าเดียว"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "ขอบด้านยาว (มาตรฐาน)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "ขอบด้านสั้น (พลิก)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "แนวตั้ง"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "แนวนอน"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "แนวนอนกลับด้าน"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "แนวตั้งกลับด้าน"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:103
-msgctxt "print job"
-msgid "Pending"
-msgstr "รอดำเนินการ"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:107
-msgctxt "print job"
-msgid "Paused"
-msgstr "พักพิมพ์"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:111
-msgctxt "print job"
-msgid "Processing"
-msgstr "กำลังดำเนินการ"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:115
-msgctxt "print job"
-msgid "Stopped"
-msgstr "หยุด"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:119
-msgctxt "print job"
-msgid "Canceled"
-msgstr "ยกเลิก"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:123
-msgctxt "print job"
-msgid "Aborted"
-msgstr "เลิกพิมพ์"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:127
-msgctxt "print job"
-msgid "Completed"
-msgstr "เสร็จแล้ว"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: ../panels/printers/pp-jobs-dialog.c:289
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s - Active Jobs"
-msgstr "%s - งานที่พิมพ์อยู่"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1659
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1664
-msgid "Serial Port"
-msgstr "พอร์ตอนุกรม"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "Parallel Port"
-msgstr "พอร์ตขนาน"
-
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Bluetooth"
-msgstr "บลูทูท"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1713
-#, c-format
-msgid "Location: %s"
-msgstr "ตำแหน่งที่ตั้ง: %s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1718
-#, c-format
-msgid "Address: %s"
-msgstr "ที่อยู่: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1747
-msgid "Server requires authentication"
-msgstr "เซิร์ฟเวอร์ต้องการยืนยันตัวบุคคล"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "สองหน้า"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "ชนิดกระดาษ"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "แหล่งป้อนกระดาษ"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "ถาดกระดาษออก"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "การกรองเบื้องต้นด้วย GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:533
-msgid "Pages per side"
-msgstr "จำนวนหน้าต่อหน้ากระดาษ"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:545
-msgid "Two-sided"
-msgstr "สองหน้า"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:557
-msgid "Orientation"
-msgstr "แนววาง"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "ทั่วไป"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "ตั้งหน้ากระดาษ"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "ตัวเลือกที่สามารถติดตั้งได้"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "งานพิมพ์"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "คุณภาพของรูปภาพ"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "สี"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "การจัดขั้นสุดท้าย"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:675
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "ขั้นสูง"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "เลือกโดยอัตโนมัติ"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "ค่าปริยายเครื่องพิมพ์"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "ฝังแบบอักษร GhostScript เท่านั้น"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "แปลงเป็น PS ระดับ 1"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "แปลงเป็น PS ระดับ 2"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "ไม่ต้องกรองเบื้องต้น"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "ผู้ผลิต"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "ไดรเวอร์"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr "ป้อนชื่อผู้ใช้และรหัสผ่านของคุณเพื่อดูเครื่องพิมพ์ที่มีใน %s"
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "เพิ่มเครื่องพิมพ์"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "ลบเครื่องพิมพ์"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "ปลดล็อค"
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "แหล่งจ่าย"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "ไม่พบรูปภาพ"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "ป้อนที่อยู่เครือข่ายหรือค้นหาเครื่องพิมพ์"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "ต้องยืนยันตัวบุคคล"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr "ป้อนชื่อผู้ใช้และรหัสผ่านของคุณเพื่อดูเครื่องพิมพ์ที่มีใน %s"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ชื่อผู้ใช้"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "ตำแหน่งที่ตั้ง"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default printer"
-msgstr "เครื่องพิมพ์_ปริยาย"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "ไดรเวอร์"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "งานพิมพ์"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "กำลังค้นหาไดรเวอร์สำหรับเครื่องพิมพ์…"
 
-#. Translators: Opens a dialog containing printer
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "แสดง_งานพิมพ์"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "ค้นหาเมือง"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "เลือกจากฐานข้อมูล…"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "ป้อนแฟ้ม PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "เลือกไดรเวอร์เครื่องพิมพ์"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "กำลังโหลดฐานข้อมูลไดรเวอร์..."
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "ยกเลิก"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "เลือก"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "เซิร์ฟเวอร์ต้องการยืนยันตัวบุคคล"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "โ_ดเมน"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "ยื_นยันตัวบุคคล"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "ลบทั้งหมด"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "ยืนยันตัวบุคคล"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "ไม่มีงานพิมพ์ที่ดำเนินการอยู่"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "หน้าทดสอบ"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "ตัวเลือกของการเข้าระบบ"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "ค่าปริยายเครื่องพิมพ์"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "ค่าปริยายเครื่องพิมพ์"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "ยกเลิกงานพิมพ์"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "ลบเครื่องพิมพ์"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "งานพิมพ์ที่ทำงานอยู่"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "รุ่น"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "ฉลาก"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "ระดับน้ำหมึก"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "กำลังตั้งค่าไดรเวอร์ตัวใหม่…"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "กรุณาตรวจสอบการติดตั้งแอพเพล็ตว่าเรียบร้อยดีหรือไม่"
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "หน้า 3"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "ตั้งต้นใหม่เดี๋ยวนี้"
 
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "พิมพ์หน้า_ทดสอบ"
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "เพิ่มเครื่องพิมพ์"
 
-#. Translators: This button opens printer
-#: ../panels/printers/printers.ui.h:22 ../panels/region/region.ui.h:6
-msgid "_Options"
-msgstr "_ตัวเลือก"
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "ตั้งค่าเครื่องพิมพ์"
 
-#: ../panels/printers/printers.ui.h:23
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "ไม่มีเครื่องพิมพ์"
 
-#. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:25
-msgid "Add a Printer"
-msgstr "เพิ่มเครื่องพิมพ์"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:27
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "ขออภัย! ดูเหมือนไม่มีบริการจัดพิมพ์ของระบบ\n"
 "เปิดอยู่"
 
-#: ../panels/privacy/cc-privacy-panel.c:387 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "การล็อคหน้าจอ"
-
-#: ../panels/privacy/cc-privacy-panel.c:438
-msgid "In use"
-msgstr "ใช้งานอยู่"
-
-#: ../panels/privacy/cc-privacy-panel.c:443
-msgctxt "Location services status"
-msgid "On"
-msgstr "เปิด"
-
-#: ../panels/privacy/cc-privacy-panel.c:444
-msgctxt "Location services status"
-msgid "Off"
-msgstr "ปิด"
-
-#: ../panels/privacy/cc-privacy-panel.c:823 ../panels/privacy/privacy.ui.h:42
-msgid "Location Services"
-msgstr "บริการตำแหน่งที่ตั้ง"
-
-#: ../panels/privacy/cc-privacy-panel.c:942 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "การใช้งาน & ประวัติ"
-
-#: ../panels/privacy/cc-privacy-panel.c:1067
-msgid "Empty all items from Trash?"
-msgstr "แน่ใจหรือไม่ว่าต้องการลบทุกอย่างในถังขยะอย่างถาวร?"
-
-#: ../panels/privacy/cc-privacy-panel.c:1068
-msgid "All items in the Trash will be permanently deleted."
-msgstr "ทุกรายการในถังขยะจะถูกลบทิ้งอย่างถาวร"
-
-#: ../panels/privacy/cc-privacy-panel.c:1069 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "เ_ทขยะ"
-
-#: ../panels/privacy/cc-privacy-panel.c:1092
-msgid "Delete all the temporary files?"
-msgstr "ลบแฟ้มชั่วคราวทั้งหมดหรือไม่?"
-
-#: ../panels/privacy/cc-privacy-panel.c:1093
-msgid "All the temporary files will be permanently deleted."
-msgstr "แฟ้มชั่วคราวทั้งหมดจะถูกลบทิ้งอย่างถาวร"
-
-#: ../panels/privacy/cc-privacy-panel.c:1094 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "_ล้างแฟ้มชั่วคราวต่างๆ"
-
-#: ../panels/privacy/cc-privacy-panel.c:1116 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "ล้างขยะ & แฟ้มชั่วคราว"
-
-#: ../panels/privacy/cc-privacy-panel.c:1156 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr "การใช้ซอฟต์แวร์"
-
-#: ../panels/privacy/cc-privacy-panel.c:1197 ../panels/privacy/privacy.ui.h:46
-msgid "Problem Reporting"
-msgstr "การรายงานปัญหา"
-
-#. translators: '%s' is the distributor's name, such as 'Fedora'
-#: ../panels/privacy/cc-privacy-panel.c:1211
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data."
-msgstr ""
-"การส่งรายงานปัญหาทางเทคนิคเป็นการช่วยเราปรับปรุง %s ให้ดีขึ้น รายงานจะถูกส่งโดยไม่ระบุชื่อ "
-"และปราศจากข้อมูลส่วนบุคคล"
-
-#: ../panels/privacy/cc-privacy-panel.c:1223 ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "นโยบายความเป็นส่วนตัว"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Pri­va­cy"
-msgstr "ความ­เป็น­ส่วน­ตัว"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:3
-msgid "Protect your personal information and control what others might see"
-msgstr "ปกป้องข้อมูลส่วนตัวของคุณและควบคุมสิ่งที่จะให้คนอื่นเห็น"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:5
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr "หน้าจอ;ล็อค;วินิจฉัย;พัง;ส่วนตัว;ล่าสุด;ชั่วคราว;tmp;ดัชนี;ชื่อ;เครือข่าย;เอกลักษณ์;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "หน้าจอปิด"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 วินาที"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 วัน"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 วัน"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 วัน"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 วัน"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 วัน"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 วัน"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 วัน"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 วัน"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 วัน"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "ตลอดไป"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr ""
-"การจำประวัติของคุณทำให้หาสิ่งต่างๆ อีกครั้งได้ง่าย รายการเหล่านี้จะไม่มีการแบ่งปันในเครือข่าย"
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "ใช้_ล่าสุด"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "จดจำ_ประวัติ"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "_ล้างประวัติล่าสุด"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "การล็อคหน้าจอจะปกป้องความเป็นส่วนตัวของคุณเมื่อคุณลุกไปจากเครื่อง"
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "_ล็อคหน้าจออัตโนมัติ"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "ล็อคหน้าจอ_หลังจากแสดงจอเปล่าเป็นเวลา"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "แสดงการแ_จ้งเหตุ"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr ""
-"ล้างถังขยะและแฟ้มชั่วคราวโดยอัตโนมัติ "
-"เพื่อช่วยให้คอมพิวเตอร์ของคุณปลอดจากข้อมูลที่ล่อแหลมโดยไม่จำเป็น"
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "เ_ทขยะโดยอัตโนมัติ"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "ล้างแ_ฟ้มชั่วคราวโดยอัตโนมัติ"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "ล้าง_หลังจาก"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"การส่งข้อมูลเกี่ยวกับซอฟต์แวร์ที่คุณใช้ ช่วยให้เราเตรียมคำแนะนำได้ถูกต้องยิ่งขึ้นสำหรับคุณ "
-"และยังเป็นการช่วยเราปรับปรุงซอฟต์แวร์ของเราอีกด้วย\n"
-"\n"
-"ข้อมูลทั้งหมดที่เรารวบรวมจะไม่มีการระบุชื่อผู้ใช้ และเราจะไม่แบ่งปันข้อมูลของคุณกับบุคคลที่สาม"
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "_ส่งสถิติการใช้ซอฟต์แวร์"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid ""
-"Location services allow applications to know your location. Using Wi-Fi and "
-"mobile broadband increases accuracy."
-msgstr ""
-"บริการตำแหน่งที่ตั้งจะทำให้โปรแกรมต่างๆ รู้ตำแหน่งภูมิศาสตร์ที่คุณอยู่ การใช้ Wi-Fi "
-"และบรอดแบนด์มือถือจะช่วยเพิ่มความแม่นยำได้"
-
-#: ../panels/privacy/privacy.ui.h:44
-msgid "_Location Services"
-msgstr "บริการ_ตำแหน่งที่ตั้ง"
-
-#: ../panels/privacy/privacy.ui.h:47
-msgid "_Automatic Problem Reporting"
-msgstr "การรายงานปัญหาโดย_อัตโนมัติ"
-
-#: ../panels/region/cc-format-chooser.c:120
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "อังกฤษ"
-
-#: ../panels/region/cc-format-chooser.c:122
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "เมตริก"
-
-#: ../panels/region/cc-format-chooser.c:287
-msgid "No regions found"
-msgstr "ไม่พบภูมิภาค"
-
-#: ../panels/region/cc-input-chooser.c:182
-msgid "No input sources found"
-msgstr "ไม่พบช่องทางป้อนข้อความ"
-
-#: ../panels/region/cc-input-chooser.c:992
-msgctxt "Input Source"
-msgid "Other"
-msgstr "อื่นๆ"
-
-#: ../panels/region/cc-region-panel.c:247
-#: ../panels/user-accounts/um-user-panel.c:1087
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "คุณต้องตั้งต้นวาระใหม่เพื่อให้การเปลี่ยนแปลงมีผล"
-
-#: ../panels/region/cc-region-panel.c:251
-#: ../panels/user-accounts/um-user-panel.c:1091
-msgid "Restart Now"
-msgstr "ตั้งต้นใหม่เดี๋ยวนี้"
-
-#: ../panels/region/cc-region-panel.c:888
-msgid "No input source selected"
-msgstr "ไม่ได้เลือกช่องทางป้อนข้อความใด"
-
-#: ../panels/region/cc-region-panel.c:1779
-msgid "Login _Screen"
-msgstr "_หน้าจอเข้าระบบ"
-
-#: ../panels/region/format-chooser.ui.h:1
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "รูปแบบ"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "ค้นหาตำแหน่งที่ตั้ง"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "รูปแบบ"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "รูปแบบ"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "ดูตัวอย่าง"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "วันที่"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "เวลา"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "วันที่ & เวลา"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "ตัวเลข"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "หน่วยความยาว"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "กระดาษ"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid "Re­gion & Lan­guage"
-msgstr "ภูมิ­ภาค & ภา­ษา"
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
 msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
-msgstr "เลือกภาษาที่แสดง, รูปแบบ, ผังแป้นพิมพ์ และช่องทางป้อนข้อความของคุณ"
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:5
-msgid "Language;Layout;Keyboard;Input;"
-msgstr "ภาษา;ผังแป้นพิมพ์;แป้นพิมพ์;ป้อนข้อความ;"
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "ติดตั้งภาษา..."
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "เพิ่มช่องทางป้อนข้อความ"
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "บัญชีของฉัน"
 
-#: ../panels/region/input-chooser.ui.h:4
-msgid "Input methods can't be used on the login screen"
-msgstr "ไม่สามารถใช้วิธีป้อนข้อความในหน้าจอเข้าระบบได้"
-
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "ตัวเลือกของช่องทางป้อนข้อความ"
-
-#: ../panels/region/input-options.ui.h:2
-msgid "Use the _same source for all windows"
-msgstr "ใช้ช่องทางป้อนข้อความเ_ดียวกันหมดทุกหน้าต่าง"
-
-#: ../panels/region/input-options.ui.h:3
-msgid "Allow _different sources for each window"
-msgstr "ใช้ช่องทางป้อนข้อความ_ต่างกันสำหรับแต่ละหน้าต่าง"
-
-#: ../panels/region/input-options.ui.h:4 ../shell/cc-application.c:251
-msgid "Keyboard Shortcuts"
-msgstr "ปุ่มลัด"
-
-#: ../panels/region/input-options.ui.h:5
-msgid "Switch to previous source"
-msgstr "สลับไปยังช่องทางก่อนหน้า"
-
-#: ../panels/region/input-options.ui.h:6
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
-
-#: ../panels/region/input-options.ui.h:7
-msgid "Switch to next source"
-msgstr "สลับไปยังช่องทางถัดไป"
-
-#: ../panels/region/input-options.ui.h:8
-msgid "Super+Space"
-msgstr "Super+Space"
-
-#: ../panels/region/input-options.ui.h:9
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "คุณสามารถเปลี่ยนปุ่มลัดเหล่านี้ได้ในการตั้งค่าแป้นพิมพ์"
-
-#: ../panels/region/input-options.ui.h:10
-msgid "Alternative switch to next source"
-msgstr "ปุ่มลัดทางเลือกสำหรับสลับไปยังช่องทางถัดไป"
-
-#: ../panels/region/input-options.ui.h:11
-msgid "Left+Right Alt"
-msgstr "Alt ซ้าย+ขวา"
-
-#: ../panels/region/region.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_ภาษา"
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "อังกฤษ (สหราชอาณาจักร)"
-
-#: ../panels/region/region.ui.h:3
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "รูปแ_บบ"
 
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "สหราชอาณาจักร"
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "_หน้าจอเข้าระบบ"
 
-#: ../panels/region/region.ui.h:5
-msgid "Input Sources"
-msgstr "ช่องทางป้อนข้อความ"
+#: panels/region/gnome-region-panel.desktop.in.in:3
+#, fuzzy
+msgid "Region & Language"
+msgstr "ภูมิ­ภาค & ภา­ษา"
 
-#: ../panels/region/region.ui.h:7
-msgid "Add input source"
-msgstr "เพิ่มช่องทางป้อนข้อความ"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "เลือกภาษาที่แสดง, รูปแบบ, ผังแป้นพิมพ์ และช่องทางป้อนข้อความของคุณ"
 
-#: ../panels/region/region.ui.h:8
-msgid "Remove input source"
-msgstr "ลบช่องทางป้อนข้อความ"
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "ภาษา;ผังแป้นพิมพ์;แป้นพิมพ์;ป้อนข้อความ;"
 
-#: ../panels/region/region.ui.h:9
-msgid "Move input source up"
-msgstr "เลื่อนช่องทางป้อนข้อความขึ้น"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "เลือกวิธีจัดการสื่อ"
 
-#: ../panels/region/region.ui.h:10
-msgid "Move input source down"
-msgstr "เลื่อนช่องทางป้อนข้อความลง"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "ซีดีเ_พลง"
 
-#: ../panels/region/region.ui.h:11
-msgid "Configure input source"
-msgstr "ตั้งค่าช่องทางป้อนข้อความ"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_ดีวีดีภาพยนตร์"
 
-#: ../panels/region/region.ui.h:12
-msgid "Show input source keyboard layout"
-msgstr "แสดงผังแป้นพิมพ์ของช่องทางป้อนข้อความ"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "เ_ครื่องเล่นเพลง"
 
-#: ../panels/region/region.ui.h:13
-msgid "Login settings are used by all users when logging into the system"
-msgstr "การตั้งค่าการเข้าระบบใช้จะใช้กับผู้ใช้ทั้งหมดขณะเข้าสู่ระบบ"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "ซอ_ฟต์แวร์"
 
-#: ../panels/search/cc-search-locations-dialog.c:634
-msgid "Select Location"
-msgstr "เลือกสถานที่"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_สื่ออื่นๆ…"
 
-#: ../panels/search/cc-search-locations-dialog.c:638
-msgid "_OK"
-msgstr "_ตกลง"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "ไ_ม่ต้องถามหรือเปิดโปรแกรมในสื่อเมื่อใส่เข้ามา"
 
-#: ../panels/search/cc-search-panel.c:177
-msgid "No applications found"
-msgstr "ไม่พบโปรแกรม"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "เลือกวิธีจัดการสื่ออื่นๆ"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
-msgid "Search"
-msgstr "ค้นหา"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_การกระทำ:"
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:3
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_ชนิด:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "สื่อถอดเสียบ"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "ตั้งค่าบลูทูท"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"อุปกรณ์;ระบบ;ข้อมูล;หน่วยความจำ;ตัวประมวลผล;รุ่น;ปริยาย;โปรแกรม;โปรแกรมหลักๆ;ซีดี;ดีวีดี;"
+"usb;เสียง;วีดิทัศน์;ดิสก์;ถอดเสียบ;สื่อ;autorun;"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "การล็อคหน้าจอ"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "แสดงหน้าจอ_ว่าง"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_ล็อคหน้าจออัตโนมัติ"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "_ล็อคหน้าจออัตโนมัติ"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "แสดงการแ_จ้งเหตุ"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "หน้าจอ_ล็อค"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "ความเป็นส่วนตัว"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "หน้าจอ"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "ตั้งค่าเสียง"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "ค้นหาตำแหน่งที่ตั้ง"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "ที่หลักๆ"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "ที่คั่นหน้า"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "อื่นๆ"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "ตำแหน่งที่ตั้ง"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "โปรแกรม"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "_ค้นหาจากที่อยู่"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "กำหนดโปรแกรมที่จะแสดงผลการค้นหาในหน้าภาพรวมกิจกรรม"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:5
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "ค้นหา;หา;ดัชนี;ซ่อน;ความเป็นส่วนตัว;ผล;"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr "ค้นหาตำแหน่งที่ตั้ง"
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "เครือข่าย"
 
-#: ../panels/search/search-locations-dialog.ui.h:2
-msgid "Places"
-msgstr "ที่หลักๆ"
-
-#: ../panels/search/search-locations-dialog.ui.h:3
-msgid "Bookmarks"
-msgstr "ที่คั่นหน้า"
-
-#: ../panels/search/search-locations-dialog.ui.h:4
-msgid "Other"
-msgstr "อื่นๆ"
-
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "เลื่อนขึ้น"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "เลื่อนลง"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "ปรับแต่ง"
-
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:303
-msgid "No networks selected for sharing"
-msgstr "ไม่มีเครือข่ายที่เลือกเพื่อใช้ร่วม"
-
-#: ../panels/sharing/cc-sharing-panel.c:263
-msgctxt "service is enabled"
-msgid "On"
-msgstr "เปิด"
-
-#: ../panels/sharing/cc-sharing-panel.c:265
-#: ../panels/sharing/cc-sharing-panel.c:292
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "ปิด"
-
-#: ../panels/sharing/cc-sharing-panel.c:295
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "เปิดใช้"
-
-#: ../panels/sharing/cc-sharing-panel.c:298
-msgctxt "service is active"
-msgid "Active"
-msgstr "ทำงานอยู่"
-
-#: ../panels/sharing/cc-sharing-panel.c:369
-msgid "Choose a Folder"
-msgstr "เลือกโฟลเดอร์"
-
-#: ../panels/sharing/cc-sharing-panel.c:680
-#, c-format
-msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr ""
-"การแบ่งปันแฟ้มส่วนตัว ช่วยคุณแบ่งปันโฟลเดอร์ \"สาธารณะ\" ของคุณกับผู้อื่นในเครือข่ายปัจจุบันของคุณ "
-"โดยใช้: <a href=\"dav://%s\">dav://%s</a>"
-
-#: ../panels/sharing/cc-sharing-panel.c:682
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr ""
-"เมื่อเปิดใช้การเข้าระบบผ่านเครือข่าย ผู้ใช้จากเครื่องอื่นจะสามารถเชื่อมต่อ โดยใช้คำสั่งเชลล์นิรภัย:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-
-#: ../panels/sharing/cc-sharing-panel.c:684
-#, c-format
-msgid ""
-"Screen sharing allows remote users to view or control your screen by "
-"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
-msgstr ""
-"การแบ่งปันหน้าจอจะเปิดให้ผู้ใช้จากเครื่องอื่นดูหรือควบคุมหน้าจอของคุณ ด้วยการเชื่อมต่อไปยัง: <a "
-"href=\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/cc-sharing-panel.c:796
-msgid "Copy"
-msgstr "คัดลอก"
-
-#: ../panels/sharing/cc-sharing-panel.c:1122
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "การแบ่งปัน"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Sha­ring"
-msgstr "การ­แบ่ง­ปัน"
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_ชื่อเครื่อง"
 
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:3
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "การแบ่งปันแ_ฟ้ม"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "เดสก์ท็อป"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "การแบ่งปัน_สื่อ"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "การเข้าระบบผ่านเ_ครือข่าย"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "การแบ่งปันแฟ้ม"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_ต้องใช้รหัสผ่าน"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "การเข้าระบบผ่านเครือข่าย"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "เดสก์ท็อป"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "เปิดหรือปิดการเข้าระบบผ่านเครือข่าย"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "อนุญาตให้ควบคุมหน้าจอผ่านเครือข่าย"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+#, fuzzy
+msgid "Allows remote connections to control the screen."
+msgstr "_อนุญาตให้คู่เชื่อมต่อควบคุมหน้าจอ"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "ไม่ได้เชื่อมต่อ"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "คัดลอก"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "ลบที่อยู่"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "การ_ยืนยันตัวบุคคล"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ชื่อผู้ใช้"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "เก็บลายนิ้วมือ"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "การแบ่งปันสื่อ"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "แบ่งปันดนตรี, ภาพถ่าย และวีดิทัศน์ผ่านทางเครือข่าย"
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "โฟลเดอร์"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
 msgstr "ควบคุมสิ่งที่คุณต้องการแบ่งปันกับผู้อื่น"
 
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:5
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
 "movies;server;renderer;"
@@ -5219,840 +3690,803 @@ msgstr ""
 "แบ่งปัน;ใช้ร่วม;ssh;โฮสต์;ชื่อ;แม่ข่าย;เดสก์ท็อป;สื่อ;เสียง;วีดิทัศน์;ภาพ;ภาพถ่าย;ภาพยนตร์;"
 "เซิร์ฟเวอร์;โปรแกรมวาดแสดง;"
 
-#: ../panels/sharing/networks.ui.h:1
-msgid "Networks"
-msgstr "เครือข่าย"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
 msgid "Enable or disable remote login"
 msgstr "เปิดหรือปิดการเข้าระบบผ่านเครือข่าย"
 
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "ต้องยืนยันตัวบุคคลเพื่อจะเปิดหรือปิดการเข้าระบบผ่านเครือข่าย"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "_Computer Name"
-msgstr "_ชื่อเครื่อง"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "การคลิกด้วยการวางแช่"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid "_File Sharing"
-msgstr "การแบ่งปันแ_ฟ้ม"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "การแบ่งปัน"
 
-#: ../panels/sharing/sharing.ui.h:3
-msgid "_Screen Sharing"
-msgstr "การแบ่งปันหน้า_จอ"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:4
-msgid "_Media Sharing"
-msgstr "การแบ่งปัน_สื่อ"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:5
-msgid "_Remote Login"
-msgstr "การเข้าระบบผ่านเ_ครือข่าย"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "_สมดุล:"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Some services are disabled because of no network access."
-msgstr "บางบริการถูกปิดใช้เพราะเข้าถึงเครือข่ายไม่ได้"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "เ_ฟด:"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "File Sharing"
-msgstr "การแบ่งปันแฟ้ม"
-
-#: ../panels/sharing/sharing.ui.h:8
-msgid "_Require Password"
-msgstr "_ต้องใช้รหัสผ่าน"
-
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Remote Login"
-msgstr "การเข้าระบบผ่านเครือข่าย"
-
-#: ../panels/sharing/sharing.ui.h:11
-msgid "Screen Sharing"
-msgstr "การแบ่งปันหน้าจอ"
-
-#: ../panels/sharing/sharing.ui.h:12
-msgid "_Allow connections to control the screen"
-msgstr "_อนุญาตให้คู่เชื่อมต่อควบคุมหน้าจอ"
-
-#: ../panels/sharing/sharing.ui.h:13
-msgid "_Password:"
-msgstr "_รหัสผ่าน:"
-
-#: ../panels/sharing/sharing.ui.h:14
-msgid "_Show Password"
-msgstr "แ_สดงรหัสผ่าน"
-
-#: ../panels/sharing/sharing.ui.h:15
-msgid "Access Options"
-msgstr "ตัวเลือกของการเข้าถึง"
-
-#: ../panels/sharing/sharing.ui.h:16
-msgid "_New connections must ask for access"
-msgstr "การเชื่อมต่อใ_หม่ต้องร้องขอการเข้าถึง"
-
-#: ../panels/sharing/sharing.ui.h:17
-msgid "_Require a password"
-msgstr "_ต้องใช้รหัสผ่าน"
-
-#: ../panels/sharing/sharing.ui.h:18
-msgid "Media Sharing"
-msgstr "การแบ่งปันสื่อ"
-
-#: ../panels/sharing/sharing.ui.h:19
-msgid "Share music, photos and videos over the network."
-msgstr "แบ่งปันดนตรี, ภาพถ่าย และวีดิทัศน์ผ่านทางเครือข่าย"
-
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Folders"
-msgstr "โฟลเดอร์"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "เสียง"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "ปรับระดับเสียง เสียงเข้า เสียงออก และเสียงแจ้งเหตุ"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "การ์ด;ไมโครโฟน;ความดัง;เฟด;สมดุล;บลูทูท;ชุดหูฟัง;เสียง;"
-
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "เห่า"
-
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "หยดน้ำ"
-
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "แก้ว"
-
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "โซนาร์"
-
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "ซ้าย"
-
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "ขวา"
-
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "หลัง"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "หน้า"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "ต่ำสุด"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "สูงสุด"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "_สมดุล:"
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "เ_ฟด:"
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "_ซับวูฟเฟอร์:"
-
-#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:615
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "ไม่ขยาย"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
-#: ../panels/sound/gvc-mixer-dialog.c:515
-msgid "_Profile:"
-msgstr "โ_พรไฟล์:"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "เสียงออก %u ช่อง"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "เสียงเข้า %u ช่อง"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "เสียงของระบบ"
 
-#: ../panels/sound/gvc-mixer-dialog.c:251
-msgid "_Test Speakers"
-msgstr "_ทดสอบลำโพง"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "ความดังเสียงแ_จ้งเตือน:"
 
-#: ../panels/sound/gvc-mixer-dialog.c:420
-msgid "Peak detect"
-msgstr "ตรวจหายอดคลื่น"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "ปิดเสียง"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1512
-msgid "Device"
-msgstr "อุปกรณ์"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1575
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "การทดสอบลำโพงสำหรับ %s"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1631
-msgid "_Output volume:"
-msgstr "ความดังเสียง_ออก:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1645
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "เสียงออก"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1650
-msgid "C_hoose a device for sound output:"
-msgstr "เ_ลือกอุปกรณ์สำหรับเสียงออก:"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "ความดังเสียง_ออก:"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1672
-msgid "Settings for the selected device:"
-msgstr "ค่าตั้งสำหรับอุปกรณ์ที่เลือก:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1683
-msgid "Input"
-msgstr "เสียงเข้า"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1690
-msgid "_Input volume:"
-msgstr "ความดังเสียงเ_ข้า:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "Input level:"
-msgstr "ระดับเสียงเข้า:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1737
-msgid "C_hoose a device for sound input:"
-msgstr "เ_ลือกอุปกรณ์สำหรับเสียงเข้า:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1761
-msgid "Sound Effects"
-msgstr "เอฟเฟ็กต์เสียง"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1768
-msgid "_Alert volume:"
-msgstr "ความดังเสียงแ_จ้งเตือน:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1785
-msgid "No application is currently playing or recording audio."
-msgstr "ไม่มีโปรแกรมที่เล่นหรืออัดเสียงอยู่"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "ฝังในโปรแกรม"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "ปรับแต่งเสียง"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "กำลังทดสอบเสียงของเหตุการณ์"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:554
-msgid "Default"
-msgstr "ปริยาย"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:555
-msgid "From theme"
-msgstr "จากชุดเสียง"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:740
-msgid "C_hoose an alert sound:"
-msgstr "เ_ลือกเสียงแจ้งเหตุ:"
-
-#: ../panels/sound/gvc-speaker-test.c:231
-msgid "Stop"
-msgstr "หยุด"
-
-#: ../panels/sound/gvc-speaker-test.c:231
-#: ../panels/sound/gvc-speaker-test.c:343
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "ทดสอบ"
 
-#: ../panels/sound/gvc-speaker-test.c:239
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "URL สำหรับตั้ง_ค่า"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "ซับวูฟเฟอร์"
 
-#: ../panels/sound/sound-theme-file-utils.c:304
-msgid "Custom"
-msgstr "กำหนดเอง"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "เสียงเข้า"
 
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Uni­ver­sal Access"
-msgstr "การ­เข้า­ถึง­หลาก­หลาย"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "ระดับเสียงเข้า:"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "ทำให้ง่ายต่อการเห็น, ได้ยิน, พิมพ์, ชี้ และคลิก"
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "เร่งเสียงขึ้น"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:5
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "ความดังเสียงแ_จ้งเตือน:"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "ปิดเสียง"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "เสียง"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ปรับระดับเสียง เสียงเข้า เสียงออก และเสียงแจ้งเหตุ"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr "การ์ด;ไมโครโฟน;ความดัง;เฟด;สมดุล;บลูทูท;ชุดหูฟัง;เสียง;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "แสดงการแ_จ้งเหตุ"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "_ชื่อ:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
-"แป้นพิมพ์;เมาส์;a11y;สิ่งอำนวยความสะดวก;ความต่างระดับสี;ซูม;อ่านหน้าจอ;ข้อความ;แบบอักษร;"
-"ขนาด;AccessX;ค้างปุ่มกด;พิมพ์แบบช้า;ป้องกันการกดแป้นรัว;บังคับเมาส์ด้วยแป้น;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "แ_สดงเมนูการเข้าถึงหลากหลายเสมอ"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "การมองเห็น"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "เชื่อม_ต่ออัตโนมัติ"
 
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "_สีตัดกัน"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "ลบอุปกรณ์ออก"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "อักษร_ขนาดใหญ่"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:5
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "_Zoom"
-msgstr "_ขยาย"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "ไม่สามารถเชื่อมต่อกับโดเมน %s: %s"
 
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr "การ_อ่านหน้าจอ"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "การเข้าถึงหลากหลาย"
 
-#: ../panels/universal-access/uap.ui.h:8
-msgid "_Sound Keys"
-msgstr "ส่งเ_สียงปุ่มกด"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "การได้ยิน"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "เพิ่มอุปกรณ์"
 
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
-msgstr "การแจ้งเหตุด้วย_ภาพ"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Screen _Keyboard"
-msgstr "แ_ป้นพิมพ์บนจอ"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:13
-msgid "R_epeat Keys"
-msgstr "การซ้ำ_ตัวอักษร"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Cursor _Blinking"
-msgstr "การ_กะพริบของเคอร์เซอร์"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:15
-msgid "_Typing Assist (AccessX)"
-msgstr "เครื่องมือช่วย_พิมพ์ (AccessX)"
-
-#: ../panels/universal-access/uap.ui.h:16
-msgid "Pointing & Clicking"
-msgstr "การชี้และการคลิก"
-
-#: ../panels/universal-access/uap.ui.h:17
-msgid "_Mouse Keys"
-msgstr "บังคับเ_มาส์ด้วยแป้น"
-
-#: ../panels/universal-access/uap.ui.h:18
-msgid "_Click Assist"
-msgstr "เครื่องมือช่วย_คลิก"
-
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Double-Click Delay"
-msgstr "เวลาหน่วงดับเ_บิลคลิก"
-
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Double-Click Delay"
-msgstr "เวลาหน่วงของดับเบิลคลิก"
-
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Screen Reader"
-msgstr "การอ่านหน้าจอ"
-
-#: ../panels/universal-access/uap.ui.h:22
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "การอ่านหน้าจอจะอ่านข้อความที่แสดงขณะที่คุณย้ายโฟกัส"
-
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Screen Reader"
-msgstr "การ_อ่านหน้าจอ"
-
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Sound Keys"
-msgstr "ส่งเสียงปุ่มกด"
-
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "ส่งเสียงบี๊บเมื่อ Num Lock หรือ Caps Lock เปิดหรือปิด"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Visual Alerts"
-msgstr "การแจ้งเหตุด้วยภาพ"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "_Test flash"
-msgstr "_ทดสอบการกะพริบ"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "ใช้การบ่งชี้ด้วยภาพเมื่อมีเสียงแจ้งเหตุ"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Flash the _window title"
-msgstr "กะพริบหัว_หน้าต่าง"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "Flash the entire _screen"
-msgstr "กะพริบทั้งหน้า_จอ"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Repeat Keys"
-msgstr "การซ้ำตัวอักษร"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Key presses repeat when key is held down."
-msgstr "ซ้ำปุ่มเมื่อกดปุ่มค้างไว้"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Repeat keys delay"
-msgstr "เวลาหน่วงของการซ้ำปุ่มเมื่อกดค้าง"
-
-#: ../panels/universal-access/uap.ui.h:35
-msgid "Speed"
-msgstr "ความเร็ว"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Repeat keys speed"
-msgstr "ความเร็วของการซ้ำปุ่มเมื่อกดค้าง"
-
-#: ../panels/universal-access/uap.ui.h:37
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 msgid "Cursor Blinking"
 msgstr "การกะพริบของเคอร์เซอร์"
 
-#: ../panels/universal-access/uap.ui.h:38
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "เคอร์เซอร์กะพริบในช่องข้อความ"
 
-#: ../panels/universal-access/uap.ui.h:39
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "ความเร็ว"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "อัตราการกะพริบของเคอร์เซอร์"
 
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Typing Assist"
-msgstr "สิ่งอำนวยความสะดวกในการพิมพ์"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "การกะพริบของเคอร์เซอร์"
 
-#: ../panels/universal-access/uap.ui.h:41
-msgid "_Sticky Keys"
-msgstr "_ค้างปุ่มกด"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "นับการกดปุ่มประกอบทีละปุ่มเสมือนการกดพร้อมกัน"
-
-#: ../panels/universal-access/uap.ui.h:43
-msgid "_Disable if two keys are pressed together"
-msgstr "เ_ลิกใช้ถ้ามีการกดปุ่มสองปุ่มพร้อมกัน"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Beep when a _modifier key is pressed"
-msgstr "ส่งเสียงบี๊บเมื่อกดปุ่ม_ประกอบ"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "S_low Keys"
-msgstr "พิมพ์แบบ_ช้า"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "หน่วงเวลาหลังจากปุ่มถูกกดก่อนที่จะรับการกด"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "A_cceptance delay:"
-msgstr "เวลาห_น่วงก่อนรับ:"
-
-#: ../panels/universal-access/uap.ui.h:48
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "สั้น"
-
-#: ../panels/universal-access/uap.ui.h:49
-msgid "Slow keys typing delay"
-msgstr "เวลาหน่วงในการพิมพ์แบบช้า"
-
-#: ../panels/universal-access/uap.ui.h:50
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "ยาว"
-
-#: ../panels/universal-access/uap.ui.h:51
-msgid "Beep when a key is pr_essed"
-msgstr "ส่งเสียงบี๊บเมื่อ_กดปุ่ม"
-
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Beep when a key is _accepted"
-msgstr "ส่งเสียงบี๊บเมื่อปุ่มถูก_ยอมรับ"
-
-#: ../panels/universal-access/uap.ui.h:53
-msgid "Beep when a key is _rejected"
-msgstr "ส่งเสียงบี๊บเมื่อปุ่มถูก_ปฏิเสธ"
-
-#: ../panels/universal-access/uap.ui.h:54
-msgid "_Bounce Keys"
-msgstr "ป้องกันการกดแป้น_รัว"
-
-#: ../panels/universal-access/uap.ui.h:55
-msgid "Ignores fast duplicate keypresses"
-msgstr "ไม่รับการกดปุ่มรัว"
-
-#: ../panels/universal-access/uap.ui.h:56
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "สั้น"
-
-#: ../panels/universal-access/uap.ui.h:57
-msgid "Bounce keys typing delay"
-msgstr "เวลาหน่วงในการป้องกันการกดแป้นรัว"
-
-#: ../panels/universal-access/uap.ui.h:58
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "ยาว"
-
-#: ../panels/universal-access/uap.ui.h:59
-msgid "_Enable by Keyboard"
-msgstr "_เปิดใช้ด้วยแป้นพิมพ์"
-
-#: ../panels/universal-access/uap.ui.h:60
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "เปิด/ปิดเทคโนโลยีสิ่งอำนวยความสะดวกจากแป้นพิมพ์"
-
-#: ../panels/universal-access/uap.ui.h:61
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "เครื่องมือช่วยคลิก"
 
-#: ../panels/universal-access/uap.ui.h:62
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "_จำลองคลิกที่สอง"
 
-#: ../panels/universal-access/uap.ui.h:63
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "สร้างคลิกที่สองโดยกดปุ่มแรกของเมาส์ค้างไว้"
 
-#: ../panels/universal-access/uap.ui.h:64
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "เวลาห_น่วงก่อนรับ:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "สั้น"
 
-#: ../panels/universal-access/uap.ui.h:65
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "เวลาหน่วงสำหรับคลิกที่สอง"
 
-#: ../panels/universal-access/uap.ui.h:66
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "ยาว"
 
-#: ../panels/universal-access/uap.ui.h:67
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "การคลิกด้วยการวางแ_ช่"
 
-#: ../panels/universal-access/uap.ui.h:68
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "สร้างการคลิกเมื่อตัวชี้วางแช่"
 
-#: ../panels/universal-access/uap.ui.h:69
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "_รอ:"
 
-#: ../panels/universal-access/uap.ui.h:70
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "สั้น"
 
-#: ../panels/universal-access/uap.ui.h:71
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "ยาว"
 
-#: ../panels/universal-access/uap.ui.h:72
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "ระยะเริ่_มเคลื่อน:"
 
-#: ../panels/universal-access/uap.ui.h:73
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "สั้น"
 
-#: ../panels/universal-access/uap.ui.h:74
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "ยาว"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "การซ้ำตัวอักษร"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "ซ้ำปุ่มเมื่อกดปุ่มค้างไว้"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "เวลาหน่วงของการซ้ำปุ่มเมื่อกดค้าง"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "ความเร็วของการซ้ำปุ่มเมื่อกดค้าง"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "สิ่งอำนวยความสะดวกในการพิมพ์"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_ค้างปุ่มกด"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "นับการกดปุ่มประกอบทีละปุ่มเสมือนการกดพร้อมกัน"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "เ_ลิกใช้ถ้ามีการกดปุ่มสองปุ่มพร้อมกัน"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "ส่งเสียงบี๊บเมื่อกดปุ่ม_ประกอบ"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "พิมพ์แบบ_ช้า"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "หน่วงเวลาหลังจากปุ่มถูกกดก่อนที่จะรับการกด"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "สั้น"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ หน้าจอ"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "เวลาหน่วงในการพิมพ์แบบช้า"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ หน้าจอ"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ หน้าจอ"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "ยาว"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "ส่งเสียงบี๊บเมื่อ_กดปุ่ม"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "ส่งเสียงบี๊บเมื่อปุ่มถูก_ยอมรับ"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "ส่งเสียงบี๊บเมื่อปุ่มถูก_ปฏิเสธ"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "ป้องกันการกดแป้น_รัว"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "ไม่รับการกดปุ่มรัว"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "สั้น"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "เวลาหน่วงในการป้องกันการกดแป้นรัว"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "ยาว"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_เปิดใช้ด้วยแป้นพิมพ์"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "เปิด/ปิดเทคโนโลยีสิ่งอำนวยความสะดวกจากแป้นพิมพ์"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "แ_สดงเมนูการเข้าถึงหลากหลายเสมอ"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "การมองเห็น"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_สีตัดกัน"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "อักษร_ขนาดใหญ่"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "การ_อ่านหน้าจอ"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "การอ่านหน้าจอจะอ่านข้อความที่แสดงขณะที่คุณย้ายโฟกัส"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "ส่งเ_สียงปุ่มกด"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "ส่งเสียงบี๊บเมื่อ Num Lock หรือ Caps Lock เปิดหรือปิด"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_ขยาย"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "การได้ยิน"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "การแจ้งเหตุด้วย_ภาพ"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "แ_ป้นพิมพ์บนจอ"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "การซ้ำ_ตัวอักษร"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "การ_กะพริบของเคอร์เซอร์"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "เครื่องมือช่วย_พิมพ์ (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "การชี้และการคลิก"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "บังคับเ_มาส์ด้วยแป้น"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "ลบเครื่องพิมพ์"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "เครื่องมือช่วย_คลิก"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "เวลาหน่วงดับเ_บิลคลิก"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "เวลาหน่วงของดับเบิลคลิก"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "การแจ้งเหตุด้วยภาพ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "_ทดสอบการกะพริบ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ใช้การบ่งชี้ด้วยภาพเมื่อมีเสียงแจ้งเหตุ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "กะพริบทั้งหน้า_จอ"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "กะพริบทั้งหน้า_จอ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "เต็มจอ"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "ครึ่งบน"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "ครึ่งล่าง"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "ครึ่งซ้าย"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "ครึ่งขวา"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "ตัวเลือกของการซูม"
 
-#: ../panels/universal-access/zoom-options.ui.h:8
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
 msgstr "_อัตราขยาย:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "_Follow mouse cursor"
-msgstr "_ติดตามตัวชี้เมาส์"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "_Screen part:"
-msgstr "_ส่วนของหน้าจอ:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier _extends outside of screen"
-msgstr "แว่นขยาย_ขยายขอบเขตออกไปนอกหน้าจอ"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "_Keep magnifier cursor centered"
-msgstr "_รักษาตำแหน่งตัวชี้ของแว่นขยายไว้ตรงกลาง"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor _pushes contents around"
-msgstr "ตัวชี้ของแว่นขยาย_ผลักเนื้อหาตามไปด้วย"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with _contents"
-msgstr "ตัวชี้ของแว่นขยายเลื่อนไปตามเ_นื้อหา"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "ตำแหน่งของแว่นขยาย:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_ติดตามตัวชี้เมาส์"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_ส่วนของหน้าจอ:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "แว่นขยาย_ขยายขอบเขตออกไปนอกหน้าจอ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_รักษาตำแหน่งตัวชี้ของแว่นขยายไว้ตรงกลาง"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "ตัวชี้ของแว่นขยาย_ผลักเนื้อหาตามไปด้วย"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "ตัวชี้ของแว่นขยายเลื่อนไปตามเ_นื้อหา"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "แว่นขยาย"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "เส้น_พิกัด:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "ซ้อน_ทับกับตัวชี้เมาส์"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
 msgstr "ความ_หนา:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "บาง"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "หนา"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
 msgid "_Length:"
 msgstr "ความ_ยาว:"
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
 msgid "Co_lor:"
 msgstr "_สี:"
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "_Crosshairs:"
-msgstr "เส้น_พิกัด:"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "_Overlaps mouse cursor"
-msgstr "ซ้อน_ทับกับตัวชี้เมาส์"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "เส้นพิกัด"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "เอฟเฟ็กต์สี:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
 msgid "_White on black:"
 msgstr "_ขาวบนพื้นดำ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
 msgid "_Brightness:"
 msgstr "ความส_ว่าง:"
 
-#: ../panels/universal-access/zoom-options.ui.h:28
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
 msgid "_Contrast:"
 msgstr "ความ_ต่างระดับสี:"
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
 msgid "Co_lor"
 msgstr "_สี"
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "ไม่ใช้"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "เต็มที่"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "ต่ำ"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "สูง"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "ต่ำ"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "สูง"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "เอฟเฟ็กต์สี:"
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "เอฟเฟ็กต์สี"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/join-dialog.ui.h:1
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "ทำให้ง่ายต่อการเห็น, ได้ยิน, พิมพ์, ชี้ และคลิก"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"แป้นพิมพ์;เมาส์;a11y;สิ่งอำนวยความสะดวก;ความต่างระดับสี;ซูม;อ่านหน้าจอ;ข้อความ;แบบอักษร;"
+"ขนาด;AccessX;ค้างปุ่มกด;พิมพ์แบบช้า;ป้องกันการกดแป้นรัว;บังคับเมาส์ด้วยแป้น;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ประวัติ"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "ประวัติ"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "_ล้างประวัติล่าสุด"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "ล้างขยะ & แฟ้มชั่วคราว"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "เ_ทขยะโดยอัตโนมัติ"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "ล้างแ_ฟ้มชั่วคราวโดยอัตโนมัติ"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "เ_ทขยะโดยอัตโนมัติ"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "เ_ทขยะ"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "_ล้างแฟ้มชั่วคราวต่างๆ"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "เพิ่มผู้ใช้"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "_Full Name"
-msgstr "ชื่_อเต็ม"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-msgid "Standard"
-msgstr "มาตรฐาน"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+#: panels/user-accounts/cc-add-user-dialog.ui:131
 msgid "Administrator"
 msgstr "ผู้ดูแลระบบ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Account _Type"
-msgstr "_ชนิดของบัญชี:"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "Allow user to set a password when they next _login"
-msgstr "อนุญาตให้ผู้ใช้ตั้งรหัสผ่านในครั้งต่อไปที่เ_ข้าระบบ"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "อนุญาตให้ผู้ใช้เปลี่ยนรหัสผ่านในครั้งต่อไปที่เข้าระบบ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-msgid "Set a password _now"
-msgstr "ตั้งรหัสผ่านเ_ดี๋ยวนี้"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "ตั้งรหัสผ่านเดี๋ยวนี้"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid "_Confirm"
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
 msgstr "_ยืนยัน"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:14
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "บัญชีเข้าระบบ_องค์กร"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "คุณออฟไลน์อยู่"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -6061,101 +4495,235 @@ msgstr ""
 "บัญชีเข้าระบบองค์กร อนุญาตให้ใช้บัญชีผู้ใช้ที่มีการจัดการแบบรวมศูนย์ที่มีอยู่กับอุปกรณ์นี้ "
 "คุณสามารถใช้บัญชีนี้ในการเข้าถึงทรัพยากรของบริษัทในอินเทอร์เน็ตด้วย"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-#: ../panels/user-accounts/data/join-dialog.ui.h:9
-msgid "_Domain"
-msgstr "โ_ดเมน"
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "เลือกแฟ้ม PPD"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-msgid "You are Offline"
-msgstr "คุณออฟไลน์อยู่"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "การเข้าระบบด้วย_ลายนิ้วมือ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-msgid "You must be online in order to add enterprise users."
-msgstr "คุณต้องออนไลน์เพื่อเพิ่มผู้ใช้องค์กร"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "การเข้าระบบด้วย_ลายนิ้วมือ"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:18
-msgid "_Enterprise Login"
-msgstr "บัญชีเข้าระบบ_องค์กร"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "ไม่"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "นิ้วหัวแม่มือซ้าย"
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "นิ้วกลางซ้าย"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "นิ้วนางซ้าย"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "นิ้วก้อยซ้าย"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "นิ้วหัวแม่มือขวา"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "นิ้วกลางขวา"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "นิ้วนางขวา"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "นิ้วก้อยขวา"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:687
-msgid "Enable Fingerprint Login"
-msgstr "เปิดใช้การเข้าระบบด้วยลายนิ้วมือ"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "นิ้วชี้_ขวา"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "นิ้วชี้ซ้า_ย"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "นิ้ว_อื่น: "
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr "บันทึกลายนิ้วมือของคุณสำเร็จแล้ว คุณควรสามารถเข้าระบบโดยใช้เครื่องอ่านลายนิ้วมือได้แล้ว"
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "คุณต้องการลบลายนิ้วมือของคุณเองที่ได้ลงทะเบียนไว้ เพื่อปิดการเข้าระบบด้วยลายนิ้วมือหรือไม่?"
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "ไม่พบเครื่องพิมพ์"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "การเข้าระบบด้วย_ลายนิ้วมือ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "การเข้าระบบด้วย_ลายนิ้วมือ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "เ_ลือกอุปกรณ์ที่จะตั้งค่า:"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "การเข้าระบบด้วย_ลายนิ้วมือ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "_ลบลายนิ้วมือ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "การเข้าระบบด้วย_ลายนิ้วมือ"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "สัปดาห์ก่อนหน้า"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "สัปดาห์หน้า"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "เปลี่ยนรหัสผ่าน"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "เป_ลี่ยน"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "รหัสผ่าน_ปัจจุบัน"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "รหัสผ่านให_ม่"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "ยื_นยันรหัสผ่าน"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "รหัสผ่านไม่ตรงกัน"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "อนุญาตให้ผู้ใช้เปลี่ยนรหัสผ่านในครั้งต่อไปที่เข้าระบบ"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "ตั้งรหัสผ่านเดี๋ยวนี้"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "ผู้ใช้"
 
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "คุณต้องตั้งต้นวาระใหม่เพื่อให้การเปลี่ยนแปลงมีผล"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "ตั้งต้นใหม่เดี๋ยวนี้"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "ปิด"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "ชื่_อเต็ม"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "แก้ไข"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "การเข้าระบบด้วย_ลายนิ้วมือ"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "การเข้าระบบ_อัตโนมัติ"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "%s - ความเคลื่อนไหวของบัญชี"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "ผู้ดูแลระบบ"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "ลบบัญชีผู้ใช้"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "นิ้ว_อื่น: "
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "เ_พิ่มผู้ใช้…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "ไม่พบรูปภาพ"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "สร้างบัญชีผู้ใช้"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
 msgstr "เพิ่มหรือลบผู้ใช้และเปลี่ยนรหัสผ่านของคุณ"
 
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "เข้าระบบ;ชื่อ;ลายนิ้วมือ;รูปแทนตัว;โลโก้;รูปหน้า;รหัสผ่าน;"
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
 
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/join-dialog.ui.h:4
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "_ลงทะเบียน"
 
-#: ../panels/user-accounts/data/join-dialog.ui.h:5
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "การเข้าระบบสำหรับผู้ดูแลโดเมน"
 
-#: ../panels/user-accounts/data/join-dialog.ui.h:6
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -6164,1090 +4732,3329 @@ msgstr ""
 "ในการใช้การเข้าระบบขององค์กร คอมพิวเตอร์นี้จำเป็นต้องลงทะเบียนในโดเมน\n"
 "กรุณาขอให้ผู้ดูแลเครือข่ายของคุณป้อนรหัสผ่านโดเมนที่นี่"
 
-#: ../panels/user-accounts/data/join-dialog.ui.h:10
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "_ชื่อผู้ดูแลระบบ"
 
-#: ../panels/user-accounts/data/join-dialog.ui.h:11
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "รหัสผ่านผู้ดูแลระบบ"
 
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr "เปลี่ยนรหัสผ่าน"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "เป_ลี่ยน"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "_ตรวจสอบรหัสผ่านใหม่"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "รหัสผ่านให_ม่"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "รหัสผ่าน_ปัจจุบัน"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to change their password on next login"
-msgstr "อนุญาตให้ผู้ใช้เปลี่ยนรหัสผ่านในครั้งต่อไปที่เข้าระบบ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "ตั้งรหัสผ่านเดี๋ยวนี้"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-msgid "_Add User…"
-msgstr "เ_พิ่มผู้ใช้…"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "A_utomatic Login"
-msgstr "การเข้าระบบ_อัตโนมัติ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Fingerprint Login"
-msgstr "การเข้าระบบด้วย_ลายนิ้วมือ"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "User Icon"
-msgstr "ไอคอนบัญชีผู้ใช้"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "Last Login"
-msgstr "เข้าระบบล่าสุด"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "จัดการบัญชีผู้ใช้"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "ต้องยืนยันตัวบุคคลเพื่อจะเปลี่ยนข้อมูลของผู้ใช้"
 
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "รหัสผ่านใหม่ต้องต่างจากรหัสผ่านเดิม"
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "ลองเปลี่ยนอักษรและตัวเลขบางตัว"
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "ลองเปลี่ยนรหัสผ่านให้ต่างจากเดิมกว่านี้อีกสักหน่อย"
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "รหัสผ่านที่ไม่มีชื่อผู้ใช้อยู่ในรหัสผ่านจะแน่นหนากว่า"
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "พยายามหลีกเลี่ยงการใช้ชื่อของคุณในรหัสผ่าน"
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "พยายามหลีกเลี่ยงคำบางคำในรหัสผ่าน"
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "พยายามหลีกเลี่ยงคำทั่วไป"
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "พยายามหลีกเลี่ยงการกลับลำดับคำเดิม"
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "พยายามใช้ตัวเลขเพิ่มอีก"
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "พยายามใช้ตัวพิมพ์ใหญ่เพิ่มอีก"
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "พยายามใช้ตัวพิมพ์เล็กเพิ่มอีก"
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "พยายามใช้อักขระพิเศษเพิ่มอีก เช่น เครื่องหมายวรรคตอน"
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "พยายามใช้ตัวอักษร ตัวเลข และเครื่องหมายวรรคตอนผสมกัน"
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "พยายามหลีกเลี่ยงการซ้ำอักขระเดิม"
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"พยายามหลีกเลี่ยงการใช้อักขระชนิดเดิมซ้ำ คุณต้องผสมตัวอักษร ตัวเลข และเครื่องหมายวรรคตอน"
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "พยายามหลีกเลี่ยงการใช้ลำดับ เช่น 1234 หรือ abcd"
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "พยายามเพิ่มตัวอักษร ตัวเลข และสัญลักษณ์ให้มากขึ้น"
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "ผสมตัวพิมพ์ใหญ่และตัวพิมพ์เล็ก และพยายามใช้ตัวเลขสักตัวสองตัว"
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr "รหัสผ่านดี! การเพิ่มตัวอักษร ตัวเลข และเครื่องหมายวรรคตอนอีก จะทำให้รหัสผ่านแน่นหนาขึ้น"
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "ความแน่นหนา: หละหลวม"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "ความแน่นหนา: ต่ำ"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "ความแน่นหนา: ปานกลาง"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "ความแน่นหนา: ดี"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "ความแน่นหนา: สูง"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "ยืนยันตัวบุคคลไม่ผ่าน"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "รหัสผ่านใหม่สั้นเกินไป"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "รหัสผ่านใหม่เดาง่ายเกินไป"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "รหัสผ่านใหม่คล้ายกับรหัสผ่านเก่าเกินไป"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "รหัสผ่านใหม่เพิ่งใช้ไปเมื่อเร็วๆ นี้"
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "รหัสผ่านใหม่ต้องมีตัวเลขหรือเครื่องหมายพิเศษด้วย"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "รหัสผ่านใหม่เหมือนกันกับรหัสผ่านเก่า"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "รหัสผ่านของคุณถูกเปลี่ยนหลังจากการยืนยันตัวบุคคลครั้งก่อน"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "รหัสผ่านใหม่มีอักขระต่างกันไม่มากพอ"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "ข้อผิดพลาดไม่ทราบสาเหตุ"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your login provider."
-msgstr "ควรจะตรงกับที่อยู่เว็บของผู้ให้บริการบัญชีเข้าระบบของคุณ"
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "เพิ่มบัญชีไม่สำเร็จ"
-
-#: ../panels/user-accounts/um-account-dialog.c:448
-msgid "Passwords do not match."
-msgstr "รหัสผ่านไม่ตรงกัน"
-
-#: ../panels/user-accounts/um-account-dialog.c:702
-#: ../panels/user-accounts/um-account-dialog.c:748
-#: ../panels/user-accounts/um-account-dialog.c:769
-msgid "Failed to register account"
-msgstr "ลงทะเบียนบัญชีไม่สำเร็จ"
-
-#: ../panels/user-accounts/um-account-dialog.c:892
-msgid "No supported way to authenticate with this domain"
-msgstr "ไม่มีวิธีการยืนยันตัวบุคคลที่รองรับสำหรับโดเมนนี้"
-
-#: ../panels/user-accounts/um-account-dialog.c:965
-msgid "Failed to join domain"
-msgstr "เข้าร่วมในโดเมนไม่สำเร็จ"
-
-#: ../panels/user-accounts/um-account-dialog.c:1026
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"ชื่อสำหรับเข้าระบบไม่ถูกต้อง\n"
-"กรุณาลองใหม่"
-
-#: ../panels/user-accounts/um-account-dialog.c:1033
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"รหัสผ่านสำหรับเข้าระบบไม่ถูกต้อง\n"
-"กรุณาลองใหม่"
-
-#: ../panels/user-accounts/um-account-dialog.c:1041
-msgid "Failed to log into domain"
-msgstr "เข้าระบบในโดเมนไม่สำเร็จ"
-
-#: ../panels/user-accounts/um-account-dialog.c:1099
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "หาโดเมนไม่พบ คุณอาจสะกดผิดหรือไม่?"
-
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "มาตรฐาน"
-
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "ผู้ดูแลระบบ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:138
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr "คุณไม่ได้รับอนุญาตให้เข้าใช้อุปกรณ์ กรุณาติดต่อผู้ดูแลระบบของคุณ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:140
-msgid "The device is already in use."
-msgstr "อุปกรณ์กำลังถูกใช้งานอยู่"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:142
-msgid "An internal error occurred."
-msgstr "เกิดข้อผิดพลาดภายใน"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Enabled"
-msgstr "เปิดใช้"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:264
-msgid "Delete registered fingerprints?"
-msgstr "จะลบลายนิ้วมือที่ลงทะเบียนไว้หรือไม่?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:268
-msgid "_Delete Fingerprints"
-msgstr "_ลบลายนิ้วมือ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:274
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr "คุณต้องการลบลายนิ้วมือของคุณเองที่ได้ลงทะเบียนไว้ เพื่อปิดการเข้าระบบด้วยลายนิ้วมือหรือไม่?"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:444
-msgid "Done!"
-msgstr "เสร็จแล้ว!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:505
-#: ../panels/user-accounts/um-fingerprint-dialog.c:547
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "ไม่สามารถเข้าใช้อุปกรณ์ '%s'"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:588
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "ไม่สามารถเริ่มอ่านลายนิ้วมือที่อุปกรณ์ '%s'"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:638
-msgid "Could not access any fingerprint readers"
-msgstr "ไม่สามารถเข้าใช้เครื่องอ่านลายนิ้วมือใดๆ ได้เลย"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:639
-msgid "Please contact your system administrator for help."
-msgstr "กรุณาติดต่อผู้ดูแลระบบของคุณเพื่อขอความช่วยเหลือ"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:721
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr ""
-"ในการเปิดใช้การเข้าระบบด้วยลายนิ้วมือ คุณต้องบันทึกลายนิ้วมือของคุณก่อน โดยใช้อุปกรณ์ '%s'"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:728
-msgid "Selecting finger"
-msgstr "เลือกนิ้ว"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:729
-msgid "Enrolling fingerprints"
-msgstr "เก็บลายนิ้วมือ"
-
-#: ../panels/user-accounts/um-history-dialog.c:70
-msgid "This Week"
-msgstr "สัปดาห์นี้"
-
-#: ../panels/user-accounts/um-history-dialog.c:73
-msgid "Last Week"
-msgstr "สัปดาห์ที่แล้ว"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:79
-#: ../panels/user-accounts/um-history-dialog.c:83
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b %Ey"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:93
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:177
-#: ../panels/user-accounts/um-user-panel.c:841
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:180
-#: ../panels/user-accounts/um-user-panel.c:845
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: ../panels/user-accounts/um-history-dialog.c:250
-msgid "Session Ended"
-msgstr "วาระสิ้นสุด"
-
-#: ../panels/user-accounts/um-history-dialog.c:256
-msgid "Session Started"
-msgstr "วาระเริ่มต้น"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: ../panels/user-accounts/um-history-dialog.c:299
-#, c-format
-msgid "%s - Account Activity"
-msgstr "%s - ความเคลื่อนไหวของบัญชี"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "กรุณาตั้งรหัสผ่านใหม่"
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "กรุณาป้อนรหัสผ่านปัจจุบันของคุณอีกครั้ง"
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "ไม่สามารถเปลี่ยนรหัสผ่านได้"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-msgid "The passwords do not match."
-msgstr "รหัสผ่านไม่ตรงกัน"
-
-#: ../panels/user-accounts/um-photo-dialog.c:214
-msgid "Browse for more pictures"
-msgstr "ท่องดูรูปภาพเพิ่มเติม"
-
-#: ../panels/user-accounts/um-photo-dialog.c:448
-msgid "Disable image"
-msgstr "ไม่ใช้รูปภาพ"
-
-#: ../panels/user-accounts/um-photo-dialog.c:466
-msgid "Take a photo…"
-msgstr "ถ่ายภาพ…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:484
-msgid "Browse for more pictures…"
-msgstr "ท่องดูรูปภาพเพิ่มเติม…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:708
-#, c-format
-msgid "Used by %s"
-msgstr "ใช้โดย %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "ไม่สามารถเข้าร่วมโดเมนชนิดนี้โดยอัตโนมัติได้"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "ไม่พบโดเมนหรือ realm ดังกล่าว"
-
-#: ../panels/user-accounts/um-realm-manager.c:815
-#: ../panels/user-accounts/um-realm-manager.c:829
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "ไม่สามารถเข้าระบบในนาม %s ที่โดเมน %s"
-
-#: ../panels/user-accounts/um-realm-manager.c:821
-msgid "Invalid password, please try again"
-msgstr "รหัสผ่านไม่ถูกต้อง กรุณาลองใหม่"
-
-#: ../panels/user-accounts/um-realm-manager.c:834
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "ไม่สามารถเชื่อมต่อกับโดเมน %s: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:239
-msgid "Other Accounts"
-msgstr "บัญชีอื่นๆ"
-
-#: ../panels/user-accounts/um-user-panel.c:447
-msgid "Failed to delete user"
-msgstr "ลบผู้ใช้ไม่สำเร็จ"
-
-#: ../panels/user-accounts/um-user-panel.c:507
-#: ../panels/user-accounts/um-user-panel.c:566
-#: ../panels/user-accounts/um-user-panel.c:618
-msgid "Failed to revoke remotely managed user"
-msgstr "เพิกถอนผู้ใช้ที่จัดการผ่านเครือข่ายไม่สำเร็จ"
-
-#: ../panels/user-accounts/um-user-panel.c:674
-msgid "You cannot delete your own account."
-msgstr "คุณจะลบบัญชีของคุณเองไม่ได้"
-
-#: ../panels/user-accounts/um-user-panel.c:683
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s ยังคงเข้าระบบอยู่"
-
-#: ../panels/user-accounts/um-user-panel.c:687
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "การลบบัญชีผู้ใช้ในระหว่างที่ผู้ใช้นั้นกำลังเข้าระบบอยู่ จะทำให้ระบบอยู่ในสถานะที่สับสน"
-
-#: ../panels/user-accounts/um-user-panel.c:696
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "คุณต้องการเก็บรักษาแฟ้มต่างๆ ของ %s ไว้หรือไม่?"
-
-#: ../panels/user-accounts/um-user-panel.c:700
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr "ในการลบบัญชีผู้ใช้ คุณสามารถเก็บรักษาไดเรกทอรีบ้าน, ถุงเมล และแฟ้มชั่วคราวของผู้ใช้ไว้ได้"
-
-#: ../panels/user-accounts/um-user-panel.c:703
-msgid "_Delete Files"
-msgstr "_ลบแฟ้ม"
-
-#: ../panels/user-accounts/um-user-panel.c:704
-msgid "_Keep Files"
-msgstr "เ_ก็บรักษาแฟ้ม"
-
-#: ../panels/user-accounts/um-user-panel.c:718
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s's account?"
-msgstr "ยืนยันที่จะเพิกถอนบัญชีของ %s ที่จัดการผ่านเครือข่ายหรือไม่?"
-
-#: ../panels/user-accounts/um-user-panel.c:722
-msgid "_Delete"
-msgstr "_ลบ"
-
-#: ../panels/user-accounts/um-user-panel.c:774
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "บัญชีถูกระงับ"
-
-#: ../panels/user-accounts/um-user-panel.c:782
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "รอตั้งรหัสผ่านในครั้งต่อไปที่เข้าระบบ"
-
-#: ../panels/user-accounts/um-user-panel.c:785
-msgctxt "Password mode"
-msgid "None"
-msgstr "ไม่มีรหัสผ่าน"
-
-#: ../panels/user-accounts/um-user-panel.c:834
-msgid "Logged in"
-msgstr "เข้าระบบ"
-
-#: ../panels/user-accounts/um-user-panel.c:1290
-msgid "Failed to contact the accounts service"
-msgstr "ติดต่อบริการบัญชีผู้ใช้ไม่สำเร็จ"
-
-#: ../panels/user-accounts/um-user-panel.c:1292
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "กรุณาตรวจสอบให้แน่ใจว่าได้ติดตั้งและเปิดใช้งาน AccountService"
-
-#: ../panels/user-accounts/um-user-panel.c:1334
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"หากต้องการเปลี่ยนแปลง\n"
-"ให้คลิกที่ไอคอน * ก่อน"
-
-#: ../panels/user-accounts/um-user-panel.c:1374
-msgid "Create a user account"
-msgstr "สร้างบัญชีผู้ใช้"
-
-#: ../panels/user-accounts/um-user-panel.c:1385
-#: ../panels/user-accounts/um-user-panel.c:1677
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"หากต้องการสร้างบัญชีผู้ใช้\n"
-"ให้คลิกที่ไอคอน * ก่อน"
-
-#: ../panels/user-accounts/um-user-panel.c:1395
-msgid "Delete the selected user account"
-msgstr "ลบบัญชีผู้ใช้ที่เลือก"
-
-#: ../panels/user-accounts/um-user-panel.c:1407
-#: ../panels/user-accounts/um-user-panel.c:1682
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"หากต้องการลบบัญชีผู้ใช้ที่เลือก\n"
-"ให้คลิกที่ไอคอน * ก่อน"
-
-#: ../panels/user-accounts/um-user-panel.c:1591
-msgid "My Account"
-msgstr "บัญชีของฉัน"
-
-#: ../panels/user-accounts/um-utils.c:563
-msgid "Sorry, that user name isn't available. Please try another."
-msgstr "ขออภัย ชื่อผู้ใช้นี้ถูกใช้ไปแล้ว กรุณาลองหาชื่ออื่น"
-
-#: ../panels/user-accounts/um-utils.c:566
-#, c-format
-msgid "The username is too long."
-msgstr "ชื่อผู้ใช้ยาวเกินไป"
-
-#: ../panels/user-accounts/um-utils.c:569
-msgid "The username cannot start with a '-'."
-msgstr "ชื่อผู้ใช้ขึ้นต้นด้วย '-' ไม่ได้"
-
-#: ../panels/user-accounts/um-utils.c:572
-msgid ""
-"The username should only consist of upper and lower case letters from a-z, "
-"digits and the following characters: . - _"
-msgstr ""
-"ชื่อผู้ใช้ควรประกอบด้วยตัวพิมพ์ใหญ่และตัวพิมพ์เล็กตั้งแต่ a-z, ตัวเลข และอักขระต่อไปนี้เท่านั้น: . - _"
-
-#: ../panels/user-accounts/um-utils.c:576
-msgid "This will be used to name your home folder and can't be changed."
-msgstr "ชื่อนี้จะนำมาใช้เป็นชื่อโฟลเดอร์บ้านของคุณ และไม่สามารถเปลี่ยนแปลงได้"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "กำหนดปุ่ม"
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "กำหนดการใช้งานปุ่มต่างๆ"
 
-#: ../panels/wacom/button-mapping.ui.h:4
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 "ถ้าต้องการแก้ไขปุ่มลัด ให้เลือกการกระทำ \"ส่งการกดแป้นพิมพ์\" จากนั้น กดปุ่มลัดแป้นพิมพ์ "
 "แล้วกดปุ่มลัดใหม่ หรือกด Backspace ถ้าต้องการล้างปุ่มลัด"
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "ปิ_ด"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr "กรุณาแตะที่เครื่องหมายเป้าที่ปรากฏบนหน้าจอเพื่อปรับเทียบมาตรฐานแท็บเล็ต"
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "ตรวจพบการคลิกที่ผิดพลาด จะเริ่มทำงานใหม่..."
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "ขึ้น"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "สร้างอุปกรณ์เสมือน"
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "ลง"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "แท็บเล็ต"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "ไม่ทำอะไร"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "ส่งการกดแป้นพิมพ์"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "สำหรับมือถนัดซ้าย"
 
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "สลับจอภาพ"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "แสดงวิธีใช้บนหน้าจอ"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "ปรับตำแหน่งกับจอภาพ…"
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "เอาต์พุต:"
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "สัดส่วนจอภาพ"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "รักษาสัดส่วนภาพ (กล่องอักษร):"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "ปรับตำแหน่งกับจอภาพเดียว"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "เทียบมาตรฐาน…"
 
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d จาก %d"
-
-#: ../panels/wacom/cc-wacom-page.c:522
-msgid "Display Mapping"
-msgstr "การแทนตำแหน่งจอแสดงผล"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:377
-msgid "Button"
-msgstr "ปุ่ม"
-
-#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Wa­com Tab­let"
-msgstr "แท็บ­เล็ต Wa­com"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr "ตั้งผังปุ่มและปรับความไวของสไตลัสสำหรับแท็บเล็ตกราฟิก"
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:5
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "แท็บเล็ต;Wacom;ปากกา;สไตลัส;ยางลบ;เมาส์;"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "แท็บเล็ต (สัมบูรณ์)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "ทัชแพด (สัมพัทธ์)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "ปรับแต่งแท็บเล็ต"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
-msgid "_Help"
-msgstr "_วิธีใช้"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "ไม่พบแท็บเล็ต"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "กรุณาต่อหรือเปิดแท็บเล็ต Wacom ของคุณ"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Bluetooth Settings"
-msgstr "ตั้งค่าบลูทูท"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Wacom Tablet"
-msgstr "แท็บเล็ต Wacom"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Map to Monitor…"
-msgstr "ปรับตำแหน่งกับจอภาพ…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Map Buttons…"
-msgstr "กำหนดปุ่ม…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Calibrate…"
-msgstr "เทียบมาตรฐาน…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Adjust display resolution"
-msgstr "ปรับความละเอียดการแสดงผล"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Adjust mouse settings"
-msgstr "ปรับการตั้งค่าเมาส์"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:15
-msgid "Tracking Mode"
-msgstr "โหมดการจับตำแหน่ง"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:16
-msgid "Left-Handed Orientation"
-msgstr "สำหรับมือถนัดซ้าย"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1028
-msgid "Left Ring"
-msgstr "วงแหวนสัมผัสซ้าย"
-
-#: ../panels/wacom/gsd-wacom-device.c:1039
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "โหมดวงแหวนสัมผัสซ้าย #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1059
-msgid "Right Ring"
-msgstr "วงแหวนสัมผัสขวา"
-
-#: ../panels/wacom/gsd-wacom-device.c:1070
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "โหมดวงแหวนสัมผัสขวา #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1112
-msgid "Left Touchstrip"
-msgstr "แถบสัมผัสซ้าย"
-
-#: ../panels/wacom/gsd-wacom-device.c:1123
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "โหมดแถบสัมผัสซ้าย #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1143
-msgid "Right Touchstrip"
-msgstr "แถบสัมผัสขวา"
-
-#: ../panels/wacom/gsd-wacom-device.c:1154
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "โหมดแถบสัมผัสขวา #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1180
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "ปุ่มเปลี่ยนโหมดวงแหวนสัมผัสซ้าย"
-
-#: ../panels/wacom/gsd-wacom-device.c:1182
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "ปุ่มเปลี่ยนโหมดวงแหวนสัมผัสขวา"
-
-#: ../panels/wacom/gsd-wacom-device.c:1185
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "ปุ่มเปลี่ยนโหมดแถบสัมผัสซ้าย"
-
-#: ../panels/wacom/gsd-wacom-device.c:1187
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "ปุ่มเปลี่ยนโหมดแถบสัมผัสขวา"
-
-#: ../panels/wacom/gsd-wacom-device.c:1192
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "ปุ่มเปลี่ยนโหมด #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1238
-#, c-format
-msgid "Left Button #%d"
-msgstr "ปุ่มซ้าย #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1241
-#, c-format
-msgid "Right Button #%d"
-msgstr "ปุ่มขวา #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1244
-#, c-format
-msgid "Top Button #%d"
-msgstr "ปุ่มบน #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1247
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "ปุ่มล่าง #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "ปุ่มลัดใหม่…"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "ไม่ทำสิ่งใด"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "คลิกเมาส์ปุ่มซ้าย"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "คลิกเมาส์ปุ่มกลาง"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "คลิกเมาส์ปุ่มขวา"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "เลื่อนหน้าจอขึ้น"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "เลื่อนหน้าจอลง"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "เลื่อนหน้าจอไปทางซ้าย"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "เลื่อนหน้าจอไปทางขวา"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "ย้อนกลับ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "เดินหน้า"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "ปากกา"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "การรับแรงกดของยางลบ"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "นุ่ม"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "แข็ง"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "ปุ่มบน"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "ปุ่มล่าง"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "การรับแรงกดของปลายปากกา"
 
-#: ../shell/alt/cc-window.c:765 ../shell/cc-window.c:53
-#: ../shell/cc-window.c:1478
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "นุ่ม"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "แข็ง"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "ปุ่ม"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "ปุ่ม"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "ปุ่ม"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "การรับแรงกดของยางลบ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "การรับแรงกดของยางลบ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "คลิกเมาส์ปุ่มกลาง"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "คลิกเมาส์ปุ่มขวา"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "เดินหน้า"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "แท็บเล็ต Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "ตั้งผังปุ่มและปรับความไวของสไตลัสสำหรับแท็บเล็ตกราฟิก"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "แท็บเล็ต;Wacom;ปากกา;สไตลัส;ยางลบ;เมาส์;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "ผังแป้นพิมพ์"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "วางตรงกลาง"
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_จำลองคลิกที่สอง"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "ซอฟต์แวร์สำหรับวินโดวส์"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "ผงหมึกใกล้หมด"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "จอรอง"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "ซอฟต์แวร์สำหรับวินโดวส์"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "ตัวเลือกของการเข้าถึง"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "เพิ่ม"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_บันทึก"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "รายละเอียด"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "เวลาเ_ครือข่าย"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "ตั้งค่าเครือข่าย"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "ตัวเลข"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "ชนิดของอุปกรณ์"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "ผู้ผลิต"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "ขาดเฟิร์มแวร์"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "ล็อคอยู่"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "บรอดแบนด์_มือถือ"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "เวลาเ_ครือข่าย"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "เครือข่าย"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "ขั้นสูง"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "ตัวเลือกของการเข้าถึง"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "ล็อค"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "รายละเอียด"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "ชื่อเครือข่าย"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "อัตโนมัติ"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "เครือข่ายของบ้านฉัน"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "เครือข่ายของบ้านฉัน"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+#, fuzzy
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "บลูทูทจะถูกปิดใช้งานเมื่อเปิดใช้โหมดเครื่องบิน"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "ปิดโหมดเครื่องบิน"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "การเชื่อมต่อ"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "ไม่ได้ใส่ SIM card"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "ล็อค"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "เป_ลี่ยน"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "เครือข่ายของบ้านฉัน"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+#, fuzzy
+msgid "Utility to configure the GNOME desktop"
+msgstr "เครื่องมือสำหรับตั้งค่าเดสก์ท็อป GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "กำลังตั้งค่าไดรเวอร์ตัวใหม่…"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "ความเป็นส่วนตัว"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "ค่าตั้งทั้งหมด"
 
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
-msgid "GNOME Control Center"
-msgstr "ศูนย์ควบคุมของ GNOME"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "จอหลัก"
 
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
-msgid "Utilities to configure the GNOME desktop"
-msgstr "เครื่องมือสำหรับตั้งค่าเดสก์ท็อป GNOME"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
+#: shell/cc-window.ui:153
 msgid ""
-"The control center is GNOME's main interface for configuration of various "
-"aspects of your desktop."
-msgstr "ศูนย์ควบคุมเป็นส่วนติดต่อหลักของ GNOME สำหรับตั้งค่าส่วนต่างๆ ของเดสก์ท็อปของคุณ"
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/cc-application.c:45
-msgid "Display version number"
-msgstr "แสดงหมายเลขรุ่น"
-
-#: ../shell/cc-application.c:46
-msgid "Enable verbose mode"
-msgstr "เปิดใช้ข้อความละเอียด"
-
-#: ../shell/cc-application.c:47
-msgid "Show the overview"
-msgstr "แสดงภาพรวม"
-
-#: ../shell/cc-application.c:48
-msgid "Search for the string"
-msgstr "ค้นหาข้อความ"
-
-#: ../shell/cc-application.c:49
-msgid "List possible panel names and exit"
-msgstr "แสดงรายชื่อพาเนลที่เป็นไปได้และออก"
-
-#: ../shell/cc-application.c:50
-msgid "Panel to display"
-msgstr "แผงควบคุมที่จะแสดง"
-
-#: ../shell/cc-application.c:50
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[แผงควบคุม] [อาร์กิวเมนต์…]"
-
-#: ../shell/cc-application.c:113
-msgid "Available panels:"
-msgstr "แผงควบคุมที่มี"
-
-#: ../shell/cc-application.c:252
+#: shell/cc-window.ui:164
 msgid "Help"
 msgstr "วิธีใช้"
 
-#: ../shell/cc-application.c:253
-msgid "Quit"
-msgstr "ออก"
-
-#. Add categories
-#: ../shell/cc-window.c:871
-msgctxt "category"
-msgid "Personal"
-msgstr "ส่วนบุคคล"
-
-#: ../shell/cc-window.c:872
-msgctxt "category"
-msgid "Hardware"
-msgstr "ฮาร์ดแวร์"
-
-#: ../shell/cc-window.c:873
-msgctxt "category"
-msgid "System"
-msgstr "ระบบ"
-
-#: ../shell/gnome-control-center.desktop.in.in.h:2
-msgid "Preferences;Settings;"
-msgstr "ปรับแต่ง;ตั้งค่า;"
-
-#: ../shell/help-overlay.ui.h:1
+#: shell/help-overlay.ui:15
 msgctxt "shortcut window"
 msgid "General"
 msgstr "ทั่วไป"
 
-#: ../shell/help-overlay.ui.h:2
+#: shell/help-overlay.ui:20
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "ออก"
 
-#: ../shell/help-overlay.ui.h:3
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
 msgid "Search"
 msgstr "ค้นหา"
 
-#: ../shell/help-overlay.ui.h:4
+#: shell/help-overlay.ui:35
 msgctxt "shortcut window"
 msgid "Panels"
 msgstr "พาเนล"
 
-#: ../shell/help-overlay.ui.h:5
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
 msgctxt "shortcut window"
-msgid "Go back to the overview"
+msgid "Go back to previous panel"
 msgstr "ย้อนกลับไปยังภาพรวม"
 
-#: ../shell/help-overlay.ui.h:6
+#: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "ยกเลิกการค้นหา"
 
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: ../shell/hostname-helper.c:189
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "จุดแพร่สัญญาณ"
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "ปรับแต่ง;ตั้งค่า;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "เสียงออก %u ช่อง"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "เสียงเข้า %u ช่อง"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "เปลี่ยนแปลงตลอดวัน"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "เรียงกระเบื้อง"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "ซูม"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "วางตรงกลาง"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "ยืดเต็มจอ"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "แสดงเต็มภาพ"
+
+#~ msgid "Colors"
+#~ msgstr "สี"
+
+#~ msgid "Select Background"
+#~ msgstr "เลือกพื้นหลัง"
+
+#~ msgid "Pictures"
+#~ msgstr "รูปภาพ"
+
+#~ msgid "Home"
+#~ msgstr "บ้าน"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "คุณสามารถเพิ่มรูปภาพลงในโฟลเดอร์ %s ของคุณ แล้วรูปภาพจะปรากฏที่นี่"
+
+#~ msgid "multiple sizes"
+#~ msgstr "หลายขนาด"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "ไม่ใช้ภาพพื้นหลังพื้นโต๊ะ"
+
+#~ msgid "Current background"
+#~ msgstr "พื้นหลังปัจจุบัน"
+
+#~ msgid "Back­ground"
+#~ msgstr "พื้น­หลัง"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "ภาพพื้นหลัง;หน้าจอ;พื้นโต๊ะ;"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "บลู­ทูท"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "วางอุปกรณ์เทียบมาตรฐานของคุณบนสี่เหลี่ยม แล้วกด 'เริ่ม'"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "เลื่อนอุปกรณ์เทียบมาตรฐานของคุณไปยังตำแหน่งเทียบมาตรฐาน แล้วกด 'ทำต่อไป'"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "เลื่อนอุปกรณ์เทียบมาตรฐานของคุณไปยังตำแหน่งผิวหน้า แล้วกด 'ทำต่อไป'"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "ปิดฝาพับของแล็ปท็อป"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "เกิดข้อผิดพลาดภายในที่ไม่สามารถกู้คืนได้"
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "เครื่องมือที่ต้องใช้ในการเทียบมาตรฐานไม่ได้ติดตั้งไว้"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "ไม่สามารถสร้างโพรไฟล์ได้"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "ไม่สามารถอ่านค่าจุดขาวเป้าหมายได้"
+
+#~ msgid "Complete!"
+#~ msgstr "เสร็จสมบูรณ์!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "เทียบมาตรฐานไม่สำเร็จ!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "คุณสามารถถอดอุปกรณ์เทียบมาตรฐานออกได้"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "ห้ามรบกวนอุปกรณ์เทียบมาตรฐานขณะทำงาน"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "หน้าจอแล็ปท็อป"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "จอภาพ %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "สแกนเนอร์ %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "เครื่องพิมพ์ %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "เว็บแคม %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "เปิดใช้การจัดการสีสำหรับ %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "แสดงโพรไฟล์สีสำหรับ %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "ยังไม่เทียบมาตรฐาน"
+
+#~ msgid "Default: "
+#~ msgstr "ปริยาย: "
+
+#~ msgid "Test profile: "
+#~ msgstr "โพรไฟล์ทดสอบ: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "เลือกแฟ้มโพรไฟล์ ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_นำเข้า"
+
+#~ msgid "All files"
+#~ msgstr "ทุกแฟ้ม"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "อัปโหลดแฟ้มไม่สำเร็จ: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "ได้อัปโหลดโพรไฟล์ไปแล้วที่:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "จด URL นี้ไว้"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "เริ่มเปิดคอมพิวเตอร์ใหม่และบูตระบบปฏิบัติการปกติของคุณ"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "ป้อน URL ดังกล่าวในเบราว์เซอร์ของคุณเพื่อดาวน์โหลดและติดตั้งโพรไฟล์นี้"
+
+#~ msgid "Save Profile"
+#~ msgstr "บันทึกโพรไฟล์"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "สร้างโพรไฟล์สีสำหรับอุปกรณ์ที่เลือก"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "ตรวจไม่พบอุปกรณ์ตรวจวัด กรุณาตรวจสอบว่าได้เปิดอุปกรณ์หรือยัง และได้เชื่อมต่อถูกต้องหรือไม่"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "อุปกรณ์ตรวจวัดไม่รองรับการทำโพรไฟล์เครื่องพิมพ์"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "ยังไม่รองรับอุปกรณ์ตรวจวัดชนิดนี้"
+
+#~ msgid "Standard Space"
+#~ msgstr "สเปซมาตรฐาน"
+
+#~ msgid "Test Profile"
+#~ msgstr "โพรไฟล์ทดสอบ"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "อัตโนมัติ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "คุณภาพต่ำ"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "คุณภาพปานกลาง"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "คุณภาพสูง"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB ปริยาย"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK ปริยาย"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "โทนสีเทาปริยาย"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "ข้อมูลสำหรับเทียบมาตรฐานจากโรงงานที่ผู้จำหน่ายให้มา"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "ไม่สามารถปรับแก้การแสดงผลแบบเต็มหน้าจอได้สำหรับโพรไฟล์นี้"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "โพรไฟล์นี้อาจไม่ถูกต้องแม่นยำอีกต่อไป"
+
+#~ msgid "Upload profile"
+#~ msgstr "อัปโหลดโพรไฟล์"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "ต้องการการเชื่อมต่ออินเทอร์เน็ต"
+
+#~ msgid "Co­lor"
+#~ msgstr "สี"
+
+#~ msgid "Other…"
+#~ msgstr "อื่นๆ…"
+
+#~ msgid "Today"
+#~ msgstr "วันนี้"
+
+#~ msgid "Yesterday"
+#~ msgstr "เมื่อวาน"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Ey"
+
+#~ msgid "Language"
+#~ msgstr "ภาษา"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Ey, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Ey, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "24-hour"
+#~ msgstr "24 ชั่วโมง"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "Lid Closed"
+#~ msgstr "ฝาแล็ปท็อปปิด"
+
+#~ msgid "Mirrored"
+#~ msgstr "แสดงเหมือนกัน"
+
+#~ msgid "Off"
+#~ msgstr "ปิด"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "จัดเรียงจอแสดงผลประกอบกัน"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "ลากจอแสดงผลเพื่อจัดเรียง"
+
+#, c-format
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "หมุนทวนเข็มนาฬิกา 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "หมุน 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "หมุนตามเข็มนาฬิกา 90°"
+
+#~ msgid "Size"
+#~ msgstr "ขนาด"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "แสดงแถบด้านบนและภาพรวมกิจกรรมในจอแสดงผลนี้"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "เชื่อมจอแสดงผลนี้กับจออื่นเพื่อสร้างพื้นที่ทำงานเพิ่มพิเศษ"
+
+#~ msgid "Presentation"
+#~ msgstr "งานนำเสนอ"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "แสดงภาพสไลด์และสื่อเท่านั้น"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "แสดงหน้าจอของคุณออกทางจอแสดงผลทั้งคู่"
+
+#~ msgid "Turn Off"
+#~ msgstr "ปิด"
+
+#~ msgid "Don't use this display"
+#~ msgstr "ไม่ใช้จอแสดงผลนี้"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "ไม่สามารถอ่านข้อมูลเกี่ยวกับหน้าจอ"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_จัดเรียงจอแสดงผลประกอบกัน"
+
+#~ msgid "Dis­plays"
+#~ msgstr "จอ­แสดง­ผล"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "Unknown"
+#~ msgstr "ไม่ทราบ"
+
+#, c-format
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d บิต (ID ประกอบสร้าง: %s)"
+
+#, c-format
+#~ msgid "%d-bit (Build ID: %s)"
+#~ msgstr "%d บิต (ID ประกอบสร้าง: %s)"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d บิต"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d บิต"
+
+#~ msgid "Ask what to do"
+#~ msgstr "ถามว่าจะให้ทำอะไร"
+
+# probably wrong spelling
+#~ msgid "Do nothing"
+#~ msgstr "ไม่ต้องทำอะไร"
+
+#~ msgid "Open folder"
+#~ msgstr "เปิดโฟลเดอร์"
+
+#~ msgid "Other Media"
+#~ msgstr "สื่ออื่นๆ"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "เลือกโปรแกรมสำหรับซีดีเพลง"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "เลือกโปรแกรมสำหรับดีวีดีภาพยนตร์"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "เลือกโปรแกรมที่จะเรียกเมื่อมีการเชื่อมต่อกับเครื่องเล่นเพลง"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "เลือกโปรแกรมที่จะเรียกเมื่อมีการเชื่อมต่อกับกล้องถ่ายรูป"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "เลือกโปรแกรมสำหรับซีดีซอฟต์แวร์"
+
+#~ msgid "audio DVD"
+#~ msgstr "ดีวีดีเพลง"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "แผ่นบลูเรย์เปล่า"
+
+#~ msgid "blank CD disc"
+#~ msgstr "แผ่นซีดีเปล่า"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "แผ่นดีวีดีเปล่า"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "แผ่นดีวีดีเปล่าความจุสูง"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "แผ่นภาพยนตร์บลูเรย์"
+
+#~ msgid "e-book reader"
+#~ msgstr "เครื่องอ่านอีบุ๊ก"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "แผ่นดีวีดีภาพยนตร์ความจุสูง"
+
+#~ msgid "Picture CD"
+#~ msgstr "ซีดีรูปภาพ"
+
+#~ msgid "Super Video CD"
+#~ msgstr "ซูเปอร์วิดีโอซีดี"
+
+#~ msgid "Video CD"
+#~ msgstr "วิดีโอซีดี"
+
+#~ msgid "Overview"
+#~ msgstr "ทั่วไป"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "รุ่น %s"
+
+#~ msgid "De­tails"
+#~ msgstr "ราย­ละเอียด"
+
+#~ msgid "Base system"
+#~ msgstr "ระบบพื้นฐาน"
+
+#~ msgid "Disk"
+#~ msgstr "ดิสก์"
+
+#~ msgid "Check for updates"
+#~ msgstr "ตรวจสอบซอฟต์แวร์รุ่นใหม่"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "จับภาพหน้าจอไปเก็บไว้ที่โฟลเดอร์ $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "จับภาพหน้าต่างไปเก็บไว้ที่โฟลเดอร์ $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "จับภาพพื้นที่หน้าจอไปเก็บไว้ที่โฟลเดอร์ $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "จับภาพหน้าจอเข้าไปไว้ในคลิปบอร์ด"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "จับภาพหน้าต่างเข้าไปไว้ในคลิปบอร์ด"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "จับภาพพื้นที่หน้าจอเข้าไปไว้ในคลิปบอร์ด"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "บันทึกภาพถ่ายทอดหน้าจออย่างสั้น"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "ปุ่มสลับไปยังช่องทางถัดไปโดยใช้ปุ่มประกอบเท่านั้น"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for <b>%s</b>. If you replace it, %s will be "
+#~ "disabled"
+#~ msgstr "%s ถูกใช้กับ <b>%s</b> ไปแล้ว ถ้าคุณกำหนดทับ %s ก็จะถูกปิดไม่ให้ใช้งาน"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "ตั้งค่าปุ่มลัดที่กำหนดเอง"
+
+#, c-format
+#~ msgid "Enter new shortcut to change <b>%s</b>."
+#~ msgstr "กดปุ่มลัดใหม่เพื่อเปลี่ยน <b>%s</b>"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "ปุ่มลัด;ซ้ำปุ่ม;กะพริบ;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "กด Esc เพื่อยกเลิก"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "กดปุ่มลัดอันใหม่"
+
+#~ msgid "Set"
+#~ msgstr "กำหนดค่า"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "ความเร็วของดับเบิลคลิก"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "เลื่อนหน้าจอด้วยสองนิ้ว"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "ห้าคลิก ได้เวลา GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "ดับเบิลคลิก ปุ่มหลัก"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "คลิกเดียว ปุ่มหลัก"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "ดับเบิลคลิก ปุ่มกลาง"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "คลิกเดียว ปุ่มกลาง"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "ดับเบิลคลิก ปุ่มรอง"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "คลิกเดียว ปุ่มรอง"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "page 1"
+#~ msgstr "หน้า 1"
+
+#~ msgid "page 2"
+#~ msgstr "หน้า 2"
+
+#~ msgid "automatic"
+#~ msgstr "อัตโนมัติ"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "โพรไฟล์ %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "เอนเทอร์ไพรส์"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "ไม่มี"
+
+#~ msgid "Never"
+#~ msgstr "ไม่มี"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "ไม่มี"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "อ่อน"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "พอใช้"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "ดี"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "ดีมาก"
+
+#~ msgid "Identity"
+#~ msgstr "ชื่อ"
+
+#~ msgid "Server"
+#~ msgstr "เซิร์ฟเวอร์"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "ลบเซิร์ฟเวอร์ DNS"
+
+#~ msgid "Delete Route"
+#~ msgstr "ลบเส้นทาง"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "ไม่ใช้"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/กุญแจ 128 บิต (ฐานสิบหกหรือ ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP วลีรหัสผ่าน 128 บิต"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP แบบผันแปร (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 ส่วนบุคคล"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 เอนเทอร์ไพรส์"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Twisted Pair (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Attachment Unit Interface (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Media Independent Interface (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "เปิดให้ผู้ใ_ช้อื่นใช้ด้วย"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "เ_ขตไฟร์วอลล์"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "ปริยาย"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "เขตนี้จะกำหนดระดับความเชื่อถือของการเชื่อมต่อ"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "ไม่สามารถเปิดเครื่องมือแก้ไขการเชื่อมต่อ"
+
+#~ msgid "New Profile"
+#~ msgstr "โพรไฟล์ใหม่"
+
+#~ msgid "Import from file…"
+#~ msgstr "นำเข้าจากแฟ้ม…"
+
+#~ msgid "Add VPN"
+#~ msgstr "เพิ่ม VPN"
+
+#~ msgid "_Reset"
+#~ msgstr "_ล้างค่า"
+
+#~ msgid "_Forget"
+#~ msgstr "ล_บทิ้ง"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr "ล้างการตั้งค่าสำหรับเครือข่ายนี้ รวมถึงรหัสผ่าน แต่จำเครือข่ายไว้"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr "ลบรายละเอียดที่เกี่ยวข้องกับเครือข่ายนี้ทั้งหมด และไม่พยายามเชื่อมต่ออัตโนมัติ"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "ไม่สามารถนำเข้าการเชื่อมต่อ VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "แฟ้ม '%s' ไม่สามารถอ่านได้ หรือไม่มีข้อมูลการเชื่อมต่อ VPN ที่รู้จัก\n"
+#~ "\n"
+#~ "ข้อผิดพลาด: %s"
+
+#~ msgid "Select file to import"
+#~ msgstr "เลือกแฟ้มที่จะนำเข้า"
+
+#~ msgid "_Open"
+#~ msgstr "_เปิด"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "มีแฟ้มชื่อ \"%s\" อยู่ก่อนแล้ว"
+
+#~ msgid "_Replace"
+#~ msgstr "แ_ทนที่"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "คุณต้องการจะแทนที่ %s ด้วยการเชื่อมต่อ VPN ที่คุณกำลังจะบันทึกนี้หรือไม่?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "ไม่สามารถส่งออกการเชื่อมต่อ VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "ไม่สามารถส่งออกการเชื่อมต่อ '%s' ออกยัง %s\n"
+#~ "\n"
+#~ "ข้อผิดพลาด: %s"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "ส่งออกการเชื่อมต่อ VPN"
+
+#~ msgid "Net­work"
+#~ msgstr "เครือ­ข่าย"
+
+#~ msgid "never"
+#~ msgstr "ยังไม่เคยใช้"
+
+#~ msgid "today"
+#~ msgstr "วันนี้"
+
+#~ msgid "yesterday"
+#~ msgstr "เมื่อวาน"
+
+#~ msgid "Last used"
+#~ msgstr "ใช้ครั้งล่าสุด"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "ถ้าคุณมีการเชื่อมต่อไปยังอินเทอร์เน็ตทางอื่นนอกเหนือจากเครือข่ายไร้สาย "
+#~ "คุณก็สามารถตั้งค่าจุดแพร่สัญญาณไร้สายเพื่อแบ่งปันการเชื่อมต่ออินเทอร์เน็ตให้ผู้อื่นใช้ได้"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "การเปิดใช้จุดแพร่สัญญาณไร้สายจะเป็นการตัดการเชื่อมต่อจาก <b>%s</b>"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "คุณจะไม่สามารถเข้าถึงอินเทอร์เน็ตผ่านเครือข่ายไร้สายได้ในระหว่างเปิดใช้จุดแพร่สัญญาณ"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "จะปิดจุดแพร่สัญญาณและตัดการเชื่อมต่อกับผู้ใช้ทั้งหมดหรือไม่?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "ปิ_ดจุดแพร่สัญญาณ"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "นโยบายของระบบห้ามใช้เป็นจุดแพร่สัญญาณ"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "อุปกรณ์ไร้สายไม่รองรับโหมดจุดแพร่สัญญาณ"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr "รายละเอียดของเครือข่ายที่เลือก รวมถึงรหัสผ่านและค่าปรับแต่งใดๆ จะถูกลบทิ้ง"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_ลบทิ้ง"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "การตรวจหาเว็บพร็อกซีอัตโนมัติจะใช้เมื่อไม่มีการกำหนด URL สำหรับตั้งค่าไว้"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "ไม่แนะนำให้ใช้ในเครือข่ายสาธารณะที่ไม่น่าเชื่อถือ"
+
+#~ msgid "Proxy"
+#~ msgstr "พร็อกซี"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "ไม่ใช้"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "กำหนดเอง"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "อัตโนมัติ"
+
+#~ msgid "VPN Type"
+#~ msgstr "ชนิด VPN"
+
+#~ msgid "Group Name"
+#~ msgstr "ชื่อกลุ่ม"
+
+#~ msgid "Group Password"
+#~ msgstr "รหัสผ่านกลุ่ม"
+
+#~ msgid "details"
+#~ msgstr "รายละเอียด"
+
+#~ msgid "Show P_assword"
+#~ msgstr "แ_สดงรหัสผ่าน"
+
+#~ msgid "Make available to other users"
+#~ msgstr "เปิดให้ผู้ใช้อื่นใช้ด้วย"
+
+#~ msgid "identity"
+#~ msgstr "ชื่อ"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "อัตโนมัติ (DHCP) เฉพาะที่อยู่"
+
+#~ msgid "Link-local only"
+#~ msgstr "เชื่อมต่อภายในเท่านั้น"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "ไ_ม่สนใจเส้นทางเครือข่ายที่ได้รับมาแบบอัตโนมัติ"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "_ถอดแบบที่อยู่ MAC"
+
+#~ msgid "hardware"
+#~ msgstr "ฮาร์ดแวร์"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr "ล้างการตั้งค่าสำหรับการเชื่อมต่อนี้ให้เป็นค่าปริยาย แต่จำการเชื่อมต่อไว้"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "ลบรายละเอียดที่เกี่ยวข้องกับเครือข่ายนี้ทั้งหมด และไม่พยายามเชื่อมต่ออัตโนมัติกับเครือข่ายนี้"
+
+#~ msgid "reset"
+#~ msgstr "ล้างค่า"
+
+#~ msgid "Hardware"
+#~ msgstr "ฮาร์ดแวร์"
+
+#~ msgid "_History"
+#~ msgstr "_ประวัติ"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "ปิดหากต้องการเชื่อมต่อไปยังเครือข่าย Wi-Fi"
+
+#~ msgid "Connected Devices"
+#~ msgstr "อุปกรณ์ที่เชื่อมต่อ"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Infrastructure"
+
+#~ msgid "Status unknown"
+#~ msgstr "ไม่ทราบสถานะ"
+
+#~ msgid "Unmanaged"
+#~ msgstr "ไม่มีการจัดการ"
+
+#~ msgid "Unavailable"
+#~ msgstr "ใช้งานไม่ได้"
+
+#~ msgid "Connecting"
+#~ msgstr "กำลังเชื่อมต่อ"
+
+#~ msgid "Authentication required"
+#~ msgstr "ต้องยืนยันตัวบุคคล"
+
+#~ msgid "Disconnecting"
+#~ msgstr "กำลังตัดการเชื่อมต่อ"
+
+#~ msgid "Connection failed"
+#~ msgstr "เชื่อมต่อไม่สำเร็จ"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "ไม่ทราบสถานะ (ค่าหายไป)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "ตั้งค่าไม่สำเร็จ"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "ตั้งค่าไอพีไม่สำเร็จ"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "ค่าไอพีหมดอายุ"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "ต้องการข้อมูลลับ แต่ไม่ได้ป้อนไว้"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x supplicant ถูกตัดการเชื่อมต่อ"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "ตั้งค่า 802.1x supplicant ไม่สำเร็จ"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x supplicant ล้มเหลว"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant ใช้เวลายืนยันตัวบุคคลนานเกินไป"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "เปิดบริการ PPP ไม่สำเร็จ"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "บริการ PPP ถูกตัดการเชื่อมต่อ"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP ล้มเหลว"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "เปิดใช้ลูกข่าย DHCP ไม่สำเร็จ"
+
+#~ msgid "DHCP client error"
+#~ msgstr "เกิดข้อผิดพลาดที่ลูกข่าย DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "ลูกข่าย DHCP ล้มเหลว"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "เปิดบริการแบ่งปันการเชื่อมต่อไม่สำเร็จ"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "บริการแบ่งปันการเชื่อมต่อล้มเหลว"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "เปิดบริการ AutoIP ไม่สำเร็จ"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "เกิดข้อผิดพลาดที่บริการ AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "บริการ AutoIP ล้มเหลว"
+
+#~ msgid "Line busy"
+#~ msgstr "สายไม่ว่าง"
+
+#~ msgid "No dial tone"
+#~ msgstr "ไม่มีสัญญาณหมุนเลขหมาย"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "ไม่สามารถเชื่อมต่อกับผู้ให้บริการ"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "หมดเวลาคอยการหมุนเลขหมาย"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "หมุนเลขหมายไม่สำเร็จ"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "ตั้งค่าเริ่มต้นโมเด็มไม่สำเร็จ"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "เลือก APN ที่กำหนดไม่สำเร็จ"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "ไม่ได้อยู่ระหว่างค้นหาเครือข่าย"
+
+#~ msgid "Network registration denied"
+#~ msgstr "การลงทะเบียนเครือข่ายถูกปฏิเสธ"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "หมดเวลาคอยลงทะเบียนเครือข่าย"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "ลงทะเบียนกับเครือข่ายที่ร้องขอไม่สำเร็จ"
+
+#~ msgid "PIN check failed"
+#~ msgstr "การตรวจสอบ PIN ล้มเหลว"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "อาจขาดเฟิร์มแวร์สำหรับอุปกรณ์"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "การเชื่อมต่อหายไป"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "ถือว่ามีการเชื่อมต่ออยู่ก่อนแล้ว"
+
+#~ msgid "Modem not found"
+#~ msgstr "ไม่พบโมเด็ม"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "เชื่อมต่อบลูทูทไม่สำเร็จ"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "ต้องการรหัส PIN ของ SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "ต้องการรหัส PUK ของ SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM ผิด"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "สิ่งที่ต้องใช้สำหรับการเชื่อมต่อล้มเหลว"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "สายเคเบิลถูกถอดออก"
+
+#~ msgid "undefined error in 802.1x security (wpa-eap)"
+#~ msgstr "เกิดข้อผิดพลาดที่ไม่ได้บัญญัติไว้ในความปลอดภัย 802.1x (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "ไม่ได้เลือกแฟ้ม"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "เกิดข้อผิดพลาดที่ไม่ได้บัญญัติไว้ขณะตรวจความถูกต้องของแฟ้ม eap-method"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "กุญแจส่วนตัวแบบ DER, PEM, หรือ PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "ใบรับรองแบบ DER หรือ PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "ไม่มีแฟ้ม PAC สำหรับ EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "แฟ้ม PAC (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "ขาดชื่อผู้ใช้ EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "ขาดรหัสผ่าน EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "ใบรับรอง EAP-PEAP CA ไม่ถูกต้อง: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "ใบรับรอง EAP-PEAP CA ไม่ถูกต้อง: ไม่ได้ระบุใบรับรอง"
+
+#~ msgid "missing EAP username"
+#~ msgstr "ขาดชื่อผู้ใช้ EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "ขาดรหัสผ่าน EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "ขาดเอกลักษณ์ EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "ใบรับรอง EAP-TLS CA ไม่ถูกต้อง: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "ใบรับรอง EAP-TLS CA ไม่ถูกต้อง: ไม่ได้ระบุใบรับรอง"
+
+#~ msgid "invalid EAP-TLS password: missing"
+#~ msgstr "รหัสผ่าน EAP-TLS ไม่ถูกต้อง: ไม่มีรหัสผ่าน"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "กุญแจส่วนตัว EAP-TLS ไม่ถูกต้อง: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "ใบรับรองผู้ใช้ EAP-TLS ไม่ถูกต้อง: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "กุญแจส่วนตัวที่ไม่เข้ารหัสลับนั้นไม่มีความปลอดภัย"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "กุญแจส่วนตัวที่เลือกไม่มีการปกป้องด้วยรหัสผ่าน "
+#~ "ซึ่งอาจทำให้ข้อมูลลับของระบบรักษาความปลอดภัยของคุณถูกขโมยใช้ได้ "
+#~ "กรุณาเลือกกุญแจส่วนตัวที่มีการปกป้องด้วยรหัสผ่าน\n"
+#~ "\n"
+#~ "(คุณสามารถปกป้องกุญแจส่วนตัวของคุณด้วยรหัสผ่านได้ โดยใช้ openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "เลือกใบรับรองส่วนตัวของคุณ"
+
+#~ msgid "Choose your private key"
+#~ msgstr "เลือกกุญแจส่วนตัวของคุณ"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "ใบรับรอง EAP-TTLS CA ไม่ถูกต้อง: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "ใบรับรอง EAP-TTLS CA ไม่ถูกต้อง: ไม่ได้ระบุใบรับรอง"
+
+#~ msgid "Unknown error validating 802.1x security"
+#~ msgstr "เกิดข้อผิดพลาดไม่ทราบสาเหตุขณะตรวจสอบความปลอดภัย 802.1x"
+
+#~ msgid "missing leap-username"
+#~ msgstr "ขาดชื่อผู้ใช้ leap"
+
+#~ msgid "missing leap-password"
+#~ msgstr "ขาดรหัสผ่าน leap"
+
+#~ msgid "missing wep-key"
+#~ msgstr "ขาด wep-key"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr "wep-key ไม่ถูกต้อง: คีย์ความยาว %zu ต้องมีเฉพาะตัวเลขฐานสิบหกเท่านั้น"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr "wep-key ไม่ถูกต้อง: คีย์ความยาว %zu ต้องมีเฉพาะอักขระแอสกี้เท่านั้น"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "wep-key ไม่ถูกต้อง: ความยาวคีย์ %zu ไม่ถูกต้อง คีย์ต้องยาว 5/13 (แอสกี) หรือ 10/26 "
+#~ "(ฐานสิบหก) อย่างใดอย่างหนึ่ง"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "wep-key ไม่ถูกต้อง: วลีรหัสผ่านต้องไม่ว่างเปล่า"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "wep-key ไม่ถูกต้อง: วลีรหัสผ่านต้องสั้นกว่า 64 อักขระ"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk ไม่ถูกต้อง: ความยาวคีย์ %zu ไม่ถูกต้อง ต้องยาวตั้งแต่ 8 ถึง 63 ไบต์ "
+#~ "หรือเป็นเลขฐานสิบหก 64 หลักเท่านั้น"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "wpa-psk ไม่ถูกต้อง: ไม่สามารถอ่านค่าคีย์ความยาว 64 ไบต์เป็นเลขฐานสิบหกได้"
+
+#~ msgid "On"
+#~ msgstr "เปิด"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_พาดหัวการแจ้งเหตุ"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "การ­แจ้ง­เหตุ"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "_พาดหัวการแจ้งเหตุ"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "อื่นๆ"
+
+#~ msgid "Add Account"
+#~ msgstr "เพิ่มบัญชี"
+
+#~ msgid "Mail"
+#~ msgstr "เมล"
+
+#~ msgid "Contacts"
+#~ msgstr "ผู้ติดต่อ"
+
+#~ msgid "Chat"
+#~ msgstr "สนทนา"
+
+#~ msgid "Resources"
+#~ msgstr "ทรัพยากร"
+
+#~ msgid "Error creating account"
+#~ msgstr "เกิดข้อผิดพลาดขณะสร้างบัญชี"
+
+#~ msgid "Error removing account"
+#~ msgstr "เกิดข้อผิดพลาดขณะลบบัญชี"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "ยืนยันที่จะลบบัญชีหรือไม่?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "การลบนี้จะไม่มีการลบบัญชีที่เซิร์ฟเวอร์"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "ไม่ได้ตั้งค่าบัญชีออนไลน์ใดไว้"
+
+#~ msgid "Remove Account"
+#~ msgstr "ลบบัญชี"
+
+#~ msgid "Add an online account"
+#~ msgstr "เพิ่มบัญชีออนไลน์"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "การเพิ่มบัญชีจะช่วยให้โปรแกรมต่างๆ ของคุณสามารถเข้าถึงเอกสาร เมล ผู้ติดต่อ ปฏิทิน "
+#~ "การสนทนา และอื่นๆ จากบัญชีนั้นๆ"
+
+#~ msgid "Unknown time"
+#~ msgstr "ไม่ทราบเวลา"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "อีก %s จะเต็ม"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "คำเตือน: อีก %s จะหมด"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "อีก %s จะหมด"
+
+#~ msgid "Fully charged"
+#~ msgstr "ประจุไฟเต็มแล้ว"
+
+#~ msgid "Empty"
+#~ msgstr "ไม่มีประจุเหลืออยู่"
+
+#~ msgid "Charging"
+#~ msgstr "กำลังประจุไฟ"
+
+#~ msgid "Discharging"
+#~ msgstr "กำลังจ่ายไฟ"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "หลัก"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "พิเศษ"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "เมาส์ไร้สาย"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "แป้นพิมพ์ไร้สาย"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "อุปกรณ์จ่ายไฟสำรอง"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "เครื่องช่วยงานส่วนบุคคลแบบดิจิทัล"
+
+#~ msgid "Cellphone"
+#~ msgstr "โทรศัพท์เคลื่อนที่"
+
+#~ msgid "Media player"
+#~ msgstr "เครื่องเล่นสื่อ"
+
+#~ msgid "Computer"
+#~ msgstr "คอมพิวเตอร์"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "กำลังประจุไฟ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "ระวัง"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "ต่ำ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "ดี"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "ประจุไฟเต็มแล้ว"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "ไม่มีประจุเหลืออยู่"
+
+#~ msgid "Batteries"
+#~ msgstr "แบตเตอรี่"
+
+#~ msgid "When _idle"
+#~ msgstr "เมื่อไ_ม่ใช้งาน"
+
+#~ msgid "_Screen brightness"
+#~ msgstr "ความ_สว่างหน้าจอ"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "ความสว่างแ_ป้นพิมพ์"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "_หรี่หน้าจอเมื่อไม่มีการใช้งาน"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+#~ msgstr "ปิดอุปกรณ์บรอดแบนด์มือถือ (3G, 4G, LTE ฯลฯ) เพื่อประหยัดพลังงาน"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_บลูทูท"
+
+#~ msgid "When on battery power"
+#~ msgstr "เมื่อใช้ไฟจากแบตเตอรี่"
+
+#~ msgid "When plugged in"
+#~ msgstr "เมื่อเสียบปลั๊กไฟ"
+
+#~ msgid "Suspend"
+#~ msgstr "พักเครื่อง"
+
+#~ msgid "Hibernate"
+#~ msgstr "จำศีลเครื่อง"
+
+# probably wrong spelling
+#~ msgid "Nothing"
+#~ msgstr "ไม่ต้องทำอะไร"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "ปุ่มพัก & เปิด/ปิดเครื่อง"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "พักเครื่องโดย_อัตโนมัติ"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "พักเครื่องโดยอัตโนมัติ"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "เมื่อกดปุ่มเปิ_ด/ปิดเครื่อง"
+
+#~ msgid "Po­wer"
+#~ msgstr "พลัง­งาน"
+
+#~ msgid "1 minute"
+#~ msgstr "1 นาที"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 นาที"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 นาที"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 นาที"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 นาที"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 นาที"
+
+#~ msgid "Out of toner"
+#~ msgstr "ผงหมึกหมด"
+
+#~ msgid "Low on developer"
+#~ msgstr "น้ำยาใกล้หมด"
+
+#~ msgid "Out of developer"
+#~ msgstr "น้ำยาหมด"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "ตลับสีหมึกใกล้หมด"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "ตลับสีหมึกหมด"
+
+#~ msgid "Open cover"
+#~ msgstr "ฝาครอบเปิด"
+
+#~ msgid "Open door"
+#~ msgstr "ประตูเปิด"
+
+#~ msgid "Low on paper"
+#~ msgstr "กระดาษใกล้หมด"
+
+#~ msgid "Out of paper"
+#~ msgstr "กระดาษหมด"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "ออฟไลน์"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "หยุด"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "ที่เก็บของเสียใกล้เต็ม"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "ที่เก็บของเสียเต็ม"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "ลูกกลิ้งไวแสงใกล้หมดอายุ"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "ลูกกลิ้งไวแสงไม่ทำงานแล้ว"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "กำลังตั้งค่า"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "พร้อม"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "ไม่รับงานพิมพ์"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "กำลังดำเนินการ"
+
+#~ msgid "Toner Level"
+#~ msgstr "ระดับผงหมึก"
+
+#~ msgid "Supply Level"
+#~ msgstr "ระดับแหล่งจ่าย"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "กำลังติดตั้ง"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "ทำงานอยู่ %u"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "เพิ่มเครื่องพิมพ์เครื่องใหม่ไม่สำเร็จ"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "แฟ้มบรรยายเครื่องพิมพ์โพสต์สคริปต์ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "ไม่พบไดรเวอร์ที่เหมาะสม"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "อ่านส่วนติดต่อผู้ใช้ไม่สำเร็จ: %s"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "เพิ่มเครื่องพิมพ์เครื่องใหม่"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "เครื่องพิมพ์ JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "เครื่องพิมพ์ LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "หน้าเดียว"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "ขอบด้านยาว (มาตรฐาน)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "ขอบด้านสั้น (พลิก)"
+
+#~ msgid "Portrait"
+#~ msgstr "แนวตั้ง"
+
+#~ msgid "Landscape"
+#~ msgstr "แนวนอน"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "แนวนอนกลับด้าน"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "แนวตั้งกลับด้าน"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "รอดำเนินการ"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "พักพิมพ์"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "กำลังดำเนินการ"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "หยุด"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "ยกเลิก"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "เลิกพิมพ์"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "เสร็จแล้ว"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s - Active Jobs"
+#~ msgstr "%s - งานที่พิมพ์อยู่"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "พอร์ตอนุกรม"
+
+#~ msgid "Parallel Port"
+#~ msgstr "พอร์ตขนาน"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "ตำแหน่งที่ตั้ง: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "ที่อยู่: %s"
+
+#~ msgid "Two Sided"
+#~ msgstr "สองหน้า"
+
+#~ msgid "Paper Type"
+#~ msgstr "ชนิดกระดาษ"
+
+#~ msgid "Paper Source"
+#~ msgstr "แหล่งป้อนกระดาษ"
+
+#~ msgid "Output Tray"
+#~ msgstr "ถาดกระดาษออก"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "การกรองเบื้องต้นด้วย GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "จำนวนหน้าต่อหน้ากระดาษ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "ทั่วไป"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "ตั้งหน้ากระดาษ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "ตัวเลือกที่สามารถติดตั้งได้"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "งานพิมพ์"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "คุณภาพของรูปภาพ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "สี"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "การจัดขั้นสุดท้าย"
+
+#~ msgid "Auto Select"
+#~ msgstr "เลือกโดยอัตโนมัติ"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "ฝังแบบอักษร GhostScript เท่านั้น"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "แปลงเป็น PS ระดับ 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "แปลงเป็น PS ระดับ 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "ไม่ต้องกรองเบื้องต้น"
+
+#~ msgid "Supply"
+#~ msgstr "แหล่งจ่าย"
+
+#~ msgid "_Default printer"
+#~ msgstr "เครื่องพิมพ์_ปริยาย"
+
+#~ msgid "Jobs"
+#~ msgstr "งานพิมพ์"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "แสดง_งานพิมพ์"
+
+#~ msgid "label"
+#~ msgstr "ฉลาก"
+
+#~ msgid "page 3"
+#~ msgstr "หน้า 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "พิมพ์หน้า_ทดสอบ"
+
+#~ msgid "_Options"
+#~ msgstr "_ตัวเลือก"
+
+#~ msgid "Add a Printer"
+#~ msgstr "เพิ่มเครื่องพิมพ์"
+
+#~ msgid "In use"
+#~ msgstr "ใช้งานอยู่"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "เปิด"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "ปิด"
+
+#~ msgid "Usage & History"
+#~ msgstr "การใช้งาน & ประวัติ"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "แน่ใจหรือไม่ว่าต้องการลบทุกอย่างในถังขยะอย่างถาวร?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "ทุกรายการในถังขยะจะถูกลบทิ้งอย่างถาวร"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "ลบแฟ้มชั่วคราวทั้งหมดหรือไม่?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "แฟ้มชั่วคราวทั้งหมดจะถูกลบทิ้งอย่างถาวร"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data."
+#~ msgstr ""
+#~ "การส่งรายงานปัญหาทางเทคนิคเป็นการช่วยเราปรับปรุง %s ให้ดีขึ้น รายงานจะถูกส่งโดยไม่ระบุชื่อ "
+#~ "และปราศจากข้อมูลส่วนบุคคล"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "นโยบายความเป็นส่วนตัว"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "ความ­เป็น­ส่วน­ตัว"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "ปกป้องข้อมูลส่วนตัวของคุณและควบคุมสิ่งที่จะให้คนอื่นเห็น"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "หน้าจอปิด"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 วินาที"
+
+#~ msgid "1 day"
+#~ msgstr "1 วัน"
+
+#~ msgid "2 days"
+#~ msgstr "2 วัน"
+
+#~ msgid "3 days"
+#~ msgstr "3 วัน"
+
+#~ msgid "4 days"
+#~ msgstr "4 วัน"
+
+#~ msgid "5 days"
+#~ msgstr "5 วัน"
+
+#~ msgid "6 days"
+#~ msgstr "6 วัน"
+
+#~ msgid "7 days"
+#~ msgstr "7 วัน"
+
+#~ msgid "14 days"
+#~ msgstr "14 วัน"
+
+#~ msgid "30 days"
+#~ msgstr "30 วัน"
+
+#~ msgid "Forever"
+#~ msgstr "ตลอดไป"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "การจำประวัติของคุณทำให้หาสิ่งต่างๆ อีกครั้งได้ง่าย รายการเหล่านี้จะไม่มีการแบ่งปันในเครือข่าย"
+
+#~ msgid "_Recently Used"
+#~ msgstr "ใช้_ล่าสุด"
+
+#~ msgid "Retain _History"
+#~ msgstr "จดจำ_ประวัติ"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "การล็อคหน้าจอจะปกป้องความเป็นส่วนตัวของคุณเมื่อคุณลุกไปจากเครื่อง"
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "ล็อคหน้าจอ_หลังจากแสดงจอเปล่าเป็นเวลา"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "ล้างถังขยะและแฟ้มชั่วคราวโดยอัตโนมัติ "
+#~ "เพื่อช่วยให้คอมพิวเตอร์ของคุณปลอดจากข้อมูลที่ล่อแหลมโดยไม่จำเป็น"
+
+#~ msgid "Purge _After"
+#~ msgstr "ล้าง_หลังจาก"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "การส่งข้อมูลเกี่ยวกับซอฟต์แวร์ที่คุณใช้ ช่วยให้เราเตรียมคำแนะนำได้ถูกต้องยิ่งขึ้นสำหรับคุณ "
+#~ "และยังเป็นการช่วยเราปรับปรุงซอฟต์แวร์ของเราอีกด้วย\n"
+#~ "\n"
+#~ "ข้อมูลทั้งหมดที่เรารวบรวมจะไม่มีการระบุชื่อผู้ใช้ และเราจะไม่แบ่งปันข้อมูลของคุณกับบุคคลที่สาม"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_ส่งสถิติการใช้ซอฟต์แวร์"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "บริการตำแหน่งที่ตั้งจะทำให้โปรแกรมต่างๆ รู้ตำแหน่งภูมิศาสตร์ที่คุณอยู่ การใช้ Wi-Fi "
+#~ "และบรอดแบนด์มือถือจะช่วยเพิ่มความแม่นยำได้"
+
+#~ msgid "_Location Services"
+#~ msgstr "บริการ_ตำแหน่งที่ตั้ง"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "อังกฤษ"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "เมตริก"
+
+#~ msgid "No input sources found"
+#~ msgstr "ไม่พบช่องทางป้อนข้อความ"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "อื่นๆ"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "สลับไปยังช่องทางก่อนหน้า"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "สลับไปยังช่องทางถัดไป"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "คุณสามารถเปลี่ยนปุ่มลัดเหล่านี้ได้ในการตั้งค่าแป้นพิมพ์"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "ปุ่มลัดทางเลือกสำหรับสลับไปยังช่องทางถัดไป"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Alt ซ้าย+ขวา"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "อังกฤษ (สหราชอาณาจักร)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "สหราชอาณาจักร"
+
+#~ msgid "Add input source"
+#~ msgstr "เพิ่มช่องทางป้อนข้อความ"
+
+#~ msgid "Remove input source"
+#~ msgstr "ลบช่องทางป้อนข้อความ"
+
+#~ msgid "Move input source up"
+#~ msgstr "เลื่อนช่องทางป้อนข้อความขึ้น"
+
+#~ msgid "Move input source down"
+#~ msgstr "เลื่อนช่องทางป้อนข้อความลง"
+
+#~ msgid "Configure input source"
+#~ msgstr "ตั้งค่าช่องทางป้อนข้อความ"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "แสดงผังแป้นพิมพ์ของช่องทางป้อนข้อความ"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "การตั้งค่าการเข้าระบบใช้จะใช้กับผู้ใช้ทั้งหมดขณะเข้าสู่ระบบ"
+
+#~ msgid "Select Location"
+#~ msgstr "เลือกสถานที่"
+
+#~ msgid "_OK"
+#~ msgstr "_ตกลง"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "ไม่มีเครือข่ายที่เลือกเพื่อใช้ร่วม"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "เปิด"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "ปิด"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "เปิดใช้"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "เลือกโฟลเดอร์"
+
+#, c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "การแบ่งปันแฟ้มส่วนตัว ช่วยคุณแบ่งปันโฟลเดอร์ \"สาธารณะ\" "
+#~ "ของคุณกับผู้อื่นในเครือข่ายปัจจุบันของคุณ โดยใช้: <a href=\"dav://%s\">dav://%s</a>"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "เมื่อเปิดใช้การเข้าระบบผ่านเครือข่าย ผู้ใช้จากเครื่องอื่นจะสามารถเชื่อมต่อ "
+#~ "โดยใช้คำสั่งเชลล์นิรภัย:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "การแบ่งปันหน้าจอจะเปิดให้ผู้ใช้จากเครื่องอื่นดูหรือควบคุมหน้าจอของคุณ ด้วยการเชื่อมต่อไปยัง: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "Sha­ring"
+#~ msgstr "การ­แบ่ง­ปัน"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "การแบ่งปันหน้า_จอ"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "บางบริการถูกปิดใช้เพราะเข้าถึงเครือข่ายไม่ได้"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "การแบ่งปันหน้าจอ"
+
+#~ msgid "_Password:"
+#~ msgstr "_รหัสผ่าน:"
+
+#~ msgid "_Show Password"
+#~ msgstr "แ_สดงรหัสผ่าน"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "การเชื่อมต่อใ_หม่ต้องร้องขอการเข้าถึง"
+
+#~ msgid "_Require a password"
+#~ msgstr "_ต้องใช้รหัสผ่าน"
+
+#~ msgid "Bark"
+#~ msgstr "เห่า"
+
+#~ msgid "Drip"
+#~ msgstr "หยดน้ำ"
+
+#~ msgid "Glass"
+#~ msgstr "แก้ว"
+
+#~ msgid "Sonar"
+#~ msgstr "โซนาร์"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "ซ้าย"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "ขวา"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "ต่ำสุด"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "สูงสุด"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_ซับวูฟเฟอร์:"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "ไม่ขยาย"
+
+#~ msgid "_Profile:"
+#~ msgstr "โ_พรไฟล์:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "_ทดสอบลำโพง"
+
+#~ msgid "Peak detect"
+#~ msgstr "ตรวจหายอดคลื่น"
+
+#~ msgid "Device"
+#~ msgstr "อุปกรณ์"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "การทดสอบลำโพงสำหรับ %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "เ_ลือกอุปกรณ์สำหรับเสียงออก:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "ค่าตั้งสำหรับอุปกรณ์ที่เลือก:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "ความดังเสียงเ_ข้า:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "เ_ลือกอุปกรณ์สำหรับเสียงเข้า:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "เอฟเฟ็กต์เสียง"
+
+#~ msgid "Built-in"
+#~ msgstr "ฝังในโปรแกรม"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ปรับแต่งเสียง"
+
+#~ msgid "Testing event sound"
+#~ msgstr "กำลังทดสอบเสียงของเหตุการณ์"
+
+#~ msgid "From theme"
+#~ msgstr "จากชุดเสียง"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "เ_ลือกเสียงแจ้งเหตุ:"
+
+#~ msgid "Stop"
+#~ msgstr "หยุด"
+
+#~ msgid "Custom"
+#~ msgstr "กำหนดเอง"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "การ­เข้า­ถึง­หลาก­หลาย"
+
+#~ msgid "Screen Reader"
+#~ msgstr "การอ่านหน้าจอ"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "การ_อ่านหน้าจอ"
+
+#~ msgid "Sound Keys"
+#~ msgstr "ส่งเสียงปุ่มกด"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "กะพริบหัว_หน้าต่าง"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "สั้น"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ หน้าจอ"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ หน้าจอ"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ หน้าจอ"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "ยาว"
+
+#~ msgid "Standard"
+#~ msgstr "มาตรฐาน"
+
+#~ msgid "Account _Type"
+#~ msgstr "_ชนิดของบัญชี:"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "อนุญาตให้ผู้ใช้ตั้งรหัสผ่านในครั้งต่อไปที่เ_ข้าระบบ"
+
+#~ msgid "Set a password _now"
+#~ msgstr "ตั้งรหัสผ่านเ_ดี๋ยวนี้"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "คุณต้องออนไลน์เพื่อเพิ่มผู้ใช้องค์กร"
+
+#~ msgid "Left thumb"
+#~ msgstr "นิ้วหัวแม่มือซ้าย"
+
+#~ msgid "Left middle finger"
+#~ msgstr "นิ้วกลางซ้าย"
+
+#~ msgid "Left ring finger"
+#~ msgstr "นิ้วนางซ้าย"
+
+#~ msgid "Left little finger"
+#~ msgstr "นิ้วก้อยซ้าย"
+
+#~ msgid "Right thumb"
+#~ msgstr "นิ้วหัวแม่มือขวา"
+
+#~ msgid "Right middle finger"
+#~ msgstr "นิ้วกลางขวา"
+
+#~ msgid "Right ring finger"
+#~ msgstr "นิ้วนางขวา"
+
+#~ msgid "Right little finger"
+#~ msgstr "นิ้วก้อยขวา"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "เปิดใช้การเข้าระบบด้วยลายนิ้วมือ"
+
+#~ msgid "_Right index finger"
+#~ msgstr "นิ้วชี้_ขวา"
+
+#~ msgid "_Left index finger"
+#~ msgstr "นิ้วชี้ซ้า_ย"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "บันทึกลายนิ้วมือของคุณสำเร็จแล้ว คุณควรสามารถเข้าระบบโดยใช้เครื่องอ่านลายนิ้วมือได้แล้ว"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "เข้าระบบ;ชื่อ;ลายนิ้วมือ;รูปแทนตัว;โลโก้;รูปหน้า;รหัสผ่าน;"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "_ตรวจสอบรหัสผ่านใหม่"
+
+#~ msgid "User Icon"
+#~ msgstr "ไอคอนบัญชีผู้ใช้"
+
+#~ msgid "Last Login"
+#~ msgstr "เข้าระบบล่าสุด"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "รหัสผ่านใหม่ต้องต่างจากรหัสผ่านเดิม"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "ลองเปลี่ยนอักษรและตัวเลขบางตัว"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "ลองเปลี่ยนรหัสผ่านให้ต่างจากเดิมกว่านี้อีกสักหน่อย"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "รหัสผ่านที่ไม่มีชื่อผู้ใช้อยู่ในรหัสผ่านจะแน่นหนากว่า"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "พยายามหลีกเลี่ยงการใช้ชื่อของคุณในรหัสผ่าน"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "พยายามหลีกเลี่ยงคำบางคำในรหัสผ่าน"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "พยายามหลีกเลี่ยงคำทั่วไป"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "พยายามหลีกเลี่ยงการกลับลำดับคำเดิม"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "พยายามใช้ตัวเลขเพิ่มอีก"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "พยายามใช้ตัวพิมพ์ใหญ่เพิ่มอีก"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "พยายามใช้ตัวพิมพ์เล็กเพิ่มอีก"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "พยายามใช้อักขระพิเศษเพิ่มอีก เช่น เครื่องหมายวรรคตอน"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "พยายามใช้ตัวอักษร ตัวเลข และเครื่องหมายวรรคตอนผสมกัน"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "พยายามหลีกเลี่ยงการซ้ำอักขระเดิม"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "พยายามหลีกเลี่ยงการใช้อักขระชนิดเดิมซ้ำ คุณต้องผสมตัวอักษร ตัวเลข และเครื่องหมายวรรคตอน"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "พยายามหลีกเลี่ยงการใช้ลำดับ เช่น 1234 หรือ abcd"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "พยายามเพิ่มตัวอักษร ตัวเลข และสัญลักษณ์ให้มากขึ้น"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "ผสมตัวพิมพ์ใหญ่และตัวพิมพ์เล็ก และพยายามใช้ตัวเลขสักตัวสองตัว"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr ""
+#~ "รหัสผ่านดี! การเพิ่มตัวอักษร ตัวเลข และเครื่องหมายวรรคตอนอีก จะทำให้รหัสผ่านแน่นหนาขึ้น"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "ความแน่นหนา: หละหลวม"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "ความแน่นหนา: ต่ำ"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "ความแน่นหนา: ปานกลาง"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "ความแน่นหนา: ดี"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "ความแน่นหนา: สูง"
+
+#~ msgid "Authentication failed"
+#~ msgstr "ยืนยันตัวบุคคลไม่ผ่าน"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "รหัสผ่านใหม่สั้นเกินไป"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "รหัสผ่านใหม่เดาง่ายเกินไป"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "รหัสผ่านใหม่คล้ายกับรหัสผ่านเก่าเกินไป"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "รหัสผ่านใหม่เพิ่งใช้ไปเมื่อเร็วๆ นี้"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "รหัสผ่านใหม่ต้องมีตัวเลขหรือเครื่องหมายพิเศษด้วย"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "รหัสผ่านใหม่เหมือนกันกับรหัสผ่านเก่า"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "รหัสผ่านของคุณถูกเปลี่ยนหลังจากการยืนยันตัวบุคคลครั้งก่อน"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "รหัสผ่านใหม่มีอักขระต่างกันไม่มากพอ"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "ข้อผิดพลาดไม่ทราบสาเหตุ"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "ควรจะตรงกับที่อยู่เว็บของผู้ให้บริการบัญชีเข้าระบบของคุณ"
+
+#~ msgid "Failed to add account"
+#~ msgstr "เพิ่มบัญชีไม่สำเร็จ"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "รหัสผ่านไม่ตรงกัน"
+
+#~ msgid "Failed to register account"
+#~ msgstr "ลงทะเบียนบัญชีไม่สำเร็จ"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "ไม่มีวิธีการยืนยันตัวบุคคลที่รองรับสำหรับโดเมนนี้"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "เข้าร่วมในโดเมนไม่สำเร็จ"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "ชื่อสำหรับเข้าระบบไม่ถูกต้อง\n"
+#~ "กรุณาลองใหม่"
+
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "รหัสผ่านสำหรับเข้าระบบไม่ถูกต้อง\n"
+#~ "กรุณาลองใหม่"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "เข้าระบบในโดเมนไม่สำเร็จ"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "หาโดเมนไม่พบ คุณอาจสะกดผิดหรือไม่?"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "มาตรฐาน"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "ผู้ดูแลระบบ"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "คุณไม่ได้รับอนุญาตให้เข้าใช้อุปกรณ์ กรุณาติดต่อผู้ดูแลระบบของคุณ"
+
+#~ msgid "The device is already in use."
+#~ msgstr "อุปกรณ์กำลังถูกใช้งานอยู่"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "เกิดข้อผิดพลาดภายใน"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "จะลบลายนิ้วมือที่ลงทะเบียนไว้หรือไม่?"
+
+#~ msgid "Done!"
+#~ msgstr "เสร็จแล้ว!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "ไม่สามารถเข้าใช้อุปกรณ์ '%s'"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "ไม่สามารถเริ่มอ่านลายนิ้วมือที่อุปกรณ์ '%s'"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "ไม่สามารถเข้าใช้เครื่องอ่านลายนิ้วมือใดๆ ได้เลย"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "กรุณาติดต่อผู้ดูแลระบบของคุณเพื่อขอความช่วยเหลือ"
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "ในการเปิดใช้การเข้าระบบด้วยลายนิ้วมือ คุณต้องบันทึกลายนิ้วมือของคุณก่อน โดยใช้อุปกรณ์ '%s'"
+
+#~ msgid "Selecting finger"
+#~ msgstr "เลือกนิ้ว"
+
+#~ msgid "This Week"
+#~ msgstr "สัปดาห์นี้"
+
+#~ msgid "Last Week"
+#~ msgstr "สัปดาห์ที่แล้ว"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b %Ey"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "วาระสิ้นสุด"
+
+#~ msgid "Session Started"
+#~ msgstr "วาระเริ่มต้น"
+
+#~ msgid "Please choose another password."
+#~ msgstr "กรุณาตั้งรหัสผ่านใหม่"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "กรุณาป้อนรหัสผ่านปัจจุบันของคุณอีกครั้ง"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "ไม่สามารถเปลี่ยนรหัสผ่านได้"
+
+#~ msgid "Disable image"
+#~ msgstr "ไม่ใช้รูปภาพ"
+
+#~ msgid "Take a photo…"
+#~ msgstr "ถ่ายภาพ…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "ท่องดูรูปภาพเพิ่มเติม…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "ใช้โดย %s"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "ไม่สามารถเข้าร่วมโดเมนชนิดนี้โดยอัตโนมัติได้"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "ไม่พบโดเมนหรือ realm ดังกล่าว"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "ไม่สามารถเข้าระบบในนาม %s ที่โดเมน %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "รหัสผ่านไม่ถูกต้อง กรุณาลองใหม่"
+
+#~ msgid "Other Accounts"
+#~ msgstr "บัญชีอื่นๆ"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ลบผู้ใช้ไม่สำเร็จ"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "เพิกถอนผู้ใช้ที่จัดการผ่านเครือข่ายไม่สำเร็จ"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "คุณจะลบบัญชีของคุณเองไม่ได้"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s ยังคงเข้าระบบอยู่"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "การลบบัญชีผู้ใช้ในระหว่างที่ผู้ใช้นั้นกำลังเข้าระบบอยู่ จะทำให้ระบบอยู่ในสถานะที่สับสน"
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "คุณต้องการเก็บรักษาแฟ้มต่างๆ ของ %s ไว้หรือไม่?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ในการลบบัญชีผู้ใช้ คุณสามารถเก็บรักษาไดเรกทอรีบ้าน, ถุงเมล และแฟ้มชั่วคราวของผู้ใช้ไว้ได้"
+
+#~ msgid "_Delete Files"
+#~ msgstr "_ลบแฟ้ม"
+
+#~ msgid "_Keep Files"
+#~ msgstr "เ_ก็บรักษาแฟ้ม"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s's account?"
+#~ msgstr "ยืนยันที่จะเพิกถอนบัญชีของ %s ที่จัดการผ่านเครือข่ายหรือไม่?"
+
+#~ msgid "_Delete"
+#~ msgstr "_ลบ"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "บัญชีถูกระงับ"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "รอตั้งรหัสผ่านในครั้งต่อไปที่เข้าระบบ"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "ไม่มีรหัสผ่าน"
+
+#~ msgid "Logged in"
+#~ msgstr "เข้าระบบ"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "ติดต่อบริการบัญชีผู้ใช้ไม่สำเร็จ"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "กรุณาตรวจสอบให้แน่ใจว่าได้ติดตั้งและเปิดใช้งาน AccountService"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "หากต้องการเปลี่ยนแปลง\n"
+#~ "ให้คลิกที่ไอคอน * ก่อน"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "หากต้องการสร้างบัญชีผู้ใช้\n"
+#~ "ให้คลิกที่ไอคอน * ก่อน"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "ลบบัญชีผู้ใช้ที่เลือก"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "หากต้องการลบบัญชีผู้ใช้ที่เลือก\n"
+#~ "ให้คลิกที่ไอคอน * ก่อน"
+
+#~ msgid "Sorry, that user name isn't available. Please try another."
+#~ msgstr "ขออภัย ชื่อผู้ใช้นี้ถูกใช้ไปแล้ว กรุณาลองหาชื่ออื่น"
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "ชื่อผู้ใช้ยาวเกินไป"
+
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "ชื่อผู้ใช้ขึ้นต้นด้วย '-' ไม่ได้"
+
+#~ msgid ""
+#~ "The username should only consist of upper and lower case letters from a-"
+#~ "z, digits and the following characters: . - _"
+#~ msgstr ""
+#~ "ชื่อผู้ใช้ควรประกอบด้วยตัวพิมพ์ใหญ่และตัวพิมพ์เล็กตั้งแต่ a-z, ตัวเลข และอักขระต่อไปนี้เท่านั้น: . "
+#~ "- _"
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr "ชื่อนี้จะนำมาใช้เป็นชื่อโฟลเดอร์บ้านของคุณ และไม่สามารถเปลี่ยนแปลงได้"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "ขึ้น"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "ลง"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "ไม่ทำอะไร"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "ส่งการกดแป้นพิมพ์"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "สลับจอภาพ"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "แสดงวิธีใช้บนหน้าจอ"
+
+#~ msgid "Output:"
+#~ msgstr "เอาต์พุต:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "รักษาสัดส่วนภาพ (กล่องอักษร):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "ปรับตำแหน่งกับจอภาพเดียว"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d จาก %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "การแทนตำแหน่งจอแสดงผล"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "แท็บ­เล็ต Wa­com"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "แท็บเล็ต (สัมบูรณ์)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "ปรับแต่งแท็บเล็ต"
+
+#~ msgid "_Help"
+#~ msgstr "_วิธีใช้"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "ตั้งค่าบลูทูท"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "กำหนดปุ่ม…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "ปรับความละเอียดการแสดงผล"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "ปรับการตั้งค่าเมาส์"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "โหมดการจับตำแหน่ง"
+
+#~ msgid "Left Ring"
+#~ msgstr "วงแหวนสัมผัสซ้าย"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "โหมดวงแหวนสัมผัสซ้าย #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "โหมดวงแหวนสัมผัสขวา #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "แถบสัมผัสซ้าย"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "โหมดแถบสัมผัสซ้าย #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "แถบสัมผัสขวา"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "โหมดแถบสัมผัสขวา #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "ปุ่มเปลี่ยนโหมดวงแหวนสัมผัสซ้าย"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "ปุ่มเปลี่ยนโหมดวงแหวนสัมผัสขวา"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "ปุ่มเปลี่ยนโหมดแถบสัมผัสซ้าย"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "ปุ่มเปลี่ยนโหมดแถบสัมผัสขวา"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "ปุ่มเปลี่ยนโหมด #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "ปุ่มซ้าย #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "ปุ่มขวา #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "ปุ่มบน #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "ปุ่มล่าง #%d"
+
+#~ msgid "New shortcut…"
+#~ msgstr "ปุ่มลัดใหม่…"
+
+#~ msgid "No Action"
+#~ msgstr "ไม่ทำสิ่งใด"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "คลิกเมาส์ปุ่มซ้าย"
+
+#~ msgid "Scroll Up"
+#~ msgstr "เลื่อนหน้าจอขึ้น"
+
+#~ msgid "Scroll Right"
+#~ msgstr "เลื่อนหน้าจอไปทางขวา"
+
+#~ msgid "Top Button"
+#~ msgstr "ปุ่มบน"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "ศูนย์ควบคุมของ GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME's main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr "ศูนย์ควบคุมเป็นส่วนติดต่อหลักของ GNOME สำหรับตั้งค่าส่วนต่างๆ ของเดสก์ท็อปของคุณ"
+
+#~ msgid "Display version number"
+#~ msgstr "แสดงหมายเลขรุ่น"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "เปิดใช้ข้อความละเอียด"
+
+#~ msgid "Show the overview"
+#~ msgstr "แสดงภาพรวม"
+
+#~ msgid "Search for the string"
+#~ msgstr "ค้นหาข้อความ"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "แสดงรายชื่อพาเนลที่เป็นไปได้และออก"
+
+#~ msgid "Panel to display"
+#~ msgstr "แผงควบคุมที่จะแสดง"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[แผงควบคุม] [อาร์กิวเมนต์…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "แผงควบคุมที่มี"
+
+#~ msgid "Quit"
+#~ msgstr "ออก"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "ส่วนบุคคล"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "ฮาร์ดแวร์"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "ระบบ"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
 #~ msgstr "ปุ่มลัดสำหรับ <b>%s</b> กดปุ่มลัดใหม่เพื่อเปลี่ยนแปลง"
@@ -7262,17 +8069,8 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Done"
 #~ msgstr "เสร็จสิ้น"
 
-#~ msgid "Color"
-#~ msgstr "สี"
-
 #~ msgid "Time _Zone"
 #~ msgstr "เ_ขตเวลา"
-
-#~ msgid "_Name:"
-#~ msgstr "_ชื่อ:"
-
-#~ msgid "Add Shortcut"
-#~ msgstr "เพิ่มปุ่มลัด"
 
 #~ msgid "Remove Shortcut"
 #~ msgstr "ลบปุ่มลัด"
@@ -7372,9 +8170,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Don't _warn me again"
 #~ msgstr "ไ_ม่ต้องเตือนฉันอีก"
 
-#~ msgid "No"
-#~ msgstr "ไม่"
-
 #~ msgid "Yes"
 #~ msgstr "ใช่"
 
@@ -7390,23 +8185,11 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "_Sign In"
 #~ msgstr "เ_ข้าระบบ"
 
-#~ msgid "Power"
-#~ msgstr "พลังงาน"
-
-#~ msgid "Active Jobs"
-#~ msgstr "งานพิมพ์ที่ทำงานอยู่"
-
-#~ msgid "Close"
-#~ msgstr "ปิด"
-
 #~ msgid "Resume Printing"
 #~ msgstr "พิมพ์ต่อ"
 
 #~ msgid "Pause Printing"
 #~ msgstr "พักการพิมพ์"
-
-#~ msgid "Cancel Print Job"
-#~ msgstr "ยกเลิกงานพิมพ์"
 
 #~ msgctxt "print job"
 #~ msgid "Held"
@@ -7418,24 +8201,12 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Job State"
 #~ msgstr "สถานะงานพิมพ์"
 
-#~ msgid "Time"
-#~ msgstr "เวลา"
-
-#~ msgid "Privacy"
-#~ msgstr "ความเป็นส่วนตัว"
-
 #~ msgid "Used to determine your geographical location"
 #~ msgstr "ใช้กำหนดตำแหน่งที่ตั้งทางภูมิศาสตร์ของคุณ"
-
-#~ msgid "Options"
-#~ msgstr "ตัวเลือก"
 
 #~ msgctxt "Search Location"
 #~ msgid "Other"
 #~ msgstr "อื่นๆ"
-
-#~ msgid "Allow Remote Control"
-#~ msgstr "อนุญาตให้ควบคุมหน้าจอผ่านเครือข่าย"
 
 #~ msgid "Password:"
 #~ msgstr "รหัสผ่าน:"
@@ -7461,12 +8232,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "Add User Account"
 #~ msgstr "เพิ่มบัญชีผู้ใช้"
-
-#~ msgid "Remove User Account"
-#~ msgstr "ลบบัญชีผู้ใช้"
-
-#~ msgid "Login Options"
-#~ msgstr "ตัวเลือกของการเข้าระบบ"
 
 #~ msgid "A user with the username '%s' already exists."
 #~ msgstr "มีผู้ใช้ชื่อ '%s' อยู่ก่อนแล้ว"
@@ -7496,14 +8261,8 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "S_peed:"
 #~ msgstr "_ความเร็ว:"
 
-#~ msgid "Shortcuts"
-#~ msgstr "ปุ่มลัด"
-
 #~ msgid "For mice and touchpads."
 #~ msgstr "สำหรับเมาส์และทัชแพด"
-
-#~ msgid "Bluetooth is disabled"
-#~ msgstr "บลูทูทถูกปิดใช้งาน"
 
 #~ msgid "Test Your Settings"
 #~ msgstr "ทดสอบค่าตั้งของคุณ"
@@ -7546,9 +8305,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Wireless devices require extra power"
 #~ msgstr "อุปกรณ์ไร้สายต้องการพลังงานเพิ่มพิเศษ"
 
-#~ msgid "No printers available"
-#~ msgstr "ไม่มีเครื่องพิมพ์"
-
 #~ msgid "Add New Printer"
 #~ msgstr "เพิ่มเครื่องพิมพ์"
 
@@ -7562,9 +8318,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "Save Received Files to Downloads Folder"
 #~ msgstr "บันทึกแฟ้มที่ได้รับลงในโฟลเดอร์ \"ดาวน์โหลด\""
-
-#~ msgid "Security key"
-#~ msgstr "กุญแจระบบรักษาความปลอดภัย"
 
 #~ msgid "Show help options"
 #~ msgstr "แสดงวิธีใช้ตัวเลือกต่างๆ"
@@ -7585,35 +8338,20 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Power Off"
 #~ msgstr "ปิดเครื่อง"
 
-#~ msgid "Power off"
-#~ msgstr "ปิดเครื่อง"
-
 #~ msgid "Set Up New Device"
 #~ msgstr "ตั้งค่าอุปกรณ์ชิ้นใหม่"
-
-#~ msgid "Connection"
-#~ msgstr "การเชื่อมต่อ"
 
 #~ msgid "Paired"
 #~ msgstr "จับคู่แล้ว"
 
-#~ msgid "Type"
-#~ msgstr "ชนิด"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "ตั้งค่าเมาส์และทัชแพด"
-
-#~ msgid "Sound Settings"
-#~ msgstr "ตั้งค่าเสียง"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "ตั้งค่าแป้นพิมพ์"
 
 #~ msgid "Send Files…"
 #~ msgstr "ส่งแฟ้ม…"
-
-#~ msgid "Visibility"
-#~ msgstr "ความปรากฏเห็น"
 
 #~ msgid "Visibility of “%s”"
 #~ msgstr "ความปรากฏเห็นของ “%s”"
@@ -7646,9 +8384,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Germany"
 #~ msgstr "เยอรมนี"
 
-#~ msgid "France"
-#~ msgstr "ฝรั่งเศส"
-
 #~ msgid "Spain"
 #~ msgstr "สเปน"
 
@@ -7658,17 +8393,11 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Switch between AM and PM."
 #~ msgstr "สลับค่าระหว่าง AM กับ PM"
 
-#~ msgid "Install Updates"
-#~ msgstr "ติดตั้งรุ่นใหม่"
-
 #~ msgid "System Up-To-Date"
 #~ msgstr "ระบบเป็นรุ่นใหม่ล่าสุดแล้ว"
 
 #~ msgid "Mouse Preferences"
 #~ msgstr "ปรับแต่งเมาส์"
-
-#~ msgid "Disable while _typing"
-#~ msgstr "ปิดขณะ_พิมพ์แป้นพิมพ์"
 
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "บริการเครือข่ายของระบบเข้ากันไม่ได้กับรุ่นนี้"
@@ -7800,9 +8529,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "_City:"
 #~ msgstr "เ_มือง:"
 
-#~ msgid "_Network Time"
-#~ msgstr "เวลาเ_ครือข่าย"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "ตั้งเวลาไปข้างหน้าหนึ่งชั่วโมง"
 
@@ -7830,12 +8556,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "180 Degrees"
 #~ msgstr "180 องศา"
 
-#~ msgid "Monitor"
-#~ msgstr "จอภาพ"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "ลากเพื่อเปลี่ยนจอแสดงผลหลัก"
-
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
 #~ "placement."
@@ -7858,9 +8578,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "หมายเหตุ: อาจทำให้เลือกความละเอียดได้จำกัด"
-
-#~ msgid "_Detect Displays"
-#~ msgstr "_ตรวจหาจอแสดงผล"
 
 #~ msgctxt "mouse, speed"
 #~ msgid "Slow"
@@ -7975,9 +8692,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Large"
 #~ msgstr "ใหญ่"
 
-#~ msgid "Add account"
-#~ msgstr "เพิ่มบัญชี"
-
 #~ msgid "_Local Account"
 #~ msgstr "บัญชีใ_นเครื่อง"
 
@@ -7990,12 +8704,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "C_ontinue"
 #~ msgstr "ทำ_ต่อไป"
 
-#~ msgid "Previous Week"
-#~ msgstr "สัปดาห์ก่อนหน้า"
-
-#~ msgid "Next Week"
-#~ msgstr "สัปดาห์หน้า"
-
 #~ msgid "Next week"
 #~ msgstr "สัปดาห์หน้า"
 
@@ -8007,12 +8715,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "Enable this account"
 #~ msgstr "เปิดใช้บัญชีนี้"
-
-#~ msgid "C_onfirm password"
-#~ msgstr "ยื_นยันรหัสผ่าน"
-
-#~ msgid "Generate a password"
-#~ msgstr "สุ่มรหัสผ่าน"
 
 #~ msgid "_Action"
 #~ msgstr "_การกระทำ"
@@ -8085,18 +8787,12 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Change the background"
 #~ msgstr "เปลี่ยนพื้นหลังของพื้นโต๊ะ"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "ตั้งค่าบลูทูท"
-
 #~ msgid "Browse Files..."
 #~ msgstr "ท่องดูแฟ้ม..."
 
 #~ msgctxt "Power"
 #~ msgid "Bluetooth"
 #~ msgstr "บลูทูท"
-
-#~ msgid "Create virtual device"
-#~ msgstr "สร้างอุปกรณ์เสมือน"
 
 #~ msgid "Available Profiles for Displays"
 #~ msgstr "โพรไฟล์ที่มีสำหรับจอแสดงผล"
@@ -8187,9 +8883,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Unspecified"
 #~ msgstr "ไม่ระบุ"
 
-#~ msgid "Select a language"
-#~ msgstr "เลือกภาษา"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "แผงปรับแต่งวันที่และเวลา"
 
@@ -8228,9 +8921,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "Layout Settings"
 #~ msgstr "ตั้งค่าผังแป้นพิมพ์"
-
-#~ msgid "Network settings"
-#~ msgstr "ตั้งค่าเครือข่าย"
 
 #~ msgid "Network;Wireless;IP;LAN;Proxy;"
 #~ msgstr "เครือข่าย;ไร้สาย;ไอพี;แลน;พร็อกซี;"
@@ -8316,9 +9006,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Suspend when inactive for"
 #~ msgstr "พักเครื่องเมื่อไม่มีการใช้งานเป็นเวลา"
 
-#~ msgid "Change printer settings"
-#~ msgstr "ตั้งค่าเครื่องพิมพ์"
-
 #~ msgid "Manufacturers"
 #~ msgstr "ผู้ผลิต"
 
@@ -8366,9 +9053,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Remove Language"
 #~ msgstr "ลบภาษา"
 
-#~ msgid "Install languages..."
-#~ msgstr "ติดตั้งภาษา..."
-
 #~ msgid "Select a region (change will be applied the next time you log in)"
 #~ msgstr "เลือกภูมิภาค (การเปลี่ยนแปลงจะเริ่มมีผลเมื่อคุณเข้าระบบครั้งหน้า)"
 
@@ -8405,9 +9089,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Brightness & Lock"
 #~ msgstr "ความสว่าง & การล็อค"
 
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "ตั้งค่าความสว่างและการล็อคหน้าจอ"
-
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "ความสว่าง;ล็อค;หรี่;จอเปล่า;จอภาพ;"
 
@@ -8419,9 +9100,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "Locations..."
 #~ msgstr "สถานที่..."
-
-#~ msgid "Lock"
-#~ msgstr "ล็อค"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "เปิดใช้โค้ดส่วนดีบั๊ก"
@@ -8437,9 +9115,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "Sound Output Volume"
 #~ msgstr "ความดังของเสียงออก"
-
-#~ msgid "Microphone Volume"
-#~ msgstr "ความดังของไมโครโฟน"
 
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "ไม่สามารถเปิดเครื่องมือปรับแต่งเกี่ยวกับเสียง: %s"
@@ -8534,9 +9209,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Take a screenshot"
 #~ msgstr "จับภาพหน้าจอ"
 
-#~ msgid "A_cceleration:"
-#~ msgstr "ความเร่_ง:"
-
 #~ msgid "Drag Threshold"
 #~ msgstr "ระยะเริ่มลาก"
 
@@ -8589,9 +9261,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Subnet Mask"
 #~ msgstr "แมสก์เครือข่ายย่อย"
 
-#~ msgid "Unlock"
-#~ msgstr "ปลดล็อค"
-
 #~ msgid "_Network Name"
 #~ msgstr "_ชื่อเครือข่าย"
 
@@ -8622,9 +9291,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "%.0lf%% charged"
 #~ msgstr "ประจุไฟ %.0lf%%"
 
-#~ msgid "_Search by Address"
-#~ msgstr "_ค้นหาจากที่อยู่"
-
 #~ msgid ""
 #~ "FirewallD is not running. Network printer detection needs services mdns, "
 #~ "ipp, ipp-client and samba-client enabled on firewall."
@@ -8639,9 +9305,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgctxt "printer type"
 #~ msgid "Network"
 #~ msgstr "เครือข่าย"
-
-#~ msgid "Device types"
-#~ msgstr "ชนิดของอุปกรณ์"
 
 #~ msgid "Opening firewall for mDNS connections"
 #~ msgstr "กำลังเปิดไฟร์วอลล์สำหรับการเชื่อมต่อ mDNS"
@@ -8680,26 +9343,8 @@ msgstr "จุดแพร่สัญญาณ"
 #~ "แทนที่ค่าตั้งผังแป้นพิมพ์ปัจจุบัน\n"
 #~ "ด้วยค่าปริยาย"
 
-#~ msgid "Reset to De_faults"
-#~ msgstr "_กลับไปใช้ค่าปริยาย"
-
-#~ msgid "View and edit keyboard layout options"
-#~ msgstr "แสดงและแก้ไขตัวเลือกสำหรับผังแป้นพิมพ์"
-
-#~ msgid "Layout"
-#~ msgstr "ผังแป้นพิมพ์"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "เ_ลือกอุปกรณ์ที่จะตั้งค่า:"
-
 #~ msgid "Change contrast:"
 #~ msgstr "เปลี่ยนความต่างระดับสี:"
-
-#~ msgid "Decrease size:"
-#~ msgstr "ลดขนาด:"
-
-#~ msgid "Increase size:"
-#~ msgstr "เพิ่มขนาด:"
 
 #~ msgid "Type here to test settings"
 #~ msgstr "ลองพิมพ์ที่นี่เพื่อทดสอบ"
@@ -8708,15 +9353,8 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgstr "_ขนาดตัวอักษร:"
 
 #~ msgctxt "universal access, seeing"
-#~ msgid "Display"
-#~ msgstr "การแสดงผล"
-
-#~ msgctxt "universal access, seeing"
 #~ msgid "Zoom"
 #~ msgstr "ซูม"
-
-#~ msgid "Centered"
-#~ msgstr "วางตรงกลาง"
 
 #~ msgid "Show"
 #~ msgstr "แสดง"
@@ -8796,9 +9434,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "_Turn off after:"
 #~ msgstr "ปิ_ดหลังจาก:"
-
-#~ msgid "Mute"
-#~ msgstr "ปิดเสียง"
 
 #~ msgid "GConf key to which this property editor is attached"
 #~ msgstr "คีย์ของ GConf ที่เครื่องมือแก้ไขคุณสมบัตินี้แนบอยู่ด้วย"
@@ -8886,12 +9521,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "On AC _power:"
 #~ msgstr "เมื่อใช้ไ_ฟ AC:"
 
-#~ msgid "Put the computer to sleep when inactive:"
-#~ msgstr "ให้เครื่องหลับเมื่อไม่มีการใช้งาน:"
-
-#~ msgid "Locked"
-#~ msgstr "ล็อคอยู่"
-
 #~ msgid ""
 #~ "Dialog is unlocked.\n"
 #~ "Click to prevent further changes"
@@ -8977,9 +9606,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "Error setting default mailer: %s"
 #~ msgstr "เกิดข้อผิดพลาดขณะกำหนดโปรแกรมรับส่งเมลปริยาย: %s"
 
-#~ msgid "Please make sure that the applet is properly installed"
-#~ msgstr "กรุณาตรวจสอบการติดตั้งแอพเพล็ตว่าเรียบร้อยดีหรือไม่"
-
 #~ msgid "All %s occurrences will be replaced with actual link"
 #~ msgstr "ข้อความ '%s' ทั้งหมดจะถูกแทนด้วยลิงก์จริง"
 
@@ -9028,9 +9654,6 @@ msgstr "จุดแพร่สัญญาณ"
 #~ msgid "GNOME OnScreen Keyboard"
 #~ msgstr "แป้นพิมพ์บนจอของ GNOME"
 
-#~ msgid "GNOME Terminal"
-#~ msgstr "เทอร์มินัลของ GNOME"
-
 #~ msgid "KDE Magnifier without Screen Reader"
 #~ msgstr "แว่นขยายของ KDE ซึ่งไม่มีโปรแกรมอ่านหน้าจอ"
 
@@ -9057,9 +9680,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "Upside Down"
 #~ msgstr "กลับหัว"
-
-#~ msgid "Desktop"
-#~ msgstr "เดสก์ท็อป"
 
 #~ msgid "Error unsetting accelerator in configuration database: %s"
 #~ msgstr "เกิดข้อผิดพลาดขณะลบปุ่มลัดออกจากฐานข้อมูลค่าปรับแต่ง: %s"
@@ -9117,9 +9737,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "D_rag click:"
 #~ msgstr "คลิกเ_พื่อลาก:"
-
-#~ msgid "Dwell Click"
-#~ msgstr "การคลิกด้วยการวางแช่"
 
 #~ msgid "Show click type _window"
 #~ msgstr "แสดง_หน้าต่างเลือกชนิดการคลิก"
@@ -9183,9 +9800,6 @@ msgstr "จุดแพร่สัญญาณ"
 
 #~ msgid "E-mail address:"
 #~ msgstr "ที่อยู่อีเมล:"
-
-#~ msgid "Open"
-#~ msgstr "เปิด"
 
 #~ msgid "Restrictions:"
 #~ msgstr "ข้อจำกัด:"

--- a/po/th.po~
+++ b/po/th.po~
@@ -1,0 +1,9396 @@
+# Thai gnome-control-center translation.
+# Copyright (C) 2003-2016 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+# Paisa Seeluangsawat <paisa@users.sf.net>, 2003, 2004.
+# Supakorn Siddhichai <supakorn.siddhichai@nectec.or.th>, 2004.
+# Supranee Thirawatthanasuk <supranee@opentle.org>, 2004.
+# Surichat Sumrit <nook@opentle.org>, 2004.
+# Chanchai Junlouchai <taz@opentle.org>, 2004.
+# Theppitak Karoonboonyanan <theppitak@gmail.com>, 2004-2012.
+# Akom Chotiphantawanon <knight2000@gmail.com>, 2010-2011, 2013, 2015-2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2016-09-10 00:29+0000\n"
+"PO-Revision-Date: 2016-10-13 10:42+0700\n"
+"Last-Translator: Theppitak Karoonboonyanan <theppitak@gmail.com>\n"
+"Language-Team: Thai <thai-l10n@googlegroups.com>\n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Gtranslator 2.91.6\n"
+
+#: ../panels/background/background.ui.h:1
+msgid "_Background"
+msgstr "_พื้นหลัง"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "เปลี่ยนแปลงตลอดวัน"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "_Lock Screen"
+msgstr "หน้าจอ_ล็อค"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "เรียงกระเบื้อง"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "ซูม"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "วางตรงกลาง"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "ขยายพอดีหน้าจอ"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "ยืดเต็มจอ"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "แสดงเต็มภาพ"
+
+#: ../panels/background/cc-background-chooser-dialog.c:437
+msgid "Wallpapers"
+msgstr "ภาพพื้นหลัง"
+
+#: ../panels/background/cc-background-chooser-dialog.c:446
+msgid "Colors"
+msgstr "สี"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:483
+msgid "Select Background"
+msgstr "เลือกพื้นหลัง"
+
+#: ../panels/background/cc-background-chooser-dialog.c:511
+msgid "Pictures"
+msgstr "รูปภาพ"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:543
+msgid "No Pictures Found"
+msgstr "ไม่พบรูปภาพ"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:561
+#: ../panels/search/cc-search-locations-dialog.c:302
+msgid "Home"
+msgstr "บ้าน"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:573
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "คุณสามารถเพิ่มรูปภาพลงในโฟลเดอร์ %s ของคุณ แล้วรูปภาพจะปรากฏที่นี่"
+
+#: ../panels/background/cc-background-chooser-dialog.c:580
+#: ../panels/color/cc-color-panel.c:225 ../panels/color/cc-color-panel.c:963
+#: ../panels/color/color-calibrate.ui.h:2 ../panels/color/color.ui.h:30
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1561
+#: ../panels/display/cc-display-panel.c:2206
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+#: ../panels/network/connection-editor/vpn-helpers.c:181
+#: ../panels/network/connection-editor/vpn-helpers.c:310
+#: ../panels/network/net-device-wifi.c:1298
+#: ../panels/network/net-device-wifi.c:1535
+#: ../panels/network/network-wifi.ui.h:1
+#: ../panels/printers/cc-printers-panel.c:2076
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:1048
+#: ../panels/region/format-chooser.ui.h:3 ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:637
+#: ../panels/sharing/cc-sharing-panel.c:372
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/join-dialog.ui.h:2
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:265
+#: ../panels/user-accounts/um-photo-dialog.c:94
+#: ../panels/user-accounts/um-photo-dialog.c:217
+#: ../panels/user-accounts/um-user-panel.c:705
+#: ../panels/user-accounts/um-user-panel.c:723
+msgid "_Cancel"
+msgstr "_ยกเลิก"
+
+#: ../panels/background/cc-background-chooser-dialog.c:581
+msgid "_Select"
+msgstr "เ_ลือก"
+
+#: ../panels/background/cc-background-item.c:203
+msgid "multiple sizes"
+msgstr "หลายขนาด"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:207
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:333
+msgid "No Desktop Background"
+msgstr "ไม่ใช้ภาพพื้นหลังพื้นโต๊ะ"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "พื้นหลังปัจจุบัน"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Back­ground"
+msgstr "พื้น­หลัง"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:3
+msgid "Change your background image to a wallpaper or photo"
+msgstr "เปลี่ยนภาพพื้นหลังของคุณเป็นลวดลายหรือภาพถ่าย"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:5
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "ภาพพื้นหลัง;หน้าจอ;พื้นโต๊ะ;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Turn Off Airplane Mode"
+msgstr "ปิดโหมดเครื่องบิน"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:330
+msgid "No Bluetooth Found"
+msgstr "ไม่พบบลูทูท"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:330
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "เสียบ dongle เพื่อใช้บลูทูท"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:331
+msgid "Bluetooth Turned Off"
+msgstr "บลูทูทถูกปิดอยู่"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:331
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "เปิดเพื่อเชื่อมต่ออุปกรณ์และรับการถ่ายโอนแฟ้ม"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:332
+msgid "Airplane Mode is on"
+msgstr "โหมดเครื่องบินเปิดอยู่"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:332
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "บลูทูทจะถูกปิดใช้งานเมื่อเปิดใช้โหมดเครื่องบิน"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:333
+msgid "Hardware Airplane Mode is on"
+msgstr "โหมดเครื่องบินแบบฮาร์ดแวร์เปิดอยู่"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:333
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "ปิดสวิตช์โหมดเครื่องบินหากต้องการเปิดใช้งานบลูทูท"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Blue­tooth"
+msgstr "บลู­ทูท"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:3
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "เปิด-ปิดบูลทูท และเชื่อมต่ออุปกรณ์ของคุณ"
+
+#. Translators: those are keywords for the bluetooth control-center panel
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:5
+msgid "share;sharing;bluetooth;obex;"
+msgstr "แบ่งปัน;ใช้ร่วม;บลูทูท;obex;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "วางอุปกรณ์เทียบมาตรฐานของคุณบนสี่เหลี่ยม แล้วกด 'เริ่ม'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr "เลื่อนอุปกรณ์เทียบมาตรฐานของคุณไปยังตำแหน่งเทียบมาตรฐาน แล้วกด 'ทำต่อไป'"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr "เลื่อนอุปกรณ์เทียบมาตรฐานของคุณไปยังตำแหน่งผิวหน้า แล้วกด 'ทำต่อไป'"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "ปิดฝาพับของแล็ปท็อป"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "เกิดข้อผิดพลาดภายในที่ไม่สามารถกู้คืนได้"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "เครื่องมือที่ต้องใช้ในการเทียบมาตรฐานไม่ได้ติดตั้งไว้"
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "ไม่สามารถสร้างโพรไฟล์ได้"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "ไม่สามารถอ่านค่าจุดขาวเป้าหมายได้"
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "เสร็จสมบูรณ์!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "เทียบมาตรฐานไม่สำเร็จ!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "คุณสามารถถอดอุปกรณ์เทียบมาตรฐานออกได้"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "ห้ามรบกวนอุปกรณ์เทียบมาตรฐานขณะทำงาน"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "หน้าจอแล็ปท็อป"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "เว็บแคมในตัว"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "จอภาพ %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "สแกนเนอร์ %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "กล้อง %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "เครื่องพิมพ์ %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "เว็บแคม %s"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "เปิดใช้การจัดการสีสำหรับ %s"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "แสดงโพรไฟล์สีสำหรับ %s"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:323
+msgid "Not calibrated"
+msgstr "ยังไม่เทียบมาตรฐาน"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:141
+msgid "Default: "
+msgstr "ปริยาย: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:149
+msgid "Colorspace: "
+msgstr "สเปซสี: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:156
+msgid "Test profile: "
+msgstr "โพรไฟล์ทดสอบ: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:223
+msgid "Select ICC Profile File"
+msgstr "เลือกแฟ้มโพรไฟล์ ICC"
+
+#: ../panels/color/cc-color-panel.c:226
+msgid "_Import"
+msgstr "_นำเข้า"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:237
+msgid "Supported ICC profiles"
+msgstr "โพรไฟล์ ICC ที่รองรับ"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:244
+#: ../panels/network/wireless-security/eap-method-fast.c:417
+msgid "All files"
+msgstr "ทุกแฟ้ม"
+
+#: ../panels/color/cc-color-panel.c:583
+msgid "Screen"
+msgstr "หน้าจอ"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:908
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "อัปโหลดแฟ้มไม่สำเร็จ: %s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:922
+msgid "The profile has been uploaded to:"
+msgstr "ได้อัปโหลดโพรไฟล์ไปแล้วที่:"
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Write down this URL."
+msgstr "จด URL นี้ไว้"
+
+#: ../panels/color/cc-color-panel.c:925
+msgid "Restart this computer and boot your normal operating system."
+msgstr "เริ่มเปิดคอมพิวเตอร์ใหม่และบูตระบบปฏิบัติการปกติของคุณ"
+
+#: ../panels/color/cc-color-panel.c:926
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "ป้อน URL ดังกล่าวในเบราว์เซอร์ของคุณเพื่อดาวน์โหลดและติดตั้งโพรไฟล์นี้"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:960
+msgid "Save Profile"
+msgstr "บันทึกโพรไฟล์"
+
+#: ../panels/color/cc-color-panel.c:964
+#: ../panels/network/connection-editor/vpn-helpers.c:311
+msgid "_Save"
+msgstr "_บันทึก"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1324
+msgid "Create a color profile for the selected device"
+msgstr "สร้างโพรไฟล์สีสำหรับอุปกรณ์ที่เลือก"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1339 ../panels/color/cc-color-panel.c:1363
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "ตรวจไม่พบอุปกรณ์ตรวจวัด กรุณาตรวจสอบว่าได้เปิดอุปกรณ์หรือยัง และได้เชื่อมต่อถูกต้องหรือไม่"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1373
+msgid "The measuring instrument does not support printer profiling."
+msgstr "อุปกรณ์ตรวจวัดไม่รองรับการทำโพรไฟล์เครื่องพิมพ์"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1384
+msgid "The device type is not currently supported."
+msgstr "ยังไม่รองรับอุปกรณ์ตรวจวัดชนิดนี้"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "สเปซมาตรฐาน"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "โพรไฟล์ทดสอบ"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "อัตโนมัติ"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "คุณภาพต่ำ"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "คุณภาพปานกลาง"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "คุณภาพสูง"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB ปริยาย"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK ปริยาย"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "โทนสีเทาปริยาย"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "ข้อมูลสำหรับเทียบมาตรฐานจากโรงงานที่ผู้จำหน่ายให้มา"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "ไม่สามารถปรับแก้การแสดงผลแบบเต็มหน้าจอได้สำหรับโพรไฟล์นี้"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "โพรไฟล์นี้อาจไม่ถูกต้องแม่นยำอีกต่อไป"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "การเทียบมาตรฐานจอแสดงผล"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "_Start"
+msgstr "เ_ริ่ม"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "_Resume"
+msgstr "_ทำงานต่อ"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "เ_สร็จสิ้น"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "การปรับเทียบมาตรฐานหน้าจอ"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"การเทียบมาตรฐานจะสร้างโพรไฟล์ที่คุณสามารถใช้จัดการการใช้สีบนหน้าจอของคุณ "
+"ยิ่งคุณใช้เวลาเทียบมาตรฐานนาน ก็จะยิ่งได้โพรไฟล์สีที่มีคุณภาพสูง"
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "คุณจะไม่สามารถใช้คอมพิวเตอร์ของคุณขณะที่เทียบมาตรฐานอยู่"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "คุณภาพ"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "เวลาโดยประมาณ"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "คุณภาพการเทียบมาตรฐาน"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "เลือกอุปกรณ์รับรู้ที่คุณต้องการใช้ในการเทียบมาตรฐาน"
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "อุปกรณ์เทียบมาตรฐาน"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "เลือกชนิดของจอแสดงผลที่เชื่อมต่ออยู่"
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "ชนิดจอแสดงผล"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"เลือกจุดขาวเป้าหมายของจอแสดงผล จอแสดงผลส่วนใหญ่ควรเทียบมาตรฐานกับแหล่งกำเนิดแสง D65"
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "จุดขาวของโพรไฟล์"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"กรุณาปรับจอแสดงผลให้มีความสว่างเป็นปกติสำหรับคุณ การจัดการสีจะแม่นยำที่สุดที่ระดับความสว่างนี้"
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"หรือมิฉะนั้น คุณก็อาจใช้ระดับความสว่างที่ใช้กับโพรไฟล์อื่นๆ โพรไฟล์ใดโพรไฟล์หนึ่งสำหรับอุปกรณ์นี้"
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "ความสว่างจอแสดงผล"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"คุณสามารถใช้โพรไฟล์สีกับคอมพิวเตอร์อื่นได้ หรือแม้แต่สร้างโพรไฟล์ต่างๆ สำหรับสภาพแสงที่ต่างกันก็ได้"
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "ชื่อโพรไฟล์:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "ชื่อโพรไฟล์"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "สร้างโพร์ไฟล์สำเร็จแล้ว!"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "คัดลอกโพรไฟล์"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "ต้องการสื่อที่สามารถเขียนได้"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "อัปโหลดโพรไฟล์"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "ต้องการการเชื่อมต่ออินเทอร์เน็ต"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"คำแนะนำเกี่ยวกับวิธีใช้โพรไฟล์สีบนระบบ <a href=\"linux\">GNU/Linux</a>, <a href=\"osx"
+"\">Apple OS X</a> และ <a href=\"windows\">Microsoft Windows</a> "
+"เหล่านี้อาจเป็นประโยชน์สำหรับคุณ"
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:730
+msgid "Summary"
+msgstr "สรุป"
+
+#: ../panels/color/color.ui.h:28
+msgid "Add profile"
+msgstr "เพิ่มโพรไฟล์"
+
+#: ../panels/color/color.ui.h:29
+msgid "_Import File…"
+msgstr "_นำเข้าแฟ้ม…"
+
+#: ../panels/color/color.ui.h:31
+#: ../panels/network/connection-editor/net-connection-editor.c:546
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Add"
+msgstr "เ_พิ่ม"
+
+#: ../panels/color/color.ui.h:32
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr "พบปัญหา โพรไฟล์นี้อาจทำงานไม่ถูกต้อง <a href=\"\">แสดงรายละเอียด</a>"
+
+#: ../panels/color/color.ui.h:33
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "อุปกรณ์แต่ละชิ้นต้องมีโพรไฟล์สีที่เป็นค่าล่าสุดเพื่อที่จะจัดการสี"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more"
+msgstr "ศึกษาเพิ่มเติม"
+
+#: ../panels/color/color.ui.h:35
+msgid "Learn more about color management"
+msgstr "ศึกษาเพิ่มเติมเกี่ยวกับการจัดการสี"
+
+#: ../panels/color/color.ui.h:36
+msgid "_Set for all users"
+msgstr "_กำหนดสำหรับผู้ใช้ทุกคน"
+
+#: ../panels/color/color.ui.h:37
+msgid "Set this profile for all users on this computer"
+msgstr "กำหนดโพรไฟล์นี้ให้ผู้ใช้ทุกคนในเครื่องนี้ใช้"
+
+#: ../panels/color/color.ui.h:38
+msgid "_Enable"
+msgstr "_เปิดใช้"
+
+#: ../panels/color/color.ui.h:39
+msgid "_Add profile"
+msgstr "เ_พิ่มโพรไฟล์"
+
+#: ../panels/color/color.ui.h:40
+msgid "_Calibrate…"
+msgstr "เ_ทียบมาตรฐาน…"
+
+#: ../panels/color/color.ui.h:41
+msgid "Calibrate the device"
+msgstr "เทียบมาตรฐานค่าอุปกรณ์"
+
+#: ../panels/color/color.ui.h:42
+msgid "_Remove profile"
+msgstr "_ลบโพรไฟล์ออก"
+
+#: ../panels/color/color.ui.h:43
+msgid "_View details"
+msgstr "ดู_รายละเอียด"
+
+#: ../panels/color/color.ui.h:44
+msgid "Unable to detect any devices that can be color managed"
+msgstr "ตรวจไม่พบอุปกรณ์ใดที่สามารถจัดการสีได้"
+
+#: ../panels/color/color.ui.h:45
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:46
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:47
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:48
+msgid "Projector"
+msgstr "เครื่องฉาย"
+
+#: ../panels/color/color.ui.h:49
+msgid "Plasma"
+msgstr "พลาสมา"
+
+#: ../panels/color/color.ui.h:50
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (แสงหลังแบบ CCFL)"
+
+#: ../panels/color/color.ui.h:51
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (แสงหลังแบบ LED ชนิด RGB)"
+
+#: ../panels/color/color.ui.h:52
+msgid "LCD (white LED backlight)"
+msgstr "LCD (แสงหลังแบบ LED ขาว)"
+
+#: ../panels/color/color.ui.h:53
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD ย่านสีกว้าง (แสงหลังแบบ CCFL)"
+
+#: ../panels/color/color.ui.h:54
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD ย่านสีกว้าง (แสงหลังแบบ LED ชนิด RGB)"
+
+#: ../panels/color/color.ui.h:55
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "สูง"
+
+#: ../panels/color/color.ui.h:56
+msgid "40 minutes"
+msgstr "40 นาที"
+
+#: ../panels/color/color.ui.h:57
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "ปานกลาง"
+
+#: ../panels/color/color.ui.h:58 ../panels/power/power.ui.h:2
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 นาที"
+
+#: ../panels/color/color.ui.h:59
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "ต่ำ"
+
+#: ../panels/color/color.ui.h:60 ../panels/power/power.ui.h:1
+msgid "15 minutes"
+msgstr "15 นาที"
+
+#: ../panels/color/color.ui.h:61
+msgid "Native to display"
+msgstr "ตามธรรมชาติจอแสดงผล"
+
+#: ../panels/color/color.ui.h:62
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (การพิมพ์และการจัดพิมพ์)"
+
+#: ../panels/color/color.ui.h:63
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:64
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (การถ่ายภาพและกราฟิกส์)"
+
+#: ../panels/color/color.ui.h:65
+msgid "D75"
+msgstr "D75"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Co­lor"
+msgstr "สี"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:3
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "เทียบมาตรฐานสีอุปกรณ์ของคุณ เช่น จอภาพ กล้องถ่ายรูป หรือเครื่องพิมพ์"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:5
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "สี;ICC;โพรไฟล์;เทียบมาตรฐาน;เครื่องพิมพ์;จอภาพ;"
+
+#: ../panels/common/cc-common-language.c:323
+msgid "Other…"
+msgstr "อื่นๆ…"
+
+#: ../panels/common/cc-language-chooser.c:124
+#: ../panels/region/cc-format-chooser.c:271
+#: ../panels/region/cc-input-chooser.c:169
+msgid "More…"
+msgstr "เพิ่มเติม…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "ไม่พบภาษา"
+
+#: ../panels/common/cc-util.c:127
+#: ../panels/network/connection-editor/ce-page-details.c:100
+msgid "Today"
+msgstr "วันนี้"
+
+#: ../panels/common/cc-util.c:131
+#: ../panels/network/connection-editor/ce-page-details.c:102
+msgid "Yesterday"
+msgstr "เมื่อวาน"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b %Ey"
+
+#: ../panels/common/language-chooser.ui.h:1
+msgid "Language"
+msgstr "ภาษา"
+
+#: ../panels/datetime/big.ui.h:1 ../panels/datetime/little.ui.h:1
+#: ../panels/datetime/middle.ui.h:1 ../panels/datetime/ydm.ui.h:1
+msgid "Day"
+msgstr "วันที่"
+
+#: ../panels/datetime/big.ui.h:2 ../panels/datetime/little.ui.h:2
+#: ../panels/datetime/middle.ui.h:2 ../panels/datetime/ydm.ui.h:2
+msgid "Month"
+msgstr "เดือน"
+
+#: ../panels/datetime/big.ui.h:3 ../panels/datetime/little.ui.h:3
+#: ../panels/datetime/middle.ui.h:3 ../panels/datetime/ydm.ui.h:3
+msgid "Year"
+msgstr "ค.ศ."
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Ey, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Ey, %R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "มกราคม"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "กุมภาพันธ์"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "มีนาคม"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "เมษายน"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "พฤษภาคม"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "มิถุนายน"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "กรกฎาคม"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "สิงหาคม"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "กันยายน"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "ตุลาคม"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "พฤศจิกายน"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "ธันวาคม"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Date & Time"
+msgstr "วันที่ & เวลา"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "ชั่วโมง"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "นาที"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Time Zone"
+msgstr "เขตเวลา"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Search for a city"
+msgstr "ค้นหาเมือง"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Automatic _Date & Time"
+msgstr "_วันที่ & เวลาอัตโนมัติ"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Requires internet access"
+msgstr "ต้องการการเข้าถึงอินเทอร์เน็ต"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Automatic Time _Zone"
+msgstr "เ_ขตเวลาอัตโนมัติ"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Date & _Time"
+msgstr "วันที่ & เ_วลา"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Time Z_one"
+msgstr "เ_ขตเวลา"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Time _Format"
+msgstr "รู_ปแบบเวลา"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "24-hour"
+msgstr "24 ชั่วโมง"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:3
+msgid "Change the date and time, including time zone"
+msgstr "ตั้งวันที่และเวลา รวมถึงเขตเวลา"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:5
+msgid "Clock;Timezone;Location;"
+msgstr "นาฬิกา;เขตเวลา;ตำแหน่งที่ตั้ง;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "ตั้งเวลาระบบและตั้งค่าเกี่ยวกับวันที่"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "ในการตั้งเวลาหรือวันที่ คุณต้องยืนยันตัวบุคคลก่อน"
+
+#: ../panels/display/cc-display-panel.c:573
+msgid "Lid Closed"
+msgstr "ฝาแล็ปท็อปปิด"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:576
+msgid "Mirrored"
+msgstr "แสดงเหมือนกัน"
+
+#: ../panels/display/cc-display-panel.c:578
+#: ../panels/display/cc-display-panel.c:2429
+msgid "Primary"
+msgstr "จอหลัก"
+
+#: ../panels/display/cc-display-panel.c:580
+#: ../panels/notifications/cc-notifications-panel.c:257
+#: ../panels/power/cc-power-panel.c:1960 ../panels/power/cc-power-panel.c:1971
+#: ../panels/privacy/cc-privacy-panel.c:190
+#: ../panels/privacy/cc-privacy-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:269
+#: ../panels/universal-access/cc-ua-panel.c:590
+#: ../panels/universal-access/cc-ua-panel.c:603
+#: ../panels/universal-access/cc-ua-panel.c:615
+#: ../panels/universal-access/cc-ua-panel.c:786
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "ปิด"
+
+#: ../panels/display/cc-display-panel.c:583
+msgid "Secondary"
+msgstr "จอรอง"
+
+#. Title of displays dialog when multiple monitors are present.
+#: ../panels/display/cc-display-panel.c:1558
+msgid "Arrange Combined Displays"
+msgstr "จัดเรียงจอแสดงผลประกอบกัน"
+
+#: ../panels/display/cc-display-panel.c:1562
+#: ../panels/display/cc-display-panel.c:2207
+#: ../panels/network/connection-editor/connection-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:2
+msgid "_Apply"
+msgstr "เริ่มใ_ช้"
+
+#: ../panels/display/cc-display-panel.c:1586
+msgid "Drag displays to rearrange them"
+msgstr "ลากจอแสดงผลเพื่อจัดเรียง"
+
+#. translators: example string is "60 Hz (NTSC)"
+#. * NTSC is https://en.wikipedia.org/wiki/NTSC
+#: ../panels/display/cc-display-panel.c:1793
+#, c-format
+msgid "%d Hz (NTSC)"
+msgstr "%d Hz (NTSC)"
+
+#. translators: example string is "60 Hz"
+#: ../panels/display/cc-display-panel.c:1799
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../panels/display/cc-display-panel.c:2259
+msgid "Rotate counterclockwise by 90°"
+msgstr "หมุนทวนเข็มนาฬิกา 90°"
+
+#: ../panels/display/cc-display-panel.c:2277
+msgid "Rotate by 180°"
+msgstr "หมุน 180°"
+
+#: ../panels/display/cc-display-panel.c:2295
+msgid "Rotate clockwise by 90°"
+msgstr "หมุนตามเข็มนาฬิกา 90°"
+
+#: ../panels/display/cc-display-panel.c:2316
+msgid "Size"
+msgstr "ขนาด"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2331
+msgid "Aspect Ratio"
+msgstr "สัดส่วนจอภาพ"
+
+#: ../panels/display/cc-display-panel.c:2354
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "ความละเอียด"
+
+#: ../panels/display/cc-display-panel.c:2374
+msgid "Adjust for TV"
+msgstr "ปรับสำหรับโทรทัศน์"
+
+#: ../panels/display/cc-display-panel.c:2398
+msgid "Refresh Rate"
+msgstr "อัตราการรีเฟรช"
+
+#: ../panels/display/cc-display-panel.c:2430
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "แสดงแถบด้านบนและภาพรวมกิจกรรมในจอแสดงผลนี้"
+
+#: ../panels/display/cc-display-panel.c:2436
+msgid "Secondary Display"
+msgstr "จอแสดงผลรอง"
+
+#: ../panels/display/cc-display-panel.c:2437
+msgid "Join this display with another to create an extra workspace"
+msgstr "เชื่อมจอแสดงผลนี้กับจออื่นเพื่อสร้างพื้นที่ทำงานเพิ่มพิเศษ"
+
+#: ../panels/display/cc-display-panel.c:2444
+msgid "Presentation"
+msgstr "งานนำเสนอ"
+
+#: ../panels/display/cc-display-panel.c:2445
+msgid "Show slideshows and media only"
+msgstr "แสดงภาพสไลด์และสื่อเท่านั้น"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2450
+msgid "Mirror"
+msgstr "แสดงเหมือนกัน"
+
+#: ../panels/display/cc-display-panel.c:2451
+msgid "Show your existing view on both displays"
+msgstr "แสดงหน้าจอของคุณออกทางจอแสดงผลทั้งคู่"
+
+#: ../panels/display/cc-display-panel.c:2457
+msgid "Turn Off"
+msgstr "ปิด"
+
+#: ../panels/display/cc-display-panel.c:2458
+msgid "Don't use this display"
+msgstr "ไม่ใช้จอแสดงผลนี้"
+
+#: ../panels/display/cc-display-panel.c:2769
+msgid "Could not get screen information"
+msgstr "ไม่สามารถอ่านข้อมูลเกี่ยวกับหน้าจอ"
+
+#: ../panels/display/cc-display-panel.c:2800
+msgid "_Arrange Combined Displays"
+msgstr "_จัดเรียงจอแสดงผลประกอบกัน"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Dis­plays"
+msgstr "จอ­แสดง­ผล"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:3
+msgid "Choose how to use connected monitors and projectors"
+msgstr "เลือกวิธีใช้งานจอภาพและเครื่องฉายที่เชื่อมต่ออยู่"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:5
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "แผงควบคุม;เครื่องฉาย;xrandr;หน้าจอ;ความละเอียด;รีเฟรช;จอภาพ;"
+
+#: ../panels/info/cc-info-panel.c:345
+msgid "Wayland"
+msgstr "Wayland"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:348 ../panels/network/panel-common.c:123
+msgid "Unknown"
+msgstr "ไม่ทราบ"
+
+#: ../panels/info/cc-info-panel.c:481
+#, c-format
+msgid "%s %d-bit (Build ID: %s)"
+msgstr "%s %d บิต (ID ประกอบสร้าง: %s)"
+
+#: ../panels/info/cc-info-panel.c:483
+#, c-format
+msgid "%d-bit (Build ID: %s)"
+msgstr "%d บิต (ID ประกอบสร้าง: %s)"
+
+#: ../panels/info/cc-info-panel.c:491
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d บิต"
+
+#: ../panels/info/cc-info-panel.c:493
+#, c-format
+msgid "%d-bit"
+msgstr "%d บิต"
+
+#: ../panels/info/cc-info-panel.c:1174
+msgid "Ask what to do"
+msgstr "ถามว่าจะให้ทำอะไร"
+
+# probably wrong spelling
+#: ../panels/info/cc-info-panel.c:1178
+msgid "Do nothing"
+msgstr "ไม่ต้องทำอะไร"
+
+#: ../panels/info/cc-info-panel.c:1182
+msgid "Open folder"
+msgstr "เปิดโฟลเดอร์"
+
+#: ../panels/info/cc-info-panel.c:1273
+msgid "Other Media"
+msgstr "สื่ออื่นๆ"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "Select an application for audio CDs"
+msgstr "เลือกโปรแกรมสำหรับซีดีเพลง"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Select an application for video DVDs"
+msgstr "เลือกโปรแกรมสำหรับดีวีดีภาพยนตร์"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "Select an application to run when a music player is connected"
+msgstr "เลือกโปรแกรมที่จะเรียกเมื่อมีการเชื่อมต่อกับเครื่องเล่นเพลง"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "Select an application to run when a camera is connected"
+msgstr "เลือกโปรแกรมที่จะเรียกเมื่อมีการเชื่อมต่อกับกล้องถ่ายรูป"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Select an application for software CDs"
+msgstr "เลือกโปรแกรมสำหรับซีดีซอฟต์แวร์"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1320
+msgid "audio DVD"
+msgstr "ดีวีดีเพลง"
+
+#: ../panels/info/cc-info-panel.c:1321
+msgid "blank Blu-ray disc"
+msgstr "แผ่นบลูเรย์เปล่า"
+
+#: ../panels/info/cc-info-panel.c:1322
+msgid "blank CD disc"
+msgstr "แผ่นซีดีเปล่า"
+
+#: ../panels/info/cc-info-panel.c:1323
+msgid "blank DVD disc"
+msgstr "แผ่นดีวีดีเปล่า"
+
+#: ../panels/info/cc-info-panel.c:1324
+msgid "blank HD DVD disc"
+msgstr "แผ่นดีวีดีเปล่าความจุสูง"
+
+#: ../panels/info/cc-info-panel.c:1325
+msgid "Blu-ray video disc"
+msgstr "แผ่นภาพยนตร์บลูเรย์"
+
+#: ../panels/info/cc-info-panel.c:1326
+msgid "e-book reader"
+msgstr "เครื่องอ่านอีบุ๊ก"
+
+#: ../panels/info/cc-info-panel.c:1327
+msgid "HD DVD video disc"
+msgstr "แผ่นดีวีดีภาพยนตร์ความจุสูง"
+
+#: ../panels/info/cc-info-panel.c:1328
+msgid "Picture CD"
+msgstr "ซีดีรูปภาพ"
+
+#: ../panels/info/cc-info-panel.c:1329
+msgid "Super Video CD"
+msgstr "ซูเปอร์วิดีโอซีดี"
+
+#: ../panels/info/cc-info-panel.c:1330
+msgid "Video CD"
+msgstr "วิดีโอซีดี"
+
+#: ../panels/info/cc-info-panel.c:1331
+msgid "Windows software"
+msgstr "ซอฟต์แวร์สำหรับวินโดวส์"
+
+#: ../panels/info/cc-info-panel.c:1454
+msgid "Section"
+msgstr "หัวข้อ"
+
+#: ../panels/info/cc-info-panel.c:1463 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "ทั่วไป"
+
+#: ../panels/info/cc-info-panel.c:1469 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "โปรแกรมหลัก"
+
+#: ../panels/info/cc-info-panel.c:1474 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "สื่อถอดเสียบ"
+
+#: ../panels/info/cc-info-panel.c:1499
+#, c-format
+msgid "Version %s"
+msgstr "รุ่น %s"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "De­tails"
+msgstr "ราย­ละเอียด"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:3
+msgid "View information about your system"
+msgstr "ดูข้อมูลเกี่ยวกับระบบของคุณ"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:5
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"อุปกรณ์;ระบบ;ข้อมูล;หน่วยความจำ;ตัวประมวลผล;รุ่น;ปริยาย;โปรแกรม;โปรแกรมหลักๆ;ซีดี;ดีวีดี;"
+"usb;เสียง;วีดิทัศน์;ดิสก์;ถอดเสียบ;สื่อ;autorun;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "เลือกวิธีจัดการสื่ออื่นๆ"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "_การกระทำ:"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "_ชนิด:"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "ชื่ออุปกรณ์"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "หน่วยความจำ"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "ตัวประมวลผล"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "ระบบพื้นฐาน"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "ดิสก์"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "กำลังคำนวณ…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "กราฟิกส์"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "การจำลองเครื่องเสมือน"
+
+#: ../panels/info/info.ui.h:13
+msgid "Check for updates"
+msgstr "ตรวจสอบซอฟต์แวร์รุ่นใหม่"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "เ_ว็บ"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "เ_มล"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "_ปฏิทิน"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "เ_พลง"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "วีดิ_ทัศน์"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "_ภาพถ่าย:"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "เลือกวิธีจัดการสื่อ"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "ซีดีเ_พลง"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "_ดีวีดีภาพยนตร์"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "เ_ครื่องเล่นเพลง"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "ซอ_ฟต์แวร์"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "_สื่ออื่นๆ…"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr "ไ_ม่ต้องถามหรือเปิดโปรแกรมในสื่อเมื่อใส่เข้ามา"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "เสียงและเพลง"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "ปิดเสียง"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "เบาเสียงลง"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "เร่งเสียงขึ้น"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "เรียกโปรแกรมเล่นสื่อ"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "เล่น (หรือ เล่น/พัก)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "พักเพลง"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "หยุดเล่นเพลง"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "เพลงก่อนหน้า"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "เพลงถัดไป"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "เอาสื่อออก"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "การพิมพ์"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "สลับไปยังช่องทางป้อนข้อความเข้าถัดไป"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "สลับไปยังช่องทางป้อนข้อความเข้าก่อนหน้า"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "ปุ่มเรียก"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "เรียกโปรแกรมแสดงวิธีใช้"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/alt/cc-window.c:274
+#: ../shell/alt/cc-window.c:829 ../shell/cc-window.c:1584
+#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/window.ui.h:1
+msgid "Settings"
+msgstr "ตั้งค่า"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "เรียกเครื่องคิดเลข"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "เรียกโปรแกรมอ่าน-เขียนเมล"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "เรียกเว็บเบราว์เซอร์"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "โฟลเดอร์บ้าน"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ค้นหา"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "ภาพหน้าจอ"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "จับภาพหน้าจอไปเก็บไว้ที่โฟลเดอร์ $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "จับภาพหน้าต่างไปเก็บไว้ที่โฟลเดอร์ $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "จับภาพพื้นที่หน้าจอไปเก็บไว้ที่โฟลเดอร์ $PICTURES"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "จับภาพหน้าจอเข้าไปไว้ในคลิปบอร์ด"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "จับภาพหน้าต่างเข้าไปไว้ในคลิปบอร์ด"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "จับภาพพื้นที่หน้าจอเข้าไปไว้ในคลิปบอร์ด"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "บันทึกภาพถ่ายทอดหน้าจออย่างสั้น"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "ระบบ"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "ออกจากระบบ"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "ล็อคหน้าจอ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+msgid "Universal Access"
+msgstr "การเข้าถึงหลากหลาย"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "เปิดหรือปิดการซูม"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "ซูมเข้า"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "ซูมออก"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "เปิดหรือปิดการอ่านหน้าจอ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "เปิดหรือปิดแป้นพิมพ์บนจอ"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "เพิ่มขนาดตัวอักษร"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "ลดขนาดตัวอักษร"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "เปิดหรือปิดการแสดงสีตัดกัน"
+
+#: ../panels/keyboard/cc-keyboard-manager.c:514
+#: ../panels/keyboard/cc-keyboard-manager.c:522
+#: ../panels/keyboard/cc-keyboard-manager.c:830
+msgid "Custom Shortcuts"
+msgstr "ปุ่มลัดกำหนดเอง"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:440
+#: ../panels/keyboard/shortcut-editor.ui.h:2
+#: ../panels/network/network-wifi.ui.h:31
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+msgid "Disabled"
+msgstr "ไม่ใช้"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "ปุ่มยกแคร่ระดับสาม"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "ปุ่ม Compose"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "ปุ่มสลับไปยังช่องทางถัดไปโดยใช้ปุ่มประกอบเท่านั้น"
+
+#: ../panels/keyboard/cc-keyboard-panel.c:215
+msgid "Reset the shortcut to its default value"
+msgstr "คืนค่าปุ่มลัดกลับเป็นค่าปริยาย"
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:357
+#, c-format
+msgid ""
+"%s is already being used for <b>%s</b>. If you replace it, %s will be "
+"disabled"
+msgstr "%s ถูกใช้กับ <b>%s</b> ไปแล้ว ถ้าคุณกำหนดทับ %s ก็จะถูกปิดไม่ให้ใช้งาน"
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:514
+msgid "Set Custom Shortcut"
+msgstr "ตั้งค่าปุ่มลัดที่กำหนดเอง"
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:514
+#: ../panels/keyboard/shortcut-editor.ui.h:7
+msgid "Set Shortcut"
+msgstr "ตั้งค่าปุ่มลัด"
+
+#. Setup the top label
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:523
+#, c-format
+msgid "Enter new shortcut to change <b>%s</b>."
+msgstr "กดปุ่มลัดใหม่เพื่อเปลี่ยน <b>%s</b>"
+
+#: ../panels/keyboard/cc-keyboard-shortcut-editor.c:937
+msgid "Add Custom Shortcut"
+msgstr "เพิ่มปุ่มลัดกำหนดเอง"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "Key­board"
+msgstr "แป้น­พิมพ์"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:3
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "ดูและตั้งปุ่มลัดและปรับแต่งการป้อนข้อความของคุณ"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:5
+msgid "Shortcut;Repeat;Blink;"
+msgstr "ปุ่มลัด;ซ้ำปุ่ม;กะพริบ;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "No keyboard shortcut found"
+msgstr "ไม่พบปุ่มลัด"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "Try a different search"
+msgstr "ลองค้นหาด้วยคำอื่น"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:1
+msgid "Press Esc to cancel."
+msgstr "กด Esc เพื่อยกเลิก"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:3
+#: ../panels/sound/gvc-mixer-dialog.c:1493
+#: ../panels/sound/gvc-sound-theme-chooser.c:564
+msgid "Name"
+msgstr "ชื่อ"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:4
+msgid "Command"
+msgstr "คำสั่ง"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:5
+msgid "Shortcut"
+msgstr "ปุ่มลัด"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:6
+msgid "Edit"
+msgstr "แก้ไข"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:8
+#: ../panels/network/network-wifi.ui.h:20
+msgid "None"
+msgstr "ไม่ใช้"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:9
+msgid "Remove"
+msgstr "ลบออก"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:10
+msgid "Enter the new shortcut"
+msgstr "กดปุ่มลัดอันใหม่"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:11
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+msgid "Cancel"
+msgstr "ยกเลิก"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:12
+#: ../panels/network/connection-editor/ce-page-ip4.c:276
+#: ../panels/network/connection-editor/ce-page-ip6.c:277
+msgid "Add"
+msgstr "เพิ่ม"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:13
+msgid "Replace"
+msgstr "กำหนดทับ"
+
+#: ../panels/keyboard/shortcut-editor.ui.h:14
+msgid "Set"
+msgstr "กำหนดค่า"
+
+#: ../panels/mouse/cc-mouse-panel.c:82
+msgid "Test Your _Settings"
+msgstr "_ทดสอบค่าตั้งของคุณ"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Mouse & Touch­pad"
+msgstr "เมาส์ & ทัช­แพด"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:3
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "ตั้งความไวของเมาส์หรือทัชแพดของคุณ และเลือกใช้เมาส์มือขวาหรือมือซ้าย"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:5
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "ทัชแพด;ตัวชี้;คลิก;แตะ;ดับเบิล;ปุ่ม;แทร็กบอล;เลื่อน;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "ทั่วไป"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "Primary Button"
+msgstr "ปุ่มหลัก"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "กำหนดลำดับของปุ่มจริงบนเมาส์และทัชแพด"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Left"
+msgstr "ซ้าย"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "Right"
+msgstr "ขวา"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Mouse"
+msgstr "เมาส์"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Mouse Speed"
+msgstr "ความเร็วเมาส์"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgid "Double-click timeout"
+msgstr "ความเร็วของดับเบิลคลิก"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "Natural Scrolling"
+msgstr "เลื่อนหน้าจอแบบธรรมชาติ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgid "Scrolling moves the content, not the view."
+msgstr "การเลื่อนจะเลื่อนเนื้อหา ไม่ใช่เลื่อนช่องมอง"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgid "Touchpad"
+msgstr "ทัชแพด"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad Speed"
+msgstr "ความเร็วทัชแพด"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgid "Tap to Click"
+msgstr "คลิกด้วยการแตะ"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgid "Two-finger Scrolling"
+msgstr "เลื่อนหน้าจอด้วยสองนิ้ว"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Edge Scrolling"
+msgstr "เลื่อนหน้าจอที่ขอบ"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "ทดลองคลิก ดับเบิลคลิก และเลื่อนหน้า"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "ห้าคลิก ได้เวลา GEGL!"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "ดับเบิลคลิก ปุ่มหลัก"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "คลิกเดียว ปุ่มหลัก"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "ดับเบิลคลิก ปุ่มกลาง"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "คลิกเดียว ปุ่มกลาง"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "ดับเบิลคลิก ปุ่มรอง"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "คลิกเดียว ปุ่มรอง"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:349
+msgid "Air_plane Mode"
+msgstr "โหมดเ_ครื่องบิน"
+
+#: ../panels/network/cc-network-panel.c:953
+msgid "Network proxy"
+msgstr "พร็อกซีเครือข่าย"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1129 ../panels/network/net-vpn.c:283
+#: ../panels/network/net-vpn.c:440
+#, c-format
+msgid "%s VPN"
+msgstr "VPN %s"
+
+#: ../panels/network/cc-network-panel.c:1194
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "มีบางอย่างไม่ถูกต้อง กรุณาติดต่อผู้จำหน่ายซอฟต์แวร์ของคุณ"
+
+#: ../panels/network/cc-network-panel.c:1200
+msgid "NetworkManager needs to be running."
+msgstr "ต้องมี NetworkManager ทำงานอยู่"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "การรักษาความปลอดภัยของ 802.1x"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "หน้า 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "เอกลักษณ์แบบนิ_รนาม"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:5
+msgid "Inner _authentication"
+msgstr "การยืนยันตัวบุคคลชั้นใ_น"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:6
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "หน้า 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:101
+#: ../panels/network/connection-editor/ce-page-security.c:459
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6
+msgid "Security"
+msgstr "การรักษาความปลอดภัย"
+
+#: ../panels/network/connection-editor/ce-page.c:481
+msgid "automatic"
+msgstr "อัตโนมัติ"
+
+#: ../panels/network/connection-editor/ce-page.c:521
+#, c-format
+msgid "Profile %d"
+msgstr "โพรไฟล์ %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:50
+#: ../panels/network/net-device-wifi.c:214
+#: ../panels/network/net-device-wifi.c:390
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:54
+#: ../panels/network/net-device-wifi.c:218
+#: ../panels/network/net-device-wifi.c:395
+#: ../panels/network/network-wifi.ui.h:19
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:58
+#: ../panels/network/net-device-wifi.c:222
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:63
+#: ../panels/network/net-device-wifi.c:227
+msgid "Enterprise"
+msgstr "เอนเทอร์ไพรส์"
+
+#: ../panels/network/connection-editor/ce-page-details.c:68
+#: ../panels/network/net-device-wifi.c:232
+#: ../panels/network/net-device-wifi.c:380
+msgctxt "Wifi security"
+msgid "None"
+msgstr "ไม่มี"
+
+#: ../panels/network/connection-editor/ce-page-details.c:89
+#: ../panels/power/power.ui.h:17
+msgid "Never"
+msgstr "ไม่มี"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/network/net-device-ethernet.c:120
+#: ../panels/network/net-device-wifi.c:485
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i วันก่อน"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:153
+#: ../panels/network/net-device-ethernet.c:50
+#: ../panels/network/net-device-wifi.c:542
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:179
+#: ../panels/network/net-device-wifi.c:571
+msgctxt "Signal strength"
+msgid "None"
+msgstr "ไม่มี"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:573
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "อ่อน"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:575
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "พอใช้"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:577
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "ดี"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:579
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "ดีมาก"
+
+#: ../panels/network/connection-editor/ce-page-details.c:225
+#: ../panels/network/network-wifi.ui.h:46 ../shell/alt/cc-window.c:266
+msgid "Details"
+msgstr "รายละเอียด"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:215
+#: ../panels/network/connection-editor/ce-page-vpn.c:221
+#: ../panels/network/connection-editor/ce-page-wifi.c:227
+#: ../panels/network/network-wifi.ui.h:47
+msgid "Identity"
+msgstr "ชื่อ"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:178
+#: ../panels/network/connection-editor/ce-page-ip4.c:432
+#: ../panels/network/connection-editor/ce-page-ip6.c:180
+#: ../panels/network/connection-editor/ce-page-ip6.c:427
+msgid "Address"
+msgstr "ที่อยู่"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:191
+#: ../panels/network/connection-editor/ce-page-ip4.c:445
+msgid "Netmask"
+msgstr "เน็ตแมสก์"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:205
+#: ../panels/network/connection-editor/ce-page-ip4.c:458
+#: ../panels/network/connection-editor/ce-page-ip6.c:206
+#: ../panels/network/connection-editor/ce-page-ip6.c:453
+#: ../panels/network/network-vpn.ui.h:2
+msgid "Gateway"
+msgstr "เกตเวย์"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:222
+#: ../panels/network/connection-editor/ce-page-ip6.c:223
+msgid "Delete Address"
+msgstr "ลบที่อยู่"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:339
+#: ../panels/network/connection-editor/ce-page-ip6.c:334
+msgid "Server"
+msgstr "เซิร์ฟเวอร์"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:356
+#: ../panels/network/connection-editor/ce-page-ip6.c:351
+msgid "Delete DNS Server"
+msgstr "ลบเซิร์ฟเวอร์ DNS"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:472
+#: ../panels/network/connection-editor/ce-page-ip6.c:467
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "เมตริก"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:493
+#: ../panels/network/connection-editor/ce-page-ip6.c:484
+msgid "Delete Route"
+msgstr "ลบเส้นทาง"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:597
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP)"
+msgstr "อัตโนมัติ (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:601
+#: ../panels/network/connection-editor/ce-page-ip6.c:592
+#: ../panels/network/network-wifi.ui.h:26
+#: ../panels/privacy/cc-privacy-panel.c:217
+msgid "Manual"
+msgstr "กำหนดเอง"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:605
+#: ../panels/network/connection-editor/ce-page-ip6.c:596
+msgid "Link-Local Only"
+msgstr "เชื่อมต่อภายในเท่านั้น"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:935
+#: ../panels/network/network-wifi.ui.h:48
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:193
+#: ../panels/network/connection-editor/ce-page-ip6.c:440
+msgid "Prefix"
+msgstr "Prefix"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:584
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:217
+msgid "Automatic"
+msgstr "อัตโนมัติ"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:588
+msgid "Automatic, DHCP only"
+msgstr "อัตโนมัติ ใช้ DHCP เท่านั้น"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:898
+#: ../panels/network/network-wifi.ui.h:49
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:78
+#: ../panels/network/network-wifi.ui.h:51
+msgid "Reset"
+msgstr "ล้างค่า"
+
+#: ../panels/network/connection-editor/ce-page-security.c:248
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "ไม่ใช้"
+
+#: ../panels/network/connection-editor/ce-page-security.c:271
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/กุญแจ 128 บิต (ฐานสิบหกหรือ ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:281
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP วลีรหัสผ่าน 128 บิต"
+
+#: ../panels/network/connection-editor/ce-page-security.c:294
+#: ../panels/network/wireless-security/wireless-security.c:463
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:307
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP แบบผันแปร (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:321
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 ส่วนบุคคล"
+
+#: ../panels/network/connection-editor/ce-page-security.c:335
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 เอนเทอร์ไพรส์"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Signal Strength"
+msgstr "ความแรงของสัญญาณ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5
+msgid "Link speed"
+msgstr "อัตราเร็วลิงก์"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:153
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:7 ../panels/network/panel-common.c:644
+msgid "IPv4 Address"
+msgstr "ที่อยู่ IPv4"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:154
+#: ../panels/network/net-device-ethernet.c:158
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8 ../panels/network/panel-common.c:645
+msgid "IPv6 Address"
+msgstr "ที่อยู่ IPv6"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:161
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:9
+msgid "Hardware Address"
+msgstr "ที่อยู่ฮาร์ดแวร์"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:165
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Default Route"
+msgstr "เส้นทางปริยาย"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:11
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "ใช้ครั้งล่าสุด"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "Twisted Pair (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "Attachment Unit Interface (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "Media Independent Interface (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "_ชื่อ"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:38
+msgid "_MAC Address"
+msgstr "ที่อยู่ _MAC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "ที่อยู่ที่_ถอดแบบมา"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "ไบต์"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "เปิดให้ผู้ใ_ช้อื่นใช้ด้วย"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "เชื่อมต่อโดย_อัตโนมัติ"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+msgid "Firewall _Zone"
+msgstr "เ_ขตไฟร์วอลล์"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+#: ../panels/network/connection-editor/firewall-helpers.c:118
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "ปริยาย"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:50
+msgid "The zone defines the trust level of the connection"
+msgstr "เขตนี้จะกำหนดระดับความเชื่อถือของการเชื่อมต่อ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:24
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:25
+msgid "_Addresses"
+msgstr "_ที่อยู่"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "DNS อัตโนมัติ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Routes"
+msgstr "เส้นทาง"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "เส้นทางอัตโนมัติ"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:34
+msgid "Use this connection _only for resources on its network"
+msgstr "ใช้การเชื่อมต่อนี้สำหรับทรัพยากรในเครือข่ายของมันเ_ท่านั้น"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:36
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:296
+msgid "Unable to open connection editor"
+msgstr "ไม่สามารถเปิดเครื่องมือแก้ไขการเชื่อมต่อ"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:314
+msgid "New Profile"
+msgstr "โพรไฟล์ใหม่"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:635
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:783
+msgid "Import from file…"
+msgstr "นำเข้าจากแฟ้ม…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:817
+msgid "Add VPN"
+msgstr "เพิ่ม VPN"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:41
+msgid "_Reset"
+msgstr "_ล้างค่า"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1536
+#: ../panels/network/network-wifi.ui.h:42
+msgid "_Forget"
+msgstr "ล_บทิ้ง"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr "ล้างการตั้งค่าสำหรับเครือข่ายนี้ รวมถึงรหัสผ่าน แต่จำเครือข่ายไว้"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr "ลบรายละเอียดที่เกี่ยวข้องกับเครือข่ายนี้ทั้งหมด และไม่พยายามเชื่อมต่ออัตโนมัติ"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:16
+msgid "S_ecurity"
+msgstr "การ_รักษาความปลอดภัย"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:141
+msgid "Cannot import VPN connection"
+msgstr "ไม่สามารถนำเข้าการเชื่อมต่อ VPN"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:143
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"แฟ้ม '%s' ไม่สามารถอ่านได้ หรือไม่มีข้อมูลการเชื่อมต่อ VPN ที่รู้จัก\n"
+"\n"
+"ข้อผิดพลาด: %s"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:178
+msgid "Select file to import"
+msgstr "เลือกแฟ้มที่จะนำเข้า"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:182
+#: ../panels/printers/cc-printers-panel.c:2077
+#: ../panels/sharing/cc-sharing-panel.c:373
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "_Open"
+msgstr "_เปิด"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:230
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "มีแฟ้มชื่อ \"%s\" อยู่ก่อนแล้ว"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:232
+msgid "_Replace"
+msgstr "แ_ทนที่"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:234
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "คุณต้องการจะแทนที่ %s ด้วยการเชื่อมต่อ VPN ที่คุณกำลังจะบันทึกนี้หรือไม่?"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:270
+msgid "Cannot export VPN connection"
+msgstr "ไม่สามารถส่งออกการเชื่อมต่อ VPN"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:272
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"ไม่สามารถส่งออกการเชื่อมต่อ '%s' ออกยัง %s\n"
+"\n"
+"ข้อผิดพลาด: %s"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:307
+msgid "Export VPN connection"
+msgstr "ส่งออกการเชื่อมต่อ VPN"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(ข้อผิดพลาด: ไม่สามารถโหลดเครื่องมือแก้ไขการเชื่อมต่อ VPN)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:15
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:18
+msgid "My Home Network"
+msgstr "เครือข่ายของบ้านฉัน"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "เปิดให้ผู้ใ_ช้อื่นใช้ด้วย"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Net­work"
+msgstr "เครือ­ข่าย"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:3
+msgid "Control how you connect to the Internet"
+msgstr "ควบคุมวิธีการเชื่อมต่อกับอินเทอร์เน็ตของคุณ"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:5
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"DNS;"
+msgstr ""
+"เครือข่าย;ไร้สาย;Wi-Fi;Wifi;ไอพี;แลน;พร็อกซี;แวน;บรอดแบนด์;โมเด็ม;บลูทูท;vpn;DNS;"
+
+#: ../panels/network/net-device-ethernet.c:106
+#: ../panels/network/net-device-wifi.c:471
+msgid "never"
+msgstr "ยังไม่เคยใช้"
+
+#: ../panels/network/net-device-ethernet.c:116
+#: ../panels/network/net-device-wifi.c:481
+msgid "today"
+msgstr "วันนี้"
+
+#: ../panels/network/net-device-ethernet.c:118
+#: ../panels/network/net-device-wifi.c:483
+msgid "yesterday"
+msgstr "เมื่อวาน"
+
+#: ../panels/network/net-device-ethernet.c:156
+#: ../panels/network/network-mobile.ui.h:3 ../panels/network/panel-common.c:647
+#: ../panels/network/panel-common.c:649 ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "ที่อยู่ไอพี"
+
+#: ../panels/network/net-device-ethernet.c:172
+#: ../panels/network/network-wifi.ui.h:12
+msgid "Last used"
+msgstr "ใช้ครั้งล่าสุด"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:280
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "ใช้สาย"
+
+#: ../panels/network/net-device-ethernet.c:348
+#: ../panels/network/net-device-wifi.c:1694
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8 ../panels/network/network-vpn.ui.h:7
+msgid "Options…"
+msgstr "ตัวเลือก…"
+
+#: ../panels/network/net-device-mobile.c:223
+msgid "Add new connection"
+msgstr "เพิ่มช่องเชื่อมต่อ"
+
+#: ../panels/network/net-device-wifi.c:1205
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr ""
+"ถ้าคุณมีการเชื่อมต่อไปยังอินเทอร์เน็ตทางอื่นนอกเหนือจากเครือข่ายไร้สาย "
+"คุณก็สามารถตั้งค่าจุดแพร่สัญญาณไร้สายเพื่อแบ่งปันการเชื่อมต่ออินเทอร์เน็ตให้ผู้อื่นใช้ได้"
+
+#: ../panels/network/net-device-wifi.c:1209
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "การเปิดใช้จุดแพร่สัญญาณไร้สายจะเป็นการตัดการเชื่อมต่อจาก <b>%s</b>"
+
+#: ../panels/network/net-device-wifi.c:1213
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr "คุณจะไม่สามารถเข้าถึงอินเทอร์เน็ตผ่านเครือข่ายไร้สายได้ในระหว่างเปิดใช้จุดแพร่สัญญาณ"
+
+#: ../panels/network/net-device-wifi.c:1296
+msgid "Stop hotspot and disconnect any users?"
+msgstr "จะปิดจุดแพร่สัญญาณและตัดการเชื่อมต่อกับผู้ใช้ทั้งหมดหรือไม่?"
+
+#: ../panels/network/net-device-wifi.c:1299
+msgid "_Stop Hotspot"
+msgstr "ปิ_ดจุดแพร่สัญญาณ"
+
+#: ../panels/network/net-device-wifi.c:1397
+msgid "System policy prohibits use as a Hotspot"
+msgstr "นโยบายของระบบห้ามใช้เป็นจุดแพร่สัญญาณ"
+
+#: ../panels/network/net-device-wifi.c:1400
+msgid "Wireless device does not support Hotspot mode"
+msgstr "อุปกรณ์ไร้สายไม่รองรับโหมดจุดแพร่สัญญาณ"
+
+#: ../panels/network/net-device-wifi.c:1532
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr "รายละเอียดของเครือข่ายที่เลือก รวมถึงรหัสผ่านและค่าปรับแต่งใดๆ จะถูกลบทิ้ง"
+
+#: ../panels/network/net-device-wifi.c:1842
+msgid "History"
+msgstr "ประวัติ"
+
+#: ../panels/network/net-device-wifi.c:1846
+#: ../panels/printers/options-dialog.ui.h:2
+#: ../panels/wacom/button-mapping.ui.h:2 ../panels/wacom/cc-wacom-page.c:525
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "_Close"
+msgstr "ปิ_ด"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1854
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_ลบทิ้ง"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "การตรวจหาเว็บพร็อกซีอัตโนมัติจะใช้เมื่อไม่มีการกำหนด URL สำหรับตั้งค่าไว้"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "ไม่แนะนำให้ใช้ในเครือข่ายสาธารณะที่ไม่น่าเชื่อถือ"
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "พร็อกซี"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "เ_พิ่มโพรไฟล์…"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "ผู้ให้บริการ"
+
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "เครือข่าย"
+
+#: ../panels/network/network-proxy.ui.h:1
+msgctxt "proxy method"
+msgid "None"
+msgstr "ไม่ใช้"
+
+#: ../panels/network/network-proxy.ui.h:2
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "กำหนดเอง"
+
+#: ../panels/network/network-proxy.ui.h:3
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "อัตโนมัติ"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "_วิธีการ"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "URL สำหรับตั้ง_ค่า"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "พร็อกซี _HTTP"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "พร็อกซี H_TTPS"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "พร็อกซี _FTP"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "โฮสต์ _Socks"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "โฮสต์ที่ไ_ม่ผ่านพร็อกซี"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "พอร์ตพร็อกซี HTTP"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "พอร์ตพร็อกซี HTTPS"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "พอร์ตพร็อกซี FTP"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "พอร์ตพร็อกซี Socks"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "ปิดอุปกรณ์"
+
+#: ../panels/network/network.ui.h:1
+msgid "Add Device"
+msgstr "เพิ่มอุปกรณ์"
+
+#: ../panels/network/network.ui.h:2
+msgid "Remove Device"
+msgstr "ลบอุปกรณ์ออก"
+
+#: ../panels/network/network-vpn.ui.h:1
+msgid "VPN Type"
+msgstr "ชนิด VPN"
+
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Group Name"
+msgstr "ชื่อกลุ่ม"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Password"
+msgstr "รหัสผ่านกลุ่ม"
+
+#: ../panels/network/network-vpn.ui.h:5
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "ชื่อผู้ใช้"
+
+#: ../panels/network/network-vpn.ui.h:6
+msgid "Turn VPN connection off"
+msgstr "ปิดการเชื่อมต่อ VPN"
+
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Automatic _Connect"
+msgstr "เชื่อม_ต่ออัตโนมัติ"
+
+#: ../panels/network/network-wifi.ui.h:13
+msgid "details"
+msgstr "รายละเอียด"
+
+#: ../panels/network/network-wifi.ui.h:17
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/sharing/sharing.ui.h:9
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "_Password"
+msgstr "_รหัสผ่าน"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Show P_assword"
+msgstr "แ_สดงรหัสผ่าน"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "Make available to other users"
+msgstr "เปิดให้ผู้ใช้อื่นใช้ด้วย"
+
+#: ../panels/network/network-wifi.ui.h:23
+msgid "identity"
+msgstr "ชื่อ"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Automatic (DHCP) addresses only"
+msgstr "อัตโนมัติ (DHCP) เฉพาะที่อยู่"
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Link-local only"
+msgstr "เชื่อมต่อภายในเท่านั้น"
+
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Shared with other computers"
+msgstr "แบ่งปันให้เครื่องอื่น"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "_Ignore automatically obtained routes"
+msgstr "ไ_ม่สนใจเส้นทางเครือข่ายที่ได้รับมาแบบอัตโนมัติ"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Cloned MAC Address"
+msgstr "_ถอดแบบที่อยู่ MAC"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid "hardware"
+msgstr "ฮาร์ดแวร์"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr "ล้างการตั้งค่าสำหรับการเชื่อมต่อนี้ให้เป็นค่าปริยาย แต่จำการเชื่อมต่อไว้"
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr "ลบรายละเอียดที่เกี่ยวข้องกับเครือข่ายนี้ทั้งหมด และไม่พยายามเชื่อมต่ออัตโนมัติกับเครือข่ายนี้"
+
+#: ../panels/network/network-wifi.ui.h:45
+msgid "reset"
+msgstr "ล้างค่า"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Hardware"
+msgstr "ฮาร์ดแวร์"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi Hotspot"
+msgstr "จุดแพร่สัญญาณ Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Turn On"
+msgstr "_เปิด"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "Turn Wi-Fi off"
+msgstr "ปิด Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_Use as Hotspot…"
+msgstr "ใช้เป็นจุดแ_พร่สัญญาณ…"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "_Connect to Hidden Network…"
+msgstr "เ_ชื่อมต่อไปยังเครือข่ายที่ซ่อนตัวอยู่…"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "_History"
+msgstr "_ประวัติ"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "ปิดหากต้องการเชื่อมต่อไปยังเครือข่าย Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Network Name"
+msgstr "ชื่อเครือข่าย"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Connected Devices"
+msgstr "อุปกรณ์ที่เชื่อมต่อ"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "Security type"
+msgstr "ระบบรักษาความปลอดภัย"
+
+#: ../panels/network/network-wifi.ui.h:63
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+msgid "Password"
+msgstr "รหัสผ่าน"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:127
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Infrastructure"
+msgstr "Infrastructure"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:147 ../panels/network/panel-common.c:201
+msgid "Status unknown"
+msgstr "ไม่ทราบสถานะ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:151
+msgid "Unmanaged"
+msgstr "ไม่มีการจัดการ"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unavailable"
+msgstr "ใช้งานไม่ได้"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:165 ../panels/network/panel-common.c:207
+msgid "Connecting"
+msgstr "กำลังเชื่อมต่อ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Authentication required"
+msgstr "ต้องยืนยันตัวบุคคล"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Connected"
+msgstr "เชื่อมต่อแล้ว"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:177
+msgid "Disconnecting"
+msgstr "กำลังตัดการเชื่อมต่อ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:181 ../panels/network/panel-common.c:219
+msgid "Connection failed"
+msgstr "เชื่อมต่อไม่สำเร็จ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:227
+msgid "Status unknown (missing)"
+msgstr "ไม่ทราบสถานะ (ค่าหายไป)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:223
+msgid "Not connected"
+msgstr "ไม่ได้เชื่อมต่อ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:248
+msgid "Configuration failed"
+msgstr "ตั้งค่าไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "IP configuration failed"
+msgstr "ตั้งค่าไอพีไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration expired"
+msgstr "ค่าไอพีหมดอายุ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "Secrets were required, but not provided"
+msgstr "ต้องการข้อมูลลับ แต่ไม่ได้ป้อนไว้"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x supplicant ถูกตัดการเชื่อมต่อ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant configuration failed"
+msgstr "ตั้งค่า 802.1x supplicant ไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant failed"
+msgstr "802.1x supplicant ล้มเหลว"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant ใช้เวลายืนยันตัวบุคคลนานเกินไป"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "PPP service failed to start"
+msgstr "เปิดบริการ PPP ไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service disconnected"
+msgstr "บริการ PPP ถูกตัดการเชื่อมต่อ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP failed"
+msgstr "PPP ล้มเหลว"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "DHCP client failed to start"
+msgstr "เปิดใช้ลูกข่าย DHCP ไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client error"
+msgstr "เกิดข้อผิดพลาดที่ลูกข่าย DHCP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client failed"
+msgstr "ลูกข่าย DHCP ล้มเหลว"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "Shared connection service failed to start"
+msgstr "เปิดบริการแบ่งปันการเชื่อมต่อไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed"
+msgstr "บริการแบ่งปันการเชื่อมต่อล้มเหลว"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "AutoIP service failed to start"
+msgstr "เปิดบริการ AutoIP ไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service error"
+msgstr "เกิดข้อผิดพลาดที่บริการ AutoIP"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service failed"
+msgstr "บริการ AutoIP ล้มเหลว"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "Line busy"
+msgstr "สายไม่ว่าง"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "No dial tone"
+msgstr "ไม่มีสัญญาณหมุนเลขหมาย"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No carrier could be established"
+msgstr "ไม่สามารถเชื่อมต่อกับผู้ให้บริการ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "Dialing request timed out"
+msgstr "หมดเวลาคอยการหมุนเลขหมาย"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing attempt failed"
+msgstr "หมุนเลขหมายไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Modem initialization failed"
+msgstr "ตั้งค่าเริ่มต้นโมเด็มไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Failed to select the specified APN"
+msgstr "เลือก APN ที่กำหนดไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Not searching for networks"
+msgstr "ไม่ได้อยู่ระหว่างค้นหาเครือข่าย"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Network registration denied"
+msgstr "การลงทะเบียนเครือข่ายถูกปฏิเสธ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration timed out"
+msgstr "หมดเวลาคอยลงทะเบียนเครือข่าย"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Failed to register with the requested network"
+msgstr "ลงทะเบียนกับเครือข่ายที่ร้องขอไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "PIN check failed"
+msgstr "การตรวจสอบ PIN ล้มเหลว"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "Firmware for the device may be missing"
+msgstr "อาจขาดเฟิร์มแวร์สำหรับอุปกรณ์"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Connection disappeared"
+msgstr "การเชื่อมต่อหายไป"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Existing connection was assumed"
+msgstr "ถือว่ามีการเชื่อมต่ออยู่ก่อนแล้ว"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Modem not found"
+msgstr "ไม่พบโมเด็ม"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Bluetooth connection failed"
+msgstr "เชื่อมต่อบลูทูทไม่สำเร็จ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "SIM Card not inserted"
+msgstr "ไม่ได้ใส่ SIM card"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Pin required"
+msgstr "ต้องการรหัส PIN ของ SIM"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Puk required"
+msgstr "ต้องการรหัส PUK ของ SIM"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM wrong"
+msgstr "SIM ผิด"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "Connection dependency failed"
+msgstr "สิ่งที่ต้องใช้สำหรับการเชื่อมต่อล้มเหลว"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:433
+msgid "Firmware missing"
+msgstr "ขาดเฟิร์มแวร์"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:437
+msgid "Cable unplugged"
+msgstr "สายเคเบิลถูกถอดออก"
+
+#: ../panels/network/wireless-security/eap-method.c:69
+msgid "undefined error in 802.1x security (wpa-eap)"
+msgstr "เกิดข้อผิดพลาดที่ไม่ได้บัญญัติไว้ในความปลอดภัย 802.1x (wpa-eap)"
+
+#: ../panels/network/wireless-security/eap-method.c:245
+msgid "no file selected"
+msgstr "ไม่ได้เลือกแฟ้ม"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid "unspecified error validating eap-method file"
+msgstr "เกิดข้อผิดพลาดที่ไม่ได้บัญญัติไว้ขณะตรวจความถูกต้องของแฟ้ม eap-method"
+
+#: ../panels/network/wireless-security/eap-method.c:480
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "กุญแจส่วนตัวแบบ DER, PEM, หรือ PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: ../panels/network/wireless-security/eap-method.c:483
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "ใบรับรองแบบ DER หรือ PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:72
+msgid "missing EAP-FAST PAC file"
+msgstr "ไม่มีแฟ้ม PAC สำหรับ EAP-FAST"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:268
+#: ../panels/network/wireless-security/eap-method-peap.c:302
+#: ../panels/network/wireless-security/eap-method-ttls.c:333
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:283
+#: ../panels/network/wireless-security/eap-method-peap.c:272
+#: ../panels/network/wireless-security/eap-method-ttls.c:288
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:406
+msgid "Choose a PAC file"
+msgstr "เลือกแฟ้ม PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:413
+msgid "PAC files (*.pac)"
+msgstr "แฟ้ม PAC (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "Anonymous"
+msgstr "นิรนาม"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+msgid "Authenticated"
+msgstr "ผ่านการยืนยันตัวบุคคล"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "Both"
+msgstr "ทั้งสองอย่าง"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "PAC _file"
+msgstr "แ_ฟ้ม PAC"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:5
+msgid "_Inner authentication"
+msgstr "การยืนยันตัวบุคคลชั้นใ_น"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Allow automatic PAC pro_visioning"
+msgstr "อนุญาตให้_จัดเตรียม PAC อัตโนมัติ"
+
+#: ../panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "ขาดชื่อผู้ใช้ EAP-LEAP"
+
+#: ../panels/network/wireless-security/eap-method-leap.c:74
+msgid "missing EAP-LEAP password"
+msgstr "ขาดรหัสผ่าน EAP-LEAP"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Username"
+msgstr "ชื่อ_ผู้ใช้"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:7
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "แ_สดงรหัสผ่าน"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:63
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "ใบรับรอง EAP-PEAP CA ไม่ถูกต้อง: %s"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:68
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "ใบรับรอง EAP-PEAP CA ไม่ถูกต้อง: ไม่ได้ระบุใบรับรอง"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:287
+#: ../panels/network/wireless-security/eap-method-ttls.c:318
+#: ../panels/network/wireless-security/wireless-security.c:439
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:381
+#: ../panels/network/wireless-security/eap-method-tls.c:501
+#: ../panels/network/wireless-security/eap-method-ttls.c:412
+msgid "Choose a Certificate Authority certificate"
+msgstr "เลือกใบรับรองจากองค์กรออกใบรับรอง"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "รุ่น 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "รุ่น 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "ใ_บรับรอง CA"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "No CA certificate is _required"
+msgstr "ไ_ม่ต้องใช้ใบรับรอง CA"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:9
+msgid "PEAP _version"
+msgstr "รุ่_นของ PEAP"
+
+#: ../panels/network/wireless-security/eap-method-simple.c:74
+msgid "missing EAP username"
+msgstr "ขาดชื่อผู้ใช้ EAP"
+
+#: ../panels/network/wireless-security/eap-method-simple.c:87
+msgid "missing EAP password"
+msgstr "ขาดรหัสผ่าน EAP"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:68
+msgid "missing EAP-TLS identity"
+msgstr "ขาดเอกลักษณ์ EAP-TLS"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:77
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "ใบรับรอง EAP-TLS CA ไม่ถูกต้อง: %s"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:84
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "ใบรับรอง EAP-TLS CA ไม่ถูกต้อง: ไม่ได้ระบุใบรับรอง"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:95
+msgid "invalid EAP-TLS password: missing"
+msgstr "รหัสผ่าน EAP-TLS ไม่ถูกต้อง: ไม่มีรหัสผ่าน"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:109
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "กุญแจส่วนตัว EAP-TLS ไม่ถูกต้อง: %s"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:119
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "ใบรับรองผู้ใช้ EAP-TLS ไม่ถูกต้อง: %s"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:316
+msgid "Unencrypted private keys are insecure"
+msgstr "กุญแจส่วนตัวที่ไม่เข้ารหัสลับนั้นไม่มีความปลอดภัย"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:319
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"กุญแจส่วนตัวที่เลือกไม่มีการปกป้องด้วยรหัสผ่าน "
+"ซึ่งอาจทำให้ข้อมูลลับของระบบรักษาความปลอดภัยของคุณถูกขโมยใช้ได้ "
+"กรุณาเลือกกุญแจส่วนตัวที่มีการปกป้องด้วยรหัสผ่าน\n"
+"\n"
+"(คุณสามารถปกป้องกุญแจส่วนตัวของคุณด้วยรหัสผ่านได้ โดยใช้ openssl)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:495
+msgid "Choose your personal certificate"
+msgstr "เลือกใบรับรองส่วนตัวของคุณ"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:507
+msgid "Choose your private key"
+msgstr "เลือกกุญแจส่วนตัวของคุณ"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "_ชื่อ"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "ใ_บรับรองของผู้ใช้"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "Private _key"
+msgstr "กุญแจ_ส่วนตัว"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+msgid "_Private key password"
+msgstr "_รหัสผ่านกุญแจส่วนตัว"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:63
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "ใบรับรอง EAP-TTLS CA ไม่ถูกต้อง: %s"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:68
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "ใบรับรอง EAP-TTLS CA ไม่ถูกต้อง: ไม่ได้ระบุใบรับรอง"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:258
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:273
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:303
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/wireless-security.c:87
+msgid "Unknown error validating 802.1x security"
+msgstr "เกิดข้อผิดพลาดไม่ทราบสาเหตุขณะตรวจสอบความปลอดภัย 802.1x"
+
+#: ../panels/network/wireless-security/wireless-security.c:451
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:475
+msgid "PWD"
+msgstr "PWD"
+
+#: ../panels/network/wireless-security/wireless-security.c:486
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:497
+msgid "Tunneled TLS"
+msgstr "TLS ผ่านทันเนล"
+
+#: ../panels/network/wireless-security/wireless-security.c:508
+msgid "Protected EAP (PEAP)"
+msgstr "EAP ที่มีการปกป้อง (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "การ_ยืนยันตัวบุคคล"
+
+#: ../panels/network/wireless-security/ws-leap.c:63
+msgid "missing leap-username"
+msgstr "ขาดชื่อผู้ใช้ leap"
+
+#: ../panels/network/wireless-security/ws-leap.c:74
+msgid "missing leap-password"
+msgstr "ขาดรหัสผ่าน leap"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:107
+msgid "missing wep-key"
+msgstr "ขาด wep-key"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:116
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "wep-key ไม่ถูกต้อง: คีย์ความยาว %zu ต้องมีเฉพาะตัวเลขฐานสิบหกเท่านั้น"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:124
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "wep-key ไม่ถูกต้อง: คีย์ความยาว %zu ต้องมีเฉพาะอักขระแอสกี้เท่านั้น"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:130
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"wep-key ไม่ถูกต้อง: ความยาวคีย์ %zu ไม่ถูกต้อง คีย์ต้องยาว 5/13 (แอสกี) หรือ 10/26 "
+"(ฐานสิบหก) อย่างใดอย่างหนึ่ง"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:137
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "wep-key ไม่ถูกต้อง: วลีรหัสผ่านต้องไม่ว่างเปล่า"
+
+#: ../panels/network/wireless-security/ws-wep-key.c:139
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "wep-key ไม่ถูกต้อง: วลีรหัสผ่านต้องสั้นกว่า 64 อักขระ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (ปริยาย)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "ระบบเปิด"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "ใช้กุญแจร่วมกัน"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "กุญแ_จ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "แ_สดงกุญแจ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "_ดัชนี WEP"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.c:70
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk ไม่ถูกต้อง: ความยาวคีย์ %zu ไม่ถูกต้อง ต้องยาวตั้งแต่ 8 ถึง 63 ไบต์ "
+"หรือเป็นเลขฐานสิบหก 64 หลักเท่านั้น"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.c:79
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "wpa-psk ไม่ถูกต้อง: ไม่สามารถอ่านค่าคีย์ความยาว 64 ไบต์เป็นเลขฐานสิบหกได้"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "_ชนิด"
+
+#: ../panels/notifications/cc-notifications-panel.c:257
+#: ../panels/power/cc-power-panel.c:1966 ../panels/power/cc-power-panel.c:1973
+#: ../panels/privacy/cc-privacy-panel.c:190
+#: ../panels/privacy/cc-privacy-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:269
+#: ../panels/universal-access/cc-ua-panel.c:590
+#: ../panels/universal-access/cc-ua-panel.c:603
+#: ../panels/universal-access/cc-ua-panel.c:615
+#: ../panels/universal-access/cc-ua-panel.c:786
+msgid "On"
+msgstr "เปิด"
+
+#. This is the per application switch for message tray usage.
+#: ../panels/notifications/edit-dialog.ui.h:2
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_การแจ้งเหตุ"
+
+#. This is the setting to configure sounds associated with notifications.
+#: ../panels/notifications/edit-dialog.ui.h:4
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "เสียงแจ้งเ_ตือน"
+
+#: ../panels/notifications/edit-dialog.ui.h:5
+msgctxt "notifications"
+msgid "Notification _Banners"
+msgstr "_พาดหัวการแจ้งเหตุ"
+
+#. Banners here refers to message tray notifications in the middle of the screen.
+#: ../panels/notifications/edit-dialog.ui.h:7
+msgctxt "notifications"
+msgid "Show Message _Content in Banners"
+msgstr "แสดงเ_นื้อหาข้อความในพาดหัว"
+
+#: ../panels/notifications/edit-dialog.ui.h:8
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "การแจ้งเหตุการ_ล็อคหน้าจอ"
+
+#: ../panels/notifications/edit-dialog.ui.h:9
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "แสดงเนื้อ_หาข้อความในหน้าล็อคหน้าจอ"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "No­ti­fi­ca­tions"
+msgstr "การ­แจ้ง­เหตุ"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:3
+msgid "Control which notifications are displayed and what they show"
+msgstr "ควบคุมการแจ้งเหตุว่าจะแสดงรายการใดหรือสิ่งใดบ้าง"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:5
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "การแจ้งเหตุ;พาดหัว;ข้อความ;ถาด;กล่องผุดขึ้น;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Notification _Banners"
+msgstr "_พาดหัวการแจ้งเหตุ"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "_Lock Screen Notifications"
+msgstr "การแจ้งเหตุการ_ล็อคหน้าจอ"
+
+#. List of applications.
+#: ../panels/notifications/notifications.ui.h:4
+#: ../panels/privacy/privacy.ui.h:45 ../panels/sound/gvc-mixer-dialog.c:1781
+msgid "Applications"
+msgstr "โปรแกรม"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:170
+msgctxt "Online Account"
+msgid "Other"
+msgstr "อื่นๆ"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:291
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "เพิ่มบัญชี"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Mail"
+msgstr "เมล"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Calendar"
+msgstr "ปฏิทิน"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Contacts"
+msgstr "ผู้ติดต่อ"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:346
+msgid "Chat"
+msgstr "สนทนา"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:352
+msgid "Resources"
+msgstr "ทรัพยากร"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:640
+msgid "Error creating account"
+msgstr "เกิดข้อผิดพลาดขณะสร้างบัญชี"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:700
+msgid "Error removing account"
+msgstr "เกิดข้อผิดพลาดขณะลบบัญชี"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:736
+msgid "Are you sure you want to remove the account?"
+msgstr "ยืนยันที่จะลบบัญชีหรือไม่?"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:738
+msgid "This will not remove the account on the server."
+msgstr "การลบนี้จะไม่มีการลบบัญชีที่เซิร์ฟเวอร์"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:739
+msgid "_Remove"
+msgstr "_ลบออก"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "On­line Accounts"
+msgstr "บัญชี­ออน­ไลน์"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:3
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "เชื่อมต่อไปยังบัญชีออนไลน์ของคุณและตัดสินใจว่าจะใช้เพื่อทำอะไร"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:5
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"กูเกิล;เฟซบุ๊ก;ทวิตเตอร์;ยาฮู;เว็บ;ออนไลน์;แช็ต;ปฏิทิน;เมล;ผู้ติดต่อ;ownCloud;Kerberos;IMAP;"
+"SMTP;พ็อกเก็ต;ReadItLater;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "ไม่ได้ตั้งค่าบัญชีออนไลน์ใดไว้"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "Remove Account"
+msgstr "ลบบัญชี"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "เพิ่มบัญชีออนไลน์"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr ""
+"การเพิ่มบัญชีจะช่วยให้โปรแกรมต่างๆ ของคุณสามารถเข้าถึงเอกสาร เมล ผู้ติดต่อ ปฏิทิน การสนทนา "
+"และอื่นๆ จากบัญชีนั้นๆ"
+
+#: ../panels/power/cc-power-panel.c:253
+msgid "Unknown time"
+msgstr "ไม่ทราบเวลา"
+
+#: ../panels/power/cc-power-panel.c:259
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i นาที"
+
+#: ../panels/power/cc-power-panel.c:271
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i ชั่วโมง"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:279
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:280
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "ชั่วโมง"
+
+#: ../panels/power/cc-power-panel.c:281
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "นาที"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:300
+#, c-format
+msgid "%s until fully charged"
+msgstr "อีก %s จะเต็ม"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:307
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "คำเตือน: อีก %s จะหมด"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:312
+#, c-format
+msgid "%s remaining"
+msgstr "อีก %s จะหมด"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:317 ../panels/power/cc-power-panel.c:345
+msgid "Fully charged"
+msgstr "ประจุไฟเต็มแล้ว"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:321 ../panels/power/cc-power-panel.c:349
+msgid "Empty"
+msgstr "ไม่มีประจุเหลืออยู่"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:336
+msgid "Charging"
+msgstr "กำลังประจุไฟ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:341
+msgid "Discharging"
+msgstr "กำลังจ่ายไฟ"
+
+#: ../panels/power/cc-power-panel.c:464
+msgctxt "Battery name"
+msgid "Main"
+msgstr "หลัก"
+
+#: ../panels/power/cc-power-panel.c:466
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "พิเศษ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:537
+msgid "Wireless mouse"
+msgstr "เมาส์ไร้สาย"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgid "Wireless keyboard"
+msgstr "แป้นพิมพ์ไร้สาย"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:543
+msgid "Uninterruptible power supply"
+msgstr "อุปกรณ์จ่ายไฟสำรอง"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:546
+msgid "Personal digital assistant"
+msgstr "เครื่องช่วยงานส่วนบุคคลแบบดิจิทัล"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:549
+msgid "Cellphone"
+msgstr "โทรศัพท์เคลื่อนที่"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgid "Media player"
+msgstr "เครื่องเล่นสื่อ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:555
+msgid "Tablet"
+msgstr "แท็บเล็ต"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:558
+msgid "Computer"
+msgstr "คอมพิวเตอร์"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:561 ../panels/power/cc-power-panel.c:801
+#: ../panels/power/cc-power-panel.c:2358
+msgid "Battery"
+msgstr "แบตเตอรี่"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:615
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "กำลังประจุไฟ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:622
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "ระวัง"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:627
+msgctxt "Battery power"
+msgid "Low"
+msgstr "ต่ำ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:632
+msgctxt "Battery power"
+msgid "Good"
+msgstr "ดี"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:637
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "ประจุไฟเต็มแล้ว"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:641
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "ไม่มีประจุเหลืออยู่"
+
+#: ../panels/power/cc-power-panel.c:799
+msgid "Batteries"
+msgstr "แบตเตอรี่"
+
+#: ../panels/power/cc-power-panel.c:1227
+msgid "When _idle"
+msgstr "เมื่อไ_ม่ใช้งาน"
+
+#: ../panels/power/cc-power-panel.c:1680
+msgid "Power Saving"
+msgstr "การประหยัดพลังงาน"
+
+#: ../panels/power/cc-power-panel.c:1715
+msgid "_Screen brightness"
+msgstr "ความ_สว่างหน้าจอ"
+
+#: ../panels/power/cc-power-panel.c:1734
+msgid "Automatic brightness"
+msgstr "ความสว่างอัตโนมัติ"
+
+#: ../panels/power/cc-power-panel.c:1754
+msgid "_Keyboard brightness"
+msgstr "ความสว่างแ_ป้นพิมพ์"
+
+#: ../panels/power/cc-power-panel.c:1764
+msgid "_Dim screen when inactive"
+msgstr "_หรี่หน้าจอเมื่อไม่มีการใช้งาน"
+
+#: ../panels/power/cc-power-panel.c:1789
+msgid "_Blank screen"
+msgstr "แสดงหน้าจอ_ว่าง"
+
+#: ../panels/power/cc-power-panel.c:1826
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: ../panels/power/cc-power-panel.c:1831
+msgid "Turn off Wi-Fi to save power."
+msgstr "ปิด Wi-Fi เพื่อประหยัดพลังงาน"
+
+#: ../panels/power/cc-power-panel.c:1856
+msgid "_Mobile broadband"
+msgstr "บรอดแบนด์_มือถือ"
+
+#: ../panels/power/cc-power-panel.c:1861
+msgid "Turn off mobile broadband (3G, 4G, LTE, etc.) to save power."
+msgstr "ปิดอุปกรณ์บรอดแบนด์มือถือ (3G, 4G, LTE ฯลฯ) เพื่อประหยัดพลังงาน"
+
+#: ../panels/power/cc-power-panel.c:1906
+msgid "_Bluetooth"
+msgstr "_บลูทูท"
+
+#: ../panels/power/cc-power-panel.c:1962
+msgid "When on battery power"
+msgstr "เมื่อใช้ไฟจากแบตเตอรี่"
+
+#: ../panels/power/cc-power-panel.c:1964
+msgid "When plugged in"
+msgstr "เมื่อเสียบปลั๊กไฟ"
+
+#: ../panels/power/cc-power-panel.c:2059
+msgid "Suspend"
+msgstr "พักเครื่อง"
+
+#: ../panels/power/cc-power-panel.c:2060
+msgid "Hibernate"
+msgstr "จำศีลเครื่อง"
+
+# probably wrong spelling
+#: ../panels/power/cc-power-panel.c:2061
+msgid "Nothing"
+msgstr "ไม่ต้องทำอะไร"
+
+#. Frame header
+#: ../panels/power/cc-power-panel.c:2175
+msgid "Suspend & Power Button"
+msgstr "ปุ่มพัก & เปิด/ปิดเครื่อง"
+
+#: ../panels/power/cc-power-panel.c:2218
+msgid "_Automatic suspend"
+msgstr "พักเครื่องโดย_อัตโนมัติ"
+
+#: ../panels/power/cc-power-panel.c:2219
+msgid "Automatic suspend"
+msgstr "พักเครื่องโดยอัตโนมัติ"
+
+#: ../panels/power/cc-power-panel.c:2286
+msgid "_When the Power Button is pressed"
+msgstr "เมื่อกดปุ่มเปิ_ด/ปิดเครื่อง"
+
+#: ../panels/power/cc-power-panel.c:2412 ../shell/alt/cc-window.c:270
+msgid "Devices"
+msgstr "อุปกรณ์"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Po­wer"
+msgstr "พลัง­งาน"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:3
+msgid "View your battery status and change power saving settings"
+msgstr "ดูสถานะแบตเตอรี่และตั้งค่าการประหยัดพลังงาน"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:5
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr ""
+"พลังงาน;หลับ;พักเครื่อง;จำศีลเครื่อง;แบตเตอรี่;ความสว่าง;หรี่;ว่าง;จอภาพ;DPMS;ไม่ใช้งาน;"
+
+#: ../panels/power/power.ui.h:3
+msgid "45 minutes"
+msgstr "45 นาที"
+
+#: ../panels/power/power.ui.h:4 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 ชั่วโมง"
+
+#: ../panels/power/power.ui.h:5
+msgid "80 minutes"
+msgstr "80 นาที"
+
+#: ../panels/power/power.ui.h:6
+msgid "90 minutes"
+msgstr "90 นาที"
+
+#: ../panels/power/power.ui.h:7
+msgid "100 minutes"
+msgstr "100 นาที"
+
+#: ../panels/power/power.ui.h:8
+msgid "2 hours"
+msgstr "2 ชั่วโมง"
+
+#: ../panels/power/power.ui.h:9 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 นาที"
+
+#: ../panels/power/power.ui.h:10 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 นาที"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 นาที"
+
+#: ../panels/power/power.ui.h:12
+msgid "4 minutes"
+msgstr "4 นาที"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 นาที"
+
+#: ../panels/power/power.ui.h:14
+msgid "8 minutes"
+msgstr "8 นาที"
+
+#: ../panels/power/power.ui.h:15
+msgid "10 minutes"
+msgstr "10 นาที"
+
+#: ../panels/power/power.ui.h:16
+msgid "12 minutes"
+msgstr "12 นาที"
+
+#: ../panels/power/power.ui.h:18
+msgid "Automatic Suspend"
+msgstr "พักเครื่องอัตโนมัติ"
+
+#: ../panels/power/power.ui.h:19
+msgid "_Plugged In"
+msgstr "เมื่อเสียบ_ปลั๊กไฟ"
+
+#: ../panels/power/power.ui.h:20
+msgid "On _Battery Power"
+msgstr "เมื่อใช้ไฟจากแ_บตเตอรี่"
+
+#: ../panels/power/power.ui.h:21 ../panels/universal-access/uap.ui.h:33
+msgid "Delay"
+msgstr "รอ"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "ยืนยันตัวบุคคล"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "ต้องยืนยันตัวบุคคล"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:683
+msgid "Low on toner"
+msgstr "ผงหมึกใกล้หมด"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:685
+msgid "Out of toner"
+msgstr "ผงหมึกหมด"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:688
+msgid "Low on developer"
+msgstr "น้ำยาใกล้หมด"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:691
+msgid "Out of developer"
+msgstr "น้ำยาหมด"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:693
+msgid "Low on a marker supply"
+msgstr "ตลับสีหมึกใกล้หมด"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:695
+msgid "Out of a marker supply"
+msgstr "ตลับสีหมึกหมด"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:697
+msgid "Open cover"
+msgstr "ฝาครอบเปิด"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:699
+msgid "Open door"
+msgstr "ประตูเปิด"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:701
+msgid "Low on paper"
+msgstr "กระดาษใกล้หมด"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:703
+msgid "Out of paper"
+msgstr "กระดาษหมด"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:705
+msgctxt "printer state"
+msgid "Offline"
+msgstr "ออฟไลน์"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:707
+#: ../panels/printers/cc-printers-panel.c:897
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "หยุด"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:709
+msgid "Waste receptacle almost full"
+msgstr "ที่เก็บของเสียใกล้เต็ม"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:711
+msgid "Waste receptacle full"
+msgstr "ที่เก็บของเสียเต็ม"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:713
+msgid "The optical photo conductor is near end of life"
+msgstr "ลูกกลิ้งไวแสงใกล้หมดอายุ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:715
+msgid "The optical photo conductor is no longer functioning"
+msgstr "ลูกกลิ้งไวแสงไม่ทำงานแล้ว"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:824
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "กำลังตั้งค่า"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:883
+msgctxt "printer state"
+msgid "Ready"
+msgstr "พร้อม"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:888
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "ไม่รับงานพิมพ์"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:893
+msgctxt "printer state"
+msgid "Processing"
+msgstr "กำลังดำเนินการ"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:1013
+msgid "Toner Level"
+msgstr "ระดับผงหมึก"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:1016
+msgid "Ink Level"
+msgstr "ระดับน้ำหมึก"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:1019
+msgid "Supply Level"
+msgstr "ระดับแหล่งจ่าย"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:1037
+msgctxt "printer state"
+msgid "Installing"
+msgstr "กำลังติดตั้ง"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1551
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "ทำงานอยู่ %u"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1892
+msgid "Failed to add new printer."
+msgstr "เพิ่มเครื่องพิมพ์เครื่องใหม่ไม่สำเร็จ"
+
+#: ../panels/printers/cc-printers-panel.c:2073
+msgid "Select PPD File"
+msgstr "เลือกแฟ้ม PPD"
+
+#: ../panels/printers/cc-printers-panel.c:2082
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"แฟ้มบรรยายเครื่องพิมพ์โพสต์สคริปต์ (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2389
+msgid "No suitable driver found"
+msgstr "ไม่พบไดรเวอร์ที่เหมาะสม"
+
+#: ../panels/printers/cc-printers-panel.c:2460
+msgid "Searching for preferred drivers…"
+msgstr "กำลังค้นหาไดรเวอร์สำหรับเครื่องพิมพ์…"
+
+#: ../panels/printers/cc-printers-panel.c:2481
+msgid "Select from database…"
+msgstr "เลือกจากฐานข้อมูล…"
+
+#: ../panels/printers/cc-printers-panel.c:2490
+msgid "Provide PPD File…"
+msgstr "ป้อนแฟ้ม PPD…"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2637
+#: ../panels/printers/cc-printers-panel.c:2660
+msgid "Test page"
+msgstr "หน้าทดสอบ"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:3115
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "อ่านส่วนติดต่อผู้ใช้ไม่สำเร็จ: %s"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Prin­ters"
+msgstr "เครื่อง­พิมพ์"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:3
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "เพิ่มเครื่องพิมพ์, ดูงานพิมพ์ที่เครื่องพิมพ์ และเลือกวิธีการพิมพ์"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:5
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "เครื่องพิมพ์;คิว;พิมพ์;กระดาษ;หมึก;ผงหมึก;"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Clear All"
+msgstr "ลบทั้งหมด"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "No Active Printer Jobs"
+msgstr "ไม่มีงานพิมพ์ที่ดำเนินการอยู่"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "เพิ่มเครื่องพิมพ์เครื่องใหม่"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "A_uthenticate"
+msgstr "ยื_นยันตัวบุคคล"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "ไม่พบเครื่องพิมพ์"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter a network address or search for a printer"
+msgstr "ป้อนที่อยู่เครือข่ายหรือค้นหาเครื่องพิมพ์"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "กำลังโหลดตัวเลือก…"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "เลือกไดรเวอร์เครื่องพิมพ์"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:96
+msgid "Select"
+msgstr "เลือก"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "กำลังโหลดฐานข้อมูลไดรเวอร์..."
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:526
+msgid "JetDirect Printer"
+msgstr "เครื่องพิมพ์ JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:782
+msgid "LPD Printer"
+msgstr "เครื่องพิมพ์ LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "หน้าเดียว"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "ขอบด้านยาว (มาตรฐาน)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "ขอบด้านสั้น (พลิก)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "แนวตั้ง"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "แนวนอน"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "แนวนอนกลับด้าน"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "แนวตั้งกลับด้าน"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:103
+msgctxt "print job"
+msgid "Pending"
+msgstr "รอดำเนินการ"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:107
+msgctxt "print job"
+msgid "Paused"
+msgstr "พักพิมพ์"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:111
+msgctxt "print job"
+msgid "Processing"
+msgstr "กำลังดำเนินการ"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:115
+msgctxt "print job"
+msgid "Stopped"
+msgstr "หยุด"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:119
+msgctxt "print job"
+msgid "Canceled"
+msgstr "ยกเลิก"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:123
+msgctxt "print job"
+msgid "Aborted"
+msgstr "เลิกพิมพ์"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:127
+msgctxt "print job"
+msgid "Completed"
+msgstr "เสร็จแล้ว"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: ../panels/printers/pp-jobs-dialog.c:289
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s - Active Jobs"
+msgstr "%s - งานที่พิมพ์อยู่"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1659
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1664
+msgid "Serial Port"
+msgstr "พอร์ตอนุกรม"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "Parallel Port"
+msgstr "พอร์ตขนาน"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Bluetooth"
+msgstr "บลูทูท"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1713
+#, c-format
+msgid "Location: %s"
+msgstr "ตำแหน่งที่ตั้ง: %s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1718
+#, c-format
+msgid "Address: %s"
+msgstr "ที่อยู่: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1747
+msgid "Server requires authentication"
+msgstr "เซิร์ฟเวอร์ต้องการยืนยันตัวบุคคล"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "สองหน้า"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "ชนิดกระดาษ"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "แหล่งป้อนกระดาษ"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "ถาดกระดาษออก"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "การกรองเบื้องต้นด้วย GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:533
+msgid "Pages per side"
+msgstr "จำนวนหน้าต่อหน้ากระดาษ"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:545
+msgid "Two-sided"
+msgstr "สองหน้า"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:557
+msgid "Orientation"
+msgstr "แนววาง"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "ทั่วไป"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "ตั้งหน้ากระดาษ"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "ตัวเลือกที่สามารถติดตั้งได้"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "งานพิมพ์"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "คุณภาพของรูปภาพ"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "สี"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "การจัดขั้นสุดท้าย"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:675
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "ขั้นสูง"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "เลือกโดยอัตโนมัติ"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "ค่าปริยายเครื่องพิมพ์"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "ฝังแบบอักษร GhostScript เท่านั้น"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "แปลงเป็น PS ระดับ 1"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "แปลงเป็น PS ระดับ 2"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "ไม่ต้องกรองเบื้องต้น"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "ผู้ผลิต"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "ไดรเวอร์"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr "ป้อนชื่อผู้ใช้และรหัสผ่านของคุณเพื่อดูเครื่องพิมพ์ที่มีใน %s"
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "เพิ่มเครื่องพิมพ์"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "ลบเครื่องพิมพ์"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "แหล่งจ่าย"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "ตำแหน่งที่ตั้ง"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default printer"
+msgstr "เครื่องพิมพ์_ปริยาย"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "งานพิมพ์"
+
+#. Translators: Opens a dialog containing printer
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "แสดง_งานพิมพ์"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "รุ่น"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "ฉลาก"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "กำลังตั้งค่าไดรเวอร์ตัวใหม่…"
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "หน้า 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "พิมพ์หน้า_ทดสอบ"
+
+#. Translators: This button opens printer
+#: ../panels/printers/printers.ui.h:22 ../panels/region/region.ui.h:6
+msgid "_Options"
+msgstr "_ตัวเลือก"
+
+#: ../panels/printers/printers.ui.h:23
+msgid "No printers"
+msgstr "ไม่มีเครื่องพิมพ์"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:25
+msgid "Add a Printer"
+msgstr "เพิ่มเครื่องพิมพ์"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:27
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"ขออภัย! ดูเหมือนไม่มีบริการจัดพิมพ์ของระบบ\n"
+"เปิดอยู่"
+
+#: ../panels/privacy/cc-privacy-panel.c:387 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "การล็อคหน้าจอ"
+
+#: ../panels/privacy/cc-privacy-panel.c:438
+msgid "In use"
+msgstr "ใช้งานอยู่"
+
+#: ../panels/privacy/cc-privacy-panel.c:443
+msgctxt "Location services status"
+msgid "On"
+msgstr "เปิด"
+
+#: ../panels/privacy/cc-privacy-panel.c:444
+msgctxt "Location services status"
+msgid "Off"
+msgstr "ปิด"
+
+#: ../panels/privacy/cc-privacy-panel.c:823 ../panels/privacy/privacy.ui.h:42
+msgid "Location Services"
+msgstr "บริการตำแหน่งที่ตั้ง"
+
+#: ../panels/privacy/cc-privacy-panel.c:942 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "การใช้งาน & ประวัติ"
+
+#: ../panels/privacy/cc-privacy-panel.c:1067
+msgid "Empty all items from Trash?"
+msgstr "แน่ใจหรือไม่ว่าต้องการลบทุกอย่างในถังขยะอย่างถาวร?"
+
+#: ../panels/privacy/cc-privacy-panel.c:1068
+msgid "All items in the Trash will be permanently deleted."
+msgstr "ทุกรายการในถังขยะจะถูกลบทิ้งอย่างถาวร"
+
+#: ../panels/privacy/cc-privacy-panel.c:1069 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "เ_ทขยะ"
+
+#: ../panels/privacy/cc-privacy-panel.c:1092
+msgid "Delete all the temporary files?"
+msgstr "ลบแฟ้มชั่วคราวทั้งหมดหรือไม่?"
+
+#: ../panels/privacy/cc-privacy-panel.c:1093
+msgid "All the temporary files will be permanently deleted."
+msgstr "แฟ้มชั่วคราวทั้งหมดจะถูกลบทิ้งอย่างถาวร"
+
+#: ../panels/privacy/cc-privacy-panel.c:1094 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "_ล้างแฟ้มชั่วคราวต่างๆ"
+
+#: ../panels/privacy/cc-privacy-panel.c:1116 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "ล้างขยะ & แฟ้มชั่วคราว"
+
+#: ../panels/privacy/cc-privacy-panel.c:1156 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr "การใช้ซอฟต์แวร์"
+
+#: ../panels/privacy/cc-privacy-panel.c:1197 ../panels/privacy/privacy.ui.h:46
+msgid "Problem Reporting"
+msgstr "การรายงานปัญหา"
+
+#. translators: '%s' is the distributor's name, such as 'Fedora'
+#: ../panels/privacy/cc-privacy-panel.c:1211
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data."
+msgstr ""
+"การส่งรายงานปัญหาทางเทคนิคเป็นการช่วยเราปรับปรุง %s ให้ดีขึ้น รายงานจะถูกส่งโดยไม่ระบุชื่อ "
+"และปราศจากข้อมูลส่วนบุคคล"
+
+#: ../panels/privacy/cc-privacy-panel.c:1223 ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "นโยบายความเป็นส่วนตัว"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Pri­va­cy"
+msgstr "ความ­เป็น­ส่วน­ตัว"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:3
+msgid "Protect your personal information and control what others might see"
+msgstr "ปกป้องข้อมูลส่วนตัวของคุณและควบคุมสิ่งที่จะให้คนอื่นเห็น"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:5
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr "หน้าจอ;ล็อค;วินิจฉัย;พัง;ส่วนตัว;ล่าสุด;ชั่วคราว;tmp;ดัชนี;ชื่อ;เครือข่าย;เอกลักษณ์;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "หน้าจอปิด"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 วินาที"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 วัน"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 วัน"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 วัน"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 วัน"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 วัน"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 วัน"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 วัน"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 วัน"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 วัน"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "ตลอดไป"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr ""
+"การจำประวัติของคุณทำให้หาสิ่งต่างๆ อีกครั้งได้ง่าย รายการเหล่านี้จะไม่มีการแบ่งปันในเครือข่าย"
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "ใช้_ล่าสุด"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "จดจำ_ประวัติ"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "_ล้างประวัติล่าสุด"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "การล็อคหน้าจอจะปกป้องความเป็นส่วนตัวของคุณเมื่อคุณลุกไปจากเครื่อง"
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "_ล็อคหน้าจออัตโนมัติ"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "ล็อคหน้าจอ_หลังจากแสดงจอเปล่าเป็นเวลา"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "แสดงการแ_จ้งเหตุ"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr ""
+"ล้างถังขยะและแฟ้มชั่วคราวโดยอัตโนมัติ "
+"เพื่อช่วยให้คอมพิวเตอร์ของคุณปลอดจากข้อมูลที่ล่อแหลมโดยไม่จำเป็น"
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "เ_ทขยะโดยอัตโนมัติ"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "ล้างแ_ฟ้มชั่วคราวโดยอัตโนมัติ"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "ล้าง_หลังจาก"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"การส่งข้อมูลเกี่ยวกับซอฟต์แวร์ที่คุณใช้ ช่วยให้เราเตรียมคำแนะนำได้ถูกต้องยิ่งขึ้นสำหรับคุณ "
+"และยังเป็นการช่วยเราปรับปรุงซอฟต์แวร์ของเราอีกด้วย\n"
+"\n"
+"ข้อมูลทั้งหมดที่เรารวบรวมจะไม่มีการระบุชื่อผู้ใช้ และเราจะไม่แบ่งปันข้อมูลของคุณกับบุคคลที่สาม"
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "_ส่งสถิติการใช้ซอฟต์แวร์"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy."
+msgstr ""
+"บริการตำแหน่งที่ตั้งจะทำให้โปรแกรมต่างๆ รู้ตำแหน่งภูมิศาสตร์ที่คุณอยู่ การใช้ Wi-Fi "
+"และบรอดแบนด์มือถือจะช่วยเพิ่มความแม่นยำได้"
+
+#: ../panels/privacy/privacy.ui.h:44
+msgid "_Location Services"
+msgstr "บริการ_ตำแหน่งที่ตั้ง"
+
+#: ../panels/privacy/privacy.ui.h:47
+msgid "_Automatic Problem Reporting"
+msgstr "การรายงานปัญหาโดย_อัตโนมัติ"
+
+#: ../panels/region/cc-format-chooser.c:120
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "อังกฤษ"
+
+#: ../panels/region/cc-format-chooser.c:122
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "เมตริก"
+
+#: ../panels/region/cc-format-chooser.c:287
+msgid "No regions found"
+msgstr "ไม่พบภูมิภาค"
+
+#: ../panels/region/cc-input-chooser.c:182
+msgid "No input sources found"
+msgstr "ไม่พบช่องทางป้อนข้อความ"
+
+#: ../panels/region/cc-input-chooser.c:992
+msgctxt "Input Source"
+msgid "Other"
+msgstr "อื่นๆ"
+
+#: ../panels/region/cc-region-panel.c:247
+#: ../panels/user-accounts/um-user-panel.c:1087
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "คุณต้องตั้งต้นวาระใหม่เพื่อให้การเปลี่ยนแปลงมีผล"
+
+#: ../panels/region/cc-region-panel.c:251
+#: ../panels/user-accounts/um-user-panel.c:1091
+msgid "Restart Now"
+msgstr "ตั้งต้นใหม่เดี๋ยวนี้"
+
+#: ../panels/region/cc-region-panel.c:888
+msgid "No input source selected"
+msgstr "ไม่ได้เลือกช่องทางป้อนข้อความใด"
+
+#: ../panels/region/cc-region-panel.c:1779
+msgid "Login _Screen"
+msgstr "_หน้าจอเข้าระบบ"
+
+#: ../panels/region/format-chooser.ui.h:1
+msgid "Formats"
+msgstr "รูปแบบ"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "ดูตัวอย่าง"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "วันที่"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "เวลา"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "ตัวเลข"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "หน่วยความยาว"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "กระดาษ"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid "Re­gion & Lan­guage"
+msgstr "ภูมิ­ภาค & ภา­ษา"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:3
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr "เลือกภาษาที่แสดง, รูปแบบ, ผังแป้นพิมพ์ และช่องทางป้อนข้อความของคุณ"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:5
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "ภาษา;ผังแป้นพิมพ์;แป้นพิมพ์;ป้อนข้อความ;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "เพิ่มช่องทางป้อนข้อความ"
+
+#: ../panels/region/input-chooser.ui.h:4
+msgid "Input methods can't be used on the login screen"
+msgstr "ไม่สามารถใช้วิธีป้อนข้อความในหน้าจอเข้าระบบได้"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "ตัวเลือกของช่องทางป้อนข้อความ"
+
+#: ../panels/region/input-options.ui.h:2
+msgid "Use the _same source for all windows"
+msgstr "ใช้ช่องทางป้อนข้อความเ_ดียวกันหมดทุกหน้าต่าง"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Allow _different sources for each window"
+msgstr "ใช้ช่องทางป้อนข้อความ_ต่างกันสำหรับแต่ละหน้าต่าง"
+
+#: ../panels/region/input-options.ui.h:4 ../shell/cc-application.c:251
+msgid "Keyboard Shortcuts"
+msgstr "ปุ่มลัด"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Switch to previous source"
+msgstr "สลับไปยังช่องทางก่อนหน้า"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Switch to next source"
+msgstr "สลับไปยังช่องทางถัดไป"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "คุณสามารถเปลี่ยนปุ่มลัดเหล่านี้ได้ในการตั้งค่าแป้นพิมพ์"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "Alternative switch to next source"
+msgstr "ปุ่มลัดทางเลือกสำหรับสลับไปยังช่องทางถัดไป"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Left+Right Alt"
+msgstr "Alt ซ้าย+ขวา"
+
+#: ../panels/region/region.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Language"
+msgstr "_ภาษา"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "อังกฤษ (สหราชอาณาจักร)"
+
+#: ../panels/region/region.ui.h:3
+msgid "_Formats"
+msgstr "รูปแ_บบ"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "สหราชอาณาจักร"
+
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "ช่องทางป้อนข้อความ"
+
+#: ../panels/region/region.ui.h:7
+msgid "Add input source"
+msgstr "เพิ่มช่องทางป้อนข้อความ"
+
+#: ../panels/region/region.ui.h:8
+msgid "Remove input source"
+msgstr "ลบช่องทางป้อนข้อความ"
+
+#: ../panels/region/region.ui.h:9
+msgid "Move input source up"
+msgstr "เลื่อนช่องทางป้อนข้อความขึ้น"
+
+#: ../panels/region/region.ui.h:10
+msgid "Move input source down"
+msgstr "เลื่อนช่องทางป้อนข้อความลง"
+
+#: ../panels/region/region.ui.h:11
+msgid "Configure input source"
+msgstr "ตั้งค่าช่องทางป้อนข้อความ"
+
+#: ../panels/region/region.ui.h:12
+msgid "Show input source keyboard layout"
+msgstr "แสดงผังแป้นพิมพ์ของช่องทางป้อนข้อความ"
+
+#: ../panels/region/region.ui.h:13
+msgid "Login settings are used by all users when logging into the system"
+msgstr "การตั้งค่าการเข้าระบบใช้จะใช้กับผู้ใช้ทั้งหมดขณะเข้าสู่ระบบ"
+
+#: ../panels/search/cc-search-locations-dialog.c:634
+msgid "Select Location"
+msgstr "เลือกสถานที่"
+
+#: ../panels/search/cc-search-locations-dialog.c:638
+msgid "_OK"
+msgstr "_ตกลง"
+
+#: ../panels/search/cc-search-panel.c:177
+msgid "No applications found"
+msgstr "ไม่พบโปรแกรม"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid "Search"
+msgstr "ค้นหา"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:3
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "กำหนดโปรแกรมที่จะแสดงผลการค้นหาในหน้าภาพรวมกิจกรรม"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:5
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "ค้นหา;หา;ดัชนี;ซ่อน;ความเป็นส่วนตัว;ผล;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "ค้นหาตำแหน่งที่ตั้ง"
+
+#: ../panels/search/search-locations-dialog.ui.h:2
+msgid "Places"
+msgstr "ที่หลักๆ"
+
+#: ../panels/search/search-locations-dialog.ui.h:3
+msgid "Bookmarks"
+msgstr "ที่คั่นหน้า"
+
+#: ../panels/search/search-locations-dialog.ui.h:4
+msgid "Other"
+msgstr "อื่นๆ"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "เลื่อนขึ้น"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "เลื่อนลง"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "ปรับแต่ง"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:303
+msgid "No networks selected for sharing"
+msgstr "ไม่มีเครือข่ายที่เลือกเพื่อใช้ร่วม"
+
+#: ../panels/sharing/cc-sharing-panel.c:263
+msgctxt "service is enabled"
+msgid "On"
+msgstr "เปิด"
+
+#: ../panels/sharing/cc-sharing-panel.c:265
+#: ../panels/sharing/cc-sharing-panel.c:292
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "ปิด"
+
+#: ../panels/sharing/cc-sharing-panel.c:295
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "เปิดใช้"
+
+#: ../panels/sharing/cc-sharing-panel.c:298
+msgctxt "service is active"
+msgid "Active"
+msgstr "ทำงานอยู่"
+
+#: ../panels/sharing/cc-sharing-panel.c:369
+msgid "Choose a Folder"
+msgstr "เลือกโฟลเดอร์"
+
+#: ../panels/sharing/cc-sharing-panel.c:680
+#, c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr ""
+"การแบ่งปันแฟ้มส่วนตัว ช่วยคุณแบ่งปันโฟลเดอร์ \"สาธารณะ\" ของคุณกับผู้อื่นในเครือข่ายปัจจุบันของคุณ "
+"โดยใช้: <a href=\"dav://%s\">dav://%s</a>"
+
+#: ../panels/sharing/cc-sharing-panel.c:682
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"เมื่อเปิดใช้การเข้าระบบผ่านเครือข่าย ผู้ใช้จากเครื่องอื่นจะสามารถเชื่อมต่อ โดยใช้คำสั่งเชลล์นิรภัย:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/cc-sharing-panel.c:684
+#, c-format
+msgid ""
+"Screen sharing allows remote users to view or control your screen by "
+"connecting to <a href=\"vnc://%s\">vnc://%s</a>"
+msgstr ""
+"การแบ่งปันหน้าจอจะเปิดให้ผู้ใช้จากเครื่องอื่นดูหรือควบคุมหน้าจอของคุณ ด้วยการเชื่อมต่อไปยัง: <a "
+"href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/cc-sharing-panel.c:796
+msgid "Copy"
+msgstr "คัดลอก"
+
+#: ../panels/sharing/cc-sharing-panel.c:1122
+msgid "Sharing"
+msgstr "การแบ่งปัน"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Sha­ring"
+msgstr "การ­แบ่ง­ปัน"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:3
+msgid "Control what you want to share with others"
+msgstr "ควบคุมสิ่งที่คุณต้องการแบ่งปันกับผู้อื่น"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:5
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"แบ่งปัน;ใช้ร่วม;ssh;โฮสต์;ชื่อ;แม่ข่าย;เดสก์ท็อป;สื่อ;เสียง;วีดิทัศน์;ภาพ;ภาพถ่าย;ภาพยนตร์;"
+"เซิร์ฟเวอร์;โปรแกรมวาดแสดง;"
+
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "เครือข่าย"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "เปิดหรือปิดการเข้าระบบผ่านเครือข่าย"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "ต้องยืนยันตัวบุคคลเพื่อจะเปิดหรือปิดการเข้าระบบผ่านเครือข่าย"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "_Computer Name"
+msgstr "_ชื่อเครื่อง"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid "_File Sharing"
+msgstr "การแบ่งปันแ_ฟ้ม"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "_Screen Sharing"
+msgstr "การแบ่งปันหน้า_จอ"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "_Media Sharing"
+msgstr "การแบ่งปัน_สื่อ"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "_Remote Login"
+msgstr "การเข้าระบบผ่านเ_ครือข่าย"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Some services are disabled because of no network access."
+msgstr "บางบริการถูกปิดใช้เพราะเข้าถึงเครือข่ายไม่ได้"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "File Sharing"
+msgstr "การแบ่งปันแฟ้ม"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "_Require Password"
+msgstr "_ต้องใช้รหัสผ่าน"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Remote Login"
+msgstr "การเข้าระบบผ่านเครือข่าย"
+
+#: ../panels/sharing/sharing.ui.h:11
+msgid "Screen Sharing"
+msgstr "การแบ่งปันหน้าจอ"
+
+#: ../panels/sharing/sharing.ui.h:12
+msgid "_Allow connections to control the screen"
+msgstr "_อนุญาตให้คู่เชื่อมต่อควบคุมหน้าจอ"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "_Password:"
+msgstr "_รหัสผ่าน:"
+
+#: ../panels/sharing/sharing.ui.h:14
+msgid "_Show Password"
+msgstr "แ_สดงรหัสผ่าน"
+
+#: ../panels/sharing/sharing.ui.h:15
+msgid "Access Options"
+msgstr "ตัวเลือกของการเข้าถึง"
+
+#: ../panels/sharing/sharing.ui.h:16
+msgid "_New connections must ask for access"
+msgstr "การเชื่อมต่อใ_หม่ต้องร้องขอการเข้าถึง"
+
+#: ../panels/sharing/sharing.ui.h:17
+msgid "_Require a password"
+msgstr "_ต้องใช้รหัสผ่าน"
+
+#: ../panels/sharing/sharing.ui.h:18
+msgid "Media Sharing"
+msgstr "การแบ่งปันสื่อ"
+
+#: ../panels/sharing/sharing.ui.h:19
+msgid "Share music, photos and videos over the network."
+msgstr "แบ่งปันดนตรี, ภาพถ่าย และวีดิทัศน์ผ่านทางเครือข่าย"
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Folders"
+msgstr "โฟลเดอร์"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "เสียง"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ปรับระดับเสียง เสียงเข้า เสียงออก และเสียงแจ้งเหตุ"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "การ์ด;ไมโครโฟน;ความดัง;เฟด;สมดุล;บลูทูท;ชุดหูฟัง;เสียง;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "เห่า"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "หยดน้ำ"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "แก้ว"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "โซนาร์"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "ซ้าย"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "ขวา"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "หลัง"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "หน้า"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "ต่ำสุด"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "สูงสุด"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "_สมดุล:"
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "เ_ฟด:"
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "_ซับวูฟเฟอร์:"
+
+#: ../panels/sound/gvc-channel-bar.c:611 ../panels/sound/gvc-channel-bar.c:620
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:615
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "ไม่ขยาย"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:249
+#: ../panels/sound/gvc-mixer-dialog.c:515
+msgid "_Profile:"
+msgstr "โ_พรไฟล์:"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "เสียงออก %u ช่อง"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "เสียงเข้า %u ช่อง"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "เสียงของระบบ"
+
+#: ../panels/sound/gvc-mixer-dialog.c:251
+msgid "_Test Speakers"
+msgstr "_ทดสอบลำโพง"
+
+#: ../panels/sound/gvc-mixer-dialog.c:420
+msgid "Peak detect"
+msgstr "ตรวจหายอดคลื่น"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1512
+msgid "Device"
+msgstr "อุปกรณ์"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1575
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "การทดสอบลำโพงสำหรับ %s"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1631
+msgid "_Output volume:"
+msgstr "ความดังเสียง_ออก:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1645
+msgid "Output"
+msgstr "เสียงออก"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1650
+msgid "C_hoose a device for sound output:"
+msgstr "เ_ลือกอุปกรณ์สำหรับเสียงออก:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1672
+msgid "Settings for the selected device:"
+msgstr "ค่าตั้งสำหรับอุปกรณ์ที่เลือก:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1683
+msgid "Input"
+msgstr "เสียงเข้า"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1690
+msgid "_Input volume:"
+msgstr "ความดังเสียงเ_ข้า:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "Input level:"
+msgstr "ระดับเสียงเข้า:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1737
+msgid "C_hoose a device for sound input:"
+msgstr "เ_ลือกอุปกรณ์สำหรับเสียงเข้า:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1761
+msgid "Sound Effects"
+msgstr "เอฟเฟ็กต์เสียง"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1768
+msgid "_Alert volume:"
+msgstr "ความดังเสียงแ_จ้งเตือน:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1785
+msgid "No application is currently playing or recording audio."
+msgstr "ไม่มีโปรแกรมที่เล่นหรืออัดเสียงอยู่"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "ฝังในโปรแกรม"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "ปรับแต่งเสียง"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "กำลังทดสอบเสียงของเหตุการณ์"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:554
+msgid "Default"
+msgstr "ปริยาย"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:555
+msgid "From theme"
+msgstr "จากชุดเสียง"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:740
+msgid "C_hoose an alert sound:"
+msgstr "เ_ลือกเสียงแจ้งเหตุ:"
+
+#: ../panels/sound/gvc-speaker-test.c:231
+msgid "Stop"
+msgstr "หยุด"
+
+#: ../panels/sound/gvc-speaker-test.c:231
+#: ../panels/sound/gvc-speaker-test.c:343
+msgid "Test"
+msgstr "ทดสอบ"
+
+#: ../panels/sound/gvc-speaker-test.c:239
+msgid "Subwoofer"
+msgstr "ซับวูฟเฟอร์"
+
+#: ../panels/sound/sound-theme-file-utils.c:304
+msgid "Custom"
+msgstr "กำหนดเอง"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Uni­ver­sal Access"
+msgstr "การ­เข้า­ถึง­หลาก­หลาย"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:3
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "ทำให้ง่ายต่อการเห็น, ได้ยิน, พิมพ์, ชี้ และคลิก"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:5
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr ""
+"แป้นพิมพ์;เมาส์;a11y;สิ่งอำนวยความสะดวก;ความต่างระดับสี;ซูม;อ่านหน้าจอ;ข้อความ;แบบอักษร;"
+"ขนาด;AccessX;ค้างปุ่มกด;พิมพ์แบบช้า;ป้องกันการกดแป้นรัว;บังคับเมาส์ด้วยแป้น;"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "แ_สดงเมนูการเข้าถึงหลากหลายเสมอ"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "การมองเห็น"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "_สีตัดกัน"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "อักษร_ขนาดใหญ่"
+
+#: ../panels/universal-access/uap.ui.h:5
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "_Zoom"
+msgstr "_ขยาย"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr "การ_อ่านหน้าจอ"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "_Sound Keys"
+msgstr "ส่งเ_สียงปุ่มกด"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "การได้ยิน"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr "การแจ้งเหตุด้วย_ภาพ"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Screen _Keyboard"
+msgstr "แ_ป้นพิมพ์บนจอ"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "R_epeat Keys"
+msgstr "การซ้ำ_ตัวอักษร"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Cursor _Blinking"
+msgstr "การ_กะพริบของเคอร์เซอร์"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "_Typing Assist (AccessX)"
+msgstr "เครื่องมือช่วย_พิมพ์ (AccessX)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "Pointing & Clicking"
+msgstr "การชี้และการคลิก"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "_Mouse Keys"
+msgstr "บังคับเ_มาส์ด้วยแป้น"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "_Click Assist"
+msgstr "เครื่องมือช่วย_คลิก"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Double-Click Delay"
+msgstr "เวลาหน่วงดับเ_บิลคลิก"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Double-Click Delay"
+msgstr "เวลาหน่วงของดับเบิลคลิก"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Screen Reader"
+msgstr "การอ่านหน้าจอ"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "การอ่านหน้าจอจะอ่านข้อความที่แสดงขณะที่คุณย้ายโฟกัส"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Screen Reader"
+msgstr "การ_อ่านหน้าจอ"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Sound Keys"
+msgstr "ส่งเสียงปุ่มกด"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "ส่งเสียงบี๊บเมื่อ Num Lock หรือ Caps Lock เปิดหรือปิด"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Visual Alerts"
+msgstr "การแจ้งเหตุด้วยภาพ"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "_Test flash"
+msgstr "_ทดสอบการกะพริบ"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ใช้การบ่งชี้ด้วยภาพเมื่อมีเสียงแจ้งเหตุ"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Flash the _window title"
+msgstr "กะพริบหัว_หน้าต่าง"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "Flash the entire _screen"
+msgstr "กะพริบทั้งหน้า_จอ"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Repeat Keys"
+msgstr "การซ้ำตัวอักษร"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Key presses repeat when key is held down."
+msgstr "ซ้ำปุ่มเมื่อกดปุ่มค้างไว้"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Repeat keys delay"
+msgstr "เวลาหน่วงของการซ้ำปุ่มเมื่อกดค้าง"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgid "Speed"
+msgstr "ความเร็ว"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Repeat keys speed"
+msgstr "ความเร็วของการซ้ำปุ่มเมื่อกดค้าง"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgid "Cursor Blinking"
+msgstr "การกะพริบของเคอร์เซอร์"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Cursor blinks in text fields."
+msgstr "เคอร์เซอร์กะพริบในช่องข้อความ"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Cursor blinking speed"
+msgstr "อัตราการกะพริบของเคอร์เซอร์"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Typing Assist"
+msgstr "สิ่งอำนวยความสะดวกในการพิมพ์"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "_Sticky Keys"
+msgstr "_ค้างปุ่มกด"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "นับการกดปุ่มประกอบทีละปุ่มเสมือนการกดพร้อมกัน"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgid "_Disable if two keys are pressed together"
+msgstr "เ_ลิกใช้ถ้ามีการกดปุ่มสองปุ่มพร้อมกัน"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Beep when a _modifier key is pressed"
+msgstr "ส่งเสียงบี๊บเมื่อกดปุ่ม_ประกอบ"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "S_low Keys"
+msgstr "พิมพ์แบบ_ช้า"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "หน่วงเวลาหลังจากปุ่มถูกกดก่อนที่จะรับการกด"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "A_cceptance delay:"
+msgstr "เวลาห_น่วงก่อนรับ:"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "สั้น"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Slow keys typing delay"
+msgstr "เวลาหน่วงในการพิมพ์แบบช้า"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "ยาว"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgid "Beep when a key is pr_essed"
+msgstr "ส่งเสียงบี๊บเมื่อ_กดปุ่ม"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Beep when a key is _accepted"
+msgstr "ส่งเสียงบี๊บเมื่อปุ่มถูก_ยอมรับ"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgid "Beep when a key is _rejected"
+msgstr "ส่งเสียงบี๊บเมื่อปุ่มถูก_ปฏิเสธ"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "_Bounce Keys"
+msgstr "ป้องกันการกดแป้น_รัว"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Ignores fast duplicate keypresses"
+msgstr "ไม่รับการกดปุ่มรัว"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "สั้น"
+
+#: ../panels/universal-access/uap.ui.h:57
+msgid "Bounce keys typing delay"
+msgstr "เวลาหน่วงในการป้องกันการกดแป้นรัว"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "ยาว"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "_Enable by Keyboard"
+msgstr "_เปิดใช้ด้วยแป้นพิมพ์"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "เปิด/ปิดเทคโนโลยีสิ่งอำนวยความสะดวกจากแป้นพิมพ์"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgid "Click Assist"
+msgstr "เครื่องมือช่วยคลิก"
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "_Simulated Secondary Click"
+msgstr "_จำลองคลิกที่สอง"
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "สร้างคลิกที่สองโดยกดปุ่มแรกของเมาส์ค้างไว้"
+
+#: ../panels/universal-access/uap.ui.h:64
+msgctxt "secondary click"
+msgid "Short"
+msgstr "สั้น"
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Secondary click delay"
+msgstr "เวลาหน่วงสำหรับคลิกที่สอง"
+
+#: ../panels/universal-access/uap.ui.h:66
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "ยาว"
+
+#: ../panels/universal-access/uap.ui.h:67
+msgid "_Hover Click"
+msgstr "การคลิกด้วยการวางแ_ช่"
+
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Trigger a click when the pointer hovers"
+msgstr "สร้างการคลิกเมื่อตัวชี้วางแช่"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "D_elay:"
+msgstr "_รอ:"
+
+#: ../panels/universal-access/uap.ui.h:70
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "สั้น"
+
+#: ../panels/universal-access/uap.ui.h:71
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "ยาว"
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "Motion _threshold:"
+msgstr "ระยะเริ่_มเคลื่อน:"
+
+#: ../panels/universal-access/uap.ui.h:73
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "สั้น"
+
+#: ../panels/universal-access/uap.ui.h:74
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "ยาว"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "สั้น"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ หน้าจอ"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ หน้าจอ"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ หน้าจอ"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "ยาว"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "เต็มจอ"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "ครึ่งบน"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "ครึ่งล่าง"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "ครึ่งซ้าย"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "ครึ่งขวา"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "ตัวเลือกของการซูม"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "_Magnification:"
+msgstr "_อัตราขยาย:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "_Follow mouse cursor"
+msgstr "_ติดตามตัวชี้เมาส์"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "_Screen part:"
+msgstr "_ส่วนของหน้าจอ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier _extends outside of screen"
+msgstr "แว่นขยาย_ขยายขอบเขตออกไปนอกหน้าจอ"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "_Keep magnifier cursor centered"
+msgstr "_รักษาตำแหน่งตัวชี้ของแว่นขยายไว้ตรงกลาง"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor _pushes contents around"
+msgstr "ตัวชี้ของแว่นขยาย_ผลักเนื้อหาตามไปด้วย"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with _contents"
+msgstr "ตัวชี้ของแว่นขยายเลื่อนไปตามเ_นื้อหา"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "ตำแหน่งของแว่นขยาย:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "แว่นขยาย"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "_Thickness:"
+msgstr "ความ_หนา:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "บาง"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "หนา"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "_Length:"
+msgstr "ความ_ยาว:"
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Co_lor:"
+msgstr "_สี:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "_Crosshairs:"
+msgstr "เส้น_พิกัด:"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "_Overlaps mouse cursor"
+msgstr "ซ้อน_ทับกับตัวชี้เมาส์"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "เส้นพิกัด"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "_White on black:"
+msgstr "_ขาวบนพื้นดำ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "_Brightness:"
+msgstr "ความส_ว่าง:"
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "_Contrast:"
+msgstr "ความ_ต่างระดับสี:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_สี"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "ไม่ใช้"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "เต็มที่"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "ต่ำ"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "สูง"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "ต่ำ"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "สูง"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "เอฟเฟ็กต์สี:"
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "เอฟเฟ็กต์สี"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/join-dialog.ui.h:1
+msgid "Add User"
+msgstr "เพิ่มผู้ใช้"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "_Full Name"
+msgstr "ชื่_อเต็ม"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+msgid "Standard"
+msgstr "มาตรฐาน"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Administrator"
+msgstr "ผู้ดูแลระบบ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Account _Type"
+msgstr "_ชนิดของบัญชี:"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "Allow user to set a password when they next _login"
+msgstr "อนุญาตให้ผู้ใช้ตั้งรหัสผ่านในครั้งต่อไปที่เ_ข้าระบบ"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid "Set a password _now"
+msgstr "ตั้งรหัสผ่านเ_ดี๋ยวนี้"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid "_Confirm"
+msgstr "_ยืนยัน"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:14
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"บัญชีเข้าระบบองค์กร อนุญาตให้ใช้บัญชีผู้ใช้ที่มีการจัดการแบบรวมศูนย์ที่มีอยู่กับอุปกรณ์นี้ "
+"คุณสามารถใช้บัญชีนี้ในการเข้าถึงทรัพยากรของบริษัทในอินเทอร์เน็ตด้วย"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+#: ../panels/user-accounts/data/join-dialog.ui.h:9
+msgid "_Domain"
+msgstr "โ_ดเมน"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+msgid "You are Offline"
+msgstr "คุณออฟไลน์อยู่"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+msgid "You must be online in order to add enterprise users."
+msgstr "คุณต้องออนไลน์เพื่อเพิ่มผู้ใช้องค์กร"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:18
+msgid "_Enterprise Login"
+msgstr "บัญชีเข้าระบบ_องค์กร"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "นิ้วหัวแม่มือซ้าย"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "นิ้วกลางซ้าย"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "นิ้วนางซ้าย"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "นิ้วก้อยซ้าย"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "นิ้วหัวแม่มือขวา"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "นิ้วกลางขวา"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "นิ้วนางขวา"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "นิ้วก้อยขวา"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:687
+msgid "Enable Fingerprint Login"
+msgstr "เปิดใช้การเข้าระบบด้วยลายนิ้วมือ"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "นิ้วชี้_ขวา"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "นิ้วชี้ซ้า_ย"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "นิ้ว_อื่น: "
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr "บันทึกลายนิ้วมือของคุณสำเร็จแล้ว คุณควรสามารถเข้าระบบโดยใช้เครื่องอ่านลายนิ้วมือได้แล้ว"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "ผู้ใช้"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "เพิ่มหรือลบผู้ใช้และเปลี่ยนรหัสผ่านของคุณ"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "เข้าระบบ;ชื่อ;ลายนิ้วมือ;รูปแทนตัว;โลโก้;รูปหน้า;รหัสผ่าน;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/join-dialog.ui.h:4
+msgid "_Enroll"
+msgstr "_ลงทะเบียน"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:5
+msgid "Domain Administrator Login"
+msgstr "การเข้าระบบสำหรับผู้ดูแลโดเมน"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:6
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"ในการใช้การเข้าระบบขององค์กร คอมพิวเตอร์นี้จำเป็นต้องลงทะเบียนในโดเมน\n"
+"กรุณาขอให้ผู้ดูแลเครือข่ายของคุณป้อนรหัสผ่านโดเมนที่นี่"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:10
+msgid "Administrator _Name"
+msgstr "_ชื่อผู้ดูแลระบบ"
+
+#: ../panels/user-accounts/data/join-dialog.ui.h:11
+msgid "Administrator Password"
+msgstr "รหัสผ่านผู้ดูแลระบบ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr "เปลี่ยนรหัสผ่าน"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "เป_ลี่ยน"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "_ตรวจสอบรหัสผ่านใหม่"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "รหัสผ่านให_ม่"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "รหัสผ่าน_ปัจจุบัน"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to change their password on next login"
+msgstr "อนุญาตให้ผู้ใช้เปลี่ยนรหัสผ่านในครั้งต่อไปที่เข้าระบบ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "ตั้งรหัสผ่านเดี๋ยวนี้"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+msgid "_Add User…"
+msgstr "เ_พิ่มผู้ใช้…"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "A_utomatic Login"
+msgstr "การเข้าระบบ_อัตโนมัติ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Fingerprint Login"
+msgstr "การเข้าระบบด้วย_ลายนิ้วมือ"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "User Icon"
+msgstr "ไอคอนบัญชีผู้ใช้"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "Last Login"
+msgstr "เข้าระบบล่าสุด"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "จัดการบัญชีผู้ใช้"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "ต้องยืนยันตัวบุคคลเพื่อจะเปลี่ยนข้อมูลของผู้ใช้"
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "รหัสผ่านใหม่ต้องต่างจากรหัสผ่านเดิม"
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "ลองเปลี่ยนอักษรและตัวเลขบางตัว"
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "ลองเปลี่ยนรหัสผ่านให้ต่างจากเดิมกว่านี้อีกสักหน่อย"
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "รหัสผ่านที่ไม่มีชื่อผู้ใช้อยู่ในรหัสผ่านจะแน่นหนากว่า"
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "พยายามหลีกเลี่ยงการใช้ชื่อของคุณในรหัสผ่าน"
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "พยายามหลีกเลี่ยงคำบางคำในรหัสผ่าน"
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "พยายามหลีกเลี่ยงคำทั่วไป"
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "พยายามหลีกเลี่ยงการกลับลำดับคำเดิม"
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "พยายามใช้ตัวเลขเพิ่มอีก"
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "พยายามใช้ตัวพิมพ์ใหญ่เพิ่มอีก"
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "พยายามใช้ตัวพิมพ์เล็กเพิ่มอีก"
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "พยายามใช้อักขระพิเศษเพิ่มอีก เช่น เครื่องหมายวรรคตอน"
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "พยายามใช้ตัวอักษร ตัวเลข และเครื่องหมายวรรคตอนผสมกัน"
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "พยายามหลีกเลี่ยงการซ้ำอักขระเดิม"
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"พยายามหลีกเลี่ยงการใช้อักขระชนิดเดิมซ้ำ คุณต้องผสมตัวอักษร ตัวเลข และเครื่องหมายวรรคตอน"
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "พยายามหลีกเลี่ยงการใช้ลำดับ เช่น 1234 หรือ abcd"
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "พยายามเพิ่มตัวอักษร ตัวเลข และสัญลักษณ์ให้มากขึ้น"
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "ผสมตัวพิมพ์ใหญ่และตัวพิมพ์เล็ก และพยายามใช้ตัวเลขสักตัวสองตัว"
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr "รหัสผ่านดี! การเพิ่มตัวอักษร ตัวเลข และเครื่องหมายวรรคตอนอีก จะทำให้รหัสผ่านแน่นหนาขึ้น"
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "ความแน่นหนา: หละหลวม"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "ความแน่นหนา: ต่ำ"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "ความแน่นหนา: ปานกลาง"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "ความแน่นหนา: ดี"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "ความแน่นหนา: สูง"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "ยืนยันตัวบุคคลไม่ผ่าน"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "รหัสผ่านใหม่สั้นเกินไป"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "รหัสผ่านใหม่เดาง่ายเกินไป"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "รหัสผ่านใหม่คล้ายกับรหัสผ่านเก่าเกินไป"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "รหัสผ่านใหม่เพิ่งใช้ไปเมื่อเร็วๆ นี้"
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "รหัสผ่านใหม่ต้องมีตัวเลขหรือเครื่องหมายพิเศษด้วย"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "รหัสผ่านใหม่เหมือนกันกับรหัสผ่านเก่า"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "รหัสผ่านของคุณถูกเปลี่ยนหลังจากการยืนยันตัวบุคคลครั้งก่อน"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "รหัสผ่านใหม่มีอักขระต่างกันไม่มากพอ"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "ข้อผิดพลาดไม่ทราบสาเหตุ"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your login provider."
+msgstr "ควรจะตรงกับที่อยู่เว็บของผู้ให้บริการบัญชีเข้าระบบของคุณ"
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "เพิ่มบัญชีไม่สำเร็จ"
+
+#: ../panels/user-accounts/um-account-dialog.c:448
+msgid "Passwords do not match."
+msgstr "รหัสผ่านไม่ตรงกัน"
+
+#: ../panels/user-accounts/um-account-dialog.c:702
+#: ../panels/user-accounts/um-account-dialog.c:748
+#: ../panels/user-accounts/um-account-dialog.c:769
+msgid "Failed to register account"
+msgstr "ลงทะเบียนบัญชีไม่สำเร็จ"
+
+#: ../panels/user-accounts/um-account-dialog.c:892
+msgid "No supported way to authenticate with this domain"
+msgstr "ไม่มีวิธีการยืนยันตัวบุคคลที่รองรับสำหรับโดเมนนี้"
+
+#: ../panels/user-accounts/um-account-dialog.c:965
+msgid "Failed to join domain"
+msgstr "เข้าร่วมในโดเมนไม่สำเร็จ"
+
+#: ../panels/user-accounts/um-account-dialog.c:1026
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"ชื่อสำหรับเข้าระบบไม่ถูกต้อง\n"
+"กรุณาลองใหม่"
+
+#: ../panels/user-accounts/um-account-dialog.c:1033
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"รหัสผ่านสำหรับเข้าระบบไม่ถูกต้อง\n"
+"กรุณาลองใหม่"
+
+#: ../panels/user-accounts/um-account-dialog.c:1041
+msgid "Failed to log into domain"
+msgstr "เข้าระบบในโดเมนไม่สำเร็จ"
+
+#: ../panels/user-accounts/um-account-dialog.c:1099
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "หาโดเมนไม่พบ คุณอาจสะกดผิดหรือไม่?"
+
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "มาตรฐาน"
+
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "ผู้ดูแลระบบ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:138
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr "คุณไม่ได้รับอนุญาตให้เข้าใช้อุปกรณ์ กรุณาติดต่อผู้ดูแลระบบของคุณ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:140
+msgid "The device is already in use."
+msgstr "อุปกรณ์กำลังถูกใช้งานอยู่"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:142
+msgid "An internal error occurred."
+msgstr "เกิดข้อผิดพลาดภายใน"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Enabled"
+msgstr "เปิดใช้"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:264
+msgid "Delete registered fingerprints?"
+msgstr "จะลบลายนิ้วมือที่ลงทะเบียนไว้หรือไม่?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:268
+msgid "_Delete Fingerprints"
+msgstr "_ลบลายนิ้วมือ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:274
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "คุณต้องการลบลายนิ้วมือของคุณเองที่ได้ลงทะเบียนไว้ เพื่อปิดการเข้าระบบด้วยลายนิ้วมือหรือไม่?"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:444
+msgid "Done!"
+msgstr "เสร็จแล้ว!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:505
+#: ../panels/user-accounts/um-fingerprint-dialog.c:547
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "ไม่สามารถเข้าใช้อุปกรณ์ '%s'"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:588
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "ไม่สามารถเริ่มอ่านลายนิ้วมือที่อุปกรณ์ '%s'"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:638
+msgid "Could not access any fingerprint readers"
+msgstr "ไม่สามารถเข้าใช้เครื่องอ่านลายนิ้วมือใดๆ ได้เลย"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:639
+msgid "Please contact your system administrator for help."
+msgstr "กรุณาติดต่อผู้ดูแลระบบของคุณเพื่อขอความช่วยเหลือ"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:721
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr ""
+"ในการเปิดใช้การเข้าระบบด้วยลายนิ้วมือ คุณต้องบันทึกลายนิ้วมือของคุณก่อน โดยใช้อุปกรณ์ '%s'"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:728
+msgid "Selecting finger"
+msgstr "เลือกนิ้ว"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:729
+msgid "Enrolling fingerprints"
+msgstr "เก็บลายนิ้วมือ"
+
+#: ../panels/user-accounts/um-history-dialog.c:70
+msgid "This Week"
+msgstr "สัปดาห์นี้"
+
+#: ../panels/user-accounts/um-history-dialog.c:73
+msgid "Last Week"
+msgstr "สัปดาห์ที่แล้ว"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:79
+#: ../panels/user-accounts/um-history-dialog.c:83
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b %Ey"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:93
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:177
+#: ../panels/user-accounts/um-user-panel.c:841
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:180
+#: ../panels/user-accounts/um-user-panel.c:845
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: ../panels/user-accounts/um-history-dialog.c:250
+msgid "Session Ended"
+msgstr "วาระสิ้นสุด"
+
+#: ../panels/user-accounts/um-history-dialog.c:256
+msgid "Session Started"
+msgstr "วาระเริ่มต้น"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: ../panels/user-accounts/um-history-dialog.c:299
+#, c-format
+msgid "%s - Account Activity"
+msgstr "%s - ความเคลื่อนไหวของบัญชี"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "กรุณาตั้งรหัสผ่านใหม่"
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "กรุณาป้อนรหัสผ่านปัจจุบันของคุณอีกครั้ง"
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "ไม่สามารถเปลี่ยนรหัสผ่านได้"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "The passwords do not match."
+msgstr "รหัสผ่านไม่ตรงกัน"
+
+#: ../panels/user-accounts/um-photo-dialog.c:214
+msgid "Browse for more pictures"
+msgstr "ท่องดูรูปภาพเพิ่มเติม"
+
+#: ../panels/user-accounts/um-photo-dialog.c:448
+msgid "Disable image"
+msgstr "ไม่ใช้รูปภาพ"
+
+#: ../panels/user-accounts/um-photo-dialog.c:466
+msgid "Take a photo…"
+msgstr "ถ่ายภาพ…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:484
+msgid "Browse for more pictures…"
+msgstr "ท่องดูรูปภาพเพิ่มเติม…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:708
+#, c-format
+msgid "Used by %s"
+msgstr "ใช้โดย %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "ไม่สามารถเข้าร่วมโดเมนชนิดนี้โดยอัตโนมัติได้"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "ไม่พบโดเมนหรือ realm ดังกล่าว"
+
+#: ../panels/user-accounts/um-realm-manager.c:815
+#: ../panels/user-accounts/um-realm-manager.c:829
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "ไม่สามารถเข้าระบบในนาม %s ที่โดเมน %s"
+
+#: ../panels/user-accounts/um-realm-manager.c:821
+msgid "Invalid password, please try again"
+msgstr "รหัสผ่านไม่ถูกต้อง กรุณาลองใหม่"
+
+#: ../panels/user-accounts/um-realm-manager.c:834
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "ไม่สามารถเชื่อมต่อกับโดเมน %s: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:239
+msgid "Other Accounts"
+msgstr "บัญชีอื่นๆ"
+
+#: ../panels/user-accounts/um-user-panel.c:447
+msgid "Failed to delete user"
+msgstr "ลบผู้ใช้ไม่สำเร็จ"
+
+#: ../panels/user-accounts/um-user-panel.c:507
+#: ../panels/user-accounts/um-user-panel.c:566
+#: ../panels/user-accounts/um-user-panel.c:618
+msgid "Failed to revoke remotely managed user"
+msgstr "เพิกถอนผู้ใช้ที่จัดการผ่านเครือข่ายไม่สำเร็จ"
+
+#: ../panels/user-accounts/um-user-panel.c:674
+msgid "You cannot delete your own account."
+msgstr "คุณจะลบบัญชีของคุณเองไม่ได้"
+
+#: ../panels/user-accounts/um-user-panel.c:683
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s ยังคงเข้าระบบอยู่"
+
+#: ../panels/user-accounts/um-user-panel.c:687
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "การลบบัญชีผู้ใช้ในระหว่างที่ผู้ใช้นั้นกำลังเข้าระบบอยู่ จะทำให้ระบบอยู่ในสถานะที่สับสน"
+
+#: ../panels/user-accounts/um-user-panel.c:696
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "คุณต้องการเก็บรักษาแฟ้มต่างๆ ของ %s ไว้หรือไม่?"
+
+#: ../panels/user-accounts/um-user-panel.c:700
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr "ในการลบบัญชีผู้ใช้ คุณสามารถเก็บรักษาไดเรกทอรีบ้าน, ถุงเมล และแฟ้มชั่วคราวของผู้ใช้ไว้ได้"
+
+#: ../panels/user-accounts/um-user-panel.c:703
+msgid "_Delete Files"
+msgstr "_ลบแฟ้ม"
+
+#: ../panels/user-accounts/um-user-panel.c:704
+msgid "_Keep Files"
+msgstr "เ_ก็บรักษาแฟ้ม"
+
+#: ../panels/user-accounts/um-user-panel.c:718
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s's account?"
+msgstr "ยืนยันที่จะเพิกถอนบัญชีของ %s ที่จัดการผ่านเครือข่ายหรือไม่?"
+
+#: ../panels/user-accounts/um-user-panel.c:722
+msgid "_Delete"
+msgstr "_ลบ"
+
+#: ../panels/user-accounts/um-user-panel.c:774
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "บัญชีถูกระงับ"
+
+#: ../panels/user-accounts/um-user-panel.c:782
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "รอตั้งรหัสผ่านในครั้งต่อไปที่เข้าระบบ"
+
+#: ../panels/user-accounts/um-user-panel.c:785
+msgctxt "Password mode"
+msgid "None"
+msgstr "ไม่มีรหัสผ่าน"
+
+#: ../panels/user-accounts/um-user-panel.c:834
+msgid "Logged in"
+msgstr "เข้าระบบ"
+
+#: ../panels/user-accounts/um-user-panel.c:1290
+msgid "Failed to contact the accounts service"
+msgstr "ติดต่อบริการบัญชีผู้ใช้ไม่สำเร็จ"
+
+#: ../panels/user-accounts/um-user-panel.c:1292
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "กรุณาตรวจสอบให้แน่ใจว่าได้ติดตั้งและเปิดใช้งาน AccountService"
+
+#: ../panels/user-accounts/um-user-panel.c:1334
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"หากต้องการเปลี่ยนแปลง\n"
+"ให้คลิกที่ไอคอน * ก่อน"
+
+#: ../panels/user-accounts/um-user-panel.c:1374
+msgid "Create a user account"
+msgstr "สร้างบัญชีผู้ใช้"
+
+#: ../panels/user-accounts/um-user-panel.c:1385
+#: ../panels/user-accounts/um-user-panel.c:1677
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"หากต้องการสร้างบัญชีผู้ใช้\n"
+"ให้คลิกที่ไอคอน * ก่อน"
+
+#: ../panels/user-accounts/um-user-panel.c:1395
+msgid "Delete the selected user account"
+msgstr "ลบบัญชีผู้ใช้ที่เลือก"
+
+#: ../panels/user-accounts/um-user-panel.c:1407
+#: ../panels/user-accounts/um-user-panel.c:1682
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"หากต้องการลบบัญชีผู้ใช้ที่เลือก\n"
+"ให้คลิกที่ไอคอน * ก่อน"
+
+#: ../panels/user-accounts/um-user-panel.c:1591
+msgid "My Account"
+msgstr "บัญชีของฉัน"
+
+#: ../panels/user-accounts/um-utils.c:563
+msgid "Sorry, that user name isn't available. Please try another."
+msgstr "ขออภัย ชื่อผู้ใช้นี้ถูกใช้ไปแล้ว กรุณาลองหาชื่ออื่น"
+
+#: ../panels/user-accounts/um-utils.c:566
+#, c-format
+msgid "The username is too long."
+msgstr "ชื่อผู้ใช้ยาวเกินไป"
+
+#: ../panels/user-accounts/um-utils.c:569
+msgid "The username cannot start with a '-'."
+msgstr "ชื่อผู้ใช้ขึ้นต้นด้วย '-' ไม่ได้"
+
+#: ../panels/user-accounts/um-utils.c:572
+msgid ""
+"The username should only consist of upper and lower case letters from a-z, "
+"digits and the following characters: . - _"
+msgstr ""
+"ชื่อผู้ใช้ควรประกอบด้วยตัวพิมพ์ใหญ่และตัวพิมพ์เล็กตั้งแต่ a-z, ตัวเลข และอักขระต่อไปนี้เท่านั้น: . - _"
+
+#: ../panels/user-accounts/um-utils.c:576
+msgid "This will be used to name your home folder and can't be changed."
+msgstr "ชื่อนี้จะนำมาใช้เป็นชื่อโฟลเดอร์บ้านของคุณ และไม่สามารถเปลี่ยนแปลงได้"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "กำหนดปุ่ม"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid "Map buttons to functions"
+msgstr "กำหนดการใช้งานปุ่มต่างๆ"
+
+#: ../panels/wacom/button-mapping.ui.h:4
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"ถ้าต้องการแก้ไขปุ่มลัด ให้เลือกการกระทำ \"ส่งการกดแป้นพิมพ์\" จากนั้น กดปุ่มลัดแป้นพิมพ์ "
+"แล้วกดปุ่มลัดใหม่ หรือกด Backspace ถ้าต้องการล้างปุ่มลัด"
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "กรุณาแตะที่เครื่องหมายเป้าที่ปรากฏบนหน้าจอเพื่อปรับเทียบมาตรฐานแท็บเล็ต"
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "ตรวจพบการคลิกที่ผิดพลาด จะเริ่มทำงานใหม่..."
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "ขึ้น"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "ลง"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "ไม่ทำอะไร"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "ส่งการกดแป้นพิมพ์"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "สลับจอภาพ"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "แสดงวิธีใช้บนหน้าจอ"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "เอาต์พุต:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "รักษาสัดส่วนภาพ (กล่องอักษร):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "ปรับตำแหน่งกับจอภาพเดียว"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d จาก %d"
+
+#: ../panels/wacom/cc-wacom-page.c:522
+msgid "Display Mapping"
+msgstr "การแทนตำแหน่งจอแสดงผล"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:377
+msgid "Button"
+msgstr "ปุ่ม"
+
+#. Translators: Add soft hyphens to your translations so that the icon view won't clip your translations. See https://bugzilla.gnome.org/show_bug.cgi?id=647087#c13 for details
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Wa­com Tab­let"
+msgstr "แท็บ­เล็ต Wa­com"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:3
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "ตั้งผังปุ่มและปรับความไวของสไตลัสสำหรับแท็บเล็ตกราฟิก"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:5
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "แท็บเล็ต;Wacom;ปากกา;สไตลัส;ยางลบ;เมาส์;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "แท็บเล็ต (สัมบูรณ์)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "ทัชแพด (สัมพัทธ์)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "ปรับแต่งแท็บเล็ต"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "_Help"
+msgstr "_วิธีใช้"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "No tablet detected"
+msgstr "ไม่พบแท็บเล็ต"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "กรุณาต่อหรือเปิดแท็บเล็ต Wacom ของคุณ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Bluetooth Settings"
+msgstr "ตั้งค่าบลูทูท"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Wacom Tablet"
+msgstr "แท็บเล็ต Wacom"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Map to Monitor…"
+msgstr "ปรับตำแหน่งกับจอภาพ…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Map Buttons…"
+msgstr "กำหนดปุ่ม…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Calibrate…"
+msgstr "เทียบมาตรฐาน…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Adjust display resolution"
+msgstr "ปรับความละเอียดการแสดงผล"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Adjust mouse settings"
+msgstr "ปรับการตั้งค่าเมาส์"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:15
+msgid "Tracking Mode"
+msgstr "โหมดการจับตำแหน่ง"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:16
+msgid "Left-Handed Orientation"
+msgstr "สำหรับมือถนัดซ้าย"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1028
+msgid "Left Ring"
+msgstr "วงแหวนสัมผัสซ้าย"
+
+#: ../panels/wacom/gsd-wacom-device.c:1039
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "โหมดวงแหวนสัมผัสซ้าย #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1059
+msgid "Right Ring"
+msgstr "วงแหวนสัมผัสขวา"
+
+#: ../panels/wacom/gsd-wacom-device.c:1070
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "โหมดวงแหวนสัมผัสขวา #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1112
+msgid "Left Touchstrip"
+msgstr "แถบสัมผัสซ้าย"
+
+#: ../panels/wacom/gsd-wacom-device.c:1123
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "โหมดแถบสัมผัสซ้าย #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1143
+msgid "Right Touchstrip"
+msgstr "แถบสัมผัสขวา"
+
+#: ../panels/wacom/gsd-wacom-device.c:1154
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "โหมดแถบสัมผัสขวา #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1180
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "ปุ่มเปลี่ยนโหมดวงแหวนสัมผัสซ้าย"
+
+#: ../panels/wacom/gsd-wacom-device.c:1182
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "ปุ่มเปลี่ยนโหมดวงแหวนสัมผัสขวา"
+
+#: ../panels/wacom/gsd-wacom-device.c:1185
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "ปุ่มเปลี่ยนโหมดแถบสัมผัสซ้าย"
+
+#: ../panels/wacom/gsd-wacom-device.c:1187
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "ปุ่มเปลี่ยนโหมดแถบสัมผัสขวา"
+
+#: ../panels/wacom/gsd-wacom-device.c:1192
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "ปุ่มเปลี่ยนโหมด #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1238
+#, c-format
+msgid "Left Button #%d"
+msgstr "ปุ่มซ้าย #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1241
+#, c-format
+msgid "Right Button #%d"
+msgstr "ปุ่มขวา #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1244
+#, c-format
+msgid "Top Button #%d"
+msgstr "ปุ่มบน #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1247
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "ปุ่มล่าง #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "ปุ่มลัดใหม่…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "ไม่ทำสิ่งใด"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "คลิกเมาส์ปุ่มซ้าย"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "คลิกเมาส์ปุ่มกลาง"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "คลิกเมาส์ปุ่มขวา"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "เลื่อนหน้าจอขึ้น"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "เลื่อนหน้าจอลง"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "เลื่อนหน้าจอไปทางซ้าย"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "เลื่อนหน้าจอไปทางขวา"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "ย้อนกลับ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "เดินหน้า"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "ปากกา"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "การรับแรงกดของยางลบ"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "นุ่ม"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "แข็ง"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "ปุ่มบน"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "ปุ่มล่าง"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "การรับแรงกดของปลายปากกา"
+
+#: ../shell/alt/cc-window.c:765 ../shell/cc-window.c:53
+#: ../shell/cc-window.c:1478
+msgid "All Settings"
+msgstr "ค่าตั้งทั้งหมด"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:1
+msgid "GNOME Control Center"
+msgstr "ศูนย์ควบคุมของ GNOME"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:2
+msgid "Utilities to configure the GNOME desktop"
+msgstr "เครื่องมือสำหรับตั้งค่าเดสก์ท็อป GNOME"
+
+#: ../shell/appdata/gnome-control-center.appdata.xml.in.h:3
+msgid ""
+"The control center is GNOME's main interface for configuration of various "
+"aspects of your desktop."
+msgstr "ศูนย์ควบคุมเป็นส่วนติดต่อหลักของ GNOME สำหรับตั้งค่าส่วนต่างๆ ของเดสก์ท็อปของคุณ"
+
+#: ../shell/cc-application.c:45
+msgid "Display version number"
+msgstr "แสดงหมายเลขรุ่น"
+
+#: ../shell/cc-application.c:46
+msgid "Enable verbose mode"
+msgstr "เปิดใช้ข้อความละเอียด"
+
+#: ../shell/cc-application.c:47
+msgid "Show the overview"
+msgstr "แสดงภาพรวม"
+
+#: ../shell/cc-application.c:48
+msgid "Search for the string"
+msgstr "ค้นหาข้อความ"
+
+#: ../shell/cc-application.c:49
+msgid "List possible panel names and exit"
+msgstr "แสดงรายชื่อพาเนลที่เป็นไปได้และออก"
+
+#: ../shell/cc-application.c:50
+msgid "Panel to display"
+msgstr "แผงควบคุมที่จะแสดง"
+
+#: ../shell/cc-application.c:50
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[แผงควบคุม] [อาร์กิวเมนต์…]"
+
+#: ../shell/cc-application.c:113
+msgid "Available panels:"
+msgstr "แผงควบคุมที่มี"
+
+#: ../shell/cc-application.c:252
+msgid "Help"
+msgstr "วิธีใช้"
+
+#: ../shell/cc-application.c:253
+msgid "Quit"
+msgstr "ออก"
+
+#. Add categories
+#: ../shell/cc-window.c:871
+msgctxt "category"
+msgid "Personal"
+msgstr "ส่วนบุคคล"
+
+#: ../shell/cc-window.c:872
+msgctxt "category"
+msgid "Hardware"
+msgstr "ฮาร์ดแวร์"
+
+#: ../shell/cc-window.c:873
+msgctxt "category"
+msgid "System"
+msgstr "ระบบ"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "ปรับแต่ง;ตั้งค่า;"
+
+#: ../shell/help-overlay.ui.h:1
+msgctxt "shortcut window"
+msgid "General"
+msgstr "ทั่วไป"
+
+#: ../shell/help-overlay.ui.h:2
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "ออก"
+
+#: ../shell/help-overlay.ui.h:3
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "ค้นหา"
+
+#: ../shell/help-overlay.ui.h:4
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "พาเนล"
+
+#: ../shell/help-overlay.ui.h:5
+msgctxt "shortcut window"
+msgid "Go back to the overview"
+msgstr "ย้อนกลับไปยังภาพรวม"
+
+#: ../shell/help-overlay.ui.h:6
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "ยกเลิกการค้นหา"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: ../shell/hostname-helper.c:189
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "จุดแพร่สัญญาณ"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr "ปุ่มลัดสำหรับ <b>%s</b> กดปุ่มลัดใหม่เพื่อเปลี่ยนแปลง"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "ถ้าต้องการแก้ไขปุ่มลัด คลิกที่รายการที่ต้องการแล้วกดปุ่มลัดชุดใหม่ หรือกดปุ่ม Backspace "
+#~ "ถ้าต้องการล้างปุ่มลัด"
+
+#~ msgid "Done"
+#~ msgstr "เสร็จสิ้น"
+
+#~ msgid "Color"
+#~ msgstr "สี"
+
+#~ msgid "Time _Zone"
+#~ msgstr "เ_ขตเวลา"
+
+#~ msgid "_Name:"
+#~ msgstr "_ชื่อ:"
+
+#~ msgid "Add Shortcut"
+#~ msgstr "เพิ่มปุ่มลัด"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "ลบปุ่มลัด"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<ปฏิบัติการที่ไม่รู้จัก>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "ไม่สามารถใช้ปุ่มลัด \"%s\" ได้ เพราะจะทำให้ใช้ปุ่มนี้ป้อนข้อความไม่ได้\n"
+#~ "กรุณาใช้ปุ่มอย่าง Control, Alt หรือ Shift ประกอบด้วย"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "ปุ่มลัด \"%s\" ถูกใช้อยู่แล้วสำหรับ\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "ถ้าคุณกำหนดปุ่มลัดนี้ซ้ำให้เป็น \"%s\" ปุ่มลัด \"%s\" ก็จะถูกปิดไป"
+
+#~ msgid "_Reassign"
+#~ msgstr "_กำหนดซ้ำ"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "ปุ่มลัด \"%s\" มีปุ่มลัด \"%s\" ที่เชื่อมโยงกันอยู่ คุณต้องการกำหนดปุ่มลัดดังกล่าวเป็น \"%s\" "
+#~ "โดยอัตโนมัติหรือไม่?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr "ขณะนี้ \"%s\" เชื่อมโยงกับ \"%s\" อยู่ ปุ่มลัดนี้จะถูกปิดถ้าคุณดำเนินการต่อไป"
+
+#~ msgid "_Assign"
+#~ msgstr "_กำหนด"
+
+#~ msgid "Bond"
+#~ msgstr "บอนด์"
+
+#~ msgid "Team"
+#~ msgstr "ทีม"
+
+#~ msgid "Bridge"
+#~ msgstr "บริดจ์"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "ไม่สามารถโหลดปลั๊กอิน VPN"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "เพิ่มการเชื่อมต่อเครือข่าย"
+
+#~ msgid "Bond slaves"
+#~ msgstr "หน่วยลูกของบอนด์"
+
+#~ msgid "(none)"
+#~ msgstr "(ไม่มี)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "หน่วยลูกของบริดจ์"
+
+#~ msgid "Team slaves"
+#~ msgstr "หน่วยลูกของทีม"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "อุปกรณ์ InfiniBand ไม่รองรับโหมดเชื่อมต่อ"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "ไม่ได้เลือกใบรับรองจากองค์กรออกใบรับรอง"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "การไม่ใช้ใบรับรองจากองค์กรออกใบรับรอง (CA) อาจทำให้การเชื่อมต่อไม่นิรภัย "
+#~ "หรือได้พบกับเครือข่าย Wi-Fi ที่ไม่ประสงค์ดี "
+#~ "คุณต้องการเลือกใบรับรองจากองค์กรออกใบรับรองหรือไม่?"
+
+#~ msgid "Ignore"
+#~ msgstr "ไม่สนใจ"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "เลือกใบรับรอง CA"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "_ถามรหัสผ่านทุกครั้ง"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "ไ_ม่ต้องเตือนฉันอีก"
+
+#~ msgid "No"
+#~ msgstr "ไม่"
+
+#~ msgid "Yes"
+#~ msgstr "ใช่"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "เกิดข้อผิดพลาดขณะเข้าระบบด้วยบัญชีนี้"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "ข้อมูลลับหมดอายุแล้ว"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "เข้าระบบเพื่อเปิดใช้บัญชีนี้"
+
+#~ msgid "_Sign In"
+#~ msgstr "เ_ข้าระบบ"
+
+#~ msgid "Power"
+#~ msgstr "พลังงาน"
+
+#~ msgid "Active Jobs"
+#~ msgstr "งานพิมพ์ที่ทำงานอยู่"
+
+#~ msgid "Close"
+#~ msgstr "ปิด"
+
+#~ msgid "Resume Printing"
+#~ msgstr "พิมพ์ต่อ"
+
+#~ msgid "Pause Printing"
+#~ msgstr "พักการพิมพ์"
+
+#~ msgid "Cancel Print Job"
+#~ msgstr "ยกเลิกงานพิมพ์"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "เข้าแถวคอย"
+
+#~ msgid "Job Title"
+#~ msgstr "ชื่องานพิมพ์"
+
+#~ msgid "Job State"
+#~ msgstr "สถานะงานพิมพ์"
+
+#~ msgid "Time"
+#~ msgstr "เวลา"
+
+#~ msgid "Privacy"
+#~ msgstr "ความเป็นส่วนตัว"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "ใช้กำหนดตำแหน่งที่ตั้งทางภูมิศาสตร์ของคุณ"
+
+#~ msgid "Options"
+#~ msgstr "ตัวเลือก"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "อื่นๆ"
+
+#~ msgid "Allow Remote Control"
+#~ msgstr "อนุญาตให้ควบคุมหน้าจอผ่านเครือข่าย"
+
+#~ msgid "Password:"
+#~ msgstr "รหัสผ่าน:"
+
+#~ msgid "_Repeat Keys"
+#~ msgstr "การซ้ำปุ่_มกด"
+
+#~ msgid "_Cursor Blinking"
+#~ msgstr "การกะพริบเ_คอร์เซอร์"
+
+#~ msgid "Zoom"
+#~ msgstr "ซูม"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "สี"
+
+#~ msgid "_Verify"
+#~ msgstr "_ตรวจสอบ"
+
+#~ msgid "Login History"
+#~ msgstr "ประวัติการเข้าระบบ"
+
+#~ msgid "Add User Account"
+#~ msgstr "เพิ่มบัญชีผู้ใช้"
+
+#~ msgid "Remove User Account"
+#~ msgstr "ลบบัญชีผู้ใช้"
+
+#~ msgid "Login Options"
+#~ msgstr "ตัวเลือกของการเข้าระบบ"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "มีผู้ใช้ชื่อ '%s' อยู่ก่อนแล้ว"
+
+#~ msgid "_Delay:"
+#~ msgstr "ร_อ:"
+
+#~ msgid "_Speed:"
+#~ msgstr "ความเ_ร็ว:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "สั้น"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "ช้า"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "ยาว"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "เร็ว"
+
+#~ msgid "S_peed:"
+#~ msgstr "_ความเร็ว:"
+
+#~ msgid "Shortcuts"
+#~ msgstr "ปุ่มลัด"
+
+#~ msgid "For mice and touchpads."
+#~ msgstr "สำหรับเมาส์และทัชแพด"
+
+#~ msgid "Bluetooth is disabled"
+#~ msgstr "บลูทูทถูกปิดใช้งาน"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "ทดสอบค่าตั้งของคุณ"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "ช้า"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "เร็ว"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "ซ้า_ย"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "_ขวา"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "_ความเร็วตัวชี้"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ช้า"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "เร็ว"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "ช้า"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "เร็ว"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "อุปกรณ์ไร้สายต้องการพลังงานเพิ่มพิเศษ"
+
+#~ msgid "No printers available"
+#~ msgstr "ไม่มีเครื่องพิมพ์"
+
+#~ msgid "Add New Printer"
+#~ msgstr "เพิ่มเครื่องพิมพ์"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr "การแบ่งปันบลูทูทช่วยให้คุณแบ่งปันแฟ้มกับอุปกรณ์อื่นที่เปิดใช้บลูทูทได้"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "รับจากอุปกรณ์ที่เชื่อถือเท่านั้น"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "บันทึกแฟ้มที่ได้รับลงในโฟลเดอร์ \"ดาวน์โหลด\""
+
+#~ msgid "Security key"
+#~ msgstr "กุญแจระบบรักษาความปลอดภัย"
+
+#~ msgid "Show help options"
+#~ msgstr "แสดงวิธีใช้ตัวเลือกต่างๆ"
+
+#~ msgid "- Settings"
+#~ msgstr "- ตั้งค่า"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "เรียก '%s --help' เพื่อดูตัวเลือกทั้งหมดที่มีสำหรับบรรทัดคำสั่ง\n"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "เมื่อพลังงานแบตเตอรี่_วิกฤติ"
+
+#~ msgid "Power Off"
+#~ msgstr "ปิดเครื่อง"
+
+#~ msgid "Power off"
+#~ msgstr "ปิดเครื่อง"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "ตั้งค่าอุปกรณ์ชิ้นใหม่"
+
+#~ msgid "Connection"
+#~ msgstr "การเชื่อมต่อ"
+
+#~ msgid "Paired"
+#~ msgstr "จับคู่แล้ว"
+
+#~ msgid "Type"
+#~ msgstr "ชนิด"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "ตั้งค่าเมาส์และทัชแพด"
+
+#~ msgid "Sound Settings"
+#~ msgstr "ตั้งค่าเสียง"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "ตั้งค่าแป้นพิมพ์"
+
+#~ msgid "Send Files…"
+#~ msgstr "ส่งแฟ้ม…"
+
+#~ msgid "Visibility"
+#~ msgstr "ความปรากฏเห็น"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "ความปรากฏเห็นของ “%s”"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "ลบ '%s' ออกจากรายชื่ออุปกรณ์หรือไม่?"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr "ถ้าคุณลบอุปกรณ์นี้ คุณจะต้องตั้งค่าอุปกรณ์ใหม่อีกครั้งก่อนใช้ครั้งต่อไป"
+
+#~ msgid "Device type:"
+#~ msgstr "ชนิดของอุปกรณ์:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "ผู้ผลิต:"
+
+#~ msgid "Model:"
+#~ msgstr "รุ่น:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "คุณสามารถลากแฟ้มอิมเมจมาวางในหน้าต่างนี้ เพื่อเติมข้อมูลด้านบนโดยอัตโนมัติได้"
+
+#~ msgid "United States"
+#~ msgstr "สหรัฐอเมริกา"
+
+#~ msgid "Germany"
+#~ msgstr "เยอรมนี"
+
+#~ msgid "France"
+#~ msgstr "ฝรั่งเศส"
+
+#~ msgid "Spain"
+#~ msgstr "สเปน"
+
+#~ msgid "China"
+#~ msgstr "จีน"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "สลับค่าระหว่าง AM กับ PM"
+
+#~ msgid "Install Updates"
+#~ msgstr "ติดตั้งรุ่นใหม่"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "ระบบเป็นรุ่นใหม่ล่าสุดแล้ว"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "ปรับแต่งเมาส์"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "ปิดขณะ_พิมพ์แป้นพิมพ์"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "บริการเครือข่ายของระบบเข้ากันไม่ได้กับรุ่นนี้"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "เลือกอินเทอร์เฟซที่จะใช้กับบริการใหม่"
+
+#~ msgid "C_reate…"
+#~ msgstr "_สร้าง…"
+
+#~ msgid "_Interface"
+#~ msgstr "_อินเทอร์เฟซ"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "แสดงพาดหัวแบบผุดขึ้น"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "แสดงในหน้าล็อคหน้าจอ"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "แสดงพาดหัวแบบผุดขึ้น"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "แสดงในหน้าล็อคหน้าจอ"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "ความจุของแบตเตอรี่โดยประมาณ: %s"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "ปิดอุปกรณ์ไร้สาย"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "ค้นหาเครื่องพิมพ์ในเครือข่ายหรือกรองผลการค้นหา"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "ป้อนที่อยู่ของเครื่องพิมพ์ หรือป้อนข้อความเพื่อกรองผลการค้นหา"
+
+#~ msgid "_Default"
+#~ msgstr "_ปริยาย"
+
+#~ msgid "Immediately"
+#~ msgstr "ทันที"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "ไม่มี"
+
+#~ msgid "Sorry"
+#~ msgstr "ขออภัย"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "แบ่งปันโฟลเดอร์ \"สาธารณะ\""
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "ใช้ร่วมกับอุปกรณ์ที่เชื่อถือเท่านั้น"
+
+#~ msgid "Shared Folders"
+#~ msgstr "โฟลเดอร์ที่แบ่งปัน"
+
+#~ msgid "column"
+#~ msgstr "คอลัมน์"
+
+#~ msgid "Remove Folder"
+#~ msgstr "ลบโฟลเดอร์"
+
+#~ msgid "Remote View"
+#~ msgstr "การดูหน้าจอผ่านเครือข่าย"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "ตอบรับการเชื่อมต่อทั้งหมด"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "เปลี่ยนภาพถ่ายสำหรับ:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "เลือกรูปภาพสำหรับแสดงที่หน้าจอเข้าระบบของบัญชีนี้"
+
+#~ msgid "Gallery"
+#~ msgstr "ห้องภาพ"
+
+#~ msgid "Take a photograph"
+#~ msgstr "ถ่ายภาพ"
+
+#~ msgid "Browse"
+#~ msgstr "ท่องดู"
+
+#~ msgid "Photograph"
+#~ msgstr "ภาพถ่าย"
+
+#~ msgid "Account Information"
+#~ msgstr "ข้อมูลบัญชี"
+
+#~ msgid "Export"
+#~ msgstr "ส่งออก"
+
+#~ msgid "Left Shift"
+#~ msgstr "Shift ซ้าย"
+
+#~ msgid "Left Alt"
+#~ msgstr "Alt ซ้าย"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "Ctrl ซ้าย"
+
+#~ msgid "Right Shift"
+#~ msgstr "Shift ขวา"
+
+#~ msgid "Right Alt"
+#~ msgstr "Alt ขวา"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl ขวา"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "Alt+Shift ซ้าย"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "Ctrl+Shift ซ้าย"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "Ctrl+Shift ขวา"
+
+#~ msgid "_Region:"
+#~ msgstr "ภูมิ_ภาค:"
+
+#~ msgid "_City:"
+#~ msgstr "เ_มือง:"
+
+#~ msgid "_Network Time"
+#~ msgstr "เวลาเ_ครือข่าย"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "ตั้งเวลาไปข้างหน้าหนึ่งชั่วโมง"
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "ตั้งเวลาถอยหลังหนึ่งชั่วโมง"
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "ตั้งเวลาไปข้างหน้าหนึ่งนาที"
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "ตั้งเวลาถอยหลังหนึ่งนาที"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "ปกติ"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "ตามเข็มนาฬิกา"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 องศา"
+
+#~ msgid "Monitor"
+#~ msgstr "จอภาพ"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "ลากเพื่อเปลี่ยนจอแสดงผลหลัก"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "เลือกจอภาพเพื่อปรับค่า; ลากจอภาพเพื่อจัดวางตำแหน่งใหม่"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "ไม่สามารถบันทึกค่าตั้งของจอภาพ"
+
+#~ msgid "_Resolution"
+#~ msgstr "ความ_ละเอียด"
+
+#~ msgid "R_otation"
+#~ msgstr "การ_หมุน"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "จอแสดงผลแสดงเห_มือนกัน"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "หมายเหตุ: อาจทำให้เลือกความละเอียดได้จำกัด"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "_ตรวจหาจอแสดงผล"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "ช้า"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "เร็ว"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "เ_นื้อหาเลื่อนไปตามนิ้ว"
+
+#~ msgid "_Options…"
+#~ msgstr "_ตัวเลือก…"
+
+#~ msgid "Hidden"
+#~ msgstr "ซ่อน"
+
+#~ msgid "Visible"
+#~ msgstr "มองเห็น"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "ชื่อ & ความปรากฏเห็น"
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "แสดงชื้อเ_ต็มในแถบด้านบน"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "แสดงชื่อเต็มใน_ล็อคหน้าจอ"
+
+#~ msgid "No shortcut set"
+#~ msgstr "ไม่มีการกำหนดปุ่มลัด"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "ปกติ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "สูง/กลับสี"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "แป้นพิมพ์บนจอ"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "ปกติ"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "ใหญ่มาก"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "ส่งเสียงบี๊บเมื่อกด Caps Lock หรือ Num Lock"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "เปิดหรือปิด:"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "ซูม"
+
+#~ msgid "Zoom in:"
+#~ msgstr "ซูมเข้า:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "ซูมออก:"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "การแสดงคำบรรยายประกอบ"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "แสดงคำบรรยายเป็นตัวอักษรสำหรับเสียงพูดและเสียงต่างๆ"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "สั้น"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "ยาว"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "ส่งเสียงบี๊บเมื่อปุ่ม"
+
+#~ msgid "pressed"
+#~ msgstr "ถูกกด"
+
+#~ msgid "accepted"
+#~ msgstr "ถูกรับ"
+
+#~ msgid "rejected"
+#~ msgstr "ถูกปฏิเสธ"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "เวลาหน่วงก่อน_รับ:"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "ควบคุมตัวชี้เมาส์ด้วยแป้นกดเลข"
+
+#~ msgid "Video Mouse"
+#~ msgstr "เมาส์วีดิทัศน์"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "ควบคุมตัวชี้เมาส์ด้วยกล้องวีดิทัศน์"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "เล็ก"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "ใหญ่"
+
+#~ msgid "Add account"
+#~ msgstr "เพิ่มบัญชี"
+
+#~ msgid "_Local Account"
+#~ msgstr "บัญชีใ_นเครื่อง"
+
+#~ msgid "_Login Name"
+#~ msgstr "ชื่อเ_ข้าระบบ"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "คำแนะนำ: ชื่อโดเมนหรือ realm ขององค์กร"
+
+#~ msgid "C_ontinue"
+#~ msgstr "ทำ_ต่อไป"
+
+#~ msgid "Previous Week"
+#~ msgstr "สัปดาห์ก่อนหน้า"
+
+#~ msgid "Next Week"
+#~ msgstr "สัปดาห์หน้า"
+
+#~ msgid "Next week"
+#~ msgstr "สัปดาห์หน้า"
+
+#~ msgid "Log in without a password"
+#~ msgstr "เข้าระบบโดยไม่ใช้รหัสผ่าน"
+
+#~ msgid "Disable this account"
+#~ msgstr "ระงับบัญชีนี้"
+
+#~ msgid "Enable this account"
+#~ msgstr "เปิดใช้บัญชีนี้"
+
+#~ msgid "C_onfirm password"
+#~ msgstr "ยื_นยันรหัสผ่าน"
+
+#~ msgid "Generate a password"
+#~ msgstr "สุ่มรหัสผ่าน"
+
+#~ msgid "_Action"
+#~ msgstr "_การกระทำ"
+
+#~ msgid "_Show password"
+#~ msgstr "แ_สดงรหัสผ่าน"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr ""
+#~ "<a href=\"http://www.bu.ac.th/hotnews/apr_june46/password/"
+#~ "\">การตั้งรหัสผ่านให้ถูกวิธี</a>"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "สั้นเกินไป"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "ยังไม่ดีเท่าที่ควร"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "หละหลวม"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "พอใช้"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "ดี"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "แน่นหนา"
+
+#~ msgid "_Generate a password"
+#~ msgstr "สุ่_มรหัสผ่าน"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "คุณต้องป้อนรหัสผ่านใหม่ที่จะตั้ง"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "คุณต้องป้อนรหัสผ่านที่ตั้งใหม่อีกครั้งเพื่อยืนยัน"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "คุณต้องป้อนรหัสผ่านปัจจุบันของคุณ"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "รหัสผ่านปัจจุบันที่ป้อนไม่ถูกต้อง"
+
+#~ msgid "Switch Modes"
+#~ msgstr "สลับโหมด"
+
+#~ msgid "Action"
+#~ msgstr "การกระทำ"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "Alt+Shift ขวา"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "Shift ซ้าย+ขวา"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "Ctrl ซ้าย+ขวา"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "Change the background"
+#~ msgstr "เปลี่ยนพื้นหลังของพื้นโต๊ะ"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "ตั้งค่าบลูทูท"
+
+#~ msgid "Browse Files..."
+#~ msgstr "ท่องดูแฟ้ม..."
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "บลูทูท"
+
+#~ msgid "Create virtual device"
+#~ msgstr "สร้างอุปกรณ์เสมือน"
+
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "โพรไฟล์ที่มีสำหรับจอแสดงผล"
+
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "โพรไฟล์ที่มีสำหรับสแกนเนอร์"
+
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "โพรไฟล์ที่มีสำหรับเครื่องพิมพ์"
+
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "โพรไฟล์ที่มีสำหรับกล้องถ่ายรูป"
+
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "โพรไฟล์ที่มีสำหรับเว็บแคม"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i ปี"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i เดือน"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i สัปดาห์"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "น้อยกว่า 1 สัปดาห์"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "อุปกรณ์นี้ไม่มีการจัดการเรื่องสี"
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "อุปกรณ์นี้กำลังใช้ค่ามาตรฐานจากโรงงาน"
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr "อุปกรณ์นี้ไม่มีโพรไฟล์ที่เหมาะสมสำหรับการปรับค่าสีทั้งหน้าจอ"
+
+#~ msgid "Not specified"
+#~ msgstr "ไม่ระบุ"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "ตรวจไม่พบอุปกรณ์ใดที่รองรับการจัดการสี"
+
+#~ msgid "Add device"
+#~ msgstr "เพิ่มอุปกรณ์"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "เพิ่มอุปกรณ์เสมือน"
+
+#~ msgid "Remove a device"
+#~ msgstr "ลบอุปกรณ์ออก"
+
+#~ msgid "Color management settings"
+#~ msgstr "ตั้งค่าการจัดการสี"
+
+#~ msgid "English"
+#~ msgstr "อังกฤษ"
+
+#~ msgid "British English"
+#~ msgstr "อังกฤษบริติช"
+
+#~ msgid "German"
+#~ msgstr "เยอรมัน"
+
+#~ msgid "French"
+#~ msgstr "ฝรั่งเศส"
+
+#~ msgid "Spanish"
+#~ msgstr "สเปน"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "จีน (ตัวย่อ)"
+
+#~ msgid "Russian"
+#~ msgstr "รัสเซีย"
+
+#~ msgid "Arabic"
+#~ msgstr "อารบิก"
+
+#~ msgid "Select a region"
+#~ msgstr "เลือกภูมิภาค"
+
+#~ msgid "Unspecified"
+#~ msgstr "ไม่ระบุ"
+
+#~ msgid "Select a language"
+#~ msgstr "เลือกภาษา"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "แผงปรับแต่งวันที่และเวลา"
+
+#~ msgid "Unknown model"
+#~ msgstr "ไม่ทราบรุ่น"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr "การเข้าระบบครั้งหน้าจะพยายามใช้เดสก์ท็อปแบบมาตรฐาน"
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr "การเข้าระบบครั้งหน้าจะใช้โหมดสำรองสำหรับการ์ดจอที่ไม่รองรับ"
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "สำรอง"
+
+#~ msgid "System Information"
+#~ msgstr "ข้อมูลเกี่ยวกับระบบ"
+
+#~ msgid "OS type"
+#~ msgstr "ชนิด OS"
+
+#~ msgid "_Other Media..."
+#~ msgstr "สื่อ_อื่นๆ..."
+
+#~ msgid "Experience"
+#~ msgstr "รูปแบบเดสก์ท็อป"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "บังคับใช้โหมด_สำรอง"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "ตั้งค่าแป้นพิมพ์"
+
+#~ msgid "Layout Settings"
+#~ msgstr "ตั้งค่าผังแป้นพิมพ์"
+
+#~ msgid "Network settings"
+#~ msgstr "ตั้งค่าเครือข่าย"
+
+#~ msgid "Network;Wireless;IP;LAN;Proxy;"
+#~ msgstr "เครือข่าย;ไร้สาย;ไอพี;แลน;พร็อกซี;"
+
+#~ msgid "Out of range"
+#~ msgstr "อยู่นอกรัศมี"
+
+#~ msgid "_Options..."
+#~ msgstr "_ตัวเลือก..."
+
+#~ msgid "C_reate..."
+#~ msgstr "_สร้าง..."
+
+#~ msgid "Wireless Hotspot"
+#~ msgstr "จุดแพร่_สัญญาณไร้สาย"
+
+#~ msgid "Wireless"
+#~ msgstr "ไร้สาย"
+
+#~ msgid "_Disconnect"
+#~ msgstr "_ตัดการเชื่อมต่อ"
+
+#~ msgid "_Connect"
+#~ msgstr "เ_ชื่อมต่อ"
+
+#~ msgid "Disconnected"
+#~ msgstr "ตัดการเชื่อมต่อแล้ว"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "ผู้ให้บริการ/การเชื่อมสายเปลี่ยนไป"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "ข้อมูลลับหมดอายุแล้ว กรุณาเข้าระบบใหม่อีกครั้ง"
+
+#~ msgid "_Log In"
+#~ msgstr "เ_ข้าระบบ"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "จัดการบัญชีออนไลน์"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "ระวัง แบตเตอรี่เหลือไฟต่ำ อีก %s จะหมด"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "กำลังใช้ไฟจากแบตเตอรี่ - ใช้ได้อีก %s"
+
+#~ msgid "Using battery power"
+#~ msgstr "กำลังใช้ไฟจากแบตเตอรี่"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "กำลังประจุไฟ - เต็มแล้ว"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "กำลังใช้ไฟจาก UPS - ใช้ได้อีก %s"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "ระวัง UPS เหลือไฟต่ำ"
+
+#~ msgid "Using UPS power"
+#~ msgstr "กำลังใช้ไฟจาก UPS"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "แบตเตอรี่สำรองของคุณประจุไฟเต็มแล้ว"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "แบตเตอรี่สำรองของคุณไม่มีประจุไฟเหลืออยู่"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "กำลังประจุไฟ - เต็มแล้ว"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr "คำแนะนำ: <a href=\"screen\">ความสว่างของจอ</a> มีผลกับปริมาณการใช้พลังงาน"
+
+#~ msgid "Power management settings"
+#~ msgstr "ตั้งค่าการจัดการพลังงาน"
+
+#~ msgid "Don't suspend"
+#~ msgstr "ไม่ต้องพักเครื่อง"
+
+#~ msgid "Suspend when inactive for"
+#~ msgstr "พักเครื่องเมื่อไม่มีการใช้งานเป็นเวลา"
+
+#~ msgid "Change printer settings"
+#~ msgstr "ตั้งค่าเครื่องพิมพ์"
+
+#~ msgid "Manufacturers"
+#~ msgstr "ผู้ผลิต"
+
+#~ msgid "Drivers"
+#~ msgstr "ไดรเวอร์"
+
+#~ msgid "_Show"
+#~ msgstr "แ_สดง"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "เปลี่ยนค่าตั้งเกี่ยวกับภูมิภาคและภาษาของคุณ"
+
+#~ msgid "Select an input source to add"
+#~ msgstr "เลือกช่องทางป้อนข้อความที่จะเพิ่ม"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr "หน้าจอเข้าระบบ บัญชีระบบ และบัญชีผู้ใช้ใหม่ จะใช้ค่าตั้งภูมิภาคและภาษาโดยรวมของระบบ"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "หน้าจอเข้าระบบ บัญชีระบบ และบัญชีผู้ใช้ใหม่ จะใช้ค่าตั้งภูมิภาคและภาษาโดยรวมของระบบ "
+#~ "คุณอาจเปลี่ยนค่าตั้งของระบบให้ตรงกับที่คุณใช้ก็ได้"
+
+#~ msgid "Copy Settings"
+#~ msgstr "คัดลอกค่าตั้ง"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "คัดลอกค่าตั้ง..."
+
+#~ msgid "Region and Language"
+#~ msgstr "ภูมิภาคและภาษา"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr "เลือกภาษาของการแสดงผล (การเปลี่ยนแปลงจะเริ่มมีผลเมื่อคุณเข้าระบบครั้งหน้า)"
+
+#~ msgid "Add Language"
+#~ msgstr "เพิ่มภาษา"
+
+#~ msgid "Remove Language"
+#~ msgstr "ลบภาษา"
+
+#~ msgid "Install languages..."
+#~ msgstr "ติดตั้งภาษา..."
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "เลือกภูมิภาค (การเปลี่ยนแปลงจะเริ่มมีผลเมื่อคุณเข้าระบบครั้งหน้า)"
+
+#~ msgid "Add Region"
+#~ msgstr "เพิ่มภูมิภาค"
+
+#~ msgid "Currency"
+#~ msgstr "สกุลเงิน"
+
+#~ msgid "Examples"
+#~ msgstr "ตัวอย่าง"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "เลือกแป้นพิมพ์หรือช่องทางป้อนข้อความอื่นๆ"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "ตั้งค่าปุ่มลัด"
+
+#~ msgid "Display language:"
+#~ msgstr "ภาษาข้อความ:"
+
+#~ msgid "Input source:"
+#~ msgstr "ช่องทางป้อนข้อความ:"
+
+#~ msgid "Format:"
+#~ msgstr "รูปแบบ:"
+
+#~ msgid "Your settings"
+#~ msgstr "ค่าตั้งของคุณ"
+
+#~ msgid "System settings"
+#~ msgstr "ค่าตั้งระบบ"
+
+#~ msgid "Brightness & Lock"
+#~ msgstr "ความสว่าง & การล็อค"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "ตั้งค่าความสว่างและการล็อคหน้าจอ"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "ความสว่าง;ล็อค;หรี่;จอเปล่า;จอภาพ;"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "ห_รี่จอภาพเพื่อประหยัดพลังงาน"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "ไม่ต้องล็อคเมื่ออยู่บ้าน"
+
+#~ msgid "Locations..."
+#~ msgstr "สถานที่..."
+
+#~ msgid "Lock"
+#~ msgstr "ล็อค"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "เปิดใช้โค้ดส่วนดีบั๊ก"
+
+#~ msgid "Version of this application"
+#~ msgstr "รุ่นของโปรแกรมนี้"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — แอพเพล็ตปรับความดังเสียงของ GNOME"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "แสดงเครื่องมือปรับความดังเสียงของเดสก์ท็อป"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "ความดังของเสียงออก"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "ความดังของไมโครโฟน"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "ไม่สามารถเปิดเครื่องมือปรับแต่งเกี่ยวกับเสียง: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "ปิ_ดเสียง"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "ปรับแต่งเ_สียง"
+
+#~ msgid "Muted"
+#~ msgstr "ปิดเสียงอยู่"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "ปรับแต่งการเข้าถึงหลากหลาย"
+
+#~ msgid "Options..."
+#~ msgstr "ตัวเลือก..."
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "Color"
+#~ msgstr "สี"
+
+#~ msgctxt "Zoom Grayscale"
+#~ msgid "None"
+#~ msgstr "ไม่มีสี"
+
+#~ msgid "User Accounts"
+#~ msgstr "บัญชีผู้ใช้"
+
+#~ msgid "_Hint"
+#~ msgstr "คำใ_บ้"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "คำใบ้นี้อาจแสดงในหน้าจอเข้าระบบ และจะปรากฏต่อผู้ใช้ทั้งหมดในระบบนี้ <b>อย่า</"
+#~ "b>ใส่รหัสผ่านไว้ในนี้"
+
+#~ msgid "Fair"
+#~ msgstr "พอใช้"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "ท่องดูรูปภาพเพิ่มเติม..."
+
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "ไม่มีมีผู้ใช้ชื่อ '%s'"
+
+#~ msgid "This user does not exist."
+#~ msgstr "ไม่มีผู้ใช้นี้"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "ปรับแต่งค่าตั้งสำหรับแท็บเล็ต Wacom"
+
+#~ msgid "Map Buttons..."
+#~ msgstr "กำหนดปุ่ม..."
+
+#~ msgid "Calibrate..."
+#~ msgstr "เทียบมาตรฐาน..."
+
+#~ msgid "- System Settings"
+#~ msgstr "- ตั้งค่าระบบ"
+
+#~ msgid "System Settings"
+#~ msgstr "ตั้งค่าระบบ"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "เพิ่มภาพพื้นหลัง"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "ลบภาพพื้นหลังออก"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "ไล่ระดับสีแนวนอน"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "ไล่ระดับสีแนวตั้ง"
+
+#~ msgid "Solid Color"
+#~ msgstr "สีล้วน"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "สี & การไล่ระดับสี"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr "ไม่สามารถอ่านบัสของวาระขณะเริ่มใช้ค่าตั้งของจอแสดงผล"
+
+#~ msgid "Acti_on:"
+#~ msgstr "_ปฏิบัติการ:"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "จับภาพหน้าจอ"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "ความเร่_ง:"
+
+#~ msgid "Drag Threshold"
+#~ msgstr "ระยะเริ่มลาก"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "การลากวาง"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "เปิดใช้การคลิ_กเมาส์ด้วยทัชแพด"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "แ_สดงตำแหน่งของตัวชี้เมื่อกดปุ่ม Control"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "_ระยะเริ่มลาก:"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "ทดสอบค่าตั้งของคุณได้ โดยลองดับเบิลคลิกที่รูปหน้า"
+
+#~ msgid "_Disabled"
+#~ msgstr "ไ_ม่ใช้"
+
+#~ msgid "_Left-handed"
+#~ msgstr "เ_มาส์มือซ้าย"
+
+#~ msgid "_Right-handed"
+#~ msgstr "เมาส์มือ_ขวา"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_ความตอบสนอง:"
+
+#~ msgid "_Timeout:"
+#~ msgstr "_ภายใน:"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "อื่นๆ..."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "จะสร้างจุดแพร่สัญญาณต่อไปหรือไม่?"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "จะตัดการเชื่อมต่อกับ %s แล้วสร้างจุดแพร่สัญญาณอันใหม่หรือไม่?"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "นี่เป็นช่องทางเชื่อมต่ออินเทอร์เน็ตเพียงช่องทางเดียวของคุณ"
+
+#~ msgid "Disable VPN"
+#~ msgstr "ปิดใช้งาน VPN"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "แมสก์เครือข่ายย่อย"
+
+#~ msgid "Unlock"
+#~ msgstr "ปลดล็อค"
+
+#~ msgid "_Network Name"
+#~ msgstr "_ชื่อเครือข่าย"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "ปิ_ดจุดแพร่สัญญาณ..."
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "กรุณาเลือกชนิดของบัญชีที่จะเพิ่ม"
+
+#~ msgid "_Add..."
+#~ msgstr "เ_พิ่ม..."
+
+#~ msgid "Select an account"
+#~ msgstr "เลือกบัญชี"
+
+#~ msgid "Battery charging"
+#~ msgstr "แบตเตอรี่กำลังประจุไฟ"
+
+#~ msgid "Battery discharging"
+#~ msgstr "แบตเตอรี่กำลังจ่ายไฟ"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "อีก %s จะเต็ม (%.01f%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "อีก %s จะหมด (%.01f%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "ประจุไฟ %.0lf%%"
+
+#~ msgid "_Search by Address"
+#~ msgstr "_ค้นหาจากที่อยู่"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD ไม่ได้ทำงานอยู่ การตรวจหาเครื่องพิมพ์ในเครือข่ายต้องเปิดทางให้กับบริการ mdns, "
+#~ "ipp, ipp-client และ samba-client ที่ไฟร์วอลล์ด้วย"
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "ต่อตรง"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "เครือข่าย"
+
+#~ msgid "Device types"
+#~ msgstr "ชนิดของอุปกรณ์"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "กำลังเปิดไฟร์วอลล์สำหรับการเชื่อมต่อ mDNS"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "กำลังเปิดไฟร์วอลล์สำหรับการเชื่อมต่อ Samba"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "กำลังเปิดไฟร์วอลล์สำหรับการเชื่อมต่อ IPP"
+
+#~ msgid "_Back"
+#~ msgstr "_ย้อนกลับ"
+
+#~ msgid "Add Layout"
+#~ msgstr "เพิ่มผังแป้นพิมพ์"
+
+#~ msgid "Layouts"
+#~ msgstr "ผังแป้นพิมพ์"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "หน้าต่างเปิดใหม่ใช้ผังแป้นพิมพ์ปริยาย"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "หน้าต่างเปิดใหม่ใช้ผังแป้นพิมพ์เหมือนหน้าต่างก่อนหน้า"
+
+#~ msgid "Preview Layout"
+#~ msgstr "ดูตัวอย่างผังแป้นพิมพ์"
+
+#~ msgid "Remove Layout"
+#~ msgstr "ลบผังแป้นพิมพ์"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "แทนที่ค่าตั้งผังแป้นพิมพ์ปัจจุบัน\n"
+#~ "ด้วยค่าปริยาย"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "_กลับไปใช้ค่าปริยาย"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "แสดงและแก้ไขตัวเลือกสำหรับผังแป้นพิมพ์"
+
+#~ msgid "Layout"
+#~ msgstr "ผังแป้นพิมพ์"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "เ_ลือกอุปกรณ์ที่จะตั้งค่า:"
+
+#~ msgid "Change contrast:"
+#~ msgstr "เปลี่ยนความต่างระดับสี:"
+
+#~ msgid "Decrease size:"
+#~ msgstr "ลดขนาด:"
+
+#~ msgid "Increase size:"
+#~ msgstr "เพิ่มขนาด:"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "ลองพิมพ์ที่นี่เพื่อทดสอบ"
+
+#~ msgid "_Text size:"
+#~ msgstr "_ขนาดตัวอักษร:"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "การแสดงผล"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "ซูม"
+
+#~ msgid "Centered"
+#~ msgstr "วางตรงกลาง"
+
+#~ msgid "Show"
+#~ msgstr "แสดง"
+
+#~ msgid "Cr_eate"
+#~ msgstr "_สร้าง"
+
+#~ msgid "Create new account"
+#~ msgstr "สร้างบัญชีผู้ใช้ใหม่"
+
+#~ msgid "_Account Type"
+#~ msgstr "_ชนิดของบัญชี"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "เลือกรหัสผ่านจากการสุ่ม"
+
+#~ msgid "Account _type"
+#~ msgstr "_ชนิดของบัญชี"
+
+#~ msgid "More choices..."
+#~ msgstr "เลือกเพิ่มเติม..."
+
+#~ msgid "Wacom Graphics Tablet"
+#~ msgstr "แท็บเล็ตกราฟิกส์ Wacom"
+
+#~ msgid "System Info"
+#~ msgstr "ข้อมูลระบบ"
+
+#~ msgid "_Photos:"
+#~ msgstr "_ภาพถ่าย:"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "เปิด/ปิดความต่างระดับสี"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "เปิด/ปิดแว่นขยาย"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "เปิด/ปิดโปรแกรมอ่านหน้าจอ"
+
+#~ msgid "Accelerator key"
+#~ msgstr "ปุ่มลัด"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "ปุ่มประกอบปุ่มลัด"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "รหัสปุ่มของปุ่มลัด"
+
+#~ msgid "Accel Mode"
+#~ msgstr "โหมดของปุ่มลัด"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "ชนิดของปุ่มลัด"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "ปุ่มลัดที่กำหนดเองมีมากเกินไป"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "สื่อและ Autorun"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "ตั้งค่าสื่อและ autorun"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "ซีดี;ดีวีดี;usb;เพลง;ภาพยนตร์;วีดิทัศน์;แผ่น;"
+
+#~ msgid "Ask me"
+#~ msgstr "ถาม"
+
+#~ msgid "Shutdown"
+#~ msgstr "ปิดเครื่อง"
+
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr "จะแสดงเฉพาะโพรไฟล์ที่เข้ากันได้กับอุปกรณ์เท่านั้น"
+
+#~ msgid "_Turn off after:"
+#~ msgstr "ปิ_ดหลังจาก:"
+
+#~ msgid "Mute"
+#~ msgstr "ปิดเสียง"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "คีย์ของ GConf ที่เครื่องมือแก้ไขคุณสมบัตินี้แนบอยู่ด้วย"
+
+#~ msgid "Callback"
+#~ msgstr "เรียกกลับ"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr "ใช้การเรียกกลับหากค่าที่ติดกับคีย์เปลี่ยนไป"
+
+#~ msgid "Change set"
+#~ msgstr "ชุดการเปลี่ยนแปลง"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "ชุดการเปลี่ยนแปลงของ GConf ซึ่งเก็บข้อมูลที่จะส่งต่อไปยังไคลเอนต์ของ gconf เมื่อจะเริ่มใช้"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "การแปลงค่าเป็น callback ของวิดเจ็ต"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr "callback จะถูกกำหนดขึ้นเวลาข้อมูลถูกแปลงจาก GConf ไปเป็นวิดเจ็ต"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "การแปลงจากค่า callback ของวิดเจ็ต"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr "callback จะถูกกำหนดขึ้นเวลาข้อมูลถูกแปลงจากวิดเจ็ตไปเป็น GConf"
+
+#~ msgid "UI Control"
+#~ msgstr "ตัวควบคุม UI"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "วัตถุที่ทำหน้าที่ควบคุมคุณสมบัติ (โดยปกติจะเป็นวิดเจ็ต)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "ข้อมูลของวัตถุเครื่องมือแก้ไขคุณสมบัติ"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "ข้อมูลกำหนดเองที่ต้องใช้สำหรับเครื่องมือแก้ไขคุณสมบัติ"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "callback เมื่อปล่อยข้อมูลของเครื่องมือแก้ไขคุณสมบัติ"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr "callback ที่จะเรียกเมื่อข้อมูลของเครื่องมือแก้ไขคุณสมบัติจะถูกปล่อย"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "ไม่พบแฟ้ม '%s'\n"
+#~ "\n"
+#~ "กรุณาตรวจดูว่าภาพนี้มีอยู่จริงแล้วลองใหม่ หรือเลือกภาพพื้นหลังอื่น"
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "ไม่รู้จักชนิดของแฟ้ม '%s'\n"
+#~ "แฟ้มอาจจะเป็นรูปภาพชนิดที่โปรแกรมยังไม่รองรับ\n"
+#~ "\n"
+#~ "กรุณาเลือกภาพอื่น"
+
+#~ msgid "Please select an image."
+#~ msgstr "กรุณาเลือกภาพที่จะใช้"
+
+#~ msgid "Create a user"
+#~ msgstr "สร้างบัญชีผู้ใช้"
+
+#~ msgid "Upside-down"
+#~ msgstr "กลับหัว"
+
+#~ msgid "On AC _power:"
+#~ msgstr "เมื่อใช้ไ_ฟ AC:"
+
+#~ msgid "Put the computer to sleep when inactive:"
+#~ msgstr "ให้เครื่องหลับเมื่อไม่มีการใช้งาน:"
+
+#~ msgid "Locked"
+#~ msgstr "ล็อคอยู่"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "กล่องโต้ตอบไม่ได้ล็อคไว้\n"
+#~ "คลิกเพื่อล็อคป้องกันการแก้ไข"
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "กล่องโต้ตอบถูกล็อคอยู่\n"
+#~ "คลิกเพื่อเริ่มแก้ไข"
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "นโยบายของระบบได้ป้องกันการเปลี่ยนแปลงไว้\n"
+#~ "กรุณาติดต่อผู้ดูแลระบบของคุณ"
+
+#~ msgid "24-Hour Time"
+#~ msgstr "เวลาแบบ 24 ชั่วโมง"
+
+#~ msgid "Photos"
+#~ msgstr "ภาพถ่าย"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "ใช้ผังแป้นพิมพ์ปริยายในหน้าต่างใหม่"
+
+#~ msgid "Use previous window's layout in new windows"
+#~ msgstr "ใช้ผังแป้นพิมพ์ของหน้าต่างก่อนหน้าในหน้าต่างใหม่"
+
+#~ msgid "When the sleep button is pressed:"
+#~ msgstr "เมื่อกดปุ่มหลับเครื่อง:"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "แป้นพิมพ์;เมาส์;สิ่งอำนวยความสะดวก;"
+
+#~ msgid "Current network location"
+#~ msgstr "สถานที่เครือข่ายปัจจุบัน"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "URL สำหรับภาพพื้นหลังเพิ่มเติม"
+
+#~ msgid "More themes URL"
+#~ msgstr "URL สำหรับชุดตกแต่งเพิ่มเติม"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "กำหนดค่านี้เป็นชื่อสถานที่ปัจจุบันของคุณ ค่านี้จะใช้พิจารณาค่าที่เหมาะสมสำหรับพร็อกซีเครือข่าย"
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr "URL สำหรับหาภาพพื้นหลังพื้นโต๊ะเพิ่มเติม ถ้ากำหนดเป็นข้อความว่าง ก็จะไม่แสดงลิงก์"
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr "URL สำหรับหาชุดตกแต่งเดสก์ท็อปเพิ่มเติม ถ้ากำหนดเป็นข้อความว่าง ก็จะไม่แสดงลิงก์"
+
+#~ msgid "12 hour format"
+#~ msgstr "แบบ AM/PM"
+
+#~ msgid "24 hour format"
+#~ msgstr "แบบ 24 ชั่วโมง"
+
+#~ msgid "Preferred Applications"
+#~ msgstr "เลือกโปรแกรมหลักๆ"
+
+#~ msgid "Start the preferred visual assistive technology"
+#~ msgstr "เรียกโปรแกรมอำนวยความสะดวกสำหรับสายตาที่กำหนดไว้"
+
+#~ msgid "Visual Assistance"
+#~ msgstr "สิ่งอำนวยความสะดวกสำหรับสายตา"
+
+#~ msgid "Error setting default browser: %s"
+#~ msgstr "เกิดข้อผิดพลาดขณะกำหนดเบราว์เซอร์ปริยาย: %s"
+
+#~ msgid "Error setting default mailer: %s"
+#~ msgstr "เกิดข้อผิดพลาดขณะกำหนดโปรแกรมรับส่งเมลปริยาย: %s"
+
+#~ msgid "Please make sure that the applet is properly installed"
+#~ msgstr "กรุณาตรวจสอบการติดตั้งแอพเพล็ตว่าเรียบร้อยดีหรือไม่"
+
+#~ msgid "All %s occurrences will be replaced with actual link"
+#~ msgstr "ข้อความ '%s' ทั้งหมดจะถูกแทนด้วยลิงก์จริง"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "_คำสั่ง:"
+
+#~ msgid "E_xecute flag:"
+#~ msgstr "_ตัวเลือกเพิ่มเติม:"
+
+#~ msgid "Instant Messenger"
+#~ msgstr "ข้อความทันใจ"
+
+#~ msgid "Mail Reader"
+#~ msgstr "โปรแกรมอ่านเมล"
+
+#~ msgid "Mobility"
+#~ msgstr "อุปกรณ์พกพา"
+
+#~ msgid "Run at st_art"
+#~ msgstr "เรียกเมื่อเ_ข้าระบบ"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "เรียกใช้ในเทอร์_มินัล"
+
+#~ msgid "Terminal Emulator"
+#~ msgstr "โปรแกรมจำลองเทอร์มินัล"
+
+#~ msgid "Text Editor"
+#~ msgstr "เครื่องมือแก้ไขข้อความ"
+
+#~ msgid "Visual"
+#~ msgstr "ด้านการมองเห็น"
+
+#~ msgid "_Run at start"
+#~ msgstr "เ_รียกเมื่อเข้าระบบ"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "โปรแกรมเล่นเพลง Banshee"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "เทอร์มินัลปริยายของเดเบียน"
+
+#~ msgid "GNOME Magnifier without Screen Reader"
+#~ msgstr "แว่นขยายของ GNOME ซึ่งไม่มีโปรแกรมอ่านหน้าจอ"
+
+#~ msgid "GNOME OnScreen Keyboard"
+#~ msgstr "แป้นพิมพ์บนจอของ GNOME"
+
+#~ msgid "GNOME Terminal"
+#~ msgstr "เทอร์มินัลของ GNOME"
+
+#~ msgid "KDE Magnifier without Screen Reader"
+#~ msgstr "แว่นขยายของ KDE ซึ่งไม่มีโปรแกรมอ่านหน้าจอ"
+
+#~ msgid "Linux Screen Reader"
+#~ msgstr "โปรแกรมอ่านหน้าจอสำหรับลินุกซ์"
+
+#~ msgid "Linux Screen Reader with Magnifier"
+#~ msgstr "โปรแกรมอ่านหน้าจอสำหรับลินุกซ์ พร้อมแว่นขยาย"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "โปรแกรมเล่นเพลง Muine"
+
+#~ msgid "Orca with Magnifier"
+#~ msgstr "Orca พร้อมแว่นขยาย"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "โปรแกรมเล่นเพลง Rhythmbox"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "เทอร์มินัลปกติของ X"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "โปรแกรมเล่นภาพยนตร์ Totem"
+
+#~ msgid "Upside Down"
+#~ msgstr "กลับหัว"
+
+#~ msgid "Desktop"
+#~ msgstr "เดสก์ท็อป"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s"
+#~ msgstr "เกิดข้อผิดพลาดขณะลบปุ่มลัดออกจากฐานข้อมูลค่าปรับแต่ง: %s"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "รุ่_นแป้นพิมพ์:"
+
+#~ msgid "Move the selected keyboard layout down in the list"
+#~ msgstr "เลื่อนลำดับในรายชื่อของผังแป้นพิมพ์ที่เลือกลง"
+
+#~ msgid "Move the selected keyboard layout up in the list"
+#~ msgstr "เลื่อนลำดับในรายชื่อของผังแป้นพิมพ์ที่เลือกขึ้น"
+
+#~ msgid "Print a diagram of the selected keyboard layout"
+#~ msgstr "แสดงแผนผังของผังแป้นพิมพ์ที่เลือก"
+
+#~ msgid "Remove the selected keyboard layout from the list"
+#~ msgstr "ลบผังแป้นพิมพ์ที่เลือกออกจากรายชื่อ"
+
+#~ msgid "Select a keyboard layout to be added to the list"
+#~ msgstr "เลือกผังแป้นพิมพ์ที่จะเพิ่มเข้าในรายชื่อ"
+
+#~ msgid "_Pointer can be controlled using the keypad"
+#~ msgstr "เ_ปิดใช้การบังคับตัวชี้เมาส์ด้วยแป้นกดเลข"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "ลองพิมพ์เพื่อ_ทดสอบ:"
+
+#~ msgid "By _country"
+#~ msgstr "ตาม_ประเทศ"
+
+#~ msgid "_Country:"
+#~ msgstr "ประเ_ทศ:"
+
+#~ msgid "_Variants:"
+#~ msgstr "แ_บบย่อย:"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "เลือกรุ่นแป้นพิมพ์"
+
+#~ msgid "_Models:"
+#~ msgstr "รุ่_นแป้นพิมพ์:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "ผู้_จำหน่าย:"
+
+#~ msgid "Vendors"
+#~ msgstr "ผู้จำหน่าย"
+
+#~ msgid "Choose type of click _beforehand"
+#~ msgstr "เลือกชนิดของการคลิกไว้_ล่วงหน้า"
+
+#~ msgid "Choose type of click with mo_use gestures"
+#~ msgstr "เลือกชนิดของการคลิกด้วยท่า_ขยับเมาส์"
+
+#~ msgid "D_rag click:"
+#~ msgstr "คลิกเ_พื่อลาก:"
+
+#~ msgid "Dwell Click"
+#~ msgstr "การคลิกด้วยการวางแช่"
+
+#~ msgid "Show click type _window"
+#~ msgstr "แสดง_หน้าต่างเลือกชนิดการคลิก"
+
+#~ msgid ""
+#~ "You can also use the Dwell Click panel applet to choose the click type."
+#~ msgstr "คุณสามารถใช้แอพเพล็ต \"คลิกโดยวางแช่\" บนพาเนลในการเลือกวิธีคลิกได้เช่นกัน"
+
+#~ msgid "_Initiate click when stopping pointer movement"
+#~ msgstr "เริ่มการคลิ_กเมื่อหยุดเคลื่อนเมาส์"
+
+#~ msgid "_Single click:"
+#~ msgstr "_คลิกเดียว:"
+
+#~ msgid "_Trigger secondary click by holding down the primary button"
+#~ msgstr "_สร้างคลิกที่สองโดยกดปุ่มแรกของเมาส์"
+
+#~ msgid "Set the system proxy settings"
+#~ msgstr "ตั้งค่าพร็อกซีของระบบ"
+
+#~ msgid "Preparing connection"
+#~ msgstr "กำลังเตรียมการเชื่อมต่อ"
+
+#~ msgid "Getting network address"
+#~ msgstr "กำลังขอที่อยู่เครือข่าย"
+
+#~ msgid "Secure HTTP Proxy:"
+#~ msgstr "พร็อกซี HTTP นิรภัย:"
+
+#~ msgid "LowContrast"
+#~ msgstr "สีไม่ตัดกัน"
+
+#~ msgid "Use an alternative form of text input"
+#~ msgstr "ใช้การป้อนข้อความแบบอื่น"
+
+#~ msgctxt "Account type"
+#~ msgid "Supervised"
+#~ msgstr "มีการกำกับดูแล"
+
+#~ msgid ""
+#~ "A guest account will allow anyone to temporarily log in to this computer "
+#~ "without a password.  For security, remote logins to this account are not "
+#~ "allowed.\n"
+#~ "\n"
+#~ "<b>When the guest user logs out, all files and data associated with the "
+#~ "account will be deleted.</b>"
+#~ msgstr ""
+#~ "บัญชีผู้มาเยือนจะอนุญาตให้ใครก็ได้เข้าระบบในคอมพิวเตอร์เครื่องนี้ได้แบบชั่วคราวโดยไม่ต้องใช้รหัสผ่าน "
+#~ "เพื่อความปลอดภัย จะไม่อนุญาตให้เข้าระบบด้วยบัญชีนี้จากเครื่องอื่นในเครือข่าย\n"
+#~ "\n"
+#~ "<b>เมื่อผู้มาเยือนออกจากระบบ แฟ้มและข้อมูลที่เชื่อมโยงกับบัญชีนี้จะถูกลบทิ้งทั้งหมด</b>"
+
+#~ msgid "Accounts"
+#~ msgstr "บัญชี"
+
+#~ msgid "Address Book Card:"
+#~ msgstr "บัตรในสมุดที่อยู่:"
+
+#~ msgid "Allow guests to log in to this computer"
+#~ msgstr "อนุญาตให้ผู้มาเยือนเข้าระบบในคอมพิวเตอร์เครื่องนี้"
+
+#~ msgid "E-mail address:"
+#~ msgstr "ที่อยู่อีเมล:"
+
+#~ msgid "Open"
+#~ msgstr "เปิด"
+
+#~ msgid "Restrictions:"
+#~ msgstr "ข้อจำกัด:"
+
+#~ msgid "Show Shutdown, Suspend and Restart actions"
+#~ msgstr "แสดงคำสั่งปิดเครื่อง พักเครื่อง และเปิดเครื่องใหม่"
+
+#~ msgid "Show list of users"
+#~ msgstr "แสดงรายชื่อผู้ใช้"
+
+#~ msgid "Show password hints"
+#~ msgstr "แสดงคำใบ้ของรหัสผ่าน"
+
+#~ msgid "Example preferences panel"
+#~ msgstr "แผงปรับแต่งตัวอย่าง"
+
+#~ msgid "Foo;Bar;Baz;"
+#~ msgstr "ขี้หมูรา;ขี้หมาแห้ง;"
+
+#~ msgid "Orange"
+#~ msgstr "ส้ม"
+
+#~ msgid "Chocolate"
+#~ msgstr "ช็อกโกเลต"
+
+#~ msgid "Chameleon"
+#~ msgstr "กิ้งก่า"
+
+#~ msgid "Blue"
+#~ msgstr "น้ำเงิน"
+
+#~ msgid "Plum"
+#~ msgstr "เหมย"
+
+#~ msgid "Aluminium"
+#~ msgstr "อะลูมิเนียม"
+
+#~ msgid "Location already exists"
+#~ msgstr "สถานที่นี้มีอยู่ก่อนแล้ว"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "ตั้งค่าพร็อกซีของเครือข่าย"
+
+#~ msgid "Web;Location;"
+#~ msgstr "เว็บ;สถานที่;"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>ตั้งค่าพร็อกซีเอ_ง</b>"
+
+#~ msgid "Autoconfiguration _URL:"
+#~ msgstr "_URL สำหรับตั้งค่าอัตโนมัติ:"
+
+#~ msgid "Create New Location"
+#~ msgstr "เพิ่มสถานที่ใหม่"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "รายละเอียดพร็อกซี HTTP"
+
+#~ msgid "Ignore Host List"
+#~ msgstr "รายชื่อโฮสต์ที่ไม่ผ่านพร็อกซี"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "ตั้งค่าพร็อกซีเครือข่าย"
+
+#~ msgid "S_ocks host:"
+#~ msgstr "โฮสต์ S_ocks:"
+
+#~ msgid "The location already exists."
+#~ msgstr "สถานที่นี้มีอยู่ก่อนแล้ว"
+
+#~ msgid "U_sername:"
+#~ msgstr "_ชื่อผู้ใช้:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "พร็อกซี _Secure HTTP:"
+
+#~ msgid "_Use the same proxy for all protocols"
+#~ msgstr "ใ_ช้พร็อกซีเดียวกันสำหรับทุกโพรโทคอล"
+
+#~ msgid "Slide Show"
+#~ msgstr "การแสดงสไลด์"
+
+#~ msgid "Image"
+#~ msgstr "รูปภาพ"
+
+#~ msgid "_Detect monitors"
+#~ msgstr "_ตรวจหาจอภาพต่างๆ"
+
+#~ msgid "_Mirror Screens"
+#~ msgstr "หน้าจอแสดงเห_มือนกัน"
+
+#~ msgid "Open with \"%s\""
+#~ msgstr "เปิดด้วย \"%s\""
+
+#~ msgid "Image/label border"
+#~ msgstr "เส้นขอบรูป/ป้าย"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "ความกว้างของเส้นขอบรอบป้ายและรูปภาพในกล่องโต้ตอบแจ้งเหตุ"
+
+#~ msgid "The type of alert"
+#~ msgstr "ชนิดของการแจ้งเหตุ"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "ปุ่มที่จะแสดงในกล่องโต้ตอบแจ้งเหตุ"
+
+#~ msgid "Show more _details"
+#~ msgstr "แสดง_รายละเอียดเพิ่มเติม"
+
+#~ msgid "Place your left thumb on %s"
+#~ msgstr "วางนิ้วหัวแม่มือซ้ายของคุณลงบน %s"
+
+#~ msgid "Swipe your left thumb on %s"
+#~ msgstr "กลิ้งนิ้วหัวแม่มือซ้ายของคุณลงบน %s"
+
+#~ msgid "Place your left index finger on %s"
+#~ msgstr "วางนิ้วชี้ซ้ายของคุณลงบน %s"
+
+#~ msgid "Swipe your left index finger on %s"
+#~ msgstr "กลิ้งนิ้วชี้ซ้ายของคุณลงบน %s"
+
+#~ msgid "Place your left middle finger on %s"
+#~ msgstr "วางนิ้วกลางซ้ายของคุณลงบน %s"
+
+#~ msgid "Swipe your left middle finger on %s"
+#~ msgstr "กลิ้งนิ้วกลางซ้ายของคุณลงบน %s"
+
+#~ msgid "Place your left ring finger on %s"
+#~ msgstr "วางนิ้วนางซ้ายของคุณลงบน %s"
+
+#~ msgid "Swipe your left ring finger on %s"
+#~ msgstr "กลิ้งนิ้วนางซ้ายของคุณลงบน %s"
+
+#~ msgid "Place your left little finger on %s"
+#~ msgstr "วางนิ้วก้อยซ้ายของคุณลงบน %s"
+
+#~ msgid "Swipe your left little finger on %s"
+#~ msgstr "กลิ้งนิ้วก้อยซ้ายของคุณลงบน %s"
+
+#~ msgid "Place your right thumb on %s"
+#~ msgstr "วางนิ้วหัวแม่มือขวาของคุณลงบน %s"
+
+#~ msgid "Swipe your right thumb on %s"
+#~ msgstr "กลิ้งนิ้วหัวแม่มือขวาของคุณลงบน %s"
+
+#~ msgid "Place your right index finger on %s"
+#~ msgstr "วางนิ้วชี้ขวาของคุณลงบน %s"
+
+#~ msgid "Swipe your right index finger on %s"
+#~ msgstr "กลิ้งนิ้วชี้ขวาของคุณลงบน %s"
+
+#~ msgid "Place your right middle finger on %s"
+#~ msgstr "วางนิ้วกลางขวาของคุณลงบน %s"
+
+#~ msgid "Swipe your right middle finger on %s"
+#~ msgstr "กลิ้งนิ้วกลางขวาของคุณลงบน %s"
+
+#~ msgid "Place your right ring finger on %s"
+#~ msgstr "วางนิ้วนางขวาของคุณลงบน %s"
+
+#~ msgid "Swipe your right ring finger on %s"
+#~ msgstr "กลิ้งนิ้วนางขวาของคุณลงบน %s"
+
+#~ msgid "Place your right little finger on %s"
+#~ msgstr "วางนิ้วก้อยขวาของคุณลงบน %s"
+
+#~ msgid "Swipe your right little finger on %s"
+#~ msgstr "กลิ้งนิ้วก้อยขวาของคุณลงบน %s"
+
+#~ msgid "Place your finger on the reader again"
+#~ msgstr "วางนิ้วของคุณบนเครื่องอ่านอีกครั้ง"
+
+#~ msgid "Swipe your finger again"
+#~ msgstr "กลิ้งนิ้วของคุณอีกครั้ง"
+
+#~ msgid "Swipe was too short, try again"
+#~ msgstr "คุณกลิ้งสั้นเกินไป กรุณาลองใหม่อีกครั้ง"
+
+#~ msgid "Your finger was not centered, try swiping your finger again"
+#~ msgstr "นิ้วของคุณไม่ได้กึ่งกลาง กรุณาลองกลิ้งนิ้วใหม่อีกครั้ง"
+
+#~ msgid "Remove your finger, and try swiping your finger again"
+#~ msgstr "กรุณาเอานิ้วออก แล้วลองกลิ้งนิ้วใหม่อีกครั้ง"
+
+#~ msgid "No Image"
+#~ msgstr "ไม่มีรูป"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "เกิดข้อผิดพลาดขณะพยายามอ่านข้อมูลสมุดที่อยู่\n"
+#~ "Evolution Data Server ไม่สามารถจัดการกับโพรโทคอลได้"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "เปิดสมุดที่อยู่ไม่สำเร็จ"
+
+#~ msgid "C_ompany:"
+#~ msgstr "_บริษัท:"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "เมือง/_อำเภอ:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "_ประเทศ:"
+
+#~ msgid "Disable _Fingerprint Login..."
+#~ msgstr "ปิดการเข้าระบบด้วยลาย_นิ้วมือ..."

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,7 +1,6 @@
 # Turkish translation of gnome-control-center.
-#
 # Copyright (C) 2000-2003, 2004, 2005, 2008, 2009, 2011 Free Software Foundation, Inc.
-# Copyright (C) 2012-2022 gnome-control-center'S COPYRIGHT HOLDER
+# Copyright (C) 2012-2022 gnome-control-center's COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-control-center package.
 #
 # Nilgün Belma Bugüner <nilgun@fide.org>, 2001.
@@ -19,10 +18,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-09-12 15:11+0000\n"
-"PO-Revision-Date: 2022-09-01 18:47+0300\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-09-23 20:14+0300\n"
 "Last-Translator: Emin Tufan Çetin <etcetin@gmail.com>\n"
 "Language-Team: Turkish <gnometurk@gnome.org>\n"
 "Language: tr\n"
@@ -32,98 +30,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Sistem Veriyolu"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Tam erişim"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Oturum Veriyolu"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Aygıtlar"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "/dev konumuna tam erişim"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Ağ"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Ağ erişimi var"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Ev"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Salt Okunur"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Dosya Sistemi"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Ayarlar"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Ayarları değiştirebilir"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s, aşağıdaki izinleri yerleşik olarak bulundurur. Bunlar değiştirilemez. Bu "
-"izinlerden kaygılıysanız uygulamayı kaldırmayı düşünün."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "Uygulamaca açılan %u dosya ve bağlantı türü"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b>, şu türden dosya ve bağlantıları açmada kullanılmaktadır."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "%s disk alanı kullanıldı."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -139,7 +46,6 @@ msgid "Install some…"
 msgstr "Birkaç tane kur…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Aç"
 
@@ -163,24 +69,13 @@ msgstr "Arama"
 msgid "Receive system searches and send results."
 msgstr "Sistem aramaları al ve sonuçları gönder."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Devre dışı"
 
@@ -346,80 +241,20 @@ msgstr "Önbelleği Temizle…"
 msgid "Control various application permissions and settings"
 msgstr "Türlü uygulama izinlerini ve ayarlarını denetle"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "uygulama;flatpak;izin;yetki;ayar;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Resim seç"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_İptal"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Aç"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "birden çok boyut"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Masaüstü Arka Planı Yok"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Geçerli arka plan"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Biçim"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Öntanımlı"
 
@@ -443,7 +278,6 @@ msgstr "Görünüm"
 msgid "Change your background image or the UI colors"
 msgstr "Arka plan görüntüsü veya kullanıcı arayüzü renklerinizi değiştirin"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -496,9 +330,7 @@ msgstr "Donanımsal Uçak Kipi Açık"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Bluetooth’u etkinleştirmek için Uçak kipini kapat."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -506,7 +338,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Bluetooth’u açıp kapatın ve aygıtlarınızı bağlayın"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "paylaş;paylaşım;bluetooth;obex;"
@@ -540,91 +371,35 @@ msgstr "Hiçbir Uygulama Kamera Erişimi İsteği Yapmadı"
 msgid "Protect your pictures"
 msgstr "Fotoğraflarınızı koruyun"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "kamera;fotoğraflar;resimler;video;görüntü;webcam;web kamerası;webkam;kilitle;"
 "özel;gizlilik;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Kalibrasyon aygıtınızı karenin üzerine yerleştirin ve “Başlat”a basın"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "Kalibrasyon aygıtınızı kalibrasyon konumuna getirip “Sürdür”e basın"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Kalibrasyon aygıtınızı yüzey konumuna getirip “Sürdür”e basın"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Dizüstü bilgisayarın kapağını kapat"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Düzeltilemeyecek iç hata oluştu."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Kalibrasyon için gerekli araçlar kurulu değil."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Profil oluşturulamadı."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Hedef beyaznokta bulunabilir değildi."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Tamamlandı!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Kalibrasyon başarısız!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Kalibrasyon aygıtını çıkartabilirsiniz."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Kalibrasyon esnasında kalibrasyon aygıtıyla oynamayın"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Ekran Kalibrasyonu"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_İptal"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -641,140 +416,6 @@ msgstr "_Sürdür"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Bitti"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Dizüstü Ekranı"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Yerleşik Web Kamerası"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s Monitör"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s Tarayıcı"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s Kamera"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s Yazıcı"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s Web Kamerası"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "%s için renk yönetimini etkinleştir"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s için renk profillerini göster"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Kalibrasyon yok"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Öntanımlı: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Renk uzayı: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Sınama profili: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "ICC Profil Dosyasını Seç"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_İçe Aktar"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Desteklenen ICC profilleri"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Tüm dosyalar"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Ekran"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Profili Kaydet"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Kaydet"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Seçilen aygıt için renk profili oluştur"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Ölçüm aygıtı algılanamadı. Lütfen açık durumda olduğundan ve doğru "
-"bağlandığından emin olunuz."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Ölçüm aygıtı yazıcı profillemeyi desteklemiyor."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Aygıt türü şu anda desteklenmiyor."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -890,9 +531,9 @@ msgstr "Yazılabilir ortam gerektirir"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Profili <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> ve "
 "<a href=\"windows\">Microsoft Windows</a> sistemleri üzerinde nasıl "
@@ -907,8 +548,8 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Bazı sorunlar saptandı. Bu profil düzgün çalışmayabilir. <a href="
-"\"\">Ayrıntıları göster.</a>"
+"Bazı sorunlar saptandı. Bu profil düzgün çalışmayabilir. <a "
+"href=\"\">Ayrıntıları göster.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -916,7 +557,6 @@ msgstr "Dosyayı _İçe Aktar…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -926,9 +566,7 @@ msgstr "_Ekle"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "Her aygıt, renk yönetimleri için güncel renk profiline gereksinir."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Daha çoğunu öğren"
 
@@ -1060,82 +698,6 @@ msgstr "D65 (Fotoğraf ve grafik)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Standart Uzaylar"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Sınama Profili"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Kendiliğinden"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Düşük Nitelik"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Orta Nitelik"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Yüksek Nitelik"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Öntanımlı RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Öntanımlı CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Öntanımlı Gri"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Üretici tarafından sağlanan fabrika kalibrasyon verisi"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Bu profille tam-ekran görüntü düzeltme olası değil"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Bu profil artık doğru olmayabilir"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Renk"
@@ -1146,14 +708,9 @@ msgid ""
 msgstr ""
 "Ekran, kamera veya yazıcı gibi aygıtlarınızın renk kalibrasyonunu yapın"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Renk;ICC;Profil;Ayar;Yazıcı;Ekran;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Diğer…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1168,13 +725,8 @@ msgid "No languages found"
 msgstr "Dil bulunamadı"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Daha çok…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Ayarları Değiştirmek İçin Kilidi Kaldır"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1203,148 +755,6 @@ msgstr "Saati Azalt"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Dakikayı Azalt"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Bugün"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Dün"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d saat"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d dakika"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d saniye"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 saniye"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Erişim Noktası"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 saat"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "ÖÖ / ÖS"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1439,17 +849,11 @@ msgstr "Kendiliğinden Saat _Dilimi"
 msgid "Requires location services enabled and internet access"
 msgstr "Konum hizmetlerinin etkin olmasını ve İnternet erişimi gerektirir"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Etkin"
 
@@ -1457,15 +861,43 @@ msgstr "Etkin"
 msgid "Time Z_one"
 msgstr "Saat _Dilimi"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Kilidi Aç"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Saat _Biçimi"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Tarihler"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 saniye"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Takvim"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Sayılar"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Tarihi, saati ve saat dilimini değiştir"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Saat;Saat Dilimi;Zaman Dilimi;Yer;Konum;"
@@ -1513,20 +945,9 @@ msgstr "Öntanımlı Uygulamalar"
 msgid "Configure Default Applications"
 msgstr "Öntanımlı Uygulamaları Yapılandır"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "öntanımlı;uygulama;tercihen;yeğlenen;ortam;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Teknik sorunları bildirmeniz %s gelişimine yaramaktadır. Bu bildirimler, "
-"anonim olarak gönderilir ve kişisel veriden arındırılmıştır. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1544,44 +965,9 @@ msgstr "Tanılama"
 msgid "Report your problems"
 msgstr "Sorunları raporla"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "tanılama;teşhis;çökme;bozulma;kırılma;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Açık"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Kapalı"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Değişiklikler Uygulansın Mı?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Değişiklikler Uygulanamadı"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Bu donanım kısıtlamalarından kaynaklanabilir."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1631,31 +1017,6 @@ msgstr "Birincil Ekran"
 msgid "Night Light"
 msgstr "Gece Işığı"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Yatay"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Dikey Sağ"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Dikey Sol"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Yatay (ters yüz)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1679,6 +1040,17 @@ msgstr "TV için Ayarla"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Ölçekle"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Doğal Kaydırma"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1773,7 +1145,6 @@ msgstr "Ekranlar"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Bağlanan ekranların ya da projektörlerin nasıl kullanılacağını seçin"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1781,77 +1152,6 @@ msgid ""
 msgstr ""
 "Panel;Projektör;Gösterici;xrandr;Ekran;Çözünürlük;Tazele;Yenile;Monitör;Gece;"
 "Işık;Mavi;redshift;renk;gün doğumu;gün batımı;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:112
-msgid "Secure Boot is Active"
-msgstr "Güvenli Önyükleme Etkin"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
-"önler. Şu anda açıktır ve düzgün çalışmaktadır."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Güvenli Önyükleme Sorunlu"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
-"önler. Şu anda açıktır ancak geçersiz anahtar olduğundan çalışmayacaktır."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Güvenli önyükleme sorunları genellikle bilgisayarınızın UEFI donanım "
-"yazılımı ayarlarından (BIOS) çözülebilir. Donanım üreticiniz, bunu nasıl "
-"yapacağınızla ilgili bilgiyi sağlayabilir."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "Yardım için donanım üreticinize veya BT desteğine başvurun."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Güvenli Önyükleme Kapatıldı"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
-"önler. Şu anda kapalıdır."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Güvenli önyükleme, genellikle bilgisayarınızın UEFI donanım yazılımı "
-"ayarlarından (BIOS) açılabilir. Yardım için donanım üreticinize veya BT "
-"desteğine başvurun."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1865,130 +1165,9 @@ msgstr ""
 "\n"
 "Daha ayrıntılı bilgi için donanım üreticisine veya BT desteğine başvurun."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Geçti"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Başarısız"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Aygıt, HSI %d düzeyine uymaktadır"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:486
-msgid "Security Level 0"
-msgstr "Güvenlik Düzeyi 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Bu aygıt, donanım güvenliği sorunlarına karşı korumasızdır. Bunun nedeni "
-"donanım veya donanım yazılımı yapılandırma sorunu olabilir. BT destek "
-"sağlayıcınıza danışmanız önerilmektedir."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:358
-#: panels/firmware-security/cc-firmware-security-panel.c:493
-msgid "Security Level 1"
-msgstr "Güvenlik Düzeyi 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Bu aygıt, donanım güvenliği sorunlarına karşı en düşük korumadadır. Bu en "
-"düşük aygıt güvenliği düzeyidir ve yalnızca kolay güvenlik gözdağlarına "
-"karşı koruma sağlar."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:363
-#: panels/firmware-security/cc-firmware-security-panel.c:500
-msgid "Security Level 2"
-msgstr "Güvenlik Düzeyi 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Bu aygıt, donanım güvenliği sorunlarına karşı temel korumadadır. Bu bazı "
-"yaygın güvenlik gözdağlarına karşı koruma sağlar."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:368
-#: panels/firmware-security/cc-firmware-security-panel.c:507
-msgid "Security Level 3"
-msgstr "Güvenlik Düzeyi 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Bu aygıt, donanım güvenliği sorunlarına karşı geniş korumadadır. Bu en "
-"yüksek aygıt güvenliği düzeyidir ve gelişmiş güvenlik gözdağlarına karşı "
-"koruma sağlar."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:522
 msgid "Security Level"
 msgstr "Güvenlik Düzeyi"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:523
-msgid "Security levels are not available for this device."
-msgstr "Güvenlik düzeyleri bu aygıt için kullanılabilir değil."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Güvenlik güncelleştirmeleriyle ilgili yardım için donanım üreticinize "
-"başvurun."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Bu sorun, aygıtın UEFI donanım yazılımı ayarlarından veya destek "
-"teknisyenince çözülebilir."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr "Bu sorun, aygıtın UEFI donanım yazılımı ayarlarından çözülebilir."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "Bu sorunun destek teknisyenince çözülmesi olasıdır."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2002,338 +1181,9 @@ msgstr "Düzey 2"
 msgid "Level 3"
 msgstr "Düzey 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:113
-msgid "Protected against malicious software when the device starts."
-msgstr "Aygıt başladığında kötücül yazılımlara karşı korunmaktadır."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:119
-msgid "Secure Boot has Problems"
-msgstr "Güvenli Önyükleme Sorunlu"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:120
-msgid "Some protection when the device is started."
-msgstr "Aygıt başladığında bazı korumalar vardır."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:125
-msgid "Secure Boot is Off"
-msgstr "Güvenli Önyükleme Kapalı"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:126
-msgid "No protection when the device is started."
-msgstr "Aygıt başladığında koruma yoktur."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:145
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Bu sorun; UEFI donanım yazılımı ayarlarındaki değişimden, işletim sistemi "
-"yapılandırma değişiminden veya bu sistemdeki kötücül yazılımdan "
-"kaynaklanabilir."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:153
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Bu sorun, UEFI donanım yazılımı ayarlarındaki değişimden veya bu sistemdeki "
-"kötücül yazılımdan kaynaklanabilir."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:160
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Bu sorun, işletim sistemi yapılandırma değişiminden veya bu sistemdeki "
-"kötücül yazılımdan kaynaklanabilir."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:487
-msgid "Exposed to serious security threats."
-msgstr "Ciddi güvenlik gözdağlarına açık."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:494
-msgid "Limited protection against simple security threats."
-msgstr "Kolay güvenlik gözdağlarına karşı kısıtlı koruma."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:501
-msgid "Protected against common security threats."
-msgstr "Yaygın güvenlik gözdağlarına karşı korunmaktadır."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:508
-#: panels/firmware-security/cc-firmware-security-panel.c:516
-msgid "Protected against a wide range of security threats."
-msgstr "Geniş kapsamlı güvenlik gözdağlarına karşı koruma."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:515
-msgid "Comprehensive Protection"
-msgstr "Kapsamlı Koruma"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Olay Yok"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Donanım Yazılımı Yazma Koruması"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "AMD Donanım Yazılımı Yazma Koruması Kilitli"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Donanım Yazılımı BIOS Bölgesi"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Donanım Yazılımı BIOS Tanımlayıcı"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Önyükleme öncesi DMA Koruması"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Intel BootGuard Doğrulanmış Önyükleme"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Intel BootGuard ACM Korumalı"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Intel BootGuard Hata İlkesi"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Intel BootGuard Sigortası"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Intel CET Etkin"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET Etkin"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Şifrelenmiş RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU Koruması"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux Çekirdek Yalıtımı"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linux Çekirdek Doğrulama"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux Takas Alanı"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Belleğe Askıya Al"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Boşta Beklet"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI Platform Anahtarı"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI Güvenli Önyükleme"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TPM Platform Yapılandırma"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM Yeniden İnşası"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Intel Management Engine Üretim Kipi"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Intel Management Engine Geçersiz Kıl"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Intel Management Engine Sürümü"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Donanım Yazılımı Güncellemeleri"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Donanım Yazılımı Onayı"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Donanım Yazılımı Doğrulaması"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Platform Hata Ayıklama"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "İşlemci Güvenlik Denetimleri"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD Geri Alma Koruması"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD Donanım Yazılımı Yeniden Oynatma Koruması"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "AMD Donanım Yazılımı Yazma Koruması"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Sigortalı Platform"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Geçerli"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Geçersiz"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Etkin Değil"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Kilitli"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Kilitsiz"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Şifrelenmiş"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Şifrelenmemiş"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Lekeli"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Lekesiz"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Bulundu"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Bulunamadı"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Destekleniyor"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Desteklenmiyor"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2343,7 +1193,6 @@ msgstr "Aygıt Güvenliği"
 msgid "Host firmware security status"
 msgstr "Bilgisayar donanım yazılımı güvenlik durumu"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2351,49 +1200,6 @@ msgid ""
 msgstr ""
 "ekran;kilit;tanılama;kırılma;bozulma;çökme;özel;son;geçici;tmp;endeks;"
 "içindekiler;indeks;isim;ad;ağ;kimlik;gizlilik;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Bilinmeyen"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-bit"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-bit"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Bilinmiyor"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Yok"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Sistem Logosu"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2487,11 +1293,6 @@ msgstr "Hakkında"
 msgid "View information about your system"
 msgstr "Sisteminiz hakkında bilgi edinin"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2570,6 +1371,12 @@ msgstr "Başlatıcılar"
 msgid "Launch help browser"
 msgstr "Yardım tarayıcısını çalıştır"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Ayarlar"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Hesap makinesini çalıştır"
@@ -2591,7 +1398,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Arama"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Sistem"
 
@@ -2640,15 +1447,6 @@ msgstr "Yazıyı küçült"
 msgid "High contrast on or off"
 msgstr "Yüksek karşıtlık açık ya da kapalı"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Girdi kaynağı bulunamadı"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Diğer"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Girdi Kaynağı Ekle"
@@ -2681,106 +1479,9 @@ msgstr "Tercihler"
 msgid "View Keyboard Layout"
 msgstr "Klavye Düzenini Gör"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Kaldır"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Özel Kısayollar"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Karakterler Tuşunu Değiştir"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Alternatif harfler tuşu, ek karakterler girmek için kullanılabilir. Bunlar "
-"bazen klavyenize üçüncü seçenek olarak basılmış olabilir."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Sol Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Sağ Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Sol Süper"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Sağ Süper"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Menü tuşu"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Sağ Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Birleştirme Tuşu"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Birleştirme tuşu, geniş türde karakterlerin girilmesini sağlar. Kullanmak "
-"için birleştirmeye ardından bir karakter dizisine basılır.  Örneğin, "
-"birleştirme tuşu ardından <b>C</b> ve <b>o</b>’ya basılması <b>©</b> "
-"girecektir, <b>a</b> ardından <b>'</b> basılması <b>á</b> girecektir."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"%s klavye kısayoluyla girdi kaynakları arasında geçiş yapılabilir.\n"
-"Bu, klavye kısayolları ayarlarından değiştirilebilir."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2810,43 +1511,21 @@ msgstr "Özel Karakter Girdisi"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Klavye kullanarak simge ve değişik harfler girmek için yöntemler."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Karakterler Tuşunu Değiştir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Birleştirme Tuşu"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Klavye Kısayolları"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Kısayolları Gör ve Özelleştir"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d değiştirildi"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Tüm Kısayolları Sıfırla?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Kısayolları sıfırlamak özel kısayollarınızı etkileyebilir. Bu geri alınamaz."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "İptal"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Tümünü Sıfırla"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2886,35 +1565,6 @@ msgstr "Kısayol Ekle"
 msgid "No keyboard shortcut found"
 msgstr "Klavye kısayolu bulunamadı"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s, %s için kullanılıyor. Eğer yerine başka şey koyarsanız, %s devre dışı "
-"bırakılacak"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Yeni kısayolu girin"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Özel Kısayol Belirle"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Kısayol Belirle"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Değiştirmek için yeni kısayol girin: %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Özel Kısayol Ekle"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "_Kaldır"
@@ -2926,7 +1576,6 @@ msgstr "Yerine _koy"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Belirle"
 
@@ -2964,6 +1613,11 @@ msgstr "Hiçbiri"
 msgid "Reset the shortcut to its default value"
 msgstr "Kısayolu öntanımlı değerine sıfırla"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Yazıcıyı Öntanımlı Olarak Kullan"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Klavye"
@@ -2976,7 +1630,6 @@ msgstr ""
 "Klavye kısayollarını, klavye düzenlerini, girdi kaynaklarını değiştirin ve "
 "yazım tercihlerinizi belirleyin"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3017,7 +1670,6 @@ msgstr "Hiçbir Uygulama Konum Erişimi İsteği Yapmadı"
 msgid "Protect your location information"
 msgstr "Konum bilginizi koruyun"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "konum;lokasyon;gps;özel;gizlilik;"
@@ -3051,7 +1703,6 @@ msgstr "Hiçbir Uygulama Mikrofon Erişimi İsteği Yapmadı"
 msgid "Protect your conversations"
 msgstr "Konuşmalarınızı koruyun"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr "mikrofon;kayıt;kaydetme;uygulama;gizlilik;"
@@ -3082,81 +1733,139 @@ msgstr "Sol"
 msgid "Right"
 msgstr "Sağ"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Arama Konumları"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Fare"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Fare Hızı"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Doğal Kaydırma"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Bölme"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Kaydırma, görünümü değil içeriği hareket ettirir."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Kaydırma, görünümü değil içeriği hareket ettirir."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Etkin"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Dokunmatik Yüzey"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Dokunmatik Yüzey Hızı"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Tıklamak için Dokun"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Tıklamak için dokun"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "İki Parmak Kaydırma"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Dokunmatik Yüzey Hızı"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Kenar Kaydırma"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Çift taraflı"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Tek tıklamayı, çift tıklamayı ve kaydırmayı deneyin"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Beş tık, GEGL zamanı!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Çift tıklama, birincil düğme"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Tek tıklama, birincil düğme"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Çift tıklama, orta düğme"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Tek tıklama, orta düğme"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Çift tıklama, ikincil düğme"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Tek tıklama, ikincil düğme"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3169,7 +1878,6 @@ msgstr ""
 "Farenizin veya dokunmatik yüzeyin duyarlılığını değiştirin ve sağ veya sol "
 "elle kullanımı ayarlayın"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3248,7 +1956,6 @@ msgstr "Çoklu Görev"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Verimlilik ve çoklu görev için tercihleri yönet"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3256,20 +1963,11 @@ msgstr ""
 "Çoklugörev;Çoklu Görev;Çoğulgörev;Verimlilik;Üretkenlik;Özelleştir;Masaüstü;"
 "Sıcak Köşe;Sıcak Kenar;Çalışma Alanları;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "Tüh, bir şeyler ters gitti. Lütfen yazılım sağlayıcınıza başvurun."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "NetworkManager’in çalışması gerekir."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Diğer Aygıtlar"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3281,59 +1979,16 @@ msgstr "Bağlantı ekle"
 msgid "Not set up"
 msgstr "Ayarlanmamış"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Güvensiz ağ (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Güvenli ağ (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Güvenli ağ (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Güvenli ağ (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Güvenli ağ"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Bağlı"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Seçenekler…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Erişim noktasını açmak %s bağlantısını kesecek ve internete kablosuz "
-"üzerinden erişilemeyecek."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "En az 8 karakter içermelidir"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3382,20 +2037,6 @@ msgstr "Kendiliğinden Parola Oluştur"
 msgid "_Turn On"
 msgstr "_Aç"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Kablosuz"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Erişim noktası durdurulup tüm kullanıcıların bağlantısı kesilsin mi?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "Erişim Noktasını _Durdur"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Uçak Kipi"
@@ -3440,89 +2081,13 @@ msgstr "Görünür Ağlar"
 msgid "NetworkManager needs to be running"
 msgstr "NetworkManager’in çalışması gerekir"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Tüh, bir şeyler ters gitti. Lütfen yazılım sağlayıcınıza başvurun."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x _Güvenliği"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Güvenlik"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Koru"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Kalıcı"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Rastgele"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Kararlı"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Buraya girilen MAC adresi, bu bağlantı kurulduğunda, ağ aygıtının donanım "
-"adresi olarak kullanılacak. Bu özellik MAC klonlama veya hilekarlığı olarak "
-"bilinir. Örnek: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Profil %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Kurumsal"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Hiçbiri"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Asla"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3530,183 +2095,6 @@ msgstr "Asla"
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i gün önce"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/sn"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Yok"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Zayıf"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "İyi"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "İyi"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Mükemmel"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 Adresi"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 Adresi"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP Adresi"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Bağlantıyı Unut"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Bağlantı Profilini Kaldır"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "VPN’yi Kaldır"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Ayrıntılar"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "kendiliğinden"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Kimlik"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Adresi Sil"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Rotayı Sil"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Hiçbiri"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-bit Anahtar (Onaltılık veya ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-bit Parola"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Dinamik WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA ve WPA2 Kişisel"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA ve WPA2 Kurumsal"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Kişisel"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3717,8 +2105,20 @@ msgstr "Sinyal Gücü"
 msgid "Link speed"
 msgstr "Hat hızı"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Güvenlik"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 Adresi"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 Adresi"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Donanım Adresi"
 
@@ -3727,12 +2127,17 @@ msgid "Supported Frequencies"
 msgstr "Desteklenen Frekanslar"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Öntanımlı Geçit"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3795,7 +2200,7 @@ msgstr "Yalnızca Yerel Bağlantı"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Elle"
 
@@ -3839,9 +2244,8 @@ msgstr "Geçit"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:656
 msgid "Automatic"
 msgstr "Kendiliğinden"
 
@@ -3894,90 +2298,9 @@ msgstr "Kendiliğinden, yalnızca DHCP"
 msgid "Prefix"
 msgstr "Ön ek"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Bağlantı düzenleyicisi açılamadı"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Yeni Profil"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Geçersiz ayar %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Geçersiz ayar %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Dosyadan içe aktar…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "VPN Ekle"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "Güv_enlik"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "VPN bağlantısı içe aktarılamıyor"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"“%s” dosyası okunamadı ya da herhangi bir VPN bağlantı bilgisi içermiyor\n"
-"\n"
-"Hata: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "İçe aktarılacak dosyayı seçin"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "“%s” adında dosya zaten var."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "Değişti_r"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr ""
-"%s bağlantısını kaydetmek istediğiniz VPN bağlantısıyla değiştirmek istiyor "
-"musunuz?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "VPN bağlantısı dışa aktarılamıyor"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"“%s” VPN bağlantısı %s’a aktarılamıyor.\n"
-"\n"
-"Hata: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "VPN bağlantısını dışa aktar"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3991,101 +2314,38 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Ağ"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "İnternete nasıl bağlandığınızı denetleyin"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Ağ;IP;LAN;Proxy;WAN;Broadband;Genişbant;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Kablosuz"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Kablosuz ağlarına nasıl bağlandığınızı denetleyin"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Ağ;Wireless;Wi-Fi;Wifi;Kablosuz;Kablosuz Ağ;IP;LAN;Broadband;Genişbant;DNS;"
 "Hotspot;Bağlantı Noktası;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "asla"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "bugün"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "dün"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Son kullanım"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Kablolu"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Yeni bağlantı ekle"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Seçilen ağlar için ağ ayrıntıları, parolalar ve her türlü özel "
-"yapılandırmalar kaybolacak."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Unut"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Bilinen Kablosuz Ağlar"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Unut"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Sistem ilkeleri Erişim Noktası olarak kullanmayı yasaklıyor"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Kablosuz aygıt Erişim Noktası kipini desteklememektedir"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Yapılandırma URL’si verilmediğinde Vekil Sunucuyu Kendiliğinden Bulma "
-"kullanılır."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Bu güvenli olmayan açık ağlarda önerilmez."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4104,6 +2364,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Sağlayıcı"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP Adresi"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4188,289 +2452,6 @@ msgstr "Kablosuz Erişim Nok_tasını Aç…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Bilinen Kablosuz Ağlar"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Durum bilinmiyor"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Yönetilmeyen"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Kullanılamıyor"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Bağlanıyor"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Kimlik doğrulası gerekli"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Bağlantı kesiliyor"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Bağlantı başarısız"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Durum bilinmiyor (kayıp)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Yapılandırma başarısız"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP yapılandırması başarısız"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP yapılandırmasının süresi dolmuş"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Özel bilgiler gerekli ancak sağlanmamış"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x istekçisinin bağlantısı kesildi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x istekçi yapılandırması başarısız oldu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x istekçisi başarısız oldu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x istekçisinin kimlik doğrulaması çok uzun sürdü"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP hizmeti başlatılamadı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP hizmetinin bağlantısı kesildi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP başarısız"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP istemci başlatılamadı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP istemci hatası"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP istemcisi başarısız"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Paylaşımlı bağlantı hizmeti başlatılamadı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Paylaşılmış bağlantı hizmeti başarısız oldu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP hizmeti başlatılamadı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP hizmet hatası"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP hizmeti başarısız oldu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Hat meşgul"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Çevir sesi yok"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Hiçbir taşıyıcı (carrier) elde edilemedi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Çevirme isteği zaman aşımına uğradı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Çevirme denemesi başarısız"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Modem başlatma başarısız oldu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Belirtilen APN seçilemedi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Ağlar için arama yapılmıyor"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Ağ kaydı reddedildi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Ağ kaydı zaman aşımına uğradı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "İstenilen ağa kaydolunamadı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN doğrulanamadı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Aygıt için donanım yazılımı eksik olabilir"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Bağlantı yitirildi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Var olan bağlantı varsayıldı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Modem bulunamadı"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Bluetooth bağlantı başarısız"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM Kart takılı değil"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "SIM Pin gerekli"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "SIM Puk gerekli"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Yanlış SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Bağlantı bağımlılığı başarısız"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Donanım yazılımı eksik"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Kablo çıkık"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "802.1X güvenliğinde (wpa-eap) tanımlanmamış hata"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "hiçbir dosya seçilmedi"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "eap-method dosyası doğrulamada belirtilmemiş hata"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER, PEM, PKCS#12 veya PGP özel anahtarı"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER veya PEM sertifikaları"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "EAP-FAST PAC dosyası eksik"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC dosyaları (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4519,14 +2500,6 @@ msgstr "İç k_imlik doğrulaması"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Kendiliğinden PAC ön _hazırlığına izin ver"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "EAP-LEAP kullanıcı adı eksik"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "EAP-LEAP parolası eksik"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4552,15 +2525,6 @@ msgstr "_Parola"
 msgid "Sho_w password"
 msgstr "Parolayı _göster"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "geçersiz EAP-PEAP CA sertifikası: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "geçersiz EAP-PEAP CA sertifikası: sertifika belirtilmedi"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4582,7 +2546,6 @@ msgid "C_A certificate"
 msgstr "C_A sertifikası"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4597,62 +2560,6 @@ msgstr "CA sertifikası _gerekli değildir"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP _sürümü"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "eksik EAP kullanıcı adı"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "eksik EAP parolası"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "eksik EAP-TLS kimliği"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "geçersiz EAP-TLS CA sertifikası: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "geçersiz EAP-TLS CA sertifikası: sertifika belirtilmedi"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "geçersiz EAP-TLS gizli-anahtarı: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "geçersiz EAP-TLS kullanıcı-sertifikası: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Şifrelenmemiş özel anahtarlar güvensizdir"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Seçilen özel anahtar parolayla korunmuyor. Bu güvenliğinizi tehlikeye "
-"düşürebilir. Lütfen parola ile korunan özel anahtar seçin.\n"
-"\n"
-"(OpenSSL ile özel anahtarınızı şifreleyebilirsiniz)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Kişisel sertifikanızı seçin"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Özel anahtarınızı seçin"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4669,15 +2576,6 @@ msgstr "Özel _anahtar"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Özel anahtar _parolası"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "geçersiz EAP-TTLS CA sertifikası: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "geçersiz EAP-TTLS CA sertifikası: sertifika belirtilmedi"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4700,14 +2598,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Etki Alanı"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "802.1X güvenliğini doğrulamada bilinmeyen hata"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4735,62 +2634,10 @@ msgstr "Korumalı EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "Kimlik _doğrulaması"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Dosya seç"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "leap-kullanıcı adı eksik"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "leap-parolası eksik"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Kablosuz parolası eksik."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Tür"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "wep-anahtarı eksik"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"geçersiz wep-anahtarı: %zu uzunluğundaki anahtar yalnızca onaltılı (hex) "
-"rakamlardan oluşmalı"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"geçersiz wep-anahtarı: %zu uzunluğundaki anahtar yalnızca ascii karakterler "
-"içermelidir"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"geçersiz wep-anahtarı: geçersiz anahtar uzunluğu %zu. Anahtar ya 5/13 "
-"(ascii) ya da 10/26 (onaltılık) uzunluğunda olmalıdır"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "geçersiz wep-anahtarı: parola boş olmamalıdır"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "geçersiz wep-anahtarı: parola 64 karakterden kısa olmalıdır"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4815,19 +2662,6 @@ msgstr "Anahtarı g_öster"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP ende_ksi"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"geçersiz wpa-psk: geçersiz anahtar uzunluğu %zu. [8,63] bayt ya da 64 "
-"onaltılık rakam olmalıdır"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "geçersiz wpa-psk: 64 baytlık anahtar onaltılık olarak yorumlanamıyor"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4882,27 +2716,9 @@ msgstr "Ki_lit Ekranı Bildirimleri"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Hangi bildirimlerin gösterileceğini ve ne göstereceklerini ayarlayın"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Bildirimler;Pencerecik;İleti;Mesaj;Tepsi;Açılır Pencere;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Diğer"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s kaldırıldı"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Hesap kaldırılırken hata oluştu"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4926,17 +2742,6 @@ msgstr "İnternet bağlantısı yok — yeni çevrim içi hesaplar kurmak için 
 msgid "Add an account"
 msgstr "Hesap ekle"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s Hesabı"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Hesabı Kaldır"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Çevrim İçi Hesaplar"
@@ -4946,10 +2751,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Çevrim içi hesaplarınıza bağlanın ve ne için kullanacağınızı belirleyin"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4958,10 +2759,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;Çevrimiçi;Çevrim içi;Sohbet;Takvim;"
 "Mektup;Posta;Bağlantı;Kişi;Cep;SonraOku;SonradanOku;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Bilinmeyen süre"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4975,13 +2772,6 @@ msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i saat"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4991,190 +2781,6 @@ msgstr[0] "saat"
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "dakika"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "Tümüyle dolana dek %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Dikkat: %s kaldı"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "%s kaldı"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Tümüyle dolu"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Şarj olmuyor"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Boş"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Şarj oluyor"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Boşalıyor"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Kablosuz fare"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Kablosuz klavye"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Kesintisiz güç kaynağı"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Kişisel sayısal yardımcı (PDA)"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Cep telefonu"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Ortam oynatıcısı"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Tablet"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Bilgisayar"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Oyun girdi aygıtı"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Pil"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Birincil"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Ek"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Piller"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Bo_şta olduğunda"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Askıya al"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Kapat"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Derin uyku"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Hiçbir şey"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Pille çalışırken"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Fişe takıldığında"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Asla"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Kendiliğinden askıya al"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Yüksek çalışma sıcaklığı nedeniyle başarım kipi geçici olarak devre dışı "
-"bırakıldı."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Diz saptandı: başarım kipi geçici olarak kullanılamıyor. Düzeltmek için "
-"aygıtı sabit yüzeye taşıyın."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Başarım kipi geçici olarak devre dışı bırakıldı."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Düşük pil: güç tutumu etkinleştirildi. Pil yeterince dolduğunda önceki kipe "
-"dönülecek."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "“%s”, Güç Tutum kipini aktifleştirdi."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "“%s”, başarım kipini aktifleştirdi."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5235,6 +2841,15 @@ msgstr "100 dakika"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 saat"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Pil"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Aygıtlar"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5313,33 +2928,6 @@ msgstr "_Pil ile Çalışırken"
 msgid "Delay"
 msgstr "Gecikme"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Başarım"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Yüksek başarım ve güç kullanımı."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Dengeli"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Temel başarım ve güç kullanımı."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Güç Tutumu"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Düşük başarım ve güç kullanımı."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Güç"
@@ -5348,7 +2936,6 @@ msgstr "Güç"
 msgid "View your battery status and change power saving settings"
 msgstr "Pil durumunuzu görüntüleyin ve güç koruma ayarlarını değiştirin"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5356,27 +2943,6 @@ msgid ""
 msgstr ""
 "Güç;Uyku;Bekleme;Derin Uyku;Pil;Parlaklık;Karartma;Boş;Monitör;DPMS;Boşta;"
 "Eylemsiz;Enerji;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "“%s” yazıcısı silindi"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Yeni yazıcı eklenemedi."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Arayüz yüklenemedi: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Yazıcı Eklemek ve Ayarları Değiştirmek İçin Kilidi Kaldır"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5388,7 +2954,6 @@ msgstr ""
 "Yazıcı ekleyin, yazıcı görevlerini görüntüleyin ve nasıl çıktı alacağınıza "
 "karar verin"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Yazıcı;Kuyruk;Yazdır;Kâğıt;Mürekkep;Toner;"
@@ -5396,8 +2961,6 @@ msgstr "Yazıcı;Kuyruk;Yazdır;Kâğıt;Mürekkep;Toner;"
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Yazıcı Ekle"
 
@@ -5438,29 +3001,6 @@ msgstr ""
 msgid "Username"
 msgstr "Kullanıcı Adı"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s Ayrıntıları"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Uygun sürücü bulunamadı"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "PPD Dosyası Seç"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"PostScript Yazıcı Tanımlama dosyaları (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Yazıcı adları BOŞLUK, SEKME, # veya / içeremez"
@@ -5469,9 +3009,7 @@ msgstr "Yazıcı adları BOŞLUK, SEKME, # veya / içeremez"
 msgid "Location"
 msgstr "Konum"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Sürücü"
 
@@ -5499,139 +3037,19 @@ msgstr "Yazıcı Sürücüsü Seçin"
 msgid "Loading drivers database…"
 msgstr "Sürücü veritabanı yükleniyor…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "İptal"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Seç"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect Yazıcı"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD Yazıcı"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Tek Taraflı"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Uzun Kenar (Standart)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Kısa Kenar (Çevrilmiş)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Dikey"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Yatay"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Ters yatay"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Ters dikey"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Sürdür"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Duraklat"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Beklemede"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Duraklatıldı"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Kimlik doğrulaması gerekli"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "İşleniyor"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Durduruldu"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "İptal edildi"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Hata nedeniyle iptal edildi"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Tamamlandı"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Bu görevi sıranın en üstüne taşı"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u Görev Kimlik Doğrulaması Gerektiriyor"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — Etkin Görevler"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "%s üzerinden yazdırmak için kimlik bilgilerini gir."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5659,320 +3077,16 @@ msgstr "Kimlik doğrul_ama"
 msgid "No Active Printer Jobs"
 msgstr "Etkin Yazıcı Görevi Yok"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Yazıcı Sunucusu Kilidini Aç"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "%s Kilidini Aç."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "%s üzerindeki yazıcıları görmek için kullanıcı adı ve parola gir."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Yazıcılar Aranıyor"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Seri Bağlantı Noktası"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Paralel Bağlantı Noktası"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Konum: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Adres: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Sunucu kimlik doğrulaması gerektiriyor"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Çift Taraflı"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Kağıt Türü"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Kağıt Kaynağı"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Çıktı Tepsisi"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Çözünürlük"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript ön-süzgeçleme"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Yüz başına sayfa"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Çift taraflı"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Yönelim"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Genel"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Sayfa Ayarları"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Kurulabilir Seçenekler"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Görev"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Görüntü Niteliği"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Renk"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Rötuş"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Gelişmiş"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Sınama Sayfası"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Sınama sayfası"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Kendiliğinden Seç"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Yazıcı Öntanımlısı"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Yalnızca GhostScript yazıtiplerini göm"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "PS düzey 1’e dönüştür"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "PS düzey 2’ye dönüştür"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Ön-süzgeçleme yok"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Üretici"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Etkin Görev Yok"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u Görev"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Yazdırma başlıklarını temizle"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Toner düşük düzeyde"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Toner tükendi"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Film banyo kimyasalı az"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Film banyo kimyasalı tükendi"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Renk kartuşu az"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Renk kartuşu tükendi"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Kapak açık"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Kapı açık"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Kağıt az"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Kağıt tükendi"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Kapalı"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Durduruldu"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Atık kutusu neredeyse dolu"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Atık kutusu dolu"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Baskı silindiri ömrünü doldurmak üzere"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Baskı silindiri artık çalışmıyor"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Hazır"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Görev kabul etmiyor"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "İşleniyor"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5996,6 +3110,10 @@ msgstr "Yazdırma Başlıklarını Temizle"
 msgid "Remove Printer"
 msgstr "Yazıcıyı Kaldır"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Etkin Görev Yok"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6016,16 +3134,21 @@ msgid "Restart"
 msgstr "Yeniden Başlat"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Yazıcı Ekle…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Yazıcı Ekle…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Yazıcı yok"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6033,7 +3156,6 @@ msgstr ""
 "Üzgünüm! Sistem yazdırma hizmeti\n"
 "    kullanılamıyor."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Biçimler"
@@ -6061,16 +3183,6 @@ msgstr "Ülkeler veya diller aranabilir."
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Ön İzleme"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "İngiliz"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Metrik"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6108,20 +3220,24 @@ msgstr ""
 "Dil ayarı arayüz metinleri ve web sayfalarında kullanılmaktadır. Biçimlerse "
 "sayı, tarih ve para birimlerinde kullanılmaktadır."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Hesabınız"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Dil"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Biçimler"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Oturum Açma Ekranı"
 
@@ -6133,99 +3249,9 @@ msgstr "Bölge ve Dil"
 msgid "Select your display language and formats"
 msgstr "Ekran dilinizi ve biçimlerinizi seçin"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Dil;Yerleşim;Düzen;Klavye;Girdi;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Yapılacak şeyi sor"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Bir şey yapma"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Klasör aç"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Diğer Ortamlar"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Ses CD’leri için uygulama seç"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Video DVD’leri için uygulama seç"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Müzik çalar bağlandığında çalıştırılacak uygulamayı seç"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Kamera bağlandığında çalıştırılacak uygulamayı seç"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Yazılım CD’leri için uygulama seç"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "ses DVD’si"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "boş Blu-ray diski"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "boş CD diski"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "boş DVD diski"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "boş HD DVD diski"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video diski"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "e-kitap okuyucu"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD video diski"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Resim CD’si"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Süper Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows yazılımı"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6275,7 +3301,6 @@ msgstr "Çıkarılabilir Ortam"
 msgid "Configure Removable Media settings"
 msgstr "Çıkarılabilir Ortam ayarlarını yapılandır"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6283,114 +3308,6 @@ msgid ""
 msgstr ""
 "aygıt;sistem;öntanımlı;uygulama;tercihedilen;yeğlenen;cd;dvd;usb;ses;video;"
 "disk;çıkarılabilir;ortam;otomatikçalıştır;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Ekran Kapanınca"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 saniye"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 dakika"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 dakika"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 dakika"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 dakika"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 dakika"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 saat"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 dakika"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 dakika"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 dakika"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 dakika"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 dakika"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 dakika"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 dakika"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 dakika"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 dakika"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Asla"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6429,40 +3346,40 @@ msgstr ""
 msgid "Show _Notifications on Lock Screen"
 msgstr "_Bildirimleri Kilit Ekranında Göster"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Ki_lit Ekranı Bildirimleri"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Yeni _USB aygıtlarını önle"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr "Ekran kilitliyken yeni USB aygıtlarının sistemle etkileşmesini önle."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Ekran Gizliliği"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Görüş Açısını Kısıtla"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekran"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Ekran Ayarları"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "ekran;monitör;kilit;özel;gizlilik;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Konum Seç"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Tamam"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6493,10 +3410,6 @@ msgstr "Diğerleri"
 msgid "Add Location"
 msgstr "Konum Ekle"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Uygulama bulunamadı"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Uygulama Arama"
@@ -6524,93 +3437,13 @@ msgstr ""
 "Hangi uygulamaların arama sonuçlarını Etkinlikler Genel Görünümünde "
 "göstereceğini belirleyin"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Ara;Bul;Endeks;Gizle;Gizlilik;Sonuçlar;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Paylaşımı için ağ seçilmedi"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Ağlar"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Açık"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Kapalı"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Etkin"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Etkin"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Klasör Seç"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Ekle"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Ortam paylaşımını etkinleştir"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Dosya Paylaşımı, Genel dizininizi ağınızdaki diğer kişilerle şunu kullanarak "
-"paylaşmanızı sağlar: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Uzaktan oturum açma etkinleştirildiğinde, uzak kullanıcılar Güvenli Kabuk "
-"komutunu kullanarak bağlanabilirler:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Kişisel ortam paylaşımını etkinleştir"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Aygıt adı kopyalandı"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Aygıt adresi kopyalandı"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Kullanıcı adı kopyalandı"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Parola kopyalandı"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6741,7 +3574,6 @@ msgstr "Klasörler"
 msgid "Control what you want to share with others"
 msgstr "Diğerleri ile ne paylaşacağınızı denetleyin"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6759,10 +3591,6 @@ msgid "Authentication is required to enable or disable remote login"
 msgstr ""
 "Uzaktan oturum açmayı etkinleştirmek veya devre dışı bırakmak için kimlik "
 "doğrulaması gerekiyor"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Özel"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6795,11 +3623,6 @@ msgstr "Arka"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Ön"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "%s Sınanıyor"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6853,11 +3676,6 @@ msgstr "Ses"
 msgid "Alert Sound"
 msgstr "Uyarı Sesi"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "%100"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Kıs"
@@ -6870,82 +3688,11 @@ msgstr "Ses"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Ses düzeylerini, girdileri, çıktıları ve uyarı seslerini değiştir"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Kart;Mikrofon;Ses;Kaybolma;Denge;Bluetooth;Kulaklık Seti;Ses;Çıktı;Girdi;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Bağlantısı Kesilmiş"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Bağlanıyor"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Bağlı"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Yetkilendirme Hatası"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Yetkilendiriliyor"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Azaltılmış İşlev"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Bağlı ve Yetkilendirilmiş"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Bilinmeyen"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Yetkilendirilmiş:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Bağlı:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Kaydedilmiş:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Aygıt yetkilendirilemedi: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Aygıt unutulamadı: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6978,56 +3725,6 @@ msgstr "Yetkilendir ve Bağla"
 msgid "Forget Device"
 msgstr "Aygıtı Unut"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Hata"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Yetkilendirilmiş"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Thunderbolt altsistemi (boltd) yüklenmemiş veya doğru şekilde ayarlanmamış."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Bağlantı istasyonları ve dış grafik işlemciler gibi aygıtlara doğrudan "
-"erişim tanı."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Yalnızca USB ve Display Port aygıtları bağlanabilir."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt algılanamadı.\n"
-"Sistemin Thunderbolt desteği yok, BIOS’tan devre dışı bırakılmış veya "
-"BIOS’tan desteklenmeyen güvenlik düzeyine ayarlanmış."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt desteği BIOS’tan devre dışı bırakılmış."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Thunderbolt güvenlik düzeyi saptanamadı."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Doğrudan kipe geçilirken hata: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Thunderbolt Desteği Yok"
@@ -7039,6 +3736,12 @@ msgstr "Thunderbolt alt sistemine bağlanılamadı."
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Doğrudan Erişim"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Bağlantı istasyonları ve dış grafik işlemciler gibi aygıtlara doğrudan "
+"erişim tanı."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7056,7 +3759,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Thunderbolt aygıtlarını yönet"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;gizlilik;"
@@ -7258,39 +3960,6 @@ msgstr "Klavyeden _Etkinleştir"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Erişilebilirlik özelliklerini klavyeden aç/kapa"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Öntanımlı"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Orta"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Büyük"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Çok Büyük"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "En Büyük"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d piksel"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Her Zaman Erişilebilirlik Menüsünü Göster"
@@ -7403,32 +4072,7 @@ msgstr "Tüm _ekran yanıp sönsün"
 
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
-msgstr "Tüm _ekran yanıp sönsün"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Kısa"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ Ekran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ Ekran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ Ekran"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Uzun"
+msgstr "Tüm _pencere yanıp sönsün"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7464,7 +4108,7 @@ msgstr "Büyüteç Konumu:"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:163
 msgid "_Follow mouse cursor"
-msgstr "_Fare imlecini takip et"
+msgstr "Fare imlecini _izle"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:174
 msgid "_Screen part:"
@@ -7484,7 +4128,7 @@ msgstr "Büyüteç imleci çevresindeki içeriği _iter"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:231
 msgid "Magnifier cursor moves with _contents"
-msgstr "Büyüteç imleci i_çerik ile birlikte hareket eder"
+msgstr "Büyüteç imleci i_çerik ile birlikte oynar"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
@@ -7585,7 +4229,6 @@ msgstr "Renk Etkileri"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Görme, duyma, yazma, işaretleme ve tıklamayı kolaylaştır"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7599,114 +4242,6 @@ msgstr ""
 "Yardım;Tekrar;Tekrarlanan;Tekrarlayan;Yineleme;Yinelenen;Yineleyen;Yanıp "
 "sönme;görsel;duyma;işitsel;İşitsel;ses;yazım;yazma;canlandırmalar;"
 "animasyonlar;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 saat"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 gün"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 gün"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 gün"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 gün"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 gün"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 gün"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 gün"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 gün"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 gün"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Çöpteki tüm ögeler boşaltılsın mı?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Çöpteki tüm ögeler kalıcı olarak silinecek."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Çöpü _Boşalt"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Tüm geçici dosyalar silinsin mi?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Tüm geçici dosyalar kalıcı olarak silinecek."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "Geçici Dosyaları _Temizle"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 gün"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 gün"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 gün"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Sonsuza dek"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7774,64 +4309,12 @@ msgstr "Dosya Geçmişi ve Çöp"
 msgid "Don't leave traces"
 msgstr "İz bırakma"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "kullanım;son;en son;geçmiş;tarihçe;dosyalar;geçici;tmp;özel;gizlilik;çöp;"
 "geri dönüşüm;temizlik;arınma;koru;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Hesap sağlayıcınızın web adresi ile aynı olmalıdır."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Hesap eklenemedi"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Parolalar eşleşmiyor."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Hesap kaydedilemedi"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Bu alan adıyla kimlik doğrulama yapılamaz"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Etki alanına katılma başarısız"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Oturum açma adı işe yaramadı.\n"
-"Lütfen yeniden deneyin."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Oturum açma parolası işe yaramadı.\n"
-"Lütfen yeniden deneyin."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Etki alanına girilemedi"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Etki alanı bulunamadı. Belki yanlış yazmışsınızdır."
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7884,10 +4367,6 @@ msgstr ""
 "Kurumsal giriş, merkezi yönetimli var olan kullanıcı hesabının bu aygıtta "
 "kullanılmasını sağlar. Ayrıca bu hesabı internet üzerindeki şirket "
 "kaynaklarına erişmede de kullanabilirsiniz."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Daha çok resim için göz at"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7957,222 +4436,6 @@ msgstr "Parmak İzlerini _Sil"
 msgid "Fingerprint Enroll"
 msgstr "Parmak İzi Kaydı"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "aygıt, bu eylemi gerçekleştirmek için elde edilmelidir"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "aygıt, başka süreççe önceden elde edildi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "bu eylemi gerçekleştirmeye izniniz yok"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "herhangi bir iz kaydedilmedi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Kayıt sürecinde aygıtla iletişim kurulamadı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Parmak izi okuyucuyla iletişim kurulamadı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Parmak izi art alan süreciyle iletişim kurulamadı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Parmak izleri listelenemedi: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Kayıtlı parmak izleri silinemedi: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Sol başparmak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Sol orta parmak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "So_l işaret parmağı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Sol yüzük parmağı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Sol serçe parmağı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Sağ başparmak"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Sağ orta parmağı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Sağ işaret pa_rmağı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Sağ yüzük parmağı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Sağ serçe parmağı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Bilinmeyen Parmak İzi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Tamamlandı"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Parmak izi aygıtının bağlantısı kesildi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Parmak izi aygıtının deposu dolu"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Yeni parmak izi kaydedilemedi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Kayıt başlatılamadı: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Yeni parmak izi kaydedilemedi"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Kayıt durdurulamadı: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Parmak izinizi kaydetmek için parmağınızı okuyucuya ardı ardına koyun ve "
-"kaldırın"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Bu parmağı _yeniden kaydet…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Yeni parmak izi tara"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "%s parmak izi aygıtı salınamadı: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Aygıt Okumada Sorun"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "%s parmak izi aygıtı elde edilemedi: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Parmak izi aygıtları alınamadı: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Bu Hafta"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Geçen Hafta"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Oturum Sonlandı"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Oturum Başladı"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Hesap Etkinliği"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Önceki"
@@ -8180,18 +4443,6 @@ msgstr "Önceki"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Sonraki"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Lütfen başka parola seçin."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Lütfen parolanızı yeniden girin."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Parolanız değiştirilemedi"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8213,6 +4464,10 @@ msgstr "Yeni Parola"
 msgid "Confirm Password"
 msgstr "Yeni Parolayı Doğrula"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Parolalar eşleşmiyor."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Sonraki girişte kullanıcının parolasını değiştirmesine olanak tanı"
@@ -8220,134 +4475,6 @@ msgstr "Sonraki girişte kullanıcının parolasını değiştirmesine olanak ta
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Şimdi parola belirle"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Bu türde etki alanına kendiliğinden girilemiyor"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Böylesi etki alanı veya alan (realm) yok"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%2$s etki alanına %1$s olarak giriş yapılamıyor"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Yanlış parola, lütfen yeniden deneyin"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "%s etki alanına bağlanılamadı: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Kullanıcı silinemedi"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Uzaktan yönetilen kullanıcı iptal edilemedi"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Kendi hesabınızı silemezsiniz."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s halen sisteme giriş yapmış durumda"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "Giriş yapmış kullanıcıyı silmek sistemi tutarsız duruma sokabilir."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "%s’in dosyalarını tutmak ister misiniz?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Kullanıcı hesabı silerken ev dizinini, postalarını ve geçici dosyalarını "
-"tutabilirsiniz."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "_Dosyaları Sil"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "Dosyaları _Tut"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
-"Uzaktan yönetilen %s kullanıcısının hesabını iptal etmek istediğinizden emin "
-"misiniz?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "_Sil"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Hesap devre dışı"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Sonraki girişte ayarlanacak"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Hiçbiri"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Oturum açık"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Hesap hizmetiyle bağlantı kurulamadı"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Lütfen AccountService’in kurulu ve etkin olduğundan emin olun."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Bu ayarı değiştirmek için bu bölmenin kilidi açılmalıdır"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Seçilen kullanıcı hesabını sil"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Seçilen kullanıcı hesabını silmek için\n"
-"önce * simgesine tıklayın"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Kullanıcı Eklemek ve Ayarları Değiştirmek İçin Kilidi Kaldır"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8375,7 +4502,6 @@ msgid "Full name"
 msgstr "Tam ad"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Düzenle"
 
@@ -8437,7 +4563,6 @@ msgstr "Kullanıcı hesabı eklemek için kilidi kaldır."
 msgid "Add or remove users and change your password"
 msgstr "Kullanıcı ekleyip kaldırın veya parolanızı değiştirin"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8483,178 +4608,6 @@ msgstr "Kullanıcı hesaplarını yönet"
 msgid "Authentication is required to change user data"
 msgstr "Kullanıcı verisini değiştirmek için kimlik doğrulama gerekiyor"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Yeni parolanın eskisinden farklı olması gerekir."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Bazı harf ve rakamları değiştirmeyi deneyin."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Parolayı biraz daha değiştirmeyi deneyin."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Kullanıcı adınızı içermeyen parola daha güçlü olacaktır."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Adınızı içermeyen parola deneyin."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Paroladaki bazı sözcüklerden kaçınmayı deneyin."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Yaygın sözcükler olmadan deneyin."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Aynı sözcükleri kullanmadan deneyin."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Daha çok sayı kullanmayı dene."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Daha çok büyük harf kullanmayı dene."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Daha çok küçük harf kullanmayı dene."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Noktalama işaretleri gibi daha çok özel karakter kullanmayı dene."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Harf, sayı ve noktalama işareti karışımları kullanmayı deneyin."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Aynı karakterleri yinelemeden deneyin."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Aynı türdeki karakterleri yinelemeden deneyin: harfleri, sayıları ve "
-"noktalama işaretlerini karıştırmalısınız."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "1234 veya abcd gibi sıralamalardan kaçınarak deneyin."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Parola daha uzun olmalıdır. Harf, sayı ve noktalama işareti karışımları "
-"kullanmayı deneyin."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Büyük, küçük karakter karıştırın ve bir iki de sayı kullanın."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr ""
-"Daha çok harf, sayı ve noktalama işareti kullanmak parolanızı daha güçlü "
-"yapacaktır."
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Kimlik doğrulama başarısız"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Yeni parola çok kısa"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Yeni parola çok kolay"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Eski ve yeni parolalar birbirine çok benziyor"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Yeni parola yakın zamanda zaten kullanılmış."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Yeni parola rakam ya da özel karakterler içermeli"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Eski ve yeni parolalar birbirinin aynısı"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Parolanız önceki kimlik doğrulamasından sonra değiştirildi!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Yeni parola yeterli sayıda farklı karakterler içermiyor"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Bilinmeyen hata"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Kullanıcı adı yalnızca a’dan z’ye küçük ya da büyük harfler, rakamlar ve şu "
-"karakterlerin herhangi birinden oluşmalıdır: . - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Üzgünüm, bu kullanıcı adı uygun değil. Lütfen başka deneyin."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Kullanıcı adı fazlasıyla uzun."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8689,53 +4642,11 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Yanlış tıklama saptandı, yeniden başlatılıyor…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "%d düğmesi"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Uygulama tanımlı"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Tuş Vuruşu Gönder"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Monitörü Değiştir"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Ekran Yardımını Görüntüle"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Tablet dizüstü paneline takıldı"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Tablet dış ekrana takıldı"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Dış tablet aygıtı"
-
 # Burada Pad tablete benzeyen fakat ekranı olmayan çizim padleri için kullanılmış.
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Dış çizim aygıtı"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:643
-msgid "All Displays"
-msgstr "Tüm Ekranlar"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8832,22 +4743,6 @@ msgstr "Sağ Fare Düğmesi Tıklaması"
 msgid "Forward"
 msgstr "İleri"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Basınç, eğim ve tümleşik kaydırıcı destekli airbrush kalem"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Basınç, eğim ve dönüş destekli airbrush kalem"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Basınç ve eğim destekli standart kalem"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Basınç destekli standart kalem"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom Tablet"
@@ -8856,54 +4751,96 @@ msgstr "Wacom Tablet"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Düğme eşlemelerini ve grafik tabletler için kalem hassasiyetini ayarla"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Kalem;Silgi;Fare;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Yeni kısayol…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Sahte İkincil Tıklama"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows yazılımı"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Toner düşük düzeyde"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "İkinci tıklama gecikmesi"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows yazılımı"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Verimlilik ve çoklu görev için tercihleri yönet"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Erişim Noktaları"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Ekle"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Kaydet"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "İşlem İptal Edildi"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Hata:</b> Ayar değiştirme izni reddedildi"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Hata:</b> Mobil Donanım Hatası"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Kayıtlı Değil"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Kayıtlı"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Dolaşım"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Aranıyor"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Reddedildi"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8933,212 +4870,13 @@ msgstr "Kendi Numarası"
 msgid "Device Details"
 msgstr "Aygıt Ayrıntıları"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Üretici"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Donanım Yazılımı Sürümü"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Yalnızca 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Yalnızca 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Yalnızca 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Yalnızca 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G, 5G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (Yeğlenen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (Yeğlenen), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (Yeğlenen), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Yeğlenen), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Yeğlenen), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (Yeğlenen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (Yeğlenen), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (Yeğlenen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (Yeğlenen), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (Yeğlenen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (Yeğlenen), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (Yeğlenen), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (Yeğlenen), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (Yeğlenen), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (Yeğlenen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (Yeğlenen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "3G, 5G (Yeğlenen)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (Yeğlenen), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Bilinmeyen"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "SIM kart kilidini aç"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Kilidi Aç"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Lütfen SIM %d için PIN kodu sağlayın"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "SIM kartınızın kilidini açmak için PIN girin"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Lütfen SIM %d için PUK kodu sağlayın"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "SIM kartınızın kilidini açmak için PUK girin"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9151,26 +4889,6 @@ msgstr[0] "Yanlış parola girildi. %1$u hakkınız kaldı"
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "%u hakkınız kaldı"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Yanlış parola girildi."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK kodu 8 haneli sayı olmalıdır"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Yeni PIN Gir"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN kodu 4-8 haneli sayı olmalıdır"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Kilidi Açılıyor…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9228,94 +4946,6 @@ msgstr "SIM’i PIN ile kilitle"
 msgid "M_odem Details"
 msgstr "M_odem Ayrıntıları"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Telefon başarısız"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Telefona bağlantı yok"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "İşleme izin verilmedi"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "İşlem desteklenmiyor"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM takılı değil"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "SIM PIN gerekli"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "SIM PUK gerekli"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM başarısız"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM meşgul"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Geçersiz parola"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "SIM PIN2 gerekli"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "SIM PUK2 gerekli"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Bulunamadı"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Ağ servisi yok"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Ağ zaman aşımı"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "GPRS servislerine izin verilmedi"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Bu konum alanında dolaşıma izin verilmedi"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Belirtilmemiş GPRS hatası"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Hata Yok"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Eylem İptal Edildi"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Erişim reddedildi"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Bilinmeyen Hata"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Ağ Kipi"
@@ -9331,11 +4961,6 @@ msgstr "Ağ Seç"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Ağ Sağlayıcılarını Yenile"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9393,7 +5018,6 @@ msgstr "Mobil Ağ"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Telefon ve mobil veri bağlantılarını yapılandır"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -9412,41 +5036,13 @@ msgstr "Ayarlar, sisteminizi yapılandırmak için birincil arayüzdür."
 msgid "The GNOME Project"
 msgstr "GNOME Projesi"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Sürüm numarasını göster"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Ayrıntılı kipi etkinleştir"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Dizgeyi ara"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Olası panel adlarını listele ve çık"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Gösterilecek panel"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [BAĞIMSIZ DEĞİŞKEN…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Ayar kategorileri"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Gizlilik"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Kullanılabilir Paneller:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9504,7 +5100,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Aramayı iptal et"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Tercihler;Ayarlar;"
@@ -9542,43 +5137,3115 @@ msgstr ""
 "Uygulama penceresinin ilk genişlik, yükseklik ve büyütülüş durumunu içeren "
 "demet."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u Çıktı"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u Girdi"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Sistem Sesleri"
+#~ msgid "System Bus"
+#~ msgstr "Sistem Veriyolu"
 
-#~ msgid "Error: unable to determine HSI level."
-#~ msgstr "Hata: HSI düzeyi saptanamadı."
+#~ msgid "Full access"
+#~ msgstr "Tam erişim"
 
-#~ msgid "Error: unable to determine Incorrect HSI level."
-#~ msgstr "Hata: Geçersiz HSI düzeyi saptanamadı."
+#~ msgid "Session Bus"
+#~ msgstr "Oturum Veriyolu"
 
-#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-#~ msgstr "DER veya PEM sertifikaları (*.der, *.pem, *.crt, *.cer)"
+#~ msgid "Full access to /dev"
+#~ msgstr "/dev konumuna tam erişim"
 
-#~ msgid "Add a Printer…"
-#~ msgstr "Yazıcı Ekle…"
+#~ msgid "Has network access"
+#~ msgstr "Ağ erişimi var"
 
-#~ msgid "Drip"
-#~ msgstr "Damlama"
+#~ msgid "Home"
+#~ msgstr "Ev"
 
-#~ msgid "Glass"
-#~ msgstr "Cam"
+#~ msgid "Read-only"
+#~ msgstr "Salt Okunur"
 
-#~ msgid "Sonar"
-#~ msgstr "Sonar"
+#~ msgid "File System"
+#~ msgstr "Dosya Sistemi"
+
+#~ msgid "Can change settings"
+#~ msgstr "Ayarları değiştirebilir"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s, aşağıdaki izinleri yerleşik olarak bulundurur. Bunlar değiştirilemez. "
+#~ "Bu izinlerden kaygılıysanız uygulamayı kaldırmayı düşünün."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "Uygulamaca açılan %u dosya ve bağlantı türü"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b>, şu türden dosya ve bağlantıları açmada kullanılmaktadır."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "%s disk alanı kullanıldı."
+
+#~ msgid "Select a picture"
+#~ msgstr "Resim seç"
+
+#~ msgid "_Open"
+#~ msgstr "_Aç"
+
+#~ msgid "multiple sizes"
+#~ msgstr "birden çok boyut"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Masaüstü Arka Planı Yok"
+
+#~ msgid "Current background"
+#~ msgstr "Geçerli arka plan"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Kalibrasyon aygıtınızı karenin üzerine yerleştirin ve “Başlat”a basın"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "Kalibrasyon aygıtınızı kalibrasyon konumuna getirip “Sürdür”e basın"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "Kalibrasyon aygıtınızı yüzey konumuna getirip “Sürdür”e basın"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Dizüstü bilgisayarın kapağını kapat"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Düzeltilemeyecek iç hata oluştu."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Kalibrasyon için gerekli araçlar kurulu değil."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Profil oluşturulamadı."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Hedef beyaznokta bulunabilir değildi."
+
+#~ msgid "Complete!"
+#~ msgstr "Tamamlandı!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Kalibrasyon başarısız!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Kalibrasyon aygıtını çıkartabilirsiniz."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Kalibrasyon esnasında kalibrasyon aygıtıyla oynamayın"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Dizüstü Ekranı"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Yerleşik Web Kamerası"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s Monitör"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s Tarayıcı"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s Kamera"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s Yazıcı"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s Web Kamerası"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s için renk yönetimini etkinleştir"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s için renk profillerini göster"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Kalibrasyon yok"
+
+#~ msgid "Default: "
+#~ msgstr "Öntanımlı: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Renk uzayı: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Sınama profili: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC Profil Dosyasını Seç"
+
+#~ msgid "_Import"
+#~ msgstr "_İçe Aktar"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Desteklenen ICC profilleri"
+
+#~ msgid "All files"
+#~ msgstr "Tüm dosyalar"
+
+#~ msgid "Save Profile"
+#~ msgstr "Profili Kaydet"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Seçilen aygıt için renk profili oluştur"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Ölçüm aygıtı algılanamadı. Lütfen açık durumda olduğundan ve doğru "
+#~ "bağlandığından emin olunuz."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Ölçüm aygıtı yazıcı profillemeyi desteklemiyor."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Aygıt türü şu anda desteklenmiyor."
+
+#~ msgid "Standard Space"
+#~ msgstr "Standart Uzaylar"
+
+#~ msgid "Test Profile"
+#~ msgstr "Sınama Profili"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Kendiliğinden"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Düşük Nitelik"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Orta Nitelik"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Yüksek Nitelik"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Öntanımlı RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Öntanımlı CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Öntanımlı Gri"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Üretici tarafından sağlanan fabrika kalibrasyon verisi"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Bu profille tam-ekran görüntü düzeltme olası değil"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Bu profil artık doğru olmayabilir"
+
+#~ msgid "Other…"
+#~ msgstr "Diğer…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Ayarları Değiştirmek İçin Kilidi Kaldır"
+
+#~ msgid "Today"
+#~ msgstr "Bugün"
+
+#~ msgid "Yesterday"
+#~ msgstr "Dün"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d saat"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d dakika"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d saniye"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Erişim Noktası"
+
+#~ msgid "24-hour"
+#~ msgstr "24 saat"
+
+#~ msgid "AM / PM"
+#~ msgstr "ÖÖ / ÖS"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Teknik sorunları bildirmeniz %s gelişimine yaramaktadır. Bu bildirimler, "
+#~ "anonim olarak gönderilir ve kişisel veriden arındırılmıştır. %s"
+
+#~ msgid "On"
+#~ msgstr "Açık"
+
+#~ msgid "Off"
+#~ msgstr "Kapalı"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Değişiklikler Uygulansın Mı?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Değişiklikler Uygulanamadı"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Bu donanım kısıtlamalarından kaynaklanabilir."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Yatay"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Dikey Sağ"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Dikey Sol"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Yatay (ters yüz)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Güvenli Önyükleme Etkin"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
+#~ "önler. Şu anda açıktır ve düzgün çalışmaktadır."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Güvenli Önyükleme Sorunlu"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
+#~ "önler. Şu anda açıktır ancak geçersiz anahtar olduğundan çalışmayacaktır."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Güvenli önyükleme sorunları genellikle bilgisayarınızın UEFI donanım "
+#~ "yazılımı ayarlarından (BIOS) çözülebilir. Donanım üreticiniz, bunu nasıl "
+#~ "yapacağınızla ilgili bilgiyi sağlayabilir."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr "Yardım için donanım üreticinize veya BT desteğine başvurun."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Güvenli Önyükleme Kapatıldı"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
+#~ "önler. Şu anda kapalıdır."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Güvenli önyükleme, genellikle bilgisayarınızın UEFI donanım yazılımı "
+#~ "ayarlarından (BIOS) açılabilir. Yardım için donanım üreticinize veya BT "
+#~ "desteğine başvurun."
+
+#~ msgid "Passed"
+#~ msgstr "Geçti"
+
+#~ msgid "Failed"
+#~ msgstr "Başarısız"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Aygıt, HSI %d düzeyine uymaktadır"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Güvenlik Düzeyi 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Bu aygıt, donanım güvenliği sorunlarına karşı korumasızdır. Bunun nedeni "
+#~ "donanım veya donanım yazılımı yapılandırma sorunu olabilir. BT destek "
+#~ "sağlayıcınıza danışmanız önerilmektedir."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Güvenlik Düzeyi 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Bu aygıt, donanım güvenliği sorunlarına karşı en düşük korumadadır. Bu en "
+#~ "düşük aygıt güvenliği düzeyidir ve yalnızca kolay güvenlik gözdağlarına "
+#~ "karşı koruma sağlar."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Güvenlik Düzeyi 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Bu aygıt, donanım güvenliği sorunlarına karşı temel korumadadır. Bu bazı "
+#~ "yaygın güvenlik gözdağlarına karşı koruma sağlar."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Güvenlik Düzeyi 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Bu aygıt, donanım güvenliği sorunlarına karşı geniş korumadadır. Bu en "
+#~ "yüksek aygıt güvenliği düzeyidir ve gelişmiş güvenlik gözdağlarına karşı "
+#~ "koruma sağlar."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Güvenlik düzeyleri bu aygıt için kullanılabilir değil."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Güvenlik güncelleştirmeleriyle ilgili yardım için donanım üreticinize "
+#~ "başvurun."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Bu sorun, aygıtın UEFI donanım yazılımı ayarlarından veya destek "
+#~ "teknisyenince çözülebilir."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr "Bu sorun, aygıtın UEFI donanım yazılımı ayarlarından çözülebilir."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "Bu sorunun destek teknisyenince çözülmesi olasıdır."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "Aygıt başladığında kötücül yazılımlara karşı korunmaktadır."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Güvenli Önyükleme Sorunlu"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Aygıt başladığında bazı korumalar vardır."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Güvenli Önyükleme Kapalı"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Aygıt başladığında koruma yoktur."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Bu sorun; UEFI donanım yazılımı ayarlarındaki değişimden, işletim sistemi "
+#~ "yapılandırma değişiminden veya bu sistemdeki kötücül yazılımdan "
+#~ "kaynaklanabilir."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Bu sorun, UEFI donanım yazılımı ayarlarındaki değişimden veya bu "
+#~ "sistemdeki kötücül yazılımdan kaynaklanabilir."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Bu sorun, işletim sistemi yapılandırma değişiminden veya bu sistemdeki "
+#~ "kötücül yazılımdan kaynaklanabilir."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Ciddi güvenlik gözdağlarına açık."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Kolay güvenlik gözdağlarına karşı kısıtlı koruma."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Yaygın güvenlik gözdağlarına karşı korunmaktadır."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Geniş kapsamlı güvenlik gözdağlarına karşı koruma."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Kapsamlı Koruma"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Donanım Yazılımı Yazma Koruması"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "AMD Donanım Yazılımı Yazma Koruması Kilitli"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Donanım Yazılımı BIOS Bölgesi"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Donanım Yazılımı BIOS Tanımlayıcı"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Önyükleme öncesi DMA Koruması"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard Doğrulanmış Önyükleme"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM Korumalı"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard Hata İlkesi"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard Sigortası"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET Etkin"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET Etkin"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Şifrelenmiş RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU Koruması"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux Çekirdek Yalıtımı"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux Çekirdek Doğrulama"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux Takas Alanı"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Belleğe Askıya Al"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Boşta Beklet"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI Platform Anahtarı"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI Güvenli Önyükleme"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM Platform Yapılandırma"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM Yeniden İnşası"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel Management Engine Üretim Kipi"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel Management Engine Geçersiz Kıl"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel Management Engine Sürümü"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Donanım Yazılımı Güncellemeleri"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Donanım Yazılımı Onayı"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Donanım Yazılımı Doğrulaması"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Platform Hata Ayıklama"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "İşlemci Güvenlik Denetimleri"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD Geri Alma Koruması"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD Donanım Yazılımı Yeniden Oynatma Koruması"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD Donanım Yazılımı Yazma Koruması"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Sigortalı Platform"
+
+#~ msgid "Valid"
+#~ msgstr "Geçerli"
+
+#~ msgid "Not Valid"
+#~ msgstr "Geçersiz"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Etkin Değil"
+
+#~ msgid "Locked"
+#~ msgstr "Kilitli"
+
+#~ msgid "Not Locked"
+#~ msgstr "Kilitsiz"
+
+#~ msgid "Encrypted"
+#~ msgstr "Şifrelenmiş"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Şifrelenmemiş"
+
+#~ msgid "Tainted"
+#~ msgstr "Lekeli"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Lekesiz"
+
+#~ msgid "Found"
+#~ msgstr "Bulundu"
+
+#~ msgid "Not Found"
+#~ msgstr "Bulunamadı"
+
+#~ msgid "Supported"
+#~ msgstr "Destekleniyor"
+
+#~ msgid "Not Supported"
+#~ msgstr "Desteklenmiyor"
+
+#~ msgid "Unknown"
+#~ msgstr "Bilinmeyen"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bit"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bit"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Bilinmiyor"
+
+#~ msgid "Not Available"
+#~ msgstr "Yok"
+
+#~ msgid "System Logo"
+#~ msgstr "Sistem Logosu"
+
+#~ msgid "No input sources found"
+#~ msgstr "Girdi kaynağı bulunamadı"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Diğer"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Özel Kısayollar"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Alternatif harfler tuşu, ek karakterler girmek için kullanılabilir. "
+#~ "Bunlar bazen klavyenize üçüncü seçenek olarak basılmış olabilir."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Sol Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Sağ Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Sol Süper"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Sağ Süper"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Menü tuşu"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Sağ Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Birleştirme tuşu, geniş türde karakterlerin girilmesini sağlar. Kullanmak "
+#~ "için birleştirmeye ardından bir karakter dizisine basılır.  Örneğin, "
+#~ "birleştirme tuşu ardından <b>C</b> ve <b>o</b>’ya basılması <b>©</b> "
+#~ "girecektir, <b>a</b> ardından <b>'</b> basılması <b>á</b> girecektir."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "%s klavye kısayoluyla girdi kaynakları arasında geçiş yapılabilir.\n"
+#~ "Bu, klavye kısayolları ayarlarından değiştirilebilir."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d değiştirildi"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Tüm Kısayolları Sıfırla?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Kısayolları sıfırlamak özel kısayollarınızı etkileyebilir. Bu geri "
+#~ "alınamaz."
+
+#~ msgid "Reset All"
+#~ msgstr "Tümünü Sıfırla"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s, %s için kullanılıyor. Eğer yerine başka şey koyarsanız, %s devre dışı "
+#~ "bırakılacak"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Yeni kısayolu girin"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Özel Kısayol Belirle"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Kısayol Belirle"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Değiştirmek için yeni kısayol girin: %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Özel Kısayol Ekle"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "İki Parmak Kaydırma"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Beş tık, GEGL zamanı!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Çift tıklama, birincil düğme"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Tek tıklama, birincil düğme"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Çift tıklama, orta düğme"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Tek tıklama, orta düğme"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Çift tıklama, ikincil düğme"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Tek tıklama, ikincil düğme"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "NetworkManager’in çalışması gerekir."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Güvensiz ağ (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Güvenli ağ (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Güvenli ağ (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Güvenli ağ (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Güvenli ağ"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Erişim noktasını açmak %s bağlantısını kesecek ve internete kablosuz "
+#~ "üzerinden erişilemeyecek."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "En az 8 karakter içermelidir"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr ""
+#~ "Erişim noktası durdurulup tüm kullanıcıların bağlantısı kesilsin mi?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "Erişim Noktasını _Durdur"
+
+#~ msgid "Preserve"
+#~ msgstr "Koru"
+
+#~ msgid "Permanent"
+#~ msgstr "Kalıcı"
+
+#~ msgid "Random"
+#~ msgstr "Rastgele"
+
+#~ msgid "Stable"
+#~ msgstr "Kararlı"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Buraya girilen MAC adresi, bu bağlantı kurulduğunda, ağ aygıtının donanım "
+#~ "adresi olarak kullanılacak. Bu özellik MAC klonlama veya hilekarlığı "
+#~ "olarak bilinir. Örnek: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Profil %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Kurumsal"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Hiçbiri"
+
+#~ msgid "Never"
+#~ msgstr "Asla"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/sn"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Yok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Zayıf"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "İyi"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "İyi"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Mükemmel"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Bağlantıyı Unut"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Bağlantı Profilini Kaldır"
+
+#~ msgid "Remove VPN"
+#~ msgstr "VPN’yi Kaldır"
+
+#~ msgid "Details"
+#~ msgstr "Ayrıntılar"
+
+#~ msgid "automatic"
+#~ msgstr "kendiliğinden"
+
+#~ msgid "Identity"
+#~ msgstr "Kimlik"
+
+#~ msgid "Delete Address"
+#~ msgstr "Adresi Sil"
+
+#~ msgid "Delete Route"
+#~ msgstr "Rotayı Sil"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Hiçbiri"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-bit Anahtar (Onaltılık veya ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-bit Parola"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Dinamik WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA ve WPA2 Kişisel"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA ve WPA2 Kurumsal"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Kişisel"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Bağlantı düzenleyicisi açılamadı"
+
+#~ msgid "New Profile"
+#~ msgstr "Yeni Profil"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Geçersiz ayar %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Geçersiz ayar %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Dosyadan içe aktar…"
+
+#~ msgid "Add VPN"
+#~ msgstr "VPN Ekle"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN bağlantısı içe aktarılamıyor"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "“%s” dosyası okunamadı ya da herhangi bir VPN bağlantı bilgisi içermiyor\n"
+#~ "\n"
+#~ "Hata: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "İçe aktarılacak dosyayı seçin"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "“%s” adında dosya zaten var."
+
+#~ msgid "_Replace"
+#~ msgstr "Değişti_r"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr ""
+#~ "%s bağlantısını kaydetmek istediğiniz VPN bağlantısıyla değiştirmek "
+#~ "istiyor musunuz?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "VPN bağlantısı dışa aktarılamıyor"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "“%s” VPN bağlantısı %s’a aktarılamıyor.\n"
+#~ "\n"
+#~ "Hata: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "VPN bağlantısını dışa aktar"
+
+#~ msgid "never"
+#~ msgstr "asla"
+
+#~ msgid "today"
+#~ msgstr "bugün"
+
+#~ msgid "yesterday"
+#~ msgstr "dün"
+
+#~ msgid "Last used"
+#~ msgstr "Son kullanım"
+
+#~ msgid "Add new connection"
+#~ msgstr "Yeni bağlantı ekle"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Seçilen ağlar için ağ ayrıntıları, parolalar ve her türlü özel "
+#~ "yapılandırmalar kaybolacak."
+
+#~ msgid "_Forget"
+#~ msgstr "_Unut"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Bilinen Kablosuz Ağlar"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Unut"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "Sistem ilkeleri Erişim Noktası olarak kullanmayı yasaklıyor"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Kablosuz aygıt Erişim Noktası kipini desteklememektedir"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Yapılandırma URL’si verilmediğinde Vekil Sunucuyu Kendiliğinden Bulma "
+#~ "kullanılır."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Bu güvenli olmayan açık ağlarda önerilmez."
+
+#~ msgid "Status unknown"
+#~ msgstr "Durum bilinmiyor"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Yönetilmeyen"
+
+#~ msgid "Unavailable"
+#~ msgstr "Kullanılamıyor"
+
+#~ msgid "Connecting"
+#~ msgstr "Bağlanıyor"
+
+#~ msgid "Authentication required"
+#~ msgstr "Kimlik doğrulası gerekli"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Bağlantı kesiliyor"
+
+#~ msgid "Connection failed"
+#~ msgstr "Bağlantı başarısız"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Durum bilinmiyor (kayıp)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Yapılandırma başarısız"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP yapılandırması başarısız"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP yapılandırmasının süresi dolmuş"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Özel bilgiler gerekli ancak sağlanmamış"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x istekçisinin bağlantısı kesildi"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x istekçi yapılandırması başarısız oldu"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x istekçisi başarısız oldu"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x istekçisinin kimlik doğrulaması çok uzun sürdü"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP hizmeti başlatılamadı"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP hizmetinin bağlantısı kesildi"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP başarısız"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP istemci başlatılamadı"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP istemci hatası"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP istemcisi başarısız"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Paylaşımlı bağlantı hizmeti başlatılamadı"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Paylaşılmış bağlantı hizmeti başarısız oldu"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP hizmeti başlatılamadı"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP hizmet hatası"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP hizmeti başarısız oldu"
+
+#~ msgid "Line busy"
+#~ msgstr "Hat meşgul"
+
+#~ msgid "No dial tone"
+#~ msgstr "Çevir sesi yok"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Hiçbir taşıyıcı (carrier) elde edilemedi"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Çevirme isteği zaman aşımına uğradı"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Çevirme denemesi başarısız"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Modem başlatma başarısız oldu"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Belirtilen APN seçilemedi"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Ağlar için arama yapılmıyor"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Ağ kaydı reddedildi"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Ağ kaydı zaman aşımına uğradı"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "İstenilen ağa kaydolunamadı"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN doğrulanamadı"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Aygıt için donanım yazılımı eksik olabilir"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Bağlantı yitirildi"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Var olan bağlantı varsayıldı"
+
+#~ msgid "Modem not found"
+#~ msgstr "Modem bulunamadı"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Bluetooth bağlantı başarısız"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM Kart takılı değil"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM Pin gerekli"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM Puk gerekli"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Yanlış SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Bağlantı bağımlılığı başarısız"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Donanım yazılımı eksik"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Kablo çıkık"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "802.1X güvenliğinde (wpa-eap) tanımlanmamış hata"
+
+#~ msgid "no file selected"
+#~ msgstr "hiçbir dosya seçilmedi"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "eap-method dosyası doğrulamada belirtilmemiş hata"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER, PEM, PKCS#12 veya PGP özel anahtarı"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER veya PEM sertifikaları"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "EAP-FAST PAC dosyası eksik"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC dosyaları (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "EAP-LEAP kullanıcı adı eksik"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "EAP-LEAP parolası eksik"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "geçersiz EAP-PEAP CA sertifikası: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "geçersiz EAP-PEAP CA sertifikası: sertifika belirtilmedi"
+
+#~ msgid "missing EAP username"
+#~ msgstr "eksik EAP kullanıcı adı"
+
+#~ msgid "missing EAP password"
+#~ msgstr "eksik EAP parolası"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "eksik EAP-TLS kimliği"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "geçersiz EAP-TLS CA sertifikası: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "geçersiz EAP-TLS CA sertifikası: sertifika belirtilmedi"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "geçersiz EAP-TLS gizli-anahtarı: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "geçersiz EAP-TLS kullanıcı-sertifikası: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Şifrelenmemiş özel anahtarlar güvensizdir"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Seçilen özel anahtar parolayla korunmuyor. Bu güvenliğinizi tehlikeye "
+#~ "düşürebilir. Lütfen parola ile korunan özel anahtar seçin.\n"
+#~ "\n"
+#~ "(OpenSSL ile özel anahtarınızı şifreleyebilirsiniz)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Kişisel sertifikanızı seçin"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Özel anahtarınızı seçin"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "geçersiz EAP-TTLS CA sertifikası: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "geçersiz EAP-TTLS CA sertifikası: sertifika belirtilmedi"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "802.1X güvenliğini doğrulamada bilinmeyen hata"
+
+#~ msgid "Select a file"
+#~ msgstr "Dosya seç"
+
+#~ msgid "missing leap-username"
+#~ msgstr "leap-kullanıcı adı eksik"
+
+#~ msgid "missing leap-password"
+#~ msgstr "leap-parolası eksik"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Kablosuz parolası eksik."
+
+#~ msgid "missing wep-key"
+#~ msgstr "wep-anahtarı eksik"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "geçersiz wep-anahtarı: %zu uzunluğundaki anahtar yalnızca onaltılı (hex) "
+#~ "rakamlardan oluşmalı"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "geçersiz wep-anahtarı: %zu uzunluğundaki anahtar yalnızca ascii "
+#~ "karakterler içermelidir"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "geçersiz wep-anahtarı: geçersiz anahtar uzunluğu %zu. Anahtar ya 5/13 "
+#~ "(ascii) ya da 10/26 (onaltılık) uzunluğunda olmalıdır"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "geçersiz wep-anahtarı: parola boş olmamalıdır"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "geçersiz wep-anahtarı: parola 64 karakterden kısa olmalıdır"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "geçersiz wpa-psk: geçersiz anahtar uzunluğu %zu. [8,63] bayt ya da 64 "
+#~ "onaltılık rakam olmalıdır"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "geçersiz wpa-psk: 64 baytlık anahtar onaltılık olarak yorumlanamıyor"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Diğer"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s kaldırıldı"
+
+#~ msgid "Error removing account"
+#~ msgstr "Hesap kaldırılırken hata oluştu"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s Hesabı"
+
+#~ msgid "Remove Account"
+#~ msgstr "Hesabı Kaldır"
+
+#~ msgid "Unknown time"
+#~ msgstr "Bilinmeyen süre"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "Tümüyle dolana dek %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Dikkat: %s kaldı"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "%s kaldı"
+
+#~ msgid "Fully charged"
+#~ msgstr "Tümüyle dolu"
+
+#~ msgid "Not charging"
+#~ msgstr "Şarj olmuyor"
+
+#~ msgid "Empty"
+#~ msgstr "Boş"
+
+#~ msgid "Charging"
+#~ msgstr "Şarj oluyor"
+
+#~ msgid "Discharging"
+#~ msgstr "Boşalıyor"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Kablosuz fare"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Kablosuz klavye"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Kesintisiz güç kaynağı"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Kişisel sayısal yardımcı (PDA)"
+
+#~ msgid "Cellphone"
+#~ msgstr "Cep telefonu"
+
+#~ msgid "Media player"
+#~ msgstr "Ortam oynatıcısı"
+
+#~ msgid "Tablet"
+#~ msgstr "Tablet"
+
+#~ msgid "Computer"
+#~ msgstr "Bilgisayar"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Oyun girdi aygıtı"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Birincil"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Ek"
+
+#~ msgid "Batteries"
+#~ msgstr "Piller"
+
+#~ msgid "When _idle"
+#~ msgstr "Bo_şta olduğunda"
+
+#~ msgid "Suspend"
+#~ msgstr "Askıya al"
+
+#~ msgid "Power Off"
+#~ msgstr "Kapat"
+
+#~ msgid "Hibernate"
+#~ msgstr "Derin uyku"
+
+#~ msgid "Nothing"
+#~ msgstr "Hiçbir şey"
+
+#~ msgid "When on battery power"
+#~ msgstr "Pille çalışırken"
+
+#~ msgid "When plugged in"
+#~ msgstr "Fişe takıldığında"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Asla"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Kendiliğinden askıya al"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Yüksek çalışma sıcaklığı nedeniyle başarım kipi geçici olarak devre dışı "
+#~ "bırakıldı."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Diz saptandı: başarım kipi geçici olarak kullanılamıyor. Düzeltmek için "
+#~ "aygıtı sabit yüzeye taşıyın."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Başarım kipi geçici olarak devre dışı bırakıldı."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Düşük pil: güç tutumu etkinleştirildi. Pil yeterince dolduğunda önceki "
+#~ "kipe dönülecek."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "“%s”, Güç Tutum kipini aktifleştirdi."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "“%s”, başarım kipini aktifleştirdi."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Başarım"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Yüksek başarım ve güç kullanımı."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Dengeli"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Temel başarım ve güç kullanımı."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Güç Tutumu"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Düşük başarım ve güç kullanımı."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "“%s” yazıcısı silindi"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Yeni yazıcı eklenemedi."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Arayüz yüklenemedi: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Yazıcı Eklemek ve Ayarları Değiştirmek İçin Kilidi Kaldır"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s Ayrıntıları"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Uygun sürücü bulunamadı"
+
+#~ msgid "Select PPD File"
+#~ msgstr "PPD Dosyası Seç"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript Yazıcı Tanımlama dosyaları (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+#~ "*.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect Yazıcı"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD Yazıcı"
+
+#~ msgid "One Sided"
+#~ msgstr "Tek Taraflı"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Uzun Kenar (Standart)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Kısa Kenar (Çevrilmiş)"
+
+#~ msgid "Portrait"
+#~ msgstr "Dikey"
+
+#~ msgid "Landscape"
+#~ msgstr "Yatay"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Ters yatay"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Ters dikey"
+
+#~ msgid "Resume"
+#~ msgstr "Sürdür"
+
+#~ msgid "Pause"
+#~ msgstr "Duraklat"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Beklemede"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Duraklatıldı"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Kimlik doğrulaması gerekli"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "İşleniyor"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Durduruldu"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "İptal edildi"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Hata nedeniyle iptal edildi"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Tamamlandı"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Bu görevi sıranın en üstüne taşı"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — Etkin Görevler"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "%s üzerinden yazdırmak için kimlik bilgilerini gir."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Yazıcı Sunucusu Kilidini Aç"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "%s Kilidini Aç."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "%s üzerindeki yazıcıları görmek için kullanıcı adı ve parola gir."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Yazıcılar Aranıyor"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Seri Bağlantı Noktası"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Paralel Bağlantı Noktası"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Konum: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Adres: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Sunucu kimlik doğrulaması gerektiriyor"
+
+#~ msgid "Two Sided"
+#~ msgstr "Çift Taraflı"
+
+#~ msgid "Paper Type"
+#~ msgstr "Kağıt Türü"
+
+#~ msgid "Paper Source"
+#~ msgstr "Kağıt Kaynağı"
+
+#~ msgid "Output Tray"
+#~ msgstr "Çıktı Tepsisi"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Çözünürlük"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript ön-süzgeçleme"
+
+#~ msgid "Pages per side"
+#~ msgstr "Yüz başına sayfa"
+
+#~ msgid "Orientation"
+#~ msgstr "Yönelim"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Genel"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Sayfa Ayarları"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Kurulabilir Seçenekler"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Görev"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Görüntü Niteliği"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Renk"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Rötuş"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Gelişmiş"
+
+#~ msgid "Test page"
+#~ msgstr "Sınama sayfası"
+
+#~ msgid "Auto Select"
+#~ msgstr "Kendiliğinden Seç"
+
+#~ msgid "Printer Default"
+#~ msgstr "Yazıcı Öntanımlısı"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Yalnızca GhostScript yazıtiplerini göm"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS düzey 1’e dönüştür"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS düzey 2’ye dönüştür"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Ön-süzgeçleme yok"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Yazdırma başlıklarını temizle"
+
+#~ msgid "Out of toner"
+#~ msgstr "Toner tükendi"
+
+#~ msgid "Low on developer"
+#~ msgstr "Film banyo kimyasalı az"
+
+#~ msgid "Out of developer"
+#~ msgstr "Film banyo kimyasalı tükendi"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Renk kartuşu az"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Renk kartuşu tükendi"
+
+#~ msgid "Open cover"
+#~ msgstr "Kapak açık"
+
+#~ msgid "Open door"
+#~ msgstr "Kapı açık"
+
+#~ msgid "Low on paper"
+#~ msgstr "Kağıt az"
+
+#~ msgid "Out of paper"
+#~ msgstr "Kağıt tükendi"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Kapalı"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Durduruldu"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Atık kutusu neredeyse dolu"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Atık kutusu dolu"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Baskı silindiri ömrünü doldurmak üzere"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Baskı silindiri artık çalışmıyor"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Hazır"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Görev kabul etmiyor"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "İşleniyor"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "İngiliz"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Metrik"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Yapılacak şeyi sor"
+
+#~ msgid "Do nothing"
+#~ msgstr "Bir şey yapma"
+
+#~ msgid "Open folder"
+#~ msgstr "Klasör aç"
+
+#~ msgid "Other Media"
+#~ msgstr "Diğer Ortamlar"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Ses CD’leri için uygulama seç"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Video DVD’leri için uygulama seç"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Müzik çalar bağlandığında çalıştırılacak uygulamayı seç"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Kamera bağlandığında çalıştırılacak uygulamayı seç"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Yazılım CD’leri için uygulama seç"
+
+#~ msgid "audio DVD"
+#~ msgstr "ses DVD’si"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "boş Blu-ray diski"
+
+#~ msgid "blank CD disc"
+#~ msgstr "boş CD diski"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "boş DVD diski"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "boş HD DVD diski"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video diski"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-kitap okuyucu"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video diski"
+
+#~ msgid "Picture CD"
+#~ msgstr "Resim CD’si"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Süper Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Ekran Kapanınca"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 saniye"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 dakika"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 dakika"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 dakika"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 dakika"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 dakika"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 saat"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 dakika"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 dakika"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 dakika"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 dakika"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 dakika"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 dakika"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 dakika"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 dakika"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 dakika"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Asla"
+
+#~ msgid "Select Location"
+#~ msgstr "Konum Seç"
+
+#~ msgid "_OK"
+#~ msgstr "_Tamam"
+
+#~ msgid "No applications found"
+#~ msgstr "Uygulama bulunamadı"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Paylaşımı için ağ seçilmedi"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Açık"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Kapalı"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Etkin"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Etkin"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Klasör Seç"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Ortam paylaşımını etkinleştir"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Dosya Paylaşımı, Genel dizininizi ağınızdaki diğer kişilerle şunu "
+#~ "kullanarak paylaşmanızı sağlar: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Uzaktan oturum açma etkinleştirildiğinde, uzak kullanıcılar Güvenli Kabuk "
+#~ "komutunu kullanarak bağlanabilirler:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Kişisel ortam paylaşımını etkinleştir"
+
+#~ msgid "Device name copied"
+#~ msgstr "Aygıt adı kopyalandı"
+
+#~ msgid "Device address copied"
+#~ msgstr "Aygıt adresi kopyalandı"
+
+#~ msgid "Username copied"
+#~ msgstr "Kullanıcı adı kopyalandı"
+
+#~ msgid "Password copied"
+#~ msgstr "Parola kopyalandı"
+
+#~ msgid "Custom"
+#~ msgstr "Özel"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "%s Sınanıyor"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "%100"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Bağlantısı Kesilmiş"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Bağlanıyor"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Bağlı"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Yetkilendirme Hatası"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Yetkilendiriliyor"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Azaltılmış İşlev"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Bağlı ve Yetkilendirilmiş"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Bilinmeyen"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Yetkilendirilmiş:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Bağlı:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Kaydedilmiş:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Aygıt yetkilendirilemedi: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Aygıt unutulamadı: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Hata"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Yetkilendirilmiş"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Thunderbolt altsistemi (boltd) yüklenmemiş veya doğru şekilde "
+#~ "ayarlanmamış."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Yalnızca USB ve Display Port aygıtları bağlanabilir."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt algılanamadı.\n"
+#~ "Sistemin Thunderbolt desteği yok, BIOS’tan devre dışı bırakılmış veya "
+#~ "BIOS’tan desteklenmeyen güvenlik düzeyine ayarlanmış."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt desteği BIOS’tan devre dışı bırakılmış."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Thunderbolt güvenlik düzeyi saptanamadı."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Doğrudan kipe geçilirken hata: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Öntanımlı"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Orta"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Büyük"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Çok Büyük"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "En Büyük"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d piksel"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Kısa"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ Ekran"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ Ekran"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ Ekran"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Uzun"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 saat"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 gün"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 gün"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 gün"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 gün"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 gün"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 gün"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 gün"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 gün"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 gün"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Çöpteki tüm ögeler boşaltılsın mı?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Çöpteki tüm ögeler kalıcı olarak silinecek."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Çöpü _Boşalt"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Tüm geçici dosyalar silinsin mi?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Tüm geçici dosyalar kalıcı olarak silinecek."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "Geçici Dosyaları _Temizle"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 gün"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 gün"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 gün"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Sonsuza dek"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Hesap sağlayıcınızın web adresi ile aynı olmalıdır."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Hesap eklenemedi"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Hesap kaydedilemedi"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Bu alan adıyla kimlik doğrulama yapılamaz"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Etki alanına katılma başarısız"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Oturum açma adı işe yaramadı.\n"
+#~ "Lütfen yeniden deneyin."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Oturum açma parolası işe yaramadı.\n"
+#~ "Lütfen yeniden deneyin."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Etki alanına girilemedi"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Etki alanı bulunamadı. Belki yanlış yazmışsınızdır."
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Daha çok resim için göz at"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "aygıt, bu eylemi gerçekleştirmek için elde edilmelidir"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "aygıt, başka süreççe önceden elde edildi"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "bu eylemi gerçekleştirmeye izniniz yok"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "herhangi bir iz kaydedilmedi"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Kayıt sürecinde aygıtla iletişim kurulamadı"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Parmak izi okuyucuyla iletişim kurulamadı"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Parmak izi art alan süreciyle iletişim kurulamadı"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Parmak izleri listelenemedi: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Kayıtlı parmak izleri silinemedi: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Sol başparmak"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Sol orta parmak"
+
+#~ msgid "_Left index finger"
+#~ msgstr "So_l işaret parmağı"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Sol yüzük parmağı"
+
+#~ msgid "Left little finger"
+#~ msgstr "Sol serçe parmağı"
+
+#~ msgid "Right thumb"
+#~ msgstr "Sağ başparmak"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Sağ orta parmağı"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Sağ işaret pa_rmağı"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Sağ yüzük parmağı"
+
+#~ msgid "Right little finger"
+#~ msgstr "Sağ serçe parmağı"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Bilinmeyen Parmak İzi"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Tamamlandı"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Parmak izi aygıtının bağlantısı kesildi"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Parmak izi aygıtının deposu dolu"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Yeni parmak izi kaydedilemedi"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Kayıt başlatılamadı: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Yeni parmak izi kaydedilemedi"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Kayıt durdurulamadı: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Parmak izinizi kaydetmek için parmağınızı okuyucuya ardı ardına koyun ve "
+#~ "kaldırın"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Bu parmağı _yeniden kaydet…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Yeni parmak izi tara"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "%s parmak izi aygıtı salınamadı: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Aygıt Okumada Sorun"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "%s parmak izi aygıtı elde edilemedi: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Parmak izi aygıtları alınamadı: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Bu Hafta"
+
+#~ msgid "Last Week"
+#~ msgstr "Geçen Hafta"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Oturum Sonlandı"
+
+#~ msgid "Session Started"
+#~ msgstr "Oturum Başladı"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Hesap Etkinliği"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Lütfen başka parola seçin."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Lütfen parolanızı yeniden girin."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Parolanız değiştirilemedi"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Bu türde etki alanına kendiliğinden girilemiyor"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Böylesi etki alanı veya alan (realm) yok"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%2$s etki alanına %1$s olarak giriş yapılamıyor"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Yanlış parola, lütfen yeniden deneyin"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "%s etki alanına bağlanılamadı: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Kullanıcı silinemedi"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Uzaktan yönetilen kullanıcı iptal edilemedi"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Kendi hesabınızı silemezsiniz."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s halen sisteme giriş yapmış durumda"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "Giriş yapmış kullanıcıyı silmek sistemi tutarsız duruma sokabilir."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "%s’in dosyalarını tutmak ister misiniz?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Kullanıcı hesabı silerken ev dizinini, postalarını ve geçici dosyalarını "
+#~ "tutabilirsiniz."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Dosyaları Sil"
+
+#~ msgid "_Keep Files"
+#~ msgstr "Dosyaları _Tut"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Uzaktan yönetilen %s kullanıcısının hesabını iptal etmek istediğinizden "
+#~ "emin misiniz?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Sil"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Hesap devre dışı"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Sonraki girişte ayarlanacak"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Hiçbiri"
+
+#~ msgid "Logged in"
+#~ msgstr "Oturum açık"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Hesap hizmetiyle bağlantı kurulamadı"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Lütfen AccountService’in kurulu ve etkin olduğundan emin olun."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Bu ayarı değiştirmek için bu bölmenin kilidi açılmalıdır"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Seçilen kullanıcı hesabını sil"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Seçilen kullanıcı hesabını silmek için\n"
+#~ "önce * simgesine tıklayın"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Kullanıcı Eklemek ve Ayarları Değiştirmek İçin Kilidi Kaldır"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Yeni parolanın eskisinden farklı olması gerekir."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Bazı harf ve rakamları değiştirmeyi deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Parolayı biraz daha değiştirmeyi deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Kullanıcı adınızı içermeyen parola daha güçlü olacaktır."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Adınızı içermeyen parola deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Paroladaki bazı sözcüklerden kaçınmayı deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Yaygın sözcükler olmadan deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Aynı sözcükleri kullanmadan deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Daha çok sayı kullanmayı dene."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Daha çok büyük harf kullanmayı dene."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Daha çok küçük harf kullanmayı dene."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "Noktalama işaretleri gibi daha çok özel karakter kullanmayı dene."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Harf, sayı ve noktalama işareti karışımları kullanmayı deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Aynı karakterleri yinelemeden deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Aynı türdeki karakterleri yinelemeden deneyin: harfleri, sayıları ve "
+#~ "noktalama işaretlerini karıştırmalısınız."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "1234 veya abcd gibi sıralamalardan kaçınarak deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Parola daha uzun olmalıdır. Harf, sayı ve noktalama işareti karışımları "
+#~ "kullanmayı deneyin."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Büyük, küçük karakter karıştırın ve bir iki de sayı kullanın."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Daha çok harf, sayı ve noktalama işareti kullanmak parolanızı daha güçlü "
+#~ "yapacaktır."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Kimlik doğrulama başarısız"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Yeni parola çok kısa"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Yeni parola çok kolay"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Eski ve yeni parolalar birbirine çok benziyor"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Yeni parola yakın zamanda zaten kullanılmış."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Yeni parola rakam ya da özel karakterler içermeli"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Eski ve yeni parolalar birbirinin aynısı"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Parolanız önceki kimlik doğrulamasından sonra değiştirildi!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Yeni parola yeterli sayıda farklı karakterler içermiyor"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Bilinmeyen hata"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Kullanıcı adı yalnızca a’dan z’ye küçük ya da büyük harfler, rakamlar ve "
+#~ "şu karakterlerin herhangi birinden oluşmalıdır: . - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Üzgünüm, bu kullanıcı adı uygun değil. Lütfen başka deneyin."
+
+#~ msgid "The username is too long."
+#~ msgstr "Kullanıcı adı fazlasıyla uzun."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "%d düğmesi"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Uygulama tanımlı"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Tuş Vuruşu Gönder"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Monitörü Değiştir"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Ekran Yardımını Görüntüle"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Tablet dizüstü paneline takıldı"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Tablet dış ekrana takıldı"
+
+#~ msgid "External tablet device"
+#~ msgstr "Dış tablet aygıtı"
+
+#~ msgid "All Displays"
+#~ msgstr "Tüm Ekranlar"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Basınç, eğim ve tümleşik kaydırıcı destekli airbrush kalem"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Basınç, eğim ve dönüş destekli airbrush kalem"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Basınç ve eğim destekli standart kalem"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Basınç destekli standart kalem"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Yeni kısayol…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "İşlem İptal Edildi"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Hata:</b> Ayar değiştirme izni reddedildi"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Hata:</b> Mobil Donanım Hatası"
+
+#~ msgid "Not Registered"
+#~ msgstr "Kayıtlı Değil"
+
+#~ msgid "Registered"
+#~ msgstr "Kayıtlı"
+
+#~ msgid "Roaming"
+#~ msgstr "Dolaşım"
+
+#~ msgid "Searching"
+#~ msgstr "Aranıyor"
+
+#~ msgid "Denied"
+#~ msgstr "Reddedildi"
+
+#~ msgid "2G Only"
+#~ msgstr "Yalnızca 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Yalnızca 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Yalnızca 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Yalnızca 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G, 5G (Yeğlenen)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (Yeğlenen), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (Yeğlenen), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (Yeğlenen), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Yeğlenen)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Yeğlenen), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Yeğlenen), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (Yeğlenen)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (Yeğlenen), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (Yeğlenen), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (Yeğlenen)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (Yeğlenen), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (Yeğlenen), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (Yeğlenen)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (Yeğlenen), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (Yeğlenen), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Yeğlenen)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Yeğlenen), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Yeğlenen)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Yeğlenen), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Yeğlenen)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Yeğlenen), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (Yeğlenen)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (Yeğlenen), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Yeğlenen)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (Yeğlenen), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "3G, 5G (Yeğlenen)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (Yeğlenen), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Bilinmeyen"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "SIM kart kilidini aç"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Lütfen SIM %d için PIN kodu sağlayın"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "SIM kartınızın kilidini açmak için PIN girin"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Lütfen SIM %d için PUK kodu sağlayın"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "SIM kartınızın kilidini açmak için PUK girin"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Yanlış parola girildi."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK kodu 8 haneli sayı olmalıdır"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Yeni PIN Gir"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN kodu 4-8 haneli sayı olmalıdır"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Kilidi Açılıyor…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Telefon başarısız"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Telefona bağlantı yok"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "İşleme izin verilmedi"
+
+#~ msgid "Operation not supported"
+#~ msgstr "İşlem desteklenmiyor"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM takılı değil"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "SIM PIN gerekli"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "SIM PUK gerekli"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM başarısız"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM meşgul"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Geçersiz parola"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "SIM PIN2 gerekli"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "SIM PUK2 gerekli"
+
+#~ msgid "Not found"
+#~ msgstr "Bulunamadı"
+
+#~ msgid "No network service"
+#~ msgstr "Ağ servisi yok"
+
+#~ msgid "Network timeout"
+#~ msgstr "Ağ zaman aşımı"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "GPRS servislerine izin verilmedi"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Bu konum alanında dolaşıma izin verilmedi"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Belirtilmemiş GPRS hatası"
+
+#~ msgid "No Error"
+#~ msgstr "Hata Yok"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Eylem İptal Edildi"
+
+#~ msgid "Access denied"
+#~ msgstr "Erişim reddedildi"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Bilinmeyen Hata"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Sürüm numarasını göster"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Ayrıntılı kipi etkinleştir"
+
+#~ msgid "Search for the string"
+#~ msgstr "Dizgeyi ara"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Olası panel adlarını listele ve çık"
+
+#~ msgid "Panel to display"
+#~ msgstr "Gösterilecek panel"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [BAĞIMSIZ DEĞİŞKEN…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Kullanılabilir Paneller:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Sistem Sesleri"

--- a/po/tr.po~
+++ b/po/tr.po~
@@ -1,0 +1,9562 @@
+# Turkish translation of gnome-control-center.
+# Copyright (C) 2000-2003, 2004, 2005, 2008, 2009, 2011 Free Software Foundation, Inc.
+# Copyright (C) 2012-2022 gnome-control-center's COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Nilgün Belma Bugüner <nilgun@fide.org>, 2001.
+# Fatih Demir <kabalak@gtranslator.org>, 2000.
+# Baris Cicek <baris@teamforce.name.tr>, 2004, 2005, 2008, 2009.
+# Erçin EKER <ercin@linux.org.tr>, 2011.
+# ztugcesirin <ztugcesirin@gmail.com>, 2014.
+# Furkan Tokaç <developmentft@gmail.com>, 2017.
+# Furkan Ahmet Kara <furkanahmetkara.fk@gmail.com>, 2018.
+# Çağatay Yiğit Şahin <cyigitsahin@outlook.com>, 2018.
+# Muhammet Kara <muhammetk@gmail.com>, 2011-2021.
+# Sabri Ünal <libreajans@gmail.com>, 2014, 2019, 2022.
+# Emin Tufan Çetin <etcetin@gmail.com>, 2013-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-09-19 20:16+0000\n"
+"PO-Revision-Date: 2022-09-23 20:14+0300\n"
+"Last-Translator: Emin Tufan Çetin <etcetin@gmail.com>\n"
+"Language-Team: Turkish <gnometurk@gnome.org>\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Sistem Veriyolu"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Tam erişim"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Oturum Veriyolu"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Aygıtlar"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "/dev konumuna tam erişim"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Ağ"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Ağ erişimi var"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Ev"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Salt Okunur"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Dosya Sistemi"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Ayarlar"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Ayarları değiştirebilir"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s, aşağıdaki izinleri yerleşik olarak bulundurur. Bunlar değiştirilemez. Bu "
+"izinlerden kaygılıysanız uygulamayı kaldırmayı düşünün."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "Uygulamaca açılan %u dosya ve bağlantı türü"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b>, şu türden dosya ve bağlantıları açmada kullanılmaktadır."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "%s disk alanı kullanıldı."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Uygulamalar"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Uygulama yok"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Birkaç tane kur…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Aç"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Ayrıntıları Görüntüle"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Arama"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Sistem aramaları al ve sonuçları gönder."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Devre dışı"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Bildirimler"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Sistem bildirimlerini göster."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Arka Planda Çalış"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Uygulama kapanınca etkinliğe izin ver."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Ekran Görüntüleri"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Herhangi bir zamanda ekranın resimlerini çek."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Duvar Kağıdını Değiştir"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Masaüstü duvar kağıdını değiştir."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Sesler"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Sesleri türet."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Kısayolları Kısıtla"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Standart klavye kısayollarını engelle."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Kamera"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Kamerayla fotoğraf çek."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Mikrofon"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Mikrofonla ses kaydet."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Konum Hizmetleri"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Aygıt konum bilgisine eriş."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Yerleşik İzinler"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Uygulamanın gereksindiği sistem erişimi"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Dosya ve Bağlantı İlişkileri"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Biriktirme"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Sonuç bulunamadı"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Başka arama dene"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Dosya ve Bağlantı İlişkileri"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Dosya Türleri"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Bağlantı Türleri"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Sıfırla"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Bu uygulamanın uygulama verisi ve önbelleklerle ne kadar disk alanı "
+"kapladığı."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Uygulama"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Veri"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Önbellek"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Toplam</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Önbelleği Temizle…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Türlü uygulama izinlerini ve ayarlarını denetle"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "uygulama;flatpak;izin;yetki;ayar;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Resim seç"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_İptal"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Aç"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "birden çok boyut"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Masaüstü Arka Planı Yok"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Geçerli arka plan"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Biçim"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Öntanımlı"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Koyu"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Arka Plan"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Resim Ekle…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Görünüm"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Arka plan görüntüsü veya kullanıcı arayüzü renklerinizi değiştirin"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Arka plan;Arkaplan;Duvar kağıdı;Ekran;Masaüstü;Biçim;Biçem;Stil;Aydınlık;"
+"Açık;Karanlık;Koyu;Görünüm;Görünüş;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Etkinleştir"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Bluetooth Bulunamadı"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Bluetooth özelliğini kullanmak için aygıt takmalısınız."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth Kapatıldı"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Aygıtlara bağlanmak ve dosya aktarımı yapmak için açın."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Uçak Kipi Açık"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Uçak kipi açıldığında Bluetooth devre dışı kalır."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Uçak Kipini Kapat"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Donanımsal Uçak Kipi Açık"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Bluetooth’u etkinleştirmek için Uçak kipini kapat."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Bluetooth’u açıp kapatın ve aygıtlarınızı bağlayın"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "paylaş;paylaşım;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Kamera Kapatıldı"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Hiçbir uygulama fotoğraf veya video yakalayamıyor."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Kamera kullanımı uygulamaların fotoğraf ve video yakalamasını sağlar. "
+"Kamerayı devre dışı bırakmak bazı uygulamaların işlevini yerine "
+"getirememesine neden olabilir.\n"
+"\n"
+"Aşağıdaki uygulamaların kameranızı kullanmasını sağlayın."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Hiçbir Uygulama Kamera Erişimi İsteği Yapmadı"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Fotoğraflarınızı koruyun"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"kamera;fotoğraflar;resimler;video;görüntü;webcam;web kamerası;webkam;kilitle;"
+"özel;gizlilik;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Kalibrasyon aygıtınızı karenin üzerine yerleştirin ve “Başlat”a basın"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "Kalibrasyon aygıtınızı kalibrasyon konumuna getirip “Sürdür”e basın"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Kalibrasyon aygıtınızı yüzey konumuna getirip “Sürdür”e basın"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Dizüstü bilgisayarın kapağını kapat"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Düzeltilemeyecek iç hata oluştu."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Kalibrasyon için gerekli araçlar kurulu değil."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Profil oluşturulamadı."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Hedef beyaznokta bulunabilir değildi."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Tamamlandı!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Kalibrasyon başarısız!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Kalibrasyon aygıtını çıkartabilirsiniz."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Kalibrasyon esnasında kalibrasyon aygıtıyla oynamayın"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Ekran Kalibrasyonu"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Başlat"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Sürdür"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Bitti"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Dizüstü Ekranı"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Yerleşik Web Kamerası"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s Monitör"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s Tarayıcı"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s Kamera"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s Yazıcı"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s Web Kamerası"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "%s için renk yönetimini etkinleştir"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s için renk profillerini göster"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Kalibrasyon yok"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Öntanımlı: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Renk uzayı: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Sınama profili: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "ICC Profil Dosyasını Seç"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_İçe Aktar"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Desteklenen ICC profilleri"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Tüm dosyalar"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekran"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Profili Kaydet"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Kaydet"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Seçilen aygıt için renk profili oluştur"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Ölçüm aygıtı algılanamadı. Lütfen açık durumda olduğundan ve doğru "
+"bağlandığından emin olunuz."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Ölçüm aygıtı yazıcı profillemeyi desteklemiyor."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Aygıt türü şu anda desteklenmiyor."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Ekran Kalibrasyonu"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Kalibrasyon Niteliği"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Kalibrasyon, ekran renk ayarlarınızı yönetebileceğiniz profil üretecektir. "
+"Kalibrasyon için ne kadar vakit harcarsanız, renk profiliniz o denli "
+"nitelikli olacaktır."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Kalibrasyon esnasında bilgisayarınızı kullanamayacaksınız."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Nitelik"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Yaklaşık Süre"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Kalibrasyon Aygıtı"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Kalibrasyon için kullanılacak algılayıcı aygıtını seçin."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Ekran Türü"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Bağlı olan ekran türünü seçin."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Profil Beyaznoktası"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Ekran için hedef beyaz nokta seç. Çoğu ekran D65 parlaklığına ayarlanmalıdır."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Ekran Parlaklığı"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Lütfen ekran parlaklığını kişisel tercihinize göre ayarlayın. Renk yönetimi "
+"ayarladığınız düzeyde en doğru olacaktır."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Alternatif olarak, bu aygıt için diğer profillerde kullanılan parlaklık "
+"düzeyini kullanabilirsiniz."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Profil Adı"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Renk profilini başka bilgisayarlarda kullanabilir ya da başka ışıklandırma "
+"koşulları için de profiller oluşturabilirsiniz."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Profil Adı:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Özet"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Profil başarıyla yaratıldı!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Profil kopyala"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Yazılabilir ortam gerektirir"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Profili <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> ve "
+"<a href=\"windows\">Microsoft Windows</a> sistemleri üzerinde nasıl "
+"kullanacağınıza dair bu yönergeleri yararlı bulabilirsiniz."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Profil Ekle"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Bazı sorunlar saptandı. Bu profil düzgün çalışmayabilir. <a "
+"href=\"\">Ayrıntıları göster.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "Dosyayı _İçe Aktar…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Ekle"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "Her aygıt, renk yönetimleri için güncel renk profiline gereksinir."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Daha çoğunu öğren"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Renk yönetimi hakkında daha çok bilgi edin"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Tüm kullanıcılar için _ayarla"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Bu profili bilgisayardaki tüm kullanıcılar için ayarla"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Etkinleştir"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Profil _ekle"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Kalibrasyon…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Aygıtı kalibre et"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "Profili kaldı_r"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "Ayrıntıları _görüntüle"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Renk yönetimi yapılabilecek aygıt algılanamadı"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Projektör"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plazma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL aydınlatma)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED aydınlatma)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (beyaz LED aydınlatma)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Geniş renk yelpazeli LCD (CCFL aydınlatma)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Geniş renk yelpazeli LCD (RGB LED aydınlatma)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Yüksek"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 dakika"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Orta"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 dakika"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Düşük"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 dakika"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Ekrana özgü"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (Baskı ve yayınlama)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Fotoğraf ve grafik)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Standart Uzaylar"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Sınama Profili"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Kendiliğinden"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Düşük Nitelik"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Orta Nitelik"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Yüksek Nitelik"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Öntanımlı RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Öntanımlı CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Öntanımlı Gri"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Üretici tarafından sağlanan fabrika kalibrasyon verisi"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Bu profille tam-ekran görüntü düzeltme olası değil"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Bu profil artık doğru olmayabilir"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Renk"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Ekran, kamera veya yazıcı gibi aygıtlarınızın renk kalibrasyonunu yapın"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Renk;ICC;Profil;Ayar;Yazıcı;Ekran;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Diğer…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Dil Seç"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Seç"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Dil bulunamadı"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Daha çok…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Ayarları Değiştirmek İçin Kilidi Kaldır"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Bazı ayarların kilidi değiştirilmeden önce kaldırılmalıdır."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Kilidi Aç…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Saati Artır"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Dakikayı Artır"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Zaman"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Saati Azalt"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Dakikayı Azalt"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Bugün"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Dün"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d saat"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d dakika"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d saniye"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 saniye"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Erişim Noktası"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 saat"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "ÖÖ / ÖS"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Tarih ve Saat"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Yıl"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Ay"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Ocak"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Şubat"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Mart"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Nisan"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Mayıs"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Haziran"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Temmuz"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Ağustos"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Eylül"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Ekim"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Kasım"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Aralık"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Gün"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Saat Dilimi"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Şehir ara"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Kendiliğinden _Tarih ve Saat"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "İnternet erişimi gerektirir"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Tarih ve _Saat"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Kendiliğinden Saat _Dilimi"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "Konum hizmetlerinin etkin olmasını ve İnternet erişimi gerektirir"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Etkin"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "Saat _Dilimi"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "Saat _Biçimi"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Tarihi, saati ve saat dilimini değiştir"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Saat;Saat Dilimi;Zaman Dilimi;Yer;Konum;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Sistem saatini ve tarihini değiştir"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+"Saat ya da tarih ayarlarını değiştirmek için kimliğinizi doğrulamanız "
+"gerekiyor."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Posta"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Takvim"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "M_üzik"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Video"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Fotoğraflar"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Öntanımlı Uygulamalar"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Öntanımlı Uygulamaları Yapılandır"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "öntanımlı;uygulama;tercihen;yeğlenen;ortam;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Teknik sorunları bildirmeniz %s gelişimine yaramaktadır. Bu bildirimler, "
+"anonim olarak gönderilir ve kişisel veriden arındırılmıştır. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Sorun Bildirimi"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Kendiliğinden Sorun Bildirimi"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Tanılama"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Sorunları raporla"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "tanılama;teşhis;çökme;bozulma;kırılma;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Açık"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Kapalı"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Değişiklikler Uygulansın Mı?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Değişiklikler Uygulanamadı"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Bu donanım kısıtlamalarından kaynaklanabilir."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Uygula"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Geri"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Ekran Ayarları Devre Dışı"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Çoklu Ekranlar"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "Birleşik"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Aynala"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Üst çubuk ve Etkinlikleri içerir"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Birincil Ekran"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Gece Işığı"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Yatay"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Dikey Sağ"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Dikey Sol"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Yatay (ters yüz)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Yönelim"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Çözünürlük"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Tazeleme Hızı"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "TV için Ayarla"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Ölçekle"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "Gece Işığı kullanılamıyor"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Bu, grafik sürücüsü veya masaüstünün uzaktan kullanılmasından kaynaklanabilir"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Yarına Dek Geçici Olarak Devre Dışı Bırakıldı"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Süzgeci Yeniden Başlat"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Gece ışığı, ekran rengini daha sıcak yapar. Bu, göz yorgunluğunu ve "
+"uykusuzluğu önlemeye yardımcı olur."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Zamanlama"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Gün Batımından Gün Doğumuna"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Elle Zamanlama"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Saatler"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "Şu Zamandan"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Saat"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Dakika"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "ÖÖ"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "ÖS"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "Şu Zamana"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Renk Sıcaklığı"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Ekranlar"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Bağlanan ekranların ya da projektörlerin nasıl kullanılacağını seçin"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projektör;Gösterici;xrandr;Ekran;Çözünürlük;Tazele;Yenile;Monitör;Gece;"
+"Işık;Mavi;redshift;renk;gün doğumu;gün batımı;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Güvenli Önyükleme Etkin"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
+"önler. Şu anda açıktır ve düzgün çalışmaktadır."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Güvenli Önyükleme Sorunlu"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
+"önler. Şu anda açıktır ancak geçersiz anahtar olduğundan çalışmayacaktır."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Güvenli önyükleme sorunları genellikle bilgisayarınızın UEFI donanım "
+"yazılımı ayarlarından (BIOS) çözülebilir. Donanım üreticiniz, bunu nasıl "
+"yapacağınızla ilgili bilgiyi sağlayabilir."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "Yardım için donanım üreticinize veya BT desteğine başvurun."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Güvenli Önyükleme Kapatıldı"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
+"önler. Şu anda kapalıdır."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Güvenli önyükleme, genellikle bilgisayarınızın UEFI donanım yazılımı "
+"ayarlarından (BIOS) açılabilir. Yardım için donanım üreticinize veya BT "
+"desteğine başvurun."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Güvenli önyükleme, aygıt çalıştığında kötücül yazılımların yüklenmesini "
+"önler.\n"
+"\n"
+"Daha ayrıntılı bilgi için donanım üreticisine veya BT desteğine başvurun."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Geçti"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Başarısız"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Aygıt, HSI %d düzeyine uymaktadır"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Security Level 0"
+msgstr "Güvenlik Düzeyi 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Bu aygıt, donanım güvenliği sorunlarına karşı korumasızdır. Bunun nedeni "
+"donanım veya donanım yazılımı yapılandırma sorunu olabilir. BT destek "
+"sağlayıcınıza danışmanız önerilmektedir."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:358
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Security Level 1"
+msgstr "Güvenlik Düzeyi 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Bu aygıt, donanım güvenliği sorunlarına karşı en düşük korumadadır. Bu en "
+"düşük aygıt güvenliği düzeyidir ve yalnızca kolay güvenlik gözdağlarına "
+"karşı koruma sağlar."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:363
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Security Level 2"
+msgstr "Güvenlik Düzeyi 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Bu aygıt, donanım güvenliği sorunlarına karşı temel korumadadır. Bu bazı "
+"yaygın güvenlik gözdağlarına karşı koruma sağlar."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:368
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+msgid "Security Level 3"
+msgstr "Güvenlik Düzeyi 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Bu aygıt, donanım güvenliği sorunlarına karşı geniş korumadadır. Bu en "
+"yüksek aygıt güvenliği düzeyidir ve gelişmiş güvenlik gözdağlarına karşı "
+"koruma sağlar."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security Level"
+msgstr "Güvenlik Düzeyi"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:523
+msgid "Security levels are not available for this device."
+msgstr "Güvenlik düzeyleri bu aygıt için kullanılabilir değil."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Güvenlik güncelleştirmeleriyle ilgili yardım için donanım üreticinize "
+"başvurun."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Bu sorun, aygıtın UEFI donanım yazılımı ayarlarından veya destek "
+"teknisyenince çözülebilir."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "Bu sorun, aygıtın UEFI donanım yazılımı ayarlarından çözülebilir."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "Bu sorunun destek teknisyenince çözülmesi olasıdır."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Düzey 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Düzey 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Düzey 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "Aygıt başladığında kötücül yazılımlara karşı korunmaktadır."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Güvenli Önyükleme Sorunlu"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Aygıt başladığında bazı korumalar vardır."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Güvenli Önyükleme Kapalı"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Aygıt başladığında koruma yoktur."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Bu sorun; UEFI donanım yazılımı ayarlarındaki değişimden, işletim sistemi "
+"yapılandırma değişiminden veya bu sistemdeki kötücül yazılımdan "
+"kaynaklanabilir."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Bu sorun, UEFI donanım yazılımı ayarlarındaki değişimden veya bu sistemdeki "
+"kötücül yazılımdan kaynaklanabilir."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Bu sorun, işletim sistemi yapılandırma değişiminden veya bu sistemdeki "
+"kötücül yazılımdan kaynaklanabilir."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:487
+msgid "Exposed to serious security threats."
+msgstr "Ciddi güvenlik gözdağlarına açık."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:494
+msgid "Limited protection against simple security threats."
+msgstr "Kolay güvenlik gözdağlarına karşı kısıtlı koruma."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:501
+msgid "Protected against common security threats."
+msgstr "Yaygın güvenlik gözdağlarına karşı korunmaktadır."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:508
+#: panels/firmware-security/cc-firmware-security-panel.c:516
+msgid "Protected against a wide range of security threats."
+msgstr "Geniş kapsamlı güvenlik gözdağlarına karşı koruma."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Comprehensive Protection"
+msgstr "Kapsamlı Koruma"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Olay Yok"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Donanım Yazılımı Yazma Koruması"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "AMD Donanım Yazılımı Yazma Koruması Kilitli"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Donanım Yazılımı BIOS Bölgesi"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Donanım Yazılımı BIOS Tanımlayıcı"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Önyükleme öncesi DMA Koruması"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard Doğrulanmış Önyükleme"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM Korumalı"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard Hata İlkesi"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard Sigortası"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET Etkin"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET Etkin"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Şifrelenmiş RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU Koruması"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux Çekirdek Yalıtımı"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux Çekirdek Doğrulama"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux Takas Alanı"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Belleğe Askıya Al"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Boşta Beklet"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI Platform Anahtarı"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI Güvenli Önyükleme"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM Platform Yapılandırma"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM Yeniden İnşası"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel Management Engine Üretim Kipi"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel Management Engine Geçersiz Kıl"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel Management Engine Sürümü"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Donanım Yazılımı Güncellemeleri"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Donanım Yazılımı Onayı"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Donanım Yazılımı Doğrulaması"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Platform Hata Ayıklama"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "İşlemci Güvenlik Denetimleri"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD Geri Alma Koruması"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD Donanım Yazılımı Yeniden Oynatma Koruması"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD Donanım Yazılımı Yazma Koruması"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Sigortalı Platform"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Geçerli"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Geçersiz"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Etkin Değil"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Kilitli"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Kilitsiz"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Şifrelenmiş"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Şifrelenmemiş"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Lekeli"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Lekesiz"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Bulundu"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Bulunamadı"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Destekleniyor"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Desteklenmiyor"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Aygıt Güvenliği"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Bilgisayar donanım yazılımı güvenlik durumu"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"ekran;kilit;tanılama;kırılma;bozulma;çökme;özel;son;geçici;tmp;endeks;"
+"içindekiler;indeks;isim;ad;ağ;kimlik;gizlilik;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Bilinmeyen"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-bit"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-bit"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Bilinmiyor"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Yok"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Sistem Logosu"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Aygıt Adı"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Donanım Modeli"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Bellek"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "İşlemci"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Grafik"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Disk Kapasitesi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Hesaplanıyor…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "İşletim Sistemi Adı"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "İşletim Sistemi İnşa Kimliği"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "İşletim Sistemi Türü"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME Sürümü"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Yükleniyor…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Pencere Sistemi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Sanallaştırma"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Yazılım Güncellemeleri"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Aygıtı Yeniden Adlandır"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Aygıt adı, aygıt ağ üzerinden görüntülendiğinde veya Bluetooth aygıtları "
+"eşleştirirken tanımlamada kullanılır."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Aygıt adı"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "Yeniden _Adlandır"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Hakkında"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Sisteminiz hakkında bilgi edinin"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"aygıt;sistem;bilgi;makineadı;anamakineadı;bellek;işlemci;sürüm;öntanımlı;"
+"uygulama;korumalı;tercihedilen;yeğlenen;cd;dvd;usb;ses;video;disk;"
+"çıkarılabilir;ortam;otomatikçalıştır;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Ses ve Ortam"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Ses kapat/aç"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Ses kıs"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Ses aç"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Mikrofon kapat/aç"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Ortam oynatıcısını çalıştır"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Oynat (ya da oynat/beklet)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Oynatmayı beklet"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Oynatmayı durdur"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Önceki parça"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Sonraki parça"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Çıkar"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Yazma"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Diğer girdi kaynağına geç"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Önceki girdi kaynağına geç"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Başlatıcılar"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Yardım tarayıcısını çalıştır"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Hesap makinesini çalıştır"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "E-posta istemcisini çalıştır"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Web tarayıcısını çalıştır"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Ev klasörü"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Arama"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Sistem"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Çıkış"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Ekranları kilitle"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Erişilebilirlik"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Yakınlaştırmayı aç ya da kapat"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Yakınlaştır"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Uzaklaştır"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Ekran okuyucuyu aç ya da kapat"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Ekran klavyesini aç ya da kapat"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Yazıyı büyüt"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Yazıyı küçült"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Yüksek karşıtlık açık ya da kapalı"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Girdi kaynağı bulunamadı"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Diğer"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Girdi Kaynağı Ekle"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Girdi yöntemleri oturum açma ekranında kullanılamaz"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Girdi kaynağı seçilmedi"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Seçenekler"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Yukarı Taşı"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Aşağı Taşı"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Tercihler"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Klavye Düzenini Gör"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Kaldır"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Özel Kısayollar"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Karakterler Tuşunu Değiştir"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Alternatif harfler tuşu, ek karakterler girmek için kullanılabilir. Bunlar "
+"bazen klavyenize üçüncü seçenek olarak basılmış olabilir."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Sol Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Sağ Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Sol Süper"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Sağ Süper"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Menü tuşu"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Sağ Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Birleştirme Tuşu"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Birleştirme tuşu, geniş türde karakterlerin girilmesini sağlar. Kullanmak "
+"için birleştirmeye ardından bir karakter dizisine basılır.  Örneğin, "
+"birleştirme tuşu ardından <b>C</b> ve <b>o</b>’ya basılması <b>©</b> "
+"girecektir, <b>a</b> ardından <b>'</b> basılması <b>á</b> girecektir."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"%s klavye kısayoluyla girdi kaynakları arasında geçiş yapılabilir.\n"
+"Bu, klavye kısayolları ayarlarından değiştirilebilir."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Girdi Kaynakları"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Klavye düzenleri ve girdi yöntemlerini içerir."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Girdi Kaynağı Geçişi"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Tüm pencereler için _aynı kaynağı kullan"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Girdi kaynaklarını her pencere için _ayrı ayrı değiştir"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Özel Karakter Girdisi"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Klavye kullanarak simge ve değişik harfler girmek için yöntemler."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Klavye Kısayolları"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Kısayolları Gör ve Özelleştir"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d değiştirildi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Tüm Kısayolları Sıfırla?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Kısayolları sıfırlamak özel kısayollarınızı etkileyebilir. Bu geri alınamaz."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "İptal"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Tümünü Sıfırla"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Tümünü Sıfırla…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Tüm kısayolları öntanımlı tuş bağlarına sıfırla"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Bölme"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Kısayollar"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Kısayol ekle"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Özel Kısayollar Ekle"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Uygulamaları başlatmak, betikleri çalıştırmak ve daha çoğu için özel "
+"kısayollar belirle."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Kısayol Ekle"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Klavye kısayolu bulunamadı"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s, %s için kullanılıyor. Eğer yerine başka şey koyarsanız, %s devre dışı "
+"bırakılacak"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Yeni kısayolu girin"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Özel Kısayol Belirle"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Kısayol Belirle"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Değiştirmek için yeni kısayol girin: %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Özel Kısayol Ekle"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Kaldır"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "Yerine _koy"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Belirle"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"İptal etmek için Esc’ye veya klavye kısayolunu devre dışı bırakmak için "
+"Backspace’e bas."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Ad"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Komut"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Kısayol"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Kısayol Belirle…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Hiçbiri"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Kısayolu öntanımlı değerine sıfırla"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klavye"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Klavye kısayollarını, klavye düzenlerini, girdi kaynaklarını değiştirin ve "
+"yazım tercihlerinizi belirleyin"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Kısayol;Çalışma alanı;Pencere;Yeniden boyutlandır;Yakınlaşma;Karşıtlık;Girdi;"
+"Kaynak;Kilit;Ses;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Konum Hizmetleri Kapalı"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Hiçbir uygulama konum bilgisi toplayamıyor."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Konum servisleri uygulamaların konumunuzu bilmesini sağlar. Kablosuz ve "
+"mobil geniş bant doğruluğu artırır.\n"
+"\n"
+"Mozilla Konum Servisini kullanır: <a href='https://location.services.mozilla."
+"com/privacy'>Gizlilik İlkesi</a>\n"
+"Aşağıdaki uygulamaların konumunuzu saptamasını sağlayın."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "Hiçbir Uygulama Konum Erişimi İsteği Yapmadı"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Konum bilginizi koruyun"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "konum;lokasyon;gps;özel;gizlilik;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Mikrofon Kapalı"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Hiçbir uygulama ses kaydedemiyor."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Mikrofon kullanımı uygulamaların sesleri kaydetmesini sağlar. Mikrofonu "
+"devre dışı bırakmak bazı uygulamaların düzgün çalışmamasına neden olabilir.\n"
+"\n"
+"Aşağıdaki uygulamaların mikrofonunuzu kullanmasını sağlayın."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Hiçbir Uygulama Mikrofon Erişimi İsteği Yapmadı"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Konuşmalarınızı koruyun"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "mikrofon;kayıt;kaydetme;uygulama;gizlilik;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Ayarlarınızı Sınayın"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Genel"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Birincil Düğme"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+"Fare ve dokunmatik yüzeyler üzerindeki fiziksel tuşların sırasını ayarlar."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Sol"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Sağ"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Fare"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Fare Hızı"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Doğal Kaydırma"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Kaydırma, görünümü değil içeriği hareket ettirir."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Dokunmatik Yüzey"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Dokunmatik Yüzey Hızı"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Tıklamak için Dokun"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Tıklamak için dokun"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "İki Parmak Kaydırma"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Kenar Kaydırma"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Tek tıklamayı, çift tıklamayı ve kaydırmayı deneyin"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Beş tık, GEGL zamanı!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Çift tıklama, birincil düğme"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Tek tıklama, birincil düğme"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Çift tıklama, orta düğme"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Tek tıklama, orta düğme"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Çift tıklama, ikincil düğme"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Tek tıklama, ikincil düğme"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Fare ve Dokunmatik Yüzey"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+"Farenizin veya dokunmatik yüzeyin duyarlılığını değiştirin ve sağ veya sol "
+"elle kullanımı ayarlayın"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;İzleme Yüzeyi;İşaretçi;Tıklama;Vurma;Çift;Düğme;Trackball;Kaydırma;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Sıcak Köşe"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Etkinlikler Genel Görünümünü açmak için sol üst köşeye dokun."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Etkin Ekran Köşeleri"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr "Pencereleri üste, sola ve sağa sürükleyerek yeniden boyutlandır."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Çalışma Alanları"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Dinamik çalışma alanları"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Boş çalışma alanlarını kendiliğinden kaldırır."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Belirli sayıda çalışma alanları"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Kalıcı çalışma alanı sayısını belirt."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "Çalışma Alanı _Sayısı"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Çoklu Monitör"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Çalışma alanları yalnızca _birincil ekranda"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Çalışma alanları tüm _ekranlarda"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Uygulama Geçişi"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Tüm _çalışma alanlarından uygulamaları içer"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Yalnızca _geçerli çalışma alanından uygulamaları içer"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Çoklu Görev"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Verimlilik ve çoklu görev için tercihleri yönet"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Çoklugörev;Çoklu Görev;Çoğulgörev;Verimlilik;Üretkenlik;Özelleştir;Masaüstü;"
+"Sıcak Köşe;Sıcak Kenar;Çalışma Alanları;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "Tüh, bir şeyler ters gitti. Lütfen yazılım sağlayıcınıza başvurun."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "NetworkManager’in çalışması gerekir."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Diğer Aygıtlar"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Bağlantı ekle"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Ayarlanmamış"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Güvensiz ağ (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Güvenli ağ (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Güvenli ağ (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Güvenli ağ (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Güvenli ağ"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Bağlı"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Seçenekler…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Erişim noktasını açmak %s bağlantısını kesecek ve internete kablosuz "
+"üzerinden erişilemeyecek."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "En az 8 karakter içermelidir"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "En çok %d karakter içermelidir"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Kablosuz Erişim Noktasını Aç?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Kablosuz erişim noktası, başkasının bağlanabileceği kablosuz ağı oluşturarak "
+"internet bağlantınızı paylaşmanızı sağlar. Bunun için kablosuz dışındaki "
+"kaynaktan internet bağlantınız olmalıdır."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Ağ Adı"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Parola"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Rastgele Parola Oluştur"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Kendiliğinden Parola Oluştur"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Aç"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Kablosuz"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Erişim noktası durdurulup tüm kullanıcıların bağlantısı kesilsin mi?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "Erişim Noktasını _Durdur"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Uçak Kipi"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Kablosuz, Bluetooth ve mobil genişbantı devre dışı bırakır"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Kablosuz Bağdaştırıcısı Bulunamadı"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Kablosuz bağdaştırıcınızın takılı ve açık olduğundan emin olun"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Uçak Kipi Açık"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Kablosuz Ağı kullanmak için kapatın"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Kablosuz Erişim Noktası Aktif"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Mobil aygıtlar, QR kodu tarayarak bağlanabilir."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Kablosuz Erişim Noktasını Kapat…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Görünür Ağlar"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "NetworkManager’in çalışması gerekir"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x _Güvenliği"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Güvenlik"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Koru"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Kalıcı"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Rastgele"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Kararlı"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Buraya girilen MAC adresi, bu bağlantı kurulduğunda, ağ aygıtının donanım "
+"adresi olarak kullanılacak. Bu özellik MAC klonlama veya hilekarlığı olarak "
+"bilinir. Örnek: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Profil %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Kurumsal"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Hiçbiri"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Asla"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i gün önce"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/sn"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Yok"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Zayıf"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "İyi"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "İyi"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Mükemmel"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 Adresi"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 Adresi"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP Adresi"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "Bağlantıyı Unut"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "Bağlantı Profilini Kaldır"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "VPN’yi Kaldır"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "Ayrıntılar"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "kendiliğinden"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Kimlik"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Adresi Sil"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Rotayı Sil"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Hiçbiri"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-bit Anahtar (Onaltılık veya ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-bit Parola"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Dinamik WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA ve WPA2 Kişisel"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA ve WPA2 Kurumsal"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Kişisel"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Sinyal Gücü"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Hat hızı"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Donanım Adresi"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Desteklenen Frekanslar"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Öntanımlı Geçit"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Son Kullanım"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "_Kendiliğinden bağlan"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Diğer k_ullanıcılar için de kullanılabilir kıl"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "_Ölçülen bağlantı: veri sınırı vardır veya ücrete neden olabilir"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Yazılım güncellemeleri ve diğer büyük indirmeler kendiliğinden "
+"başlamayacaktır."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Ad"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC Adresi"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Klonlanmış Adres"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "bayt"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 Yöntemi"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Kendiliğinden (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Yalnızca Yerel Bağlantı"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Elle"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Devre Dışı Bırak"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Diğer bilgisayarlara paylaşılmış"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Adresler"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Adres"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Ağ maskesi"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Geçit"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Kendiliğinden"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Kendiliğinden DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS sunucu adres(ler)i"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "IP adreslerini virgüllerle ayırın"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Rotalar"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Kendiliğinden Rota"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Bu bağlantıyı _yalnızca kendi ağı üzerindeki kaynaklar için kullan"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 Yöntemi"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Kendiliğinden, yalnızca DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Ön ek"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Bağlantı düzenleyicisi açılamadı"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Yeni Profil"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Geçersiz ayar %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Geçersiz ayar %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Dosyadan içe aktar…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "VPN Ekle"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "Güv_enlik"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "VPN bağlantısı içe aktarılamıyor"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"“%s” dosyası okunamadı ya da herhangi bir VPN bağlantı bilgisi içermiyor\n"
+"\n"
+"Hata: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "İçe aktarılacak dosyayı seçin"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "“%s” adında dosya zaten var."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "Değişti_r"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr ""
+"%s bağlantısını kaydetmek istediğiniz VPN bağlantısıyla değiştirmek istiyor "
+"musunuz?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "VPN bağlantısı dışa aktarılamıyor"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"“%s” VPN bağlantısı %s’a aktarılamıyor.\n"
+"\n"
+"Hata: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "VPN bağlantısını dışa aktar"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Hata: VPN bağlantı düzenleyicisi yüklenemedi)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "İnternete nasıl bağlandığınızı denetleyin"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Ağ;IP;LAN;Proxy;WAN;Broadband;Genişbant;Modem;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Kablosuz ağlarına nasıl bağlandığınızı denetleyin"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Ağ;Wireless;Wi-Fi;Wifi;Kablosuz;Kablosuz Ağ;IP;LAN;Broadband;Genişbant;DNS;"
+"Hotspot;Bağlantı Noktası;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "asla"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "bugün"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "dün"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Son kullanım"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Kablolu"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Yeni bağlantı ekle"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Seçilen ağlar için ağ ayrıntıları, parolalar ve her türlü özel "
+"yapılandırmalar kaybolacak."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Unut"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Bilinen Kablosuz Ağlar"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Unut"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Sistem ilkeleri Erişim Noktası olarak kullanmayı yasaklıyor"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Kablosuz aygıt Erişim Noktası kipini desteklememektedir"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Yapılandırma URL’si verilmediğinde Vekil Sunucuyu Kendiliğinden Bulma "
+"kullanılır."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Bu güvenli olmayan açık ağlarda önerilmez."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Aygıtı kapat"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Etkin"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Sağlayıcı"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Ağ Vekili"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP Vekili"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS Vekili"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP Vekili"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Socks Makinesi"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "Ana Bilgisayarları _Yok Say"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP vekil portu"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS vekil portu"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP vekil portu"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks vekil portu"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Yapılandırma URL’si"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "VPN bağlantısını kapat"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Ağ Adı"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Güvenlik türü"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Parola"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Kablosuzu Kapat"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Daha çok seçenek…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "Gizli Ağa _Bağlan…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Kablosuz Erişim Nok_tasını Aç…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Bilinen Kablosuz Ağlar"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Durum bilinmiyor"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Yönetilmeyen"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Kullanılamıyor"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Bağlanıyor"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Kimlik doğrulası gerekli"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Bağlantı kesiliyor"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Bağlantı başarısız"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Durum bilinmiyor (kayıp)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Yapılandırma başarısız"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP yapılandırması başarısız"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP yapılandırmasının süresi dolmuş"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Özel bilgiler gerekli ancak sağlanmamış"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x istekçisinin bağlantısı kesildi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x istekçi yapılandırması başarısız oldu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x istekçisi başarısız oldu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x istekçisinin kimlik doğrulaması çok uzun sürdü"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP hizmeti başlatılamadı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP hizmetinin bağlantısı kesildi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP başarısız"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP istemci başlatılamadı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP istemci hatası"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP istemcisi başarısız"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Paylaşımlı bağlantı hizmeti başlatılamadı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Paylaşılmış bağlantı hizmeti başarısız oldu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP hizmeti başlatılamadı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP hizmet hatası"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP hizmeti başarısız oldu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Hat meşgul"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Çevir sesi yok"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Hiçbir taşıyıcı (carrier) elde edilemedi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Çevirme isteği zaman aşımına uğradı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Çevirme denemesi başarısız"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Modem başlatma başarısız oldu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Belirtilen APN seçilemedi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Ağlar için arama yapılmıyor"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Ağ kaydı reddedildi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Ağ kaydı zaman aşımına uğradı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "İstenilen ağa kaydolunamadı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN doğrulanamadı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Aygıt için donanım yazılımı eksik olabilir"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Bağlantı yitirildi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Var olan bağlantı varsayıldı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Modem bulunamadı"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Bluetooth bağlantı başarısız"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM Kart takılı değil"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "SIM Pin gerekli"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "SIM Puk gerekli"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Yanlış SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Bağlantı bağımlılığı başarısız"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Donanım yazılımı eksik"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Kablo çıkık"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "802.1X güvenliğinde (wpa-eap) tanımlanmamış hata"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "hiçbir dosya seçilmedi"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "eap-method dosyası doğrulamada belirtilmemiş hata"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER, PEM, PKCS#12 veya PGP özel anahtarı"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER veya PEM sertifikaları"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "EAP-FAST PAC dosyası eksik"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC dosyaları (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Anonim"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Kimlik doğrulama başarılı"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "İkisi de"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Anoni_m kimlik"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC _dosyası"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "PAC dosyası seçin"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "İç k_imlik doğrulaması"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Kendiliğinden PAC ön _hazırlığına izin ver"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "EAP-LEAP kullanıcı adı eksik"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "EAP-LEAP parolası eksik"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "K_ullanıcı adı"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Parola"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "Parolayı _göster"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "geçersiz EAP-PEAP CA sertifikası: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "geçersiz EAP-PEAP CA sertifikası: sertifika belirtilmedi"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Sürüm 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Sürüm 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A sertifikası"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Sertifika Yetkilisi (CA) sertifikası seç"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "CA sertifikası _gerekli değildir"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP _sürümü"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "eksik EAP kullanıcı adı"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "eksik EAP parolası"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "eksik EAP-TLS kimliği"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "geçersiz EAP-TLS CA sertifikası: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "geçersiz EAP-TLS CA sertifikası: sertifika belirtilmedi"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "geçersiz EAP-TLS gizli-anahtarı: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "geçersiz EAP-TLS kullanıcı-sertifikası: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Şifrelenmemiş özel anahtarlar güvensizdir"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Seçilen özel anahtar parolayla korunmuyor. Bu güvenliğinizi tehlikeye "
+"düşürebilir. Lütfen parola ile korunan özel anahtar seçin.\n"
+"\n"
+"(OpenSSL ile özel anahtarınızı şifreleyebilirsiniz)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Kişisel sertifikanızı seçin"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Özel anahtarınızı seçin"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Kimlik"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "_Kullanıcı sertifikası"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Özel _anahtar"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Özel anahtar _parolası"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "geçersiz EAP-TTLS CA sertifikası: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "geçersiz EAP-TTLS CA sertifikası: sertifika belirtilmedi"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (EAP yok)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Etki Alanı"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "802.1X güvenliğini doğrulamada bilinmeyen hata"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Tünellenmiş TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Korumalı EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "Kimlik _doğrulaması"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Dosya seç"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "leap-kullanıcı adı eksik"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "leap-parolası eksik"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Kablosuz parolası eksik."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Tür"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "wep-anahtarı eksik"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"geçersiz wep-anahtarı: %zu uzunluğundaki anahtar yalnızca onaltılı (hex) "
+"rakamlardan oluşmalı"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"geçersiz wep-anahtarı: %zu uzunluğundaki anahtar yalnızca ascii karakterler "
+"içermelidir"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"geçersiz wep-anahtarı: geçersiz anahtar uzunluğu %zu. Anahtar ya 5/13 "
+"(ascii) ya da 10/26 (onaltılık) uzunluğunda olmalıdır"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "geçersiz wep-anahtarı: parola boş olmamalıdır"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "geçersiz wep-anahtarı: parola 64 karakterden kısa olmalıdır"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Öntanımlı)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Açık Sistem"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Paylaşımlı Anahtar"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Anahtar"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "Anahtarı g_öster"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP ende_ksi"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"geçersiz wpa-psk: geçersiz anahtar uzunluğu %zu. [8,63] bayt ya da 64 "
+"onaltılık rakam olmalıdır"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "geçersiz wpa-psk: 64 baytlık anahtar onaltılık olarak yorumlanamıyor"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Bildirimler"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Sesli Uy_arılar"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "Bildirim _Pencerecikleri"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Pencerecikler devre dışı bırakıldığında bildirimler bildirim listesinde "
+"gözükmeyi sürdürecek."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Pencereciklerde İleti İ_çeriğini Göster"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Ki_lit Ekranı Bildirimleri"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Kilit Ekranında İleti İ_çeriğini Göster"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Rahatsız Etme"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Ki_lit Ekranı Bildirimleri"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Hangi bildirimlerin gösterileceğini ve ne göstereceklerini ayarlayın"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Bildirimler;Pencerecik;İleti;Mesaj;Tepsi;Açılır Pencere;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Diğer"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s kaldırıldı"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Hesap kaldırılırken hata oluştu"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Geri Al"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Bildirimi kapat"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "Buluttaki verinize bağlanın"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "İnternet bağlantısı yok — yeni çevrim içi hesaplar kurmak için bağlan"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Hesap ekle"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s Hesabı"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Hesabı Kaldır"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Çevrim İçi Hesaplar"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Çevrim içi hesaplarınıza bağlanın ve ne için kullanacağınızı belirleyin"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;Çevrimiçi;Çevrim içi;Sohbet;Takvim;"
+"Mektup;Posta;Bağlantı;Kişi;Cep;SonraOku;SonradanOku;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Bilinmeyen süre"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i dakika"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i saat"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "saat"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "dakika"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "Tümüyle dolana dek %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Dikkat: %s kaldı"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "%s kaldı"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Tümüyle dolu"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Şarj olmuyor"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Boş"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Şarj oluyor"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Boşalıyor"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Kablosuz fare"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Kablosuz klavye"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Kesintisiz güç kaynağı"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Kişisel sayısal yardımcı (PDA)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Cep telefonu"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Ortam oynatıcısı"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Tablet"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Bilgisayar"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Oyun girdi aygıtı"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Pil"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Birincil"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Ek"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Piller"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Bo_şta olduğunda"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Askıya al"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Kapat"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Derin uyku"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Hiçbir şey"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Pille çalışırken"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Fişe takıldığında"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Asla"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Kendiliğinden askıya al"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Yüksek çalışma sıcaklığı nedeniyle başarım kipi geçici olarak devre dışı "
+"bırakıldı."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Diz saptandı: başarım kipi geçici olarak kullanılamıyor. Düzeltmek için "
+"aygıtı sabit yüzeye taşıyın."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Başarım kipi geçici olarak devre dışı bırakıldı."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Düşük pil: güç tutumu etkinleştirildi. Pil yeterince dolduğunda önceki kipe "
+"dönülecek."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "“%s”, Güç Tutum kipini aktifleştirdi."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "“%s”, başarım kipini aktifleştirdi."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 dakika"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 dakika"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 dakika"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 dakika"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 dakika"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 saat"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 dakika"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 dakika"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 dakika"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 saat"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Güç Kipi"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Sistem başarımını ve güç kullanımını etkiler."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Güç Kazanım Seçenekleri"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Kendiliğinden Ekran Parlaklığı"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Ekran parlaklığı çevredeki ışığa uyarlanacak."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Ekranı Karart"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Bilgisayar kullanılmıyorken ekran parlaklığını düşürür."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "Ekranı _Kapat"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Bir süre aktif olunmadığında ekranı kapatır."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Kendiliğinden Güç Tutumu"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "Pil düşükken güç tutum kipini etkinleştirir."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Kendiliğinden Askıya Al"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Bir süre aktif olunmadığında bilgisayarı duraklatır."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "_Güç Düğmesi Davranışı"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Pil _Yüzdesini Göster"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Kendiliğinden Askıya Al"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Fişe Takılıyken"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "_Pil ile Çalışırken"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Gecikme"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Başarım"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Yüksek başarım ve güç kullanımı."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Dengeli"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Temel başarım ve güç kullanımı."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Güç Tutumu"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Düşük başarım ve güç kullanımı."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Güç"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Pil durumunuzu görüntüleyin ve güç koruma ayarlarını değiştirin"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Güç;Uyku;Bekleme;Derin Uyku;Pil;Parlaklık;Karartma;Boş;Monitör;DPMS;Boşta;"
+"Eylemsiz;Enerji;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "“%s” yazıcısı silindi"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Yeni yazıcı eklenemedi."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Arayüz yüklenemedi: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Yazıcı Eklemek ve Ayarları Değiştirmek İçin Kilidi Kaldır"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Yazıcılar"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Yazıcı ekleyin, yazıcı görevlerini görüntüleyin ve nasıl çıktı alacağınıza "
+"karar verin"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Yazıcı;Kuyruk;Yazdır;Kâğıt;Mürekkep;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Yazıcı Ekle"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Kilidi Aç"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Yazıcı Bulunamadı"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Ağ adresi girin ya da yazıcı arayın"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Kimlik Doğrulaması Gerekli"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Yazıcı Sunucusu üzerindeki yazıcıları görmek için kullanıcı adı ve parola "
+"gir."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Kullanıcı Adı"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s Ayrıntıları"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Uygun sürücü bulunamadı"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "PPD Dosyası Seç"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"PostScript Yazıcı Tanımlama dosyaları (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Yazıcı adları BOŞLUK, SEKME, # veya / içeremez"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Konum"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Sürücü"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Yeğlenen sürücüler aranıyor…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Sürücüler İçin Ara"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Veri Tabanından Seç…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "PPD Dosyası Kur…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Yazıcı Sürücüsü Seçin"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Sürücü veritabanı yükleniyor…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Seç"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect Yazıcı"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD Yazıcı"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Tek Taraflı"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Uzun Kenar (Standart)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Kısa Kenar (Çevrilmiş)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Dikey"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Yatay"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Ters yatay"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Ters dikey"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Sürdür"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Duraklat"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Beklemede"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Duraklatıldı"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Kimlik doğrulaması gerekli"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "İşleniyor"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Durduruldu"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "İptal edildi"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Hata nedeniyle iptal edildi"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Tamamlandı"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Bu görevi sıranın en üstüne taşı"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u Görev Kimlik Doğrulaması Gerektiriyor"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — Etkin Görevler"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "%s üzerinden yazdırmak için kimlik bilgilerini gir."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Etki Alanı"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "Kimlik doğr_ulama"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Tümünü Temizle"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "Kimlik doğrul_ama"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Etkin Yazıcı Görevi Yok"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Yazıcı Sunucusu Kilidini Aç"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "%s Kilidini Aç."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "%s üzerindeki yazıcıları görmek için kullanıcı adı ve parola gir."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Yazıcılar Aranıyor"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Seri Bağlantı Noktası"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Paralel Bağlantı Noktası"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Konum: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Adres: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Sunucu kimlik doğrulaması gerektiriyor"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Çift Taraflı"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Kağıt Türü"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Kağıt Kaynağı"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Çıktı Tepsisi"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Çözünürlük"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript ön-süzgeçleme"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Yüz başına sayfa"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Çift taraflı"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Yönelim"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Genel"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Sayfa Ayarları"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Kurulabilir Seçenekler"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Görev"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Görüntü Niteliği"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Renk"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Rötuş"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Gelişmiş"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Sınama Sayfası"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Sınama sayfası"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Kendiliğinden Seç"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Yazıcı Öntanımlısı"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Yalnızca GhostScript yazıtiplerini göm"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "PS düzey 1’e dönüştür"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "PS düzey 2’ye dönüştür"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Ön-süzgeçleme yok"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Üretici"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Etkin Görev Yok"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u Görev"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Yazdırma başlıklarını temizle"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Toner düşük düzeyde"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Toner tükendi"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Film banyo kimyasalı az"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Film banyo kimyasalı tükendi"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Renk kartuşu az"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Renk kartuşu tükendi"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Kapak açık"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Kapı açık"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Kağıt az"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Kağıt tükendi"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Kapalı"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Durduruldu"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Atık kutusu neredeyse dolu"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Atık kutusu dolu"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Baskı silindiri ömrünü doldurmak üzere"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Baskı silindiri artık çalışmıyor"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Hazır"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Görev kabul etmiyor"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "İşleniyor"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Yazdırma Seçenekleri"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Yazıcı Ayrıntıları"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Yazıcıyı Öntanımlı Olarak Kullan"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Yazdırma Başlıklarını Temizle"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Yazıcıyı Kaldır"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Model"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Mürekkep Düzeyi"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Sorun çözüldüğünde lütfen yeniden başlatınız."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Yeniden Başlat"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Yazıcı Ekle…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Yazıcı yok"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Üzgünüm! Sistem yazdırma hizmeti\n"
+"    kullanılamıyor."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Biçimler"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Yerel ara…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Ortak Biçimler"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Tüm Biçimler"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Arama Sonucu Yok"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Ülkeler veya diller aranabilir."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Ön İzleme"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "İngiliz"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Metrik"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Tarihler"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Tarihler ve Saatler"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Sayılar"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Ölçüm"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Kağıt"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Dil ve biçim sonraki girişte değişecektir"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Oturumu Kapat…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Dil ayarı arayüz metinleri ve web sayfalarında kullanılmaktadır. Biçimlerse "
+"sayı, tarih ve para birimlerinde kullanılmaktadır."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Hesabınız"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Dil"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Biçimler"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Oturum Açma Ekranı"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Bölge ve Dil"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Ekran dilinizi ve biçimlerinizi seçin"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Dil;Yerleşim;Düzen;Klavye;Girdi;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Yapılacak şeyi sor"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Bir şey yapma"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Klasör aç"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Diğer Ortamlar"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Ses CD’leri için uygulama seç"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Video DVD’leri için uygulama seç"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Müzik çalar bağlandığında çalıştırılacak uygulamayı seç"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Kamera bağlandığında çalıştırılacak uygulamayı seç"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Yazılım CD’leri için uygulama seç"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "ses DVD’si"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "boş Blu-ray diski"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "boş CD diski"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "boş DVD diski"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "boş HD DVD diski"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video diski"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "e-kitap okuyucu"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD video diski"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Resim CD’si"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Süper Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows yazılımı"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Ortamın nasıl kullanılacağını seç"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _sesi"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD videosu"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Müzik çalar"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Yazılım"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "Diğer _Ortam…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Ortam takıldığında asla program başlatma ve sorma"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Diğer ortamların nasıl kullanılacağını seç"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Eylem:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Tür:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Çıkarılabilir Ortam"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Çıkarılabilir Ortam ayarlarını yapılandır"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"aygıt;sistem;öntanımlı;uygulama;tercihedilen;yeğlenen;cd;dvd;usb;ses;video;"
+"disk;çıkarılabilir;ortam;otomatikçalıştır;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Ekran Kapanınca"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 saniye"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 dakika"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 dakika"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 dakika"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 dakika"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 dakika"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 saat"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 dakika"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 dakika"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 dakika"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 dakika"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 dakika"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 dakika"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 dakika"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 dakika"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 dakika"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Asla"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Ekran Kilidi"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Ekranı kendiliğinden kilitlemek, siz uzaktayken bilgisayarınıza erişilmesini "
+"önler."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Ekranı Karart Gecikmesi"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Hareketsiz kalma süresi, ardından ekran karartılacak."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Kendiliğinden Ekran Ki_lidi"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Kendiliğinden _Ekran Kilidi Gecikmesi"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+"Ekran kendiliğinden kilitlendikten sonra ekranın kararması için gereken süre."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "_Bildirimleri Kilit Ekranında Göster"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Yeni _USB aygıtlarını önle"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "Ekran kilitliyken yeni USB aygıtlarının sistemle etkileşmesini önle."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Ekran Gizliliği"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Görüş Açısını Kısıtla"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Ekran Ayarları"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "ekran;monitör;kilit;özel;gizlilik;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Konum Seç"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Tamam"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Arama Konumları"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Dosyalar, Fotoğraflar ve Videolar gibi sistem uygulamaları tarafından aranan "
+"klasörler."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Yerler"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Yer İmleri"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Diğerleri"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Konum Ekle"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Uygulama bulunamadı"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Uygulama Arama"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Uygulamaların sağladığı arama sonuçlarını içer."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Sistem uygulamalarınca aranan klasörler."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Arama Sonuçları"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Sonuçlar liste sırasına göre görüntülenmektedir."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Hangi uygulamaların arama sonuçlarını Etkinlikler Genel Görünümünde "
+"göstereceğini belirleyin"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Ara;Bul;Endeks;Gizle;Gizlilik;Sonuçlar;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Paylaşımı için ağ seçilmedi"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Ağlar"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Açık"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Kapalı"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Etkin"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Etkin"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Klasör Seç"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Ekle"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Ortam paylaşımını etkinleştir"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Dosya Paylaşımı, Genel dizininizi ağınızdaki diğer kişilerle şunu kullanarak "
+"paylaşmanızı sağlar: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Uzaktan oturum açma etkinleştirildiğinde, uzak kullanıcılar Güvenli Kabuk "
+"komutunu kullanarak bağlanabilirler:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Kişisel ortam paylaşımını etkinleştir"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Aygıt adı kopyalandı"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Aygıt adresi kopyalandı"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Kullanıcı adı kopyalandı"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Parola kopyalandı"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Paylaşım"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "_Bilgisayar Adı"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Dosya _Paylaşımı"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Uzak _Masaüstü"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "_Ortam Paylaşımı"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "_Uzaktan Oturum Açma"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Dosya Paylaşımı"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Parola _Gerektir"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Uzaktan Oturum Açma"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Uzak Masaüstü"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Uzak masaüstü, başka bilgisayardan masaüstünüzü görmeyi ve denetlemenizi "
+"sağlar."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Bu bilgisayara uzak masaüstü bağlantısını etkinleştir veya devre dışı bırak."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Uzaktan Denetim"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Uzaktan bağlantıların ekranı denetlemesini sağlar."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Nasıl Bağlanılır"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Aygıt adını veya uzak masaüstü adresini kullanarak bu bilgisayara bağlan."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Kopyala"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Uzak Masaüstü Adresi"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Kimlik Doğrulaması"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "Bu bilgisayara bağlanmak için kullanıcı adı ve parola gereklidir."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Kullanıcı Adı"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Şifrelemeyi Doğrula"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Şifreleme Parmak İzi"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Bağlanan istemcilerde şifreleme parmak izi görünmelidir ve birbiriyle aynı "
+"olmalıdır."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Ortam Paylaşımı"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Müzikleri, fotoğrafları ve videoları ağda paylaşın."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Klasörler"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Diğerleri ile ne paylaşacağınızı denetleyin"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"paylaş;paylaşım;ssh;makine;host;isim;ad;uzak;masaüstü;ortam;ses;video;"
+"görüntü;resimler;fotoğraflar;filmler;sunucu;renderer;yorumlayıcı;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Uzaktan oturum açmayı etkinleştir veya devre dışı bırak"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"Uzaktan oturum açmayı etkinleştirmek veya devre dışı bırakmak için kimlik "
+"doğrulaması gerekiyor"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Özel"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Tık"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Tel"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Salla"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Vız"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Denge"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Kayboluş"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Arka"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Ön"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "%s Sınanıyor"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Sınanacak hoparlöre tıkla"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Sistem Sesi"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Ana ses"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Ses Düzeyleri"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Çıktı"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Çıktı Aygıtı"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Sına"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Yapılandırma"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Subwoofer"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Girdi"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Girdi Aygıtı"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Ses"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Uyarı Sesi"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "%100"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Kıs"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Ses"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Ses düzeylerini, girdileri, çıktıları ve uyarı seslerini değiştir"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Kart;Mikrofon;Ses;Kaybolma;Denge;Bluetooth;Kulaklık Seti;Ses;Çıktı;Girdi;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Bağlantısı Kesilmiş"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Bağlanıyor"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Bağlı"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Yetkilendirme Hatası"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Yetkilendiriliyor"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Azaltılmış İşlev"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Bağlı ve Yetkilendirilmiş"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Bilinmeyen"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Yetkilendirilmiş:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Bağlı:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Kaydedilmiş:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Aygıt yetkilendirilemedi: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Aygıt unutulamadı: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "%u diğer aygıta bağımlıdır"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Bildirimi kapat"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Ad:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Durum:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Yetkilendir ve Bağla"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Aygıtı Unut"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Hata"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Yetkilendirilmiş"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Thunderbolt altsistemi (boltd) yüklenmemiş veya doğru şekilde ayarlanmamış."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Bağlantı istasyonları ve dış grafik işlemciler gibi aygıtlara doğrudan "
+"erişim tanı."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Yalnızca USB ve Display Port aygıtları bağlanabilir."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt algılanamadı.\n"
+"Sistemin Thunderbolt desteği yok, BIOS’tan devre dışı bırakılmış veya "
+"BIOS’tan desteklenmeyen güvenlik düzeyine ayarlanmış."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt desteği BIOS’tan devre dışı bırakılmış."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Thunderbolt güvenlik düzeyi saptanamadı."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Doğrudan kipe geçilirken hata: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Thunderbolt Desteği Yok"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Thunderbolt alt sistemine bağlanılamadı."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Doğrudan Erişim"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Bekleyen Aygıtlar"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Aygıt bağlanmamış"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Thunderbolt aygıtlarını yönet"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;gizlilik;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "İmleç Yanıp Sönmesi"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Metin alanlarında imleç yanıp söner."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Hız"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "İmleç yanıp sönme hızı"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "İmleç Boyutu"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"İmleç boyutu, imleci görmeyi kolaylaştırması için yakınlaştırma ile "
+"birleştirilebilir."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Tıklama Yardımı"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Sahte İkincil Tıklama"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "İlk düğme basılı tutulduğunda ikincil tıklama tetikle"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Kabul ge_cikmesi:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Kısa"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "İkinci tıklama gecikmesi"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Uzun"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "_Üzerindeyken Tıklama"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Belirteç nesne üstüne geldiğinde tıkla"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "G_ecikme:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Kısa"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Uzun"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Hareket _eşiği:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Küçük"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Büyük"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Tuş Yinelemesi"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Tuş basılı tutulduğunda tuş basımları yinelenir."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Tuş yineleme gecikmesi"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Tuş yineleme hızı"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Yazım Yardımı"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Yapışkan Tuşlar"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Bir dizi değiştirici tuşu, birleşim olarak algılar"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "İki tuşa birden basıldığında _devre dışı bırak"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "_Değiştirici tuşa basıldığında biple"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Yavaş Tuş_lar"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Bir tuşa basılmasıyla kabulü arasına gecikme koyar"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Kısa"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Yavaş tuşlar yazım gecikmesi"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Uzun"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Bir _tuşa basıldığında uyar"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Bir tuş k_abul edildiğinde uyar"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Bir tuş _reddedildiğinde biple"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "_Zıplayan Tuşlar"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Kısa aralıklı tuş yinelemelerini yok sayar"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Kısa"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Seken tuşlar yazma gecikmesi"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Uzun"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "Klavyeden _Etkinleştir"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Erişilebilirlik özelliklerini klavyeden aç/kapa"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Öntanımlı"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Orta"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Büyük"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Çok Büyük"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "En Büyük"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d piksel"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Her Zaman Erişilebilirlik Menüsünü Göster"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Görme"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Yüksek Karşıtlık"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "_Büyük Metin"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "A_nimasyonları Etkinleştir"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Ekran _Okuyucu"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Ekran okuyucu, siz odağı hareket ettirdikçe görüntülenen metni okur."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Tuş _Sesleri"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Num Lock veya Caps Lock açıldığında veya kapandığında sesli uyarı ver."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "İ_mleç Boyutu"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Yaklaştır"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "İşitme"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "_Görsel Uyarılar"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Ekran _Klavyesi"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Tuş Yin_elemesi"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_İmleç Yanıp Sönmesi"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Yazım Yardımı (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "İmleme ve Tıklama"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "_Fare Tuşları"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "İmlecin Yerini _Sapta"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Tıklama Yardımı"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "_Çift Tıklama Gecikmesi"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Çift Tıklama Gecikmesi"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Görsel Uyarılar"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Flaşı _sına"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Uyarı sesi çalındığında görsel uyarı kullan."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Tüm _ekran yanıp sönsün"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Tüm _pencere yanıp sönsün"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Kısa"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ Ekran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ Ekran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ Ekran"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Uzun"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Tam Ekran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Üst Yarı"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Alt Yarı"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Sol Yarı"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Sağ Yarı"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Yakınlaştırma Seçenekleri"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "Büyüt_me:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Büyüteç Konumu:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "Fare imlecini _izle"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "_Ekrandan bölüm:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Büyüt_eç ekranın dışına taşar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "B_üyüteç imlecini ortalı tut"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Büyüteç imleci çevresindeki içeriği _iter"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Büyüteç imleci i_çerik ile birlikte oynar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Büyüteç"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Artı:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Fare imleci ile _örtüşür"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Kalınlık:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "İnce"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Kalın"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Uzunluk:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Renk:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Artı"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Renk Etkileri:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Siyah üzerine beyaz:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Parlaklık:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Karşıtlık:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Renk"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Hiçbiri"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Tam"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Düşük"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Yüksek"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Düşük"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Yüksek"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Renk Etkileri"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Görme, duyma, yazma, işaretleme ve tıklamayı kolaylaştır"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Klavye;Fare;a11y;Erişilebilirlik;Erişebilirlik;Evrensel Erişim;Karşıtlık;"
+"İmleç;Ses;Yakınlaştırma;Ekran;Okuyucu;büyük;yüksek;geniş;metin;yazıtipi;yazı "
+"tipi;boyut;AccessX;Yapışkan;Tuşlar;Yavaş;Seken;Çift;tıklama;Gecikme;Hız;"
+"Yardım;Tekrar;Tekrarlanan;Tekrarlayan;Yineleme;Yinelenen;Yineleyen;Yanıp "
+"sönme;görsel;duyma;işitsel;İşitsel;ses;yazım;yazma;canlandırmalar;"
+"animasyonlar;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 saat"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 gün"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 gün"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 gün"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 gün"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 gün"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 gün"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 gün"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 gün"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 gün"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Çöpteki tüm ögeler boşaltılsın mı?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Çöpteki tüm ögeler kalıcı olarak silinecek."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Çöpü _Boşalt"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Tüm geçici dosyalar silinsin mi?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Tüm geçici dosyalar kalıcı olarak silinecek."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "Geçici Dosyaları _Temizle"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 gün"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 gün"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 gün"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Sonsuza dek"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Dosya Geçmişi"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Dosya geçmişi, kullandığınız dosyaların kaydını tutar. Bu bilgiler "
+"uygulamalar arasında paylaşılır ve kullanmak isteyebileceğiniz dosyaları "
+"bulmayı kolaylaştırır."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Dosya _Geçmişi"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Dosya _Geçmişi Süresi"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "_Geçmişi Temizle…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Çöp Kutusu ve Geçici Dosyalar"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Çöp kutusu ve geçici dosyalar kişisel veya hassas bilgiler içerebilir. "
+"Bunları kendiliğinden silmek gizliliğin korunmasına yardımcı olabilir."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "_Çöpü Kendiliğinden Sil"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Geçici _Dosyaları Kendiliğinden Sil"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Kendiliğinden _Silme Sıklığı"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Çöpü _Boşalt…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "Geçici Dosyaları _Sil…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Dosya Geçmişi ve Çöp"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "İz bırakma"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"kullanım;son;en son;geçmiş;tarihçe;dosyalar;geçici;tmp;özel;gizlilik;çöp;"
+"geri dönüşüm;temizlik;arınma;koru;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Hesap sağlayıcınızın web adresi ile aynı olmalıdır."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Hesap eklenemedi"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Parolalar eşleşmiyor."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Hesap kaydedilemedi"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Bu alan adıyla kimlik doğrulama yapılamaz"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Etki alanına katılma başarısız"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Oturum açma adı işe yaramadı.\n"
+"Lütfen yeniden deneyin."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Oturum açma parolası işe yaramadı.\n"
+"Lütfen yeniden deneyin."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Etki alanına girilemedi"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Etki alanı bulunamadı. Belki yanlış yazmışsınızdır."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Kullanıcı Ekle"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Yönetici"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Yöneticiler diğer kullanıcıları ekleyebilir veya kaldırabilir ve diğer tüm "
+"kullanıcılar için ayarları değiştirebilir. Yöneticilere ebeveyn denetimi "
+"uygulanamaz."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Kullanıcı parolasını ilk girişte belirler"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Parolayı şimdi belirle"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Doğrula"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Kurumsal Giriş"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "Şirket veya kurumca yönetilen kullanıcı hesapları."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Çevrim Dışısınız"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Kurumsal giriş, merkezi yönetimli var olan kullanıcı hesabının bu aygıtta "
+"kullanılmasını sağlar. Ayrıca bu hesabı internet üzerindeki şirket "
+"kaynaklarına erişmede de kullanabilirsiniz."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Daha çok resim için göz at"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Dosya Seç…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Parmak İzi Yönetici"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Parmak İzi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Hayır"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Evet"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Kayıtlı parmak izlerini silerek parmak izi girişini kapatmak ister misiniz?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Parmak izi aygıtı yok"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Parmak İzi Aygıtı Yok"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Aygıtın düzgünce bağlandığına emin olun."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Parmak İzi Aygıtı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Yapılandırmak istediğiniz parmak izi aygıtını seçin"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Parmak İzi Girişi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Parmak izi girişi, bilgisayarınızın kilidini parmağınızla açmayı ve giriş "
+"yapmanızı sağlar"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "Parmak İzlerini _Sil"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Parmak İzi Kaydı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "aygıt, bu eylemi gerçekleştirmek için elde edilmelidir"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "aygıt, başka süreççe önceden elde edildi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "bu eylemi gerçekleştirmeye izniniz yok"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "herhangi bir iz kaydedilmedi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Kayıt sürecinde aygıtla iletişim kurulamadı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Parmak izi okuyucuyla iletişim kurulamadı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Parmak izi art alan süreciyle iletişim kurulamadı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Parmak izleri listelenemedi: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Kayıtlı parmak izleri silinemedi: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Sol başparmak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Sol orta parmak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "So_l işaret parmağı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Sol yüzük parmağı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Sol serçe parmağı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Sağ başparmak"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Sağ orta parmağı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Sağ işaret pa_rmağı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Sağ yüzük parmağı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Sağ serçe parmağı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Bilinmeyen Parmak İzi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Tamamlandı"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Parmak izi aygıtının bağlantısı kesildi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Parmak izi aygıtının deposu dolu"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Yeni parmak izi kaydedilemedi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Kayıt başlatılamadı: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Yeni parmak izi kaydedilemedi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Kayıt durdurulamadı: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Parmak izinizi kaydetmek için parmağınızı okuyucuya ardı ardına koyun ve "
+"kaldırın"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Bu parmağı _yeniden kaydet…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Yeni parmak izi tara"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "%s parmak izi aygıtı salınamadı: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Aygıt Okumada Sorun"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "%s parmak izi aygıtı elde edilemedi: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Parmak izi aygıtları alınamadı: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Bu Hafta"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Geçen Hafta"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Oturum Sonlandı"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Oturum Başladı"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Hesap Etkinliği"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Önceki"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Sonraki"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Lütfen başka parola seçin."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Lütfen parolanızı yeniden girin."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Parolanız değiştirilemedi"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Parola Değiştir"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "D_eğiştir"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Geçerli Parola"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Yeni Parola"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Yeni Parolayı Doğrula"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Sonraki girişte kullanıcının parolasını değiştirmesine olanak tanı"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Şimdi parola belirle"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Bu türde etki alanına kendiliğinden girilemiyor"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Böylesi etki alanı veya alan (realm) yok"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%2$s etki alanına %1$s olarak giriş yapılamıyor"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Yanlış parola, lütfen yeniden deneyin"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "%s etki alanına bağlanılamadı: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Kullanıcı silinemedi"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Uzaktan yönetilen kullanıcı iptal edilemedi"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Kendi hesabınızı silemezsiniz."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s halen sisteme giriş yapmış durumda"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "Giriş yapmış kullanıcıyı silmek sistemi tutarsız duruma sokabilir."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "%s’in dosyalarını tutmak ister misiniz?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Kullanıcı hesabı silerken ev dizinini, postalarını ve geçici dosyalarını "
+"tutabilirsiniz."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "_Dosyaları Sil"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "Dosyaları _Tut"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr ""
+"Uzaktan yönetilen %s kullanıcısının hesabını iptal etmek istediğinizden emin "
+"misiniz?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "_Sil"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Hesap devre dışı"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Sonraki girişte ayarlanacak"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Hiçbiri"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Oturum açık"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Hesap hizmetiyle bağlantı kurulamadı"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Lütfen AccountService’in kurulu ve etkin olduğundan emin olun."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Bu ayarı değiştirmek için bu bölmenin kilidi açılmalıdır"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Seçilen kullanıcı hesabını sil"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Seçilen kullanıcı hesabını silmek için\n"
+"önce * simgesine tıklayın"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Kullanıcı Eklemek ve Ayarları Değiştirmek İçin Kilidi Kaldır"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Kullanıcılar"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Değişikliklerin etkin olması için oturumunuzu yeniden başlatmalısınız"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Yeniden Başlat"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Kapat"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Avatarı düzenle"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Tam ad"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Düzenle"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "_Parmak İziyle Giriş"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Kendiliğinden Giriş"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Hesap Etkinliği"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Yönetici"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Yöneticiler diğer kullanıcıları ekleyebilir veya kaldırabilir ve diğer tüm "
+"kullanıcılar için ayarları değiştirebilir."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Ebeveyn Denetimleri"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Ebeveyn Denetimleri uygulamasını aç."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Kullanıcı Hesabını Kaldır…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Diğer Kullanıcılar"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Kullanıcı Ekle…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Kullanıcı Bulunamadı"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Kullanıcı hesabı eklemek için kilidi kaldır."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Kullanıcı ekleyip kaldırın veya parolanızı değiştirin"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Giriş;Oturum aç;Ad;İsim;Parmak izi;Avatar;Resim;Fotoğraf;Logo;Yüz;Parola;"
+"Şifre;Ebeveyn Denetimleri;Aile Denetimleri;Ekran Saati;Ekran Zamanı;Uygulama "
+"Kısıtlamaları;Uygulama Sınırlamaları;Web Kısıtlamaları;Web Sınırlamaları;"
+"Kullanım;Kullanım Sınırı;Kullanım Kısıtı;Çocuk;Evlat;Velet;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "_Kaydet"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Etki Alanı Yöneticisi Girişi"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Bu bilgisayar, kurumsal girişleri kullanmak için etki alanına\n"
+"kayıtlı olmalıdır. Lütfen ağ yöneticinizin etki alanı\n"
+"parolasını buraya girmesini sağlayın."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "Yö_netici Adı"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Yönetici Parolası"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Kullanıcı hesaplarını yönet"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Kullanıcı verisini değiştirmek için kimlik doğrulama gerekiyor"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Yeni parolanın eskisinden farklı olması gerekir."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Bazı harf ve rakamları değiştirmeyi deneyin."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Parolayı biraz daha değiştirmeyi deneyin."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Kullanıcı adınızı içermeyen parola daha güçlü olacaktır."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Adınızı içermeyen parola deneyin."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Paroladaki bazı sözcüklerden kaçınmayı deneyin."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Yaygın sözcükler olmadan deneyin."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Aynı sözcükleri kullanmadan deneyin."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Daha çok sayı kullanmayı dene."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Daha çok büyük harf kullanmayı dene."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Daha çok küçük harf kullanmayı dene."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Noktalama işaretleri gibi daha çok özel karakter kullanmayı dene."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Harf, sayı ve noktalama işareti karışımları kullanmayı deneyin."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Aynı karakterleri yinelemeden deneyin."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Aynı türdeki karakterleri yinelemeden deneyin: harfleri, sayıları ve "
+"noktalama işaretlerini karıştırmalısınız."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "1234 veya abcd gibi sıralamalardan kaçınarak deneyin."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Parola daha uzun olmalıdır. Harf, sayı ve noktalama işareti karışımları "
+"kullanmayı deneyin."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Büyük, küçük karakter karıştırın ve bir iki de sayı kullanın."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr ""
+"Daha çok harf, sayı ve noktalama işareti kullanmak parolanızı daha güçlü "
+"yapacaktır."
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Kimlik doğrulama başarısız"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Yeni parola çok kısa"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Yeni parola çok kolay"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Eski ve yeni parolalar birbirine çok benziyor"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Yeni parola yakın zamanda zaten kullanılmış."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Yeni parola rakam ya da özel karakterler içermeli"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Eski ve yeni parolalar birbirinin aynısı"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Parolanız önceki kimlik doğrulamasından sonra değiştirildi!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Yeni parola yeterli sayıda farklı karakterler içermiyor"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Bilinmeyen hata"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Kullanıcı adı yalnızca a’dan z’ye küçük ya da büyük harfler, rakamlar ve şu "
+"karakterlerin herhangi birinden oluşmalıdır: . - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Üzgünüm, bu kullanıcı adı uygun değil. Lütfen başka deneyin."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Kullanıcı adı fazlasıyla uzun."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Düğmeleri Eşleştir"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Düğmeleri işlevlerle eşleştir"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Kısayolu düzenlemek için, “Tuş Vuruşu Gönder” eylemini seç, klavye kısayol "
+"düğmesine bas ve yeni tuşlara basılı tut ya da temizlemek için Backspace "
+"tuşuna bas."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Kapat"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Tabletinizi kalibre etmek için lütfen ekranda göründükçe hedef imleçlerine "
+"dokunun."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Yanlış tıklama saptandı, yeniden başlatılıyor…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "%d düğmesi"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Uygulama tanımlı"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Tuş Vuruşu Gönder"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Monitörü Değiştir"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Ekran Yardımını Görüntüle"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Tablet dizüstü paneline takıldı"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Tablet dış ekrana takıldı"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Dış tablet aygıtı"
+
+# Burada Pad tablete benzeyen fakat ekranı olmayan çizim padleri için kullanılmış.
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Dış çizim aygıtı"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Tüm Ekranlar"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Tablet Kipi"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Kalem için mutlak konumlama kullan"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Sol El Yerleşimi"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Tablet ve Express Keys™, sol el kullanımı için döndürülmektedir"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Monitöre Eşle"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "En-Boy Oranını Koru"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Monitör en boy oranını korumak için tabletin yalnızca bir bölümünü kullan"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Kalibre Et"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Tablet bulunamadı"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Lütfen Wacom tabletinizi açın veya bağlayın."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Uç Basınç Hissi"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Yumuşak"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Kalem uç basıncı"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Sıkı"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "1. Düğme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "2. Düğme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "3. Düğme"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Silgi Basınç Hissi"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Silgi basıncı"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Orta Fare Düğmesi Tıklaması"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Sağ Fare Düğmesi Tıklaması"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "İleri"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Basınç, eğim ve tümleşik kaydırıcı destekli airbrush kalem"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Basınç, eğim ve dönüş destekli airbrush kalem"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Basınç ve eğim destekli standart kalem"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Basınç destekli standart kalem"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Düğme eşlemelerini ve grafik tabletler için kalem hassasiyetini ayarla"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Kalem;Silgi;Fare;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Yeni kısayol…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Erişim Noktaları"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "İşlem İptal Edildi"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Hata:</b> Ayar değiştirme izni reddedildi"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Hata:</b> Mobil Donanım Hatası"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Kayıtlı Değil"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Kayıtlı"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Dolaşım"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Aranıyor"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Reddedildi"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Modem Ayrıntıları"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Modem Durumu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Taşıyıcı"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Ağ Türü"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Ağ Durumu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Kendi Numarası"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Aygıt Ayrıntıları"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Donanım Yazılımı Sürümü"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Yalnızca 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Yalnızca 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Yalnızca 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Yalnızca 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G, 5G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (Yeğlenen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (Yeğlenen), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (Yeğlenen), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Yeğlenen), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Yeğlenen), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (Yeğlenen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (Yeğlenen), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (Yeğlenen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (Yeğlenen), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (Yeğlenen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (Yeğlenen), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (Yeğlenen), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (Yeğlenen), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (Yeğlenen), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (Yeğlenen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (Yeğlenen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "3G, 5G (Yeğlenen)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (Yeğlenen), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Bilinmeyen"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "SIM kart kilidini aç"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Kilidi Aç"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Lütfen SIM %d için PIN kodu sağlayın"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "SIM kartınızın kilidini açmak için PIN girin"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Lütfen SIM %d için PUK kodu sağlayın"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "SIM kartınızın kilidini açmak için PUK girin"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Yanlış parola girildi. %1$u hakkınız kaldı"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "%u hakkınız kaldı"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Yanlış parola girildi."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK kodu 8 haneli sayı olmalıdır"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Yeni PIN Gir"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN kodu 4-8 haneli sayı olmalıdır"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Kilidi Açılıyor…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "SIM Yok"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Bu modemi kullanmak için SIM kartı yerleştir"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM Kilitli"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Mobil Veri"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Mobil ağ kullanarak veriye eriş"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "_Veri Dolaşımı"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Dolaşımda mobil veriyi kullan"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "_Ağ Kipi"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "A_ğ"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Gelişmiş"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Erişim Noktası Adları"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM Kilidi"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "SIM’i PIN ile kilitle"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "M_odem Ayrıntıları"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Telefon başarısız"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Telefona bağlantı yok"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "İşleme izin verilmedi"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "İşlem desteklenmiyor"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM takılı değil"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "SIM PIN gerekli"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "SIM PUK gerekli"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM başarısız"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM meşgul"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Geçersiz parola"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "SIM PIN2 gerekli"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "SIM PUK2 gerekli"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Bulunamadı"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Ağ servisi yok"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Ağ zaman aşımı"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "GPRS servislerine izin verilmedi"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Bu konum alanında dolaşıma izin verilmedi"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Belirtilmemiş GPRS hatası"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Hata Yok"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Eylem İptal Edildi"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Erişim reddedildi"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Bilinmeyen Hata"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Ağ Kipi"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Kendiliğinden"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Ağ Seç"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Ağ Sağlayıcılarını Yenile"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Mobil Ağı Etkinleştir"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "WWAN Bağdaştırıcısı Bulunamadı"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Kablosuz Wan/Hücresel aygıtınızın olduğundan emin olun"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Uçak kipi açıldığında Kablosuz Wan devre dışı kalır"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Uçak Kipini _Kapat"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "Veri Bağlantısı"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM kart internette kullanıldı"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM Kilidi"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Sonraki"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "SIM’i PIN ile _Kilitle"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "PIN Değiştir"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "SIM kilit ayarlarını değiştirmek için geçerli PIN’i gir"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mobil Ağ"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Telefon ve mobil veri bağlantılarını yapılandır"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+"hücresel;wwan;telefon;telefonculuk;sim;mobil;taşınabilir;taşınır;seyyar;"
+"gezici;gezgin;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "GNOME masaüstünü yapılandırma aracı"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Ayarlar, sisteminizi yapılandırmak için birincil arayüzdür."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME Projesi"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Sürüm numarasını göster"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Ayrıntılı kipi etkinleştir"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Dizgeyi ara"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Olası panel adlarını listele ve çık"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Gösterilecek panel"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [BAĞIMSIZ DEĞİŞKEN…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Ayar kategorileri"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Gizlilik"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Kullanılabilir Paneller:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Tüm Ayarlar"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Birincil Menü"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Uyarı: Geliştirme Sürümü"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Ayarlarʼın bu sürümü yalnızca geliştirme amaçları için kullanılmalıdır. "
+"Doğru olmayan sistem davranışları, veri kaybı ve diğer beklenmeyen "
+"sorunlarla karşılaşabilirsiniz. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Yardım"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Genel"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Çık"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Ara"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Paneller"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Önceki panele geri dön"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Aramayı iptal et"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Tercihler;Ayarlar;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "En son açılan Ayarlar paneli için tanımlayıcı"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"En son açılan Ayarlar paneli için tanımlayıcı. Tanınmayan değerler göz ardı "
+"edilecek ve listedeki ilk panel seçilecek."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Ayarlarʼın geliştirme inşasını çalıştırırken uyarı göster"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "Geliştirme inşası çalışırken Ayarlarʼın uyarı gösterip göstermeyeceği."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Pencerenin ilk durumu"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Uygulama penceresinin ilk genişlik, yükseklik ve büyütülüş durumunu içeren "
+"demet."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u Çıktı"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u Girdi"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Sistem Sesleri"

--- a/po/ug.po
+++ b/po/ug.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2013-02-15 20:13+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2013-02-16 10:05+0900\n"
 "Last-Translator: Gheyret Kenji <gheyret@gmail.com>\n"
 "Language-Team: Uyghur Computer Science Association <UKIJ@yahoogroups.com>\n"
@@ -19,6836 +19,8252 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-08-09 22:20+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:2
-msgid "Changes throughout the day"
-msgstr "بىر كۈن ئىچىدە ئۈزلۈكسىز ئالماشتۇرىدۇ"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "پروگراممىلار"
 
-#: ../panels/background/background.ui.h:3
-msgctxt "background, style"
-msgid "Tile"
-msgstr "ياي"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "پروگرامما تېپىلمىدى"
 
-#: ../panels/background/background.ui.h:4
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "كېڭەيت-تارايت"
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "يېڭىلاش قاچىلا"
 
-#: ../panels/background/background.ui.h:5
-msgctxt "background, style"
-msgid "Center"
-msgstr "مەركەز"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "ئىشىكنى ئاچ"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Scale"
-msgstr "نىسبىتى"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "تەپسىلاتىنى كۆرسەت"
 
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Fill"
-msgstr "تولدۇر"
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "ئىزدە"
 
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Span"
-msgstr "ئارىلىق"
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
 
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:199
-msgid "Select Background"
-msgstr "تەگلىك تاللا"
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "ئىناۋەتسىز قىلىنغان"
 
-#: ../panels/background/cc-background-chooser-dialog.c:218
-msgid "Wallpapers"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "ئۇقتۇرۇشلار"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "ئۇقتۇرۇش كۆرسەت(_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "تەگلىك"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "ئېكران كۆرۈنۈشى"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
 msgstr "تام قەغەزلىرى"
 
-#: ../panels/background/cc-background-chooser-dialog.c:227
-msgid "Pictures"
-msgstr "سۈرەتلەر"
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
 
-#: ../panels/background/cc-background-chooser-dialog.c:235
-msgid "Colors"
-msgstr "رەڭلەر"
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "ئاۋاز"
 
-#: ../panels/background/cc-background-chooser-dialog.c:244
-msgid "Flickr"
-msgstr "Flickr"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
 
-#: ../panels/background/cc-background-chooser-dialog.c:286
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/data/photo-dialog.ui.h:9
-#: ../panels/user-accounts/um-photo-dialog.c:98
-msgid "Select"
-msgstr "تاللا"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "تېزلەتمىلەر"
 
-#: ../panels/background/cc-background-item.c:150
-msgid "multiple sizes"
-msgstr "كۆپ خىل چوڭلۇق"
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr ""
 
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:154
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s كامېرا"
 
-#: ../panels/background/cc-background-item.c:283
-msgid "No Desktop Background"
-msgstr "ئۈستەلئۈستى تەگلىك يوق"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../panels/background/cc-background-panel.c:453
-msgid "Current background"
-msgstr "نۆۋەتتىكى تەگلىك"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+#, fuzzy
+msgid "Microphone"
+msgstr "مىكروفون ئاۋاز مىقدارى"
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "ئورنى"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "ئۆزىدىكى توركامېراسى"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "پروگرامما تېپىلمىدى"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "ئېكران تىپى"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "ئۇلىنىش تېزلىكى"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "ئەسلىگە قايتۇرۇش"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "پروگراممىلار"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "قەلەم"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "كۆڭۈلدىكى"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "تەگلىك"
 
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change the background"
-msgstr "تەگلىكنى ئۆزگەرتىدۇ"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "سەپلىمە ھۆججەت قوش(_A)…"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Wallpaper;Screen;Desktop;تام قەغىزى;ئېكران;ئۈستەلئۈستى;"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "فىرانسىيە"
 
-#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
-#: ../panels/bluetooth/bluetooth.ui.h:2
-msgctxt "Power"
-msgid "Bluetooth"
-msgstr "كۆكچىش"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
 
-#: ../panels/bluetooth/bluetooth.ui.h:3
-msgid "Set Up New Device"
-msgstr "يېڭى ئۈسكۈنە تەڭشىكى"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/bluetooth.ui.h:4 ../panels/network/network.ui.h:9
-msgid "Remove Device"
-msgstr "ئۈسكۈنىنى چىقىرىۋەت"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "قوزغات"
 
-#: ../panels/bluetooth/bluetooth.ui.h:5
-msgid "Connection"
-msgstr "باغلىنىش"
-
-#: ../panels/bluetooth/bluetooth.ui.h:6
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-#: ../panels/region/gnome-region-panel.ui.h:3
-msgid "page 1"
-msgstr "1-بەت"
-
-#: ../panels/bluetooth/bluetooth.ui.h:7
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-#: ../panels/region/gnome-region-panel.ui.h:5
-msgid "page 2"
-msgstr "2-بەت"
-
-#: ../panels/bluetooth/bluetooth.ui.h:8
-msgid "Paired"
-msgstr "جۈپلەنگەن"
-
-#: ../panels/bluetooth/bluetooth.ui.h:9 ../panels/wacom/cc-wacom-page.c:789
-msgid "Type"
-msgstr "تىپى"
-
-#: ../panels/bluetooth/bluetooth.ui.h:10
-#: ../panels/network/connection-editor/ce-page-ip4.c:189
-#: ../panels/network/connection-editor/ce-page-ip4.c:441
-#: ../panels/network/connection-editor/ce-page-ip6.c:191
-#: ../panels/network/connection-editor/ce-page-ip6.c:445
-msgid "Address"
-msgstr "ئادرېس"
-
-#: ../panels/bluetooth/bluetooth.ui.h:11
-msgid "Mouse & Touchpad Settings"
-msgstr "چاشقىنەك ۋە سېزىمچان تاختا تەڭشىكى"
-
-#: ../panels/bluetooth/bluetooth.ui.h:12
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Sound Settings"
-msgstr "ئاۋاز تەڭشەكلىرى‏"
-
-#: ../panels/bluetooth/bluetooth.ui.h:13
-msgid "Keyboard Settings"
-msgstr "ھەرپتاختا تەڭشەكلىرى‏"
-
-#: ../panels/bluetooth/bluetooth.ui.h:14
-msgid "Send Files…"
-msgstr "ھۆججەت يوللاش…"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:355
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "ھەئە"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:355
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "ياق"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:469
-msgid "Bluetooth is disabled"
-msgstr "كۆكچىش ئىناۋەتسىز قىلىندى"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:474
-msgid "Bluetooth is disabled by hardware switch"
-msgstr "كۆكچىش قاتتىق ئۈزچات تەرىپىدىن چەكلەنگەن"
-
-#: ../panels/bluetooth/cc-bluetooth-panel.c:478
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "كۆكچىش ماسلاشتۇرغۇچىسى تېپىلمىدى"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:577
-msgid "Visibility"
-msgstr "كۆرۈشچانلىقى"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:581
-#, c-format
-msgid "Visibility of “%s”"
-msgstr "«%s» نىڭ كۆرۈنۈشچانلىقى"
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "كۆكچىشتا ھەمبەھىرلەش"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:625
-#, c-format
-msgid "Remove '%s' from the list of devices?"
-msgstr "‹%s› نى ئۈسكۈنە تىزىمىدىن ئۆچۈرسۇنمۇ؟"
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:627
-msgid ""
-"If you remove the device, you will have to set it up again before next use."
-msgstr "ئەگەر سىز بۇ ئۈسكىنىنى ئۆچۈرۈۋەتسىڭىز،كىيىن ئىشلەتكەندە قايتا تەڭشەش زۆرۈر بولىدۇ."
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "ئايروپىلان ھالىتى(_P)"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "كۆكچىش قاتتىق ئۈزچات تەرىپىدىن چەكلەنگەن"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "ئايروپىلان ھالىتى(_P)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "ئايروپىلان ھالىتى(_P)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "كۆكچىش"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
-msgid "Configure Bluetooth settings"
-msgstr "كۆكچىش تەڭشىكىنى تەڭشەش"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:360
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "تەڭشەيدىغان  ئۈسكۈنىنى تىك تۆتبۇلۇڭ ئۈستىگە قويۇپ ‹باشلا› نى بېسىڭ"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:366
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "نۆۋەتتە ئاۋاز قويىدىغان ياكى خاتىرىلەيدىغان پروگرامما يوق."
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
-msgstr "تەڭشەيدىغان ئۈسكۈنىنى تەڭشەيدىغان ئورۇنغا يۆتكەپ ‹داۋاملاشتۇر› نى بېسىڭ"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:372
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr "تەڭشەيدىغان ئۈسكۈنىنى سىرتقى يۈزدىكى ئورۇنغا يۆتكەپ ‹داۋاملاشتۇر› نى بېسىڭ"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:378
-msgid "Shut the laptop lid"
-msgstr "يان كومپيۇتېرنىڭ قېپىنى يېپىڭ"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "تېخىمۇ كۆپ سۈرەتكە كۆز يۈگۈرت"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:409
-msgid "An internal error occurred that could not be recovered."
-msgstr "ئىچكى خاتالىق كۆرۈلۈپ، ئەسلىگە كەلتۈرگىلى بولمىدى."
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:414
-msgid "Tools required for calibration are not installed."
-msgstr "تەڭشەشكە زۆرۈر بولغان قوراللار ئورنىتىلماپتۇ."
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:420
-msgid "The profile could not be generated."
-msgstr "بۇ profile نى قۇرغىلى بولمىدى."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:426
-msgid "The target whitepoint was not obtainable."
-msgstr "نىشاندىكى ئاق نۇقتىغا ئېرىشكىلى بولمايدۇ."
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:466
-msgid "Complete!"
-msgstr "تامام!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:474
-msgid "Calibration failed!"
-msgstr "تەڭشەش مەغلۇپ بولدى!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:481
-msgid "You can remove the calibration device."
-msgstr "تەڭشەيدىغان ئۈسكۈنىنى چىقىرىۋەتسىڭىز بولمايدۇ."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:552
-msgid "Do not disturb the calibration device while in progress"
-msgstr "بىر تەرەپ قىلىۋاتقاندا تەڭشەيدىغان ئۈسكۈنىگە دەخلى قىلماڭ"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "يان كومپيۇتېر ئېكرانى"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "ئۆزىدىكى توركامېراسى"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s ئېكران"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s شويلىلىغۇچ"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s كامېرا"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s پرىنتېر"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s تور كامېراسى"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-#| msgid "Learn more about color management"
-msgid "Enable color management for %s"
-msgstr "%s نىڭ نىسبەتەن رەڭ باشقۇرۇشىنى ئىناۋەتلىك قىل"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "%s نىڭ رەڭ profiles نى كۆرسەت"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:318
-msgid "Not calibrated"
-msgstr "تەڭشەلمىگەن"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:132
-msgid "Default: "
-msgstr "كۆڭۈلدىكى: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:140
-msgid "Colorspace: "
-msgstr "رەڭ بوشلۇق: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:147
-msgid "Test profile: "
-msgstr "سىناق سەپلىمە ھۆججەت: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:215
-msgid "Select ICC Profile File"
-msgstr "ICC سەپلىمە ھۆججەتنى تاللايدۇ"
-
-#: ../panels/color/cc-color-panel.c:218
-msgid "_Import"
-msgstr "ئىمپورت قىل(_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:229
-msgid "Supported ICC profiles"
-msgstr "قوللايدىغان ICC سەپلىمە ھۆججەتلەر"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-#: ../panels/network/wireless-security/eap-method-fast.c:410
-msgid "All files"
-msgstr "ھەممە ھۆججەتلەر"
-
-#: ../panels/color/cc-color-panel.c:580
-msgid "Screen"
-msgstr "ئېكران"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:852
-msgid "Save Profile"
-msgstr "Profile نى ساقلاش"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1213
-msgid "Create a color profile for the selected device"
-msgstr "تاللانغان ئۈسكۈنە ئۈچۈن بىر رەڭ سەپلىمە ھۆججىتى قۇرىدۇ"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1228 ../panels/color/cc-color-panel.c:1252
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "تەكشۈرىدىغان چالغۇ بايقالمىدى. ئۇنىڭ ئېچىلىپ توغرا باغلانغانلىقىنى تەكشۈرۈڭ."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1262
-msgid "The measuring instrument does not support printer profiling."
-msgstr "تەكشۈرىدىغان چالغۇ پرىنتېر سەپلىمە ھۆججىتىنى قوللىمايدۇ."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1273
-msgid "The device type is not currently supported."
-msgstr "بۇ خىل ئۈسكۈنە تىپىنى نۆۋەتتە قوللىمايدۇ."
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:101
-msgid "Standard Space"
-msgstr "ئۆلچەملىك بوشلۇق"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:107
-msgid "Test Profile"
-msgstr "سىناق سەپلىمە ھۆججەت(Profile)"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:115
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "ئاپتوماتىك"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:125
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "سۈپىتى تۆۋەن"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:130
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "سۈپىتى نورمال"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:137
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "سۈپىتى يۇقىرى"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:154
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "كۆڭۈلدىكى RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:161
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "كۆڭۈلدىكى CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:168
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "كۆڭۈلدىكى كۈلرەڭلىك"
-
-#: ../panels/color/cc-color-profile.c:192
-msgid "Vendor supplied factory calibration data"
-msgstr "ياسىغۇچى ئورۇن تەمىنلىگەن ئەسلىدىكى تەڭشەش سانلىق-مەلۇماتلار"
-
-#: ../panels/color/cc-color-profile.c:201
-msgid "Full-screen display correction not possible with this profile"
-msgstr "بۇ profile دا تولۇق ئېكراننى تەڭشەشكە مۇمكىن بولمايدۇ"
-
-#: ../panels/color/cc-color-profile.c:223
-msgid "This profile may no longer be accurate"
-msgstr "مەزكۇر profile ئەمدى توغرا بولماسلىقى مۇمكىن"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "ئېكراننى تەڭشەش"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/data/photo-dialog.ui.h:8
-#: ../panels/user-accounts/um-account-dialog.c:1067
-msgid "Cancel"
-msgstr "ئەمەلدىن قالدۇر"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "ئەمەلدىن قالدۇر(_C)"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "باشلاش"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "داۋاملاشتۇر"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+#, fuzzy
+msgid "_Done"
 msgstr "تامام"
 
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/gui_gtk.c:78
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "ئېكراننى تەڭشەش"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "تەڭشەش سۈپىتى"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "تەڭشەش ئېلىپ بېرىۋاتقان چاغدا سىز باشقا مەشغۇلاتلارنى قىلالمايسىز."
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "سۈپەت"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "تەخمىنىي ۋاقىت"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "تەڭشەش سۈپىتى"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "تەڭشەشتە ئىشلىتىدىغان سەزگۈچنى تاللاڭ."
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "تەڭشەش ئۈسكۈنىسى"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "چېتىلغان كۆرسەتكۈچنىڭ تىپىنى تاللاڭ."
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "تەڭشەشتە ئىشلىتىدىغان سەزگۈچنى تاللاڭ."
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "ئېكران تىپى"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "چېتىلغان كۆرسەتكۈچنىڭ تىپىنى تاللاڭ."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr ""
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr ""
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "ئېكران يورۇقلۇقى"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
-msgstr "سىز ماس كەلگەن يورۇقلۇقنى بەلگىلەڭ.  مۇشۇ يورۇقلۇق دەرىجىسىدە رەڭ باشقۇرۇش تېخىمۇ توغرا بولىدۇ."
+msgstr ""
+"سىز ماس كەلگەن يورۇقلۇقنى بەلگىلەڭ.  مۇشۇ يورۇقلۇق دەرىجىسىدە رەڭ باشقۇرۇش "
+"تېخىمۇ توغرا بولىدۇ."
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr ""
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "ئېكران يورۇقلۇقى"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "سەپلىمە ھۆججەت ئاتى"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr ""
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "سەپلىمە ھۆججەت ئاتى:"
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "سەپلىمە ھۆججەت ئاتى"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "سەپلىمە ھۆججەت مۇۋەپپەقىيەتلىك ياسالدى."
-
-#: ../panels/color/color.ui.h:22
-msgid "Export"
-msgstr "ئېكسپورت قىلىش"
-
-#: ../panels/color/color.ui.h:23
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr ""
-
-#: ../panels/color/color.ui.h:24
-#: ../panels/user-accounts/um-fingerprint-dialog.c:743
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "ئۈزۈندى"
 
-#: ../panels/color/color.ui.h:25
-msgid "Import File…"
-msgstr "ھۆججەت ئىمپورت قىلىش"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "سەپلىمە ھۆججەت مۇۋەپپەقىيەتلىك ياسالدى."
 
-#: ../panels/color/color.ui.h:26
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "سەپلىمە ھۆججەت يوق"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "سەپلىمە ھۆججەت قوش"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
-msgstr "مەسىلە بايقالدى. بۇ profile نورمال ئىشلىمىگەندەك قىلىدۇ. <a href=\"\">تەپسىلاتى بۇ يەردە.</a>"
+msgstr ""
+"مەسىلە بايقالدى. بۇ profile نورمال ئىشلىمىگەندەك قىلىدۇ. <a "
+"href=\"\">تەپسىلاتى بۇ يەردە.</a>"
 
-#: ../panels/color/color.ui.h:27
-msgid "Device type:"
-msgstr "ئۈسكۈنە تىپى:"
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "ھۆججەت ئىمپورت قىلىش"
 
-#: ../panels/color/color.ui.h:28
-msgid "Manufacturer:"
-msgstr "ياسىغۇچى:"
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "قوش(_A)"
 
-#: ../panels/color/color.ui.h:29
-msgid "Model:"
-msgstr "تىپى:"
-
-#: ../panels/color/color.ui.h:30
-msgid ""
-"Image files can be dragged on this window to auto-complete the above fields."
-msgstr "سۈرەت ھۆججەتنى بۇ كۆزنەككە سۆرەپ ئۈستىدىكى سۆز بۆلەكلىرىنى ئۆزلۈكىدىن تولدۇرغىلى بولىدۇ."
-
-#: ../panels/color/color.ui.h:31
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Color"
-msgstr "رەڭ"
-
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
-msgstr "ھەر بىر ئۈسكۈنە رەڭ باشقۇرغۇچ ئارقىلىق رەڭ سەپلىمە ھۆججىتىنى يېڭىلاشقا ئېھتىياجلىق."
+msgstr ""
+"ھەر بىر ئۈسكۈنە رەڭ باشقۇرغۇچ ئارقىلىق رەڭ سەپلىمە ھۆججىتىنى يېڭىلاشقا "
+"ئېھتىياجلىق."
 
-#: ../panels/color/color.ui.h:33
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "تەپسىلات بىلدۈرگۈسى"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "رەڭ باشقۇرۇش ھەققىدە تېخىمۇ كۆپ ئۇچۇر"
 
-#: ../panels/color/color.ui.h:35
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "ھەممە ئىشلەتكۈچىنىڭ تەڭشىكى"
 
-#: ../panels/color/color.ui.h:36
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "كومپيۇتېردىكى بارلىق ئىشلەتكۈچىدە مۇشۇ profile نى ئىشلەتسۇن"
 
-#: ../panels/color/color.ui.h:37
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "قوزغات"
 
-#: ../panels/color/color.ui.h:38
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "سەپلىمە ھۆججەت قوش"
 
-#: ../panels/color/color.ui.h:39
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "تۈزەت…"
 
-#: ../panels/color/color.ui.h:40
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "ئۈسكۈنىنى تۈزەت"
 
-#: ../panels/color/color.ui.h:41
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "سەپلىمە ھۆججەت چىقىرىۋەت"
 
-#: ../panels/color/color.ui.h:42
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "تەپسىلاتىنى كۆرسەت"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "رەڭ باشقۇرىدىغان ھېچقانداق ئۈسكۈنىنى بايقىمىدى"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "پرويېكتور"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "پلازما"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "يۇقىرى"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 مىنۇت"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "ئوتتۇراھال"
 
-#: ../panels/color/color.ui.h:52 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 مىنۇت"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "تۆۋەن"
 
-#: ../panels/color/color.ui.h:54 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 مىنۇت"
 
-#: ../panels/color/color.ui.h:55
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr ""
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (باسمىچىلىق ۋە نەشرىيات)"
 
-#: ../panels/color/color.ui.h:57
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (سۈرەتچىلىك ۋە گرافىك)"
 
-#: ../panels/color/color.ui.h:59
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
-msgid "Color management settings"
-msgstr "رەڭ باشقۇرۇش تەڭشىكى"
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "رەڭ"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "رەڭ;ICC;سەپلىمە ھۆججەت;تۈزىتىش;پرىنتېر;ئېكران;"
 
-#: ../panels/common/cc-common-language.c:639
-msgid "British English"
-msgstr "ئەنگلىيە ئىنگلىزچە"
-
-#: ../panels/common/cc-common-language.c:642
-msgid "Spanish"
-msgstr "ئىسپانچە"
-
-#: ../panels/common/cc-common-language.c:643
-msgid "Chinese (simplified)"
-msgstr "ئاددىي خەنزۇچە"
-
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:687
-msgid "United States"
-msgstr "ئامېرىكا قوشما شتاتلىرى"
-
-#: ../panels/common/cc-common-language.c:688
-msgid "Germany"
-msgstr "گېرمانىيە"
-
-#: ../panels/common/cc-common-language.c:689
-msgid "France"
-msgstr "فىرانسىيە"
-
-#: ../panels/common/cc-common-language.c:690
-msgid "Spain"
-msgstr "ئىسپانىيە"
-
-#: ../panels/common/cc-common-language.c:691
-msgid "China"
-msgstr "جۇڭگو"
-
-#: ../panels/common/cc-language-chooser.c:120
-msgid "Other…"
-msgstr "باشقا…"
-
-#: ../panels/common/cc-language-chooser.c:292
-msgid "Select a region"
-msgstr "رايون تاللاڭ"
-
-#: ../panels/common/language-chooser.ui.h:1
-msgid "Select a language"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
 msgstr "تىل تاللا"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/user-accounts/um-user-panel.c:467
-msgid "_Cancel"
-msgstr "ئەمەلدىن قالدۇر(_C)"
-
-#: ../panels/common/language-chooser.ui.h:3
+#: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
 msgstr "تاللا(_S)"
 
-#: ../panels/datetime/datetime.ui.h:1
-msgid "_Region:"
-msgstr "رايون(_R):"
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "پروگرامما تېپىلمىدى"
 
-#: ../panels/datetime/datetime.ui.h:2
-msgid "_City:"
-msgstr "شەھەر(_C):"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:3
-msgid "_Network Time"
-msgstr "تور ۋاقتى(_N):"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translator: this is the separator between hours and minutes, like in HH:MM
-#: ../panels/datetime/datetime.ui.h:5
-msgid ":"
-msgstr ":"
+#: panels/common/cc-permission-infobar.ui:59
+#, fuzzy
+msgid "Unlock…"
+msgstr "قۇلۇپ ئاچ"
 
-#: ../panels/datetime/datetime.ui.h:6
-msgid "Set the time one hour ahead."
-msgstr "ۋاقىتنى بىر سائەت ئىلگىرى تەڭشەيدۇ."
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:7
-msgid "Set the time one hour back."
-msgstr "ۋاقىتنى بىر سائەت كېيىن تەڭشەيدۇ."
+#: panels/common/cc-time-editor.ui:53
+#, fuzzy
+msgid "Increment Minute"
+msgstr "چوڭلۇقىنى چوڭايتىش:"
 
-#: ../panels/datetime/datetime.ui.h:8
-msgid "Set the time one minute ahead."
-msgstr "ۋاقىتنى بىر مىنۇت ئىلگىرى تەڭشەيدۇ."
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "ۋاقىت"
 
-#: ../panels/datetime/datetime.ui.h:9
-msgid "Set the time one minute back."
-msgstr "ۋاقىتنى بىر مىنۇت كېيىن تەڭشەيدۇ."
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:10
-msgid "Switch between AM and PM."
-msgstr "چۈشتىن بۇرۇن بىلەن چۈشتىن كېيىن ئارىسىدا ئالماشتۇرىدۇ."
+#: panels/common/cc-time-editor.ui:122
+#, fuzzy
+msgid "Decrement Minute"
+msgstr "كىچىكلەت:"
 
-#: ../panels/datetime/datetime.ui.h:11
-msgid "Month"
-msgstr "ئاي"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "Day"
-msgstr "كۈن"
-
-#: ../panels/datetime/datetime.ui.h:13
-msgid "Year"
-msgstr "يىل"
-
-#: ../panels/datetime/datetime.ui.h:14
-msgid "24-hour"
-msgstr "24 سائەت"
-
-#: ../panels/datetime/datetime.ui.h:15
-msgid "AM/PM"
-msgstr "چ ب/چ ك"
-
-#: ../panels/datetime/datetime.ui.h:16
-msgid "January"
-msgstr "قەھرىتان"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "February"
-msgstr "ھۇت"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "March"
-msgstr "نەۋرۇز"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "April"
-msgstr "ئۈمىد"
-
-#: ../panels/datetime/datetime.ui.h:20
-msgid "May"
-msgstr "باھار"
-
-#: ../panels/datetime/datetime.ui.h:21
-msgid "June"
-msgstr "سەپەر"
-
-#: ../panels/datetime/datetime.ui.h:22
-msgid "July"
-msgstr "چىللە"
-
-#: ../panels/datetime/datetime.ui.h:23
-msgid "August"
-msgstr "تومۇز"
-
-#: ../panels/datetime/datetime.ui.h:24
-msgid "September"
-msgstr "مىزان"
-
-#: ../panels/datetime/datetime.ui.h:25
-msgid "October"
-msgstr "ئوغۇز"
-
-#: ../panels/datetime/datetime.ui.h:26
-msgid "November"
-msgstr "ئوغلاق"
-
-#: ../panels/datetime/datetime.ui.h:27
-msgid "December"
-msgstr "كۆنەك"
-
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "چېسلا & ۋاقىت"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
-msgid "Date and Time preferences panel"
-msgstr "چېسلا ۋە ۋاقىت مايىللىق تاختىسى"
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "يىل"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "ئاي"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "قەھرىتان"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "ھۇت"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "نەۋرۇز"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "ئۈمىد"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "باھار"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "سەپەر"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "چىللە"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "تومۇز"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "مىزان"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "ئوغۇز"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "ئوغلاق"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "كۆنەك"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "كۈن"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+#, fuzzy
+msgid "Time Zone"
+msgstr "ۋاقىت"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "بۇ تېكىستنى ئىزدە"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "چېسلا & ۋاقىت"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+#, fuzzy
+msgid "Automatic Time _Zone"
+msgstr "ئاپتوماتىك باغلانسۇن(_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "ئىناۋەتلىك قىلىنغان"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "قۇلۇپ ئاچ"
+
+#: panels/datetime/cc-datetime-panel.ui:246
+#, fuzzy
+msgid "Time _Format"
+msgstr "پىچىملار"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "چېسلا"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "30 سېكۇنت"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "يىلنامە(_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "سانلار"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "سائەت;ۋاقىت رايونى;ئورۇن;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "سىستېمىنىڭ ۋاقىت ۋە چېسلا تەڭشىكىنى ئۆزگەرت"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "ۋاقىت ۋە چېسلا تەڭشىكى ئۆزگەرتىش ئۈچۈن سالاھىيەت دەلىللەش زۆرۈردۇر"
 
-#: ../panels/display/cc-display-panel.c:483
-msgctxt "display panel, rotation"
-msgid "Normal"
-msgstr "نورمال"
-
-#: ../panels/display/cc-display-panel.c:484
-msgctxt "display panel, rotation"
-msgid "Counterclockwise"
-msgstr "سائەت يۆنىلىشىگە قارشى"
-
-#: ../panels/display/cc-display-panel.c:485
-msgctxt "display panel, rotation"
-msgid "Clockwise"
-msgstr "سائەت يۆنىلىشى"
-
-#: ../panels/display/cc-display-panel.c:486
-msgctxt "display panel, rotation"
-msgid "180 Degrees"
-msgstr "180 گرادۇس"
-
-#. Keep this string in sync with gnome-desktop/libgnome-desktop/gnome-rr-labeler.c
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external projector.  Here, "Mirrored" is being
-#. * used as an adjective.  For example, the Spanish translation could be
-#. * "Pantallas en Espejo".
-#.
-#. Keep this string in sync with gnome-control-center/capplets/display/xrandr-capplet.c:get_display_name()
-#. Translators:  this is the feature where what you see on your
-#. * laptop's screen is the same as your external projector.
-#. * Here, "Mirrored" is being used as an adjective.  For example,
-#. * the Spanish translation could be "Pantallas en Espejo".
-#.
-#: ../panels/display/cc-display-panel.c:625
-#: ../panels/display/cc-rr-labeler.c:449
-msgid "Mirrored Displays"
-msgstr "نۇسخىلانغان كۆرسەتكۈچلەر"
-
-#: ../panels/display/cc-display-panel.c:649
-#: ../panels/display/display-capplet.ui.h:1
-msgid "Monitor"
-msgstr "ئېكران"
-
-#: ../panels/display/cc-display-panel.c:1669
-msgid "Drag to change primary display."
-msgstr "ئاساسىي كۆزەتكۈچ سۆرەپ تەڭشىلىدۇ."
-
-#: ../panels/display/cc-display-panel.c:1727
-msgid ""
-"Select a monitor to change its properties; drag it to rearrange its "
-"placement."
-msgstr "كۆزەتكۈچتىن بىرنى تاللاپ خاسلىقى ئۆزگەرتىلىدۇ؛ سۆرەپ ئۇلارنىڭ ئورنى تەڭشىلىدۇ."
-
-#: ../panels/display/cc-display-panel.c:2115
-msgid "%a %R"
-msgstr "%a %R"
-
-#: ../panels/display/cc-display-panel.c:2117
-msgid "%a %l:%M %p"
-msgstr "%p%l:%M (%a)"
-
-#: ../panels/display/cc-display-panel.c:2279
-#: ../panels/display/cc-display-panel.c:2331
-#, c-format
-msgid "Failed to apply configuration: %s"
-msgstr "سەپلىمىنى قوللىنالمىدى: %s"
-
-#: ../panels/display/cc-display-panel.c:2359
-msgid "Could not save the monitor configuration"
-msgstr "كۆزەتكۈچ تەڭشەكلىرىنى ساقلىغىلى بولمىدى"
-
-#: ../panels/display/cc-display-panel.c:2419
-msgid "Could not detect displays"
-msgstr "كۆرسەتكۈچلەر بايقالمىدى"
-
-#: ../panels/display/cc-display-panel.c:2614
-msgid "Could not get screen information"
-msgstr "ئېكران ئۇچۇرىغا ئېرىشكىلى بولمىدى"
-
-#: ../panels/display/display-capplet.ui.h:2
-msgid "_Resolution"
-msgstr "ئېنىقلىقى(_R)"
-
-#: ../panels/display/display-capplet.ui.h:3
-msgid "R_otation"
-msgstr "چۆرگىلىتىش(_O)"
-
-#. Note that mirror is a verb in this string
-#: ../panels/display/display-capplet.ui.h:5
-msgid "_Mirror displays"
-msgstr "نۇسخىلانغان كۆرسەتكۈچلەر(_M)"
-
-#: ../panels/display/display-capplet.ui.h:6
-msgid "Note: may limit resolution options"
-msgstr "ئىزاھات: ئېنىقلىق نىسبىتى تاللانمىسىنى چەكلىمىگە ئۇچرىشى مۇمكىن"
-
-#: ../panels/display/display-capplet.ui.h:7
-msgid "_Detect Displays"
-msgstr "كۆرسەتكۈچلەرنى بايقا(_D)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "كۆرسەتكۈچلەر"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Change resolution and position of monitors and projectors"
-msgstr "كۆزەتكۈچ ۋە پرويېكتورنىڭ ئېنىقلىق ۋە ئورنىنى ئۆزگەرت"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
-msgstr "تاختا;پرويېكتور;xrandr;ئېكران;ئېنىقلىق;يېڭىلا;"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:441 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "نامەلۇم"
-
-#: ../panels/info/cc-info-panel.c:542
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d-بىت"
-
-#: ../panels/info/cc-info-panel.c:544
-#, c-format
-msgid "%d-bit"
-msgstr "%d-بىت"
-
-#: ../panels/info/cc-info-panel.c:1219
-msgid "Ask what to do"
-msgstr "مەشغۇلاتنى سورا"
-
-#: ../panels/info/cc-info-panel.c:1223
-msgid "Do nothing"
-msgstr "ھېچقانداق قىلما"
-
-#: ../panels/info/cc-info-panel.c:1227
-msgid "Open folder"
-msgstr "قىسقۇچ ئاچ"
-
-#: ../panels/info/cc-info-panel.c:1318
-msgid "Other Media"
-msgstr "باشقا ۋاسىتە"
-
-#: ../panels/info/cc-info-panel.c:1349
-msgid "Select an application for audio CDs"
-msgstr "ئۈن CD ئۈچۈن پروگرامما تاللاڭ"
-
-#: ../panels/info/cc-info-panel.c:1350
-msgid "Select an application for video DVDs"
-msgstr "سىن CD ئۈچۈن پروگرامما تاللاڭ"
-
-#: ../panels/info/cc-info-panel.c:1351
-msgid "Select an application to run when a music player is connected"
-msgstr "مۇزىكا قويغۇ باغلانغاندا ئىجرا بولىدىغان پروگراممىنى تاللايدۇ"
-
-#: ../panels/info/cc-info-panel.c:1352
-msgid "Select an application to run when a camera is connected"
-msgstr "كامېرا باغلانغاندا ئىجرا بولىدىغان پروگراممىنى تاللايدۇ"
-
-#: ../panels/info/cc-info-panel.c:1353
-msgid "Select an application for software CDs"
-msgstr "يۇمشاق دېتال CD سى ئۈچۈن پروگرامما تاللاڭ"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1365
-msgid "audio DVD"
-msgstr "ئۈن DVD"
-
-#: ../panels/info/cc-info-panel.c:1366
-msgid "blank Blu-ray disc"
-msgstr "قۇرۇق كۆكنۇر دىسكىسى"
-
-#: ../panels/info/cc-info-panel.c:1367
-msgid "blank CD disc"
-msgstr "قۇرۇق CD دىسكىسى"
-
-#: ../panels/info/cc-info-panel.c:1368
-msgid "blank DVD disc"
-msgstr "قۇرۇق DVD دىسكىسى"
-
-#: ../panels/info/cc-info-panel.c:1369
-msgid "blank HD DVD disc"
-msgstr "قۇرۇق HD DVD دىسكىسى"
-
-#: ../panels/info/cc-info-panel.c:1370
-msgid "Blu-ray video disc"
-msgstr "كۆكنۇر سىن دىسكىسى"
-
-#: ../panels/info/cc-info-panel.c:1371
-msgid "e-book reader"
-msgstr "ئې-كىتاب ئوقۇغۇ"
-
-#: ../panels/info/cc-info-panel.c:1372
-msgid "HD DVD video disc"
-msgstr "HD DVD سىن دىسكىسى :"
-
-#: ../panels/info/cc-info-panel.c:1373
-msgid "Picture CD"
-msgstr "سۈرەت CD"
-
-#: ../panels/info/cc-info-panel.c:1374
-msgid "Super Video CD"
-msgstr "ئالاھىدە سىن CD"
-
-#: ../panels/info/cc-info-panel.c:1375
-msgid "Video CD"
-msgstr "سىن CD"
-
-#: ../panels/info/cc-info-panel.c:1376
-msgid "Windows software"
-msgstr "ۋىندوۋس يۇمشاق دېتاللىرى"
-
-#: ../panels/info/cc-info-panel.c:1377
-msgid "Software"
-msgstr "يۇمشاق دېتال"
-
-#: ../panels/info/cc-info-panel.c:1500
-#: ../panels/keyboard/keyboard-shortcuts.c:1697
-msgid "Section"
-msgstr "گۇرۇپپىسى"
-
-#: ../panels/info/cc-info-panel.c:1509 ../panels/info/info.ui.h:13
-msgid "Overview"
-msgstr "قىسقىچە بايان"
-
-#: ../panels/info/cc-info-panel.c:1515 ../panels/info/info.ui.h:20
-msgid "Default Applications"
-msgstr "كۆڭۈلدىكى پروگراممىلار"
-
-#: ../panels/info/cc-info-panel.c:1520 ../panels/info/info.ui.h:28
-msgid "Removable Media"
-msgstr "چىقىرىۋېتىشكە بولىدىغان ۋاسىتە"
-
-#: ../panels/info/cc-info-panel.c:1545
-#, c-format
-msgid "Version %s"
-msgstr "نەشر %s"
-
-#: ../panels/info/cc-info-panel.c:1595
-msgid "Install Updates"
-msgstr "يېڭىلاش قاچىلا"
-
-#: ../panels/info/cc-info-panel.c:1599
-msgid "System Up-To-Date"
-msgstr "سىستېما ئەڭ يېڭى ھالەتتە"
-
-#: ../panels/info/cc-info-panel.c:1603
-msgid "Checking for Updates"
-msgstr "يېڭىلانمىلارنى تەكشۈرۈۋاتىدۇ"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:58
-msgid "Details"
-msgstr "تەپسىلاتلار"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "System Information"
-msgstr "سىستېما ئۇچۇرى"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr "device;system;information;memory;processor;version;default;application;fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;ئۈسكۈنە;سىستېما;ئۇچۇر;ئەسلەك;بىر تەرەپ قىلغۇچ;نەشرى;كۆڭۈلدىكى;ئەپ;زاپاس;ئارقىغا قايتۇر;مايىللىق;cd;dvd;usb;ئۈن;سىن;ئوپتىك دىسكا;نۇر دىسكا;دىسكا;كۆچمە;ۋاسىتە;تاراتقۇ;ئۆزلۈكىدىن ئىجرا قىل;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "بىر تەرەپ قىلىنىدىغان باشقا ۋاسىتىنى تاللاڭ"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "مەشغۇلات(_A):"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "تىپى(_T):"
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "ئۈسكۈنە ئاتى"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "ئەسلەك"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "بىر تەرەپ قىلغۇچ"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "ئاساسى سىستېما"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "دىسكا"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "ھېسابلاش…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "گرافىك"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "مەۋھۇملاشتۇرۇش"
-
-#: ../panels/info/info.ui.h:14
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "تور(_W)"
 
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "خەت(_M)"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "يىلنامە(_C)"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "نەغمە(_U)"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "سىن(_V)"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "سۈرەتلەر(_P)"
 
-#: ../panels/info/info.ui.h:21
-msgid "Select how media should be handled"
-msgstr "بىر تەرەپ قىلىنىدىغان ۋاسىتىنى تاللاڭ"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "كۆڭۈلدىكى پروگراممىلار"
 
-#: ../panels/info/info.ui.h:22
-msgid "CD _audio"
-msgstr "CD ئۈن(_A)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "كۆڭۈلدىكى پروگراممىلار"
 
-#: ../panels/info/info.ui.h:23
-msgid "_DVD video"
-msgstr "_DVD سىن"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/info.ui.h:24
-msgid "_Music player"
-msgstr "نەغمە چالغۇچ(_M)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:25
-msgid "_Software"
-msgstr "يۇمشاق دېتال(_S)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:26
-msgid "_Other Media…"
-msgstr "باشقا ۋاسىتە(_O)…"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/info/info.ui.h:27
-msgid "_Never prompt or start programs on media insertion"
-msgstr "ۋاسىتە قىستۇرۇلغاندا ھەرگىز ئەسكەرتمە ياكى پروگرامما قوزغاتما(_N)"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "قوللان(_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "كەينى"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "كۆكچىش ئىناۋەتسىز قىلىندى"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "نۇسخىلانغان كۆرسەتكۈچلەر"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "كۆرسەتكۈچ"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "ئوڭ نامسىز بارماق"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "يۆنىلىش"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "ئېنىقلىق"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "نىسبىتى"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "پرىنتېر مەۋجۇت ئەمەس"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "ۋاقىت"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "مىنۇت"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "كۆرسەتكۈچلەر"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+#, fuzzy
+msgid "Choose how to use connected monitors and projectors"
+msgstr "كۆزەتكۈچ ۋە پرويېكتورنىڭ ئېنىقلىق ۋە ئورنىنى ئۆزگەرت"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr "تاختا;پرويېكتور;xrandr;ئېكران;ئېنىقلىق;يېڭىلا;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "بىخەتەرلىك ئاچقۇچى"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "سىياھ دەرىجىسى"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "سىياھ دەرىجىسى"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "سىياھ دەرىجىسى"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "بىخەتەرلىك"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;ئېكران;قۇلۇپ;يېقىنقى;ۋاقىتلىق;ئاتى;تور;كىملىك;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "ئۈسكۈنە ئاتى"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "قاتتىق دېتال ئادرېسى"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "ئەسلەك"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "بىر تەرەپ قىلغۇچ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "گرافىك"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "ھېسابلاش…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "ئاتى"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "تىپى"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "نەشرى 0"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "تاللانمىلارنى ئوقۇۋاتىدۇ…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "ۋىندوۋس يۇمشاق دېتاللىرى"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "مەۋھۇملاشتۇرۇش"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "يۇمشاق دېتال"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "ئۈسكۈنىنى چىقىرىۋەت"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "ئۈسكۈنە ئاتى"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "ئىشلەتكۈچى ئاتى(_U)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"ئۈسكۈنە;سىستېما;ئۇچۇر;ئەسلەك;بىر تەرەپ قىلغۇچ;نەشرى;كۆڭۈلدىكى;ئەپ;زاپاس;"
+"ئارقىغا قايتۇر;مايىللىق;cd;dvd;usb;ئۈن;سىن;ئوپتىك دىسكا;نۇر دىسكا;دىسكا;"
+"كۆچمە;ۋاسىتە;تاراتقۇ;ئۆزلۈكىدىن ئىجرا قىل;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "ئاۋاز ۋە ۋاسىتە"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "ئۈنسىزلە"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "ئاۋازنى كىچىكلەت"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "ئاۋازنى چوڭايت"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+#, fuzzy
+msgid "Microphone mute/unmute"
+msgstr "مىكروفون ئاۋاز مىقدارى"
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "ۋاسىتە قويغۇنى قوزغات"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "چال(ياكى چال/ۋاقىتلىق توختات)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "ۋاقىتلىق توختات"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "توختات"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "ئالدىنقى ئاۋاز يولى"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "كېيىنكى ئاۋاز يولى"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "چىقار"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/universal-access/uap.ui.h:66
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "كىرگۈزۈۋاتىدۇ"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
-#: ../panels/region/gnome-region-panel.ui.h:27
-msgid "Switch to next source"
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
 msgstr "كېيىنكى مەنبەگە ئالماشتۇر"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
-#: ../panels/region/gnome-region-panel.ui.h:25
-msgid "Switch to previous source"
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
 msgstr "ئالدىنقى مەنبەگە ئالماشتۇر"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "ئىجراچىلار"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "ياردەم قوزغاتقۇنى قوزغات"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "تەڭشەكلەر"
+
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "ھېسابلىغۇچنى قوزغات"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "ئەخلەت ئوقۇغۇنى قوزغات"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "توركۆرگۈنى قوزغات"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "ماكان مۇندەرىجە"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "ئىزدە"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "ئېكران كۆرۈنۈشى"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "ئېكران كۆرۈنۈشىنى $PICTURES غا ساقلايدۇ"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "كۆزنەكنىڭ ئېكران كۆرۈنۈشىنى $PICTURES غا ساقلايدۇ"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "رايوننىڭ ئېكران كۆرۈنۈشىنى $PICTURES غا ساقلايدۇ"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "بىر ئېكران كۆرۈنۈشىنى چاپلاش تاختىسىغا كۆچۈرىدۇ"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "بىر كۆزنەكنىڭ ئېكران كۆرۈنۈشىنى چاپلاش تاختىسىغا كۆچۈرىدۇ"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "بىر دائىرىنىڭ ئېكران كۆرۈنۈشىنى چاپلاش تاختىسىغا كۆچۈرىدۇ"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
-#: ../panels/region/gnome-region-panel.ui.h:43
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "سىستېما"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "تىزىمدىن چىق"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "ئېكراننى قۇلۇپلا"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "ئۇنىۋېرسال زىيارەت"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "كۆرۈشچانلىقى"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "ئېكران چوڭايت كىچىكلەتنى ئاچ ياكى تاقا"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "چوڭايت"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "كىچىكلەت"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "ئېكران ئوقۇغۇچنى ئاچ ياكى تاقا"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "ئېكران ھەرپتاختىنى ئاچ ياكى تاقا"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "تېكىستنى چوڭايت"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "تېكىستنى كىچىكلەت"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "يۇقىرى پەرقنى ئاچ ياكى تاقا"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:254
-#: ../panels/keyboard/cc-keyboard-option.c:304
-#: ../panels/keyboard/cc-keyboard-option.c:436
-#: ../panels/keyboard/keyboard-shortcuts.c:1160
-#: ../panels/network/network-wifi.ui.h:30
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:215
-#: ../panels/user-accounts/um-fingerprint-dialog.c:216
-msgid "Disabled"
-msgstr "ئىناۋەتسىز قىلىنغان"
+#: panels/keyboard/cc-input-chooser.ui:5
+#, fuzzy
+msgid "Add an Input Source"
+msgstr "كىرگۈزۈش مەنبەسى قوشۇش"
 
-#: ../panels/keyboard/cc-keyboard-option.c:255
-msgid "Left Shift"
-msgstr "سول Shift"
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
 
-#: ../panels/keyboard/cc-keyboard-option.c:256
-msgid "Left Alt"
-msgstr "سول Alt"
+#: panels/keyboard/cc-input-list-box.ui:24
+#, fuzzy
+msgid "No input source selected"
+msgstr "پرىنتېر بايقالمىدى."
 
-#: ../panels/keyboard/cc-keyboard-option.c:257
-msgid "Left Ctrl"
-msgstr "سول Ctrl"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "تاللانما"
 
-#: ../panels/keyboard/cc-keyboard-option.c:258
-msgid "Right Shift"
-msgstr "ئوڭ Shift"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "ئۈستىگە"
 
-#: ../panels/keyboard/cc-keyboard-option.c:259
-msgid "Right Alt"
-msgstr "ئوڭ Alt"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "پەسكە"
 
-#: ../panels/keyboard/cc-keyboard-option.c:260
-msgid "Right Ctrl"
-msgstr "ئوڭ Ctrl"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "مايىللىق"
 
-#: ../panels/keyboard/cc-keyboard-option.c:261
-msgid "Left Alt+Shift"
-msgstr "سول Alt+Shift"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "ھەرپ تاختا ئورۇنلاشتۇرۇشىنى كۆرسىتىش"
 
-#: ../panels/keyboard/cc-keyboard-option.c:262
-msgid "Right Alt+Shift"
-msgstr "ئوڭ Alt+Shift"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "چىقىرىۋەت(_R)"
 
-#: ../panels/keyboard/cc-keyboard-option.c:263
-msgid "Left Ctrl+Shift"
-msgstr "سول Ctrl+Shift"
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "كىرگۈزۈش مەنبەلىرى"
 
-#: ../panels/keyboard/cc-keyboard-option.c:264
-msgid "Right Ctrl+Shift"
-msgstr "ئوڭ Ctrl+Shift"
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
 
-#: ../panels/keyboard/cc-keyboard-option.c:265
-msgid "Left+Right Shift"
-msgstr "سول+ئوڭ Shift"
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "كىرگۈزۈش مەنبەسى تەڭشىكى"
 
-#: ../panels/keyboard/cc-keyboard-option.c:266
-msgid "Left+Right Alt"
-msgstr "سول+ئوڭ Alt"
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "ھەممە كۆزنەكلەرگە ئوخشاش مەنبەنى ئىشلەتسۇن"
 
-#: ../panels/keyboard/cc-keyboard-option.c:267
-msgid "Left+Right Ctrl"
-msgstr "سول+ئوڭ Ctrl"
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "ھەر بىر كۆزنەكنىڭ ئايرىم-ئايرىم بولسۇن"
 
-#: ../panels/keyboard/cc-keyboard-option.c:268
-msgid "Alt+Shift"
-msgstr "Alt+Shift"
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
 
-#: ../panels/keyboard/cc-keyboard-option.c:269
-msgid "Ctrl+Shift"
-msgstr "Ctrl+Shift"
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
 
-#: ../panels/keyboard/cc-keyboard-option.c:270
-msgid "Alt+Ctrl"
-msgstr "Alt+Ctrl"
-
-#: ../panels/keyboard/cc-keyboard-option.c:271
-msgid "Caps"
-msgstr "Caps"
-
-#: ../panels/keyboard/cc-keyboard-option.c:272
-msgid "Shift+Caps"
-msgstr "Shift+Caps"
-
-#: ../panels/keyboard/cc-keyboard-option.c:273
-msgid "Alt+Caps"
-msgstr "Alt+Caps"
-
-#: ../panels/keyboard/cc-keyboard-option.c:274
-msgid "Ctrl+Caps"
-msgstr "Ctrl+Caps"
-
-#: ../panels/keyboard/cc-keyboard-option.c:390
-msgid "Alternative Characters Key"
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
 msgstr "ئورنىغا ئىشلىتىدىغان ھەرپلەر كۇنۇپكىسى"
 
-#: ../panels/keyboard/cc-keyboard-option.c:395
+#: panels/keyboard/cc-keyboard-panel.ui:80
 msgid "Compose Key"
 msgstr "Compose كۇنۇپكىسى"
 
-#: ../panels/keyboard/cc-keyboard-option.c:399
-msgid "Modifiers-only switch to next source"
-msgstr ""
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+#, fuzzy
+msgid "Keyboard Shortcuts"
+msgstr "ھەرپتاختا تەڭشەكلىرى‏"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "Keyboard"
-msgstr "ھەرپتاختا"
-
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "Change keyboard settings"
-msgstr "ھەرپتاختا تەڭشىكىنى ئۆزگەرت"
-
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Shortcut;Repeat;Blink;قىسقا يول;تەكرارلاش;چاقناش;"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
 msgstr "ئىختىيارى تېزلەتمە"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-msgid "_Name:"
-msgstr "ئاتى(_N):"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-msgid "C_ommand:"
-msgstr "بۇيرۇق(_O):"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "Repeat Keys"
-msgstr "تەكرار كۇنۇپكا"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "گۇرۇپپىسى"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Key presses _repeat when key is held down"
-msgstr "مەلۇم كۇنۇپكا بېسىپ تۇرۇلغاندا شۇ كۇنۇپكىنى تەكرارلا(_R)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "_Delay:"
-msgstr "كېچىكتۈر(_D):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Speed:"
-msgstr "سۈرئەت(_S):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "قىسقا"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "ئاستا"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgid "Repeat keys speed"
-msgstr "تەكرار كۇنۇپكا سۈرئىتى"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "ئۇزۇن"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "تېز"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgid "Cursor Blinking"
-msgstr "نۇربەلگىنىڭ لىپىلدىشى"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor _blinks in text fields"
-msgstr "تېكىست رايونىدا نۇربەلگىسى لىپىلدىسۇن(_B)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "S_peed:"
-msgstr "سۈرئىتى(_P):"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "Cursor blink speed"
-msgstr "سىنبەلگە لىپىلداش سۈرئىتى"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Layout Settings"
-msgstr "جايلاشتۇر تەڭشىكى"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-msgid "Add Shortcut"
-msgstr "قىسقا يول قوش"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Remove Shortcut"
-msgstr "قىسقا يولنى چىقىرىۋەت"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-#: ../panels/wacom/button-mapping.ui.h:3
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
-msgstr "تېزلەتمىنى تەھرىرلەشتە، مۇناسىپ قۇرنى تاق چېكىپ ئاندىن يېڭى تېزلەتمە كىرگۈزۈلىدۇ ياكى backspace ئۆچۈرۈش كۇنۇپكىسىدا تازىلىنىدۇ."
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-#: ../panels/region/gnome-region-panel.ui.h:30
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "تېزلەتمىلەر"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:585
-#: ../panels/keyboard/keyboard-shortcuts.c:593
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "قىسقا يول قوش"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "ئىختىيارى تېزلەتمە"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:804
-msgid "<Unknown Action>"
-msgstr "<نامەلۇم مەشغۇلات>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1301
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr "تېزلەتمە «%s» ئىشلەتكىلى بولمايدۇ، چۈنكى ئۇنى ئىشلەتكەندە كىرگۈزگىلى بولمايدۇ، بىرلا ۋاقىتتا Control ، Alt ياكى Shift نى ئىشلىتىشنى سىناڭ."
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1333
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr "«%s» تېزلەتمە «%s» غا ئىشلىتىلگەن"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1338
-#, c-format
-msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "ئەگەر تېزلەتمىنى «%s»غا بەلگىلىسىڭىز،  «%s» نىڭ تېزلەتمە چەكلىنىدۇ."
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1344
-msgid "_Reassign"
-msgstr "قايتا تەيىنلە(_R)"
-
-#: ../panels/mouse/cc-mouse-panel.c:123
-msgid "Test Your _Settings"
-msgstr "تەڭشىكىمنى سىناپ كۆرەي(_S)"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
-msgid "Mouse & Touchpad"
-msgstr "چاشقىنەك ۋە سەزگۈر تاختا"
-
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
-msgid "Set your mouse and touchpad preferences"
-msgstr "چاشقىنەك ۋە سېزىمچان تاختا مايىللىقىنى تەڭشەيدۇ"
-
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
-msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
-msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;سەزگۈر تاختا;ئىسترېلكا;چەك;نوقۇ;قوش;توپچا;ئىزلاش شارچىسى;"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "Mouse Preferences"
-msgstr "چاشقىنەك مايىللىقى"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgid "General"
-msgstr "ئادەتتىكى"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgctxt "mouse, speed"
-msgid "Slow"
-msgstr "ئاستا"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgid "Double-click timeout"
-msgstr "قوش چېكىش مۆھلىتى"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgctxt "mouse, speed"
-msgid "Fast"
-msgstr "تېز"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "_Double-click"
-msgstr "قوش چېكىش(_D)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgid "Primary _button"
-msgstr "ئاساسىي توپچا(_B)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "سول(_L)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "ئوڭ(_R)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "Mouse"
-msgstr "چاشقىنەك"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgid "_Pointer speed"
-msgstr "كۆرسەتكۈچنىڭ تېزلىكى(_P)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgid "Touchpad"
-msgstr "سېزىمچان تاختا"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Disable while _typing"
-msgstr "كىرگۈزۈۋاتقاندا ئىناۋەتسىز بولسۇن(_T)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgid "Tap to _click"
-msgstr "بېسىلسا چېكىلسۇن(_C)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgid "Two _finger scroll"
-msgstr "ئىككى بارماقتا سىيرىسۇن(_F)"
-
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "C_ontent sticks to fingers"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:134
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "چېكىش، قوش چېكىش، سىيرىشنى سىناپ كۆرۈڭ"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "قىسقا يول قوش"
 
-#: ../panels/mouse/gnome-mouse-test.c:139
-msgid "Five clicks, GEGL time!"
-msgstr "بەش قېتىم چېكىلدى، GEGL ۋاقتى"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:144
-msgid "Double click, primary button"
-msgstr "قوش چېكىش، ئاساسىي توپچا"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "چىقىرىۋەت(_R)"
 
-#: ../panels/mouse/gnome-mouse-test.c:144
-msgid "Single click, primary button"
-msgstr "يەككە چېكىش، ئاساسىي توپچا"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "ئالماشتۇر(_R)"
 
-#: ../panels/mouse/gnome-mouse-test.c:147
-msgid "Double click, middle button"
-msgstr "قوش چېكىش، ئوتتۇرا توپچا"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:147
-msgid "Single click, middle button"
-msgstr "يەككە چېكىش، ئوتتۇرا توپچا"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:150
-msgid "Double click, secondary button"
-msgstr "قوش چېكىش، ئىككىنچى توپچا"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "ئاتى"
 
-#: ../panels/mouse/gnome-mouse-test.c:150
-msgid "Single click, secondary button"
-msgstr "يەككە چېكىش، ئىككىنچى توپچا"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "بۇيرۇق(_O):"
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:341
-msgid "Air_plane Mode"
-msgstr "ئايروپىلان ھالىتى(_P)"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+#, fuzzy
+msgid "Shortcut"
+msgstr "تېزلەتمىلەر"
 
-#: ../panels/network/cc-network-panel.c:904
-msgid "Network proxy"
-msgstr "تور ۋاكالەتچىسى"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "ئىختىيارى تېزلەتمە"
 
-#: ../panels/network/cc-network-panel.c:1083 ../panels/network/net-vpn.c:280
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
-
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1217
-msgid "The system network services are not compatible with this version."
-msgstr "سىستېمىنىڭ تور مۇلازىمىتى بۇ نەشرىدىكى تور باشقۇرغۇچ بىلەن ماسلاشمايدۇ."
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
-msgid "802.1x _Security"
-msgstr "802.1x بىخەتەرلىكى(_S)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "ئاتسىز كىملىك(_M)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "ئىچكى ئىسپات"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:4
-msgid "Security"
-msgstr "بىخەتەرلىك"
-
-#: ../panels/network/connection-editor/ce-page.c:502
-msgid "automatic"
-msgstr "ئاپتوماتىك"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:224
-#: ../panels/network/net-device-wifi.c:385
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:228
-#: ../panels/network/net-device-wifi.c:390
-#: ../panels/network/network-wifi.ui.h:17
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:232
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:237
-msgid "Enterprise"
-msgstr "كارخانا"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:242
-#: ../panels/network/net-device-wifi.c:375
-msgctxt "Wifi security"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "يوق"
 
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "ھەرگىز"
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
 
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:770
-msgid "Today"
-msgstr "بۈگۈن"
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "كۆڭۈلدىكىگە قايتۇر(_F)"
 
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:773
-msgid "Yesterday"
-msgstr "تۈنۈگۈن"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "ھەرپتاختا"
 
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:479
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "نۆۋەتتە ئاۋاز قويىدىغان ياكى خاتىرىلەيدىغان پروگرامما يوق."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "مىكروفون ئاۋاز مىقدارى"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "پروگرامما تېپىلمىدى"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "تەڭشىكىمنى سىناپ كۆرەي(_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "ئادەتتىكى"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "ئاساسىي توپچا(_B)"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "سول"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "ئوڭ"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "ئورۇنلارنى ئىزدەش"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "چاشقىنەك"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "چاشقىنەك كۇنۇپكىلىرى"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "ئاستىغا سىيرىش"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "چوڭايتقۇچ نۇربەلگىسى مەزمۇنغا ئەگىشىپ يۆتكىلىدۇ"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "تېزلىتىش(_C):"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "سېزىمچان تاختا"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "سېزىمچان تاختا"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "ئۇسۇل(_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "بېسىلسا چېكىلسۇن(_C)"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "بېسىلسا چېكىلسۇن(_C)"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "كىرگۈزۈۋاتقاندا ئىناۋەتسىز بولسۇن(_T)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "سېزىمچان تاختا (نىسپىي)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr "دومىلات"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "سولغا سۈر"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "قوش يۈزلۈك"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "چېكىش، قوش چېكىش، سىيرىشنى سىناپ كۆرۈڭ"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "چاشقىنەك ۋە سەزگۈر تاختا"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+#, fuzzy
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;سەزگۈر تاختا;ئىسترېلكا;"
+"چەك;نوقۇ;قوش;توپچا;ئىزلاش شارچىسى;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "رەڭ بوشلۇق: "
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "ئەخلەتخانىنى ئاپتوماتىك تازىلا(_T)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "ئېكران"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "ئاساسىي كۆزەتكۈچ سۆرەپ تەڭشىلىدۇ."
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "پروگراممىلار"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "ئۈسكۈنىلەر"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "يېڭى باغلىنىش قوشۇش"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "باغلاندى"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "تاللانمىلار…"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi قىزىق نۇقتىسى"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "تور ئاتى"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "ئىم"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "ئىم ھاسىللاش"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "ئىم ھاسىللاش"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "ئاچ(_T)"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "ئايروپىلان ھالىتى(_P)"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "كۆكچىش ماسلاشتۇرغۇچىسى تېپىلمىدى"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "ئايروپىلان ھالىتى(_P)"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi قىزىق نۇقتىسى"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "قىزىق نۇقتا سۈپىتىدە ئىشلەت(_U)…"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "تور"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x بىخەتەرلىكى(_S)"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i  كۈن ئىلگىرى"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:537
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d مېگابايت/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "None"
-msgstr "يوق"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:568
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "ئاجىز"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:570
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "تامام"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:572
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "ياخشى"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:574
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "ناھايىتى ياخشى"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:200
-#: ../panels/network/connection-editor/ce-page-vpn.c:172
-#: ../panels/network/connection-editor/ce-page-wifi.c:243
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Identity"
-msgstr "سالاھىيەت"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:202
-#: ../panels/network/connection-editor/ce-page-ip4.c:454
-msgid "Netmask"
-msgstr "تور ماسكىسى"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:216
-#: ../panels/network/connection-editor/ce-page-ip4.c:467
-#: ../panels/network/connection-editor/ce-page-ip6.c:217
-#: ../panels/network/connection-editor/ce-page-ip6.c:475
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "تور ئۆتكىلى"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:233
-#: ../panels/network/connection-editor/ce-page-ip6.c:234
-#| msgid "_Cloned Address"
-msgid "Delete Address"
-msgstr "ئادرېسلارنى ئۆچۈرۈش"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:285
-#: ../panels/network/connection-editor/ce-page-ip6.c:286
-#| msgid "_Add"
-msgid "Add"
-msgstr "قوش"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:350
-#: ../panels/network/connection-editor/ce-page-ip6.c:354
-msgid "Server"
-msgstr "مۇلازىمېتىر"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:367
-#: ../panels/network/connection-editor/ce-page-ip6.c:371
-#| msgid "Delete device"
-msgid "Delete DNS Server"
-msgstr "DNS مۇلازىمېتىرنى ئۆچۈرۈش"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:481
-#: ../panels/network/connection-editor/ce-page-ip6.c:489
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "مېترىك"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:502
-#: ../panels/network/connection-editor/ce-page-ip6.c:510
-#| msgid "Default Route"
-msgid "Delete Route"
-msgstr "يولنى(Route) ئۆچۈرۈش"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:616
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Automatic (DHCP)"
-msgstr "ئاپتوماتىك(DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:620
-#: ../panels/network/connection-editor/ce-page-ip6.c:622
-#: ../panels/network/network-wifi.ui.h:25
-msgid "Manual"
-msgstr "قولدا"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:624
-#: ../panels/network/connection-editor/ce-page-ip6.c:626
-msgid "Link-Local Only"
-msgstr "پەقەت Link-Local"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:925
-#: ../panels/network/network-wifi.ui.h:60
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:204
-#: ../panels/network/connection-editor/ce-page-ip6.c:458
-msgid "Prefix"
-msgstr "ئالدى قوشۇلغۇچى"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:614
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "ئاپتوماتىك"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:618
-msgid "Automatic, DHCP only"
-msgstr "ئاپتوماتىك، پەقەت DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:886
-#: ../panels/network/network-wifi.ui.h:61
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:63
-msgid "Reset"
-msgstr "ئەسلىگە قايتۇرۇش"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "يوق"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128 بىتلىق ئاچقۇچ(16لىك ياكى ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128 بىتلىق شىفىر"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "دىنامىكىلىق WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA ۋە WPA2 كىشىلىك نۇسخىسى"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA ۋە WPA2 كارخانا نۇسخىسى"
-
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-msgid "_Apply"
-msgstr "قوللان(_A)"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:2
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "سىگنال كۈچلۈكلۈكى"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:3
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "ئۇلىنىش تېزلىكى"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "بىخەتەرلىك"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "‍‍IPv4 ئادرېس"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "‍IPv6 ئادرېس"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:1
-#: ../panels/network/network-wifi.ui.h:7
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "قاتتىق دېتال ئادرېسى"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:8
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "قوللايدىغان ICC سەپلىمە ھۆججەتلەر"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "كۆڭۈلدىكى يېتەكلىگۈ"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "ئاخىرقى قېتىم ئىشلەتكەن"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "قوش پىلاستىك لىنىيە (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "قوشۇلما بۆلۈم ئارايۈزى(AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "ۋاسىتە مۇستەقىل ئارايۈزى(MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 مېگابايت/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 مېگابايت/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 گىگابايت/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 گىگابايت/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "ئاتى(_N)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:49
-msgid "_MAC Address"
-msgstr "MAC ئادرېس(_M)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "M_TU"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "كۇلونلانغان ئادرېس(_C):"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "ئاپتوماتىك باغلان(_A)"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-msgid "Make available to other _users"
-msgstr "باشقا ئىشلەتكۈچىلەرمۇ ئىشلىتەلەيدىغان بولسۇن(_U)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-msgid "bytes"
-msgstr "بايت"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:23
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:24
-msgid "_Addresses"
-msgstr "ئادرېسلار(_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-#| msgid "Automatic"
-msgid "Automatic DNS"
-msgstr "ئاپتوماتىك DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:39
-msgid "Routes"
-msgstr "يوللار"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-#| msgid "Automatic Suspend"
-msgid "Automatic Routes"
-msgstr "ئاپتوماتىك يوللار(Routes)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:45
-msgid "Use this connection _only for resources on its network"
-msgstr ""
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:47
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:267
-msgid "Unable to open connection editor"
-msgstr "باغلىنىش تەھرىرلىگۈچىنى ئاچقىلى بولمىدى"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:282
-msgid "New Profile"
-msgstr "يېڭى سەپلىمە ھۆججەت"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:504
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1068
-msgid "_Add"
-msgstr "قوش(_A)"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:586
-#: ../panels/network/network.ui.h:4 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:587
-msgid "Bond"
-msgstr ""
-
-#: ../panels/network/connection-editor/net-connection-editor.c:588
-msgid "Bridge"
-msgstr "كۆۋرۈك"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:589
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:739
-msgid "Could not load VPN plugins"
-msgstr "ۋ پ ن(VPN) قىستۇرمىلىرىنى ئوقۇغىلى بولمىدى"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "ھۆججەتتىن ئەكىر…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:870
-msgid "Add Network Connection"
-msgstr "تور باغلىنىشى قوشۇش"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:53
-msgid "_Reset"
-msgstr "ئەسلىگە قايتۇر(_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1411
-#: ../panels/network/network-wifi.ui.h:54
-msgid "_Forget"
-msgstr "ئۇنتۇپ كەت(_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr "مەزكۇر تورنىڭ تەڭشەكلىرىنى ئەسلىگە قايتۇرىدۇ، بىراق ئۇنى ئالدى بىلەن ئۇلىنىدىغان تور قىلىپ ئەستە تۇتىدۇ"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr "مەزكۇر تورغا مۇناسىۋەتلىك بولغان بارلىق تەپسىلاتلارنى ئۆچۈرىدۇ ۋە ئۇنىڭغا  ئاپتوماتىك ئۇلانمايدىغان بولىدۇ"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "S_ecurity"
-msgstr "بىخەتەرلىك(_E)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "VPN باغلىنىشىنى ئىمپورت قىلالمىدى"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr "‹%s› ھۆججىتىنى ئوقۇيالمىدى ياكى تونۇلغان VPN باغلىنىش ئۇچۇرىنى ئۆز ئىچىگە ئالمىغان\n"
-"\n"
-"خاتالىق: %s."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "ئىمپورت قىلىدىغان ھۆججەتنى تاللا"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "«%s» ئاتلىق بىر ھۆججەت ئەزەلدىن مەۋجۇت."
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "ئالماشتۇر(_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "سىز ساقلىغان %s نى VPN باغلىنىشىغا ئالماشتۇرامسىز؟"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "ۋ پ ن (VPN)  باغلىنىشىنى ئېكسپورت قىلغىلى بولمىدى"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr "ۋ پ ن(VPN) باغلىنىشى ‹%s› نى %s گە ئېكسپورت قىلغىلى بولمىدى.\n"
-"\n"
-"خاتالىق: %s"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-msgid "Export VPN connection..."
-msgstr "ۋ پ ن (VPN)  باغلىنىشىنى ئېكسپورت قىل..."
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(خاتالىق: ۋ پ ن (VPN) باغلىنىش تەھرىرلىگۈچىنى ئوقۇغىلى بولمىدى)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:12
-msgid "_SSID"
-msgstr "SSID (_S):"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:13
-msgid "_BSSID"
-msgstr "BSSID (_B):"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:16
-msgid "My Home Network"
-msgstr "ئۆيۈمدىكى تور"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "باشقا ئىشلەتكۈچىلەرمۇ ئىشلىتەلەيدىغان بولسۇن(_O)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "تور"
-
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Network settings"
-msgstr "تور تەڭشەك"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
-msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
-msgstr "تور;سىمسىز تور;Wi-Fi;Wifi;IP;LAN;ۋاكالەتچى;WAN;يۆتكەلمە خەۋەرلىشىش;مودېم;كۆكچىش;"
-
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:465
-msgid "never"
-msgstr "ھەرگىز"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "ئاتى(_N)"
 
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:475
-msgid "today"
-msgstr "بۈگۈن"
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC ئادرېس(_M)"
 
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:477
-msgid "yesterday"
-msgstr "تۈنۈگۈن"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
 
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "‍IP ئادرېس:"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "كۇلونلانغان ئادرېس(_C):"
 
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:10
-msgid "Last used"
-msgstr "ئەڭ ئاخىرقى قېتىم ئىشلەتكىنى"
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "بايت"
 
-#: ../panels/network/net-device-ethernet.c:337
-#: ../panels/network/net-device-wifi.c:1549
-#: ../panels/network/network-ethernet.ui.h:2
-#: ../panels/network/network-vpn.ui.h:8 ../panels/universal-access/uap.ui.h:23
-msgid "Options…"
-msgstr "تاللانمىلار…"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "ئۇسۇل(_M)"
 
-#: ../panels/network/net-device-ethernet.c:472
-#, c-format
-msgid "Profile %d"
-msgstr ""
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "ئاپتوماتىك(DHCP)"
 
-#: ../panels/network/net-device-mobile.c:239
-msgid "Add new connection"
-msgstr "يېڭى باغلىنىش قوشۇش"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "پەقەت Link-Local"
 
-#: ../panels/network/net-device-wifi.c:1120
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr "ئەگەر سىزنىڭ سىمسىز توردىن باشقا ئىنتېرنېت باغلىنىشىڭىز بار بولسا، سىمسىز قىزىق نۇقتا قۇرۇپ، باغلىنىشىڭىزنى باشقىلار بىلەن ھەمبەھىر قىلالايسىز."
-
-#: ../panels/network/net-device-wifi.c:1124
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "سىمسىز قىزىق نۇقتىغا ئالماشسىڭىز <b>%s</b> بىلەن بولغان باغلىنىش ئۈزۈلىدۇ."
-
-#: ../panels/network/net-device-wifi.c:1128
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr "سىمسىز قىزىق نۇقتا ئاكتىپ ھالەتتە تۇرۇۋاتقاندا، سىمسىز تورىڭىز ئارقىلىق ئىنتېرنېتنى زىيارەت قىلالمايسىز."
-
-#: ../panels/network/net-device-wifi.c:1202
-msgid "Stop hotspot and disconnect any users?"
-msgstr "قىزىق نۇقتىنى توختىتىپ، ھەر قانداق ئىشلەتكۈچىنى ئۈزەمدۇ؟"
-
-#: ../panels/network/net-device-wifi.c:1205
-msgid "_Stop Hotspot"
-msgstr "قىزىق نۇقتىنى توختات(_S)"
-
-#: ../panels/network/net-device-wifi.c:1277
-msgid "System policy prohibits use as a Hotspot"
-msgstr "سىستېما سىياسىتى بويىچە Hotspot قىلىپ ئىشلىتىش چەكلەنگەن"
-
-#: ../panels/network/net-device-wifi.c:1280
-#| msgid "InfiniBand device does not support connected mode"
-msgid "Wireless device does not support Hotspot mode"
-msgstr "سىمسىز ئۈسكۈنە Hotspot ھالىتىنى قوللىمايدىكەن"
-
-#: ../panels/network/net-device-wifi.c:1407
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr "تاللانغان تورنىڭ تەپسىلاتلىرى يەنى ئىم ۋە باشقا ئىختىيارىي سەپلىمە قاتارلار يوقىلىدۇ."
-
-#: ../panels/network/net-device-wifi.c:1714
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:14
-msgid "History"
-msgstr "ئىز"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1726
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "ئۇنتۇپ كەت(_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "سەپلەنگەن URL تەمىنلەنمىگەن بولسا تور ۋاكالەتچىسىنى ئۆزلۈكىدىن بايقاپ ئىشلىتىدۇ."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "ئىشەنچسىز ئاممىۋى تورغا نىسبەتەن بۇنداق قىلىش تەۋسىيە قىلىنمايدۇ."
-
-#: ../panels/network/net-proxy.c:408
-msgid "Proxy"
-msgstr "ۋاكالەتچى"
-
-#: ../panels/network/network-ethernet.ui.h:1
-msgid "_Add Profile…"
-msgstr "سەپلىمە ھۆججەت قوش(_A)…"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "تەمىنلىگۈچى"
-
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:7
-msgid "_Options…"
-msgstr "تاللانمىلار(_O)…"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:5
-msgctxt "proxy method"
-msgid "None"
-msgstr "يوق"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:6
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "قولدا"
 
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:7
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "ئىناۋەتسىز قىلىنغان"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "باشقا كومپيۇتېرلار بىلەن ھەمبەھىرلەنگەن"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "ئادرېسلار(_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "ئادرېس"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "تور ماسكىسى"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "تور ئۆتكىلى"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "ئاپتوماتىك"
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "ئاپتوماتىك DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "يوللار"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "ئاپتوماتىك يوللار(Routes)"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "مېترىك"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
 msgstr "ئۇسۇل(_M)"
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "سەپلىمە URL (_C)"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "ئاپتوماتىك، پەقەت DHCP"
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "_HTTP ۋاكالەتچى"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "ئالدى قوشۇلغۇچى"
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "H_TTPS ۋاكالەتچى"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "بىخەتەرلىك(_E)"
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "_FTP ۋاكالەتچى"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(خاتالىق: ۋ پ ن (VPN) باغلىنىش تەھرىرلىگۈچىنى ئوقۇغىلى بولمىدى)"
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "SOCKS مۇلازىمېتىر"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "SSID (_S):"
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "كومپيۇتېرلارغا پەرۋا قىلما(_I) "
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "BSSID (_B):"
 
-#: ../panels/network/network-proxy.ui.h:11
-#| msgid "_HTTP Proxy"
-msgid "HTTP proxy port"
-msgstr "HTTP ۋاكالەتچىنىڭ ئېغىزى"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "تور"
 
-#: ../panels/network/network-proxy.ui.h:12
-#| msgid "H_TTPS Proxy"
-msgid "HTTPS proxy port"
-msgstr "HTTPS ۋاكالەتچى ئېغىزى"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to the Internet"
+msgstr "ئىنتېرنېتقا باغلانمىغان."
 
-#: ../panels/network/network-proxy.ui.h:13
-#| msgid "_FTP Proxy"
-msgid "FTP proxy port"
-msgstr "FTP ۋاكالەتچى ئېغىزى"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"تور;سىمسىز تور;Wi-Fi;Wifi;IP;LAN;ۋاكالەتچى;WAN;يۆتكەلمە خەۋەرلىشىش;مودېم;"
+"كۆكچىش;"
 
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "Socks ۋاكالەتچى ئېغىزى"
-
-#: ../panels/network/network-simple.ui.h:6
-#| msgid "Turn on or off:"
-msgid "Turn device off"
-msgstr "ئۈسكۈنىنى ئەت"
-
-#: ../panels/network/network.ui.h:1
-msgid "Select the interface to use for the new service"
-msgstr "يېڭى مۇلازىمەتكە ئىشلىتىدىغان ئېغىزنى تاللاڭ"
-
-#: ../panels/network/network.ui.h:2
-msgid "C_reate…"
-msgstr "قۇر(_R)…"
-
-#: ../panels/network/network.ui.h:3
-msgid "_Interface"
-msgstr "ئارايۈز(_I)"
-
-#: ../panels/network/network.ui.h:8
-msgid "Add Device"
-msgstr "ئۈسكۈنە قوش"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN تىپى"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "گۇرۇپپا ئاتى"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "گۇرۇپپا ئىم"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "ئىشلەتكۈچى ئاتى"
-
-#: ../panels/network/network-vpn.ui.h:7
-#| msgid "Export VPN connection..."
-msgid "Turn VPN connection off"
-msgstr "ۋ پ ن(VPN) باغلىنىشىنى ئەت"
-
-#: ../panels/network/network-wifi.ui.h:1
-msgid "Automatic _Connect"
-msgstr "ئاپتوماتىك باغلانسۇن(_C)"
-
-#: ../panels/network/network-wifi.ui.h:11
-msgid "details"
-msgstr "تەپسىلاتلار"
-
-#: ../panels/network/network-wifi.ui.h:15
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "_Password"
-msgstr "ئىم(_P)"
-
-#: ../panels/network/network-wifi.ui.h:18
-#: ../panels/universal-access/uap.ui.h:8
-msgid "None"
-msgstr "يوق"
-
-#: ../panels/network/network-wifi.ui.h:19
-msgid "blablabla"
-msgstr "blablabla"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "Show P_assword"
-msgstr "ئىم كۆرسەت(_A)"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "Make available to other users"
-msgstr "باشقا ئىشلەتكۈچىلەرمۇ ئىشلىتەلەيدىغان بولسۇن"
-
-#: ../panels/network/network-wifi.ui.h:22
-msgid "identity"
-msgstr "سالاھىيەت، كىملىك"
-
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Automatic (DHCP) addresses only"
-msgstr "پەقەت ئاپتوماتىك(DHCP) ئادرېسلار"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Link-local only"
-msgstr "پەقەت Link-Local"
-
-#: ../panels/network/network-wifi.ui.h:29
-msgid "Shared with other computers"
-msgstr "باشقا كومپيۇتېرلار بىلەن ھەمبەھىرلەنگەن"
-
-#: ../panels/network/network-wifi.ui.h:31
-msgid ""
-"Address\n"
-"section\n"
-"goes\n"
-"here"
-msgstr "ئادرېس\n"
-"بۆلىكىنى\n"
-"بۇ يەرگە\n"
-"يېزىڭ"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid ""
-"DNS\n"
-"section\n"
-"goes\n"
-"here"
-msgstr "DNS\n"
-"بۆلىكىنى\n"
-"بۇ يەرگە\n"
-"يېزىڭ"
-
-#: ../panels/network/network-wifi.ui.h:40
-msgid ""
-"Routes\n"
-"section\n"
-"goes\n"
-"here"
-msgstr "يېتەكچىلەر\n"
-"بۆلىكىنى\n"
-"بۇ يەرگە\n"
-"يېزىڭ"
-
-#: ../panels/network/network-wifi.ui.h:44
-msgid "_Ignore automatically obtained routes"
-msgstr "ئاپتوماتىك ئېرىشكەن route لارنى نەزەرگە ئالمىسۇن(_I)"
-
-#: ../panels/network/network-wifi.ui.h:46
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:48
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "_Cloned MAC Address"
-msgstr "كۇلونلانغان MAC ئادرېسلار(_C)"
-
-#: ../panels/network/network-wifi.ui.h:51
-msgid "00:24:16:31:8G:7A"
-msgstr "00:24:16:31:8G:7A"
-
-#: ../panels/network/network-wifi.ui.h:52
-msgid "hardware"
-msgstr "قاتتىق دېتال"
-
-#: ../panels/network/network-wifi.ui.h:55
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr "مەزكۇر تورنىڭ تەڭشەكلىرىنى كۆڭۈلدىكى قىممەتلەرگە قايتۇرىدۇ، بىراق ئۇنى ئالدى بىلەن ئۇلىنىدىغان تور قىلىپ ئەستە تۇتىدۇ"
-
-#: ../panels/network/network-wifi.ui.h:56
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr "مەزكۇر تورغا مۇناسىۋەتلىك بولغان بارلىق تەپسىلاتلارنى ئۆچۈرىدۇ ۋە ئۇنىڭغا  ئاپتوماتىك ئۇلانمايدىغان بولىدۇ."
-
-#: ../panels/network/network-wifi.ui.h:57
-msgid "reset"
-msgstr "ئەسلىگە قايتۇر"
-
-#: ../panels/network/network-wifi.ui.h:62
-msgid "Hardware"
-msgstr "قاتتىق دېتال"
-
-#: ../panels/network/network-wifi.ui.h:64
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi قىزىق نۇقتىسى"
-
-#: ../panels/network/network-wifi.ui.h:65
-msgid "_Turn On"
-msgstr "ئاچ(_T)"
-
-#: ../panels/network/network-wifi.ui.h:66
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:67
-#| msgid "Turn on or off:"
-msgid "Turn Wi-Fi off"
-msgstr "Wi-Fi نى ئەت"
-
-#: ../panels/network/network-wifi.ui.h:68
-msgid "_Use as Hotspot…"
-msgstr "قىزىق نۇقتا سۈپىتىدە ئىشلەت(_U)…"
-
-#: ../panels/network/network-wifi.ui.h:69
-msgid "_Connect to Hidden Network…"
-msgstr "يوشۇرۇن تورغا باغلا(_C)…"
-
-#: ../panels/network/network-wifi.ui.h:70
-msgid "_History"
-msgstr "ئىز(_H)"
-
-#: ../panels/network/network-wifi.ui.h:71
-msgid "Switch off to connect to a Wi-Fi network"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
 msgstr "Wi-Fi تورىغا باغلىنىشنى يېپىش"
 
-#: ../panels/network/network-wifi.ui.h:72
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"تور;سىمسىز تور;Wi-Fi;Wifi;IP;LAN;ۋاكالەتچى;WAN;يۆتكەلمە خەۋەرلىشىش;مودېم;"
+"كۆكچىش;"
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "سىملىق"
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "ئۈسكۈنىنى ئەت"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "ئاكتىپ خىزمەتلەر"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "تەمىنلىگۈچى"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "‍IP ئادرېس:"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "تور ۋاكالەتچىسى"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP ۋاكالەتچى"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS ۋاكالەتچى"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP ۋاكالەتچى"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "SOCKS مۇلازىمېتىر"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "كومپيۇتېرلارغا پەرۋا قىلما(_I) "
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP ۋاكالەتچىنىڭ ئېغىزى"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS ۋاكالەتچى ئېغىزى"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP ۋاكالەتچى ئېغىزى"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks ۋاكالەتچى ئېغىزى"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "سەپلىمە URL (_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "ۋ پ ن(VPN) باغلىنىشىنى ئەت"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "تور ئاتى"
 
-#: ../panels/network/network-wifi.ui.h:73
-msgid "Connected Devices"
-msgstr "باغلانغان ئۈسكۈنىلەر"
-
-#: ../panels/network/network-wifi.ui.h:74
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "بىخەتەرلىك تىپى"
 
-#: ../panels/network/network-wifi.ui.h:75
-msgid "Security key"
-msgstr "بىخەتەرلىك ئاچقۇچى"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "ئىم"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi نى ئەت"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "قۇرۇلما"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "تاللانمىلارنى ئوقۇۋاتىدۇ…"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "ھالىتى نامەلۇم"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "يوشۇرۇن تورغا باغلا(_C)…"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "باشقۇرۇلمىغان"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi قىزىق نۇقتىسى"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "ئىشلەتكىلى بولمايدۇ"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "باغلىنىۋاتىدۇ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "سالاھىيەت دەلىللەش زۆرۈر"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "باغلاندى"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "ئۈزۈۋاتىدۇ"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "باغلىنىش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "ھالىتى نامەلۇم (يوقالدى)"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "باغلانمىغان"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "سەپلەش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "IP سەپلەش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "IP سەپلەشنىڭ قەرەلى توشتى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "بىخەتەرلىك ئۇچۇرلىرى كېرەك ئىدى، بىراق تەمىنلەنمەپتۇ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x supplicant ئۈزۈلدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x supplicant نى سەپلەش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1x supplicant مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "كىملىك دەلىللەشتە 802.1x supplicant جىق ۋاقىت ئالدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "PPP مۇلازىمىتىنى باشلاش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "PPP مۇلازىمىتى ئۈزۈلدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "DHCP خېرىدارىنى باشلاش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP خېرىدارىدا خاتالىق كۆرۈلدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP خېرىدارى مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "ھەمبەھىر باغلىنىش مۇلازىمىتىنى باشلاش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "ھەمبەھىر باغلىنىش مۇلازىمىتى مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "AutoIP مۇلازىمىتىنى باشلاش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "AutoIP مۇلازىمىتىدە خاتالىق كۆرۈلدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "AutoIP مۇلازىمىتى مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "ئالاقە يولى ئالدىراش"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "نومۇر باسقاندىكى ئاۋاز يوق"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "توشۇغۇچىنى قۇرغىلى بولمىدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "نومۇر بېسىشنىڭ قەرەلى توشتى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "نومۇر بېسىش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "مودېمنى دەسلەپلەشتۈرۈش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "كۆرسىتىلگەن APN نى تاللاش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "تورنى ئىزدىمىدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "تورغا خەتلىتىش رەت قىلىندى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "تورغا خەتلىتىشنىڭ قەرەلى توشتى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "تەلەپ قىلىنغان تورغا خەتلىتىش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "PIN تەكشۈرۈش مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "مەزكۇر ئۈسكۈنىنىڭ مۇقىم دېتالى يوقتەك قىلىدۇ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "باغلىنىش غايىب بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "مەۋجۇت باغلىنىش دەپ قارايدۇ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "مودېم تېپىلمىدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "كۆكچىش باغلىنىشى مەغلۇپ بولدى"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "SIM كارتىسى سېلىنمىغان"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "SIM نىڭ Pin نومۇرى زۆرۈر"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "SIM نىڭ Puk ئى زۆرۈر"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "SIM خاتا"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "InfiniBand ئۈسكۈنىسى باغلىنىش ھالىتىنى قوللىمايدۇ"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "باغلىنىشقا كېرەكلىك ئۈسكۈنە تەييار بولمىدى"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "مۇقىم دېتال كەم"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "كابېل چېتىلمىغان"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "گۇۋاھنامە تارقاتقان ئورگان گۇۋاھنامىسىنى تاللىمىدى"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
-msgstr "تەكشۈرۈش مەركىزى(CA)نىڭ گۇۋاھنامىسىنى ئىشلەتمەسلىك بىخەتەر بولمىغان، مۈجمەل سىمسىز تورغا(Wi-Fi) باغلاپ قويۇشى مۇمكىن. تەكشۈرۈش مەركىزىنىڭ گۇۋاھنامىسىنى تاللاشنى ئىستەمسىز؟"
-
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "پەرۋا قىلما"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "CA گۇۋاھنامىسى تاللا"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER، PEM ياكى PKCS#12 شەخسىي ئاچقۇچلار(*.der، *.pem،*.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER ياكى PEM گۇۋاھنامىسى(der.*، pem.*، crt.*، cer.*)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:261
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:277
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:399
-msgid "Choose a PAC file..."
-msgstr "PAC ھۆججىتىنى تاللاڭ…"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:406
-msgid "PAC files (*.pac)"
-msgstr "PAC ھۆججەتلىرى(*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC ھۆججىتى(_F)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "ئىچكى ئىسپات(_I)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr ""
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "ئاتسىز"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "سالاھىيىتى دەلىللەنگەن"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "ئىككىلىسى"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "ئاتسىز كىملىك(_M)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC ھۆججىتى(_F)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+#, fuzzy
+msgid "Choose a PAC file"
+msgstr "PAC ھۆججىتىنى تاللاڭ…"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "ئىچكى ئىسپات(_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "ئىشلەتكۈچى ئاتى(_U)"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "ئىم(_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "ئىمنى كۆرسەت(_W)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:434
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate..."
-msgstr "بىر گۇۋاھنامە تەكشۈرۈش گۇۋاھنامىسى تاللا..."
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "نەشرى 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "نەشرى 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "C_A گۇۋاھنامىسى"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+#, fuzzy
+msgid "Choose a Certificate Authority certificate"
+msgstr "بىر گۇۋاھنامە تەكشۈرۈش گۇۋاھنامىسى تاللا..."
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "سالاھىيەت دەلىللەش زۆرۈر"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP نەشرى(_V)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "بۇ ئىمنى ھەر ۋاقىت سورىسۇن(_K)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:260
-msgid "Unencrypted private keys are insecure"
-msgstr "شىفىرلانمىغان شەخسىي ئاچقۇچلار بىخەتەر ئەمەس"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:263
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr "تاللىغان شەخسىي ئاچقۇچ بىر ئىم تەرىپىدىن قوغدالمىغاندەك قىلىدۇ. بۇ سىزنىڭ بىخەتەرلىك ئىسپاتنامىڭىزگە تەسىر قىلىدۇ. بىر ئىم تاللاپ شەخسىي ئاچقۇچىڭىزنى قوغداڭ.(شەخسىي ئاچقۇچىڭىزنى openssl ئارقىلىق ئىملىق قوغدىيالايسىز)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:428
-msgid "Choose your personal certificate..."
-msgstr "خۇسۇسىي گۇۋاھنامىڭىزنى تاللاڭ..."
-
-#: ../panels/network/wireless-security/eap-method-tls.c:440
-msgid "Choose your private key..."
-msgstr "شەخسىي ئاچقۇچىڭىزنى تاللاڭ:"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "كىملىك(_I)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "ئىشلەتكۈچى ئىسپاتنامىسى(_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "شەخسىي ئاچقۇچ(_K)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "شەخسىي ئاچقۇچ ئىمى(_P)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "مېنى يەنە ئاگاھلاندۇرما(_W)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "دائىرە(_D)"
 
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "تونىل TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "قوغدىلىدىغان EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "كىملىك دەلىللەش(_T)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (كۆڭۈلدىكى)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "ئوچۇق سىستېما"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "ھەمبەھىرلەنگەن ئاچقۇچ"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "ئاچقۇچ(_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "ئاچقۇچنى كۆرسەت(_W)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP ئىندېكسى(_X)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "تىپى(_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:39
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (كۆڭۈلدىكى)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "ئوچۇق سىستېما"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "ھەمبەھىرلەنگەن ئاچقۇچ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "ئاچقۇچ(_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "ئاچقۇچنى كۆرسەت(_W)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP ئىندېكسى(_X)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "ئۇقتۇرۇشلار"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:41
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "ئاۋازلىق ئۇقتۇرۇشلار"
 
-#: ../panels/notifications/cc-edit-dialog.c:42
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "سەكرىمە لەۋھەلەرنى كۆرسەت"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "لەۋھەلەردە تەپسىلاتلارنى كۆرسەت"
-
-#: ../panels/notifications/cc-edit-dialog.c:45
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "قۇلۇپ ئېكراندا كۆرۈش"
-
-#: ../panels/notifications/cc-edit-dialog.c:46
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "تەپسىلاتلارنى قۇلۇپ ئېكراندا كۆرسىتىش"
-
-#: ../panels/notifications/cc-notifications-panel.c:203
-#: ../panels/power/cc-power-panel.c:1637 ../panels/power/cc-power-panel.c:1644
-#: ../panels/privacy/cc-privacy-panel.c:78
-#: ../panels/privacy/cc-privacy-panel.c:145
-msgid "On"
-msgstr "ئوچۇق"
-
-#: ../panels/notifications/cc-notifications-panel.c:203
-#: ../panels/power/cc-power-panel.c:1631 ../panels/power/cc-power-panel.c:1642
-#: ../panels/privacy/cc-privacy-panel.c:78
-#: ../panels/privacy/cc-privacy-panel.c:145
-msgid "Off"
-msgstr "تاقا"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "ئۇقتۇرۇشلار"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
-msgid "Manage notifications"
-msgstr "ئۇقتۇرۇشلارنى باشقۇرۇش"
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "ئۇقتۇرۇشلار"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "تەپسىلاتلارنى قۇلۇپ ئېكراندا كۆرسىتىش"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "ئۇقتۇرۇشلار"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifications;Banner;Message;Tray;Popup;ئۇقتۇرۇش;ئۇچۇر;قونداق;سەكرىمە;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "سەكرەپ چىقىدىغان لەۋھەلەرنى كۆرسەت"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "قۇلۇپ ئېكراندا كۆرسىتىش"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "ئۇقتۇرۇشلارنى باشقۇرۇش"
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:190
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
-msgstr "ھېسابات قوشۇش"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:358
-msgid "Error logging into the account"
-msgstr "ھېساباتقا كىرىشتە خاتالىق كۆرۈلدى"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:412
-msgid "Expired credentials. Please log in again."
-msgstr "ئىسپاتنامىنىڭ ۋاقتى ئۆتكەن. قايتا كىرىڭ."
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
+msgstr "ھېسابات قوش"
 
-#: ../panels/online-accounts/cc-online-accounts-panel.c:415
-msgid "_Log In"
-msgstr "تىزىمغا كىر(_L)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:651
-msgid "Error creating account"
-msgstr "ھېسابات قۇرۇۋاتقاندا خاتالىق كۆرۈلدى"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:693
-msgid "Error removing account"
-msgstr "ھېساباتنى چىقىرىۋېتىشتە خاتالىق كۆرۈلدى"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:729
-msgid "Are you sure you want to remove the account?"
-msgstr "ھېساباتنى راستلا چىقىرىۋېتەمسىز؟"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:731
-msgid "This will not remove the account on the server."
-msgstr "بۇ مۇلازىمېتىردىكى ھېساباتنى چىقىرىۋەتمەيدۇ."
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:732
-msgid "_Remove"
-msgstr "چىقىرىۋەت(_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "توردىكى ھېساباتلار"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
-msgid "Manage online accounts"
-msgstr "توردىكى ھېساباتلارنى باشقۇرۇش"
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
 
-#. Translators: those are keywords for the online-accounts control-center panel
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
-msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
-msgstr "Google;Facebook;Twitter;Yahoo;Web;توردا;سۆزلىشىش;يىلنامە;خەت;ئالاقەداش;"
-
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "توردىكى ھېساباتلار سەپلەنمىگەن"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "ھېساباتنى چىقىرىۋېتىش"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "بىر تور ھېساباتى قوشۇش"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+#, fuzzy
 msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr "تور ھېساباتى قوشۇلسا، پروگرامما تور ھېساباتىنىڭ پۈتۈكلىرىنى، ئېلخەت، ئالاقەداش، يىلنامە، سۆھبەت ۋە باشقىلارنى زىيارەت قىلالايدۇ."
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;توردا;سۆزلىشىش;يىلنامە;خەت;ئالاقەداش;"
 
-#: ../panels/power/cc-power-panel.c:184
-msgid "Unknown time"
-msgstr "نامەلۇم"
-
-#: ../panels/power/cc-power-panel.c:190
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i مىنۇت"
 
-#: ../panels/power/cc-power-panel.c:202
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i سائەت"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:210
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "سائەت"
 
-#: ../panels/power/cc-power-panel.c:212
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "مىنۇت"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:231
-#, c-format
-msgid "%s until fully charged"
-msgstr "تولۇق توكلىنىشقا %s بار"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:238
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "دىققەت: قالغىنى %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:243
-#, c-format
-msgid "%s remaining"
-msgstr "قالغىنى %s"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:248 ../panels/power/cc-power-panel.c:276
-msgid "Fully charged"
-msgstr "تولۇق توكلاندى"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:252 ../panels/power/cc-power-panel.c:280
-msgid "Empty"
-msgstr "بوش"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:267
-msgid "Charging"
-msgstr "توكلاۋاتىدۇ"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:272
-msgid "Discharging"
-msgstr "توكسىزلاۋاتىدۇ"
-
-#: ../panels/power/cc-power-panel.c:324
-#, c-format
-msgid "Estimated battery capacity: %s"
-msgstr "توكداننىڭ تەخمىنىي سىغىمى: %s"
-
-#: ../panels/power/cc-power-panel.c:404
-msgctxt "Battery name"
-msgid "Main"
-msgstr "ئاساس"
-
-#: ../panels/power/cc-power-panel.c:406
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "قوشۇمچە"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:493
-msgid "Wireless mouse"
-msgstr "سىمسىز چاشقىنەك"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:497
-msgid "Wireless keyboard"
-msgstr "سىمسىز ھەرپتاختا"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:501
-msgid "Uninterruptible power supply"
-msgstr "ئۈزۈلمەس توك مەنبەسى"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:506
-msgid "Personal digital assistant"
-msgstr "شەخسىي رەقەملىك ياردەمچى"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:510
-msgid "Cellphone"
-msgstr "يانفون"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:514
-msgid "Media player"
-msgstr "ۋاسىتە قويغۇ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:518
-msgid "Tablet"
-msgstr "سەزگۈر تاختا"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:522
-msgid "Computer"
-msgstr "كومپيۇتېر"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:526 ../panels/power/cc-power-panel.c:734
-#: ../panels/power/cc-power-panel.c:1938
-msgid "Battery"
-msgstr "توكدان"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:535
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "توكلاۋاتىدۇ"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:542
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "دىققەت"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Low"
-msgstr "تۆۋەن"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Good"
-msgstr "ياخشى"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "تولۇق توكلاندى"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:561
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "بوش"
-
-#: ../panels/power/cc-power-panel.c:732
-msgid "Batteries"
-msgstr "توكدانلار"
-
-#: ../panels/power/cc-power-panel.c:1074
-msgid "When _idle"
-msgstr "بوش ۋاقىتتا(_I)"
-
-#: ../panels/power/cc-power-panel.c:1401
-msgid "Power Saving"
-msgstr "توك تېجەش"
-
-#: ../panels/power/cc-power-panel.c:1430
-msgid "_Screen Brightness"
-msgstr "ئېكران يورۇقلۇقى(_S)"
-
-#: ../panels/power/cc-power-panel.c:1458
-msgid "_Dim Screen when Inactive"
-msgstr "ئاكتىپ ئەمەس ۋاقتىدا ئېكراننى سۇس قىل(_D)"
-
-#: ../panels/power/cc-power-panel.c:1481
-#| msgid "Full Screen"
-msgid "_Blank Screen"
-msgstr "قۇرۇق ئەركان(_B)"
-
-#: ../panels/power/cc-power-panel.c:1516
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: ../panels/power/cc-power-panel.c:1544
-msgid "_Mobile Broadband"
-msgstr "كۆچمە كەڭ بەلۋاغ(_M)"
-
-#: ../panels/power/cc-power-panel.c:1582
-msgid "_Bluetooth"
-msgstr "كۆكچىش(_B)"
-
-#: ../panels/power/cc-power-panel.c:1633
-msgid "When on battery power"
-msgstr "توكداندا ئىشلەۋاتقاندا"
-
-#: ../panels/power/cc-power-panel.c:1635
-msgid "When plugged in"
-msgstr "توك مەنبەسى ئۇلانغاندا"
-
-#: ../panels/power/cc-power-panel.c:1762
-msgid "Suspend & Power Off"
-msgstr "توڭلات ۋە توكنى ئۈز"
-
-#: ../panels/power/cc-power-panel.c:1793
-msgid "_Automatic Suspend"
-msgstr "ئاپتوماتىك توڭلات(_A)"
-
-#: ../panels/power/cc-power-panel.c:1815
-msgid "When Battery Power is _Critical"
-msgstr "توكداننىڭ توكى تۆۋەنلەپ خەتەرلىك ھالەتكە كەلگەندە(_C)"
-
-#: ../panels/power/cc-power-panel.c:1848
-msgid "Power Off"
-msgstr "توكنى ئۈز"
-
-#: ../panels/power/cc-power-panel.c:1990
-msgid "Devices"
-msgstr "ئۈسكۈنىلەر"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "توك مەنبە"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "Power management settings"
-msgstr "توك مەنبە باشقۇرۇش تەڭشىكى"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
 #, fuzzy
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;توك مەنبە؛ئۇخلاش؛ئۈچەك؛توكدان؛يورۇقلۇق؛قۇرۇق؛ئېكران؛كۆزەتكۈچ؛"
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 مىنۇت"
 
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "ئۈچەك"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 مىنۇت"
 
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "توكنى ئۈز"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 مىنۇت"
 
-#: ../panels/power/power.ui.h:5
-#| msgid "5 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 مىنۇت"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 مىنۇت"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 سائەت"
 
-#: ../panels/power/power.ui.h:7
-#| msgid "40 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 مىنۇت"
 
-#: ../panels/power/power.ui.h:8
-#| msgid "40 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 مىنۇت"
 
-#: ../panels/power/power.ui.h:9
-#| msgid "10 minutes"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 مىنۇت"
 
-#: ../panels/power/power.ui.h:10
-#| msgid "1 hour"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 سائەت"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "%1 مىنۇت"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "توكدان"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 مىنۇت"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "ئۈسكۈنىلەر"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 مىنۇت"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "توكنى ئۈز"
 
-#: ../panels/power/power.ui.h:14
-#| msgid "40 minutes"
-msgid "4 minutes"
-msgstr "4 مىنۇت"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 مىنۇت"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "توك تېجەش"
 
-#: ../panels/power/power.ui.h:16
-#| msgid "5 minutes"
-msgid "8 minutes"
-msgstr "8 مىنۇت"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "ئېكران يورۇقلۇقى(_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 مىنۇت"
+#: panels/power/cc-power-panel.ui:127
+#, fuzzy
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "ئېكران يورۇقلۇقى ۋە قۇلۇپ تەڭشىكى"
 
-#: ../panels/power/power.ui.h:18
-#| msgid "2 minutes"
-msgid "12 minutes"
-msgstr "12 مىنۇت"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "ئېكران"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "ئېكران قۇلۇپلاش"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "ئاپتوماتىك يوللار(Routes)"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "ئاپتوماتىك توڭلات(_A)"
+
+#: panels/power/cc-power-panel.ui:175
+#, fuzzy
+msgid "Pauses the computer after a period of inactivity."
+msgstr "ئاكتىپ ئەمەس ۋاقىتتا كومپيۇتېرنى ئۇخلىتىدۇ:"
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "تۆۋەندىكى توپچا"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "ئاپتوماتىك توڭلىتىش"
 
-#: ../panels/power/power.ui.h:21 ../panels/privacy/privacy.ui.h:10
-msgid "_Close"
-msgstr "ياپ(_C)"
-
-#: ../panels/power/power.ui.h:22
-#| msgid "When _Plugged In"
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "قىستۇرۇلدى(_P)"
 
-#: ../panels/power/power.ui.h:23
-msgid "Delay"
-msgstr "كېچىكتۈر"
-
-#: ../panels/power/power.ui.h:24
-#| msgid "When on _Battery Power"
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "توكداندا ئىشلەۋاتقاندا(_B)"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-#| msgid "Authenticated"
-msgid "Authenticate"
-msgstr "كىملىك دەلىللەش"
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "كېچىكتۈر"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:21
-msgid "Password"
-msgstr "ئىم"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "توك مەنبە"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-#| msgid "Authentication required"
-msgid "Authentication Required"
-msgstr "سالاھىيەت دەلىللەش زۆرۈر"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
 
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:591
-msgid "Low on toner"
-msgstr "كۇكۇن ئاز قالدى"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:593
-msgid "Out of toner"
-msgstr "كۇكۇن تۈگەپ كەتتى"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:596
-msgid "Low on developer"
-msgstr "تەسۋىر روشەنلەشتۈرگۈچ ئاز قالدى"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:599
-msgid "Out of developer"
-msgstr "تەسۋىر روشەنلەشتۈرگۈچ تۈگەپ قالدى"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:601
-msgid "Low on a marker supply"
-msgstr "بەلگە سىياھ تەمىنلەش ئاز قالدى"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:603
-msgid "Out of a marker supply"
-msgstr "بەلگە سىياھ تەمىنلەش تۈگەپ قالدى"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:605
-msgid "Open cover"
-msgstr "قاپقاقنى ئاچ"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:607
-msgid "Open door"
-msgstr "ئىشىكنى ئاچ"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:609
-msgid "Low on paper"
-msgstr "قەغەز ئاز قالدى"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:611
-msgid "Out of paper"
-msgstr "قەغەز يېتىشمىدى"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:613
-msgctxt "printer state"
-msgid "Offline"
-msgstr "توردا يوق"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:615
-#: ../panels/printers/cc-printers-panel.c:806
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "توختىدى"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:617
-msgid "Waste receptacle almost full"
-msgstr "ئەخلەت قاچىسى توشۇپ قالاي دېدى"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:619
-msgid "Waste receptacle full"
-msgstr "ئەخلەت قاچىسى توشۇپ قالدى"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:621
-msgid "The optical photo conductor is near end of life"
-msgstr "نۇر سەزگۈچنىڭ ئۆمرى ئاز قالدى"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:623
-msgid "The optical photo conductor is no longer functioning"
-msgstr "نۇر سەزگۈچ خىزمەت قىلالمايدۇ"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:733
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "سەپلەۋاتىدۇ"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:792
-msgctxt "printer state"
-msgid "Ready"
-msgstr "تەييار"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:797
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "ۋەزىپىنى قوبۇل قىلمايدۇ"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:802
-msgctxt "printer state"
-msgid "Processing"
-msgstr "بىر تەرەپ قىلىۋاتىدۇ"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:923
-msgid "Toner Level"
-msgstr " كۇكۇن دەرىجىسى"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:926
-msgid "Ink Level"
-msgstr "سىياھ دەرىجىسى"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:929
-msgid "Supply Level"
-msgstr "تەمىنلەش دەرىجىسى"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:947
-msgctxt "printer state"
-msgid "Installing"
-msgstr "ئورنىتىۋاتىدۇ"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1124
-msgid "No printers available"
-msgstr "پرىنتېر مەۋجۇت ئەمەس"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1429
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u ئاكتىپ"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1773
-msgid "Failed to add new printer."
-msgstr "يېڭى پرىنتېر قوشالمىدى."
-
-#: ../panels/printers/cc-printers-panel.c:1940
-msgid "Select PPD File"
-msgstr "PPD ھۆججىتىنى تاللاش"
-
-#: ../panels/printers/cc-printers-panel.c:1949
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr "PostScript پرىنتېرىنىڭ چۈشەندۈرۈش ھۆججەتلىرى(*.ppd، *.PPD، *.ppd.gz، *.PPD.gz، *.PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"توك مەنبە؛ئۇخلاش؛ئۈچەك؛توكدان؛يورۇقلۇق؛قۇرۇق؛ئېكران؛كۆزەتكۈچ؛"
 
-#: ../panels/printers/cc-printers-panel.c:2254
-msgid "No suitable driver found"
-msgstr "مۇۋاپىق قوزغاتقۇ تېپىلمىدى"
-
-#: ../panels/printers/cc-printers-panel.c:2323
-msgid "Searching for preferred drivers…"
-msgstr "ئەڭ مۇۋاپىق قوزغاتقۇلارنى ئىزدەۋاتىدۇ…"
-
-#: ../panels/printers/cc-printers-panel.c:2338
-msgid "Select from database…"
-msgstr "سانداندىن تاللاش…"
-
-#: ../panels/printers/cc-printers-panel.c:2347
-msgid "Provide PPD File…"
-msgstr "PPD ھۆججەت تەمىنلەش…"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2498
-#: ../panels/printers/cc-printers-panel.c:2521
-msgid "Test page"
-msgstr "سىناق بەت"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2929
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "كۆرۈنمەيۈزنى ئوقۇغىلى بولمىدى: %s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "پرىنتېرلار"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
-msgid "Change printer settings"
-msgstr "پرىنتېر تەڭشىكىنى ئۆزگەرت"
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
-msgstr "Printer;Queue;Print;Paper;Ink;Toner;پرىنتېر;ئۆچىرەت;بېسىش;قەغەز;سىياھ;كۇكۇن;"
+msgstr ""
+"Printer;Queue;Print;Paper;Ink;Toner;پرىنتېر;ئۆچىرەت;بېسىش;قەغەز;سىياھ;كۇكۇن;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "ئاكتىپ خىزمەتلەر"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Close"
-msgstr "ياپ"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "بېسىشنى داۋاملاشتۇرۇش"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "بېسىشنى ۋاقىتلىق توختىتىش"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "بېسىشتىن ۋاز كېچىش"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "بىر يېڭى پرىنتېر قوش"
-
-#: ../panels/printers/new-printer-dialog.ui.h:4
-msgid "Search for network printers or filter result"
-msgstr "تور پرىنتېرلىرىنى ئىزدەش ياكى نەتىجىنى سۈزۈش"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "تاللانمىلارنى ئوقۇۋاتىدۇ…"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "پرىنتېر قوزغاتقۇسىنى تاللاش"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "قوزغاتقۇلار ساندانىنى ئوقۇۋاتىدۇ…"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:65
-#: ../panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "تاق تەرەپلىك"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:67
-#: ../panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "ئۇزۇن يان (ئۆلچەملىك)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:69
-#: ../panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "قىسقا يان (ئۆرۈ)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:71
-msgid "Portrait"
-msgstr "بوي يۆنىلىش"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:73
-msgid "Landscape"
-msgstr "توغرا يۆنىلىش"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:75
-msgid "Reverse landscape"
-msgstr "تەتۈر توغرا يۆنىلىش"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:77
-msgid "Reverse portrait"
-msgstr "تەتۈر بوي يۆنىلىش"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:143
-msgctxt "print job"
-msgid "Pending"
-msgstr "كۈتۈۋاتىدۇ"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:147
-msgctxt "print job"
-msgid "Held"
-msgstr "تۇتۇپ تۇردى"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:151
-msgctxt "print job"
-msgid "Processing"
-msgstr "بىر تەرەپ قىلىۋاتىدۇ"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:155
-msgctxt "print job"
-msgid "Stopped"
-msgstr "توختىدى"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:159
-msgctxt "print job"
-msgid "Canceled"
-msgstr "قالدۇرۇۋېتىلدى"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:163
-msgctxt "print job"
-msgid "Aborted"
-msgstr "توختىتىلدى"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:167
-msgctxt "print job"
-msgid "Completed"
-msgstr "تاماملاندى"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:289
-msgid "Job Title"
-msgstr "خىزمەت ۋەزىپىسى"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:298
-msgid "Job State"
-msgstr "خىزمەت ھالىتى"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:304
-msgid "Time"
-msgstr "ۋاقىت"
-
-#: ../panels/printers/pp-jobs-dialog.c:496
-#, c-format
-msgid "%s Active Jobs"
-msgstr "ئاكتىپ خىزمەت سانى %s"
-
-#. Translators: No printers were found
-#: ../panels/printers/pp-new-printer-dialog.c:1465
-msgid "No printers detected."
-msgstr "پرىنتېر بايقالمىدى."
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Two Sided"
-msgstr "قوش يۈزلۈك"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Type"
-msgstr "قەغەز تىپى"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Paper Source"
-msgstr "قەغەز مەنبەسى"
-
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Output Tray"
-msgstr "قەغەز چىقارغۇچ"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "Resolution"
-msgstr "ئېنىقلىق"
-
-#: ../panels/printers/pp-options-dialog.c:87
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript ئالدىن سۈزگۈچ"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:533
-msgid "Pages per side"
-msgstr "ھەر يۈزىنىڭ بەت سانى"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:545
-msgid "Two-sided"
-msgstr "قوش يۈزلۈك"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:557
-msgid "Orientation"
-msgstr "يۆنىلىش"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:654
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "ئادەتتىكى"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:657
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "بەت تەڭشەك"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:660
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "ئورناتقىلى بولىدىغان تاللانمىلار"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:663
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "ۋەزىپە"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:666
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "سۈرەت سۈپىتى"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:669
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "رەڭ"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:672
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "تامام"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:675
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "ئالىي"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:75
-#: ../panels/printers/pp-ppd-option-widget.c:77
-#: ../panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "ئۆزلۈكىدىن تاللا"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:79
-#: ../panels/printers/pp-ppd-option-widget.c:81
-#: ../panels/printers/pp-ppd-option-widget.c:83
-#: ../panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "ئالدىن تەڭشەلگەن پرىنتېر"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "GhostScript خەت نۇسخىنىلا سىڭدۈر"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "PS دەرىجە 1 گە ئايلاندۇر"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "PS دەرىجە 2 گە ئايلاندۇر"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "ئالدىن سۈزگۈچ يوق"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-#| msgid "Manufacturer:"
-msgid "Manufacturer"
-msgstr "ياسىغۇچى سودىگەر"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "قوزغاتقۇچ"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:247
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr "ئىشلەتكۈچى ئاتى ۋە ئىمنى كىرگۈزسىڭىز %s دىكى پرىنتېرلارنى كۆرەلەيسىز."
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "پرىنتېر قوشۇش"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "پرىنتېر چىقىرىۋېتىش"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+#, fuzzy
+msgid "_Unlock"
+msgstr "قۇلۇپ ئاچ"
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "تەمىنلىگۈچى"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "پرىنتېرلار"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "سالاھىيەت دەلىللەش زۆرۈر"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr "ئىشلەتكۈچى ئاتى ۋە ئىمنى كىرگۈزسىڭىز %s دىكى پرىنتېرلارنى كۆرەلەيسىز."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "ئىشلەتكۈچى ئاتى"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "ئورنى"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default"
-msgstr "كۆڭۈلدىكى(_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "قوزغاتقۇچ"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "ۋەزىپىلەر"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "ئەڭ مۇۋاپىق قوزغاتقۇلارنى ئىزدەۋاتىدۇ…"
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "ۋەزىپىلەرنى كۆرسەت(_J)"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "بۇ تېكىستنى ئىزدە"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "سانداندىن تاللاش…"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "PPD ھۆججەت تەمىنلەش…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "پرىنتېر قوزغاتقۇسىنى تاللاش"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "قوزغاتقۇلار ساندانىنى ئوقۇۋاتىدۇ…"
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "ئەمەلدىن قالدۇر"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "تاللا"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "ئىچكى ئىسپات"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "دائىرە(_D)"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "كىملىك دەلىللەش"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "كىملىك دەلىللەش"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "ئاكتىپ خىزمەت سانى %s"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "سىناق بەت"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "تىزىمغا كىرىش تاللانمىسى"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "ئالدىن تەڭشەلگەن پرىنتېر"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "ئالدىن تەڭشەلگەن پرىنتېر"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "بېسىش باشىنى تازىلا"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "پرىنتېر چىقىرىۋېتىش"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "ئاكتىپ خىزمەتلەر"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "ئەندىزە"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "ئەن"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "سىياھ دەرىجىسى"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "يېڭى قوزغاتقۇنى تەڭشەۋاتىدۇ…"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "بەت 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "سىناق بەتنى باس(_T)"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "تاللانما(_O)"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "باشلاش"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "يېڭى پرىنتېر قوش"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "پرىنتېر قوشۇش"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "پرىنتېر تەڭشىكىنى ئۆزگەرت"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "پرىنتېرلار"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr "كەچۈرۈڭ! سىستېما بېسىش مۇلازىمىتىنى ئىشلەتكىلى بولمايدىغاندەك تۇرىدۇ."
 
-#: ../panels/privacy/cc-privacy-panel.c:105
-msgid "Hidden"
-msgstr "يوشۇرۇن"
-
-#: ../panels/privacy/cc-privacy-panel.c:105
-msgid "Visible"
-msgstr "كۆرۈنۈشچان"
-
-#: ../panels/privacy/cc-privacy-panel.c:271 ../panels/privacy/privacy.ui.h:31
-msgid "Screen Lock"
-msgstr "ئېكران قۇلۇپلاش"
-
-#: ../panels/privacy/cc-privacy-panel.c:338 ../panels/privacy/privacy.ui.h:9
-msgid "Name & Visibility"
-msgstr "ئاتى ۋە كۆرۈنۈشچانلىقى"
-
-#: ../panels/privacy/cc-privacy-panel.c:446 ../panels/privacy/privacy.ui.h:26
-msgid "Usage & History"
-msgstr "ئىشلىتىلىش ئەھۋالى ۋە ئىز"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-msgid "Purge Trash & Temporary Files"
-msgstr "ئەخلەتخانىنى پاكىزلاش ۋە ۋاقىتلىق ھۆججەتلەر"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "شەخسىيەت"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Privacy settings"
-msgstr "شەخسىيەت تەڭشەكلىرى"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;ئېكران;قۇلۇپ;يېقىنقى;ۋاقىتلىق;ئاتى;تور;كىملىك;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "ئېكران تاقىلىدۇ"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 سېكۇنت"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "Control how you appear on the screen and the network."
-msgstr "ئېكران ۋە توردا قانداق كۆرۈنىدىغانلىقىنى تىزگىنلەيدۇ"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "Display _full name in top bar"
-msgstr "ئۇستى بالداقتا تولۇق ئاتىنى كۆرسەتسۇن(_F)"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "Display full name in _lock screen"
-msgstr "قۇلۇپلانغان ئېكراندا تولۇق ئاتىنى كۆرسەتسۇن(_F)"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "_Stealth Mode"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "Immediately"
-msgstr "دەرھال"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "1 day"
-msgstr "1 كۈن"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "2 days"
-msgstr "2 كۈن"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "3 days"
-msgstr "3 كۈن"
-
-#: ../panels/privacy/privacy.ui.h:19
-msgid "4 days"
-msgstr "4 كۈن"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid "5 days"
-msgstr "5 كۈن"
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "6 days"
-msgstr "6 كۈن"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "7 days"
-msgstr "7 كۈن"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "14 days"
-msgstr "14 كۈن"
-
-#: ../panels/privacy/privacy.ui.h:24
-msgid "30 days"
-msgstr "30 كۈن"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "Forever"
-msgstr "مەڭگۈ"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr "ئىزلارنى ساقلاپ قويۇپ كېيىن ئىزدەشكە قۇلايلىق يارىتىدۇ. بۇلار توردا ھەرگىز ھەمبەھىرلەنمەيدۇ."
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Cl_ear Recent History"
-msgstr "يېقىنقى تارىخنى تازىلا(_E)"
-
-#: ../panels/privacy/privacy.ui.h:29
-msgid "_Recently Used"
-msgstr "يېقىندا ئىشلىتىلگەنلىرى(_R)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid "Retain _History"
-msgstr "ئىزلارنى ساقلاپ قوي(_H)"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "ئېكران قۇلۇپلاش — سىز ئورنىڭىزدا يوق ۋاقىتتا سىزنىڭ شەخسىيىتىڭىزنى قوغدايدۇ."
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Automatic Screen _Lock"
-msgstr "ئېكراننى ئاپتوماتىك قۇلۇپلاش"
-
-#: ../panels/privacy/privacy.ui.h:34
-#| msgid "Lock Screen _After"
-msgid "Lock Screen _After Blank For"
-msgstr ""
-
-#: ../panels/privacy/privacy.ui.h:35
-msgid "Show _Notifications"
-msgstr "ئۇقتۇرۇش كۆرسەت(_N)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid "_Empty Trash"
-msgstr "ئەخلەتخانا تازىلا(_E)"
-
-#: ../panels/privacy/privacy.ui.h:38
-msgid "_Purge Temporary Files"
-msgstr "ۋاقىتلىق ھۆججەتلەرنى تازىلا(_F)"
-
-#: ../panels/privacy/privacy.ui.h:39
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr "ئەخلەتخانىنى ۋە ۋاقىتلىق ھۆججەتلەرنى تازىلاپ كومپيۇتېرىڭىزنى مۇھىم ئۇچۇرلاردىن خالىي قىلىپ تۇرىدۇ."
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "Automatically Empty _Trash"
-msgstr "ئەخلەتخانىنى ئاپتوماتىك تازىلا(_T)"
-
-#: ../panels/privacy/privacy.ui.h:41
-msgid "Automatically Purge Temporary _Files"
-msgstr "ۋاقىتلىق ھۆججەتلەرنى ئاپتوماتىك تازىلا(_F)"
-
-#: ../panels/privacy/privacy.ui.h:42
-msgid "Purge _After"
-msgstr "كۆرسىتىلگەن ۋاقىتتىن كېيىن تازىلا(_A)"
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
-msgid "Region & Language"
-msgstr "رايون ۋە تىل"
-
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid "Change your region and language settings"
-msgstr "رايون ۋە تىل تەڭشىكىڭىزنى ئۆزگەرتىدۇ"
-
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
-msgid "Language;Layout;Keyboard;Input;"
-msgstr "Language;Layout;Keyboard;Input;تىل;ھەرپتاختا;كىرگۈزۈش;"
-
-#: ../panels/region/gnome-region-panel-formats.c:144
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "ئىمپېرىئال"
-
-#: ../panels/region/gnome-region-panel-formats.c:146
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "مېترىك"
-
-#: ../panels/region/gnome-region-panel-input-chooser.ui.h:1
-msgid "Select an input source"
-msgstr "كىرگۈزۈش مەنبەسىنى تاللاڭ"
-
-#: ../panels/region/gnome-region-panel-lang.c:115
-#: ../panels/region/gnome-region-panel.ui.h:4
-msgid "Log out for changes to take effect"
-msgstr "ئۆزگىرىشلەرنى ئىناۋەتلىك قىلىش ئۈچۈن چىقىپ كەت"
-
-#: ../panels/region/gnome-region-panel-system.c:471
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings."
-msgstr "كىرىش ئېكرانى، سىستېما ھېساباتى ۋە يېڭى ئىشلەتكۈچى ھېساباتلىرى مەزكۇر سىستېما مىقياسىدىكى رايون ۋە تىل تەڭشىكىنى ئىشلىتىدۇ."
-
-#: ../panels/region/gnome-region-panel-system.c:476
-#: ../panels/region/gnome-region-panel.ui.h:35
-msgid ""
-"The login screen, system accounts and new user accounts use the system-wide "
-"Region and Language settings. You may change the system settings to match "
-"yours."
-msgstr "كىرىش ئېكرانى، سىستېما ھېساباتى ۋە يېڭى ئىشلەتكۈچى ھېساباتلىرى مەزكۇر سىستېما مىقياسىدىكى رايون ۋە تىل تەڭشىكىنى ئىشلىتىدۇ. سىز ئۆزىڭىزگە مەست كېلىدىغان قىلىپ تەڭشىسىڭىز بولىدۇ."
-
-#: ../panels/region/gnome-region-panel-system.c:479
-msgid "Copy Settings"
-msgstr "تەڭشەكنى كۆچۈرۈش"
-
-#: ../panels/region/gnome-region-panel-system.c:482
-#: ../panels/region/gnome-region-panel.ui.h:42
-msgid "Copy Settings…"
-msgstr "تەڭشەكنى كۆچۈرۈش…"
-
-#: ../panels/region/gnome-region-panel.ui.h:1
-msgid "Region and Language"
-msgstr "رايون ۋە تىل"
-
-#: ../panels/region/gnome-region-panel.ui.h:2
-msgid "Select a display language"
-msgstr "كۆرسىتىلىدىغان تىلنى تاللايدۇ"
-
-#: ../panels/region/gnome-region-panel.ui.h:6
-msgid "Add Language"
-msgstr "تىل قوشۇش"
-
-#: ../panels/region/gnome-region-panel.ui.h:7
-msgid "Language"
-msgstr "تىل"
-
-#: ../panels/region/gnome-region-panel.ui.h:8
-msgid "Select a region (change will be applied the next time you log in)"
-msgstr "رايون تاللاڭ(ئۆزگىرىش كېيىنكى قېتىم كىرگەندە كۈچكە ئىگە)"
-
-#: ../panels/region/gnome-region-panel.ui.h:9
-msgid "Add Region"
-msgstr "رايون قوشۇش"
-
-#: ../panels/region/gnome-region-panel.ui.h:10
-msgid "Remove Region"
-msgstr "رايون چىقىرىۋېتىش"
-
-#: ../panels/region/gnome-region-panel.ui.h:11
-msgid "Dates"
-msgstr "چېسلا"
-
-#: ../panels/region/gnome-region-panel.ui.h:12
-msgid "Times"
-msgstr "ۋاقىت"
-
-#: ../panels/region/gnome-region-panel.ui.h:13
-msgid "Numbers"
-msgstr "سانلار"
-
-#: ../panels/region/gnome-region-panel.ui.h:14
-msgid "Currency"
-msgstr "پۇل"
-
-#: ../panels/region/gnome-region-panel.ui.h:15
-msgid "Measurement"
-msgstr "ئۆلچەم"
-
-#: ../panels/region/gnome-region-panel.ui.h:16
-msgid "Examples"
-msgstr "مىساللار"
-
-#: ../panels/region/gnome-region-panel.ui.h:17
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "پىچىملار"
 
-#: ../panels/region/gnome-region-panel.ui.h:18
-msgid "Select keyboards or other input sources"
-msgstr "ھەرپ تاختا ياكى باشقا كىرگۈزۈش مەنبەسىنى تاللاڭ"
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "ئورۇنلارنى ئىزدەش"
 
-#: ../panels/region/gnome-region-panel.ui.h:19
-msgid "Add Input Source"
-msgstr "كىرگۈزۈش مەنبەسى قوشۇش"
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "پىچىملار"
 
-#: ../panels/region/gnome-region-panel.ui.h:20
-msgid "Remove Input Source"
-msgstr "كىرگۈزۈش مەنبەسىنى چىقىرىۋېتىش"
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "پىچىملار"
 
-#: ../panels/region/gnome-region-panel.ui.h:21
-msgid "Move Input Source Up"
-msgstr "كىرگۈزۈش مەنبەسىنى ئۈستىگە يۆتكەش"
-
-#: ../panels/region/gnome-region-panel.ui.h:22
-msgid "Move Input Source Down"
-msgstr "كىرگۈزۈش مەنبەسىنى ئاستىغا يۆتكەش"
-
-#: ../panels/region/gnome-region-panel.ui.h:23
-msgid "Input Source Settings"
-msgstr "كىرگۈزۈش مەنبەسى تەڭشىكى"
-
-#: ../panels/region/gnome-region-panel.ui.h:24
-msgid "Show Keyboard Layout"
-msgstr "ھەرپ تاختا ئورۇنلاشتۇرۇشىنى كۆرسىتىش"
-
-#: ../panels/region/gnome-region-panel.ui.h:26
-msgid "Ctrl+Alt+Space"
-msgstr "Ctrl+Alt+Space"
-
-#: ../panels/region/gnome-region-panel.ui.h:28
-msgid "Ctrl+Alt+Shift+Space"
-msgstr "Ctrl+Alt+Shift+Space"
-
-#: ../panels/region/gnome-region-panel.ui.h:29
-msgid "Shortcut Settings"
-msgstr "تېزلەتمە تەڭشىكى"
-
-#: ../panels/region/gnome-region-panel.ui.h:31
-msgid "Use the same source for all windows"
-msgstr "ھەممە كۆزنەكلەرگە ئوخشاش مەنبەنى ئىشلەتسۇن"
-
-#: ../panels/region/gnome-region-panel.ui.h:32
-msgid "Allow different sources for each window"
-msgstr "ھەر بىر كۆزنەكنىڭ ئايرىم-ئايرىم بولسۇن"
-
-#: ../panels/region/gnome-region-panel.ui.h:33
-msgid "Options"
-msgstr "تاللانما"
-
-#: ../panels/region/gnome-region-panel.ui.h:34
-msgid "Input Sources"
-msgstr "كىرگۈزۈش مەنبەلىرى"
-
-#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
-#: ../panels/region/gnome-region-panel.ui.h:37
-msgid "Display language:"
-msgstr "كۆرۈنۈش تىلى:"
-
-#: ../panels/region/gnome-region-panel.ui.h:38
-msgid "Input source:"
-msgstr "كىرگۈزۈش مەنبەسى"
-
-#: ../panels/region/gnome-region-panel.ui.h:39
-msgid "Format:"
-msgstr "فورمات:"
-
-#: ../panels/region/gnome-region-panel.ui.h:40
-msgid "Your settings"
-msgstr "تەڭشىكىڭىز"
-
-#: ../panels/region/gnome-region-panel.ui.h:41
-msgid "System settings"
-msgstr "سىستېما تەڭشەكلىرى"
-
-#: ../panels/search/cc-search-locations-dialog.c:275
-msgid "Home"
-msgstr "ماكان"
-
-#: ../panels/search/cc-search-locations-dialog.c:475
-msgid "Places"
-msgstr "ئورۇنلار"
-
-#: ../panels/search/cc-search-locations-dialog.c:477
-msgid "Bookmarks"
-msgstr "خەتكۈشلەر"
-
-#: ../panels/search/cc-search-locations-dialog.c:479
-msgid "Other"
-msgstr "باشقا"
-
-#: ../panels/search/cc-search-locations-dialog.c:675
-msgid "Select Location"
-msgstr "ئورۇن تاللاش"
-
-#: ../panels/search/cc-search-panel.c:193
-msgid "No applications found"
-msgstr "پروگرامما تېپىلمىدى"
-
-#: ../panels/search/cc-search-panel.c:551
-#: ../panels/user-accounts/um-fingerprint-dialog.c:219
-#: ../panels/user-accounts/um-fingerprint-dialog.c:220
-msgid "Enabled"
-msgstr "ئىناۋەتلىك قىلىنغان"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "ئىزدە"
-
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
-msgid "Search settings"
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
 msgstr "ئىزدەش تەڭشىكى"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
-msgid "Search;Find;Index;Hide;Privacy;Results;"
-msgstr "Search;Find;Index;Hide;Privacy;Results;ئىزدەش;تېپىش;ئىندېكس;يوشۇرۇش;شەخسىيەت;نەتىجىلەر;"
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
 
-#: ../panels/search/search-locations-dialog.ui.h:1
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "ئالدىن كۆزەت"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "چېسلا"
+
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "چېسلا & ۋاقىت"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "سانلار"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "ئۆلچەم"
+
+#: panels/region/cc-format-preview.ui:107
+#, fuzzy
+msgid "Paper"
+msgstr "قەغەز تىپى"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+#, fuzzy
+msgid "Manage Installed Languages"
+msgstr "تىللارنى ئورنات…"
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "ھېساباتىم"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "تىل(_L)"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "پىچىملار"
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "يان كومپيۇتېر ئېكرانى"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "رايون ۋە تىل"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "كۆرسىتىلىدىغان تىلنى تاللايدۇ"
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;تىل;ھەرپتاختا;كىرگۈزۈش;"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "بىر تەرەپ قىلىنىدىغان ۋاسىتىنى تاللاڭ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD ئۈن(_A)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD سىن"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "نەغمە چالغۇچ(_M)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "يۇمشاق دېتال(_S)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "باشقا ۋاسىتە(_O)…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "ۋاسىتە قىستۇرۇلغاندا ھەرگىز ئەسكەرتمە ياكى پروگرامما قوزغاتما(_N)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "بىر تەرەپ قىلىنىدىغان باشقا ۋاسىتىنى تاللاڭ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "مەشغۇلات(_A):"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "تىپى(_T):"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "چىقىرىۋېتىشكە بولىدىغان ۋاسىتە"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "كۆكچىش تەڭشىكىنى تەڭشەش"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+"ئۈسكۈنە;سىستېما;ئۇچۇر;ئەسلەك;بىر تەرەپ قىلغۇچ;نەشرى;كۆڭۈلدىكى;ئەپ;زاپاس;"
+"ئارقىغا قايتۇر;مايىللىق;cd;dvd;usb;ئۈن;سىن;ئوپتىك دىسكا;نۇر دىسكا;دىسكا;"
+"كۆچمە;ۋاسىتە;تاراتقۇ;ئۆزلۈكىدىن ئىجرا قىل;"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "ئېكران قۇلۇپلاش"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "قۇرۇق ئەركان(_B)"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "ئېكراننى ئاپتوماتىك قۇلۇپلاش"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "ئېكراننى ئاپتوماتىك قۇلۇپلاش"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "تەپسىلاتلارنى قۇلۇپ ئېكراندا كۆرسىتىش"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "ئېكراننى قۇلۇپلا"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "شەخسىيەت"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "ئېكران"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "ئاۋاز تەڭشەكلىرى‏"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
 msgid "Search Locations"
 msgstr "ئورۇنلارنى ئىزدەش"
 
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "ئۈستىگە"
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
 
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "پەسكە"
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "ئورۇنلار"
 
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "مايىللىق"
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "خەتكۈشلەر"
 
-#: ../panels/sharing/cc-sharing-panel.c:220
-msgctxt "service is enabled"
-msgid "On"
-msgstr "ئوچۇق"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "باشقا"
 
-#: ../panels/sharing/cc-sharing-panel.c:222
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "تاقا"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "ئورنى"
 
-#: ../panels/sharing/cc-sharing-panel.c:362
-msgid "Choose a Folder"
-msgstr "قىسقۇچ تاللاڭ"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "پروگراممىلار"
 
-#: ../panels/sharing/cc-sharing-panel.c:540
-msgid "Copy"
-msgstr "كۆچۈر"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "ئىزدەش تەڭشىكى"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Find;Index;Hide;Privacy;Results;ئىزدەش;تېپىش;ئىندېكس;يوشۇرۇش;شەخسىيەت;"
+"نەتىجىلەر;"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "تور"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
 msgid "Sharing"
 msgstr "ھەمبەھىر"
 
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:3
-msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
-msgstr "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;pictures;photos;movies;server;renderer;ھەمبەھىر;يىراق;ئۈستەلئۈستى;كۆكچىش;ئۈن;سىن;سۈرەت;رەسىم;كىنو;مۇلازىمېتىر;"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "يىراقتىن كىرىشنى ئىناۋەتلىك ۋە ئىناۋەتسىز قىلىدۇ"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "يىراقتىن كىرىشنى ئىناۋەتلىك ۋە ئىناۋەتسىز قىلىش ئۈچۈن سالاھىيەت دەلىللەش زۆرۈردۇر"
-
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "كۆكچىشتا ھەمبەھىرلەش"
-
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr "كۆكچىشتا ھەمبەھىرلەش — ھۆججەتلەرنى كۆكچىش بار ئۈسكۈنىلەر ئارىسىدا ھەمبەھىرلەشكە ئىمكان يارىتىدۇ."
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Share Public Folder"
-msgstr "ئاممىۋى قىسقۇچنى ھەمبەھىرلە"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Only Receive From Trusted Devices"
-msgstr "ئىشەنچلىك ئۈسكۈنىلەردىنلا قوبۇل قىلسۇن"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Save Received Files to Downloads Folder"
-msgstr "قوبۇل قىلغان ھۆججەتلەرنى چۈشۈرۈلمىلەر قىسقۇچىغا ساقلىسۇن"
-
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Only share with Trusted Devices"
-msgstr "ئىشەنچلىك ئۈسكۈنىلەر بىلەنلا ھەمبەھىر قىلسۇن"
-
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "كومپيۇتېر ئاتى"
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Some services are disabled because of no network access."
-msgstr "تور بولمىغاچقا بىر قىسىم مۇلازىمەتلەر ئىناۋەتسىز قىلىندى."
-
-#: ../panels/sharing/sharing.ui.h:9
-msgid "Media Sharing"
-msgstr "ۋاسىتە ھەمبەھىرلەش"
-
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Share Music, Photos and Videos with others on the current network."
-msgstr "مەزكۇر توردا مۇزىكا، سۈرەت ۋە سىنلارنى باشقىلار بىلەن ھەمبەھىر قىلىپ ئىشلىتىدۇ."
-
-#: ../panels/sharing/sharing.ui.h:11
-msgid "Share Media On This Network"
-msgstr "مەزكۇر توردا ۋاسىتىلەرنى ھەمبەھىر قىلسۇن"
-
-#: ../panels/sharing/sharing.ui.h:12
-msgid "Shared Folders"
-msgstr "ھەمبەھىرلەنگەن قىسقۇچلار"
-
-#: ../panels/sharing/sharing.ui.h:13
-msgid "column"
-msgstr "ئىستونلار"
-
-#: ../panels/sharing/sharing.ui.h:14
-msgid "Add Folder"
-msgstr "قىسقۇچ قوشۇش"
-
-#: ../panels/sharing/sharing.ui.h:15
-msgid "Remove Folder"
-msgstr "قىسقۇچ چىقىرىۋېتىش"
-
-#: ../panels/sharing/sharing.ui.h:16
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "خۇسۇسىي ھۆججەت ھەمبەھىرى"
 
-#: ../panels/sharing/sharing.ui.h:18
-#, no-c-format
-msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr "شەخسىي ھۆججەت ھەمبەھىرلەشنى ئىشلىتىش ئارقىلىق، ئاممىۋى قىسقۇچلارنى <a href=\"dav://%s\">dav://%s</a> نى ئىشلىتىپ باشقىلار بىلەن ھەمبەھىر قىلالايسىز"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "يىراقتا تىزگىنلەش"
 
-#: ../panels/sharing/sharing.ui.h:19
-msgid "Share Public Folder On This Network"
-msgstr "مەزكۇر توردا ئاممىۋى قىسقۇچنى ھەمبەھىر قىلسۇن"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "ۋاسىتە ھەمبەھىرلەش"
 
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Require Password"
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "يىراقتىن كىرىش"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "ھەمبەھىر"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
 msgstr "ئىم زۆرۈر"
 
-#: ../panels/sharing/sharing.ui.h:22
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "يىراقتىن كىرىش"
 
-#: ../panels/sharing/sharing.ui.h:24
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "يىراقتا تىزگىنلەش"
+
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
-msgstr "يىرىقتىكى ئىشلەتكۈچىنىڭ بىخەتەر Shell بۇيرۇقىنى ئىشلىتىپ باغلىنىشىغا ئىجازەت بېرىدۇ:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:26
-msgid "Screen Sharing"
-msgstr "ئېكراننى ھەمبەھىر قىلىش"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "يىراقتىن كىرىشنى ئىناۋەتلىك ۋە ئىناۋەتسىز قىلىدۇ"
 
-#: ../panels/sharing/sharing.ui.h:28
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr "يىرىقتىكى ئىشلەتكۈچىنىڭ باغلىنىپ ئېكراننى تىزگىنلىشىگە ئىجازەت بېرىدۇ: <a href=\"vnc://%s\">vnc://%s</a>"
-
-#: ../panels/sharing/sharing.ui.h:29
-msgid "Remote View"
-msgstr "يىراقتا كۆرۈش"
-
-#: ../panels/sharing/sharing.ui.h:30
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "يىراقتا تىزگىنلەش"
 
-#: ../panels/sharing/sharing.ui.h:31
-msgid "Approve All Connections"
-msgstr "ھەممە باغلىنىشنى قوبۇل قىلسۇن"
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:32
-msgid "Show Password"
-msgstr "ئىم كۆرسەت"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "ئاۋاز"
-
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound volume and event sounds"
-msgstr "ئاۋاز چوڭلۇقى ۋە ھادىسىنىڭ ئاۋازلىرىنى ئۆزگەرتىش"
-
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+#: panels/sharing/cc-sharing-panel.ui:299
 #, fuzzy
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "كارتا؛مىكروفون؛ئاۋاز چوڭلۇقى؛Fade؛Balance؛كۆكچىش؛مىكروفونلۇق تىڭشىغۇچ؛ئاۋاز؛ئۈن؛"
+msgid "How to Connect"
+msgstr "باغلانمىغان"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "ئىتنىڭ قاۋىشى"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "سۇنىڭ تامچىلىشى"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "كۆچۈر"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "ئەينەكنىڭ جىرىڭلىشى"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "ئادرېسلارنى ئۆچۈرۈش"
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "سونار"
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "كىملىك دەلىللەش(_T)"
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Left"
-msgstr "سول"
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:107
-msgctxt "balance"
-msgid "Right"
-msgstr "ئوڭ"
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "ئىشلەتكۈچى ئاتى"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "بارماق ئىزى تىزىملىنىۋاتىدۇ"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "ۋاسىتە ھەمبەھىرلەش"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+#, fuzzy
+msgid "Share music, photos and videos over the network."
+msgstr ""
+"مەزكۇر توردا مۇزىكا، سۈرەت ۋە سىنلارنى باشقىلار بىلەن ھەمبەھىر قىلىپ "
+"ئىشلىتىدۇ."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+#, fuzzy
+msgid "Folders"
+msgstr "قىسقۇچ قوشۇش"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;ھەمبەھىر;يىراق;ئۈستەلئۈستى;كۆكچىش;ئۈن;"
+"سىن;سۈرەت;رەسىم;كىنو;مۇلازىمېتىر;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "يىراقتىن كىرىشنى ئىناۋەتلىك ۋە ئىناۋەتسىز قىلىدۇ"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+"يىراقتىن كىرىشنى ئىناۋەتلىك ۋە ئىناۋەتسىز قىلىش ئۈچۈن سالاھىيەت دەلىللەش "
+"زۆرۈردۇر"
+
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
+
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "ھەمبەھىر"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "ھېساباتتىكى پۇل(_B):"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "سۇسلاشتۇر(_F):"
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "ئارقا تەرەپ"
 
-#: ../panels/sound/gvc-balance-bar.c:111
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "ئالدى"
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Minimum"
-msgstr "ئەڭ كىچىك"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:115
-msgctxt "balance"
-msgid "Maximum"
-msgstr "ئەڭ چوڭ"
-
-#: ../panels/sound/gvc-balance-bar.c:290
-msgid "_Balance:"
-msgstr "ھېساباتتىكى پۇل(_B):"
-
-#: ../panels/sound/gvc-balance-bar.c:293
-msgid "_Fade:"
-msgstr "سۇسلاشتۇر(_F):"
-
-#: ../panels/sound/gvc-balance-bar.c:296
-msgid "_Subwoofer:"
-msgstr "ئۇلترا تۆۋەن ئاۋاز(_S):"
-
-#: ../panels/sound/gvc-channel-bar.c:613 ../panels/sound/gvc-channel-bar.c:622
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:617
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "چوڭايتىلمىغان"
-
-#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "سەپلىمە ھۆججەت(_P):"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u چىقىرىلما"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u كىرگۈزۈلمە"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2371
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "سىستېما ئاۋازى"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "ياڭراتقۇ سىنا(_T)"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "ئاگاھلاندۇرۇش ئاۋاز مىقدارى(_A):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "چوققا قىممەت بايقا"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "ئۈنسىزلە"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1511
-#: ../panels/sound/gvc-sound-theme-chooser.c:595
-msgid "Name"
-msgstr "ئاتى"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1530
-msgid "Device"
-msgstr "ئۈسكۈنە"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1593
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s نىڭ ياڭراتقۇسىنى سىناش"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1647
-msgid "_Output volume:"
-msgstr "ئاۋاز مىقدارى(_O):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1661
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "چىقار"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1666
-msgid "C_hoose a device for sound output:"
-msgstr "ئاۋاز چىقىرىش ئۈسكۈنىسى تاللاش(_H):"
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "ئاۋاز مىقدارى(_O):"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1691
-msgid "Settings for the selected device:"
-msgstr "تاللىغان ئۈسكۈنىنىڭ تەڭشىكى:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1702
-msgid "Input"
-msgstr "كىرگۈز"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1709
-msgid "_Input volume:"
-msgstr "كىرىش ئاۋاز مىقدارى(_I):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1732
-msgid "Input level:"
-msgstr "كىرىش دەرىجىسى:"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1760
-msgid "C_hoose a device for sound input:"
-msgstr "ئاۋاز كىرگۈزۈش ئۈسكۈنىسى تاللاش(_H):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1787
-msgid "Sound Effects"
-msgstr "ئاۋاز ئۈنۈمى"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1794
-msgid "_Alert volume:"
-msgstr "ئاگاھلاندۇرۇش ئاۋاز مىقدارى(_A):"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1807
-msgid "Applications"
-msgstr "پروگراممىلار"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1811
-msgid "No application is currently playing or recording audio."
-msgstr "نۆۋەتتە ئاۋاز قويىدىغان ياكى خاتىرىلەيدىغان پروگرامما يوق."
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:189
-msgid "Built-in"
-msgstr "ئىچكى"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:455
-#: ../panels/sound/gvc-sound-theme-chooser.c:467
-#: ../panels/sound/gvc-sound-theme-chooser.c:479
-msgid "Sound Preferences"
-msgstr "ئاۋاز مايىللىقى"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:458
-#: ../panels/sound/gvc-sound-theme-chooser.c:469
-#: ../panels/sound/gvc-sound-theme-chooser.c:481
-msgid "Testing event sound"
-msgstr "ھادىسە ئاۋازىنى سىناۋاتىدۇ"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "Default"
-msgstr "كۆڭۈلدىكى"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:586
-msgid "From theme"
-msgstr "ئۆرنەكتىن"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:770
-msgid "C_hoose an alert sound:"
-msgstr "ئاگاھلاندۇرۇش ئاۋازى تاللاڭ(_H):"
-
-#: ../panels/sound/gvc-speaker-test.c:220
-msgid "Stop"
-msgstr "توختا"
-
-#: ../panels/sound/gvc-speaker-test.c:220
-#: ../panels/sound/gvc-speaker-test.c:332
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "سىنا"
 
-#: ../panels/sound/gvc-speaker-test.c:228
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "سەپلىمە URL (_C)"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "ئۇلترا تۆۋەن ئاۋاز ياڭراتقۇ"
 
-#: ../panels/sound/sound-theme-file-utils.c:292
-msgid "Custom"
-msgstr "ئىختىيارى"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "كىرگۈز"
 
-#: ../panels/universal-access/cc-ua-panel.c:281
-#: ../panels/universal-access/cc-ua-panel.c:287
-msgid "No shortcut set"
-msgstr "تېزلەتمە بەلگىلەنمىگەن"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "كىرىش دەرىجىسى:"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Universal Access Preferences"
-msgstr "ئۇنىۋېرسال زىيارەت مايىللىقى"
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "ئاۋازنى چوڭايت"
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "ئاگاھلاندۇرۇش ئاۋاز مىقدارى(_A):"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "ئۈنسىز"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "ئاۋاز"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "ئاۋاز چوڭلۇقى ۋە ھادىسىنىڭ ئاۋازلىرىنى ئۆزگەرتىش"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
-"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
-msgstr "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;ھەرپتاختا;چاشقىنەك;ياردەمچى;چوڭلۇقى;چاپلاشقاق كۇنۇپكا;ئاستا كۇنۇپكا;چاشقىنەك كۇنۇپكىسى;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"كارتا؛مىكروفون؛ئاۋاز چوڭلۇقى؛Fade؛Balance؛كۆكچىش؛مىكروفونلۇق تىڭشىغۇچ؛ئاۋاز؛"
+"ئۈن؛"
 
-#: ../panels/universal-access/uap.ui.h:1
-#: ../panels/universal-access/zoom-options.ui.h:33
-msgctxt "universal access, contrast"
-msgid "Low"
-msgstr "تۆۋەن"
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgctxt "universal access, contrast"
-msgid "Normal"
-msgstr "نورمال"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "ئۇقتۇرۇشلارنى باشقۇرۇش"
 
-#: ../panels/universal-access/uap.ui.h:3
-#: ../panels/universal-access/zoom-options.ui.h:34
-msgctxt "universal access, contrast"
-msgid "High"
-msgstr "يۇقىرى"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "ئاتى(_N):"
 
-#: ../panels/universal-access/uap.ui.h:4
-msgctxt "universal access, contrast"
-msgid "High/Inverse"
-msgstr "يۇقىرى/ئەكسى"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:5
-msgid "On screen keyboard"
-msgstr "ئېكران ھەرپتاختىسى"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:6
-msgid "GOK"
-msgstr "GOK"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "ئاپتوماتىك باغلانسۇن(_C)"
 
-#: ../panels/universal-access/uap.ui.h:7
-msgid "OnBoard"
-msgstr "تاختىدىكى"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "ئۈسكۈنىنى چىقىرىۋەت"
 
-#: ../panels/universal-access/uap.ui.h:10
-#, no-c-format
-msgid "75%"
-msgstr "75%"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:11
-msgctxt "universal access, text size"
-msgid "Small"
-msgstr "كىچىك"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "دائىرە %s غا باغلانغىلى بولمىدى: %s"
 
-#: ../panels/universal-access/uap.ui.h:13
-#, no-c-format
-msgid "100%"
-msgstr "100%"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "ئۇنىۋېرسال زىيارەت"
 
-#: ../panels/universal-access/uap.ui.h:14
-msgctxt "universal access, text size"
-msgid "Normal"
-msgstr "نورمال"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:16
-#, no-c-format
-msgid "125%"
-msgstr "125%"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "ئۈسكۈنە قوش"
 
-#: ../panels/universal-access/uap.ui.h:17
-msgctxt "universal access, text size"
-msgid "Large"
-msgstr "چوڭ"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:19
-#, no-c-format
-msgid "150%"
-msgstr "150%"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:20
-msgctxt "universal access, text size"
-msgid "Larger"
-msgstr "چوڭراق"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "High Contrast"
-msgstr "يۇقىرى ئاق-قارىلىقى"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Beep on Caps and Num Lock"
-msgstr "Caps ۋە Num Lock كۇنۇپكىلىرىنى ئىشلەتكەندە ئاۋاز چىقارسۇن"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "نۇربەلگىنىڭ لىپىلدىشى"
 
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Screen Reader"
-msgstr "ئېكران ئوقۇغۇچ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "تېكىست رايونىدا نۇربەلگىسى لىپىلدىسۇن(_B)"
 
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Turn on or off:"
-msgstr "ئاچ ياكى ياپ"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "سۈرئىتى"
 
-#: ../panels/universal-access/uap.ui.h:26
-msgctxt "universal access, zoom"
-msgid "Zoom"
-msgstr "كېڭەيت-تارايت"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "سىنبەلگە لىپىلداش سۈرئىتى"
 
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Zoom in:"
-msgstr "كېڭەيت:"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "سىنبەلگە لىپىلداش سۈرئىتى"
 
-#: ../panels/universal-access/uap.ui.h:28
-msgid "Zoom out:"
-msgstr "تارايت:"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Large Text"
-msgstr "چوڭ تېكىست"
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:30
-msgid "Seeing"
-msgstr "كۆرۈش سېزىمى"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Visual Alerts"
-msgstr "كۆرۈنمە ئاگاھلاندۇرۇش"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "Use a visual indication when an alert sound occurs"
-msgstr "ئاگاھلاندۇرۇش ئاۋازى يۈز بەرسە كۆرۈنمە ئەسكەرتىشنى كۆرسەت"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Flash the window title"
-msgstr "كۆزنەك ماۋزۇسىنى چاقنات"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "Flash the entire screen"
-msgstr "پۈتۈن ئېكراننى چاقنات"
-
-#: ../panels/universal-access/uap.ui.h:35
-msgid "Closed Captioning"
-msgstr "تاقالغان خەتلىك چۈشەندۈرۈش"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Display a textual description of speech and sounds"
-msgstr "تەلەپپۇز ۋە ئاۋازنىڭ تېكىست چۈشەندۈرۈشىنى كۆرسەت"
-
-#: ../panels/universal-access/uap.ui.h:37
-msgid "_Test flash"
-msgstr "چاقناشنى سىنا(_T)"
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Hearing"
-msgstr "ئاڭلاش سېزىمى"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "On Screen Keyboard"
-msgstr "ئېكران ھەرپتاختىسى"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "Sticky Keys"
-msgstr "يېپىشقاق كۇنۇپكىلار"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "بىر تىزىق ئۆزگەرتىلگەن كۇنۇپكىنى بىرىكمە كۇنۇپكا قىلىدۇ"
-
-#: ../panels/universal-access/uap.ui.h:43
-msgid "_Disable if two keys are pressed together"
-msgstr "ئەگەر ئىككى كۇنۇپكا بىرلا ۋاقىتتا بېسىلسا چەكلە(_D)"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Beep when a _modifer key is pressed"
-msgstr "ئۆزگەرتىش كۇنۇپكىسى بېسىلسا ئاۋاز چىقار(_M)"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgid "Slow Keys"
-msgstr "ئاستا كۇنۇپكىلار"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "كۇنۇپكا بېسىلىپ قوبۇل قىلغىچە بولغان ئارىلىقتا كېچىكتۈرۈش ئورنات"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "A_cceptance delay:"
-msgstr "قوبۇل قىلىشچان كېچىكتۈرۈش(_C):"
-
-#: ../panels/universal-access/uap.ui.h:48
-msgctxt "universal access, delay"
-msgid "Short"
-msgstr "قىسقا"
-
-#: ../panels/universal-access/uap.ui.h:49
-msgid "Slow keys typing delay"
-msgstr "ئاستا كۇنۇپكىلارنىڭ كېچىكىش ۋاقتى"
-
-#: ../panels/universal-access/uap.ui.h:50
-msgctxt "universal access, delay"
-msgid "Long"
-msgstr "ئۇزۇن"
-
-#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
-#: ../panels/universal-access/uap.ui.h:52
-msgid "Beep when a key is"
-msgstr "كۇنۇپكىسى ئىشلەتكەندە دۈت-دۈت ئاۋاز چىقار"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:54
-msgid "pressed"
-msgstr "بېسىلغان"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:56
-msgid "accepted"
-msgstr "قوشۇلغان"
-
-#. This completes the sentence "Beep when a key is"
-#: ../panels/universal-access/uap.ui.h:58
-msgid "rejected"
-msgstr "رەت قىلىنغان"
-
-#: ../panels/universal-access/uap.ui.h:59
-msgid "Bounce Keys"
-msgstr "سەكرىمە كۇنۇپكىلار"
-
-#: ../panels/universal-access/uap.ui.h:60
-msgid "Ignores fast duplicate keypresses"
-msgstr "تېز سۈرئەتتە تەكرار كۇنۇپكا بېسىشقا پەرۋا قىلما"
-
-#: ../panels/universal-access/uap.ui.h:61
-msgid "Acc_eptance delay:"
-msgstr "قوبۇل قىلىشچان كېچىكتۈرۈش(_E):"
-
-#: ../panels/universal-access/uap.ui.h:62
-msgid "Bounce keys typing delay"
-msgstr "‹سەكرىمە كۇنۇپكىلار›نى ئىناۋەتلىك قىلسۇن"
-
-#: ../panels/universal-access/uap.ui.h:63
-msgid "Beep when a key is _rejected"
-msgstr "بىر كۇنۇپكا رەت قىلىنسا ئاۋاز چىقار(_R)"
-
-#: ../panels/universal-access/uap.ui.h:64
-msgid "Enable by Keyboard"
-msgstr "ھەرپتاختىسى ئارقىلىق ئىناۋەتلىك قىلسۇن"
-
-#: ../panels/universal-access/uap.ui.h:65
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "ياردەمچى ئىقتىدارلارنى ھەرپتاختىسى ئارقىلىق ئىناۋەتلىك ياكى ئىناۋەتسىز قىلىدۇ"
-
-#: ../panels/universal-access/uap.ui.h:67
-msgid "Mouse Keys"
-msgstr "چاشقىنەك كۇنۇپكىلىرى"
-
-#: ../panels/universal-access/uap.ui.h:68
-msgid "Control the pointer using the keypad"
-msgstr "نۇربەلگىنى كۇنۇپكا تاختىدا تىزگىنلىسۇن"
-
-#: ../panels/universal-access/uap.ui.h:69
-msgid "Video Mouse"
-msgstr "سىن چاشقىنەك"
-
-#: ../panels/universal-access/uap.ui.h:70
-msgid "Control the pointer using the video camera."
-msgstr "نۇربەلگىنى سىن كامېرادا تىزگىنلەيدۇ."
-
-#: ../panels/universal-access/uap.ui.h:71
-msgid "Simulated Secondary Click"
+#: panels/universal-access/cc-pointing-dialog.ui:38
+#, fuzzy
+msgid "_Simulated Secondary Click"
 msgstr "تەقلىدلىك ئىككىنچى چېكىش"
 
-#: ../panels/universal-access/uap.ui.h:72
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "چاشقىنەك ئاساسىي توپچىسىنى قويۇۋەتمىگەندە ئىككىنچى چېكىشنى قوزغات"
 
-#: ../panels/universal-access/uap.ui.h:73
-msgid "Secondary click delay"
-msgstr "ئىككىنچى چېكىشنى كېچىكتۈرۈش"
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "قوبۇل قىلىشچان كېچىكتۈرۈش(_C):"
 
-#: ../panels/universal-access/uap.ui.h:74
-msgid "Hover Click"
-msgstr "لەيلىتىپ چەك"
-
-#: ../panels/universal-access/uap.ui.h:75
-msgid "Trigger a click when the pointer hovers"
-msgstr "ئىسترېلكا لەيلەپ توختىغاندا چېكىش مەشغۇلاتىنى ئىجرا قىلىدۇ"
-
-#: ../panels/universal-access/uap.ui.h:76
-msgid "D_elay:"
-msgstr "كېچىكتۈر(_E):"
-
-#: ../panels/universal-access/uap.ui.h:77
-msgid "Motion _threshold:"
-msgstr "ھەرىكەت بوسۇغا قىممىتى(_T):"
-
-#: ../panels/universal-access/uap.ui.h:78
-msgctxt "universal access, threshold"
-msgid "Small"
-msgstr "كىچىك"
-
-#: ../panels/universal-access/uap.ui.h:79
-msgctxt "universal access, threshold"
-msgid "Large"
-msgstr "چوڭ"
-
-#: ../panels/universal-access/uap.ui.h:80
-msgid "Mouse Settings"
-msgstr "چاشقىنەك تەڭشەكلىرى"
-
-#: ../panels/universal-access/uap.ui.h:81
-msgid "Pointing and Clicking"
-msgstr "كۆرسىتىش ۋە چېكىش"
-
-#: ../panels/universal-access/zoom-options.c:357
-msgctxt "Distance"
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
 msgid "Short"
 msgstr "قىسقا"
 
-#: ../panels/universal-access/zoom-options.c:358
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ ئېكران"
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "ئىككىنچى چېكىشنى كېچىكتۈرۈش"
 
-#: ../panels/universal-access/zoom-options.c:359
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ ئېكران"
-
-#: ../panels/universal-access/zoom-options.c:360
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ ئېكران"
-
-#: ../panels/universal-access/zoom-options.c:361
-msgctxt "Distance"
+#: panels/universal-access/cc-pointing-dialog.ui:97
+#, fuzzy
+msgctxt "secondary click delay"
 msgid "Long"
 msgstr "ئۇزۇن"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-pointing-dialog.ui:126
+#, fuzzy
+msgid "_Hover Click"
+msgstr "لەيلىتىپ چەك"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "ئىسترېلكا لەيلەپ توختىغاندا چېكىش مەشغۇلاتىنى ئىجرا قىلىدۇ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "كېچىكتۈر(_E):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "قىسقا"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "ئۇزۇن"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "ھەرىكەت بوسۇغا قىممىتى(_T):"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "كىچىك"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "چوڭ"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "تەكرار كۇنۇپكا"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "مەلۇم كۇنۇپكا بېسىپ تۇرۇلغاندا شۇ كۇنۇپكىنى تەكرارلا(_R)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "تەكرار كۇنۇپكا سۈرئىتى"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "تەكرار كۇنۇپكا سۈرئىتى"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+#, fuzzy
+msgid "Typing Assist"
+msgstr "كىرگۈزۈش ياردەمچىسى"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "يېپىشقاق كۇنۇپكىلار"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "بىر تىزىق ئۆزگەرتىلگەن كۇنۇپكىنى بىرىكمە كۇنۇپكا قىلىدۇ"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "ئەگەر ئىككى كۇنۇپكا بىرلا ۋاقىتتا بېسىلسا چەكلە(_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "ئۆزگەرتىش كۇنۇپكىسى بېسىلسا ئاۋاز چىقار(_M)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "ئاستا كۇنۇپكىلار"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "كۇنۇپكا بېسىلىپ قوبۇل قىلغىچە بولغان ئارىلىقتا كېچىكتۈرۈش ئورنات"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "قىسقا"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "ئاستا كۇنۇپكىلارنىڭ كېچىكىش ۋاقتى"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "ئۇزۇن"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "ئۆزگەرتىش كۇنۇپكىسى بېسىلسا ئاۋاز چىقار(_M)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "بىر كۇنۇپكا رەت قىلىنسا ئاۋاز چىقار(_R)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "بىر كۇنۇپكا رەت قىلىنسا ئاۋاز چىقار(_R)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "سەكرىمە كۇنۇپكىلار"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "تېز سۈرئەتتە تەكرار كۇنۇپكا بېسىشقا پەرۋا قىلما"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "قىسقا"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "‹سەكرىمە كۇنۇپكىلار›نى ئىناۋەتلىك قىلسۇن"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "ئۇزۇن"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+#, fuzzy
+msgid "_Enable by Keyboard"
+msgstr "ھەرپتاختىسى ئارقىلىق ئىناۋەتلىك قىلسۇن"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+"ياردەمچى ئىقتىدارلارنى ھەرپتاختىسى ئارقىلىق ئىناۋەتلىك ياكى ئىناۋەتسىز قىلىدۇ"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "كۆرۈش سېزىمى"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+#, fuzzy
+msgid "_High Contrast"
+msgstr "يۇقىرى ئاق-قارىلىقى"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "چوڭ تېكىست"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+#, fuzzy
+msgid "Enable A_nimations"
+msgstr "ئۇقتۇرۇشلارنى باشقۇرۇش"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "ئېكران ئوقۇغۇچ"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "سەكرىمە كۇنۇپكىلار"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "سىنبەلگە لىپىلداش سۈرئىتى"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+#, fuzzy
+msgid "_Zoom"
+msgstr "كېڭەيت-تارايت"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "ئاڭلاش سېزىمى"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+#, fuzzy
+msgid "_Visual Alerts"
+msgstr "كۆرۈنمە ئاگاھلاندۇرۇش"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "ئېكران ھەرپتاختىسى"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "تەكرار كۇنۇپكا"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "نۇربەلگىنىڭ لىپىلدىشى"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+#, fuzzy
+msgid "_Typing Assist (AccessX)"
+msgstr "كىرگۈزۈش ياردەمچىسى"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "كۆرسىتىش ۋە چېكىش"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "چاشقىنەك كۇنۇپكىلىرى"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "پرىنتېر چىقىرىۋېتىش"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "قوش چېكىش(_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "قوش چېكىش(_D)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "كۆرۈنمە ئاگاھلاندۇرۇش"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "چاقناشنى سىنا(_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+#, fuzzy
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "ئاگاھلاندۇرۇش ئاۋازى يۈز بەرسە كۆرۈنمە ئەسكەرتىشنى كۆرسەت"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "پۈتۈن ئېكراننى چاقنات"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "پۈتۈن ئېكراننى چاقنات"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "پۈتۈن ئېكران"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "ئۈستۈنكى يېرىمى"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "ئاستىنقى يېرىمى"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "سول يېرىمى"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "ئوڭ يېرىمى"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "چوڭايتىش تاللانمىلىرى"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "كېڭەيت-تارايت"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "چوڭايتىش:"
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "چاشقىنەك نۇربەلگىگە ئەگىشىش"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "ئېكران قىسمى:"
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "چوڭايتقۇچنى ئېكران سىرتىغا كېڭەيتىدۇ"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "چوڭايتقۇچنى ئوتتۇرىغا توغرىلايدۇ"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "چوڭايتقۇچ نۇربەلگىسى مەزمۇنلارنى ئەتراپقا ئىتتىرىدۇ"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "چوڭايتقۇچ نۇربەلگىسى مەزمۇنغا ئەگىشىپ يۆتكىلىدۇ"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "چوڭايتىش ئورنى:"
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "چاشقىنەك نۇربەلگىگە ئەگىشىش"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "ئېكران قىسمى:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "چوڭايتقۇچنى ئېكران سىرتىغا كېڭەيتىدۇ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "چوڭايتقۇچنى ئوتتۇرىغا توغرىلايدۇ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "چوڭايتقۇچ نۇربەلگىسى مەزمۇنلارنى ئەتراپقا ئىتتىرىدۇ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "چوڭايتقۇچ نۇربەلگىسى مەزمۇنغا ئەگىشىپ يۆتكىلىدۇ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "چوڭايتقۇچ"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "كرېست:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "چاشقىنەك نۇربەلگىسىنى قەۋەتلەيدۇ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "قېلىنلىقى:"
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "نېپىز"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "توم"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "ئۇزۇنلۇق:"
 
-#: ../panels/universal-access/zoom-options.ui.h:21
-msgid "Color:"
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "رەڭ:"
 
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Crosshairs:"
-msgstr "كرېست:"
-
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Overlaps mouse cursor"
-msgstr "چاشقىنەك نۇربەلگىسىنى قەۋەتلەيدۇ"
-
-#: ../panels/universal-access/zoom-options.ui.h:24
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "كرېست"
 
-#: ../panels/universal-access/zoom-options.ui.h:25
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "رەڭ ئۈنۈملىرى:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "ئاقە ۋە قارا"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "يورۇقلۇق:"
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "سېلىشتۇرما دەرىجە:"
 
-#: ../panels/universal-access/zoom-options.ui.h:29
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "يوق"
 
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "تامامەن"
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "تۆۋەن"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "يۇقىرى"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
-msgid "Color Effects:"
-msgstr "رەڭ ئۈنۈملىرى:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "تۆۋەن"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "يۇقىرى"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "رەڭ ئۈنۈملىرى"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:35
-msgctxt "Account type"
-msgid "Standard"
-msgstr "ئۆلچەملىك"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:37
-msgctxt "Account type"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
+"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;ھەرپتاختا;چاشقىنەك;"
+"ياردەمچى;چوڭلۇقى;چاپلاشقاق كۇنۇپكا;ئاستا كۇنۇپكا;چاشقىنەك كۇنۇپكىسى;"
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "ئىز"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "ئىز"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "يېقىنقى تارىخنى تازىلا(_E)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "ئەخلەتخانىنى پاكىزلاش ۋە ۋاقىتلىق ھۆججەتلەر"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "ئەخلەتخانىنى ئاپتوماتىك تازىلا(_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "ۋاقىتلىق ھۆججەتلەرنى ئاپتوماتىك تازىلا(_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "ئەخلەتخانىنى ئاپتوماتىك تازىلا(_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "ئەخلەتخانا تازىلا(_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "ۋاقىتلىق ھۆججەتلەرنى تازىلا(_F)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+#, fuzzy
+msgid "Add User"
+msgstr "ئىشلەتكۈچى  ھېساباتى قوشۇش"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
 msgid "Administrator"
 msgstr "باشقۇرغۇچى"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
-msgid "Add account"
-msgstr "ھېسابات قوش"
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Local Account"
-msgstr "يەرلىك ھېسابات(_L)"
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "كېيىنكى قېتىم تىزىمغا كىرگەندە تاللا"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-msgid "_Enterprise Login"
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "ھازىر ئىم تەڭشە"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "سەپلەۋاتىدۇ"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
 msgstr "شىركەت ھېساباتى(_E)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-msgid "_Full name"
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "توردا يوق"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "PPD ھۆججىتىنى تاللاش"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "بارماق ئىزىدا تىزىمغا كىرىش(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "بارماق ئىزىدا تىزىمغا كىرىش(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "ياق"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"خەتلەنگەن بارماق ئىزلىرىڭىزنى ئۆچۈرەمسىز؟ بارماق ئىزىدا تىزىمغا كىرىش "
+"چەكلىنىدۇ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "پرىنتېر بايقالمىدى."
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "بارماق ئىزىدا تىزىمغا كىرىش(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "بارماق ئىزىدا تىزىمغا كىرىش(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+#, fuzzy
+msgid "Choose the fingerprint device you want to configure"
+msgstr "سەپلەيدىغان ئۈسكۈنە تاللاش(_H):"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "بارماق ئىزىدا تىزىمغا كىرىش(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "بارماق ئىزلىرىنى ئۆچۈر (_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "بارماق ئىزىدا تىزىمغا كىرىش(_F)"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "ئالدىنقى ھەپتە"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "كېيىنكى ھەپتە"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "بۇ ئىشلەتكۈچىنىڭ ئىمنى ئۆزگەرتىدۇ"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "ئۆزگەرت_A)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "نۆۋەتتىكى ئىم(_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "يېڭى ئىم(_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "ئىم جەزملە(_O)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "ئىم ماسلاشمىدى"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "كېيىنكى قېتىم تىزىمغا كىرگەندە تاللا"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "ھازىر ئىم تەڭشە"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "ئىشلەتكۈچىلەر"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+#, fuzzy
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "ئۆزگىرىشلەرنى ئىناۋەتلىك قىلىش ئۈچۈن چىقىپ كەت"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "ياپ"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
 msgstr "تولۇق ئاتى(_F):"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Account _Type"
-msgstr "ھېسابات تىپ(_T)"
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-msgid "_Domain"
-msgstr "دائىرە(_D)"
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "بارماق ئىزىدا تىزىمغا كىرىش(_F)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Login Name"
-msgstr "كىرىش ئاتى(_L)"
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "ئۆزلۈكىدىن تىزىمغا كىرىش(_U)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "Tip: Enterprise domain or realm name"
-msgstr "ئەسكەرتىش: شىركەت دائىرە ئاتى ياكى realm ئاتى"
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "ھېسابات تىپى(_T)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid "C_ontinue"
-msgstr "داۋاملاشتۇر(_O)"
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "باشقۇرغۇچى"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:14
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "يىراقتا تىزگىنلەش"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "ئىشلەتكۈچى  ھېساباتى چىقىرىۋېتىش"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "باشقا بارماق(_O):"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "سەپلىمە ھۆججەت قوش(_A)…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "ئىشلەتكۈچى سىنبەلگىسى"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "بىر ئىشلەتكۈچى ھېساباتى قۇرىدۇ"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+#, fuzzy
+msgid "Add or remove users and change your password"
+msgstr "ئىشلەتكۈچى قوشىدۇ ياكى ئۆچۈرىدۇ"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "دائىرە باشقۇرغۇچى كىرىش"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here."
-msgstr "شىركەت كىرىشىنى ئىشلىتىش ئۈچۈن، مەزكۇر كومپيۇتېرنى دائىرىگە خەتلىتىش كېرەك. تور باشقۇرغۇچىنىڭ دائىرىدە ئىشلىتىدىغان ئىمىنى كىرگۈزۈڭ."
+msgstr ""
+"شىركەت كىرىشىنى ئىشلىتىش ئۈچۈن، مەزكۇر كومپيۇتېرنى دائىرىگە خەتلىتىش كېرەك. "
+"تور باشقۇرغۇچىنىڭ دائىرىدە ئىشلىتىدىغان ئىمىنى كىرگۈزۈڭ."
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:18
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "باشقۇرغۇچى ئاتى(_N)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "باشقۇرغۇچى ئىمى"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "سول قول باش بارماق"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "سول قول ئوتتۇرا بارماق"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "سول قول نامسىز بارماق"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "سول قول چىمچىلاق"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "ئوڭ قول باش بارماق"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "ئوڭ قول ئوتتۇرا بارماق"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "ئوڭ قول نامسىز بارماق"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "ئوڭ قول چىمچىلاق"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:700
-msgid "Enable Fingerprint Login"
-msgstr "بارماق ئىزىدا تىزىمغا كىرىشنى قوزغات"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "ئوڭ قول كۆرسەتكۈچ بارماق(_R)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "سول قول كۆرسەتكۈچ بارماق(_L)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "باشقا بارماق(_O):"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr "بارماق ئىزىڭىز مۇۋەپپەقىيەتلىك ساقلاندى. ئەمدى بارماق ئىزى ئوقۇغۇچىڭىز ئارقىلىق تىزىمغا كىرەلەيسىز."
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "ئىشلەتكۈچىلەر"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users"
-msgstr "ئىشلەتكۈچى قوشىدۇ ياكى ئۆچۈرىدۇ"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;تىزىمغا كىر;ئات;بارماق ئىزى;سىما;تۇغ;چىراي;ئىم;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:2
-#| msgid "Previous track"
-msgid "Previous Week"
-msgstr "ئالدىنقى ھەپتە"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:3
-#| msgid "Last Week"
-msgid "Next Week"
-msgstr "كېيىنكى ھەپتە"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:4
-#| msgid "Next track"
-msgid "Next week"
-msgstr "كېيىنكى ھەپتە"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Set a password now"
-msgstr "ھازىر ئىم تەڭشە"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-msgid "Choose password at next login"
-msgstr "كېيىنكى قېتىم تىزىمغا كىرگەندە تاللا"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Log in without a password"
-msgstr "ئىمسىز تىزىمغا كىرىدۇ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "Disable this account"
-msgstr "بۇ ھېساباتنى ئىناۋەتسىز قىلىدۇ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "Enable this account"
-msgstr "بۇ ھېساباتنى قوزغات"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "_Hint"
-msgstr "يىپ ئۇچى(_H)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid ""
-"This hint may be displayed at the login screen.  It will be visible to all "
-"users of this system.  Do <b>not</b> include the password here."
-msgstr "بۇ ئەسكەرتىش تىزىمغا كىرىش كۆزنىكىدە كۆرۈنۈشى مۇمكىن. ئۇنى سىستېمىدىكى ھەممە ئىشلەتكۈچى كۆرەلەيدۇ. ئىمنى بۇ جايغا <b>يازماڭ</b>."
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "C_onfirm password"
-msgstr "ئىم جەزملە(_O)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:9
-msgid "_New password"
-msgstr "يېڭى ئىم(_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:10
-msgid "Generate a password"
-msgstr "ئىم ھاسىللاش"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:11
-msgid "Fair"
-msgstr "ياخشىراق"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:12
-msgid "Current _password"
-msgstr "نۆۋەتتىكى ئىم(_P)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:13
-msgid "_Action"
-msgstr "مەشغۇلات(_A)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:14
-msgid "Changing password for"
-msgstr "بۇ ئىشلەتكۈچىنىڭ ئىمنى ئۆزگەرتىدۇ"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:15
-msgid "_Show password"
-msgstr "ئىم كۆرسەت(_S)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:16
-msgid "How to choose a strong password"
-msgstr "كۈچلۈك ئىمنى قانداق تاللاش كېرەك"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:17
-msgid "Ch_ange"
-msgstr "ئۆزگەرت_A)"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:1
-msgid "Changing photo for:"
-msgstr "سۈرەت ئۆزگەرت:"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:2
-msgid ""
-"Choose a picture that will be shown at the login screen for this account."
-msgstr "تىزىمغا كىرىش كۆزنىكىدە مەزكۇر ھېسابات بىلەن بىللە كۆرۈنىدىغان سۈرەتتىن بىرنى تاللاڭ."
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:3
-msgid "Gallery"
-msgstr "سۈرەت يىغقۇچ"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:4
-#: ../panels/user-accounts/um-photo-dialog.c:218
-msgid "Browse for more pictures"
-msgstr "تېخىمۇ كۆپ سۈرەتكە كۆز يۈگۈرت"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:5
-msgid "Take a photograph"
-msgstr "فوتو سۈرەتكە تارت"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:6
-msgid "Browse"
-msgstr "كۆز يۈگۈرت"
-
-#: ../panels/user-accounts/data/photo-dialog.ui.h:7
-msgid "Photograph"
-msgstr "فوتو سۈرەت"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Account Information"
-msgstr "ھېساب ئۇچۇرى"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Add User Account"
-msgstr "ئىشلەتكۈچى  ھېساباتى قوشۇش"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Remove User Account"
-msgstr "ئىشلەتكۈچى  ھېساباتى چىقىرىۋېتىش"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "Login Options"
-msgstr "تىزىمغا كىرىش تاللانمىسى"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "A_utomatic Login"
-msgstr "ئۆزلۈكىدىن تىزىمغا كىرىش(_U)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "_Fingerprint Login"
-msgstr "بارماق ئىزىدا تىزىمغا كىرىش(_F)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "User Icon"
-msgstr "ئىشلەتكۈچى سىنبەلگىسى"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "_Language"
-msgstr "تىل(_L)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "Last Login"
-msgstr "ئەڭ ئاخىرقى قېتىم كىرگەن ۋاقىت"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "ئىشلەتكۈچى ھېساباتىنى باشقۇر"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "ئىشلەتكۈچى سانلىق-مەلۇماتىنى ئۆزگەرتىش ئۈچۈن سالاھىيەت دەلىللەش زۆرۈر"
 
-#: ../panels/user-accounts/pw-utils.c:94
-#: ../panels/user-accounts/um-password-dialog.c:605
-msgctxt "Password strength"
-msgid "Too short"
-msgstr "بەك قىسقا"
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password strength"
-msgid "Not good enough"
-msgstr "تازا ياخشى ئەمەس"
-
-#: ../panels/user-accounts/pw-utils.c:108
-#: ../panels/user-accounts/um-password-dialog.c:606
-msgctxt "Password strength"
-msgid "Weak"
-msgstr "ئاجىز"
-
-#: ../panels/user-accounts/pw-utils.c:111
-#: ../panels/user-accounts/um-password-dialog.c:607
-msgctxt "Password strength"
-msgid "Fair"
-msgstr "ياخشىراق"
-
-#: ../panels/user-accounts/pw-utils.c:114
-#: ../panels/user-accounts/um-password-dialog.c:608
-msgctxt "Password strength"
-msgid "Good"
-msgstr "ياخشى"
-
-#: ../panels/user-accounts/pw-utils.c:117
-#: ../panels/user-accounts/um-password-dialog.c:609
-msgctxt "Password strength"
-msgid "Strong"
-msgstr "كۈچلۈك"
-
-#: ../panels/user-accounts/run-passwd.c:424
-msgid "Authentication failed"
-msgstr "سالاھىيەت دەلىللەش مەغلۇپ بولدى"
-
-#: ../panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The new password is too short"
-msgstr "يېڭى ئىم بەك قىسقا"
-
-#: ../panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password is too simple"
-msgstr "يېڭى ئىم بەك ئاددىي"
-
-#: ../panels/user-accounts/run-passwd.c:516
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "يېڭى ئىم بىلەن كونا ئىم ئوخشىشىپ قالىدىكەن"
-
-#: ../panels/user-accounts/run-passwd.c:519
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "يېڭى ئىم يېقىندا ئىشلىتىلگەن."
-
-#: ../panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "يېڭى ئىم چوقۇم  سان ياكى ئالاھىدە ھەرپلەرنى ئۆز ئىچىگە ئېلىشى لازىم"
-
-#: ../panels/user-accounts/run-passwd.c:526
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "كونا ۋە يېڭى ئىم ئوخشاش"
-
-#: ../panels/user-accounts/run-passwd.c:530
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "تۇنجى قېتىم سالاھىيەت تەكشۈرتكىنىڭىزدىن بۇيان ئىم ئۆزگەرتىلدى!"
-
-#: ../panels/user-accounts/run-passwd.c:534
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "يېڭى ئىم يېتەرلىك پەرقلىق ھەرپلەرنى ئۆز ئىچىگە ئالمىغان"
-
-#: ../panels/user-accounts/run-passwd.c:538
-#, c-format
-msgid "Unknown error"
-msgstr "نامەلۇم خاتالىق"
-
-#: ../panels/user-accounts/um-account-dialog.c:182
-msgid "Failed to add account"
-msgstr "ھېسابات قوشۇش مەغلۇپ بولدى"
-
-#: ../panels/user-accounts/um-account-dialog.c:403
-#: ../panels/user-accounts/um-account-dialog.c:444
-msgid "Failed to register account"
-msgstr "ھېسابات خەتلىتىش مەغلۇپ بولدى"
-
-#: ../panels/user-accounts/um-account-dialog.c:577
-msgid "No supported way to authenticate with this domain"
-msgstr "مەزكۇر دائىرىدە كىملىك دەلىللەشتە قوللىمايدىغان ئۇسۇل"
-
-#: ../panels/user-accounts/um-account-dialog.c:631
-msgid "Failed to join domain"
-msgstr "دائىرىگە قوشۇلۇش مەغلۇپ بولدى"
-
-#: ../panels/user-accounts/um-account-dialog.c:688
-msgid "Failed to log into domain"
-msgstr "دائىرىگە كىرىش مەغلۇپ بولدى"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr "سىزنىڭ بۇ ئۈسكۈنىنى زىيارەت قىلىش ھوقۇقىڭىز يوقكەن. سىستېما باشقۇرغۇچىسى بىلەن ئالاقىلىشىڭ."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "The device is already in use."
-msgstr "ئۈسكۈنە ئىشلىتىلىۋاتىدۇ."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:143
-msgid "An internal error occurred."
-msgstr "ئىچكى خاتالىق يۈز بەردى."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:268
-msgid "Delete registered fingerprints?"
-msgstr "خەتلەنگەن بارماق ئىزلىرىنى ئۆچۈرۈۋېتەمسىز؟"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:272
-msgid "_Delete Fingerprints"
-msgstr "بارماق ئىزلىرىنى ئۆچۈر (_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:279
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr "خەتلەنگەن بارماق ئىزلىرىڭىزنى ئۆچۈرەمسىز؟ بارماق ئىزىدا تىزىمغا كىرىش چەكلىنىدۇ"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:455
-msgid "Done!"
-msgstr "تامام!"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:516
-#: ../panels/user-accounts/um-fingerprint-dialog.c:558
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "‹%s› ئۈسكۈنىنى زىيارەت قىلالمىدى."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:599
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "‹%s› ئۈسكۈنىسىدە بارماق ئىزىغا ئېرىشىشنى باشلىغىلى بولمىدى."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:650
-msgid "Could not access any fingerprint readers"
-msgstr "ھېچقانداق بارماق ئىزى ئوقۇغۇچ ئۈسكۈنىسى بىلەن ئالاقە قىلغىلى بولمىدى."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:651
-msgid "Please contact your system administrator for help."
-msgstr "ياردەمگە ئېرىشىش ئۈچۈن سىستېما باشقۇرغۇچىسى بىلەن ئالاقىلىشىڭ."
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:734
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr "بارماق ئىزى ئارقىلىق تىزىمغا كىرىشنى قوزغىتىش ئۈچۈن، «%s» ئۈسكۈنىسى ئارقىلىق بىر بارمىقىڭىزنىڭ ئۇچۇرىنى ساقلىشىڭىز كېرەك."
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:741
-msgid "Selecting finger"
-msgstr "تاللانغان بارماق"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:742
-msgid "Enrolling fingerprints"
-msgstr "بارماق ئىزى تىزىملىنىۋاتىدۇ"
-
-#: ../panels/user-accounts/um-history-dialog.c:88
-msgid "This Week"
-msgstr "بۇ ھەپتە"
-
-#: ../panels/user-accounts/um-history-dialog.c:91
-msgid "Last Week"
-msgstr "ئۆتكەن ھەپتە"
-
-#: ../panels/user-accounts/um-password-dialog.c:130
-msgid "_Generate a password"
-msgstr "ئىم ھاسىللا(_G)"
-
-#: ../panels/user-accounts/um-password-dialog.c:184
-msgid "Please choose another password."
-msgstr "باشقا ئىم تاللاڭ."
-
-#: ../panels/user-accounts/um-password-dialog.c:193
-msgid "Please type your current password again."
-msgstr "ھازىرقى ئىمنى قايتا كىرگۈزۈڭ."
-
-#: ../panels/user-accounts/um-password-dialog.c:199
-msgid "Password could not be changed"
-msgstr "ئىمنى ئۆزگەرتكىلى بولمىدى"
-
-#: ../panels/user-accounts/um-password-dialog.c:297
-msgid "You need to enter a new password"
-msgstr "يېڭى ئىم كىرگۈزۈشىڭىز زۆرۈر"
-
-#: ../panels/user-accounts/um-password-dialog.c:300
-#| msgid "The new password is too short"
-msgid "The new password is not strong enough"
-msgstr "يېڭى ئىم تازا پۇختا ئەمەس"
-
-#: ../panels/user-accounts/um-password-dialog.c:306
-msgid "You need to confirm the password"
-msgstr "ئىمنى جەزملىشىڭىز زۆرۈر"
-
-#: ../panels/user-accounts/um-password-dialog.c:309
-msgid "The passwords do not match"
-msgstr "ئىم ماسلاشمىدى"
-
-#: ../panels/user-accounts/um-password-dialog.c:315
-msgid "You need to enter your current password"
-msgstr "نۆۋەتتىكى ئىمنى كىرگۈزۈشىڭىز زۆرۈر"
-
-#: ../panels/user-accounts/um-password-dialog.c:318
-msgid "The current password is not correct"
-msgstr "نۆۋەتتىكى ئىم خاتا"
-
-#: ../panels/user-accounts/um-password-dialog.c:385
-msgid "Passwords do not match"
-msgstr "ئىم ماس كەلمىدى"
-
-#: ../panels/user-accounts/um-password-dialog.c:447
-msgid "Wrong password"
-msgstr "ئىم خاتا"
-
-#: ../panels/user-accounts/um-photo-dialog.c:443
-msgid "Disable image"
-msgstr "سۈرەتنى ئىناۋەتسىز قىل"
-
-#: ../panels/user-accounts/um-photo-dialog.c:461
-msgid "Take a photo…"
-msgstr "سۈرەت تارتىش…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:479
-msgid "Browse for more pictures…"
-msgstr "تېخىمۇ كۆپ سۈرەتكە كۆز يۈگۈرت…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:703
-#, c-format
-msgid "Used by %s"
-msgstr "%s ئىشلەتكەن"
-
-#: ../panels/user-accounts/um-realm-manager.c:351
-msgid "Cannot automatically join this type of domain"
-msgstr "بۇ تىپتىكى دائىرىگە ئاپتوماتىك كىرگىلى بولمايدۇ"
-
-#: ../panels/user-accounts/um-realm-manager.c:414
-#, c-format
-msgid "No such domain or realm found"
-msgstr "بۇنداق دائىرە ئاتى ياكى realm نى تاپقىلى بولمىدى"
-
-#: ../panels/user-accounts/um-realm-manager.c:815
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "%s سۈپىتىدە دائىرە %s غا كىرگىلى بولمىدى"
-
-#: ../panels/user-accounts/um-realm-manager.c:820
-msgid "Invalid password, please try again"
-msgstr "ئىم خاتا، قايتا سىناڭ"
-
-#: ../panels/user-accounts/um-realm-manager.c:824
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "دائىرە %s غا باغلانغىلى بولمىدى: %s"
-
-#: ../panels/user-accounts/um-user-panel.c:376
-msgid "Failed to delete user"
-msgstr "ئىشلەتكۈچى ئۆچۈرۈش مەغلۇپ بولدى"
-
-#: ../panels/user-accounts/um-user-panel.c:436
-msgid "You cannot delete your own account."
-msgstr "ئۆزىڭىزنىڭ ھېساباتىنى ئۆچۈرەلمەيسىز."
-
-#: ../panels/user-accounts/um-user-panel.c:445
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s يەنىلا تىزىمدا بار"
-
-#: ../panels/user-accounts/um-user-panel.c:449
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "ئىشلەتكۈچى سىستېمىنى ئىشلىتىۋاتقان ئۇنى ئۆچۈرسە سىستېما مۇقىمسىز ھالەتكە كېلىپ قالىدۇ"
-
-#: ../panels/user-accounts/um-user-panel.c:458
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "%s نىڭ ھۆججىتىنى ساقلاپ قالامسىز؟"
-
-#: ../panels/user-accounts/um-user-panel.c:462
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr "ئىشلەتكۈچى ھېساباتىنى ئۆچۈرگەندە ماكان مۇندەرىجە، ئېلخەت مۇندەرىجە ۋە ۋاقىتلىق ھۆججەتنى ساقلاپ قېلىشقا بولىدۇ."
-
-#: ../panels/user-accounts/um-user-panel.c:465
-msgid "_Delete Files"
-msgstr "ھۆججەت ئۆچۈر(_D)"
-
-#: ../panels/user-accounts/um-user-panel.c:466
-msgid "_Keep Files"
-msgstr "ھۆججەتنى ساقلاپ قال(_K)"
-
-#: ../panels/user-accounts/um-user-panel.c:518
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "ھېسابات چەكلەنگەن"
-
-#: ../panels/user-accounts/um-user-panel.c:526
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "كېيىنكى قېتىم تىزىمغا كىرگەندە تەڭشە"
-
-#: ../panels/user-accounts/um-user-panel.c:529
-msgctxt "Password mode"
-msgid "None"
-msgstr "يوق"
-
-#: ../panels/user-accounts/um-user-panel.c:578
-msgid "Logged in"
-msgstr "كىرگەن"
-
-#: ../panels/user-accounts/um-user-panel.c:941
-msgid "Failed to contact the accounts service"
-msgstr "ھېسابات مۇلازىمېتىرى بىلەن ئالاقىلىشىش مەغلۇپ بولدى"
-
-#: ../panels/user-accounts/um-user-panel.c:943
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "AccountService توغرا ئورنىتىلىپ قوزغىتىلغانلىقىنى جەزملەڭ."
-
-#: ../panels/user-accounts/um-user-panel.c:984
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr "ئۆزگەرتىشتە،\n"
-"ئالدى بىلەن * سىنبەلگىنى چېكىڭ"
-
-#: ../panels/user-accounts/um-user-panel.c:1022
-msgid "Create a user account"
-msgstr "بىر ئىشلەتكۈچى ھېساباتى قۇرىدۇ"
-
-#: ../panels/user-accounts/um-user-panel.c:1033
-#: ../panels/user-accounts/um-user-panel.c:1319
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr "ئىشلەتكۈچى ھېساباتى قۇرۇش ئۈچۈن،\n"
-"ئالدى بىلەن * سىنبەلگىسىنى چېكىڭ"
-
-#: ../panels/user-accounts/um-user-panel.c:1042
-msgid "Delete the selected user account"
-msgstr "تاللانغان ئىشلەتكۈچى ھېساباتىنى ئۆچۈرىدۇ"
-
-#: ../panels/user-accounts/um-user-panel.c:1054
-#: ../panels/user-accounts/um-user-panel.c:1324
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr "تاللانغان ئىشلەتكۈچى ھېساباتىنى ئۆچۈرۈش ئۈچۈن،\n"
-"ئالدى بىلەن * سىنبەلگىسىنى چېكىڭ"
-
-#: ../panels/user-accounts/um-user-panel.c:1228
-msgid "My Account"
-msgstr "ھېساباتىم"
-
-#: ../panels/user-accounts/um-user-panel.c:1237
-msgid "Other Accounts"
-msgstr "باشقا ھېساباتلار"
-
-#: ../panels/user-accounts/um-utils.c:516
-#, c-format
-msgid "A user with the username '%s' already exists"
-msgstr "‹%s› ئاتلىق ئىشلەتكۈچىدىن بىرى مەۋجۇت"
-
-#: ../panels/user-accounts/um-utils.c:520
-#, c-format
-msgid "The username is too long"
-msgstr "ئىشلەتكۈچى ئاتى بەك ئۇزۇن"
-
-#: ../panels/user-accounts/um-utils.c:523
-msgid "The username cannot start with a '-'"
-msgstr "ئىشلەتكۈچى ئاتى '-' ھەرپتىن باشلانمايدۇ"
-
-#: ../panels/user-accounts/um-utils.c:526
-msgid ""
-"The username must only consist of:\n"
-" ➣ letters from the English alphabet\n"
-" ➣ digits\n"
-" ➣ any of the characters '.', '-' and '_'"
-msgstr "ئىشلەتكۈچى ئاتىنىڭ تەركىبىدە بولىدىغىنى:\n"
-"  ئىنگلىزچە ئېلىپبەدىكى ھەرپلەر ➣\n"
-"  رەقەملەر ➣ \n"
-"  \"-\" خالىغان ھەرپ \".\"، \"_\"  ۋە ➣"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "خەرىتە توپچىلار"
 
-#: ../panels/wacom/button-mapping.ui.h:2
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "خەرىتە توپچىلار ئىقتىدارى"
 
-#: ../panels/wacom/calibrator/gui_gtk.c:79
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"تېزلەتمىنى تەھرىرلەشتە، مۇناسىپ قۇرنى تاق چېكىپ ئاندىن يېڭى تېزلەتمە "
+"كىرگۈزۈلىدۇ ياكى backspace ئۆچۈرۈش كۇنۇپكىسىدا تازىلىنىدۇ."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "ياپ(_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr "ئېكراندا كۆرۈنگەن نىشاننى چېكىپ تاختىنى توغرىلاڭ."
 
-#: ../panels/wacom/calibrator/gui_gtk.c:368
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "خاتا چېكىش بايقالدى، قايتا قوزغىتىۋاتىدۇ…"
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Output:"
-msgstr "چىقار:"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
+msgstr "مەۋھۇم ئۈسكۈنە قۇر"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:287
-msgid "Keep aspect ratio (letterbox):"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "سەزگۈر تاختا"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "سول قول يۆنىلىش"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "كۆزەتكۈچكە خەرىتىلەش…"
+
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
 msgstr "كەڭلىك ۋە ئېگىزلىكنىڭ نىسبىتى ئۆزگەرمىسۇن(letterbox):"
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:298
-msgid "Map to single monitor"
-msgstr "يەككە كۆزەتكۈچكە خەرىتىلە"
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-nav-button.c:89
-#, c-format
-msgid "%d of %d"
-msgstr "%d / %d"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "تۈزەت…"
 
-#: ../panels/wacom/cc-wacom-page.c:118 ../panels/wacom/cc-wacom-page.c:384
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "يوق"
-
-#: ../panels/wacom/cc-wacom-page.c:119
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "كۇنۇپكا بېسىلىشىنى يوللاش"
-
-#: ../panels/wacom/cc-wacom-page.c:120
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "ئېكران ئالماشتۇرۇش"
-
-#: ../panels/wacom/cc-wacom-page.c:121
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "ئېكران ئۈستى ياردىمىنى كۆرسەت"
-
-#: ../panels/wacom/cc-wacom-page.c:621
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "ئۈستى"
-
-#: ../panels/wacom/cc-wacom-page.c:621
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "ئاستى"
-
-#: ../panels/wacom/cc-wacom-page.c:662
-msgid "Switch Modes"
-msgstr "ئالماشتۇرۇش ھالىتى"
-
-#: ../panels/wacom/cc-wacom-page.c:752
-#: ../panels/wacom/cc-wacom-stylus-page.c:373
-msgid "Button"
-msgstr "توپچا"
-
-#: ../panels/wacom/cc-wacom-page.c:810
-msgid "Action"
-msgstr "مەشغۇلات"
-
-#: ../panels/wacom/cc-wacom-page.c:920
-msgid "Display Mapping"
-msgstr "خەرىتە كۆرسەت"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr "Wacom Tablet"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set your Wacom tablet preferences"
-msgstr "Wacom tablet نىڭ مايىللىقىنى تەڭشەيدۇ"
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "Tablet;Wacom;قەلەم;ئۆچۈرگۈچ;چاشقىنەك;"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "Tablet (مۇتلەق)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "سېزىمچان تاختا (نىسپىي)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "Tablet مايىللىقى"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "tablet بايقالمىدى"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "Wacom tablet نى چېتىڭ ياكى توكىنى ئېچىڭ."
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr "كۆكچىش تەڭشىكى"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Map to Monitor…"
-msgstr "كۆزەتكۈچكە خەرىتىلەش…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map Buttons…"
-msgstr "خەرىتە توپچىلار…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr "كۆرسىتىش ئېنىقلىقىنى تەڭشەيدۇ"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Tracking Mode"
-msgstr "ئىزلاش ھالىتى"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Left-Handed Orientation"
-msgstr "سول قول يۆنىلىش"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1076
-msgid "Left Ring"
-msgstr "سول نامسىز بارماق"
-
-#: ../panels/wacom/gsd-wacom-device.c:1086
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "سول نامسىز بارماق ھالىتى #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1105
-msgid "Right Ring"
-msgstr "ئوڭ نامسىز بارماق"
-
-#: ../panels/wacom/gsd-wacom-device.c:1115
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "ئوڭ نامسىز بارماق ھالىتى #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1156
-msgid "Left Touchstrip"
-msgstr "سول Touchstrip"
-
-#: ../panels/wacom/gsd-wacom-device.c:1166
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "سول Touchstrip ھالىتى #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1185
-msgid "Right Touchstrip"
-msgstr "ئوڭ Touchstrip"
-
-#: ../panels/wacom/gsd-wacom-device.c:1195
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "ئوڭ Touchstrip ھالىتى #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1220
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "سول Touchstrip ھالەت ئالماشتۇرغۇچ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1222
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "ئوڭ Touchstrip ھالەت ئالماشتۇرغۇچ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1225
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "سول Touchstrip ھالەت ئالماشتۇرغۇچ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1227
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "ئوڭ Touchstrip ھالەت ئالماشتۇرغۇچ"
-
-#: ../panels/wacom/gsd-wacom-device.c:1232
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "ھالەت ئۈزچاتى #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1336
-#, c-format
-msgid "Left Button #%d"
-msgstr "سول توپچا #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1339
-#, c-format
-msgid "Right Button #%d"
-msgstr "ئوڭ توپچا #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1342
-#, c-format
-msgid "Top Button #%d"
-msgstr "ئۈستى توپچا #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1345
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "ئاستى توپچا #%d"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "مەشغۇلات يوق"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "چاشقىنەك سول توپچىسىنىڭ چېكىلىشى"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "چاشقىنەك ئوتتۇرا توپچىسىنىڭ چېكىلىشى"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "چاشقىنەك ئوڭ توپچىسىنىڭ چېكىلىشى"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "ئۈستىگە سىيرىش"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "ئاستىغا سىيرىش"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "سولغا سۈر"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "ئوڭغا سۈر"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "كەينى"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "ئالدى"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "قەلەم"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "ئۆچۈرگۈچ بېسىم سەزگۈسى"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "يۇمشاق"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "قاتتىق"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "ئۈستى توپچا"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "تۆۋەندىكى توپچا"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "قەلەم ئۇچىنىڭ بېسىش سېزىمى"
 
-#: ../shell/control-center.c:66
-msgid "Enable verbose mode"
-msgstr "تەپسىلىي ھالەتنى قوزغات"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "يۇمشاق"
 
-#: ../shell/control-center.c:67
-msgid "Show the overview"
-msgstr "ئۈزۈندىنى كۆرسەت"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
 
-#: ../shell/control-center.c:68
-msgid "Search for the string"
-msgstr "بۇ تېكىستنى ئىزدە"
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "قاتتىق"
 
-#: ../shell/control-center.c:69
-msgid "List possible panel names and exit"
-msgstr "تىزغىلى بولىدىغان تاختا(panel) ئاتلىرىنى تىزىپ ئاخىرلاشتۇرىدۇ"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "توپچا"
 
-#: ../shell/control-center.c:70 ../shell/control-center.c:71
-#: ../shell/control-center.c:72
-msgid "Show help options"
-msgstr "ياردەم تاللانمىلىرىنى كۆرسەت"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "توپچا"
 
-#: ../shell/control-center.c:73
-msgid "Panel to display"
-msgstr "كۆرسىتىدىغان تاختا"
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "توپچا"
 
-#: ../shell/control-center.c:73
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "ئۆچۈرگۈچ بېسىم سەزگۈسى"
 
-#: ../shell/control-center.c:95
-msgid "- Settings"
-msgstr "- تەڭشەكلەر"
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "ئۆچۈرگۈچ بېسىم سەزگۈسى"
 
-#: ../shell/control-center.c:103
-#, c-format
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "چاشقىنەك ئوتتۇرا توپچىسىنىڭ چېكىلىشى"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "چاشقىنەك ئوڭ توپچىسىنىڭ چېكىلىشى"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "ئالدى"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;قەلەم;ئۆچۈرگۈچ;چاشقىنەك;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "ئۇسلۇب"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
 msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
-msgstr "%s\n"
-"'%s --help' ئىجرا قىلىپ بۇيرۇق قۇرىنىڭ تولۇق تاللانما تىزىمىنى كۆرۈڭ.\n"
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: ../shell/control-center.c:133
-msgid "Available panels:"
-msgstr "ئىشلەتكىلى بولىدىغان تاختىلار:"
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
 
-#: ../shell/control-center.c:244
-msgid "Help"
-msgstr "ياردەم"
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "تەقلىدلىك ئىككىنچى چېكىش"
 
-#: ../shell/control-center.c:245
-msgid "Quit"
-msgstr "ئاخىرلاشتۇر"
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "ۋىندوۋس يۇمشاق دېتاللىرى"
 
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "باشقۇرۇش مەركىزى"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
 
-#. Add categories
-#: ../shell/gnome-control-center.c:887
-msgctxt "category"
-msgid "Personal"
-msgstr "شەخسىي"
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "كۇكۇن ئاز قالدى"
 
-#: ../shell/gnome-control-center.c:888
-msgctxt "category"
-msgid "Hardware"
-msgstr "قاتتىق دېتال"
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "ئىككىنچى چېكىشنى كېچىكتۈرۈش"
 
-#: ../shell/gnome-control-center.c:889
-msgctxt "category"
-msgid "System"
-msgstr "سىستېما"
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "ۋىندوۋس يۇمشاق دېتاللىرى"
 
-#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
-msgid "Settings"
-msgstr "تەڭشەكلەر"
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
-msgid "Preferences;Settings;"
-msgstr "Preferences;Settings;مايىللىق;تەڭشەكلەر;"
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
-#: ../shell/shell.ui.h:2
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "قوش"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "تەپسىلاتلار"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "تور ۋاقتى(_N):"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "تور تەڭشەك"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "سانلار"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "ئۈسكۈنە تىپلىرى"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "ياسىغۇچى سودىگەر"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "مۇقىم دېتال كەم"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+#, fuzzy
+msgid "SIM Locked"
+msgstr "قۇلۇپلانغان"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "كۆچمە كەڭ بەلۋاغ(_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "تور ۋاقتى(_N):"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "تور"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "ئالىي"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "كىرىش ئاتى(_L)"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "قۇلۇپلا"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "تەپسىلاتلار"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "تور ئاتى"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "ئاپتوماتىك"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "ئۆيۈمدىكى تور"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "ھەرپتاختىسى ئارقىلىق ئىناۋەتلىك قىلسۇن"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "كۆكچىش ماسلاشتۇرغۇچىسى تېپىلمىدى"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "ئايروپىلان ھالىتى(_P)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "باغلىنىش"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM كارتىسى سېلىنمىغان"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "قۇلۇپلا"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "ئۆزگەرت_A)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "ئۆيۈمدىكى تور"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "يېڭى قوزغاتقۇنى تەڭشەۋاتىدۇ…"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "شەخسىيەت"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "بارلىق تەڭشەكلەر"
 
-#~| msgid "Paired"
-#~ msgid "Wired"
-#~ msgstr "سىملىق"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "ئاساسىي توپچا(_B)"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "ياردەم"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "ئادەتتىكى"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "ئاخىرلاشتۇر"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "ئىزدە"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "ئالدىنقى مەنبەگە ئالماشتۇر"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "قالدۇرۇۋېتىلدى"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;مايىللىق;تەڭشەكلەر;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u چىقىرىلما"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u كىرگۈزۈلمە"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "بىر كۈن ئىچىدە ئۈزلۈكسىز ئالماشتۇرىدۇ"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "ياي"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "كېڭەيت-تارايت"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "مەركەز"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "تولدۇر"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "ئارىلىق"
+
+#~ msgid "Select Background"
+#~ msgstr "تەگلىك تاللا"
+
+#~ msgid "Pictures"
+#~ msgstr "سۈرەتلەر"
+
+#~ msgid "Colors"
+#~ msgstr "رەڭلەر"
+
+#~ msgid "multiple sizes"
+#~ msgstr "كۆپ خىل چوڭلۇق"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "ئۈستەلئۈستى تەگلىك يوق"
+
+#~ msgid "Current background"
+#~ msgstr "نۆۋەتتىكى تەگلىك"
+
+#~ msgid "Change the background"
+#~ msgstr "تەگلىكنى ئۆزگەرتىدۇ"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Wallpaper;Screen;Desktop;تام قەغىزى;ئېكران;ئۈستەلئۈستى;"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "كۆكچىش"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "يېڭى ئۈسكۈنە تەڭشىكى"
+
+#~ msgid "page 1"
+#~ msgstr "1-بەت"
+
+#~ msgid "page 2"
+#~ msgstr "2-بەت"
+
+#~ msgid "Paired"
+#~ msgstr "جۈپلەنگەن"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "چاشقىنەك ۋە سېزىمچان تاختا تەڭشىكى"
+
+#~ msgid "Send Files…"
+#~ msgstr "ھۆججەت يوللاش…"
+
+#~ msgid "Yes"
+#~ msgstr "ھەئە"
+
+#, c-format
+#~ msgid "Visibility of “%s”"
+#~ msgstr "«%s» نىڭ كۆرۈنۈشچانلىقى"
+
+#, c-format
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "‹%s› نى ئۈسكۈنە تىزىمىدىن ئۆچۈرسۇنمۇ؟"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr ""
+#~ "ئەگەر سىز بۇ ئۈسكىنىنى ئۆچۈرۈۋەتسىڭىز،كىيىن ئىشلەتكەندە قايتا تەڭشەش "
+#~ "زۆرۈر بولىدۇ."
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "تەڭشەيدىغان  ئۈسكۈنىنى تىك تۆتبۇلۇڭ ئۈستىگە قويۇپ ‹باشلا› نى بېسىڭ"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr ""
+#~ "تەڭشەيدىغان ئۈسكۈنىنى تەڭشەيدىغان ئورۇنغا يۆتكەپ ‹داۋاملاشتۇر› نى بېسىڭ"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr ""
+#~ "تەڭشەيدىغان ئۈسكۈنىنى سىرتقى يۈزدىكى ئورۇنغا يۆتكەپ ‹داۋاملاشتۇر› نى بېسىڭ"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "يان كومپيۇتېرنىڭ قېپىنى يېپىڭ"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "ئىچكى خاتالىق كۆرۈلۈپ، ئەسلىگە كەلتۈرگىلى بولمىدى."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "تەڭشەشكە زۆرۈر بولغان قوراللار ئورنىتىلماپتۇ."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "بۇ profile نى قۇرغىلى بولمىدى."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "نىشاندىكى ئاق نۇقتىغا ئېرىشكىلى بولمايدۇ."
+
+#~ msgid "Complete!"
+#~ msgstr "تامام!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "تەڭشەش مەغلۇپ بولدى!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "تەڭشەيدىغان ئۈسكۈنىنى چىقىرىۋەتسىڭىز بولمايدۇ."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "بىر تەرەپ قىلىۋاتقاندا تەڭشەيدىغان ئۈسكۈنىگە دەخلى قىلماڭ"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s ئېكران"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s شويلىلىغۇچ"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s پرىنتېر"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s تور كامېراسى"
+
+#, c-format
+#~| msgid "Learn more about color management"
+#~ msgid "Enable color management for %s"
+#~ msgstr "%s نىڭ نىسبەتەن رەڭ باشقۇرۇشىنى ئىناۋەتلىك قىل"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "%s نىڭ رەڭ profiles نى كۆرسەت"
+
+#~ msgid "Not calibrated"
+#~ msgstr "تەڭشەلمىگەن"
+
+#~ msgid "Default: "
+#~ msgstr "كۆڭۈلدىكى: "
+
+#~ msgid "Test profile: "
+#~ msgstr "سىناق سەپلىمە ھۆججەت: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "ICC سەپلىمە ھۆججەتنى تاللايدۇ"
+
+#~ msgid "_Import"
+#~ msgstr "ئىمپورت قىل(_I)"
+
+#~ msgid "All files"
+#~ msgstr "ھەممە ھۆججەتلەر"
+
+#~ msgid "Save Profile"
+#~ msgstr "Profile نى ساقلاش"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "تاللانغان ئۈسكۈنە ئۈچۈن بىر رەڭ سەپلىمە ھۆججىتى قۇرىدۇ"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "تەكشۈرىدىغان چالغۇ بايقالمىدى. ئۇنىڭ ئېچىلىپ توغرا باغلانغانلىقىنى "
+#~ "تەكشۈرۈڭ."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "تەكشۈرىدىغان چالغۇ پرىنتېر سەپلىمە ھۆججىتىنى قوللىمايدۇ."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "بۇ خىل ئۈسكۈنە تىپىنى نۆۋەتتە قوللىمايدۇ."
+
+#~ msgid "Standard Space"
+#~ msgstr "ئۆلچەملىك بوشلۇق"
+
+#~ msgid "Test Profile"
+#~ msgstr "سىناق سەپلىمە ھۆججەت(Profile)"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "ئاپتوماتىك"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "سۈپىتى تۆۋەن"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "سۈپىتى نورمال"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "سۈپىتى يۇقىرى"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "كۆڭۈلدىكى RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "كۆڭۈلدىكى CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "كۆڭۈلدىكى كۈلرەڭلىك"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "ياسىغۇچى ئورۇن تەمىنلىگەن ئەسلىدىكى تەڭشەش سانلىق-مەلۇماتلار"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "بۇ profile دا تولۇق ئېكراننى تەڭشەشكە مۇمكىن بولمايدۇ"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "مەزكۇر profile ئەمدى توغرا بولماسلىقى مۇمكىن"
+
+#~ msgid "Export"
+#~ msgstr "ئېكسپورت قىلىش"
+
+#~ msgid "Device type:"
+#~ msgstr "ئۈسكۈنە تىپى:"
+
+#~ msgid "Manufacturer:"
+#~ msgstr "ياسىغۇچى:"
+
+#~ msgid "Model:"
+#~ msgstr "تىپى:"
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr ""
+#~ "سۈرەت ھۆججەتنى بۇ كۆزنەككە سۆرەپ ئۈستىدىكى سۆز بۆلەكلىرىنى ئۆزلۈكىدىن "
+#~ "تولدۇرغىلى بولىدۇ."
+
+#~ msgid "Color management settings"
+#~ msgstr "رەڭ باشقۇرۇش تەڭشىكى"
+
+#~ msgid "British English"
+#~ msgstr "ئەنگلىيە ئىنگلىزچە"
+
+#~ msgid "Spanish"
+#~ msgstr "ئىسپانچە"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "ئاددىي خەنزۇچە"
+
+#~ msgid "United States"
+#~ msgstr "ئامېرىكا قوشما شتاتلىرى"
+
+#~ msgid "Germany"
+#~ msgstr "گېرمانىيە"
+
+#~ msgid "Spain"
+#~ msgstr "ئىسپانىيە"
+
+#~ msgid "China"
+#~ msgstr "جۇڭگو"
+
+#~ msgid "Other…"
+#~ msgstr "باشقا…"
+
+#~ msgid "Select a region"
+#~ msgstr "رايون تاللاڭ"
+
+#~ msgid "_Region:"
+#~ msgstr "رايون(_R):"
+
+#~ msgid "_City:"
+#~ msgstr "شەھەر(_C):"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "ۋاقىتنى بىر سائەت ئىلگىرى تەڭشەيدۇ."
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "ۋاقىتنى بىر سائەت كېيىن تەڭشەيدۇ."
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "ۋاقىتنى بىر مىنۇت ئىلگىرى تەڭشەيدۇ."
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "ۋاقىتنى بىر مىنۇت كېيىن تەڭشەيدۇ."
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "چۈشتىن بۇرۇن بىلەن چۈشتىن كېيىن ئارىسىدا ئالماشتۇرىدۇ."
+
+#~ msgid "24-hour"
+#~ msgstr "24 سائەت"
+
+#~ msgid "AM/PM"
+#~ msgstr "چ ب/چ ك"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "چېسلا ۋە ۋاقىت مايىللىق تاختىسى"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "نورمال"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "سائەت يۆنىلىشىگە قارشى"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "سائەت يۆنىلىشى"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 گرادۇس"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr ""
+#~ "كۆزەتكۈچتىن بىرنى تاللاپ خاسلىقى ئۆزگەرتىلىدۇ؛ سۆرەپ ئۇلارنىڭ ئورنى "
+#~ "تەڭشىلىدۇ."
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "%a %l:%M %p"
+#~ msgstr "%p%l:%M (%a)"
+
+#, c-format
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "سەپلىمىنى قوللىنالمىدى: %s"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "كۆزەتكۈچ تەڭشەكلىرىنى ساقلىغىلى بولمىدى"
+
+#~ msgid "Could not detect displays"
+#~ msgstr "كۆرسەتكۈچلەر بايقالمىدى"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "ئېكران ئۇچۇرىغا ئېرىشكىلى بولمىدى"
+
+#~ msgid "_Resolution"
+#~ msgstr "ئېنىقلىقى(_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "چۆرگىلىتىش(_O)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "نۇسخىلانغان كۆرسەتكۈچلەر(_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "ئىزاھات: ئېنىقلىق نىسبىتى تاللانمىسىنى چەكلىمىگە ئۇچرىشى مۇمكىن"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "كۆرسەتكۈچلەرنى بايقا(_D)"
+
+#~ msgid "Unknown"
+#~ msgstr "نامەلۇم"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-بىت"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d-بىت"
+
+#~ msgid "Ask what to do"
+#~ msgstr "مەشغۇلاتنى سورا"
+
+#~ msgid "Do nothing"
+#~ msgstr "ھېچقانداق قىلما"
+
+#~ msgid "Open folder"
+#~ msgstr "قىسقۇچ ئاچ"
+
+#~ msgid "Other Media"
+#~ msgstr "باشقا ۋاسىتە"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "ئۈن CD ئۈچۈن پروگرامما تاللاڭ"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "سىن CD ئۈچۈن پروگرامما تاللاڭ"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "مۇزىكا قويغۇ باغلانغاندا ئىجرا بولىدىغان پروگراممىنى تاللايدۇ"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "كامېرا باغلانغاندا ئىجرا بولىدىغان پروگراممىنى تاللايدۇ"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "يۇمشاق دېتال CD سى ئۈچۈن پروگرامما تاللاڭ"
+
+#~ msgid "audio DVD"
+#~ msgstr "ئۈن DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "قۇرۇق كۆكنۇر دىسكىسى"
+
+#~ msgid "blank CD disc"
+#~ msgstr "قۇرۇق CD دىسكىسى"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "قۇرۇق DVD دىسكىسى"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "قۇرۇق HD DVD دىسكىسى"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "كۆكنۇر سىن دىسكىسى"
+
+#~ msgid "e-book reader"
+#~ msgstr "ئې-كىتاب ئوقۇغۇ"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD سىن دىسكىسى :"
+
+#~ msgid "Picture CD"
+#~ msgstr "سۈرەت CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "ئالاھىدە سىن CD"
+
+#~ msgid "Video CD"
+#~ msgstr "سىن CD"
+
+#~ msgid "Overview"
+#~ msgstr "قىسقىچە بايان"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "نەشر %s"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "سىستېما ئەڭ يېڭى ھالەتتە"
+
+#~ msgid "Checking for Updates"
+#~ msgstr "يېڭىلانمىلارنى تەكشۈرۈۋاتىدۇ"
+
+#~ msgid "System Information"
+#~ msgstr "سىستېما ئۇچۇرى"
+
+#~ msgid "Base system"
+#~ msgstr "ئاساسى سىستېما"
+
+#~ msgid "Disk"
+#~ msgstr "دىسكا"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "ئېكران كۆرۈنۈشىنى $PICTURES غا ساقلايدۇ"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "كۆزنەكنىڭ ئېكران كۆرۈنۈشىنى $PICTURES غا ساقلايدۇ"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "رايوننىڭ ئېكران كۆرۈنۈشىنى $PICTURES غا ساقلايدۇ"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "بىر ئېكران كۆرۈنۈشىنى چاپلاش تاختىسىغا كۆچۈرىدۇ"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "بىر كۆزنەكنىڭ ئېكران كۆرۈنۈشىنى چاپلاش تاختىسىغا كۆچۈرىدۇ"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "بىر دائىرىنىڭ ئېكران كۆرۈنۈشىنى چاپلاش تاختىسىغا كۆچۈرىدۇ"
+
+#~ msgid "Left Shift"
+#~ msgstr "سول Shift"
+
+#~ msgid "Left Alt"
+#~ msgstr "سول Alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "سول Ctrl"
+
+#~ msgid "Right Shift"
+#~ msgstr "ئوڭ Shift"
+
+#~ msgid "Right Alt"
+#~ msgstr "ئوڭ Alt"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "ئوڭ Ctrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "سول Alt+Shift"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "ئوڭ Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "سول Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "ئوڭ Ctrl+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "سول+ئوڭ Shift"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "سول+ئوڭ Alt"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "سول+ئوڭ Ctrl"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "Caps"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "ھەرپتاختا تەڭشىكىنى ئۆزگەرت"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;قىسقا يول;تەكرارلاش;چاقناش;"
+
+#~ msgid "_Delay:"
+#~ msgstr "كېچىكتۈر(_D):"
+
+#~ msgid "_Speed:"
+#~ msgstr "سۈرئەت(_S):"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "ئاستا"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "تېز"
+
+#~ msgid "S_peed:"
+#~ msgstr "سۈرئىتى(_P):"
+
+#~ msgid "Layout Settings"
+#~ msgstr "جايلاشتۇر تەڭشىكى"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "قىسقا يولنى چىقىرىۋەت"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<نامەلۇم مەشغۇلات>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "تېزلەتمە «%s» ئىشلەتكىلى بولمايدۇ، چۈنكى ئۇنى ئىشلەتكەندە كىرگۈزگىلى "
+#~ "بولمايدۇ، بىرلا ۋاقىتتا Control ، Alt ياكى Shift نى ئىشلىتىشنى سىناڭ."
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr "«%s» تېزلەتمە «%s» غا ئىشلىتىلگەن"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "ئەگەر تېزلەتمىنى «%s»غا بەلگىلىسىڭىز،  «%s» نىڭ تېزلەتمە چەكلىنىدۇ."
+
+#~ msgid "_Reassign"
+#~ msgstr "قايتا تەيىنلە(_R)"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "چاشقىنەك ۋە سېزىمچان تاختا مايىللىقىنى تەڭشەيدۇ"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "چاشقىنەك مايىللىقى"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "ئاستا"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "قوش چېكىش مۆھلىتى"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "تېز"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "سول(_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "ئوڭ(_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "كۆرسەتكۈچنىڭ تېزلىكى(_P)"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "ئىككى بارماقتا سىيرىسۇن(_F)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "بەش قېتىم چېكىلدى، GEGL ۋاقتى"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "قوش چېكىش، ئاساسىي توپچا"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "يەككە چېكىش، ئاساسىي توپچا"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "قوش چېكىش، ئوتتۇرا توپچا"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "يەككە چېكىش، ئوتتۇرا توپچا"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "قوش چېكىش، ئىككىنچى توپچا"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "يەككە چېكىش، ئىككىنچى توپچا"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr ""
+#~ "سىستېمىنىڭ تور مۇلازىمىتى بۇ نەشرىدىكى تور باشقۇرغۇچ بىلەن ماسلاشمايدۇ."
+
+#~ msgid "automatic"
+#~ msgstr "ئاپتوماتىك"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "كارخانا"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "يوق"
+
+#~ msgid "Never"
+#~ msgstr "ھەرگىز"
+
+#~ msgid "Today"
+#~ msgstr "بۈگۈن"
+
+#~ msgid "Yesterday"
+#~ msgstr "تۈنۈگۈن"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d مېگابايت/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "يوق"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "ئاجىز"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "تامام"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "ياخشى"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "ناھايىتى ياخشى"
+
+#~ msgid "Identity"
+#~ msgstr "سالاھىيەت"
+
+#~ msgid "Server"
+#~ msgstr "مۇلازىمېتىر"
+
+#~| msgid "Delete device"
+#~ msgid "Delete DNS Server"
+#~ msgstr "DNS مۇلازىمېتىرنى ئۆچۈرۈش"
+
+#~| msgid "Default Route"
+#~ msgid "Delete Route"
+#~ msgstr "يولنى(Route) ئۆچۈرۈش"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "يوق"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128 بىتلىق ئاچقۇچ(16لىك ياكى ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128 بىتلىق شىفىر"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "دىنامىكىلىق WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA ۋە WPA2 كىشىلىك نۇسخىسى"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA ۋە WPA2 كارخانا نۇسخىسى"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "قوش پىلاستىك لىنىيە (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "قوشۇلما بۆلۈم ئارايۈزى(AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "ۋاسىتە مۇستەقىل ئارايۈزى(MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 مېگابايت/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 مېگابايت/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 گىگابايت/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 گىگابايت/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "باشقا ئىشلەتكۈچىلەرمۇ ئىشلىتەلەيدىغان بولسۇن(_U)"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "باغلىنىش تەھرىرلىگۈچىنى ئاچقىلى بولمىدى"
+
+#~ msgid "New Profile"
+#~ msgstr "يېڭى سەپلىمە ھۆججەت"
+
+#~ msgid "Bridge"
+#~ msgstr "كۆۋرۈك"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "ۋ پ ن(VPN) قىستۇرمىلىرىنى ئوقۇغىلى بولمىدى"
+
+#~ msgid "Import from file…"
+#~ msgstr "ھۆججەتتىن ئەكىر…"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "تور باغلىنىشى قوشۇش"
+
+#~ msgid "_Reset"
+#~ msgstr "ئەسلىگە قايتۇر(_R)"
+
+#~ msgid "_Forget"
+#~ msgstr "ئۇنتۇپ كەت(_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "مەزكۇر تورنىڭ تەڭشەكلىرىنى ئەسلىگە قايتۇرىدۇ، بىراق ئۇنى ئالدى بىلەن "
+#~ "ئۇلىنىدىغان تور قىلىپ ئەستە تۇتىدۇ"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "مەزكۇر تورغا مۇناسىۋەتلىك بولغان بارلىق تەپسىلاتلارنى ئۆچۈرىدۇ ۋە "
+#~ "ئۇنىڭغا  ئاپتوماتىك ئۇلانمايدىغان بولىدۇ"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "VPN باغلىنىشىنى ئىمپورت قىلالمىدى"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "‹%s› ھۆججىتىنى ئوقۇيالمىدى ياكى تونۇلغان VPN باغلىنىش ئۇچۇرىنى ئۆز ئىچىگە "
+#~ "ئالمىغان\n"
+#~ "\n"
+#~ "خاتالىق: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "ئىمپورت قىلىدىغان ھۆججەتنى تاللا"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "«%s» ئاتلىق بىر ھۆججەت ئەزەلدىن مەۋجۇت."
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "سىز ساقلىغان %s نى VPN باغلىنىشىغا ئالماشتۇرامسىز؟"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "ۋ پ ن (VPN)  باغلىنىشىنى ئېكسپورت قىلغىلى بولمىدى"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "ۋ پ ن(VPN) باغلىنىشى ‹%s› نى %s گە ئېكسپورت قىلغىلى بولمىدى.\n"
+#~ "\n"
+#~ "خاتالىق: %s"
+
+#~ msgid "Export VPN connection..."
+#~ msgstr "ۋ پ ن (VPN)  باغلىنىشىنى ئېكسپورت قىل..."
+
+#~ msgid "never"
+#~ msgstr "ھەرگىز"
+
+#~ msgid "today"
+#~ msgstr "بۈگۈن"
+
+#~ msgid "yesterday"
+#~ msgstr "تۈنۈگۈن"
+
+#~ msgid "Last used"
+#~ msgstr "ئەڭ ئاخىرقى قېتىم ئىشلەتكىنى"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "ئەگەر سىزنىڭ سىمسىز توردىن باشقا ئىنتېرنېت باغلىنىشىڭىز بار بولسا، سىمسىز "
+#~ "قىزىق نۇقتا قۇرۇپ، باغلىنىشىڭىزنى باشقىلار بىلەن ھەمبەھىر قىلالايسىز."
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr ""
+#~ "سىمسىز قىزىق نۇقتىغا ئالماشسىڭىز <b>%s</b> بىلەن بولغان باغلىنىش ئۈزۈلىدۇ."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "سىمسىز قىزىق نۇقتا ئاكتىپ ھالەتتە تۇرۇۋاتقاندا، سىمسىز تورىڭىز ئارقىلىق "
+#~ "ئىنتېرنېتنى زىيارەت قىلالمايسىز."
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "قىزىق نۇقتىنى توختىتىپ، ھەر قانداق ئىشلەتكۈچىنى ئۈزەمدۇ؟"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "قىزىق نۇقتىنى توختات(_S)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "سىستېما سىياسىتى بويىچە Hotspot قىلىپ ئىشلىتىش چەكلەنگەن"
+
+#~| msgid "InfiniBand device does not support connected mode"
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "سىمسىز ئۈسكۈنە Hotspot ھالىتىنى قوللىمايدىكەن"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "تاللانغان تورنىڭ تەپسىلاتلىرى يەنى ئىم ۋە باشقا ئىختىيارىي سەپلىمە "
+#~ "قاتارلار يوقىلىدۇ."
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "ئۇنتۇپ كەت(_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "سەپلەنگەن URL تەمىنلەنمىگەن بولسا تور ۋاكالەتچىسىنى ئۆزلۈكىدىن بايقاپ "
+#~ "ئىشلىتىدۇ."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "ئىشەنچسىز ئاممىۋى تورغا نىسبەتەن بۇنداق قىلىش تەۋسىيە قىلىنمايدۇ."
+
+#~ msgid "Proxy"
+#~ msgstr "ۋاكالەتچى"
+
+#~ msgid "_Options…"
+#~ msgstr "تاللانمىلار(_O)…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "يوق"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "قولدا"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "ئاپتوماتىك"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "يېڭى مۇلازىمەتكە ئىشلىتىدىغان ئېغىزنى تاللاڭ"
+
+#~ msgid "C_reate…"
+#~ msgstr "قۇر(_R)…"
+
+#~ msgid "_Interface"
+#~ msgstr "ئارايۈز(_I)"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN تىپى"
+
+#~ msgid "Group Name"
+#~ msgstr "گۇرۇپپا ئاتى"
+
+#~ msgid "Group Password"
+#~ msgstr "گۇرۇپپا ئىم"
+
+#~ msgid "details"
+#~ msgstr "تەپسىلاتلار"
+
+#~ msgid "blablabla"
+#~ msgstr "blablabla"
+
+#~ msgid "Show P_assword"
+#~ msgstr "ئىم كۆرسەت(_A)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "باشقا ئىشلەتكۈچىلەرمۇ ئىشلىتەلەيدىغان بولسۇن"
+
+#~ msgid "identity"
+#~ msgstr "سالاھىيەت، كىملىك"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "پەقەت ئاپتوماتىك(DHCP) ئادرېسلار"
+
+#~ msgid "Link-local only"
+#~ msgstr "پەقەت Link-Local"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "ئادرېس\n"
+#~ "بۆلىكىنى\n"
+#~ "بۇ يەرگە\n"
+#~ "يېزىڭ"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "بۆلىكىنى\n"
+#~ "بۇ يەرگە\n"
+#~ "يېزىڭ"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "يېتەكچىلەر\n"
+#~ "بۆلىكىنى\n"
+#~ "بۇ يەرگە\n"
+#~ "يېزىڭ"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "ئاپتوماتىك ئېرىشكەن route لارنى نەزەرگە ئالمىسۇن(_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "كۇلونلانغان MAC ئادرېسلار(_C)"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgid "hardware"
+#~ msgstr "قاتتىق دېتال"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "مەزكۇر تورنىڭ تەڭشەكلىرىنى كۆڭۈلدىكى قىممەتلەرگە قايتۇرىدۇ، بىراق ئۇنى "
+#~ "ئالدى بىلەن ئۇلىنىدىغان تور قىلىپ ئەستە تۇتىدۇ"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "مەزكۇر تورغا مۇناسىۋەتلىك بولغان بارلىق تەپسىلاتلارنى ئۆچۈرىدۇ ۋە "
+#~ "ئۇنىڭغا  ئاپتوماتىك ئۇلانمايدىغان بولىدۇ."
+
+#~ msgid "reset"
+#~ msgstr "ئەسلىگە قايتۇر"
+
+#~ msgid "Hardware"
+#~ msgstr "قاتتىق دېتال"
+
+#~ msgid "_History"
+#~ msgstr "ئىز(_H)"
+
+#~ msgid "Connected Devices"
+#~ msgstr "باغلانغان ئۈسكۈنىلەر"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "قۇرۇلما"
+
+#~ msgid "Status unknown"
+#~ msgstr "ھالىتى نامەلۇم"
+
+#~ msgid "Unmanaged"
+#~ msgstr "باشقۇرۇلمىغان"
+
+#~ msgid "Unavailable"
+#~ msgstr "ئىشلەتكىلى بولمايدۇ"
+
+#~ msgid "Connecting"
+#~ msgstr "باغلىنىۋاتىدۇ"
+
+#~ msgid "Disconnecting"
+#~ msgstr "ئۈزۈۋاتىدۇ"
+
+#~ msgid "Connection failed"
+#~ msgstr "باغلىنىش مەغلۇپ بولدى"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "ھالىتى نامەلۇم (يوقالدى)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "سەپلەش مەغلۇپ بولدى"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP سەپلەش مەغلۇپ بولدى"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP سەپلەشنىڭ قەرەلى توشتى"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "بىخەتەرلىك ئۇچۇرلىرى كېرەك ئىدى، بىراق تەمىنلەنمەپتۇ"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x supplicant ئۈزۈلدى"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x supplicant نى سەپلەش مەغلۇپ بولدى"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x supplicant مەغلۇپ بولدى"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "كىملىك دەلىللەشتە 802.1x supplicant جىق ۋاقىت ئالدى"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP مۇلازىمىتىنى باشلاش مەغلۇپ بولدى"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP مۇلازىمىتى ئۈزۈلدى"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP مەغلۇپ بولدى"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP خېرىدارىنى باشلاش مەغلۇپ بولدى"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP خېرىدارىدا خاتالىق كۆرۈلدى"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP خېرىدارى مەغلۇپ بولدى"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "ھەمبەھىر باغلىنىش مۇلازىمىتىنى باشلاش مەغلۇپ بولدى"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "ھەمبەھىر باغلىنىش مۇلازىمىتى مەغلۇپ بولدى"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP مۇلازىمىتىنى باشلاش مەغلۇپ بولدى"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP مۇلازىمىتىدە خاتالىق كۆرۈلدى"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP مۇلازىمىتى مەغلۇپ بولدى"
+
+#~ msgid "Line busy"
+#~ msgstr "ئالاقە يولى ئالدىراش"
+
+#~ msgid "No dial tone"
+#~ msgstr "نومۇر باسقاندىكى ئاۋاز يوق"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "توشۇغۇچىنى قۇرغىلى بولمىدى"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "نومۇر بېسىشنىڭ قەرەلى توشتى"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "نومۇر بېسىش مەغلۇپ بولدى"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "مودېمنى دەسلەپلەشتۈرۈش مەغلۇپ بولدى"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "كۆرسىتىلگەن APN نى تاللاش مەغلۇپ بولدى"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "تورنى ئىزدىمىدى"
+
+#~ msgid "Network registration denied"
+#~ msgstr "تورغا خەتلىتىش رەت قىلىندى"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "تورغا خەتلىتىشنىڭ قەرەلى توشتى"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "تەلەپ قىلىنغان تورغا خەتلىتىش مەغلۇپ بولدى"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN تەكشۈرۈش مەغلۇپ بولدى"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "مەزكۇر ئۈسكۈنىنىڭ مۇقىم دېتالى يوقتەك قىلىدۇ"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "باغلىنىش غايىب بولدى"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "مەۋجۇت باغلىنىش دەپ قارايدۇ"
+
+#~ msgid "Modem not found"
+#~ msgstr "مودېم تېپىلمىدى"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "كۆكچىش باغلىنىشى مەغلۇپ بولدى"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "SIM نىڭ Pin نومۇرى زۆرۈر"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "SIM نىڭ Puk ئى زۆرۈر"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM خاتا"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand ئۈسكۈنىسى باغلىنىش ھالىتىنى قوللىمايدۇ"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "باغلىنىشقا كېرەكلىك ئۈسكۈنە تەييار بولمىدى"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "كابېل چېتىلمىغان"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "گۇۋاھنامە تارقاتقان ئورگان گۇۋاھنامىسىنى تاللىمىدى"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "تەكشۈرۈش مەركىزى(CA)نىڭ گۇۋاھنامىسىنى ئىشلەتمەسلىك بىخەتەر بولمىغان، "
+#~ "مۈجمەل سىمسىز تورغا(Wi-Fi) باغلاپ قويۇشى مۇمكىن. تەكشۈرۈش مەركىزىنىڭ "
+#~ "گۇۋاھنامىسىنى تاللاشنى ئىستەمسىز؟"
+
+#~ msgid "Ignore"
+#~ msgstr "پەرۋا قىلما"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "CA گۇۋاھنامىسى تاللا"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER، PEM ياكى PKCS#12 شەخسىي ئاچقۇچلار(*.der، *.pem،*.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER ياكى PEM گۇۋاھنامىسى(der.*، pem.*، crt.*، cer.*)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC ھۆججەتلىرى(*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "بۇ ئىمنى ھەر ۋاقىت سورىسۇن(_K)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "شىفىرلانمىغان شەخسىي ئاچقۇچلار بىخەتەر ئەمەس"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "تاللىغان شەخسىي ئاچقۇچ بىر ئىم تەرىپىدىن قوغدالمىغاندەك قىلىدۇ. بۇ سىزنىڭ "
+#~ "بىخەتەرلىك ئىسپاتنامىڭىزگە تەسىر قىلىدۇ. بىر ئىم تاللاپ شەخسىي "
+#~ "ئاچقۇچىڭىزنى قوغداڭ.(شەخسىي ئاچقۇچىڭىزنى openssl ئارقىلىق ئىملىق "
+#~ "قوغدىيالايسىز)"
+
+#~ msgid "Choose your personal certificate..."
+#~ msgstr "خۇسۇسىي گۇۋاھنامىڭىزنى تاللاڭ..."
+
+#~ msgid "Choose your private key..."
+#~ msgstr "شەخسىي ئاچقۇچىڭىزنى تاللاڭ:"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "مېنى يەنە ئاگاھلاندۇرما(_W)"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "سەكرىمە لەۋھەلەرنى كۆرسەت"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "لەۋھەلەردە تەپسىلاتلارنى كۆرسەت"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "قۇلۇپ ئېكراندا كۆرۈش"
+
+#~ msgid "On"
+#~ msgstr "ئوچۇق"
+
+#~ msgid "Off"
+#~ msgstr "تاقا"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "سەكرەپ چىقىدىغان لەۋھەلەرنى كۆرسەت"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "قۇلۇپ ئېكراندا كۆرسىتىش"
+
+#~ msgid "Add Account"
+#~ msgstr "ھېسابات قوشۇش"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "ھېساباتقا كىرىشتە خاتالىق كۆرۈلدى"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "ئىسپاتنامىنىڭ ۋاقتى ئۆتكەن. قايتا كىرىڭ."
+
+#~ msgid "_Log In"
+#~ msgstr "تىزىمغا كىر(_L)"
+
+#~ msgid "Error creating account"
+#~ msgstr "ھېسابات قۇرۇۋاتقاندا خاتالىق كۆرۈلدى"
+
+#~ msgid "Error removing account"
+#~ msgstr "ھېساباتنى چىقىرىۋېتىشتە خاتالىق كۆرۈلدى"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "ھېساباتنى راستلا چىقىرىۋېتەمسىز؟"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "بۇ مۇلازىمېتىردىكى ھېساباتنى چىقىرىۋەتمەيدۇ."
+
+#~ msgid "Manage online accounts"
+#~ msgstr "توردىكى ھېساباتلارنى باشقۇرۇش"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "توردىكى ھېساباتلار سەپلەنمىگەن"
+
+#~ msgid "Remove Account"
+#~ msgstr "ھېساباتنى چىقىرىۋېتىش"
+
+#~ msgid "Add an online account"
+#~ msgstr "بىر تور ھېساباتى قوشۇش"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "تور ھېساباتى قوشۇلسا، پروگرامما تور ھېساباتىنىڭ پۈتۈكلىرىنى، ئېلخەت، "
+#~ "ئالاقەداش، يىلنامە، سۆھبەت ۋە باشقىلارنى زىيارەت قىلالايدۇ."
+
+#~ msgid "Unknown time"
+#~ msgstr "نامەلۇم"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "تولۇق توكلىنىشقا %s بار"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "دىققەت: قالغىنى %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "قالغىنى %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "تولۇق توكلاندى"
+
+#~ msgid "Empty"
+#~ msgstr "بوش"
+
+#~ msgid "Charging"
+#~ msgstr "توكلاۋاتىدۇ"
+
+#~ msgid "Discharging"
+#~ msgstr "توكسىزلاۋاتىدۇ"
+
+#, c-format
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "توكداننىڭ تەخمىنىي سىغىمى: %s"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "ئاساس"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "قوشۇمچە"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "سىمسىز چاشقىنەك"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "سىمسىز ھەرپتاختا"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "ئۈزۈلمەس توك مەنبەسى"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "شەخسىي رەقەملىك ياردەمچى"
+
+#~ msgid "Cellphone"
+#~ msgstr "يانفون"
+
+#~ msgid "Media player"
+#~ msgstr "ۋاسىتە قويغۇ"
+
+#~ msgid "Computer"
+#~ msgstr "كومپيۇتېر"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "توكلاۋاتىدۇ"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "دىققەت"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "تۆۋەن"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "ياخشى"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "تولۇق توكلاندى"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "بوش"
+
+#~ msgid "Batteries"
+#~ msgstr "توكدانلار"
+
+#~ msgid "When _idle"
+#~ msgstr "بوش ۋاقىتتا(_I)"
+
+#~ msgid "_Dim Screen when Inactive"
+#~ msgstr "ئاكتىپ ئەمەس ۋاقتىدا ئېكراننى سۇس قىل(_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "كۆكچىش(_B)"
+
+#~ msgid "When on battery power"
+#~ msgstr "توكداندا ئىشلەۋاتقاندا"
+
+#~ msgid "When plugged in"
+#~ msgstr "توك مەنبەسى ئۇلانغاندا"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "توڭلات ۋە توكنى ئۈز"
+
+#~ msgid "When Battery Power is _Critical"
+#~ msgstr "توكداننىڭ توكى تۆۋەنلەپ خەتەرلىك ھالەتكە كەلگەندە(_C)"
+
+#~ msgid "Power Off"
+#~ msgstr "توكنى ئۈز"
+
+#~ msgid "Power management settings"
+#~ msgstr "توك مەنبە باشقۇرۇش تەڭشىكى"
+
+#~ msgid "Hibernate"
+#~ msgstr "ئۈچەك"
+
+#~ msgid "1 minute"
+#~ msgstr "%1 مىنۇت"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 مىنۇت"
+
+#~| msgid "40 minutes"
+#~ msgid "4 minutes"
+#~ msgstr "4 مىنۇت"
+
+#~| msgid "5 minutes"
+#~ msgid "8 minutes"
+#~ msgstr "8 مىنۇت"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 مىنۇت"
+
+#~| msgid "2 minutes"
+#~ msgid "12 minutes"
+#~ msgstr "12 مىنۇت"
+
+#~ msgid "Out of toner"
+#~ msgstr "كۇكۇن تۈگەپ كەتتى"
+
+#~ msgid "Low on developer"
+#~ msgstr "تەسۋىر روشەنلەشتۈرگۈچ ئاز قالدى"
+
+#~ msgid "Out of developer"
+#~ msgstr "تەسۋىر روشەنلەشتۈرگۈچ تۈگەپ قالدى"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "بەلگە سىياھ تەمىنلەش ئاز قالدى"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "بەلگە سىياھ تەمىنلەش تۈگەپ قالدى"
+
+#~ msgid "Open cover"
+#~ msgstr "قاپقاقنى ئاچ"
+
+#~ msgid "Low on paper"
+#~ msgstr "قەغەز ئاز قالدى"
+
+#~ msgid "Out of paper"
+#~ msgstr "قەغەز يېتىشمىدى"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "توختىدى"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "ئەخلەت قاچىسى توشۇپ قالاي دېدى"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "ئەخلەت قاچىسى توشۇپ قالدى"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "نۇر سەزگۈچنىڭ ئۆمرى ئاز قالدى"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "نۇر سەزگۈچ خىزمەت قىلالمايدۇ"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "تەييار"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "ۋەزىپىنى قوبۇل قىلمايدۇ"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "بىر تەرەپ قىلىۋاتىدۇ"
+
+#~ msgid "Toner Level"
+#~ msgstr " كۇكۇن دەرىجىسى"
+
+#~ msgid "Supply Level"
+#~ msgstr "تەمىنلەش دەرىجىسى"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "ئورنىتىۋاتىدۇ"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u ئاكتىپ"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "يېڭى پرىنتېر قوشالمىدى."
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript پرىنتېرىنىڭ چۈشەندۈرۈش ھۆججەتلىرى(*.ppd، *.PPD، *.ppd.gz، *."
+#~ "PPD.gz، *.PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "مۇۋاپىق قوزغاتقۇ تېپىلمىدى"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "كۆرۈنمەيۈزنى ئوقۇغىلى بولمىدى: %s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "بېسىشنى داۋاملاشتۇرۇش"
+
+#~ msgid "Pause Printing"
+#~ msgstr "بېسىشنى ۋاقىتلىق توختىتىش"
+
+#~ msgid "Cancel Print Job"
+#~ msgstr "بېسىشتىن ۋاز كېچىش"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "بىر يېڭى پرىنتېر قوش"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "تور پرىنتېرلىرىنى ئىزدەش ياكى نەتىجىنى سۈزۈش"
+
+#~ msgid "One Sided"
+#~ msgstr "تاق تەرەپلىك"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "ئۇزۇن يان (ئۆلچەملىك)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "قىسقا يان (ئۆرۈ)"
+
+#~ msgid "Portrait"
+#~ msgstr "بوي يۆنىلىش"
+
+#~ msgid "Landscape"
+#~ msgstr "توغرا يۆنىلىش"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "تەتۈر توغرا يۆنىلىش"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "تەتۈر بوي يۆنىلىش"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "كۈتۈۋاتىدۇ"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "تۇتۇپ تۇردى"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "بىر تەرەپ قىلىۋاتىدۇ"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "توختىدى"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "توختىتىلدى"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "تاماملاندى"
+
+#~ msgid "Job Title"
+#~ msgstr "خىزمەت ۋەزىپىسى"
+
+#~ msgid "Job State"
+#~ msgstr "خىزمەت ھالىتى"
+
+#~ msgid "Two Sided"
+#~ msgstr "قوش يۈزلۈك"
+
+#~ msgid "Paper Source"
+#~ msgstr "قەغەز مەنبەسى"
+
+#~ msgid "Output Tray"
+#~ msgstr "قەغەز چىقارغۇچ"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript ئالدىن سۈزگۈچ"
+
+#~ msgid "Pages per side"
+#~ msgstr "ھەر يۈزىنىڭ بەت سانى"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "ئادەتتىكى"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "بەت تەڭشەك"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "ئورناتقىلى بولىدىغان تاللانمىلار"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "ۋەزىپە"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "سۈرەت سۈپىتى"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "رەڭ"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "تامام"
+
+#~ msgid "Auto Select"
+#~ msgstr "ئۆزلۈكىدىن تاللا"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "GhostScript خەت نۇسخىنىلا سىڭدۈر"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "PS دەرىجە 1 گە ئايلاندۇر"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "PS دەرىجە 2 گە ئايلاندۇر"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "ئالدىن سۈزگۈچ يوق"
+
+#~ msgid "Supply"
+#~ msgstr "تەمىنلىگۈچى"
+
+#~ msgid "_Default"
+#~ msgstr "كۆڭۈلدىكى(_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "ۋەزىپىلەر"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "ۋەزىپىلەرنى كۆرسەت(_J)"
+
+#~ msgid "label"
+#~ msgstr "ئەن"
+
+#~ msgid "page 3"
+#~ msgstr "بەت 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "سىناق بەتنى باس(_T)"
+
+#~ msgid "_Options"
+#~ msgstr "تاللانما(_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "يېڭى پرىنتېر قوش"
+
+#~ msgid "Hidden"
+#~ msgstr "يوشۇرۇن"
+
+#~ msgid "Visible"
+#~ msgstr "كۆرۈنۈشچان"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "ئاتى ۋە كۆرۈنۈشچانلىقى"
+
+#~ msgid "Usage & History"
+#~ msgstr "ئىشلىتىلىش ئەھۋالى ۋە ئىز"
+
+#~ msgid "Privacy settings"
+#~ msgstr "شەخسىيەت تەڭشەكلىرى"
+
+#~ msgid "Screen Turns Off"
+#~ msgstr "ئېكران تاقىلىدۇ"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "ئېكران ۋە توردا قانداق كۆرۈنىدىغانلىقىنى تىزگىنلەيدۇ"
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "ئۇستى بالداقتا تولۇق ئاتىنى كۆرسەتسۇن(_F)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "قۇلۇپلانغان ئېكراندا تولۇق ئاتىنى كۆرسەتسۇن(_F)"
+
+#~ msgid "Immediately"
+#~ msgstr "دەرھال"
+
+#~ msgid "1 day"
+#~ msgstr "1 كۈن"
+
+#~ msgid "2 days"
+#~ msgstr "2 كۈن"
+
+#~ msgid "3 days"
+#~ msgstr "3 كۈن"
+
+#~ msgid "4 days"
+#~ msgstr "4 كۈن"
+
+#~ msgid "5 days"
+#~ msgstr "5 كۈن"
+
+#~ msgid "6 days"
+#~ msgstr "6 كۈن"
+
+#~ msgid "7 days"
+#~ msgstr "7 كۈن"
+
+#~ msgid "14 days"
+#~ msgstr "14 كۈن"
+
+#~ msgid "30 days"
+#~ msgstr "30 كۈن"
+
+#~ msgid "Forever"
+#~ msgstr "مەڭگۈ"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "ئىزلارنى ساقلاپ قويۇپ كېيىن ئىزدەشكە قۇلايلىق يارىتىدۇ. بۇلار توردا "
+#~ "ھەرگىز ھەمبەھىرلەنمەيدۇ."
+
+#~ msgid "_Recently Used"
+#~ msgstr "يېقىندا ئىشلىتىلگەنلىرى(_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "ئىزلارنى ساقلاپ قوي(_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "ئېكران قۇلۇپلاش — سىز ئورنىڭىزدا يوق ۋاقىتتا سىزنىڭ شەخسىيىتىڭىزنى "
+#~ "قوغدايدۇ."
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "ئەخلەتخانىنى ۋە ۋاقىتلىق ھۆججەتلەرنى تازىلاپ كومپيۇتېرىڭىزنى مۇھىم "
+#~ "ئۇچۇرلاردىن خالىي قىلىپ تۇرىدۇ."
+
+#~ msgid "Purge _After"
+#~ msgstr "كۆرسىتىلگەن ۋاقىتتىن كېيىن تازىلا(_A)"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "رايون ۋە تىل تەڭشىكىڭىزنى ئۆزگەرتىدۇ"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "ئىمپېرىئال"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "مېترىك"
+
+#~ msgid "Select an input source"
+#~ msgstr "كىرگۈزۈش مەنبەسىنى تاللاڭ"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr ""
+#~ "كىرىش ئېكرانى، سىستېما ھېساباتى ۋە يېڭى ئىشلەتكۈچى ھېساباتلىرى مەزكۇر "
+#~ "سىستېما مىقياسىدىكى رايون ۋە تىل تەڭشىكىنى ئىشلىتىدۇ."
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "كىرىش ئېكرانى، سىستېما ھېساباتى ۋە يېڭى ئىشلەتكۈچى ھېساباتلىرى مەزكۇر "
+#~ "سىستېما مىقياسىدىكى رايون ۋە تىل تەڭشىكىنى ئىشلىتىدۇ. سىز ئۆزىڭىزگە مەست "
+#~ "كېلىدىغان قىلىپ تەڭشىسىڭىز بولىدۇ."
+
+#~ msgid "Copy Settings"
+#~ msgstr "تەڭشەكنى كۆچۈرۈش"
+
+#~ msgid "Copy Settings…"
+#~ msgstr "تەڭشەكنى كۆچۈرۈش…"
+
+#~ msgid "Region and Language"
+#~ msgstr "رايون ۋە تىل"
+
+#~ msgid "Add Language"
+#~ msgstr "تىل قوشۇش"
+
+#~ msgid "Language"
+#~ msgstr "تىل"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "رايون تاللاڭ(ئۆزگىرىش كېيىنكى قېتىم كىرگەندە كۈچكە ئىگە)"
+
+#~ msgid "Add Region"
+#~ msgstr "رايون قوشۇش"
+
+#~ msgid "Remove Region"
+#~ msgstr "رايون چىقىرىۋېتىش"
+
+#~ msgid "Currency"
+#~ msgstr "پۇل"
+
+#~ msgid "Examples"
+#~ msgstr "مىساللار"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "ھەرپ تاختا ياكى باشقا كىرگۈزۈش مەنبەسىنى تاللاڭ"
+
+#~ msgid "Remove Input Source"
+#~ msgstr "كىرگۈزۈش مەنبەسىنى چىقىرىۋېتىش"
+
+#~ msgid "Move Input Source Up"
+#~ msgstr "كىرگۈزۈش مەنبەسىنى ئۈستىگە يۆتكەش"
+
+#~ msgid "Move Input Source Down"
+#~ msgstr "كىرگۈزۈش مەنبەسىنى ئاستىغا يۆتكەش"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Ctrl+Alt+Shift+Space"
+#~ msgstr "Ctrl+Alt+Shift+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "تېزلەتمە تەڭشىكى"
+
+#~ msgid "Display language:"
+#~ msgstr "كۆرۈنۈش تىلى:"
+
+#~ msgid "Input source:"
+#~ msgstr "كىرگۈزۈش مەنبەسى"
+
+#~ msgid "Format:"
+#~ msgstr "فورمات:"
+
+#~ msgid "Your settings"
+#~ msgstr "تەڭشىكىڭىز"
+
+#~ msgid "System settings"
+#~ msgstr "سىستېما تەڭشەكلىرى"
+
+#~ msgid "Home"
+#~ msgstr "ماكان"
+
+#~ msgid "Select Location"
+#~ msgstr "ئورۇن تاللاش"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "ئوچۇق"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "تاقا"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "قىسقۇچ تاللاڭ"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "كۆكچىشتا ھەمبەھىرلەش — ھۆججەتلەرنى كۆكچىش بار ئۈسكۈنىلەر ئارىسىدا "
+#~ "ھەمبەھىرلەشكە ئىمكان يارىتىدۇ."
+
+#~ msgid "Share Public Folder"
+#~ msgstr "ئاممىۋى قىسقۇچنى ھەمبەھىرلە"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "ئىشەنچلىك ئۈسكۈنىلەردىنلا قوبۇل قىلسۇن"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "قوبۇل قىلغان ھۆججەتلەرنى چۈشۈرۈلمىلەر قىسقۇچىغا ساقلىسۇن"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "ئىشەنچلىك ئۈسكۈنىلەر بىلەنلا ھەمبەھىر قىلسۇن"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "تور بولمىغاچقا بىر قىسىم مۇلازىمەتلەر ئىناۋەتسىز قىلىندى."
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "مەزكۇر توردا ۋاسىتىلەرنى ھەمبەھىر قىلسۇن"
+
+#~ msgid "Shared Folders"
+#~ msgstr "ھەمبەھىرلەنگەن قىسقۇچلار"
+
+#~ msgid "column"
+#~ msgstr "ئىستونلار"
+
+#~ msgid "Remove Folder"
+#~ msgstr "قىسقۇچ چىقىرىۋېتىش"
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "شەخسىي ھۆججەت ھەمبەھىرلەشنى ئىشلىتىش ئارقىلىق، ئاممىۋى قىسقۇچلارنى <a "
+#~ "href=\"dav://%s\">dav://%s</a> نى ئىشلىتىپ باشقىلار بىلەن ھەمبەھىر "
+#~ "قىلالايسىز"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "مەزكۇر توردا ئاممىۋى قىسقۇچنى ھەمبەھىر قىلسۇن"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "يىرىقتىكى ئىشلەتكۈچىنىڭ بىخەتەر Shell بۇيرۇقىنى ئىشلىتىپ باغلىنىشىغا "
+#~ "ئىجازەت بېرىدۇ:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "ئېكراننى ھەمبەھىر قىلىش"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "يىرىقتىكى ئىشلەتكۈچىنىڭ باغلىنىپ ئېكراننى تىزگىنلىشىگە ئىجازەت بېرىدۇ: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+
+#~ msgid "Remote View"
+#~ msgstr "يىراقتا كۆرۈش"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "ھەممە باغلىنىشنى قوبۇل قىلسۇن"
+
+#~ msgid "Show Password"
+#~ msgstr "ئىم كۆرسەت"
+
+#~ msgid "Bark"
+#~ msgstr "ئىتنىڭ قاۋىشى"
+
+#~ msgid "Drip"
+#~ msgstr "سۇنىڭ تامچىلىشى"
+
+#~ msgid "Glass"
+#~ msgstr "ئەينەكنىڭ جىرىڭلىشى"
+
+#~ msgid "Sonar"
+#~ msgstr "سونار"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "ئەڭ كىچىك"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "ئەڭ چوڭ"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "ئۇلترا تۆۋەن ئاۋاز(_S):"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "چوڭايتىلمىغان"
+
+#~ msgid "_Profile:"
+#~ msgstr "سەپلىمە ھۆججەت(_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "ياڭراتقۇ سىنا(_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "چوققا قىممەت بايقا"
+
+#~ msgid "Device"
+#~ msgstr "ئۈسكۈنە"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s نىڭ ياڭراتقۇسىنى سىناش"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "ئاۋاز چىقىرىش ئۈسكۈنىسى تاللاش(_H):"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "تاللىغان ئۈسكۈنىنىڭ تەڭشىكى:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "كىرىش ئاۋاز مىقدارى(_I):"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "ئاۋاز كىرگۈزۈش ئۈسكۈنىسى تاللاش(_H):"
+
+#~ msgid "Sound Effects"
+#~ msgstr "ئاۋاز ئۈنۈمى"
+
+#~ msgid "Built-in"
+#~ msgstr "ئىچكى"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "ئاۋاز مايىللىقى"
+
+#~ msgid "Testing event sound"
+#~ msgstr "ھادىسە ئاۋازىنى سىناۋاتىدۇ"
+
+#~ msgid "From theme"
+#~ msgstr "ئۆرنەكتىن"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "ئاگاھلاندۇرۇش ئاۋازى تاللاڭ(_H):"
+
+#~ msgid "Stop"
+#~ msgstr "توختا"
+
+#~ msgid "Custom"
+#~ msgstr "ئىختىيارى"
+
+#~ msgid "No shortcut set"
+#~ msgstr "تېزلەتمە بەلگىلەنمىگەن"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "ئۇنىۋېرسال زىيارەت مايىللىقى"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "نورمال"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "يۇقىرى/ئەكسى"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "ئېكران ھەرپتاختىسى"
+
+#~ msgid "GOK"
+#~ msgstr "GOK"
+
+#~ msgid "OnBoard"
+#~ msgstr "تاختىدىكى"
+
+#, no-c-format
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#, no-c-format
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "نورمال"
+
+#, no-c-format
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#, no-c-format
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "چوڭراق"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "Caps ۋە Num Lock كۇنۇپكىلىرىنى ئىشلەتكەندە ئاۋاز چىقارسۇن"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "ئاچ ياكى ياپ"
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "كېڭەيت-تارايت"
+
+#~ msgid "Zoom in:"
+#~ msgstr "كېڭەيت:"
+
+#~ msgid "Zoom out:"
+#~ msgstr "تارايت:"
+
+#~ msgid "Flash the window title"
+#~ msgstr "كۆزنەك ماۋزۇسىنى چاقنات"
+
+#~ msgid "Closed Captioning"
+#~ msgstr "تاقالغان خەتلىك چۈشەندۈرۈش"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "تەلەپپۇز ۋە ئاۋازنىڭ تېكىست چۈشەندۈرۈشىنى كۆرسەت"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "قىسقا"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "ئۇزۇن"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "كۇنۇپكىسى ئىشلەتكەندە دۈت-دۈت ئاۋاز چىقار"
+
+#~ msgid "pressed"
+#~ msgstr "بېسىلغان"
+
+#~ msgid "accepted"
+#~ msgstr "قوشۇلغان"
+
+#~ msgid "rejected"
+#~ msgstr "رەت قىلىنغان"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "قوبۇل قىلىشچان كېچىكتۈرۈش(_E):"
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "نۇربەلگىنى كۇنۇپكا تاختىدا تىزگىنلىسۇن"
+
+#~ msgid "Video Mouse"
+#~ msgstr "سىن چاشقىنەك"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "نۇربەلگىنى سىن كامېرادا تىزگىنلەيدۇ."
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "كىچىك"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "چوڭ"
+
+#~ msgid "Mouse Settings"
+#~ msgstr "چاشقىنەك تەڭشەكلىرى"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "قىسقا"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ ئېكران"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ ئېكران"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ ئېكران"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "ئۇزۇن"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "ئۆلچەملىك"
+
+#~ msgid "_Local Account"
+#~ msgstr "يەرلىك ھېسابات(_L)"
+
+#~ msgid "Account _Type"
+#~ msgstr "ھېسابات تىپ(_T)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "ئەسكەرتىش: شىركەت دائىرە ئاتى ياكى realm ئاتى"
+
+#~ msgid "C_ontinue"
+#~ msgstr "داۋاملاشتۇر(_O)"
+
+#~ msgid "Left thumb"
+#~ msgstr "سول قول باش بارماق"
+
+#~ msgid "Left middle finger"
+#~ msgstr "سول قول ئوتتۇرا بارماق"
+
+#~ msgid "Left ring finger"
+#~ msgstr "سول قول نامسىز بارماق"
+
+#~ msgid "Left little finger"
+#~ msgstr "سول قول چىمچىلاق"
+
+#~ msgid "Right thumb"
+#~ msgstr "ئوڭ قول باش بارماق"
+
+#~ msgid "Right middle finger"
+#~ msgstr "ئوڭ قول ئوتتۇرا بارماق"
+
+#~ msgid "Right ring finger"
+#~ msgstr "ئوڭ قول نامسىز بارماق"
+
+#~ msgid "Right little finger"
+#~ msgstr "ئوڭ قول چىمچىلاق"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "بارماق ئىزىدا تىزىمغا كىرىشنى قوزغات"
+
+#~ msgid "_Right index finger"
+#~ msgstr "ئوڭ قول كۆرسەتكۈچ بارماق(_R)"
+
+#~ msgid "_Left index finger"
+#~ msgstr "سول قول كۆرسەتكۈچ بارماق(_L)"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "بارماق ئىزىڭىز مۇۋەپپەقىيەتلىك ساقلاندى. ئەمدى بارماق ئىزى ئوقۇغۇچىڭىز "
+#~ "ئارقىلىق تىزىمغا كىرەلەيسىز."
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;تىزىمغا كىر;ئات;بارماق "
+#~ "ئىزى;سىما;تۇغ;چىراي;ئىم;"
+
+#~| msgid "Next track"
+#~ msgid "Next week"
+#~ msgstr "كېيىنكى ھەپتە"
+
+#~ msgid "Log in without a password"
+#~ msgstr "ئىمسىز تىزىمغا كىرىدۇ"
+
+#~ msgid "Disable this account"
+#~ msgstr "بۇ ھېساباتنى ئىناۋەتسىز قىلىدۇ"
+
+#~ msgid "Enable this account"
+#~ msgstr "بۇ ھېساباتنى قوزغات"
+
+#~ msgid "_Hint"
+#~ msgstr "يىپ ئۇچى(_H)"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "بۇ ئەسكەرتىش تىزىمغا كىرىش كۆزنىكىدە كۆرۈنۈشى مۇمكىن. ئۇنى سىستېمىدىكى "
+#~ "ھەممە ئىشلەتكۈچى كۆرەلەيدۇ. ئىمنى بۇ جايغا <b>يازماڭ</b>."
+
+#~ msgid "Fair"
+#~ msgstr "ياخشىراق"
+
+#~ msgid "_Action"
+#~ msgstr "مەشغۇلات(_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "ئىم كۆرسەت(_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "كۈچلۈك ئىمنى قانداق تاللاش كېرەك"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "سۈرەت ئۆزگەرت:"
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr ""
+#~ "تىزىمغا كىرىش كۆزنىكىدە مەزكۇر ھېسابات بىلەن بىللە كۆرۈنىدىغان سۈرەتتىن "
+#~ "بىرنى تاللاڭ."
+
+#~ msgid "Gallery"
+#~ msgstr "سۈرەت يىغقۇچ"
+
+#~ msgid "Take a photograph"
+#~ msgstr "فوتو سۈرەتكە تارت"
+
+#~ msgid "Browse"
+#~ msgstr "كۆز يۈگۈرت"
+
+#~ msgid "Photograph"
+#~ msgstr "فوتو سۈرەت"
+
+#~ msgid "Account Information"
+#~ msgstr "ھېساب ئۇچۇرى"
+
+#~ msgid "Last Login"
+#~ msgstr "ئەڭ ئاخىرقى قېتىم كىرگەن ۋاقىت"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "بەك قىسقا"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "تازا ياخشى ئەمەس"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "ئاجىز"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "ياخشىراق"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "ياخشى"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "كۈچلۈك"
+
+#~ msgid "Authentication failed"
+#~ msgstr "سالاھىيەت دەلىللەش مەغلۇپ بولدى"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "يېڭى ئىم بەك قىسقا"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "يېڭى ئىم بەك ئاددىي"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "يېڭى ئىم بىلەن كونا ئىم ئوخشىشىپ قالىدىكەن"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "يېڭى ئىم يېقىندا ئىشلىتىلگەن."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "يېڭى ئىم چوقۇم  سان ياكى ئالاھىدە ھەرپلەرنى ئۆز ئىچىگە ئېلىشى لازىم"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "كونا ۋە يېڭى ئىم ئوخشاش"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "تۇنجى قېتىم سالاھىيەت تەكشۈرتكىنىڭىزدىن بۇيان ئىم ئۆزگەرتىلدى!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "يېڭى ئىم يېتەرلىك پەرقلىق ھەرپلەرنى ئۆز ئىچىگە ئالمىغان"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "نامەلۇم خاتالىق"
+
+#~ msgid "Failed to add account"
+#~ msgstr "ھېسابات قوشۇش مەغلۇپ بولدى"
+
+#~ msgid "Failed to register account"
+#~ msgstr "ھېسابات خەتلىتىش مەغلۇپ بولدى"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "مەزكۇر دائىرىدە كىملىك دەلىللەشتە قوللىمايدىغان ئۇسۇل"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "دائىرىگە قوشۇلۇش مەغلۇپ بولدى"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "دائىرىگە كىرىش مەغلۇپ بولدى"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "سىزنىڭ بۇ ئۈسكۈنىنى زىيارەت قىلىش ھوقۇقىڭىز يوقكەن. سىستېما باشقۇرغۇچىسى "
+#~ "بىلەن ئالاقىلىشىڭ."
+
+#~ msgid "The device is already in use."
+#~ msgstr "ئۈسكۈنە ئىشلىتىلىۋاتىدۇ."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "ئىچكى خاتالىق يۈز بەردى."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "خەتلەنگەن بارماق ئىزلىرىنى ئۆچۈرۈۋېتەمسىز؟"
+
+#~ msgid "Done!"
+#~ msgstr "تامام!"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "‹%s› ئۈسكۈنىنى زىيارەت قىلالمىدى."
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "‹%s› ئۈسكۈنىسىدە بارماق ئىزىغا ئېرىشىشنى باشلىغىلى بولمىدى."
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr ""
+#~ "ھېچقانداق بارماق ئىزى ئوقۇغۇچ ئۈسكۈنىسى بىلەن ئالاقە قىلغىلى بولمىدى."
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "ياردەمگە ئېرىشىش ئۈچۈن سىستېما باشقۇرغۇچىسى بىلەن ئالاقىلىشىڭ."
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr ""
+#~ "بارماق ئىزى ئارقىلىق تىزىمغا كىرىشنى قوزغىتىش ئۈچۈن، «%s» ئۈسكۈنىسى "
+#~ "ئارقىلىق بىر بارمىقىڭىزنىڭ ئۇچۇرىنى ساقلىشىڭىز كېرەك."
+
+#~ msgid "Selecting finger"
+#~ msgstr "تاللانغان بارماق"
+
+#~ msgid "This Week"
+#~ msgstr "بۇ ھەپتە"
+
+#~ msgid "Last Week"
+#~ msgstr "ئۆتكەن ھەپتە"
+
+#~ msgid "_Generate a password"
+#~ msgstr "ئىم ھاسىللا(_G)"
+
+#~ msgid "Please choose another password."
+#~ msgstr "باشقا ئىم تاللاڭ."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "ھازىرقى ئىمنى قايتا كىرگۈزۈڭ."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "ئىمنى ئۆزگەرتكىلى بولمىدى"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "يېڭى ئىم كىرگۈزۈشىڭىز زۆرۈر"
+
+#~| msgid "The new password is too short"
+#~ msgid "The new password is not strong enough"
+#~ msgstr "يېڭى ئىم تازا پۇختا ئەمەس"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "ئىمنى جەزملىشىڭىز زۆرۈر"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "نۆۋەتتىكى ئىمنى كىرگۈزۈشىڭىز زۆرۈر"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "نۆۋەتتىكى ئىم خاتا"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "ئىم ماس كەلمىدى"
+
+#~ msgid "Wrong password"
+#~ msgstr "ئىم خاتا"
+
+#~ msgid "Disable image"
+#~ msgstr "سۈرەتنى ئىناۋەتسىز قىل"
+
+#~ msgid "Take a photo…"
+#~ msgstr "سۈرەت تارتىش…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "تېخىمۇ كۆپ سۈرەتكە كۆز يۈگۈرت…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "%s ئىشلەتكەن"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "بۇ تىپتىكى دائىرىگە ئاپتوماتىك كىرگىلى بولمايدۇ"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "بۇنداق دائىرە ئاتى ياكى realm نى تاپقىلى بولمىدى"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "%s سۈپىتىدە دائىرە %s غا كىرگىلى بولمىدى"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "ئىم خاتا، قايتا سىناڭ"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "ئىشلەتكۈچى ئۆچۈرۈش مەغلۇپ بولدى"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "ئۆزىڭىزنىڭ ھېساباتىنى ئۆچۈرەلمەيسىز."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s يەنىلا تىزىمدا بار"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "ئىشلەتكۈچى سىستېمىنى ئىشلىتىۋاتقان ئۇنى ئۆچۈرسە سىستېما مۇقىمسىز ھالەتكە "
+#~ "كېلىپ قالىدۇ"
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "%s نىڭ ھۆججىتىنى ساقلاپ قالامسىز؟"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "ئىشلەتكۈچى ھېساباتىنى ئۆچۈرگەندە ماكان مۇندەرىجە، ئېلخەت مۇندەرىجە ۋە "
+#~ "ۋاقىتلىق ھۆججەتنى ساقلاپ قېلىشقا بولىدۇ."
+
+#~ msgid "_Delete Files"
+#~ msgstr "ھۆججەت ئۆچۈر(_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "ھۆججەتنى ساقلاپ قال(_K)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "ھېسابات چەكلەنگەن"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "كېيىنكى قېتىم تىزىمغا كىرگەندە تەڭشە"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "يوق"
+
+#~ msgid "Logged in"
+#~ msgstr "كىرگەن"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "ھېسابات مۇلازىمېتىرى بىلەن ئالاقىلىشىش مەغلۇپ بولدى"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "AccountService توغرا ئورنىتىلىپ قوزغىتىلغانلىقىنى جەزملەڭ."
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ئۆزگەرتىشتە،\n"
+#~ "ئالدى بىلەن * سىنبەلگىنى چېكىڭ"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "ئىشلەتكۈچى ھېساباتى قۇرۇش ئۈچۈن،\n"
+#~ "ئالدى بىلەن * سىنبەلگىسىنى چېكىڭ"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "تاللانغان ئىشلەتكۈچى ھېساباتىنى ئۆچۈرىدۇ"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "تاللانغان ئىشلەتكۈچى ھېساباتىنى ئۆچۈرۈش ئۈچۈن،\n"
+#~ "ئالدى بىلەن * سىنبەلگىسىنى چېكىڭ"
+
+#~ msgid "Other Accounts"
+#~ msgstr "باشقا ھېساباتلار"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists"
+#~ msgstr "‹%s› ئاتلىق ئىشلەتكۈچىدىن بىرى مەۋجۇت"
+
+#, c-format
+#~ msgid "The username is too long"
+#~ msgstr "ئىشلەتكۈچى ئاتى بەك ئۇزۇن"
+
+#~ msgid "The username cannot start with a '-'"
+#~ msgstr "ئىشلەتكۈچى ئاتى '-' ھەرپتىن باشلانمايدۇ"
+
+#~ msgid ""
+#~ "The username must only consist of:\n"
+#~ " ➣ letters from the English alphabet\n"
+#~ " ➣ digits\n"
+#~ " ➣ any of the characters '.', '-' and '_'"
+#~ msgstr ""
+#~ "ئىشلەتكۈچى ئاتىنىڭ تەركىبىدە بولىدىغىنى:\n"
+#~ "  ئىنگلىزچە ئېلىپبەدىكى ھەرپلەر ➣\n"
+#~ "  رەقەملەر ➣ \n"
+#~ "  \"-\" خالىغان ھەرپ \".\"، \"_\"  ۋە ➣"
+
+#~ msgid "Output:"
+#~ msgstr "چىقار:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "يەككە كۆزەتكۈچكە خەرىتىلە"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d / %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "يوق"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "كۇنۇپكا بېسىلىشىنى يوللاش"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "ئېكران ئالماشتۇرۇش"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "ئېكران ئۈستى ياردىمىنى كۆرسەت"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "ئۈستى"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "ئاستى"
+
+#~ msgid "Switch Modes"
+#~ msgstr "ئالماشتۇرۇش ھالىتى"
+
+#~ msgid "Action"
+#~ msgstr "مەشغۇلات"
+
+#~ msgid "Display Mapping"
+#~ msgstr "خەرىتە كۆرسەت"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "Wacom tablet نىڭ مايىللىقىنى تەڭشەيدۇ"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Tablet (مۇتلەق)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Tablet مايىللىقى"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "كۆكچىش تەڭشىكى"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "خەرىتە توپچىلار…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "كۆرسىتىش ئېنىقلىقىنى تەڭشەيدۇ"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "ئىزلاش ھالىتى"
+
+#~ msgid "Left Ring"
+#~ msgstr "سول نامسىز بارماق"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "سول نامسىز بارماق ھالىتى #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "ئوڭ نامسىز بارماق ھالىتى #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "سول Touchstrip"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "سول Touchstrip ھالىتى #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "ئوڭ Touchstrip"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "ئوڭ Touchstrip ھالىتى #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "سول Touchstrip ھالەت ئالماشتۇرغۇچ"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "ئوڭ Touchstrip ھالەت ئالماشتۇرغۇچ"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "سول Touchstrip ھالەت ئالماشتۇرغۇچ"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "ئوڭ Touchstrip ھالەت ئالماشتۇرغۇچ"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "ھالەت ئۈزچاتى #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "سول توپچا #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "ئوڭ توپچا #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "ئۈستى توپچا #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "ئاستى توپچا #%d"
+
+#~ msgid "No Action"
+#~ msgstr "مەشغۇلات يوق"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "چاشقىنەك سول توپچىسىنىڭ چېكىلىشى"
+
+#~ msgid "Scroll Up"
+#~ msgstr "ئۈستىگە سىيرىش"
+
+#~ msgid "Scroll Right"
+#~ msgstr "ئوڭغا سۈر"
+
+#~ msgid "Top Button"
+#~ msgstr "ئۈستى توپچا"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "تەپسىلىي ھالەتنى قوزغات"
+
+#~ msgid "Show the overview"
+#~ msgstr "ئۈزۈندىنى كۆرسەت"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "تىزغىلى بولىدىغان تاختا(panel) ئاتلىرىنى تىزىپ ئاخىرلاشتۇرىدۇ"
+
+#~ msgid "Show help options"
+#~ msgstr "ياردەم تاللانمىلىرىنى كۆرسەت"
+
+#~ msgid "Panel to display"
+#~ msgstr "كۆرسىتىدىغان تاختا"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[PANEL] [ARGUMENT…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- تەڭشەكلەر"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "'%s --help' ئىجرا قىلىپ بۇيرۇق قۇرىنىڭ تولۇق تاللانما تىزىمىنى كۆرۈڭ.\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "ئىشلەتكىلى بولىدىغان تاختىلار:"
+
+#~ msgid "Control Center"
+#~ msgstr "باشقۇرۇش مەركىزى"
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "شەخسىي"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "قاتتىق دېتال"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "سىستېما"
 
 #~| msgid "_Mobile Broadband"
 #~ msgid "Mobile broadband"
@@ -6893,9 +8309,6 @@ msgstr "بارلىق تەڭشەكلەر"
 #~ msgid "Disconnected"
 #~ msgstr "ئۈزۈلدى"
 
-#~ msgid "No profile"
-#~ msgstr "سەپلىمە ھۆججەت يوق"
-
 #~ msgid "%i year"
 #~ msgid_plural "%i years"
 #~ msgstr[0] "%i يىل"
@@ -6935,9 +8348,6 @@ msgstr "بارلىق تەڭشەكلەر"
 #~| msgid "Browse for more pictures..."
 #~ msgid "Browse Files..."
 #~ msgstr "ھۆججەتكە كۆز يۈگۈرت..."
-
-#~ msgid "Create virtual device"
-#~ msgstr "مەۋھۇم ئۈسكۈنە قۇر"
 
 #~| msgid "Available Profiles"
 #~ msgid "Available Profiles for Displays"
@@ -7102,15 +8512,9 @@ msgstr "بارلىق تەڭشەكلەر"
 #~ "كۆرسىتىش تىلىدىن بىرنى تاللاڭ(كېيىنكى قېتىم تىزىمغا كىرگەندە ئۆزگەرتىشنى "
 #~ "قوللىنىدۇ)"
 
-#~ msgid "Install languages..."
-#~ msgstr "تىللارنى ئورنات…"
-
 #~| msgid "Brightness"
 #~ msgid "Brightness & Lock"
 #~ msgstr "يورۇقلۇقى ۋە قۇلۇپ"
-
-#~ msgid "Screen brightness and lock settings"
-#~ msgstr "ئېكران يورۇقلۇقى ۋە قۇلۇپ تەڭشىكى"
 
 #~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
 #~ msgstr "يورۇقلۇق؛قۇلۇپ؛غۇۋا؛قارا؛ئېكران؛"
@@ -7123,9 +8527,6 @@ msgstr "بارلىق تەڭشەكلەر"
 
 #~ msgid "Locations..."
 #~ msgstr "ئورۇنلار…"
-
-#~ msgid "Lock"
-#~ msgstr "قۇلۇپلا"
 
 #~ msgid "Enable debugging code"
 #~ msgstr "سازلاش كودىنى قوزغات"
@@ -7141,9 +8542,6 @@ msgstr "بارلىق تەڭشەكلەر"
 
 #~ msgid "Sound Output Volume"
 #~ msgstr "ئاۋاز مىقدارى"
-
-#~ msgid "Microphone Volume"
-#~ msgstr "مىكروفون ئاۋاز مىقدارى"
 
 #~ msgid "Failed to start Sound Preferences: %s"
 #~ msgstr "ئاۋاز مايىللىقىنى قوزغىتالمىدى: %s"
@@ -7285,9 +8683,6 @@ msgstr "بارلىق تەڭشەكلەر"
 #~ msgid "Network"
 #~ msgstr "تور"
 
-#~ msgid "Device types"
-#~ msgstr "ئۈسكۈنە تىپلىرى"
-
 #~ msgid "Opening firewall for mDNS connections"
 #~ msgstr "mDNS باغلىنىشىنىڭ مۇداپىئە تامنى ئېچىۋاتىدۇ"
 
@@ -7299,9 +8694,6 @@ msgstr "بارلىق تەڭشەكلەر"
 
 #~ msgid "_Back"
 #~ msgstr "كەينى(_B)"
-
-#~ msgid "Preview"
-#~ msgstr "ئالدىن كۆزەت"
 
 #~ msgid "Layouts"
 #~ msgstr "ئۇسلۇبلار"
@@ -7319,26 +8711,14 @@ msgstr "بارلىق تەڭشەكلەر"
 #~ "تاللانغان ھەرپتاختا ئورۇنلاشتۇرۇلۇشىنىڭ تەڭشىكىنى\n"
 #~ "كۆڭۈلدىكى تەڭشەك بىلەن ئالماشتۇرىدۇ"
 
-#~ msgid "Reset to De_faults"
-#~ msgstr "كۆڭۈلدىكىگە قايتۇر(_F)"
-
 #~ msgid "View and edit keyboard layout options"
 #~ msgstr "ھەرپتاختا جايلاشتۇرۇش تاللانمىسىنى كۆرۈش ۋە تەھرىرلەش"
-
-#~ msgid "Layout"
-#~ msgstr "ئۇسلۇب"
-
-#~ msgid "A_cceleration:"
-#~ msgstr "تېزلىتىش(_C):"
 
 #~ msgid "Drag and Drop"
 #~ msgstr "سۆرەپ تاشلاش"
 
 #~ msgid "Enable _mouse clicks with touchpad"
 #~ msgstr "سەزگۈر تاختىدا چاشقىنەك چېكىشنى قوزغات(_M)"
-
-#~ msgid "Scrolling"
-#~ msgstr "دومىلات"
 
 #~ msgid "Sh_ow position of pointer when the Control key is pressed"
 #~ msgstr "Ctrl كۇنۇپكا بېسىلسا ئىسترېلكا ئورنى كۆرۈنىدۇ(_O)"
@@ -7371,9 +8751,6 @@ msgstr "بارلىق تەڭشەكلەر"
 #~ msgid "Other..."
 #~ msgstr "باشقا…"
 
-#~ msgid "Not connected to the internet."
-#~ msgstr "ئىنتېرنېتقا باغلانمىغان."
-
 #~ msgid "Create the hotspot anyway?"
 #~ msgstr "قىزىق نۇقتا قۇرۇۋېرەمسىز؟"
 
@@ -7389,14 +8766,8 @@ msgstr "بارلىق تەڭشەكلەر"
 #~ msgid "Network;Wireless;IP;LAN;"
 #~ msgstr "تور؛سىمسىز؛IP؛LAN؛"
 
-#~ msgid "Speed"
-#~ msgstr "سۈرئىتى"
-
 #~ msgid "Subnet Mask"
 #~ msgstr "تارماق تور ماسكىسى"
-
-#~ msgid "Unlock"
-#~ msgstr "قۇلۇپ ئاچ"
 
 #~ msgid "_Network Name"
 #~ msgstr "تور ئاتى(_N)"
@@ -7422,9 +8793,6 @@ msgstr "بارلىق تەڭشەكلەر"
 #~ msgid "On AC _power:"
 #~ msgstr "ئۆزگىرىشچان توك مەنبەسىدە(_P):"
 
-#~ msgid "Put the computer to sleep when inactive:"
-#~ msgstr "ئاكتىپ ئەمەس ۋاقىتتا كومپيۇتېرنى ئۇخلىتىدۇ:"
-
 #~ msgid "Shutdown"
 #~ msgstr "تاقا"
 
@@ -7434,12 +8802,6 @@ msgstr "بارلىق تەڭشەكلەر"
 
 #~ msgid "_Turn off after:"
 #~ msgstr "كېيىن ياپ(_L):"
-
-#~ msgid "Mute"
-#~ msgstr "ئۈنسىز"
-
-#~ msgid "C_hoose a device to configure:"
-#~ msgstr "سەپلەيدىغان ئۈسكۈنە تاللاش(_H):"
 
 #~ msgid "Key"
 #~ msgstr "ئاچقۇچ"
@@ -7539,27 +8901,14 @@ msgstr "بارلىق تەڭشەكلەر"
 #~ msgid "Dasher"
 #~ msgstr "Dasher"
 
-#~ msgid "Decrease size:"
-#~ msgstr "كىچىكلەت:"
-
-#~ msgid "Increase size:"
-#~ msgstr "چوڭلۇقىنى چوڭايتىش:"
-
 #~ msgid "Nomon"
 #~ msgstr "Nomon"
 
 #~ msgid "Type here to test settings"
 #~ msgstr "ھەرپ كىرگۈزۈپ تەڭشەك سىناڭ"
 
-#~ msgid "Typing Assistant"
-#~ msgstr "كىرگۈزۈش ياردەمچىسى"
-
 #~ msgid "_Text size:"
 #~ msgstr "تېكىست چوڭلۇقى(_T):"
-
-#~ msgctxt "universal access, seeing"
-#~ msgid "Display"
-#~ msgstr "كۆرسەتكۈچ"
 
 #~ msgctxt "universal access, seeing"
 #~ msgid "Zoom"
@@ -7579,9 +8928,6 @@ msgstr "بارلىق تەڭشەكلەر"
 
 #~ msgid "Choose a generated password"
 #~ msgstr "ئۆزلۈكىدىن قۇرۇلغان ئىمنى تاللا"
-
-#~ msgid "Account _type"
-#~ msgstr "ھېسابات تىپى(_T)"
 
 #~ msgid "- System Settings"
 #~ msgstr "- سىستېما تەڭشەكلىرى"
@@ -7606,9 +8952,6 @@ msgstr "بارلىق تەڭشەكلەر"
 
 #~ msgid "Keyboard;Mouse;a11y;Accessibility;"
 #~ msgstr "ھەرپتاختا;چاشقىنەك;a11y;قوشۇمچە ئىقتىدار;"
-
-#~ msgid "Locked"
-#~ msgstr "قۇلۇپلانغان"
 
 #~ msgid ""
 #~ "Dialog is unlocked.\n"
@@ -7703,9 +9046,6 @@ msgstr "بارلىق تەڭشەكلەر"
 #~ msgstr ""
 #~ "تېخىمۇ كۆپ ئۈستەلئۈستى باش تېمىسىغا ئېرىشىش URL. ئەگەر بوش ھەرپ تىزمىسى "
 #~ "قىلىپ تەڭشەلسە ئۇنداقتا ئۇلانما كۆرۈنمەيدۇ."
-
-#~ msgid "Clean print heads"
-#~ msgstr "بېسىش باشىنى تازىلا"
 
 #~ msgid "An error has occured during a maintenance command."
 #~ msgstr "ئاسراش بۇيرۇقى ئىجرا بولۇۋاتقاندا خاتالىق كۆرۈلدى."

--- a/po/ug.po~
+++ b/po/ug.po~
@@ -1,0 +1,7721 @@
+# Uighur translation for gnome-control-center
+# Copyright (c) 2008 Rosetta Contributors and Canonical Ltd 2008
+# This file is distributed under the same license as the gnome-control-center package.
+# Sahran <sahran@live.com>, 2010.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2013-02-15 20:13+0000\n"
+"PO-Revision-Date: 2013-02-16 10:05+0900\n"
+"Last-Translator: Gheyret Kenji <gheyret@gmail.com>\n"
+"Language-Team: Uyghur Computer Science Association <UKIJ@yahoogroups.com>\n"
+"Language: ug\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Launchpad-Export-Date: 2010-08-09 22:20+0000\n"
+"X-Generator: Launchpad (build Unknown)\n"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:2
+msgid "Changes throughout the day"
+msgstr "بىر كۈن ئىچىدە ئۈزلۈكسىز ئالماشتۇرىدۇ"
+
+#: ../panels/background/background.ui.h:3
+msgctxt "background, style"
+msgid "Tile"
+msgstr "ياي"
+
+#: ../panels/background/background.ui.h:4
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "كېڭەيت-تارايت"
+
+#: ../panels/background/background.ui.h:5
+msgctxt "background, style"
+msgid "Center"
+msgstr "مەركەز"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Scale"
+msgstr "نىسبىتى"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Fill"
+msgstr "تولدۇر"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Span"
+msgstr "ئارىلىق"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:199
+msgid "Select Background"
+msgstr "تەگلىك تاللا"
+
+#: ../panels/background/cc-background-chooser-dialog.c:218
+msgid "Wallpapers"
+msgstr "تام قەغەزلىرى"
+
+#: ../panels/background/cc-background-chooser-dialog.c:227
+msgid "Pictures"
+msgstr "سۈرەتلەر"
+
+#: ../panels/background/cc-background-chooser-dialog.c:235
+msgid "Colors"
+msgstr "رەڭلەر"
+
+#: ../panels/background/cc-background-chooser-dialog.c:244
+msgid "Flickr"
+msgstr "Flickr"
+
+#: ../panels/background/cc-background-chooser-dialog.c:286
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/data/photo-dialog.ui.h:9
+#: ../panels/user-accounts/um-photo-dialog.c:98
+msgid "Select"
+msgstr "تاللا"
+
+#: ../panels/background/cc-background-item.c:150
+msgid "multiple sizes"
+msgstr "كۆپ خىل چوڭلۇق"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:154
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:283
+msgid "No Desktop Background"
+msgstr "ئۈستەلئۈستى تەگلىك يوق"
+
+#: ../panels/background/cc-background-panel.c:453
+msgid "Current background"
+msgstr "نۆۋەتتىكى تەگلىك"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "تەگلىك"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change the background"
+msgstr "تەگلىكنى ئۆزگەرتىدۇ"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Wallpaper;Screen;Desktop;تام قەغىزى;ئېكران;ئۈستەلئۈستى;"
+
+#. Translator: This string appears next to a toggle switch which controls enabling/disabling Bluetooth radio's on the device.
+#: ../panels/bluetooth/bluetooth.ui.h:2
+msgctxt "Power"
+msgid "Bluetooth"
+msgstr "كۆكچىش"
+
+#: ../panels/bluetooth/bluetooth.ui.h:3
+msgid "Set Up New Device"
+msgstr "يېڭى ئۈسكۈنە تەڭشىكى"
+
+#: ../panels/bluetooth/bluetooth.ui.h:4 ../panels/network/network.ui.h:9
+msgid "Remove Device"
+msgstr "ئۈسكۈنىنى چىقىرىۋەت"
+
+#: ../panels/bluetooth/bluetooth.ui.h:5
+msgid "Connection"
+msgstr "باغلىنىش"
+
+#: ../panels/bluetooth/bluetooth.ui.h:6
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+#: ../panels/region/gnome-region-panel.ui.h:3
+msgid "page 1"
+msgstr "1-بەت"
+
+#: ../panels/bluetooth/bluetooth.ui.h:7
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+#: ../panels/region/gnome-region-panel.ui.h:5
+msgid "page 2"
+msgstr "2-بەت"
+
+#: ../panels/bluetooth/bluetooth.ui.h:8
+msgid "Paired"
+msgstr "جۈپلەنگەن"
+
+#: ../panels/bluetooth/bluetooth.ui.h:9 ../panels/wacom/cc-wacom-page.c:789
+msgid "Type"
+msgstr "تىپى"
+
+#: ../panels/bluetooth/bluetooth.ui.h:10
+#: ../panels/network/connection-editor/ce-page-ip4.c:189
+#: ../panels/network/connection-editor/ce-page-ip4.c:441
+#: ../panels/network/connection-editor/ce-page-ip6.c:191
+#: ../panels/network/connection-editor/ce-page-ip6.c:445
+msgid "Address"
+msgstr "ئادرېس"
+
+#: ../panels/bluetooth/bluetooth.ui.h:11
+msgid "Mouse & Touchpad Settings"
+msgstr "چاشقىنەك ۋە سېزىمچان تاختا تەڭشىكى"
+
+#: ../panels/bluetooth/bluetooth.ui.h:12
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Sound Settings"
+msgstr "ئاۋاز تەڭشەكلىرى‏"
+
+#: ../panels/bluetooth/bluetooth.ui.h:13
+msgid "Keyboard Settings"
+msgstr "ھەرپتاختا تەڭشەكلىرى‏"
+
+#: ../panels/bluetooth/bluetooth.ui.h:14
+msgid "Send Files…"
+msgstr "ھۆججەت يوللاش…"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:355
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "ھەئە"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:355
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "ياق"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:469
+msgid "Bluetooth is disabled"
+msgstr "كۆكچىش ئىناۋەتسىز قىلىندى"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:474
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "كۆكچىش قاتتىق ئۈزچات تەرىپىدىن چەكلەنگەن"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:478
+msgid "No Bluetooth adapters found"
+msgstr "كۆكچىش ماسلاشتۇرغۇچىسى تېپىلمىدى"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:577
+msgid "Visibility"
+msgstr "كۆرۈشچانلىقى"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:581
+#, c-format
+msgid "Visibility of “%s”"
+msgstr "«%s» نىڭ كۆرۈنۈشچانلىقى"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:625
+#, c-format
+msgid "Remove '%s' from the list of devices?"
+msgstr "‹%s› نى ئۈسكۈنە تىزىمىدىن ئۆچۈرسۇنمۇ؟"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:627
+msgid ""
+"If you remove the device, you will have to set it up again before next use."
+msgstr "ئەگەر سىز بۇ ئۈسكىنىنى ئۆچۈرۈۋەتسىڭىز،كىيىن ئىشلەتكەندە قايتا تەڭشەش زۆرۈر بولىدۇ."
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+msgid "Bluetooth"
+msgstr "كۆكچىش"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Configure Bluetooth settings"
+msgstr "كۆكچىش تەڭشىكىنى تەڭشەش"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:360
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "تەڭشەيدىغان  ئۈسكۈنىنى تىك تۆتبۇلۇڭ ئۈستىگە قويۇپ ‹باشلا› نى بېسىڭ"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:366
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr "تەڭشەيدىغان ئۈسكۈنىنى تەڭشەيدىغان ئورۇنغا يۆتكەپ ‹داۋاملاشتۇر› نى بېسىڭ"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:372
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr "تەڭشەيدىغان ئۈسكۈنىنى سىرتقى يۈزدىكى ئورۇنغا يۆتكەپ ‹داۋاملاشتۇر› نى بېسىڭ"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:378
+msgid "Shut the laptop lid"
+msgstr "يان كومپيۇتېرنىڭ قېپىنى يېپىڭ"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:409
+msgid "An internal error occurred that could not be recovered."
+msgstr "ئىچكى خاتالىق كۆرۈلۈپ، ئەسلىگە كەلتۈرگىلى بولمىدى."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:414
+msgid "Tools required for calibration are not installed."
+msgstr "تەڭشەشكە زۆرۈر بولغان قوراللار ئورنىتىلماپتۇ."
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:420
+msgid "The profile could not be generated."
+msgstr "بۇ profile نى قۇرغىلى بولمىدى."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:426
+msgid "The target whitepoint was not obtainable."
+msgstr "نىشاندىكى ئاق نۇقتىغا ئېرىشكىلى بولمايدۇ."
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:466
+msgid "Complete!"
+msgstr "تامام!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:474
+msgid "Calibration failed!"
+msgstr "تەڭشەش مەغلۇپ بولدى!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:481
+msgid "You can remove the calibration device."
+msgstr "تەڭشەيدىغان ئۈسكۈنىنى چىقىرىۋەتسىڭىز بولمايدۇ."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:552
+msgid "Do not disturb the calibration device while in progress"
+msgstr "بىر تەرەپ قىلىۋاتقاندا تەڭشەيدىغان ئۈسكۈنىگە دەخلى قىلماڭ"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "يان كومپيۇتېر ئېكرانى"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "ئۆزىدىكى توركامېراسى"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s ئېكران"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s شويلىلىغۇچ"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s كامېرا"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s پرىنتېر"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s تور كامېراسى"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+#| msgid "Learn more about color management"
+msgid "Enable color management for %s"
+msgstr "%s نىڭ نىسبەتەن رەڭ باشقۇرۇشىنى ئىناۋەتلىك قىل"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "%s نىڭ رەڭ profiles نى كۆرسەت"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:318
+msgid "Not calibrated"
+msgstr "تەڭشەلمىگەن"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:132
+msgid "Default: "
+msgstr "كۆڭۈلدىكى: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:140
+msgid "Colorspace: "
+msgstr "رەڭ بوشلۇق: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:147
+msgid "Test profile: "
+msgstr "سىناق سەپلىمە ھۆججەت: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:215
+msgid "Select ICC Profile File"
+msgstr "ICC سەپلىمە ھۆججەتنى تاللايدۇ"
+
+#: ../panels/color/cc-color-panel.c:218
+msgid "_Import"
+msgstr "ئىمپورت قىل(_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:229
+msgid "Supported ICC profiles"
+msgstr "قوللايدىغان ICC سەپلىمە ھۆججەتلەر"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+#: ../panels/network/wireless-security/eap-method-fast.c:410
+msgid "All files"
+msgstr "ھەممە ھۆججەتلەر"
+
+#: ../panels/color/cc-color-panel.c:580
+msgid "Screen"
+msgstr "ئېكران"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:852
+msgid "Save Profile"
+msgstr "Profile نى ساقلاش"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1213
+msgid "Create a color profile for the selected device"
+msgstr "تاللانغان ئۈسكۈنە ئۈچۈن بىر رەڭ سەپلىمە ھۆججىتى قۇرىدۇ"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1228 ../panels/color/cc-color-panel.c:1252
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "تەكشۈرىدىغان چالغۇ بايقالمىدى. ئۇنىڭ ئېچىلىپ توغرا باغلانغانلىقىنى تەكشۈرۈڭ."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1262
+msgid "The measuring instrument does not support printer profiling."
+msgstr "تەكشۈرىدىغان چالغۇ پرىنتېر سەپلىمە ھۆججىتىنى قوللىمايدۇ."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1273
+msgid "The device type is not currently supported."
+msgstr "بۇ خىل ئۈسكۈنە تىپىنى نۆۋەتتە قوللىمايدۇ."
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:101
+msgid "Standard Space"
+msgstr "ئۆلچەملىك بوشلۇق"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:107
+msgid "Test Profile"
+msgstr "سىناق سەپلىمە ھۆججەت(Profile)"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:115
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "ئاپتوماتىك"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:125
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "سۈپىتى تۆۋەن"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:130
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "سۈپىتى نورمال"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:137
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "سۈپىتى يۇقىرى"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:154
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "كۆڭۈلدىكى RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:161
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "كۆڭۈلدىكى CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:168
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "كۆڭۈلدىكى كۈلرەڭلىك"
+
+#: ../panels/color/cc-color-profile.c:192
+msgid "Vendor supplied factory calibration data"
+msgstr "ياسىغۇچى ئورۇن تەمىنلىگەن ئەسلىدىكى تەڭشەش سانلىق-مەلۇماتلار"
+
+#: ../panels/color/cc-color-profile.c:201
+msgid "Full-screen display correction not possible with this profile"
+msgstr "بۇ profile دا تولۇق ئېكراننى تەڭشەشكە مۇمكىن بولمايدۇ"
+
+#: ../panels/color/cc-color-profile.c:223
+msgid "This profile may no longer be accurate"
+msgstr "مەزكۇر profile ئەمدى توغرا بولماسلىقى مۇمكىن"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "ئېكراننى تەڭشەش"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/data/photo-dialog.ui.h:8
+#: ../panels/user-accounts/um-account-dialog.c:1067
+msgid "Cancel"
+msgstr "ئەمەلدىن قالدۇر"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "باشلاش"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "داۋاملاشتۇر"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "تامام"
+
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/gui_gtk.c:78
+msgid "Screen Calibration"
+msgstr "ئېكراننى تەڭشەش"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "تەڭشەش ئېلىپ بېرىۋاتقان چاغدا سىز باشقا مەشغۇلاتلارنى قىلالمايسىز."
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "سۈپەت"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "تەخمىنىي ۋاقىت"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "تەڭشەش سۈپىتى"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "تەڭشەشتە ئىشلىتىدىغان سەزگۈچنى تاللاڭ."
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "تەڭشەش ئۈسكۈنىسى"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "چېتىلغان كۆرسەتكۈچنىڭ تىپىنى تاللاڭ."
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "ئېكران تىپى"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr "سىز ماس كەلگەن يورۇقلۇقنى بەلگىلەڭ.  مۇشۇ يورۇقلۇق دەرىجىسىدە رەڭ باشقۇرۇش تېخىمۇ توغرا بولىدۇ."
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "ئېكران يورۇقلۇقى"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "سەپلىمە ھۆججەت ئاتى:"
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "سەپلىمە ھۆججەت ئاتى"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "سەپلىمە ھۆججەت مۇۋەپپەقىيەتلىك ياسالدى."
+
+#: ../panels/color/color.ui.h:22
+msgid "Export"
+msgstr "ئېكسپورت قىلىش"
+
+#: ../panels/color/color.ui.h:23
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: ../panels/color/color.ui.h:24
+#: ../panels/user-accounts/um-fingerprint-dialog.c:743
+msgid "Summary"
+msgstr "ئۈزۈندى"
+
+#: ../panels/color/color.ui.h:25
+msgid "Import File…"
+msgstr "ھۆججەت ئىمپورت قىلىش"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr "مەسىلە بايقالدى. بۇ profile نورمال ئىشلىمىگەندەك قىلىدۇ. <a href=\"\">تەپسىلاتى بۇ يەردە.</a>"
+
+#: ../panels/color/color.ui.h:27
+msgid "Device type:"
+msgstr "ئۈسكۈنە تىپى:"
+
+#: ../panels/color/color.ui.h:28
+msgid "Manufacturer:"
+msgstr "ياسىغۇچى:"
+
+#: ../panels/color/color.ui.h:29
+msgid "Model:"
+msgstr "تىپى:"
+
+#: ../panels/color/color.ui.h:30
+msgid ""
+"Image files can be dragged on this window to auto-complete the above fields."
+msgstr "سۈرەت ھۆججەتنى بۇ كۆزنەككە سۆرەپ ئۈستىدىكى سۆز بۆلەكلىرىنى ئۆزلۈكىدىن تولدۇرغىلى بولىدۇ."
+
+#: ../panels/color/color.ui.h:31
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Color"
+msgstr "رەڭ"
+
+#: ../panels/color/color.ui.h:32
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "ھەر بىر ئۈسكۈنە رەڭ باشقۇرغۇچ ئارقىلىق رەڭ سەپلىمە ھۆججىتىنى يېڭىلاشقا ئېھتىياجلىق."
+
+#: ../panels/color/color.ui.h:33
+msgid "Learn more"
+msgstr "تەپسىلات بىلدۈرگۈسى"
+
+#: ../panels/color/color.ui.h:34
+msgid "Learn more about color management"
+msgstr "رەڭ باشقۇرۇش ھەققىدە تېخىمۇ كۆپ ئۇچۇر"
+
+#: ../panels/color/color.ui.h:35
+msgid "Set for all users"
+msgstr "ھەممە ئىشلەتكۈچىنىڭ تەڭشىكى"
+
+#: ../panels/color/color.ui.h:36
+msgid "Set this profile for all users on this computer"
+msgstr "كومپيۇتېردىكى بارلىق ئىشلەتكۈچىدە مۇشۇ profile نى ئىشلەتسۇن"
+
+#: ../panels/color/color.ui.h:37
+msgid "Enable"
+msgstr "قوزغات"
+
+#: ../panels/color/color.ui.h:38
+msgid "Add profile"
+msgstr "سەپلىمە ھۆججەت قوش"
+
+#: ../panels/color/color.ui.h:39
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate…"
+msgstr "تۈزەت…"
+
+#: ../panels/color/color.ui.h:40
+msgid "Calibrate the device"
+msgstr "ئۈسكۈنىنى تۈزەت"
+
+#: ../panels/color/color.ui.h:41
+msgid "Remove profile"
+msgstr "سەپلىمە ھۆججەت چىقىرىۋەت"
+
+#: ../panels/color/color.ui.h:42
+msgid "View details"
+msgstr "تەپسىلاتىنى كۆرسەت"
+
+#: ../panels/color/color.ui.h:43
+msgid "Unable to detect any devices that can be color managed"
+msgstr "رەڭ باشقۇرىدىغان ھېچقانداق ئۈسكۈنىنى بايقىمىدى"
+
+#: ../panels/color/color.ui.h:44
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:45
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:46
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:47
+msgid "Projector"
+msgstr "پرويېكتور"
+
+#: ../panels/color/color.ui.h:48
+msgid "Plasma"
+msgstr "پلازما"
+
+#: ../panels/color/color.ui.h:49
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "يۇقىرى"
+
+#: ../panels/color/color.ui.h:50
+msgid "40 minutes"
+msgstr "40 مىنۇت"
+
+#: ../panels/color/color.ui.h:51
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "ئوتتۇراھال"
+
+#: ../panels/color/color.ui.h:52 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 مىنۇت"
+
+#: ../panels/color/color.ui.h:53
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "تۆۋەن"
+
+#: ../panels/color/color.ui.h:54 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 مىنۇت"
+
+#: ../panels/color/color.ui.h:55
+msgid "Native to display"
+msgstr ""
+
+#: ../panels/color/color.ui.h:56
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (باسمىچىلىق ۋە نەشرىيات)"
+
+#: ../panels/color/color.ui.h:57
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:58
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (سۈرەتچىلىك ۋە گرافىك)"
+
+#: ../panels/color/color.ui.h:59
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid "Color management settings"
+msgstr "رەڭ باشقۇرۇش تەڭشىكى"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "رەڭ;ICC;سەپلىمە ھۆججەت;تۈزىتىش;پرىنتېر;ئېكران;"
+
+#: ../panels/common/cc-common-language.c:639
+msgid "British English"
+msgstr "ئەنگلىيە ئىنگلىزچە"
+
+#: ../panels/common/cc-common-language.c:642
+msgid "Spanish"
+msgstr "ئىسپانچە"
+
+#: ../panels/common/cc-common-language.c:643
+msgid "Chinese (simplified)"
+msgstr "ئاددىي خەنزۇچە"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:687
+msgid "United States"
+msgstr "ئامېرىكا قوشما شتاتلىرى"
+
+#: ../panels/common/cc-common-language.c:688
+msgid "Germany"
+msgstr "گېرمانىيە"
+
+#: ../panels/common/cc-common-language.c:689
+msgid "France"
+msgstr "فىرانسىيە"
+
+#: ../panels/common/cc-common-language.c:690
+msgid "Spain"
+msgstr "ئىسپانىيە"
+
+#: ../panels/common/cc-common-language.c:691
+msgid "China"
+msgstr "جۇڭگو"
+
+#: ../panels/common/cc-language-chooser.c:120
+msgid "Other…"
+msgstr "باشقا…"
+
+#: ../panels/common/cc-language-chooser.c:292
+msgid "Select a region"
+msgstr "رايون تاللاڭ"
+
+#: ../panels/common/language-chooser.ui.h:1
+msgid "Select a language"
+msgstr "تىل تاللا"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/user-accounts/um-user-panel.c:467
+msgid "_Cancel"
+msgstr "ئەمەلدىن قالدۇر(_C)"
+
+#: ../panels/common/language-chooser.ui.h:3
+msgid "_Select"
+msgstr "تاللا(_S)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "_Region:"
+msgstr "رايون(_R):"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "_City:"
+msgstr "شەھەر(_C):"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "_Network Time"
+msgstr "تور ۋاقتى(_N):"
+
+#. Translator: this is the separator between hours and minutes, like in HH:MM
+#: ../panels/datetime/datetime.ui.h:5
+msgid ":"
+msgstr ":"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "Set the time one hour ahead."
+msgstr "ۋاقىتنى بىر سائەت ئىلگىرى تەڭشەيدۇ."
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "Set the time one hour back."
+msgstr "ۋاقىتنى بىر سائەت كېيىن تەڭشەيدۇ."
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "Set the time one minute ahead."
+msgstr "ۋاقىتنى بىر مىنۇت ئىلگىرى تەڭشەيدۇ."
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "Set the time one minute back."
+msgstr "ۋاقىتنى بىر مىنۇت كېيىن تەڭشەيدۇ."
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "Switch between AM and PM."
+msgstr "چۈشتىن بۇرۇن بىلەن چۈشتىن كېيىن ئارىسىدا ئالماشتۇرىدۇ."
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "Month"
+msgstr "ئاي"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "Day"
+msgstr "كۈن"
+
+#: ../panels/datetime/datetime.ui.h:13
+msgid "Year"
+msgstr "يىل"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "24-hour"
+msgstr "24 سائەت"
+
+#: ../panels/datetime/datetime.ui.h:15
+msgid "AM/PM"
+msgstr "چ ب/چ ك"
+
+#: ../panels/datetime/datetime.ui.h:16
+msgid "January"
+msgstr "قەھرىتان"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "February"
+msgstr "ھۇت"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "March"
+msgstr "نەۋرۇز"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "April"
+msgstr "ئۈمىد"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "May"
+msgstr "باھار"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "June"
+msgstr "سەپەر"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "July"
+msgstr "چىللە"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "August"
+msgstr "تومۇز"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "September"
+msgstr "مىزان"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "October"
+msgstr "ئوغۇز"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "November"
+msgstr "ئوغلاق"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "December"
+msgstr "كۆنەك"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "چېسلا & ۋاقىت"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Date and Time preferences panel"
+msgstr "چېسلا ۋە ۋاقىت مايىللىق تاختىسى"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "سائەت;ۋاقىت رايونى;ئورۇن;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "سىستېمىنىڭ ۋاقىت ۋە چېسلا تەڭشىكىنى ئۆزگەرت"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "ۋاقىت ۋە چېسلا تەڭشىكى ئۆزگەرتىش ئۈچۈن سالاھىيەت دەلىللەش زۆرۈردۇر"
+
+#: ../panels/display/cc-display-panel.c:483
+msgctxt "display panel, rotation"
+msgid "Normal"
+msgstr "نورمال"
+
+#: ../panels/display/cc-display-panel.c:484
+msgctxt "display panel, rotation"
+msgid "Counterclockwise"
+msgstr "سائەت يۆنىلىشىگە قارشى"
+
+#: ../panels/display/cc-display-panel.c:485
+msgctxt "display panel, rotation"
+msgid "Clockwise"
+msgstr "سائەت يۆنىلىشى"
+
+#: ../panels/display/cc-display-panel.c:486
+msgctxt "display panel, rotation"
+msgid "180 Degrees"
+msgstr "180 گرادۇس"
+
+#. Keep this string in sync with gnome-desktop/libgnome-desktop/gnome-rr-labeler.c
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external projector.  Here, "Mirrored" is being
+#. * used as an adjective.  For example, the Spanish translation could be
+#. * "Pantallas en Espejo".
+#.
+#. Keep this string in sync with gnome-control-center/capplets/display/xrandr-capplet.c:get_display_name()
+#. Translators:  this is the feature where what you see on your
+#. * laptop's screen is the same as your external projector.
+#. * Here, "Mirrored" is being used as an adjective.  For example,
+#. * the Spanish translation could be "Pantallas en Espejo".
+#.
+#: ../panels/display/cc-display-panel.c:625
+#: ../panels/display/cc-rr-labeler.c:449
+msgid "Mirrored Displays"
+msgstr "نۇسخىلانغان كۆرسەتكۈچلەر"
+
+#: ../panels/display/cc-display-panel.c:649
+#: ../panels/display/display-capplet.ui.h:1
+msgid "Monitor"
+msgstr "ئېكران"
+
+#: ../panels/display/cc-display-panel.c:1669
+msgid "Drag to change primary display."
+msgstr "ئاساسىي كۆزەتكۈچ سۆرەپ تەڭشىلىدۇ."
+
+#: ../panels/display/cc-display-panel.c:1727
+msgid ""
+"Select a monitor to change its properties; drag it to rearrange its "
+"placement."
+msgstr "كۆزەتكۈچتىن بىرنى تاللاپ خاسلىقى ئۆزگەرتىلىدۇ؛ سۆرەپ ئۇلارنىڭ ئورنى تەڭشىلىدۇ."
+
+#: ../panels/display/cc-display-panel.c:2115
+msgid "%a %R"
+msgstr "%a %R"
+
+#: ../panels/display/cc-display-panel.c:2117
+msgid "%a %l:%M %p"
+msgstr "%p%l:%M (%a)"
+
+#: ../panels/display/cc-display-panel.c:2279
+#: ../panels/display/cc-display-panel.c:2331
+#, c-format
+msgid "Failed to apply configuration: %s"
+msgstr "سەپلىمىنى قوللىنالمىدى: %s"
+
+#: ../panels/display/cc-display-panel.c:2359
+msgid "Could not save the monitor configuration"
+msgstr "كۆزەتكۈچ تەڭشەكلىرىنى ساقلىغىلى بولمىدى"
+
+#: ../panels/display/cc-display-panel.c:2419
+msgid "Could not detect displays"
+msgstr "كۆرسەتكۈچلەر بايقالمىدى"
+
+#: ../panels/display/cc-display-panel.c:2614
+msgid "Could not get screen information"
+msgstr "ئېكران ئۇچۇرىغا ئېرىشكىلى بولمىدى"
+
+#: ../panels/display/display-capplet.ui.h:2
+msgid "_Resolution"
+msgstr "ئېنىقلىقى(_R)"
+
+#: ../panels/display/display-capplet.ui.h:3
+msgid "R_otation"
+msgstr "چۆرگىلىتىش(_O)"
+
+#. Note that mirror is a verb in this string
+#: ../panels/display/display-capplet.ui.h:5
+msgid "_Mirror displays"
+msgstr "نۇسخىلانغان كۆرسەتكۈچلەر(_M)"
+
+#: ../panels/display/display-capplet.ui.h:6
+msgid "Note: may limit resolution options"
+msgstr "ئىزاھات: ئېنىقلىق نىسبىتى تاللانمىسىنى چەكلىمىگە ئۇچرىشى مۇمكىن"
+
+#: ../panels/display/display-capplet.ui.h:7
+msgid "_Detect Displays"
+msgstr "كۆرسەتكۈچلەرنى بايقا(_D)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "كۆرسەتكۈچلەر"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Change resolution and position of monitors and projectors"
+msgstr "كۆزەتكۈچ ۋە پرويېكتورنىڭ ئېنىقلىق ۋە ئورنىنى ئۆزگەرت"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;"
+msgstr "تاختا;پرويېكتور;xrandr;ئېكران;ئېنىقلىق;يېڭىلا;"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:441 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "نامەلۇم"
+
+#: ../panels/info/cc-info-panel.c:542
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d-بىت"
+
+#: ../panels/info/cc-info-panel.c:544
+#, c-format
+msgid "%d-bit"
+msgstr "%d-بىت"
+
+#: ../panels/info/cc-info-panel.c:1219
+msgid "Ask what to do"
+msgstr "مەشغۇلاتنى سورا"
+
+#: ../panels/info/cc-info-panel.c:1223
+msgid "Do nothing"
+msgstr "ھېچقانداق قىلما"
+
+#: ../panels/info/cc-info-panel.c:1227
+msgid "Open folder"
+msgstr "قىسقۇچ ئاچ"
+
+#: ../panels/info/cc-info-panel.c:1318
+msgid "Other Media"
+msgstr "باشقا ۋاسىتە"
+
+#: ../panels/info/cc-info-panel.c:1349
+msgid "Select an application for audio CDs"
+msgstr "ئۈن CD ئۈچۈن پروگرامما تاللاڭ"
+
+#: ../panels/info/cc-info-panel.c:1350
+msgid "Select an application for video DVDs"
+msgstr "سىن CD ئۈچۈن پروگرامما تاللاڭ"
+
+#: ../panels/info/cc-info-panel.c:1351
+msgid "Select an application to run when a music player is connected"
+msgstr "مۇزىكا قويغۇ باغلانغاندا ئىجرا بولىدىغان پروگراممىنى تاللايدۇ"
+
+#: ../panels/info/cc-info-panel.c:1352
+msgid "Select an application to run when a camera is connected"
+msgstr "كامېرا باغلانغاندا ئىجرا بولىدىغان پروگراممىنى تاللايدۇ"
+
+#: ../panels/info/cc-info-panel.c:1353
+msgid "Select an application for software CDs"
+msgstr "يۇمشاق دېتال CD سى ئۈچۈن پروگرامما تاللاڭ"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1365
+msgid "audio DVD"
+msgstr "ئۈن DVD"
+
+#: ../panels/info/cc-info-panel.c:1366
+msgid "blank Blu-ray disc"
+msgstr "قۇرۇق كۆكنۇر دىسكىسى"
+
+#: ../panels/info/cc-info-panel.c:1367
+msgid "blank CD disc"
+msgstr "قۇرۇق CD دىسكىسى"
+
+#: ../panels/info/cc-info-panel.c:1368
+msgid "blank DVD disc"
+msgstr "قۇرۇق DVD دىسكىسى"
+
+#: ../panels/info/cc-info-panel.c:1369
+msgid "blank HD DVD disc"
+msgstr "قۇرۇق HD DVD دىسكىسى"
+
+#: ../panels/info/cc-info-panel.c:1370
+msgid "Blu-ray video disc"
+msgstr "كۆكنۇر سىن دىسكىسى"
+
+#: ../panels/info/cc-info-panel.c:1371
+msgid "e-book reader"
+msgstr "ئې-كىتاب ئوقۇغۇ"
+
+#: ../panels/info/cc-info-panel.c:1372
+msgid "HD DVD video disc"
+msgstr "HD DVD سىن دىسكىسى :"
+
+#: ../panels/info/cc-info-panel.c:1373
+msgid "Picture CD"
+msgstr "سۈرەت CD"
+
+#: ../panels/info/cc-info-panel.c:1374
+msgid "Super Video CD"
+msgstr "ئالاھىدە سىن CD"
+
+#: ../panels/info/cc-info-panel.c:1375
+msgid "Video CD"
+msgstr "سىن CD"
+
+#: ../panels/info/cc-info-panel.c:1376
+msgid "Windows software"
+msgstr "ۋىندوۋس يۇمشاق دېتاللىرى"
+
+#: ../panels/info/cc-info-panel.c:1377
+msgid "Software"
+msgstr "يۇمشاق دېتال"
+
+#: ../panels/info/cc-info-panel.c:1500
+#: ../panels/keyboard/keyboard-shortcuts.c:1697
+msgid "Section"
+msgstr "گۇرۇپپىسى"
+
+#: ../panels/info/cc-info-panel.c:1509 ../panels/info/info.ui.h:13
+msgid "Overview"
+msgstr "قىسقىچە بايان"
+
+#: ../panels/info/cc-info-panel.c:1515 ../panels/info/info.ui.h:20
+msgid "Default Applications"
+msgstr "كۆڭۈلدىكى پروگراممىلار"
+
+#: ../panels/info/cc-info-panel.c:1520 ../panels/info/info.ui.h:28
+msgid "Removable Media"
+msgstr "چىقىرىۋېتىشكە بولىدىغان ۋاسىتە"
+
+#: ../panels/info/cc-info-panel.c:1545
+#, c-format
+msgid "Version %s"
+msgstr "نەشر %s"
+
+#: ../panels/info/cc-info-panel.c:1595
+msgid "Install Updates"
+msgstr "يېڭىلاش قاچىلا"
+
+#: ../panels/info/cc-info-panel.c:1599
+msgid "System Up-To-Date"
+msgstr "سىستېما ئەڭ يېڭى ھالەتتە"
+
+#: ../panels/info/cc-info-panel.c:1603
+msgid "Checking for Updates"
+msgstr "يېڭىلانمىلارنى تەكشۈرۈۋاتىدۇ"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:58
+msgid "Details"
+msgstr "تەپسىلاتلار"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "System Information"
+msgstr "سىستېما ئۇچۇرى"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr "device;system;information;memory;processor;version;default;application;fallback;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;ئۈسكۈنە;سىستېما;ئۇچۇر;ئەسلەك;بىر تەرەپ قىلغۇچ;نەشرى;كۆڭۈلدىكى;ئەپ;زاپاس;ئارقىغا قايتۇر;مايىللىق;cd;dvd;usb;ئۈن;سىن;ئوپتىك دىسكا;نۇر دىسكا;دىسكا;كۆچمە;ۋاسىتە;تاراتقۇ;ئۆزلۈكىدىن ئىجرا قىل;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "بىر تەرەپ قىلىنىدىغان باشقا ۋاسىتىنى تاللاڭ"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "مەشغۇلات(_A):"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "تىپى(_T):"
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "ئۈسكۈنە ئاتى"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "ئەسلەك"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "بىر تەرەپ قىلغۇچ"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "ئاساسى سىستېما"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "دىسكا"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "ھېسابلاش…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "گرافىك"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "مەۋھۇملاشتۇرۇش"
+
+#: ../panels/info/info.ui.h:14
+msgid "_Web"
+msgstr "تور(_W)"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Mail"
+msgstr "خەت(_M)"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Calendar"
+msgstr "يىلنامە(_C)"
+
+#: ../panels/info/info.ui.h:17
+msgid "M_usic"
+msgstr "نەغمە(_U)"
+
+#: ../panels/info/info.ui.h:18
+msgid "_Video"
+msgstr "سىن(_V)"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Photos"
+msgstr "سۈرەتلەر(_P)"
+
+#: ../panels/info/info.ui.h:21
+msgid "Select how media should be handled"
+msgstr "بىر تەرەپ قىلىنىدىغان ۋاسىتىنى تاللاڭ"
+
+#: ../panels/info/info.ui.h:22
+msgid "CD _audio"
+msgstr "CD ئۈن(_A)"
+
+#: ../panels/info/info.ui.h:23
+msgid "_DVD video"
+msgstr "_DVD سىن"
+
+#: ../panels/info/info.ui.h:24
+msgid "_Music player"
+msgstr "نەغمە چالغۇچ(_M)"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Software"
+msgstr "يۇمشاق دېتال(_S)"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Other Media…"
+msgstr "باشقا ۋاسىتە(_O)…"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Never prompt or start programs on media insertion"
+msgstr "ۋاسىتە قىستۇرۇلغاندا ھەرگىز ئەسكەرتمە ياكى پروگرامما قوزغاتما(_N)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "ئاۋاز ۋە ۋاسىتە"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "ئۈنسىزلە"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "ئاۋازنى كىچىكلەت"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "ئاۋازنى چوڭايت"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "ۋاسىتە قويغۇنى قوزغات"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "چال(ياكى چال/ۋاقىتلىق توختات)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "ۋاقىتلىق توختات"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "توختات"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "ئالدىنقى ئاۋاز يولى"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "كېيىنكى ئاۋاز يولى"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "چىقار"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/universal-access/uap.ui.h:66
+msgid "Typing"
+msgstr "كىرگۈزۈۋاتىدۇ"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: ../panels/region/gnome-region-panel.ui.h:27
+msgid "Switch to next source"
+msgstr "كېيىنكى مەنبەگە ئالماشتۇر"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: ../panels/region/gnome-region-panel.ui.h:25
+msgid "Switch to previous source"
+msgstr "ئالدىنقى مەنبەگە ئالماشتۇر"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "ئىجراچىلار"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "ياردەم قوزغاتقۇنى قوزغات"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3
+msgid "Launch calculator"
+msgstr "ھېسابلىغۇچنى قوزغات"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch email client"
+msgstr "ئەخلەت ئوقۇغۇنى قوزغات"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch web browser"
+msgstr "توركۆرگۈنى قوزغات"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Home folder"
+msgstr "ماكان مۇندەرىجە"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgctxt "keybinding"
+msgid "Search"
+msgstr "ئىزدە"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "ئېكران كۆرۈنۈشى"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "ئېكران كۆرۈنۈشىنى $PICTURES غا ساقلايدۇ"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "كۆزنەكنىڭ ئېكران كۆرۈنۈشىنى $PICTURES غا ساقلايدۇ"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "رايوننىڭ ئېكران كۆرۈنۈشىنى $PICTURES غا ساقلايدۇ"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "بىر ئېكران كۆرۈنۈشىنى چاپلاش تاختىسىغا كۆچۈرىدۇ"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "بىر كۆزنەكنىڭ ئېكران كۆرۈنۈشىنى چاپلاش تاختىسىغا كۆچۈرىدۇ"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "بىر دائىرىنىڭ ئېكران كۆرۈنۈشىنى چاپلاش تاختىسىغا كۆچۈرىدۇ"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+#: ../panels/region/gnome-region-panel.ui.h:43
+msgid "System"
+msgstr "سىستېما"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "تىزىمدىن چىق"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "ئېكراننى قۇلۇپلا"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "ئۇنىۋېرسال زىيارەت"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "ئېكران چوڭايت كىچىكلەتنى ئاچ ياكى تاقا"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "چوڭايت"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "كىچىكلەت"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "ئېكران ئوقۇغۇچنى ئاچ ياكى تاقا"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "ئېكران ھەرپتاختىنى ئاچ ياكى تاقا"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "تېكىستنى چوڭايت"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "تېكىستنى كىچىكلەت"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "يۇقىرى پەرقنى ئاچ ياكى تاقا"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:254
+#: ../panels/keyboard/cc-keyboard-option.c:304
+#: ../panels/keyboard/cc-keyboard-option.c:436
+#: ../panels/keyboard/keyboard-shortcuts.c:1160
+#: ../panels/network/network-wifi.ui.h:30
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:215
+#: ../panels/user-accounts/um-fingerprint-dialog.c:216
+msgid "Disabled"
+msgstr "ئىناۋەتسىز قىلىنغان"
+
+#: ../panels/keyboard/cc-keyboard-option.c:255
+msgid "Left Shift"
+msgstr "سول Shift"
+
+#: ../panels/keyboard/cc-keyboard-option.c:256
+msgid "Left Alt"
+msgstr "سول Alt"
+
+#: ../panels/keyboard/cc-keyboard-option.c:257
+msgid "Left Ctrl"
+msgstr "سول Ctrl"
+
+#: ../panels/keyboard/cc-keyboard-option.c:258
+msgid "Right Shift"
+msgstr "ئوڭ Shift"
+
+#: ../panels/keyboard/cc-keyboard-option.c:259
+msgid "Right Alt"
+msgstr "ئوڭ Alt"
+
+#: ../panels/keyboard/cc-keyboard-option.c:260
+msgid "Right Ctrl"
+msgstr "ئوڭ Ctrl"
+
+#: ../panels/keyboard/cc-keyboard-option.c:261
+msgid "Left Alt+Shift"
+msgstr "سول Alt+Shift"
+
+#: ../panels/keyboard/cc-keyboard-option.c:262
+msgid "Right Alt+Shift"
+msgstr "ئوڭ Alt+Shift"
+
+#: ../panels/keyboard/cc-keyboard-option.c:263
+msgid "Left Ctrl+Shift"
+msgstr "سول Ctrl+Shift"
+
+#: ../panels/keyboard/cc-keyboard-option.c:264
+msgid "Right Ctrl+Shift"
+msgstr "ئوڭ Ctrl+Shift"
+
+#: ../panels/keyboard/cc-keyboard-option.c:265
+msgid "Left+Right Shift"
+msgstr "سول+ئوڭ Shift"
+
+#: ../panels/keyboard/cc-keyboard-option.c:266
+msgid "Left+Right Alt"
+msgstr "سول+ئوڭ Alt"
+
+#: ../panels/keyboard/cc-keyboard-option.c:267
+msgid "Left+Right Ctrl"
+msgstr "سول+ئوڭ Ctrl"
+
+#: ../panels/keyboard/cc-keyboard-option.c:268
+msgid "Alt+Shift"
+msgstr "Alt+Shift"
+
+#: ../panels/keyboard/cc-keyboard-option.c:269
+msgid "Ctrl+Shift"
+msgstr "Ctrl+Shift"
+
+#: ../panels/keyboard/cc-keyboard-option.c:270
+msgid "Alt+Ctrl"
+msgstr "Alt+Ctrl"
+
+#: ../panels/keyboard/cc-keyboard-option.c:271
+msgid "Caps"
+msgstr "Caps"
+
+#: ../panels/keyboard/cc-keyboard-option.c:272
+msgid "Shift+Caps"
+msgstr "Shift+Caps"
+
+#: ../panels/keyboard/cc-keyboard-option.c:273
+msgid "Alt+Caps"
+msgstr "Alt+Caps"
+
+#: ../panels/keyboard/cc-keyboard-option.c:274
+msgid "Ctrl+Caps"
+msgstr "Ctrl+Caps"
+
+#: ../panels/keyboard/cc-keyboard-option.c:390
+msgid "Alternative Characters Key"
+msgstr "ئورنىغا ئىشلىتىدىغان ھەرپلەر كۇنۇپكىسى"
+
+#: ../panels/keyboard/cc-keyboard-option.c:395
+msgid "Compose Key"
+msgstr "Compose كۇنۇپكىسى"
+
+#: ../panels/keyboard/cc-keyboard-option.c:399
+msgid "Modifiers-only switch to next source"
+msgstr ""
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "Keyboard"
+msgstr "ھەرپتاختا"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "Change keyboard settings"
+msgstr "ھەرپتاختا تەڭشىكىنى ئۆزگەرت"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Shortcut;Repeat;Blink;قىسقا يول;تەكرارلاش;چاقناش;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "ئىختىيارى تېزلەتمە"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+msgid "_Name:"
+msgstr "ئاتى(_N):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+msgid "C_ommand:"
+msgstr "بۇيرۇق(_O):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "Repeat Keys"
+msgstr "تەكرار كۇنۇپكا"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Key presses _repeat when key is held down"
+msgstr "مەلۇم كۇنۇپكا بېسىپ تۇرۇلغاندا شۇ كۇنۇپكىنى تەكرارلا(_R)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "_Delay:"
+msgstr "كېچىكتۈر(_D):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Speed:"
+msgstr "سۈرئەت(_S):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "قىسقا"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "ئاستا"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgid "Repeat keys speed"
+msgstr "تەكرار كۇنۇپكا سۈرئىتى"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "ئۇزۇن"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "تېز"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgid "Cursor Blinking"
+msgstr "نۇربەلگىنىڭ لىپىلدىشى"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor _blinks in text fields"
+msgstr "تېكىست رايونىدا نۇربەلگىسى لىپىلدىسۇن(_B)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "S_peed:"
+msgstr "سۈرئىتى(_P):"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "Cursor blink speed"
+msgstr "سىنبەلگە لىپىلداش سۈرئىتى"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Layout Settings"
+msgstr "جايلاشتۇر تەڭشىكى"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+msgid "Add Shortcut"
+msgstr "قىسقا يول قوش"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Remove Shortcut"
+msgstr "قىسقا يولنى چىقىرىۋەت"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr "تېزلەتمىنى تەھرىرلەشتە، مۇناسىپ قۇرنى تاق چېكىپ ئاندىن يېڭى تېزلەتمە كىرگۈزۈلىدۇ ياكى backspace ئۆچۈرۈش كۇنۇپكىسىدا تازىلىنىدۇ."
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+#: ../panels/region/gnome-region-panel.ui.h:30
+msgid "Shortcuts"
+msgstr "تېزلەتمىلەر"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:585
+#: ../panels/keyboard/keyboard-shortcuts.c:593
+msgid "Custom Shortcuts"
+msgstr "ئىختىيارى تېزلەتمە"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:804
+msgid "<Unknown Action>"
+msgstr "<نامەلۇم مەشغۇلات>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1301
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr "تېزلەتمە «%s» ئىشلەتكىلى بولمايدۇ، چۈنكى ئۇنى ئىشلەتكەندە كىرگۈزگىلى بولمايدۇ، بىرلا ۋاقىتتا Control ، Alt ياكى Shift نى ئىشلىتىشنى سىناڭ."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1333
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr "«%s» تېزلەتمە «%s» غا ئىشلىتىلگەن"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1338
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "ئەگەر تېزلەتمىنى «%s»غا بەلگىلىسىڭىز،  «%s» نىڭ تېزلەتمە چەكلىنىدۇ."
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1344
+msgid "_Reassign"
+msgstr "قايتا تەيىنلە(_R)"
+
+#: ../panels/mouse/cc-mouse-panel.c:123
+msgid "Test Your _Settings"
+msgstr "تەڭشىكىمنى سىناپ كۆرەي(_S)"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "چاشقىنەك ۋە سەزگۈر تاختا"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid "Set your mouse and touchpad preferences"
+msgstr "چاشقىنەك ۋە سېزىمچان تاختا مايىللىقىنى تەڭشەيدۇ"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;سەزگۈر تاختا;ئىسترېلكا;چەك;نوقۇ;قوش;توپچا;ئىزلاش شارچىسى;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "Mouse Preferences"
+msgstr "چاشقىنەك مايىللىقى"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgid "General"
+msgstr "ئادەتتىكى"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgctxt "mouse, speed"
+msgid "Slow"
+msgstr "ئاستا"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgid "Double-click timeout"
+msgstr "قوش چېكىش مۆھلىتى"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgctxt "mouse, speed"
+msgid "Fast"
+msgstr "تېز"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "_Double-click"
+msgstr "قوش چېكىش(_D)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgid "Primary _button"
+msgstr "ئاساسىي توپچا(_B)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "سول(_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "ئوڭ(_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "Mouse"
+msgstr "چاشقىنەك"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgid "_Pointer speed"
+msgstr "كۆرسەتكۈچنىڭ تېزلىكى(_P)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgid "Touchpad"
+msgstr "سېزىمچان تاختا"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Disable while _typing"
+msgstr "كىرگۈزۈۋاتقاندا ئىناۋەتسىز بولسۇن(_T)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgid "Tap to _click"
+msgstr "بېسىلسا چېكىلسۇن(_C)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgid "Two _finger scroll"
+msgstr "ئىككى بارماقتا سىيرىسۇن(_F)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "C_ontent sticks to fingers"
+msgstr ""
+
+#: ../panels/mouse/gnome-mouse-test.c:134
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "چېكىش، قوش چېكىش، سىيرىشنى سىناپ كۆرۈڭ"
+
+#: ../panels/mouse/gnome-mouse-test.c:139
+msgid "Five clicks, GEGL time!"
+msgstr "بەش قېتىم چېكىلدى، GEGL ۋاقتى"
+
+#: ../panels/mouse/gnome-mouse-test.c:144
+msgid "Double click, primary button"
+msgstr "قوش چېكىش، ئاساسىي توپچا"
+
+#: ../panels/mouse/gnome-mouse-test.c:144
+msgid "Single click, primary button"
+msgstr "يەككە چېكىش، ئاساسىي توپچا"
+
+#: ../panels/mouse/gnome-mouse-test.c:147
+msgid "Double click, middle button"
+msgstr "قوش چېكىش، ئوتتۇرا توپچا"
+
+#: ../panels/mouse/gnome-mouse-test.c:147
+msgid "Single click, middle button"
+msgstr "يەككە چېكىش، ئوتتۇرا توپچا"
+
+#: ../panels/mouse/gnome-mouse-test.c:150
+msgid "Double click, secondary button"
+msgstr "قوش چېكىش، ئىككىنچى توپچا"
+
+#: ../panels/mouse/gnome-mouse-test.c:150
+msgid "Single click, secondary button"
+msgstr "يەككە چېكىش، ئىككىنچى توپچا"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:341
+msgid "Air_plane Mode"
+msgstr "ئايروپىلان ھالىتى(_P)"
+
+#: ../panels/network/cc-network-panel.c:904
+msgid "Network proxy"
+msgstr "تور ۋاكالەتچىسى"
+
+#: ../panels/network/cc-network-panel.c:1083 ../panels/network/net-vpn.c:280
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1217
+msgid "The system network services are not compatible with this version."
+msgstr "سىستېمىنىڭ تور مۇلازىمىتى بۇ نەشرىدىكى تور باشقۇرغۇچ بىلەن ماسلاشمايدۇ."
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x بىخەتەرلىكى(_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "ئاتسىز كىملىك(_M)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "ئىچكى ئىسپات"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Security"
+msgstr "بىخەتەرلىك"
+
+#: ../panels/network/connection-editor/ce-page.c:502
+msgid "automatic"
+msgstr "ئاپتوماتىك"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:224
+#: ../panels/network/net-device-wifi.c:385
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:228
+#: ../panels/network/net-device-wifi.c:390
+#: ../panels/network/network-wifi.ui.h:17
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:232
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:237
+msgid "Enterprise"
+msgstr "كارخانا"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:242
+#: ../panels/network/net-device-wifi.c:375
+msgctxt "Wifi security"
+msgid "None"
+msgstr "يوق"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "ھەرگىز"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:770
+msgid "Today"
+msgstr "بۈگۈن"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:773
+msgid "Yesterday"
+msgstr "تۈنۈگۈن"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:479
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i  كۈن ئىلگىرى"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:537
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d مېگابايت/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "None"
+msgstr "يوق"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:568
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "ئاجىز"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:570
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "تامام"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:572
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "ياخشى"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:574
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "ناھايىتى ياخشى"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:200
+#: ../panels/network/connection-editor/ce-page-vpn.c:172
+#: ../panels/network/connection-editor/ce-page-wifi.c:243
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Identity"
+msgstr "سالاھىيەت"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:202
+#: ../panels/network/connection-editor/ce-page-ip4.c:454
+msgid "Netmask"
+msgstr "تور ماسكىسى"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:216
+#: ../panels/network/connection-editor/ce-page-ip4.c:467
+#: ../panels/network/connection-editor/ce-page-ip6.c:217
+#: ../panels/network/connection-editor/ce-page-ip6.c:475
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "تور ئۆتكىلى"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:233
+#: ../panels/network/connection-editor/ce-page-ip6.c:234
+#| msgid "_Cloned Address"
+msgid "Delete Address"
+msgstr "ئادرېسلارنى ئۆچۈرۈش"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:285
+#: ../panels/network/connection-editor/ce-page-ip6.c:286
+#| msgid "_Add"
+msgid "Add"
+msgstr "قوش"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:350
+#: ../panels/network/connection-editor/ce-page-ip6.c:354
+msgid "Server"
+msgstr "مۇلازىمېتىر"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:367
+#: ../panels/network/connection-editor/ce-page-ip6.c:371
+#| msgid "Delete device"
+msgid "Delete DNS Server"
+msgstr "DNS مۇلازىمېتىرنى ئۆچۈرۈش"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:481
+#: ../panels/network/connection-editor/ce-page-ip6.c:489
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "مېترىك"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:502
+#: ../panels/network/connection-editor/ce-page-ip6.c:510
+#| msgid "Default Route"
+msgid "Delete Route"
+msgstr "يولنى(Route) ئۆچۈرۈش"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:616
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Automatic (DHCP)"
+msgstr "ئاپتوماتىك(DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:620
+#: ../panels/network/connection-editor/ce-page-ip6.c:622
+#: ../panels/network/network-wifi.ui.h:25
+msgid "Manual"
+msgstr "قولدا"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:624
+#: ../panels/network/connection-editor/ce-page-ip6.c:626
+msgid "Link-Local Only"
+msgstr "پەقەت Link-Local"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:925
+#: ../panels/network/network-wifi.ui.h:60
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:204
+#: ../panels/network/connection-editor/ce-page-ip6.c:458
+msgid "Prefix"
+msgstr "ئالدى قوشۇلغۇچى"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:614
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "ئاپتوماتىك"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:618
+msgid "Automatic, DHCP only"
+msgstr "ئاپتوماتىك، پەقەت DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:886
+#: ../panels/network/network-wifi.ui.h:61
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:63
+msgid "Reset"
+msgstr "ئەسلىگە قايتۇرۇش"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "يوق"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128 بىتلىق ئاچقۇچ(16لىك ياكى ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128 بىتلىق شىفىر"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "دىنامىكىلىق WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA ۋە WPA2 كىشىلىك نۇسخىسى"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA ۋە WPA2 كارخانا نۇسخىسى"
+
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+msgid "_Apply"
+msgstr "قوللان(_A)"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:2
+msgid "Signal Strength"
+msgstr "سىگنال كۈچلۈكلۈكى"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Link speed"
+msgstr "ئۇلىنىش تېزلىكى"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "‍‍IPv4 ئادرېس"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "‍IPv6 ئادرېس"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:1
+#: ../panels/network/network-wifi.ui.h:7
+msgid "Hardware Address"
+msgstr "قاتتىق دېتال ئادرېسى"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:8
+msgid "Default Route"
+msgstr "كۆڭۈلدىكى يېتەكلىگۈ"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:9
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "ئاخىرقى قېتىم ئىشلەتكەن"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "قوش پىلاستىك لىنىيە (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "قوشۇلما بۆلۈم ئارايۈزى(AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "ۋاسىتە مۇستەقىل ئارايۈزى(MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 مېگابايت/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 مېگابايت/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 گىگابايت/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 گىگابايت/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "ئاتى(_N)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:49
+msgid "_MAC Address"
+msgstr "MAC ئادرېس(_M)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "كۇلونلانغان ئادرېس(_C):"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Connect _automatically"
+msgstr "ئاپتوماتىك باغلان(_A)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+msgid "Make available to other _users"
+msgstr "باشقا ئىشلەتكۈچىلەرمۇ ئىشلىتەلەيدىغان بولسۇن(_U)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+msgid "bytes"
+msgstr "بايت"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:23
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:24
+msgid "_Addresses"
+msgstr "ئادرېسلار(_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+#| msgid "Automatic"
+msgid "Automatic DNS"
+msgstr "ئاپتوماتىك DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:39
+msgid "Routes"
+msgstr "يوللار"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+#| msgid "Automatic Suspend"
+msgid "Automatic Routes"
+msgstr "ئاپتوماتىك يوللار(Routes)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:45
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:47
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:267
+msgid "Unable to open connection editor"
+msgstr "باغلىنىش تەھرىرلىگۈچىنى ئاچقىلى بولمىدى"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:282
+msgid "New Profile"
+msgstr "يېڭى سەپلىمە ھۆججەت"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:504
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1068
+msgid "_Add"
+msgstr "قوش(_A)"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:586
+#: ../panels/network/network.ui.h:4 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:587
+msgid "Bond"
+msgstr ""
+
+#: ../panels/network/connection-editor/net-connection-editor.c:588
+msgid "Bridge"
+msgstr "كۆۋرۈك"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:589
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:739
+msgid "Could not load VPN plugins"
+msgstr "ۋ پ ن(VPN) قىستۇرمىلىرىنى ئوقۇغىلى بولمىدى"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "ھۆججەتتىن ئەكىر…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:870
+msgid "Add Network Connection"
+msgstr "تور باغلىنىشى قوشۇش"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:53
+msgid "_Reset"
+msgstr "ئەسلىگە قايتۇر(_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1411
+#: ../panels/network/network-wifi.ui.h:54
+msgid "_Forget"
+msgstr "ئۇنتۇپ كەت(_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr "مەزكۇر تورنىڭ تەڭشەكلىرىنى ئەسلىگە قايتۇرىدۇ، بىراق ئۇنى ئالدى بىلەن ئۇلىنىدىغان تور قىلىپ ئەستە تۇتىدۇ"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr "مەزكۇر تورغا مۇناسىۋەتلىك بولغان بارلىق تەپسىلاتلارنى ئۆچۈرىدۇ ۋە ئۇنىڭغا  ئاپتوماتىك ئۇلانمايدىغان بولىدۇ"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "S_ecurity"
+msgstr "بىخەتەرلىك(_E)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "VPN باغلىنىشىنى ئىمپورت قىلالمىدى"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr "‹%s› ھۆججىتىنى ئوقۇيالمىدى ياكى تونۇلغان VPN باغلىنىش ئۇچۇرىنى ئۆز ئىچىگە ئالمىغان\n"
+"\n"
+"خاتالىق: %s."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "ئىمپورت قىلىدىغان ھۆججەتنى تاللا"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "«%s» ئاتلىق بىر ھۆججەت ئەزەلدىن مەۋجۇت."
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "ئالماشتۇر(_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "سىز ساقلىغان %s نى VPN باغلىنىشىغا ئالماشتۇرامسىز؟"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "ۋ پ ن (VPN)  باغلىنىشىنى ئېكسپورت قىلغىلى بولمىدى"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr "ۋ پ ن(VPN) باغلىنىشى ‹%s› نى %s گە ئېكسپورت قىلغىلى بولمىدى.\n"
+"\n"
+"خاتالىق: %s"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+msgid "Export VPN connection..."
+msgstr "ۋ پ ن (VPN)  باغلىنىشىنى ئېكسپورت قىل..."
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(خاتالىق: ۋ پ ن (VPN) باغلىنىش تەھرىرلىگۈچىنى ئوقۇغىلى بولمىدى)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:12
+msgid "_SSID"
+msgstr "SSID (_S):"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:13
+msgid "_BSSID"
+msgstr "BSSID (_B):"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:16
+msgid "My Home Network"
+msgstr "ئۆيۈمدىكى تور"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Make available to _other users"
+msgstr "باشقا ئىشلەتكۈچىلەرمۇ ئىشلىتەلەيدىغان بولسۇن(_O)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "تور"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Network settings"
+msgstr "تور تەڭشەك"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;"
+msgstr "تور;سىمسىز تور;Wi-Fi;Wifi;IP;LAN;ۋاكالەتچى;WAN;يۆتكەلمە خەۋەرلىشىش;مودېم;كۆكچىش;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr ""
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr ""
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:465
+msgid "never"
+msgstr "ھەرگىز"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:475
+msgid "today"
+msgstr "بۈگۈن"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:477
+msgid "yesterday"
+msgstr "تۈنۈگۈن"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "‍IP ئادرېس:"
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Last used"
+msgstr "ئەڭ ئاخىرقى قېتىم ئىشلەتكىنى"
+
+#: ../panels/network/net-device-ethernet.c:337
+#: ../panels/network/net-device-wifi.c:1549
+#: ../panels/network/network-ethernet.ui.h:2
+#: ../panels/network/network-vpn.ui.h:8 ../panels/universal-access/uap.ui.h:23
+msgid "Options…"
+msgstr "تاللانمىلار…"
+
+#: ../panels/network/net-device-ethernet.c:472
+#, c-format
+msgid "Profile %d"
+msgstr ""
+
+#: ../panels/network/net-device-mobile.c:239
+msgid "Add new connection"
+msgstr "يېڭى باغلىنىش قوشۇش"
+
+#: ../panels/network/net-device-wifi.c:1120
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr "ئەگەر سىزنىڭ سىمسىز توردىن باشقا ئىنتېرنېت باغلىنىشىڭىز بار بولسا، سىمسىز قىزىق نۇقتا قۇرۇپ، باغلىنىشىڭىزنى باشقىلار بىلەن ھەمبەھىر قىلالايسىز."
+
+#: ../panels/network/net-device-wifi.c:1124
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "سىمسىز قىزىق نۇقتىغا ئالماشسىڭىز <b>%s</b> بىلەن بولغان باغلىنىش ئۈزۈلىدۇ."
+
+#: ../panels/network/net-device-wifi.c:1128
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr "سىمسىز قىزىق نۇقتا ئاكتىپ ھالەتتە تۇرۇۋاتقاندا، سىمسىز تورىڭىز ئارقىلىق ئىنتېرنېتنى زىيارەت قىلالمايسىز."
+
+#: ../panels/network/net-device-wifi.c:1202
+msgid "Stop hotspot and disconnect any users?"
+msgstr "قىزىق نۇقتىنى توختىتىپ، ھەر قانداق ئىشلەتكۈچىنى ئۈزەمدۇ؟"
+
+#: ../panels/network/net-device-wifi.c:1205
+msgid "_Stop Hotspot"
+msgstr "قىزىق نۇقتىنى توختات(_S)"
+
+#: ../panels/network/net-device-wifi.c:1277
+msgid "System policy prohibits use as a Hotspot"
+msgstr "سىستېما سىياسىتى بويىچە Hotspot قىلىپ ئىشلىتىش چەكلەنگەن"
+
+#: ../panels/network/net-device-wifi.c:1280
+#| msgid "InfiniBand device does not support connected mode"
+msgid "Wireless device does not support Hotspot mode"
+msgstr "سىمسىز ئۈسكۈنە Hotspot ھالىتىنى قوللىمايدىكەن"
+
+#: ../panels/network/net-device-wifi.c:1407
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr "تاللانغان تورنىڭ تەپسىلاتلىرى يەنى ئىم ۋە باشقا ئىختىيارىي سەپلىمە قاتارلار يوقىلىدۇ."
+
+#: ../panels/network/net-device-wifi.c:1714
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:14
+msgid "History"
+msgstr "ئىز"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1726
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "ئۇنتۇپ كەت(_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "سەپلەنگەن URL تەمىنلەنمىگەن بولسا تور ۋاكالەتچىسىنى ئۆزلۈكىدىن بايقاپ ئىشلىتىدۇ."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "ئىشەنچسىز ئاممىۋى تورغا نىسبەتەن بۇنداق قىلىش تەۋسىيە قىلىنمايدۇ."
+
+#: ../panels/network/net-proxy.c:408
+msgid "Proxy"
+msgstr "ۋاكالەتچى"
+
+#: ../panels/network/network-ethernet.ui.h:1
+msgid "_Add Profile…"
+msgstr "سەپلىمە ھۆججەت قوش(_A)…"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "تەمىنلىگۈچى"
+
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:7
+msgid "_Options…"
+msgstr "تاللانمىلار(_O)…"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:5
+msgctxt "proxy method"
+msgid "None"
+msgstr "يوق"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:6
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "قولدا"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:7
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "ئاپتوماتىك"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "ئۇسۇل(_M)"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "سەپلىمە URL (_C)"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "_HTTP ۋاكالەتچى"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS ۋاكالەتچى"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "_FTP ۋاكالەتچى"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "SOCKS مۇلازىمېتىر"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "كومپيۇتېرلارغا پەرۋا قىلما(_I) "
+
+#: ../panels/network/network-proxy.ui.h:11
+#| msgid "_HTTP Proxy"
+msgid "HTTP proxy port"
+msgstr "HTTP ۋاكالەتچىنىڭ ئېغىزى"
+
+#: ../panels/network/network-proxy.ui.h:12
+#| msgid "H_TTPS Proxy"
+msgid "HTTPS proxy port"
+msgstr "HTTPS ۋاكالەتچى ئېغىزى"
+
+#: ../panels/network/network-proxy.ui.h:13
+#| msgid "_FTP Proxy"
+msgid "FTP proxy port"
+msgstr "FTP ۋاكالەتچى ئېغىزى"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "Socks ۋاكالەتچى ئېغىزى"
+
+#: ../panels/network/network-simple.ui.h:6
+#| msgid "Turn on or off:"
+msgid "Turn device off"
+msgstr "ئۈسكۈنىنى ئەت"
+
+#: ../panels/network/network.ui.h:1
+msgid "Select the interface to use for the new service"
+msgstr "يېڭى مۇلازىمەتكە ئىشلىتىدىغان ئېغىزنى تاللاڭ"
+
+#: ../panels/network/network.ui.h:2
+msgid "C_reate…"
+msgstr "قۇر(_R)…"
+
+#: ../panels/network/network.ui.h:3
+msgid "_Interface"
+msgstr "ئارايۈز(_I)"
+
+#: ../panels/network/network.ui.h:8
+msgid "Add Device"
+msgstr "ئۈسكۈنە قوش"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN تىپى"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "گۇرۇپپا ئاتى"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "گۇرۇپپا ئىم"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "ئىشلەتكۈچى ئاتى"
+
+#: ../panels/network/network-vpn.ui.h:7
+#| msgid "Export VPN connection..."
+msgid "Turn VPN connection off"
+msgstr "ۋ پ ن(VPN) باغلىنىشىنى ئەت"
+
+#: ../panels/network/network-wifi.ui.h:1
+msgid "Automatic _Connect"
+msgstr "ئاپتوماتىك باغلانسۇن(_C)"
+
+#: ../panels/network/network-wifi.ui.h:11
+msgid "details"
+msgstr "تەپسىلاتلار"
+
+#: ../panels/network/network-wifi.ui.h:15
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "_Password"
+msgstr "ئىم(_P)"
+
+#: ../panels/network/network-wifi.ui.h:18
+#: ../panels/universal-access/uap.ui.h:8
+msgid "None"
+msgstr "يوق"
+
+#: ../panels/network/network-wifi.ui.h:19
+msgid "blablabla"
+msgstr "blablabla"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "Show P_assword"
+msgstr "ئىم كۆرسەت(_A)"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "Make available to other users"
+msgstr "باشقا ئىشلەتكۈچىلەرمۇ ئىشلىتەلەيدىغان بولسۇن"
+
+#: ../panels/network/network-wifi.ui.h:22
+msgid "identity"
+msgstr "سالاھىيەت، كىملىك"
+
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Automatic (DHCP) addresses only"
+msgstr "پەقەت ئاپتوماتىك(DHCP) ئادرېسلار"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Link-local only"
+msgstr "پەقەت Link-Local"
+
+#: ../panels/network/network-wifi.ui.h:29
+msgid "Shared with other computers"
+msgstr "باشقا كومپيۇتېرلار بىلەن ھەمبەھىرلەنگەن"
+
+#: ../panels/network/network-wifi.ui.h:31
+msgid ""
+"Address\n"
+"section\n"
+"goes\n"
+"here"
+msgstr "ئادرېس\n"
+"بۆلىكىنى\n"
+"بۇ يەرگە\n"
+"يېزىڭ"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid ""
+"DNS\n"
+"section\n"
+"goes\n"
+"here"
+msgstr "DNS\n"
+"بۆلىكىنى\n"
+"بۇ يەرگە\n"
+"يېزىڭ"
+
+#: ../panels/network/network-wifi.ui.h:40
+msgid ""
+"Routes\n"
+"section\n"
+"goes\n"
+"here"
+msgstr "يېتەكچىلەر\n"
+"بۆلىكىنى\n"
+"بۇ يەرگە\n"
+"يېزىڭ"
+
+#: ../panels/network/network-wifi.ui.h:44
+msgid "_Ignore automatically obtained routes"
+msgstr "ئاپتوماتىك ئېرىشكەن route لارنى نەزەرگە ئالمىسۇن(_I)"
+
+#: ../panels/network/network-wifi.ui.h:46
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:48
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "_Cloned MAC Address"
+msgstr "كۇلونلانغان MAC ئادرېسلار(_C)"
+
+#: ../panels/network/network-wifi.ui.h:51
+msgid "00:24:16:31:8G:7A"
+msgstr "00:24:16:31:8G:7A"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "hardware"
+msgstr "قاتتىق دېتال"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr "مەزكۇر تورنىڭ تەڭشەكلىرىنى كۆڭۈلدىكى قىممەتلەرگە قايتۇرىدۇ، بىراق ئۇنى ئالدى بىلەن ئۇلىنىدىغان تور قىلىپ ئەستە تۇتىدۇ"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr "مەزكۇر تورغا مۇناسىۋەتلىك بولغان بارلىق تەپسىلاتلارنى ئۆچۈرىدۇ ۋە ئۇنىڭغا  ئاپتوماتىك ئۇلانمايدىغان بولىدۇ."
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "reset"
+msgstr "ئەسلىگە قايتۇر"
+
+#: ../panels/network/network-wifi.ui.h:62
+msgid "Hardware"
+msgstr "قاتتىق دېتال"
+
+#: ../panels/network/network-wifi.ui.h:64
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi قىزىق نۇقتىسى"
+
+#: ../panels/network/network-wifi.ui.h:65
+msgid "_Turn On"
+msgstr "ئاچ(_T)"
+
+#: ../panels/network/network-wifi.ui.h:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:67
+#| msgid "Turn on or off:"
+msgid "Turn Wi-Fi off"
+msgstr "Wi-Fi نى ئەت"
+
+#: ../panels/network/network-wifi.ui.h:68
+msgid "_Use as Hotspot…"
+msgstr "قىزىق نۇقتا سۈپىتىدە ئىشلەت(_U)…"
+
+#: ../panels/network/network-wifi.ui.h:69
+msgid "_Connect to Hidden Network…"
+msgstr "يوشۇرۇن تورغا باغلا(_C)…"
+
+#: ../panels/network/network-wifi.ui.h:70
+msgid "_History"
+msgstr "ئىز(_H)"
+
+#: ../panels/network/network-wifi.ui.h:71
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "Wi-Fi تورىغا باغلىنىشنى يېپىش"
+
+#: ../panels/network/network-wifi.ui.h:72
+msgid "Network Name"
+msgstr "تور ئاتى"
+
+#: ../panels/network/network-wifi.ui.h:73
+msgid "Connected Devices"
+msgstr "باغلانغان ئۈسكۈنىلەر"
+
+#: ../panels/network/network-wifi.ui.h:74
+msgid "Security type"
+msgstr "بىخەتەرلىك تىپى"
+
+#: ../panels/network/network-wifi.ui.h:75
+msgid "Security key"
+msgstr "بىخەتەرلىك ئاچقۇچى"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "قۇرۇلما"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "ھالىتى نامەلۇم"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "باشقۇرۇلمىغان"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "ئىشلەتكىلى بولمايدۇ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "باغلىنىۋاتىدۇ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "سالاھىيەت دەلىللەش زۆرۈر"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "باغلاندى"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "ئۈزۈۋاتىدۇ"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "باغلىنىش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "ھالىتى نامەلۇم (يوقالدى)"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "باغلانمىغان"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "سەپلەش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "IP سەپلەش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "IP سەپلەشنىڭ قەرەلى توشتى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "بىخەتەرلىك ئۇچۇرلىرى كېرەك ئىدى، بىراق تەمىنلەنمەپتۇ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x supplicant ئۈزۈلدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x supplicant نى سەپلەش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1x supplicant مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "كىملىك دەلىللەشتە 802.1x supplicant جىق ۋاقىت ئالدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "PPP مۇلازىمىتىنى باشلاش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "PPP مۇلازىمىتى ئۈزۈلدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "DHCP خېرىدارىنى باشلاش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP خېرىدارىدا خاتالىق كۆرۈلدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP خېرىدارى مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "ھەمبەھىر باغلىنىش مۇلازىمىتىنى باشلاش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "ھەمبەھىر باغلىنىش مۇلازىمىتى مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "AutoIP مۇلازىمىتىنى باشلاش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "AutoIP مۇلازىمىتىدە خاتالىق كۆرۈلدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "AutoIP مۇلازىمىتى مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "ئالاقە يولى ئالدىراش"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "نومۇر باسقاندىكى ئاۋاز يوق"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "توشۇغۇچىنى قۇرغىلى بولمىدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "نومۇر بېسىشنىڭ قەرەلى توشتى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "نومۇر بېسىش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "مودېمنى دەسلەپلەشتۈرۈش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "كۆرسىتىلگەن APN نى تاللاش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "تورنى ئىزدىمىدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "تورغا خەتلىتىش رەت قىلىندى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "تورغا خەتلىتىشنىڭ قەرەلى توشتى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "تەلەپ قىلىنغان تورغا خەتلىتىش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "PIN تەكشۈرۈش مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "مەزكۇر ئۈسكۈنىنىڭ مۇقىم دېتالى يوقتەك قىلىدۇ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "باغلىنىش غايىب بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "مەۋجۇت باغلىنىش دەپ قارايدۇ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "مودېم تېپىلمىدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "كۆكچىش باغلىنىشى مەغلۇپ بولدى"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "SIM كارتىسى سېلىنمىغان"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "SIM نىڭ Pin نومۇرى زۆرۈر"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "SIM نىڭ Puk ئى زۆرۈر"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "SIM خاتا"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "InfiniBand ئۈسكۈنىسى باغلىنىش ھالىتىنى قوللىمايدۇ"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "باغلىنىشقا كېرەكلىك ئۈسكۈنە تەييار بولمىدى"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "مۇقىم دېتال كەم"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "كابېل چېتىلمىغان"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "گۇۋاھنامە تارقاتقان ئورگان گۇۋاھنامىسىنى تاللىمىدى"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr "تەكشۈرۈش مەركىزى(CA)نىڭ گۇۋاھنامىسىنى ئىشلەتمەسلىك بىخەتەر بولمىغان، مۈجمەل سىمسىز تورغا(Wi-Fi) باغلاپ قويۇشى مۇمكىن. تەكشۈرۈش مەركىزىنىڭ گۇۋاھنامىسىنى تاللاشنى ئىستەمسىز؟"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "پەرۋا قىلما"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "CA گۇۋاھنامىسى تاللا"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER، PEM ياكى PKCS#12 شەخسىي ئاچقۇچلار(*.der، *.pem،*.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER ياكى PEM گۇۋاھنامىسى(der.*، pem.*، crt.*، cer.*)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:261
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:277
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:399
+msgid "Choose a PAC file..."
+msgstr "PAC ھۆججىتىنى تاللاڭ…"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:406
+msgid "PAC files (*.pac)"
+msgstr "PAC ھۆججەتلىرى(*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC ھۆججىتى(_F)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "ئىچكى ئىسپات(_I)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr ""
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "ئاتسىز"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "سالاھىيىتى دەلىللەنگەن"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "ئىككىلىسى"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "_Username"
+msgstr "ئىشلەتكۈچى ئاتى(_U)"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "ئىمنى كۆرسەت(_W)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:434
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate..."
+msgstr "بىر گۇۋاھنامە تەكشۈرۈش گۇۋاھنامىسى تاللا..."
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "نەشرى 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "نەشرى 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "C_A گۇۋاھنامىسى"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP نەشرى(_V)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "بۇ ئىمنى ھەر ۋاقىت سورىسۇن(_K)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:260
+msgid "Unencrypted private keys are insecure"
+msgstr "شىفىرلانمىغان شەخسىي ئاچقۇچلار بىخەتەر ئەمەس"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:263
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr "تاللىغان شەخسىي ئاچقۇچ بىر ئىم تەرىپىدىن قوغدالمىغاندەك قىلىدۇ. بۇ سىزنىڭ بىخەتەرلىك ئىسپاتنامىڭىزگە تەسىر قىلىدۇ. بىر ئىم تاللاپ شەخسىي ئاچقۇچىڭىزنى قوغداڭ.(شەخسىي ئاچقۇچىڭىزنى openssl ئارقىلىق ئىملىق قوغدىيالايسىز)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:428
+msgid "Choose your personal certificate..."
+msgstr "خۇسۇسىي گۇۋاھنامىڭىزنى تاللاڭ..."
+
+#: ../panels/network/wireless-security/eap-method-tls.c:440
+msgid "Choose your private key..."
+msgstr "شەخسىي ئاچقۇچىڭىزنى تاللاڭ:"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "كىملىك(_I)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "ئىشلەتكۈچى ئىسپاتنامىسى(_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "شەخسىي ئاچقۇچ(_K)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "شەخسىي ئاچقۇچ ئىمى(_P)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "مېنى يەنە ئاگاھلاندۇرما(_W)"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "تونىل TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "قوغدىلىدىغان EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "كىملىك دەلىللەش(_T)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (كۆڭۈلدىكى)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "ئوچۇق سىستېما"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "ھەمبەھىرلەنگەن ئاچقۇچ"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "ئاچقۇچ(_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "ئاچقۇچنى كۆرسەت(_W)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP ئىندېكسى(_X)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "تىپى(_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "ئۇقتۇرۇشلار"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:41
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "ئاۋازلىق ئۇقتۇرۇشلار"
+
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "سەكرىمە لەۋھەلەرنى كۆرسەت"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "لەۋھەلەردە تەپسىلاتلارنى كۆرسەت"
+
+#: ../panels/notifications/cc-edit-dialog.c:45
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "قۇلۇپ ئېكراندا كۆرۈش"
+
+#: ../panels/notifications/cc-edit-dialog.c:46
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "تەپسىلاتلارنى قۇلۇپ ئېكراندا كۆرسىتىش"
+
+#: ../panels/notifications/cc-notifications-panel.c:203
+#: ../panels/power/cc-power-panel.c:1637 ../panels/power/cc-power-panel.c:1644
+#: ../panels/privacy/cc-privacy-panel.c:78
+#: ../panels/privacy/cc-privacy-panel.c:145
+msgid "On"
+msgstr "ئوچۇق"
+
+#: ../panels/notifications/cc-notifications-panel.c:203
+#: ../panels/power/cc-power-panel.c:1631 ../panels/power/cc-power-panel.c:1642
+#: ../panels/privacy/cc-privacy-panel.c:78
+#: ../panels/privacy/cc-privacy-panel.c:145
+msgid "Off"
+msgstr "تاقا"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "ئۇقتۇرۇشلار"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Manage notifications"
+msgstr "ئۇقتۇرۇشلارنى باشقۇرۇش"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Banner;Message;Tray;Popup;ئۇقتۇرۇش;ئۇچۇر;قونداق;سەكرىمە;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "سەكرەپ چىقىدىغان لەۋھەلەرنى كۆرسەت"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "قۇلۇپ ئېكراندا كۆرسىتىش"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:190
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "ھېسابات قوشۇش"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:358
+msgid "Error logging into the account"
+msgstr "ھېساباتقا كىرىشتە خاتالىق كۆرۈلدى"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:412
+msgid "Expired credentials. Please log in again."
+msgstr "ئىسپاتنامىنىڭ ۋاقتى ئۆتكەن. قايتا كىرىڭ."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:415
+msgid "_Log In"
+msgstr "تىزىمغا كىر(_L)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:651
+msgid "Error creating account"
+msgstr "ھېسابات قۇرۇۋاتقاندا خاتالىق كۆرۈلدى"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:693
+msgid "Error removing account"
+msgstr "ھېساباتنى چىقىرىۋېتىشتە خاتالىق كۆرۈلدى"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:729
+msgid "Are you sure you want to remove the account?"
+msgstr "ھېساباتنى راستلا چىقىرىۋېتەمسىز؟"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:731
+msgid "This will not remove the account on the server."
+msgstr "بۇ مۇلازىمېتىردىكى ھېساباتنى چىقىرىۋەتمەيدۇ."
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:732
+msgid "_Remove"
+msgstr "چىقىرىۋەت(_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "توردىكى ھېساباتلار"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Manage online accounts"
+msgstr "توردىكى ھېساباتلارنى باشقۇرۇش"
+
+#. Translators: those are keywords for the online-accounts control-center panel
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;"
+msgstr "Google;Facebook;Twitter;Yahoo;Web;توردا;سۆزلىشىش;يىلنامە;خەت;ئالاقەداش;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "توردىكى ھېساباتلار سەپلەنمىگەن"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "ھېساباتنى چىقىرىۋېتىش"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "بىر تور ھېساباتى قوشۇش"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr "تور ھېساباتى قوشۇلسا، پروگرامما تور ھېساباتىنىڭ پۈتۈكلىرىنى، ئېلخەت، ئالاقەداش، يىلنامە، سۆھبەت ۋە باشقىلارنى زىيارەت قىلالايدۇ."
+
+#: ../panels/power/cc-power-panel.c:184
+msgid "Unknown time"
+msgstr "نامەلۇم"
+
+#: ../panels/power/cc-power-panel.c:190
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i مىنۇت"
+
+#: ../panels/power/cc-power-panel.c:202
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i سائەت"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:210
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "سائەت"
+
+#: ../panels/power/cc-power-panel.c:212
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "مىنۇت"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:231
+#, c-format
+msgid "%s until fully charged"
+msgstr "تولۇق توكلىنىشقا %s بار"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:238
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "دىققەت: قالغىنى %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:243
+#, c-format
+msgid "%s remaining"
+msgstr "قالغىنى %s"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:248 ../panels/power/cc-power-panel.c:276
+msgid "Fully charged"
+msgstr "تولۇق توكلاندى"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:252 ../panels/power/cc-power-panel.c:280
+msgid "Empty"
+msgstr "بوش"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:267
+msgid "Charging"
+msgstr "توكلاۋاتىدۇ"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:272
+msgid "Discharging"
+msgstr "توكسىزلاۋاتىدۇ"
+
+#: ../panels/power/cc-power-panel.c:324
+#, c-format
+msgid "Estimated battery capacity: %s"
+msgstr "توكداننىڭ تەخمىنىي سىغىمى: %s"
+
+#: ../panels/power/cc-power-panel.c:404
+msgctxt "Battery name"
+msgid "Main"
+msgstr "ئاساس"
+
+#: ../panels/power/cc-power-panel.c:406
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "قوشۇمچە"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:493
+msgid "Wireless mouse"
+msgstr "سىمسىز چاشقىنەك"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:497
+msgid "Wireless keyboard"
+msgstr "سىمسىز ھەرپتاختا"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:501
+msgid "Uninterruptible power supply"
+msgstr "ئۈزۈلمەس توك مەنبەسى"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:506
+msgid "Personal digital assistant"
+msgstr "شەخسىي رەقەملىك ياردەمچى"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:510
+msgid "Cellphone"
+msgstr "يانفون"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:514
+msgid "Media player"
+msgstr "ۋاسىتە قويغۇ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:518
+msgid "Tablet"
+msgstr "سەزگۈر تاختا"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:522
+msgid "Computer"
+msgstr "كومپيۇتېر"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:526 ../panels/power/cc-power-panel.c:734
+#: ../panels/power/cc-power-panel.c:1938
+msgid "Battery"
+msgstr "توكدان"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:535
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "توكلاۋاتىدۇ"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:542
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "دىققەت"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Low"
+msgstr "تۆۋەن"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Good"
+msgstr "ياخشى"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "تولۇق توكلاندى"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:561
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "بوش"
+
+#: ../panels/power/cc-power-panel.c:732
+msgid "Batteries"
+msgstr "توكدانلار"
+
+#: ../panels/power/cc-power-panel.c:1074
+msgid "When _idle"
+msgstr "بوش ۋاقىتتا(_I)"
+
+#: ../panels/power/cc-power-panel.c:1401
+msgid "Power Saving"
+msgstr "توك تېجەش"
+
+#: ../panels/power/cc-power-panel.c:1430
+msgid "_Screen Brightness"
+msgstr "ئېكران يورۇقلۇقى(_S)"
+
+#: ../panels/power/cc-power-panel.c:1458
+msgid "_Dim Screen when Inactive"
+msgstr "ئاكتىپ ئەمەس ۋاقتىدا ئېكراننى سۇس قىل(_D)"
+
+#: ../panels/power/cc-power-panel.c:1481
+#| msgid "Full Screen"
+msgid "_Blank Screen"
+msgstr "قۇرۇق ئەركان(_B)"
+
+#: ../panels/power/cc-power-panel.c:1516
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: ../panels/power/cc-power-panel.c:1544
+msgid "_Mobile Broadband"
+msgstr "كۆچمە كەڭ بەلۋاغ(_M)"
+
+#: ../panels/power/cc-power-panel.c:1582
+msgid "_Bluetooth"
+msgstr "كۆكچىش(_B)"
+
+#: ../panels/power/cc-power-panel.c:1633
+msgid "When on battery power"
+msgstr "توكداندا ئىشلەۋاتقاندا"
+
+#: ../panels/power/cc-power-panel.c:1635
+msgid "When plugged in"
+msgstr "توك مەنبەسى ئۇلانغاندا"
+
+#: ../panels/power/cc-power-panel.c:1762
+msgid "Suspend & Power Off"
+msgstr "توڭلات ۋە توكنى ئۈز"
+
+#: ../panels/power/cc-power-panel.c:1793
+msgid "_Automatic Suspend"
+msgstr "ئاپتوماتىك توڭلات(_A)"
+
+#: ../panels/power/cc-power-panel.c:1815
+msgid "When Battery Power is _Critical"
+msgstr "توكداننىڭ توكى تۆۋەنلەپ خەتەرلىك ھالەتكە كەلگەندە(_C)"
+
+#: ../panels/power/cc-power-panel.c:1848
+msgid "Power Off"
+msgstr "توكنى ئۈز"
+
+#: ../panels/power/cc-power-panel.c:1990
+msgid "Devices"
+msgstr "ئۈسكۈنىلەر"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "توك مەنبە"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "Power management settings"
+msgstr "توك مەنبە باشقۇرۇش تەڭشىكى"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+#, fuzzy
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;توك مەنبە؛ئۇخلاش؛ئۈچەك؛توكدان؛يورۇقلۇق؛قۇرۇق؛ئېكران؛كۆزەتكۈچ؛"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "ئۈچەك"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "توكنى ئۈز"
+
+#: ../panels/power/power.ui.h:5
+#| msgid "5 minutes"
+msgid "45 minutes"
+msgstr "45 مىنۇت"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 سائەت"
+
+#: ../panels/power/power.ui.h:7
+#| msgid "40 minutes"
+msgid "80 minutes"
+msgstr "80 مىنۇت"
+
+#: ../panels/power/power.ui.h:8
+#| msgid "40 minutes"
+msgid "90 minutes"
+msgstr "90 مىنۇت"
+
+#: ../panels/power/power.ui.h:9
+#| msgid "10 minutes"
+msgid "100 minutes"
+msgstr "100 مىنۇت"
+
+#: ../panels/power/power.ui.h:10
+#| msgid "1 hour"
+msgid "2 hours"
+msgstr "2 سائەت"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "%1 مىنۇت"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 مىنۇت"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 مىنۇت"
+
+#: ../panels/power/power.ui.h:14
+#| msgid "40 minutes"
+msgid "4 minutes"
+msgstr "4 مىنۇت"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 مىنۇت"
+
+#: ../panels/power/power.ui.h:16
+#| msgid "5 minutes"
+msgid "8 minutes"
+msgstr "8 مىنۇت"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 مىنۇت"
+
+#: ../panels/power/power.ui.h:18
+#| msgid "2 minutes"
+msgid "12 minutes"
+msgstr "12 مىنۇت"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "ئاپتوماتىك توڭلىتىش"
+
+#: ../panels/power/power.ui.h:21 ../panels/privacy/privacy.ui.h:10
+msgid "_Close"
+msgstr "ياپ(_C)"
+
+#: ../panels/power/power.ui.h:22
+#| msgid "When _Plugged In"
+msgid "_Plugged In"
+msgstr "قىستۇرۇلدى(_P)"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "كېچىكتۈر"
+
+#: ../panels/power/power.ui.h:24
+#| msgid "When on _Battery Power"
+msgid "On _Battery Power"
+msgstr "توكداندا ئىشلەۋاتقاندا(_B)"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+#| msgid "Authenticated"
+msgid "Authenticate"
+msgstr "كىملىك دەلىللەش"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:21
+msgid "Password"
+msgstr "ئىم"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+#| msgid "Authentication required"
+msgid "Authentication Required"
+msgstr "سالاھىيەت دەلىللەش زۆرۈر"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:591
+msgid "Low on toner"
+msgstr "كۇكۇن ئاز قالدى"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:593
+msgid "Out of toner"
+msgstr "كۇكۇن تۈگەپ كەتتى"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:596
+msgid "Low on developer"
+msgstr "تەسۋىر روشەنلەشتۈرگۈچ ئاز قالدى"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:599
+msgid "Out of developer"
+msgstr "تەسۋىر روشەنلەشتۈرگۈچ تۈگەپ قالدى"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:601
+msgid "Low on a marker supply"
+msgstr "بەلگە سىياھ تەمىنلەش ئاز قالدى"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:603
+msgid "Out of a marker supply"
+msgstr "بەلگە سىياھ تەمىنلەش تۈگەپ قالدى"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:605
+msgid "Open cover"
+msgstr "قاپقاقنى ئاچ"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:607
+msgid "Open door"
+msgstr "ئىشىكنى ئاچ"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:609
+msgid "Low on paper"
+msgstr "قەغەز ئاز قالدى"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:611
+msgid "Out of paper"
+msgstr "قەغەز يېتىشمىدى"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:613
+msgctxt "printer state"
+msgid "Offline"
+msgstr "توردا يوق"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:615
+#: ../panels/printers/cc-printers-panel.c:806
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "توختىدى"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:617
+msgid "Waste receptacle almost full"
+msgstr "ئەخلەت قاچىسى توشۇپ قالاي دېدى"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:619
+msgid "Waste receptacle full"
+msgstr "ئەخلەت قاچىسى توشۇپ قالدى"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:621
+msgid "The optical photo conductor is near end of life"
+msgstr "نۇر سەزگۈچنىڭ ئۆمرى ئاز قالدى"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:623
+msgid "The optical photo conductor is no longer functioning"
+msgstr "نۇر سەزگۈچ خىزمەت قىلالمايدۇ"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:733
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "سەپلەۋاتىدۇ"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:792
+msgctxt "printer state"
+msgid "Ready"
+msgstr "تەييار"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:797
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "ۋەزىپىنى قوبۇل قىلمايدۇ"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:802
+msgctxt "printer state"
+msgid "Processing"
+msgstr "بىر تەرەپ قىلىۋاتىدۇ"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:923
+msgid "Toner Level"
+msgstr " كۇكۇن دەرىجىسى"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:926
+msgid "Ink Level"
+msgstr "سىياھ دەرىجىسى"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:929
+msgid "Supply Level"
+msgstr "تەمىنلەش دەرىجىسى"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:947
+msgctxt "printer state"
+msgid "Installing"
+msgstr "ئورنىتىۋاتىدۇ"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1124
+msgid "No printers available"
+msgstr "پرىنتېر مەۋجۇت ئەمەس"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1429
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u ئاكتىپ"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1773
+msgid "Failed to add new printer."
+msgstr "يېڭى پرىنتېر قوشالمىدى."
+
+#: ../panels/printers/cc-printers-panel.c:1940
+msgid "Select PPD File"
+msgstr "PPD ھۆججىتىنى تاللاش"
+
+#: ../panels/printers/cc-printers-panel.c:1949
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr "PostScript پرىنتېرىنىڭ چۈشەندۈرۈش ھۆججەتلىرى(*.ppd، *.PPD، *.ppd.gz، *.PPD.gz، *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2254
+msgid "No suitable driver found"
+msgstr "مۇۋاپىق قوزغاتقۇ تېپىلمىدى"
+
+#: ../panels/printers/cc-printers-panel.c:2323
+msgid "Searching for preferred drivers…"
+msgstr "ئەڭ مۇۋاپىق قوزغاتقۇلارنى ئىزدەۋاتىدۇ…"
+
+#: ../panels/printers/cc-printers-panel.c:2338
+msgid "Select from database…"
+msgstr "سانداندىن تاللاش…"
+
+#: ../panels/printers/cc-printers-panel.c:2347
+msgid "Provide PPD File…"
+msgstr "PPD ھۆججەت تەمىنلەش…"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2498
+#: ../panels/printers/cc-printers-panel.c:2521
+msgid "Test page"
+msgstr "سىناق بەت"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2929
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "كۆرۈنمەيۈزنى ئوقۇغىلى بولمىدى: %s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "پرىنتېرلار"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Change printer settings"
+msgstr "پرىنتېر تەڭشىكىنى ئۆزگەرت"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;پرىنتېر;ئۆچىرەت;بېسىش;قەغەز;سىياھ;كۇكۇن;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "ئاكتىپ خىزمەتلەر"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Close"
+msgstr "ياپ"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "بېسىشنى داۋاملاشتۇرۇش"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "بېسىشنى ۋاقىتلىق توختىتىش"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "بېسىشتىن ۋاز كېچىش"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "بىر يېڭى پرىنتېر قوش"
+
+#: ../panels/printers/new-printer-dialog.ui.h:4
+msgid "Search for network printers or filter result"
+msgstr "تور پرىنتېرلىرىنى ئىزدەش ياكى نەتىجىنى سۈزۈش"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "تاللانمىلارنى ئوقۇۋاتىدۇ…"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "پرىنتېر قوزغاتقۇسىنى تاللاش"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "قوزغاتقۇلار ساندانىنى ئوقۇۋاتىدۇ…"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:65
+#: ../panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "تاق تەرەپلىك"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:67
+#: ../panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "ئۇزۇن يان (ئۆلچەملىك)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:69
+#: ../panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "قىسقا يان (ئۆرۈ)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:71
+msgid "Portrait"
+msgstr "بوي يۆنىلىش"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:73
+msgid "Landscape"
+msgstr "توغرا يۆنىلىش"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:75
+msgid "Reverse landscape"
+msgstr "تەتۈر توغرا يۆنىلىش"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:77
+msgid "Reverse portrait"
+msgstr "تەتۈر بوي يۆنىلىش"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:143
+msgctxt "print job"
+msgid "Pending"
+msgstr "كۈتۈۋاتىدۇ"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:147
+msgctxt "print job"
+msgid "Held"
+msgstr "تۇتۇپ تۇردى"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:151
+msgctxt "print job"
+msgid "Processing"
+msgstr "بىر تەرەپ قىلىۋاتىدۇ"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:155
+msgctxt "print job"
+msgid "Stopped"
+msgstr "توختىدى"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:159
+msgctxt "print job"
+msgid "Canceled"
+msgstr "قالدۇرۇۋېتىلدى"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:163
+msgctxt "print job"
+msgid "Aborted"
+msgstr "توختىتىلدى"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:167
+msgctxt "print job"
+msgid "Completed"
+msgstr "تاماملاندى"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:289
+msgid "Job Title"
+msgstr "خىزمەت ۋەزىپىسى"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:298
+msgid "Job State"
+msgstr "خىزمەت ھالىتى"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:304
+msgid "Time"
+msgstr "ۋاقىت"
+
+#: ../panels/printers/pp-jobs-dialog.c:496
+#, c-format
+msgid "%s Active Jobs"
+msgstr "ئاكتىپ خىزمەت سانى %s"
+
+#. Translators: No printers were found
+#: ../panels/printers/pp-new-printer-dialog.c:1465
+msgid "No printers detected."
+msgstr "پرىنتېر بايقالمىدى."
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Two Sided"
+msgstr "قوش يۈزلۈك"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Type"
+msgstr "قەغەز تىپى"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Paper Source"
+msgstr "قەغەز مەنبەسى"
+
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Output Tray"
+msgstr "قەغەز چىقارغۇچ"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "Resolution"
+msgstr "ئېنىقلىق"
+
+#: ../panels/printers/pp-options-dialog.c:87
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript ئالدىن سۈزگۈچ"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:533
+msgid "Pages per side"
+msgstr "ھەر يۈزىنىڭ بەت سانى"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:545
+msgid "Two-sided"
+msgstr "قوش يۈزلۈك"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:557
+msgid "Orientation"
+msgstr "يۆنىلىش"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:654
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "ئادەتتىكى"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:657
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "بەت تەڭشەك"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:660
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "ئورناتقىلى بولىدىغان تاللانمىلار"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:663
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "ۋەزىپە"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:666
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "سۈرەت سۈپىتى"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:669
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "رەڭ"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:672
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "تامام"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:675
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "ئالىي"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:75
+#: ../panels/printers/pp-ppd-option-widget.c:77
+#: ../panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "ئۆزلۈكىدىن تاللا"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:79
+#: ../panels/printers/pp-ppd-option-widget.c:81
+#: ../panels/printers/pp-ppd-option-widget.c:83
+#: ../panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "ئالدىن تەڭشەلگەن پرىنتېر"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "GhostScript خەت نۇسخىنىلا سىڭدۈر"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "PS دەرىجە 1 گە ئايلاندۇر"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "PS دەرىجە 2 گە ئايلاندۇر"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "ئالدىن سۈزگۈچ يوق"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+#| msgid "Manufacturer:"
+msgid "Manufacturer"
+msgstr "ياسىغۇچى سودىگەر"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "قوزغاتقۇچ"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:247
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr "ئىشلەتكۈچى ئاتى ۋە ئىمنى كىرگۈزسىڭىز %s دىكى پرىنتېرلارنى كۆرەلەيسىز."
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "پرىنتېر قوشۇش"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "پرىنتېر چىقىرىۋېتىش"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "تەمىنلىگۈچى"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "ئورنى"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default"
+msgstr "كۆڭۈلدىكى(_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "ۋەزىپىلەر"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "ۋەزىپىلەرنى كۆرسەت(_J)"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "ئەندىزە"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "ئەن"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "يېڭى قوزغاتقۇنى تەڭشەۋاتىدۇ…"
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "بەت 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "سىناق بەتنى باس(_T)"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "تاللانما(_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "يېڭى پرىنتېر قوش"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr "كەچۈرۈڭ! سىستېما بېسىش مۇلازىمىتىنى ئىشلەتكىلى بولمايدىغاندەك تۇرىدۇ."
+
+#: ../panels/privacy/cc-privacy-panel.c:105
+msgid "Hidden"
+msgstr "يوشۇرۇن"
+
+#: ../panels/privacy/cc-privacy-panel.c:105
+msgid "Visible"
+msgstr "كۆرۈنۈشچان"
+
+#: ../panels/privacy/cc-privacy-panel.c:271 ../panels/privacy/privacy.ui.h:31
+msgid "Screen Lock"
+msgstr "ئېكران قۇلۇپلاش"
+
+#: ../panels/privacy/cc-privacy-panel.c:338 ../panels/privacy/privacy.ui.h:9
+msgid "Name & Visibility"
+msgstr "ئاتى ۋە كۆرۈنۈشچانلىقى"
+
+#: ../panels/privacy/cc-privacy-panel.c:446 ../panels/privacy/privacy.ui.h:26
+msgid "Usage & History"
+msgstr "ئىشلىتىلىش ئەھۋالى ۋە ئىز"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+msgid "Purge Trash & Temporary Files"
+msgstr "ئەخلەتخانىنى پاكىزلاش ۋە ۋاقىتلىق ھۆججەتلەر"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "شەخسىيەت"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Privacy settings"
+msgstr "شەخسىيەت تەڭشەكلىرى"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;ئېكران;قۇلۇپ;يېقىنقى;ۋاقىتلىق;ئاتى;تور;كىملىك;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "ئېكران تاقىلىدۇ"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 سېكۇنت"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "Control how you appear on the screen and the network."
+msgstr "ئېكران ۋە توردا قانداق كۆرۈنىدىغانلىقىنى تىزگىنلەيدۇ"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "Display _full name in top bar"
+msgstr "ئۇستى بالداقتا تولۇق ئاتىنى كۆرسەتسۇن(_F)"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "Display full name in _lock screen"
+msgstr "قۇلۇپلانغان ئېكراندا تولۇق ئاتىنى كۆرسەتسۇن(_F)"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "_Stealth Mode"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "Immediately"
+msgstr "دەرھال"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "1 day"
+msgstr "1 كۈن"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "2 days"
+msgstr "2 كۈن"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "3 days"
+msgstr "3 كۈن"
+
+#: ../panels/privacy/privacy.ui.h:19
+msgid "4 days"
+msgstr "4 كۈن"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid "5 days"
+msgstr "5 كۈن"
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "6 days"
+msgstr "6 كۈن"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "7 days"
+msgstr "7 كۈن"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "14 days"
+msgstr "14 كۈن"
+
+#: ../panels/privacy/privacy.ui.h:24
+msgid "30 days"
+msgstr "30 كۈن"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "Forever"
+msgstr "مەڭگۈ"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr "ئىزلارنى ساقلاپ قويۇپ كېيىن ئىزدەشكە قۇلايلىق يارىتىدۇ. بۇلار توردا ھەرگىز ھەمبەھىرلەنمەيدۇ."
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Cl_ear Recent History"
+msgstr "يېقىنقى تارىخنى تازىلا(_E)"
+
+#: ../panels/privacy/privacy.ui.h:29
+msgid "_Recently Used"
+msgstr "يېقىندا ئىشلىتىلگەنلىرى(_R)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid "Retain _History"
+msgstr "ئىزلارنى ساقلاپ قوي(_H)"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "ئېكران قۇلۇپلاش — سىز ئورنىڭىزدا يوق ۋاقىتتا سىزنىڭ شەخسىيىتىڭىزنى قوغدايدۇ."
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Automatic Screen _Lock"
+msgstr "ئېكراننى ئاپتوماتىك قۇلۇپلاش"
+
+#: ../panels/privacy/privacy.ui.h:34
+#| msgid "Lock Screen _After"
+msgid "Lock Screen _After Blank For"
+msgstr ""
+
+#: ../panels/privacy/privacy.ui.h:35
+msgid "Show _Notifications"
+msgstr "ئۇقتۇرۇش كۆرسەت(_N)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid "_Empty Trash"
+msgstr "ئەخلەتخانا تازىلا(_E)"
+
+#: ../panels/privacy/privacy.ui.h:38
+msgid "_Purge Temporary Files"
+msgstr "ۋاقىتلىق ھۆججەتلەرنى تازىلا(_F)"
+
+#: ../panels/privacy/privacy.ui.h:39
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr "ئەخلەتخانىنى ۋە ۋاقىتلىق ھۆججەتلەرنى تازىلاپ كومپيۇتېرىڭىزنى مۇھىم ئۇچۇرلاردىن خالىي قىلىپ تۇرىدۇ."
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "Automatically Empty _Trash"
+msgstr "ئەخلەتخانىنى ئاپتوماتىك تازىلا(_T)"
+
+#: ../panels/privacy/privacy.ui.h:41
+msgid "Automatically Purge Temporary _Files"
+msgstr "ۋاقىتلىق ھۆججەتلەرنى ئاپتوماتىك تازىلا(_F)"
+
+#: ../panels/privacy/privacy.ui.h:42
+msgid "Purge _After"
+msgstr "كۆرسىتىلگەن ۋاقىتتىن كېيىن تازىلا(_A)"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "رايون ۋە تىل"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid "Change your region and language settings"
+msgstr "رايون ۋە تىل تەڭشىكىڭىزنى ئۆزگەرتىدۇ"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;تىل;ھەرپتاختا;كىرگۈزۈش;"
+
+#: ../panels/region/gnome-region-panel-formats.c:144
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "ئىمپېرىئال"
+
+#: ../panels/region/gnome-region-panel-formats.c:146
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "مېترىك"
+
+#: ../panels/region/gnome-region-panel-input-chooser.ui.h:1
+msgid "Select an input source"
+msgstr "كىرگۈزۈش مەنبەسىنى تاللاڭ"
+
+#: ../panels/region/gnome-region-panel-lang.c:115
+#: ../panels/region/gnome-region-panel.ui.h:4
+msgid "Log out for changes to take effect"
+msgstr "ئۆزگىرىشلەرنى ئىناۋەتلىك قىلىش ئۈچۈن چىقىپ كەت"
+
+#: ../panels/region/gnome-region-panel-system.c:471
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings."
+msgstr "كىرىش ئېكرانى، سىستېما ھېساباتى ۋە يېڭى ئىشلەتكۈچى ھېساباتلىرى مەزكۇر سىستېما مىقياسىدىكى رايون ۋە تىل تەڭشىكىنى ئىشلىتىدۇ."
+
+#: ../panels/region/gnome-region-panel-system.c:476
+#: ../panels/region/gnome-region-panel.ui.h:35
+msgid ""
+"The login screen, system accounts and new user accounts use the system-wide "
+"Region and Language settings. You may change the system settings to match "
+"yours."
+msgstr "كىرىش ئېكرانى، سىستېما ھېساباتى ۋە يېڭى ئىشلەتكۈچى ھېساباتلىرى مەزكۇر سىستېما مىقياسىدىكى رايون ۋە تىل تەڭشىكىنى ئىشلىتىدۇ. سىز ئۆزىڭىزگە مەست كېلىدىغان قىلىپ تەڭشىسىڭىز بولىدۇ."
+
+#: ../panels/region/gnome-region-panel-system.c:479
+msgid "Copy Settings"
+msgstr "تەڭشەكنى كۆچۈرۈش"
+
+#: ../panels/region/gnome-region-panel-system.c:482
+#: ../panels/region/gnome-region-panel.ui.h:42
+msgid "Copy Settings…"
+msgstr "تەڭشەكنى كۆچۈرۈش…"
+
+#: ../panels/region/gnome-region-panel.ui.h:1
+msgid "Region and Language"
+msgstr "رايون ۋە تىل"
+
+#: ../panels/region/gnome-region-panel.ui.h:2
+msgid "Select a display language"
+msgstr "كۆرسىتىلىدىغان تىلنى تاللايدۇ"
+
+#: ../panels/region/gnome-region-panel.ui.h:6
+msgid "Add Language"
+msgstr "تىل قوشۇش"
+
+#: ../panels/region/gnome-region-panel.ui.h:7
+msgid "Language"
+msgstr "تىل"
+
+#: ../panels/region/gnome-region-panel.ui.h:8
+msgid "Select a region (change will be applied the next time you log in)"
+msgstr "رايون تاللاڭ(ئۆزگىرىش كېيىنكى قېتىم كىرگەندە كۈچكە ئىگە)"
+
+#: ../panels/region/gnome-region-panel.ui.h:9
+msgid "Add Region"
+msgstr "رايون قوشۇش"
+
+#: ../panels/region/gnome-region-panel.ui.h:10
+msgid "Remove Region"
+msgstr "رايون چىقىرىۋېتىش"
+
+#: ../panels/region/gnome-region-panel.ui.h:11
+msgid "Dates"
+msgstr "چېسلا"
+
+#: ../panels/region/gnome-region-panel.ui.h:12
+msgid "Times"
+msgstr "ۋاقىت"
+
+#: ../panels/region/gnome-region-panel.ui.h:13
+msgid "Numbers"
+msgstr "سانلار"
+
+#: ../panels/region/gnome-region-panel.ui.h:14
+msgid "Currency"
+msgstr "پۇل"
+
+#: ../panels/region/gnome-region-panel.ui.h:15
+msgid "Measurement"
+msgstr "ئۆلچەم"
+
+#: ../panels/region/gnome-region-panel.ui.h:16
+msgid "Examples"
+msgstr "مىساللار"
+
+#: ../panels/region/gnome-region-panel.ui.h:17
+msgid "Formats"
+msgstr "پىچىملار"
+
+#: ../panels/region/gnome-region-panel.ui.h:18
+msgid "Select keyboards or other input sources"
+msgstr "ھەرپ تاختا ياكى باشقا كىرگۈزۈش مەنبەسىنى تاللاڭ"
+
+#: ../panels/region/gnome-region-panel.ui.h:19
+msgid "Add Input Source"
+msgstr "كىرگۈزۈش مەنبەسى قوشۇش"
+
+#: ../panels/region/gnome-region-panel.ui.h:20
+msgid "Remove Input Source"
+msgstr "كىرگۈزۈش مەنبەسىنى چىقىرىۋېتىش"
+
+#: ../panels/region/gnome-region-panel.ui.h:21
+msgid "Move Input Source Up"
+msgstr "كىرگۈزۈش مەنبەسىنى ئۈستىگە يۆتكەش"
+
+#: ../panels/region/gnome-region-panel.ui.h:22
+msgid "Move Input Source Down"
+msgstr "كىرگۈزۈش مەنبەسىنى ئاستىغا يۆتكەش"
+
+#: ../panels/region/gnome-region-panel.ui.h:23
+msgid "Input Source Settings"
+msgstr "كىرگۈزۈش مەنبەسى تەڭشىكى"
+
+#: ../panels/region/gnome-region-panel.ui.h:24
+msgid "Show Keyboard Layout"
+msgstr "ھەرپ تاختا ئورۇنلاشتۇرۇشىنى كۆرسىتىش"
+
+#: ../panels/region/gnome-region-panel.ui.h:26
+msgid "Ctrl+Alt+Space"
+msgstr "Ctrl+Alt+Space"
+
+#: ../panels/region/gnome-region-panel.ui.h:28
+msgid "Ctrl+Alt+Shift+Space"
+msgstr "Ctrl+Alt+Shift+Space"
+
+#: ../panels/region/gnome-region-panel.ui.h:29
+msgid "Shortcut Settings"
+msgstr "تېزلەتمە تەڭشىكى"
+
+#: ../panels/region/gnome-region-panel.ui.h:31
+msgid "Use the same source for all windows"
+msgstr "ھەممە كۆزنەكلەرگە ئوخشاش مەنبەنى ئىشلەتسۇن"
+
+#: ../panels/region/gnome-region-panel.ui.h:32
+msgid "Allow different sources for each window"
+msgstr "ھەر بىر كۆزنەكنىڭ ئايرىم-ئايرىم بولسۇن"
+
+#: ../panels/region/gnome-region-panel.ui.h:33
+msgid "Options"
+msgstr "تاللانما"
+
+#: ../panels/region/gnome-region-panel.ui.h:34
+msgid "Input Sources"
+msgstr "كىرگۈزۈش مەنبەلىرى"
+
+#. 'display' means 'output' here, as in 'translated messages that are displayed to the user'
+#: ../panels/region/gnome-region-panel.ui.h:37
+msgid "Display language:"
+msgstr "كۆرۈنۈش تىلى:"
+
+#: ../panels/region/gnome-region-panel.ui.h:38
+msgid "Input source:"
+msgstr "كىرگۈزۈش مەنبەسى"
+
+#: ../panels/region/gnome-region-panel.ui.h:39
+msgid "Format:"
+msgstr "فورمات:"
+
+#: ../panels/region/gnome-region-panel.ui.h:40
+msgid "Your settings"
+msgstr "تەڭشىكىڭىز"
+
+#: ../panels/region/gnome-region-panel.ui.h:41
+msgid "System settings"
+msgstr "سىستېما تەڭشەكلىرى"
+
+#: ../panels/search/cc-search-locations-dialog.c:275
+msgid "Home"
+msgstr "ماكان"
+
+#: ../panels/search/cc-search-locations-dialog.c:475
+msgid "Places"
+msgstr "ئورۇنلار"
+
+#: ../panels/search/cc-search-locations-dialog.c:477
+msgid "Bookmarks"
+msgstr "خەتكۈشلەر"
+
+#: ../panels/search/cc-search-locations-dialog.c:479
+msgid "Other"
+msgstr "باشقا"
+
+#: ../panels/search/cc-search-locations-dialog.c:675
+msgid "Select Location"
+msgstr "ئورۇن تاللاش"
+
+#: ../panels/search/cc-search-panel.c:193
+msgid "No applications found"
+msgstr "پروگرامما تېپىلمىدى"
+
+#: ../panels/search/cc-search-panel.c:551
+#: ../panels/user-accounts/um-fingerprint-dialog.c:219
+#: ../panels/user-accounts/um-fingerprint-dialog.c:220
+msgid "Enabled"
+msgstr "ئىناۋەتلىك قىلىنغان"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "ئىزدە"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid "Search settings"
+msgstr "ئىزدەش تەڭشىكى"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;ئىزدەش;تېپىش;ئىندېكس;يوشۇرۇش;شەخسىيەت;نەتىجىلەر;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "ئورۇنلارنى ئىزدەش"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "ئۈستىگە"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "پەسكە"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "مايىللىق"
+
+#: ../panels/sharing/cc-sharing-panel.c:220
+msgctxt "service is enabled"
+msgid "On"
+msgstr "ئوچۇق"
+
+#: ../panels/sharing/cc-sharing-panel.c:222
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "تاقا"
+
+#: ../panels/sharing/cc-sharing-panel.c:362
+msgid "Choose a Folder"
+msgstr "قىسقۇچ تاللاڭ"
+
+#: ../panels/sharing/cc-sharing-panel.c:540
+msgid "Copy"
+msgstr "كۆچۈر"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "ھەمبەھىر"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:3
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;pictures;photos;movies;server;renderer;ھەمبەھىر;يىراق;ئۈستەلئۈستى;كۆكچىش;ئۈن;سىن;سۈرەت;رەسىم;كىنو;مۇلازىمېتىر;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "يىراقتىن كىرىشنى ئىناۋەتلىك ۋە ئىناۋەتسىز قىلىدۇ"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "يىراقتىن كىرىشنى ئىناۋەتلىك ۋە ئىناۋەتسىز قىلىش ئۈچۈن سالاھىيەت دەلىللەش زۆرۈردۇر"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "كۆكچىشتا ھەمبەھىرلەش"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr "كۆكچىشتا ھەمبەھىرلەش — ھۆججەتلەرنى كۆكچىش بار ئۈسكۈنىلەر ئارىسىدا ھەمبەھىرلەشكە ئىمكان يارىتىدۇ."
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Share Public Folder"
+msgstr "ئاممىۋى قىسقۇچنى ھەمبەھىرلە"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Only Receive From Trusted Devices"
+msgstr "ئىشەنچلىك ئۈسكۈنىلەردىنلا قوبۇل قىلسۇن"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Save Received Files to Downloads Folder"
+msgstr "قوبۇل قىلغان ھۆججەتلەرنى چۈشۈرۈلمىلەر قىسقۇچىغا ساقلىسۇن"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Only share with Trusted Devices"
+msgstr "ئىشەنچلىك ئۈسكۈنىلەر بىلەنلا ھەمبەھىر قىلسۇن"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Computer Name"
+msgstr "كومپيۇتېر ئاتى"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Some services are disabled because of no network access."
+msgstr "تور بولمىغاچقا بىر قىسىم مۇلازىمەتلەر ئىناۋەتسىز قىلىندى."
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Media Sharing"
+msgstr "ۋاسىتە ھەمبەھىرلەش"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Share Music, Photos and Videos with others on the current network."
+msgstr "مەزكۇر توردا مۇزىكا، سۈرەت ۋە سىنلارنى باشقىلار بىلەن ھەمبەھىر قىلىپ ئىشلىتىدۇ."
+
+#: ../panels/sharing/sharing.ui.h:11
+msgid "Share Media On This Network"
+msgstr "مەزكۇر توردا ۋاسىتىلەرنى ھەمبەھىر قىلسۇن"
+
+#: ../panels/sharing/sharing.ui.h:12
+msgid "Shared Folders"
+msgstr "ھەمبەھىرلەنگەن قىسقۇچلار"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "column"
+msgstr "ئىستونلار"
+
+#: ../panels/sharing/sharing.ui.h:14
+msgid "Add Folder"
+msgstr "قىسقۇچ قوشۇش"
+
+#: ../panels/sharing/sharing.ui.h:15
+msgid "Remove Folder"
+msgstr "قىسقۇچ چىقىرىۋېتىش"
+
+#: ../panels/sharing/sharing.ui.h:16
+msgid "Personal File Sharing"
+msgstr "خۇسۇسىي ھۆججەت ھەمبەھىرى"
+
+#: ../panels/sharing/sharing.ui.h:18
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr "شەخسىي ھۆججەت ھەمبەھىرلەشنى ئىشلىتىش ئارقىلىق، ئاممىۋى قىسقۇچلارنى <a href=\"dav://%s\">dav://%s</a> نى ئىشلىتىپ باشقىلار بىلەن ھەمبەھىر قىلالايسىز"
+
+#: ../panels/sharing/sharing.ui.h:19
+msgid "Share Public Folder On This Network"
+msgstr "مەزكۇر توردا ئاممىۋى قىسقۇچنى ھەمبەھىر قىلسۇن"
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Require Password"
+msgstr "ئىم زۆرۈر"
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Remote Login"
+msgstr "يىراقتىن كىرىش"
+
+#: ../panels/sharing/sharing.ui.h:24
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr "يىرىقتىكى ئىشلەتكۈچىنىڭ بىخەتەر Shell بۇيرۇقىنى ئىشلىتىپ باغلىنىشىغا ئىجازەت بېرىدۇ:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:26
+msgid "Screen Sharing"
+msgstr "ئېكراننى ھەمبەھىر قىلىش"
+
+#: ../panels/sharing/sharing.ui.h:28
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr "يىرىقتىكى ئىشلەتكۈچىنىڭ باغلىنىپ ئېكراننى تىزگىنلىشىگە ئىجازەت بېرىدۇ: <a href=\"vnc://%s\">vnc://%s</a>"
+
+#: ../panels/sharing/sharing.ui.h:29
+msgid "Remote View"
+msgstr "يىراقتا كۆرۈش"
+
+#: ../panels/sharing/sharing.ui.h:30
+msgid "Remote Control"
+msgstr "يىراقتا تىزگىنلەش"
+
+#: ../panels/sharing/sharing.ui.h:31
+msgid "Approve All Connections"
+msgstr "ھەممە باغلىنىشنى قوبۇل قىلسۇن"
+
+#: ../panels/sharing/sharing.ui.h:32
+msgid "Show Password"
+msgstr "ئىم كۆرسەت"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "ئاۋاز"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound volume and event sounds"
+msgstr "ئاۋاز چوڭلۇقى ۋە ھادىسىنىڭ ئاۋازلىرىنى ئۆزگەرتىش"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+#, fuzzy
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "كارتا؛مىكروفون؛ئاۋاز چوڭلۇقى؛Fade؛Balance؛كۆكچىش؛مىكروفونلۇق تىڭشىغۇچ؛ئاۋاز؛ئۈن؛"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "ئىتنىڭ قاۋىشى"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "سۇنىڭ تامچىلىشى"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "ئەينەكنىڭ جىرىڭلىشى"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "سونار"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Left"
+msgstr "سول"
+
+#: ../panels/sound/gvc-balance-bar.c:107
+msgctxt "balance"
+msgid "Right"
+msgstr "ئوڭ"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Rear"
+msgstr "ئارقا تەرەپ"
+
+#: ../panels/sound/gvc-balance-bar.c:111
+msgctxt "balance"
+msgid "Front"
+msgstr "ئالدى"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Minimum"
+msgstr "ئەڭ كىچىك"
+
+#: ../panels/sound/gvc-balance-bar.c:115
+msgctxt "balance"
+msgid "Maximum"
+msgstr "ئەڭ چوڭ"
+
+#: ../panels/sound/gvc-balance-bar.c:290
+msgid "_Balance:"
+msgstr "ھېساباتتىكى پۇل(_B):"
+
+#: ../panels/sound/gvc-balance-bar.c:293
+msgid "_Fade:"
+msgstr "سۇسلاشتۇر(_F):"
+
+#: ../panels/sound/gvc-balance-bar.c:296
+msgid "_Subwoofer:"
+msgstr "ئۇلترا تۆۋەن ئاۋاز(_S):"
+
+#: ../panels/sound/gvc-channel-bar.c:613 ../panels/sound/gvc-channel-bar.c:622
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:617
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "چوڭايتىلمىغان"
+
+#: ../panels/sound/gvc-combo-box.c:167 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "سەپلىمە ھۆججەت(_P):"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u چىقىرىلما"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u كىرگۈزۈلمە"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2371
+msgid "System Sounds"
+msgstr "سىستېما ئاۋازى"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "ياڭراتقۇ سىنا(_T)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "چوققا قىممەت بايقا"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1511
+#: ../panels/sound/gvc-sound-theme-chooser.c:595
+msgid "Name"
+msgstr "ئاتى"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1530
+msgid "Device"
+msgstr "ئۈسكۈنە"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1593
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s نىڭ ياڭراتقۇسىنى سىناش"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1647
+msgid "_Output volume:"
+msgstr "ئاۋاز مىقدارى(_O):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1661
+msgid "Output"
+msgstr "چىقار"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1666
+msgid "C_hoose a device for sound output:"
+msgstr "ئاۋاز چىقىرىش ئۈسكۈنىسى تاللاش(_H):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1691
+msgid "Settings for the selected device:"
+msgstr "تاللىغان ئۈسكۈنىنىڭ تەڭشىكى:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1702
+msgid "Input"
+msgstr "كىرگۈز"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1709
+msgid "_Input volume:"
+msgstr "كىرىش ئاۋاز مىقدارى(_I):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1732
+msgid "Input level:"
+msgstr "كىرىش دەرىجىسى:"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1760
+msgid "C_hoose a device for sound input:"
+msgstr "ئاۋاز كىرگۈزۈش ئۈسكۈنىسى تاللاش(_H):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1787
+msgid "Sound Effects"
+msgstr "ئاۋاز ئۈنۈمى"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1794
+msgid "_Alert volume:"
+msgstr "ئاگاھلاندۇرۇش ئاۋاز مىقدارى(_A):"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1807
+msgid "Applications"
+msgstr "پروگراممىلار"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1811
+msgid "No application is currently playing or recording audio."
+msgstr "نۆۋەتتە ئاۋاز قويىدىغان ياكى خاتىرىلەيدىغان پروگرامما يوق."
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:189
+msgid "Built-in"
+msgstr "ئىچكى"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:455
+#: ../panels/sound/gvc-sound-theme-chooser.c:467
+#: ../panels/sound/gvc-sound-theme-chooser.c:479
+msgid "Sound Preferences"
+msgstr "ئاۋاز مايىللىقى"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:458
+#: ../panels/sound/gvc-sound-theme-chooser.c:469
+#: ../panels/sound/gvc-sound-theme-chooser.c:481
+msgid "Testing event sound"
+msgstr "ھادىسە ئاۋازىنى سىناۋاتىدۇ"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "Default"
+msgstr "كۆڭۈلدىكى"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:586
+msgid "From theme"
+msgstr "ئۆرنەكتىن"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:770
+msgid "C_hoose an alert sound:"
+msgstr "ئاگاھلاندۇرۇش ئاۋازى تاللاڭ(_H):"
+
+#: ../panels/sound/gvc-speaker-test.c:220
+msgid "Stop"
+msgstr "توختا"
+
+#: ../panels/sound/gvc-speaker-test.c:220
+#: ../panels/sound/gvc-speaker-test.c:332
+msgid "Test"
+msgstr "سىنا"
+
+#: ../panels/sound/gvc-speaker-test.c:228
+msgid "Subwoofer"
+msgstr "ئۇلترا تۆۋەن ئاۋاز ياڭراتقۇ"
+
+#: ../panels/sound/sound-theme-file-utils.c:292
+msgid "Custom"
+msgstr "ئىختىيارى"
+
+#: ../panels/universal-access/cc-ua-panel.c:281
+#: ../panels/universal-access/cc-ua-panel.c:287
+msgid "No shortcut set"
+msgstr "تېزلەتمە بەلگىلەنمىگەن"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Universal Access Preferences"
+msgstr "ئۇنىۋېرسال زىيارەت مايىللىقى"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
+"AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;"
+msgstr "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;AccessX;Sticky Keys;Slow Keys;Bounce Keys;Mouse Keys;ھەرپتاختا;چاشقىنەك;ياردەمچى;چوڭلۇقى;چاپلاشقاق كۇنۇپكا;ئاستا كۇنۇپكا;چاشقىنەك كۇنۇپكىسى;"
+
+#: ../panels/universal-access/uap.ui.h:1
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "تۆۋەن"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgctxt "universal access, contrast"
+msgid "Normal"
+msgstr "نورمال"
+
+#: ../panels/universal-access/uap.ui.h:3
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "يۇقىرى"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgctxt "universal access, contrast"
+msgid "High/Inverse"
+msgstr "يۇقىرى/ئەكسى"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "On screen keyboard"
+msgstr "ئېكران ھەرپتاختىسى"
+
+#: ../panels/universal-access/uap.ui.h:6
+msgid "GOK"
+msgstr "GOK"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "OnBoard"
+msgstr "تاختىدىكى"
+
+#: ../panels/universal-access/uap.ui.h:10
+#, no-c-format
+msgid "75%"
+msgstr "75%"
+
+#: ../panels/universal-access/uap.ui.h:11
+msgctxt "universal access, text size"
+msgid "Small"
+msgstr "كىچىك"
+
+#: ../panels/universal-access/uap.ui.h:13
+#, no-c-format
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgctxt "universal access, text size"
+msgid "Normal"
+msgstr "نورمال"
+
+#: ../panels/universal-access/uap.ui.h:16
+#, no-c-format
+msgid "125%"
+msgstr "125%"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgctxt "universal access, text size"
+msgid "Large"
+msgstr "چوڭ"
+
+#: ../panels/universal-access/uap.ui.h:19
+#, no-c-format
+msgid "150%"
+msgstr "150%"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgctxt "universal access, text size"
+msgid "Larger"
+msgstr "چوڭراق"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "High Contrast"
+msgstr "يۇقىرى ئاق-قارىلىقى"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Beep on Caps and Num Lock"
+msgstr "Caps ۋە Num Lock كۇنۇپكىلىرىنى ئىشلەتكەندە ئاۋاز چىقارسۇن"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Screen Reader"
+msgstr "ئېكران ئوقۇغۇچ"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Turn on or off:"
+msgstr "ئاچ ياكى ياپ"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgctxt "universal access, zoom"
+msgid "Zoom"
+msgstr "كېڭەيت-تارايت"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Zoom in:"
+msgstr "كېڭەيت:"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "Zoom out:"
+msgstr "تارايت:"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Large Text"
+msgstr "چوڭ تېكىست"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "Seeing"
+msgstr "كۆرۈش سېزىمى"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Visual Alerts"
+msgstr "كۆرۈنمە ئاگاھلاندۇرۇش"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "Use a visual indication when an alert sound occurs"
+msgstr "ئاگاھلاندۇرۇش ئاۋازى يۈز بەرسە كۆرۈنمە ئەسكەرتىشنى كۆرسەت"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Flash the window title"
+msgstr "كۆزنەك ماۋزۇسىنى چاقنات"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "Flash the entire screen"
+msgstr "پۈتۈن ئېكراننى چاقنات"
+
+#: ../panels/universal-access/uap.ui.h:35
+msgid "Closed Captioning"
+msgstr "تاقالغان خەتلىك چۈشەندۈرۈش"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Display a textual description of speech and sounds"
+msgstr "تەلەپپۇز ۋە ئاۋازنىڭ تېكىست چۈشەندۈرۈشىنى كۆرسەت"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgid "_Test flash"
+msgstr "چاقناشنى سىنا(_T)"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Hearing"
+msgstr "ئاڭلاش سېزىمى"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "On Screen Keyboard"
+msgstr "ئېكران ھەرپتاختىسى"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "Sticky Keys"
+msgstr "يېپىشقاق كۇنۇپكىلار"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "بىر تىزىق ئۆزگەرتىلگەن كۇنۇپكىنى بىرىكمە كۇنۇپكا قىلىدۇ"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgid "_Disable if two keys are pressed together"
+msgstr "ئەگەر ئىككى كۇنۇپكا بىرلا ۋاقىتتا بېسىلسا چەكلە(_D)"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Beep when a _modifer key is pressed"
+msgstr "ئۆزگەرتىش كۇنۇپكىسى بېسىلسا ئاۋاز چىقار(_M)"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgid "Slow Keys"
+msgstr "ئاستا كۇنۇپكىلار"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "كۇنۇپكا بېسىلىپ قوبۇل قىلغىچە بولغان ئارىلىقتا كېچىكتۈرۈش ئورنات"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "A_cceptance delay:"
+msgstr "قوبۇل قىلىشچان كېچىكتۈرۈش(_C):"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgctxt "universal access, delay"
+msgid "Short"
+msgstr "قىسقا"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "Slow keys typing delay"
+msgstr "ئاستا كۇنۇپكىلارنىڭ كېچىكىش ۋاقتى"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgctxt "universal access, delay"
+msgid "Long"
+msgstr "ئۇزۇن"
+
+#. This string is part of a line of checkboxes: Beep when a key is [ ] pressed  [ ] accepted  [ ] rejected
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Beep when a key is"
+msgstr "كۇنۇپكىسى ئىشلەتكەندە دۈت-دۈت ئاۋاز چىقار"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:54
+msgid "pressed"
+msgstr "بېسىلغان"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:56
+msgid "accepted"
+msgstr "قوشۇلغان"
+
+#. This completes the sentence "Beep when a key is"
+#: ../panels/universal-access/uap.ui.h:58
+msgid "rejected"
+msgstr "رەت قىلىنغان"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Bounce Keys"
+msgstr "سەكرىمە كۇنۇپكىلار"
+
+#: ../panels/universal-access/uap.ui.h:60
+msgid "Ignores fast duplicate keypresses"
+msgstr "تېز سۈرئەتتە تەكرار كۇنۇپكا بېسىشقا پەرۋا قىلما"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgid "Acc_eptance delay:"
+msgstr "قوبۇل قىلىشچان كېچىكتۈرۈش(_E):"
+
+#: ../panels/universal-access/uap.ui.h:62
+msgid "Bounce keys typing delay"
+msgstr "‹سەكرىمە كۇنۇپكىلار›نى ئىناۋەتلىك قىلسۇن"
+
+#: ../panels/universal-access/uap.ui.h:63
+msgid "Beep when a key is _rejected"
+msgstr "بىر كۇنۇپكا رەت قىلىنسا ئاۋاز چىقار(_R)"
+
+#: ../panels/universal-access/uap.ui.h:64
+msgid "Enable by Keyboard"
+msgstr "ھەرپتاختىسى ئارقىلىق ئىناۋەتلىك قىلسۇن"
+
+#: ../panels/universal-access/uap.ui.h:65
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "ياردەمچى ئىقتىدارلارنى ھەرپتاختىسى ئارقىلىق ئىناۋەتلىك ياكى ئىناۋەتسىز قىلىدۇ"
+
+#: ../panels/universal-access/uap.ui.h:67
+msgid "Mouse Keys"
+msgstr "چاشقىنەك كۇنۇپكىلىرى"
+
+#: ../panels/universal-access/uap.ui.h:68
+msgid "Control the pointer using the keypad"
+msgstr "نۇربەلگىنى كۇنۇپكا تاختىدا تىزگىنلىسۇن"
+
+#: ../panels/universal-access/uap.ui.h:69
+msgid "Video Mouse"
+msgstr "سىن چاشقىنەك"
+
+#: ../panels/universal-access/uap.ui.h:70
+msgid "Control the pointer using the video camera."
+msgstr "نۇربەلگىنى سىن كامېرادا تىزگىنلەيدۇ."
+
+#: ../panels/universal-access/uap.ui.h:71
+msgid "Simulated Secondary Click"
+msgstr "تەقلىدلىك ئىككىنچى چېكىش"
+
+#: ../panels/universal-access/uap.ui.h:72
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "چاشقىنەك ئاساسىي توپچىسىنى قويۇۋەتمىگەندە ئىككىنچى چېكىشنى قوزغات"
+
+#: ../panels/universal-access/uap.ui.h:73
+msgid "Secondary click delay"
+msgstr "ئىككىنچى چېكىشنى كېچىكتۈرۈش"
+
+#: ../panels/universal-access/uap.ui.h:74
+msgid "Hover Click"
+msgstr "لەيلىتىپ چەك"
+
+#: ../panels/universal-access/uap.ui.h:75
+msgid "Trigger a click when the pointer hovers"
+msgstr "ئىسترېلكا لەيلەپ توختىغاندا چېكىش مەشغۇلاتىنى ئىجرا قىلىدۇ"
+
+#: ../panels/universal-access/uap.ui.h:76
+msgid "D_elay:"
+msgstr "كېچىكتۈر(_E):"
+
+#: ../panels/universal-access/uap.ui.h:77
+msgid "Motion _threshold:"
+msgstr "ھەرىكەت بوسۇغا قىممىتى(_T):"
+
+#: ../panels/universal-access/uap.ui.h:78
+msgctxt "universal access, threshold"
+msgid "Small"
+msgstr "كىچىك"
+
+#: ../panels/universal-access/uap.ui.h:79
+msgctxt "universal access, threshold"
+msgid "Large"
+msgstr "چوڭ"
+
+#: ../panels/universal-access/uap.ui.h:80
+msgid "Mouse Settings"
+msgstr "چاشقىنەك تەڭشەكلىرى"
+
+#: ../panels/universal-access/uap.ui.h:81
+msgid "Pointing and Clicking"
+msgstr "كۆرسىتىش ۋە چېكىش"
+
+#: ../panels/universal-access/zoom-options.c:357
+msgctxt "Distance"
+msgid "Short"
+msgstr "قىسقا"
+
+#: ../panels/universal-access/zoom-options.c:358
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ ئېكران"
+
+#: ../panels/universal-access/zoom-options.c:359
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ ئېكران"
+
+#: ../panels/universal-access/zoom-options.c:360
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ ئېكران"
+
+#: ../panels/universal-access/zoom-options.c:361
+msgctxt "Distance"
+msgid "Long"
+msgstr "ئۇزۇن"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "پۈتۈن ئېكران"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "ئۈستۈنكى يېرىمى"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "ئاستىنقى يېرىمى"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "سول يېرىمى"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "ئوڭ يېرىمى"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "چوڭايتىش تاللانمىلىرى"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "كېڭەيت-تارايت"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "چوڭايتىش:"
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "چاشقىنەك نۇربەلگىگە ئەگىشىش"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "ئېكران قىسمى:"
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "چوڭايتقۇچنى ئېكران سىرتىغا كېڭەيتىدۇ"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "چوڭايتقۇچنى ئوتتۇرىغا توغرىلايدۇ"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "چوڭايتقۇچ نۇربەلگىسى مەزمۇنلارنى ئەتراپقا ئىتتىرىدۇ"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "چوڭايتقۇچ نۇربەلگىسى مەزمۇنغا ئەگىشىپ يۆتكىلىدۇ"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "چوڭايتىش ئورنى:"
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "چوڭايتقۇچ"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "قېلىنلىقى:"
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "نېپىز"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "توم"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "ئۇزۇنلۇق:"
+
+#: ../panels/universal-access/zoom-options.ui.h:21
+msgid "Color:"
+msgstr "رەڭ:"
+
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Crosshairs:"
+msgstr "كرېست:"
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Overlaps mouse cursor"
+msgstr "چاشقىنەك نۇربەلگىسىنى قەۋەتلەيدۇ"
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Crosshairs"
+msgstr "كرېست"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "White on black:"
+msgstr "ئاقە ۋە قارا"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "Brightness:"
+msgstr "يورۇقلۇق:"
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Contrast:"
+msgstr "سېلىشتۇرما دەرىجە:"
+
+#: ../panels/universal-access/zoom-options.ui.h:29
+msgctxt "universal access, color"
+msgid "None"
+msgstr "يوق"
+
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "تامامەن"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "تۆۋەن"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "يۇقىرى"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgid "Color Effects:"
+msgstr "رەڭ ئۈنۈملىرى:"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgid "Color Effects"
+msgstr "رەڭ ئۈنۈملىرى"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:35
+msgctxt "Account type"
+msgid "Standard"
+msgstr "ئۆلچەملىك"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:37
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "باشقۇرغۇچى"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "Add account"
+msgstr "ھېسابات قوش"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Local Account"
+msgstr "يەرلىك ھېسابات(_L)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+msgid "_Enterprise Login"
+msgstr "شىركەت ھېساباتى(_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+msgid "_Full name"
+msgstr "تولۇق ئاتى(_F):"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Account _Type"
+msgstr "ھېسابات تىپ(_T)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+msgid "_Domain"
+msgstr "دائىرە(_D)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Login Name"
+msgstr "كىرىش ئاتى(_L)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "Tip: Enterprise domain or realm name"
+msgstr "ئەسكەرتىش: شىركەت دائىرە ئاتى ياكى realm ئاتى"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid "C_ontinue"
+msgstr "داۋاملاشتۇر(_O)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:14
+msgid "Domain Administrator Login"
+msgstr "دائىرە باشقۇرغۇچى كىرىش"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr "شىركەت كىرىشىنى ئىشلىتىش ئۈچۈن، مەزكۇر كومپيۇتېرنى دائىرىگە خەتلىتىش كېرەك. تور باشقۇرغۇچىنىڭ دائىرىدە ئىشلىتىدىغان ئىمىنى كىرگۈزۈڭ."
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:18
+msgid "Administrator _Name"
+msgstr "باشقۇرغۇچى ئاتى(_N)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "Administrator Password"
+msgstr "باشقۇرغۇچى ئىمى"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "سول قول باش بارماق"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "سول قول ئوتتۇرا بارماق"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "سول قول نامسىز بارماق"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "سول قول چىمچىلاق"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "ئوڭ قول باش بارماق"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "ئوڭ قول ئوتتۇرا بارماق"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "ئوڭ قول نامسىز بارماق"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "ئوڭ قول چىمچىلاق"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:700
+msgid "Enable Fingerprint Login"
+msgstr "بارماق ئىزىدا تىزىمغا كىرىشنى قوزغات"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "ئوڭ قول كۆرسەتكۈچ بارماق(_R)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "سول قول كۆرسەتكۈچ بارماق(_L)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "باشقا بارماق(_O):"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr "بارماق ئىزىڭىز مۇۋەپپەقىيەتلىك ساقلاندى. ئەمدى بارماق ئىزى ئوقۇغۇچىڭىز ئارقىلىق تىزىمغا كىرەلەيسىز."
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "ئىشلەتكۈچىلەر"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users"
+msgstr "ئىشلەتكۈچى قوشىدۇ ياكى ئۆچۈرىدۇ"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;تىزىمغا كىر;ئات;بارماق ئىزى;سىما;تۇغ;چىراي;ئىم;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:2
+#| msgid "Previous track"
+msgid "Previous Week"
+msgstr "ئالدىنقى ھەپتە"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:3
+#| msgid "Last Week"
+msgid "Next Week"
+msgstr "كېيىنكى ھەپتە"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:4
+#| msgid "Next track"
+msgid "Next week"
+msgstr "كېيىنكى ھەپتە"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Set a password now"
+msgstr "ھازىر ئىم تەڭشە"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+msgid "Choose password at next login"
+msgstr "كېيىنكى قېتىم تىزىمغا كىرگەندە تاللا"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Log in without a password"
+msgstr "ئىمسىز تىزىمغا كىرىدۇ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "Disable this account"
+msgstr "بۇ ھېساباتنى ئىناۋەتسىز قىلىدۇ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "Enable this account"
+msgstr "بۇ ھېساباتنى قوزغات"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "_Hint"
+msgstr "يىپ ئۇچى(_H)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid ""
+"This hint may be displayed at the login screen.  It will be visible to all "
+"users of this system.  Do <b>not</b> include the password here."
+msgstr "بۇ ئەسكەرتىش تىزىمغا كىرىش كۆزنىكىدە كۆرۈنۈشى مۇمكىن. ئۇنى سىستېمىدىكى ھەممە ئىشلەتكۈچى كۆرەلەيدۇ. ئىمنى بۇ جايغا <b>يازماڭ</b>."
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "C_onfirm password"
+msgstr "ئىم جەزملە(_O)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:9
+msgid "_New password"
+msgstr "يېڭى ئىم(_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:10
+msgid "Generate a password"
+msgstr "ئىم ھاسىللاش"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:11
+msgid "Fair"
+msgstr "ياخشىراق"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:12
+msgid "Current _password"
+msgstr "نۆۋەتتىكى ئىم(_P)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:13
+msgid "_Action"
+msgstr "مەشغۇلات(_A)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:14
+msgid "Changing password for"
+msgstr "بۇ ئىشلەتكۈچىنىڭ ئىمنى ئۆزگەرتىدۇ"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:15
+msgid "_Show password"
+msgstr "ئىم كۆرسەت(_S)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:16
+msgid "How to choose a strong password"
+msgstr "كۈچلۈك ئىمنى قانداق تاللاش كېرەك"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:17
+msgid "Ch_ange"
+msgstr "ئۆزگەرت_A)"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:1
+msgid "Changing photo for:"
+msgstr "سۈرەت ئۆزگەرت:"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:2
+msgid ""
+"Choose a picture that will be shown at the login screen for this account."
+msgstr "تىزىمغا كىرىش كۆزنىكىدە مەزكۇر ھېسابات بىلەن بىللە كۆرۈنىدىغان سۈرەتتىن بىرنى تاللاڭ."
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:3
+msgid "Gallery"
+msgstr "سۈرەت يىغقۇچ"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:4
+#: ../panels/user-accounts/um-photo-dialog.c:218
+msgid "Browse for more pictures"
+msgstr "تېخىمۇ كۆپ سۈرەتكە كۆز يۈگۈرت"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:5
+msgid "Take a photograph"
+msgstr "فوتو سۈرەتكە تارت"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:6
+msgid "Browse"
+msgstr "كۆز يۈگۈرت"
+
+#: ../panels/user-accounts/data/photo-dialog.ui.h:7
+msgid "Photograph"
+msgstr "فوتو سۈرەت"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Account Information"
+msgstr "ھېساب ئۇچۇرى"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Add User Account"
+msgstr "ئىشلەتكۈچى  ھېساباتى قوشۇش"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Remove User Account"
+msgstr "ئىشلەتكۈچى  ھېساباتى چىقىرىۋېتىش"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "Login Options"
+msgstr "تىزىمغا كىرىش تاللانمىسى"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "A_utomatic Login"
+msgstr "ئۆزلۈكىدىن تىزىمغا كىرىش(_U)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "_Fingerprint Login"
+msgstr "بارماق ئىزىدا تىزىمغا كىرىش(_F)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "User Icon"
+msgstr "ئىشلەتكۈچى سىنبەلگىسى"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "_Language"
+msgstr "تىل(_L)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "Last Login"
+msgstr "ئەڭ ئاخىرقى قېتىم كىرگەن ۋاقىت"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "ئىشلەتكۈچى ھېساباتىنى باشقۇر"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "ئىشلەتكۈچى سانلىق-مەلۇماتىنى ئۆزگەرتىش ئۈچۈن سالاھىيەت دەلىللەش زۆرۈر"
+
+#: ../panels/user-accounts/pw-utils.c:94
+#: ../panels/user-accounts/um-password-dialog.c:605
+msgctxt "Password strength"
+msgid "Too short"
+msgstr "بەك قىسقا"
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password strength"
+msgid "Not good enough"
+msgstr "تازا ياخشى ئەمەس"
+
+#: ../panels/user-accounts/pw-utils.c:108
+#: ../panels/user-accounts/um-password-dialog.c:606
+msgctxt "Password strength"
+msgid "Weak"
+msgstr "ئاجىز"
+
+#: ../panels/user-accounts/pw-utils.c:111
+#: ../panels/user-accounts/um-password-dialog.c:607
+msgctxt "Password strength"
+msgid "Fair"
+msgstr "ياخشىراق"
+
+#: ../panels/user-accounts/pw-utils.c:114
+#: ../panels/user-accounts/um-password-dialog.c:608
+msgctxt "Password strength"
+msgid "Good"
+msgstr "ياخشى"
+
+#: ../panels/user-accounts/pw-utils.c:117
+#: ../panels/user-accounts/um-password-dialog.c:609
+msgctxt "Password strength"
+msgid "Strong"
+msgstr "كۈچلۈك"
+
+#: ../panels/user-accounts/run-passwd.c:424
+msgid "Authentication failed"
+msgstr "سالاھىيەت دەلىللەش مەغلۇپ بولدى"
+
+#: ../panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The new password is too short"
+msgstr "يېڭى ئىم بەك قىسقا"
+
+#: ../panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password is too simple"
+msgstr "يېڭى ئىم بەك ئاددىي"
+
+#: ../panels/user-accounts/run-passwd.c:516
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "يېڭى ئىم بىلەن كونا ئىم ئوخشىشىپ قالىدىكەن"
+
+#: ../panels/user-accounts/run-passwd.c:519
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "يېڭى ئىم يېقىندا ئىشلىتىلگەن."
+
+#: ../panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "يېڭى ئىم چوقۇم  سان ياكى ئالاھىدە ھەرپلەرنى ئۆز ئىچىگە ئېلىشى لازىم"
+
+#: ../panels/user-accounts/run-passwd.c:526
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "كونا ۋە يېڭى ئىم ئوخشاش"
+
+#: ../panels/user-accounts/run-passwd.c:530
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "تۇنجى قېتىم سالاھىيەت تەكشۈرتكىنىڭىزدىن بۇيان ئىم ئۆزگەرتىلدى!"
+
+#: ../panels/user-accounts/run-passwd.c:534
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "يېڭى ئىم يېتەرلىك پەرقلىق ھەرپلەرنى ئۆز ئىچىگە ئالمىغان"
+
+#: ../panels/user-accounts/run-passwd.c:538
+#, c-format
+msgid "Unknown error"
+msgstr "نامەلۇم خاتالىق"
+
+#: ../panels/user-accounts/um-account-dialog.c:182
+msgid "Failed to add account"
+msgstr "ھېسابات قوشۇش مەغلۇپ بولدى"
+
+#: ../panels/user-accounts/um-account-dialog.c:403
+#: ../panels/user-accounts/um-account-dialog.c:444
+msgid "Failed to register account"
+msgstr "ھېسابات خەتلىتىش مەغلۇپ بولدى"
+
+#: ../panels/user-accounts/um-account-dialog.c:577
+msgid "No supported way to authenticate with this domain"
+msgstr "مەزكۇر دائىرىدە كىملىك دەلىللەشتە قوللىمايدىغان ئۇسۇل"
+
+#: ../panels/user-accounts/um-account-dialog.c:631
+msgid "Failed to join domain"
+msgstr "دائىرىگە قوشۇلۇش مەغلۇپ بولدى"
+
+#: ../panels/user-accounts/um-account-dialog.c:688
+msgid "Failed to log into domain"
+msgstr "دائىرىگە كىرىش مەغلۇپ بولدى"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr "سىزنىڭ بۇ ئۈسكۈنىنى زىيارەت قىلىش ھوقۇقىڭىز يوقكەن. سىستېما باشقۇرغۇچىسى بىلەن ئالاقىلىشىڭ."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "The device is already in use."
+msgstr "ئۈسكۈنە ئىشلىتىلىۋاتىدۇ."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:143
+msgid "An internal error occurred."
+msgstr "ئىچكى خاتالىق يۈز بەردى."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:268
+msgid "Delete registered fingerprints?"
+msgstr "خەتلەنگەن بارماق ئىزلىرىنى ئۆچۈرۈۋېتەمسىز؟"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:272
+msgid "_Delete Fingerprints"
+msgstr "بارماق ئىزلىرىنى ئۆچۈر (_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:279
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "خەتلەنگەن بارماق ئىزلىرىڭىزنى ئۆچۈرەمسىز؟ بارماق ئىزىدا تىزىمغا كىرىش چەكلىنىدۇ"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:455
+msgid "Done!"
+msgstr "تامام!"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:516
+#: ../panels/user-accounts/um-fingerprint-dialog.c:558
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "‹%s› ئۈسكۈنىنى زىيارەت قىلالمىدى."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:599
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "‹%s› ئۈسكۈنىسىدە بارماق ئىزىغا ئېرىشىشنى باشلىغىلى بولمىدى."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:650
+msgid "Could not access any fingerprint readers"
+msgstr "ھېچقانداق بارماق ئىزى ئوقۇغۇچ ئۈسكۈنىسى بىلەن ئالاقە قىلغىلى بولمىدى."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:651
+msgid "Please contact your system administrator for help."
+msgstr "ياردەمگە ئېرىشىش ئۈچۈن سىستېما باشقۇرغۇچىسى بىلەن ئالاقىلىشىڭ."
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:734
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr "بارماق ئىزى ئارقىلىق تىزىمغا كىرىشنى قوزغىتىش ئۈچۈن، «%s» ئۈسكۈنىسى ئارقىلىق بىر بارمىقىڭىزنىڭ ئۇچۇرىنى ساقلىشىڭىز كېرەك."
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:741
+msgid "Selecting finger"
+msgstr "تاللانغان بارماق"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:742
+msgid "Enrolling fingerprints"
+msgstr "بارماق ئىزى تىزىملىنىۋاتىدۇ"
+
+#: ../panels/user-accounts/um-history-dialog.c:88
+msgid "This Week"
+msgstr "بۇ ھەپتە"
+
+#: ../panels/user-accounts/um-history-dialog.c:91
+msgid "Last Week"
+msgstr "ئۆتكەن ھەپتە"
+
+#: ../panels/user-accounts/um-password-dialog.c:130
+msgid "_Generate a password"
+msgstr "ئىم ھاسىللا(_G)"
+
+#: ../panels/user-accounts/um-password-dialog.c:184
+msgid "Please choose another password."
+msgstr "باشقا ئىم تاللاڭ."
+
+#: ../panels/user-accounts/um-password-dialog.c:193
+msgid "Please type your current password again."
+msgstr "ھازىرقى ئىمنى قايتا كىرگۈزۈڭ."
+
+#: ../panels/user-accounts/um-password-dialog.c:199
+msgid "Password could not be changed"
+msgstr "ئىمنى ئۆزگەرتكىلى بولمىدى"
+
+#: ../panels/user-accounts/um-password-dialog.c:297
+msgid "You need to enter a new password"
+msgstr "يېڭى ئىم كىرگۈزۈشىڭىز زۆرۈر"
+
+#: ../panels/user-accounts/um-password-dialog.c:300
+#| msgid "The new password is too short"
+msgid "The new password is not strong enough"
+msgstr "يېڭى ئىم تازا پۇختا ئەمەس"
+
+#: ../panels/user-accounts/um-password-dialog.c:306
+msgid "You need to confirm the password"
+msgstr "ئىمنى جەزملىشىڭىز زۆرۈر"
+
+#: ../panels/user-accounts/um-password-dialog.c:309
+msgid "The passwords do not match"
+msgstr "ئىم ماسلاشمىدى"
+
+#: ../panels/user-accounts/um-password-dialog.c:315
+msgid "You need to enter your current password"
+msgstr "نۆۋەتتىكى ئىمنى كىرگۈزۈشىڭىز زۆرۈر"
+
+#: ../panels/user-accounts/um-password-dialog.c:318
+msgid "The current password is not correct"
+msgstr "نۆۋەتتىكى ئىم خاتا"
+
+#: ../panels/user-accounts/um-password-dialog.c:385
+msgid "Passwords do not match"
+msgstr "ئىم ماس كەلمىدى"
+
+#: ../panels/user-accounts/um-password-dialog.c:447
+msgid "Wrong password"
+msgstr "ئىم خاتا"
+
+#: ../panels/user-accounts/um-photo-dialog.c:443
+msgid "Disable image"
+msgstr "سۈرەتنى ئىناۋەتسىز قىل"
+
+#: ../panels/user-accounts/um-photo-dialog.c:461
+msgid "Take a photo…"
+msgstr "سۈرەت تارتىش…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:479
+msgid "Browse for more pictures…"
+msgstr "تېخىمۇ كۆپ سۈرەتكە كۆز يۈگۈرت…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:703
+#, c-format
+msgid "Used by %s"
+msgstr "%s ئىشلەتكەن"
+
+#: ../panels/user-accounts/um-realm-manager.c:351
+msgid "Cannot automatically join this type of domain"
+msgstr "بۇ تىپتىكى دائىرىگە ئاپتوماتىك كىرگىلى بولمايدۇ"
+
+#: ../panels/user-accounts/um-realm-manager.c:414
+#, c-format
+msgid "No such domain or realm found"
+msgstr "بۇنداق دائىرە ئاتى ياكى realm نى تاپقىلى بولمىدى"
+
+#: ../panels/user-accounts/um-realm-manager.c:815
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "%s سۈپىتىدە دائىرە %s غا كىرگىلى بولمىدى"
+
+#: ../panels/user-accounts/um-realm-manager.c:820
+msgid "Invalid password, please try again"
+msgstr "ئىم خاتا، قايتا سىناڭ"
+
+#: ../panels/user-accounts/um-realm-manager.c:824
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "دائىرە %s غا باغلانغىلى بولمىدى: %s"
+
+#: ../panels/user-accounts/um-user-panel.c:376
+msgid "Failed to delete user"
+msgstr "ئىشلەتكۈچى ئۆچۈرۈش مەغلۇپ بولدى"
+
+#: ../panels/user-accounts/um-user-panel.c:436
+msgid "You cannot delete your own account."
+msgstr "ئۆزىڭىزنىڭ ھېساباتىنى ئۆچۈرەلمەيسىز."
+
+#: ../panels/user-accounts/um-user-panel.c:445
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s يەنىلا تىزىمدا بار"
+
+#: ../panels/user-accounts/um-user-panel.c:449
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "ئىشلەتكۈچى سىستېمىنى ئىشلىتىۋاتقان ئۇنى ئۆچۈرسە سىستېما مۇقىمسىز ھالەتكە كېلىپ قالىدۇ"
+
+#: ../panels/user-accounts/um-user-panel.c:458
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "%s نىڭ ھۆججىتىنى ساقلاپ قالامسىز؟"
+
+#: ../panels/user-accounts/um-user-panel.c:462
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr "ئىشلەتكۈچى ھېساباتىنى ئۆچۈرگەندە ماكان مۇندەرىجە، ئېلخەت مۇندەرىجە ۋە ۋاقىتلىق ھۆججەتنى ساقلاپ قېلىشقا بولىدۇ."
+
+#: ../panels/user-accounts/um-user-panel.c:465
+msgid "_Delete Files"
+msgstr "ھۆججەت ئۆچۈر(_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:466
+msgid "_Keep Files"
+msgstr "ھۆججەتنى ساقلاپ قال(_K)"
+
+#: ../panels/user-accounts/um-user-panel.c:518
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "ھېسابات چەكلەنگەن"
+
+#: ../panels/user-accounts/um-user-panel.c:526
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "كېيىنكى قېتىم تىزىمغا كىرگەندە تەڭشە"
+
+#: ../panels/user-accounts/um-user-panel.c:529
+msgctxt "Password mode"
+msgid "None"
+msgstr "يوق"
+
+#: ../panels/user-accounts/um-user-panel.c:578
+msgid "Logged in"
+msgstr "كىرگەن"
+
+#: ../panels/user-accounts/um-user-panel.c:941
+msgid "Failed to contact the accounts service"
+msgstr "ھېسابات مۇلازىمېتىرى بىلەن ئالاقىلىشىش مەغلۇپ بولدى"
+
+#: ../panels/user-accounts/um-user-panel.c:943
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "AccountService توغرا ئورنىتىلىپ قوزغىتىلغانلىقىنى جەزملەڭ."
+
+#: ../panels/user-accounts/um-user-panel.c:984
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr "ئۆزگەرتىشتە،\n"
+"ئالدى بىلەن * سىنبەلگىنى چېكىڭ"
+
+#: ../panels/user-accounts/um-user-panel.c:1022
+msgid "Create a user account"
+msgstr "بىر ئىشلەتكۈچى ھېساباتى قۇرىدۇ"
+
+#: ../panels/user-accounts/um-user-panel.c:1033
+#: ../panels/user-accounts/um-user-panel.c:1319
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr "ئىشلەتكۈچى ھېساباتى قۇرۇش ئۈچۈن،\n"
+"ئالدى بىلەن * سىنبەلگىسىنى چېكىڭ"
+
+#: ../panels/user-accounts/um-user-panel.c:1042
+msgid "Delete the selected user account"
+msgstr "تاللانغان ئىشلەتكۈچى ھېساباتىنى ئۆچۈرىدۇ"
+
+#: ../panels/user-accounts/um-user-panel.c:1054
+#: ../panels/user-accounts/um-user-panel.c:1324
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr "تاللانغان ئىشلەتكۈچى ھېساباتىنى ئۆچۈرۈش ئۈچۈن،\n"
+"ئالدى بىلەن * سىنبەلگىسىنى چېكىڭ"
+
+#: ../panels/user-accounts/um-user-panel.c:1228
+msgid "My Account"
+msgstr "ھېساباتىم"
+
+#: ../panels/user-accounts/um-user-panel.c:1237
+msgid "Other Accounts"
+msgstr "باشقا ھېساباتلار"
+
+#: ../panels/user-accounts/um-utils.c:516
+#, c-format
+msgid "A user with the username '%s' already exists"
+msgstr "‹%s› ئاتلىق ئىشلەتكۈچىدىن بىرى مەۋجۇت"
+
+#: ../panels/user-accounts/um-utils.c:520
+#, c-format
+msgid "The username is too long"
+msgstr "ئىشلەتكۈچى ئاتى بەك ئۇزۇن"
+
+#: ../panels/user-accounts/um-utils.c:523
+msgid "The username cannot start with a '-'"
+msgstr "ئىشلەتكۈچى ئاتى '-' ھەرپتىن باشلانمايدۇ"
+
+#: ../panels/user-accounts/um-utils.c:526
+msgid ""
+"The username must only consist of:\n"
+" ➣ letters from the English alphabet\n"
+" ➣ digits\n"
+" ➣ any of the characters '.', '-' and '_'"
+msgstr "ئىشلەتكۈچى ئاتىنىڭ تەركىبىدە بولىدىغىنى:\n"
+"  ئىنگلىزچە ئېلىپبەدىكى ھەرپلەر ➣\n"
+"  رەقەملەر ➣ \n"
+"  \"-\" خالىغان ھەرپ \".\"، \"_\"  ۋە ➣"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "خەرىتە توپچىلار"
+
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr "خەرىتە توپچىلار ئىقتىدارى"
+
+#: ../panels/wacom/calibrator/gui_gtk.c:79
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "ئېكراندا كۆرۈنگەن نىشاننى چېكىپ تاختىنى توغرىلاڭ."
+
+#: ../panels/wacom/calibrator/gui_gtk.c:368
+msgid "Mis-click detected, restarting..."
+msgstr "خاتا چېكىش بايقالدى، قايتا قوزغىتىۋاتىدۇ…"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Output:"
+msgstr "چىقار:"
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:287
+msgid "Keep aspect ratio (letterbox):"
+msgstr "كەڭلىك ۋە ئېگىزلىكنىڭ نىسبىتى ئۆزگەرمىسۇن(letterbox):"
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:298
+msgid "Map to single monitor"
+msgstr "يەككە كۆزەتكۈچكە خەرىتىلە"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:89
+#, c-format
+msgid "%d of %d"
+msgstr "%d / %d"
+
+#: ../panels/wacom/cc-wacom-page.c:118 ../panels/wacom/cc-wacom-page.c:384
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "يوق"
+
+#: ../panels/wacom/cc-wacom-page.c:119
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "كۇنۇپكا بېسىلىشىنى يوللاش"
+
+#: ../panels/wacom/cc-wacom-page.c:120
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "ئېكران ئالماشتۇرۇش"
+
+#: ../panels/wacom/cc-wacom-page.c:121
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "ئېكران ئۈستى ياردىمىنى كۆرسەت"
+
+#: ../panels/wacom/cc-wacom-page.c:621
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "ئۈستى"
+
+#: ../panels/wacom/cc-wacom-page.c:621
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "ئاستى"
+
+#: ../panels/wacom/cc-wacom-page.c:662
+msgid "Switch Modes"
+msgstr "ئالماشتۇرۇش ھالىتى"
+
+#: ../panels/wacom/cc-wacom-page.c:752
+#: ../panels/wacom/cc-wacom-stylus-page.c:373
+msgid "Button"
+msgstr "توپچا"
+
+#: ../panels/wacom/cc-wacom-page.c:810
+msgid "Action"
+msgstr "مەشغۇلات"
+
+#: ../panels/wacom/cc-wacom-page.c:920
+msgid "Display Mapping"
+msgstr "خەرىتە كۆرسەت"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr "Wacom Tablet"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set your Wacom tablet preferences"
+msgstr "Wacom tablet نىڭ مايىللىقىنى تەڭشەيدۇ"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;قەلەم;ئۆچۈرگۈچ;چاشقىنەك;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "Tablet (مۇتلەق)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "سېزىمچان تاختا (نىسپىي)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "Tablet مايىللىقى"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr "tablet بايقالمىدى"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "Wacom tablet نى چېتىڭ ياكى توكىنى ئېچىڭ."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr "كۆكچىش تەڭشىكى"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Map to Monitor…"
+msgstr "كۆزەتكۈچكە خەرىتىلەش…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map Buttons…"
+msgstr "خەرىتە توپچىلار…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr "كۆرسىتىش ئېنىقلىقىنى تەڭشەيدۇ"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Tracking Mode"
+msgstr "ئىزلاش ھالىتى"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Left-Handed Orientation"
+msgstr "سول قول يۆنىلىش"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1076
+msgid "Left Ring"
+msgstr "سول نامسىز بارماق"
+
+#: ../panels/wacom/gsd-wacom-device.c:1086
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "سول نامسىز بارماق ھالىتى #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1105
+msgid "Right Ring"
+msgstr "ئوڭ نامسىز بارماق"
+
+#: ../panels/wacom/gsd-wacom-device.c:1115
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "ئوڭ نامسىز بارماق ھالىتى #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1156
+msgid "Left Touchstrip"
+msgstr "سول Touchstrip"
+
+#: ../panels/wacom/gsd-wacom-device.c:1166
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "سول Touchstrip ھالىتى #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1185
+msgid "Right Touchstrip"
+msgstr "ئوڭ Touchstrip"
+
+#: ../panels/wacom/gsd-wacom-device.c:1195
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "ئوڭ Touchstrip ھالىتى #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1220
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "سول Touchstrip ھالەت ئالماشتۇرغۇچ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1222
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "ئوڭ Touchstrip ھالەت ئالماشتۇرغۇچ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1225
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "سول Touchstrip ھالەت ئالماشتۇرغۇچ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1227
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "ئوڭ Touchstrip ھالەت ئالماشتۇرغۇچ"
+
+#: ../panels/wacom/gsd-wacom-device.c:1232
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "ھالەت ئۈزچاتى #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1336
+#, c-format
+msgid "Left Button #%d"
+msgstr "سول توپچا #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1339
+#, c-format
+msgid "Right Button #%d"
+msgstr "ئوڭ توپچا #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1342
+#, c-format
+msgid "Top Button #%d"
+msgstr "ئۈستى توپچا #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1345
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "ئاستى توپچا #%d"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "مەشغۇلات يوق"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "چاشقىنەك سول توپچىسىنىڭ چېكىلىشى"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "چاشقىنەك ئوتتۇرا توپچىسىنىڭ چېكىلىشى"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "چاشقىنەك ئوڭ توپچىسىنىڭ چېكىلىشى"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "ئۈستىگە سىيرىش"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "ئاستىغا سىيرىش"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "سولغا سۈر"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "ئوڭغا سۈر"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "كەينى"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "ئالدى"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "قەلەم"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "ئۆچۈرگۈچ بېسىم سەزگۈسى"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "يۇمشاق"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "قاتتىق"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "ئۈستى توپچا"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "تۆۋەندىكى توپچا"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "قەلەم ئۇچىنىڭ بېسىش سېزىمى"
+
+#: ../shell/control-center.c:66
+msgid "Enable verbose mode"
+msgstr "تەپسىلىي ھالەتنى قوزغات"
+
+#: ../shell/control-center.c:67
+msgid "Show the overview"
+msgstr "ئۈزۈندىنى كۆرسەت"
+
+#: ../shell/control-center.c:68
+msgid "Search for the string"
+msgstr "بۇ تېكىستنى ئىزدە"
+
+#: ../shell/control-center.c:69
+msgid "List possible panel names and exit"
+msgstr "تىزغىلى بولىدىغان تاختا(panel) ئاتلىرىنى تىزىپ ئاخىرلاشتۇرىدۇ"
+
+#: ../shell/control-center.c:70 ../shell/control-center.c:71
+#: ../shell/control-center.c:72
+msgid "Show help options"
+msgstr "ياردەم تاللانمىلىرىنى كۆرسەت"
+
+#: ../shell/control-center.c:73
+msgid "Panel to display"
+msgstr "كۆرسىتىدىغان تاختا"
+
+#: ../shell/control-center.c:73
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMENT…]"
+
+#: ../shell/control-center.c:95
+msgid "- Settings"
+msgstr "- تەڭشەكلەر"
+
+#: ../shell/control-center.c:103
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr "%s\n"
+"'%s --help' ئىجرا قىلىپ بۇيرۇق قۇرىنىڭ تولۇق تاللانما تىزىمىنى كۆرۈڭ.\n"
+
+#: ../shell/control-center.c:133
+msgid "Available panels:"
+msgstr "ئىشلەتكىلى بولىدىغان تاختىلار:"
+
+#: ../shell/control-center.c:244
+msgid "Help"
+msgstr "ياردەم"
+
+#: ../shell/control-center.c:245
+msgid "Quit"
+msgstr "ئاخىرلاشتۇر"
+
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "باشقۇرۇش مەركىزى"
+
+#. Add categories
+#: ../shell/gnome-control-center.c:887
+msgctxt "category"
+msgid "Personal"
+msgstr "شەخسىي"
+
+#: ../shell/gnome-control-center.c:888
+msgctxt "category"
+msgid "Hardware"
+msgstr "قاتتىق دېتال"
+
+#: ../shell/gnome-control-center.c:889
+msgctxt "category"
+msgid "System"
+msgstr "سىستېما"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:1 ../shell/shell.ui.h:1
+msgid "Settings"
+msgstr "تەڭشەكلەر"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;مايىللىق;تەڭشەكلەر;"
+
+#: ../shell/shell.ui.h:2
+msgid "All Settings"
+msgstr "بارلىق تەڭشەكلەر"
+
+#~| msgid "Paired"
+#~ msgid "Wired"
+#~ msgstr "سىملىق"
+
+#~| msgid "_Mobile Broadband"
+#~ msgid "Mobile broadband"
+#~ msgstr "كۆچمە كەڭ بەلۋاغ"
+
+#~ msgid "Mesh"
+#~ msgstr "تورسىمان"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "Carrier/ئۇلىنىش ئۆزگەرتىلدى"
+
+#~ msgid "_Mark As Inactive After"
+#~ msgstr "بۇ ۋاقىتتىن كېيىن ئاكتىپ ئەمەس دەپ بىر تەرەپ قىل(_M)"
+
+#~ msgid "%s Options"
+#~ msgstr "%s نىڭ تاللانمىلىرى"
+
+#~ msgid "Manufacturers"
+#~ msgstr "ياسىغۇچى ئورۇن"
+
+#~ msgid "Drivers"
+#~ msgstr "قوزغاتقۇلار"
+
+#~ msgid "Don't retain history"
+#~ msgstr "ئىزلارنى ساقلىما"
+
+#~ msgid "Out of range"
+#~ msgstr "دائىرە سىرتىدا"
+
+#~ msgid "_Configure…"
+#~ msgstr "سەپلە(_C)…"
+
+#~ msgid "_Disconnect"
+#~ msgstr "ئۈز(_D)"
+
+#~ msgid "_Connect"
+#~ msgstr "باغلا(_C)"
+
+#~ msgid "_Settings…"
+#~ msgstr "تەڭشەكلەر(_S)…"
+
+#~ msgid "Disconnected"
+#~ msgstr "ئۈزۈلدى"
+
+#~ msgid "No profile"
+#~ msgstr "سەپلىمە ھۆججەت يوق"
+
+#~ msgid "%i year"
+#~ msgid_plural "%i years"
+#~ msgstr[0] "%i يىل"
+
+#~ msgid "%i month"
+#~ msgid_plural "%i months"
+#~ msgstr[0] "%i ئاي"
+
+#~ msgid "%i week"
+#~ msgid_plural "%i weeks"
+#~ msgstr[0] "%i ھەپتە"
+
+#~ msgid "Less than 1 week"
+#~ msgstr "بىر ھەپتىدىن قىسقا"
+
+#~ msgid "This device is not color managed."
+#~ msgstr "بۇ ئۈسكۈنە رەڭ باشقۇرمايدۇ."
+
+#~ msgid "This device is using manufacturing calibrated data."
+#~ msgstr "بۇ ئۈسكۈنە زاۋۇتتا تۈزىتىلگەن سانلىق-مەلۇماتنى ئىشلىتىۋاتىدۇ."
+
+#~ msgid ""
+#~ "This device does not have a profile suitable for whole-screen color "
+#~ "correction."
+#~ msgstr ""
+#~ "بۇ ئۈسكۈنە پۈتكۈل ئېكران رەڭ تۈزىتىش سەپلىمە ھۆججىتىنىڭ يۈرۈشلۈكى يوق."
+
+#~ msgid "Not specified"
+#~ msgstr "بەلگىلەنمىگەن"
+
+#~ msgid "No devices supporting color management detected"
+#~ msgstr "رەڭ باشقۇرۇشنى قوللايدىغان ھېچقانداق ئۈسكۈنە تېپىلمىدى"
+
+#~ msgid "Unspecified"
+#~ msgstr "بەلگىلەنمىگەن"
+
+#~| msgid "Browse for more pictures..."
+#~ msgid "Browse Files..."
+#~ msgstr "ھۆججەتكە كۆز يۈگۈرت..."
+
+#~ msgid "Create virtual device"
+#~ msgstr "مەۋھۇم ئۈسكۈنە قۇر"
+
+#~| msgid "Available Profiles"
+#~ msgid "Available Profiles for Displays"
+#~ msgstr "ئىشلەتكىلى بولىدىغان كۆرسىتىش سەپلىمىسى"
+
+#~| msgid "Available Profiles"
+#~ msgid "Available Profiles for Scanners"
+#~ msgstr "شويلىلىغۇچ ئۈچۈن ئىشلەتكىلى بولىدىغان سەپلىمە ھۆججەتلەر"
+
+#~| msgid "Available Profiles"
+#~ msgid "Available Profiles for Printers"
+#~ msgstr "پرىنتېر ئۈچۈن ئىشلەتكىلى بولىدىغان سەپلىمە ھۆججەتلەر"
+
+#~| msgid "Available Profiles"
+#~ msgid "Available Profiles for Cameras"
+#~ msgstr "ئىشلەتكىلى بولىدىغان كامېرا سەپلىمە ھۆججەتلىرى"
+
+#~| msgid "Available Profiles"
+#~ msgid "Available Profiles for Webcams"
+#~ msgstr "ئىشلەتكىلى بولىدىغان تور كامېرا سەپلىمە ھۆججەتلىرى"
+
+#~ msgid "Add device"
+#~ msgstr "ئۈسكۈنە قوش"
+
+#~ msgid "Add a virtual device"
+#~ msgstr "بىر مەۋھۇم ئۈسكۈنە قوش"
+
+#~ msgid "Remove a device"
+#~ msgstr "بىر ئۈسكۈنە چىقىرىۋەت"
+
+#~ msgid "English"
+#~ msgstr "ئىنگلىزچە"
+
+#~| msgid "General"
+#~ msgid "German"
+#~ msgstr "گېرمانچە"
+
+#~ msgid "French"
+#~ msgstr "فىرانسۇزچە"
+
+#~ msgid "Russian"
+#~ msgstr "رۇسچە"
+
+#~ msgid "Arabic"
+#~ msgstr "ئەرەبچە"
+
+#~ msgid "%d x %d (%s)"
+#~ msgstr "%d x %d (%s)"
+
+#~ msgid "%d x %d"
+#~ msgstr "%d x %d"
+
+#~ msgid "VESA: %s"
+#~ msgstr "VESA: %s"
+
+#~ msgid "Unknown model"
+#~ msgstr "نامەلۇم مودېل"
+
+#~ msgid "The next login will attempt to use the standard experience."
+#~ msgstr ""
+#~ "كېيىنكى قېتىم تىزىمغا كىرگەندە ئۆلچەملىك ئىشلەتكۈچى كەچمىشى بىلەن "
+#~ "تەمىنلەيدۇ."
+
+#~ msgid ""
+#~ "The next login will use the fallback mode intended for unsupported "
+#~ "graphics hardware."
+#~ msgstr ""
+#~ "كېيىنكى قېتىم تىزىمغا كىرگەندە قوللىمايدىغان كۆرسىتىش قاتتىق دېتالىغا "
+#~ "لايىھىلەنگەن زاپاس ھالەتنى ئىشلىتىدۇ."
+
+#~ msgctxt "Experience"
+#~ msgid "Fallback"
+#~ msgstr "زاپاس"
+
+#~ msgctxt "Experience"
+#~ msgid "Standard"
+#~ msgstr "ئۆلچەملىك"
+
+#~ msgid "OS type"
+#~ msgstr "مەشغۇلات سىستېمىسى تىپى"
+
+#~ msgid "_Other Media..."
+#~ msgstr "باشقا ۋاسىتە(_O)…"
+
+#~ msgid "Experience"
+#~ msgstr "كەچمىش"
+
+#~ msgid "Forced _Fallback Mode"
+#~ msgstr "مەجبۇرىي زاپاس ھالەتنى ئىشلەت(_F)"
+
+#~ msgid "_Options..."
+#~ msgstr "تاللانما(_O)…"
+
+#~| msgid "Create..."
+#~ msgid "C_reate..."
+#~ msgstr "قۇر(_R)…"
+
+#~| msgid "Copy Settings..."
+#~ msgid "_Settings..."
+#~ msgstr "تەڭشەك(_S)…"
+
+#~ msgid "Caution low battery, %s remaining"
+#~ msgstr "توكداننىڭ توكى ئازلاپ كېتى - %s ئىشلەتكىلى بولىدۇ"
+
+#~ msgid "Using battery power - %s remaining"
+#~ msgstr "توكداننى ئىشلىتىۋاتىدۇ - %s ئىشلەتكىلى بولىدۇ"
+
+#~| msgid "On _battery power:"
+#~ msgid "Using battery power"
+#~ msgstr "توكداننى ئىشلىتىۋاتىدۇ"
+
+#~ msgid "Charging - fully charged"
+#~ msgstr "توكلىنىۋاتىدۇ - تولدى"
+
+#~ msgid "Using UPS power - %s remaining"
+#~ msgstr "UPS  توكىنى ئىشلىتىۋاتىدۇ - %s قالدى"
+
+#~ msgid "Caution low UPS"
+#~ msgstr "دىققەت UPS نىڭ توكى ئاز"
+
+#~ msgid "Using UPS power"
+#~ msgstr "‏USP نى ئىشلىتىۋاتىدۇ"
+
+#~ msgid "Your secondary battery is fully charged"
+#~ msgstr "ئىككىلەمچى توكدان تولدى"
+
+#~ msgid "Your secondary battery is empty"
+#~ msgstr "ئىككىلەمچى توكدان قۇرۇق"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging - fully charged"
+#~ msgstr "توكلىنىۋاتىدۇ - تولدى"
+
+#~ msgid ""
+#~ "Tip: <a href=\"screen\">screen brightness</a> affects how much power is "
+#~ "used"
+#~ msgstr ""
+#~ "كۆرسەتمە: <a href=\"screen\">ئېكران يورۇقلۇقى</a> سەرپ بولىدىغان "
+#~ "ئېنېرگىيىگە تەسىر قىلىدۇ"
+
+#~| msgid "Suspend"
+#~ msgid "Don't suspend"
+#~ msgstr "توڭلاتما"
+
+#~ msgctxt "printer state"
+#~ msgid "Paused"
+#~ msgstr "ۋاقىتلىق توختىدى"
+
+#~ msgid "_Show"
+#~ msgstr "كۆرسەت(_S)"
+
+#~| msgid "Select an input source to add"
+#~ msgid "Choose an input source"
+#~ msgstr "كىرگۈزۈش مەنبەسىنى تاللاڭ"
+
+#~ msgid "Copy Settings..."
+#~ msgstr "تەڭشەكنى كۆچۈر…"
+
+#~ msgid ""
+#~ "Select a display language (change will be applied next time you log in)"
+#~ msgstr ""
+#~ "كۆرسىتىش تىلىدىن بىرنى تاللاڭ(كېيىنكى قېتىم تىزىمغا كىرگەندە ئۆزگەرتىشنى "
+#~ "قوللىنىدۇ)"
+
+#~ msgid "Install languages..."
+#~ msgstr "تىللارنى ئورنات…"
+
+#~| msgid "Brightness"
+#~ msgid "Brightness & Lock"
+#~ msgstr "يورۇقلۇقى ۋە قۇلۇپ"
+
+#~ msgid "Screen brightness and lock settings"
+#~ msgstr "ئېكران يورۇقلۇقى ۋە قۇلۇپ تەڭشىكى"
+
+#~ msgid "Brightness;Lock;Dim;Blank;Monitor;"
+#~ msgstr "يورۇقلۇق؛قۇلۇپ؛غۇۋا؛قارا؛ئېكران؛"
+
+#~ msgid "_Dim screen to save power"
+#~ msgstr "ئېكراننى تۇتۇقلاشتۇرۇپ توك تېجىسۇن(_D)"
+
+#~ msgid "Don't lock when at home"
+#~ msgstr "ئۆيدىكى چاغدا قۇلۇپلىمىسۇن"
+
+#~ msgid "Locations..."
+#~ msgstr "ئورۇنلار…"
+
+#~ msgid "Lock"
+#~ msgstr "قۇلۇپلا"
+
+#~ msgid "Enable debugging code"
+#~ msgstr "سازلاش كودىنى قوزغات"
+
+#~ msgid "Version of this application"
+#~ msgstr "بۇ پروگراممىنىڭ نەشرى"
+
+#~ msgid " — GNOME Volume Control Applet"
+#~ msgstr " — گىنوم ئاۋاز تىزگىن قوللانچاق"
+
+#~ msgid "Show desktop volume control"
+#~ msgstr "ئۈستەلئۈستى ئاۋاز تىزگىننى كۆرسەت"
+
+#~ msgid "Sound Output Volume"
+#~ msgstr "ئاۋاز مىقدارى"
+
+#~ msgid "Microphone Volume"
+#~ msgstr "مىكروفون ئاۋاز مىقدارى"
+
+#~ msgid "Failed to start Sound Preferences: %s"
+#~ msgstr "ئاۋاز مايىللىقىنى قوزغىتالمىدى: %s"
+
+#~ msgid "_Mute"
+#~ msgstr "ئۈنسىز(_M)"
+
+#~ msgid "_Sound Preferences"
+#~ msgstr "ئاۋاز مايىللىقى(_S)"
+
+#~ msgid "Muted"
+#~ msgstr "ئۈنسىز"
+
+#~ msgid "Options..."
+#~ msgstr "تاللانما…"
+
+#~ msgid "User Accounts"
+#~ msgstr "ئىشلەتكۈچى ھېساباتى"
+
+#~ msgid "Browse for more pictures..."
+#~ msgstr "تېخىمۇ كۆپ رەسىمگە كۆز يۈگۈرت…"
+
+#~| msgid "A user with the username '%s' already exists"
+#~ msgid "No user with the name '%s' exists."
+#~ msgstr "ئاتى ‹%s› بولغان ئىشلەتكۈچى يوق."
+
+#~ msgid "This user does not exist."
+#~ msgstr "بۇ ئىشلەتكۈچى مەۋجۇت ئەمەس."
+
+#~| msgid "Options..."
+#~ msgid "Map Buttons..."
+#~ msgstr "خەرىتە توپچىلار…"
+
+#~| msgid "Create..."
+#~ msgid "Calibrate..."
+#~ msgstr "تەڭشەش…"
+
+#~ msgid "Add wallpaper"
+#~ msgstr "تام قەغىزى قوش"
+
+#~ msgid "Remove wallpaper"
+#~ msgstr "تام قەغىزىنى چىقىرىۋەت"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "توغرىسىغا يانتۇلۇق دەرىجىسى"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "بويىغا يانتۇلۇق دەرىجىسى"
+
+#~ msgid "Solid Color"
+#~ msgstr "ساپ رەڭ"
+
+#~ msgid "Colors & Gradients"
+#~ msgstr "رەڭ ۋە تەدرىجىي ئۆزگىرىشلەر"
+
+#~ msgid "Upside-down"
+#~ msgstr "ئاستى ئۈستىنى ئالماشتۇر"
+
+#~ msgid "Could not get session bus while applying display configuration"
+#~ msgstr ""
+#~ "كۆرسىتىش تەڭشەكلىرىنى قوللىنىش جەريانىدا ئەڭگىمە باش لىنىيىسىگە ئېرىشكىلى "
+#~ "بولمىدى."
+
+#~ msgid "System Info"
+#~ msgstr "سىستېما ئۇچۇرى"
+
+#~ msgid "Magnifier zoom out"
+#~ msgstr "كىچىكلەت"
+
+#~ msgid "Toggle contrast"
+#~ msgstr "ئاق-قارىلىقنى ئالماشتۇر"
+
+#~ msgid "Toggle magnifier"
+#~ msgstr "لوپا ئەينەك ئالماشتۇر"
+
+#~ msgid "Toggle screen reader"
+#~ msgstr "ئېكران ئوقۇغۇچقا ئالماشتۇر"
+
+#~ msgid "New shortcut..."
+#~ msgstr "يېڭى تېزلەتمە…"
+
+#~ msgid "Accelerator key"
+#~ msgstr "تېزلەتكۈچ كۇنۇپكىسى"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "تېزلەتكۈچ ئۆزگەرتكۈچ"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "تېزلەتكۈچ كۇنۇپكا نومۇرى"
+
+#~ msgid "Accel Mode"
+#~ msgstr "تېزلەتكۈچ ھالىتى"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "تېزلەتكۈچ تىپى."
+
+#~ msgid "Error saving the new shortcut"
+#~ msgstr "يېڭى تېزلەتمە ساقلىغاندا خاتالىق كۆرۈلدى"
+
+#~ msgid "Too many custom shortcuts"
+#~ msgstr "ئىختىيارى تېزلەتمە بەك كۆپ"
+
+#~ msgid "Acti_on:"
+#~ msgstr "مەشغۇلات(_O):"
+
+#~ msgid "Media and Autorun"
+#~ msgstr "ۋاسىتە ۋە ئۆزلۈكىدىن ئىجرا قىل"
+
+#~ msgid "_Photos:"
+#~ msgstr "سۈرەتلەر(_P):"
+
+#~ msgid "Configure media and autorun preferences"
+#~ msgstr "ۋاسىتە ۋە ئۆزلۈكىدىن ئىجرا قىلىش مايىللىقى سەپلىنىدۇ"
+
+#~ msgid "cd;dvd;usb;audio;video;disc;"
+#~ msgstr "cd؛dvd؛usb؛ئۈن؛سىن؛دىسكا؛"
+
+#~ msgid "To add a new account, first select the account type"
+#~ msgstr "يېڭى بىر ھېسابات قوشۇشتا ئالدى بىلەن ھېسابات تىپىنى تاللاڭ"
+
+#~ msgid "_Add..."
+#~ msgstr "قوش(_A)…"
+
+#~ msgid "_Search by Address"
+#~ msgstr "ئادرېس بويىچە ئىزدە(_S)"
+
+#~ msgid ""
+#~ "FirewallD is not running. Network printer detection needs services mdns, "
+#~ "ipp, ipp-client and samba-client enabled on firewall."
+#~ msgstr ""
+#~ "FirewallD ئىجرا قىلىنمىغان. تور پرىنتېرىنى بايقاشتا mdns، ipp، ipp-"
+#~ "client، samba-client مۇداپىئە تېمىدا قوزغىتىلىشى لازىم."
+
+#~ msgctxt "printer type"
+#~ msgid "Local"
+#~ msgstr "يەرلىك"
+
+#~ msgctxt "printer type"
+#~ msgid "Network"
+#~ msgstr "تور"
+
+#~ msgid "Device types"
+#~ msgstr "ئۈسكۈنە تىپلىرى"
+
+#~ msgid "Opening firewall for mDNS connections"
+#~ msgstr "mDNS باغلىنىشىنىڭ مۇداپىئە تامنى ئېچىۋاتىدۇ"
+
+#~ msgid "Opening firewall for Samba connections"
+#~ msgstr "Samba باغلىنىشىنىڭ مۇداپىئە تامنى ئېچىۋاتىدۇ"
+
+#~ msgid "Opening firewall for IPP connections"
+#~ msgstr "IPP باغلىنىشىنىڭ مۇداپىئە تامنى ئېچىۋاتىدۇ"
+
+#~ msgid "_Back"
+#~ msgstr "كەينى(_B)"
+
+#~ msgid "Preview"
+#~ msgstr "ئالدىن كۆزەت"
+
+#~ msgid "Layouts"
+#~ msgstr "ئۇسلۇبلار"
+
+#~ msgid "New windows use the default layout"
+#~ msgstr "يېڭى كۆزنەكلەر كۆڭۈلدىكى ئۇسلۇبنى ئىشلىتىدۇ"
+
+#~ msgid "New windows use the previous window's layout"
+#~ msgstr "يېڭى كۆزنەكلەر ئالدىنقى كۆزنەكنىڭ ئۇسلۇبنى ئىشلىتىدۇ"
+
+#~ msgid ""
+#~ "Replace the current keyboard layout settings with the\n"
+#~ "default settings"
+#~ msgstr ""
+#~ "تاللانغان ھەرپتاختا ئورۇنلاشتۇرۇلۇشىنىڭ تەڭشىكىنى\n"
+#~ "كۆڭۈلدىكى تەڭشەك بىلەن ئالماشتۇرىدۇ"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "كۆڭۈلدىكىگە قايتۇر(_F)"
+
+#~ msgid "View and edit keyboard layout options"
+#~ msgstr "ھەرپتاختا جايلاشتۇرۇش تاللانمىسىنى كۆرۈش ۋە تەھرىرلەش"
+
+#~ msgid "Layout"
+#~ msgstr "ئۇسلۇب"
+
+#~ msgid "A_cceleration:"
+#~ msgstr "تېزلىتىش(_C):"
+
+#~ msgid "Drag and Drop"
+#~ msgstr "سۆرەپ تاشلاش"
+
+#~ msgid "Enable _mouse clicks with touchpad"
+#~ msgstr "سەزگۈر تاختىدا چاشقىنەك چېكىشنى قوزغات(_M)"
+
+#~ msgid "Scrolling"
+#~ msgstr "دومىلات"
+
+#~ msgid "Sh_ow position of pointer when the Control key is pressed"
+#~ msgstr "Ctrl كۇنۇپكا بېسىلسا ئىسترېلكا ئورنى كۆرۈنىدۇ(_O)"
+
+#~ msgid "Thr_eshold:"
+#~ msgstr "بوسۇغا قىممەت(_E):"
+
+#~ msgid "To test your settings, try to double-click on the face."
+#~ msgstr "تەڭشىكىڭىزنى سىناشتا چىراينىڭ ئۈستىدە قوش چېكىشنى سىناڭ."
+
+#~ msgid "_Disabled"
+#~ msgstr "چەكلەنگەن(_D)"
+
+#~ msgid "_Edge scrolling"
+#~ msgstr "يان سىيرىش(_E)"
+
+#~ msgid "_Left-handed"
+#~ msgstr "سولخاي(_L)"
+
+#~ msgid "_Right-handed"
+#~ msgstr "ئوڭخاي(_R)"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "سەزگۈرلۈكى(_S):"
+
+#~ msgid "_Timeout:"
+#~ msgstr "مۆھلىتى(_T):"
+
+#~ msgctxt "Wireless access point"
+#~ msgid "Other..."
+#~ msgstr "باشقا…"
+
+#~ msgid "Not connected to the internet."
+#~ msgstr "ئىنتېرنېتقا باغلانمىغان."
+
+#~ msgid "Create the hotspot anyway?"
+#~ msgstr "قىزىق نۇقتا قۇرۇۋېرەمسىز؟"
+
+#~ msgid "Disconnect from %s and create a new hotspot?"
+#~ msgstr "%s دىن ئۈزۈپ يېڭى بىر قىزىق نۇقتا قۇرامسىز؟"
+
+#~ msgid "This is your only connection to the internet."
+#~ msgstr "بۇ سىزنىڭ ئىنتېرنېت بىلەن بولغان بىردىنبىر باغلىنىشىڭىز."
+
+#~ msgid "Create _Hotspot"
+#~ msgstr "قىزىق نۇقتا قۇر(_H)"
+
+#~ msgid "Network;Wireless;IP;LAN;"
+#~ msgstr "تور؛سىمسىز؛IP؛LAN؛"
+
+#~ msgid "Speed"
+#~ msgstr "سۈرئىتى"
+
+#~ msgid "Subnet Mask"
+#~ msgstr "تارماق تور ماسكىسى"
+
+#~ msgid "Unlock"
+#~ msgstr "قۇلۇپ ئاچ"
+
+#~ msgid "_Network Name"
+#~ msgstr "تور ئاتى(_N)"
+
+#~ msgid "_Stop Hotspot..."
+#~ msgstr "قىزىق نۇقتىنى توختات(_S)…"
+
+#~ msgid "Battery discharging"
+#~ msgstr "توكدان توكسىزلىنىۋاتىدۇ"
+
+#~ msgid "%s until charged (%.0lf%%)"
+#~ msgstr "توك توشۇشقا %s قالدى (%.0lf%%)"
+
+#~ msgid "%s until empty (%.0lf%%)"
+#~ msgstr "توك تۈگەشكە %s قالدى (%.0lf%%)"
+
+#~ msgid "%.0lf%% charged"
+#~ msgstr "%.0lf%% توكلاندى"
+
+#~ msgid "Ask me"
+#~ msgstr "مەندىن سورا"
+
+#~ msgid "On AC _power:"
+#~ msgstr "ئۆزگىرىشچان توك مەنبەسىدە(_P):"
+
+#~ msgid "Put the computer to sleep when inactive:"
+#~ msgstr "ئاكتىپ ئەمەس ۋاقىتتا كومپيۇتېرنى ئۇخلىتىدۇ:"
+
+#~ msgid "Shutdown"
+#~ msgstr "تاقا"
+
+#~ msgid ""
+#~ "Only profiles that are compatible with the device will be listed above."
+#~ msgstr "ئۈستىدە تىزىلغان ئۈسكۈنىلەرلا سەپلىمە ھۆججەتنى قوللايدۇ."
+
+#~ msgid "_Turn off after:"
+#~ msgstr "كېيىن ياپ(_L):"
+
+#~ msgid "Mute"
+#~ msgstr "ئۈنسىز"
+
+#~ msgid "C_hoose a device to configure:"
+#~ msgstr "سەپلەيدىغان ئۈسكۈنە تاللاش(_H):"
+
+#~ msgid "Key"
+#~ msgstr "ئاچقۇچ"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "مەزكۇر تەھرىرلىگۈچ باغلانغان GConf كۇنۇپكىسى"
+
+#~ msgid "Callback"
+#~ msgstr "قايتۇرما چاقىرىق"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "كۇنۇپكىغا باغلانغان قىممەت ئۆزگەرگەندە، مۇشۇ قايتۇرما چاقىرىقنى ئىجرا قىل"
+
+#~ msgid "Change set"
+#~ msgstr "ئۆزگىرىش توپى"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "GConf خېرىدارىغا تەتبىقلاشقا يوللىنىدىغان مەلۇماتلارنى ئۆز ئىچىگە ئالغان "
+#~ "GConf ئۆزگىرىش توپى"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "ۋىجېت قايتۇرما چاقىرىقىغا ئايلاندۇرۇش"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "مەلۇماتلار GConf تىن ۋىجېتقا ئايلاندۇرۇلغاندا ئىجرا قىلىنىدىغان قايتۇرما "
+#~ "چاقىرىق"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "ۋىجېتتىن ئايلاندۇرۇلۇش قايتۇرما چاقىرىقى"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "مەلۇماتلار ۋىجېتتىن GConf قا ئايلاندۇرماقچى بولغاندا ئىجرا قىلىنىدىغان "
+#~ "قايتۇرما چاقىرىق"
+
+#~ msgid "UI Control"
+#~ msgstr "ئىشلەتكۈچى يۈزى تىزگىنىكى"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "خاسلىقنى تىزگىنلەيدىغان نەڭ (ئادەتتە بىر ۋىجېت)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "خاسلىق تەھرىرلىگۈچ جىسىم مەلۇماتى"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "مۇئەييەن خاسلىق تەھرىرلىگۈچ تەلەپ قىلىدىغان ئۆزگىچە مەلۇماتلار"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "خاسلىق تەھرىرلىگۈچ مەلۇمات بوشىتىش قايتۇرما چاقىرىقى"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "خاسلىق تەھرىرلىگۈچ جىسىم مەلۇماتى بوشىتىلغاندا ئىجرا قىلىنىدىغان قايتۇرما "
+#~ "چاقىرىق"
+
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "ھۆججەت '%s' تېپىلمىدى.\n"
+#~ "\n"
+#~ "ئۇنىڭ بارلىقىنى جەزملەشتۈرۈپ قايتا سىناڭ ياكى باشقا بىر تەگلىك رەسىم "
+#~ "تاللاڭ."
+
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "ھۆججەت '%s' نى قانداق ئېچىشنى بىلمەيمەن.\n"
+#~ "ئېھتىمال ئۇ تېخى قوللىمايدىغان رەسىم تىپى ئوخشايدۇ.\n"
+#~ "\n"
+#~ "باشقا رەسىم تاللاڭ"
+
+#~ msgid "Please select an image."
+#~ msgstr "سۈرەت تاللاڭ."
+
+#~ msgid "Caribou"
+#~ msgstr "Caribou"
+
+#~ msgid "Change contrast:"
+#~ msgstr "سېلىشتۇرما دەرىجە ئۆزگەرت:"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Decrease size:"
+#~ msgstr "كىچىكلەت:"
+
+#~ msgid "Increase size:"
+#~ msgstr "چوڭلۇقىنى چوڭايتىش:"
+
+#~ msgid "Nomon"
+#~ msgstr "Nomon"
+
+#~ msgid "Type here to test settings"
+#~ msgstr "ھەرپ كىرگۈزۈپ تەڭشەك سىناڭ"
+
+#~ msgid "Typing Assistant"
+#~ msgstr "كىرگۈزۈش ياردەمچىسى"
+
+#~ msgid "_Text size:"
+#~ msgstr "تېكىست چوڭلۇقى(_T):"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Display"
+#~ msgstr "كۆرسەتكۈچ"
+
+#~ msgctxt "universal access, seeing"
+#~ msgid "Zoom"
+#~ msgstr "كېڭەيت تارايت"
+
+#~ msgid "More choices..."
+#~ msgstr "تېخىمۇ كۆپ تاللاش…"
+
+#~ msgid "Create a user"
+#~ msgstr "ئىشلەتكۈچى قۇرىدۇ"
+
+#~ msgid "Cr_eate"
+#~ msgstr "قۇر(_E)"
+
+#~ msgid "_Account Type"
+#~ msgstr "ھېسابات تىپى(_A)"
+
+#~ msgid "Choose a generated password"
+#~ msgstr "ئۆزلۈكىدىن قۇرۇلغان ئىمنى تاللا"
+
+#~ msgid "Account _type"
+#~ msgstr "ھېسابات تىپى(_T)"
+
+#~ msgid "- System Settings"
+#~ msgstr "- سىستېما تەڭشەكلىرى"
+
+#~ msgid "System Settings"
+#~ msgstr "سىستېما تەڭشىكى"
+
+#~| msgid "24-Hour Time"
+#~ msgid "24-_Hour Time"
+#~ msgstr "24 سائەتلىك ۋاقىت"
+
+#~ msgid "Updates Available"
+#~ msgstr "يېڭىلانما بار"
+
+#~| msgid "When the sleep button is pressed:"
+#~ msgid "When the _sleep button is pressed:"
+#~ msgstr "ئۇخلاش تۈگمىسى بېسىلغاندا(_S):"
+
+#~| msgid "When the power button is pressed:"
+#~ msgid "When the p_ower button is pressed:"
+#~ msgstr "توك مەنبە تۈگمىسى بېسىلغاندا(_O):"
+
+#~ msgid "Keyboard;Mouse;a11y;Accessibility;"
+#~ msgstr "ھەرپتاختا;چاشقىنەك;a11y;قوشۇمچە ئىقتىدار;"
+
+#~ msgid "Locked"
+#~ msgstr "قۇلۇپلانغان"
+
+#~ msgid ""
+#~ "Dialog is unlocked.\n"
+#~ "Click to prevent further changes"
+#~ msgstr ""
+#~ "سۆزلەشكۈ قۇلۇپسىزلاندى.\n"
+#~ "ئەمدى ئۆزگەرتمەسلىك ئۈچۈن چېكىڭ"
+
+#~ msgid ""
+#~ "Dialog is locked.\n"
+#~ "Click to make changes"
+#~ msgstr ""
+#~ "سۆزلەشكۈ قۇلۇپلانغان.\n"
+#~ "ئۆزگەرتىش ئۈچۈن چېكىڭ"
+
+#~ msgid ""
+#~ "System policy prevents changes.\n"
+#~ "Contact your system administrator"
+#~ msgstr ""
+#~ "سىستېما تاكتىكىسى ئۆزگەرتىشنى چەكلىگەن.\n"
+#~ "سىستېما باشقۇرغۇچىڭىز بىلەن ئالاقىلىشىڭ"
+
+#~ msgid "%.1f KB"
+#~ msgstr "%.1f KB"
+
+#~ msgid "%.1f MB"
+#~ msgstr "%.1f MB"
+
+#~ msgid "%.1f GB"
+#~ msgstr "%.1f GB"
+
+#~ msgid "%.1f TB"
+#~ msgstr "%.1f TB"
+
+#~ msgid "%.1f PB"
+#~ msgstr "%.1f PB"
+
+#~ msgid "%.1f EB"
+#~ msgstr "%.1f EB"
+
+#~ msgid "Photos"
+#~ msgstr "سۈرەتلەر"
+
+#~ msgid "---"
+#~ msgstr "---"
+
+#~ msgid "Use default layout in new windows"
+#~ msgstr "يېڭى كۆزنەكتە كۆڭۈلدىكى ئۇسلۇبنى ئىشلىتىدۇ"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High/Inverse</span>"
+#~ msgstr "<span size=\"x-large\">يۇقىرى/ئەكسى رەڭ</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">High</span>"
+#~ msgstr "<span size=\"x-large\">يۇقىرى</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Low</span>"
+#~ msgstr "<span size=\"x-large\">تۆۋەن</span>"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "<span size=\"x-large\">Normal</span>"
+#~ msgstr "<span size=\"x-large\">نورمال</span>"
+
+#~ msgid "Current network location"
+#~ msgstr "نۆۋەتتىكى تور ئورنى"
+
+#~ msgid "More backgrounds URL"
+#~ msgstr "تېخىمۇ كۆپ تەگلىك URL"
+
+#~ msgid "More themes URL"
+#~ msgstr "تېخىمۇ كۆپ باش تېما URL"
+
+#~ msgid ""
+#~ "Set this to your current location name. This is used to determine the "
+#~ "appropriate network proxy configuration."
+#~ msgstr ""
+#~ "بۇنى نۆۋەتتىكى ئورنىڭىزنىڭ ئاتى قىلىپ تەڭشەڭ. بۇ توغرا بولغان تور "
+#~ "ۋاكالەتچى تەڭشىكىنى بايقاشتا لازىمى بار."
+
+#~ msgid ""
+#~ "URL for where to get more desktop backgrounds. If set to an empty string "
+#~ "the link will not appear."
+#~ msgstr ""
+#~ "تېخىمۇ كۆپ ئۈستەلئۈستى تەگلىككە ئېرىشىش URL. ئەگەر بوش ھەرپ تىزمىسى قىلىپ "
+#~ "تەڭشەلسە ئۇنداقتا ئۇلانما كۆرۈنمەيدۇ."
+
+#~ msgid ""
+#~ "URL for where to get more desktop themes. If set to an empty string the "
+#~ "link will not appear."
+#~ msgstr ""
+#~ "تېخىمۇ كۆپ ئۈستەلئۈستى باش تېمىسىغا ئېرىشىش URL. ئەگەر بوش ھەرپ تىزمىسى "
+#~ "قىلىپ تەڭشەلسە ئۇنداقتا ئۇلانما كۆرۈنمەيدۇ."
+
+#~ msgid "Clean print heads"
+#~ msgstr "بېسىش باشىنى تازىلا"
+
+#~ msgid "An error has occured during a maintenance command."
+#~ msgstr "ئاسراش بۇيرۇقى ئىجرا بولۇۋاتقاندا خاتالىق كۆرۈلدى."
+
+#~ msgid ""
+#~ "<a href=\"http://wolfram.org/writing/howto/password.html\">How to choose "
+#~ "a strong password</a>"
+#~ msgstr ""
+#~ "<a href=\"http://wolfram.org/writing/howto/password.html\">كۈچلۈك ئىمنى "
+#~ "قانداق تاللاش كېرەك</a>"
+
+#~ msgid "DSL"
+#~ msgstr "DSL"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,117 +8,21 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/iss"
-"ues\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-08-25 23:15+0300\n"
-"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
+"Last-Translator: two@envs.net <two@envs.net>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
-"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : "
+"n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Lokalize 20.12.0\n"
 "X-Project-Style: gnome\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "Системна шина"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "Повний доступ"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "Шина сеансів"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "Пристрої"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "Повний доступ до /dev"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Мережа"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "Має доступ до мережі"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Домівка"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "Лише читання"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "Файлова система"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Параметри"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "Може змінювати налаштування"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s має вказані нижче вбудовані дозволи. Це неможливо змінити. Якщо вас "
-"турбують ці дозволи, розгляньте можливість вилучення цієї програми."
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u тип файлів і посилань, які може відкривати програма"
-msgstr[1] "%u типи файлів і посилань, які може відкривати програма"
-msgstr[2] "%u типів файлів і посилань, які може відкривати програма"
-msgstr[3] "%u тип файлів і посилань, які може відкривати програма"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr ""
-"<b>%s</b> використовується для відкриття файлів і посилань таких типів."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "Використано %s місця на диску."
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -134,7 +38,6 @@ msgid "Install some…"
 msgstr "Встановіть щось…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Відкрити"
 
@@ -158,24 +61,13 @@ msgstr "Пошук"
 msgid "Receive system searches and send results."
 msgstr "Отримання сигналів системи про пошук і надсилання результатів."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Вимкнено"
 
@@ -341,80 +233,20 @@ msgstr "Очистити кеш…"
 msgid "Control various application permissions and settings"
 msgstr "Керування різними дозволами й налаштуваннями програм"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "програма;flatpak;дозвіл;налаштування;application;permission;setting;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "Виберіть зображення"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "_Скасувати"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Відкрити"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "декілька розмірів"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Без тла стільниці"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Поточне тло"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Стиль"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "Типовий"
 
@@ -438,7 +270,6 @@ msgstr "Вигляд"
 msgid "Change your background image or the UI colors"
 msgstr "Змінити зображення тла або кольори інтерфейсу користувача"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -491,9 +322,7 @@ msgstr "Апаратний режим польоту ввімкнено"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Вимкніть режим польоту, щоб увімкнути Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -501,7 +330,6 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Увімкнути або вимкнути з'єднання з пристроєм через Bluetooth"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "оприлюднення;поділитись;блютуз;obex;"
@@ -534,97 +362,35 @@ msgstr "Немає програм, які надсилають запит щод
 msgid "Protect your pictures"
 msgstr "Захистіть ваші зображення"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "camera;photos;video;webcam;lock;private;privacy;камера;фотоапарат;фото;"
 "фотографії;відео;вебкамера;блокування;конфіденційність;приватність;приватний;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr ""
-"Розмістіть ваш калібрувальний пристрій поверх квадрату й натисніть "
-"«Запустити»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Перемістіть ваш калібрувальний пристрій на відповідну позицію та натисніть "
-"«Далі»"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr ""
-"Перемістіть ваш калібрувальний пристрій на позицію поверхні та натисніть "
-"«Далі»"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Закрити кришку ноутбука"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Виникла внутрішня помилка й роботу неможливо відновити."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Не встановлено засоби для калібрування."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Профіль неможливо породити."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Відмітка білого для цілі недоступна."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Завершено!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Помилка калібрування!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Можете витягнути калібрувальний пристрій."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Не чіпайте калібрувальний пристрій поки він працює"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Калібрування екрана"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Скасувати"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -641,140 +407,6 @@ msgstr "_Відновити"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Завершити"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Екран ноутбука"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Вбудована камера"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Монітор %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Сканер %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Камера %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Принтер %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Камера %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Увімкнути керування кольорами для %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Показати профілі кольорів для %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Нескалібровано"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Типовий:"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Простір кольорів: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Тестовий профіль: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Виберіть файл профілю ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Імпортувати"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Підтримувані профілі ICC"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Усі файли"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "Екран"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Зберегти профіль"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "З_берегти"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Створити профіль кольорів для вибраного пристрою"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Інструмент міри не виявлено. Будь ласка, перевірте, чи це ввімкнено й "
-"правильно з'єднано."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Інструмент міри не підтримує профілювання принтерів."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Цей тип пристрою не підтримується. "
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -891,9 +523,9 @@ msgstr "Вимагає пристрій, на який можна записув
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Ці інструкції про використання профілів на системах <a href=\"linux\">GNU/"
 "Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows\">Microsoft "
@@ -908,8 +540,8 @@ msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr ""
-"Виявлено проблему. Профіль може не працювати правильно. <a href="
-"\"\">Показати подробиці.</a>"
+"Виявлено проблему. Профіль може не працювати правильно. <a "
+"href=\"\">Показати подробиці.</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
@@ -917,7 +549,6 @@ msgstr "_Імпортувати файл…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -928,9 +559,7 @@ msgid "Each device needs an up to date color profile to be color managed."
 msgstr ""
 "Кожен пристрій потребує оновлення профілю кольорів для керування кольорами."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Дізнатись більше"
 
@@ -1062,82 +691,6 @@ msgstr "D65 (фотографії і графіки)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Стандартний простір"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Тестовий профіль"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Автоматично"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Низька якість"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Середня якість"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Висока якість"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "Типовий RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "Типовий CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Типовий сірий"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Виробник надав фабричні калібрувальні дані"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Повноекранний зв'язок неможливий з цим профілем"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Цей профіль може бути неточним"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Колір"
@@ -1147,14 +700,9 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "Відкалібрувати кольори таких пристроїв, як екрани, камери і принтери"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr "Колір;ICC;Профіль;Калібрування;Принтер;Екран;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Інше…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1169,13 +717,8 @@ msgid "No languages found"
 msgstr "Не знайдено мов"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Більше…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Розблокуйте, щоб змінити налаштування"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1204,157 +747,6 @@ msgstr "Зменшити на годину"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Зменшити на хвилину"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "Сьогодні"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "Учора"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d година"
-msgstr[1] "%i години"
-msgstr[2] "%d годин"
-msgstr[3] "%d година"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d хвилина"
-msgstr[1] "%d хвилини"
-msgstr[2] "%d хвилин"
-msgstr[3] "%d хвилина"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d секунда"
-msgstr[1] "%d секунди"
-msgstr[2] "%d секунд"
-msgstr[3] "%d секунда"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 секунд"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Хот-спот"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-ох годинний"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "До / після полудня "
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%e %B %Y, %l:%M %p"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%e %B %Y, %R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1450,17 +842,11 @@ msgid "Requires location services enabled and internet access"
 msgstr ""
 "Вимагає увімкнених служб даних місця перебування і доступу до інтернету"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "Увімкнено"
 
@@ -1468,15 +854,43 @@ msgstr "Увімкнено"
 msgid "Time Z_one"
 msgstr "_Часовий пояс"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Розблокувати"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "_Формат часу"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Дати"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 секунд"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "_Календар"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Числа"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Змінити дату та час, і часовий пояс зокрема"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Годинник;Пояс;Місцевість;"
@@ -1522,20 +936,9 @@ msgstr "Типові програми"
 msgid "Configure Default Applications"
 msgstr "Налаштовування типових програм"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "типове;програма;бажане;носій;default;application;preferred;media;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Надсилання звітів про технічні проблеми допомагає нам покращити %s. Звіти "
-"надсилаються анонімно і не містять особистих даних. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1553,44 +956,9 @@ msgstr "Діагностика"
 msgid "Report your problems"
 msgstr "Повідомити про помилки"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostics;crash;діагностика;аварія;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Увімкнено"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Вимкнено"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "Застосувати зміни?"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "Не вдалося застосувати зміни"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "Причиною можуть бути апаратні обмеження."
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1640,31 +1008,6 @@ msgstr "Основний дисплей"
 msgid "Night Light"
 msgstr "Нічне світло"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Альбомна"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Портретна праворуч"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Портретна ліворуч"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Альбомна перевернута"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Гц"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1688,6 +1031,17 @@ msgstr "Підкоригувати для телебачення"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Масштаб"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Природне гортання"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1783,7 +1137,6 @@ msgstr "Дисплеї"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Змінити використання під'єднаних моніторів та проекторів"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1791,81 +1144,6 @@ msgid ""
 msgstr ""
 "Панель;Проектори;xrandr;Екран;Роздільність;Оновлення;Монітор;Нічне;Світло;"
 "Синій;redshift;колір;захід;світанок;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "Secure Boot є активним"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr ""
-"Secure boot запобігає завантаженню програмного забезпечення зловмисників під "
-"час запуску пристрою. Зараз цей захист увімкнено, і він працює належним "
-"чином."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "Маємо проблеми із Secure Boot"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"Secure boot запобігає завантаженню програмного забезпечення зловмисників під "
-"час запуску пристрою. Зараз цей захист увімкнено, але він не працює через "
-"некоректний ключ."
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"Проблеми із Secure boot часто можна розв'язати за допомогою параметрів "
-"мікропрограми UEFI вашого комп'ютера (BIOS). Довідкові дані щодо цього може "
-"бути надано виробником обладнання."
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr ""
-"Довідкові дані можна отримати у виробника обладнання або надавача послуг з "
-"комп'ютерної підтримки."
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "Secure Boot вимкнено"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr ""
-"Secure boot запобігає завантаженню програмного забезпечення зловмисників під "
-"час запуску пристрою. Зараз цей захист вимкнено."
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"Secure boot часто можна увімкнути за допомогою параметрів мікропрограми UEFI "
-"вашого комп'ютера (BIOS). Довідкові дані можна отримати у виробника "
-"обладнання або надавача послуг з комп'ютерної підтримки."
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1880,132 +1158,9 @@ msgstr ""
 "Докладніший його опис можна отримати від виробника обладнання або служби "
 "комп'ютерної підтримки."
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "Пройдено"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "Не пройдено"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "Пристрій є сумісним із рівнем HSI %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "Рівень безпеки 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"Цей пристрій не захищено від апаратних проблем із безпекою. Причиною можуть "
-"бути проблеми із налаштуваннями апаратної частини або мікропрограми. "
-"Рекомендуємо повідомити про цю проблему службі надання гарантійної "
-"комп'ютерної підтримки."
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "Рівень безпеки 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"Цей пристрій має мінімальний захист від апаратних проблем із безпекою. Це "
-"найнижчий рівень захисту пристрою, який усуває лише прості загрози безпеці."
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "Рівень безпеки 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"Цей пристрій має базовий захист від апаратних проблем із безпекою. Цей "
-"рівень захисту надає захист від деяких типових загроз безпеці."
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "Рівень безпеки 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"Цей пристрій має розширений захист від апаратних проблем із безпекою. Це "
-"рівень захисту пристрою, який усуває деякі додаткові загрози безпеці."
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "Рівень безпеки"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr "Для цього пристрою рівні безпеки є недоступними."
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr ""
-"Зверніться до виробника вашого обладнання за допомогою у розв'язанні проблем "
-"захисту."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr ""
-"Можливо, проблему можна розв'язати за допомогою параметрів мікропрограми "
-"UEFI або працівника служби підтримки."
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr ""
-"Можливо, проблему можна розв'язати за допомогою параметрів мікропрограми "
-"UEFI."
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr ""
-"Можливо, проблему можна розв'язати за допомогою працівника служби підтримки."
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -2019,339 +1174,9 @@ msgstr "Рівень 2"
 msgid "Level 3"
 msgstr "Рівень 3"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr ""
-"Захист від програмного забезпечення зловмисників під час запуску пристрою."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "Маємо проблеми із Secure Boot"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "Деякий захист, коли пристрій розпочав роботу."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "Secure Boot вимкнено"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "Без захисту, коли пристрій розпочав роботу."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"Цю проблему могло бути спричинено змінами у параметрах мікропрограми UEFI, "
-"налаштуваннях операційної системи або помилками у роботі програмного "
-"забезпечення у цій системі."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr ""
-"Цю проблему могло бути спричинено змінами у параметрах мікропрограми UEFI "
-"або помилками у роботі програмного забезпечення у цій системі."
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr ""
-"Цю проблему могло бути спричинено змінами у налаштуваннях операційної "
-"системи або помилками у роботі програмного забезпечення у цій системі."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "Відкритий щодо суттєвих загроз захисту."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "Обмежений захист від простих загроз."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "Захищено від поширених загроз."
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "Захищено від широкого діапазону загроз."
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "Всебічний захист"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "Немає подій"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "Захист від запису мікропрограми"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "Блокування захисту мікропрограми від запису"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "Регіон мікропрограми BIOS"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "Дескриптор мікропрограми BIOS"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "Захист DMA до завантаження"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "Перевірене завантаження Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "Захист ACM Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "Правила щодо помилок Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "Синтез Intel BootGuard"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "Увімкнено Intel CET"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "Intel CET є активним"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "Intel SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "Шифрування RAM"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "Захист IOMMU"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Блокування ядра Linux"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Перевірка ядра Linux"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux swap"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "Сон зі збереженням до RAM"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "Сон із переведенням до бездіяльності"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "Ключ платформи UEFI"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "Secure Boot UEFI"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "Налаштування платформи TPM"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "Реконструкція TPM"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Режим виробника Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "Перевизначення Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "Версія Intel Management Engine"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "Оновлення мікропрограми"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "Засвідчення мікропрограми"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "Перевірка засобу оновлення мікропрограми"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "Діагностика платформи"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "Перевірки захисту процесора"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "Захист від повернення AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "Захист від відтворення мікропрограми AMD"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "Захист від запису мікропрограми AMD"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "Синтезована платформа"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "Чинний"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "Нечинний"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "Не увімкнено"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "Заблоковано"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "Не заблоковано"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "Зашифровано"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "Не зашифровано"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "Зіпсовано"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "Не зіпсовано"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "Знайдено"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "Не знайдено"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "Є підтримка"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "Немає підтримки"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2361,7 +1186,6 @@ msgstr "Безпека пристрою"
 msgid "Host firmware security status"
 msgstr "Стан захисту мікропрограми основної системи"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2369,49 +1193,6 @@ msgid ""
 msgstr ""
 "екран;блокування;діагностика;крах;особисте;нещодавнє;тимчасове;tmp;індекс;"
 "назва;мережа;засвідчення;конфіденційність;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Невідома"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64-бітова"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32-бітова"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Невідомо"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "Недоступний"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Логотип системи"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2505,11 +1286,6 @@ msgstr "Про систему"
 msgid "View information about your system"
 msgstr "Переглянути інформацію про вашу систему"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2590,6 +1366,12 @@ msgstr "Пускач"
 msgid "Launch help browser"
 msgstr "Запустити переглядача довідки"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Параметри"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Запустити калькулятор"
@@ -2611,7 +1393,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Пошук"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Система"
 
@@ -2660,15 +1442,6 @@ msgstr "Зменшити розмір тексту"
 msgid "High contrast on or off"
 msgstr "Увімкнути або вимкнути високий контраст"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Не знайдено жодного джерела введення"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Інше"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Додати джерело введення"
@@ -2701,108 +1474,9 @@ msgstr "Параметри"
 msgid "View Keyboard Layout"
 msgstr "Переглянути розкладку клавіатури"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Вилучити"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Власне скорочення"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "Клавіша альтернативних символів"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Клавіша альтернативних символів може використовуватися для уведення "
-"додаткових символів. Вони інколи зображені на кнопках клавіатури як третій "
-"варіант."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Ліва Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Права Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Ліва Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Права Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Клавіша меню"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Права Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Скомпонувати клавіші"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Клавіша компонування дозволяє вводити велику кількість символів Щоб "
-"скористатися нею, натисніть клавішу складання, а потім послідовність "
-"символів. Наприклад, якщо за клавішею складання йтиме <b>C</b> і <b>o</b> "
-"буде виведено <b>©</b>, натиснувши <b>a</b>, за яким слідує <b>'</b>, "
-"отримаємо <b>á</b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Джерела введення можна перемикати за допомогою клавіатурного скорочення %s.\n"
-"Змінити скорочення можна у параметрах клавіатурних скорочень."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2832,47 +1506,21 @@ msgstr "Введення спеціальних символів"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "Способи введення символів та варіантів літер за допомогою клавіатури."
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Клавіша альтернативних символів"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Скомпонувати клавіші"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Клавіатурні скорочення"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Перегляд і налаштовування скорочень"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d змінене"
-msgstr[1] "%d змінених"
-msgstr[2] "%d змінених"
-msgstr[3] "%d змінене"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "Скинути всі скорочення?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Скидання скорочень може вплинути і на ваші власні скорочення. Це неможливо "
-"вернути."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Скасувати"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "Скинути все"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2912,36 +1560,6 @@ msgstr "Додати скорочення"
 msgid "No keyboard shortcut found"
 msgstr "Не знайдено клавіатурного скорочення"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid ""
-"%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr ""
-"%s вже використовується для %s. Якщо застосувати, сполучення для %s буде "
-"вимкнено"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Уведіть нове скорочення"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Встановити своє скорочення"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Встановити скорочення"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Уведіть нове сполучення для зміни %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "Додати своє скорочення"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "Ви_лучити"
@@ -2953,7 +1571,6 @@ msgstr "За_мінити"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "_Встановити"
 
@@ -2990,6 +1607,11 @@ msgstr "Немає"
 msgid "Reset the shortcut to its default value"
 msgstr "Повернути скороченню типове значення"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Використовувати як типовий принтер"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "Клавіатура"
@@ -3002,7 +1624,6 @@ msgstr ""
 "Змінити клавіатурні скорочення і вказати параметри введення, розкладки "
 "клавіатури та джерела введення даних"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -3047,7 +1668,6 @@ msgstr ""
 msgid "Protect your location information"
 msgstr "Захистіть ваші дані щодо місця перебування"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr ""
@@ -3084,7 +1704,6 @@ msgstr "Немає програм, які б надсилали запит що�
 msgid "Protect your conversations"
 msgstr "Захистіть ваш обмін повідомленнями"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
@@ -3116,81 +1735,139 @@ msgstr "Ліва"
 msgid "Right"
 msgstr "Права"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Місця пошуку"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Миша"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Швидкість миші"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "Природне гортання"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Без захисту"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Гортання переміщує вміст, а не перегляд."
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Гортання переміщує вміст, а не перегляд."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Активний"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Сенсорний пристрій"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Швидкість сенсору"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Натиск для клацання"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "Натиск для клацання"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "Гортання двома пальцями"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Сенсорна панель (відносно)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Гортання на краях"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Scroll Lock"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Двобічний"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Випробувати клацання, подвійне клацання, гортання"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "П'ять клацань, час для GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Подвійний клац, основна кнопка"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Одинарний клац, основна кнопка"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Подвійний клац, середня кнопка"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Одинарний клац, середня кнопка"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Подвійний клац, вторинна кнопка"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Одинарний клац, вторинна кнопка"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3201,7 +1878,6 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "Змінити чутливість вашої миші та сенсорного пристрою і вибрати руку"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr "Сенсор;Вказівник;Клік;Стукіт;Подвійний;Кнопка;Кулька;Прокрутити;"
@@ -3281,7 +1957,6 @@ msgstr "Багатозадачність"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Керування параметрами продуктивності та багатозадачності"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3290,21 +1965,11 @@ msgstr ""
 "багатозадачність;задача;завдання;продуктивність;налаштовування;налаштування;"
 "стільниця;активний кут;робочі простори;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Отакої, щось не так. Зв'яжіться з вашим постачальником програмних засобів."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Потрібно запустити NetworkManager."
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Інші пристрої"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3316,59 +1981,16 @@ msgstr "Додати з'єднання"
 msgid "Not set up"
 msgstr "Не налаштовано"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "Незахищена мережа (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "Захищена мережа (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "Захищена мережа (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "Захищена мережа (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "Захищена мережа"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "З'єднано"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Параметри…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Увімкнення хот-споту, призведе до від'єднання від %s і неможливості доступу "
-"до інтернету за допомогою Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Має містити не менше 8 символів"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3421,20 +2043,6 @@ msgstr "Автоматично створити пароль"
 msgid "_Turn On"
 msgstr "_Увімкнути"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "Зупинити гарячу точку й від'єднати користувачів?"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "_Зупинити гарячу точку"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Режим польоту"
@@ -3480,89 +2088,14 @@ msgstr "Видимі мережі"
 msgid "NetworkManager needs to be running"
 msgstr "Має бути запущено NetworkManager"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Отакої, щось не так. Зв'яжіться з вашим постачальником програмних засобів."
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_Безпека 802.1x"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "Безпека"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Зберегти"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Постійна"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Випадкова"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Стабільна"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Введена тут МАС-адреса буде використовуватися як апаратна адреса для "
-"пристрою мережі, на якому активовано це з'єднання. Ця функція відома як "
-"клонування або підробка MAC-адреси. Приклад: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Профіль %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "Enterprise"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Немає"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "Ніколи"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3574,183 +2107,6 @@ msgstr[1] "%i дні тому"
 msgstr[2] "%i днів тому"
 msgstr[3] "%i день тому"
 
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Мб/с (%1.1f ГГц)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Мб/с"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 ГГц / 5 ГГц"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 ГГц"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 ГГц"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Немає"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Слабке"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Добре"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Непогане"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Відмінне"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Адреса IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "Адреса IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Адреса IP"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "Забути з'єднання"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "Вилучити профіль з'єднання"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "Вилучити VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "Подробиці"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "автоматично"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Засвідчення"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "Вилучити адресу"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "Вилучити маршрут"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Немає"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "40/128 бітний ключ WEP (шістнадцяткова або ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "128-ох бітний пароль для WEP"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "Динамічний WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "Особистий WPA і WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "Комерційний WPA & WPA2"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "Особистий WPA3"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
@@ -3760,8 +2116,20 @@ msgstr "Потужність сигналу"
 msgid "Link speed"
 msgstr "Швидкість сполучення"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Безпека"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Адреса IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Адреса IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Апаратна адреса"
 
@@ -3770,12 +2138,17 @@ msgid "Supported Frequencies"
 msgstr "Підтримувані частоти"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Типовий маршрут"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3840,7 +2213,7 @@ msgstr "Лише місцевий"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Вручну"
 
@@ -3884,9 +2257,8 @@ msgstr "Шлюз"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Автоматично"
 
@@ -3939,89 +2311,9 @@ msgstr "Автоматично, лише DHCP"
 msgid "Prefix"
 msgstr "Префікс"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Не вдалося відкрити редактор з'єднань"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Створити профіль"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "Некоректний параметр %s: %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "Некоректний параметр %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "Імпортувати з файла…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "Додати VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_Захист"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Не вдалось імпортувати з'єднання з VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Файл «%s» неможливо прочитати або він містить невідому інформацію про "
-"з'єднання з VPN\n"
-"\n"
-"Помилка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Виберіть файл для імпортування"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Файл з назвою «%s» уже існує."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Замінити"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Бажаєте замінити %s на з'єднання з VPN, яке ви зберігаєте?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Неможливо експортувати з'єднання з VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"З'єднання з VPN «%s» неможливо експортувати в %s.\n"
-"\n"
-"Помилка: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Експортувати з'єднання з VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -4035,99 +2327,36 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Мережа"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Вказати яким способом з'єднуватись з інтернетом"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr "Мережа;IP;LAN;Проксі;WAN;Broadband;Модем;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Керування способами з'єднання із мережами Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr "Мережа;Бездротова;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "ніколи"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "сьогодні"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "вчора"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Востаннє використано"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Дротовий"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Додати нове з'єднання"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Подробиці мережі для вибраної мережі, зокрема паролі та інші параметри буде "
-"втрачено."
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "_Забути"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "Відомі мережі Wi-Fi"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Забути"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "Системна політика забороняє використовувати комп'ютер як гарячу точку"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Бездротовий пристрій не підтримує режиму гарячої точки"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr ""
-"Коли URL налаштувань не надається, використовується автоматичне виявлення "
-"проксі. "
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Це не рекомендовано для ненадійних прилюдних мереж."
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4146,6 +2375,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "Провайдер"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Адреса IP"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4230,289 +2463,6 @@ msgstr "_Увімкнути точку доступу Wi-Fi…"
 msgid "_Known Wi-Fi Networks"
 msgstr "_Відомі мережі Wi-Fi"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Стан невідомий"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Некерований"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Недоступний"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "З'єднання"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Слід пройти розпізнавання"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Від'єднання"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Не вдалось з'єднатись"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Стан невідомий (немає)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Не вдалося налаштувати"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Не вдалося налаштувати IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Налаштування IP застаріли"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Таємниці є обов'язковими, проте їх не надано"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "Шукача 802.1x від'єднано"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Не вдалося налаштувати шукач 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Помилка шукача 802.1x"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "Шукач 802.1x забрав надто багато часу для автентифікації "
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Не вдалося запустити службу PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Службу PPP від'єднано"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "Помилка PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Не вдалося запустити клієнт DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Помилка клієнта DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Помилка роботи клієнта DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Не вдалося запустити службу спільного з'єднання"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Помилка роботи служби спільного з'єднання"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Не вдалося запустити службу AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Помилка служби AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Помилка роботи служби AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Лінію зайнято"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Немає гудка"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Неможливо встановити жодного носія"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Час очікування набирання збіг"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Не вдала спроба набирання номеру"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Не вдалося запустити модем"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Не вдалось вибрати вказаний APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Немає пошуку мереж"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Реєстрацію мережі заборонено"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Час реєстрації мережі вичерпано "
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Не вдалось зареєструватись з мережею"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Не вдалось перевірити PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Може бракувати мікропрограми для пристрою"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "З'єднання зникло"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Наявне з'єднання вигадано"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Не знайдено модему"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Не вдалось з'єднатись з Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Не вставлено картки SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Потрібно SIM Pin"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Потрібно SIM Puk"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "Неправильний SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Помилка роботи залежності з'єднання"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Бракує мікропрограми"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Кабель від'єднано"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "невідома помилка у захисті 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "не вибрано жодного файла"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "Невизначена помилка завірення файла з методом eap"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "Закриті ключі DER, PEM, PKCS#12 або PGP"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "Сертифікати DER або PEM"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "Бракує файла EAP-FAST PAC"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Файли PAC (*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4561,14 +2511,6 @@ msgstr "Вн_утрішнє засвідчення"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Дозволити автоматичне за_готовлення PAC"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "бракує користувача EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "бракує паролю EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4594,15 +2536,6 @@ msgstr "_Пароль"
 msgid "Sho_w password"
 msgstr "П_оказати пароль"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "неправильний сертифікат ЦС EAP-PEAP: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "Неправильний сертифікат ЦС EAP-PEAP: не вказано сертифікату"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4624,7 +2557,6 @@ msgid "C_A certificate"
 msgstr "Сертифікат _ЦС"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4639,63 +2571,6 @@ msgstr "Не _вимагається сертифікату ЦС"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "Ве_рсія PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "бракує користувача EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "бракує паролю EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "бракує ототожнення EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "неправильний сертифікат ЦС EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "Неправильний сертифікат ЦА EAP-TLS: не вказано сертифікату"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "неправильний закритий ключ EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "неправильний сертифікат користувача EAP-TLS: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Небезпечно використовувати секретні ключі без шифрування"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Схоже, що обраний закритий ключ не захищено паролем. Це може призвести до "
-"компрометації ваших облікових даних. Будь ласка, виберіть закритий ключ, "
-"захищений паролем.\n"
-"\n"
-"(Ви можете захистити закритий ключ за допомогою openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Виберіть ваш особистий сертифікат"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Виберіть ваш особистий ключ"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4712,15 +2587,6 @@ msgstr "Закритий _ключ"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Пароль _закритого ключа"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "неправильний сертифікат ЦС EAP-TTLS: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "неправильний сертифікат ЦА EAP-TTLS: не вказано сертифікату"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4743,14 +2609,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Домен"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Невідома помилка перевірки безпеки 802.1x"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4778,62 +2645,10 @@ msgstr "Захищений EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "За_свідчення"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Виберіть файл"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "бракує користувача LEAP"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "бракує паролю LEAP"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Бракує пароля Wi-Fi."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Тип"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "бракує ключа WEP"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"неправильний ключ WEP: ключ з довжиною %zu мусить містити тільки "
-"шістнадцяткові значення"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"неправильний ключ WEP: ключ з довжиною %zu мусить містити тільки символи "
-"ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"неправильний ключ WEP: хибний довжина ключа %zu. Ключ має бути: або довжина "
-"5/13 (ascii), або 10/26 (шістнадцятковий)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "неправильний ключ WEP: пароль не може бути порожній"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "неправильний ключ WEP: пароль не може перевищувати 64 символи"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4858,20 +2673,6 @@ msgstr "П_оказати ключ"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "_Індекс WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"неправильний ключ PSK: неправильна довжина ключа %zu. Має бути [8,63] біти "
-"або 64 шістнадцяткових значення"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"неправильний WPA-PSK: неможливо означити ключ з 64 шістнадцятковими бітами"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4925,27 +2726,9 @@ msgstr "Сповіщення на за_блокованому екрані"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Вказує які сповіщення показуються і що вони показують"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Сповіщення;Шапка;Повідомлення;Лоток;Контекстний;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Інше"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s вилучений"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "Помилка вилучення облікового запису"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4970,17 +2753,6 @@ msgstr ""
 msgid "Add an account"
 msgstr "Додати обліковий запис"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Обліковий запис %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Вилучити обліковий запис"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "Облікові записи в інтернеті"
@@ -4991,10 +2763,6 @@ msgstr ""
 "З'єднатись з вашим мережевими обліковими записами і вирішити, що з ними "
 "робити "
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -5002,10 +2770,6 @@ msgid ""
 msgstr ""
 "Google;Facebook;Twitter;Yahoo;Інтернет;Мережа;Балачка;Календар;Пошта;Контакт;"
 "ownCloud;IMAP;SMTP;Pocket;ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Час невідомий"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -5025,13 +2789,6 @@ msgstr[1] "%i години"
 msgstr[2] "%i годин"
 msgstr[3] "%i година"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -5047,191 +2804,6 @@ msgstr[0] "хвилина"
 msgstr[1] "хвилини"
 msgstr[2] "хвилин"
 msgstr[3] "хвилина"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s до повного зарядження"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Обережно: залишилось %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "Залишилось %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Повністю заряджено"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Не заряджається"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Вичерпано"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Заряджання"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Розряджається"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Бездротова миша"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Бездротова клавіатура"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Постачання безперебійного живлення"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Особистий цифровий помічник"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Мобільний телефон"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Програвач"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Планшет"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Комп'ютер"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Ігровий пристрій введення"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Батарея"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Основна"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Додаткова"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Батареї"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "Коли _бездіяльний"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "Призупинити"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "Вимкнути"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "Приспати"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "Нічого"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "Коли живлення від батареї"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "Коли під'єднано"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Ніколи"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "Автоматично призупиняти роботу"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr ""
-"Режим підвищеної швидкодії тимчасово вимкнено через високу операційну "
-"температуру."
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Виявлено розташування на нетривкій поверхні: режим високої швидкодії "
-"тимчасово недоступний. Перенесіть пристрій на стабільну поверхню, щоб "
-"відновити доступ."
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "Режим підвищеної швидкодії тимчасово вимкнено."
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Низький рівень заряду акумулятора: увімкнено заощадження енергії. Попередній "
-"режим буде відновлено за достатнього рівня заряду акумулятора."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Режим заощадження енергії активовано «%s»."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Режим високої швидкодії активовано «%s»."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5292,6 +2864,15 @@ msgstr "100 хвилин"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 години"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батарея"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Пристрої"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5374,43 +2955,14 @@ msgstr "Живлення від _батареї"
 msgid "Delay"
 msgstr "Затримка"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Швидкодія"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Висока швидкодія та споживання енергії."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Баланс"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Стандартна швидкодія та споживання енергії."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Заощадження"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Знижена швидкодія та споживання енергії."
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "Живлення"
 
 #: panels/power/gnome-power-panel.desktop.in.in:4
 msgid "View your battery status and change power saving settings"
-msgstr ""
-"Переглянути стан вашої батареї і змінити параметри заощадження енергії"
+msgstr "Переглянути стан вашої батареї і змінити параметри заощадження енергії"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5418,27 +2970,6 @@ msgid ""
 msgstr ""
 "Живлення;Сон;Призупинити;Приспати;Батарея;Яскравість;Затемнення;Порожній;"
 "DPMS;Бездіяльність;живлення;енергія;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Принтер «%s» було успішно вилучено"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "Не вдалось додати принтер."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Не вдалось завантажити інтерфейс: %s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Розблокуйте, щоб додати принтери і змінити налаштування"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -5449,7 +2980,6 @@ msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Додати принтер, переглянути завдання і визначити, яким способом друкувати"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Принтер;Черга;Друк;Папір;Чорнило;Тонер;"
@@ -5457,8 +2987,6 @@ msgstr "Принтер;Черга;Друк;Папір;Чорнило;Тонер;
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Додати принтер"
 
@@ -5498,28 +3026,6 @@ msgstr ""
 msgid "Username"
 msgstr "Користувач"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "Подробиці про %s "
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "Не знайдено придатного драйвера"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "Виберіть файл PPD"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr ""
-"Файли опису принтера PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "Назви принтерів не можуть містити пробілів, табуляцій, # або /"
@@ -5528,9 +3034,7 @@ msgstr "Назви принтерів не можуть містити проб�
 msgid "Location"
 msgstr "Адреса"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "Драйвер"
 
@@ -5558,121 +3062,14 @@ msgstr "Вибрати драйвер принтера"
 msgid "Loading drivers database…"
 msgstr "Завантаження бази даних драйверів…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Скасувати"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Вибрати"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Принтер JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Принтер LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Односторонній"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Впродовж довгої сторони (типово)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Впродовж короткої сторони"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Книжкова"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Альбомна"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Зворотна альбомна"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Зворотна книжкова"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "Відновити"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "Призупинити"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "Очікування"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "Призупинено"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Слід пройти розпізнавання"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "Оброблення"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Зупинено"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Скасовано"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Припинено"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "Завершено"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "Пересунути це завдання на вершину черги"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
@@ -5681,19 +3078,6 @@ msgstr[0] "Для %u завдання слід пройти розпізнава
 msgstr[1] "Для %u завдань слід пройти розпізнавання"
 msgstr[2] "Для %u завдань слід пройти розпізнавання"
 msgstr[3] "Для %u завдання слід пройти розпізнавання"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — запущені завдання"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Для друку з %s введіть реєстраційні дані."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5721,207 +3105,11 @@ msgstr "_Автентифікація"
 msgid "No Active Printer Jobs"
 msgstr "Немає робочих завдань для принтерів"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Розблокувати сервер друкування"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Розблокувати %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr ""
-"Введіть користувача та пароль, щоб переглянути доступні принтери на %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Шукати принтери"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Послідовний порт"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Паралельний порт"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Розміщення: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Адреса: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Сервер потребує засвідчення"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Двосторонній"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Тип паперу"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Джерело паперу"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Лоток виводу"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Роздільна здатність"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Попередня відсіювання GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Сторінок на сторону"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Двобічний"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Орієнтація"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Загальне"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Параметри сторінки"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Змінні параметри"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Завдання"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Якість зображення"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Колір"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Завершення"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Додатково"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Тестова сторінка"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Тестова сторінка"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Автоматичне вибрати"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Типове для принтера"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Вбудовувати лише шрифти GhostScript"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Перетворити у PS 1-го рівня"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Перетворити у PS 2-го рівня"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Без попереднього відсіювання"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Виробник"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Немає запущених завдань"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
@@ -5930,115 +3118,6 @@ msgstr[0] "%u завдання"
 msgstr[1] "%u завдання"
 msgstr[2] "%u завдань"
 msgstr[3] "%u завдання"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Очищення головок принтера"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Закінчується тонер"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Вичерпався тонер"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Закінчується проявник"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Вичерпався проявник"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Закінчується фарба"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Вичерпано фарбу"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Відкрита кришка"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Відкриті двері"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Закінчується папір"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Вичерпано папір"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Вимкнено"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Зупинено"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Майже повністю витрачено запас"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Повністю витрачено запас"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Оптичний фотопровідник близький до виходу з ладу"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Оптичний фотопровідник вийшов з ладу"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Готовий"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Завдання не прийнято"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Оброблення"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -6062,6 +3141,10 @@ msgstr "Очистити друкарські голівки"
 msgid "Remove Printer"
 msgstr "Вилучити принтер"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Немає запущених завдань"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -6082,16 +3165,21 @@ msgid "Restart"
 msgstr "Перезапустити"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Додати принтер…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Додати принтер…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Немає принтерів"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -6099,7 +3187,6 @@ msgstr ""
 "Вибачте! Загальносистемна служба друкування,\n"
 "     здається, недоступна."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Формати"
@@ -6127,16 +3214,6 @@ msgstr "Пошук може бути виконано за країнами аб
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Перегляд"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Імперська"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Метрична"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6174,20 +3251,24 @@ msgstr ""
 "Параметр мови використовується для тексту інтерфейсу та сторінок інтернету. "
 "Формати буде використано для чисел, дат і валют."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Ваш обліковий запис"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Мова"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "_Формати"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Вікно входу"
 
@@ -6199,99 +3280,9 @@ msgstr "Регіон та мова"
 msgid "Select your display language and formats"
 msgstr "Вибрати мову і формати показу даних"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Мова;Розкладка;Клавіатура;Введення;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Питати, що робити"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Нічого не робити"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Відкрити теку"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Інший носій"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Вибрати програму для звукових CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Вибрати програму для відео DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Вибрати програму для запуску, коли музичний програвач під'єднано"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Вибрати програму для запуску, коли камеру під'єднано"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Вибрати програму для програмного CD"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "audio DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "blank Blu-ray disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "blank CD disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "blank DVD disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "blank HD DVD disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray video disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "e-book reader"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD video disc"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "Picture CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "Super Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "Video CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Програми Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6341,7 +3332,6 @@ msgstr "Змінний носій"
 msgid "Configure Removable Media settings"
 msgstr "Налаштування параметрів портативних носіїв даних"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6349,114 +3339,6 @@ msgid ""
 msgstr ""
 "пристрій;система;типове;програма;бажане;cd;dvd;usb;аудіо;відео;диск;знімний;"
 "носій;автозапуск;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Екран вимикається"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 секунд"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 хвилина"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 хвилини"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 хвилини"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 хвилин"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 хвилин"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 година"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 хвилина"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 хвилини"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 хвилини"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 хвилини"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 хвилин"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 хвилин"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 хвилин"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 хвилин"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 хвилин"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Ніколи"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6487,19 +3369,23 @@ msgid "Automatic _Screen Lock Delay"
 msgstr "Затримка _автоматичного блокування екрана"
 
 #: panels/screen/cc-screen-panel.ui:51
-msgid ""
-"Period after the screen blanks when the screen is automatically locked."
+msgid "Period after the screen blanks when the screen is automatically locked."
 msgstr "Затримка автоматичного блокування після вимикання екрана."
 
 #: panels/screen/cc-screen-panel.ui:69
 msgid "Show _Notifications on Lock Screen"
 msgstr "Показувати с_повіщення на екрані блокування"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Сповіщення на за_блокованому екрані"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "Заборонити _нові пристрої USB"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
@@ -6507,32 +3393,27 @@ msgstr ""
 "Заборонити новим пристроям USB взаємодіяти із системою, коли екран "
 "заблоковано."
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "Конфіденційність екрана"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "Обмеження кута видимості"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Екран"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "Параметри екрана"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr ""
 "screen;lock;private;privacy;екран;блокування;конфіденційність;приватність;"
 "приватний;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "Вибрати регіон"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "_Гаразд"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6563,10 +3444,6 @@ msgstr "Інші"
 msgid "Add Location"
 msgstr "Додати місце"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Не знайдено жодної програми"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "Пошук за допомогою програм"
@@ -6593,93 +3470,13 @@ msgid ""
 msgstr ""
 "Вказує, які програми показувати у результатах пошуку в огляді діяльності"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Пошук;Знайти;Індекс;Сховати;Конфіденційність;Результати;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "Немає жодної вибраної мережі для оприлюднення"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Мережі"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Увімкнено"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Вимкнено"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Увімкнено"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "Активний"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "Вибрати теку"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Додати"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "Увімкнути оприлюднення матеріалів"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Спільний доступ до файлів надає вам змогу спільного використовувати вашу "
-"теку із іншими користувачами вашої поточної мережі за допомогою: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Якщо дистанційний доступ увімкнено, віддалені користувачі можуть "
-"під'єднуватися за допомогою команди SSH:\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "Увімкнути оприлюднення особистих матеріалів"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "Скопійовано назву пристрою"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "Скопійовано адресу пристрою"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "Ім'я користувача скопійовано"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "Пароль скопійовано"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6813,7 +3610,6 @@ msgstr "Теки"
 msgid "Control what you want to share with others"
 msgstr "Вказує, чим ви бажаєте поділитись з іншими"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6829,10 +3625,6 @@ msgstr "Увімкнути або вимкнути віддалений вхід
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Потрібно засвідчення, щоб увімкнути або вимкнути віддалений вхід"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "Свій"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6865,11 +3657,6 @@ msgstr "Задній"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Передній"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Тестування %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6923,11 +3710,6 @@ msgstr "Гучність"
 msgid "Alert Sound"
 msgstr "Звук попередження"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "Вимкнути звук"
@@ -6940,83 +3722,12 @@ msgstr "Звук"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Змінити рівень звуку"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Карта;Мікрофон;Гучність;Згасання;Баланс;Bluetooth;Гарнітура;Аудіо;Вивід;Ввід;"
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Від'єднано"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "З'єднання"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "З'єднано"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Помилка авторизації"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Авторизація"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Обмежена функціональність"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "З'єднано та авторизовано"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Невідомо"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Авторизовано як:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "З'єднано на:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Зареєстровано на:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Не вдалося авторизувати пристрій: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Не вдалося забути пристрій: "
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -7052,57 +3763,6 @@ msgstr "Авторизація та з'єднання"
 msgid "Forget Device"
 msgstr "Забути про пристрій"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Помилка"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Авторизовано"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Підсистема Thunderbolt (boltd) не встановлена і не налаштована належним "
-"чином."
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr ""
-"Дозволити безпосередній доступ до таких пристроїв, як зарядні станції та "
-"зовнішні графічні процесори."
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Можна приєднати лише пристрої USB та Display Port."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Не вдалося виявити Thunderbolt. \n"
-"Або у системі немає підтримки Thunderbolt, або вона була вимкнена в BIOS чи "
-"заданий непідтримуваний рівень захисту в BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Підтримку Thunderbolt було вимкнено у BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Не вдається визначити рівень безпеки Thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Помилка перемикання безпосереднього режиму: %s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "Немає підтримки Thunderbolt"
@@ -7114,6 +3774,12 @@ msgstr "Не вдалося встановити з'єднання із підс
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "Безпосередній доступ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Дозволити безпосередній доступ до таких пристроїв, як зарядні станції та "
+"зовнішні графічні процесори."
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -7131,7 +3797,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Керування пристроями Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;тандерболт;конфіденційність;"
@@ -7332,42 +3997,6 @@ msgstr "_Увімкнути клавіатурою"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Вмикати і вимикати можливості доступності через клавіатуру"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Типовий"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Середній"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Великий"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Більший"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Найбільший"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d піксель"
-msgstr[1] "%d пікселі"
-msgstr[2] "%d пікселів"
-msgstr[3] "%d піксель"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "_Завжди показувати меню доступності"
@@ -7448,7 +4077,7 @@ msgstr "Кнопки ми_ші"
 
 #: panels/universal-access/cc-ua-panel.ui:255
 msgid "_Locate Pointer"
-msgstr "Ви_явити принтер"
+msgstr "_Знаходити вказівник миші"
 
 #: panels/universal-access/cc-ua-panel.ui:267
 msgid "_Click Assist"
@@ -7481,31 +4110,6 @@ msgstr "Блимання всього _екрана"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Блимати усім _вікном"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Короткий"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ екрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ екрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ екрана"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Довгий"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7662,7 +4266,6 @@ msgstr "Ефекти кольорів"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Полегшує читання, слухання, набирання, наведення і натискання"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7677,114 +4280,6 @@ msgstr ""
 "Universal Access;Contrast;Cursor;Sound;Zoom;Screen;Reader;big;high;large;"
 "text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;"
 "Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;animations;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 година"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 день"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 дні"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 дні"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 дні"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 днів"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 днів"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 днів"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 днів"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 днів"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Очистити всі елементи зі смітника?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Якщо вилучити елементи в смітнику, їх буде вилучено безповоротно."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "С_порожнити смітник"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Вилучити усі тимчасові файли?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Усі тимчасові файли буде безповоротно вилучено."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "П_очистити тимчасові файли"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 день"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 днів"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 днів"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Завжди"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7853,7 +4348,6 @@ msgstr "Журнал файлів та смітник"
 msgid "Don't leave traces"
 msgstr "Не залишати слідів"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
@@ -7861,57 +4355,6 @@ msgstr ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 "користування;нещодавні;недавні;журнал;файли;тимчасовий;приватний;"
 "конфіденційність;приватність;смітник;кошик;витерти;витирання;збереження;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Мусить збігатись з адресою вашого постачальника."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Не вдалось додати обліковий запис"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "Паролі не збігаються."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Не вдалося зареєструвати обліковий запис"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Непідтримуваний спосіб автентифікації з цим доменом"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Не вдалось долучитись до домену"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"Цей користувач не спрацював.\n"
-"Спробуйте ще."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Цей пароль не спрацював.\n"
-"Спробуйте ще."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Не вдалось увійти до домену"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Не вдалося знайти домен. Можливо, ви неправильно це написали?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7965,10 +4408,6 @@ msgstr ""
 "Комерційний вхід дозволяє наявним обліковим записам централізовано "
 "використовуватись на цьому пристрою. Можете також використовувати цей "
 "обліковий запис для доступу ресурсів компанії через інтернет."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Огляд інших зображень"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -8038,222 +4477,6 @@ msgstr "В_илучити відбитки"
 msgid "Fingerprint Enroll"
 msgstr "Реєстрація відбитка"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "для виконання цієї дії пристрій має бути зарезервовано"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "пристрій вже зарезервовано іншим процесом"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "у вас немає прав доступу для виконання цієї дії"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "ролі не було надано жодному відбитку"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Не вдалося виконати обмін даними з пристроєм під час надання ролей"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Не вдалося виконати обмін даних із засобом читання відбитків"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Не вдалося виконати обмін даних із фоновою службою відбитків"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Не вдалося побудувати список відбитків: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Не вдалося вилучити збережені відбитки пальців: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Великий палець лівої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Середній палець лівої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Вказівний палець _лівої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Безіменний палець лівої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Мізинець лівої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Великий палець правої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Середній палець правої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Вказівний палець _правої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Безіменний палець правої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Мізинець палець правої руки"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Невідомий палець"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Завершено"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Пристрій для зчитування відбитків від'єднано"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Сховище даних пристрою зчитування відбитків переповнено"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Не вдалося зареєструвати новий відбиток"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Не вдалося розпочати реєстрацію: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Не вдалося зареєструвати новий відбиток"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Не вдалося зупинити реєстрацію: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Знімайте і притискайте ваш палець до пристрою зчитування, щоб зареєструвати "
-"відбиток пальця"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "П_еревизначити цей палець…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Сканувати новий відбиток"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Не вдалося звільнити пристрій зчитування відбитків %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Проблема з читанням з пристрою"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Не вдалося зайняти пристрій зчитування відбитків %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Не вдалося отримати список пристроїв для зчитування відбитків: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Цього тижня"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Минулого тижня"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Сеанс завершено"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Сеанс розпочато"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — Діяльність облікового запису"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "Назад"
@@ -8261,18 +4484,6 @@ msgstr "Назад"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "Далі"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "Будь ласка, виберіть інший пароль."
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "Будь ласка, введіть поточний пароль ще раз."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "Пароль неможливо змінити"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8294,6 +4505,10 @@ msgstr "Новий пароль"
 msgid "Confirm Password"
 msgstr "Підтвердити пароль"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Паролі не збігаються."
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Дозволяє користувачу змінювати пароль під час наступного входу"
@@ -8301,135 +4516,6 @@ msgstr "Дозволяє користувачу змінювати пароль 
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Вкажіть пароль зараз"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Неможливо автоматично долучити цей тип домену"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Нема такого домену чи області"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Неможливо ввійти як %s на домен %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Неправильний пароль, спробуйте ще раз"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Неможливо з'єднатися із доменом %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "Помилка при вилученні користувача"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "Не вдалось відкликати віддаленого користувача"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "Неможливо вилучити власний обліковий запис."
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s досі у системі"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr ""
-"Вилучивши користувача, коли він у системі, змусить його покинути систему в "
-"нестійкому стані."
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Зберегти файли користувача %s?"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Можна утримати домашній каталог, поштову скриньку та тимчасові файли, коли "
-"обліковий запис користувача буде вилучатись."
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "В_илучити файли"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "З_берегти файли"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Відкликати віддалено запущеного користувача на обліковому записі %s?"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "В_илучити"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Обліковий запис вимкнено"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Буде встановлено при наступному вході"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "Немає"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "Увійшов"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "Не вдалось зв'язатись зі службою облікових записів"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
-"Будь ласка, переконайтесь, що AccountService встановлено та ввімкнено."
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "Цю панель має бути розблоковано для зміни цього параметра"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "Вилучити вибраний обліковий запис користувача"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Щоб вилучити вибраний обліковий запис користувача,\n"
-"натисніть спочатку на піктограму *"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Розблокуйте, щоб додати користувачів і змінити налаштування"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8457,7 +4543,6 @@ msgid "Full name"
 msgstr "Повне ім'я"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "Редагувати"
 
@@ -8519,7 +4604,6 @@ msgstr "Розблокуйте, щоб додати обліковий запи�
 msgid "Add or remove users and change your password"
 msgstr "Додати або вилучити користувачів і змінити свій пароль"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8566,177 +4650,6 @@ msgstr "Організувати обліковий запис"
 msgid "Authentication is required to change user data"
 msgstr "Потрібна автентифікація, щоб змінити дані про користувача"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Новий пароль повинен бути відмінним від попереднього."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Спробуйте змінити якісь цифри або букви."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Спробуйте трохи переінакшити пароль."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Пароль без згадування користувача буде надійніший."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Намагайтесь уникати згадування користувача в паролі."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Намагайтесь уникати деяких слів, вказаних у паролі."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Намагайтесь уникати звичайних слів."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Намагайтесь уникати переставлення наявних слів."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Намагайтесь використовувати більше чисел."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Намагайтесь використовувати великі букви."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Намагайтесь використовувати малі букви."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr ""
-"Намагайтесь використовувати спеціальні символи, наприклад, розділові знаки."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Намагайтесь використовувати суміш букв, чисел і розділових знаків."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Намагайтесь уникати повторення однакових символів."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Намагайтесь уникати повторення однакового типу символів: варто змішувати "
-"букви з числами і розділові знаки."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Намагайтесь уникати послідовностей, наприклад, 1234 або абвг."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr ""
-"Пароль має бути довшим. Спробуйте додати більше літер, цифр та символів "
-"пунктуації."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Змішуйте великі букви з малими і намагайтесь використовувати числа."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Додавання літер, цифр і розділових знаків зробить пароль надійнішим!"
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "Помилка при автентифікації"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "Новий пароль надто короткий"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "Новий пароль надто простий"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Старий і новий пароль надто подібні"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Новий пароль уже використовувався."
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Новий пароль містить цифри або спеціальні символи"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Старий і новий пароль — однакові."
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Ваш пароль змінився з моменту початкової аутентифікації!"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Новий пароль не містити достатньо різноманітних символів"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Невідома помилка"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Ім'я користувача зазвичай має містити лише літери нижнього регістру a-z, "
-"цифри і такі символи: - _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Вибачте, цей користувач недоступний. Спробуйте інакшого."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Перейменуйте користувача на меншу кількістю літер."
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8771,52 +4684,10 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Промах виявлено, перезавантаження…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Кнопка %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Програму визначено"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Надіслати натискання клавіші"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Перемкнути монітор"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Показати екранну довідку"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Планшет, який змонтовано на панелі ноутбука"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Планшет, який змонтовано на зовнішньому дисплеї"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "Зовнішній пристрій планшета"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "Зовнішній пристрій панелі"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Усі дисплеї"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8914,23 +4785,6 @@ msgstr "Натиск правою кнопкою миші"
 msgid "Forward"
 msgstr "Далі"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr ""
-"Стило-пульверизатор із вимірюванням тиску, нахилу та інтегрованим повзунком"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Стило-пульверизатор із вимірюванням тиску, нахилу і обертання"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Стандартне стило із вимірюванням тиску і нахилу"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Стандартне стило із вимірюванням тиску"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Планшет Wacom"
@@ -8941,54 +4795,96 @@ msgstr ""
 "Вкажіть прив'язування кнопок і скоригуйте чутливість стила для графічних "
 "планшетів"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Планшет;Wacom;Стилус;стило;Гумка;Миша;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Створити скорочення…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "_Імітація клацання другою кнопкою"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Програми Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Закінчується тонер"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Затримка другого натискання"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Програми Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Керування параметрами продуктивності та багатозадачності"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Точки доступу"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Додати"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "З_берегти"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Дію скасовано"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Помилка:</b> відмовлено у доступі до зміни параметрів"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Помилка:</b> помилка мобільного обладнання"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Не зареєстровано"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Зареєстровано"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Роумінг"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Пошук"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Відмовлено"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -9018,212 +4914,13 @@ msgstr "Власний номер"
 msgid "Device Details"
 msgstr "Дані щодо пристрою"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Виробник"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Версія мікропрограми"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Лише 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Лише 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Лише 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "Лише 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G, 3G, 4G? 5G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G, 3G, 4G (бажаний), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G, 3G (бажаний), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G (бажаний), 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G, 3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (бажаний), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (бажаний), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G, 4G, 5G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G, 4G (бажаний), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G (бажаний), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G, 4G, 5G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G, 4G (бажаний), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G (бажаний), 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G, 4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G, 3G, 5G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G, 3G (бажаний), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G (бажаний), 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G, 3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G (бажаний), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G (бажаний), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G (бажаний), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G, 5G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G (бажаний), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G, 5G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G (бажаний), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G, 5G (бажаний)"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G (бажаний), 5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G, 5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Невідомий"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Розблокувати SIM-картку"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Розблокувати"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Будь ласка, вкажіть пінкод для SIM-картки %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Введіть пінкод для розблокування вашої SIM-картки"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Будь ласка, вкажіть PUK-код для SIM-картки %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Введіть PUK-код для розблокування вашої SIM-картки"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9242,26 +4939,6 @@ msgstr[0] "У вас лишилася %u спроба"
 msgstr[1] "У вас лишилося %u спроби"
 msgstr[2] "У вас лишилося %u спроб"
 msgstr[3] "У вас лишилася одна спроба"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Введено помилковий пароль."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK-код має бути 8-цифровим числом"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Введіть новий пінкод"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Пінкод має бути числом, у якому має бути від 4 до 8 цифр"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Розблокування…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9319,94 +4996,6 @@ msgstr "Заблокувати SIM-картку за допомогою пінк
 msgid "M_odem Details"
 msgstr "Параметри м_одему"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Помилка телефону"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Немає з'єднання з телефоном"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Дію заборонено"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Підтримки дії не передбачено"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM не вставлено"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Потрібен пінкод SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Потрібен PUK-код SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Помилка SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM зайнято"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Помилковий пароль"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Потрібен PIN2-код SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Потрібен PUK2-код SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Не знайдено"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Немає мережевої служби"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Час очікування на мережу"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Служби GPRS заборонено"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Роумінґ у цій місцевості заборонено"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Невказана помилка GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "Без помилок"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "Дію скасовано"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "Доступ заборонено"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "Невідома помилка"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Режим мережі"
@@ -9422,11 +5011,6 @@ msgstr "Виберіть мережу"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Освіжити список надавачів послуг мережі"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM-картка %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9485,7 +5069,6 @@ msgstr "Мобільна мережа"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Налаштовування телефонії та мобільних з'єднань для передавання даних"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr ""
@@ -9504,41 +5087,13 @@ msgstr "«Параметри» є основним інтерфейсом для
 msgid "The GNOME Project"
 msgstr "Проєкт GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Показати номер версії"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Увімкнути докладний режим"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Шукати рядок"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Подати можливі назви панелі й вийти"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Панель для показу"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[ПАНЕЛЬ] [АРГУМЕНТ…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "Категорії параметрів"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Конфіденційність"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "Доступні панелі:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9596,7 +5151,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Скасувати пошук"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Налаштування;Параметри;"
@@ -9635,8 +5189,6 @@ msgstr ""
 "Кортеж, що містить початкову ширину, висоту і стан максимізації вікна "
 "програми."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
@@ -9646,8 +5198,6 @@ msgstr[1] "%u виводи"
 msgstr[2] "%u виводів"
 msgstr[3] "%u вивід"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
@@ -9657,18 +5207,3155 @@ msgstr[1] "%u входи"
 msgstr[2] "%u входів"
 msgstr[3] "%u вхід"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Системні звуки"
+#~ msgid "System Bus"
+#~ msgstr "Системна шина"
+
+#~ msgid "Full access"
+#~ msgstr "Повний доступ"
+
+#~ msgid "Session Bus"
+#~ msgstr "Шина сеансів"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Повний доступ до /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Має доступ до мережі"
+
+#~ msgid "Home"
+#~ msgstr "Домівка"
+
+#~ msgid "Read-only"
+#~ msgstr "Лише читання"
+
+#~ msgid "File System"
+#~ msgstr "Файлова система"
+
+#~ msgid "Can change settings"
+#~ msgstr "Може змінювати налаштування"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s має вказані нижче вбудовані дозволи. Це неможливо змінити. Якщо вас "
+#~ "турбують ці дозволи, розгляньте можливість вилучення цієї програми."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u тип файлів і посилань, які може відкривати програма"
+#~ msgstr[1] "%u типи файлів і посилань, які може відкривати програма"
+#~ msgstr[2] "%u типів файлів і посилань, які може відкривати програма"
+#~ msgstr[3] "%u тип файлів і посилань, які може відкривати програма"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr ""
+#~ "<b>%s</b> використовується для відкриття файлів і посилань таких типів."
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "Використано %s місця на диску."
+
+#~ msgid "Select a picture"
+#~ msgstr "Виберіть зображення"
+
+#~ msgid "_Open"
+#~ msgstr "_Відкрити"
+
+#~ msgid "multiple sizes"
+#~ msgstr "декілька розмірів"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Без тла стільниці"
+
+#~ msgid "Current background"
+#~ msgstr "Поточне тло"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Розмістіть ваш калібрувальний пристрій поверх квадрату й натисніть "
+#~ "«Запустити»"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Перемістіть ваш калібрувальний пристрій на відповідну позицію та "
+#~ "натисніть «Далі»"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Перемістіть ваш калібрувальний пристрій на позицію поверхні та натисніть "
+#~ "«Далі»"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Закрити кришку ноутбука"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Виникла внутрішня помилка й роботу неможливо відновити."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Не встановлено засоби для калібрування."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Профіль неможливо породити."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Відмітка білого для цілі недоступна."
+
+#~ msgid "Complete!"
+#~ msgstr "Завершено!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Помилка калібрування!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Можете витягнути калібрувальний пристрій."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Не чіпайте калібрувальний пристрій поки він працює"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Екран ноутбука"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Вбудована камера"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Монітор %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Сканер %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Камера %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Принтер %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Камера %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Увімкнути керування кольорами для %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Показати профілі кольорів для %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Нескалібровано"
+
+#~ msgid "Default: "
+#~ msgstr "Типовий:"
+
+#~ msgid "Colorspace: "
+#~ msgstr "Простір кольорів: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Тестовий профіль: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Виберіть файл профілю ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Імпортувати"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Підтримувані профілі ICC"
+
+#~ msgid "All files"
+#~ msgstr "Усі файли"
+
+#~ msgid "Save Profile"
+#~ msgstr "Зберегти профіль"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Створити профіль кольорів для вибраного пристрою"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Інструмент міри не виявлено. Будь ласка, перевірте, чи це ввімкнено й "
+#~ "правильно з'єднано."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Інструмент міри не підтримує профілювання принтерів."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Цей тип пристрою не підтримується. "
+
+#~ msgid "Standard Space"
+#~ msgstr "Стандартний простір"
+
+#~ msgid "Test Profile"
+#~ msgstr "Тестовий профіль"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Автоматично"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Низька якість"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Середня якість"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Висока якість"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "Типовий RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "Типовий CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Типовий сірий"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Виробник надав фабричні калібрувальні дані"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Повноекранний зв'язок неможливий з цим профілем"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Цей профіль може бути неточним"
+
+#~ msgid "Other…"
+#~ msgstr "Інше…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Розблокуйте, щоб змінити налаштування"
+
+#~ msgid "Today"
+#~ msgstr "Сьогодні"
+
+#~ msgid "Yesterday"
+#~ msgstr "Учора"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d година"
+#~ msgstr[1] "%i години"
+#~ msgstr[2] "%d годин"
+#~ msgstr[3] "%d година"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d хвилина"
+#~ msgstr[1] "%d хвилини"
+#~ msgstr[2] "%d хвилин"
+#~ msgstr[3] "%d хвилина"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d секунда"
+#~ msgstr[1] "%d секунди"
+#~ msgstr[2] "%d секунд"
+#~ msgstr[3] "%d секунда"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Хот-спот"
+
+#~ msgid "24-hour"
+#~ msgstr "24-ох годинний"
+
+#~ msgid "AM / PM"
+#~ msgstr "До / після полудня "
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%e %B %Y, %l:%M %p"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%e %B %Y, %R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Надсилання звітів про технічні проблеми допомагає нам покращити %s. Звіти "
+#~ "надсилаються анонімно і не містять особистих даних. %s"
+
+#~ msgid "On"
+#~ msgstr "Увімкнено"
+
+#~ msgid "Off"
+#~ msgstr "Вимкнено"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Застосувати зміни?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Не вдалося застосувати зміни"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Причиною можуть бути апаратні обмеження."
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Альбомна"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Портретна праворуч"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Портретна ліворуч"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Альбомна перевернута"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Гц"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "Secure Boot є активним"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "Secure boot запобігає завантаженню програмного забезпечення зловмисників "
+#~ "під час запуску пристрою. Зараз цей захист увімкнено, і він працює "
+#~ "належним чином."
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "Маємо проблеми із Secure Boot"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "Secure boot запобігає завантаженню програмного забезпечення зловмисників "
+#~ "під час запуску пристрою. Зараз цей захист увімкнено, але він не працює "
+#~ "через некоректний ключ."
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "Проблеми із Secure boot часто можна розв'язати за допомогою параметрів "
+#~ "мікропрограми UEFI вашого комп'ютера (BIOS). Довідкові дані щодо цього "
+#~ "може бути надано виробником обладнання."
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr ""
+#~ "Довідкові дані можна отримати у виробника обладнання або надавача послуг "
+#~ "з комп'ютерної підтримки."
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "Secure Boot вимкнено"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "Secure boot запобігає завантаженню програмного забезпечення зловмисників "
+#~ "під час запуску пристрою. Зараз цей захист вимкнено."
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "Secure boot часто можна увімкнути за допомогою параметрів мікропрограми "
+#~ "UEFI вашого комп'ютера (BIOS). Довідкові дані можна отримати у виробника "
+#~ "обладнання або надавача послуг з комп'ютерної підтримки."
+
+#~ msgid "Passed"
+#~ msgstr "Пройдено"
+
+#~ msgid "Failed"
+#~ msgstr "Не пройдено"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "Пристрій є сумісним із рівнем HSI %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "Рівень безпеки 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "Цей пристрій не захищено від апаратних проблем із безпекою. Причиною "
+#~ "можуть бути проблеми із налаштуваннями апаратної частини або "
+#~ "мікропрограми. Рекомендуємо повідомити про цю проблему службі надання "
+#~ "гарантійної комп'ютерної підтримки."
+
+#~ msgid "Security Level 1"
+#~ msgstr "Рівень безпеки 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "Цей пристрій має мінімальний захист від апаратних проблем із безпекою. Це "
+#~ "найнижчий рівень захисту пристрою, який усуває лише прості загрози "
+#~ "безпеці."
+
+#~ msgid "Security Level 2"
+#~ msgstr "Рівень безпеки 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "Цей пристрій має базовий захист від апаратних проблем із безпекою. Цей "
+#~ "рівень захисту надає захист від деяких типових загроз безпеці."
+
+#~ msgid "Security Level 3"
+#~ msgstr "Рівень безпеки 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "Цей пристрій має розширений захист від апаратних проблем із безпекою. Це "
+#~ "рівень захисту пристрою, який усуває деякі додаткові загрози безпеці."
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "Для цього пристрою рівні безпеки є недоступними."
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr ""
+#~ "Зверніться до виробника вашого обладнання за допомогою у розв'язанні "
+#~ "проблем захисту."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "Можливо, проблему можна розв'язати за допомогою параметрів мікропрограми "
+#~ "UEFI або працівника служби підтримки."
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr ""
+#~ "Можливо, проблему можна розв'язати за допомогою параметрів мікропрограми "
+#~ "UEFI."
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr ""
+#~ "Можливо, проблему можна розв'язати за допомогою працівника служби "
+#~ "підтримки."
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr ""
+#~ "Захист від програмного забезпечення зловмисників під час запуску пристрою."
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "Маємо проблеми із Secure Boot"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "Деякий захист, коли пристрій розпочав роботу."
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "Secure Boot вимкнено"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "Без захисту, коли пристрій розпочав роботу."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "Цю проблему могло бути спричинено змінами у параметрах мікропрограми "
+#~ "UEFI, налаштуваннях операційної системи або помилками у роботі "
+#~ "програмного забезпечення у цій системі."
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Цю проблему могло бути спричинено змінами у параметрах мікропрограми UEFI "
+#~ "або помилками у роботі програмного забезпечення у цій системі."
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "Цю проблему могло бути спричинено змінами у налаштуваннях операційної "
+#~ "системи або помилками у роботі програмного забезпечення у цій системі."
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "Відкритий щодо суттєвих загроз захисту."
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "Обмежений захист від простих загроз."
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "Захищено від поширених загроз."
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "Захищено від широкого діапазону загроз."
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "Всебічний захист"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "Захист від запису мікропрограми"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "Блокування захисту мікропрограми від запису"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "Регіон мікропрограми BIOS"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "Дескриптор мікропрограми BIOS"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "Захист DMA до завантаження"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Перевірене завантаження Intel BootGuard"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Захист ACM Intel BootGuard"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Правила щодо помилок Intel BootGuard"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Синтез Intel BootGuard"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Увімкнено Intel CET"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET є активним"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "Шифрування RAM"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "Захист IOMMU"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Блокування ядра Linux"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Перевірка ядра Linux"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux swap"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "Сон зі збереженням до RAM"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "Сон із переведенням до бездіяльності"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "Ключ платформи UEFI"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "Secure Boot UEFI"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "Налаштування платформи TPM"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "Реконструкція TPM"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Режим виробника Intel Management Engine"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Перевизначення Intel Management Engine"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Версія Intel Management Engine"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "Оновлення мікропрограми"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "Засвідчення мікропрограми"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "Перевірка засобу оновлення мікропрограми"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "Діагностика платформи"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "Перевірки захисту процесора"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "Захист від повернення AMD"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "Захист від відтворення мікропрограми AMD"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "Захист від запису мікропрограми AMD"
+
+#~ msgid "Fused Platform"
+#~ msgstr "Синтезована платформа"
+
+#~ msgid "Valid"
+#~ msgstr "Чинний"
+
+#~ msgid "Not Valid"
+#~ msgstr "Нечинний"
+
+#~ msgid "Not Enabled"
+#~ msgstr "Не увімкнено"
+
+#~ msgid "Locked"
+#~ msgstr "Заблоковано"
+
+#~ msgid "Not Locked"
+#~ msgstr "Не заблоковано"
+
+#~ msgid "Encrypted"
+#~ msgstr "Зашифровано"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "Не зашифровано"
+
+#~ msgid "Tainted"
+#~ msgstr "Зіпсовано"
+
+#~ msgid "Not Tainted"
+#~ msgstr "Не зіпсовано"
+
+#~ msgid "Found"
+#~ msgstr "Знайдено"
+
+#~ msgid "Not Found"
+#~ msgstr "Не знайдено"
+
+#~ msgid "Supported"
+#~ msgstr "Є підтримка"
+
+#~ msgid "Not Supported"
+#~ msgstr "Немає підтримки"
+
+#~ msgid "Unknown"
+#~ msgstr "Невідома"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-бітова"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-бітова"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Невідомо"
+
+#~ msgid "Not Available"
+#~ msgstr "Недоступний"
+
+#~ msgid "System Logo"
+#~ msgstr "Логотип системи"
+
+#~ msgid "No input sources found"
+#~ msgstr "Не знайдено жодного джерела введення"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Інше"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Власне скорочення"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Клавіша альтернативних символів може використовуватися для уведення "
+#~ "додаткових символів. Вони інколи зображені на кнопках клавіатури як "
+#~ "третій варіант."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Ліва Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Права Alt"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Ліва Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Права Super"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Клавіша меню"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Права Ctrl"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Клавіша компонування дозволяє вводити велику кількість символів Щоб "
+#~ "скористатися нею, натисніть клавішу складання, а потім послідовність "
+#~ "символів. Наприклад, якщо за клавішею складання йтиме <b>C</b> і <b>o</b> "
+#~ "буде виведено <b>©</b>, натиснувши <b>a</b>, за яким слідує <b>'</b>, "
+#~ "отримаємо <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Джерела введення можна перемикати за допомогою клавіатурного скорочення "
+#~ "%s.\n"
+#~ "Змінити скорочення можна у параметрах клавіатурних скорочень."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d змінене"
+#~ msgstr[1] "%d змінених"
+#~ msgstr[2] "%d змінених"
+#~ msgstr[3] "%d змінене"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Скинути всі скорочення?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Скидання скорочень може вплинути і на ваші власні скорочення. Це "
+#~ "неможливо вернути."
+
+#~ msgid "Reset All"
+#~ msgstr "Скинути все"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr ""
+#~ "%s вже використовується для %s. Якщо застосувати, сполучення для %s буде "
+#~ "вимкнено"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Уведіть нове скорочення"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Встановити своє скорочення"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Встановити скорочення"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Уведіть нове сполучення для зміни %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Додати своє скорочення"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Гортання двома пальцями"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "П'ять клацань, час для GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Подвійний клац, основна кнопка"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Одинарний клац, основна кнопка"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Подвійний клац, середня кнопка"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Одинарний клац, середня кнопка"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Подвійний клац, вторинна кнопка"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Одинарний клац, вторинна кнопка"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Потрібно запустити NetworkManager."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Незахищена мережа (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Захищена мережа (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Захищена мережа (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Захищена мережа (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Захищена мережа"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Увімкнення хот-споту, призведе до від'єднання від %s і неможливості "
+#~ "доступу до інтернету за допомогою Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Має містити не менше 8 символів"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "Зупинити гарячу точку й від'єднати користувачів?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Зупинити гарячу точку"
+
+#~ msgid "Preserve"
+#~ msgstr "Зберегти"
+
+#~ msgid "Permanent"
+#~ msgstr "Постійна"
+
+#~ msgid "Random"
+#~ msgstr "Випадкова"
+
+#~ msgid "Stable"
+#~ msgstr "Стабільна"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Введена тут МАС-адреса буде використовуватися як апаратна адреса для "
+#~ "пристрою мережі, на якому активовано це з'єднання. Ця функція відома як "
+#~ "клонування або підробка MAC-адреси. Приклад: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Профіль %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Enterprise"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Немає"
+
+#~ msgid "Never"
+#~ msgstr "Ніколи"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Мб/с (%1.1f ГГц)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Мб/с"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 ГГц / 5 ГГц"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 ГГц"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 ГГц"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Немає"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Слабке"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Добре"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Непогане"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Відмінне"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Забути з'єднання"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Вилучити профіль з'єднання"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Вилучити VPN"
+
+#~ msgid "Details"
+#~ msgstr "Подробиці"
+
+#~ msgid "automatic"
+#~ msgstr "автоматично"
+
+#~ msgid "Identity"
+#~ msgstr "Засвідчення"
+
+#~ msgid "Delete Address"
+#~ msgstr "Вилучити адресу"
+
+#~ msgid "Delete Route"
+#~ msgstr "Вилучити маршрут"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Немає"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "40/128 бітний ключ WEP (шістнадцяткова або ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "128-ох бітний пароль для WEP"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "Динамічний WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "Особистий WPA і WPA2"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "Комерційний WPA & WPA2"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "Особистий WPA3"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Не вдалося відкрити редактор з'єднань"
+
+#~ msgid "New Profile"
+#~ msgstr "Створити профіль"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "Некоректний параметр %s: %s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "Некоректний параметр %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "Імпортувати з файла…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Додати VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Не вдалось імпортувати з'єднання з VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Файл «%s» неможливо прочитати або він містить невідому інформацію про "
+#~ "з'єднання з VPN\n"
+#~ "\n"
+#~ "Помилка: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Виберіть файл для імпортування"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Файл з назвою «%s» уже існує."
+
+#~ msgid "_Replace"
+#~ msgstr "_Замінити"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Бажаєте замінити %s на з'єднання з VPN, яке ви зберігаєте?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Неможливо експортувати з'єднання з VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "З'єднання з VPN «%s» неможливо експортувати в %s.\n"
+#~ "\n"
+#~ "Помилка: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Експортувати з'єднання з VPN"
+
+#~ msgid "never"
+#~ msgstr "ніколи"
+
+#~ msgid "today"
+#~ msgstr "сьогодні"
+
+#~ msgid "yesterday"
+#~ msgstr "вчора"
+
+#~ msgid "Last used"
+#~ msgstr "Востаннє використано"
+
+#~ msgid "Add new connection"
+#~ msgstr "Додати нове з'єднання"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Подробиці мережі для вибраної мережі, зокрема паролі та інші параметри "
+#~ "буде втрачено."
+
+#~ msgid "_Forget"
+#~ msgstr "_Забути"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Відомі мережі Wi-Fi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Забути"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr ""
+#~ "Системна політика забороняє використовувати комп'ютер як гарячу точку"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Бездротовий пристрій не підтримує режиму гарячої точки"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Коли URL налаштувань не надається, використовується автоматичне виявлення "
+#~ "проксі. "
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Це не рекомендовано для ненадійних прилюдних мереж."
+
+#~ msgid "Status unknown"
+#~ msgstr "Стан невідомий"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Некерований"
+
+#~ msgid "Unavailable"
+#~ msgstr "Недоступний"
+
+#~ msgid "Connecting"
+#~ msgstr "З'єднання"
+
+#~ msgid "Authentication required"
+#~ msgstr "Слід пройти розпізнавання"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Від'єднання"
+
+#~ msgid "Connection failed"
+#~ msgstr "Не вдалось з'єднатись"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Стан невідомий (немає)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Не вдалося налаштувати"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Не вдалося налаштувати IP"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Налаштування IP застаріли"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Таємниці є обов'язковими, проте їх не надано"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "Шукача 802.1x від'єднано"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Не вдалося налаштувати шукач 802.1x"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Помилка шукача 802.1x"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "Шукач 802.1x забрав надто багато часу для автентифікації "
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Не вдалося запустити службу PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Службу PPP від'єднано"
+
+#~ msgid "PPP failed"
+#~ msgstr "Помилка PPP"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Не вдалося запустити клієнт DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Помилка клієнта DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Помилка роботи клієнта DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Не вдалося запустити службу спільного з'єднання"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Помилка роботи служби спільного з'єднання"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Не вдалося запустити службу AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Помилка служби AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Помилка роботи служби AutoIP"
+
+#~ msgid "Line busy"
+#~ msgstr "Лінію зайнято"
+
+#~ msgid "No dial tone"
+#~ msgstr "Немає гудка"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Неможливо встановити жодного носія"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Час очікування набирання збіг"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Не вдала спроба набирання номеру"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Не вдалося запустити модем"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Не вдалось вибрати вказаний APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Немає пошуку мереж"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Реєстрацію мережі заборонено"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Час реєстрації мережі вичерпано "
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Не вдалось зареєструватись з мережею"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Не вдалось перевірити PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Може бракувати мікропрограми для пристрою"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "З'єднання зникло"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Наявне з'єднання вигадано"
+
+#~ msgid "Modem not found"
+#~ msgstr "Не знайдено модему"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Не вдалось з'єднатись з Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Не вставлено картки SIM"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Потрібно SIM Pin"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Потрібно SIM Puk"
+
+#~ msgid "SIM wrong"
+#~ msgstr "Неправильний SIM"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Помилка роботи залежності з'єднання"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Бракує мікропрограми"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Кабель від'єднано"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "невідома помилка у захисті 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "не вибрано жодного файла"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "Невизначена помилка завірення файла з методом eap"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "Закриті ключі DER, PEM, PKCS#12 або PGP"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "Сертифікати DER або PEM"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "Бракує файла EAP-FAST PAC"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Файли PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "бракує користувача EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "бракує паролю EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "неправильний сертифікат ЦС EAP-PEAP: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "Неправильний сертифікат ЦС EAP-PEAP: не вказано сертифікату"
+
+#~ msgid "missing EAP username"
+#~ msgstr "бракує користувача EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "бракує паролю EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "бракує ототожнення EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "неправильний сертифікат ЦС EAP-TLS: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "Неправильний сертифікат ЦА EAP-TLS: не вказано сертифікату"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "неправильний закритий ключ EAP-TLS: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "неправильний сертифікат користувача EAP-TLS: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Небезпечно використовувати секретні ключі без шифрування"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Схоже, що обраний закритий ключ не захищено паролем. Це може призвести до "
+#~ "компрометації ваших облікових даних. Будь ласка, виберіть закритий ключ, "
+#~ "захищений паролем.\n"
+#~ "\n"
+#~ "(Ви можете захистити закритий ключ за допомогою openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Виберіть ваш особистий сертифікат"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Виберіть ваш особистий ключ"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "неправильний сертифікат ЦС EAP-TTLS: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "неправильний сертифікат ЦА EAP-TTLS: не вказано сертифікату"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Невідома помилка перевірки безпеки 802.1x"
+
+#~ msgid "Select a file"
+#~ msgstr "Виберіть файл"
+
+#~ msgid "missing leap-username"
+#~ msgstr "бракує користувача LEAP"
+
+#~ msgid "missing leap-password"
+#~ msgstr "бракує паролю LEAP"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Бракує пароля Wi-Fi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "бракує ключа WEP"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "неправильний ключ WEP: ключ з довжиною %zu мусить містити тільки "
+#~ "шістнадцяткові значення"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "неправильний ключ WEP: ключ з довжиною %zu мусить містити тільки символи "
+#~ "ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "неправильний ключ WEP: хибний довжина ключа %zu. Ключ має бути: або "
+#~ "довжина 5/13 (ascii), або 10/26 (шістнадцятковий)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "неправильний ключ WEP: пароль не може бути порожній"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "неправильний ключ WEP: пароль не може перевищувати 64 символи"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "неправильний ключ PSK: неправильна довжина ключа %zu. Має бути [8,63] "
+#~ "біти або 64 шістнадцяткових значення"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "неправильний WPA-PSK: неможливо означити ключ з 64 шістнадцятковими бітами"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Інше"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s вилучений"
+
+#~ msgid "Error removing account"
+#~ msgstr "Помилка вилучення облікового запису"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Обліковий запис %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Вилучити обліковий запис"
+
+#~ msgid "Unknown time"
+#~ msgstr "Час невідомий"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s до повного зарядження"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Обережно: залишилось %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "Залишилось %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Повністю заряджено"
+
+#~ msgid "Not charging"
+#~ msgstr "Не заряджається"
+
+#~ msgid "Empty"
+#~ msgstr "Вичерпано"
+
+#~ msgid "Charging"
+#~ msgstr "Заряджання"
+
+#~ msgid "Discharging"
+#~ msgstr "Розряджається"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Бездротова миша"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Бездротова клавіатура"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Постачання безперебійного живлення"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Особистий цифровий помічник"
+
+#~ msgid "Cellphone"
+#~ msgstr "Мобільний телефон"
+
+#~ msgid "Media player"
+#~ msgstr "Програвач"
+
+#~ msgid "Tablet"
+#~ msgstr "Планшет"
+
+#~ msgid "Computer"
+#~ msgstr "Комп'ютер"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Ігровий пристрій введення"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Основна"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Додаткова"
+
+#~ msgid "Batteries"
+#~ msgstr "Батареї"
+
+#~ msgid "When _idle"
+#~ msgstr "Коли _бездіяльний"
+
+#~ msgid "Suspend"
+#~ msgstr "Призупинити"
+
+#~ msgid "Power Off"
+#~ msgstr "Вимкнути"
+
+#~ msgid "Hibernate"
+#~ msgstr "Приспати"
+
+#~ msgid "Nothing"
+#~ msgstr "Нічого"
+
+#~ msgid "When on battery power"
+#~ msgstr "Коли живлення від батареї"
+
+#~ msgid "When plugged in"
+#~ msgstr "Коли під'єднано"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Ніколи"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Автоматично призупиняти роботу"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr ""
+#~ "Режим підвищеної швидкодії тимчасово вимкнено через високу операційну "
+#~ "температуру."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Виявлено розташування на нетривкій поверхні: режим високої швидкодії "
+#~ "тимчасово недоступний. Перенесіть пристрій на стабільну поверхню, щоб "
+#~ "відновити доступ."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Режим підвищеної швидкодії тимчасово вимкнено."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Низький рівень заряду акумулятора: увімкнено заощадження енергії. "
+#~ "Попередній режим буде відновлено за достатнього рівня заряду акумулятора."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Режим заощадження енергії активовано «%s»."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Режим високої швидкодії активовано «%s»."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Швидкодія"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Висока швидкодія та споживання енергії."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Баланс"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Стандартна швидкодія та споживання енергії."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Заощадження"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Знижена швидкодія та споживання енергії."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Принтер «%s» було успішно вилучено"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Не вдалось додати принтер."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Не вдалось завантажити інтерфейс: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Розблокуйте, щоб додати принтери і змінити налаштування"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Подробиці про %s "
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Не знайдено придатного драйвера"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Виберіть файл PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Файли опису принтера PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD."
+#~ "GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Принтер JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Принтер LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Односторонній"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Впродовж довгої сторони (типово)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Впродовж короткої сторони"
+
+#~ msgid "Portrait"
+#~ msgstr "Книжкова"
+
+#~ msgid "Landscape"
+#~ msgstr "Альбомна"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Зворотна альбомна"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Зворотна книжкова"
+
+#~ msgid "Resume"
+#~ msgstr "Відновити"
+
+#~ msgid "Pause"
+#~ msgstr "Призупинити"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Очікування"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Призупинено"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Слід пройти розпізнавання"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Оброблення"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Зупинено"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Скасовано"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Припинено"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Завершено"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Пересунути це завдання на вершину черги"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — запущені завдання"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Для друку з %s введіть реєстраційні дані."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Розблокувати сервер друкування"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Розблокувати %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr ""
+#~ "Введіть користувача та пароль, щоб переглянути доступні принтери на %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Шукати принтери"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Послідовний порт"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Паралельний порт"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Розміщення: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Адреса: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Сервер потребує засвідчення"
+
+#~ msgid "Two Sided"
+#~ msgstr "Двосторонній"
+
+#~ msgid "Paper Type"
+#~ msgstr "Тип паперу"
+
+#~ msgid "Paper Source"
+#~ msgstr "Джерело паперу"
+
+#~ msgid "Output Tray"
+#~ msgstr "Лоток виводу"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Роздільна здатність"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Попередня відсіювання GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Сторінок на сторону"
+
+#~ msgid "Orientation"
+#~ msgstr "Орієнтація"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Загальне"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Параметри сторінки"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Змінні параметри"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Завдання"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Якість зображення"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Колір"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Завершення"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Додатково"
+
+#~ msgid "Test page"
+#~ msgstr "Тестова сторінка"
+
+#~ msgid "Auto Select"
+#~ msgstr "Автоматичне вибрати"
+
+#~ msgid "Printer Default"
+#~ msgstr "Типове для принтера"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Вбудовувати лише шрифти GhostScript"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Перетворити у PS 1-го рівня"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Перетворити у PS 2-го рівня"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Без попереднього відсіювання"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Очищення головок принтера"
+
+#~ msgid "Out of toner"
+#~ msgstr "Вичерпався тонер"
+
+#~ msgid "Low on developer"
+#~ msgstr "Закінчується проявник"
+
+#~ msgid "Out of developer"
+#~ msgstr "Вичерпався проявник"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Закінчується фарба"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Вичерпано фарбу"
+
+#~ msgid "Open cover"
+#~ msgstr "Відкрита кришка"
+
+#~ msgid "Open door"
+#~ msgstr "Відкриті двері"
+
+#~ msgid "Low on paper"
+#~ msgstr "Закінчується папір"
+
+#~ msgid "Out of paper"
+#~ msgstr "Вичерпано папір"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Вимкнено"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Зупинено"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Майже повністю витрачено запас"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Повністю витрачено запас"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Оптичний фотопровідник близький до виходу з ладу"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Оптичний фотопровідник вийшов з ладу"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Готовий"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Завдання не прийнято"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Оброблення"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Імперська"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Метрична"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Питати, що робити"
+
+#~ msgid "Do nothing"
+#~ msgstr "Нічого не робити"
+
+#~ msgid "Open folder"
+#~ msgstr "Відкрити теку"
+
+#~ msgid "Other Media"
+#~ msgstr "Інший носій"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Вибрати програму для звукових CD"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Вибрати програму для відео DVD"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Вибрати програму для запуску, коли музичний програвач під'єднано"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Вибрати програму для запуску, коли камеру під'єднано"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Вибрати програму для програмного CD"
+
+#~ msgid "audio DVD"
+#~ msgstr "audio DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "blank Blu-ray disc"
+
+#~ msgid "blank CD disc"
+#~ msgstr "blank CD disc"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "blank DVD disc"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "blank HD DVD disc"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-ray video disc"
+
+#~ msgid "e-book reader"
+#~ msgstr "e-book reader"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD video disc"
+
+#~ msgid "Picture CD"
+#~ msgstr "Picture CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "Super Video CD"
+
+#~ msgid "Video CD"
+#~ msgstr "Video CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Екран вимикається"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 секунд"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 хвилина"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 хвилини"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 хвилини"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 хвилин"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 хвилин"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 година"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 хвилина"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 хвилини"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 хвилини"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 хвилини"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 хвилин"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 хвилин"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 хвилин"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 хвилин"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 хвилин"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Ніколи"
+
+#~ msgid "Select Location"
+#~ msgstr "Вибрати регіон"
+
+#~ msgid "_OK"
+#~ msgstr "_Гаразд"
+
+#~ msgid "No applications found"
+#~ msgstr "Не знайдено жодної програми"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Немає жодної вибраної мережі для оприлюднення"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Увімкнено"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Вимкнено"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Увімкнено"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "Активний"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Вибрати теку"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "Увімкнути оприлюднення матеріалів"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Спільний доступ до файлів надає вам змогу спільного використовувати вашу "
+#~ "теку із іншими користувачами вашої поточної мережі за допомогою: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Якщо дистанційний доступ увімкнено, віддалені користувачі можуть "
+#~ "під'єднуватися за допомогою команди SSH:\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "Увімкнути оприлюднення особистих матеріалів"
+
+#~ msgid "Device name copied"
+#~ msgstr "Скопійовано назву пристрою"
+
+#~ msgid "Device address copied"
+#~ msgstr "Скопійовано адресу пристрою"
+
+#~ msgid "Username copied"
+#~ msgstr "Ім'я користувача скопійовано"
+
+#~ msgid "Password copied"
+#~ msgstr "Пароль скопійовано"
+
+#~ msgid "Custom"
+#~ msgstr "Свій"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Тестування %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Від'єднано"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "З'єднання"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "З'єднано"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Помилка авторизації"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Авторизація"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Обмежена функціональність"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "З'єднано та авторизовано"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Невідомо"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Авторизовано як:"
+
+#~ msgid "Connected at:"
+#~ msgstr "З'єднано на:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Зареєстровано на:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Не вдалося авторизувати пристрій: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Не вдалося забути пристрій: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Помилка"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Авторизовано"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Підсистема Thunderbolt (boltd) не встановлена і не налаштована належним "
+#~ "чином."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Можна приєднати лише пристрої USB та Display Port."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Не вдалося виявити Thunderbolt. \n"
+#~ "Або у системі немає підтримки Thunderbolt, або вона була вимкнена в BIOS "
+#~ "чи заданий непідтримуваний рівень захисту в BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Підтримку Thunderbolt було вимкнено у BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Не вдається визначити рівень безпеки Thunderbolt."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Помилка перемикання безпосереднього режиму: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Типовий"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Середній"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Великий"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Більший"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Найбільший"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d піксель"
+#~ msgstr[1] "%d пікселі"
+#~ msgstr[2] "%d пікселів"
+#~ msgstr[3] "%d піксель"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Короткий"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ екрана"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ екрана"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ екрана"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Довгий"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 година"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 день"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 дні"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 дні"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 дні"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 днів"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 днів"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 днів"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 днів"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 днів"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Очистити всі елементи зі смітника?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Якщо вилучити елементи в смітнику, їх буде вилучено безповоротно."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "С_порожнити смітник"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Вилучити усі тимчасові файли?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Усі тимчасові файли буде безповоротно вилучено."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "П_очистити тимчасові файли"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 день"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 днів"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 днів"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Завжди"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Мусить збігатись з адресою вашого постачальника."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Не вдалось додати обліковий запис"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Не вдалося зареєструвати обліковий запис"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Непідтримуваний спосіб автентифікації з цим доменом"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Не вдалось долучитись до домену"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Цей користувач не спрацював.\n"
+#~ "Спробуйте ще."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Цей пароль не спрацював.\n"
+#~ "Спробуйте ще."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Не вдалось увійти до домену"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Не вдалося знайти домен. Можливо, ви неправильно це написали?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Огляд інших зображень"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "для виконання цієї дії пристрій має бути зарезервовано"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "пристрій вже зарезервовано іншим процесом"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "у вас немає прав доступу для виконання цієї дії"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "ролі не було надано жодному відбитку"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Не вдалося виконати обмін даними з пристроєм під час надання ролей"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Не вдалося виконати обмін даних із засобом читання відбитків"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Не вдалося виконати обмін даних із фоновою службою відбитків"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Не вдалося побудувати список відбитків: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Не вдалося вилучити збережені відбитки пальців: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Великий палець лівої руки"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Середній палець лівої руки"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Вказівний палець _лівої руки"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Безіменний палець лівої руки"
+
+#~ msgid "Left little finger"
+#~ msgstr "Мізинець лівої руки"
+
+#~ msgid "Right thumb"
+#~ msgstr "Великий палець правої руки"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Середній палець правої руки"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Вказівний палець _правої руки"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Безіменний палець правої руки"
+
+#~ msgid "Right little finger"
+#~ msgstr "Мізинець палець правої руки"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Невідомий палець"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Завершено"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Пристрій для зчитування відбитків від'єднано"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Сховище даних пристрою зчитування відбитків переповнено"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Не вдалося зареєструвати новий відбиток"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Не вдалося розпочати реєстрацію: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Не вдалося зареєструвати новий відбиток"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Не вдалося зупинити реєстрацію: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Знімайте і притискайте ваш палець до пристрою зчитування, щоб "
+#~ "зареєструвати відбиток пальця"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "П_еревизначити цей палець…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Сканувати новий відбиток"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Не вдалося звільнити пристрій зчитування відбитків %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Проблема з читанням з пристрою"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Не вдалося зайняти пристрій зчитування відбитків %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Не вдалося отримати список пристроїв для зчитування відбитків: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Цього тижня"
+
+#~ msgid "Last Week"
+#~ msgstr "Минулого тижня"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Сеанс завершено"
+
+#~ msgid "Session Started"
+#~ msgstr "Сеанс розпочато"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — Діяльність облікового запису"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Будь ласка, виберіть інший пароль."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Будь ласка, введіть поточний пароль ще раз."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Пароль неможливо змінити"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Неможливо автоматично долучити цей тип домену"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Нема такого домену чи області"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Неможливо ввійти як %s на домен %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Неправильний пароль, спробуйте ще раз"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Неможливо з'єднатися із доменом %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Помилка при вилученні користувача"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Не вдалось відкликати віддаленого користувача"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Неможливо вилучити власний обліковий запис."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s досі у системі"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr ""
+#~ "Вилучивши користувача, коли він у системі, змусить його покинути систему "
+#~ "в нестійкому стані."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Зберегти файли користувача %s?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Можна утримати домашній каталог, поштову скриньку та тимчасові файли, "
+#~ "коли обліковий запис користувача буде вилучатись."
+
+#~ msgid "_Delete Files"
+#~ msgstr "В_илучити файли"
+
+#~ msgid "_Keep Files"
+#~ msgstr "З_берегти файли"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Відкликати віддалено запущеного користувача на обліковому записі %s?"
+
+#~ msgid "_Delete"
+#~ msgstr "В_илучити"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Обліковий запис вимкнено"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Буде встановлено при наступному вході"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Немає"
+
+#~ msgid "Logged in"
+#~ msgstr "Увійшов"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Не вдалось зв'язатись зі службою облікових записів"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr ""
+#~ "Будь ласка, переконайтесь, що AccountService встановлено та ввімкнено."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Цю панель має бути розблоковано для зміни цього параметра"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Вилучити вибраний обліковий запис користувача"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Щоб вилучити вибраний обліковий запис користувача,\n"
+#~ "натисніть спочатку на піктограму *"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Розблокуйте, щоб додати користувачів і змінити налаштування"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Новий пароль повинен бути відмінним від попереднього."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Спробуйте змінити якісь цифри або букви."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Спробуйте трохи переінакшити пароль."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Пароль без згадування користувача буде надійніший."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Намагайтесь уникати згадування користувача в паролі."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Намагайтесь уникати деяких слів, вказаних у паролі."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Намагайтесь уникати звичайних слів."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Намагайтесь уникати переставлення наявних слів."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Намагайтесь використовувати більше чисел."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Намагайтесь використовувати великі букви."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Намагайтесь використовувати малі букви."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Намагайтесь використовувати спеціальні символи, наприклад, розділові "
+#~ "знаки."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Намагайтесь використовувати суміш букв, чисел і розділових знаків."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Намагайтесь уникати повторення однакових символів."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Намагайтесь уникати повторення однакового типу символів: варто змішувати "
+#~ "букви з числами і розділові знаки."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Намагайтесь уникати послідовностей, наприклад, 1234 або абвг."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr ""
+#~ "Пароль має бути довшим. Спробуйте додати більше літер, цифр та символів "
+#~ "пунктуації."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Змішуйте великі букви з малими і намагайтесь використовувати числа."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr ""
+#~ "Додавання літер, цифр і розділових знаків зробить пароль надійнішим!"
+
+#~ msgid "Authentication failed"
+#~ msgstr "Помилка при автентифікації"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Новий пароль надто короткий"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Новий пароль надто простий"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Старий і новий пароль надто подібні"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Новий пароль уже використовувався."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Новий пароль містить цифри або спеціальні символи"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Старий і новий пароль — однакові."
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Ваш пароль змінився з моменту початкової аутентифікації!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Новий пароль не містити достатньо різноманітних символів"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Невідома помилка"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Ім'я користувача зазвичай має містити лише літери нижнього регістру a-z, "
+#~ "цифри і такі символи: - _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Вибачте, цей користувач недоступний. Спробуйте інакшого."
+
+#~ msgid "The username is too long."
+#~ msgstr "Перейменуйте користувача на меншу кількістю літер."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Кнопка %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Програму визначено"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Надіслати натискання клавіші"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Перемкнути монітор"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Показати екранну довідку"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Планшет, який змонтовано на панелі ноутбука"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Планшет, який змонтовано на зовнішньому дисплеї"
+
+#~ msgid "External tablet device"
+#~ msgstr "Зовнішній пристрій планшета"
+
+#~ msgid "All Displays"
+#~ msgstr "Усі дисплеї"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr ""
+#~ "Стило-пульверизатор із вимірюванням тиску, нахилу та інтегрованим "
+#~ "повзунком"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Стило-пульверизатор із вимірюванням тиску, нахилу і обертання"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Стандартне стило із вимірюванням тиску і нахилу"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Стандартне стило із вимірюванням тиску"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Створити скорочення…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Дію скасовано"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Помилка:</b> відмовлено у доступі до зміни параметрів"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Помилка:</b> помилка мобільного обладнання"
+
+#~ msgid "Not Registered"
+#~ msgstr "Не зареєстровано"
+
+#~ msgid "Registered"
+#~ msgstr "Зареєстровано"
+
+#~ msgid "Roaming"
+#~ msgstr "Роумінг"
+
+#~ msgid "Searching"
+#~ msgstr "Пошук"
+
+#~ msgid "Denied"
+#~ msgstr "Відмовлено"
+
+#~ msgid "2G Only"
+#~ msgstr "Лише 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Лише 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Лише 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "Лише 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 4G? 5G (бажаний)"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G, 3G, 4G (бажаний), 5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G, 3G (бажаний), 4G, 5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G (бажаний), 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G, 3G, 4G, 5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (бажаний)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (бажаний), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (бажаний), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G, 4G, 5G (бажаний)"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G, 4G (бажаний), 5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G (бажаний), 4G, 5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G, 4G, 5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G, 4G, 5G (бажаний)"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G, 4G (бажаний), 5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G (бажаний), 4G, 5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G, 4G, 5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G, 3G, 5G (бажаний)"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G, 3G (бажаний), 5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G (бажаний), 3G, 5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G, 3G, 5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (бажаний)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (бажаний), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (бажаний)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (бажаний), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (бажаний)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (бажаний), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G, 5G (бажаний)"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G (бажаний), 5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G, 5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G, 5G (бажаний)"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G (бажаний), 5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G, 5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G, 5G (бажаний)"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G (бажаний), 5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G, 5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Невідомий"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Розблокувати SIM-картку"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Будь ласка, вкажіть пінкод для SIM-картки %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Введіть пінкод для розблокування вашої SIM-картки"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Будь ласка, вкажіть PUK-код для SIM-картки %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Введіть PUK-код для розблокування вашої SIM-картки"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Введено помилковий пароль."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK-код має бути 8-цифровим числом"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Введіть новий пінкод"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Пінкод має бути числом, у якому має бути від 4 до 8 цифр"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Розблокування…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Помилка телефону"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Немає з'єднання з телефоном"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Дію заборонено"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Підтримки дії не передбачено"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM не вставлено"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Потрібен пінкод SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Потрібен PUK-код SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Помилка SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM зайнято"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Помилковий пароль"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Потрібен PIN2-код SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Потрібен PUK2-код SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Не знайдено"
+
+#~ msgid "No network service"
+#~ msgstr "Немає мережевої служби"
+
+#~ msgid "Network timeout"
+#~ msgstr "Час очікування на мережу"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Служби GPRS заборонено"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Роумінґ у цій місцевості заборонено"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Невказана помилка GPRS"
+
+#~ msgid "No Error"
+#~ msgstr "Без помилок"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Дію скасовано"
+
+#~ msgid "Access denied"
+#~ msgstr "Доступ заборонено"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Невідома помилка"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM-картка %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Показати номер версії"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Увімкнути докладний режим"
+
+#~ msgid "Search for the string"
+#~ msgstr "Шукати рядок"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Подати можливі назви панелі й вийти"
+
+#~ msgid "Panel to display"
+#~ msgstr "Панель для показу"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[ПАНЕЛЬ] [АРГУМЕНТ…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Доступні панелі:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Системні звуки"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "Помилка: не вдалося визначити рівень HSI."
 
 #~ msgid "Error: unable to determine Incorrect HSI level."
 #~ msgstr "Помилка: не вдалося визначити помилковий рівень HSI."
-
-#~ msgid "Add a Printer…"
-#~ msgstr "Додати принтер…"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "Сертифікати DER або PEM (*.der, *.pem, *.crt, *.cer)"
@@ -9685,9 +8372,6 @@ msgstr "Системні звуки"
 #~| msgid "Take a screenshot of a window"
 #~ msgid "Take screenshots of application windows and the desktop."
 #~ msgstr "Робити знімки вікон програм та стільниці."
-
-#~ msgid "No Protection"
-#~ msgstr "Без захисту"
 
 #~ msgid "Minimal Protection"
 #~ msgstr "Мінімальний захист"
@@ -9971,9 +8655,6 @@ msgstr "Системні звуки"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Планшет (абсолютно)"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Сенсорна панель (відносно)"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "Параметри планшета"
 
@@ -10094,11 +8775,11 @@ msgstr "Системні звуки"
 #~ msgstr "Неможливо змінити"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
-#~ "Індивідуальні дозволи для програм можна переглянути в розділі <a href="
-#~ "\"privacy\">Конфіденційність</a> налаштувань."
+#~ "Індивідуальні дозволи для програм можна переглянути в розділі <a "
+#~ "href=\"privacy\">Конфіденційність</a> налаштувань."
 
 #~ msgid "Integration"
 #~ msgstr "Інтеграція"

--- a/po/uk.po~
+++ b/po/uk.po~
@@ -1,0 +1,10421 @@
+# Ukrainian translation of control-center.
+# Copyright (C) 1999 Free Software Foundation, Inc.
+# Yuri Syrota <rasta@renome.rovno.ua>, 1999.
+# Maxim Dzumanenko <dziumanenko@gmail.com>, 2002-2009.
+# Wanderlust <wanderlust@ukr.net>, 2009.
+# Daniel Korostil <ted.korostiled@gmail.com>, 2013, 2014, 2015, 2016, 2017.
+# Yuri Chornoivan <yurchor@ukr.net>, 2020, 2021, 2022.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-10-25 14:38+0000\n"
+"PO-Revision-Date: 2022-08-25 23:15+0300\n"
+"Last-Translator: two@envs.net <two@envs.net>\n"
+"Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Lokalize 20.12.0\n"
+"X-Project-Style: gnome\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "Системна шина"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "Повний доступ"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "Шина сеансів"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Пристрої"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "Повний доступ до /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Мережа"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "Має доступ до мережі"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Домівка"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "Лише читання"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "Файлова система"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Параметри"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "Може змінювати налаштування"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s має вказані нижче вбудовані дозволи. Це неможливо змінити. Якщо вас "
+"турбують ці дозволи, розгляньте можливість вилучення цієї програми."
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u тип файлів і посилань, які може відкривати програма"
+msgstr[1] "%u типи файлів і посилань, які може відкривати програма"
+msgstr[2] "%u типів файлів і посилань, які може відкривати програма"
+msgstr[3] "%u тип файлів і посилань, які може відкривати програма"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr ""
+"<b>%s</b> використовується для відкриття файлів і посилань таких типів."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "Використано %s місця на диску."
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Програми"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Немає програм"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Встановіть щось…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Відкрити"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Переглянути подробиці"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Пошук"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Отримання сигналів системи про пошук і надсилання результатів."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Сповіщення"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Показ сповіщень системи."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "Запустити у фоновому режимі"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Дозвіл на виконання дій, якщо вікно програми закрито."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Знімки екрана"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "Створення знімків екрана у будь-який момент."
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "Змінити зображення тла"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "Зміна фонового зображення стільниці."
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Звуки"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "Відтворення звукових даних."
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "Заборона використання скорочень"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "Блокування стандартних клавіатурних скорочень."
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Камера"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "Створення знімків за допомогою камери."
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Мікрофон"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "Запис звукових даних за допомогою мікрофона."
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Служби розташування"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "Доступ до даних пристрою щодо місця перебування."
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "Вбудовані дозволи"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "Рівень доступу до системи, який потрібен програмі"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "Прив'язка файлів та посилань до програм"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "Сховище даних"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "Не знайдено жодного результату"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "Спробуйте пошукати по-інакшому"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "Прив'язка файлів та посилань до програм"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "Типи файлів"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "Типи посилань"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "Скинути"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Обсяг дискового простору, що займає ця програма разом зі своїми даними і "
+"кешем."
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "Програма"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "Дані"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "Кеш"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>Загалом</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "Очистити кеш…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Керування різними дозволами й налаштуваннями програм"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "програма;flatpak;дозвіл;налаштування;application;permission;setting;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "Виберіть зображення"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "_Скасувати"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Відкрити"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "декілька розмірів"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Без тла стільниці"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Поточне тло"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Стиль"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Типовий"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "Темна"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Тло"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "Додати зображення…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Вигляд"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Змінити зображення тла або кольори інтерфейсу користувача"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;Тло;Фон;"
+"Шпалери;Екран;Стільниця;Стиль;Світлий;Світла;Темний;Темна;Вигляд;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "Увімкнути"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "Немає знайдено жодного Bluetooth"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Приєднайте пристрій для Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth вимкнено"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Увімкніть, щоб під'єднати пристрої та одержати файли."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "Режим польоту ввімкнено"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth вимкнено, коли режим польоту ввімкнено."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "Вимкнути режим польоту"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "Апаратний режим польоту ввімкнено"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Вимкніть режим польоту, щоб увімкнути Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Увімкнути або вимкнути з'єднання з пристроєм через Bluetooth"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "оприлюднення;поділитись;блютуз;obex;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "Камеру вимкнено"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "Немає програм, які здатні знімати фотографії та відео."
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Використання камери надає програмам змогу створювати знімки і записувати "
+"відео. Вимкнення камери може спричинити неправильну роботу програм.\n"
+"\n"
+"Дозволити вказаним нижче програмами використовувати камеру."
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Немає програм, які надсилають запит щодо доступу до камери"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Захистіть ваші зображення"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;камера;фотоапарат;фото;"
+"фотографії;відео;вебкамера;блокування;конфіденційність;приватність;приватний;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr ""
+"Розмістіть ваш калібрувальний пристрій поверх квадрату й натисніть "
+"«Запустити»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Перемістіть ваш калібрувальний пристрій на відповідну позицію та натисніть "
+"«Далі»"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr ""
+"Перемістіть ваш калібрувальний пристрій на позицію поверхні та натисніть "
+"«Далі»"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Закрити кришку ноутбука"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Виникла внутрішня помилка й роботу неможливо відновити."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Не встановлено засоби для калібрування."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Профіль неможливо породити."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Відмітка білого для цілі недоступна."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Завершено!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Помилка калібрування!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Можете витягнути калібрувальний пристрій."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Не чіпайте калібрувальний пристрій поки він працює"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Калібрування екрана"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Запустити"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Відновити"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "_Завершити"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Екран ноутбука"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Вбудована камера"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Монітор %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Сканер %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Камера %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Принтер %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Камера %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Увімкнути керування кольорами для %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Показати профілі кольорів для %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Нескалібровано"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Типовий:"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Простір кольорів: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Тестовий профіль: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Виберіть файл профілю ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Імпортувати"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Підтримувані профілі ICC"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Усі файли"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Екран"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Зберегти профіль"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "З_берегти"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Створити профіль кольорів для вибраного пристрою"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Інструмент міри не виявлено. Будь ласка, перевірте, чи це ввімкнено й "
+"правильно з'єднано."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Інструмент міри не підтримує профілювання принтерів."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Цей тип пристрою не підтримується. "
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Калібрування екрана"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Якість калібрування"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Калібрування створить профіль, який ви можете для керування кольорами на "
+"вашому екрані. Чим довше проходить калібрування, тим краща якість профілю "
+"кольорів."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "Не можна використовувати комп'ютер під час калібрування."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Якість"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Приблизна тривалість"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Калібрувальний пристрій"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Виберіть сенсорний пристрій для калібрування."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Тип екрана"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Виберіть тип екрана, що під'єднано."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Профіль відмітки білого"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Виберіть відмітку білого екрана. Більшість екранів слід відкалібрувати до "
+"освітлювача D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Яскравість екрана"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Вкажіть яскравість екрана, яка типова для вас. Керування кольором буде "
+"найточніше саме для цього рівня яскравості."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Як варіант, можете використовувати рівень яскравості з інших профілів для "
+"цього пристрою."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Назва профілю:"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Можете використовувати профіль кольорів на різних комп'ютерах, або навіть "
+"створити профілі для різних умов освітлення."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Назва профілю:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Підсумок"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Профіль успішно створено!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Скопіювати профіль"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Вимагає пристрій, на який можна записувати"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Ці інструкції про використання профілів на системах <a href=\"linux\">GNU/"
+"Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows\">Microsoft "
+"Windows</a> можуть стати в пригоді."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Додати профіль"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Виявлено проблему. Профіль може не працювати правильно. <a href="
+"\"\">Показати подробиці.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "_Імпортувати файл…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Додати"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Кожен пристрій потребує оновлення профілю кольорів для керування кольорами."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Дізнатись більше"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Дізнатись більше про керування кольорами"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "_Вказати для всіх користувачів"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Встановити цей профіль для всіх користувачів цього комп'ютера"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Увімкнути"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "_Додати профіль"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Калібрувати…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Калібрувати пристрій"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Вилучити профіль"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Переглянути подробиці"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Неможливо виявити пристрій, на якому можна керувати кольорами"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "Рідкокристалічний"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "Індикатор LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "Електронна трубка"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Проектор"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Плазма"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "Рідкокристалічний (підсвічування CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "Рідкокристалічний (підсвічування RGB LED)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "Рідкокристалічний (підсвічування білий LED)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "Широка палітра LCD (підсвічування CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "Широка палітра LCD (підсвічування RGB LED)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Висока"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 хвилин"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Середня"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 хвилин"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Низька"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 хвилин"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Рідний для показу"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (друкування й публікування)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (фотографії і графіки)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Стандартний простір"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Тестовий профіль"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Автоматично"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Низька якість"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Середня якість"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Висока якість"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "Типовий RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "Типовий CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Типовий сірий"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Виробник надав фабричні калібрувальні дані"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Повноекранний зв'язок неможливий з цим профілем"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Цей профіль може бути неточним"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Колір"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "Відкалібрувати кольори таких пристроїв, як екрани, камери і принтери"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Колір;ICC;Профіль;Калібрування;Принтер;Екран;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Інше…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Виберіть мову"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Вибрати"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Не знайдено мов"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Більше…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Розблокуйте, щоб змінити налаштування"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Перед внесенням змін слід розблокувати деякі налаштування."
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "Розблокувати…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Збільшити на годину"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Збільшити на хвилину"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Час"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Зменшити на годину"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Зменшити на хвилину"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "Сьогодні"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "Учора"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d година"
+msgstr[1] "%i години"
+msgstr[2] "%d годин"
+msgstr[3] "%d година"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d хвилина"
+msgstr[1] "%d хвилини"
+msgstr[2] "%d хвилин"
+msgstr[3] "%d хвилина"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d секунда"
+msgstr[1] "%d секунди"
+msgstr[2] "%d секунд"
+msgstr[3] "%d секунда"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 секунд"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Хот-спот"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-ох годинний"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "До / після полудня "
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%e %B %Y, %l:%M %p"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%e %B %Y, %R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Дата й час"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Рік"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Місяць"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Січень"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Лютий"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Березень"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Квітень"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Травень"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Червень"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Липень"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Серпень"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Вересень"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Жовтень"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Листопад"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Грудень"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "День"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Часовий пояс"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Пошук за містом"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Автоматичні _дата та час"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Потребує зв'язок з інтернетом"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "Дата й _час"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "Автоматичні часові _пояси"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+"Вимагає увімкнених служб даних місця перебування і доступу до інтернету"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "_Часовий пояс"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "_Формат часу"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Змінити дату та час, і часовий пояс зокрема"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Годинник;Пояс;Місцевість;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Змінити параметри системних часу і дати"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Щоб змінити параметри часу і дати, потрібно авторизуватись."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Інтернет"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Пошта"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Календар"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "М_узика"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "_Відеозаписи"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "_Фотографії"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Типові програми"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Налаштовування типових програм"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "типове;програма;бажане;носій;default;application;preferred;media;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Надсилання звітів про технічні проблеми допомагає нам покращити %s. Звіти "
+"надсилаються анонімно і не містять особистих даних. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Звітування про проблему"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "_Автоматичне звітування про проблеми"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Діагностика"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Повідомити про помилки"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;діагностика;аварія;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Увімкнено"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Вимкнено"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "Застосувати зміни?"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "Не вдалося застосувати зміни"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "Причиною можуть бути апаратні обмеження."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "_Застосувати"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Назад"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "Параметри дисплея вимкнено"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "Декілька дисплеїв"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "З'єднати"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "Відзеркалля"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "Містить верхню панель та меню «Діяльність»"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "Основний дисплей"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "Нічне світло"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Альбомна"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Портретна праворуч"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Портретна ліворуч"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Альбомна перевернута"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Гц"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Орієнтація"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Роздільна здатність"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "Частота оновлення"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "Підкоригувати для телебачення"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Масштаб"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "«Нічне світло» недоступне"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+"Це може бути результатом використаного драйвера до графічної картки або "
+"використання стільниці у віддаленому режимі"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Тимчасово вимкнено до завтра"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "Перезапустити фільтр"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Нічне світло робить колір екрана теплішим. Це дозволяє запобігти "
+"примружуванню очей і сонливості."
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "Розклад"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "Від заходу до світанку"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "Власний розклад"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Терміни"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "З"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "Година"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "Хвилина"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "AM"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "PM"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "По"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "Кольорова температура"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Дисплеї"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Змінити використання під'єднаних моніторів та проекторів"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Панель;Проектори;xrandr;Екран;Роздільність;Оновлення;Монітор;Нічне;Світло;"
+"Синій;redshift;колір;захід;світанок;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "Secure Boot є активним"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"Secure boot запобігає завантаженню програмного забезпечення зловмисників під "
+"час запуску пристрою. Зараз цей захист увімкнено, і він працює належним "
+"чином."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "Маємо проблеми із Secure Boot"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"Secure boot запобігає завантаженню програмного забезпечення зловмисників під "
+"час запуску пристрою. Зараз цей захист увімкнено, але він не працює через "
+"некоректний ключ."
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"Проблеми із Secure boot часто можна розв'язати за допомогою параметрів "
+"мікропрограми UEFI вашого комп'ютера (BIOS). Довідкові дані щодо цього може "
+"бути надано виробником обладнання."
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr ""
+"Довідкові дані можна отримати у виробника обладнання або надавача послуг з "
+"комп'ютерної підтримки."
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "Secure Boot вимкнено"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr ""
+"Secure boot запобігає завантаженню програмного забезпечення зловмисників під "
+"час запуску пристрою. Зараз цей захист вимкнено."
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"Secure boot часто можна увімкнути за допомогою параметрів мікропрограми UEFI "
+"вашого комп'ютера (BIOS). Довідкові дані можна отримати у виробника "
+"обладнання або надавача послуг з комп'ютерної підтримки."
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"Secure boot запобігає завантаженню програмного забезпечення зловмисників під "
+"час запуску пристрою.\n"
+"\n"
+"Докладніший його опис можна отримати від виробника обладнання або служби "
+"комп'ютерної підтримки."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "Пройдено"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "Не пройдено"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "Пристрій є сумісним із рівнем HSI %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "Рівень безпеки 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"Цей пристрій не захищено від апаратних проблем із безпекою. Причиною можуть "
+"бути проблеми із налаштуваннями апаратної частини або мікропрограми. "
+"Рекомендуємо повідомити про цю проблему службі надання гарантійної "
+"комп'ютерної підтримки."
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "Рівень безпеки 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"Цей пристрій має мінімальний захист від апаратних проблем із безпекою. Це "
+"найнижчий рівень захисту пристрою, який усуває лише прості загрози безпеці."
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "Рівень безпеки 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"Цей пристрій має базовий захист від апаратних проблем із безпекою. Цей "
+"рівень захисту надає захист від деяких типових загроз безпеці."
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "Рівень безпеки 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"Цей пристрій має розширений захист від апаратних проблем із безпекою. Це "
+"рівень захисту пристрою, який усуває деякі додаткові загрози безпеці."
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "Рівень безпеки"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "Для цього пристрою рівні безпеки є недоступними."
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr ""
+"Зверніться до виробника вашого обладнання за допомогою у розв'язанні проблем "
+"захисту."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr ""
+"Можливо, проблему можна розв'язати за допомогою параметрів мікропрограми "
+"UEFI або працівника служби підтримки."
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr ""
+"Можливо, проблему можна розв'язати за допомогою параметрів мікропрограми "
+"UEFI."
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr ""
+"Можливо, проблему можна розв'язати за допомогою працівника служби підтримки."
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "Рівень 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "Рівень 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "Рівень 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr ""
+"Захист від програмного забезпечення зловмисників під час запуску пристрою."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "Маємо проблеми із Secure Boot"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "Деякий захист, коли пристрій розпочав роботу."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "Secure Boot вимкнено"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "Без захисту, коли пристрій розпочав роботу."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"Цю проблему могло бути спричинено змінами у параметрах мікропрограми UEFI, "
+"налаштуваннях операційної системи або помилками у роботі програмного "
+"забезпечення у цій системі."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"Цю проблему могло бути спричинено змінами у параметрах мікропрограми UEFI "
+"або помилками у роботі програмного забезпечення у цій системі."
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"Цю проблему могло бути спричинено змінами у налаштуваннях операційної "
+"системи або помилками у роботі програмного забезпечення у цій системі."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "Відкритий щодо суттєвих загроз захисту."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "Обмежений захист від простих загроз."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "Захищено від поширених загроз."
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "Захищено від широкого діапазону загроз."
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "Всебічний захист"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "Немає подій"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "Захист від запису мікропрограми"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "Блокування захисту мікропрограми від запису"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "Регіон мікропрограми BIOS"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "Дескриптор мікропрограми BIOS"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "Захист DMA до завантаження"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Перевірене завантаження Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Захист ACM Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Правила щодо помилок Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Синтез Intel BootGuard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Увімкнено Intel CET"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET є активним"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "Шифрування RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "Захист IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Блокування ядра Linux"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Перевірка ядра Linux"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux swap"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "Сон зі збереженням до RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "Сон із переведенням до бездіяльності"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "Ключ платформи UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "Secure Boot UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "Налаштування платформи TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "Реконструкція TPM"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Режим виробника Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Перевизначення Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Версія Intel Management Engine"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "Оновлення мікропрограми"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "Засвідчення мікропрограми"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "Перевірка засобу оновлення мікропрограми"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "Діагностика платформи"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "Перевірки захисту процесора"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "Захист від повернення AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "Захист від відтворення мікропрограми AMD"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "Захист від запису мікропрограми AMD"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "Синтезована платформа"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "Чинний"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "Нечинний"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "Не увімкнено"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "Заблоковано"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "Не заблоковано"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "Зашифровано"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "Не зашифровано"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "Зіпсовано"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "Не зіпсовано"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "Знайдено"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "Не знайдено"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "Є підтримка"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "Немає підтримки"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "Безпека пристрою"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "Стан захисту мікропрограми основної системи"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"екран;блокування;діагностика;крах;особисте;нещодавнє;тимчасове;tmp;індекс;"
+"назва;мережа;засвідчення;конфіденційність;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Невідома"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64-бітова"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32-бітова"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Невідомо"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "Недоступний"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Логотип системи"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "Назва пристрою"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Модель обладнання"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Пам'ять"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Процесор"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Графіка"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Місткість диска"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Обчислення…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Назва ОС"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "Ідентифікатор збірки ОС"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "Тип ОС"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "Версія GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "Завантаження…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "Керування вікнами"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "Віртуалізація"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "Оновлення програм"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "Перейменувати пристрій"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Назва пристрою використовується для ідентифікації цього пристрою при "
+"перегляді у мережі або при прив'язуванні пристроїв Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "Назва пристрою"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "Перей_менувати"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Про систему"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Переглянути інформацію про вашу систему"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"пристрій;система;інформація;назва;вузол;пам'ять;процесор;версія;типово;"
+"програма;альтернативний;переважний;cd;dvd;usb;аудіо;звук;відео;диск;знімний;"
+"знімний;носій;автозапуск;device;system;information;hostname;memory;processor;"
+"version;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;"
+"media;autorun;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Звук та відео"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Вимикання/вмикання звуку"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Тихіше"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Гучніше"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Вимикання/вмикання мікрофона"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Запустити програвач"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Грати (або грати/зупинити)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Призупинити відтворення"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Зупинити відтворення"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Попередня доріжка"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Наступна доріжка"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Витягнути"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Набирання"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Перемкнутись до наступного джерела введення"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Перемкнутись до попереднього джерела введення"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Пускач"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Запустити переглядача довідки"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Запустити калькулятор"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Запустити поштовий клієнт"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Запустити переглядача тенет"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Домівка"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Пошук"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Система"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Вийти"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Заблокувати екран"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Доступність"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Вимкнути або ввімкнути масштаб"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Наблизити"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Віддалити"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Увімкнути або вимкнути читач екрана"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Увімкнути або вимкнути екранну клавіатуру"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Збільшити розмір тексту"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Зменшити розмір тексту"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Увімкнути або вимкнути високий контраст"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Не знайдено жодного джерела введення"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Інше"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Додати джерело введення"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "Способи введення неможливо використовувати у вікні входу"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Не вибрано жодного джерела введення"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Параметри"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "Перемістити вгору"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "Пересунути вниз"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "Параметри"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "Переглянути розкладку клавіатури"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "Вилучити"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Власне скорочення"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Клавіша альтернативних символів"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Клавіша альтернативних символів може використовуватися для уведення "
+"додаткових символів. Вони інколи зображені на кнопках клавіатури як третій "
+"варіант."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Ліва Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Права Alt"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Ліва Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Права Super"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Клавіша меню"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Права Ctrl"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Скомпонувати клавіші"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Клавіша компонування дозволяє вводити велику кількість символів Щоб "
+"скористатися нею, натисніть клавішу складання, а потім послідовність "
+"символів. Наприклад, якщо за клавішею складання йтиме <b>C</b> і <b>o</b> "
+"буде виведено <b>©</b>, натиснувши <b>a</b>, за яким слідує <b>'</b>, "
+"отримаємо <b>á</b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Джерела введення можна перемикати за допомогою клавіатурного скорочення %s.\n"
+"Змінити скорочення можна у параметрах клавіатурних скорочень."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Джерела введення"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Включно із розкладками клавіатури та способами введення."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Перемикання джерел введення"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Використовувати _однакові джерела для всіх вікон"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Перемикати джерела введення _окремо для кожного з вікон"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "Введення спеціальних символів"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "Способи введення символів та варіантів літер за допомогою клавіатури."
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Клавіатурні скорочення"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "Перегляд і налаштовування скорочень"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d змінене"
+msgstr[1] "%d змінених"
+msgstr[2] "%d змінених"
+msgstr[3] "%d змінене"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "Скинути всі скорочення?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Скидання скорочень може вплинути і на ваші власні скорочення. Це неможливо "
+"вернути."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "Скинути все"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Скинути все…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Скинути всі скорочення до їхніх типових значень"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Розділ"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "Скорочення"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "Додати скорочення"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "Додати нетипові скорочення"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+"Налаштувати нетипові клавіатурні скорочення для запуску програм, скриптів "
+"тощо."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "Додати скорочення"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "Не знайдено клавіатурного скорочення"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr ""
+"%s вже використовується для %s. Якщо застосувати, сполучення для %s буде "
+"вимкнено"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Уведіть нове скорочення"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Встановити своє скорочення"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Встановити скорочення"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Уведіть нове сполучення для зміни %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "Додати своє скорочення"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "Ви_лучити"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "За_мінити"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "_Встановити"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+"Натисніть Esc, щоб скасувати, або Backspace, щоб вимкнути комбінації клавіш."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Назва"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "Команда"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Скорочення"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "Вказати скорочення…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "Немає"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Повернути скороченню типове значення"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Клавіатура"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Змінити клавіатурні скорочення і вказати параметри введення, розкладки "
+"клавіатури та джерела введення даних"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Комбінація;Робоча область;Вікно;Зміна розміру;Масштаб;Контраст;Введення;"
+"Джерело;Блокування;Том;Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;"
+"Source;Lock;Volume;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "Служби даних місця перебування вимкнено"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "Немає програм, які здатні отримувати дані щодо місця перебування."
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Служба розташування дозволяє програмам дізнаватись ваше місце перебування. "
+"Точність даних буде вищою, якщо ввімкнути WiFi і мобільний зв'язок.\n"
+"\n"
+"Використано службу розташування Mozilla: <a href='https://location.services."
+"mozilla.com/privacy'>правила конфіденційності</a>\n"
+"\n"
+"Дозволити вказаним нижче програмам визначає ваше місце перебування."
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+"Немає програм, які б надсилали запит щодо доступу до даних щодо місця "
+"перебування"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Захистіть ваші дані щодо місця перебування"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+"location;gps;private;privacy;місце;перебування;конфіденційність;приватність;"
+"приватний"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "Мікрофон вимкнено"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "Немає програм, які можуть записувати звук."
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Використання мікрофона надає програмам змогу записувати та отримувати "
+"звукові дані. Вимикання мікрофона може призвести до неправильної роботи "
+"деяких програм.\n"
+"\n"
+"Програмам із наведеного нижче списку буде дозволено використовувати мікрофон."
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Немає програм, які б надсилали запит щодо доступу до мікрофона"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Захистіть ваш обмін повідомленнями"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"microphone;recording;application;privacy;мікрофон;запис;записування;програма;"
+"конфіденційність;приватність;приватний;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "Випробувати ваші _параметри"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Загальне"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Основна кнопка"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Вказує порядок фізичних кнопок на мишці чи сенсорних пристроях."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "Ліва"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "Права"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Миша"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Швидкість миші"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "Природне гортання"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "Гортання переміщує вміст, а не перегляд."
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "Сенсорний пристрій"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "Швидкість сенсору"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "Натиск для клацання"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "Натиск для клацання"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "Гортання двома пальцями"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "Гортання на краях"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Випробувати клацання, подвійне клацання, гортання"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "П'ять клацань, час для GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Подвійний клац, основна кнопка"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Одинарний клац, основна кнопка"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Подвійний клац, середня кнопка"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Одинарний клац, середня кнопка"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Подвійний клац, вторинна кнопка"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Одинарний клац, вторинна кнопка"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Миша та сенсорний пристрій"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "Змінити чутливість вашої миші та сенсорного пристрою і вибрати руку"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Сенсор;Вказівник;Клік;Стукіт;Подвійний;Кнопка;Кулька;Прокрутити;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Гарячий кут"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Торкніться верхнього лівого кута, щоб відкрити огляд «Діяльності»."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Активні краї екрана"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Перетягніть вікна до верхнього, лівого або правого країв екрана, щоб змінити "
+"їхній розмір."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Робочі простори"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Динамічні робочі простори"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Автоматично вилучає порожні робочі простори."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Фіксована кількість робочих просторів"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Вкажіть кількість сталих робочих просторів."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "_Кількість робочих просторів"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Декілька моніторів"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Робочі простори _лише на основному дисплеї"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Робочі простори на усіх д_исплеях"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Перемикання програм"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Включити програми з усіх _робочих просторів"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Включити лише програми з пото_чного робочого простору"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Багатозадачність"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Керування параметрами продуктивності та багатозадачності"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"багатозадачність;задача;завдання;продуктивність;налаштовування;налаштування;"
+"стільниця;активний кут;робочі простори;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Отакої, щось не так. Зв'яжіться з вашим постачальником програмних засобів."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Потрібно запустити NetworkManager."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Інші пристрої"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "Додати з'єднання"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "Не налаштовано"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "Незахищена мережа (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "Захищена мережа (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "Захищена мережа (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "Захищена мережа (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "Захищена мережа"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "З'єднано"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Параметри…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Увімкнення хот-споту, призведе до від'єднання від %s і неможливості доступу "
+"до інтернету за допомогою Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Має містити не менше 8 символів"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Має складатися з не більше за %d символу"
+msgstr[1] "Має складатися з не більше за %d символів"
+msgstr[2] "Має складатися з не більше за %d символів"
+msgstr[3] "Має складатися з не більше за %d символу"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Увімкнути точку доступу Wi-Fi?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Точка доступу Wi-Fi надає змогу іншим користувачам використовувати ваше "
+"інтернет-з'єднання, створюючи мережу Wi-Fi, до якої вони можуть "
+"під'єднуватися. Для цього у вас має бути під'єднання до інтернету за "
+"допомогою джерела, відмінного від Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Назва мережі"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "Пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "Створити випадковий пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "Автоматично створити пароль"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "_Увімкнути"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "Зупинити гарячу точку й від'єднати користувачів?"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "_Зупинити гарячу точку"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "Режим польоту"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Вимикає Wi-Fi, Bluetooth та мобільну широкосмугову мережу"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "Жодного адаптера Wi-Fi не знайдено"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Впевніться, що адаптер Wi-Fi приєднано та увімкнено"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "Режим польоту увімкнено"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "Вимкніть для використання Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Активна точка доступу Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+"На мобільних пристроях можна сканувати штрих-код для встановлення з'єднання."
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "Вимкнути точку доступу Wi-Fi…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "Видимі мережі"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "Має бути запущено NetworkManager"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_Безпека 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "Безпека"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Зберегти"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Постійна"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Випадкова"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Стабільна"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Введена тут МАС-адреса буде використовуватися як апаратна адреса для "
+"пристрою мережі, на якому активовано це з'єднання. Ця функція відома як "
+"клонування або підробка MAC-адреси. Приклад: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Профіль %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Немає"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "Ніколи"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i день тому"
+msgstr[1] "%i дні тому"
+msgstr[2] "%i днів тому"
+msgstr[3] "%i день тому"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Мб/с (%1.1f ГГц)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Мб/с"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 ГГц / 5 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 ГГц"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Немає"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Слабке"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Добре"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Непогане"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Відмінне"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Адреса IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Адреса IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Адреса IP"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "Забути з'єднання"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "Вилучити профіль з'єднання"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "Вилучити VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "Подробиці"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "автоматично"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Засвідчення"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "Вилучити адресу"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "Вилучити маршрут"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Немає"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "40/128 бітний ключ WEP (шістнадцяткова або ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "128-ох бітний пароль для WEP"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "Динамічний WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "Особистий WPA і WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "Комерційний WPA & WPA2"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "Особистий WPA3"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Потужність сигналу"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Швидкість сполучення"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Апаратна адреса"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Підтримувані частоти"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "Типовий маршрут"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Востаннє використано"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "З'єднуватись _автоматично"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Зробити доступним для _інших користувачів"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"З'єднання із об_ліком: мають обмеження на об'єм даних або обліковуються за "
+"тарифним планом"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Оновлення програмного забезпечення та отримання інших великих обсягів даних "
+"не виконуватиметься автоматично."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "_Назва"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Адреса _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "_Клонована адреса"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "байтів"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Метод IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Автоматично (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Лише місцевий"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "Вручну"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Вимкнути"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Спільне разом з іншими комп'ютерами"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Адреси"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Адреса"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "Маска"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "Автоматично"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "Автоматичний DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "Адреси серверів DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "IP-адреси слід відокремлювати комами"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "Маршрути"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "Автоматичні маршрути"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "Метрична"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "Використовувати цей зв'язок _тільки для ресурсів на її мережі"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Метод IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Автоматично, лише DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "Префікс"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Не вдалося відкрити редактор з'єднань"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Створити профіль"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "Некоректний параметр %s: %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "Некоректний параметр %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "Імпортувати з файла…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "Додати VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_Захист"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Не вдалось імпортувати з'єднання з VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Файл «%s» неможливо прочитати або він містить невідому інформацію про "
+"з'єднання з VPN\n"
+"\n"
+"Помилка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Виберіть файл для імпортування"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Файл з назвою «%s» уже існує."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Замінити"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Бажаєте замінити %s на з'єднання з VPN, яке ви зберігаєте?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Неможливо експортувати з'єднання з VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"З'єднання з VPN «%s» неможливо експортувати в %s.\n"
+"\n"
+"Помилка: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Експортувати з'єднання з VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Помилка: неможливо завантажити редактор з'єднань з VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Вказати яким способом з'єднуватись з інтернетом"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr "Мережа;IP;LAN;Проксі;WAN;Broadband;Модем;Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Керування способами з'єднання із мережами Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr "Мережа;Бездротова;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "ніколи"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "сьогодні"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "вчора"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Востаннє використано"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Дротовий"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Додати нове з'єднання"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Подробиці мережі для вибраної мережі, зокрема паролі та інші параметри буде "
+"втрачено."
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "_Забути"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "Відомі мережі Wi-Fi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Забути"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "Системна політика забороняє використовувати комп'ютер як гарячу точку"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Бездротовий пристрій не підтримує режиму гарячої точки"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr ""
+"Коли URL налаштувань не надається, використовується автоматичне виявлення "
+"проксі. "
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Це не рекомендовано для ненадійних прилюдних мереж."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Вимкнути пристрій"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "Активний"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Провайдер"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Проксі-сервер мережі"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "П_роксі HTTP"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "П_роксі HTTP"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "Пр_оксі FTP"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "_Вузол Socks:"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "_Знехтувати вузлом"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "Порт проксі HTTP"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "Порт проксі HTTPS"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "Порт проксі FTP"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Порт проксі SOCKS"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "_Налаштування URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Розірвати з'єднання з VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Назва мережі"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Тип захисту"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Пароль"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Вимкнути Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "Додаткові параметри…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "_З'єднатись з прихованою мережею…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Увімкнути точку доступу Wi-Fi…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "_Відомі мережі Wi-Fi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Стан невідомий"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Некерований"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Недоступний"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "З'єднання"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Слід пройти розпізнавання"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Від'єднання"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Не вдалось з'єднатись"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Стан невідомий (немає)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Не вдалося налаштувати"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Не вдалося налаштувати IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Налаштування IP застаріли"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Таємниці є обов'язковими, проте їх не надано"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "Шукача 802.1x від'єднано"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Не вдалося налаштувати шукач 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Помилка шукача 802.1x"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "Шукач 802.1x забрав надто багато часу для автентифікації "
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Не вдалося запустити службу PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Службу PPP від'єднано"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "Помилка PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Не вдалося запустити клієнт DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Помилка клієнта DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Помилка роботи клієнта DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Не вдалося запустити службу спільного з'єднання"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Помилка роботи служби спільного з'єднання"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Не вдалося запустити службу AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Помилка служби AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Помилка роботи служби AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Лінію зайнято"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Немає гудка"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Неможливо встановити жодного носія"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Час очікування набирання збіг"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Не вдала спроба набирання номеру"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Не вдалося запустити модем"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Не вдалось вибрати вказаний APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Немає пошуку мереж"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Реєстрацію мережі заборонено"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Час реєстрації мережі вичерпано "
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Не вдалось зареєструватись з мережею"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Не вдалось перевірити PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Може бракувати мікропрограми для пристрою"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "З'єднання зникло"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Наявне з'єднання вигадано"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Не знайдено модему"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Не вдалось з'єднатись з Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Не вставлено картки SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Потрібно SIM Pin"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Потрібно SIM Puk"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "Неправильний SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Помилка роботи залежності з'єднання"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Бракує мікропрограми"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Кабель від'єднано"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "невідома помилка у захисті 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "не вибрано жодного файла"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "Невизначена помилка завірення файла з методом eap"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "Закриті ключі DER, PEM, PKCS#12 або PGP"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "Сертифікати DER або PEM"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "Бракує файла EAP-FAST PAC"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Файли PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Анонімно"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Розпізнано"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Обидва"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "_Анонімне засвідчення"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "_Файл PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Виберіть файл PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Вн_утрішнє засвідчення"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Дозволити автоматичне за_готовлення PAC"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "бракує користувача EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "бракує паролю EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Користувач"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "_Пароль"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "П_оказати пароль"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "неправильний сертифікат ЦС EAP-PEAP: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "Неправильний сертифікат ЦС EAP-PEAP: не вказано сертифікату"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Версія 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Версія 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Сертифікат _ЦС"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Виберіть сертифікат видавця"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "Не _вимагається сертифікату ЦС"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "Ве_рсія PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "бракує користувача EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "бракує паролю EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "бракує ототожнення EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "неправильний сертифікат ЦС EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "Неправильний сертифікат ЦА EAP-TLS: не вказано сертифікату"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "неправильний закритий ключ EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "неправильний сертифікат користувача EAP-TLS: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Небезпечно використовувати секретні ключі без шифрування"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Схоже, що обраний закритий ключ не захищено паролем. Це може призвести до "
+"компрометації ваших облікових даних. Будь ласка, виберіть закритий ключ, "
+"захищений паролем.\n"
+"\n"
+"(Ви можете захистити закритий ключ за допомогою openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Виберіть ваш особистий сертифікат"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Виберіть ваш особистий ключ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "За_свідчення"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Сертифікат _користувача"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "Закритий _ключ"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Пароль _закритого ключа"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "неправильний сертифікат ЦС EAP-TTLS: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "неправильний сертифікат ЦА EAP-TTLS: не вказано сертифікату"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (без EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Домен"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Невідома помилка перевірки безпеки 802.1x"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "Тунельований TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "Захищений EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "За_свідчення"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Виберіть файл"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "бракує користувача LEAP"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "бракує паролю LEAP"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Бракує пароля Wi-Fi."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Тип"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "бракує ключа WEP"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"неправильний ключ WEP: ключ з довжиною %zu мусить містити тільки "
+"шістнадцяткові значення"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"неправильний ключ WEP: ключ з довжиною %zu мусить містити тільки символи "
+"ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"неправильний ключ WEP: хибний довжина ключа %zu. Ключ має бути: або довжина "
+"5/13 (ascii), або 10/26 (шістнадцятковий)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "неправильний ключ WEP: пароль не може бути порожній"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "неправильний ключ WEP: пароль не може перевищувати 64 символи"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (типово)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Відкрити систему"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Спільний ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "П_оказати ключ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "_Індекс WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"неправильний ключ PSK: неправильна довжина ключа %zu. Має бути [8,63] біти "
+"або 64 шістнадцяткових значення"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"неправильний WPA-PSK: неможливо означити ключ з 64 шістнадцятковими бітами"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Сповіщення"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Звукові _сигнали"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Поява сповіщення"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Сповіщення будуть накопичуватись у переліку сповіщень і після їхньої появи."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Показувати в_міст повідомлень"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Сповіщення на за_блокованому екрані"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Показувати в_міст повідомлення в заблокованому екрані"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "_Не турбувати"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Сповіщення на за_блокованому екрані"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Вказує які сповіщення показуються і що вони показують"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Сповіщення;Шапка;Повідомлення;Лоток;Контекстний;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Інше"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s вилучений"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "Помилка вилучення облікового запису"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "Повернути"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "Закрити сповіщення"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "З'єднати ваші дані з хмарою"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Немає інтернету — з'єднайтеся з мережею, щоб створювати облікові записи"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "Додати обліковий запис"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Обліковий запис %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Вилучити обліковий запис"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Облікові записи в інтернеті"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"З'єднатись з вашим мережевими обліковими записами і вирішити, що з ними "
+"робити "
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Інтернет;Мережа;Балачка;Календар;Пошта;Контакт;"
+"ownCloud;IMAP;SMTP;Pocket;ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Час невідомий"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i хвилина"
+msgstr[1] "%i хвилини"
+msgstr[2] "%i хвилин"
+msgstr[3] "%i хвилина"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i година"
+msgstr[1] "%i години"
+msgstr[2] "%i годин"
+msgstr[3] "%i година"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "година"
+msgstr[1] "години"
+msgstr[2] "годин"
+msgstr[3] "година"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "хвилина"
+msgstr[1] "хвилини"
+msgstr[2] "хвилин"
+msgstr[3] "хвилина"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s до повного зарядження"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Обережно: залишилось %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "Залишилось %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Повністю заряджено"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Не заряджається"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Вичерпано"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Заряджання"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Розряджається"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Бездротова миша"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Бездротова клавіатура"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Постачання безперебійного живлення"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Особистий цифровий помічник"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Мобільний телефон"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Програвач"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Планшет"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Комп'ютер"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Ігровий пристрій введення"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Батарея"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Основна"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Додаткова"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Батареї"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "Коли _бездіяльний"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "Призупинити"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "Вимкнути"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "Приспати"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "Нічого"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "Коли живлення від батареї"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "Коли під'єднано"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Ніколи"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "Автоматично призупиняти роботу"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr ""
+"Режим підвищеної швидкодії тимчасово вимкнено через високу операційну "
+"температуру."
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Виявлено розташування на нетривкій поверхні: режим високої швидкодії "
+"тимчасово недоступний. Перенесіть пристрій на стабільну поверхню, щоб "
+"відновити доступ."
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "Режим підвищеної швидкодії тимчасово вимкнено."
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Низький рівень заряду акумулятора: увімкнено заощадження енергії. Попередній "
+"режим буде відновлено за достатнього рівня заряду акумулятора."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Режим заощадження енергії активовано «%s»."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Режим високої швидкодії активовано «%s»."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 хвилин"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 хвилин"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 хвилин"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 хвилин"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 хвилин"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 година"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 хвилин"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 хвилин"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 хвилин"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 години"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Режим живлення"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Впливає на швидкодію системи та споживання енергії."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Параметри заощадження енергії"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Автоматична яскравість екрана"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Яскравість екрана коригується за зовнішнім освітленням."
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "Притлумлення екрана"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "Зменшує яскравість екрана, якщо комп'ютер є бездіяльним."
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "В_имикання екрана"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+"Вимикає екран, якщо комп'ютер є неактивним протягом певного періоду часу."
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "Автоматичне заощадження енергії"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+"Вмикає режим заощадження енергії при низькому рівні заряду акумулятора."
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "_Автоматично призупиняти"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+"Призупиняє роботу комп'ютера, якщо той є неактивним протягом певного періоду "
+"часу."
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "Поведінка _кнопки живлення"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "Показувати _відсоток заряду акумулятора"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "Автоматично призупиняти"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "_Під'єднано"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "Живлення від _батареї"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "Затримка"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Швидкодія"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Висока швидкодія та споживання енергії."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Баланс"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Стандартна швидкодія та споживання енергії."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Заощадження"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Знижена швидкодія та споживання енергії."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Живлення"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Переглянути стан вашої батареї і змінити параметри заощадження енергії"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Живлення;Сон;Призупинити;Приспати;Батарея;Яскравість;Затемнення;Порожній;"
+"DPMS;Бездіяльність;живлення;енергія;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Принтер «%s» було успішно вилучено"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "Не вдалось додати принтер."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Не вдалось завантажити інтерфейс: %s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Розблокуйте, щоб додати принтери і змінити налаштування"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Принтери"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Додати принтер, переглянути завдання і визначити, яким способом друкувати"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Принтер;Черга;Друк;Папір;Чорнило;Тонер;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Додати принтер"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Розблокувати"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "Не знайдено жодного принтера"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "Уведіть адресу мережі або знайдіть принтер"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "Потрібно засвідчитись"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+"Введіть користувача та пароль, щоб переглянути доступні принтери на сервері."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "Користувач"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "Подробиці про %s "
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "Не знайдено придатного драйвера"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "Виберіть файл PPD"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Файли опису принтера PostScript (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "Назви принтерів не можуть містити пробілів, табуляцій, # або /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "Адреса"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Драйвер"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "Пошук бажаних драйверів…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "Шукати драйвери"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "Вибрати з бази даних…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "Встановити файл PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Вибрати драйвер принтера"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Завантаження бази даних драйверів…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Вибрати"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Принтер JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Принтер LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Односторонній"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Впродовж довгої сторони (типово)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Впродовж короткої сторони"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Книжкова"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Альбомна"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Зворотна альбомна"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Зворотна книжкова"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "Відновити"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "Призупинити"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "Очікування"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "Призупинено"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Слід пройти розпізнавання"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "Оброблення"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Зупинено"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Скасовано"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Припинено"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "Завершено"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "Пересунути це завдання на вершину черги"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "Для %u завдання слід пройти розпізнавання"
+msgstr[1] "Для %u завдань слід пройти розпізнавання"
+msgstr[2] "Для %u завдань слід пройти розпізнавання"
+msgstr[3] "Для %u завдання слід пройти розпізнавання"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — запущені завдання"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Для друку з %s введіть реєстраційні дані."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Домен"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "За_свідчення"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "Очистити все"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Автентифікація"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "Немає робочих завдань для принтерів"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Розблокувати сервер друкування"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Розблокувати %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr ""
+"Введіть користувача та пароль, щоб переглянути доступні принтери на %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Шукати принтери"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Послідовний порт"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Паралельний порт"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Розміщення: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Адреса: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Сервер потребує засвідчення"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Двосторонній"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Тип паперу"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Джерело паперу"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Лоток виводу"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Роздільна здатність"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Попередня відсіювання GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Сторінок на сторону"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Двобічний"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Орієнтація"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Загальне"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Параметри сторінки"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Змінні параметри"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Завдання"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Якість зображення"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Колір"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Завершення"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Додатково"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Тестова сторінка"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Тестова сторінка"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Автоматичне вибрати"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Типове для принтера"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Вбудовувати лише шрифти GhostScript"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Перетворити у PS 1-го рівня"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Перетворити у PS 2-го рівня"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Без попереднього відсіювання"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Виробник"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Немає запущених завдань"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u завдання"
+msgstr[1] "%u завдання"
+msgstr[2] "%u завдань"
+msgstr[3] "%u завдання"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Очищення головок принтера"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Закінчується тонер"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Вичерпався тонер"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Закінчується проявник"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Вичерпався проявник"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Закінчується фарба"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Вичерпано фарбу"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Відкрита кришка"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Відкриті двері"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Закінчується папір"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Вичерпано папір"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Вимкнено"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Зупинено"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Майже повністю витрачено запас"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Повністю витрачено запас"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Оптичний фотопровідник близький до виходу з ладу"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Оптичний фотопровідник вийшов з ладу"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Готовий"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Завдання не прийнято"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Оброблення"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Параметри друкування"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Подробиці про принтер"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Використовувати як типовий принтер"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Очистити друкарські голівки"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Вилучити принтер"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Модель"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "Рівень чорнила"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "Перезапустіть, коли проблему буде виправлено."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "Перезапустити"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "Додати принтер…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "Немає принтерів"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Вибачте! Загальносистемна служба друкування,\n"
+"     здається, недоступна."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Формати"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Пошук локалей…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "Загальні формати"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "Всі формати"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "Нічого не знайдено"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "Пошук може бути виконано за країнами або мовами."
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "Перегляд"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Імперська"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Метрична"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Дати"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Дата та час"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Числа"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Вимірювання"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Папір"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Мову і формат буде змінено під час наступного входу до системи"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Вихід…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Параметр мови використовується для тексту інтерфейсу та сторінок інтернету. "
+"Формати буде використано для чисел, дат і валют."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Ваш обліковий запис"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "_Мова"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "_Формати"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Вікно входу"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Регіон та мова"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Вибрати мову і формати показу даних"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Мова;Розкладка;Клавіатура;Введення;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Питати, що робити"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Нічого не робити"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Відкрити теку"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Інший носій"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Вибрати програму для звукових CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Вибрати програму для відео DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Вибрати програму для запуску, коли музичний програвач під'єднано"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Вибрати програму для запуску, коли камеру під'єднано"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Вибрати програму для програмного CD"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "audio DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "blank Blu-ray disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "blank CD disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "blank DVD disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "blank HD DVD disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Blu-ray video disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "e-book reader"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD video disc"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "Picture CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "Super Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "Video CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Програми Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Виберіть, як варто опрацьовувати носій"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "_Аудіо CD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_Відео DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Музичний програвач"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Програми"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Інший носій…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "_Ніколи не питати про запуск програм при вставленні носія"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Виберіть, як варто опрацьовувати інші носії"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Дія:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Тип:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Змінний носій"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Налаштування параметрів портативних носіїв даних"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"пристрій;система;типове;програма;бажане;cd;dvd;usb;аудіо;відео;диск;знімний;"
+"носій;автозапуск;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Екран вимикається"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 секунд"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 хвилина"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 хвилини"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 хвилини"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 хвилин"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 хвилин"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 година"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 хвилина"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 хвилини"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 хвилини"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 хвилини"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 хвилин"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 хвилин"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 хвилин"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 хвилин"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 хвилин"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Ніколи"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Блокування екрана"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Автоматичне блокування екрана запобігає доступу інших користувачів до "
+"комп'ютера, поки вас немає."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Затримка вимкнення екрана"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Період бездіяльності, після якого екран вимкнеться."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "Автоматично _блокувати екран"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "Затримка _автоматичного блокування екрана"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Затримка автоматичного блокування після вимикання екрана."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Показувати с_повіщення на екрані блокування"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "Заборонити _нові пристрої USB"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+"Заборонити новим пристроям USB взаємодіяти із системою, коли екран "
+"заблоковано."
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "Конфіденційність екрана"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "Обмеження кута видимості"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "Параметри екрана"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+"screen;lock;private;privacy;екран;блокування;конфіденційність;приватність;"
+"приватний;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "Вибрати регіон"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "_Гаразд"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Місця пошуку"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Теки, у яких виконуватимуть пошук загальносистемні програмами, наприклад, "
+"«Файли», «Фото» і «Відео»."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Місця"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "Закладки"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Інші"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "Додати місце"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Не знайдено жодної програми"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Пошук за допомогою програм"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Включити надані програмами результати пошуку."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Теки, у яких виконуватимуть пошук загальносистемні програми."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Результати пошуку"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Результати показано відповідно до порядку у списку."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Вказує, які програми показувати у результатах пошуку в огляді діяльності"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Пошук;Знайти;Індекс;Сховати;Конфіденційність;Результати;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "Немає жодної вибраної мережі для оприлюднення"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Мережі"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Увімкнено"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Вимкнено"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "Активний"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "Вибрати теку"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Додати"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "Увімкнути оприлюднення матеріалів"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Спільний доступ до файлів надає вам змогу спільного використовувати вашу "
+"теку із іншими користувачами вашої поточної мережі за допомогою: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Якщо дистанційний доступ увімкнено, віддалені користувачі можуть "
+"під'єднуватися за допомогою команди SSH:\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "Увімкнути оприлюднення особистих матеріалів"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "Скопійовано назву пристрою"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "Скопійовано адресу пристрою"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "Ім'я користувача скопійовано"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "Пароль скопійовано"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Оприлюднення"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Назва _комп'ютера"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "_Оприлюднення файлів"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Віддалена с_тільниця"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Оприлюднення _матеріалів"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Віддалений в_хід"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Оприлюднення файлів"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "Вимагати па_роль"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Віддалений вхід"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "Віддалена стільниця"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"За допомогою інструментів віддаленої стільниці можна переглядати і керувати "
+"вашою стільницею з іншого комп'ютера."
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+"Увімкнути або вимкнути віддалені з'єднання зі стільницею на цьому комп'ютері."
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "Дистанційне керування"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "Уможливлює керування екраном за допомогою віддалених з'єднань."
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "Як з'єднатися"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"З'єднатися з цим комп'ютером на основі назви пристрою та адреси віддаленої "
+"стільниці."
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Копіювати"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "Адреса віддаленої стільниці"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "Розпізнавання"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+"Для встановлення з'єднання із цим комп'ютером потрібне ім'я користувача і "
+"пароль."
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "Користувач"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "Перевірити шифрування"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Відбиток шифрування"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+"Відбиток шифрування можна переглянути у клієнтах з'єднання — він має бути "
+"таким самим."
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Оприлюднення матеріалів"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Ділитись музикою, світлинами та відеозаписами через мережу."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Теки"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "Вказує, чим ви бажаєте поділитись з іншими"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"спільне;оприлюднення;ssh;вузол;назва;віддалений;стільниця;носій;аудіо;відео;"
+"малюнок;фотографії;фільми;сервер;відтворення;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Увімкнути або вимкнути віддалений вхід"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Потрібно засвідчення, щоб увімкнути або вимкнути віддалений вхід"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "Свій"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "Клацання"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "Струна"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "Свінг"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "Гудіння"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Баланс"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Згасання"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "Задній"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "Передній"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Тестування %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Натисніть на гучномовці для перевірки"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Гучність системи"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "Головна гучність"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "Рівні гучності"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "Вивід"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "Пристрій відтворення"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Випробувати"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "Конфігурація"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "Низькочастотний динамік"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "Вхід"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "Пристрій введення"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Гучність"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "Звук попередження"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "Вимкнути звук"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Звук"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Змінити рівень звуку"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Карта;Мікрофон;Гучність;Згасання;Баланс;Bluetooth;Гарнітура;Аудіо;Вивід;Ввід;"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Від'єднано"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "З'єднання"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "З'єднано"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Помилка авторизації"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Авторизація"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Обмежена функціональність"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "З'єднано та авторизовано"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Невідомо"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Авторизовано як:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "З'єднано на:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Зареєстровано на:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Не вдалося авторизувати пристрій: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Не вдалося забути пристрій: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Залежить від %u іншого пристрою"
+msgstr[1] "Залежить від %u інших пристроїв"
+msgstr[2] "Залежить від %u інших пристроїв"
+msgstr[3] "Залежить від %u іншого пристрою"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "Закрити сповіщення"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Назва:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "Стан:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "Авторизація та з'єднання"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "Забути про пристрій"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Помилка"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Авторизовано"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Підсистема Thunderbolt (boltd) не встановлена і не налаштована належним "
+"чином."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Дозволити безпосередній доступ до таких пристроїв, як зарядні станції та "
+"зовнішні графічні процесори."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Можна приєднати лише пристрої USB та Display Port."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Не вдалося виявити Thunderbolt. \n"
+"Або у системі немає підтримки Thunderbolt, або вона була вимкнена в BIOS чи "
+"заданий непідтримуваний рівень захисту в BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Підтримку Thunderbolt було вимкнено у BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Не вдається визначити рівень безпеки Thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Помилка перемикання безпосереднього режиму: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Немає підтримки Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Не вдалося встановити з'єднання із підсистемою thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Безпосередній доступ"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "Пристрої в очікуванні"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "Немає приєднаних пристроїв"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Керування пристроями Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;тандерболт;конфіденційність;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Блимання курсора"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "Курсор _блимає у полях вводу тексту."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "Швидкість"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "Швидкість блимання курсору"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Розмір курсора"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Розмір курсора може бути об'єднаний з масштабуванням, щоб він був помітніший."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Асистент з натискання"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "_Імітація клацання другою кнопкою"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Увімкнути подвійне клацання при утриманні натисненою основної кнопки"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "_Допустима затримка:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Коротка"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Затримка другого натискання"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Довга"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Клацання під час н_аведення"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Увімкнути клацання при зупинці вказівника миші"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "За_тримка:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Коротка"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Довга"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "_Поріг руху:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Маленький"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Великий"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Повторення клавіш"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "Клавіша натискається повторно, якщо утримувати її. "
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "Затримка повторення клавіш"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "Швидкість повтору клавіш"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Асистент з набирання"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "_Липкі клавіші"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Обробляє послідовність клавіш-модифікаторів як комбінації"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Вимкнено, якщо дві клавіші натиснуто одночасно"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Подавати сигнал, коли _модифікатор натиснуто"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "_Повільні клавіші"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Вказує затримку між натиском і прийняттям клавіші"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Коротка"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Показувати затримку натискання клавіш"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Довга"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Подавати сигнал, коли клавішу на_тиснуто"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Гудок, коли клавішу при_йнято"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Подавати сигнал, коли клавішу в_ідпущено"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "П_ружні клавіші"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ігнорувати швидкі повторні натискання клавіш"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Коротко"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Затримка натиснення пружних клавіш"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Довго"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "_Увімкнути клавіатурою"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Вмикати і вимикати можливості доступності через клавіатуру"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Типовий"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Середній"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Великий"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Більший"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Найбільший"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d піксель"
+msgstr[1] "%d пікселі"
+msgstr[2] "%d пікселів"
+msgstr[3] "%d піксель"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Завжди показувати меню доступності"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Бачення"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "_Висока контрастність"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Ве_ликий текст"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Увімкнути _анімацію"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "З_читувач екрана"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Зчитувач екрана читає показаний текст у міру пересування фокусу."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Зв_укові клавіші"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Подавати гудок, коли перемикається Num Lock або Caps Lock."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "Розмір к_урсора"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Масштаб"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Слухання"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "В_ізуальні попередження"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Екранна _клавіатура"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "Пов_торення клавіш"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "_Блимання курсора"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "Асистент з _набирання (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Вказування та натискання"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Кнопки ми_ші"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "_Знаходити вказівник миші"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "Асистент з на_тискання"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Затримка п_одвійного клацання"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Затримка подвійного клацання"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Візуальне попередження"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Ви_пробувати спалах"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Використовувати візуальний індикатор, коли виникає звук попередження."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Блимання всього _екрана"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Блимати усім _вікном"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Короткий"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ екрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ екрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ екрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Довгий"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "На весь екран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Верхня половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Нижня половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Ліва половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Права половина"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Параметри масштабу"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Збільшення:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Позиція лупи:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "_Слідкувати за курсором миші"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Частина _екрана:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Лупа _розтягує за межі екрана"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Утримувати курсор лупи в центрі"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Курсор лупи від_штовхує вміст довкола"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Курсор лупи рухається зі _вмістом"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Лупа"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Перехрестя:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "_Перекриває курсор миші"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "_Товщина:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Тонка"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Товста"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "_Довжина:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "_Колір:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Перехрестя"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Ефекти кольорів:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "_Білий по чорному:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "_Яскравість:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "_Контрастність:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "_Колір"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Немає"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Повний"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Низький"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Високий"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Низька"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Висока"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Ефекти кольорів"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Полегшує читання, слухання, набирання, наведення і натискання"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Клавіатура;Миша;Доступність;Універсальний доступ;Контраст;Курсор;Звук;"
+"Масштаб;Екран;Читач;розмір;висота;великий;текст;шрифт;Доступ;Липкі;Клавіші;"
+"Повільно;Клацання;Подвійний;клік;Затримка;Швидкість;Допомога;Повторити;Blink;"
+"візуальний;слух;аудіо;введення;анімації;Keyboard;Mouse;a11y;Accessibility;"
+"Universal Access;Contrast;Cursor;Sound;Zoom;Screen;Reader;big;high;large;"
+"text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;"
+"Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;animations;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 година"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 день"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 дні"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 дні"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 дні"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 днів"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 днів"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 днів"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 днів"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 днів"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Очистити всі елементи зі смітника?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Якщо вилучити елементи в смітнику, їх буде вилучено безповоротно."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "С_порожнити смітник"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Вилучити усі тимчасові файли?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Усі тимчасові файли буде безповоротно вилучено."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "П_очистити тимчасові файли"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 день"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 днів"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 днів"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Завжди"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Журнал файлів"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"У журналі роботи з файлами обліковуються файли, якими ви користувалися. Ця "
+"відомості є спільними для усіх програм. Вони полегшують пошук файлів, які "
+"можуть вам знадобитися."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Журнал _файлів"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Тривалість _журналу файлів"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "О_чистити журнал…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Смітник та тимчасові файли"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Смітник та тимчасові файли можуть інколи містити особисту або конфіденційну "
+"інформацію. Автоматичне вилучення цих файлів може допомогти захистити "
+"конфіденційність."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Автоматично очищувати _смітник"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Автоматично вилучати тимчасові _файли"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "Інтервал _автоматичного вилучення"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "С_порожнити смітник…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Вилучити тимчасові файли…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Журнал файлів та смітник"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Не залишати слідів"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"користування;нещодавні;недавні;журнал;файли;тимчасовий;приватний;"
+"конфіденційність;приватність;смітник;кошик;витерти;витирання;збереження;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Мусить збігатись з адресою вашого постачальника."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Не вдалось додати обліковий запис"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Паролі не збігаються."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Не вдалося зареєструвати обліковий запис"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Непідтримуваний спосіб автентифікації з цим доменом"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Не вдалось долучитись до домену"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Цей користувач не спрацював.\n"
+"Спробуйте ще."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Цей пароль не спрацював.\n"
+"Спробуйте ще."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Не вдалось увійти до домену"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Не вдалося знайти домен. Можливо, ви неправильно це написали?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Додати користувача"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Адміністратор"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Адміністратори можуть додавати або вилучати інших користувачів, а також "
+"змінювати параметри для усіх користувачів. Батьківський контроль не може "
+"бути застосовано до адміністраторів."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Користувач встановлює пароль при першому вході"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Вкажіть пароль зараз"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Підтвердити"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Комерційний вхід"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+"Облікові записи користувачів, які керуються компанією або організацією."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "Ви поза мережею"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Комерційний вхід дозволяє наявним обліковим записам централізовано "
+"використовуватись на цьому пристрою. Можете також використовувати цей "
+"обліковий запис для доступу ресурсів компанії через інтернет."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Огляд інших зображень"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Вибрати файл…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Керування відбитками"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Відбиток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "_Ні"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "_Так"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Вилучити зареєстровані відбитки пальців та заборонити вхід через відбитки?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "Немає пристроїв для зчитування відбитків"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "Немає пристроїв для зчитування відбитків"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "Переконайтеся, що пристрій з'єднано належним чином."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "Пристрій для зчитування відбитків"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Виберіть пристрій для читання відбитків, який ви хочете налаштувати"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "Вхід за відбитком пальця"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Вхід за допомогою відбитка пальця надасть вам змогу розблоковувати систему і "
+"входити до вашого облікового запису за допомогою вашого пальця"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "В_илучити відбитки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "Реєстрація відбитка"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "для виконання цієї дії пристрій має бути зарезервовано"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "пристрій вже зарезервовано іншим процесом"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "у вас немає прав доступу для виконання цієї дії"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "ролі не було надано жодному відбитку"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Не вдалося виконати обмін даними з пристроєм під час надання ролей"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Не вдалося виконати обмін даних із засобом читання відбитків"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Не вдалося виконати обмін даних із фоновою службою відбитків"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Не вдалося побудувати список відбитків: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Не вдалося вилучити збережені відбитки пальців: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "Великий палець лівої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "Середній палець лівої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "Вказівний палець _лівої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "Безіменний палець лівої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "Мізинець лівої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "Великий палець правої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "Середній палець правої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "Вказівний палець _правої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "Безіменний палець правої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "Мізинець палець правої руки"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "Невідомий палець"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Завершено"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "Пристрій для зчитування відбитків від'єднано"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "Сховище даних пристрою зчитування відбитків переповнено"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "Не вдалося зареєструвати новий відбиток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Не вдалося розпочати реєстрацію: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Не вдалося зареєструвати новий відбиток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Не вдалося зупинити реєстрацію: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Знімайте і притискайте ваш палець до пристрою зчитування, щоб зареєструвати "
+"відбиток пальця"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "П_еревизначити цей палець…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "Сканувати новий відбиток"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Не вдалося звільнити пристрій зчитування відбитків %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Проблема з читанням з пристрою"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Не вдалося зайняти пристрій зчитування відбитків %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Не вдалося отримати список пристроїв для зчитування відбитків: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Цього тижня"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Минулого тижня"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Сеанс завершено"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Сеанс розпочато"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — Діяльність облікового запису"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "Назад"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "Далі"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "Будь ласка, виберіть інший пароль."
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "Будь ласка, введіть поточний пароль ще раз."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "Пароль неможливо змінити"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Змінити пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "З_мінити"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "Поточний пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "Новий пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "Підтвердити пароль"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "Дозволяє користувачу змінювати пароль під час наступного входу"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "Вкажіть пароль зараз"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Неможливо автоматично долучити цей тип домену"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Нема такого домену чи області"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Неможливо ввійти як %s на домен %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Неправильний пароль, спробуйте ще раз"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Неможливо з'єднатися із доменом %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "Помилка при вилученні користувача"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "Не вдалось відкликати віддаленого користувача"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "Неможливо вилучити власний обліковий запис."
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s досі у системі"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr ""
+"Вилучивши користувача, коли він у системі, змусить його покинути систему в "
+"нестійкому стані."
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Зберегти файли користувача %s?"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Можна утримати домашній каталог, поштову скриньку та тимчасові файли, коли "
+"обліковий запис користувача буде вилучатись."
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "В_илучити файли"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "З_берегти файли"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Відкликати віддалено запущеного користувача на обліковому записі %s?"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "В_илучити"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Обліковий запис вимкнено"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Буде встановлено при наступному вході"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "Немає"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "Увійшов"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "Не вдалось зв'язатись зі службою облікових записів"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Будь ласка, переконайтесь, що AccountService встановлено та ввімкнено."
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "Цю панель має бути розблоковано для зміни цього параметра"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "Вилучити вибраний обліковий запис користувача"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Щоб вилучити вибраний обліковий запис користувача,\n"
+"натисніть спочатку на піктограму *"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Розблокуйте, щоб додати користувачів і змінити налаштування"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Користувачі"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "Щоб зміни набрали чинності, потрібно перезапустити ваш сеанс"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "Перезапустити зараз"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Закрити"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "Редагувати аватар"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "Повне ім'я"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "Редагувати"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "Вхід через відбитки _пальців"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "_Автоматичний вхід"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "Активність облікового запису"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "_Адміністратор"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Адміністратори можуть додавати або вилучати інших користувачів, а також "
+"змінювати параметри для усіх користувачів."
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "_Батьківський контроль"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "Відкрийте вікно програми «Батьківський контроль»."
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "Вилучити користувача…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "Інші користувачі"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "Додати користувача…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "Не знайдено жодного користувача"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "Розблокуйте, щоб додати обліковий запис користувача."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Додати або вилучити користувачів і змінити свій пароль"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;вхід;"
+"логін;лоґін;назва;ім'я;відбиток;аватар;логотип;обличчя;пароль;батьківський "
+"контроль;час за екраном;обмеження програм;обмеження інтернету;використання;"
+"користування;обмеження користування;діти;дитина;дитячий;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "З_ареєструвати"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Вхід адміністратора домену"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Комп'ютер потрібно зареєструвати в домені, щоб\n"
+"використовувати комерційний вхід. Попрохайте вашого \n"
+"мережевого адміністратора ввести тут пароль домену."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Адміністратор"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Пароль адміністратора"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Організувати обліковий запис"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Потрібна автентифікація, щоб змінити дані про користувача"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Новий пароль повинен бути відмінним від попереднього."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Спробуйте змінити якісь цифри або букви."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Спробуйте трохи переінакшити пароль."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Пароль без згадування користувача буде надійніший."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Намагайтесь уникати згадування користувача в паролі."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Намагайтесь уникати деяких слів, вказаних у паролі."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Намагайтесь уникати звичайних слів."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Намагайтесь уникати переставлення наявних слів."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Намагайтесь використовувати більше чисел."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Намагайтесь використовувати великі букви."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Намагайтесь використовувати малі букви."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr ""
+"Намагайтесь використовувати спеціальні символи, наприклад, розділові знаки."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Намагайтесь використовувати суміш букв, чисел і розділових знаків."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Намагайтесь уникати повторення однакових символів."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Намагайтесь уникати повторення однакового типу символів: варто змішувати "
+"букви з числами і розділові знаки."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Намагайтесь уникати послідовностей, наприклад, 1234 або абвг."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr ""
+"Пароль має бути довшим. Спробуйте додати більше літер, цифр та символів "
+"пунктуації."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Змішуйте великі букви з малими і намагайтесь використовувати числа."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Додавання літер, цифр і розділових знаків зробить пароль надійнішим!"
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "Помилка при автентифікації"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "Новий пароль надто короткий"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "Новий пароль надто простий"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Старий і новий пароль надто подібні"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Новий пароль уже використовувався."
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Новий пароль містить цифри або спеціальні символи"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Старий і новий пароль — однакові."
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Ваш пароль змінився з моменту початкової аутентифікації!"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Новий пароль не містити достатньо різноманітних символів"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Невідома помилка"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Ім'я користувача зазвичай має містити лише літери нижнього регістру a-z, "
+"цифри і такі символи: - _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Вибачте, цей користувач недоступний. Спробуйте інакшого."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Перейменуйте користувача на меншу кількістю літер."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "Прив'язування кнопок"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Прив'язування кнопок до функцій"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Щоб змінити комбінацію клавіш, виберіть дію «Надіслати натискання клавіші», "
+"натисніть кнопку скорочення й утримайте нові клавіші або натисніть "
+"Backspace, щоб очистити."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "_Закрити"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Торкніться цільового маркера, коли той з'явиться на екрані, щоб калібрувати "
+"планшет."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Промах виявлено, перезавантаження…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Кнопка %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Програму визначено"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Надіслати натискання клавіші"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Перемкнути монітор"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Показати екранну довідку"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Планшет, який змонтовано на панелі ноутбука"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Планшет, який змонтовано на зовнішньому дисплеї"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Зовнішній пристрій планшета"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "Зовнішній пристрій панелі"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "Усі дисплеї"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Режим планшета"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Абсолютне позиціювання пера"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "Орієнтація для шульги"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Планшет і Express Keys™ обернено для користування лівою рукою"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Прив'язка до монітора"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "Зберігати пропорції"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+"Використовувати лише частину поверхні планшета для збереження пропорцій "
+"монітора"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "Калібрування"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Не виявлено планшета"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Під'єднайте або ввімкніть планшет Wacom."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Чутливість дотику"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "М'яка"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Натиск кінчика стила"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Тверда"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Кнопка 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Кнопка 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Кнопка 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Чутливість гумки"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Натиск гумки"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Натиск середньою кнопкою миші"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Натиск правою кнопкою миші"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Далі"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr ""
+"Стило-пульверизатор із вимірюванням тиску, нахилу та інтегрованим повзунком"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Стило-пульверизатор із вимірюванням тиску, нахилу і обертання"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Стандартне стило із вимірюванням тиску і нахилу"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Стандартне стило із вимірюванням тиску"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Планшет Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+"Вкажіть прив'язування кнопок і скоригуйте чутливість стила для графічних "
+"планшетів"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Планшет;Wacom;Стилус;стило;Гумка;Миша;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Створити скорочення…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Точки доступу"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Дію скасовано"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Помилка:</b> відмовлено у доступі до зміни параметрів"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Помилка:</b> помилка мобільного обладнання"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Не зареєстровано"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Зареєстровано"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Роумінг"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Пошук"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Відмовлено"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Параметри модема"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Стан модему"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Носій сигналу"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Тип мережі"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Стан мережі"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Власний номер"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Дані щодо пристрою"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Версія мікропрограми"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Лише 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Лише 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Лише 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "Лише 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G, 3G, 4G? 5G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G, 3G, 4G (бажаний), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G, 3G (бажаний), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G (бажаний), 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G, 3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (бажаний), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (бажаний), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G, 4G, 5G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G, 4G (бажаний), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G (бажаний), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G, 4G, 5G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G, 4G (бажаний), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G (бажаний), 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G, 4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G, 3G, 5G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G, 3G (бажаний), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G (бажаний), 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G, 3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G (бажаний), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G (бажаний), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G (бажаний), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G, 5G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G (бажаний), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G, 5G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G (бажаний), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G, 5G (бажаний)"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G (бажаний), 5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G, 5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Невідомий"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Розблокувати SIM-картку"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Розблокувати"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Будь ласка, вкажіть пінкод для SIM-картки %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Введіть пінкод для розблокування вашої SIM-картки"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Будь ласка, вкажіть PUK-код для SIM-картки %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Введіть PUK-код для розблокування вашої SIM-картки"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Введено помилковий пароль. У вас лишилася %1$u спроба"
+msgstr[1] "Введено помилковий пароль. У вас лишилося %1$u спроби"
+msgstr[2] "Введено помилковий пароль. У вас лишилося %1$u спроб"
+msgstr[3] "Введено помилковий пароль. У вас лишилася %1$u спроба"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "У вас лишилася %u спроба"
+msgstr[1] "У вас лишилося %u спроби"
+msgstr[2] "У вас лишилося %u спроб"
+msgstr[3] "У вас лишилася одна спроба"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Введено помилковий пароль."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK-код має бути 8-цифровим числом"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Введіть новий пінкод"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Пінкод має бути числом, у якому має бути від 4 до 8 цифр"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Розблокування…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Немає SIM-картки"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Вставте SIM-картку, щоб скористатися цим модемом"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM-картку заблоковано"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "_Мобільні дані"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Доступ до даних за допомогою мобільної мережі"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "Роумінг _даних"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Використовувати мобільний доступ до даних при роумінгу"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Режим _мережі"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "М_ережа"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Додатково"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "Назви _точок доступу"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Б_локування SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Заблокувати SIM-картку за допомогою пінкоду"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Параметри м_одему"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Помилка телефону"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Немає з'єднання з телефоном"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Дію заборонено"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Підтримки дії не передбачено"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM не вставлено"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Потрібен пінкод SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Потрібен PUK-код SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Помилка SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM зайнято"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Помилковий пароль"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Потрібен PIN2-код SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Потрібен PUK2-код SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Не знайдено"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Немає мережевої служби"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Час очікування на мережу"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Служби GPRS заборонено"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Роумінґ у цій місцевості заборонено"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Невказана помилка GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "Без помилок"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "Дію скасовано"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "Доступ заборонено"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "Невідома помилка"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Режим мережі"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "_Автоматично"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "Виберіть мережу"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "Освіжити список надавачів послуг мережі"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM-картка %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Увімкнути мобільну мережу"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "Не знайдено жодного адаптера WWAN"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+"Переконайтеся, що у вас є пристрій бездротової WAN або стільникової мережі"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Бездротову WAN вимкнено, коли увімкнено режим польоту"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "Ви_мкнути режим польоту"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "З'єднання із передаванням даних"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "SIM-картка для інтернету"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Блокування SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "_Далі"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "За_блокувати SIM-картку за допомогою пінкоду"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "Змінити пінкод"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Введіть поточний пінкод, щоб змінити параметри блокування SIM-картки"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Мобільна мережа"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Налаштовування телефонії та мобільних з'єднань для передавання даних"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+"cellular;wwan;telephony;sim;mobile;стільниковий;телефонія;телефон;сім;картка;"
+"мобільний;вван;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Програма для налаштовування середовища GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "«Параметри» є основним інтерфейсом для налаштовування вашої системи."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Проєкт GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Показати номер версії"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Увімкнути докладний режим"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Шукати рядок"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Подати можливі назви панелі й вийти"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Панель для показу"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[ПАНЕЛЬ] [АРГУМЕНТ…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "Категорії параметрів"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Конфіденційність"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "Доступні панелі:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Усі параметри"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Основне меню"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Попередження: розробницька версія"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Цю версію «Налаштувань» слід використовувати лише для розробки. Ви можете "
+"спостерігати неправильну роботу системи, втрату даних та інші "
+"непередбачувані проблеми. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Довідка"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Загальне"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Вийти"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Пошук"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Панелі"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Повернутися на попередню панель"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Скасувати пошук"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Налаштування;Параметри;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Ідентифікатор останньої панелі «Параметри», яку буде відкрито"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Ідентифікатор останньої панелі «Параметри», яку буде відкрито. Нерозпізнані "
+"значення будуть проігноровані і вибрана перша панель у списку."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Показати застереження при запуску розробницької збірки «Параметри»"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Чи «Параметри» показуватимуть попередження при запуску розробницької збірки."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Початковий стан вікна"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Кортеж, що містить початкову ширину, висоту і стан максимізації вікна "
+"програми."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u вивід"
+msgstr[1] "%u виводи"
+msgstr[2] "%u виводів"
+msgstr[3] "%u вивід"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u вхід"
+msgstr[1] "%u входи"
+msgstr[2] "%u входів"
+msgstr[3] "%u вхід"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Системні звуки"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "Помилка: не вдалося визначити рівень HSI."
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "Помилка: не вдалося визначити помилковий рівень HSI."
+
+#~ msgid "Add a Printer…"
+#~ msgstr "Додати принтер…"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Сертифікати DER або PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Drip"
+#~ msgstr "Капля"
+
+#~ msgid "Glass"
+#~ msgstr "Скло"
+
+#~ msgid "Sonar"
+#~ msgstr "Сонар"
+
+#~| msgid "Take a screenshot of a window"
+#~ msgid "Take screenshots of application windows and the desktop."
+#~ msgstr "Робити знімки вікон програм та стільниці."
+
+#~ msgid "No Protection"
+#~ msgstr "Без захисту"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "Мінімальний захист"
+
+#~ msgid "Basic Protection"
+#~ msgstr "Базовий захист"
+
+#~ msgid "Extended Protection"
+#~ msgstr "Розширений захист"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "Мінімальний захист"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "Базовий захист"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "Розширений захист"
+
+#~ msgid "SPI write"
+#~ msgstr "Запис SPI"
+
+#~ msgid "SPI lock"
+#~ msgstr "Блокування SPI"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "Регіон BIOS SPI"
+
+#~ msgid "Pre-boot DMA protection is"
+#~ msgstr "Захист DMA до завантаження"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "Ядро забруднено"
+
+#~ msgid "Suspend-to-ram"
+#~ msgstr "Сон зі збереженням до RAM"
+
+#~ msgid "All TPM PCRs are"
+#~ msgstr "Усі PCR TPM"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "Режим виробника MEI"
+
+#~ msgid "MEI override"
+#~ msgstr "Перевизначення MEI"
+
+#~ msgid "MEI version"
+#~ msgstr "Версія MEI"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "Додатки fwupd"
+
+#~ msgid "Intel DCI debugger"
+#~ msgstr "Діагностика DCI Intel"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "Захист пристрою IOMMU увімкнено"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "Захист пристрою IOMMU вимкнено"
+
+#~ msgid "Kernel is no longer tainted"
+#~ msgstr "Ядро більше не забруднено сторонніми модулями"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "Ядро забруднено сторонніми модулями"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "Блокування ядра вимкнено"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "Блокування ядра увімкнено"
+
+#~ msgid "Pre-boot DMA protection is disabled"
+#~ msgstr "Захист DMA до завантаження вимкнено"
+
+#~ msgid "Pre-boot DMA protection is enabled"
+#~ msgstr "Захист DMA до завантаження увімкнено"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "Secure Boot вимкнено"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "Secure Boot увімкнено"
+
+#~ msgid "All TPM PCRs are valid"
+#~ msgstr "Усі PCR TPM є коректними"
+
+#~ msgid "All TPM PCRs are now valid"
+#~ msgstr "Усі PCR TPM тепер є коректними"
+
+#~ msgid "A TPM PCR is now an invalid value"
+#~ msgstr "PCR TPM тепер є некоректним значенням"
+
+#~ msgid "TPM PCR0 reconstruction is invalid"
+#~ msgstr "Реконструкція PCR0 TPM є некоректною"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Заблокувати екран"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Розташування дисплеїв"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "Secure Boot є неактивним"
+
+#~ msgid "Light"
+#~ msgstr "Світла"
+
+#~ msgid "Set"
+#~ msgstr "Встановити"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "екран;блокування;діагностика;крах;особисте;нещодавнє;тимчасове;tmp;індекс;"
+#~ "назва;мережа;засвідчення;"
+
+#~ msgid "Bark"
+#~ msgstr "Гав"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "Панель «Звук» «Параметрів GNOME»"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "Панель «Параметрів GNOME» «Миша та сенсорний пристрій»"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "Панель «Тло» «Параметрів GNOME»"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "Панель «Клавіатура» «Параметрів GNOME»"
+
+#~ msgid "More Warm"
+#~ msgstr "Тепліше"
+
+#~ msgid "Less Warm"
+#~ msgstr "Холодніше"
+
+#~ msgid "Move up"
+#~ msgstr "Пересунути вище"
+
+#~ msgid "Move down"
+#~ msgstr "Пересунути нижче"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Засвідчення"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Спільний доступ до екрана надає змогу віддаленим користувачам переглядати "
+#~ "або керувати вашим екраном, під'єднавшись до %s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Оприлюднення _екрана"
+
+#~ msgid "_Password:"
+#~ msgstr "_Пароль:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Показати пароль"
+
+#~ msgid "Access Options"
+#~ msgstr "Параметри доступу"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "_Нові з'єднання мають вимагати доступ"
+
+#~ msgid "_Require a password"
+#~ msgstr "Вимагати _пароль"
+
+#~ msgid "Show the screenshot UI"
+#~ msgstr "Показати інтерфейс знімків екрана"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "Зробити знімок екрана"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "Показати інтерфейс запису з екрана"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Дозволити вказаним нижче програмам доступ до мікрофона."
+
+#~ msgid "Standard"
+#~ msgstr "Стандартно"
+
+#~ msgid "Account _Type"
+#~ msgstr "_Тип облікового запису"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr ""
+#~ "Дозволяє користувачу вказати пароль, коли він в_ходитиме наступного разу"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Вкажіть пароль _зараз"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "Увійдіть у мережу, щоб додавати комерційних користувачів."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Зробити фотографію…"
+
+#~ msgid "Your account"
+#~ msgstr "Ваш обліковий запис"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Щоб унести зміни,\n"
+#~ "натисніть спочатку на піктограму *"
+
+#~ msgid "Create a user account"
+#~ msgstr "Створити обліковий запис користувача"
+
+#~ msgid "User Icon"
+#~ msgstr "Піктограма користувача"
+
+#~ msgid "Account Settings"
+#~ msgstr "Параметри облікового запису"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Автентифікація та вхід"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Це буде назвою вашого домашнього каталогу, яку згодом змінити буде "
+#~ "неможливо."
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Вкажіть формат чисел, дат і валют. Зміни буде застосовано при наступному "
+#~ "вході до системи."
+
+#~ msgid "My Account"
+#~ msgstr "Обліковий запис"
+
+#~ msgid "Language"
+#~ msgstr "Мова"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Мова, яку буде використано у тексті вікон та вебсторінок."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "Перезапустити сеанс, щоб зміни вступили набули чинності"
+
+#~ msgid "Restart…"
+#~ msgstr "Перезапустити…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Параметри входу використовуються всіма користувачами, коли вони входять у "
+#~ "систему"
+
+#~ msgid "Output:"
+#~ msgstr "Вивід:"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Відбити на одному моніторі"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d з %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Відбиття екрана"
+
+#~ msgid "Stylus"
+#~ msgstr "Стило"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Планшет (абсолютно)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Сенсорна панель (відносно)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Параметри планшета"
+
+#~ msgid "_Help"
+#~ msgstr "_Довідка"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Параметри Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Режим стеження"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Кнопки відбиття…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Скоригувати параметри миші"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Коригувати роздільність екрана"
+
+#~ msgid "Decouple Display"
+#~ msgstr "Роз'єднати дисплей"
+
+#~ msgid "No stylus found"
+#~ msgstr "Не знайдено стила"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Будь ласка, перемістіть ваше стило ближче до планшету, що його налаштувати"
+
+#~ msgid "Top Button"
+#~ msgstr "Верхня кнопка"
+
+#~ msgid "Lower Button"
+#~ msgstr "Нижня кнопка"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Найнижча кнопка"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Зберегти знімок екрана у $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Зберегти знімок ділянки у $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Копіювати знімок до буфера"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Копіювати знімок вікна у буфер"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Копіювати знімок ділянки у буфер"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Записати короткий відеозапис"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Керуйте тим, які результати пошуку буде показано в огляді діяльності. "
+#~ "Порядок результатів пошуку також можна змінити пересуванням рядків у "
+#~ "списку."
+
+#~ msgid "Web Links"
+#~ msgstr "Вебпосилання"
+
+#~ msgid "Git Links"
+#~ msgstr "Git-посилання"
+
+#~ msgid "%s Links"
+#~ msgstr "%s-посилання"
+
+#~ msgid "Unset"
+#~ msgstr "Зняти"
+
+#~ msgid "Links"
+#~ msgstr "Посилання"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Гіпертекстові файли"
+
+#~ msgid "Text Files"
+#~ msgstr "Текстові файли"
+
+#~ msgid "Image Files"
+#~ msgstr "Файли зображень"
+
+#~ msgid "Font Files"
+#~ msgstr "Файли шрифтів"
+
+#~ msgid "Archive Files"
+#~ msgstr "Файли архівів"
+
+#~ msgid "Package Files"
+#~ msgstr "Файли пакунків"
+
+#~ msgid "Audio Files"
+#~ msgstr "Аудіофайли"
+
+#~ msgid "Video Files"
+#~ msgstr "Відеофайли"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Дозволи і доступ"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Дані й служби, до яких ця програма запитала доступ та дозволи, яких вона "
+#~ "вимагає."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Неможливо змінити"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Індивідуальні дозволи для програм можна переглянути в розділі <a href="
+#~ "\"privacy\">Конфіденційність</a> налаштувань."
+
+#~ msgid "Integration"
+#~ msgstr "Інтеграція"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Зробити тлом стільниці"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Типові обробники"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Типи файлів та посилань, які відкриває ця програма."
+
+#~ msgid "Usage"
+#~ msgstr "Використання"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Обсяг ресурсів, які використовує ця програма."
+
+#~ msgid "Open in Software"
+#~ msgstr "Відкрити у «Програмах»"
+
+#~ msgid "Display Mode"
+#~ msgstr "Режим показу"
+
+#~ msgid "Join Displays"
+#~ msgstr "З'єднання дисплеїв"
+
+#~ msgid "Single Display"
+#~ msgstr "Один дисплей"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Перетягніть дисплеї, щоб зіставити налаштування вашого фізичного дисплея. "
+#~ "Виберіть дисплей, щоб змінити його налаштування."
+
+#~ msgid "Active Display"
+#~ msgstr "Активний дисплей"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Дозволити вказаним нижче програмам доступ до камери."
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Служба розташування дозволяє програмам дізнаватись ваше розміщення. "
+#~ "Точність підвищується, якщо ввімкнути WiFi і мобільний зв'язок."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Використовує Mozilla Location Service: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Умови конфіденційності</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr ""
+#~ "Дозволити вказаним нижче програмам доступ до даних щодо вашого місця "
+#~ "перебування."
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr ""
+#~ "Виявлено розташування на нетривкій поверхні: режим високої швидкодії "
+#~ "недоступний"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Висока температура обладнання: режим найвищої швидкодії недоступний"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Режим високої швидкодії недоступний"
+
+#~ msgid "Activities"
+#~ msgstr "Дії"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Звукові клавіші"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Зчитувач екрана"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "З_читувач екрана"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Не вдалося вивантажити файл: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Профіль вивантажено на:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Запишіть собі це посилання."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr ""
+#~ "Перезапустіть цей комп'ютер і завантажте вашу звичайну операційну систему."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "Введіть URL у веб-переглядач, щоб звантажити і встановити профіль."
+
+#~ msgid "Upload profile"
+#~ msgstr "Вивантажити профіль"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Потребує зв'язок з інтернетом"
+
+#~ msgid "_Copy"
+#~ msgstr "_Копіювати"
+
+#~ msgid "Select _All"
+#~ msgstr "Позна_чити все"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Затримка подвійного клацання"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Кнопка призупинення і вимикання"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Деякі служби вимкнено через недоступність мережі."
+
+#~ msgid "Unlocking..."
+#~ msgstr "Розблоковування…"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr "Вхід;Назва;Відбитки;Аватар;Логотип;Лице;Пароль;"
+
+#~| msgid "Password"
+#~ msgid "Passsword"
+#~ msgstr "Пароль"
+
+#~ msgid "Phone-adaptor link reserved"
+#~ msgstr "Зв'язок телефон-адаптер зарезервовано"
+
+#~| msgid "SIM Pin required"
+#~ msgid "PH-SIM PIN required"
+#~ msgstr "Потрібен пінкод PH-SIM"
+
+#~| msgid "SIM Pin required"
+#~ msgid "PH-FSIM PIN required"
+#~ msgstr "Потрібен пінкод PH-FSIM"
+
+#~| msgid "SIM Pin required"
+#~ msgid "PH-FSIM PUK required"
+#~ msgstr "Потрібен PUK-код PH-FSIM"
+
+#~| msgid "Memory"
+#~ msgid "Memory full"
+#~ msgstr "Пам'ять переповнено"
+
+#~| msgid "Memory"
+#~ msgid "Memory failure"
+#~ msgstr "Помилка пам'яті"
+
+#~ msgid "Network not allowed - emergency calls only"
+#~ msgstr "З'єднання з мережею заборонено — лише термінові виклики"
+
+#~| msgid "Network registration denied"
+#~ msgid "Network personalization PIN required"
+#~ msgstr "Потрібен мережевий пінкод персоналізації"
+
+#~| msgid "Network registration denied"
+#~ msgid "Network personalization PUK required"
+#~ msgstr "Потрібен мережевий PUK-код персоналізації"
+
+#~| msgid "Network registration denied"
+#~ msgid "Network subset personalization PIN required"
+#~ msgstr "Потрібен пінкод персоналізації підмережі"
+
+#~| msgid "Network registration denied"
+#~ msgid "Network subset personalization PUK required"
+#~ msgstr "Потрібен PUK-код персоналізації підмережі"
+
+#~ msgid "Service provider personalization PIN required"
+#~ msgstr "Потрібен пінкод персоналізації надавача послуг"
+
+#~ msgid "Service provider personalization PUK required"
+#~ msgstr "Потрібен PUK-код персоналізації надавача послуг"
+
+#~ msgid "Corporate personalization PIN required"
+#~ msgstr "Потрібен корпоративний пінкод персоналізації"
+
+#~ msgid "Corporate personalization PUK required"
+#~ msgstr "Потрібен корпоративний PUK-код персоналізації"
+
+#~ msgid "Illegal MS"
+#~ msgstr "Заборонений MS"
+
+#~ msgid "Illegal ME"
+#~ msgstr "Заборонений ME"
+
+#~ msgid "PLMN not allowed"
+#~ msgstr "PLMN заборонено"
+
+#~ msgid "Location area not allowed"
+#~ msgstr "Обслуговування у цій місцевості заборонено"
+
+#~| msgid "The device type is not currently supported."
+#~ msgid "Service option not supported"
+#~ msgstr "Підтримки варіанта служби не передбачено"
+
+#~ msgid "Requested service option not subscribed"
+#~ msgstr "Немає передплати на запитану службу"
+
+#~ msgid "Service option temporarily out of order"
+#~ msgstr "Варіант служби тимчасово не працює"
+
+#~| msgid "Authentication failed"
+#~ msgid "PDP authentication failure"
+#~ msgstr "Помилка розпізнавання у PDP"
+
+#~ msgid "Invalid mobile class"
+#~ msgstr "Некоректний клас мобільного"
+
+#~ msgid "Balanced Power"
+#~ msgstr "Збалансоване споживання"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "_Яскравість екрана"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "_Яскравість клавіатури"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Притлумлювати яскравість екрана, якщо немає дій"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "По_гасити екран"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "Wi_-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wi-Fi може бути вимкнений для заощадження енергії."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Мобільна мережа (LTE, 4G, 3G тощо) може бути вимкнена для заощадження "
+#~ "енергії."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Bluetooth може бути вимкнений для заощадження енергії."
+
+#~ msgid "Add…"
+#~ msgstr "Додати…"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Клавіатурне скорочення"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Це можна змінити у налаштуваннях клавіатурних скорочень"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Затисніть кнопку і друкуйте для уведення різноманітних символів"
+
+#~ msgid "Previous source"
+#~ msgstr "Попереднє джерело"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "Наступне джерело"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "Лівий та правий Alt"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "Альтернативна клавіша символів"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Тільки модифікатори перемикають наступне джерело"
+
+#~ msgid "Left Alt"
+#~ msgstr "Ліва Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "Права Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "Ліва Super"
+
+#~ msgid "Right Super"
+#~ msgstr "Права Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "Права Ctrl"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "Кнопка меню"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Заряджання"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Застереження"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Низько"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Працездатно"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Повністю заряджено"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Вичерпано"

--- a/po/uz.po
+++ b/po/uz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center-2.0 trunk\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-01-07 20:26+0500\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2007-11-12 09:36+0500\n"
 "Last-Translator: Nurali Abdurahmonov <mavnur@gmail.com>\n"
 "Language-Team: Uzbek\n"
@@ -18,3333 +18,6024 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=0;\n"
 "X-Generator: KBabel 1.11.4\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "Rasm/yorliq chegarasi"
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "Ogohlantirish dialogidagi rasm va yorliqlarning kengligi"
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr "Ogohlantirish turi"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "Ogohlantirish turi"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "Ogohlantirish tugmalari"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "Ogohlantirish oynasida koʻrsatiladigan tugmalar"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "_Tafsilotlarni koʻrsatish"
-
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Place your left thumb on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Swipe your left thumb on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Place your left index finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Swipe your left index finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Place your left middle finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Swipe your left middle finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Place your left ring finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Swipe your left ring finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Place your left little finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Swipe your left little finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Place your right thumb on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Swipe your right thumb on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Place your right index finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Swipe your right index finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Place your right middle finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Swipe your right middle finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Place your right ring finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Swipe your right ring finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Place your right little finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Swipe your right little finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:72
-#: ../capplets/about-me/fingerprint-strings.h:98
-msgid "Place your finger on the reader again"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:74
-#: ../capplets/about-me/fingerprint-strings.h:100
-msgid "Swipe your finger again"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:77
-#: ../capplets/about-me/fingerprint-strings.h:103
-msgid "Swipe was too short, try again"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:79
-#: ../capplets/about-me/fingerprint-strings.h:105
-msgid "Your finger was not centered, try swiping your finger again"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:81
-#: ../capplets/about-me/fingerprint-strings.h:107
-msgid "Remove your finger, and try swiping your finger again"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:772
-msgid "Select Image"
-msgstr "Rasmni tanlang"
-
-#: ../capplets/about-me/gnome-about-me.c:774
-msgid "No Image"
-msgstr "Rasmsiz"
-
-#: ../capplets/about-me/gnome-about-me.c:802
-#: ../capplets/appearance/appearance-desktop.c:660
-msgid "Images"
-msgstr "Rasmlar"
-
-#: ../capplets/about-me/gnome-about-me.c:806
-#: ../capplets/appearance/theme-installer.c:700
-msgid "All Files"
-msgstr "Hamma fayllar"
-
-#: ../capplets/about-me/gnome-about-me.c:952
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-"Manzillar daftaridan maʼlumot olib boʻlmadi.\n"
-"Evolution maʼlumot serveri protokolni qoʻllamaydi"
-
-#: ../capplets/about-me/gnome-about-me.c:973
-msgid "Unable to open address book"
-msgstr "Manzillar daftarini ochib boʻlmadi"
-
-#: ../capplets/about-me/gnome-about-me.c:987
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr "Nomaʼlum foydalanuvchi ID'si. foydalanuvchi maʼlumot bazasi zararlangan boʻlishi mumkin"
-
-#: ../capplets/about-me/gnome-about-me.c:1017
-#: ../capplets/about-me/gnome-about-me.c:1019
-#, c-format
-msgid "About %s"
-msgstr "%s haqida"
-
-#: ../capplets/about-me/gnome-about-me.c:1037
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Enable _Fingerprint Login..."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:1040
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Disable _Fingerprint Login..."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "About Me"
-msgstr "Men haqimda"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "Shaxsiy maʼlumotlaringiz"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
-msgid "You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
-msgid "The device is already in use."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:103
-msgid "An internal error occured"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:220
-msgid "Delete registered fingerprints?"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:223
-msgid "_Delete Fingerprints"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:230
-msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:343
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:583
-msgid "Done!"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
-#, c-format
-msgid "Could not access '%s' device"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:444
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:491
-msgid "Could not access any fingerprint readers"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:492
-msgid "Please contact your system administrator for help."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:518
-msgid "Enable Fingerprint Login"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:534
-msgid "Select finger"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:555
-#, c-format
-msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:568
-msgid "Swipe finger on reader"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:570
-msgid "Place finger on reader"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:1
-msgid "Left index finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:2
-msgid ""
-"Left thumb\n"
-"Left middle finger\n"
-"Left ring finger\n"
-"Left little finger\n"
-"Right thumb\n"
-"Right middle finger\n"
-"Right ring finger\n"
-"Right little finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:10
-msgid "Other finger: "
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:11
-msgid "Right index finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:12
-msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-msgid "<b>Email</b>"
-msgstr "<b>El.pochta</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-msgid "<b>Home</b>"
-msgstr "<b>Uy</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Instant Messaging</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Job</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Telephone</b>"
-msgstr "<b>Telefon</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Web</b>"
-msgstr "<b>WWW</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Work</b>"
-msgstr "<b>Ish</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Maxfiy soʻzni oʻzgartirish</span>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "A_ddress:"
-msgstr "_Manzil:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_ssistant:"
-msgstr "_Yordamchi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "Address"
-msgstr "Manzil"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "C_ity:"
-msgstr "_Shahar:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "C_ompany:"
-msgstr "_Tashkilot:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "Cale_ndar:"
-msgstr "Ta_qvim:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "Change Passwo_rd..."
-msgstr "Maxfiy _soʻzni oʻzgartirish..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Change pa_ssword"
-msgstr "Maxfiy s_oʻzni oʻzgartirish"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change password"
-msgstr "Maxfiy soʻzni oʻzgartirish"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Ci_ty:"
-msgstr "Sh_ahar:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Co_untry:"
-msgstr "_Davlat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Contact"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Cou_ntry:"
-msgstr "Dav_lat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Current _password:"
-msgstr "Joriy _maxfiy soʻz:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "Full Name"
-msgstr "Toʻliq ism"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "Hom_e:"
-msgstr "U_y:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P.O. _box:"
-msgstr "Pochta q_utisi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "P._O. box:"
-msgstr "_Pochta qutisi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "Personal Info"
-msgstr "Shaxsiy maʼlumot"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#: ../capplets/about-me/gnome-about-me-password.c:938
-msgid "Please type your password again in the <b>Retype new password</b> field."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Select your photo"
-msgstr "Rasm tanlang"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "State/Pro_vince:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid ""
-"To change your password, enter your current password in the field below and click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for verification and click <b>Change password</b>."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "User name:"
-msgstr "Foydalanuvchi nomi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "Web _log:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "Wor_k:"
-msgstr "I_sh:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "Work _fax:"
-msgstr "_Faks (ish):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "Zip/_Postal code:"
-msgstr "_Pochta indeksi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Address:"
-msgstr "_Manzil:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Authenticate"
-msgstr "_Tasdiqlash"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Department:"
-msgstr "_Boʻlim:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_Groupwise:"
-msgstr "_Groupwise:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Home page:"
-msgstr "_Uy sahifasi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Home:"
-msgstr "_Uy:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_Jabber:"
-msgstr "_Jabber:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Manager:"
-msgstr "_Boshqaruvchi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Mobile:"
-msgstr "Uyali telefon:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_New password:"
-msgstr "_Yangi maxfiy soʻz:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Profession:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:55
-msgid "_Retype new password:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:56
-msgid "_State/Province:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:57
-msgid "_Title:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:58
-msgid "_Work:"
-msgstr "_Ish:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:59
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:60
-msgid "_Zip/Postal code:"
-msgstr "Pochta _indeksi:"
-
-#: ../capplets/about-me/gnome-about-me-password.c:162
-msgid "Child exited unexpectedly"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:297
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:310
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:409
-msgid "Authenticated!"
-msgstr "Tasdiqlandi!"
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:475
-#: ../capplets/about-me/gnome-about-me-password.c:551
-msgid "Your password has been changed since you initially authenticated! Please re-authenticate."
-msgstr "Maxfiy soʻzingiz keyingi safargi tasdiqlanishdan keyin oʻzgartiriladi! Iltimos qayta tasdiqlang."
-
-#: ../capplets/about-me/gnome-about-me-password.c:477
-msgid "That password was incorrect."
-msgstr "Maxfiy soʻz xato."
-
-#: ../capplets/about-me/gnome-about-me-password.c:524
-msgid "Your password has been changed."
-msgstr "Maxfiy soʻzingiz oʻzgartirildi."
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:534
-#, c-format
-msgid "System error: %s."
-msgstr "Tizim xatosi: %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:537
-msgid "The password is too short."
-msgstr "Maxfiy soʻz juda qisqa."
-
-#: ../capplets/about-me/gnome-about-me-password.c:540
-msgid "The password is too simple."
-msgstr "Maxfiy soʻz juda oddiy."
-
-#: ../capplets/about-me/gnome-about-me-password.c:543
-msgid "The old and new passwords are too similar."
-msgstr "Eski va yangi maxfiy soʻz juda oʻxshash."
-
-#: ../capplets/about-me/gnome-about-me-password.c:545
-msgid "The new password must contain numeric or special character(s)."
-msgstr "Yangi maxfiy soʻz raqam va maxsus belgi(lar)dan iborat boʻlishi kerak."
-
-#: ../capplets/about-me/gnome-about-me-password.c:548
-msgid "The old and new passwords are the same."
-msgstr "Eski va yangi maxfiy soʻz bir xil."
-
-#. translators: Unable to launch <program>: <error message>
-#: ../capplets/about-me/gnome-about-me-password.c:820
-#, c-format
-msgid "Unable to launch %s: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:824
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:825
-msgid "A system error has occurred"
-msgstr "Tizimda xatolik roʻy berdi"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:845
-msgid "Checking password..."
-msgstr "Maxfiy soʻz tekshirilmoqda..."
-
-#: ../capplets/about-me/gnome-about-me-password.c:932
-msgid "Click <b>Change password</b> to change your password."
-msgstr "Maxfiy soʻzni oʻzgartirish uchun <b>Maxfiy soʻzni oʻzgartirish</b> tugmasini bosing."
-
-#: ../capplets/about-me/gnome-about-me-password.c:935
-msgid "Please type your password in the <b>New password</b> field."
-msgstr "Iltimos <b>yangi maxfiy soʻz</b> maydoniga maxfiy soʻzni kiriting."
-
-#: ../capplets/about-me/gnome-about-me-password.c:941
-msgid "The two passwords are not equal."
-msgstr "Ikkala maxfiy soʻz mos kelmadi."
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Assistive Technologies</b>"
-msgstr "<b>Yordamchi texnologiyalar</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Preferences</b>"
-msgstr "<b>Parametrlar</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid "Accessible Lo_gin"
-msgstr "Tizimga _kirishdagi yordamchi texnologiyalar"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technologies Preferences"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Changes to enable assistive technologies will not take effect until your next log in."
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Close and _Log Out"
-msgstr "Yopish va tizimdan _chiqish"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "Jump to Preferred Applications dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "Jump to the Accessible Login dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "Jump to the Keyboard Accessibility dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "Jump to the Mouse Accessibility dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
-msgid "_Enable assistive technologies"
-msgstr "Yordamchi texnologiyalarni _yoqish"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
-msgid "_Keyboard Accessibility"
-msgstr "_Klaviatura maxsus imkoniyatlari"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
-msgid "_Mouse Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
-msgid "_Preferred Applications"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Choose which accessibility features to enable when you log in"
-msgstr ""
-
-#: ../capplets/appearance/appearance-desktop.c:628
-msgid "Add Wallpaper"
-msgstr "Gulqogʻoz qoʻshish"
-
-#: ../capplets/appearance/appearance-desktop.c:664
-msgid "All files"
-msgstr "Hamma fayllar"
-
-#: ../capplets/appearance/appearance-font.c:495
-msgid "Font may be too large"
-msgstr "Shrift juda katta boʻlishi mumkin"
-
-#: ../capplets/appearance/appearance-font.c:499
-#, c-format
-msgid "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is recommended that you select a size smaller than %d."
-msgid_plural "The font selected is %d points large, and may make it difficult to effectively use the computer. It is recommended that you select a size smaller than %d."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:512
-#, c-format
-msgid "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is recommended that you select a smaller sized font."
-msgid_plural "The font selected is %d points large, and may make it difficult to effectively use the computer. It is recommended that you select a smaller sized font."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:535
-msgid "Use previous font"
-msgstr "Oldingi shriftdan foydalanish"
-
-#: ../capplets/appearance/appearance-font.c:537
-msgid "Use selected font"
-msgstr "Tanlangan shriftdan foydalanish"
-
-#: ../capplets/appearance/appearance-main.c:124
-msgid "Specify the filename of a theme to install"
-msgstr "Oʻrnatiladigan mavzu fayli nomini koʻrsating"
-
-#: ../capplets/appearance/appearance-main.c:125
-msgid "filename"
-msgstr "fayl nomi"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/appearance/appearance-main.c:132
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:133
-#: ../capplets/default-applications/gnome-da-capplet.c:879
-#: ../capplets/mouse/gnome-mouse-properties.c:442
-msgid "page"
-msgstr "sahifa"
-
-#: ../capplets/appearance/appearance-main.c:140
-msgid "[WALLPAPER...]"
-msgstr "[GULQOGʻOZ...]"
-
-#: ../capplets/appearance/appearance-style.c:173
-#: ../capplets/common/gnome-theme-info.c:445
-#: ../capplets/common/gnome-theme-info.c:637
-msgid "Default Pointer"
-msgstr "Andoza koʻrsatgich"
-
-#: ../capplets/appearance/appearance-style.c:235
-#: ../capplets/appearance/appearance-themes.c:686
-msgid "Install"
-msgstr ""
-
-#: ../capplets/appearance/appearance-style.c:255
-#: ../capplets/common/gnome-theme-info.c:1647
-#, c-format
-msgid "This theme will not look as intended because the required GTK+ theme engine '%s' is not installed."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:674
-msgid "Apply Background"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:678
-msgid "Apply Font"
-msgstr "Shriftni qoʻllash"
-
-#: ../capplets/appearance/appearance-themes.c:682
-msgid "Revert Font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:712
-msgid "The current theme suggests a background and a font. Also, the last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:714
-msgid "The current theme suggests a background. Also, the last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:716
-msgid "The current theme suggests a background and a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:718
-msgid "The current theme suggests a font. Also, the last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:720
-msgid "The current theme suggests a background."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:722
-msgid "The last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:724
-msgid "The current theme suggests a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:1045
-#: ../capplets/default-applications/gnome-da-capplet.c:630
-msgid "Custom"
-msgstr "Boshqa"
-
-#: ../capplets/appearance/data/appearance.glade.h:1
-msgid "<b>C_olors</b>"
-msgstr "<b>_Ranglar</b>"
-
-#. font hinting
-#: ../capplets/appearance/data/appearance.glade.h:3
-msgid "<b>Hinting</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:4
-msgid "<b>Menus and Toolbars</b>"
-msgstr "<b>Menyu va asboblar paneli</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:5
-msgid "<b>Preview</b>"
-msgstr "<b>Oldindan koʻrish</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:6
-msgid "<b>Rendering</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:7
-msgid "<b>Smoothing</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:8
-msgid "<b>Subpixel Order</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:9
-msgid "<b>_Wallpaper</b>"
-msgstr "<b>_Gulqogʻoz</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:10
-msgid "Appearance Preferences"
-msgstr "Tashqi koʻrinishni moslash"
-
-#: ../capplets/appearance/data/appearance.glade.h:11
-msgid "Background"
-msgstr "Orqa fon"
-
-#: ../capplets/appearance/data/appearance.glade.h:12
-msgid "Best _shapes"
-msgstr "Eng yaxshi _shakllar"
-
-#: ../capplets/appearance/data/appearance.glade.h:13
-msgid "Best co_ntrast"
-msgstr "Eng yaxshi ko_ntrast"
-
-#: ../capplets/appearance/data/appearance.glade.h:14
-msgid "C_ustomize..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:15
-msgid "C_ut"
-msgstr "K_yesish"
-
-#: ../capplets/appearance/data/appearance.glade.h:16
-msgid "Changing your cursor theme takes effect the next time you log in."
-msgstr "Kursor mavzusi keyingi safar tizimga kirganda kuchga kiradi."
-
-#: ../capplets/appearance/data/appearance.glade.h:17
-msgid "Colors"
-msgstr "Ranglar"
-
-#: ../capplets/appearance/data/appearance.glade.h:18
-msgid "Controls"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:19
-msgid "Customize Theme"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:20
-msgid "D_etails..."
-msgstr "_Tafsilotlar..."
-
-#: ../capplets/appearance/data/appearance.glade.h:21
-msgid "Des_ktop font:"
-msgstr "Ish _stoli shrifti:"
-
-#: ../capplets/appearance/data/appearance.glade.h:22
-msgid "Edit"
-msgstr "Tahrirlash"
-
-#: ../capplets/appearance/data/appearance.glade.h:23
-msgid "Font Rendering Details"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:24
-msgid "Fonts"
-msgstr "Shriftlar"
-
-#: ../capplets/appearance/data/appearance.glade.h:25
-msgid "Gra_yscale"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:26
-msgid "Icons"
-msgstr "Nishonchalar"
-
-#: ../capplets/appearance/data/appearance.glade.h:27
-msgid "Interface"
-msgstr "Interfeys"
-
-#: ../capplets/appearance/data/appearance.glade.h:28
-msgid "Large"
-msgstr "Katta"
-
-#: ../capplets/appearance/data/appearance.glade.h:29
-msgid "N_one"
-msgstr "_Yoʻq"
-
-#: ../capplets/appearance/data/appearance.glade.h:30
-msgid "New File"
-msgstr "Yangi  fayl"
-
-#: ../capplets/appearance/data/appearance.glade.h:31
-msgid "Open File"
-msgstr "Faylni ochish"
-
-#: ../capplets/appearance/data/appearance.glade.h:32
-msgid "Open a dialog to specify the color"
-msgstr "Rangni koʻrsatish uchun dialogni ochish"
-
-#: ../capplets/appearance/data/appearance.glade.h:33
-msgid "Pointer"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:34
-msgid "R_esolution:"
-msgstr "Oʻ_lchami:"
-
-#: ../capplets/appearance/data/appearance.glade.h:35
-msgid "Save File"
-msgstr "Faylni saqlash"
-
-#: ../capplets/appearance/data/appearance.glade.h:36
-msgid "Save Theme As..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:37
-msgid "Save _As..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:38
-msgid "Save _background image"
-msgstr "_Orqa fon rasmini saqlash"
-
-#: ../capplets/appearance/data/appearance.glade.h:39
-msgid "Show _icons in menus"
-msgstr "Menyularda _nishonchalarni koʻrsatish"
-
-#: ../capplets/appearance/data/appearance.glade.h:40
-msgid "Small"
-msgstr "Kichkina"
-
-#: ../capplets/appearance/data/appearance.glade.h:41
-msgid ""
-"Solid color\n"
-"Horizontal gradient\n"
-"Vertical gradient"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:44
-msgid "Sub_pixel (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:45
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:46
-msgid "Text"
-msgstr "Matn"
-
-#: ../capplets/appearance/data/appearance.glade.h:47
-msgid ""
-"Text below items\n"
-"Text beside items\n"
-"Icons only\n"
-"Text only"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:51
-msgid "The current controls theme does not support color schemes."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:52
-msgid "Theme"
-msgstr "Mavzu"
-
-#: ../capplets/appearance/data/appearance.glade.h:53
-msgid ""
-"Tiled\n"
-"Zoom\n"
-"Centered\n"
-"Scaled\n"
-"Fill screen"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:58
-msgid "Toolbar _button labels:"
-msgstr ""
-
-#. vertical hinting, pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:60
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/appearance/data/appearance.glade.h:61
-msgid "Window Border"
-msgstr "Oyna chegarasi"
-
-#: ../capplets/appearance/data/appearance.glade.h:62
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
-msgid "_Add..."
-msgstr "_Qoʻshish..."
-
-#: ../capplets/appearance/data/appearance.glade.h:63
-msgid "_Application font:"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
 msgstr "_Dastur shrifti:"
 
-#. pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:65
-msgid "_BGR"
-msgstr "_BGR"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Dastur shrifti sifatida oʻrnatish"
 
-#: ../capplets/appearance/data/appearance.glade.h:66
-msgid "_Copy"
-msgstr "_Nusxa olish"
-
-#: ../capplets/appearance/data/appearance.glade.h:67
-msgid "_Description:"
-msgstr "_Taʼrifi:"
-
-#: ../capplets/appearance/data/appearance.glade.h:68
-msgid "_Document font:"
-msgstr "_Hujjat shrifti:"
-
-#: ../capplets/appearance/data/appearance.glade.h:69
-msgid "_Editable menu shortcut keys"
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:70
-msgid "_File"
-msgstr "_Fayl"
-
-#: ../capplets/appearance/data/appearance.glade.h:71
-msgid "_Fixed width font:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:72
-msgid "_Full"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:73
-msgid "_Input boxes:"
-msgstr "_Kiritish maydonlari:"
-
-#: ../capplets/appearance/data/appearance.glade.h:74
-msgid "_Install..."
-msgstr "_Oʻrnatish..."
-
-#: ../capplets/appearance/data/appearance.glade.h:75
-msgid "_Medium"
-msgstr "_Oʻrtacha"
-
-#: ../capplets/appearance/data/appearance.glade.h:76
-msgid "_Monochrome"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:77
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:5
-msgid "_Name:"
-msgstr "_Nomi:"
-
-#: ../capplets/appearance/data/appearance.glade.h:78
-msgid "_New"
-msgstr "_Yangi"
-
-#: ../capplets/appearance/data/appearance.glade.h:79
-msgid "_None"
-msgstr "_Yoʻq"
-
-#: ../capplets/appearance/data/appearance.glade.h:80
-msgid "_Open"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
 msgstr "_Ochish"
 
-#: ../capplets/appearance/data/appearance.glade.h:81
-msgid "_Paste"
-msgstr "_Qoʻyish"
-
-#: ../capplets/appearance/data/appearance.glade.h:82
-msgid "_Print"
-msgstr "_Bosib chiqarish"
-
-#: ../capplets/appearance/data/appearance.glade.h:83
-msgid "_Quit"
-msgstr "_Chiqish"
-
-#. pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:85
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:86
-msgid "_Reset to Defaults"
-msgstr "Andoza qiymatga _qaytarish"
-
-#: ../capplets/appearance/data/appearance.glade.h:87
-msgid "_Save"
-msgstr "_Saqlash"
-
-#: ../capplets/appearance/data/appearance.glade.h:88
-msgid "_Selected items:"
-msgstr "_Tanlangan elementlar:"
-
-#: ../capplets/appearance/data/appearance.glade.h:89
-msgid "_Size:"
-msgstr "_Hajmi:"
-
-#: ../capplets/appearance/data/appearance.glade.h:90
-msgid "_Slight"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:91
-msgid "_Style:"
-msgstr "_Uslub:"
-
-#: ../capplets/appearance/data/appearance.glade.h:92
-msgid "_Tooltips:"
-msgstr ""
-
-#. vertical hinting, pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:94
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:95
-msgid "_Window title font:"
-msgstr "_Oyna sarlavhasi shrifti:"
-
-#: ../capplets/appearance/data/appearance.glade.h:96
-msgid "_Windows:"
-msgstr "_Oynalar:"
-
-#: ../capplets/appearance/data/appearance.glade.h:97
-msgid "dots per inch"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr "Tashqi koʻrinishi"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr "Mavzu oʻrnatgich"
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr "Gnome mavzu paketi"
-
-#: ../capplets/appearance/gnome-wp-info.c:50
-msgid "No Wallpaper"
-msgstr "Gulqogʻozsiz"
-
-#: ../capplets/appearance/gnome-wp-item.c:208
-msgid "Slide Show"
-msgstr ""
-
-#. translators: <b>wallpaper name</b>
-#. * mime type, x pixel(s) by y pixel(s)
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:216
-#, c-format
-msgid ""
-"<b>%s</b>\n"
-"%s, %d %s by %d %s\n"
-"Folder: %s"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-item.c:222
-#: ../capplets/appearance/gnome-wp-item.c:224
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "piksel"
-msgstr[1] "piksel"
-
-#: ../capplets/appearance/theme-installer.c:174
-#: ../capplets/appearance/theme-installer.c:224
-msgid "Cannot install theme"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:176
-#, c-format
-msgid "The %s utility is not installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:226
-msgid "There was a problem while extracting the theme."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:249
-msgid "There was an error installing the selected file"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:250
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:251
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme. It may be a theme engine which you need to compile."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:290
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "%s Gnome mavzusi muvaffaqiyatli oʻrnatildi"
-
-#: ../capplets/appearance/theme-installer.c:357
-#, c-format
-msgid "Installation for theme \"%s\" failed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:396
-#, c-format
-msgid "The theme \"%s\" has been installed."
-msgstr "\"%s\" mavzu oʻrnatildi."
-
-#: ../capplets/appearance/theme-installer.c:402
-msgid "Would you like to apply it now, or keep your current theme?"
-msgstr "Uni qoʻllashni istaysizmi yoki joriy mavzuni saqlab qolasizmi?"
-
-#: ../capplets/appearance/theme-installer.c:404
-msgid "Keep Current Theme"
-msgstr "Joriy mavzu saqlab qolinsin"
-
-#: ../capplets/appearance/theme-installer.c:406
-msgid "Apply New Theme"
-msgstr "Yangi mavzu qoʻllansin"
-
-#: ../capplets/appearance/theme-installer.c:510
-msgid "Failed to create temporary directory"
-msgstr "Vaqtinchalik direktoriya yaratib boʻlmadi"
-
-#: ../capplets/appearance/theme-installer.c:573
-msgid "New themes have been successfully installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:598
-msgid "No theme file location specified to install"
-msgstr "Oʻrnatish uchun mavzu fayli yoʻli koʻrsatilmagan"
-
-#: ../capplets/appearance/theme-installer.c:619
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"Mavzuni quyidagi manzilga oʻrnatish uchun huquq yetarli emas:\n"
-"%s"
-
-#: ../capplets/appearance/theme-installer.c:689
-msgid "Select Theme"
-msgstr "Mavzuni tanlash"
-
-#: ../capplets/appearance/theme-installer.c:693
-msgid "Theme Packages"
-msgstr "Mavzu paketlari"
-
-#: ../capplets/appearance/theme-save.c:93
-#, c-format
-msgid "Theme name must be present"
-msgstr ""
-
-#: ../capplets/appearance/theme-save.c:156
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Mavzu allaqachon mavjud. Almashtirishni istaysizmi?"
-
-#: ../capplets/appearance/theme-save.c:157
-#: ../capplets/common/file-transfer-dialog.c:450
-msgid "_Overwrite"
-msgstr "_Almashtirish"
-
-#: ../capplets/appearance/theme-util.c:75
-msgid "Would you like to delete this theme?"
-msgstr "Ushbu mavzuni olib tashlashni istaysizmi?"
-
-#: ../capplets/appearance/theme-util.c:125
-msgid "Theme cannot be deleted"
-msgstr "Mavzuni olib tashlab boʻlmaydi"
-
-#: ../capplets/appearance/theme-util.c:252
-msgid "Could not install theme engine"
-msgstr ""
-
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) settings manager may already be active and conflicting with the GNOME settings manager."
-msgstr ""
-
-#: ../capplets/common/capplet-stock-icons.c:66
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:88
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Yordam faylini koʻrsatishda xatolik yuz berdi: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:98
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "Fayldan nusxa olinmoqda: %u dan %u"
-
-#: ../capplets/common/file-transfer-dialog.c:145
-#, c-format
-msgid "Copying '%s'"
-msgstr "'%s' nusxa olinmoqda"
-
-#: ../capplets/common/file-transfer-dialog.c:185
-#: ../capplets/common/file-transfer-dialog.c:312
-msgid "Copying files"
-msgstr "Fayllardan nusxa olinmoqda"
-
-#: ../capplets/common/file-transfer-dialog.c:224
-msgid "Parent Window"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Parent window of the dialog"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:231
-msgid "From URI"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:232
-msgid "URI currently transferring from"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:239
-msgid "To URI"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:240
-msgid "URI currently transferring to"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:247
-msgid "Fraction completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:248
-msgid "Fraction of transfer currently completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:255
-msgid "Current URI index"
-msgstr "Joriy URI indeksi"
-
-#: ../capplets/common/file-transfer-dialog.c:256
-msgid "Current URI index - starts from 1"
-msgstr "Joriy URI indeksi - 1'dan boshlanadi"
-
-#: ../capplets/common/file-transfer-dialog.c:263
-msgid "Total URIs"
-msgstr "Jami URI"
-
-#: ../capplets/common/file-transfer-dialog.c:264
-msgid "Total number of URIs"
-msgstr "Jami URI soni"
-
-#: ../capplets/common/file-transfer-dialog.c:444
-#, c-format
-msgid "File '%s' already exists. Do you want to overwrite it?"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:447
-msgid "_Skip"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Overwrite _All"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:134
-msgid "Key"
-msgstr "Kalit"
-
-#: ../capplets/common/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:141
-msgid "Callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:147
-msgid "Change set"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:148
-msgid "GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:154
-msgid "Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:160
-msgid "Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "Grafik interfeys boshqaruvi"
-
-#: ../capplets/common/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1404
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background picture."
-msgstr ""
-"'%s' faylini topib boʻlmadi.\n"
-"\n"
-"Iltimos uni mavjudligini tekshirib koʻring va qayta urinib koʻring yoki boshqa orqa fon rasmini tanlang."
-
-#: ../capplets/common/gconf-property-editor.c:1412
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"'%s' faylini qanday ochish mumkin.\n"
-"Balki bu rasm turi xali qoʻllanilmasligi mumkin.\n"
-"\n"
-"Iltimos buning oʻrniga boshqa rasm tanlang."
-
-#: ../capplets/common/gconf-property-editor.c:1532
-msgid "Please select an image."
-msgstr "Iltimos rasm tanlang."
-
-#: ../capplets/common/gconf-property-editor.c:1537
-msgid "_Select"
-msgstr "_Tanlash"
-
-#: ../capplets/common/gnome-theme-info.c:638
-msgid "Default Pointer - Current"
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:642
-msgid "White Pointer"
-msgstr "Oq koʻrsatgich"
-
-#: ../capplets/common/gnome-theme-info.c:643
-msgid "White Pointer - Current"
-msgstr "Oq koʻrsatgich - joriy"
-
-#: ../capplets/common/gnome-theme-info.c:647
-msgid "Large Pointer"
-msgstr "Katta koʻrsatgich"
-
-#: ../capplets/common/gnome-theme-info.c:648
-msgid "Large Pointer - Current"
-msgstr "Katta koʻrsatgich - joriy"
-
-#: ../capplets/common/gnome-theme-info.c:652
-msgid "Large White Pointer - Current"
-msgstr "Katta oq koʻrsatgich - joriy"
-
-#: ../capplets/common/gnome-theme-info.c:653
-msgid "Large White Pointer"
-msgstr "Katta oq koʻrsatgich"
-
-#: ../capplets/common/gnome-theme-info.c:1623
-#, c-format
-msgid "This theme will not look as intended because the required GTK+ theme '%s' is not installed."
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1631
-#, c-format
-msgid "This theme will not look as intended because the required window manager theme '%s' is not installed."
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1638
-#, c-format
-msgid "This theme will not look as intended because the required icon theme '%s' is not installed."
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Preferred Applications"
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Andoza dasturni tanlang"
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Start the preferred visual assistive technology"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:94
-#: ../capplets/default-applications/gnome-da-capplet.c:345
-#: ../capplets/default-applications/gnome-da-capplet.c:366
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "Moslamani saqlash xatoligi: %s"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:650
-msgid "Could not load the main interface"
-msgstr "Asosiy interfeysni yuklab boʻlmadi"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:652
-msgid "Please make sure that the applet is properly installed"
-msgstr "Iltimos aplet toʻgʻri oʻrnatilganligiga ishonch xosil qiling"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/default-applications/gnome-da-capplet.c:878
-msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:883
-msgid "- GNOME Default Applications"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Image Viewer</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Instant Messenger</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Mail Reader</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mobility</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Multimedia Player</b>"
-msgstr "<b>Multimedia pleyeri</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>Terminal emulyatori</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Text Editor</b>"
-msgstr "<b>Matn tahrirchisi</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Video Player</b>"
-msgstr "<b>Video pleyer</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "<b>Visual</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "<b>Web Browser</b>"
-msgstr "<b>Veb-brauzer</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
-msgid "Accessibility"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "C_ommand:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Co_mmand:"
-msgstr "Buy_ruq:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "E_xecute flag:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Internet"
-msgstr "Internet"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Multimedia"
-msgstr "Multimedia"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Open link in new _tab"
-msgstr "Bogʻlamani yangi _tabda ochish"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "Open link in new _window"
-msgstr "Bogʻlamani yangi _oynada ochish"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid "Open link with web browser _default"
-msgstr "Bogʻlamani brauzer _andozasi bilan ochish"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Run at st_art"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Run in t_erminal"
-msgstr "T_yerminalda bajarish"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "System"
-msgstr "Tizim"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "_Run at start"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr "Banshee musiqiy pleyeri"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr "Dasher"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr "Debian terminal emulyatori"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr "Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr "Epiphany veb brauzeri"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr "Evolution pochta klienti"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr "Firebird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr "GNOME terminali"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Gnopernicus"
-msgstr "Gnopernicus"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Gnopernicus with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Iceape"
-msgstr "Iceape"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Iceape Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Icedove"
-msgstr "Icedove"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Iceweasel"
-msgstr "Iceweasel"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr "KMail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Konsole"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Listen"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Midori"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Mozilla Mail"
-msgstr "Mozilla Mail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Muine Music Player"
-msgstr "Muine musiqa pleyeri"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Netscape Communicator"
-msgstr "Netscape Communicator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Opera"
-msgstr "Opera"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca"
-msgstr "Orca"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "Orca with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-msgid "Rhythmbox Music Player"
-msgstr "Rhythmbox musiqa pleyeri"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-msgid "SeaMonkey Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Standard XTerminal"
-msgstr "Andoza X-terminali"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-msgid "Sylpheed"
-msgstr "Sylpheed"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Terminator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "Totem Movie Player"
-msgstr "Totem pleyeri"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/display/display-capplet.glade.h:1
-#: ../capplets/display/xrandr-capplet.c:450
-msgid "<b>Monitor</b>"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:2
-msgid "<b>Panel icon</b>"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:3
-msgid "<i>Drag the monitors to set their place</i>"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:4
-msgid "Display Settings"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:5
-msgid "Include _panel"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:6
-msgid ""
-"Normal\n"
-"Left\n"
-"Right\n"
-"Upside-down\n"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:11
-msgid "R_otation:"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:12
-msgid "Re_fresh rate:"
-msgstr "_Yangilanish darajasi"
-
-#: ../capplets/display/display-capplet.glade.h:13
-msgid "_Detect Monitors"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:14
-msgid "_Mirror screens"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:15
-msgid "_Resolution:"
-msgstr "_Oʻlchami:"
-
-#: ../capplets/display/display-capplet.glade.h:16
-msgid "_Show displays in panel"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Ekran oʻlchamini oʻzgartirish"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Ekran oʻlchami"
-
-#: ../capplets/display/xrandr-capplet.c:318
-#: ../capplets/display/xrandr-capplet.c:357
-msgid "Normal"
-msgstr "Oʻrtacha"
-
-#: ../capplets/display/xrandr-capplet.c:319
-msgid "Left"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:320
-msgid "Right"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:321
-msgid "Upside Down"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:393
-#: ../capplets/display/xrandr-capplet.c:401
-#: ../capplets/display/xrandr-capplet.c:402
-#, c-format
-msgid "%d Hz"
-msgstr "%d Gs"
-
-#: ../capplets/display/xrandr-capplet.c:443
-#, c-format
-msgid "<b>Monitor: %s</b>"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:489
-#: ../capplets/display/xrandr-capplet.c:508
-#: ../capplets/display/xrandr-capplet.c:518
-#, c-format
-msgid "%d x %d"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:500
-msgid "Off"
-msgstr ""
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../capplets/display/xrandr-capplet.c:1306
-msgid "Mirror Screens"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1624
-msgid "Could not save the monitor configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1631
-msgid "Could not get session bus while applying display configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1641
-msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1647
-msgid "Could not apply the selected configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1687
-msgid "Could not detect displays"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1885
-msgid "Could not get screen information"
-msgstr ""
-
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-msgid "Sound"
-msgstr "Tovush"
-
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-#: ../libslab/bookmark-agent.c:1146
-msgid "Desktop"
-msgstr "Ish stoli"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Akselerator tugmasi"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Akselerator modifikatorlari"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Akselerator tugmasi kodi"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Akselerator usuli"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Akselerator turi."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:103
-#: ../typing-break/drwright.c:479
-msgid "Disabled"
-msgstr "Oʻchirilgan"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:184
-msgid "<Unknown Action>"
-msgstr "<Nomaʼlum amal>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:918
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1528
-msgid "Custom Shortcuts"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1057
-msgid "Error saving the new shortcut"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1136
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1166
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1172
-#, c-format
-msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1180
-msgid "_Reassign"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1300
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1483
-msgid "Too many custom shortcuts"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1768
-msgid "Action"
-msgstr "Amal"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1790
-msgid "Shortcut"
-msgstr "Tugmalar birikmasi"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-msgid "Custom Shortcut"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Klaviatura tugmalar birikmasi:"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:3
-msgid "To edit a shortcut key, click on the corresponding row and type a new key combination, or press backspace to clear."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:4
-msgid "_Command:"
-msgstr ""
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Buyruqlarga tugmalar birikmasi tayinlash"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:209
-#: ../capplets/keyboard/gnome-keyboard-properties.c:214
-msgid "Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:219
-msgid "Start the page with the typing break settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:224
-msgid "Start the page with the accessibility settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:230
-msgid "- GNOME Keyboard Preferences"
-msgstr "- GNOME klaviatura parametrlari"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-msgid "<b>Bounce Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-msgid "<b>Cursor Blinking</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "<b>General</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Repeat Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Slow Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>Sticky Keys</b>"
-msgstr ""
-
-#. fast acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Tez</i></small>"
-
-#. long delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Uzun</i></small>"
-
-#. short delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Qisqa</i></small>"
-
-#. slow acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Sekin</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_cceleration:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "All_ow postponing of breaks"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "Audio _Feedback..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Beep when _accessibility features are turned on or off"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Beep when a _modifier key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Beep when a _toggle key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Beep when a key is pr_essed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Beep when a key is reje_cted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Beep when key is _accepted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Beep when key is _rejected"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "By _country"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "By _language"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Check if breaks are allowed to be postponed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Choose a Keyboard Model"
-msgstr "Klaviatura rusumini tanlang"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Choose a Layout"
-msgstr "Tugmalar tartibini tanlang"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Cursor _blinks in text fields"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
-msgid "Cursor blinks speed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
-msgid "D_elay:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Disa_ble sticky keys if two keys are pressed together"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Duration of the break when typing is disallowed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Duration of work before forcing a break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
-msgid "General"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "Key presses _repeat when key is held down"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "Keyboard Accessibility Audio Feedback"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "Keyboard Layout Options"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "Keyboard Preferences"
-msgstr "Klaviatura moslamalari"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "Keyboard _model:"
-msgstr "Klaviatura _rusumi:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "Layout _Options..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "Layouts"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "Lock screen after a certain duration to help prevent repetitive keyboard use injuries"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "Mouse Keys"
-msgstr "Sichqoncha tugmalari"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "Preview:"
-msgstr "Oldindan koʻrish:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
-msgid "Repeat keys speed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
-msgid "Reset to De_faults"
-msgstr "_Andoza parametrlarni tiklash"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
-msgid "S_peed:"
-msgstr "_Tezlik:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
-msgid "Separate _layout for each window"
-msgstr "Har bir oyna uchun alohida _tugmalar tartibi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
-msgid "Typing Break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
-msgid "_Accessibility features can be toggled with keyboard shortcuts"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
-msgid "_Break interval lasts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
-msgid "_Country:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
-msgid "_Delay:"
-msgstr "_Kechikish:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
-msgid "_Ignore fast duplicate keypresses"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
-msgid "_Language:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
-msgid "_Lock screen to enforce typing break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
-msgid "_Models:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
-msgid "_Only accept long keypresses"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
-msgid "_Pointer can be controlled using the keypad"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
-msgid "_Selected layouts:"
-msgstr "_Tanlangan tugmalar tartibi:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
-msgid "_Simulate simultaneous keypresses"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
-msgid "_Speed:"
-msgstr "_Tezlik:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
-msgid "_Type to test settings:"
-msgstr "Parametrlarni _sinash maydoni:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
-msgid "_Variants:"
-msgstr "_Variantlar:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
-msgid "_Vendors:"
-msgstr "_Ish.chiqaruvchilar:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
-msgid "_Work interval lasts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
-msgid "minutes"
-msgstr "daqiqa"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
-msgid "Unknown"
-msgstr "Nomaʼlum"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:215
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:234
-#: ../capplets/network/gnome-network-preferences.c:561
-msgid "Default"
-msgstr "Andoza"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:333
-msgid "Layout"
-msgstr "Tugmalar tartibi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
-msgid "Vendors"
-msgstr "Ish.chiqaruvchilar"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
-msgid "Models"
-msgstr ""
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Klaviatura"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:90
-msgid "gesture|Move left"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:95
-msgid "gesture|Move right"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:100
-msgid "gesture|Move up"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:105
-msgid "gesture|Move down"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:110
-msgid "gesture|Disabled"
-msgstr ""
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/mouse/gnome-mouse-properties.c:441
-msgid "Specify the name of the page to show (general|accessibility)"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:446
-msgid "- GNOME Mouse Preferences"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-msgid "<b>Double-Click Timeout</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Ushlab olib qoʻyish</b>"
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Dwell Click</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Locate Pointer</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Mouse Orientation</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<b>Pointer Speed</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<b>Simulated Secondary Click</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>To test your double-click settings, try to double-click on the light bulb.</i>"
-msgstr ""
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>You can also use the Dwell Click panel applet to choose the click type.</i>"
-msgstr ""
-
-#. high sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "<small><i>High</i></small>"
-msgstr ""
-
-#. large threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "<small><i>Large</i></small>"
-msgstr ""
-
-#. low sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "<small><i>Low</i></small>"
-msgstr ""
-
-#. small threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "<small><i>Small</i></small>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
-msgid "Choose type of click _beforehand"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
-msgid "Choose type of click with mo_use gestures"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
-msgid "D_ouble click:"
-msgstr ""
-
-#. click to initiate drag-and-drop (like normally click and hold)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
-msgid "D_rag click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
-msgid "Mouse Preferences"
-msgstr "Sichqoncha moslamalari"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
-msgid "Seco_ndary click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
-msgid "Show click type _window"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
-msgid "Thr_eshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
-msgid "_Acceleration:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
-msgid "_Initiate click when stopping pointer movement"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
-msgid "_Left-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
-msgid "_Motion threshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
-msgid "_Right-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
-msgid "_Sensitivity:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
-msgid "_Single click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
-msgid "_Timeout:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr ""
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Sichqoncha"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.c:677
-#: ../capplets/network/gnome-network-preferences.c:816
-msgid "New Location..."
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.c:782
-msgid "Location already exists"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Tarmoq proksisi"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>Internetga _toʻgʻridan-toʻgʻri ulanish</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>Ignore Host List</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>Proksi moslamasini _avto-aniqlash</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>Proksi moslamalarini _qoʻlbola koʻrsatish</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Use authentication</b>"
-msgstr "<b>Tasdiqlashdan _foydalanish</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "Autoconfiguration _URL:"
-msgstr "Avto-moslash _URL'i:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "C_reate"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Create New Location"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "H_TTP proksi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Ignored Hosts"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Location:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "Network Proxy Preferences"
-msgstr "Tarmoq proksi moslamalari"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "Port:"
-msgstr "Port:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "Proxy Configuration"
-msgstr "Proksi parametrlari"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "S_ocks host:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "The location already exists."
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "U_sername:"
-msgstr "F_oydalunuvchi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Delete Location"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:20
-msgid "_Details"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
 msgstr "_Tafsilotlar"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:21
-msgid "_FTP proxy:"
-msgstr "_FTP proksi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:22
-msgid "_Location name:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:23
-msgid "_Password:"
-msgstr "_Maxfiy soʻz:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:24
-msgid "_Secure HTTP proxy:"
-msgstr "HTTP_S proksi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:25
-msgid "_Use the same proxy for all protocols"
-msgstr "Barcha protokollar uchun bitta proksidan _foydalanish"
-
-#: ../capplets/windows/gnome-window-properties.c:346
-msgid "Cannot start the preferences application for your window manager"
-msgstr ""
-
-#. translators: this is the Control key
-#: ../capplets/windows/gnome-window-properties.c:600
-msgid "C_ontrol"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:605
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:611
-msgid "H_yper"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:618
-msgid "S_uper (or \"Windows logo\")"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:625
-msgid "_Meta"
-msgstr "_Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Oyna tanlash</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Oyna parametrlari"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "soniya"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "Oyna moslamalarini oʻrnatish"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "Oynalar"
-
-#. make start action
-#: ../libslab/application-tile.c:372
-#, c-format
-msgid "<b>Start %s</b>"
-msgstr "<b>%s'ni ishga tushirish</b>"
-
-#: ../libslab/application-tile.c:391
-msgid "Help"
-msgstr "Yordam"
-
-#: ../libslab/application-tile.c:438
-msgid "Upgrade"
-msgstr "Yangilash"
-
-#: ../libslab/application-tile.c:453
-msgid "Uninstall"
-msgstr ""
-
-#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
-msgid "Remove from Favorites"
-msgstr ""
-
-#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
-msgid "Add to Favorites"
-msgstr ""
-
-#: ../libslab/application-tile.c:867
-msgid "Remove from Startup Programs"
-msgstr ""
-
-#: ../libslab/application-tile.c:869
-msgid "Add to Startup Programs"
-msgstr ""
-
-#: ../libslab/app-shell.c:753
-#, c-format
-msgid ""
-"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
-"\n"
-" Your filter \"<b>%s</b>\" does not match any items.</span>"
-msgstr ""
-
-#: ../libslab/app-shell.c:903
-msgid "Other"
-msgstr "Boshqa"
-
-#: ../libslab/bookmark-agent.c:1077
-msgid "New Spreadsheet"
-msgstr "Yangi elektron jadval"
-
-#: ../libslab/bookmark-agent.c:1082
-msgid "New Document"
-msgstr "Yangi hujjat"
-
-#: ../libslab/bookmark-agent.c:1135
-msgid "Home"
-msgstr ""
-
-#: ../libslab/bookmark-agent.c:1140
-msgid "Documents"
-msgstr ""
-
-#: ../libslab/bookmark-agent.c:1153
-msgid "File System"
-msgstr "Fayl tizimi"
-
-#: ../libslab/bookmark-agent.c:1157
-msgid "Network Servers"
-msgstr "Tarmoq serverlari"
-
-#: ../libslab/bookmark-agent.c:1186
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Qidirish"
 
-#. make open with default action
-#: ../libslab/directory-tile.c:171
-#, c-format
-msgid "<b>Open</b>"
-msgstr "<b>Ochish</b>"
-
-#. make rename action
-#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:231
-msgid "Rename..."
-msgstr "Nomini oʻzgartirish..."
-
-#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
-#: ../libslab/document-tile.c:245 ../libslab/document-tile.c:254
-msgid "Send To..."
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#. make move to trash action
-#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:280
-msgid "Move to Trash"
-msgstr "Chiqindilar qutisiga olib tashlash"
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Oʻchirilgan"
 
-#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
-#: ../libslab/document-tile.c:290 ../libslab/document-tile.c:831
-msgid "Delete"
-msgstr "Olib tashlash"
-
-#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:979
-#, c-format
-msgid "Are you sure you want to permanently delete \"%s\"?"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
 msgstr ""
 
-#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:980
-msgid "If you delete an item, it is permanently lost."
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
 msgstr ""
 
-#: ../libslab/document-tile.c:192
-#, c-format
-msgid "<b>Open with \"%s\"</b>"
-msgstr "<b>\"%s\" bilan ochish</b>"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Orqa fon"
 
-#: ../libslab/document-tile.c:204
-msgid "Open with Default Application"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Ekran"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Gulqogʻozsiz"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Tovushlar"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Tugmalar birikmasi"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Klaviatura tugmalar birikmasi:"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Tovush yoʻq"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Ogohlantirish turi"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "_Dastur shrifti:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>El.pochta</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Uslubi:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Andoza"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Orqa fon"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Tashqi koʻrinishi"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Ekran oʻlchami"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Katta oq koʻrsatgich"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "fayl nomi"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "fayl nomi"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Fayllardan nusxa olinmoqda"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Hamma fayllar"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Import"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Qoʻshish..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "_Yuklangan fayllar:"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Tafsilotlar"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "daqiqa"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "_Oʻrtacha"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "daqiqa"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "daqiqa"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Ranglar"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Rasmni tanlang"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Tanlash"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Tovush yoʻq"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Qidirish"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "_Kechikish:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "Qidirish uchun tugmalar birikmasi."
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Oʻchirilgan"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "soniya"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Ta_qvim:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Ta_qvim:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
 msgstr "Andoza dastur bilan ochish"
 
-#: ../libslab/document-tile.c:215
-msgid "Open in File Manager"
-msgstr "Fayl menejerida ochish"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Andoza dastur bilan ochish"
 
-#: ../libslab/document-tile.c:611
-msgid "?"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
 msgstr ""
 
-#: ../libslab/document-tile.c:618
-msgid "%l:%M %p"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
 msgstr ""
 
-#: ../libslab/document-tile.c:626
-msgid "Today %l:%M %p"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
 msgstr ""
 
-#: ../libslab/document-tile.c:636
-msgid "Yesterday %l:%M %p"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
 msgstr ""
 
-#: ../libslab/document-tile.c:648
-msgid "%a %l:%M %p"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
 msgstr ""
 
-#: ../libslab/document-tile.c:656
-msgid "%b %d %l:%M %p"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
 msgstr ""
 
-#: ../libslab/document-tile.c:658
-msgid "%b %d %Y"
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Shriftni _qoʻllash"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
 msgstr ""
 
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
 msgstr ""
 
-#: ../libslab/system-tile.c:128
-#, c-format
-msgid "<b>Open %s</b>"
-msgstr "<b>%s'ni ochish</b>"
-
-#: ../libslab/system-tile.c:141
-#, c-format
-msgid "Remove from System Items"
-msgstr "Tizim elementlaridan olib tashlash"
-
-#: ../libwindow-settings/gnome-wm-manager.c:316
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
 msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:404
-msgid "Maximize"
-msgstr "Yoyish"
-
-#: ../libwindow-settings/metacity-window-manager.c:405
-msgid "Maximize Vertically"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
 msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:406
-msgid "Maximize Horizontally"
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
 msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:407
-msgid "Minimize"
-msgstr "Yigʻish"
-
-#: ../libwindow-settings/metacity-window-manager.c:408
-msgid "Roll up"
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
 msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:409
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Oʻlchami:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "_Yangilanish darajasi"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Filtr"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "daqiqa"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Uskunalar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Nomi:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Turi"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME terminali"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Oynalar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Uskunalar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Uskunalar"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Nomini oʻzgartirish..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Haqida"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Ovozni oʻchirish uchun tugmalar birikmasi"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Tovushni pasaytirish"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+#, fuzzy
+msgid "Volume up"
+msgstr "Tovush"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+#, fuzzy
+msgid "Launch media player"
+msgstr "Musiqa pleyeri"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+#, fuzzy
+msgid "Play (or play/pause)"
+msgstr "Oʻynash (yoki oʻynash/vaqtincha toʻxtatish) tugmalar birikmasi."
+
+#: panels/keyboard/00-multimedia.xml.in:16
+#, fuzzy
+msgid "Pause playback"
+msgstr "T_ovushni oʻynash:"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Oʻynashni toʻxtatish tugmasi"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Oldin yoʻlakchaga oʻtish"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Keyingi yoʻlakchaga oʻtish"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Chiqarish"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Keyingi yoʻlakchaga oʻtish"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Oldin yoʻlakchaga oʻtish"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Veb brauzerni ishga tushirish"
+
+#: panels/keyboard/01-launchers.xml.in:4
+#, fuzzy
+msgid "Launch help browser"
+msgstr "Veb brauzerni ishga tushirish"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Andoza moslamalar"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Veb brauzerni ishga tushirish"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Uy jildi"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Qidirish"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Tizim"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Seansni tugatish"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Ekranni qulflash"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Seansni tugatish"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Parametrlar"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Parametrlar"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Klaviatura tugmalar birikmasi:"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "_Kiritish maydonlari:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "Barcha protokollar uchun bitta proksidan _foydalanish"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Sichqoncha tugmalari"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Klaviatura tugmalar birikmasi:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Amal"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Tugmalar birikmasi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Tugmalar birikmasi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Tugmalar birikmasi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Klaviatura tugmalar birikmasi:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Nomi:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Buy_ruq:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Tugmalar birikmasi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Tugmalar birikmasi"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Yoʻq"
 
-#: ../shell/control-center.c:54
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Andoza qiymatga _qaytarish"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Klaviatura"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Shaxsiy maʼlumotlaringiz"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Andoza moslamalar"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+msgid "Pointer Location"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Sichqoncha"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Sichqoncha tugmalari"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "Yangi akselerator..."
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_Dastur shrifti:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Uskunalar"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Amal"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Aloqa oʻrnatilmoqda..."
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Parametrlar"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "key not found [%s]\n"
-msgstr ""
-
-#: ../shell/control-center.c:151
-msgid "Filter"
-msgstr "Filtr"
-
-#: ../shell/control-center.c:151
-msgid "Groups"
-msgstr "Guruhlar"
-
-#: ../shell/control-center.c:151
-msgid "Common Tasks"
-msgstr ""
-
-#: ../shell/control-center.c:155 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Boshqaruv markazi"
-
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:5
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:8
-msgid "Indicates whether to close the shell when an add or remove action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:9
-msgid "Indicates whether to close the shell when an upgrade or uninstall action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:11
-msgid "The task name to be displayed in the control-center followed by a \";\" separator then the filename of an associated .desktop file to launch for that task."
-msgstr ""
-
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
-msgid "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:14
-msgid "if true, the control-center will close when a \"Common Task\" is activated."
-msgstr ""
-
-#: ../shell/gnomecc.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "GNOME moslash vositasi"
-
-#: ../typing-break/drw-break-window.c:189
-msgid "_Postpone Break"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:245
-msgid "Take a break!"
-msgstr ""
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#. translators: keep the initial "/"
-#: ../typing-break/drwright.c:129
-msgid "/_Preferences"
-msgstr "/_Parametrlar"
-
-#: ../typing-break/drwright.c:130
-msgid "/_About"
-msgstr "/_Haqida"
-
-#: ../typing-break/drwright.c:132
-msgid "/_Take a Break"
-msgstr ""
-
-#: ../typing-break/drwright.c:488
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../typing-break/drwright.c:492
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Tarmoq serverlari"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Maxfiy soʻz:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Joriy _maxfiy soʻz:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Akselerator usuli"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
-msgid "Less than one minute until the next break"
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
 msgstr ""
 
-#: ../typing-break/drwright.c:579
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Manzil"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Manzil"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Manzil"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Andoza koʻrsatgich"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Nomi:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Manzil:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Manzil:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Oʻchirilgan"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Manzil"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Manzil"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "Avto-aniqlash"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "daqiqa"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Tarmoq proksisi"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "_Aktivlashtirilsin"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "Manzil"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Tarmoq proksisi"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "H_TTP proksi:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "H_TTP proksi:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP proksi:"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "H_TTP proksi:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "H_TTP proksi:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP proksi:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Avto-moslash _URL'i:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Tarmoq serverlari"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Maxfiy soʻz:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "Tasdiqlandi!"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "Hamma fayllar"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>Tasdiqlashdan _foydalanish</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "F_oydalunuvchi:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Maxfiy soʻz:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Yangi maxfiy soʻz:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Versiyasi:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Versiyasi:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_Tasdiqlash"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Yangi maxfiy soʻz:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_Tasdiqlash"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Turi"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Andoza"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Fayl tizimi"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr ""
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Tovushlar"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Ekranni qulflash tugmalar birikmasi."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Ekranni qulflash tugmalar birikmasi."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>Tasdiqlashdan _foydalanish</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "daqiqa"
+msgstr[1] "daqiqa"
+
+#: panels/power/cc-battery-row.c:92
 #, c-format
-msgid "Unable to bring up the typing break properties dialog with the following error: %s"
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "daqiqa"
+msgstr[1] "daqiqa"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "daqiqa"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "daqiqa"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "daqiqa"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "daqiqa"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "daqiqa"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
 msgstr ""
 
-#: ../typing-break/drwright.c:598
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "Muallif: Richard Xalt (Richard Hult) <richard@imendio.com>"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "daqiqa"
 
-#: ../typing-break/drwright.c:599
-msgid "Eye candy added by Anders Carlsson"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "daqiqa"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "daqiqa"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
 msgstr ""
 
-#: ../typing-break/drwright.c:608
-msgid "A computer break reminder."
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
 msgstr ""
 
-#: ../typing-break/drwright.c:610
-msgid "translator-credits"
-msgstr "Nurali Abdurahmonov <mavnur@gmail.com>"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Uskunalar"
 
-#: ../typing-break/main.c:61
-msgid "Enable debugging code"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Akselerator usuli"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
 msgstr ""
 
-#: ../typing-break/main.c:63
-msgid "Don't check whether the notification area exists"
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
 msgstr ""
 
-#: ../typing-break/main.c:89
-msgid "Typing Monitor"
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
 msgstr ""
 
-#: ../typing-break/main.c:105
-msgid "The typing monitor uses the notification area to display information. You don't seem to have a notification area on your panel. You can add it by right-clicking on your panel and choosing 'Add to panel', selecting 'Notification area' and clicking 'Add'."
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Ekran"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Ekran"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:5
-msgid "Set this key to the command used to create thumbnails for OpenType fonts."
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:7
-msgid "Set this key to the command used to create thumbnails for TrueType fonts."
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Kechikish:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "_Bosib chiqarish"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
 
-#: ../font-viewer/font-view.c:113
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "Oq choynakka oq qopqoq, koʻk choynakka koʻk qopqoq. 0123456789"
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
 
-#: ../font-viewer/font-view.c:275
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Tovush yoʻq"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Tasdiqlandi!"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "F_oydalunuvchi:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Amal"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Oʻrnatib boʻlmadi"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Tanlash"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_Tasdiqlash"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Tasdiqlash"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Sinash"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Parametrlar"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "_Tafsilotlar"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Andoza qiymatga _qaytarish"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Iltimos aplet toʻgʻri oʻrnatilganligiga ishonch xosil qiling"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "Oʻrtacha"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Hamma fayllar"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Oldindan koʻrish:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "_Boʻlim:"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "Chiqish"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Ekranni qulflash"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "Musiqa pleyeri"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Amal"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Turi:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Ekran"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Ekranni qulflash"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Ekran"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ekran"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "%d ekran moslamalari\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Boshqa"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Amal"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_Dastur shrifti:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Qidirish uchun tugmalar birikmasi."
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Tarmoq serverlari"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Ish stoli"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "Musiqa pleyeri"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Maxfiy soʻz:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Ish stoli"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Grafik interfeys boshqaruvi"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Nusxa olish"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Tasdiqlash"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Foydalanuvchi nomi:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "Musiqa pleyeri"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Tizim tovushlari"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Tovush"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Uskunalar"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Sinash"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Proksi parametrlari"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Uskunalar"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Tovush"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Ogohlantirish tugmalari"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Tovush"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Nomi:"
 
-#: ../font-viewer/font-view.c:278
-msgid "Style:"
-msgstr "Uslubi:"
-
-#: ../font-viewer/font-view.c:291
-msgid "Type:"
-msgstr "Turi:"
-
-#: ../font-viewer/font-view.c:295
-msgid "Size:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
 
-#: ../font-viewer/font-view.c:339 ../font-viewer/font-view.c:352
-msgid "Version:"
-msgstr "Versiyasi:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../font-viewer/font-view.c:343 ../font-viewer/font-view.c:354
-msgid "Copyright:"
-msgstr "Mualliflik huquqi:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../font-viewer/font-view.c:347
-msgid "Description:"
-msgstr "Taʼrifi:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Uskunalar"
 
-#: ../font-viewer/font-view.c:437
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Uskunalar"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Tezlik:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Tugmalar birikmasi"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Tugmalar birikmasi"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Kichkina"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Katta"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Ikki tugma birga bosilsa, _oʻchirish"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Sichqoncha tugmalari"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Tugmalar birikmasi"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "_modifikator bosilganda signal berish"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "_modifikator bosilganda signal berish"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Sichqoncha tugmalari"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Tugmalar birikmasi"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Klaviatura maxsus imkoniyatlari"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Katta"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Ekran"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Tovushlar"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Klaviatura"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Sichqoncha tugmalari"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Katta koʻrsatgich"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Ekran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Parametrlar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Ekran"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "Ranglar"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr ""
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Yoʻq"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Toʻliq ism"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "Ranglar"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Fayl tizimi"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "Chiqindilar qutisiga olib tashlash"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "Aktivlashtiril_masin"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Yangi maxfiy soʻz:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Tovush faylini tanlang"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Yoʻq"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Oldindan koʻrish:"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Maxfiy soʻzni oʻzgartirish"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Joriy _maxfiy soʻz:"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Yangi maxfiy soʻz:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Maxfiy soʻzni oʻzgartirish"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Maxfiy soʻz juda qisqa."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Yangi maxfiy soʻz:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Toʻliq ism"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Tahrirlash"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Andoza dastur bilan ochish"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Boshqa"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Tovush yoʻq"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Tugmalar"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Tugmalar"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Tugmalar"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Tugmalar"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Tugmalar tartibi"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Oynalar"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Tugatish uchun OK tugmasini bosing."
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Oynalar"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Tizimga _kirishdagi yordamchi texnologiyalar"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Manzil"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Saqlash"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Tafsilotlar"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Tarmoq proksisi"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Tarmoq serverlari"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Uskunalar"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid "usage: %s fontfile\n"
-msgstr ""
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
-msgid "Font Viewer"
-msgstr ""
-
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
-msgid "Preview fonts"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:243
-msgid "Text to thumbnail (default: Aa)"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:243
-msgid "TEXT"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "Font size (default: 64)"
-msgstr "Shrift oʻlchami (andoza: 64)"
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "SIZE"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "FONT-FILE OUTPUT-FILE"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:263
+#: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
-msgid "Error parsing arguments: %s\n"
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "Uyali telefon:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Tarmoq proksisi"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Tarmoq proksisi"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Tafsilotlar"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Tarmoq proksisi"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_Tasdiqlash"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "Tarmoq serverlari"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Aloqa oʻrnatilmoqda..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Andoza moslamalar"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Yordam"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Chiqish"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Qidirish"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Oldin yoʻlakchaga oʻtish"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Parametrlar"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgid "Image/label border"
+#~ msgstr "Rasm/yorliq chegarasi"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "Ogohlantirish dialogidagi rasm va yorliqlarning kengligi"
+
+#~ msgid "The type of alert"
+#~ msgstr "Ogohlantirish turi"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Ogohlantirish oynasida koʻrsatiladigan tugmalar"
+
+#~ msgid "Show more _details"
+#~ msgstr "_Tafsilotlarni koʻrsatish"
+
+#~ msgid "No Image"
+#~ msgstr "Rasmsiz"
+
+#~ msgid "Images"
+#~ msgstr "Rasmlar"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Manzillar daftaridan maʼlumot olib boʻlmadi.\n"
+#~ "Evolution maʼlumot serveri protokolni qoʻllamaydi"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Manzillar daftarini ochib boʻlmadi"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr ""
+#~ "Nomaʼlum foydalanuvchi ID'si. foydalanuvchi maʼlumot bazasi zararlangan "
+#~ "boʻlishi mumkin"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "%s haqida"
+
+#~ msgid "About Me"
+#~ msgstr "Men haqimda"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Uy</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Telefon</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>WWW</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Ish</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr ""
+#~ "<span size=\"larger\" weight=\"bold\">Maxfiy soʻzni oʻzgartirish</span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "_Manzil:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "_Yordamchi:"
+
+#~ msgid "C_ity:"
+#~ msgstr "_Shahar:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "_Tashkilot:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Maxfiy _soʻzni oʻzgartirish..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "Maxfiy s_oʻzni oʻzgartirish"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Sh_ahar:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "_Davlat:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "Dav_lat:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "U_y:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "Pochta q_utisi:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "_Pochta qutisi:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Shaxsiy maʼlumot"
+
+#~ msgid "Select your photo"
+#~ msgstr "Rasm tanlang"
+
+#~ msgid "Wor_k:"
+#~ msgstr "I_sh:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "_Faks (ish):"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "_Pochta indeksi:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Uy sahifasi:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Uy:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Boshqaruvchi:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Ish:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "Pochta _indeksi:"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr ""
+#~ "Maxfiy soʻzingiz keyingi safargi tasdiqlanishdan keyin oʻzgartiriladi! "
+#~ "Iltimos qayta tasdiqlang."
+
+#~ msgid "That password was incorrect."
+#~ msgstr "Maxfiy soʻz xato."
+
+#~ msgid "Your password has been changed."
+#~ msgstr "Maxfiy soʻzingiz oʻzgartirildi."
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "Tizim xatosi: %s."
+
+#~ msgid "The password is too simple."
+#~ msgstr "Maxfiy soʻz juda oddiy."
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "Eski va yangi maxfiy soʻz juda oʻxshash."
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr ""
+#~ "Yangi maxfiy soʻz raqam va maxsus belgi(lar)dan iborat boʻlishi kerak."
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "Eski va yangi maxfiy soʻz bir xil."
+
+#~ msgid "A system error has occurred"
+#~ msgstr "Tizimda xatolik roʻy berdi"
+
+#~ msgid "Checking password..."
+#~ msgstr "Maxfiy soʻz tekshirilmoqda..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr ""
+#~ "Maxfiy soʻzni oʻzgartirish uchun <b>Maxfiy soʻzni oʻzgartirish</b> "
+#~ "tugmasini bosing."
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "Iltimos <b>yangi maxfiy soʻz</b> maydoniga maxfiy soʻzni kiriting."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "Ikkala maxfiy soʻz mos kelmadi."
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>Yordamchi texnologiyalar</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>Parametrlar</b>"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Yopish va tizimdan _chiqish"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "Yordamchi texnologiyalarni _yoqish"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Gulqogʻoz qoʻshish"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Shrift juda katta boʻlishi mumkin"
+
+#~ msgid "Use previous font"
+#~ msgstr "Oldingi shriftdan foydalanish"
+
+#~ msgid "Use selected font"
+#~ msgstr "Tanlangan shriftdan foydalanish"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Oʻrnatiladigan mavzu fayli nomini koʻrsating"
+
+#~ msgid "page"
+#~ msgstr "sahifa"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[GULQOGʻOZ...]"
+
+#~ msgid "Apply Font"
+#~ msgstr "Shriftni qoʻllash"
+
+#~ msgid "Custom"
+#~ msgstr "Boshqa"
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>_Ranglar</b>"
+
+#~ msgid "<b>Menus and Toolbars</b>"
+#~ msgstr "<b>Menyu va asboblar paneli</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Oldindan koʻrish</b>"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>_Gulqogʻoz</b>"
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "Tashqi koʻrinishni moslash"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Eng yaxshi _shakllar"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Eng yaxshi ko_ntrast"
+
+#~ msgid "C_ut"
+#~ msgstr "K_yesish"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "Kursor mavzusi keyingi safar tizimga kirganda kuchga kiradi."
+
+#~ msgid "D_etails..."
+#~ msgstr "_Tafsilotlar..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Ish _stoli shrifti:"
+
+#~ msgid "Fonts"
+#~ msgstr "Shriftlar"
+
+#~ msgid "Icons"
+#~ msgstr "Nishonchalar"
+
+#~ msgid "Interface"
+#~ msgstr "Interfeys"
+
+#~ msgid "N_one"
+#~ msgstr "_Yoʻq"
+
+#~ msgid "New File"
+#~ msgstr "Yangi  fayl"
+
+#~ msgid "Open File"
+#~ msgstr "Faylni ochish"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Rangni koʻrsatish uchun dialogni ochish"
+
+#~ msgid "R_esolution:"
+#~ msgstr "Oʻ_lchami:"
+
+#~ msgid "Save File"
+#~ msgstr "Faylni saqlash"
+
+#~ msgid "Save _background image"
+#~ msgstr "_Orqa fon rasmini saqlash"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Menyularda _nishonchalarni koʻrsatish"
+
+#~ msgid "Text"
+#~ msgstr "Matn"
+
+#~ msgid "Theme"
+#~ msgstr "Mavzu"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "Window Border"
+#~ msgstr "Oyna chegarasi"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "_Taʼrifi:"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Hujjat shrifti:"
+
+#~ msgid "_File"
+#~ msgstr "_Fayl"
+
+#~ msgid "_Install..."
+#~ msgstr "_Oʻrnatish..."
+
+#~ msgid "_New"
+#~ msgstr "_Yangi"
+
+#~ msgid "_Paste"
+#~ msgstr "_Qoʻyish"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Selected items:"
+#~ msgstr "_Tanlangan elementlar:"
+
+#~ msgid "_Size:"
+#~ msgstr "_Hajmi:"
+
+#~ msgid "_Style:"
+#~ msgstr "_Uslub:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Oyna sarlavhasi shrifti:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Oynalar:"
+
+#~ msgid "Theme Installer"
+#~ msgstr "Mavzu oʻrnatgich"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Gnome mavzu paketi"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "piksel"
+#~ msgstr[1] "piksel"
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "%s Gnome mavzusi muvaffaqiyatli oʻrnatildi"
+
+#, c-format
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "\"%s\" mavzu oʻrnatildi."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "Uni qoʻllashni istaysizmi yoki joriy mavzuni saqlab qolasizmi?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Joriy mavzu saqlab qolinsin"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Yangi mavzu qoʻllansin"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Vaqtinchalik direktoriya yaratib boʻlmadi"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Oʻrnatish uchun mavzu fayli yoʻli koʻrsatilmagan"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Mavzuni quyidagi manzilga oʻrnatish uchun huquq yetarli emas:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "Mavzuni tanlash"
+
+#~ msgid "Theme Packages"
+#~ msgstr "Mavzu paketlari"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Mavzu allaqachon mavjud. Almashtirishni istaysizmi?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_Almashtirish"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Ushbu mavzuni olib tashlashni istaysizmi?"
+
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "Mavzuni olib tashlab boʻlmaydi"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Yordam faylini koʻrsatishda xatolik yuz berdi: %s"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Fayldan nusxa olinmoqda: %u dan %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' nusxa olinmoqda"
+
+#~ msgid "Current URI index"
+#~ msgstr "Joriy URI indeksi"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Joriy URI indeksi - 1'dan boshlanadi"
+
+#~ msgid "Total URIs"
+#~ msgstr "Jami URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Jami URI soni"
+
+#~ msgid "Key"
+#~ msgstr "Kalit"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "'%s' faylini topib boʻlmadi.\n"
+#~ "\n"
+#~ "Iltimos uni mavjudligini tekshirib koʻring va qayta urinib koʻring yoki "
+#~ "boshqa orqa fon rasmini tanlang."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' faylini qanday ochish mumkin.\n"
+#~ "Balki bu rasm turi xali qoʻllanilmasligi mumkin.\n"
+#~ "\n"
+#~ "Iltimos buning oʻrniga boshqa rasm tanlang."
+
+#~ msgid "Please select an image."
+#~ msgstr "Iltimos rasm tanlang."
+
+#~ msgid "White Pointer"
+#~ msgstr "Oq koʻrsatgich"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Oq koʻrsatgich - joriy"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Katta koʻrsatgich - joriy"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Katta oq koʻrsatgich - joriy"
+
+#~ msgid "Select your default applications"
+#~ msgstr "Andoza dasturni tanlang"
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Moslamani saqlash xatoligi: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Asosiy interfeysni yuklab boʻlmadi"
+
+#~ msgid "<b>Multimedia Player</b>"
+#~ msgstr "<b>Multimedia pleyeri</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Terminal emulyatori</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Matn tahrirchisi</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Video pleyer</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Veb-brauzer</b>"
+
+#~ msgid "Internet"
+#~ msgstr "Internet"
+
+#~ msgid "Multimedia"
+#~ msgstr "Multimedia"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Bogʻlamani yangi _tabda ochish"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Bogʻlamani yangi _oynada ochish"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Bogʻlamani brauzer _andozasi bilan ochish"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "T_yerminalda bajarish"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee musiqiy pleyeri"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian terminal emulyatori"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Epiphany veb brauzeri"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution pochta klienti"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "Muine musiqa pleyeri"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox musiqa pleyeri"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Andoza X-terminali"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem pleyeri"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Ekran oʻlchamini oʻzgartirish"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Gs"
+
+#~ msgid "Accelerator key"
+#~ msgstr "Akselerator tugmasi"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Akselerator modifikatorlari"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Akselerator tugmasi kodi"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Akselerator turi."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Nomaʼlum amal>"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Buyruqlarga tugmalar birikmasi tayinlash"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- GNOME klaviatura parametrlari"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Tez</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Uzun</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Qisqa</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Sekin</i></small>"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Klaviatura rusumini tanlang"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Tugmalar tartibini tanlang"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Klaviatura moslamalari"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Klaviatura _rusumi:"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "_Andoza parametrlarni tiklash"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Tezlik:"
+
+#~ msgid "Separate _layout for each window"
+#~ msgstr "Har bir oyna uchun alohida _tugmalar tartibi"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Tanlangan tugmalar tartibi:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "Parametrlarni _sinash maydoni:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Variantlar:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_Ish.chiqaruvchilar:"
+
+#~ msgid "Unknown"
+#~ msgstr "Nomaʼlum"
+
+#~ msgid "Vendors"
+#~ msgstr "Ish.chiqaruvchilar"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Ushlab olib qoʻyish</b>"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Sichqoncha moslamalari"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Internetga _toʻgʻridan-toʻgʻri ulanish</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>Proksi moslamasini _avto-aniqlash</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Proksi moslamalarini _qoʻlbola koʻrsatish</b>"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Tarmoq proksi moslamalari"
+
+#~ msgid "Port:"
+#~ msgstr "Port:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "HTTP_S proksi:"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "_Meta"
+#~ msgstr "_Meta"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Oyna tanlash</b>"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Oyna parametrlari"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Oyna moslamalarini oʻrnatish"
+
+#, c-format
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>%s'ni ishga tushirish</b>"
+
+#~ msgid "Upgrade"
+#~ msgstr "Yangilash"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "Yangi elektron jadval"
+
+#~ msgid "New Document"
+#~ msgstr "Yangi hujjat"
+
+#, c-format
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Ochish</b>"
+
+#~ msgid "Delete"
+#~ msgstr "Olib tashlash"
+
+#, c-format
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>\"%s\" bilan ochish</b>"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "Fayl menejerida ochish"
+
+#, c-format
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s'ni ochish</b>"
+
+#, c-format
+#~ msgid "Remove from System Items"
+#~ msgstr "Tizim elementlaridan olib tashlash"
+
+#~ msgid "Maximize"
+#~ msgstr "Yoyish"
+
+#~ msgid "Minimize"
+#~ msgstr "Yigʻish"
+
+#~ msgid "Groups"
+#~ msgstr "Guruhlar"
+
+#~ msgid "Control Center"
+#~ msgstr "Boshqaruv markazi"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME moslash vositasi"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Muallif: Richard Xalt (Richard Hult) <richard@imendio.com>"
+
+#~ msgid "translator-credits"
+#~ msgstr "Nurali Abdurahmonov <mavnur@gmail.com>"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Oq choynakka oq qopqoq, koʻk choynakka koʻk qopqoq. 0123456789"
+
+#~ msgid "Copyright:"
+#~ msgstr "Mualliflik huquqi:"
+
+#~ msgid "Description:"
+#~ msgstr "Taʼrifi:"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Shrift oʻlchami (andoza: 64)"
 
 #~ msgid " "
 #~ msgstr " "
@@ -3364,14 +6055,15 @@ msgstr ""
 #~ msgid "Import Feature Settings File"
 #~ msgstr "Parametrlar faylini import qilish"
 
-#~ msgid "_Import"
-#~ msgstr "_Import"
-
 #~ msgid "Keyboard Accessibility"
 #~ msgstr "Klaviatura maxsus imkoniyatlari"
 
-#~ msgid "This system does not seem to have the XKB extension.  The keyboard accessibility features will not operate without it."
-#~ msgstr "Tizimda XKB kengaytmasi yoʻq.  Klaviatura maxsus imkoniyatlari usiz ishlamaydi."
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Tizimda XKB kengaytmasi yoʻq.  Klaviatura maxsus imkoniyatlari usiz "
+#~ "ishlamaydi."
 
 #~ msgid "Basic"
 #~ msgstr "Asosiy"
@@ -3379,14 +6071,8 @@ msgstr ""
 #~ msgid "Beep when _features turned on or off from keyboard"
 #~ msgstr "Klaviaturadan tugmalar _aktivlashtirilganda signal berish"
 
-#~ msgid "Beep when _modifier is pressed"
-#~ msgstr "_modifikator bosilganda signal berish"
-
 #~ msgid "Del_ay:"
 #~ msgstr "Ke_chikish:"
-
-#~ msgid "Disa_ble if two keys pressed together"
-#~ msgstr "Ikki tugma birga bosilsa, _oʻchirish"
 
 #~ msgid "Filters"
 #~ msgstr "Filtrlar"
@@ -3444,23 +6130,20 @@ msgstr ""
 #~ msgid "The file format is invalid"
 #~ msgstr "Faylning formati xato"
 
-#~ msgid "Installation Failed"
-#~ msgstr "Oʻrnatib boʻlmadi"
-
 #~ msgid "This theme is not in a supported format."
 #~ msgstr "Mavzu qoʻllanilmaydigan formatda."
 
-#~ msgid "%s is the path where the theme files will be installed. This can not be selected as the source location"
-#~ msgstr "%s mavzu oʻrnatiladigan yoʻldir. Undan manba sifatida foydalanib boʻlmaydi"
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s mavzu oʻrnatiladigan yoʻldir. Undan manba sifatida foydalanib boʻlmaydi"
 
 #~ msgid "The file format is invalid."
 #~ msgstr "Faylning formati xato."
 
 #~ msgid "Just apply settings and quit"
 #~ msgstr "Faqat moslamalarni qoʻllash va chiqish"
-
-#~ msgid "Connecting..."
-#~ msgstr "Aloqa oʻrnatilmoqda..."
 
 #~ msgid "Evolution Mail Reader 1.4"
 #~ msgstr "Evolution 1.4 pochta klienti"
@@ -3489,25 +6172,24 @@ msgstr ""
 #~ msgid "W3M Text Browser"
 #~ msgstr "W3M matnli veb brauzer"
 
-#~ msgid "Default Settings"
-#~ msgstr "Andoza moslamalar"
-
-#~ msgid "Screen %d Settings\n"
-#~ msgstr "%d ekran moslamalari\n"
-
 #~ msgid "Screen Resolution Preferences"
 #~ msgstr "Ekran oʻlchami parametrlari"
 
 #~ msgid "_Make default for this computer (%s) only"
 #~ msgstr "Ushbu kompyuter (%s) uchun andoza etib _belgilash"
 
-#~ msgid "Options"
-#~ msgstr "Parametrlar"
-
-#~ msgid "Testing the new settings. If you don't respond in %d second the previous settings will be restored."
-#~ msgid_plural "Testing the new settings. If you don't respond in %d seconds the previous settings will be restored."
-#~ msgstr[0] "Moslamalarni tekshirish. Agar %d soniya ichida tasdiqlamasangiz eski moslama qoʻllaniladi."
-#~ msgstr[1] "Moslamalarni tekshirish. Agar %d soniya ichida tasdiqlamasangiz eski moslama qoʻllaniladi."
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Moslamalarni tekshirish. Agar %d soniya ichida tasdiqlamasangiz eski "
+#~ "moslama qoʻllaniladi."
+#~ msgstr[1] ""
+#~ "Moslamalarni tekshirish. Agar %d soniya ichida tasdiqlamasangiz eski "
+#~ "moslama qoʻllaniladi."
 
 #~ msgid "Keep Resolution"
 #~ msgstr "Ushbu oʻlchamni saqlab qolish"
@@ -3520,9 +6202,6 @@ msgstr ""
 
 #~ msgid "_Keep resolution"
 #~ msgstr "Ushbu oʻlchamni _saqlab qolish"
-
-#~ msgid "New accelerator..."
-#~ msgstr "Yangi akselerator..."
 
 #~ msgid ""
 #~ "The shortcut \"%s\" is already used for:\n"
@@ -3567,9 +6246,6 @@ msgstr ""
 #~ msgid "<i>Small</i>"
 #~ msgstr "<i>Kichik</i>"
 
-#~ msgid "Buttons"
-#~ msgstr "Tugmalar"
-
 #~ msgid "Motion"
 #~ msgstr "Harakat"
 
@@ -3584,9 +6260,6 @@ msgstr ""
 
 #~ msgid "Unknown Volume Control %d"
 #~ msgstr "Nomaʼlum tovush moslovchisi %d"
-
-#~ msgid "Autodetect"
-#~ msgstr "Avto-aniqlash"
 
 #~ msgid "ALSA - Advanced Linux Sound Architecture"
 #~ msgstr "ALSA - Takomillashtirilgan Linux tovush tizimi"
@@ -3615,29 +6288,14 @@ msgstr ""
 #~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
 #~ msgstr "<span weight=\"bold\" size=\"x-large\">Sinalmoqda...</span>"
 
-#~ msgid "Click OK to finish."
-#~ msgstr "Tugatish uchun OK tugmasini bosing."
-
-#~ msgid "Devices"
-#~ msgstr "Uskunalar"
-
-#~ msgid "S_ound playback:"
-#~ msgstr "T_ovushni oʻynash:"
-
 #~ msgid "So_und playback:"
 #~ msgstr "To_vushni oʻynash:"
 
 #~ msgid "Sound Preferences"
 #~ msgstr "Tovush parametrlari"
 
-#~ msgid "Sounds"
-#~ msgstr "Tovushlar"
-
 #~ msgid "System Beep"
 #~ msgstr "Tizim tovushi"
-
-#~ msgid "Test"
-#~ msgstr "Sinash"
 
 #~ msgid "_Device:"
 #~ msgstr "_Uskuna:"
@@ -3650,15 +6308,6 @@ msgstr ""
 
 #~ msgid "_Sound playback:"
 #~ msgstr "_Tovushni oʻynash:"
-
-#~ msgid "Volume"
-#~ msgstr "Tovush"
-
-#~ msgid "_Activate"
-#~ msgstr "_Aktivlashtirilsin"
-
-#~ msgid "Do_n't activate"
-#~ msgstr "Aktivlashtiril_masin"
 
 #~ msgid "Do _not show this warning again"
 #~ msgstr "Ushbu ogohlantirish boshqa koʻrsatil_masin"
@@ -3694,15 +6343,6 @@ msgstr ""
 #~ msgid "_Load"
 #~ msgstr "_Yuklash"
 
-#~ msgid "_Loaded files:"
-#~ msgstr "_Yuklangan fayllar:"
-
-#~ msgid "Type"
-#~ msgstr "Turi"
-
-#~ msgid "Screen"
-#~ msgstr "Ekran"
-
 #~ msgid "No valid bookmark file found in data dirs"
 #~ msgstr "Maʼlumotlar direktoriyasida xatchoʻp topilmadi"
 
@@ -3718,21 +6358,16 @@ msgstr ""
 #~ msgid "Login"
 #~ msgstr "Kirish"
 
-#~ msgid "Logout"
-#~ msgstr "Chiqish"
-
 #~ msgid "Boing"
 #~ msgstr "Boing"
-
-#~ msgid "No sound"
-#~ msgstr "Tovush yoʻq"
 
 #~ msgid "Sound not set for this event."
 #~ msgstr "Ushbu hodisa uchun tovush oʻrnatilmagan."
 
 #~ msgid ""
 #~ "The sound file for this event does not exist.\n"
-#~ "You may want to install the gnome-audio package for a set of default sounds."
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
 #~ msgstr ""
 #~ "Ushbu hodisa uchun tovush fayli mavjud emas.\n"
 #~ "Andoza tovushlaridan foydalanish uchun gnome-audio paketlarini oʻrnating."
@@ -3740,17 +6375,11 @@ msgstr ""
 #~ msgid "The sound file for this event does not exist."
 #~ msgstr "Ushbu hodisa uchun tovush fayli mavjud emas."
 
-#~ msgid "Select Sound File"
-#~ msgstr "Tovush faylini tanlang"
-
 #~ msgid "The file %s is not a valid wav file"
 #~ msgstr "%s fayli wav fayl emas"
 
 #~ msgid "Select sound file..."
 #~ msgstr "Tovush faylini tanlang..."
-
-#~ msgid "System Sounds"
-#~ msgstr "Tizim tovushlari"
 
 #~ msgid "E-mail"
 #~ msgstr "El.pochta"
@@ -3758,35 +6387,14 @@ msgstr ""
 #~ msgid "E-mail's shortcut."
 #~ msgstr "El.pochta klientini ishga tushirish tugmalar birikmasi."
 
-#~ msgid "Eject"
-#~ msgstr "Chiqarish"
-
-#~ msgid "Home folder"
-#~ msgstr "Uy jildi"
-
 #~ msgid "Home folder's shortcut."
 #~ msgstr "Uy jildi uchun tugmalar birikmasi."
-
-#~ msgid "Launch web browser"
-#~ msgstr "Veb brauzerni ishga tushirish"
 
 #~ msgid "Launch web browser's shortcut."
 #~ msgstr "Veb brauzerni ishga tushirish tugmalar birikmasi."
 
-#~ msgid "Lock screen"
-#~ msgstr "Ekranni qulflash"
-
-#~ msgid "Lock screen's shortcut."
-#~ msgstr "Ekranni qulflash tugmalar birikmasi."
-
-#~ msgid "Log out"
-#~ msgstr "Seansni tugatish"
-
 #~ msgid "Log out's shortcut."
 #~ msgstr "Seansni tugatish tugmalar birikmasi."
-
-#~ msgid "Media player"
-#~ msgstr "Musiqa pleyeri"
 
 #~ msgid "Pause"
 #~ msgstr "Vaqtincha toʻxtatish"
@@ -3794,44 +6402,20 @@ msgstr ""
 #~ msgid "Pause key's shortcut."
 #~ msgstr "Vaqtincha toʻxtatish tugmasi tugmalar birikmasi."
 
-#~ msgid "Play (or play/pause) key's shortcut."
-#~ msgstr "Oʻynash (yoki oʻynash/vaqtincha toʻxtatish) tugmalar birikmasi."
-
 #~ msgid "Previous track key's shortcut."
 #~ msgstr "Oldingi qoʻshiq uchun tugmalar birikmasi."
-
-#~ msgid "Search's shortcut."
-#~ msgstr "Qidirish uchun tugmalar birikmasi."
-
-#~ msgid "Skip to next track"
-#~ msgstr "Keyingi yoʻlakchaga oʻtish"
-
-#~ msgid "Skip to previous track"
-#~ msgstr "Oldin yoʻlakchaga oʻtish"
-
-#~ msgid "Stop playback key"
-#~ msgstr "Oʻynashni toʻxtatish tugmasi"
 
 #~ msgid "Stop playback key's shortcut."
 #~ msgstr "Oʻynashni toʻxtatish uchun tugmalar birikmasi."
 
-#~ msgid "Volume down"
-#~ msgstr "Tovushni pasaytirish"
-
 #~ msgid "Volume down's shortcut."
 #~ msgstr "Tovushni pasaytirish uchun tugmalar birikmasi"
-
-#~ msgid "Volume mute's shortcut."
-#~ msgstr "Ovozni oʻchirish uchun tugmalar birikmasi"
 
 #~ msgid "Run screensaver at login"
 #~ msgstr "Seans boshlanganda ekran saqlovchisini  ishga tushirish"
 
 #~ msgid "Start screensaver"
 #~ msgstr "Ekran saqlovchisini ishga tushirish"
-
-#~ msgid "Set as Application Font"
-#~ msgstr "Dastur shrifti sifatida oʻrnatish"
 
 #~ msgid "Sets the default application font"
 #~ msgstr "Andoza dastur shriftini tanlang"
@@ -3840,13 +6424,11 @@ msgstr ""
 #~ msgstr "GNOME shrift koʻruvchisi"
 
 #~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-#~ msgstr "<span weight=\"bold\" size=\"larger\">Yangi shrift qoʻllansinmi?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">Yangi shrift qoʻllansinmi?</span>"
 
 #~ msgid "Do _not apply font"
 #~ msgstr "Shrift _qoʻllanmasin"
-
-#~ msgid "_Apply font"
-#~ msgstr "Shriftni _qoʻllash"
 
 #~ msgid "Themes"
 #~ msgstr "Mavzular"

--- a/po/uz.po~
+++ b/po/uz.po~
@@ -1,0 +1,3873 @@
+# translation of gnome-control-center-2.0 to Uzbek
+# Copyright (C) 2008 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Nurali Abdurahmonov <mavnur@gmail.com>, 2007.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center-2.0 trunk\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-01-07 20:26+0500\n"
+"PO-Revision-Date: 2007-11-12 09:36+0500\n"
+"Last-Translator: Nurali Abdurahmonov <mavnur@gmail.com>\n"
+"Language-Team: Uzbek\n"
+"Language: uz\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=0;\n"
+"X-Generator: KBabel 1.11.4\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "Rasm/yorliq chegarasi"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "Ogohlantirish dialogidagi rasm va yorliqlarning kengligi"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "Ogohlantirish turi"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "Ogohlantirish turi"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "Ogohlantirish tugmalari"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "Ogohlantirish oynasida koʻrsatiladigan tugmalar"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "_Tafsilotlarni koʻrsatish"
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Place your left thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Swipe your left thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Place your left index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Swipe your left index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Place your left middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Swipe your left middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Place your left ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Swipe your left ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Place your left little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Swipe your left little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Place your right thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Swipe your right thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Place your right index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Swipe your right index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Place your right middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Swipe your right middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Place your right ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Swipe your right ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Place your right little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Swipe your right little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:72
+#: ../capplets/about-me/fingerprint-strings.h:98
+msgid "Place your finger on the reader again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:74
+#: ../capplets/about-me/fingerprint-strings.h:100
+msgid "Swipe your finger again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:77
+#: ../capplets/about-me/fingerprint-strings.h:103
+msgid "Swipe was too short, try again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:79
+#: ../capplets/about-me/fingerprint-strings.h:105
+msgid "Your finger was not centered, try swiping your finger again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:81
+#: ../capplets/about-me/fingerprint-strings.h:107
+msgid "Remove your finger, and try swiping your finger again"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:772
+msgid "Select Image"
+msgstr "Rasmni tanlang"
+
+#: ../capplets/about-me/gnome-about-me.c:774
+msgid "No Image"
+msgstr "Rasmsiz"
+
+#: ../capplets/about-me/gnome-about-me.c:802
+#: ../capplets/appearance/appearance-desktop.c:660
+msgid "Images"
+msgstr "Rasmlar"
+
+#: ../capplets/about-me/gnome-about-me.c:806
+#: ../capplets/appearance/theme-installer.c:700
+msgid "All Files"
+msgstr "Hamma fayllar"
+
+#: ../capplets/about-me/gnome-about-me.c:952
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"Manzillar daftaridan maʼlumot olib boʻlmadi.\n"
+"Evolution maʼlumot serveri protokolni qoʻllamaydi"
+
+#: ../capplets/about-me/gnome-about-me.c:973
+msgid "Unable to open address book"
+msgstr "Manzillar daftarini ochib boʻlmadi"
+
+#: ../capplets/about-me/gnome-about-me.c:987
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr "Nomaʼlum foydalanuvchi ID'si. foydalanuvchi maʼlumot bazasi zararlangan boʻlishi mumkin"
+
+#: ../capplets/about-me/gnome-about-me.c:1017
+#: ../capplets/about-me/gnome-about-me.c:1019
+#, c-format
+msgid "About %s"
+msgstr "%s haqida"
+
+#: ../capplets/about-me/gnome-about-me.c:1037
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Enable _Fingerprint Login..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:1040
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Disable _Fingerprint Login..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "About Me"
+msgstr "Men haqimda"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "Shaxsiy maʼlumotlaringiz"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
+msgid "You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
+msgid "The device is already in use."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:103
+msgid "An internal error occured"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:220
+msgid "Delete registered fingerprints?"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:223
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:230
+msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:343
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:583
+msgid "Done!"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
+#, c-format
+msgid "Could not access '%s' device"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:444
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:491
+msgid "Could not access any fingerprint readers"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:492
+msgid "Please contact your system administrator for help."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:518
+msgid "Enable Fingerprint Login"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:534
+msgid "Select finger"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:555
+#, c-format
+msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:568
+msgid "Swipe finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:570
+msgid "Place finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:1
+msgid "Left index finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:2
+msgid ""
+"Left thumb\n"
+"Left middle finger\n"
+"Left ring finger\n"
+"Left little finger\n"
+"Right thumb\n"
+"Right middle finger\n"
+"Right ring finger\n"
+"Right little finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:10
+msgid "Other finger: "
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:11
+msgid "Right index finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:12
+msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+msgid "<b>Email</b>"
+msgstr "<b>El.pochta</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+msgid "<b>Home</b>"
+msgstr "<b>Uy</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Instant Messaging</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Job</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Telephone</b>"
+msgstr "<b>Telefon</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Web</b>"
+msgstr "<b>WWW</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Work</b>"
+msgstr "<b>Ish</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Maxfiy soʻzni oʻzgartirish</span>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "A_ddress:"
+msgstr "_Manzil:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_ssistant:"
+msgstr "_Yordamchi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "Address"
+msgstr "Manzil"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "C_ity:"
+msgstr "_Shahar:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "C_ompany:"
+msgstr "_Tashkilot:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "Cale_ndar:"
+msgstr "Ta_qvim:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "Change Passwo_rd..."
+msgstr "Maxfiy _soʻzni oʻzgartirish..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Change pa_ssword"
+msgstr "Maxfiy s_oʻzni oʻzgartirish"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change password"
+msgstr "Maxfiy soʻzni oʻzgartirish"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Ci_ty:"
+msgstr "Sh_ahar:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Co_untry:"
+msgstr "_Davlat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Contact"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Cou_ntry:"
+msgstr "Dav_lat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Current _password:"
+msgstr "Joriy _maxfiy soʻz:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "Full Name"
+msgstr "Toʻliq ism"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "Hom_e:"
+msgstr "U_y:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P.O. _box:"
+msgstr "Pochta q_utisi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "P._O. box:"
+msgstr "_Pochta qutisi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "Personal Info"
+msgstr "Shaxsiy maʼlumot"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#: ../capplets/about-me/gnome-about-me-password.c:938
+msgid "Please type your password again in the <b>Retype new password</b> field."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Select your photo"
+msgstr "Rasm tanlang"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "State/Pro_vince:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid ""
+"To change your password, enter your current password in the field below and click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for verification and click <b>Change password</b>."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "User name:"
+msgstr "Foydalanuvchi nomi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "Web _log:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "Wor_k:"
+msgstr "I_sh:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "Work _fax:"
+msgstr "_Faks (ish):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "Zip/_Postal code:"
+msgstr "_Pochta indeksi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Address:"
+msgstr "_Manzil:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Authenticate"
+msgstr "_Tasdiqlash"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Department:"
+msgstr "_Boʻlim:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_Groupwise:"
+msgstr "_Groupwise:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Home page:"
+msgstr "_Uy sahifasi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Home:"
+msgstr "_Uy:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_Jabber:"
+msgstr "_Jabber:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Manager:"
+msgstr "_Boshqaruvchi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Mobile:"
+msgstr "Uyali telefon:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_New password:"
+msgstr "_Yangi maxfiy soʻz:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Profession:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:55
+msgid "_Retype new password:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:56
+msgid "_State/Province:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:57
+msgid "_Title:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:58
+msgid "_Work:"
+msgstr "_Ish:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:59
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:60
+msgid "_Zip/Postal code:"
+msgstr "Pochta _indeksi:"
+
+#: ../capplets/about-me/gnome-about-me-password.c:162
+msgid "Child exited unexpectedly"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:297
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:310
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:409
+msgid "Authenticated!"
+msgstr "Tasdiqlandi!"
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:475
+#: ../capplets/about-me/gnome-about-me-password.c:551
+msgid "Your password has been changed since you initially authenticated! Please re-authenticate."
+msgstr "Maxfiy soʻzingiz keyingi safargi tasdiqlanishdan keyin oʻzgartiriladi! Iltimos qayta tasdiqlang."
+
+#: ../capplets/about-me/gnome-about-me-password.c:477
+msgid "That password was incorrect."
+msgstr "Maxfiy soʻz xato."
+
+#: ../capplets/about-me/gnome-about-me-password.c:524
+msgid "Your password has been changed."
+msgstr "Maxfiy soʻzingiz oʻzgartirildi."
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:534
+#, c-format
+msgid "System error: %s."
+msgstr "Tizim xatosi: %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:537
+msgid "The password is too short."
+msgstr "Maxfiy soʻz juda qisqa."
+
+#: ../capplets/about-me/gnome-about-me-password.c:540
+msgid "The password is too simple."
+msgstr "Maxfiy soʻz juda oddiy."
+
+#: ../capplets/about-me/gnome-about-me-password.c:543
+msgid "The old and new passwords are too similar."
+msgstr "Eski va yangi maxfiy soʻz juda oʻxshash."
+
+#: ../capplets/about-me/gnome-about-me-password.c:545
+msgid "The new password must contain numeric or special character(s)."
+msgstr "Yangi maxfiy soʻz raqam va maxsus belgi(lar)dan iborat boʻlishi kerak."
+
+#: ../capplets/about-me/gnome-about-me-password.c:548
+msgid "The old and new passwords are the same."
+msgstr "Eski va yangi maxfiy soʻz bir xil."
+
+#. translators: Unable to launch <program>: <error message>
+#: ../capplets/about-me/gnome-about-me-password.c:820
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:824
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:825
+msgid "A system error has occurred"
+msgstr "Tizimda xatolik roʻy berdi"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:845
+msgid "Checking password..."
+msgstr "Maxfiy soʻz tekshirilmoqda..."
+
+#: ../capplets/about-me/gnome-about-me-password.c:932
+msgid "Click <b>Change password</b> to change your password."
+msgstr "Maxfiy soʻzni oʻzgartirish uchun <b>Maxfiy soʻzni oʻzgartirish</b> tugmasini bosing."
+
+#: ../capplets/about-me/gnome-about-me-password.c:935
+msgid "Please type your password in the <b>New password</b> field."
+msgstr "Iltimos <b>yangi maxfiy soʻz</b> maydoniga maxfiy soʻzni kiriting."
+
+#: ../capplets/about-me/gnome-about-me-password.c:941
+msgid "The two passwords are not equal."
+msgstr "Ikkala maxfiy soʻz mos kelmadi."
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Assistive Technologies</b>"
+msgstr "<b>Yordamchi texnologiyalar</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Preferences</b>"
+msgstr "<b>Parametrlar</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid "Accessible Lo_gin"
+msgstr "Tizimga _kirishdagi yordamchi texnologiyalar"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technologies Preferences"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Changes to enable assistive technologies will not take effect until your next log in."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Close and _Log Out"
+msgstr "Yopish va tizimdan _chiqish"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "Jump to Preferred Applications dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "Jump to the Accessible Login dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "Jump to the Mouse Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
+msgid "_Enable assistive technologies"
+msgstr "Yordamchi texnologiyalarni _yoqish"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
+msgid "_Keyboard Accessibility"
+msgstr "_Klaviatura maxsus imkoniyatlari"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
+msgid "_Mouse Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
+msgid "_Preferred Applications"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Choose which accessibility features to enable when you log in"
+msgstr ""
+
+#: ../capplets/appearance/appearance-desktop.c:628
+msgid "Add Wallpaper"
+msgstr "Gulqogʻoz qoʻshish"
+
+#: ../capplets/appearance/appearance-desktop.c:664
+msgid "All files"
+msgstr "Hamma fayllar"
+
+#: ../capplets/appearance/appearance-font.c:495
+msgid "Font may be too large"
+msgstr "Shrift juda katta boʻlishi mumkin"
+
+#: ../capplets/appearance/appearance-font.c:499
+#, c-format
+msgid "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is recommended that you select a size smaller than %d."
+msgid_plural "The font selected is %d points large, and may make it difficult to effectively use the computer. It is recommended that you select a size smaller than %d."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:512
+#, c-format
+msgid "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is recommended that you select a smaller sized font."
+msgid_plural "The font selected is %d points large, and may make it difficult to effectively use the computer. It is recommended that you select a smaller sized font."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:535
+msgid "Use previous font"
+msgstr "Oldingi shriftdan foydalanish"
+
+#: ../capplets/appearance/appearance-font.c:537
+msgid "Use selected font"
+msgstr "Tanlangan shriftdan foydalanish"
+
+#: ../capplets/appearance/appearance-main.c:124
+msgid "Specify the filename of a theme to install"
+msgstr "Oʻrnatiladigan mavzu fayli nomini koʻrsating"
+
+#: ../capplets/appearance/appearance-main.c:125
+msgid "filename"
+msgstr "fayl nomi"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/appearance/appearance-main.c:132
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:133
+#: ../capplets/default-applications/gnome-da-capplet.c:879
+#: ../capplets/mouse/gnome-mouse-properties.c:442
+msgid "page"
+msgstr "sahifa"
+
+#: ../capplets/appearance/appearance-main.c:140
+msgid "[WALLPAPER...]"
+msgstr "[GULQOGʻOZ...]"
+
+#: ../capplets/appearance/appearance-style.c:173
+#: ../capplets/common/gnome-theme-info.c:445
+#: ../capplets/common/gnome-theme-info.c:637
+msgid "Default Pointer"
+msgstr "Andoza koʻrsatgich"
+
+#: ../capplets/appearance/appearance-style.c:235
+#: ../capplets/appearance/appearance-themes.c:686
+msgid "Install"
+msgstr ""
+
+#: ../capplets/appearance/appearance-style.c:255
+#: ../capplets/common/gnome-theme-info.c:1647
+#, c-format
+msgid "This theme will not look as intended because the required GTK+ theme engine '%s' is not installed."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:674
+msgid "Apply Background"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:678
+msgid "Apply Font"
+msgstr "Shriftni qoʻllash"
+
+#: ../capplets/appearance/appearance-themes.c:682
+msgid "Revert Font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:712
+msgid "The current theme suggests a background and a font. Also, the last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:714
+msgid "The current theme suggests a background. Also, the last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:716
+msgid "The current theme suggests a background and a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:718
+msgid "The current theme suggests a font. Also, the last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:720
+msgid "The current theme suggests a background."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:722
+msgid "The last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:724
+msgid "The current theme suggests a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:1045
+#: ../capplets/default-applications/gnome-da-capplet.c:630
+msgid "Custom"
+msgstr "Boshqa"
+
+#: ../capplets/appearance/data/appearance.glade.h:1
+msgid "<b>C_olors</b>"
+msgstr "<b>_Ranglar</b>"
+
+#. font hinting
+#: ../capplets/appearance/data/appearance.glade.h:3
+msgid "<b>Hinting</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:4
+msgid "<b>Menus and Toolbars</b>"
+msgstr "<b>Menyu va asboblar paneli</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:5
+msgid "<b>Preview</b>"
+msgstr "<b>Oldindan koʻrish</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:6
+msgid "<b>Rendering</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:7
+msgid "<b>Smoothing</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:8
+msgid "<b>Subpixel Order</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:9
+msgid "<b>_Wallpaper</b>"
+msgstr "<b>_Gulqogʻoz</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:10
+msgid "Appearance Preferences"
+msgstr "Tashqi koʻrinishni moslash"
+
+#: ../capplets/appearance/data/appearance.glade.h:11
+msgid "Background"
+msgstr "Orqa fon"
+
+#: ../capplets/appearance/data/appearance.glade.h:12
+msgid "Best _shapes"
+msgstr "Eng yaxshi _shakllar"
+
+#: ../capplets/appearance/data/appearance.glade.h:13
+msgid "Best co_ntrast"
+msgstr "Eng yaxshi ko_ntrast"
+
+#: ../capplets/appearance/data/appearance.glade.h:14
+msgid "C_ustomize..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:15
+msgid "C_ut"
+msgstr "K_yesish"
+
+#: ../capplets/appearance/data/appearance.glade.h:16
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr "Kursor mavzusi keyingi safar tizimga kirganda kuchga kiradi."
+
+#: ../capplets/appearance/data/appearance.glade.h:17
+msgid "Colors"
+msgstr "Ranglar"
+
+#: ../capplets/appearance/data/appearance.glade.h:18
+msgid "Controls"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:19
+msgid "Customize Theme"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:20
+msgid "D_etails..."
+msgstr "_Tafsilotlar..."
+
+#: ../capplets/appearance/data/appearance.glade.h:21
+msgid "Des_ktop font:"
+msgstr "Ish _stoli shrifti:"
+
+#: ../capplets/appearance/data/appearance.glade.h:22
+msgid "Edit"
+msgstr "Tahrirlash"
+
+#: ../capplets/appearance/data/appearance.glade.h:23
+msgid "Font Rendering Details"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:24
+msgid "Fonts"
+msgstr "Shriftlar"
+
+#: ../capplets/appearance/data/appearance.glade.h:25
+msgid "Gra_yscale"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:26
+msgid "Icons"
+msgstr "Nishonchalar"
+
+#: ../capplets/appearance/data/appearance.glade.h:27
+msgid "Interface"
+msgstr "Interfeys"
+
+#: ../capplets/appearance/data/appearance.glade.h:28
+msgid "Large"
+msgstr "Katta"
+
+#: ../capplets/appearance/data/appearance.glade.h:29
+msgid "N_one"
+msgstr "_Yoʻq"
+
+#: ../capplets/appearance/data/appearance.glade.h:30
+msgid "New File"
+msgstr "Yangi  fayl"
+
+#: ../capplets/appearance/data/appearance.glade.h:31
+msgid "Open File"
+msgstr "Faylni ochish"
+
+#: ../capplets/appearance/data/appearance.glade.h:32
+msgid "Open a dialog to specify the color"
+msgstr "Rangni koʻrsatish uchun dialogni ochish"
+
+#: ../capplets/appearance/data/appearance.glade.h:33
+msgid "Pointer"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:34
+msgid "R_esolution:"
+msgstr "Oʻ_lchami:"
+
+#: ../capplets/appearance/data/appearance.glade.h:35
+msgid "Save File"
+msgstr "Faylni saqlash"
+
+#: ../capplets/appearance/data/appearance.glade.h:36
+msgid "Save Theme As..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:37
+msgid "Save _As..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:38
+msgid "Save _background image"
+msgstr "_Orqa fon rasmini saqlash"
+
+#: ../capplets/appearance/data/appearance.glade.h:39
+msgid "Show _icons in menus"
+msgstr "Menyularda _nishonchalarni koʻrsatish"
+
+#: ../capplets/appearance/data/appearance.glade.h:40
+msgid "Small"
+msgstr "Kichkina"
+
+#: ../capplets/appearance/data/appearance.glade.h:41
+msgid ""
+"Solid color\n"
+"Horizontal gradient\n"
+"Vertical gradient"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:44
+msgid "Sub_pixel (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:45
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:46
+msgid "Text"
+msgstr "Matn"
+
+#: ../capplets/appearance/data/appearance.glade.h:47
+msgid ""
+"Text below items\n"
+"Text beside items\n"
+"Icons only\n"
+"Text only"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:51
+msgid "The current controls theme does not support color schemes."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:52
+msgid "Theme"
+msgstr "Mavzu"
+
+#: ../capplets/appearance/data/appearance.glade.h:53
+msgid ""
+"Tiled\n"
+"Zoom\n"
+"Centered\n"
+"Scaled\n"
+"Fill screen"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:58
+msgid "Toolbar _button labels:"
+msgstr ""
+
+#. vertical hinting, pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:60
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/appearance/data/appearance.glade.h:61
+msgid "Window Border"
+msgstr "Oyna chegarasi"
+
+#: ../capplets/appearance/data/appearance.glade.h:62
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
+msgid "_Add..."
+msgstr "_Qoʻshish..."
+
+#: ../capplets/appearance/data/appearance.glade.h:63
+msgid "_Application font:"
+msgstr "_Dastur shrifti:"
+
+#. pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:65
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/appearance/data/appearance.glade.h:66
+msgid "_Copy"
+msgstr "_Nusxa olish"
+
+#: ../capplets/appearance/data/appearance.glade.h:67
+msgid "_Description:"
+msgstr "_Taʼrifi:"
+
+#: ../capplets/appearance/data/appearance.glade.h:68
+msgid "_Document font:"
+msgstr "_Hujjat shrifti:"
+
+#: ../capplets/appearance/data/appearance.glade.h:69
+msgid "_Editable menu shortcut keys"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:70
+msgid "_File"
+msgstr "_Fayl"
+
+#: ../capplets/appearance/data/appearance.glade.h:71
+msgid "_Fixed width font:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:72
+msgid "_Full"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:73
+msgid "_Input boxes:"
+msgstr "_Kiritish maydonlari:"
+
+#: ../capplets/appearance/data/appearance.glade.h:74
+msgid "_Install..."
+msgstr "_Oʻrnatish..."
+
+#: ../capplets/appearance/data/appearance.glade.h:75
+msgid "_Medium"
+msgstr "_Oʻrtacha"
+
+#: ../capplets/appearance/data/appearance.glade.h:76
+msgid "_Monochrome"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:77
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:5
+msgid "_Name:"
+msgstr "_Nomi:"
+
+#: ../capplets/appearance/data/appearance.glade.h:78
+msgid "_New"
+msgstr "_Yangi"
+
+#: ../capplets/appearance/data/appearance.glade.h:79
+msgid "_None"
+msgstr "_Yoʻq"
+
+#: ../capplets/appearance/data/appearance.glade.h:80
+msgid "_Open"
+msgstr "_Ochish"
+
+#: ../capplets/appearance/data/appearance.glade.h:81
+msgid "_Paste"
+msgstr "_Qoʻyish"
+
+#: ../capplets/appearance/data/appearance.glade.h:82
+msgid "_Print"
+msgstr "_Bosib chiqarish"
+
+#: ../capplets/appearance/data/appearance.glade.h:83
+msgid "_Quit"
+msgstr "_Chiqish"
+
+#. pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:85
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:86
+msgid "_Reset to Defaults"
+msgstr "Andoza qiymatga _qaytarish"
+
+#: ../capplets/appearance/data/appearance.glade.h:87
+msgid "_Save"
+msgstr "_Saqlash"
+
+#: ../capplets/appearance/data/appearance.glade.h:88
+msgid "_Selected items:"
+msgstr "_Tanlangan elementlar:"
+
+#: ../capplets/appearance/data/appearance.glade.h:89
+msgid "_Size:"
+msgstr "_Hajmi:"
+
+#: ../capplets/appearance/data/appearance.glade.h:90
+msgid "_Slight"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:91
+msgid "_Style:"
+msgstr "_Uslub:"
+
+#: ../capplets/appearance/data/appearance.glade.h:92
+msgid "_Tooltips:"
+msgstr ""
+
+#. vertical hinting, pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:94
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:95
+msgid "_Window title font:"
+msgstr "_Oyna sarlavhasi shrifti:"
+
+#: ../capplets/appearance/data/appearance.glade.h:96
+msgid "_Windows:"
+msgstr "_Oynalar:"
+
+#: ../capplets/appearance/data/appearance.glade.h:97
+msgid "dots per inch"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr "Tashqi koʻrinishi"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr "Mavzu oʻrnatgich"
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr "Gnome mavzu paketi"
+
+#: ../capplets/appearance/gnome-wp-info.c:50
+msgid "No Wallpaper"
+msgstr "Gulqogʻozsiz"
+
+#: ../capplets/appearance/gnome-wp-item.c:208
+msgid "Slide Show"
+msgstr ""
+
+#. translators: <b>wallpaper name</b>
+#. * mime type, x pixel(s) by y pixel(s)
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:216
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %d %s by %d %s\n"
+"Folder: %s"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:222
+#: ../capplets/appearance/gnome-wp-item.c:224
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "piksel"
+msgstr[1] "piksel"
+
+#: ../capplets/appearance/theme-installer.c:174
+#: ../capplets/appearance/theme-installer.c:224
+msgid "Cannot install theme"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:176
+#, c-format
+msgid "The %s utility is not installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:226
+msgid "There was a problem while extracting the theme."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:249
+msgid "There was an error installing the selected file"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:250
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:251
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme. It may be a theme engine which you need to compile."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:290
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "%s Gnome mavzusi muvaffaqiyatli oʻrnatildi"
+
+#: ../capplets/appearance/theme-installer.c:357
+#, c-format
+msgid "Installation for theme \"%s\" failed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:396
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr "\"%s\" mavzu oʻrnatildi."
+
+#: ../capplets/appearance/theme-installer.c:402
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr "Uni qoʻllashni istaysizmi yoki joriy mavzuni saqlab qolasizmi?"
+
+#: ../capplets/appearance/theme-installer.c:404
+msgid "Keep Current Theme"
+msgstr "Joriy mavzu saqlab qolinsin"
+
+#: ../capplets/appearance/theme-installer.c:406
+msgid "Apply New Theme"
+msgstr "Yangi mavzu qoʻllansin"
+
+#: ../capplets/appearance/theme-installer.c:510
+msgid "Failed to create temporary directory"
+msgstr "Vaqtinchalik direktoriya yaratib boʻlmadi"
+
+#: ../capplets/appearance/theme-installer.c:573
+msgid "New themes have been successfully installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:598
+msgid "No theme file location specified to install"
+msgstr "Oʻrnatish uchun mavzu fayli yoʻli koʻrsatilmagan"
+
+#: ../capplets/appearance/theme-installer.c:619
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"Mavzuni quyidagi manzilga oʻrnatish uchun huquq yetarli emas:\n"
+"%s"
+
+#: ../capplets/appearance/theme-installer.c:689
+msgid "Select Theme"
+msgstr "Mavzuni tanlash"
+
+#: ../capplets/appearance/theme-installer.c:693
+msgid "Theme Packages"
+msgstr "Mavzu paketlari"
+
+#: ../capplets/appearance/theme-save.c:93
+#, c-format
+msgid "Theme name must be present"
+msgstr ""
+
+#: ../capplets/appearance/theme-save.c:156
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Mavzu allaqachon mavjud. Almashtirishni istaysizmi?"
+
+#: ../capplets/appearance/theme-save.c:157
+#: ../capplets/common/file-transfer-dialog.c:450
+msgid "_Overwrite"
+msgstr "_Almashtirish"
+
+#: ../capplets/appearance/theme-util.c:75
+msgid "Would you like to delete this theme?"
+msgstr "Ushbu mavzuni olib tashlashni istaysizmi?"
+
+#: ../capplets/appearance/theme-util.c:125
+msgid "Theme cannot be deleted"
+msgstr "Mavzuni olib tashlab boʻlmaydi"
+
+#: ../capplets/appearance/theme-util.c:252
+msgid "Could not install theme engine"
+msgstr ""
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) settings manager may already be active and conflicting with the GNOME settings manager."
+msgstr ""
+
+#: ../capplets/common/capplet-stock-icons.c:66
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:88
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Yordam faylini koʻrsatishda xatolik yuz berdi: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:98
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "Fayldan nusxa olinmoqda: %u dan %u"
+
+#: ../capplets/common/file-transfer-dialog.c:145
+#, c-format
+msgid "Copying '%s'"
+msgstr "'%s' nusxa olinmoqda"
+
+#: ../capplets/common/file-transfer-dialog.c:185
+#: ../capplets/common/file-transfer-dialog.c:312
+msgid "Copying files"
+msgstr "Fayllardan nusxa olinmoqda"
+
+#: ../capplets/common/file-transfer-dialog.c:224
+msgid "Parent Window"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Parent window of the dialog"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:231
+msgid "From URI"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:232
+msgid "URI currently transferring from"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:239
+msgid "To URI"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:240
+msgid "URI currently transferring to"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:247
+msgid "Fraction completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:248
+msgid "Fraction of transfer currently completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:255
+msgid "Current URI index"
+msgstr "Joriy URI indeksi"
+
+#: ../capplets/common/file-transfer-dialog.c:256
+msgid "Current URI index - starts from 1"
+msgstr "Joriy URI indeksi - 1'dan boshlanadi"
+
+#: ../capplets/common/file-transfer-dialog.c:263
+msgid "Total URIs"
+msgstr "Jami URI"
+
+#: ../capplets/common/file-transfer-dialog.c:264
+msgid "Total number of URIs"
+msgstr "Jami URI soni"
+
+#: ../capplets/common/file-transfer-dialog.c:444
+#, c-format
+msgid "File '%s' already exists. Do you want to overwrite it?"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:447
+msgid "_Skip"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Overwrite _All"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:134
+msgid "Key"
+msgstr "Kalit"
+
+#: ../capplets/common/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:141
+msgid "Callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:147
+msgid "Change set"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:148
+msgid "GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:154
+msgid "Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:160
+msgid "Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "Grafik interfeys boshqaruvi"
+
+#: ../capplets/common/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1404
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background picture."
+msgstr ""
+"'%s' faylini topib boʻlmadi.\n"
+"\n"
+"Iltimos uni mavjudligini tekshirib koʻring va qayta urinib koʻring yoki boshqa orqa fon rasmini tanlang."
+
+#: ../capplets/common/gconf-property-editor.c:1412
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"'%s' faylini qanday ochish mumkin.\n"
+"Balki bu rasm turi xali qoʻllanilmasligi mumkin.\n"
+"\n"
+"Iltimos buning oʻrniga boshqa rasm tanlang."
+
+#: ../capplets/common/gconf-property-editor.c:1532
+msgid "Please select an image."
+msgstr "Iltimos rasm tanlang."
+
+#: ../capplets/common/gconf-property-editor.c:1537
+msgid "_Select"
+msgstr "_Tanlash"
+
+#: ../capplets/common/gnome-theme-info.c:638
+msgid "Default Pointer - Current"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:642
+msgid "White Pointer"
+msgstr "Oq koʻrsatgich"
+
+#: ../capplets/common/gnome-theme-info.c:643
+msgid "White Pointer - Current"
+msgstr "Oq koʻrsatgich - joriy"
+
+#: ../capplets/common/gnome-theme-info.c:647
+msgid "Large Pointer"
+msgstr "Katta koʻrsatgich"
+
+#: ../capplets/common/gnome-theme-info.c:648
+msgid "Large Pointer - Current"
+msgstr "Katta koʻrsatgich - joriy"
+
+#: ../capplets/common/gnome-theme-info.c:652
+msgid "Large White Pointer - Current"
+msgstr "Katta oq koʻrsatgich - joriy"
+
+#: ../capplets/common/gnome-theme-info.c:653
+msgid "Large White Pointer"
+msgstr "Katta oq koʻrsatgich"
+
+#: ../capplets/common/gnome-theme-info.c:1623
+#, c-format
+msgid "This theme will not look as intended because the required GTK+ theme '%s' is not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1631
+#, c-format
+msgid "This theme will not look as intended because the required window manager theme '%s' is not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1638
+#, c-format
+msgid "This theme will not look as intended because the required icon theme '%s' is not installed."
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Preferred Applications"
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Andoza dasturni tanlang"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Start the preferred visual assistive technology"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:94
+#: ../capplets/default-applications/gnome-da-capplet.c:345
+#: ../capplets/default-applications/gnome-da-capplet.c:366
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "Moslamani saqlash xatoligi: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:650
+msgid "Could not load the main interface"
+msgstr "Asosiy interfeysni yuklab boʻlmadi"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:652
+msgid "Please make sure that the applet is properly installed"
+msgstr "Iltimos aplet toʻgʻri oʻrnatilganligiga ishonch xosil qiling"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/default-applications/gnome-da-capplet.c:878
+msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:883
+msgid "- GNOME Default Applications"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Image Viewer</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Instant Messenger</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Mail Reader</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mobility</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Multimedia Player</b>"
+msgstr "<b>Multimedia pleyeri</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>Terminal emulyatori</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Text Editor</b>"
+msgstr "<b>Matn tahrirchisi</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Video Player</b>"
+msgstr "<b>Video pleyer</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "<b>Visual</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "<b>Web Browser</b>"
+msgstr "<b>Veb-brauzer</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
+msgid "Accessibility"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "C_ommand:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Co_mmand:"
+msgstr "Buy_ruq:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "E_xecute flag:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Internet"
+msgstr "Internet"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Multimedia"
+msgstr "Multimedia"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Open link in new _tab"
+msgstr "Bogʻlamani yangi _tabda ochish"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "Open link in new _window"
+msgstr "Bogʻlamani yangi _oynada ochish"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid "Open link with web browser _default"
+msgstr "Bogʻlamani brauzer _andozasi bilan ochish"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Run at st_art"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Run in t_erminal"
+msgstr "T_yerminalda bajarish"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "System"
+msgstr "Tizim"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "_Run at start"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr "Banshee musiqiy pleyeri"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr "Dasher"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr "Debian terminal emulyatori"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr "Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr "Epiphany veb brauzeri"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr "Evolution pochta klienti"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr "GNOME terminali"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Gnopernicus"
+msgstr "Gnopernicus"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Gnopernicus with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Iceape"
+msgstr "Iceape"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Iceape Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Icedove"
+msgstr "Icedove"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Iceweasel"
+msgstr "Iceweasel"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Konsole"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Listen"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Midori"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Mozilla Mail"
+msgstr "Mozilla Mail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Muine Music Player"
+msgstr "Muine musiqa pleyeri"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Netscape Communicator"
+msgstr "Netscape Communicator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Opera"
+msgstr "Opera"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca"
+msgstr "Orca"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "Orca with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+msgid "Rhythmbox Music Player"
+msgstr "Rhythmbox musiqa pleyeri"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+msgid "SeaMonkey Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Standard XTerminal"
+msgstr "Andoza X-terminali"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+msgid "Sylpheed"
+msgstr "Sylpheed"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Terminator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "Totem Movie Player"
+msgstr "Totem pleyeri"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/display/display-capplet.glade.h:1
+#: ../capplets/display/xrandr-capplet.c:450
+msgid "<b>Monitor</b>"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:2
+msgid "<b>Panel icon</b>"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:3
+msgid "<i>Drag the monitors to set their place</i>"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:4
+msgid "Display Settings"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:5
+msgid "Include _panel"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:6
+msgid ""
+"Normal\n"
+"Left\n"
+"Right\n"
+"Upside-down\n"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:11
+msgid "R_otation:"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:12
+msgid "Re_fresh rate:"
+msgstr "_Yangilanish darajasi"
+
+#: ../capplets/display/display-capplet.glade.h:13
+msgid "_Detect Monitors"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:14
+msgid "_Mirror screens"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:15
+msgid "_Resolution:"
+msgstr "_Oʻlchami:"
+
+#: ../capplets/display/display-capplet.glade.h:16
+msgid "_Show displays in panel"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Ekran oʻlchamini oʻzgartirish"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Ekran oʻlchami"
+
+#: ../capplets/display/xrandr-capplet.c:318
+#: ../capplets/display/xrandr-capplet.c:357
+msgid "Normal"
+msgstr "Oʻrtacha"
+
+#: ../capplets/display/xrandr-capplet.c:319
+msgid "Left"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:320
+msgid "Right"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:321
+msgid "Upside Down"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:393
+#: ../capplets/display/xrandr-capplet.c:401
+#: ../capplets/display/xrandr-capplet.c:402
+#, c-format
+msgid "%d Hz"
+msgstr "%d Gs"
+
+#: ../capplets/display/xrandr-capplet.c:443
+#, c-format
+msgid "<b>Monitor: %s</b>"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:489
+#: ../capplets/display/xrandr-capplet.c:508
+#: ../capplets/display/xrandr-capplet.c:518
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:500
+msgid "Off"
+msgstr ""
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../capplets/display/xrandr-capplet.c:1306
+msgid "Mirror Screens"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1624
+msgid "Could not save the monitor configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1631
+msgid "Could not get session bus while applying display configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1641
+msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1647
+msgid "Could not apply the selected configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1687
+msgid "Could not detect displays"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1885
+msgid "Could not get screen information"
+msgstr ""
+
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+msgid "Sound"
+msgstr "Tovush"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+#: ../libslab/bookmark-agent.c:1146
+msgid "Desktop"
+msgstr "Ish stoli"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Akselerator tugmasi"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Akselerator modifikatorlari"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Akselerator tugmasi kodi"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Akselerator usuli"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Akselerator turi."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:103
+#: ../typing-break/drwright.c:479
+msgid "Disabled"
+msgstr "Oʻchirilgan"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:184
+msgid "<Unknown Action>"
+msgstr "<Nomaʼlum amal>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:918
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1528
+msgid "Custom Shortcuts"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1057
+msgid "Error saving the new shortcut"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1136
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1166
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1172
+#, c-format
+msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1180
+msgid "_Reassign"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1300
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1483
+msgid "Too many custom shortcuts"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1768
+msgid "Action"
+msgstr "Amal"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1790
+msgid "Shortcut"
+msgstr "Tugmalar birikmasi"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+msgid "Custom Shortcut"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Klaviatura tugmalar birikmasi:"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:3
+msgid "To edit a shortcut key, click on the corresponding row and type a new key combination, or press backspace to clear."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:4
+msgid "_Command:"
+msgstr ""
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Buyruqlarga tugmalar birikmasi tayinlash"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:209
+#: ../capplets/keyboard/gnome-keyboard-properties.c:214
+msgid "Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:219
+msgid "Start the page with the typing break settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:224
+msgid "Start the page with the accessibility settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:230
+msgid "- GNOME Keyboard Preferences"
+msgstr "- GNOME klaviatura parametrlari"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+msgid "<b>Bounce Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+msgid "<b>Cursor Blinking</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "<b>General</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Repeat Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Slow Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>Sticky Keys</b>"
+msgstr ""
+
+#. fast acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Tez</i></small>"
+
+#. long delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Uzun</i></small>"
+
+#. short delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Qisqa</i></small>"
+
+#. slow acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Sekin</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_cceleration:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "All_ow postponing of breaks"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "Audio _Feedback..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Beep when _accessibility features are turned on or off"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Beep when a _toggle key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Beep when a key is reje_cted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Beep when key is _accepted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Beep when key is _rejected"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "By _country"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "By _language"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Check if breaks are allowed to be postponed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Choose a Keyboard Model"
+msgstr "Klaviatura rusumini tanlang"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Choose a Layout"
+msgstr "Tugmalar tartibini tanlang"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Cursor _blinks in text fields"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
+msgid "Cursor blinks speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
+msgid "D_elay:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Duration of the break when typing is disallowed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Duration of work before forcing a break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
+msgid "General"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "Key presses _repeat when key is held down"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "Keyboard Accessibility Audio Feedback"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "Keyboard Layout Options"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "Keyboard Preferences"
+msgstr "Klaviatura moslamalari"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "Keyboard _model:"
+msgstr "Klaviatura _rusumi:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "Layout _Options..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "Layouts"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "Lock screen after a certain duration to help prevent repetitive keyboard use injuries"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "Mouse Keys"
+msgstr "Sichqoncha tugmalari"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "Preview:"
+msgstr "Oldindan koʻrish:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
+msgid "Repeat keys speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
+msgid "Reset to De_faults"
+msgstr "_Andoza parametrlarni tiklash"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
+msgid "S_peed:"
+msgstr "_Tezlik:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
+msgid "Separate _layout for each window"
+msgstr "Har bir oyna uchun alohida _tugmalar tartibi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
+msgid "Typing Break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
+msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
+msgid "_Break interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
+msgid "_Country:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
+msgid "_Delay:"
+msgstr "_Kechikish:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
+msgid "_Ignore fast duplicate keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
+msgid "_Language:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
+msgid "_Lock screen to enforce typing break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
+msgid "_Models:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
+msgid "_Only accept long keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
+msgid "_Pointer can be controlled using the keypad"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
+msgid "_Selected layouts:"
+msgstr "_Tanlangan tugmalar tartibi:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
+msgid "_Simulate simultaneous keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
+msgid "_Speed:"
+msgstr "_Tezlik:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
+msgid "_Type to test settings:"
+msgstr "Parametrlarni _sinash maydoni:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
+msgid "_Variants:"
+msgstr "_Variantlar:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
+msgid "_Vendors:"
+msgstr "_Ish.chiqaruvchilar:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
+msgid "_Work interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
+msgid "minutes"
+msgstr "daqiqa"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
+msgid "Unknown"
+msgstr "Nomaʼlum"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:215
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:234
+#: ../capplets/network/gnome-network-preferences.c:561
+msgid "Default"
+msgstr "Andoza"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:333
+msgid "Layout"
+msgstr "Tugmalar tartibi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
+msgid "Vendors"
+msgstr "Ish.chiqaruvchilar"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
+msgid "Models"
+msgstr ""
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Klaviatura"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:90
+msgid "gesture|Move left"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:95
+msgid "gesture|Move right"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:100
+msgid "gesture|Move up"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:105
+msgid "gesture|Move down"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:110
+msgid "gesture|Disabled"
+msgstr ""
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/mouse/gnome-mouse-properties.c:441
+msgid "Specify the name of the page to show (general|accessibility)"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:446
+msgid "- GNOME Mouse Preferences"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+msgid "<b>Double-Click Timeout</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Ushlab olib qoʻyish</b>"
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Dwell Click</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Locate Pointer</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Mouse Orientation</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<b>Pointer Speed</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<b>Simulated Secondary Click</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>To test your double-click settings, try to double-click on the light bulb.</i>"
+msgstr ""
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>You can also use the Dwell Click panel applet to choose the click type.</i>"
+msgstr ""
+
+#. high sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "<small><i>High</i></small>"
+msgstr ""
+
+#. large threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "<small><i>Large</i></small>"
+msgstr ""
+
+#. low sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "<small><i>Low</i></small>"
+msgstr ""
+
+#. small threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "<small><i>Small</i></small>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
+msgid "Choose type of click _beforehand"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
+msgid "Choose type of click with mo_use gestures"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
+msgid "D_ouble click:"
+msgstr ""
+
+#. click to initiate drag-and-drop (like normally click and hold)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
+msgid "D_rag click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
+msgid "Mouse Preferences"
+msgstr "Sichqoncha moslamalari"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
+msgid "Seco_ndary click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
+msgid "Show click type _window"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
+msgid "Thr_eshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
+msgid "_Acceleration:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
+msgid "_Initiate click when stopping pointer movement"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
+msgid "_Left-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
+msgid "_Motion threshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
+msgid "_Right-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
+msgid "_Sensitivity:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
+msgid "_Single click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
+msgid "_Timeout:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr ""
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Sichqoncha"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.c:677
+#: ../capplets/network/gnome-network-preferences.c:816
+msgid "New Location..."
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.c:782
+msgid "Location already exists"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Tarmoq proksisi"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>Internetga _toʻgʻridan-toʻgʻri ulanish</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>Ignore Host List</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>Proksi moslamasini _avto-aniqlash</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>Proksi moslamalarini _qoʻlbola koʻrsatish</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Use authentication</b>"
+msgstr "<b>Tasdiqlashdan _foydalanish</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "Autoconfiguration _URL:"
+msgstr "Avto-moslash _URL'i:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "C_reate"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Create New Location"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "H_TTP proksi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Ignored Hosts"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Location:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "Network Proxy Preferences"
+msgstr "Tarmoq proksi moslamalari"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "Port:"
+msgstr "Port:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "Proxy Configuration"
+msgstr "Proksi parametrlari"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "S_ocks host:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "The location already exists."
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "U_sername:"
+msgstr "F_oydalunuvchi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Delete Location"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:20
+msgid "_Details"
+msgstr "_Tafsilotlar"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:21
+msgid "_FTP proxy:"
+msgstr "_FTP proksi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:22
+msgid "_Location name:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:23
+msgid "_Password:"
+msgstr "_Maxfiy soʻz:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:24
+msgid "_Secure HTTP proxy:"
+msgstr "HTTP_S proksi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:25
+msgid "_Use the same proxy for all protocols"
+msgstr "Barcha protokollar uchun bitta proksidan _foydalanish"
+
+#: ../capplets/windows/gnome-window-properties.c:346
+msgid "Cannot start the preferences application for your window manager"
+msgstr ""
+
+#. translators: this is the Control key
+#: ../capplets/windows/gnome-window-properties.c:600
+msgid "C_ontrol"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:605
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:611
+msgid "H_yper"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:618
+msgid "S_uper (or \"Windows logo\")"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:625
+msgid "_Meta"
+msgstr "_Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Oyna tanlash</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Oyna parametrlari"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "soniya"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "Oyna moslamalarini oʻrnatish"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Oynalar"
+
+#. make start action
+#: ../libslab/application-tile.c:372
+#, c-format
+msgid "<b>Start %s</b>"
+msgstr "<b>%s'ni ishga tushirish</b>"
+
+#: ../libslab/application-tile.c:391
+msgid "Help"
+msgstr "Yordam"
+
+#: ../libslab/application-tile.c:438
+msgid "Upgrade"
+msgstr "Yangilash"
+
+#: ../libslab/application-tile.c:453
+msgid "Uninstall"
+msgstr ""
+
+#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
+msgid "Remove from Favorites"
+msgstr ""
+
+#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
+msgid "Add to Favorites"
+msgstr ""
+
+#: ../libslab/application-tile.c:867
+msgid "Remove from Startup Programs"
+msgstr ""
+
+#: ../libslab/application-tile.c:869
+msgid "Add to Startup Programs"
+msgstr ""
+
+#: ../libslab/app-shell.c:753
+#, c-format
+msgid ""
+"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+"\n"
+" Your filter \"<b>%s</b>\" does not match any items.</span>"
+msgstr ""
+
+#: ../libslab/app-shell.c:903
+msgid "Other"
+msgstr "Boshqa"
+
+#: ../libslab/bookmark-agent.c:1077
+msgid "New Spreadsheet"
+msgstr "Yangi elektron jadval"
+
+#: ../libslab/bookmark-agent.c:1082
+msgid "New Document"
+msgstr "Yangi hujjat"
+
+#: ../libslab/bookmark-agent.c:1135
+msgid "Home"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1140
+msgid "Documents"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1153
+msgid "File System"
+msgstr "Fayl tizimi"
+
+#: ../libslab/bookmark-agent.c:1157
+msgid "Network Servers"
+msgstr "Tarmoq serverlari"
+
+#: ../libslab/bookmark-agent.c:1186
+msgid "Search"
+msgstr "Qidirish"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:171
+#, c-format
+msgid "<b>Open</b>"
+msgstr "<b>Ochish</b>"
+
+#. make rename action
+#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:231
+msgid "Rename..."
+msgstr "Nomini oʻzgartirish..."
+
+#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
+#: ../libslab/document-tile.c:245 ../libslab/document-tile.c:254
+msgid "Send To..."
+msgstr ""
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:280
+msgid "Move to Trash"
+msgstr "Chiqindilar qutisiga olib tashlash"
+
+#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
+#: ../libslab/document-tile.c:290 ../libslab/document-tile.c:831
+msgid "Delete"
+msgstr "Olib tashlash"
+
+#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:979
+#, c-format
+msgid "Are you sure you want to permanently delete \"%s\"?"
+msgstr ""
+
+#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:980
+msgid "If you delete an item, it is permanently lost."
+msgstr ""
+
+#: ../libslab/document-tile.c:192
+#, c-format
+msgid "<b>Open with \"%s\"</b>"
+msgstr "<b>\"%s\" bilan ochish</b>"
+
+#: ../libslab/document-tile.c:204
+msgid "Open with Default Application"
+msgstr "Andoza dastur bilan ochish"
+
+#: ../libslab/document-tile.c:215
+msgid "Open in File Manager"
+msgstr "Fayl menejerida ochish"
+
+#: ../libslab/document-tile.c:611
+msgid "?"
+msgstr ""
+
+#: ../libslab/document-tile.c:618
+msgid "%l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:626
+msgid "Today %l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:636
+msgid "Yesterday %l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:648
+msgid "%a %l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:656
+msgid "%b %d %l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:658
+msgid "%b %d %Y"
+msgstr ""
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr ""
+
+#: ../libslab/system-tile.c:128
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr "<b>%s'ni ochish</b>"
+
+#: ../libslab/system-tile.c:141
+#, c-format
+msgid "Remove from System Items"
+msgstr "Tizim elementlaridan olib tashlash"
+
+#: ../libwindow-settings/gnome-wm-manager.c:316
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:404
+msgid "Maximize"
+msgstr "Yoyish"
+
+#: ../libwindow-settings/metacity-window-manager.c:405
+msgid "Maximize Vertically"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:406
+msgid "Maximize Horizontally"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:407
+msgid "Minimize"
+msgstr "Yigʻish"
+
+#: ../libwindow-settings/metacity-window-manager.c:408
+msgid "Roll up"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:409
+msgid "None"
+msgstr "Yoʻq"
+
+#: ../shell/control-center.c:54
+#, c-format
+msgid "key not found [%s]\n"
+msgstr ""
+
+#: ../shell/control-center.c:151
+msgid "Filter"
+msgstr "Filtr"
+
+#: ../shell/control-center.c:151
+msgid "Groups"
+msgstr "Guruhlar"
+
+#: ../shell/control-center.c:151
+msgid "Common Tasks"
+msgstr ""
+
+#: ../shell/control-center.c:155 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Boshqaruv markazi"
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:5
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:8
+msgid "Indicates whether to close the shell when an add or remove action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:9
+msgid "Indicates whether to close the shell when an upgrade or uninstall action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:11
+msgid "The task name to be displayed in the control-center followed by a \";\" separator then the filename of an associated .desktop file to launch for that task."
+msgstr ""
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+msgid "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:14
+msgid "if true, the control-center will close when a \"Common Task\" is activated."
+msgstr ""
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "GNOME moslash vositasi"
+
+#: ../typing-break/drw-break-window.c:189
+msgid "_Postpone Break"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:245
+msgid "Take a break!"
+msgstr ""
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#. translators: keep the initial "/"
+#: ../typing-break/drwright.c:129
+msgid "/_Preferences"
+msgstr "/_Parametrlar"
+
+#: ../typing-break/drwright.c:130
+msgid "/_About"
+msgstr "/_Haqida"
+
+#: ../typing-break/drwright.c:132
+msgid "/_Take a Break"
+msgstr ""
+
+#: ../typing-break/drwright.c:488
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../typing-break/drwright.c:492
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr ""
+
+#: ../typing-break/drwright.c:579
+#, c-format
+msgid "Unable to bring up the typing break properties dialog with the following error: %s"
+msgstr ""
+
+#: ../typing-break/drwright.c:598
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "Muallif: Richard Xalt (Richard Hult) <richard@imendio.com>"
+
+#: ../typing-break/drwright.c:599
+msgid "Eye candy added by Anders Carlsson"
+msgstr ""
+
+#: ../typing-break/drwright.c:608
+msgid "A computer break reminder."
+msgstr ""
+
+#: ../typing-break/drwright.c:610
+msgid "translator-credits"
+msgstr "Nurali Abdurahmonov <mavnur@gmail.com>"
+
+#: ../typing-break/main.c:61
+msgid "Enable debugging code"
+msgstr ""
+
+#: ../typing-break/main.c:63
+msgid "Don't check whether the notification area exists"
+msgstr ""
+
+#: ../typing-break/main.c:89
+msgid "Typing Monitor"
+msgstr ""
+
+#: ../typing-break/main.c:105
+msgid "The typing monitor uses the notification area to display information. You don't seem to have a notification area on your panel. You can add it by right-clicking on your panel and choosing 'Add to panel', selecting 'Notification area' and clicking 'Add'."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:5
+msgid "Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:7
+msgid "Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr ""
+
+#: ../font-viewer/font-view.c:113
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "Oq choynakka oq qopqoq, koʻk choynakka koʻk qopqoq. 0123456789"
+
+#: ../font-viewer/font-view.c:275
+msgid "Name:"
+msgstr "Nomi:"
+
+#: ../font-viewer/font-view.c:278
+msgid "Style:"
+msgstr "Uslubi:"
+
+#: ../font-viewer/font-view.c:291
+msgid "Type:"
+msgstr "Turi:"
+
+#: ../font-viewer/font-view.c:295
+msgid "Size:"
+msgstr ""
+
+#: ../font-viewer/font-view.c:339 ../font-viewer/font-view.c:352
+msgid "Version:"
+msgstr "Versiyasi:"
+
+#: ../font-viewer/font-view.c:343 ../font-viewer/font-view.c:354
+msgid "Copyright:"
+msgstr "Mualliflik huquqi:"
+
+#: ../font-viewer/font-view.c:347
+msgid "Description:"
+msgstr "Taʼrifi:"
+
+#: ../font-viewer/font-view.c:437
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr ""
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
+msgid "Font Viewer"
+msgstr ""
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
+msgid "Preview fonts"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:243
+msgid "Text to thumbnail (default: Aa)"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:243
+msgid "TEXT"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "Font size (default: 64)"
+msgstr "Shrift oʻlchami (andoza: 64)"
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "SIZE"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:263
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr ""
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Yordamchi texnologiyalarni moslash"
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "Sichqonchani moslash oynasini ochishda xatolik: %s"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "«%s» faylidan AccessX parametrlarini import qilib boʻlmadi"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Parametrlar faylini import qilish"
+
+#~ msgid "_Import"
+#~ msgstr "_Import"
+
+#~ msgid "Keyboard Accessibility"
+#~ msgstr "Klaviatura maxsus imkoniyatlari"
+
+#~ msgid "This system does not seem to have the XKB extension.  The keyboard accessibility features will not operate without it."
+#~ msgstr "Tizimda XKB kengaytmasi yoʻq.  Klaviatura maxsus imkoniyatlari usiz ishlamaydi."
+
+#~ msgid "Basic"
+#~ msgstr "Asosiy"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr "Klaviaturadan tugmalar _aktivlashtirilganda signal berish"
+
+#~ msgid "Beep when _modifier is pressed"
+#~ msgstr "_modifikator bosilganda signal berish"
+
+#~ msgid "Del_ay:"
+#~ msgstr "Ke_chikish:"
+
+#~ msgid "Disa_ble if two keys pressed together"
+#~ msgstr "Ikki tugma birga bosilsa, _oʻchirish"
+
+#~ msgid "Filters"
+#~ msgstr "Filtrlar"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Sichqoncha _moslamalari..."
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Klaviaturaning raqamli qismidan sichqoncha sifatida foydalanish."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "Quyidagi oraliqda ishlatilmasa _oʻchirish:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "Klaviatura maxsus imkoniyatlarini _yoqish"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "Parametrlarni _import qilish..."
+
+#~ msgid "_accepted"
+#~ msgstr "_qabul qilindi"
+
+#~ msgid "_pressed"
+#~ msgstr "_bosildi"
+
+#~ msgid "_rejected"
+#~ msgstr "q_abul qilinmadi"
+
+#~ msgid "characters/second"
+#~ msgstr "belgi/soniya"
+
+#~ msgid "milliseconds"
+#~ msgstr "millisoniya"
+
+#~ msgid "pixels/second"
+#~ msgstr "piksel/soniya"
+
+#~ msgid "Go _to Fonts Folder"
+#~ msgstr "Shrift jildiga _oʻtish"
+
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "The %s utility is not installed."
+#~ msgstr ""
+#~ "Mavzuni oʻrnatib boʻlmadi.\n"
+#~ "%s yutilitisi oʻrnatilmagan."
+
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "There was a problem while extracting the theme."
+#~ msgstr ""
+#~ "Mavzuni oʻrnatib boʻlmadi.\n"
+#~ "Mavzuni ajratishda xatolik yuz berdi."
+
+#~ msgid "The file format is invalid"
+#~ msgstr "Faylning formati xato"
+
+#~ msgid "Installation Failed"
+#~ msgstr "Oʻrnatib boʻlmadi"
+
+#~ msgid "This theme is not in a supported format."
+#~ msgstr "Mavzu qoʻllanilmaydigan formatda."
+
+#~ msgid "%s is the path where the theme files will be installed. This can not be selected as the source location"
+#~ msgstr "%s mavzu oʻrnatiladigan yoʻldir. Undan manba sifatida foydalanib boʻlmaydi"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "Faylning formati xato."
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Faqat moslamalarni qoʻllash va chiqish"
+
+#~ msgid "Connecting..."
+#~ msgstr "Aloqa oʻrnatilmoqda..."
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "Evolution 1.4 pochta klienti"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "Evolution 1.5 pochta klienti"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "Evolution 1.6 pochta klienti"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "Evolution 2.0 pochta klienti"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "Evolution 2.2 pochta klienti"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "Evolution 2.4 pochta klienti"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Links matnli veb brauzer"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Lynx matnli veb brauzer"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M matnli veb brauzer"
+
+#~ msgid "Default Settings"
+#~ msgstr "Andoza moslamalar"
+
+#~ msgid "Screen %d Settings\n"
+#~ msgstr "%d ekran moslamalari\n"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Ekran oʻlchami parametrlari"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "Ushbu kompyuter (%s) uchun andoza etib _belgilash"
+
+#~ msgid "Options"
+#~ msgstr "Parametrlar"
+
+#~ msgid "Testing the new settings. If you don't respond in %d second the previous settings will be restored."
+#~ msgid_plural "Testing the new settings. If you don't respond in %d seconds the previous settings will be restored."
+#~ msgstr[0] "Moslamalarni tekshirish. Agar %d soniya ichida tasdiqlamasangiz eski moslama qoʻllaniladi."
+#~ msgstr[1] "Moslamalarni tekshirish. Agar %d soniya ichida tasdiqlamasangiz eski moslama qoʻllaniladi."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Ushbu oʻlchamni saqlab qolish"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Ushbu oʻlchamni saqlab qolishni istaysizmi?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "_Oldingi oʻlchamdan foydalanish"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "Ushbu oʻlchamni _saqlab qolish"
+
+#~ msgid "New accelerator..."
+#~ msgstr "Yangi akselerator..."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "\"%s\" tugmalar birikmasi quyidagi uchun ishlatilmoqda:\n"
+#~ " \"%s\"\n"
+
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "Yangi akseleratorni maʼlumot bazasiga qayd qilishda xatolik: %s\n"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "Akseleratorni maʼlumot bazasidan olib tashlashda xatolik: %s\n"
+
+#~ msgid "Choose..."
+#~ msgstr "Tanlash..."
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Microsoft Natural klaviaturasi"
+
+#~ msgid "_Layouts:"
+#~ msgstr "_Tugmalar tartibi:"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Tezlik</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Tez</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Yuqori</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Katta</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Past</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Sekin</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Kichik</i>"
+
+#~ msgid "Buttons"
+#~ msgstr "Tugmalar"
+
+#~ msgid "Motion"
+#~ msgstr "Harakat"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Chap qoʻl uchun"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Qoʻshimcha parametrlar"
+
+#~ msgid "Unknown Volume Control %d"
+#~ msgstr "Nomaʼlum tovush moslovchisi %d"
+
+#~ msgid "Autodetect"
+#~ msgstr "Avto-aniqlash"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - Takomillashtirilgan Linux tovush tizimi"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART tovush demoni"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - Ochiq tovush tizimi"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "PulseAudio tovush serveri"
+
+#~ msgid "Silence"
+#~ msgstr "Jimlik"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "- GNOME tovush parametrlari"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Musiqa va filmlar</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>Tovush hodisalar</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">Sinalmoqda...</span>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "Tugatish uchun OK tugmasini bosing."
+
+#~ msgid "Devices"
+#~ msgstr "Uskunalar"
+
+#~ msgid "S_ound playback:"
+#~ msgstr "T_ovushni oʻynash:"
+
+#~ msgid "So_und playback:"
+#~ msgstr "To_vushni oʻynash:"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Tovush parametrlari"
+
+#~ msgid "Sounds"
+#~ msgstr "Tovushlar"
+
+#~ msgid "System Beep"
+#~ msgstr "Tizim tovushi"
+
+#~ msgid "Test"
+#~ msgstr "Sinash"
+
+#~ msgid "_Device:"
+#~ msgstr "_Uskuna:"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "Tizim tovushini _yoqish"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "Tizim tovushini _oʻynash"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "_Tovushni oʻynash:"
+
+#~ msgid "Volume"
+#~ msgstr "Tovush"
+
+#~ msgid "_Activate"
+#~ msgstr "_Aktivlashtirilsin"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "Aktivlashtiril_masin"
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "Ushbu ogohlantirish boshqa koʻrsatil_masin"
+
+#~ msgid "Use X settings"
+#~ msgstr "X moslamalaridan foydalanish"
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this is a valid command."
+#~ msgstr ""
+#~ "Buyruqni bajarib boʻlmadi: %s\n"
+#~ "Buyruq mavjudligini tekshirib koʻring."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "Ushbu xabar boshqa _koʻrsatilmasin"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Foydalanuvchi uy direktoriyasini aniqlab boʻlmadi"
+
+#~ msgid "A_vailable files:"
+#~ msgstr "_Mavjud fayllar:"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "Ushbu ogohlantirish boshqa koʻrsatil_masin."
+
+#~ msgid "Load modmap files"
+#~ msgstr "modmap fayllarini yuklash"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "modmap fayl(lar)ini yuklashni istaysizmi?"
+
+#~ msgid "_Load"
+#~ msgstr "_Yuklash"
+
+#~ msgid "_Loaded files:"
+#~ msgstr "_Yuklangan fayllar:"
+
+#~ msgid "Type"
+#~ msgstr "Turi"
+
+#~ msgid "Screen"
+#~ msgstr "Ekran"
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "Maʼlumotlar direktoriyasida xatchoʻp topilmadi"
+
+#~ msgid "A bookmark for URI '%s' already exists"
+#~ msgstr "URI '%s' uchun xatchoʻp allaqachon mavjud"
+
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "URI \"%s\" uchun xatchoʻp topilmadi"
+
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "URI '%s' uchun xatchoʻpda MIME turi aniqlanmagan"
+
+#~ msgid "Login"
+#~ msgstr "Kirish"
+
+#~ msgid "Logout"
+#~ msgstr "Chiqish"
+
+#~ msgid "Boing"
+#~ msgstr "Boing"
+
+#~ msgid "No sound"
+#~ msgstr "Tovush yoʻq"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "Ushbu hodisa uchun tovush oʻrnatilmagan."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default sounds."
+#~ msgstr ""
+#~ "Ushbu hodisa uchun tovush fayli mavjud emas.\n"
+#~ "Andoza tovushlaridan foydalanish uchun gnome-audio paketlarini oʻrnating."
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Ushbu hodisa uchun tovush fayli mavjud emas."
+
+#~ msgid "Select Sound File"
+#~ msgstr "Tovush faylini tanlang"
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "%s fayli wav fayl emas"
+
+#~ msgid "Select sound file..."
+#~ msgstr "Tovush faylini tanlang..."
+
+#~ msgid "System Sounds"
+#~ msgstr "Tizim tovushlari"
+
+#~ msgid "E-mail"
+#~ msgstr "El.pochta"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "El.pochta klientini ishga tushirish tugmalar birikmasi."
+
+#~ msgid "Eject"
+#~ msgstr "Chiqarish"
+
+#~ msgid "Home folder"
+#~ msgstr "Uy jildi"
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Uy jildi uchun tugmalar birikmasi."
+
+#~ msgid "Launch web browser"
+#~ msgstr "Veb brauzerni ishga tushirish"
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Veb brauzerni ishga tushirish tugmalar birikmasi."
+
+#~ msgid "Lock screen"
+#~ msgstr "Ekranni qulflash"
+
+#~ msgid "Lock screen's shortcut."
+#~ msgstr "Ekranni qulflash tugmalar birikmasi."
+
+#~ msgid "Log out"
+#~ msgstr "Seansni tugatish"
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Seansni tugatish tugmalar birikmasi."
+
+#~ msgid "Media player"
+#~ msgstr "Musiqa pleyeri"
+
+#~ msgid "Pause"
+#~ msgstr "Vaqtincha toʻxtatish"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Vaqtincha toʻxtatish tugmasi tugmalar birikmasi."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Oʻynash (yoki oʻynash/vaqtincha toʻxtatish) tugmalar birikmasi."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Oldingi qoʻshiq uchun tugmalar birikmasi."
+
+#~ msgid "Search's shortcut."
+#~ msgstr "Qidirish uchun tugmalar birikmasi."
+
+#~ msgid "Skip to next track"
+#~ msgstr "Keyingi yoʻlakchaga oʻtish"
+
+#~ msgid "Skip to previous track"
+#~ msgstr "Oldin yoʻlakchaga oʻtish"
+
+#~ msgid "Stop playback key"
+#~ msgstr "Oʻynashni toʻxtatish tugmasi"
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Oʻynashni toʻxtatish uchun tugmalar birikmasi."
+
+#~ msgid "Volume down"
+#~ msgstr "Tovushni pasaytirish"
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Tovushni pasaytirish uchun tugmalar birikmasi"
+
+#~ msgid "Volume mute's shortcut."
+#~ msgstr "Ovozni oʻchirish uchun tugmalar birikmasi"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "Seans boshlanganda ekran saqlovchisini  ishga tushirish"
+
+#~ msgid "Start screensaver"
+#~ msgstr "Ekran saqlovchisini ishga tushirish"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Dastur shrifti sifatida oʻrnatish"
+
+#~ msgid "Sets the default application font"
+#~ msgstr "Andoza dastur shriftini tanlang"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "GNOME shrift koʻruvchisi"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Yangi shrift qoʻllansinmi?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Shrift _qoʻllanmasin"
+
+#~ msgid "_Apply font"
+#~ msgstr "Shriftni _qoʻllash"
+
+#~ msgid "Themes"
+#~ msgstr "Mavzular"
+
+#~ msgid "Description"
+#~ msgstr "Taʼrifi"
+
+#~ msgid "Window border theme"
+#~ msgstr "Oyna chegarasi mavzusi"
+
+#~ msgid "Icon theme"
+#~ msgstr "Nishoncha mavzusi"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#~ msgid "[FILE]"
+#~ msgstr "[FAYL]"
+
+#~ msgid "Apply theme"
+#~ msgstr "Mavzuni qoʻllash"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Mavzuni andoza qilib belgilaydi"

--- a/po/uz@cyrillic.po
+++ b/po/uz@cyrillic.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center-2.0 trunk\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-01-07 20:26+0500\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2007-11-12 09:36+0500\n"
 "Last-Translator: Nurali Abdurahmonov <mavnur@gmail.com>\n"
 "Language-Team: Uzbek\n"
@@ -18,3333 +18,6023 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=0;\n"
 "X-Generator: KBabel 1.11.4\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr "Расм/ёрлиқ чегараси"
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr "Огоҳлантириш диалогидаги расм ва ёрлиқларнинг кенглиги"
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
-msgid "Alert Type"
-msgstr "Огоҳлантириш тури"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr "Огоҳлантириш тури"
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-msgid "Alert Buttons"
-msgstr "Огоҳлантириш тугмалари"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr "Огоҳлантириш ойнасида кўрсатиладиган тугмалар"
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-msgid "Show more _details"
-msgstr "_Тафсилотларни кўрсатиш"
-
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Place your left thumb on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:28
-#, c-format
-msgid "Swipe your left thumb on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Place your left index finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:29
-#, c-format
-msgid "Swipe your left index finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Place your left middle finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:30
-#, c-format
-msgid "Swipe your left middle finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Place your left ring finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:31
-#, c-format
-msgid "Swipe your left ring finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Place your left little finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:32
-#, c-format
-msgid "Swipe your left little finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Place your right thumb on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:33
-#, c-format
-msgid "Swipe your right thumb on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Place your right index finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:34
-#, c-format
-msgid "Swipe your right index finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Place your right middle finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:35
-#, c-format
-msgid "Swipe your right middle finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Place your right ring finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:36
-#, c-format
-msgid "Swipe your right ring finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Place your right little finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:37
-#, c-format
-msgid "Swipe your right little finger on %s"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:72
-#: ../capplets/about-me/fingerprint-strings.h:98
-msgid "Place your finger on the reader again"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:74
-#: ../capplets/about-me/fingerprint-strings.h:100
-msgid "Swipe your finger again"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:77
-#: ../capplets/about-me/fingerprint-strings.h:103
-msgid "Swipe was too short, try again"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:79
-#: ../capplets/about-me/fingerprint-strings.h:105
-msgid "Your finger was not centered, try swiping your finger again"
-msgstr ""
-
-#: ../capplets/about-me/fingerprint-strings.h:81
-#: ../capplets/about-me/fingerprint-strings.h:107
-msgid "Remove your finger, and try swiping your finger again"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:772
-msgid "Select Image"
-msgstr "Расмни танланг"
-
-#: ../capplets/about-me/gnome-about-me.c:774
-msgid "No Image"
-msgstr "Расмсиз"
-
-#: ../capplets/about-me/gnome-about-me.c:802
-#: ../capplets/appearance/appearance-desktop.c:660
-msgid "Images"
-msgstr "Расмлар"
-
-#: ../capplets/about-me/gnome-about-me.c:806
-#: ../capplets/appearance/theme-installer.c:700
-msgid "All Files"
-msgstr "Ҳамма файллар"
-
-#: ../capplets/about-me/gnome-about-me.c:952
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-"Манзиллар дафтаридан маълумот олиб бўлмади.\n"
-"Evolution маълумот сервери протоколни қўлламайди"
-
-#: ../capplets/about-me/gnome-about-me.c:973
-msgid "Unable to open address book"
-msgstr "Манзиллар дафтарини очиб бўлмади"
-
-#: ../capplets/about-me/gnome-about-me.c:987
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr "Номаълум фойдаланувчи ID'си. фойдаланувчи маълумот базаси зарарланган бўлиши мумкин"
-
-#: ../capplets/about-me/gnome-about-me.c:1017
-#: ../capplets/about-me/gnome-about-me.c:1019
-#, c-format
-msgid "About %s"
-msgstr "%s ҳақида"
-
-#: ../capplets/about-me/gnome-about-me.c:1037
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-msgid "Enable _Fingerprint Login..."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:1040
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Disable _Fingerprint Login..."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-msgid "About Me"
-msgstr "Мен ҳақимда"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-msgid "Set your personal information"
-msgstr "Шахсий маълумотларингиз"
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
-msgid "You are not allowed to access the device. Contact your system administrator."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
-msgid "The device is already in use."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:103
-msgid "An internal error occured"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:220
-msgid "Delete registered fingerprints?"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:223
-msgid "_Delete Fingerprints"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:230
-msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:343
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:583
-msgid "Done!"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
-#, c-format
-msgid "Could not access '%s' device"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:444
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:491
-msgid "Could not access any fingerprint readers"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:492
-msgid "Please contact your system administrator for help."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:518
-msgid "Enable Fingerprint Login"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:534
-msgid "Select finger"
-msgstr ""
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:555
-#, c-format
-msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:568
-msgid "Swipe finger on reader"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.c:570
-msgid "Place finger on reader"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:1
-msgid "Left index finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:2
-msgid ""
-"Left thumb\n"
-"Left middle finger\n"
-"Left ring finger\n"
-"Left little finger\n"
-"Right thumb\n"
-"Right middle finger\n"
-"Right ring finger\n"
-"Right little finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:10
-msgid "Other finger: "
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:11
-msgid "Right index finger"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:12
-msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-msgid "<b>Email</b>"
-msgstr "<b>Эл.почта</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-msgid "<b>Home</b>"
-msgstr "<b>Уй</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Instant Messaging</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Job</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Telephone</b>"
-msgstr "<b>Телефон</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Web</b>"
-msgstr "<b>WWW</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Work</b>"
-msgstr "<b>Иш</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Махфий сўзни ўзгартириш</span>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "A_IM/iChat:"
-msgstr "A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "A_ddress:"
-msgstr "_Манзил:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_ssistant:"
-msgstr "_Ёрдамчи:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "Address"
-msgstr "Манзил"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "C_ity:"
-msgstr "_Шаҳар:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-msgid "C_ompany:"
-msgstr "_Ташкилот:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "Cale_ndar:"
-msgstr "Та_қвим:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "Change Passwo_rd..."
-msgstr "Махфий _сўзни ўзгартириш..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Change pa_ssword"
-msgstr "Махфий с_ўзни ўзгартириш"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-msgid "Change password"
-msgstr "Махфий сўзни ўзгартириш"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Ci_ty:"
-msgstr "Ш_аҳар:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-msgid "Co_untry:"
-msgstr "_Давлат:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Contact"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-msgid "Cou_ntry:"
-msgstr "Дав_лат:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-msgid "Current _password:"
-msgstr "Жорий _махфий сўз:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "Full Name"
-msgstr "Тўлиқ исм"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "Hom_e:"
-msgstr "У_й:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-msgid "IC_Q:"
-msgstr "IC_Q:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "M_SN:"
-msgstr "M_SN:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P.O. _box:"
-msgstr "Почта қ_утиси:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-msgid "P._O. box:"
-msgstr "_Почта қутиси:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "Personal Info"
-msgstr "Шахсий маълумот"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#: ../capplets/about-me/gnome-about-me-password.c:938
-msgid "Please type your password again in the <b>Retype new password</b> field."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Select your photo"
-msgstr "Расм танланг"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "State/Pro_vince:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid ""
-"To change your password, enter your current password in the field below and click <b>Authenticate</b>.\n"
-"After you have authenticated, enter your new password, retype it for verification and click <b>Change password</b>."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "User name:"
-msgstr "Фойдаланувчи номи:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "Web _log:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "Wor_k:"
-msgstr "И_ш:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-msgid "Work _fax:"
-msgstr "_Факс (иш):"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "Zip/_Postal code:"
-msgstr "_Почта индекси:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Address:"
-msgstr "_Манзил:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Authenticate"
-msgstr "_Тасдиқлаш"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Department:"
-msgstr "_Бўлим:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-msgid "_Groupwise:"
-msgstr "_Groupwise:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Home page:"
-msgstr "_Уй саҳифаси:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-msgid "_Home:"
-msgstr "_Уй:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_Jabber:"
-msgstr "_Jabber:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Manager:"
-msgstr "_Бошқарувчи:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Mobile:"
-msgstr "Уяли телефон:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_New password:"
-msgstr "_Янги махфий сўз:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Profession:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:55
-msgid "_Retype new password:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:56
-msgid "_State/Province:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:57
-msgid "_Title:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:58
-msgid "_Work:"
-msgstr "_Иш:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:59
-msgid "_Yahoo:"
-msgstr "_Yahoo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:60
-msgid "_Zip/Postal code:"
-msgstr "Почта _индекси:"
-
-#: ../capplets/about-me/gnome-about-me-password.c:162
-msgid "Child exited unexpectedly"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:297
-#, c-format
-msgid "Could not shutdown backend_stdin IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:310
-#, c-format
-msgid "Could not shutdown backend_stdout IO channel: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:409
-msgid "Authenticated!"
-msgstr "Тасдиқланди!"
-
-#. This is a re-auth, and it failed.
-#. * The password must have been changed in the meantime!
-#. * Ask the user to re-authenticate
-#.
-#. Update status message and auth state
-#. Authentication failure
-#: ../capplets/about-me/gnome-about-me-password.c:475
-#: ../capplets/about-me/gnome-about-me-password.c:551
-msgid "Your password has been changed since you initially authenticated! Please re-authenticate."
-msgstr "Махфий сўзингиз кейинги сафарги тасдиқланишдан кейин ўзгартирилади! Илтимос қайта тасдиқланг."
-
-#: ../capplets/about-me/gnome-about-me-password.c:477
-msgid "That password was incorrect."
-msgstr "Махфий сўз хато."
-
-#: ../capplets/about-me/gnome-about-me-password.c:524
-msgid "Your password has been changed."
-msgstr "Махфий сўзингиз ўзгартирилди."
-
-#. What does this indicate?
-#. * "Authentication information cannot be recovered?" from libpam?
-#: ../capplets/about-me/gnome-about-me-password.c:534
-#, c-format
-msgid "System error: %s."
-msgstr "Тизим хатоси: %s."
-
-#: ../capplets/about-me/gnome-about-me-password.c:537
-msgid "The password is too short."
-msgstr "Махфий сўз жуда қисқа."
-
-#: ../capplets/about-me/gnome-about-me-password.c:540
-msgid "The password is too simple."
-msgstr "Махфий сўз жуда оддий."
-
-#: ../capplets/about-me/gnome-about-me-password.c:543
-msgid "The old and new passwords are too similar."
-msgstr "Эски ва янги махфий сўз жуда ўхшаш."
-
-#: ../capplets/about-me/gnome-about-me-password.c:545
-msgid "The new password must contain numeric or special character(s)."
-msgstr "Янги махфий сўз рақам ва махсус белги(лар)дан иборат бўлиши керак."
-
-#: ../capplets/about-me/gnome-about-me-password.c:548
-msgid "The old and new passwords are the same."
-msgstr "Эски ва янги махфий сўз бир хил."
-
-#. translators: Unable to launch <program>: <error message>
-#: ../capplets/about-me/gnome-about-me-password.c:820
-#, c-format
-msgid "Unable to launch %s: %s"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:824
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:825
-msgid "A system error has occurred"
-msgstr "Тизимда хатолик рўй берди"
-
-#. Update status message
-#: ../capplets/about-me/gnome-about-me-password.c:845
-msgid "Checking password..."
-msgstr "Махфий сўз текширилмоқда..."
-
-#: ../capplets/about-me/gnome-about-me-password.c:932
-msgid "Click <b>Change password</b> to change your password."
-msgstr "Махфий сўзни ўзгартириш учун <b>Махфий сўзни ўзгартириш</b> тугмасини босинг."
-
-#: ../capplets/about-me/gnome-about-me-password.c:935
-msgid "Please type your password in the <b>New password</b> field."
-msgstr "Илтимос <b>янги махфий сўз</b> майдонига махфий сўзни киритинг."
-
-#: ../capplets/about-me/gnome-about-me-password.c:941
-msgid "The two passwords are not equal."
-msgstr "Иккала махфий сўз мос келмади."
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Assistive Technologies</b>"
-msgstr "<b>Ёрдамчи технологиялар</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Preferences</b>"
-msgstr "<b>Параметрлар</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid "Accessible Lo_gin"
-msgstr "Тизимга _киришдаги ёрдамчи технологиялар"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technologies Preferences"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Changes to enable assistive technologies will not take effect until your next log in."
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Close and _Log Out"
-msgstr "Ёпиш ва тизимдан _чиқиш"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "Jump to Preferred Applications dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "Jump to the Accessible Login dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "Jump to the Keyboard Accessibility dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "Jump to the Mouse Accessibility dialog"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
-msgid "_Enable assistive technologies"
-msgstr "Ёрдамчи технологияларни _ёқиш"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
-msgid "_Keyboard Accessibility"
-msgstr "_Клавиатура махсус имкониятлари"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
-msgid "_Mouse Accessibility"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
-msgid "_Preferred Applications"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Choose which accessibility features to enable when you log in"
-msgstr ""
-
-#: ../capplets/appearance/appearance-desktop.c:628
-msgid "Add Wallpaper"
-msgstr "Гулқоғоз қўшиш"
-
-#: ../capplets/appearance/appearance-desktop.c:664
-msgid "All files"
-msgstr "Ҳамма файллар"
-
-#: ../capplets/appearance/appearance-font.c:495
-msgid "Font may be too large"
-msgstr "Шрифт жуда катта бўлиши мумкин"
-
-#: ../capplets/appearance/appearance-font.c:499
-#, c-format
-msgid "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is recommended that you select a size smaller than %d."
-msgid_plural "The font selected is %d points large, and may make it difficult to effectively use the computer. It is recommended that you select a size smaller than %d."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:512
-#, c-format
-msgid "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is recommended that you select a smaller sized font."
-msgid_plural "The font selected is %d points large, and may make it difficult to effectively use the computer. It is recommended that you select a smaller sized font."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/appearance/appearance-font.c:535
-msgid "Use previous font"
-msgstr "Олдинги шрифтдан фойдаланиш"
-
-#: ../capplets/appearance/appearance-font.c:537
-msgid "Use selected font"
-msgstr "Танланган шрифтдан фойдаланиш"
-
-#: ../capplets/appearance/appearance-main.c:124
-msgid "Specify the filename of a theme to install"
-msgstr "Ўрнатиладиган мавзу файли номини кўрсатинг"
-
-#: ../capplets/appearance/appearance-main.c:125
-msgid "filename"
-msgstr "файл номи"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/appearance/appearance-main.c:132
-msgid "Specify the name of the page to show (theme|background|fonts|interface)"
-msgstr ""
-
-#: ../capplets/appearance/appearance-main.c:133
-#: ../capplets/default-applications/gnome-da-capplet.c:879
-#: ../capplets/mouse/gnome-mouse-properties.c:442
-msgid "page"
-msgstr "саҳифа"
-
-#: ../capplets/appearance/appearance-main.c:140
-msgid "[WALLPAPER...]"
-msgstr "[ГУЛҚОҒОЗ...]"
-
-#: ../capplets/appearance/appearance-style.c:173
-#: ../capplets/common/gnome-theme-info.c:445
-#: ../capplets/common/gnome-theme-info.c:637
-msgid "Default Pointer"
-msgstr "Андоза кўрсатгич"
-
-#: ../capplets/appearance/appearance-style.c:235
-#: ../capplets/appearance/appearance-themes.c:686
-msgid "Install"
-msgstr ""
-
-#: ../capplets/appearance/appearance-style.c:255
-#: ../capplets/common/gnome-theme-info.c:1647
-#, c-format
-msgid "This theme will not look as intended because the required GTK+ theme engine '%s' is not installed."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:674
-msgid "Apply Background"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:678
-msgid "Apply Font"
-msgstr "Шрифтни қўллаш"
-
-#: ../capplets/appearance/appearance-themes.c:682
-msgid "Revert Font"
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:712
-msgid "The current theme suggests a background and a font. Also, the last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:714
-msgid "The current theme suggests a background. Also, the last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:716
-msgid "The current theme suggests a background and a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:718
-msgid "The current theme suggests a font. Also, the last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:720
-msgid "The current theme suggests a background."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:722
-msgid "The last applied font suggestion can be reverted."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:724
-msgid "The current theme suggests a font."
-msgstr ""
-
-#: ../capplets/appearance/appearance-themes.c:1045
-#: ../capplets/default-applications/gnome-da-capplet.c:630
-msgid "Custom"
-msgstr "Бошқа"
-
-#: ../capplets/appearance/data/appearance.glade.h:1
-msgid "<b>C_olors</b>"
-msgstr "<b>_Ранглар</b>"
-
-#. font hinting
-#: ../capplets/appearance/data/appearance.glade.h:3
-msgid "<b>Hinting</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:4
-msgid "<b>Menus and Toolbars</b>"
-msgstr "<b>Меню ва асбоблар панели</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:5
-msgid "<b>Preview</b>"
-msgstr "<b>Олдиндан кўриш</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:6
-msgid "<b>Rendering</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:7
-msgid "<b>Smoothing</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:8
-msgid "<b>Subpixel Order</b>"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:9
-msgid "<b>_Wallpaper</b>"
-msgstr "<b>_Гулқоғоз</b>"
-
-#: ../capplets/appearance/data/appearance.glade.h:10
-msgid "Appearance Preferences"
-msgstr "Ташқи кўринишни мослаш"
-
-#: ../capplets/appearance/data/appearance.glade.h:11
-msgid "Background"
-msgstr "Орқа фон"
-
-#: ../capplets/appearance/data/appearance.glade.h:12
-msgid "Best _shapes"
-msgstr "Энг яхши _шакллар"
-
-#: ../capplets/appearance/data/appearance.glade.h:13
-msgid "Best co_ntrast"
-msgstr "Энг яхши ко_нтраст"
-
-#: ../capplets/appearance/data/appearance.glade.h:14
-msgid "C_ustomize..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:15
-msgid "C_ut"
-msgstr "К_есиш"
-
-#: ../capplets/appearance/data/appearance.glade.h:16
-msgid "Changing your cursor theme takes effect the next time you log in."
-msgstr "Курсор мавзуси кейинги сафар тизимга кирганда кучга киради."
-
-#: ../capplets/appearance/data/appearance.glade.h:17
-msgid "Colors"
-msgstr "Ранглар"
-
-#: ../capplets/appearance/data/appearance.glade.h:18
-msgid "Controls"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:19
-msgid "Customize Theme"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:20
-msgid "D_etails..."
-msgstr "_Тафсилотлар..."
-
-#: ../capplets/appearance/data/appearance.glade.h:21
-msgid "Des_ktop font:"
-msgstr "Иш _столи шрифти:"
-
-#: ../capplets/appearance/data/appearance.glade.h:22
-msgid "Edit"
-msgstr "Таҳрирлаш"
-
-#: ../capplets/appearance/data/appearance.glade.h:23
-msgid "Font Rendering Details"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:24
-msgid "Fonts"
-msgstr "Шрифтлар"
-
-#: ../capplets/appearance/data/appearance.glade.h:25
-msgid "Gra_yscale"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:26
-msgid "Icons"
-msgstr "Нишончалар"
-
-#: ../capplets/appearance/data/appearance.glade.h:27
-msgid "Interface"
-msgstr "Интерфейс"
-
-#: ../capplets/appearance/data/appearance.glade.h:28
-msgid "Large"
-msgstr "Катта"
-
-#: ../capplets/appearance/data/appearance.glade.h:29
-msgid "N_one"
-msgstr "_Йўқ"
-
-#: ../capplets/appearance/data/appearance.glade.h:30
-msgid "New File"
-msgstr "Янги  файл"
-
-#: ../capplets/appearance/data/appearance.glade.h:31
-msgid "Open File"
-msgstr "Файлни очиш"
-
-#: ../capplets/appearance/data/appearance.glade.h:32
-msgid "Open a dialog to specify the color"
-msgstr "Рангни кўрсатиш учун диалогни очиш"
-
-#: ../capplets/appearance/data/appearance.glade.h:33
-msgid "Pointer"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:34
-msgid "R_esolution:"
-msgstr "Ў_лчами:"
-
-#: ../capplets/appearance/data/appearance.glade.h:35
-msgid "Save File"
-msgstr "Файлни сақлаш"
-
-#: ../capplets/appearance/data/appearance.glade.h:36
-msgid "Save Theme As..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:37
-msgid "Save _As..."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:38
-msgid "Save _background image"
-msgstr "_Орқа фон расмини сақлаш"
-
-#: ../capplets/appearance/data/appearance.glade.h:39
-msgid "Show _icons in menus"
-msgstr "Менюларда _нишончаларни кўрсатиш"
-
-#: ../capplets/appearance/data/appearance.glade.h:40
-msgid "Small"
-msgstr "Кичкина"
-
-#: ../capplets/appearance/data/appearance.glade.h:41
-msgid ""
-"Solid color\n"
-"Horizontal gradient\n"
-"Vertical gradient"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:44
-msgid "Sub_pixel (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:45
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:46
-msgid "Text"
-msgstr "Матн"
-
-#: ../capplets/appearance/data/appearance.glade.h:47
-msgid ""
-"Text below items\n"
-"Text beside items\n"
-"Icons only\n"
-"Text only"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:51
-msgid "The current controls theme does not support color schemes."
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:52
-msgid "Theme"
-msgstr "Мавзу"
-
-#: ../capplets/appearance/data/appearance.glade.h:53
-msgid ""
-"Tiled\n"
-"Zoom\n"
-"Centered\n"
-"Scaled\n"
-"Fill screen"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:58
-msgid "Toolbar _button labels:"
-msgstr ""
-
-#. vertical hinting, pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:60
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/appearance/data/appearance.glade.h:61
-msgid "Window Border"
-msgstr "Ойна чегараси"
-
-#: ../capplets/appearance/data/appearance.glade.h:62
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
-msgid "_Add..."
-msgstr "_Қўшиш..."
-
-#: ../capplets/appearance/data/appearance.glade.h:63
-msgid "_Application font:"
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+#, fuzzy
+msgid "Applications"
 msgstr "_Дастур шрифти:"
 
-#. pixel order blue, green, red
-#: ../capplets/appearance/data/appearance.glade.h:65
-msgid "_BGR"
-msgstr "_BGR"
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "Дастур шрифти сифатида ўрнатиш"
 
-#: ../capplets/appearance/data/appearance.glade.h:66
-msgid "_Copy"
-msgstr "_Нусха олиш"
-
-#: ../capplets/appearance/data/appearance.glade.h:67
-msgid "_Description:"
-msgstr "_Таърифи:"
-
-#: ../capplets/appearance/data/appearance.glade.h:68
-msgid "_Document font:"
-msgstr "_Ҳужжат шрифти:"
-
-#: ../capplets/appearance/data/appearance.glade.h:69
-msgid "_Editable menu shortcut keys"
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
 msgstr ""
 
-#: ../capplets/appearance/data/appearance.glade.h:70
-msgid "_File"
-msgstr "_Файл"
-
-#: ../capplets/appearance/data/appearance.glade.h:71
-msgid "_Fixed width font:"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:72
-msgid "_Full"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:73
-msgid "_Input boxes:"
-msgstr "_Киритиш майдонлари:"
-
-#: ../capplets/appearance/data/appearance.glade.h:74
-msgid "_Install..."
-msgstr "_Ўрнатиш..."
-
-#: ../capplets/appearance/data/appearance.glade.h:75
-msgid "_Medium"
-msgstr "_Ўртача"
-
-#: ../capplets/appearance/data/appearance.glade.h:76
-msgid "_Monochrome"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:77
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:5
-msgid "_Name:"
-msgstr "_Номи:"
-
-#: ../capplets/appearance/data/appearance.glade.h:78
-msgid "_New"
-msgstr "_Янги"
-
-#: ../capplets/appearance/data/appearance.glade.h:79
-msgid "_None"
-msgstr "_Йўқ"
-
-#: ../capplets/appearance/data/appearance.glade.h:80
-msgid "_Open"
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
 msgstr "_Очиш"
 
-#: ../capplets/appearance/data/appearance.glade.h:81
-msgid "_Paste"
-msgstr "_Қўйиш"
-
-#: ../capplets/appearance/data/appearance.glade.h:82
-msgid "_Print"
-msgstr "_Босиб чиқариш"
-
-#: ../capplets/appearance/data/appearance.glade.h:83
-msgid "_Quit"
-msgstr "_Чиқиш"
-
-#. pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:85
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:86
-msgid "_Reset to Defaults"
-msgstr "Андоза қийматга _қайтариш"
-
-#: ../capplets/appearance/data/appearance.glade.h:87
-msgid "_Save"
-msgstr "_Сақлаш"
-
-#: ../capplets/appearance/data/appearance.glade.h:88
-msgid "_Selected items:"
-msgstr "_Танланган элементлар:"
-
-#: ../capplets/appearance/data/appearance.glade.h:89
-msgid "_Size:"
-msgstr "_Ҳажми:"
-
-#: ../capplets/appearance/data/appearance.glade.h:90
-msgid "_Slight"
-msgstr ""
-
-#: ../capplets/appearance/data/appearance.glade.h:91
-msgid "_Style:"
-msgstr "_Услуб:"
-
-#: ../capplets/appearance/data/appearance.glade.h:92
-msgid "_Tooltips:"
-msgstr ""
-
-#. vertical hinting, pixel order red, green, blue
-#: ../capplets/appearance/data/appearance.glade.h:94
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/appearance/data/appearance.glade.h:95
-msgid "_Window title font:"
-msgstr "_Ойна сарлавҳаси шрифти:"
-
-#: ../capplets/appearance/data/appearance.glade.h:96
-msgid "_Windows:"
-msgstr "_Ойналар:"
-
-#: ../capplets/appearance/data/appearance.glade.h:97
-msgid "dots per inch"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
-msgid "Appearance"
-msgstr "Ташқи кўриниши"
-
-#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
-msgid "Customize the look of the desktop"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
-msgid "Installs themes packages for various parts of the desktop"
-msgstr ""
-
-#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
-msgid "Theme Installer"
-msgstr "Мавзу ўрнатгич"
-
-#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
-msgid "Gnome Theme Package"
-msgstr "Gnome мавзу пакети"
-
-#: ../capplets/appearance/gnome-wp-info.c:50
-msgid "No Wallpaper"
-msgstr "Гулқоғозсиз"
-
-#: ../capplets/appearance/gnome-wp-item.c:208
-msgid "Slide Show"
-msgstr ""
-
-#. translators: <b>wallpaper name</b>
-#. * mime type, x pixel(s) by y pixel(s)
-#. * Folder: /path/to/file
-#.
-#: ../capplets/appearance/gnome-wp-item.c:216
-#, c-format
-msgid ""
-"<b>%s</b>\n"
-"%s, %d %s by %d %s\n"
-"Folder: %s"
-msgstr ""
-
-#: ../capplets/appearance/gnome-wp-item.c:222
-#: ../capplets/appearance/gnome-wp-item.c:224
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "пиксел"
-msgstr[1] "пиксел"
-
-#: ../capplets/appearance/theme-installer.c:174
-#: ../capplets/appearance/theme-installer.c:224
-msgid "Cannot install theme"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:176
-#, c-format
-msgid "The %s utility is not installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:226
-msgid "There was a problem while extracting the theme."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:249
-msgid "There was an error installing the selected file"
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:250
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:251
-#, c-format
-msgid "\"%s\" does not appear to be a valid theme. It may be a theme engine which you need to compile."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:290
-#, c-format
-msgid "GNOME Theme %s correctly installed"
-msgstr "%s Gnome мавзуси муваффақиятли ўрнатилди"
-
-#: ../capplets/appearance/theme-installer.c:357
-#, c-format
-msgid "Installation for theme \"%s\" failed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:396
-#, c-format
-msgid "The theme \"%s\" has been installed."
-msgstr "\"%s\" мавзу ўрнатилди."
-
-#: ../capplets/appearance/theme-installer.c:402
-msgid "Would you like to apply it now, or keep your current theme?"
-msgstr "Уни қўллашни истайсизми ёки жорий мавзуни сақлаб қоласизми?"
-
-#: ../capplets/appearance/theme-installer.c:404
-msgid "Keep Current Theme"
-msgstr "Жорий мавзу сақлаб қолинсин"
-
-#: ../capplets/appearance/theme-installer.c:406
-msgid "Apply New Theme"
-msgstr "Янги мавзу қўллансин"
-
-#: ../capplets/appearance/theme-installer.c:510
-msgid "Failed to create temporary directory"
-msgstr "Вақтинчалик директория яратиб бўлмади"
-
-#: ../capplets/appearance/theme-installer.c:573
-msgid "New themes have been successfully installed."
-msgstr ""
-
-#: ../capplets/appearance/theme-installer.c:598
-msgid "No theme file location specified to install"
-msgstr "Ўрнатиш учун мавзу файли йўли кўрсатилмаган"
-
-#: ../capplets/appearance/theme-installer.c:619
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"Мавзуни қуйидаги манзилга ўрнатиш учун ҳуқуқ етарли эмас:\n"
-"%s"
-
-#: ../capplets/appearance/theme-installer.c:689
-msgid "Select Theme"
-msgstr "Мавзуни танлаш"
-
-#: ../capplets/appearance/theme-installer.c:693
-msgid "Theme Packages"
-msgstr "Мавзу пакетлари"
-
-#: ../capplets/appearance/theme-save.c:93
-#, c-format
-msgid "Theme name must be present"
-msgstr ""
-
-#: ../capplets/appearance/theme-save.c:156
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Мавзу аллақачон мавжуд. Алмаштиришни истайсизми?"
-
-#: ../capplets/appearance/theme-save.c:157
-#: ../capplets/common/file-transfer-dialog.c:450
-msgid "_Overwrite"
-msgstr "_Алмаштириш"
-
-#: ../capplets/appearance/theme-util.c:75
-msgid "Would you like to delete this theme?"
-msgstr "Ушбу мавзуни олиб ташлашни истайсизми?"
-
-#: ../capplets/appearance/theme-util.c:125
-msgid "Theme cannot be deleted"
-msgstr "Мавзуни олиб ташлаб бўлмайди"
-
-#: ../capplets/appearance/theme-util.c:252
-msgid "Could not install theme engine"
-msgstr ""
-
-#: ../capplets/common/activate-settings-daemon.c:16
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) settings manager may already be active and conflicting with the GNOME settings manager."
-msgstr ""
-
-#: ../capplets/common/capplet-stock-icons.c:66
-#, c-format
-msgid "Unable to load stock icon '%s'\n"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:88
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Ёрдам файлини кўрсатишда хатолик юз берди: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:98
-#, c-format
-msgid "Copying file: %u of %u"
-msgstr "Файлдан нусха олинмоқда: %u дан %u"
-
-#: ../capplets/common/file-transfer-dialog.c:145
-#, c-format
-msgid "Copying '%s'"
-msgstr "'%s' нусха олинмоқда"
-
-#: ../capplets/common/file-transfer-dialog.c:185
-#: ../capplets/common/file-transfer-dialog.c:312
-msgid "Copying files"
-msgstr "Файллардан нусха олинмоқда"
-
-#: ../capplets/common/file-transfer-dialog.c:224
-msgid "Parent Window"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Parent window of the dialog"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:231
-msgid "From URI"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:232
-msgid "URI currently transferring from"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:239
-msgid "To URI"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:240
-msgid "URI currently transferring to"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:247
-msgid "Fraction completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:248
-msgid "Fraction of transfer currently completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:255
-msgid "Current URI index"
-msgstr "Жорий URI индекси"
-
-#: ../capplets/common/file-transfer-dialog.c:256
-msgid "Current URI index - starts from 1"
-msgstr "Жорий URI индекси - 1'дан бошланади"
-
-#: ../capplets/common/file-transfer-dialog.c:263
-msgid "Total URIs"
-msgstr "Жами URI"
-
-#: ../capplets/common/file-transfer-dialog.c:264
-msgid "Total number of URIs"
-msgstr "Жами URI сони"
-
-#: ../capplets/common/file-transfer-dialog.c:444
-#, c-format
-msgid "File '%s' already exists. Do you want to overwrite it?"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:447
-msgid "_Skip"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Overwrite _All"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:134
-msgid "Key"
-msgstr "Калит"
-
-#: ../capplets/common/gconf-property-editor.c:135
-msgid "GConf key to which this property editor is attached"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:141
-msgid "Callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:142
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:147
-msgid "Change set"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:148
-msgid "GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:153
-msgid "Conversion to widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:154
-msgid "Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:159
-msgid "Conversion from widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:160
-msgid "Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:165
-msgid "UI Control"
-msgstr "График интерфейс бошқаруви"
-
-#: ../capplets/common/gconf-property-editor.c:166
-msgid "Object that controls the property (normally a widget)"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:181
-msgid "Property editor object data"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:182
-msgid "Custom data required by the specific property editor"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:188
-msgid "Property editor data freeing callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1404
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background picture."
-msgstr ""
-"'%s' файлини топиб бўлмади.\n"
-"\n"
-"Илтимос уни мавжудлигини текшириб кўринг ва қайта уриниб кўринг ёки бошқа орқа фон расмини танланг."
-
-#: ../capplets/common/gconf-property-editor.c:1412
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"'%s' файлини қандай очиш мумкин.\n"
-"Балки бу расм тури хали қўлланилмаслиги мумкин.\n"
-"\n"
-"Илтимос бунинг ўрнига бошқа расм танланг."
-
-#: ../capplets/common/gconf-property-editor.c:1532
-msgid "Please select an image."
-msgstr "Илтимос расм танланг."
-
-#: ../capplets/common/gconf-property-editor.c:1537
-msgid "_Select"
-msgstr "_Танлаш"
-
-#: ../capplets/common/gnome-theme-info.c:638
-msgid "Default Pointer - Current"
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:642
-msgid "White Pointer"
-msgstr "Оқ кўрсатгич"
-
-#: ../capplets/common/gnome-theme-info.c:643
-msgid "White Pointer - Current"
-msgstr "Оқ кўрсатгич - жорий"
-
-#: ../capplets/common/gnome-theme-info.c:647
-msgid "Large Pointer"
-msgstr "Катта кўрсатгич"
-
-#: ../capplets/common/gnome-theme-info.c:648
-msgid "Large Pointer - Current"
-msgstr "Катта кўрсатгич - жорий"
-
-#: ../capplets/common/gnome-theme-info.c:652
-msgid "Large White Pointer - Current"
-msgstr "Катта оқ кўрсатгич - жорий"
-
-#: ../capplets/common/gnome-theme-info.c:653
-msgid "Large White Pointer"
-msgstr "Катта оқ кўрсатгич"
-
-#: ../capplets/common/gnome-theme-info.c:1623
-#, c-format
-msgid "This theme will not look as intended because the required GTK+ theme '%s' is not installed."
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1631
-#, c-format
-msgid "This theme will not look as intended because the required window manager theme '%s' is not installed."
-msgstr ""
-
-#: ../capplets/common/gnome-theme-info.c:1638
-#, c-format
-msgid "This theme will not look as intended because the required icon theme '%s' is not installed."
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Preferred Applications"
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Андоза дастурни танланг"
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
-msgid "Start the preferred visual assistive technology"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
-msgid "Visual Assistance"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:94
-#: ../capplets/default-applications/gnome-da-capplet.c:345
-#: ../capplets/default-applications/gnome-da-capplet.c:366
-#, c-format
-msgid "Error saving configuration: %s"
-msgstr "Мосламани сақлаш хатолиги: %s"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:650
-msgid "Could not load the main interface"
-msgstr "Асосий интерфейсни юклаб бўлмади"
-
-#: ../capplets/default-applications/gnome-da-capplet.c:652
-msgid "Please make sure that the applet is properly installed"
-msgstr "Илтимос аплет тўғри ўрнатилганлигига ишонч хосил қилинг"
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/default-applications/gnome-da-capplet.c:878
-msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-da-capplet.c:883
-msgid "- GNOME Default Applications"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-msgid "<b>Image Viewer</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "<b>Instant Messenger</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "<b>Mail Reader</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "<b>Mobility</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "<b>Multimedia Player</b>"
-msgstr "<b>Мултимедиа плейери</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "<b>Terminal Emulator</b>"
-msgstr "<b>Терминал эмулятори</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "<b>Text Editor</b>"
-msgstr "<b>Матн таҳрирчиси</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "<b>Video Player</b>"
-msgstr "<b>Видео плейер</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "<b>Visual</b>"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "<b>Web Browser</b>"
-msgstr "<b>Веб-браузер</b>"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
-msgid "Accessibility"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-#, no-c-format
-msgid "All %s occurrences will be replaced with actual link"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "C_ommand:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "Co_mmand:"
-msgstr "Буй_руқ:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "E_xecute flag:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Internet"
-msgstr "Интернет"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Multimedia"
-msgstr "Мултимедиа"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Open link in new _tab"
-msgstr "Боғламани янги _табда очиш"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "Open link in new _window"
-msgstr "Боғламани янги _ойнада очиш"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid "Open link with web browser _default"
-msgstr "Боғламани браузер _андозаси билан очиш"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Run at st_art"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Run in t_erminal"
-msgstr "Т_ерминалда бажариш"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "System"
-msgstr "Тизим"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "_Run at start"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
-msgid "Banshee Music Player"
-msgstr "Banshee мусиқий плейери"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
-msgid "Claws Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
-msgid "Dasher"
-msgstr "Dasher"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
-msgid "Debian Sensible Browser"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
-msgid "Debian Terminal Emulator"
-msgstr "Debian терминал эмулятори"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
-msgid "Encompass"
-msgstr "Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
-msgid "Epiphany Web Browser"
-msgstr "Epiphany веб браузери"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
-msgid "Evolution Mail Reader"
-msgstr "Evolution почта клиенти"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
-msgid "Firebird"
-msgstr "Firebird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
-msgid "Firefox"
-msgstr "Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
-msgid "GNOME Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
-msgid "GNOME OnScreen Keyboard"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
-msgid "GNOME Terminal"
-msgstr "GNOME терминали"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
-msgid "Gnopernicus"
-msgstr "Gnopernicus"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
-msgid "Gnopernicus with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
-msgid "Iceape"
-msgstr "Iceape"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
-msgid "Iceape Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
-msgid "Icedove"
-msgstr "Icedove"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
-msgid "Iceweasel"
-msgstr "Iceweasel"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
-msgid "KDE Magnifier without Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
-msgid "KMail"
-msgstr "KMail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
-msgid "Konsole"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
-msgid "Linux Screen Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
-msgid "Linux Screen Reader with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
-msgid "Listen"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
-msgid "Midori"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
-msgid "Mozilla"
-msgstr "Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
-msgid "Mozilla 1.6"
-msgstr "Mozilla 1.6"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
-msgid "Mozilla Mail"
-msgstr "Mozilla Mail"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
-msgid "Mozilla Thunderbird"
-msgstr "Mozilla Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
-msgid "Muine Music Player"
-msgstr "Muine мусиқа плейери"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
-msgid "NXterm"
-msgstr "NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
-msgid "Netscape Communicator"
-msgstr "Netscape Communicator"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
-msgid "Opera"
-msgstr "Opera"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
-msgid "Orca"
-msgstr "Orca"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
-msgid "Orca with Magnifier"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
-msgid "Rhythmbox Music Player"
-msgstr "Rhythmbox мусиқа плейери"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
-msgid "SeaMonkey"
-msgstr "SeaMonkey"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
-msgid "SeaMonkey Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
-msgid "Standard XTerminal"
-msgstr "Андоза X-терминали"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
-msgid "Sylpheed"
-msgstr "Sylpheed"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
-msgid "Sylpheed-Claws"
-msgstr "Sylpheed-Claws"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
-msgid "Terminator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
-msgid "Thunderbird"
-msgstr "Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
-msgid "Totem Movie Player"
-msgstr "Totem плейери"
-
-#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
-msgid "aterm"
-msgstr "aterm"
-
-#: ../capplets/display/display-capplet.glade.h:1
-#: ../capplets/display/xrandr-capplet.c:450
-msgid "<b>Monitor</b>"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:2
-msgid "<b>Panel icon</b>"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:3
-msgid "<i>Drag the monitors to set their place</i>"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:4
-msgid "Display Settings"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:5
-msgid "Include _panel"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:6
-msgid ""
-"Normal\n"
-"Left\n"
-"Right\n"
-"Upside-down\n"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:11
-msgid "R_otation:"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:12
-msgid "Re_fresh rate:"
-msgstr "_Янгиланиш даражаси"
-
-#: ../capplets/display/display-capplet.glade.h:13
-msgid "_Detect Monitors"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:14
-msgid "_Mirror screens"
-msgstr ""
-
-#: ../capplets/display/display-capplet.glade.h:15
-msgid "_Resolution:"
-msgstr "_Ўлчами:"
-
-#: ../capplets/display/display-capplet.glade.h:16
-msgid "_Show displays in panel"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Экран ўлчамини ўзгартириш"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Экран ўлчами"
-
-#: ../capplets/display/xrandr-capplet.c:318
-#: ../capplets/display/xrandr-capplet.c:357
-msgid "Normal"
-msgstr "Ўртача"
-
-#: ../capplets/display/xrandr-capplet.c:319
-msgid "Left"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:320
-msgid "Right"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:321
-msgid "Upside Down"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:393
-#: ../capplets/display/xrandr-capplet.c:401
-#: ../capplets/display/xrandr-capplet.c:402
-#, c-format
-msgid "%d Hz"
-msgstr "%d Гц"
-
-#: ../capplets/display/xrandr-capplet.c:443
-#, c-format
-msgid "<b>Monitor: %s</b>"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:489
-#: ../capplets/display/xrandr-capplet.c:508
-#: ../capplets/display/xrandr-capplet.c:518
-#, c-format
-msgid "%d x %d"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:500
-msgid "Off"
-msgstr ""
-
-#. Translators:  this is the feature where what you see on your laptop's
-#. * screen is the same as your external monitor.  Here, "Mirror" is being
-#. * used as an adjective, not as a verb.  For example, the Spanish
-#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
-#.
-#: ../capplets/display/xrandr-capplet.c:1306
-msgid "Mirror Screens"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1624
-msgid "Could not save the monitor configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1631
-msgid "Could not get session bus while applying display configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1641
-msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1647
-msgid "Could not apply the selected configuration"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1687
-msgid "Could not detect displays"
-msgstr ""
-
-#: ../capplets/display/xrandr-capplet.c:1885
-msgid "Could not get screen information"
-msgstr ""
-
-#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
-msgid "Sound"
-msgstr "Товуш"
-
-#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
-#: ../libslab/bookmark-agent.c:1146
-msgid "Desktop"
-msgstr "Иш столи"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New shortcut..."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Акселератор тугмаси"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Акселератор модификаторлари"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Акселератор тугмаси коди"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Акселератор усули"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Акселератор тури."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:103
-#: ../typing-break/drwright.c:479
-msgid "Disabled"
-msgstr "Ўчирилган"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:184
-msgid "<Unknown Action>"
-msgstr "<Номаълум амал>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:918
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1528
-msgid "Custom Shortcuts"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1057
-msgid "Error saving the new shortcut"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1136
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1166
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1172
-#, c-format
-msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1180
-msgid "_Reassign"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1300
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1483
-msgid "Too many custom shortcuts"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1768
-msgid "Action"
-msgstr "Амал"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:1790
-msgid "Shortcut"
-msgstr "Тугмалар бирикмаси"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-msgid "Custom Shortcut"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Клавиатура тугмалар бирикмаси:"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:3
-msgid "To edit a shortcut key, click on the corresponding row and type a new key combination, or press backspace to clear."
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:4
-msgid "_Command:"
-msgstr ""
-
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Буйруқларга тугмалар бирикмаси тайинлаш"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:209
-#: ../capplets/keyboard/gnome-keyboard-properties.c:214
-msgid "Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:219
-msgid "Start the page with the typing break settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:224
-msgid "Start the page with the accessibility settings showing"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:230
-msgid "- GNOME Keyboard Preferences"
-msgstr "- GNOME клавиатура параметрлари"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-msgid "<b>Bounce Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-msgid "<b>Cursor Blinking</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "<b>General</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Repeat Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Slow Keys</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>Sticky Keys</b>"
-msgstr ""
-
-#. fast acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Тез</i></small>"
-
-#. long delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Узун</i></small>"
-
-#. short delay
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Қисқа</i></small>"
-
-#. slow acceleration
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Секин</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_cceleration:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "All_ow postponing of breaks"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "Audio _Feedback..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Beep when _accessibility features are turned on or off"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Beep when a _modifier key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Beep when a _toggle key is pressed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Beep when a key is pr_essed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Beep when a key is reje_cted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-msgid "Beep when key is _accepted"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Beep when key is _rejected"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "By _country"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "By _language"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Check if breaks are allowed to be postponed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid "Choose a Keyboard Model"
-msgstr "Клавиатура русумини танланг"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Choose a Layout"
-msgstr "Тугмалар тартибини танланг"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Cursor _blinks in text fields"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
-msgid "Cursor blinks speed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
-msgid "D_elay:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Disa_ble sticky keys if two keys are pressed together"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Duration of the break when typing is disallowed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "Duration of work before forcing a break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
-msgid "General"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "Key presses _repeat when key is held down"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "Keyboard Accessibility Audio Feedback"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "Keyboard Layout Options"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "Keyboard Preferences"
-msgstr "Клавиатура мосламалари"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "Keyboard _model:"
-msgstr "Клавиатура _русуми:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "Layout _Options..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "Layouts"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "Lock screen after a certain duration to help prevent repetitive keyboard use injuries"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
-msgid "Mouse Keys"
-msgstr "Сичқонча тугмалари"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
-msgid "Preview:"
-msgstr "Олдиндан кўриш:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
-msgid "Repeat keys speed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
-msgid "Reset to De_faults"
-msgstr "_Андоза параметрларни тиклаш"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
-msgid "S_peed:"
-msgstr "_Тезлик:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
-msgid "Separate _layout for each window"
-msgstr "Ҳар бир ойна учун алоҳида _тугмалар тартиби"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
-msgid "Typing Break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
-msgid "_Accessibility features can be toggled with keyboard shortcuts"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
-msgid "_Break interval lasts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
-msgid "_Country:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
-msgid "_Delay:"
-msgstr "_Кечикиш:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
-msgid "_Ignore fast duplicate keypresses"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
-msgid "_Language:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
-msgid "_Lock screen to enforce typing break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
-msgid "_Models:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
-msgid "_Only accept long keypresses"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
-msgid "_Pointer can be controlled using the keypad"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
-msgid "_Selected layouts:"
-msgstr "_Танланган тугмалар тартиби:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
-msgid "_Simulate simultaneous keypresses"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
-msgid "_Speed:"
-msgstr "_Тезлик:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
-msgid "_Type to test settings:"
-msgstr "Параметрларни _синаш майдони:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
-msgid "_Variants:"
-msgstr "_Вариантлар:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
-msgid "_Vendors:"
-msgstr "_Иш.чиқарувчилар:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
-msgid "_Work interval lasts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
-msgid "minutes"
-msgstr "дақиқа"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
-msgid "Unknown"
-msgstr "Номаълум"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:215
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:234
-#: ../capplets/network/gnome-network-preferences.c:561
-msgid "Default"
-msgstr "Андоза"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:333
-msgid "Layout"
-msgstr "Тугмалар тартиби"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
-msgid "Vendors"
-msgstr "Иш.чиқарувчилар"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
-msgid "Models"
-msgstr ""
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Клавиатура"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:90
-msgid "gesture|Move left"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:95
-msgid "gesture|Move right"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:100
-msgid "gesture|Move up"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:105
-msgid "gesture|Move down"
-msgstr ""
-
-#. Translators: this is the gesture to trigger/choose the click type.
-#. Don't include the prefix "gesture|" in the translation.
-#: ../capplets/mouse/gnome-mouse-accessibility.c:110
-msgid "gesture|Disabled"
-msgstr ""
-
-#. TRANSLATORS: don't translate the terms in brackets
-#: ../capplets/mouse/gnome-mouse-properties.c:441
-msgid "Specify the name of the page to show (general|accessibility)"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.c:446
-msgid "- GNOME Mouse Preferences"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-msgid "<b>Double-Click Timeout</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Ушлаб олиб қўйиш</b>"
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Dwell Click</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Locate Pointer</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Mouse Orientation</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<b>Pointer Speed</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<b>Simulated Secondary Click</b>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>To test your double-click settings, try to double-click on the light bulb.</i>"
-msgstr ""
-
-#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>You can also use the Dwell Click panel applet to choose the click type.</i>"
-msgstr ""
-
-#. high sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "<small><i>High</i></small>"
-msgstr ""
-
-#. large threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-msgid "<small><i>Large</i></small>"
-msgstr ""
-
-#. low sensitivity
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-msgid "<small><i>Low</i></small>"
-msgstr ""
-
-#. small threshold
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-msgid "<small><i>Small</i></small>"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
-msgid "Choose type of click _beforehand"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
-msgid "Choose type of click with mo_use gestures"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
-msgid "D_ouble click:"
-msgstr ""
-
-#. click to initiate drag-and-drop (like normally click and hold)
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
-msgid "D_rag click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
-msgid "Mouse Preferences"
-msgstr "Сичқонча мосламалари"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
-msgid "Seco_ndary click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
-msgid "Sh_ow position of pointer when the Control key is pressed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
-msgid "Show click type _window"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
-msgid "Thr_eshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
-msgid "_Acceleration:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
-msgid "_Initiate click when stopping pointer movement"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
-msgid "_Left-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
-msgid "_Motion threshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
-msgid "_Right-handed"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
-msgid "_Sensitivity:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
-msgid "_Single click:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
-msgid "_Timeout:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
-msgid "_Trigger secondary click by holding down the primary button"
-msgstr ""
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Сичқонча"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.c:677
-#: ../capplets/network/gnome-network-preferences.c:816
-msgid "New Location..."
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.c:782
-msgid "Location already exists"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Тармоқ проксиси"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "<b>Di_rect internet connection</b>"
-msgstr "<b>Интернетга _тўғридан-тўғри уланиш</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-msgid "<b>Ignore Host List</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>Прокси мосламасини _авто-аниқлаш</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>Прокси мосламаларини _қўлбола кўрсатиш</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Use authentication</b>"
-msgstr "<b>Тасдиқлашдан _фойдаланиш</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "Autoconfiguration _URL:"
-msgstr "Авто-мослаш _URL'и:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "C_reate"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Create New Location"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "H_TTP прокси:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Ignored Hosts"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Location:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "Network Proxy Preferences"
-msgstr "Тармоқ прокси мосламалари"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "Port:"
-msgstr "Порт:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "Proxy Configuration"
-msgstr "Прокси параметрлари"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "S_ocks host:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "The location already exists."
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "U_sername:"
-msgstr "Ф_ойдалунувчи:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Delete Location"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:20
-msgid "_Details"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
 msgstr "_Тафсилотлар"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:21
-msgid "_FTP proxy:"
-msgstr "_FTP прокси:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:22
-msgid "_Location name:"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:23
-msgid "_Password:"
-msgstr "_Махфий сўз:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:24
-msgid "_Secure HTTP proxy:"
-msgstr "HTTP_S прокси:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:25
-msgid "_Use the same proxy for all protocols"
-msgstr "Барча протоколлар учун битта проксидан _фойдаланиш"
-
-#: ../capplets/windows/gnome-window-properties.c:346
-msgid "Cannot start the preferences application for your window manager"
-msgstr ""
-
-#. translators: this is the Control key
-#: ../capplets/windows/gnome-window-properties.c:600
-msgid "C_ontrol"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:605
-msgid "_Alt"
-msgstr "_Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:611
-msgid "H_yper"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:618
-msgid "S_uper (or \"Windows logo\")"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.c:625
-msgid "_Meta"
-msgstr "_Мета"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Ойна танлаш</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To move a window, press-and-hold this key then grab the window:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Ойна параметрлари"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "сония"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "Ойна мосламаларини ўрнатиш"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "Ойналар"
-
-#. make start action
-#: ../libslab/application-tile.c:372
-#, c-format
-msgid "<b>Start %s</b>"
-msgstr "<b>%s'ни ишга тушириш</b>"
-
-#: ../libslab/application-tile.c:391
-msgid "Help"
-msgstr "Ёрдам"
-
-#: ../libslab/application-tile.c:438
-msgid "Upgrade"
-msgstr "Янгилаш"
-
-#: ../libslab/application-tile.c:453
-msgid "Uninstall"
-msgstr ""
-
-#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
-msgid "Remove from Favorites"
-msgstr ""
-
-#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
-msgid "Add to Favorites"
-msgstr ""
-
-#: ../libslab/application-tile.c:867
-msgid "Remove from Startup Programs"
-msgstr ""
-
-#: ../libslab/application-tile.c:869
-msgid "Add to Startup Programs"
-msgstr ""
-
-#: ../libslab/app-shell.c:753
-#, c-format
-msgid ""
-"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
-"\n"
-" Your filter \"<b>%s</b>\" does not match any items.</span>"
-msgstr ""
-
-#: ../libslab/app-shell.c:903
-msgid "Other"
-msgstr "Бошқа"
-
-#: ../libslab/bookmark-agent.c:1077
-msgid "New Spreadsheet"
-msgstr "Янги электрон жадвал"
-
-#: ../libslab/bookmark-agent.c:1082
-msgid "New Document"
-msgstr "Янги ҳужжат"
-
-#: ../libslab/bookmark-agent.c:1135
-msgid "Home"
-msgstr ""
-
-#: ../libslab/bookmark-agent.c:1140
-msgid "Documents"
-msgstr ""
-
-#: ../libslab/bookmark-agent.c:1153
-msgid "File System"
-msgstr "Файл тизими"
-
-#: ../libslab/bookmark-agent.c:1157
-msgid "Network Servers"
-msgstr "Тармоқ серверлари"
-
-#: ../libslab/bookmark-agent.c:1186
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Қидириш"
 
-#. make open with default action
-#: ../libslab/directory-tile.c:171
-#, c-format
-msgid "<b>Open</b>"
-msgstr "<b>Очиш</b>"
-
-#. make rename action
-#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:231
-msgid "Rename..."
-msgstr "Номини ўзгартириш..."
-
-#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
-#: ../libslab/document-tile.c:245 ../libslab/document-tile.c:254
-msgid "Send To..."
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#. make move to trash action
-#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:280
-msgid "Move to Trash"
-msgstr "Чиқиндилар қутисига олиб ташлаш"
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Ўчирилган"
 
-#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
-#: ../libslab/document-tile.c:290 ../libslab/document-tile.c:831
-msgid "Delete"
-msgstr "Олиб ташлаш"
-
-#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:979
-#, c-format
-msgid "Are you sure you want to permanently delete \"%s\"?"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
 msgstr ""
 
-#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:980
-msgid "If you delete an item, it is permanently lost."
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
 msgstr ""
 
-#: ../libslab/document-tile.c:192
-#, c-format
-msgid "<b>Open with \"%s\"</b>"
-msgstr "<b>\"%s\" билан очиш</b>"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Орқа фон"
 
-#: ../libslab/document-tile.c:204
-msgid "Open with Default Application"
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Экран"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Гулқоғозсиз"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "Товушлар"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Клавиатура тугмалар бирикмаси:"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "Товуш йўқ"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Огоҳлантириш тури"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "_Дастур шрифти:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<b>Эл.почта</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Услуби:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Андоза"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "Орқа фон"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Ташқи кўриниши"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Экран ўлчами"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+#, fuzzy
+msgid "Profile Whitepoint"
+msgstr "Катта оқ кўрсатгич"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+#, fuzzy
+msgid "Profile Name"
+msgstr "файл номи"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+#, fuzzy
+msgid "Profile Name:"
+msgstr "файл номи"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+#, fuzzy
+msgid "Copy profile"
+msgstr "Файллардан нусха олинмоқда"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "Ҳамма файллар"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Импорт"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Қўшиш..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "_Юкланган файллар:"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Тафсилотлар"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "дақиқа"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "_Ўртача"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "дақиқа"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "дақиқа"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Ранглар"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Расмни танланг"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Танлаш"
+
+#: panels/common/cc-language-chooser.ui:58
+#, fuzzy
+msgid "No languages found"
+msgstr "Товуш йўқ"
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Қидириш"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "_Кечикиш:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "Қидириш учун тугмалар бирикмаси."
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Ўчирилган"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "сония"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Та_қвим:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Та_қвим:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
 msgstr "Андоза дастур билан очиш"
 
-#: ../libslab/document-tile.c:215
-msgid "Open in File Manager"
-msgstr "Файл менежерида очиш"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Андоза дастур билан очиш"
 
-#: ../libslab/document-tile.c:611
-msgid "?"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
 msgstr ""
 
-#: ../libslab/document-tile.c:618
-msgid "%l:%M %p"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
 msgstr ""
 
-#: ../libslab/document-tile.c:626
-msgid "Today %l:%M %p"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
 msgstr ""
 
-#: ../libslab/document-tile.c:636
-msgid "Yesterday %l:%M %p"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
 msgstr ""
 
-#: ../libslab/document-tile.c:648
-msgid "%a %l:%M %p"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
 msgstr ""
 
-#: ../libslab/document-tile.c:656
-msgid "%b %d %l:%M %p"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
 msgstr ""
 
-#: ../libslab/document-tile.c:658
-msgid "%b %d %Y"
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Шрифтни _қўллаш"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
 msgstr ""
 
-#: ../libslab/search-bar.c:255
-msgid "Find Now"
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
 msgstr ""
 
-#: ../libslab/system-tile.c:128
-#, c-format
-msgid "<b>Open %s</b>"
-msgstr "<b>%s'ни очиш</b>"
-
-#: ../libslab/system-tile.c:141
-#, c-format
-msgid "Remove from System Items"
-msgstr "Тизим элементларидан олиб ташлаш"
-
-#: ../libwindow-settings/gnome-wm-manager.c:316
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
 msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:404
-msgid "Maximize"
-msgstr "Ёйиш"
-
-#: ../libwindow-settings/metacity-window-manager.c:405
-msgid "Maximize Vertically"
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
 msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:406
-msgid "Maximize Horizontally"
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
 msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:407
-msgid "Minimize"
-msgstr "Йиғиш"
-
-#: ../libwindow-settings/metacity-window-manager.c:408
-msgid "Roll up"
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
 msgstr ""
 
-#: ../libwindow-settings/metacity-window-manager.c:409
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Ўлчами:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "_Янгиланиш даражаси"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "Филтр"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "дақиқа"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "Ускуналар"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Номи:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Тури"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "GNOME терминали"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Ойналар"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "Ускуналар"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Ускуналар"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "Номини ўзгартириш..."
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Ҳақида"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Овозни ўчириш учун тугмалар бирикмаси"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Товушни пасайтириш"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+#, fuzzy
+msgid "Volume up"
+msgstr "Товуш"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+#, fuzzy
+msgid "Launch media player"
+msgstr "Мусиқа плейери"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+#, fuzzy
+msgid "Play (or play/pause)"
+msgstr "Ўйнаш (ёки ўйнаш/вақтинча тўхтатиш) тугмалар бирикмаси."
+
+#: panels/keyboard/00-multimedia.xml.in:16
+#, fuzzy
+msgid "Pause playback"
+msgstr "Т_овушни ўйнаш:"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Ўйнашни тўхтатиш тугмаси"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Олдин йўлакчага ўтиш"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Кейинги йўлакчага ўтиш"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Чиқариш"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Кейинги йўлакчага ўтиш"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Олдин йўлакчага ўтиш"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Веб браузерни ишга тушириш"
+
+#: panels/keyboard/01-launchers.xml.in:4
+#, fuzzy
+msgid "Launch help browser"
+msgstr "Веб браузерни ишга тушириш"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Андоза мосламалар"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Веб браузерни ишга тушириш"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Уй жилди"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Қидириш"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr "Тизим"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Сеансни тугатиш"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Экранни қулфлаш"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Сеансни тугатиш"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Параметрлар"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Параметрлар"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Клавиатура тугмалар бирикмаси:"
+
+#: panels/keyboard/cc-input-row.ui:54
+msgid "Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+#, fuzzy
+msgid "Input Sources"
+msgstr "_Киритиш майдонлари:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+#, fuzzy
+msgid "Use the _same source for all windows"
+msgstr "Барча протоколлар учун битта проксидан _фойдаланиш"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Сичқонча тугмалари"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Клавиатура тугмалар бирикмаси:"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Амал"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Клавиатура тугмалар бирикмаси:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Номи:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Буй_руқ:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Йўқ"
 
-#: ../shell/control-center.c:54
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Андоза қийматга _қайтариш"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Клавиатура"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Шахсий маълумотларингиз"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Андоза мосламалар"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+msgid "Pointer Location"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Сичқонча"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Сичқонча тугмалари"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "Янги акселератор..."
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_Дастур шрифти:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Ускуналар"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Амал"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Алоқа ўрнатилмоқда..."
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Параметрлар"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "key not found [%s]\n"
-msgstr ""
-
-#: ../shell/control-center.c:151
-msgid "Filter"
-msgstr "Филтр"
-
-#: ../shell/control-center.c:151
-msgid "Groups"
-msgstr "Гуруҳлар"
-
-#: ../shell/control-center.c:151
-msgid "Common Tasks"
-msgstr ""
-
-#: ../shell/control-center.c:155 ../shell/gnomecc.desktop.in.in.h:1
-#: ../shell/gnomecc.directory.in.h:1
-msgid "Control Center"
-msgstr "Бошқарув маркази"
-
-#: ../shell/control-center.schemas.in.h:1
-msgid "Close the control-center when a task is activated"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:2
-msgid "Exit shell on add or remove action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:3
-msgid "Exit shell on help action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:4
-msgid "Exit shell on start action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:5
-msgid "Exit shell on upgrade or uninstall action performed"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:6
-msgid "Indicates whether to close the shell when a help action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:7
-msgid "Indicates whether to close the shell when a start action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:8
-msgid "Indicates whether to close the shell when an add or remove action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:9
-msgid "Indicates whether to close the shell when an upgrade or uninstall action is performed."
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:10
-msgid "Task names and associated .desktop files"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:11
-msgid "The task name to be displayed in the control-center followed by a \";\" separator then the filename of an associated .desktop file to launch for that task."
-msgstr ""
-
-#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
-#: ../shell/control-center.schemas.in.h:13
-msgid "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
-msgstr ""
-
-#: ../shell/control-center.schemas.in.h:14
-msgid "if true, the control-center will close when a \"Common Task\" is activated."
-msgstr ""
-
-#: ../shell/gnomecc.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "GNOME мослаш воситаси"
-
-#: ../typing-break/drw-break-window.c:189
-msgid "_Postpone Break"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:245
-msgid "Take a break!"
-msgstr ""
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#. translators: keep the initial "/"
-#: ../typing-break/drwright.c:129
-msgid "/_Preferences"
-msgstr "/_Параметрлар"
-
-#: ../typing-break/drwright.c:130
-msgid "/_About"
-msgstr "/_Ҳақида"
-
-#: ../typing-break/drwright.c:132
-msgid "/_Take a Break"
-msgstr ""
-
-#: ../typing-break/drwright.c:488
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../typing-break/drwright.c:492
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Тармоқ серверлари"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Махфий сўз:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Жорий _махфий сўз:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Акселератор усули"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
-msgid "Less than one minute until the next break"
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
 msgstr ""
 
-#: ../typing-break/drwright.c:579
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "Манзил"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "Манзил"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "Манзил"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Андоза кўрсатгич"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Номи:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Манзил:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Манзил:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Ўчирилган"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "Манзил"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "Манзил"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#, fuzzy
+msgid "Automatic"
+msgstr "Авто-аниқлаш"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "дақиқа"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Тармоқ проксиси"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "_Активлаштирилсин"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "Манзил"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Тармоқ проксиси"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "H_TTP прокси:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "H_TTP прокси:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP прокси:"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr ""
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "H_TTP прокси:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "H_TTP прокси:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP прокси:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Авто-мослаш _URL'и:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Тармоқ серверлари"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Махфий сўз:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+#, fuzzy
+msgid "Authenticated"
+msgstr "Тасдиқланди!"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+#, fuzzy
+msgid "PAC _file"
+msgstr "Ҳамма файллар"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>Тасдиқлашдан _фойдаланиш</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "Ф_ойдалунувчи:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Махфий сўз:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Янги махфий сўз:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Версияси:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Версияси:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+#, fuzzy
+msgid "C_A certificate"
+msgstr "_Тасдиқлаш"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Янги махфий сўз:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "_Тасдиқлаш"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Тури"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Андоза"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Файл тизими"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr ""
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Товушлар"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Экранни қулфлаш тугмалар бирикмаси."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Экранни қулфлаш тугмалар бирикмаси."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>Тасдиқлашдан _фойдаланиш</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "дақиқа"
+msgstr[1] "дақиқа"
+
+#: panels/power/cc-battery-row.c:92
 #, c-format
-msgid "Unable to bring up the typing break properties dialog with the following error: %s"
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "дақиқа"
+msgstr[1] "дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
 msgstr ""
 
-#: ../typing-break/drwright.c:598
-msgid "Written by Richard Hult <richard@imendio.com>"
-msgstr "Муаллиф: Ричард Халт (Richard Hult) <richard@imendio.com>"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "дақиқа"
 
-#: ../typing-break/drwright.c:599
-msgid "Eye candy added by Anders Carlsson"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "дақиқа"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
 msgstr ""
 
-#: ../typing-break/drwright.c:608
-msgid "A computer break reminder."
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
 msgstr ""
 
-#: ../typing-break/drwright.c:610
-msgid "translator-credits"
-msgstr "Нурали Абдураҳмонов <mavnur@gmail.com>"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Ускуналар"
 
-#: ../typing-break/main.c:61
-msgid "Enable debugging code"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Акселератор усули"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
 msgstr ""
 
-#: ../typing-break/main.c:63
-msgid "Don't check whether the notification area exists"
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
 msgstr ""
 
-#: ../typing-break/main.c:89
-msgid "Typing Monitor"
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
 msgstr ""
 
-#: ../typing-break/main.c:105
-msgid "The typing monitor uses the notification area to display information. You don't seem to have a notification area on your panel. You can add it by right-clicking on your panel and choosing 'Add to panel', selecting 'Notification area' and clicking 'Add'."
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Экран"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Экран"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:5
-msgid "Set this key to the command used to create thumbnails for OpenType fonts."
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:7
-msgid "Set this key to the command used to create thumbnails for TrueType fonts."
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Кечикиш:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "_Босиб чиқариш"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 
-#: ../font-viewer/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
 
-#: ../font-viewer/font-view.c:113
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "Оқ чойнакка оқ қопқоқ, кўк чойнакка кўк қопқоқ. 0123456789"
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
 
-#: ../font-viewer/font-view.c:275
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "Товуш йўқ"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+#, fuzzy
+msgid "Authentication Required"
+msgstr "Тасдиқланди!"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "Ф_ойдалунувчи:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Амал"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Ўрнатиб бўлмади"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Танлаш"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+#, fuzzy
+msgid "A_uthenticate"
+msgstr "_Тасдиқлаш"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "_Тасдиқлаш"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "Синаш"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Параметрлар"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "_Тафсилотлар"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Андоза қийматга _қайтариш"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+#, fuzzy
+msgid "Please restart when the problem is resolved."
+msgstr "Илтимос аплет тўғри ўрнатилганлигига ишонч хосил қилинг"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+#, fuzzy
+msgid "Formats"
+msgstr "Ўртача"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "Ҳамма файллар"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Олдиндан кўриш:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "_Бўлим:"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+#, fuzzy
+msgid "Logout…"
+msgstr "Чиқиш"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Экранни қулфлаш"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+#, fuzzy
+msgid "_Music player"
+msgstr "Мусиқа плейери"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Амал"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Тури:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Экран"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Экранни қулфлаш"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Экран"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Экран"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "%d экран мосламалари\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Бошқа"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Амал"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_Дастур шрифти:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Қидириш учун тугмалар бирикмаси."
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Тармоқ серверлари"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Иш столи"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
+msgstr "Мусиқа плейери"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Махфий сўз:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Иш столи"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "График интерфейс бошқаруви"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Нусха олиш"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "_Тасдиқлаш"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "Фойдаланувчи номи:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+#, fuzzy
+msgid "Media Sharing"
+msgstr "Мусиқа плейери"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Тизим товушлари"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Товуш"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "Ускуналар"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "Синаш"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Прокси параметрлари"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "Ускуналар"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Товуш"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Огоҳлантириш тугмалари"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Товуш"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Номи:"
 
-#: ../font-viewer/font-view.c:278
-msgid "Style:"
-msgstr "Услуби:"
-
-#: ../font-viewer/font-view.c:291
-msgid "Type:"
-msgstr "Тури:"
-
-#: ../font-viewer/font-view.c:295
-msgid "Size:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
 
-#: ../font-viewer/font-view.c:339 ../font-viewer/font-view.c:352
-msgid "Version:"
-msgstr "Версияси:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../font-viewer/font-view.c:343 ../font-viewer/font-view.c:354
-msgid "Copyright:"
-msgstr "Муаллифлик ҳуқуқи:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../font-viewer/font-view.c:347
-msgid "Description:"
-msgstr "Таърифи:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "Ускуналар"
 
-#: ../font-viewer/font-view.c:437
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "Ускуналар"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Тезлик:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Кичкина"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Катта"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Икки тугма бирга босилса, _ўчириш"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Сичқонча тугмалари"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "_модификатор босилганда сигнал бериш"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "_модификатор босилганда сигнал бериш"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Сичқонча тугмалари"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Тугмалар бирикмаси"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Клавиатура махсус имкониятлари"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Катта"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Экран"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "Товушлар"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Клавиатура"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Сичқонча тугмалари"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Катта кўрсатгич"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Экран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Параметрлар"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Экран"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+#, fuzzy
+msgid "Color Effects:"
+msgstr "Ранглар"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr ""
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Йўқ"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Тўлиқ исм"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+#, fuzzy
+msgid "Color Effects"
+msgstr "Ранглар"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "Файл тизими"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+#, fuzzy
+msgid "File History & Trash"
+msgstr "Чиқиндилар қутисига олиб ташлаш"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+#, fuzzy
+msgid "Don't leave traces"
+msgstr "Активлаштирил_масин"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Янги махфий сўз:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Товуш файлини танланг"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Йўқ"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Олдиндан кўриш:"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Махфий сўзни ўзгартириш"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Жорий _махфий сўз:"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Янги махфий сўз:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Махфий сўзни ўзгартириш"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+#, fuzzy
+msgid "The passwords do not match."
+msgstr "Махфий сўз жуда қисқа."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Янги махфий сўз:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "Тўлиқ исм"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Таҳрирлаш"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Андоза дастур билан очиш"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Бошқа"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "Товуш йўқ"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Тугмалар"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Тугмалар"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Тугмалар"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Тугмалар"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Тугмалар тартиби"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Ойналар"
+
+#: panels/windows/cc-windows-panel.ui:94
+#, fuzzy
+msgid "Click to Focus"
+msgstr "Тугатиш учун OK тугмасини босинг."
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Ойналар"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "Тизимга _киришдаги ёрдамчи технологиялар"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Манзил"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Сақлаш"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Тафсилотлар"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Тармоқ проксиси"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "Тармоқ серверлари"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Ускуналар"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
-msgid "usage: %s fontfile\n"
-msgstr ""
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
-msgid "Font Viewer"
-msgstr ""
-
-#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
-msgid "Preview fonts"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:243
-msgid "Text to thumbnail (default: Aa)"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:243
-msgid "TEXT"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "Font size (default: 64)"
-msgstr "Шрифт ўлчами (андоза: 64)"
-
-#: ../font-viewer/font-thumbnailer.c:245
-msgid "SIZE"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:247
-msgid "FONT-FILE OUTPUT-FILE"
-msgstr ""
-
-#: ../font-viewer/font-thumbnailer.c:263
+#: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
-msgid "Error parsing arguments: %s\n"
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "Уяли телефон:"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Тармоқ проксиси"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Тармоқ проксиси"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Тафсилотлар"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Тармоқ проксиси"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "_Тасдиқлаш"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+#, fuzzy
+msgid "Refresh Network Providers"
+msgstr "Тармоқ серверлари"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Алоқа ўрнатилмоқда..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Андоза мосламалар"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Ёрдам"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Чиқиш"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Қидириш"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Олдин йўлакчага ўтиш"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Параметрлар"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#~ msgid "Image/label border"
+#~ msgstr "Расм/ёрлиқ чегараси"
+
+#~ msgid "Width of border around the label and image in the alert dialog"
+#~ msgstr "Огоҳлантириш диалогидаги расм ва ёрлиқларнинг кенглиги"
+
+#~ msgid "The type of alert"
+#~ msgstr "Огоҳлантириш тури"
+
+#~ msgid "The buttons shown in the alert dialog"
+#~ msgstr "Огоҳлантириш ойнасида кўрсатиладиган тугмалар"
+
+#~ msgid "Show more _details"
+#~ msgstr "_Тафсилотларни кўрсатиш"
+
+#~ msgid "No Image"
+#~ msgstr "Расмсиз"
+
+#~ msgid "Images"
+#~ msgstr "Расмлар"
+
+#~ msgid ""
+#~ "There was an error while trying to get the addressbook information\n"
+#~ "Evolution Data Server can't handle the protocol"
+#~ msgstr ""
+#~ "Манзиллар дафтаридан маълумот олиб бўлмади.\n"
+#~ "Evolution маълумот сервери протоколни қўлламайди"
+
+#~ msgid "Unable to open address book"
+#~ msgstr "Манзиллар дафтарини очиб бўлмади"
+
+#~ msgid "Unknown login ID, the user database might be corrupted"
+#~ msgstr ""
+#~ "Номаълум фойдаланувчи ID'си. фойдаланувчи маълумот базаси зарарланган "
+#~ "бўлиши мумкин"
+
+#, c-format
+#~ msgid "About %s"
+#~ msgstr "%s ҳақида"
+
+#~ msgid "About Me"
+#~ msgstr "Мен ҳақимда"
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Уй</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Телефон</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>WWW</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Иш</b>"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+#~ msgstr ""
+#~ "<span size=\"larger\" weight=\"bold\">Махфий сўзни ўзгартириш</span>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "A_IM/iChat:"
+
+#~ msgid "A_ddress:"
+#~ msgstr "_Манзил:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "_Ёрдамчи:"
+
+#~ msgid "C_ity:"
+#~ msgstr "_Шаҳар:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "_Ташкилот:"
+
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Махфий _сўзни ўзгартириш..."
+
+#~ msgid "Change pa_ssword"
+#~ msgstr "Махфий с_ўзни ўзгартириш"
+
+#~ msgid "Ci_ty:"
+#~ msgstr "Ш_аҳар:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "_Давлат:"
+
+#~ msgid "Cou_ntry:"
+#~ msgstr "Дав_лат:"
+
+#~ msgid "Hom_e:"
+#~ msgstr "У_й:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "M_SN:"
+
+#~ msgid "P.O. _box:"
+#~ msgstr "Почта қ_утиси:"
+
+#~ msgid "P._O. box:"
+#~ msgstr "_Почта қутиси:"
+
+#~ msgid "Personal Info"
+#~ msgstr "Шахсий маълумот"
+
+#~ msgid "Select your photo"
+#~ msgstr "Расм танланг"
+
+#~ msgid "Wor_k:"
+#~ msgstr "И_ш:"
+
+#~ msgid "Work _fax:"
+#~ msgstr "_Факс (иш):"
+
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "_Почта индекси:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Groupwise:"
+
+#~ msgid "_Home page:"
+#~ msgstr "_Уй саҳифаси:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Уй:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Бошқарувчи:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Иш:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "_Yahoo:"
+
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "Почта _индекси:"
+
+#~ msgid ""
+#~ "Your password has been changed since you initially authenticated! Please "
+#~ "re-authenticate."
+#~ msgstr ""
+#~ "Махфий сўзингиз кейинги сафарги тасдиқланишдан кейин ўзгартирилади! "
+#~ "Илтимос қайта тасдиқланг."
+
+#~ msgid "That password was incorrect."
+#~ msgstr "Махфий сўз хато."
+
+#~ msgid "Your password has been changed."
+#~ msgstr "Махфий сўзингиз ўзгартирилди."
+
+#, c-format
+#~ msgid "System error: %s."
+#~ msgstr "Тизим хатоси: %s."
+
+#~ msgid "The password is too simple."
+#~ msgstr "Махфий сўз жуда оддий."
+
+#~ msgid "The old and new passwords are too similar."
+#~ msgstr "Эски ва янги махфий сўз жуда ўхшаш."
+
+#~ msgid "The new password must contain numeric or special character(s)."
+#~ msgstr "Янги махфий сўз рақам ва махсус белги(лар)дан иборат бўлиши керак."
+
+#~ msgid "The old and new passwords are the same."
+#~ msgstr "Эски ва янги махфий сўз бир хил."
+
+#~ msgid "A system error has occurred"
+#~ msgstr "Тизимда хатолик рўй берди"
+
+#~ msgid "Checking password..."
+#~ msgstr "Махфий сўз текширилмоқда..."
+
+#~ msgid "Click <b>Change password</b> to change your password."
+#~ msgstr ""
+#~ "Махфий сўзни ўзгартириш учун <b>Махфий сўзни ўзгартириш</b> тугмасини "
+#~ "босинг."
+
+#~ msgid "Please type your password in the <b>New password</b> field."
+#~ msgstr "Илтимос <b>янги махфий сўз</b> майдонига махфий сўзни киритинг."
+
+#~ msgid "The two passwords are not equal."
+#~ msgstr "Иккала махфий сўз мос келмади."
+
+#~ msgid "<b>Assistive Technologies</b>"
+#~ msgstr "<b>Ёрдамчи технологиялар</b>"
+
+#~ msgid "<b>Preferences</b>"
+#~ msgstr "<b>Параметрлар</b>"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Ёпиш ва тизимдан _чиқиш"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "Ёрдамчи технологияларни _ёқиш"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Гулқоғоз қўшиш"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Шрифт жуда катта бўлиши мумкин"
+
+#~ msgid "Use previous font"
+#~ msgstr "Олдинги шрифтдан фойдаланиш"
+
+#~ msgid "Use selected font"
+#~ msgstr "Танланган шрифтдан фойдаланиш"
+
+#~ msgid "Specify the filename of a theme to install"
+#~ msgstr "Ўрнатиладиган мавзу файли номини кўрсатинг"
+
+#~ msgid "page"
+#~ msgstr "саҳифа"
+
+#~ msgid "[WALLPAPER...]"
+#~ msgstr "[ГУЛҚОҒОЗ...]"
+
+#~ msgid "Apply Font"
+#~ msgstr "Шрифтни қўллаш"
+
+#~ msgid "Custom"
+#~ msgstr "Бошқа"
+
+#~ msgid "<b>C_olors</b>"
+#~ msgstr "<b>_Ранглар</b>"
+
+#~ msgid "<b>Menus and Toolbars</b>"
+#~ msgstr "<b>Меню ва асбоблар панели</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Олдиндан кўриш</b>"
+
+#~ msgid "<b>_Wallpaper</b>"
+#~ msgstr "<b>_Гулқоғоз</b>"
+
+#~ msgid "Appearance Preferences"
+#~ msgstr "Ташқи кўринишни мослаш"
+
+#~ msgid "Best _shapes"
+#~ msgstr "Энг яхши _шакллар"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Энг яхши ко_нтраст"
+
+#~ msgid "C_ut"
+#~ msgstr "К_есиш"
+
+#~ msgid "Changing your cursor theme takes effect the next time you log in."
+#~ msgstr "Курсор мавзуси кейинги сафар тизимга кирганда кучга киради."
+
+#~ msgid "D_etails..."
+#~ msgstr "_Тафсилотлар..."
+
+#~ msgid "Des_ktop font:"
+#~ msgstr "Иш _столи шрифти:"
+
+#~ msgid "Fonts"
+#~ msgstr "Шрифтлар"
+
+#~ msgid "Icons"
+#~ msgstr "Нишончалар"
+
+#~ msgid "Interface"
+#~ msgstr "Интерфейс"
+
+#~ msgid "N_one"
+#~ msgstr "_Йўқ"
+
+#~ msgid "New File"
+#~ msgstr "Янги  файл"
+
+#~ msgid "Open File"
+#~ msgstr "Файлни очиш"
+
+#~ msgid "Open a dialog to specify the color"
+#~ msgstr "Рангни кўрсатиш учун диалогни очиш"
+
+#~ msgid "R_esolution:"
+#~ msgstr "Ў_лчами:"
+
+#~ msgid "Save File"
+#~ msgstr "Файлни сақлаш"
+
+#~ msgid "Save _background image"
+#~ msgstr "_Орқа фон расмини сақлаш"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Менюларда _нишончаларни кўрсатиш"
+
+#~ msgid "Text"
+#~ msgstr "Матн"
+
+#~ msgid "Theme"
+#~ msgstr "Мавзу"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "Window Border"
+#~ msgstr "Ойна чегараси"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Description:"
+#~ msgstr "_Таърифи:"
+
+#~ msgid "_Document font:"
+#~ msgstr "_Ҳужжат шрифти:"
+
+#~ msgid "_File"
+#~ msgstr "_Файл"
+
+#~ msgid "_Install..."
+#~ msgstr "_Ўрнатиш..."
+
+#~ msgid "_New"
+#~ msgstr "_Янги"
+
+#~ msgid "_Paste"
+#~ msgstr "_Қўйиш"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Selected items:"
+#~ msgstr "_Танланган элементлар:"
+
+#~ msgid "_Size:"
+#~ msgstr "_Ҳажми:"
+
+#~ msgid "_Style:"
+#~ msgstr "_Услуб:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Ойна сарлавҳаси шрифти:"
+
+#~ msgid "_Windows:"
+#~ msgstr "_Ойналар:"
+
+#~ msgid "Theme Installer"
+#~ msgstr "Мавзу ўрнатгич"
+
+#~ msgid "Gnome Theme Package"
+#~ msgstr "Gnome мавзу пакети"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "пиксел"
+#~ msgstr[1] "пиксел"
+
+#, c-format
+#~ msgid "GNOME Theme %s correctly installed"
+#~ msgstr "%s Gnome мавзуси муваффақиятли ўрнатилди"
+
+#, c-format
+#~ msgid "The theme \"%s\" has been installed."
+#~ msgstr "\"%s\" мавзу ўрнатилди."
+
+#~ msgid "Would you like to apply it now, or keep your current theme?"
+#~ msgstr "Уни қўллашни истайсизми ёки жорий мавзуни сақлаб қоласизми?"
+
+#~ msgid "Keep Current Theme"
+#~ msgstr "Жорий мавзу сақлаб қолинсин"
+
+#~ msgid "Apply New Theme"
+#~ msgstr "Янги мавзу қўллансин"
+
+#~ msgid "Failed to create temporary directory"
+#~ msgstr "Вақтинчалик директория яратиб бўлмади"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Ўрнатиш учун мавзу файли йўли кўрсатилмаган"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Мавзуни қуйидаги манзилга ўрнатиш учун ҳуқуқ етарли эмас:\n"
+#~ "%s"
+
+#~ msgid "Select Theme"
+#~ msgstr "Мавзуни танлаш"
+
+#~ msgid "Theme Packages"
+#~ msgstr "Мавзу пакетлари"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Мавзу аллақачон мавжуд. Алмаштиришни истайсизми?"
+
+#~ msgid "_Overwrite"
+#~ msgstr "_Алмаштириш"
+
+#~ msgid "Would you like to delete this theme?"
+#~ msgstr "Ушбу мавзуни олиб ташлашни истайсизми?"
+
+#~ msgid "Theme cannot be deleted"
+#~ msgstr "Мавзуни олиб ташлаб бўлмайди"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Ёрдам файлини кўрсатишда хатолик юз берди: %s"
+
+#, c-format
+#~ msgid "Copying file: %u of %u"
+#~ msgstr "Файлдан нусха олинмоқда: %u дан %u"
+
+#, c-format
+#~ msgid "Copying '%s'"
+#~ msgstr "'%s' нусха олинмоқда"
+
+#~ msgid "Current URI index"
+#~ msgstr "Жорий URI индекси"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Жорий URI индекси - 1'дан бошланади"
+
+#~ msgid "Total URIs"
+#~ msgstr "Жами URI"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Жами URI сони"
+
+#~ msgid "Key"
+#~ msgstr "Калит"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "'%s' файлини топиб бўлмади.\n"
+#~ "\n"
+#~ "Илтимос уни мавжудлигини текшириб кўринг ва қайта уриниб кўринг ёки бошқа "
+#~ "орқа фон расмини танланг."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "'%s' файлини қандай очиш мумкин.\n"
+#~ "Балки бу расм тури хали қўлланилмаслиги мумкин.\n"
+#~ "\n"
+#~ "Илтимос бунинг ўрнига бошқа расм танланг."
+
+#~ msgid "Please select an image."
+#~ msgstr "Илтимос расм танланг."
+
+#~ msgid "White Pointer"
+#~ msgstr "Оқ кўрсатгич"
+
+#~ msgid "White Pointer - Current"
+#~ msgstr "Оқ кўрсатгич - жорий"
+
+#~ msgid "Large Pointer - Current"
+#~ msgstr "Катта кўрсатгич - жорий"
+
+#~ msgid "Large White Pointer - Current"
+#~ msgstr "Катта оқ кўрсатгич - жорий"
+
+#~ msgid "Select your default applications"
+#~ msgstr "Андоза дастурни танланг"
+
+#, c-format
+#~ msgid "Error saving configuration: %s"
+#~ msgstr "Мосламани сақлаш хатолиги: %s"
+
+#~ msgid "Could not load the main interface"
+#~ msgstr "Асосий интерфейсни юклаб бўлмади"
+
+#~ msgid "<b>Multimedia Player</b>"
+#~ msgstr "<b>Мултимедиа плейери</b>"
+
+#~ msgid "<b>Terminal Emulator</b>"
+#~ msgstr "<b>Терминал эмулятори</b>"
+
+#~ msgid "<b>Text Editor</b>"
+#~ msgstr "<b>Матн таҳрирчиси</b>"
+
+#~ msgid "<b>Video Player</b>"
+#~ msgstr "<b>Видео плейер</b>"
+
+#~ msgid "<b>Web Browser</b>"
+#~ msgstr "<b>Веб-браузер</b>"
+
+#~ msgid "Internet"
+#~ msgstr "Интернет"
+
+#~ msgid "Multimedia"
+#~ msgstr "Мултимедиа"
+
+#~ msgid "Open link in new _tab"
+#~ msgstr "Боғламани янги _табда очиш"
+
+#~ msgid "Open link in new _window"
+#~ msgstr "Боғламани янги _ойнада очиш"
+
+#~ msgid "Open link with web browser _default"
+#~ msgstr "Боғламани браузер _андозаси билан очиш"
+
+#~ msgid "Run in t_erminal"
+#~ msgstr "Т_ерминалда бажариш"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Banshee Music Player"
+#~ msgstr "Banshee мусиқий плейери"
+
+#~ msgid "Dasher"
+#~ msgstr "Dasher"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Debian терминал эмулятори"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#~ msgid "Epiphany Web Browser"
+#~ msgstr "Epiphany веб браузери"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Evolution почта клиенти"
+
+#~ msgid "Firebird"
+#~ msgstr "Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "Firefox"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Gnopernicus"
+#~ msgstr "Gnopernicus"
+
+#~ msgid "Iceape"
+#~ msgstr "Iceape"
+
+#~ msgid "Icedove"
+#~ msgstr "Icedove"
+
+#~ msgid "Iceweasel"
+#~ msgstr "Iceweasel"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "Mozilla"
+#~ msgstr "Mozilla"
+
+#~ msgid "Mozilla 1.6"
+#~ msgstr "Mozilla 1.6"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Mozilla Mail"
+
+#~ msgid "Mozilla Thunderbird"
+#~ msgstr "Mozilla Thunderbird"
+
+#~ msgid "Muine Music Player"
+#~ msgstr "Muine мусиқа плейери"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#~ msgid "NXterm"
+#~ msgstr "NXterm"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Netscape Communicator"
+
+#~ msgid "Opera"
+#~ msgstr "Opera"
+
+#~ msgid "Orca"
+#~ msgstr "Orca"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#~ msgid "Rhythmbox Music Player"
+#~ msgstr "Rhythmbox мусиқа плейери"
+
+#~ msgid "SeaMonkey"
+#~ msgstr "SeaMonkey"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Андоза X-терминали"
+
+#~ msgid "Sylpheed"
+#~ msgstr "Sylpheed"
+
+#~ msgid "Sylpheed-Claws"
+#~ msgstr "Sylpheed-Claws"
+
+#~ msgid "Totem Movie Player"
+#~ msgstr "Totem плейери"
+
+#~ msgid "aterm"
+#~ msgstr "aterm"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Экран ўлчамини ўзгартириш"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Гц"
+
+#~ msgid "Accelerator key"
+#~ msgstr "Акселератор тугмаси"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Акселератор модификаторлари"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Акселератор тугмаси коди"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Акселератор тури."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Номаълум амал>"
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Буйруқларга тугмалар бирикмаси тайинлаш"
+
+#~ msgid "- GNOME Keyboard Preferences"
+#~ msgstr "- GNOME клавиатура параметрлари"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Тез</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Узун</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Қисқа</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Секин</i></small>"
+
+#~ msgid "Choose a Keyboard Model"
+#~ msgstr "Клавиатура русумини танланг"
+
+#~ msgid "Choose a Layout"
+#~ msgstr "Тугмалар тартибини танланг"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Клавиатура мосламалари"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "Клавиатура _русуми:"
+
+#~ msgid "Reset to De_faults"
+#~ msgstr "_Андоза параметрларни тиклаш"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Тезлик:"
+
+#~ msgid "Separate _layout for each window"
+#~ msgstr "Ҳар бир ойна учун алоҳида _тугмалар тартиби"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Танланган тугмалар тартиби:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "Параметрларни _синаш майдони:"
+
+#~ msgid "_Variants:"
+#~ msgstr "_Вариантлар:"
+
+#~ msgid "_Vendors:"
+#~ msgstr "_Иш.чиқарувчилар:"
+
+#~ msgid "Unknown"
+#~ msgstr "Номаълум"
+
+#~ msgid "Vendors"
+#~ msgstr "Иш.чиқарувчилар"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Ушлаб олиб қўйиш</b>"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Сичқонча мосламалари"
+
+#~ msgid "<b>Di_rect internet connection</b>"
+#~ msgstr "<b>Интернетга _тўғридан-тўғри уланиш</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>Прокси мосламасини _авто-аниқлаш</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Прокси мосламаларини _қўлбола кўрсатиш</b>"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Тармоқ прокси мосламалари"
+
+#~ msgid "Port:"
+#~ msgstr "Порт:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "HTTP_S прокси:"
+
+#~ msgid "_Alt"
+#~ msgstr "_Alt"
+
+#~ msgid "_Meta"
+#~ msgstr "_Мета"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Ойна танлаш</b>"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Ойна параметрлари"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Ойна мосламаларини ўрнатиш"
+
+#, c-format
+#~ msgid "<b>Start %s</b>"
+#~ msgstr "<b>%s'ни ишга тушириш</b>"
+
+#~ msgid "Upgrade"
+#~ msgstr "Янгилаш"
+
+#~ msgid "New Spreadsheet"
+#~ msgstr "Янги электрон жадвал"
+
+#~ msgid "New Document"
+#~ msgstr "Янги ҳужжат"
+
+#, c-format
+#~ msgid "<b>Open</b>"
+#~ msgstr "<b>Очиш</b>"
+
+#~ msgid "Delete"
+#~ msgstr "Олиб ташлаш"
+
+#, c-format
+#~ msgid "<b>Open with \"%s\"</b>"
+#~ msgstr "<b>\"%s\" билан очиш</b>"
+
+#~ msgid "Open in File Manager"
+#~ msgstr "Файл менежерида очиш"
+
+#, c-format
+#~ msgid "<b>Open %s</b>"
+#~ msgstr "<b>%s'ни очиш</b>"
+
+#, c-format
+#~ msgid "Remove from System Items"
+#~ msgstr "Тизим элементларидан олиб ташлаш"
+
+#~ msgid "Maximize"
+#~ msgstr "Ёйиш"
+
+#~ msgid "Minimize"
+#~ msgstr "Йиғиш"
+
+#~ msgid "Groups"
+#~ msgstr "Гуруҳлар"
+
+#~ msgid "Control Center"
+#~ msgstr "Бошқарув маркази"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "GNOME мослаш воситаси"
+
+#~ msgid "Written by Richard Hult <richard@imendio.com>"
+#~ msgstr "Муаллиф: Ричард Халт (Richard Hult) <richard@imendio.com>"
+
+#~ msgid "translator-credits"
+#~ msgstr "Нурали Абдураҳмонов <mavnur@gmail.com>"
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr "Оқ чойнакка оқ қопқоқ, кўк чойнакка кўк қопқоқ. 0123456789"
+
+#~ msgid "Copyright:"
+#~ msgstr "Муаллифлик ҳуқуқи:"
+
+#~ msgid "Description:"
+#~ msgstr "Таърифи:"
+
+#~ msgid "Font size (default: 64)"
+#~ msgstr "Шрифт ўлчами (андоза: 64)"
 
 #~ msgid " "
 #~ msgstr " "
@@ -3364,14 +6054,15 @@ msgstr ""
 #~ msgid "Import Feature Settings File"
 #~ msgstr "Параметрлар файлини импорт қилиш"
 
-#~ msgid "_Import"
-#~ msgstr "_Импорт"
-
 #~ msgid "Keyboard Accessibility"
 #~ msgstr "Клавиатура махсус имкониятлари"
 
-#~ msgid "This system does not seem to have the XKB extension.  The keyboard accessibility features will not operate without it."
-#~ msgstr "Тизимда XKB кенгайтмаси йўқ.  Клавиатура махсус имкониятлари усиз ишламайди."
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Тизимда XKB кенгайтмаси йўқ.  Клавиатура махсус имкониятлари усиз "
+#~ "ишламайди."
 
 #~ msgid "Basic"
 #~ msgstr "Асосий"
@@ -3379,14 +6070,8 @@ msgstr ""
 #~ msgid "Beep when _features turned on or off from keyboard"
 #~ msgstr "Клавиатурадан тугмалар _активлаштирилганда сигнал бериш"
 
-#~ msgid "Beep when _modifier is pressed"
-#~ msgstr "_модификатор босилганда сигнал бериш"
-
 #~ msgid "Del_ay:"
 #~ msgstr "Ке_чикиш:"
-
-#~ msgid "Disa_ble if two keys pressed together"
-#~ msgstr "Икки тугма бирга босилса, _ўчириш"
 
 #~ msgid "Filters"
 #~ msgstr "Филтрлар"
@@ -3444,23 +6129,20 @@ msgstr ""
 #~ msgid "The file format is invalid"
 #~ msgstr "Файлнинг формати хато"
 
-#~ msgid "Installation Failed"
-#~ msgstr "Ўрнатиб бўлмади"
-
 #~ msgid "This theme is not in a supported format."
 #~ msgstr "Мавзу қўлланилмайдиган форматда."
 
-#~ msgid "%s is the path where the theme files will be installed. This can not be selected as the source location"
-#~ msgstr "%s мавзу ўрнатиладиган йўлдир. Ундан манба сифатида фойдаланиб бўлмайди"
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s мавзу ўрнатиладиган йўлдир. Ундан манба сифатида фойдаланиб бўлмайди"
 
 #~ msgid "The file format is invalid."
 #~ msgstr "Файлнинг формати хато."
 
 #~ msgid "Just apply settings and quit"
 #~ msgstr "Фақат мосламаларни қўллаш ва чиқиш"
-
-#~ msgid "Connecting..."
-#~ msgstr "Алоқа ўрнатилмоқда..."
 
 #~ msgid "Evolution Mail Reader 1.4"
 #~ msgstr "Evolution 1.4 почта клиенти"
@@ -3489,25 +6171,24 @@ msgstr ""
 #~ msgid "W3M Text Browser"
 #~ msgstr "W3M матнли веб браузер"
 
-#~ msgid "Default Settings"
-#~ msgstr "Андоза мосламалар"
-
-#~ msgid "Screen %d Settings\n"
-#~ msgstr "%d экран мосламалари\n"
-
 #~ msgid "Screen Resolution Preferences"
 #~ msgstr "Экран ўлчами параметрлари"
 
 #~ msgid "_Make default for this computer (%s) only"
 #~ msgstr "Ушбу компьютер (%s) учун андоза этиб _белгилаш"
 
-#~ msgid "Options"
-#~ msgstr "Параметрлар"
-
-#~ msgid "Testing the new settings. If you don't respond in %d second the previous settings will be restored."
-#~ msgid_plural "Testing the new settings. If you don't respond in %d seconds the previous settings will be restored."
-#~ msgstr[0] "Мосламаларни текшириш. Агар %d сония ичида тасдиқламасангиз эски мослама қўлланилади."
-#~ msgstr[1] "Мосламаларни текшириш. Агар %d сония ичида тасдиқламасангиз эски мослама қўлланилади."
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Мосламаларни текшириш. Агар %d сония ичида тасдиқламасангиз эски мослама "
+#~ "қўлланилади."
+#~ msgstr[1] ""
+#~ "Мосламаларни текшириш. Агар %d сония ичида тасдиқламасангиз эски мослама "
+#~ "қўлланилади."
 
 #~ msgid "Keep Resolution"
 #~ msgstr "Ушбу ўлчамни сақлаб қолиш"
@@ -3520,9 +6201,6 @@ msgstr ""
 
 #~ msgid "_Keep resolution"
 #~ msgstr "Ушбу ўлчамни _сақлаб қолиш"
-
-#~ msgid "New accelerator..."
-#~ msgstr "Янги акселератор..."
 
 #~ msgid ""
 #~ "The shortcut \"%s\" is already used for:\n"
@@ -3567,9 +6245,6 @@ msgstr ""
 #~ msgid "<i>Small</i>"
 #~ msgstr "<i>Кичик</i>"
 
-#~ msgid "Buttons"
-#~ msgstr "Тугмалар"
-
 #~ msgid "Motion"
 #~ msgstr "Ҳаракат"
 
@@ -3584,9 +6259,6 @@ msgstr ""
 
 #~ msgid "Unknown Volume Control %d"
 #~ msgstr "Номаълум товуш мословчиси %d"
-
-#~ msgid "Autodetect"
-#~ msgstr "Авто-аниқлаш"
 
 #~ msgid "ALSA - Advanced Linux Sound Architecture"
 #~ msgstr "ALSA - Такомиллаштирилган Linux товуш тизими"
@@ -3615,29 +6287,14 @@ msgstr ""
 #~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
 #~ msgstr "<span weight=\"bold\" size=\"x-large\">Синалмоқда...</span>"
 
-#~ msgid "Click OK to finish."
-#~ msgstr "Тугатиш учун OK тугмасини босинг."
-
-#~ msgid "Devices"
-#~ msgstr "Ускуналар"
-
-#~ msgid "S_ound playback:"
-#~ msgstr "Т_овушни ўйнаш:"
-
 #~ msgid "So_und playback:"
 #~ msgstr "То_вушни ўйнаш:"
 
 #~ msgid "Sound Preferences"
 #~ msgstr "Товуш параметрлари"
 
-#~ msgid "Sounds"
-#~ msgstr "Товушлар"
-
 #~ msgid "System Beep"
 #~ msgstr "Тизим товуши"
-
-#~ msgid "Test"
-#~ msgstr "Синаш"
 
 #~ msgid "_Device:"
 #~ msgstr "_Ускуна:"
@@ -3650,15 +6307,6 @@ msgstr ""
 
 #~ msgid "_Sound playback:"
 #~ msgstr "_Товушни ўйнаш:"
-
-#~ msgid "Volume"
-#~ msgstr "Товуш"
-
-#~ msgid "_Activate"
-#~ msgstr "_Активлаштирилсин"
-
-#~ msgid "Do_n't activate"
-#~ msgstr "Активлаштирил_масин"
 
 #~ msgid "Do _not show this warning again"
 #~ msgstr "Ушбу огоҳлантириш бошқа кўрсатил_масин"
@@ -3694,15 +6342,6 @@ msgstr ""
 #~ msgid "_Load"
 #~ msgstr "_Юклаш"
 
-#~ msgid "_Loaded files:"
-#~ msgstr "_Юкланган файллар:"
-
-#~ msgid "Type"
-#~ msgstr "Тури"
-
-#~ msgid "Screen"
-#~ msgstr "Экран"
-
 #~ msgid "No valid bookmark file found in data dirs"
 #~ msgstr "Маълумотлар директориясида хатчўп топилмади"
 
@@ -3718,21 +6357,16 @@ msgstr ""
 #~ msgid "Login"
 #~ msgstr "Кириш"
 
-#~ msgid "Logout"
-#~ msgstr "Чиқиш"
-
 #~ msgid "Boing"
 #~ msgstr "Боинг"
-
-#~ msgid "No sound"
-#~ msgstr "Товуш йўқ"
 
 #~ msgid "Sound not set for this event."
 #~ msgstr "Ушбу ҳодиса учун товуш ўрнатилмаган."
 
 #~ msgid ""
 #~ "The sound file for this event does not exist.\n"
-#~ "You may want to install the gnome-audio package for a set of default sounds."
+#~ "You may want to install the gnome-audio package for a set of default "
+#~ "sounds."
 #~ msgstr ""
 #~ "Ушбу ҳодиса учун товуш файли мавжуд эмас.\n"
 #~ "Андоза товушларидан фойдаланиш учун gnome-audio пакетларини ўрнатинг."
@@ -3740,17 +6374,11 @@ msgstr ""
 #~ msgid "The sound file for this event does not exist."
 #~ msgstr "Ушбу ҳодиса учун товуш файли мавжуд эмас."
 
-#~ msgid "Select Sound File"
-#~ msgstr "Товуш файлини танланг"
-
 #~ msgid "The file %s is not a valid wav file"
 #~ msgstr "%s файли wav файл эмас"
 
 #~ msgid "Select sound file..."
 #~ msgstr "Товуш файлини танланг..."
-
-#~ msgid "System Sounds"
-#~ msgstr "Тизим товушлари"
 
 #~ msgid "E-mail"
 #~ msgstr "Эл.почта"
@@ -3758,35 +6386,14 @@ msgstr ""
 #~ msgid "E-mail's shortcut."
 #~ msgstr "Эл.почта клиентини ишга тушириш тугмалар бирикмаси."
 
-#~ msgid "Eject"
-#~ msgstr "Чиқариш"
-
-#~ msgid "Home folder"
-#~ msgstr "Уй жилди"
-
 #~ msgid "Home folder's shortcut."
 #~ msgstr "Уй жилди учун тугмалар бирикмаси."
-
-#~ msgid "Launch web browser"
-#~ msgstr "Веб браузерни ишга тушириш"
 
 #~ msgid "Launch web browser's shortcut."
 #~ msgstr "Веб браузерни ишга тушириш тугмалар бирикмаси."
 
-#~ msgid "Lock screen"
-#~ msgstr "Экранни қулфлаш"
-
-#~ msgid "Lock screen's shortcut."
-#~ msgstr "Экранни қулфлаш тугмалар бирикмаси."
-
-#~ msgid "Log out"
-#~ msgstr "Сеансни тугатиш"
-
 #~ msgid "Log out's shortcut."
 #~ msgstr "Сеансни тугатиш тугмалар бирикмаси."
-
-#~ msgid "Media player"
-#~ msgstr "Мусиқа плейери"
 
 #~ msgid "Pause"
 #~ msgstr "Вақтинча тўхтатиш"
@@ -3794,44 +6401,20 @@ msgstr ""
 #~ msgid "Pause key's shortcut."
 #~ msgstr "Вақтинча тўхтатиш тугмаси тугмалар бирикмаси."
 
-#~ msgid "Play (or play/pause) key's shortcut."
-#~ msgstr "Ўйнаш (ёки ўйнаш/вақтинча тўхтатиш) тугмалар бирикмаси."
-
 #~ msgid "Previous track key's shortcut."
 #~ msgstr "Олдинги қўшиқ учун тугмалар бирикмаси."
-
-#~ msgid "Search's shortcut."
-#~ msgstr "Қидириш учун тугмалар бирикмаси."
-
-#~ msgid "Skip to next track"
-#~ msgstr "Кейинги йўлакчага ўтиш"
-
-#~ msgid "Skip to previous track"
-#~ msgstr "Олдин йўлакчага ўтиш"
-
-#~ msgid "Stop playback key"
-#~ msgstr "Ўйнашни тўхтатиш тугмаси"
 
 #~ msgid "Stop playback key's shortcut."
 #~ msgstr "Ўйнашни тўхтатиш учун тугмалар бирикмаси."
 
-#~ msgid "Volume down"
-#~ msgstr "Товушни пасайтириш"
-
 #~ msgid "Volume down's shortcut."
 #~ msgstr "Товушни пасайтириш учун тугмалар бирикмаси"
-
-#~ msgid "Volume mute's shortcut."
-#~ msgstr "Овозни ўчириш учун тугмалар бирикмаси"
 
 #~ msgid "Run screensaver at login"
 #~ msgstr "Сеанс бошланганда экран сақловчисини  ишга тушириш"
 
 #~ msgid "Start screensaver"
 #~ msgstr "Экран сақловчисини ишга тушириш"
-
-#~ msgid "Set as Application Font"
-#~ msgstr "Дастур шрифти сифатида ўрнатиш"
 
 #~ msgid "Sets the default application font"
 #~ msgstr "Андоза дастур шрифтини танланг"
@@ -3840,13 +6423,11 @@ msgstr ""
 #~ msgstr "GNOME шрифт кўрувчиси"
 
 #~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-#~ msgstr "<span weight=\"bold\" size=\"larger\">Янги шрифт қўллансинми?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">Янги шрифт қўллансинми?</span>"
 
 #~ msgid "Do _not apply font"
 #~ msgstr "Шрифт _қўлланмасин"
-
-#~ msgid "_Apply font"
-#~ msgstr "Шрифтни _қўллаш"
 
 #~ msgid "Themes"
 #~ msgstr "Мавзулар"

--- a/po/uz@cyrillic.po~
+++ b/po/uz@cyrillic.po~
@@ -1,0 +1,3873 @@
+# translation of gnome-control-center-2.0 to Uzbek
+# Copyright (C) 2008 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Nurali Abdurahmonov <mavnur@gmail.com>, 2007.
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center-2.0 trunk\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-01-07 20:26+0500\n"
+"PO-Revision-Date: 2007-11-12 09:36+0500\n"
+"Last-Translator: Nurali Abdurahmonov <mavnur@gmail.com>\n"
+"Language-Team: Uzbek\n"
+"Language: uz@cyrillic\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=0;\n"
+"X-Generator: KBabel 1.11.4\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr "Расм/ёрлиқ чегараси"
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr "Огоҳлантириш диалогидаги расм ва ёрлиқларнинг кенглиги"
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+msgid "Alert Type"
+msgstr "Огоҳлантириш тури"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr "Огоҳлантириш тури"
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+msgid "Alert Buttons"
+msgstr "Огоҳлантириш тугмалари"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr "Огоҳлантириш ойнасида кўрсатиладиган тугмалар"
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+msgid "Show more _details"
+msgstr "_Тафсилотларни кўрсатиш"
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Place your left thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:28
+#, c-format
+msgid "Swipe your left thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Place your left index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:29
+#, c-format
+msgid "Swipe your left index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Place your left middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:30
+#, c-format
+msgid "Swipe your left middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Place your left ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:31
+#, c-format
+msgid "Swipe your left ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Place your left little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:32
+#, c-format
+msgid "Swipe your left little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Place your right thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:33
+#, c-format
+msgid "Swipe your right thumb on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Place your right index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:34
+#, c-format
+msgid "Swipe your right index finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Place your right middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:35
+#, c-format
+msgid "Swipe your right middle finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Place your right ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:36
+#, c-format
+msgid "Swipe your right ring finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Place your right little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:37
+#, c-format
+msgid "Swipe your right little finger on %s"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:72
+#: ../capplets/about-me/fingerprint-strings.h:98
+msgid "Place your finger on the reader again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:74
+#: ../capplets/about-me/fingerprint-strings.h:100
+msgid "Swipe your finger again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:77
+#: ../capplets/about-me/fingerprint-strings.h:103
+msgid "Swipe was too short, try again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:79
+#: ../capplets/about-me/fingerprint-strings.h:105
+msgid "Your finger was not centered, try swiping your finger again"
+msgstr ""
+
+#: ../capplets/about-me/fingerprint-strings.h:81
+#: ../capplets/about-me/fingerprint-strings.h:107
+msgid "Remove your finger, and try swiping your finger again"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:772
+msgid "Select Image"
+msgstr "Расмни танланг"
+
+#: ../capplets/about-me/gnome-about-me.c:774
+msgid "No Image"
+msgstr "Расмсиз"
+
+#: ../capplets/about-me/gnome-about-me.c:802
+#: ../capplets/appearance/appearance-desktop.c:660
+msgid "Images"
+msgstr "Расмлар"
+
+#: ../capplets/about-me/gnome-about-me.c:806
+#: ../capplets/appearance/theme-installer.c:700
+msgid "All Files"
+msgstr "Ҳамма файллар"
+
+#: ../capplets/about-me/gnome-about-me.c:952
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+"Манзиллар дафтаридан маълумот олиб бўлмади.\n"
+"Evolution маълумот сервери протоколни қўлламайди"
+
+#: ../capplets/about-me/gnome-about-me.c:973
+msgid "Unable to open address book"
+msgstr "Манзиллар дафтарини очиб бўлмади"
+
+#: ../capplets/about-me/gnome-about-me.c:987
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr "Номаълум фойдаланувчи ID'си. фойдаланувчи маълумот базаси зарарланган бўлиши мумкин"
+
+#: ../capplets/about-me/gnome-about-me.c:1017
+#: ../capplets/about-me/gnome-about-me.c:1019
+#, c-format
+msgid "About %s"
+msgstr "%s ҳақида"
+
+#: ../capplets/about-me/gnome-about-me.c:1037
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+msgid "Enable _Fingerprint Login..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:1040
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Disable _Fingerprint Login..."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+msgid "About Me"
+msgstr "Мен ҳақимда"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+msgid "Set your personal information"
+msgstr "Шахсий маълумотларингиз"
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:99
+msgid "You are not allowed to access the device. Contact your system administrator."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:101
+msgid "The device is already in use."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:103
+msgid "An internal error occured"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:220
+msgid "Delete registered fingerprints?"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:223
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:230
+msgid "Do you want to delete your registered fingerprints so fingerprint login is disabled?"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:343
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:583
+msgid "Done!"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:388
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:410
+#, c-format
+msgid "Could not access '%s' device"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:444
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:491
+msgid "Could not access any fingerprint readers"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:492
+msgid "Please contact your system administrator for help."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:518
+msgid "Enable Fingerprint Login"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:534
+msgid "Select finger"
+msgstr ""
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:555
+#, c-format
+msgid "To enable fingerprint login, you need to save one of your fingerprints, using the '%s' device."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:568
+msgid "Swipe finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.c:570
+msgid "Place finger on reader"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:1
+msgid "Left index finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:2
+msgid ""
+"Left thumb\n"
+"Left middle finger\n"
+"Left ring finger\n"
+"Left little finger\n"
+"Right thumb\n"
+"Right middle finger\n"
+"Right ring finger\n"
+"Right little finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:10
+msgid "Other finger: "
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:11
+msgid "Right index finger"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-fingerprint.glade.h:12
+msgid "Your fingerprint was successfully saved. You should now be able to log in using your fingerprint reader."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+msgid "<b>Email</b>"
+msgstr "<b>Эл.почта</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+msgid "<b>Home</b>"
+msgstr "<b>Уй</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Instant Messaging</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Job</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Telephone</b>"
+msgstr "<b>Телефон</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Web</b>"
+msgstr "<b>WWW</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Work</b>"
+msgstr "<b>Иш</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<span size=\"larger\" weight=\"bold\">Change your password</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Махфий сўзни ўзгартириш</span>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "A_IM/iChat:"
+msgstr "A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "A_ddress:"
+msgstr "_Манзил:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_ssistant:"
+msgstr "_Ёрдамчи:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "Address"
+msgstr "Манзил"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "C_ity:"
+msgstr "_Шаҳар:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+msgid "C_ompany:"
+msgstr "_Ташкилот:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "Cale_ndar:"
+msgstr "Та_қвим:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "Change Passwo_rd..."
+msgstr "Махфий _сўзни ўзгартириш..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Change pa_ssword"
+msgstr "Махфий с_ўзни ўзгартириш"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+msgid "Change password"
+msgstr "Махфий сўзни ўзгартириш"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Ci_ty:"
+msgstr "Ш_аҳар:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+msgid "Co_untry:"
+msgstr "_Давлат:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Contact"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+msgid "Cou_ntry:"
+msgstr "Дав_лат:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+msgid "Current _password:"
+msgstr "Жорий _махфий сўз:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "Full Name"
+msgstr "Тўлиқ исм"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "Hom_e:"
+msgstr "У_й:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+msgid "IC_Q:"
+msgstr "IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "M_SN:"
+msgstr "M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P.O. _box:"
+msgstr "Почта қ_утиси:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+msgid "P._O. box:"
+msgstr "_Почта қутиси:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "Personal Info"
+msgstr "Шахсий маълумот"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#: ../capplets/about-me/gnome-about-me-password.c:938
+msgid "Please type your password again in the <b>Retype new password</b> field."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Select your photo"
+msgstr "Расм танланг"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "State/Pro_vince:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid ""
+"To change your password, enter your current password in the field below and click <b>Authenticate</b>.\n"
+"After you have authenticated, enter your new password, retype it for verification and click <b>Change password</b>."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "User name:"
+msgstr "Фойдаланувчи номи:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "Web _log:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "Wor_k:"
+msgstr "И_ш:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+msgid "Work _fax:"
+msgstr "_Факс (иш):"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "Zip/_Postal code:"
+msgstr "_Почта индекси:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Address:"
+msgstr "_Манзил:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Authenticate"
+msgstr "_Тасдиқлаш"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Department:"
+msgstr "_Бўлим:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+msgid "_Groupwise:"
+msgstr "_Groupwise:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Home page:"
+msgstr "_Уй саҳифаси:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+msgid "_Home:"
+msgstr "_Уй:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_Jabber:"
+msgstr "_Jabber:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Manager:"
+msgstr "_Бошқарувчи:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Mobile:"
+msgstr "Уяли телефон:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_New password:"
+msgstr "_Янги махфий сўз:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Profession:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:55
+msgid "_Retype new password:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:56
+msgid "_State/Province:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:57
+msgid "_Title:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:58
+msgid "_Work:"
+msgstr "_Иш:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:59
+msgid "_Yahoo:"
+msgstr "_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:60
+msgid "_Zip/Postal code:"
+msgstr "Почта _индекси:"
+
+#: ../capplets/about-me/gnome-about-me-password.c:162
+msgid "Child exited unexpectedly"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:297
+#, c-format
+msgid "Could not shutdown backend_stdin IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:310
+#, c-format
+msgid "Could not shutdown backend_stdout IO channel: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:409
+msgid "Authenticated!"
+msgstr "Тасдиқланди!"
+
+#. This is a re-auth, and it failed.
+#. * The password must have been changed in the meantime!
+#. * Ask the user to re-authenticate
+#.
+#. Update status message and auth state
+#. Authentication failure
+#: ../capplets/about-me/gnome-about-me-password.c:475
+#: ../capplets/about-me/gnome-about-me-password.c:551
+msgid "Your password has been changed since you initially authenticated! Please re-authenticate."
+msgstr "Махфий сўзингиз кейинги сафарги тасдиқланишдан кейин ўзгартирилади! Илтимос қайта тасдиқланг."
+
+#: ../capplets/about-me/gnome-about-me-password.c:477
+msgid "That password was incorrect."
+msgstr "Махфий сўз хато."
+
+#: ../capplets/about-me/gnome-about-me-password.c:524
+msgid "Your password has been changed."
+msgstr "Махфий сўзингиз ўзгартирилди."
+
+#. What does this indicate?
+#. * "Authentication information cannot be recovered?" from libpam?
+#: ../capplets/about-me/gnome-about-me-password.c:534
+#, c-format
+msgid "System error: %s."
+msgstr "Тизим хатоси: %s."
+
+#: ../capplets/about-me/gnome-about-me-password.c:537
+msgid "The password is too short."
+msgstr "Махфий сўз жуда қисқа."
+
+#: ../capplets/about-me/gnome-about-me-password.c:540
+msgid "The password is too simple."
+msgstr "Махфий сўз жуда оддий."
+
+#: ../capplets/about-me/gnome-about-me-password.c:543
+msgid "The old and new passwords are too similar."
+msgstr "Эски ва янги махфий сўз жуда ўхшаш."
+
+#: ../capplets/about-me/gnome-about-me-password.c:545
+msgid "The new password must contain numeric or special character(s)."
+msgstr "Янги махфий сўз рақам ва махсус белги(лар)дан иборат бўлиши керак."
+
+#: ../capplets/about-me/gnome-about-me-password.c:548
+msgid "The old and new passwords are the same."
+msgstr "Эски ва янги махфий сўз бир хил."
+
+#. translators: Unable to launch <program>: <error message>
+#: ../capplets/about-me/gnome-about-me-password.c:820
+#, c-format
+msgid "Unable to launch %s: %s"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:824
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:825
+msgid "A system error has occurred"
+msgstr "Тизимда хатолик рўй берди"
+
+#. Update status message
+#: ../capplets/about-me/gnome-about-me-password.c:845
+msgid "Checking password..."
+msgstr "Махфий сўз текширилмоқда..."
+
+#: ../capplets/about-me/gnome-about-me-password.c:932
+msgid "Click <b>Change password</b> to change your password."
+msgstr "Махфий сўзни ўзгартириш учун <b>Махфий сўзни ўзгартириш</b> тугмасини босинг."
+
+#: ../capplets/about-me/gnome-about-me-password.c:935
+msgid "Please type your password in the <b>New password</b> field."
+msgstr "Илтимос <b>янги махфий сўз</b> майдонига махфий сўзни киритинг."
+
+#: ../capplets/about-me/gnome-about-me-password.c:941
+msgid "The two passwords are not equal."
+msgstr "Иккала махфий сўз мос келмади."
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Assistive Technologies</b>"
+msgstr "<b>Ёрдамчи технологиялар</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Preferences</b>"
+msgstr "<b>Параметрлар</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid "Accessible Lo_gin"
+msgstr "Тизимга _киришдаги ёрдамчи технологиялар"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technologies Preferences"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Changes to enable assistive technologies will not take effect until your next log in."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Close and _Log Out"
+msgstr "Ёпиш ва тизимдан _чиқиш"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "Jump to Preferred Applications dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "Jump to the Accessible Login dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "Jump to the Keyboard Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "Jump to the Mouse Accessibility dialog"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:11
+msgid "_Enable assistive technologies"
+msgstr "Ёрдамчи технологияларни _ёқиш"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:12
+msgid "_Keyboard Accessibility"
+msgstr "_Клавиатура махсус имкониятлари"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:13
+msgid "_Mouse Accessibility"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:14
+msgid "_Preferred Applications"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Choose which accessibility features to enable when you log in"
+msgstr ""
+
+#: ../capplets/appearance/appearance-desktop.c:628
+msgid "Add Wallpaper"
+msgstr "Гулқоғоз қўшиш"
+
+#: ../capplets/appearance/appearance-desktop.c:664
+msgid "All files"
+msgstr "Ҳамма файллар"
+
+#: ../capplets/appearance/appearance-font.c:495
+msgid "Font may be too large"
+msgstr "Шрифт жуда катта бўлиши мумкин"
+
+#: ../capplets/appearance/appearance-font.c:499
+#, c-format
+msgid "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is recommended that you select a size smaller than %d."
+msgid_plural "The font selected is %d points large, and may make it difficult to effectively use the computer. It is recommended that you select a size smaller than %d."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:512
+#, c-format
+msgid "The font selected is %d point large, and may make it difficult to effectively use the computer.  It is recommended that you select a smaller sized font."
+msgid_plural "The font selected is %d points large, and may make it difficult to effectively use the computer. It is recommended that you select a smaller sized font."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/appearance/appearance-font.c:535
+msgid "Use previous font"
+msgstr "Олдинги шрифтдан фойдаланиш"
+
+#: ../capplets/appearance/appearance-font.c:537
+msgid "Use selected font"
+msgstr "Танланган шрифтдан фойдаланиш"
+
+#: ../capplets/appearance/appearance-main.c:124
+msgid "Specify the filename of a theme to install"
+msgstr "Ўрнатиладиган мавзу файли номини кўрсатинг"
+
+#: ../capplets/appearance/appearance-main.c:125
+msgid "filename"
+msgstr "файл номи"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/appearance/appearance-main.c:132
+msgid "Specify the name of the page to show (theme|background|fonts|interface)"
+msgstr ""
+
+#: ../capplets/appearance/appearance-main.c:133
+#: ../capplets/default-applications/gnome-da-capplet.c:879
+#: ../capplets/mouse/gnome-mouse-properties.c:442
+msgid "page"
+msgstr "саҳифа"
+
+#: ../capplets/appearance/appearance-main.c:140
+msgid "[WALLPAPER...]"
+msgstr "[ГУЛҚОҒОЗ...]"
+
+#: ../capplets/appearance/appearance-style.c:173
+#: ../capplets/common/gnome-theme-info.c:445
+#: ../capplets/common/gnome-theme-info.c:637
+msgid "Default Pointer"
+msgstr "Андоза кўрсатгич"
+
+#: ../capplets/appearance/appearance-style.c:235
+#: ../capplets/appearance/appearance-themes.c:686
+msgid "Install"
+msgstr ""
+
+#: ../capplets/appearance/appearance-style.c:255
+#: ../capplets/common/gnome-theme-info.c:1647
+#, c-format
+msgid "This theme will not look as intended because the required GTK+ theme engine '%s' is not installed."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:674
+msgid "Apply Background"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:678
+msgid "Apply Font"
+msgstr "Шрифтни қўллаш"
+
+#: ../capplets/appearance/appearance-themes.c:682
+msgid "Revert Font"
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:712
+msgid "The current theme suggests a background and a font. Also, the last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:714
+msgid "The current theme suggests a background. Also, the last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:716
+msgid "The current theme suggests a background and a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:718
+msgid "The current theme suggests a font. Also, the last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:720
+msgid "The current theme suggests a background."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:722
+msgid "The last applied font suggestion can be reverted."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:724
+msgid "The current theme suggests a font."
+msgstr ""
+
+#: ../capplets/appearance/appearance-themes.c:1045
+#: ../capplets/default-applications/gnome-da-capplet.c:630
+msgid "Custom"
+msgstr "Бошқа"
+
+#: ../capplets/appearance/data/appearance.glade.h:1
+msgid "<b>C_olors</b>"
+msgstr "<b>_Ранглар</b>"
+
+#. font hinting
+#: ../capplets/appearance/data/appearance.glade.h:3
+msgid "<b>Hinting</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:4
+msgid "<b>Menus and Toolbars</b>"
+msgstr "<b>Меню ва асбоблар панели</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:5
+msgid "<b>Preview</b>"
+msgstr "<b>Олдиндан кўриш</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:6
+msgid "<b>Rendering</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:7
+msgid "<b>Smoothing</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:8
+msgid "<b>Subpixel Order</b>"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:9
+msgid "<b>_Wallpaper</b>"
+msgstr "<b>_Гулқоғоз</b>"
+
+#: ../capplets/appearance/data/appearance.glade.h:10
+msgid "Appearance Preferences"
+msgstr "Ташқи кўринишни мослаш"
+
+#: ../capplets/appearance/data/appearance.glade.h:11
+msgid "Background"
+msgstr "Орқа фон"
+
+#: ../capplets/appearance/data/appearance.glade.h:12
+msgid "Best _shapes"
+msgstr "Энг яхши _шакллар"
+
+#: ../capplets/appearance/data/appearance.glade.h:13
+msgid "Best co_ntrast"
+msgstr "Энг яхши ко_нтраст"
+
+#: ../capplets/appearance/data/appearance.glade.h:14
+msgid "C_ustomize..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:15
+msgid "C_ut"
+msgstr "К_есиш"
+
+#: ../capplets/appearance/data/appearance.glade.h:16
+msgid "Changing your cursor theme takes effect the next time you log in."
+msgstr "Курсор мавзуси кейинги сафар тизимга кирганда кучга киради."
+
+#: ../capplets/appearance/data/appearance.glade.h:17
+msgid "Colors"
+msgstr "Ранглар"
+
+#: ../capplets/appearance/data/appearance.glade.h:18
+msgid "Controls"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:19
+msgid "Customize Theme"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:20
+msgid "D_etails..."
+msgstr "_Тафсилотлар..."
+
+#: ../capplets/appearance/data/appearance.glade.h:21
+msgid "Des_ktop font:"
+msgstr "Иш _столи шрифти:"
+
+#: ../capplets/appearance/data/appearance.glade.h:22
+msgid "Edit"
+msgstr "Таҳрирлаш"
+
+#: ../capplets/appearance/data/appearance.glade.h:23
+msgid "Font Rendering Details"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:24
+msgid "Fonts"
+msgstr "Шрифтлар"
+
+#: ../capplets/appearance/data/appearance.glade.h:25
+msgid "Gra_yscale"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:26
+msgid "Icons"
+msgstr "Нишончалар"
+
+#: ../capplets/appearance/data/appearance.glade.h:27
+msgid "Interface"
+msgstr "Интерфейс"
+
+#: ../capplets/appearance/data/appearance.glade.h:28
+msgid "Large"
+msgstr "Катта"
+
+#: ../capplets/appearance/data/appearance.glade.h:29
+msgid "N_one"
+msgstr "_Йўқ"
+
+#: ../capplets/appearance/data/appearance.glade.h:30
+msgid "New File"
+msgstr "Янги  файл"
+
+#: ../capplets/appearance/data/appearance.glade.h:31
+msgid "Open File"
+msgstr "Файлни очиш"
+
+#: ../capplets/appearance/data/appearance.glade.h:32
+msgid "Open a dialog to specify the color"
+msgstr "Рангни кўрсатиш учун диалогни очиш"
+
+#: ../capplets/appearance/data/appearance.glade.h:33
+msgid "Pointer"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:34
+msgid "R_esolution:"
+msgstr "Ў_лчами:"
+
+#: ../capplets/appearance/data/appearance.glade.h:35
+msgid "Save File"
+msgstr "Файлни сақлаш"
+
+#: ../capplets/appearance/data/appearance.glade.h:36
+msgid "Save Theme As..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:37
+msgid "Save _As..."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:38
+msgid "Save _background image"
+msgstr "_Орқа фон расмини сақлаш"
+
+#: ../capplets/appearance/data/appearance.glade.h:39
+msgid "Show _icons in menus"
+msgstr "Менюларда _нишончаларни кўрсатиш"
+
+#: ../capplets/appearance/data/appearance.glade.h:40
+msgid "Small"
+msgstr "Кичкина"
+
+#: ../capplets/appearance/data/appearance.glade.h:41
+msgid ""
+"Solid color\n"
+"Horizontal gradient\n"
+"Vertical gradient"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:44
+msgid "Sub_pixel (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:45
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:46
+msgid "Text"
+msgstr "Матн"
+
+#: ../capplets/appearance/data/appearance.glade.h:47
+msgid ""
+"Text below items\n"
+"Text beside items\n"
+"Icons only\n"
+"Text only"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:51
+msgid "The current controls theme does not support color schemes."
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:52
+msgid "Theme"
+msgstr "Мавзу"
+
+#: ../capplets/appearance/data/appearance.glade.h:53
+msgid ""
+"Tiled\n"
+"Zoom\n"
+"Centered\n"
+"Scaled\n"
+"Fill screen"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:58
+msgid "Toolbar _button labels:"
+msgstr ""
+
+#. vertical hinting, pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:60
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/appearance/data/appearance.glade.h:61
+msgid "Window Border"
+msgstr "Ойна чегараси"
+
+#: ../capplets/appearance/data/appearance.glade.h:62
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:50
+msgid "_Add..."
+msgstr "_Қўшиш..."
+
+#: ../capplets/appearance/data/appearance.glade.h:63
+msgid "_Application font:"
+msgstr "_Дастур шрифти:"
+
+#. pixel order blue, green, red
+#: ../capplets/appearance/data/appearance.glade.h:65
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/appearance/data/appearance.glade.h:66
+msgid "_Copy"
+msgstr "_Нусха олиш"
+
+#: ../capplets/appearance/data/appearance.glade.h:67
+msgid "_Description:"
+msgstr "_Таърифи:"
+
+#: ../capplets/appearance/data/appearance.glade.h:68
+msgid "_Document font:"
+msgstr "_Ҳужжат шрифти:"
+
+#: ../capplets/appearance/data/appearance.glade.h:69
+msgid "_Editable menu shortcut keys"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:70
+msgid "_File"
+msgstr "_Файл"
+
+#: ../capplets/appearance/data/appearance.glade.h:71
+msgid "_Fixed width font:"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:72
+msgid "_Full"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:73
+msgid "_Input boxes:"
+msgstr "_Киритиш майдонлари:"
+
+#: ../capplets/appearance/data/appearance.glade.h:74
+msgid "_Install..."
+msgstr "_Ўрнатиш..."
+
+#: ../capplets/appearance/data/appearance.glade.h:75
+msgid "_Medium"
+msgstr "_Ўртача"
+
+#: ../capplets/appearance/data/appearance.glade.h:76
+msgid "_Monochrome"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:77
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:5
+msgid "_Name:"
+msgstr "_Номи:"
+
+#: ../capplets/appearance/data/appearance.glade.h:78
+msgid "_New"
+msgstr "_Янги"
+
+#: ../capplets/appearance/data/appearance.glade.h:79
+msgid "_None"
+msgstr "_Йўқ"
+
+#: ../capplets/appearance/data/appearance.glade.h:80
+msgid "_Open"
+msgstr "_Очиш"
+
+#: ../capplets/appearance/data/appearance.glade.h:81
+msgid "_Paste"
+msgstr "_Қўйиш"
+
+#: ../capplets/appearance/data/appearance.glade.h:82
+msgid "_Print"
+msgstr "_Босиб чиқариш"
+
+#: ../capplets/appearance/data/appearance.glade.h:83
+msgid "_Quit"
+msgstr "_Чиқиш"
+
+#. pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:85
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:86
+msgid "_Reset to Defaults"
+msgstr "Андоза қийматга _қайтариш"
+
+#: ../capplets/appearance/data/appearance.glade.h:87
+msgid "_Save"
+msgstr "_Сақлаш"
+
+#: ../capplets/appearance/data/appearance.glade.h:88
+msgid "_Selected items:"
+msgstr "_Танланган элементлар:"
+
+#: ../capplets/appearance/data/appearance.glade.h:89
+msgid "_Size:"
+msgstr "_Ҳажми:"
+
+#: ../capplets/appearance/data/appearance.glade.h:90
+msgid "_Slight"
+msgstr ""
+
+#: ../capplets/appearance/data/appearance.glade.h:91
+msgid "_Style:"
+msgstr "_Услуб:"
+
+#: ../capplets/appearance/data/appearance.glade.h:92
+msgid "_Tooltips:"
+msgstr ""
+
+#. vertical hinting, pixel order red, green, blue
+#: ../capplets/appearance/data/appearance.glade.h:94
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/appearance/data/appearance.glade.h:95
+msgid "_Window title font:"
+msgstr "_Ойна сарлавҳаси шрифти:"
+
+#: ../capplets/appearance/data/appearance.glade.h:96
+msgid "_Windows:"
+msgstr "_Ойналар:"
+
+#: ../capplets/appearance/data/appearance.glade.h:97
+msgid "dots per inch"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:1
+msgid "Appearance"
+msgstr "Ташқи кўриниши"
+
+#: ../capplets/appearance/data/gnome-appearance-properties.desktop.in.in.h:2
+msgid "Customize the look of the desktop"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:1
+msgid "Installs themes packages for various parts of the desktop"
+msgstr ""
+
+#: ../capplets/appearance/data/gnome-theme-installer.desktop.in.in.h:2
+msgid "Theme Installer"
+msgstr "Мавзу ўрнатгич"
+
+#: ../capplets/appearance/data/gnome-theme-package.xml.in.h:1
+msgid "Gnome Theme Package"
+msgstr "Gnome мавзу пакети"
+
+#: ../capplets/appearance/gnome-wp-info.c:50
+msgid "No Wallpaper"
+msgstr "Гулқоғозсиз"
+
+#: ../capplets/appearance/gnome-wp-item.c:208
+msgid "Slide Show"
+msgstr ""
+
+#. translators: <b>wallpaper name</b>
+#. * mime type, x pixel(s) by y pixel(s)
+#. * Folder: /path/to/file
+#.
+#: ../capplets/appearance/gnome-wp-item.c:216
+#, c-format
+msgid ""
+"<b>%s</b>\n"
+"%s, %d %s by %d %s\n"
+"Folder: %s"
+msgstr ""
+
+#: ../capplets/appearance/gnome-wp-item.c:222
+#: ../capplets/appearance/gnome-wp-item.c:224
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "пиксел"
+msgstr[1] "пиксел"
+
+#: ../capplets/appearance/theme-installer.c:174
+#: ../capplets/appearance/theme-installer.c:224
+msgid "Cannot install theme"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:176
+#, c-format
+msgid "The %s utility is not installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:226
+msgid "There was a problem while extracting the theme."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:249
+msgid "There was an error installing the selected file"
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:250
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:251
+#, c-format
+msgid "\"%s\" does not appear to be a valid theme. It may be a theme engine which you need to compile."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:290
+#, c-format
+msgid "GNOME Theme %s correctly installed"
+msgstr "%s Gnome мавзуси муваффақиятли ўрнатилди"
+
+#: ../capplets/appearance/theme-installer.c:357
+#, c-format
+msgid "Installation for theme \"%s\" failed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:396
+#, c-format
+msgid "The theme \"%s\" has been installed."
+msgstr "\"%s\" мавзу ўрнатилди."
+
+#: ../capplets/appearance/theme-installer.c:402
+msgid "Would you like to apply it now, or keep your current theme?"
+msgstr "Уни қўллашни истайсизми ёки жорий мавзуни сақлаб қоласизми?"
+
+#: ../capplets/appearance/theme-installer.c:404
+msgid "Keep Current Theme"
+msgstr "Жорий мавзу сақлаб қолинсин"
+
+#: ../capplets/appearance/theme-installer.c:406
+msgid "Apply New Theme"
+msgstr "Янги мавзу қўллансин"
+
+#: ../capplets/appearance/theme-installer.c:510
+msgid "Failed to create temporary directory"
+msgstr "Вақтинчалик директория яратиб бўлмади"
+
+#: ../capplets/appearance/theme-installer.c:573
+msgid "New themes have been successfully installed."
+msgstr ""
+
+#: ../capplets/appearance/theme-installer.c:598
+msgid "No theme file location specified to install"
+msgstr "Ўрнатиш учун мавзу файли йўли кўрсатилмаган"
+
+#: ../capplets/appearance/theme-installer.c:619
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"Мавзуни қуйидаги манзилга ўрнатиш учун ҳуқуқ етарли эмас:\n"
+"%s"
+
+#: ../capplets/appearance/theme-installer.c:689
+msgid "Select Theme"
+msgstr "Мавзуни танлаш"
+
+#: ../capplets/appearance/theme-installer.c:693
+msgid "Theme Packages"
+msgstr "Мавзу пакетлари"
+
+#: ../capplets/appearance/theme-save.c:93
+#, c-format
+msgid "Theme name must be present"
+msgstr ""
+
+#: ../capplets/appearance/theme-save.c:156
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Мавзу аллақачон мавжуд. Алмаштиришни истайсизми?"
+
+#: ../capplets/appearance/theme-save.c:157
+#: ../capplets/common/file-transfer-dialog.c:450
+msgid "_Overwrite"
+msgstr "_Алмаштириш"
+
+#: ../capplets/appearance/theme-util.c:75
+msgid "Would you like to delete this theme?"
+msgstr "Ушбу мавзуни олиб ташлашни истайсизми?"
+
+#: ../capplets/appearance/theme-util.c:125
+msgid "Theme cannot be deleted"
+msgstr "Мавзуни олиб ташлаб бўлмайди"
+
+#: ../capplets/appearance/theme-util.c:252
+msgid "Could not install theme engine"
+msgstr ""
+
+#: ../capplets/common/activate-settings-daemon.c:16
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) settings manager may already be active and conflicting with the GNOME settings manager."
+msgstr ""
+
+#: ../capplets/common/capplet-stock-icons.c:66
+#, c-format
+msgid "Unable to load stock icon '%s'\n"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:88
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Ёрдам файлини кўрсатишда хатолик юз берди: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:98
+#, c-format
+msgid "Copying file: %u of %u"
+msgstr "Файлдан нусха олинмоқда: %u дан %u"
+
+#: ../capplets/common/file-transfer-dialog.c:145
+#, c-format
+msgid "Copying '%s'"
+msgstr "'%s' нусха олинмоқда"
+
+#: ../capplets/common/file-transfer-dialog.c:185
+#: ../capplets/common/file-transfer-dialog.c:312
+msgid "Copying files"
+msgstr "Файллардан нусха олинмоқда"
+
+#: ../capplets/common/file-transfer-dialog.c:224
+msgid "Parent Window"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Parent window of the dialog"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:231
+msgid "From URI"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:232
+msgid "URI currently transferring from"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:239
+msgid "To URI"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:240
+msgid "URI currently transferring to"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:247
+msgid "Fraction completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:248
+msgid "Fraction of transfer currently completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:255
+msgid "Current URI index"
+msgstr "Жорий URI индекси"
+
+#: ../capplets/common/file-transfer-dialog.c:256
+msgid "Current URI index - starts from 1"
+msgstr "Жорий URI индекси - 1'дан бошланади"
+
+#: ../capplets/common/file-transfer-dialog.c:263
+msgid "Total URIs"
+msgstr "Жами URI"
+
+#: ../capplets/common/file-transfer-dialog.c:264
+msgid "Total number of URIs"
+msgstr "Жами URI сони"
+
+#: ../capplets/common/file-transfer-dialog.c:444
+#, c-format
+msgid "File '%s' already exists. Do you want to overwrite it?"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:447
+msgid "_Skip"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Overwrite _All"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:134
+msgid "Key"
+msgstr "Калит"
+
+#: ../capplets/common/gconf-property-editor.c:135
+msgid "GConf key to which this property editor is attached"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:141
+msgid "Callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:142
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:147
+msgid "Change set"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:148
+msgid "GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:153
+msgid "Conversion to widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:154
+msgid "Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:159
+msgid "Conversion from widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:160
+msgid "Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:165
+msgid "UI Control"
+msgstr "График интерфейс бошқаруви"
+
+#: ../capplets/common/gconf-property-editor.c:166
+msgid "Object that controls the property (normally a widget)"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:181
+msgid "Property editor object data"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:182
+msgid "Custom data required by the specific property editor"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:188
+msgid "Property editor data freeing callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1404
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background picture."
+msgstr ""
+"'%s' файлини топиб бўлмади.\n"
+"\n"
+"Илтимос уни мавжудлигини текшириб кўринг ва қайта уриниб кўринг ёки бошқа орқа фон расмини танланг."
+
+#: ../capplets/common/gconf-property-editor.c:1412
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"'%s' файлини қандай очиш мумкин.\n"
+"Балки бу расм тури хали қўлланилмаслиги мумкин.\n"
+"\n"
+"Илтимос бунинг ўрнига бошқа расм танланг."
+
+#: ../capplets/common/gconf-property-editor.c:1532
+msgid "Please select an image."
+msgstr "Илтимос расм танланг."
+
+#: ../capplets/common/gconf-property-editor.c:1537
+msgid "_Select"
+msgstr "_Танлаш"
+
+#: ../capplets/common/gnome-theme-info.c:638
+msgid "Default Pointer - Current"
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:642
+msgid "White Pointer"
+msgstr "Оқ кўрсатгич"
+
+#: ../capplets/common/gnome-theme-info.c:643
+msgid "White Pointer - Current"
+msgstr "Оқ кўрсатгич - жорий"
+
+#: ../capplets/common/gnome-theme-info.c:647
+msgid "Large Pointer"
+msgstr "Катта кўрсатгич"
+
+#: ../capplets/common/gnome-theme-info.c:648
+msgid "Large Pointer - Current"
+msgstr "Катта кўрсатгич - жорий"
+
+#: ../capplets/common/gnome-theme-info.c:652
+msgid "Large White Pointer - Current"
+msgstr "Катта оқ кўрсатгич - жорий"
+
+#: ../capplets/common/gnome-theme-info.c:653
+msgid "Large White Pointer"
+msgstr "Катта оқ кўрсатгич"
+
+#: ../capplets/common/gnome-theme-info.c:1623
+#, c-format
+msgid "This theme will not look as intended because the required GTK+ theme '%s' is not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1631
+#, c-format
+msgid "This theme will not look as intended because the required window manager theme '%s' is not installed."
+msgstr ""
+
+#: ../capplets/common/gnome-theme-info.c:1638
+#, c-format
+msgid "This theme will not look as intended because the required icon theme '%s' is not installed."
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Preferred Applications"
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Андоза дастурни танланг"
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:1
+msgid "Start the preferred visual assistive technology"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-at-session.desktop.in.in.h:2
+msgid "Visual Assistance"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:94
+#: ../capplets/default-applications/gnome-da-capplet.c:345
+#: ../capplets/default-applications/gnome-da-capplet.c:366
+#, c-format
+msgid "Error saving configuration: %s"
+msgstr "Мосламани сақлаш хатолиги: %s"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:650
+msgid "Could not load the main interface"
+msgstr "Асосий интерфейсни юклаб бўлмади"
+
+#: ../capplets/default-applications/gnome-da-capplet.c:652
+msgid "Please make sure that the applet is properly installed"
+msgstr "Илтимос аплет тўғри ўрнатилганлигига ишонч хосил қилинг"
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/default-applications/gnome-da-capplet.c:878
+msgid "Specify the name of the page to show (internet|multimedia|system|a11y)"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-da-capplet.c:883
+msgid "- GNOME Default Applications"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+msgid "<b>Image Viewer</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "<b>Instant Messenger</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "<b>Mail Reader</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "<b>Mobility</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "<b>Multimedia Player</b>"
+msgstr "<b>Мултимедиа плейери</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "<b>Terminal Emulator</b>"
+msgstr "<b>Терминал эмулятори</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "<b>Text Editor</b>"
+msgstr "<b>Матн таҳрирчиси</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "<b>Video Player</b>"
+msgstr "<b>Видео плейер</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "<b>Visual</b>"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "<b>Web Browser</b>"
+msgstr "<b>Веб-браузер</b>"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:28
+msgid "Accessibility"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+#, no-c-format
+msgid "All %s occurrences will be replaced with actual link"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "C_ommand:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "Co_mmand:"
+msgstr "Буй_руқ:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "E_xecute flag:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Internet"
+msgstr "Интернет"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Multimedia"
+msgstr "Мултимедиа"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Open link in new _tab"
+msgstr "Боғламани янги _табда очиш"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "Open link in new _window"
+msgstr "Боғламани янги _ойнада очиш"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid "Open link with web browser _default"
+msgstr "Боғламани браузер _андозаси билан очиш"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Run at st_art"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Run in t_erminal"
+msgstr "Т_ерминалда бажариш"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "System"
+msgstr "Тизим"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "_Run at start"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:1
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:2
+msgid "Banshee Music Player"
+msgstr "Banshee мусиқий плейери"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:3
+msgid "Claws Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:4
+msgid "Dasher"
+msgstr "Dasher"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:5
+msgid "Debian Sensible Browser"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:6
+msgid "Debian Terminal Emulator"
+msgstr "Debian терминал эмулятори"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:7
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:8
+msgid "Encompass"
+msgstr "Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:9
+msgid "Epiphany Web Browser"
+msgstr "Epiphany веб браузери"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:10
+msgid "Evolution Mail Reader"
+msgstr "Evolution почта клиенти"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:11
+msgid "Firebird"
+msgstr "Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:12
+msgid "Firefox"
+msgstr "Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:13
+msgid "GNOME Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:14
+msgid "GNOME OnScreen Keyboard"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:15
+msgid "GNOME Terminal"
+msgstr "GNOME терминали"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:16
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:17
+msgid "Gnopernicus"
+msgstr "Gnopernicus"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:18
+msgid "Gnopernicus with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:19
+msgid "Iceape"
+msgstr "Iceape"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:20
+msgid "Iceape Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:21
+msgid "Icedove"
+msgstr "Icedove"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:22
+msgid "Iceweasel"
+msgstr "Iceweasel"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:23
+msgid "KDE Magnifier without Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:24
+msgid "KMail"
+msgstr "KMail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:25
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:26
+msgid "Konsole"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:27
+msgid "Linux Screen Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:28
+msgid "Linux Screen Reader with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:29
+msgid "Listen"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:30
+msgid "Midori"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:31
+msgid "Mozilla"
+msgstr "Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:32
+msgid "Mozilla 1.6"
+msgstr "Mozilla 1.6"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:33
+msgid "Mozilla Mail"
+msgstr "Mozilla Mail"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:34
+msgid "Mozilla Thunderbird"
+msgstr "Mozilla Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:35
+msgid "Muine Music Player"
+msgstr "Muine мусиқа плейери"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:36
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:37
+msgid "NXterm"
+msgstr "NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:38
+msgid "Netscape Communicator"
+msgstr "Netscape Communicator"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:39
+msgid "Opera"
+msgstr "Opera"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:40
+msgid "Orca"
+msgstr "Orca"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:41
+msgid "Orca with Magnifier"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:42
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:43
+msgid "Rhythmbox Music Player"
+msgstr "Rhythmbox мусиқа плейери"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:44
+msgid "SeaMonkey"
+msgstr "SeaMonkey"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:45
+msgid "SeaMonkey Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:46
+msgid "Standard XTerminal"
+msgstr "Андоза X-терминали"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:47
+msgid "Sylpheed"
+msgstr "Sylpheed"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:48
+msgid "Sylpheed-Claws"
+msgstr "Sylpheed-Claws"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:49
+msgid "Terminator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:50
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:51
+msgid "Totem Movie Player"
+msgstr "Totem плейери"
+
+#: ../capplets/default-applications/gnome-default-applications.xml.in.h:52
+msgid "aterm"
+msgstr "aterm"
+
+#: ../capplets/display/display-capplet.glade.h:1
+#: ../capplets/display/xrandr-capplet.c:450
+msgid "<b>Monitor</b>"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:2
+msgid "<b>Panel icon</b>"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:3
+msgid "<i>Drag the monitors to set their place</i>"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:4
+msgid "Display Settings"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:5
+msgid "Include _panel"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:6
+msgid ""
+"Normal\n"
+"Left\n"
+"Right\n"
+"Upside-down\n"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:11
+msgid "R_otation:"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:12
+msgid "Re_fresh rate:"
+msgstr "_Янгиланиш даражаси"
+
+#: ../capplets/display/display-capplet.glade.h:13
+msgid "_Detect Monitors"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:14
+msgid "_Mirror screens"
+msgstr ""
+
+#: ../capplets/display/display-capplet.glade.h:15
+msgid "_Resolution:"
+msgstr "_Ўлчами:"
+
+#: ../capplets/display/display-capplet.glade.h:16
+msgid "_Show displays in panel"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Экран ўлчамини ўзгартириш"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Экран ўлчами"
+
+#: ../capplets/display/xrandr-capplet.c:318
+#: ../capplets/display/xrandr-capplet.c:357
+msgid "Normal"
+msgstr "Ўртача"
+
+#: ../capplets/display/xrandr-capplet.c:319
+msgid "Left"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:320
+msgid "Right"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:321
+msgid "Upside Down"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:393
+#: ../capplets/display/xrandr-capplet.c:401
+#: ../capplets/display/xrandr-capplet.c:402
+#, c-format
+msgid "%d Hz"
+msgstr "%d Гц"
+
+#: ../capplets/display/xrandr-capplet.c:443
+#, c-format
+msgid "<b>Monitor: %s</b>"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:489
+#: ../capplets/display/xrandr-capplet.c:508
+#: ../capplets/display/xrandr-capplet.c:518
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:500
+msgid "Off"
+msgstr ""
+
+#. Translators:  this is the feature where what you see on your laptop's
+#. * screen is the same as your external monitor.  Here, "Mirror" is being
+#. * used as an adjective, not as a verb.  For example, the Spanish
+#. * translation could be "Pantallas en Espejo", *not* "Espejar Pantallas".
+#.
+#: ../capplets/display/xrandr-capplet.c:1306
+msgid "Mirror Screens"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1624
+msgid "Could not save the monitor configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1631
+msgid "Could not get session bus while applying display configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1641
+msgid "Could not get org.gnome.SettingsDaemon.XRANDR"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1647
+msgid "Could not apply the selected configuration"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1687
+msgid "Could not detect displays"
+msgstr ""
+
+#: ../capplets/display/xrandr-capplet.c:1885
+msgid "Could not get screen information"
+msgstr ""
+
+#: ../capplets/keybindings/00-multimedia-key.xml.in.h:1
+msgid "Sound"
+msgstr "Товуш"
+
+#: ../capplets/keybindings/01-desktop-key.xml.in.h:1
+#: ../libslab/bookmark-agent.c:1146
+msgid "Desktop"
+msgstr "Иш столи"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New shortcut..."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Акселератор тугмаси"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Акселератор модификаторлари"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Акселератор тугмаси коди"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Акселератор усули"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Акселератор тури."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:103
+#: ../typing-break/drwright.c:479
+msgid "Disabled"
+msgstr "Ўчирилган"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:184
+msgid "<Unknown Action>"
+msgstr "<Номаълум амал>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:918
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1528
+msgid "Custom Shortcuts"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1057
+msgid "Error saving the new shortcut"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1136
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1166
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1172
+#, c-format
+msgid "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1180
+msgid "_Reassign"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1300
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1483
+msgid "Too many custom shortcuts"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1768
+msgid "Action"
+msgstr "Амал"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:1790
+msgid "Shortcut"
+msgstr "Тугмалар бирикмаси"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+msgid "Custom Shortcut"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Клавиатура тугмалар бирикмаси:"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:3
+msgid "To edit a shortcut key, click on the corresponding row and type a new key combination, or press backspace to clear."
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:4
+msgid "_Command:"
+msgstr ""
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Буйруқларга тугмалар бирикмаси тайинлаш"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:209
+#: ../capplets/keyboard/gnome-keyboard-properties.c:214
+msgid "Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:219
+msgid "Start the page with the typing break settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:224
+msgid "Start the page with the accessibility settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:230
+msgid "- GNOME Keyboard Preferences"
+msgstr "- GNOME клавиатура параметрлари"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+msgid "<b>Bounce Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+msgid "<b>Cursor Blinking</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "<b>General</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Repeat Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Slow Keys</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>Sticky Keys</b>"
+msgstr ""
+
+#. fast acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Тез</i></small>"
+
+#. long delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Узун</i></small>"
+
+#. short delay
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Қисқа</i></small>"
+
+#. slow acceleration
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Секин</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_cceleration:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "All_ow postponing of breaks"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "Audio _Feedback..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Beep when _accessibility features are turned on or off"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Beep when a _toggle key is pressed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Beep when a key is reje_cted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+msgid "Beep when key is _accepted"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Beep when key is _rejected"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "By _country"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "By _language"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Check if breaks are allowed to be postponed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid "Choose a Keyboard Model"
+msgstr "Клавиатура русумини танланг"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Choose a Layout"
+msgstr "Тугмалар тартибини танланг"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Cursor _blinks in text fields"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:31
+msgid "Cursor blinks speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:32
+msgid "D_elay:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Disa_ble sticky keys if two keys are pressed together"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Duration of the break when typing is disallowed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "Duration of work before forcing a break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:36
+msgid "General"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "Key presses _repeat when key is held down"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "Keyboard Accessibility Audio Feedback"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "Keyboard Layout Options"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "Keyboard Preferences"
+msgstr "Клавиатура мосламалари"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "Keyboard _model:"
+msgstr "Клавиатура _русуми:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "Layout _Options..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "Layouts"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "Lock screen after a certain duration to help prevent repetitive keyboard use injuries"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:42
+msgid "Mouse Keys"
+msgstr "Сичқонча тугмалари"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:43
+msgid "Preview:"
+msgstr "Олдиндан кўриш:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:44
+msgid "Repeat keys speed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:45
+msgid "Reset to De_faults"
+msgstr "_Андоза параметрларни тиклаш"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:46
+msgid "S_peed:"
+msgstr "_Тезлик:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:47
+msgid "Separate _layout for each window"
+msgstr "Ҳар бир ойна учун алоҳида _тугмалар тартиби"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:48
+msgid "Typing Break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:49
+msgid "_Accessibility features can be toggled with keyboard shortcuts"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:51
+msgid "_Break interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:52
+msgid "_Country:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:53
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:43
+msgid "_Delay:"
+msgstr "_Кечикиш:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:54
+msgid "_Ignore fast duplicate keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:55
+msgid "_Language:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:56
+msgid "_Lock screen to enforce typing break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:57
+msgid "_Models:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:58
+msgid "_Only accept long keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:59
+msgid "_Pointer can be controlled using the keypad"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:60
+msgid "_Selected layouts:"
+msgstr "_Танланган тугмалар тартиби:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:61
+msgid "_Simulate simultaneous keypresses"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:62
+msgid "_Speed:"
+msgstr "_Тезлик:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:63
+msgid "_Type to test settings:"
+msgstr "Параметрларни _синаш майдони:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:64
+msgid "_Variants:"
+msgstr "_Вариантлар:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:65
+msgid "_Vendors:"
+msgstr "_Иш.чиқарувчилар:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:66
+msgid "_Work interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:67
+msgid "minutes"
+msgstr "дақиқа"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:82
+msgid "Unknown"
+msgstr "Номаълум"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:215
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:234
+#: ../capplets/network/gnome-network-preferences.c:561
+msgid "Default"
+msgstr "Андоза"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:333
+msgid "Layout"
+msgstr "Тугмалар тартиби"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:169
+msgid "Vendors"
+msgstr "Иш.чиқарувчилар"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:235
+msgid "Models"
+msgstr ""
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Клавиатура"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:90
+msgid "gesture|Move left"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:95
+msgid "gesture|Move right"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:100
+msgid "gesture|Move up"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:105
+msgid "gesture|Move down"
+msgstr ""
+
+#. Translators: this is the gesture to trigger/choose the click type.
+#. Don't include the prefix "gesture|" in the translation.
+#: ../capplets/mouse/gnome-mouse-accessibility.c:110
+msgid "gesture|Disabled"
+msgstr ""
+
+#. TRANSLATORS: don't translate the terms in brackets
+#: ../capplets/mouse/gnome-mouse-properties.c:441
+msgid "Specify the name of the page to show (general|accessibility)"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:446
+msgid "- GNOME Mouse Preferences"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+msgid "<b>Double-Click Timeout</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Ушлаб олиб қўйиш</b>"
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Dwell Click</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Locate Pointer</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Mouse Orientation</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<b>Pointer Speed</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<b>Simulated Secondary Click</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>To test your double-click settings, try to double-click on the light bulb.</i>"
+msgstr ""
+
+#. Dwell Click = Clicking without hardware buttons (by letting the pointer sit on the click target for a certain amount of time)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>You can also use the Dwell Click panel applet to choose the click type.</i>"
+msgstr ""
+
+#. high sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "<small><i>High</i></small>"
+msgstr ""
+
+#. large threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+msgid "<small><i>Large</i></small>"
+msgstr ""
+
+#. low sensitivity
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+msgid "<small><i>Low</i></small>"
+msgstr ""
+
+#. small threshold
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+msgid "<small><i>Small</i></small>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:29
+msgid "Choose type of click _beforehand"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:30
+msgid "Choose type of click with mo_use gestures"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:33
+msgid "D_ouble click:"
+msgstr ""
+
+#. click to initiate drag-and-drop (like normally click and hold)
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:35
+msgid "D_rag click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:37
+msgid "Mouse Preferences"
+msgstr "Сичқонча мосламалари"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:38
+msgid "Seco_ndary click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:39
+msgid "Sh_ow position of pointer when the Control key is pressed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:40
+msgid "Show click type _window"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:41
+msgid "Thr_eshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:42
+msgid "_Acceleration:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:44
+msgid "_Initiate click when stopping pointer movement"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:45
+msgid "_Left-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:46
+msgid "_Motion threshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:47
+msgid "_Right-handed"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:48
+msgid "_Sensitivity:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:49
+msgid "_Single click:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:50
+msgid "_Timeout:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:51
+msgid "_Trigger secondary click by holding down the primary button"
+msgstr ""
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Сичқонча"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.c:677
+#: ../capplets/network/gnome-network-preferences.c:816
+msgid "New Location..."
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.c:782
+msgid "Location already exists"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Тармоқ проксиси"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "<b>Di_rect internet connection</b>"
+msgstr "<b>Интернетга _тўғридан-тўғри уланиш</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+msgid "<b>Ignore Host List</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>Прокси мосламасини _авто-аниқлаш</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>Прокси мосламаларини _қўлбола кўрсатиш</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Use authentication</b>"
+msgstr "<b>Тасдиқлашдан _фойдаланиш</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "Autoconfiguration _URL:"
+msgstr "Авто-мослаш _URL'и:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "C_reate"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Create New Location"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "H_TTP прокси:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Ignored Hosts"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Location:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "Network Proxy Preferences"
+msgstr "Тармоқ прокси мосламалари"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "Port:"
+msgstr "Порт:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "Proxy Configuration"
+msgstr "Прокси параметрлари"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "S_ocks host:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "The location already exists."
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "U_sername:"
+msgstr "Ф_ойдалунувчи:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Delete Location"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:20
+msgid "_Details"
+msgstr "_Тафсилотлар"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:21
+msgid "_FTP proxy:"
+msgstr "_FTP прокси:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:22
+msgid "_Location name:"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:23
+msgid "_Password:"
+msgstr "_Махфий сўз:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:24
+msgid "_Secure HTTP proxy:"
+msgstr "HTTP_S прокси:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:25
+msgid "_Use the same proxy for all protocols"
+msgstr "Барча протоколлар учун битта проксидан _фойдаланиш"
+
+#: ../capplets/windows/gnome-window-properties.c:346
+msgid "Cannot start the preferences application for your window manager"
+msgstr ""
+
+#. translators: this is the Control key
+#: ../capplets/windows/gnome-window-properties.c:600
+msgid "C_ontrol"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:605
+msgid "_Alt"
+msgstr "_Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:611
+msgid "H_yper"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:618
+msgid "S_uper (or \"Windows logo\")"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:625
+msgid "_Meta"
+msgstr "_Мета"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Ойна танлаш</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To move a window, press-and-hold this key then grab the window:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Ойна параметрлари"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "сония"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "Ойна мосламаларини ўрнатиш"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Ойналар"
+
+#. make start action
+#: ../libslab/application-tile.c:372
+#, c-format
+msgid "<b>Start %s</b>"
+msgstr "<b>%s'ни ишга тушириш</b>"
+
+#: ../libslab/application-tile.c:391
+msgid "Help"
+msgstr "Ёрдам"
+
+#: ../libslab/application-tile.c:438
+msgid "Upgrade"
+msgstr "Янгилаш"
+
+#: ../libslab/application-tile.c:453
+msgid "Uninstall"
+msgstr ""
+
+#: ../libslab/application-tile.c:780 ../libslab/document-tile.c:715
+msgid "Remove from Favorites"
+msgstr ""
+
+#: ../libslab/application-tile.c:782 ../libslab/document-tile.c:717
+msgid "Add to Favorites"
+msgstr ""
+
+#: ../libslab/application-tile.c:867
+msgid "Remove from Startup Programs"
+msgstr ""
+
+#: ../libslab/application-tile.c:869
+msgid "Add to Startup Programs"
+msgstr ""
+
+#: ../libslab/app-shell.c:753
+#, c-format
+msgid ""
+"<span size=\"large\"><b>No matches found.</b> </span><span>\n"
+"\n"
+" Your filter \"<b>%s</b>\" does not match any items.</span>"
+msgstr ""
+
+#: ../libslab/app-shell.c:903
+msgid "Other"
+msgstr "Бошқа"
+
+#: ../libslab/bookmark-agent.c:1077
+msgid "New Spreadsheet"
+msgstr "Янги электрон жадвал"
+
+#: ../libslab/bookmark-agent.c:1082
+msgid "New Document"
+msgstr "Янги ҳужжат"
+
+#: ../libslab/bookmark-agent.c:1135
+msgid "Home"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1140
+msgid "Documents"
+msgstr ""
+
+#: ../libslab/bookmark-agent.c:1153
+msgid "File System"
+msgstr "Файл тизими"
+
+#: ../libslab/bookmark-agent.c:1157
+msgid "Network Servers"
+msgstr "Тармоқ серверлари"
+
+#: ../libslab/bookmark-agent.c:1186
+msgid "Search"
+msgstr "Қидириш"
+
+#. make open with default action
+#: ../libslab/directory-tile.c:171
+#, c-format
+msgid "<b>Open</b>"
+msgstr "<b>Очиш</b>"
+
+#. make rename action
+#: ../libslab/directory-tile.c:190 ../libslab/document-tile.c:231
+msgid "Rename..."
+msgstr "Номини ўзгартириш..."
+
+#: ../libslab/directory-tile.c:204 ../libslab/directory-tile.c:213
+#: ../libslab/document-tile.c:245 ../libslab/document-tile.c:254
+msgid "Send To..."
+msgstr ""
+
+#. make move to trash action
+#: ../libslab/directory-tile.c:228 ../libslab/document-tile.c:280
+msgid "Move to Trash"
+msgstr "Чиқиндилар қутисига олиб ташлаш"
+
+#: ../libslab/directory-tile.c:238 ../libslab/directory-tile.c:457
+#: ../libslab/document-tile.c:290 ../libslab/document-tile.c:831
+msgid "Delete"
+msgstr "Олиб ташлаш"
+
+#: ../libslab/directory-tile.c:533 ../libslab/document-tile.c:979
+#, c-format
+msgid "Are you sure you want to permanently delete \"%s\"?"
+msgstr ""
+
+#: ../libslab/directory-tile.c:534 ../libslab/document-tile.c:980
+msgid "If you delete an item, it is permanently lost."
+msgstr ""
+
+#: ../libslab/document-tile.c:192
+#, c-format
+msgid "<b>Open with \"%s\"</b>"
+msgstr "<b>\"%s\" билан очиш</b>"
+
+#: ../libslab/document-tile.c:204
+msgid "Open with Default Application"
+msgstr "Андоза дастур билан очиш"
+
+#: ../libslab/document-tile.c:215
+msgid "Open in File Manager"
+msgstr "Файл менежерида очиш"
+
+#: ../libslab/document-tile.c:611
+msgid "?"
+msgstr ""
+
+#: ../libslab/document-tile.c:618
+msgid "%l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:626
+msgid "Today %l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:636
+msgid "Yesterday %l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:648
+msgid "%a %l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:656
+msgid "%b %d %l:%M %p"
+msgstr ""
+
+#: ../libslab/document-tile.c:658
+msgid "%b %d %Y"
+msgstr ""
+
+#: ../libslab/search-bar.c:255
+msgid "Find Now"
+msgstr ""
+
+#: ../libslab/system-tile.c:128
+#, c-format
+msgid "<b>Open %s</b>"
+msgstr "<b>%s'ни очиш</b>"
+
+#: ../libslab/system-tile.c:141
+#, c-format
+msgid "Remove from System Items"
+msgstr "Тизим элементларидан олиб ташлаш"
+
+#: ../libwindow-settings/gnome-wm-manager.c:316
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:404
+msgid "Maximize"
+msgstr "Ёйиш"
+
+#: ../libwindow-settings/metacity-window-manager.c:405
+msgid "Maximize Vertically"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:406
+msgid "Maximize Horizontally"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:407
+msgid "Minimize"
+msgstr "Йиғиш"
+
+#: ../libwindow-settings/metacity-window-manager.c:408
+msgid "Roll up"
+msgstr ""
+
+#: ../libwindow-settings/metacity-window-manager.c:409
+msgid "None"
+msgstr "Йўқ"
+
+#: ../shell/control-center.c:54
+#, c-format
+msgid "key not found [%s]\n"
+msgstr ""
+
+#: ../shell/control-center.c:151
+msgid "Filter"
+msgstr "Филтр"
+
+#: ../shell/control-center.c:151
+msgid "Groups"
+msgstr "Гуруҳлар"
+
+#: ../shell/control-center.c:151
+msgid "Common Tasks"
+msgstr ""
+
+#: ../shell/control-center.c:155 ../shell/gnomecc.desktop.in.in.h:1
+#: ../shell/gnomecc.directory.in.h:1
+msgid "Control Center"
+msgstr "Бошқарув маркази"
+
+#: ../shell/control-center.schemas.in.h:1
+msgid "Close the control-center when a task is activated"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:2
+msgid "Exit shell on add or remove action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:3
+msgid "Exit shell on help action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:4
+msgid "Exit shell on start action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:5
+msgid "Exit shell on upgrade or uninstall action performed"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:6
+msgid "Indicates whether to close the shell when a help action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:7
+msgid "Indicates whether to close the shell when a start action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:8
+msgid "Indicates whether to close the shell when an add or remove action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:9
+msgid "Indicates whether to close the shell when an upgrade or uninstall action is performed."
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:10
+msgid "Task names and associated .desktop files"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:11
+msgid "The task name to be displayed in the control-center followed by a \";\" separator then the filename of an associated .desktop file to launch for that task."
+msgstr ""
+
+#. Translators: The format of this string is the task name to be displayed (translate that part) followed by a ";" separator then the filename (DONT translate the file name) of a .desktop file to launch. Multiple entries are separated by a ","
+#: ../shell/control-center.schemas.in.h:13
+msgid "[Change Theme;gtk-theme-selector.desktop,Set Preferred Applications;default-applications.desktop,Add Printer;gnome-cups-manager.desktop]"
+msgstr ""
+
+#: ../shell/control-center.schemas.in.h:14
+msgid "if true, the control-center will close when a \"Common Task\" is activated."
+msgstr ""
+
+#: ../shell/gnomecc.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "GNOME мослаш воситаси"
+
+#: ../typing-break/drw-break-window.c:189
+msgid "_Postpone Break"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:245
+msgid "Take a break!"
+msgstr ""
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#. translators: keep the initial "/"
+#: ../typing-break/drwright.c:129
+msgid "/_Preferences"
+msgstr "/_Параметрлар"
+
+#: ../typing-break/drwright.c:130
+msgid "/_About"
+msgstr "/_Ҳақида"
+
+#: ../typing-break/drwright.c:132
+msgid "/_Take a Break"
+msgstr ""
+
+#: ../typing-break/drwright.c:488
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../typing-break/drwright.c:492
+#, c-format
+msgid "Less than one minute until the next break"
+msgstr ""
+
+#: ../typing-break/drwright.c:579
+#, c-format
+msgid "Unable to bring up the typing break properties dialog with the following error: %s"
+msgstr ""
+
+#: ../typing-break/drwright.c:598
+msgid "Written by Richard Hult <richard@imendio.com>"
+msgstr "Муаллиф: Ричард Халт (Richard Hult) <richard@imendio.com>"
+
+#: ../typing-break/drwright.c:599
+msgid "Eye candy added by Anders Carlsson"
+msgstr ""
+
+#: ../typing-break/drwright.c:608
+msgid "A computer break reminder."
+msgstr ""
+
+#: ../typing-break/drwright.c:610
+msgid "translator-credits"
+msgstr "Нурали Абдураҳмонов <mavnur@gmail.com>"
+
+#: ../typing-break/main.c:61
+msgid "Enable debugging code"
+msgstr ""
+
+#: ../typing-break/main.c:63
+msgid "Don't check whether the notification area exists"
+msgstr ""
+
+#: ../typing-break/main.c:89
+msgid "Typing Monitor"
+msgstr ""
+
+#: ../typing-break/main.c:105
+msgid "The typing monitor uses the notification area to display information. You don't seem to have a notification area on your panel. You can add it by right-clicking on your panel and choosing 'Add to panel', selecting 'Notification area' and clicking 'Add'."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:5
+msgid "Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:7
+msgid "Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr ""
+
+#: ../font-viewer/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr ""
+
+#: ../font-viewer/font-view.c:113
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "Оқ чойнакка оқ қопқоқ, кўк чойнакка кўк қопқоқ. 0123456789"
+
+#: ../font-viewer/font-view.c:275
+msgid "Name:"
+msgstr "Номи:"
+
+#: ../font-viewer/font-view.c:278
+msgid "Style:"
+msgstr "Услуби:"
+
+#: ../font-viewer/font-view.c:291
+msgid "Type:"
+msgstr "Тури:"
+
+#: ../font-viewer/font-view.c:295
+msgid "Size:"
+msgstr ""
+
+#: ../font-viewer/font-view.c:339 ../font-viewer/font-view.c:352
+msgid "Version:"
+msgstr "Версияси:"
+
+#: ../font-viewer/font-view.c:343 ../font-viewer/font-view.c:354
+msgid "Copyright:"
+msgstr "Муаллифлик ҳуқуқи:"
+
+#: ../font-viewer/font-view.c:347
+msgid "Description:"
+msgstr "Таърифи:"
+
+#: ../font-viewer/font-view.c:437
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr ""
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:1
+msgid "Font Viewer"
+msgstr ""
+
+#: ../font-viewer/gnome-font-viewer.desktop.in.in.h:2
+msgid "Preview fonts"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:243
+msgid "Text to thumbnail (default: Aa)"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:243
+msgid "TEXT"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "Font size (default: 64)"
+msgstr "Шрифт ўлчами (андоза: 64)"
+
+#: ../font-viewer/font-thumbnailer.c:245
+msgid "SIZE"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:247
+msgid "FONT-FILE OUTPUT-FILE"
+msgstr ""
+
+#: ../font-viewer/font-thumbnailer.c:263
+#, c-format
+msgid "Error parsing arguments: %s\n"
+msgstr ""
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Ёрдамчи технологияларни мослаш"
+
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr "Сичқончани мослаш ойнасини очишда хатолик: %s"
+
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "«%s» файлидан AccessX параметрларини импорт қилиб бўлмади"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Параметрлар файлини импорт қилиш"
+
+#~ msgid "_Import"
+#~ msgstr "_Импорт"
+
+#~ msgid "Keyboard Accessibility"
+#~ msgstr "Клавиатура махсус имкониятлари"
+
+#~ msgid "This system does not seem to have the XKB extension.  The keyboard accessibility features will not operate without it."
+#~ msgstr "Тизимда XKB кенгайтмаси йўқ.  Клавиатура махсус имкониятлари усиз ишламайди."
+
+#~ msgid "Basic"
+#~ msgstr "Асосий"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr "Клавиатурадан тугмалар _активлаштирилганда сигнал бериш"
+
+#~ msgid "Beep when _modifier is pressed"
+#~ msgstr "_модификатор босилганда сигнал бериш"
+
+#~ msgid "Del_ay:"
+#~ msgstr "Ке_чикиш:"
+
+#~ msgid "Disa_ble if two keys pressed together"
+#~ msgstr "Икки тугма бирга босилса, _ўчириш"
+
+#~ msgid "Filters"
+#~ msgstr "Филтрлар"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "Сичқонча _мосламалари..."
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Клавиатуранинг рақамли қисмидан сичқонча сифатида фойдаланиш."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "Қуйидаги оралиқда ишлатилмаса _ўчириш:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "Клавиатура махсус имкониятларини _ёқиш"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "Параметрларни _импорт қилиш..."
+
+#~ msgid "_accepted"
+#~ msgstr "_қабул қилинди"
+
+#~ msgid "_pressed"
+#~ msgstr "_босилди"
+
+#~ msgid "_rejected"
+#~ msgstr "қ_абул қилинмади"
+
+#~ msgid "characters/second"
+#~ msgstr "белги/сония"
+
+#~ msgid "milliseconds"
+#~ msgstr "миллисония"
+
+#~ msgid "pixels/second"
+#~ msgstr "пиксел/сония"
+
+#~ msgid "Go _to Fonts Folder"
+#~ msgstr "Шрифт жилдига _ўтиш"
+
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "The %s utility is not installed."
+#~ msgstr ""
+#~ "Мавзуни ўрнатиб бўлмади.\n"
+#~ "%s ютилитиси ўрнатилмаган."
+
+#~ msgid ""
+#~ "Cannot install theme.\n"
+#~ "There was a problem while extracting the theme."
+#~ msgstr ""
+#~ "Мавзуни ўрнатиб бўлмади.\n"
+#~ "Мавзуни ажратишда хатолик юз берди."
+
+#~ msgid "The file format is invalid"
+#~ msgstr "Файлнинг формати хато"
+
+#~ msgid "Installation Failed"
+#~ msgstr "Ўрнатиб бўлмади"
+
+#~ msgid "This theme is not in a supported format."
+#~ msgstr "Мавзу қўлланилмайдиган форматда."
+
+#~ msgid "%s is the path where the theme files will be installed. This can not be selected as the source location"
+#~ msgstr "%s мавзу ўрнатиладиган йўлдир. Ундан манба сифатида фойдаланиб бўлмайди"
+
+#~ msgid "The file format is invalid."
+#~ msgstr "Файлнинг формати хато."
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Фақат мосламаларни қўллаш ва чиқиш"
+
+#~ msgid "Connecting..."
+#~ msgstr "Алоқа ўрнатилмоқда..."
+
+#~ msgid "Evolution Mail Reader 1.4"
+#~ msgstr "Evolution 1.4 почта клиенти"
+
+#~ msgid "Evolution Mail Reader 1.5"
+#~ msgstr "Evolution 1.5 почта клиенти"
+
+#~ msgid "Evolution Mail Reader 1.6"
+#~ msgstr "Evolution 1.6 почта клиенти"
+
+#~ msgid "Evolution Mail Reader 2.0"
+#~ msgstr "Evolution 2.0 почта клиенти"
+
+#~ msgid "Evolution Mail Reader 2.2"
+#~ msgstr "Evolution 2.2 почта клиенти"
+
+#~ msgid "Evolution Mail Reader 2.4"
+#~ msgstr "Evolution 2.4 почта клиенти"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Links матнли веб браузер"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Lynx матнли веб браузер"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M матнли веб браузер"
+
+#~ msgid "Default Settings"
+#~ msgstr "Андоза мосламалар"
+
+#~ msgid "Screen %d Settings\n"
+#~ msgstr "%d экран мосламалари\n"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Экран ўлчами параметрлари"
+
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "Ушбу компьютер (%s) учун андоза этиб _белгилаш"
+
+#~ msgid "Options"
+#~ msgstr "Параметрлар"
+
+#~ msgid "Testing the new settings. If you don't respond in %d second the previous settings will be restored."
+#~ msgid_plural "Testing the new settings. If you don't respond in %d seconds the previous settings will be restored."
+#~ msgstr[0] "Мосламаларни текшириш. Агар %d сония ичида тасдиқламасангиз эски мослама қўлланилади."
+#~ msgstr[1] "Мосламаларни текшириш. Агар %d сония ичида тасдиқламасангиз эски мослама қўлланилади."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Ушбу ўлчамни сақлаб қолиш"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Ушбу ўлчамни сақлаб қолишни истайсизми?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "_Олдинги ўлчамдан фойдаланиш"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "Ушбу ўлчамни _сақлаб қолиш"
+
+#~ msgid "New accelerator..."
+#~ msgstr "Янги акселератор..."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "\"%s\" тугмалар бирикмаси қуйидаги учун ишлатилмоқда:\n"
+#~ " \"%s\"\n"
+
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "Янги акселераторни маълумот базасига қайд қилишда хатолик: %s\n"
+
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "Акселераторни маълумот базасидан олиб ташлашда хатолик: %s\n"
+
+#~ msgid "Choose..."
+#~ msgstr "Танлаш..."
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Microsoft Natural клавиатураси"
+
+#~ msgid "_Layouts:"
+#~ msgstr "_Тугмалар тартиби:"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Тезлик</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Тез</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Юқори</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Катта</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Паст</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Секин</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Кичик</i>"
+
+#~ msgid "Buttons"
+#~ msgstr "Тугмалар"
+
+#~ msgid "Motion"
+#~ msgstr "Ҳаракат"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Чап қўл учун"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Қўшимча параметрлар"
+
+#~ msgid "Unknown Volume Control %d"
+#~ msgstr "Номаълум товуш мословчиси %d"
+
+#~ msgid "Autodetect"
+#~ msgstr "Авто-аниқлаш"
+
+#~ msgid "ALSA - Advanced Linux Sound Architecture"
+#~ msgstr "ALSA - Такомиллаштирилган Linux товуш тизими"
+
+#~ msgid "Artsd - ART Sound Daemon"
+#~ msgstr "Artsd - ART товуш демони"
+
+#~ msgid "OSS - Open Sound System"
+#~ msgstr "OSS - Очиқ товуш тизими"
+
+#~ msgid "PulseAudio Sound Server"
+#~ msgstr "PulseAudio товуш сервери"
+
+#~ msgid "Silence"
+#~ msgstr "Жимлик"
+
+#~ msgid "- GNOME Sound Preferences"
+#~ msgstr "- GNOME товуш параметрлари"
+
+#~ msgid "<b>Music and Movies</b>"
+#~ msgstr "<b>Мусиқа ва фильмлар</b>"
+
+#~ msgid "<b>Sound Events</b>"
+#~ msgstr "<b>Товуш ҳодисалар</b>"
+
+#~ msgid "<span weight=\"bold\" size=\"x-large\">Testing...</span>"
+#~ msgstr "<span weight=\"bold\" size=\"x-large\">Синалмоқда...</span>"
+
+#~ msgid "Click OK to finish."
+#~ msgstr "Тугатиш учун OK тугмасини босинг."
+
+#~ msgid "Devices"
+#~ msgstr "Ускуналар"
+
+#~ msgid "S_ound playback:"
+#~ msgstr "Т_овушни ўйнаш:"
+
+#~ msgid "So_und playback:"
+#~ msgstr "То_вушни ўйнаш:"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Товуш параметрлари"
+
+#~ msgid "Sounds"
+#~ msgstr "Товушлар"
+
+#~ msgid "System Beep"
+#~ msgstr "Тизим товуши"
+
+#~ msgid "Test"
+#~ msgstr "Синаш"
+
+#~ msgid "_Device:"
+#~ msgstr "_Ускуна:"
+
+#~ msgid "_Enable system beep"
+#~ msgstr "Тизим товушини _ёқиш"
+
+#~ msgid "_Play system sounds"
+#~ msgstr "Тизим товушини _ўйнаш"
+
+#~ msgid "_Sound playback:"
+#~ msgstr "_Товушни ўйнаш:"
+
+#~ msgid "Volume"
+#~ msgstr "Товуш"
+
+#~ msgid "_Activate"
+#~ msgstr "_Активлаштирилсин"
+
+#~ msgid "Do_n't activate"
+#~ msgstr "Активлаштирил_масин"
+
+#~ msgid "Do _not show this warning again"
+#~ msgstr "Ушбу огоҳлантириш бошқа кўрсатил_масин"
+
+#~ msgid "Use X settings"
+#~ msgstr "X мосламаларидан фойдаланиш"
+
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this is a valid command."
+#~ msgstr ""
+#~ "Буйруқни бажариб бўлмади: %s\n"
+#~ "Буйруқ мавжудлигини текшириб кўринг."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "Ушбу хабар бошқа _кўрсатилмасин"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Фойдаланувчи уй директориясини аниқлаб бўлмади"
+
+#~ msgid "A_vailable files:"
+#~ msgstr "_Мавжуд файллар:"
+
+#~ msgid "Do _not show this warning again."
+#~ msgstr "Ушбу огоҳлантириш бошқа кўрсатил_масин."
+
+#~ msgid "Load modmap files"
+#~ msgstr "modmap файлларини юклаш"
+
+#~ msgid "Would you like to load the modmap file(s)?"
+#~ msgstr "modmap файл(лар)ини юклашни истайсизми?"
+
+#~ msgid "_Load"
+#~ msgstr "_Юклаш"
+
+#~ msgid "_Loaded files:"
+#~ msgstr "_Юкланган файллар:"
+
+#~ msgid "Type"
+#~ msgstr "Тури"
+
+#~ msgid "Screen"
+#~ msgstr "Экран"
+
+#~ msgid "No valid bookmark file found in data dirs"
+#~ msgstr "Маълумотлар директориясида хатчўп топилмади"
+
+#~ msgid "A bookmark for URI '%s' already exists"
+#~ msgstr "URI '%s' учун хатчўп аллақачон мавжуд"
+
+#~ msgid "No bookmark found for URI '%s'"
+#~ msgstr "URI \"%s\" учун хатчўп топилмади"
+
+#~ msgid "No MIME type defined in the bookmark for URI '%s'"
+#~ msgstr "URI '%s' учун хатчўпда MIME тури аниқланмаган"
+
+#~ msgid "Login"
+#~ msgstr "Кириш"
+
+#~ msgid "Logout"
+#~ msgstr "Чиқиш"
+
+#~ msgid "Boing"
+#~ msgstr "Боинг"
+
+#~ msgid "No sound"
+#~ msgstr "Товуш йўқ"
+
+#~ msgid "Sound not set for this event."
+#~ msgstr "Ушбу ҳодиса учун товуш ўрнатилмаган."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package for a set of default sounds."
+#~ msgstr ""
+#~ "Ушбу ҳодиса учун товуш файли мавжуд эмас.\n"
+#~ "Андоза товушларидан фойдаланиш учун gnome-audio пакетларини ўрнатинг."
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Ушбу ҳодиса учун товуш файли мавжуд эмас."
+
+#~ msgid "Select Sound File"
+#~ msgstr "Товуш файлини танланг"
+
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "%s файли wav файл эмас"
+
+#~ msgid "Select sound file..."
+#~ msgstr "Товуш файлини танланг..."
+
+#~ msgid "System Sounds"
+#~ msgstr "Тизим товушлари"
+
+#~ msgid "E-mail"
+#~ msgstr "Эл.почта"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Эл.почта клиентини ишга тушириш тугмалар бирикмаси."
+
+#~ msgid "Eject"
+#~ msgstr "Чиқариш"
+
+#~ msgid "Home folder"
+#~ msgstr "Уй жилди"
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Уй жилди учун тугмалар бирикмаси."
+
+#~ msgid "Launch web browser"
+#~ msgstr "Веб браузерни ишга тушириш"
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Веб браузерни ишга тушириш тугмалар бирикмаси."
+
+#~ msgid "Lock screen"
+#~ msgstr "Экранни қулфлаш"
+
+#~ msgid "Lock screen's shortcut."
+#~ msgstr "Экранни қулфлаш тугмалар бирикмаси."
+
+#~ msgid "Log out"
+#~ msgstr "Сеансни тугатиш"
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Сеансни тугатиш тугмалар бирикмаси."
+
+#~ msgid "Media player"
+#~ msgstr "Мусиқа плейери"
+
+#~ msgid "Pause"
+#~ msgstr "Вақтинча тўхтатиш"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Вақтинча тўхтатиш тугмаси тугмалар бирикмаси."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Ўйнаш (ёки ўйнаш/вақтинча тўхтатиш) тугмалар бирикмаси."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Олдинги қўшиқ учун тугмалар бирикмаси."
+
+#~ msgid "Search's shortcut."
+#~ msgstr "Қидириш учун тугмалар бирикмаси."
+
+#~ msgid "Skip to next track"
+#~ msgstr "Кейинги йўлакчага ўтиш"
+
+#~ msgid "Skip to previous track"
+#~ msgstr "Олдин йўлакчага ўтиш"
+
+#~ msgid "Stop playback key"
+#~ msgstr "Ўйнашни тўхтатиш тугмаси"
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Ўйнашни тўхтатиш учун тугмалар бирикмаси."
+
+#~ msgid "Volume down"
+#~ msgstr "Товушни пасайтириш"
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Товушни пасайтириш учун тугмалар бирикмаси"
+
+#~ msgid "Volume mute's shortcut."
+#~ msgstr "Овозни ўчириш учун тугмалар бирикмаси"
+
+#~ msgid "Run screensaver at login"
+#~ msgstr "Сеанс бошланганда экран сақловчисини  ишга тушириш"
+
+#~ msgid "Start screensaver"
+#~ msgstr "Экран сақловчисини ишга тушириш"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Дастур шрифти сифатида ўрнатиш"
+
+#~ msgid "Sets the default application font"
+#~ msgstr "Андоза дастур шрифтини танланг"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "GNOME шрифт кўрувчиси"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Янги шрифт қўллансинми?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Шрифт _қўлланмасин"
+
+#~ msgid "_Apply font"
+#~ msgstr "Шрифтни _қўллаш"
+
+#~ msgid "Themes"
+#~ msgstr "Мавзулар"
+
+#~ msgid "Description"
+#~ msgstr "Таърифи"
+
+#~ msgid "Window border theme"
+#~ msgstr "Ойна чегараси мавзуси"
+
+#~ msgid "Icon theme"
+#~ msgstr "Нишонча мавзуси"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#~ msgid "[FILE]"
+#~ msgstr "[ФАЙЛ]"
+
+#~ msgid "Apply theme"
+#~ msgstr "Мавзуни қўллаш"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Мавзуни андоза қилиб белгилайди"

--- a/po/vi.po
+++ b/po/vi.po
@@ -10,9 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-04-23 00:38+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-04-23 08:12+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <gnome-vi-list@gnome.org>\n"
@@ -23,98 +22,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Gtranslator 3.38.0\n"
 
-#: panels/applications/cc-applications-panel.c:803
-msgid "System Bus"
-msgstr "Bus hệ thống"
-
-#: panels/applications/cc-applications-panel.c:803
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:823
-msgid "Full access"
-msgstr "Truy cập đầy đủ"
-
-#: panels/applications/cc-applications-panel.c:805
-msgid "Session Bus"
-msgstr "Bus phiên làm việc"
-
-#: panels/applications/cc-applications-panel.c:809
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "Thiết bị"
-
-#: panels/applications/cc-applications-panel.c:809
-msgid "Full access to /dev"
-msgstr "Truy cập đầy đủ vào /dev"
-
-#: panels/applications/cc-applications-panel.c:813
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "Mạng"
-
-#: panels/applications/cc-applications-panel.c:813
-msgid "Has network access"
-msgstr "Có truy cập mạng"
-
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:820
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "Thư mục riêng"
-
-#: panels/applications/cc-applications-panel.c:820
-#: panels/applications/cc-applications-panel.c:825
-msgid "Read-only"
-msgstr "Chỉ đọc"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-msgid "File System"
-msgstr "Hệ thống tập tin"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "Cài đặt"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Can change settings"
-msgstr "Không thể thay đổi các cài đặt"
-
-#: panels/applications/cc-applications-panel.c:831
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s có các quyền sau được tích hợp sẵn. Chúng không thể thay đổi được. Nếu "
-"bạn lo ngại về các quyền này, hãy cân nhắc loại bỏ ứng dụng này."
-
-#: panels/applications/cc-applications-panel.c:1164
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u liên kết và tập tin cái mà được mở bởi ứng dụng"
-
-#: panels/applications/cc-applications-panel.c:1171
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> được sử dụng để mở các kiểu của tập tin và liên kết sau."
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1223
-#, c-format
-msgid "%s of disk space used"
-msgstr "%s đĩa đã được sử dụng"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1387
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -130,7 +38,6 @@ msgid "Install some…"
 msgstr "Cài đặt một số…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "Mở"
 
@@ -141,6 +48,10 @@ msgstr "Hiện chi tiết"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "Tìm kiếm"
@@ -150,24 +61,13 @@ msgstr "Tìm kiếm"
 msgid "Receive system searches and send results."
 msgstr "Để hệ thống tìm kiếm và gửi kết quả."
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Tắt"
 
@@ -181,7 +81,8 @@ msgid "Show system notifications."
 msgstr "Hiện thông báo hệ thống."
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+#, fuzzy
+msgid "Run in Background"
 msgstr "Chạy dưới nền hệ thống"
 
 #: panels/applications/cc-applications-panel.ui:134
@@ -189,132 +90,144 @@ msgid "Allow activity when the app is closed."
 msgstr "Cho phép hoạt động khi ứng dụng đã bị đóng lại."
 
 #: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "Chụp màn hình"
+
+#: panels/applications/cc-applications-panel.ui:141
+#, fuzzy
+msgid "Take pictures of the screen at any time."
+msgstr "Chụp ảnh bằng máy ảnh."
+
+#: panels/applications/cc-applications-panel.ui:147
 msgid "Change Wallpaper"
 msgstr "Đổi hình nền"
 
-#: panels/applications/cc-applications-panel.ui:141
+#: panels/applications/cc-applications-panel.ui:148
 msgid "Change the desktop wallpaper."
 msgstr "Đổi hình nền trên màn hình máy tính để bàn."
 
-#: panels/applications/cc-applications-panel.ui:147
 #: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
 msgid "Sounds"
 msgstr "Âm thanh"
 
-#: panels/applications/cc-applications-panel.ui:148
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "Tái sinh âm thanh."
 
-#: panels/applications/cc-applications-panel.ui:161
+#: panels/applications/cc-applications-panel.ui:168
 msgid "Inhibit Shortcuts"
 msgstr "Chặn phím tắt"
 
-#: panels/applications/cc-applications-panel.ui:162
+#: panels/applications/cc-applications-panel.ui:169
 msgid "Block standard keyboard shortcuts."
 msgstr "Ngăn cản phím tắt bàn phím tiêu chuẩn."
 
-#: panels/applications/cc-applications-panel.ui:168
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "Máy ảnh"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
 msgstr "Chụp ảnh bằng máy ảnh."
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "Micrô"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
 msgstr "Ghi âm với míc."
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "Dịch vụ vị trí"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
 msgstr "Truy cập dữ liệu vị trí thiết bị."
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
 msgstr "Quyền tích-hợp"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
 msgstr "Ứng dụng yêu cầu truy cập hệ thống"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
 msgstr "Kết hợp Tập tin &amp; Liên kết"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "Lưu trữ"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "Không tìm thấy kết quả nào"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "Thử tìm kiếm khác"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
 msgstr "Kết hợp Tập tin & Liên kết"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "Kiểu tập tin"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "Kiểu liên kết"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "Đặt lại"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
 msgstr ""
 "Ứng dụng này chiếm bao nhiêu dung lượng đĩa với dữ liệu ứng dụng và bộ nhớ "
 "cache."
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "Ứng dụng"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "Dữ liệu"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "Bộ nhớ đệm"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>Tổng</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "Xóa bộ nhớ truy cập nhanh…"
 
@@ -322,93 +235,34 @@ msgstr "Xóa bộ nhớ truy cập nhanh…"
 msgid "Control various application permissions and settings"
 msgstr "Điều khiển các phân quyền và cài đặt của ứng dụng nhiều thứ khác nhau"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr ""
 "application;flatpak;permission;setting;ứng dụng;ung dung;quyền;quyen;cài đặt;"
 "cai dat;"
 
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "Chọn một ảnh"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "T_hôi"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:524
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "_Mở"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "nhiều kích cỡ"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "Không có ảnh nền"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "Ảnh nền hiện tại"
-
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "Kiểu"
 
-#: panels/background/cc-background-panel.ui:45
-msgid "Light"
-msgstr "Sáng"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Mặc định"
 
-#: panels/background/cc-background-panel.ui:72
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
 msgstr "Tối"
 
-#: panels/background/cc-background-panel.ui:91
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "Màu nền"
 
-#: panels/background/cc-background-panel.ui:97
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "Thêm ảnh chụp…"
 
@@ -420,52 +274,61 @@ msgstr "Diện mạo"
 msgid "Change your background image or the UI colors"
 msgstr "Thay đổi ảnh nền màn hình hay màu UI của bạn"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+#, fuzzy
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
 "Background;Wallpaper;Ảnh;nền;Anh;nen;Screen;Màn;hình;Man;hinh;Desktop;Style;"
 "Light;Dark;Sáng;Sang;Tối;Toi;Kiểu;Kieu;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+#, fuzzy
+msgid "Enable"
+msgstr "_Bật"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "Không tìm thấy Bluetooth nào"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
 msgstr "Cắm thiết bị để dùng Bluetooth."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "Bluetooth bị tắt"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
 msgstr "Bật để kết nối các thiết bị và nhận các tập tin được truyền."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "Chế độ máy bay đang bật"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
 msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "Bluetooth bị tắt khi chế độ máy bay được bật."
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "Tắt chế độ máy bay"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "Chế độ máy bay phần cứng được bật"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "Tắt chế độ máy bay chuyển sang bật Bluetooth."
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
@@ -473,20 +336,19 @@ msgstr "Bluetooth"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "Bật/tắt Bluetooth và kết nối các thiết bị của bạn"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;chia sẻ;chia se;sharing;bluetooth;obex;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "Máy ảnh bị tắt"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
 msgstr "Không có ứng dụng nào có thể chụp ảnh hoặc quay phim."
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
@@ -498,7 +360,7 @@ msgstr ""
 "\n"
 "Cho phép các ứng dụng dưới đây sử dụng máy ảnh của bạn."
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
 msgstr "Không có ứng dụng nào yêu cầu truy cập máy ảnh"
 
@@ -506,98 +368,33 @@ msgstr "Không có ứng dụng nào yêu cầu truy cập máy ảnh"
 msgid "Protect your pictures"
 msgstr "Bảo vệ các ảnh của bạn"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"screen;màn;hình;man;hình;lock;khóa;khoa;diagnostics;chẩn;đoán;chan;doan;;"
-"crash;hư;hu;private;riêng;tư;rieng;tu;recent;mới;dùng;moi;dung;gần;đây;gan;"
-"day;temporary;tạm;tam;tmp;index;name;tên;ten;network;mạng;mang;identity;thực;"
-"thể;thuc;the;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "Đặt thiết bị cân chỉnh của bạn phía trên ô vuông rồi ấn nút “Bắt đầu”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr ""
-"Di chuyển thiết bị cân chỉnh đến vị trí cân chỉnh rồi bấm nút “Tiếp tục”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "Di chuyển thiết bị cân chỉnh đến vị trí bề mặt rồi bấm nút “Tiếp tục”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "Tắt lid máy tính xách tay"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "Gặp lỗi nội bộ và không thể phục hồi."
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "Các công cụ cần thiết để cân chỉnh chưa được cài đặt."
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "Hồ sơ không thể được tạo ra."
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "Điểm trắng đích không thể thu được."
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "Hoàn tất!"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "Cân chỉnh gặp lỗi!"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "Bạn có thể gỡ bỏ thiết bị cân chỉnh."
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "Đừng làm thiết bị cân chỉnh chạm vào màn hình khi đang chạy"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "Cân chỉnh màn hình"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "T_hôi"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -611,142 +408,9 @@ msgstr "_Tiếp tục lại"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "_Xong"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "Màn hình máy tính xách tay"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "Webcam tích hợp"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "Màn hình %s"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "Máy quét %s"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "Máy ảnh %s"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "Máy in %s"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "Webcam %s"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "Bật quản lý màu sắc cho %s"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "Hiển thị hồ sơ màu dành cho %s"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "Chưa cân chỉnh"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "Mặc định: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "Không gian màu: "
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "Hồ sơ thử: "
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "Chọn tập tin hồ sơ ICC"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "_Nhập"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "Các hồ sơ ICC được hỗ trợ"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "Mọi tập tin"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "Màn hình"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "Lưu hồ sơ"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "_Lưu"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "Tạo một hồ sơ màu cho thiết bị được chọn"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr ""
-"Không tìm thấy thiết bị đo. Hãy kiểm tra xem nó đã được bật nguồn và cắm cáp "
-"kết nối chưa."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "Thiết bị đo không hỗ trợ tạo hồ sơ màu cho máy in."
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "Kiểu thiết bị này hiện chưa được hỗ trợ."
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -864,9 +528,9 @@ msgstr "Yêu cầu ổ đĩa có thể ghi được"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "Bạn có thể tìm thấy các chỉ dẫn để làm thế nào có thể sử dụng hồ sơ trên hệ "
 "thống <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> và <a "
@@ -889,8 +553,8 @@ msgid "_Import File…"
 msgstr "Nhậ_p tập tin…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "_Thêm"
@@ -901,9 +565,7 @@ msgstr ""
 "Mỗi thiết bị cần một bộ hồ sơ màu cập nhật để có thể được quản lý màu chính "
 "xác."
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "Tìm hiểu thêm"
 
@@ -1035,82 +697,6 @@ msgstr "D65 (Nhiếp ảnh và đồ họa)"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "Không gian chuẩn"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "Hồ sơ thử"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "Tự động"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "Chất lượng thấp"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "Chất lượng trung bình"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "Chất lượng cao"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "RGB mặc định"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "CMYK mặc định"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "Đen trắng mặc định"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "Dữ liệu nhà cung ứng thiết bị cân chỉnh"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "Hồ sơ này không được phép sửa chữa hiển thị toàn màn hình"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "Hồ sơ này có thể không còn chính xác"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "Màu sắc"
@@ -1121,16 +707,11 @@ msgid ""
 msgstr ""
 "Cân chỉnh màu sắc của thiết bị của bạn, như là màn hình, máy ảnh hay máy in"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Color;Màu;Mau;ICC;Profile;Calibrate;Chinh;Printer;Máy;in;May;Display;Màn;"
 "hình;Man;hinh;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "Khác…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1145,19 +726,14 @@ msgid "No languages found"
 msgstr "Không tìm thấy ngôn ngữ"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "Còn nữa…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "Mở khóa để thay đổi cài đặt"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
 msgstr "Một số cài đặt phải được mở khóa trước khi có thể thay đổi được chúng."
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "Mở khoá…"
 
@@ -1180,148 +756,6 @@ msgstr "Giảm giờ"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "Giảm phút"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "Hôm nay"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "Hôm qua"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d giờ"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d phút"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d giây"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 giây"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "Điểm truy cập"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24-giờ"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "SA / CH"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%l:%M %p, %e %b %Y"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%R, %e %B %Y"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s, %s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%l:%M %p"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1404,31 +838,67 @@ msgstr "Ngà_y &amp; Giờ tự động"
 msgid "Requires internet access"
 msgstr "Cần nối mạng internet"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
 msgstr "Ngày &amp; _Giờ"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "_Múi giờ tự động"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
 msgstr "Cần dịch vụ vị trí được bật và có nối mạng internet"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "Bật"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "Mú_i giờ"
 
-#: panels/datetime/cc-datetime-panel.ui:239
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "Mở khóa"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "Định _dạng thời gian"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+# Name: don't translate / Tên: đừng dịch
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "Ngày tháng"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 giây"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "Lịch"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "Con số"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "Thay đổi ngày giờ hay múi giờ"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr ""
@@ -1476,22 +946,11 @@ msgstr "Ứng dụng mặc định"
 msgid "Configure Default Applications"
 msgstr "Cấu hình ứng dụng mặc định"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr ""
 "default;application;preferred;media;mặc định;mac dinh;ứng dụng;ung dung;ưa "
 "dùng;uu dung;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"Gửi báo cáo các trục trặc kỹ thuật để giúp chúng tôi cải tiến %s. Báo cáo "
-"được gửi nặc danh và được xóa các dữ liệu cá nhân. %s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1509,156 +968,116 @@ msgstr "Chẩn đoán"
 msgid "Report your problems"
 msgstr "Báo cáo vấn đề trục trặc của bạn"
 
-#. FIXME
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"screen;màn;hình;man;hình;lock;khóa;khoa;diagnostics;chẩn;đoán;chan;doan;"
-"crash;hư;hu;private;riêng;tư;rieng;tu;recent;mới;dùng;moi;dung;gần;đây;gan;"
-"day;temporary;tạm;tam;tmp;index;name;tên;ten;network;mạng;mang;identity;thực;"
-"thể;thuc;the;privacy;chính sách riêng tư;chinh sach rieng tu;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "Bật"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "Tắt"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "Áp dụng thay đổi?"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "Thay đổi không thể áp dụng được"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "Việc này có thể là do giới hạn phần cứng."
+#, fuzzy
+msgid "diagnostics;crash;"
+msgstr "Chẩn đoán"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "Á_p dụng"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Kế trước"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr "Cài đặt hiển thị bị tắt"
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "Sắp xếp màn hình"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "Nhiều màn hình"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
 msgstr "Ghép nối"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
 msgstr "Giống nhau"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "Chứa thanh đỉnh và “Tổng quan hoạt động”"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
 msgstr "Màn hình chính"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
 msgstr "Ánh sáng đêm"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "Nằm ngang"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "Dọc (quay phải)"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "Dọc (quay trái)"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "Nằm gang (lật ngược)"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "Hướng"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "Độ phân giải"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "Tốc độ làm tươi"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
 msgstr "Chỉnh cho TV"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "Co giãn"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Cuộn Tự nhiên"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "Ánh sáng đêm"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
 msgstr "Tạm thời tắt cho đến ngày mai"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
 msgstr "Khởi động lại bộ lọc"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
@@ -1666,59 +1085,59 @@ msgstr ""
 "Ánh sáng đêm làm cho màn hình có màu ấm hơn. Việc này có thể giúp ngăn ngừa "
 "mắt bị mỏi mệt và buồn ngủ."
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "Lịch biểu"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
 msgstr "Hoàng hôn tới Bình minh"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "Thời gian biểu thủ công"
 
-#: panels/display/cc-night-light-page.ui:110
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
 msgstr "Thời gian"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "Từ"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "Giờ"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "Phút"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "SA"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "CH"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
 msgstr "Tới"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
 msgstr "Nhiệt độ màu"
 
@@ -1730,7 +1149,6 @@ msgstr "Màn hình"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "Chọn cách dùng màn hình và máy chiếu được kết nối"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1741,54 +1159,59 @@ msgstr ""
 "sáng;anh sang;Blue;Xanh;redshift;color;màu;mau;sunset;hoàng hôn;hoang hon;"
 "sunrise;bình minh;binh minh;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "Chưa biết"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s; Mã số biên dịch: %s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "Kiểu an ninh"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64-bít"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "Mức mực"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32-bít"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "Mức mực"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "Mức mực"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "Chưa biết"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "An ninh"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "Logo hệ thống"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;màn;hình;man;hình;lock;khóa;khoa;diagnostics;chẩn;đoán;chan;doan;"
+"crash;hư;hu;private;riêng;tư;rieng;tu;recent;mới;dùng;moi;dung;gần;đây;gan;"
+"day;temporary;tạm;tam;tmp;index;name;tên;ten;network;mạng;mang;identity;thực;"
+"thể;thuc;the;privacy;chính sách riêng tư;chinh sach rieng tu;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "Tên thiết bị"
 
@@ -1821,31 +1244,43 @@ msgstr "Đang tính toán…"
 msgid "OS Name"
 msgstr "Tên HĐH"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+#, fuzzy
+msgid "OS Build ID"
+msgstr "%s; Mã số biên dịch: %s"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "Kiểu HĐH"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "Phiên bản GNOME"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "Tùy chọn tải…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "Hệ thống Cửa sổ"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "Ảo hóa"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "Cập nhật phần mềm"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "Đổi tên thiết bị"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
@@ -1853,7 +1288,12 @@ msgstr ""
 "Tên thiết bị được sử dụng để xác định thiết bị này khi nó được xem qua mạng "
 "hoặc khi ghép nối thiết bị Bluetooth."
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "Tên thiết bị"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "Đổ_i tên"
 
@@ -1865,11 +1305,6 @@ msgstr "Giới thiệu"
 msgid "View information about your system"
 msgstr "Xem thông tin về hệ thống của bạn"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1950,6 +1385,12 @@ msgstr "Chạy phần mềm"
 msgid "Launch help browser"
 msgstr "Chạy trình duyệt trợ giúp"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Cài đặt"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "Chạy máy tính bỏ túi"
@@ -1971,7 +1412,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "Hệ thống"
 
@@ -2020,20 +1461,11 @@ msgstr "Giảm cỡ chữ"
 msgid "High contrast on or off"
 msgstr "Bật hoặc tắt tương phản cao"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "Không tìm thấy nguồn nhập liệu"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "Khác"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "Thêm nguồn nhập liệu"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
 msgstr "Các phương thức nhập liệu không thể dùng tại màn hình đăng nhập"
 
@@ -2041,122 +1473,29 @@ msgstr "Các phương thức nhập liệu không thể dùng tại màn hình �
 msgid "No input source selected"
 msgstr "Chưa chọn nguồn nhập liệu"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Tùy chọn"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
 msgstr "Chuyển lên"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
 msgstr "Chuyển xuống"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "Tùy thích"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "Xem bố cục bàn phím"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "Xóa"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "Phím tắt tự chọn"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "Phím ký tự thay thế"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"Phím ký tự thay thế có thể được sử dụng để nhập các ký tự bổ sung. Đôi khi "
-"chúng được in dưới dạng tùy chọn thứ ba trên bàn phím của bạn."
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "Alt trái"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "Alt phải"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "Phím Win trái"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "Phím Win phải"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "Phím trình đơn"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "Ctrl phải"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "Phím tổ hợp"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Phím tổ hợp cho phép nhập nhiều ký tự khác nhau. Để sử dụng nó, nhấn compose "
-"sau đó một chuỗi các ký tự. Ví dụ: phím compose tiếp theo là <b>C</b> và "
-"<b>o</b> sẽ nhập <b>©</b>, <b>a</b> tiếp theo là <b>'</b> sẽ nhập <b>á</"
-"b>."
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "Caps Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "Scroll Lock"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "Print Screen"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"Nuồn nhập liệu bạn có thể thay đổi sử dụng phím tắt %s\n"
-"Cái này có thể được thay đổi trong cài đặt phím tắt."
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2178,55 +1517,31 @@ msgstr "Sử dụng _cùng kiểu bố trí cho mọi cửa sổ"
 msgid "Switch input sources _individually for each window"
 msgstr "Cho phép chuyển nguồn nhập liệu _khác nhau cho mỗi cửa sổ"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
+#: panels/keyboard/cc-keyboard-panel.ui:59
 msgid "Special Character Entry"
 msgstr "Nhập ký tự đặc biệt"
 
-#: panels/keyboard/cc-keyboard-panel.ui:59
+#: panels/keyboard/cc-keyboard-panel.ui:60
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr ""
 "Phương thức để nhập vào các ký hiệu đặc biệt và các biến thể chữ sử dụng bàn "
 "phím."
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "Phím ký tự thay thế"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Phím tổ hợp"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "Phím tắt"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "Xem và tùy chỉnh Phím tắt"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d mục bị sửa đổi"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
-msgid "Reset All Shortcuts?"
-msgstr "Đặt lại toàn bộ phím tắt chứ?"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr ""
-"Việc đặt lại phím tắt có thể ảnh hưởng đến các phím tắt tự chọn của bạn. "
-"Hành động này không thể hoàn lại được."
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "Thôi"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
-msgid "Reset All"
-msgstr "Đặt lại tất cả"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2236,93 +1551,87 @@ msgstr "Đặt lại tất cả…"
 msgid "Reset all shortcuts to their default keybindings"
 msgstr "Đặt lại các phím tắt thành giá trị mặc định của chúng"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "Phần"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Phím tắt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Thêm phím tắt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "Thêm Phím tắt tự chọn"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr "Cài đặt phím tắt tùy chỉnh để khởi chạy ứng dụng, chạy tập lệnh, v.v."
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
 msgstr "Thêm phím tắt"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "Không tìm thấy phím tắt bàn phím nào"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s đang được sử dụng cho %s. Nếu bạn thay thế nó, %s sẽ bị tắt"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Xóa"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "Gõ phím tắt mới"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "Đặt phím tắt tự chọn"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "Đặt phím tắt"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "Gõ phím tắt mới để thay đổi %s."
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "Thêm phím tắt tự chọn"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "Thêm"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
 msgstr "Thay thế"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "Đặt"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "Đặ_t"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
 msgstr "Nhấn Esc để thôi hoặc Backspace để tắt phím tắt bàn phím."
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "Tên"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
 msgstr "Câu lệnh"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "Phím tắt"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "Đặt phím tắt…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "Không có"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
 msgstr "Đặt lại các phím tắt thành giá trị mặc định của chúng"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Dùng máy in theo mặc định"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2336,7 +1645,6 @@ msgstr ""
 "Thay đổi phím tắt và đặt tùy thích cách bạn gõ, bố cục bàn phín và nguồn "
 "nhập liệu"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2346,15 +1654,15 @@ msgstr ""
 "tương phản;tuong phan;Input;Source;nguồn;nguon;Lock;khóa;khoa;Volume;âm "
 "lượng;am luong;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "Dịch vụ vị trí bị tắt"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
 msgstr "Không ứng dụng nào có thể thu thập thông tin vị trí của bạn."
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2372,7 +1680,7 @@ msgstr ""
 "\n"
 "Cho phép các ứng dụng phía dưới dò tìm vị trí của bạn."
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
 msgstr "Không có ứng dụng nào từng hỏi quyền truy cập vị trí của bạn"
 
@@ -2380,175 +1688,19 @@ msgstr "Không có ứng dụng nào từng hỏi quyền truy cập vị trí c
 msgid "Protect your location information"
 msgstr "Bảo vệ thông tin vị trí của bạn"
 
-#. FIXME
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "Màn hình tắt"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 giây"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 phút"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 phút"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 phút"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 phút"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 phút"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 giờ"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 phút"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 phút"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 phút"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 phút"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 phút"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 phút"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 phút"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 phút"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 phút"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "Không bao giờ"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
 msgstr ""
-"Tự động khóa màn hình để ngăn người khác truy cập vào máy tính trong khi bạn "
-"đi vắng."
 
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "Trễ tắt màn hình"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "Chu kỳ không hoạt động mà sau đó màn hình sẽ tắt."
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "_Khóa màn hình tự động"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "_Trễ Khóa màn hình tự động"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "Chu kỳ mà sau đó màn hình tắt khi màn hình được tự động khóa lại."
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "Thông báo trên màn hình _khóa"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "Ngăn cản Thiết bị _USB mới"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr "Ngăn các thiết bị USB mới tương tác với hệ thống khi màn hình bị khóa."
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "Khóa màn hình"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "Khóa màn hình của bạn"
-
-#. FIXME
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "Míc đang bị tắt"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
 msgstr "Không tìm thấy ứng dụng nào có thể ghi âm."
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2561,7 +1713,7 @@ msgstr ""
 "\n"
 "Cho phép các ứng dụng dưới đây sử dụng míc của bạn."
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
 msgstr "Không có ứng dụng nào từng hỏi quyền truy cập míc của bạn"
 
@@ -2569,7 +1721,10 @@ msgstr "Không có ứng dụng nào từng hỏi quyền truy cập míc của 
 msgid "Protect your conversations"
 msgstr "Bảo vệ các cuộc chuyện trò của bạn"
 
-#. FIXME
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "_Kiểm tra cài đặt của bạn"
@@ -2587,83 +1742,150 @@ msgstr "Nút chính"
 msgid "Sets the order of physical buttons on mice and touchpads."
 msgstr "Đặt thứ tự của các nút vật lý trên con chuột và touchpads."
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "Trái"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "Phải"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Vị trí tìm"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "Chuột"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "Tốc độ chuột"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "Cuộn Tự nhiên"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "Cuộn xuống"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "Cuộn di chuyển nội dung, không phải bộ trình bày."
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "Cuộn di chuyển nội dung, không phải bộ trình bày."
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "Hoạt động"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "Tốc độ Touchpad"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "_Phương thức"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "Vỗ nhẹ để bấm chuột"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "Cuộn hai-ngón"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "Vỗ nhẹ để bấm chuột"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "_Tắt khi đang gõ"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "Touchpad (tương đối)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "Cuộn cạnh"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "Cuộn xuống"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "Hai mặt"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "Thử nhấn, bấm đúp, cuộn chuột"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "Bấm năm lần, sự kiện GEGL!"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "Bấm đúp, nút chính"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "Bấm đơn, nút chính"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "Bấm đúp, nút giữa"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "Bấm đơn, nút giữa"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "Bấm đúp, nút phụ"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "Bấm đơn, nút phụ"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2674,7 +1896,6 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "Thay đổi độ nhạy chuột và touchpad và chọn thuận tay phải/trái"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -2755,87 +1976,41 @@ msgstr "Đa nhiệm"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "Quản lý các tùy chỉnh cho năng suất và đa nhiệm"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+#, fuzzy
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Đa;nhiệm;Tùy;chọn;"
 "chỉnh;da nhiem;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr ""
-"Ôi trời, có gì đó sai rồi. Vui lòng liên lạc với nhà cung cấp phần mềm."
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "Trình quản lý kết nối mạng cần phải đang chạy."
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "Thiết bị khác"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Thêm kết nối mới"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
 msgstr "Chưa cài đặt"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "Mạng không an toàn (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "Mạng an toàn (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "Mạng an toàn (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "Mạng an toàn (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "Mạng an toàn"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "Đã kết nối"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "Tùy chọn…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr ""
-"Bật điểm phát sóng sẽ ngắt kết nối khỏi %s và sẽ không thể truy cập internet "
-"thông qua Wi-Fi."
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "Mật khẩu phải dài ít nhất 8 ký tự"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -2862,354 +2037,87 @@ msgid "Network Name"
 msgstr "Tên mạng"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "Tạo mật khẩu ngẫu nhiên"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "Mật khẩu tạo tự động"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "_Bật"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr ""
-"Bạn có muốn dừng điểm truy cập này và ngắt kết nối những người đang sử dụng?"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "_Dừng điểm truy cập"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "Chế độ máy bay"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "Tắt Wi-Fi, Bluetooth và di động băng thông rộng"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "Không tìm thấy thiết bị Wi-Fi nào"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "Hãy chắc chắn là bạn có thiết bị Wi-Fi và nó được bật"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "Chế độ máy bay đang được bật"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "Tắt để dùng Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
 msgstr "Kích hoạt Wi-Fi Hotspot"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
 msgstr "Thiết bị di động có thể quét mã QR để kết nối."
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "Tắt Wi-Fi Hotspot…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
 msgstr "Mạng thấy được"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
 msgstr "Trình quản lý kết nối mạng cần phải đang chạy"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ôi trời, có gì đó sai rồi. Vui lòng liên lạc với nhà cung cấp phần mềm."
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "_An ninh 802.1x"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "An ninh"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "Giữ nguyên"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "Vĩnh viễn"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "Ngẫn nhiên"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "Ổn định"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"Địa chỉ MAC được nhập ở đây sẽ được dùng làm địa chỉ phần cứng cho thiết bị "
-"mạng được kết nối này dùng. Tính năng này còn được biết là MAC nhân bản hay "
-"MAC giả. Ví dụ: 00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "Hồ sơ %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "Doanh nghiệp"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "Không"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "Không bao giờ"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i ngày trước"
-
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "Không có"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "Yếu"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "Ok"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "Tốt"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "Tuyệt hảo"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "Địa chỉ IPv4"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "Địa chỉ IPv6"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "Địa chỉ IP"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "Quên kết nối"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "Xóa bỏ Hồ sơ Kết nối"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "Xóa VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "Chi tiết"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "tự động"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "Thực thể"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "Xóa địa chỉ"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "Xóa định tuyến"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "Không"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "Khóa WEP 40/128-bit (thập lục phân hoặc ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "Mật khẩu WEP 128-bit"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "WEP động (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 Cá nhân"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 Doanh nghiệp"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 Cá nhân"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3220,8 +2128,20 @@ msgstr "Cường độ tín hiệu"
 msgid "Link speed"
 msgstr "Tốc độ đường truyền"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "An ninh"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "Địa chỉ IPv4"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "Địa chỉ IPv6"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "Địa chỉ phần cứng"
 
@@ -3230,12 +2150,17 @@ msgid "Supported Frequencies"
 msgstr "Tần số được hỗ trợ"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "Định tuyến mặc định"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3249,13 +2174,13 @@ msgstr "Kết nối _tự động"
 msgid "Make available to _other users"
 msgstr "Cho người dùng _khác sử dụng"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
 msgstr ""
 "Kết nối Đ_o dung lượng: có giới hạn dữ liệu hoặc có thể phải tính phí theo "
 "dung lượng sử dụng"
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
 msgstr ""
@@ -3300,7 +2225,7 @@ msgstr "Chỉ Link-Local"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "Thủ công"
 
@@ -3320,33 +2245,32 @@ msgid "Addresses"
 msgstr "Các địa chỉ"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
 msgstr "Địa chỉ"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
 msgstr "Mặt nạ mạng"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
 msgstr "Máy cổng"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "Tự động"
 
@@ -3355,29 +2279,34 @@ msgstr "Tự động"
 msgid "Automatic DNS"
 msgstr "DNS tự động"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
 msgid "Separate IP addresses with commas"
 msgstr "Ngăn cách địa chỉ IP bằng các dấu phẩy"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "Định tuyến"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "Định tuyến tự động"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
 msgstr "Metric"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
 msgstr "Dùng kết nối này _chỉ cho tài nguyên trên mạng này"
 
@@ -3390,83 +2319,13 @@ msgid "Automatic, DHCP only"
 msgstr "Tự động, chỉ DHCP"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "Tiền tố"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "Không thể mở cửa sổ điều chỉnh kết nối"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "Hồ sơ mới"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "Nhập từ tập tin…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "Thêm VPN"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "_An ninh"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "Không thể nhập kết nối VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Tập tin “%s” không thể đọc được hay nó chứa thông tin kết nối VPN không được "
-"chấp nhận\n"
-"\n"
-"Lỗi: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "Chọn tập tin cần nhập"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "Đã có tập tin tên “%s” rồi."
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "_Thay thế"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "Bạn có muốn thay thế %s bằng kết nối này?"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "Không thể xuất kết nối VPN"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"Kết nối VPN “%s” không thể xuất ra %s.\n"
-"\n"
-"Lỗi: %s."
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "Xuất kết nối VPN"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3480,107 +2339,50 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Mạng"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "Điều khiển cách kết nối Internet"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;mạng;mang;IP;LAN;Proxy;ủy nhiệm;uy nhiem;WAN;Broadband;Modem;"
 "Bluetooth;vpn;DNS;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "Điều khiển cách kết nối đến mạng Wi-Fi"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;mạng;mang;Wireless;không dây;khong day;Wi-Fi;Wifi;IP;LAN;Broadband;"
 "DNS;Hotspot;điểm truy cập;diem truy cap;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "không bao giờ"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "hôm nay"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "hôm qua"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "Dùng lần cuối"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "Có dây"
 
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "Thêm kết nối mới"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr ""
-"Sẽ mất chi tiết của những mạng được chọn, bao gồm mật khẩu và các cài đặt "
-"tùy biến khác."
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "_Quên"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "Mạng đã biết Wi-Fi"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "_Quên"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr ""
-"Chính sách của hệ thống cấm chỉ dùng máy tính này như một Hotspot (Điểm tập "
-"trung để máy khác truy cập mạng)"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "Thiết bị không dây không hỗ trợ chế độ điểm truy cập"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "Dùng Tự động phát hiện ủy nhiệm Web nếu không cung cấp URL cấu hình."
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "Không khuyến khích đối với mạng công cộng không đáng tin."
-
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "Tắt thiết bị"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Hoạt động"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3591,47 +2393,51 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "Nhà cung cấp"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Địa chỉ IP"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "Ủy nhiệm mạng"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "Ủy nhiệm _HTTP"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "Ủy nhiệm H_TTPS"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "Ủy nhiệm _FTP"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Máy chủ _Socks"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "_Bỏ qua máy"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
 msgstr "Cổng ủy nhiệm HTTP"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
 msgstr "Cổng ủy nhiệm HTTPS"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
 msgstr "Cổng ủy nhiệm FTP"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Cổng ủy nhiệm Socks"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
 msgstr "_Cấu hình URL"
 
@@ -3658,301 +2464,22 @@ msgstr "Mật khẩu"
 msgid "Turn Wi-Fi off"
 msgstr "Tắt Wi-Fi"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Tùy chọn tải…"
+
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
 msgstr "_Nối vào mạng ẩn…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "_Bật Wi-Fi Hotspot…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
 msgstr "Mạng Wi-Fi đã _biết"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "Tình trạng không rõ"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "Chưa được quản lý"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "Không sẵn sàng"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "Đang kết nối"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "Cần xác thực"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "Đang ngắt kết nối"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "Kết nối gặp lỗi"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "Tình trạng không rõ (thiếu)"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "Cấu hình gặp lỗi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "Cấu hình IP gặp lỗi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "Hết hạn cấu hình IP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "Cần bí mật nhưng chưa được cung cấp"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x supplicant ngắt kết nối"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "Lỗi cấu hình 802.1x supplicant"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "Lỗi 802.1x supplicant"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x supplicant tốn quá nhiều thời gian để xác thực"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "Gặp lỗi khi khởi động dịch vụ PPP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "Dịch vụ PPP bị ngắt"
-
-# Name: don't translate / Tên: đừng dịch
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP bị lỗi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "Lỗi khởi động trình khách DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "Lỗi trình khách DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "Lỗi trình khách DHCP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "Lỗi khởi động dịch vụ kết nối chia sẻ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "Lỗi dịch vụ kết nối chia sẻ"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "Lỗi khởi động dịch vụ AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "Lỗi dịch vụ AutoIP"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "Dịch vụ AutoIP gặp lỗi"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "Đường dây bận"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "Không có tông"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "Không thể cài đặt carrier"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "Hết hạn yêu cầu quay số"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "Lỗi quay số"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "Lỗi khởi động Modem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "Lỗi chọn APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "Không tìm thấy mạng"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "Đăng ký mạng bị từ chối"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "Hết hạn đăng ký mạng"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "Lỗi đăng ký mạng yêu cầu"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "Gặp lỗi khi kiểm tra PIN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "Có lẽ thiếu firmware cho thiết bị"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "Kết nối bị biến mất"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "Ngầm định kết nối đã tồn tại"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "Không tìm thấy Modem"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "Gặp lỗi khi kết nối Bluetooth"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "Chưa cài SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "Cần Pin của SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "Cần Puk của SIM"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM không đúng"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "Lỗi phụ thuộc kết nối"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "Thiếu firmware"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "Chưa cắm dây"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "lỗi chưa biết trong an ninh 802.1X (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "chưa chọn tập tin"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "lỗi chưa định nghĩa khi xác thực lại tập tin eap-method"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "Khóa riêng DER, PEM, hay PKCS#12 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "Giấy phép DER hay PEM (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "thiếu tập tin EAP-FAST"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "Tập tin PAC (*.pac)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -4002,14 +2529,6 @@ msgstr "Xác thực _bên trong"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "Cho phép PAC _dự liệu tự động"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "thiếu tên tài khoản EAP-LEAP"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "thiếu mật khẩu EAP-LEAP"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4022,7 +2541,7 @@ msgstr "_Tài khoản"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "_Mật khẩu"
 
@@ -4034,16 +2553,6 @@ msgstr "_Mật khẩu"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "_Hiện mật khẩu"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "giấy chứng nhận CA EAP-PEAP không hợp lệ: %s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr ""
-"giấy chứng nhận CA EAP-PEAP không hợp lệ: chưa chỉ định giấy chứng nhận"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -4066,7 +2575,6 @@ msgid "C_A certificate"
 msgstr "Giấy chứng nhận C_A"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4081,62 +2589,6 @@ msgstr "_Yêu cầu là không giấy chứng nhận CA"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "_Phiên bản PEAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "thiếu tên tài khoản EAP"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "thiếu mật khẩu EAP"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "sai định danh EAP-TLS"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "giấy chứng nhận CA EAP-TLS không hợp lệ: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "giấy chứng nhận CA EAP-TLS không hợp lệ: chưa chỉ định giấy chứng nhận"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "khóa riêng EAP-TLS không hợp lệ: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "giấy chứng nhận người dùng EAP-TLS không hợp lệ: %s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "Khóa riêng mà không được mã hóa là không an toàn"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"Khóa riêng đã chọn không được bảo vệ bằng mật khẩu. Điều đó làm giảm bớt mức "
-"độ an toàn của hệ thống. Hãy đặt mật khẩu để bảo vệ khóa riêng.\n"
-"\n"
-"(Bạn có thể bảo vệ khóa riêng bằng mật khẩu với openssl)"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "Chọn chứng nhận cá nhân của bạn"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "Chọn khóa riêng của bạn"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4153,16 +2605,6 @@ msgstr "_Khóa riêng"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "Mật khẩu khóa _riêng"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "giấy chứng nhận CA EAP-TTLS không hợp lệ: %s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr ""
-"giấy chứng nhận CA EAP-TTLS không hợp lệ: chưa chỉ định giấy chứng nhận"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4185,14 +2627,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "_Miền"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "Lỗi thẩm tra an ninh 802.1X chưa biết"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4220,62 +2663,10 @@ msgstr "EAP được bảo vệ (PEAP)"
 msgid "Au_thentication"
 msgstr "_Xác thực"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "Chọn một tập tin"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "thiếu leap-username"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "thiếu leap-password"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Thiếu mật khẩu Wi-Fi."
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "_Kiểu"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "thiếu wep-key"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr ""
-"wep-key không hợp lệ: khóa phải có chiều dài của %zu phải chỉ chứa chữ số "
-"thập lục"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr ""
-"wep-key không hợp lệ: khóa phải có chiều dài của %zu phải chỉ chứa các ký tự "
-"ascii"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"wep-key không hợp lệ: khóa phải có chiều dài của %zu. Một khóa phải hoặc là "
-"có chiều dài 5/4 (ascii) hoặc là 10/26 (chữ số thập lục)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "wep-key không hợp lệ: mật khẩu phải không rỗng"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "wep-key không hợp lệ: mật khẩu phải ngắn hơn 64 ký tự"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4300,20 +2691,6 @@ msgstr "_Hiện khóa"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "_Mục lục WEP"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"wpa-psk không hợp lệ: chiều dài khóa %zu không hợp lệ. Phải là [8,63] bye "
-"hoặc 64 số thập lục"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr ""
-"wpa-psk không hợp lệ: không thể phiên dịch khóa với 64 bye như là số thập lục"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4368,59 +2745,35 @@ msgstr "Thông báo trên màn hình _khóa"
 msgid "Control which notifications are displayed and what they show"
 msgstr "Cấu hình xem cảnh báo nào sẽ được hiển thị và hiển thị nó như thế nào"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Notifications;Thông;báo;Thong;bao;Banner;Message;Nhắn;nhan;Tray;Khay;Popup;"
 "Nổi;lên;Noi;len;"
 
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "%s đã bị gỡ bỏ"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "Khác"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "Không thể xóa tài khoản"
-
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
 msgstr "Hoàn tác"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "Hiện thông báo hệ thống."
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
 msgstr "Kết nối đến dữ liệu trên mây của bạn"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
 msgstr ""
 "Không có kết nối internet - kết nối để cài đặt tài khoản trực tuyến mới"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "Thêm tài khoản"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "Tài khoản %s"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "Xóa tài khoản"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4431,10 +2784,6 @@ msgid "Connect to your online accounts and decide what to use them for"
 msgstr ""
 "Kết nối các tài khoản trực tuyến của bạn và quyết định dùng chúng vào việc gì"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4443,10 +2792,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Truc;tuyen;Chat;Calendar;Lịch;Lich;"
 "Mail;Thư;Thu;Contact;Liên;lạc;Lien;lac;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
 "ReadItLater;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "Thời gian không rõ"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4460,13 +2805,6 @@ msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i giờ"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4476,188 +2814,6 @@ msgstr[0] "giờ"
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "phút"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s đến khi sạc đầy"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "Cảnh báo: còn %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "còn %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "Đã sạc đầy"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "Không sạc"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "Rỗng"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "Đang sạc"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "Đang xả"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "Chuột không dây"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "Bàn phím không dây"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "Nguồn không ngắt"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "Trợ lý điện tử cá nhân"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "Điện thoại di động"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "Phát đa phương tiện"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "Máy tính bảng"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "Máy tính"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "Thiết bị chơi game"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "Pin"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "Chính"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "Phụ"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "Pin"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "Kh_i nghỉ"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "Tạm ngưng"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "Tắt máy"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "Ngủ đông"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "Không gì"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "Khi sử dụng nguồn pin"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "Khi cắm dây nguồn"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "Không bao giờ"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "Tự động ngưng"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "Chế độ năng suất tạm thời bị tắt bởi vì nhiệt độ của hoạt dộng cao."
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"Dò thấy máy tính đang để trên đùi: chế độ năng suất hiện tạm thời không sẵn "
-"sàng. Hãy chuyển thiết bị đến mặt phẳng ổn định hơn để phục hồi lại."
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr "Tạm thời tắt chế độ năng suất."
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr ""
-"Sắp hết pin: nên chế độ tiết kiệm điện được bật. Chế độ dùng trước đây sẽ "
-"được dùng lại khi pin đã được sạc đủ dùng."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "Chế độ tiết kiệm điện được kích hoạt bởi “%s”."
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "Chế độ năng suất được kích hoạt bởi “%s”."
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4719,6 +2875,15 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 giờ"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Pin"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "Thiết bị"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "Chế độ nguồn điện"
@@ -4739,90 +2904,63 @@ msgstr "Tự động chỉnh độ sáng màn hình"
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "Chỉnh độ sáng màn hình theo ánh sáng xung quanh."
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "Giảm sáng màn hình"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
 msgstr ""
 "Giảm độ sáng màn hình sau một khoảng thời gian máy tính không hoạt động."
 
-#: panels/power/cc-power-panel.ui:150
+#: panels/power/cc-power-panel.ui:151
 msgid "Screen _Blank"
 msgstr "_Tắt màn hình"
 
-#: panels/power/cc-power-panel.ui:151
+#: panels/power/cc-power-panel.ui:152
 msgid "Turns the screen off after a period of inactivity."
 msgstr "Tắt màn hình sau một khoảng thời gian không hoạt động."
 
-#: panels/power/cc-power-panel.ui:159
+#: panels/power/cc-power-panel.ui:160
 msgid "Automatic Power Saver"
 msgstr "Tự động tiết kiệm năng lượng"
 
-#: panels/power/cc-power-panel.ui:160
+#: panels/power/cc-power-panel.ui:161
 msgid "Enables power saver mode when battery is low."
 msgstr "Cho phép chế độ tiết kiệm điện khi sắp hết pin."
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "_Tự động tạm ngưng"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
 msgstr "Tạm dừng máy tính sau một khoảng thời gian không hoạt động."
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "Ứng _xử nút nguồn"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
 msgstr "Hiển thị _Phần trăm pin"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "Tự động ngưng"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "Đã _cắm"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "Dùng nguồn _pin"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "Khoảng trễ"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "Hiệu suất"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "Hiệu năng cao và tiêu dùng nhiều năng lượng."
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "Cân bằng"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "Hiệu suất và tiêu dùng điện năng tiêu chuẩn."
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "Tiết kiệm năng lượng"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "Giảm hiệu năng và tiêu dùng ít năng lượng."
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4832,7 +2970,6 @@ msgstr "Nguồn điện"
 msgid "View your battery status and change power saving settings"
 msgstr "Hiển thị trạng thái pin và thay đổi cài đặt chế độ tiết kiệm pin"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -4841,27 +2978,6 @@ msgstr ""
 "Power;Nguồn;Nguon;dien;Sleep;Ngủ;Ngu;Suspend;Ngưng;Ngung;Hibernate;Battery;"
 "Pin;Brightness;Sáng;sang;Dim;Tối;toi;Blank;Trắng;Trống;trong;trang;Monitor;"
 "Màn;Hình;man;hinh;DPMS;Idle;Rảnh;ranh;Energy;năng lượng;nang luong;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "Máy in “%s” đã bị xóa bỏ"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "Không thể thêm máy in mới."
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "Không thể tải giao diện: %s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "Mở khóa để Thêm máy in và thay đổi cài đặt"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4872,7 +2988,6 @@ msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
 "Thêm máy in, xem các công việc in và quyết định bạn muốn in như thế nào"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Máy;in;May;Queue;Print;In;Paper;Giấy;Giay;Ink;Mực;Muc;Toner;"
@@ -4880,92 +2995,69 @@ msgstr "Printer;Máy;in;May;Queue;Print;In;Paper;Giấy;Giay;Ink;Mực;Muc;Toner
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "Thêm máy in"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "_Mở khóa"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "Không tìm thấy máy in nào"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "Nhập địa chỉ mạng hoặc tìm kiếm máy in"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
 msgstr "Cần xác thực"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr "Nhận tên tài khoản và mật khẩu để xem các máy in trên Máy phục vụ in."
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "Tên người dùng"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "Chi tiết %s"
-
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "Không tìm thấy trình điều khiển phù hợp"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "Chọn tập tin PPD"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr ""
-"Tập tin PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
 
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "Vị trí"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "Trình điều khiển"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "Đang tìm trình điều khiển phù hợp…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
 msgstr "Tìm trình điều khiển"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "Chọn từ cơ sở dữ liệu…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "Cài đặt tập tin PPD…"
 
@@ -4977,131 +3069,19 @@ msgstr "Chọn trình điều khiển máy in"
 msgid "Loading drivers database…"
 msgstr "Đang tải cơ sở dữ liệu trình điều khiển…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "Thôi"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "Chọn"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "Máy in JetDirect"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "Máy in LPD"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "Một mặt"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "Cạnh dài (Tiêu chuẩn)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "Cạnh ngắn (lật)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "Dọc"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "Ngang"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "Ngang ngược"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "Dọc ngược"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "Đang chờ"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "Tạm dừng"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "Cần xác thực"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "Đang xử lý"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "Dừng"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "Thôi"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "Bị bãi bỏ"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "Hoàn tất"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "Di chuyển công việc này lên đỉnh của hàng đợi"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u nhiệm vụ in yêu cầu xác thực"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s - Yêu cầu in hoạt động"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "Nhập giấy ủy nhiệm để in từ %s."
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5110,339 +3090,35 @@ msgid "Domain"
 msgstr "Miền"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
 msgstr "_Xác thực"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "Dọn sạch"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
 msgstr "_Xác thực"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
 msgstr "Không có yêu cầu in nào hoạt động"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "Bỏ khóa Máy phục vụ in"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "Mở khóa %s."
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "Nhập tên tài khoản và mật khẩu để xem các máy in trên %s."
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "Tìm máy in"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "Cổng USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "Cổng nối tiếp"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "Cổng song song"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "Vị trí: %s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "Địa chỉ: %s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "Máy chủ yêu cầu xác thực"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "Hai mặt"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "Kiểu giấy"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "Nguồn giấy"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "Khay ra"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "Độ phân giải"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "Tiền lọc GhostScript"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "Trang mỗi mặt"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "Hai mặt"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "Hướng"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "Chung"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "Cài đặt giấy"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "Tùy chọn có thể cài"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "Yêu cầu"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "Chất lượng ảnh"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "Màu sắc"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "Hoàn tất"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "Nâng cao"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "Trang in thử"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "Trang in thử"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "Chọn tự động"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "Mặc định máy in"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "Chỉ phông GhostScript nhúng"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "Chuyển sang PS cấp 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "Chuyển sang PS cấp 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "Không tiền lọc"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "Nhà sản xuất"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "Yêu cầu in hoạt động"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u yêu cầu in"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "Lau đầu in"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "Sắp hết mực"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "Hết mực"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "Sắp hết thuốc hiện hình"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "Hết thuốc hiện hình"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "Sắp hết một ống mực"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "Một ống mực đã hết"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "Mở nắp"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "Mở cửa"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "Sắp hết giấy"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "Hết giấy"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "Ngoại tuyến"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "Dừng"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "Thùng chứa chất thải sắp đầy"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "Thùng chứa chất thải đã đầy"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "Trống quang máy in sắp quá tuổi thọ"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "Trống quang máy in không còn hoạt động được nữa"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "Sẵn sàng"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "Không chấp nhận lệnh in"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "Đang xử lý"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5466,41 +3142,45 @@ msgstr "Lau đầu in"
 msgid "Remove Printer"
 msgstr "Bỏ máy in"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Yêu cầu in hoạt động"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "Kiểu"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
 msgstr "Mức mực"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
 msgstr "Vui lòng khởi động lại khi trục trặc được giải quyết."
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "Khởi động lại"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "Thêm máy in…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "Thêm máy in…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "Không có máy in"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "Thêm máy in…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5508,50 +3188,33 @@ msgstr ""
 "Rất tiếc! Dịch vụ in hệ thống\n"
 "    hình như không sẵn sàng."
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "Định dạng"
-
-#: panels/region/cc-format-chooser.ui:37
-#: panels/wacom/cc-wacom-stylus-page.ui:136
-#: panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "Kế trước"
 
 #: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr "Tìm địa phương…"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "Định dạng chung"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "Mọi định dạng"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "Không tìm thấy kết quả nào"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "Các tìm kiếm có thể là nước hoặc ngôn ngữ."
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "Xem thử"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "Anh-Mỹ"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "Hệ mét"
 
 # Name: don't translate / Tên: đừng dịch
 #: panels/region/cc-format-preview.ui:17
@@ -5583,27 +3246,32 @@ msgid "Logout…"
 msgstr "Đăng xuất…"
 
 #: panels/region/cc-region-panel.ui:45
+#, fuzzy
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
 msgstr ""
 "Cài đặt ngôn ngữ để sử dụng cho chữ trong giao diện và các trang web. Định "
 "dạng dùng cho con số, ngày tháng, và tiền tệ."
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "Tài khoản của bạn"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "_Ngôn ngữ"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "Địn_h dạng"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "Màn hình đăng nhập"
 
@@ -5615,101 +3283,11 @@ msgstr "Lãnh thổ & ngôn ngữ"
 msgid "Select your display language and formats"
 msgstr "Chọn ngôn ngữ hiển thị, định dạng"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 "Language;Ngôn;ngữ;Ngon;ngu;Layout;Bố;trí;Bo;tri;Keyboard;Bàn;phím;Ban;phim;"
 "Kieu;go;Input;nhập;nhap;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "Hỏi cần phải làm gì"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "Không làm gì cả"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "Mở thư mục"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "Thiết bị lưu trữ khác"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "Chọn ứng dụng dành cho đĩa CD nhạc"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "Chọn ứng dụng cho DVD phim"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "Chọn ứng dụng cần chạy khi kết nối máy nghe nhạc"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "Chọn ứng dụng cần chạy khi kết nối máy ảnh, máy quay phim"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "Chọn ứng dụng cho CD phần mềm"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "DVD nhạc"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "đĩa Blu-ray trắng"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "đĩa CD trắng"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "đĩa DVD trắng"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "đĩa HD DVD trắng"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Đĩa phim Blu-ray"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "máy đọc e-book"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "Đĩa phim HD DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "CD hình"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "CD Siêu phim"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "CD Phim"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Phần mềm Windows"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -5761,7 +3339,6 @@ msgstr "Đa phương tiện"
 msgid "Configure Removable Media settings"
 msgstr "Cấu hình cho các cài đặt đĩa đa phương tiện"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5772,13 +3349,78 @@ msgstr ""
 "dvd;usb;audio;video;disc;đĩa;dia;removable;di động;di dong;media;đa phương "
 "tiện;da phuong tien;autorun;tự chạy;tu chay;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "_Chọn vị trí"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "Khóa màn hình"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "Đồn_g ý"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Tự động khóa màn hình để ngăn người khác truy cập vào máy tính trong khi bạn "
+"đi vắng."
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "Trễ tắt màn hình"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Chu kỳ không hoạt động mà sau đó màn hình sẽ tắt."
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "_Khóa màn hình tự động"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Trễ Khóa màn hình tự động"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Chu kỳ mà sau đó màn hình tắt khi màn hình được tự động khóa lại."
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "Thông báo trên màn hình _khóa"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Màn hình _khóa"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "Ngăn cản Thiết bị _USB mới"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "Ngăn các thiết bị USB mới tương tác với hệ thống khi màn hình bị khóa."
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Riêng tư"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Màn hình"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Chia sẻ màn hình"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5797,21 +3439,17 @@ msgstr ""
 msgid "Places"
 msgstr "Mở nhanh"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "Đánh dấu"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "Khác"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "Thêm địa điểm"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "Không tìm thấy ứng dụng"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5840,67 +3478,15 @@ msgstr ""
 "Điều chỉnh ứng dụng nào hiển thị kết quả tìm kiếm trong một “Tổng quan hoạt "
 "động”"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Search;Tìm;tim;Find;Index;Mục;lục;muc;luc;Hide;Ẩn;an;Privacy;Riêng;tư;rieng;"
 "tu;Results;Kết;quả;ket;qua;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "Chưa chọn mạng để chia sẻ"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "Mạng"
-
-#: panels/sharing/cc-sharing-panel.c:367
-msgctxt "service is enabled"
-msgid "On"
-msgstr "Bật"
-
-#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "Tắt"
-
-#: panels/sharing/cc-sharing-panel.c:399
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "Bật"
-
-#: panels/sharing/cc-sharing-panel.c:402
-msgctxt "service is active"
-msgid "Active"
-msgstr "Hoạt động"
-
-#: panels/sharing/cc-sharing-panel.c:520
-msgid "Choose a Folder"
-msgstr "Chọn thư mục"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:748
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr ""
-"Chia sẻ Tập tin cho phép bạn chia sẻ thư mục Công khai với những máy khác "
-"trong mạng hiện đang sử dụng: %s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:754
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"Khi đăng nhập từ xa được bật, những người dùng máy mạng có thể kết nối sử "
-"dụng lệnh “Secure Shell” (ssh):\n"
-"%s"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -5940,12 +3526,12 @@ msgstr "_Cần mật khẩu"
 msgid "Remote Login"
 msgstr "Đăng nhập từ xa"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "Điều khiển máy tính từ xa"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
@@ -5953,45 +3539,52 @@ msgstr ""
 "Điều khiển máy tính từ xa cho phép xem và điều khiển máy tính của bạn từ máy "
 "tính khác."
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
 msgstr "Bật hoặc tắt điều khiển máy tính từ xa cho máy tính này."
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
 msgstr "Điều khiển từ xa"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
 msgstr "Cho phép các kết nối điều khiển màn hinh."
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
 msgstr "Kết nối như thế nào"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
 msgstr ""
 "Kết nối đến máy tính này sử dụng tên thiết bị hoặc địa chỉ máy tính từ xa."
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "Sao chép"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "Địa chỉ máy tính điều khiển từ xa"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
 msgstr "Xác thực"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
 msgstr "Cần tài khoản và mật khẩu để kết nối đến máy tính này."
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "Tên người dùng"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "Xác thực mã hóa"
 
@@ -6000,9 +3593,10 @@ msgid "Encryption Fingerprint"
 msgstr "Vân tay mã hóa"
 
 #: panels/sharing/cc-sharing-panel.ui:435
+#, fuzzy
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
+"identical."
 msgstr ""
 "Dấu vân tay mã hóa có thể được thấy trong kết nối máy khách và nên là định "
 "danh duy nhất"
@@ -6024,7 +3618,6 @@ msgid "Control what you want to share with others"
 msgstr ""
 "Điều khiển việc bạn muôn chia sẻ những gì với các máy tính hay thiết bị khác"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6042,38 +3635,39 @@ msgstr "Bật hoặc tắt đăng nhập từ xa"
 msgid "Authentication is required to enable or disable remote login"
 msgstr "Cần xác thực để bật hoặc tắt đăng nhập từ xa"
 
-#: panels/sound/cc-alert-chooser.c:150
-msgid "Custom"
-msgstr "Tự chọn"
-
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "Chó sủa"
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "Giọt nước rơi"
+#, fuzzy
+msgid "String"
+msgstr "Chia sẻ"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "Thủy tinh"
+msgid "Swing"
+msgstr ""
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "Tiếng vọng tàu ngầm"
+msgid "Hum"
+msgstr ""
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "Cân bằng"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "Làm mờ dần"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
 msgstr "Đằng sau"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "Đằng trước"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "Đang kiểm tra “%s”"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6083,59 +3677,55 @@ msgstr "Nhấn vào “hình chiếc loa” để nghe thử"
 msgid "System Volume"
 msgstr "Âm lượng hệ thống"
 
-#: panels/sound/cc-sound-panel.ui:25
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "Âm lượng hệ thống"
+
+#: panels/sound/cc-sound-panel.ui:28
 msgid "Volume Levels"
 msgstr "Mức âm lượng"
 
 # Name: don't translate / Tên: đừng dịch
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "Đầu ra"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "Thiết bị xuất"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "Thử"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "Cấu hình"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "Cân bằng"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "Làm mờ dần"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "Siêu trầm"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "Đầu vào"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "Thiết bị đầu vào"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "Âm lượng"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
 msgstr "Âm thanh báo động"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
@@ -6145,7 +3735,6 @@ msgstr "Âm thanh"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "Thay đổi âm lượng, đầu vào/ra và âm thanh cảnh báo"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6153,168 +3742,60 @@ msgstr ""
 "Card;Cac;Microphone;Míc;Volume;Âm;lượng;Am;luong;thanh;Fade;Balance;Cân bằng;"
 "Can bang;Bluetooth;Headset;Audio;Tiếng;Tieng;Input;Đầu vào;dau vao;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "Đã ngắt kết nối"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "Đang kết nối"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "Đã kết nối"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "Lỗi xác thực"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "Xác thực"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "Tính năng bị Giảm bớt"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "Kết nối & Xác thực"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "Chưa biết"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "Được xác thực lúc:"
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "Được kết nối ở:"
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "Đăng ký vào:"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "Gặp lỗi khi xác thực thiết bị: "
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "Gặp lỗi khi quên thiết-bị: "
-
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] "Phụ thuộc vào %u thiết bị khác"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "Hiện thông báo hệ thống."
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Tên:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "Trạng thái:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID:"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
 msgstr "Ủy quyền và Kết nối"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
 msgstr "Quên thiết bị"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "Lỗi"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "Không hỗ trợ Thunderbolt"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "Xác thực"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Không thể kết nối đến hệ thống con thunderbolt."
 
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr ""
-"Hệ thống phụ Thunderbolt (boltd) chưa được cài đặt hoặc cài đặt chưa đúng."
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "Truy cập trực tiếp"
 
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
+#: panels/thunderbolt/cc-bolt-panel.ui:156
 msgid "Allow direct access to devices such as docks and external GPUs."
 msgstr ""
 "Cho phép truy cập trực tiếp vào các thiết bị như docks và GPU bên ngoài."
 
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "Chỉ có thể gắn các thiết bị USB và Display Port."
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"Thunderbolt không thể được phát hiện.\n"
-"Hoặc hệ thống thiếu hỗ trợ Thunderbolt, nó đã bị vô hiệu hóa trong BIOS hoặc "
-"được đặt ở mức bảo mật không được hỗ trợ trong BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Hỗ trợ Thunderbolt đã bị tắt trong BIOS."
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "Mức an ninh Thunderbolt không thể dò tìm thấy."
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "Lỗi chế độ chuyển trực tiếp: %s"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:103
-msgid "No Thunderbolt Support"
-msgstr "Không hỗ trợ Thunderbolt"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:104
-msgid "Could not connect to the thunderbolt subsystem."
-msgstr "Không thể kết nối đến hệ thống con thunderbolt."
-
-#: panels/thunderbolt/cc-bolt-panel.ui:153
-msgid "Direct Access"
-msgstr "Truy cập trực tiếp"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:225
+#: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
 msgstr "Thiết bị còn đợi"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "Chưa gắn thiết bị nào"
 
@@ -6326,7 +3807,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "Quản lý thiết bị Thunderbolt"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;riêng tư;rieng tu;"
@@ -6335,16 +3815,16 @@ msgstr "Thunderbolt;privacy;riêng tư;rieng tu;"
 msgid "Cursor Blinking"
 msgstr "Chớp nháy con trỏ"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
 msgstr "Chớp nháy con trỏ trong trường nhập văn bản."
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "Tốc độ"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "Tốc độ chớp con trỏ"
 
@@ -6430,15 +3910,15 @@ msgstr "Lớn"
 msgid "Repeat Keys"
 msgstr "Lặp phím"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
 msgstr "Phím nhấn được lặp lại khi được giữ nhấn xuống."
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "Độ trễ lặp phím"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "Tốc độ lặp"
 
@@ -6519,46 +3999,13 @@ msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "Lâu"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
 msgstr "_Bật bằng bàn phím"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "Bật các tính năng hỗ trợ bằng bàn phím"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "Mặc định"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "Trung bình"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "Lớn"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "Lớn hơn"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "Lớn nhất"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d điểm ảnh"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
@@ -6673,31 +4120,6 @@ msgstr "Nháy toàn _màn hình"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "Nháy toàn màn _hình"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "Ngắn"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ màn hình"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ màn hình"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ màn hình"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "Dài"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -6854,7 +4276,6 @@ msgstr "Hiệu ứng màu"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "Làm cho việc xem, nghe, gõ, di và bấm chuột trở nên dễ dàng hơn"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -6871,114 +4292,6 @@ msgstr ""
 "Tốc độ;Toc do;Assist;Trợ lý;Tro ly;Repeat;Lặp;Lap;Blink;Nháy;Nhay;visual;ảo;"
 "hearing;nghe;audio;Âm thanh;Am thanh;typing;gõ;go;animations;hoạt hình;hoat "
 "hinh;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 giờ"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 ngày"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 ngày"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 ngày"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 ngày"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 ngày"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 ngày"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 ngày"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 ngày"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 ngày"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "Bỏ mọi thứ trong thùng rác chứ?"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "Toàn bộ nội dung chứa trong Thùng rác sẽ bị xóa vĩnh viễn."
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "Đổ _rác"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "Xóa tất cả các tập tin tạm?"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "Toàn bộ các tập tin tạm sẽ bị xóa vĩnh viễn."
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "_Xóa tập tin tạm"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 ngày"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 ngày"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 ngày"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "Vô hạn"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7046,57 +4359,10 @@ msgstr "Lịch sử tập tin & Thùng rác"
 msgid "Don't leave traces"
 msgstr "Đừng để lại dấu vết"
 
-#. FIXME
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "Nên khớp với địa chỉ web của nhà cung cấp tài khoản cho bạn."
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "Gặp lỗi khi thêm tài khoản"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr "Mật khẩu không khớp nhau."
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "Gặp lỗi khi đăng ký tài khoản"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "Không có cách xác thực được hỗ trợ nào với miền này"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "Gặp lỗi khi gia nhập miền"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"Tên tài khoản đăng nhập đó không đúng.\n"
-"Vui lòng thử lại."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"Mật khẩu đăng nhập đó không đúng.\n"
-"Vui lòng thử lại."
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "Gặp lỗi khi đăng nhập miền"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "Không thể tìm thấy miền. Có lẽ bạn gõ sai chăng?"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7133,14 +4399,15 @@ msgid "Enterprise Login"
 msgstr "Đăng nhập kiểu công ty"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
+#, fuzzy
+msgid "User accounts which are managed by a company or organization."
 msgstr "Các tài khản người dùng cái mà được quản lý bởi công ty hay tổ chức."
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "Bạn đang Ngoại tuyến"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
@@ -7149,10 +4416,6 @@ msgstr ""
 "Đăng nhập theo cách doanh nghiệp cho phép các tài khoản người dùng được quản "
 "lý theo kiểu tập trung để sử dụng trên thiết bị này. Bạn có thể sử dụng tài "
 "khoản này để truy cập các nguồn tài nguyên của công ty trên mạng internet."
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "Duyệt thêm ảnh"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7166,15 +4429,15 @@ msgstr "Quản lý dấu vân tay"
 msgid "Fingerprint"
 msgstr "Vân tay"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "Khô_ng"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "_Có"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
@@ -7182,32 +4445,32 @@ msgstr ""
 "Bạn có muốn xóa các vân tay đã đăng ký để tắt chức năng đăng nhập bằng vân "
 "tay không?"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "Không có thiết bị đọc dấu vân tay"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "Không có thiết bị đọc dấu vân tay"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
 msgstr "Đảm bảo rằng các thiết bị được kết nối đúng."
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "Thiết bị đọc dấu vân tay"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
 msgstr "Chọn thiết bị đọc dấu vân tay bạn muốn cấu hình"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "Đăng nhập bằng vân tay"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
@@ -7215,435 +4478,106 @@ msgstr ""
 "Đăng nhập bằng vân tay cho phép bạn mở khóa và đăng nhập vào máy tính bằng "
 "ngón tay"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "_Xóa các vân tay"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
 msgstr "Đăng ký dấu vân tay"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "thiết bị cần để yêu cầu thực hiện thao tác này"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Bài trước"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "thiết bị này đang được dùng bởi một tiến trình khác"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "bạn không có đủ quyền hạn thực hiện thao tác"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "không có dấu tay nào được đăng ký"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "Không thể giao tiếp với thiết bị trong khi đăng ký"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "Gặp lỗi khi giao tiếp với bộ đọc dấu vân tay"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "Gặp lỗi khi giao tiếp với dịch vụ đọc dấu vân tay"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "Gặp lỗi khi liệt kê các dấu vân tay: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "Gặp lỗi khi xóa các dấu vân tay đã lưu: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "Ngón cái tay trái"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "Ngón giữa tay trái"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "Ngón trỏ _trái"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "Ngón đeo nhẫn tay trái"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "Ngón út tay trái"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "Ngón cái tay phải"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "Ngón giữa tay phải"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "Ngón trỏ _phải"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "Ngón đeo nhẫn tay phải"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "Ngón út tay phải"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "Ngón tay chưa biết"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "Hoàn thành"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "Thiết bị đọc dấu vân tay đã ngắt kết nối"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "Phần lưu trữ của thiết bị đọc dấu vân tay đã bị đầy"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "Gặp lỗi khi đăng ký dấu vân tay mới"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "Gặp lỗi khi bắt đầu đăng ký: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "Gặp lỗi khi đăng ký dấu vân tay mới"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "Gặp lỗi khi dừng đăng ký: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr ""
-"Liên tục nhấc và đặt ngón tay lên đầu đọc để đăng ký dấu vân tay của bạn"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "Đăng ký _lại ngón này…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "Quét dấu vân tay mới"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "Gặp lỗi giải phóng thiết bị đọc dấu vân tay %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "Lỗi đọc từ thiết bị"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "Gặp lỗi khi yêu cầu thiết bị đọc dấu vân tay %s: %s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "Gặp lỗi khi lấy các thiết vị đọc dấu vân tay: %s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "Tuần này"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "Tuần trước"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%e %b"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%e %b, %Y"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%2$s, %1$s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "Phiên đã chấm dứt"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "Phiên được bắt đầu"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s - Sự hoạt động của tài khoản"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "Vui lòng chọn mật khẩu khác."
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "Hãy gõ mật khẩu hiện tại một lần nữa."
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "Mật khẩu của bạn không thể bị thay đổi"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "Tiế_p"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "Đổi mật khẩu"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
 msgstr "Đổ_i"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
 msgstr "Mật khẩu hiện tại"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "Mật khẩu mới"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "Xác nhận mật khẩu mới"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "Mật khẩu không khớp nhau."
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "Cho phép người dùng thay đổi mật khẩu khi họ đăng nhập lần kế tiếp"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "Đặt mật khẩu mới ngay"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "Không thể tự động gia nhập kiểu miền này"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "Không tìm thấy miền hay địa hạt"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "Không thể đăng nhập là %s tại miền %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "Mật khẩu không đúng, vui lòng thử lại"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "Không thể kết nối đến miền %s: %s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "Gặp lỗi khi xóa người dùng"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "Gặp lỗi khi thu hồi quyền quản trị từ xa"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "Không thể xóa tài khoản của chính bạn."
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s vẫn đang đăng nhập"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "Xóa người dùng vẫn đang đăng nhập có thể gây bất ổn hệ thống."
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "Bạn có muốn giữ các tập tin của %s không?"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"Có thể giữ lại thư mục cá nhân, thư từ và tập tin tạm khi xóa tài khoản "
-"người dùng."
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "_Xóa tập tin"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "_Giữ tập tin"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "Bạn có chắc chắn muốn thu hồi tài khoản quản trị từ xa của %s không?"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "_Xóa"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "Tài khoản bị vô hiệu hóa"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "Cần đặt vào lần đăng nhập tiếp theo"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "Không có"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "Đang đăng nhập"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "Bật"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "Gặp lỗi khi liên lạc dịch vụ tài khoản (accountsservice)"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "Hãy kiểm tra xem AccountService có cài và được bật không."
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "Bảng này phải được bỏ khóa mới thay đổi được cài đặt này"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "Xóa tài khoản người dùng được chọn"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"Để xóa tài khoản người dùng được chọn,\n"
-"nhấn biểu tượng * trước"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "Mở khóa để Thêm người dùng và Thay đổi cài đặt"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "Người dùng"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
 msgstr ""
 "Phiên làm việc của bạn cần phải khởi động lại thì các thay đổi mới được áp "
 "dụng"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
 msgstr "Khởi động lại ngay"
 
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "Đóng"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "_Họ tên"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "Chỉnh sửa"
+
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "Đăng nhập bằng _vân tay"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "Đăng nhập _tự động"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "Sự hoạt động của tài khoản"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "_Quản trị"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
@@ -7651,32 +4585,32 @@ msgstr ""
 "Quản trị viên có thể thêm và loại bỏ người dùng khác và có thể thay đổi các "
 "cài đặt cho tất cả người dùng."
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "Điều khiển _cha mẹ"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "Mở ứng dụng dành cho cha mẹ quản lý con cái."
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "Gỡ bỏ người dùng…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "Người dùng khác"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "Thêm người dùng…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "Không tìm thấy người dùng nào"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
 msgstr "Mở khóa để thêm tài khoản người dùng mới."
 
@@ -7684,7 +4618,6 @@ msgstr "Mở khóa để thêm tài khoản người dùng mới."
 msgid "Add or remove users and change your password"
 msgstr "Thêm, xóa người dùng và thay đổi mật khẩu"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7729,174 +4662,8 @@ msgstr "Quản lý tài khoản người dùng"
 msgid "Authentication is required to change user data"
 msgstr "Cần xác thực để thay đổi dữ liệu người dùng"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "Mật khẩu mới cần phải khác với mật khẩu cũ."
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "Hãy thay đổi một số chữ cái và chữ số."
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "Hãy thay đổi mật khẩu một chút nữa."
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "Mật khẩu mạnh hơn nếu không chứa tên của bạn."
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "Không nên dùng tên của bạn làm mật khẩu."
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "Tránh sử dụng mật khẩu có chứa một số từ."
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "Không nên dùng các từ thông dụng."
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "Tránh đảo ngược thứ tự chữ cái của một từ cụ thể."
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "Hãy dùng nhiều chữ số hơn."
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "Hãy dùng thêm các chữ HOA."
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "Nên dùng nhiều chữ cái thường hơn."
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "Hãy dùng nhiều ký tự đặc biệt hơn nữa, như là dấu chấm câu chẳng hạn."
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "Hãy trộn lẫn chữ cái, chữ số và dấu chấm câu."
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "Tránh lặp lại cùng một ký tự."
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr ""
-"Không được lặp cùng một kiểu chữ: bạn cần trộn lẫn chữ cái, số và dấu chấm."
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "Hãy tránh sử dụng các chuỗi kế tiếp nhau như là 1234 hay abcd."
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr "Mật khẩu cần dài hơn. Hãy thêm chữ cái, chữ số và dấu chấm câu."
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "Trộn chữ cái HOA và thường cùng với một chữ số hoặc hai."
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "Thêm các chữ cái, chữ số và dấu chấm câu sẽ làm cho nó mạnh thêm."
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "Gặp lỗi khi xác thực"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "Mật khẩu quá ngắn"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "Mật khẩu quá đơn giản"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "Mật khẩu cũ và mật khẩu mới quá giống nhau"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "Mật khẩu mới đã được sử dụng gần đây."
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "Mật khẩu mới phải chứa ký tự số hay ký tự đặc biệt"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "Mật khẩu cũ và mật khẩu mới là một"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "Mật khẩu của bạn bị thay đổi kể từ khi bạn xác thực đầu tiên!"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "Mật khẩu mới phải chứa đủ các ký tự khác nhau"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "Lỗi chưa biết"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr ""
-"Tên tài khoản chỉ được phép chứa các chữ cái HOA/thường từ a-z, chữ số và "
-"các ký tự sau: “-” và “_”"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "Rất tiếc, tên tài khoản đó không sẵn sàng. Vui lòng thử cái khác."
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "Tên người dùng quá dài."
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "Ánh xạ nút"
 
@@ -7927,47 +4694,11 @@ msgstr ""
 msgid "Mis-click detected, restarting…"
 msgstr "Phát hiện ấn nhầm, đang khởi động lại…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "Nút %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "Ứng dụng đã định nghĩa"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "Gửi phím nhấn"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "Chuyển màn hình"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "Hiển thị Trợ giúp Trên-Màn-Hình"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "Bảng vẽ được gắn trên bảng máy tính xách tay"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "Bảng vẽ được gắn trên màn hình ngoài"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+#, fuzzy
+msgid "External pad device"
 msgstr "Thiết bị bảng bên ngoài"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "Mọi màn hình"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -7977,28 +4708,28 @@ msgstr "Chế độ máy tính bảng"
 msgid "Use absolute positioning for the pen"
 msgstr "Dùng vị trí tuyệt đối cho bút"
 
-#: panels/wacom/cc-wacom-page.ui:27
+#: panels/wacom/cc-wacom-page.ui:28
 msgid "Left Hand Orientation"
 msgstr "Hướng thuận tay trái"
 
-#: panels/wacom/cc-wacom-page.ui:28
+#: panels/wacom/cc-wacom-page.ui:29
 msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr "Bảng vẽ và Express Keys™ được xoay cho người sử dụng tay trái"
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
 msgstr "Ánh xạ sang màn hình"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "Giữ nguyên tỷ lệ"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
 msgstr "Chỉ dùng một vị trí của bề mặt bảng vẽ để giữ tỷ lệ hình dáng màn hình"
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "Cân chỉnh"
 
@@ -8023,6 +4754,11 @@ msgstr "Mềm"
 msgid "Stylus tip pressure"
 msgstr "Áp lực đầu bút vẽ"
 
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Cứng"
+
 #: panels/wacom/cc-wacom-stylus-page.ui:54
 msgctxt "display setting"
 msgid "Button 1"
@@ -8046,14 +4782,6 @@ msgstr "Cảm giác ấn tẩy"
 msgid "Eraser pressure"
 msgstr "Cảm biến ấn tẩy"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:102
-msgid "Firm"
-msgstr "Cứng"
-
-#: panels/wacom/cc-wacom-stylus-page.ui:133
-msgid "Default"
-msgstr "Mặc định"
-
 #: panels/wacom/cc-wacom-stylus-page.ui:134
 msgid "Middle Mouse Button Click"
 msgstr "Nhấn nút chuột giữa"
@@ -8066,22 +4794,6 @@ msgstr "Nhấn nút chuột phải"
 msgid "Forward"
 msgstr "Kế tiếp"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Bút vẽ tiêu chuẩn với áp lực, nghiêng và con trượt tích hợp"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Bút vẽ tiêu chuẩn với áp lực, nghiêng và xoay"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "Bút vẽ tiêu chuẩn với áp lực và nghiêng"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "Bút vẽ tiêu chuẩn với áp lực"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Bảng vẽ Wacom"
@@ -8090,56 +4802,98 @@ msgstr "Bảng vẽ Wacom"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "Đặt ảnh của nút và sửa kiểu dáng cho thích hợp dành cho bảng đồ họa"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 "Tablet;Bảng;bang;Wacom;Stylus;Bút;trỏ;but;tro;Eraser;Tẩy;Tay;Mouse;Chuột;"
 "Chuot;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "Phím tắt mới…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "Cú nhấn thứ hai mô _phỏng"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Phần mềm Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Sắp hết mực"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "Phụ"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Phần mềm Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "Quản lý các tùy chỉnh cho năng suất và đa nhiệm"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "Điểm truy cập"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Thêm"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Lưu"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "Thao tác bị hủy"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>Lỗi:</b> Truy nhập thay đổi cài đặt bị từ chối"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>Lỗi:</b> Lỗi thiết bị di động"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "Chưa đăng ký"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "Đã đăng ký"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "Chuyển vùng"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "Tìm kiếm"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "Bị từ chối"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8169,104 +4923,13 @@ msgstr "Số sở hữu"
 msgid "Device Details"
 msgstr "Chi tiết thiết bị"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Nhà sản xuất"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "Phiên bản Firmware"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "Chỉ 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "Chỉ 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "Chỉ 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G, 3G, 4G (Ưu tiên)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G, 3G (Ưu tiên), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (Ưu tiên), 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G, 3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G, 4G (Ưu tiên)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (Ưu tiên), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G, 4G (Ưu tiên)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (Ưu tiên), 4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G, 4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G, 3G (Ưu tiên)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (Ưu tiên), 3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G, 3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "Chưa biết"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "Mở khóa Thẻ SIM"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "Mở khóa"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "Vui lòng cung cấp mã PIN cho SIM %d"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "Nhập mã PIN để mở khóa thẻ SIM của bạn"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "Vui lòng cung cấp mã PUK cho sim %d"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "Nhập PUK để mở khóa thẻ SIM của bạn"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -8279,26 +4942,6 @@ msgstr[0] "Nhập sai mật khẩu. Bạn còn được thử %1$u lần nữa"
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "Bạn còn được thử %u lần nữa"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "Đã nhập vào sai mật khẩu."
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "Mã PUK phải là số có 8 chữ số"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "Nhập mã PIN mới"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "Mã PIN phải là số có 4-8 chữ số"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "Mở khoá…"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -8356,147 +4999,47 @@ msgstr "Khóa SIM với PIN"
 msgid "M_odem Details"
 msgstr "Chi tiết M_odem"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "Lỗi nghiêm trọng điện thoại"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "Không có kết nối đến điện thoại"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "Thao tác không được phép"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "Thao tác không được hỗ trợ"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "Chưa cài SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "Cần PIN của SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "Cần PUK của SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "Lỗi SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM bận"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "Mật khẩu không đúng"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "Cần PIN2 của SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "Cần PUK2 của SIM"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "Không tìm thấy"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "Không có dịch vụ mạng"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "Chờ mạng tối đa"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "Không có phép dịch vụ GPRS"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "Chuyển vùng không được phép ở khu vực vị trí này"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "Lỗi GPRS không xác định"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "Thao tác bị bãi bỏ"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "Truy cấp bị từ chối"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "Lỗi chưa biết"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "Chế độ mạng"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "Đặ_t"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "Đóng"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "_Tự động"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "Chọn mạng"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "Làm mới các nhà cung cấp mạng"
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "Cho phép dùng mạng di động"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "Không tìm bộ chuyển đổi WWAN nào"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
 msgstr "Hãy chắc chắn là bạn có thiết bị Wireless Wan/Cellular"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
 msgstr "Wireless Wan bị tắt khi chế độ máy bay được bật"
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "_Tắt chế độ máy bay"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
 msgstr "Kết nối dữ liệu"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "Thẻ SIM được dùng cho internet"
 
@@ -8508,15 +5051,15 @@ msgstr "Khóa SIM"
 msgid "_Next"
 msgstr "Tiế_p"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
 msgstr "_Khóa SIM với PIN"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
 msgstr "Đổi PIN"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
 msgstr "Nhập vào PIN hiện tại để thay đổi các cài đặt khóa SIM"
 
@@ -8528,8 +5071,6 @@ msgstr "Mạng di động"
 msgid "Configure Telephony and mobile data connections"
 msgstr "Cấu hình kết nối cho điện thoại và dữ liệu di động"
 
-#. FIXME
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;wwan;telephony;sim;mobile;di động;di dong;"
@@ -8546,37 +5087,14 @@ msgstr "Cài đặt là giao diện chính để cấu hình hệ thống của 
 msgid "The GNOME Project"
 msgstr "Dự án GNOME"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "Hiển thị số hiệu phiên bản"
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "Đang cài đặt trình điều khiển…"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "Bật chế độ chi tiết"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "Tìm chuỗi"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "Liệt kê các tên bảng điều khiển có thể rồi thoát"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "Khung hiển thị"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[BẢNG] [Đ.SỐ…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "Riêng tư"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "Bảng điều khiển hiện có:"
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8634,7 +5152,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "Ngừng tìm kiếm"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr ""
@@ -8676,25 +5193,2690 @@ msgstr ""
 "Bộ dữ liệu chứa chiều rộng, cao và trạng thái phóng to ban đầu của cửa sổ "
 "ứng dụng."
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u đầu ra"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u đầu vào"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "Âm thanh hệ thống"
+#~ msgid "System Bus"
+#~ msgstr "Bus hệ thống"
+
+#~ msgid "Full access"
+#~ msgstr "Truy cập đầy đủ"
+
+#~ msgid "Session Bus"
+#~ msgstr "Bus phiên làm việc"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "Truy cập đầy đủ vào /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "Có truy cập mạng"
+
+#~ msgid "Home"
+#~ msgstr "Thư mục riêng"
+
+#~ msgid "Read-only"
+#~ msgstr "Chỉ đọc"
+
+#~ msgid "File System"
+#~ msgstr "Hệ thống tập tin"
+
+#~ msgid "Can change settings"
+#~ msgstr "Không thể thay đổi các cài đặt"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s có các quyền sau được tích hợp sẵn. Chúng không thể thay đổi được. Nếu "
+#~ "bạn lo ngại về các quyền này, hãy cân nhắc loại bỏ ứng dụng này."
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u liên kết và tập tin cái mà được mở bởi ứng dụng"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> được sử dụng để mở các kiểu của tập tin và liên kết sau."
+
+#, c-format
+#~ msgid "%s of disk space used"
+#~ msgstr "%s đĩa đã được sử dụng"
+
+#~ msgid "Select a picture"
+#~ msgstr "Chọn một ảnh"
+
+#~ msgid "_Open"
+#~ msgstr "_Mở"
+
+#~ msgid "multiple sizes"
+#~ msgstr "nhiều kích cỡ"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "Không có ảnh nền"
+
+#~ msgid "Current background"
+#~ msgstr "Ảnh nền hiện tại"
+
+#~ msgid "Light"
+#~ msgstr "Sáng"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;màn;hình;man;hình;lock;khóa;khoa;diagnostics;chẩn;đoán;chan;doan;;"
+#~ "crash;hư;hu;private;riêng;tư;rieng;tu;recent;mới;dùng;moi;dung;gần;đây;"
+#~ "gan;day;temporary;tạm;tam;tmp;index;name;tên;ten;network;mạng;mang;"
+#~ "identity;thực;thể;thuc;the;"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr ""
+#~ "Đặt thiết bị cân chỉnh của bạn phía trên ô vuông rồi ấn nút “Bắt đầu”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr ""
+#~ "Di chuyển thiết bị cân chỉnh đến vị trí cân chỉnh rồi bấm nút “Tiếp tục”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr ""
+#~ "Di chuyển thiết bị cân chỉnh đến vị trí bề mặt rồi bấm nút “Tiếp tục”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "Tắt lid máy tính xách tay"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "Gặp lỗi nội bộ và không thể phục hồi."
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "Các công cụ cần thiết để cân chỉnh chưa được cài đặt."
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "Hồ sơ không thể được tạo ra."
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "Điểm trắng đích không thể thu được."
+
+#~ msgid "Complete!"
+#~ msgstr "Hoàn tất!"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "Cân chỉnh gặp lỗi!"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "Bạn có thể gỡ bỏ thiết bị cân chỉnh."
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "Đừng làm thiết bị cân chỉnh chạm vào màn hình khi đang chạy"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "Màn hình máy tính xách tay"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "Webcam tích hợp"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "Màn hình %s"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "Máy quét %s"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "Máy ảnh %s"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "Máy in %s"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "Webcam %s"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "Bật quản lý màu sắc cho %s"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "Hiển thị hồ sơ màu dành cho %s"
+
+#~ msgid "Not calibrated"
+#~ msgstr "Chưa cân chỉnh"
+
+#~ msgid "Default: "
+#~ msgstr "Mặc định: "
+
+#~ msgid "Colorspace: "
+#~ msgstr "Không gian màu: "
+
+#~ msgid "Test profile: "
+#~ msgstr "Hồ sơ thử: "
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "Chọn tập tin hồ sơ ICC"
+
+#~ msgid "_Import"
+#~ msgstr "_Nhập"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "Các hồ sơ ICC được hỗ trợ"
+
+#~ msgid "All files"
+#~ msgstr "Mọi tập tin"
+
+#~ msgid "Save Profile"
+#~ msgstr "Lưu hồ sơ"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "Tạo một hồ sơ màu cho thiết bị được chọn"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr ""
+#~ "Không tìm thấy thiết bị đo. Hãy kiểm tra xem nó đã được bật nguồn và cắm "
+#~ "cáp kết nối chưa."
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "Thiết bị đo không hỗ trợ tạo hồ sơ màu cho máy in."
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "Kiểu thiết bị này hiện chưa được hỗ trợ."
+
+#~ msgid "Standard Space"
+#~ msgstr "Không gian chuẩn"
+
+#~ msgid "Test Profile"
+#~ msgstr "Hồ sơ thử"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "Tự động"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "Chất lượng thấp"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "Chất lượng trung bình"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "Chất lượng cao"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "RGB mặc định"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "CMYK mặc định"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "Đen trắng mặc định"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "Dữ liệu nhà cung ứng thiết bị cân chỉnh"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "Hồ sơ này không được phép sửa chữa hiển thị toàn màn hình"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "Hồ sơ này có thể không còn chính xác"
+
+#~ msgid "Other…"
+#~ msgstr "Khác…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "Mở khóa để thay đổi cài đặt"
+
+#~ msgid "Today"
+#~ msgstr "Hôm nay"
+
+#~ msgid "Yesterday"
+#~ msgstr "Hôm qua"
+
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d giờ"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d phút"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d giây"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "Điểm truy cập"
+
+#~ msgid "24-hour"
+#~ msgstr "24-giờ"
+
+#~ msgid "AM / PM"
+#~ msgstr "SA / CH"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%l:%M %p, %e %b %Y"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%R, %e %B %Y"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s, %s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%l:%M %p"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "Gửi báo cáo các trục trặc kỹ thuật để giúp chúng tôi cải tiến %s. Báo cáo "
+#~ "được gửi nặc danh và được xóa các dữ liệu cá nhân. %s"
+
+#~ msgid "On"
+#~ msgstr "Bật"
+
+#~ msgid "Off"
+#~ msgstr "Tắt"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "Áp dụng thay đổi?"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "Thay đổi không thể áp dụng được"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "Việc này có thể là do giới hạn phần cứng."
+
+#~ msgid "Display Arrangement"
+#~ msgstr "Sắp xếp màn hình"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "Nằm ngang"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "Dọc (quay phải)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "Dọc (quay trái)"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "Nằm gang (lật ngược)"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Unknown"
+#~ msgstr "Chưa biết"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64-bít"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32-bít"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "Chưa biết"
+
+#~ msgid "System Logo"
+#~ msgstr "Logo hệ thống"
+
+#~ msgid "No input sources found"
+#~ msgstr "Không tìm thấy nguồn nhập liệu"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "Khác"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "Phím tắt tự chọn"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "Phím ký tự thay thế có thể được sử dụng để nhập các ký tự bổ sung. Đôi "
+#~ "khi chúng được in dưới dạng tùy chọn thứ ba trên bàn phím của bạn."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "Alt trái"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "Alt phải"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "Phím Win trái"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "Phím Win phải"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "Phím trình đơn"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "Ctrl phải"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Phím tổ hợp cho phép nhập nhiều ký tự khác nhau. Để sử dụng nó, nhấn "
+#~ "compose sau đó một chuỗi các ký tự. Ví dụ: phím compose tiếp theo là "
+#~ "<b>C</b> và <b>o</b> sẽ nhập <b>©</b>, <b>a</b> tiếp theo là <b>'</b> sẽ "
+#~ "nhập <b>á</b>."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "Nuồn nhập liệu bạn có thể thay đổi sử dụng phím tắt %s\n"
+#~ "Cái này có thể được thay đổi trong cài đặt phím tắt."
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "%d mục bị sửa đổi"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "Đặt lại toàn bộ phím tắt chứ?"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr ""
+#~ "Việc đặt lại phím tắt có thể ảnh hưởng đến các phím tắt tự chọn của bạn. "
+#~ "Hành động này không thể hoàn lại được."
+
+#~ msgid "Reset All"
+#~ msgstr "Đặt lại tất cả"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s đang được sử dụng cho %s. Nếu bạn thay thế nó, %s sẽ bị tắt"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "Gõ phím tắt mới"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "Đặt phím tắt tự chọn"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "Đặt phím tắt"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "Gõ phím tắt mới để thay đổi %s."
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "Thêm phím tắt tự chọn"
+
+#~ msgid "Set"
+#~ msgstr "Đặt"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "Màn hình tắt"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 giây"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 phút"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 phút"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 phút"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 phút"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 phút"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 giờ"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 phút"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 phút"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 phút"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 phút"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 phút"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 phút"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 phút"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 phút"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 phút"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "Không bao giờ"
+
+#~ msgid "Lock your screen"
+#~ msgstr "Khóa màn hình của bạn"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "Cuộn hai-ngón"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "Bấm năm lần, sự kiện GEGL!"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "Bấm đúp, nút chính"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "Bấm đơn, nút chính"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "Bấm đúp, nút giữa"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "Bấm đơn, nút giữa"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "Bấm đúp, nút phụ"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "Bấm đơn, nút phụ"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "Trình quản lý kết nối mạng cần phải đang chạy."
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "Mạng không an toàn (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "Mạng an toàn (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "Mạng an toàn (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "Mạng an toàn (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "Mạng an toàn"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr ""
+#~ "Bật điểm phát sóng sẽ ngắt kết nối khỏi %s và sẽ không thể truy cập "
+#~ "internet thông qua Wi-Fi."
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "Mật khẩu phải dài ít nhất 8 ký tự"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr ""
+#~ "Bạn có muốn dừng điểm truy cập này và ngắt kết nối những người đang sử "
+#~ "dụng?"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "_Dừng điểm truy cập"
+
+#~ msgid "Preserve"
+#~ msgstr "Giữ nguyên"
+
+#~ msgid "Permanent"
+#~ msgstr "Vĩnh viễn"
+
+#~ msgid "Random"
+#~ msgstr "Ngẫn nhiên"
+
+#~ msgid "Stable"
+#~ msgstr "Ổn định"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "Địa chỉ MAC được nhập ở đây sẽ được dùng làm địa chỉ phần cứng cho thiết "
+#~ "bị mạng được kết nối này dùng. Tính năng này còn được biết là MAC nhân "
+#~ "bản hay MAC giả. Ví dụ: 00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "Hồ sơ %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "Doanh nghiệp"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "Không"
+
+#~ msgid "Never"
+#~ msgstr "Không bao giờ"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "Không có"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "Yếu"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "Ok"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "Tốt"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "Tuyệt hảo"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "Quên kết nối"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "Xóa bỏ Hồ sơ Kết nối"
+
+#~ msgid "Remove VPN"
+#~ msgstr "Xóa VPN"
+
+#~ msgid "Details"
+#~ msgstr "Chi tiết"
+
+#~ msgid "automatic"
+#~ msgstr "tự động"
+
+#~ msgid "Identity"
+#~ msgstr "Thực thể"
+
+#~ msgid "Delete Address"
+#~ msgstr "Xóa địa chỉ"
+
+#~ msgid "Delete Route"
+#~ msgstr "Xóa định tuyến"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "Không"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "Khóa WEP 40/128-bit (thập lục phân hoặc ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "Mật khẩu WEP 128-bit"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "WEP động (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 Cá nhân"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 Doanh nghiệp"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 Cá nhân"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "Không thể mở cửa sổ điều chỉnh kết nối"
+
+#~ msgid "New Profile"
+#~ msgstr "Hồ sơ mới"
+
+#~ msgid "Import from file…"
+#~ msgstr "Nhập từ tập tin…"
+
+#~ msgid "Add VPN"
+#~ msgstr "Thêm VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "Không thể nhập kết nối VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Tập tin “%s” không thể đọc được hay nó chứa thông tin kết nối VPN không "
+#~ "được chấp nhận\n"
+#~ "\n"
+#~ "Lỗi: %s."
+
+#~ msgid "Select file to import"
+#~ msgstr "Chọn tập tin cần nhập"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "Đã có tập tin tên “%s” rồi."
+
+#~ msgid "_Replace"
+#~ msgstr "_Thay thế"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "Bạn có muốn thay thế %s bằng kết nối này?"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "Không thể xuất kết nối VPN"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "Kết nối VPN “%s” không thể xuất ra %s.\n"
+#~ "\n"
+#~ "Lỗi: %s."
+
+#~ msgid "Export VPN connection"
+#~ msgstr "Xuất kết nối VPN"
+
+#~ msgid "never"
+#~ msgstr "không bao giờ"
+
+#~ msgid "today"
+#~ msgstr "hôm nay"
+
+#~ msgid "yesterday"
+#~ msgstr "hôm qua"
+
+#~ msgid "Last used"
+#~ msgstr "Dùng lần cuối"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr ""
+#~ "Sẽ mất chi tiết của những mạng được chọn, bao gồm mật khẩu và các cài đặt "
+#~ "tùy biến khác."
+
+#~ msgid "_Forget"
+#~ msgstr "_Quên"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "Mạng đã biết Wi-Fi"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "_Quên"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr ""
+#~ "Chính sách của hệ thống cấm chỉ dùng máy tính này như một Hotspot (Điểm "
+#~ "tập trung để máy khác truy cập mạng)"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "Thiết bị không dây không hỗ trợ chế độ điểm truy cập"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr ""
+#~ "Dùng Tự động phát hiện ủy nhiệm Web nếu không cung cấp URL cấu hình."
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "Không khuyến khích đối với mạng công cộng không đáng tin."
+
+#~ msgid "Status unknown"
+#~ msgstr "Tình trạng không rõ"
+
+#~ msgid "Unmanaged"
+#~ msgstr "Chưa được quản lý"
+
+#~ msgid "Unavailable"
+#~ msgstr "Không sẵn sàng"
+
+#~ msgid "Connecting"
+#~ msgstr "Đang kết nối"
+
+#~ msgid "Authentication required"
+#~ msgstr "Cần xác thực"
+
+#~ msgid "Disconnecting"
+#~ msgstr "Đang ngắt kết nối"
+
+#~ msgid "Connection failed"
+#~ msgstr "Kết nối gặp lỗi"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "Tình trạng không rõ (thiếu)"
+
+#~ msgid "Configuration failed"
+#~ msgstr "Cấu hình gặp lỗi"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "Cấu hình IP gặp lỗi"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "Hết hạn cấu hình IP"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "Cần bí mật nhưng chưa được cung cấp"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x supplicant ngắt kết nối"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "Lỗi cấu hình 802.1x supplicant"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "Lỗi 802.1x supplicant"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant tốn quá nhiều thời gian để xác thực"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "Gặp lỗi khi khởi động dịch vụ PPP"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "Dịch vụ PPP bị ngắt"
+
+# Name: don't translate / Tên: đừng dịch
+#~ msgid "PPP failed"
+#~ msgstr "PPP bị lỗi"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "Lỗi khởi động trình khách DHCP"
+
+#~ msgid "DHCP client error"
+#~ msgstr "Lỗi trình khách DHCP"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "Lỗi trình khách DHCP"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "Lỗi khởi động dịch vụ kết nối chia sẻ"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "Lỗi dịch vụ kết nối chia sẻ"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "Lỗi khởi động dịch vụ AutoIP"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "Lỗi dịch vụ AutoIP"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "Dịch vụ AutoIP gặp lỗi"
+
+#~ msgid "Line busy"
+#~ msgstr "Đường dây bận"
+
+#~ msgid "No dial tone"
+#~ msgstr "Không có tông"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "Không thể cài đặt carrier"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "Hết hạn yêu cầu quay số"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "Lỗi quay số"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "Lỗi khởi động Modem"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "Lỗi chọn APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "Không tìm thấy mạng"
+
+#~ msgid "Network registration denied"
+#~ msgstr "Đăng ký mạng bị từ chối"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "Hết hạn đăng ký mạng"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "Lỗi đăng ký mạng yêu cầu"
+
+#~ msgid "PIN check failed"
+#~ msgstr "Gặp lỗi khi kiểm tra PIN"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "Có lẽ thiếu firmware cho thiết bị"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "Kết nối bị biến mất"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "Ngầm định kết nối đã tồn tại"
+
+#~ msgid "Modem not found"
+#~ msgstr "Không tìm thấy Modem"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "Gặp lỗi khi kết nối Bluetooth"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "Chưa cài SIM"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "Cần Pin của SIM"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "Cần Puk của SIM"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM không đúng"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "Lỗi phụ thuộc kết nối"
+
+#~ msgid "Firmware missing"
+#~ msgstr "Thiếu firmware"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "Chưa cắm dây"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "lỗi chưa biết trong an ninh 802.1X (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "chưa chọn tập tin"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "lỗi chưa định nghĩa khi xác thực lại tập tin eap-method"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+#~ msgstr "Khóa riêng DER, PEM, hay PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "Giấy phép DER hay PEM (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "thiếu tập tin EAP-FAST"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "Tập tin PAC (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "thiếu tên tài khoản EAP-LEAP"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "thiếu mật khẩu EAP-LEAP"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "giấy chứng nhận CA EAP-PEAP không hợp lệ: %s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "giấy chứng nhận CA EAP-PEAP không hợp lệ: chưa chỉ định giấy chứng nhận"
+
+#~ msgid "missing EAP username"
+#~ msgstr "thiếu tên tài khoản EAP"
+
+#~ msgid "missing EAP password"
+#~ msgstr "thiếu mật khẩu EAP"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "sai định danh EAP-TLS"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "giấy chứng nhận CA EAP-TLS không hợp lệ: %s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "giấy chứng nhận CA EAP-TLS không hợp lệ: chưa chỉ định giấy chứng nhận"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "khóa riêng EAP-TLS không hợp lệ: %s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "giấy chứng nhận người dùng EAP-TLS không hợp lệ: %s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "Khóa riêng mà không được mã hóa là không an toàn"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "Khóa riêng đã chọn không được bảo vệ bằng mật khẩu. Điều đó làm giảm bớt "
+#~ "mức độ an toàn của hệ thống. Hãy đặt mật khẩu để bảo vệ khóa riêng.\n"
+#~ "\n"
+#~ "(Bạn có thể bảo vệ khóa riêng bằng mật khẩu với openssl)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "Chọn chứng nhận cá nhân của bạn"
+
+#~ msgid "Choose your private key"
+#~ msgstr "Chọn khóa riêng của bạn"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "giấy chứng nhận CA EAP-TTLS không hợp lệ: %s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr ""
+#~ "giấy chứng nhận CA EAP-TTLS không hợp lệ: chưa chỉ định giấy chứng nhận"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "Lỗi thẩm tra an ninh 802.1X chưa biết"
+
+#~ msgid "Select a file"
+#~ msgstr "Chọn một tập tin"
+
+#~ msgid "missing leap-username"
+#~ msgstr "thiếu leap-username"
+
+#~ msgid "missing leap-password"
+#~ msgstr "thiếu leap-password"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Thiếu mật khẩu Wi-Fi."
+
+#~ msgid "missing wep-key"
+#~ msgstr "thiếu wep-key"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr ""
+#~ "wep-key không hợp lệ: khóa phải có chiều dài của %zu phải chỉ chứa chữ số "
+#~ "thập lục"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr ""
+#~ "wep-key không hợp lệ: khóa phải có chiều dài của %zu phải chỉ chứa các ký "
+#~ "tự ascii"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "wep-key không hợp lệ: khóa phải có chiều dài của %zu. Một khóa phải hoặc "
+#~ "là có chiều dài 5/4 (ascii) hoặc là 10/26 (chữ số thập lục)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "wep-key không hợp lệ: mật khẩu phải không rỗng"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "wep-key không hợp lệ: mật khẩu phải ngắn hơn 64 ký tự"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "wpa-psk không hợp lệ: chiều dài khóa %zu không hợp lệ. Phải là [8,63] bye "
+#~ "hoặc 64 số thập lục"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr ""
+#~ "wpa-psk không hợp lệ: không thể phiên dịch khóa với 64 bye như là số thập "
+#~ "lục"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s đã bị gỡ bỏ"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "Khác"
+
+#~ msgid "Error removing account"
+#~ msgstr "Không thể xóa tài khoản"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "Tài khoản %s"
+
+#~ msgid "Remove Account"
+#~ msgstr "Xóa tài khoản"
+
+#~ msgid "Unknown time"
+#~ msgstr "Thời gian không rõ"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s đến khi sạc đầy"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "Cảnh báo: còn %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "còn %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "Đã sạc đầy"
+
+#~ msgid "Not charging"
+#~ msgstr "Không sạc"
+
+#~ msgid "Empty"
+#~ msgstr "Rỗng"
+
+#~ msgid "Charging"
+#~ msgstr "Đang sạc"
+
+#~ msgid "Discharging"
+#~ msgstr "Đang xả"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "Chuột không dây"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "Bàn phím không dây"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "Nguồn không ngắt"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "Trợ lý điện tử cá nhân"
+
+#~ msgid "Cellphone"
+#~ msgstr "Điện thoại di động"
+
+#~ msgid "Media player"
+#~ msgstr "Phát đa phương tiện"
+
+#~ msgid "Tablet"
+#~ msgstr "Máy tính bảng"
+
+#~ msgid "Computer"
+#~ msgstr "Máy tính"
+
+#~ msgid "Gaming input device"
+#~ msgstr "Thiết bị chơi game"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "Chính"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "Phụ"
+
+#~ msgid "Batteries"
+#~ msgstr "Pin"
+
+#~ msgid "When _idle"
+#~ msgstr "Kh_i nghỉ"
+
+#~ msgid "Suspend"
+#~ msgstr "Tạm ngưng"
+
+#~ msgid "Power Off"
+#~ msgstr "Tắt máy"
+
+#~ msgid "Hibernate"
+#~ msgstr "Ngủ đông"
+
+#~ msgid "Nothing"
+#~ msgstr "Không gì"
+
+#~ msgid "When on battery power"
+#~ msgstr "Khi sử dụng nguồn pin"
+
+#~ msgid "When plugged in"
+#~ msgstr "Khi cắm dây nguồn"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "Không bao giờ"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "Tự động ngưng"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "Chế độ năng suất tạm thời bị tắt bởi vì nhiệt độ của hoạt dộng cao."
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "Dò thấy máy tính đang để trên đùi: chế độ năng suất hiện tạm thời không "
+#~ "sẵn sàng. Hãy chuyển thiết bị đến mặt phẳng ổn định hơn để phục hồi lại."
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "Tạm thời tắt chế độ năng suất."
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "Sắp hết pin: nên chế độ tiết kiệm điện được bật. Chế độ dùng trước đây sẽ "
+#~ "được dùng lại khi pin đã được sạc đủ dùng."
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "Chế độ tiết kiệm điện được kích hoạt bởi “%s”."
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "Chế độ năng suất được kích hoạt bởi “%s”."
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "Hiệu suất"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "Hiệu năng cao và tiêu dùng nhiều năng lượng."
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "Cân bằng"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "Hiệu suất và tiêu dùng điện năng tiêu chuẩn."
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "Tiết kiệm năng lượng"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "Giảm hiệu năng và tiêu dùng ít năng lượng."
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "Máy in “%s” đã bị xóa bỏ"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "Không thể thêm máy in mới."
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "Không thể tải giao diện: %s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "Mở khóa để Thêm máy in và thay đổi cài đặt"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "Chi tiết %s"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "Không tìm thấy trình điều khiển phù hợp"
+
+#~ msgid "Select PPD File"
+#~ msgstr "Chọn tập tin PPD"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "Tập tin PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, "
+#~ "*.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "Máy in JetDirect"
+
+#~ msgid "LPD Printer"
+#~ msgstr "Máy in LPD"
+
+#~ msgid "One Sided"
+#~ msgstr "Một mặt"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "Cạnh dài (Tiêu chuẩn)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "Cạnh ngắn (lật)"
+
+#~ msgid "Portrait"
+#~ msgstr "Dọc"
+
+#~ msgid "Landscape"
+#~ msgstr "Ngang"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "Ngang ngược"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "Dọc ngược"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "Đang chờ"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "Tạm dừng"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "Cần xác thực"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "Đang xử lý"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "Dừng"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "Thôi"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "Bị bãi bỏ"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "Hoàn tất"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "Di chuyển công việc này lên đỉnh của hàng đợi"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s - Yêu cầu in hoạt động"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "Nhập giấy ủy nhiệm để in từ %s."
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "Bỏ khóa Máy phục vụ in"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "Mở khóa %s."
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "Nhập tên tài khoản và mật khẩu để xem các máy in trên %s."
+
+#~ msgid "Searching for Printers"
+#~ msgstr "Tìm máy in"
+
+#~ msgid "USB"
+#~ msgstr "Cổng USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "Cổng nối tiếp"
+
+#~ msgid "Parallel Port"
+#~ msgstr "Cổng song song"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "Vị trí: %s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "Địa chỉ: %s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "Máy chủ yêu cầu xác thực"
+
+#~ msgid "Two Sided"
+#~ msgstr "Hai mặt"
+
+#~ msgid "Paper Type"
+#~ msgstr "Kiểu giấy"
+
+#~ msgid "Paper Source"
+#~ msgstr "Nguồn giấy"
+
+#~ msgid "Output Tray"
+#~ msgstr "Khay ra"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "Độ phân giải"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "Tiền lọc GhostScript"
+
+#~ msgid "Pages per side"
+#~ msgstr "Trang mỗi mặt"
+
+#~ msgid "Orientation"
+#~ msgstr "Hướng"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "Chung"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "Cài đặt giấy"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "Tùy chọn có thể cài"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "Yêu cầu"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "Chất lượng ảnh"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "Màu sắc"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "Hoàn tất"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "Nâng cao"
+
+#~ msgid "Test page"
+#~ msgstr "Trang in thử"
+
+#~ msgid "Auto Select"
+#~ msgstr "Chọn tự động"
+
+#~ msgid "Printer Default"
+#~ msgstr "Mặc định máy in"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "Chỉ phông GhostScript nhúng"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "Chuyển sang PS cấp 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "Chuyển sang PS cấp 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "Không tiền lọc"
+
+#~ msgid "Clean print heads"
+#~ msgstr "Lau đầu in"
+
+#~ msgid "Out of toner"
+#~ msgstr "Hết mực"
+
+#~ msgid "Low on developer"
+#~ msgstr "Sắp hết thuốc hiện hình"
+
+#~ msgid "Out of developer"
+#~ msgstr "Hết thuốc hiện hình"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "Sắp hết một ống mực"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "Một ống mực đã hết"
+
+#~ msgid "Open cover"
+#~ msgstr "Mở nắp"
+
+#~ msgid "Open door"
+#~ msgstr "Mở cửa"
+
+#~ msgid "Low on paper"
+#~ msgstr "Sắp hết giấy"
+
+#~ msgid "Out of paper"
+#~ msgstr "Hết giấy"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "Ngoại tuyến"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "Dừng"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "Thùng chứa chất thải sắp đầy"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "Thùng chứa chất thải đã đầy"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "Trống quang máy in sắp quá tuổi thọ"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "Trống quang máy in không còn hoạt động được nữa"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "Sẵn sàng"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "Không chấp nhận lệnh in"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "Đang xử lý"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "Anh-Mỹ"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "Hệ mét"
+
+#~ msgid "Ask what to do"
+#~ msgstr "Hỏi cần phải làm gì"
+
+#~ msgid "Do nothing"
+#~ msgstr "Không làm gì cả"
+
+#~ msgid "Open folder"
+#~ msgstr "Mở thư mục"
+
+#~ msgid "Other Media"
+#~ msgstr "Thiết bị lưu trữ khác"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "Chọn ứng dụng dành cho đĩa CD nhạc"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "Chọn ứng dụng cho DVD phim"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "Chọn ứng dụng cần chạy khi kết nối máy nghe nhạc"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "Chọn ứng dụng cần chạy khi kết nối máy ảnh, máy quay phim"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "Chọn ứng dụng cho CD phần mềm"
+
+#~ msgid "audio DVD"
+#~ msgstr "DVD nhạc"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "đĩa Blu-ray trắng"
+
+#~ msgid "blank CD disc"
+#~ msgstr "đĩa CD trắng"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "đĩa DVD trắng"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "đĩa HD DVD trắng"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Đĩa phim Blu-ray"
+
+#~ msgid "e-book reader"
+#~ msgstr "máy đọc e-book"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "Đĩa phim HD DVD"
+
+#~ msgid "Picture CD"
+#~ msgstr "CD hình"
+
+#~ msgid "Super Video CD"
+#~ msgstr "CD Siêu phim"
+
+#~ msgid "Video CD"
+#~ msgstr "CD Phim"
+
+#~ msgid "Select Location"
+#~ msgstr "_Chọn vị trí"
+
+#~ msgid "_OK"
+#~ msgstr "Đồn_g ý"
+
+#~ msgid "No applications found"
+#~ msgstr "Không tìm thấy ứng dụng"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "Chưa chọn mạng để chia sẻ"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "Bật"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "Tắt"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "Bật"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "Chọn thư mục"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr ""
+#~ "Chia sẻ Tập tin cho phép bạn chia sẻ thư mục Công khai với những máy khác "
+#~ "trong mạng hiện đang sử dụng: %s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Khi đăng nhập từ xa được bật, những người dùng máy mạng có thể kết nối sử "
+#~ "dụng lệnh “Secure Shell” (ssh):\n"
+#~ "%s"
+
+#~ msgid "Custom"
+#~ msgstr "Tự chọn"
+
+#~ msgid "Bark"
+#~ msgstr "Chó sủa"
+
+#~ msgid "Drip"
+#~ msgstr "Giọt nước rơi"
+
+#~ msgid "Glass"
+#~ msgstr "Thủy tinh"
+
+#~ msgid "Sonar"
+#~ msgstr "Tiếng vọng tàu ngầm"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "Đang kiểm tra “%s”"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "Đã ngắt kết nối"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "Đang kết nối"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "Đã kết nối"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "Lỗi xác thực"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "Xác thực"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "Tính năng bị Giảm bớt"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "Kết nối & Xác thực"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "Chưa biết"
+
+#~ msgid "Authorized at:"
+#~ msgstr "Được xác thực lúc:"
+
+#~ msgid "Connected at:"
+#~ msgstr "Được kết nối ở:"
+
+#~ msgid "Enrolled at:"
+#~ msgstr "Đăng ký vào:"
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "Gặp lỗi khi xác thực thiết bị: "
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "Gặp lỗi khi quên thiết-bị: "
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "Lỗi"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "Xác thực"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr ""
+#~ "Hệ thống phụ Thunderbolt (boltd) chưa được cài đặt hoặc cài đặt chưa đúng."
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "Chỉ có thể gắn các thiết bị USB và Display Port."
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "Thunderbolt không thể được phát hiện.\n"
+#~ "Hoặc hệ thống thiếu hỗ trợ Thunderbolt, nó đã bị vô hiệu hóa trong BIOS "
+#~ "hoặc được đặt ở mức bảo mật không được hỗ trợ trong BIOS."
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Hỗ trợ Thunderbolt đã bị tắt trong BIOS."
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "Mức an ninh Thunderbolt không thể dò tìm thấy."
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "Lỗi chế độ chuyển trực tiếp: %s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "Mặc định"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "Trung bình"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "Lớn"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "Lớn hơn"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "Lớn nhất"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d điểm ảnh"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "Ngắn"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ màn hình"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ màn hình"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ màn hình"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "Dài"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 giờ"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 ngày"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 ngày"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 ngày"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 ngày"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 ngày"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 ngày"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 ngày"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 ngày"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 ngày"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "Bỏ mọi thứ trong thùng rác chứ?"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "Toàn bộ nội dung chứa trong Thùng rác sẽ bị xóa vĩnh viễn."
+
+#~ msgid "_Empty Trash"
+#~ msgstr "Đổ _rác"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "Xóa tất cả các tập tin tạm?"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "Toàn bộ các tập tin tạm sẽ bị xóa vĩnh viễn."
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "_Xóa tập tin tạm"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 ngày"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 ngày"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 ngày"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "Vô hạn"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "Nên khớp với địa chỉ web của nhà cung cấp tài khoản cho bạn."
+
+#~ msgid "Failed to add account"
+#~ msgstr "Gặp lỗi khi thêm tài khoản"
+
+#~ msgid "Failed to register account"
+#~ msgstr "Gặp lỗi khi đăng ký tài khoản"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "Không có cách xác thực được hỗ trợ nào với miền này"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "Gặp lỗi khi gia nhập miền"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Tên tài khoản đăng nhập đó không đúng.\n"
+#~ "Vui lòng thử lại."
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Mật khẩu đăng nhập đó không đúng.\n"
+#~ "Vui lòng thử lại."
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "Gặp lỗi khi đăng nhập miền"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "Không thể tìm thấy miền. Có lẽ bạn gõ sai chăng?"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "Duyệt thêm ảnh"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "thiết bị cần để yêu cầu thực hiện thao tác này"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "thiết bị này đang được dùng bởi một tiến trình khác"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "bạn không có đủ quyền hạn thực hiện thao tác"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "không có dấu tay nào được đăng ký"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "Không thể giao tiếp với thiết bị trong khi đăng ký"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "Gặp lỗi khi giao tiếp với bộ đọc dấu vân tay"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "Gặp lỗi khi giao tiếp với dịch vụ đọc dấu vân tay"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "Gặp lỗi khi liệt kê các dấu vân tay: %s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "Gặp lỗi khi xóa các dấu vân tay đã lưu: %s"
+
+#~ msgid "Left thumb"
+#~ msgstr "Ngón cái tay trái"
+
+#~ msgid "Left middle finger"
+#~ msgstr "Ngón giữa tay trái"
+
+#~ msgid "_Left index finger"
+#~ msgstr "Ngón trỏ _trái"
+
+#~ msgid "Left ring finger"
+#~ msgstr "Ngón đeo nhẫn tay trái"
+
+#~ msgid "Left little finger"
+#~ msgstr "Ngón út tay trái"
+
+#~ msgid "Right thumb"
+#~ msgstr "Ngón cái tay phải"
+
+#~ msgid "Right middle finger"
+#~ msgstr "Ngón giữa tay phải"
+
+#~ msgid "_Right index finger"
+#~ msgstr "Ngón trỏ _phải"
+
+#~ msgid "Right ring finger"
+#~ msgstr "Ngón đeo nhẫn tay phải"
+
+#~ msgid "Right little finger"
+#~ msgstr "Ngón út tay phải"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "Ngón tay chưa biết"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "Hoàn thành"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "Thiết bị đọc dấu vân tay đã ngắt kết nối"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "Phần lưu trữ của thiết bị đọc dấu vân tay đã bị đầy"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Gặp lỗi khi đăng ký dấu vân tay mới"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "Gặp lỗi khi bắt đầu đăng ký: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "Gặp lỗi khi đăng ký dấu vân tay mới"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "Gặp lỗi khi dừng đăng ký: %s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr ""
+#~ "Liên tục nhấc và đặt ngón tay lên đầu đọc để đăng ký dấu vân tay của bạn"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "Đăng ký _lại ngón này…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "Quét dấu vân tay mới"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "Gặp lỗi giải phóng thiết bị đọc dấu vân tay %s: %s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "Lỗi đọc từ thiết bị"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "Gặp lỗi khi yêu cầu thiết bị đọc dấu vân tay %s: %s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "Gặp lỗi khi lấy các thiết vị đọc dấu vân tay: %s"
+
+#~ msgid "This Week"
+#~ msgstr "Tuần này"
+
+#~ msgid "Last Week"
+#~ msgstr "Tuần trước"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%e %b"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%e %b, %Y"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%2$s, %1$s"
+
+#~ msgid "Session Ended"
+#~ msgstr "Phiên đã chấm dứt"
+
+#~ msgid "Session Started"
+#~ msgstr "Phiên được bắt đầu"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s - Sự hoạt động của tài khoản"
+
+#~ msgid "Please choose another password."
+#~ msgstr "Vui lòng chọn mật khẩu khác."
+
+#~ msgid "Please type your current password again."
+#~ msgstr "Hãy gõ mật khẩu hiện tại một lần nữa."
+
+#~ msgid "Password could not be changed"
+#~ msgstr "Mật khẩu của bạn không thể bị thay đổi"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "Không thể tự động gia nhập kiểu miền này"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "Không tìm thấy miền hay địa hạt"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "Không thể đăng nhập là %s tại miền %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "Mật khẩu không đúng, vui lòng thử lại"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "Không thể kết nối đến miền %s: %s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "Gặp lỗi khi xóa người dùng"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "Gặp lỗi khi thu hồi quyền quản trị từ xa"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "Không thể xóa tài khoản của chính bạn."
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s vẫn đang đăng nhập"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "Xóa người dùng vẫn đang đăng nhập có thể gây bất ổn hệ thống."
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "Bạn có muốn giữ các tập tin của %s không?"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr ""
+#~ "Có thể giữ lại thư mục cá nhân, thư từ và tập tin tạm khi xóa tài khoản "
+#~ "người dùng."
+
+#~ msgid "_Delete Files"
+#~ msgstr "_Xóa tập tin"
+
+#~ msgid "_Keep Files"
+#~ msgstr "_Giữ tập tin"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr ""
+#~ "Bạn có chắc chắn muốn thu hồi tài khoản quản trị từ xa của %s không?"
+
+#~ msgid "_Delete"
+#~ msgstr "_Xóa"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "Tài khoản bị vô hiệu hóa"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "Cần đặt vào lần đăng nhập tiếp theo"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "Không có"
+
+#~ msgid "Logged in"
+#~ msgstr "Đang đăng nhập"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "Gặp lỗi khi liên lạc dịch vụ tài khoản (accountsservice)"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "Hãy kiểm tra xem AccountService có cài và được bật không."
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "Bảng này phải được bỏ khóa mới thay đổi được cài đặt này"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "Xóa tài khoản người dùng được chọn"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Để xóa tài khoản người dùng được chọn,\n"
+#~ "nhấn biểu tượng * trước"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "Mở khóa để Thêm người dùng và Thay đổi cài đặt"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "Mật khẩu mới cần phải khác với mật khẩu cũ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "Hãy thay đổi một số chữ cái và chữ số."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "Hãy thay đổi mật khẩu một chút nữa."
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "Mật khẩu mạnh hơn nếu không chứa tên của bạn."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "Không nên dùng tên của bạn làm mật khẩu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "Tránh sử dụng mật khẩu có chứa một số từ."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "Không nên dùng các từ thông dụng."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "Tránh đảo ngược thứ tự chữ cái của một từ cụ thể."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "Hãy dùng nhiều chữ số hơn."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "Hãy dùng thêm các chữ HOA."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "Nên dùng nhiều chữ cái thường hơn."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr ""
+#~ "Hãy dùng nhiều ký tự đặc biệt hơn nữa, như là dấu chấm câu chẳng hạn."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "Hãy trộn lẫn chữ cái, chữ số và dấu chấm câu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "Tránh lặp lại cùng một ký tự."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "Không được lặp cùng một kiểu chữ: bạn cần trộn lẫn chữ cái, số và dấu "
+#~ "chấm."
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "Hãy tránh sử dụng các chuỗi kế tiếp nhau như là 1234 hay abcd."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr "Mật khẩu cần dài hơn. Hãy thêm chữ cái, chữ số và dấu chấm câu."
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "Trộn chữ cái HOA và thường cùng với một chữ số hoặc hai."
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "Thêm các chữ cái, chữ số và dấu chấm câu sẽ làm cho nó mạnh thêm."
+
+#~ msgid "Authentication failed"
+#~ msgstr "Gặp lỗi khi xác thực"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "Mật khẩu quá ngắn"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "Mật khẩu quá đơn giản"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "Mật khẩu cũ và mật khẩu mới quá giống nhau"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "Mật khẩu mới đã được sử dụng gần đây."
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "Mật khẩu mới phải chứa ký tự số hay ký tự đặc biệt"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "Mật khẩu cũ và mật khẩu mới là một"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "Mật khẩu của bạn bị thay đổi kể từ khi bạn xác thực đầu tiên!"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "Mật khẩu mới phải chứa đủ các ký tự khác nhau"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "Lỗi chưa biết"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr ""
+#~ "Tên tài khoản chỉ được phép chứa các chữ cái HOA/thường từ a-z, chữ số và "
+#~ "các ký tự sau: “-” và “_”"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "Rất tiếc, tên tài khoản đó không sẵn sàng. Vui lòng thử cái khác."
+
+#~ msgid "The username is too long."
+#~ msgstr "Tên người dùng quá dài."
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "Nút %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "Ứng dụng đã định nghĩa"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "Gửi phím nhấn"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "Chuyển màn hình"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "Hiển thị Trợ giúp Trên-Màn-Hình"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "Bảng vẽ được gắn trên bảng máy tính xách tay"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "Bảng vẽ được gắn trên màn hình ngoài"
+
+#~ msgid "All Displays"
+#~ msgstr "Mọi màn hình"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Bút vẽ tiêu chuẩn với áp lực, nghiêng và con trượt tích hợp"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Bút vẽ tiêu chuẩn với áp lực, nghiêng và xoay"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "Bút vẽ tiêu chuẩn với áp lực và nghiêng"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "Bút vẽ tiêu chuẩn với áp lực"
+
+#~ msgid "New shortcut…"
+#~ msgstr "Phím tắt mới…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "Thao tác bị hủy"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>Lỗi:</b> Truy nhập thay đổi cài đặt bị từ chối"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>Lỗi:</b> Lỗi thiết bị di động"
+
+#~ msgid "Not Registered"
+#~ msgstr "Chưa đăng ký"
+
+#~ msgid "Registered"
+#~ msgstr "Đã đăng ký"
+
+#~ msgid "Roaming"
+#~ msgstr "Chuyển vùng"
+
+#~ msgid "Searching"
+#~ msgstr "Tìm kiếm"
+
+#~ msgid "Denied"
+#~ msgstr "Bị từ chối"
+
+#~ msgid "2G Only"
+#~ msgstr "Chỉ 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "Chỉ 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "Chỉ 4G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G, 3G, 4G (Ưu tiên)"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G, 3G (Ưu tiên), 4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G (Ưu tiên), 3G, 4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G, 3G, 4G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G, 4G (Ưu tiên)"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G (Ưu tiên), 4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G, 4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G, 4G (Ưu tiên)"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G (Ưu tiên), 4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G, 4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G, 3G (Ưu tiên)"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G (Ưu tiên), 3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G, 3G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "Chưa biết"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "Mở khóa Thẻ SIM"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "Vui lòng cung cấp mã PIN cho SIM %d"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "Nhập mã PIN để mở khóa thẻ SIM của bạn"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "Vui lòng cung cấp mã PUK cho sim %d"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "Nhập PUK để mở khóa thẻ SIM của bạn"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "Đã nhập vào sai mật khẩu."
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "Mã PUK phải là số có 8 chữ số"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "Nhập mã PIN mới"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "Mã PIN phải là số có 4-8 chữ số"
+
+#~ msgid "Unlocking…"
+#~ msgstr "Mở khoá…"
+
+#~ msgid "Phone failure"
+#~ msgstr "Lỗi nghiêm trọng điện thoại"
+
+#~ msgid "No connection to phone"
+#~ msgstr "Không có kết nối đến điện thoại"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "Thao tác không được phép"
+
+#~ msgid "Operation not supported"
+#~ msgstr "Thao tác không được hỗ trợ"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "Chưa cài SIM"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "Cần PIN của SIM"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "Cần PUK của SIM"
+
+#~ msgid "SIM failure"
+#~ msgstr "Lỗi SIM"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM bận"
+
+#~ msgid "Incorrect password"
+#~ msgstr "Mật khẩu không đúng"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "Cần PIN2 của SIM"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "Cần PUK2 của SIM"
+
+#~ msgid "Not found"
+#~ msgstr "Không tìm thấy"
+
+#~ msgid "No network service"
+#~ msgstr "Không có dịch vụ mạng"
+
+#~ msgid "Network timeout"
+#~ msgstr "Chờ mạng tối đa"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "Không có phép dịch vụ GPRS"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "Chuyển vùng không được phép ở khu vực vị trí này"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "Lỗi GPRS không xác định"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "Thao tác bị bãi bỏ"
+
+#~ msgid "Access denied"
+#~ msgstr "Truy cấp bị từ chối"
+
+#~ msgid "Unknown Error"
+#~ msgstr "Lỗi chưa biết"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "Hiển thị số hiệu phiên bản"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "Bật chế độ chi tiết"
+
+#~ msgid "Search for the string"
+#~ msgstr "Tìm chuỗi"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "Liệt kê các tên bảng điều khiển có thể rồi thoát"
+
+#~ msgid "Panel to display"
+#~ msgstr "Khung hiển thị"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[BẢNG] [Đ.SỐ…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "Bảng điều khiển hiện có:"
+
+#~ msgid "System Sounds"
+#~ msgstr "Âm thanh hệ thống"
 
 #~ msgid "Web Links"
 #~ msgstr "Liên kết trang thông tin điện tử"
@@ -8750,8 +7932,8 @@ msgstr "Âm thanh hệ thống"
 #~ msgstr "Không thể thay đổi"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr ""
 #~ "Bạn có thể xem xét các quyền riêng lẻ cho các ứng dụng trong Cài đặt <a "
 #~ "href=\"privacy\">quyền riêng tư</a>."
@@ -8839,9 +8021,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "Less Warm"
 #~ msgstr "Ít ấm hơn"
-
-#~ msgid "Screenshots"
-#~ msgstr "Chụp màn hình"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "Chụp màn hình vào $PICTURES"
@@ -8958,17 +8137,11 @@ msgstr "Âm thanh hệ thống"
 #~ "Chia sẻ màn hình cho phép người từ xa có thể xem, điều khiển màn hình của "
 #~ "bạn bằng cách kết nối đến %s"
 
-#~ msgid "Copy"
-#~ msgstr "Sao chép"
-
 #~ msgid "_Screen Sharing"
 #~ msgstr "Chia sẻ _màn hình"
 
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr "Một số dịch vụ bị tắt bởi vì không truy cập được mạng."
-
-#~ msgid "Screen Sharing"
-#~ msgstr "Chia sẻ màn hình"
 
 #~ msgid "_Password:"
 #~ msgstr "_Mật khẩu:"
@@ -8993,9 +8166,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "_Screen Reader"
 #~ msgstr "Bộ đọc _màn hình"
-
-#~ msgid "_Full Name"
-#~ msgstr "_Họ tên"
 
 #~ msgid "Standard"
 #~ msgstr "Tiêu chuẩn"
@@ -9059,9 +8229,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "Bảng vẽ (tuyệt đối)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "Touchpad (tương đối)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "Cá nhân hóa bảng vẽ"
@@ -9162,9 +8329,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "Changes throughout the day"
 #~ msgstr "Thay đổi liên tục trong ngày"
-
-#~ msgid "_Lock Screen"
-#~ msgstr "Màn hình _khóa"
 
 #~ msgctxt "background, style"
 #~ msgid "Tile"
@@ -9765,9 +8929,6 @@ msgstr "Âm thanh hệ thống"
 #~ msgid "Co­lor"
 #~ msgstr "Màu"
 
-#~ msgid "Section"
-#~ msgstr "Phần"
-
 #~ msgid "Overview"
 #~ msgstr "Tổng quan"
 
@@ -9826,9 +8987,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "Mirrored"
 #~ msgstr "Hiển thị giống nhau"
-
-#~ msgid "Secondary"
-#~ msgstr "Phụ"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "Sắp xếp màn hình hiển thị tổ hợp"
@@ -9903,9 +9061,6 @@ msgstr "Âm thanh hệ thống"
 #~ msgid "Automatic"
 #~ msgstr "Tự động"
 
-#~ msgid "_Method"
-#~ msgstr "_Phương thức"
-
 #~ msgid "Group Name"
 #~ msgstr "Tên nhóm"
 
@@ -9973,9 +9128,6 @@ msgstr "Âm thanh hệ thống"
 #~ msgid "4"
 #~ msgstr "4"
 
-#~ msgid "Loading options…"
-#~ msgstr "Tùy chọn tải…"
-
 #~ msgctxt "Password hint"
 #~ msgid "Try to add more letters, numbers and symbols."
 #~ msgstr "Hãy thử thêm các chữ cái, chữ số và ký hiệu."
@@ -10000,9 +9152,6 @@ msgstr "Âm thanh hệ thống"
 #~ msgid "Strength: High"
 #~ msgstr "Mức an toàn: Cao"
 
-#~ msgid "Edit"
-#~ msgstr "Chỉnh sửa"
-
 #~ msgctxt "button"
 #~ msgid "Set Shortcut"
 #~ msgstr "Đặt phím tắt"
@@ -10019,9 +9168,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "Mail"
 #~ msgstr "Thư điện tử"
-
-#~ msgid "Calendar"
-#~ msgstr "Lịch"
 
 #~ msgid "Contacts"
 #~ msgstr "Danh bạ"
@@ -10040,9 +9186,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "Hành động này không xóa tài khoản trên máy chủ."
-
-#~ msgid "_Remove"
-#~ msgstr "_Xóa"
 
 #~ msgid "No online accounts configured"
 #~ msgstr "Chưa cấu hình tài khoản trực tuyến"
@@ -10083,9 +9226,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "label"
 #~ msgstr "nhãn"
-
-#~ msgid "Setting new driver…"
-#~ msgstr "Đang cài đặt trình điều khiển…"
 
 #~ msgid "Print _Test Page"
 #~ msgstr "_In thử"
@@ -10161,9 +9301,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "Scroll Up"
 #~ msgstr "Cuộn lên"
-
-#~ msgid "Scroll Down"
-#~ msgstr "Cuộn xuống"
 
 #~ msgid "Scroll Right"
 #~ msgstr "Cuộn sang phải"
@@ -10416,9 +9553,6 @@ msgstr "Âm thanh hệ thống"
 #~ msgid "Used to determine your geographical location"
 #~ msgstr "Dùng để nhận dạng vị trí địa lý của bạn"
 
-#~ msgid "Options"
-#~ msgstr "Tùy chọn"
-
 #~ msgid "Password:"
 #~ msgstr "Mật khẩu:"
 
@@ -10461,9 +9595,6 @@ msgstr "Âm thanh hệ thống"
 #~ msgid "Turns off wireless devices"
 #~ msgstr "Tắt thiết bị wireless (không dây)"
 
-#~ msgid "Disable while _typing"
-#~ msgstr "_Tắt khi đang gõ"
-
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "Dịch vụ mạng hệ thống không tương thích với phiên bản này."
 
@@ -10486,9 +9617,6 @@ msgstr "Âm thanh hệ thống"
 
 #~ msgid "Sorry"
 #~ msgstr "Xin lỗi"
-
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "Cài đặt thiết bị mới"

--- a/po/vi.po~
+++ b/po/vi.po~
@@ -1,0 +1,10494 @@
+# Vietnamese Translation for GNOME Control Center.
+# Bản dịch tiếng Việt dành cho GNOME Control Center.
+# Copyright © 2016 Free Software Foundation, Inc.
+# This file is distributed under the same license as the gnome-control-center package.
+# Nguyễn Thái Ngọc Duy <pclouds@gmail.com>, 2004,2007,2010-2013.
+# Clytie Siddall <clytie@riverland.net.au>, 2005-2009.
+# Ngô Chin <ndtrung4419@gmail.com>, 2011.
+# Trần Ngọc Quân <vnwildman@gmail.com>, 2013-2018, 2021-2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-04-23 00:38+0000\n"
+"PO-Revision-Date: 2022-04-23 08:12+0700\n"
+"Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
+"Language-Team: Vietnamese <gnome-vi-list@gnome.org>\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Gtranslator 3.38.0\n"
+
+#: panels/applications/cc-applications-panel.c:803
+msgid "System Bus"
+msgstr "Bus hệ thống"
+
+#: panels/applications/cc-applications-panel.c:803
+#: panels/applications/cc-applications-panel.c:805
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:823
+msgid "Full access"
+msgstr "Truy cập đầy đủ"
+
+#: panels/applications/cc-applications-panel.c:805
+msgid "Session Bus"
+msgstr "Bus phiên làm việc"
+
+#: panels/applications/cc-applications-panel.c:809
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
+#: panels/thunderbolt/cc-bolt-panel.ui:310
+msgid "Devices"
+msgstr "Thiết bị"
+
+#: panels/applications/cc-applications-panel.c:809
+msgid "Full access to /dev"
+msgstr "Truy cập đầy đủ vào /dev"
+
+#: panels/applications/cc-applications-panel.c:813
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "Mạng"
+
+#: panels/applications/cc-applications-panel.c:813
+msgid "Has network access"
+msgstr "Có truy cập mạng"
+
+#: panels/applications/cc-applications-panel.c:818
+#: panels/applications/cc-applications-panel.c:820
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "Thư mục riêng"
+
+#: panels/applications/cc-applications-panel.c:820
+#: panels/applications/cc-applications-panel.c:825
+msgid "Read-only"
+msgstr "Chỉ đọc"
+
+#: panels/applications/cc-applications-panel.c:823
+#: panels/applications/cc-applications-panel.c:825
+msgid "File System"
+msgstr "Hệ thống tập tin"
+
+#: panels/applications/cc-applications-panel.c:829
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:878 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "Cài đặt"
+
+#: panels/applications/cc-applications-panel.c:829
+msgid "Can change settings"
+msgstr "Không thể thay đổi các cài đặt"
+
+#: panels/applications/cc-applications-panel.c:831
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s có các quyền sau được tích hợp sẵn. Chúng không thể thay đổi được. Nếu "
+"bạn lo ngại về các quyền này, hãy cân nhắc loại bỏ ứng dụng này."
+
+#: panels/applications/cc-applications-panel.c:1164
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u liên kết và tập tin cái mà được mở bởi ứng dụng"
+
+#: panels/applications/cc-applications-panel.c:1171
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> được sử dụng để mở các kiểu của tập tin và liên kết sau."
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1223
+#, c-format
+msgid "%s of disk space used"
+msgstr "%s đĩa đã được sử dụng"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1387
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "Ứng dụng"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "Không có ứng dụng nào"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "Cài đặt một số…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "Mở"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "Hiện chi tiết"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Tìm kiếm"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "Để hệ thống tìm kiếm và gửi kết quả."
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:156
+#: panels/applications/cc-applications-panel.ui:177
+#: panels/applications/cc-applications-panel.ui:191
+#: panels/applications/cc-applications-panel.ui:205
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
+#: panels/user-accounts/cc-user-panel.c:789
+#: panels/user-accounts/cc-user-panel.c:879
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "Tắt"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "Thông báo"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "Hiện thông báo hệ thống."
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in background"
+msgstr "Chạy dưới nền hệ thống"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "Cho phép hoạt động khi ứng dụng đã bị đóng lại."
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Change Wallpaper"
+msgstr "Đổi hình nền"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Change the desktop wallpaper."
+msgstr "Đổi hình nền trên màn hình máy tính để bàn."
+
+#: panels/applications/cc-applications-panel.ui:147
+#: panels/applications/cc-applications-panel.ui:154
+msgid "Sounds"
+msgstr "Âm thanh"
+
+#: panels/applications/cc-applications-panel.ui:148
+#: panels/applications/cc-applications-panel.ui:155
+msgid "Reproduce sounds."
+msgstr "Tái sinh âm thanh."
+
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Inhibit Shortcuts"
+msgstr "Chặn phím tắt"
+
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Block standard keyboard shortcuts."
+msgstr "Ngăn cản phím tắt bàn phím tiêu chuẩn."
+
+#: panels/applications/cc-applications-panel.ui:168
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "Máy ảnh"
+
+#: panels/applications/cc-applications-panel.ui:169
+#: panels/applications/cc-applications-panel.ui:176
+msgid "Take pictures with the camera."
+msgstr "Chụp ảnh bằng máy ảnh."
+
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "Micrô"
+
+#: panels/applications/cc-applications-panel.ui:183
+#: panels/applications/cc-applications-panel.ui:190
+msgid "Record audio with the microphone."
+msgstr "Ghi âm với míc."
+
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "Dịch vụ vị trí"
+
+#: panels/applications/cc-applications-panel.ui:197
+#: panels/applications/cc-applications-panel.ui:204
+msgid "Access device location data."
+msgstr "Truy cập dữ liệu vị trí thiết bị."
+
+#: panels/applications/cc-applications-panel.ui:215
+#: panels/applications/cc-applications-panel.ui:319
+msgid "Built-in Permissions"
+msgstr "Quyền tích-hợp"
+
+#: panels/applications/cc-applications-panel.ui:216
+msgid "System access that is required by the app"
+msgstr "Ứng dụng yêu cầu truy cập hệ thống"
+
+#: panels/applications/cc-applications-panel.ui:224
+msgid "File &amp; Link Associations"
+msgstr "Kết hợp Tập tin &amp; Liên kết"
+
+#: panels/applications/cc-applications-panel.ui:232
+#: panels/applications/cc-applications-panel.ui:399
+msgid "Storage"
+msgstr "Lưu trữ"
+
+#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+msgid "No results found"
+msgstr "Không tìm thấy kết quả nào"
+
+#: panels/applications/cc-applications-panel.ui:304
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
+#: shell/cc-panel-list.ui:114
+msgid "Try a different search"
+msgstr "Thử tìm kiếm khác"
+
+#: panels/applications/cc-applications-panel.ui:344
+msgid "File & Link Associations"
+msgstr "Kết hợp Tập tin & Liên kết"
+
+#: panels/applications/cc-applications-panel.ui:367
+msgid "File Types"
+msgstr "Kiểu tập tin"
+
+#: panels/applications/cc-applications-panel.ui:373
+msgid "Link Types"
+msgstr "Kiểu liên kết"
+
+#: panels/applications/cc-applications-panel.ui:383
+msgid "Reset"
+msgstr "Đặt lại"
+
+#: panels/applications/cc-applications-panel.ui:410
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+"Ứng dụng này chiếm bao nhiêu dung lượng đĩa với dữ liệu ứng dụng và bộ nhớ "
+"cache."
+
+#: panels/applications/cc-applications-panel.ui:413
+msgid "Application"
+msgstr "Ứng dụng"
+
+#: panels/applications/cc-applications-panel.ui:419
+msgid "Data"
+msgstr "Dữ liệu"
+
+#: panels/applications/cc-applications-panel.ui:425
+msgid "Cache"
+msgstr "Bộ nhớ đệm"
+
+#: panels/applications/cc-applications-panel.ui:431
+msgid "<b>Total</b>"
+msgstr "<b>Tổng</b>"
+
+#: panels/applications/cc-applications-panel.ui:441
+msgid "Clear Cache…"
+msgstr "Xóa bộ nhớ truy cập nhanh…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "Điều khiển các phân quyền và cài đặt của ứng dụng nhiều thứ khác nhau"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"application;flatpak;permission;setting;ứng dụng;ung dung;quyền;quyen;cài đặt;"
+"cai dat;"
+
+#: panels/background/cc-background-chooser.c:307
+msgid "Select a picture"
+msgstr "Chọn một ảnh"
+
+#: panels/background/cc-background-chooser.c:310
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:198
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/network/cc-wifi-hotspot-dialog.ui:123
+#: panels/network/cc-wifi-panel.c:881
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:860
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:263
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:523 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:18
+#: panels/user-accounts/cc-user-panel.c:579
+#: panels/user-accounts/cc-user-panel.c:597
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:139
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
+msgid "_Cancel"
+msgstr "T_hôi"
+
+#: panels/background/cc-background-chooser.c:311
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:264
+#: panels/sharing/cc-sharing-panel.c:524
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "_Mở"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "nhiều kích cỡ"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "Không có ảnh nền"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "Ảnh nền hiện tại"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "Kiểu"
+
+#: panels/background/cc-background-panel.ui:45
+msgid "Light"
+msgstr "Sáng"
+
+#: panels/background/cc-background-panel.ui:72
+msgid "Dark"
+msgstr "Tối"
+
+#: panels/background/cc-background-panel.ui:91
+msgid "Background"
+msgstr "Màu nền"
+
+#: panels/background/cc-background-panel.ui:97
+msgid "Add Picture…"
+msgstr "Thêm ảnh chụp…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "Diện mạo"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "Thay đổi ảnh nền màn hình hay màu UI của bạn"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgstr ""
+"Background;Wallpaper;Ảnh;nền;Anh;nen;Screen;Màn;hình;Man;hinh;Desktop;Style;"
+"Light;Dark;Sáng;Sang;Tối;Toi;Kiểu;Kieu;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:21
+msgid "No Bluetooth Found"
+msgstr "Không tìm thấy Bluetooth nào"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:22
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "Cắm thiết bị để dùng Bluetooth."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:28
+msgid "Bluetooth Turned Off"
+msgstr "Bluetooth bị tắt"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:29
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "Bật để kết nối các thiết bị và nhận các tập tin được truyền."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:35
+msgid "Airplane Mode is On"
+msgstr "Chế độ máy bay đang bật"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:36
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "Bluetooth bị tắt khi chế độ máy bay được bật."
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Turn Off Airplane Mode"
+msgstr "Tắt chế độ máy bay"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:53
+msgid "Hardware Airplane Mode is On"
+msgstr "Chế độ máy bay phần cứng được bật"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:54
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "Tắt chế độ máy bay chuyển sang bật Bluetooth."
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "Bật/tắt Bluetooth và kết nối các thiết bị của bạn"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;chia sẻ;chia se;sharing;bluetooth;obex;"
+
+#: panels/camera/cc-camera-panel.ui:21
+msgid "Camera is Turned Off"
+msgstr "Máy ảnh bị tắt"
+
+#: panels/camera/cc-camera-panel.ui:22
+msgid "No applications can capture photos or video."
+msgstr "Không có ứng dụng nào có thể chụp ảnh hoặc quay phim."
+
+#: panels/camera/cc-camera-panel.ui:36
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"Sử dụng máy ảnh cho phép các ứng dụng chụp ảnh và quay phim. Vô hiệu hóa máy "
+"ảnh có thể khiến một số ứng dụng không hoạt động bình thường.\n"
+"\n"
+"Cho phép các ứng dụng dưới đây sử dụng máy ảnh của bạn."
+
+#: panels/camera/cc-camera-panel.ui:52
+msgid "No Applications Have Asked for Camera Access"
+msgstr "Không có ứng dụng nào yêu cầu truy cập máy ảnh"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "Bảo vệ các ảnh của bạn"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr ""
+"screen;màn;hình;man;hình;lock;khóa;khoa;diagnostics;chẩn;đoán;chan;doan;;"
+"crash;hư;hu;private;riêng;tư;rieng;tu;recent;mới;dùng;moi;dung;gần;đây;gan;"
+"day;temporary;tạm;tam;tmp;index;name;tên;ten;network;mạng;mang;identity;thực;"
+"thể;thuc;the;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "Đặt thiết bị cân chỉnh của bạn phía trên ô vuông rồi ấn nút “Bắt đầu”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr ""
+"Di chuyển thiết bị cân chỉnh đến vị trí cân chỉnh rồi bấm nút “Tiếp tục”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "Di chuyển thiết bị cân chỉnh đến vị trí bề mặt rồi bấm nút “Tiếp tục”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "Tắt lid máy tính xách tay"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "Gặp lỗi nội bộ và không thể phục hồi."
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "Các công cụ cần thiết để cân chỉnh chưa được cài đặt."
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "Hồ sơ không thể được tạo ra."
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "Điểm trắng đích không thể thu được."
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "Hoàn tất!"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "Cân chỉnh gặp lỗi!"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "Bạn có thể gỡ bỏ thiết bị cân chỉnh."
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "Đừng làm thiết bị cân chỉnh chạm vào màn hình khi đang chạy"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "Cân chỉnh màn hình"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "_Bắt đầu"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "_Tiếp tục lại"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+msgid "_Done"
+msgstr "_Xong"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "Màn hình máy tính xách tay"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "Webcam tích hợp"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "Màn hình %s"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "Máy quét %s"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "Máy ảnh %s"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "Máy in %s"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "Webcam %s"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "Bật quản lý màu sắc cho %s"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "Hiển thị hồ sơ màu dành cho %s"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "Chưa cân chỉnh"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "Mặc định: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "Không gian màu: "
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "Hồ sơ thử: "
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "Chọn tập tin hồ sơ ICC"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "_Nhập"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "Các hồ sơ ICC được hỗ trợ"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "Mọi tập tin"
+
+#: panels/color/cc-color-panel.c:586
+msgid "Screen"
+msgstr "Màn hình"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "Lưu hồ sơ"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Lưu"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "Tạo một hồ sơ màu cho thiết bị được chọn"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr ""
+"Không tìm thấy thiết bị đo. Hãy kiểm tra xem nó đã được bật nguồn và cắm cáp "
+"kết nối chưa."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "Thiết bị đo không hỗ trợ tạo hồ sơ màu cho máy in."
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "Kiểu thiết bị này hiện chưa được hỗ trợ."
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "Cân chỉnh màn hình"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "Chất lượng cân chỉnh"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"Việc cân chỉnh sẽ sản sinh một hồ sơ cái mà bạn có thể dùng để quản lý màu "
+"sắc trên màn hình của mình. Bạn càng dành nhiều công sức để cân chỉnh bao "
+"nhiêu thì bạn sẽ có được hồ sơ màu sắc tốt bấy nhiêu."
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+"Bạn sẽ không thể dùng máy tính trong khi việc cân chỉnh đang được tiến hành."
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "Chất lượng"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "Thời gian ước tính"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "Thiết bị cân chỉnh"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "Chọn thiết bị dò tìm bạn muốn dùng cho việc cân chỉnh."
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "Kiểu màn hình"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "Chọn kiểu của màn hình cái mà nó đã được kết nối."
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "Hồ sơ Điểm trắng"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+"Chọn điểm trắng màn hình đích. Phần lớn màn hình có thể được cân chỉnh bằng "
+"một vật chiếu sáng D65."
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "Độ sáng màn hình"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"Xin hãy đặt màn hình thành sáng nhất cái mà đặc trưng dành cho bạn. Quản lý "
+"màu sẽ làm chính xác nhất tại mức sáng này."
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+"Thay vì cách trên, bạn có thể dùng mức sáng nhất được dùng với một hồ sơ "
+"khác cho thiết bị này."
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "Tên hồ sơ"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"Bạn có thể dùng một hồ sơ màu trên các máy tính khác nhau hay thậm chí còn "
+"có thể tạo hồ sơ cho những điều kiện sáng khác nhau."
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "Tên hồ sơ:"
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "Tóm tắt"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "Hồ sơ đã được tạo ra!"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "Chép hồ sơ"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "Yêu cầu ổ đĩa có thể ghi được"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"Bạn có thể tìm thấy các chỉ dẫn để làm thế nào có thể sử dụng hồ sơ trên hệ "
+"thống <a href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> và <a "
+"href=\"windows\">Microsoft Windows</a> một cách hữu ích."
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "Thêm hồ sơ"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+"Đã phát hiện thấy có trục trặc. Hồ sơ có thể hoạt động không chính xác. <a "
+"href=\"\">Hiện chi tiết.</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "Nhậ_p tập tin…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/network/connection-editor/net-connection-editor.c:497
+#: panels/printers/new-printer-dialog.ui:84
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "_Thêm"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+"Mỗi thiết bị cần một bộ hồ sơ màu cập nhật để có thể được quản lý màu chính "
+"xác."
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "Tìm hiểu thêm"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "Tìm hiểu thêm về quản lý màu sắc"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "Đặ_t cho tất cả mọi người dùng"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "Đặt hồ sơ này cho tất cả người dùng trên máy"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "_Bật"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "Thê_m hồ sơ"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "_Cân chỉnh…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "Cân chỉnh thiết bị này"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "_Xóa hồ sơ"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "_Hiện chi tiết"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "Không dò tìm thấy bất kỳ thiết bị nào có thể quản lý màu sắc"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "Máy chiếu"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "Plasma"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (đèn nền CCFL)"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (đèn nền LED RGB)"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD (đèn nền LED trắng)"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "LCD gam màu rộng (đèn nền CCFL)"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "LCD gam màu rộng (đèn nền LED RGB)"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "Cao"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 phút"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "Trung bình"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 phút"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "Thấp"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 phút"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "Dùng màu tự nhiên"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (In ấn và xuất bản)"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (Nhiếp ảnh và đồ họa)"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "Không gian chuẩn"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "Hồ sơ thử"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "Tự động"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "Chất lượng thấp"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "Chất lượng trung bình"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "Chất lượng cao"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "RGB mặc định"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "CMYK mặc định"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "Đen trắng mặc định"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "Dữ liệu nhà cung ứng thiết bị cân chỉnh"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "Hồ sơ này không được phép sửa chữa hiển thị toàn màn hình"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "Hồ sơ này có thể không còn chính xác"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "Màu sắc"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+"Cân chỉnh màu sắc của thiết bị của bạn, như là màn hình, máy ảnh hay máy in"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Color;Màu;Mau;ICC;Profile;Calibrate;Chinh;Printer;Máy;in;May;Display;Màn;"
+"hình;Man;hinh;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "Khác…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "Chọn ngôn ngữ"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Chọn"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "Không tìm thấy ngôn ngữ"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "Còn nữa…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "Mở khóa để thay đổi cài đặt"
+
+#: panels/common/cc-permission-infobar.ui:40
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "Một số cài đặt phải được mở khóa trước khi có thể thay đổi được chúng."
+
+#: panels/common/cc-permission-infobar.ui:57
+msgid "Unlock…"
+msgstr "Mở khoá…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "Tăng giờ"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "Tăng phút"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "Thời gian"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "Giảm giờ"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "Giảm phút"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:162
+msgid "Today"
+msgstr "Hôm nay"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:164
+msgid "Yesterday"
+msgstr "Hôm qua"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d giờ"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d phút"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d giây"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 giây"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "Điểm truy cập"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24-giờ"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "SA / CH"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%l:%M %p, %e %b %Y"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%R, %e %B %Y"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s, %s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%l:%M %p"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "Ngày & giờ"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "Năm"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "Tháng"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "Tháng giêng"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "Tháng hai"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "Tháng ba"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "Tháng tư"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "Tháng năm"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "Tháng sáu"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "Tháng bảy"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "Tháng tám"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "Tháng chín"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "Tháng mười"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "Tháng mười một"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "Tháng mười hai"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "Ngày"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "Múi giờ"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "Tìm thành phố"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "Ngà_y &amp; Giờ tự động"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "Cần nối mạng internet"
+
+#: panels/datetime/cc-datetime-panel.ui:177
+msgid "Date &amp; _Time"
+msgstr "Ngày &amp; _Giờ"
+
+#: panels/datetime/cc-datetime-panel.ui:201
+msgid "Automatic Time _Zone"
+msgstr "_Múi giờ tự động"
+
+#: panels/datetime/cc-datetime-panel.ui:202
+msgid "Requires location services enabled and internet access"
+msgstr "Cần dịch vụ vị trí được bật và có nối mạng internet"
+
+#: panels/datetime/cc-datetime-panel.ui:214
+msgid "Time Z_one"
+msgstr "Mú_i giờ"
+
+#: panels/datetime/cc-datetime-panel.ui:239
+msgid "Time _Format"
+msgstr "Định _dạng thời gian"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "Thay đổi ngày giờ hay múi giờ"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+"Clock;Đồng;hồ;Dong;ho;Timezone;Múi;giờ;Mui;gio;Location;Vị;trí;Vi;tri;nước;"
+"nuoc;tỉnh;tỉnh;thành;phố;thanh;pho;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "Thay đổi thời gian và ngày tháng"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "Bạn cần xác thực để có thể sửa đổi thời gian hoặc ngày tháng."
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "_Web"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "_Thư"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "_Lịch"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "_Nhạc"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "Ph_im"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "Ả_nh"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "Ứng dụng mặc định"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "Cấu hình ứng dụng mặc định"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+"default;application;preferred;media;mặc định;mac dinh;ứng dụng;ung dung;ưa "
+"dùng;uu dung;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"Gửi báo cáo các trục trặc kỹ thuật để giúp chúng tôi cải tiến %s. Báo cáo "
+"được gửi nặc danh và được xóa các dữ liệu cá nhân. %s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "Báo cáo trục trặc"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "Báo cáo trục trặc _tự động"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "Chẩn đoán"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "Báo cáo vấn đề trục trặc của bạn"
+
+#. FIXME
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+#: panels/location/gnome-location-panel.desktop.in.in:20
+#: panels/lock/gnome-lock-panel.desktop.in.in:20
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;màn;hình;man;hình;lock;khóa;khoa;diagnostics;chẩn;đoán;chan;doan;"
+"crash;hư;hu;private;riêng;tư;rieng;tu;recent;mới;dùng;moi;dung;gần;đây;gan;"
+"day;temporary;tạm;tam;tmp;index;name;tên;ten;network;mạng;mang;identity;thực;"
+"thể;thuc;the;privacy;chính sách riêng tư;chinh sach rieng tu;"
+
+#: panels/display/cc-display-panel.c:512
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "Bật"
+
+#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "Tắt"
+
+#: panels/display/cc-display-panel.c:945
+msgid "Apply Changes?"
+msgstr "Áp dụng thay đổi?"
+
+#: panels/display/cc-display-panel.c:950
+msgid "Changes Cannot be Applied"
+msgstr "Thay đổi không thể áp dụng được"
+
+#: panels/display/cc-display-panel.c:952
+msgid "This could be due to hardware limitations."
+msgstr "Việc này có thể là do giới hạn phần cứng."
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "Á_p dụng"
+
+#: panels/display/cc-display-panel.ui:97
+msgid "Display Settings Disabled"
+msgstr "Cài đặt hiển thị bị tắt"
+
+#: panels/display/cc-display-panel.ui:113
+msgid "Display Arrangement"
+msgstr "Sắp xếp màn hình"
+
+#: panels/display/cc-display-panel.ui:124
+msgid "Multiple Displays"
+msgstr "Nhiều màn hình"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:133
+msgid "Join"
+msgstr "Ghép nối"
+
+#: panels/display/cc-display-panel.ui:140
+msgid "Mirror"
+msgstr "Giống nhau"
+
+#: panels/display/cc-display-panel.ui:153
+msgid "Contains top bar and Activities"
+msgstr "Chứa thanh đỉnh và “Tổng quan hoạt động”"
+
+#: panels/display/cc-display-panel.ui:154
+msgid "Primary Display"
+msgstr "Màn hình chính"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:175
+#: panels/display/cc-display-panel.ui:223
+#: panels/display/cc-night-light-page.ui:77
+msgid "Night Light"
+msgstr "Ánh sáng đêm"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "Nằm ngang"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "Dọc (quay phải)"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "Dọc (quay trái)"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "Nằm gang (lật ngược)"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:40
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "Hướng"
+
+#: panels/display/cc-display-settings.ui:47
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "Độ phân giải"
+
+#: panels/display/cc-display-settings.ui:54
+msgid "Refresh Rate"
+msgstr "Tốc độ làm tươi"
+
+#: panels/display/cc-display-settings.ui:61
+msgid "Adjust for TV"
+msgstr "Chỉnh cho TV"
+
+#: panels/display/cc-display-settings.ui:75
+#: panels/display/cc-display-settings.ui:90
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Co giãn"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:21
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "Tạm thời tắt cho đến ngày mai"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:35
+msgid "Restart Filter"
+msgstr "Khởi động lại bộ lọc"
+
+#: panels/display/cc-night-light-page.ui:57
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+"Ánh sáng đêm làm cho màn hình có màu ấm hơn. Việc này có thể giúp ngăn ngừa "
+"mắt bị mỏi mệt và buồn ngủ."
+
+#: panels/display/cc-night-light-page.ui:91
+msgid "Schedule"
+msgstr "Lịch biểu"
+
+#: panels/display/cc-night-light-page.ui:99
+msgid "Sunset to Sunrise"
+msgstr "Hoàng hôn tới Bình minh"
+
+#: panels/display/cc-night-light-page.ui:100
+msgid "Manual Schedule"
+msgstr "Thời gian biểu thủ công"
+
+#: panels/display/cc-night-light-page.ui:110
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "Thời gian"
+
+#: panels/display/cc-night-light-page.ui:123
+msgid "From"
+msgstr "Từ"
+
+#: panels/display/cc-night-light-page.ui:148
+#: panels/display/cc-night-light-page.ui:235
+msgid "Hour"
+msgstr "Giờ"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/display/cc-night-light-page.ui:241
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:171
+#: panels/display/cc-night-light-page.ui:258
+msgid "Minute"
+msgstr "Phút"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:181
+#: panels/display/cc-night-light-page.ui:268
+msgid "AM"
+msgstr "SA"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:193
+#: panels/display/cc-night-light-page.ui:280
+msgid "PM"
+msgstr "CH"
+
+#: panels/display/cc-night-light-page.ui:210
+msgid "To"
+msgstr "Tới"
+
+#: panels/display/cc-night-light-page.ui:316
+msgid "Color Temperature"
+msgstr "Nhiệt độ màu"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "Màn hình"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "Chọn cách dùng màn hình và máy chiếu được kết nối"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Bảng;bang;Projector;Máy;chiếu;May;chieu;xrandr;Screen;Màn;hình;Man;"
+"hinh;Resolution;Độ;phân;giải;Do;phan;gia;Refresh;Night;Đêm;Dem;Light;Ánh "
+"sáng;anh sang;Blue;Xanh;redshift;color;màu;mau;sunset;hoàng hôn;hoang hon;"
+"sunrise;bình minh;binh minh;"
+
+#: panels/info-overview/cc-info-overview-panel.c:411
+#: panels/info-overview/cc-info-overview-panel.c:435
+#: panels/info-overview/cc-info-overview-panel.c:481
+#: panels/info-overview/cc-info-overview-panel.c:511
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "Chưa biết"
+
+#. translators: This is the name of the OS, followed by the build ID, for
+#. * example:
+#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
+#. * "Ubuntu 16.04 LTS; Build ID: jki"
+#: panels/info-overview/cc-info-overview-panel.c:443
+#, c-format
+msgid "%s; Build ID: %s"
+msgstr "%s; Mã số biên dịch: %s"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:458
+#, c-format
+msgid "64-bit"
+msgstr "64-bít"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:461
+#, c-format
+msgid "32-bit"
+msgstr "32-bít"
+
+#: panels/info-overview/cc-info-overview-panel.c:720
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:724
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:726
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "Chưa biết"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "Logo hệ thống"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "Device Name"
+msgstr "Tên thiết bị"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "Mô hình phần cứng"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "Bộ nhớ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "Bộ vi xử lý"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "Đồ họa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "Dung lượng đĩa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "Đang tính toán…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "Tên HĐH"
+
+#: panels/info-overview/cc-info-overview-panel.ui:106
+msgid "OS Type"
+msgstr "Kiểu HĐH"
+
+#: panels/info-overview/cc-info-overview-panel.ui:114
+msgid "GNOME Version"
+msgstr "Phiên bản GNOME"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "Windowing System"
+msgstr "Hệ thống Cửa sổ"
+
+#: panels/info-overview/cc-info-overview-panel.ui:131
+msgid "Virtualization"
+msgstr "Ảo hóa"
+
+#: panels/info-overview/cc-info-overview-panel.ui:139
+msgid "Software Updates"
+msgstr "Cập nhật phần mềm"
+
+#: panels/info-overview/cc-info-overview-panel.ui:158
+msgid "Rename Device"
+msgstr "Đổi tên thiết bị"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+"Tên thiết bị được sử dụng để xác định thiết bị này khi nó được xem qua mạng "
+"hoặc khi ghép nối thiết bị Bluetooth."
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid "_Rename"
+msgstr "Đổ_i tên"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "Giới thiệu"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "Xem thông tin về hệ thống của bạn"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;thiết;bị;thiet;bi;system;hệ;thống;he;thong;information;thông;tin;"
+"thong;memory;bộ;nhớ;bo;nho;processor;xử;lý;xu;ly;li;version;phiên;bản;phien;"
+"ban;default;mặc;định;mac;dinh;application;ứng;dụng;ung;dung;preferred;ưa;"
+"thích;ua;thich;cd;dvd;usb;audio;video;disc;đĩa;dia;removable;di;động;dong;"
+"media;autorun;tự;chạy;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "Âm thanh và phương tiện"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "Câm/thôi câm tiếng"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Vặn nhỏ"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Vặn to"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "Câm/thôi câm míc"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "Phát đa phương tiện"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Phát (hoặc phát/dừng)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "Tạm ngừng"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "Dừng phát"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "Bài trước"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "Bài tiếp"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Đẩy ra"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "Gõ phím"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "Chuyển sang kiểu gõ kế"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "Chuyển sang kiểu gõ trước"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "Chạy phần mềm"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Chạy trình duyệt trợ giúp"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "Chạy máy tính bỏ túi"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "Chạy trình đọc thư"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Chạy trình duyệt web"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Thư mục cá nhân"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Tìm kiếm"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "Hệ thống"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Đăng xuất"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Khóa màn hình"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "Truy cập"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "Bật hoặc tắt thu phóng"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "Phóng to"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "Thu nhỏ"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "Bật hoặc tắt trình đọc màn hình"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "Bật hoặc tắt bàn phím ảo"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "Tăng cỡ chữ"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "Giảm cỡ chữ"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "Bật hoặc tắt tương phản cao"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "Không tìm thấy nguồn nhập liệu"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "Khác"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "Thêm nguồn nhập liệu"
+
+#: panels/keyboard/cc-input-chooser.ui:81
+msgid "Input methods can’t be used on the login screen"
+msgstr "Các phương thức nhập liệu không thể dùng tại màn hình đăng nhập"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "Chưa chọn nguồn nhập liệu"
+
+#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+msgid "Move Up"
+msgstr "Chuyển lên"
+
+#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+msgid "Move Down"
+msgstr "Chuyển xuống"
+
+#: panels/keyboard/cc-input-row.ui:38
+msgid "Preferences"
+msgstr "Tùy thích"
+
+#: panels/keyboard/cc-input-row.ui:45
+msgid "View Keyboard Layout"
+msgstr "Xem bố cục bàn phím"
+
+#: panels/keyboard/cc-input-row.ui:51
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+msgid "Remove"
+msgstr "Xóa"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "Phím tắt tự chọn"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:62
+msgid "Alternate Characters Key"
+msgstr "Phím ký tự thay thế"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"Phím ký tự thay thế có thể được sử dụng để nhập các ký tự bổ sung. Đôi khi "
+"chúng được in dưới dạng tùy chọn thứ ba trên bàn phím của bạn."
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "Alt trái"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "Alt phải"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "Phím Win trái"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "Phím Win phải"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "Phím trình đơn"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "Ctrl phải"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:79
+msgid "Compose Key"
+msgstr "Phím tổ hợp"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Phím tổ hợp cho phép nhập nhiều ký tự khác nhau. Để sử dụng nó, nhấn compose "
+"sau đó một chuỗi các ký tự. Ví dụ: phím compose tiếp theo là <b>C</b> và "
+"<b>o</b> sẽ nhập <b>©</b>, <b>a</b> tiếp theo là <b>'</b> sẽ nhập <b>á</"
+"b>."
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"Nuồn nhập liệu bạn có thể thay đổi sử dụng phím tắt %s\n"
+"Cái này có thể được thay đổi trong cài đặt phím tắt."
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "Thiết bị nhập"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "Bao gồm bố cục bàn phím và phương thức nhập liệu."
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "Chuyển đổi nguồn nhập liệu"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "Sử dụng _cùng kiểu bố trí cho mọi cửa sổ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "Cho phép chuyển nguồn nhập liệu _khác nhau cho mỗi cửa sổ"
+
+#: panels/keyboard/cc-keyboard-panel.ui:58
+msgid "Special Character Entry"
+msgstr "Nhập ký tự đặc biệt"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+"Phương thức để nhập vào các ký hiệu đặc biệt và các biến thể chữ sử dụng bàn "
+"phím."
+
+#: panels/keyboard/cc-keyboard-panel.ui:97
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Phím tắt"
+
+#: panels/keyboard/cc-keyboard-panel.ui:100
+msgid "View and Customize Shortcuts"
+msgstr "Xem và tùy chỉnh Phím tắt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "%d mục bị sửa đổi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
+msgid "Reset All Shortcuts?"
+msgstr "Đặt lại toàn bộ phím tắt chứ?"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr ""
+"Việc đặt lại phím tắt có thể ảnh hưởng đến các phím tắt tự chọn của bạn. "
+"Hành động này không thể hoàn lại được."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "Thôi"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
+msgid "Reset All"
+msgstr "Đặt lại tất cả"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "Đặt lại tất cả…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "Đặt lại các phím tắt thành giá trị mặc định của chúng"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+msgid "Add Custom Shortcuts"
+msgstr "Thêm Phím tắt tự chọn"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "Cài đặt phím tắt tùy chỉnh để khởi chạy ứng dụng, chạy tập lệnh, v.v."
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+msgid "Add Shortcut"
+msgstr "Thêm phím tắt"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+msgid "No keyboard shortcut found"
+msgstr "Không tìm thấy phím tắt bàn phím nào"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s đang được sử dụng cho %s. Nếu bạn thay thế nó, %s sẽ bị tắt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "Gõ phím tắt mới"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "Đặt phím tắt tự chọn"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "Đặt phím tắt"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "Gõ phím tắt mới để thay đổi %s."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
+msgid "Add Custom Shortcut"
+msgstr "Thêm phím tắt tự chọn"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "Thêm"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
+msgid "Replace"
+msgstr "Thay thế"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
+msgid "Set"
+msgstr "Đặt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "Nhấn Esc để thôi hoặc Backspace để tắt phím tắt bàn phím."
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "Tên"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+msgid "Command"
+msgstr "Câu lệnh"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+msgid "Shortcut"
+msgstr "Phím tắt"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+msgid "Set Shortcut…"
+msgstr "Đặt phím tắt…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+msgid "None"
+msgstr "Không có"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "Đặt lại các phím tắt thành giá trị mặc định của chúng"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Bàm phím"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+"Thay đổi phím tắt và đặt tùy thích cách bạn gõ, bố cục bàn phín và nguồn "
+"nhập liệu"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;phím tắt;phim tat;Workspace;không gian làm việc;khong gian làm viec;"
+"Window;cửa sổ;cua so;Resize;đổi cỡ;doi co;Zoom;phóng to;phong to;Contrast;"
+"tương phản;tuong phan;Input;Source;nguồn;nguon;Lock;khóa;khoa;Volume;âm "
+"lượng;am luong;"
+
+#: panels/location/cc-location-panel.ui:20
+msgid "Location Services Turned Off"
+msgstr "Dịch vụ vị trí bị tắt"
+
+#: panels/location/cc-location-panel.ui:21
+msgid "No applications can obtain location information."
+msgstr "Không ứng dụng nào có thể thu thập thông tin vị trí của bạn."
+
+#: panels/location/cc-location-panel.ui:35
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"Dịch vụ vị tri cho phép các ứng dụng biết vị trí của bạn. Sử dụng Wi-Fi và "
+"thiết bị di động để gia tăng độ chính xác.\n"
+"\n"
+"Sử dụng dịch vụ vị trí Mozilla: <a href='https://location.services.mozilla."
+"com/privacy'>Chính sách riêng tư</a>\n"
+"\n"
+"Cho phép các ứng dụng phía dưới dò tìm vị trí của bạn."
+
+#: panels/location/cc-location-panel.ui:53
+msgid "No Applications Have Asked for Location Access"
+msgstr "Không có ứng dụng nào từng hỏi quyền truy cập vị trí của bạn"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "Bảo vệ thông tin vị trí của bạn"
+
+#. FIXME
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:62
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "Màn hình tắt"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:65
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 giây"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:68
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 phút"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:71
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 phút"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:74
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 phút"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:77
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 phút"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:80
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 phút"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:83
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 giờ"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:126
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 phút"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:129
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 phút"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:132
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 phút"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:135
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 phút"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:138
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 phút"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:141
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 phút"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:144
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 phút"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:147
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 phút"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:150
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 phút"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/lock/cc-lock-panel.c:153
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "Không bao giờ"
+
+#: panels/lock/cc-lock-panel.ui:8
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+"Tự động khóa màn hình để ngăn người khác truy cập vào máy tính trong khi bạn "
+"đi vắng."
+
+#: panels/lock/cc-lock-panel.ui:13
+msgid "Blank Screen Delay"
+msgstr "Trễ tắt màn hình"
+
+#: panels/lock/cc-lock-panel.ui:14
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "Chu kỳ không hoạt động mà sau đó màn hình sẽ tắt."
+
+#: panels/lock/cc-lock-panel.ui:32
+msgid "Automatic Screen _Lock"
+msgstr "_Khóa màn hình tự động"
+
+#: panels/lock/cc-lock-panel.ui:46
+msgid "Automatic _Screen Lock Delay"
+msgstr "_Trễ Khóa màn hình tự động"
+
+#: panels/lock/cc-lock-panel.ui:47
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "Chu kỳ mà sau đó màn hình tắt khi màn hình được tự động khóa lại."
+
+#: panels/lock/cc-lock-panel.ui:65
+msgid "Show _Notifications on Lock Screen"
+msgstr "Thông báo trên màn hình _khóa"
+
+#: panels/lock/cc-lock-panel.ui:80
+msgid "Forbid new _USB devices"
+msgstr "Ngăn cản Thiết bị _USB mới"
+
+#: panels/lock/cc-lock-panel.ui:81
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "Ngăn các thiết bị USB mới tương tác với hệ thống khi màn hình bị khóa."
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:3
+msgid "Screen Lock"
+msgstr "Khóa màn hình"
+
+#: panels/lock/gnome-lock-panel.desktop.in.in:4
+msgid "Lock your screen"
+msgstr "Khóa màn hình của bạn"
+
+#. FIXME
+#: panels/microphone/cc-microphone-panel.ui:20
+msgid "Microphone Turned Off"
+msgstr "Míc đang bị tắt"
+
+#: panels/microphone/cc-microphone-panel.ui:21
+msgid "No applications can record sound."
+msgstr "Không tìm thấy ứng dụng nào có thể ghi âm."
+
+#: panels/microphone/cc-microphone-panel.ui:34
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"Việc sử dụng micrô cho phép các ứng dụng ghi lại và nghe âm thanh. Vô hiệu "
+"hóa micrô có thể khiến một số ứng dụng không hoạt động bình thường.\n"
+"\n"
+"Cho phép các ứng dụng dưới đây sử dụng míc của bạn."
+
+#: panels/microphone/cc-microphone-panel.ui:51
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "Không có ứng dụng nào từng hỏi quyền truy cập míc của bạn"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "Bảo vệ các cuộc chuyện trò của bạn"
+
+#. FIXME
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "_Kiểm tra cài đặt của bạn"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Chung"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "Nút chính"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "Đặt thứ tự của các nút vật lý trên con chuột và touchpads."
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+msgid "Left"
+msgstr "Trái"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+msgid "Right"
+msgstr "Phải"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "Chuột"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "Tốc độ chuột"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
+msgid "Natural Scrolling"
+msgstr "Cuộn Tự nhiên"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
+msgid "Scrolling moves the content, not the view."
+msgstr "Cuộn di chuyển nội dung, không phải bộ trình bày."
+
+#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+msgid "Touchpad"
+msgstr "Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:119
+msgid "Touchpad Speed"
+msgstr "Tốc độ Touchpad"
+
+#: panels/mouse/cc-mouse-panel.ui:136
+msgid "Tap to Click"
+msgstr "Vỗ nhẹ để bấm chuột"
+
+#: panels/mouse/cc-mouse-panel.ui:147
+msgid "Two-finger Scrolling"
+msgstr "Cuộn hai-ngón"
+
+#: panels/mouse/cc-mouse-panel.ui:159
+msgid "Edge Scrolling"
+msgstr "Cuộn cạnh"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "Thử nhấn, bấm đúp, cuộn chuột"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "Bấm năm lần, sự kiện GEGL!"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "Bấm đúp, nút chính"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "Bấm đơn, nút chính"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "Bấm đúp, nút giữa"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "Bấm đơn, nút giữa"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "Bấm đúp, nút phụ"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "Bấm đơn, nút phụ"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "Chuột & Touchpad"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "Thay đổi độ nhạy chuột và touchpad và chọn thuận tay phải/trái"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Con;trỏ;tro;Click;Nhấn;Nhắp;Nhan;Nhap;Tap;Double;Dup;Button;"
+"Nút;Nut;Trackball;Scroll;cuộn;cuon;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "_Góc nóng"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "Di chuyển chuột đến góc trên-trái để mở “Tổng quan hoạt động”."
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "_Kích hoạt cạnh màn hình"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+"Kéo cửa sổ vào đỉnh, trái, và phải màn hình để thay đổi kích thước của chúng."
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "Không gian làm việc"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "_Không gian làm việc động"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "Tự động xóa bỏ không gian làm việc trống rỗng."
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "_Cố định số lượng không gian làm việc"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "Chỉ định số không gian làm việc cố định."
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "Số lượng _không gian làm việc"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "Đa màn hình"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "Không gian làm việc chỉ ở trên màn hình _chính"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "Hiển thị không gian làm việc trên mọ_i màn hình"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "Chuyển ứng dụng"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "Bao gồm các ứng dụng từ mọi _không gian việc"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "Bao gồm các ứng dụng _chỉ từ không gian việc hiện tại thôi"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "Đa nhiệm"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "Quản lý các tùy chỉnh cho năng suất và đa nhiệm"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Đa;nhiệm;Tùy;chọn;"
+"chỉnh;da nhiem;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+"Ôi trời, có gì đó sai rồi. Vui lòng liên lạc với nhà cung cấp phần mềm."
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "Trình quản lý kết nối mạng cần phải đang chạy."
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "Thiết bị khác"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
+#: panels/network/connection-editor/net-connection-editor.c:580
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:70
+msgid "Not set up"
+msgstr "Chưa cài đặt"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:207
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:263
+msgid "Insecure network (WEP)"
+msgstr "Mạng không an toàn (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:267
+msgid "Secure network (WPA)"
+msgstr "Mạng an toàn (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:271
+msgid "Secure network (WPA2)"
+msgstr "Mạng an toàn (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Secure network (WPA3)"
+msgstr "Mạng an toàn (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network"
+msgstr "Mạng an toàn"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "Đã kết nối"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
+#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "Tùy chọn…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr ""
+"Bật điểm phát sóng sẽ ngắt kết nối khỏi %s và sẽ không thể truy cập internet "
+"thông qua Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "Mật khẩu phải dài ít nhất 8 ký tự"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "Mật khẩu phải dài tối đa %d ký tự"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Bật Wi-Fi Hotspot?"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Điểm truy cập Wi-Fi cho phép người khác chia sẻ kết nối internet của bạn "
+"bằng cách tạo mạng Wi-Fi mà họ có thể kết nối. Để làm điều này, bạn phải có "
+"kết nối internet thông qua một nguồn khác ngoài Wi-Fi."
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "Tên mạng"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:74
+#: panels/printers/new-printer-dialog.ui:331
+#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:362
+#: panels/wwan/cc-wwan-apn-dialog.ui:172
+msgid "Password"
+msgstr "Mật khẩu"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:86
+msgid "Generate Random Password"
+msgstr "Tạo mật khẩu ngẫu nhiên"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:87
+msgid "Autogenerate Password"
+msgstr "Mật khẩu tạo tự động"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:129
+msgid "_Turn On"
+msgstr "_Bật"
+
+#: panels/network/cc-wifi-panel.c:544
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:879
+msgid "Stop hotspot and disconnect any users?"
+msgstr ""
+"Bạn có muốn dừng điểm truy cập này và ngắt kết nối những người đang sử dụng?"
+
+#: panels/network/cc-wifi-panel.c:882
+msgid "_Stop Hotspot"
+msgstr "_Dừng điểm truy cập"
+
+#: panels/network/cc-wifi-panel.ui:72
+msgid "Airplane Mode"
+msgstr "Chế độ máy bay"
+
+#: panels/network/cc-wifi-panel.ui:73
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "Tắt Wi-Fi, Bluetooth và di động băng thông rộng"
+
+#: panels/network/cc-wifi-panel.ui:110
+msgid "No Wi-Fi Adapter Found"
+msgstr "Không tìm thấy thiết bị Wi-Fi nào"
+
+#: panels/network/cc-wifi-panel.ui:120
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "Hãy chắc chắn là bạn có thiết bị Wi-Fi và nó được bật"
+
+#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+msgid "Airplane Mode On"
+msgstr "Chế độ máy bay đang được bật"
+
+#: panels/network/cc-wifi-panel.ui:162
+msgid "Turn off to use Wi-Fi"
+msgstr "Tắt để dùng Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:199
+msgid "Wi-Fi Hotspot Active"
+msgstr "Kích hoạt Wi-Fi Hotspot"
+
+#: panels/network/cc-wifi-panel.ui:209
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "Thiết bị di động có thể quét mã QR để kết nối."
+
+#: panels/network/cc-wifi-panel.ui:217
+msgid "Turn Off Hotspot…"
+msgstr "Tắt Wi-Fi Hotspot…"
+
+#: panels/network/cc-wifi-panel.ui:237
+msgid "Visible Networks"
+msgstr "Mạng thấy được"
+
+#: panels/network/cc-wifi-panel.ui:294
+msgid "NetworkManager needs to be running"
+msgstr "Trình quản lý kết nối mạng cần phải đang chạy"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "_An ninh 802.1x"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "An ninh"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "Giữ nguyên"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "Vĩnh viễn"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "Ngẫn nhiên"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "Ổn định"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"Địa chỉ MAC được nhập ở đây sẽ được dùng làm địa chỉ phần cứng cho thiết bị "
+"mạng được kết nối này dùng. Tính năng này còn được biết là MAC nhân bản hay "
+"MAC giả. Ví dụ: 00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "Hồ sơ %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:97
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:101
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:107
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:112
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:119
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "Enterprise"
+msgstr "Doanh nghiệp"
+
+#: panels/network/connection-editor/ce-page-details.c:130
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "Không"
+
+#: panels/network/connection-editor/ce-page-details.c:151
+msgid "Never"
+msgstr "Không bao giờ"
+
+#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i ngày trước"
+
+#: panels/network/connection-editor/ce-page-details.c:293
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:295
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:310
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:312
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:334
+msgctxt "Signal strength"
+msgid "None"
+msgstr "Không có"
+
+#: panels/network/connection-editor/ce-page-details.c:336
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "Yếu"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "Ok"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "Tốt"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "Tuyệt hảo"
+
+#: panels/network/connection-editor/ce-page-details.c:409
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "Địa chỉ IPv4"
+
+#: panels/network/connection-editor/ce-page-details.c:410
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
+msgid "IPv6 Address"
+msgstr "Địa chỉ IPv6"
+
+#: panels/network/connection-editor/ce-page-details.c:412
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "Địa chỉ IP"
+
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:420
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
+#: panels/network/network-mobile.ui:217
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:473
+msgid "Forget Connection"
+msgstr "Quên kết nối"
+
+#: panels/network/connection-editor/ce-page-details.c:475
+msgid "Remove Connection Profile"
+msgstr "Xóa bỏ Hồ sơ Kết nối"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Remove VPN"
+msgstr "Xóa VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:495
+msgid "Details"
+msgstr "Chi tiết"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "tự động"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "Thực thể"
+
+#: panels/network/connection-editor/ce-page-ip4.c:245
+#: panels/network/connection-editor/ce-page-ip6.c:226
+msgid "Delete Address"
+msgstr "Xóa địa chỉ"
+
+#: panels/network/connection-editor/ce-page-ip4.c:392
+#: panels/network/connection-editor/ce-page-ip6.c:361
+msgid "Delete Route"
+msgstr "Xóa định tuyến"
+
+#: panels/network/connection-editor/ce-page-ip4.c:742
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:712
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "Không"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "Khóa WEP 40/128-bit (thập lục phân hoặc ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "Mật khẩu WEP 128-bit"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "WEP động (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 Cá nhân"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 Doanh nghiệp"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 Cá nhân"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "Cường độ tín hiệu"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "Tốc độ đường truyền"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "Địa chỉ phần cứng"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "Tần số được hỗ trợ"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:189
+msgid "Default Route"
+msgstr "Định tuyến mặc định"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "Dùng lần cuối"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "Kết nối _tự động"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "Cho người dùng _khác sử dụng"
+
+#: panels/network/connection-editor/details-page.ui:412
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+"Kết nối Đ_o dung lượng: có giới hạn dữ liệu hoặc có thể phải tính phí theo "
+"dung lượng sử dụng"
+
+#: panels/network/connection-editor/details-page.ui:421
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+"Các bản cập nhật phần mềm và các bản tải xuống lớn khác sẽ không được chạy "
+"tự động."
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "Tê_n"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "Địa chỉ _MAC"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "Địa chỉ _nhân bản"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "byte"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "Phương thức IPv_4"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "Tự động (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "Chỉ Link-Local"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+msgid "Manual"
+msgstr "Thủ công"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "Tắt"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "Chia sẻ với máy khác"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "Các địa chỉ"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:255
+#: panels/printers/pp-details-dialog.ui:90
+msgid "Address"
+msgstr "Địa chỉ"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:258
+msgid "Netmask"
+msgstr "Mặt nạ mạng"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:279
+msgid "Gateway"
+msgstr "Máy cổng"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:232
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "Tự động"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "DNS tự động"
+
+#: panels/network/connection-editor/ip4-page.ui:196
+#: panels/network/connection-editor/ip6-page.ui:205
+msgid "Separate IP addresses with commas"
+msgstr "Ngăn cách địa chỉ IP bằng các dấu phẩy"
+
+#: panels/network/connection-editor/ip4-page.ui:213
+#: panels/network/connection-editor/ip6-page.ui:222
+msgid "Routes"
+msgstr "Định tuyến"
+
+#: panels/network/connection-editor/ip4-page.ui:231
+#: panels/network/connection-editor/ip6-page.ui:240
+msgid "Automatic Routes"
+msgstr "Định tuyến tự động"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:281
+#: panels/network/connection-editor/ip6-page.ui:290
+msgid "Metric"
+msgstr "Metric"
+
+#: panels/network/connection-editor/ip4-page.ui:304
+#: panels/network/connection-editor/ip6-page.ui:313
+msgid "Use this connection _only for resources on its network"
+msgstr "Dùng kết nối này _chỉ cho tài nguyên trên mạng này"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "Phương thức IPv_6"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "Tự động, chỉ DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:267
+msgid "Prefix"
+msgstr "Tiền tố"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "Không thể mở cửa sổ điều chỉnh kết nối"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "Hồ sơ mới"
+
+#: panels/network/connection-editor/net-connection-editor.c:715
+msgid "Import from file…"
+msgstr "Nhập từ tập tin…"
+
+#: panels/network/connection-editor/net-connection-editor.c:741
+msgid "Add VPN"
+msgstr "Thêm VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "_An ninh"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "Không thể nhập kết nối VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Tập tin “%s” không thể đọc được hay nó chứa thông tin kết nối VPN không được "
+"chấp nhận\n"
+"\n"
+"Lỗi: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "Chọn tập tin cần nhập"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "Đã có tập tin tên “%s” rồi."
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "_Thay thế"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "Bạn có muốn thay thế %s bằng kết nối này?"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "Không thể xuất kết nối VPN"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"Kết nối VPN “%s” không thể xuất ra %s.\n"
+"\n"
+"Lỗi: %s."
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "Xuất kết nối VPN"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(Lỗi: không thể tải bộ biên soạn kết nối VPN)"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "Điều khiển cách kết nối Internet"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;mạng;mang;IP;LAN;Proxy;ủy nhiệm;uy nhiem;WAN;Broadband;Modem;"
+"Bluetooth;vpn;DNS;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "Điều khiển cách kết nối đến mạng Wi-Fi"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;mạng;mang;Wireless;không dây;khong day;Wi-Fi;Wifi;IP;LAN;Broadband;"
+"DNS;Hotspot;điểm truy cập;diem truy cap;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "không bao giờ"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "hôm nay"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "hôm qua"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "Dùng lần cuối"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "Có dây"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "Thêm kết nối mới"
+
+#: panels/network/net-device-wifi.c:857
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr ""
+"Sẽ mất chi tiết của những mạng được chọn, bao gồm mật khẩu và các cài đặt "
+"tùy biến khác."
+
+#: panels/network/net-device-wifi.c:861
+msgid "_Forget"
+msgstr "_Quên"
+
+#: panels/network/net-device-wifi.c:1041
+msgid "Known Wi-Fi Networks"
+msgstr "Mạng đã biết Wi-Fi"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1073
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "_Quên"
+
+#: panels/network/net-device-wifi.c:1216
+msgid "System policy prohibits use as a Hotspot"
+msgstr ""
+"Chính sách của hệ thống cấm chỉ dùng máy tính này như một Hotspot (Điểm tập "
+"trung để máy khác truy cập mạng)"
+
+#: panels/network/net-device-wifi.c:1219
+msgid "Wireless device does not support Hotspot mode"
+msgstr "Thiết bị không dây không hỗ trợ chế độ điểm truy cập"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "Dùng Tự động phát hiện ủy nhiệm Web nếu không cung cấp URL cấu hình."
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "Không khuyến khích đối với mạng công cộng không đáng tin."
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "Tắt thiết bị"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "Nhà cung cấp"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+msgid "Network Proxy"
+msgstr "Ủy nhiệm mạng"
+
+#: panels/network/network-proxy.ui:139
+msgid "_HTTP Proxy"
+msgstr "Ủy nhiệm _HTTP"
+
+#: panels/network/network-proxy.ui:156
+msgid "H_TTPS Proxy"
+msgstr "Ủy nhiệm H_TTPS"
+
+#: panels/network/network-proxy.ui:173
+msgid "_FTP Proxy"
+msgstr "Ủy nhiệm _FTP"
+
+#: panels/network/network-proxy.ui:190
+msgid "_Socks Host"
+msgstr "Máy chủ _Socks"
+
+#: panels/network/network-proxy.ui:207
+msgid "_Ignore Hosts"
+msgstr "_Bỏ qua máy"
+
+#: panels/network/network-proxy.ui:244
+msgid "HTTP proxy port"
+msgstr "Cổng ủy nhiệm HTTP"
+
+#: panels/network/network-proxy.ui:307
+msgid "HTTPS proxy port"
+msgstr "Cổng ủy nhiệm HTTPS"
+
+#: panels/network/network-proxy.ui:322
+msgid "FTP proxy port"
+msgstr "Cổng ủy nhiệm FTP"
+
+#: panels/network/network-proxy.ui:337
+msgid "Socks proxy port"
+msgstr "Cổng ủy nhiệm Socks"
+
+#: panels/network/network-proxy.ui:357
+msgid "_Configuration URL"
+msgstr "_Cấu hình URL"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "Tắt kết nối VPN"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Tên mạng"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "Kiểu an ninh"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "Mật khẩu"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "Tắt Wi-Fi"
+
+#: panels/network/network-wifi.ui:121
+msgid "_Connect to Hidden Network…"
+msgstr "_Nối vào mạng ẩn…"
+
+#: panels/network/network-wifi.ui:128
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "_Bật Wi-Fi Hotspot…"
+
+#: panels/network/network-wifi.ui:135
+msgid "_Known Wi-Fi Networks"
+msgstr "Mạng Wi-Fi đã _biết"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "Tình trạng không rõ"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "Chưa được quản lý"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "Không sẵn sàng"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "Đang kết nối"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "Cần xác thực"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "Đang ngắt kết nối"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "Kết nối gặp lỗi"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "Tình trạng không rõ (thiếu)"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "Cấu hình gặp lỗi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "Cấu hình IP gặp lỗi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "Hết hạn cấu hình IP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "Cần bí mật nhưng chưa được cung cấp"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x supplicant ngắt kết nối"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "Lỗi cấu hình 802.1x supplicant"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "Lỗi 802.1x supplicant"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant tốn quá nhiều thời gian để xác thực"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "Gặp lỗi khi khởi động dịch vụ PPP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "Dịch vụ PPP bị ngắt"
+
+# Name: don't translate / Tên: đừng dịch
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP bị lỗi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "Lỗi khởi động trình khách DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "Lỗi trình khách DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "Lỗi trình khách DHCP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "Lỗi khởi động dịch vụ kết nối chia sẻ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "Lỗi dịch vụ kết nối chia sẻ"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "Lỗi khởi động dịch vụ AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "Lỗi dịch vụ AutoIP"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "Dịch vụ AutoIP gặp lỗi"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "Đường dây bận"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "Không có tông"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "Không thể cài đặt carrier"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "Hết hạn yêu cầu quay số"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "Lỗi quay số"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "Lỗi khởi động Modem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "Lỗi chọn APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "Không tìm thấy mạng"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "Đăng ký mạng bị từ chối"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "Hết hạn đăng ký mạng"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "Lỗi đăng ký mạng yêu cầu"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "Gặp lỗi khi kiểm tra PIN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "Có lẽ thiếu firmware cho thiết bị"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "Kết nối bị biến mất"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "Ngầm định kết nối đã tồn tại"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "Không tìm thấy Modem"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "Gặp lỗi khi kết nối Bluetooth"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "Chưa cài SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "Cần Pin của SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "Cần Puk của SIM"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM không đúng"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "Lỗi phụ thuộc kết nối"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "Thiếu firmware"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "Chưa cắm dây"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "lỗi chưa biết trong an ninh 802.1X (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "chưa chọn tập tin"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "lỗi chưa định nghĩa khi xác thực lại tập tin eap-method"
+
+#: panels/network/wireless-security/eap-method.c:389
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
+msgstr "Khóa riêng DER, PEM, hay PKCS#12 (*.der, *.pem, *.p12, *.key)"
+
+#: panels/network/wireless-security/eap-method.c:392
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "Giấy phép DER hay PEM (*.der, *.pem, *.crt, *.cer)"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "thiếu tập tin EAP-FAST"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "Tập tin PAC (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "Nặc danh"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "Đã xác thực"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "Cả hai"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "Thực thể _vô danh"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "Tập tin _PAC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "Chọn tập tin PAC của bạn"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "Xác thực _bên trong"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "Cho phép PAC _dự liệu tự động"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "thiếu tên tài khoản EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "thiếu mật khẩu EAP-LEAP"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "_Tài khoản"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:175
+msgid "_Password"
+msgstr "_Mật khẩu"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "_Hiện mật khẩu"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "giấy chứng nhận CA EAP-PEAP không hợp lệ: %s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr ""
+"giấy chứng nhận CA EAP-PEAP không hợp lệ: chưa chỉ định giấy chứng nhận"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "Phiên bản 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "Phiên bản 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "Giấy chứng nhận C_A"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "Chọn một giấy chứng nhận CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "_Yêu cầu là không giấy chứng nhận CA"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "_Phiên bản PEAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "thiếu tên tài khoản EAP"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "thiếu mật khẩu EAP"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "sai định danh EAP-TLS"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "giấy chứng nhận CA EAP-TLS không hợp lệ: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "giấy chứng nhận CA EAP-TLS không hợp lệ: chưa chỉ định giấy chứng nhận"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "khóa riêng EAP-TLS không hợp lệ: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "giấy chứng nhận người dùng EAP-TLS không hợp lệ: %s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "Khóa riêng mà không được mã hóa là không an toàn"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"Khóa riêng đã chọn không được bảo vệ bằng mật khẩu. Điều đó làm giảm bớt mức "
+"độ an toàn của hệ thống. Hãy đặt mật khẩu để bảo vệ khóa riêng.\n"
+"\n"
+"(Bạn có thể bảo vệ khóa riêng bằng mật khẩu với openssl)"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "Chọn chứng nhận cá nhân của bạn"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "Chọn khóa riêng của bạn"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "_Thực thể"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "Chứng nhận _người dùng"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "_Khóa riêng"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "Mật khẩu khóa _riêng"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "giấy chứng nhận CA EAP-TTLS không hợp lệ: %s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr ""
+"giấy chứng nhận CA EAP-TTLS không hợp lệ: chưa chỉ định giấy chứng nhận"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2 (không EAP)"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "_Miền"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "Lỗi thẩm tra an ninh 802.1X chưa biết"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "TLS Xuyên hầm"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "EAP được bảo vệ (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "_Xác thực"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "Chọn một tập tin"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "thiếu leap-username"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "thiếu leap-password"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Thiếu mật khẩu Wi-Fi."
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "_Kiểu"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "thiếu wep-key"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr ""
+"wep-key không hợp lệ: khóa phải có chiều dài của %zu phải chỉ chứa chữ số "
+"thập lục"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr ""
+"wep-key không hợp lệ: khóa phải có chiều dài của %zu phải chỉ chứa các ký tự "
+"ascii"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"wep-key không hợp lệ: khóa phải có chiều dài của %zu. Một khóa phải hoặc là "
+"có chiều dài 5/4 (ascii) hoặc là 10/26 (chữ số thập lục)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "wep-key không hợp lệ: mật khẩu phải không rỗng"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "wep-key không hợp lệ: mật khẩu phải ngắn hơn 64 ký tự"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (Mặc định)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "Hệ thống mở"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "Khóa chia sẻ"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "_Khóa"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "_Hiện khóa"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "_Mục lục WEP"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"wpa-psk không hợp lệ: chiều dài khóa %zu không hợp lệ. Phải là [8,63] bye "
+"hoặc 64 số thập lục"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr ""
+"wpa-psk không hợp lệ: không thể phiên dịch khóa với 64 bye như là số thập lục"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Thông báo"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Bá_o động âm thanh"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "_Thông báo nổi lên"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+"Thông báo sẽ tiếp tục xuất hiện trong danh sách thông báo khi các popup bị "
+"tắt."
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "Hiển thị nội dun_g lời nhắn ở Popups"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Thông báo trên màn hình _khóa"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "Hiển thị nội _dung lời nhắn trên màn hình khóa"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "Đừn_g làm phiền"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "Thông báo trên màn hình _khóa"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "Cấu hình xem cảnh báo nào sẽ được hiển thị và hiển thị nó như thế nào"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;Thông;báo;Thong;bao;Banner;Message;Nhắn;nhan;Tray;Khay;Popup;"
+"Nổi;lên;Noi;len;"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:277
+#, c-format
+msgid "%s removed"
+msgstr "%s đã bị gỡ bỏ"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:406
+msgctxt "Online Account"
+msgid "Other"
+msgstr "Khác"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "Không thể xóa tài khoản"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:51
+msgid "Undo"
+msgstr "Hoàn tác"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:55
+msgid "Connect to your data in the cloud"
+msgstr "Kết nối đến dữ liệu trên mây của bạn"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:66
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+"Không có kết nối internet - kết nối để cài đặt tài khoản trực tuyến mới"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:93
+msgid "Add an account"
+msgstr "Thêm tài khoản"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "Tài khoản %s"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "Xóa tài khoản"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "Tài khoản trực tuyến"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+"Kết nối các tài khoản trực tuyến của bạn và quyết định dùng chúng vào việc gì"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Truc;tuyen;Chat;Calendar;Lịch;Lich;"
+"Mail;Thư;Thu;Contact;Liên;lạc;Lien;lac;ownCloud;Kerberos;IMAP;SMTP;Pocket;"
+"ReadItLater;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "Thời gian không rõ"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i phút"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i giờ"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "giờ"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "phút"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s đến khi sạc đầy"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "Cảnh báo: còn %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "còn %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "Đã sạc đầy"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "Không sạc"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "Rỗng"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "Đang sạc"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "Đang xả"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "Chuột không dây"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "Bàn phím không dây"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "Nguồn không ngắt"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "Trợ lý điện tử cá nhân"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "Điện thoại di động"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "Phát đa phương tiện"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "Máy tính bảng"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "Máy tính"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "Thiết bị chơi game"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "Pin"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "Chính"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "Phụ"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "Pin"
+
+#: panels/power/cc-power-panel.c:511
+msgid "When _idle"
+msgstr "Kh_i nghỉ"
+
+#: panels/power/cc-power-panel.c:671
+msgid "Suspend"
+msgstr "Tạm ngưng"
+
+#: panels/power/cc-power-panel.c:672
+msgid "Power Off"
+msgstr "Tắt máy"
+
+#: panels/power/cc-power-panel.c:673
+msgid "Hibernate"
+msgstr "Ngủ đông"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Nothing"
+msgstr "Không gì"
+
+#: panels/power/cc-power-panel.c:730
+msgid "When on battery power"
+msgstr "Khi sử dụng nguồn pin"
+
+#: panels/power/cc-power-panel.c:732
+msgid "When plugged in"
+msgstr "Khi cắm dây nguồn"
+
+#: panels/power/cc-power-panel.c:853
+msgctxt "Idle time"
+msgid "Never"
+msgstr "Không bao giờ"
+
+#: panels/power/cc-power-panel.c:937
+msgid "Automatic suspend"
+msgstr "Tự động ngưng"
+
+#: panels/power/cc-power-panel.c:1030
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "Chế độ năng suất tạm thời bị tắt bởi vì nhiệt độ của hoạt dộng cao."
+
+#: panels/power/cc-power-panel.c:1032
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"Dò thấy máy tính đang để trên đùi: chế độ năng suất hiện tạm thời không sẵn "
+"sàng. Hãy chuyển thiết bị đến mặt phẳng ổn định hơn để phục hồi lại."
+
+#: panels/power/cc-power-panel.c:1034
+msgid "Performance mode temporarily disabled."
+msgstr "Tạm thời tắt chế độ năng suất."
+
+#: panels/power/cc-power-panel.c:1076
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr ""
+"Sắp hết pin: nên chế độ tiết kiệm điện được bật. Chế độ dùng trước đây sẽ "
+"được dùng lại khi pin đã được sạc đủ dùng."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1084
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "Chế độ tiết kiệm điện được kích hoạt bởi “%s”."
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1088
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "Chế độ năng suất được kích hoạt bởi “%s”."
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 phút"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 phút"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 phút"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 phút"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 phút"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 giờ"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 phút"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 phút"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 phút"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 giờ"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "Chế độ nguồn điện"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "Ảnh hưởng đến hiệu suất hệ thống và sử dụng điện."
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "Tùy chọn tiết kiệm điện năng"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "Tự động chỉnh độ sáng màn hình"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "Chỉnh độ sáng màn hình theo ánh sáng xung quanh."
+
+#: panels/power/cc-power-panel.ui:138
+msgid "Dim Screen"
+msgstr "Giảm sáng màn hình"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+"Giảm độ sáng màn hình sau một khoảng thời gian máy tính không hoạt động."
+
+#: panels/power/cc-power-panel.ui:150
+msgid "Screen _Blank"
+msgstr "_Tắt màn hình"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Turns the screen off after a period of inactivity."
+msgstr "Tắt màn hình sau một khoảng thời gian không hoạt động."
+
+#: panels/power/cc-power-panel.ui:159
+msgid "Automatic Power Saver"
+msgstr "Tự động tiết kiệm năng lượng"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Enables power saver mode when battery is low."
+msgstr "Cho phép chế độ tiết kiệm điện khi sắp hết pin."
+
+#: panels/power/cc-power-panel.ui:173
+msgid "_Automatic Suspend"
+msgstr "_Tự động tạm ngưng"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "Pauses the computer after a period of inactivity."
+msgstr "Tạm dừng máy tính sau một khoảng thời gian không hoạt động."
+
+#: panels/power/cc-power-panel.ui:199
+msgid "Po_wer Button Behavior"
+msgstr "Ứng _xử nút nguồn"
+
+#: panels/power/cc-power-panel.ui:207
+msgid "Show Battery _Percentage"
+msgstr "Hiển thị _Phần trăm pin"
+
+#: panels/power/cc-power-panel.ui:243
+msgid "Automatic Suspend"
+msgstr "Tự động ngưng"
+
+#: panels/power/cc-power-panel.ui:266
+msgid "_Plugged In"
+msgstr "Đã _cắm"
+
+#: panels/power/cc-power-panel.ui:278
+msgid "On _Battery Power"
+msgstr "Dùng nguồn _pin"
+
+#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
+#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+msgid "Delay"
+msgstr "Khoảng trễ"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "Hiệu suất"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "Hiệu năng cao và tiêu dùng nhiều năng lượng."
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "Cân bằng"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "Hiệu suất và tiêu dùng điện năng tiêu chuẩn."
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "Tiết kiệm năng lượng"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "Giảm hiệu năng và tiêu dùng ít năng lượng."
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "Nguồn điện"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "Hiển thị trạng thái pin và thay đổi cài đặt chế độ tiết kiệm pin"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Nguồn;Nguon;dien;Sleep;Ngủ;Ngu;Suspend;Ngưng;Ngung;Hibernate;Battery;"
+"Pin;Brightness;Sáng;sang;Dim;Tối;toi;Blank;Trắng;Trống;trong;trang;Monitor;"
+"Màn;Hình;man;hinh;DPMS;Idle;Rảnh;ranh;Energy;năng lượng;nang luong;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:676
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "Máy in “%s” đã bị xóa bỏ"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:928
+msgid "Failed to add new printer."
+msgstr "Không thể thêm máy in mới."
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1229
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "Không thể tải giao diện: %s"
+
+#: panels/printers/cc-printers-panel.c:1297
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "Mở khóa để Thêm máy in và thay đổi cài đặt"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "Máy in"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+"Thêm máy in, xem các công việc in và quyết định bạn muốn in như thế nào"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Máy;in;May;Queue;Print;In;Paper;Giấy;Giay;Ink;Mực;Muc;Toner;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "Thêm máy in"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:100
+#: panels/printers/new-printer-dialog.ui:115
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "_Mở khóa"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:194
+msgid "No Printers Found"
+msgstr "Không tìm thấy máy in nào"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:244
+msgid "Enter a network address or search for a printer"
+msgstr "Nhập địa chỉ mạng hoặc tìm kiếm máy in"
+
+#: panels/printers/new-printer-dialog.ui:286
+msgid "Authentication Required"
+msgstr "Cần xác thực"
+
+#: panels/printers/new-printer-dialog.ui:302
+msgid "Enter username and password to view printers on Print Server."
+msgstr "Nhận tên tài khoản và mật khẩu để xem các máy in trên Máy phục vụ in."
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:311
+#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:148
+msgid "Username"
+msgstr "Tên người dùng"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:74
+#: panels/printers/pp-details-dialog.c:365
+#, c-format
+msgid "%s Details"
+msgstr "Chi tiết %s"
+
+#: panels/printers/pp-details-dialog.c:101
+msgid "No suitable driver found"
+msgstr "Không tìm thấy trình điều khiển phù hợp"
+
+#: panels/printers/pp-details-dialog.c:260
+msgid "Select PPD File"
+msgstr "Chọn tập tin PPD"
+
+#: panels/printers/pp-details-dialog.c:269
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr ""
+"Tập tin PostScript Printer Description (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+msgid "Location"
+msgstr "Vị trí"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:115
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "Trình điều khiển"
+
+#: panels/printers/pp-details-dialog.ui:154
+msgid "Searching for preferred drivers…"
+msgstr "Đang tìm trình điều khiển phù hợp…"
+
+#: panels/printers/pp-details-dialog.ui:173
+msgid "Search for Drivers"
+msgstr "Tìm trình điều khiển"
+
+#: panels/printers/pp-details-dialog.ui:181
+msgid "Select from Database…"
+msgstr "Chọn từ cơ sở dữ liệu…"
+
+#: panels/printers/pp-details-dialog.ui:189
+msgid "Install PPD File…"
+msgstr "Cài đặt tập tin PPD…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "Chọn trình điều khiển máy in"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "Đang tải cơ sở dữ liệu trình điều khiển…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "Chọn"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "Máy in JetDirect"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "Máy in LPD"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "Một mặt"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "Cạnh dài (Tiêu chuẩn)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "Cạnh ngắn (lật)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "Dọc"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "Ngang"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "Ngang ngược"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "Dọc ngược"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:134
+msgctxt "print job"
+msgid "Pending"
+msgstr "Đang chờ"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:140
+msgctxt "print job"
+msgid "Paused"
+msgstr "Tạm dừng"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:145
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "Cần xác thực"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "Đang xử lý"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "Dừng"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "Thôi"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "Bị bãi bỏ"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "Hoàn tất"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:176
+msgid "Move this job to the top of the queue"
+msgstr "Di chuyển công việc này lên đỉnh của hàng đợi"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u nhiệm vụ in yêu cầu xác thực"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s - Yêu cầu in hoạt động"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "Nhập giấy ủy nhiệm để in từ %s."
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "Miền"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:100
+msgid "A_uthenticate"
+msgstr "_Xác thực"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:128
+msgid "Clear All"
+msgstr "Dọn sạch"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:173
+msgid "_Authenticate"
+msgstr "_Xác thực"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:214
+msgid "No Active Printer Jobs"
+msgstr "Không có yêu cầu in nào hoạt động"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "Bỏ khóa Máy phục vụ in"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "Mở khóa %s."
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "Nhập tên tài khoản và mật khẩu để xem các máy in trên %s."
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "Tìm máy in"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "Cổng USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "Cổng nối tiếp"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "Cổng song song"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "Vị trí: %s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "Địa chỉ: %s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "Máy chủ yêu cầu xác thực"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "Hai mặt"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "Kiểu giấy"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "Nguồn giấy"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "Khay ra"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "Độ phân giải"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "Tiền lọc GhostScript"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "Trang mỗi mặt"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "Hai mặt"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "Hướng"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "Chung"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "Cài đặt giấy"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "Tùy chọn có thể cài"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "Yêu cầu"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "Chất lượng ảnh"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "Màu sắc"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "Hoàn tất"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "Nâng cao"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "Trang in thử"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "Trang in thử"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "Chọn tự động"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "Mặc định máy in"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "Chỉ phông GhostScript nhúng"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "Chuyển sang PS cấp 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "Chuyển sang PS cấp 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "Không tiền lọc"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "Nhà sản xuất"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "Yêu cầu in hoạt động"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u yêu cầu in"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "Lau đầu in"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "Sắp hết mực"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "Hết mực"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "Sắp hết thuốc hiện hình"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "Hết thuốc hiện hình"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "Sắp hết một ống mực"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "Một ống mực đã hết"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "Mở nắp"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "Mở cửa"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "Sắp hết giấy"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "Hết giấy"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "Ngoại tuyến"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "Dừng"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "Thùng chứa chất thải sắp đầy"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "Thùng chứa chất thải đã đầy"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "Trống quang máy in sắp quá tuổi thọ"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "Trống quang máy in không còn hoạt động được nữa"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "Sẵn sàng"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "Không chấp nhận lệnh in"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "Đang xử lý"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "Tùy chọn in"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "Chi tiết máy in"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "Dùng máy in theo mặc định"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "Lau đầu in"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "Bỏ máy in"
+
+#: panels/printers/printer-entry.ui:187
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "Kiểu"
+
+#: panels/printers/printer-entry.ui:242
+msgid "Ink Level"
+msgstr "Mức mực"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:304
+msgid "Please restart when the problem is resolved."
+msgstr "Vui lòng khởi động lại khi trục trặc được giải quyết."
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:310
+msgid "Restart"
+msgstr "Khởi động lại"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10
+msgid "Add Printer…"
+msgstr "Thêm máy in…"
+
+#: panels/printers/printers.ui:168
+msgid "No printers"
+msgstr "Không có máy in"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:179
+msgid "Add a Printer…"
+msgstr "Thêm máy in…"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:204
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"Rất tiếc! Dịch vụ in hệ thống\n"
+"    hình như không sẵn sàng."
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "Định dạng"
+
+#: panels/region/cc-format-chooser.ui:37
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "Kế trước"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "Tìm địa phương…"
+
+#: panels/region/cc-format-chooser.ui:113
+msgid "Common Formats"
+msgstr "Định dạng chung"
+
+#: panels/region/cc-format-chooser.ui:140
+msgid "All Formats"
+msgstr "Mọi định dạng"
+
+#: panels/region/cc-format-chooser.ui:188
+msgid "No Search Results"
+msgstr "Không tìm thấy kết quả nào"
+
+#: panels/region/cc-format-chooser.ui:200
+msgid "Searches can be for countries or languages."
+msgstr "Các tìm kiếm có thể là nước hoặc ngôn ngữ."
+
+#: panels/region/cc-format-chooser.ui:236
+msgid "Preview"
+msgstr "Xem thử"
+
+#: panels/region/cc-format-preview.c:135
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "Anh-Mỹ"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "Hệ mét"
+
+# Name: don't translate / Tên: đừng dịch
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "Ngày tháng"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "Ngày & giờ"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "Con số"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "Hệ đo lường"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "Giấy"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "Ngôn ngữ và định dạng sẽ thay đổi sau lần đăng nhập tới"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "Đăng xuất…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats is "
+"used for numbers, dates, and currencies."
+msgstr ""
+"Cài đặt ngôn ngữ để sử dụng cho chữ trong giao diện và các trang web. Định "
+"dạng dùng cho con số, ngày tháng, và tiền tệ."
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "Tài khoản của bạn"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:299
+msgid "_Language"
+msgstr "_Ngôn ngữ"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "Địn_h dạng"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "Màn hình đăng nhập"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "Lãnh thổ & ngôn ngữ"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "Chọn ngôn ngữ hiển thị, định dạng"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+"Language;Ngôn;ngữ;Ngon;ngu;Layout;Bố;trí;Bo;tri;Keyboard;Bàn;phím;Ban;phim;"
+"Kieu;go;Input;nhập;nhap;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "Hỏi cần phải làm gì"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "Không làm gì cả"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "Mở thư mục"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "Thiết bị lưu trữ khác"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "Chọn ứng dụng dành cho đĩa CD nhạc"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "Chọn ứng dụng cho DVD phim"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "Chọn ứng dụng cần chạy khi kết nối máy nghe nhạc"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "Chọn ứng dụng cần chạy khi kết nối máy ảnh, máy quay phim"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "Chọn ứng dụng cho CD phần mềm"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "DVD nhạc"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "đĩa Blu-ray trắng"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "đĩa CD trắng"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "đĩa DVD trắng"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "đĩa HD DVD trắng"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "Đĩa phim Blu-ray"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "máy đọc e-book"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "Đĩa phim HD DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "CD hình"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "CD Siêu phim"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "CD Phim"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Phần mềm Windows"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "Chọn cách xử lý thiết bị lưu trữ"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD _nhạc"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD phim"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "_Máy nghe nhạc"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "_Phần mềm"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "_Thiết bị lưu trữ khác…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+"_Không bao giờ hỏi hay khởi động chương trình khi nhận ra thiết bị lưu trữ "
+"mới"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "Chọn cách xử lý thiết bị lưu trữ khác"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "_Hành động:"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "_Kiểu:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "Đa phương tiện"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "Cấu hình cho các cài đặt đĩa đa phương tiện"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;thiết bị;thiet bi;system;hệ thống;he thong;default;mặc định;mac dinh;"
+"dinh;application ứng dụng;ung dung;fallback;preferred;ưa thích;ua thich;cd;"
+"dvd;usb;audio;video;disc;đĩa;dia;removable;di động;di dong;media;đa phương "
+"tiện;da phuong tien;autorun;tự chạy;tu chay;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "_Chọn vị trí"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "Đồn_g ý"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "Vị trí tìm"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+"Các thư mục được tìm kiếm bởi các ứng dụng hệ thống, chẳng hạn như Tập tin, "
+"Ảnh và Phim."
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "Mở nhanh"
+
+#: panels/search/cc-search-locations-dialog.ui:33
+msgid "Bookmarks"
+msgstr "Đánh dấu"
+
+#: panels/search/cc-search-locations-dialog.ui:48
+msgid "Others"
+msgstr "Khác"
+
+#: panels/search/cc-search-locations-dialog.ui:55
+msgid "Add Location"
+msgstr "Thêm địa điểm"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "Không tìm thấy ứng dụng"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "Tìm kiếm ứng dụng"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "Bao gồm các kết quả tìm kiếm được cung cấp bởi ứng dụng."
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "Các thư mục được tìm kiếm bởi các ứng dụng hệ thống."
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "Kết quả tìm kiếm"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "Kết quả được hiển thị tuân theo thứ tự liệt kê."
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+"Điều chỉnh ứng dụng nào hiển thị kết quả tìm kiếm trong một “Tổng quan hoạt "
+"động”"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Tìm;tim;Find;Index;Mục;lục;muc;luc;Hide;Ẩn;an;Privacy;Riêng;tư;rieng;"
+"tu;Results;Kết;quả;ket;qua;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:265
+msgid "No networks selected for sharing"
+msgstr "Chưa chọn mạng để chia sẻ"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "Mạng"
+
+#: panels/sharing/cc-sharing-panel.c:367
+msgctxt "service is enabled"
+msgid "On"
+msgstr "Bật"
+
+#: panels/sharing/cc-sharing-panel.c:369 panels/sharing/cc-sharing-panel.c:396
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "Tắt"
+
+#: panels/sharing/cc-sharing-panel.c:399
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "Bật"
+
+#: panels/sharing/cc-sharing-panel.c:402
+msgctxt "service is active"
+msgid "Active"
+msgstr "Hoạt động"
+
+#: panels/sharing/cc-sharing-panel.c:520
+msgid "Choose a Folder"
+msgstr "Chọn thư mục"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:748
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr ""
+"Chia sẻ Tập tin cho phép bạn chia sẻ thư mục Công khai với những máy khác "
+"trong mạng hiện đang sử dụng: %s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:754
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"Khi đăng nhập từ xa được bật, những người dùng máy mạng có thể kết nối sử "
+"dụng lệnh “Secure Shell” (ssh):\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "Chia sẻ"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "Tên má_y tính"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "Chia sẻ _tập tin"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "Điều khiển máy tính từ _xa"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "Chia sẻ đa _phương tiện"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "Đăng nhập từ _xa"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "Chia sẻ tập tin"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "_Cần mật khẩu"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "Đăng nhập từ xa"
+
+#: panels/sharing/cc-sharing-panel.ui:250
+#: panels/sharing/cc-sharing-panel.ui:267
+msgid "Remote Desktop"
+msgstr "Điều khiển máy tính từ xa"
+
+#: panels/sharing/cc-sharing-panel.ui:263
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+"Điều khiển máy tính từ xa cho phép xem và điều khiển máy tính của bạn từ máy "
+"tính khác."
+
+#: panels/sharing/cc-sharing-panel.ui:268
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "Bật hoặc tắt điều khiển máy tính từ xa cho máy tính này."
+
+#: panels/sharing/cc-sharing-panel.ui:280
+msgid "Remote Control"
+msgstr "Điều khiển từ xa"
+
+#: panels/sharing/cc-sharing-panel.ui:281
+msgid "Allows remote connections to control the screen."
+msgstr "Cho phép các kết nối điều khiển màn hinh."
+
+#: panels/sharing/cc-sharing-panel.ui:294
+msgid "How to Connect"
+msgstr "Kết nối như thế nào"
+
+#: panels/sharing/cc-sharing-panel.ui:295
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+"Kết nối đến máy tính này sử dụng tên thiết bị hoặc địa chỉ máy tính từ xa."
+
+#: panels/sharing/cc-sharing-panel.ui:323
+msgid "Remote Desktop Address"
+msgstr "Địa chỉ máy tính điều khiển từ xa"
+
+#: panels/sharing/cc-sharing-panel.ui:350
+msgid "Authentication"
+msgstr "Xác thực"
+
+#: panels/sharing/cc-sharing-panel.ui:351
+msgid "The user name and password are required to connect to this computer."
+msgstr "Cần tài khoản và mật khẩu để kết nối đến máy tính này."
+
+#: panels/sharing/cc-sharing-panel.ui:355
+msgid "User Name"
+msgstr "Tên người dùng"
+
+#: panels/sharing/cc-sharing-panel.ui:401
+msgid "Verify Encryption"
+msgstr "Xác thực mã hóa"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "Vân tay mã hóa"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical"
+msgstr ""
+"Dấu vân tay mã hóa có thể được thấy trong kết nối máy khách và nên là định "
+"danh duy nhất"
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "Chia sẻ phương tiện"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "Chia sẻ nhạc, ảnh, phim với những người khác qua mạng."
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "Thư mục"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+"Điều khiển việc bạn muôn chia sẻ những gì với các máy tính hay thiết bị khác"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;chia;sẻ;se;sharing;ssh;host;chủ;máy;chu;may;name;tên;ten;remote;xa;"
+"điều;khiển;desktop;media;đa phương tiện;da phuong tien;audio;nhạc;nhạc;video;"
+"phim;pictures;photos;ảnh;anh;movies;server;renderer;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "Bật hoặc tắt đăng nhập từ xa"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "Cần xác thực để bật hoặc tắt đăng nhập từ xa"
+
+#: panels/sound/cc-alert-chooser.c:150
+msgid "Custom"
+msgstr "Tự chọn"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Bark"
+msgstr "Chó sủa"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "Drip"
+msgstr "Giọt nước rơi"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Glass"
+msgstr "Thủy tinh"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Sonar"
+msgstr "Tiếng vọng tàu ngầm"
+
+#: panels/sound/cc-fade-slider.ui:13
+msgid "Rear"
+msgstr "Đằng sau"
+
+#: panels/sound/cc-fade-slider.ui:15
+msgid "Front"
+msgstr "Đằng trước"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "Đang kiểm tra “%s”"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "Nhấn vào “hình chiếc loa” để nghe thử"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "Âm lượng hệ thống"
+
+#: panels/sound/cc-sound-panel.ui:25
+msgid "Volume Levels"
+msgstr "Mức âm lượng"
+
+# Name: don't translate / Tên: đừng dịch
+#: panels/sound/cc-sound-panel.ui:35
+msgid "Output"
+msgstr "Đầu ra"
+
+#: panels/sound/cc-sound-panel.ui:56
+msgid "Output Device"
+msgstr "Thiết bị xuất"
+
+#: panels/sound/cc-sound-panel.ui:75
+msgid "Test"
+msgstr "Thử"
+
+#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+msgid "Configuration"
+msgstr "Cấu hình"
+
+#: panels/sound/cc-sound-panel.ui:135
+msgid "Balance"
+msgstr "Cân bằng"
+
+#: panels/sound/cc-sound-panel.ui:161
+msgid "Fade"
+msgstr "Làm mờ dần"
+
+#: panels/sound/cc-sound-panel.ui:187
+msgid "Subwoofer"
+msgstr "Siêu trầm"
+
+#: panels/sound/cc-sound-panel.ui:205
+msgid "Input"
+msgstr "Đầu vào"
+
+#: panels/sound/cc-sound-panel.ui:226
+msgid "Input Device"
+msgstr "Thiết bị đầu vào"
+
+#: panels/sound/cc-sound-panel.ui:294
+msgid "Volume"
+msgstr "Âm lượng"
+
+#: panels/sound/cc-sound-panel.ui:312
+msgid "Alert Sound"
+msgstr "Âm thanh báo động"
+
+#: panels/sound/cc-volume-slider.c:117
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Âm thanh"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "Thay đổi âm lượng, đầu vào/ra và âm thanh cảnh báo"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Cac;Microphone;Míc;Volume;Âm;lượng;Am;luong;thanh;Fade;Balance;Cân bằng;"
+"Can bang;Bluetooth;Headset;Audio;Tiếng;Tieng;Input;Đầu vào;dau vao;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "Đã ngắt kết nối"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "Đang kết nối"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "Đã kết nối"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "Lỗi xác thực"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "Xác thực"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "Tính năng bị Giảm bớt"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "Kết nối & Xác thực"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "Chưa biết"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "Được xác thực lúc:"
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "Được kết nối ở:"
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "Đăng ký vào:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "Gặp lỗi khi xác thực thiết bị: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "Gặp lỗi khi quên thiết-bị: "
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "Phụ thuộc vào %u thiết bị khác"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+msgid "Name:"
+msgstr "Tên:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+msgid "Status:"
+msgstr "Trạng thái:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+msgid "UUID:"
+msgstr "UUID:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+msgid "Authorize and Connect"
+msgstr "Ủy quyền và Kết nối"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+msgid "Forget Device"
+msgstr "Quên thiết bị"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "Lỗi"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "Xác thực"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr ""
+"Hệ thống phụ Thunderbolt (boltd) chưa được cài đặt hoặc cài đặt chưa đúng."
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:157
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+"Cho phép truy cập trực tiếp vào các thiết bị như docks và GPU bên ngoài."
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "Chỉ có thể gắn các thiết bị USB và Display Port."
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"Thunderbolt không thể được phát hiện.\n"
+"Hoặc hệ thống thiếu hỗ trợ Thunderbolt, nó đã bị vô hiệu hóa trong BIOS hoặc "
+"được đặt ở mức bảo mật không được hỗ trợ trong BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Hỗ trợ Thunderbolt đã bị tắt trong BIOS."
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "Mức an ninh Thunderbolt không thể dò tìm thấy."
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "Lỗi chế độ chuyển trực tiếp: %s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "No Thunderbolt Support"
+msgstr "Không hỗ trợ Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:104
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "Không thể kết nối đến hệ thống con thunderbolt."
+
+#: panels/thunderbolt/cc-bolt-panel.ui:153
+msgid "Direct Access"
+msgstr "Truy cập trực tiếp"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:225
+msgid "Pending Devices"
+msgstr "Thiết bị còn đợi"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:319
+msgid "No devices attached"
+msgstr "Chưa gắn thiết bị nào"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "Quản lý thiết bị Thunderbolt"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;riêng tư;rieng tu;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "Chớp nháy con trỏ"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+msgid "Cursor blinks in text fields."
+msgstr "Chớp nháy con trỏ trong trường nhập văn bản."
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
+#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+msgid "Speed"
+msgstr "Tốc độ"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+msgid "Cursor blinking speed"
+msgstr "Tốc độ chớp con trỏ"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "Kích cỡ con trỏ"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+"Kích cỡ con trỏ có thể tổ hợp cùng với phóng to để làm cho nó dễ nhìn thấy."
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "Hỗ trợ bấm"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "Cú nhấn thứ hai mô _phỏng"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "Gây ra cú nhấn phụ bằng cách nhấn giữ nút chính"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "Độ t_rễ chấp nhận:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Nhanh"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "Khoảng chờ nhấn lần hai"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "Lâu"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "Bấm _khi lướt qua"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "Gây ra cú nhấn khi lướt con trỏ qua"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "T_rễ:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Ngắn"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "Dài"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "Ngưỡng di chu_yển:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Nhỏ"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Lớn"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "Lặp phím"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+msgid "Key presses repeat when key is held down."
+msgstr "Phím nhấn được lặp lại khi được giữ nhấn xuống."
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+msgid "Repeat keys delay"
+msgstr "Độ trễ lặp phím"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+msgid "Repeat keys speed"
+msgstr "Tốc độ lặp"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "Hỗ trợ nhập liệu"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "Phím _dính"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "Xem chuỗi phím bổ trợ là tổ hợp phím"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "_Tắt nếu nhấn hai phím cùng lúc"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "Kêu bíp khi nhấn một _phím bổ trợ"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "Phím chậ_m"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "Đặt độ trễ từ lúc nhấn phím đến lúc phím được chấp nhận"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Nhanh"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "Khoảng trễ nhập phím chậm"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "Dài"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "Kêu bíp khi n_hấn một phím"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "Kêu bíp khi một phím được chấ_p nhận"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "Kêu bíp khi một phím bị _từ chối"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "Phím chống _lặp"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "Bỏ qua phím nhấn lặp lại nhanh"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Nhanh"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "Khoảng chờ nhập phím dội"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "Lâu"
+
+#: panels/universal-access/cc-typing-dialog.ui:326
+msgid "_Enable by Keyboard"
+msgstr "_Bật bằng bàn phím"
+
+#: panels/universal-access/cc-typing-dialog.ui:336
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "Bật các tính năng hỗ trợ bằng bàn phím"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "Mặc định"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "Trung bình"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "Lớn"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "Lớn hơn"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "Lớn nhất"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d điểm ảnh"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "_Luôn hiện trình đơn truy cập"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "Nhìn"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "Tương phản ca_o"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "Chữ _lớn"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "Cho phép Hoạt hì_nh"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "Bộ đọ_c màn hình"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "Bộ đọc màn hình đọc những chữ được hiển thị mỗi khi bạn di chuột vào."
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "Phím â_m thanh"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "Kêu bíp khi các phím Num Lock hay Caps Lock được bật hay tắt."
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "_Kích cỡ con trỏ"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "_Phóng"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "Nghe"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "Cảnh báo trực _quan"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "Bàn phím ả_o trên màn hình"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "_Lặp phím"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "Chớp nhá_y con trỏ"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "_Hỗ trợ nhập liệu (AccessX)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "Trỏ &amp; Nhấn"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "Phím ch_uột"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "Định _vị con trỏ"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "_Hỗ trợ bấm"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "Độ trễ Nhấn đú_p"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "Độ trễ Nhấn đúp"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "Cảnh báo trực quan"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "Nháy _thử"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "Hiện bộ chỉ thị trực quan khi có báo động âm thanh."
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "Nháy toàn _màn hình"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "Nháy toàn màn _hình"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "Ngắn"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ màn hình"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ màn hình"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ màn hình"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "Dài"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "Toàn màn hình"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "Nửa trên"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "Nửa dưới"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "Nửa trái"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "Nửa phải"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "Tùy chọn thu phóng"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "_Phóng đại:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "Vị trí kính lúp:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "The_o con trỏ chuột"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "Phần _màn hình:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "Kính lúp mở _rộng ra ngoài màn hình"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "_Giữ con trỏ kính lúp ở trung tâm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "Con trỏ kính lúp đẩ_y nội dung ra"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "Con trỏ kính lúp di chuyển nội dun_g"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "Kính lúp"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "_Khung nhắm:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "Đè _lên con trỏ chuột"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "Độ _dày:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "Mỏng"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "Dày"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "Chiề_u dài:"
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "Mà_u :"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "Khung nhắm"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "Hiệu ứng màu:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "T_rắng nền đen:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "Độ _sáng:"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "Độ tương _phản:"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "Mà_u"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "Không có"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "Đầy"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "Thấp"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "Cao"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "Thấp"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "Cao"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "Hiệu ứng màu"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "Làm cho việc xem, nghe, gõ, di và bấm chuột trở nên dễ dàng hơn"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Bàn phím;Ban phim;Mouse;Chuột;Chuot;a11y;Accessibility;Hỗ trợ truy "
+"cập;ho tro truy cap;Universal Access;Contrast;Tương phản;Tuong phan;Cursor;"
+"Con trỏ;con tro;Sound;Âm thanh;am thanh;Zoom;Phóng;Phong;Thu;Screen;Reader;"
+"Bộ đọc;Bo doc;Màn hình;Man hinh;big;lớn;high;cao;large;rộng;text;chữ;chu;"
+"font;phông;phong;size;Kích thước;Kich thuoc;AccessX;Sticky;Dính;Dinh;Keys;"
+"phím;Slow;Chậm;Cham;Bounce;Dội;Doi;Mouse;Double;Đúp;click;Bấm;Delay;Speed;"
+"Tốc độ;Toc do;Assist;Trợ lý;Tro ly;Repeat;Lặp;Lap;Blink;Nháy;Nhay;visual;ảo;"
+"hearing;nghe;audio;Âm thanh;Am thanh;typing;gõ;go;animations;hoạt hình;hoat "
+"hinh;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 giờ"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 ngày"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 ngày"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 ngày"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 ngày"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 ngày"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 ngày"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 ngày"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 ngày"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 ngày"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "Bỏ mọi thứ trong thùng rác chứ?"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "Toàn bộ nội dung chứa trong Thùng rác sẽ bị xóa vĩnh viễn."
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "Đổ _rác"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "Xóa tất cả các tập tin tạm?"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "Toàn bộ các tập tin tạm sẽ bị xóa vĩnh viễn."
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "_Xóa tập tin tạm"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 ngày"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 ngày"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 ngày"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "Vô hạn"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "Lịch sử tập tin"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"Lịch sử tập tin lưu giữ bản ghi các tập tin mà bạn đã sử dụng. Thông tin này "
+"được chia sẻ giữa các ứng dụng và giúp bạn dễ dàng tìm thấy các tập tin mà "
+"bạn có thể muốn dùng."
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "Lịch sử tập t_in"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "Thời lượng lịc_h sử"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "Xóa lịch _sử…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "Thùng rác &amp; Tập tin tạm"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"Thùng rác và tập tin tạm thời đôi khi có thể bao gồm thông tin cá nhân hoặc "
+"nhạy cảm. Tự động xóa chúng có thể giúp bảo vệ quyền riêng tư."
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "Tự động xóa nội dung trong _thùng rác"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "Tự động _xóa tập tin tạm"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "_Chu kỳ tự động xóa"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "Đổ _rác…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "_Xóa các tập tin tạm…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "Lịch sử tập tin & Thùng rác"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "Đừng để lại dấu vết"
+
+#. FIXME
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "Nên khớp với địa chỉ web của nhà cung cấp tài khoản cho bạn."
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "Gặp lỗi khi thêm tài khoản"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.c:260
+msgid "The passwords do not match."
+msgstr "Mật khẩu không khớp nhau."
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "Gặp lỗi khi đăng ký tài khoản"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "Không có cách xác thực được hỗ trợ nào với miền này"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "Gặp lỗi khi gia nhập miền"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"Tên tài khoản đăng nhập đó không đúng.\n"
+"Vui lòng thử lại."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"Mật khẩu đăng nhập đó không đúng.\n"
+"Vui lòng thử lại."
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "Gặp lỗi khi đăng nhập miền"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "Không thể tìm thấy miền. Có lẽ bạn gõ sai chăng?"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "Thêm người dùng"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "Quản trị"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"Quản trị viên có thể thêm và loại bỏ người dùng khác và có thể thay đổi các "
+"cài đặt cho tất cả người dùng. Quản lý cha mẹ không thể được áp dụng cho "
+"quản trị viên."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "Người dùng thay đổi mật khẩu khi họ đăng nhập lần đầu tiên"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "Đặt mật khẩu ngay"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "Xác nhận"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "Đăng nhập kiểu công ty"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organisation."
+msgstr "Các tài khản người dùng cái mà được quản lý bởi công ty hay tổ chức."
+
+#: panels/user-accounts/cc-add-user-dialog.ui:385
+msgid "You are Offline"
+msgstr "Bạn đang Ngoại tuyến"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:386
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"Đăng nhập theo cách doanh nghiệp cho phép các tài khoản người dùng được quản "
+"lý theo kiểu tập trung để sử dụng trên thiết bị này. Bạn có thể sử dụng tài "
+"khoản này để truy cập các nguồn tài nguyên của công ty trên mạng internet."
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "Duyệt thêm ảnh"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "Chọn một tập tin…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "Quản lý dấu vân tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "Vân tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+msgid "_No"
+msgstr "Khô_ng"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+msgid "_Yes"
+msgstr "_Có"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+"Bạn có muốn xóa các vân tay đã đăng ký để tắt chức năng đăng nhập bằng vân "
+"tay không?"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+msgid "No fingerprint device"
+msgstr "Không có thiết bị đọc dấu vân tay"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+msgid "No Fingerprint device"
+msgstr "Không có thiết bị đọc dấu vân tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+msgid "Ensure the device is properly connected."
+msgstr "Đảm bảo rằng các thiết bị được kết nối đúng."
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+msgid "Fingerprint Device"
+msgstr "Thiết bị đọc dấu vân tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+msgid "Choose the fingerprint device you want to configure"
+msgstr "Chọn thiết bị đọc dấu vân tay bạn muốn cấu hình"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+msgid "Fingerprint Login"
+msgstr "Đăng nhập bằng vân tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+"Đăng nhập bằng vân tay cho phép bạn mở khóa và đăng nhập vào máy tính bằng "
+"ngón tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+msgid "_Delete Fingerprints"
+msgstr "_Xóa các vân tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+msgid "Fingerprint Enroll"
+msgstr "Đăng ký dấu vân tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "thiết bị cần để yêu cầu thực hiện thao tác này"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "thiết bị này đang được dùng bởi một tiến trình khác"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "bạn không có đủ quyền hạn thực hiện thao tác"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "không có dấu tay nào được đăng ký"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "Không thể giao tiếp với thiết bị trong khi đăng ký"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "Gặp lỗi khi giao tiếp với bộ đọc dấu vân tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "Gặp lỗi khi giao tiếp với dịch vụ đọc dấu vân tay"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "Gặp lỗi khi liệt kê các dấu vân tay: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "Gặp lỗi khi xóa các dấu vân tay đã lưu: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "Ngón cái tay trái"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "Ngón giữa tay trái"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "Ngón trỏ _trái"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "Ngón đeo nhẫn tay trái"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "Ngón út tay trái"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "Ngón cái tay phải"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "Ngón giữa tay phải"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "Ngón trỏ _phải"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "Ngón đeo nhẫn tay phải"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "Ngón út tay phải"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "Ngón tay chưa biết"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "Hoàn thành"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "Thiết bị đọc dấu vân tay đã ngắt kết nối"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "Phần lưu trữ của thiết bị đọc dấu vân tay đã bị đầy"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "Gặp lỗi khi đăng ký dấu vân tay mới"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "Gặp lỗi khi bắt đầu đăng ký: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "Gặp lỗi khi đăng ký dấu vân tay mới"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "Gặp lỗi khi dừng đăng ký: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr ""
+"Liên tục nhấc và đặt ngón tay lên đầu đọc để đăng ký dấu vân tay của bạn"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "Đăng ký _lại ngón này…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "Quét dấu vân tay mới"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "Gặp lỗi giải phóng thiết bị đọc dấu vân tay %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "Lỗi đọc từ thiết bị"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "Gặp lỗi khi yêu cầu thiết bị đọc dấu vân tay %s: %s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "Gặp lỗi khi lấy các thiết vị đọc dấu vân tay: %s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "Tuần này"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "Tuần trước"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%e %b"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%e %b, %Y"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:712
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:716
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%2$s, %1$s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "Phiên đã chấm dứt"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "Phiên được bắt đầu"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s - Sự hoạt động của tài khoản"
+
+#: panels/user-accounts/cc-password-dialog.c:133
+msgid "Please choose another password."
+msgstr "Vui lòng chọn mật khẩu khác."
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Please type your current password again."
+msgstr "Hãy gõ mật khẩu hiện tại một lần nữa."
+
+#: panels/user-accounts/cc-password-dialog.c:148
+msgid "Password could not be changed"
+msgstr "Mật khẩu của bạn không thể bị thay đổi"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Đổi mật khẩu"
+
+#: panels/user-accounts/cc-password-dialog.ui:32
+msgid "Ch_ange"
+msgstr "Đổ_i"
+
+#: panels/user-accounts/cc-password-dialog.ui:51
+msgid "Current Password"
+msgstr "Mật khẩu hiện tại"
+
+#: panels/user-accounts/cc-password-dialog.ui:76
+msgid "New Password"
+msgstr "Mật khẩu mới"
+
+#: panels/user-accounts/cc-password-dialog.ui:121
+msgid "Confirm Password"
+msgstr "Xác nhận mật khẩu mới"
+
+#: panels/user-accounts/cc-password-dialog.ui:175
+msgid "Allow user to change their password on next login"
+msgstr "Cho phép người dùng thay đổi mật khẩu khi họ đăng nhập lần kế tiếp"
+
+#: panels/user-accounts/cc-password-dialog.ui:186
+msgid "Set a password now"
+msgstr "Đặt mật khẩu mới ngay"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "Không thể tự động gia nhập kiểu miền này"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "Không tìm thấy miền hay địa hạt"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "Không thể đăng nhập là %s tại miền %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "Mật khẩu không đúng, vui lòng thử lại"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "Không thể kết nối đến miền %s: %s"
+
+#: panels/user-accounts/cc-user-panel.c:341
+msgid "Failed to delete user"
+msgstr "Gặp lỗi khi xóa người dùng"
+
+#: panels/user-accounts/cc-user-panel.c:398
+#: panels/user-accounts/cc-user-panel.c:453
+#: panels/user-accounts/cc-user-panel.c:499
+msgid "Failed to revoke remotely managed user"
+msgstr "Gặp lỗi khi thu hồi quyền quản trị từ xa"
+
+#: panels/user-accounts/cc-user-panel.c:548
+msgid "You cannot delete your own account."
+msgstr "Không thể xóa tài khoản của chính bạn."
+
+#: panels/user-accounts/cc-user-panel.c:557
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s vẫn đang đăng nhập"
+
+#: panels/user-accounts/cc-user-panel.c:561
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "Xóa người dùng vẫn đang đăng nhập có thể gây bất ổn hệ thống."
+
+#: panels/user-accounts/cc-user-panel.c:570
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "Bạn có muốn giữ các tập tin của %s không?"
+
+#: panels/user-accounts/cc-user-panel.c:574
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr ""
+"Có thể giữ lại thư mục cá nhân, thư từ và tập tin tạm khi xóa tài khoản "
+"người dùng."
+
+#: panels/user-accounts/cc-user-panel.c:577
+msgid "_Delete Files"
+msgstr "_Xóa tập tin"
+
+#: panels/user-accounts/cc-user-panel.c:578
+msgid "_Keep Files"
+msgstr "_Giữ tập tin"
+
+#: panels/user-accounts/cc-user-panel.c:592
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "Bạn có chắc chắn muốn thu hồi tài khoản quản trị từ xa của %s không?"
+
+#: panels/user-accounts/cc-user-panel.c:596
+msgid "_Delete"
+msgstr "_Xóa"
+
+#: panels/user-accounts/cc-user-panel.c:646
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "Tài khoản bị vô hiệu hóa"
+
+#: panels/user-accounts/cc-user-panel.c:654
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "Cần đặt vào lần đăng nhập tiếp theo"
+
+#: panels/user-accounts/cc-user-panel.c:657
+msgctxt "Password mode"
+msgid "None"
+msgstr "Không có"
+
+#: panels/user-accounts/cc-user-panel.c:700
+msgid "Logged in"
+msgstr "Đang đăng nhập"
+
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/user-accounts/cc-user-panel.c:787
+#: panels/user-accounts/cc-user-panel.c:876
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "Bật"
+
+#: panels/user-accounts/cc-user-panel.c:1173
+msgid "Failed to contact the accounts service"
+msgstr "Gặp lỗi khi liên lạc dịch vụ tài khoản (accountsservice)"
+
+#: panels/user-accounts/cc-user-panel.c:1175
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "Hãy kiểm tra xem AccountService có cài và được bật không."
+
+#: panels/user-accounts/cc-user-panel.c:1197
+msgid "This panel must be unlocked to change this setting"
+msgstr "Bảng này phải được bỏ khóa mới thay đổi được cài đặt này"
+
+#: panels/user-accounts/cc-user-panel.c:1264
+msgid "Delete the selected user account"
+msgstr "Xóa tài khoản người dùng được chọn"
+
+#: panels/user-accounts/cc-user-panel.c:1268
+#: panels/user-accounts/cc-user-panel.c:1377
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"Để xóa tài khoản người dùng được chọn,\n"
+"nhấn biểu tượng * trước"
+
+#: panels/user-accounts/cc-user-panel.c:1423
+msgid "Unlock to Add Users and Change Settings"
+msgstr "Mở khóa để Thêm người dùng và Thay đổi cài đặt"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "Người dùng"
+
+#: panels/user-accounts/cc-user-panel.ui:60
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+"Phiên làm việc của bạn cần phải khởi động lại thì các thay đổi mới được áp "
+"dụng"
+
+#: panels/user-accounts/cc-user-panel.ui:67
+msgid "Restart Now"
+msgstr "Khởi động lại ngay"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:195
+msgid "_Fingerprint Login"
+msgstr "Đăng nhập bằng _vân tay"
+
+#: panels/user-accounts/cc-user-panel.ui:218
+msgid "A_utomatic Login"
+msgstr "Đăng nhập _tự động"
+
+#: panels/user-accounts/cc-user-panel.ui:231
+msgid "Account Activity"
+msgstr "Sự hoạt động của tài khoản"
+
+#: panels/user-accounts/cc-user-panel.ui:259
+msgid "_Administrator"
+msgstr "_Quản trị"
+
+#: panels/user-accounts/cc-user-panel.ui:260
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+"Quản trị viên có thể thêm và loại bỏ người dùng khác và có thể thay đổi các "
+"cài đặt cho tất cả người dùng."
+
+#: panels/user-accounts/cc-user-panel.ui:276
+msgid "_Parental Controls"
+msgstr "Điều khiển _cha mẹ"
+
+#: panels/user-accounts/cc-user-panel.ui:277
+msgid "Open the Parental Controls application."
+msgstr "Mở ứng dụng dành cho cha mẹ quản lý con cái."
+
+#: panels/user-accounts/cc-user-panel.ui:328
+msgid "Remove User…"
+msgstr "Gỡ bỏ người dùng…"
+
+#: panels/user-accounts/cc-user-panel.ui:340
+msgid "Other Users"
+msgstr "Người dùng khác"
+
+#: panels/user-accounts/cc-user-panel.ui:353
+msgid "Add User…"
+msgstr "Thêm người dùng…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:381
+msgid "No Users Found"
+msgstr "Không tìm thấy người dùng nào"
+
+#: panels/user-accounts/cc-user-panel.ui:390
+msgid "Unlock to add a user account."
+msgstr "Mở khóa để thêm tài khoản người dùng mới."
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "Thêm, xóa người dùng và thay đổi mật khẩu"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;Mật khẩu;"
+"Hạn chế;Trẻ em;Giới hạn;Cha mẹ;Dấu vân tay;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "Đă_ng ký"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "Đăng nhập quản trị miền"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"Để dùng đăng nhập kiểu doanh nghiệp, máy này cần được\n"
+"đăng ký trong miền. Vui lòng nhờ quản trị mạng của bạn\n"
+"nhập mật khẩu miền vào đây."
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "_Tên quản trị"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "Mật khẩu quản trị"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "Quản lý tài khoản người dùng"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "Cần xác thực để thay đổi dữ liệu người dùng"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "Mật khẩu mới cần phải khác với mật khẩu cũ."
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "Hãy thay đổi một số chữ cái và chữ số."
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "Hãy thay đổi mật khẩu một chút nữa."
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "Mật khẩu mạnh hơn nếu không chứa tên của bạn."
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "Không nên dùng tên của bạn làm mật khẩu."
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "Tránh sử dụng mật khẩu có chứa một số từ."
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "Không nên dùng các từ thông dụng."
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "Tránh đảo ngược thứ tự chữ cái của một từ cụ thể."
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "Hãy dùng nhiều chữ số hơn."
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "Hãy dùng thêm các chữ HOA."
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "Nên dùng nhiều chữ cái thường hơn."
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "Hãy dùng nhiều ký tự đặc biệt hơn nữa, như là dấu chấm câu chẳng hạn."
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "Hãy trộn lẫn chữ cái, chữ số và dấu chấm câu."
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "Tránh lặp lại cùng một ký tự."
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr ""
+"Không được lặp cùng một kiểu chữ: bạn cần trộn lẫn chữ cái, số và dấu chấm."
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "Hãy tránh sử dụng các chuỗi kế tiếp nhau như là 1234 hay abcd."
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr "Mật khẩu cần dài hơn. Hãy thêm chữ cái, chữ số và dấu chấm câu."
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "Trộn chữ cái HOA và thường cùng với một chữ số hoặc hai."
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "Thêm các chữ cái, chữ số và dấu chấm câu sẽ làm cho nó mạnh thêm."
+
+#: panels/user-accounts/run-passwd.c:413
+msgid "Authentication failed"
+msgstr "Gặp lỗi khi xác thực"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The new password is too short"
+msgstr "Mật khẩu quá ngắn"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password is too simple"
+msgstr "Mật khẩu quá đơn giản"
+
+#: panels/user-accounts/run-passwd.c:504
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "Mật khẩu cũ và mật khẩu mới quá giống nhau"
+
+#: panels/user-accounts/run-passwd.c:507
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "Mật khẩu mới đã được sử dụng gần đây."
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "Mật khẩu mới phải chứa ký tự số hay ký tự đặc biệt"
+
+#: panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "Mật khẩu cũ và mật khẩu mới là một"
+
+#: panels/user-accounts/run-passwd.c:518
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "Mật khẩu của bạn bị thay đổi kể từ khi bạn xác thực đầu tiên!"
+
+#: panels/user-accounts/run-passwd.c:522
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "Mật khẩu mới phải chứa đủ các ký tự khác nhau"
+
+#: panels/user-accounts/run-passwd.c:526
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "Lỗi chưa biết"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr ""
+"Tên tài khoản chỉ được phép chứa các chữ cái HOA/thường từ a-z, chữ số và "
+"các ký tự sau: “-” và “_”"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "Rất tiếc, tên tài khoản đó không sẵn sàng. Vui lòng thử cái khác."
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "Tên người dùng quá dài."
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+msgid "Map Buttons"
+msgstr "Ánh xạ nút"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "Ánh xạ nút sang chức năng"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"Để sửa đổi phím tắt, chọn hành động “Gửi phím đánh”, ấn vào nút phím tắt tổ "
+"hợp phím và giữ các phím mới hoặc nhấn Backspace để xóa phím tắt."
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "Đón_g"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+"Bấm vào đánh dấu đích khi xuất hiện trên màn hình để tinh chỉnh tablet."
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "Phát hiện ấn nhầm, đang khởi động lại…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "Nút %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "Ứng dụng đã định nghĩa"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "Gửi phím nhấn"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "Chuyển màn hình"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "Hiển thị Trợ giúp Trên-Màn-Hình"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "Bảng vẽ được gắn trên bảng máy tính xách tay"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "Bảng vẽ được gắn trên màn hình ngoài"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "Thiết bị bảng bên ngoài"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "Mọi màn hình"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "Chế độ máy tính bảng"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "Dùng vị trí tuyệt đối cho bút"
+
+#: panels/wacom/cc-wacom-page.ui:27
+msgid "Left Hand Orientation"
+msgstr "Hướng thuận tay trái"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "Bảng vẽ và Express Keys™ được xoay cho người sử dụng tay trái"
+
+#: panels/wacom/cc-wacom-page.ui:56
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "Ánh xạ sang màn hình"
+
+#: panels/wacom/cc-wacom-page.ui:62
+msgid "Keep Aspect Ratio"
+msgstr "Giữ nguyên tỷ lệ"
+
+#: panels/wacom/cc-wacom-page.ui:63
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "Chỉ dùng một vị trí của bề mặt bảng vẽ để giữ tỷ lệ hình dáng màn hình"
+
+#: panels/wacom/cc-wacom-page.ui:73
+msgid "Calibrate"
+msgstr "Cân chỉnh"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "Không tìm thấy bảng vẽ"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "Vui lòng cắm vào và bật bảng vẽ Wacom của bạn."
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "Cảm giác ấn ngón"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "Mềm"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "Áp lực đầu bút vẽ"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Nút 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Nút 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Nút 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "Cảm giác ấn tẩy"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "Cảm biến ấn tẩy"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "Cứng"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "Mặc định"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "Nhấn nút chuột giữa"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "Nhấn nút chuột phải"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "Kế tiếp"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Bút vẽ tiêu chuẩn với áp lực, nghiêng và con trượt tích hợp"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Bút vẽ tiêu chuẩn với áp lực, nghiêng và xoay"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "Bút vẽ tiêu chuẩn với áp lực và nghiêng"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "Bút vẽ tiêu chuẩn với áp lực"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Bảng vẽ Wacom"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "Đặt ảnh của nút và sửa kiểu dáng cho thích hợp dành cho bảng đồ họa"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+"Tablet;Bảng;bang;Wacom;Stylus;Bút;trỏ;but;tro;Eraser;Tẩy;Tay;Mouse;Chuột;"
+"Chuot;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "Phím tắt mới…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "Điểm truy cập"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:122
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "Thao tác bị hủy"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>Lỗi:</b> Truy nhập thay đổi cài đặt bị từ chối"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>Lỗi:</b> Lỗi thiết bị di động"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "Chưa đăng ký"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "Đã đăng ký"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "Chuyển vùng"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "Tìm kiếm"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "Bị từ chối"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "Chi tiết Modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "Tình trạng Modem"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "Nhà mạng"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "Kiểu mạng"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "Trạng thái mạng"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "Số sở hữu"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "Chi tiết thiết bị"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "Phiên bản Firmware"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "Chỉ 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "Chỉ 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "Chỉ 4G"
+
+#: panels/wwan/cc-wwan-device.c:1003
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G, 3G, 4G (Ưu tiên)"
+
+#: panels/wwan/cc-wwan-device.c:1005
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G, 3G (Ưu tiên), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G (Ưu tiên), 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G"
+msgstr "2G, 3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "3G, 4G (Preferred)"
+msgstr "3G, 4G (Ưu tiên)"
+
+#: panels/wwan/cc-wwan-device.c:1017
+msgid "3G (Preferred), 4G"
+msgstr "3G (Ưu tiên), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1019
+msgid "3G, 4G"
+msgstr "3G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1025
+msgid "2G, 4G (Preferred)"
+msgstr "2G, 4G (Ưu tiên)"
+
+#: panels/wwan/cc-wwan-device.c:1027
+msgid "2G (Preferred), 4G"
+msgstr "2G (Ưu tiên), 4G"
+
+#: panels/wwan/cc-wwan-device.c:1029
+msgid "2G, 4G"
+msgstr "2G, 4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "2G, 3G (Preferred)"
+msgstr "2G, 3G (Ưu tiên)"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "2G (Preferred), 3G"
+msgstr "2G (Ưu tiên), 3G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "2G, 3G"
+msgstr "2G, 3G"
+
+#: panels/wwan/cc-wwan-device.c:1043
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "Chưa biết"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "Mở khóa Thẻ SIM"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "Mở khóa"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "Vui lòng cung cấp mã PIN cho SIM %d"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "Nhập mã PIN để mở khóa thẻ SIM của bạn"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "Vui lòng cung cấp mã PUK cho sim %d"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "Nhập PUK để mở khóa thẻ SIM của bạn"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "Nhập sai mật khẩu. Bạn còn được thử %1$u lần nữa"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "Bạn còn được thử %u lần nữa"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "Đã nhập vào sai mật khẩu."
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "Mã PUK phải là số có 8 chữ số"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "Nhập mã PIN mới"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "Mã PIN phải là số có 4-8 chữ số"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "Mở khoá…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "Không SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "Lắp thẻ SIM để sử dụng modem này"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM bị khóa"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "Dữ liệu _di động"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "Truy cập dữ liệu sử dụng mạng di động"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "Chuyển vùng _dữ liệu"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "Sử dụng dữ liệu di động khi chuyển vùng"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "Chế độ mạ_ng"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "_Mạng"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "Nâng cao"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "_Tên điểm truy cập"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "Khóa _SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "Khóa SIM với PIN"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "Chi tiết M_odem"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "Lỗi nghiêm trọng điện thoại"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "Không có kết nối đến điện thoại"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "Thao tác không được phép"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "Thao tác không được hỗ trợ"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "Chưa cài SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "Cần PIN của SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "Cần PUK của SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "Lỗi SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM bận"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "Mật khẩu không đúng"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "Cần PIN2 của SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "Cần PUK2 của SIM"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "Không tìm thấy"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "Không có dịch vụ mạng"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "Chờ mạng tối đa"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "Không có phép dịch vụ GPRS"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "Chuyển vùng không được phép ở khu vực vị trí này"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "Lỗi GPRS không xác định"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "Action Cancelled"
+msgstr "Thao tác bị bãi bỏ"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Access denied"
+msgstr "Truy cấp bị từ chối"
+
+#: panels/wwan/cc-wwan-errors-private.h:103
+msgid "Unknown Error"
+msgstr "Lỗi chưa biết"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "Chế độ mạng"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:146
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "Đặ_t"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
+msgid "Close"
+msgstr "Đóng"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:69
+msgid "_Automatic"
+msgstr "_Tự động"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:84
+msgid "Choose Network"
+msgstr "Chọn mạng"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:99
+msgid "Refresh Network Providers"
+msgstr "Làm mới các nhà cung cấp mạng"
+
+#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "Cho phép dùng mạng di động"
+
+#: panels/wwan/cc-wwan-panel.ui:94
+msgid "No WWAN Adapter Found"
+msgstr "Không tìm bộ chuyển đổi WWAN nào"
+
+#: panels/wwan/cc-wwan-panel.ui:104
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "Hãy chắc chắn là bạn có thiết bị Wireless Wan/Cellular"
+
+#: panels/wwan/cc-wwan-panel.ui:145
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "Wireless Wan bị tắt khi chế độ máy bay được bật"
+
+#: panels/wwan/cc-wwan-panel.ui:153
+msgid "_Turn off Airplane Mode"
+msgstr "_Tắt chế độ máy bay"
+
+#: panels/wwan/cc-wwan-panel.ui:184
+msgid "Data Connection"
+msgstr "Kết nối dữ liệu"
+
+#: panels/wwan/cc-wwan-panel.ui:185
+msgid "SIM card used for internet"
+msgstr "Thẻ SIM được dùng cho internet"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "Khóa SIM"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "Tiế_p"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+msgid "_Lock SIM with PIN"
+msgstr "_Khóa SIM với PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+msgid "Change PIN"
+msgstr "Đổi PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "Nhập vào PIN hiện tại để thay đổi các cài đặt khóa SIM"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "Mạng di động"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "Cấu hình kết nối cho điện thoại và dữ liệu di động"
+
+#. FIXME
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;wwan;telephony;sim;mobile;di động;di dong;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "Tiện ích để cấu hình môi trường máy tính để bàn GNOME"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "Cài đặt là giao diện chính để cấu hình hệ thống của bạn."
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "Dự án GNOME"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "Hiển thị số hiệu phiên bản"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "Bật chế độ chi tiết"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "Tìm chuỗi"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "Liệt kê các tên bảng điều khiển có thể rồi thoát"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "Khung hiển thị"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[BẢNG] [Đ.SỐ…]"
+
+#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "Riêng tư"
+
+#: shell/cc-panel-loader.c:301
+msgid "Available panels:"
+msgstr "Bảng điều khiển hiện có:"
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "Mọi cài đặt"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "Trình đơn chính"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "Cảnh bào: Phiên bản phát triển"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"Phiên bản Cài đặt này chỉ nên được sử dụng cho mục đích phát triển. Bạn có "
+"thể gặp phải hành vi hệ thống không chính xác, mất dữ liệu và các vấn đề "
+"không mong muốn khác. "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "Trợ giúp"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Chung"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Thoát"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Tìm kiếm"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "Bảng điều khiển"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Trở về bảng điều khiển kế trước"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "Ngừng tìm kiếm"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr ""
+"Preferences;Tùy;thích;Tuy;thich;Cấu;hình;Cau;hinh;Settings;Thiết;lập;Thiet;"
+"lap;Cài;đặt;cai;dat;Tùy;chọn;Tuy;chon;Cá;ca;nhân;nhan;hóa;hoa;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "Định danh cho bảng Cài đặt cuối được mở"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"Định danh cho bảng Cài đặt cuối được mở. Các giá trị không nhận ra sẽ được "
+"bỏ qua và bảng đầu tiên trong danh sách đã chọn."
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "Hiển thị cảnh báo khi chạy bản biên dịch phát triển của Cài đặt"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+"Liệu Cài đặt có hiển thị cảnh báo khi chạy bản biên dịch phát triển hay "
+"không."
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "Trạng thái cửa sổ ban đầu"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+"Bộ dữ liệu chứa chiều rộng, cao và trạng thái phóng to ban đầu của cửa sổ "
+"ứng dụng."
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u đầu ra"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u đầu vào"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "Âm thanh hệ thống"
+
+#~ msgid "Web Links"
+#~ msgstr "Liên kết trang thông tin điện tử"
+
+#~ msgid "Git Links"
+#~ msgstr "Liên kết Git"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "Liên kết %s"
+
+#~ msgid "Unset"
+#~ msgstr "Chưa đặt"
+
+#~ msgid "Links"
+#~ msgstr "Liên kết"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "Tập tin đánh dấu siêu văn bản"
+
+#~ msgid "Text Files"
+#~ msgstr "Tập tin văn bản"
+
+#~ msgid "Image Files"
+#~ msgstr "Tập tin ảnh"
+
+#~ msgid "Font Files"
+#~ msgstr "Tập tin phông chữ"
+
+#~ msgid "Archive Files"
+#~ msgstr "Tập tin nén"
+
+#~ msgid "Package Files"
+#~ msgstr "Tập tin gói"
+
+#~ msgid "Audio Files"
+#~ msgstr "Tập tin âm thanh"
+
+#~ msgid "Video Files"
+#~ msgstr "Tập tin phim ảnh"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "Phân quyền & Truy cập"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr ""
+#~ "Dữ liệu và dịch vụ mà ứng dụng này đã yêu cầu quyền truy cập và quyền mà "
+#~ "ứng dụng yêu cầu."
+
+#~ msgid "Cannot be changed"
+#~ msgstr "Không thể thay đổi"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr ""
+#~ "Bạn có thể xem xét các quyền riêng lẻ cho các ứng dụng trong Cài đặt <a "
+#~ "href=\"privacy\">quyền riêng tư</a>."
+
+#~ msgid "Integration"
+#~ msgstr "Tích hợp"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "Đặt làm ảnh màn hình nền"
+
+#~ msgid "Default Handlers"
+#~ msgstr "Bộ xử lý mặc định"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "Kiểu của tập tin và liên kết mà ứng dụng này mở."
+
+#~ msgid "Usage"
+#~ msgstr "Tiêu dùng"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "Ứng dụng này đang sử dụng bao nhiêu tài nguyên."
+
+#~ msgid "Open in Software"
+#~ msgstr "Mở trong Phần mềm"
+
+#~ msgid "Activities"
+#~ msgstr "Hoạt động"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "Các ứng dụng phía dưới dùng máy ảnh của bạn."
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "Gặp lỗi khi tải tập tin lên: %s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "Hồ sơ đã được tải lên:"
+
+#~ msgid "Write down this URL."
+#~ msgstr "Ghi lại URL này."
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "Khởi động lại máy tính này và mồi máy vào hệ điều hành bình thường."
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr ""
+#~ "Nhập địa chỉ URL vào trình duyệt của bạn để tải về vào cài đặt hồ sơ."
+
+#~ msgid "Upload profile"
+#~ msgstr "Tải hồ sơ lên"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "Cần có kết nối mạng Internet"
+
+#~ msgid "_Copy"
+#~ msgstr "_Sao chép"
+
+#~ msgid "Select _All"
+#~ msgstr "Chọn _Tất cả"
+
+#~ msgid "Single Display"
+#~ msgstr "Màn hình đơn"
+
+#~ msgid "Join Displays"
+#~ msgstr "Ghép màn hình"
+
+#~ msgid "Display Mode"
+#~ msgstr "Chế độ màn hình"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr ""
+#~ "Kéo thả các màn hình cho phù hợp với cài đặt vật lý của bạn. Chọn một màn "
+#~ "hình để thay đổi các cài đặt của nó."
+
+#~ msgid "Active Display"
+#~ msgstr "Màn hình hoạt động"
+
+#~ msgid "Display Configuration"
+#~ msgstr "Cấu hình màn hình"
+
+#~ msgid "More Warm"
+#~ msgstr "Ấm hơn"
+
+#~ msgid "Less Warm"
+#~ msgstr "Ít ấm hơn"
+
+#~ msgid "Screenshots"
+#~ msgstr "Chụp màn hình"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "Chụp màn hình vào $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "Chụp hình cửa sổ vào $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "Chụp một vùng màn hình vào $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "Chụp màn hình vào clipboard"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "Chụp hình cửa sổ vào clipboard"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "Chụp một vùng màn hình vào clipboard"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "Chụp màn hình"
+
+#~ msgid "Move up"
+#~ msgstr "Di chuyển lên"
+
+#~ msgid "Move down"
+#~ msgstr "Di chuyển xuống"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "Dịch vụ vị trí cho phép ứng dùng biết bạn ở đâu. Dùng Wi-Fi và di động "
+#~ "băng thông rộng để gia tăng độ chính xác."
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "Dùng Dịch vụ Vị trí của Mozilla: <a href='https://location.services."
+#~ "mozilla.com/privacy'>Chính sách riêng tư</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "Cho phép các ứng dụng phía dưới sử dụng vị trí của bạn."
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "Cho phép các ứng dụng bên dưới sử dụng micrô của bạn."
+
+#~ msgid "Double-click timeout"
+#~ msgstr "Thời hạn bấm đúp chuột"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "VPN %s"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "Nút tạm ngưng & Tắt máy"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "Dò thấy máy tính xách tay: cho nên chế độ năng suất không sẵn sàng"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "Nhiệt độ phần cứng cao: chế độ năng suất không sẵn sàng"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "Chế độ năng suất không sẵn sàng"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "Xác thực"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr ""
+#~ "Chọn định dạng cho chữ số, ngày và đơn vị tiền tệ. Các thay đổi có hiệu "
+#~ "lực vào lần đăng nhập tiếp theo."
+
+#~ msgid "My Account"
+#~ msgstr "Tài khoản của tôi"
+
+#~ msgid "Language"
+#~ msgstr "Ngôn ngữ"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "Ngôn ngữ được dùng cho chữ trong cửa sổ và trang web."
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr ""
+#~ "Cần phải khởi động lại phiên làm việc thì các thay đổi mới được áp dụng"
+
+#~ msgid "Restart…"
+#~ msgstr "Khởi động lại…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr ""
+#~ "Cài đặt đăng nhập được dùng bởi mọi người dùng khi đăng nhập vào hệ thống"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "Kiểm soát kết quả tìm kiếm nào được hiển thị trong Tổng quan về hoạt "
+#~ "động. Thứ tự kết quả tìm kiếm cũng có thể được thay đổi bằng cách di "
+#~ "chuyển các hàng trong danh sách."
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr ""
+#~ "Chia sẻ màn hình cho phép người từ xa có thể xem, điều khiển màn hình của "
+#~ "bạn bằng cách kết nối đến %s"
+
+#~ msgid "Copy"
+#~ msgstr "Sao chép"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "Chia sẻ _màn hình"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "Một số dịch vụ bị tắt bởi vì không truy cập được mạng."
+
+#~ msgid "Screen Sharing"
+#~ msgstr "Chia sẻ màn hình"
+
+#~ msgid "_Password:"
+#~ msgstr "_Mật khẩu:"
+
+#~ msgid "_Show Password"
+#~ msgstr "_Hiện mật khẩu"
+
+#~ msgid "Access Options"
+#~ msgstr "Tùy chọn truy cập"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "Kết nối mớ_i phải được chấp nhận mới được phép"
+
+#~ msgid "_Require a password"
+#~ msgstr "_Cần mật khẩu"
+
+#~ msgid "Sound Keys"
+#~ msgstr "Phím âm thanh"
+
+#~ msgid "Screen Reader"
+#~ msgstr "Bộ đọc màn hình"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "Bộ đọc _màn hình"
+
+#~ msgid "_Full Name"
+#~ msgstr "_Họ tên"
+
+#~ msgid "Standard"
+#~ msgstr "Tiêu chuẩn"
+
+#~ msgid "Account _Type"
+#~ msgstr "Kiểu _tài khoản"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "Cho phép người dùng đặt mật khẩu khi họ đăng nhậ_p lần kế tiếp"
+
+#~ msgid "Set a password _now"
+#~ msgstr "Đặt mật khẩu mới _ngay"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr ""
+#~ "Bạn phải kết nối trực tuyến để thêm tài khoản đăng nhập kiểu doanh nghiệp."
+
+#~ msgid "Take a Picture…"
+#~ msgstr "Chụp ảnh…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Để thay đổi,\n"
+#~ "nhấn biểu tượng * trước"
+
+#~ msgid "Create a user account"
+#~ msgstr "Tạo tài khoản người dùng mới"
+
+#~ msgid "User Icon"
+#~ msgstr "Biểu tượng người dùng"
+
+#~ msgid "Account Settings"
+#~ msgstr "Cài đặt tài khoản"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "Xác thực & Đăng nhập"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr ""
+#~ "Cái này sẽ được dùng để đặt tên cho thư mục riêng của bạn và không thể "
+#~ "thay đổi nó được."
+
+# Name: don't translate / Tên: đừng dịch
+#~ msgid "Output:"
+#~ msgstr "Đầu ra:"
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "Giữ tỉ lệ biên dạng (letterbox):"
+
+#~ msgid "Map to single monitor"
+#~ msgstr "Ánh xạ sang màn hình đơn"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d / %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "Hiện ánh xạ"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "Bảng vẽ (tuyệt đối)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "Touchpad (tương đối)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "Cá nhân hóa bảng vẽ"
+
+#~ msgid "_Help"
+#~ msgstr "Trợ _giúp"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "Cài đặt Bluetooth"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "Chế độ rà"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "Ánh xạ nút…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "Sửa các cài đặt dành cho con chuột"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "Điều chỉnh độ phân giải"
+
+#~ msgid "No stylus found"
+#~ msgstr "Không tìm thấy bút trỏ nào"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr ""
+#~ "Vui lòng di chuyển bút trỏ của bạn đến lân cận của bảng để cấu hình nó"
+
+#~ msgid "Top Button"
+#~ msgstr "Nút cao"
+
+#~ msgid "Lower Button"
+#~ msgstr "Nút thấp"
+
+#~ msgid "Lowest Button"
+#~ msgstr "Nút thấp nhất"
+
+#~ msgid "Unlocking..."
+#~ msgstr "Đang mở khóa..."
+
+#~ msgid "GNOME Settings"
+#~ msgstr "Cài đặt GNOME"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "Phím tắt bàn phím"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "Cái này có thể được thay đổi trong Phím tắt tự chọn"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "Nhấn giữ và gõ để nhập các ký tự khác nhau"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "Độ sáng _màn hình"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "Độ sáng _bàn phím"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "Giảm sáng màn hình nếu máy không hoạt động"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "_Tắt màn hình"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "Wi-Fi có thể được tắt để tiết kiệm điện."
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr ""
+#~ "Có thể tắt thiết bị di động băng thông rộng (LTE, 4G, 3G, v.v..) để tiết "
+#~ "kiệm điện."
+
+#~ msgid "_Bluetooth"
+#~ msgstr "_Bluetooth"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "Có thể tắt Bluetooth để tiết kiệm điện."
+
+#~ msgid "Balanced Power"
+#~ msgstr "Cân bằng năng lượng"
+
+#~ msgid "Add…"
+#~ msgstr "Thêm…"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Đăng;nhập;Dang;nhap;Name;Tên;Ten;Fingerprint;Vân;tay;Van;Avatar;"
+#~ "Logo;Face;Mặt;Mat;Password;Mật;khẩu;mã;Mat;khau;ma;"
+
+#~ msgid "_Background"
+#~ msgstr "Ảnh _nền"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "Thay đổi liên tục trong ngày"
+
+#~ msgid "_Lock Screen"
+#~ msgstr "Màn hình _khóa"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "Lát gạch"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "Phóng to"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "Ở giữa"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "Dãn tỉ lệ"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "Điền đầy"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "Bề rộng"
+
+#~ msgid "Colors"
+#~ msgstr "Màu sắc"
+
+#~ msgid "Select Background"
+#~ msgstr "Chọn ảnh nền"
+
+#~ msgid "Pictures"
+#~ msgstr "Ảnh"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "Không tìm thấy ảnh nào"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr ""
+#~ "Bạn có thể thêm ảnh vào thư mục %s của mình và chúng sẽ hiện ra ở đây"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "_Night Light"
+#~ msgstr "Ánh sáng đê_m"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "Không thể lấy thông tin về màn hình"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "Version %s"
+#~ msgstr "Phiên bản %s"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "OS name"
+#~ msgstr "Tên HDH"
+
+#~ msgid "OS type"
+#~ msgstr "Kiểu HDH"
+
+#~ msgid "Disk"
+#~ msgstr "Đĩa"
+
+#~ msgid "Check for updates"
+#~ msgstr "Kiểm tra phiên bản mới"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "Chuyển sang kiểu gõ kế chỉ dùng phím bổ trợ"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Network proxy"
+#~ msgstr "Ủy nhiệm mạng"
+
+#~ msgid "page 1"
+#~ msgstr "trang 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "_Xác thực bên trong"
+
+#~ msgid "page 2"
+#~ msgstr "trang 2"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "Hạn chế tiêu dùng dữ liệu ảnh nền"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "Dành riêng cho các kết nối mà có dữ liệu thay đổi hay giới hạn."
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "Dây xoắn đôi (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "Giao diện Đơn vị Đính kèm (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "Giao diện Đa phương tiện Độc lập (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "Chuyển qua kết nối không dây, bạn sẽ bị ngắt khỏi <b>%s</b>."
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr ""
+#~ "Không thể truy cập Internet không dây khi điểm kết nối không dây vẫn đang "
+#~ "hoạt động."
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr ""
+#~ "Wi-Fi hotspots thường được sử dụng để chia sẻ kết nối Internet thông qua "
+#~ "Wi-Fi."
+
+#~ msgid "details"
+#~ msgstr "chi tiết"
+
+#~ msgid "Show P_assword"
+#~ msgstr "_Hiện mật khẩu"
+
+#~ msgid "Make available to other users"
+#~ msgstr "Cho phép những người dùng khác sử dụng"
+
+#~ msgid "identity"
+#~ msgstr "thực thể"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "Đị_a chỉ"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "Chỉ địa chỉ tự động (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "Chỉ link-local"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "_Bỏ qua định tuyến lấy tự động"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "Địa chỉ MAC _nhân bản"
+
+#~ msgid "hardware"
+#~ msgstr "phần cứng"
+
+#~ msgid "_Reset"
+#~ msgstr "Đặ_t lại"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr ""
+#~ "Đặt lại các cài đặt cho kết này thành mặc định, nhưng ghi nhớ đây là một "
+#~ "kết nối được ưa thích."
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr ""
+#~ "Xóa bỏ mọi thông tin chi tiết liên quan đến mạng này và không cố kết nối "
+#~ "tự động đến nó."
+
+#~ msgid "Hardware"
+#~ msgstr "Phần cứng"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "Đặt lại"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "Tắt kết nối vào mạng không dây"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "Mật khẩu"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "Hạ tầng"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "Thông báo _Popups"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "Đang sạc"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "Thận trọng"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "Thấp"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "Tốt"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "Đã sạc đầy"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "Hết điện"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "_Tự động tạm dừng"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "_Khi nút bật tắt nguồn được ấn"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "In use"
+#~ msgstr "Đang dùng"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "Bật"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "Tắt"
+
+#~ msgid "Usage & History"
+#~ msgstr "Sử dụng & Lịch sử"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "Chính sách riêng tư"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr ""
+#~ "Bảo về thông tin cá nhân của bạn và không khiển xem người khác có thể xem "
+#~ "được những gì"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "Việc ghi nhớ lịch sử giúp bạn có thể tìm lại các thứ dễ dàng hơn. Những "
+#~ "mục này không bao giờ được chia sẻ thông qua mạng cả."
+
+#~ msgid "_Recently Used"
+#~ msgstr "_Mới dùng"
+
+#~ msgid "Retain _History"
+#~ msgstr "Giữ lại _Lịch sử"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr ""
+#~ "Khóa Màn hình giúp bảo vệ sự riêng tư khi bạn rời khỏi bàn làm việc."
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "Khóa _sau khi tắt màn hình"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr ""
+#~ "Tự động xóa sạch Thùng Rác và tập tin tạm thời để máy tính của bạn không "
+#~ "còn lưu giữ các thông tin nhạy cảm không cần thiết nữa."
+
+#~ msgid "Purge _After"
+#~ msgstr "Làm sạch _sau"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "Gửi cho chúng tôi những thông tin về những phần mềm nào bạn đang dùng để "
+#~ "giúp chúng tôi đưa ra cho bạn những gợi ý chính xác. Nó cũng giúp chúng "
+#~ "tôi cải tiến phần mềm của mình.\n"
+#~ "\n"
+#~ "Mọi thông tin chúng tôi thu thập được giấu tên, và chúng tôi sẽ không bao "
+#~ "giờ chia sẻ dữ liệu của bạn với bên thứ ba."
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "_Gửi thống kê cách dùng phần mềm"
+
+#~ msgid "_Location Services"
+#~ msgstr "Dịch vụ _vị trí"
+
+#~ msgid "No regions found"
+#~ msgstr "Không tìm thấy lãnh thổ"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "Chuyển sang nguồn trước"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Phím_cách"
+
+#~ msgid "Switch to next source"
+#~ msgstr "Chuyển sang nguồn kế"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Phím_cách"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "Công tắt chuyển sang nguồn kế"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "Tiếng Anh (Vương quốc Anh)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "Vương quốc Anh"
+
+#~ msgid "_Options"
+#~ msgstr "_Tùy chọn"
+
+#~ msgid "Add input source"
+#~ msgstr "Thêm nguồn nhập liệu"
+
+#~ msgid "Remove input source"
+#~ msgstr "Gỡ bỏ nguồn nhập liệu"
+
+#~ msgid "Move input source up"
+#~ msgstr "Đưa nguồn nhập liệu lên trên"
+
+#~ msgid "Move input source down"
+#~ msgstr "Đưa nguồn nhập liệu xuống dưới"
+
+#~ msgid "Configure input source"
+#~ msgstr "Cấu hình nguồn nhập liệu"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "Hiển thị bố trí bàn phím nguồn nhập liệu"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "Trái"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "Phải"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "Tối thiểu"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "Tối đa"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "_Siêu trầm:"
+
+#~ msgid "_Profile:"
+#~ msgstr "_Hồ sơ:"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "Thử _loa"
+
+#~ msgid "Peak detect"
+#~ msgstr "Dò tìm đỉnh"
+
+#~ msgid "Device"
+#~ msgstr "Thiết bị"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "Thử loa %s"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "_Chọn thiết bị âm thanh đầu ra:"
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "Cài đặt cho thiết bị được chọn:"
+
+#~ msgid "_Input volume:"
+#~ msgstr "Âm lượng đầu _vào:"
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "_Chọn thiết bị âm thanh đầu vào:"
+
+#~ msgid "Sound Effects"
+#~ msgstr "Hiệu ứng âm thanh"
+
+#~ msgid "Built-in"
+#~ msgstr "Tích hợp"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Tùy thích âm thanh"
+
+#~ msgid "Testing event sound"
+#~ msgstr "Thử âm thanh sự kiện"
+
+#~ msgid "From theme"
+#~ msgstr "Từ sắc thái"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "_Chọn âm cảnh báo:"
+
+#~ msgid "Stop"
+#~ msgstr "Dừng"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "Tiêu đề cửa _sổ nháy"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "Bật đăng nhập bằng vân tay"
+
+#~ msgid "_Other finger:"
+#~ msgstr "Ngón tay _khác:"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr ""
+#~ "Vân tay của bạn đã được lưu. Sau đó thì bạn nên có khả năng đăng nhập "
+#~ "dùng máy đọc vân tay."
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "Gõ lại mật khẩu _mới"
+
+#~ msgid "Last Login"
+#~ msgstr "Đăng nhập cuối"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "Mật khẩu không khớp nhau."
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "Tiêu chuẩn"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "Quản trị"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr ""
+#~ "Bạn không có quyền truy cập đến thiết bị này. Hãy liên lạc với quản trị "
+#~ "hệ thống."
+
+#~ msgid "An internal error occurred."
+#~ msgstr "Gặp lỗi nội bộ."
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "Xóa các vân tay đã đăng ký?"
+
+#~ msgid "Done!"
+#~ msgstr "Hoàn tất!"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "Không thể truy cập thiết bị “%s”"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "Không thể khởi chạy đọc vân tay trên thiết bị “%s”"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "Hãy liên lạc với quản trị hệ thống để yêu cầu sự giúp đỡ."
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr ""
+#~ "Để bật tính năng đăng nhập bằng vân tay, bạn cần lưu một bản vân tay của "
+#~ "mình, sử dụng thiết bị “%s”."
+
+#~ msgid "Selecting finger"
+#~ msgstr "Chọn ngón tay"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "Để tạo tài khoản người dùng,\n"
+#~ "nhấn biểu tượng * trước"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "Tên người dùng không thể bắt đầu bằng “-”."
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "page 3"
+#~ msgstr "trang 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Trung tâm điều khiển GNOME"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr ""
+#~ "Trung tâm điều kiển là giao diện chính của GNOME để cấu hình các khía "
+#~ "cạnh khác nhau của máy tính để bàn của bạn."
+
+#~ msgid "Show the overview"
+#~ msgstr "Hiện tổng quan"
+
+#~ msgid "Quit"
+#~ msgstr "Thoát"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "Back­ground"
+#~ msgstr "Ảnh nền"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "Blue­tooth"
+
+#~ msgid "Co­lor"
+#~ msgstr "Màu"
+
+#~ msgid "Section"
+#~ msgstr "Phần"
+
+#~ msgid "Overview"
+#~ msgstr "Tổng quan"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "Ứng dụng mặc định"
+
+#~ msgid "Ab­out"
+#~ msgstr "Giới thiệu"
+
+#~ msgid "De­tails"
+#~ msgstr "Chi tiết"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "Đĩa đa phương tiện"
+
+#~ msgid "Net­work"
+#~ msgstr "Mạng"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "Thông báo"
+
+#~ msgid "Po­wer"
+#~ msgstr "Nguồn điện"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "Riêng tư"
+
+#~ msgid "Sha­ring"
+#~ msgstr "Chia sẻ"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "Hỗ trợ truy cập"
+
+#~ msgid "Disable image"
+#~ msgstr "Tắt ảnh"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "Duyệt thêm ảnh…"
+
+#~ msgid "Used by %s"
+#~ msgstr "Được dùng bởi %s"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Bảng vẽ Wacom"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "Phần cứng"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "Hệ thống"
+
+#~ msgid "Lid Closed"
+#~ msgstr "Nắp đã đóng"
+
+#~ msgid "Mirrored"
+#~ msgstr "Hiển thị giống nhau"
+
+#~ msgid "Secondary"
+#~ msgstr "Phụ"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "Sắp xếp màn hình hiển thị tổ hợp"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "Kéo các bộ hiển thị để sắp xếp chúng"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "Quay ngược chiều kim đồng hồ 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "Quay 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "Quay xuôi chiều kim đồng hồ 90°"
+
+#~ msgid "Size"
+#~ msgstr "Cỡ"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr ""
+#~ "Hiển thị thanh đỉnh và “Tổng quan hoạt động” trên màn hình hiển thị này"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "Nối hai màn hình để tạo không gian làm việc rộng hơn"
+
+#~ msgid "Presentation"
+#~ msgstr "Trình diễn"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "Chỉ hiển thị phần trình diễn và đa phương tiện"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "Cả hai màn hình hiện cùng nội dung"
+
+#~ msgid "Turn Off"
+#~ msgstr "_Tắt"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "Không dùng màn hình này"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "_Sắp xếp màn hình hiển thị tổ hợp"
+
+#~ msgid "Server"
+#~ msgstr "Máy chủ"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "Xóa máy chủ DNS"
+
+#~ msgid "Proxy"
+#~ msgstr "Ủy nhiệm"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "_Thêm hồ sơ…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "Không có"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "Thủ công"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "Tự động"
+
+#~ msgid "_Method"
+#~ msgstr "_Phương thức"
+
+#~ msgid "Group Name"
+#~ msgstr "Tên nhóm"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "_Dùng làm điểm truy cập…"
+
+#~ msgid "_History"
+#~ msgstr "_Lịch sử"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d-bit (Mã số biên dịch: %s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d-bít"
+
+#~ msgid "Base system"
+#~ msgstr "Hệ thống nền"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Phím;tắt;phim;tat;Repeat;Lặp;lap;Blink;Nháy;nhay;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "Nhấn phím Esc để thôi."
+
+#~ msgid "Make available to other _users"
+#~ msgstr "Cho người dùng _khác sử dụng"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "_Vùng tường lửa"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "Mặc định"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "Đây là vùng định nghĩa mức tin cậy của kết nối"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr ""
+#~ "Đặt lại toàn bộ cài đặt cho mạng này, bao gồm mật khẩu, nhưng vẫn ghi nhớ "
+#~ "nó là mạng ưa dùng"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr ""
+#~ "Xóa bỏ mọi thông tin chi tiết liên quan đến mạng và không kết nối tự động"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "Nếu bạn có kết nối Internet không phải không dây, bạn có thể cài đặt một "
+#~ "điểm kết nối không dây (hotspot) để chia sẻ kết nối Internet với người "
+#~ "khác."
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "Loading options…"
+#~ msgstr "Tùy chọn tải…"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "Hãy thử thêm các chữ cái, chữ số và ký hiệu."
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "Mức an toàn: Yếu"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "Mức an toàn: Thấp"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "Mức an toàn: Vừa"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "Mức an toàn: Tốt"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "Mức an toàn: Cao"
+
+#~ msgid "Edit"
+#~ msgstr "Chỉnh sửa"
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "Đặt phím tắt"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "_Băng cờ thông báo"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "Các _băng cờ thông báo"
+
+#~ msgid "Add Account"
+#~ msgstr "Thêm tài khoản"
+
+#~ msgid "Mail"
+#~ msgstr "Thư điện tử"
+
+#~ msgid "Calendar"
+#~ msgstr "Lịch"
+
+#~ msgid "Contacts"
+#~ msgstr "Danh bạ"
+
+#~ msgid "Chat"
+#~ msgstr "Tán gẫu"
+
+#~ msgid "Resources"
+#~ msgstr "Tài nguyên"
+
+#~ msgid "Error creating account"
+#~ msgstr "Không thể tạo tài khoản mới"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "Bạn có chắc chắn muốn xóa tài khoản này không?"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "Hành động này không xóa tài khoản trên máy chủ."
+
+#~ msgid "_Remove"
+#~ msgstr "_Xóa"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "Chưa cấu hình tài khoản trực tuyến"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "Thêm tài khoản cho phép ứng dụng của bạn truy cập tài liệu, thư từ, liên "
+#~ "lạc, lịch hẹn, tán gẫu và nhiều nữa."
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "Đang cấu hình"
+
+#~ msgid "Toner Level"
+#~ msgstr "Mức trống mực"
+
+#~ msgid "Supply Level"
+#~ msgstr "Mức cung cấp"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "Đang cài đặt"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u đang hoạt động"
+
+#~ msgid "Supply"
+#~ msgstr "Nguyên liệu in"
+
+#~ msgid "Jobs"
+#~ msgstr "Yêu cầu"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "Hiện _việc in"
+
+#~ msgid "label"
+#~ msgstr "nhãn"
+
+#~ msgid "Setting new driver…"
+#~ msgstr "Đang cài đặt trình điều khiển…"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "_In thử"
+
+#~ msgid "Other Accounts"
+#~ msgstr "Tài khoản khác"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "Lên"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "Xuống"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "Không"
+
+#~ msgid "Left Ring"
+#~ msgstr "Vòng trái"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "Chế độ vòng trái #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "Chế độ vòng phải #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "Touchstrip Trái"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "Chế độ Touchstrip Trái #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "Touchstrip Phải"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "Chế độ Touchstrip Phải #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "Nút chuyển Chế độ sang Touchring Trái"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "Nút chuyển Chế độ sang Touchring Phải"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "Nút chuyển Chế độ sang Touchstrip Trái"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "Nút chuyển Chế độ sang Touchstrip Phải"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "Công tắc chế độ #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "Nút trái #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "Nút phải #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "Nút cao #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "Nút thấp #%d"
+
+#~ msgid "No Action"
+#~ msgstr "Không hành động"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "Nhấn nút chuột trái"
+
+#~ msgid "Scroll Up"
+#~ msgstr "Cuộn lên"
+
+#~ msgid "Scroll Down"
+#~ msgstr "Cuộn xuống"
+
+#~ msgid "Scroll Right"
+#~ msgstr "Cuộn sang phải"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "Thêm máy in mới"
+
+#~ msgid "No printers detected."
+#~ msgstr "Không tìm thấy máy in nào."
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Keyboard shortcut for <b>%s</b>. Enter new shortcut to change."
+#~ msgstr "Phím tắt cho <b>%s</b>. Nhập vào phím tắt mới để thay đổi."
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "Để sửa đổi phím tắt, nhấn vào hàng muốn sửa rồi ấn tổ hợp phím mới hoặc "
+#~ "nhấn Backspace để xóa phím tắt."
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "Bỏ phím tắt"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Hành động lạ>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "Không thể dùng \"%s\" làm phím tắt vì sẽ không thể gõ được phím này nữa.\n"
+#~ "Xin hãy thêm một phím bổ trợ như Ctrl, Alt, Shift."
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "Phím tắt \"%s\" đã dùng cho\n"
+#~ "\"%s\""
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "Nếu bạn gán lại phím tắt là \"%s\", \"%s\" sẽ bị tắt."
+
+#~ msgid "_Reassign"
+#~ msgstr "_Gán lại"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr ""
+#~ "Tổ hợp phím tắt \"%s\" đã được gán cho \"%s\". Bạn có muốn tự động đặt nó "
+#~ "thành \"%s\"?"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr ""
+#~ "\"%s\" hiện tại được gán cho \"%s\", phím tắt này sẽ bị tắt nếu bạn di "
+#~ "chuyển về phía trước."
+
+#~ msgid "_Assign"
+#~ msgstr "_Gán"
+
+#~ msgid "Bond"
+#~ msgstr "Bond"
+
+#~ msgid "Team"
+#~ msgstr "Team"
+
+#~ msgid "Bridge"
+#~ msgstr "Bridge"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "Không thể tải phần mở rộng VPN"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "Thêm kết nối mạng"
+
+#~ msgid "Bond slaves"
+#~ msgstr "Bond slave"
+
+#~ msgid "(none)"
+#~ msgstr "(không)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "Bridge slave"
+
+#~ msgid "Team slaves"
+#~ msgstr "Team slave"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "Thiết bị InfiniBand không hỗ trợ chế độ kết nối"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "Chưa chọn chứng nhận CA."
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "Không dùng giấy chứng nhận CA có thể là nguyên nhân gây nên mất an toàn "
+#~ "của kết nối, mạng Wi-Fi lừa đảo. Bạn có muốn chọn một giấy chứng nhận CA "
+#~ "không?"
+
+#~ msgid "Ignore"
+#~ msgstr "Bỏ qua"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "Chọn chứng nhận CA"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "Luôn _Hỏi mật khẩu này"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "Đừng _cảnh báo tôi nữa"
+
+#~ msgid "Yes"
+#~ msgstr "Có"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "Không thể đăng nhập vào tài khoản này"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "Các giấy ủy nhiệm đã hết hạn."
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "Đăng nhập để bật tài khoản này."
+
+#~ msgid "_Sign In"
+#~ msgstr "Đă_ng nhập"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "Khác"
+
+#~ msgid "Personal File Sharing"
+#~ msgstr "Chia sẻ tập tin cá nhân"
+
+#~ msgid "_Verify"
+#~ msgstr "_Kiểm tra"
+
+#~ msgid "Login History"
+#~ msgstr "Lịch sử đăng nhập"
+
+#~ msgid "Add User Account"
+#~ msgstr "Thêm tài khoản người dùng"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "Đã có người dùng tên “%s” rồi."
+
+#~ msgid "Done"
+#~ msgstr "Xong"
+
+#~ msgid "Time _Zone"
+#~ msgstr "_Múi giờ"
+
+#~ msgid "_Delay:"
+#~ msgstr "_Khoảng trễ:"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "Ngắn"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "Chậm"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "Chậm"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "Nhanh"
+
+#~ msgid "S_peed:"
+#~ msgstr "_Tốc độ:"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "Kiểm tra các cài đặt của bạn"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "Chậm"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "Nhanh"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "Nút _trái"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "Nút _phải"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "Tốc độ _con trỏ"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Chậm"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Nhanh"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "Chậm"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "Nhanh"
+
+#~ msgid "No printers available"
+#~ msgstr "Không có máy in"
+
+#~ msgid "Resume Printing"
+#~ msgstr "Tiếp tục in"
+
+#~ msgid "Pause Printing"
+#~ msgstr "Tạm ngừng in"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "Đang giữ"
+
+#~ msgid "Job Title"
+#~ msgstr "Tên yêu cầu"
+
+#~ msgid "Job State"
+#~ msgstr "Tình trạng"
+
+#~ msgid "Add New Printer"
+#~ msgstr "Thêm máy in"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "Dùng để nhận dạng vị trí địa lý của bạn"
+
+#~ msgid "Options"
+#~ msgstr "Tùy chọn"
+
+#~ msgid "Password:"
+#~ msgstr "Mật khẩu:"
+
+#~ msgid "Zoom"
+#~ msgstr "Phóng"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "Màu sắc"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "Thiết bị Wireless cần thêm nguồn điện"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "Khi nguồn pin _cực thấp"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr ""
+#~ "Chia sẻ Bluetooth cho phép bạn chia sẻ các tập tin với các thiết bị "
+#~ "Bluetooth đang bật khác"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "Chỉ nhận từ các thiết bị đáng tin"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "Ghi các tập tin nhận được vào thư mục “Tải về”"
+
+#~ msgid "Show help options"
+#~ msgstr "Hiển thị các tùy chọn trợ giúp"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Chạy “%s --help” để xem danh sách tùy chọn dòng lệnh.\n"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "Tắt thiết bị wireless (không dây)"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "_Tắt khi đang gõ"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "Dịch vụ mạng hệ thống không tương thích với phiên bản này."
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "Hiển thị Banner nổi lên"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "Xem trong màn hình khóa"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "Hiển thị Banner nổi lên"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "Xem trong màn hình khóa"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "Nhập địa chỉ của một máy in hay đoạn văn để lọc kết quả"
+
+#~ msgid "Sorry"
+#~ msgstr "Xin lỗi"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "Cài đặt thiết bị mới"

--- a/po/wa.po
+++ b/po/wa.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center 1.5.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2003-01-02 12:26+0100\n"
 "Last-Translator: Pablo Saratxaga <pablo@mandrakesoft.com>\n"
 "Language-Team: Walon <linux-wa@chanae.alphanet.ch>\n"
@@ -22,3479 +22,6036 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
 #, fuzzy
-msgid "Alert Type"
-msgstr "Radjouter sôre di fitchî"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-msgid "The type of alert"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-#, fuzzy
-msgid "Alert Buttons"
-msgstr "Botons"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-#, fuzzy
-msgid "Show more _details"
-msgstr "_Detays"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-#, fuzzy
-msgid "About Me"
-msgstr "Å _dfait"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your personal information"
-msgstr "Tchoezixhoz vos prémetous programes"
-
-#: ../capplets/about-me/gnome-about-me.c:554
-#, fuzzy
-msgid "Select Image"
-msgstr "Disfacer"
-
-#: ../capplets/about-me/gnome-about-me.c:556
-#, fuzzy
-msgid "No Image"
-msgstr "Imådjes"
-
-#: ../capplets/about-me/gnome-about-me.c:706
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:727
-msgid "Unable to open address book"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:739
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:770
-#: ../capplets/about-me/gnome-about-me.c:772
-#, fuzzy, c-format
-msgid "About %s"
-msgstr "Å _dfait"
-
-#: ../capplets/about-me/gnome-about-me-password.c:101
-#: ../capplets/about-me/gnome-about-me-password.c:479
-msgid "Old password is incorrect, please retype it"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:112
-msgid "System error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:113
-msgid "Could not run /usr/bin/passwd"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:114
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:117
-msgid "Unexpected error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:315
-msgid "Password is too short"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:318
-#: ../capplets/about-me/gnome-about-me-password.c:321
-msgid "Password is too simple"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:324
-msgid "Old and new passwords are too similar"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:328
-msgid "Old and new password are the same"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:406
-#, fuzzy
-msgid "Please type the passwords."
-msgstr "_Sicrete:"
-
-#: ../capplets/about-me/gnome-about-me-password.c:414
-msgid "Please type the password again, it is wrong."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:417
-msgid "Click on Change Password to change the password."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/font/font-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-#, fuzzy
-msgid "    "
-msgstr "      "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-#, fuzzy
-msgid "<b>Email</b>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-#, fuzzy
-msgid "<b>Home</b>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-#, fuzzy
-msgid "<b>Instant Messaging</b>"
-msgstr "Rindou del fonte"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-#, fuzzy
-msgid "<b>Job</b>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-#, fuzzy
-msgid "<b>Telephone</b>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-#, fuzzy
-msgid "<b>Web</b>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-#, fuzzy
-msgid "<b>Work</b>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-#, fuzzy
-msgid "A_ddress:"
-msgstr "_Radjouter:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-#, fuzzy
-msgid "Address"
-msgstr "_Radjouter:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-#, fuzzy
-msgid "C_ity:"
-msgstr "Cô_per"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-#, fuzzy
-msgid "C_ompany:"
-msgstr "Co_mande:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-#, fuzzy
-msgid "Cale_ndar:"
-msgstr "Cate_goreye:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-#, fuzzy
-msgid "Change Passwo_rd..."
-msgstr "_Sicrete:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-#, fuzzy
-msgid "Change Password"
-msgstr "_Sicrete:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-#, fuzzy
-msgid "Ci_ty:"
-msgstr "Cô_per"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-#, fuzzy
-msgid "Co_untry:"
-msgstr "C_oleur:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-#, fuzzy
-msgid "Contact"
-msgstr "Å d_vins"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-#, fuzzy
-msgid "Cou_ntry:"
-msgstr "C_oleur:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-#, fuzzy
-msgid "Hom_e:"
-msgstr "_No:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-#, fuzzy
-msgid "Old pa_ssword:"
-msgstr "_Sicrete:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P.O. _box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P._O. box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-#, fuzzy
-msgid "Personal Info"
-msgstr "Fonte po les _terminås:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "State/Pro_vince:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#, fuzzy
-msgid "User name:"
-msgstr "No d' _uzeu:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Web _log:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-#, fuzzy
-msgid "Wor_k:"
-msgstr "C_oleur:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-#, fuzzy
-msgid "Work _fax:"
-msgstr "C_oleur:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Zip/_Postal code:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-#, fuzzy
-msgid "_Address:"
-msgstr "_Radjouter:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-#, fuzzy
-msgid "_Home page:"
-msgstr "No d' _uzeu:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-#, fuzzy
-msgid "_Home:"
-msgstr "_No:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-#, fuzzy
-msgid "_Manager:"
-msgstr "Manaedjeu di purneas"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-#, fuzzy
-msgid "_Mobile:"
-msgstr "_Fitchî"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-#, fuzzy
-msgid "_New password:"
-msgstr "_Sicrete:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-#, fuzzy
-msgid "_Profession:"
-msgstr "_Discrijhaedje:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-#, fuzzy
-msgid "_Retype new password:"
-msgstr "_Sicrete:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-#, fuzzy
-msgid "_Title:"
-msgstr "_Fitchî"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-#, fuzzy
-msgid "_Work:"
-msgstr "C_oleur:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Zip/Postal code:"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-#, fuzzy
-msgid "<b>Applications</b>"
+msgid "Applications"
 msgstr "<b>_Eployî l' otintifiaedje</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+#: panels/applications/cc-applications-panel.ui:31
 #, fuzzy
-msgid "<b>Support</b>"
-msgstr "<i>Roed</i>"
+msgid "No applications"
+msgstr "<b>_Eployî l' otintifiaedje</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+#: panels/applications/cc-applications-panel.ui:34
 #, fuzzy
-msgid "Assistive Technology Preferences"
-msgstr "Preferinces pol purnea"
+msgid "Install some…"
+msgstr "_Astaler novea tinme..."
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+#: panels/applications/cc-applications-panel.ui:84
 #, fuzzy
-msgid "_Screenreader"
-msgstr "Waitroûle"
+msgid "Open"
+msgstr "_Drovi"
 
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/main.c:60
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
-msgid "Import Feature Settings File"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
-msgid "_Import"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Taprece"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-#: ../capplets/theme-switcher/theme-install.glade.h:1
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+#: panels/applications/cc-applications-panel.ui:94
 #, fuzzy
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "Mete en alaedje les _londjinnès tapes"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-#, fuzzy
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "Mete en alaedje les _londjinnès tapes"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-#, fuzzy
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "Mete en alaedje les _londjinnès tapes"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-#, fuzzy
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "_Ripeter les tapes:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-#, fuzzy
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "Mete en alaedje les _londjinnès tapes"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-#, fuzzy
-msgid "<b>Features</b>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "Di båze"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr "_Tårdjaedje:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr "Tårdjaedje inte les tapes eyet pol mo_vmint do cursoe:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Passetes"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-#, fuzzy
-msgid "Mouse Keys"
-msgstr "Sori"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr "_Preferinces pol sori..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "S_peed:"
-msgstr "_Roedeu:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Type to test settings:"
-msgstr "_Tapez po sayî l' apontiaedje:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr ""
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr "caracteres/segonde"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-msgid "milliseconds"
-msgstr "milisegondes"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr "picsels/segonde"
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:885
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "segondes"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-#, fuzzy
-msgid "Change your Desktop Background settings"
-msgstr "Apontiaedje da vosse do fond do scribanne"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-#, fuzzy
-msgid "Desktop Background"
-msgstr "Fond"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-#, fuzzy
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "_Tapisreye"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-#, fuzzy
-msgid "<b>_Desktop Colors</b>"
-msgstr "_Tapisreye"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-#, fuzzy
-msgid "Desktop Background Preferences"
-msgstr "Preferinces pol fond"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-#, fuzzy
-msgid "_Add Wallpaper"
-msgstr "_Tapisreye"
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-msgid "_Style:"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr ""
-
-#: ../capplets/background/gnome-wp-capplet.c:1042
-#: ../capplets/background/gnome-wp-capplet.c:1060
-#, fuzzy
-msgid "Centered"
-msgstr "Å _mitan"
-
-#: ../capplets/background/gnome-wp-capplet.c:1068
-#: ../capplets/background/gnome-wp-capplet.c:1085
-#, fuzzy
-msgid "Fill Screen"
-msgstr "Waitroûle"
-
-#: ../capplets/background/gnome-wp-capplet.c:1093
-#: ../capplets/background/gnome-wp-capplet.c:1110
-#, fuzzy
-msgid "Scaled"
-msgstr "Al _schåle"
-
-#: ../capplets/background/gnome-wp-capplet.c:1118
-#: ../capplets/background/gnome-wp-capplet.c:1135
-#, fuzzy
-msgid "Tiled"
-msgstr "_Fitchî"
-
-#: ../capplets/background/gnome-wp-capplet.c:1159
-#: ../capplets/background/gnome-wp-capplet.c:1168
-#, fuzzy
-msgid "Solid Color"
-msgstr "Coleur solide"
-
-#: ../capplets/background/gnome-wp-capplet.c:1176
-#: ../capplets/background/gnome-wp-capplet.c:1185
-#, fuzzy
-msgid "Horizontal Gradient"
-msgstr "Degradé di coûtchî"
-
-#: ../capplets/background/gnome-wp-capplet.c:1193
-#: ../capplets/background/gnome-wp-capplet.c:1202
-#, fuzzy
-msgid "Vertical Gradient"
-msgstr "Degradé d' astampé"
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1251
-#, fuzzy
-msgid "Add Wallpaper"
-msgstr "_Tapisreye"
-
-#: ../capplets/background/gnome-wp-info.c:57
-#, fuzzy
-msgid "No Wallpaper"
-msgstr "_Tapisreye"
-
-#: ../capplets/background/gnome-wp-item.c:292
-#: ../capplets/background/gnome-wp-item.c:294
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/common/activate-settings-daemon.c:18
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-
-#: ../capplets/common/capplet-stock-icons.c:94
-#, c-format
-msgid "Unable to load capplet stock icon '%s'\n"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr ""
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/default-applications/gnome-default-applications-properties.c:765
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1021
-#: ../capplets/sound/sound-properties-capplet.c:244
-msgid "Retrieve and store legacy settings"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %i of %i"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:345
-msgid "From:"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:349
-#, fuzzy
-msgid "To:"
-msgstr "Deus"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Clé"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Dji n' a savou trover l' fitchî «%s».\n"
-"\n"
-"Acertinez vs s' i vs plait k' il egzistêye bén, eyet rssayîz oudonbén "
-"tchoezixhoz ene imådje di fond diferinne."
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr "Tchoezixhoz ene imådje s' i vs plait."
-
-#: ../capplets/common/gconf-property-editor.c:1598
-#, fuzzy
-msgid "_Select"
-msgstr "Disfacer"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
-msgstr ""
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Tchoezixhoz vos prémetous programes"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
-#, fuzzy
-msgid "Debian Sensible Browser"
-msgstr "Prémetou betchteu waibe"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
-msgid "Epiphany"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
-msgid "Galeon"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
-msgid "Encompass"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
-msgid "Firebird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
-msgid "Firefox"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
-msgid "Mozilla"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
-msgid "Netscape Communicator"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
-msgid "Konqueror"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
-#, fuzzy
-msgid "W3M Text Browser"
-msgstr "Betchteu waibe"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
-#, fuzzy
-msgid "Lynx Text Browser"
-msgstr "Betchteu waibe"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
-#, fuzzy
-msgid "Links Text Browser"
-msgstr "Betchteu waibe"
-
-#. The code in gnome-default-applications-properties.c makes sure
-#. * there is only one (the first entry in this list) Evolution entry
-#. * in the list shown to the user
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
-#, fuzzy
-msgid "Evolution Mail Reader"
-msgstr "Foyteuse di l' aidance da _vosse"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
-msgid "Balsa"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
-msgid "KMail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
-msgid "Thunderbird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
-msgid "Mozilla Mail"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
-msgid "Mutt"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
-#, fuzzy
-msgid "Debian Terminal Emulator"
-msgstr "Prémetou terminå"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
-#, fuzzy
-msgid "GNOME Terminal"
-msgstr "Terminå"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
-#, fuzzy
-msgid "Standard XTerminal"
-msgstr "Enonder dins on t_erminå"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
-msgid "NXterm"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
-msgid "RXVT"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
-#, fuzzy
-msgid "aterm"
-msgstr "Categoreye"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
-#, fuzzy
-msgid "ETerm"
-msgstr "Terminå"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.c:123
-msgid "Please specify a name and a command for this editor."
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "Add..."
-msgstr "Radjouter..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-#, fuzzy
-msgid "C_ustom"
-msgstr "A _vosse môde:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "C_ustom:"
-msgstr "A _vosse môde:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "Can open _URIs"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "Can open multiple _files"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "Co_mmand:"
-msgstr "Co_mande:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "Custom Editor Properties"
-msgstr "Prôpietés di l' aspougneu di tecse da vosse"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-#, fuzzy
-msgid "Default Mail Reader"
-msgstr "Prémetou manaedjeu di purneas"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "Default Terminal"
-msgstr "Prémetou terminå"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Default Text Editor"
-msgstr "Prémetou aspougneu di tecse"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "Default Web Browser"
-msgstr "Prémetou betchteu waibe"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Default Window Manager"
-msgstr "Prémetou manaedjeu di purneas"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Delete"
-msgstr "Disfacer"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "E_xec Flag:"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Edit..."
-msgstr "Candjî..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Mail Reader"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-#, fuzzy
-msgid "Run in a _terminal"
-msgstr "Enonder dins on _terminå"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-#, fuzzy
-msgid "Run in a t_erminal"
-msgstr "Enonder dins on _terminå"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid ""
-"Select the window manager you want.  You will need to hit apply, wave the "
-"magic wand, and do a magic dance for it to work."
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Terminal"
-msgstr "Terminå"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Text Editor"
-msgstr "Aspougneu di tecse"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Understands _Netscape Remote Control"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "Use this _editor to open text files in the file manager"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "Web Browser"
-msgstr "Betchteu waibe"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
-msgid "Window Manager"
-msgstr "Manaedjeu di purneas"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
-#, fuzzy
-msgid "_Command:"
-msgstr "Co_mande:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
-msgid "_Name:"
-msgstr "_No:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
-msgid "_Properties..."
-msgstr "_Prôpietés..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
-#, fuzzy
-msgid "_Select:"
-msgstr "Disfacer"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr ""
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr ""
-
-#: ../capplets/display/main.c:448
-#, fuzzy
-msgid "_Resolution:"
-msgstr "_Discrijhaedje:"
-
-#: ../capplets/display/main.c:467
-msgid "Re_fresh rate:"
-msgstr ""
-
-#: ../capplets/display/main.c:488
-#, fuzzy
-msgid "Default Settings"
-msgstr "Prémetou terminå"
-
-#: ../capplets/display/main.c:490
-#, fuzzy, c-format
-msgid "Screen %d Settings\n"
-msgstr "Sipepieus apontiaedjes"
-
-#: ../capplets/display/main.c:516
-#, fuzzy
-msgid "Screen Resolution Preferences"
-msgstr "Preferinces pol son"
-
-#: ../capplets/display/main.c:553
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr ""
-
-#: ../capplets/display/main.c:571
-#, fuzzy
-msgid "Options"
-msgstr "Accions"
-
-#: ../capplets/display/main.c:592
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/display/main.c:638
-#, fuzzy
-msgid "Keep Resolution"
-msgstr "_Discrijhaedje:"
-
-#: ../capplets/display/main.c:642
-msgid "Do you want to keep this resolution?"
-msgstr ""
-
-#: ../capplets/display/main.c:667
-msgid "Use _previous resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:667
-msgid "_Keep resolution"
-msgstr ""
-
-#: ../capplets/display/main.c:818
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-
-#: ../capplets/display/main.c:826
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Fonte"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr "Tchoezi les fontes pol sicribanne"
-
-#: ../capplets/font/font-properties.glade.h:2
-#, fuzzy
-msgid "<b>Font Rendering</b>"
-msgstr "Rindou del fonte"
-
-#: ../capplets/font/font-properties.glade.h:3
-#, fuzzy
-msgid "<b>Hinting</b>:"
-msgstr "Rindou del fonte"
-
-#: ../capplets/font/font-properties.glade.h:4
-#, fuzzy
-msgid "<b>Smoothing</b>:"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/font/font-properties.glade.h:5
-#, fuzzy
-msgid "<b>Subpixel order</b>:"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best _shapes"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "Best co_ntrast"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:8
-#, fuzzy
-msgid "D_etails..."
-msgstr "De_tays..."
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "Preferinces pol fonte"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr "Detays do rindou del fonte"
-
-#: ../capplets/font/font-properties.glade.h:11
-#, fuzzy
-msgid "Go _to font folder"
-msgstr "_Potchî å ridant des tinmes"
-
-#: ../capplets/font/font-properties.glade.h:12
-#, fuzzy
-msgid "Gra_yscale"
-msgstr "Schåle di _gris"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "N_ole"
-
-#: ../capplets/font/font-properties.glade.h:14
-#, fuzzy
-msgid "R_esolution:"
-msgstr "_Discrijhaedje:"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
-msgstr "Fonte po les _programes:"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Desktop font:"
-msgstr "Fonte pol _sicribanne:"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Full"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Medium"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Monochrome"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_None"
-msgstr "_Nouk"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_RGB"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_Slight"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Terminal font:"
-msgstr "Fonte po les _terminås:"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr ""
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "Fonte pol tite des _purneas:"
-
-#: ../capplets/font/font-properties.glade.h:30
-#, fuzzy
-msgid "dots per inch"
-msgstr "Finté (_ponts par pôce):"
-
-#: ../capplets/font/main.c:488
-msgid "Font may be too large"
-msgstr ""
-
-#: ../capplets/font/main.c:492
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/font/main.c:505
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr ""
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:197
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+msgid "View Details"
+msgstr "_Detays"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Dismetou"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:545
-msgid "<Unknown Action>"
-msgstr "<Accion nén cnoxhowe>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:566
-msgid "Desktop"
-msgstr "Sicribanne"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:567
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
-msgstr "Son"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:571
-msgid "Window Management"
-msgstr "Manaedjmint des purneas"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:668
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:700
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:750
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr ""
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:857
-msgid "Action"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
 msgstr "Accion"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:881
-msgid "Shortcut"
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Fond"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Waitroûle"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "_Tapisreye"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Son"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
 msgstr "Rascourti"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
 msgstr "Rascourtis del taprece"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
 msgstr ""
 
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
 #, fuzzy
-msgid "Unknown"
+msgid "File Types"
+msgstr "Radjouter sôre di fitchî"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
 msgstr ""
-"<b>Cursoe nén cnoxhou</b>\n"
-"%s"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
-msgid "Layout"
-msgstr "Adjinçmint"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
 
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Fonte po les _programes:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<i>Roed</i>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 #, fuzzy
 msgid "Default"
 msgstr "Prémetou betchteu waibe"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 #, fuzzy
-msgid "Models"
-msgstr "Modele"
+msgid "Background"
+msgstr "Fond"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:106
-#, c-format
-msgid "There was an error launching the keyboard capplet : %s"
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:240
-#: ../capplets/sound/sound-properties-capplet.c:242
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
 #, fuzzy
-msgid "..."
+msgid "_Add"
 msgstr "Radjouter..."
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
 #, fuzzy
-msgid "<b>Cursor Blinking</b>"
-msgstr "Tinme do cursoe"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-#, fuzzy
-msgid "<b>Repeat Keys</b>"
-msgstr "_Ripeter les tapes:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Roed</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Long</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Court</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Londjin</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_vailable layouts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "All_ow postponing of breaks"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Check if breaks are allowed to be postponed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-#, fuzzy
-msgid "Choose A Keyboard Model"
-msgstr "Xhuflet del taprece"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Choose A Layout"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Duration of the break when typing is disallowed"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of work before forcing a break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Key presses _repeat when key is held down"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Keyboard Preferences"
-msgstr "Preferinces del taprece"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-#, fuzzy
-msgid "Keyboard _model:"
-msgstr "Xhuflet del taprece"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-#, fuzzy
-msgid "Layout Options"
-msgstr "Tchuzes po les imådjes:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-#, fuzzy
-msgid "Layouts"
-msgstr "Adjinçmint"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Microsoft Natural Keyboard"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-#, fuzzy
-msgid "Preview:"
-msgstr "Vey divant"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Reset To De_faults"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Separate _group for each window"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Typing Break"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "_Accessibility..."
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-#, fuzzy
-msgid "_Add..."
-msgstr "Radjouter..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Break interval lasts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Delay:"
-msgstr "_Tårdjaedje:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-#, fuzzy
-msgid "_Models:"
+msgid "_Add profile"
 msgstr "Modele"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
 #, fuzzy
-msgid "_Selected layouts:"
-msgstr "_Tchoezi on aspougneu di tecse:"
+msgid "_Remove profile"
+msgstr "_Bodjî"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Speed:"
-msgstr "_Roedeu:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Work interval lasts:"
-msgstr ""
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "minutes"
-msgstr ""
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Defini vos preferinces pol taprece"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:559
+#: panels/color/cc-color-panel.ui:517
 #, fuzzy
-msgid "Unknown Cursor"
-msgstr ""
-"<b>Cursoe nén cnoxhou</b>\n"
-"%s"
+msgid "_View details"
+msgstr "_Detays"
 
-#: ../capplets/mouse/gnome-mouse-properties.c:761
-#, fuzzy
-msgid "Default Cursor"
-msgstr "Prémetou betchteu waibe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Cursor - Current"
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-#, fuzzy
-msgid "The default cursor that ships with X"
-msgstr ""
-"<b>Prémetou cursoe</b>\n"
-"Li prémetou cursoe ki vént avou X11"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-#, fuzzy
-msgid "White Cursor"
-msgstr "Cursoes"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Cursor - Current"
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-#, fuzzy
-msgid "The default cursor inverted"
-msgstr ""
-"<b>Blanc cursoe</b>\n"
-"Li prémetou cursoe, avou les coleurs å rvier"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-#, fuzzy
-msgid "Large Cursor"
-msgstr "Cursoes"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Cursor - Current"
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-#, fuzzy
-msgid "Large version of normal cursor"
-msgstr ""
-"<b>Lådje cursoe</b>\n"
-"Modêye lådje do cursoe normå"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-#, fuzzy
-msgid "Large White Cursor - Current"
-msgstr ""
-"<b>Lådje blanc cursoe - cursoe do moumint</b>\n"
-"Modêye lådje do blanc cursoe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Cursor"
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-#, fuzzy
-msgid "Large version of white cursor"
-msgstr ""
-"<b>Lådje blanc cursoe</b>\n"
-"Modêye lådje do blanc cursoe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:975
-#, fuzzy
-msgid "Cursor Theme"
-msgstr "Tinme do cursoe"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-#, fuzzy
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>_Eployî l' otintifiaedje</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-#, fuzzy
-msgid "<b>Speed</b>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>Hôt</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>Lådje</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>Bas</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>Londjin</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>Pitit</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Botons"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
-#, fuzzy
-msgid "Cursor Size:"
-msgstr "Cursoes"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Cursors"
-msgstr "Cursoes"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Highlight the _pointer when you press Ctrl"
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-#, fuzzy
-msgid "Large"
-msgstr "Pådjes di manuel"
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
 msgid "Medium"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Motion"
-msgstr "Movmint"
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Mouse Preferences"
-msgstr "Preferinces pol sori"
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
 #, fuzzy
-msgid "Small"
-msgstr "Al _schåle"
+msgid "Color"
+msgstr "Coleur solide"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
-msgstr ""
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Sori"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Defini vos preferinces pol sori"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+#: panels/common/cc-language-chooser.ui:5
 #, fuzzy
-msgid "Network Proxy"
-msgstr "Proxy pol rantoele"
+msgid "Select Language"
+msgstr "Disfacer"
 
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#: panels/common/cc-language-chooser.ui:13
 #, fuzzy
-msgid "Set your network proxy preferences"
-msgstr "Preferinces pol proxy del rantoele"
+msgid "_Select"
+msgstr "Disfacer"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-#, fuzzy
-msgid "<b>D_irect internet connection</b>"
-msgstr "<b>Raloyaedje _direk al daegntoele</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
 msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>Apontiaedje _otomatike do proxy</b>"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>Apontiaedje al _mwin do proxy</b>"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "_Tårdjaedje:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "Rascourti"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Dismetou"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "segondes"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Cate_goreye:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Cate_goreye:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Tchoezixhoz vos prémetous programes"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Tchoezixhoz vos prémetous programes"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "Fonte po les _programes:"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
 msgstr "<b>_Eployî l' otintifiaedje</b>"
 
-#: ../capplets/network/gnome-network-preferences.glade.h:7
+#: panels/display/cc-display-settings.ui:50
 #, fuzzy
-msgid "Advanced Configuration"
-msgstr "Sipepieus apontiaedjes"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr "_Hårdêye po l' apontiaedje otomatike:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "Detays do proxy HTTP"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-#, fuzzy
-msgid "H_TTP proxy:"
-msgstr "Proxy _HTTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-#, fuzzy
-msgid "Network Proxy Preferences"
-msgstr "Preferinces pol proxy del rantoele"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Pôrt:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-#, fuzzy
-msgid "Proxy Configuration"
-msgstr "Apontiaedje do proxy pol rantoele"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr "Lodjoe S_OCKS:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-#, fuzzy
-msgid "U_sername:"
-msgstr "No d' _uzeu:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_Detays"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr "Proxy _FTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "_Sicrete:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr ""
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Mete en alaedje les sons eyet ls assocyî avou des evenmints"
-
-#: ../capplets/sound/sound-properties-capplet.c:271
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Sound Preferences"
-msgstr "Preferinces pol son"
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "E_nable sound server startup"
-msgstr "Mete en _ouve li sierveu di sons a l' enondaedje"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "Flash _entire screen"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "Flash _window titlebar"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "General"
-msgstr "Djenerå"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "Sound Events"
-msgstr "Sons po ls evenmints"
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "System Bell"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "_Sound an audible bell"
-msgstr ""
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "_Sounds for events"
-msgstr "_Sons po ls evenmints"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "_Visual feedback:"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:347
-msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:227
-msgid "This theme is not in a supported format."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:244
-msgid "Failed to create temporary directory"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:264
-msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:282
-#: ../capplets/theme-switcher/gnome-theme-installer.c:319
-#: ../capplets/theme-switcher/gnome-theme-installer.c:399
-msgid "Installation Failed"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:302
-msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:340
-#, c-format
-msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:343
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:346
-#, c-format
-msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:349
-#, c-format
-msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:357
-msgid "The theme is an engine. You need to compile the theme."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:374
-msgid "The file format is invalid"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:468
-msgid "No theme file location specified to install"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:485
-msgid "The theme file location specified to install is invalid"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:505
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:526
-msgid "The file format is invalid."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:553
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:607
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-#, fuzzy
-msgid "Custom theme"
-msgstr "Tinme do cursoe"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:72
-msgid "Theme name must be present"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:104
-msgid "The theme already exists. Would you like to replace it?"
-msgstr ""
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr "Tchoezi les tinmes po sacwantès pårteyes do scribanne"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "Tinme"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-install.glade.h:3
-msgid "Theme Installation"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-install.glade.h:4
-msgid "_Install"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-install.glade.h:5
-#, fuzzy
-msgid "_Location:"
-msgstr "Accion"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-#, fuzzy
-msgid "Apply _Background"
-msgstr "Fond"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Apply _Font"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Controls"
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "Icons"
-msgstr "Imådjetes"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "New themes can also be installed by dragging them into the window."
-msgstr ""
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-#, fuzzy
-msgid "Save Theme"
-msgstr "_Schaper tinme"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-#, fuzzy
-msgid "Select theme for the desktop"
-msgstr "Tchoezi les fontes pol sicribanne"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-#, fuzzy
-msgid "Short _description:"
+msgctxt "display setting"
+msgid "Resolution"
 msgstr "_Discrijhaedje:"
 
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-#, fuzzy
-msgid "Theme Details"
-msgstr "_Detays"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "Theme Preferences"
-msgstr "Preferinces pol tinme"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-#, fuzzy
-msgid "Theme _Details"
-msgstr "_Detays"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-#, fuzzy
-msgid "This theme does not suggest any particular font or background."
-msgstr "Apontiaedje da vosse do fond do scribanne"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-#, fuzzy
-msgid "This theme suggests a background:"
-msgstr "Apontiaedje da vosse do fond do scribanne"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-#, fuzzy
-msgid "This theme suggests a font and a background:"
-msgstr "Apontiaedje da vosse do fond do scribanne"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-#, fuzzy
-msgid "This theme suggests a font:"
-msgstr "Apontiaedje da vosse do fond do scribanne"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "Window Border"
-msgstr "Boird do purnea"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-#, fuzzy
-msgid "_Go To Theme Folder"
-msgstr "_Potchî å ridant des tinmes"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-#, fuzzy
-msgid "_Install Theme..."
-msgstr "_Astaler novea tinme..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-#, fuzzy
-msgid "_Revert"
-msgstr "_Bodjî"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-#, fuzzy
-msgid "_Save Theme..."
-msgstr "_Schaper tinme"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-#, fuzzy
-msgid "_Theme name:"
-msgstr "No d' _uzeu:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:24
-msgid "theme selection tree"
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
 msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
 msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "Menus & Bårs ås usteyes"
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Al _schåle"
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
 msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<i>Roed</i>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "Cô_per"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-#, fuzzy
-msgid "Icons only"
-msgstr "Rén k' les imådjetes"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "Preferinces pol menu eyet l' bår ås usteyes"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "Novea fitchî"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Drovi on fitchî"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Schaper fitchî"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr "Håyner les _imådjetes dins les menus"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-#, fuzzy
-msgid "Text below icons"
-msgstr "Tecse pa dzo les imådjetes"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-#, fuzzy
-msgid "Text beside icons"
-msgstr "Tecse a costé des imådjetes"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-#, fuzzy
-msgid "Text only"
-msgstr "Rén kel tecse"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
-#, fuzzy
-msgid "Toolbar _button labels:"
-msgstr "Etiketes des _botons:"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_Copyî"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
 msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
-msgstr "_Candjî"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
 msgstr ""
 
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "_Fitchî"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_Novea"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
-msgstr "_Drovi"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "C_laper"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "_Eprimî"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "Moussî _foû"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "_Schaper"
-
-#: ../capplets/windows/gnome-window-properties.c:386
-#, c-format
+#: panels/display/cc-night-light-page.ui:33
 msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr ""
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "Deus"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
 "\n"
-"%s"
+"For more information, contact the hardware manufacturer or IT support."
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.c:644
-msgid "Control"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.c:649
-msgid "Alt"
-msgstr "Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:655
-msgid "Hyper"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.c:662
-msgid "Super (or \"Windows logo\")"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
 msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.c:669
-msgid "Meta"
-msgstr "Meta"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
 
-#: ../capplets/windows/gnome-window-properties.glade.h:1
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
 #, fuzzy
-msgid "<b>Movement Key</b>"
-msgstr "_Ripeter les tapes:"
+msgid "No Events"
+msgstr "Sons po ls evenmints"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:2
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
 #, fuzzy
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>_Eployî l' otintifiaedje</b>"
+msgid "OS Name"
+msgstr "_No:"
 
-#: ../capplets/windows/gnome-window-properties.glade.h:3
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 #, fuzzy
-msgid "<b>Window Selection</b>"
-msgstr "Rindou del fonte"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To _move a window, press-and-hold this key then grab the window:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Preferinces pol purnea"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-#, fuzzy
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_Dobe-clitchî sol tite des purneas po:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr ""
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Tchoezi les purneas cwand l' sori passe å dzeur"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-#, fuzzy
-msgid "Set your window properties"
-msgstr "Propietés pol purnea"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "Purneas"
-
-#: ../control-center/control-center-categories.c:257
-#, fuzzy
-msgid "Others"
-msgstr "Passetes"
-
-#: ../control-center/control-center.c:42
-#, fuzzy
-msgid "Desktop Preferences"
-msgstr "Preferinces del taprece"
-
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr "Cinte di Contrôle di GNOME"
-
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "L' usteye d' apontiaedje di GNOME"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-#, fuzzy
-msgid "Volume"
-msgstr "_Volume:"
-
-#: ../gnome-settings-daemon/factory.c:36
-msgid "Could not initialize Bonobo"
-msgstr "Dji n' a savou inicyî Bonobo"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
-msgid "Slow Keys Alert"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
-msgid "Do you want to activate Slow Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
-msgid "Do you want to deactivate Slow Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Sticky Keys Alert"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
-msgid "Do you want to activate Sticky Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:107
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-"Dji n' a savou ahiver l' ridant «%s».\n"
-"I gn a mezåjhe del fé po permete li candjmint des cursoes."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
-#, c-format
-msgid "It seems that another application already has access to key '%d'."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
-#, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
-msgid "Do _not show this warning again"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
-msgid ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
-#, fuzzy
-msgid "Use X settings"
-msgstr "Sipepieus apontiaedjes"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
-msgid "Use GNOME settings"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
-#, c-format
-msgid "Permissions on the file %s are broken\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
-msgid "_Do not show this message again"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:129
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
-msgid "Cannot determine user's home directory"
-msgstr ""
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-#, fuzzy
-msgid "A_vailable files:"
-msgstr "Tchuzes po les imådjes:"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-msgid "Do _not show this warning again."
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-#, fuzzy
-msgid "_Loaded files:"
-msgstr "Modele"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr ""
-
-#: ../libbackground/applier.c:255
-msgid "Type"
+msgid "OS Type"
 msgstr "Sôre"
 
-#: ../libbackground/applier.c:256
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Terminå"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Purneas"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
 msgstr ""
 
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "No d' _uzeu:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "No d' _uzeu:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "Å _dfait"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
 msgstr ""
 
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr ""
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr ""
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr ""
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Waitroûle"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr ""
-
-#: ../libgswitchit/gswitchit_config.c:1035
-#, c-format
-msgid "There was an error loading an image: %s"
-msgstr ""
-
-#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
-msgid "The sound file for this event does not exist."
-msgstr ""
-
-#: ../libsounds/sound-view.c:149
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package\n"
-"for a set of default sounds."
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
 msgstr ""
 
-#: ../libsounds/sound-view.c:224
-#, c-format
-msgid "The file %s is not a valid wav file"
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
 msgstr ""
 
-#: ../libsounds/sound-view.c:289
-msgid "Event"
-msgstr "Evenmint"
-
-#: ../libsounds/sound-view.c:298
+#: panels/keyboard/00-multimedia.xml.in:4
 #, fuzzy
-msgid "Sound File"
-msgstr "Son"
+msgid "Volume mute/unmute"
+msgstr "_Volume:"
 
-#: ../libsounds/sound-view.c:314
-#, fuzzy
-msgid "_Sounds:"
-msgstr "_Sons"
-
-#: ../libsounds/sound-view.c:328
-#, fuzzy
-msgid "Sound _file:"
-msgstr "Tchoezi on fitchî di son"
-
-#: ../libsounds/sound-view.c:332
-#, fuzzy
-msgid "Select Sound File"
-msgstr "Tchoezi on fitchî di son"
-
-#: ../libsounds/sound-view.c:356
-msgid "_Play"
-msgstr "_Djower"
-
-#: ../libsounds/sound-view.c:366
-msgid "_Remove"
-msgstr "_Bodjî"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr ""
-"Li manaedjeu di purneas «%s» n' a nén redjistré ene usteye d' apontiaedje\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Å pus grand"
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Erôler"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "Brightness down"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "Brightness down's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Brightness up"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Brightness up's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "E-mail"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "E-mail's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-#, fuzzy
-msgid "Eject"
-msgstr "Evenmint"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-#, fuzzy
-msgid "Eject's shortcut."
-msgstr "Rascourtis do _scribanne:"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-#, fuzzy
-msgid "Home folder"
-msgstr "_Potchî å ridant des tinmes"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-#, fuzzy
-msgid "Home folder's shortcut."
-msgstr "Rascourti"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-#, fuzzy
-msgid "Launch help browser"
-msgstr "Foyteuse di l' aidance"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-#, fuzzy
-msgid "Launch help browser's shortcut."
-msgstr "Foyteuse di l' aidance"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-#, fuzzy
-msgid "Launch web browser"
-msgstr "Betchteu waibe"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-#, fuzzy
-msgid "Launch web browser's shortcut."
-msgstr "Betchteu waibe"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-#, fuzzy
-msgid "Lock screen"
-msgstr "Waitroûle"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-#, fuzzy
-msgid "Lock screen's shortcut."
-msgstr "Rascourti"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-#, fuzzy
-msgid "Log out"
-msgstr "Adjinçmint"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-#, fuzzy
-msgid "Log out's shortcut."
-msgstr "Rascourtis do _scribanne:"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Next track key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-#, fuzzy
-msgid "Pause"
-msgstr "C_laper"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-msgid "Pause key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Play (or play/pause)"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Play (or play/pause) key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Previous track key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
-msgid "Search"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-#, fuzzy
-msgid "Search's shortcut."
-msgstr "Rascourti"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Skip to next track"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Skip to previous track"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-#, fuzzy
-msgid "Sleep"
-msgstr "Roedeu"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-#, fuzzy
-msgid "Sleep's shortcut."
-msgstr "Rascourti"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Stop playback key"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Stop playback key's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+#: panels/keyboard/00-multimedia.xml.in:6
 #, fuzzy
 msgid "Volume down"
 msgstr "_Volume:"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume down's shortcut."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-#, fuzzy
-msgid "Volume mute"
-msgstr "_Volume:"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume mute's shortcut"
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
-#, fuzzy
-msgid "Volume step"
-msgstr "_Volume:"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-msgid "Volume step as percentage of volume."
-msgstr ""
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+#: panels/keyboard/00-multimedia.xml.in:8
 #, fuzzy
 msgid "Volume up"
 msgstr "_Volume:"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
-msgid "Volume up's shortcut."
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
-msgid "Display a dialog when there are errors running the screensaver"
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-msgid "Run screensaver at login"
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
 msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:24
 #, fuzzy
-msgid "Start screensaver"
+msgid "Eject"
+msgstr "Evenmint"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr ""
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Betchteu waibe"
+
+#: panels/keyboard/01-launchers.xml.in:4
+#, fuzzy
+msgid "Launch help browser"
+msgstr "Foyteuse di l' aidance"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Prémetou terminå"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+#, fuzzy
+msgid "Launch web browser"
+msgstr "Betchteu waibe"
+
+#: panels/keyboard/01-launchers.xml.in:14
+#, fuzzy
+msgid "Home folder"
+msgstr "_Potchî å ridant des tinmes"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+msgid "System"
+msgstr ""
+
+#: panels/keyboard/01-system.xml.in:4
+#, fuzzy
+msgid "Log out"
+msgstr "Adjinçmint"
+
+#: panels/keyboard/01-system.xml.in:6
+#, fuzzy
+msgid "Lock screen"
 msgstr "Waitroûle"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:8
 #, fuzzy
-msgid "Keyboard Update Handlers"
-msgstr "Xhuflet del taprece"
+msgid "Zoom out"
+msgstr "Adjinçmint"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
 #, fuzzy
-msgid "Keyboard layout"
-msgstr "Rascourtis del taprece"
+msgid "Options"
+msgstr "Accions"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
 #, fuzzy
-msgid "Keyboard model"
-msgstr "Xhuflet del taprece"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
-#, fuzzy
-msgid "Keyboard options"
-msgstr "Rascourtis del taprece"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
-#, fuzzy
-msgid "keyboard layout"
-msgstr "Rascourtis del taprece"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
-#, fuzzy
-msgid "keyboard model"
-msgstr "Xhuflet del taprece"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "modmap file list"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:212
-msgid "_Postpone break"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:259
-msgid "Take a break!"
-msgstr ""
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:141
-#, fuzzy
-msgid "/_Preferences"
+msgid "Preferences"
 msgstr "Preferinces pol fonte"
 
-#: ../typing-break/drwright.c:142
+#: panels/keyboard/cc-input-row.ui:48
 #, fuzzy
-msgid "/_About"
-msgstr "Å _dfait"
+msgid "View Keyboard Layout"
+msgstr "Rascourtis del taprece"
 
-#: ../typing-break/drwright.c:144
-msgid "/_Take a Break"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Bodjî"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
 msgstr ""
 
-#: ../typing-break/drwright.c:495
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Sori"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Rascourtis del taprece"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Accion"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Rascourti"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Rascourti"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Rascourti"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Rascourtis del taprece"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Bodjî"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "_No:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Co_mande:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Rascourti"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Rascourti"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_Nouk"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Taprece"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Tchoezixhoz vos prémetous programes"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Prémetou terminå"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Djenerå"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "Accion"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Sori"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Sori"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+msgid "Touchpad Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Fonte po les _programes:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Passetes"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Accion"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Accions"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../typing-break/drwright.c:499
-msgid "Less than one minute until the next break"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
 msgstr ""
 
-#: ../typing-break/drwright.c:587
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Proxy pol rantoele"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Sicrete:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "_Sicrete:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "_Radjouter:"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "_Radjouter:"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "_Radjouter:"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Prémetou betchteu waibe"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+"Software updates and other large downloads will not be started automatically."
 msgstr ""
 
-#: ../typing-break/drwright.c:635
-msgid "About GNOME Typing Monitor"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_No:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Radjouter:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
 msgstr ""
 
-#: ../typing-break/drwright.c:659
-msgid "A computer break reminder."
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Radjouter:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
 msgstr ""
 
-#: ../typing-break/drwright.c:660
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
 msgstr ""
 
-#: ../typing-break/drwright.c:661
-msgid "Eye candy added by Anders Carlsson"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
 msgstr ""
 
-#: ../typing-break/drwright.c:837
-msgid "Break reminder"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
 msgstr ""
 
-#: ../typing-break/main.c:93
-msgid "The typing monitor is already running."
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
 msgstr ""
 
-#: ../typing-break/main.c:106
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Dismetou"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_Radjouter:"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+#, fuzzy
+msgid "Address"
+msgstr "_Radjouter:"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Proxy pol rantoele"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Accion"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "_Radjouter:"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Proxy pol rantoele"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "Proxy _HTTP:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "Proxy _HTTP:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "Proxy _FTP:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Lodjoe S_OCKS:"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "Proxy _HTTP:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "Proxy _HTTP:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "Proxy _FTP:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "_Hårdêye po l' apontiaedje otomatike:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Proxy pol rantoele"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Sicrete:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Rascourtis del taprece"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Eployî l' otintifiaedje</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "No d' _uzeu:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Sicrete:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Sicrete:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Sicrete:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "<b>_Eployî l' otintifiaedje</b>"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Sôre"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Prémetou betchteu waibe"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Drovi on fitchî"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "Accion"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Tchoezi on fitchî di son"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
 msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
 msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:276
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Rascourti"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Rascourti"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Eployî l' otintifiaedje</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Waitroûle"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Waitroûle"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Tårdjaedje:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "_Eprimî"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "No d' _uzeu:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "Accion"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "Disfacer"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Accions"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Detays do rindou del fonte"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr ""
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Modele"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Vey divant"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Waitroûle"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Accion"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Sôre"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Waitroûle"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Waitroûle"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Waitroûle"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Waitroûle"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Sipepieus apontiaedjes"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Rascourtis del taprece"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
+msgstr "Passetes"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "Accion"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Fonte po les _programes:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Rascourti"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Proxy pol rantoele"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Sicribanne"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Bodjî"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Sicrete:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Sicribanne"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Copyî"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<b>_Eployî l' otintifiaedje</b>"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "No d' _uzeu:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "_Volume:"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "_Volume:"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Apontiaedje do proxy pol rantoele"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "_Volume:"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Botons"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Son"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 #, fuzzy
 msgid "Name:"
 msgstr "_No:"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
 msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:289
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 #, fuzzy
-msgid "Type:"
-msgstr "Sôre"
+msgid "Cursor Blinking"
+msgstr "Tinme do cursoe"
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
 msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr ""
-
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr ""
-
-#: ../vfs-methods/fontilus/font-view.c:347
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 #, fuzzy
-msgid "Description:"
-msgstr "_Discrijhaedje:"
+msgid "Speed"
+msgstr "_Roedeu:"
 
-#: ../vfs-methods/fontilus/font-view.c:408
-#, c-format
-msgid "usage: %s fontfile\n"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "Tinme do cursoe"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Cursoes"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-#, fuzzy
-msgid "Set as Application Font"
-msgstr "Fonte po les _programes:"
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 #, fuzzy
-msgid "Sets the default application font"
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Rascourti"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Tårdjaedje:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Rascourti"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "Al _schåle"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "Pådjes di manuel"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "_Ripeter les tapes:"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Mete en alaedje les _londjinnès tapes"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Sori"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Rascourti"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Sori"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Rascourti"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "Pådjes di manuel"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "Waitroûle"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "_Sons"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Cursoes"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "Taprece"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "_Ripeter les tapes:"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "Tinme do cursoe"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Sori"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "Accion"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Waitroûle"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Accions"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "Accion"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "Waitroûle"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "Å d_vins"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Nouk"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Sicrete:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Tchoezi on fitchî di son"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Manaedjeu di purneas"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Nouk"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Vey divant"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "_Sicrete:"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "_Sicrete:"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Sicrete:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "_Sicrete:"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Sicrete:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_Candjî"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
 msgstr "Tchoezixhoz vos prémetous programes"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Passetes"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
 msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr ""
-
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 #, fuzzy
-msgid "GNOME Font Viewer"
-msgstr "Cinte di Contrôle di GNOME"
+msgid "Map Buttons"
+msgstr "Botons"
 
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
 msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr ""
-
-#: ../vfs-methods/themus/apply-font.glade.h:4
+#: panels/wacom/button-mapping.ui:51
 msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-#, fuzzy
-msgid "_Apply font"
-msgstr "Fonte po les _programes:"
-
-#: ../vfs-methods/themus/theme-method.c:520
-#, fuzzy
-msgid "Themes"
-msgstr "Tinme"
-
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "Discrijhaedje"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-#, fuzzy
-msgid "Control theme"
-msgstr "Tinme do cursoe"
-
-#: ../vfs-methods/themus/themus-properties-view.c:139
-#, fuzzy
-msgid "Window border theme"
-msgstr "Boird do purnea"
-
-#: ../vfs-methods/themus/themus-properties-view.c:145
-#, fuzzy
-msgid "Icon theme"
-msgstr "Tinme do cursoe"
-
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
 msgstr ""
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-#, fuzzy
-msgid "Apply theme"
-msgstr "_Astaler novea tinme..."
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-msgid "Sets the default theme"
-msgstr ""
-
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr ""
-
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr ""
-
-#: ../vfs-methods/themus/themus.schemas.in.h:3
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
 msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
 msgstr ""
 
-msgid "Show help options"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
 msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Botons"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Botons"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Botons"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Adjinçmint"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Å _mitan"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Purneas"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Purneas"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Radjouter..."
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Schaper"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "_Detays"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Proxy pol rantoele"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "_Detays"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Fitchî"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Proxy pol rantoele"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Proxy pol rantoele"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "_Detays"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Proxy pol rantoele"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "_Sicrete:"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Prémetou terminå"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Djenerå"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Moussî _foû"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr ""
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr ""
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "Preferinces pol fonte"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#, fuzzy
+#~ msgid "Show more _details"
+#~ msgstr "_Detays"
+
+#, fuzzy
+#~ msgid "About Me"
+#~ msgstr "Å _dfait"
+
+#, fuzzy
+#~ msgid "No Image"
+#~ msgstr "Imådjes"
+
+#, fuzzy, c-format
+#~ msgid "About %s"
+#~ msgstr "Å _dfait"
+
+#, fuzzy
+#~ msgid "Please type the passwords."
+#~ msgstr "_Sicrete:"
+
+#, fuzzy
+#~ msgid "    "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "<b>Home</b>"
+#~ msgstr "<i>Roed</i>"
+
+#, fuzzy
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "Rindou del fonte"
+
+#, fuzzy
+#~ msgid "<b>Job</b>"
+#~ msgstr "<i>Roed</i>"
+
+#, fuzzy
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<i>Roed</i>"
+
+#, fuzzy
+#~ msgid "<b>Web</b>"
+#~ msgstr "<i>Roed</i>"
+
+#, fuzzy
+#~ msgid "<b>Work</b>"
+#~ msgstr "<i>Roed</i>"
+
+#, fuzzy
+#~ msgid "A_ddress:"
+#~ msgstr "_Radjouter:"
+
+#, fuzzy
+#~ msgid "C_ity:"
+#~ msgstr "Cô_per"
+
+#, fuzzy
+#~ msgid "C_ompany:"
+#~ msgstr "Co_mande:"
+
+#, fuzzy
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "_Sicrete:"
+
+#, fuzzy
+#~ msgid "Ci_ty:"
+#~ msgstr "Cô_per"
+
+#, fuzzy
+#~ msgid "Co_untry:"
+#~ msgstr "C_oleur:"
+
+#, fuzzy
+#~ msgid "Cou_ntry:"
+#~ msgstr "C_oleur:"
+
+#, fuzzy
+#~ msgid "Hom_e:"
+#~ msgstr "_No:"
+
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "_Sicrete:"
+
+#, fuzzy
+#~ msgid "Personal Info"
+#~ msgstr "Fonte po les _terminås:"
+
+#, fuzzy
+#~ msgid "Wor_k:"
+#~ msgstr "C_oleur:"
+
+#, fuzzy
+#~ msgid "Work _fax:"
+#~ msgstr "C_oleur:"
+
+#, fuzzy
+#~ msgid "_Home page:"
+#~ msgstr "No d' _uzeu:"
+
+#, fuzzy
+#~ msgid "_Home:"
+#~ msgstr "_No:"
+
+#, fuzzy
+#~ msgid "_Manager:"
+#~ msgstr "Manaedjeu di purneas"
+
+#, fuzzy
+#~ msgid "_Profession:"
+#~ msgstr "_Discrijhaedje:"
+
+#, fuzzy
+#~ msgid "_Title:"
+#~ msgstr "_Fitchî"
+
+#, fuzzy
+#~ msgid "_Work:"
+#~ msgstr "C_oleur:"
+
+#, fuzzy
+#~ msgid "<b>Support</b>"
+#~ msgstr "<i>Roed</i>"
+
+#, fuzzy
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Preferinces pol purnea"
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#, fuzzy
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "Mete en alaedje les _londjinnès tapes"
+
+#, fuzzy
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "Mete en alaedje les _londjinnès tapes"
+
+#, fuzzy
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "Mete en alaedje les _londjinnès tapes"
+
+#, fuzzy
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "_Ripeter les tapes:"
+
+#, fuzzy
+#~ msgid "<b>Features</b>"
+#~ msgstr "<i>Roed</i>"
+
+#~ msgid "Basic"
+#~ msgstr "Di båze"
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Tårdjaedje inte les tapes eyet pol mo_vmint do cursoe:"
+
+#~ msgid "Filters"
+#~ msgstr "Passetes"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "_Preferinces pol sori..."
+
+#~ msgid "S_peed:"
+#~ msgstr "_Roedeu:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Tapez po sayî l' apontiaedje:"
+
+#~ msgid "characters/second"
+#~ msgstr "caracteres/segonde"
+
+#~ msgid "milliseconds"
+#~ msgstr "milisegondes"
+
+#~ msgid "pixels/second"
+#~ msgstr "picsels/segonde"
+
+#, fuzzy
+#~ msgid "Desktop Background"
+#~ msgstr "Fond"
+
+#, fuzzy
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "_Tapisreye"
+
+#, fuzzy
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "_Tapisreye"
+
+#, fuzzy
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Preferinces pol fond"
+
+#, fuzzy
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Tapisreye"
+
+#, fuzzy
+#~ msgid "Tiled"
+#~ msgstr "_Fitchî"
+
+#, fuzzy
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Degradé di coûtchî"
+
+#, fuzzy
+#~ msgid "Vertical Gradient"
+#~ msgstr "Degradé d' astampé"
+
+#, fuzzy
+#~ msgid "Add Wallpaper"
+#~ msgstr "_Tapisreye"
+
+#~ msgid "Key"
+#~ msgstr "Clé"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Dji n' a savou trover l' fitchî «%s».\n"
+#~ "\n"
+#~ "Acertinez vs s' i vs plait k' il egzistêye bén, eyet rssayîz oudonbén "
+#~ "tchoezixhoz ene imådje di fond diferinne."
+
+#~ msgid "Please select an image."
+#~ msgstr "Tchoezixhoz ene imådje s' i vs plait."
+
+#, fuzzy
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Prémetou betchteu waibe"
+
+#, fuzzy
+#~ msgid "W3M Text Browser"
+#~ msgstr "Betchteu waibe"
+
+#, fuzzy
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Betchteu waibe"
+
+#, fuzzy
+#~ msgid "Links Text Browser"
+#~ msgstr "Betchteu waibe"
+
+#, fuzzy
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Foyteuse di l' aidance da _vosse"
+
+#, fuzzy
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Prémetou terminå"
+
+#, fuzzy
+#~ msgid "Standard XTerminal"
+#~ msgstr "Enonder dins on t_erminå"
+
+#, fuzzy
+#~ msgid "aterm"
+#~ msgstr "Categoreye"
+
+#, fuzzy
+#~ msgid "ETerm"
+#~ msgstr "Terminå"
+
+#, fuzzy
+#~ msgid "C_ustom"
+#~ msgstr "A _vosse môde:"
+
+#~ msgid "C_ustom:"
+#~ msgstr "A _vosse môde:"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Co_mande:"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Prôpietés di l' aspougneu di tecse da vosse"
+
+#, fuzzy
+#~ msgid "Default Mail Reader"
+#~ msgstr "Prémetou manaedjeu di purneas"
+
+#~ msgid "Default Terminal"
+#~ msgstr "Prémetou terminå"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "Prémetou aspougneu di tecse"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "Prémetou betchteu waibe"
+
+#~ msgid "Default Window Manager"
+#~ msgstr "Prémetou manaedjeu di purneas"
+
+#~ msgid "Delete"
+#~ msgstr "Disfacer"
+
+#~ msgid "Edit..."
+#~ msgstr "Candjî..."
+
+#, fuzzy
+#~ msgid "Run in a _terminal"
+#~ msgstr "Enonder dins on _terminå"
+
+#, fuzzy
+#~ msgid "Run in a t_erminal"
+#~ msgstr "Enonder dins on _terminå"
+
+#~ msgid "Terminal"
+#~ msgstr "Terminå"
+
+#~ msgid "Text Editor"
+#~ msgstr "Aspougneu di tecse"
+
+#~ msgid "Web Browser"
+#~ msgstr "Betchteu waibe"
+
+#~ msgid "_Properties..."
+#~ msgstr "_Prôpietés..."
+
+#, fuzzy
+#~ msgid "_Select:"
+#~ msgstr "Disfacer"
+
+#, fuzzy
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Preferinces pol son"
+
+#, fuzzy
+#~ msgid "Keep Resolution"
+#~ msgstr "_Discrijhaedje:"
+
+#~ msgid "Font"
+#~ msgstr "Fonte"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Tchoezi les fontes pol sicribanne"
+
+#, fuzzy
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "Rindou del fonte"
+
+#, fuzzy
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "Rindou del fonte"
+
+#, fuzzy
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<i>Roed</i>"
+
+#, fuzzy
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<i>Roed</i>"
+
+#, fuzzy
+#~ msgid "D_etails..."
+#~ msgstr "De_tays..."
+
+#~ msgid "Font Preferences"
+#~ msgstr "Preferinces pol fonte"
+
+#, fuzzy
+#~ msgid "Go _to font folder"
+#~ msgstr "_Potchî å ridant des tinmes"
+
+#, fuzzy
+#~ msgid "Gra_yscale"
+#~ msgstr "Schåle di _gris"
+
+#~ msgid "N_one"
+#~ msgstr "N_ole"
+
+#, fuzzy
+#~ msgid "R_esolution:"
+#~ msgstr "_Discrijhaedje:"
+
+#~ msgid "_Desktop font:"
+#~ msgstr "Fonte pol _sicribanne:"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "Fonte po les _terminås:"
+
+#~ msgid "_Window title font:"
+#~ msgstr "Fonte pol tite des _purneas:"
+
+#, fuzzy
+#~ msgid "dots per inch"
+#~ msgstr "Finté (_ponts par pôce):"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Accion nén cnoxhowe>"
+
+#~ msgid "Window Management"
+#~ msgstr "Manaedjmint des purneas"
+
+#, fuzzy
+#~ msgid "Unknown"
+#~ msgstr ""
+#~ "<b>Cursoe nén cnoxhou</b>\n"
+#~ "%s"
+
+#, fuzzy
+#~ msgid "..."
+#~ msgstr "Radjouter..."
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Roed</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Long</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Court</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Londjin</i></small>"
+
+#, fuzzy
+#~ msgid "Choose A Keyboard Model"
+#~ msgstr "Xhuflet del taprece"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Preferinces del taprece"
+
+#, fuzzy
+#~ msgid "Keyboard _model:"
+#~ msgstr "Xhuflet del taprece"
+
+#, fuzzy
+#~ msgid "Layout Options"
+#~ msgstr "Tchuzes po les imådjes:"
+
+#, fuzzy
+#~ msgid "Layouts"
+#~ msgstr "Adjinçmint"
+
+#, fuzzy
+#~ msgid "_Models:"
+#~ msgstr "Modele"
+
+#, fuzzy
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Tchoezi on aspougneu di tecse:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Defini vos preferinces pol taprece"
+
+#, fuzzy
+#~ msgid "Unknown Cursor"
+#~ msgstr ""
+#~ "<b>Cursoe nén cnoxhou</b>\n"
+#~ "%s"
+
+#, fuzzy
+#~ msgid "Default Cursor"
+#~ msgstr "Prémetou betchteu waibe"
+
+#, fuzzy
+#~ msgid "The default cursor that ships with X"
+#~ msgstr ""
+#~ "<b>Prémetou cursoe</b>\n"
+#~ "Li prémetou cursoe ki vént avou X11"
+
+#, fuzzy
+#~ msgid "White Cursor"
+#~ msgstr "Cursoes"
+
+#, fuzzy
+#~ msgid "The default cursor inverted"
+#~ msgstr ""
+#~ "<b>Blanc cursoe</b>\n"
+#~ "Li prémetou cursoe, avou les coleurs å rvier"
+
+#, fuzzy
+#~ msgid "Large Cursor"
+#~ msgstr "Cursoes"
+
+#, fuzzy
+#~ msgid "Large version of normal cursor"
+#~ msgstr ""
+#~ "<b>Lådje cursoe</b>\n"
+#~ "Modêye lådje do cursoe normå"
+
+#, fuzzy
+#~ msgid "Large White Cursor - Current"
+#~ msgstr ""
+#~ "<b>Lådje blanc cursoe - cursoe do moumint</b>\n"
+#~ "Modêye lådje do blanc cursoe"
+
+#, fuzzy
+#~ msgid "Large version of white cursor"
+#~ msgstr ""
+#~ "<b>Lådje blanc cursoe</b>\n"
+#~ "Modêye lådje do blanc cursoe"
+
+#, fuzzy
+#~ msgid "Cursor Theme"
+#~ msgstr "Tinme do cursoe"
+
+#, fuzzy
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<i>Roed</i>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Roed</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Hôt</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Lådje</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Bas</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Londjin</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Pitit</i>"
+
+#~ msgid "Cursors"
+#~ msgstr "Cursoes"
+
+#~ msgid "Motion"
+#~ msgstr "Movmint"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Preferinces pol sori"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Defini vos preferinces pol sori"
+
+#, fuzzy
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Preferinces pol proxy del rantoele"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "<b>D_irect internet connection</b>"
+#~ msgstr "<b>Raloyaedje _direk al daegntoele</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>Apontiaedje _otomatike do proxy</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>Apontiaedje al _mwin do proxy</b>"
+
+#, fuzzy
+#~ msgid "Advanced Configuration"
+#~ msgstr "Sipepieus apontiaedjes"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Detays do proxy HTTP"
+
+#, fuzzy
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Preferinces pol proxy del rantoele"
+
+#~ msgid "Port:"
+#~ msgstr "Pôrt:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Mete en alaedje les sons eyet ls assocyî avou des evenmints"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Preferinces pol son"
+
+#~ msgid "E_nable sound server startup"
+#~ msgstr "Mete en _ouve li sierveu di sons a l' enondaedje"
+
+#~ msgid "_Sounds for events"
+#~ msgstr "_Sons po ls evenmints"
+
+#, fuzzy
+#~ msgid "Custom theme"
+#~ msgstr "Tinme do cursoe"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Tchoezi les tinmes po sacwantès pårteyes do scribanne"
+
+#~ msgid "Theme"
+#~ msgstr "Tinme"
+
+#~ msgid "Icons"
+#~ msgstr "Imådjetes"
+
+#, fuzzy
+#~ msgid "Save Theme"
+#~ msgstr "_Schaper tinme"
+
+#, fuzzy
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Tchoezi les fontes pol sicribanne"
+
+#, fuzzy
+#~ msgid "Short _description:"
+#~ msgstr "_Discrijhaedje:"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "Preferinces pol tinme"
+
+#, fuzzy
+#~ msgid "Theme _Details"
+#~ msgstr "_Detays"
+
+#, fuzzy
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#, fuzzy
+#~ msgid "This theme suggests a background:"
+#~ msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#, fuzzy
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#, fuzzy
+#~ msgid "This theme suggests a font:"
+#~ msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#~ msgid "Window Border"
+#~ msgstr "Boird do purnea"
+
+#, fuzzy
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "_Potchî å ridant des tinmes"
+
+#, fuzzy
+#~ msgid "_Revert"
+#~ msgstr "_Bodjî"
+
+#, fuzzy
+#~ msgid "_Save Theme..."
+#~ msgstr "_Schaper tinme"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Menus & Bårs ås usteyes"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<i>Roed</i>"
+
+#~ msgid "C_ut"
+#~ msgstr "Cô_per"
+
+#, fuzzy
+#~ msgid "Icons only"
+#~ msgstr "Rén k' les imådjetes"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Preferinces pol menu eyet l' bår ås usteyes"
+
+#~ msgid "New File"
+#~ msgstr "Novea fitchî"
+
+#~ msgid "Save File"
+#~ msgstr "Schaper fitchî"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Håyner les _imådjetes dins les menus"
+
+#, fuzzy
+#~ msgid "Text below icons"
+#~ msgstr "Tecse pa dzo les imådjetes"
+
+#, fuzzy
+#~ msgid "Text beside icons"
+#~ msgstr "Tecse a costé des imådjetes"
+
+#, fuzzy
+#~ msgid "Text only"
+#~ msgstr "Rén kel tecse"
+
+#, fuzzy
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Etiketes des _botons:"
+
+#~ msgid "_File"
+#~ msgstr "_Fitchî"
+
+#~ msgid "_New"
+#~ msgstr "_Novea"
+
+#~ msgid "_Paste"
+#~ msgstr "C_laper"
+
+#~ msgid "Alt"
+#~ msgstr "Alt"
+
+#~ msgid "Meta"
+#~ msgstr "Meta"
+
+#, fuzzy
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "_Ripeter les tapes:"
+
+#, fuzzy
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>_Eployî l' otintifiaedje</b>"
+
+#, fuzzy
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "Rindou del fonte"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Preferinces pol purnea"
+
+#, fuzzy
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Dobe-clitchî sol tite des purneas po:"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Tchoezi les purneas cwand l' sori passe å dzeur"
+
+#, fuzzy
+#~ msgid "Set your window properties"
+#~ msgstr "Propietés pol purnea"
+
+#, fuzzy
+#~ msgid "Desktop Preferences"
+#~ msgstr "Preferinces del taprece"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "Cinte di Contrôle di GNOME"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "L' usteye d' apontiaedje di GNOME"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "Dji n' a savou inicyî Bonobo"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Dji n' a savou ahiver l' ridant «%s».\n"
+#~ "I gn a mezåjhe del fé po permete li candjmint des cursoes."
+
+#, fuzzy
+#~ msgid "Use X settings"
+#~ msgstr "Sipepieus apontiaedjes"
+
+#, fuzzy
+#~ msgid "A_vailable files:"
+#~ msgstr "Tchuzes po les imådjes:"
+
+#~ msgid "Event"
+#~ msgstr "Evenmint"
+
+#, fuzzy
+#~ msgid "Sound File"
+#~ msgstr "Son"
+
+#~ msgid "_Play"
+#~ msgstr "_Djower"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "Li manaedjeu di purneas «%s» n' a nén redjistré ene usteye "
+#~ "d' apontiaedje\n"
+
+#~ msgid "Maximize"
+#~ msgstr "Å pus grand"
+
+#~ msgid "Roll up"
+#~ msgstr "Erôler"
+
+#, fuzzy
+#~ msgid "Eject's shortcut."
+#~ msgstr "Rascourtis do _scribanne:"
+
+#, fuzzy
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Rascourti"
+
+#, fuzzy
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Foyteuse di l' aidance"
+
+#, fuzzy
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Betchteu waibe"
+
+#, fuzzy
+#~ msgid "Log out's shortcut."
+#~ msgstr "Rascourtis do _scribanne:"
+
+#, fuzzy
+#~ msgid "Pause"
+#~ msgstr "C_laper"
+
+#, fuzzy
+#~ msgid "Sleep"
+#~ msgstr "Roedeu"
+
+#, fuzzy
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Rascourti"
+
+#, fuzzy
+#~ msgid "Volume step"
+#~ msgstr "_Volume:"
+
+#, fuzzy
+#~ msgid "Start screensaver"
+#~ msgstr "Waitroûle"
+
+#, fuzzy
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "Xhuflet del taprece"
+
+#, fuzzy
+#~ msgid "Keyboard model"
+#~ msgstr "Xhuflet del taprece"
+
+#, fuzzy
+#~ msgid "keyboard layout"
+#~ msgstr "Rascourtis del taprece"
+
+#, fuzzy
+#~ msgid "keyboard model"
+#~ msgstr "Xhuflet del taprece"
+
+#, fuzzy
+#~ msgid "Description:"
+#~ msgstr "_Discrijhaedje:"
+
+#, fuzzy
+#~ msgid "Set as Application Font"
+#~ msgstr "Fonte po les _programes:"
+
+#, fuzzy
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "Cinte di Contrôle di GNOME"
+
+#, fuzzy
+#~ msgid "Themes"
+#~ msgstr "Tinme"
+
+#~ msgid "Description"
+#~ msgstr "Discrijhaedje"
+
+#, fuzzy
+#~ msgid "Control theme"
+#~ msgstr "Tinme do cursoe"
+
+#, fuzzy
+#~ msgid "Window border theme"
+#~ msgstr "Boird do purnea"
+
+#, fuzzy
+#~ msgid "Icon theme"
+#~ msgstr "Tinme do cursoe"
+
+#, fuzzy
+#~ msgid "Apply theme"
+#~ msgstr "_Astaler novea tinme..."

--- a/po/wa.po~
+++ b/po/wa.po~
@@ -1,0 +1,3500 @@
+# Traduction into the walloon language.
+#
+# Si vos voloz donner on côp di spale pol ratournaedje di Gnome (ou des
+# ôtes libes programes) sicrijhoz mu a l' adresse emile
+# <srtxg@chanae.alphanet.ch>; nos avons co bråmint di l' ovraedje a fé.
+#
+# Copyright (C) 1999 Free Software Foundation, Inc.
+# Pablo Saratxaga <srtxg@chanae.alphanet.ch> 1999-2002
+# Lorint Hendschel <LorintHendschel@skynet.be> 1999,2000
+# Lucyin Mahin <lucyin@walon.org>, 2000
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center 1.5.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"PO-Revision-Date: 2003-01-02 12:26+0100\n"
+"Last-Translator: Pablo Saratxaga <pablo@mandrakesoft.com>\n"
+"Language-Team: Walon <linux-wa@chanae.alphanet.ch>\n"
+"Language: wa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+#, fuzzy
+msgid "Alert Type"
+msgstr "Radjouter sôre di fitchî"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+msgid "The type of alert"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+#, fuzzy
+msgid "Alert Buttons"
+msgstr "Botons"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+#, fuzzy
+msgid "Show more _details"
+msgstr "_Detays"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+#, fuzzy
+msgid "About Me"
+msgstr "Å _dfait"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your personal information"
+msgstr "Tchoezixhoz vos prémetous programes"
+
+#: ../capplets/about-me/gnome-about-me.c:554
+#, fuzzy
+msgid "Select Image"
+msgstr "Disfacer"
+
+#: ../capplets/about-me/gnome-about-me.c:556
+#, fuzzy
+msgid "No Image"
+msgstr "Imådjes"
+
+#: ../capplets/about-me/gnome-about-me.c:706
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:727
+msgid "Unable to open address book"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:739
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:770
+#: ../capplets/about-me/gnome-about-me.c:772
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "Å _dfait"
+
+#: ../capplets/about-me/gnome-about-me-password.c:101
+#: ../capplets/about-me/gnome-about-me-password.c:479
+msgid "Old password is incorrect, please retype it"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:112
+msgid "System error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:113
+msgid "Could not run /usr/bin/passwd"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:114
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:117
+msgid "Unexpected error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:315
+msgid "Password is too short"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:318
+#: ../capplets/about-me/gnome-about-me-password.c:321
+msgid "Password is too simple"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:324
+msgid "Old and new passwords are too similar"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:328
+msgid "Old and new password are the same"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:406
+#, fuzzy
+msgid "Please type the passwords."
+msgstr "_Sicrete:"
+
+#: ../capplets/about-me/gnome-about-me-password.c:414
+msgid "Please type the password again, it is wrong."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:417
+msgid "Click on Change Password to change the password."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/font/font-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+#, fuzzy
+msgid "    "
+msgstr "      "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+#, fuzzy
+msgid "<b>Email</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+#, fuzzy
+msgid "<b>Home</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+#, fuzzy
+msgid "<b>Instant Messaging</b>"
+msgstr "Rindou del fonte"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+#, fuzzy
+msgid "<b>Job</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+#, fuzzy
+msgid "<b>Telephone</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+#, fuzzy
+msgid "<b>Web</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+#, fuzzy
+msgid "<b>Work</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+#, fuzzy
+msgid "A_ddress:"
+msgstr "_Radjouter:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+#, fuzzy
+msgid "Address"
+msgstr "_Radjouter:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+#, fuzzy
+msgid "C_ity:"
+msgstr "Cô_per"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+#, fuzzy
+msgid "C_ompany:"
+msgstr "Co_mande:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+#, fuzzy
+msgid "Cale_ndar:"
+msgstr "Cate_goreye:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+#, fuzzy
+msgid "Change Passwo_rd..."
+msgstr "_Sicrete:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+#, fuzzy
+msgid "Change Password"
+msgstr "_Sicrete:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+#, fuzzy
+msgid "Ci_ty:"
+msgstr "Cô_per"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+#, fuzzy
+msgid "Co_untry:"
+msgstr "C_oleur:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+#, fuzzy
+msgid "Contact"
+msgstr "Å d_vins"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+#, fuzzy
+msgid "Cou_ntry:"
+msgstr "C_oleur:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+#, fuzzy
+msgid "Hom_e:"
+msgstr "_No:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+#, fuzzy
+msgid "Old pa_ssword:"
+msgstr "_Sicrete:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P.O. _box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P._O. box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+#, fuzzy
+msgid "Personal Info"
+msgstr "Fonte po les _terminås:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "State/Pro_vince:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#, fuzzy
+msgid "User name:"
+msgstr "No d' _uzeu:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Web _log:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+#, fuzzy
+msgid "Wor_k:"
+msgstr "C_oleur:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+#, fuzzy
+msgid "Work _fax:"
+msgstr "C_oleur:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Zip/_Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+#, fuzzy
+msgid "_Address:"
+msgstr "_Radjouter:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+#, fuzzy
+msgid "_Home page:"
+msgstr "No d' _uzeu:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+#, fuzzy
+msgid "_Home:"
+msgstr "_No:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+#, fuzzy
+msgid "_Manager:"
+msgstr "Manaedjeu di purneas"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+#, fuzzy
+msgid "_Mobile:"
+msgstr "_Fitchî"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+#, fuzzy
+msgid "_New password:"
+msgstr "_Sicrete:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+#, fuzzy
+msgid "_Profession:"
+msgstr "_Discrijhaedje:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+#, fuzzy
+msgid "_Retype new password:"
+msgstr "_Sicrete:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+#, fuzzy
+msgid "_Title:"
+msgstr "_Fitchî"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+#, fuzzy
+msgid "_Work:"
+msgstr "C_oleur:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Zip/Postal code:"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+#, fuzzy
+msgid "<b>Applications</b>"
+msgstr "<b>_Eployî l' otintifiaedje</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+#, fuzzy
+msgid "<b>Support</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+#, fuzzy
+msgid "Assistive Technology Preferences"
+msgstr "Preferinces pol purnea"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+#, fuzzy
+msgid "_Screenreader"
+msgstr "Waitroûle"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
+msgid "Import Feature Settings File"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
+msgid "_Import"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Taprece"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+#: ../capplets/theme-switcher/theme-install.glade.h:1
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+#, fuzzy
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "Mete en alaedje les _londjinnès tapes"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+#, fuzzy
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "Mete en alaedje les _londjinnès tapes"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+#, fuzzy
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "Mete en alaedje les _londjinnès tapes"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+#, fuzzy
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "_Ripeter les tapes:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+#, fuzzy
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "Mete en alaedje les _londjinnès tapes"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+#, fuzzy
+msgid "<b>Features</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "Di båze"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr "_Tårdjaedje:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr "Tårdjaedje inte les tapes eyet pol mo_vmint do cursoe:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Passetes"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+#, fuzzy
+msgid "Mouse Keys"
+msgstr "Sori"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr "_Preferinces pol sori..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "S_peed:"
+msgstr "_Roedeu:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Type to test settings:"
+msgstr "_Tapez po sayî l' apontiaedje:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr ""
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr "caracteres/segonde"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+msgid "milliseconds"
+msgstr "milisegondes"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr "picsels/segonde"
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:885
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "segondes"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+#, fuzzy
+msgid "Change your Desktop Background settings"
+msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+#, fuzzy
+msgid "Desktop Background"
+msgstr "Fond"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+#, fuzzy
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "_Tapisreye"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+#, fuzzy
+msgid "<b>_Desktop Colors</b>"
+msgstr "_Tapisreye"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+#, fuzzy
+msgid "Desktop Background Preferences"
+msgstr "Preferinces pol fond"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+#, fuzzy
+msgid "_Add Wallpaper"
+msgstr "_Tapisreye"
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+msgid "_Style:"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr ""
+
+#: ../capplets/background/gnome-wp-capplet.c:1042
+#: ../capplets/background/gnome-wp-capplet.c:1060
+#, fuzzy
+msgid "Centered"
+msgstr "Å _mitan"
+
+#: ../capplets/background/gnome-wp-capplet.c:1068
+#: ../capplets/background/gnome-wp-capplet.c:1085
+#, fuzzy
+msgid "Fill Screen"
+msgstr "Waitroûle"
+
+#: ../capplets/background/gnome-wp-capplet.c:1093
+#: ../capplets/background/gnome-wp-capplet.c:1110
+#, fuzzy
+msgid "Scaled"
+msgstr "Al _schåle"
+
+#: ../capplets/background/gnome-wp-capplet.c:1118
+#: ../capplets/background/gnome-wp-capplet.c:1135
+#, fuzzy
+msgid "Tiled"
+msgstr "_Fitchî"
+
+#: ../capplets/background/gnome-wp-capplet.c:1159
+#: ../capplets/background/gnome-wp-capplet.c:1168
+#, fuzzy
+msgid "Solid Color"
+msgstr "Coleur solide"
+
+#: ../capplets/background/gnome-wp-capplet.c:1176
+#: ../capplets/background/gnome-wp-capplet.c:1185
+#, fuzzy
+msgid "Horizontal Gradient"
+msgstr "Degradé di coûtchî"
+
+#: ../capplets/background/gnome-wp-capplet.c:1193
+#: ../capplets/background/gnome-wp-capplet.c:1202
+#, fuzzy
+msgid "Vertical Gradient"
+msgstr "Degradé d' astampé"
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1251
+#, fuzzy
+msgid "Add Wallpaper"
+msgstr "_Tapisreye"
+
+#: ../capplets/background/gnome-wp-info.c:57
+#, fuzzy
+msgid "No Wallpaper"
+msgstr "_Tapisreye"
+
+#: ../capplets/background/gnome-wp-item.c:292
+#: ../capplets/background/gnome-wp-item.c:294
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/common/activate-settings-daemon.c:18
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+
+#: ../capplets/common/capplet-stock-icons.c:94
+#, c-format
+msgid "Unable to load capplet stock icon '%s'\n"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr ""
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/default-applications/gnome-default-applications-properties.c:765
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1021
+#: ../capplets/sound/sound-properties-capplet.c:244
+msgid "Retrieve and store legacy settings"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %i of %i"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:345
+msgid "From:"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:349
+#, fuzzy
+msgid "To:"
+msgstr "Deus"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Clé"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Dji n' a savou trover l' fitchî «%s».\n"
+"\n"
+"Acertinez vs s' i vs plait k' il egzistêye bén, eyet rssayîz oudonbén "
+"tchoezixhoz ene imådje di fond diferinne."
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr "Tchoezixhoz ene imådje s' i vs plait."
+
+#: ../capplets/common/gconf-property-editor.c:1598
+#, fuzzy
+msgid "_Select"
+msgstr "Disfacer"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr ""
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Tchoezixhoz vos prémetous programes"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+#, fuzzy
+msgid "Debian Sensible Browser"
+msgstr "Prémetou betchteu waibe"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
+msgid "Epiphany"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
+msgid "Galeon"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
+msgid "Encompass"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+msgid "Firebird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
+msgid "Firefox"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
+msgid "Mozilla"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
+msgid "Netscape Communicator"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
+msgid "Konqueror"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
+#, fuzzy
+msgid "W3M Text Browser"
+msgstr "Betchteu waibe"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
+#, fuzzy
+msgid "Lynx Text Browser"
+msgstr "Betchteu waibe"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
+#, fuzzy
+msgid "Links Text Browser"
+msgstr "Betchteu waibe"
+
+#. The code in gnome-default-applications-properties.c makes sure
+#. * there is only one (the first entry in this list) Evolution entry
+#. * in the list shown to the user
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
+#, fuzzy
+msgid "Evolution Mail Reader"
+msgstr "Foyteuse di l' aidance da _vosse"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
+msgid "Balsa"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
+msgid "KMail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
+msgid "Thunderbird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
+msgid "Mozilla Mail"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
+msgid "Mutt"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
+#, fuzzy
+msgid "Debian Terminal Emulator"
+msgstr "Prémetou terminå"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
+#, fuzzy
+msgid "GNOME Terminal"
+msgstr "Terminå"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
+#, fuzzy
+msgid "Standard XTerminal"
+msgstr "Enonder dins on t_erminå"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
+msgid "NXterm"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
+msgid "RXVT"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
+#, fuzzy
+msgid "aterm"
+msgstr "Categoreye"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
+#, fuzzy
+msgid "ETerm"
+msgstr "Terminå"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.c:123
+msgid "Please specify a name and a command for this editor."
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "Add..."
+msgstr "Radjouter..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+#, fuzzy
+msgid "C_ustom"
+msgstr "A _vosse môde:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "C_ustom:"
+msgstr "A _vosse môde:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "Can open _URIs"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "Can open multiple _files"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "Co_mmand:"
+msgstr "Co_mande:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "Custom Editor Properties"
+msgstr "Prôpietés di l' aspougneu di tecse da vosse"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+#, fuzzy
+msgid "Default Mail Reader"
+msgstr "Prémetou manaedjeu di purneas"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "Default Terminal"
+msgstr "Prémetou terminå"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Default Text Editor"
+msgstr "Prémetou aspougneu di tecse"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "Default Web Browser"
+msgstr "Prémetou betchteu waibe"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Default Window Manager"
+msgstr "Prémetou manaedjeu di purneas"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Delete"
+msgstr "Disfacer"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "E_xec Flag:"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Edit..."
+msgstr "Candjî..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Mail Reader"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+#, fuzzy
+msgid "Run in a _terminal"
+msgstr "Enonder dins on _terminå"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+#, fuzzy
+msgid "Run in a t_erminal"
+msgstr "Enonder dins on _terminå"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid ""
+"Select the window manager you want.  You will need to hit apply, wave the "
+"magic wand, and do a magic dance for it to work."
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Terminal"
+msgstr "Terminå"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Text Editor"
+msgstr "Aspougneu di tecse"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Understands _Netscape Remote Control"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "Use this _editor to open text files in the file manager"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "Web Browser"
+msgstr "Betchteu waibe"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
+msgid "Window Manager"
+msgstr "Manaedjeu di purneas"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
+#, fuzzy
+msgid "_Command:"
+msgstr "Co_mande:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
+msgid "_Name:"
+msgstr "_No:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
+msgid "_Properties..."
+msgstr "_Prôpietés..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
+#, fuzzy
+msgid "_Select:"
+msgstr "Disfacer"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr ""
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr ""
+
+#: ../capplets/display/main.c:448
+#, fuzzy
+msgid "_Resolution:"
+msgstr "_Discrijhaedje:"
+
+#: ../capplets/display/main.c:467
+msgid "Re_fresh rate:"
+msgstr ""
+
+#: ../capplets/display/main.c:488
+#, fuzzy
+msgid "Default Settings"
+msgstr "Prémetou terminå"
+
+#: ../capplets/display/main.c:490
+#, fuzzy, c-format
+msgid "Screen %d Settings\n"
+msgstr "Sipepieus apontiaedjes"
+
+#: ../capplets/display/main.c:516
+#, fuzzy
+msgid "Screen Resolution Preferences"
+msgstr "Preferinces pol son"
+
+#: ../capplets/display/main.c:553
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr ""
+
+#: ../capplets/display/main.c:571
+#, fuzzy
+msgid "Options"
+msgstr "Accions"
+
+#: ../capplets/display/main.c:592
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/display/main.c:638
+#, fuzzy
+msgid "Keep Resolution"
+msgstr "_Discrijhaedje:"
+
+#: ../capplets/display/main.c:642
+msgid "Do you want to keep this resolution?"
+msgstr ""
+
+#: ../capplets/display/main.c:667
+msgid "Use _previous resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:667
+msgid "_Keep resolution"
+msgstr ""
+
+#: ../capplets/display/main.c:818
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+
+#: ../capplets/display/main.c:826
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Fonte"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr "Tchoezi les fontes pol sicribanne"
+
+#: ../capplets/font/font-properties.glade.h:2
+#, fuzzy
+msgid "<b>Font Rendering</b>"
+msgstr "Rindou del fonte"
+
+#: ../capplets/font/font-properties.glade.h:3
+#, fuzzy
+msgid "<b>Hinting</b>:"
+msgstr "Rindou del fonte"
+
+#: ../capplets/font/font-properties.glade.h:4
+#, fuzzy
+msgid "<b>Smoothing</b>:"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/font/font-properties.glade.h:5
+#, fuzzy
+msgid "<b>Subpixel order</b>:"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best _shapes"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "Best co_ntrast"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:8
+#, fuzzy
+msgid "D_etails..."
+msgstr "De_tays..."
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "Preferinces pol fonte"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr "Detays do rindou del fonte"
+
+#: ../capplets/font/font-properties.glade.h:11
+#, fuzzy
+msgid "Go _to font folder"
+msgstr "_Potchî å ridant des tinmes"
+
+#: ../capplets/font/font-properties.glade.h:12
+#, fuzzy
+msgid "Gra_yscale"
+msgstr "Schåle di _gris"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "N_ole"
+
+#: ../capplets/font/font-properties.glade.h:14
+#, fuzzy
+msgid "R_esolution:"
+msgstr "_Discrijhaedje:"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "Fonte po les _programes:"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Desktop font:"
+msgstr "Fonte pol _sicribanne:"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Full"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Medium"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Monochrome"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_None"
+msgstr "_Nouk"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_RGB"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_Slight"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Terminal font:"
+msgstr "Fonte po les _terminås:"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr ""
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "Fonte pol tite des _purneas:"
+
+#: ../capplets/font/font-properties.glade.h:30
+#, fuzzy
+msgid "dots per inch"
+msgstr "Finté (_ponts par pôce):"
+
+#: ../capplets/font/main.c:488
+msgid "Font may be too large"
+msgstr ""
+
+#: ../capplets/font/main.c:492
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/font/main.c:505
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr ""
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:197
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+msgid "Disabled"
+msgstr "Dismetou"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:545
+msgid "<Unknown Action>"
+msgstr "<Accion nén cnoxhowe>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:566
+msgid "Desktop"
+msgstr "Sicribanne"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:567
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Son"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:571
+msgid "Window Management"
+msgstr "Manaedjmint des purneas"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:668
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:700
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:750
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr ""
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:857
+msgid "Action"
+msgstr "Accion"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:881
+msgid "Shortcut"
+msgstr "Rascourti"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Rascourtis del taprece"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+#, fuzzy
+msgid "Unknown"
+msgstr ""
+"<b>Cursoe nén cnoxhou</b>\n"
+"%s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+msgid "Layout"
+msgstr "Adjinçmint"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#, fuzzy
+msgid "Default"
+msgstr "Prémetou betchteu waibe"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+#, fuzzy
+msgid "Models"
+msgstr "Modele"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:106
+#, c-format
+msgid "There was an error launching the keyboard capplet : %s"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:240
+#: ../capplets/sound/sound-properties-capplet.c:242
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+#, fuzzy
+msgid "..."
+msgstr "Radjouter..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+#, fuzzy
+msgid "<b>Cursor Blinking</b>"
+msgstr "Tinme do cursoe"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+#, fuzzy
+msgid "<b>Repeat Keys</b>"
+msgstr "_Ripeter les tapes:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Roed</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Long</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Court</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Londjin</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_vailable layouts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "All_ow postponing of breaks"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Check if breaks are allowed to be postponed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+#, fuzzy
+msgid "Choose A Keyboard Model"
+msgstr "Xhuflet del taprece"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Choose A Layout"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Duration of the break when typing is disallowed"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of work before forcing a break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Key presses _repeat when key is held down"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Keyboard Preferences"
+msgstr "Preferinces del taprece"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+#, fuzzy
+msgid "Keyboard _model:"
+msgstr "Xhuflet del taprece"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+#, fuzzy
+msgid "Layout Options"
+msgstr "Tchuzes po les imådjes:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+#, fuzzy
+msgid "Layouts"
+msgstr "Adjinçmint"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Microsoft Natural Keyboard"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+#, fuzzy
+msgid "Preview:"
+msgstr "Vey divant"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Reset To De_faults"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Separate _group for each window"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Typing Break"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "_Accessibility..."
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#, fuzzy
+msgid "_Add..."
+msgstr "Radjouter..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Break interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Delay:"
+msgstr "_Tårdjaedje:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#, fuzzy
+msgid "_Models:"
+msgstr "Modele"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+#, fuzzy
+msgid "_Selected layouts:"
+msgstr "_Tchoezi on aspougneu di tecse:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Speed:"
+msgstr "_Roedeu:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Work interval lasts:"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "minutes"
+msgstr ""
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Defini vos preferinces pol taprece"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:559
+#, fuzzy
+msgid "Unknown Cursor"
+msgstr ""
+"<b>Cursoe nén cnoxhou</b>\n"
+"%s"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+#, fuzzy
+msgid "Default Cursor"
+msgstr "Prémetou betchteu waibe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+#, fuzzy
+msgid "The default cursor that ships with X"
+msgstr ""
+"<b>Prémetou cursoe</b>\n"
+"Li prémetou cursoe ki vént avou X11"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+#, fuzzy
+msgid "White Cursor"
+msgstr "Cursoes"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+#, fuzzy
+msgid "The default cursor inverted"
+msgstr ""
+"<b>Blanc cursoe</b>\n"
+"Li prémetou cursoe, avou les coleurs å rvier"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+#, fuzzy
+msgid "Large Cursor"
+msgstr "Cursoes"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Cursor - Current"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+#, fuzzy
+msgid "Large version of normal cursor"
+msgstr ""
+"<b>Lådje cursoe</b>\n"
+"Modêye lådje do cursoe normå"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+#, fuzzy
+msgid "Large White Cursor - Current"
+msgstr ""
+"<b>Lådje blanc cursoe - cursoe do moumint</b>\n"
+"Modêye lådje do blanc cursoe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Cursor"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+#, fuzzy
+msgid "Large version of white cursor"
+msgstr ""
+"<b>Lådje blanc cursoe</b>\n"
+"Modêye lådje do blanc cursoe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:975
+#, fuzzy
+msgid "Cursor Theme"
+msgstr "Tinme do cursoe"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+#, fuzzy
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>_Eployî l' otintifiaedje</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+#, fuzzy
+msgid "<b>Speed</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>Hôt</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>Lådje</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>Bas</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>Londjin</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>Pitit</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Botons"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#, fuzzy
+msgid "Cursor Size:"
+msgstr "Cursoes"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Cursors"
+msgstr "Cursoes"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+#, fuzzy
+msgid "Large"
+msgstr "Pådjes di manuel"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+msgid "Medium"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Motion"
+msgstr "Movmint"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Mouse Preferences"
+msgstr "Preferinces pol sori"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#, fuzzy
+msgid "Small"
+msgstr "Al _schåle"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr ""
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Sori"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Defini vos preferinces pol sori"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+#, fuzzy
+msgid "Network Proxy"
+msgstr "Proxy pol rantoele"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your network proxy preferences"
+msgstr "Preferinces pol proxy del rantoele"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+#, fuzzy
+msgid "<b>D_irect internet connection</b>"
+msgstr "<b>Raloyaedje _direk al daegntoele</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>Apontiaedje _otomatike do proxy</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>Apontiaedje al _mwin do proxy</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Eployî l' otintifiaedje</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+#, fuzzy
+msgid "Advanced Configuration"
+msgstr "Sipepieus apontiaedjes"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr "_Hårdêye po l' apontiaedje otomatike:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "Detays do proxy HTTP"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+#, fuzzy
+msgid "H_TTP proxy:"
+msgstr "Proxy _HTTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+#, fuzzy
+msgid "Network Proxy Preferences"
+msgstr "Preferinces pol proxy del rantoele"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Pôrt:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+#, fuzzy
+msgid "Proxy Configuration"
+msgstr "Apontiaedje do proxy pol rantoele"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr "Lodjoe S_OCKS:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+#, fuzzy
+msgid "U_sername:"
+msgstr "No d' _uzeu:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_Detays"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr "Proxy _FTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "_Sicrete:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr ""
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Mete en alaedje les sons eyet ls assocyî avou des evenmints"
+
+#: ../capplets/sound/sound-properties-capplet.c:271
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Sound Preferences"
+msgstr "Preferinces pol son"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "E_nable sound server startup"
+msgstr "Mete en _ouve li sierveu di sons a l' enondaedje"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "Flash _entire screen"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "Flash _window titlebar"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "General"
+msgstr "Djenerå"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "Sound Events"
+msgstr "Sons po ls evenmints"
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "System Bell"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "_Sound an audible bell"
+msgstr ""
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "_Sounds for events"
+msgstr "_Sons po ls evenmints"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "_Visual feedback:"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:347
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:227
+msgid "This theme is not in a supported format."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:244
+msgid "Failed to create temporary directory"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:264
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:282
+#: ../capplets/theme-switcher/gnome-theme-installer.c:319
+#: ../capplets/theme-switcher/gnome-theme-installer.c:399
+msgid "Installation Failed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:302
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:340
+#, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:343
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:346
+#, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:349
+#, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:357
+msgid "The theme is an engine. You need to compile the theme."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:374
+msgid "The file format is invalid"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:468
+msgid "No theme file location specified to install"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:485
+msgid "The theme file location specified to install is invalid"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:505
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:526
+msgid "The file format is invalid."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:553
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:607
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+#, fuzzy
+msgid "Custom theme"
+msgstr "Tinme do cursoe"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:72
+msgid "Theme name must be present"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:104
+msgid "The theme already exists. Would you like to replace it?"
+msgstr ""
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr "Tchoezi les tinmes po sacwantès pårteyes do scribanne"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "Tinme"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-install.glade.h:3
+msgid "Theme Installation"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-install.glade.h:4
+msgid "_Install"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-install.glade.h:5
+#, fuzzy
+msgid "_Location:"
+msgstr "Accion"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+#, fuzzy
+msgid "Apply _Background"
+msgstr "Fond"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Apply _Font"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Controls"
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "Icons"
+msgstr "Imådjetes"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "New themes can also be installed by dragging them into the window."
+msgstr ""
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+#, fuzzy
+msgid "Save Theme"
+msgstr "_Schaper tinme"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+#, fuzzy
+msgid "Select theme for the desktop"
+msgstr "Tchoezi les fontes pol sicribanne"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+#, fuzzy
+msgid "Short _description:"
+msgstr "_Discrijhaedje:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+#, fuzzy
+msgid "Theme Details"
+msgstr "_Detays"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "Theme Preferences"
+msgstr "Preferinces pol tinme"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+#, fuzzy
+msgid "Theme _Details"
+msgstr "_Detays"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+#, fuzzy
+msgid "This theme does not suggest any particular font or background."
+msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+#, fuzzy
+msgid "This theme suggests a background:"
+msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+#, fuzzy
+msgid "This theme suggests a font and a background:"
+msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+#, fuzzy
+msgid "This theme suggests a font:"
+msgstr "Apontiaedje da vosse do fond do scribanne"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "Window Border"
+msgstr "Boird do purnea"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+#, fuzzy
+msgid "_Go To Theme Folder"
+msgstr "_Potchî å ridant des tinmes"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+#, fuzzy
+msgid "_Install Theme..."
+msgstr "_Astaler novea tinme..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+#, fuzzy
+msgid "_Revert"
+msgstr "_Bodjî"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+#, fuzzy
+msgid "_Save Theme..."
+msgstr "_Schaper tinme"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+#, fuzzy
+msgid "_Theme name:"
+msgstr "No d' _uzeu:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:24
+msgid "theme selection tree"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "Menus & Bårs ås usteyes"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+#, fuzzy
+msgid "<b>Preview</b>"
+msgstr "<i>Roed</i>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "Cô_per"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+#, fuzzy
+msgid "Icons only"
+msgstr "Rén k' les imådjetes"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "Preferinces pol menu eyet l' bår ås usteyes"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "Novea fitchî"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Drovi on fitchî"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Schaper fitchî"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr "Håyner les _imådjetes dins les menus"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+#, fuzzy
+msgid "Text below icons"
+msgstr "Tecse pa dzo les imådjetes"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+#, fuzzy
+msgid "Text beside icons"
+msgstr "Tecse a costé des imådjetes"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+#, fuzzy
+msgid "Text only"
+msgstr "Rén kel tecse"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+#, fuzzy
+msgid "Toolbar _button labels:"
+msgstr "Etiketes des _botons:"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_Copyî"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_Candjî"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "_Fitchî"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_Novea"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "_Drovi"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "C_laper"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "_Eprimî"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "Moussî _foû"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "_Schaper"
+
+#: ../capplets/windows/gnome-window-properties.c:386
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:644
+msgid "Control"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:649
+msgid "Alt"
+msgstr "Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:655
+msgid "Hyper"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:662
+msgid "Super (or \"Windows logo\")"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.c:669
+msgid "Meta"
+msgstr "Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+#, fuzzy
+msgid "<b>Movement Key</b>"
+msgstr "_Ripeter les tapes:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+#, fuzzy
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>_Eployî l' otintifiaedje</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+#, fuzzy
+msgid "<b>Window Selection</b>"
+msgstr "Rindou del fonte"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To _move a window, press-and-hold this key then grab the window:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Preferinces pol purnea"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+#, fuzzy
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_Dobe-clitchî sol tite des purneas po:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr ""
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Tchoezi les purneas cwand l' sori passe å dzeur"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+#, fuzzy
+msgid "Set your window properties"
+msgstr "Propietés pol purnea"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Purneas"
+
+#: ../control-center/control-center-categories.c:257
+#, fuzzy
+msgid "Others"
+msgstr "Passetes"
+
+#: ../control-center/control-center.c:42
+#, fuzzy
+msgid "Desktop Preferences"
+msgstr "Preferinces del taprece"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr "Cinte di Contrôle di GNOME"
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "L' usteye d' apontiaedje di GNOME"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+#, fuzzy
+msgid "Volume"
+msgstr "_Volume:"
+
+#: ../gnome-settings-daemon/factory.c:36
+msgid "Could not initialize Bonobo"
+msgstr "Dji n' a savou inicyî Bonobo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
+msgid "Slow Keys Alert"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
+msgid "Do you want to activate Slow Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
+msgid "Do you want to deactivate Slow Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Sticky Keys Alert"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
+msgid "Do you want to activate Sticky Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:107
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+"Dji n' a savou ahiver l' ridant «%s».\n"
+"I gn a mezåjhe del fé po permete li candjmint des cursoes."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
+#, c-format
+msgid "It seems that another application already has access to key '%d'."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
+#, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
+msgid "Do _not show this warning again"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
+msgid ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
+#, fuzzy
+msgid "Use X settings"
+msgstr "Sipepieus apontiaedjes"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
+msgid "Use GNOME settings"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
+#, c-format
+msgid "Permissions on the file %s are broken\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
+msgid "_Do not show this message again"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:129
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
+msgid "Cannot determine user's home directory"
+msgstr ""
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+#, fuzzy
+msgid "A_vailable files:"
+msgstr "Tchuzes po les imådjes:"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+msgid "Do _not show this warning again."
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+#, fuzzy
+msgid "_Loaded files:"
+msgstr "Modele"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr ""
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Sôre"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr ""
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr ""
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr ""
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr ""
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Waitroûle"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr ""
+
+#: ../libgswitchit/gswitchit_config.c:1035
+#, c-format
+msgid "There was an error loading an image: %s"
+msgstr ""
+
+#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
+msgid "The sound file for this event does not exist."
+msgstr ""
+
+#: ../libsounds/sound-view.c:149
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package\n"
+"for a set of default sounds."
+msgstr ""
+
+#: ../libsounds/sound-view.c:224
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr ""
+
+#: ../libsounds/sound-view.c:289
+msgid "Event"
+msgstr "Evenmint"
+
+#: ../libsounds/sound-view.c:298
+#, fuzzy
+msgid "Sound File"
+msgstr "Son"
+
+#: ../libsounds/sound-view.c:314
+#, fuzzy
+msgid "_Sounds:"
+msgstr "_Sons"
+
+#: ../libsounds/sound-view.c:328
+#, fuzzy
+msgid "Sound _file:"
+msgstr "Tchoezi on fitchî di son"
+
+#: ../libsounds/sound-view.c:332
+#, fuzzy
+msgid "Select Sound File"
+msgstr "Tchoezi on fitchî di son"
+
+#: ../libsounds/sound-view.c:356
+msgid "_Play"
+msgstr "_Djower"
+
+#: ../libsounds/sound-view.c:366
+msgid "_Remove"
+msgstr "_Bodjî"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+"Li manaedjeu di purneas «%s» n' a nén redjistré ene usteye d' apontiaedje\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Å pus grand"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Erôler"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "Brightness down"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "Brightness down's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Brightness up"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Brightness up's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "E-mail"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "E-mail's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+#, fuzzy
+msgid "Eject"
+msgstr "Evenmint"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+#, fuzzy
+msgid "Eject's shortcut."
+msgstr "Rascourtis do _scribanne:"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+#, fuzzy
+msgid "Home folder"
+msgstr "_Potchî å ridant des tinmes"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+#, fuzzy
+msgid "Home folder's shortcut."
+msgstr "Rascourti"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+#, fuzzy
+msgid "Launch help browser"
+msgstr "Foyteuse di l' aidance"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+#, fuzzy
+msgid "Launch help browser's shortcut."
+msgstr "Foyteuse di l' aidance"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+#, fuzzy
+msgid "Launch web browser"
+msgstr "Betchteu waibe"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+#, fuzzy
+msgid "Launch web browser's shortcut."
+msgstr "Betchteu waibe"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+#, fuzzy
+msgid "Lock screen"
+msgstr "Waitroûle"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+#, fuzzy
+msgid "Lock screen's shortcut."
+msgstr "Rascourti"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+#, fuzzy
+msgid "Log out"
+msgstr "Adjinçmint"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+#, fuzzy
+msgid "Log out's shortcut."
+msgstr "Rascourtis do _scribanne:"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Next track key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+#, fuzzy
+msgid "Pause"
+msgstr "C_laper"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Pause key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Play (or play/pause)"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Play (or play/pause) key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Previous track key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Search"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+#, fuzzy
+msgid "Search's shortcut."
+msgstr "Rascourti"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Skip to next track"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Skip to previous track"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+#, fuzzy
+msgid "Sleep"
+msgstr "Roedeu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+#, fuzzy
+msgid "Sleep's shortcut."
+msgstr "Rascourti"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Stop playback key"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Stop playback key's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+#, fuzzy
+msgid "Volume down"
+msgstr "_Volume:"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume down's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+#, fuzzy
+msgid "Volume mute"
+msgstr "_Volume:"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume mute's shortcut"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+#, fuzzy
+msgid "Volume step"
+msgstr "_Volume:"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+msgid "Volume step as percentage of volume."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+#, fuzzy
+msgid "Volume up"
+msgstr "_Volume:"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
+msgid "Volume up's shortcut."
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+msgid "Run screensaver at login"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr ""
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#, fuzzy
+msgid "Start screensaver"
+msgstr "Waitroûle"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+#, fuzzy
+msgid "Keyboard Update Handlers"
+msgstr "Xhuflet del taprece"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#, fuzzy
+msgid "Keyboard layout"
+msgstr "Rascourtis del taprece"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#, fuzzy
+msgid "Keyboard model"
+msgstr "Xhuflet del taprece"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+#, fuzzy
+msgid "Keyboard options"
+msgstr "Rascourtis del taprece"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+#, fuzzy
+msgid "keyboard layout"
+msgstr "Rascourtis del taprece"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+#, fuzzy
+msgid "keyboard model"
+msgstr "Xhuflet del taprece"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "modmap file list"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:212
+msgid "_Postpone break"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:259
+msgid "Take a break!"
+msgstr ""
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:141
+#, fuzzy
+msgid "/_Preferences"
+msgstr "Preferinces pol fonte"
+
+#: ../typing-break/drwright.c:142
+#, fuzzy
+msgid "/_About"
+msgstr "Å _dfait"
+
+#: ../typing-break/drwright.c:144
+msgid "/_Take a Break"
+msgstr ""
+
+#: ../typing-break/drwright.c:495
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../typing-break/drwright.c:499
+msgid "Less than one minute until the next break"
+msgstr ""
+
+#: ../typing-break/drwright.c:587
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+
+#: ../typing-break/drwright.c:635
+msgid "About GNOME Typing Monitor"
+msgstr ""
+
+#: ../typing-break/drwright.c:659
+msgid "A computer break reminder."
+msgstr ""
+
+#: ../typing-break/drwright.c:660
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr ""
+
+#: ../typing-break/drwright.c:661
+msgid "Eye candy added by Anders Carlsson"
+msgstr ""
+
+#: ../typing-break/drwright.c:837
+msgid "Break reminder"
+msgstr ""
+
+#: ../typing-break/main.c:93
+msgid "The typing monitor is already running."
+msgstr ""
+
+#: ../typing-break/main.c:106
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:276
+#, fuzzy
+msgid "Name:"
+msgstr "_No:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:289
+#, fuzzy
+msgid "Type:"
+msgstr "Sôre"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr ""
+
+#: ../vfs-methods/fontilus/font-view.c:347
+#, fuzzy
+msgid "Description:"
+msgstr "_Discrijhaedje:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+#, fuzzy
+msgid "Set as Application Font"
+msgstr "Fonte po les _programes:"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+#, fuzzy
+msgid "Sets the default application font"
+msgstr "Tchoezixhoz vos prémetous programes"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr ""
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+#, fuzzy
+msgid "GNOME Font Viewer"
+msgstr "Cinte di Contrôle di GNOME"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+#, fuzzy
+msgid "_Apply font"
+msgstr "Fonte po les _programes:"
+
+#: ../vfs-methods/themus/theme-method.c:520
+#, fuzzy
+msgid "Themes"
+msgstr "Tinme"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "Discrijhaedje"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+#, fuzzy
+msgid "Control theme"
+msgstr "Tinme do cursoe"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+#, fuzzy
+msgid "Window border theme"
+msgstr "Boird do purnea"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+#, fuzzy
+msgid "Icon theme"
+msgstr "Tinme do cursoe"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr ""
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+#, fuzzy
+msgid "Apply theme"
+msgstr "_Astaler novea tinme..."
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+msgid "Sets the default theme"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr ""
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr ""
+
+msgid "Show help options"
+msgstr ""

--- a/po/xh.po
+++ b/po/xh.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2005-03-23 09:53+0200\n"
 "Last-Translator: Canonical Ltd <translations@canonical.com>\n"
 "Language-Team: Xhosa <xh-translate@ubuntu.com>\n"
@@ -18,3490 +18,7272 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n!=1;\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
 #, fuzzy
-msgid "Alert Type"
+msgid "Applications"
+msgstr "<b>Iinkqubo</b>"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "IiNkqubo eziKhethwayo"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "_Seka uMxholo..."
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "_Vula"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "IiNkcukacha zomXholo"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Khangela"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "Ukhubazekile"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_Indawo:"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "Bonisa amancedo anokukhethwa"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Faka _Okungasemva"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Iskrini"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Akukho mHombiso"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "Isandi"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "Indlela enqumlayo"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "Iindlela eziNqumlayo ze-Keyboard"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
 msgstr "Yongeza uHlobo lweFayili"
 
-#: ../capplets/about-me/eel-alert-dialog.c:125
-#, fuzzy
-msgid "The type of alert"
-msgstr "Uhlobo lwesibalekisi."
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-#, fuzzy
-msgid "Alert Buttons"
-msgstr "Amaqhosha"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
 msgstr ""
 
-#: ../capplets/about-me/eel-alert-dialog.c:198
-#, fuzzy
-msgid "Show more _details"
-msgstr "_Iinkcukacha zoMxholo"
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-msgid "About Me"
-msgstr "Malunga Nam"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your personal information"
-msgstr "Uhlobo lolwazi i-MIME"
-
-#: ../capplets/about-me/gnome-about-me.c:554
-msgid "Select Image"
-msgstr "Khetha uMfanekiso"
-
-#: ../capplets/about-me/gnome-about-me.c:556
-msgid "No Image"
-msgstr "Akukho Mfanekiso"
-
-#: ../capplets/about-me/gnome-about-me.c:706
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
+"How much disk space this application is occupying with app data and caches."
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.c:727
-msgid "Unable to open address book"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:739
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:770
-#: ../capplets/about-me/gnome-about-me.c:772
-#, fuzzy, c-format
-msgid "About %s"
-msgstr "Malunga Nam"
-
-#: ../capplets/about-me/gnome-about-me-password.c:101
-#: ../capplets/about-me/gnome-about-me-password.c:479
-msgid "Old password is incorrect, please retype it"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:112
+#: panels/applications/cc-applications-panel.ui:420
 #, fuzzy
-msgid "System error has occurred"
-msgstr "Kwenzeke impazamo engalindelekanga"
+msgid "Application"
+msgstr "_Ifonti yenkqubo:"
 
-#: ../capplets/about-me/gnome-about-me-password.c:113
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
 #, fuzzy
-msgid "Could not run /usr/bin/passwd"
-msgstr "Akukwazekanga ukusebenzisa i-passwd"
-
-#: ../capplets/about-me/gnome-about-me-password.c:114
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:117
-#, fuzzy
-msgid "Unexpected error has occurred"
-msgstr "Kwenzeke impazamo engalindelekanga"
-
-#: ../capplets/about-me/gnome-about-me-password.c:315
-msgid "Password is too short"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:318
-#: ../capplets/about-me/gnome-about-me-password.c:321
-msgid "Password is too simple"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:324
-msgid "Old and new passwords are too similar"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:328
-msgid "Old and new password are the same"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:406
-#, fuzzy
-msgid "Please type the passwords."
-msgstr "Chwetheza kwakhona i-Password eNtsha:"
-
-#: ../capplets/about-me/gnome-about-me-password.c:414
-msgid "Please type the password again, it is wrong."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:417
-msgid "Click on Change Password to change the password."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/font/font-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-msgid "    "
-msgstr "    "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-msgid "<b>Email</b>"
+msgid "<b>Total</b>"
 msgstr "<b>I-imeyile</b>"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-msgid "<b>Home</b>"
-msgstr "<b>Ikhaya</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Umyalezo wesiquphe</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-msgid "<b>Job</b>"
-msgstr "<b>Umsebenzi</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-msgid "<b>Telephone</b>"
-msgstr "<b>Imfonomfono</b>"
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-msgid "<b>Web</b>"
-msgstr "<b>I-Web</b>"
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-msgid "<b>Work</b>"
-msgstr "<b>Umsebenzi</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr "I-A_IM/iChat:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
+#: panels/background/cc-background-panel.ui:9
 #, fuzzy
-msgid "A_ddress:"
+msgid "Style"
+msgstr "Isimbo:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "Esilelayo"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "Faka _Okungasemva"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+#, fuzzy
+msgid "Screen Calibration"
+msgstr "Isigqibo seSkrini"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
+#, fuzzy
+msgid "Display Brightness"
+msgstr "Ukukhanya makunyuswe"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Ngenisa"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
+msgstr "_Yongeza..."
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
+msgstr "Ii_modeli:"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "_Susa"
+
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Iinkcukacha"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
+msgstr "imizuzu"
+
+#: panels/color/cc-color-panel.ui:635
+#, fuzzy
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "_Phakathi"
+
+#: panels/color/cc-color-panel.ui:636
+#, fuzzy
+msgid "30 minutes"
+msgstr "imizuzu"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "imizuzu"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Umbala oNgqingqwa"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "Khetha uMfanekiso"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Khetha"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
+msgstr "_Ukuphela kwexesha:"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
+#, fuzzy
+msgid "March"
+msgstr "Khangela"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "Libaz_isa:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
+msgstr "Indlela enqumlayo yokukhangela."
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Ukhubazekile"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "imizuzwana"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Ikhale_nda:"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Tshintsha imimiselo yokungaSemva kwi-Desktop"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "I-KMail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Ikhale_nda:"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "IiNkqubo eziKhethwayo"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Khetha iinkqubo zakho ezimiselweyo"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "_Faka ifonti"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<b>UQhelaniso lweMawusi</b>"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Isigqibo:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Umda wokwenza ntsha_kwakhona:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Ihlengahlengisiwe"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Iqhezu ligqityiwe"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Ivela: %s"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "imizuzu"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "Iya: %s"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+#, fuzzy
+msgid "No Events"
+msgstr "Izehlo zesandi"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Igama:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Uhlobo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "I-Terminal ye-GNOME"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "U-Windows"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "_Igama lomxholo:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "I_gama lomsebenzisi:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Malunga"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Ukuthula kwesandi"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "Isandi masithotywe"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "Nyusa isandi"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Dlala (okanye dlala/nqumama)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
+#, fuzzy
+msgid "Stop playback"
+msgstr "Iqhosha lokumisa ukudlala okungasemva"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+#, fuzzy
+msgid "Previous track"
+msgstr "Tsibela kwingoma yangaphambili"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+#, fuzzy
+msgid "Next track"
+msgstr "Tsibela kwingoma elandelayo"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Khupha"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+#, fuzzy
+msgid "Typing"
+msgstr "Unqanyulo lokuChwetheza"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+#, fuzzy
+msgid "Switch to next input source"
+msgstr "Tsibela kwingoma elandelayo"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+#, fuzzy
+msgid "Switch to previous input source"
+msgstr "Tsibela kwingoma yangaphambili"
+
+#: panels/keyboard/01-launchers.xml.in:2
+#, fuzzy
+msgid "Launchers"
+msgstr "Isikhangeli sewebhu sokundulula"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Isikhangeli soncedo sokundulula"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+#, fuzzy
+msgid "Settings"
+msgstr "Imimiselo emiselweyo"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr ""
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Isikhangeli sewebhu sokundulula"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Isiqulathi seefayili sasekhaya"
+
+#: panels/keyboard/01-launchers.xml.in:16
+#, fuzzy
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Khangela"
+
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
+#, fuzzy
+msgid "System"
+msgstr "INtsimbi yeNkqubo"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Phuma"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Tshixa iskrini"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Ukufumaneka"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Phuma"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "_I-keyboard ekwiskrini"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Ekunokukhethwa kuko"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
+msgstr "/_Uluhlu lokukhetha"
+
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Ubume be-keyboard"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Susa"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Amaqhosha emawusi"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Iindlela eziNqumlayo ze-Keyboard"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Isenzo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Indlela enqumlayo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Indlela enqumlayo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Indlela enqumlayo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Iindlela eziNqumlayo ze-Keyboard"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Susa"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Igama:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "_Umyalelo:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Indlela enqumlayo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Indlela enqumlayo"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_Ayikho"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Misela kwakhona Kokumi_selweyo"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "I-keyboard"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Uhlobo lolwazi i-MIME"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Imimiselo emiselweyo"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Jikelele"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "_Kancinci"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_Indawo:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Imawusi"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Amaqhosha emawusi"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Ukhawuleziso:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Ukhawuleziso:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "_Ifonti yenkqubo:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Ezinye"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Isenzo"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Iyahlangana..."
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Ekunokukhethwa kuko"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "I-_Password:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Tshintsha i-Password"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Inkqubo i-Accel"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "_Idilesi"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "_Idilesi"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "_Idilesi"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Esilelayo"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Igama:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
 msgstr "_Idilesi:"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr "Um_ncedisi:"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:15
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Idilesi:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Ukhubazekile"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_Idilesi"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 #, fuzzy
 msgid "Address"
 msgstr "_Idilesi"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-msgid "C_ity:"
-msgstr "Isi_xeko:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-msgid "C_ompany:"
-msgstr "Inka_mpani:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-msgid "Cale_ndar:"
-msgstr "Ikhale_nda:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-#, fuzzy
-msgid "Change Passwo_rd..."
-msgstr "Tshintsha i-Passwo_rd"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-msgid "Change Password"
-msgstr "Tshintsha i-Password"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-#, fuzzy
-msgid "Ci_ty:"
-msgstr "Isi_xeko:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-msgid "Co_untry:"
-msgstr "Ili_zwe:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-#, fuzzy
-msgid "Contact"
-msgstr "_Nxibelelana"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-#, fuzzy
-msgid "Cou_ntry:"
-msgstr "Ili_zwe:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
 msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:26
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 #, fuzzy
-msgid "Hom_e:"
-msgstr "_Ikhaya:"
+msgid "Routes"
+msgstr "imizuzu"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr "I-IC_Q:"
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr "I-M_SN:"
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:29
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
 #, fuzzy
-msgid "Old pa_ssword:"
-msgstr "I-Password eNdala:"
+msgid "Network"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-#, fuzzy
-msgid "P.O. _box:"
-msgstr "IBhokisi:"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-#, fuzzy
-msgid "P._O. box:"
-msgstr "IBhokisi:"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-#, fuzzy
-msgid "Personal Info"
-msgstr "_Iinkcukacha Zakho"
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-#, fuzzy
-msgid "State/Pro_vince:"
-msgstr "_Ilizwe/Iphondo:"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:34
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
 #, fuzzy
-msgid "User name:"
+msgid "Active"
+msgstr "Isenzo"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "_Idilesi"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "Ikhompyutha esebenza njengomqobo eyi-H_TTP:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "Ikhompyutha esebenza njengomqobo eyi-H_TTP:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "Ikhompyutha esebenza njengomqobo i-_FTP:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Umququzeleli we-S_ocks:"
+
+#: panels/network/network-proxy.ui:209
+#, fuzzy
+msgid "_Ignore Hosts"
+msgstr "<b>Sukuluhoya uluhlu lwabaququzeleli</b>"
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "Ikhompyutha esebenza njengomqobo eyi-H_TTP:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "Ikhompyutha esebenza njengomqobo eyi-H_TTP:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "Ikhompyutha esebenza njengomqobo i-_FTP:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "I-Autoconfiguration _URL:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "I-_Password:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Ekunokukhethwa kuko kwe-keyboard"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Sebenzisa uqinisekiso</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
 msgstr "I_gama lomsebenzisi:"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:35
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
 #, fuzzy
-msgid "Web _log:"
-msgstr "I-Web _Log:"
+msgid "_Password"
+msgstr "I-_Password:"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:36
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 #, fuzzy
-msgid "Wor_k:"
-msgstr "_Umsebenzi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-#, fuzzy
-msgid "Work _fax:"
-msgstr "IFeksi _yoMsebenzi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-#, fuzzy
-msgid "Zip/_Postal code:"
-msgstr "U-_zip/Ikhowudi yePosi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-msgid "_Address:"
-msgstr "_Idilesi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr "_Isebe:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr "_Ngokweqela:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-#, fuzzy
-msgid "_Home page:"
-msgstr "_Iphepha laseKhaya:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-msgid "_Home:"
-msgstr "_Ikhaya:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr "I-_Jabber:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-msgid "_Manager:"
-msgstr "_Umlawuli:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-msgid "_Mobile:"
-msgstr "_Ephathwayo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-#, fuzzy
-msgid "_New password:"
+msgid "Sho_w password"
 msgstr "I-Password eNtsha:"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-msgid "_Profession:"
-msgstr "_Ikhondo:"
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:49
+#: panels/network/wireless-security/eap-method-peap.ui:36
 #, fuzzy
-msgid "_Retype new password:"
+msgid "Version 0"
+msgstr "Uhlobo:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Uhlobo:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
 msgstr "Chwetheza kwakhona i-Password eNtsha:"
 
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr "_Ilizwe/Iphondo:"
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-msgid "_Title:"
-msgstr "_Isihloko:"
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Work:"
-msgstr "_Umsebenzi:"
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr "U-_Yahoo:"
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
 
-#: ../capplets/about-me/gnome-about-me.glade.h:54
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 #, fuzzy
-msgid "_Zip/Postal code:"
-msgstr "U-_zip/Ikhowudi yePosi:"
+msgid "Au_thentication"
+msgstr "<b>_Sebenzisa uqinisekiso</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Applications</b>"
-msgstr "<b>Iinkqubo</b>"
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Uhlobo"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Support</b>"
-msgstr "<b>Inkxaso</b>"
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Esilelayo"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Vula iFayili"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Indawo:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "i_Fayili yesandi:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
 msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
 msgstr ""
-"<small><i><b>Qaphela:</b> Iinguqulelo kulo mmiselo azizukwenziwa de ungene "
-"kwakhona.</i></small>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technology Preferences"
-msgstr "Uluhlu lokukhetha lobuChwephesha oluNcedayo"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr "Vala _Uphume"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr "Qalisa obu buchwephesha buncedayo ngalo lonke ixesha ungena:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr "_Yenza ukuba ubuchwepheshe obuncedayo busebenze"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr "_Isandisi"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr "_I-keyboard ekwiskrini"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Screenreader"
-msgstr "_Okufunda iskrini"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr "INkxaso yobuChwepheshe eNcedayo"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
 msgstr ""
-"Yenza ukuba kusebenze inkxaso ukulungiselela ubuchwephesha boncedo be-GNOME "
-"kungeno"
 
-#: ../capplets/accessibility/at-properties/main.c:60
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Indlela enqumlayo yokutshixa iskrini."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Indlela enqumlayo yokutshixa iskrini."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Sebenzisa uqinisekiso</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
 msgstr ""
-"Akukho buChwephesha boNcedo bukhoyo kwinkqubo yakho. Umqulu wenkqubo we'gok' "
-"kufuneka umiselwe ukuze kufikelelwe kwinkxaso ye-keyboard ekwiskrin, yaye "
-"umpakisho we'gnopernicus' kufuneka umiselwe ufundo lweskrini namandla okwazi "
-"ukwandisa."
 
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-"Ayibubo bonke ubuchwepheshe obuncedayo obumiselweyo kwinkqubo yakho. Umqulu "
-"wenkqubo ye-'gok' kufuneka imiselwe ukuze kufikeleleke kwinkxaso ye-keyboard "
-"ekwiskrini."
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "imizuzu"
+msgstr[1] "imizuzu"
 
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Asibubo bonke ubuchwepheshe obuncedayo obusekiweyo kwinkqubo yakho. Umqulu "
-"wenkqubo we-'gnopernicus' kufuneka usekiwe ukulungiselela ufundo lweskrini "
-"namandla okwazi ukwandisa."
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
+#: panels/power/cc-battery-row.c:92
 #, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "imizuzu"
+msgstr[1] "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
 msgstr ""
-"Kubekho impazamo ekundululeni unxibelelwano loluhlu ekukhethwa kulo "
-"lwemawusi: %s"
 
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr "Akukwazeki ukudlulisa imimiselo ye-AccessX kwifayili '%s'"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "imizuzu"
 
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
-msgid "Import Feature Settings File"
-msgstr "IFayili yeMimiselo yoPhawu lokuNgenisa"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "imizuzu"
 
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
-msgid "_Import"
-msgstr "_Ngenisa"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "imizuzu"
 
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "I-keyboard"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
 
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr "Misela uluhlu lokukhetha lwakho lokufikelela lwe-keyboard"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
 
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Inkqubo i-Accel"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Zalisa iSkrini"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Iskrini"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Libazisa:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
 msgstr ""
-"Le nkqubo ayibonakalisi ukuba inesongezo i-XKB. Iimpawu ze-keyboard "
-"zokufumaneka azizukusebenza ngaphandle kwayo."
 
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-#: ../capplets/theme-switcher/theme-install.glade.h:1
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "*"
-msgstr "*"
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "_Shicilela"
 
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "<b>Yenza ukuba amaQhosha okuQa_katha asebenze</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "<b>Yenza ukuba amaQhosha okuCo_thisa asebenze</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "<b>Yenza ukuba amaQhosha _Emawusi asebenze</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "<b>Yenza ukuba amaQhosha _Okuphinda asebenze</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "<b>Yenza ukuba amaQhosha _Ancamathelayo asebenze</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-msgid "<b>Features</b>"
-msgstr "<b>Iimpawu</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr "<b>AmaQhosha i-Toggle</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "Esisiseko"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr "Yenza isandi esifutshane esiphindaphindayo ukuba iqhosha la_liwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr ""
-"Yenza isandi esifutshane esiphindaphindayo xa _iimpawu zivuliwe okanye "
-"zivaliwe kwi-keyboard"
 
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "I_gama lomsebenzisi:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "_Indawo:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Ukusekwa komxholo"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Khetha"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Ekunokukhethwa kuko"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Iinkcukacha Zokwenza iFonti"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Misela kwakhona Kokumi_selweyo"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Iimodeli"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "Okuqale kubonakaliswe:"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+#, fuzzy
+msgid "Measurement"
+msgstr "_Isebe:"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Zalisa iSkrini"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Isenzo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Uhlobo:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Iskrini"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Tshixa iskrini"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Iskrini"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Iskrini"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Iskrini %d Imimiselo\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Ekunokukhethwa kuko kwe-keyboard"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Ezinye"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "_Indawo:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "_Ifonti yenkqubo:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Indlela enqumlayo yokukhangela."
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "I-desktop"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Susa"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "I-_Password:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "I-desktop"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "ULawulo lwe-UI"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Kopa"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<b>_Sebenzisa uqinisekiso</b>"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "I_gama lomsebenzisi:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "INtsimbi yeNkqubo"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Ukuthula kwesandi"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "UkuMiselwa kwenkqubo kwiKhompyutha esbenza njengomqobo"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Isandi"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Amaqhosha"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Isandi"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "Igama:"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+#, fuzzy
+msgid "Thunderbolt"
+msgstr "i-Thunderbird"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+#, fuzzy
+msgid "Cursor Blinking"
+msgstr "<b>Ikhesa iyaDanyaza</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Ikhesa _iyadanyaza kwiibhokisi zombhalo nakwiindawo"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "I_santya:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "<b>Ikhesa iyaDanyaza</b>"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "UbuNgakanani beKhesa"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Indlela enqumlayo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Libazisa:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Indlela enqumlayo"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Umda:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "_Ncinci"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "_Nkulu"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Amaqhosha okuPhinda</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Iqhosha licinezela _u-phinda xa iqhosha licinezelwe"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "IsiLumkiso samaQhosha aNcamathelayo"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Yenza ukuba inga_sebenzi ukuba amaqhosha amabini acinezelwe kunye"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
 msgstr ""
 "Yenza isandi esifutshane esiphindaphindayo xa _iqhosha elisisilungisi "
 "licinezelwe"
 
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr ""
-"Yenza isandi esifutshane esiphindaphindayo xa iLED ivuliwe uze wenze izandi "
-"ezibini ezifutshane xa ivaliwe."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr "Yenza isandi esifutshane esiphindaphindayo xa iqhosha li:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr "Libaz_isa:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr "Ukulibazisa phakathi kocinezelo qhosha nentshu_kumo yesalathisi:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr "Yenza ukuba inga_sebenzi ukuba amaqhosha amabini acinezelwe kunye"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr "Yenza ukuba amaQhosha e-Toggle ase_benze"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Izihluzi"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr "Suku_hoya ukucofwa kwamaqhosha okuphindiweyo ngaphakathi:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-"Sukuhoya konke ukucofa okulandelayo kweqhosha ELIFANAYO ukuba akwixesha "
-"elikhethwe ngumsebenzisi."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr "Uluhlu lokukhetha lokufikelela lwe-Keyboard (AccessX)"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr "Isantya sesalathisi esisesona Siphe_zulu:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr "Amaqhosha emawusi"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr "_Uluhlu lokukhetha lwemawusi..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-"Yamkela amaqhosha kuphela emva kokuba ecinezelwe aze agcinwa ngexesha "
-"lomsebenzisi elilungelelanisiweyo."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-"Yenza imisebenzi yokucinezela amaqhosha ngaxeshanye kaninzi ngokucinezela "
-"amaqhosha azizilungisi ngokulandelelana."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "S_peed:"
-msgstr "I_santya:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr "Lixesha lokunqu_mla ngesantya esisesona siphezulu:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr "Guqulela i-keypad yamanani kwi-pad yolawulo lwemawusi."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr "_Yenza ukuba ingasebenzi ukuba ayisetyenziswa:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr "_Yenza ukuba iimpawu zokufikelela ze-keyboard zingasebenzi"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr "_Imimiselo yeeMpawu zokuDlulisa..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr "_Yamkela kuphela amaqhosha abanjelwe i:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Type to test settings:"
-msgstr "_Chwetheza ukuvavanya imimiselo:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr "_ivunyiwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr "_icinezelwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr "_yaliwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr "iimpawu/umzuzwana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-msgid "milliseconds"
-msgstr "i-mizuzwana yemizuzwana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr "i-pixels/umzuzwana"
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:885
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "imizuzwana"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-msgid "Change your Desktop Background settings"
-msgstr "Tshintsha imimiselo yokungaSemva kwi-Desktop"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-msgid "Desktop Background"
-msgstr "OkungaSemva kwi-Desktop"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "<b>_Umhombiso we-Desktop</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-msgid "<b>_Desktop Colors</b>"
-msgstr "<b>Imibala ye-_Desktop</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-msgid "Desktop Background Preferences"
-msgstr "Uluhlu lokukhetha lokungaSemva kwi-Desktop"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr "_Faka umHombiso weskrini"
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-msgid "_Style:"
-msgstr "I_simbo:"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Kubekho impazamo ekuvezeni uncedo: %s"
-
-#: ../capplets/background/gnome-wp-capplet.c:1042
-#: ../capplets/background/gnome-wp-capplet.c:1060
-msgid "Centered"
-msgstr "Ibekwe embindini"
-
-#: ../capplets/background/gnome-wp-capplet.c:1068
-#: ../capplets/background/gnome-wp-capplet.c:1085
-msgid "Fill Screen"
-msgstr "Zalisa iSkrini"
-
-#: ../capplets/background/gnome-wp-capplet.c:1093
-#: ../capplets/background/gnome-wp-capplet.c:1110
-msgid "Scaled"
-msgstr "Ihlengahlengisiwe"
-
-#: ../capplets/background/gnome-wp-capplet.c:1118
-#: ../capplets/background/gnome-wp-capplet.c:1135
-msgid "Tiled"
-msgstr "Ifakwe iithayili"
-
-#: ../capplets/background/gnome-wp-capplet.c:1159
-#: ../capplets/background/gnome-wp-capplet.c:1168
-msgid "Solid Color"
-msgstr "Umbala oNgqingqwa"
-
-#: ../capplets/background/gnome-wp-capplet.c:1176
-#: ../capplets/background/gnome-wp-capplet.c:1185
-msgid "Horizontal Gradient"
-msgstr "UkuThambeka okuNqamlezileyo"
-
-#: ../capplets/background/gnome-wp-capplet.c:1193
-#: ../capplets/background/gnome-wp-capplet.c:1202
-msgid "Vertical Gradient"
-msgstr "UkuThambeka okuthe Nkqo"
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1251
-msgid "Add Wallpaper"
-msgstr "Hombisa iSkrini"
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr "Akukho mHombiso"
-
-#: ../capplets/background/gnome-wp-item.c:292
-#: ../capplets/background/gnome-wp-item.c:294
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] "i-pixel"
-msgstr[1] "ii-pixels"
-
-#: ../capplets/common/activate-settings-daemon.c:18
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"Akukwazeki ukuqalisa imimiselo yomlawuli i-'gnome-settings-daemon'.\n"
-"Ngaphandle kokuqhubeka komlawuli wemimiselo i-GNOME, uluhlu lokukhetha "
-"oluthile lunokungasebenzi. Oku kunokubonisa ingxaki ye-Bonobo, okanye "
-"umlawuli wemimiselo ongengo-GNOME (umz. KDE) inoba sele esebenza yaye abe "
-"uyakhabana nomlawuli wemimiselo ye-GNOME."
-
-#: ../capplets/common/capplet-stock-icons.c:94
-#, c-format
-msgid "Unable to load capplet stock icon '%s'\n"
-msgstr "Akukwazeki ukufaka umfanekiso we-capplet stock '%s'\n"
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr "Faka nje kuphela imimiselo uze uphume"
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/default-applications/gnome-default-applications-properties.c:765
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1021
-#: ../capplets/sound/sound-properties-capplet.c:244
-msgid "Retrieve and store legacy settings"
-msgstr "Fumana kwakhona uze ugcine imimiselo elilifa"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %i of %i"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr "Ivela kwi-URI"
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr "I-URI idlulisela ngoku ukusuka"
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr "Ukuya kwi-URI"
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr "I-URI ngoku idlulisela"
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr "Iqhezu ligqityiwe"
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr "Iqhezu lokudlulisa ligqityiwe ngoku"
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr "Isalathiso se-URI sangoku"
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr "Isalathiso se-URI sangoku - siqala ku1"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr "I-URIs zizonke"
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr "Inani lilonke le-URIs"
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:345
+#: panels/universal-access/cc-typing-dialog.ui:96
 #, fuzzy
-msgid "From:"
-msgstr "Ivela: %s"
+msgid "S_low Keys"
+msgstr "IsiLumkiso samaQhosha aCothayo"
 
-#: ../capplets/common/file-transfer-dialog.c:349
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
 #, fuzzy
-msgid "To:"
-msgstr "Iya: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr "Iyahlangana..."
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Iqhosha"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr "Iqhosha le-GConf apho umhleli wophawu aqhotyoshelwe khona"
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr "Ubuyiselo nxulumano"
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-"Khupha le ubuyiselo nxulumano xa ixabiso elinxulunyaniswa neqhosha "
-"litshintshiwe"
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr "Utshintsho lommiselo"
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"Utshintsho lommiselo we-GConf oqulethe i-data emayithunyelwe kumxumi we-"
-"gconf iyasebenza"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr "Uguqulo ku-widget callback"
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-"Ubuyiselo nxulumano malukhutshwe xa i-data kufuneka iguqulelwe ukusuka kwi-"
-"GConf ukuya ku-widget"
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr "Uguqulo olusuka ku-widget callback"
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"Ubuyiselo nxulumano malukhutshwe xa i-data kufuneka iguqulelwe ukuya kwi-"
-"GConf isuka ku-widget"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr "ULawulo lwe-UI"
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr "Into elawula uphawu (ngokuqhelekileyo i-widget)"
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr "Ulwazi lomhleli lophawu lwento"
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr "Ulwazi ozenzeleyo olufunwa ngumhleli wophawu othile"
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr "Ulwazi lomhleli lophawu ikhulula ubuyiselo nxulumano"
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Ubuyiselo nxulumano emalikhutshwe xa i-data yomhleli yento kufuneka ikhululwe"
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Ayifumanekanga ifayili '%s'.\n"
-"\n"
-"Nceda uqinisekise ukuba ikhona uze uzame kwakhona, okanye khetha umfanekiso "
-"wokungasemva owohlukileyo."
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Andikwazi ukuvula ifayili '%s'.\n"
-"Mhlawumbi luhlobo lomfanekiso olungekaxhaswa.\n"
-"\n"
-"Nceda ukhethe umfanekiso owohlukileyo endaweni yoko."
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr "Nceda ukhethe umfanekiso."
-
-#: ../capplets/common/gconf-property-editor.c:1598
-msgid "_Select"
-msgstr "_Khetha"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
-msgstr "IiNkqubo eziKhethwayo"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Khetha iinkqubo zakho ezimiselweyo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
-msgid "Debian Sensible Browser"
-msgstr "I-Debian Sensible Browser"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
-msgid "Epiphany"
-msgstr "I-Epiphany"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
-msgid "Galeon"
-msgstr "I-Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
-msgid "Encompass"
-msgstr "i-Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
-msgid "Firebird"
-msgstr "i-Firebird"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
-msgid "Firefox"
-msgstr "I-Firefox"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
-msgid "Mozilla"
-msgstr "I-Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
-msgid "Netscape Communicator"
-msgstr "Umnxibelelanisi we-Netscape"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
-msgid "Konqueror"
-msgstr "I-Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
-msgid "W3M Text Browser"
-msgstr "IsiKhangeli soMbhalo we-W3M"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
-msgid "Lynx Text Browser"
-msgstr "Isikhangeli soMbhalo we-Lynx"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
-msgid "Links Text Browser"
-msgstr "Inxulumanisa isiKhangeli soMbhalo"
-
-#. The code in gnome-default-applications-properties.c makes sure
-#. * there is only one (the first entry in this list) Evolution entry
-#. * in the list shown to the user
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
-msgid "Evolution Mail Reader"
-msgstr "I-Evolution Mail Reader"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
-msgid "Balsa"
-msgstr "I-Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
-msgid "KMail"
-msgstr "I-KMail"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
-msgid "Thunderbird"
-msgstr "i-Thunderbird"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
-msgid "Mozilla Mail"
-msgstr "I-Mozilla Mail"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
-msgid "Mutt"
-msgstr "I-Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
-msgid "Debian Terminal Emulator"
-msgstr "IsiLinganisi sexesha elimiselweyo seDebian"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
-msgid "GNOME Terminal"
-msgstr "I-Terminal ye-GNOME"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
-msgid "Standard XTerminal"
-msgstr "I-Standard XTerminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
-msgid "NXterm"
-msgstr "I-NXterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
-msgid "RXVT"
-msgstr "I-RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
-msgid "aterm"
-msgstr "i-aterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
-msgid "ETerm"
-msgstr "I-ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.c:123
-msgid "Please specify a name and a command for this editor."
-msgstr "Nceda uchaze igama nomyalelo walo mhleli."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "Add..."
-msgstr "Yongeza..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-msgid "C_ustom"
-msgstr "Isi_qhelo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-msgid "C_ustom:"
-msgstr "Isi_qhelo:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "Can open _URIs"
-msgstr "Ingavula ii _URIs"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-msgid "Can open multiple _files"
-msgstr "Ingavula ii _fayili ezininzi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "Co_mmand:"
-msgstr "Um_yalelo:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "Custom Editor Properties"
-msgstr "Iimpawu zoMhleli zokuZenzela"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "Default Mail Reader"
-msgstr "Umfundi we-Imeyile omiselweyo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "Default Terminal"
-msgstr "I-Terminal eMiselweyo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Default Text Editor"
-msgstr "UMhleli woMbhalo oMiselweyo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "Default Web Browser"
-msgstr "IsiKhangeli se-Web esiMiselweyo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Default Window Manager"
-msgstr "UMlawuli weFestile eMiselweyo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Delete"
-msgstr "Cima"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "E_xec Flag:"
-msgstr "I-E_xec Flag:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Edit..."
-msgstr "Hlela..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Mail Reader"
-msgstr "UMfundi we-Imeyile"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-msgid "Run in a _terminal"
-msgstr "Ukusebenza kwi _terminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-msgid "Run in a t_erminal"
-msgstr "Ukusebenza kwi-t_erminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid ""
-"Select the window manager you want.  You will need to hit apply, wave the "
-"magic wand, and do a magic dance for it to work."
-msgstr ""
-"Khetha umlawuli wefestile omfunayo. Kuza kufuneka ubethe u-apply, wave the "
-"magic wand, uze."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Terminal"
-msgstr "I-Terminal"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Text Editor"
-msgstr "Umhleli woMbhalo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Understands _Netscape Remote Control"
-msgstr "Iqonda i _Netscape Remote Control"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "Use this _editor to open text files in the file manager"
-msgstr "Sebenzisa lo _mhleli ukuvula iifayili zombhalo kumlawuli wefayili"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "Web Browser"
-msgstr "IsiKhangeli seWeb"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
-msgid "Window Manager"
-msgstr "UMlawuli weFestile"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
-msgid "_Command:"
-msgstr "_Umyalelo:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
-msgid "_Name:"
-msgstr "_Igama:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
-msgid "_Properties..."
-msgstr "_Iimpawu..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
-msgid "_Select:"
-msgstr "_Khetha:"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Tshintsha isigqibo seskrini"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Isigqibo seSkrini"
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr "I-%d Hz"
-
-#: ../capplets/display/main.c:448
-msgid "_Resolution:"
-msgstr "_Isigqibo:"
-
-#: ../capplets/display/main.c:467
-msgid "Re_fresh rate:"
-msgstr "Umda wokwenza ntsha_kwakhona:"
-
-#: ../capplets/display/main.c:488
-msgid "Default Settings"
-msgstr "Imimiselo emiselweyo"
-
-#: ../capplets/display/main.c:490
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr "Iskrini %d Imimiselo\n"
-
-#: ../capplets/display/main.c:516
-msgid "Screen Resolution Preferences"
-msgstr "Uluhlu lokuKhetha lweSigqibo seSkrini"
-
-#: ../capplets/display/main.c:553
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "_Yenza okumiselweyo kule khompyutha (%s) kuphela"
-
-#: ../capplets/display/main.c:571
-msgid "Options"
-msgstr "Ekunokukhethwa kuko"
-
-#: ../capplets/display/main.c:592
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"Kuvavanywa imimiselo emitsha. Ukuba awuphenduli kwi %d yomzuzwana imimiselo "
-"yangaphambili iyabuyiselwa kwakhona."
-msgstr[1] ""
-"Kuvavanywa imimiselo emitsha. Ukuba awuphenduli kwi %d yemizuzwana imimiselo "
-"yangaphambili iyabuyiselwa kwakhona."
-
-#: ../capplets/display/main.c:638
-msgid "Keep Resolution"
-msgstr "Gcina isiGqibo"
-
-#: ../capplets/display/main.c:642
-msgid "Do you want to keep this resolution?"
-msgstr "Uyafuna ukugcina esi sigqibo?"
-
-#: ../capplets/display/main.c:667
-msgid "Use _previous resolution"
-msgstr "Sebenzisa isigqibo _sangaphambili"
-
-#: ../capplets/display/main.c:667
-msgid "_Keep resolution"
-msgstr "_Gcina isigqibo"
-
-#: ../capplets/display/main.c:818
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"I-X Server ayisixhasi isandiso se-XR ne-R. Iinguqulo zesigqibo sexesha "
-"lokusebenza kubungakanani kokukwiskrini azikho."
-
-#: ../capplets/display/main.c:826
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"Uhlobo lwesandiso se-XR neR aluhambelani nale nkqubo. Iinguqulo zesigqibo "
-"sexesha kubungakanani bokwiskrini azikho."
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Ifonti"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr "Khetha iifonti ze-desktop"
-
-#: ../capplets/font/font-properties.glade.h:2
-msgid "<b>Font Rendering</b>"
-msgstr "<b>Ukwenza iFonti</b>"
-
-#: ../capplets/font/font-properties.glade.h:3
-msgid "<b>Hinting</b>:"
-msgstr "<b>Ukucebisa</b>:"
-
-#: ../capplets/font/font-properties.glade.h:4
-msgid "<b>Smoothing</b>:"
-msgstr "<b>Ukugudisa</b>:"
-
-#: ../capplets/font/font-properties.glade.h:5
-msgid "<b>Subpixel order</b>:"
-msgstr "<b>Ulungelelwano oluyi-Subpixel</b>:"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best _shapes"
-msgstr "_Izazobe ezizezona ezibhetele"
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "Best co_ntrast"
-msgstr "Ink_caso eyiyeyona ingcono"
-
-#: ../capplets/font/font-properties.glade.h:8
-msgid "D_etails..."
-msgstr "Iink_cukacha..."
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "ULuhlu lokukhetha lwefonti"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr "Iinkcukacha Zokwenza iFonti"
-
-#: ../capplets/font/font-properties.glade.h:11
-msgid "Go _to font folder"
-msgstr "Yiya _kwisiqulathi seefayili"
-
-#: ../capplets/font/font-properties.glade.h:12
-msgid "Gra_yscale"
-msgstr "I-Gra_yscale"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "A_yikho"
-
-#: ../capplets/font/font-properties.glade.h:14
-msgid "R_esolution:"
-msgstr "Isi_gqibo:"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr "I-Sub_pixel (LCDs)"
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "Ukugudisa i-sub_pixel (LCDs)"
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr "i-VB_GR"
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
-msgstr "_Ifonti yenkqubo:"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr "I-_BGR"
-
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Desktop font:"
-msgstr "Ifonti ye-_desktop:"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Full"
-msgstr "_Zele"
-
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Medium"
-msgstr "_Phakathi"
-
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Monochrome"
-msgstr "I-_Monochrome"
-
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_None"
-msgstr "_Ayikho"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_RGB"
-msgstr "I-_RGB"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_Slight"
-msgstr "_Kancinci"
-
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Terminal font:"
-msgstr "Ifonti ye-_terminal:"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr "I-_VRGB"
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "_Ifonti yesihloko sefestile:"
-
-#: ../capplets/font/font-properties.glade.h:30
-msgid "dots per inch"
-msgstr "amachaphaza nge-intshi"
-
-#: ../capplets/font/main.c:488
-msgid "Font may be too large"
-msgstr "Inokuba ifonti inkulu kakhulu"
-
-#: ../capplets/font/main.c:492
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Ifonti ekhethiweyo ilichaphaza %d ubukhulu, yaye inokwenza ukuba kube nzima "
-"ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe ubungakanani "
-"obuncinci kuno%d."
-msgstr[1] ""
-"Ifonti ekhethiweyo ingamachaphaza %d ubukhulu, yaye inokwenza ukuba kube "
-"nzima ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe "
-"ubungakanani obuncinci kuno%d."
-
-#: ../capplets/font/main.c:505
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Ifonti ekhethiweyo ilichaphaza %d ubukhulu, yaye inokwenza ukuba kube nzima "
-"ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe ifonti "
-"encinci."
-msgstr[1] ""
-"Ifonti ekhethiweyo ingamachaphaza %d ubukhulu, yaye inokwenza ukuba kube "
-"nzima ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe ifonti "
-"encinci."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "Isikhawulezisi esitsha..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Iqhosha lokubalekisa"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Amaqhosha azizilungisi zokubalekisa"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Ibhodi yamaqhosha okubalekisa"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Inkqubo i-Accel"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Uhlobo lwesibalekisi."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:197
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
-msgid "Disabled"
-msgstr "Ukhubazekile"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:545
-msgid "<Unknown Action>"
-msgstr "<Isenzo esingaziwayo>"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:566
-msgid "Desktop"
-msgstr "I-desktop"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:567
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
-msgstr "Isandi"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:571
-msgid "Window Management"
-msgstr "Ulawulo lwefestile"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:668
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
-msgstr ""
-"Indlela enqumlayo i- \"%s\" seyisetyenziselwe i-:\n"
-" \"%s\"\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:700
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr ""
-"Impazamo imisela isinqumlisi esitsha kwi-database yomiselo lwenkqubo "
-"yekhompyutha: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:750
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr ""
-"Impazamo iyeka ukumisela isinqumlisi kwi-database yomiselo lwenkqubo "
-"yekhompyutha: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:857
-msgid "Action"
-msgstr "Isenzo"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:881
-msgid "Shortcut"
+msgctxt "slow keys delay"
+msgid "Short"
 msgstr "Indlela enqumlayo"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
-msgstr "Iindlela eziNqumlayo ze-Keyboard"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
 msgstr ""
-"Ukuhlela iqhosha lendlela enqumlayo, cofa kumgca ohambelanayo uze uchwetheze "
-"isinqumlisi esitsha, okanye cinezela isithuba esiya emva ukucima."
 
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Nikela amaqhosha endlela enqumlayo kwimiyalelo"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
-msgid "Unknown"
-msgstr "Ayaziwa"
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr ""
+"Yenza isandi esifutshane esiphindaphindayo xa _iqhosha elisisilungisi "
+"licinezelwe"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Yenza isandi esifutshane esiphindaphindayo xa iqhosha li:"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Yenza isandi esifutshane esiphindaphindayo ukuba iqhosha la_liwe"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Amaqhosha emawusi"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Suku_hoya ukucofwa kwamaqhosha okuphindiweyo ngaphakathi:"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Indlela enqumlayo"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Ukufumaneka"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "_Nkulu"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "_Okufunda iskrini"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "I_zandi:"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "UbuNgakanani beKhesa"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "_I-keyboard ekwiskrini"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Amaqhosha okuPhinda</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Ikhesa iyaDanyaza</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Amaqhosha emawusi"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "<b>Fumana iSalathisi</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<b>Ukuphela kweXesha lokuCofa-Kabini </b>"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Danyazisa iskrini _sonke"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Danyazisa iskrini _sonke"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Zalisa iSkrini"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Ekunokukhethwa kuko"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_Isandisi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "_Isandisi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "_Okufunda iskrini"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "_Isandisi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Ukukhanya makunyuswe"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "_Nxibelelana"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Ayikho"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Zele"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "I-Password eNtsha:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Khetha iFayili yeSandi"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "UMlawuli weFestile"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Ayikho"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "Okuqale kubonakaliswe:"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "Tshintsha i-Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Utshintsho lommiselo"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Tshintsha i-Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "I-Password eNtsha:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Tshintsha i-Password"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "I-Password eNtsha:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_Hlela"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Izilawuli"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
+msgstr "Imisela ifonti yenkqubo emiselweyo"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "Ezinye"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr ""
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Amaqhosha"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Amaqhosha"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Amaqhosha"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Amaqhosha"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
 msgid "Layout"
 msgstr "Ubume"
 
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
-msgid "Default"
-msgstr "Esilelayo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
-msgid "Models"
-msgstr "Iimodeli"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:106
-#, c-format
-msgid "There was an error launching the keyboard capplet : %s"
-msgstr "Bekukho impazamo ekundululeni i-capplet ye-keyboard : %s"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
-msgstr "_Ukufumaneka"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:240
-#: ../capplets/sound/sound-properties-capplet.c:242
-msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
 msgstr ""
-"Faka nje kuphela imimiselo uze uphume (ukungqinelana kuphela; ngoku "
-"kuphethwe yi-daemon)"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
-msgstr "Qalisa iphepha ngemimiselo yohlulo lokuchwetheza ebonakalayo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "..."
-msgstr "..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>Ikhesa iyaDanyaza</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Amaqhosha okuPhinda</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<b>_Tshixa iskrini ukunyanzela ulwahlulo lokuchwetheza</b>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Khawulezayo</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Nde</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Mfutshane</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Cothayo</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_vailable layouts:"
-msgstr "Ubume obu_khoyo:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "All_ow postponing of breaks"
-msgstr "Vume_la ukumisela elinye ixesha ulwahlulo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Jonga ukuba ulwahlulo luvumelekile na ukuba limiselwe elinye ixesha"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
-msgid "Choose A Keyboard Model"
-msgstr "Khetha iModeli ye-Keyboard"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-msgid "Choose A Layout"
-msgstr "Khetha uBume"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
-msgstr "Ikhesa _iyadanyaza kwiibhokisi zombhalo nakwiindawo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Duration of the break when typing is disallowed"
-msgstr "Ixesha lolwahlulo xa ukuchwetheza kungavumelekanga"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of work before forcing a break"
-msgstr "Ixesha lomsebenzi phambi kokunyanzela ulwahlulo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Key presses _repeat when key is held down"
-msgstr "Iqhosha licinezela _u-phinda xa iqhosha licinezelwe"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Keyboard Preferences"
-msgstr "Uluhlu lokukhetha lwe-Keyboard"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Keyboard _model:"
-msgstr "I_modeli ye-keyboard:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Layout Options"
-msgstr "Iindlela zokukhetha zobume"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Layouts"
-msgstr "Ubume"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
-msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
 msgstr ""
-"Tshixa iskrini emva kwexesha elithile ukunceda ukunqanda iingozi "
-"zokusetyenziswa kwe-keyboard"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Microsoft Natural Keyboard"
-msgstr "I-Microsoft Natural Keyboard"
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-msgid "Preview:"
-msgstr "Okuqale kubonakaliswe:"
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-msgid "Reset To De_faults"
-msgstr "Misela kwakhona Kokumi_selweyo"
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Separate _group for each window"
-msgstr "_Iqela elohlukeneyo ngefestile nganye"
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Typing Break"
-msgstr "Unqanyulo lokuChwetheza"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "_Accessibility..."
-msgstr "_Ukufikelela..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
-msgid "_Add..."
-msgstr "_Yongeza..."
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Break interval lasts:"
-msgstr "_Ithuba lokuhlala liyahlala:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Delay:"
-msgstr "_Libazisa:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
-msgid "_Models:"
-msgstr "Ii_modeli:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Selected layouts:"
-msgstr "_Ubume obukhethiweyo:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Speed:"
-msgstr "I_santya:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Work interval lasts:"
-msgstr "_Isithuba sokusebenza siyahlala:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "minutes"
-msgstr "imizuzu"
-
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Misela uluhlu lokukhetha lwe-keyboard"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:559
-msgid "Unknown Cursor"
-msgstr "IKhesa eNgaziwayo"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:761
-msgid "Default Cursor"
-msgstr "IKhesa eMiselweyo"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Cursor - Current"
-msgstr "IKhesa eMiselweyo - Ngoku"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-msgid "The default cursor that ships with X"
-msgstr "Ikhesa emiselweyo ethumela kunye no-X"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-msgid "White Cursor"
-msgstr "IKhesa eMhlophe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Cursor - Current"
-msgstr "IKhesa eMhlophe - Ngoku"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-msgid "The default cursor inverted"
-msgstr "Ikhesa emiselweyo igqwethiwe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-msgid "Large Cursor"
-msgstr "IKhesa eNkulu"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Cursor - Current"
-msgstr "IKhesa eNkulu - Ngoku"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-msgid "Large version of normal cursor"
-msgstr "Uhlobo olukhulu lwekhesa eqhelekileyo"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-msgid "Large White Cursor - Current"
-msgstr "IKhesa eNkulu eMhlophe - Ngoku"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Cursor"
-msgstr "IKhesa eNkulu eMhlophe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-msgid "Large version of white cursor"
-msgstr "Uhlobo olukhulu lwekhesa emhlophe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:975
-msgid "Cursor Theme"
-msgstr "UMxholo weKhesa"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr "<b>Ukuphela kweXesha lokuCofa-Kabini </b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Tsala uze uFake</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Fumana iSalathisi</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>UQhelaniso lweMawusi</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Speed</b>"
-msgstr "<b>Isantya</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>Khawulezayo</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>Phezulu</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>Nkulu</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>Phantsi</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>Cothayo</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>Ncinci</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Amaqhosha"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#: panels/windows/cc-windows-panel.ui:75
 #, fuzzy
-msgid "Cursor Size:"
-msgstr "UbuNgakanani beKhesa"
+msgid "Center New Windows"
+msgstr "Ibekwe embindini"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Cursors"
-msgstr "Iikhesa"
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr "Qaqambisa _isalathisi xa ucinezela u-Ctrl"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+#: panels/windows/cc-windows-panel.ui:89
 #, fuzzy
-msgid "Large"
-msgstr "_Nkulu"
+msgid "Windows Focus"
+msgstr "U-Windows"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-#, fuzzy
-msgid "Medium"
-msgstr "_Phakathi"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Motion"
-msgstr "Intshukumo"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Mouse Preferences"
-msgstr "ULuhlu lokuKhetha lweMawusi"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
-#, fuzzy
-msgid "Small"
-msgstr "_Ncinci"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
-msgstr "_Ukhawuleziso:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
-msgstr "_Imawusi elinxele"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr "_Uvakalelo:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr "_Umda:"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
-msgstr "_Ukuphela kwexesha:"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Imawusi"
-
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Misela uluhlu lwakho lokukhetha lwemawusi"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
-
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
-msgid "Set your network proxy preferences"
-msgstr ""
-"Misela uluhlu lokukhetha lonxibelelwano lwekhompyutha esbenza njengomqobo"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-#, fuzzy
-msgid "<b>D_irect internet connection</b>"
-msgstr "<b>_Unxulumano lwe-intanethi oluthe gqo</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-#, fuzzy
-msgid "<b>Ignore Host List</b>"
-msgstr "<b>Sukuluhoya uluhlu lwabaququzeleli</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr ""
-"<b>Ukumiselwa kwenkqubo kwikhompyutha esebenza njengomqobo _ezenzekelayo</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr ""
-"<b>_Ukumiselwa kwenkqubo yoxwebhu kwikhompyutha esebenza njengomqobo</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Sebenzisa uqinisekiso</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-msgid "Advanced Configuration"
-msgstr "Ukumiselwa kwenkqubo yekhompyutha okunkqenkqeza phambili"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr "I-Autoconfiguration _URL:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "Iinkcukacha zeKhompyutha esebenza njengomqobo ye-HTTP"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "Ikhompyutha esebenza njengomqobo eyi-H_TTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-msgid "Network Proxy Preferences"
-msgstr "Uluhlu lokukhetha loThungelwano lweKhompyutha esebenza njengomqobo"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Isiqhakamsheli:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-msgid "Proxy Configuration"
-msgstr "UkuMiselwa kwenkqubo kwiKhompyutha esbenza njengomqobo"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr "Umququzeleli we-S_ocks:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "U_sername:"
-msgstr "I_gama lomsebenzisi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_Iinkcukacha"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr "Ikhompyutha esebenza njengomqobo i-_FTP:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "I-_Password:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr "_Qinisekisa ikhompyutha esebenza njengomqobo i-HTTP:"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Yenza ukuba kusebenze isandi nezandi ezinxulumeneyo kunye nezehlo"
-
-#: ../capplets/sound/sound-properties-capplet.c:271
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Sound Preferences"
-msgstr "Uluhlu lwezinto ekukhethwa kuzo lwesandi"
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "E_nable sound server startup"
-msgstr "Y_enza ukuba ukuvula kwesandi seseva kusebenze"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "Flash _entire screen"
-msgstr "Danyazisa iskrini _sonke"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "Flash _window titlebar"
-msgstr "Danyazisa _ifestile ye-titlebar"
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "General"
-msgstr "Jikelele"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "Sound Events"
-msgstr "Izehlo zesandi"
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "System Bell"
-msgstr "INtsimbi yeNkqubo"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "_Sound an audible bell"
-msgstr "_Betha intsimbi evakalayo"
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "_Sounds for events"
-msgstr "_Izandi zezehlo"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "_Visual feedback:"
-msgstr "Impendulo_ebonakalayo:"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:347
-msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
-msgstr ""
-"Akukho mixholo ifumanekileyo kwinkqubo yakho.  Oku mhlawumbi kuthetha ukuba "
-"unxibelelwano lwakho i-\"Theme Preferences\" ayisekwanga kakuhle, okanye "
-"awuwusekanga umqulu wenkqubo we-\"gnome-themes\"."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:227
-msgid "This theme is not in a supported format."
-msgstr "Lo mxholo awukho kulungiselelo oluxhasiweyo."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:244
-msgid "Failed to create temporary directory"
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:264
-msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:282
-#: ../capplets/theme-switcher/gnome-theme-installer.c:319
-#: ../capplets/theme-switcher/gnome-theme-installer.c:399
-#, fuzzy
-msgid "Installation Failed"
-msgstr "Ukusekwa komxholo"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:302
-msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
 msgstr ""
 
-#: ../capplets/theme-switcher/gnome-theme-installer.c:340
-#, c-format
-msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:343
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:346
-#, c-format
-msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:349
-#, c-format
-msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:357
-msgid "The theme is an engine. You need to compile the theme."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:374
-#, fuzzy
-msgid "The file format is invalid"
-msgstr "I-password efakiweyo ayilunganga"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:468
-msgid "No theme file location specified to install"
-msgstr "Akukho ndawo yomxholo wefayili ichaziweyo ukuba isekwe"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:485
-msgid "The theme file location specified to install is invalid"
-msgstr "Indawo yomxholo wefayili echaziweyo ukuba isekwe ayilunganga"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:505
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-"Iimvume ezingonelanga ukuseka imixholo ku:\n"
-"%s"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:526
-#, fuzzy
-msgid "The file format is invalid."
-msgstr "I-password efakiweyo ayilunganga"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:553
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-"I-%s yindlela apho iifayili zemixholo ziza kusekwa khona. Oku akunakukhethwa "
-"njengendawo yomthombo"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:607
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "Custom theme"
-msgstr "Umxholo ozenzelayo"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr "Ungawugcina lo mxholo ngokucinezela iqhosha lokuGcina umXholo."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr ""
-"Iinkcazelo zomxholo ezimiselweyo azifumanekanga kwinkqubo yakho. Oku "
-"kuthetha ukuba awunayo i-metacity esekiweyo, okanye i-gconf yakho imiselwe "
-"ngokungalunganga."
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:72
-msgid "Theme name must be present"
-msgstr "Igama lomxholo malibekhona"
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:104
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Umxholo sowukhona. Ungathanda ukubeka omnye endaweni yawo?"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr "Khetha imixholo yeendawo ngeendawo ze-desktop"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "Umxholo"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Seka umxholo</span>"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:3
-msgid "Theme Installation"
-msgstr "Ukusekwa komxholo"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:4
-msgid "_Install"
-msgstr "_Faka"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:5
-msgid "_Location:"
-msgstr "_Indawo:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Gcina umXholo kwiDiski</span>"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Apply _Background"
-msgstr "Faka _Okungasemva"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Apply _Font"
-msgstr "Faka i_Fonti"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Controls"
-msgstr "Izilawuli"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "Icons"
-msgstr "Imifanekiso"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "New themes can also be installed by dragging them into the window."
-msgstr "Imixholo emitsha ikwanokusekwa ngokuyitsalela kwifestile."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-msgid "Save Theme"
-msgstr "Gcina umxholo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-msgid "Select theme for the desktop"
-msgstr "Khetha umxholo we-desktop"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-msgid "Short _description:"
-msgstr "Inkcazelo _emfutshane:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "Theme Details"
-msgstr "IiNkcukacha zomXholo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "Theme Preferences"
-msgstr "Uluhlu lokukhetha lwemixholo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-msgid "Theme _Details"
-msgstr "_Iinkcukacha zoMxholo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-msgid "This theme does not suggest any particular font or background."
-msgstr "Lo mxholo awucebisi nayiphina ifonti ethile okanye okungasemva."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-msgid "This theme suggests a background:"
-msgstr "Lo mxholo ucebisa okungasemva:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-msgid "This theme suggests a font and a background:"
-msgstr "Lo mxholo ucebisa ifonti nokungasemva:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-msgid "This theme suggests a font:"
-msgstr "Lo mxholo ucebisa ifonti:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "Window Border"
-msgstr "UMqukumbelo weFestile"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-msgid "_Go To Theme Folder"
-msgstr "_Yiya kwisiQulathi soMxholo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-msgid "_Install Theme..."
-msgstr "_Seka uMxholo..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-msgid "_Revert"
-msgstr "_Buyela"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-msgid "_Save Theme..."
-msgstr "_Gcina uMxholo..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-msgid "_Theme name:"
-msgstr "_Igama lomxholo:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:24
-msgid "theme selection tree"
-msgstr "ukhetho lomxholo ngokwemo-mthi"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
-msgstr "Zenzele inkangeleko ye-toolbars namaqhosha emenyu kwiinkqubo"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "IiMenyu & ne-Toolbars"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
-msgstr "<b>Isimbo kunye neNkangeleko</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-msgid "<b>Preview</b>"
-msgstr "<b>Ukubonakalisa kuqala</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "Si_ka"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-msgid "Icons only"
-msgstr "Imifanekiso engumqondiso kuphela"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "Uluhlu lwezinto ekukhethwa kuzo lweMenyu ne-Toolbar"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "IFayili eNtsha"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Vula iFayili"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Gcina iFayili"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr "Bonisa _imifanekiso kwiimenyu"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-msgid "Text below icons"
-msgstr "Umbhalo ongaphantsi kwemifanekiso"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-msgid "Text beside icons"
-msgstr "Umbhalo osecaleni kwemifanekiso"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-msgid "Text only"
-msgstr "Umbhalo kuphela"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
-#, fuzzy
-msgid "Toolbar _button labels:"
-msgstr "Iilebhile zeqhosha le_Toolbar: "
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_Kopa"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
-msgstr "I-toolbars _ezisukayo"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
-msgstr "_Hlela"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
-msgstr "_Izinqumlisi zemenyu ezihlelekayo"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "i_Fayili"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_Entsha"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
-msgstr "_Vula"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "_Ncamathisela"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "_Shicilela"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "_Phuma"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "_Gcina"
-
-#: ../capplets/windows/gnome-window-properties.c:386
-#, c-format
-msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
-msgstr ""
-"<b>Ayinakuqalisa inkqubo yoluhlu lokukhetha lomlawuli wefestile wakho</b>\n"
-"\n"
-"%s"
-
-#: ../capplets/windows/gnome-window-properties.c:644
-msgid "Control"
-msgstr "Lawula"
-
-#: ../capplets/windows/gnome-window-properties.c:649
-msgid "Alt"
-msgstr "Tshintshanisa"
-
-#: ../capplets/windows/gnome-window-properties.c:655
-msgid "Hyper"
-msgstr "I-Hyper"
-
-#: ../capplets/windows/gnome-window-properties.c:662
-msgid "Super (or \"Windows logo\")"
-msgstr "Ngaphezulu kombhalo (okanye \"ilogo ka-Windows\")"
-
-#: ../capplets/windows/gnome-window-properties.c:669
-msgid "Meta"
-msgstr "I-Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Iqhosha leNtshukumo</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>ISenzo se-Titlebar</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Ukukhethwa kweFestile</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To _move a window, press-and-hold this key then grab the window:"
-msgstr ""
-"Uku _hambisa ifestile, cinezela-uze-ubambe eliqhosha uze uthathe ugcine "
-"ifestile:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "ULuhlu lokukhetha lweeFestile"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_Cofa-kabini i-titlebar ukwenza esi senzo:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "_Isithuba phambi kokunyusa:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_Nyusa iifestile ezikhethiweyo emva kwesithuba"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Khetha iifestile xa imawusi ishukuma phezu kwazo"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-msgid "Set your window properties"
-msgstr "Misela iimpawu zefestile yakho"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
 msgid "Windows"
 msgstr "U-Windows"
 
-#: ../control-center/control-center-categories.c:257
-msgid "Others"
-msgstr "Ezinye"
-
-#: ../control-center/control-center.c:42
-msgid "Desktop Preferences"
-msgstr "ULuhlu lokukhetha lwe-Desktop"
-
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr "ULungelelaniso ngasembindini lwe-GNOME"
-
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "Isixhobo sokumiselwa kwe-GNOME"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "Isandi"
-
-#: ../gnome-settings-daemon/factory.c:36
-msgid "Could not initialize Bonobo"
-msgstr "Ayikwazanga ukuqalisa ukwaba amaxabiso eenkcukacha ze-Bonobo"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
-msgid "Slow Keys Alert"
-msgstr "IsiLumkiso samaQhosha aCothayo"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
 msgstr ""
-"Ucinezele iqhosha u-Shift imizuzu eyi-8. Le yindlela enqumlayo yophawu "
-"lwamaQhosha aCothayo, echaphazela indlela esebenza ngayo i-keyboard yakho."
 
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
-msgid "Do you want to activate Slow Keys?"
-msgstr "Uyafuna ukwenza amaQhosha aCothayo ukuba asebenze?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
-msgid "Do you want to deactivate Slow Keys?"
-msgstr "Uyafuna ukwenza ukuba amaQhosha aCothayo angasebenzi?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Sticky Keys Alert"
-msgstr "IsiLumkiso samaQhosha aNcamathelayo"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
 msgstr ""
-"Uvele wacinezela iqhosha i-Shift ka-5 kuluhlu. Le yindlela enqumlayo yophawu "
-"lwamaQhosha aNcamathelayo, echaphazela indlela esebenza ngayo i-keyboard "
-"yakho."
 
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
 msgstr ""
-"Uvele wacinezela amaqhosha amabini kwakanye, okanye wacinezela iqhosha u-"
-"Shift ka-5 kuluhlu. Oku kuvala uphawu lwamaQhosha aNcamathelayo, "
-"okuchaphazela indlela esebenza ngayo i-keyboard yakho."
 
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
-msgid "Do you want to activate Sticky Keys?"
-msgstr "Ufuna ukuwenza asebenze amaQhosha aNcamathelayo?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr "Ufuna ukuwenza angasebenzi amaQhosha aNcamathelayo?"
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:107
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-"Akukwazeki ukwenza uvimba weefayili \"%s\".\n"
-"Oku kuyafuneka ukuvumela ukutshintsha iikhesa."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr ""
-"IKhowudi exhomekekileyo yeQhosa (%s) inesenzo sayo esichazwe amaxesha "
-"amaninzi\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr ""
-"IKhowudi exhomekekileyo yeQhosha(%s) inekhowudi exhomekekileyo echazwe "
-"amaxesha amaninzi\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr "IKhowudi exhomekekileyo yeQhosha (%s) ayiphelelanga\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr "IKhowudi exhomekekileyo yeQhosha (%s) ayiphelelanga\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
-#, c-format
-msgid "It seems that another application already has access to key '%d'."
-msgstr "Kubonakala ngathi enye inkqubo sele inokufukelela kwiqhosha '%d'."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr "IKhowudi exhomekekileyo yeQhosha (%s) sele isetyenziswa\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-"Impazamo xa bekuzanywa ukusebenzisa i- (%s)\n"
-"edityaniswe kwiqhosha (%s)"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
-#, fuzzy, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-"Impazamo ekwenzeni ukuba ukumiselwa kwenkqubo i-XKB kusebenze.\n"
-"Phantsi kweemeko ezininzi inokuba :\n"
-"- nesiphene kwi-libxklavier library\n"
-"- nesiphene kwi-X server (xkbcomp, xmodmap utilities)\n"
-"- I-X server enokwenziwa kwe-libxkbfile okungangqinelaniyo\n"
-"\n"
-"I-data yohlobo lwe-X server :\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"Ukuba uchaza le meko njengesiphene, nceda uquke:\n"
-"- Isiphumo se-<b>xprop -root | grep XKB</b>\n"
-"- Isiphumo se <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/kbd</b>"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
 #, fuzzy
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-"Usebenzisa i-XFree 4.3.0.\n"
-"Kukhona iingxaki ezaziwayo ngokumiselwa kwe-XKB okunabileyo.\n"
-"Zama ukusebenzisa ukumiselwa kwenkqubo okulula okanye uthathe uhlobo olutsha "
-"lobucukubhede be-XFree."
+msgid "Add"
+msgstr "Yongeza..."
 
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Gcina"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
 #, fuzzy
-msgid "Do _not show this warning again"
-msgstr "_Ungaphinde uwubonise lo myalezo kwakhona"
+msgid "Modem Details"
+msgstr "IiNkcukacha zomXholo"
 
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
-msgid ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
 msgstr ""
-"Imimiselo yesixokelelwano u-X se-keyboard siyohluka kwimimiselo ye-keyboard "
-"ye-GNOME ekhoyo. Ngowuphi ummiselo ongathanda ukuwusebenzisa?"
 
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
-msgid "Use X settings"
-msgstr "Sebenzisa imimiselo u-X"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
-msgid "Use GNOME settings"
-msgstr "Sebenzisa imimiselo ye-GNOME"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
 msgstr ""
-"Akukwazekanga ukwenza umyalelo: %s\n"
-"Qinisekisa ukuba lo myalelo ukhona."
 
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-"Akukwazekanga ukubeka umatshini kwimo yokulala.\n"
-"Qinisekisa ukuba imatshini imiselwe kakuhle."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
-#, c-format
-msgid "Permissions on the file %s are broken\n"
-msgstr "Iimvume kwifayilii %s azilandelwanga\n"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-"Akukwazekanga ukufaka ifayili i-Glade.\n"
-"Qinisekisa ukuba le daemon isekwe kakuhle."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-"Kubekho impazamo ukuqalisa i-screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Ukusebenza kwe-Screensaver akuzukusebenza kule seshoni."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
-msgid "_Do not show this message again"
-msgstr "_Ungaphinde uwubonise lo myalezo kwakhona"
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:129
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr "Akukwazekanga ukufaka ifayili yesandi %s njengesampuli %s"
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
-msgid "Cannot determine user's home directory"
-msgstr "Akukwazeki ukumisa uvimba weefayili wasekhaya womsebenzisi"
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr ""
-"Iqhosha le-GConf %s limiselwe ukuba lichwetheze %s kodwa umchwethezo walo "
-"olindelekileyo ibingu %s\n"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+#: panels/wwan/cc-wwan-details-dialog.ui:49
 #, fuzzy
-msgid "A_vailable files:"
-msgstr "Ubume obu_khoyo:"
+msgid "Network Type"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
 
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
 #, fuzzy
-msgid "Do _not show this warning again."
-msgstr "_Ungaphinde uwubonise lo myalezo kwakhona"
+msgid "Device Details"
+msgstr "IiNkcukacha zomXholo"
 
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
 msgstr ""
 
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
 msgstr ""
 
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
 msgstr ""
 
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
 #, fuzzy
-msgid "_Loaded files:"
-msgstr "Ii_modeli:"
+msgid "_Mobile Data"
+msgstr "_Ephathwayo:"
 
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr "Impazamo edala umqondiso wombhobho wothungelwano."
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
 
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "Uhlobo"
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
 
-#: ../libbackground/applier.c:256
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "IiNkcukacha zomXholo"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Yenza ukuba amaQhosha e-Toggle ase_benze"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Iyahlangana..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Utshintsho lommiselo"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Imimiselo emiselweyo"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
 msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
 msgstr ""
-"Uhlobo lwe-bg_applier: i-BG_APPLIER_ROOT yefestile yomsebenzi onikwe amandla "
-"akhethekileyo okanye i-BG_APPLIER_PREVIEW yokubonakalayo kuqala"
 
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr "Ububanzi obubonakalisa kuqala"
-
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
+#: shell/cc-window.ui:164
+msgid "Help"
 msgstr ""
-"Ububanzi ukuba isifaki sesokubonakalisa kuqala: Ezimiselweyo ukuya ku 64."
 
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr "Ubude bokuBonakalisa kuqala"
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Jikelele"
 
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr "Ubude ukuba isifaki sesokubonakalisa kuqala: Ezimiselweyo ukuya ku 48."
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Phuma"
 
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Iskrini"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr "Iskrini apho i-BGApplier iza kuzoba khona"
-
-#: ../libgswitchit/gswitchit_config.c:1035
-#, fuzzy, c-format
-msgid "There was an error loading an image: %s"
-msgstr "Kubekho impazamo ekuvezeni uncedo: %s"
-
-#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
-msgid "The sound file for this event does not exist."
-msgstr "Ifayili yesandi yesi sehlo ayikho."
-
-#: ../libsounds/sound-view.c:149
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package\n"
-"for a set of default sounds."
-msgstr ""
-"Ifayili yesandi yesi sehlo ayikho.\n"
-"Unokufuna ukuseka umqulu onesandi we-gnome\n"
-"womiselo wezandi ezimiselweyo."
-
-#: ../libsounds/sound-view.c:224
-#, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "Ifayili %s asiyofayili i-wav elungileyo"
-
-#: ../libsounds/sound-view.c:289
-msgid "Event"
-msgstr "Isehlo"
-
-#: ../libsounds/sound-view.c:298
-msgid "Sound File"
-msgstr "IFayili yeSandi"
-
-#: ../libsounds/sound-view.c:314
-msgid "_Sounds:"
-msgstr "I_zandi:"
-
-#: ../libsounds/sound-view.c:328
-msgid "Sound _file:"
-msgstr "i_Fayili yesandi:"
-
-#: ../libsounds/sound-view.c:332
-msgid "Select Sound File"
-msgstr "Khetha iFayili yeSandi"
-
-#: ../libsounds/sound-view.c:356
-msgid "_Play"
-msgstr "_Dlala"
-
-#: ../libsounds/sound-view.c:366
-msgid "_Remove"
-msgstr "_Susa"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr ""
-"Umlawuli wefestile \"%s\" akasifakanga isixhobo sokumiselwa kwenkqubo\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Yenza ibe nkulu"
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Ukusonga"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr ""
-"Ukuba kuyinyani, izibambi ze-mime text/plain kunye text/* ziza kugcinwa kwi-"
-"sync"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr "Umbhalo owenzeka text/plain kunye text/* izibambi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "Brightness down"
-msgstr "Ukukhanya makuthotywe"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "Brightness down's shortcut."
-msgstr "Indlela enqumlayo yokuthotywa kokukhanya."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Brightness up"
-msgstr "Ukukhanya makunyuswe"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Brightness up's shortcut."
-msgstr "Indlela enqumlayo yokunyuswa kokukhanya."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "E-mail"
-msgstr "I-imeyili"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "E-mail's shortcut."
-msgstr "Indlela enqumlayo ye-imeyili."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Eject"
-msgstr "Khupha"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-msgid "Eject's shortcut."
-msgstr "Indlela enqumlayo yokukhupha."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-msgid "Home folder"
-msgstr "Isiqulathi seefayili sasekhaya"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-msgid "Home folder's shortcut."
-msgstr "Indlela enqumlayo yesiqulathi seefayili zasekhaya."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-msgid "Launch help browser"
-msgstr "Isikhangeli soncedo sokundulula"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-msgid "Launch help browser's shortcut."
-msgstr "Indlela enqumlayo yesikhangeli soncedo sokundulula."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-msgid "Launch web browser"
-msgstr "Isikhangeli sewebhu sokundulula"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-msgid "Launch web browser's shortcut."
-msgstr "Indlela enqumlayo yesikhangeli sewebhu sokundulula."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-msgid "Lock screen"
-msgstr "Tshixa iskrini"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-msgid "Lock screen's shortcut."
-msgstr "Indlela enqumlayo yokutshixa iskrini."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-msgid "Log out"
-msgstr "Phuma"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-msgid "Log out's shortcut."
-msgstr "Indlela enqumlayo yokuphuma."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Next track key's shortcut."
-msgstr "Indlela enqumlayo yeqhosha lomzila elandelayo."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Pause"
-msgstr "Nqumama"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-msgid "Pause key's shortcut."
-msgstr "Indlela enqumlayo yeqhosha lokunqumama."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Play (or play/pause)"
-msgstr "Dlala (okanye dlala/nqumama)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Play (or play/pause) key's shortcut."
-msgstr "Indlela enqumlayo yeqhosha u-Dlala (okanye dlala/nqumama)."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Previous track key's shortcut."
-msgstr "Indlela enqumlayo yamaqhosha omzila angaphambili."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
 msgid "Search"
 msgstr "Khangela"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-msgid "Search's shortcut."
-msgstr "Indlela enqumlayo yokukhangela."
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Skip to next track"
-msgstr "Tsibela kwingoma elandelayo"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Skip to previous track"
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
 msgstr "Tsibela kwingoma yangaphambili"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-msgid "Sleep"
-msgstr "Lala"
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-msgid "Sleep's shortcut."
-msgstr "Indlela enqumlayo yokulala."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Stop playback key"
-msgstr "Iqhosha lokumisa ukudlala okungasemva"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Stop playback key's shortcut."
-msgstr "Indlela enqumlayo yeqhosha lokumisa ukudlala."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
-msgid "Volume down"
-msgstr "Isandi masithotywe"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume down's shortcut."
-msgstr "Indlela enqumlayo yokuthotywa kwesandi."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-msgid "Volume mute"
-msgstr "Ukuthula kwesandi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume mute's shortcut"
-msgstr "Indlela enqumlayo yokuthula kwesandi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
-msgid "Volume step"
-msgstr "Inqanaba lesandi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-msgid "Volume step as percentage of volume."
-msgstr "Inqanaba lesandi njengepesenti yesandi."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
-msgid "Volume up"
-msgstr "Nyusa isandi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
-msgid "Volume up's shortcut."
-msgstr "Indlela enqumlayo yokunyuswa kwesandi."
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+#: shell/org.gnome.Settings.desktop.in.in:17
 #, fuzzy
-msgid "Display a dialog when there are errors running the screensaver"
-msgstr "Bonisa unxibelelwano xa kukho iimpazamo ezenzekayo kwi-XSscreenSaver"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
-#, fuzzy
-msgid "Run screensaver at login"
-msgstr "Yenza i-XScreenSaver ku-ngena"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
-msgstr "Bonisa iiMpazamo zokuVula"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
-#, fuzzy
-msgid "Start screensaver"
-msgstr "Qalisa i-XScreenSaver"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
-msgstr ""
-"Ingqokelela yamaxwebhu emawasetyenzwe naninina isimo se-keyboard sifakiwe "
-"kwakhona. Iluncedo ukufaka kwakhona ulungelelwaniso olusekelwe kwi-xmodmap"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
-msgstr "Iqela elimiselweyo, elabelwe kuyilo lwefestile"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr "Gcina uze ulawule iqela elahlukeneyo ngefestile nganye"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
-msgid "Keyboard Update Handlers"
-msgstr "IziBambi zokuHlaziya i-Keyboard"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
-msgid "Keyboard layout"
-msgstr "Ubume be-keyboard"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
-msgid "Keyboard model"
-msgstr "Imodeli ye-keyboard"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
-msgid "Keyboard options"
-msgstr "Ekunokukhethwa kuko kwe-keyboard"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
-#, fuzzy
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
-msgstr ""
-"Imimiselo ye-keyboard ku-gconf ayizukunanzwa kwinkqubo NGOKUKHAWULEZILEYO"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
-msgstr "Gcina/gcina kwakhona izibonisi kunye namaqela obume"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
-msgstr "Bonisa amagama obume endaweni yamagama eqela"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
-msgstr ""
-"Bonisa amagama obume endaweni yamagama eqela (kuphela ngeentlobo zobume "
-"obunabileyo benkxaso i-XFree)"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
-msgid "keyboard layout"
-msgstr "ubume be-keyboard"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
-msgid "keyboard model"
-msgstr "imodeli ye-keyboard"
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "modmap file list"
-msgstr ""
-
-#: ../typing-break/drw-break-window.c:212
-msgid "_Postpone break"
-msgstr "_Nqumamisa isithuba"
-
-#: ../typing-break/drw-break-window.c:259
-msgid "Take a break!"
-msgstr "Thatha isithuba!"
-
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:141
-msgid "/_Preferences"
+msgid "Preferences;Settings;"
 msgstr "/_Uluhlu lokukhetha"
 
-#: ../typing-break/drwright.c:142
-msgid "/_About"
-msgstr "/_Malunga"
-
-#: ../typing-break/drwright.c:144
-msgid "/_Take a Break"
-msgstr "/_Thatha isiThuba"
-
-#: ../typing-break/drwright.c:495
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "%d umzuzu kude kube sisithuba esilandelayo"
-msgstr[1] "%d imizuzu kude kube sisithuba esilandelayo"
-
-#: ../typing-break/drwright.c:499
-msgid "Less than one minute until the next break"
-msgstr "Ngaphantsi komzuzu omnye kude kube sisithuba esilandelayo"
-
-#: ../typing-break/drwright.c:587
-#, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
 msgstr ""
-"Akukwazeki ukuvela nonxibelelwano lweempawu zesithuba sokuchwetheza ngale "
-"mpazamo ilandelayo: %s"
 
-#: ../typing-break/drwright.c:635
-msgid "About GNOME Typing Monitor"
-msgstr "Malunga neMonitha yokuChwetheza ye-GNOME"
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
 
-#: ../typing-break/drwright.c:659
-msgid "A computer break reminder."
-msgstr "Isikhumbuzi sesithuba sekhompyutha."
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
 
-#: ../typing-break/drwright.c:660
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
-msgstr "Ibhalwe nguRichard Hult &lt;richard@imendio.com&gt;"
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
 
-#: ../typing-break/drwright.c:661
-msgid "Eye candy added by Anders Carlsson"
-msgstr "I-eye candy yongezwe ngu-Anders Carlsson"
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
 
-#: ../typing-break/drwright.c:837
-msgid "Break reminder"
-msgstr "Isikhumbuzi sesithuba"
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
 
-#: ../typing-break/main.c:93
-msgid "The typing monitor is already running."
-msgstr "Imonitha yokuchwetheza sele iqhubeka."
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../typing-break/main.c:106
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
 #, fuzzy
-msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
-msgstr ""
-"Imonitha yokuchwetheza isebenzisa indawo yokwazisa ukubonisa ulwazi. "
-"Awubonakali unendawo yokwazisa kwindawo yolawulo yakho. Ungayongeza "
-"ngokucofa ekunene kwemawusi kwindawo yolawulo yakho uze ukhethe 'Yongeza "
-"kwindawo yolawulo -> Indawo yamancedo -> Indawo yokwazisa'."
+#~ msgid "The type of alert"
+#~ msgstr "Uhlobo lwesibalekisi."
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
-msgstr "Ingcuka emdaka ekhawulezayo itsiba phezu kwenja eyonqenayo. 0123456789"
+#, fuzzy
+#~ msgid "Show more _details"
+#~ msgstr "_Iinkcukacha zoMxholo"
 
-#: ../vfs-methods/fontilus/font-view.c:276
-msgid "Name:"
-msgstr "Igama:"
+#~ msgid "About Me"
+#~ msgstr "Malunga Nam"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "Isimbo:"
+#~ msgid "No Image"
+#~ msgstr "Akukho Mfanekiso"
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "Uhlobo:"
+#, fuzzy, c-format
+#~ msgid "About %s"
+#~ msgstr "Malunga Nam"
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "Ubungakanani:"
+#, fuzzy
+#~ msgid "System error has occurred"
+#~ msgstr "Kwenzeke impazamo engalindelekanga"
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "Uhlobo:"
+#, fuzzy
+#~ msgid "Could not run /usr/bin/passwd"
+#~ msgstr "Akukwazekanga ukusebenzisa i-passwd"
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "Amalungelo omqulunqi:"
+#, fuzzy
+#~ msgid "Unexpected error has occurred"
+#~ msgstr "Kwenzeke impazamo engalindelekanga"
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "Inkcazelo:"
+#, fuzzy
+#~ msgid "Please type the passwords."
+#~ msgstr "Chwetheza kwakhona i-Password eNtsha:"
 
-#: ../vfs-methods/fontilus/font-view.c:408
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Ikhaya</b>"
+
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Umyalezo wesiquphe</b>"
+
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Umsebenzi</b>"
+
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Imfonomfono</b>"
+
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>I-Web</b>"
+
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Umsebenzi</b>"
+
+#~ msgid "A_IM/iChat:"
+#~ msgstr "I-A_IM/iChat:"
+
+#, fuzzy
+#~ msgid "A_ddress:"
+#~ msgstr "_Idilesi:"
+
+#~ msgid "A_ssistant:"
+#~ msgstr "Um_ncedisi:"
+
+#~ msgid "C_ity:"
+#~ msgstr "Isi_xeko:"
+
+#~ msgid "C_ompany:"
+#~ msgstr "Inka_mpani:"
+
+#, fuzzy
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Tshintsha i-Passwo_rd"
+
+#, fuzzy
+#~ msgid "Ci_ty:"
+#~ msgstr "Isi_xeko:"
+
+#~ msgid "Co_untry:"
+#~ msgstr "Ili_zwe:"
+
+#, fuzzy
+#~ msgid "Cou_ntry:"
+#~ msgstr "Ili_zwe:"
+
+#, fuzzy
+#~ msgid "Hom_e:"
+#~ msgstr "_Ikhaya:"
+
+#~ msgid "IC_Q:"
+#~ msgstr "I-IC_Q:"
+
+#~ msgid "M_SN:"
+#~ msgstr "I-M_SN:"
+
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "I-Password eNdala:"
+
+#, fuzzy
+#~ msgid "P.O. _box:"
+#~ msgstr "IBhokisi:"
+
+#, fuzzy
+#~ msgid "P._O. box:"
+#~ msgstr "IBhokisi:"
+
+#, fuzzy
+#~ msgid "Personal Info"
+#~ msgstr "_Iinkcukacha Zakho"
+
+#, fuzzy
+#~ msgid "State/Pro_vince:"
+#~ msgstr "_Ilizwe/Iphondo:"
+
+#, fuzzy
+#~ msgid "Web _log:"
+#~ msgstr "I-Web _Log:"
+
+#, fuzzy
+#~ msgid "Wor_k:"
+#~ msgstr "_Umsebenzi:"
+
+#, fuzzy
+#~ msgid "Work _fax:"
+#~ msgstr "IFeksi _yoMsebenzi:"
+
+#, fuzzy
+#~ msgid "Zip/_Postal code:"
+#~ msgstr "U-_zip/Ikhowudi yePosi:"
+
+#~ msgid "_Groupwise:"
+#~ msgstr "_Ngokweqela:"
+
+#, fuzzy
+#~ msgid "_Home page:"
+#~ msgstr "_Iphepha laseKhaya:"
+
+#~ msgid "_Home:"
+#~ msgstr "_Ikhaya:"
+
+#~ msgid "_Jabber:"
+#~ msgstr "I-_Jabber:"
+
+#~ msgid "_Manager:"
+#~ msgstr "_Umlawuli:"
+
+#~ msgid "_Profession:"
+#~ msgstr "_Ikhondo:"
+
+#~ msgid "_State/Province:"
+#~ msgstr "_Ilizwe/Iphondo:"
+
+#~ msgid "_Title:"
+#~ msgstr "_Isihloko:"
+
+#~ msgid "_Work:"
+#~ msgstr "_Umsebenzi:"
+
+#~ msgid "_Yahoo:"
+#~ msgstr "U-_Yahoo:"
+
+#, fuzzy
+#~ msgid "_Zip/Postal code:"
+#~ msgstr "U-_zip/Ikhowudi yePosi:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Inkxaso</b>"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>Qaphela:</b> Iinguqulelo kulo mmiselo azizukwenziwa de "
+#~ "ungene kwakhona.</i></small>"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Uluhlu lokukhetha lobuChwephesha oluNcedayo"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Vala _Uphume"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Qalisa obu buchwephesha buncedayo ngalo lonke ixesha ungena:"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Yenza ukuba ubuchwepheshe obuncedayo busebenze"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "INkxaso yobuChwepheshe eNcedayo"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr ""
+#~ "Yenza ukuba kusebenze inkxaso ukulungiselela ubuchwephesha boncedo be-"
+#~ "GNOME kungeno"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Akukho buChwephesha boNcedo bukhoyo kwinkqubo yakho. Umqulu wenkqubo "
+#~ "we'gok' kufuneka umiselwe ukuze kufikelelwe kwinkxaso ye-keyboard "
+#~ "ekwiskrin, yaye umpakisho we'gnopernicus' kufuneka umiselwe ufundo "
+#~ "lweskrini namandla okwazi ukwandisa."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Ayibubo bonke ubuchwepheshe obuncedayo obumiselweyo kwinkqubo yakho. "
+#~ "Umqulu wenkqubo ye-'gok' kufuneka imiselwe ukuze kufikeleleke kwinkxaso "
+#~ "ye-keyboard ekwiskrini."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+#~ msgstr ""
+#~ "Asibubo bonke ubuchwepheshe obuncedayo obusekiweyo kwinkqubo yakho. "
+#~ "Umqulu wenkqubo we-'gnopernicus' kufuneka usekiwe ukulungiselela ufundo "
+#~ "lweskrini namandla okwazi ukwandisa."
+
 #, c-format
-msgid "usage: %s fontfile\n"
-msgstr "ukusetyenziswa: %s i-fontfile\n"
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr ""
+#~ "Kubekho impazamo ekundululeni unxibelelwano loluhlu ekukhethwa kulo "
+#~ "lwemawusi: %s"
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
-msgstr "Misela njengeFonti yeNkqubo"
+#, c-format
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Akukwazeki ukudlulisa imimiselo ye-AccessX kwifayili '%s'"
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
-msgid "Sets the default application font"
-msgstr "Imisela ifonti yenkqubo emiselweyo"
+#~ msgid "Import Feature Settings File"
+#~ msgstr "IFayili yeMimiselo yoPhawu lokuNgenisa"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr ""
-"Ukuba imiselwe ku-inyani, ngako oko iifonti i-OpenType ziza kwenziwa "
-"zityhile ngokukhawulezayo."
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Misela uluhlu lokukhetha lwakho lokufikelela lwe-keyboard"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr ""
-"Ukuba imiselwe ku-inyani, ngako oko iifonti ze-PCF ziza kwenziwa zityhileke "
-"ngokukhawulezayo."
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Le nkqubo ayibonakalisi ukuba inesongezo i-XKB. Iimpawu ze-keyboard "
+#~ "zokufumaneka azizukusebenza ngaphandle kwayo."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr ""
-"Ukuba imiselwe ku-inyani, ngako oko iifonti i-TrueType ziza kwenziwa "
-"zityhileke ngokukhawuleza."
+#~ msgid "*"
+#~ msgstr "*"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr ""
-"Ukuba imiselwe ku-inyani, ngako oko iifonti i-Type1 ziza kwenziwa zityhileke "
-"ngokukhawuleza."
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>Yenza ukuba amaQhosha okuQa_katha asebenze</b>"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
-msgstr ""
-"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
-"kweefonti i-OpenType."
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>Yenza ukuba amaQhosha okuCo_thisa asebenze</b>"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr ""
-"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
-"kweefonti i-PCF."
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Yenza ukuba amaQhosha _Emawusi asebenze</b>"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr ""
-"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
-"kweefonti i-TrueType."
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>Yenza ukuba amaQhosha _Okuphinda asebenze</b>"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr ""
-"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
-"kweefonti i-Type1."
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>Yenza ukuba amaQhosha _Ancamathelayo asebenze</b>"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-OpenType"
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Iimpawu</b>"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-PCF"
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>AmaQhosha i-Toggle</b>"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-TrueType"
+#~ msgid "Basic"
+#~ msgstr "Esisiseko"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-Type1"
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr ""
+#~ "Yenza isandi esifutshane esiphindaphindayo xa _iimpawu zivuliwe okanye "
+#~ "zivaliwe kwi-keyboard"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "Noba kwenziwe ukutyhila okukhawulezayo kweefonti i-OpenType"
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr ""
+#~ "Yenza isandi esifutshane esiphindaphindayo xa iLED ivuliwe uze wenze "
+#~ "izandi ezibini ezifutshane xa ivaliwe."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "Noba kwenziwe ukutyhila okukhawulezayo kweefonti i-PCF"
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr "Ukulibazisa phakathi kocinezelo qhosha nentshu_kumo yesalathisi:"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "Noba kwenziwe ukutyhila okukhawulezileyo kweefonti i-TrueType"
+#~ msgid "Filters"
+#~ msgstr "Izihluzi"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "Noba kwenziwe ukutyhila okukhawulezayo kweefonti i-Type1"
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Sukuhoya konke ukucofa okulandelayo kweqhosha ELIFANAYO ukuba akwixesha "
+#~ "elikhethwe ngumsebenzisi."
 
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
-msgid "GNOME Font Viewer"
-msgstr "Isibonakalisi seFonti se-GNOME"
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Uluhlu lokukhetha lokufikelela lwe-Keyboard (AccessX)"
 
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
-msgstr "<span weight=\"bold\" size=\"larger\">Faka ifonti entsha?</span>"
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Isantya sesalathisi esisesona Siphe_zulu:"
 
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr "Unga _faki ifonti"
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "_Uluhlu lokukhetha lwemawusi..."
 
-#: ../vfs-methods/themus/apply-font.glade.h:4
-msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
-msgstr ""
-"Umxholo owukhethileyo ucebisa ifonti entsha. Ukubonakaliswa kuqala kwefonti "
-"kuboniswe ngezantsi."
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Yamkela amaqhosha kuphela emva kokuba ecinezelwe aze agcinwa ngexesha "
+#~ "lomsebenzisi elilungelelanisiweyo."
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-msgid "_Apply font"
-msgstr "_Faka ifonti"
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Yenza imisebenzi yokucinezela amaqhosha ngaxeshanye kaninzi ngokucinezela "
+#~ "amaqhosha azizilungisi ngokulandelelana."
 
-#: ../vfs-methods/themus/theme-method.c:520
-msgid "Themes"
-msgstr "Imixholo"
+#~ msgid "S_peed:"
+#~ msgstr "I_santya:"
 
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "Inkcazelo"
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Lixesha lokunqu_mla ngesantya esisesona siphezulu:"
 
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
-msgstr "Lawula umxholo"
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr "Guqulela i-keypad yamanani kwi-pad yolawulo lwemawusi."
 
-#: ../vfs-methods/themus/themus-properties-view.c:139
-msgid "Window border theme"
-msgstr "Umxholo womqukumbelo wefestile"
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Yenza ukuba ingasebenzi ukuba ayisetyenziswa:"
 
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
-msgstr "Umxholo womfanekiso"
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "_Yenza ukuba iimpawu zokufikelela ze-keyboard zingasebenzi"
 
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
-msgstr "ABCDEFG"
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Imimiselo yeeMpawu zokuDlulisa..."
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-msgid "Apply theme"
-msgstr "Faka umxholo"
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "_Yamkela kuphela amaqhosha abanjelwe i:"
 
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-msgid "Sets the default theme"
-msgstr "Imisela umxholo omiselweyo"
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Chwetheza ukuvavanya imimiselo:"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr ""
-"Ukuba imiselwe ku-inyani, ngako oko imixholo esekiweyo iza kwenziwa ityhilwe "
-"ngokukhawulezayo."
+#~ msgid "_accepted"
+#~ msgstr "_ivunyiwe"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr ""
-"Ukuba imiselwe ku-inyani, ngako oko imixholo iza kwenziwa ityhileke "
-"ngokukhawulezileyo."
+#~ msgid "_pressed"
+#~ msgstr "_icinezelwe"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:3
-msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
-msgstr ""
-"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo."
+#~ msgid "_rejected"
+#~ msgstr "_yaliwe"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
-msgstr ""
-"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
-"kwemixholo."
+#~ msgid "characters/second"
+#~ msgstr "iimpawu/umzuzwana"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr "Yenza ukutyhila okukhawulezayo komyalelo kwemixholo okusekiweyo"
+#~ msgid "milliseconds"
+#~ msgstr "i-mizuzwana yemizuzwana"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr "Ukutyhila okukhawulezayo kwemixholo"
+#~ msgid "pixels/second"
+#~ msgstr "i-pixels/umzuzwana"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr "Nokuba ngaba kwenziwe ukutyhila okukhawulezayo kwemixholo esekiweyo"
+#~ msgid "Desktop Background"
+#~ msgstr "OkungaSemva kwi-Desktop"
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr "Nokuba ngaba kwenziwe ukutyhila okukhawulezayo kwemixholo"
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>_Umhombiso we-Desktop</b>"
 
-msgid "Show help options"
-msgstr "Bonisa amancedo anokukhethwa"
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>Imibala ye-_Desktop</b>"
+
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Uluhlu lokukhetha lokungaSemva kwi-Desktop"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Faka umHombiso weskrini"
+
+#~ msgid "_Style:"
+#~ msgstr "I_simbo:"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Kubekho impazamo ekuvezeni uncedo: %s"
+
+#~ msgid "Tiled"
+#~ msgstr "Ifakwe iithayili"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "UkuThambeka okuNqamlezileyo"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "UkuThambeka okuthe Nkqo"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Hombisa iSkrini"
+
+#~ msgid "pixel"
+#~ msgid_plural "pixels"
+#~ msgstr[0] "i-pixel"
+#~ msgstr[1] "ii-pixels"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Akukwazeki ukuqalisa imimiselo yomlawuli i-'gnome-settings-daemon'.\n"
+#~ "Ngaphandle kokuqhubeka komlawuli wemimiselo i-GNOME, uluhlu lokukhetha "
+#~ "oluthile lunokungasebenzi. Oku kunokubonisa ingxaki ye-Bonobo, okanye "
+#~ "umlawuli wemimiselo ongengo-GNOME (umz. KDE) inoba sele esebenza yaye abe "
+#~ "uyakhabana nomlawuli wemimiselo ye-GNOME."
+
+#, c-format
+#~ msgid "Unable to load capplet stock icon '%s'\n"
+#~ msgstr "Akukwazeki ukufaka umfanekiso we-capplet stock '%s'\n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Faka nje kuphela imimiselo uze uphume"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Fumana kwakhona uze ugcine imimiselo elilifa"
+
+#~ msgid "From URI"
+#~ msgstr "Ivela kwi-URI"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "I-URI idlulisela ngoku ukusuka"
+
+#~ msgid "To URI"
+#~ msgstr "Ukuya kwi-URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "I-URI ngoku idlulisela"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Iqhezu lokudlulisa ligqityiwe ngoku"
+
+#~ msgid "Current URI index"
+#~ msgstr "Isalathiso se-URI sangoku"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Isalathiso se-URI sangoku - siqala ku1"
+
+#~ msgid "Total URIs"
+#~ msgstr "I-URIs zizonke"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Inani lilonke le-URIs"
+
+#~ msgid "Key"
+#~ msgstr "Iqhosha"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Iqhosha le-GConf apho umhleli wophawu aqhotyoshelwe khona"
+
+#~ msgid "Callback"
+#~ msgstr "Ubuyiselo nxulumano"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Khupha le ubuyiselo nxulumano xa ixabiso elinxulunyaniswa neqhosha "
+#~ "litshintshiwe"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Utshintsho lommiselo we-GConf oqulethe i-data emayithunyelwe kumxumi we-"
+#~ "gconf iyasebenza"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Uguqulo ku-widget callback"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Ubuyiselo nxulumano malukhutshwe xa i-data kufuneka iguqulelwe ukusuka "
+#~ "kwi-GConf ukuya ku-widget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Uguqulo olusuka ku-widget callback"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Ubuyiselo nxulumano malukhutshwe xa i-data kufuneka iguqulelwe ukuya kwi-"
+#~ "GConf isuka ku-widget"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Into elawula uphawu (ngokuqhelekileyo i-widget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Ulwazi lomhleli lophawu lwento"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Ulwazi ozenzeleyo olufunwa ngumhleli wophawu othile"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Ulwazi lomhleli lophawu ikhulula ubuyiselo nxulumano"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Ubuyiselo nxulumano emalikhutshwe xa i-data yomhleli yento kufuneka "
+#~ "ikhululwe"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Ayifumanekanga ifayili '%s'.\n"
+#~ "\n"
+#~ "Nceda uqinisekise ukuba ikhona uze uzame kwakhona, okanye khetha "
+#~ "umfanekiso wokungasemva owohlukileyo."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Andikwazi ukuvula ifayili '%s'.\n"
+#~ "Mhlawumbi luhlobo lomfanekiso olungekaxhaswa.\n"
+#~ "\n"
+#~ "Nceda ukhethe umfanekiso owohlukileyo endaweni yoko."
+
+#~ msgid "Please select an image."
+#~ msgstr "Nceda ukhethe umfanekiso."
+
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "I-Debian Sensible Browser"
+
+#~ msgid "Epiphany"
+#~ msgstr "I-Epiphany"
+
+#~ msgid "Galeon"
+#~ msgstr "I-Galeon"
+
+#~ msgid "Encompass"
+#~ msgstr "i-Encompass"
+
+#~ msgid "Firebird"
+#~ msgstr "i-Firebird"
+
+#~ msgid "Firefox"
+#~ msgstr "I-Firefox"
+
+#~ msgid "Mozilla"
+#~ msgstr "I-Mozilla"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Umnxibelelanisi we-Netscape"
+
+#~ msgid "Konqueror"
+#~ msgstr "I-Konqueror"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "IsiKhangeli soMbhalo we-W3M"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Isikhangeli soMbhalo we-Lynx"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Inxulumanisa isiKhangeli soMbhalo"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "I-Evolution Mail Reader"
+
+#~ msgid "Balsa"
+#~ msgstr "I-Balsa"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "I-Mozilla Mail"
+
+#~ msgid "Mutt"
+#~ msgstr "I-Mutt"
+
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "IsiLinganisi sexesha elimiselweyo seDebian"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "I-Standard XTerminal"
+
+#~ msgid "NXterm"
+#~ msgstr "I-NXterm"
+
+#~ msgid "RXVT"
+#~ msgstr "I-RXVT"
+
+#~ msgid "aterm"
+#~ msgstr "i-aterm"
+
+#~ msgid "ETerm"
+#~ msgstr "I-ETerm"
+
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "Nceda uchaze igama nomyalelo walo mhleli."
+
+#~ msgid "C_ustom"
+#~ msgstr "Isi_qhelo"
+
+#~ msgid "C_ustom:"
+#~ msgstr "Isi_qhelo:"
+
+#~ msgid "Can open _URIs"
+#~ msgstr "Ingavula ii _URIs"
+
+#~ msgid "Can open multiple _files"
+#~ msgstr "Ingavula ii _fayili ezininzi"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Um_yalelo:"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Iimpawu zoMhleli zokuZenzela"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "Umfundi we-Imeyile omiselweyo"
+
+#~ msgid "Default Terminal"
+#~ msgstr "I-Terminal eMiselweyo"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "UMhleli woMbhalo oMiselweyo"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "IsiKhangeli se-Web esiMiselweyo"
+
+#~ msgid "Default Window Manager"
+#~ msgstr "UMlawuli weFestile eMiselweyo"
+
+#~ msgid "Delete"
+#~ msgstr "Cima"
+
+#~ msgid "E_xec Flag:"
+#~ msgstr "I-E_xec Flag:"
+
+#~ msgid "Edit..."
+#~ msgstr "Hlela..."
+
+#~ msgid "Mail Reader"
+#~ msgstr "UMfundi we-Imeyile"
+
+#~ msgid "Run in a _terminal"
+#~ msgstr "Ukusebenza kwi _terminal"
+
+#~ msgid "Run in a t_erminal"
+#~ msgstr "Ukusebenza kwi-t_erminal"
+
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "Khetha umlawuli wefestile omfunayo. Kuza kufuneka ubethe u-apply, wave "
+#~ "the magic wand, uze."
+
+#~ msgid "Terminal"
+#~ msgstr "I-Terminal"
+
+#~ msgid "Text Editor"
+#~ msgstr "Umhleli woMbhalo"
+
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "Iqonda i _Netscape Remote Control"
+
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr "Sebenzisa lo _mhleli ukuvula iifayili zombhalo kumlawuli wefayili"
+
+#~ msgid "Web Browser"
+#~ msgstr "IsiKhangeli seWeb"
+
+#~ msgid "_Properties..."
+#~ msgstr "_Iimpawu..."
+
+#~ msgid "_Select:"
+#~ msgstr "_Khetha:"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Tshintsha isigqibo seskrini"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "I-%d Hz"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Uluhlu lokuKhetha lweSigqibo seSkrini"
+
+#, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Yenza okumiselweyo kule khompyutha (%s) kuphela"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Kuvavanywa imimiselo emitsha. Ukuba awuphenduli kwi %d yomzuzwana "
+#~ "imimiselo yangaphambili iyabuyiselwa kwakhona."
+#~ msgstr[1] ""
+#~ "Kuvavanywa imimiselo emitsha. Ukuba awuphenduli kwi %d yemizuzwana "
+#~ "imimiselo yangaphambili iyabuyiselwa kwakhona."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Gcina isiGqibo"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Uyafuna ukugcina esi sigqibo?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "Sebenzisa isigqibo _sangaphambili"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Gcina isigqibo"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "I-X Server ayisixhasi isandiso se-XR ne-R. Iinguqulo zesigqibo sexesha "
+#~ "lokusebenza kubungakanani kokukwiskrini azikho."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Uhlobo lwesandiso se-XR neR aluhambelani nale nkqubo. Iinguqulo zesigqibo "
+#~ "sexesha kubungakanani bokwiskrini azikho."
+
+#~ msgid "Font"
+#~ msgstr "Ifonti"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Khetha iifonti ze-desktop"
+
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<b>Ukwenza iFonti</b>"
+
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<b>Ukucebisa</b>:"
+
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<b>Ukugudisa</b>:"
+
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<b>Ulungelelwano oluyi-Subpixel</b>:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "_Izazobe ezizezona ezibhetele"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Ink_caso eyiyeyona ingcono"
+
+#~ msgid "D_etails..."
+#~ msgstr "Iink_cukacha..."
+
+#~ msgid "Font Preferences"
+#~ msgstr "ULuhlu lokukhetha lwefonti"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "Yiya _kwisiqulathi seefayili"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "I-Gra_yscale"
+
+#~ msgid "N_one"
+#~ msgstr "A_yikho"
+
+#~ msgid "R_esolution:"
+#~ msgstr "Isi_gqibo:"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "I-Sub_pixel (LCDs)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Ukugudisa i-sub_pixel (LCDs)"
+
+#~ msgid "VB_GR"
+#~ msgstr "i-VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "I-_BGR"
+
+#~ msgid "_Desktop font:"
+#~ msgstr "Ifonti ye-_desktop:"
+
+#~ msgid "_Medium"
+#~ msgstr "_Phakathi"
+
+#~ msgid "_Monochrome"
+#~ msgstr "I-_Monochrome"
+
+#~ msgid "_RGB"
+#~ msgstr "I-_RGB"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "Ifonti ye-_terminal:"
+
+#~ msgid "_VRGB"
+#~ msgstr "I-_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Ifonti yesihloko sefestile:"
+
+#~ msgid "dots per inch"
+#~ msgstr "amachaphaza nge-intshi"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Inokuba ifonti inkulu kakhulu"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Ifonti ekhethiweyo ilichaphaza %d ubukhulu, yaye inokwenza ukuba kube "
+#~ "nzima ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe "
+#~ "ubungakanani obuncinci kuno%d."
+#~ msgstr[1] ""
+#~ "Ifonti ekhethiweyo ingamachaphaza %d ubukhulu, yaye inokwenza ukuba kube "
+#~ "nzima ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe "
+#~ "ubungakanani obuncinci kuno%d."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Ifonti ekhethiweyo ilichaphaza %d ubukhulu, yaye inokwenza ukuba kube "
+#~ "nzima ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe "
+#~ "ifonti encinci."
+#~ msgstr[1] ""
+#~ "Ifonti ekhethiweyo ingamachaphaza %d ubukhulu, yaye inokwenza ukuba kube "
+#~ "nzima ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe "
+#~ "ifonti encinci."
+
+#~ msgid "New accelerator..."
+#~ msgstr "Isikhawulezisi esitsha..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Iqhosha lokubalekisa"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Amaqhosha azizilungisi zokubalekisa"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Ibhodi yamaqhosha okubalekisa"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Uhlobo lwesibalekisi."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Isenzo esingaziwayo>"
+
+#~ msgid "Window Management"
+#~ msgstr "Ulawulo lwefestile"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "Indlela enqumlayo i- \"%s\" seyisetyenziselwe i-:\n"
+#~ " \"%s\"\n"
+
+#, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Impazamo imisela isinqumlisi esitsha kwi-database yomiselo lwenkqubo "
+#~ "yekhompyutha: %s\n"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr ""
+#~ "Impazamo iyeka ukumisela isinqumlisi kwi-database yomiselo lwenkqubo "
+#~ "yekhompyutha: %s\n"
+
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "Ukuhlela iqhosha lendlela enqumlayo, cofa kumgca ohambelanayo uze "
+#~ "uchwetheze isinqumlisi esitsha, okanye cinezela isithuba esiya emva "
+#~ "ukucima."
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Nikela amaqhosha endlela enqumlayo kwimiyalelo"
+
+#~ msgid "Unknown"
+#~ msgstr "Ayaziwa"
+
+#, c-format
+#~ msgid "There was an error launching the keyboard capplet : %s"
+#~ msgstr "Bekukho impazamo ekundululeni i-capplet ye-keyboard : %s"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr ""
+#~ "Faka nje kuphela imimiselo uze uphume (ukungqinelana kuphela; ngoku "
+#~ "kuphethwe yi-daemon)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Qalisa iphepha ngemimiselo yohlulo lokuchwetheza ebonakalayo"
+
+#~ msgid "..."
+#~ msgstr "..."
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>_Tshixa iskrini ukunyanzela ulwahlulo lokuchwetheza</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Khawulezayo</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Nde</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Mfutshane</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Cothayo</i></small>"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "Ubume obu_khoyo:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "Vume_la ukumisela elinye ixesha ulwahlulo"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Jonga ukuba ulwahlulo luvumelekile na ukuba limiselwe elinye ixesha"
+
+#~ msgid "Choose A Keyboard Model"
+#~ msgstr "Khetha iModeli ye-Keyboard"
+
+#~ msgid "Choose A Layout"
+#~ msgstr "Khetha uBume"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Ixesha lolwahlulo xa ukuchwetheza kungavumelekanga"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Ixesha lomsebenzi phambi kokunyanzela ulwahlulo"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Uluhlu lokukhetha lwe-Keyboard"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "I_modeli ye-keyboard:"
+
+#~ msgid "Layout Options"
+#~ msgstr "Iindlela zokukhetha zobume"
+
+#~ msgid "Layouts"
+#~ msgstr "Ubume"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Tshixa iskrini emva kwexesha elithile ukunceda ukunqanda iingozi "
+#~ "zokusetyenziswa kwe-keyboard"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "I-Microsoft Natural Keyboard"
+
+#~ msgid "Separate _group for each window"
+#~ msgstr "_Iqela elohlukeneyo ngefestile nganye"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Ukufikelela..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Ithuba lokuhlala liyahlala:"
+
+#~ msgid "_Models:"
+#~ msgstr "Ii_modeli:"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Ubume obukhethiweyo:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Isithuba sokusebenza siyahlala:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Misela uluhlu lokukhetha lwe-keyboard"
+
+#~ msgid "Unknown Cursor"
+#~ msgstr "IKhesa eNgaziwayo"
+
+#~ msgid "Default Cursor"
+#~ msgstr "IKhesa eMiselweyo"
+
+#~ msgid "Default Cursor - Current"
+#~ msgstr "IKhesa eMiselweyo - Ngoku"
+
+#~ msgid "The default cursor that ships with X"
+#~ msgstr "Ikhesa emiselweyo ethumela kunye no-X"
+
+#~ msgid "White Cursor"
+#~ msgstr "IKhesa eMhlophe"
+
+#~ msgid "White Cursor - Current"
+#~ msgstr "IKhesa eMhlophe - Ngoku"
+
+#~ msgid "The default cursor inverted"
+#~ msgstr "Ikhesa emiselweyo igqwethiwe"
+
+#~ msgid "Large Cursor"
+#~ msgstr "IKhesa eNkulu"
+
+#~ msgid "Large Cursor - Current"
+#~ msgstr "IKhesa eNkulu - Ngoku"
+
+#~ msgid "Large version of normal cursor"
+#~ msgstr "Uhlobo olukhulu lwekhesa eqhelekileyo"
+
+#~ msgid "Large White Cursor - Current"
+#~ msgstr "IKhesa eNkulu eMhlophe - Ngoku"
+
+#~ msgid "Large White Cursor"
+#~ msgstr "IKhesa eNkulu eMhlophe"
+
+#~ msgid "Large version of white cursor"
+#~ msgstr "Uhlobo olukhulu lwekhesa emhlophe"
+
+#~ msgid "Cursor Theme"
+#~ msgstr "UMxholo weKhesa"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Tsala uze uFake</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Isantya</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Khawulezayo</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Phezulu</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Nkulu</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Phantsi</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Cothayo</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Ncinci</i>"
+
+#~ msgid "Cursors"
+#~ msgstr "Iikhesa"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Qaqambisa _isalathisi xa ucinezela u-Ctrl"
+
+#~ msgid "Motion"
+#~ msgstr "Intshukumo"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "ULuhlu lokuKhetha lweMawusi"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Imawusi elinxele"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Uvakalelo:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Misela uluhlu lwakho lokukhetha lwemawusi"
+
+#~ msgid "Set your network proxy preferences"
+#~ msgstr ""
+#~ "Misela uluhlu lokukhetha lonxibelelwano lwekhompyutha esbenza njengomqobo"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "<b>D_irect internet connection</b>"
+#~ msgstr "<b>_Unxulumano lwe-intanethi oluthe gqo</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr ""
+#~ "<b>Ukumiselwa kwenkqubo kwikhompyutha esebenza njengomqobo _ezenzekelayo</"
+#~ "b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr ""
+#~ "<b>_Ukumiselwa kwenkqubo yoxwebhu kwikhompyutha esebenza njengomqobo</b>"
+
+#~ msgid "Advanced Configuration"
+#~ msgstr "Ukumiselwa kwenkqubo yekhompyutha okunkqenkqeza phambili"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Iinkcukacha zeKhompyutha esebenza njengomqobo ye-HTTP"
+
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Uluhlu lokukhetha loThungelwano lweKhompyutha esebenza njengomqobo"
+
+#~ msgid "Port:"
+#~ msgstr "Isiqhakamsheli:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Qinisekisa ikhompyutha esebenza njengomqobo i-HTTP:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Yenza ukuba kusebenze isandi nezandi ezinxulumeneyo kunye nezehlo"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Uluhlu lwezinto ekukhethwa kuzo lwesandi"
+
+#~ msgid "E_nable sound server startup"
+#~ msgstr "Y_enza ukuba ukuvula kwesandi seseva kusebenze"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Danyazisa _ifestile ye-titlebar"
+
+#~ msgid "_Sound an audible bell"
+#~ msgstr "_Betha intsimbi evakalayo"
+
+#~ msgid "_Sounds for events"
+#~ msgstr "_Izandi zezehlo"
+
+#~ msgid "_Visual feedback:"
+#~ msgstr "Impendulo_ebonakalayo:"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Akukho mixholo ifumanekileyo kwinkqubo yakho.  Oku mhlawumbi kuthetha "
+#~ "ukuba unxibelelwano lwakho i-\"Theme Preferences\" ayisekwanga kakuhle, "
+#~ "okanye awuwusekanga umqulu wenkqubo we-\"gnome-themes\"."
+
+#~ msgid "This theme is not in a supported format."
+#~ msgstr "Lo mxholo awukho kulungiselelo oluxhasiweyo."
+
+#, fuzzy
+#~ msgid "The file format is invalid"
+#~ msgstr "I-password efakiweyo ayilunganga"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Akukho ndawo yomxholo wefayili ichaziweyo ukuba isekwe"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Indawo yomxholo wefayili echaziweyo ukuba isekwe ayilunganga"
+
+#, c-format
+#~ msgid ""
+#~ "Insufficient permissions to install the theme in:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Iimvume ezingonelanga ukuseka imixholo ku:\n"
+#~ "%s"
+
+#, fuzzy
+#~ msgid "The file format is invalid."
+#~ msgstr "I-password efakiweyo ayilunganga"
+
+#, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "I-%s yindlela apho iifayili zemixholo ziza kusekwa khona. Oku "
+#~ "akunakukhethwa njengendawo yomthombo"
+
+#~ msgid "Custom theme"
+#~ msgstr "Umxholo ozenzelayo"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr "Ungawugcina lo mxholo ngokucinezela iqhosha lokuGcina umXholo."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "Iinkcazelo zomxholo ezimiselweyo azifumanekanga kwinkqubo yakho. Oku "
+#~ "kuthetha ukuba awunayo i-metacity esekiweyo, okanye i-gconf yakho "
+#~ "imiselwe ngokungalunganga."
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Igama lomxholo malibekhona"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Umxholo sowukhona. Ungathanda ukubeka omnye endaweni yawo?"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Khetha imixholo yeendawo ngeendawo ze-desktop"
+
+#~ msgid "Theme"
+#~ msgstr "Umxholo"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Seka umxholo</span>"
+
+#~ msgid "Theme Installation"
+#~ msgstr "Ukusekwa komxholo"
+
+#~ msgid "_Install"
+#~ msgstr "_Faka"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Gcina umXholo kwiDiski</span>"
+
+#~ msgid "Apply _Font"
+#~ msgstr "Faka i_Fonti"
+
+#~ msgid "Icons"
+#~ msgstr "Imifanekiso"
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr "Imixholo emitsha ikwanokusekwa ngokuyitsalela kwifestile."
+
+#~ msgid "Save Theme"
+#~ msgstr "Gcina umxholo"
+
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Khetha umxholo we-desktop"
+
+#~ msgid "Short _description:"
+#~ msgstr "Inkcazelo _emfutshane:"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "Uluhlu lokukhetha lwemixholo"
+
+#~ msgid "Theme _Details"
+#~ msgstr "_Iinkcukacha zoMxholo"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "Lo mxholo awucebisi nayiphina ifonti ethile okanye okungasemva."
+
+#~ msgid "This theme suggests a background:"
+#~ msgstr "Lo mxholo ucebisa okungasemva:"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Lo mxholo ucebisa ifonti nokungasemva:"
+
+#~ msgid "This theme suggests a font:"
+#~ msgstr "Lo mxholo ucebisa ifonti:"
+
+#~ msgid "Window Border"
+#~ msgstr "UMqukumbelo weFestile"
+
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "_Yiya kwisiQulathi soMxholo"
+
+#~ msgid "_Revert"
+#~ msgstr "_Buyela"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "_Gcina uMxholo..."
+
+#~ msgid "theme selection tree"
+#~ msgstr "ukhetho lomxholo ngokwemo-mthi"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr "Zenzele inkangeleko ye-toolbars namaqhosha emenyu kwiinkqubo"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "IiMenyu & ne-Toolbars"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Isimbo kunye neNkangeleko</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Ukubonakalisa kuqala</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "Si_ka"
+
+#~ msgid "Icons only"
+#~ msgstr "Imifanekiso engumqondiso kuphela"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Uluhlu lwezinto ekukhethwa kuzo lweMenyu ne-Toolbar"
+
+#~ msgid "New File"
+#~ msgstr "IFayili eNtsha"
+
+#~ msgid "Save File"
+#~ msgstr "Gcina iFayili"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Bonisa _imifanekiso kwiimenyu"
+
+#~ msgid "Text below icons"
+#~ msgstr "Umbhalo ongaphantsi kwemifanekiso"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Umbhalo osecaleni kwemifanekiso"
+
+#~ msgid "Text only"
+#~ msgstr "Umbhalo kuphela"
+
+#, fuzzy
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Iilebhile zeqhosha le_Toolbar: "
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "I-toolbars _ezisukayo"
+
+#~ msgid "_Editable menu accelerators"
+#~ msgstr "_Izinqumlisi zemenyu ezihlelekayo"
+
+#~ msgid "_File"
+#~ msgstr "i_Fayili"
+
+#~ msgid "_New"
+#~ msgstr "_Entsha"
+
+#~ msgid "_Paste"
+#~ msgstr "_Ncamathisela"
+
+#, c-format
+#~ msgid ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "<b>Ayinakuqalisa inkqubo yoluhlu lokukhetha lomlawuli wefestile wakho</"
+#~ "b>\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "Control"
+#~ msgstr "Lawula"
+
+#~ msgid "Alt"
+#~ msgstr "Tshintshanisa"
+
+#~ msgid "Hyper"
+#~ msgstr "I-Hyper"
+
+#~ msgid "Super (or \"Windows logo\")"
+#~ msgstr "Ngaphezulu kombhalo (okanye \"ilogo ka-Windows\")"
+
+#~ msgid "Meta"
+#~ msgstr "I-Meta"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Iqhosha leNtshukumo</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>ISenzo se-Titlebar</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Ukukhethwa kweFestile</b>"
+
+#~ msgid "To _move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Uku _hambisa ifestile, cinezela-uze-ubambe eliqhosha uze uthathe ugcine "
+#~ "ifestile:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "ULuhlu lokukhetha lweeFestile"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Cofa-kabini i-titlebar ukwenza esi senzo:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Isithuba phambi kokunyusa:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Nyusa iifestile ezikhethiweyo emva kwesithuba"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Khetha iifestile xa imawusi ishukuma phezu kwazo"
+
+#~ msgid "Set your window properties"
+#~ msgstr "Misela iimpawu zefestile yakho"
+
+#~ msgid "Desktop Preferences"
+#~ msgstr "ULuhlu lokukhetha lwe-Desktop"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "ULungelelaniso ngasembindini lwe-GNOME"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Isixhobo sokumiselwa kwe-GNOME"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "Ayikwazanga ukuqalisa ukwaba amaxabiso eenkcukacha ze-Bonobo"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Ucinezele iqhosha u-Shift imizuzu eyi-8. Le yindlela enqumlayo yophawu "
+#~ "lwamaQhosha aCothayo, echaphazela indlela esebenza ngayo i-keyboard yakho."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Uyafuna ukwenza amaQhosha aCothayo ukuba asebenze?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Uyafuna ukwenza ukuba amaQhosha aCothayo angasebenzi?"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Uvele wacinezela iqhosha i-Shift ka-5 kuluhlu. Le yindlela enqumlayo "
+#~ "yophawu lwamaQhosha aNcamathelayo, echaphazela indlela esebenza ngayo i-"
+#~ "keyboard yakho."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "Uvele wacinezela amaqhosha amabini kwakanye, okanye wacinezela iqhosha u-"
+#~ "Shift ka-5 kuluhlu. Oku kuvala uphawu lwamaQhosha aNcamathelayo, "
+#~ "okuchaphazela indlela esebenza ngayo i-keyboard yakho."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Ufuna ukuwenza asebenze amaQhosha aNcamathelayo?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Ufuna ukuwenza angasebenzi amaQhosha aNcamathelayo?"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Akukwazeki ukwenza uvimba weefayili \"%s\".\n"
+#~ "Oku kuyafuneka ukuvumela ukutshintsha iikhesa."
+
+#, c-format
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr ""
+#~ "IKhowudi exhomekekileyo yeQhosa (%s) inesenzo sayo esichazwe amaxesha "
+#~ "amaninzi\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr ""
+#~ "IKhowudi exhomekekileyo yeQhosha(%s) inekhowudi exhomekekileyo echazwe "
+#~ "amaxesha amaninzi\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "IKhowudi exhomekekileyo yeQhosha (%s) ayiphelelanga\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "IKhowudi exhomekekileyo yeQhosha (%s) ayiphelelanga\n"
+
+#, c-format
+#~ msgid "It seems that another application already has access to key '%d'."
+#~ msgstr "Kubonakala ngathi enye inkqubo sele inokufukelela kwiqhosha '%d'."
+
+#, c-format
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "IKhowudi exhomekekileyo yeQhosha (%s) sele isetyenziswa\n"
+
+#, c-format
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Impazamo xa bekuzanywa ukusebenzisa i- (%s)\n"
+#~ "edityaniswe kwiqhosha (%s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Impazamo ekwenzeni ukuba ukumiselwa kwenkqubo i-XKB kusebenze.\n"
+#~ "Phantsi kweemeko ezininzi inokuba :\n"
+#~ "- nesiphene kwi-libxklavier library\n"
+#~ "- nesiphene kwi-X server (xkbcomp, xmodmap utilities)\n"
+#~ "- I-X server enokwenziwa kwe-libxkbfile okungangqinelaniyo\n"
+#~ "\n"
+#~ "I-data yohlobo lwe-X server :\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "Ukuba uchaza le meko njengesiphene, nceda uquke:\n"
+#~ "- Isiphumo se-<b>xprop -root | grep XKB</b>\n"
+#~ "- Isiphumo se <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/kbd</"
+#~ "b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "Usebenzisa i-XFree 4.3.0.\n"
+#~ "Kukhona iingxaki ezaziwayo ngokumiselwa kwe-XKB okunabileyo.\n"
+#~ "Zama ukusebenzisa ukumiselwa kwenkqubo okulula okanye uthathe uhlobo "
+#~ "olutsha lobucukubhede be-XFree."
+
+#, fuzzy
+#~ msgid "Do _not show this warning again"
+#~ msgstr "_Ungaphinde uwubonise lo myalezo kwakhona"
+
+#~ msgid ""
+#~ "The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.  Which set would you like to use?"
+#~ msgstr ""
+#~ "Imimiselo yesixokelelwano u-X se-keyboard siyohluka kwimimiselo ye-"
+#~ "keyboard ye-GNOME ekhoyo. Ngowuphi ummiselo ongathanda ukuwusebenzisa?"
+
+#~ msgid "Use X settings"
+#~ msgstr "Sebenzisa imimiselo u-X"
+
+#~ msgid "Use GNOME settings"
+#~ msgstr "Sebenzisa imimiselo ye-GNOME"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Akukwazekanga ukwenza umyalelo: %s\n"
+#~ "Qinisekisa ukuba lo myalelo ukhona."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Akukwazekanga ukubeka umatshini kwimo yokulala.\n"
+#~ "Qinisekisa ukuba imatshini imiselwe kakuhle."
+
+#, c-format
+#~ msgid "Permissions on the file %s are broken\n"
+#~ msgstr "Iimvume kwifayilii %s azilandelwanga\n"
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "Akukwazekanga ukufaka ifayili i-Glade.\n"
+#~ "Qinisekisa ukuba le daemon isekwe kakuhle."
+
+#, c-format
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Kubekho impazamo ukuqalisa i-screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Ukusebenza kwe-Screensaver akuzukusebenza kule seshoni."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Ungaphinde uwubonise lo myalezo kwakhona"
+
+#, c-format
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "Akukwazekanga ukufaka ifayili yesandi %s njengesampuli %s"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Akukwazeki ukumisa uvimba weefayili wasekhaya womsebenzisi"
+
+#, c-format
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "Iqhosha le-GConf %s limiselwe ukuba lichwetheze %s kodwa umchwethezo walo "
+#~ "olindelekileyo ibingu %s\n"
+
+#, fuzzy
+#~ msgid "A_vailable files:"
+#~ msgstr "Ubume obu_khoyo:"
+
+#, fuzzy
+#~ msgid "Do _not show this warning again."
+#~ msgstr "_Ungaphinde uwubonise lo myalezo kwakhona"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "Impazamo edala umqondiso wombhobho wothungelwano."
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Uhlobo lwe-bg_applier: i-BG_APPLIER_ROOT yefestile yomsebenzi onikwe "
+#~ "amandla akhethekileyo okanye i-BG_APPLIER_PREVIEW yokubonakalayo kuqala"
+
+#~ msgid "Preview Width"
+#~ msgstr "Ububanzi obubonakalisa kuqala"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr ""
+#~ "Ububanzi ukuba isifaki sesokubonakalisa kuqala: Ezimiselweyo ukuya ku 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Ubude bokuBonakalisa kuqala"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr ""
+#~ "Ubude ukuba isifaki sesokubonakalisa kuqala: Ezimiselweyo ukuya ku 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Iskrini apho i-BGApplier iza kuzoba khona"
+
+#, fuzzy, c-format
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Kubekho impazamo ekuvezeni uncedo: %s"
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Ifayili yesandi yesi sehlo ayikho."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package\n"
+#~ "for a set of default sounds."
+#~ msgstr ""
+#~ "Ifayili yesandi yesi sehlo ayikho.\n"
+#~ "Unokufuna ukuseka umqulu onesandi we-gnome\n"
+#~ "womiselo wezandi ezimiselweyo."
+
+#, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "Ifayili %s asiyofayili i-wav elungileyo"
+
+#~ msgid "Event"
+#~ msgstr "Isehlo"
+
+#~ msgid "Sound File"
+#~ msgstr "IFayili yeSandi"
+
+#~ msgid "_Play"
+#~ msgstr "_Dlala"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "Umlawuli wefestile \"%s\" akasifakanga isixhobo sokumiselwa kwenkqubo\n"
+
+#~ msgid "Maximize"
+#~ msgstr "Yenza ibe nkulu"
+
+#~ msgid "Roll up"
+#~ msgstr "Ukusonga"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "Ukuba kuyinyani, izibambi ze-mime text/plain kunye text/* ziza kugcinwa "
+#~ "kwi-sync"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Umbhalo owenzeka text/plain kunye text/* izibambi"
+
+#~ msgid "Brightness down"
+#~ msgstr "Ukukhanya makuthotywe"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Indlela enqumlayo yokuthotywa kokukhanya."
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Indlela enqumlayo yokunyuswa kokukhanya."
+
+#~ msgid "E-mail"
+#~ msgstr "I-imeyili"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Indlela enqumlayo ye-imeyili."
+
+#~ msgid "Eject's shortcut."
+#~ msgstr "Indlela enqumlayo yokukhupha."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Indlela enqumlayo yesiqulathi seefayili zasekhaya."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Indlela enqumlayo yesikhangeli soncedo sokundulula."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Indlela enqumlayo yesikhangeli sewebhu sokundulula."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Indlela enqumlayo yokuphuma."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Indlela enqumlayo yeqhosha lomzila elandelayo."
+
+#~ msgid "Pause"
+#~ msgstr "Nqumama"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Indlela enqumlayo yeqhosha lokunqumama."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Indlela enqumlayo yeqhosha u-Dlala (okanye dlala/nqumama)."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Indlela enqumlayo yamaqhosha omzila angaphambili."
+
+#~ msgid "Sleep"
+#~ msgstr "Lala"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Indlela enqumlayo yokulala."
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Indlela enqumlayo yeqhosha lokumisa ukudlala."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Indlela enqumlayo yokuthotywa kwesandi."
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Indlela enqumlayo yokuthula kwesandi"
+
+#~ msgid "Volume step"
+#~ msgstr "Inqanaba lesandi"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Inqanaba lesandi njengepesenti yesandi."
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Indlela enqumlayo yokunyuswa kwesandi."
+
+#, fuzzy
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr ""
+#~ "Bonisa unxibelelwano xa kukho iimpazamo ezenzekayo kwi-XSscreenSaver"
+
+#, fuzzy
+#~ msgid "Run screensaver at login"
+#~ msgstr "Yenza i-XScreenSaver ku-ngena"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Bonisa iiMpazamo zokuVula"
+
+#, fuzzy
+#~ msgid "Start screensaver"
+#~ msgstr "Qalisa i-XScreenSaver"
+
+#~ msgid ""
+#~ "A collection of scripts to run whenever the keyboard state is reloaded. "
+#~ "Useful for re-applying xmodmap based adjustments"
+#~ msgstr ""
+#~ "Ingqokelela yamaxwebhu emawasetyenzwe naninina isimo se-keyboard sifakiwe "
+#~ "kwakhona. Iluncedo ukufaka kwakhona ulungelelwaniso olusekelwe kwi-xmodmap"
+
+#~ msgid "Default group, assigned on window creation"
+#~ msgstr "Iqela elimiselweyo, elabelwe kuyilo lwefestile"
+
+#~ msgid "Keep and manage separate group per window"
+#~ msgstr "Gcina uze ulawule iqela elahlukeneyo ngefestile nganye"
+
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "IziBambi zokuHlaziya i-Keyboard"
+
+#~ msgid "Keyboard model"
+#~ msgstr "Imodeli ye-keyboard"
+
+#, fuzzy
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr ""
+#~ "Imimiselo ye-keyboard ku-gconf ayizukunanzwa kwinkqubo NGOKUKHAWULEZILEYO"
+
+#~ msgid "Save/restore indicators together with layout groups"
+#~ msgstr "Gcina/gcina kwakhona izibonisi kunye namaqela obume"
+
+#~ msgid "Show layout names instead of group names"
+#~ msgstr "Bonisa amagama obume endaweni yamagama eqela"
+
+#~ msgid ""
+#~ "Show layout names instead of group names (only for versions of XFree "
+#~ "supporting multiple layouts)"
+#~ msgstr ""
+#~ "Bonisa amagama obume endaweni yamagama eqela (kuphela ngeentlobo zobume "
+#~ "obunabileyo benkxaso i-XFree)"
+
+#~ msgid "keyboard layout"
+#~ msgstr "ubume be-keyboard"
+
+#~ msgid "keyboard model"
+#~ msgstr "imodeli ye-keyboard"
+
+#~ msgid "_Postpone break"
+#~ msgstr "_Nqumamisa isithuba"
+
+#~ msgid "Take a break!"
+#~ msgstr "Thatha isithuba!"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Thatha isiThuba"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d umzuzu kude kube sisithuba esilandelayo"
+#~ msgstr[1] "%d imizuzu kude kube sisithuba esilandelayo"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Ngaphantsi komzuzu omnye kude kube sisithuba esilandelayo"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Akukwazeki ukuvela nonxibelelwano lweempawu zesithuba sokuchwetheza ngale "
+#~ "mpazamo ilandelayo: %s"
+
+#~ msgid "About GNOME Typing Monitor"
+#~ msgstr "Malunga neMonitha yokuChwetheza ye-GNOME"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Isikhumbuzi sesithuba sekhompyutha."
+
+#~ msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgstr "Ibhalwe nguRichard Hult &lt;richard@imendio.com&gt;"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "I-eye candy yongezwe ngu-Anders Carlsson"
+
+#~ msgid "Break reminder"
+#~ msgstr "Isikhumbuzi sesithuba"
+
+#~ msgid "The typing monitor is already running."
+#~ msgstr "Imonitha yokuchwetheza sele iqhubeka."
+
+#, fuzzy
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Imonitha yokuchwetheza isebenzisa indawo yokwazisa ukubonisa ulwazi. "
+#~ "Awubonakali unendawo yokwazisa kwindawo yolawulo yakho. Ungayongeza "
+#~ "ngokucofa ekunene kwemawusi kwindawo yolawulo yakho uze ukhethe 'Yongeza "
+#~ "kwindawo yolawulo -> Indawo yamancedo -> Indawo yokwazisa'."
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr ""
+#~ "Ingcuka emdaka ekhawulezayo itsiba phezu kwenja eyonqenayo. 0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Ubungakanani:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Amalungelo omqulunqi:"
+
+#~ msgid "Description:"
+#~ msgstr "Inkcazelo:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "ukusetyenziswa: %s i-fontfile\n"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Misela njengeFonti yeNkqubo"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Ukuba imiselwe ku-inyani, ngako oko iifonti i-OpenType ziza kwenziwa "
+#~ "zityhile ngokukhawulezayo."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Ukuba imiselwe ku-inyani, ngako oko iifonti ze-PCF ziza kwenziwa "
+#~ "zityhileke ngokukhawulezayo."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Ukuba imiselwe ku-inyani, ngako oko iifonti i-TrueType ziza kwenziwa "
+#~ "zityhileke ngokukhawuleza."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Ukuba imiselwe ku-inyani, ngako oko iifonti i-Type1 ziza kwenziwa "
+#~ "zityhileke ngokukhawuleza."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila "
+#~ "okukhawulezayo kweefonti i-OpenType."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila "
+#~ "okukhawulezayo kweefonti i-PCF."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila "
+#~ "okukhawulezayo kweefonti i-TrueType."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila "
+#~ "okukhawulezayo kweefonti i-Type1."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-OpenType"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-PCF"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-TrueType"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-Type1"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Noba kwenziwe ukutyhila okukhawulezayo kweefonti i-OpenType"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Noba kwenziwe ukutyhila okukhawulezayo kweefonti i-PCF"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Noba kwenziwe ukutyhila okukhawulezileyo kweefonti i-TrueType"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Noba kwenziwe ukutyhila okukhawulezayo kweefonti i-Type1"
+
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "Isibonakalisi seFonti se-GNOME"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr "<span weight=\"bold\" size=\"larger\">Faka ifonti entsha?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Unga _faki ifonti"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Umxholo owukhethileyo ucebisa ifonti entsha. Ukubonakaliswa kuqala "
+#~ "kwefonti kuboniswe ngezantsi."
+
+#~ msgid "Themes"
+#~ msgstr "Imixholo"
+
+#~ msgid "Description"
+#~ msgstr "Inkcazelo"
+
+#~ msgid "Control theme"
+#~ msgstr "Lawula umxholo"
+
+#~ msgid "Window border theme"
+#~ msgstr "Umxholo womqukumbelo wefestile"
+
+#~ msgid "Icon theme"
+#~ msgstr "Umxholo womfanekiso"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#~ msgid "Apply theme"
+#~ msgstr "Faka umxholo"
+
+#~ msgid "Sets the default theme"
+#~ msgstr "Imisela umxholo omiselweyo"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr ""
+#~ "Ukuba imiselwe ku-inyani, ngako oko imixholo esekiweyo iza kwenziwa "
+#~ "ityhilwe ngokukhawulezayo."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr ""
+#~ "Ukuba imiselwe ku-inyani, ngako oko imixholo iza kwenziwa ityhileke "
+#~ "ngokukhawulezileyo."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila "
+#~ "okukhawulezayo."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila "
+#~ "okukhawulezayo kwemixholo."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Yenza ukutyhila okukhawulezayo komyalelo kwemixholo okusekiweyo"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Ukutyhila okukhawulezayo kwemixholo"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Nokuba ngaba kwenziwe ukutyhila okukhawulezayo kwemixholo esekiweyo"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Nokuba ngaba kwenziwe ukutyhila okukhawulezayo kwemixholo"

--- a/po/xh.po~
+++ b/po/xh.po~
@@ -1,0 +1,3507 @@
+# Xhosa translation of gnome-control-center
+# Copyright (C) 2005 Canonical Ltd.
+# This file is distributed under the same license as the gnome-control-center package.
+# Translation by Canonical Ltd <translations@canonical.com> with thanks to
+# Translation World CC in South Africa, 2005.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"PO-Revision-Date: 2005-03-23 09:53+0200\n"
+"Last-Translator: Canonical Ltd <translations@canonical.com>\n"
+"Language-Team: Xhosa <xh-translate@ubuntu.com>\n"
+"Language: xh\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n!=1;\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+#, fuzzy
+msgid "Alert Type"
+msgstr "Yongeza uHlobo lweFayili"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+#, fuzzy
+msgid "The type of alert"
+msgstr "Uhlobo lwesibalekisi."
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+#, fuzzy
+msgid "Alert Buttons"
+msgstr "Amaqhosha"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+#, fuzzy
+msgid "Show more _details"
+msgstr "_Iinkcukacha zoMxholo"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+msgid "About Me"
+msgstr "Malunga Nam"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your personal information"
+msgstr "Uhlobo lolwazi i-MIME"
+
+#: ../capplets/about-me/gnome-about-me.c:554
+msgid "Select Image"
+msgstr "Khetha uMfanekiso"
+
+#: ../capplets/about-me/gnome-about-me.c:556
+msgid "No Image"
+msgstr "Akukho Mfanekiso"
+
+#: ../capplets/about-me/gnome-about-me.c:706
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:727
+msgid "Unable to open address book"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:739
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:770
+#: ../capplets/about-me/gnome-about-me.c:772
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "Malunga Nam"
+
+#: ../capplets/about-me/gnome-about-me-password.c:101
+#: ../capplets/about-me/gnome-about-me-password.c:479
+msgid "Old password is incorrect, please retype it"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:112
+#, fuzzy
+msgid "System error has occurred"
+msgstr "Kwenzeke impazamo engalindelekanga"
+
+#: ../capplets/about-me/gnome-about-me-password.c:113
+#, fuzzy
+msgid "Could not run /usr/bin/passwd"
+msgstr "Akukwazekanga ukusebenzisa i-passwd"
+
+#: ../capplets/about-me/gnome-about-me-password.c:114
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:117
+#, fuzzy
+msgid "Unexpected error has occurred"
+msgstr "Kwenzeke impazamo engalindelekanga"
+
+#: ../capplets/about-me/gnome-about-me-password.c:315
+msgid "Password is too short"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:318
+#: ../capplets/about-me/gnome-about-me-password.c:321
+msgid "Password is too simple"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:324
+msgid "Old and new passwords are too similar"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:328
+msgid "Old and new password are the same"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:406
+#, fuzzy
+msgid "Please type the passwords."
+msgstr "Chwetheza kwakhona i-Password eNtsha:"
+
+#: ../capplets/about-me/gnome-about-me-password.c:414
+msgid "Please type the password again, it is wrong."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:417
+msgid "Click on Change Password to change the password."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/font/font-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+msgid "    "
+msgstr "    "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+msgid "<b>Email</b>"
+msgstr "<b>I-imeyile</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+msgid "<b>Home</b>"
+msgstr "<b>Ikhaya</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Umyalezo wesiquphe</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+msgid "<b>Job</b>"
+msgstr "<b>Umsebenzi</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+msgid "<b>Telephone</b>"
+msgstr "<b>Imfonomfono</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+msgid "<b>Web</b>"
+msgstr "<b>I-Web</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+msgid "<b>Work</b>"
+msgstr "<b>Umsebenzi</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr "I-A_IM/iChat:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+#, fuzzy
+msgid "A_ddress:"
+msgstr "_Idilesi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr "Um_ncedisi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+#, fuzzy
+msgid "Address"
+msgstr "_Idilesi"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+msgid "C_ity:"
+msgstr "Isi_xeko:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+msgid "C_ompany:"
+msgstr "Inka_mpani:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+msgid "Cale_ndar:"
+msgstr "Ikhale_nda:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+#, fuzzy
+msgid "Change Passwo_rd..."
+msgstr "Tshintsha i-Passwo_rd"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+msgid "Change Password"
+msgstr "Tshintsha i-Password"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+#, fuzzy
+msgid "Ci_ty:"
+msgstr "Isi_xeko:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+msgid "Co_untry:"
+msgstr "Ili_zwe:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+#, fuzzy
+msgid "Contact"
+msgstr "_Nxibelelana"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+#, fuzzy
+msgid "Cou_ntry:"
+msgstr "Ili_zwe:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+#, fuzzy
+msgid "Hom_e:"
+msgstr "_Ikhaya:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr "I-IC_Q:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr "I-M_SN:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+#, fuzzy
+msgid "Old pa_ssword:"
+msgstr "I-Password eNdala:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+#, fuzzy
+msgid "P.O. _box:"
+msgstr "IBhokisi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+#, fuzzy
+msgid "P._O. box:"
+msgstr "IBhokisi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+#, fuzzy
+msgid "Personal Info"
+msgstr "_Iinkcukacha Zakho"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+#, fuzzy
+msgid "State/Pro_vince:"
+msgstr "_Ilizwe/Iphondo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#, fuzzy
+msgid "User name:"
+msgstr "I_gama lomsebenzisi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+#, fuzzy
+msgid "Web _log:"
+msgstr "I-Web _Log:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+#, fuzzy
+msgid "Wor_k:"
+msgstr "_Umsebenzi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+#, fuzzy
+msgid "Work _fax:"
+msgstr "IFeksi _yoMsebenzi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+#, fuzzy
+msgid "Zip/_Postal code:"
+msgstr "U-_zip/Ikhowudi yePosi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+msgid "_Address:"
+msgstr "_Idilesi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr "_Isebe:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr "_Ngokweqela:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+#, fuzzy
+msgid "_Home page:"
+msgstr "_Iphepha laseKhaya:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+msgid "_Home:"
+msgstr "_Ikhaya:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr "I-_Jabber:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+msgid "_Manager:"
+msgstr "_Umlawuli:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+msgid "_Mobile:"
+msgstr "_Ephathwayo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+#, fuzzy
+msgid "_New password:"
+msgstr "I-Password eNtsha:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+msgid "_Profession:"
+msgstr "_Ikhondo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+#, fuzzy
+msgid "_Retype new password:"
+msgstr "Chwetheza kwakhona i-Password eNtsha:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr "_Ilizwe/Iphondo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+msgid "_Title:"
+msgstr "_Isihloko:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Work:"
+msgstr "_Umsebenzi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr "U-_Yahoo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+#, fuzzy
+msgid "_Zip/Postal code:"
+msgstr "U-_zip/Ikhowudi yePosi:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Applications</b>"
+msgstr "<b>Iinkqubo</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Support</b>"
+msgstr "<b>Inkxaso</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+"<small><i><b>Qaphela:</b> Iinguqulelo kulo mmiselo azizukwenziwa de ungene "
+"kwakhona.</i></small>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technology Preferences"
+msgstr "Uluhlu lokukhetha lobuChwephesha oluNcedayo"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr "Vala _Uphume"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr "Qalisa obu buchwephesha buncedayo ngalo lonke ixesha ungena:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr "_Yenza ukuba ubuchwepheshe obuncedayo busebenze"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr "_Isandisi"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr "_I-keyboard ekwiskrini"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Screenreader"
+msgstr "_Okufunda iskrini"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr "INkxaso yobuChwepheshe eNcedayo"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr ""
+"Yenza ukuba kusebenze inkxaso ukulungiselela ubuchwephesha boncedo be-GNOME "
+"kungeno"
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Akukho buChwephesha boNcedo bukhoyo kwinkqubo yakho. Umqulu wenkqubo we'gok' "
+"kufuneka umiselwe ukuze kufikelelwe kwinkxaso ye-keyboard ekwiskrin, yaye "
+"umpakisho we'gnopernicus' kufuneka umiselwe ufundo lweskrini namandla okwazi "
+"ukwandisa."
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+"Ayibubo bonke ubuchwepheshe obuncedayo obumiselweyo kwinkqubo yakho. Umqulu "
+"wenkqubo ye-'gok' kufuneka imiselwe ukuze kufikeleleke kwinkxaso ye-keyboard "
+"ekwiskrini."
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Asibubo bonke ubuchwepheshe obuncedayo obusekiweyo kwinkqubo yakho. Umqulu "
+"wenkqubo we-'gnopernicus' kufuneka usekiwe ukulungiselela ufundo lweskrini "
+"namandla okwazi ukwandisa."
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr ""
+"Kubekho impazamo ekundululeni unxibelelwano loluhlu ekukhethwa kulo "
+"lwemawusi: %s"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr "Akukwazeki ukudlulisa imimiselo ye-AccessX kwifayili '%s'"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
+msgid "Import Feature Settings File"
+msgstr "IFayili yeMimiselo yoPhawu lokuNgenisa"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
+msgid "_Import"
+msgstr "_Ngenisa"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "I-keyboard"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr "Misela uluhlu lokukhetha lwakho lokufikelela lwe-keyboard"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+"Le nkqubo ayibonakalisi ukuba inesongezo i-XKB. Iimpawu ze-keyboard "
+"zokufumaneka azizukusebenza ngaphandle kwayo."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+#: ../capplets/theme-switcher/theme-install.glade.h:1
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "<b>Yenza ukuba amaQhosha okuQa_katha asebenze</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "<b>Yenza ukuba amaQhosha okuCo_thisa asebenze</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "<b>Yenza ukuba amaQhosha _Emawusi asebenze</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "<b>Yenza ukuba amaQhosha _Okuphinda asebenze</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "<b>Yenza ukuba amaQhosha _Ancamathelayo asebenze</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+msgid "<b>Features</b>"
+msgstr "<b>Iimpawu</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr "<b>AmaQhosha i-Toggle</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "Esisiseko"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr "Yenza isandi esifutshane esiphindaphindayo ukuba iqhosha la_liwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr ""
+"Yenza isandi esifutshane esiphindaphindayo xa _iimpawu zivuliwe okanye "
+"zivaliwe kwi-keyboard"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr ""
+"Yenza isandi esifutshane esiphindaphindayo xa _iqhosha elisisilungisi "
+"licinezelwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr ""
+"Yenza isandi esifutshane esiphindaphindayo xa iLED ivuliwe uze wenze izandi "
+"ezibini ezifutshane xa ivaliwe."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr "Yenza isandi esifutshane esiphindaphindayo xa iqhosha li:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr "Libaz_isa:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr "Ukulibazisa phakathi kocinezelo qhosha nentshu_kumo yesalathisi:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr "Yenza ukuba inga_sebenzi ukuba amaqhosha amabini acinezelwe kunye"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr "Yenza ukuba amaQhosha e-Toggle ase_benze"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Izihluzi"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr "Suku_hoya ukucofwa kwamaqhosha okuphindiweyo ngaphakathi:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+"Sukuhoya konke ukucofa okulandelayo kweqhosha ELIFANAYO ukuba akwixesha "
+"elikhethwe ngumsebenzisi."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr "Uluhlu lokukhetha lokufikelela lwe-Keyboard (AccessX)"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr "Isantya sesalathisi esisesona Siphe_zulu:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr "Amaqhosha emawusi"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr "_Uluhlu lokukhetha lwemawusi..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+"Yamkela amaqhosha kuphela emva kokuba ecinezelwe aze agcinwa ngexesha "
+"lomsebenzisi elilungelelanisiweyo."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+"Yenza imisebenzi yokucinezela amaqhosha ngaxeshanye kaninzi ngokucinezela "
+"amaqhosha azizilungisi ngokulandelelana."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "S_peed:"
+msgstr "I_santya:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr "Lixesha lokunqu_mla ngesantya esisesona siphezulu:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr "Guqulela i-keypad yamanani kwi-pad yolawulo lwemawusi."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr "_Yenza ukuba ingasebenzi ukuba ayisetyenziswa:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr "_Yenza ukuba iimpawu zokufikelela ze-keyboard zingasebenzi"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr "_Imimiselo yeeMpawu zokuDlulisa..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr "_Yamkela kuphela amaqhosha abanjelwe i:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Type to test settings:"
+msgstr "_Chwetheza ukuvavanya imimiselo:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr "_ivunyiwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr "_icinezelwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr "_yaliwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr "iimpawu/umzuzwana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+msgid "milliseconds"
+msgstr "i-mizuzwana yemizuzwana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr "i-pixels/umzuzwana"
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:885
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "imizuzwana"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+msgid "Change your Desktop Background settings"
+msgstr "Tshintsha imimiselo yokungaSemva kwi-Desktop"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+msgid "Desktop Background"
+msgstr "OkungaSemva kwi-Desktop"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "<b>_Umhombiso we-Desktop</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+msgid "<b>_Desktop Colors</b>"
+msgstr "<b>Imibala ye-_Desktop</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+msgid "Desktop Background Preferences"
+msgstr "Uluhlu lokukhetha lokungaSemva kwi-Desktop"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr "_Faka umHombiso weskrini"
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+msgid "_Style:"
+msgstr "I_simbo:"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Kubekho impazamo ekuvezeni uncedo: %s"
+
+#: ../capplets/background/gnome-wp-capplet.c:1042
+#: ../capplets/background/gnome-wp-capplet.c:1060
+msgid "Centered"
+msgstr "Ibekwe embindini"
+
+#: ../capplets/background/gnome-wp-capplet.c:1068
+#: ../capplets/background/gnome-wp-capplet.c:1085
+msgid "Fill Screen"
+msgstr "Zalisa iSkrini"
+
+#: ../capplets/background/gnome-wp-capplet.c:1093
+#: ../capplets/background/gnome-wp-capplet.c:1110
+msgid "Scaled"
+msgstr "Ihlengahlengisiwe"
+
+#: ../capplets/background/gnome-wp-capplet.c:1118
+#: ../capplets/background/gnome-wp-capplet.c:1135
+msgid "Tiled"
+msgstr "Ifakwe iithayili"
+
+#: ../capplets/background/gnome-wp-capplet.c:1159
+#: ../capplets/background/gnome-wp-capplet.c:1168
+msgid "Solid Color"
+msgstr "Umbala oNgqingqwa"
+
+#: ../capplets/background/gnome-wp-capplet.c:1176
+#: ../capplets/background/gnome-wp-capplet.c:1185
+msgid "Horizontal Gradient"
+msgstr "UkuThambeka okuNqamlezileyo"
+
+#: ../capplets/background/gnome-wp-capplet.c:1193
+#: ../capplets/background/gnome-wp-capplet.c:1202
+msgid "Vertical Gradient"
+msgstr "UkuThambeka okuthe Nkqo"
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1251
+msgid "Add Wallpaper"
+msgstr "Hombisa iSkrini"
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr "Akukho mHombiso"
+
+#: ../capplets/background/gnome-wp-item.c:292
+#: ../capplets/background/gnome-wp-item.c:294
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] "i-pixel"
+msgstr[1] "ii-pixels"
+
+#: ../capplets/common/activate-settings-daemon.c:18
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"Akukwazeki ukuqalisa imimiselo yomlawuli i-'gnome-settings-daemon'.\n"
+"Ngaphandle kokuqhubeka komlawuli wemimiselo i-GNOME, uluhlu lokukhetha "
+"oluthile lunokungasebenzi. Oku kunokubonisa ingxaki ye-Bonobo, okanye "
+"umlawuli wemimiselo ongengo-GNOME (umz. KDE) inoba sele esebenza yaye abe "
+"uyakhabana nomlawuli wemimiselo ye-GNOME."
+
+#: ../capplets/common/capplet-stock-icons.c:94
+#, c-format
+msgid "Unable to load capplet stock icon '%s'\n"
+msgstr "Akukwazeki ukufaka umfanekiso we-capplet stock '%s'\n"
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr "Faka nje kuphela imimiselo uze uphume"
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/default-applications/gnome-default-applications-properties.c:765
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1021
+#: ../capplets/sound/sound-properties-capplet.c:244
+msgid "Retrieve and store legacy settings"
+msgstr "Fumana kwakhona uze ugcine imimiselo elilifa"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %i of %i"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr "Ivela kwi-URI"
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr "I-URI idlulisela ngoku ukusuka"
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr "Ukuya kwi-URI"
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr "I-URI ngoku idlulisela"
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr "Iqhezu ligqityiwe"
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr "Iqhezu lokudlulisa ligqityiwe ngoku"
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr "Isalathiso se-URI sangoku"
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr "Isalathiso se-URI sangoku - siqala ku1"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr "I-URIs zizonke"
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr "Inani lilonke le-URIs"
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:345
+#, fuzzy
+msgid "From:"
+msgstr "Ivela: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:349
+#, fuzzy
+msgid "To:"
+msgstr "Iya: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr "Iyahlangana..."
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Iqhosha"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr "Iqhosha le-GConf apho umhleli wophawu aqhotyoshelwe khona"
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr "Ubuyiselo nxulumano"
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+"Khupha le ubuyiselo nxulumano xa ixabiso elinxulunyaniswa neqhosha "
+"litshintshiwe"
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr "Utshintsho lommiselo"
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"Utshintsho lommiselo we-GConf oqulethe i-data emayithunyelwe kumxumi we-"
+"gconf iyasebenza"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr "Uguqulo ku-widget callback"
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+"Ubuyiselo nxulumano malukhutshwe xa i-data kufuneka iguqulelwe ukusuka kwi-"
+"GConf ukuya ku-widget"
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr "Uguqulo olusuka ku-widget callback"
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"Ubuyiselo nxulumano malukhutshwe xa i-data kufuneka iguqulelwe ukuya kwi-"
+"GConf isuka ku-widget"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr "ULawulo lwe-UI"
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr "Into elawula uphawu (ngokuqhelekileyo i-widget)"
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr "Ulwazi lomhleli lophawu lwento"
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr "Ulwazi ozenzeleyo olufunwa ngumhleli wophawu othile"
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr "Ulwazi lomhleli lophawu ikhulula ubuyiselo nxulumano"
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Ubuyiselo nxulumano emalikhutshwe xa i-data yomhleli yento kufuneka ikhululwe"
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Ayifumanekanga ifayili '%s'.\n"
+"\n"
+"Nceda uqinisekise ukuba ikhona uze uzame kwakhona, okanye khetha umfanekiso "
+"wokungasemva owohlukileyo."
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Andikwazi ukuvula ifayili '%s'.\n"
+"Mhlawumbi luhlobo lomfanekiso olungekaxhaswa.\n"
+"\n"
+"Nceda ukhethe umfanekiso owohlukileyo endaweni yoko."
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr "Nceda ukhethe umfanekiso."
+
+#: ../capplets/common/gconf-property-editor.c:1598
+msgid "_Select"
+msgstr "_Khetha"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr "IiNkqubo eziKhethwayo"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Khetha iinkqubo zakho ezimiselweyo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+msgid "Debian Sensible Browser"
+msgstr "I-Debian Sensible Browser"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
+msgid "Epiphany"
+msgstr "I-Epiphany"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
+msgid "Galeon"
+msgstr "I-Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
+msgid "Encompass"
+msgstr "i-Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+msgid "Firebird"
+msgstr "i-Firebird"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
+msgid "Firefox"
+msgstr "I-Firefox"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
+msgid "Mozilla"
+msgstr "I-Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
+msgid "Netscape Communicator"
+msgstr "Umnxibelelanisi we-Netscape"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
+msgid "Konqueror"
+msgstr "I-Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
+msgid "W3M Text Browser"
+msgstr "IsiKhangeli soMbhalo we-W3M"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
+msgid "Lynx Text Browser"
+msgstr "Isikhangeli soMbhalo we-Lynx"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
+msgid "Links Text Browser"
+msgstr "Inxulumanisa isiKhangeli soMbhalo"
+
+#. The code in gnome-default-applications-properties.c makes sure
+#. * there is only one (the first entry in this list) Evolution entry
+#. * in the list shown to the user
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
+msgid "Evolution Mail Reader"
+msgstr "I-Evolution Mail Reader"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
+msgid "Balsa"
+msgstr "I-Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
+msgid "KMail"
+msgstr "I-KMail"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
+msgid "Thunderbird"
+msgstr "i-Thunderbird"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
+msgid "Mozilla Mail"
+msgstr "I-Mozilla Mail"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
+msgid "Mutt"
+msgstr "I-Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
+msgid "Debian Terminal Emulator"
+msgstr "IsiLinganisi sexesha elimiselweyo seDebian"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
+msgid "GNOME Terminal"
+msgstr "I-Terminal ye-GNOME"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
+msgid "Standard XTerminal"
+msgstr "I-Standard XTerminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
+msgid "NXterm"
+msgstr "I-NXterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
+msgid "RXVT"
+msgstr "I-RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
+msgid "aterm"
+msgstr "i-aterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
+msgid "ETerm"
+msgstr "I-ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.c:123
+msgid "Please specify a name and a command for this editor."
+msgstr "Nceda uchaze igama nomyalelo walo mhleli."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "Add..."
+msgstr "Yongeza..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+msgid "C_ustom"
+msgstr "Isi_qhelo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+msgid "C_ustom:"
+msgstr "Isi_qhelo:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "Can open _URIs"
+msgstr "Ingavula ii _URIs"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+msgid "Can open multiple _files"
+msgstr "Ingavula ii _fayili ezininzi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "Co_mmand:"
+msgstr "Um_yalelo:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "Custom Editor Properties"
+msgstr "Iimpawu zoMhleli zokuZenzela"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "Default Mail Reader"
+msgstr "Umfundi we-Imeyile omiselweyo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "Default Terminal"
+msgstr "I-Terminal eMiselweyo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Default Text Editor"
+msgstr "UMhleli woMbhalo oMiselweyo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "Default Web Browser"
+msgstr "IsiKhangeli se-Web esiMiselweyo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Default Window Manager"
+msgstr "UMlawuli weFestile eMiselweyo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Delete"
+msgstr "Cima"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "E_xec Flag:"
+msgstr "I-E_xec Flag:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Edit..."
+msgstr "Hlela..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Mail Reader"
+msgstr "UMfundi we-Imeyile"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+msgid "Run in a _terminal"
+msgstr "Ukusebenza kwi _terminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+msgid "Run in a t_erminal"
+msgstr "Ukusebenza kwi-t_erminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid ""
+"Select the window manager you want.  You will need to hit apply, wave the "
+"magic wand, and do a magic dance for it to work."
+msgstr ""
+"Khetha umlawuli wefestile omfunayo. Kuza kufuneka ubethe u-apply, wave the "
+"magic wand, uze."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Terminal"
+msgstr "I-Terminal"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Text Editor"
+msgstr "Umhleli woMbhalo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Understands _Netscape Remote Control"
+msgstr "Iqonda i _Netscape Remote Control"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "Use this _editor to open text files in the file manager"
+msgstr "Sebenzisa lo _mhleli ukuvula iifayili zombhalo kumlawuli wefayili"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "Web Browser"
+msgstr "IsiKhangeli seWeb"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
+msgid "Window Manager"
+msgstr "UMlawuli weFestile"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
+msgid "_Command:"
+msgstr "_Umyalelo:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
+msgid "_Name:"
+msgstr "_Igama:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
+msgid "_Properties..."
+msgstr "_Iimpawu..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
+msgid "_Select:"
+msgstr "_Khetha:"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Tshintsha isigqibo seskrini"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Isigqibo seSkrini"
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr "I-%d Hz"
+
+#: ../capplets/display/main.c:448
+msgid "_Resolution:"
+msgstr "_Isigqibo:"
+
+#: ../capplets/display/main.c:467
+msgid "Re_fresh rate:"
+msgstr "Umda wokwenza ntsha_kwakhona:"
+
+#: ../capplets/display/main.c:488
+msgid "Default Settings"
+msgstr "Imimiselo emiselweyo"
+
+#: ../capplets/display/main.c:490
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr "Iskrini %d Imimiselo\n"
+
+#: ../capplets/display/main.c:516
+msgid "Screen Resolution Preferences"
+msgstr "Uluhlu lokuKhetha lweSigqibo seSkrini"
+
+#: ../capplets/display/main.c:553
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "_Yenza okumiselweyo kule khompyutha (%s) kuphela"
+
+#: ../capplets/display/main.c:571
+msgid "Options"
+msgstr "Ekunokukhethwa kuko"
+
+#: ../capplets/display/main.c:592
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"Kuvavanywa imimiselo emitsha. Ukuba awuphenduli kwi %d yomzuzwana imimiselo "
+"yangaphambili iyabuyiselwa kwakhona."
+msgstr[1] ""
+"Kuvavanywa imimiselo emitsha. Ukuba awuphenduli kwi %d yemizuzwana imimiselo "
+"yangaphambili iyabuyiselwa kwakhona."
+
+#: ../capplets/display/main.c:638
+msgid "Keep Resolution"
+msgstr "Gcina isiGqibo"
+
+#: ../capplets/display/main.c:642
+msgid "Do you want to keep this resolution?"
+msgstr "Uyafuna ukugcina esi sigqibo?"
+
+#: ../capplets/display/main.c:667
+msgid "Use _previous resolution"
+msgstr "Sebenzisa isigqibo _sangaphambili"
+
+#: ../capplets/display/main.c:667
+msgid "_Keep resolution"
+msgstr "_Gcina isigqibo"
+
+#: ../capplets/display/main.c:818
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"I-X Server ayisixhasi isandiso se-XR ne-R. Iinguqulo zesigqibo sexesha "
+"lokusebenza kubungakanani kokukwiskrini azikho."
+
+#: ../capplets/display/main.c:826
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"Uhlobo lwesandiso se-XR neR aluhambelani nale nkqubo. Iinguqulo zesigqibo "
+"sexesha kubungakanani bokwiskrini azikho."
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Ifonti"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr "Khetha iifonti ze-desktop"
+
+#: ../capplets/font/font-properties.glade.h:2
+msgid "<b>Font Rendering</b>"
+msgstr "<b>Ukwenza iFonti</b>"
+
+#: ../capplets/font/font-properties.glade.h:3
+msgid "<b>Hinting</b>:"
+msgstr "<b>Ukucebisa</b>:"
+
+#: ../capplets/font/font-properties.glade.h:4
+msgid "<b>Smoothing</b>:"
+msgstr "<b>Ukugudisa</b>:"
+
+#: ../capplets/font/font-properties.glade.h:5
+msgid "<b>Subpixel order</b>:"
+msgstr "<b>Ulungelelwano oluyi-Subpixel</b>:"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best _shapes"
+msgstr "_Izazobe ezizezona ezibhetele"
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "Best co_ntrast"
+msgstr "Ink_caso eyiyeyona ingcono"
+
+#: ../capplets/font/font-properties.glade.h:8
+msgid "D_etails..."
+msgstr "Iink_cukacha..."
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "ULuhlu lokukhetha lwefonti"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr "Iinkcukacha Zokwenza iFonti"
+
+#: ../capplets/font/font-properties.glade.h:11
+msgid "Go _to font folder"
+msgstr "Yiya _kwisiqulathi seefayili"
+
+#: ../capplets/font/font-properties.glade.h:12
+msgid "Gra_yscale"
+msgstr "I-Gra_yscale"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "A_yikho"
+
+#: ../capplets/font/font-properties.glade.h:14
+msgid "R_esolution:"
+msgstr "Isi_gqibo:"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr "I-Sub_pixel (LCDs)"
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "Ukugudisa i-sub_pixel (LCDs)"
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr "i-VB_GR"
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "_Ifonti yenkqubo:"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr "I-_BGR"
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Desktop font:"
+msgstr "Ifonti ye-_desktop:"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Full"
+msgstr "_Zele"
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Medium"
+msgstr "_Phakathi"
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Monochrome"
+msgstr "I-_Monochrome"
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_None"
+msgstr "_Ayikho"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_RGB"
+msgstr "I-_RGB"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_Slight"
+msgstr "_Kancinci"
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Terminal font:"
+msgstr "Ifonti ye-_terminal:"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr "I-_VRGB"
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "_Ifonti yesihloko sefestile:"
+
+#: ../capplets/font/font-properties.glade.h:30
+msgid "dots per inch"
+msgstr "amachaphaza nge-intshi"
+
+#: ../capplets/font/main.c:488
+msgid "Font may be too large"
+msgstr "Inokuba ifonti inkulu kakhulu"
+
+#: ../capplets/font/main.c:492
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Ifonti ekhethiweyo ilichaphaza %d ubukhulu, yaye inokwenza ukuba kube nzima "
+"ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe ubungakanani "
+"obuncinci kuno%d."
+msgstr[1] ""
+"Ifonti ekhethiweyo ingamachaphaza %d ubukhulu, yaye inokwenza ukuba kube "
+"nzima ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe "
+"ubungakanani obuncinci kuno%d."
+
+#: ../capplets/font/main.c:505
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Ifonti ekhethiweyo ilichaphaza %d ubukhulu, yaye inokwenza ukuba kube nzima "
+"ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe ifonti "
+"encinci."
+msgstr[1] ""
+"Ifonti ekhethiweyo ingamachaphaza %d ubukhulu, yaye inokwenza ukuba kube "
+"nzima ukusebenzisa ngokukuko ikhompyutha. Kuyacetyiswa ukuba ukhethe ifonti "
+"encinci."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "Isikhawulezisi esitsha..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Iqhosha lokubalekisa"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Amaqhosha azizilungisi zokubalekisa"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Ibhodi yamaqhosha okubalekisa"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Inkqubo i-Accel"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Uhlobo lwesibalekisi."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:197
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+msgid "Disabled"
+msgstr "Ukhubazekile"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:545
+msgid "<Unknown Action>"
+msgstr "<Isenzo esingaziwayo>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:566
+msgid "Desktop"
+msgstr "I-desktop"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:567
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Isandi"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:571
+msgid "Window Management"
+msgstr "Ulawulo lwefestile"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:668
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+"Indlela enqumlayo i- \"%s\" seyisetyenziselwe i-:\n"
+" \"%s\"\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:700
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr ""
+"Impazamo imisela isinqumlisi esitsha kwi-database yomiselo lwenkqubo "
+"yekhompyutha: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:750
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr ""
+"Impazamo iyeka ukumisela isinqumlisi kwi-database yomiselo lwenkqubo "
+"yekhompyutha: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:857
+msgid "Action"
+msgstr "Isenzo"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:881
+msgid "Shortcut"
+msgstr "Indlela enqumlayo"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Iindlela eziNqumlayo ze-Keyboard"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"Ukuhlela iqhosha lendlela enqumlayo, cofa kumgca ohambelanayo uze uchwetheze "
+"isinqumlisi esitsha, okanye cinezela isithuba esiya emva ukucima."
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Nikela amaqhosha endlela enqumlayo kwimiyalelo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+msgid "Unknown"
+msgstr "Ayaziwa"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+msgid "Layout"
+msgstr "Ubume"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+msgid "Default"
+msgstr "Esilelayo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+msgid "Models"
+msgstr "Iimodeli"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:106
+#, c-format
+msgid "There was an error launching the keyboard capplet : %s"
+msgstr "Bekukho impazamo ekundululeni i-capplet ye-keyboard : %s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr "_Ukufumaneka"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:240
+#: ../capplets/sound/sound-properties-capplet.c:242
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr ""
+"Faka nje kuphela imimiselo uze uphume (ukungqinelana kuphela; ngoku "
+"kuphethwe yi-daemon)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr "Qalisa iphepha ngemimiselo yohlulo lokuchwetheza ebonakalayo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "..."
+msgstr "..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Ikhesa iyaDanyaza</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Amaqhosha okuPhinda</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<b>_Tshixa iskrini ukunyanzela ulwahlulo lokuchwetheza</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Khawulezayo</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Nde</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Mfutshane</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Cothayo</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_vailable layouts:"
+msgstr "Ubume obu_khoyo:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "All_ow postponing of breaks"
+msgstr "Vume_la ukumisela elinye ixesha ulwahlulo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Jonga ukuba ulwahlulo luvumelekile na ukuba limiselwe elinye ixesha"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+msgid "Choose A Keyboard Model"
+msgstr "Khetha iModeli ye-Keyboard"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+msgid "Choose A Layout"
+msgstr "Khetha uBume"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr "Ikhesa _iyadanyaza kwiibhokisi zombhalo nakwiindawo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Duration of the break when typing is disallowed"
+msgstr "Ixesha lolwahlulo xa ukuchwetheza kungavumelekanga"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of work before forcing a break"
+msgstr "Ixesha lomsebenzi phambi kokunyanzela ulwahlulo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Key presses _repeat when key is held down"
+msgstr "Iqhosha licinezela _u-phinda xa iqhosha licinezelwe"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Keyboard Preferences"
+msgstr "Uluhlu lokukhetha lwe-Keyboard"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Keyboard _model:"
+msgstr "I_modeli ye-keyboard:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Layout Options"
+msgstr "Iindlela zokukhetha zobume"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Layouts"
+msgstr "Ubume"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Tshixa iskrini emva kwexesha elithile ukunceda ukunqanda iingozi "
+"zokusetyenziswa kwe-keyboard"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Microsoft Natural Keyboard"
+msgstr "I-Microsoft Natural Keyboard"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+msgid "Preview:"
+msgstr "Okuqale kubonakaliswe:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+msgid "Reset To De_faults"
+msgstr "Misela kwakhona Kokumi_selweyo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Separate _group for each window"
+msgstr "_Iqela elohlukeneyo ngefestile nganye"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Typing Break"
+msgstr "Unqanyulo lokuChwetheza"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "_Accessibility..."
+msgstr "_Ukufikelela..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+msgid "_Add..."
+msgstr "_Yongeza..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Break interval lasts:"
+msgstr "_Ithuba lokuhlala liyahlala:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Delay:"
+msgstr "_Libazisa:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+msgid "_Models:"
+msgstr "Ii_modeli:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Selected layouts:"
+msgstr "_Ubume obukhethiweyo:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Speed:"
+msgstr "I_santya:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Work interval lasts:"
+msgstr "_Isithuba sokusebenza siyahlala:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "minutes"
+msgstr "imizuzu"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Misela uluhlu lokukhetha lwe-keyboard"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:559
+msgid "Unknown Cursor"
+msgstr "IKhesa eNgaziwayo"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+msgid "Default Cursor"
+msgstr "IKhesa eMiselweyo"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Cursor - Current"
+msgstr "IKhesa eMiselweyo - Ngoku"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+msgid "The default cursor that ships with X"
+msgstr "Ikhesa emiselweyo ethumela kunye no-X"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+msgid "White Cursor"
+msgstr "IKhesa eMhlophe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Cursor - Current"
+msgstr "IKhesa eMhlophe - Ngoku"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+msgid "The default cursor inverted"
+msgstr "Ikhesa emiselweyo igqwethiwe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+msgid "Large Cursor"
+msgstr "IKhesa eNkulu"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Cursor - Current"
+msgstr "IKhesa eNkulu - Ngoku"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+msgid "Large version of normal cursor"
+msgstr "Uhlobo olukhulu lwekhesa eqhelekileyo"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+msgid "Large White Cursor - Current"
+msgstr "IKhesa eNkulu eMhlophe - Ngoku"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Cursor"
+msgstr "IKhesa eNkulu eMhlophe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+msgid "Large version of white cursor"
+msgstr "Uhlobo olukhulu lwekhesa emhlophe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:975
+msgid "Cursor Theme"
+msgstr "UMxholo weKhesa"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr "<b>Ukuphela kweXesha lokuCofa-Kabini </b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Tsala uze uFake</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Fumana iSalathisi</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>UQhelaniso lweMawusi</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Speed</b>"
+msgstr "<b>Isantya</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>Khawulezayo</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>Phezulu</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>Nkulu</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>Phantsi</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>Cothayo</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>Ncinci</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Amaqhosha"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#, fuzzy
+msgid "Cursor Size:"
+msgstr "UbuNgakanani beKhesa"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Cursors"
+msgstr "Iikhesa"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr "Qaqambisa _isalathisi xa ucinezela u-Ctrl"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+#, fuzzy
+msgid "Large"
+msgstr "_Nkulu"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+#, fuzzy
+msgid "Medium"
+msgstr "_Phakathi"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Motion"
+msgstr "Intshukumo"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Mouse Preferences"
+msgstr "ULuhlu lokuKhetha lweMawusi"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#, fuzzy
+msgid "Small"
+msgstr "_Ncinci"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr "_Ukhawuleziso:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr "_Imawusi elinxele"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr "_Uvakalelo:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr "_Umda:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr "_Ukuphela kwexesha:"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Imawusi"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Misela uluhlu lwakho lokukhetha lwemawusi"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Unxibelelwano lweKhompyutha esebenza njengomqobo"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+msgid "Set your network proxy preferences"
+msgstr ""
+"Misela uluhlu lokukhetha lonxibelelwano lwekhompyutha esbenza njengomqobo"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+#, fuzzy
+msgid "<b>D_irect internet connection</b>"
+msgstr "<b>_Unxulumano lwe-intanethi oluthe gqo</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+#, fuzzy
+msgid "<b>Ignore Host List</b>"
+msgstr "<b>Sukuluhoya uluhlu lwabaququzeleli</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr ""
+"<b>Ukumiselwa kwenkqubo kwikhompyutha esebenza njengomqobo _ezenzekelayo</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr ""
+"<b>_Ukumiselwa kwenkqubo yoxwebhu kwikhompyutha esebenza njengomqobo</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Sebenzisa uqinisekiso</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+msgid "Advanced Configuration"
+msgstr "Ukumiselwa kwenkqubo yekhompyutha okunkqenkqeza phambili"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr "I-Autoconfiguration _URL:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "Iinkcukacha zeKhompyutha esebenza njengomqobo ye-HTTP"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "Ikhompyutha esebenza njengomqobo eyi-H_TTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+msgid "Network Proxy Preferences"
+msgstr "Uluhlu lokukhetha loThungelwano lweKhompyutha esebenza njengomqobo"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Isiqhakamsheli:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+msgid "Proxy Configuration"
+msgstr "UkuMiselwa kwenkqubo kwiKhompyutha esbenza njengomqobo"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr "Umququzeleli we-S_ocks:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "U_sername:"
+msgstr "I_gama lomsebenzisi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_Iinkcukacha"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr "Ikhompyutha esebenza njengomqobo i-_FTP:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "I-_Password:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr "_Qinisekisa ikhompyutha esebenza njengomqobo i-HTTP:"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Yenza ukuba kusebenze isandi nezandi ezinxulumeneyo kunye nezehlo"
+
+#: ../capplets/sound/sound-properties-capplet.c:271
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Sound Preferences"
+msgstr "Uluhlu lwezinto ekukhethwa kuzo lwesandi"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "E_nable sound server startup"
+msgstr "Y_enza ukuba ukuvula kwesandi seseva kusebenze"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "Flash _entire screen"
+msgstr "Danyazisa iskrini _sonke"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "Flash _window titlebar"
+msgstr "Danyazisa _ifestile ye-titlebar"
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "General"
+msgstr "Jikelele"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "Sound Events"
+msgstr "Izehlo zesandi"
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "System Bell"
+msgstr "INtsimbi yeNkqubo"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "_Sound an audible bell"
+msgstr "_Betha intsimbi evakalayo"
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "_Sounds for events"
+msgstr "_Izandi zezehlo"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "_Visual feedback:"
+msgstr "Impendulo_ebonakalayo:"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:347
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+"Akukho mixholo ifumanekileyo kwinkqubo yakho.  Oku mhlawumbi kuthetha ukuba "
+"unxibelelwano lwakho i-\"Theme Preferences\" ayisekwanga kakuhle, okanye "
+"awuwusekanga umqulu wenkqubo we-\"gnome-themes\"."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:227
+msgid "This theme is not in a supported format."
+msgstr "Lo mxholo awukho kulungiselelo oluxhasiweyo."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:244
+msgid "Failed to create temporary directory"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:264
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:282
+#: ../capplets/theme-switcher/gnome-theme-installer.c:319
+#: ../capplets/theme-switcher/gnome-theme-installer.c:399
+#, fuzzy
+msgid "Installation Failed"
+msgstr "Ukusekwa komxholo"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:302
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:340
+#, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:343
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:346
+#, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:349
+#, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:357
+msgid "The theme is an engine. You need to compile the theme."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:374
+#, fuzzy
+msgid "The file format is invalid"
+msgstr "I-password efakiweyo ayilunganga"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:468
+msgid "No theme file location specified to install"
+msgstr "Akukho ndawo yomxholo wefayili ichaziweyo ukuba isekwe"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:485
+msgid "The theme file location specified to install is invalid"
+msgstr "Indawo yomxholo wefayili echaziweyo ukuba isekwe ayilunganga"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:505
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+"Iimvume ezingonelanga ukuseka imixholo ku:\n"
+"%s"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:526
+#, fuzzy
+msgid "The file format is invalid."
+msgstr "I-password efakiweyo ayilunganga"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:553
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+"I-%s yindlela apho iifayili zemixholo ziza kusekwa khona. Oku akunakukhethwa "
+"njengendawo yomthombo"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:607
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "Custom theme"
+msgstr "Umxholo ozenzelayo"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr "Ungawugcina lo mxholo ngokucinezela iqhosha lokuGcina umXholo."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+"Iinkcazelo zomxholo ezimiselweyo azifumanekanga kwinkqubo yakho. Oku "
+"kuthetha ukuba awunayo i-metacity esekiweyo, okanye i-gconf yakho imiselwe "
+"ngokungalunganga."
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:72
+msgid "Theme name must be present"
+msgstr "Igama lomxholo malibekhona"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:104
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Umxholo sowukhona. Ungathanda ukubeka omnye endaweni yawo?"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr "Khetha imixholo yeendawo ngeendawo ze-desktop"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "Umxholo"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Seka umxholo</span>"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:3
+msgid "Theme Installation"
+msgstr "Ukusekwa komxholo"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:4
+msgid "_Install"
+msgstr "_Faka"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:5
+msgid "_Location:"
+msgstr "_Indawo:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Gcina umXholo kwiDiski</span>"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Apply _Background"
+msgstr "Faka _Okungasemva"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Apply _Font"
+msgstr "Faka i_Fonti"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Controls"
+msgstr "Izilawuli"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "Icons"
+msgstr "Imifanekiso"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "New themes can also be installed by dragging them into the window."
+msgstr "Imixholo emitsha ikwanokusekwa ngokuyitsalela kwifestile."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+msgid "Save Theme"
+msgstr "Gcina umxholo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+msgid "Select theme for the desktop"
+msgstr "Khetha umxholo we-desktop"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+msgid "Short _description:"
+msgstr "Inkcazelo _emfutshane:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "Theme Details"
+msgstr "IiNkcukacha zomXholo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "Theme Preferences"
+msgstr "Uluhlu lokukhetha lwemixholo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+msgid "Theme _Details"
+msgstr "_Iinkcukacha zoMxholo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+msgid "This theme does not suggest any particular font or background."
+msgstr "Lo mxholo awucebisi nayiphina ifonti ethile okanye okungasemva."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+msgid "This theme suggests a background:"
+msgstr "Lo mxholo ucebisa okungasemva:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+msgid "This theme suggests a font and a background:"
+msgstr "Lo mxholo ucebisa ifonti nokungasemva:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+msgid "This theme suggests a font:"
+msgstr "Lo mxholo ucebisa ifonti:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "Window Border"
+msgstr "UMqukumbelo weFestile"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+msgid "_Go To Theme Folder"
+msgstr "_Yiya kwisiQulathi soMxholo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+msgid "_Install Theme..."
+msgstr "_Seka uMxholo..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+msgid "_Revert"
+msgstr "_Buyela"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+msgid "_Save Theme..."
+msgstr "_Gcina uMxholo..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+msgid "_Theme name:"
+msgstr "_Igama lomxholo:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:24
+msgid "theme selection tree"
+msgstr "ukhetho lomxholo ngokwemo-mthi"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr "Zenzele inkangeleko ye-toolbars namaqhosha emenyu kwiinkqubo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "IiMenyu & ne-Toolbars"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr "<b>Isimbo kunye neNkangeleko</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+msgid "<b>Preview</b>"
+msgstr "<b>Ukubonakalisa kuqala</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "Si_ka"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+msgid "Icons only"
+msgstr "Imifanekiso engumqondiso kuphela"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "Uluhlu lwezinto ekukhethwa kuzo lweMenyu ne-Toolbar"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "IFayili eNtsha"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Vula iFayili"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Gcina iFayili"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr "Bonisa _imifanekiso kwiimenyu"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+msgid "Text below icons"
+msgstr "Umbhalo ongaphantsi kwemifanekiso"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+msgid "Text beside icons"
+msgstr "Umbhalo osecaleni kwemifanekiso"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+msgid "Text only"
+msgstr "Umbhalo kuphela"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+#, fuzzy
+msgid "Toolbar _button labels:"
+msgstr "Iilebhile zeqhosha le_Toolbar: "
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_Kopa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr "I-toolbars _ezisukayo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_Hlela"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr "_Izinqumlisi zemenyu ezihlelekayo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "i_Fayili"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_Entsha"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "_Vula"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "_Ncamathisela"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "_Shicilela"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "_Phuma"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "_Gcina"
+
+#: ../capplets/windows/gnome-window-properties.c:386
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+"<b>Ayinakuqalisa inkqubo yoluhlu lokukhetha lomlawuli wefestile wakho</b>\n"
+"\n"
+"%s"
+
+#: ../capplets/windows/gnome-window-properties.c:644
+msgid "Control"
+msgstr "Lawula"
+
+#: ../capplets/windows/gnome-window-properties.c:649
+msgid "Alt"
+msgstr "Tshintshanisa"
+
+#: ../capplets/windows/gnome-window-properties.c:655
+msgid "Hyper"
+msgstr "I-Hyper"
+
+#: ../capplets/windows/gnome-window-properties.c:662
+msgid "Super (or \"Windows logo\")"
+msgstr "Ngaphezulu kombhalo (okanye \"ilogo ka-Windows\")"
+
+#: ../capplets/windows/gnome-window-properties.c:669
+msgid "Meta"
+msgstr "I-Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Iqhosha leNtshukumo</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>ISenzo se-Titlebar</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Ukukhethwa kweFestile</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To _move a window, press-and-hold this key then grab the window:"
+msgstr ""
+"Uku _hambisa ifestile, cinezela-uze-ubambe eliqhosha uze uthathe ugcine "
+"ifestile:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "ULuhlu lokukhetha lweeFestile"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_Cofa-kabini i-titlebar ukwenza esi senzo:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "_Isithuba phambi kokunyusa:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_Nyusa iifestile ezikhethiweyo emva kwesithuba"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Khetha iifestile xa imawusi ishukuma phezu kwazo"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+msgid "Set your window properties"
+msgstr "Misela iimpawu zefestile yakho"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "U-Windows"
+
+#: ../control-center/control-center-categories.c:257
+msgid "Others"
+msgstr "Ezinye"
+
+#: ../control-center/control-center.c:42
+msgid "Desktop Preferences"
+msgstr "ULuhlu lokukhetha lwe-Desktop"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr "ULungelelaniso ngasembindini lwe-GNOME"
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "Isixhobo sokumiselwa kwe-GNOME"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "Isandi"
+
+#: ../gnome-settings-daemon/factory.c:36
+msgid "Could not initialize Bonobo"
+msgstr "Ayikwazanga ukuqalisa ukwaba amaxabiso eenkcukacha ze-Bonobo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
+msgid "Slow Keys Alert"
+msgstr "IsiLumkiso samaQhosha aCothayo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Ucinezele iqhosha u-Shift imizuzu eyi-8. Le yindlela enqumlayo yophawu "
+"lwamaQhosha aCothayo, echaphazela indlela esebenza ngayo i-keyboard yakho."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
+msgid "Do you want to activate Slow Keys?"
+msgstr "Uyafuna ukwenza amaQhosha aCothayo ukuba asebenze?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
+msgid "Do you want to deactivate Slow Keys?"
+msgstr "Uyafuna ukwenza ukuba amaQhosha aCothayo angasebenzi?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Sticky Keys Alert"
+msgstr "IsiLumkiso samaQhosha aNcamathelayo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Uvele wacinezela iqhosha i-Shift ka-5 kuluhlu. Le yindlela enqumlayo yophawu "
+"lwamaQhosha aNcamathelayo, echaphazela indlela esebenza ngayo i-keyboard "
+"yakho."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+"Uvele wacinezela amaqhosha amabini kwakanye, okanye wacinezela iqhosha u-"
+"Shift ka-5 kuluhlu. Oku kuvala uphawu lwamaQhosha aNcamathelayo, "
+"okuchaphazela indlela esebenza ngayo i-keyboard yakho."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
+msgid "Do you want to activate Sticky Keys?"
+msgstr "Ufuna ukuwenza asebenze amaQhosha aNcamathelayo?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr "Ufuna ukuwenza angasebenzi amaQhosha aNcamathelayo?"
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:107
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+"Akukwazeki ukwenza uvimba weefayili \"%s\".\n"
+"Oku kuyafuneka ukuvumela ukutshintsha iikhesa."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr ""
+"IKhowudi exhomekekileyo yeQhosa (%s) inesenzo sayo esichazwe amaxesha "
+"amaninzi\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr ""
+"IKhowudi exhomekekileyo yeQhosha(%s) inekhowudi exhomekekileyo echazwe "
+"amaxesha amaninzi\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr "IKhowudi exhomekekileyo yeQhosha (%s) ayiphelelanga\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr "IKhowudi exhomekekileyo yeQhosha (%s) ayiphelelanga\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
+#, c-format
+msgid "It seems that another application already has access to key '%d'."
+msgstr "Kubonakala ngathi enye inkqubo sele inokufukelela kwiqhosha '%d'."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr "IKhowudi exhomekekileyo yeQhosha (%s) sele isetyenziswa\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+"Impazamo xa bekuzanywa ukusebenzisa i- (%s)\n"
+"edityaniswe kwiqhosha (%s)"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
+#, fuzzy, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+"Impazamo ekwenzeni ukuba ukumiselwa kwenkqubo i-XKB kusebenze.\n"
+"Phantsi kweemeko ezininzi inokuba :\n"
+"- nesiphene kwi-libxklavier library\n"
+"- nesiphene kwi-X server (xkbcomp, xmodmap utilities)\n"
+"- I-X server enokwenziwa kwe-libxkbfile okungangqinelaniyo\n"
+"\n"
+"I-data yohlobo lwe-X server :\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"Ukuba uchaza le meko njengesiphene, nceda uquke:\n"
+"- Isiphumo se-<b>xprop -root | grep XKB</b>\n"
+"- Isiphumo se <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/kbd</b>"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+#, fuzzy
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+"Usebenzisa i-XFree 4.3.0.\n"
+"Kukhona iingxaki ezaziwayo ngokumiselwa kwe-XKB okunabileyo.\n"
+"Zama ukusebenzisa ukumiselwa kwenkqubo okulula okanye uthathe uhlobo olutsha "
+"lobucukubhede be-XFree."
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
+#, fuzzy
+msgid "Do _not show this warning again"
+msgstr "_Ungaphinde uwubonise lo myalezo kwakhona"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
+msgid ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+msgstr ""
+"Imimiselo yesixokelelwano u-X se-keyboard siyohluka kwimimiselo ye-keyboard "
+"ye-GNOME ekhoyo. Ngowuphi ummiselo ongathanda ukuwusebenzisa?"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
+msgid "Use X settings"
+msgstr "Sebenzisa imimiselo u-X"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
+msgid "Use GNOME settings"
+msgstr "Sebenzisa imimiselo ye-GNOME"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+"Akukwazekanga ukwenza umyalelo: %s\n"
+"Qinisekisa ukuba lo myalelo ukhona."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+"Akukwazekanga ukubeka umatshini kwimo yokulala.\n"
+"Qinisekisa ukuba imatshini imiselwe kakuhle."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
+#, c-format
+msgid "Permissions on the file %s are broken\n"
+msgstr "Iimvume kwifayilii %s azilandelwanga\n"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+"Akukwazekanga ukufaka ifayili i-Glade.\n"
+"Qinisekisa ukuba le daemon isekwe kakuhle."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+"Kubekho impazamo ukuqalisa i-screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Ukusebenza kwe-Screensaver akuzukusebenza kule seshoni."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
+msgid "_Do not show this message again"
+msgstr "_Ungaphinde uwubonise lo myalezo kwakhona"
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:129
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr "Akukwazekanga ukufaka ifayili yesandi %s njengesampuli %s"
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
+msgid "Cannot determine user's home directory"
+msgstr "Akukwazeki ukumisa uvimba weefayili wasekhaya womsebenzisi"
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr ""
+"Iqhosha le-GConf %s limiselwe ukuba lichwetheze %s kodwa umchwethezo walo "
+"olindelekileyo ibingu %s\n"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+#, fuzzy
+msgid "A_vailable files:"
+msgstr "Ubume obu_khoyo:"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+#, fuzzy
+msgid "Do _not show this warning again."
+msgstr "_Ungaphinde uwubonise lo myalezo kwakhona"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+#, fuzzy
+msgid "_Loaded files:"
+msgstr "Ii_modeli:"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr "Impazamo edala umqondiso wombhobho wothungelwano."
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Uhlobo"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+"Uhlobo lwe-bg_applier: i-BG_APPLIER_ROOT yefestile yomsebenzi onikwe amandla "
+"akhethekileyo okanye i-BG_APPLIER_PREVIEW yokubonakalayo kuqala"
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr "Ububanzi obubonakalisa kuqala"
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr ""
+"Ububanzi ukuba isifaki sesokubonakalisa kuqala: Ezimiselweyo ukuya ku 64."
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr "Ubude bokuBonakalisa kuqala"
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr "Ubude ukuba isifaki sesokubonakalisa kuqala: Ezimiselweyo ukuya ku 48."
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Iskrini"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr "Iskrini apho i-BGApplier iza kuzoba khona"
+
+#: ../libgswitchit/gswitchit_config.c:1035
+#, fuzzy, c-format
+msgid "There was an error loading an image: %s"
+msgstr "Kubekho impazamo ekuvezeni uncedo: %s"
+
+#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
+msgid "The sound file for this event does not exist."
+msgstr "Ifayili yesandi yesi sehlo ayikho."
+
+#: ../libsounds/sound-view.c:149
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package\n"
+"for a set of default sounds."
+msgstr ""
+"Ifayili yesandi yesi sehlo ayikho.\n"
+"Unokufuna ukuseka umqulu onesandi we-gnome\n"
+"womiselo wezandi ezimiselweyo."
+
+#: ../libsounds/sound-view.c:224
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "Ifayili %s asiyofayili i-wav elungileyo"
+
+#: ../libsounds/sound-view.c:289
+msgid "Event"
+msgstr "Isehlo"
+
+#: ../libsounds/sound-view.c:298
+msgid "Sound File"
+msgstr "IFayili yeSandi"
+
+#: ../libsounds/sound-view.c:314
+msgid "_Sounds:"
+msgstr "I_zandi:"
+
+#: ../libsounds/sound-view.c:328
+msgid "Sound _file:"
+msgstr "i_Fayili yesandi:"
+
+#: ../libsounds/sound-view.c:332
+msgid "Select Sound File"
+msgstr "Khetha iFayili yeSandi"
+
+#: ../libsounds/sound-view.c:356
+msgid "_Play"
+msgstr "_Dlala"
+
+#: ../libsounds/sound-view.c:366
+msgid "_Remove"
+msgstr "_Susa"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr ""
+"Umlawuli wefestile \"%s\" akasifakanga isixhobo sokumiselwa kwenkqubo\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Yenza ibe nkulu"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Ukusonga"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr ""
+"Ukuba kuyinyani, izibambi ze-mime text/plain kunye text/* ziza kugcinwa kwi-"
+"sync"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr "Umbhalo owenzeka text/plain kunye text/* izibambi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "Brightness down"
+msgstr "Ukukhanya makuthotywe"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "Brightness down's shortcut."
+msgstr "Indlela enqumlayo yokuthotywa kokukhanya."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Brightness up"
+msgstr "Ukukhanya makunyuswe"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Brightness up's shortcut."
+msgstr "Indlela enqumlayo yokunyuswa kokukhanya."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "E-mail"
+msgstr "I-imeyili"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "E-mail's shortcut."
+msgstr "Indlela enqumlayo ye-imeyili."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Eject"
+msgstr "Khupha"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+msgid "Eject's shortcut."
+msgstr "Indlela enqumlayo yokukhupha."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+msgid "Home folder"
+msgstr "Isiqulathi seefayili sasekhaya"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+msgid "Home folder's shortcut."
+msgstr "Indlela enqumlayo yesiqulathi seefayili zasekhaya."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+msgid "Launch help browser"
+msgstr "Isikhangeli soncedo sokundulula"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+msgid "Launch help browser's shortcut."
+msgstr "Indlela enqumlayo yesikhangeli soncedo sokundulula."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+msgid "Launch web browser"
+msgstr "Isikhangeli sewebhu sokundulula"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+msgid "Launch web browser's shortcut."
+msgstr "Indlela enqumlayo yesikhangeli sewebhu sokundulula."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+msgid "Lock screen"
+msgstr "Tshixa iskrini"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+msgid "Lock screen's shortcut."
+msgstr "Indlela enqumlayo yokutshixa iskrini."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+msgid "Log out"
+msgstr "Phuma"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+msgid "Log out's shortcut."
+msgstr "Indlela enqumlayo yokuphuma."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Next track key's shortcut."
+msgstr "Indlela enqumlayo yeqhosha lomzila elandelayo."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Pause"
+msgstr "Nqumama"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Pause key's shortcut."
+msgstr "Indlela enqumlayo yeqhosha lokunqumama."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Play (or play/pause)"
+msgstr "Dlala (okanye dlala/nqumama)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Play (or play/pause) key's shortcut."
+msgstr "Indlela enqumlayo yeqhosha u-Dlala (okanye dlala/nqumama)."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Previous track key's shortcut."
+msgstr "Indlela enqumlayo yamaqhosha omzila angaphambili."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Search"
+msgstr "Khangela"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+msgid "Search's shortcut."
+msgstr "Indlela enqumlayo yokukhangela."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Skip to next track"
+msgstr "Tsibela kwingoma elandelayo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Skip to previous track"
+msgstr "Tsibela kwingoma yangaphambili"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Sleep"
+msgstr "Lala"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+msgid "Sleep's shortcut."
+msgstr "Indlela enqumlayo yokulala."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Stop playback key"
+msgstr "Iqhosha lokumisa ukudlala okungasemva"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Stop playback key's shortcut."
+msgstr "Indlela enqumlayo yeqhosha lokumisa ukudlala."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume down"
+msgstr "Isandi masithotywe"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume down's shortcut."
+msgstr "Indlela enqumlayo yokuthotywa kwesandi."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume mute"
+msgstr "Ukuthula kwesandi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume mute's shortcut"
+msgstr "Indlela enqumlayo yokuthula kwesandi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+msgid "Volume step"
+msgstr "Inqanaba lesandi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+msgid "Volume step as percentage of volume."
+msgstr "Inqanaba lesandi njengepesenti yesandi."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+msgid "Volume up"
+msgstr "Nyusa isandi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
+msgid "Volume up's shortcut."
+msgstr "Indlela enqumlayo yokunyuswa kwesandi."
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+#, fuzzy
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr "Bonisa unxibelelwano xa kukho iimpazamo ezenzekayo kwi-XSscreenSaver"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+#, fuzzy
+msgid "Run screensaver at login"
+msgstr "Yenza i-XScreenSaver ku-ngena"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr "Bonisa iiMpazamo zokuVula"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#, fuzzy
+msgid "Start screensaver"
+msgstr "Qalisa i-XScreenSaver"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+"Ingqokelela yamaxwebhu emawasetyenzwe naninina isimo se-keyboard sifakiwe "
+"kwakhona. Iluncedo ukufaka kwakhona ulungelelwaniso olusekelwe kwi-xmodmap"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr "Iqela elimiselweyo, elabelwe kuyilo lwefestile"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr "Gcina uze ulawule iqela elahlukeneyo ngefestile nganye"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+msgid "Keyboard Update Handlers"
+msgstr "IziBambi zokuHlaziya i-Keyboard"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+msgid "Keyboard layout"
+msgstr "Ubume be-keyboard"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+msgid "Keyboard model"
+msgstr "Imodeli ye-keyboard"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+msgid "Keyboard options"
+msgstr "Ekunokukhethwa kuko kwe-keyboard"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+#, fuzzy
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr ""
+"Imimiselo ye-keyboard ku-gconf ayizukunanzwa kwinkqubo NGOKUKHAWULEZILEYO"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr "Gcina/gcina kwakhona izibonisi kunye namaqela obume"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr "Bonisa amagama obume endaweni yamagama eqela"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+"Bonisa amagama obume endaweni yamagama eqela (kuphela ngeentlobo zobume "
+"obunabileyo benkxaso i-XFree)"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+msgid "keyboard layout"
+msgstr "ubume be-keyboard"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+msgid "keyboard model"
+msgstr "imodeli ye-keyboard"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "modmap file list"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:212
+msgid "_Postpone break"
+msgstr "_Nqumamisa isithuba"
+
+#: ../typing-break/drw-break-window.c:259
+msgid "Take a break!"
+msgstr "Thatha isithuba!"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:141
+msgid "/_Preferences"
+msgstr "/_Uluhlu lokukhetha"
+
+#: ../typing-break/drwright.c:142
+msgid "/_About"
+msgstr "/_Malunga"
+
+#: ../typing-break/drwright.c:144
+msgid "/_Take a Break"
+msgstr "/_Thatha isiThuba"
+
+#: ../typing-break/drwright.c:495
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "%d umzuzu kude kube sisithuba esilandelayo"
+msgstr[1] "%d imizuzu kude kube sisithuba esilandelayo"
+
+#: ../typing-break/drwright.c:499
+msgid "Less than one minute until the next break"
+msgstr "Ngaphantsi komzuzu omnye kude kube sisithuba esilandelayo"
+
+#: ../typing-break/drwright.c:587
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Akukwazeki ukuvela nonxibelelwano lweempawu zesithuba sokuchwetheza ngale "
+"mpazamo ilandelayo: %s"
+
+#: ../typing-break/drwright.c:635
+msgid "About GNOME Typing Monitor"
+msgstr "Malunga neMonitha yokuChwetheza ye-GNOME"
+
+#: ../typing-break/drwright.c:659
+msgid "A computer break reminder."
+msgstr "Isikhumbuzi sesithuba sekhompyutha."
+
+#: ../typing-break/drwright.c:660
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr "Ibhalwe nguRichard Hult &lt;richard@imendio.com&gt;"
+
+#: ../typing-break/drwright.c:661
+msgid "Eye candy added by Anders Carlsson"
+msgstr "I-eye candy yongezwe ngu-Anders Carlsson"
+
+#: ../typing-break/drwright.c:837
+msgid "Break reminder"
+msgstr "Isikhumbuzi sesithuba"
+
+#: ../typing-break/main.c:93
+msgid "The typing monitor is already running."
+msgstr "Imonitha yokuchwetheza sele iqhubeka."
+
+#: ../typing-break/main.c:106
+#, fuzzy
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Imonitha yokuchwetheza isebenzisa indawo yokwazisa ukubonisa ulwazi. "
+"Awubonakali unendawo yokwazisa kwindawo yolawulo yakho. Ungayongeza "
+"ngokucofa ekunene kwemawusi kwindawo yolawulo yakho uze ukhethe 'Yongeza "
+"kwindawo yolawulo -> Indawo yamancedo -> Indawo yokwazisa'."
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr "Ingcuka emdaka ekhawulezayo itsiba phezu kwenja eyonqenayo. 0123456789"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "Igama:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "Isimbo:"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "Uhlobo:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "Ubungakanani:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "Uhlobo:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "Amalungelo omqulunqi:"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "Inkcazelo:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "ukusetyenziswa: %s i-fontfile\n"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr "Misela njengeFonti yeNkqubo"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+msgid "Sets the default application font"
+msgstr "Imisela ifonti yenkqubo emiselweyo"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr ""
+"Ukuba imiselwe ku-inyani, ngako oko iifonti i-OpenType ziza kwenziwa "
+"zityhile ngokukhawulezayo."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr ""
+"Ukuba imiselwe ku-inyani, ngako oko iifonti ze-PCF ziza kwenziwa zityhileke "
+"ngokukhawulezayo."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr ""
+"Ukuba imiselwe ku-inyani, ngako oko iifonti i-TrueType ziza kwenziwa "
+"zityhileke ngokukhawuleza."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr ""
+"Ukuba imiselwe ku-inyani, ngako oko iifonti i-Type1 ziza kwenziwa zityhileke "
+"ngokukhawuleza."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
+"kweefonti i-OpenType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
+"kweefonti i-PCF."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
+"kweefonti i-TrueType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
+"kweefonti i-Type1."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-OpenType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-PCF"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-TrueType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Umyalelo wokutyhila okukhawulezayo kweefonti i-Type1"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "Noba kwenziwe ukutyhila okukhawulezayo kweefonti i-OpenType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "Noba kwenziwe ukutyhila okukhawulezayo kweefonti i-PCF"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "Noba kwenziwe ukutyhila okukhawulezileyo kweefonti i-TrueType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "Noba kwenziwe ukutyhila okukhawulezayo kweefonti i-Type1"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+msgid "GNOME Font Viewer"
+msgstr "Isibonakalisi seFonti se-GNOME"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr "<span weight=\"bold\" size=\"larger\">Faka ifonti entsha?</span>"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr "Unga _faki ifonti"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"Umxholo owukhethileyo ucebisa ifonti entsha. Ukubonakaliswa kuqala kwefonti "
+"kuboniswe ngezantsi."
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+msgid "_Apply font"
+msgstr "_Faka ifonti"
+
+#: ../vfs-methods/themus/theme-method.c:520
+msgid "Themes"
+msgstr "Imixholo"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "Inkcazelo"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr "Lawula umxholo"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+msgid "Window border theme"
+msgstr "Umxholo womqukumbelo wefestile"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr "Umxholo womfanekiso"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr "ABCDEFG"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+msgid "Apply theme"
+msgstr "Faka umxholo"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+msgid "Sets the default theme"
+msgstr "Imisela umxholo omiselweyo"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr ""
+"Ukuba imiselwe ku-inyani, ngako oko imixholo esekiweyo iza kwenziwa ityhilwe "
+"ngokukhawulezayo."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr ""
+"Ukuba imiselwe ku-inyani, ngako oko imixholo iza kwenziwa ityhileke "
+"ngokukhawulezileyo."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+"Misela eli qhosha kumyalelo osetyenzisiweyo ukudala ukutyhila okukhawulezayo "
+"kwemixholo."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr "Yenza ukutyhila okukhawulezayo komyalelo kwemixholo okusekiweyo"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr "Ukutyhila okukhawulezayo kwemixholo"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr "Nokuba ngaba kwenziwe ukutyhila okukhawulezayo kwemixholo esekiweyo"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr "Nokuba ngaba kwenziwe ukutyhila okukhawulezayo kwemixholo"
+
+msgid "Show help options"
+msgstr "Bonisa amancedo anokukhethwa"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -33,9 +33,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center master\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2022-08-28 21:16+0800\n"
 "Last-Translator: lumingzh <lumingzh@qq.com>\n"
 "Language-Team: Chinese - China <i18n-zh@googlegroups.com>\n"
@@ -46,98 +45,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "X-Generator: Gtranslator 42.0\n"
 
-#: panels/applications/cc-applications-panel.c:822
-msgid "System Bus"
-msgstr "系统总线"
-
-#: panels/applications/cc-applications-panel.c:822
-#: panels/applications/cc-applications-panel.c:824
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:842
-msgid "Full access"
-msgstr "完全访问"
-
-#: panels/applications/cc-applications-panel.c:824
-msgid "Session Bus"
-msgstr "会话总线"
-
-#: panels/applications/cc-applications-panel.c:828
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
-#: panels/thunderbolt/cc-bolt-panel.ui:309
-msgid "Devices"
-msgstr "设备"
-
-#: panels/applications/cc-applications-panel.c:828
-msgid "Full access to /dev"
-msgstr "对 /dev 的完全访问"
-
-#: panels/applications/cc-applications-panel.c:832
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "网络"
-
-#: panels/applications/cc-applications-panel.c:832
-msgid "Has network access"
-msgstr "拥有网络访问"
-
-#: panels/applications/cc-applications-panel.c:837
-#: panels/applications/cc-applications-panel.c:839
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "主目录"
-
-#: panels/applications/cc-applications-panel.c:839
-#: panels/applications/cc-applications-panel.c:844
-msgid "Read-only"
-msgstr "只读"
-
-#: panels/applications/cc-applications-panel.c:842
-#: panels/applications/cc-applications-panel.c:844
-msgid "File System"
-msgstr "文件系统"
-
-#: panels/applications/cc-applications-panel.c:848
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:880 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "设置"
-
-#: panels/applications/cc-applications-panel.c:848
-msgid "Can change settings"
-msgstr "可以更改设置"
-
-#: panels/applications/cc-applications-panel.c:850
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s 拥有以下内置权限。这些无法被更改。如果您在意这些权限，请考虑移除该应用程"
-"序。"
-
-#: panels/applications/cc-applications-panel.c:1192
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "%u 个文件和链接类型可以被该应用打开"
-
-#: panels/applications/cc-applications-panel.c:1199
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> 用来打开下列文件和链接类型。"
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1251
-#, c-format
-msgid "%s of disk space used."
-msgstr "已占用 %s 磁盘空间。"
-
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1415
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
@@ -153,7 +61,6 @@ msgid "Install some…"
 msgstr "安装一些…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "打开"
 
@@ -177,24 +84,13 @@ msgstr "搜索"
 msgid "Receive system searches and send results."
 msgstr "接收系统搜索并发送结果。"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
 #: panels/applications/cc-applications-panel.ui:163
 #: panels/applications/cc-applications-panel.ui:184
 #: panels/applications/cc-applications-panel.ui:198
 #: panels/applications/cc-applications-panel.ui:212
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
-#: panels/user-accounts/cc-user-panel.c:804
-#: panels/user-accounts/cc-user-panel.c:907
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "已禁用"
 
@@ -359,80 +255,20 @@ msgstr "清空缓存…"
 msgid "Control various application permissions and settings"
 msgstr "控制不同应用程序权限和设置"
 
-#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
 msgstr "application;flatpak;permission;setting;应用程序;权限;设置;"
-
-#: panels/background/cc-background-chooser.c:312
-msgid "Select a picture"
-msgstr "选择图片"
-
-#: panels/background/cc-background-chooser.c:315
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:218
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/cc-wifi-hotspot-dialog.ui:125
-#: panels/network/cc-wifi-panel.c:886
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:866
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:269
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:20
-#: panels/user-accounts/cc-user-panel.c:594
-#: panels/user-accounts/cc-user-panel.c:612
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:108
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
-msgid "_Cancel"
-msgstr "取消(_C)"
-
-#: panels/background/cc-background-chooser.c:316
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:270
-#: panels/sharing/cc-sharing-panel.c:523
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "打开(_O)"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "多个尺寸"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "无桌面背景"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "当前背景"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "样式"
 
 #: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
 #: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 msgid "Default"
 msgstr "默认"
 
@@ -456,7 +292,6 @@ msgstr "外观"
 msgid "Change your background image or the UI colors"
 msgstr "更改您的背景图像或用户界面配色"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
 msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
@@ -509,9 +344,7 @@ msgstr "硬件飞行模式已打开"
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "关闭飞行模式开关以开启蓝牙。"
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "蓝牙"
 
@@ -519,7 +352,6 @@ msgstr "蓝牙"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "开关蓝牙及连接您的设备"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;分享;共享;蓝牙;"
@@ -552,91 +384,35 @@ msgstr "没有应用程序要求访问摄像头"
 msgid "Protect your pictures"
 msgstr "保护您的图片"
 
-#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
 msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
 "camera;photos;video;webcam;lock;private;privacy;相机;摄像头;照片;视频;网络摄"
 "像头;锁定;私人;隐私;"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "将您的校准设备放在方块上并按“开始”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "将您的校准器移动到校准位置并按“继续”"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "将您的校准器移动到表面位置并按“继续”"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "合上笔记本盖子"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "发生了一个无法恢复的内部错误。"
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "未安装校准所需的工具。"
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "无法生成配置。"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "无法获取目标白点。"
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "完成！"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "校准失败！"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "您现在可以移除校准设备。"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "校准过程中不要干扰校准设备"
-
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "显示校准"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "取消(_C)"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -653,138 +429,6 @@ msgstr "恢复(_R)"
 #: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "完成(_D)"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "笔记本屏幕"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "内置摄像头"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s 显示器"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s 扫描仪"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s 相机"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s 打印机"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s 摄像头"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "为 %s 启用色彩管理"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "为 %s 显示颜色管理"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "未校准"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "默认："
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "色彩空间："
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "测试配置："
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "选择 ICC 配置文件"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "导入(_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "支持的 ICC 配置"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "所有文件"
-
-#: panels/color/cc-color-panel.c:586
-#: panels/screen/gnome-screen-panel.desktop.in.in:3
-msgid "Screen"
-msgstr "屏幕"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "保存配置"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "保存(_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "为选中的设备创建一份色彩配置"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "未检测到测量仪器，请检查仪器是否已打开并已正确连接。"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "测量仪器不支持打印机校正。"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "目前不支持此设备类型。"
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -891,9 +535,9 @@ msgstr "需要可写介质"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
 "有关如何在 <a href=\"linux\">GNU/Linux</a>、<a href=\"osx\">Apple OS X</a> "
 "和 <a href=\"windows\">Microsoft Windows</a> 系统中使用配置的这些说明可能对您"
@@ -915,7 +559,6 @@ msgstr "导入文件(_I)…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
-#: panels/network/connection-editor/net-connection-editor.c:503
 #: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
@@ -925,9 +568,7 @@ msgstr "添加(_A)"
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "每个设备都需要一份最新色彩配置以进行色彩管理。"
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "了解更多"
 
@@ -1059,82 +700,6 @@ msgstr "D65（摄影及图形）"
 msgid "D75"
 msgstr "D75"
 
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "标准空间"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "测试配置"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "自动"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "低质量"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "中等质量"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "高质量"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "默认 RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "默认 CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "默认灰度"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "生产商提供的工厂校准数据"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "无法使用此配置进行全屏显示校准"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "此配置可能已不准确"
-
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "色彩"
@@ -1144,15 +709,10 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "校准显示器、相机、打印机等设备的色彩"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
 "Color;ICC;Profile;Calibrate;Printer;Display;颜色;色彩;配置;校准;打印机;显示;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "其他…"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1167,13 +727,8 @@ msgid "No languages found"
 msgstr "未找到语言"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "更多…"
-
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "解锁以更改设置"
 
 #: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
@@ -1202,148 +757,6 @@ msgstr "减少小时"
 #: panels/common/cc-time-editor.ui:122
 msgid "Decrement Minute"
 msgstr "减少分钟"
-
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:168
-msgid "Today"
-msgstr "今天"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:170
-msgid "Yesterday"
-msgstr "昨天"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%-m月%-d日"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%Y年%-m月%-d日"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d 小时"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d 分钟"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d 秒"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 秒"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "热点"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24 小时"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "上午/下午"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%Y年%m月%d日，%p %-l:%M"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%Y年%m月%d日，%R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s，%s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s（%s）"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%p %-l:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
 
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
@@ -1438,17 +851,11 @@ msgstr "自动设置时区(_Z)"
 msgid "Requires location services enabled and internet access"
 msgstr "需要启用定位服务和互联网连接"
 
-#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
-#. TRANSLATORS: Status of Parental Controls setup
 #: panels/datetime/cc-datetime-panel.ui:212
 #: panels/display/cc-display-settings.ui:23
-#: panels/firmware-security/cc-firmware-security-utils.c:247
-#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
 #: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
-#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
-#: panels/user-accounts/cc-user-panel.c:802
-#: panels/user-accounts/cc-user-panel.c:904
-#: panels/wwan/cc-wwan-device-page.c:476
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
 msgid "Enabled"
 msgstr "已启用"
 
@@ -1456,15 +863,42 @@ msgstr "已启用"
 msgid "Time Z_one"
 msgstr "时区(_O)"
 
-#: panels/datetime/cc-datetime-panel.ui:245
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "解锁"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "时间格式(_F)"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "日期"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 秒"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "日历"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "数字"
 
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "改变日期、时间和时区"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;时钟;时区;位置;"
@@ -1510,18 +944,9 @@ msgstr "默认应用程序"
 msgid "Configure Default Applications"
 msgstr "配置默认应用程序"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "default;application;preferred;media;默认;应用程序;首选;偏好;媒体;介质;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr "发送匿名的技术问题报告能帮助我们改进 %s，这些报告中不含个人数据。%s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1539,44 +964,9 @@ msgstr "诊断"
 msgid "Report your problems"
 msgstr "报告问题"
 
-#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
 msgid "diagnostics;crash;"
 msgstr "diagnostics;crash;诊断;崩溃;"
-
-#: panels/display/cc-display-panel.c:492
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "开"
-
-#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "关"
-
-#: panels/display/cc-display-panel.c:930
-msgid "Apply Changes?"
-msgstr "应用更改？"
-
-#: panels/display/cc-display-panel.c:935
-msgid "Changes Cannot be Applied"
-msgstr "无法应用更改"
-
-#: panels/display/cc-display-panel.c:937
-msgid "This could be due to hardware limitations."
-msgstr "这可能是硬件限制造成的。"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
@@ -1626,31 +1016,6 @@ msgstr "主显示器"
 msgid "Night Light"
 msgstr "夜灯"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "横向"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "纵向，朝右"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "纵向，朝左"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "横向翻转"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf 赫兹"
-
 #: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
@@ -1674,6 +1039,17 @@ msgstr "为电视调整"
 msgctxt "display setting"
 msgid "Scale"
 msgstr "缩放"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "自然滚动"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
 
 #: panels/display/cc-night-light-page.ui:22
 msgid "Night Light unavailable"
@@ -1765,7 +1141,6 @@ msgstr "显示器"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "选择如何使用接入的显示器和投影仪"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1774,71 +1149,6 @@ msgstr ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
 "redshift;color;sunset;sunrise;面板;投影仪;屏幕;分辨率;刷新;夜晚;晚上;光;蓝;红"
 "移;颜色;日落;日出;"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
-#: panels/firmware-security/cc-firmware-security-panel.c:109
-msgid "Secure Boot is Active"
-msgstr "安全启动已激活"
-
-#. TRANSLATORS: this is the first section of the decription
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on and is functioning correctly."
-msgstr "安全启动会在设备启动时阻止恶意软件加载。安全启动当前已开启并正确工作。"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
-msgid "Secure Boot Has Problems"
-msgstr "安全启动有问题"
-
-#. TRANSLATORS: this is the first section of the decription.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned on, but will not work due to having an "
-"invalid key."
-msgstr ""
-"安全启动会在设备启动时阻止恶意软件加载。安全启动当前已开启但因密钥无效无法工"
-"作。"
-
-#. TRANSLATORS: this is the second section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
-msgid ""
-"Secure boot problems can often be resolved from your computer's UEFI "
-"firmware settings (BIOS) and your hardware manufacturer may provide "
-"information on how to do this."
-msgstr ""
-"安全启动的问题通常可以从您计算机的 UEFI 固件设置（BIOS）解决且您的硬件厂商可"
-"能会提供如何操作的信息。"
-
-#. TRANSLATORS: this is the third section of description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
-msgid "For help, contact your hardware manufacturer or IT support provider."
-msgstr "要寻求帮助，请联系您的硬件厂商或 IT 支持提供者。"
-
-#. TRANSLATORS: secure boot refers to the system firmware security mode
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
-msgid "Secure Boot is Turned Off"
-msgstr "安全启动已关闭"
-
-#. TRANSLATORS: this is the first section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
-msgid ""
-"Secure boot prevents malicious software from being loaded when the device "
-"starts. It is currently turned off."
-msgstr "安全启动会在设备启动时阻止恶意软件加载。安全启动当前已关闭。"
-
-#. TRANSLATORS: this is the second section of the description.
-#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
-msgid ""
-"Secure boot can often be turned on from your computer's UEFI firmware "
-"settings (BIOS). For help, contact your hardware manufacturer or IT support "
-"provider."
-msgstr ""
-"安全启动通常可以从您计算机的 UEFI 固件设置（BIOS）开启。要寻求帮助，请联系您"
-"的硬件厂商或 IT 支持提供者。"
 
 #: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
 msgid ""
@@ -1851,122 +1161,9 @@ msgstr ""
 "\n"
 "获取更多信息请联系硬件厂商或 IT 支持。"
 
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Passed"
-msgstr "已通过"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:96
-#: panels/firmware-security/cc-firmware-security-dialog.c:98
-#: panels/firmware-security/cc-firmware-security-dialog.c:100
-msgid "Failed"
-msgstr "已失败"
-
-#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
-#: panels/firmware-security/cc-firmware-security-dialog.c:137
-#, c-format
-msgid "Device conforms to HSI level %d"
-msgstr "设备遵从 HSI 级别 %d"
-
-#. TRANSLATORS: in reference to firmware protection: 0/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:149
-#: panels/firmware-security/cc-firmware-security-panel.c:482
-msgid "Security Level 0"
-msgstr "安全级别 0"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:150
-msgid ""
-"This device has no protection against hardware security issues. This could "
-"be because of a hardware or firmware configuration issue. It is recommended "
-"to contact your IT support provider."
-msgstr ""
-"该设备没有针对硬件安全问题的保护。这可能是因为硬件或固件配置问题。推荐联系您"
-"的 IT 支持提供者。"
-
-#. TRANSLATORS: in reference to firmware protection: 1/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:158
-#: panels/firmware-security/cc-firmware-security-dialog.c:357
-#: panels/firmware-security/cc-firmware-security-panel.c:489
-msgid "Security Level 1"
-msgstr "安全级别 1"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:159
-msgid ""
-"This device has minimal protection against hardware security issues. This is "
-"the lowest device security level and only provides protection against simple "
-"security threats."
-msgstr ""
-"该设备具有针对硬件安全问题的最小化保护。这是最低的设备安全级别且仅提供对简单"
-"安全威胁的保护。"
-
-#. TRANSLATORS: in reference to firmware protection: 2/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:167
-#: panels/firmware-security/cc-firmware-security-dialog.c:362
-#: panels/firmware-security/cc-firmware-security-panel.c:496
-msgid "Security Level 2"
-msgstr "安全级别 2"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:168
-msgid ""
-"This device has basic protection against hardware security issues. This "
-"provides protection against some common security threats."
-msgstr ""
-"该设备具有针对硬件安全问题的基本保护。这提供了对一些常见安全威胁的保护。"
-
-#. TRANSLATORS: in reference to firmware protection: 3/4 stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:176
-#: panels/firmware-security/cc-firmware-security-dialog.c:367
-#: panels/firmware-security/cc-firmware-security-panel.c:503
-msgid "Security Level 3"
-msgstr "安全级别 3"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:177
-msgid ""
-"This device has extended protection against hardware security issues. This "
-"is the highest device security level and provides protection against "
-"advanced security threats."
-msgstr ""
-"该设备具有针对硬件安全问题的扩展保护。这是最高的设备安全级别且提供了对高级安"
-"全威胁的保护。"
-
-#. TRANSLATORS: in reference to firmware protection: ??? stars
-#: panels/firmware-security/cc-firmware-security-dialog.c:185
 #: panels/firmware-security/cc-firmware-security-dialog.ui:22
-#: panels/firmware-security/cc-firmware-security-panel.c:518
 msgid "Security Level"
 msgstr "安全级别"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:186
-#: panels/firmware-security/cc-firmware-security-panel.c:519
-msgid "Security levels are not available for this device."
-msgstr "安全级别对该设备不可用。"
-
-#. TRANSLATORS: hardware manufacturer as in OEM
-#: panels/firmware-security/cc-firmware-security-dialog.c:201
-#: panels/firmware-security/cc-firmware-security-dialog.c:211
-#: panels/firmware-security/cc-firmware-security-dialog.c:218
-msgid "Contact your hardware manufacturer for help with security updates."
-msgstr "请联系您的硬件厂商获取有关安全更新的帮助。"
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:203
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings, or by a support technician."
-msgstr "在该设备的 UEFI 固件设置中有可能会解决该问题，或寻求支持技术员的帮助。"
-
-#: panels/firmware-security/cc-firmware-security-dialog.c:212
-#: panels/firmware-security/cc-firmware-security-dialog.c:223
-msgid ""
-"It might be possible to resolve this issue in the device’s UEFI firmware "
-"settings."
-msgstr "在该设备的 UEFI 固件设置中有可能会解决该问题。"
-
-#. TRANSLATORS: support technician as in someone with root
-#: panels/firmware-security/cc-firmware-security-dialog.c:229
-msgid "It might be possible for a support technician to resolve this issue."
-msgstr "支持技术员有可能会解决该问题。"
 
 #: panels/firmware-security/cc-firmware-security-dialog.ui:88
 msgid "Level 1"
@@ -1980,333 +1177,9 @@ msgstr "2 级"
 msgid "Level 3"
 msgstr "3 级"
 
-#: panels/firmware-security/cc-firmware-security-panel.c:110
-msgid "Protected against malicious software when the device starts."
-msgstr "设备启动时针对恶意软件的保护。"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:116
-msgid "Secure Boot has Problems"
-msgstr "安全启动有问题"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:117
-msgid "Some protection when the device is started."
-msgstr "设备启动时的一些保护。"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:122
-msgid "Secure Boot is Off"
-msgstr "安全启动已关闭"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:123
-msgid "No protection when the device is started."
-msgstr "设备启动时没有保护。"
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:142
-msgid ""
-"This issue could have been caused by a change in UEFI firmware settings, an "
-"operating system configuration change, or because of malicious software on "
-"this system."
-msgstr ""
-"该问题可能由 UEFI 固件设置中的更改，操作系统配置的更改，或系统上的恶意软件等"
-"所造成。"
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:150
-msgid ""
-"This issue could have been caused by a change in the UEFI firmware settings, "
-"or because of malicious software on this system."
-msgstr "该问题可能由 UEFI 固件设置中的更改，或系统上的恶意软件等所造成。"
-
-#. TRANSLATORS: this is to explain an event that has already happened
-#: panels/firmware-security/cc-firmware-security-panel.c:157
-msgid ""
-"This issue could have been caused by an operating system configuration "
-"change, or because of malicious software on this system."
-msgstr "该问题可能由操作系统配置的更改，或系统上的恶意软件等所造成。"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:483
-msgid "Exposed to serious security threats."
-msgstr "暴露于严重的安全威胁。"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:490
-msgid "Limited protection against simple security threats."
-msgstr "对简单安全威胁的有限保护。"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:497
-msgid "Protected against common security threats."
-msgstr "对常见安全威胁的保护。"
-
-#: panels/firmware-security/cc-firmware-security-panel.c:504
-#: panels/firmware-security/cc-firmware-security-panel.c:512
-msgid "Protected against a wide range of security threats."
-msgstr "对宽泛安全威胁的保护。"
-
-#. TRANSLATORS: in reference to firmware protection: 4/4 stars
-#: panels/firmware-security/cc-firmware-security-panel.c:511
-msgid "Comprehensive Protection"
-msgstr "全面保护"
-
 #: panels/firmware-security/cc-firmware-security-panel.ui:150
 msgid "No Events"
 msgstr "无事件"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:37
-msgid "Firmware Write Protection"
-msgstr "固件写入保护"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:42
-msgid "Firmware Write Protection Lock"
-msgstr "固件写入保护锁"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:47
-msgid "Firmware BIOS Region"
-msgstr "固件 BIOS 区域"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-#: panels/firmware-security/cc-firmware-security-utils.c:52
-msgid "Firmware BIOS Descriptor"
-msgstr "固件 BIOS 描述符"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-#: panels/firmware-security/cc-firmware-security-utils.c:57
-msgid "Pre-boot DMA Protection"
-msgstr "预启动 DMA 保护"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:62
-msgid "Intel BootGuard"
-msgstr "英特尔启动卫士"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-#: panels/firmware-security/cc-firmware-security-utils.c:68
-msgid "Intel BootGuard Verified Boot"
-msgstr "英特尔启动卫士验证的启动"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-#: panels/firmware-security/cc-firmware-security-utils.c:74
-msgid "Intel BootGuard ACM Protected"
-msgstr "英特尔启动卫士 ACM 保护"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-#: panels/firmware-security/cc-firmware-security-utils.c:80
-msgid "Intel BootGuard Error Policy"
-msgstr "英特尔启动卫士错误策略"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-#: panels/firmware-security/cc-firmware-security-utils.c:85
-msgid "Intel BootGuard Fuse"
-msgstr "英特尔启动卫士保险"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-#: panels/firmware-security/cc-firmware-security-utils.c:91
-msgid "Intel CET Enabled"
-msgstr "英特尔 CET 已启用"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * active means being used by the OS
-#: panels/firmware-security/cc-firmware-security-utils.c:97
-msgid "Intel CET Active"
-msgstr "英特尔 CET 已激活"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-#: panels/firmware-security/cc-firmware-security-utils.c:102
-msgid "Intel SMAP"
-msgstr "英特尔 SMAP"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-#: panels/firmware-security/cc-firmware-security-utils.c:107
-msgid "Encrypted RAM"
-msgstr "加密的内存"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-#: panels/firmware-security/cc-firmware-security-utils.c:113
-msgid "IOMMU Protection"
-msgstr "IOMMU 保护"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-#: panels/firmware-security/cc-firmware-security-utils.c:118
-msgid "Linux Kernel Lockdown"
-msgstr "Linux 内核封锁"
-
-#. TRANSLATORS: Title: if it's tainted or not
-#: panels/firmware-security/cc-firmware-security-utils.c:123
-msgid "Linux Kernel Verification"
-msgstr "Linux 内核确认"
-
-#. TRANSLATORS: Title: swap space or swap partition
-#: panels/firmware-security/cc-firmware-security-utils.c:128
-msgid "Linux Swap"
-msgstr "Linux 交换空间"
-
-#. TRANSLATORS: Title: sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:133
-msgid "Suspend To RAM"
-msgstr "挂起到内存"
-
-#. TRANSLATORS: Title: a better sleep state
-#: panels/firmware-security/cc-firmware-security-utils.c:138
-msgid "Suspend To Idle"
-msgstr "挂起到空闲"
-
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-#: panels/firmware-security/cc-firmware-security-utils.c:143
-msgid "UEFI Platform Key"
-msgstr "UEFI 平台密钥"
-
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-#: panels/firmware-security/cc-firmware-security-utils.c:148
-msgid "UEFI Secure Boot"
-msgstr "UEFI 安全启动"
-
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
-#: panels/firmware-security/cc-firmware-security-utils.c:153
-msgid "TPM Platform Configuration"
-msgstr "TPM 平台配置"
-
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-#: panels/firmware-security/cc-firmware-security-utils.c:158
-msgid "TPM Reconstruction"
-msgstr "TPM 复原"
-
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-#: panels/firmware-security/cc-firmware-security-utils.c:163
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:168
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "英特尔管理引擎厂商模式"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on consumer
-#. * boards
-#: panels/firmware-security/cc-firmware-security-utils.c:175
-msgid "Intel Management Engine Override"
-msgstr "英特尔管理引擎覆盖"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-#: panels/firmware-security/cc-firmware-security-utils.c:180
-msgid "Intel Management Engine Version"
-msgstr "英特尔管理引擎版本"
-
-#. TRANSLATORS: Title: if firmware updates are available
-#: panels/firmware-security/cc-firmware-security-utils.c:185
-msgid "Firmware Updates"
-msgstr "固件更新"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-#: panels/firmware-security/cc-firmware-security-utils.c:190
-msgid "Firmware Attestation"
-msgstr "固件认证"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-#: panels/firmware-security/cc-firmware-security-utils.c:195
-msgid "Firmware Updater Verification"
-msgstr "固件更新器验证"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-#: panels/firmware-security/cc-firmware-security-utils.c:201
-msgid "Platform Debugging"
-msgstr "平台调试"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-#: panels/firmware-security/cc-firmware-security-utils.c:206
-msgid "Processor Security Checks"
-msgstr "处理器安全检查"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-#: panels/firmware-security/cc-firmware-security-utils.c:211
-msgid "AMD Rollback Protection"
-msgstr "AMD 回滚保护"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-#: panels/firmware-security/cc-firmware-security-utils.c:216
-msgid "AMD Firmware Replay Protection"
-msgstr "AMD 固件重播保护"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-#: panels/firmware-security/cc-firmware-security-utils.c:221
-msgid "AMD Firmware Write Protection"
-msgstr "AMD 固件写入保护"
-
-#. TRANSLATORS: Title: if the part has been fused
-#: panels/firmware-security/cc-firmware-security-utils.c:226
-msgid "Fused Platform"
-msgstr "已熔断的平台"
-
-#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:237
-msgid "Valid"
-msgstr "已验证"
-
-#. TRANSLATORS: if the status or key is not valid.
-#: panels/firmware-security/cc-firmware-security-utils.c:242
-msgid "Not Valid"
-msgstr "未验证"
-
-#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
-#: panels/firmware-security/cc-firmware-security-utils.c:252
-msgid "Not Enabled"
-msgstr "未启用"
-
-#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
-#: panels/firmware-security/cc-firmware-security-utils.c:257
-msgid "Locked"
-msgstr "已锁定"
-
-#. TRANSLATORS: the memory space or system mode is not locked.
-#: panels/firmware-security/cc-firmware-security-utils.c:262
-msgid "Not Locked"
-msgstr "未锁定"
-
-#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
-#: panels/firmware-security/cc-firmware-security-utils.c:267
-msgid "Encrypted"
-msgstr "已加密"
-
-#. TRANSLATORS: the data in memory is plane text.
-#: panels/firmware-security/cc-firmware-security-utils.c:272
-msgid "Not Encrypted"
-msgstr "未加密"
-
-#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
-#: panels/firmware-security/cc-firmware-security-utils.c:277
-msgid "Tainted"
-msgstr "受污染"
-
-#. TRANSLATORS: All the loaded kernel module are licensed.
-#: panels/firmware-security/cc-firmware-security-utils.c:282
-msgid "Not Tainted"
-msgstr "未污染"
-
-#. TRANSLATORS: the feature can be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:287
-msgid "Found"
-msgstr "已找到"
-
-#. TRANSLATORS: the feature can't be detected.
-#: panels/firmware-security/cc-firmware-security-utils.c:292
-msgid "Not Found"
-msgstr "未找到"
-
-#. TRANSLATORS: the function is supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:297
-msgid "Supported"
-msgstr "已支持"
-
-#. TRANSLATORS: the function isn't supported by hardware.
-#: panels/firmware-security/cc-firmware-security-utils.c:302
-msgid "Not Supported"
-msgstr "未支持"
 
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
 msgid "Device Security"
@@ -2316,7 +1189,6 @@ msgstr "设备安全"
 msgid "Host firmware security status"
 msgstr "主机固件安全状态"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
 msgid ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
@@ -2325,49 +1197,6 @@ msgstr ""
 "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
 "network;identity;privacy;屏幕;锁;诊断;崩溃;私有;最近;临时;索引;名称;网络;认"
 "证;标志;身份;隐私;"
-
-#: panels/info-overview/cc-info-overview-panel.c:297
-#: panels/info-overview/cc-info-overview-panel.c:317
-#: panels/info-overview/cc-info-overview-panel.c:358
-#: panels/info-overview/cc-info-overview-panel.c:388
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "未知"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:335
-#, c-format
-msgid "64-bit"
-msgstr "64 位"
-
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:338
-#, c-format
-msgid "32-bit"
-msgstr "32 位"
-
-#: panels/info-overview/cc-info-overview-panel.c:597
-msgid "X11"
-msgstr "X11"
-
-#: panels/info-overview/cc-info-overview-panel.c:601
-msgid "Wayland"
-msgstr "Wayland"
-
-#: panels/info-overview/cc-info-overview-panel.c:603
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "未知"
-
-#. translators: this is the placeholder string when the GNOME Shell
-#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
-#: panels/info-overview/cc-info-overview-panel.c:681
-msgid "Not Available"
-msgstr "不可用"
-
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "系统标志"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
 #: panels/sharing/cc-sharing-panel.ui:304
@@ -2459,11 +1288,6 @@ msgstr "关于"
 msgid "View information about your system"
 msgstr "查看系统信息"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -2543,6 +1367,12 @@ msgstr "启动器"
 msgid "Launch help browser"
 msgstr "启动帮助浏览器"
 
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "设置"
+
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "启动计算器"
@@ -2564,7 +1394,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "搜索"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "系统"
 
@@ -2613,15 +1443,6 @@ msgstr "减小文本字号"
 msgid "High contrast on or off"
 msgstr "高对比度开关"
 
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "无输入源"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "其他"
-
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "添加输入源"
@@ -2654,103 +1475,9 @@ msgstr "首选项"
 msgid "View Keyboard Layout"
 msgstr "查看键盘布局"
 
-#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
-#: panels/sharing/cc-sharing-panel.c:646
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "移除"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "自定义快捷键"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:63
-msgid "Alternate Characters Key"
-msgstr "备用字符键"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr "备用字符键可用于输入其他字符。这些有时会作为第三选项打印在键盘上。"
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "左 Alt 键"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "右 Alt 键"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "左 Super 键"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "右 Super 键"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "菜单键"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "右 Ctrl 键"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:80
-msgid "Compose Key"
-msgstr "Compose 键"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"Compose 键可帮助输入更多种类的字符。如需使用，请按下该键然后按下一串字符序"
-"列。例如，compose 键之后跟着 <b>C</b> 和 <b>o</b> 可以输入 <b>©</b>，<b>a</"
-"b> 后接 <b>'</b> 可以输入 <b>á</b>。"
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "大写锁定"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "滚动锁定"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "打印屏幕"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"使用键盘快捷键 %s 可以切换输入源。\n"
-"这可以在键盘快捷键设置中更改。"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2780,42 +1507,21 @@ msgstr "特殊字符输入"
 msgid "Methods for entering symbols and letter variants using the keyboard."
 msgstr "使用键盘输入符号和字母变体的方法。"
 
-#: panels/keyboard/cc-keyboard-panel.ui:98
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "备用字符键"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose 键"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "键盘快捷键"
 
 #: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "查看及自定义快捷键"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "已修改 %d 个"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid "Reset All Shortcuts?"
-msgstr "重置所有快捷键？"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr "重新设置快捷键可能影响您的自定义快捷键。此操作无法撤销。"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "取消"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
-msgid "Reset All"
-msgstr "全部重置"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
@@ -2853,33 +1559,6 @@ msgstr "添加快捷键"
 msgid "No keyboard shortcut found"
 msgstr "未找到键盘快捷键"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s 已被用于 %s。如果您替换了它，%s 将被禁用"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "输入新的快捷键"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "设置自定义快捷键"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "设置快捷键"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "输入新的快捷键以更改 %s。"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
-msgid "Add Custom Shortcut"
-msgstr "添加自定义快捷键"
-
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
 msgid "_Remove"
 msgstr "移除(_R)"
@@ -2891,7 +1570,6 @@ msgstr "替换(_P)"
 #: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
 #: panels/wwan/cc-wwan-mode-dialog.ui:39
 #: panels/wwan/cc-wwan-network-dialog.ui:115
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
 msgid "_Set"
 msgstr "设置(_S)"
 
@@ -2927,6 +1605,11 @@ msgstr "无"
 msgid "Reset the shortcut to its default value"
 msgstr "重置快捷键为它的默认值"
 
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "使用相机"
+
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
 msgstr "键盘"
@@ -2937,7 +1620,6 @@ msgid ""
 "and input sources"
 msgstr "更改键盘快捷键并设置您的输入首选项、键盘布局和输入源"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
@@ -2978,7 +1660,6 @@ msgstr "没有应用程序要求访问位置"
 msgid "Protect your location information"
 msgstr "保护您的位置信息"
 
-#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/location/gnome-location-panel.desktop.in.in:20
 msgid "location;gps;private;privacy;"
 msgstr "location;gps;private;privacy;位置;定位;私人;隐私;"
@@ -3012,7 +1693,6 @@ msgstr "没有应用程序要求访问麦克风"
 msgid "Protect your conversations"
 msgstr "保护对话"
 
-#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:20
 msgid "microphone;recording;application;privacy;"
 msgstr ""
@@ -3043,81 +1723,140 @@ msgstr "左"
 msgid "Right"
 msgstr "右"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "搜索位置"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "鼠标"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
 msgstr "鼠标速度"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
-#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
-msgid "Natural Scrolling"
-msgstr "自然滚动"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "向下滚动"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
-msgid "Scrolling moves the content, not the view."
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
 msgstr "滚动移动内容而非视图。"
 
-#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
-#: panels/mouse/cc-mouse-panel.ui:106
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "滚动移动内容而非视图。"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "活动"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "触摸板"
 
-#: panels/mouse/cc-mouse-panel.ui:128
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "触摸板速度"
 
-#: panels/mouse/cc-mouse-panel.ui:145
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
 msgstr "轻触以点击"
 
-#: panels/mouse/cc-mouse-panel.ui:150
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
 msgid "Tap to click"
 msgstr "轻触以点击"
 
-#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
-msgid "Two-finger Scrolling"
-msgstr "双指滚动"
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "禁用图像"
 
-#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "触摸板（相对）"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "边缘滚动"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "向下滚动"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "双面"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
 msgstr "尝试单击、双击、滚动"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "点击五次，开始 GEGL！"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "主键双击"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "主键单击"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "中键双击"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "中键单击"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "副键双击"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "副键单击"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -3128,7 +1867,6 @@ msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "改变鼠标和触摸板灵敏度，并选择右手或左手习惯"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
@@ -3208,7 +1946,6 @@ msgstr "多任务"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "管理生产力和多任务的首选项"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
 msgid ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
@@ -3216,20 +1953,11 @@ msgstr ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 "多任务;生产力;自定义;桌面;热区;工作区;"
 
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "抱歉，发生错误。请联系软件提供商。"
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "需要运行 NetworkManager。"
-
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "其他设备"
 
 #: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
-#: panels/network/connection-editor/net-connection-editor.c:586
 msgid "VPN"
 msgstr "VPN"
 
@@ -3241,57 +1969,16 @@ msgstr "添加连接"
 msgid "Not set up"
 msgstr "未设置"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:216
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Insecure network (WEP)"
-msgstr "不安全网络（WEP）"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network (WPA)"
-msgstr "安全网络（WPA）"
-
-#: panels/network/cc-wifi-connection-row.c:283
-msgid "Secure network (WPA2)"
-msgstr "安全网络（WPA2）"
-
-#: panels/network/cc-wifi-connection-row.c:287
-msgid "Secure network (WPA3)"
-msgstr "安全网络（WPA3）"
-
-#: panels/network/cc-wifi-connection-row.c:291
-msgid "Secure network"
-msgstr "安全网络"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "已连接"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
 #: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
 #: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
 #: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "选项…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr "开启热点将从 %s 断开连接，并将无法通过 Wi-Fi 连接网络。"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "至少包含 8 个字符"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
@@ -3339,20 +2026,6 @@ msgstr "自动生成密码"
 msgid "_Turn On"
 msgstr "打开(_T)"
 
-#: panels/network/cc-wifi-panel.c:549
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:884
-msgid "Stop hotspot and disconnect any users?"
-msgstr "停止热点并断开所有用户？"
-
-#: panels/network/cc-wifi-panel.c:887
-msgid "_Stop Hotspot"
-msgstr "停止热点(_S)"
-
 #: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "飞行模式"
@@ -3397,88 +2070,13 @@ msgstr "可见网络"
 msgid "NetworkManager needs to be running"
 msgstr "需要运行 NetworkManager"
 
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "抱歉，发生错误。请联系软件提供商。"
+
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1X 安全性(_S)"
-
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "安全"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "预留"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "永久"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "随机"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "固定"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"此处输入的 MAC 地址将用作此连接激活所在的网络设备的硬件地址。该特性被称为 "
-"MAC 克隆或欺骗。例如：00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "配置 %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:98
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:102
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:108
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:113
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "增强开放"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:131
-msgid "Enterprise"
-msgstr "企业"
-
-#: panels/network/connection-editor/ce-page-details.c:136
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "无"
-
-#: panels/network/connection-editor/ce-page-details.c:157
-msgid "Never"
-msgstr "从不"
 
 #: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
@@ -3486,183 +2084,6 @@ msgstr "从不"
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i 天前"
-
-#: panels/network/connection-editor/ce-page-details.c:299
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:301
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/秒"
-
-#: panels/network/connection-editor/ce-page-details.c:316
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:318
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:320
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "None"
-msgstr "无"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "较弱"
-
-#: panels/network/connection-editor/ce-page-details.c:344
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "一般"
-
-#: panels/network/connection-editor/ce-page-details.c:346
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "良好"
-
-#: panels/network/connection-editor/ce-page-details.c:348
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "非常好"
-
-#: panels/network/connection-editor/ce-page-details.c:415
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 地址"
-
-#: panels/network/connection-editor/ce-page-details.c:416
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
-msgid "IPv6 Address"
-msgstr "IPv6 地址"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/connection-editor/ce-page-details.c:419
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP 地址"
-
-#: panels/network/connection-editor/ce-page-details.c:423
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:424
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:426
-#: panels/network/connection-editor/ce-page-details.c:427
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
-#: panels/network/network-mobile.ui:221
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:479
-msgid "Forget Connection"
-msgstr "忘记连接"
-
-#: panels/network/connection-editor/ce-page-details.c:481
-msgid "Remove Connection Profile"
-msgstr "移除连接配置"
-
-#: panels/network/connection-editor/ce-page-details.c:483
-msgid "Remove VPN"
-msgstr "移除 VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:501
-msgid "Details"
-msgstr "详细信息"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "自动"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "身份"
-
-#: panels/network/connection-editor/ce-page-ip4.c:261
-#: panels/network/connection-editor/ce-page-ip6.c:242
-msgid "Delete Address"
-msgstr "删除地址"
-
-#: panels/network/connection-editor/ce-page-ip4.c:420
-#: panels/network/connection-editor/ce-page-ip6.c:389
-msgid "Delete Route"
-msgstr "删除路由"
-
-#: panels/network/connection-editor/ce-page-ip4.c:770
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:740
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "无"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128 位密钥（Hex 或 ASCII）"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128 位密码"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "动态 WEP (802.1X)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA 和 WPA2 个人"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA 和 WPA2 企业"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3个人"
 
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
@@ -3673,8 +2094,20 @@ msgstr "信号强度"
 msgid "Link speed"
 msgstr "链路速度"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "安全"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 地址"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 地址"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "硬件地址"
 
@@ -3683,12 +2116,17 @@ msgid "Supported Frequencies"
 msgstr "支持频率"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
 #: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "默认路由"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
 
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
@@ -3749,7 +2187,7 @@ msgstr "仅本地链路"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "手动"
 
@@ -3793,9 +2231,8 @@ msgstr "网关"
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
 #: panels/network/connection-editor/ip6-page.ui:237
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "自动"
 
@@ -3848,88 +2285,9 @@ msgstr "自动，仅 DHCP"
 msgid "Prefix"
 msgstr "前缀"
 
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "无法打开连接编辑器"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "新配置"
-
-#: panels/network/connection-editor/net-connection-editor.c:360
-#, c-format
-msgid "Invalid setting %s: %s"
-msgstr "无效的设置 %s：%s"
-
-#: panels/network/connection-editor/net-connection-editor.c:363
-#, c-format
-msgid "Invalid setting %s"
-msgstr "无效的设置 %s"
-
-#: panels/network/connection-editor/net-connection-editor.c:721
-msgid "Import from file…"
-msgstr "从文件导入…"
-
-#: panels/network/connection-editor/net-connection-editor.c:747
-msgid "Add VPN"
-msgstr "添加 VPN"
-
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "安全(_E)"
-
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "无法导入 VPN 连接"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"文件“%s”无法读取或未包含可识别的 VPN 连接信息\n"
-"\n"
-"错误：%s。"
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "选择要导入的文件"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "名为“%s”的文件已存在。"
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "替换(_R)"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "您希望用将要保存的 VPN 连接替换 %s 么？"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "无法导入 VPN 连接"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"无法将 VPN 连接“%s”导出到 %s。\n"
-"\n"
-"错误：%s。"
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "导出 VPN 连接"
 
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
@@ -3943,99 +2301,40 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "网络"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "控制连接到互联网的方式"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;网络;互联网协议;局"
 "域网;代理;广域网;宽带;调制解调器;蓝牙;虚拟专用网;域名系统;"
 
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "控制连接到 Wi-Fi 网络的方式"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;网络;无线;无线保真;"
 "互联网协议;局域网;宽带;域名系统;热点;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "从不"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "今天"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "昨天"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "上次使用"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
 msgstr "有线"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "添加新连接"
-
-#: panels/network/net-device-wifi.c:863
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr "所选网络的细节，包括密码和全部自定义设置都将丢失。"
-
-#: panels/network/net-device-wifi.c:867
-msgid "_Forget"
-msgstr "忘记(_F)"
-
-#: panels/network/net-device-wifi.c:1048
-msgid "Known Wi-Fi Networks"
-msgstr "已知的 Wi-Fi 网络"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1067
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "忘记(_F)"
-
-#: panels/network/net-device-wifi.c:1221
-msgid "System policy prohibits use as a Hotspot"
-msgstr "系统策略禁止作为热点使用"
-
-#: panels/network/net-device-wifi.c:1224
-msgid "Wireless device does not support Hotspot mode"
-msgstr "无线设备不支持热点模式"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "若未提供配置 URL，将使用网络代理自动发现。"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "对于不可信的公共网络，不建议这样做。"
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
@@ -4054,6 +2353,10 @@ msgstr "IMEI"
 #: panels/network/network-mobile.ui:41
 msgid "Provider"
 msgstr "提供者"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP 地址"
 
 #: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
@@ -4138,289 +2441,6 @@ msgstr "打开 Wi-Fi 热点(_T)…"
 msgid "_Known Wi-Fi Networks"
 msgstr "已知的 Wi-Fi 网络(_K)"
 
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "未知状态"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "未托管"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "不可用"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "正在连接"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "需要认证"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "正在断开"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "连接失败"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "未知状态（丢失）"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "配置失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP 配置失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP 配置已过期"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "需要认证凭据，但没有提供"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1X 客户端已断开"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1X 客户端配置失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1X 客户端失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1X 客户端认证耗时过长"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "PPP 服务启动失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP 服务已断开"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP 失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP 客户端启动失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP 客户端错误"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP 客户端失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "共享连接服务启动失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "共享连接服务失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "AutoIP 服务启动失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP 服务出错"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP 服务失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "线路忙"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "无拨号音"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "无法建立载波"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "拨号请求超时"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "拨号尝试失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "调制解调器初始化失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "无法选择指定的 APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "未在搜索网络"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "网络注册被拒绝"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "网络注册超时"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "无法在请求的网络上注册"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN 检查失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "设备可能缺少固件"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "连接丢失"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "已假定为现有连接"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "未找到调制解调器"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "蓝牙连接失败"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "未插入 SIM 卡"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "需要 SIM PIN 码"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "需要 SIM PUK 码"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM 错误"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "连接依赖失败"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "固件缺失"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "线缆已拔出"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "802.1X 安全性里未定义的错误 (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "未选择文件"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "验证 eap-method 文件时发生未知错误"
-
-#: panels/network/wireless-security/eap-method.c:394
-msgid "DER, PEM, PKCS#12, or PGP private keys"
-msgstr "DER、PEM、PKCS#12 或 PGP 私钥"
-
-#: panels/network/wireless-security/eap-method.c:397
-msgid "DER or PEM certificates"
-msgstr "DER 或 PEM 证书"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "缺失 EAP-FAST PAC 文件"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC 文件(*.pac)"
-
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
 #: panels/network/wireless-security/eap-method-ttls.ui:37
@@ -4469,14 +2489,6 @@ msgstr "内部认证(_I)"
 msgid "Allow automatic PAC pro_visioning"
 msgstr "允许自动 PAC 配置(_V)"
 
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "缺失 EAP-LEAP 用户名"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "缺失 EAP-LEAP 密码"
-
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
 #: panels/network/wireless-security/ws-leap.ui:11
@@ -4502,15 +2514,6 @@ msgstr "密码(_P)"
 msgid "Sho_w password"
 msgstr "显示密码(_W)"
 
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "无效的 EAP-PEAP CA 证书：%s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "无效的 EAP-PEAP CA 证书：未指定证书"
-
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
 #: panels/network/wireless-security/ws-wpa-eap.ui:15
@@ -4532,7 +2535,6 @@ msgid "C_A certificate"
 msgstr "C_A 证书"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4547,62 +2549,6 @@ msgstr "不需要 CA 证书(_R)"
 #: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP 版本(_V)"
-
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "缺失 EAP 用户名"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "缺失 EAP 密码"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "缺失 EAP-TLS 身份"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "无效的 EAP-TLS CA 证书：%s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "无效的 EAP-TLS CA 证书：未指定证书"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "无效的 EAP-TLS CA 私钥：%s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "无效的 EAP-TLS 用户证书：%s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "未加密的私钥不安全"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"所选私钥似乎没有密码保护，这可能使您的安全凭据遭到泄露。请选择一个有密码保护"
-"的私钥。\n"
-"\n"
-"（您可以使用 openssl 来对私钥进行密码保护）"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "选择您的个人证书"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "选择您的私钥"
 
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
@@ -4619,15 +2565,6 @@ msgstr "私钥(_K)"
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "私钥密码(_P)"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "无效的 EAP-TTLS CA 证书：%s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "无效的 EAP-TTLS CA 证书：未指定证书"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4650,14 +2587,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "域(_D)"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "验证 802.1X 安全性时发生未知错误"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4685,58 +2623,10 @@ msgstr "受保护的 EAP (PEAP)"
 msgid "Au_thentication"
 msgstr "认证(_T)"
 
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "选择文件"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "缺失 leap-username"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "缺失 leap-password"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "Wi-Fi 密码缺失。"
-
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "类型(_T)"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "缺失 wep-key"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "无效的 wep-key：%zu 长度的密钥只能包含十六进制数字"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "无效的 wep-key：%zu 长度的密钥只能包含 ASCII 字符"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"无效的 wep-key：错误的密钥长度 %zu。密钥必须为长度 5/13 (ASCII) 或者 10/26 "
-"(十六进制)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "无效的 wep-key：密码字段不能为空"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "无效的 wep-key：密码字段必须短于 64 个字符"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4761,18 +2651,6 @@ msgstr "显示密钥(_W)"
 #: panels/network/wireless-security/ws-wep-key.ui:115
 msgid "WEP inde_x"
 msgstr "WEP 索引(_X)"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr ""
-"无效的 wep-psk：无效的密钥长度 %zu。必须为 [8,63] 字节或者 64 位十六进制数字"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "无效的 wep-psk：无法将 64 字节作为十六进制来解析密钥"
 
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
@@ -4825,28 +2703,10 @@ msgstr "锁屏通知(_L)"
 msgid "Control which notifications are displayed and what they show"
 msgstr "控制显示的通知种类及内容"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr ""
 "Notifications;Banner;Message;Tray;Popup;通知;横幅;条幅;消息;托盘;弹出;弹窗;"
-
-#: panels/online-accounts/cc-online-account-provider-row.c:95
-msgctxt "Online Account"
-msgid "Other"
-msgstr "其他"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:280
-#, c-format
-msgid "%s removed"
-msgstr "%s 已移除"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:695
-msgid "Error removing account"
-msgstr "移除帐号出错"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
@@ -4870,17 +2730,6 @@ msgstr "无互联网连接——连接以设置新的在线帐号"
 msgid "Add an account"
 msgstr "添加帐号"
 
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s 帐号"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "移除帐号"
-
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "在线帐号"
@@ -4889,10 +2738,6 @@ msgstr "在线帐号"
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "连接在线帐号并决定如何使用"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4901,10 +2746,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;谷歌;脸谱;脸书;推特;雅虎;互联网;网络;在"
 "线;聊天;日历;邮件;联系人;云存储;稍后阅读;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "未知时间"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4918,13 +2759,6 @@ msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i 小时"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4934,184 +2768,6 @@ msgstr[0] "时"
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "分"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s 后充满"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "注意：剩余 %s 的电量"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "剩余 %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "已充满"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "未充电"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "已耗尽"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "正在充电"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "正在放电"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "无线鼠标"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "无线键盘"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "不间断电源（UPS）"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "个人数字助理（PDA）"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "手机"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "媒体播放器"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "数位板"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "计算机"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "游戏输入设备"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "电池"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "主电池"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "附加电池"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "电池"
-
-#: panels/power/cc-power-panel.c:514
-msgid "When _idle"
-msgstr "空闲时(_I)"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Suspend"
-msgstr "挂起"
-
-#: panels/power/cc-power-panel.c:675
-msgid "Power Off"
-msgstr "电源关闭"
-
-#: panels/power/cc-power-panel.c:676
-msgid "Hibernate"
-msgstr "休眠"
-
-#: panels/power/cc-power-panel.c:677
-msgid "Nothing"
-msgstr "不处理"
-
-#: panels/power/cc-power-panel.c:733
-msgid "When on battery power"
-msgstr "电池供电时"
-
-#: panels/power/cc-power-panel.c:735
-msgid "When plugged in"
-msgstr "插入电源时"
-
-#: panels/power/cc-power-panel.c:856
-msgctxt "Idle time"
-msgid "Never"
-msgstr "从不"
-
-#: panels/power/cc-power-panel.c:940
-msgid "Automatic suspend"
-msgstr "自动挂起"
-
-#: panels/power/cc-power-panel.c:1033
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "由于工作温度高，性能模式暂时禁用。"
-
-#: panels/power/cc-power-panel.c:1035
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr "检测到膝上使用：性能模式暂时不可用。将设备移动到稳定的表面以恢复。"
-
-#: panels/power/cc-power-panel.c:1037
-msgid "Performance mode temporarily disabled."
-msgstr "性能模式暂时禁用。"
-
-#: panels/power/cc-power-panel.c:1079
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr "电池电量低：节电模式已启用。电池充满电时，将恢复之前的模式。"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1087
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "节电模式由“%s”激活。"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1091
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "性能模式由“%s”激活。"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -5172,6 +2828,15 @@ msgstr "100 分钟"
 msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 小时"
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "电池"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "设备"
 
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
@@ -5250,33 +2915,6 @@ msgstr "使用电池时(_B)"
 msgid "Delay"
 msgstr "延迟"
 
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "性能"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "高性能和功耗。"
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "均衡"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "标准性能和功耗。"
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "节电"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "降低性能和功耗。"
-
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
 msgstr "电源"
@@ -5285,7 +2923,6 @@ msgstr "电源"
 msgid "View your battery status and change power saving settings"
 msgstr "查看电池状态并更改省电设置"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
@@ -5295,27 +2932,6 @@ msgstr ""
 "Energy;电源;睡眠;挂起;休眠;电池;亮度;暗;空白;息屏;监视器;显示器;空闲;能源;能"
 "耗;"
 
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:685
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "已删除打印机“%s”"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:942
-msgid "Failed to add new printer."
-msgstr "添加新打印机失败。"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1247
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "无法载入界面：%s"
-
-#: panels/printers/cc-printers-panel.c:1315
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "解锁以添加打印机及更改设置"
-
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "打印机"
@@ -5324,7 +2940,6 @@ msgstr "打印机"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "添加打印机，查看打印任务和管理打印"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr ""
@@ -5334,8 +2949,6 @@ msgstr ""
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "添加打印机"
 
@@ -5374,27 +2987,6 @@ msgstr "输入用户名和密码以查看打印服务器上的打印机。"
 msgid "Username"
 msgstr "用户名"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:76
-#: panels/printers/pp-details-dialog.c:372
-#, c-format
-msgid "%s Details"
-msgstr "%s 详细信息"
-
-#: panels/printers/pp-details-dialog.c:107
-msgid "No suitable driver found"
-msgstr "未找到合适的驱动"
-
-#: panels/printers/pp-details-dialog.c:266
-msgid "Select PPD File"
-msgstr "选择 PPD 文件"
-
-#: panels/printers/pp-details-dialog.c:275
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr "PostScript 打印机描述文件 (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
 #: panels/printers/pp-details-dialog.ui:69
 msgid "Printer names cannot contain SPACE, TAB, #, or /"
 msgstr "打印机名称不能包含空格、制表符、# 或 /"
@@ -5403,9 +2995,7 @@ msgstr "打印机名称不能包含空格、制表符、# 或 /"
 msgid "Location"
 msgstr "位置"
 
-#. Translators: Name of column showing printer drivers
 #: panels/printers/pp-details-dialog.ui:139
-#: panels/printers/pp-ppd-selection-dialog.c:236
 msgid "Driver"
 msgstr "驱动"
 
@@ -5433,139 +3023,19 @@ msgstr "选择打印机驱动"
 msgid "Loading drivers database…"
 msgstr "正在载入驱动数据库…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "取消"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "选择"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect 打印机"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD 打印机"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "单面"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "长边（标准）"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "短边（翻转）"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "纵向"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "横向"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "横向倒转"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "纵向倒转"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Resume"
-msgstr "恢复"
-
-#: panels/printers/pp-job-row.c:55
-msgid "Pause"
-msgstr "暂停"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:144
-msgctxt "print job"
-msgid "Pending"
-msgstr "等待中"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Paused"
-msgstr "已暂停"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:155
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "需要认证"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:160
-msgctxt "print job"
-msgid "Processing"
-msgstr "处理中"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:164
-msgctxt "print job"
-msgid "Stopped"
-msgstr "已停止"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:168
-msgctxt "print job"
-msgid "Canceled"
-msgstr "已取消"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:172
-msgctxt "print job"
-msgid "Aborted"
-msgstr "已中止"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:176
-msgctxt "print job"
-msgid "Completed"
-msgstr "已完成"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:186
-msgid "Move this job to the top of the queue"
-msgstr "将此任务移至队列顶端"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
 msgstr[0] "%u 项任务需要认证"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — 活动任务"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "从 %s 输入凭据以打印。"
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5593,320 +3063,16 @@ msgstr "认证(_A)"
 msgid "No Active Printer Jobs"
 msgstr "没有活动的打印机任务"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "解锁打印服务器"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "解锁 %s。"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "输入用户名和密码以查看 %s 上的打印机。"
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "正在搜索打印机"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "串口"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "并口"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "位置：%s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "地址：%s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "服务器要求认证"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "双面"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "纸张类型"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "纸张来源"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "出纸托盘"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "分辨率"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript 预过滤"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "每面页数"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "双面"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "方向"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "常规"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "页面设置"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "可安装选项"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "任务"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "图像质量"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "色彩"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "正在完成"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "高级"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "测试页"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "测试页"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "自动选择"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "打印机默认设置"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "仅内嵌 GhostScript 字体"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "转换为 PS 等级 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "转换为 PS 等级 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "无预过滤"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "厂商"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "无活动任务"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u 项任务"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "清理喷墨头"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "墨粉不足"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "墨粉用尽"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "显影剂不足"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "显影剂用尽"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "标记墨水不足"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "标记墨水用尽"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "打开上盖"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "打开后盖"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "纸张不足"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "纸张用尽"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "离线"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "已停止"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "废粉仓将满"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "废粉仓已满"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "感光鼓使用寿命已快耗尽"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "感光鼓故障"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "就绪"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "不接收任务"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "正在处理"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5930,6 +3096,10 @@ msgstr "清理喷墨头"
 msgid "Remove Printer"
 msgstr "移除打印机"
 
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "无活动任务"
+
 #: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
@@ -5950,16 +3120,21 @@ msgid "Restart"
 msgstr "重启"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "添加打印机…"
 
-#: panels/printers/printers.ui:160
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "添加打印机…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "无打印机"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:196
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
@@ -5967,7 +3142,6 @@ msgstr ""
 "抱歉，系统打印服务\n"
 "似乎不可用。"
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "格式"
@@ -5995,16 +3169,6 @@ msgstr "搜索可以是国家或语言。"
 #: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "预览"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "英制"
-
-#: panels/region/cc-format-preview.c:139
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "公制"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
@@ -6040,20 +3204,24 @@ msgid ""
 "used for numbers, dates, and currencies."
 msgstr "语言设置用于界面文本和网页。格式用于数字、日期和货币。"
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "您的帐号"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
 #: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "语言(_L)"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "格式(_F)"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "登录屏幕"
 
@@ -6065,100 +3233,9 @@ msgstr "区域与语言"
 msgid "Select your display language and formats"
 msgstr "选择您的显示语言和格式"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;语言;布局;键盘;输入;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "询问如何处理"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "无动作"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "打开文件夹"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "其他介质"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "选择播放音频 CD 的应用程序"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "选择播放视频 DVD 的应用程序"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "选择连接音乐播放器后运行的应用程序"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "选择连接相机后运行的应用程序"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "选择插入软件 CD 时运行的应用程序"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "音频 DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "空白蓝光光盘"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "空白 CD 光盘"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "空白 DVD 光盘"
-
-# 空白 HD DVD 光盘
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "空白 HD DVD 光盘"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "蓝光视频光盘"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "电子书阅读器"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD 视频光盘"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "图片 CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "超级 VCD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "视频 CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows 软件"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
@@ -6208,7 +3285,6 @@ msgstr "可移动介质"
 msgid "Configure Removable Media settings"
 msgstr "配置可移动介质设置"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -6217,114 +3293,6 @@ msgstr ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;设备;系统;默认;应用程序;首选;音频;视频;光盘;光碟;盘"
 "片;可擦写;可移除;可移动;媒体;介质;自动运行;"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:70
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "屏幕关闭"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:73
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 秒"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:76
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 分钟"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:79
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 分钟"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:82
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 分钟"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:85
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 分钟"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:88
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 分钟"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:91
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 小时"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:134
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 分钟"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:137
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 分钟"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:140
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 分钟"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:143
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 分钟"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:146
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 分钟"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:149
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 分钟"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:152
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 分钟"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:155
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 分钟"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:158
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 分钟"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/screen/cc-screen-panel.c:161
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "从不"
 
 #: panels/screen/cc-screen-panel.ui:8
 msgid "Screen Lock"
@@ -6360,40 +3328,40 @@ msgstr "息屏后屏幕自动锁定的时间。"
 msgid "Show _Notifications on Lock Screen"
 msgstr "在锁定屏幕上显示通知(_N)"
 
-#: panels/screen/cc-screen-panel.ui:87
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "锁屏通知(_L)"
+
+#: panels/screen/cc-screen-panel.ui:101
 msgid "Forbid new _USB devices"
 msgstr "禁止新 USB 设备(_U)"
 
-#: panels/screen/cc-screen-panel.ui:88
+#: panels/screen/cc-screen-panel.ui:102
 msgid ""
 "Prevent new USB devices from interacting with the system when the screen is "
 "locked."
 msgstr "在屏幕锁定时阻止新 USB 设备与系统进行交互。"
 
-#: panels/screen/cc-screen-panel.ui:108
+#: panels/screen/cc-screen-panel.ui:122
 msgid "Screen Privacy"
 msgstr "屏幕隐私"
 
-#: panels/screen/cc-screen-panel.ui:113
+#: panels/screen/cc-screen-panel.ui:127
 msgid "Restrict Viewing Angle"
 msgstr "限制可视角度"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "屏幕"
 
 #: panels/screen/gnome-screen-panel.desktop.in.in:4
 msgid "Screen Settings"
 msgstr "屏幕设置"
 
-#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/screen/gnome-screen-panel.desktop.in.in:20
 msgid "screen;lock;private;privacy;"
 msgstr "screen;lock;private;privacy;屏幕;显示器;锁定;私人;隐私;"
-
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "选择位置"
-
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "确定(_O)"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -6422,10 +3390,6 @@ msgstr "其它"
 msgid "Add Location"
 msgstr "添加位置"
 
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "未找到应用"
-
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
 msgstr "应用程序搜索"
@@ -6451,91 +3415,14 @@ msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "控制在活动概览中显示哪些程序的搜索结果"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr ""
 "Search;Find;Index;Hide;Privacy;Results;搜索;查找;寻找;索引;隐藏;隐私;结果;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:268
-msgid "No networks selected for sharing"
-msgstr "未选择要共享的网络"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "网络"
-
-#: panels/sharing/cc-sharing-panel.c:366
-msgctxt "service is enabled"
-msgid "On"
-msgstr "已开启"
-
-#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "已关闭"
-
-#: panels/sharing/cc-sharing-panel.c:398
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "已启用"
-
-#: panels/sharing/cc-sharing-panel.c:401
-msgctxt "service is active"
-msgid "Active"
-msgstr "活动"
-
-#: panels/sharing/cc-sharing-panel.c:519
-msgid "Choose a Folder"
-msgstr "选择文件夹"
-
-#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "添加"
-
-#: panels/sharing/cc-sharing-panel.c:736
-msgid "Enable media sharing"
-msgstr "启用媒体共享"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:756
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr "文件共享可以共享“公共”文件夹，使用地址：%s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:762
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"当启用远程登录时，远程用户可以使用 SSH 命令来连接：\n"
-"%s"
-
-#: panels/sharing/cc-sharing-panel.c:942
-msgid "Enable personal media sharing"
-msgstr "启用个人媒体共享"
-
-#: panels/sharing/cc-sharing-panel.c:1308
-msgid "Device name copied"
-msgstr "设备名称已复制"
-
-#: panels/sharing/cc-sharing-panel.c:1319
-msgid "Device address copied"
-msgstr "设备地址已复制"
-
-#: panels/sharing/cc-sharing-panel.c:1330
-msgid "Username copied"
-msgstr "用户名已复制"
-
-#: panels/sharing/cc-sharing-panel.c:1341
-msgid "Password copied"
-msgstr "密码已复制"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -6660,7 +3547,6 @@ msgstr "文件夹"
 msgid "Control what you want to share with others"
 msgstr "控制想要与其他用户共享的内容"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -6677,10 +3563,6 @@ msgstr "启用或禁用远程登录"
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
 msgstr "启用或禁用远程登录需要认证"
-
-#: panels/sound/cc-alert-chooser.c:153
-msgid "Custom"
-msgstr "自定义"
 
 #: panels/sound/cc-alert-chooser.ui:12
 msgid "Click"
@@ -6713,12 +3595,6 @@ msgstr "后"
 #: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
 msgstr "前"
-
-# 对话框标题
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "测试 %s"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -6772,11 +3648,6 @@ msgstr "音量"
 msgid "Alert Sound"
 msgstr "警报声"
 
-#: panels/sound/cc-volume-slider.c:116
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
 #: panels/sound/cc-volume-slider.ui:22
 msgid "Mute"
 msgstr "静音"
@@ -6789,83 +3660,12 @@ msgstr "声音"
 msgid "Change sound levels, inputs, outputs, and alert sounds"
 msgstr "更改音频音量、音频输入输出和事件声音"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
 msgstr ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;声"
 "卡;麦克风;话筒;音量;淡入淡出;均衡;蓝牙;耳机;耳麦;音频;输出;输入;"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "已断开"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "正在连接"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "已连接"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "认证错误"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "正在认证"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "功能受限"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "已连接并认证"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "未知状态"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "授权于："
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "连接于："
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "登记于："
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "无法授权设备："
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "无法忘记设备："
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
@@ -6898,53 +3698,6 @@ msgstr "认证并连接"
 msgid "Forget Device"
 msgstr "忘记设备"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "错误"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "已授权"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr "雷电接口子系统（boltd）未安装或配置不正确。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:156
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "允许直接访问底座和外置图形处理器一类的设备。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "只能挂接 USB 和 Display Port 设备。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"无法探测到雷电接口。\n"
-"可能是该系统无雷电接口支持，或在 BIOS 中被禁用，抑或是设置成了不被支持的安全"
-"级别。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "雷电接口支持在 BIOS 中被禁用。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "无法确定雷电接口安全级别。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "无法切换为直接模式：%s"
-
 #: panels/thunderbolt/cc-bolt-panel.ui:102
 msgid "No Thunderbolt Support"
 msgstr "无雷电接口支持"
@@ -6956,6 +3709,10 @@ msgstr "无法连接到雷电接口子系统。"
 #: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "直接访问"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "允许直接访问底座和外置图形处理器一类的设备。"
 
 #: panels/thunderbolt/cc-bolt-panel.ui:224
 msgid "Pending Devices"
@@ -6973,7 +3730,6 @@ msgstr "雷电接口"
 msgid "Manage Thunderbolt devices"
 msgstr "管理雷电接口设备"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;雷雳;雷电;隐私;"
@@ -7173,39 +3929,6 @@ msgstr "通过键盘启用(_E)"
 msgid "Turn accessibility features on and off using the keyboard"
 msgstr "通过键盘开关辅助功能特性"
 
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "默认"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "中"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "大"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "更大"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "最大"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d 个像素"
-
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
 msgstr "始终显示辅助功能菜单(_A)"
@@ -7319,31 +4042,6 @@ msgstr "闪烁整个屏幕(_S)"
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
 msgstr "闪烁整个窗口(_W)"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "短"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ 屏幕"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ 屏幕"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ 屏幕"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "长"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
@@ -7500,7 +4198,6 @@ msgstr "色彩效果"
 msgid "Make it easier to see, hear, type, point and click"
 msgstr "辅助视觉、听觉、打字和指点操作"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -7515,114 +4212,6 @@ msgstr ""
 "标;声音;缩放;屏幕;读取器;阅读器;大;高;巨大;文本;文字;字体;大小;粘滞;按键;慢;"
 "回弹;鼠标;双击;点击;单击;延迟;速度;助手;重复;闪烁;可视化;视觉;听觉;音频;输入;"
 "打字;动画;"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 小时"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 天"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "清空回收站中的所有项目吗？"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "回收站内的所有项目将会永久删除。"
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "清空回收站(_E)"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "删除所有临时文件吗？"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "所有临时文件将会永久删除。"
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "清理临时文件(_P)"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 天"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 天"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 天"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "永久"
 
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
@@ -7689,64 +4278,12 @@ msgstr "文件历史与回收站"
 msgid "Don't leave traces"
 msgstr "不留痕迹"
 
-#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
 "usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 "占用;最近;历史;文件;临时;私人;隐私;回收站;垃圾;清除;保留;"
-
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "应与您登录提供商的网络地址相同。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "添加帐号失败"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.ui:114
-msgid "The passwords do not match."
-msgstr "密码不匹配。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "注册用户失败"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "没有支持该域的验证方法"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "加入域失败"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
-msgid ""
-"That login name didn’t work.\n"
-"Please try again."
-msgstr ""
-"登录名不正确。\n"
-"请重试。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"登录密码不正确。\n"
-"请重试。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "登录到域失败"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "找不到该域名，也许拼写有误？"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -7797,10 +4334,6 @@ msgid ""
 msgstr ""
 "企业登录允许在本设备上使用已有的、集中管理的用户帐号。您也可以使用此帐号访问"
 "公司在互联网上的资源。"
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "浏览更多图片"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7867,220 +4400,6 @@ msgstr "删除指纹(_D)"
 msgid "Fingerprint Enroll"
 msgstr "指纹登记"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "设备需要被请求执行该动作"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "设备正被另一个进程请求"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "您没有权限执行该动作"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "没有登记到指纹"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "注册时连接设备失败"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "连接指纹读取器失败"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "连接指纹守护程序失败"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "列出指纹失败：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "删除已保存的指纹失败：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "左手拇指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "左手中指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "左手食指(_L)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "左手无名指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "左手小指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "右手拇指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "右手中指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "右手食指(_R)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "右手无名指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "右手小指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "未知手指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "完成"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "指纹设备已断开连接"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "指纹设备存储已满"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "登记新指纹失败"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "登记过程初始化失败：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "登记新指纹失败"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "停止登记过程失败：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr "要登记指纹，请重复将手指举起然后放置在读取设备上的动作"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "重新登记该手指(_R)…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "扫描新指纹"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "释放指纹设备 %s 失败：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "读取设备时出现问题"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "无法请求指纹设备 %s：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "获取指纹设备失败：%s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "本周"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
-msgstr "上周"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b %e"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%Y %b %e"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:727
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:731
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s，%s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "会话结束"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "会话开始"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — 帐号活动"
-
 #: panels/user-accounts/cc-login-history-dialog.ui:30
 msgid "Previous"
 msgstr "上页"
@@ -8088,18 +4407,6 @@ msgstr "上页"
 #: panels/user-accounts/cc-login-history-dialog.ui:40
 msgid "Next"
 msgstr "下页"
-
-#: panels/user-accounts/cc-password-dialog.c:127
-msgid "Please choose another password."
-msgstr "请选择另一个密码。"
-
-#: panels/user-accounts/cc-password-dialog.c:136
-msgid "Please type your current password again."
-msgstr "请再次输入当前密码。"
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Password could not be changed"
-msgstr "无法更改密码"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
@@ -8121,6 +4428,10 @@ msgstr "新建密码"
 msgid "Confirm Password"
 msgstr "确认密码"
 
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "密码不匹配。"
+
 #: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
 msgstr "允许用户下次登录时更改密码"
@@ -8128,130 +4439,6 @@ msgstr "允许用户下次登录时更改密码"
 #: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
 msgstr "现在设置密码"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "无法自动加入此类域"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "无此域或 Realm"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "无法以 %s 的身份登录域 %s"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "无效密码，请重试"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "无法连接到 %s 域：%s"
-
-#: panels/user-accounts/cc-user-panel.c:356
-msgid "Failed to delete user"
-msgstr "删除用户失败"
-
-#: panels/user-accounts/cc-user-panel.c:413
-#: panels/user-accounts/cc-user-panel.c:468
-#: panels/user-accounts/cc-user-panel.c:514
-msgid "Failed to revoke remotely managed user"
-msgstr "吊销远程管理的用户失败"
-
-#: panels/user-accounts/cc-user-panel.c:563
-msgid "You cannot delete your own account."
-msgstr "不能删除自己的帐号。"
-
-#: panels/user-accounts/cc-user-panel.c:572
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s 已经登录"
-
-#: panels/user-accounts/cc-user-panel.c:576
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "删除已登录帐号可能导致系统不一致。"
-
-#: panels/user-accounts/cc-user-panel.c:585
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "要保留 %s 的文件吗？"
-
-#: panels/user-accounts/cc-user-panel.c:589
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr "删除用户时可以保留其主目录、电子邮件目录和临时文件。"
-
-#: panels/user-accounts/cc-user-panel.c:592
-msgid "_Delete Files"
-msgstr "删除文件(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:593
-msgid "_Keep Files"
-msgstr "保留文件(_K)"
-
-#: panels/user-accounts/cc-user-panel.c:607
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "您确定要吊销远程管理的帐号 %s 吗？"
-
-#: panels/user-accounts/cc-user-panel.c:611
-msgid "_Delete"
-msgstr "删除(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:661
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "帐号已禁用"
-
-#: panels/user-accounts/cc-user-panel.c:669
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "下次登录时设置"
-
-#: panels/user-accounts/cc-user-panel.c:672
-msgctxt "Password mode"
-msgid "None"
-msgstr "无"
-
-#: panels/user-accounts/cc-user-panel.c:715
-msgid "Logged in"
-msgstr "已登录"
-
-#: panels/user-accounts/cc-user-panel.c:1202
-msgid "Failed to contact the accounts service"
-msgstr "联系帐号服务失败"
-
-#: panels/user-accounts/cc-user-panel.c:1204
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "请确定帐号服务已正确安装并启用。"
-
-#: panels/user-accounts/cc-user-panel.c:1226
-msgid "This panel must be unlocked to change this setting"
-msgstr "该面板必须解锁才能更改设置"
-
-#: panels/user-accounts/cc-user-panel.c:1293
-msgid "Delete the selected user account"
-msgstr "删除选中的用户帐号"
-
-#: panels/user-accounts/cc-user-panel.c:1297
-#: panels/user-accounts/cc-user-panel.c:1409
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"要删除选中的用户帐号，\n"
-"请先点击 * 图标"
-
-#: panels/user-accounts/cc-user-panel.c:1455
-msgid "Unlock to Add Users and Change Settings"
-msgstr "解锁以允许用户更改设置"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
@@ -8279,7 +4466,6 @@ msgid "Full name"
 msgstr "全名"
 
 #: panels/user-accounts/cc-user-panel.ui:171
-#: panels/wwan/cc-wwan-apn-dialog.c:295
 msgid "Edit"
 msgstr "编辑"
 
@@ -8339,7 +4525,6 @@ msgstr "解锁以添加用户帐号。"
 msgid "Add or remove users and change your password"
 msgstr "添加或删除用户及更改密码"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -8384,170 +4569,6 @@ msgstr "管理用户帐号"
 msgid "Authentication is required to change user data"
 msgstr "改变用户数据需要认证"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "新密码不能和旧密码相同。"
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "请改动一些字母和数字。"
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "请进一步修改密码。"
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "不包含用户名的密码更安全。"
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "请勿在密码中使用您的名字。"
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "请勿在密码中使用单词。"
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "请勿使用常用单词。"
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "请勿仅变更现有单词顺序。"
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "请使用更多数字。"
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "请使用更多大写字母。"
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "请使用更多小写字母。"
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "请使用更多特殊字符，如标点符号。"
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "请混用字母、数字和标点符号。"
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "请避免重复相同的字符。"
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr "请避免重复相同类型的字符：你需要混合字母、数字和标点符号。"
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "请避免使用如 1234 或 abcd 的有规律序列。"
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr "需要更长的密码。请试着加入更多的字母、数字和标点符号。"
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "密码需要大小写字母混用并试着使用一到两个数字。"
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "增加更多字母、数字和标点可进一步提高密码强度。"
-
-#: panels/user-accounts/run-passwd.c:401
-msgid "Authentication failed"
-msgstr "认证失败"
-
-#: panels/user-accounts/run-passwd.c:480
-#, c-format
-msgid "The new password is too short"
-msgstr "新密码太短"
-
-#: panels/user-accounts/run-passwd.c:486
-#, c-format
-msgid "The new password is too simple"
-msgstr "新密码太简单"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "新密码和旧密码太相似"
-
-#: panels/user-accounts/run-passwd.c:495
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "新的密码最近已使用过。"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "新密码必须包含数字或特殊字符"
-
-#: panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "新旧密码相同"
-
-#: panels/user-accounts/run-passwd.c:506
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "密码在您首次认证后已经更改！"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "新密码必须一定量不同的字符"
-
-#: panels/user-accounts/run-passwd.c:514
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "未知错误"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr "用户名只能包含小写英文字母（a 至 z）、数字和“-”、“_”符号"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "抱歉，该用户名不可用。请试下别的。"
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "用户名太长。"
-
 #: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
 #: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
@@ -8579,52 +4600,10 @@ msgstr "请触摸屏幕上出现的标记以校准平板电脑。"
 msgid "Mis-click detected, restarting…"
 msgstr "检测到误点击，重新开始校准…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "按键 %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "应用程序定义"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "发送按键"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "切换显示器"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "显示屏幕帮助"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "数位板已挂载在笔记本屏幕上"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "数位板已挂载在外部显示器上"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
-msgstr "外部数位板设备"
-
 #. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
 #: panels/wacom/cc-wacom-ekr-page.ui:9
 msgid "External pad device"
 msgstr "外部平板设备"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "全部显示器"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -8721,22 +4700,6 @@ msgstr "鼠标右键单击"
 msgid "Forward"
 msgstr "前进"
 
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "具有压感、倾斜和集成滑块的喷枪笔"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "具有压感、倾斜和旋转的喷枪笔"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "具有压感和倾斜的标准笔"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "具有压感的标准笔"
-
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
 msgstr "Wacom 数位板"
@@ -8745,56 +4708,98 @@ msgstr "Wacom 数位板"
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
 msgstr "为绘图用平板设备设置按键映射并调整触控笔灵敏度"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr ""
 "Tablet;Wacom;Stylus;Eraser;Mouse;数位板;绘图板;绘画板;手绘板;手写板;触控笔;橡"
 "皮擦;擦除器;鼠标;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "新建快捷键…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "模拟副键点击(_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows 软件"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "墨粉不足"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "副显示器"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows 软件"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "管理生产力和多任务的首选项"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "接入点"
 
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "添加"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "保存(_S)"
+
 #: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "操作已取消"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>错误：</b>更改设置被拒绝"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>错误：</b>移动设备错误"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "未注册"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "已注册"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "漫游中"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "搜索中"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "已拒绝"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8824,212 +4829,13 @@ msgstr "所有号码"
 msgid "Device Details"
 msgstr "设备详细信息"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "厂商"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "固件版本"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "仅 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "仅 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "仅 4G"
-
-#: panels/wwan/cc-wwan-device.c:997
-msgid "5G Only"
-msgstr "仅 5G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G, 3G, 4G, 5G (Preferred)"
-msgstr "2G、3G、4G、5G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G (Preferred), 5G"
-msgstr "2G、3G、4G（首选）、5G"
-
-#: panels/wwan/cc-wwan-device.c:1011
-msgid "2G, 3G (Preferred), 4G, 5G"
-msgstr "2G、3G（首选）、4G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1013
-msgid "2G (Preferred), 3G, 4G, 5G"
-msgstr "2G（首选）、3G、4G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "2G, 3G, 4G, 5G"
-msgstr "2G、3G、4G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1022
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G、3G、4G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1024
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G、3G（首选）、4G"
-
-#: panels/wwan/cc-wwan-device.c:1026
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G（首选）、3G、4G"
-
-#: panels/wwan/cc-wwan-device.c:1028
-msgid "2G, 3G, 4G"
-msgstr "2G、3G、4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "3G, 4G, 5G (Preferred)"
-msgstr "3G、4G、5G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "3G, 4G (Preferred), 5G"
-msgstr "3G、4G（首选）、5G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "3G (Preferred), 4G, 5G"
-msgstr "3G（首选）、4G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1041
-msgid "3G, 4G, 5G"
-msgstr "3G、4G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1048
-msgid "2G, 4G, 5G (Preferred)"
-msgstr "2G、4G、5G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1050
-msgid "2G, 4G (Preferred), 5G"
-msgstr "2G、4G（首选）、5G"
-
-#: panels/wwan/cc-wwan-device.c:1052
-msgid "2G (Preferred), 4G, 5G"
-msgstr "2G（首选）、4G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1054
-msgid "2G, 4G, 5G"
-msgstr "2G、4G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1061
-msgid "2G, 3G, 5G (Preferred)"
-msgstr "2G、3G、5G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1063
-msgid "2G, 3G (Preferred), 5G"
-msgstr "2G、3G（首选）、5G"
-
-#: panels/wwan/cc-wwan-device.c:1065
-msgid "2G (Preferred), 3G, 5G"
-msgstr "2G（首选）、3G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1067
-msgid "2G, 3G, 5G"
-msgstr "2G、3G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1073
-msgid "3G, 4G (Preferred)"
-msgstr "3G、4G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1075
-msgid "3G (Preferred), 4G"
-msgstr "3G（首选）、4G"
-
-#: panels/wwan/cc-wwan-device.c:1077
-msgid "3G, 4G"
-msgstr "3G、4G"
-
-#: panels/wwan/cc-wwan-device.c:1083
-msgid "2G, 4G (Preferred)"
-msgstr "2G、4G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1085
-msgid "2G (Preferred), 4G"
-msgstr "2G（首选）、4G"
-
-#: panels/wwan/cc-wwan-device.c:1087
-msgid "2G, 4G"
-msgstr "2G、4G"
-
-#: panels/wwan/cc-wwan-device.c:1093
-msgid "2G, 3G (Preferred)"
-msgstr "2G、3G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1095
-msgid "2G (Preferred), 3G"
-msgstr "2G（首选）、3G"
-
-#: panels/wwan/cc-wwan-device.c:1097
-msgid "2G, 3G"
-msgstr "2G、3G"
-
-#: panels/wwan/cc-wwan-device.c:1103
-msgid "2G, 5G (Preferred)"
-msgstr "2G、5G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1105
-msgid "2G (Preferred), 5G"
-msgstr "2G（首选）、5G"
-
-#: panels/wwan/cc-wwan-device.c:1107
-msgid "2G, 5G"
-msgstr "2G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1113
-msgid "3G, 5G (Preferred)"
-msgstr "3G、5G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1115
-msgid "3G (Preferred), 5G"
-msgstr "3G（首选）、5G"
-
-#: panels/wwan/cc-wwan-device.c:1117
-msgid "3G, 5G"
-msgstr "3G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1123
-msgid "4G, 5G (Preferred)"
-msgstr "4G、5G（首选）"
-
-#: panels/wwan/cc-wwan-device.c:1125
-msgid "4G (Preferred), 5G"
-msgstr "4G（首选）、5G"
-
-#: panels/wwan/cc-wwan-device.c:1127
-msgid "4G, 5G"
-msgstr "4G、5G"
-
-#: panels/wwan/cc-wwan-device.c:1131
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "未知"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "解锁 SIM 卡"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "解锁"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "请提供 SIM 卡 %d 的 PIN 码"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "输入 PIN 以解锁您的 SIM 卡"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "请提供 SIM 卡 %d 的 PUK 码"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "输入 PUK 以解锁您的 SIM 卡"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
@@ -9042,26 +4848,6 @@ msgstr[0] "密码输入错误。您还有 %1$u 次尝试机会"
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
 msgstr[0] "您还有 %u 次尝试机会"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "密码输入错误。"
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK 码应为 8 位数字"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "输入新 PIN"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN 码应为 4 到 8 位数字"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "正在解锁……"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
@@ -9119,94 +4905,6 @@ msgstr "使用 PIN 锁定 SIM"
 msgid "M_odem Details"
 msgstr "调制解调器详细信息(_O)"
 
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "移动电话错误"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "没有到电话的连接"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "操作不允许"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "操作不支持"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM 卡未插入"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "需要 SIM PIN"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "需要 SIM PUK"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM 卡失败"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM 卡忙"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "密码不正确"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "需要 SIM PIN2"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "需要 SIM PUK2"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "未找到"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "无网络服务"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "网络超时"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "不允许 GPRS 服务"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "此位置区域不允许漫游"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "未指定的 GPRS 错误"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "No Error"
-msgstr "没有错误"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Action Cancelled"
-msgstr "操作已取消"
-
-#: panels/wwan/cc-wwan-errors-private.h:97
-msgid "Access denied"
-msgstr "拒绝访问"
-
-#: panels/wwan/cc-wwan-errors-private.h:106
-msgid "Unknown Error"
-msgstr "未知错误"
-
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "网络模式"
@@ -9222,11 +4920,6 @@ msgstr "选择网络"
 #: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
 msgstr "刷新网络提供商"
-
-#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
@@ -9284,7 +4977,6 @@ msgstr "移动网络"
 msgid "Configure Telephony and mobile data connections"
 msgstr "配置电话和移动数据连接"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
 msgstr "cellular;wwan;telephony;sim;mobile;蜂窝;移动;无线;"
@@ -9301,41 +4993,13 @@ msgstr "“设置”是配置您的系统的主要界面。"
 msgid "The GNOME Project"
 msgstr "GNOME 项目"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "显示版本号"
-
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "启用详细模式"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "搜索字符串"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "列出所有面板名称并退出"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "要显示的面板"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[面板] [参数…]"
-
 #: shell/cc-panel-list.ui:18
 msgid "Settings categories"
 msgstr "设置分类"
 
-#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "隐私"
-
-#: shell/cc-panel-loader.c:304
-msgid "Available panels:"
-msgstr "可用面板："
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -9392,7 +5056,6 @@ msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "取消搜索"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;Settings;首选项;设置;"
@@ -9426,25 +5089,3054 @@ msgid ""
 "application window."
 msgstr "元组类型的值，包含应用程序窗口的初始宽度、高度和最大化状态。"
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u 路输出"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u 路输入"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "系统声音"
+#~ msgid "System Bus"
+#~ msgstr "系统总线"
+
+#~ msgid "Full access"
+#~ msgstr "完全访问"
+
+#~ msgid "Session Bus"
+#~ msgstr "会话总线"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "对 /dev 的完全访问"
+
+#~ msgid "Has network access"
+#~ msgstr "拥有网络访问"
+
+#~ msgid "Home"
+#~ msgstr "主目录"
+
+#~ msgid "Read-only"
+#~ msgstr "只读"
+
+#~ msgid "File System"
+#~ msgstr "文件系统"
+
+#~ msgid "Can change settings"
+#~ msgstr "可以更改设置"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "%s 拥有以下内置权限。这些无法被更改。如果您在意这些权限，请考虑移除该应用"
+#~ "程序。"
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "%u 个文件和链接类型可以被该应用打开"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "<b>%s</b> 用来打开下列文件和链接类型。"
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "已占用 %s 磁盘空间。"
+
+#~ msgid "Select a picture"
+#~ msgstr "选择图片"
+
+#~ msgid "_Open"
+#~ msgstr "打开(_O)"
+
+#~ msgid "multiple sizes"
+#~ msgstr "多个尺寸"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "无桌面背景"
+
+#~ msgid "Current background"
+#~ msgstr "当前背景"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "将您的校准设备放在方块上并按“开始”"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "将您的校准器移动到校准位置并按“继续”"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "将您的校准器移动到表面位置并按“继续”"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "合上笔记本盖子"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "发生了一个无法恢复的内部错误。"
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "未安装校准所需的工具。"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "无法生成配置。"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "无法获取目标白点。"
+
+#~ msgid "Complete!"
+#~ msgstr "完成！"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "校准失败！"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "您现在可以移除校准设备。"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "校准过程中不要干扰校准设备"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "笔记本屏幕"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "内置摄像头"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s 显示器"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s 扫描仪"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s 相机"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s 打印机"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s 摄像头"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "为 %s 启用色彩管理"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "为 %s 显示颜色管理"
+
+#~ msgid "Not calibrated"
+#~ msgstr "未校准"
+
+#~ msgid "Default: "
+#~ msgstr "默认："
+
+#~ msgid "Colorspace: "
+#~ msgstr "色彩空间："
+
+#~ msgid "Test profile: "
+#~ msgstr "测试配置："
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "选择 ICC 配置文件"
+
+#~ msgid "_Import"
+#~ msgstr "导入(_I)"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "支持的 ICC 配置"
+
+#~ msgid "All files"
+#~ msgstr "所有文件"
+
+#~ msgid "Save Profile"
+#~ msgstr "保存配置"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "为选中的设备创建一份色彩配置"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr "未检测到测量仪器，请检查仪器是否已打开并已正确连接。"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "测量仪器不支持打印机校正。"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "目前不支持此设备类型。"
+
+#~ msgid "Standard Space"
+#~ msgstr "标准空间"
+
+#~ msgid "Test Profile"
+#~ msgstr "测试配置"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "自动"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "低质量"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "中等质量"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "高质量"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "默认 RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "默认 CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "默认灰度"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "生产商提供的工厂校准数据"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "无法使用此配置进行全屏显示校准"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "此配置可能已不准确"
+
+#~ msgid "Other…"
+#~ msgstr "其他…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "解锁以更改设置"
+
+#~ msgid "Today"
+#~ msgstr "今天"
+
+#~ msgid "Yesterday"
+#~ msgstr "昨天"
+
+#~ msgid "%b %e"
+#~ msgstr "%-m月%-d日"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y年%-m月%-d日"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d 小时"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d 分钟"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d 秒"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "热点"
+
+#~ msgid "24-hour"
+#~ msgstr "24 小时"
+
+#~ msgid "AM / PM"
+#~ msgstr "上午/下午"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%Y年%m月%d日，%p %-l:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%Y年%m月%d日，%R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s，%s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s（%s）"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%p %-l:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr "发送匿名的技术问题报告能帮助我们改进 %s，这些报告中不含个人数据。%s"
+
+#~ msgid "On"
+#~ msgstr "开"
+
+#~ msgid "Off"
+#~ msgstr "关"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "应用更改？"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "无法应用更改"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "这可能是硬件限制造成的。"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "横向"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "纵向，朝右"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "纵向，朝左"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "横向翻转"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf 赫兹"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "安全启动已激活"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "安全启动会在设备启动时阻止恶意软件加载。安全启动当前已开启并正确工作。"
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "安全启动有问题"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "安全启动会在设备启动时阻止恶意软件加载。安全启动当前已开启但因密钥无效无法"
+#~ "工作。"
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "安全启动的问题通常可以从您计算机的 UEFI 固件设置（BIOS）解决且您的硬件厂商"
+#~ "可能会提供如何操作的信息。"
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr "要寻求帮助，请联系您的硬件厂商或 IT 支持提供者。"
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "安全启动已关闭"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr "安全启动会在设备启动时阻止恶意软件加载。安全启动当前已关闭。"
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "安全启动通常可以从您计算机的 UEFI 固件设置（BIOS）开启。要寻求帮助，请联系"
+#~ "您的硬件厂商或 IT 支持提供者。"
+
+#~ msgid "Passed"
+#~ msgstr "已通过"
+
+#~ msgid "Failed"
+#~ msgstr "已失败"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "设备遵从 HSI 级别 %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "安全级别 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "该设备没有针对硬件安全问题的保护。这可能是因为硬件或固件配置问题。推荐联系"
+#~ "您的 IT 支持提供者。"
+
+#~ msgid "Security Level 1"
+#~ msgstr "安全级别 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "该设备具有针对硬件安全问题的最小化保护。这是最低的设备安全级别且仅提供对简"
+#~ "单安全威胁的保护。"
+
+#~ msgid "Security Level 2"
+#~ msgstr "安全级别 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "该设备具有针对硬件安全问题的基本保护。这提供了对一些常见安全威胁的保护。"
+
+#~ msgid "Security Level 3"
+#~ msgstr "安全级别 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "该设备具有针对硬件安全问题的扩展保护。这是最高的设备安全级别且提供了对高级"
+#~ "安全威胁的保护。"
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "安全级别对该设备不可用。"
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr "请联系您的硬件厂商获取有关安全更新的帮助。"
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr ""
+#~ "在该设备的 UEFI 固件设置中有可能会解决该问题，或寻求支持技术员的帮助。"
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr "在该设备的 UEFI 固件设置中有可能会解决该问题。"
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "支持技术员有可能会解决该问题。"
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "设备启动时针对恶意软件的保护。"
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "安全启动有问题"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "设备启动时的一些保护。"
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "安全启动已关闭"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "设备启动时没有保护。"
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "该问题可能由 UEFI 固件设置中的更改，操作系统配置的更改，或系统上的恶意软件"
+#~ "等所造成。"
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr "该问题可能由 UEFI 固件设置中的更改，或系统上的恶意软件等所造成。"
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr "该问题可能由操作系统配置的更改，或系统上的恶意软件等所造成。"
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "暴露于严重的安全威胁。"
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "对简单安全威胁的有限保护。"
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "对常见安全威胁的保护。"
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "对宽泛安全威胁的保护。"
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "全面保护"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "固件写入保护"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "固件写入保护锁"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "固件 BIOS 区域"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "固件 BIOS 描述符"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "预启动 DMA 保护"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "英特尔启动卫士"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "英特尔启动卫士验证的启动"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "英特尔启动卫士 ACM 保护"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "英特尔启动卫士错误策略"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "英特尔启动卫士保险"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "英特尔 CET 已启用"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "英特尔 CET 已激活"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "英特尔 SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "加密的内存"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU 保护"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux 内核封锁"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux 内核确认"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux 交换空间"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "挂起到内存"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "挂起到空闲"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI 平台密钥"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI 安全启动"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM 平台配置"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM 复原"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "英特尔管理引擎厂商模式"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "英特尔管理引擎覆盖"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "英特尔管理引擎版本"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "固件更新"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "固件认证"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "固件更新器验证"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "平台调试"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "处理器安全检查"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD 回滚保护"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD 固件重播保护"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD 固件写入保护"
+
+#~ msgid "Fused Platform"
+#~ msgstr "已熔断的平台"
+
+#~ msgid "Valid"
+#~ msgstr "已验证"
+
+#~ msgid "Not Valid"
+#~ msgstr "未验证"
+
+#~ msgid "Not Enabled"
+#~ msgstr "未启用"
+
+#~ msgid "Locked"
+#~ msgstr "已锁定"
+
+#~ msgid "Not Locked"
+#~ msgstr "未锁定"
+
+#~ msgid "Encrypted"
+#~ msgstr "已加密"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "未加密"
+
+#~ msgid "Tainted"
+#~ msgstr "受污染"
+
+#~ msgid "Not Tainted"
+#~ msgstr "未污染"
+
+#~ msgid "Found"
+#~ msgstr "已找到"
+
+#~ msgid "Not Found"
+#~ msgstr "未找到"
+
+#~ msgid "Supported"
+#~ msgstr "已支持"
+
+#~ msgid "Not Supported"
+#~ msgstr "未支持"
+
+#~ msgid "Unknown"
+#~ msgstr "未知"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 位"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 位"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "未知"
+
+#~ msgid "Not Available"
+#~ msgstr "不可用"
+
+#~ msgid "System Logo"
+#~ msgstr "系统标志"
+
+#~ msgid "No input sources found"
+#~ msgstr "无输入源"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "其他"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "自定义快捷键"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr "备用字符键可用于输入其他字符。这些有时会作为第三选项打印在键盘上。"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "左 Alt 键"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "右 Alt 键"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "左 Super 键"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "右 Super 键"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "菜单键"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "右 Ctrl 键"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "Compose 键可帮助输入更多种类的字符。如需使用，请按下该键然后按下一串字符序"
+#~ "列。例如，compose 键之后跟着 <b>C</b> 和 <b>o</b> 可以输入 <b>©</b>，"
+#~ "<b>a</b> 后接 <b>'</b> 可以输入 <b>á</b>。"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "大写锁定"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "滚动锁定"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "打印屏幕"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "使用键盘快捷键 %s 可以切换输入源。\n"
+#~ "这可以在键盘快捷键设置中更改。"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "已修改 %d 个"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "重置所有快捷键？"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr "重新设置快捷键可能影响您的自定义快捷键。此操作无法撤销。"
+
+#~ msgid "Reset All"
+#~ msgstr "全部重置"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s 已被用于 %s。如果您替换了它，%s 将被禁用"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "输入新的快捷键"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "设置自定义快捷键"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "设置快捷键"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "输入新的快捷键以更改 %s。"
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "添加自定义快捷键"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "双指滚动"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "点击五次，开始 GEGL！"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "主键双击"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "主键单击"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "中键双击"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "中键单击"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "副键双击"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "副键单击"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "需要运行 NetworkManager。"
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "不安全网络（WEP）"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "安全网络（WPA）"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "安全网络（WPA2）"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "安全网络（WPA3）"
+
+#~ msgid "Secure network"
+#~ msgstr "安全网络"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr "开启热点将从 %s 断开连接，并将无法通过 Wi-Fi 连接网络。"
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "至少包含 8 个字符"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "停止热点并断开所有用户？"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "停止热点(_S)"
+
+#~ msgid "Preserve"
+#~ msgstr "预留"
+
+#~ msgid "Permanent"
+#~ msgstr "永久"
+
+#~ msgid "Random"
+#~ msgstr "随机"
+
+#~ msgid "Stable"
+#~ msgstr "固定"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "此处输入的 MAC 地址将用作此连接激活所在的网络设备的硬件地址。该特性被称为 "
+#~ "MAC 克隆或欺骗。例如：00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "配置 %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "增强开放"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "企业"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "无"
+
+#~ msgid "Never"
+#~ msgstr "从不"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/秒"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "无"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "较弱"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "一般"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "良好"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "非常好"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "忘记连接"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "移除连接配置"
+
+#~ msgid "Remove VPN"
+#~ msgstr "移除 VPN"
+
+#~ msgid "Details"
+#~ msgstr "详细信息"
+
+#~ msgid "automatic"
+#~ msgstr "自动"
+
+#~ msgid "Identity"
+#~ msgstr "身份"
+
+#~ msgid "Delete Address"
+#~ msgstr "删除地址"
+
+#~ msgid "Delete Route"
+#~ msgstr "删除路由"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "无"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128 位密钥（Hex 或 ASCII）"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128 位密码"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "动态 WEP (802.1X)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA 和 WPA2 个人"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA 和 WPA2 企业"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3个人"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "无法打开连接编辑器"
+
+#~ msgid "New Profile"
+#~ msgstr "新配置"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "无效的设置 %s：%s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "无效的设置 %s"
+
+#~ msgid "Import from file…"
+#~ msgstr "从文件导入…"
+
+#~ msgid "Add VPN"
+#~ msgstr "添加 VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "无法导入 VPN 连接"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "文件“%s”无法读取或未包含可识别的 VPN 连接信息\n"
+#~ "\n"
+#~ "错误：%s。"
+
+#~ msgid "Select file to import"
+#~ msgstr "选择要导入的文件"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "名为“%s”的文件已存在。"
+
+#~ msgid "_Replace"
+#~ msgstr "替换(_R)"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "您希望用将要保存的 VPN 连接替换 %s 么？"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "无法导入 VPN 连接"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "无法将 VPN 连接“%s”导出到 %s。\n"
+#~ "\n"
+#~ "错误：%s。"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "导出 VPN 连接"
+
+#~ msgid "never"
+#~ msgstr "从不"
+
+#~ msgid "today"
+#~ msgstr "今天"
+
+#~ msgid "yesterday"
+#~ msgstr "昨天"
+
+#~ msgid "Last used"
+#~ msgstr "上次使用"
+
+#~ msgid "Add new connection"
+#~ msgstr "添加新连接"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr "所选网络的细节，包括密码和全部自定义设置都将丢失。"
+
+#~ msgid "_Forget"
+#~ msgstr "忘记(_F)"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "已知的 Wi-Fi 网络"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "忘记(_F)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "系统策略禁止作为热点使用"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "无线设备不支持热点模式"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "若未提供配置 URL，将使用网络代理自动发现。"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "对于不可信的公共网络，不建议这样做。"
+
+#~ msgid "Status unknown"
+#~ msgstr "未知状态"
+
+#~ msgid "Unmanaged"
+#~ msgstr "未托管"
+
+#~ msgid "Unavailable"
+#~ msgstr "不可用"
+
+#~ msgid "Connecting"
+#~ msgstr "正在连接"
+
+#~ msgid "Authentication required"
+#~ msgstr "需要认证"
+
+#~ msgid "Disconnecting"
+#~ msgstr "正在断开"
+
+#~ msgid "Connection failed"
+#~ msgstr "连接失败"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "未知状态（丢失）"
+
+#~ msgid "Configuration failed"
+#~ msgstr "配置失败"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP 配置失败"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP 配置已过期"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "需要认证凭据，但没有提供"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1X 客户端已断开"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1X 客户端配置失败"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1X 客户端失败"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1X 客户端认证耗时过长"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "PPP 服务启动失败"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP 服务已断开"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP 失败"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP 客户端启动失败"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP 客户端错误"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP 客户端失败"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "共享连接服务启动失败"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "共享连接服务失败"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "AutoIP 服务启动失败"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP 服务出错"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP 服务失败"
+
+#~ msgid "Line busy"
+#~ msgstr "线路忙"
+
+#~ msgid "No dial tone"
+#~ msgstr "无拨号音"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "无法建立载波"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "拨号请求超时"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "拨号尝试失败"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "调制解调器初始化失败"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "无法选择指定的 APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "未在搜索网络"
+
+#~ msgid "Network registration denied"
+#~ msgstr "网络注册被拒绝"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "网络注册超时"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "无法在请求的网络上注册"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN 检查失败"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "设备可能缺少固件"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "连接丢失"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "已假定为现有连接"
+
+#~ msgid "Modem not found"
+#~ msgstr "未找到调制解调器"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "蓝牙连接失败"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "未插入 SIM 卡"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "需要 SIM PIN 码"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "需要 SIM PUK 码"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM 错误"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "连接依赖失败"
+
+#~ msgid "Firmware missing"
+#~ msgstr "固件缺失"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "线缆已拔出"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "802.1X 安全性里未定义的错误 (wpa-eap)"
+
+#~ msgid "no file selected"
+#~ msgstr "未选择文件"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "验证 eap-method 文件时发生未知错误"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER、PEM、PKCS#12 或 PGP 私钥"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER 或 PEM 证书"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "缺失 EAP-FAST PAC 文件"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC 文件(*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "缺失 EAP-LEAP 用户名"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "缺失 EAP-LEAP 密码"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "无效的 EAP-PEAP CA 证书：%s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "无效的 EAP-PEAP CA 证书：未指定证书"
+
+#~ msgid "missing EAP username"
+#~ msgstr "缺失 EAP 用户名"
+
+#~ msgid "missing EAP password"
+#~ msgstr "缺失 EAP 密码"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "缺失 EAP-TLS 身份"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "无效的 EAP-TLS CA 证书：%s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "无效的 EAP-TLS CA 证书：未指定证书"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "无效的 EAP-TLS CA 私钥：%s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "无效的 EAP-TLS 用户证书：%s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "未加密的私钥不安全"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "所选私钥似乎没有密码保护，这可能使您的安全凭据遭到泄露。请选择一个有密码保"
+#~ "护的私钥。\n"
+#~ "\n"
+#~ "（您可以使用 openssl 来对私钥进行密码保护）"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "选择您的个人证书"
+
+#~ msgid "Choose your private key"
+#~ msgstr "选择您的私钥"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "无效的 EAP-TTLS CA 证书：%s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "无效的 EAP-TTLS CA 证书：未指定证书"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "验证 802.1X 安全性时发生未知错误"
+
+#~ msgid "Select a file"
+#~ msgstr "选择文件"
+
+#~ msgid "missing leap-username"
+#~ msgstr "缺失 leap-username"
+
+#~ msgid "missing leap-password"
+#~ msgstr "缺失 leap-password"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "Wi-Fi 密码缺失。"
+
+#~ msgid "missing wep-key"
+#~ msgstr "缺失 wep-key"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr "无效的 wep-key：%zu 长度的密钥只能包含十六进制数字"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr "无效的 wep-key：%zu 长度的密钥只能包含 ASCII 字符"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "无效的 wep-key：错误的密钥长度 %zu。密钥必须为长度 5/13 (ASCII) 或者 "
+#~ "10/26 (十六进制)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "无效的 wep-key：密码字段不能为空"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "无效的 wep-key：密码字段必须短于 64 个字符"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "无效的 wep-psk：无效的密钥长度 %zu。必须为 [8,63] 字节或者 64 位十六进制数"
+#~ "字"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "无效的 wep-psk：无法将 64 字节作为十六进制来解析密钥"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "其他"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "%s 已移除"
+
+#~ msgid "Error removing account"
+#~ msgstr "移除帐号出错"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s 帐号"
+
+#~ msgid "Remove Account"
+#~ msgstr "移除帐号"
+
+#~ msgid "Unknown time"
+#~ msgstr "未知时间"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s 后充满"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "注意：剩余 %s 的电量"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "剩余 %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "已充满"
+
+#~ msgid "Not charging"
+#~ msgstr "未充电"
+
+#~ msgid "Empty"
+#~ msgstr "已耗尽"
+
+#~ msgid "Charging"
+#~ msgstr "正在充电"
+
+#~ msgid "Discharging"
+#~ msgstr "正在放电"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "无线鼠标"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "无线键盘"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "不间断电源（UPS）"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "个人数字助理（PDA）"
+
+#~ msgid "Cellphone"
+#~ msgstr "手机"
+
+#~ msgid "Media player"
+#~ msgstr "媒体播放器"
+
+#~ msgid "Tablet"
+#~ msgstr "数位板"
+
+#~ msgid "Computer"
+#~ msgstr "计算机"
+
+#~ msgid "Gaming input device"
+#~ msgstr "游戏输入设备"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "主电池"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "附加电池"
+
+#~ msgid "Batteries"
+#~ msgstr "电池"
+
+#~ msgid "When _idle"
+#~ msgstr "空闲时(_I)"
+
+#~ msgid "Suspend"
+#~ msgstr "挂起"
+
+#~ msgid "Power Off"
+#~ msgstr "电源关闭"
+
+#~ msgid "Hibernate"
+#~ msgstr "休眠"
+
+#~ msgid "Nothing"
+#~ msgstr "不处理"
+
+#~ msgid "When on battery power"
+#~ msgstr "电池供电时"
+
+#~ msgid "When plugged in"
+#~ msgstr "插入电源时"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "从不"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "自动挂起"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "由于工作温度高，性能模式暂时禁用。"
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr "检测到膝上使用：性能模式暂时不可用。将设备移动到稳定的表面以恢复。"
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "性能模式暂时禁用。"
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr "电池电量低：节电模式已启用。电池充满电时，将恢复之前的模式。"
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "节电模式由“%s”激活。"
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "性能模式由“%s”激活。"
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "性能"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "高性能和功耗。"
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "均衡"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "标准性能和功耗。"
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "节电"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "降低性能和功耗。"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "已删除打印机“%s”"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "添加新打印机失败。"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "无法载入界面：%s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "解锁以添加打印机及更改设置"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "%s 详细信息"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "未找到合适的驱动"
+
+#~ msgid "Select PPD File"
+#~ msgstr "选择 PPD 文件"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript 打印机描述文件 (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect 打印机"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD 打印机"
+
+#~ msgid "One Sided"
+#~ msgstr "单面"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "长边（标准）"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "短边（翻转）"
+
+#~ msgid "Portrait"
+#~ msgstr "纵向"
+
+#~ msgid "Landscape"
+#~ msgstr "横向"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "横向倒转"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "纵向倒转"
+
+#~ msgid "Resume"
+#~ msgstr "恢复"
+
+#~ msgid "Pause"
+#~ msgstr "暂停"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "等待中"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "已暂停"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "需要认证"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "处理中"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "已停止"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "已取消"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "已中止"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "已完成"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "将此任务移至队列顶端"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — 活动任务"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "从 %s 输入凭据以打印。"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "解锁打印服务器"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "解锁 %s。"
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "输入用户名和密码以查看 %s 上的打印机。"
+
+#~ msgid "Searching for Printers"
+#~ msgstr "正在搜索打印机"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "串口"
+
+#~ msgid "Parallel Port"
+#~ msgstr "并口"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "位置：%s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "地址：%s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "服务器要求认证"
+
+#~ msgid "Two Sided"
+#~ msgstr "双面"
+
+#~ msgid "Paper Type"
+#~ msgstr "纸张类型"
+
+#~ msgid "Paper Source"
+#~ msgstr "纸张来源"
+
+#~ msgid "Output Tray"
+#~ msgstr "出纸托盘"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "分辨率"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript 预过滤"
+
+#~ msgid "Pages per side"
+#~ msgstr "每面页数"
+
+#~ msgid "Orientation"
+#~ msgstr "方向"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "常规"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "页面设置"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "可安装选项"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "任务"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "图像质量"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "色彩"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "正在完成"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "高级"
+
+#~ msgid "Test page"
+#~ msgstr "测试页"
+
+#~ msgid "Auto Select"
+#~ msgstr "自动选择"
+
+#~ msgid "Printer Default"
+#~ msgstr "打印机默认设置"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "仅内嵌 GhostScript 字体"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "转换为 PS 等级 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "转换为 PS 等级 1"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "无预过滤"
+
+#~ msgid "Clean print heads"
+#~ msgstr "清理喷墨头"
+
+#~ msgid "Out of toner"
+#~ msgstr "墨粉用尽"
+
+#~ msgid "Low on developer"
+#~ msgstr "显影剂不足"
+
+#~ msgid "Out of developer"
+#~ msgstr "显影剂用尽"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "标记墨水不足"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "标记墨水用尽"
+
+#~ msgid "Open cover"
+#~ msgstr "打开上盖"
+
+#~ msgid "Open door"
+#~ msgstr "打开后盖"
+
+#~ msgid "Low on paper"
+#~ msgstr "纸张不足"
+
+#~ msgid "Out of paper"
+#~ msgstr "纸张用尽"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "离线"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "已停止"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "废粉仓将满"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "废粉仓已满"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "感光鼓使用寿命已快耗尽"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "感光鼓故障"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "就绪"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "不接收任务"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "正在处理"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "英制"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "公制"
+
+#~ msgid "Ask what to do"
+#~ msgstr "询问如何处理"
+
+#~ msgid "Do nothing"
+#~ msgstr "无动作"
+
+#~ msgid "Open folder"
+#~ msgstr "打开文件夹"
+
+#~ msgid "Other Media"
+#~ msgstr "其他介质"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "选择播放音频 CD 的应用程序"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "选择播放视频 DVD 的应用程序"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "选择连接音乐播放器后运行的应用程序"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "选择连接相机后运行的应用程序"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "选择插入软件 CD 时运行的应用程序"
+
+#~ msgid "audio DVD"
+#~ msgstr "音频 DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "空白蓝光光盘"
+
+#~ msgid "blank CD disc"
+#~ msgstr "空白 CD 光盘"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "空白 DVD 光盘"
+
+# 空白 HD DVD 光盘
+#~ msgid "blank HD DVD disc"
+#~ msgstr "空白 HD DVD 光盘"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "蓝光视频光盘"
+
+#~ msgid "e-book reader"
+#~ msgstr "电子书阅读器"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD 视频光盘"
+
+#~ msgid "Picture CD"
+#~ msgstr "图片 CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "超级 VCD"
+
+#~ msgid "Video CD"
+#~ msgstr "视频 CD"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "屏幕关闭"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 秒"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 分钟"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 分钟"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 分钟"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 分钟"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 分钟"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 小时"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 分钟"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 分钟"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 分钟"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 分钟"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 分钟"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 分钟"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 分钟"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 分钟"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 分钟"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "从不"
+
+#~ msgid "Select Location"
+#~ msgstr "选择位置"
+
+#~ msgid "_OK"
+#~ msgstr "确定(_O)"
+
+#~ msgid "No applications found"
+#~ msgstr "未找到应用"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "未选择要共享的网络"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "已开启"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "已关闭"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "已启用"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "活动"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "选择文件夹"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "启用媒体共享"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr "文件共享可以共享“公共”文件夹，使用地址：%s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "当启用远程登录时，远程用户可以使用 SSH 命令来连接：\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "启用个人媒体共享"
+
+#~ msgid "Device name copied"
+#~ msgstr "设备名称已复制"
+
+#~ msgid "Device address copied"
+#~ msgstr "设备地址已复制"
+
+#~ msgid "Username copied"
+#~ msgstr "用户名已复制"
+
+#~ msgid "Password copied"
+#~ msgstr "密码已复制"
+
+#~ msgid "Custom"
+#~ msgstr "自定义"
+
+# 对话框标题
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "测试 %s"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "已断开"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "正在连接"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "已连接"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "认证错误"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "正在认证"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "功能受限"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "已连接并认证"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "未知状态"
+
+#~ msgid "Authorized at:"
+#~ msgstr "授权于："
+
+#~ msgid "Connected at:"
+#~ msgstr "连接于："
+
+#~ msgid "Enrolled at:"
+#~ msgstr "登记于："
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "无法授权设备："
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "无法忘记设备："
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "错误"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "已授权"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr "雷电接口子系统（boltd）未安装或配置不正确。"
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "只能挂接 USB 和 Display Port 设备。"
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "无法探测到雷电接口。\n"
+#~ "可能是该系统无雷电接口支持，或在 BIOS 中被禁用，抑或是设置成了不被支持的安"
+#~ "全级别。"
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "雷电接口支持在 BIOS 中被禁用。"
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "无法确定雷电接口安全级别。"
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "无法切换为直接模式：%s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "默认"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "中"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "大"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "更大"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "最大"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d 个像素"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "短"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ 屏幕"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ 屏幕"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ 屏幕"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "长"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 小时"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 天"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "清空回收站中的所有项目吗？"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "回收站内的所有项目将会永久删除。"
+
+#~ msgid "_Empty Trash"
+#~ msgstr "清空回收站(_E)"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "删除所有临时文件吗？"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "所有临时文件将会永久删除。"
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "清理临时文件(_P)"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 天"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 天"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 天"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "永久"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "应与您登录提供商的网络地址相同。"
+
+#~ msgid "Failed to add account"
+#~ msgstr "添加帐号失败"
+
+#~ msgid "Failed to register account"
+#~ msgstr "注册用户失败"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "没有支持该域的验证方法"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "加入域失败"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "登录名不正确。\n"
+#~ "请重试。"
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "登录密码不正确。\n"
+#~ "请重试。"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "登录到域失败"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "找不到该域名，也许拼写有误？"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "浏览更多图片"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "设备需要被请求执行该动作"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "设备正被另一个进程请求"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "您没有权限执行该动作"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "没有登记到指纹"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "注册时连接设备失败"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "连接指纹读取器失败"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "连接指纹守护程序失败"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "列出指纹失败：%s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "删除已保存的指纹失败：%s"
+
+#~ msgid "Left thumb"
+#~ msgstr "左手拇指"
+
+#~ msgid "Left middle finger"
+#~ msgstr "左手中指"
+
+#~ msgid "_Left index finger"
+#~ msgstr "左手食指(_L)"
+
+#~ msgid "Left ring finger"
+#~ msgstr "左手无名指"
+
+#~ msgid "Left little finger"
+#~ msgstr "左手小指"
+
+#~ msgid "Right thumb"
+#~ msgstr "右手拇指"
+
+#~ msgid "Right middle finger"
+#~ msgstr "右手中指"
+
+#~ msgid "_Right index finger"
+#~ msgstr "右手食指(_R)"
+
+#~ msgid "Right ring finger"
+#~ msgstr "右手无名指"
+
+#~ msgid "Right little finger"
+#~ msgstr "右手小指"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "未知手指"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "完成"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "指纹设备已断开连接"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "指纹设备存储已满"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "登记新指纹失败"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "登记过程初始化失败：%s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "登记新指纹失败"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "停止登记过程失败：%s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr "要登记指纹，请重复将手指举起然后放置在读取设备上的动作"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "重新登记该手指(_R)…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "扫描新指纹"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "释放指纹设备 %s 失败：%s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "读取设备时出现问题"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "无法请求指纹设备 %s：%s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "获取指纹设备失败：%s"
+
+#~ msgid "This Week"
+#~ msgstr "本周"
+
+#~ msgid "Last Week"
+#~ msgstr "上周"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b %e"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y %b %e"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s，%s"
+
+#~ msgid "Session Ended"
+#~ msgstr "会话结束"
+
+#~ msgid "Session Started"
+#~ msgstr "会话开始"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — 帐号活动"
+
+#~ msgid "Please choose another password."
+#~ msgstr "请选择另一个密码。"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "请再次输入当前密码。"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "无法更改密码"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "无法自动加入此类域"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "无此域或 Realm"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "无法以 %s 的身份登录域 %s"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "无效密码，请重试"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "无法连接到 %s 域：%s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "删除用户失败"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "吊销远程管理的用户失败"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "不能删除自己的帐号。"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s 已经登录"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "删除已登录帐号可能导致系统不一致。"
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "要保留 %s 的文件吗？"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr "删除用户时可以保留其主目录、电子邮件目录和临时文件。"
+
+#~ msgid "_Delete Files"
+#~ msgstr "删除文件(_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "保留文件(_K)"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "您确定要吊销远程管理的帐号 %s 吗？"
+
+#~ msgid "_Delete"
+#~ msgstr "删除(_D)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "帐号已禁用"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "下次登录时设置"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "无"
+
+#~ msgid "Logged in"
+#~ msgstr "已登录"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "联系帐号服务失败"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "请确定帐号服务已正确安装并启用。"
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "该面板必须解锁才能更改设置"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "删除选中的用户帐号"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "要删除选中的用户帐号，\n"
+#~ "请先点击 * 图标"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "解锁以允许用户更改设置"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "新密码不能和旧密码相同。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "请改动一些字母和数字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "请进一步修改密码。"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "不包含用户名的密码更安全。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "请勿在密码中使用您的名字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "请勿在密码中使用单词。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "请勿使用常用单词。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "请勿仅变更现有单词顺序。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "请使用更多数字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "请使用更多大写字母。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "请使用更多小写字母。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "请使用更多特殊字符，如标点符号。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "请混用字母、数字和标点符号。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "请避免重复相同的字符。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr "请避免重复相同类型的字符：你需要混合字母、数字和标点符号。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "请避免使用如 1234 或 abcd 的有规律序列。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr "需要更长的密码。请试着加入更多的字母、数字和标点符号。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "密码需要大小写字母混用并试着使用一到两个数字。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "增加更多字母、数字和标点可进一步提高密码强度。"
+
+#~ msgid "Authentication failed"
+#~ msgstr "认证失败"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "新密码太短"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "新密码太简单"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "新密码和旧密码太相似"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "新的密码最近已使用过。"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "新密码必须包含数字或特殊字符"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "新旧密码相同"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "密码在您首次认证后已经更改！"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "新密码必须一定量不同的字符"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "未知错误"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr "用户名只能包含小写英文字母（a 至 z）、数字和“-”、“_”符号"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "抱歉，该用户名不可用。请试下别的。"
+
+#~ msgid "The username is too long."
+#~ msgstr "用户名太长。"
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "按键 %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "应用程序定义"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "发送按键"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "切换显示器"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "显示屏幕帮助"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "数位板已挂载在笔记本屏幕上"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "数位板已挂载在外部显示器上"
+
+#~ msgid "External tablet device"
+#~ msgstr "外部数位板设备"
+
+#~ msgid "All Displays"
+#~ msgstr "全部显示器"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "具有压感、倾斜和集成滑块的喷枪笔"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "具有压感、倾斜和旋转的喷枪笔"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "具有压感和倾斜的标准笔"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "具有压感的标准笔"
+
+#~ msgid "New shortcut…"
+#~ msgstr "新建快捷键…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "操作已取消"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>错误：</b>更改设置被拒绝"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>错误：</b>移动设备错误"
+
+#~ msgid "Not Registered"
+#~ msgstr "未注册"
+
+#~ msgid "Registered"
+#~ msgstr "已注册"
+
+#~ msgid "Roaming"
+#~ msgstr "漫游中"
+
+#~ msgid "Searching"
+#~ msgstr "搜索中"
+
+#~ msgid "Denied"
+#~ msgstr "已拒绝"
+
+#~ msgid "2G Only"
+#~ msgstr "仅 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "仅 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "仅 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "仅 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G、3G、4G、5G（首选）"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G、3G、4G（首选）、5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G、3G（首选）、4G、5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G（首选）、3G、4G、5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G、3G、4G、5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G、3G、4G（首选）"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G、3G（首选）、4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G（首选）、3G、4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G、3G、4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G、4G、5G（首选）"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G、4G（首选）、5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G（首选）、4G、5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G、4G、5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G、4G、5G（首选）"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G、4G（首选）、5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G（首选）、4G、5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G、4G、5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G、3G、5G（首选）"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G、3G（首选）、5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G（首选）、3G、5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G、3G、5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G、4G（首选）"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G（首选）、4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G、4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G、4G（首选）"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G（首选）、4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G、4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G、3G（首选）"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G（首选）、3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G、3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G、5G（首选）"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G（首选）、5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G、5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G、5G（首选）"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G（首选）、5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G、5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "4G、5G（首选）"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G（首选）、5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G、5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "未知"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "解锁 SIM 卡"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "请提供 SIM 卡 %d 的 PIN 码"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "输入 PIN 以解锁您的 SIM 卡"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "请提供 SIM 卡 %d 的 PUK 码"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "输入 PUK 以解锁您的 SIM 卡"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "密码输入错误。"
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK 码应为 8 位数字"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "输入新 PIN"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN 码应为 4 到 8 位数字"
+
+#~ msgid "Unlocking…"
+#~ msgstr "正在解锁……"
+
+#~ msgid "Phone failure"
+#~ msgstr "移动电话错误"
+
+#~ msgid "No connection to phone"
+#~ msgstr "没有到电话的连接"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "操作不允许"
+
+#~ msgid "Operation not supported"
+#~ msgstr "操作不支持"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM 卡未插入"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "需要 SIM PIN"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "需要 SIM PUK"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM 卡失败"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM 卡忙"
+
+#~ msgid "Incorrect password"
+#~ msgstr "密码不正确"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "需要 SIM PIN2"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "需要 SIM PUK2"
+
+#~ msgid "Not found"
+#~ msgstr "未找到"
+
+#~ msgid "No network service"
+#~ msgstr "无网络服务"
+
+#~ msgid "Network timeout"
+#~ msgstr "网络超时"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "不允许 GPRS 服务"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "此位置区域不允许漫游"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "未指定的 GPRS 错误"
+
+#~ msgid "No Error"
+#~ msgstr "没有错误"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "操作已取消"
+
+#~ msgid "Access denied"
+#~ msgstr "拒绝访问"
+
+#~ msgid "Unknown Error"
+#~ msgstr "未知错误"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "显示版本号"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "启用详细模式"
+
+#~ msgid "Search for the string"
+#~ msgstr "搜索字符串"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "列出所有面板名称并退出"
+
+#~ msgid "Panel to display"
+#~ msgstr "要显示的面板"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[面板] [参数…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "可用面板："
+
+#~ msgid "System Sounds"
+#~ msgstr "系统声音"
 
 #~ msgid "Error: unable to determine HSI level."
 #~ msgstr "错误：无法确定 HSI 级别。"
@@ -9454,9 +8146,6 @@ msgstr "系统声音"
 
 #~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
 #~ msgstr "DER 或 PEM 证书 (*.der, *.pem, *.crt, *.cer)"
-
-#~ msgid "Add a Printer…"
-#~ msgstr "添加打印机…"
 
 #~ msgid "Drip"
 #~ msgstr "雨滴"
@@ -9750,9 +8439,6 @@ msgstr "系统声音"
 #~ msgid "Tablet (absolute)"
 #~ msgstr "数位板（绝对）"
 
-#~ msgid "Touchpad (relative)"
-#~ msgstr "触摸板（相对）"
-
 #~ msgid "Tablet Preferences"
 #~ msgstr "数位板首选项"
 
@@ -9870,8 +8556,8 @@ msgstr "系统声音"
 #~ msgstr "无法被更改"
 
 #~ msgid ""
-#~ "Individual permissions for applications can be reviewed in the <a href="
-#~ "\"privacy\">Privacy</a> Settings."
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
 #~ msgstr "应用程序的各个权限可以在 <a href=\"privacy\">隐私</a> 设置中查看。"
 
 # 左撇子有歧视色彩。
@@ -10125,9 +8811,6 @@ msgstr "系统声音"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "直接访问蓝牙硬件"
-
-#~ msgid "Use your camera"
-#~ msgstr "使用相机"
 
 #~ msgid "Print documents"
 #~ msgstr "打印文档"
@@ -10879,9 +9562,6 @@ msgstr "系统声音"
 #~ msgid "Mirrored"
 #~ msgstr "镜像显示"
 
-#~ msgid "Secondary"
-#~ msgstr "副显示器"
-
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "安排多个显示"
 
@@ -11040,9 +9720,6 @@ msgstr "系统声音"
 #~ msgid "Mail"
 #~ msgstr "邮件"
 
-#~ msgid "Calendar"
-#~ msgstr "日历"
-
 #~ msgid "Contacts"
 #~ msgstr "联系人"
 
@@ -11148,9 +9825,6 @@ msgstr "系统声音"
 #~ msgid "%s - %s"
 #~ msgstr "%s - %s"
 
-#~ msgid "Disable image"
-#~ msgstr "禁用图像"
-
 #~ msgid "Browse for more pictures…"
 #~ msgstr "浏览更多图片…"
 
@@ -11230,9 +9904,6 @@ msgstr "系统声音"
 
 #~ msgid "Scroll Up"
 #~ msgstr "向上滚动"
-
-#~ msgid "Scroll Down"
-#~ msgstr "向下滚动"
 
 #~ msgid "Scroll Right"
 #~ msgstr "向右滚动"

--- a/po/zh_CN.po~
+++ b/po/zh_CN.po~
@@ -1,0 +1,11518 @@
+# Simplified Chinese translation for gnome-control-center.
+# Copyright (C) 2001-2021 gnome-control-center's COPYRIGHT HOLDER
+# This file is distributed under the same license as gnome-control-center package.
+# Some translations are taken from tranditional Chinese translation.
+# by Abel Cheung <maddog@linuxhall.org>, 2001.
+# He Qiangqiang <carton@linux.net.cn>, 2002.
+# Sun G11n <gnome_int_l10n@ireland.sun.com>, 2002.
+# Funda Wang <fundawang@linux.net.cn>, 2003-2006.
+# 甘露(Gan Lu) <rhythm.gan@gmail.com>,  2009, 2013.
+# Deng Xiyue <manphiz@gmail.com>, 2009.
+# FujianWzh <fujianwzh@gmail.com>, 2009.
+# Tao Wei <weitao1979@gmail.com>, 2009, 2010.
+# Xhacker Liu <liu.dongyuan@gmail.com>, 2010.
+# 朱涛 <bill_zt@sina.com>, 2010.
+# zhang ping <zhangping159@gmail.com>, 2010.
+# 指冷玉笙寒 (dhyang) <dhyang555@gmail.com>, 2011.
+# Lele Long <schemacs@gmail.com>, 2011.
+# Wind He <lofwind@gmail.com>, 2011.
+# bsfmig <bigslowfat@gmail.com>, 2012.
+# Cheng Lu <chenglu1990@gmail.com>, 2012.
+# YunQiang Su <wzssyqa@gmail.com>, 2011, 2013.
+# Wylmer Wang <wantinghard@gmail.com>, 2011, 2012, 2014.
+# Tong Hui <tonghuix@gmail.com>, 2014.
+# Eleanor Chen <chenyueg@gmail.com>, 2014.
+# Aron Xu <happyaron.xu@gmail.com>, 2010, 2011, 2012, 2013, 2014, 2015.
+# Mingye Wang <arthur2e5@aosc.xyz>, 2015.
+# Mingcong Bai <jeffbai@aosc.xyz>, 2015, 2016, 2018.
+# Yuchen Guo <egyc@live.com>, 2020.
+# Liu Tao <lyuutau@outlook.com>, 2021.
+# Dingzhong Chen <wsxy162@gmail.com>, 2016-2021.
+# lumingzh <lumingzh@qq.com>, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center master\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-08-24 14:00+0000\n"
+"PO-Revision-Date: 2022-08-28 21:16+0800\n"
+"Last-Translator: lumingzh <lumingzh@qq.com>\n"
+"Language-Team: Chinese - China <i18n-zh@googlegroups.com>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Gtranslator 42.0\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "系统总线"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "完全访问"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "会话总线"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "设备"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "对 /dev 的完全访问"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "网络"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "拥有网络访问"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "主目录"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "只读"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "文件系统"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "设置"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "可以更改设置"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"%s 拥有以下内置权限。这些无法被更改。如果您在意这些权限，请考虑移除该应用程"
+"序。"
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "%u 个文件和链接类型可以被该应用打开"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "<b>%s</b> 用来打开下列文件和链接类型。"
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "已占用 %s 磁盘空间。"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "应用程序"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "没有应用程序"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "安装一些…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "打开"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "查看详情"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "搜索"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "接收系统搜索并发送结果。"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "已禁用"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "通知"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "显示系统通知。"
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "后台运行"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "允许应用关闭后活动。"
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "截图"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "在任何时候都能获取屏幕截图。"
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "更改壁纸"
+
+# 图标条目，保留无需翻译。
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "更换桌面壁纸。"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "声音"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "再现声音。"
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "禁止快捷键"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "封锁标准的键盘快捷键。"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "摄像头"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "使用摄像头拍照。"
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "麦克风"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "使用麦克风录音。"
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "定位服务"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "访问设备的位置数据。"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "内置权限"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "该应用需要的系统访问权限"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "文件与链接关联"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "存储"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "未找到结果"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "尝试不同的搜索"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "文件与链接关联"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "文件类型"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "链接类型"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "重置"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "此应用程序包括应用数据和缓存占用了多少硬盘空间。"
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "应用程序"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "数据"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "缓存"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>全部</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "清空缓存…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "控制不同应用程序权限和设置"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr "application;flatpak;permission;setting;应用程序;权限;设置;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "选择图片"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "取消(_C)"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "打开(_O)"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "多个尺寸"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "无桌面背景"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "当前背景"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "样式"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "默认"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "暗色"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "背景"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "添加图片…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "外观"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "更改您的背景图像或用户界面配色"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;背景;墙纸;屏"
+"幕;桌面;样式;亮色;暗色;夜间模式;外观;个性化;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "启用"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "未找到蓝牙"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "插入蓝牙适配器以使用蓝牙。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "蓝牙已关闭"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "打开以连接设备和接收文件传送。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "飞行模式已打开"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "蓝牙已禁用当开启飞行模式时。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "关闭飞行模式"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "硬件飞行模式已打开"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "关闭飞行模式开关以开启蓝牙。"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "蓝牙"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "开关蓝牙及连接您的设备"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;分享;共享;蓝牙;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "摄像头已关闭"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "没有应用程序可以捕获照片或视频。"
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"使用摄像头允许应用程序拍摄照片和视频。禁用摄像头可能会导致一些应用程序功能无"
+"法正常使用。\n"
+"\n"
+"允许以下应用程序使用您的摄像头。"
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "没有应用程序要求访问摄像头"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "保护您的图片"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;相机;摄像头;照片;视频;网络摄"
+"像头;锁定;私人;隐私;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "将您的校准设备放在方块上并按“开始”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "将您的校准器移动到校准位置并按“继续”"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "将您的校准器移动到表面位置并按“继续”"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "合上笔记本盖子"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "发生了一个无法恢复的内部错误。"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "未安装校准所需的工具。"
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "无法生成配置。"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "无法获取目标白点。"
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "完成！"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "校准失败！"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "您现在可以移除校准设备。"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "校准过程中不要干扰校准设备"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "显示校准"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "开始(_S)"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "恢复(_R)"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "完成(_D)"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "笔记本屏幕"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "内置摄像头"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s 显示器"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s 扫描仪"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s 相机"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s 打印机"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s 摄像头"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "为 %s 启用色彩管理"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "为 %s 显示颜色管理"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "未校准"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "默认："
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "色彩空间："
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "测试配置："
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "选择 ICC 配置文件"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "导入(_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "支持的 ICC 配置"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "所有文件"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "屏幕"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "保存配置"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "保存(_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "为选中的设备创建一份色彩配置"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "未检测到测量仪器，请检查仪器是否已打开并已正确连接。"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "测量仪器不支持打印机校正。"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "目前不支持此设备类型。"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "屏幕校准"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "校准质量"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr "校准将生成用于屏幕色彩管理的配置。校准时花费的时间越多效果越好。"
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "校准进行时您将不能使用您的计算机。"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "质量"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "预计耗时"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "校准设备"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "选择校准所使用的传感器设备。"
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "显示类型"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "选择连接的显示类型。"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "配置参考白点"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr "选择显示目标白点。多数显示器应该校准到 D65 光源。"
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "显示亮度"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr "请选择通常使用的显示亮度。色彩管理在此亮度下将最准确。"
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr "或者，也可以使用亮度配合此设备的其他配置使用。"
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "配置名称"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+"您可以对不同的计算机使用同一个配置，或者甚至可以对不同的光照条件创建配置。"
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "配置名称："
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "摘要"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "创建配置成功！"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "复制配置"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "需要可写介质"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr ""
+"有关如何在 <a href=\"linux\">GNU/Linux</a>、<a href=\"osx\">Apple OS X</a> "
+"和 <a href=\"windows\">Microsoft Windows</a> 系统中使用配置的这些说明可能对您"
+"有所帮助。"
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "添加配置"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr "检测到问题，此配置可能无法正常工作。<a href=\"\">显示详细信息。</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "导入文件(_I)…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "添加(_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "每个设备都需要一份最新色彩配置以进行色彩管理。"
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "了解更多"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "了解更多有关色彩管理的信息"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "为所有用户设置(_S)"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "为此计算机上的所有用户设置此配置"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "启用(_E)"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "添加配置(_A)"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "校准(_C)…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "校准该设备"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "移除配置(_R)"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "查看详情(_V)"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "未检测到可以管理颜色的设备"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "投影仪"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "等离子"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD（CCFL 背光）"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD（RGB LED 背光）"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD（白色 LED 背光）"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "广色域 LCD（CCFL 背光）"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "广色域 LCD（RGB LED 背光）"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "高"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 分钟"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "中"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 分钟"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "低"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 分钟"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "显示设备原生"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50（打印和出版）"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65（摄影及图形）"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "标准空间"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "测试配置"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "自动"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "低质量"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "中等质量"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "高质量"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "默认 RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "默认 CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "默认灰度"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "生产商提供的工厂校准数据"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "无法使用此配置进行全屏显示校准"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "此配置可能已不准确"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "色彩"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "校准显示器、相机、打印机等设备的色彩"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Color;ICC;Profile;Calibrate;Printer;Display;颜色;色彩;配置;校准;打印机;显示;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "其他…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "选择语言"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "选择(_S)"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "未找到语言"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "更多…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "解锁以更改设置"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "某些设置必须先解锁才能更改。"
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "解锁…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "增加小时"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "增加分钟"
+
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "时间"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "减少小时"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "减少分钟"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "今天"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "昨天"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%-m月%-d日"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%Y年%-m月%-d日"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d 小时"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d 分钟"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d 秒"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 秒"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "热点"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 小时"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "上午/下午"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%Y年%m月%d日，%p %-l:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%Y年%m月%d日，%R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s，%s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s（%s）"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%p %-l:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "日期和时间"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "年"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "月"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "一月"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "二月"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "三月"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "四月"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "五月"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "六月"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "七月"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "八月"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "九月"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "十月"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "十一月"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "十二月"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "日"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "时区"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "搜索城市"
+
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "自动设置日期和时间(_D)"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "需要互联网连接"
+
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "日期和时间(_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "自动设置时区(_Z)"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "需要启用定位服务和互联网连接"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "已启用"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "时区(_O)"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "时间格式(_F)"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "改变日期、时间和时区"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;时钟;时区;位置;"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "更改系统时间和日期设置"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "更改时间或日期设置需要认证。"
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "Web(_W)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "邮件(_M)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "日历(_C)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "音乐(_U)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "视频(_V)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "照片(_P)"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "默认应用程序"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "配置默认应用程序"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;默认;应用程序;首选;偏好;媒体;介质;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr "发送匿名的技术问题报告能帮助我们改进 %s，这些报告中不含个人数据。%s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "报告问题"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "自动报告问题(_A)"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "诊断"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "报告问题"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;诊断;崩溃;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "开"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "关"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "应用更改？"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "无法应用更改"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "这可能是硬件限制造成的。"
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "应用(_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "后退"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "显示器设置已禁用"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "多显示器"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "加入"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "镜像"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "包含顶栏和活动按钮"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "主显示器"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "夜灯"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "横向"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "纵向，朝右"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "纵向，朝左"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "横向翻转"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf 赫兹"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "方向"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "分辨率"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "刷新频率"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "为电视调整"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "缩放"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "夜灯不可用"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr "这可能是使用的显卡驱动或者桌面是远程使用造成的"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "暂时禁用直到明天"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "重启滤镜"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr "夜灯使屏幕颜色更暖。这可以帮助预防眼疲劳和失眠。"
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "计划"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "日落到日出"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "手动计划"
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "时间"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "从"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "时"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "分"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "上午"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "下午"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "到"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "色温"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "显示器"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "选择如何使用接入的显示器和投影仪"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;面板;投影仪;屏幕;分辨率;刷新;夜晚;晚上;光;蓝;红"
+"移;颜色;日落;日出;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:109
+msgid "Secure Boot is Active"
+msgstr "安全启动已激活"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr "安全启动会在设备启动时阻止恶意软件加载。安全启动当前已开启并正确工作。"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "安全启动有问题"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"安全启动会在设备启动时阻止恶意软件加载。安全启动当前已开启但因密钥无效无法工"
+"作。"
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"安全启动的问题通常可以从您计算机的 UEFI 固件设置（BIOS）解决且您的硬件厂商可"
+"能会提供如何操作的信息。"
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "要寻求帮助，请联系您的硬件厂商或 IT 支持提供者。"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "安全启动已关闭"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr "安全启动会在设备启动时阻止恶意软件加载。安全启动当前已关闭。"
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"安全启动通常可以从您计算机的 UEFI 固件设置（BIOS）开启。要寻求帮助，请联系您"
+"的硬件厂商或 IT 支持提供者。"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"安全启动会在设备启动时阻止恶意软件加载。\n"
+"\n"
+"获取更多信息请联系硬件厂商或 IT 支持。"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "已通过"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "已失败"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "设备遵从 HSI 级别 %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:482
+msgid "Security Level 0"
+msgstr "安全级别 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"该设备没有针对硬件安全问题的保护。这可能是因为硬件或固件配置问题。推荐联系您"
+"的 IT 支持提供者。"
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:489
+msgid "Security Level 1"
+msgstr "安全级别 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"该设备具有针对硬件安全问题的最小化保护。这是最低的设备安全级别且仅提供对简单"
+"安全威胁的保护。"
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:496
+msgid "Security Level 2"
+msgstr "安全级别 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"该设备具有针对硬件安全问题的基本保护。这提供了对一些常见安全威胁的保护。"
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:503
+msgid "Security Level 3"
+msgstr "安全级别 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"该设备具有针对硬件安全问题的扩展保护。这是最高的设备安全级别且提供了对高级安"
+"全威胁的保护。"
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:518
+msgid "Security Level"
+msgstr "安全级别"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:519
+msgid "Security levels are not available for this device."
+msgstr "安全级别对该设备不可用。"
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr "请联系您的硬件厂商获取有关安全更新的帮助。"
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr "在该设备的 UEFI 固件设置中有可能会解决该问题，或寻求支持技术员的帮助。"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "在该设备的 UEFI 固件设置中有可能会解决该问题。"
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "支持技术员有可能会解决该问题。"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "1 级"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "2 级"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "3 级"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:110
+msgid "Protected against malicious software when the device starts."
+msgstr "设备启动时针对恶意软件的保护。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:116
+msgid "Secure Boot has Problems"
+msgstr "安全启动有问题"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:117
+msgid "Some protection when the device is started."
+msgstr "设备启动时的一些保护。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:122
+msgid "Secure Boot is Off"
+msgstr "安全启动已关闭"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:123
+msgid "No protection when the device is started."
+msgstr "设备启动时没有保护。"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:142
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"该问题可能由 UEFI 固件设置中的更改，操作系统配置的更改，或系统上的恶意软件等"
+"所造成。"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:150
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr "该问题可能由 UEFI 固件设置中的更改，或系统上的恶意软件等所造成。"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:157
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr "该问题可能由操作系统配置的更改，或系统上的恶意软件等所造成。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:483
+msgid "Exposed to serious security threats."
+msgstr "暴露于严重的安全威胁。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:490
+msgid "Limited protection against simple security threats."
+msgstr "对简单安全威胁的有限保护。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:497
+msgid "Protected against common security threats."
+msgstr "对常见安全威胁的保护。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:504
+#: panels/firmware-security/cc-firmware-security-panel.c:512
+msgid "Protected against a wide range of security threats."
+msgstr "对宽泛安全威胁的保护。"
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:511
+msgid "Comprehensive Protection"
+msgstr "全面保护"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "无事件"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "固件写入保护"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "固件写入保护锁"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "固件 BIOS 区域"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "固件 BIOS 描述符"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "预启动 DMA 保护"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "英特尔启动卫士"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "英特尔启动卫士验证的启动"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "英特尔启动卫士 ACM 保护"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "英特尔启动卫士错误策略"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "英特尔启动卫士保险"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "英特尔 CET 已启用"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "英特尔 CET 已激活"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "英特尔 SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "加密的内存"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU 保护"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux 内核封锁"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux 内核确认"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux 交换空间"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "挂起到内存"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "挂起到空闲"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI 平台密钥"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI 安全启动"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM 平台配置"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM 复原"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "英特尔管理引擎厂商模式"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "英特尔管理引擎覆盖"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "英特尔管理引擎版本"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "固件更新"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "固件认证"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "固件更新器验证"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "平台调试"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "处理器安全检查"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD 回滚保护"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD 固件重播保护"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD 固件写入保护"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "已熔断的平台"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "已验证"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "未验证"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "未启用"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "已锁定"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "未锁定"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "已加密"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "未加密"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "受污染"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "未污染"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "已找到"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "未找到"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "已支持"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "未支持"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "设备安全"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "主机固件安全状态"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;屏幕;锁;诊断;崩溃;私有;最近;临时;索引;名称;网络;认"
+"证;标志;身份;隐私;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "未知"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64 位"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32 位"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "未知"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "不可用"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "系统标志"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "设备名称"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "硬件型号"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "内存"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "处理器"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "显卡"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "磁盘容量"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "正在计算…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "操作系统名称"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "系统构建标识"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "操作系统类型"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME 版本"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "正在加载…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "窗口系统"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "虚拟化"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "软件更新"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "重命名设备"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr "通过网络查看该设备或配对蓝牙设备时，设备名称用于标识该设备。"
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "设备名称"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "重命名(_R)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "关于"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "查看系统信息"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;设备;系统;信息;"
+"内存;处理器;CPU;版本;默认;应用程序;首选;音频;视频;光盘;光碟;盘片;可擦写;可移"
+"除;可移动;媒体;介质;自动运行;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "声音和媒体"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "音量静音/取消静音"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "减小音量"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "增大音量"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "麦克风静音/取消静音"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "启动媒体播放器"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "播放（或播放/暂停）"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "暂停播放"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "停止播放"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "上一曲目"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "下一曲目"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "弹出"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "打字"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "切换至下个输入源"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "切换至上个输入源"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "启动器"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "启动帮助浏览器"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "启动计算器"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "启动邮件客户端"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "启动网页浏览器"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "主目录"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "搜索"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "系统"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "注销"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "锁定屏幕"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "辅助功能"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "开关屏幕缩放"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "放大"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "缩小"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "开关屏幕阅读器"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "开关屏幕键盘"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "增大文本字号"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "减小文本字号"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "高对比度开关"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "无输入源"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "其他"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "添加输入源"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "无法在登录屏幕上使用输入法"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "未选择输入源"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "选项"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "上移"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "下移"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "首选项"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "查看键盘布局"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "移除"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "自定义快捷键"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "备用字符键"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr "备用字符键可用于输入其他字符。这些有时会作为第三选项打印在键盘上。"
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "左 Alt 键"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "右 Alt 键"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "左 Super 键"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "右 Super 键"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "菜单键"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "右 Ctrl 键"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "Compose 键"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"Compose 键可帮助输入更多种类的字符。如需使用，请按下该键然后按下一串字符序"
+"列。例如，compose 键之后跟着 <b>C</b> 和 <b>o</b> 可以输入 <b>©</b>，<b>a</"
+"b> 后接 <b>'</b> 可以输入 <b>á</b>。"
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "大写锁定"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "滚动锁定"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "打印屏幕"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"使用键盘快捷键 %s 可以切换输入源。\n"
+"这可以在键盘快捷键设置中更改。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "输入源"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "包括键盘布局与输入法。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "输入源切换"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "所有窗口使用相同的输入源(_S)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "每个窗口使用不同的输入源(_I)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "特殊字符输入"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "使用键盘输入符号和字母变体的方法。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "键盘快捷键"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "查看及自定义快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "已修改 %d 个"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "重置所有快捷键？"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr "重新设置快捷键可能影响您的自定义快捷键。此操作无法撤销。"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "取消"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "全部重置"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "全部重置…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "重置所有快捷键为它们的默认键绑定"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "节"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "添加快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "添加自定义快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "设置快捷键以启动应用、运行脚本等。"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "添加快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "未找到键盘快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s 已被用于 %s。如果您替换了它，%s 将被禁用"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "输入新的快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "设置自定义快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "设置快捷键"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "输入新的快捷键以更改 %s。"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "添加自定义快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "移除(_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "替换(_P)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "设置(_S)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "按 Esc 以取消或 Backspace 以停用此键盘快捷键。"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "名称"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "命令"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "快捷键"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "设置快捷键…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "无"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "重置快捷键为它的默认值"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "键盘"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "更改键盘快捷键并设置您的输入首选项、键盘布局和输入源"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;快捷"
+"键;工作空间;窗口;更改大小;缩放;对比度;输入;源;锁定;音量;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "定位服务已关闭"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "没有应用程序可以获取位置信息。"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"定位服务允许应用程序知晓您的位置。使用 Wi-Fi 和移动宽带增强精确度。\n"
+"\n"
+"使用 Mozilla 定位服务：<a href='https://location.services.mozilla.com/"
+"privacy'>隐私政策</a>\n"
+"\n"
+"允许以下应用程序测定您的位置。"
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "没有应用程序要求访问位置"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "保护您的位置信息"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;位置;定位;私人;隐私;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "麦克风已关闭"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "未找到音频录制应用。"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"使用麦克风允许应用程序录制和监听音频。禁用麦克风可能会导致一些应用程序功能无"
+"法正常使用。\n"
+"\n"
+"允许下列应用程序使用您的麦克风。"
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "没有应用程序要求访问麦克风"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "保护对话"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+"microphone;recording;application;privacy;麦克风;话筒;录制;应用程序;隐私;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "测试您的设置(_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "常规"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "主按钮"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "设置鼠标和触控板上的物理按钮的排列。"
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "左"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "右"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "鼠标"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "鼠标速度"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "自然滚动"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "滚动移动内容而非视图。"
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "触摸板"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "触摸板速度"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "轻触以点击"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "轻触以点击"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "双指滚动"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "边缘滚动"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "尝试单击、双击、滚动"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "点击五次，开始 GEGL！"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "主键双击"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "主键单击"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "中键双击"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "中键单击"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "副键双击"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "副键单击"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "鼠标和触摸板"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "改变鼠标和触摸板灵敏度，并选择右手或左手习惯"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;触摸板;指针;触摸;单"
+"击;双击;按钮;轨迹球;滚动;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "热区(_H)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "触碰屏幕左上角以打开活动概览界面。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "激活屏幕边缘(_A)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr "将窗口拖曳至顶部、底部、左侧和右侧边缘以更改其大小。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "工作空间"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "动态工作空间(_D)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "自动移除空的工作空间。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "固定数量的工作空间(_F)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "指定永久存在的工作空间的数量。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "工作空间数量(_N)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "多显示器"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "工作空间仅位于主显示器上(_P)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "工作空间位于所有显示器上(_I)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "应用程序切换"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "包括所有工作空间的应用程序(_W)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "仅包括当前工作空间中的应用程序(_C)"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "多任务"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "管理生产力和多任务的首选项"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+"多任务;生产力;自定义;桌面;热区;工作区;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "抱歉，发生错误。请联系软件提供商。"
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "需要运行 NetworkManager。"
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "其他设备"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "添加连接"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "未设置"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "不安全网络（WEP）"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "安全网络（WPA）"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "安全网络（WPA2）"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "安全网络（WPA3）"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "安全网络"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "已连接"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "选项…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr "开启热点将从 %s 断开连接，并将无法通过 Wi-Fi 连接网络。"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "至少包含 8 个字符"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "至多包含 %d 个字符"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "要打开 Wi-Fi 热点吗？"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-Fi热点允许其他人通过创建他们可以连接的Wi-Fi网络来共享您的互联网连接。 为"
+"此，您必须通过Wi-Fi以外的其他来源建立互联网连接。"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "网络名称"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "密码"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "生成随机密码"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "自动生成密码"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "打开(_T)"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "停止热点并断开所有用户？"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "停止热点(_S)"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "飞行模式"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "禁用 Wi-Fi、蓝牙及移动宽带"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "未找到 Wi-Fi 适配器"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "请确保您已插入并打开了 Wi-Fi 适配器"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "飞行模式已开启"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "关闭以使用 Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "已启用 Wi-Fi 热点"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "移动设备可以扫描二维码进行连接。"
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "关闭热点…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "可见网络"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "需要运行 NetworkManager"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1X 安全性(_S)"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "安全"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "预留"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "永久"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "随机"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "固定"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"此处输入的 MAC 地址将用作此连接激活所在的网络设备的硬件地址。该特性被称为 "
+"MAC 克隆或欺骗。例如：00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "配置 %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "增强开放"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "企业"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "无"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "从不"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i 天前"
+
+#: panels/network/connection-editor/ce-page-details.c:299
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:301
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/秒"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:320
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "None"
+msgstr "无"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "较弱"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "一般"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "良好"
+
+#: panels/network/connection-editor/ce-page-details.c:348
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "非常好"
+
+#: panels/network/connection-editor/ce-page-details.c:415
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 地址"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 地址"
+
+#: panels/network/connection-editor/ce-page-details.c:418
+#: panels/network/connection-editor/ce-page-details.c:419
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP 地址"
+
+#: panels/network/connection-editor/ce-page-details.c:423
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:426
+#: panels/network/connection-editor/ce-page-details.c:427
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Forget Connection"
+msgstr "忘记连接"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove Connection Profile"
+msgstr "移除连接配置"
+
+#: panels/network/connection-editor/ce-page-details.c:483
+msgid "Remove VPN"
+msgstr "移除 VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:501
+msgid "Details"
+msgstr "详细信息"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "自动"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "身份"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "删除地址"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "删除路由"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "无"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128 位密钥（Hex 或 ASCII）"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128 位密码"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "动态 WEP (802.1X)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA 和 WPA2 个人"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA 和 WPA2 企业"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3个人"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "信号强度"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "链路速度"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "硬件地址"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "支持频率"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "默认路由"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "上次使用"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "自动连接(_A)"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "对其他用户可用(_O)"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "计费连接：有数据限制或可能产生费用(_M)"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr "软件更新和其他大型下载将不会自动启动。"
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "名称(_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "MAC 地址(_M)"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "MTU(_T)"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "克隆的地址(_C)"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "字节"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 方式"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "自动 (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "仅本地链路"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "手动"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "禁用"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "与其他计算机共享"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "地址"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "地址"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "子网掩码"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "网关"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:621
+msgid "Automatic"
+msgstr "自动"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "自动 DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS 服务器地址"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "使用逗号分隔 IP 地址"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "路由"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "自动路由"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "跃点"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "仅对该网络上的资源使用此连接(_O)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 方式"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "自动，仅 DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "前缀"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "无法打开连接编辑器"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "新配置"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "无效的设置 %s：%s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "无效的设置 %s"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "从文件导入…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "添加 VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "安全(_E)"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "无法导入 VPN 连接"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"文件“%s”无法读取或未包含可识别的 VPN 连接信息\n"
+"\n"
+"错误：%s。"
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "选择要导入的文件"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "名为“%s”的文件已存在。"
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "替换(_R)"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "您希望用将要保存的 VPN 连接替换 %s 么？"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "无法导入 VPN 连接"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"无法将 VPN 连接“%s”导出到 %s。\n"
+"\n"
+"错误：%s。"
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "导出 VPN 连接"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "（错误：无法载入 VPN 连接编辑器）"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "控制连接到互联网的方式"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;网络;互联网协议;局"
+"域网;代理;广域网;宽带;调制解调器;蓝牙;虚拟专用网;域名系统;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "控制连接到 Wi-Fi 网络的方式"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;网络;无线;无线保真;"
+"互联网协议;局域网;宽带;域名系统;热点;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "从不"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "今天"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "昨天"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "上次使用"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "有线"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "添加新连接"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr "所选网络的细节，包括密码和全部自定义设置都将丢失。"
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "忘记(_F)"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "已知的 Wi-Fi 网络"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "忘记(_F)"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "系统策略禁止作为热点使用"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "无线设备不支持热点模式"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "若未提供配置 URL，将使用网络代理自动发现。"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "对于不可信的公共网络，不建议这样做。"
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "关闭设备"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "活动"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "提供者"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "网络代理"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "HTTP 代理(_H)"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "HTTPS 代理(_T)"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "FTP 代理(_F)"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Socks 主机(_S)"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "忽略主机(_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP 代理端口"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS 代理端口"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP 代理端口"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "SOCKS 代理端口"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "配置 URL(_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "关闭 VPN 连接"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "热点网络名称"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "热点安全类型"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "热点密码"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "关闭 Wi-Fi"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "更多选项…"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "连接到隐藏网络(_C)…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "打开 Wi-Fi 热点(_T)…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "已知的 Wi-Fi 网络(_K)"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "未知状态"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "未托管"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "不可用"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "正在连接"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "需要认证"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "正在断开"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "连接失败"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "未知状态（丢失）"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "配置失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP 配置失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP 配置已过期"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "需要认证凭据，但没有提供"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1X 客户端已断开"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1X 客户端配置失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1X 客户端失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1X 客户端认证耗时过长"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "PPP 服务启动失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP 服务已断开"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP 失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP 客户端启动失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP 客户端错误"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP 客户端失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "共享连接服务启动失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "共享连接服务失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "AutoIP 服务启动失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP 服务出错"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP 服务失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "线路忙"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "无拨号音"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "无法建立载波"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "拨号请求超时"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "拨号尝试失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "调制解调器初始化失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "无法选择指定的 APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "未在搜索网络"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "网络注册被拒绝"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "网络注册超时"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "无法在请求的网络上注册"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN 检查失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "设备可能缺少固件"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "连接丢失"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "已假定为现有连接"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "未找到调制解调器"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "蓝牙连接失败"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "未插入 SIM 卡"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "需要 SIM PIN 码"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "需要 SIM PUK 码"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM 错误"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "连接依赖失败"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "固件缺失"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "线缆已拔出"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "802.1X 安全性里未定义的错误 (wpa-eap)"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "未选择文件"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "验证 eap-method 文件时发生未知错误"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER、PEM、PKCS#12 或 PGP 私钥"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER 或 PEM 证书"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "缺失 EAP-FAST PAC 文件"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC 文件(*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "匿名"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "已认证"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "两者"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "匿名身份(_M)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC 文件(_F)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "选择 PAC 文件"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "内部认证(_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "允许自动 PAC 配置(_V)"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "缺失 EAP-LEAP 用户名"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "缺失 EAP-LEAP 密码"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "用户名(_U)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "密码(_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "显示密码(_W)"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "无效的 EAP-PEAP CA 证书：%s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "无效的 EAP-PEAP CA 证书：未指定证书"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "版本 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "版本 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A 证书"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "选择 CA 证书"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "不需要 CA 证书(_R)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP 版本(_V)"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "缺失 EAP 用户名"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "缺失 EAP 密码"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "缺失 EAP-TLS 身份"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "无效的 EAP-TLS CA 证书：%s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "无效的 EAP-TLS CA 证书：未指定证书"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "无效的 EAP-TLS CA 私钥：%s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "无效的 EAP-TLS 用户证书：%s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "未加密的私钥不安全"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"所选私钥似乎没有密码保护，这可能使您的安全凭据遭到泄露。请选择一个有密码保护"
+"的私钥。\n"
+"\n"
+"（您可以使用 openssl 来对私钥进行密码保护）"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "选择您的个人证书"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "选择您的私钥"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "身份(_D)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "用户证书(_U)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "私钥(_K)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "私钥密码(_P)"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "无效的 EAP-TTLS CA 证书：%s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "无效的 EAP-TTLS CA 证书：未指定证书"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2（无 EAP）"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "域(_D)"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "验证 802.1X 安全性时发生未知错误"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "隧道 TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "受保护的 EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "认证(_T)"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "选择文件"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "缺失 leap-username"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "缺失 leap-password"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "Wi-Fi 密码缺失。"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "类型(_T)"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "缺失 wep-key"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "无效的 wep-key：%zu 长度的密钥只能包含十六进制数字"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "无效的 wep-key：%zu 长度的密钥只能包含 ASCII 字符"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"无效的 wep-key：错误的密钥长度 %zu。密钥必须为长度 5/13 (ASCII) 或者 10/26 "
+"(十六进制)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "无效的 wep-key：密码字段不能为空"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "无效的 wep-key：密码字段必须短于 64 个字符"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1（默认）"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "开放系统"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "共享密钥"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "密钥(_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "显示密钥(_W)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP 索引(_X)"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr ""
+"无效的 wep-psk：无效的密钥长度 %zu。必须为 [8,63] 字节或者 64 位十六进制数字"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "无效的 wep-psk：无法将 64 字节作为十六进制来解析密钥"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "通知(_N)"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "声音警报(_A)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "通知弹窗(_P)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr "禁用弹窗时通知将继续在通知列表里显示。"
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "在弹窗中显示消息内容(_C)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "锁屏通知(_L)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "锁屏时显示显示消息内容(_O)"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "勿扰(_D)"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "锁屏通知(_L)"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "控制显示的通知种类及内容"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;Banner;Message;Tray;Popup;通知;横幅;条幅;消息;托盘;弹出;弹窗;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "其他"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "%s 已移除"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "移除帐号出错"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "撤消"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "关闭通知"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "连接您的云端数据"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "无互联网连接——连接以设置新的在线帐号"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "添加帐号"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s 帐号"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "移除帐号"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "在线帐号"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "连接在线帐号并决定如何使用"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;谷歌;脸谱;脸书;推特;雅虎;互联网;网络;在"
+"线;聊天;日历;邮件;联系人;云存储;稍后阅读;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "未知时间"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i 分钟"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i 小时"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "时"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "分"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s 后充满"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "注意：剩余 %s 的电量"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "剩余 %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "已充满"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "未充电"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "已耗尽"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "正在充电"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "正在放电"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "无线鼠标"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "无线键盘"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "不间断电源（UPS）"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "个人数字助理（PDA）"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "手机"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "媒体播放器"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "数位板"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "计算机"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "游戏输入设备"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "电池"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "主电池"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "附加电池"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "电池"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "空闲时(_I)"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "挂起"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "电源关闭"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "休眠"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "不处理"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "电池供电时"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "插入电源时"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "从不"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "自动挂起"
+
+#: panels/power/cc-power-panel.c:1033
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "由于工作温度高，性能模式暂时禁用。"
+
+#: panels/power/cc-power-panel.c:1035
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr "检测到膝上使用：性能模式暂时不可用。将设备移动到稳定的表面以恢复。"
+
+#: panels/power/cc-power-panel.c:1037
+msgid "Performance mode temporarily disabled."
+msgstr "性能模式暂时禁用。"
+
+#: panels/power/cc-power-panel.c:1079
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr "电池电量低：节电模式已启用。电池充满电时，将恢复之前的模式。"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1087
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "节电模式由“%s”激活。"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1091
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "性能模式由“%s”激活。"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 分钟"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 分钟"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 分钟"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 分钟"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 分钟"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 小时"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 分钟"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 分钟"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 分钟"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 小时"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "电源模式"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "影响系统性能和功耗。"
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "节电选项"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "自动屏幕亮度"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "屏幕亮度根据周围光线进行调整。"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "屏幕变暗"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "当计算机处于非活动状态时降低屏幕亮度。"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "息屏(_B)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "在一段时间的不活动后关闭屏幕。"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "自动节电"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "电池电量低时启用节电模式。"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "自动挂起(_A)"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "在一段时间的不活动后暂停计算机。"
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "电源按钮行为(_W)"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "显示电池百分比(_P)"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "自动挂起"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "已插入电源(_P)"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "使用电池时(_B)"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "延迟"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "性能"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "高性能和功耗。"
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "均衡"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "标准性能和功耗。"
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "节电"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "降低性能和功耗。"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "电源"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "查看电池状态并更改省电设置"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;电源;睡眠;挂起;休眠;电池;亮度;暗;空白;息屏;监视器;显示器;空闲;能源;能"
+"耗;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "已删除打印机“%s”"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "添加新打印机失败。"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "无法载入界面：%s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "解锁以添加打印机及更改设置"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "打印机"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "添加打印机，查看打印任务和管理打印"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+"Printer;Queue;Print;Paper;Ink;Toner;打印机;队列;打印;纸张;墨水;墨粉;硒鼓;墨"
+"盒;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "添加打印机"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "解锁(_U)"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "未找到打印机"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "输入网络地址或搜索打印机"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "需要认证"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr "输入用户名和密码以查看打印服务器上的打印机。"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "用户名"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "%s 详细信息"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "未找到合适的驱动"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "选择 PPD 文件"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr "PostScript 打印机描述文件 (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "打印机名称不能包含空格、制表符、# 或 /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "位置"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "驱动"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "正在搜索首选驱动…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "搜索驱动"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "从数据库选择…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "安装 PPD 文件…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "选择打印机驱动"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "正在载入驱动数据库…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "选择"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect 打印机"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD 打印机"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "单面"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "长边（标准）"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "短边（翻转）"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "纵向"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "横向"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "横向倒转"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "纵向倒转"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "恢复"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "暂停"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "等待中"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "已暂停"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "需要认证"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "处理中"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "已停止"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "已取消"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "已中止"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "已完成"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "将此任务移至队列顶端"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "%u 项任务需要认证"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — 活动任务"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "从 %s 输入凭据以打印。"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "域"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "认证(_U)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "全部清除"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "认证(_A)"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr "没有活动的打印机任务"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "解锁打印服务器"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "解锁 %s。"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "输入用户名和密码以查看 %s 上的打印机。"
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "正在搜索打印机"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "串口"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "并口"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "位置：%s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "地址：%s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "服务器要求认证"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "双面"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "纸张类型"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "纸张来源"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "出纸托盘"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "分辨率"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript 预过滤"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "每面页数"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "双面"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "方向"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "常规"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "页面设置"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "可安装选项"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "任务"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "图像质量"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "色彩"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "正在完成"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "高级"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "测试页"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "测试页"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "自动选择"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "打印机默认设置"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "仅内嵌 GhostScript 字体"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "转换为 PS 等级 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "转换为 PS 等级 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "无预过滤"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "厂商"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "无活动任务"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u 项任务"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "清理喷墨头"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "墨粉不足"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "墨粉用尽"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "显影剂不足"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "显影剂用尽"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "标记墨水不足"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "标记墨水用尽"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "打开上盖"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "打开后盖"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "纸张不足"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "纸张用尽"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "离线"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "已停止"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "废粉仓将满"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "废粉仓已满"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "感光鼓使用寿命已快耗尽"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "感光鼓故障"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "就绪"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "不接收任务"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "正在处理"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "打印选项"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "打印机详细信息"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "默认使用的打印机"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "清理喷墨头"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "移除打印机"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "型号"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "墨水量"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "问题解决后请重启。"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "重启"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "添加打印机…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "无打印机"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"抱歉，系统打印服务\n"
+"似乎不可用。"
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "格式"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "搜索区域…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "常见格式"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "所有格式"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "无结果"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "搜索可以是国家或语言。"
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "预览"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "英制"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "公制"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "日期"
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "日期与时间"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "数字"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "度量"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "纸张"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "语言和格式的修改将在下次登录后生效"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "注销…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr "语言设置用于界面文本和网页。格式用于数字、日期和货币。"
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "您的帐号"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "语言(_L)"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "格式(_F)"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "登录屏幕"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "区域与语言"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "选择您的显示语言和格式"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;语言;布局;键盘;输入;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "询问如何处理"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "无动作"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "打开文件夹"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "其他介质"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "选择播放音频 CD 的应用程序"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "选择播放视频 DVD 的应用程序"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "选择连接音乐播放器后运行的应用程序"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "选择连接相机后运行的应用程序"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "选择插入软件 CD 时运行的应用程序"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "音频 DVD"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "空白蓝光光盘"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "空白 CD 光盘"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "空白 DVD 光盘"
+
+# 空白 HD DVD 光盘
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "空白 HD DVD 光盘"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "蓝光视频光盘"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "电子书阅读器"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "HD DVD 视频光盘"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "图片 CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "超级 VCD"
+
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "视频 CD"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "Windows 软件"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "选择如何处理介质"
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD 音频(_A)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "DVD 视频(_D)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "音乐播放器(_M)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "软件(_S)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "其他介质(_O)…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "介质插入时从不提示或启动程序(_N)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "选择如何处理其他介质"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "动作(_A)："
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "类型(_T)："
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "可移动介质"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "配置可移动介质设置"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;设备;系统;默认;应用程序;首选;音频;视频;光盘;光碟;盘"
+"片;可擦写;可移除;可移动;媒体;介质;自动运行;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "屏幕关闭"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 秒"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 分钟"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 分钟"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 分钟"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 分钟"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 分钟"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 小时"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 分钟"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 分钟"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 分钟"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 分钟"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 分钟"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 分钟"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 分钟"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 分钟"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 分钟"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "从不"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "锁屏"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr "自动锁定屏幕可防止其他人在您不在时访问计算机。"
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "息屏延时"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "闲置一段时间后，屏幕将变为黑屏。"
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "自动锁屏(_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "自动锁屏延迟(_S)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "息屏后屏幕自动锁定的时间。"
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "在锁定屏幕上显示通知(_N)"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "禁止新 USB 设备(_U)"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "在屏幕锁定时阻止新 USB 设备与系统进行交互。"
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "屏幕隐私"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "限制可视角度"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "屏幕设置"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;屏幕;显示器;锁定;私人;隐私;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "选择位置"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "确定(_O)"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "搜索位置"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr "系统应用程序所搜索的文件夹，比如文件、照片和视频。"
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "位置"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "书签"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "其它"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "添加位置"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "未找到应用"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "应用程序搜索"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "包括应用程序提供的搜索结果。"
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "系统应用程序所搜索的文件夹。"
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "搜索结果"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "结果会根据列表顺序显示。"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "控制在活动概览中显示哪些程序的搜索结果"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+"Search;Find;Index;Hide;Privacy;Results;搜索;查找;寻找;索引;隐藏;隐私;结果;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "未选择要共享的网络"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "网络"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "已开启"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "已关闭"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "已启用"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "活动"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "选择文件夹"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "添加"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "启用媒体共享"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr "文件共享可以共享“公共”文件夹，使用地址：%s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"当启用远程登录时，远程用户可以使用 SSH 命令来连接：\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "启用个人媒体共享"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "设备名称已复制"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "设备地址已复制"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "用户名已复制"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "密码已复制"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "共享"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "计算机名(_C)"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "文件共享(_F)"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "远程桌面(_D)"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "媒体共享(_M)"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "远程登录(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "文件共享"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "需要密码(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "远程登录"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "远程桌面"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr "远程桌面允许从另一个计算机查看和操控您的桌面。"
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "启用或禁用远程桌面连接至该计算机。"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "远程控制"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "允许远程连接操控该屏幕。"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "如何连接"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr "使用设备名称或远程桌面地址连接至该计算机。"
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "复制"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "远程桌面地址"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "认证"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "连接至该计算机需要用户名和密码。"
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "用户名"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "验证加密"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "加密指纹"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr "加密指纹可以在连接的客户端中看到且应一致。"
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "媒体共享"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "通过网络共享音乐、照片和视频。"
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "文件夹"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "控制想要与其他用户共享的内容"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;共享;主机;名称;远程;桌面;介质;媒体;音频;视频;图片;照"
+"片;电影;服务器;渲染;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "启用或禁用远程登录"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "启用或禁用远程登录需要认证"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "自定义"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "点击"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "弦乐"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "摇摆"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "哼唱"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "均衡"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "淡出"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "后"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "前"
+
+# 对话框标题
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "测试 %s"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "单击扬声器进行测试"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "系统音量"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "主音量"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "音量级别"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "输出"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "输出设备"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "测试"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "配置"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "重低音"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "输入"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "输入设备"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "音量"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "警报声"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "静音"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "声音"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "更改音频音量、音频输入输出和事件声音"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;声"
+"卡;麦克风;话筒;音量;淡入淡出;均衡;蓝牙;耳机;耳麦;音频;输出;输入;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "已断开"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "正在连接"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "已连接"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "认证错误"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "正在认证"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "功能受限"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "已连接并认证"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "未知状态"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "授权于："
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "连接于："
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "登记于："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "无法授权设备："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "无法忘记设备："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "依赖于 %u 个其它设备"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "关闭通知"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "名称："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "状态："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "认证并连接"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "忘记设备"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "错误"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "已授权"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr "雷电接口子系统（boltd）未安装或配置不正确。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "允许直接访问底座和外置图形处理器一类的设备。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "只能挂接 USB 和 Display Port 设备。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"无法探测到雷电接口。\n"
+"可能是该系统无雷电接口支持，或在 BIOS 中被禁用，抑或是设置成了不被支持的安全"
+"级别。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "雷电接口支持在 BIOS 中被禁用。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "无法确定雷电接口安全级别。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "无法切换为直接模式：%s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "无雷电接口支持"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "无法连接到雷电接口子系统。"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "直接访问"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "等待中的设备"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "未连接设备"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "雷电接口"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "管理雷电接口设备"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;雷雳;雷电;隐私;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "光标闪烁"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "文本字段中光标闪烁。"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "速度"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "光标闪烁速度"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "光标大小"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "可通过缩放光标大小来更清晰地看见光标。"
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "点击助手"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "模拟副键点击(_S)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "按住鼠标主键不放时触发副键点击"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "按键接受延迟(_C)："
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "副键点击延迟"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "长"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "悬停点击(_H)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "指针悬停时触发点击"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "延迟(_E)："
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "长"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "运动阈值(_T)："
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "小"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "大"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "重复"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "按住某一键时重复该键。"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "重复键延时"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "重复键速度"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "打字助手"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "粘滞键(_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "将一系列按键当作组合键"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "同时按下两个键时禁用输入(_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "按修饰键时蜂鸣(_M)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "慢速键(_L)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "在按下按键和接受按键之间添加延迟"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "慢速键输入延迟"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "长"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "按键时蜂鸣(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "按键被接受时蜂鸣(_A)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "按键被拒绝时蜂鸣(_R)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "重复键(_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "忽略快速重复按键"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "重复键输入延迟"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "长"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "通过键盘启用(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "通过键盘开关辅助功能特性"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "默认"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "中"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "大"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "更大"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "最大"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d 个像素"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "始终显示辅助功能菜单(_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "视觉"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "高对比度(_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "大号文本(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "启用动画(_N)"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "屏幕朗读(_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "移动焦点时朗读显示的文本。"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "发声键(_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "数字键盘锁定或大小写锁定开启或关闭时发出蜂鸣声。"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "光标大小(_U)"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "缩放(_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "听觉"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "视觉警报(_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "屏幕键盘(_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "重复键(_E)"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "光标闪烁(_B)"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "AccessX 打字助手(_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "指向和点击"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "鼠标键(_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "定位指针(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "点击助手(_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "双击延时(_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "双击延时"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "视觉警报"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "测试闪烁(_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "发出警报声时使用视觉提示。"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "闪烁整个屏幕(_S)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "闪烁整个窗口(_W)"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ 屏幕"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ 屏幕"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ 屏幕"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "长"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "全屏"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "上半部分"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "下半部分"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "左半部分"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "右半部分"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "缩放选项"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "放大比率(_M)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "放大镜位置："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "跟随鼠标光标(_F)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "屏幕区域(_S)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "放大镜可延伸至屏幕外(_E)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "保持放大镜光标居中(_K)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "放大镜光标推动内容(_P)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "放大镜光标与内容同步移动(_C)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "放大镜"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "十字光标(_C)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "光标与鼠标指针重叠（——O）"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "粗细(_T)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "细"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "粗"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "长度(_L)："
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "颜色(_L)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "十字光标"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "色彩效果："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "黑底白字(_W)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "亮度(_B)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "对比度(_C)："
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "色彩(_L)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "无"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "完全"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "低"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "高"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "低"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "高"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "色彩效果"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "辅助视觉、听觉、打字和指点操作"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;键盘;鼠标;无障碍;辅助功能;通用访问;可访问;对比度;光"
+"标;声音;缩放;屏幕;读取器;阅读器;大;高;巨大;文本;文字;字体;大小;粘滞;按键;慢;"
+"回弹;鼠标;双击;点击;单击;延迟;速度;助手;重复;闪烁;可视化;视觉;听觉;音频;输入;"
+"打字;动画;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 小时"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 天"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "清空回收站中的所有项目吗？"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "回收站内的所有项目将会永久删除。"
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "清空回收站(_E)"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "删除所有临时文件吗？"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "所有临时文件将会永久删除。"
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "清理临时文件(_P)"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 天"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 天"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 天"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "永久"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "文件历史"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"文件历史记录会记录您已使用的文件。此信息在应用程序之间共享，使查找您可能想要"
+"使用的文件更加容易。"
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "文件历史(_I)"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "文件历史持续时间(_H)"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "清理历史(_C)…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "回收站与临时文件"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"回收站和临时文件有时可能包含个人信息或敏感信息。自动删除它们可以帮助保护隐"
+"私。"
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "自动清空回收站(_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "自动清理临时文件(_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "自动清空周期(_P)"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "清空回收站(_E)…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "清除临时文件(_D)…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "文件历史与回收站"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "不留痕迹"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"占用;最近;历史;文件;临时;私人;隐私;回收站;垃圾;清除;保留;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "应与您登录提供商的网络地址相同。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "添加帐号失败"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "密码不匹配。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "注册用户失败"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "没有支持该域的验证方法"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "加入域失败"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"登录名不正确。\n"
+"请重试。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"登录密码不正确。\n"
+"请重试。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "登录到域失败"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "找不到该域名，也许拼写有误？"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "添加用户"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "管理员"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"管理员可以添加和移除其他用户，并且可以更改所有用户的设置。家长控制不能应用到"
+"管理员上。"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "用户在首次登录时设置密码"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "现在设置密码"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "确认"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "企业登录"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "由企业或组织管理的用户账户。"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "您已离线"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"企业登录允许在本设备上使用已有的、集中管理的用户帐号。您也可以使用此帐号访问"
+"公司在互联网上的资源。"
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "浏览更多图片"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "选择文件…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "指纹管理器"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "指纹"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "否(_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "是(_Y)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "您想要删除登记的指纹使指纹登录被禁用吗？"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "无指纹设备"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "无指纹设备"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "请确保设备已正常连接。"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "指纹设备"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "选择您想要配置的指纹设备"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "指纹登录"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr "指纹登录可以帮助您使用手指解锁并登录您的计算机"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "删除指纹(_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "指纹登记"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "设备需要被请求执行该动作"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "设备正被另一个进程请求"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "您没有权限执行该动作"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "没有登记到指纹"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "注册时连接设备失败"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "连接指纹读取器失败"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "连接指纹守护程序失败"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:539
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "列出指纹失败：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:606
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "删除已保存的指纹失败：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:637
+msgid "Left thumb"
+msgstr "左手拇指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:639
+msgid "Left middle finger"
+msgstr "左手中指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:641
+msgid "_Left index finger"
+msgstr "左手食指(_L)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:643
+msgid "Left ring finger"
+msgstr "左手无名指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:645
+msgid "Left little finger"
+msgstr "左手小指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:647
+msgid "Right thumb"
+msgstr "右手拇指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:649
+msgid "Right middle finger"
+msgstr "右手中指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:651
+msgid "_Right index finger"
+msgstr "右手食指(_R)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:653
+msgid "Right ring finger"
+msgstr "右手无名指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:655
+msgid "Right little finger"
+msgstr "右手小指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:657
+msgid "Unknown Finger"
+msgstr "未知手指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:791
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "完成"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:802
+msgid "Fingerprint device disconnected"
+msgstr "指纹设备已断开连接"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:808
+msgid "Fingerprint device storage is full"
+msgstr "指纹设备存储已满"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:812
+msgid "Failed to enroll new fingerprint"
+msgstr "登记新指纹失败"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:843
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "登记过程初始化失败：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:851
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "登记新指纹失败"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:882
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "停止登记过程失败：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:928
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr "要登记指纹，请重复将手指举起然后放置在读取设备上的动作"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1047
+msgid "_Re-enroll this finger…"
+msgstr "重新登记该手指(_R)…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1062
+msgid "Scan new fingerprint"
+msgstr "扫描新指纹"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1100
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "释放指纹设备 %s 失败：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1172
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "读取设备时出现问题"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1207
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "无法请求指纹设备 %s：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1358
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "获取指纹设备失败：%s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "本周"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "上周"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b %e"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%Y %b %e"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s，%s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "会话结束"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "会话开始"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — 帐号活动"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "上页"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "下页"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "请选择另一个密码。"
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "请再次输入当前密码。"
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "无法更改密码"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "更改密码"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "更改(_A)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "当前密码"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "新建密码"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "确认密码"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "允许用户下次登录时更改密码"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "现在设置密码"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "无法自动加入此类域"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "无此域或 Realm"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "无法以 %s 的身份登录域 %s"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "无效密码，请重试"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "无法连接到 %s 域：%s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "删除用户失败"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "吊销远程管理的用户失败"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "不能删除自己的帐号。"
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s 已经登录"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "删除已登录帐号可能导致系统不一致。"
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "要保留 %s 的文件吗？"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr "删除用户时可以保留其主目录、电子邮件目录和临时文件。"
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "删除文件(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "保留文件(_K)"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "您确定要吊销远程管理的帐号 %s 吗？"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "删除(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "帐号已禁用"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "下次登录时设置"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "无"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "已登录"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "联系帐号服务失败"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "请确定帐号服务已正确安装并启用。"
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "该面板必须解锁才能更改设置"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "删除选中的用户帐号"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"要删除选中的用户帐号，\n"
+"请先点击 * 图标"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "解锁以允许用户更改设置"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "用户"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "更改需要重启会话才能生效"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "现在重启"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "关闭"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "编辑头像"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "全名"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "编辑"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "指纹登录(_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "自动登录(_U)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "帐号活动"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "管理员(_A)"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr "管理员可以增删用户，也能为所有用户更改设置。"
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "家长控制(_P)"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "打开家长控制应用程序。"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "移除用户…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "其它用户"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "添加用户…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "未找到用户"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "解锁以添加用户帐号。"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "添加或删除用户及更改密码"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;登录;名字;"
+"名称;指纹;头像;标志;脸部;密码;家长控制;亮屏时间;应用限制;网络限制;占用;占用限"
+"制;孩子;儿童;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "登记(_E)"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "域管理员登录"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"要使用企业登录，需要在域中注册该计算机。\n"
+"请要求网络管理员在此输入域密码。"
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "管理员名称(_N)"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "管理员密码"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "管理用户帐号"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "改变用户数据需要认证"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "新密码不能和旧密码相同。"
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "请改动一些字母和数字。"
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "请进一步修改密码。"
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "不包含用户名的密码更安全。"
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "请勿在密码中使用您的名字。"
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "请勿在密码中使用单词。"
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "请勿使用常用单词。"
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "请勿仅变更现有单词顺序。"
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "请使用更多数字。"
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "请使用更多大写字母。"
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "请使用更多小写字母。"
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "请使用更多特殊字符，如标点符号。"
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "请混用字母、数字和标点符号。"
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "请避免重复相同的字符。"
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr "请避免重复相同类型的字符：你需要混合字母、数字和标点符号。"
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "请避免使用如 1234 或 abcd 的有规律序列。"
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr "需要更长的密码。请试着加入更多的字母、数字和标点符号。"
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "密码需要大小写字母混用并试着使用一到两个数字。"
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "增加更多字母、数字和标点可进一步提高密码强度。"
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "认证失败"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "新密码太短"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "新密码太简单"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "新密码和旧密码太相似"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "新的密码最近已使用过。"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "新密码必须包含数字或特殊字符"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "新旧密码相同"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "密码在您首次认证后已经更改！"
+
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "新密码必须一定量不同的字符"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "未知错误"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr "用户名只能包含小写英文字母（a 至 z）、数字和“-”、“_”符号"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "抱歉，该用户名不可用。请试下别的。"
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "用户名太长。"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "映射按键"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "将功能映射到按键"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"要编辑快捷键，请选择“发送按键”动作，按下键盘快捷键，然后输入新按键组合，或按"
+"退格键清除。"
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "关闭(_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "请触摸屏幕上出现的标记以校准平板电脑。"
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "检测到误点击，重新开始校准…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "按键 %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "应用程序定义"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "发送按键"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "切换显示器"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "显示屏幕帮助"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "数位板已挂载在笔记本屏幕上"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "数位板已挂载在外部显示器上"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "外部数位板设备"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "外部平板设备"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:608
+msgid "All Displays"
+msgstr "全部显示器"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "数位板模式"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "为笔使用绝对位置"
+
+# 左撇子有歧视色彩。
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "惯用左手"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "数位板和快捷按键已旋转为左手使用"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "映射到显示器"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "保持宽高比"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "仅使用数位板表面的一部分来保持显示器宽高比"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "校准"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "未检测到数位板"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "请插入或打开您的 Wacom 数位板。"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "笔尖压感"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "软"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "笔尖压力"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "硬"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "按键 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "按键 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "按键 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "擦除压感"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "擦除压力"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "鼠标中键单击"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "鼠标右键单击"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "前进"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "具有压感、倾斜和集成滑块的喷枪笔"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "具有压感、倾斜和旋转的喷枪笔"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "具有压感和倾斜的标准笔"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "具有压感的标准笔"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom 数位板"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "为绘图用平板设备设置按键映射并调整触控笔灵敏度"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+"Tablet;Wacom;Stylus;Eraser;Mouse;数位板;绘图板;绘画板;手绘板;手写板;触控笔;橡"
+"皮擦;擦除器;鼠标;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "新建快捷键…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "接入点"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "操作已取消"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>错误：</b>更改设置被拒绝"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>错误：</b>移动设备错误"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "未注册"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "已注册"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "漫游中"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "搜索中"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "已拒绝"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "调制解调器详细信息"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "调制解调器状态"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "运营商"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "网络类型"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "网络状态"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "所有号码"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "设备详细信息"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "固件版本"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "仅 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "仅 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "仅 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "仅 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G、3G、4G、5G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G、3G、4G（首选）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G、3G（首选）、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G（首选）、3G、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G、3G、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G、3G、4G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G、3G（首选）、4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G（首选）、3G、4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G、3G、4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G、4G、5G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G、4G（首选）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G（首选）、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G、4G、5G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G、4G（首选）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G（首选）、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G、3G、5G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G、3G（首选）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G（首选）、3G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G、3G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G、4G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G（首选）、4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G、4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G、4G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G（首选）、4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G、4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G、3G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G（首选）、3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G、3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G、5G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G（首选）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G、5G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G（首选）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "4G、5G（首选）"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G（首选）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "未知"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "解锁 SIM 卡"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "解锁"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "请提供 SIM 卡 %d 的 PIN 码"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "输入 PIN 以解锁您的 SIM 卡"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "请提供 SIM 卡 %d 的 PUK 码"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "输入 PUK 以解锁您的 SIM 卡"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "密码输入错误。您还有 %1$u 次尝试机会"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "您还有 %u 次尝试机会"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "密码输入错误。"
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK 码应为 8 位数字"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "输入新 PIN"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN 码应为 4 到 8 位数字"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "正在解锁……"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "无 SIM 卡"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "插入 SIM 卡以使用该调制解调器"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM 卡已锁定"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "移动数据(_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "使用移动网络访问数据"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "数据漫游(_D)"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "漫游时使用移动数据"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "网络模式(_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "网络(_E)"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "高级"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "接入点名称"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "SIM 锁(_S)"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "使用 PIN 锁定 SIM"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "调制解调器详细信息(_O)"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "移动电话错误"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "没有到电话的连接"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "操作不允许"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "操作不支持"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM 卡未插入"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "需要 SIM PIN"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "需要 SIM PUK"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM 卡失败"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM 卡忙"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "密码不正确"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "需要 SIM PIN2"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "需要 SIM PUK2"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "未找到"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "无网络服务"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "网络超时"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "不允许 GPRS 服务"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "此位置区域不允许漫游"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "未指定的 GPRS 错误"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "没有错误"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "操作已取消"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "拒绝访问"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "未知错误"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "网络模式"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "自动(_A)"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "选择网络"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "刷新网络提供商"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "启用移动网络"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "未找到 WWAN 适配器"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "请确保您拥有无线 Wan/蜂窝设备"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "无线 Wan 在飞行模式下已禁用"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "关闭飞行模式(_T)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "数据连接"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "用于互联网的 SIM 卡"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM 锁"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "下一步(_N)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "使用 PIN 锁定 SIM (_L)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "更改 PIN"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "输入当前 PIN 以更改 SIM 锁设置"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "移动网络"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "配置电话和移动数据连接"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr "cellular;wwan;telephony;sim;mobile;蜂窝;移动;无线;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "用来配置 GNOME 桌面的工具"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "“设置”是配置您的系统的主要界面。"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME 项目"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "显示版本号"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "启用详细模式"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "搜索字符串"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "列出所有面板名称并退出"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "要显示的面板"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[面板] [参数…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "设置分类"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "隐私"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "可用面板："
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "全部设置"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "主菜单"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "警告：开发版本"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"该版本的 GNOME 设置仅适用于开发工作。您可能会遇到不正常的系统行为、数据丢失及"
+"其他未预期的问题。 "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "帮助"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "常规"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "退出"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "搜索"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "面板"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "后退到上个面板"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "取消搜索"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;首选项;设置;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "要打开最后面板的身份"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr "要打开最近面板的身份。未识别的值将被忽略，然后选中第一个面板。"
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "运行开发版本的 GNOME 设置时显示警告"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "是否在运行开发版本的 GNOME 设置时显示警告。"
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "窗口初始状态"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr "元组类型的值，包含应用程序窗口的初始宽度、高度和最大化状态。"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u 路输出"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u 路输入"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "系统声音"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "错误：无法确定 HSI 级别。"
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "错误：无法确定错误的 HSI 级别。"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER 或 PEM 证书 (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "添加打印机…"
+
+#~ msgid "Drip"
+#~ msgstr "雨滴"
+
+#~ msgid "Glass"
+#~ msgstr "玻璃"
+
+#~ msgid "Sonar"
+#~ msgstr "声纳"
+
+#~ msgid "No Protection"
+#~ msgstr "无保护"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "最小保护"
+
+#~ msgid "Basic Protection"
+#~ msgstr "基本保护"
+
+#~ msgid "Extended Protection"
+#~ msgstr "扩展保护"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "最小安全保护"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "基本安全保护"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "扩展安全保护"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI 写入"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI 锁定"
+
+#~ msgid "SPI BIOS region"
+#~ msgstr "SPI BIOS 区域"
+
+#~ msgid "Pre-boot DMA protection is"
+#~ msgstr "预启动 DMA 保护为"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "内核感染"
+
+#~ msgid "Suspend-to-ram"
+#~ msgstr "挂起到内存"
+
+#~ msgid "All TPM PCRs are"
+#~ msgstr "所有 TPM PCR 为"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "MEI 制造商模式"
+
+#~ msgid "MEI override"
+#~ msgstr "MEI 覆盖"
+
+#~ msgid "MEI version"
+#~ msgstr "MEI 版本"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "fwupd 插件"
+
+#~ msgid "Intel DCI debugger"
+#~ msgstr "英特尔 DCI 调试器"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "IOMMU 设备保护已启用"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "IOMMU 设备保护已禁用"
+
+#~ msgid "Kernel is no longer tainted"
+#~ msgstr "内核不再被感染"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "内核已感染"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "内核封锁已禁用"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "内核封锁已启用"
+
+#~ msgid "Pre-boot DMA protection is disabled"
+#~ msgstr "预启动 DMA 保护已禁用"
+
+#~ msgid "Pre-boot DMA protection is enabled"
+#~ msgstr "预启动 DMA 保护已启用"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "安全启动已禁用"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "安全启动已启用"
+
+#~ msgid "All TPM PCRs are valid"
+#~ msgstr "所有 TPM PCR 已验证"
+
+#~ msgid "All TPM PCRs are now valid"
+#~ msgstr "所有 TPM PCR 现在已验证"
+
+#~ msgid "A TPM PCR is now an invalid value"
+#~ msgstr "一个 TPM PCR 现在为无效值"
+
+#~ msgid "TPM PCR0 reconstruction is invalid"
+#~ msgstr "TPM PCR0 复原无效"
+
+#~ msgid "Lock your screen"
+#~ msgstr "锁定屏幕"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "安全启动未激活"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "显示器布局"
+
+#~ msgid "Light"
+#~ msgstr "亮色"
+
+#~ msgid "Set"
+#~ msgstr "设置"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;屏幕;锁;诊断;崩溃;私;最近;临时;索引;名称;网络;认证;标志;"
+#~ "身份;"
+
+#~ msgid "Bark"
+#~ msgstr "犬吠"
+
+#~ msgid "GNOME Settings Sound Panel"
+#~ msgstr "GNOME 设置声音面板"
+
+#~ msgid "GNOME Settings Mouse &amp; Touchpad Panel"
+#~ msgstr "GNOME 设置鼠标和触摸板面板"
+
+#~ msgid "GNOME Settings Background Panel"
+#~ msgstr "GNOME 设置背景面板"
+
+#~ msgid "GNOME Settings Keyboard Panel"
+#~ msgstr "GNOME 设置键盘面板"
+
+#~ msgid "More Warm"
+#~ msgstr "增加暖色"
+
+#~ msgid "Less Warm"
+#~ msgstr "减少暖色"
+
+#~ msgid "Move up"
+#~ msgstr "上移"
+
+#~ msgid "Move down"
+#~ msgstr "下移"
+
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "认证"
+
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr "屏幕共享允许远程用户查看或控制您的屏幕%s"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "屏幕共享(_S)"
+
+#~ msgid "_Password:"
+#~ msgstr "密码(_P)："
+
+#~ msgid "_Show Password"
+#~ msgstr "显示密码(_S)"
+
+#~ msgid "Access Options"
+#~ msgstr "访问选项"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "建立新连接前必须询问访问权限(_N)"
+
+#~ msgid "_Require a password"
+#~ msgstr "需要密码(_R)"
+
+#~ msgid "Show the screenshot UI"
+#~ msgstr "显示截图界面"
+
+#~ msgid "Take a screenshot"
+#~ msgstr "截图"
+
+#~ msgid "Take a screenshot of a window"
+#~ msgstr "对窗口进行截图"
+
+#~ msgid "Show the screen recording UI"
+#~ msgstr "显示录屏界面"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "允许以下应用程序使用您的麦克风。"
+
+#~ msgid "Standard"
+#~ msgstr "标准"
+
+#~ msgid "Account _Type"
+#~ msgstr "帐号类型(_T)"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "允许用户下次登录时更改密码(_L)"
+
+#~ msgid "Set a password _now"
+#~ msgstr "现在设置密码(_N)"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "您必须在线以添加企业用户。"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "拍张照片…"
+
+#~ msgid "Your account"
+#~ msgstr "您的帐号"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "要进行更改，\n"
+#~ "请先点击 * 图标"
+
+#~ msgid "Create a user account"
+#~ msgstr "创建用户帐号"
+
+#~ msgid "User Icon"
+#~ msgstr "用户图标"
+
+#~ msgid "Account Settings"
+#~ msgstr "帐号设置"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "认证与登录"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "将作为您主文件夹的名称且不可再次更改。"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr "选择数字，日期和货币的格式。 更改将在下次登录时生效。"
+
+#~ msgid "My Account"
+#~ msgstr "我的帐号"
+
+#~ msgid "Language"
+#~ msgstr "语言"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "窗口和网页使用的语言。"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "重启会话以让更改生效"
+
+#~ msgid "Restart…"
+#~ msgstr "重启…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "登录设置将对所有于本机登录的用户共享"
+
+#~ msgid "Output:"
+#~ msgstr "输出："
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "保持长宽比（黑边）："
+
+#~ msgid "Map to single monitor"
+#~ msgstr "映射到单个显示器"
+
+#~ msgid "%d of %d"
+#~ msgstr "%d/%d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "显示映射"
+
+#~ msgid "Stylus"
+#~ msgstr "触控笔"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "数位板（绝对）"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "触摸板（相对）"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "数位板首选项"
+
+#~ msgid "_Help"
+#~ msgstr "帮助(_H)"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "蓝牙设置"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "跟踪模式"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "映射按键…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "调整鼠标设置"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "调整显示分辨率"
+
+#~ msgid "Decouple Display"
+#~ msgstr "显示器解耦"
+
+#~ msgid "No stylus found"
+#~ msgstr "未找到触控笔"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "请将您的触控笔移到平板附近以进行配置"
+
+#~ msgid "Top Button"
+#~ msgstr "顶部按钮"
+
+#~ msgid "Lower Button"
+#~ msgstr "下部按钮"
+
+#~ msgid "Lowest Button"
+#~ msgstr "底部按钮"
+
+# 与下面的剪贴板“位置”相对。
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "将屏幕截图保存到 $PICTURES 目录"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "将选区截图保存到 $PICTURES 目录"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "复制截图到剪贴板"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "复制窗口截图到剪贴板"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "复制选区截图到剪贴板"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "记录一小段屏幕录像"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "控制活动概览中显示哪些搜索结果。搜索结果顺序也可以通过移动列表中的行排序进"
+#~ "行更改。"
+
+#~ msgid "Web Links"
+#~ msgstr "网络链接"
+
+#~ msgid "Git Links"
+#~ msgstr "Git 链接"
+
+#~ msgid "%s Links"
+#~ msgstr "%s 链接"
+
+#~ msgid "Unset"
+#~ msgstr "移除关联"
+
+#~ msgid "Links"
+#~ msgstr "链接"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "超文本文件"
+
+#~ msgid "Text Files"
+#~ msgstr "文本文件"
+
+#~ msgid "Image Files"
+#~ msgstr "图像文件"
+
+#~ msgid "Font Files"
+#~ msgstr "字体文件"
+
+#~ msgid "Archive Files"
+#~ msgstr "归档文件"
+
+#~ msgid "Package Files"
+#~ msgstr "软件包文件"
+
+#~ msgid "Audio Files"
+#~ msgstr "音频文件"
+
+#~ msgid "Video Files"
+#~ msgstr "视频文件"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "权限和访问"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr "应用要求访问的数据和服务以及它需要的权限。"
+
+#~ msgid "Cannot be changed"
+#~ msgstr "无法被更改"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a href="
+#~ "\"privacy\">Privacy</a> Settings."
+#~ msgstr "应用程序的各个权限可以在 <a href=\"privacy\">隐私</a> 设置中查看。"
+
+# 左撇子有歧视色彩。
+#~ msgid "Integration"
+#~ msgstr "集成"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "设置桌面背景"
+
+#~ msgid "Default Handlers"
+#~ msgstr "默认处理程序"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "应用程序打开的文件和链接类型。"
+
+#~ msgid "Usage"
+#~ msgstr "占用"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "应用程序使用了多少资源。"
+
+#~ msgid "Open in Software"
+#~ msgstr "在“软件”中打开"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "允许以下应用程序使用您的相机。"
+
+#~ msgid "Display Mode"
+#~ msgstr "显示模式"
+
+#~ msgid "Join Displays"
+#~ msgstr "加入显示器"
+
+#~ msgid "Single Display"
+#~ msgstr "单显示器"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr "拖动显示器来匹配您的物理显示器布局。选择显示器可以改变其设置。"
+
+#~ msgid "Active Display"
+#~ msgstr "使用中的显示器"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "定位服务允许应用得知您的地理定位。使用 Wi-Fi 和移动宽带可以提高精确度。"
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "使用 Mozilla 定位服务：<a href='https://location.services.mozilla.com/"
+#~ "privacy'>隐私策略</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "允许以下应用程序确定您的位置。"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "检测到膝上使用：性能模式不可用"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "硬件温度过高：性能模式不可用"
+
+#~ msgid "Performance mode unavailable"
+#~ msgstr "性能模式不可用"
+
+#~ msgid "Sound Keys"
+#~ msgstr "发声键"
+
+#~ msgid "Screen Reader"
+#~ msgstr "屏幕朗读"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "屏幕朗读(_S)"
+
+#~ msgid "Activities"
+#~ msgstr "活动"
+
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "上传文件失败：%s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "配置已上传到："
+
+#~ msgid "Write down this URL."
+#~ msgstr "请记下此 URL。"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "重启计算机并引导您日常使用的操作系统。"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "在浏览器中输入该 URL 以下载和安装该配置。"
+
+#~ msgid "Upload profile"
+#~ msgstr "上传配置"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "需要互联网连接"
+
+#~ msgid "_Copy"
+#~ msgstr "复制(_C)"
+
+#~ msgid "Select _All"
+#~ msgstr "选择全部(_A)"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "双击超时"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "挂起和关机按钮"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "因为没有网络，一些服务已经禁用。"
+
+#~ msgid "Unlocking..."
+#~ msgstr "正在解锁…"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;登录;名称;指纹;头像;标志;"
+#~ "密码;"
+
+#~ msgid "Balanced Power"
+#~ msgstr "平衡"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "键盘快捷键"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "可以在键盘快捷键设置中修改"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "按住并输入其他字符"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "屏幕亮度(_S)"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "键盘亮度(_K)"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "无操作时使屏幕变暗"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "息屏(_B)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "Wi-Fi(_W)"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "可以关闭 Wi-Fi 以节省电源。"
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr "可以关闭移动宽带（LTE、4G、3G 等）以节省电源。"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "蓝牙(_B)"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "可以关闭蓝牙以节省电源。"
+
+#~ msgid "Add…"
+#~ msgstr "添加…"
+
+#~ msgid "Left Alt"
+#~ msgstr "左Alt键"
+
+#~ msgid "Right Alt"
+#~ msgstr "右Alt键"
+
+#~ msgid "Left Super"
+#~ msgstr "左Super徽标键"
+
+#~ msgid "Right Super"
+#~ msgstr "右Super徽标键"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "右Ctrl键"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "替代的字符键"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "切换至下一输入源的修饰键"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "菜单键"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "正在充电"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "警告"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "低"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "充足"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "已充满"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "电池已耗尽"
+
+#~ msgid "Previous source"
+#~ msgstr "上个源"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "下个源"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "左+右 Alt"
+
+#~ msgid "Universal Access"
+#~ msgstr "通用辅助"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "关闭以连接到无线网络"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "密码"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "添加用户及更改密码"
+
+#~ msgid "Play and record sound"
+#~ msgstr "播放和录制声音"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "使用mDNS / DNS-SD（Bonjour / zeroconf）检测网络设备"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "直接访问蓝牙硬件"
+
+#~ msgid "Use your camera"
+#~ msgstr "使用相机"
+
+#~ msgid "Print documents"
+#~ msgstr "打印文档"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "使用任何连接的操纵杆"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "允许连接Docker服务"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "配置网络防火墙"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "设置和使用特权FUSE文件系统"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "更新此设备上的固件"
+
+#~ msgid "Access hardware information"
+#~ msgstr "访问硬件信息"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "向硬件随机数生成器提供熵"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "使用硬件生成的随机数"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "访问主文件夹中的文件"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "访问libvirt服务"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "更改系统语言与区域设置"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "更改位置设置和提供者"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "读取系统和应用程序日志"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "访问媒体中心服务"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "使用和配置调制解调器"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "阅读系统安装信息和磁盘配额"
+
+#~ msgid "Control music and video players"
+#~ msgstr "控制音视频播放器"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "更改底层网络设置"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr "访问NetworkManager服务以读取和更改网络设置"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "对网络设置的读取权限"
+
+#~ msgid "Change network settings"
+#~ msgstr "更改网络设置"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr "访问ofono服务以读取和更改电话网络设置"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "控制Open vSwitch硬件"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "从CD / DVD读取"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "增减或修改密码"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr "访问pppd和ppp设备以配置点对点协议连接"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "暂停或结束系统上的任何进程"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "直接访问USB硬件"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "在可移动存储设备上读写文件"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "阻止屏幕锁定"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "访问串行端口硬件"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "重新启动或关闭设备电源"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "安装，删除和配置软件"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "访问存储框架服务"
+
+#~ msgid "Read process and system information"
+#~ msgstr "读取过程和系统信息"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "监视和控制任何正在运行的程序"
+
+#~ msgid "Change the date and time"
+#~ msgstr "更改日期、时间"
+
+#~ msgid "Change time server settings"
+#~ msgstr "更改时间服务器设置"
+
+#~ msgid "Change the time zone"
+#~ msgstr "更改时区"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr "访问用于配置磁盘和可移动媒体的UDisks2服务"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "在Ubuntu Unity 8中读取/更改共享日历事件"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "阅读/更改Ubuntu Unity 8中的共享联系人"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "访问能源使用数据"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "U2F设备的读/写访问已开启"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "设定背景和锁屏"
+
+#~ msgid "Set Background"
+#~ msgstr "设定背景"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "设定锁屏"
+
+#~ msgid "Remove Background"
+#~ msgstr "移除背景"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "报告以匿名方式发送，并清除了个人数据。"
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr "发送技术问题报告有助于我们改进此操作系统。"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "要创建用户帐号，\n"
+#~ "请先点击 * 图标"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "启用指纹登录"
+
+#~ msgid "_Other finger:"
+#~ msgstr "其他手指(_O)："
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr "您的指纹已成功保存，从现在起可以使用指纹登录。"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "您未被允许访问该设备。请联系系统管理员。"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "发生了一个内部错误。"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "要删除已登记的指纹吗？"
+
+#~ msgid "Done!"
+#~ msgstr "完成！"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "无法访问设备“%s”"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "无法在设备“%s”上启动指纹采集"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "无法访问指纹读取器"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "请联系系统管理员以寻求帮助。"
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr "要启用指纹登录，您需要使用设备“%s”保存一个指纹。"
+
+#~ msgid "Selecting finger"
+#~ msgstr "选择手指"
+
+#~ msgid "Version %s"
+#~ msgstr "版本 %s"
+
+#~ msgid "OS name"
+#~ msgstr "系统名称"
+
+#~ msgid "OS type"
+#~ msgstr "系统类型"
+
+#~ msgid "Disk"
+#~ msgstr "磁盘"
+
+#~ msgid "Check for updates"
+#~ msgstr "检查更新"
+
+#~ msgid "Network proxy"
+#~ msgstr "网络代理"
+
+#~ msgid "page 1"
+#~ msgstr "第 1 页"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "内部认证(_A)"
+
+#~ msgid "page 2"
+#~ msgstr "第 2 页"
+
+#~ msgid "Restrict background data usage"
+#~ msgstr "限制后台数据的使用"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "适用于有数据费用或限制的连接。"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "双绞线 (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "连接单元接口 (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "媒体独立接口 (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "打开无线网热点将使您从 <b>%s</b> 断开。"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "启用热点模式时无法通过无线网络访问互联网。"
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr "Wi-Fi 热点常用于在 Wi-Fi 上共享其互联网连接。"
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "自动连接(_C)"
+
+#~ msgid "details"
+#~ msgstr "详细信息"
+
+#~ msgid "Show P_assword"
+#~ msgstr "显示密码(_A)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "对其他用户可用"
+
+#~ msgid "identity"
+#~ msgstr "身份"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "地址(_A)"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "仅自动分配地址 (DHCP)"
+
+#~ msgid "Link-local only"
+#~ msgstr "仅本地链路"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "忽略自动获取的路由(_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "克隆的 MAC 地址(_C)"
+
+#~ msgid "_Reset"
+#~ msgstr "重置(_R)"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr "将这个连接的设置重置为默认值，但仍作为首选连接。"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr "删除关于这个网络的所有细节，不再尝试自动连接。"
+
+#~ msgid "Hardware"
+#~ msgstr "硬件"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "重置"
+
+#~ msgid "Connected Devices"
+#~ msgstr "已连接的设备"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "架构"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "通知弹窗(_P)"
+
+#~ msgid "In use"
+#~ msgstr "已占用"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "开启"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "关闭"
+
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "关闭"
+
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "开启"
+
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "关闭"
+
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "开启"
+
+#~ msgid "Usage & History"
+#~ msgstr "用量及历史"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "隐私政策"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr "记住历史能够在下次使用时方便查找。这些条目永远不会通过网络共享。"
+
+#~ msgid "_Recently Used"
+#~ msgstr "最近使用(_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "保留历史(_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "离开时锁定屏幕可以保护隐私。"
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "黑屏至锁屏的等待时间(_A)"
+
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "锁屏通知(_N)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr "自动清理回收站和临时文件，避免计算机保存不必要的敏感信息。"
+
+#~ msgid "Purge _After"
+#~ msgstr "清理延时(_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "发送软件的使用情况有助于我们向提供更准确的推荐，帮助改进软件。\n"
+#~ "\n"
+#~ "信息均为匿名收集，不会与他人分享。"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "发送软件使用统计信息(_S)"
+
+#~ msgid "_Camera"
+#~ msgstr "相机(_C)"
+
+#~ msgid "_Microphone"
+#~ msgstr "麦克风(_M)"
+
+#~ msgid "_Location Services"
+#~ msgstr "定位服务(_L)"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "保护个人信息并控制他人可见的信息"
+
+#~ msgid "No regions found"
+#~ msgstr "无可用区域"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "闪烁窗口标题栏(_W)"
+
+#~ msgid "Last Login"
+#~ msgstr "最近登录"
+
+#~ msgid "_Background"
+#~ msgstr "背景(_B)"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "在一天内按时变化"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "平铺"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "缩放"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "居中"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "比例放大"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "填充"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "适合宽度"
+
+#~ msgid "Colors"
+#~ msgstr "色彩"
+
+#~ msgid "Pictures"
+#~ msgstr "图片"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "无图片"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "您添加到 %s 文件夹的图片将在此显示"
+
+#~ msgid "_Off"
+#~ msgstr "关闭(_O)"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "自动挂起(_A)"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "按下电源按钮时(_W)"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "用户名不能以“-”开头。"
+
+#~ msgid "application-x-executable"
+#~ msgstr "application-x-executable"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "Connection/SSID"
+#~ msgstr "连接/SSID"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "org.gnome.Settings"
+#~ msgstr "org.gnome.Settings"
+
+#~ msgid "Drag displays to match your setup."
+#~ msgstr "拖动显示屏以达到您的设置。"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "左"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "右"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "最小"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "最大"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "重低音(_S)："
+
+#~ msgid "_Profile:"
+#~ msgstr "配置(_P)："
+
+#~ msgid "_Test Speakers"
+#~ msgstr "测试扬声器(_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "峰值检测"
+
+#~ msgid "Device"
+#~ msgstr "设备"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s 扬声器测试"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "选择音频输出设备(_H)："
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "选中设备的设置："
+
+#~ msgid "_Input volume:"
+#~ msgstr "输入音量(_I)："
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "选择音频输入设备(_H)："
+
+#~ msgid "Sound Effects"
+#~ msgstr "声音效果"
+
+#~ msgid "Built-in"
+#~ msgstr "内置"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "声音首选项"
+
+#~ msgid "Testing event sound"
+#~ msgstr "测试事件声音"
+
+#~ msgid "From theme"
+#~ msgstr "来自主题"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "选择警报声音(_H)："
+
+#~ msgid "Stop"
+#~ msgstr "停止"
+
+#~ msgid "Add input source"
+#~ msgstr "添加输入源"
+
+#~ msgid "Remove input source"
+#~ msgstr "移除输入源"
+
+#~ msgid "Move input source up"
+#~ msgstr "上移输入源"
+
+#~ msgid "Move input source down"
+#~ msgstr "下移输入源"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "显示输入源键盘布局"
+
+#~ msgid "_Night Light"
+#~ msgstr "夜光(_N)"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "无法获取屏幕信息"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME 控制中心"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr "控制中心是 GNOME 用于配置桌面各方面设置的主要界面。"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "切换至上个输入源"
+
+#~ msgid "Switch to next source"
+#~ msgstr "切换至下个输入源"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "切换至下个源第二组快捷键"
+
+#~ msgid "_Options"
+#~ msgstr "选项(_O)"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "标准"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "管理员"
+
+#~ msgid "Quit"
+#~ msgstr "退出"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "hardware"
+#~ msgstr "硬件"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "英语（英国）"
+
+#~ msgid "United Kingdom"
+#~ msgstr "英国"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "确认新密码(_V)"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "密码不匹配。"
+
+#~ msgid "page 3"
+#~ msgstr "第 3 页"
+
+#~ msgid "Show the overview"
+#~ msgstr "显示摘要"
+
+#~ msgid "Back­ground"
+#~ msgstr "背景"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "蓝牙"
+
+#~ msgid "Co­lor"
+#~ msgstr "色彩"
+
+#~ msgid "Lid Closed"
+#~ msgstr "上盖已合上"
+
+#~ msgid "Mirrored"
+#~ msgstr "镜像显示"
+
+#~ msgid "Secondary"
+#~ msgstr "副显示器"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "安排多个显示"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "逆时针旋转 90°"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "旋转 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "顺时针旋转 90°"
+
+#~ msgid "Size"
+#~ msgstr "大小"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "在此显示器上显示顶栏和活动概览"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "将该显示器与另一显示器合并以扩展工作空间"
+
+# 左撇子有歧视色彩。
+#~ msgid "Presentation"
+#~ msgstr "演示"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "只显示幻灯片和多媒体"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "在两块显示器上同时显示当前视图"
+
+#~ msgid "Turn Off"
+#~ msgstr "关闭"
+
+#~ msgid "Don't use this display"
+#~ msgstr "不使用该显示器"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "安排多个显示(_A)"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d 位（构建 ID：%s）"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d 位"
+
+#~ msgid "Overview"
+#~ msgstr "总览"
+
+#~ msgid "De­tails"
+#~ msgstr "详细信息"
+
+#~ msgid "Base system"
+#~ msgstr "基本系统"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;快捷键;重复;闪烁;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "按 Esc 键取消。"
+
+#~ msgid "Server"
+#~ msgstr "服务器"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "删除 DNS 服务器"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "对其他用户可用(_U)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "防火墙区域(_Z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "默认"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "此区域定义了对连接的信任级别"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr "重置这个网络包括密码在内的设置，但仍作为首选连接"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr "删除关于这个网络的所有细节，不再尝试自动连接"
+
+#~ msgid "Net­work"
+#~ msgstr "网络"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "如果有无线网络以外的方式连接互联网，您可以配置无线热点并与他人共享网络连"
+#~ "接。"
+
+#~ msgid "Proxy"
+#~ msgstr "代理"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "添加配置(_A)…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "无"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "手动"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "自动"
+
+#~ msgid "Group Name"
+#~ msgstr "组名"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "用作热点(_U)…"
+
+#~ msgid "_History"
+#~ msgstr "历史(_H)"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "通知条幅(_B)"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "通知"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "通知条幅"
+
+#~ msgid "Add Account"
+#~ msgstr "添加帐号"
+
+#~ msgid "Mail"
+#~ msgstr "邮件"
+
+#~ msgid "Calendar"
+#~ msgstr "日历"
+
+#~ msgid "Contacts"
+#~ msgstr "联系人"
+
+#~ msgid "Chat"
+#~ msgstr "聊天"
+
+#~ msgid "Error creating account"
+#~ msgstr "创建帐号出错"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "确定要移除这个帐号吗？"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "这不会将该帐号从服务器上移除。"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "未设置在线帐号"
+
+# 统一下翻译
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "添加一个帐号以让您的应用访问帐号的文档、邮件、联系人、日历、聊天等。"
+
+#~ msgid "Po­wer"
+#~ msgstr "电源"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "正在配置"
+
+# 以下几个level似乎译为“量”更好
+#~ msgid "Toner Level"
+#~ msgstr "碳粉量"
+
+#~ msgid "Supply Level"
+#~ msgstr "耗材量"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "正在安装"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u 项活动任务"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "添加打印机"
+
+#~ msgid "No printers detected."
+#~ msgstr "未检测到打印机。"
+
+#~ msgid "Supply"
+#~ msgstr "耗材"
+
+#~ msgid "Jobs"
+#~ msgstr "任务"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "显示任务(_J)"
+
+#~ msgid "label"
+#~ msgstr "标签"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "打印测试页(_T)"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "隐私"
+
+#~ msgid "Sha­ring"
+#~ msgstr "共享"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "通用辅助功能"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "请使用更多字母、数字和符号。"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "强度：较弱"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "强度：较低"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "强度：中等"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "强度：良好"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "强度：较高"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgid "Disable image"
+#~ msgstr "禁用图像"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "浏览更多图片…"
+
+#~ msgid "Used by %s"
+#~ msgstr "已被 %s 使用"
+
+#~ msgid "Other Accounts"
+#~ msgstr "其他帐号"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "上键"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "下键"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "无"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wacom 手写板"
+
+#~ msgid "Left Ring"
+#~ msgstr "左环模式"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "左环模式 #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "右环模式 #%d"
+
+# Touchstrip和touchring都是商标。
+#~ msgid "Left Touchstrip"
+#~ msgstr "左 Touchstrip 模式"
+
+# Touchstrip和touchring都是商标。
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "左 Touchstrip 模式 #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "右 Touchstrip"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "右 Touchstrip 模式 #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "左 Touchring 模式切换"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "右 Touchring 模式切换"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "左 Touchstrip 模式切换"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "右 Touchstrip 模式切换"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "模式切换 #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "左键 #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "右键 #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "上键 #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "底键 #%d"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "鼠标左键单击"
+
+#~ msgid "Scroll Up"
+#~ msgstr "向上滚动"
+
+#~ msgid "Scroll Down"
+#~ msgstr "向下滚动"
+
+#~ msgid "Scroll Right"
+#~ msgstr "向右滚动"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "硬件"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "系统"
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "设置快捷键"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "移除快捷键"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "要编辑快捷键，请单击相应的行，然后输入新按键组合，或按 Backspace 清除。"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<未知动作>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "%s 不能用作快捷键，否则将无法使用其进行正常输入。\n"
+#~ "请组合 Ctrl、Alt 或 Shift 键再试一次"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "快捷键“%s”已被用于\n"
+#~ "“%s”"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "如果您重新分配快捷键为“%s”，快捷键“%s”将被禁用"
+
+#~ msgid "_Reassign"
+#~ msgstr "重新分配(_R)"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr "“%s”已占用快捷键“%s”，您是否想将它自动设置为“%s”？"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr "快捷键 %s 已被分配给 %s ，如果继续，该快捷键将被禁用。"
+
+#~ msgid "_Assign"
+#~ msgstr "分配(_A)"
+
+#~ msgid "Bond"
+#~ msgstr "绑定（Bond 方式）"
+
+#~ msgid "Team"
+#~ msgstr "绑定（Team 方式）"
+
+#~ msgid "Bridge"
+#~ msgstr "桥接"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "无法载入 VPN 插件"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "添加网络连接"
+
+#~ msgid "Bond slaves"
+#~ msgstr "绑定从属设备（Bond 方式）"
+
+#~ msgid "(none)"
+#~ msgstr "（无）"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "桥接从属设备"
+
+#~ msgid "Team slaves"
+#~ msgstr "绑定从属设备（Team 方式）"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand 不支持已连接模式"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "未选择 CA 证书"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "不使用 CA 证书可能导致连接到不安全或恶意的无线网络。您要选择一个 CA 证书"
+#~ "吗？"
+
+#~ msgid "Ignore"
+#~ msgstr "忽略"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "选择 CA 证书"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "每次询问密码(_K)"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "不再警告(_W)"
+
+#~ msgid "Yes"
+#~ msgstr "是"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "登录到帐号出错"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "凭据已过期。"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "登录以启用此帐号。"
+
+#~ msgid "_Sign In"
+#~ msgstr "登录(_S)"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "其他"
+
+#~ msgid "_Verify"
+#~ msgstr "验证(_V)"
+
+#~ msgid "Login History"
+#~ msgstr "登录历史"
+
+#~ msgid "Add User Account"
+#~ msgstr "添加用户帐号"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "用户“%s”已存在。"
+
+#~ msgid "Done"
+#~ msgstr "完成"
+
+#~ msgid "Time _Zone"
+#~ msgstr "时区(_Z)"
+
+#~ msgid "Resume Printing"
+#~ msgstr "恢复打印"
+
+#~ msgid "Pause Printing"
+#~ msgstr "暂停打印"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "挂起"
+
+#~ msgid "Job Title"
+#~ msgstr "任务标题"
+
+#~ msgid "Job State"
+#~ msgstr "任务状态"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "用于获得您的位置信息"
+
+#~ msgid "Password:"
+#~ msgstr "密码："
+
+#~| msgid "Repeat Keys"
+#~ msgid "_Repeat Keys"
+#~ msgstr "重复键(_R)"
+
+#~| msgid "Cursor Blinking"
+#~ msgid "_Cursor Blinking"
+#~ msgstr "光标闪烁(_C)"
+
+#~ msgid "Zoom"
+#~ msgstr "缩放"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "色彩"
+
+#~ msgid "_Delay:"
+#~ msgstr "延时(_D)："
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "短"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "慢"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "长"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "快"
+
+#~ msgid "S_peed:"
+#~ msgstr "速度(_P)："
+
+#~ msgid "Test Your Settings"
+#~ msgstr "测试您的设置"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "慢"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "快"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "左(_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "右(_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "指针速度(_P)"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "慢"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "快"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "慢"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "快"
+
+#~ msgid "Add New Printer"
+#~ msgstr "添加新打印机"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "无线设备需要消耗更多电"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "电量严重不足时(_C)"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr "蓝牙共享允许您使用带有蓝牙的设备共享文件"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "只从信任的设备接收"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "将接收的文件保存到下载文件夹"
+
+#~ msgid "Show help options"
+#~ msgstr "显示帮助选项"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "运行 %s --help 查看所有可用的命令行选项。\n"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -12,9 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center 3.3.91\n"
-"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
-"control-center&keywords=I18N+L10N&component=general\n"
-"POT-Creation-Date: 2014-08-23 18:31+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2014-08-25 14:05+0800\n"
 "Last-Translator: Chao-Hsiung Liao <j_h_liau@yahoo.com.tw>\n"
 "Language-Team: Chinese (Hong Kong) <community@linuxhall.org>\n"
@@ -25,5871 +24,4768 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.6.5\n"
 
-#: ../panels/background/background.ui.h:1
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "程式集"
+
+#: panels/applications/cc-applications-panel.ui:31
+#, fuzzy
+msgid "No applications"
+msgstr "找不到應用程式"
+
+#: panels/applications/cc-applications-panel.ui:34
+#, fuzzy
+msgid "Install some…"
+msgstr "安裝更新"
+
+#: panels/applications/cc-applications-panel.ui:84
+#, fuzzy
+msgid "Open"
+msgstr "開啟(_O)"
+
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "檢視詳細資料"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "搜尋"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
+msgid "Disabled"
+msgstr "已停用"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "通知"
+
+#: panels/applications/cc-applications-panel.ui:127
+#, fuzzy
+msgid "Show system notifications."
+msgstr "顯示通知(_N)"
+
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "背景"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "螢幕擷圖"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "桌布"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
+msgstr "音效"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
+msgstr "快捷鍵"
+
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
+msgstr "鍵盤捷徑鍵"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+#, fuzzy
+msgid "Camera"
+msgstr "%s 照相機"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+#, fuzzy
+msgid "Location Services"
+msgstr "位置服務(_L)"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+#, fuzzy
+msgid "Built-in Permissions"
+msgstr "內置網絡攝影機"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+#, fuzzy
+msgid "No results found"
+msgstr "找不到區域"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "顯示類型"
+
+#: panels/applications/cc-applications-panel.ui:380
+#, fuzzy
+msgid "Link Types"
+msgstr "連線速度"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "重設"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "程式集"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "觸控筆"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "預設值"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "背景"
 
-#. This refers to a slideshow background
-#: ../panels/background/background.ui.h:3
-msgid "Changes throughout the day"
-msgstr "整天的更改"
+#: panels/background/cc-background-panel.ui:104
+#, fuzzy
+msgid "Add Picture…"
+msgstr "加入設定組合(_A)…"
 
-#. To translators: This is a noun, not a verb
-#: ../panels/background/background.ui.h:5
-msgid "Lock Screen"
-msgstr "鎖定畫面"
+#: panels/background/gnome-background-panel.desktop.in.in:3
+#, fuzzy
+msgid "Appearance"
+msgstr "法國"
 
-#: ../panels/background/background.ui.h:6
-msgctxt "background, style"
-msgid "Tile"
-msgstr "鋪排"
-
-#: ../panels/background/background.ui.h:7
-msgctxt "background, style"
-msgid "Zoom"
-msgstr "縮放"
-
-#: ../panels/background/background.ui.h:8
-msgctxt "background, style"
-msgid "Center"
-msgstr "置中"
-
-#: ../panels/background/background.ui.h:9
-msgctxt "background, style"
-msgid "Scale"
-msgstr "縮放"
-
-#: ../panels/background/background.ui.h:10
-msgctxt "background, style"
-msgid "Fill"
-msgstr "填滿"
-
-#: ../panels/background/background.ui.h:11
-msgctxt "background, style"
-msgid "Span"
-msgstr "合併"
-
-#. translators: This is the title of the wallpaper chooser dialog.
-#: ../panels/background/cc-background-chooser-dialog.c:442
-msgid "Select Background"
-msgstr "選擇背景"
-
-#: ../panels/background/cc-background-chooser-dialog.c:463
-msgid "Wallpapers"
-msgstr "桌布"
-
-#: ../panels/background/cc-background-chooser-dialog.c:472
-msgid "Pictures"
-msgstr "圖片"
-
-#: ../panels/background/cc-background-chooser-dialog.c:481
-msgid "Colors"
-msgstr "顏色"
-
-#. translators: No pictures were found
-#: ../panels/background/cc-background-chooser-dialog.c:540
-msgid "No Pictures Found"
-msgstr "找不到圖片"
-
-#. translators: "Home" is used in place of the Pictures
-#. * directory in the string below when XDG_PICTURES_DIR is
-#. * undefined
-#: ../panels/background/cc-background-chooser-dialog.c:558
-#: ../panels/search/cc-search-locations-dialog.c:274
-msgid "Home"
-msgstr "家"
-
-#. translators: %s here is the name of the Pictures directory, the string should be translated in
-#. * the context "You can add images to your Pictures folder and they will show up here"
-#: ../panels/background/cc-background-chooser-dialog.c:570
-#, c-format
-msgid "You can add images to your %s folder and they will show up here"
-msgstr "你可以將影像加入你的%s資料夾，它們會顯示在這裏"
-
-#: ../panels/background/cc-background-chooser-dialog.c:592
-#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
-#: ../panels/common/language-chooser.ui.h:3
-#: ../panels/display/cc-display-panel.c:1537
-#: ../panels/display/cc-display-panel.c:1976
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
-#: ../panels/network/connection-editor/vpn-helpers.c:245
-#: ../panels/network/connection-editor/vpn-helpers.c:374
-#: ../panels/network/net-device-wifi.c:1240
-#: ../panels/network/net-device-wifi.c:1448
-#: ../panels/printers/cc-printers-panel.c:1947
-#: ../panels/printers/new-printer-dialog.ui.h:2
-#: ../panels/privacy/cc-privacy-panel.c:468
-#: ../panels/region/format-chooser.ui.h:3
-#: ../panels/region/input-chooser.ui.h:2
-#: ../panels/search/cc-search-locations-dialog.c:681
-#: ../panels/sharing/cc-sharing-panel.c:491
-#: ../panels/user-accounts/data/account-dialog.ui.h:17
-#: ../panels/user-accounts/data/password-dialog.ui.h:2
-#: ../panels/user-accounts/um-fingerprint-dialog.c:267
-#: ../panels/user-accounts/um-photo-dialog.c:95
-#: ../panels/user-accounts/um-photo-dialog.c:222
-#: ../panels/user-accounts/um-user-panel.c:513
-msgid "_Cancel"
-msgstr "取消(_C)"
-
-#: ../panels/background/cc-background-chooser-dialog.c:593
-#: ../panels/printers/ppd-selection-dialog.ui.h:3
-#: ../panels/user-accounts/um-photo-dialog.c:97
-msgid "Select"
-msgstr "選取"
-
-#: ../panels/background/cc-background-item.c:197
-msgid "multiple sizes"
-msgstr "多重尺寸"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: ../panels/background/cc-background-item.c:201
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: ../panels/background/cc-background-item.c:327
-msgid "No Desktop Background"
-msgstr "無桌面背景"
-
-#: ../panels/background/cc-background-panel.c:493
-msgid "Current background"
-msgstr "目前的背景"
-
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
-msgid "Change your background image to a wallpaper or photo"
+#: panels/background/gnome-background-panel.desktop.in.in:4
+#, fuzzy
+msgid "Change your background image or the UI colors"
 msgstr "將你的背景影像更改為桌布或相片"
 
-#. Translators: those are keywords for the background control-center panel
-#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
-msgid "Wallpaper;Screen;Desktop;"
-msgstr "Wallpaper;Screen;Desktop;桌布;螢幕;桌面;"
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:262
-msgid "Bluetooth is disabled"
-msgstr "藍牙已停用"
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "啟用"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:263
-msgid "No Bluetooth adapters found"
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+#, fuzzy
+msgid "No Bluetooth Found"
 msgstr "找不到藍牙接配器"
 
-#: ../panels/bluetooth/cc-bluetooth-panel.c:264
-msgid "Bluetooth is disabled by hardware switch"
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+#, fuzzy
+msgid "Bluetooth Turned Off"
+msgstr "藍牙分享"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+#, fuzzy
+msgid "Airplane Mode is On"
+msgstr "飛安模式(_P)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+#, fuzzy
+msgid "Bluetooth is disabled when airplane mode is on."
 msgstr "藍牙已被硬件開關停用"
 
-#. Translators: The found device is a printer connected via Bluetooth
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
-#: ../panels/printers/pp-new-printer-dialog.c:1688
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+#, fuzzy
+msgid "Turn Off Airplane Mode"
+msgstr "飛安模式(_P)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+#, fuzzy
+msgid "Hardware Airplane Mode is On"
+msgstr "飛安模式(_P)"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
 msgid "Bluetooth"
 msgstr "藍牙"
 
-#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "開啟或關閉藍牙與連接你的裝置"
 
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: ../panels/color/cc-color-calibrate.c:361
-msgid "Place your calibration device over the square and press 'Start'"
-msgstr "將你的校準裝置放在矩形上並按「開始」"
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:367
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+#, fuzzy
+msgid "No applications can capture photos or video."
+msgstr "沒有應用程式目前正在播放或錄製音效。"
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Move your calibration device to the calibrate position and press 'Continue'"
-msgstr "將你的校準裝置移到校準位置並按「繼續」"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: ../panels/color/cc-color-calibrate.c:373
-msgid ""
-"Move your calibration device to the surface position and press 'Continue'"
-msgstr "將你的校準裝置移到表面位置並按「繼續」"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: ../panels/color/cc-color-calibrate.c:379
-msgid "Shut the laptop lid"
-msgstr "關上手提電腦上蓋"
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your pictures"
+msgstr "瀏覽更多照片"
 
-#. TRANSLATORS: We suck, the calibation failed and we have no
-#. * good idea why or any suggestions
-#: ../panels/color/cc-color-calibrate.c:410
-msgid "An internal error occurred that could not be recovered."
-msgstr "發生內部的錯誤，無法復原。"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: ../panels/color/cc-color-calibrate.c:415
-msgid "Tools required for calibration are not installed."
-msgstr "校準所需的工具尚未安裝。"
-
-#. TRANSLATORS: The profile failed for some reason
-#: ../panels/color/cc-color-calibrate.c:421
-msgid "The profile could not be generated."
-msgstr "無法產生描述檔。"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: ../panels/color/cc-color-calibrate.c:427
-msgid "The target whitepoint was not obtainable."
-msgstr "尚無法獲取目標白點。"
-
-#. TRANSLATORS: the display calibration process is finished
-#: ../panels/color/cc-color-calibrate.c:467
-msgid "Complete!"
-msgstr "完成！"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: ../panels/color/cc-color-calibrate.c:475
-msgid "Calibration failed!"
-msgstr "校準已失敗！"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: ../panels/color/cc-color-calibrate.c:482
-msgid "You can remove the calibration device."
-msgstr "你可以移除校準裝置。"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: ../panels/color/cc-color-calibrate.c:553
-msgid "Do not disturb the calibration device while in progress"
-msgstr "過程中請勿干擾校準裝置"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: ../panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "手提電腦螢幕"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: ../panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "內置網絡攝影機"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: ../panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s 顯示器"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: ../panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s 掃描器"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: ../panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s 照相機"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: ../panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s 打印機"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: ../panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s 網絡攝影機"
-
-#: ../panels/color/cc-color-device.c:89
-#, c-format
-msgid "Enable color management for %s"
-msgstr "啟用 %s 的顏色管理"
-
-#: ../panels/color/cc-color-device.c:93
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "顯示 %s 的顏色描述檔"
-
-#. not calibrated
-#: ../panels/color/cc-color-device.c:322
-msgid "Not calibrated"
-msgstr "尚未校準"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: ../panels/color/cc-color-panel.c:140
-msgid "Default: "
-msgstr "預設值："
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: ../panels/color/cc-color-panel.c:148
-msgid "Colorspace: "
-msgstr "色彩空間："
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: ../panels/color/cc-color-panel.c:155
-msgid "Test profile: "
-msgstr "測試描述檔："
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: ../panels/color/cc-color-panel.c:222
-msgid "Select ICC Profile File"
-msgstr "選擇 ICC 色彩描述檔"
-
-#: ../panels/color/cc-color-panel.c:225
-msgid "_Import"
-msgstr "匯入(_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:236
-msgid "Supported ICC profiles"
-msgstr "支援的 ICC 色彩描述檔"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: ../panels/color/cc-color-panel.c:243
-#: ../panels/network/wireless-security/eap-method-fast.c:420
-msgid "All files"
-msgstr "所有檔案"
-
-#: ../panels/color/cc-color-panel.c:582
-msgid "Screen"
-msgstr "螢幕"
-
-#. TRANSLATORS: this is when the upload of the profile failed
-#: ../panels/color/cc-color-panel.c:906
-#, c-format
-msgid "Failed to upload file: %s"
-msgstr "上傳檔案失敗：%s"
-
-#. TRANSLATORS: these are instructions on how to recover
-#. * the ICC profile on the native operating system and are
-#. * only shown when the user uses a LiveCD to calibrate
-#: ../panels/color/cc-color-panel.c:920
-msgid "The profile has been uploaded to:"
-msgstr "描述檔已經上傳到："
-
-#: ../panels/color/cc-color-panel.c:922
-msgid "Write down this URL."
-msgstr "寫下這個 URL。"
-
-#: ../panels/color/cc-color-panel.c:923
-msgid "Restart this computer and boot your normal operating system."
-msgstr "重新啟動這臺電腦並開機進入你一般的作業系統。"
-
-#: ../panels/color/cc-color-panel.c:924
-msgid "Type the URL into your browser to download and install the profile."
-msgstr "在你的瀏覽器中輸入 URL 以下載並安裝描述檔。"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: ../panels/color/cc-color-panel.c:958
-msgid "Save Profile"
-msgstr "儲存描述檔"
-
-#: ../panels/color/cc-color-panel.c:962
-#: ../panels/network/connection-editor/vpn-helpers.c:375
-msgid "_Save"
-msgstr "儲存(_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: ../panels/color/cc-color-panel.c:1322
-msgid "Create a color profile for the selected device"
-msgstr "為已選取裝置建立色彩描述檔"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "尚未偵測到測量儀器。請檢查它是否已開啟並正確的連接。"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1371
-msgid "The measuring instrument does not support printer profiling."
-msgstr "測量儀器不支援打印機的分析。"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: ../panels/color/cc-color-panel.c:1382
-msgid "The device type is not currently supported."
-msgstr "目刖不支援這個裝置類型。"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: ../panels/color/cc-color-profile.c:103
-msgid "Standard Space"
-msgstr "標準空間"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: ../panels/color/cc-color-profile.c:109
-msgid "Test Profile"
-msgstr "測試描述檔"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: ../panels/color/cc-color-profile.c:117
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "自動"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: ../panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "低品質"
-
-#. TRANSLATORS: the profile quality
-#: ../panels/color/cc-color-profile.c:132
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "中品質"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: ../panels/color/cc-color-profile.c:139
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "高品質"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:156
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "預設 RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:163
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "預設 CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: ../panels/color/cc-color-profile.c:170
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "預設灰階"
-
-#: ../panels/color/cc-color-profile.c:194
-msgid "Vendor supplied factory calibration data"
-msgstr "廠商提供的出廠校準資料"
-
-#: ../panels/color/cc-color-profile.c:203
-msgid "Full-screen display correction not possible with this profile"
-msgstr "這個描述檔無法使用全螢幕顯示校正"
-
-#: ../panels/color/cc-color-profile.c:225
-msgid "This profile may no longer be accurate"
-msgstr "這個描述檔可能不再準確"
-
-#: ../panels/color/color-calibrate.ui.h:1
+#: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
 msgstr "顯示校準"
 
-#: ../panels/color/color-calibrate.ui.h:2
-#: ../panels/printers/authentication-dialog.ui.h:2
-#: ../panels/printers/ppd-selection-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-dialog.c:1468
-msgid "Cancel"
-msgstr "取消"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "取消(_C)"
 
 #. This starts the calibration process
-#: ../panels/color/color-calibrate.ui.h:4
-msgid "Start"
+#: panels/color/cc-color-calibrate.ui:28
+#, fuzzy
+msgid "_Start"
 msgstr "開始"
 
 #. This resumes the calibration process
-#: ../panels/color/color-calibrate.ui.h:6
-msgid "Resume"
+#: panels/color/cc-color-calibrate.ui:34
+#, fuzzy
+msgid "_Resume"
 msgstr "繼續"
 
 #. This button returns the user back to the color control panel
-#: ../panels/color/color-calibrate.ui.h:8
-msgid "Done"
-msgstr "完成"
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "完成(_D)"
 
-#. Timeout parameters
-#. 15000 = 15 sec
-#. 750 = 0.75 sec
-#. Text printed on screen
-#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
 msgstr "螢幕校準"
 
-#: ../panels/color/color.ui.h:2
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "校準品質"
+
+#: panels/color/cc-color-panel.ui:21
 msgid ""
 "Calibration will produce a profile that you can use to color manage your "
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
-msgstr "校準動作會產生描述檔讓你可以用來管理螢幕的顏色。你花在校準的時間愈長，顏色描述檔的品質就愈好。"
+msgstr ""
+"校準動作會產生描述檔讓你可以用來管理螢幕的顏色。你花在校準的時間愈長，顏色描"
+"述檔的品質就愈好。"
 
-#: ../panels/color/color.ui.h:3
+#: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
 msgstr "當校準在進行時將不能使用你的電腦。"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:5
+#: panels/color/cc-color-panel.ui:40
 msgid "Quality"
 msgstr "品質"
 
 #. This is the approximate time it takes to calibrate the display.
-#: ../panels/color/color.ui.h:7
+#: panels/color/cc-color-panel.ui:51
 msgid "Approximate Time"
 msgstr "大約時間"
 
-#: ../panels/color/color.ui.h:8
-msgid "Calibration Quality"
-msgstr "校準品質"
-
-#: ../panels/color/color.ui.h:9
-msgid "Select the sensor device you want to use for calibration."
-msgstr "選擇你想要使用的校準偵測裝置。"
-
-#: ../panels/color/color.ui.h:10
+#: panels/color/cc-color-panel.ui:82
 msgid "Calibration Device"
 msgstr "校準裝置"
 
-#: ../panels/color/color.ui.h:11
-msgid "Select the type of display that is connected."
-msgstr "選擇連接的顯示器類型。"
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "選擇你想要使用的校準偵測裝置。"
 
-#: ../panels/color/color.ui.h:12
+#: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
 msgstr "顯示類型"
 
-#: ../panels/color/color.ui.h:13
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "選擇連接的顯示器類型。"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "描述檔白點"
+
+#: panels/color/cc-color-panel.ui:160
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
 msgstr "選擇一個顯示目標白點。大多數顯示器應該校準到 D65 光源。"
 
-#: ../panels/color/color.ui.h:14
-msgid "Profile Whitepoint"
-msgstr "描述檔白點"
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "顯示亮度"
 
-#: ../panels/color/color.ui.h:15
+#: panels/color/cc-color-panel.ui:195
 msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
-msgstr "請將顯示器的亮度設定為你常用的狀態。顏色管理會以這個亮度等級調整到最正確。"
+msgstr ""
+"請將顯示器的亮度設定為你常用的狀態。顏色管理會以這個亮度等級調整到最正確。"
 
-#: ../panels/color/color.ui.h:16
+#: panels/color/cc-color-panel.ui:202
 msgid ""
 "Alternatively, you can use the brightness level used with one of the other "
 "profiles for this device."
 msgstr "或者，你可以使用這個裝置的其他描述檔所適用的亮度等級。"
 
-#: ../panels/color/color.ui.h:17
-msgid "Display Brightness"
-msgstr "顯示亮度"
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "描述檔名稱"
 
-#: ../panels/color/color.ui.h:18
+#: panels/color/cc-color-panel.ui:222
 msgid ""
 "You can use a color profile on different computers, or even create profiles "
 "for different lighting conditions."
 msgstr "你可以在不同電腦上使用顏色描述檔，或是為了不同的亮度條件建立描述檔。"
 
-#: ../panels/color/color.ui.h:19
+#: panels/color/cc-color-panel.ui:229
 msgid "Profile Name:"
 msgstr "描述檔名稱："
 
-#: ../panels/color/color.ui.h:20
-msgid "Profile Name"
-msgstr "描述檔名稱"
-
-#: ../panels/color/color.ui.h:21
-msgid "Profile successfully created!"
-msgstr "描述檔製作成功！"
-
-#: ../panels/color/color.ui.h:22
-msgid "Copy profile"
-msgstr "複製描述檔"
-
-#: ../panels/color/color.ui.h:23
-msgid "Requires writable media"
-msgstr "需要可寫入媒體"
-
-#: ../panels/color/color.ui.h:24
-msgid "Upload profile"
-msgstr "上傳描述檔"
-
-#: ../panels/color/color.ui.h:25
-msgid "Requires Internet connection"
-msgstr "需要互聯網連線"
-
-#: ../panels/color/color.ui.h:26
-msgid ""
-"You may find these instructions on how to use the profile on <a href=\"linux"
-"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
-"\">Microsoft Windows</a> systems useful."
-msgstr "你可以找到如何在 <a href=\"linux\">GNU/Linux</a>、<a href=\"osx\">Apple OS X</a> 和 <a href=\"windows\">Microsoft Windows</a> 系統上使用描述檔的指引。"
-
-#: ../panels/color/color.ui.h:27
-#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+#: panels/color/cc-color-panel.ui:251
 msgid "Summary"
 msgstr "摘要"
 
-#: ../panels/color/color.ui.h:28
-msgid "Import File…"
-msgstr "載入檔案…"
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "描述檔製作成功！"
 
-#: ../panels/color/color.ui.h:29
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "複製描述檔"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "需要可寫入媒體"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"你可以找到如何在 <a href=\"linux\">GNU/Linux</a>、<a href=\"osx\">Apple OS "
+"X</a> 和 <a href=\"windows\">Microsoft Windows</a> 系統上使用描述檔的指引。"
+
+#: panels/color/cc-color-panel.ui:335
+#, fuzzy
+msgid "Add Profile"
+msgstr "加入描述檔"
+
+#: panels/color/cc-color-panel.ui:373
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
 msgstr "偵測到問題。描述檔可能無法正常運作。<a href=\"\">顯示詳細資料。</a>"
 
-#: ../panels/color/color.ui.h:30
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "載入檔案…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "加入(_A)"
+
+#: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
 msgstr "每個裝置需要最新的色彩描述檔才能被管理顏色。"
 
-#: ../panels/color/color.ui.h:31
+#: panels/color/cc-color-panel.ui:434
 msgid "Learn more"
 msgstr "了解更多"
 
-#: ../panels/color/color.ui.h:32
+#: panels/color/cc-color-panel.ui:436
 msgid "Learn more about color management"
 msgstr "了解更多關於顏色管理的資訊"
 
-#: ../panels/color/color.ui.h:33
-msgid "Set for all users"
+#: panels/color/cc-color-panel.ui:473
+#, fuzzy
+msgid "_Set for all users"
 msgstr "所有使用者皆可用"
 
-#: ../panels/color/color.ui.h:34
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
 msgstr "將這個描述檔給電腦上所有使用者"
 
-#: ../panels/color/color.ui.h:35
-msgid "Enable"
+#: panels/color/cc-color-panel.ui:481
+#, fuzzy
+msgid "_Enable"
 msgstr "啟用"
 
-#: ../panels/color/color.ui.h:36
-msgid "Add profile"
+#: panels/color/cc-color-panel.ui:497
+#, fuzzy
+msgid "_Add profile"
 msgstr "加入描述檔"
 
-#: ../panels/color/color.ui.h:37
-#: ../panels/wacom/gnome-wacom-properties.ui.h:10
-msgid "Calibrate…"
+#: panels/color/cc-color-panel.ui:503
+#, fuzzy
+msgid "_Calibrate…"
 msgstr "校準…"
 
-#: ../panels/color/color.ui.h:38
+#: panels/color/cc-color-panel.ui:505
 msgid "Calibrate the device"
 msgstr "校準裝置"
 
-#: ../panels/color/color.ui.h:39
-msgid "Remove profile"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
 msgstr "移除描述檔"
 
-#: ../panels/color/color.ui.h:40
-msgid "View details"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
 msgstr "檢視詳細資料"
 
-#: ../panels/color/color.ui.h:41
+#: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
 msgstr "無法偵測到任何能被管理顏色的裝置"
 
-#: ../panels/color/color.ui.h:42
+#: panels/color/cc-color-panel.ui:568
 msgid "LCD"
 msgstr "LCD"
 
-#: ../panels/color/color.ui.h:43
+#: panels/color/cc-color-panel.ui:573
 msgid "LED"
 msgstr "LED"
 
-#: ../panels/color/color.ui.h:44
+#: panels/color/cc-color-panel.ui:578
 msgid "CRT"
 msgstr "CRT"
 
-#: ../panels/color/color.ui.h:45
+#: panels/color/cc-color-panel.ui:583
 msgid "Projector"
 msgstr "投影機"
 
-#: ../panels/color/color.ui.h:46
+#: panels/color/cc-color-panel.ui:588
 msgid "Plasma"
 msgstr "等離子"
 
-#: ../panels/color/color.ui.h:47
+#: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
 msgstr "LCD (CCFL 背光)"
 
-#: ../panels/color/color.ui.h:48
+#: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
 msgstr "LCD (RGB LED 背光)"
 
-#: ../panels/color/color.ui.h:49
+#: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
 msgstr "LCD (白色 LED 背光)"
 
-#: ../panels/color/color.ui.h:50
+#: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
 msgstr "廣色域 LCD (CCFL 背光)"
 
-#: ../panels/color/color.ui.h:51
+#: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
 msgstr "廣色域 LCD (RGB LED 背光)"
 
-#: ../panels/color/color.ui.h:52
+#: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
 msgid "High"
 msgstr "高"
 
-#: ../panels/color/color.ui.h:53
+#: panels/color/cc-color-panel.ui:631
 msgid "40 minutes"
 msgstr "40 分鐘"
 
-#: ../panels/color/color.ui.h:54
+#: panels/color/cc-color-panel.ui:635
 msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "中"
 
-#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
-#: ../panels/privacy/privacy.ui.h:7
+#: panels/color/cc-color-panel.ui:636
 msgid "30 minutes"
 msgstr "30 分鐘"
 
-#: ../panels/color/color.ui.h:56
+#: panels/color/cc-color-panel.ui:640
 msgctxt "Calibration quality"
 msgid "Low"
 msgstr "低"
 
-#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
+#: panels/color/cc-color-panel.ui:641
 msgid "15 minutes"
 msgstr "15 分鐘"
 
-#: ../panels/color/color.ui.h:58
+#: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
 msgstr "原生顯示"
 
-#: ../panels/color/color.ui.h:59
+#: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
 msgstr "D50 (列印與出版)"
 
-#: ../panels/color/color.ui.h:60
+#: panels/color/cc-color-panel.ui:671
 msgid "D55"
 msgstr "D55"
 
-#: ../panels/color/color.ui.h:61
+#: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
 msgstr "D65 (攝影與繪圖)"
 
-#: ../panels/color/color.ui.h:62
+#: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+#: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
 msgstr "顏色"
 
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+#: panels/color/gnome-color-panel.desktop.in.in:4
 msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "校準你裝置的顏色，像是顯示器、攝影機或打印機"
 
-#. Translators: those are keywords for the color control-center panel
-#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+#: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
-msgstr "Color;ICC;Profile;Calibrate;Printer;Display;顏色;色彩描述檔;校準;打印機;顯示器;"
+msgstr ""
+"Color;ICC;Profile;Calibrate;Printer;Display;顏色;色彩描述檔;校準;打印機;顯示"
+"器;"
 
-#. Add some common regions
-#: ../panels/common/cc-common-language.c:684
-msgid "United States"
-msgstr "美國"
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "選擇語言"
 
-#: ../panels/common/cc-common-language.c:685
-msgid "Germany"
-msgstr "德國"
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "選取(_S)"
 
-#: ../panels/common/cc-common-language.c:686
-msgid "France"
-msgstr "法國"
-
-#: ../panels/common/cc-common-language.c:687
-msgid "Spain"
-msgstr "西班牙"
-
-#: ../panels/common/cc-common-language.c:688
-msgid "China"
-msgstr "中國"
-
-#: ../panels/common/cc-common-language.c:758
-msgid "Other…"
-msgstr "其他…"
-
-#: ../panels/common/cc-language-chooser.c:123
-#: ../panels/region/cc-format-chooser.c:267
-#: ../panels/region/cc-input-chooser.c:165
-msgid "More…"
-msgstr "更多…"
-
-#: ../panels/common/cc-language-chooser.c:140
+#: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "找不到語言"
 
-#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
-msgid "Language"
-msgstr "語言"
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr "更多…"
 
-#: ../panels/common/language-chooser.ui.h:2
-#: ../panels/region/format-chooser.ui.h:2
-msgid "_Done"
-msgstr "完成(_D)"
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
 
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:340
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%Y年%b%e日, %p %l:%M"
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
 
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:345
-msgid "%e %B %Y, %R"
-msgstr "%Y年%b%e日，%R"
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
 
-#. Translators: "city, country"
-#: ../panels/datetime/cc-datetime-panel.c:523
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s，%s"
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
 
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: ../panels/datetime/cc-datetime-panel.c:553
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "時刻"
 
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: ../panels/datetime/cc-datetime-panel.c:561
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#. Translators: This is the time format used in 12-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:566
-msgid "%l:%M %p"
-msgstr "%p %l:%M"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#. Translators: This is the time format used in 24-hour mode.
-#: ../panels/datetime/cc-datetime-panel.c:571
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: ../panels/datetime/cc-datetime-panel.c:576
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#: ../panels/datetime/datetime.ui.h:1
-msgid "January"
-msgstr "一月"
-
-#: ../panels/datetime/datetime.ui.h:2
-msgid "February"
-msgstr "二月"
-
-#: ../panels/datetime/datetime.ui.h:3
-msgid "March"
-msgstr "三月"
-
-#: ../panels/datetime/datetime.ui.h:4
-msgid "April"
-msgstr "四月"
-
-#: ../panels/datetime/datetime.ui.h:5
-msgid "May"
-msgstr "五月"
-
-#: ../panels/datetime/datetime.ui.h:6
-msgid "June"
-msgstr "六月"
-
-#: ../panels/datetime/datetime.ui.h:7
-msgid "July"
-msgstr "七月"
-
-#: ../panels/datetime/datetime.ui.h:8
-msgid "August"
-msgstr "八月"
-
-#: ../panels/datetime/datetime.ui.h:9
-msgid "September"
-msgstr "九月"
-
-#: ../panels/datetime/datetime.ui.h:10
-msgid "October"
-msgstr "十月"
-
-#: ../panels/datetime/datetime.ui.h:11
-msgid "November"
-msgstr "十一月"
-
-#: ../panels/datetime/datetime.ui.h:12
-msgid "December"
-msgstr "十二月"
-
-#: ../panels/datetime/datetime.ui.h:13
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
 msgstr "日期與時刻"
 
-#: ../panels/datetime/datetime.ui.h:14
-msgid "Hour"
-msgstr "時"
-
-#. Translator: this is the separator between hours and minutes, like in HH∶MM
-#: ../panels/datetime/datetime.ui.h:16
-msgid "∶"
-msgstr "∶"
-
-#: ../panels/datetime/datetime.ui.h:17
-msgid "Minute"
-msgstr "分"
-
-#: ../panels/datetime/datetime.ui.h:18
-msgid "Day"
-msgstr "日"
-
-#: ../panels/datetime/datetime.ui.h:19
-msgid "Month"
-msgstr "月"
-
-#: ../panels/datetime/datetime.ui.h:20
+#: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
 msgstr "年"
 
-#: ../panels/datetime/datetime.ui.h:21
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "月"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "一月"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "二月"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "三月"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "四月"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "五月"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "六月"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "七月"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "八月"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "九月"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "十月"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "十一月"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "十二月"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "日"
+
+#: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
 msgstr "時區"
 
-#: ../panels/datetime/datetime.ui.h:22
+#: panels/datetime/cc-datetime-panel.ui:130
 msgid "Search for a city"
 msgstr "搜尋城市"
 
-#: ../panels/datetime/datetime.ui.h:23
-msgid "Automatic _Date & Time"
+#: panels/datetime/cc-datetime-panel.ui:164
+#, fuzzy
+msgid "Automatic _Date &amp; Time"
 msgstr "自動調整日期與時刻(_D)"
 
-#: ../panels/datetime/datetime.ui.h:24
+#: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "需要互聯網連線"
 
-#: ../panels/datetime/datetime.ui.h:25
+#: panels/datetime/cc-datetime-panel.ui:180
+#, fuzzy
+msgid "Date &amp; _Time"
+msgstr "日期與時刻(_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "自動調整時區(_Z)"
 
-#: ../panels/datetime/datetime.ui.h:26
-msgid "Date & _Time"
-msgstr "日期與時刻(_T)"
+#: panels/datetime/cc-datetime-panel.ui:205
+#, fuzzy
+msgid "Requires location services enabled and internet access"
+msgstr "需要互聯網連線"
 
-#: ../panels/datetime/datetime.ui.h:27
-msgid "Time _Zone"
-msgstr "時區(_Z)"
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "已啟用"
 
-#: ../panels/datetime/datetime.ui.h:28
+#: panels/datetime/cc-datetime-panel.ui:220
+#, fuzzy
+msgid "Time Z_one"
+msgstr "時區"
+
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "順時針"
+
+#: panels/datetime/cc-datetime-panel.ui:246
 msgid "Time _Format"
 msgstr "時刻格式(_F)"
 
-#: ../panels/datetime/datetime.ui.h:29
-msgid "24-hour"
-msgstr "24小時"
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
 
-#: ../panels/datetime/datetime.ui.h:30
-msgid "AM / PM"
-msgstr "AM / PM"
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "日期"
 
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "次要"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "日曆(_C)"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "數字"
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
 msgstr "改變時刻與日期，包含時區"
 
-#. Translators: those are keywords for the date and time control-center panel
-#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
 msgstr "Clock;Timezone;Location;時鐘;時區;位置;"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
 msgstr "改變系統時刻與日期設定值"
 
-#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
 msgstr "要改變時刻或日期設定值，你需要通過核對。"
 
-#: ../panels/display/cc-display-panel.c:487
-msgid "Lid Closed"
-msgstr "上蓋已經關閉"
-
-#. translators: "Mirrored" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:490
-msgid "Mirrored"
-msgstr "鏡射顯示器"
-
-#: ../panels/display/cc-display-panel.c:492
-#: ../panels/display/cc-display-panel.c:2145
-msgid "Primary"
-msgstr "主要"
-
-#: ../panels/display/cc-display-panel.c:494
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-#: ../panels/universal-access/uap.ui.h:6
-msgid "Off"
-msgstr "關閉"
-
-#: ../panels/display/cc-display-panel.c:497
-msgid "Secondary"
-msgstr "次要"
-
-#: ../panels/display/cc-display-panel.c:1533
-msgid "Arrange Combined Displays"
-msgstr "排列顯示器的組合方式"
-
-#: ../panels/display/cc-display-panel.c:1539
-#: ../panels/display/cc-display-panel.c:1979
-#: ../panels/network/connection-editor/connection-editor.ui.h:1
-msgid "_Apply"
-msgstr "套用(_A)"
-
-#: ../panels/display/cc-display-panel.c:1560
-msgid "Drag displays to rearrange them"
-msgstr "拖拉顯示器以重新排列他們"
-
-#: ../panels/display/cc-display-panel.c:2081
-msgid "Size"
-msgstr "尺寸"
-
-#. aspect ratio
-#: ../panels/display/cc-display-panel.c:2094
-msgid "Aspect Ratio"
-msgstr "長寬比"
-
-#: ../panels/display/cc-display-panel.c:2115
-#: ../panels/printers/pp-options-dialog.c:85
-msgid "Resolution"
-msgstr "解像度"
-
-#: ../panels/display/cc-display-panel.c:2146
-msgid "Show the top bar and Activities Overview on this display"
-msgstr "在這個顯示器顯示頂端列與活動概覽"
-
-#: ../panels/display/cc-display-panel.c:2152
-msgid "Secondary Display"
-msgstr "次要顯示器"
-
-#: ../panels/display/cc-display-panel.c:2153
-msgid "Join this display with another to create an extra workspace"
-msgstr "將這個顯示器與另一個顯示器結合以建立額外的工作區"
-
-#: ../panels/display/cc-display-panel.c:2160
-msgid "Presentation"
-msgstr "展示"
-
-#: ../panels/display/cc-display-panel.c:2161
-msgid "Show slideshows and media only"
-msgstr "只顯示投影片與媒體"
-
-#. translators: "Mirror" describes when both displays show the same view
-#: ../panels/display/cc-display-panel.c:2166
-msgid "Mirror"
-msgstr "鏡射"
-
-#: ../panels/display/cc-display-panel.c:2167
-msgid "Show your existing view on both displays"
-msgstr "在兩個顯示器顯示你現有的檢視"
-
-#: ../panels/display/cc-display-panel.c:2173
-msgid "Turn Off"
-msgstr "關閉"
-
-#: ../panels/display/cc-display-panel.c:2174
-msgid "Don't use this display"
-msgstr "不使用這個顯示器"
-
-#: ../panels/display/cc-display-panel.c:2383
-msgid "Could not get screen information"
-msgstr "無法取得螢幕資訊"
-
-#: ../panels/display/cc-display-panel.c:2414
-msgid "_Arrange Combined Displays"
-msgstr "排列組合的顯示器(_A)"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
-msgid "Displays"
-msgstr "顯示器"
-
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
-msgid "Choose how to use connected monitors and projectors"
-msgstr "選擇如何使用連接的顯示器和投影機"
-
-#. Translators: those are keywords for the display control-center panel
-#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
-msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
-msgstr "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;面板;投影機;螢幕;解像度;重新整理;螢幕;"
-
-#: ../panels/info/cc-info-panel.c:384
-msgid "Wayland"
-msgstr "Wayland"
-
-#. TRANSLATORS: AP type
-#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
-msgid "Unknown"
-msgstr "不明"
-
-#: ../panels/info/cc-info-panel.c:472
-#, c-format
-msgid "%s %d-bit"
-msgstr "%s %d 位元"
-
-#: ../panels/info/cc-info-panel.c:474
-#, c-format
-msgid "%d-bit"
-msgstr "%d 位元"
-
-#: ../panels/info/cc-info-panel.c:1154
-msgid "Ask what to do"
-msgstr "詢問要做什麼"
-
-#: ../panels/info/cc-info-panel.c:1158
-msgid "Do nothing"
-msgstr "不做任何事"
-
-#: ../panels/info/cc-info-panel.c:1162
-msgid "Open folder"
-msgstr "開啟資料夾"
-
-#: ../panels/info/cc-info-panel.c:1253
-msgid "Other Media"
-msgstr "其他媒體"
-
-#: ../panels/info/cc-info-panel.c:1284
-msgid "Select an application for audio CDs"
-msgstr "選擇播放音樂 CD 的應用程式"
-
-#: ../panels/info/cc-info-panel.c:1285
-msgid "Select an application for video DVDs"
-msgstr "選擇播放影片 DVD 的應用程式"
-
-#: ../panels/info/cc-info-panel.c:1286
-msgid "Select an application to run when a music player is connected"
-msgstr "選擇當音樂播放器連接時要執行的應用程式"
-
-#: ../panels/info/cc-info-panel.c:1287
-msgid "Select an application to run when a camera is connected"
-msgstr "選擇當攝影機連接時要執行的應用程式"
-
-#: ../panels/info/cc-info-panel.c:1288
-msgid "Select an application for software CDs"
-msgstr "選擇軟件 CD 要用的應用程式"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: ../panels/info/cc-info-panel.c:1300
-msgid "audio DVD"
-msgstr "音樂 DVD"
-
-#: ../panels/info/cc-info-panel.c:1301
-msgid "blank Blu-ray disc"
-msgstr "空白 Blu-ray 光碟"
-
-#: ../panels/info/cc-info-panel.c:1302
-msgid "blank CD disc"
-msgstr "空白 CD 光碟"
-
-#: ../panels/info/cc-info-panel.c:1303
-msgid "blank DVD disc"
-msgstr "空白 DVD 光碟"
-
-#: ../panels/info/cc-info-panel.c:1304
-msgid "blank HD DVD disc"
-msgstr "空白 HD DVD 光碟"
-
-#: ../panels/info/cc-info-panel.c:1305
-msgid "Blu-ray video disc"
-msgstr "Blu-Ray 影片光碟"
-
-#: ../panels/info/cc-info-panel.c:1306
-msgid "e-book reader"
-msgstr "電子書閱讀器"
-
-#: ../panels/info/cc-info-panel.c:1307
-msgid "HD DVD video disc"
-msgstr "HD DVD 影片光碟"
-
-#: ../panels/info/cc-info-panel.c:1308
-msgid "Picture CD"
-msgstr "照片 CD"
-
-#: ../panels/info/cc-info-panel.c:1309
-msgid "Super Video CD"
-msgstr "SVCD"
-
-#: ../panels/info/cc-info-panel.c:1310
-msgid "Video CD"
-msgstr "影片 CD"
-
-#: ../panels/info/cc-info-panel.c:1311
-msgid "Windows software"
-msgstr "Windows 軟件"
-
-#: ../panels/info/cc-info-panel.c:1434
-#: ../panels/keyboard/keyboard-shortcuts.c:1917
-msgid "Section"
-msgstr "節"
-
-#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
-msgid "Overview"
-msgstr "概覽"
-
-#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
-msgid "Default Applications"
-msgstr "預設應用程式"
-
-#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
-msgid "Removable Media"
-msgstr "可移除式媒體"
-
-#: ../panels/info/cc-info-panel.c:1479
-#, c-format
-msgid "Version %s"
-msgstr "版本 %s"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
-#: ../panels/network/connection-editor/ce-page-details.c:240
-#: ../panels/network/network-wifi.ui.h:44
-msgid "Details"
-msgstr "詳細資料"
-
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
-msgid "View information about your system"
-msgstr "檢視你系統的資訊"
-
-#. sure that you use the same "translation" for those keywords
-#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
-msgid ""
-"device;system;information;memory;processor;version;default;application;"
-"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
-msgstr "device;system;information;memory;processor;version;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;裝置;系統;資訊;記憶體;處理器;版本;預設;應用程式;首選;音訊;視像;光碟;可移除;媒體;自動執行;"
-
-#: ../panels/info/info.ui.h:1
-msgid "Select how other media should be handled"
-msgstr "選擇要如何處理其他媒體"
-
-#: ../panels/info/info.ui.h:2
-msgid "_Action:"
-msgstr "動作(_A):"
-
-#: ../panels/info/info.ui.h:3
-msgid "_Type:"
-msgstr "類型(_T)："
-
-#: ../panels/info/info.ui.h:4
-msgid "Device name"
-msgstr "裝置名稱"
-
-#: ../panels/info/info.ui.h:5
-msgid "Memory"
-msgstr "記憶體"
-
-#: ../panels/info/info.ui.h:6
-msgid "Processor"
-msgstr "處理器"
-
-#. To translators: this field contains the distro name, version and type
-#: ../panels/info/info.ui.h:8
-msgid "Base system"
-msgstr "基礎系統"
-
-#: ../panels/info/info.ui.h:9
-msgid "Disk"
-msgstr "磁碟"
-
-#: ../panels/info/info.ui.h:10
-msgid "Calculating…"
-msgstr "正在計算…"
-
-#: ../panels/info/info.ui.h:11
-msgid "Graphics"
-msgstr "繪圖"
-
-#: ../panels/info/info.ui.h:12
-msgid "Virtualization"
-msgstr "虛擬化"
-
-#: ../panels/info/info.ui.h:13
-msgid "Check for updates"
-msgstr "檢查更新"
-
-#: ../panels/info/info.ui.h:15
+#: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
 msgstr "網頁(_W)"
 
-#: ../panels/info/info.ui.h:16
+#: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
 msgstr "郵件(_M)"
 
-#: ../panels/info/info.ui.h:17
+#: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
 msgstr "日曆(_C)"
 
-#: ../panels/info/info.ui.h:18
+#: panels/default-apps/cc-default-apps-panel.ui:61
 msgid "M_usic"
 msgstr "音樂(_U)"
 
-#: ../panels/info/info.ui.h:19
+#: panels/default-apps/cc-default-apps-panel.ui:75
 msgid "_Video"
 msgstr "影片(_V)"
 
-#: ../panels/info/info.ui.h:20
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
 msgid "_Photos"
 msgstr "相片(_P)"
 
-#: ../panels/info/info.ui.h:22
-msgid "Select how media should be handled"
-msgstr "選擇要如何處理媒體"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "預設應用程式"
 
-#: ../panels/info/info.ui.h:23
-msgid "CD _audio"
-msgstr "CD 音樂(_A)"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "預設應用程式"
 
-#: ../panels/info/info.ui.h:24
-msgid "_DVD video"
-msgstr "_DVD 影片"
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
 
-#: ../panels/info/info.ui.h:25
-msgid "_Music player"
-msgstr "音樂播放器(_M)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:26
-msgid "_Software"
-msgstr "軟件(_S)"
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
 
-#: ../panels/info/info.ui.h:27
-msgid "_Other Media…"
-msgstr "其他(_O)…"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
 
-#: ../panels/info/info.ui.h:28
-msgid "_Never prompt or start programs on media insertion"
-msgstr "插入媒體時永遠不提示或啟動程式(_N)"
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:1
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "套用(_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "上一頁"
+
+#: panels/display/cc-display-panel.ui:100
+#, fuzzy
+msgid "Display Settings Disabled"
+msgstr "藍牙已停用"
+
+#: panels/display/cc-display-panel.ui:111
+#, fuzzy
+msgid "Multiple Displays"
+msgstr "偵測顯示器(_D)"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "鏡射"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+#, fuzzy
+msgid "Primary Display"
+msgstr "次要顯示器"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+#, fuzzy
+msgid "Night Light"
+msgstr "右環"
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "方向"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "解像度"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "更新率"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "縮放"
+
+#: panels/display/cc-display-settings.ui:101
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+#, fuzzy
+msgid "Night Light unavailable"
+msgstr "沒有可用的打印機"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+#, fuzzy
+msgid "Restart Filter"
+msgstr "立刻重新啟動"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "時刻"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "時"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "分"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "顯示器"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "選擇如何使用連接的顯示器和投影機"
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;面板;投影機;螢幕;解"
+"像度;重新整理;螢幕;"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#, fuzzy
+msgid "Security Level"
+msgstr "安全密碼匙"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+#, fuzzy
+msgid "Level 1"
+msgstr "墨水等級"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+#, fuzzy
+msgid "Level 2"
+msgstr "墨水等級"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+#, fuzzy
+msgid "Level 3"
+msgstr "墨水等級"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+#, fuzzy
+msgid "Device Security"
+msgstr "安全性"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+#, fuzzy
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;螢幕;鎖定;診斷;私隱;最近使用;暫存;索引;名稱;網絡;身分;"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+#, fuzzy
+msgid "Device Name"
+msgstr "裝置名稱"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+#, fuzzy
+msgid "Hardware Model"
+msgstr "硬件位址"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "記憶體"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "處理器"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "繪圖"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "正在計算…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "名稱"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "類型"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "版本 0"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+#, fuzzy
+msgid "Loading…"
+msgstr "正在載入選項…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows 軟件"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "虛擬化"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+#, fuzzy
+msgid "Software Updates"
+msgstr "軟件使用率"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+#, fuzzy
+msgid "Rename Device"
+msgstr "移除裝置"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "裝置名稱"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "使用者名稱(_U)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "檢視你系統的資訊"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+#, fuzzy
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;裝置;系統;資訊;"
+"記憶體;處理器;版本;預設;應用程式;首選;音訊;視像;光碟;可移除;媒體;自動執行;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
 msgstr "聲音與媒體"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:2
-msgid "Volume mute"
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
 msgstr "靜音"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:3
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "調低音量"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "調高音量"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:5
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
 msgstr "執行媒體播放程式"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:6
+#: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
 msgstr "播放 (或播放/暫停)"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:7
+#: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
 msgstr "暫停播放"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:8
+#: panels/keyboard/00-multimedia.xml.in:18
 msgid "Stop playback"
 msgstr "停止播放"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:9
+#: panels/keyboard/00-multimedia.xml.in:20
 msgid "Previous track"
 msgstr "上一首歌曲"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:10
+#: panels/keyboard/00-multimedia.xml.in:22
 msgid "Next track"
 msgstr "下一首歌曲"
 
-#: ../panels/keyboard/00-multimedia.xml.in.h:11
+#: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
 msgstr "退出"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:1
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
-#: ../panels/universal-access/uap.ui.h:11
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 msgid "Typing"
 msgstr "輸入"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:2
+#: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
 msgstr "切換到下一個輸入來源"
 
-#: ../panels/keyboard/01-input-sources.xml.in.h:3
+#: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
 msgstr "切換到上一個輸入來源"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:1
+#: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
 msgstr "執行器"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:2
+#: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
 msgstr "執行說明文件瀏覽器"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
-#: ../shell/gnome-control-center.desktop.in.in.h:1
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 msgid "Settings"
 msgstr "設定值"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:4
+#: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
 msgstr "執行計數機"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:5
+#: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
 msgstr "執行電子郵件客戶端"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:6
+#: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
 msgstr "執行網頁瀏覽器"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:7
+#: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
 msgstr "家目錄"
 
-#: ../panels/keyboard/01-launchers.xml.in.h:8
+#: panels/keyboard/01-launchers.xml.in:16
 msgctxt "keybinding"
 msgid "Search"
 msgstr "搜尋"
 
-#: ../panels/keyboard/01-screenshot.xml.in.h:1
-msgid "Screenshots"
-msgstr "螢幕擷圖"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:3
-msgid "Save a screenshot to $PICTURES"
-msgstr "將螢幕擷圖儲存為 $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:5
-msgid "Save a screenshot of a window to $PICTURES"
-msgstr "將視窗的螢幕擷圖儲存為 $PICTURES"
-
-#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
-#: ../panels/keyboard/01-screenshot.xml.in.h:7
-msgid "Save a screenshot of an area to $PICTURES"
-msgstr "將區域的螢幕擷圖儲存為 $PICTURES"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:8
-msgid "Copy a screenshot to clipboard"
-msgstr "將螢幕截圖複製到剪貼簿"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:9
-msgid "Copy a screenshot of a window to clipboard"
-msgstr "將視窗的螢幕截圖複製到剪貼簿"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:10
-msgid "Copy a screenshot of an area to clipboard"
-msgstr "將區域的螢幕截圖複製到剪貼簿"
-
-#: ../panels/keyboard/01-screenshot.xml.in.h:11
-msgid "Record a short screencast"
-msgstr "錄製短式螢幕廣播"
-
-#: ../panels/keyboard/01-system.xml.in.h:1
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "系統"
 
-#: ../panels/keyboard/01-system.xml.in.h:2
+#: panels/keyboard/01-system.xml.in:4
 msgid "Log out"
 msgstr "登出"
 
-#: ../panels/keyboard/01-system.xml.in.h:3
+#: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
 msgstr "鎖定畫面"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:1
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
-msgid "Universal Access"
-msgstr "無障礙功能"
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "顯示狀態"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:2
+#: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
 msgstr "開啟或關閉放大鏡"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:3
+#: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
 msgstr "拉近"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:4
+#: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
 msgstr "拉遠"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:5
+#: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
 msgstr "開啟或關閉螢幕閱讀器"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:6
+#: panels/keyboard/50-accessibility.xml.in:12
 msgid "Turn on-screen keyboard on or off"
 msgstr "開啟或關閉螢幕鍵盤"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:7
+#: panels/keyboard/50-accessibility.xml.in:14
 msgid "Increase text size"
 msgstr "將文字放大"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:8
+#: panels/keyboard/50-accessibility.xml.in:16
 msgid "Decrease text size"
 msgstr "將文字縮小"
 
-#: ../panels/keyboard/50-accessibility.xml.in.h:9
+#: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
 msgstr "高對比開或關"
 
-#. translators:
-#. * The device has been disabled
-#: ../panels/keyboard/cc-keyboard-option.c:276
-#: ../panels/keyboard/cc-keyboard-option.c:395
-#: ../panels/keyboard/keyboard-shortcuts.c:1217
-#: ../panels/network/network-wifi.ui.h:29
-#: ../panels/sound/gvc/gvc-mixer-control.c:1830
-#: ../panels/user-accounts/um-fingerprint-dialog.c:213
-#: ../panels/user-accounts/um-fingerprint-dialog.c:214
-msgid "Disabled"
-msgstr "已停用"
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "加入輸入來源"
 
-#. Translators: This key is also known as 'third level
-#. * chooser'. AltGr is often used for this purpose. See
-#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:354
-msgid "Alternative Characters Key"
-msgstr "替代的字符鍵"
+#: panels/keyboard/cc-input-chooser.ui:84
+#, fuzzy
+msgid "Input methods can’t be used on the login screen"
+msgstr "輸入法不能用在登入畫面"
 
-#. Translators: The Compose key is used to initiate key
-#. * sequences that are combined to form a single character.
-#. * See http://en.wikipedia.org/wiki/Compose_key
-#.
-#: ../panels/keyboard/cc-keyboard-option.c:363
-msgid "Compose Key"
-msgstr "組合鍵"
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "尚未選擇輸入來源"
 
-#: ../panels/keyboard/cc-keyboard-option.c:368
-msgid "Modifiers-only switch to next source"
-msgstr "只以修飾鍵切換至下個來源"
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "選項"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "鍵盤"
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "往上移"
 
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
-msgid "View and change keyboard shortcuts and set your typing preferences"
-msgstr "檢視與更改鍵盤捷徑鍵並設定你的輸入偏好設定"
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "往下移"
 
-#. Translators: those are keywords for the keyboard control-center panel
-#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
-msgid "Shortcut;Repeat;Blink;"
-msgstr "Shortcut;Repeat;Blink;捷徑鍵;重複;閃爍;"
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "偏好設定"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
-msgid "Custom Shortcut"
-msgstr "自選捷徑鍵"
+#: panels/keyboard/cc-input-row.ui:48
+#, fuzzy
+msgid "View Keyboard Layout"
+msgstr "顯示鍵盤配置"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
-#: ../panels/network/connection-editor/net-connection-editor.c:512
-#: ../panels/printers/new-printer-dialog.ui.h:3
-#: ../panels/region/input-chooser.ui.h:3
-#: ../panels/user-accounts/um-account-dialog.c:1469
-msgid "_Add"
-msgstr "加入(_A)"
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "移除(_R)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
-msgid "_Name:"
-msgstr "名稱(_N)："
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
-msgid "C_ommand:"
-msgstr "指令(_O)："
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
-msgid "Repeat Keys"
-msgstr "重複按鍵"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
-msgid "Key presses _repeat when key is held down"
-msgstr "當按下某鍵不放時重複輸出該字符(_R)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
-msgid "_Delay:"
-msgstr "延遲(_D)："
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
-msgid "_Speed:"
-msgstr "速度(_S)："
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
-msgctxt "keyboard, delay"
-msgid "Short"
-msgstr "短"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
-msgctxt "keyboard, speed"
-msgid "Slow"
-msgstr "慢速"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
-msgid "Repeat keys speed"
-msgstr "按鍵重複速度"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
-msgctxt "keyboard, delay"
-msgid "Long"
-msgstr "長"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
-msgctxt "keyboard, speed"
-msgid "Fast"
-msgstr "快速"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
-msgid "Cursor Blinking"
-msgstr "游標閃爍"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
-msgid "Cursor _blinks in text fields"
-msgstr "文字輸入欄中的游標可以閃爍(_B)"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
-msgid "S_peed:"
-msgstr "速度(_P)："
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
-msgid "Cursor blink speed"
-msgstr "游標閃爍速度"
-
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
-#: ../panels/region/region.ui.h:5
+#: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
 msgstr "輸入來源"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
-msgid "Add Shortcut"
-msgstr "加入捷徑鍵"
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
-msgid "Remove Shortcut"
-msgstr "移除捷徑鍵"
+#: panels/keyboard/cc-keyboard-panel.ui:28
+#, fuzzy
+msgid "Input Source Switching"
+msgstr "輸入來源選項"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
-msgid ""
-"To edit a shortcut, click the row and hold down the new keys or press "
-"Backspace to clear."
-msgstr "要編輯捷徑鍵，點選相應的列並按下新的按鍵組合，或以 Backspace 鍵來清除。"
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "在所有視窗中使用相同的來源(_S)"
 
-#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+#: panels/keyboard/cc-keyboard-panel.ui:43
+#, fuzzy
+msgid "Switch input sources _individually for each window"
+msgstr "每個視窗使用不同的輸入來源(_D)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+#, fuzzy
+msgid "Alternate Characters Key"
+msgstr "替代的字符鍵"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "組合鍵"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "鍵盤捷徑鍵"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+#, fuzzy
+msgid "View and Customize Shortcuts"
+msgstr "自選捷徑鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "節"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
 msgid "Shortcuts"
 msgstr "快捷鍵"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:634
-#: ../panels/keyboard/keyboard-shortcuts.c:642
-msgid "Custom Shortcuts"
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "加入捷徑鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+#, fuzzy
+msgid "Add Custom Shortcuts"
 msgstr "自選捷徑鍵"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:859
-msgid "<Unknown Action>"
-msgstr "<行動設定不詳>"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1356
-#, c-format
-msgid ""
-"The shortcut \"%s\" cannot be used because it will become impossible to type "
-"using this key.\n"
-"Please try with a key such as Control, Alt or Shift at the same time."
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
 msgstr ""
-"捷徑“%s”無法使用，原因是會無法按下此按鍵。\n"
-"請試用其它的按鍵：如同時使用 Control，Alt  或 Shift。"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1386
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for\n"
-"\"%s\""
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "加入捷徑鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "鍵盤捷徑鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "移除(_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+#, fuzzy
+msgid "Re_place"
+msgstr "取代(_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
 msgstr ""
-"捷徑鍵“%s”己經使用於：\n"
-"“%s”"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1391
-#, c-format
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "名稱"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "指令(_O)："
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+#, fuzzy
+msgid "Shortcut"
+msgstr "快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "新增捷徑鍵…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "沒有"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+msgid "Use layout default"
+msgstr ""
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "鍵盤"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+#, fuzzy
 msgid ""
-"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
-msgstr "如果你重新指派捷徑鍵為「%s」，「%s」的捷徑鍵就會停用。"
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "檢視與更改鍵盤捷徑鍵並設定你的輸入偏好設定"
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1397
-msgid "_Reassign"
-msgstr "重新指派(_R)"
-
-#: ../panels/keyboard/keyboard-shortcuts.c:1429
-#, c-format
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
-"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
-"automatically set it to \"%s\"?"
-msgstr "捷徑鍵「%s」已指派「%s」捷徑。你想要自動將它設定為「%s」嗎？"
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1435
-#, c-format
-#| msgid ""
-#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
-#| "disabled."
+#: panels/location/cc-location-panel.ui:23
+#, fuzzy
+msgid "Location Services Turned Off"
+msgstr "位置服務(_L)"
+
+#: panels/location/cc-location-panel.ui:24
+#, fuzzy
+msgid "No applications can obtain location information."
+msgstr "沒有應用程式目前正在播放或錄製音效。"
+
+#: panels/location/cc-location-panel.ui:38
 msgid ""
-"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
-"if you move forward."
-msgstr "「%s」目前指派為「%s」，如果你繼續這個捷徑鍵就會停用。"
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
 
-#: ../panels/keyboard/keyboard-shortcuts.c:1441
-msgid "_Assign"
-msgstr "指派(_R)"
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
 
-#: ../panels/mouse/cc-mouse-panel.c:94
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+#, fuzzy
+msgid "Microphone Turned Off"
+msgstr "螢幕關閉"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+#, fuzzy
+msgid "No applications can record sound."
+msgstr "找不到應用程式"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
 msgstr "測試你的設定值(_S)"
 
-#: ../panels/mouse/cc-mouse-panel.c:107
-msgid "Test Your Settings"
-msgstr "測試你的設定值"
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "一般"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+#: panels/mouse/cc-mouse-panel.ui:26
+#, fuzzy
+msgid "Primary Button"
+msgstr "主要按鈕(_B)"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+#, fuzzy
+msgid "Left"
+msgstr "左"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "右"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "搜尋位置"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "滑鼠"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "滑鼠按鍵(_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "向下捲動"
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "放大鏡游標隨內容移動"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "使用中"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr "觸控板"
+
+#: panels/mouse/cc-mouse-panel.ui:269
+#, fuzzy
+msgid "Touchpad Speed"
+msgstr "觸控板"
+
+#: panels/mouse/cc-mouse-panel.ui:294
+#, fuzzy
+msgid "Click Method"
+msgstr "方法(_M)"
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+#, fuzzy
+msgid "Tap to Click"
+msgstr "輕觸表示點擊(_C)"
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+#, fuzzy
+msgid "Tap to click"
+msgstr "輕觸表示點擊(_C)"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "打字時停用(_T)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "觸控板 (相對位置)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
+msgstr "向右捲動"
+
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "向左捲動"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "雙面"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "嘗試點選、連按兩下、捲動"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
 msgstr "滑鼠和觸控板"
 
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
 msgstr "改變你的滑鼠或控制板靈敏度並選擇慣用右手或左手"
 
-#. Translators: those are keywords for the mouse and touchpad control-center panel
-#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
-msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;觸控板;指標;點擊;輕觸;連按兩下;按鈕;軌跡球;捲動;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;觸控板;指標;點擊;輕"
+"觸;連按兩下;按鈕;軌跡球;捲動;"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:1
-msgid "General"
-msgstr "一般"
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:2
-msgctxt "double click, speed"
-msgid "Slow"
-msgstr "慢速"
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:3
-msgid "Double-click timeout"
-msgstr "連按兩下分辨時間"
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:4
-msgctxt "double click, speed"
-msgid "Fast"
-msgstr "快速"
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:5
-msgid "_Double-click"
-msgstr "連按兩下(_D)"
+#: panels/multitasking/cc-multitasking-panel.ui:70
+#, fuzzy
+msgid "Workspaces"
+msgstr "色彩空間："
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:6
-msgid "Primary _button"
-msgstr "主要按鈕(_B)"
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:7
-msgctxt "mouse, left button as primary"
-msgid "_Left"
-msgstr "左(_L)"
+#: panels/multitasking/cc-multitasking-panel.ui:77
+#, fuzzy
+msgid "Automatically removes empty workspaces."
+msgstr "自動清空回收筒(_T)"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:8
-msgctxt "mouse, right button as primary"
-msgid "_Right"
-msgstr "右(_R)"
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:9
-msgid "Mouse"
-msgstr "滑鼠"
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:10
-msgid "_Pointer speed"
-msgstr "指標速度(_P)"
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:11
-msgctxt "mouse pointer, speed"
-msgid "Slow"
-msgstr "慢速"
+#: panels/multitasking/cc-multitasking-panel.ui:124
+#, fuzzy
+msgid "Multi-Monitor"
+msgstr "顯示器"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:12
-msgctxt "mouse pointer, speed"
-msgid "Fast"
-msgstr "快速"
+#: panels/multitasking/cc-multitasking-panel.ui:130
+#, fuzzy
+msgid "Workspaces on _primary display only"
+msgstr "拖曳以改變主要顯示器。"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:13
-msgid "Touchpad"
-msgstr "觸控板"
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:14
-msgctxt "touchpad pointer, speed"
-msgid "Slow"
-msgstr "慢速"
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "程式集"
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:15
-msgctxt "touchpad pointer, speed"
-msgid "Fast"
-msgstr "快速"
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:16
-msgid "Disable while _typing"
-msgstr "打字時停用(_T)"
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:17
-msgid "Tap to _click"
-msgstr "輕觸表示點擊(_C)"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-properties.ui.h:18
-msgid "Two _finger scroll"
-msgstr "兩指捲動(_F)"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
 
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: ../panels/mouse/gnome-mouse-properties.ui.h:20
-msgid "_Natural scrolling"
-msgstr "自然捲動(_N)"
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:130
-#: ../panels/mouse/gnome-mouse-test.ui.h:1
-msgid "Try clicking, double clicking, scrolling"
-msgstr "嘗試點選、連按兩下、捲動"
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "裝置"
 
-#: ../panels/mouse/gnome-mouse-test.c:135
-msgid "Five clicks, GEGL time!"
-msgstr "五次點擊，GEGL 時間！"
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr "VPN"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Double click, primary button"
-msgstr "連按兩下，主要按鈕"
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "加入新連線"
 
-#: ../panels/mouse/gnome-mouse-test.c:140
-msgid "Single click, primary button"
-msgstr "點選，主要按鈕"
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Double click, middle button"
-msgstr "連按兩下，中央按鈕"
+#: panels/network/cc-wifi-connection-row.ui:41
+msgid "Connected"
+msgstr "已連線"
 
-#: ../panels/mouse/gnome-mouse-test.c:143
-msgid "Single click, middle button"
-msgstr "點選，中央按鈕"
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "選項…"
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Double click, secondary button"
-msgstr "連按兩下，次要按鈕"
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
 
-#: ../panels/mouse/gnome-mouse-test.c:146
-msgid "Single click, secondary button"
-msgstr "點選，次要按鈕"
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+#, fuzzy
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "Wi-Fi 熱點"
 
-#. TRANSLATORS: this is to disable the radio hardware in the
-#. * network panel
-#: ../panels/network/cc-network-panel.c:366
-msgid "Air_plane Mode"
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "網絡名稱"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "密碼"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+#, fuzzy
+msgid "Generate Random Password"
+msgstr "產生密碼"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "產生密碼"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "開啟(_T)"
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
 msgstr "飛安模式(_P)"
 
-#: ../panels/network/cc-network-panel.c:965
-msgid "Network proxy"
-msgstr "網絡代理伺服器"
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
 
-#. Translators: this is the title of the connection details
-#. * window for vpn connections, it is also used to display
-#. * vpn connections in the device list.
-#.
-#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
-#: ../panels/network/net-vpn.c:431
-#, c-format
-msgid "%s VPN"
-msgstr "%s VPN"
+#: panels/network/cc-wifi-panel.ui:113
+#, fuzzy
+msgid "No Wi-Fi Adapter Found"
+msgstr "找不到圖片"
 
-#. TRANSLATORS: the user is running a NM that is not API compatible
-#: ../panels/network/cc-network-panel.c:1289
-msgid "The system network services are not compatible with this version."
-msgstr "系統網絡服務與這個版本不兼容。"
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+#, fuzzy
+msgid "Airplane Mode On"
+msgstr "飛安模式(_P)"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+#, fuzzy
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi 熱點"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+#, fuzzy
+msgid "Turn Off Hotspot…"
+msgstr "做為熱點(_U)…"
+
+#: panels/network/cc-wifi-panel.ui:240
+#, fuzzy
+msgid "Visible Networks"
+msgstr "網絡"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
 msgstr "802.1x 防護(_S)"
 
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
-#: ../panels/network/connection-editor/security-page.ui.h:2
-#: ../panels/printers/printers.ui.h:14
-msgid "page 1"
-msgstr "頁 1"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
-#: ../panels/network/connection-editor/security-page.ui.h:3
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
-msgid "Anony_mous identity"
-msgstr "匿名識別(_M)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
-#: ../panels/network/connection-editor/security-page.ui.h:4
-msgid "Inner _authentication"
-msgstr "內部核對(_A)"
-
-#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
-#: ../panels/network/connection-editor/security-page.ui.h:5
-#: ../panels/printers/printers.ui.h:16
-msgid "page 2"
-msgstr "頁 2"
-
-#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
-#: ../panels/network/connection-editor/ce-page-security.c:455
-#: ../panels/network/connection-editor/details-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:4
-msgid "Security"
-msgstr "安全性"
-
-#: ../panels/network/connection-editor/ce-page.c:507
-msgid "automatic"
-msgstr "自動"
-
-#. TRANSLATORS: this WEP WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:52
-#: ../panels/network/net-device-wifi.c:217
-#: ../panels/network/net-device-wifi.c:378
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:56
-#: ../panels/network/net-device-wifi.c:221
-#: ../panels/network/net-device-wifi.c:383
-#: ../panels/network/network-wifi.ui.h:17
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:60
-#: ../panels/network/net-device-wifi.c:225
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: ../panels/network/connection-editor/ce-page-details.c:65
-#: ../panels/network/net-device-wifi.c:230
-msgid "Enterprise"
-msgstr "企業版"
-
-#: ../panels/network/connection-editor/ce-page-details.c:70
-#: ../panels/network/net-device-wifi.c:235
-#: ../panels/network/net-device-wifi.c:368
-msgctxt "Wifi security"
-msgid "None"
-msgstr "沒有"
-
-#: ../panels/network/connection-editor/ce-page-details.c:91
-#: ../panels/power/power.ui.h:19
-msgid "Never"
-msgstr "永不"
-
-#: ../panels/network/connection-editor/ce-page-details.c:102
-#: ../panels/user-accounts/um-utils.c:819
-msgid "Today"
-msgstr "今日"
-
-#: ../panels/network/connection-editor/ce-page-details.c:104
-#: ../panels/user-accounts/um-utils.c:822
-msgid "Yesterday"
-msgstr "昨日"
-
-#: ../panels/network/connection-editor/ce-page-details.c:106
-#: ../panels/network/net-device-ethernet.c:126
-#: ../panels/network/net-device-wifi.c:472
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i 天以前"
 
-#. Translators: network device speed
-#: ../panels/network/connection-editor/ce-page-details.c:155
-#: ../panels/network/net-device-ethernet.c:54
-#: ../panels/network/net-device-wifi.c:529
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: ../panels/network/connection-editor/ce-page-details.c:181
-#: ../panels/network/net-device-wifi.c:558
-msgctxt "Signal strength"
-msgid "None"
-msgstr "沒有"
-
-#: ../panels/network/connection-editor/ce-page-details.c:183
-#: ../panels/network/net-device-wifi.c:560
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "太弱"
-
-#: ../panels/network/connection-editor/ce-page-details.c:185
-#: ../panels/network/net-device-wifi.c:562
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "確定"
-
-#: ../panels/network/connection-editor/ce-page-details.c:187
-#: ../panels/network/net-device-wifi.c:564
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "良好"
-
-#: ../panels/network/connection-editor/ce-page-details.c:189
-#: ../panels/network/net-device-wifi.c:566
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "很好"
-
-#: ../panels/network/connection-editor/ce-page-ethernet.c:226
-#: ../panels/network/connection-editor/ce-page-vpn.c:204
-#: ../panels/network/connection-editor/ce-page-wifi.c:270
-#: ../panels/network/network-wifi.ui.h:45
-msgid "Identity"
-msgstr "身分"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:177
-#: ../panels/network/connection-editor/ce-page-ip4.c:439
-#: ../panels/network/connection-editor/ce-page-ip6.c:179
-#: ../panels/network/connection-editor/ce-page-ip6.c:443
-msgid "Address"
-msgstr "地址"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:190
-#: ../panels/network/connection-editor/ce-page-ip4.c:452
-msgid "Netmask"
-msgstr "網絡遮罩"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:204
-#: ../panels/network/connection-editor/ce-page-ip4.c:465
-#: ../panels/network/connection-editor/ce-page-ip6.c:205
-#: ../panels/network/connection-editor/ce-page-ip6.c:473
-#: ../panels/network/network-vpn.ui.h:3
-msgid "Gateway"
-msgstr "通訊閘"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:221
-#: ../panels/network/connection-editor/ce-page-ip6.c:222
-msgid "Delete Address"
-msgstr "刪除位址"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:275
-#: ../panels/network/connection-editor/ce-page-ip6.c:276
-msgid "Add"
-msgstr "加入"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:343
-#: ../panels/network/connection-editor/ce-page-ip6.c:347
-msgid "Server"
-msgstr "伺服器"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:360
-#: ../panels/network/connection-editor/ce-page-ip6.c:364
-msgid "Delete DNS Server"
-msgstr "刪除 DNS 伺服器"
-
-#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: ../panels/network/connection-editor/ce-page-ip4.c:479
-#: ../panels/network/connection-editor/ce-page-ip6.c:487
-msgctxt "network parameters"
-msgid "Metric"
-msgstr "公制"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:500
-#: ../panels/network/connection-editor/ce-page-ip6.c:508
-msgid "Delete Route"
-msgstr "刪除路由"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:615
-#: ../panels/network/network-wifi.ui.h:25
-msgid "Automatic (DHCP)"
-msgstr "自動 (DHCP)"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:619
-#: ../panels/network/connection-editor/ce-page-ip6.c:621
-#: ../panels/network/network-wifi.ui.h:24
-msgid "Manual"
-msgstr "手動"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:623
-#: ../panels/network/connection-editor/ce-page-ip6.c:625
-msgid "Link-Local Only"
-msgstr "只有本機連線"
-
-#: ../panels/network/connection-editor/ce-page-ip4.c:953
-#: ../panels/network/network-wifi.ui.h:46
-msgid "IPv4"
-msgstr "IPv4"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:192
-#: ../panels/network/connection-editor/ce-page-ip6.c:456
-msgid "Prefix"
-msgstr "前綴"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:613
-#: ../panels/network/connection-editor/ethernet-page.ui.h:1
-#: ../panels/network/connection-editor/ip4-page.ui.h:4
-#: ../panels/network/connection-editor/ip6-page.ui.h:4
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
-msgid "Automatic"
-msgstr "自動"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:617
-msgid "Automatic, DHCP only"
-msgstr "自動，僅使用 DHCP"
-
-#: ../panels/network/connection-editor/ce-page-ip6.c:919
-#: ../panels/network/network-wifi.ui.h:47
-msgid "IPv6"
-msgstr "IPv6"
-
-#: ../panels/network/connection-editor/ce-page-reset.c:91
-#: ../panels/network/network-wifi.ui.h:49
-msgid "Reset"
-msgstr "重設"
-
-#: ../panels/network/connection-editor/ce-page-security.c:250
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "沒有"
-
-#: ../panels/network/connection-editor/ce-page-security.c:273
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-位元密碼匙 (Hex 或 ASCII)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:283
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-位元密語"
-
-#: ../panels/network/connection-editor/ce-page-security.c:296
-#: ../panels/network/wireless-security/wireless-security.c:409
-msgid "LEAP"
-msgstr "LEAP"
-
-#: ../panels/network/connection-editor/ce-page-security.c:309
-msgid "Dynamic WEP (802.1x)"
-msgstr "動態 WEP (802.1x)"
-
-#: ../panels/network/connection-editor/ce-page-security.c:323
-msgid "WPA & WPA2 Personal"
-msgstr "WPA & WPA2 個人版"
-
-#: ../panels/network/connection-editor/ce-page-security.c:337
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA & WPA2 企業版"
-
-#: ../panels/network/connection-editor/details-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:2
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
 msgstr "信號強度"
 
-#: ../panels/network/connection-editor/details-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:3
+#: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "連線速度"
 
-#: ../panels/network/connection-editor/details-page.ui.h:4
-#: ../panels/network/net-device-ethernet.c:159
-#: ../panels/network/network-simple.ui.h:3
-#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "安全性"
+
+#: panels/network/connection-editor/details-page.ui:94
 msgid "IPv4 Address"
 msgstr "IPv4 位址"
 
-#: ../panels/network/connection-editor/details-page.ui.h:5
-#: ../panels/network/net-device-ethernet.c:160
-#: ../panels/network/net-device-ethernet.c:164
-#: ../panels/network/network-mobile.ui.h:4
-#: ../panels/network/network-simple.ui.h:4
-#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
 msgid "IPv6 Address"
 msgstr "IPv6 位址"
 
-#: ../panels/network/connection-editor/details-page.ui.h:6
-#: ../panels/network/net-device-ethernet.c:167
-#: ../panels/network/network-simple.ui.h:2
-#: ../panels/network/network-wifi.ui.h:7
+#: panels/network/connection-editor/details-page.ui:126
 msgid "Hardware Address"
 msgstr "硬件位址"
 
-#: ../panels/network/connection-editor/details-page.ui.h:7
-#: ../panels/network/net-device-ethernet.c:171
-#: ../panels/network/network-mobile.ui.h:5
-#: ../panels/network/network-simple.ui.h:5
-#: ../panels/network/network-wifi.ui.h:8
+#: panels/network/connection-editor/details-page.ui:142
+#, fuzzy
+msgid "Supported Frequencies"
+msgstr "支援的 ICC 色彩描述檔"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "預設路由"
 
-#: ../panels/network/connection-editor/details-page.ui.h:8
-#: ../panels/network/connection-editor/ip4-page.ui.h:3
-#: ../panels/network/connection-editor/ip6-page.ui.h:3
-#: ../panels/network/net-device-ethernet.c:173
-#: ../panels/network/network-mobile.ui.h:6
-#: ../panels/network/network-simple.ui.h:6
-#: ../panels/network/network-wifi.ui.h:9
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
 msgid "DNS"
 msgstr "DNS"
 
-#: ../panels/network/connection-editor/details-page.ui.h:9
+#: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
 msgstr "最後使用的"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:2
-msgid "Twisted Pair (TP)"
-msgstr "雙絞線 (TP)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:3
-msgid "Attachment Unit Interface (AUI)"
-msgstr "附加單位介面 (AUI)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:4
-msgid "BNC"
-msgstr "BNC"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:5
-msgid "Media Independent Interface (MII)"
-msgstr "媒體獨立介面 (MII)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:6
-msgid "10 Mb/s"
-msgstr "10 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:7
-msgid "100 Mb/s"
-msgstr "100 Mb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:8
-msgid "1 Gb/s"
-msgstr "1 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:9
-msgid "10 Gb/s"
-msgstr "10 Gb/s"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:10
-#: ../panels/network/connection-editor/vpn-page.ui.h:1
-msgid "_Name"
-msgstr "名稱(_N)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:11
-#: ../panels/network/connection-editor/wifi-page.ui.h:4
-#: ../panels/network/network-wifi.ui.h:36
-msgid "_MAC Address"
-msgstr "_MAC 位址"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:12
-msgid "M_TU"
-msgstr "M_TU"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:13
-#: ../panels/network/connection-editor/wifi-page.ui.h:5
-msgid "_Cloned Address"
-msgstr "複製的 MA_C 位址"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:14
-msgid "bytes"
-msgstr "位元組"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:15
-#: ../panels/network/connection-editor/vpn-page.ui.h:3
-msgid "Make available to other _users"
-msgstr "允許其他使用者使用(_U)"
-
-#: ../panels/network/connection-editor/ethernet-page.ui.h:16
-#: ../panels/network/connection-editor/wifi-page.ui.h:7
+#: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
 msgstr "自動連線(_A)"
 
-#: ../panels/network/connection-editor/ethernet-page.ui.h:17
-#: ../panels/network/connection-editor/vpn-page.ui.h:2
-#: ../panels/network/connection-editor/wifi-page.ui.h:8
-msgid "Firewall _Zone"
-msgstr "防火牆地帶(_Z)"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:48
-#: ../panels/network/connection-editor/firewall-helpers.c:112
-msgctxt "Firewall zone"
-msgid "Default"
-msgstr "預設"
-
-#: ../panels/network/connection-editor/firewall-helpers.c:49
-msgid "The zone defines the trust level of the connection"
-msgstr "這個地帶定義了連線的信任等級"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:22
-msgid "IPv_4"
-msgstr "IPv_4"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:2
-#: ../panels/network/connection-editor/ip6-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:23
-msgid "_Addresses"
-msgstr "位址(_A)"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:5
-#: ../panels/network/connection-editor/ip6-page.ui.h:5
-msgid "Automatic DNS"
-msgstr "自動 DNS"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:6
-#: ../panels/network/connection-editor/ip6-page.ui.h:6
-#: ../panels/network/network-wifi.ui.h:30
-msgid "Routes"
-msgstr "路由"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:7
-#: ../panels/network/connection-editor/ip6-page.ui.h:7
-msgid "Automatic Routes"
-msgstr "自動路由"
-
-#: ../panels/network/connection-editor/ip4-page.ui.h:8
-#: ../panels/network/connection-editor/ip6-page.ui.h:8
-#: ../panels/network/network-wifi.ui.h:32
-msgid "Use this connection _only for resources on its network"
-msgstr "只在使用這個連線的網絡資源時才使用此連線(_U)"
-
-#: ../panels/network/connection-editor/ip6-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:34
-msgid "IPv_6"
-msgstr "IPv_6"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:269
-msgid "Unable to open connection editor"
-msgstr "無法開啟連線編輯器"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:287
-msgid "New Profile"
-msgstr "新增設定組合"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:577
-#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
-msgid "VPN"
-msgstr "VPN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:578
-msgid "Bond"
-msgstr "繫結"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:580
-msgid "Team"
-msgstr "隊伍"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:582
-msgid "Bridge"
-msgstr "橋接"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:583
-msgid "VLAN"
-msgstr "VLAN"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:734
-msgid "Could not load VPN plugins"
-msgstr "無法載入 VPN 外掛程式"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:803
-msgid "Import from file…"
-msgstr "從檔案匯入…"
-
-#: ../panels/network/connection-editor/net-connection-editor.c:874
-msgid "Add Network Connection"
-msgstr "加入網絡連線"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:39
-msgid "_Reset"
-msgstr "重設(_R)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:2
-#: ../panels/network/net-device-wifi.c:1449
-#: ../panels/network/network-wifi.ui.h:40
-msgid "_Forget"
-msgstr "遺忘(_F)"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:3
-msgid ""
-"Reset the settings for this network, including passwords, but remember it as "
-"a preferred network"
-msgstr "重設這個網絡的設定值，包含密碼，但將它記住為偏好的網絡"
-
-#: ../panels/network/connection-editor/reset-page.ui.h:4
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect"
-msgstr "移除這個網絡的相關詳細資料並且不再嘗試自動連線"
-
-#: ../panels/network/connection-editor/security-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:14
-msgid "S_ecurity"
-msgstr "安全性(_E)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:205
-msgid "Cannot import VPN connection"
-msgstr "無法匯入 VPN 網絡連線"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:207
-#, c-format
-msgid ""
-"The file '%s' could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"檔案「%s」無法讀取或未包含可辨識的 VPN 連線資訊\n"
-"\n"
-"錯誤：%s。"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:242
-msgid "Select file to import"
-msgstr "選擇要匯入的檔案"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:246
-#: ../panels/printers/cc-printers-panel.c:1948
-#: ../panels/sharing/cc-sharing-panel.c:492
-#: ../panels/user-accounts/um-photo-dialog.c:223
-msgid "_Open"
-msgstr "開啟(_O)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:294
-#, c-format
-msgid "A file named \"%s\" already exists."
-msgstr "名為「%s」的檔案已經存在。"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:296
-msgid "_Replace"
-msgstr "取代(_R)"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:298
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "你是否要以準備儲存的 VPN 連線取代 %s？"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:334
-msgid "Cannot export VPN connection"
-msgstr "不能匯出 VPN 連線"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:336
-#, c-format
-msgid ""
-"The VPN connection '%s' could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN 連線「%s」不能匯出至 %s。\n"
-"\n"
-"錯誤：%s。"
-
-#: ../panels/network/connection-editor/vpn-helpers.c:371
-msgid "Export VPN connection"
-msgstr "匯出 VPN 連線"
-
-#: ../panels/network/connection-editor/vpn-page.ui.h:4
-msgid "(Error: unable to load VPN connection editor)"
-msgstr "(錯誤：無法載入 VPN 連線編輯器)"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:1
-#: ../panels/network/network-wifi.ui.h:12
-msgid "_SSID"
-msgstr "_SSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:2
-#: ../panels/network/network-wifi.ui.h:13
-msgid "_BSSID"
-msgstr "_BSSID"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:3
-#: ../panels/network/network-wifi.ui.h:16
-msgid "My Home Network"
-msgstr "我的家用網絡"
-
-#: ../panels/network/connection-editor/wifi-page.ui.h:6
+#: panels/network/connection-editor/details-page.ui:383
 msgid "Make available to _other users"
 msgstr "允許其他使用者使用(_O)"
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
-#: ../panels/network/network-mobile.ui.h:7
-msgid "Network"
-msgstr "網絡"
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
 
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
-msgid "Control how you connect to the Internet"
-msgstr "控制你如何連線至網際網絡"
-
-#. Translators: those are keywords for the network control-center panel
-#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
-"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
-"vlan;bridge;bond;DNS;"
-msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;vlan;bridge;bond;DNS;網絡;無線網絡;區域網絡;代理伺服器;寬頻;數據機;藍牙;橋接;繫結;"
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
 
-#: ../panels/network/net-device-bond.c:77
-msgid "Bond slaves"
-msgstr "繫結的連線"
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "名稱(_N)"
 
-#: ../panels/network/net-device-bond.c:102
-#: ../panels/network/net-device-bridge.c:102
-#: ../panels/network/net-device-team.c:102
-msgid "(none)"
-msgstr "(沒有)"
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC 位址"
 
-#: ../panels/network/net-device-bridge.c:77
-msgid "Bridge slaves"
-msgstr "橋接的連線"
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
 
-#: ../panels/network/net-device-ethernet.c:112
-#: ../panels/network/net-device-wifi.c:458
-msgid "never"
-msgstr "永不"
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "複製的 MA_C 位址"
 
-#: ../panels/network/net-device-ethernet.c:122
-#: ../panels/network/net-device-wifi.c:468
-msgid "today"
-msgstr "今日"
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "位元組"
 
-#: ../panels/network/net-device-ethernet.c:124
-#: ../panels/network/net-device-wifi.c:470
-msgid "yesterday"
-msgstr "昨日"
+#: panels/network/connection-editor/ip4-page.ui:21
+#, fuzzy
+msgid "IPv_4 Method"
+msgstr "方法(_M)"
 
-#: ../panels/network/net-device-ethernet.c:162
-#: ../panels/network/network-mobile.ui.h:3
-#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
-#: ../panels/printers/printers.ui.h:13
-msgid "IP Address"
-msgstr "IP 位址"
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "自動 (DHCP)"
 
-#: ../panels/network/net-device-ethernet.c:178
-#: ../panels/network/network-wifi.ui.h:10
-msgid "Last used"
-msgstr "最後使用的"
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "只有本機連線"
 
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: ../panels/network/net-device-ethernet.c:288
-#: ../panels/network/network-ethernet.ui.h:1
-#: ../panels/network/network-simple.ui.h:1
-msgid "Wired"
-msgstr "有線"
-
-#: ../panels/network/net-device-ethernet.c:356
-#: ../panels/network/net-device-wifi.c:1604
-#: ../panels/network/network-ethernet.ui.h:3
-#: ../panels/network/network-mobile.ui.h:8
-#: ../panels/network/network-simple.ui.h:8
-#: ../panels/network/network-vpn.ui.h:8
-msgid "Options…"
-msgstr "選項…"
-
-#: ../panels/network/net-device-ethernet.c:474
-#, c-format
-msgid "Profile %d"
-msgstr "設定組合 %d"
-
-#: ../panels/network/net-device-mobile.c:232
-msgid "Add new connection"
-msgstr "加入新連線"
-
-#: ../panels/network/net-device-team.c:77
-msgid "Team slaves"
-msgstr "隊伍從屬"
-
-#: ../panels/network/net-device-wifi.c:1153
-msgid ""
-"If you have a connection to the Internet other than wireless, you can set up "
-"a wireless hotspot to share the connection with others."
-msgstr "如果你有無線網絡以外的方式連線到互聯網，你可以使用它來與其他人分享你的互聯網連線。"
-
-#: ../panels/network/net-device-wifi.c:1157
-#, c-format
-msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
-msgstr "切換無線網絡熱點會讓你從 <b>%s</b> 斷線。"
-
-#: ../panels/network/net-device-wifi.c:1161
-msgid ""
-"It is not possible to access the Internet through your wireless while the "
-"hotspot is active."
-msgstr "當熱點在使用中時是沒有辦法透過你的無線網絡存取互聯網的。"
-
-#: ../panels/network/net-device-wifi.c:1238
-msgid "Stop hotspot and disconnect any users?"
-msgstr "停止熱點並中斷任何使用者的連線？"
-
-#: ../panels/network/net-device-wifi.c:1241
-msgid "_Stop Hotspot"
-msgstr "停止熱點(_S)"
-
-#: ../panels/network/net-device-wifi.c:1313
-msgid "System policy prohibits use as a Hotspot"
-msgstr "系統原則禁止做為熱點"
-
-#: ../panels/network/net-device-wifi.c:1316
-msgid "Wireless device does not support Hotspot mode"
-msgstr "無線裝置不支援熱點模式"
-
-#: ../panels/network/net-device-wifi.c:1445
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr "選取網絡的詳細資料包含密碼及任何自選的組態都會消失。"
-
-#: ../panels/network/net-device-wifi.c:1753
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
-msgid "History"
-msgstr "歷史紀錄"
-
-#: ../panels/network/net-device-wifi.c:1757
-#: ../panels/wacom/cc-wacom-page.c:533
-msgid "_Close"
-msgstr "關閉(_C)"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: ../panels/network/net-device-wifi.c:1765
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "遺忘(_F)"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: ../panels/network/net-proxy.c:67
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "當沒有提供組態 URL 時會使用網頁代理伺服器自動發現。"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: ../panels/network/net-proxy.c:75
-msgid "This is not recommended for untrusted public networks."
-msgstr "這不建議用於不信任的公用網絡。"
-
-#: ../panels/network/net-proxy.c:410
-msgid "Proxy"
-msgstr "代理伺服器"
-
-#: ../panels/network/network-ethernet.ui.h:2
-msgid "_Add Profile…"
-msgstr "加入設定組合(_A)…"
-
-#: ../panels/network/network-mobile.ui.h:1
-msgid "IMEI"
-msgstr "IMEI"
-
-#: ../panels/network/network-mobile.ui.h:2
-msgid "Provider"
-msgstr "供應商"
-
-#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
-msgctxt "proxy method"
-msgid "None"
-msgstr "沒有"
-
-#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "手動"
 
-#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
-msgctxt "proxy method"
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "已停用"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+#, fuzzy
+msgid "Shared to other computers"
+msgstr "分享給其他電腦"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "位址(_A)"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "地址"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "網絡遮罩"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "通訊閘"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
 msgid "Automatic"
 msgstr "自動"
 
-#: ../panels/network/network-proxy.ui.h:4
-msgid "_Method"
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "自動 DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "路由"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "自動路由"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+#, fuzzy
+msgid "Metric"
+msgstr "公制"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "只在使用這個連線的網絡資源時才使用此連線(_U)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+#, fuzzy
+msgid "IPv_6 Method"
 msgstr "方法(_M)"
 
-#: ../panels/network/network-proxy.ui.h:5
-msgid "_Configuration URL"
-msgstr "組態網址(_C)"
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "自動，僅使用 DHCP"
 
-#: ../panels/network/network-proxy.ui.h:6
-msgid "_HTTP Proxy"
-msgstr "_HTTP 代理伺服器"
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "前綴"
 
-#: ../panels/network/network-proxy.ui.h:7
-msgid "H_TTPS Proxy"
-msgstr "H_TTPS 代理伺服器"
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "安全性(_E)"
 
-#: ../panels/network/network-proxy.ui.h:8
-msgid "_FTP Proxy"
-msgstr "_FTP 代理伺服器"
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(錯誤：無法載入 VPN 連線編輯器)"
 
-#: ../panels/network/network-proxy.ui.h:9
-msgid "_Socks Host"
-msgstr "Socks 主機(_S)"
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
 
-#: ../panels/network/network-proxy.ui.h:10
-msgid "_Ignore Hosts"
-msgstr "忽略主機(_I)"
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
 
-#: ../panels/network/network-proxy.ui.h:11
-msgid "HTTP proxy port"
-msgstr "HTTP 代理伺服器連接埠"
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "網絡"
 
-#: ../panels/network/network-proxy.ui.h:12
-msgid "HTTPS proxy port"
-msgstr "HTTPS 代理伺服器連接埠"
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "控制你如何連線至網際網絡"
 
-#: ../panels/network/network-proxy.ui.h:13
-msgid "FTP proxy port"
-msgstr "FTP 代理伺服器連接埠"
+#: panels/network/gnome-network-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;網絡;無線網絡;區域網絡;代理伺服器;寬頻;數據機;藍牙;橋接;"
+"繫結;"
 
-#: ../panels/network/network-proxy.ui.h:14
-msgid "Socks proxy port"
-msgstr "Socks 代理伺服器通訊埠"
-
-#: ../panels/network/network-simple.ui.h:7
-msgid "Turn device off"
-msgstr "關閉裝置"
-
-#: ../panels/network/network.ui.h:5
-msgid "Add Device"
-msgstr "加入裝置"
-
-#: ../panels/network/network.ui.h:6
-msgid "Remove Device"
-msgstr "移除裝置"
-
-#: ../panels/network/network-vpn.ui.h:2
-msgid "VPN Type"
-msgstr "VPN 類型"
-
-#: ../panels/network/network-vpn.ui.h:4
-msgid "Group Name"
-msgstr "羣組名稱"
-
-#: ../panels/network/network-vpn.ui.h:5
-msgid "Group Password"
-msgstr "羣組密碼"
-
-#: ../panels/network/network-vpn.ui.h:6
-#: ../panels/printers/authentication-dialog.ui.h:4
-msgid "Username"
-msgstr "使用者名稱"
-
-#: ../panels/network/network-vpn.ui.h:7
-msgid "Turn VPN connection off"
-msgstr "關閉 VPN 連線"
-
-#: ../panels/network/network-wifi.ui.h:1
-msgid "Automatic _Connect"
-msgstr "自動連線(_C)"
-
-#: ../panels/network/network-wifi.ui.h:11
-msgid "details"
-msgstr "詳細資料"
-
-#: ../panels/network/network-wifi.ui.h:15
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
-#: ../panels/network/wireless-security/ws-leap.ui.h:2
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:9
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
-msgid "_Password"
-msgstr "密碼(_P)"
-
-#: ../panels/network/network-wifi.ui.h:18
-msgid "None"
-msgstr "沒有"
-
-#: ../panels/network/network-wifi.ui.h:19
-msgid "Show P_assword"
-msgstr "顯示密碼(_A)"
-
-#: ../panels/network/network-wifi.ui.h:20
-msgid "Make available to other users"
-msgstr "允許其他使用者使用"
-
-#: ../panels/network/network-wifi.ui.h:21
-msgid "identity"
-msgstr "身分"
-
-#: ../panels/network/network-wifi.ui.h:26
-msgid "Automatic (DHCP) addresses only"
-msgstr "只用自動 (DHCP) 位址"
-
-#: ../panels/network/network-wifi.ui.h:27
-msgid "Link-local only"
-msgstr "只有本機連線"
-
-#: ../panels/network/network-wifi.ui.h:28
-msgid "Shared with other computers"
-msgstr "分享給其他電腦"
-
-#: ../panels/network/network-wifi.ui.h:31
-msgid "_Ignore automatically obtained routes"
-msgstr "忽略自動獲得的路由(_I)"
-
-#: ../panels/network/network-wifi.ui.h:33
-msgid "ipv4"
-msgstr "ipv4"
-
-#: ../panels/network/network-wifi.ui.h:35
-msgid "ipv6"
-msgstr "ipv6"
-
-#: ../panels/network/network-wifi.ui.h:37
-msgid "_Cloned MAC Address"
-msgstr "複製的 MA_C 位址"
-
-#: ../panels/network/network-wifi.ui.h:38
-msgid "hardware"
-msgstr "硬件"
-
-#: ../panels/network/network-wifi.ui.h:41
-msgid ""
-"Reset the settings for this connection to their defaults, but remember as a "
-"preferred connection."
-msgstr "重設這個網絡的設定值為預設值，但將它記住為偏好的網絡。"
-
-#: ../panels/network/network-wifi.ui.h:42
-msgid ""
-"Remove all details relating to this network and do not try to automatically "
-"connect to it."
-msgstr "移除這個網絡的所有相關詳細資料並且不再嘗試自動連線。"
-
-#: ../panels/network/network-wifi.ui.h:43
-msgid "reset"
-msgstr "重設"
-
-#: ../panels/network/network-wifi.ui.h:48
-msgid "Hardware"
-msgstr "硬件"
-
-#: ../panels/network/network-wifi.ui.h:50
-msgid "Wi-Fi Hotspot"
-msgstr "Wi-Fi 熱點"
-
-#: ../panels/network/network-wifi.ui.h:51
-msgid "_Turn On"
-msgstr "開啟(_T)"
-
-#: ../panels/network/network-wifi.ui.h:52
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: ../panels/network/network-wifi.ui.h:53
-msgid "Turn Wi-Fi off"
-msgstr "關閉 Wi-Fi"
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+#, fuzzy
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "控制你如何連線至網際網絡"
 
-#: ../panels/network/network-wifi.ui.h:54
-msgid "_Use as Hotspot…"
-msgstr "做為熱點(_U)…"
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+#, fuzzy
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;網絡;無線網絡;區域網絡;代理伺服器;寬頻;數據機;藍牙;橋接;"
+"繫結;"
 
-#: ../panels/network/network-wifi.ui.h:55
-msgid "_Connect to Hidden Network…"
-msgstr "連接到隱藏的網絡(_C)…"
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "有線"
 
-#: ../panels/network/network-wifi.ui.h:56
-msgid "_History"
-msgstr "歷史紀錄(_H)"
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "關閉裝置"
 
-#: ../panels/network/network-wifi.ui.h:57
-msgid "Switch off to connect to a Wi-Fi network"
-msgstr "關閉連線到 Wi-Fi 網絡"
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "使用中"
 
-#: ../panels/network/network-wifi.ui.h:58
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "供應商"
+
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP 位址"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+#, fuzzy
+msgid "Network Proxy"
+msgstr "網絡代理伺服器"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP 代理伺服器"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS 代理伺服器"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP 代理伺服器"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Socks 主機(_S)"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "忽略主機(_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP 代理伺服器連接埠"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS 代理伺服器連接埠"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP 代理伺服器連接埠"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks 代理伺服器通訊埠"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "組態網址(_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "關閉 VPN 連線"
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Network Name"
 msgstr "網絡名稱"
 
-#: ../panels/network/network-wifi.ui.h:59
-msgid "Connected Devices"
-msgstr "已連線的裝置"
-
-#: ../panels/network/network-wifi.ui.h:60
+#: panels/network/network-wifi.ui:40
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
 msgid "Security type"
 msgstr "安全性類型"
 
-#: ../panels/network/network-wifi.ui.h:61
-msgid "Security key"
-msgstr "安全密碼匙"
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "密碼"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:131
-msgid "Ad-hoc"
-msgstr "Ad-hoc"
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "關閉 Wi-Fi"
 
-#. TRANSLATORS: AP type
-#: ../panels/network/panel-common.c:135
-msgid "Infrastructure"
-msgstr "基礎架構"
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "正在載入選項…"
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
-msgid "Status unknown"
-msgstr "狀態不明"
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "連接到隱藏的網絡(_C)…"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:155
-msgid "Unmanaged"
-msgstr "未管理"
+#: panels/network/network-wifi.ui:131
+#, fuzzy
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "Wi-Fi 熱點"
 
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:159
-msgid "Unavailable"
-msgstr "無法使用"
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
 
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
-msgid "Connecting"
-msgstr "連線中"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
-msgid "Authentication required"
-msgstr "需要核對"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
-msgid "Connected"
-msgstr "已連線"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:181
-msgid "Disconnecting"
-msgstr "斷線"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
-msgid "Connection failed"
-msgstr "連線失敗"
-
-#. TRANSLATORS: device status
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
-msgid "Status unknown (missing)"
-msgstr "狀態不詳（缺乏）"
-
-#. TRANSLATORS: VPN status
-#: ../panels/network/panel-common.c:227
-msgid "Not connected"
-msgstr "未連線"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:252
-msgid "Configuration failed"
-msgstr "設定失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:256
-msgid "IP configuration failed"
-msgstr "IP 組態失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:260
-msgid "IP configuration expired"
-msgstr "IP 組態過期"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:264
-msgid "Secrets were required, but not provided"
-msgstr "需要機密，但沒有提供"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:268
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x 請求已斷線"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:272
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x 請求組態失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:276
-msgid "802.1x supplicant failed"
-msgstr "802.1x 請求已失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:280
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x 請求花了太長時間核對"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:284
-msgid "PPP service failed to start"
-msgstr "無法啟動 PPP 服務"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:288
-msgid "PPP service disconnected"
-msgstr "PPP 服務已斷線"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:292
-msgid "PPP failed"
-msgstr "PPP 失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:296
-msgid "DHCP client failed to start"
-msgstr "DHCP 客戶端啟動失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:300
-msgid "DHCP client error"
-msgstr "DHCP 客戶端錯誤"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:304
-msgid "DHCP client failed"
-msgstr "DHCP 客戶端失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:308
-msgid "Shared connection service failed to start"
-msgstr "分享的連線服務啟動失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:312
-msgid "Shared connection service failed"
-msgstr "分享的連線服務失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:316
-msgid "AutoIP service failed to start"
-msgstr "無法啟動 AutoIP 服務"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:320
-msgid "AutoIP service error"
-msgstr "AutoIP 服務錯誤"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:324
-msgid "AutoIP service failed"
-msgstr "AutoIP 服務失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:328
-msgid "Line busy"
-msgstr "線路忙碌"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:332
-msgid "No dial tone"
-msgstr "沒有撥號音"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:336
-msgid "No carrier could be established"
-msgstr "無法建立載體"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:340
-msgid "Dialing request timed out"
-msgstr "撥號要求逾時"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:344
-msgid "Dialing attempt failed"
-msgstr "嘗試撥號失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:348
-msgid "Modem initialization failed"
-msgstr "數據機初始化失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:352
-msgid "Failed to select the specified APN"
-msgstr "無法選擇指定的 APN"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:356
-msgid "Not searching for networks"
-msgstr "不要搜尋網絡"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:360
-msgid "Network registration denied"
-msgstr "網絡登記被禁止"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:364
-msgid "Network registration timed out"
-msgstr "網絡登記逾時"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:368
-msgid "Failed to register with the requested network"
-msgstr "無法向要求的網絡登記"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:372
-msgid "PIN check failed"
-msgstr "PIN 檢查失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:376
-msgid "Firmware for the device may be missing"
-msgstr "可能缺少裝置的韌體"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:380
-msgid "Connection disappeared"
-msgstr "連線已消失"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:384
-msgid "Existing connection was assumed"
-msgstr "優先使用現有的連線"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:388
-msgid "Modem not found"
-msgstr "找不到數據機"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:392
-msgid "Bluetooth connection failed"
-msgstr "藍牙連線失敗"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:396
-msgid "SIM Card not inserted"
-msgstr "SIM 卡尚未插入"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:400
-msgid "SIM Pin required"
-msgstr "需要 SIM PIN 碼"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:404
-msgid "SIM Puk required"
-msgstr "需要 SIM PUK 碼"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:408
-msgid "SIM wrong"
-msgstr "SIM 錯誤"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:412
-msgid "InfiniBand device does not support connected mode"
-msgstr "InfiniBand 裝置不支援已連接模式"
-
-#. TRANSLATORS: device status reason
-#: ../panels/network/panel-common.c:416
-msgid "Connection dependency failed"
-msgstr "連線相根據性解析失敗"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:440
-msgid "Firmware missing"
-msgstr "缺少韌體"
-
-#. TRANSLATORS: device status
-#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
-msgid "Cable unplugged"
-msgstr "纜線已拔除"
-
-#: ../panels/network/wireless-security/eap-method.c:275
-msgid "No Certificate Authority certificate chosen"
-msgstr "未選擇任何證書授權單位(CA)證書"
-
-#: ../panels/network/wireless-security/eap-method.c:276
-msgid ""
-"Not using a Certificate Authority (CA) certificate can result in connections "
-"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
-"Authority certificate?"
-msgstr "不使用證書中心 (CA) 的證書會造成連線不安全、流氓 Wi-Fi 網絡。是否要選擇一個證書中心的證書？"
-
-#: ../panels/network/wireless-security/eap-method.c:281
-msgid "Ignore"
-msgstr "忽略"
-
-#: ../panels/network/wireless-security/eap-method.c:285
-msgid "Choose CA Certificate"
-msgstr "選擇 CA 證書"
-
-#: ../panels/network/wireless-security/eap-method.c:645
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
-msgstr "DER, PEM, 或 PKCS#12 私密密碼匙(*.der, *.pem, *.p12)"
-
-#: ../panels/network/wireless-security/eap-method.c:648
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER 或 PEM 證書 (*.der, *.pem, *.crt, *.cer)"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:271
-#: ../panels/network/wireless-security/eap-method-peap.c:280
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
 msgid "GTC"
 msgstr "GTC"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:287
-#: ../panels/network/wireless-security/eap-method-peap.c:246
-#: ../panels/network/wireless-security/eap-method-ttls.c:263
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
 msgid "MSCHAPv2"
 msgstr "MSCHAPv2"
 
-#: ../panels/network/wireless-security/eap-method-fast.c:409
-msgid "Choose a PAC file"
-msgstr "選擇一個 PAC 檔案"
-
-#: ../panels/network/wireless-security/eap-method-fast.c:416
-msgid "PAC files (*.pac)"
-msgstr "PAC 檔案 (*.pac)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
-msgid "PAC _file"
-msgstr "PAC 檔案(_F)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
-msgid "_Inner authentication"
-msgstr "內部核對(_I)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
-msgid "PAC pro_visioning"
-msgstr "允許自動供應 PAC (_V)"
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
-#: ../panels/printers/authentication-dialog.ui.h:1
-msgid " "
-msgstr " "
-
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+#: panels/network/wireless-security/eap-method-fast.ui:29
 msgid "Anonymous"
 msgstr "匿名"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+#: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
 msgstr "已核對"
 
-#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+#: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
 msgstr "兩者"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
-#: ../panels/network/wireless-security/ws-leap.ui.h:1
-#: ../panels/user-accounts/data/account-dialog.ui.h:3
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "匿名識別(_M)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC 檔案(_F)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "選擇一個 PAC 檔案"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "內部核對(_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+#, fuzzy
+msgid "Allow automatic PAC pro_visioning"
+msgstr "允許自動供應 PAC (_V)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
 msgid "_Username"
 msgstr "使用者名稱(_U)"
 
-#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
-#: ../panels/network/wireless-security/ws-leap.ui.h:3
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "密碼(_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "顯示密碼(_W)"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:263
-#: ../panels/network/wireless-security/wireless-security.c:385
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
 msgid "MD5"
 msgstr "MD5"
 
-#: ../panels/network/wireless-security/eap-method-peap.c:350
-#: ../panels/network/wireless-security/eap-method-tls.c:456
-#: ../panels/network/wireless-security/eap-method-ttls.c:350
-msgid "Choose a Certificate Authority certificate"
-msgstr "選擇證書授權單位 (CA) 證書"
-
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:36
 msgid "Version 0"
 msgstr "版本 0"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+#: panels/network/wireless-security/eap-method-peap.ui:39
 msgid "Version 1"
 msgstr "版本 1"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
-#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
 msgstr "證書(_A)"
 
-#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "選擇證書授權單位 (CA) 證書"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+#, fuzzy
+msgid "No CA certificate is _required"
+msgstr "需要核對"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
 msgid "PEAP _version"
 msgstr "PEAP 版本(_V)"
 
-#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
-msgid "As_k for this password every time"
-msgstr "每次都詢問密碼(_K)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:282
-msgid "Unencrypted private keys are insecure"
-msgstr "未加密的私密密碼匙是不安全的"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:285
-msgid ""
-"The selected private key does not appear to be protected by a password.  "
-"This could allow your security credentials to be compromised.  Please select "
-"a password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"所選擇的私密密碼匙似乎沒有密碼保護。 這可能會導致不安全的後果。請選擇用密碼保護的私密密碼匙。\n"
-"\n"
-"(你可以使用 openssl 來加密你的私密密碼匙)"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:450
-msgid "Choose your personal certificate"
-msgstr "選擇你的個人證書"
-
-#: ../panels/network/wireless-security/eap-method-tls.c:462
-msgid "Choose your private key"
-msgstr "選擇你的私密密碼匙"
-
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+#: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "識別(_D)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+#: panels/network/wireless-security/eap-method-tls.ui:32
 msgid "_User certificate"
 msgstr "使用者證書(_U)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+#: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
 msgstr "私人密碼匙(_K)"
 
-#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+#: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "私密密碼匙密碼(_P)"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:230
+#: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
 msgstr "PAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:247
+#: panels/network/wireless-security/eap-method-ttls.ui:17
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: ../panels/network/wireless-security/eap-method-ttls.c:280
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+#, fuzzy
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
 msgstr "CHAP"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
-msgid "Don't _warn me again"
-msgstr "不要再警告我(_W)"
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "網域(_O)"
 
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
-msgid "No"
-msgstr "否"
-
-#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
-msgid "Yes"
-msgstr "是"
-
-#: ../panels/network/wireless-security/wireless-security.c:397
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:421
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
 msgid "FAST"
 msgstr "FAST"
 
-#: ../panels/network/wireless-security/wireless-security.c:432
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
 msgid "Tunneled TLS"
 msgstr "穿隧式 TLS"
 
-#: ../panels/network/wireless-security/wireless-security.c:443
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
 msgid "Protected EAP (PEAP)"
 msgstr "保護式 EAP (PEAP)"
 
-#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
-#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
 msgstr "核對(_T)"
 
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
-msgid "1 (Default)"
-msgstr "1 (預設值)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
-msgid "2"
-msgstr "2"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
-msgid "3"
-msgstr "3"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
-msgid "4"
-msgstr "4"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
-msgid "Open System"
-msgstr "開放系統"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
-msgid "Shared Key"
-msgstr "共享密碼匙"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
-msgid "_Key"
-msgstr "密碼匙(_K)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
-msgid "Sho_w key"
-msgstr "顯示密碼匙(_W)"
-
-#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
-msgid "WEP inde_x"
-msgstr "WEP 索引(_X)"
-
-#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "類型(_T)"
 
-#. TRANSLATORS: this is the per application switch for message tray usage.
-#: ../panels/notifications/cc-edit-dialog.c:37
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (預設值)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "開放系統"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "共享密碼匙"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "密碼匙(_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "顯示密碼匙(_W)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP 索引(_X)"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
 msgctxt "notifications"
-msgid "Notifications"
+msgid "_Notifications"
 msgstr "通知"
 
-#. TRANSLATORS: this is the setting to configure sounds associated with notifications
-#: ../panels/notifications/cc-edit-dialog.c:39
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
 msgctxt "notifications"
-msgid "Sound Alerts"
+msgid "Sound _Alerts"
 msgstr "音效通知"
 
-#: ../panels/notifications/cc-edit-dialog.c:40
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+#, fuzzy
 msgctxt "notifications"
-msgid "Show Popup Banners"
-msgstr "顯示彈出式橫幅"
-
-#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
-#: ../panels/notifications/cc-edit-dialog.c:42
-msgctxt "notifications"
-msgid "Show Details in Banners"
-msgstr "在橫幅顯示詳細資料"
-
-#: ../panels/notifications/cc-edit-dialog.c:43
-msgctxt "notifications"
-msgid "View in Lock Screen"
-msgstr "在鎖定畫面中顯示"
-
-#: ../panels/notifications/cc-edit-dialog.c:44
-msgctxt "notifications"
-msgid "Show Details in Lock Screen"
-msgstr "在鎖定畫面中顯示詳細資料"
-
-#: ../panels/notifications/cc-notifications-panel.c:185
-#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
-#: ../panels/privacy/cc-privacy-panel.c:84
-#: ../panels/privacy/cc-privacy-panel.c:124
-#: ../panels/universal-access/cc-ua-panel.c:257
-#: ../panels/universal-access/cc-ua-panel.c:572
-#: ../panels/universal-access/cc-ua-panel.c:695
-msgid "On"
-msgstr "開啟"
-
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
-msgid "Notifications"
+msgid "Notification _Popups"
 msgstr "通知"
 
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "通知"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+#, fuzzy
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "在鎖定畫面中顯示詳細資料"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "通知"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
 msgstr "控制要顯示哪種通知及要顯示什麼"
 
-#. Translators: those are keywords for the notifications control-center panel
-#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
 msgstr "Notifications;Banner;Message;Tray;Popup;通知;橫幅;訊息;匣;彈出;"
 
-#: ../panels/notifications/notifications.ui.h:1
-msgid "Show Pop Up Banners"
-msgstr "顯示彈出式橫幅"
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
 
-#: ../panels/notifications/notifications.ui.h:2
-msgid "Show in Lock Screen"
-msgstr "在鎖定畫面中顯示"
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "管理通知"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
-msgctxt "Online Account"
-msgid "Other"
-msgstr "其他"
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
 
-#. translators: This is the title of the "Add Account" dialog.
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
-#: ../panels/online-accounts/online-accounts.ui.h:2
-msgid "Add Account"
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+#, fuzzy
+msgid "Add an account"
 msgstr "加入帳號"
 
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
-msgid "Mail"
-msgstr "郵件"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
-msgid "Contacts"
-msgstr "聯絡人"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
-msgid "Chat"
-msgstr "聊天"
-
-#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
-msgid "Resources"
-msgstr "資源"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:423
-msgid "Error logging into the account"
-msgstr "登入帳號時發生錯誤"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:493
-msgid "Credentials have expired."
-msgstr "證書已經過期。"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:497
-msgid "Sign in to enable this account."
-msgstr "登入以啟用這個帳號。"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:502
-msgid "_Sign In"
-msgstr "登入(_S)"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:743
-msgid "Error creating account"
-msgstr "建立帳號時發生錯誤"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "移除帳號時發生錯誤"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:839
-msgid "Are you sure you want to remove the account?"
-msgstr "確定要刪除這個帳號？"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:841
-msgid "This will not remove the account on the server."
-msgstr "這不會移除伺服器上的帳號。"
-
-#: ../panels/online-accounts/cc-online-accounts-panel.c:842
-msgid "_Remove"
-msgstr "移除(_R)"
-
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
 msgstr "網上帳號"
 
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
 msgstr "連接到你的網上帳號並決定要用它們來做什麼"
 
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
-#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
-msgstr "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;谷歌;臉書;推特;雅虎奇摩;網頁;網上;聊天;行事曆;郵件;聯絡人;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;谷歌;臉書;推特;雅虎奇摩;網頁;網上;聊天;"
+"行事曆;郵件;聯絡人;"
 
-#: ../panels/online-accounts/online-accounts.ui.h:1
-msgid "No online accounts configured"
-msgstr "尚未設定網上帳號"
-
-#: ../panels/online-accounts/online-accounts.ui.h:3
-msgid "Remove Account"
-msgstr "移除帳號"
-
-#: ../panels/online-accounts/online-accounts.ui.h:4
-msgid "Add an online account"
-msgstr "加入網上帳號"
-
-#: ../panels/online-accounts/online-accounts.ui.h:5
-msgid ""
-"Adding an account allows your applications to access it for documents, mail, "
-"contacts, calendar, chat and more."
-msgstr "加入一個帳號以允許你的應用程式存取它用於文件、郵件、聯絡人、行事曆、聊天等等。"
-
-#: ../panels/power/cc-power-panel.c:183
-msgid "Unknown time"
-msgstr "不明的時間"
-
-#: ../panels/power/cc-power-panel.c:189
+#: panels/power/cc-battery-row.c:83
 #, c-format
 msgid "%i minute"
 msgid_plural "%i minutes"
 msgstr[0] "%i 分鐘"
 
-#: ../panels/power/cc-power-panel.c:201
+#: panels/power/cc-battery-row.c:92
 #, c-format
 msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i 小時"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: ../panels/power/cc-power-panel.c:209
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
-#: ../panels/power/cc-power-panel.c:210
+#: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
 msgstr[0] "小時"
 
-#: ../panels/power/cc-power-panel.c:211
+#: panels/power/cc-battery-row.c:100
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "分鐘"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:230
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s後完全充飽"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 分鐘"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:237
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "注意：剩下 %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "2 分鐘"
 
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: ../panels/power/cc-power-panel.c:242
-#, c-format
-msgid "%s remaining"
-msgstr "剩下 %s"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "5 分鐘"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
-msgid "Fully charged"
-msgstr "已完全充飽"
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 分鐘"
 
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
-msgid "Empty"
-msgstr "沒電"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:266
-msgid "Charging"
-msgstr "充電"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:271
-msgid "Discharging"
-msgstr "放電中"
-
-#: ../panels/power/cc-power-panel.c:396
-msgctxt "Battery name"
-msgid "Main"
-msgstr "主要"
-
-#: ../panels/power/cc-power-panel.c:398
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "額外"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:470
-msgid "Wireless mouse"
-msgstr "無線滑鼠"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:473
-msgid "Wireless keyboard"
-msgstr "無線鍵盤"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:476
-msgid "Uninterruptible power supply"
-msgstr "不斷電系統"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:479
-msgid "Personal digital assistant"
-msgstr "個人數碼助理"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:482
-msgid "Cellphone"
-msgstr "手機"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:485
-msgid "Media player"
-msgstr "媒體播放器"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:488
-msgid "Tablet"
-msgstr "繪圖板"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:491
-msgid "Computer"
-msgstr "電腦"
-
-#. TRANSLATORS: secondary battery, misc
-#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
-#: ../panels/power/cc-power-panel.c:2019
-msgid "Battery"
-msgstr "電池"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:540
-msgctxt "Battery power"
-msgid "Charging"
-msgstr "充電"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:547
-msgctxt "Battery power"
-msgid "Caution"
-msgstr "注意"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:552
-msgctxt "Battery power"
-msgid "Low"
-msgstr "低"
-
-#. TRANSLATORS: secondary battery
-#: ../panels/power/cc-power-panel.c:557
-msgctxt "Battery power"
-msgid "Good"
-msgstr "良好"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:562
-msgctxt "Battery power"
-msgid "Fully charged"
-msgstr "已完全充飽"
-
-#. TRANSLATORS: primary battery
-#: ../panels/power/cc-power-panel.c:566
-msgctxt "Battery power"
-msgid "Empty"
-msgstr "沒電"
-
-#: ../panels/power/cc-power-panel.c:715
-msgid "Batteries"
-msgstr "電池"
-
-#: ../panels/power/cc-power-panel.c:1117
-msgid "When _idle"
-msgstr "閒置時(_I)"
-
-#: ../panels/power/cc-power-panel.c:1445
-msgid "Power Saving"
-msgstr "節省電源"
-
-#: ../panels/power/cc-power-panel.c:1473
-msgid "_Screen brightness"
-msgstr "螢幕亮度(_S)"
-
-#: ../panels/power/cc-power-panel.c:1479
-msgid "_Keyboard brightness"
-msgstr "鍵盤亮度(_K)"
-
-#: ../panels/power/cc-power-panel.c:1489
-msgid "_Dim screen when inactive"
-msgstr "當不活動後降低螢幕亮度(_D)"
-
-#: ../panels/power/cc-power-panel.c:1514
-msgid "_Blank screen"
-msgstr "螢幕轉黑(_B)"
-
-#: ../panels/power/cc-power-panel.c:1551
-msgid "_Wi-Fi"
-msgstr "_Wi-Fi"
-
-#: ../panels/power/cc-power-panel.c:1556
-msgid "Turns off wireless devices"
-msgstr "關閉無線裝置"
-
-#: ../panels/power/cc-power-panel.c:1581
-msgid "_Mobile broadband"
-msgstr "流動寬頻(_M)"
-
-#: ../panels/power/cc-power-panel.c:1586
-msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
-msgstr "關閉流動寬頻 (3G、4G、WiMax 等) 裝置"
-
-#: ../panels/power/cc-power-panel.c:1635
-msgid "_Bluetooth"
-msgstr "藍牙(_B)"
-
-#: ../panels/power/cc-power-panel.c:1686
-msgid "When on battery power"
-msgstr "使用電池電源時"
-
-#: ../panels/power/cc-power-panel.c:1688
-msgid "When plugged in"
-msgstr "當插入電源線時"
-
-#: ../panels/power/cc-power-panel.c:1818
-msgid "Suspend & Power Off"
-msgstr "暫停與關閉電源"
-
-#: ../panels/power/cc-power-panel.c:1851
-msgid "_Automatic suspend"
-msgstr "自動暫停(_A)"
-
-#: ../panels/power/cc-power-panel.c:1875
-msgid "When battery power is _critical"
-msgstr "當電池的電量極低時(_C)"
-
-#: ../panels/power/cc-power-panel.c:1930
-msgid "Power Off"
-msgstr "關閉電源"
-
-#: ../panels/power/cc-power-panel.c:2066
-msgid "Devices"
-msgstr "裝置"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
-msgid "Power"
-msgstr "電源"
-
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
-msgid "View your battery status and change power saving settings"
-msgstr "檢視你的電池狀態並改變電源節省設定值"
-
-#. Translators: those are keywords for the power control-center panel
-#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
-msgid ""
-"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-msgstr "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;電源;睡眠;暫停;休眠;電池;亮度;轉黑;顯示器;閒置;"
-
-#: ../panels/power/power.ui.h:1
-msgid "Hibernate"
-msgstr "休眠"
-
-#: ../panels/power/power.ui.h:2
-msgid "Power off"
-msgstr "關閉電源"
-
-#: ../panels/power/power.ui.h:5
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "45 minutes"
 msgstr "45 分鐘"
 
-#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "1 hour"
 msgstr "1 小時"
 
-#: ../panels/power/power.ui.h:7
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "80 minutes"
 msgstr "80 分鐘"
 
-#: ../panels/power/power.ui.h:8
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "90 minutes"
 msgstr "90 分鐘"
 
-#: ../panels/power/power.ui.h:9
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "100 minutes"
 msgstr "100 分鐘"
 
-#: ../panels/power/power.ui.h:10
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+#, fuzzy
+msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 小時"
 
-#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
-msgid "1 minute"
-msgstr "1 分鐘"
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "電池"
 
-#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
-msgid "2 minutes"
-msgstr "2 分鐘"
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "裝置"
 
-#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
-msgid "3 minutes"
-msgstr "3 分鐘"
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "關閉電源"
 
-#: ../panels/power/power.ui.h:14
-msgid "4 minutes"
-msgstr "4 分鐘"
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
 
-#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
-msgid "5 minutes"
-msgstr "5 分鐘"
+#: panels/power/cc-power-panel.ui:123
+#, fuzzy
+msgid "Power Saving Options"
+msgstr "節省電源"
 
-#: ../panels/power/power.ui.h:16
-msgid "8 minutes"
-msgstr "8 分鐘"
+#: panels/power/cc-power-panel.ui:126
+#, fuzzy
+msgid "Automatic Screen Brightness"
+msgstr "螢幕亮度(_S)"
 
-#: ../panels/power/power.ui.h:17
-msgid "10 minutes"
-msgstr "10 分鐘"
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
 
-#: ../panels/power/power.ui.h:18
-msgid "12 minutes"
-msgstr "12 分鐘"
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "螢幕"
 
-#: ../panels/power/power.ui.h:20
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "螢幕閱讀器(_R)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+#, fuzzy
+msgid "Automatic Power Saver"
+msgstr "自動路由"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+#, fuzzy
+msgid "_Automatic Suspend"
+msgstr "自動暫停"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+#, fuzzy
+msgid "Po_wer Button Behavior"
+msgstr "較低的按鈕"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "自動暫停"
 
-#: ../panels/power/power.ui.h:21
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
 msgstr "插入插頭(_P)"
 
-#: ../panels/power/power.ui.h:22
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "使用電池電源(_B)"
 
-#: ../panels/power/power.ui.h:23
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
 msgstr "延遲"
 
-#: ../panels/printers/authentication-dialog.ui.h:3
-msgid "Authenticate"
-msgstr "核對"
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "電源"
 
-#: ../panels/printers/authentication-dialog.ui.h:5
-#: ../panels/sharing/sharing.ui.h:14
-#: ../panels/user-accounts/data/account-dialog.ui.h:6
-msgid "Password"
-msgstr "密碼"
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "檢視你的電池狀態並改變電源節省設定值"
 
-#: ../panels/printers/authentication-dialog.ui.h:6
-msgid "Authentication Required"
-msgstr "要求核對"
-
-#. Translators: The printer is low on toner
-#: ../panels/printers/cc-printers-panel.c:590
-msgid "Low on toner"
-msgstr "碳粉不足"
-
-#. Translators: The printer has no toner left
-#: ../panels/printers/cc-printers-panel.c:592
-msgid "Out of toner"
-msgstr "碳粉用完"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:595
-msgid "Low on developer"
-msgstr "顯像劑不足"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: ../panels/printers/cc-printers-panel.c:598
-msgid "Out of developer"
-msgstr "顯像劑用完"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:600
-msgid "Low on a marker supply"
-msgstr "墨水匣不足"
-
-#. Translators: "marker" is one color bin of the printer
-#: ../panels/printers/cc-printers-panel.c:602
-msgid "Out of a marker supply"
-msgstr "墨水匣用完"
-
-#. Translators: One or more covers on the printer are open
-#: ../panels/printers/cc-printers-panel.c:604
-msgid "Open cover"
-msgstr "外殼開啟"
-
-#. Translators: One or more doors on the printer are open
-#: ../panels/printers/cc-printers-panel.c:606
-msgid "Open door"
-msgstr "紙匣門開啟"
-
-#. Translators: At least one input tray is low on media
-#: ../panels/printers/cc-printers-panel.c:608
-msgid "Low on paper"
-msgstr "紙張不足。"
-
-#. Translators: At least one input tray is empty
-#: ../panels/printers/cc-printers-panel.c:610
-msgid "Out of paper"
-msgstr "紙張用完"
-
-#. Translators: The printer is offline
-#: ../panels/printers/cc-printers-panel.c:612
-msgctxt "printer state"
-msgid "Offline"
-msgstr "離線"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: ../panels/printers/cc-printers-panel.c:614
-#: ../panels/printers/cc-printers-panel.c:805
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "已停止"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: ../panels/printers/cc-printers-panel.c:616
-msgid "Waste receptacle almost full"
-msgstr "廢墨收集器將滿"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: ../panels/printers/cc-printers-panel.c:618
-msgid "Waste receptacle full"
-msgstr "廢墨收集器已滿"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:620
-msgid "The optical photo conductor is near end of life"
-msgstr "感光鼓接近使用壽命"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: ../panels/printers/cc-printers-panel.c:622
-msgid "The optical photo conductor is no longer functioning"
-msgstr "感光鼓已無法使用"
-
-#. Translators: Printer's state (printer is being configured right now)
-#: ../panels/printers/cc-printers-panel.c:732
-msgctxt "printer state"
-msgid "Configuring"
-msgstr "正在設定"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: ../panels/printers/cc-printers-panel.c:791
-msgctxt "printer state"
-msgid "Ready"
-msgstr "準備就緒"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: ../panels/printers/cc-printers-panel.c:796
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "不接受工作"
-
-#. Translators: Printer's state (jobs are processing)
-#: ../panels/printers/cc-printers-panel.c:801
-msgctxt "printer state"
-msgid "Processing"
-msgstr "處理中"
-
-#. Translators: Toner supply
-#: ../panels/printers/cc-printers-panel.c:922
-msgid "Toner Level"
-msgstr "碳粉匣等級"
-
-#. Translators: Ink supply
-#: ../panels/printers/cc-printers-panel.c:925
-msgid "Ink Level"
-msgstr "墨水等級"
-
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/cc-printers-panel.c:928
-msgid "Supply Level"
-msgstr "耗材等級"
-
-#. Translators: Printer's state (printer is being installed right now)
-#: ../panels/printers/cc-printers-panel.c:946
-msgctxt "printer state"
-msgid "Installing"
-msgstr "正在安裝"
-
-#. Translators: There are no printers available (none is configured or CUPS is not running)
-#: ../panels/printers/cc-printers-panel.c:1123
-msgid "No printers available"
-msgstr "沒有可用的打印機"
-
-#. Translators: there is n active print jobs on this printer
-#: ../panels/printers/cc-printers-panel.c:1433
-#, c-format
-msgid "%u active"
-msgid_plural "%u active"
-msgstr[0] "%u 使用中"
-
-#. Translators: Addition of the new printer failed.
-#: ../panels/printers/cc-printers-panel.c:1777
-msgid "Failed to add new printer."
-msgstr "無法加入新的打印機。"
-
-#: ../panels/printers/cc-printers-panel.c:1944
-msgid "Select PPD File"
-msgstr "選擇 PPD 檔案"
-
-#: ../panels/printers/cc-printers-panel.c:1953
+#: panels/power/gnome-power-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr "PostScript 打印機描述檔 (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"電源;睡眠;暫停;休眠;電池;亮度;轉黑;顯示器;閒置;"
 
-#: ../panels/printers/cc-printers-panel.c:2258
-msgid "No suitable driver found"
-msgstr "找不到合適的驅動程式"
-
-#: ../panels/printers/cc-printers-panel.c:2327
-msgid "Searching for preferred drivers…"
-msgstr "正在搜尋偏好的驅動程式…"
-
-#: ../panels/printers/cc-printers-panel.c:2342
-msgid "Select from database…"
-msgstr "從資料庫搜尋…"
-
-#: ../panels/printers/cc-printers-panel.c:2351
-msgid "Provide PPD File…"
-msgstr "提供 PPD 檔案…"
-
-#. Translators: Name of job which makes printer to print test page
-#: ../panels/printers/cc-printers-panel.c:2502
-#: ../panels/printers/cc-printers-panel.c:2525
-msgid "Test page"
-msgstr "測試頁"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: ../panels/printers/cc-printers-panel.c:2933
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "無法載入 ui：%s"
-
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
 msgstr "打印機"
 
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "加入打印機、檢視打印機工作並決定你要如何列印"
 
-#. Translators: those are keywords for the printing control-center panel
-#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Queue;Print;Paper;Ink;Toner;打印機;佇列;列印;紙張;墨水;碳粉;"
 
-#. Translators: This dialog contains list of active print jobs of the selected printer
-#: ../panels/printers/jobs-dialog.ui.h:2
-msgid "Active Jobs"
-msgstr "使用中的工作"
-
-#: ../panels/printers/jobs-dialog.ui.h:3
-#: ../panels/printers/options-dialog.ui.h:2
-msgid "Close"
-msgstr "關閉"
-
-#: ../panels/printers/jobs-dialog.ui.h:4
-msgid "Resume Printing"
-msgstr "繼續列印"
-
-#: ../panels/printers/jobs-dialog.ui.h:5
-msgid "Pause Printing"
-msgstr "暫停列印"
-
-#: ../panels/printers/jobs-dialog.ui.h:6
-msgid "Cancel Print Job"
-msgstr "取消打印工作"
-
-#: ../panels/printers/new-printer-dialog.ui.h:1
-msgid "Add a New Printer"
-msgstr "加入新的打印機"
-
-#. Translators: This button opens authentication dialog for selected server.
-#: ../panels/printers/new-printer-dialog.ui.h:5
-msgid "A_uthenticate"
-msgstr "核對(_U)"
-
-#. Translators: No printers were found
-#: ../panels/printers/new-printer-dialog.ui.h:7
-msgid "No printers detected."
-msgstr "未偵測到打印機。"
-
-#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: ../panels/printers/new-printer-dialog.ui.h:9
-msgid "Enter address of a printer or a text to filter results"
-msgstr "輸入網絡打印機的位址或過濾器結果文字"
-
-#: ../panels/printers/options-dialog.ui.h:1
-msgid "Loading options…"
-msgstr "正在載入選項…"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:1
-msgid "Select Printer Driver"
-msgstr "選擇打印機驅動程式"
-
-#: ../panels/printers/ppd-selection-dialog.ui.h:4
-msgid "Loading drivers database..."
-msgstr "載入驅動程式資料庫…"
-
-#. Translators: The found device is a JetDirect printer
-#: ../panels/printers/pp-host.c:506
-msgid "JetDirect Printer"
-msgstr "JetDirect 打印機"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: ../panels/printers/pp-host.c:756
-msgid "LPD Printer"
-msgstr "LPD 打印機"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:66
-#: ../panels/printers/pp-ppd-option-widget.c:70
-msgid "One Sided"
-msgstr "單面"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:68
-#: ../panels/printers/pp-ppd-option-widget.c:72
-msgid "Long Edge (Standard)"
-msgstr "長邊 (標準)"
-
-#. Translators: this is an option of "Two Sided"
-#: ../panels/printers/pp-ipp-option-widget.c:70
-#: ../panels/printers/pp-ppd-option-widget.c:74
-msgid "Short Edge (Flip)"
-msgstr "短邊 (翻轉)"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:72
-msgid "Portrait"
-msgstr "直向"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:74
-msgid "Landscape"
-msgstr "橫向"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse landscape"
-msgstr "橫向倒轉"
-
-#. Translators: this is an option of "Orientation"
-#: ../panels/printers/pp-ipp-option-widget.c:78
-msgid "Reverse portrait"
-msgstr "直向倒轉"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: ../panels/printers/pp-jobs-dialog.c:142
-msgctxt "print job"
-msgid "Pending"
-msgstr "保留中"
-
-#. Translators: Job's state (job is held for printing)
-#: ../panels/printers/pp-jobs-dialog.c:146
-msgctxt "print job"
-msgid "Held"
-msgstr "已暫停"
-
-#. Translators: Job's state (job is currently printing)
-#: ../panels/printers/pp-jobs-dialog.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "處理中"
-
-#. Translators: Job's state (job has been stopped)
-#: ../panels/printers/pp-jobs-dialog.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "已停止"
-
-#. Translators: Job's state (job has been canceled)
-#: ../panels/printers/pp-jobs-dialog.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "已取消"
-
-#. Translators: Job's state (job has aborted due to error)
-#: ../panels/printers/pp-jobs-dialog.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "已放棄"
-
-#. Translators: Job's state (job has completed successfully)
-#: ../panels/printers/pp-jobs-dialog.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "已完成"
-
-#. Translators: Name of column showing titles of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:288
-msgid "Job Title"
-msgstr "工作名稱"
-
-#. Translators: Name of column showing statuses of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:297
-msgid "Job State"
-msgstr "工作狀態"
-
-#. Translators: Name of column showing times of creation of print jobs
-#: ../panels/printers/pp-jobs-dialog.c:303
-msgid "Time"
-msgstr "時刻"
-
-#: ../panels/printers/pp-jobs-dialog.c:495
-#, c-format
-msgid "%s Active Jobs"
-msgstr "%s 使用中的工作"
-
-#. Translators: The found device is a printer connected via USB
-#: ../panels/printers/pp-new-printer-dialog.c:1671
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: ../panels/printers/pp-new-printer-dialog.c:1676
-msgid "Serial Port"
-msgstr "序列埠"
-
-#. Translators: The found device is a printer connected via parallel port
-#: ../panels/printers/pp-new-printer-dialog.c:1683
-msgid "Parallel Port"
-msgstr "串列埠"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: ../panels/printers/pp-new-printer-dialog.c:1739
-#, c-format
-msgid "Location: %s"
-msgstr "位置：%s"
-
-#. Translators: Network address of found printer
-#: ../panels/printers/pp-new-printer-dialog.c:1744
-#, c-format
-msgid "Address: %s"
-msgstr "位址：%s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: ../panels/printers/pp-new-printer-dialog.c:1768
-msgid "Server requires authentication"
-msgstr "伺服器需要核對"
-
-#: ../panels/printers/pp-options-dialog.c:81
-msgid "Two Sided"
-msgstr "雙面"
-
-#: ../panels/printers/pp-options-dialog.c:82
-msgid "Paper Type"
-msgstr "紙張類型"
-
-#: ../panels/printers/pp-options-dialog.c:83
-msgid "Paper Source"
-msgstr "紙張來源"
-
-#: ../panels/printers/pp-options-dialog.c:84
-msgid "Output Tray"
-msgstr "出紙匣"
-
-#: ../panels/printers/pp-options-dialog.c:86
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript 前置過濾器"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: ../panels/printers/pp-options-dialog.c:531
-msgid "Pages per side"
-msgstr "每張紙的頁數"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: ../panels/printers/pp-options-dialog.c:543
-msgid "Two-sided"
-msgstr "雙面"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: ../panels/printers/pp-options-dialog.c:555
-msgid "Orientation"
-msgstr "方向"
-
-#. Translators: "General" tab contains general printer options
-#: ../panels/printers/pp-options-dialog.c:652
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "一般"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: ../panels/printers/pp-options-dialog.c:655
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "頁面設定"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: ../panels/printers/pp-options-dialog.c:658
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "可安裝選項"
-
-#. Translators: "Job" tab contains settings for jobs
-#: ../panels/printers/pp-options-dialog.c:661
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "工作"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: ../panels/printers/pp-options-dialog.c:664
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "圖片品質"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: ../panels/printers/pp-options-dialog.c:667
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "顏色"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: ../panels/printers/pp-options-dialog.c:670
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "完成"
-
-#. Translators: "Advanced" tab contains all others settings
-#: ../panels/printers/pp-options-dialog.c:673
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "進階"
-
-#. Translators: this is an option of "Paper Source"
-#: ../panels/printers/pp-ppd-option-widget.c:76
-#: ../panels/printers/pp-ppd-option-widget.c:78
-#: ../panels/printers/pp-ppd-option-widget.c:86
-msgid "Auto Select"
-msgstr "自動選擇"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: ../panels/printers/pp-ppd-option-widget.c:80
-#: ../panels/printers/pp-ppd-option-widget.c:82
-#: ../panels/printers/pp-ppd-option-widget.c:84
-#: ../panels/printers/pp-ppd-option-widget.c:88
-msgid "Printer Default"
-msgstr "打印機預設"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:90
-msgid "Embed GhostScript fonts only"
-msgstr "只有內嵌的 GhostScript 字型"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:92
-msgid "Convert to PS level 1"
-msgstr "轉換為 PS 等級 1"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:94
-msgid "Convert to PS level 2"
-msgstr "轉換為 PS 等級 2"
-
-#. Translators: this is an option of "GhostScript"
-#: ../panels/printers/pp-ppd-option-widget.c:96
-msgid "No pre-filtering"
-msgstr "無前置過濾器"
-
-#. Translators: Name of column showing printer manufacturers
-#: ../panels/printers/pp-ppd-selection-dialog.c:233
-msgid "Manufacturer"
-msgstr "製造商"
-
-#. Translators: Name of column showing printer drivers
-#: ../panels/printers/pp-ppd-selection-dialog.c:250
-msgid "Driver"
-msgstr "驅動程式"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: ../panels/printers/pp-samba.c:248
-#, c-format
-msgid "Enter your username and password to view printers available on %s."
-msgstr "輸入你的使用者名稱與密碼以檢視在 %s 可用的打印機。"
-
-#: ../panels/printers/printers.ui.h:1
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
 msgid "Add Printer"
 msgstr "加入打印機"
 
-#: ../panels/printers/printers.ui.h:2
-msgid "Remove Printer"
-msgstr "移除打印機"
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
 
-#. Translators: By supply we mean ink, toner, staples, water, ...
-#: ../panels/printers/printers.ui.h:4
-msgid "Supply"
-msgstr "耗材"
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+#, fuzzy
+msgid "No Printers Found"
+msgstr "找不到圖片"
 
-#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
-#: ../panels/printers/printers.ui.h:6
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "要求核對"
+
+#: panels/printers/new-printer-dialog.ui:308
+#, fuzzy
+msgid "Enter username and password to view printers on Print Server."
+msgstr "輸入你的使用者名稱與密碼以檢視在 %s 可用的打印機。"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "使用者名稱"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "位置"
 
-#. Translators: This checkbox is checked when the default printer is selected.
-#: ../panels/printers/printers.ui.h:8
-msgid "_Default printer"
-msgstr "預設打印機(_D)"
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr "驅動程式"
 
-#: ../panels/printers/printers.ui.h:9
-msgid "Jobs"
-msgstr "工作"
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "正在搜尋偏好的驅動程式…"
 
-#. Translators: Opens a dialog containing printer's jobs
-#: ../panels/printers/printers.ui.h:11
-msgid "Show _Jobs"
-msgstr "顯示工作(_J)"
+#: panels/printers/pp-details-dialog.ui:197
+#, fuzzy
+msgid "Search for Drivers"
+msgstr "搜尋城市"
 
-#: ../panels/printers/printers.ui.h:12
+#: panels/printers/pp-details-dialog.ui:205
+#, fuzzy
+msgid "Select from Database…"
+msgstr "從資料庫搜尋…"
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "提供 PPD 檔案…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "選擇打印機驅動程式"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+#, fuzzy
+msgid "Loading drivers database…"
+msgstr "載入驅動程式資料庫…"
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "取消"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+msgid "Select"
+msgstr "選取"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, fuzzy, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "伺服器需要核對"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+#, fuzzy
+msgid "Domain"
+msgstr "網域(_O)"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "核對(_U)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+#, fuzzy
+msgid "_Authenticate"
+msgstr "核對"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+#, fuzzy
+msgid "No Active Printer Jobs"
+msgstr "%s 使用中的工作"
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+#, fuzzy
+msgid "Test Page"
+msgstr "測試頁"
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "登入選項"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "打印機預設"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "打印機預設"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+#, fuzzy
+msgid "Clean Print Heads"
+msgstr "取消打印工作"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "移除打印機"
+
+#: panels/printers/printer-entry.ui:167
+#, fuzzy
+msgid "No Active Jobs"
+msgstr "使用中的工作"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "型號"
 
-#: ../panels/printers/printers.ui.h:15
-msgid "label"
-msgstr "標籤"
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "墨水等級"
 
-#: ../panels/printers/printers.ui.h:17
-msgid "Setting new driver…"
-msgstr "設定新的驅動程式…"
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
 
-#: ../panels/printers/printers.ui.h:18
-msgid "page 3"
-msgstr "頁 3"
-
-#. Translators: This button executes command which prints test page.
-#: ../panels/printers/printers.ui.h:20
-msgid "Print _Test Page"
-msgstr "列印測試頁(_T)"
-
-#. Translators: This button opens printer's options tab
-#: ../panels/printers/printers.ui.h:22
-msgid "_Options"
-msgstr "選項(_O)"
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+#, fuzzy
+msgid "Restart"
+msgstr "立刻重新啟動"
 
 #. Translators: This button adds new printer.
-#: ../panels/printers/printers.ui.h:24
-msgid "Add New Printer"
-msgstr "加入新的打印機"
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+#, fuzzy
+msgid "Add Printer…"
+msgstr "加入打印機"
+
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "改變印表機設定值"
+
+#: panels/printers/printers.ui:173
+#, fuzzy
+msgid "No printers"
+msgstr "打印機"
 
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: ../panels/printers/printers.ui.h:26
+#: panels/printers/printers.ui:209
+#, fuzzy
 msgid ""
 "Sorry! The system printing service\n"
-"doesn't seem to be available."
+"    doesn’t seem to be available."
 msgstr ""
 "抱歉！系統列印服務\n"
 "似乎無法使用。"
 
-#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
-msgid "Screen Lock"
-msgstr "螢幕鎖定"
-
-#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
-msgid "Usage & History"
-msgstr "使用與歷史紀錄"
-
-#: ../panels/privacy/cc-privacy-panel.c:487
-msgid "Empty all items from Trash?"
-msgstr "要清除回收筒中所有的項目？"
-
-#: ../panels/privacy/cc-privacy-panel.c:488
-msgid "All items in the Trash will be permanently deleted."
-msgstr "所有在回收筒中的項目會永遠刪除。"
-
-#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
-msgid "_Empty Trash"
-msgstr "清理回收筒(_E)"
-
-#: ../panels/privacy/cc-privacy-panel.c:512
-msgid "Delete all the temporary files?"
-msgstr "刪除所有暫存檔案？"
-
-#: ../panels/privacy/cc-privacy-panel.c:513
-msgid "All the temporary files will be permanently deleted."
-msgstr "所有的暫存檔案會永遠刪除。"
-
-#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
-msgid "_Purge Temporary Files"
-msgstr "清理暫存檔案(_P)"
-
-#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
-msgid "Purge Trash & Temporary Files"
-msgstr "清除回收筒與暫存檔案"
-
-#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
-msgid "Software Usage"
-msgstr "軟件使用率"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
-msgid "Privacy"
-msgstr "私隱"
-
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
-msgid "Protect your personal information and control what others might see"
-msgstr "保護你的個人資料並控制其他人能看到什麼"
-
-#. Translators: those are keywords for the privacy control-center panel
-#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
-msgstr "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;螢幕;鎖定;診斷;私隱;最近使用;暫存;索引;名稱;網絡;身分;"
-
-#: ../panels/privacy/privacy.ui.h:1
-msgid "Screen Turns Off"
-msgstr "螢幕關閉"
-
-#: ../panels/privacy/privacy.ui.h:2
-msgid "30 seconds"
-msgstr "30 秒"
-
-#: ../panels/privacy/privacy.ui.h:9
-msgid "1 day"
-msgstr "1 天"
-
-#: ../panels/privacy/privacy.ui.h:10
-msgid "2 days"
-msgstr "2 天"
-
-#: ../panels/privacy/privacy.ui.h:11
-msgid "3 days"
-msgstr "3 天"
-
-#: ../panels/privacy/privacy.ui.h:12
-msgid "4 days"
-msgstr "4 天"
-
-#: ../panels/privacy/privacy.ui.h:13
-msgid "5 days"
-msgstr "5 天"
-
-#: ../panels/privacy/privacy.ui.h:14
-msgid "6 days"
-msgstr "6 天"
-
-#: ../panels/privacy/privacy.ui.h:15
-msgid "7 days"
-msgstr "7 天"
-
-#: ../panels/privacy/privacy.ui.h:16
-msgid "14 days"
-msgstr "14 天"
-
-#: ../panels/privacy/privacy.ui.h:17
-msgid "30 days"
-msgstr "30 天"
-
-#: ../panels/privacy/privacy.ui.h:18
-msgid "Forever"
-msgstr "永遠"
-
-#: ../panels/privacy/privacy.ui.h:20
-msgid ""
-"Remembering your history makes things easier to find again. These items are "
-"never shared over the network."
-msgstr "記住你的歷史紀錄會讓需要再次找到某樣東西時更簡單。這些項目永遠不會透過網絡分享出去。"
-
-#: ../panels/privacy/privacy.ui.h:21
-msgid "_Recently Used"
-msgstr "最近使用(_R)"
-
-#: ../panels/privacy/privacy.ui.h:22
-msgid "Retain _History"
-msgstr "保留歷史紀錄(_H)"
-
-#: ../panels/privacy/privacy.ui.h:23
-msgid "Cl_ear Recent History"
-msgstr "清除最近使用紀錄(_E)"
-
-#: ../panels/privacy/privacy.ui.h:25
-msgid "The Screen Lock protects your privacy when you are away."
-msgstr "螢幕鎖可以在你離開時保護你的私隱。"
-
-#: ../panels/privacy/privacy.ui.h:26
-msgid "Automatic Screen _Lock"
-msgstr "自動鎖定螢幕(_L)"
-
-#: ../panels/privacy/privacy.ui.h:27
-msgid "Lock screen _after blank for"
-msgstr "螢幕轉黑後多久鎖定螢幕(_A)"
-
-#: ../panels/privacy/privacy.ui.h:28
-msgid "Show _Notifications"
-msgstr "顯示通知(_N)"
-
-#: ../panels/privacy/privacy.ui.h:30
-msgid ""
-"Automatically purge the Trash and temporary files to help keep your computer "
-"free of unnecessary sensitive information."
-msgstr "自動清除回收筒和暫存檔案可以保護你的電腦減少不必要的敏感資訊。"
-
-#: ../panels/privacy/privacy.ui.h:31
-msgid "Automatically empty _Trash"
-msgstr "自動清空回收筒(_T)"
-
-#: ../panels/privacy/privacy.ui.h:32
-msgid "Automatically purge Temporary _Files"
-msgstr "自動清除暫存檔案(_F)"
-
-#: ../panels/privacy/privacy.ui.h:33
-msgid "Purge _After"
-msgstr "清除於(_A)"
-
-#: ../panels/privacy/privacy.ui.h:37
-msgid ""
-"Sending us information about which software you use helps us provide you "
-"with more accurate recommendations. It also helps us to improve our "
-"software.\n"
-"\n"
-"All the information we collect is made anonymous, and we will never share "
-"your data with third parties."
-msgstr ""
-"傳送你所使用軟件的資訊給我們能幫助我們提供你更準確的建議。它也能協助我們改進我們的軟件。\n"
-"\n"
-"我們所收集的所有資訊都是匿名的，而且我們永遠不會將你的資料與任何第三方分享。"
-
-#: ../panels/privacy/privacy.ui.h:40
-msgid "_Send software usage statistics"
-msgstr "傳送軟件使用率統計(_S)"
-
-#: ../panels/privacy/privacy.ui.h:41
-msgid "Privacy Policy"
-msgstr "私隱權原則"
-
-#: ../panels/privacy/privacy.ui.h:42
-msgid "_Location Services"
-msgstr "位置服務(_L)"
-
-#: ../panels/privacy/privacy.ui.h:43
-msgid "Used to determine your geographical location"
-msgstr "用來判斷你所在的地理位置"
-
-#: ../panels/region/cc-format-chooser.c:119
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "英制"
-
-#: ../panels/region/cc-format-chooser.c:121
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "公制"
-
-#: ../panels/region/cc-format-chooser.c:284
-msgid "No regions found"
-msgstr "找不到區域"
-
-#: ../panels/region/cc-input-chooser.c:179
-msgid "No input sources found"
-msgstr "找不到輸入來源"
-
-#: ../panels/region/cc-input-chooser.c:1076
-msgctxt "Input Source"
-msgid "Other"
-msgstr "其他"
-
-#: ../panels/region/cc-region-panel.c:239
-#: ../panels/user-accounts/um-user-panel.c:896
-msgid "Your session needs to be restarted for changes to take effect"
-msgstr "你的作業階段需要重新啟動以讓更改生效"
-
-#: ../panels/region/cc-region-panel.c:240
-#: ../panels/user-accounts/um-user-panel.c:897
-msgid "Restart Now"
-msgstr "立刻重新啟動"
-
-#: ../panels/region/cc-region-panel.c:858
-msgid "No input source selected"
-msgstr "尚未選擇輸入來源"
-
-#: ../panels/region/cc-region-panel.c:1088
-msgid "Sorry"
-msgstr "抱歉"
-
-#: ../panels/region/cc-region-panel.c:1090
-msgid "Input methods can't be used on the login screen"
-msgstr "輸入法不能用在登入畫面"
-
-#: ../panels/region/cc-region-panel.c:1727
-msgid "Login Screen"
-msgstr "登入畫面"
-
-#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+#: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "格式"
 
-#: ../panels/region/format-chooser.ui.h:4
+#: panels/region/cc-format-chooser.ui:76
+#, fuzzy
+msgid "Search locales…"
+msgstr "搜尋位置"
+
+#: panels/region/cc-format-chooser.ui:116
+#, fuzzy
+msgid "Common Formats"
+msgstr "格式"
+
+#: panels/region/cc-format-chooser.ui:143
+#, fuzzy
+msgid "All Formats"
+msgstr "格式"
+
+#: panels/region/cc-format-chooser.ui:191
+#, fuzzy
+msgid "No Search Results"
+msgstr "搜尋設定值"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "預覽"
 
-#: ../panels/region/format-chooser.ui.h:5
+#: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "日期"
 
-#: ../panels/region/format-chooser.ui.h:6
-msgid "Times"
-msgstr "時刻"
+#: panels/region/cc-format-preview.ui:53
+#, fuzzy
+msgid "Dates & Times"
+msgstr "日期與時刻"
 
-#: ../panels/region/format-chooser.ui.h:7
+#: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
 msgstr "數字"
 
-#: ../panels/region/format-chooser.ui.h:8
+#: panels/region/cc-format-preview.ui:89
 msgid "Measurement"
 msgstr "度量衡"
 
-#: ../panels/region/format-chooser.ui.h:9
+#: panels/region/cc-format-preview.ui:107
 msgid "Paper"
 msgstr "紙張"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+#, fuzzy
+msgid "Your Account"
+msgstr "我的帳號"
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "語言(_L)"
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+#, fuzzy
+msgid "_Formats"
+msgstr "格式"
+
+#: panels/region/cc-region-panel.ui:113
+msgid "Login Screen"
+msgstr "登入畫面"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
 msgid "Region & Language"
 msgstr "地區和語言"
 
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
-msgid ""
-"Select your display language, formats, keyboard layouts and input sources"
-msgstr "選擇你的顯示語言、格式、鍵盤配置和輸入來源"
+#: panels/region/gnome-region-panel.desktop.in.in:4
+#, fuzzy
+msgid "Select your display language and formats"
+msgstr "選擇顯示的語言"
 
-#. Translators: those are keywords for the region control-center panel
-#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+#: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;語言;配置;鍵盤;輸入;"
 
-#: ../panels/region/input-chooser.ui.h:1
-msgid "Add an Input Source"
-msgstr "加入輸入來源"
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "選擇要如何處理媒體"
 
-#: ../panels/region/input-options.ui.h:1
-msgid "Input Source Options"
-msgstr "輸入來源選項"
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "CD 音樂(_A)"
 
-#: ../panels/region/input-options.ui.h:2
-msgid "Use the _same source for all windows"
-msgstr "在所有視窗中使用相同的來源(_S)"
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "_DVD 影片"
 
-#: ../panels/region/input-options.ui.h:3
-msgid "Allow _different sources for each window"
-msgstr "每個視窗使用不同的輸入來源(_D)"
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "音樂播放器(_M)"
 
-#: ../panels/region/input-options.ui.h:4
-msgid "Keyboard Shortcuts"
-msgstr "鍵盤捷徑鍵"
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "軟件(_S)"
 
-#: ../panels/region/input-options.ui.h:5
-msgid "Switch to previous source"
-msgstr "切換至上個來源"
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "其他(_O)…"
 
-#: ../panels/region/input-options.ui.h:6
-msgid "Super+Shift+Space"
-msgstr "Super+Shift+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "插入媒體時永遠不提示或啟動程式(_N)"
 
-#: ../panels/region/input-options.ui.h:7
-msgid "Switch to next source"
-msgstr "切換至下個來源"
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "選擇要如何處理其他媒體"
 
-#: ../panels/region/input-options.ui.h:8
-msgid "Super+Space"
-msgstr "Super+Space"
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "動作(_A):"
 
-#: ../panels/region/input-options.ui.h:9
-msgid "You can change these shortcuts in the keyboard settings"
-msgstr "你可以在鍵盤設定值中改變這些捷徑鍵"
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "類型(_T)："
 
-#: ../panels/region/input-options.ui.h:10
-msgid "Alternative switch to next source"
-msgstr "切換至下個來源的替代鍵"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "可移除式媒體"
 
-#: ../panels/region/input-options.ui.h:11
-msgid "Left+Right Alt"
-msgstr "左+右 Alt"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Removable Media settings"
+msgstr "設定藍牙設定值"
 
-#: ../panels/region/region.ui.h:2
-msgid "English (United Kingdom)"
-msgstr "英文 (英國)"
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+#, fuzzy
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;裝置;系統;資訊;"
+"記憶體;處理器;版本;預設;應用程式;首選;音訊;視像;光碟;可移除;媒體;自動執行;"
 
-#: ../panels/region/region.ui.h:4
-msgid "United Kingdom"
-msgstr "英國"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "螢幕鎖定"
 
-#: ../panels/region/region.ui.h:6
-msgid "Options"
-msgstr "選項"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
 
-#: ../panels/region/region.ui.h:7
-msgid "Login settings are used by all users when logging into the system"
-msgstr "登入設定值是所有的使用者在登入系統時會用到的"
+#: panels/screen/cc-screen-panel.ui:14
+#, fuzzy
+msgid "Blank Screen Delay"
+msgstr "螢幕轉黑(_B)"
 
-#: ../panels/search/cc-search-locations-dialog.c:476
-msgctxt "Search Location"
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "自動鎖定螢幕(_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+#, fuzzy
+msgid "Automatic _Screen Lock Delay"
+msgstr "自動鎖定螢幕(_L)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+#, fuzzy
+msgid "Show _Notifications on Lock Screen"
+msgstr "在鎖定畫面中顯示詳細資料"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "鎖定畫面"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "私隱"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "螢幕"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "音效設定值"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "搜尋位置"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+#, fuzzy
 msgid "Places"
 msgstr "位置"
 
-#: ../panels/search/cc-search-locations-dialog.c:478
-msgctxt "Search Location"
+#: panels/search/cc-search-locations-dialog.ui:35
+#, fuzzy
 msgid "Bookmarks"
 msgstr "書籤"
 
-#: ../panels/search/cc-search-locations-dialog.c:480
-msgctxt "Search Location"
-msgid "Other"
+#: panels/search/cc-search-locations-dialog.ui:52
+#, fuzzy
+msgid "Others"
 msgstr "其他"
 
-#: ../panels/search/cc-search-locations-dialog.c:678
-msgid "Select Location"
-msgstr "選擇位置"
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "位置"
 
-#: ../panels/search/cc-search-locations-dialog.c:682
-msgid "_OK"
-msgstr "確定(_O)"
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "程式集"
 
-#: ../panels/search/cc-search-panel.c:176
-msgid "No applications found"
-msgstr "找不到應用程式"
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
-msgid "Search"
-msgstr "搜尋"
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
 
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "搜尋設定值"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
 msgstr "控制在活動概覽中哪些應用程式會顯示在搜尋結果中"
 
-#. Translators: those are keywords for the search control-center panel
-#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+#: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Search;Find;Index;Hide;Privacy;Results;搜尋;尋找;索引;隱藏;私隱;結果;"
 
-#: ../panels/search/search-locations-dialog.ui.h:1
-msgid "Search Locations"
-msgstr "搜尋位置"
-
-#: ../panels/search/search.ui.h:1
-msgid "Move Up"
-msgstr "往上移"
-
-#: ../panels/search/search.ui.h:2
-msgid "Move Down"
-msgstr "往下移"
-
-#: ../panels/search/search.ui.h:3
-msgid "Preferences"
-msgstr "偏好設定"
-
-#: ../panels/sharing/cc-sharing-panel.c:272
-msgctxt "service is enabled"
-msgid "On"
-msgstr "開啟"
-
-#: ../panels/sharing/cc-sharing-panel.c:274
-#: ../panels/sharing/cc-sharing-panel.c:301
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "關閉"
-
-#: ../panels/sharing/cc-sharing-panel.c:304
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "已啟用"
-
-#: ../panels/sharing/cc-sharing-panel.c:307
-msgctxt "service is active"
-msgid "Active"
-msgstr "使用中"
-
-#: ../panels/sharing/cc-sharing-panel.c:488
-msgid "Choose a Folder"
-msgstr "選擇一個資料夾"
-
-#: ../panels/sharing/cc-sharing-panel.c:916
-msgid "Copy"
-msgstr "複製"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
-msgid "Sharing"
-msgstr "分享"
-
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
-msgid "Control what you want to share with others"
-msgstr "控制你想要與其他人分享什麼"
-
-#. Translators: those are keywords for the sharing control-center panel
-#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
-msgid ""
-"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
-"pictures;photos;movies;server;renderer;"
-msgstr "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;pictures;photos;movies;server;renderer;分享;主機;名稱;遠端;桌面;藍牙;媒體;音樂;視像;圖片;相片;影片;伺服器;"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
-msgid "Enable or disable remote login"
-msgstr "啟用或停用遠端登入"
-
-#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
-msgid "Authentication is required to enable or disable remote login"
-msgstr "啟用或停用遠端登入需要核對"
-
-#. Label
-#: ../panels/sharing/cc-sharing-networks.c:299
-msgid "No networks selected for sharing"
-msgstr "沒有選擇用來分享的網絡"
-
-#.
-#. * vim: sw=2 ts=8 cindent noai bs=2
-#.
-#: ../panels/sharing/networks.ui.h:1
+#: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "網絡"
 
-#: ../panels/sharing/sharing.ui.h:1
-msgid "Bluetooth Sharing"
-msgstr "藍牙分享"
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "分享"
 
-#: ../panels/sharing/sharing.ui.h:2
-msgid ""
-"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
-"devices"
-msgstr "藍牙分享允許你與其他具有藍牙的裝置分享檔案"
-
-#: ../panels/sharing/sharing.ui.h:3
-msgid "Only Receive From Trusted Devices"
-msgstr "只接收信任的裝置"
-
-#: ../panels/sharing/sharing.ui.h:4
-msgid "Save Received Files to Downloads Folder"
-msgstr "將接收的檔案儲存至下載資料夾"
-
-#: ../panels/sharing/sharing.ui.h:5
-msgid "Computer Name"
+#: panels/sharing/cc-sharing-panel.ui:31
+#, fuzzy
+msgid "_Computer Name"
 msgstr "電腦名稱"
 
-#: ../panels/sharing/sharing.ui.h:6
-msgid "Personal File Sharing"
+#: panels/sharing/cc-sharing-panel.ui:58
+#, fuzzy
+msgid "_File Sharing"
 msgstr "個人檔案分享"
 
-#: ../panels/sharing/sharing.ui.h:7
-msgid "Screen Sharing"
-msgstr "螢幕分享"
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "遠端檢視"
 
-#: ../panels/sharing/sharing.ui.h:8
-msgid "Media Sharing"
+#: panels/sharing/cc-sharing-panel.ui:72
+#, fuzzy
+msgid "_Media Sharing"
 msgstr "媒體分享"
 
-#: ../panels/sharing/sharing.ui.h:9
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "遠端登入"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+#, fuzzy
+msgid "File Sharing"
+msgstr "分享"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "需要密碼"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
 msgid "Remote Login"
 msgstr "遠端登入"
 
-#: ../panels/sharing/sharing.ui.h:10
-msgid "Some services are disabled because of no network access."
-msgstr "由於沒有網絡存取，某些服務已停用。"
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "遠端檢視"
 
-#: ../panels/sharing/sharing.ui.h:12
-#, no-c-format
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
-"Personal File Sharing allows you to share your Public folder with others on "
-"your current network using: <a href=\"dav://%s\">dav://%s</a>"
-msgstr "個人檔案分享允許你使用： <a href=\"dav://%s\">dav://%s</a> 與目前網絡上的其他人分享你的公開資料夾"
-
-#: ../panels/sharing/sharing.ui.h:13
-msgid "Require Password"
-msgstr "需要密碼"
-
-#: ../panels/sharing/sharing.ui.h:16
-#, no-c-format
-msgid ""
-"Allow remote users to connect using the Secure Shell command:\n"
-"<a href=\"ssh %s\">ssh %s</a>"
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
 msgstr ""
-"允許遠端使用者使用 SSH 指令連線：\n"
-"<a href=\"ssh %s\">ssh %s</a>"
 
-#: ../panels/sharing/sharing.ui.h:19
-#, no-c-format
-msgid ""
-"Allow remote users to view or control your screen by connecting to: <a href="
-"\"vnc://%s\">vnc://%s</a>"
-msgstr "允許遠端使用者連線到：<a href=\"vnc://%s\">vnc://%s</a> 檢視或控制你的螢幕"
+#: panels/sharing/cc-sharing-panel.ui:271
+#, fuzzy
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "啟用或停用遠端登入"
 
-#: ../panels/sharing/sharing.ui.h:20
-msgid "Allow Remote Control"
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
 msgstr "允許遙控"
 
-#: ../panels/sharing/sharing.ui.h:21
-msgid "Password:"
-msgstr "密碼："
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:22
-msgid "Show Password"
-msgstr "顯示密碼"
+#: panels/sharing/cc-sharing-panel.ui:299
+#, fuzzy
+msgid "How to Connect"
+msgstr "未連線"
 
-#: ../panels/sharing/sharing.ui.h:23
-msgid "Access Options"
-msgstr "存取選項"
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
 
-#: ../panels/sharing/sharing.ui.h:24
-msgid "New connections must ask for access"
-msgstr "存取新的連線必須詢問"
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "複製"
 
-#: ../panels/sharing/sharing.ui.h:25
-msgid "Require a password"
-msgstr "需要密碼"
+#: panels/sharing/cc-sharing-panel.ui:331
+#, fuzzy
+msgid "Remote Desktop Address"
+msgstr "刪除位址"
 
-#: ../panels/sharing/sharing.ui.h:26
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "核對(_T)"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "使用者名稱"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+#, fuzzy
+msgid "Encryption Fingerprint"
+msgstr "登記指紋"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "媒體分享"
+
+#: panels/sharing/cc-sharing-panel.ui:489
 msgid "Share music, photos and videos over the network."
 msgstr "與網絡上其他人分享音樂、相片和影片。"
 
-#: ../panels/sharing/sharing.ui.h:27
+#: panels/sharing/cc-sharing-panel.ui:502
 msgid "Folders"
 msgstr "資料夾"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
-msgid "Sound"
-msgstr "音效"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "控制你想要與其他人分享什麼"
 
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
-msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "改變音效的音量、輸入、輸出和警示音效"
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+#, fuzzy
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;分享;主機;名稱;遠端;桌面;藍牙;媒體;音"
+"樂;視像;圖片;相片;影片;伺服器;"
 
-#. Translators: those are keywords for the sound control-center panel
-#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
-msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
-msgstr "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;音效卡;麥克風;音量;淡化;平衡;藍牙;耳機;音效;"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "啟用或停用遠端登入"
 
-#. Translators: This is the name of an audio file that sounds like the bark of a dog.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
-msgid "Bark"
-msgstr "汪汪"
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "啟用或停用遠端登入需要核對"
 
-#. Translators: This is the name of an audio file that sounds like a water drip.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
-msgid "Drip"
-msgstr "水滴聲"
+#: panels/sound/cc-alert-chooser.ui:12
+#, fuzzy
+msgid "Click"
+msgstr "Flickr"
 
-#. Translators: This is the name of an audio file that sounds like tapping glass.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
-msgid "Glass"
-msgstr "敲玻璃"
+#: panels/sound/cc-alert-chooser.ui:20
+#, fuzzy
+msgid "String"
+msgstr "分享"
 
-#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
-#. You might want to translate it into the equivalent words of your language.
-#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
-msgid "Sonar"
-msgstr "聲納"
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:105
-msgctxt "balance"
-msgid "Left"
-msgstr "左"
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:106
-msgctxt "balance"
-msgid "Right"
-msgstr "右"
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+#, fuzzy
+msgid "Balance"
+msgstr "平衡(_B)："
 
-#: ../panels/sound/gvc-balance-bar.c:109
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+#, fuzzy
+msgid "Fade"
+msgstr "淡化(_F)："
+
+#: panels/sound/cc-fade-slider.ui:16
+#, fuzzy
 msgid "Rear"
 msgstr "後"
 
-#: ../panels/sound/gvc-balance-bar.c:110
-msgctxt "balance"
+#: panels/sound/cc-fade-slider.ui:18
+#, fuzzy
 msgid "Front"
 msgstr "前"
 
-#: ../panels/sound/gvc-balance-bar.c:113
-msgctxt "balance"
-msgid "Minimum"
-msgstr "最小值"
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
 
-#: ../panels/sound/gvc-balance-bar.c:114
-msgctxt "balance"
-msgid "Maximum"
-msgstr "最大值"
-
-#: ../panels/sound/gvc-balance-bar.c:289
-msgid "_Balance:"
-msgstr "平衡(_B)："
-
-#: ../panels/sound/gvc-balance-bar.c:292
-msgid "_Fade:"
-msgstr "淡化(_F)："
-
-#: ../panels/sound/gvc-balance-bar.c:295
-msgid "_Subwoofer:"
-msgstr "重低音(_S)："
-
-#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
-
-#: ../panels/sound/gvc-channel-bar.c:616
-msgctxt "volume"
-msgid "Unamplified"
-msgstr "未經放大"
-
-#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
-#: ../panels/sound/gvc-mixer-dialog.c:526
-msgid "_Profile:"
-msgstr "設定組合(_P):"
-
-#. translators:
-#. * The number of sound outputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1837
-#, c-format
-msgid "%u Output"
-msgid_plural "%u Outputs"
-msgstr[0] "%u 輸出"
-
-#. translators:
-#. * The number of sound inputs on a particular device
-#: ../panels/sound/gvc/gvc-mixer-control.c:1847
-#, c-format
-msgid "%u Input"
-msgid_plural "%u Inputs"
-msgstr[0] "%u 輸入"
-
-#: ../panels/sound/gvc/gvc-mixer-control.c:2373
-msgid "System Sounds"
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
 msgstr "系統音效"
 
-#: ../panels/sound/gvc-mixer-dialog.c:262
-msgid "_Test Speakers"
-msgstr "測試喇叭(_T)"
+#: panels/sound/cc-sound-panel.ui:12
+#, fuzzy
+msgid "Master volume"
+msgstr "警示音量(_A)："
 
-#: ../panels/sound/gvc-mixer-dialog.c:431
-msgid "Peak detect"
-msgstr "峰值檢測"
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "靜音"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1509
-#: ../panels/sound/gvc-sound-theme-chooser.c:594
-msgid "Name"
-msgstr "名稱"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1528
-msgid "Device"
-msgstr "裝置"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1591
-#, c-format
-msgid "Speaker Testing for %s"
-msgstr "%s 的喇叭測試"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1649
-msgid "_Output volume:"
-msgstr "輸出音量(_O)："
-
-#: ../panels/sound/gvc-mixer-dialog.c:1663
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "輸出"
 
-#: ../panels/sound/gvc-mixer-dialog.c:1668
-msgid "C_hoose a device for sound output:"
-msgstr "選擇聲音輸出的裝置(_H)："
+#: panels/sound/cc-sound-panel.ui:59
+#, fuzzy
+msgid "Output Device"
+msgstr "輸出音量(_O)："
 
-#: ../panels/sound/gvc-mixer-dialog.c:1693
-msgid "Settings for the selected device:"
-msgstr "已選取裝置的設定值："
-
-#: ../panels/sound/gvc-mixer-dialog.c:1704
-msgid "Input"
-msgstr "輸入"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1711
-msgid "_Input volume:"
-msgstr "輸入音量(_I)："
-
-#: ../panels/sound/gvc-mixer-dialog.c:1734
-msgid "Input level:"
-msgstr "輸入等級："
-
-#: ../panels/sound/gvc-mixer-dialog.c:1762
-msgid "C_hoose a device for sound input:"
-msgstr "選擇聲音輸入的裝置(_H)："
-
-#: ../panels/sound/gvc-mixer-dialog.c:1789
-msgid "Sound Effects"
-msgstr "聲音效果"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1796
-msgid "_Alert volume:"
-msgstr "警示音量(_A)："
-
-#: ../panels/sound/gvc-mixer-dialog.c:1809
-msgid "Applications"
-msgstr "程式集"
-
-#: ../panels/sound/gvc-mixer-dialog.c:1813
-msgid "No application is currently playing or recording audio."
-msgstr "沒有應用程式目前正在播放或錄製音效。"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:188
-msgid "Built-in"
-msgstr "內置"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:454
-#: ../panels/sound/gvc-sound-theme-chooser.c:466
-#: ../panels/sound/gvc-sound-theme-chooser.c:478
-msgid "Sound Preferences"
-msgstr "音效偏好設定"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:457
-#: ../panels/sound/gvc-sound-theme-chooser.c:468
-#: ../panels/sound/gvc-sound-theme-chooser.c:480
-msgid "Testing event sound"
-msgstr "測試事件聲音"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:584
-msgid "Default"
-msgstr "預設值"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:585
-msgid "From theme"
-msgstr "從主題"
-
-#: ../panels/sound/gvc-sound-theme-chooser.c:769
-msgid "C_hoose an alert sound:"
-msgstr "選擇警示音效(_H)："
-
-#: ../panels/sound/gvc-speaker-test.c:219
-msgid "Stop"
-msgstr "停止"
-
-#: ../panels/sound/gvc-speaker-test.c:219
-#: ../panels/sound/gvc-speaker-test.c:331
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "測試"
 
-#: ../panels/sound/gvc-speaker-test.c:227
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "組態網址(_C)"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "重低音"
 
-#: ../panels/sound/sound-theme-file-utils.c:290
-msgid "Custom"
-msgstr "自選"
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "輸入"
 
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
-msgid "Make it easier to see, hear, type, point and click"
-msgstr "讓電腦更容易看、聽、輸入、指向與點選"
+#: panels/sound/cc-sound-panel.ui:235
+#, fuzzy
+msgid "Input Device"
+msgstr "輸入等級："
 
-#. Translators: those are keywords for the universal access control-center panel
-#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+#, fuzzy
+msgid "Volume"
+msgstr "調高音量"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "警示音量(_A)："
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "音效"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "改變音效的音量、輸入、輸出和警示音效"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+#, fuzzy
 msgid ""
-"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
-"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
-msgstr "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;鍵盤;滑鼠;無障礙;對比;螢幕;閱讀器;文字;字型;大小;相黏;遲緩;反彈;滑鼠;鍵;按鍵"
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;音效卡;麥克風;音"
+"量;淡化;平衡;藍牙;耳機;音效;"
 
-#: ../panels/universal-access/uap.ui.h:1
-msgid "_Always Show Universal Access Menu"
-msgstr "永遠顯示無障礙存取選單(_A)"
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
 
-#: ../panels/universal-access/uap.ui.h:2
-msgid "Seeing"
-msgstr "視覺"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+#, fuzzy
+msgid "Close notification"
+msgstr "管理通知"
 
-#: ../panels/universal-access/uap.ui.h:3
-msgid "_High Contrast"
-msgstr "高反差(_H)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+#, fuzzy
+msgid "Name:"
+msgstr "名稱(_N)："
 
-#: ../panels/universal-access/uap.ui.h:4
-msgid "_Large Text"
-msgstr "大型文字(_L)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:5
-msgid "_Zoom"
-msgstr "縮放(_Z)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:7
-msgid "Screen _Reader"
-msgstr "螢幕閱讀器(_R)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+#, fuzzy
+msgid "Authorize and Connect"
+msgstr "自動連線(_C)"
 
-#: ../panels/universal-access/uap.ui.h:8
-msgid "_Sound Keys"
-msgstr "聲音按鍵(_S)"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+#, fuzzy
+msgid "Forget Device"
+msgstr "移除裝置"
 
-#: ../panels/universal-access/uap.ui.h:9
-msgid "Hearing"
-msgstr "聽覺"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:10
-msgid "_Visual Alerts"
-msgstr "視覺警示(_V)"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+#, fuzzy
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "無法連接到 %s 網域：%s"
 
-#: ../panels/universal-access/uap.ui.h:12
-msgid "Screen _Keyboard"
-msgstr "螢幕鍵盤(_K)"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+#, fuzzy
+msgid "Direct Access"
+msgstr "無障礙功能"
 
-#: ../panels/universal-access/uap.ui.h:13
-msgid "_Typing Assist (AccessX)"
-msgstr "打字助理 [AccessX](_T)"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:14
-msgid "Pointing & Clicking"
-msgstr "指向 & 點選"
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+#, fuzzy
+msgid "Pending Devices"
+msgstr "加入裝置"
 
-#: ../panels/universal-access/uap.ui.h:15
-msgid "_Mouse Keys"
-msgstr "滑鼠按鍵(_M)"
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:16
-msgid "_Click Assist"
-msgstr "點擊助理(_C)"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:17
-msgid "Screen Reader"
-msgstr "螢幕閱讀器"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:18
-msgid "The screen reader reads displayed text as you move the focus."
-msgstr "螢幕閱讀器能在你移動焦點時讀出顯示的文字。"
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:19
-msgid "_Screen Reader"
-msgstr "螢幕閱讀器(_S)"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "游標閃爍"
 
-#: ../panels/universal-access/uap.ui.h:20
-msgid "Sound Keys"
-msgstr "聲音按鍵"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "文字輸入欄中的游標可以閃爍(_B)"
 
-#: ../panels/universal-access/uap.ui.h:21
-msgid "Beep when Num Lock or Caps Lock are turned on."
-msgstr "當 Num Lock 或 Caps Lock 開啟時發出聲響。"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "速度(_S)："
 
-#: ../panels/universal-access/uap.ui.h:22
-msgid "Visual Alerts"
-msgstr "視覺警示"
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "游標閃爍速度"
 
-#: ../panels/universal-access/uap.ui.h:23
-msgid "_Test flash"
-msgstr "測試閃動(_T)"
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "游標閃爍速度"
 
-#: ../panels/universal-access/uap.ui.h:24
-msgid "Use a visual indication when an alert sound occurs."
-msgstr "當警示音效發出時使用視覺化的指示。"
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
 
-#: ../panels/universal-access/uap.ui.h:25
-msgid "Flash the _window title"
-msgstr "閃動視窗標題(_W)"
-
-#: ../panels/universal-access/uap.ui.h:26
-msgid "Flash the entire _screen"
-msgstr "閃動整個螢幕(_S)"
-
-#: ../panels/universal-access/uap.ui.h:27
-msgid "Typing Assist"
-msgstr "打字助理"
-
-#: ../panels/universal-access/uap.ui.h:28
-msgid "_Sticky Keys"
-msgstr "黏性特殊鍵(_S)"
-
-#: ../panels/universal-access/uap.ui.h:29
-msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "將連續按的特殊鍵視為按鍵組合"
-
-#: ../panels/universal-access/uap.ui.h:30
-msgid "_Disable if two keys are pressed together"
-msgstr "如果同時按下任何兩鍵則停用(_D)"
-
-#: ../panels/universal-access/uap.ui.h:31
-msgid "Beep when a _modifer key is pressed"
-msgstr "當按下特殊按鍵時發出聲響(_M)"
-
-#: ../panels/universal-access/uap.ui.h:32
-msgid "S_low Keys"
-msgstr "重複按鍵(_L)"
-
-#: ../panels/universal-access/uap.ui.h:33
-msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "在按鍵被按下到它被接受之間置入延遲"
-
-#: ../panels/universal-access/uap.ui.h:34
-msgid "A_cceptance delay:"
-msgstr "接受時間延遲(_C)："
-
-#: ../panels/universal-access/uap.ui.h:35
-msgctxt "slow keys delay"
-msgid "Short"
-msgstr "短"
-
-#: ../panels/universal-access/uap.ui.h:36
-msgid "Slow keys typing delay"
-msgstr "降低按鍵輸入延遲"
-
-#: ../panels/universal-access/uap.ui.h:37
-msgctxt "slow keys delay"
-msgid "Long"
-msgstr "長"
-
-#: ../panels/universal-access/uap.ui.h:38
-msgid "Beep when a key is pr_essed"
-msgstr "當按下按鍵時發出聲響(_E)"
-
-#: ../panels/universal-access/uap.ui.h:39
-msgid "Beep when a key is _accepted"
-msgstr "當接受按鍵動作時發出聲響(_A)"
-
-#: ../panels/universal-access/uap.ui.h:40
-msgid "Beep when a key is _rejected"
-msgstr "當拒絕按鍵動作則發出聲響(_R)"
-
-#: ../panels/universal-access/uap.ui.h:41
-msgid "_Bounce Keys"
-msgstr "反彈鍵(_B)"
-
-#: ../panels/universal-access/uap.ui.h:42
-msgid "Ignores fast duplicate keypresses"
-msgstr "忽略快速重複按鍵"
-
-#: ../panels/universal-access/uap.ui.h:43
-msgctxt "bounce keys delay"
-msgid "Short"
-msgstr "短"
-
-#: ../panels/universal-access/uap.ui.h:44
-msgid "Bounce keys typing delay"
-msgstr "反彈鍵輸入延遲"
-
-#: ../panels/universal-access/uap.ui.h:45
-msgctxt "bounce keys delay"
-msgid "Long"
-msgstr "長"
-
-#: ../panels/universal-access/uap.ui.h:46
-msgid "_Enable by Keyboard"
-msgstr "由鍵盤啟用(_E)"
-
-#: ../panels/universal-access/uap.ui.h:47
-msgid "Turn accessibility features on and off using the keyboard"
-msgstr "以鍵盤開啟和關閉無障礙功能"
-
-#: ../panels/universal-access/uap.ui.h:48
+#: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
 msgstr "點擊助理"
 
-#: ../panels/universal-access/uap.ui.h:49
+#: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
 msgstr "模擬次要點擊(_S)"
 
-#: ../panels/universal-access/uap.ui.h:50
+#: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
 msgstr "按住主要鍵時觸發次要點擊"
 
-#: ../panels/universal-access/uap.ui.h:51
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "接受時間延遲(_C)："
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
 msgid "Short"
 msgstr "短"
 
-#: ../panels/universal-access/uap.ui.h:52
+#: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
 msgstr "第二次點擊延遲"
 
-#: ../panels/universal-access/uap.ui.h:53
+#: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
 msgid "Long"
 msgstr "長"
 
-#: ../panels/universal-access/uap.ui.h:54
+#: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
 msgstr "停駐即點擊(_H)"
 
-#: ../panels/universal-access/uap.ui.h:55
+#: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
 msgstr "當停止游標移動時觸發點擊"
 
-#: ../panels/universal-access/uap.ui.h:56
+#: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
 msgstr "延遲(_E)："
 
-#: ../panels/universal-access/uap.ui.h:57
+#: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
 msgid "Short"
 msgstr "短"
 
-#: ../panels/universal-access/uap.ui.h:58
+#: panels/universal-access/cc-pointing-dialog.ui:184
 msgctxt "dwell click delay"
 msgid "Long"
 msgstr "長"
 
-#: ../panels/universal-access/uap.ui.h:59
+#: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
 msgstr "移動速度(_M)："
 
-#: ../panels/universal-access/uap.ui.h:60
+#: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
 msgid "Small"
 msgstr "小"
 
-#: ../panels/universal-access/uap.ui.h:61
+#: panels/universal-access/cc-pointing-dialog.ui:231
 msgctxt "dwell click threshold"
 msgid "Large"
 msgstr "大"
 
-#: ../panels/universal-access/zoom-options.c:333
-msgctxt "Distance"
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "重複按鍵"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "當按下某鍵不放時重複輸出該字符(_R)"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+#, fuzzy
+msgid "Repeat keys delay"
+msgstr "按鍵重複速度"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "按鍵重複速度"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "打字助理"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "黏性特殊鍵(_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "將連續按的特殊鍵視為按鍵組合"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "如果同時按下任何兩鍵則停用(_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "當按下特殊按鍵時發出聲響(_M)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "重複按鍵(_L)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "在按鍵被按下到它被接受之間置入延遲"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
 msgid "Short"
 msgstr "短"
 
-#: ../panels/universal-access/zoom-options.c:334
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ 螢幕"
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "降低按鍵輸入延遲"
 
-#: ../panels/universal-access/zoom-options.c:335
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ 螢幕"
-
-#: ../panels/universal-access/zoom-options.c:336
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ 螢幕"
-
-#: ../panels/universal-access/zoom-options.c:337
-msgctxt "Distance"
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
 msgid "Long"
 msgstr "長"
 
-#: ../panels/universal-access/zoom-options.ui.h:1
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "當按下按鍵時發出聲響(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "當接受按鍵動作時發出聲響(_A)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "當拒絕按鍵動作則發出聲響(_R)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "反彈鍵(_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "忽略快速重複按鍵"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "反彈鍵輸入延遲"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "長"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "由鍵盤啟用(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "以鍵盤開啟和關閉無障礙功能"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "永遠顯示無障礙存取選單(_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "視覺"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "高反差(_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "大型文字(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+#, fuzzy
+msgid "Enable A_nimations"
+msgstr "管理通知"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "螢幕閱讀器(_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "螢幕閱讀器能在你移動焦點時讀出顯示的文字。"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "聲音按鍵(_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+#, fuzzy
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "當 Num Lock 或 Caps Lock 開啟時發出聲響。"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "游標閃爍速度"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "縮放(_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "聽覺"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "視覺警示(_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "螢幕鍵盤(_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "重複按鍵"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "游標閃爍"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "打字助理 [AccessX](_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+#, fuzzy
+msgid "Pointing &amp; Clicking"
+msgstr "指向 & 點選"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "滑鼠按鍵(_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "移除打印機"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "點擊助理(_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+#, fuzzy
+msgid "_Double-Click Delay"
+msgstr "連按兩下(_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "連按兩下(_D)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "視覺警示"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "測試閃動(_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "當警示音效發出時使用視覺化的指示。"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "閃動整個螢幕(_S)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "閃動整個螢幕(_S)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
 msgstr "全螢幕"
 
-#: ../panels/universal-access/zoom-options.ui.h:2
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
 msgstr "上半部"
 
-#: ../panels/universal-access/zoom-options.ui.h:3
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
 msgid "Bottom Half"
 msgstr "下半部"
 
-#: ../panels/universal-access/zoom-options.ui.h:4
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
 msgstr "左半"
 
-#: ../panels/universal-access/zoom-options.ui.h:5
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
 msgstr "右半"
 
-#: ../panels/universal-access/zoom-options.ui.h:6
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
 msgstr "放大鏡選項"
 
-#: ../panels/universal-access/zoom-options.ui.h:7
-msgid "Zoom"
-msgstr "縮放"
-
-#: ../panels/universal-access/zoom-options.ui.h:8
-msgid "Magnification:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
 msgstr "放大率："
 
-#: ../panels/universal-access/zoom-options.ui.h:9
-msgid "Follow mouse cursor"
-msgstr "跟隨滑鼠遊標"
-
-#: ../panels/universal-access/zoom-options.ui.h:10
-msgid "Screen part:"
-msgstr "螢幕部分："
-
-#: ../panels/universal-access/zoom-options.ui.h:11
-msgid "Magnifier extends outside of screen"
-msgstr "放大鏡延伸到螢幕外"
-
-#: ../panels/universal-access/zoom-options.ui.h:12
-msgid "Keep magnifier cursor centered"
-msgstr "保持放大鏡游標置中"
-
-#: ../panels/universal-access/zoom-options.ui.h:13
-msgid "Magnifier cursor pushes contents around"
-msgstr "放大鏡游標將內容推到周圍"
-
-#: ../panels/universal-access/zoom-options.ui.h:14
-msgid "Magnifier cursor moves with contents"
-msgstr "放大鏡游標隨內容移動"
-
-#: ../panels/universal-access/zoom-options.ui.h:15
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
 msgstr "放大鏡位置："
 
-#: ../panels/universal-access/zoom-options.ui.h:16
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+#, fuzzy
+msgid "_Follow mouse cursor"
+msgstr "跟隨滑鼠遊標"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "螢幕部分："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+#, fuzzy
+msgid "Magnifier _extends outside of screen"
+msgstr "放大鏡延伸到螢幕外"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+#, fuzzy
+msgid "_Keep magnifier cursor centered"
+msgstr "保持放大鏡游標置中"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+#, fuzzy
+msgid "Magnifier cursor _pushes contents around"
+msgstr "放大鏡游標將內容推到周圍"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+#, fuzzy
+msgid "Magnifier cursor moves with _contents"
+msgstr "放大鏡游標隨內容移動"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
 msgstr "放大鏡"
 
-#: ../panels/universal-access/zoom-options.ui.h:17
-msgid "Thickness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+#, fuzzy
+msgid "_Crosshairs:"
+msgstr "十字準星："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+#, fuzzy
+msgid "_Overlaps mouse cursor"
+msgstr "重疊滑鼠遊標"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+#, fuzzy
+msgid "_Thickness:"
 msgstr "厚度："
 
-#: ../panels/universal-access/zoom-options.ui.h:18
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
 msgctxt "universal access, thickness"
 msgid "Thin"
 msgstr "薄"
 
-#: ../panels/universal-access/zoom-options.ui.h:19
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
 msgctxt "universal access, thickness"
 msgid "Thick"
 msgstr "厚"
 
-#: ../panels/universal-access/zoom-options.ui.h:20
-msgid "Length:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+#, fuzzy
+msgid "_Length:"
 msgstr "長度："
 
 #. The color of the accessibility crosshair
-#: ../panels/universal-access/zoom-options.ui.h:22
-msgid "Color:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+#, fuzzy
+msgid "Co_lor:"
 msgstr "顏色："
 
-#: ../panels/universal-access/zoom-options.ui.h:23
-msgid "Crosshairs:"
-msgstr "十字準星："
-
-#: ../panels/universal-access/zoom-options.ui.h:24
-msgid "Overlaps mouse cursor"
-msgstr "重疊滑鼠遊標"
-
-#: ../panels/universal-access/zoom-options.ui.h:25
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
 msgid "Crosshairs"
 msgstr "十字準星"
 
-#: ../panels/universal-access/zoom-options.ui.h:26
-msgid "White on black:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "顏色效果："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+#, fuzzy
+msgid "_White on black:"
 msgstr "白底黑字："
 
-#: ../panels/universal-access/zoom-options.ui.h:27
-msgid "Brightness:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
 msgstr "亮度："
 
-#: ../panels/universal-access/zoom-options.ui.h:28
-msgid "Contrast:"
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
 msgstr "對比："
 
 #. The contrast scale goes from Color to None (grayscale)
-#: ../panels/universal-access/zoom-options.ui.h:30
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
 msgctxt "universal access, contrast"
-msgid "Color"
-msgstr "顏色"
+msgid "Co_lor"
+msgstr ""
 
-#: ../panels/universal-access/zoom-options.ui.h:31
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
 msgstr "沒有"
 
-#: ../panels/universal-access/zoom-options.ui.h:32
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
 msgstr "完全"
 
-#: ../panels/universal-access/zoom-options.ui.h:33
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
 msgid "Low"
 msgstr "低"
 
-#: ../panels/universal-access/zoom-options.ui.h:34
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
 msgctxt "universal access, brightness"
 msgid "High"
 msgstr "高"
 
-#: ../panels/universal-access/zoom-options.ui.h:35
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
 msgctxt "universal access, contrast"
 msgid "Low"
 msgstr "低"
 
-#: ../panels/universal-access/zoom-options.ui.h:36
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
 msgctxt "universal access, contrast"
 msgid "High"
 msgstr "高"
 
-#: ../panels/universal-access/zoom-options.ui.h:37
-msgid "Color Effects:"
-msgstr "顏色效果："
-
-#: ../panels/universal-access/zoom-options.ui.h:38
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
 msgid "Color Effects"
 msgstr "顏色效果"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:1
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
-#: ../panels/user-accounts/um-account-type.c:34
-msgctxt "Account type"
-msgid "Standard"
-msgstr "標準"
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "讓電腦更容易看、聽、輸入、指向與點選"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:2
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
-#: ../panels/user-accounts/um-account-type.c:36
-msgctxt "Account type"
-msgid "Administrator"
-msgstr "管理員"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:4
-msgid "_Full Name"
-msgstr "全名(_F)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:5
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
-msgid "Account _Type"
-msgstr "帳號類型(_T)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:7
-#: ../panels/user-accounts/data/password-dialog.ui.h:7
-msgid "Allow user to set a password when they next login"
-msgstr "允許使用者在下次登入時選擇密碼"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:8
-#: ../panels/user-accounts/data/password-dialog.ui.h:8
-msgid "Set a password now"
-msgstr "立刻設定密碼"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:10
-msgid "_Verify"
-msgstr "驗證(_V)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:11
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+#, fuzzy
 msgid ""
-"Enterprise login allows an existing centrally managed user account to be "
-"used on this device."
-msgstr "企業登入允許現有的集中管理式使用者帳號能用在這個裝置上。"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:12
-msgid "_Domain"
-msgstr "網域(_O)"
-
-#: ../panels/user-accounts/data/account-dialog.ui.h:13
-msgid ""
-"Go online to add\n"
-"enterprise login accounts."
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
 msgstr ""
-"請上線以加入\n"
-"企業登入帳號。"
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;鍵盤;滑鼠;無障礙;對比;螢幕;閱讀器;文字;"
+"字型;大小;相黏;遲緩;反彈;滑鼠;鍵;按鍵"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:15
-msgid "_Enterprise Login"
-msgstr "企業登入(_E)"
+#: panels/usage/cc-usage-panel.ui:9
+#, fuzzy
+msgid "File History"
+msgstr "歷史紀錄"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:16
-#: ../panels/user-accounts/um-account-dialog.c:1458
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+#, fuzzy
+msgid "File H_istory"
+msgstr "歷史紀錄"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+#, fuzzy
+msgid "_Clear History…"
+msgstr "清除最近使用紀錄(_E)"
+
+#: panels/usage/cc-usage-panel.ui:63
+#, fuzzy
+msgid "Trash &amp; Temporary Files"
+msgstr "清除回收筒與暫存檔案"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+#, fuzzy
+msgid "Automatically Delete _Trash Content"
+msgstr "自動清空回收筒(_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+#, fuzzy
+msgid "Automatically Delete Temporary _Files"
+msgstr "自動清除暫存檔案(_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+#, fuzzy
+msgid "Automatically Delete _Period"
+msgstr "自動清空回收筒(_T)"
+
+#: panels/usage/cc-usage-panel.ui:115
+#, fuzzy
+msgid "_Empty Trash…"
+msgstr "清理回收筒(_E)"
+
+#: panels/usage/cc-usage-panel.ui:126
+#, fuzzy
+msgid "_Delete Temporary Files…"
+msgstr "清理暫存檔案(_P)"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
 msgid "Add User"
 msgstr "加入使用者"
 
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+#, fuzzy
+msgid "Administrator"
+msgstr "管理員"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+#, fuzzy
+msgid "User sets password on first login"
+msgstr "允許使用者在下次登入時選擇密碼"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "立刻設定密碼"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+#, fuzzy
+msgid "Confirm"
+msgstr "正在設定"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+#, fuzzy
+msgid "Enterprise Login"
+msgstr "企業登入(_E)"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+#, fuzzy
+msgid "You are Offline"
+msgstr "離線"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+#, fuzzy
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr "企業登入允許現有的集中管理式使用者帳號能用在這個裝置上。"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "選擇 PPD 檔案"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "指紋登入(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+#, fuzzy
+msgid "Fingerprint"
+msgstr "指紋登入(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "否"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "你確定要刪除已註冊的指紋嗎？這麼一來將會停用指紋登入。"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+#, fuzzy
+msgid "No fingerprint device"
+msgstr "未偵測到打印機。"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+#, fuzzy
+msgid "No Fingerprint device"
+msgstr "指紋登入(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+#, fuzzy
+msgid "Fingerprint Device"
+msgstr "指紋登入(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+#, fuzzy
+msgid "Fingerprint Login"
+msgstr "指紋登入(_F)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "刪除指紋(_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+#, fuzzy
+msgid "Fingerprint Enroll"
+msgstr "指紋登入(_F)"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "前一週"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+#, fuzzy
+msgid "Next"
+msgstr "下一週"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "更改密碼"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "改變(_A)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "目前的密碼(_P)"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "新密碼(_N)"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "確認密碼(_C)"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "密碼不相符。"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+#, fuzzy
+msgid "Allow user to change their password on next login"
+msgstr "允許使用者在下次登入時選擇密碼"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "立刻設定密碼"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "使用者"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "你的作業階段需要重新啟動以讓更改生效"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "立刻重新啟動"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "關閉"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+#, fuzzy
+msgid "Full name"
+msgstr "全名(_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr ""
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "指紋登入(_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "自動登入(_U)："
+
+#: panels/user-accounts/cc-user-panel.ui:238
+#, fuzzy
+msgid "Account Activity"
+msgstr "帳號類型(_T)"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+#, fuzzy
+msgid "_Administrator"
+msgstr "管理員"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:335
+#, fuzzy
+msgid "Remove User…"
+msgstr "移除使用者帳號"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+#, fuzzy
+msgid "Other Users"
+msgstr "其他手指(_O)："
+
+#: panels/user-accounts/cc-user-panel.ui:360
+#, fuzzy
+msgid "Add User…"
+msgstr "加入使用者"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+#, fuzzy
+msgid "No Users Found"
+msgstr "找不到圖片"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+#, fuzzy
+msgid "Unlock to add a user account."
+msgstr "建立新的使用者帳號"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "加入或移除使用者並改變你的密碼"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+
 #. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
-#: ../panels/user-accounts/data/account-dialog.ui.h:19
+#: panels/user-accounts/data/join-dialog.ui:30
 msgid "_Enroll"
 msgstr "登錄(_E)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:20
+#: panels/user-accounts/data/join-dialog.ui:59
 msgid "Domain Administrator Login"
 msgstr "網域管理員登入"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:21
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
@@ -5899,1091 +4795,3275 @@ msgstr ""
 "加入網域。請網絡系統管理員在這裏\n"
 "輸入網域密碼。"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:24
+#: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
 msgstr "管理員名稱(_N)"
 
-#: ../panels/user-accounts/data/account-dialog.ui.h:25
+#: panels/user-accounts/data/join-dialog.ui:135
 msgid "Administrator Password"
 msgstr "管理員密碼"
 
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
-msgid "Left thumb"
-msgstr "左手姆指"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
-msgid "Left middle finger"
-msgstr "左手中指"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
-msgid "Left ring finger"
-msgstr "左手無名指"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
-msgid "Left little finger"
-msgstr "左手小指"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
-msgid "Right thumb"
-msgstr "右手姆指"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
-msgid "Right middle finger"
-msgstr "右手中指"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
-msgid "Right ring finger"
-msgstr "右手無名指"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
-msgid "Right little finger"
-msgstr "右手小指"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
-#: ../panels/user-accounts/um-fingerprint-dialog.c:697
-msgid "Enable Fingerprint Login"
-msgstr "啟用指紋登入"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
-msgid "_Right index finger"
-msgstr "右手食指(_R)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
-msgid "_Left index finger"
-msgstr "左手食指(_L)"
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
-msgid "_Other finger:"
-msgstr "其他手指(_O)："
-
-#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
-msgid ""
-"Your fingerprint was successfully saved. You should now be able to log in "
-"using your fingerprint reader."
-msgstr "你的指紋已成功的儲存了。現在應該可以使用你的指紋辨識器來登入。"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
-msgid "Users"
-msgstr "使用者"
-
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
-msgid "Add or remove users and change your password"
-msgstr "加入或移除使用者並改變你的密碼"
-
-#. Translators: those are keywords for the user accounts control-center panel
-#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
-msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
-msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;登入;姓名;指紋;大頭貼;標誌;臉;密碼;"
-
-#: ../panels/user-accounts/data/history-dialog.ui.h:1
-msgid "Login History"
-msgstr "登入歷史紀錄"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:1
-msgid "Change Password"
-msgstr "更改密碼"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:3
-msgid "Ch_ange"
-msgstr "改變(_A)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:4
-msgid "_Verify New Password"
-msgstr "驗證新密碼(_V)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:5
-msgid "_New Password"
-msgstr "新密碼(_N)"
-
-#: ../panels/user-accounts/data/password-dialog.ui.h:6
-msgid "Current _Password"
-msgstr "目前的密碼(_P)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
-msgid "Add User Account"
-msgstr "加入使用者帳號"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
-msgid "Remove User Account"
-msgstr "移除使用者帳號"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
-msgid "Login Options"
-msgstr "登入選項"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
-msgid "A_utomatic Login"
-msgstr "自動登入(_U)："
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
-msgid "_Fingerprint Login"
-msgstr "指紋登入(_F)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
-msgid "User Icon"
-msgstr "使用者圖示"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
-msgid "_Language"
-msgstr "語言(_L)"
-
-#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
-msgid "Last Login"
-msgstr "上次登入"
-
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
 msgstr "管理使用者帳號"
 
-#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
 msgstr "改變使用者資料需要核對"
 
-#: ../panels/user-accounts/pw-utils.c:81
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "新的密碼需要與舊密碼有所差異。"
-
-#: ../panels/user-accounts/pw-utils.c:83
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "嘗試改變某些文字和數字。"
-
-#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "嘗試更常改變密碼。"
-
-#: ../panels/user-accounts/pw-utils.c:87
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "不含你的使用者名稱的密碼強度會比較高。"
-
-#: ../panels/user-accounts/pw-utils.c:89
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "嘗試避免在密碼中使用你的姓名。"
-
-#: ../panels/user-accounts/pw-utils.c:91
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "嘗試避免在密碼中包含某些文字。"
-
-#: ../panels/user-accounts/pw-utils.c:95
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "嘗試避免常見的文字。"
-
-#: ../panels/user-accounts/pw-utils.c:97
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "嘗試避免重新排序現有的文字。"
-
-#: ../panels/user-accounts/pw-utils.c:99
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "嘗試使用更多數字。"
-
-#: ../panels/user-accounts/pw-utils.c:101
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "嘗試使用更多大寫字母。"
-
-#: ../panels/user-accounts/pw-utils.c:103
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "嘗試使用更多小寫字母。"
-
-#: ../panels/user-accounts/pw-utils.c:105
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "嘗試使用更多特殊字符，像是標點符號。"
-
-#: ../panels/user-accounts/pw-utils.c:107
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "嘗試使用混合字母、數字和標點符號。"
-
-#: ../panels/user-accounts/pw-utils.c:109
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "嘗試避免同樣字符。"
-
-#: ../panels/user-accounts/pw-utils.c:111
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr "嘗試避免重複同樣類型的字符：你需要混合字母、數字和標點符號。"
-
-#: ../panels/user-accounts/pw-utils.c:113
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "嘗試避免像 1234 或 abcd 等順序。"
-
-#: ../panels/user-accounts/pw-utils.c:115
-msgctxt "Password hint"
-msgid "Try to add more letters, numbers and symbols."
-msgstr "嘗試加入更多字母、數字和標點符號。"
-
-#: ../panels/user-accounts/pw-utils.c:117
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and use a number or two."
-msgstr "混合大寫與小寫字符並使用一到兩個數字。"
-
-#: ../panels/user-accounts/pw-utils.c:119
-msgctxt "Password hint"
-msgid ""
-"Good password! Adding more letters, numbers and punctuation will make it "
-"stronger."
-msgstr "不錯的密碼！加入更多字母、數字和標點符號會讓它更好。"
-
-#: ../panels/user-accounts/pw-utils.c:141
-#: ../panels/user-accounts/pw-utils.c:171
-msgctxt "Password strength"
-msgid "Strength: Weak"
-msgstr "強度：很弱"
-
-#: ../panels/user-accounts/pw-utils.c:145
-#: ../panels/user-accounts/pw-utils.c:172
-msgctxt "Password strength"
-msgid "Strength: Low"
-msgstr "強度：低度"
-
-#: ../panels/user-accounts/pw-utils.c:148
-#: ../panels/user-accounts/pw-utils.c:173
-msgctxt "Password strength"
-msgid "Strength: Medium"
-msgstr "強度：中度"
-
-#: ../panels/user-accounts/pw-utils.c:151
-#: ../panels/user-accounts/pw-utils.c:174
-msgctxt "Password strength"
-msgid "Strength: Good"
-msgstr "強度：良好"
-
-#: ../panels/user-accounts/pw-utils.c:154
-#: ../panels/user-accounts/pw-utils.c:175
-msgctxt "Password strength"
-msgid "Strength: High"
-msgstr "強度：高度"
-
-#: ../panels/user-accounts/run-passwd.c:422
-msgid "Authentication failed"
-msgstr "核對失敗"
-
-#: ../panels/user-accounts/run-passwd.c:502
-#, c-format
-msgid "The new password is too short"
-msgstr "新的密碼太短"
-
-#: ../panels/user-accounts/run-passwd.c:508
-#, c-format
-msgid "The new password is too simple"
-msgstr "新的密碼太簡單"
-
-#: ../panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "舊密碼與新密碼太相似了"
-
-#: ../panels/user-accounts/run-passwd.c:517
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "新的密碼已經在最近使用過了。"
-
-#: ../panels/user-accounts/run-passwd.c:520
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "新的密碼必須包含數字或特殊字符"
-
-#: ../panels/user-accounts/run-passwd.c:524
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "舊密碼與新密碼是相同的"
-
-#: ../panels/user-accounts/run-passwd.c:528
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "你的密碼在第一次核對後已經改變過了！"
-
-#: ../panels/user-accounts/run-passwd.c:532
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "新的密碼並未包含足夠的不同字符"
-
-#: ../panels/user-accounts/run-passwd.c:536
-#, c-format
-msgid "Unknown error"
-msgstr "不明的錯誤"
-
-#: ../panels/user-accounts/um-account-dialog.c:34
-msgid "Should match the web address of your account provider."
-msgstr "應符合你帳號提供者的網絡位址。"
-
-#: ../panels/user-accounts/um-account-dialog.c:228
-msgid "Failed to add account"
-msgstr "無法加入到帳號"
-
-#: ../panels/user-accounts/um-account-dialog.c:452
-msgid "Passwords do not match."
-msgstr "密碼不相符。"
-
-#: ../panels/user-accounts/um-account-dialog.c:731
-#: ../panels/user-accounts/um-account-dialog.c:777
-msgid "Failed to register account"
-msgstr "無法註冊帳號"
-
-#: ../panels/user-accounts/um-account-dialog.c:915
-msgid "No supported way to authenticate with this domain"
-msgstr "沒有支援這個網域核對的方式"
-
-#: ../panels/user-accounts/um-account-dialog.c:974
-msgid "Failed to join domain"
-msgstr "無法加入網域"
-
-#: ../panels/user-accounts/um-account-dialog.c:1035
-msgid ""
-"That login name didn't work.\n"
-"Please try again."
-msgstr ""
-"登入名稱沒有用。\n"
-"請再試一次。"
-
-#: ../panels/user-accounts/um-account-dialog.c:1042
-msgid ""
-"That login password didn't work.\n"
-"Please try again."
-msgstr ""
-"登入密碼沒有用。\n"
-"請再試一次。"
-
-#: ../panels/user-accounts/um-account-dialog.c:1050
-msgid "Failed to log into domain"
-msgstr "無法登入到網域"
-
-#: ../panels/user-accounts/um-account-dialog.c:1108
-msgid "Unable find the domain. Maybe you misspelled it?"
-msgstr "找不到網域。也許你拼錯字了？"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:137
-msgid ""
-"You are not allowed to access the device. Contact your system administrator."
-msgstr "你不被允許使用這個裝置。請聯絡你的系統管理者。"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:139
-msgid "The device is already in use."
-msgstr "該裝置已經在使用中。"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:141
-msgid "An internal error occurred."
-msgstr "發生內部的錯誤。"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:217
-#: ../panels/user-accounts/um-fingerprint-dialog.c:218
-msgid "Enabled"
-msgstr "已啟用"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:266
-msgid "Delete registered fingerprints?"
-msgstr "是否刪除已註冊的指紋？"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:270
-msgid "_Delete Fingerprints"
-msgstr "刪除指紋(_D)"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:276
-msgid ""
-"Do you want to delete your registered fingerprints so fingerprint login is "
-"disabled?"
-msgstr "你確定要刪除已註冊的指紋嗎？這麼一來將會停用指紋登入。"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:452
-msgid "Done!"
-msgstr "完成！"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:513
-#: ../panels/user-accounts/um-fingerprint-dialog.c:555
-#, c-format
-msgid "Could not access '%s' device"
-msgstr "無法存取「%s」裝置"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
-#: ../panels/user-accounts/um-fingerprint-dialog.c:596
-#, c-format
-msgid "Could not start finger capture on '%s' device"
-msgstr "無法使用「%s」裝置上的指紋捕捉"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:647
-msgid "Could not access any fingerprint readers"
-msgstr "無法存取任何指紋辨識器"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:648
-msgid "Please contact your system administrator for help."
-msgstr "請聯絡你的系統管理員來幫忙。"
-
-#. translators:
-#. * The variable is the name of the device, for example:
-#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
-#. * 'Digital Persona U.are.U 4000/4000B' device."
-#.
-#: ../panels/user-accounts/um-fingerprint-dialog.c:731
-#, c-format
-msgid ""
-"To enable fingerprint login, you need to save one of your fingerprints, "
-"using the '%s' device."
-msgstr "要啟用指紋登入，你需要使用「%s」裝置儲存你的指紋。"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:738
-msgid "Selecting finger"
-msgstr "選擇手指"
-
-#: ../panels/user-accounts/um-fingerprint-dialog.c:739
-msgid "Enrolling fingerprints"
-msgstr "登記指紋"
-
-#: ../panels/user-accounts/um-history-dialog.c:68
-msgid "This Week"
-msgstr "本週"
-
-#: ../panels/user-accounts/um-history-dialog.c:71
-msgid "Last Week"
-msgstr "上週"
-
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:77
-#: ../panels/user-accounts/um-history-dialog.c:81
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b%e日"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: ../panels/user-accounts/um-history-dialog.c:86
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%Y年%b%e日"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: ../panels/user-accounts/um-history-dialog.c:91
-#, c-format
-msgctxt "login history week label"
-msgid "%s - %s"
-msgstr "%s - %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: ../panels/user-accounts/um-history-dialog.c:175
-#: ../panels/user-accounts/um-user-panel.c:631
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: ../panels/user-accounts/um-history-dialog.c:178
-#: ../panels/user-accounts/um-user-panel.c:635
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s，%s"
-
-#: ../panels/user-accounts/um-history-dialog.c:247
-msgid "Session Ended"
-msgstr "作業階段結束"
-
-#: ../panels/user-accounts/um-history-dialog.c:253
-msgid "Session Started"
-msgstr "作業階段開始"
-
-#: ../panels/user-accounts/um-password-dialog.c:145
-msgid "Please choose another password."
-msgstr "請選擇其他密碼。"
-
-#: ../panels/user-accounts/um-password-dialog.c:154
-msgid "Please type your current password again."
-msgstr "請再次輸入你目前的密碼。"
-
-#: ../panels/user-accounts/um-password-dialog.c:160
-msgid "Password could not be changed"
-msgstr "密碼無法更改"
-
-#: ../panels/user-accounts/um-password-dialog.c:286
-msgid "The passwords do not match."
-msgstr "密碼不相符。"
-
-#: ../panels/user-accounts/um-photo-dialog.c:219
-msgid "Browse for more pictures"
-msgstr "瀏覽更多照片"
-
-#: ../panels/user-accounts/um-photo-dialog.c:453
-msgid "Disable image"
-msgstr "停用圖片"
-
-#: ../panels/user-accounts/um-photo-dialog.c:471
-msgid "Take a photo…"
-msgstr "照相…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:489
-msgid "Browse for more pictures…"
-msgstr "瀏覽更多照片…"
-
-#: ../panels/user-accounts/um-photo-dialog.c:713
-#, c-format
-msgid "Used by %s"
-msgstr "由 %s 使用"
-
-#: ../panels/user-accounts/um-realm-manager.c:350
-msgid "Cannot automatically join this type of domain"
-msgstr "不能自動加入這個類型的網域"
-
-#: ../panels/user-accounts/um-realm-manager.c:413
-#, c-format
-msgid "No such domain or realm found"
-msgstr "找不到這個網域或領域名稱"
-
-#: ../panels/user-accounts/um-realm-manager.c:813
-#: ../panels/user-accounts/um-realm-manager.c:827
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "不能以 %s 身分登入 %s 網域"
-
-#: ../panels/user-accounts/um-realm-manager.c:819
-msgid "Invalid password, please try again"
-msgstr "密碼錯誤，請再試一次"
-
-#: ../panels/user-accounts/um-realm-manager.c:832
-#, c-format
-msgid "Couldn't connect to the %s domain: %s"
-msgstr "無法連接到 %s 網域：%s"
-
-#: ../panels/user-accounts/um-user-panel.c:198
-msgid "Other Accounts"
-msgstr "其他帳號"
-
-#: ../panels/user-accounts/um-user-panel.c:417
-msgid "Failed to delete user"
-msgstr "刪除使用者失敗"
-
-#: ../panels/user-accounts/um-user-panel.c:482
-msgid "You cannot delete your own account."
-msgstr "你不能刪除自己的帳號。"
-
-#: ../panels/user-accounts/um-user-panel.c:491
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s 仍在登入中"
-
-#: ../panels/user-accounts/um-user-panel.c:495
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "在使用者登入期間刪除他會使系統處於不穩定的狀態。"
-
-#: ../panels/user-accounts/um-user-panel.c:504
-#, c-format
-msgid "Do you want to keep %s's files?"
-msgstr "你想要保留 %s 的檔案嗎？"
-
-#: ../panels/user-accounts/um-user-panel.c:508
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr "當刪除使用者時是可以保留家目錄、新進郵件(mail spool)和暫存檔案的。"
-
-#: ../panels/user-accounts/um-user-panel.c:511
-msgid "_Delete Files"
-msgstr "刪除檔案(_D)"
-
-#: ../panels/user-accounts/um-user-panel.c:512
-msgid "_Keep Files"
-msgstr "保留檔案(_K)"
-
-#: ../panels/user-accounts/um-user-panel.c:564
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "帳號已停用"
-
-#: ../panels/user-accounts/um-user-panel.c:572
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "在下次登入時設定"
-
-#: ../panels/user-accounts/um-user-panel.c:575
-msgctxt "Password mode"
-msgid "None"
-msgstr "沒有"
-
-#: ../panels/user-accounts/um-user-panel.c:624
-msgid "Logged in"
-msgstr "已登入"
-
-#: ../panels/user-accounts/um-user-panel.c:1072
-msgid "Failed to contact the accounts service"
-msgstr "無法連接帳號服務"
-
-#: ../panels/user-accounts/um-user-panel.c:1074
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "請確定 AccountService 已經安裝並啟用。"
-
-#: ../panels/user-accounts/um-user-panel.c:1115
-msgid ""
-"To make changes,\n"
-"click the * icon first"
-msgstr ""
-"要進行更改，\n"
-"請先點選 * 圖示"
-
-#: ../panels/user-accounts/um-user-panel.c:1153
-msgid "Create a user account"
-msgstr "建立新的使用者帳號"
-
-#: ../panels/user-accounts/um-user-panel.c:1164
-#: ../panels/user-accounts/um-user-panel.c:1453
-msgid ""
-"To create a user account,\n"
-"click the * icon first"
-msgstr ""
-"要建立使用者帳號，\n"
-"請先點選 * 圖示"
-
-#: ../panels/user-accounts/um-user-panel.c:1174
-msgid "Delete the selected user account"
-msgstr "刪除選取的使用者帳號"
-
-#: ../panels/user-accounts/um-user-panel.c:1186
-#: ../panels/user-accounts/um-user-panel.c:1458
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"要刪除選取的使用者帳號，\n"
-"請先點選 * 圖示"
-
-#: ../panels/user-accounts/um-user-panel.c:1368
-msgid "My Account"
-msgstr "我的帳號"
-
-#: ../panels/user-accounts/um-utils.c:567
-#, c-format
-msgid "A user with the username '%s' already exists."
-msgstr "以「%s」為名的使用者已經存在。"
-
-#: ../panels/user-accounts/um-utils.c:571
-#, c-format
-msgid "The username is too long."
-msgstr "使用者名稱太長。"
-
-#: ../panels/user-accounts/um-utils.c:574
-msgid "The username cannot start with a '-'."
-msgstr "使用者名稱不能以「-」字符開頭。"
-
-#: ../panels/user-accounts/um-utils.c:577
-msgid ""
-"The username should only consist of lower and upper case letters from a-z, "
-"digits and any of characters '.', '-' and '_'."
-msgstr "使用者名稱只能由大小寫字母英文字母 a 到 z、數字，與其他字符如「.」、「-」和「_」構成。"
-
-#: ../panels/user-accounts/um-utils.c:581
-msgid "This will be used to name your home folder and can't be changed."
-msgstr "這會成為你家目錄資料夾的名稱，並且不能被改變。"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: ../panels/user-accounts/um-utils.c:827
-msgid "%b %e"
-msgstr "%b%e日"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: ../panels/user-accounts/um-utils.c:831
-msgid "%b %e, %Y"
-msgstr "%Y年%b%e日"
-
-#: ../panels/wacom/button-mapping.ui.h:1
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
 msgstr "對應按鈕"
 
-#: ../panels/wacom/button-mapping.ui.h:2
+#: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
 msgstr "功能對應按鈕"
 
-#: ../panels/wacom/button-mapping.ui.h:3
+#: panels/wacom/button-mapping.ui:51
+#, fuzzy
 msgid ""
-"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
-msgstr "要編輯捷徑鍵，選擇「傳送筆劃」動作，按下鍵盤捷徑按鈕與新的按鍵組合，或以 Backspace 鍵來清除。"
+msgstr ""
+"要編輯捷徑鍵，選擇「傳送筆劃」動作，按下鍵盤捷徑按鈕與新的按鍵組合，或以 "
+"Backspace 鍵來清除。"
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:83
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "關閉(_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
 msgstr "請點一下出現在螢幕上的目標標記來校準繪圖板。"
 
-#: ../panels/wacom/calibrator/calibrator-gui.c:87
-msgid "Mis-click detected, restarting..."
+#: panels/wacom/calibrator/calibrator.ui:63
+#, fuzzy
+msgid "Mis-click detected, restarting…"
 msgstr "偵測到錯誤的點擊，重新開始…"
 
-#: ../panels/wacom/cc-wacom-button-row.c:442
-msgctxt "Wacom tablet button"
-msgid "Up"
-msgstr "上"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.c:443
-msgctxt "Wacom tablet button"
-msgid "Down"
-msgstr "下"
+#: panels/wacom/cc-wacom-page.ui:16
+#, fuzzy
+msgid "Tablet Mode"
+msgstr "繪圖板"
 
-#: ../panels/wacom/cc-wacom-button-row.h:54
-msgctxt "Wacom action-type"
-msgid "None"
-msgstr "沒有"
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:55
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "傳送筆劃"
+#: panels/wacom/cc-wacom-page.ui:28
+#, fuzzy
+msgid "Left Hand Orientation"
+msgstr "左手方向"
 
-#: ../panels/wacom/cc-wacom-button-row.h:56
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "切換監視器"
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
 
-#: ../panels/wacom/cc-wacom-button-row.h:57
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "顯示螢幕求助"
+#: panels/wacom/cc-wacom-page.ui:58
+#, fuzzy
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "對應至顯示器..."
 
-#: ../panels/wacom/cc-wacom-mapping-panel.c:263
-msgid "Output:"
-msgstr "輸出："
+#: panels/wacom/cc-wacom-page.ui:64
+#, fuzzy
+msgid "Keep Aspect Ratio"
+msgstr "長寬比"
 
-#. Keep ratio switch
-#: ../panels/wacom/cc-wacom-mapping-panel.c:275
-msgid "Keep aspect ratio (letterbox):"
-msgstr "保持長寬比："
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
 
-#. Whole-desktop checkbox
-#: ../panels/wacom/cc-wacom-mapping-panel.c:286
-msgid "Map to single monitor"
-msgstr "映射到單一螢幕"
+#: panels/wacom/cc-wacom-page.ui:76
+#, fuzzy
+msgid "Calibrate"
+msgstr "校準…"
 
-#: ../panels/wacom/cc-wacom-nav-button.c:88
-#, c-format
-msgid "%d of %d"
-msgstr "%d / %d"
-
-#: ../panels/wacom/cc-wacom-page.c:530
-msgid "Display Mapping"
-msgstr "顯示對應"
-
-#: ../panels/wacom/cc-wacom-stylus-page.c:372
-msgid "Button"
-msgstr "按鈕"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
-#: ../panels/wacom/gnome-wacom-properties.ui.h:7
-msgid "Wacom Tablet"
-msgstr "Wacom 繪圖板"
-
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
-msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr "設定繪圖板的按鈕對映與調整觸控筆的靈敏度"
-
-#. Translators: those are keywords for the wacom tablet control-center panel
-#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
-msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;繪圖板;橡皮擦;滑鼠;"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:1
-msgid "Tablet (absolute)"
-msgstr "繪圖板 (絕對位置)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:2
-msgid "Touchpad (relative)"
-msgstr "觸控板 (相對位置)"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:3
-msgid "Tablet Preferences"
-msgstr "繪圖板偏好設定"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+#: panels/wacom/cc-wacom-panel.ui:56
 msgid "No tablet detected"
 msgstr "未偵測到繪圖板"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:5
-msgid "Please plug in or turn on your Wacom tablet"
+#: panels/wacom/cc-wacom-panel.ui:57
+#, fuzzy
+msgid "Please plug in or turn on your Wacom tablet."
 msgstr "請插入或開啟你的 Wacom 繪圖板"
 
-#: ../panels/wacom/gnome-wacom-properties.ui.h:6
-msgid "Bluetooth Settings"
-msgstr "藍牙設定值"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:8
-msgid "Map to Monitor…"
-msgstr "對應至顯示器..."
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:9
-msgid "Map Buttons…"
-msgstr "對應按鈕…"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:11
-msgid "Adjust display resolution"
-msgstr "調整顯示解像度"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:12
-msgid "Adjust mouse settings"
-msgstr "調整滑鼠設定值"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:13
-msgid "Tracking Mode"
-msgstr "追蹤模式"
-
-#: ../panels/wacom/gnome-wacom-properties.ui.h:14
-msgid "Left-Handed Orientation"
-msgstr "左手方向"
-
-#. If no mode is available, we use "left-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1062
-msgid "Left Ring"
-msgstr "左環"
-
-#: ../panels/wacom/gsd-wacom-device.c:1073
-#, c-format
-msgid "Left Ring Mode #%d"
-msgstr "左觸控環模式 #%d"
-
-#. If no mode is available, we use "right-ring-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1093
-msgid "Right Ring"
-msgstr "右環"
-
-#: ../panels/wacom/gsd-wacom-device.c:1104
-#, c-format
-msgid "Right Ring Mode #%d"
-msgstr "右觸控環模式 #%d"
-
-#. If no mode is available, we use "left-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1146
-msgid "Left Touchstrip"
-msgstr "左觸控列"
-
-#: ../panels/wacom/gsd-wacom-device.c:1157
-#, c-format
-msgid "Left Touchstrip Mode #%d"
-msgstr "左觸控列模式 #%d"
-
-#. If no mode is available, we use "right-strip-mode-1" for backward compat
-#: ../panels/wacom/gsd-wacom-device.c:1177
-msgid "Right Touchstrip"
-msgstr "右觸控列"
-
-#: ../panels/wacom/gsd-wacom-device.c:1188
-#, c-format
-msgid "Right Touchstrip Mode #%d"
-msgstr "右觸控列模式 #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1214
-#, c-format
-msgid "Left Touchring Mode Switch"
-msgstr "左觸控環模式切換"
-
-#: ../panels/wacom/gsd-wacom-device.c:1216
-#, c-format
-msgid "Right Touchring Mode Switch"
-msgstr "右觸控環模式切換"
-
-#: ../panels/wacom/gsd-wacom-device.c:1219
-#, c-format
-msgid "Left Touchstrip Mode Switch"
-msgstr "左觸控列模式切換"
-
-#: ../panels/wacom/gsd-wacom-device.c:1221
-#, c-format
-msgid "Right Touchstrip Mode Switch"
-msgstr "右觸控列模式切換"
-
-#: ../panels/wacom/gsd-wacom-device.c:1226
-#, c-format
-msgid "Mode Switch #%d"
-msgstr "模式切換 #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1334
-#, c-format
-msgid "Left Button #%d"
-msgstr "左側按鈕 #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1337
-#, c-format
-msgid "Right Button #%d"
-msgstr "右側按鈕 #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1340
-#, c-format
-msgid "Top Button #%d"
-msgstr "頂端按鈕 #%d"
-
-#: ../panels/wacom/gsd-wacom-device.c:1343
-#, c-format
-msgid "Bottom Button #%d"
-msgstr "底部按鈕 #%d"
-
-#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
-msgid "New shortcut…"
-msgstr "新增捷徑鍵…"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:1
-msgid "No Action"
-msgstr "沒有動作"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:2
-msgid "Left Mouse Button Click"
-msgstr "滑鼠左鍵點擊"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:3
-msgid "Middle Mouse Button Click"
-msgstr "滑鼠中鍵點擊"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:4
-msgid "Right Mouse Button Click"
-msgstr "滑鼠右鍵點擊"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:5
-msgid "Scroll Up"
-msgstr "向上捲動"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:6
-msgid "Scroll Down"
-msgstr "向下捲動"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:7
-msgid "Scroll Left"
-msgstr "向左捲動"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:8
-msgid "Scroll Right"
-msgstr "向右捲動"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:9
-msgid "Back"
-msgstr "上一頁"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:10
-msgid "Forward"
-msgstr "下一頁"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:11
-msgid "Stylus"
-msgstr "觸控筆"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:12
-msgid "Eraser Pressure Feel"
-msgstr "橡皮擦壓力感應"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:13
-msgid "Soft"
-msgstr "輕"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:14
-msgid "Firm"
-msgstr "重"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:15
-msgid "Top Button"
-msgstr "頂端按鈕"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:16
-msgid "Lower Button"
-msgstr "較低的按鈕"
-
-#: ../panels/wacom/wacom-stylus-page.ui.h:17
+#: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
 msgstr "點選壓力感應"
 
-#: ../shell/cc-application.c:69
-msgid "Enable verbose mode"
-msgstr "啟用詳細模式"
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "輕"
 
-#: ../shell/cc-application.c:70
-msgid "Show the overview"
-msgstr "顯示概覽"
-
-#: ../shell/cc-application.c:71
-msgid "Search for the string"
-msgstr "搜尋字串"
-
-#: ../shell/cc-application.c:72
-msgid "List possible panel names and exit"
-msgstr "列出可能的面板名稱並結束"
-
-#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
-#: ../shell/cc-application.c:75
-msgid "Show help options"
-msgstr "顯示說明的選項"
-
-#: ../shell/cc-application.c:76
-msgid "Panel to display"
-msgstr "要顯示的面板"
-
-#: ../shell/cc-application.c:76
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[面板] [引數…]"
-
-#: ../shell/cc-application.c:145
-msgid "- Settings"
-msgstr "- 設定值)"
-
-#: ../shell/cc-application.c:163
-#, c-format
-msgid ""
-"%s\n"
-"Run '%s --help' to see a full list of available command line options.\n"
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
 msgstr ""
-"%s\n"
-"執行 「%s --help」以查看完整的命令列可用選項清單。\n"
 
-#: ../shell/cc-application.c:193
-msgid "Available panels:"
-msgstr "可用的面板："
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "重"
 
-#: ../shell/cc-application.c:328
-msgid "Help"
-msgstr "求助"
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "按鈕"
 
-#: ../shell/cc-application.c:329
-msgid "Quit"
-msgstr "結束"
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "按鈕"
 
-#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "按鈕"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "橡皮擦壓力感應"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+#, fuzzy
+msgid "Eraser pressure"
+msgstr "橡皮擦壓力感應"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "滑鼠中鍵點擊"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "滑鼠右鍵點擊"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "下一頁"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom 繪圖板"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "設定繪圖板的按鈕對映與調整觸控筆的靈敏度"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;繪圖板;橡皮擦;滑鼠;"
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "模擬次要點擊(_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows 軟件"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "碳粉不足"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "次要"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "Windows 軟件"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+#, fuzzy
+msgid "Access Points"
+msgstr "存取選項"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "加入"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "儲存(_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+#, fuzzy
+msgid "APN"
+msgstr "VPN"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "詳細資料"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "網路時刻(_N)"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+#, fuzzy
+msgid "Network Status"
+msgstr "網路設定值"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+#, fuzzy
+msgid "Own Number"
+msgstr "數字"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "檢視詳細資料"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "製造商"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+#, fuzzy
+msgid "Firmware Version"
+msgstr "缺少韌體"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "流動寬頻(_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "網路時刻(_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "網絡"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+#, fuzzy
+msgid "Advanced"
+msgstr "進階"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+#, fuzzy
+msgid "_Access Point Names"
+msgstr "存取選項"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+#, fuzzy
+msgid "_SIM Lock"
+msgstr "螢幕鎖定"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "詳細資料"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "網絡名稱"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+#, fuzzy
+msgid "_Automatic"
+msgstr "自動"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+#, fuzzy
+msgid "Choose Network"
+msgstr "我的家用網絡"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "我的家用網絡"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+#, fuzzy
+msgid "No WWAN Adapter Found"
+msgstr "找不到藍牙接配器"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+#, fuzzy
+msgid "_Turn off Airplane Mode"
+msgstr "飛安模式(_P)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "連線"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+#, fuzzy
+msgid "SIM card used for internet"
+msgstr "SIM 卡尚未插入"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+#, fuzzy
+msgid "SIM Lock"
+msgstr "螢幕鎖定"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "改變(_A)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+#, fuzzy
+msgid "Mobile Network"
+msgstr "我的家用網絡"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+#, fuzzy
+msgid "Settings categories"
+msgstr "設定新的驅動程式…"
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr "私隱"
+
+#: shell/cc-window.ui:30
 msgid "All Settings"
 msgstr "所有設定值"
 
-#. Add categories
-#: ../shell/cc-window.c:876
-msgctxt "category"
-msgid "Personal"
-msgstr "個人"
+#: shell/cc-window.ui:54
+#, fuzzy
+msgid "Primary Menu"
+msgstr "主要"
 
-#: ../shell/cc-window.c:877
-msgctxt "category"
-msgid "Hardware"
-msgstr "硬件"
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
 
-#: ../shell/cc-window.c:878
-msgctxt "category"
-msgid "System"
-msgstr "系統"
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
 
-#: ../shell/gnome-control-center.desktop.in.in.h:2
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "求助"
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "一般"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "結束"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "搜尋"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "切換至上個來源"
+
+#: shell/help-overlay.ui:62
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "已取消"
+
+#: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;Settings;偏好設定;設定值;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u 輸出"
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u 輸入"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "整天的更改"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "鋪排"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "縮放"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "置中"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "填滿"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "合併"
+
+#~ msgid "Select Background"
+#~ msgstr "選擇背景"
+
+#~ msgid "Pictures"
+#~ msgstr "圖片"
+
+#~ msgid "Colors"
+#~ msgstr "顏色"
+
+#~ msgid "Home"
+#~ msgstr "家"
+
+#, c-format
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "你可以將影像加入你的%s資料夾，它們會顯示在這裏"
+
+#~ msgid "multiple sizes"
+#~ msgstr "多重尺寸"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "無桌面背景"
+
+#~ msgid "Current background"
+#~ msgstr "目前的背景"
+
+#~ msgid "Wallpaper;Screen;Desktop;"
+#~ msgstr "Wallpaper;Screen;Desktop;桌布;螢幕;桌面;"
+
+#~ msgid "Place your calibration device over the square and press 'Start'"
+#~ msgstr "將你的校準裝置放在矩形上並按「開始」"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "'Continue'"
+#~ msgstr "將你的校準裝置移到校準位置並按「繼續」"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press 'Continue'"
+#~ msgstr "將你的校準裝置移到表面位置並按「繼續」"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "關上手提電腦上蓋"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "發生內部的錯誤，無法復原。"
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "校準所需的工具尚未安裝。"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "無法產生描述檔。"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "尚無法獲取目標白點。"
+
+#~ msgid "Complete!"
+#~ msgstr "完成！"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "校準已失敗！"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "你可以移除校準裝置。"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "過程中請勿干擾校準裝置"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "手提電腦螢幕"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s 顯示器"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s 掃描器"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s 打印機"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s 網絡攝影機"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "啟用 %s 的顏色管理"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "顯示 %s 的顏色描述檔"
+
+#~ msgid "Not calibrated"
+#~ msgstr "尚未校準"
+
+#~ msgid "Default: "
+#~ msgstr "預設值："
+
+#~ msgid "Test profile: "
+#~ msgstr "測試描述檔："
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "選擇 ICC 色彩描述檔"
+
+#~ msgid "_Import"
+#~ msgstr "匯入(_I)"
+
+#~ msgid "All files"
+#~ msgstr "所有檔案"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "上傳檔案失敗：%s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "描述檔已經上傳到："
+
+#~ msgid "Write down this URL."
+#~ msgstr "寫下這個 URL。"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "重新啟動這臺電腦並開機進入你一般的作業系統。"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "在你的瀏覽器中輸入 URL 以下載並安裝描述檔。"
+
+#~ msgid "Save Profile"
+#~ msgstr "儲存描述檔"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "為已選取裝置建立色彩描述檔"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr "尚未偵測到測量儀器。請檢查它是否已開啟並正確的連接。"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "測量儀器不支援打印機的分析。"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "目刖不支援這個裝置類型。"
+
+#~ msgid "Standard Space"
+#~ msgstr "標準空間"
+
+#~ msgid "Test Profile"
+#~ msgstr "測試描述檔"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "自動"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "低品質"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "中品質"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "高品質"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "預設 RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "預設 CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "預設灰階"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "廠商提供的出廠校準資料"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "這個描述檔無法使用全螢幕顯示校正"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "這個描述檔可能不再準確"
+
+#~ msgid "Done"
+#~ msgstr "完成"
+
+#~ msgid "Upload profile"
+#~ msgstr "上傳描述檔"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "需要互聯網連線"
+
+#~ msgid "United States"
+#~ msgstr "美國"
+
+#~ msgid "Germany"
+#~ msgstr "德國"
+
+#~ msgid "Spain"
+#~ msgstr "西班牙"
+
+#~ msgid "China"
+#~ msgstr "中國"
+
+#~ msgid "Other…"
+#~ msgstr "其他…"
+
+#~ msgid "Language"
+#~ msgstr "語言"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%Y年%b%e日, %p %l:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%Y年%b%e日，%R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s，%s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%p %l:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Time _Zone"
+#~ msgstr "時區(_Z)"
+
+#~ msgid "24-hour"
+#~ msgstr "24小時"
+
+#~ msgid "AM / PM"
+#~ msgstr "AM / PM"
+
+#~ msgid "Lid Closed"
+#~ msgstr "上蓋已經關閉"
+
+#~ msgid "Mirrored"
+#~ msgstr "鏡射顯示器"
+
+#~ msgid "Off"
+#~ msgstr "關閉"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "排列顯示器的組合方式"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "拖拉顯示器以重新排列他們"
+
+#~ msgid "Size"
+#~ msgstr "尺寸"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "在這個顯示器顯示頂端列與活動概覽"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "將這個顯示器與另一個顯示器結合以建立額外的工作區"
+
+#~ msgid "Presentation"
+#~ msgstr "展示"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "只顯示投影片與媒體"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "在兩個顯示器顯示你現有的檢視"
+
+#~ msgid "Turn Off"
+#~ msgstr "關閉"
+
+#~ msgid "Don't use this display"
+#~ msgstr "不使用這個顯示器"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "無法取得螢幕資訊"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "排列組合的顯示器(_A)"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgid "Unknown"
+#~ msgstr "不明"
+
+#, c-format
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d 位元"
+
+#, c-format
+#~ msgid "%d-bit"
+#~ msgstr "%d 位元"
+
+#~ msgid "Ask what to do"
+#~ msgstr "詢問要做什麼"
+
+#~ msgid "Do nothing"
+#~ msgstr "不做任何事"
+
+#~ msgid "Open folder"
+#~ msgstr "開啟資料夾"
+
+#~ msgid "Other Media"
+#~ msgstr "其他媒體"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "選擇播放音樂 CD 的應用程式"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "選擇播放影片 DVD 的應用程式"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "選擇當音樂播放器連接時要執行的應用程式"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "選擇當攝影機連接時要執行的應用程式"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "選擇軟件 CD 要用的應用程式"
+
+#~ msgid "audio DVD"
+#~ msgstr "音樂 DVD"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "空白 Blu-ray 光碟"
+
+#~ msgid "blank CD disc"
+#~ msgstr "空白 CD 光碟"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "空白 DVD 光碟"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "空白 HD DVD 光碟"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "Blu-Ray 影片光碟"
+
+#~ msgid "e-book reader"
+#~ msgstr "電子書閱讀器"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "HD DVD 影片光碟"
+
+#~ msgid "Picture CD"
+#~ msgstr "照片 CD"
+
+#~ msgid "Super Video CD"
+#~ msgstr "SVCD"
+
+#~ msgid "Video CD"
+#~ msgstr "影片 CD"
+
+#~ msgid "Overview"
+#~ msgstr "概覽"
+
+#, c-format
+#~ msgid "Version %s"
+#~ msgstr "版本 %s"
+
+#~ msgid "Base system"
+#~ msgstr "基礎系統"
+
+#~ msgid "Disk"
+#~ msgstr "磁碟"
+
+#~ msgid "Check for updates"
+#~ msgstr "檢查更新"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "將螢幕擷圖儲存為 $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "將視窗的螢幕擷圖儲存為 $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "將區域的螢幕擷圖儲存為 $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "將螢幕截圖複製到剪貼簿"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "將視窗的螢幕截圖複製到剪貼簿"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "將區域的螢幕截圖複製到剪貼簿"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "錄製短式螢幕廣播"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "只以修飾鍵切換至下個來源"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;捷徑鍵;重複;閃爍;"
+
+#~ msgid "Custom Shortcut"
+#~ msgstr "自選捷徑鍵"
+
+#~ msgid "_Delay:"
+#~ msgstr "延遲(_D)："
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "短"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "長"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgid "S_peed:"
+#~ msgstr "速度(_P)："
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "移除捷徑鍵"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "要編輯捷徑鍵，點選相應的列並按下新的按鍵組合，或以 Backspace 鍵來清除。"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<行動設定不詳>"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "捷徑“%s”無法使用，原因是會無法按下此按鍵。\n"
+#~ "請試用其它的按鍵：如同時使用 Control，Alt  或 Shift。"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "捷徑鍵“%s”己經使用於：\n"
+#~ "“%s”"
+
+#, c-format
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "如果你重新指派捷徑鍵為「%s」，「%s」的捷徑鍵就會停用。"
+
+#~ msgid "_Reassign"
+#~ msgstr "重新指派(_R)"
+
+#, c-format
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr "捷徑鍵「%s」已指派「%s」捷徑。你想要自動將它設定為「%s」嗎？"
+
+#, c-format
+#~| msgid ""
+#~| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~| "disabled."
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr "「%s」目前指派為「%s」，如果你繼續這個捷徑鍵就會停用。"
+
+#~ msgid "_Assign"
+#~ msgstr "指派(_R)"
+
+#~ msgid "Test Your Settings"
+#~ msgstr "測試你的設定值"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "連按兩下分辨時間"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "左(_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "右(_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "指標速度(_P)"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgid "Two _finger scroll"
+#~ msgstr "兩指捲動(_F)"
+
+#~ msgid "_Natural scrolling"
+#~ msgstr "自然捲動(_N)"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "五次點擊，GEGL 時間！"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "連按兩下，主要按鈕"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "點選，主要按鈕"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "連按兩下，中央按鈕"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "點選，中央按鈕"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "連按兩下，次要按鈕"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "點選，次要按鈕"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "系統網絡服務與這個版本不兼容。"
+
+#~ msgid "page 1"
+#~ msgstr "頁 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "內部核對(_A)"
+
+#~ msgid "page 2"
+#~ msgstr "頁 2"
+
+#~ msgid "automatic"
+#~ msgstr "自動"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "企業版"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "Never"
+#~ msgstr "永不"
+
+#~ msgid "Today"
+#~ msgstr "今日"
+
+#~ msgid "Yesterday"
+#~ msgstr "昨日"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "太弱"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "確定"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "良好"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "很好"
+
+#~ msgid "Identity"
+#~ msgstr "身分"
+
+#~ msgid "Server"
+#~ msgstr "伺服器"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "刪除 DNS 伺服器"
+
+#~ msgid "Delete Route"
+#~ msgstr "刪除路由"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-位元密碼匙 (Hex 或 ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-位元密語"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "動態 WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA & WPA2 個人版"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA & WPA2 企業版"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "雙絞線 (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "附加單位介面 (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "媒體獨立介面 (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "允許其他使用者使用(_U)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "防火牆地帶(_Z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "預設"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "這個地帶定義了連線的信任等級"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "無法開啟連線編輯器"
+
+#~ msgid "New Profile"
+#~ msgstr "新增設定組合"
+
+#~ msgid "Bond"
+#~ msgstr "繫結"
+
+#~ msgid "Team"
+#~ msgstr "隊伍"
+
+#~ msgid "Bridge"
+#~ msgstr "橋接"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "無法載入 VPN 外掛程式"
+
+#~ msgid "Import from file…"
+#~ msgstr "從檔案匯入…"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "加入網絡連線"
+
+#~ msgid "_Reset"
+#~ msgstr "重設(_R)"
+
+#~ msgid "_Forget"
+#~ msgstr "遺忘(_F)"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr "重設這個網絡的設定值，包含密碼，但將它記住為偏好的網絡"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr "移除這個網絡的相關詳細資料並且不再嘗試自動連線"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "無法匯入 VPN 網絡連線"
+
+#, c-format
+#~ msgid ""
+#~ "The file '%s' could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "檔案「%s」無法讀取或未包含可辨識的 VPN 連線資訊\n"
+#~ "\n"
+#~ "錯誤：%s。"
+
+#~ msgid "Select file to import"
+#~ msgstr "選擇要匯入的檔案"
+
+#, c-format
+#~ msgid "A file named \"%s\" already exists."
+#~ msgstr "名為「%s」的檔案已經存在。"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "你是否要以準備儲存的 VPN 連線取代 %s？"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "不能匯出 VPN 連線"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection '%s' could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN 連線「%s」不能匯出至 %s。\n"
+#~ "\n"
+#~ "錯誤：%s。"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "匯出 VPN 連線"
+
+#~ msgid "Bond slaves"
+#~ msgstr "繫結的連線"
+
+#~ msgid "(none)"
+#~ msgstr "(沒有)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "橋接的連線"
+
+#~ msgid "never"
+#~ msgstr "永不"
+
+#~ msgid "today"
+#~ msgstr "今日"
+
+#~ msgid "yesterday"
+#~ msgstr "昨日"
+
+#~ msgid "Last used"
+#~ msgstr "最後使用的"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "設定組合 %d"
+
+#~ msgid "Team slaves"
+#~ msgstr "隊伍從屬"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "如果你有無線網絡以外的方式連線到互聯網，你可以使用它來與其他人分享你的互聯"
+#~ "網連線。"
+
+#, c-format
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "切換無線網絡熱點會讓你從 <b>%s</b> 斷線。"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "當熱點在使用中時是沒有辦法透過你的無線網絡存取互聯網的。"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "停止熱點並中斷任何使用者的連線？"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "停止熱點(_S)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "系統原則禁止做為熱點"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "無線裝置不支援熱點模式"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr "選取網絡的詳細資料包含密碼及任何自選的組態都會消失。"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "遺忘(_F)"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "當沒有提供組態 URL 時會使用網頁代理伺服器自動發現。"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "這不建議用於不信任的公用網絡。"
+
+#~ msgid "Proxy"
+#~ msgstr "代理伺服器"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "手動"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "自動"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN 類型"
+
+#~ msgid "Group Name"
+#~ msgstr "羣組名稱"
+
+#~ msgid "Group Password"
+#~ msgstr "羣組密碼"
+
+#~ msgid "details"
+#~ msgstr "詳細資料"
+
+#~ msgid "Show P_assword"
+#~ msgstr "顯示密碼(_A)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "允許其他使用者使用"
+
+#~ msgid "identity"
+#~ msgstr "身分"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "只用自動 (DHCP) 位址"
+
+#~ msgid "Link-local only"
+#~ msgstr "只有本機連線"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "忽略自動獲得的路由(_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "複製的 MA_C 位址"
+
+#~ msgid "hardware"
+#~ msgstr "硬件"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr "重設這個網絡的設定值為預設值，但將它記住為偏好的網絡。"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr "移除這個網絡的所有相關詳細資料並且不再嘗試自動連線。"
+
+#~ msgid "reset"
+#~ msgstr "重設"
+
+#~ msgid "Hardware"
+#~ msgstr "硬件"
+
+#~ msgid "_History"
+#~ msgstr "歷史紀錄(_H)"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "關閉連線到 Wi-Fi 網絡"
+
+#~ msgid "Connected Devices"
+#~ msgstr "已連線的裝置"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "基礎架構"
+
+#~ msgid "Status unknown"
+#~ msgstr "狀態不明"
+
+#~ msgid "Unmanaged"
+#~ msgstr "未管理"
+
+#~ msgid "Unavailable"
+#~ msgstr "無法使用"
+
+#~ msgid "Connecting"
+#~ msgstr "連線中"
+
+#~ msgid "Disconnecting"
+#~ msgstr "斷線"
+
+#~ msgid "Connection failed"
+#~ msgstr "連線失敗"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "狀態不詳（缺乏）"
+
+#~ msgid "Configuration failed"
+#~ msgstr "設定失敗"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP 組態失敗"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP 組態過期"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "需要機密，但沒有提供"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x 請求已斷線"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x 請求組態失敗"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x 請求已失敗"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x 請求花了太長時間核對"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "無法啟動 PPP 服務"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP 服務已斷線"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP 失敗"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP 客戶端啟動失敗"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP 客戶端錯誤"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP 客戶端失敗"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "分享的連線服務啟動失敗"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "分享的連線服務失敗"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "無法啟動 AutoIP 服務"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP 服務錯誤"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP 服務失敗"
+
+#~ msgid "Line busy"
+#~ msgstr "線路忙碌"
+
+#~ msgid "No dial tone"
+#~ msgstr "沒有撥號音"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "無法建立載體"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "撥號要求逾時"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "嘗試撥號失敗"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "數據機初始化失敗"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "無法選擇指定的 APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "不要搜尋網絡"
+
+#~ msgid "Network registration denied"
+#~ msgstr "網絡登記被禁止"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "網絡登記逾時"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "無法向要求的網絡登記"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN 檢查失敗"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "可能缺少裝置的韌體"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "連線已消失"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "優先使用現有的連線"
+
+#~ msgid "Modem not found"
+#~ msgstr "找不到數據機"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "藍牙連線失敗"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "需要 SIM PIN 碼"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "需要 SIM PUK 碼"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM 錯誤"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand 裝置不支援已連接模式"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "連線相根據性解析失敗"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "纜線已拔除"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "未選擇任何證書授權單位(CA)證書"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "不使用證書中心 (CA) 的證書會造成連線不安全、流氓 Wi-Fi 網絡。是否要選擇一"
+#~ "個證書中心的證書？"
+
+#~ msgid "Ignore"
+#~ msgstr "忽略"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "選擇 CA 證書"
+
+#~ msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+#~ msgstr "DER, PEM, 或 PKCS#12 私密密碼匙(*.der, *.pem, *.p12)"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER 或 PEM 證書 (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC 檔案 (*.pac)"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "每次都詢問密碼(_K)"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "未加密的私密密碼匙是不安全的"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password.  "
+#~ "This could allow your security credentials to be compromised.  Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "所選擇的私密密碼匙似乎沒有密碼保護。 這可能會導致不安全的後果。請選擇用密"
+#~ "碼保護的私密密碼匙。\n"
+#~ "\n"
+#~ "(你可以使用 openssl 來加密你的私密密碼匙)"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "選擇你的個人證書"
+
+#~ msgid "Choose your private key"
+#~ msgstr "選擇你的私密密碼匙"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "不要再警告我(_W)"
+
+#~ msgid "Yes"
+#~ msgstr "是"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "顯示彈出式橫幅"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Details in Banners"
+#~ msgstr "在橫幅顯示詳細資料"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "在鎖定畫面中顯示"
+
+#~ msgid "On"
+#~ msgstr "開啟"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "顯示彈出式橫幅"
+
+#~ msgid "Show in Lock Screen"
+#~ msgstr "在鎖定畫面中顯示"
+
+#~ msgid "Add Account"
+#~ msgstr "加入帳號"
+
+#~ msgid "Mail"
+#~ msgstr "郵件"
+
+#~ msgid "Contacts"
+#~ msgstr "聯絡人"
+
+#~ msgid "Chat"
+#~ msgstr "聊天"
+
+#~ msgid "Resources"
+#~ msgstr "資源"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "登入帳號時發生錯誤"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "證書已經過期。"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "登入以啟用這個帳號。"
+
+#~ msgid "_Sign In"
+#~ msgstr "登入(_S)"
+
+#~ msgid "Error creating account"
+#~ msgstr "建立帳號時發生錯誤"
+
+#~ msgid "Error removing account"
+#~ msgstr "移除帳號時發生錯誤"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "確定要刪除這個帳號？"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "這不會移除伺服器上的帳號。"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "尚未設定網上帳號"
+
+#~ msgid "Remove Account"
+#~ msgstr "移除帳號"
+
+#~ msgid "Add an online account"
+#~ msgstr "加入網上帳號"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "加入一個帳號以允許你的應用程式存取它用於文件、郵件、聯絡人、行事曆、聊天等"
+#~ "等。"
+
+#~ msgid "Unknown time"
+#~ msgstr "不明的時間"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "%s後完全充飽"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "注意：剩下 %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "剩下 %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "已完全充飽"
+
+#~ msgid "Empty"
+#~ msgstr "沒電"
+
+#~ msgid "Charging"
+#~ msgstr "充電"
+
+#~ msgid "Discharging"
+#~ msgstr "放電中"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "主要"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "額外"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "無線滑鼠"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "無線鍵盤"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "不斷電系統"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "個人數碼助理"
+
+#~ msgid "Cellphone"
+#~ msgstr "手機"
+
+#~ msgid "Media player"
+#~ msgstr "媒體播放器"
+
+#~ msgid "Computer"
+#~ msgstr "電腦"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "充電"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "注意"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "低"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "良好"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "已完全充飽"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "沒電"
+
+#~ msgid "Batteries"
+#~ msgstr "電池"
+
+#~ msgid "When _idle"
+#~ msgstr "閒置時(_I)"
+
+#~ msgid "_Keyboard brightness"
+#~ msgstr "鍵盤亮度(_K)"
+
+#~ msgid "_Dim screen when inactive"
+#~ msgstr "當不活動後降低螢幕亮度(_D)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "關閉無線裝置"
+
+#~ msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+#~ msgstr "關閉流動寬頻 (3G、4G、WiMax 等) 裝置"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "藍牙(_B)"
+
+#~ msgid "When on battery power"
+#~ msgstr "使用電池電源時"
+
+#~ msgid "When plugged in"
+#~ msgstr "當插入電源線時"
+
+#~ msgid "Suspend & Power Off"
+#~ msgstr "暫停與關閉電源"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "自動暫停(_A)"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "當電池的電量極低時(_C)"
+
+#~ msgid "Power Off"
+#~ msgstr "關閉電源"
+
+#~ msgid "Hibernate"
+#~ msgstr "休眠"
+
+#~ msgid "1 minute"
+#~ msgstr "1 分鐘"
+
+#~ msgid "3 minutes"
+#~ msgstr "3 分鐘"
+
+#~ msgid "4 minutes"
+#~ msgstr "4 分鐘"
+
+#~ msgid "8 minutes"
+#~ msgstr "8 分鐘"
+
+#~ msgid "10 minutes"
+#~ msgstr "10 分鐘"
+
+#~ msgid "12 minutes"
+#~ msgstr "12 分鐘"
+
+#~ msgid "Out of toner"
+#~ msgstr "碳粉用完"
+
+#~ msgid "Low on developer"
+#~ msgstr "顯像劑不足"
+
+#~ msgid "Out of developer"
+#~ msgstr "顯像劑用完"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "墨水匣不足"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "墨水匣用完"
+
+#~ msgid "Open cover"
+#~ msgstr "外殼開啟"
+
+#~ msgid "Open door"
+#~ msgstr "紙匣門開啟"
+
+#~ msgid "Low on paper"
+#~ msgstr "紙張不足。"
+
+#~ msgid "Out of paper"
+#~ msgstr "紙張用完"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "已停止"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "廢墨收集器將滿"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "廢墨收集器已滿"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "感光鼓接近使用壽命"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "感光鼓已無法使用"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "準備就緒"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "不接受工作"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "處理中"
+
+#~ msgid "Toner Level"
+#~ msgstr "碳粉匣等級"
+
+#~ msgid "Supply Level"
+#~ msgstr "耗材等級"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "正在安裝"
+
+#, c-format
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u 使用中"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "無法加入新的打印機。"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript 打印機描述檔 (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "找不到合適的驅動程式"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "無法載入 ui：%s"
+
+#~ msgid "Resume Printing"
+#~ msgstr "繼續列印"
+
+#~ msgid "Pause Printing"
+#~ msgstr "暫停列印"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "加入新的打印機"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "輸入網絡打印機的位址或過濾器結果文字"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect 打印機"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD 打印機"
+
+#~ msgid "One Sided"
+#~ msgstr "單面"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "長邊 (標準)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "短邊 (翻轉)"
+
+#~ msgid "Portrait"
+#~ msgstr "直向"
+
+#~ msgid "Landscape"
+#~ msgstr "橫向"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "橫向倒轉"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "直向倒轉"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "保留中"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "已暫停"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "處理中"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "已停止"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "已放棄"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "已完成"
+
+#~ msgid "Job Title"
+#~ msgstr "工作名稱"
+
+#~ msgid "Job State"
+#~ msgstr "工作狀態"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "序列埠"
+
+#~ msgid "Parallel Port"
+#~ msgstr "串列埠"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "位置：%s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "位址：%s"
+
+#~ msgid "Two Sided"
+#~ msgstr "雙面"
+
+#~ msgid "Paper Type"
+#~ msgstr "紙張類型"
+
+#~ msgid "Paper Source"
+#~ msgstr "紙張來源"
+
+#~ msgid "Output Tray"
+#~ msgstr "出紙匣"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript 前置過濾器"
+
+#~ msgid "Pages per side"
+#~ msgstr "每張紙的頁數"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "一般"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "頁面設定"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "可安裝選項"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "工作"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "圖片品質"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "顏色"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "完成"
+
+#~ msgid "Auto Select"
+#~ msgstr "自動選擇"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "只有內嵌的 GhostScript 字型"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "轉換為 PS 等級 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "轉換為 PS 等級 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "無前置過濾器"
+
+#~ msgid "Supply"
+#~ msgstr "耗材"
+
+#~ msgid "_Default printer"
+#~ msgstr "預設打印機(_D)"
+
+#~ msgid "Jobs"
+#~ msgstr "工作"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "顯示工作(_J)"
+
+#~ msgid "label"
+#~ msgstr "標籤"
+
+#~ msgid "page 3"
+#~ msgstr "頁 3"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "列印測試頁(_T)"
+
+#~ msgid "_Options"
+#~ msgstr "選項(_O)"
+
+#~ msgid "Add New Printer"
+#~ msgstr "加入新的打印機"
+
+#~ msgid "Usage & History"
+#~ msgstr "使用與歷史紀錄"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "要清除回收筒中所有的項目？"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "所有在回收筒中的項目會永遠刪除。"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "刪除所有暫存檔案？"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "所有的暫存檔案會永遠刪除。"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "保護你的個人資料並控制其他人能看到什麼"
+
+#~ msgid "30 seconds"
+#~ msgstr "30 秒"
+
+#~ msgid "1 day"
+#~ msgstr "1 天"
+
+#~ msgid "2 days"
+#~ msgstr "2 天"
+
+#~ msgid "3 days"
+#~ msgstr "3 天"
+
+#~ msgid "4 days"
+#~ msgstr "4 天"
+
+#~ msgid "5 days"
+#~ msgstr "5 天"
+
+#~ msgid "6 days"
+#~ msgstr "6 天"
+
+#~ msgid "7 days"
+#~ msgstr "7 天"
+
+#~ msgid "14 days"
+#~ msgstr "14 天"
+
+#~ msgid "30 days"
+#~ msgstr "30 天"
+
+#~ msgid "Forever"
+#~ msgstr "永遠"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "記住你的歷史紀錄會讓需要再次找到某樣東西時更簡單。這些項目永遠不會透過網絡"
+#~ "分享出去。"
+
+#~ msgid "_Recently Used"
+#~ msgstr "最近使用(_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "保留歷史紀錄(_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "螢幕鎖可以在你離開時保護你的私隱。"
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "螢幕轉黑後多久鎖定螢幕(_A)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr "自動清除回收筒和暫存檔案可以保護你的電腦減少不必要的敏感資訊。"
+
+#~ msgid "Purge _After"
+#~ msgstr "清除於(_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "傳送你所使用軟件的資訊給我們能幫助我們提供你更準確的建議。它也能協助我們改"
+#~ "進我們的軟件。\n"
+#~ "\n"
+#~ "我們所收集的所有資訊都是匿名的，而且我們永遠不會將你的資料與任何第三方分"
+#~ "享。"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "傳送軟件使用率統計(_S)"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "私隱權原則"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "用來判斷你所在的地理位置"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "英制"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "公制"
+
+#~ msgid "No input sources found"
+#~ msgstr "找不到輸入來源"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "其他"
+
+#~ msgid "Sorry"
+#~ msgstr "抱歉"
+
+#~ msgid ""
+#~ "Select your display language, formats, keyboard layouts and input sources"
+#~ msgstr "選擇你的顯示語言、格式、鍵盤配置和輸入來源"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Switch to next source"
+#~ msgstr "切換至下個來源"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "You can change these shortcuts in the keyboard settings"
+#~ msgstr "你可以在鍵盤設定值中改變這些捷徑鍵"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "切換至下個來源的替代鍵"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "左+右 Alt"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "英文 (英國)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "英國"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "登入設定值是所有的使用者在登入系統時會用到的"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "其他"
+
+#~ msgid "Select Location"
+#~ msgstr "選擇位置"
+
+#~ msgid "_OK"
+#~ msgstr "確定(_O)"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "開啟"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "關閉"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "已啟用"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "選擇一個資料夾"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "沒有選擇用來分享的網絡"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr "藍牙分享允許你與其他具有藍牙的裝置分享檔案"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "只接收信任的裝置"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "將接收的檔案儲存至下載資料夾"
+
+#~ msgid "Screen Sharing"
+#~ msgstr "螢幕分享"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "由於沒有網絡存取，某些服務已停用。"
+
+#, no-c-format
+#~ msgid ""
+#~ "Personal File Sharing allows you to share your Public folder with others "
+#~ "on your current network using: <a href=\"dav://%s\">dav://%s</a>"
+#~ msgstr ""
+#~ "個人檔案分享允許你使用： <a href=\"dav://%s\">dav://%s</a> 與目前網絡上的"
+#~ "其他人分享你的公開資料夾"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to connect using the Secure Shell command:\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+#~ msgstr ""
+#~ "允許遠端使用者使用 SSH 指令連線：\n"
+#~ "<a href=\"ssh %s\">ssh %s</a>"
+
+#, no-c-format
+#~ msgid ""
+#~ "Allow remote users to view or control your screen by connecting to: <a "
+#~ "href=\"vnc://%s\">vnc://%s</a>"
+#~ msgstr ""
+#~ "允許遠端使用者連線到：<a href=\"vnc://%s\">vnc://%s</a> 檢視或控制你的螢幕"
+
+#~ msgid "Password:"
+#~ msgstr "密碼："
+
+#~ msgid "Show Password"
+#~ msgstr "顯示密碼"
+
+#~ msgid "New connections must ask for access"
+#~ msgstr "存取新的連線必須詢問"
+
+#~ msgid "Require a password"
+#~ msgstr "需要密碼"
+
+#~ msgid "Bark"
+#~ msgstr "汪汪"
+
+#~ msgid "Drip"
+#~ msgstr "水滴聲"
+
+#~ msgid "Glass"
+#~ msgstr "敲玻璃"
+
+#~ msgid "Sonar"
+#~ msgstr "聲納"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "最小值"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "最大值"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "重低音(_S)："
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "volume"
+#~ msgid "Unamplified"
+#~ msgstr "未經放大"
+
+#~ msgid "_Profile:"
+#~ msgstr "設定組合(_P):"
+
+#~ msgid "_Test Speakers"
+#~ msgstr "測試喇叭(_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "峰值檢測"
+
+#~ msgid "Device"
+#~ msgstr "裝置"
+
+#, c-format
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s 的喇叭測試"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "選擇聲音輸出的裝置(_H)："
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "已選取裝置的設定值："
+
+#~ msgid "_Input volume:"
+#~ msgstr "輸入音量(_I)："
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "選擇聲音輸入的裝置(_H)："
+
+#~ msgid "Sound Effects"
+#~ msgstr "聲音效果"
+
+#~ msgid "Built-in"
+#~ msgstr "內置"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "音效偏好設定"
+
+#~ msgid "Testing event sound"
+#~ msgstr "測試事件聲音"
+
+#~ msgid "From theme"
+#~ msgstr "從主題"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "選擇警示音效(_H)："
+
+#~ msgid "Stop"
+#~ msgstr "停止"
+
+#~ msgid "Custom"
+#~ msgstr "自選"
+
+#~ msgid "Screen Reader"
+#~ msgstr "螢幕閱讀器"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "螢幕閱讀器(_S)"
+
+#~ msgid "Sound Keys"
+#~ msgstr "聲音按鍵"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "閃動視窗標題(_W)"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "短"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ 螢幕"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ 螢幕"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ 螢幕"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "長"
+
+#~ msgid "Zoom"
+#~ msgstr "縮放"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "顏色"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "標準"
+
+#~ msgid "_Verify"
+#~ msgstr "驗證(_V)"
+
+#~ msgid ""
+#~ "Go online to add\n"
+#~ "enterprise login accounts."
+#~ msgstr ""
+#~ "請上線以加入\n"
+#~ "企業登入帳號。"
+
+#~ msgid "Left thumb"
+#~ msgstr "左手姆指"
+
+#~ msgid "Left middle finger"
+#~ msgstr "左手中指"
+
+#~ msgid "Left ring finger"
+#~ msgstr "左手無名指"
+
+#~ msgid "Left little finger"
+#~ msgstr "左手小指"
+
+#~ msgid "Right thumb"
+#~ msgstr "右手姆指"
+
+#~ msgid "Right middle finger"
+#~ msgstr "右手中指"
+
+#~ msgid "Right ring finger"
+#~ msgstr "右手無名指"
+
+#~ msgid "Right little finger"
+#~ msgstr "右手小指"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "啟用指紋登入"
+
+#~ msgid "_Right index finger"
+#~ msgstr "右手食指(_R)"
+
+#~ msgid "_Left index finger"
+#~ msgstr "左手食指(_L)"
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr "你的指紋已成功的儲存了。現在應該可以使用你的指紋辨識器來登入。"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;登入;姓名;指紋;大頭貼;標"
+#~ "誌;臉;密碼;"
+
+#~ msgid "Login History"
+#~ msgstr "登入歷史紀錄"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "驗證新密碼(_V)"
+
+#~ msgid "Add User Account"
+#~ msgstr "加入使用者帳號"
+
+#~ msgid "User Icon"
+#~ msgstr "使用者圖示"
+
+#~ msgid "Last Login"
+#~ msgstr "上次登入"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "新的密碼需要與舊密碼有所差異。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "嘗試改變某些文字和數字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "嘗試更常改變密碼。"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "不含你的使用者名稱的密碼強度會比較高。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "嘗試避免在密碼中使用你的姓名。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "嘗試避免在密碼中包含某些文字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "嘗試避免常見的文字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "嘗試避免重新排序現有的文字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "嘗試使用更多數字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "嘗試使用更多大寫字母。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "嘗試使用更多小寫字母。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "嘗試使用更多特殊字符，像是標點符號。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "嘗試使用混合字母、數字和標點符號。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "嘗試避免同樣字符。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr "嘗試避免重複同樣類型的字符：你需要混合字母、數字和標點符號。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "嘗試避免像 1234 或 abcd 等順序。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "嘗試加入更多字母、數字和標點符號。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and use a number or two."
+#~ msgstr "混合大寫與小寫字符並使用一到兩個數字。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Good password! Adding more letters, numbers and punctuation will make it "
+#~ "stronger."
+#~ msgstr "不錯的密碼！加入更多字母、數字和標點符號會讓它更好。"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "強度：很弱"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "強度：低度"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "強度：中度"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "強度：良好"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "強度：高度"
+
+#~ msgid "Authentication failed"
+#~ msgstr "核對失敗"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "新的密碼太短"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "新的密碼太簡單"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "舊密碼與新密碼太相似了"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "新的密碼已經在最近使用過了。"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "新的密碼必須包含數字或特殊字符"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "舊密碼與新密碼是相同的"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "你的密碼在第一次核對後已經改變過了！"
+
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "新的密碼並未包含足夠的不同字符"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "不明的錯誤"
+
+#~ msgid "Should match the web address of your account provider."
+#~ msgstr "應符合你帳號提供者的網絡位址。"
+
+#~ msgid "Failed to add account"
+#~ msgstr "無法加入到帳號"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "密碼不相符。"
+
+#~ msgid "Failed to register account"
+#~ msgstr "無法註冊帳號"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "沒有支援這個網域核對的方式"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "無法加入網域"
+
+#~ msgid ""
+#~ "That login name didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "登入名稱沒有用。\n"
+#~ "請再試一次。"
+
+#~ msgid ""
+#~ "That login password didn't work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "登入密碼沒有用。\n"
+#~ "請再試一次。"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "無法登入到網域"
+
+#~ msgid "Unable find the domain. Maybe you misspelled it?"
+#~ msgstr "找不到網域。也許你拼錯字了？"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "你不被允許使用這個裝置。請聯絡你的系統管理者。"
+
+#~ msgid "The device is already in use."
+#~ msgstr "該裝置已經在使用中。"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "發生內部的錯誤。"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "是否刪除已註冊的指紋？"
+
+#~ msgid "Done!"
+#~ msgstr "完成！"
+
+#, c-format
+#~ msgid "Could not access '%s' device"
+#~ msgstr "無法存取「%s」裝置"
+
+#, c-format
+#~ msgid "Could not start finger capture on '%s' device"
+#~ msgstr "無法使用「%s」裝置上的指紋捕捉"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "無法存取任何指紋辨識器"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "請聯絡你的系統管理員來幫忙。"
+
+#, c-format
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the '%s' device."
+#~ msgstr "要啟用指紋登入，你需要使用「%s」裝置儲存你的指紋。"
+
+#~ msgid "Selecting finger"
+#~ msgstr "選擇手指"
+
+#~ msgid "This Week"
+#~ msgstr "本週"
+
+#~ msgid "Last Week"
+#~ msgstr "上週"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%b%e日"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y年%b%e日"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s，%s"
+
+#~ msgid "Session Ended"
+#~ msgstr "作業階段結束"
+
+#~ msgid "Session Started"
+#~ msgstr "作業階段開始"
+
+#~ msgid "Please choose another password."
+#~ msgstr "請選擇其他密碼。"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "請再次輸入你目前的密碼。"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "密碼無法更改"
+
+#~ msgid "Disable image"
+#~ msgstr "停用圖片"
+
+#~ msgid "Take a photo…"
+#~ msgstr "照相…"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "瀏覽更多照片…"
+
+#, c-format
+#~ msgid "Used by %s"
+#~ msgstr "由 %s 使用"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "不能自動加入這個類型的網域"
+
+#, c-format
+#~ msgid "No such domain or realm found"
+#~ msgstr "找不到這個網域或領域名稱"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "不能以 %s 身分登入 %s 網域"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "密碼錯誤，請再試一次"
+
+#~ msgid "Other Accounts"
+#~ msgstr "其他帳號"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "刪除使用者失敗"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "你不能刪除自己的帳號。"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s 仍在登入中"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "在使用者登入期間刪除他會使系統處於不穩定的狀態。"
+
+#, c-format
+#~ msgid "Do you want to keep %s's files?"
+#~ msgstr "你想要保留 %s 的檔案嗎？"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr "當刪除使用者時是可以保留家目錄、新進郵件(mail spool)和暫存檔案的。"
+
+#~ msgid "_Delete Files"
+#~ msgstr "刪除檔案(_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "保留檔案(_K)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "帳號已停用"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "在下次登入時設定"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "Logged in"
+#~ msgstr "已登入"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "無法連接帳號服務"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "請確定 AccountService 已經安裝並啟用。"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "要進行更改，\n"
+#~ "請先點選 * 圖示"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "要建立使用者帳號，\n"
+#~ "請先點選 * 圖示"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "刪除選取的使用者帳號"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "要刪除選取的使用者帳號，\n"
+#~ "請先點選 * 圖示"
+
+#, c-format
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "以「%s」為名的使用者已經存在。"
+
+#, c-format
+#~ msgid "The username is too long."
+#~ msgstr "使用者名稱太長。"
+
+#~ msgid "The username cannot start with a '-'."
+#~ msgstr "使用者名稱不能以「-」字符開頭。"
+
+#~ msgid ""
+#~ "The username should only consist of lower and upper case letters from a-"
+#~ "z, digits and any of characters '.', '-' and '_'."
+#~ msgstr ""
+#~ "使用者名稱只能由大小寫字母英文字母 a 到 z、數字，與其他字符如「.」、「-」"
+#~ "和「_」構成。"
+
+#~ msgid "This will be used to name your home folder and can't be changed."
+#~ msgstr "這會成為你家目錄資料夾的名稱，並且不能被改變。"
+
+#~ msgid "%b %e"
+#~ msgstr "%b%e日"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y年%b%e日"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "上"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "下"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "傳送筆劃"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "切換監視器"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "顯示螢幕求助"
+
+#~ msgid "Output:"
+#~ msgstr "輸出："
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "保持長寬比："
+
+#~ msgid "Map to single monitor"
+#~ msgstr "映射到單一螢幕"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d / %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "顯示對應"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "繪圖板 (絕對位置)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "繪圖板偏好設定"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "藍牙設定值"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "對應按鈕…"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "調整顯示解像度"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "調整滑鼠設定值"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "追蹤模式"
+
+#~ msgid "Left Ring"
+#~ msgstr "左環"
+
+#, c-format
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "左觸控環模式 #%d"
+
+#, c-format
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "右觸控環模式 #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "左觸控列"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "左觸控列模式 #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "右觸控列"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "右觸控列模式 #%d"
+
+#, c-format
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "左觸控環模式切換"
+
+#, c-format
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "右觸控環模式切換"
+
+#, c-format
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "左觸控列模式切換"
+
+#, c-format
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "右觸控列模式切換"
+
+#, c-format
+#~ msgid "Mode Switch #%d"
+#~ msgstr "模式切換 #%d"
+
+#, c-format
+#~ msgid "Left Button #%d"
+#~ msgstr "左側按鈕 #%d"
+
+#, c-format
+#~ msgid "Right Button #%d"
+#~ msgstr "右側按鈕 #%d"
+
+#, c-format
+#~ msgid "Top Button #%d"
+#~ msgstr "頂端按鈕 #%d"
+
+#, c-format
+#~ msgid "Bottom Button #%d"
+#~ msgstr "底部按鈕 #%d"
+
+#~ msgid "No Action"
+#~ msgstr "沒有動作"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "滑鼠左鍵點擊"
+
+#~ msgid "Scroll Up"
+#~ msgstr "向上捲動"
+
+#~ msgid "Top Button"
+#~ msgstr "頂端按鈕"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "啟用詳細模式"
+
+#~ msgid "Show the overview"
+#~ msgstr "顯示概覽"
+
+#~ msgid "Search for the string"
+#~ msgstr "搜尋字串"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "列出可能的面板名稱並結束"
+
+#~ msgid "Show help options"
+#~ msgstr "顯示說明的選項"
+
+#~ msgid "Panel to display"
+#~ msgstr "要顯示的面板"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[面板] [引數…]"
+
+#~ msgid "- Settings"
+#~ msgstr "- 設定值)"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "執行 「%s --help」以查看完整的命令列可用選項清單。\n"
+
+#~ msgid "Available panels:"
+#~ msgstr "可用的面板："
+
+#~ msgctxt "category"
+#~ msgid "Personal"
+#~ msgstr "個人"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "硬件"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "系統"
 
 #~ msgid "Share Media On This Network"
 #~ msgstr "在這個網路分享媒體"
@@ -7003,35 +8083,20 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgid "Immediately"
 #~ msgstr "立即"
 
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
-
 #~ msgid "Set Up New Device"
 #~ msgstr "設置新裝置"
-
-#~ msgid "Connection"
-#~ msgstr "連線"
 
 #~ msgid "Paired"
 #~ msgstr "已配對"
 
-#~ msgid "Type"
-#~ msgstr "類型"
-
 #~ msgid "Mouse & Touchpad Settings"
 #~ msgstr "滑鼠與觸控板設定值"
-
-#~ msgid "Sound Settings"
-#~ msgstr "音效設定值"
 
 #~ msgid "Keyboard Settings"
 #~ msgstr "鍵盤設定值"
 
 #~ msgid "Send Files…"
 #~ msgstr "傳送檔案…"
-
-#~ msgid "Visibility"
-#~ msgstr "顯示狀態"
 
 #~ msgid "Visibility of “%s”"
 #~ msgstr "「%s」的顯示狀態"
@@ -7043,9 +8108,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ "If you remove the device, you will have to set it up again before next "
 #~ "use."
 #~ msgstr "如果您刪除此裝置，下次使用時必須再次設定它。"
-
-#~ msgid "Install Updates"
-#~ msgstr "安裝更新"
 
 #~ msgid "System Up-To-Date"
 #~ msgstr "系統已是最新"
@@ -7061,9 +8123,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 
 #~ msgid "Only share with Trusted Devices"
 #~ msgstr "只與信任的裝置分享"
-
-#~ msgid "Remote View"
-#~ msgstr "遠端檢視"
 
 #~ msgid "Approve All Connections"
 #~ msgstr "允許所有的連線"
@@ -7093,9 +8152,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 
 #~ msgid "Don't use the display"
 #~ msgstr "不使用這個顯示器"
-
-#~ msgid "Refresh Rate"
-#~ msgstr "更新率"
 
 #~ msgid "Mouse Preferences"
 #~ msgstr "滑鼠偏好設定"
@@ -7147,12 +8203,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgid "_City:"
 #~ msgstr "城市(_C)："
 
-#~ msgid "_Network Time"
-#~ msgstr "網路時刻(_N)"
-
-#~ msgid ":"
-#~ msgstr ":"
-
 #~ msgid "Set the time one hour ahead."
 #~ msgstr "將時刻延後一小時。"
 
@@ -7177,18 +8227,8 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgstr "逆時針"
 
 #~ msgctxt "display panel, rotation"
-#~ msgid "Clockwise"
-#~ msgstr "順時針"
-
-#~ msgctxt "display panel, rotation"
 #~ msgid "180 Degrees"
 #~ msgstr "180 度"
-
-#~ msgid "Monitor"
-#~ msgstr "顯示器"
-
-#~ msgid "Drag to change primary display."
-#~ msgstr "拖曳以改變主要顯示器。"
 
 #~ msgid ""
 #~ "Select a monitor to change its properties; drag it to rearrange its "
@@ -7216,9 +8256,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgid "Note: may limit resolution options"
 #~ msgstr "注意：可能會限制解析度選項"
 
-#~ msgid "_Detect Displays"
-#~ msgstr "偵測顯示器(_D)"
-
 #~ msgid "Hidden"
 #~ msgstr "隱藏"
 
@@ -7242,9 +8279,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 
 #~ msgid "Show Status When _Inactive"
 #~ msgstr "當不活動後顯示狀態(_I)"
-
-#~ msgid "_Confirm Password"
-#~ msgstr "確認密碼(_C)"
 
 #~ msgid "_Login Name"
 #~ msgstr "登入名稱(_L)"
@@ -7439,9 +8473,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgid "Large"
 #~ msgstr "大"
 
-#~ msgid "Add account"
-#~ msgstr "加入帳號"
-
 #~ msgid "_Local Account"
 #~ msgstr "登入帳號(_L)"
 
@@ -7450,12 +8481,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 
 #~ msgid "C_ontinue"
 #~ msgstr "繼續(_O)"
-
-#~ msgid "Previous Week"
-#~ msgstr "前一週"
-
-#~ msgid "Next Week"
-#~ msgstr "下一週"
 
 #~ msgid "Next week"
 #~ msgstr "下一週"
@@ -7468,9 +8493,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 
 #~ msgid "Enable this account"
 #~ msgstr "啟用這個帳號"
-
-#~ msgid "Generate a password"
-#~ msgstr "產生密碼"
 
 #~ msgid "_Action"
 #~ msgstr "動作(_A)"
@@ -7587,9 +8609,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgid "Change the background"
 #~ msgstr "更改背景"
 
-#~ msgid "Configure Bluetooth settings"
-#~ msgstr "設定藍牙設定值"
-
 #~ msgctxt "Power"
 #~ msgid "Bluetooth"
 #~ msgstr "藍牙"
@@ -7609,12 +8628,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgid "Select a region"
 #~ msgstr "選擇地區"
 
-#~ msgid "Select a language"
-#~ msgstr "選擇語言"
-
-#~ msgid "_Select"
-#~ msgstr "選取(_S)"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "日期和時刻偏好設定面板"
 
@@ -7630,14 +8643,8 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgid "Set your mouse and touchpad preferences"
 #~ msgstr "設定您的滑鼠與觸控板偏好設定"
 
-#~ msgid "Network settings"
-#~ msgstr "網路設定值"
-
 #~ msgid "Carrier/link changed"
 #~ msgstr "載體/連結已變更"
-
-#~ msgid "Manage notifications"
-#~ msgstr "管理通知"
 
 #~ msgid "Manage online accounts"
 #~ msgstr "管理線上帳號"
@@ -7647,9 +8654,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 
 #~ msgid "Power management settings"
 #~ msgstr "電源管理設定值"
-
-#~ msgid "Change printer settings"
-#~ msgstr "改變印表機設定值"
 
 #~ msgid "Manufacturers"
 #~ msgstr "製造商"
@@ -7688,9 +8692,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgid "Region and Language"
 #~ msgstr "地區和語言"
 
-#~ msgid "Select a display language"
-#~ msgstr "選擇顯示的語言"
-
 #~ msgid "Add Language"
 #~ msgstr "加入語言"
 
@@ -7718,9 +8719,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 #~ msgid "Move Input Source Up"
 #~ msgstr "將輸入來源往上移"
 
-#~ msgid "Show Keyboard Layout"
-#~ msgstr "顯示鍵盤配置"
-
 #~ msgid "Ctrl+Alt+Space"
 #~ msgstr "Ctrl+Alt+Space"
 
@@ -7741,9 +8739,6 @@ msgstr "Preferences;Settings;偏好設定;設定值;"
 
 #~ msgid "System settings"
 #~ msgstr "系統設定值"
-
-#~ msgid "Search settings"
-#~ msgstr "搜尋設定值"
 
 #~ msgid "Universal Access Preferences"
 #~ msgstr "無障礙偏好設定"

--- a/po/zh_HK.po~
+++ b/po/zh_HK.po~
@@ -1,0 +1,7771 @@
+# Chinese (Hong Kong) translation of gnome-control-center.
+# Copyright (C) 1999, 2001-07 Free Software Foundation, Inc.
+# GNOME 1.x:
+# S.J. Luo <crystal@mickey.ee.nctu.edu.tw>, 1999.
+# Abel Cheung <abel@oaka.org>, 2001-2002.
+# GNOME 2.x:
+# Abel Cheung <abel@oaka.org>, 2001-2003, 2005.
+# Woodman Tuen <wmtuen@gmail.com>, 2004-07.
+# Chao-Hsiung Liao <j_h_liau@yahoo.com.tw>, 2010.
+# Wei-Lun Chao <chaoweilun@gmail.com>, 2010.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center 3.3.91\n"
+"Report-Msgid-Bugs-To: http://bugzilla.gnome.org/enter_bug.cgi?product=gnome-"
+"control-center&keywords=I18N+L10N&component=general\n"
+"POT-Creation-Date: 2014-08-23 18:31+0000\n"
+"PO-Revision-Date: 2014-08-25 14:05+0800\n"
+"Last-Translator: Chao-Hsiung Liao <j_h_liau@yahoo.com.tw>\n"
+"Language-Team: Chinese (Hong Kong) <community@linuxhall.org>\n"
+"Language: zh_HK\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 1.6.5\n"
+
+#: ../panels/background/background.ui.h:1
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:1
+msgid "Background"
+msgstr "背景"
+
+#. This refers to a slideshow background
+#: ../panels/background/background.ui.h:3
+msgid "Changes throughout the day"
+msgstr "整天的更改"
+
+#. To translators: This is a noun, not a verb
+#: ../panels/background/background.ui.h:5
+msgid "Lock Screen"
+msgstr "鎖定畫面"
+
+#: ../panels/background/background.ui.h:6
+msgctxt "background, style"
+msgid "Tile"
+msgstr "鋪排"
+
+#: ../panels/background/background.ui.h:7
+msgctxt "background, style"
+msgid "Zoom"
+msgstr "縮放"
+
+#: ../panels/background/background.ui.h:8
+msgctxt "background, style"
+msgid "Center"
+msgstr "置中"
+
+#: ../panels/background/background.ui.h:9
+msgctxt "background, style"
+msgid "Scale"
+msgstr "縮放"
+
+#: ../panels/background/background.ui.h:10
+msgctxt "background, style"
+msgid "Fill"
+msgstr "填滿"
+
+#: ../panels/background/background.ui.h:11
+msgctxt "background, style"
+msgid "Span"
+msgstr "合併"
+
+#. translators: This is the title of the wallpaper chooser dialog.
+#: ../panels/background/cc-background-chooser-dialog.c:442
+msgid "Select Background"
+msgstr "選擇背景"
+
+#: ../panels/background/cc-background-chooser-dialog.c:463
+msgid "Wallpapers"
+msgstr "桌布"
+
+#: ../panels/background/cc-background-chooser-dialog.c:472
+msgid "Pictures"
+msgstr "圖片"
+
+#: ../panels/background/cc-background-chooser-dialog.c:481
+msgid "Colors"
+msgstr "顏色"
+
+#. translators: No pictures were found
+#: ../panels/background/cc-background-chooser-dialog.c:540
+msgid "No Pictures Found"
+msgstr "找不到圖片"
+
+#. translators: "Home" is used in place of the Pictures
+#. * directory in the string below when XDG_PICTURES_DIR is
+#. * undefined
+#: ../panels/background/cc-background-chooser-dialog.c:558
+#: ../panels/search/cc-search-locations-dialog.c:274
+msgid "Home"
+msgstr "家"
+
+#. translators: %s here is the name of the Pictures directory, the string should be translated in
+#. * the context "You can add images to your Pictures folder and they will show up here"
+#: ../panels/background/cc-background-chooser-dialog.c:570
+#, c-format
+msgid "You can add images to your %s folder and they will show up here"
+msgstr "你可以將影像加入你的%s資料夾，它們會顯示在這裏"
+
+#: ../panels/background/cc-background-chooser-dialog.c:592
+#: ../panels/color/cc-color-panel.c:224 ../panels/color/cc-color-panel.c:961
+#: ../panels/common/language-chooser.ui.h:3
+#: ../panels/display/cc-display-panel.c:1537
+#: ../panels/display/cc-display-panel.c:1976
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:2
+#: ../panels/network/connection-editor/vpn-helpers.c:245
+#: ../panels/network/connection-editor/vpn-helpers.c:374
+#: ../panels/network/net-device-wifi.c:1240
+#: ../panels/network/net-device-wifi.c:1448
+#: ../panels/printers/cc-printers-panel.c:1947
+#: ../panels/printers/new-printer-dialog.ui.h:2
+#: ../panels/privacy/cc-privacy-panel.c:468
+#: ../panels/region/format-chooser.ui.h:3
+#: ../panels/region/input-chooser.ui.h:2
+#: ../panels/search/cc-search-locations-dialog.c:681
+#: ../panels/sharing/cc-sharing-panel.c:491
+#: ../panels/user-accounts/data/account-dialog.ui.h:17
+#: ../panels/user-accounts/data/password-dialog.ui.h:2
+#: ../panels/user-accounts/um-fingerprint-dialog.c:267
+#: ../panels/user-accounts/um-photo-dialog.c:95
+#: ../panels/user-accounts/um-photo-dialog.c:222
+#: ../panels/user-accounts/um-user-panel.c:513
+msgid "_Cancel"
+msgstr "取消(_C)"
+
+#: ../panels/background/cc-background-chooser-dialog.c:593
+#: ../panels/printers/ppd-selection-dialog.ui.h:3
+#: ../panels/user-accounts/um-photo-dialog.c:97
+msgid "Select"
+msgstr "選取"
+
+#: ../panels/background/cc-background-item.c:197
+msgid "multiple sizes"
+msgstr "多重尺寸"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: ../panels/background/cc-background-item.c:201
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: ../panels/background/cc-background-item.c:327
+msgid "No Desktop Background"
+msgstr "無桌面背景"
+
+#: ../panels/background/cc-background-panel.c:493
+msgid "Current background"
+msgstr "目前的背景"
+
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:2
+msgid "Change your background image to a wallpaper or photo"
+msgstr "將你的背景影像更改為桌布或相片"
+
+#. Translators: those are keywords for the background control-center panel
+#: ../panels/background/gnome-background-panel.desktop.in.in.h:4
+msgid "Wallpaper;Screen;Desktop;"
+msgstr "Wallpaper;Screen;Desktop;桌布;螢幕;桌面;"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:262
+msgid "Bluetooth is disabled"
+msgstr "藍牙已停用"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:263
+msgid "No Bluetooth adapters found"
+msgstr "找不到藍牙接配器"
+
+#: ../panels/bluetooth/cc-bluetooth-panel.c:264
+msgid "Bluetooth is disabled by hardware switch"
+msgstr "藍牙已被硬件開關停用"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:1
+#: ../panels/printers/pp-new-printer-dialog.c:1688
+msgid "Bluetooth"
+msgstr "藍牙"
+
+#: ../panels/bluetooth/gnome-bluetooth-panel.desktop.in.in.h:2
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "開啟或關閉藍牙與連接你的裝置"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: ../panels/color/cc-color-calibrate.c:361
+msgid "Place your calibration device over the square and press 'Start'"
+msgstr "將你的校準裝置放在矩形上並按「開始」"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:367
+msgid ""
+"Move your calibration device to the calibrate position and press 'Continue'"
+msgstr "將你的校準裝置移到校準位置並按「繼續」"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: ../panels/color/cc-color-calibrate.c:373
+msgid ""
+"Move your calibration device to the surface position and press 'Continue'"
+msgstr "將你的校準裝置移到表面位置並按「繼續」"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: ../panels/color/cc-color-calibrate.c:379
+msgid "Shut the laptop lid"
+msgstr "關上手提電腦上蓋"
+
+#. TRANSLATORS: We suck, the calibation failed and we have no
+#. * good idea why or any suggestions
+#: ../panels/color/cc-color-calibrate.c:410
+msgid "An internal error occurred that could not be recovered."
+msgstr "發生內部的錯誤，無法復原。"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: ../panels/color/cc-color-calibrate.c:415
+msgid "Tools required for calibration are not installed."
+msgstr "校準所需的工具尚未安裝。"
+
+#. TRANSLATORS: The profile failed for some reason
+#: ../panels/color/cc-color-calibrate.c:421
+msgid "The profile could not be generated."
+msgstr "無法產生描述檔。"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: ../panels/color/cc-color-calibrate.c:427
+msgid "The target whitepoint was not obtainable."
+msgstr "尚無法獲取目標白點。"
+
+#. TRANSLATORS: the display calibration process is finished
+#: ../panels/color/cc-color-calibrate.c:467
+msgid "Complete!"
+msgstr "完成！"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: ../panels/color/cc-color-calibrate.c:475
+msgid "Calibration failed!"
+msgstr "校準已失敗！"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: ../panels/color/cc-color-calibrate.c:482
+msgid "You can remove the calibration device."
+msgstr "你可以移除校準裝置。"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: ../panels/color/cc-color-calibrate.c:553
+msgid "Do not disturb the calibration device while in progress"
+msgstr "過程中請勿干擾校準裝置"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: ../panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "手提電腦螢幕"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: ../panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "內置網絡攝影機"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: ../panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s 顯示器"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: ../panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s 掃描器"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: ../panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s 照相機"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: ../panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s 打印機"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: ../panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s 網絡攝影機"
+
+#: ../panels/color/cc-color-device.c:89
+#, c-format
+msgid "Enable color management for %s"
+msgstr "啟用 %s 的顏色管理"
+
+#: ../panels/color/cc-color-device.c:93
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "顯示 %s 的顏色描述檔"
+
+#. not calibrated
+#: ../panels/color/cc-color-device.c:322
+msgid "Not calibrated"
+msgstr "尚未校準"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: ../panels/color/cc-color-panel.c:140
+msgid "Default: "
+msgstr "預設值："
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: ../panels/color/cc-color-panel.c:148
+msgid "Colorspace: "
+msgstr "色彩空間："
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: ../panels/color/cc-color-panel.c:155
+msgid "Test profile: "
+msgstr "測試描述檔："
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: ../panels/color/cc-color-panel.c:222
+msgid "Select ICC Profile File"
+msgstr "選擇 ICC 色彩描述檔"
+
+#: ../panels/color/cc-color-panel.c:225
+msgid "_Import"
+msgstr "匯入(_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:236
+msgid "Supported ICC profiles"
+msgstr "支援的 ICC 色彩描述檔"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: ../panels/color/cc-color-panel.c:243
+#: ../panels/network/wireless-security/eap-method-fast.c:420
+msgid "All files"
+msgstr "所有檔案"
+
+#: ../panels/color/cc-color-panel.c:582
+msgid "Screen"
+msgstr "螢幕"
+
+#. TRANSLATORS: this is when the upload of the profile failed
+#: ../panels/color/cc-color-panel.c:906
+#, c-format
+msgid "Failed to upload file: %s"
+msgstr "上傳檔案失敗：%s"
+
+#. TRANSLATORS: these are instructions on how to recover
+#. * the ICC profile on the native operating system and are
+#. * only shown when the user uses a LiveCD to calibrate
+#: ../panels/color/cc-color-panel.c:920
+msgid "The profile has been uploaded to:"
+msgstr "描述檔已經上傳到："
+
+#: ../panels/color/cc-color-panel.c:922
+msgid "Write down this URL."
+msgstr "寫下這個 URL。"
+
+#: ../panels/color/cc-color-panel.c:923
+msgid "Restart this computer and boot your normal operating system."
+msgstr "重新啟動這臺電腦並開機進入你一般的作業系統。"
+
+#: ../panels/color/cc-color-panel.c:924
+msgid "Type the URL into your browser to download and install the profile."
+msgstr "在你的瀏覽器中輸入 URL 以下載並安裝描述檔。"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: ../panels/color/cc-color-panel.c:958
+msgid "Save Profile"
+msgstr "儲存描述檔"
+
+#: ../panels/color/cc-color-panel.c:962
+#: ../panels/network/connection-editor/vpn-helpers.c:375
+msgid "_Save"
+msgstr "儲存(_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: ../panels/color/cc-color-panel.c:1322
+msgid "Create a color profile for the selected device"
+msgstr "為已選取裝置建立色彩描述檔"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1337 ../panels/color/cc-color-panel.c:1361
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "尚未偵測到測量儀器。請檢查它是否已開啟並正確的連接。"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1371
+msgid "The measuring instrument does not support printer profiling."
+msgstr "測量儀器不支援打印機的分析。"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: ../panels/color/cc-color-panel.c:1382
+msgid "The device type is not currently supported."
+msgstr "目刖不支援這個裝置類型。"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: ../panels/color/cc-color-profile.c:103
+msgid "Standard Space"
+msgstr "標準空間"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: ../panels/color/cc-color-profile.c:109
+msgid "Test Profile"
+msgstr "測試描述檔"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: ../panels/color/cc-color-profile.c:117
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "自動"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: ../panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "低品質"
+
+#. TRANSLATORS: the profile quality
+#: ../panels/color/cc-color-profile.c:132
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "中品質"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: ../panels/color/cc-color-profile.c:139
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "高品質"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:156
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "預設 RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:163
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "預設 CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: ../panels/color/cc-color-profile.c:170
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "預設灰階"
+
+#: ../panels/color/cc-color-profile.c:194
+msgid "Vendor supplied factory calibration data"
+msgstr "廠商提供的出廠校準資料"
+
+#: ../panels/color/cc-color-profile.c:203
+msgid "Full-screen display correction not possible with this profile"
+msgstr "這個描述檔無法使用全螢幕顯示校正"
+
+#: ../panels/color/cc-color-profile.c:225
+msgid "This profile may no longer be accurate"
+msgstr "這個描述檔可能不再準確"
+
+#: ../panels/color/color-calibrate.ui.h:1
+msgid "Display Calibration"
+msgstr "顯示校準"
+
+#: ../panels/color/color-calibrate.ui.h:2
+#: ../panels/printers/authentication-dialog.ui.h:2
+#: ../panels/printers/ppd-selection-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-dialog.c:1468
+msgid "Cancel"
+msgstr "取消"
+
+#. This starts the calibration process
+#: ../panels/color/color-calibrate.ui.h:4
+msgid "Start"
+msgstr "開始"
+
+#. This resumes the calibration process
+#: ../panels/color/color-calibrate.ui.h:6
+msgid "Resume"
+msgstr "繼續"
+
+#. This button returns the user back to the color control panel
+#: ../panels/color/color-calibrate.ui.h:8
+msgid "Done"
+msgstr "完成"
+
+#. Timeout parameters
+#. 15000 = 15 sec
+#. 750 = 0.75 sec
+#. Text printed on screen
+#: ../panels/color/color.ui.h:1 ../panels/wacom/calibrator/calibrator-gui.c:82
+msgid "Screen Calibration"
+msgstr "螢幕校準"
+
+#: ../panels/color/color.ui.h:2
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr "校準動作會產生描述檔讓你可以用來管理螢幕的顏色。你花在校準的時間愈長，顏色描述檔的品質就愈好。"
+
+#: ../panels/color/color.ui.h:3
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "當校準在進行時將不能使用你的電腦。"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:5
+msgid "Quality"
+msgstr "品質"
+
+#. This is the approximate time it takes to calibrate the display.
+#: ../panels/color/color.ui.h:7
+msgid "Approximate Time"
+msgstr "大約時間"
+
+#: ../panels/color/color.ui.h:8
+msgid "Calibration Quality"
+msgstr "校準品質"
+
+#: ../panels/color/color.ui.h:9
+msgid "Select the sensor device you want to use for calibration."
+msgstr "選擇你想要使用的校準偵測裝置。"
+
+#: ../panels/color/color.ui.h:10
+msgid "Calibration Device"
+msgstr "校準裝置"
+
+#: ../panels/color/color.ui.h:11
+msgid "Select the type of display that is connected."
+msgstr "選擇連接的顯示器類型。"
+
+#: ../panels/color/color.ui.h:12
+msgid "Display Type"
+msgstr "顯示類型"
+
+#: ../panels/color/color.ui.h:13
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr "選擇一個顯示目標白點。大多數顯示器應該校準到 D65 光源。"
+
+#: ../panels/color/color.ui.h:14
+msgid "Profile Whitepoint"
+msgstr "描述檔白點"
+
+#: ../panels/color/color.ui.h:15
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr "請將顯示器的亮度設定為你常用的狀態。顏色管理會以這個亮度等級調整到最正確。"
+
+#: ../panels/color/color.ui.h:16
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr "或者，你可以使用這個裝置的其他描述檔所適用的亮度等級。"
+
+#: ../panels/color/color.ui.h:17
+msgid "Display Brightness"
+msgstr "顯示亮度"
+
+#: ../panels/color/color.ui.h:18
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr "你可以在不同電腦上使用顏色描述檔，或是為了不同的亮度條件建立描述檔。"
+
+#: ../panels/color/color.ui.h:19
+msgid "Profile Name:"
+msgstr "描述檔名稱："
+
+#: ../panels/color/color.ui.h:20
+msgid "Profile Name"
+msgstr "描述檔名稱"
+
+#: ../panels/color/color.ui.h:21
+msgid "Profile successfully created!"
+msgstr "描述檔製作成功！"
+
+#: ../panels/color/color.ui.h:22
+msgid "Copy profile"
+msgstr "複製描述檔"
+
+#: ../panels/color/color.ui.h:23
+msgid "Requires writable media"
+msgstr "需要可寫入媒體"
+
+#: ../panels/color/color.ui.h:24
+msgid "Upload profile"
+msgstr "上傳描述檔"
+
+#: ../panels/color/color.ui.h:25
+msgid "Requires Internet connection"
+msgstr "需要互聯網連線"
+
+#: ../panels/color/color.ui.h:26
+msgid ""
+"You may find these instructions on how to use the profile on <a href=\"linux"
+"\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a href=\"windows"
+"\">Microsoft Windows</a> systems useful."
+msgstr "你可以找到如何在 <a href=\"linux\">GNU/Linux</a>、<a href=\"osx\">Apple OS X</a> 和 <a href=\"windows\">Microsoft Windows</a> 系統上使用描述檔的指引。"
+
+#: ../panels/color/color.ui.h:27
+#: ../panels/user-accounts/um-fingerprint-dialog.c:740
+msgid "Summary"
+msgstr "摘要"
+
+#: ../panels/color/color.ui.h:28
+msgid "Import File…"
+msgstr "載入檔案…"
+
+#: ../panels/color/color.ui.h:29
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr "偵測到問題。描述檔可能無法正常運作。<a href=\"\">顯示詳細資料。</a>"
+
+#: ../panels/color/color.ui.h:30
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "每個裝置需要最新的色彩描述檔才能被管理顏色。"
+
+#: ../panels/color/color.ui.h:31
+msgid "Learn more"
+msgstr "了解更多"
+
+#: ../panels/color/color.ui.h:32
+msgid "Learn more about color management"
+msgstr "了解更多關於顏色管理的資訊"
+
+#: ../panels/color/color.ui.h:33
+msgid "Set for all users"
+msgstr "所有使用者皆可用"
+
+#: ../panels/color/color.ui.h:34
+msgid "Set this profile for all users on this computer"
+msgstr "將這個描述檔給電腦上所有使用者"
+
+#: ../panels/color/color.ui.h:35
+msgid "Enable"
+msgstr "啟用"
+
+#: ../panels/color/color.ui.h:36
+msgid "Add profile"
+msgstr "加入描述檔"
+
+#: ../panels/color/color.ui.h:37
+#: ../panels/wacom/gnome-wacom-properties.ui.h:10
+msgid "Calibrate…"
+msgstr "校準…"
+
+#: ../panels/color/color.ui.h:38
+msgid "Calibrate the device"
+msgstr "校準裝置"
+
+#: ../panels/color/color.ui.h:39
+msgid "Remove profile"
+msgstr "移除描述檔"
+
+#: ../panels/color/color.ui.h:40
+msgid "View details"
+msgstr "檢視詳細資料"
+
+#: ../panels/color/color.ui.h:41
+msgid "Unable to detect any devices that can be color managed"
+msgstr "無法偵測到任何能被管理顏色的裝置"
+
+#: ../panels/color/color.ui.h:42
+msgid "LCD"
+msgstr "LCD"
+
+#: ../panels/color/color.ui.h:43
+msgid "LED"
+msgstr "LED"
+
+#: ../panels/color/color.ui.h:44
+msgid "CRT"
+msgstr "CRT"
+
+#: ../panels/color/color.ui.h:45
+msgid "Projector"
+msgstr "投影機"
+
+#: ../panels/color/color.ui.h:46
+msgid "Plasma"
+msgstr "等離子"
+
+#: ../panels/color/color.ui.h:47
+msgid "LCD (CCFL backlight)"
+msgstr "LCD (CCFL 背光)"
+
+#: ../panels/color/color.ui.h:48
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD (RGB LED 背光)"
+
+#: ../panels/color/color.ui.h:49
+msgid "LCD (white LED backlight)"
+msgstr "LCD (白色 LED 背光)"
+
+#: ../panels/color/color.ui.h:50
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "廣色域 LCD (CCFL 背光)"
+
+#: ../panels/color/color.ui.h:51
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "廣色域 LCD (RGB LED 背光)"
+
+#: ../panels/color/color.ui.h:52
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "高"
+
+#: ../panels/color/color.ui.h:53
+msgid "40 minutes"
+msgstr "40 分鐘"
+
+#: ../panels/color/color.ui.h:54
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "中"
+
+#: ../panels/color/color.ui.h:55 ../panels/power/power.ui.h:4
+#: ../panels/privacy/privacy.ui.h:7
+msgid "30 minutes"
+msgstr "30 分鐘"
+
+#: ../panels/color/color.ui.h:56
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "低"
+
+#: ../panels/color/color.ui.h:57 ../panels/power/power.ui.h:3
+msgid "15 minutes"
+msgstr "15 分鐘"
+
+#: ../panels/color/color.ui.h:58
+msgid "Native to display"
+msgstr "原生顯示"
+
+#: ../panels/color/color.ui.h:59
+msgid "D50 (Printing and publishing)"
+msgstr "D50 (列印與出版)"
+
+#: ../panels/color/color.ui.h:60
+msgid "D55"
+msgstr "D55"
+
+#: ../panels/color/color.ui.h:61
+msgid "D65 (Photography and graphics)"
+msgstr "D65 (攝影與繪圖)"
+
+#: ../panels/color/color.ui.h:62
+msgid "D75"
+msgstr "D75"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:1
+msgid "Color"
+msgstr "顏色"
+
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:2
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "校準你裝置的顏色，像是顯示器、攝影機或打印機"
+
+#. Translators: those are keywords for the color control-center panel
+#: ../panels/color/gnome-color-panel.desktop.in.in.h:4
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr "Color;ICC;Profile;Calibrate;Printer;Display;顏色;色彩描述檔;校準;打印機;顯示器;"
+
+#. Add some common regions
+#: ../panels/common/cc-common-language.c:684
+msgid "United States"
+msgstr "美國"
+
+#: ../panels/common/cc-common-language.c:685
+msgid "Germany"
+msgstr "德國"
+
+#: ../panels/common/cc-common-language.c:686
+msgid "France"
+msgstr "法國"
+
+#: ../panels/common/cc-common-language.c:687
+msgid "Spain"
+msgstr "西班牙"
+
+#: ../panels/common/cc-common-language.c:688
+msgid "China"
+msgstr "中國"
+
+#: ../panels/common/cc-common-language.c:758
+msgid "Other…"
+msgstr "其他…"
+
+#: ../panels/common/cc-language-chooser.c:123
+#: ../panels/region/cc-format-chooser.c:267
+#: ../panels/region/cc-input-chooser.c:165
+msgid "More…"
+msgstr "更多…"
+
+#: ../panels/common/cc-language-chooser.c:140
+msgid "No languages found"
+msgstr "找不到語言"
+
+#: ../panels/common/language-chooser.ui.h:1 ../panels/region/region.ui.h:1
+msgid "Language"
+msgstr "語言"
+
+#: ../panels/common/language-chooser.ui.h:2
+#: ../panels/region/format-chooser.ui.h:2
+msgid "_Done"
+msgstr "完成(_D)"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:340
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%Y年%b%e日, %p %l:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:345
+msgid "%e %B %Y, %R"
+msgstr "%Y年%b%e日，%R"
+
+#. Translators: "city, country"
+#: ../panels/datetime/cc-datetime-panel.c:523
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s，%s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: ../panels/datetime/cc-datetime-panel.c:553
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: ../panels/datetime/cc-datetime-panel.c:561
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:566
+msgid "%l:%M %p"
+msgstr "%p %l:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: ../panels/datetime/cc-datetime-panel.c:571
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: ../panels/datetime/cc-datetime-panel.c:576
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+#: ../panels/datetime/datetime.ui.h:1
+msgid "January"
+msgstr "一月"
+
+#: ../panels/datetime/datetime.ui.h:2
+msgid "February"
+msgstr "二月"
+
+#: ../panels/datetime/datetime.ui.h:3
+msgid "March"
+msgstr "三月"
+
+#: ../panels/datetime/datetime.ui.h:4
+msgid "April"
+msgstr "四月"
+
+#: ../panels/datetime/datetime.ui.h:5
+msgid "May"
+msgstr "五月"
+
+#: ../panels/datetime/datetime.ui.h:6
+msgid "June"
+msgstr "六月"
+
+#: ../panels/datetime/datetime.ui.h:7
+msgid "July"
+msgstr "七月"
+
+#: ../panels/datetime/datetime.ui.h:8
+msgid "August"
+msgstr "八月"
+
+#: ../panels/datetime/datetime.ui.h:9
+msgid "September"
+msgstr "九月"
+
+#: ../panels/datetime/datetime.ui.h:10
+msgid "October"
+msgstr "十月"
+
+#: ../panels/datetime/datetime.ui.h:11
+msgid "November"
+msgstr "十一月"
+
+#: ../panels/datetime/datetime.ui.h:12
+msgid "December"
+msgstr "十二月"
+
+#: ../panels/datetime/datetime.ui.h:13
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:1
+msgid "Date & Time"
+msgstr "日期與時刻"
+
+#: ../panels/datetime/datetime.ui.h:14
+msgid "Hour"
+msgstr "時"
+
+#. Translator: this is the separator between hours and minutes, like in HH∶MM
+#: ../panels/datetime/datetime.ui.h:16
+msgid "∶"
+msgstr "∶"
+
+#: ../panels/datetime/datetime.ui.h:17
+msgid "Minute"
+msgstr "分"
+
+#: ../panels/datetime/datetime.ui.h:18
+msgid "Day"
+msgstr "日"
+
+#: ../panels/datetime/datetime.ui.h:19
+msgid "Month"
+msgstr "月"
+
+#: ../panels/datetime/datetime.ui.h:20
+msgid "Year"
+msgstr "年"
+
+#: ../panels/datetime/datetime.ui.h:21
+msgid "Time Zone"
+msgstr "時區"
+
+#: ../panels/datetime/datetime.ui.h:22
+msgid "Search for a city"
+msgstr "搜尋城市"
+
+#: ../panels/datetime/datetime.ui.h:23
+msgid "Automatic _Date & Time"
+msgstr "自動調整日期與時刻(_D)"
+
+#: ../panels/datetime/datetime.ui.h:24
+msgid "Requires internet access"
+msgstr "需要互聯網連線"
+
+#: ../panels/datetime/datetime.ui.h:25
+msgid "Automatic Time _Zone"
+msgstr "自動調整時區(_Z)"
+
+#: ../panels/datetime/datetime.ui.h:26
+msgid "Date & _Time"
+msgstr "日期與時刻(_T)"
+
+#: ../panels/datetime/datetime.ui.h:27
+msgid "Time _Zone"
+msgstr "時區(_Z)"
+
+#: ../panels/datetime/datetime.ui.h:28
+msgid "Time _Format"
+msgstr "時刻格式(_F)"
+
+#: ../panels/datetime/datetime.ui.h:29
+msgid "24-hour"
+msgstr "24小時"
+
+#: ../panels/datetime/datetime.ui.h:30
+msgid "AM / PM"
+msgstr "AM / PM"
+
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:2
+msgid "Change the date and time, including time zone"
+msgstr "改變時刻與日期，包含時區"
+
+#. Translators: those are keywords for the date and time control-center panel
+#: ../panels/datetime/gnome-datetime-panel.desktop.in.in.h:4
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;時鐘;時區;位置;"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:1
+msgid "Change system time and date settings"
+msgstr "改變系統時刻與日期設定值"
+
+#: ../panels/datetime/org.gnome.controlcenter.datetime.policy.in.h:2
+msgid "To change time or date settings, you need to authenticate."
+msgstr "要改變時刻或日期設定值，你需要通過核對。"
+
+#: ../panels/display/cc-display-panel.c:487
+msgid "Lid Closed"
+msgstr "上蓋已經關閉"
+
+#. translators: "Mirrored" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:490
+msgid "Mirrored"
+msgstr "鏡射顯示器"
+
+#: ../panels/display/cc-display-panel.c:492
+#: ../panels/display/cc-display-panel.c:2145
+msgid "Primary"
+msgstr "主要"
+
+#: ../panels/display/cc-display-panel.c:494
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1684 ../panels/power/cc-power-panel.c:1695
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+#: ../panels/universal-access/uap.ui.h:6
+msgid "Off"
+msgstr "關閉"
+
+#: ../panels/display/cc-display-panel.c:497
+msgid "Secondary"
+msgstr "次要"
+
+#: ../panels/display/cc-display-panel.c:1533
+msgid "Arrange Combined Displays"
+msgstr "排列顯示器的組合方式"
+
+#: ../panels/display/cc-display-panel.c:1539
+#: ../panels/display/cc-display-panel.c:1979
+#: ../panels/network/connection-editor/connection-editor.ui.h:1
+msgid "_Apply"
+msgstr "套用(_A)"
+
+#: ../panels/display/cc-display-panel.c:1560
+msgid "Drag displays to rearrange them"
+msgstr "拖拉顯示器以重新排列他們"
+
+#: ../panels/display/cc-display-panel.c:2081
+msgid "Size"
+msgstr "尺寸"
+
+#. aspect ratio
+#: ../panels/display/cc-display-panel.c:2094
+msgid "Aspect Ratio"
+msgstr "長寬比"
+
+#: ../panels/display/cc-display-panel.c:2115
+#: ../panels/printers/pp-options-dialog.c:85
+msgid "Resolution"
+msgstr "解像度"
+
+#: ../panels/display/cc-display-panel.c:2146
+msgid "Show the top bar and Activities Overview on this display"
+msgstr "在這個顯示器顯示頂端列與活動概覽"
+
+#: ../panels/display/cc-display-panel.c:2152
+msgid "Secondary Display"
+msgstr "次要顯示器"
+
+#: ../panels/display/cc-display-panel.c:2153
+msgid "Join this display with another to create an extra workspace"
+msgstr "將這個顯示器與另一個顯示器結合以建立額外的工作區"
+
+#: ../panels/display/cc-display-panel.c:2160
+msgid "Presentation"
+msgstr "展示"
+
+#: ../panels/display/cc-display-panel.c:2161
+msgid "Show slideshows and media only"
+msgstr "只顯示投影片與媒體"
+
+#. translators: "Mirror" describes when both displays show the same view
+#: ../panels/display/cc-display-panel.c:2166
+msgid "Mirror"
+msgstr "鏡射"
+
+#: ../panels/display/cc-display-panel.c:2167
+msgid "Show your existing view on both displays"
+msgstr "在兩個顯示器顯示你現有的檢視"
+
+#: ../panels/display/cc-display-panel.c:2173
+msgid "Turn Off"
+msgstr "關閉"
+
+#: ../panels/display/cc-display-panel.c:2174
+msgid "Don't use this display"
+msgstr "不使用這個顯示器"
+
+#: ../panels/display/cc-display-panel.c:2383
+msgid "Could not get screen information"
+msgstr "無法取得螢幕資訊"
+
+#: ../panels/display/cc-display-panel.c:2414
+msgid "_Arrange Combined Displays"
+msgstr "排列組合的顯示器(_A)"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:1
+msgid "Displays"
+msgstr "顯示器"
+
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:2
+msgid "Choose how to use connected monitors and projectors"
+msgstr "選擇如何使用連接的顯示器和投影機"
+
+#. Translators: those are keywords for the display control-center panel
+#: ../panels/display/gnome-display-panel.desktop.in.in.h:4
+msgid "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;"
+msgstr "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;面板;投影機;螢幕;解像度;重新整理;螢幕;"
+
+#: ../panels/info/cc-info-panel.c:384
+msgid "Wayland"
+msgstr "Wayland"
+
+#. TRANSLATORS: AP type
+#: ../panels/info/cc-info-panel.c:387 ../panels/network/panel-common.c:127
+msgid "Unknown"
+msgstr "不明"
+
+#: ../panels/info/cc-info-panel.c:472
+#, c-format
+msgid "%s %d-bit"
+msgstr "%s %d 位元"
+
+#: ../panels/info/cc-info-panel.c:474
+#, c-format
+msgid "%d-bit"
+msgstr "%d 位元"
+
+#: ../panels/info/cc-info-panel.c:1154
+msgid "Ask what to do"
+msgstr "詢問要做什麼"
+
+#: ../panels/info/cc-info-panel.c:1158
+msgid "Do nothing"
+msgstr "不做任何事"
+
+#: ../panels/info/cc-info-panel.c:1162
+msgid "Open folder"
+msgstr "開啟資料夾"
+
+#: ../panels/info/cc-info-panel.c:1253
+msgid "Other Media"
+msgstr "其他媒體"
+
+#: ../panels/info/cc-info-panel.c:1284
+msgid "Select an application for audio CDs"
+msgstr "選擇播放音樂 CD 的應用程式"
+
+#: ../panels/info/cc-info-panel.c:1285
+msgid "Select an application for video DVDs"
+msgstr "選擇播放影片 DVD 的應用程式"
+
+#: ../panels/info/cc-info-panel.c:1286
+msgid "Select an application to run when a music player is connected"
+msgstr "選擇當音樂播放器連接時要執行的應用程式"
+
+#: ../panels/info/cc-info-panel.c:1287
+msgid "Select an application to run when a camera is connected"
+msgstr "選擇當攝影機連接時要執行的應用程式"
+
+#: ../panels/info/cc-info-panel.c:1288
+msgid "Select an application for software CDs"
+msgstr "選擇軟件 CD 要用的應用程式"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: ../panels/info/cc-info-panel.c:1300
+msgid "audio DVD"
+msgstr "音樂 DVD"
+
+#: ../panels/info/cc-info-panel.c:1301
+msgid "blank Blu-ray disc"
+msgstr "空白 Blu-ray 光碟"
+
+#: ../panels/info/cc-info-panel.c:1302
+msgid "blank CD disc"
+msgstr "空白 CD 光碟"
+
+#: ../panels/info/cc-info-panel.c:1303
+msgid "blank DVD disc"
+msgstr "空白 DVD 光碟"
+
+#: ../panels/info/cc-info-panel.c:1304
+msgid "blank HD DVD disc"
+msgstr "空白 HD DVD 光碟"
+
+#: ../panels/info/cc-info-panel.c:1305
+msgid "Blu-ray video disc"
+msgstr "Blu-Ray 影片光碟"
+
+#: ../panels/info/cc-info-panel.c:1306
+msgid "e-book reader"
+msgstr "電子書閱讀器"
+
+#: ../panels/info/cc-info-panel.c:1307
+msgid "HD DVD video disc"
+msgstr "HD DVD 影片光碟"
+
+#: ../panels/info/cc-info-panel.c:1308
+msgid "Picture CD"
+msgstr "照片 CD"
+
+#: ../panels/info/cc-info-panel.c:1309
+msgid "Super Video CD"
+msgstr "SVCD"
+
+#: ../panels/info/cc-info-panel.c:1310
+msgid "Video CD"
+msgstr "影片 CD"
+
+#: ../panels/info/cc-info-panel.c:1311
+msgid "Windows software"
+msgstr "Windows 軟件"
+
+#: ../panels/info/cc-info-panel.c:1434
+#: ../panels/keyboard/keyboard-shortcuts.c:1917
+msgid "Section"
+msgstr "節"
+
+#: ../panels/info/cc-info-panel.c:1443 ../panels/info/info.ui.h:14
+msgid "Overview"
+msgstr "概覽"
+
+#: ../panels/info/cc-info-panel.c:1449 ../panels/info/info.ui.h:21
+msgid "Default Applications"
+msgstr "預設應用程式"
+
+#: ../panels/info/cc-info-panel.c:1454 ../panels/info/info.ui.h:29
+msgid "Removable Media"
+msgstr "可移除式媒體"
+
+#: ../panels/info/cc-info-panel.c:1479
+#, c-format
+msgid "Version %s"
+msgstr "版本 %s"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:1
+#: ../panels/network/connection-editor/ce-page-details.c:240
+#: ../panels/network/network-wifi.ui.h:44
+msgid "Details"
+msgstr "詳細資料"
+
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:2
+msgid "View information about your system"
+msgstr "檢視你系統的資訊"
+
+#. sure that you use the same "translation" for those keywords
+#: ../panels/info/gnome-info-panel.desktop.in.in.h:4
+msgid ""
+"device;system;information;memory;processor;version;default;application;"
+"preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr "device;system;information;memory;processor;version;default;application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;裝置;系統;資訊;記憶體;處理器;版本;預設;應用程式;首選;音訊;視像;光碟;可移除;媒體;自動執行;"
+
+#: ../panels/info/info.ui.h:1
+msgid "Select how other media should be handled"
+msgstr "選擇要如何處理其他媒體"
+
+#: ../panels/info/info.ui.h:2
+msgid "_Action:"
+msgstr "動作(_A):"
+
+#: ../panels/info/info.ui.h:3
+msgid "_Type:"
+msgstr "類型(_T)："
+
+#: ../panels/info/info.ui.h:4
+msgid "Device name"
+msgstr "裝置名稱"
+
+#: ../panels/info/info.ui.h:5
+msgid "Memory"
+msgstr "記憶體"
+
+#: ../panels/info/info.ui.h:6
+msgid "Processor"
+msgstr "處理器"
+
+#. To translators: this field contains the distro name, version and type
+#: ../panels/info/info.ui.h:8
+msgid "Base system"
+msgstr "基礎系統"
+
+#: ../panels/info/info.ui.h:9
+msgid "Disk"
+msgstr "磁碟"
+
+#: ../panels/info/info.ui.h:10
+msgid "Calculating…"
+msgstr "正在計算…"
+
+#: ../panels/info/info.ui.h:11
+msgid "Graphics"
+msgstr "繪圖"
+
+#: ../panels/info/info.ui.h:12
+msgid "Virtualization"
+msgstr "虛擬化"
+
+#: ../panels/info/info.ui.h:13
+msgid "Check for updates"
+msgstr "檢查更新"
+
+#: ../panels/info/info.ui.h:15
+msgid "_Web"
+msgstr "網頁(_W)"
+
+#: ../panels/info/info.ui.h:16
+msgid "_Mail"
+msgstr "郵件(_M)"
+
+#: ../panels/info/info.ui.h:17
+msgid "_Calendar"
+msgstr "日曆(_C)"
+
+#: ../panels/info/info.ui.h:18
+msgid "M_usic"
+msgstr "音樂(_U)"
+
+#: ../panels/info/info.ui.h:19
+msgid "_Video"
+msgstr "影片(_V)"
+
+#: ../panels/info/info.ui.h:20
+msgid "_Photos"
+msgstr "相片(_P)"
+
+#: ../panels/info/info.ui.h:22
+msgid "Select how media should be handled"
+msgstr "選擇要如何處理媒體"
+
+#: ../panels/info/info.ui.h:23
+msgid "CD _audio"
+msgstr "CD 音樂(_A)"
+
+#: ../panels/info/info.ui.h:24
+msgid "_DVD video"
+msgstr "_DVD 影片"
+
+#: ../panels/info/info.ui.h:25
+msgid "_Music player"
+msgstr "音樂播放器(_M)"
+
+#: ../panels/info/info.ui.h:26
+msgid "_Software"
+msgstr "軟件(_S)"
+
+#: ../panels/info/info.ui.h:27
+msgid "_Other Media…"
+msgstr "其他(_O)…"
+
+#: ../panels/info/info.ui.h:28
+msgid "_Never prompt or start programs on media insertion"
+msgstr "插入媒體時永遠不提示或啟動程式(_N)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:1
+msgid "Sound and Media"
+msgstr "聲音與媒體"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:2
+msgid "Volume mute"
+msgstr "靜音"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:3
+msgid "Volume down"
+msgstr "調低音量"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:4
+msgid "Volume up"
+msgstr "調高音量"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:5
+msgid "Launch media player"
+msgstr "執行媒體播放程式"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:6
+msgid "Play (or play/pause)"
+msgstr "播放 (或播放/暫停)"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:7
+msgid "Pause playback"
+msgstr "暫停播放"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:8
+msgid "Stop playback"
+msgstr "停止播放"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:9
+msgid "Previous track"
+msgstr "上一首歌曲"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:10
+msgid "Next track"
+msgstr "下一首歌曲"
+
+#: ../panels/keyboard/00-multimedia.xml.in.h:11
+msgid "Eject"
+msgstr "退出"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:1
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:20
+#: ../panels/universal-access/uap.ui.h:11
+msgid "Typing"
+msgstr "輸入"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:2
+msgid "Switch to next input source"
+msgstr "切換到下一個輸入來源"
+
+#: ../panels/keyboard/01-input-sources.xml.in.h:3
+msgid "Switch to previous input source"
+msgstr "切換到上一個輸入來源"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:1
+msgid "Launchers"
+msgstr "執行器"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:2
+msgid "Launch help browser"
+msgstr "執行說明文件瀏覽器"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:3 ../shell/cc-window.c:1601
+#: ../shell/gnome-control-center.desktop.in.in.h:1
+msgid "Settings"
+msgstr "設定值"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:4
+msgid "Launch calculator"
+msgstr "執行計數機"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:5
+msgid "Launch email client"
+msgstr "執行電子郵件客戶端"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:6
+msgid "Launch web browser"
+msgstr "執行網頁瀏覽器"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:7
+msgid "Home folder"
+msgstr "家目錄"
+
+#: ../panels/keyboard/01-launchers.xml.in.h:8
+msgctxt "keybinding"
+msgid "Search"
+msgstr "搜尋"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:1
+msgid "Screenshots"
+msgstr "螢幕擷圖"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:3
+msgid "Save a screenshot to $PICTURES"
+msgstr "將螢幕擷圖儲存為 $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:5
+msgid "Save a screenshot of a window to $PICTURES"
+msgstr "將視窗的螢幕擷圖儲存為 $PICTURES"
+
+#. translators: $PICTURES will be replaced by the name of the XDG Pictures directory
+#: ../panels/keyboard/01-screenshot.xml.in.h:7
+msgid "Save a screenshot of an area to $PICTURES"
+msgstr "將區域的螢幕擷圖儲存為 $PICTURES"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:8
+msgid "Copy a screenshot to clipboard"
+msgstr "將螢幕截圖複製到剪貼簿"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:9
+msgid "Copy a screenshot of a window to clipboard"
+msgstr "將視窗的螢幕截圖複製到剪貼簿"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:10
+msgid "Copy a screenshot of an area to clipboard"
+msgstr "將區域的螢幕截圖複製到剪貼簿"
+
+#: ../panels/keyboard/01-screenshot.xml.in.h:11
+msgid "Record a short screencast"
+msgstr "錄製短式螢幕廣播"
+
+#: ../panels/keyboard/01-system.xml.in.h:1
+msgid "System"
+msgstr "系統"
+
+#: ../panels/keyboard/01-system.xml.in.h:2
+msgid "Log out"
+msgstr "登出"
+
+#: ../panels/keyboard/01-system.xml.in.h:3
+msgid "Lock screen"
+msgstr "鎖定畫面"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:1
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:1
+msgid "Universal Access"
+msgstr "無障礙功能"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:2
+msgid "Turn zoom on or off"
+msgstr "開啟或關閉放大鏡"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:3
+msgid "Zoom in"
+msgstr "拉近"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:4
+msgid "Zoom out"
+msgstr "拉遠"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:5
+msgid "Turn screen reader on or off"
+msgstr "開啟或關閉螢幕閱讀器"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:6
+msgid "Turn on-screen keyboard on or off"
+msgstr "開啟或關閉螢幕鍵盤"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:7
+msgid "Increase text size"
+msgstr "將文字放大"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:8
+msgid "Decrease text size"
+msgstr "將文字縮小"
+
+#: ../panels/keyboard/50-accessibility.xml.in.h:9
+msgid "High contrast on or off"
+msgstr "高對比開或關"
+
+#. translators:
+#. * The device has been disabled
+#: ../panels/keyboard/cc-keyboard-option.c:276
+#: ../panels/keyboard/cc-keyboard-option.c:395
+#: ../panels/keyboard/keyboard-shortcuts.c:1217
+#: ../panels/network/network-wifi.ui.h:29
+#: ../panels/sound/gvc/gvc-mixer-control.c:1830
+#: ../panels/user-accounts/um-fingerprint-dialog.c:213
+#: ../panels/user-accounts/um-fingerprint-dialog.c:214
+msgid "Disabled"
+msgstr "已停用"
+
+#. Translators: This key is also known as 'third level
+#. * chooser'. AltGr is often used for this purpose. See
+#. * https://live.gnome.org/Design/SystemSettings/RegionAndLanguage
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:354
+msgid "Alternative Characters Key"
+msgstr "替代的字符鍵"
+
+#. Translators: The Compose key is used to initiate key
+#. * sequences that are combined to form a single character.
+#. * See http://en.wikipedia.org/wiki/Compose_key
+#.
+#: ../panels/keyboard/cc-keyboard-option.c:363
+msgid "Compose Key"
+msgstr "組合鍵"
+
+#: ../panels/keyboard/cc-keyboard-option.c:368
+msgid "Modifiers-only switch to next source"
+msgstr "只以修飾鍵切換至下個來源"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "鍵盤"
+
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:2
+msgid "View and change keyboard shortcuts and set your typing preferences"
+msgstr "檢視與更改鍵盤捷徑鍵並設定你的輸入偏好設定"
+
+#. Translators: those are keywords for the keyboard control-center panel
+#: ../panels/keyboard/gnome-keyboard-panel.desktop.in.in.h:4
+msgid "Shortcut;Repeat;Blink;"
+msgstr "Shortcut;Repeat;Blink;捷徑鍵;重複;閃爍;"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:1
+msgid "Custom Shortcut"
+msgstr "自選捷徑鍵"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:3
+#: ../panels/network/connection-editor/net-connection-editor.c:512
+#: ../panels/printers/new-printer-dialog.ui.h:3
+#: ../panels/region/input-chooser.ui.h:3
+#: ../panels/user-accounts/um-account-dialog.c:1469
+msgid "_Add"
+msgstr "加入(_A)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:4
+msgid "_Name:"
+msgstr "名稱(_N)："
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:5
+msgid "C_ommand:"
+msgstr "指令(_O)："
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:6
+msgid "Repeat Keys"
+msgstr "重複按鍵"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:7
+msgid "Key presses _repeat when key is held down"
+msgstr "當按下某鍵不放時重複輸出該字符(_R)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:8
+msgid "_Delay:"
+msgstr "延遲(_D)："
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:9
+msgid "_Speed:"
+msgstr "速度(_S)："
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:10
+msgctxt "keyboard, delay"
+msgid "Short"
+msgstr "短"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:11
+msgctxt "keyboard, speed"
+msgid "Slow"
+msgstr "慢速"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:12
+msgid "Repeat keys speed"
+msgstr "按鍵重複速度"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:13
+msgctxt "keyboard, delay"
+msgid "Long"
+msgstr "長"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:14
+msgctxt "keyboard, speed"
+msgid "Fast"
+msgstr "快速"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:15
+msgid "Cursor Blinking"
+msgstr "游標閃爍"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:16
+msgid "Cursor _blinks in text fields"
+msgstr "文字輸入欄中的游標可以閃爍(_B)"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:17
+msgid "S_peed:"
+msgstr "速度(_P)："
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:18
+msgid "Cursor blink speed"
+msgstr "游標閃爍速度"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:19
+#: ../panels/region/region.ui.h:5
+msgid "Input Sources"
+msgstr "輸入來源"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:21
+msgid "Add Shortcut"
+msgstr "加入捷徑鍵"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:22
+msgid "Remove Shortcut"
+msgstr "移除捷徑鍵"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:23
+msgid ""
+"To edit a shortcut, click the row and hold down the new keys or press "
+"Backspace to clear."
+msgstr "要編輯捷徑鍵，點選相應的列並按下新的按鍵組合，或以 Backspace 鍵來清除。"
+
+#: ../panels/keyboard/gnome-keyboard-panel.ui.h:24
+msgid "Shortcuts"
+msgstr "快捷鍵"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:634
+#: ../panels/keyboard/keyboard-shortcuts.c:642
+msgid "Custom Shortcuts"
+msgstr "自選捷徑鍵"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:859
+msgid "<Unknown Action>"
+msgstr "<行動設定不詳>"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1356
+#, c-format
+msgid ""
+"The shortcut \"%s\" cannot be used because it will become impossible to type "
+"using this key.\n"
+"Please try with a key such as Control, Alt or Shift at the same time."
+msgstr ""
+"捷徑“%s”無法使用，原因是會無法按下此按鍵。\n"
+"請試用其它的按鍵：如同時使用 Control，Alt  或 Shift。"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1386
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for\n"
+"\"%s\""
+msgstr ""
+"捷徑鍵“%s”己經使用於：\n"
+"“%s”"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1391
+#, c-format
+msgid ""
+"If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be disabled."
+msgstr "如果你重新指派捷徑鍵為「%s」，「%s」的捷徑鍵就會停用。"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1397
+msgid "_Reassign"
+msgstr "重新指派(_R)"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1429
+#, c-format
+msgid ""
+"The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+"automatically set it to \"%s\"?"
+msgstr "捷徑鍵「%s」已指派「%s」捷徑。你想要自動將它設定為「%s」嗎？"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1435
+#, c-format
+#| msgid ""
+#| "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#| "disabled."
+msgid ""
+"\"%s\" is currently associated with \"%s\", this shortcut will be disabled "
+"if you move forward."
+msgstr "「%s」目前指派為「%s」，如果你繼續這個捷徑鍵就會停用。"
+
+#: ../panels/keyboard/keyboard-shortcuts.c:1441
+msgid "_Assign"
+msgstr "指派(_R)"
+
+#: ../panels/mouse/cc-mouse-panel.c:94
+msgid "Test Your _Settings"
+msgstr "測試你的設定值(_S)"
+
+#: ../panels/mouse/cc-mouse-panel.c:107
+msgid "Test Your Settings"
+msgstr "測試你的設定值"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:1
+msgid "Mouse & Touchpad"
+msgstr "滑鼠和觸控板"
+
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:2
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "改變你的滑鼠或控制板靈敏度並選擇慣用右手或左手"
+
+#. Translators: those are keywords for the mouse and touchpad control-center panel
+#: ../panels/mouse/gnome-mouse-panel.desktop.in.in.h:4
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;觸控板;指標;點擊;輕觸;連按兩下;按鈕;軌跡球;捲動;"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:1
+msgid "General"
+msgstr "一般"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:2
+msgctxt "double click, speed"
+msgid "Slow"
+msgstr "慢速"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:3
+msgid "Double-click timeout"
+msgstr "連按兩下分辨時間"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:4
+msgctxt "double click, speed"
+msgid "Fast"
+msgstr "快速"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:5
+msgid "_Double-click"
+msgstr "連按兩下(_D)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:6
+msgid "Primary _button"
+msgstr "主要按鈕(_B)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:7
+msgctxt "mouse, left button as primary"
+msgid "_Left"
+msgstr "左(_L)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:8
+msgctxt "mouse, right button as primary"
+msgid "_Right"
+msgstr "右(_R)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:9
+msgid "Mouse"
+msgstr "滑鼠"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:10
+msgid "_Pointer speed"
+msgstr "指標速度(_P)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:11
+msgctxt "mouse pointer, speed"
+msgid "Slow"
+msgstr "慢速"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:12
+msgctxt "mouse pointer, speed"
+msgid "Fast"
+msgstr "快速"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:13
+msgid "Touchpad"
+msgstr "觸控板"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:14
+msgctxt "touchpad pointer, speed"
+msgid "Slow"
+msgstr "慢速"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:15
+msgctxt "touchpad pointer, speed"
+msgid "Fast"
+msgstr "快速"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:16
+msgid "Disable while _typing"
+msgstr "打字時停用(_T)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:17
+msgid "Tap to _click"
+msgstr "輕觸表示點擊(_C)"
+
+#: ../panels/mouse/gnome-mouse-properties.ui.h:18
+msgid "Two _finger scroll"
+msgstr "兩指捲動(_F)"
+
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: ../panels/mouse/gnome-mouse-properties.ui.h:20
+msgid "_Natural scrolling"
+msgstr "自然捲動(_N)"
+
+#: ../panels/mouse/gnome-mouse-test.c:130
+#: ../panels/mouse/gnome-mouse-test.ui.h:1
+msgid "Try clicking, double clicking, scrolling"
+msgstr "嘗試點選、連按兩下、捲動"
+
+#: ../panels/mouse/gnome-mouse-test.c:135
+msgid "Five clicks, GEGL time!"
+msgstr "五次點擊，GEGL 時間！"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Double click, primary button"
+msgstr "連按兩下，主要按鈕"
+
+#: ../panels/mouse/gnome-mouse-test.c:140
+msgid "Single click, primary button"
+msgstr "點選，主要按鈕"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Double click, middle button"
+msgstr "連按兩下，中央按鈕"
+
+#: ../panels/mouse/gnome-mouse-test.c:143
+msgid "Single click, middle button"
+msgstr "點選，中央按鈕"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Double click, secondary button"
+msgstr "連按兩下，次要按鈕"
+
+#: ../panels/mouse/gnome-mouse-test.c:146
+msgid "Single click, secondary button"
+msgstr "點選，次要按鈕"
+
+#. TRANSLATORS: this is to disable the radio hardware in the
+#. * network panel
+#: ../panels/network/cc-network-panel.c:366
+msgid "Air_plane Mode"
+msgstr "飛安模式(_P)"
+
+#: ../panels/network/cc-network-panel.c:965
+msgid "Network proxy"
+msgstr "網絡代理伺服器"
+
+#. Translators: this is the title of the connection details
+#. * window for vpn connections, it is also used to display
+#. * vpn connections in the device list.
+#.
+#: ../panels/network/cc-network-panel.c:1144 ../panels/network/net-vpn.c:278
+#: ../panels/network/net-vpn.c:431
+#, c-format
+msgid "%s VPN"
+msgstr "%s VPN"
+
+#. TRANSLATORS: the user is running a NM that is not API compatible
+#: ../panels/network/cc-network-panel.c:1289
+msgid "The system network services are not compatible with this version."
+msgstr "系統網絡服務與這個版本不兼容。"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:1
+msgid "802.1x _Security"
+msgstr "802.1x 防護(_S)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:2
+#: ../panels/network/connection-editor/security-page.ui.h:2
+#: ../panels/printers/printers.ui.h:14
+msgid "page 1"
+msgstr "頁 1"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:3
+#: ../panels/network/connection-editor/security-page.ui.h:3
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:1
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:5
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:2
+msgid "Anony_mous identity"
+msgstr "匿名識別(_M)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:4
+#: ../panels/network/connection-editor/security-page.ui.h:4
+msgid "Inner _authentication"
+msgstr "內部核對(_A)"
+
+#: ../panels/network/connection-editor/8021x-security-page.ui.h:5
+#: ../panels/network/connection-editor/security-page.ui.h:5
+#: ../panels/printers/printers.ui.h:16
+msgid "page 2"
+msgstr "頁 2"
+
+#: ../panels/network/connection-editor/ce-page-8021x-security.c:108
+#: ../panels/network/connection-editor/ce-page-security.c:455
+#: ../panels/network/connection-editor/details-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:4
+msgid "Security"
+msgstr "安全性"
+
+#: ../panels/network/connection-editor/ce-page.c:507
+msgid "automatic"
+msgstr "自動"
+
+#. TRANSLATORS: this WEP WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:52
+#: ../panels/network/net-device-wifi.c:217
+#: ../panels/network/net-device-wifi.c:378
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:56
+#: ../panels/network/net-device-wifi.c:221
+#: ../panels/network/net-device-wifi.c:383
+#: ../panels/network/network-wifi.ui.h:17
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:60
+#: ../panels/network/net-device-wifi.c:225
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: ../panels/network/connection-editor/ce-page-details.c:65
+#: ../panels/network/net-device-wifi.c:230
+msgid "Enterprise"
+msgstr "企業版"
+
+#: ../panels/network/connection-editor/ce-page-details.c:70
+#: ../panels/network/net-device-wifi.c:235
+#: ../panels/network/net-device-wifi.c:368
+msgctxt "Wifi security"
+msgid "None"
+msgstr "沒有"
+
+#: ../panels/network/connection-editor/ce-page-details.c:91
+#: ../panels/power/power.ui.h:19
+msgid "Never"
+msgstr "永不"
+
+#: ../panels/network/connection-editor/ce-page-details.c:102
+#: ../panels/user-accounts/um-utils.c:819
+msgid "Today"
+msgstr "今日"
+
+#: ../panels/network/connection-editor/ce-page-details.c:104
+#: ../panels/user-accounts/um-utils.c:822
+msgid "Yesterday"
+msgstr "昨日"
+
+#: ../panels/network/connection-editor/ce-page-details.c:106
+#: ../panels/network/net-device-ethernet.c:126
+#: ../panels/network/net-device-wifi.c:472
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i 天以前"
+
+#. Translators: network device speed
+#: ../panels/network/connection-editor/ce-page-details.c:155
+#: ../panels/network/net-device-ethernet.c:54
+#: ../panels/network/net-device-wifi.c:529
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: ../panels/network/connection-editor/ce-page-details.c:181
+#: ../panels/network/net-device-wifi.c:558
+msgctxt "Signal strength"
+msgid "None"
+msgstr "沒有"
+
+#: ../panels/network/connection-editor/ce-page-details.c:183
+#: ../panels/network/net-device-wifi.c:560
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "太弱"
+
+#: ../panels/network/connection-editor/ce-page-details.c:185
+#: ../panels/network/net-device-wifi.c:562
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "確定"
+
+#: ../panels/network/connection-editor/ce-page-details.c:187
+#: ../panels/network/net-device-wifi.c:564
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "良好"
+
+#: ../panels/network/connection-editor/ce-page-details.c:189
+#: ../panels/network/net-device-wifi.c:566
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "很好"
+
+#: ../panels/network/connection-editor/ce-page-ethernet.c:226
+#: ../panels/network/connection-editor/ce-page-vpn.c:204
+#: ../panels/network/connection-editor/ce-page-wifi.c:270
+#: ../panels/network/network-wifi.ui.h:45
+msgid "Identity"
+msgstr "身分"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:177
+#: ../panels/network/connection-editor/ce-page-ip4.c:439
+#: ../panels/network/connection-editor/ce-page-ip6.c:179
+#: ../panels/network/connection-editor/ce-page-ip6.c:443
+msgid "Address"
+msgstr "地址"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:190
+#: ../panels/network/connection-editor/ce-page-ip4.c:452
+msgid "Netmask"
+msgstr "網絡遮罩"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:204
+#: ../panels/network/connection-editor/ce-page-ip4.c:465
+#: ../panels/network/connection-editor/ce-page-ip6.c:205
+#: ../panels/network/connection-editor/ce-page-ip6.c:473
+#: ../panels/network/network-vpn.ui.h:3
+msgid "Gateway"
+msgstr "通訊閘"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:221
+#: ../panels/network/connection-editor/ce-page-ip6.c:222
+msgid "Delete Address"
+msgstr "刪除位址"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:275
+#: ../panels/network/connection-editor/ce-page-ip6.c:276
+msgid "Add"
+msgstr "加入"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:343
+#: ../panels/network/connection-editor/ce-page-ip6.c:347
+msgid "Server"
+msgstr "伺服器"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:360
+#: ../panels/network/connection-editor/ce-page-ip6.c:364
+msgid "Delete DNS Server"
+msgstr "刪除 DNS 伺服器"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: ../panels/network/connection-editor/ce-page-ip4.c:479
+#: ../panels/network/connection-editor/ce-page-ip6.c:487
+msgctxt "network parameters"
+msgid "Metric"
+msgstr "公制"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:500
+#: ../panels/network/connection-editor/ce-page-ip6.c:508
+msgid "Delete Route"
+msgstr "刪除路由"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:615
+#: ../panels/network/network-wifi.ui.h:25
+msgid "Automatic (DHCP)"
+msgstr "自動 (DHCP)"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:619
+#: ../panels/network/connection-editor/ce-page-ip6.c:621
+#: ../panels/network/network-wifi.ui.h:24
+msgid "Manual"
+msgstr "手動"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:623
+#: ../panels/network/connection-editor/ce-page-ip6.c:625
+msgid "Link-Local Only"
+msgstr "只有本機連線"
+
+#: ../panels/network/connection-editor/ce-page-ip4.c:953
+#: ../panels/network/network-wifi.ui.h:46
+msgid "IPv4"
+msgstr "IPv4"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:192
+#: ../panels/network/connection-editor/ce-page-ip6.c:456
+msgid "Prefix"
+msgstr "前綴"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:613
+#: ../panels/network/connection-editor/ethernet-page.ui.h:1
+#: ../panels/network/connection-editor/ip4-page.ui.h:4
+#: ../panels/network/connection-editor/ip6-page.ui.h:4
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:2
+msgid "Automatic"
+msgstr "自動"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:617
+msgid "Automatic, DHCP only"
+msgstr "自動，僅使用 DHCP"
+
+#: ../panels/network/connection-editor/ce-page-ip6.c:919
+#: ../panels/network/network-wifi.ui.h:47
+msgid "IPv6"
+msgstr "IPv6"
+
+#: ../panels/network/connection-editor/ce-page-reset.c:91
+#: ../panels/network/network-wifi.ui.h:49
+msgid "Reset"
+msgstr "重設"
+
+#: ../panels/network/connection-editor/ce-page-security.c:250
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "沒有"
+
+#: ../panels/network/connection-editor/ce-page-security.c:273
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-位元密碼匙 (Hex 或 ASCII)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:283
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-位元密語"
+
+#: ../panels/network/connection-editor/ce-page-security.c:296
+#: ../panels/network/wireless-security/wireless-security.c:409
+msgid "LEAP"
+msgstr "LEAP"
+
+#: ../panels/network/connection-editor/ce-page-security.c:309
+msgid "Dynamic WEP (802.1x)"
+msgstr "動態 WEP (802.1x)"
+
+#: ../panels/network/connection-editor/ce-page-security.c:323
+msgid "WPA & WPA2 Personal"
+msgstr "WPA & WPA2 個人版"
+
+#: ../panels/network/connection-editor/ce-page-security.c:337
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA & WPA2 企業版"
+
+#: ../panels/network/connection-editor/details-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:2
+msgid "Signal Strength"
+msgstr "信號強度"
+
+#: ../panels/network/connection-editor/details-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:3
+msgid "Link speed"
+msgstr "連線速度"
+
+#: ../panels/network/connection-editor/details-page.ui.h:4
+#: ../panels/network/net-device-ethernet.c:159
+#: ../panels/network/network-simple.ui.h:3
+#: ../panels/network/network-wifi.ui.h:5 ../panels/network/panel-common.c:693
+msgid "IPv4 Address"
+msgstr "IPv4 位址"
+
+#: ../panels/network/connection-editor/details-page.ui.h:5
+#: ../panels/network/net-device-ethernet.c:160
+#: ../panels/network/net-device-ethernet.c:164
+#: ../panels/network/network-mobile.ui.h:4
+#: ../panels/network/network-simple.ui.h:4
+#: ../panels/network/network-wifi.ui.h:6 ../panels/network/panel-common.c:694
+msgid "IPv6 Address"
+msgstr "IPv6 位址"
+
+#: ../panels/network/connection-editor/details-page.ui.h:6
+#: ../panels/network/net-device-ethernet.c:167
+#: ../panels/network/network-simple.ui.h:2
+#: ../panels/network/network-wifi.ui.h:7
+msgid "Hardware Address"
+msgstr "硬件位址"
+
+#: ../panels/network/connection-editor/details-page.ui.h:7
+#: ../panels/network/net-device-ethernet.c:171
+#: ../panels/network/network-mobile.ui.h:5
+#: ../panels/network/network-simple.ui.h:5
+#: ../panels/network/network-wifi.ui.h:8
+msgid "Default Route"
+msgstr "預設路由"
+
+#: ../panels/network/connection-editor/details-page.ui.h:8
+#: ../panels/network/connection-editor/ip4-page.ui.h:3
+#: ../panels/network/connection-editor/ip6-page.ui.h:3
+#: ../panels/network/net-device-ethernet.c:173
+#: ../panels/network/network-mobile.ui.h:6
+#: ../panels/network/network-simple.ui.h:6
+#: ../panels/network/network-wifi.ui.h:9
+msgid "DNS"
+msgstr "DNS"
+
+#: ../panels/network/connection-editor/details-page.ui.h:9
+msgid "Last Used"
+msgstr "最後使用的"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:2
+msgid "Twisted Pair (TP)"
+msgstr "雙絞線 (TP)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:3
+msgid "Attachment Unit Interface (AUI)"
+msgstr "附加單位介面 (AUI)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:4
+msgid "BNC"
+msgstr "BNC"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:5
+msgid "Media Independent Interface (MII)"
+msgstr "媒體獨立介面 (MII)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:6
+msgid "10 Mb/s"
+msgstr "10 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:7
+msgid "100 Mb/s"
+msgstr "100 Mb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:8
+msgid "1 Gb/s"
+msgstr "1 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:9
+msgid "10 Gb/s"
+msgstr "10 Gb/s"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:10
+#: ../panels/network/connection-editor/vpn-page.ui.h:1
+msgid "_Name"
+msgstr "名稱(_N)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:11
+#: ../panels/network/connection-editor/wifi-page.ui.h:4
+#: ../panels/network/network-wifi.ui.h:36
+msgid "_MAC Address"
+msgstr "_MAC 位址"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:12
+msgid "M_TU"
+msgstr "M_TU"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:13
+#: ../panels/network/connection-editor/wifi-page.ui.h:5
+msgid "_Cloned Address"
+msgstr "複製的 MA_C 位址"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:14
+msgid "bytes"
+msgstr "位元組"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:15
+#: ../panels/network/connection-editor/vpn-page.ui.h:3
+msgid "Make available to other _users"
+msgstr "允許其他使用者使用(_U)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:16
+#: ../panels/network/connection-editor/wifi-page.ui.h:7
+msgid "Connect _automatically"
+msgstr "自動連線(_A)"
+
+#: ../panels/network/connection-editor/ethernet-page.ui.h:17
+#: ../panels/network/connection-editor/vpn-page.ui.h:2
+#: ../panels/network/connection-editor/wifi-page.ui.h:8
+msgid "Firewall _Zone"
+msgstr "防火牆地帶(_Z)"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:48
+#: ../panels/network/connection-editor/firewall-helpers.c:112
+msgctxt "Firewall zone"
+msgid "Default"
+msgstr "預設"
+
+#: ../panels/network/connection-editor/firewall-helpers.c:49
+msgid "The zone defines the trust level of the connection"
+msgstr "這個地帶定義了連線的信任等級"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:22
+msgid "IPv_4"
+msgstr "IPv_4"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:2
+#: ../panels/network/connection-editor/ip6-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:23
+msgid "_Addresses"
+msgstr "位址(_A)"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:5
+#: ../panels/network/connection-editor/ip6-page.ui.h:5
+msgid "Automatic DNS"
+msgstr "自動 DNS"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:6
+#: ../panels/network/connection-editor/ip6-page.ui.h:6
+#: ../panels/network/network-wifi.ui.h:30
+msgid "Routes"
+msgstr "路由"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:7
+#: ../panels/network/connection-editor/ip6-page.ui.h:7
+msgid "Automatic Routes"
+msgstr "自動路由"
+
+#: ../panels/network/connection-editor/ip4-page.ui.h:8
+#: ../panels/network/connection-editor/ip6-page.ui.h:8
+#: ../panels/network/network-wifi.ui.h:32
+msgid "Use this connection _only for resources on its network"
+msgstr "只在使用這個連線的網絡資源時才使用此連線(_U)"
+
+#: ../panels/network/connection-editor/ip6-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:34
+msgid "IPv_6"
+msgstr "IPv_6"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:269
+msgid "Unable to open connection editor"
+msgstr "無法開啟連線編輯器"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:287
+msgid "New Profile"
+msgstr "新增設定組合"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:577
+#: ../panels/network/network.ui.h:1 ../panels/network/network-vpn.ui.h:1
+msgid "VPN"
+msgstr "VPN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:578
+msgid "Bond"
+msgstr "繫結"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:580
+msgid "Team"
+msgstr "隊伍"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:582
+msgid "Bridge"
+msgstr "橋接"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:583
+msgid "VLAN"
+msgstr "VLAN"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:734
+msgid "Could not load VPN plugins"
+msgstr "無法載入 VPN 外掛程式"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:803
+msgid "Import from file…"
+msgstr "從檔案匯入…"
+
+#: ../panels/network/connection-editor/net-connection-editor.c:874
+msgid "Add Network Connection"
+msgstr "加入網絡連線"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:39
+msgid "_Reset"
+msgstr "重設(_R)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:2
+#: ../panels/network/net-device-wifi.c:1449
+#: ../panels/network/network-wifi.ui.h:40
+msgid "_Forget"
+msgstr "遺忘(_F)"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:3
+msgid ""
+"Reset the settings for this network, including passwords, but remember it as "
+"a preferred network"
+msgstr "重設這個網絡的設定值，包含密碼，但將它記住為偏好的網絡"
+
+#: ../panels/network/connection-editor/reset-page.ui.h:4
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect"
+msgstr "移除這個網絡的相關詳細資料並且不再嘗試自動連線"
+
+#: ../panels/network/connection-editor/security-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:14
+msgid "S_ecurity"
+msgstr "安全性(_E)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:205
+msgid "Cannot import VPN connection"
+msgstr "無法匯入 VPN 網絡連線"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:207
+#, c-format
+msgid ""
+"The file '%s' could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"檔案「%s」無法讀取或未包含可辨識的 VPN 連線資訊\n"
+"\n"
+"錯誤：%s。"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:242
+msgid "Select file to import"
+msgstr "選擇要匯入的檔案"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:246
+#: ../panels/printers/cc-printers-panel.c:1948
+#: ../panels/sharing/cc-sharing-panel.c:492
+#: ../panels/user-accounts/um-photo-dialog.c:223
+msgid "_Open"
+msgstr "開啟(_O)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:294
+#, c-format
+msgid "A file named \"%s\" already exists."
+msgstr "名為「%s」的檔案已經存在。"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:296
+msgid "_Replace"
+msgstr "取代(_R)"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:298
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "你是否要以準備儲存的 VPN 連線取代 %s？"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:334
+msgid "Cannot export VPN connection"
+msgstr "不能匯出 VPN 連線"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:336
+#, c-format
+msgid ""
+"The VPN connection '%s' could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN 連線「%s」不能匯出至 %s。\n"
+"\n"
+"錯誤：%s。"
+
+#: ../panels/network/connection-editor/vpn-helpers.c:371
+msgid "Export VPN connection"
+msgstr "匯出 VPN 連線"
+
+#: ../panels/network/connection-editor/vpn-page.ui.h:4
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "(錯誤：無法載入 VPN 連線編輯器)"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:1
+#: ../panels/network/network-wifi.ui.h:12
+msgid "_SSID"
+msgstr "_SSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:2
+#: ../panels/network/network-wifi.ui.h:13
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:3
+#: ../panels/network/network-wifi.ui.h:16
+msgid "My Home Network"
+msgstr "我的家用網絡"
+
+#: ../panels/network/connection-editor/wifi-page.ui.h:6
+msgid "Make available to _other users"
+msgstr "允許其他使用者使用(_O)"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:1
+#: ../panels/network/network-mobile.ui.h:7
+msgid "Network"
+msgstr "網絡"
+
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:2
+msgid "Control how you connect to the Internet"
+msgstr "控制你如何連線至網際網絡"
+
+#. Translators: those are keywords for the network control-center panel
+#: ../panels/network/gnome-network-panel.desktop.in.in.h:4
+msgid ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;"
+"vlan;bridge;bond;DNS;"
+msgstr "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;vlan;bridge;bond;DNS;網絡;無線網絡;區域網絡;代理伺服器;寬頻;數據機;藍牙;橋接;繫結;"
+
+#: ../panels/network/net-device-bond.c:77
+msgid "Bond slaves"
+msgstr "繫結的連線"
+
+#: ../panels/network/net-device-bond.c:102
+#: ../panels/network/net-device-bridge.c:102
+#: ../panels/network/net-device-team.c:102
+msgid "(none)"
+msgstr "(沒有)"
+
+#: ../panels/network/net-device-bridge.c:77
+msgid "Bridge slaves"
+msgstr "橋接的連線"
+
+#: ../panels/network/net-device-ethernet.c:112
+#: ../panels/network/net-device-wifi.c:458
+msgid "never"
+msgstr "永不"
+
+#: ../panels/network/net-device-ethernet.c:122
+#: ../panels/network/net-device-wifi.c:468
+msgid "today"
+msgstr "今日"
+
+#: ../panels/network/net-device-ethernet.c:124
+#: ../panels/network/net-device-wifi.c:470
+msgid "yesterday"
+msgstr "昨日"
+
+#: ../panels/network/net-device-ethernet.c:162
+#: ../panels/network/network-mobile.ui.h:3
+#: ../panels/network/panel-common.c:696 ../panels/network/panel-common.c:698
+#: ../panels/printers/printers.ui.h:13
+msgid "IP Address"
+msgstr "IP 位址"
+
+#: ../panels/network/net-device-ethernet.c:178
+#: ../panels/network/network-wifi.ui.h:10
+msgid "Last used"
+msgstr "最後使用的"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: ../panels/network/net-device-ethernet.c:288
+#: ../panels/network/network-ethernet.ui.h:1
+#: ../panels/network/network-simple.ui.h:1
+msgid "Wired"
+msgstr "有線"
+
+#: ../panels/network/net-device-ethernet.c:356
+#: ../panels/network/net-device-wifi.c:1604
+#: ../panels/network/network-ethernet.ui.h:3
+#: ../panels/network/network-mobile.ui.h:8
+#: ../panels/network/network-simple.ui.h:8
+#: ../panels/network/network-vpn.ui.h:8
+msgid "Options…"
+msgstr "選項…"
+
+#: ../panels/network/net-device-ethernet.c:474
+#, c-format
+msgid "Profile %d"
+msgstr "設定組合 %d"
+
+#: ../panels/network/net-device-mobile.c:232
+msgid "Add new connection"
+msgstr "加入新連線"
+
+#: ../panels/network/net-device-team.c:77
+msgid "Team slaves"
+msgstr "隊伍從屬"
+
+#: ../panels/network/net-device-wifi.c:1153
+msgid ""
+"If you have a connection to the Internet other than wireless, you can set up "
+"a wireless hotspot to share the connection with others."
+msgstr "如果你有無線網絡以外的方式連線到互聯網，你可以使用它來與其他人分享你的互聯網連線。"
+
+#: ../panels/network/net-device-wifi.c:1157
+#, c-format
+msgid "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+msgstr "切換無線網絡熱點會讓你從 <b>%s</b> 斷線。"
+
+#: ../panels/network/net-device-wifi.c:1161
+msgid ""
+"It is not possible to access the Internet through your wireless while the "
+"hotspot is active."
+msgstr "當熱點在使用中時是沒有辦法透過你的無線網絡存取互聯網的。"
+
+#: ../panels/network/net-device-wifi.c:1238
+msgid "Stop hotspot and disconnect any users?"
+msgstr "停止熱點並中斷任何使用者的連線？"
+
+#: ../panels/network/net-device-wifi.c:1241
+msgid "_Stop Hotspot"
+msgstr "停止熱點(_S)"
+
+#: ../panels/network/net-device-wifi.c:1313
+msgid "System policy prohibits use as a Hotspot"
+msgstr "系統原則禁止做為熱點"
+
+#: ../panels/network/net-device-wifi.c:1316
+msgid "Wireless device does not support Hotspot mode"
+msgstr "無線裝置不支援熱點模式"
+
+#: ../panels/network/net-device-wifi.c:1445
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr "選取網絡的詳細資料包含密碼及任何自選的組態都會消失。"
+
+#: ../panels/network/net-device-wifi.c:1753
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:13
+msgid "History"
+msgstr "歷史紀錄"
+
+#: ../panels/network/net-device-wifi.c:1757
+#: ../panels/wacom/cc-wacom-page.c:533
+msgid "_Close"
+msgstr "關閉(_C)"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: ../panels/network/net-device-wifi.c:1765
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "遺忘(_F)"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: ../panels/network/net-proxy.c:67
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "當沒有提供組態 URL 時會使用網頁代理伺服器自動發現。"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: ../panels/network/net-proxy.c:75
+msgid "This is not recommended for untrusted public networks."
+msgstr "這不建議用於不信任的公用網絡。"
+
+#: ../panels/network/net-proxy.c:410
+msgid "Proxy"
+msgstr "代理伺服器"
+
+#: ../panels/network/network-ethernet.ui.h:2
+msgid "_Add Profile…"
+msgstr "加入設定組合(_A)…"
+
+#: ../panels/network/network-mobile.ui.h:1
+msgid "IMEI"
+msgstr "IMEI"
+
+#: ../panels/network/network-mobile.ui.h:2
+msgid "Provider"
+msgstr "供應商"
+
+#: ../panels/network/network-proxy.ui.h:1 ../panels/network/network.ui.h:2
+msgctxt "proxy method"
+msgid "None"
+msgstr "沒有"
+
+#: ../panels/network/network-proxy.ui.h:2 ../panels/network/network.ui.h:3
+msgctxt "proxy method"
+msgid "Manual"
+msgstr "手動"
+
+#: ../panels/network/network-proxy.ui.h:3 ../panels/network/network.ui.h:4
+msgctxt "proxy method"
+msgid "Automatic"
+msgstr "自動"
+
+#: ../panels/network/network-proxy.ui.h:4
+msgid "_Method"
+msgstr "方法(_M)"
+
+#: ../panels/network/network-proxy.ui.h:5
+msgid "_Configuration URL"
+msgstr "組態網址(_C)"
+
+#: ../panels/network/network-proxy.ui.h:6
+msgid "_HTTP Proxy"
+msgstr "_HTTP 代理伺服器"
+
+#: ../panels/network/network-proxy.ui.h:7
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS 代理伺服器"
+
+#: ../panels/network/network-proxy.ui.h:8
+msgid "_FTP Proxy"
+msgstr "_FTP 代理伺服器"
+
+#: ../panels/network/network-proxy.ui.h:9
+msgid "_Socks Host"
+msgstr "Socks 主機(_S)"
+
+#: ../panels/network/network-proxy.ui.h:10
+msgid "_Ignore Hosts"
+msgstr "忽略主機(_I)"
+
+#: ../panels/network/network-proxy.ui.h:11
+msgid "HTTP proxy port"
+msgstr "HTTP 代理伺服器連接埠"
+
+#: ../panels/network/network-proxy.ui.h:12
+msgid "HTTPS proxy port"
+msgstr "HTTPS 代理伺服器連接埠"
+
+#: ../panels/network/network-proxy.ui.h:13
+msgid "FTP proxy port"
+msgstr "FTP 代理伺服器連接埠"
+
+#: ../panels/network/network-proxy.ui.h:14
+msgid "Socks proxy port"
+msgstr "Socks 代理伺服器通訊埠"
+
+#: ../panels/network/network-simple.ui.h:7
+msgid "Turn device off"
+msgstr "關閉裝置"
+
+#: ../panels/network/network.ui.h:5
+msgid "Add Device"
+msgstr "加入裝置"
+
+#: ../panels/network/network.ui.h:6
+msgid "Remove Device"
+msgstr "移除裝置"
+
+#: ../panels/network/network-vpn.ui.h:2
+msgid "VPN Type"
+msgstr "VPN 類型"
+
+#: ../panels/network/network-vpn.ui.h:4
+msgid "Group Name"
+msgstr "羣組名稱"
+
+#: ../panels/network/network-vpn.ui.h:5
+msgid "Group Password"
+msgstr "羣組密碼"
+
+#: ../panels/network/network-vpn.ui.h:6
+#: ../panels/printers/authentication-dialog.ui.h:4
+msgid "Username"
+msgstr "使用者名稱"
+
+#: ../panels/network/network-vpn.ui.h:7
+msgid "Turn VPN connection off"
+msgstr "關閉 VPN 連線"
+
+#: ../panels/network/network-wifi.ui.h:1
+msgid "Automatic _Connect"
+msgstr "自動連線(_C)"
+
+#: ../panels/network/network-wifi.ui.h:11
+msgid "details"
+msgstr "詳細資料"
+
+#: ../panels/network/network-wifi.ui.h:15
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:2
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:2
+#: ../panels/network/wireless-security/ws-leap.ui.h:2
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:9
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:7
+msgid "_Password"
+msgstr "密碼(_P)"
+
+#: ../panels/network/network-wifi.ui.h:18
+msgid "None"
+msgstr "沒有"
+
+#: ../panels/network/network-wifi.ui.h:19
+msgid "Show P_assword"
+msgstr "顯示密碼(_A)"
+
+#: ../panels/network/network-wifi.ui.h:20
+msgid "Make available to other users"
+msgstr "允許其他使用者使用"
+
+#: ../panels/network/network-wifi.ui.h:21
+msgid "identity"
+msgstr "身分"
+
+#: ../panels/network/network-wifi.ui.h:26
+msgid "Automatic (DHCP) addresses only"
+msgstr "只用自動 (DHCP) 位址"
+
+#: ../panels/network/network-wifi.ui.h:27
+msgid "Link-local only"
+msgstr "只有本機連線"
+
+#: ../panels/network/network-wifi.ui.h:28
+msgid "Shared with other computers"
+msgstr "分享給其他電腦"
+
+#: ../panels/network/network-wifi.ui.h:31
+msgid "_Ignore automatically obtained routes"
+msgstr "忽略自動獲得的路由(_I)"
+
+#: ../panels/network/network-wifi.ui.h:33
+msgid "ipv4"
+msgstr "ipv4"
+
+#: ../panels/network/network-wifi.ui.h:35
+msgid "ipv6"
+msgstr "ipv6"
+
+#: ../panels/network/network-wifi.ui.h:37
+msgid "_Cloned MAC Address"
+msgstr "複製的 MA_C 位址"
+
+#: ../panels/network/network-wifi.ui.h:38
+msgid "hardware"
+msgstr "硬件"
+
+#: ../panels/network/network-wifi.ui.h:41
+msgid ""
+"Reset the settings for this connection to their defaults, but remember as a "
+"preferred connection."
+msgstr "重設這個網絡的設定值為預設值，但將它記住為偏好的網絡。"
+
+#: ../panels/network/network-wifi.ui.h:42
+msgid ""
+"Remove all details relating to this network and do not try to automatically "
+"connect to it."
+msgstr "移除這個網絡的所有相關詳細資料並且不再嘗試自動連線。"
+
+#: ../panels/network/network-wifi.ui.h:43
+msgid "reset"
+msgstr "重設"
+
+#: ../panels/network/network-wifi.ui.h:48
+msgid "Hardware"
+msgstr "硬件"
+
+#: ../panels/network/network-wifi.ui.h:50
+msgid "Wi-Fi Hotspot"
+msgstr "Wi-Fi 熱點"
+
+#: ../panels/network/network-wifi.ui.h:51
+msgid "_Turn On"
+msgstr "開啟(_T)"
+
+#: ../panels/network/network-wifi.ui.h:52
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:53
+msgid "Turn Wi-Fi off"
+msgstr "關閉 Wi-Fi"
+
+#: ../panels/network/network-wifi.ui.h:54
+msgid "_Use as Hotspot…"
+msgstr "做為熱點(_U)…"
+
+#: ../panels/network/network-wifi.ui.h:55
+msgid "_Connect to Hidden Network…"
+msgstr "連接到隱藏的網絡(_C)…"
+
+#: ../panels/network/network-wifi.ui.h:56
+msgid "_History"
+msgstr "歷史紀錄(_H)"
+
+#: ../panels/network/network-wifi.ui.h:57
+msgid "Switch off to connect to a Wi-Fi network"
+msgstr "關閉連線到 Wi-Fi 網絡"
+
+#: ../panels/network/network-wifi.ui.h:58
+msgid "Network Name"
+msgstr "網絡名稱"
+
+#: ../panels/network/network-wifi.ui.h:59
+msgid "Connected Devices"
+msgstr "已連線的裝置"
+
+#: ../panels/network/network-wifi.ui.h:60
+msgid "Security type"
+msgstr "安全性類型"
+
+#: ../panels/network/network-wifi.ui.h:61
+msgid "Security key"
+msgstr "安全密碼匙"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:131
+msgid "Ad-hoc"
+msgstr "Ad-hoc"
+
+#. TRANSLATORS: AP type
+#: ../panels/network/panel-common.c:135
+msgid "Infrastructure"
+msgstr "基礎架構"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:151 ../panels/network/panel-common.c:205
+msgid "Status unknown"
+msgstr "狀態不明"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:155
+msgid "Unmanaged"
+msgstr "未管理"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:159
+msgid "Unavailable"
+msgstr "無法使用"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:169 ../panels/network/panel-common.c:211
+msgid "Connecting"
+msgstr "連線中"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:173 ../panels/network/panel-common.c:215
+msgid "Authentication required"
+msgstr "需要核對"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:177 ../panels/network/panel-common.c:219
+msgid "Connected"
+msgstr "已連線"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:181
+msgid "Disconnecting"
+msgstr "斷線"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:185 ../panels/network/panel-common.c:223
+msgid "Connection failed"
+msgstr "連線失敗"
+
+#. TRANSLATORS: device status
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:189 ../panels/network/panel-common.c:231
+msgid "Status unknown (missing)"
+msgstr "狀態不詳（缺乏）"
+
+#. TRANSLATORS: VPN status
+#: ../panels/network/panel-common.c:227
+msgid "Not connected"
+msgstr "未連線"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:252
+msgid "Configuration failed"
+msgstr "設定失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:256
+msgid "IP configuration failed"
+msgstr "IP 組態失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:260
+msgid "IP configuration expired"
+msgstr "IP 組態過期"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:264
+msgid "Secrets were required, but not provided"
+msgstr "需要機密，但沒有提供"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:268
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x 請求已斷線"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:272
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x 請求組態失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:276
+msgid "802.1x supplicant failed"
+msgstr "802.1x 請求已失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:280
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x 請求花了太長時間核對"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:284
+msgid "PPP service failed to start"
+msgstr "無法啟動 PPP 服務"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:288
+msgid "PPP service disconnected"
+msgstr "PPP 服務已斷線"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:292
+msgid "PPP failed"
+msgstr "PPP 失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:296
+msgid "DHCP client failed to start"
+msgstr "DHCP 客戶端啟動失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:300
+msgid "DHCP client error"
+msgstr "DHCP 客戶端錯誤"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:304
+msgid "DHCP client failed"
+msgstr "DHCP 客戶端失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:308
+msgid "Shared connection service failed to start"
+msgstr "分享的連線服務啟動失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:312
+msgid "Shared connection service failed"
+msgstr "分享的連線服務失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:316
+msgid "AutoIP service failed to start"
+msgstr "無法啟動 AutoIP 服務"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:320
+msgid "AutoIP service error"
+msgstr "AutoIP 服務錯誤"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:324
+msgid "AutoIP service failed"
+msgstr "AutoIP 服務失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:328
+msgid "Line busy"
+msgstr "線路忙碌"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:332
+msgid "No dial tone"
+msgstr "沒有撥號音"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:336
+msgid "No carrier could be established"
+msgstr "無法建立載體"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:340
+msgid "Dialing request timed out"
+msgstr "撥號要求逾時"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:344
+msgid "Dialing attempt failed"
+msgstr "嘗試撥號失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:348
+msgid "Modem initialization failed"
+msgstr "數據機初始化失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:352
+msgid "Failed to select the specified APN"
+msgstr "無法選擇指定的 APN"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:356
+msgid "Not searching for networks"
+msgstr "不要搜尋網絡"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:360
+msgid "Network registration denied"
+msgstr "網絡登記被禁止"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:364
+msgid "Network registration timed out"
+msgstr "網絡登記逾時"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:368
+msgid "Failed to register with the requested network"
+msgstr "無法向要求的網絡登記"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:372
+msgid "PIN check failed"
+msgstr "PIN 檢查失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:376
+msgid "Firmware for the device may be missing"
+msgstr "可能缺少裝置的韌體"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:380
+msgid "Connection disappeared"
+msgstr "連線已消失"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:384
+msgid "Existing connection was assumed"
+msgstr "優先使用現有的連線"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:388
+msgid "Modem not found"
+msgstr "找不到數據機"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:392
+msgid "Bluetooth connection failed"
+msgstr "藍牙連線失敗"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:396
+msgid "SIM Card not inserted"
+msgstr "SIM 卡尚未插入"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:400
+msgid "SIM Pin required"
+msgstr "需要 SIM PIN 碼"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:404
+msgid "SIM Puk required"
+msgstr "需要 SIM PUK 碼"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:408
+msgid "SIM wrong"
+msgstr "SIM 錯誤"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:412
+msgid "InfiniBand device does not support connected mode"
+msgstr "InfiniBand 裝置不支援已連接模式"
+
+#. TRANSLATORS: device status reason
+#: ../panels/network/panel-common.c:416
+msgid "Connection dependency failed"
+msgstr "連線相根據性解析失敗"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:440
+msgid "Firmware missing"
+msgstr "缺少韌體"
+
+#. TRANSLATORS: device status
+#: ../panels/network/panel-common.c:444 ../panels/network/panel-common.c:447
+msgid "Cable unplugged"
+msgstr "纜線已拔除"
+
+#: ../panels/network/wireless-security/eap-method.c:275
+msgid "No Certificate Authority certificate chosen"
+msgstr "未選擇任何證書授權單位(CA)證書"
+
+#: ../panels/network/wireless-security/eap-method.c:276
+msgid ""
+"Not using a Certificate Authority (CA) certificate can result in connections "
+"to insecure, rogue Wi-Fi networks.  Would you like to choose a Certificate "
+"Authority certificate?"
+msgstr "不使用證書中心 (CA) 的證書會造成連線不安全、流氓 Wi-Fi 網絡。是否要選擇一個證書中心的證書？"
+
+#: ../panels/network/wireless-security/eap-method.c:281
+msgid "Ignore"
+msgstr "忽略"
+
+#: ../panels/network/wireless-security/eap-method.c:285
+msgid "Choose CA Certificate"
+msgstr "選擇 CA 證書"
+
+#: ../panels/network/wireless-security/eap-method.c:645
+msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12)"
+msgstr "DER, PEM, 或 PKCS#12 私密密碼匙(*.der, *.pem, *.p12)"
+
+#: ../panels/network/wireless-security/eap-method.c:648
+msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+msgstr "DER 或 PEM 證書 (*.der, *.pem, *.crt, *.cer)"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:271
+#: ../panels/network/wireless-security/eap-method-peap.c:280
+msgid "GTC"
+msgstr "GTC"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:287
+#: ../panels/network/wireless-security/eap-method-peap.c:246
+#: ../panels/network/wireless-security/eap-method-ttls.c:263
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:409
+msgid "Choose a PAC file"
+msgstr "選擇一個 PAC 檔案"
+
+#: ../panels/network/wireless-security/eap-method-fast.c:416
+msgid "PAC files (*.pac)"
+msgstr "PAC 檔案 (*.pac)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:2
+msgid "PAC _file"
+msgstr "PAC 檔案(_F)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:3
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:7
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:4
+msgid "_Inner authentication"
+msgstr "內部核對(_I)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:4
+msgid "PAC pro_visioning"
+msgstr "允許自動供應 PAC (_V)"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:5
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:1
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:1
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:1
+#: ../panels/printers/authentication-dialog.ui.h:1
+msgid " "
+msgstr " "
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:6
+msgid "Anonymous"
+msgstr "匿名"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:7
+msgid "Authenticated"
+msgstr "已核對"
+
+#: ../panels/network/wireless-security/eap-method-fast.ui.h:8
+msgid "Both"
+msgstr "兩者"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:1
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:1
+#: ../panels/network/wireless-security/ws-leap.ui.h:1
+#: ../panels/user-accounts/data/account-dialog.ui.h:3
+msgid "_Username"
+msgstr "使用者名稱(_U)"
+
+#: ../panels/network/wireless-security/eap-method-leap.ui.h:3
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:4
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:6
+#: ../panels/network/wireless-security/ws-leap.ui.h:3
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:3
+msgid "Sho_w password"
+msgstr "顯示密碼(_W)"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:263
+#: ../panels/network/wireless-security/wireless-security.c:385
+msgid "MD5"
+msgstr "MD5"
+
+#: ../panels/network/wireless-security/eap-method-peap.c:350
+#: ../panels/network/wireless-security/eap-method-tls.c:456
+#: ../panels/network/wireless-security/eap-method-ttls.c:350
+msgid "Choose a Certificate Authority certificate"
+msgstr "選擇證書授權單位 (CA) 證書"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:3
+msgid "Version 0"
+msgstr "版本 0"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:4
+msgid "Version 1"
+msgstr "版本 1"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:6
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:3
+#: ../panels/network/wireless-security/eap-method-ttls.ui.h:3
+msgid "C_A certificate"
+msgstr "證書(_A)"
+
+#: ../panels/network/wireless-security/eap-method-peap.ui.h:8
+msgid "PEAP _version"
+msgstr "PEAP 版本(_V)"
+
+#: ../panels/network/wireless-security/eap-method-simple.ui.h:3
+msgid "As_k for this password every time"
+msgstr "每次都詢問密碼(_K)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:282
+msgid "Unencrypted private keys are insecure"
+msgstr "未加密的私密密碼匙是不安全的"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:285
+msgid ""
+"The selected private key does not appear to be protected by a password.  "
+"This could allow your security credentials to be compromised.  Please select "
+"a password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"所選擇的私密密碼匙似乎沒有密碼保護。 這可能會導致不安全的後果。請選擇用密碼保護的私密密碼匙。\n"
+"\n"
+"(你可以使用 openssl 來加密你的私密密碼匙)"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:450
+msgid "Choose your personal certificate"
+msgstr "選擇你的個人證書"
+
+#: ../panels/network/wireless-security/eap-method-tls.c:462
+msgid "Choose your private key"
+msgstr "選擇你的私密密碼匙"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:1
+msgid "I_dentity"
+msgstr "識別(_D)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:2
+msgid "_User certificate"
+msgstr "使用者證書(_U)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:4
+msgid "Private _key"
+msgstr "私人密碼匙(_K)"
+
+#: ../panels/network/wireless-security/eap-method-tls.ui.h:5
+msgid "_Private key password"
+msgstr "私密密碼匙密碼(_P)"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:230
+msgid "PAP"
+msgstr "PAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:247
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: ../panels/network/wireless-security/eap-method-ttls.c:280
+msgid "CHAP"
+msgstr "CHAP"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:1
+msgid "Don't _warn me again"
+msgstr "不要再警告我(_W)"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:2
+msgid "No"
+msgstr "否"
+
+#: ../panels/network/wireless-security/nag-user-dialog.ui.h:3
+msgid "Yes"
+msgstr "是"
+
+#: ../panels/network/wireless-security/wireless-security.c:397
+msgid "TLS"
+msgstr "TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:421
+msgid "FAST"
+msgstr "FAST"
+
+#: ../panels/network/wireless-security/wireless-security.c:432
+msgid "Tunneled TLS"
+msgstr "穿隧式 TLS"
+
+#: ../panels/network/wireless-security/wireless-security.c:443
+msgid "Protected EAP (PEAP)"
+msgstr "保護式 EAP (PEAP)"
+
+#: ../panels/network/wireless-security/ws-dynamic-wep.ui.h:2
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:9
+#: ../panels/network/wireless-security/ws-wpa-eap.ui.h:2
+msgid "Au_thentication"
+msgstr "核對(_T)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:1
+msgid "1 (Default)"
+msgstr "1 (預設值)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:2
+msgid "2"
+msgstr "2"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:3
+msgid "3"
+msgstr "3"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:4
+msgid "4"
+msgstr "4"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:5
+msgid "Open System"
+msgstr "開放系統"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:6
+msgid "Shared Key"
+msgstr "共享密碼匙"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:7
+msgid "_Key"
+msgstr "密碼匙(_K)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:8
+msgid "Sho_w key"
+msgstr "顯示密碼匙(_W)"
+
+#: ../panels/network/wireless-security/ws-wep-key.ui.h:10
+msgid "WEP inde_x"
+msgstr "WEP 索引(_X)"
+
+#: ../panels/network/wireless-security/ws-wpa-psk.ui.h:2
+msgid "_Type"
+msgstr "類型(_T)"
+
+#. TRANSLATORS: this is the per application switch for message tray usage.
+#: ../panels/notifications/cc-edit-dialog.c:37
+msgctxt "notifications"
+msgid "Notifications"
+msgstr "通知"
+
+#. TRANSLATORS: this is the setting to configure sounds associated with notifications
+#: ../panels/notifications/cc-edit-dialog.c:39
+msgctxt "notifications"
+msgid "Sound Alerts"
+msgstr "音效通知"
+
+#: ../panels/notifications/cc-edit-dialog.c:40
+msgctxt "notifications"
+msgid "Show Popup Banners"
+msgstr "顯示彈出式橫幅"
+
+#. TRANSLATORS: banners here refers to message tray notifications in the middle of the screen
+#: ../panels/notifications/cc-edit-dialog.c:42
+msgctxt "notifications"
+msgid "Show Details in Banners"
+msgstr "在橫幅顯示詳細資料"
+
+#: ../panels/notifications/cc-edit-dialog.c:43
+msgctxt "notifications"
+msgid "View in Lock Screen"
+msgstr "在鎖定畫面中顯示"
+
+#: ../panels/notifications/cc-edit-dialog.c:44
+msgctxt "notifications"
+msgid "Show Details in Lock Screen"
+msgstr "在鎖定畫面中顯示詳細資料"
+
+#: ../panels/notifications/cc-notifications-panel.c:185
+#: ../panels/power/cc-power-panel.c:1690 ../panels/power/cc-power-panel.c:1697
+#: ../panels/privacy/cc-privacy-panel.c:84
+#: ../panels/privacy/cc-privacy-panel.c:124
+#: ../panels/universal-access/cc-ua-panel.c:257
+#: ../panels/universal-access/cc-ua-panel.c:572
+#: ../panels/universal-access/cc-ua-panel.c:695
+msgid "On"
+msgstr "開啟"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:1
+msgid "Notifications"
+msgstr "通知"
+
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:2
+msgid "Control which notifications are displayed and what they show"
+msgstr "控制要顯示哪種通知及要顯示什麼"
+
+#. Translators: those are keywords for the notifications control-center panel
+#: ../panels/notifications/gnome-notifications-panel.desktop.in.in.h:4
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr "Notifications;Banner;Message;Tray;Popup;通知;橫幅;訊息;匣;彈出;"
+
+#: ../panels/notifications/notifications.ui.h:1
+msgid "Show Pop Up Banners"
+msgstr "顯示彈出式橫幅"
+
+#: ../panels/notifications/notifications.ui.h:2
+msgid "Show in Lock Screen"
+msgstr "在鎖定畫面中顯示"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:169
+msgctxt "Online Account"
+msgid "Other"
+msgstr "其他"
+
+#. translators: This is the title of the "Add Account" dialog.
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:283
+#: ../panels/online-accounts/online-accounts.ui.h:2
+msgid "Add Account"
+msgstr "加入帳號"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:322
+msgid "Mail"
+msgstr "郵件"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:328
+msgid "Contacts"
+msgstr "聯絡人"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:334
+msgid "Chat"
+msgstr "聊天"
+
+#: ../panels/online-accounts/cc-online-accounts-add-account-dialog.c:340
+msgid "Resources"
+msgstr "資源"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:423
+msgid "Error logging into the account"
+msgstr "登入帳號時發生錯誤"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:493
+msgid "Credentials have expired."
+msgstr "證書已經過期。"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:497
+msgid "Sign in to enable this account."
+msgstr "登入以啟用這個帳號。"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:502
+msgid "_Sign In"
+msgstr "登入(_S)"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:743
+msgid "Error creating account"
+msgstr "建立帳號時發生錯誤"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:803
+msgid "Error removing account"
+msgstr "移除帳號時發生錯誤"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:839
+msgid "Are you sure you want to remove the account?"
+msgstr "確定要刪除這個帳號？"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:841
+msgid "This will not remove the account on the server."
+msgstr "這不會移除伺服器上的帳號。"
+
+#: ../panels/online-accounts/cc-online-accounts-panel.c:842
+msgid "_Remove"
+msgstr "移除(_R)"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:1
+msgid "Online Accounts"
+msgstr "網上帳號"
+
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:2
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "連接到你的網上帳號並決定要用它們來做什麼"
+
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: ../panels/online-accounts/gnome-online-accounts-panel.desktop.in.in.h:4
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;Kerberos;IMAP;SMTP;Pocket;ReadItLater;谷歌;臉書;推特;雅虎奇摩;網頁;網上;聊天;行事曆;郵件;聯絡人;"
+
+#: ../panels/online-accounts/online-accounts.ui.h:1
+msgid "No online accounts configured"
+msgstr "尚未設定網上帳號"
+
+#: ../panels/online-accounts/online-accounts.ui.h:3
+msgid "Remove Account"
+msgstr "移除帳號"
+
+#: ../panels/online-accounts/online-accounts.ui.h:4
+msgid "Add an online account"
+msgstr "加入網上帳號"
+
+#: ../panels/online-accounts/online-accounts.ui.h:5
+msgid ""
+"Adding an account allows your applications to access it for documents, mail, "
+"contacts, calendar, chat and more."
+msgstr "加入一個帳號以允許你的應用程式存取它用於文件、郵件、聯絡人、行事曆、聊天等等。"
+
+#: ../panels/power/cc-power-panel.c:183
+msgid "Unknown time"
+msgstr "不明的時間"
+
+#: ../panels/power/cc-power-panel.c:189
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i 分鐘"
+
+#: ../panels/power/cc-power-panel.c:201
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i 小時"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: ../panels/power/cc-power-panel.c:209
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: ../panels/power/cc-power-panel.c:210
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "小時"
+
+#: ../panels/power/cc-power-panel.c:211
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "分鐘"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:230
+#, c-format
+msgid "%s until fully charged"
+msgstr "%s後完全充飽"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:237
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "注意：剩下 %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: ../panels/power/cc-power-panel.c:242
+#, c-format
+msgid "%s remaining"
+msgstr "剩下 %s"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:247 ../panels/power/cc-power-panel.c:275
+msgid "Fully charged"
+msgstr "已完全充飽"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:251 ../panels/power/cc-power-panel.c:279
+msgid "Empty"
+msgstr "沒電"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:266
+msgid "Charging"
+msgstr "充電"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:271
+msgid "Discharging"
+msgstr "放電中"
+
+#: ../panels/power/cc-power-panel.c:396
+msgctxt "Battery name"
+msgid "Main"
+msgstr "主要"
+
+#: ../panels/power/cc-power-panel.c:398
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "額外"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:470
+msgid "Wireless mouse"
+msgstr "無線滑鼠"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:473
+msgid "Wireless keyboard"
+msgstr "無線鍵盤"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:476
+msgid "Uninterruptible power supply"
+msgstr "不斷電系統"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:479
+msgid "Personal digital assistant"
+msgstr "個人數碼助理"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:482
+msgid "Cellphone"
+msgstr "手機"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:485
+msgid "Media player"
+msgstr "媒體播放器"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:488
+msgid "Tablet"
+msgstr "繪圖板"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:491
+msgid "Computer"
+msgstr "電腦"
+
+#. TRANSLATORS: secondary battery, misc
+#: ../panels/power/cc-power-panel.c:494 ../panels/power/cc-power-panel.c:717
+#: ../panels/power/cc-power-panel.c:2019
+msgid "Battery"
+msgstr "電池"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:540
+msgctxt "Battery power"
+msgid "Charging"
+msgstr "充電"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:547
+msgctxt "Battery power"
+msgid "Caution"
+msgstr "注意"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:552
+msgctxt "Battery power"
+msgid "Low"
+msgstr "低"
+
+#. TRANSLATORS: secondary battery
+#: ../panels/power/cc-power-panel.c:557
+msgctxt "Battery power"
+msgid "Good"
+msgstr "良好"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:562
+msgctxt "Battery power"
+msgid "Fully charged"
+msgstr "已完全充飽"
+
+#. TRANSLATORS: primary battery
+#: ../panels/power/cc-power-panel.c:566
+msgctxt "Battery power"
+msgid "Empty"
+msgstr "沒電"
+
+#: ../panels/power/cc-power-panel.c:715
+msgid "Batteries"
+msgstr "電池"
+
+#: ../panels/power/cc-power-panel.c:1117
+msgid "When _idle"
+msgstr "閒置時(_I)"
+
+#: ../panels/power/cc-power-panel.c:1445
+msgid "Power Saving"
+msgstr "節省電源"
+
+#: ../panels/power/cc-power-panel.c:1473
+msgid "_Screen brightness"
+msgstr "螢幕亮度(_S)"
+
+#: ../panels/power/cc-power-panel.c:1479
+msgid "_Keyboard brightness"
+msgstr "鍵盤亮度(_K)"
+
+#: ../panels/power/cc-power-panel.c:1489
+msgid "_Dim screen when inactive"
+msgstr "當不活動後降低螢幕亮度(_D)"
+
+#: ../panels/power/cc-power-panel.c:1514
+msgid "_Blank screen"
+msgstr "螢幕轉黑(_B)"
+
+#: ../panels/power/cc-power-panel.c:1551
+msgid "_Wi-Fi"
+msgstr "_Wi-Fi"
+
+#: ../panels/power/cc-power-panel.c:1556
+msgid "Turns off wireless devices"
+msgstr "關閉無線裝置"
+
+#: ../panels/power/cc-power-panel.c:1581
+msgid "_Mobile broadband"
+msgstr "流動寬頻(_M)"
+
+#: ../panels/power/cc-power-panel.c:1586
+msgid "Turns off mobile broadband (3G, 4G, WiMax, etc.) devices"
+msgstr "關閉流動寬頻 (3G、4G、WiMax 等) 裝置"
+
+#: ../panels/power/cc-power-panel.c:1635
+msgid "_Bluetooth"
+msgstr "藍牙(_B)"
+
+#: ../panels/power/cc-power-panel.c:1686
+msgid "When on battery power"
+msgstr "使用電池電源時"
+
+#: ../panels/power/cc-power-panel.c:1688
+msgid "When plugged in"
+msgstr "當插入電源線時"
+
+#: ../panels/power/cc-power-panel.c:1818
+msgid "Suspend & Power Off"
+msgstr "暫停與關閉電源"
+
+#: ../panels/power/cc-power-panel.c:1851
+msgid "_Automatic suspend"
+msgstr "自動暫停(_A)"
+
+#: ../panels/power/cc-power-panel.c:1875
+msgid "When battery power is _critical"
+msgstr "當電池的電量極低時(_C)"
+
+#: ../panels/power/cc-power-panel.c:1930
+msgid "Power Off"
+msgstr "關閉電源"
+
+#: ../panels/power/cc-power-panel.c:2066
+msgid "Devices"
+msgstr "裝置"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:1
+msgid "Power"
+msgstr "電源"
+
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:2
+msgid "View your battery status and change power saving settings"
+msgstr "檢視你的電池狀態並改變電源節省設定值"
+
+#. Translators: those are keywords for the power control-center panel
+#: ../panels/power/gnome-power-panel.desktop.in.in.h:4
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+msgstr "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;電源;睡眠;暫停;休眠;電池;亮度;轉黑;顯示器;閒置;"
+
+#: ../panels/power/power.ui.h:1
+msgid "Hibernate"
+msgstr "休眠"
+
+#: ../panels/power/power.ui.h:2
+msgid "Power off"
+msgstr "關閉電源"
+
+#: ../panels/power/power.ui.h:5
+msgid "45 minutes"
+msgstr "45 分鐘"
+
+#: ../panels/power/power.ui.h:6 ../panels/privacy/privacy.ui.h:8
+msgid "1 hour"
+msgstr "1 小時"
+
+#: ../panels/power/power.ui.h:7
+msgid "80 minutes"
+msgstr "80 分鐘"
+
+#: ../panels/power/power.ui.h:8
+msgid "90 minutes"
+msgstr "90 分鐘"
+
+#: ../panels/power/power.ui.h:9
+msgid "100 minutes"
+msgstr "100 分鐘"
+
+#: ../panels/power/power.ui.h:10
+msgid "2 hours"
+msgstr "2 小時"
+
+#: ../panels/power/power.ui.h:11 ../panels/privacy/privacy.ui.h:3
+msgid "1 minute"
+msgstr "1 分鐘"
+
+#: ../panels/power/power.ui.h:12 ../panels/privacy/privacy.ui.h:4
+msgid "2 minutes"
+msgstr "2 分鐘"
+
+#: ../panels/power/power.ui.h:13 ../panels/privacy/privacy.ui.h:5
+msgid "3 minutes"
+msgstr "3 分鐘"
+
+#: ../panels/power/power.ui.h:14
+msgid "4 minutes"
+msgstr "4 分鐘"
+
+#: ../panels/power/power.ui.h:15 ../panels/privacy/privacy.ui.h:6
+msgid "5 minutes"
+msgstr "5 分鐘"
+
+#: ../panels/power/power.ui.h:16
+msgid "8 minutes"
+msgstr "8 分鐘"
+
+#: ../panels/power/power.ui.h:17
+msgid "10 minutes"
+msgstr "10 分鐘"
+
+#: ../panels/power/power.ui.h:18
+msgid "12 minutes"
+msgstr "12 分鐘"
+
+#: ../panels/power/power.ui.h:20
+msgid "Automatic Suspend"
+msgstr "自動暫停"
+
+#: ../panels/power/power.ui.h:21
+msgid "_Plugged In"
+msgstr "插入插頭(_P)"
+
+#: ../panels/power/power.ui.h:22
+msgid "On _Battery Power"
+msgstr "使用電池電源(_B)"
+
+#: ../panels/power/power.ui.h:23
+msgid "Delay"
+msgstr "延遲"
+
+#: ../panels/printers/authentication-dialog.ui.h:3
+msgid "Authenticate"
+msgstr "核對"
+
+#: ../panels/printers/authentication-dialog.ui.h:5
+#: ../panels/sharing/sharing.ui.h:14
+#: ../panels/user-accounts/data/account-dialog.ui.h:6
+msgid "Password"
+msgstr "密碼"
+
+#: ../panels/printers/authentication-dialog.ui.h:6
+msgid "Authentication Required"
+msgstr "要求核對"
+
+#. Translators: The printer is low on toner
+#: ../panels/printers/cc-printers-panel.c:590
+msgid "Low on toner"
+msgstr "碳粉不足"
+
+#. Translators: The printer has no toner left
+#: ../panels/printers/cc-printers-panel.c:592
+msgid "Out of toner"
+msgstr "碳粉用完"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:595
+msgid "Low on developer"
+msgstr "顯像劑不足"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: ../panels/printers/cc-printers-panel.c:598
+msgid "Out of developer"
+msgstr "顯像劑用完"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:600
+msgid "Low on a marker supply"
+msgstr "墨水匣不足"
+
+#. Translators: "marker" is one color bin of the printer
+#: ../panels/printers/cc-printers-panel.c:602
+msgid "Out of a marker supply"
+msgstr "墨水匣用完"
+
+#. Translators: One or more covers on the printer are open
+#: ../panels/printers/cc-printers-panel.c:604
+msgid "Open cover"
+msgstr "外殼開啟"
+
+#. Translators: One or more doors on the printer are open
+#: ../panels/printers/cc-printers-panel.c:606
+msgid "Open door"
+msgstr "紙匣門開啟"
+
+#. Translators: At least one input tray is low on media
+#: ../panels/printers/cc-printers-panel.c:608
+msgid "Low on paper"
+msgstr "紙張不足。"
+
+#. Translators: At least one input tray is empty
+#: ../panels/printers/cc-printers-panel.c:610
+msgid "Out of paper"
+msgstr "紙張用完"
+
+#. Translators: The printer is offline
+#: ../panels/printers/cc-printers-panel.c:612
+msgctxt "printer state"
+msgid "Offline"
+msgstr "離線"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: ../panels/printers/cc-printers-panel.c:614
+#: ../panels/printers/cc-printers-panel.c:805
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "已停止"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: ../panels/printers/cc-printers-panel.c:616
+msgid "Waste receptacle almost full"
+msgstr "廢墨收集器將滿"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: ../panels/printers/cc-printers-panel.c:618
+msgid "Waste receptacle full"
+msgstr "廢墨收集器已滿"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:620
+msgid "The optical photo conductor is near end of life"
+msgstr "感光鼓接近使用壽命"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: ../panels/printers/cc-printers-panel.c:622
+msgid "The optical photo conductor is no longer functioning"
+msgstr "感光鼓已無法使用"
+
+#. Translators: Printer's state (printer is being configured right now)
+#: ../panels/printers/cc-printers-panel.c:732
+msgctxt "printer state"
+msgid "Configuring"
+msgstr "正在設定"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: ../panels/printers/cc-printers-panel.c:791
+msgctxt "printer state"
+msgid "Ready"
+msgstr "準備就緒"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: ../panels/printers/cc-printers-panel.c:796
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "不接受工作"
+
+#. Translators: Printer's state (jobs are processing)
+#: ../panels/printers/cc-printers-panel.c:801
+msgctxt "printer state"
+msgid "Processing"
+msgstr "處理中"
+
+#. Translators: Toner supply
+#: ../panels/printers/cc-printers-panel.c:922
+msgid "Toner Level"
+msgstr "碳粉匣等級"
+
+#. Translators: Ink supply
+#: ../panels/printers/cc-printers-panel.c:925
+msgid "Ink Level"
+msgstr "墨水等級"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/cc-printers-panel.c:928
+msgid "Supply Level"
+msgstr "耗材等級"
+
+#. Translators: Printer's state (printer is being installed right now)
+#: ../panels/printers/cc-printers-panel.c:946
+msgctxt "printer state"
+msgid "Installing"
+msgstr "正在安裝"
+
+#. Translators: There are no printers available (none is configured or CUPS is not running)
+#: ../panels/printers/cc-printers-panel.c:1123
+msgid "No printers available"
+msgstr "沒有可用的打印機"
+
+#. Translators: there is n active print jobs on this printer
+#: ../panels/printers/cc-printers-panel.c:1433
+#, c-format
+msgid "%u active"
+msgid_plural "%u active"
+msgstr[0] "%u 使用中"
+
+#. Translators: Addition of the new printer failed.
+#: ../panels/printers/cc-printers-panel.c:1777
+msgid "Failed to add new printer."
+msgstr "無法加入新的打印機。"
+
+#: ../panels/printers/cc-printers-panel.c:1944
+msgid "Select PPD File"
+msgstr "選擇 PPD 檔案"
+
+#: ../panels/printers/cc-printers-panel.c:1953
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr "PostScript 打印機描述檔 (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: ../panels/printers/cc-printers-panel.c:2258
+msgid "No suitable driver found"
+msgstr "找不到合適的驅動程式"
+
+#: ../panels/printers/cc-printers-panel.c:2327
+msgid "Searching for preferred drivers…"
+msgstr "正在搜尋偏好的驅動程式…"
+
+#: ../panels/printers/cc-printers-panel.c:2342
+msgid "Select from database…"
+msgstr "從資料庫搜尋…"
+
+#: ../panels/printers/cc-printers-panel.c:2351
+msgid "Provide PPD File…"
+msgstr "提供 PPD 檔案…"
+
+#. Translators: Name of job which makes printer to print test page
+#: ../panels/printers/cc-printers-panel.c:2502
+#: ../panels/printers/cc-printers-panel.c:2525
+msgid "Test page"
+msgstr "測試頁"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: ../panels/printers/cc-printers-panel.c:2933
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "無法載入 ui：%s"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:1
+msgid "Printers"
+msgstr "打印機"
+
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:2
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "加入打印機、檢視打印機工作並決定你要如何列印"
+
+#. Translators: those are keywords for the printing control-center panel
+#: ../panels/printers/gnome-printers-panel.desktop.in.in.h:4
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;打印機;佇列;列印;紙張;墨水;碳粉;"
+
+#. Translators: This dialog contains list of active print jobs of the selected printer
+#: ../panels/printers/jobs-dialog.ui.h:2
+msgid "Active Jobs"
+msgstr "使用中的工作"
+
+#: ../panels/printers/jobs-dialog.ui.h:3
+#: ../panels/printers/options-dialog.ui.h:2
+msgid "Close"
+msgstr "關閉"
+
+#: ../panels/printers/jobs-dialog.ui.h:4
+msgid "Resume Printing"
+msgstr "繼續列印"
+
+#: ../panels/printers/jobs-dialog.ui.h:5
+msgid "Pause Printing"
+msgstr "暫停列印"
+
+#: ../panels/printers/jobs-dialog.ui.h:6
+msgid "Cancel Print Job"
+msgstr "取消打印工作"
+
+#: ../panels/printers/new-printer-dialog.ui.h:1
+msgid "Add a New Printer"
+msgstr "加入新的打印機"
+
+#. Translators: This button opens authentication dialog for selected server.
+#: ../panels/printers/new-printer-dialog.ui.h:5
+msgid "A_uthenticate"
+msgstr "核對(_U)"
+
+#. Translators: No printers were found
+#: ../panels/printers/new-printer-dialog.ui.h:7
+msgid "No printers detected."
+msgstr "未偵測到打印機。"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: ../panels/printers/new-printer-dialog.ui.h:9
+msgid "Enter address of a printer or a text to filter results"
+msgstr "輸入網絡打印機的位址或過濾器結果文字"
+
+#: ../panels/printers/options-dialog.ui.h:1
+msgid "Loading options…"
+msgstr "正在載入選項…"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:1
+msgid "Select Printer Driver"
+msgstr "選擇打印機驅動程式"
+
+#: ../panels/printers/ppd-selection-dialog.ui.h:4
+msgid "Loading drivers database..."
+msgstr "載入驅動程式資料庫…"
+
+#. Translators: The found device is a JetDirect printer
+#: ../panels/printers/pp-host.c:506
+msgid "JetDirect Printer"
+msgstr "JetDirect 打印機"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: ../panels/printers/pp-host.c:756
+msgid "LPD Printer"
+msgstr "LPD 打印機"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:66
+#: ../panels/printers/pp-ppd-option-widget.c:70
+msgid "One Sided"
+msgstr "單面"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:68
+#: ../panels/printers/pp-ppd-option-widget.c:72
+msgid "Long Edge (Standard)"
+msgstr "長邊 (標準)"
+
+#. Translators: this is an option of "Two Sided"
+#: ../panels/printers/pp-ipp-option-widget.c:70
+#: ../panels/printers/pp-ppd-option-widget.c:74
+msgid "Short Edge (Flip)"
+msgstr "短邊 (翻轉)"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:72
+msgid "Portrait"
+msgstr "直向"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:74
+msgid "Landscape"
+msgstr "橫向"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse landscape"
+msgstr "橫向倒轉"
+
+#. Translators: this is an option of "Orientation"
+#: ../panels/printers/pp-ipp-option-widget.c:78
+msgid "Reverse portrait"
+msgstr "直向倒轉"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: ../panels/printers/pp-jobs-dialog.c:142
+msgctxt "print job"
+msgid "Pending"
+msgstr "保留中"
+
+#. Translators: Job's state (job is held for printing)
+#: ../panels/printers/pp-jobs-dialog.c:146
+msgctxt "print job"
+msgid "Held"
+msgstr "已暫停"
+
+#. Translators: Job's state (job is currently printing)
+#: ../panels/printers/pp-jobs-dialog.c:150
+msgctxt "print job"
+msgid "Processing"
+msgstr "處理中"
+
+#. Translators: Job's state (job has been stopped)
+#: ../panels/printers/pp-jobs-dialog.c:154
+msgctxt "print job"
+msgid "Stopped"
+msgstr "已停止"
+
+#. Translators: Job's state (job has been canceled)
+#: ../panels/printers/pp-jobs-dialog.c:158
+msgctxt "print job"
+msgid "Canceled"
+msgstr "已取消"
+
+#. Translators: Job's state (job has aborted due to error)
+#: ../panels/printers/pp-jobs-dialog.c:162
+msgctxt "print job"
+msgid "Aborted"
+msgstr "已放棄"
+
+#. Translators: Job's state (job has completed successfully)
+#: ../panels/printers/pp-jobs-dialog.c:166
+msgctxt "print job"
+msgid "Completed"
+msgstr "已完成"
+
+#. Translators: Name of column showing titles of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:288
+msgid "Job Title"
+msgstr "工作名稱"
+
+#. Translators: Name of column showing statuses of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:297
+msgid "Job State"
+msgstr "工作狀態"
+
+#. Translators: Name of column showing times of creation of print jobs
+#: ../panels/printers/pp-jobs-dialog.c:303
+msgid "Time"
+msgstr "時刻"
+
+#: ../panels/printers/pp-jobs-dialog.c:495
+#, c-format
+msgid "%s Active Jobs"
+msgstr "%s 使用中的工作"
+
+#. Translators: The found device is a printer connected via USB
+#: ../panels/printers/pp-new-printer-dialog.c:1671
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: ../panels/printers/pp-new-printer-dialog.c:1676
+msgid "Serial Port"
+msgstr "序列埠"
+
+#. Translators: The found device is a printer connected via parallel port
+#: ../panels/printers/pp-new-printer-dialog.c:1683
+msgid "Parallel Port"
+msgstr "串列埠"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: ../panels/printers/pp-new-printer-dialog.c:1739
+#, c-format
+msgid "Location: %s"
+msgstr "位置：%s"
+
+#. Translators: Network address of found printer
+#: ../panels/printers/pp-new-printer-dialog.c:1744
+#, c-format
+msgid "Address: %s"
+msgstr "位址：%s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: ../panels/printers/pp-new-printer-dialog.c:1768
+msgid "Server requires authentication"
+msgstr "伺服器需要核對"
+
+#: ../panels/printers/pp-options-dialog.c:81
+msgid "Two Sided"
+msgstr "雙面"
+
+#: ../panels/printers/pp-options-dialog.c:82
+msgid "Paper Type"
+msgstr "紙張類型"
+
+#: ../panels/printers/pp-options-dialog.c:83
+msgid "Paper Source"
+msgstr "紙張來源"
+
+#: ../panels/printers/pp-options-dialog.c:84
+msgid "Output Tray"
+msgstr "出紙匣"
+
+#: ../panels/printers/pp-options-dialog.c:86
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript 前置過濾器"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: ../panels/printers/pp-options-dialog.c:531
+msgid "Pages per side"
+msgstr "每張紙的頁數"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: ../panels/printers/pp-options-dialog.c:543
+msgid "Two-sided"
+msgstr "雙面"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: ../panels/printers/pp-options-dialog.c:555
+msgid "Orientation"
+msgstr "方向"
+
+#. Translators: "General" tab contains general printer options
+#: ../panels/printers/pp-options-dialog.c:652
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "一般"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: ../panels/printers/pp-options-dialog.c:655
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "頁面設定"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: ../panels/printers/pp-options-dialog.c:658
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "可安裝選項"
+
+#. Translators: "Job" tab contains settings for jobs
+#: ../panels/printers/pp-options-dialog.c:661
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "工作"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: ../panels/printers/pp-options-dialog.c:664
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "圖片品質"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: ../panels/printers/pp-options-dialog.c:667
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "顏色"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: ../panels/printers/pp-options-dialog.c:670
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "完成"
+
+#. Translators: "Advanced" tab contains all others settings
+#: ../panels/printers/pp-options-dialog.c:673
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "進階"
+
+#. Translators: this is an option of "Paper Source"
+#: ../panels/printers/pp-ppd-option-widget.c:76
+#: ../panels/printers/pp-ppd-option-widget.c:78
+#: ../panels/printers/pp-ppd-option-widget.c:86
+msgid "Auto Select"
+msgstr "自動選擇"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: ../panels/printers/pp-ppd-option-widget.c:80
+#: ../panels/printers/pp-ppd-option-widget.c:82
+#: ../panels/printers/pp-ppd-option-widget.c:84
+#: ../panels/printers/pp-ppd-option-widget.c:88
+msgid "Printer Default"
+msgstr "打印機預設"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:90
+msgid "Embed GhostScript fonts only"
+msgstr "只有內嵌的 GhostScript 字型"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:92
+msgid "Convert to PS level 1"
+msgstr "轉換為 PS 等級 1"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:94
+msgid "Convert to PS level 2"
+msgstr "轉換為 PS 等級 2"
+
+#. Translators: this is an option of "GhostScript"
+#: ../panels/printers/pp-ppd-option-widget.c:96
+msgid "No pre-filtering"
+msgstr "無前置過濾器"
+
+#. Translators: Name of column showing printer manufacturers
+#: ../panels/printers/pp-ppd-selection-dialog.c:233
+msgid "Manufacturer"
+msgstr "製造商"
+
+#. Translators: Name of column showing printer drivers
+#: ../panels/printers/pp-ppd-selection-dialog.c:250
+msgid "Driver"
+msgstr "驅動程式"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: ../panels/printers/pp-samba.c:248
+#, c-format
+msgid "Enter your username and password to view printers available on %s."
+msgstr "輸入你的使用者名稱與密碼以檢視在 %s 可用的打印機。"
+
+#: ../panels/printers/printers.ui.h:1
+msgid "Add Printer"
+msgstr "加入打印機"
+
+#: ../panels/printers/printers.ui.h:2
+msgid "Remove Printer"
+msgstr "移除打印機"
+
+#. Translators: By supply we mean ink, toner, staples, water, ...
+#: ../panels/printers/printers.ui.h:4
+msgid "Supply"
+msgstr "耗材"
+
+#. Translators: Location of the printer (e.g. Lab, 1st floor,...).
+#: ../panels/printers/printers.ui.h:6
+msgid "Location"
+msgstr "位置"
+
+#. Translators: This checkbox is checked when the default printer is selected.
+#: ../panels/printers/printers.ui.h:8
+msgid "_Default printer"
+msgstr "預設打印機(_D)"
+
+#: ../panels/printers/printers.ui.h:9
+msgid "Jobs"
+msgstr "工作"
+
+#. Translators: Opens a dialog containing printer's jobs
+#: ../panels/printers/printers.ui.h:11
+msgid "Show _Jobs"
+msgstr "顯示工作(_J)"
+
+#: ../panels/printers/printers.ui.h:12
+msgid "Model"
+msgstr "型號"
+
+#: ../panels/printers/printers.ui.h:15
+msgid "label"
+msgstr "標籤"
+
+#: ../panels/printers/printers.ui.h:17
+msgid "Setting new driver…"
+msgstr "設定新的驅動程式…"
+
+#: ../panels/printers/printers.ui.h:18
+msgid "page 3"
+msgstr "頁 3"
+
+#. Translators: This button executes command which prints test page.
+#: ../panels/printers/printers.ui.h:20
+msgid "Print _Test Page"
+msgstr "列印測試頁(_T)"
+
+#. Translators: This button opens printer's options tab
+#: ../panels/printers/printers.ui.h:22
+msgid "_Options"
+msgstr "選項(_O)"
+
+#. Translators: This button adds new printer.
+#: ../panels/printers/printers.ui.h:24
+msgid "Add New Printer"
+msgstr "加入新的打印機"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: ../panels/printers/printers.ui.h:26
+msgid ""
+"Sorry! The system printing service\n"
+"doesn't seem to be available."
+msgstr ""
+"抱歉！系統列印服務\n"
+"似乎無法使用。"
+
+#: ../panels/privacy/cc-privacy-panel.c:252 ../panels/privacy/privacy.ui.h:24
+msgid "Screen Lock"
+msgstr "螢幕鎖定"
+
+#: ../panels/privacy/cc-privacy-panel.c:362 ../panels/privacy/privacy.ui.h:19
+msgid "Usage & History"
+msgstr "使用與歷史紀錄"
+
+#: ../panels/privacy/cc-privacy-panel.c:487
+msgid "Empty all items from Trash?"
+msgstr "要清除回收筒中所有的項目？"
+
+#: ../panels/privacy/cc-privacy-panel.c:488
+msgid "All items in the Trash will be permanently deleted."
+msgstr "所有在回收筒中的項目會永遠刪除。"
+
+#: ../panels/privacy/cc-privacy-panel.c:489 ../panels/privacy/privacy.ui.h:34
+msgid "_Empty Trash"
+msgstr "清理回收筒(_E)"
+
+#: ../panels/privacy/cc-privacy-panel.c:512
+msgid "Delete all the temporary files?"
+msgstr "刪除所有暫存檔案？"
+
+#: ../panels/privacy/cc-privacy-panel.c:513
+msgid "All the temporary files will be permanently deleted."
+msgstr "所有的暫存檔案會永遠刪除。"
+
+#: ../panels/privacy/cc-privacy-panel.c:514 ../panels/privacy/privacy.ui.h:35
+msgid "_Purge Temporary Files"
+msgstr "清理暫存檔案(_P)"
+
+#: ../panels/privacy/cc-privacy-panel.c:536 ../panels/privacy/privacy.ui.h:29
+msgid "Purge Trash & Temporary Files"
+msgstr "清除回收筒與暫存檔案"
+
+#: ../panels/privacy/cc-privacy-panel.c:576 ../panels/privacy/privacy.ui.h:36
+msgid "Software Usage"
+msgstr "軟件使用率"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:1
+msgid "Privacy"
+msgstr "私隱"
+
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:2
+msgid "Protect your personal information and control what others might see"
+msgstr "保護你的個人資料並控制其他人能看到什麼"
+
+#. Translators: those are keywords for the privacy control-center panel
+#: ../panels/privacy/gnome-privacy-panel.desktop.in.in.h:4
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;"
+msgstr "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;network;identity;螢幕;鎖定;診斷;私隱;最近使用;暫存;索引;名稱;網絡;身分;"
+
+#: ../panels/privacy/privacy.ui.h:1
+msgid "Screen Turns Off"
+msgstr "螢幕關閉"
+
+#: ../panels/privacy/privacy.ui.h:2
+msgid "30 seconds"
+msgstr "30 秒"
+
+#: ../panels/privacy/privacy.ui.h:9
+msgid "1 day"
+msgstr "1 天"
+
+#: ../panels/privacy/privacy.ui.h:10
+msgid "2 days"
+msgstr "2 天"
+
+#: ../panels/privacy/privacy.ui.h:11
+msgid "3 days"
+msgstr "3 天"
+
+#: ../panels/privacy/privacy.ui.h:12
+msgid "4 days"
+msgstr "4 天"
+
+#: ../panels/privacy/privacy.ui.h:13
+msgid "5 days"
+msgstr "5 天"
+
+#: ../panels/privacy/privacy.ui.h:14
+msgid "6 days"
+msgstr "6 天"
+
+#: ../panels/privacy/privacy.ui.h:15
+msgid "7 days"
+msgstr "7 天"
+
+#: ../panels/privacy/privacy.ui.h:16
+msgid "14 days"
+msgstr "14 天"
+
+#: ../panels/privacy/privacy.ui.h:17
+msgid "30 days"
+msgstr "30 天"
+
+#: ../panels/privacy/privacy.ui.h:18
+msgid "Forever"
+msgstr "永遠"
+
+#: ../panels/privacy/privacy.ui.h:20
+msgid ""
+"Remembering your history makes things easier to find again. These items are "
+"never shared over the network."
+msgstr "記住你的歷史紀錄會讓需要再次找到某樣東西時更簡單。這些項目永遠不會透過網絡分享出去。"
+
+#: ../panels/privacy/privacy.ui.h:21
+msgid "_Recently Used"
+msgstr "最近使用(_R)"
+
+#: ../panels/privacy/privacy.ui.h:22
+msgid "Retain _History"
+msgstr "保留歷史紀錄(_H)"
+
+#: ../panels/privacy/privacy.ui.h:23
+msgid "Cl_ear Recent History"
+msgstr "清除最近使用紀錄(_E)"
+
+#: ../panels/privacy/privacy.ui.h:25
+msgid "The Screen Lock protects your privacy when you are away."
+msgstr "螢幕鎖可以在你離開時保護你的私隱。"
+
+#: ../panels/privacy/privacy.ui.h:26
+msgid "Automatic Screen _Lock"
+msgstr "自動鎖定螢幕(_L)"
+
+#: ../panels/privacy/privacy.ui.h:27
+msgid "Lock screen _after blank for"
+msgstr "螢幕轉黑後多久鎖定螢幕(_A)"
+
+#: ../panels/privacy/privacy.ui.h:28
+msgid "Show _Notifications"
+msgstr "顯示通知(_N)"
+
+#: ../panels/privacy/privacy.ui.h:30
+msgid ""
+"Automatically purge the Trash and temporary files to help keep your computer "
+"free of unnecessary sensitive information."
+msgstr "自動清除回收筒和暫存檔案可以保護你的電腦減少不必要的敏感資訊。"
+
+#: ../panels/privacy/privacy.ui.h:31
+msgid "Automatically empty _Trash"
+msgstr "自動清空回收筒(_T)"
+
+#: ../panels/privacy/privacy.ui.h:32
+msgid "Automatically purge Temporary _Files"
+msgstr "自動清除暫存檔案(_F)"
+
+#: ../panels/privacy/privacy.ui.h:33
+msgid "Purge _After"
+msgstr "清除於(_A)"
+
+#: ../panels/privacy/privacy.ui.h:37
+msgid ""
+"Sending us information about which software you use helps us provide you "
+"with more accurate recommendations. It also helps us to improve our "
+"software.\n"
+"\n"
+"All the information we collect is made anonymous, and we will never share "
+"your data with third parties."
+msgstr ""
+"傳送你所使用軟件的資訊給我們能幫助我們提供你更準確的建議。它也能協助我們改進我們的軟件。\n"
+"\n"
+"我們所收集的所有資訊都是匿名的，而且我們永遠不會將你的資料與任何第三方分享。"
+
+#: ../panels/privacy/privacy.ui.h:40
+msgid "_Send software usage statistics"
+msgstr "傳送軟件使用率統計(_S)"
+
+#: ../panels/privacy/privacy.ui.h:41
+msgid "Privacy Policy"
+msgstr "私隱權原則"
+
+#: ../panels/privacy/privacy.ui.h:42
+msgid "_Location Services"
+msgstr "位置服務(_L)"
+
+#: ../panels/privacy/privacy.ui.h:43
+msgid "Used to determine your geographical location"
+msgstr "用來判斷你所在的地理位置"
+
+#: ../panels/region/cc-format-chooser.c:119
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "英制"
+
+#: ../panels/region/cc-format-chooser.c:121
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "公制"
+
+#: ../panels/region/cc-format-chooser.c:284
+msgid "No regions found"
+msgstr "找不到區域"
+
+#: ../panels/region/cc-input-chooser.c:179
+msgid "No input sources found"
+msgstr "找不到輸入來源"
+
+#: ../panels/region/cc-input-chooser.c:1076
+msgctxt "Input Source"
+msgid "Other"
+msgstr "其他"
+
+#: ../panels/region/cc-region-panel.c:239
+#: ../panels/user-accounts/um-user-panel.c:896
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "你的作業階段需要重新啟動以讓更改生效"
+
+#: ../panels/region/cc-region-panel.c:240
+#: ../panels/user-accounts/um-user-panel.c:897
+msgid "Restart Now"
+msgstr "立刻重新啟動"
+
+#: ../panels/region/cc-region-panel.c:858
+msgid "No input source selected"
+msgstr "尚未選擇輸入來源"
+
+#: ../panels/region/cc-region-panel.c:1088
+msgid "Sorry"
+msgstr "抱歉"
+
+#: ../panels/region/cc-region-panel.c:1090
+msgid "Input methods can't be used on the login screen"
+msgstr "輸入法不能用在登入畫面"
+
+#: ../panels/region/cc-region-panel.c:1727
+msgid "Login Screen"
+msgstr "登入畫面"
+
+#: ../panels/region/format-chooser.ui.h:1 ../panels/region/region.ui.h:3
+msgid "Formats"
+msgstr "格式"
+
+#: ../panels/region/format-chooser.ui.h:4
+msgid "Preview"
+msgstr "預覽"
+
+#: ../panels/region/format-chooser.ui.h:5
+msgid "Dates"
+msgstr "日期"
+
+#: ../panels/region/format-chooser.ui.h:6
+msgid "Times"
+msgstr "時刻"
+
+#: ../panels/region/format-chooser.ui.h:7
+msgid "Numbers"
+msgstr "數字"
+
+#: ../panels/region/format-chooser.ui.h:8
+msgid "Measurement"
+msgstr "度量衡"
+
+#: ../panels/region/format-chooser.ui.h:9
+msgid "Paper"
+msgstr "紙張"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:1
+msgid "Region & Language"
+msgstr "地區和語言"
+
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:2
+msgid ""
+"Select your display language, formats, keyboard layouts and input sources"
+msgstr "選擇你的顯示語言、格式、鍵盤配置和輸入來源"
+
+#. Translators: those are keywords for the region control-center panel
+#: ../panels/region/gnome-region-panel.desktop.in.in.h:4
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;語言;配置;鍵盤;輸入;"
+
+#: ../panels/region/input-chooser.ui.h:1
+msgid "Add an Input Source"
+msgstr "加入輸入來源"
+
+#: ../panels/region/input-options.ui.h:1
+msgid "Input Source Options"
+msgstr "輸入來源選項"
+
+#: ../panels/region/input-options.ui.h:2
+msgid "Use the _same source for all windows"
+msgstr "在所有視窗中使用相同的來源(_S)"
+
+#: ../panels/region/input-options.ui.h:3
+msgid "Allow _different sources for each window"
+msgstr "每個視窗使用不同的輸入來源(_D)"
+
+#: ../panels/region/input-options.ui.h:4
+msgid "Keyboard Shortcuts"
+msgstr "鍵盤捷徑鍵"
+
+#: ../panels/region/input-options.ui.h:5
+msgid "Switch to previous source"
+msgstr "切換至上個來源"
+
+#: ../panels/region/input-options.ui.h:6
+msgid "Super+Shift+Space"
+msgstr "Super+Shift+Space"
+
+#: ../panels/region/input-options.ui.h:7
+msgid "Switch to next source"
+msgstr "切換至下個來源"
+
+#: ../panels/region/input-options.ui.h:8
+msgid "Super+Space"
+msgstr "Super+Space"
+
+#: ../panels/region/input-options.ui.h:9
+msgid "You can change these shortcuts in the keyboard settings"
+msgstr "你可以在鍵盤設定值中改變這些捷徑鍵"
+
+#: ../panels/region/input-options.ui.h:10
+msgid "Alternative switch to next source"
+msgstr "切換至下個來源的替代鍵"
+
+#: ../panels/region/input-options.ui.h:11
+msgid "Left+Right Alt"
+msgstr "左+右 Alt"
+
+#: ../panels/region/region.ui.h:2
+msgid "English (United Kingdom)"
+msgstr "英文 (英國)"
+
+#: ../panels/region/region.ui.h:4
+msgid "United Kingdom"
+msgstr "英國"
+
+#: ../panels/region/region.ui.h:6
+msgid "Options"
+msgstr "選項"
+
+#: ../panels/region/region.ui.h:7
+msgid "Login settings are used by all users when logging into the system"
+msgstr "登入設定值是所有的使用者在登入系統時會用到的"
+
+#: ../panels/search/cc-search-locations-dialog.c:476
+msgctxt "Search Location"
+msgid "Places"
+msgstr "位置"
+
+#: ../panels/search/cc-search-locations-dialog.c:478
+msgctxt "Search Location"
+msgid "Bookmarks"
+msgstr "書籤"
+
+#: ../panels/search/cc-search-locations-dialog.c:480
+msgctxt "Search Location"
+msgid "Other"
+msgstr "其他"
+
+#: ../panels/search/cc-search-locations-dialog.c:678
+msgid "Select Location"
+msgstr "選擇位置"
+
+#: ../panels/search/cc-search-locations-dialog.c:682
+msgid "_OK"
+msgstr "確定(_O)"
+
+#: ../panels/search/cc-search-panel.c:176
+msgid "No applications found"
+msgstr "找不到應用程式"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:1
+msgid "Search"
+msgstr "搜尋"
+
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:2
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "控制在活動概覽中哪些應用程式會顯示在搜尋結果中"
+
+#. Translators: those are keywords for the search control-center panel
+#: ../panels/search/gnome-search-panel.desktop.in.in.h:4
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;搜尋;尋找;索引;隱藏;私隱;結果;"
+
+#: ../panels/search/search-locations-dialog.ui.h:1
+msgid "Search Locations"
+msgstr "搜尋位置"
+
+#: ../panels/search/search.ui.h:1
+msgid "Move Up"
+msgstr "往上移"
+
+#: ../panels/search/search.ui.h:2
+msgid "Move Down"
+msgstr "往下移"
+
+#: ../panels/search/search.ui.h:3
+msgid "Preferences"
+msgstr "偏好設定"
+
+#: ../panels/sharing/cc-sharing-panel.c:272
+msgctxt "service is enabled"
+msgid "On"
+msgstr "開啟"
+
+#: ../panels/sharing/cc-sharing-panel.c:274
+#: ../panels/sharing/cc-sharing-panel.c:301
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "關閉"
+
+#: ../panels/sharing/cc-sharing-panel.c:304
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "已啟用"
+
+#: ../panels/sharing/cc-sharing-panel.c:307
+msgctxt "service is active"
+msgid "Active"
+msgstr "使用中"
+
+#: ../panels/sharing/cc-sharing-panel.c:488
+msgid "Choose a Folder"
+msgstr "選擇一個資料夾"
+
+#: ../panels/sharing/cc-sharing-panel.c:916
+msgid "Copy"
+msgstr "複製"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:1
+msgid "Sharing"
+msgstr "分享"
+
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:2
+msgid "Control what you want to share with others"
+msgstr "控制你想要與其他人分享什麼"
+
+#. Translators: those are keywords for the sharing control-center panel
+#: ../panels/sharing/gnome-sharing-panel.desktop.in.in.h:4
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;"
+"pictures;photos;movies;server;renderer;"
+msgstr "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;video;pictures;photos;movies;server;renderer;分享;主機;名稱;遠端;桌面;藍牙;媒體;音樂;視像;圖片;相片;影片;伺服器;"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:1
+msgid "Enable or disable remote login"
+msgstr "啟用或停用遠端登入"
+
+#: ../panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in.h:2
+msgid "Authentication is required to enable or disable remote login"
+msgstr "啟用或停用遠端登入需要核對"
+
+#. Label
+#: ../panels/sharing/cc-sharing-networks.c:299
+msgid "No networks selected for sharing"
+msgstr "沒有選擇用來分享的網絡"
+
+#.
+#. * vim: sw=2 ts=8 cindent noai bs=2
+#.
+#: ../panels/sharing/networks.ui.h:1
+msgid "Networks"
+msgstr "網絡"
+
+#: ../panels/sharing/sharing.ui.h:1
+msgid "Bluetooth Sharing"
+msgstr "藍牙分享"
+
+#: ../panels/sharing/sharing.ui.h:2
+msgid ""
+"Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+"devices"
+msgstr "藍牙分享允許你與其他具有藍牙的裝置分享檔案"
+
+#: ../panels/sharing/sharing.ui.h:3
+msgid "Only Receive From Trusted Devices"
+msgstr "只接收信任的裝置"
+
+#: ../panels/sharing/sharing.ui.h:4
+msgid "Save Received Files to Downloads Folder"
+msgstr "將接收的檔案儲存至下載資料夾"
+
+#: ../panels/sharing/sharing.ui.h:5
+msgid "Computer Name"
+msgstr "電腦名稱"
+
+#: ../panels/sharing/sharing.ui.h:6
+msgid "Personal File Sharing"
+msgstr "個人檔案分享"
+
+#: ../panels/sharing/sharing.ui.h:7
+msgid "Screen Sharing"
+msgstr "螢幕分享"
+
+#: ../panels/sharing/sharing.ui.h:8
+msgid "Media Sharing"
+msgstr "媒體分享"
+
+#: ../panels/sharing/sharing.ui.h:9
+msgid "Remote Login"
+msgstr "遠端登入"
+
+#: ../panels/sharing/sharing.ui.h:10
+msgid "Some services are disabled because of no network access."
+msgstr "由於沒有網絡存取，某些服務已停用。"
+
+#: ../panels/sharing/sharing.ui.h:12
+#, no-c-format
+msgid ""
+"Personal File Sharing allows you to share your Public folder with others on "
+"your current network using: <a href=\"dav://%s\">dav://%s</a>"
+msgstr "個人檔案分享允許你使用： <a href=\"dav://%s\">dav://%s</a> 與目前網絡上的其他人分享你的公開資料夾"
+
+#: ../panels/sharing/sharing.ui.h:13
+msgid "Require Password"
+msgstr "需要密碼"
+
+#: ../panels/sharing/sharing.ui.h:16
+#, no-c-format
+msgid ""
+"Allow remote users to connect using the Secure Shell command:\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+msgstr ""
+"允許遠端使用者使用 SSH 指令連線：\n"
+"<a href=\"ssh %s\">ssh %s</a>"
+
+#: ../panels/sharing/sharing.ui.h:19
+#, no-c-format
+msgid ""
+"Allow remote users to view or control your screen by connecting to: <a href="
+"\"vnc://%s\">vnc://%s</a>"
+msgstr "允許遠端使用者連線到：<a href=\"vnc://%s\">vnc://%s</a> 檢視或控制你的螢幕"
+
+#: ../panels/sharing/sharing.ui.h:20
+msgid "Allow Remote Control"
+msgstr "允許遙控"
+
+#: ../panels/sharing/sharing.ui.h:21
+msgid "Password:"
+msgstr "密碼："
+
+#: ../panels/sharing/sharing.ui.h:22
+msgid "Show Password"
+msgstr "顯示密碼"
+
+#: ../panels/sharing/sharing.ui.h:23
+msgid "Access Options"
+msgstr "存取選項"
+
+#: ../panels/sharing/sharing.ui.h:24
+msgid "New connections must ask for access"
+msgstr "存取新的連線必須詢問"
+
+#: ../panels/sharing/sharing.ui.h:25
+msgid "Require a password"
+msgstr "需要密碼"
+
+#: ../panels/sharing/sharing.ui.h:26
+msgid "Share music, photos and videos over the network."
+msgstr "與網絡上其他人分享音樂、相片和影片。"
+
+#: ../panels/sharing/sharing.ui.h:27
+msgid "Folders"
+msgstr "資料夾"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:1
+msgid "Sound"
+msgstr "音效"
+
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:2
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "改變音效的音量、輸入、輸出和警示音效"
+
+#. Translators: those are keywords for the sound control-center panel
+#: ../panels/sound/data/gnome-sound-panel.desktop.in.in.h:4
+msgid "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;"
+msgstr "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;音效卡;麥克風;音量;淡化;平衡;藍牙;耳機;音效;"
+
+#. Translators: This is the name of an audio file that sounds like the bark of a dog.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:3
+msgid "Bark"
+msgstr "汪汪"
+
+#. Translators: This is the name of an audio file that sounds like a water drip.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:6
+msgid "Drip"
+msgstr "水滴聲"
+
+#. Translators: This is the name of an audio file that sounds like tapping glass.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:9
+msgid "Glass"
+msgstr "敲玻璃"
+
+#. Translators: This is the name of an audio file that sounds sort of like a submarine sonar ping.
+#. You might want to translate it into the equivalent words of your language.
+#: ../panels/sound/data/sounds/gnome-sounds-default.xml.in.in.h:12
+msgid "Sonar"
+msgstr "聲納"
+
+#: ../panels/sound/gvc-balance-bar.c:105
+msgctxt "balance"
+msgid "Left"
+msgstr "左"
+
+#: ../panels/sound/gvc-balance-bar.c:106
+msgctxt "balance"
+msgid "Right"
+msgstr "右"
+
+#: ../panels/sound/gvc-balance-bar.c:109
+msgctxt "balance"
+msgid "Rear"
+msgstr "後"
+
+#: ../panels/sound/gvc-balance-bar.c:110
+msgctxt "balance"
+msgid "Front"
+msgstr "前"
+
+#: ../panels/sound/gvc-balance-bar.c:113
+msgctxt "balance"
+msgid "Minimum"
+msgstr "最小值"
+
+#: ../panels/sound/gvc-balance-bar.c:114
+msgctxt "balance"
+msgid "Maximum"
+msgstr "最大值"
+
+#: ../panels/sound/gvc-balance-bar.c:289
+msgid "_Balance:"
+msgstr "平衡(_B)："
+
+#: ../panels/sound/gvc-balance-bar.c:292
+msgid "_Fade:"
+msgstr "淡化(_F)："
+
+#: ../panels/sound/gvc-balance-bar.c:295
+msgid "_Subwoofer:"
+msgstr "重低音(_S)："
+
+#: ../panels/sound/gvc-channel-bar.c:612 ../panels/sound/gvc-channel-bar.c:621
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: ../panels/sound/gvc-channel-bar.c:616
+msgctxt "volume"
+msgid "Unamplified"
+msgstr "未經放大"
+
+#: ../panels/sound/gvc-combo-box.c:166 ../panels/sound/gvc-mixer-dialog.c:260
+#: ../panels/sound/gvc-mixer-dialog.c:526
+msgid "_Profile:"
+msgstr "設定組合(_P):"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1837
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u 輸出"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: ../panels/sound/gvc/gvc-mixer-control.c:1847
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u 輸入"
+
+#: ../panels/sound/gvc/gvc-mixer-control.c:2373
+msgid "System Sounds"
+msgstr "系統音效"
+
+#: ../panels/sound/gvc-mixer-dialog.c:262
+msgid "_Test Speakers"
+msgstr "測試喇叭(_T)"
+
+#: ../panels/sound/gvc-mixer-dialog.c:431
+msgid "Peak detect"
+msgstr "峰值檢測"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1509
+#: ../panels/sound/gvc-sound-theme-chooser.c:594
+msgid "Name"
+msgstr "名稱"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1528
+msgid "Device"
+msgstr "裝置"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1591
+#, c-format
+msgid "Speaker Testing for %s"
+msgstr "%s 的喇叭測試"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1649
+msgid "_Output volume:"
+msgstr "輸出音量(_O)："
+
+#: ../panels/sound/gvc-mixer-dialog.c:1663
+msgid "Output"
+msgstr "輸出"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1668
+msgid "C_hoose a device for sound output:"
+msgstr "選擇聲音輸出的裝置(_H)："
+
+#: ../panels/sound/gvc-mixer-dialog.c:1693
+msgid "Settings for the selected device:"
+msgstr "已選取裝置的設定值："
+
+#: ../panels/sound/gvc-mixer-dialog.c:1704
+msgid "Input"
+msgstr "輸入"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1711
+msgid "_Input volume:"
+msgstr "輸入音量(_I)："
+
+#: ../panels/sound/gvc-mixer-dialog.c:1734
+msgid "Input level:"
+msgstr "輸入等級："
+
+#: ../panels/sound/gvc-mixer-dialog.c:1762
+msgid "C_hoose a device for sound input:"
+msgstr "選擇聲音輸入的裝置(_H)："
+
+#: ../panels/sound/gvc-mixer-dialog.c:1789
+msgid "Sound Effects"
+msgstr "聲音效果"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1796
+msgid "_Alert volume:"
+msgstr "警示音量(_A)："
+
+#: ../panels/sound/gvc-mixer-dialog.c:1809
+msgid "Applications"
+msgstr "程式集"
+
+#: ../panels/sound/gvc-mixer-dialog.c:1813
+msgid "No application is currently playing or recording audio."
+msgstr "沒有應用程式目前正在播放或錄製音效。"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:188
+msgid "Built-in"
+msgstr "內置"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:454
+#: ../panels/sound/gvc-sound-theme-chooser.c:466
+#: ../panels/sound/gvc-sound-theme-chooser.c:478
+msgid "Sound Preferences"
+msgstr "音效偏好設定"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:457
+#: ../panels/sound/gvc-sound-theme-chooser.c:468
+#: ../panels/sound/gvc-sound-theme-chooser.c:480
+msgid "Testing event sound"
+msgstr "測試事件聲音"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:584
+msgid "Default"
+msgstr "預設值"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:585
+msgid "From theme"
+msgstr "從主題"
+
+#: ../panels/sound/gvc-sound-theme-chooser.c:769
+msgid "C_hoose an alert sound:"
+msgstr "選擇警示音效(_H)："
+
+#: ../panels/sound/gvc-speaker-test.c:219
+msgid "Stop"
+msgstr "停止"
+
+#: ../panels/sound/gvc-speaker-test.c:219
+#: ../panels/sound/gvc-speaker-test.c:331
+msgid "Test"
+msgstr "測試"
+
+#: ../panels/sound/gvc-speaker-test.c:227
+msgid "Subwoofer"
+msgstr "重低音"
+
+#: ../panels/sound/sound-theme-file-utils.c:290
+msgid "Custom"
+msgstr "自選"
+
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:2
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "讓電腦更容易看、聽、輸入、指向與點選"
+
+#. Translators: those are keywords for the universal access control-center panel
+#: ../panels/universal-access/gnome-universal-access-panel.desktop.in.in.h:4
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;"
+"AccessX;Sticky;Keys;Slow;Bounce;Mouse;"
+msgstr "Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen Reader;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;鍵盤;滑鼠;無障礙;對比;螢幕;閱讀器;文字;字型;大小;相黏;遲緩;反彈;滑鼠;鍵;按鍵"
+
+#: ../panels/universal-access/uap.ui.h:1
+msgid "_Always Show Universal Access Menu"
+msgstr "永遠顯示無障礙存取選單(_A)"
+
+#: ../panels/universal-access/uap.ui.h:2
+msgid "Seeing"
+msgstr "視覺"
+
+#: ../panels/universal-access/uap.ui.h:3
+msgid "_High Contrast"
+msgstr "高反差(_H)"
+
+#: ../panels/universal-access/uap.ui.h:4
+msgid "_Large Text"
+msgstr "大型文字(_L)"
+
+#: ../panels/universal-access/uap.ui.h:5
+msgid "_Zoom"
+msgstr "縮放(_Z)"
+
+#: ../panels/universal-access/uap.ui.h:7
+msgid "Screen _Reader"
+msgstr "螢幕閱讀器(_R)"
+
+#: ../panels/universal-access/uap.ui.h:8
+msgid "_Sound Keys"
+msgstr "聲音按鍵(_S)"
+
+#: ../panels/universal-access/uap.ui.h:9
+msgid "Hearing"
+msgstr "聽覺"
+
+#: ../panels/universal-access/uap.ui.h:10
+msgid "_Visual Alerts"
+msgstr "視覺警示(_V)"
+
+#: ../panels/universal-access/uap.ui.h:12
+msgid "Screen _Keyboard"
+msgstr "螢幕鍵盤(_K)"
+
+#: ../panels/universal-access/uap.ui.h:13
+msgid "_Typing Assist (AccessX)"
+msgstr "打字助理 [AccessX](_T)"
+
+#: ../panels/universal-access/uap.ui.h:14
+msgid "Pointing & Clicking"
+msgstr "指向 & 點選"
+
+#: ../panels/universal-access/uap.ui.h:15
+msgid "_Mouse Keys"
+msgstr "滑鼠按鍵(_M)"
+
+#: ../panels/universal-access/uap.ui.h:16
+msgid "_Click Assist"
+msgstr "點擊助理(_C)"
+
+#: ../panels/universal-access/uap.ui.h:17
+msgid "Screen Reader"
+msgstr "螢幕閱讀器"
+
+#: ../panels/universal-access/uap.ui.h:18
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "螢幕閱讀器能在你移動焦點時讀出顯示的文字。"
+
+#: ../panels/universal-access/uap.ui.h:19
+msgid "_Screen Reader"
+msgstr "螢幕閱讀器(_S)"
+
+#: ../panels/universal-access/uap.ui.h:20
+msgid "Sound Keys"
+msgstr "聲音按鍵"
+
+#: ../panels/universal-access/uap.ui.h:21
+msgid "Beep when Num Lock or Caps Lock are turned on."
+msgstr "當 Num Lock 或 Caps Lock 開啟時發出聲響。"
+
+#: ../panels/universal-access/uap.ui.h:22
+msgid "Visual Alerts"
+msgstr "視覺警示"
+
+#: ../panels/universal-access/uap.ui.h:23
+msgid "_Test flash"
+msgstr "測試閃動(_T)"
+
+#: ../panels/universal-access/uap.ui.h:24
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "當警示音效發出時使用視覺化的指示。"
+
+#: ../panels/universal-access/uap.ui.h:25
+msgid "Flash the _window title"
+msgstr "閃動視窗標題(_W)"
+
+#: ../panels/universal-access/uap.ui.h:26
+msgid "Flash the entire _screen"
+msgstr "閃動整個螢幕(_S)"
+
+#: ../panels/universal-access/uap.ui.h:27
+msgid "Typing Assist"
+msgstr "打字助理"
+
+#: ../panels/universal-access/uap.ui.h:28
+msgid "_Sticky Keys"
+msgstr "黏性特殊鍵(_S)"
+
+#: ../panels/universal-access/uap.ui.h:29
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "將連續按的特殊鍵視為按鍵組合"
+
+#: ../panels/universal-access/uap.ui.h:30
+msgid "_Disable if two keys are pressed together"
+msgstr "如果同時按下任何兩鍵則停用(_D)"
+
+#: ../panels/universal-access/uap.ui.h:31
+msgid "Beep when a _modifer key is pressed"
+msgstr "當按下特殊按鍵時發出聲響(_M)"
+
+#: ../panels/universal-access/uap.ui.h:32
+msgid "S_low Keys"
+msgstr "重複按鍵(_L)"
+
+#: ../panels/universal-access/uap.ui.h:33
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "在按鍵被按下到它被接受之間置入延遲"
+
+#: ../panels/universal-access/uap.ui.h:34
+msgid "A_cceptance delay:"
+msgstr "接受時間延遲(_C)："
+
+#: ../panels/universal-access/uap.ui.h:35
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "短"
+
+#: ../panels/universal-access/uap.ui.h:36
+msgid "Slow keys typing delay"
+msgstr "降低按鍵輸入延遲"
+
+#: ../panels/universal-access/uap.ui.h:37
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "長"
+
+#: ../panels/universal-access/uap.ui.h:38
+msgid "Beep when a key is pr_essed"
+msgstr "當按下按鍵時發出聲響(_E)"
+
+#: ../panels/universal-access/uap.ui.h:39
+msgid "Beep when a key is _accepted"
+msgstr "當接受按鍵動作時發出聲響(_A)"
+
+#: ../panels/universal-access/uap.ui.h:40
+msgid "Beep when a key is _rejected"
+msgstr "當拒絕按鍵動作則發出聲響(_R)"
+
+#: ../panels/universal-access/uap.ui.h:41
+msgid "_Bounce Keys"
+msgstr "反彈鍵(_B)"
+
+#: ../panels/universal-access/uap.ui.h:42
+msgid "Ignores fast duplicate keypresses"
+msgstr "忽略快速重複按鍵"
+
+#: ../panels/universal-access/uap.ui.h:43
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "短"
+
+#: ../panels/universal-access/uap.ui.h:44
+msgid "Bounce keys typing delay"
+msgstr "反彈鍵輸入延遲"
+
+#: ../panels/universal-access/uap.ui.h:45
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "長"
+
+#: ../panels/universal-access/uap.ui.h:46
+msgid "_Enable by Keyboard"
+msgstr "由鍵盤啟用(_E)"
+
+#: ../panels/universal-access/uap.ui.h:47
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "以鍵盤開啟和關閉無障礙功能"
+
+#: ../panels/universal-access/uap.ui.h:48
+msgid "Click Assist"
+msgstr "點擊助理"
+
+#: ../panels/universal-access/uap.ui.h:49
+msgid "_Simulated Secondary Click"
+msgstr "模擬次要點擊(_S)"
+
+#: ../panels/universal-access/uap.ui.h:50
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "按住主要鍵時觸發次要點擊"
+
+#: ../panels/universal-access/uap.ui.h:51
+msgctxt "secondary click"
+msgid "Short"
+msgstr "短"
+
+#: ../panels/universal-access/uap.ui.h:52
+msgid "Secondary click delay"
+msgstr "第二次點擊延遲"
+
+#: ../panels/universal-access/uap.ui.h:53
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "長"
+
+#: ../panels/universal-access/uap.ui.h:54
+msgid "_Hover Click"
+msgstr "停駐即點擊(_H)"
+
+#: ../panels/universal-access/uap.ui.h:55
+msgid "Trigger a click when the pointer hovers"
+msgstr "當停止游標移動時觸發點擊"
+
+#: ../panels/universal-access/uap.ui.h:56
+msgid "D_elay:"
+msgstr "延遲(_E)："
+
+#: ../panels/universal-access/uap.ui.h:57
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "短"
+
+#: ../panels/universal-access/uap.ui.h:58
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "長"
+
+#: ../panels/universal-access/uap.ui.h:59
+msgid "Motion _threshold:"
+msgstr "移動速度(_M)："
+
+#: ../panels/universal-access/uap.ui.h:60
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "小"
+
+#: ../panels/universal-access/uap.ui.h:61
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "大"
+
+#: ../panels/universal-access/zoom-options.c:333
+msgctxt "Distance"
+msgid "Short"
+msgstr "短"
+
+#: ../panels/universal-access/zoom-options.c:334
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ 螢幕"
+
+#: ../panels/universal-access/zoom-options.c:335
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ 螢幕"
+
+#: ../panels/universal-access/zoom-options.c:336
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ 螢幕"
+
+#: ../panels/universal-access/zoom-options.c:337
+msgctxt "Distance"
+msgid "Long"
+msgstr "長"
+
+#: ../panels/universal-access/zoom-options.ui.h:1
+msgid "Full Screen"
+msgstr "全螢幕"
+
+#: ../panels/universal-access/zoom-options.ui.h:2
+msgid "Top Half"
+msgstr "上半部"
+
+#: ../panels/universal-access/zoom-options.ui.h:3
+msgid "Bottom Half"
+msgstr "下半部"
+
+#: ../panels/universal-access/zoom-options.ui.h:4
+msgid "Left Half"
+msgstr "左半"
+
+#: ../panels/universal-access/zoom-options.ui.h:5
+msgid "Right Half"
+msgstr "右半"
+
+#: ../panels/universal-access/zoom-options.ui.h:6
+msgid "Zoom Options"
+msgstr "放大鏡選項"
+
+#: ../panels/universal-access/zoom-options.ui.h:7
+msgid "Zoom"
+msgstr "縮放"
+
+#: ../panels/universal-access/zoom-options.ui.h:8
+msgid "Magnification:"
+msgstr "放大率："
+
+#: ../panels/universal-access/zoom-options.ui.h:9
+msgid "Follow mouse cursor"
+msgstr "跟隨滑鼠遊標"
+
+#: ../panels/universal-access/zoom-options.ui.h:10
+msgid "Screen part:"
+msgstr "螢幕部分："
+
+#: ../panels/universal-access/zoom-options.ui.h:11
+msgid "Magnifier extends outside of screen"
+msgstr "放大鏡延伸到螢幕外"
+
+#: ../panels/universal-access/zoom-options.ui.h:12
+msgid "Keep magnifier cursor centered"
+msgstr "保持放大鏡游標置中"
+
+#: ../panels/universal-access/zoom-options.ui.h:13
+msgid "Magnifier cursor pushes contents around"
+msgstr "放大鏡游標將內容推到周圍"
+
+#: ../panels/universal-access/zoom-options.ui.h:14
+msgid "Magnifier cursor moves with contents"
+msgstr "放大鏡游標隨內容移動"
+
+#: ../panels/universal-access/zoom-options.ui.h:15
+msgid "Magnifier Position:"
+msgstr "放大鏡位置："
+
+#: ../panels/universal-access/zoom-options.ui.h:16
+msgid "Magnifier"
+msgstr "放大鏡"
+
+#: ../panels/universal-access/zoom-options.ui.h:17
+msgid "Thickness:"
+msgstr "厚度："
+
+#: ../panels/universal-access/zoom-options.ui.h:18
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "薄"
+
+#: ../panels/universal-access/zoom-options.ui.h:19
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "厚"
+
+#: ../panels/universal-access/zoom-options.ui.h:20
+msgid "Length:"
+msgstr "長度："
+
+#. The color of the accessibility crosshair
+#: ../panels/universal-access/zoom-options.ui.h:22
+msgid "Color:"
+msgstr "顏色："
+
+#: ../panels/universal-access/zoom-options.ui.h:23
+msgid "Crosshairs:"
+msgstr "十字準星："
+
+#: ../panels/universal-access/zoom-options.ui.h:24
+msgid "Overlaps mouse cursor"
+msgstr "重疊滑鼠遊標"
+
+#: ../panels/universal-access/zoom-options.ui.h:25
+msgid "Crosshairs"
+msgstr "十字準星"
+
+#: ../panels/universal-access/zoom-options.ui.h:26
+msgid "White on black:"
+msgstr "白底黑字："
+
+#: ../panels/universal-access/zoom-options.ui.h:27
+msgid "Brightness:"
+msgstr "亮度："
+
+#: ../panels/universal-access/zoom-options.ui.h:28
+msgid "Contrast:"
+msgstr "對比："
+
+#. The contrast scale goes from Color to None (grayscale)
+#: ../panels/universal-access/zoom-options.ui.h:30
+msgctxt "universal access, contrast"
+msgid "Color"
+msgstr "顏色"
+
+#: ../panels/universal-access/zoom-options.ui.h:31
+msgctxt "universal access, color"
+msgid "None"
+msgstr "沒有"
+
+#: ../panels/universal-access/zoom-options.ui.h:32
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "完全"
+
+#: ../panels/universal-access/zoom-options.ui.h:33
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "低"
+
+#: ../panels/universal-access/zoom-options.ui.h:34
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "高"
+
+#: ../panels/universal-access/zoom-options.ui.h:35
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "低"
+
+#: ../panels/universal-access/zoom-options.ui.h:36
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "高"
+
+#: ../panels/universal-access/zoom-options.ui.h:37
+msgid "Color Effects:"
+msgstr "顏色效果："
+
+#: ../panels/universal-access/zoom-options.ui.h:38
+msgid "Color Effects"
+msgstr "顏色效果"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:1
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:1
+#: ../panels/user-accounts/um-account-type.c:34
+msgctxt "Account type"
+msgid "Standard"
+msgstr "標準"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:2
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:2
+#: ../panels/user-accounts/um-account-type.c:36
+msgctxt "Account type"
+msgid "Administrator"
+msgstr "管理員"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:4
+msgid "_Full Name"
+msgstr "全名(_F)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:5
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:5
+msgid "Account _Type"
+msgstr "帳號類型(_T)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:7
+#: ../panels/user-accounts/data/password-dialog.ui.h:7
+msgid "Allow user to set a password when they next login"
+msgstr "允許使用者在下次登入時選擇密碼"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:8
+#: ../panels/user-accounts/data/password-dialog.ui.h:8
+msgid "Set a password now"
+msgstr "立刻設定密碼"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:10
+msgid "_Verify"
+msgstr "驗證(_V)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:11
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device."
+msgstr "企業登入允許現有的集中管理式使用者帳號能用在這個裝置上。"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:12
+msgid "_Domain"
+msgstr "網域(_O)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:13
+msgid ""
+"Go online to add\n"
+"enterprise login accounts."
+msgstr ""
+"請上線以加入\n"
+"企業登入帳號。"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:15
+msgid "_Enterprise Login"
+msgstr "企業登入(_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:16
+#: ../panels/user-accounts/um-account-dialog.c:1458
+msgid "Add User"
+msgstr "加入使用者"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: ../panels/user-accounts/data/account-dialog.ui.h:19
+msgid "_Enroll"
+msgstr "登錄(_E)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:20
+msgid "Domain Administrator Login"
+msgstr "網域管理員登入"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:21
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"為了使用企業登入，這個電腦需要\n"
+"加入網域。請網絡系統管理員在這裏\n"
+"輸入網域密碼。"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:24
+msgid "Administrator _Name"
+msgstr "管理員名稱(_N)"
+
+#: ../panels/user-accounts/data/account-dialog.ui.h:25
+msgid "Administrator Password"
+msgstr "管理員密碼"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:1
+msgid "Left thumb"
+msgstr "左手姆指"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:2
+msgid "Left middle finger"
+msgstr "左手中指"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:3
+msgid "Left ring finger"
+msgstr "左手無名指"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:4
+msgid "Left little finger"
+msgstr "左手小指"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:5
+msgid "Right thumb"
+msgstr "右手姆指"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:6
+msgid "Right middle finger"
+msgstr "右手中指"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:7
+msgid "Right ring finger"
+msgstr "右手無名指"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:8
+msgid "Right little finger"
+msgstr "右手小指"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:9
+#: ../panels/user-accounts/um-fingerprint-dialog.c:697
+msgid "Enable Fingerprint Login"
+msgstr "啟用指紋登入"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:10
+msgid "_Right index finger"
+msgstr "右手食指(_R)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:11
+msgid "_Left index finger"
+msgstr "左手食指(_L)"
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:12
+msgid "_Other finger:"
+msgstr "其他手指(_O)："
+
+#: ../panels/user-accounts/data/account-fingerprint.ui.h:13
+msgid ""
+"Your fingerprint was successfully saved. You should now be able to log in "
+"using your fingerprint reader."
+msgstr "你的指紋已成功的儲存了。現在應該可以使用你的指紋辨識器來登入。"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:1
+msgid "Users"
+msgstr "使用者"
+
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:2
+msgid "Add or remove users and change your password"
+msgstr "加入或移除使用者並改變你的密碼"
+
+#. Translators: those are keywords for the user accounts control-center panel
+#: ../panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in.h:4
+msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+msgstr "Login;Name;Fingerprint;Avatar;Logo;Face;Password;登入;姓名;指紋;大頭貼;標誌;臉;密碼;"
+
+#: ../panels/user-accounts/data/history-dialog.ui.h:1
+msgid "Login History"
+msgstr "登入歷史紀錄"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:1
+msgid "Change Password"
+msgstr "更改密碼"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:3
+msgid "Ch_ange"
+msgstr "改變(_A)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:4
+msgid "_Verify New Password"
+msgstr "驗證新密碼(_V)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:5
+msgid "_New Password"
+msgstr "新密碼(_N)"
+
+#: ../panels/user-accounts/data/password-dialog.ui.h:6
+msgid "Current _Password"
+msgstr "目前的密碼(_P)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:3
+msgid "Add User Account"
+msgstr "加入使用者帳號"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:4
+msgid "Remove User Account"
+msgstr "移除使用者帳號"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:6
+msgid "Login Options"
+msgstr "登入選項"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:8
+msgid "A_utomatic Login"
+msgstr "自動登入(_U)："
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:9
+msgid "_Fingerprint Login"
+msgstr "指紋登入(_F)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:10
+msgid "User Icon"
+msgstr "使用者圖示"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:11
+msgid "_Language"
+msgstr "語言(_L)"
+
+#: ../panels/user-accounts/data/user-accounts-dialog.ui.h:12
+msgid "Last Login"
+msgstr "上次登入"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:1
+msgid "Manage user accounts"
+msgstr "管理使用者帳號"
+
+#: ../panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in.h:2
+msgid "Authentication is required to change user data"
+msgstr "改變使用者資料需要核對"
+
+#: ../panels/user-accounts/pw-utils.c:81
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "新的密碼需要與舊密碼有所差異。"
+
+#: ../panels/user-accounts/pw-utils.c:83
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "嘗試改變某些文字和數字。"
+
+#: ../panels/user-accounts/pw-utils.c:85 ../panels/user-accounts/pw-utils.c:93
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "嘗試更常改變密碼。"
+
+#: ../panels/user-accounts/pw-utils.c:87
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "不含你的使用者名稱的密碼強度會比較高。"
+
+#: ../panels/user-accounts/pw-utils.c:89
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "嘗試避免在密碼中使用你的姓名。"
+
+#: ../panels/user-accounts/pw-utils.c:91
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "嘗試避免在密碼中包含某些文字。"
+
+#: ../panels/user-accounts/pw-utils.c:95
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "嘗試避免常見的文字。"
+
+#: ../panels/user-accounts/pw-utils.c:97
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "嘗試避免重新排序現有的文字。"
+
+#: ../panels/user-accounts/pw-utils.c:99
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "嘗試使用更多數字。"
+
+#: ../panels/user-accounts/pw-utils.c:101
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "嘗試使用更多大寫字母。"
+
+#: ../panels/user-accounts/pw-utils.c:103
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "嘗試使用更多小寫字母。"
+
+#: ../panels/user-accounts/pw-utils.c:105
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "嘗試使用更多特殊字符，像是標點符號。"
+
+#: ../panels/user-accounts/pw-utils.c:107
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "嘗試使用混合字母、數字和標點符號。"
+
+#: ../panels/user-accounts/pw-utils.c:109
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "嘗試避免同樣字符。"
+
+#: ../panels/user-accounts/pw-utils.c:111
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr "嘗試避免重複同樣類型的字符：你需要混合字母、數字和標點符號。"
+
+#: ../panels/user-accounts/pw-utils.c:113
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "嘗試避免像 1234 或 abcd 等順序。"
+
+#: ../panels/user-accounts/pw-utils.c:115
+msgctxt "Password hint"
+msgid "Try to add more letters, numbers and symbols."
+msgstr "嘗試加入更多字母、數字和標點符號。"
+
+#: ../panels/user-accounts/pw-utils.c:117
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and use a number or two."
+msgstr "混合大寫與小寫字符並使用一到兩個數字。"
+
+#: ../panels/user-accounts/pw-utils.c:119
+msgctxt "Password hint"
+msgid ""
+"Good password! Adding more letters, numbers and punctuation will make it "
+"stronger."
+msgstr "不錯的密碼！加入更多字母、數字和標點符號會讓它更好。"
+
+#: ../panels/user-accounts/pw-utils.c:141
+#: ../panels/user-accounts/pw-utils.c:171
+msgctxt "Password strength"
+msgid "Strength: Weak"
+msgstr "強度：很弱"
+
+#: ../panels/user-accounts/pw-utils.c:145
+#: ../panels/user-accounts/pw-utils.c:172
+msgctxt "Password strength"
+msgid "Strength: Low"
+msgstr "強度：低度"
+
+#: ../panels/user-accounts/pw-utils.c:148
+#: ../panels/user-accounts/pw-utils.c:173
+msgctxt "Password strength"
+msgid "Strength: Medium"
+msgstr "強度：中度"
+
+#: ../panels/user-accounts/pw-utils.c:151
+#: ../panels/user-accounts/pw-utils.c:174
+msgctxt "Password strength"
+msgid "Strength: Good"
+msgstr "強度：良好"
+
+#: ../panels/user-accounts/pw-utils.c:154
+#: ../panels/user-accounts/pw-utils.c:175
+msgctxt "Password strength"
+msgid "Strength: High"
+msgstr "強度：高度"
+
+#: ../panels/user-accounts/run-passwd.c:422
+msgid "Authentication failed"
+msgstr "核對失敗"
+
+#: ../panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The new password is too short"
+msgstr "新的密碼太短"
+
+#: ../panels/user-accounts/run-passwd.c:508
+#, c-format
+msgid "The new password is too simple"
+msgstr "新的密碼太簡單"
+
+#: ../panels/user-accounts/run-passwd.c:514
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "舊密碼與新密碼太相似了"
+
+#: ../panels/user-accounts/run-passwd.c:517
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "新的密碼已經在最近使用過了。"
+
+#: ../panels/user-accounts/run-passwd.c:520
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "新的密碼必須包含數字或特殊字符"
+
+#: ../panels/user-accounts/run-passwd.c:524
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "舊密碼與新密碼是相同的"
+
+#: ../panels/user-accounts/run-passwd.c:528
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "你的密碼在第一次核對後已經改變過了！"
+
+#: ../panels/user-accounts/run-passwd.c:532
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "新的密碼並未包含足夠的不同字符"
+
+#: ../panels/user-accounts/run-passwd.c:536
+#, c-format
+msgid "Unknown error"
+msgstr "不明的錯誤"
+
+#: ../panels/user-accounts/um-account-dialog.c:34
+msgid "Should match the web address of your account provider."
+msgstr "應符合你帳號提供者的網絡位址。"
+
+#: ../panels/user-accounts/um-account-dialog.c:228
+msgid "Failed to add account"
+msgstr "無法加入到帳號"
+
+#: ../panels/user-accounts/um-account-dialog.c:452
+msgid "Passwords do not match."
+msgstr "密碼不相符。"
+
+#: ../panels/user-accounts/um-account-dialog.c:731
+#: ../panels/user-accounts/um-account-dialog.c:777
+msgid "Failed to register account"
+msgstr "無法註冊帳號"
+
+#: ../panels/user-accounts/um-account-dialog.c:915
+msgid "No supported way to authenticate with this domain"
+msgstr "沒有支援這個網域核對的方式"
+
+#: ../panels/user-accounts/um-account-dialog.c:974
+msgid "Failed to join domain"
+msgstr "無法加入網域"
+
+#: ../panels/user-accounts/um-account-dialog.c:1035
+msgid ""
+"That login name didn't work.\n"
+"Please try again."
+msgstr ""
+"登入名稱沒有用。\n"
+"請再試一次。"
+
+#: ../panels/user-accounts/um-account-dialog.c:1042
+msgid ""
+"That login password didn't work.\n"
+"Please try again."
+msgstr ""
+"登入密碼沒有用。\n"
+"請再試一次。"
+
+#: ../panels/user-accounts/um-account-dialog.c:1050
+msgid "Failed to log into domain"
+msgstr "無法登入到網域"
+
+#: ../panels/user-accounts/um-account-dialog.c:1108
+msgid "Unable find the domain. Maybe you misspelled it?"
+msgstr "找不到網域。也許你拼錯字了？"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:137
+msgid ""
+"You are not allowed to access the device. Contact your system administrator."
+msgstr "你不被允許使用這個裝置。請聯絡你的系統管理者。"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:139
+msgid "The device is already in use."
+msgstr "該裝置已經在使用中。"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:141
+msgid "An internal error occurred."
+msgstr "發生內部的錯誤。"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:217
+#: ../panels/user-accounts/um-fingerprint-dialog.c:218
+msgid "Enabled"
+msgstr "已啟用"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:266
+msgid "Delete registered fingerprints?"
+msgstr "是否刪除已註冊的指紋？"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:270
+msgid "_Delete Fingerprints"
+msgstr "刪除指紋(_D)"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:276
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "你確定要刪除已註冊的指紋嗎？這麼一來將會停用指紋登入。"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:452
+msgid "Done!"
+msgstr "完成！"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:513
+#: ../panels/user-accounts/um-fingerprint-dialog.c:555
+#, c-format
+msgid "Could not access '%s' device"
+msgstr "無法存取「%s」裝置"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "Could you not access "Digital Persona U.are.U 4000/4000B" device
+#: ../panels/user-accounts/um-fingerprint-dialog.c:596
+#, c-format
+msgid "Could not start finger capture on '%s' device"
+msgstr "無法使用「%s」裝置上的指紋捕捉"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:647
+msgid "Could not access any fingerprint readers"
+msgstr "無法存取任何指紋辨識器"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:648
+msgid "Please contact your system administrator for help."
+msgstr "請聯絡你的系統管理員來幫忙。"
+
+#. translators:
+#. * The variable is the name of the device, for example:
+#. * "To enable fingerprint login, you need to save one of your fingerprints, using the
+#. * 'Digital Persona U.are.U 4000/4000B' device."
+#.
+#: ../panels/user-accounts/um-fingerprint-dialog.c:731
+#, c-format
+msgid ""
+"To enable fingerprint login, you need to save one of your fingerprints, "
+"using the '%s' device."
+msgstr "要啟用指紋登入，你需要使用「%s」裝置儲存你的指紋。"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:738
+msgid "Selecting finger"
+msgstr "選擇手指"
+
+#: ../panels/user-accounts/um-fingerprint-dialog.c:739
+msgid "Enrolling fingerprints"
+msgstr "登記指紋"
+
+#: ../panels/user-accounts/um-history-dialog.c:68
+msgid "This Week"
+msgstr "本週"
+
+#: ../panels/user-accounts/um-history-dialog.c:71
+msgid "Last Week"
+msgstr "上週"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:77
+#: ../panels/user-accounts/um-history-dialog.c:81
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%b%e日"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: ../panels/user-accounts/um-history-dialog.c:86
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%Y年%b%e日"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: ../panels/user-accounts/um-history-dialog.c:91
+#, c-format
+msgctxt "login history week label"
+msgid "%s - %s"
+msgstr "%s - %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: ../panels/user-accounts/um-history-dialog.c:175
+#: ../panels/user-accounts/um-user-panel.c:631
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: ../panels/user-accounts/um-history-dialog.c:178
+#: ../panels/user-accounts/um-user-panel.c:635
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s，%s"
+
+#: ../panels/user-accounts/um-history-dialog.c:247
+msgid "Session Ended"
+msgstr "作業階段結束"
+
+#: ../panels/user-accounts/um-history-dialog.c:253
+msgid "Session Started"
+msgstr "作業階段開始"
+
+#: ../panels/user-accounts/um-password-dialog.c:145
+msgid "Please choose another password."
+msgstr "請選擇其他密碼。"
+
+#: ../panels/user-accounts/um-password-dialog.c:154
+msgid "Please type your current password again."
+msgstr "請再次輸入你目前的密碼。"
+
+#: ../panels/user-accounts/um-password-dialog.c:160
+msgid "Password could not be changed"
+msgstr "密碼無法更改"
+
+#: ../panels/user-accounts/um-password-dialog.c:286
+msgid "The passwords do not match."
+msgstr "密碼不相符。"
+
+#: ../panels/user-accounts/um-photo-dialog.c:219
+msgid "Browse for more pictures"
+msgstr "瀏覽更多照片"
+
+#: ../panels/user-accounts/um-photo-dialog.c:453
+msgid "Disable image"
+msgstr "停用圖片"
+
+#: ../panels/user-accounts/um-photo-dialog.c:471
+msgid "Take a photo…"
+msgstr "照相…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:489
+msgid "Browse for more pictures…"
+msgstr "瀏覽更多照片…"
+
+#: ../panels/user-accounts/um-photo-dialog.c:713
+#, c-format
+msgid "Used by %s"
+msgstr "由 %s 使用"
+
+#: ../panels/user-accounts/um-realm-manager.c:350
+msgid "Cannot automatically join this type of domain"
+msgstr "不能自動加入這個類型的網域"
+
+#: ../panels/user-accounts/um-realm-manager.c:413
+#, c-format
+msgid "No such domain or realm found"
+msgstr "找不到這個網域或領域名稱"
+
+#: ../panels/user-accounts/um-realm-manager.c:813
+#: ../panels/user-accounts/um-realm-manager.c:827
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "不能以 %s 身分登入 %s 網域"
+
+#: ../panels/user-accounts/um-realm-manager.c:819
+msgid "Invalid password, please try again"
+msgstr "密碼錯誤，請再試一次"
+
+#: ../panels/user-accounts/um-realm-manager.c:832
+#, c-format
+msgid "Couldn't connect to the %s domain: %s"
+msgstr "無法連接到 %s 網域：%s"
+
+#: ../panels/user-accounts/um-user-panel.c:198
+msgid "Other Accounts"
+msgstr "其他帳號"
+
+#: ../panels/user-accounts/um-user-panel.c:417
+msgid "Failed to delete user"
+msgstr "刪除使用者失敗"
+
+#: ../panels/user-accounts/um-user-panel.c:482
+msgid "You cannot delete your own account."
+msgstr "你不能刪除自己的帳號。"
+
+#: ../panels/user-accounts/um-user-panel.c:491
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s 仍在登入中"
+
+#: ../panels/user-accounts/um-user-panel.c:495
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "在使用者登入期間刪除他會使系統處於不穩定的狀態。"
+
+#: ../panels/user-accounts/um-user-panel.c:504
+#, c-format
+msgid "Do you want to keep %s's files?"
+msgstr "你想要保留 %s 的檔案嗎？"
+
+#: ../panels/user-accounts/um-user-panel.c:508
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr "當刪除使用者時是可以保留家目錄、新進郵件(mail spool)和暫存檔案的。"
+
+#: ../panels/user-accounts/um-user-panel.c:511
+msgid "_Delete Files"
+msgstr "刪除檔案(_D)"
+
+#: ../panels/user-accounts/um-user-panel.c:512
+msgid "_Keep Files"
+msgstr "保留檔案(_K)"
+
+#: ../panels/user-accounts/um-user-panel.c:564
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "帳號已停用"
+
+#: ../panels/user-accounts/um-user-panel.c:572
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "在下次登入時設定"
+
+#: ../panels/user-accounts/um-user-panel.c:575
+msgctxt "Password mode"
+msgid "None"
+msgstr "沒有"
+
+#: ../panels/user-accounts/um-user-panel.c:624
+msgid "Logged in"
+msgstr "已登入"
+
+#: ../panels/user-accounts/um-user-panel.c:1072
+msgid "Failed to contact the accounts service"
+msgstr "無法連接帳號服務"
+
+#: ../panels/user-accounts/um-user-panel.c:1074
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "請確定 AccountService 已經安裝並啟用。"
+
+#: ../panels/user-accounts/um-user-panel.c:1115
+msgid ""
+"To make changes,\n"
+"click the * icon first"
+msgstr ""
+"要進行更改，\n"
+"請先點選 * 圖示"
+
+#: ../panels/user-accounts/um-user-panel.c:1153
+msgid "Create a user account"
+msgstr "建立新的使用者帳號"
+
+#: ../panels/user-accounts/um-user-panel.c:1164
+#: ../panels/user-accounts/um-user-panel.c:1453
+msgid ""
+"To create a user account,\n"
+"click the * icon first"
+msgstr ""
+"要建立使用者帳號，\n"
+"請先點選 * 圖示"
+
+#: ../panels/user-accounts/um-user-panel.c:1174
+msgid "Delete the selected user account"
+msgstr "刪除選取的使用者帳號"
+
+#: ../panels/user-accounts/um-user-panel.c:1186
+#: ../panels/user-accounts/um-user-panel.c:1458
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"要刪除選取的使用者帳號，\n"
+"請先點選 * 圖示"
+
+#: ../panels/user-accounts/um-user-panel.c:1368
+msgid "My Account"
+msgstr "我的帳號"
+
+#: ../panels/user-accounts/um-utils.c:567
+#, c-format
+msgid "A user with the username '%s' already exists."
+msgstr "以「%s」為名的使用者已經存在。"
+
+#: ../panels/user-accounts/um-utils.c:571
+#, c-format
+msgid "The username is too long."
+msgstr "使用者名稱太長。"
+
+#: ../panels/user-accounts/um-utils.c:574
+msgid "The username cannot start with a '-'."
+msgstr "使用者名稱不能以「-」字符開頭。"
+
+#: ../panels/user-accounts/um-utils.c:577
+msgid ""
+"The username should only consist of lower and upper case letters from a-z, "
+"digits and any of characters '.', '-' and '_'."
+msgstr "使用者名稱只能由大小寫字母英文字母 a 到 z、數字，與其他字符如「.」、「-」和「_」構成。"
+
+#: ../panels/user-accounts/um-utils.c:581
+msgid "This will be used to name your home folder and can't be changed."
+msgstr "這會成為你家目錄資料夾的名稱，並且不能被改變。"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: ../panels/user-accounts/um-utils.c:827
+msgid "%b %e"
+msgstr "%b%e日"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: ../panels/user-accounts/um-utils.c:831
+msgid "%b %e, %Y"
+msgstr "%Y年%b%e日"
+
+#: ../panels/wacom/button-mapping.ui.h:1
+msgid "Map Buttons"
+msgstr "對應按鈕"
+
+#: ../panels/wacom/button-mapping.ui.h:2
+msgid "Map buttons to functions"
+msgstr "功能對應按鈕"
+
+#: ../panels/wacom/button-mapping.ui.h:3
+msgid ""
+"To edit a shortcut, choose the \"Send Keystroke\" action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr "要編輯捷徑鍵，選擇「傳送筆劃」動作，按下鍵盤捷徑按鈕與新的按鍵組合，或以 Backspace 鍵來清除。"
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:83
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "請點一下出現在螢幕上的目標標記來校準繪圖板。"
+
+#: ../panels/wacom/calibrator/calibrator-gui.c:87
+msgid "Mis-click detected, restarting..."
+msgstr "偵測到錯誤的點擊，重新開始…"
+
+#: ../panels/wacom/cc-wacom-button-row.c:442
+msgctxt "Wacom tablet button"
+msgid "Up"
+msgstr "上"
+
+#: ../panels/wacom/cc-wacom-button-row.c:443
+msgctxt "Wacom tablet button"
+msgid "Down"
+msgstr "下"
+
+#: ../panels/wacom/cc-wacom-button-row.h:54
+msgctxt "Wacom action-type"
+msgid "None"
+msgstr "沒有"
+
+#: ../panels/wacom/cc-wacom-button-row.h:55
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "傳送筆劃"
+
+#: ../panels/wacom/cc-wacom-button-row.h:56
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "切換監視器"
+
+#: ../panels/wacom/cc-wacom-button-row.h:57
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "顯示螢幕求助"
+
+#: ../panels/wacom/cc-wacom-mapping-panel.c:263
+msgid "Output:"
+msgstr "輸出："
+
+#. Keep ratio switch
+#: ../panels/wacom/cc-wacom-mapping-panel.c:275
+msgid "Keep aspect ratio (letterbox):"
+msgstr "保持長寬比："
+
+#. Whole-desktop checkbox
+#: ../panels/wacom/cc-wacom-mapping-panel.c:286
+msgid "Map to single monitor"
+msgstr "映射到單一螢幕"
+
+#: ../panels/wacom/cc-wacom-nav-button.c:88
+#, c-format
+msgid "%d of %d"
+msgstr "%d / %d"
+
+#: ../panels/wacom/cc-wacom-page.c:530
+msgid "Display Mapping"
+msgstr "顯示對應"
+
+#: ../panels/wacom/cc-wacom-stylus-page.c:372
+msgid "Button"
+msgstr "按鈕"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:1
+#: ../panels/wacom/gnome-wacom-properties.ui.h:7
+msgid "Wacom Tablet"
+msgstr "Wacom 繪圖板"
+
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:2
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "設定繪圖板的按鈕對映與調整觸控筆的靈敏度"
+
+#. Translators: those are keywords for the wacom tablet control-center panel
+#: ../panels/wacom/gnome-wacom-panel.desktop.in.in.h:4
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;繪圖板;橡皮擦;滑鼠;"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:1
+msgid "Tablet (absolute)"
+msgstr "繪圖板 (絕對位置)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:2
+msgid "Touchpad (relative)"
+msgstr "觸控板 (相對位置)"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:3
+msgid "Tablet Preferences"
+msgstr "繪圖板偏好設定"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:4
+msgid "No tablet detected"
+msgstr "未偵測到繪圖板"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:5
+msgid "Please plug in or turn on your Wacom tablet"
+msgstr "請插入或開啟你的 Wacom 繪圖板"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:6
+msgid "Bluetooth Settings"
+msgstr "藍牙設定值"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:8
+msgid "Map to Monitor…"
+msgstr "對應至顯示器..."
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:9
+msgid "Map Buttons…"
+msgstr "對應按鈕…"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:11
+msgid "Adjust display resolution"
+msgstr "調整顯示解像度"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:12
+msgid "Adjust mouse settings"
+msgstr "調整滑鼠設定值"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:13
+msgid "Tracking Mode"
+msgstr "追蹤模式"
+
+#: ../panels/wacom/gnome-wacom-properties.ui.h:14
+msgid "Left-Handed Orientation"
+msgstr "左手方向"
+
+#. If no mode is available, we use "left-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1062
+msgid "Left Ring"
+msgstr "左環"
+
+#: ../panels/wacom/gsd-wacom-device.c:1073
+#, c-format
+msgid "Left Ring Mode #%d"
+msgstr "左觸控環模式 #%d"
+
+#. If no mode is available, we use "right-ring-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1093
+msgid "Right Ring"
+msgstr "右環"
+
+#: ../panels/wacom/gsd-wacom-device.c:1104
+#, c-format
+msgid "Right Ring Mode #%d"
+msgstr "右觸控環模式 #%d"
+
+#. If no mode is available, we use "left-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1146
+msgid "Left Touchstrip"
+msgstr "左觸控列"
+
+#: ../panels/wacom/gsd-wacom-device.c:1157
+#, c-format
+msgid "Left Touchstrip Mode #%d"
+msgstr "左觸控列模式 #%d"
+
+#. If no mode is available, we use "right-strip-mode-1" for backward compat
+#: ../panels/wacom/gsd-wacom-device.c:1177
+msgid "Right Touchstrip"
+msgstr "右觸控列"
+
+#: ../panels/wacom/gsd-wacom-device.c:1188
+#, c-format
+msgid "Right Touchstrip Mode #%d"
+msgstr "右觸控列模式 #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1214
+#, c-format
+msgid "Left Touchring Mode Switch"
+msgstr "左觸控環模式切換"
+
+#: ../panels/wacom/gsd-wacom-device.c:1216
+#, c-format
+msgid "Right Touchring Mode Switch"
+msgstr "右觸控環模式切換"
+
+#: ../panels/wacom/gsd-wacom-device.c:1219
+#, c-format
+msgid "Left Touchstrip Mode Switch"
+msgstr "左觸控列模式切換"
+
+#: ../panels/wacom/gsd-wacom-device.c:1221
+#, c-format
+msgid "Right Touchstrip Mode Switch"
+msgstr "右觸控列模式切換"
+
+#: ../panels/wacom/gsd-wacom-device.c:1226
+#, c-format
+msgid "Mode Switch #%d"
+msgstr "模式切換 #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1334
+#, c-format
+msgid "Left Button #%d"
+msgstr "左側按鈕 #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1337
+#, c-format
+msgid "Right Button #%d"
+msgstr "右側按鈕 #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1340
+#, c-format
+msgid "Top Button #%d"
+msgstr "頂端按鈕 #%d"
+
+#: ../panels/wacom/gsd-wacom-device.c:1343
+#, c-format
+msgid "Bottom Button #%d"
+msgstr "底部按鈕 #%d"
+
+#: ../panels/wacom/gsd-wacom-key-shortcut-button.c:263
+msgid "New shortcut…"
+msgstr "新增捷徑鍵…"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:1
+msgid "No Action"
+msgstr "沒有動作"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:2
+msgid "Left Mouse Button Click"
+msgstr "滑鼠左鍵點擊"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:3
+msgid "Middle Mouse Button Click"
+msgstr "滑鼠中鍵點擊"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:4
+msgid "Right Mouse Button Click"
+msgstr "滑鼠右鍵點擊"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:5
+msgid "Scroll Up"
+msgstr "向上捲動"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:6
+msgid "Scroll Down"
+msgstr "向下捲動"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:7
+msgid "Scroll Left"
+msgstr "向左捲動"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:8
+msgid "Scroll Right"
+msgstr "向右捲動"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:9
+msgid "Back"
+msgstr "上一頁"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:10
+msgid "Forward"
+msgstr "下一頁"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:11
+msgid "Stylus"
+msgstr "觸控筆"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:12
+msgid "Eraser Pressure Feel"
+msgstr "橡皮擦壓力感應"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:13
+msgid "Soft"
+msgstr "輕"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:14
+msgid "Firm"
+msgstr "重"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:15
+msgid "Top Button"
+msgstr "頂端按鈕"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:16
+msgid "Lower Button"
+msgstr "較低的按鈕"
+
+#: ../panels/wacom/wacom-stylus-page.ui.h:17
+msgid "Tip Pressure Feel"
+msgstr "點選壓力感應"
+
+#: ../shell/cc-application.c:69
+msgid "Enable verbose mode"
+msgstr "啟用詳細模式"
+
+#: ../shell/cc-application.c:70
+msgid "Show the overview"
+msgstr "顯示概覽"
+
+#: ../shell/cc-application.c:71
+msgid "Search for the string"
+msgstr "搜尋字串"
+
+#: ../shell/cc-application.c:72
+msgid "List possible panel names and exit"
+msgstr "列出可能的面板名稱並結束"
+
+#: ../shell/cc-application.c:73 ../shell/cc-application.c:74
+#: ../shell/cc-application.c:75
+msgid "Show help options"
+msgstr "顯示說明的選項"
+
+#: ../shell/cc-application.c:76
+msgid "Panel to display"
+msgstr "要顯示的面板"
+
+#: ../shell/cc-application.c:76
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[面板] [引數…]"
+
+#: ../shell/cc-application.c:145
+msgid "- Settings"
+msgstr "- 設定值)"
+
+#: ../shell/cc-application.c:163
+#, c-format
+msgid ""
+"%s\n"
+"Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+"%s\n"
+"執行 「%s --help」以查看完整的命令列可用選項清單。\n"
+
+#: ../shell/cc-application.c:193
+msgid "Available panels:"
+msgstr "可用的面板："
+
+#: ../shell/cc-application.c:328
+msgid "Help"
+msgstr "求助"
+
+#: ../shell/cc-application.c:329
+msgid "Quit"
+msgstr "結束"
+
+#: ../shell/cc-window.c:61 ../shell/cc-window.c:1490
+msgid "All Settings"
+msgstr "所有設定值"
+
+#. Add categories
+#: ../shell/cc-window.c:876
+msgctxt "category"
+msgid "Personal"
+msgstr "個人"
+
+#: ../shell/cc-window.c:877
+msgctxt "category"
+msgid "Hardware"
+msgstr "硬件"
+
+#: ../shell/cc-window.c:878
+msgctxt "category"
+msgid "System"
+msgstr "系統"
+
+#: ../shell/gnome-control-center.desktop.in.in.h:2
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;偏好設定;設定值;"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "在這個網路分享媒體"
+
+#~ msgid "Shared Folders"
+#~ msgstr "分享資料夾"
+
+#~ msgid "column"
+#~ msgstr "欄"
+
+#~ msgid "Remove Folder"
+#~ msgstr "移除資料夾"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "在這個網路分享公開資料夾"
+
+#~ msgid "Immediately"
+#~ msgstr "立即"
+
+#~ msgid "Flickr"
+#~ msgstr "Flickr"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "設置新裝置"
+
+#~ msgid "Connection"
+#~ msgstr "連線"
+
+#~ msgid "Paired"
+#~ msgstr "已配對"
+
+#~ msgid "Type"
+#~ msgstr "類型"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "滑鼠與觸控板設定值"
+
+#~ msgid "Sound Settings"
+#~ msgstr "音效設定值"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "鍵盤設定值"
+
+#~ msgid "Send Files…"
+#~ msgstr "傳送檔案…"
+
+#~ msgid "Visibility"
+#~ msgstr "顯示狀態"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "「%s」的顯示狀態"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "是否從裝置的清單中移除「%s」？"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr "如果您刪除此裝置，下次使用時必須再次設定它。"
+
+#~ msgid "Install Updates"
+#~ msgstr "安裝更新"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "系統已是最新"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "搜尋網路印表機或過濾器結果"
+
+#~ msgid "_Default"
+#~ msgstr "預設值(_D)"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "分享公用資料夾"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "只與信任的裝置分享"
+
+#~ msgid "Remote View"
+#~ msgstr "遠端檢視"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "允許所有的連線"
+
+#~ msgid "Device type:"
+#~ msgstr "裝置類型："
+
+#~ msgid "Manufacturer:"
+#~ msgstr "製造商："
+
+#~ msgid "Model:"
+#~ msgstr "型號："
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "可以將圖片檔案拖放到這個視窗自動完成上列欄位。"
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "也在這個螢幕顯示您的主要顯示"
+
+#~ msgid "Combine"
+#~ msgstr "組合"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "結合主要顯示器以建立額外的工作區"
+
+#~ msgid "Don't use the display"
+#~ msgstr "不使用這個顯示器"
+
+#~ msgid "Refresh Rate"
+#~ msgstr "更新率"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "滑鼠偏好設定"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "選擇要用於新服務的介面"
+
+#~ msgid "C_reate…"
+#~ msgstr "建立(_R)…"
+
+#~ msgid "_Interface"
+#~ msgstr "介面(_I)"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "正在改變相片："
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "選擇這個帳號要顯示在登入畫面的照片。"
+
+#~ msgid "Gallery"
+#~ msgstr "藝廊"
+
+#~ msgid "Take a photograph"
+#~ msgstr "照一張相片"
+
+#~ msgid "Browse"
+#~ msgstr "瀏覽"
+
+#~ msgid "Photograph"
+#~ msgstr "相片"
+
+#~ msgid "Account Information"
+#~ msgstr "帳號資訊"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "在上午與下午之間切換。"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "預估電池電力：%s"
+
+#~ msgid "_Region:"
+#~ msgstr "區域(_R)："
+
+#~ msgid "_City:"
+#~ msgstr "城市(_C)："
+
+#~ msgid "_Network Time"
+#~ msgstr "網路時刻(_N)"
+
+#~ msgid ":"
+#~ msgstr ":"
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "將時刻延後一小時。"
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "將時刻提早一小時。"
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "將時刻延後一分鐘。"
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "將時刻提早一分鐘。"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "正常"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Counterclockwise"
+#~ msgstr "逆時針"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "順時針"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 度"
+
+#~ msgid "Monitor"
+#~ msgstr "顯示器"
+
+#~ msgid "Drag to change primary display."
+#~ msgstr "拖曳以改變主要顯示器。"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "選擇一個螢幕以改變它的屬性；拖曳它則能重新排列它的位置。"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Failed to apply configuration: %s"
+#~ msgstr "無法套用組態：%s"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "無法儲存顯示器組態"
+
+#~ msgid "_Resolution"
+#~ msgstr "解析度(_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "旋轉(_O)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "鏡射顯示器(_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "注意：可能會限制解析度選項"
+
+#~ msgid "_Detect Displays"
+#~ msgstr "偵測顯示器(_D)"
+
+#~ msgid "Hidden"
+#~ msgstr "隱藏"
+
+#~ msgid "Visible"
+#~ msgstr "顯示"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "名稱與可見度"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "控制您在螢幕及網路上如何顯示。"
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "在頂端列顯示全名(_F)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "在鎖定畫面中顯示全名(_L)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "隱密模式(_S)"
+
+#~ msgid "Show Status When _Inactive"
+#~ msgstr "當不活動後顯示狀態(_I)"
+
+#~ msgid "_Confirm Password"
+#~ msgstr "確認密碼(_C)"
+
+#~ msgid "_Login Name"
+#~ msgstr "登入名稱(_L)"
+
+#~ msgid "Login _Password"
+#~ msgstr "登入密碼(_P)"
+
+#~ msgid "C_onfirm New Password"
+#~ msgstr "確認新密碼(_O)"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "密碼不相符"
+
+#~ msgid ""
+#~ "Login not recognized.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "登入無法辨識。\n"
+#~ "請再試一次。"
+
+#~ msgid "Domain not found."
+#~ msgstr "找不到網域。"
+
+#~ msgid "Wrong password"
+#~ msgstr "錯誤的密碼"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more characters."
+#~ msgstr "試著加入更多字元。"
+
+#~ msgid "Switch Modes"
+#~ msgstr "切換模式"
+
+#~ msgid "Action"
+#~ msgstr "動作"
+
+#~ msgid "Export"
+#~ msgstr "匯出"
+
+#~ msgid "Left Shift"
+#~ msgstr "左 Shift"
+
+#~ msgid "Left Alt"
+#~ msgstr "左 Alt"
+
+#~ msgid "Left Ctrl"
+#~ msgstr "左 Ctrl"
+
+#~ msgid "Right Shift"
+#~ msgstr "右 Shift"
+
+#~ msgid "Right Alt"
+#~ msgstr "右 Alt"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "右 Ctrl"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "左 Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "左 Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "右 Ctrl+Shift"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Caps"
+#~ msgstr "Caps"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "捲動時內容黏住手指(_O)"
+
+#~ msgid "_Options…"
+#~ msgstr "選項(_O)…"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "一般"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "高/反差"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "螢幕鍵盤"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "正常"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Larger"
+#~ msgstr "較大"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "當 Caps 和 Num Lock 在使用時發出聲響"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "開啟或關閉："
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "縮放"
+
+#~ msgid "Zoom in:"
+#~ msgstr "拉近："
+
+#~ msgid "Zoom out:"
+#~ msgstr "拉遠："
+
+#~ msgid "Closed Captioning"
+#~ msgstr "關閉說明"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "顯示語音和音效的文字描述"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "短"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "長"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "發出聲響條件為按鍵"
+
+#~ msgid "pressed"
+#~ msgstr "已按下"
+
+#~ msgid "accepted"
+#~ msgstr "已接受"
+
+#~ msgid "rejected"
+#~ msgstr "已拒絕"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "接受時間延遲(_E)："
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "使用鍵盤控制滑鼠指標"
+
+#~ msgid "Video Mouse"
+#~ msgstr "視訊滑鼠"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "使用視訊攝影機控制指標"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "小"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "大"
+
+#~ msgid "Add account"
+#~ msgstr "加入帳號"
+
+#~ msgid "_Local Account"
+#~ msgstr "登入帳號(_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "提示：企業網域或領域名稱"
+
+#~ msgid "C_ontinue"
+#~ msgstr "繼續(_O)"
+
+#~ msgid "Previous Week"
+#~ msgstr "前一週"
+
+#~ msgid "Next Week"
+#~ msgstr "下一週"
+
+#~ msgid "Next week"
+#~ msgstr "下一週"
+
+#~ msgid "Log in without a password"
+#~ msgstr "不使用密碼登入"
+
+#~ msgid "Disable this account"
+#~ msgstr "停用這個帳號"
+
+#~ msgid "Enable this account"
+#~ msgstr "啟用這個帳號"
+
+#~ msgid "Generate a password"
+#~ msgstr "產生密碼"
+
+#~ msgid "_Action"
+#~ msgstr "動作(_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "顯示密碼(_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "如何選擇強度高的密碼"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "太短"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "不夠好"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "太弱"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "一般"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "良好"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "強固"
+
+#~ msgid "_Generate a password"
+#~ msgstr "產生密碼(_G)"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "您需要輸入新的密碼"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "新的密碼強度不夠"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "您需要確認密碼"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "您需要輸入您目前的密碼"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "目前的密碼並不正確"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "右 Alt+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "左+右 Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "左+右 Ctrl"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "blablabla"
+#~ msgstr "…等等"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "位址\n"
+#~ "部分\n"
+#~ "在\n"
+#~ "這裡"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "部分\n"
+#~ "在\n"
+#~ "這裡"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "路由\n"
+#~ "部分\n"
+#~ "在\n"
+#~ "這裡"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "憑證已逾期。請重新登入。"
+
+#~ msgid "_Log In"
+#~ msgstr "登入(_L)"
+
+#~ msgid "Change the background"
+#~ msgstr "更改背景"
+
+#~ msgid "Configure Bluetooth settings"
+#~ msgstr "設定藍牙設定值"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "藍牙"
+
+#~ msgid "Color management settings"
+#~ msgstr "顏色管理設定值"
+
+#~ msgid "British English"
+#~ msgstr "英式英文"
+
+#~ msgid "Spanish"
+#~ msgstr "西班牙文"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "簡體中文"
+
+#~ msgid "Select a region"
+#~ msgstr "選擇地區"
+
+#~ msgid "Select a language"
+#~ msgstr "選擇語言"
+
+#~ msgid "_Select"
+#~ msgstr "選取(_S)"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "日期和時刻偏好設定面板"
+
+#~ msgid "System Information"
+#~ msgstr "系統資訊"
+
+#~ msgid "Change keyboard settings"
+#~ msgstr "改變鍵盤設定值"
+
+#~ msgid "Layout Settings"
+#~ msgstr "配置設定值"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "設定您的滑鼠與觸控板偏好設定"
+
+#~ msgid "Network settings"
+#~ msgstr "網路設定值"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "載體/連結已變更"
+
+#~ msgid "Manage notifications"
+#~ msgstr "管理通知"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "管理線上帳號"
+
+#~ msgid "_Mark As Inactive After"
+#~ msgstr "標記為不活動於(_M)"
+
+#~ msgid "Power management settings"
+#~ msgstr "電源管理設定值"
+
+#~ msgid "Change printer settings"
+#~ msgstr "改變印表機設定值"
+
+#~ msgid "Manufacturers"
+#~ msgstr "製造商"
+
+#~ msgid "Privacy settings"
+#~ msgstr "隱私設定值"
+
+#~ msgid "Don't retain history"
+#~ msgstr "不要保留歷史紀錄"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "改變您的地區和語言設定值"
+
+#~ msgid "Select an input source"
+#~ msgstr "選擇一個輸入來源"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr "登入畫面、系統帳號和新使用者帳號使用系統的地區和語言設定值。"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "登入畫面、系統帳號和新使用者帳號使用系統的地區和語言設定值。您可以將系統設"
+#~ "定值改變以符合您的需求。"
+
+#~ msgid "Copy Settings"
+#~ msgstr "複製設定值"
+
+#~ msgid "Copy Settings…"
+#~ msgstr "複製設定值…"
+
+#~ msgid "Region and Language"
+#~ msgstr "地區和語言"
+
+#~ msgid "Select a display language"
+#~ msgstr "選擇顯示的語言"
+
+#~ msgid "Add Language"
+#~ msgstr "加入語言"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "選擇地區 (變更會在您下次登入時套用)"
+
+#~ msgid "Add Region"
+#~ msgstr "加入區域"
+
+#~ msgid "Remove Region"
+#~ msgstr "移除區域"
+
+#~ msgid "Currency"
+#~ msgstr "貨幣"
+
+#~ msgid "Examples"
+#~ msgstr "範例"
+
+#~ msgid "Select keyboards or other input sources"
+#~ msgstr "選取鍵盤或其他輸入來源"
+
+#~ msgid "Remove Input Source"
+#~ msgstr "移除輸入來源"
+
+#~ msgid "Move Input Source Up"
+#~ msgstr "將輸入來源往上移"
+
+#~ msgid "Show Keyboard Layout"
+#~ msgstr "顯示鍵盤配置"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "快捷鍵設定值"
+
+#~ msgid "Display language:"
+#~ msgstr "顯示語言："
+
+#~ msgid "Input source:"
+#~ msgstr "輸入來源："
+
+#~ msgid "Format:"
+#~ msgstr "格式："
+
+#~ msgid "Your settings"
+#~ msgstr "您的設定值"
+
+#~ msgid "System settings"
+#~ msgstr "系統設定值"
+
+#~ msgid "Search settings"
+#~ msgstr "搜尋設定值"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "無障礙偏好設定"
+
+#~ msgid "_Hint"
+#~ msgstr "提示(_H)"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "這個提示可能會顯示在登入畫面。它將會顯示給這個系統上的所有使用者。請<b>不"
+#~ "要</b>在這裡寫入密碼。"
+
+#~ msgid "Fair"
+#~ msgstr "一般"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "設定您的 Wacom 繪圖板偏好設定"
+
+#~ msgid "Control Center"
+#~ msgstr "控制中心"
+
+#~ msgid "Out of range"
+#~ msgstr "超過範圍"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -10,130 +10,39 @@
 # Chao-Hsiung Liao <j_h_liau@yahoo.com.tw>, 2010.
 # Wei-Lun Chao <chaoweilun@gmail.com>, 2010.
 # pan93412 <pan93412@gmail.com>, 2019.
+# Freddy Cheng <freddy4212@gmail.com>, 2022.
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center 3.3.91\n"
-"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
-"issues\n"
-"POT-Creation-Date: 2022-05-05 13:32+0000\n"
-"PO-Revision-Date: 2022-05-12 15:04+0800\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
+"PO-Revision-Date: 2022-11-29 23:55+0800\n"
 "Last-Translator: Cheng-Chia Tseng <pswo10680@gmail.com>\n"
-"Language-Team: Chinese <zh-l10n@linux.org.tw>\n"
+"Language-Team: Chinese - Taiwan <chinese-l10n@googlegroups.com>\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.0.1\n"
-
-#: panels/applications/cc-applications-panel.c:803
-msgid "System Bus"
-msgstr "系統匯流排"
-
-#: panels/applications/cc-applications-panel.c:803
-#: panels/applications/cc-applications-panel.c:805
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:823
-msgid "Full access"
-msgstr "完整存取權限"
-
-#: panels/applications/cc-applications-panel.c:805
-msgid "Session Bus"
-msgstr "工作階段匯流排"
-
-#: panels/applications/cc-applications-panel.c:809
-#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:266
-#: panels/thunderbolt/cc-bolt-panel.ui:310
-msgid "Devices"
-msgstr "裝置"
-
-#: panels/applications/cc-applications-panel.c:809
-msgid "Full access to /dev"
-msgstr "完整 /dev 存取權限"
-
-#: panels/applications/cc-applications-panel.c:813
-#: panels/network/gnome-network-panel.desktop.in.in:3
-#: panels/network/network-mobile.ui:230 panels/wwan/cc-wwan-device-page.ui:61
-#: panels/wwan/cc-wwan-network-dialog.ui:5
-msgid "Network"
-msgstr "網路"
-
-#: panels/applications/cc-applications-panel.c:813
-msgid "Has network access"
-msgstr "有網路存取權限"
-
-#: panels/applications/cc-applications-panel.c:818
-#: panels/applications/cc-applications-panel.c:820
-#: panels/search/cc-search-locations-dialog.c:384
-msgid "Home"
-msgstr "家"
-
-#: panels/applications/cc-applications-panel.c:820
-#: panels/applications/cc-applications-panel.c:825
-msgid "Read-only"
-msgstr "唯讀"
-
-#: panels/applications/cc-applications-panel.c:823
-#: panels/applications/cc-applications-panel.c:825
-msgid "File System"
-msgstr "檔案系統"
-
-#: panels/applications/cc-applications-panel.c:829
-#: panels/keyboard/01-launchers.xml.in:6
-#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
-#: shell/cc-window.c:878 shell/cc-window.ui:22
-#: shell/org.gnome.Settings.desktop.in.in:3
-msgid "Settings"
-msgstr "設定值"
-
-#: panels/applications/cc-applications-panel.c:829
-msgid "Can change settings"
-msgstr "可以變更設定"
-
-#: panels/applications/cc-applications-panel.c:831
-#, c-format
-msgid ""
-"%s has the following permissions built-in. These cannot be altered. If you "
-"are concerned about these permissions, consider removing this application."
-msgstr ""
-"%s 內建以下權限。這部分無法變更。如果您對這些存取權設定有顧慮，請考慮移除此應"
-"用程式。"
-
-#: panels/applications/cc-applications-panel.c:1164
-#, c-format
-msgid "%u file and link type that is opened by the app"
-msgid_plural "%u file and link types that are opened by the app"
-msgstr[0] "有 %u 種檔案與連結類型由該程式開啟"
-
-#: panels/applications/cc-applications-panel.c:1171
-#, c-format
-msgid "<b>%s</b> is used to open the following types of files and links."
-msgstr "<b>%s</b> 用來開啟下列檔案與連結的類型。"
-
-#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
-#: panels/applications/cc-applications-panel.c:1223
-#, c-format
-msgid "%s of disk space used"
-msgstr "已使用 %s 磁碟空間"
+"X-Generator: Poedit 3.1.1\n"
 
 #. List of applications.
-#: panels/applications/cc-applications-panel.c:1387
 #: panels/applications/cc-applications-panel.ui:19
 #: panels/applications/gnome-applications-panel.desktop.in.in:3
 #: panels/notifications/cc-notifications-panel.ui:26
 msgid "Applications"
-msgstr "程式集"
+msgstr "應用程式"
 
 #: panels/applications/cc-applications-panel.ui:31
 msgid "No applications"
-msgstr "無應用程式"
+msgstr "沒有應用程式"
 
 #: panels/applications/cc-applications-panel.ui:34
 msgid "Install some…"
 msgstr "安裝一些…"
 
 #: panels/applications/cc-applications-panel.ui:84
-#: panels/network/wireless-security/ws-file-chooser-button.c:96
 msgid "Open"
 msgstr "開啟"
 
@@ -144,6 +53,10 @@ msgstr "檢視詳細資料"
 #: panels/applications/cc-applications-panel.ui:112
 #: panels/applications/cc-applications-panel.ui:119
 #: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
 #: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
 msgid "Search"
 msgstr "搜尋"
@@ -151,26 +64,15 @@ msgstr "搜尋"
 #: panels/applications/cc-applications-panel.ui:113
 #: panels/applications/cc-applications-panel.ui:120
 msgid "Receive system searches and send results."
-msgstr "接收系統搜尋與傳送結果。"
+msgstr "接收系統搜尋請求與傳送搜尋結果。"
 
-#. This label is displayed in a treeview cell displaying
-#. * a disabled accelerator key combination.
-#.
-#. TRANSLATORS: Status of Parental Controls setup
-#. translators:
-#. * The device has been disabled
 #: panels/applications/cc-applications-panel.ui:121
-#: panels/applications/cc-applications-panel.ui:156
-#: panels/applications/cc-applications-panel.ui:177
-#: panels/applications/cc-applications-panel.ui:191
-#: panels/applications/cc-applications-panel.ui:205
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:118
-#: panels/keyboard/cc-xkb-modifier-dialog.c:344
-#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:105
-#: panels/user-accounts/cc-user-panel.c:789
-#: panels/user-accounts/cc-user-panel.c:879
-#: panels/wwan/cc-wwan-device-page.c:478
-#: subprojects/gvc/gvc-mixer-control.c:1908
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "已停用"
 
@@ -184,138 +86,149 @@ msgid "Show system notifications."
 msgstr "顯示系統通知。"
 
 #: panels/applications/cc-applications-panel.ui:133
-msgid "Run in background"
+msgid "Run in Background"
 msgstr "背景執行"
 
 #: panels/applications/cc-applications-panel.ui:134
 msgid "Allow activity when the app is closed."
-msgstr "當程式關閉時仍允許活動。"
+msgstr "應用程式關閉時仍允許活動。"
 
 #: panels/applications/cc-applications-panel.ui:140
-msgid "Change Wallpaper"
-msgstr "變更桌布"
+msgid "Screenshots"
+msgstr "螢幕快照"
 
 #: panels/applications/cc-applications-panel.ui:141
-msgid "Change the desktop wallpaper."
-msgstr "更改桌布。"
+msgid "Take pictures of the screen at any time."
+msgstr "隨時擷取螢幕快照。"
 
 #: panels/applications/cc-applications-panel.ui:147
-#: panels/applications/cc-applications-panel.ui:154
-msgid "Sounds"
-msgstr "音效"
+msgid "Change Wallpaper"
+msgstr "更換桌布"
 
 #: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "更換桌面背景。"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "聲音"
+
 #: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
 msgid "Reproduce sounds."
 msgstr "發出聲音。"
 
-#: panels/applications/cc-applications-panel.ui:161
-msgid "Inhibit Shortcuts"
-msgstr "抑制快捷鍵"
-
-#: panels/applications/cc-applications-panel.ui:162
-msgid "Block standard keyboard shortcuts."
-msgstr "封鎖標準系統快捷鍵。"
-
 #: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "暫時停用快捷鍵"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "封鎖常規的系統快捷鍵。"
+
 #: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
 #: panels/camera/gnome-camera-panel.desktop.in.in:3
 msgid "Camera"
 msgstr "相機"
 
-#: panels/applications/cc-applications-panel.ui:169
 #: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
 msgid "Take pictures with the camera."
-msgstr "透過相機拍照。"
+msgstr "透過相機拍攝相片。"
 
-#: panels/applications/cc-applications-panel.ui:182
 #: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:3
 msgid "Microphone"
 msgstr "麥克風"
 
-#: panels/applications/cc-applications-panel.ui:183
 #: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
 msgid "Record audio with the microphone."
-msgstr "透過麥克風錄音。"
+msgstr "透過麥克風錄製聲音。"
 
-#: panels/applications/cc-applications-panel.ui:196
 #: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
 #: panels/location/gnome-location-panel.desktop.in.in:3
 msgid "Location Services"
 msgstr "定位服務"
 
-#: panels/applications/cc-applications-panel.ui:197
 #: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
 msgid "Access device location data."
-msgstr "存取裝置的地理位置資料。"
+msgstr "存取裝置的位置資訊。"
 
-#: panels/applications/cc-applications-panel.ui:215
-#: panels/applications/cc-applications-panel.ui:319
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
 msgid "Built-in Permissions"
-msgstr "內建權限"
+msgstr "內建的權限"
 
-#: panels/applications/cc-applications-panel.ui:216
+#: panels/applications/cc-applications-panel.ui:223
 msgid "System access that is required by the app"
-msgstr "此程式需要的系統存取權"
+msgstr "應用程式所要求的系統取用權"
 
-#: panels/applications/cc-applications-panel.ui:224
+#: panels/applications/cc-applications-panel.ui:231
 msgid "File &amp; Link Associations"
-msgstr "檔案與連結關聯"
+msgstr "關聯的檔案與連結"
 
-#: panels/applications/cc-applications-panel.ui:232
-#: panels/applications/cc-applications-panel.ui:399
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
 msgid "Storage"
 msgstr "儲存空間"
 
-#: panels/applications/cc-applications-panel.ui:294 shell/cc-panel-list.ui:105
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
 msgid "No results found"
 msgstr "找不到結果"
 
-#: panels/applications/cc-applications-panel.ui:304
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:198
-#: shell/cc-panel-list.ui:114
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
 msgid "Try a different search"
 msgstr "嘗試不同的搜尋內容"
 
-#: panels/applications/cc-applications-panel.ui:344
+#: panels/applications/cc-applications-panel.ui:351
 msgid "File & Link Associations"
-msgstr "檔案與連結關聯"
+msgstr "關聯的檔案與連結"
 
-#: panels/applications/cc-applications-panel.ui:367
+#: panels/applications/cc-applications-panel.ui:374
 msgid "File Types"
 msgstr "檔案類型"
 
-#: panels/applications/cc-applications-panel.ui:373
+#: panels/applications/cc-applications-panel.ui:380
 msgid "Link Types"
 msgstr "連結類型"
 
-#: panels/applications/cc-applications-panel.ui:383
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
 msgid "Reset"
 msgstr "重設"
 
-#: panels/applications/cc-applications-panel.ui:410
+#: panels/applications/cc-applications-panel.ui:417
 msgid ""
 "How much disk space this application is occupying with app data and caches."
-msgstr "此應用程式的應用程式資料及快取所佔用的磁碟空間。"
+msgstr "應用程式的資料與快取所佔用的磁碟空間。"
 
-#: panels/applications/cc-applications-panel.ui:413
+#: panels/applications/cc-applications-panel.ui:420
 msgid "Application"
 msgstr "應用程式"
 
-#: panels/applications/cc-applications-panel.ui:419
+#: panels/applications/cc-applications-panel.ui:426
 msgid "Data"
 msgstr "資料"
 
-#: panels/applications/cc-applications-panel.ui:425
+#: panels/applications/cc-applications-panel.ui:432
 msgid "Cache"
 msgstr "快取"
 
-#: panels/applications/cc-applications-panel.ui:431
+#: panels/applications/cc-applications-panel.ui:438
 msgid "<b>Total</b>"
 msgstr "<b>總計</b>"
 
-#: panels/applications/cc-applications-panel.ui:441
+#: panels/applications/cc-applications-panel.ui:448
 msgid "Clear Cache…"
 msgstr "清除快取…"
 
@@ -323,90 +236,34 @@ msgstr "清除快取…"
 msgid "Control various application permissions and settings"
 msgstr "控制各應用程式的權限與設定值"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/applications/gnome-applications-panel.desktop.in.in:16
 msgid "application;flatpak;permission;setting;"
-msgstr "application;flatpak;permission;setting;應用程式;權限;應用;設定;設置;"
-
-#: panels/background/cc-background-chooser.c:307
-msgid "Select a picture"
-msgstr "請選擇圖片"
-
-#: panels/background/cc-background-chooser.c:310
-#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
-#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
-#: panels/display/cc-display-panel.ui:31
-#: panels/info-overview/cc-info-overview-panel.ui:198
-#: panels/keyboard/cc-input-chooser.ui:11
-#: panels/network/cc-wifi-hotspot-dialog.ui:123
-#: panels/network/cc-wifi-panel.c:881
-#: panels/network/connection-editor/connection-editor.ui:14
-#: panels/network/connection-editor/vpn-helpers.c:221
-#: panels/network/connection-editor/vpn-helpers.c:341
-#: panels/network/net-device-wifi.c:860
-#: panels/printers/new-printer-dialog.ui:50
-#: panels/printers/pp-details-dialog.c:263
-#: panels/region/cc-format-chooser.ui:24
-#: panels/search/cc-search-locations-dialog.c:677
-#: panels/sharing/cc-sharing-panel.c:526 panels/usage/cc-usage-panel.c:139
-#: panels/user-accounts/cc-add-user-dialog.ui:25
-#: panels/user-accounts/cc-avatar-chooser.c:96
-#: panels/user-accounts/cc-avatar-chooser.c:167
-#: panels/user-accounts/cc-fingerprint-dialog.ui:32
-#: panels/user-accounts/cc-password-dialog.ui:18
-#: panels/user-accounts/cc-user-panel.c:579
-#: panels/user-accounts/cc-user-panel.c:597
-#: panels/user-accounts/data/join-dialog.ui:17
-#: panels/wwan/cc-wwan-mode-dialog.ui:32
-#: panels/wwan/cc-wwan-network-dialog.ui:139
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:268
-msgid "_Cancel"
-msgstr "取消(_C)"
-
-#: panels/background/cc-background-chooser.c:311
-#: panels/network/connection-editor/vpn-helpers.c:222
-#: panels/printers/pp-details-dialog.c:264
-#: panels/sharing/cc-sharing-panel.c:527
-#: panels/user-accounts/cc-avatar-chooser.c:168
-msgid "_Open"
-msgstr "開啟(_O)"
-
-#: panels/background/cc-background-item.c:169
-msgid "multiple sizes"
-msgstr "多重尺寸"
-
-#. translators: 100 × 100px
-#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
-#: panels/background/cc-background-item.c:173
-#, c-format
-msgid "%d × %d"
-msgstr "%d × %d"
-
-#: panels/background/cc-background-item.c:325
-msgid "No Desktop Background"
-msgstr "無桌面背景"
-
-#: panels/background/cc-background-panel.c:227
-msgid "Current background"
-msgstr "目前的背景"
+msgstr ""
+"application;flatpak;permission;setting;應用程式;權限;應用;設定;設置;安全;快"
+"取;關聯;連結;"
 
 #: panels/background/cc-background-panel.ui:9
 msgid "Style"
 msgstr "風格"
 
-#: panels/background/cc-background-panel.ui:46
-msgid "Light"
-msgstr "明亮"
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
+msgid "Default"
+msgstr "預設"
 
-#: panels/background/cc-background-panel.ui:73
+#: panels/background/cc-background-panel.ui:79
 msgid "Dark"
-msgstr "黑暗"
+msgstr "深色"
 
-#: panels/background/cc-background-panel.ui:92
+#: panels/background/cc-background-panel.ui:98
 msgid "Background"
 msgstr "背景"
 
-#: panels/background/cc-background-panel.ui:98
+#: panels/background/cc-background-panel.ui:104
 msgid "Add Picture…"
 msgstr "加入圖片…"
 
@@ -416,55 +273,61 @@ msgstr "外觀"
 
 #: panels/background/gnome-background-panel.desktop.in.in:4
 msgid "Change your background image or the UI colors"
-msgstr "變更您的背景影像或使用者介面色彩"
+msgstr "更改背景影像或使用者介面色彩"
 
-#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/background/gnome-background-panel.desktop.in.in:15
-#| msgid "Wallpaper;Screen;Desktop;"
-msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;"
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
 msgstr ""
 "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;背景;桌布;螢幕;風格;明"
-"亮;黑暗;亮色;暗色;"
+"亮;黑暗;亮色;暗色;深色;淺色;"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:21
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "啟用"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
 msgid "No Bluetooth Found"
 msgstr "找不到藍牙"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:22
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
 msgid "Plug in a dongle to use Bluetooth."
-msgstr "插入藍牙棒以使用藍牙。"
+msgstr "接上藍牙配接器以使用藍牙。"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:28
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
 msgid "Bluetooth Turned Off"
 msgstr "藍牙已關閉"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:29
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
 msgid "Turn on to connect devices and receive file transfers."
-msgstr "開啟以連接裝置與接收檔案傳輸。"
+msgstr "開啟以連接裝置和接收檔案傳輸。"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:35
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
 msgid "Airplane Mode is On"
 msgstr "飛安模式已開啟"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:36
-msgid "Bluetooth is disabled when airplane mode is on."
-msgstr "飛安模式開啟時將會停用藍牙。"
-
 #: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "飛安模式開啟時會停用藍牙。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
 msgid "Turn Off Airplane Mode"
 msgstr "關閉飛安模式"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:53
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
 msgid "Hardware Airplane Mode is On"
 msgstr "硬體飛安模式已開啟"
 
-#: panels/bluetooth/cc-bluetooth-panel.ui:54
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
 msgid "Turn off the Airplane mode switch to enable Bluetooth."
 msgstr "關閉飛安模式開關以啟用藍牙。"
 
-#. Translators: The found device is a printer connected via Bluetooth
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
-#: panels/printers/pp-new-printer-dialog.c:1383
 msgid "Bluetooth"
 msgstr "藍牙"
 
@@ -472,127 +335,67 @@ msgstr "藍牙"
 msgid "Turn Bluetooth on and off and connect your devices"
 msgstr "開啟或關閉藍牙與連接您的裝置"
 
-#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
 msgid "share;sharing;bluetooth;obex;"
 msgstr "share;sharing;bluetooth;obex;分享;藍牙;"
 
-#: panels/camera/cc-camera-panel.ui:21
+#: panels/camera/cc-camera-panel.ui:24
 msgid "Camera is Turned Off"
 msgstr "相機已關閉"
 
-#: panels/camera/cc-camera-panel.ui:22
+#: panels/camera/cc-camera-panel.ui:25
 msgid "No applications can capture photos or video."
-msgstr "沒有應用程式能擷取圖片或影片。"
+msgstr "沒有應用程式能拍攝相片或錄製影片。"
 
-#: panels/camera/cc-camera-panel.ui:36
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
 "Use of the camera allows applications to capture photos and video. Disabling "
 "the camera may cause some applications to not function properly.\n"
 "\n"
 "Allow the applications below to use your camera."
 msgstr ""
-"使用相機可以允許應用程式拍照或錄影。停用相機可能導致部份應用程式不能正常運"
-"作。\n"
+"相機的使用可允許應用程式拍攝相片或錄製影片。停用相機可能導致部分應用程式不能"
+"正常運作。\n"
 "\n"
 "允許下列應用程式使用您的相機。"
 
-#: panels/camera/cc-camera-panel.ui:52
+#: panels/camera/cc-camera-panel.ui:55
 msgid "No Applications Have Asked for Camera Access"
-msgstr "沒有應用程式請求相機存取權"
+msgstr "沒有應用程式請求取用相機"
 
 #: panels/camera/gnome-camera-panel.desktop.in.in:4
 msgid "Protect your pictures"
 msgstr "保護您的照片"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/camera/gnome-camera-panel.desktop.in.in:20
-#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;"
+msgid "camera;photos;video;webcam;lock;private;privacy;"
 msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;螢幕;鎖定;診斷;隱私;最近使用;暫存;索引;名稱;網路;身分;"
-
-#. TRANSLATORS: The user has to attach the sensor to the screen
-#: panels/color/cc-color-calibrate.c:347
-msgid "Place your calibration device over the square and press “Start”"
-msgstr "將您的校準裝置放在方塊上方，並按下「開始」"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:353
-msgid ""
-"Move your calibration device to the calibrate position and press “Continue”"
-msgstr "將您的校準裝置移到校準位置，並按下「繼續」"
-
-#. TRANSLATORS: Some calibration devices need the user to move a
-#. * dial or switch manually. We also show a picture showing them
-#. * what to do...
-#: panels/color/cc-color-calibrate.c:359
-msgid ""
-"Move your calibration device to the surface position and press “Continue”"
-msgstr "將您的校準裝置移到表面位置，並按下「繼續」"
-
-#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
-#. * is built into the palmrest and we need to fullscreen the
-#. * sample widget and shut the lid.
-#: panels/color/cc-color-calibrate.c:365
-msgid "Shut the laptop lid"
-msgstr "關上筆記型電腦上蓋"
-
-#. TRANSLATORS: We suck, the calibration failed and we have no
-#. * good idea why or any suggestions
-#: panels/color/cc-color-calibrate.c:396
-msgid "An internal error occurred that could not be recovered."
-msgstr "發生內部的錯誤，無法復原。"
-
-#. TRANSLATORS: Some required-at-runtime tools were not
-#. * installed, which should only affect insane distros
-#: panels/color/cc-color-calibrate.c:401
-msgid "Tools required for calibration are not installed."
-msgstr "校準所需的工具尚未安裝。"
-
-#. TRANSLATORS: The profile failed for some reason
-#: panels/color/cc-color-calibrate.c:407
-msgid "The profile could not be generated."
-msgstr "無法產生描述檔。"
-
-#. TRANSLATORS: The user specified a whitepoint that was
-#. * unobtainable with the hardware they've got -- see
-#. * https://en.wikipedia.org/wiki/White_point for details
-#: panels/color/cc-color-calibrate.c:413
-msgid "The target whitepoint was not obtainable."
-msgstr "尚無法獲取目標白點。"
-
-#. TRANSLATORS: the display calibration process is finished
-#: panels/color/cc-color-calibrate.c:452
-msgid "Complete!"
-msgstr "完成！"
-
-#. TRANSLATORS: the display calibration failed, and we also show
-#. * the translated (or untranslated) error string after this
-#: panels/color/cc-color-calibrate.c:460
-msgid "Calibration failed!"
-msgstr "校準已失敗！"
-
-#. TRANSLATORS: The user can now remove the sensor from the screen
-#: panels/color/cc-color-calibrate.c:467
-msgid "You can remove the calibration device."
-msgstr "您可以移除校準裝置。"
-
-#. TRANSLATORS: The user has to be careful not to knock the
-#. * display off the screen (although we do cope if this is
-#. * detected early enough)
-#: panels/color/cc-color-calibrate.c:535
-msgid "Do not disturb the calibration device while in progress"
-msgstr "過程中請勿干擾校準裝置"
+"camera;photos;video;webcam;lock;private;privacy;相機;照片;影片;網路攝影機;鎖"
+"定相機;隱私權;"
 
 #: panels/color/cc-color-calibrate.ui:9
 msgid "Display Calibration"
-msgstr "顯示校準"
+msgstr "顯示器校準"
+
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "取消(_C)"
 
 #. This starts the calibration process
 #: panels/color/cc-color-calibrate.ui:28
@@ -606,140 +409,9 @@ msgstr "繼續(_R)"
 
 #. This button returns the user back to the color control panel
 #: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
-#: panels/user-accounts/cc-fingerprint-dialog.ui:60
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
 msgid "_Done"
 msgstr "完成(_D)"
-
-#. TRANSLATORS: This refers to the TFT display on a laptop
-#: panels/color/cc-color-common.c:41
-msgid "Laptop Screen"
-msgstr "筆記型電腦螢幕"
-
-#. TRANSLATORS: This refers to the embedded webcam on a laptop
-#: panels/color/cc-color-common.c:50
-msgid "Built-in Webcam"
-msgstr "內建網路攝影機"
-
-#. TRANSLATORS: an externally connected display, where %s is either the
-#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
-#: panels/color/cc-color-common.c:65
-#, c-format
-msgid "%s Monitor"
-msgstr "%s 顯示器"
-
-#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
-#: panels/color/cc-color-common.c:69
-#, c-format
-msgid "%s Scanner"
-msgstr "%s 掃描器"
-
-#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
-#: panels/color/cc-color-common.c:73
-#, c-format
-msgid "%s Camera"
-msgstr "%s 照相機"
-
-#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
-#: panels/color/cc-color-common.c:77
-#, c-format
-msgid "%s Printer"
-msgstr "%s 印表機"
-
-#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
-#: panels/color/cc-color-common.c:81
-#, c-format
-msgid "%s Webcam"
-msgstr "%s 網路攝影機"
-
-#: panels/color/cc-color-device.c:87
-#, c-format
-msgid "Enable color management for %s"
-msgstr "啟用 %s 的色彩管理"
-
-#: panels/color/cc-color-device.c:92
-#, c-format
-msgid "Show color profiles for %s"
-msgstr "顯示 %s 的色彩描述檔"
-
-#. not calibrated
-#: panels/color/cc-color-device.c:292
-msgid "Not calibrated"
-msgstr "尚未校準"
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile has been auto-generated for this hardware
-#: panels/color/cc-color-panel.c:160
-msgid "Default: "
-msgstr "預設值："
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile his a standard space like AdobeRGB
-#: panels/color/cc-color-panel.c:168
-msgid "Colorspace: "
-msgstr "色彩空間："
-
-#. TRANSLATORS: this is a profile prefix to signify the
-#. * profile is a test profile
-#: panels/color/cc-color-panel.c:175
-msgid "Test profile: "
-msgstr "測試描述檔："
-
-#. TRANSLATORS: an ICC profile is a file containing colorspace data
-#: panels/color/cc-color-panel.c:282
-msgid "Select ICC Profile File"
-msgstr "選擇 ICC 色彩描述檔"
-
-#: panels/color/cc-color-panel.c:285
-msgid "_Import"
-msgstr "匯入(_I)"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:296
-msgid "Supported ICC profiles"
-msgstr "支援的 ICC 色彩描述檔"
-
-#. TRANSLATORS: filter name on the file->open dialog
-#: panels/color/cc-color-panel.c:303
-#: panels/network/wireless-security/eap-method-fast.c:357
-msgid "All files"
-msgstr "所有檔案"
-
-#: panels/color/cc-color-panel.c:586
-msgid "Screen"
-msgstr "螢幕"
-
-#. TRANSLATORS: this is the dialog to save the ICC profile
-#: panels/color/cc-color-panel.c:841
-msgid "Save Profile"
-msgstr "儲存描述檔"
-
-#: panels/color/cc-color-panel.c:845
-#: panels/network/connection-editor/vpn-helpers.c:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:43
-msgid "_Save"
-msgstr "儲存(_S)"
-
-#. TRANSLATORS: this is when the button is sensitive
-#: panels/color/cc-color-panel.c:1146
-msgid "Create a color profile for the selected device"
-msgstr "為已選取裝置建立色彩描述檔"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
-msgid ""
-"The measuring instrument is not detected. Please check it is turned on and "
-"correctly connected."
-msgstr "尚未偵測到測量儀器。請檢查它是否已開啟並正確的連接。"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1195
-msgid "The measuring instrument does not support printer profiling."
-msgstr "測量儀器不支援印表機的分析。"
-
-#. TRANSLATORS: this is when the button is insensitive
-#: panels/color/cc-color-panel.c:1206
-msgid "The device type is not currently supported."
-msgstr "目刖不支援這個裝置類型。"
 
 #: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 msgid "Screen Calibration"
@@ -755,13 +427,13 @@ msgid ""
 "screen. The longer you spend on calibration, the better the quality of the "
 "color profile."
 msgstr ""
-"校準動作會產生描述檔讓您可以用來管理螢幕的色彩。您花在校準的時間愈長，色彩描"
-"述檔的品質就愈好。"
+"校準能建立用於管理螢幕色彩的描述檔。校準所花費的時間愈長，描述檔的品質就愈"
+"好。"
 
 #: panels/color/cc-color-panel.ui:28
 msgid ""
 "You will not be able to use your computer while calibration takes place."
-msgstr "當校準在進行時將不能使用您的電腦。"
+msgstr "校準進行時無法使用您的電腦。"
 
 #. This is the approximate time it takes to calibrate the display.
 #: panels/color/cc-color-panel.ui:40
@@ -779,7 +451,7 @@ msgstr "校準裝置"
 
 #: panels/color/cc-color-panel.ui:90
 msgid "Select the sensor device you want to use for calibration."
-msgstr "選擇您想要使用的校準偵測裝置。"
+msgstr "選擇您要用於校準的偵測裝置。"
 
 #: panels/color/cc-color-panel.ui:117
 msgid "Display Type"
@@ -797,7 +469,7 @@ msgstr "描述檔白點"
 msgid ""
 "Select a display target white point. Most displays should be calibrated to a "
 "D65 illuminant."
-msgstr "選擇一個顯示目標白點。大多數顯示器應該校準到 D65 光源。"
+msgstr "選擇一個顯示目標白點；大多數顯示器應校準至 D65 光源。"
 
 #: panels/color/cc-color-panel.ui:187
 msgid "Display Brightness"
@@ -808,7 +480,8 @@ msgid ""
 "Please set the display to a brightness that is typical for you. Color "
 "management will be most accurate at this brightness level."
 msgstr ""
-"請將顯示器的亮度設定為您常用的狀態。色彩管理會以這個亮度等級調整到最正確。"
+"請將顯示器的亮度設定為您常用的狀態，色彩管理會以這個亮度等級進行最正確的調"
+"整。"
 
 #: panels/color/cc-color-panel.ui:202
 msgid ""
@@ -844,7 +517,7 @@ msgstr "複製描述檔"
 
 #: panels/color/cc-color-panel.ui:296
 msgid "Requires writable media"
-msgstr "需要可寫入媒體"
+msgstr "需要可寫入的媒體"
 
 #: panels/color/cc-color-panel.ui:313
 msgid ""
@@ -852,8 +525,9 @@ msgid ""
 "href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
 "href=\"windows\">Microsoft Windows</a> systems useful."
 msgstr ""
-"您可以找到如何在 <a href=\"linux\">GNU/Linux</a>、<a href=\"osx\">Apple OS "
-"X</a> 與 <a href=\"windows\">Microsoft Windows</a> 系統上使用描述檔的指引。"
+"您可以找到如何在 <a href=\"linux\">GNU/Linux</a>、<a href=\"osx\">Apple "
+"macOS</a> 與 <a href=\"windows\">Microsoft Windows</a> 系統上使用描述檔的指"
+"引。"
 
 #: panels/color/cc-color-panel.ui:335
 msgid "Add Profile"
@@ -863,26 +537,24 @@ msgstr "加入描述檔"
 msgid ""
 "Problems detected. The profile may not work correctly. <a href=\"\">Show "
 "details.</a>"
-msgstr "偵測到問題。描述檔可能無法正常運作。<a href=\"\">顯示詳細資料。</a>"
+msgstr "偵測到問題，描述檔可能無法正常運作。<a href=\"\">顯示詳細資料。</a>"
 
 #: panels/color/cc-color-panel.ui:384
 msgid "_Import File…"
 msgstr "載入檔案(_I)…"
 
 #: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
-#: panels/network/connection-editor/net-connection-editor.c:497
-#: panels/printers/new-printer-dialog.ui:84
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
 #: panels/user-accounts/cc-add-user-dialog.ui:39
 msgid "_Add"
 msgstr "加入(_A)"
 
 #: panels/color/cc-color-panel.ui:424
 msgid "Each device needs an up to date color profile to be color managed."
-msgstr "每個裝置需要最新的色彩描述檔才能被管理色彩。"
+msgstr "每個裝置需要最新的色彩描述檔才能進行色彩管理。"
 
-#. translators: Text used in link to privacy policy
 #: panels/color/cc-color-panel.ui:434
-#: panels/diagnostics/cc-diagnostics-panel.c:137
 msgid "Learn more"
 msgstr "深入瞭解"
 
@@ -897,7 +569,7 @@ msgstr "所有使用者皆可用(_S)"
 #: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
 #: panels/color/cc-color-panel.ui:484
 msgid "Set this profile for all users on this computer"
-msgstr "將這個描述檔給電腦上所有使用者"
+msgstr "將這個描述檔提供給電腦上的所有使用者"
 
 #: panels/color/cc-color-panel.ui:481
 msgid "_Enable"
@@ -905,7 +577,7 @@ msgstr "啟用(_E)"
 
 #: panels/color/cc-color-panel.ui:497
 msgid "_Add profile"
-msgstr "加入設定檔(_A)"
+msgstr "加入描述檔(_A)"
 
 #: panels/color/cc-color-panel.ui:503
 msgid "_Calibrate…"
@@ -925,7 +597,7 @@ msgstr "檢視詳細資料(_V)"
 
 #: panels/color/cc-color-panel.ui:529
 msgid "Unable to detect any devices that can be color managed"
-msgstr "無法偵測到任何能被管理色彩的裝置"
+msgstr "無法偵測到任何能進行色彩管理的裝置"
 
 #: panels/color/cc-color-panel.ui:568
 msgid "LCD"
@@ -949,23 +621,23 @@ msgstr "電漿"
 
 #: panels/color/cc-color-panel.ui:593
 msgid "LCD (CCFL backlight)"
-msgstr "LCD (CCFL 背光)"
+msgstr "LCD（CCFL 背光）"
 
 #: panels/color/cc-color-panel.ui:598
 msgid "LCD (RGB LED backlight)"
-msgstr "LCD (RGB LED 背光)"
+msgstr "LCD（RGB LED 背光）"
 
 #: panels/color/cc-color-panel.ui:603
 msgid "LCD (white LED backlight)"
-msgstr "LCD (白色 LED 背光)"
+msgstr "LCD（白色 LED 背光）"
 
 #: panels/color/cc-color-panel.ui:608
 msgid "Wide gamut LCD (CCFL backlight)"
-msgstr "廣色域 LCD (CCFL 背光)"
+msgstr "廣色域 LCD（CCFL 背光）"
 
 #: panels/color/cc-color-panel.ui:613
 msgid "Wide gamut LCD (RGB LED backlight)"
-msgstr "廣色域 LCD (RGB LED 背光)"
+msgstr "廣色域 LCD（RGB LED 背光）"
 
 #: panels/color/cc-color-panel.ui:630
 msgctxt "Calibration quality"
@@ -996,11 +668,11 @@ msgstr "15 分鐘"
 
 #: panels/color/cc-color-panel.ui:663
 msgid "Native to display"
-msgstr "原生顯示"
+msgstr "顯示器原生設定"
 
 #: panels/color/cc-color-panel.ui:667
 msgid "D50 (Printing and publishing)"
-msgstr "D50 (列印與出版)"
+msgstr "D50（列印與出版）"
 
 #: panels/color/cc-color-panel.ui:671
 msgid "D55"
@@ -1008,87 +680,11 @@ msgstr "D55"
 
 #: panels/color/cc-color-panel.ui:675
 msgid "D65 (Photography and graphics)"
-msgstr "D65 (攝影與繪圖)"
+msgstr "D65（攝影與繪圖）"
 
 #: panels/color/cc-color-panel.ui:679
 msgid "D75"
 msgstr "D75"
-
-#. TRANSLATORS: standard spaces are well known colorspaces like
-#. * sRGB, AdobeRGB and ProPhotoRGB
-#: panels/color/cc-color-profile.c:98
-msgid "Standard Space"
-msgstr "標準空間"
-
-#. TRANSLATORS: test profiles do things like changing the screen
-#. * a different color, or swap the red and green channels
-#: panels/color/cc-color-profile.c:104
-msgid "Test Profile"
-msgstr "測試描述檔"
-
-#. TRANSLATORS: automatic profiles are generated automatically
-#. * by the color management system based on manufacturing data,
-#. * for instance the default monitor profile is created from the
-#. * primaries specified in the monitor EDID
-#: panels/color/cc-color-profile.c:112
-msgctxt "Automatically generated profile"
-msgid "Automatic"
-msgstr "自動"
-
-#. TRANSLATORS: the profile quality - low quality profiles take
-#. * much less time to generate but may be a poor reflection of the
-#. * device capability
-#: panels/color/cc-color-profile.c:122
-msgctxt "Profile quality"
-msgid "Low Quality"
-msgstr "低品質"
-
-#. TRANSLATORS: the profile quality
-#: panels/color/cc-color-profile.c:127
-msgctxt "Profile quality"
-msgid "Medium Quality"
-msgstr "中品質"
-
-#. TRANSLATORS: the profile quality - high quality profiles take
-#. * a *long* time, and have the best calibration and
-#. * characterisation data.
-#: panels/color/cc-color-profile.c:134
-msgctxt "Profile quality"
-msgid "High Quality"
-msgstr "高品質"
-
-#. TRANSLATORS: this default RGB space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:151
-msgctxt "Colorspace fallback"
-msgid "Default RGB"
-msgstr "預設 RGB"
-
-#. TRANSLATORS: this default CMYK space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:158
-msgctxt "Colorspace fallback"
-msgid "Default CMYK"
-msgstr "預設 CMYK"
-
-#. TRANSLATORS: this default gray space is used for printers that
-#. * do not have additional printer profiles specified in the PPD
-#: panels/color/cc-color-profile.c:165
-msgctxt "Colorspace fallback"
-msgid "Default Gray"
-msgstr "預設灰階"
-
-#: panels/color/cc-color-profile.c:188
-msgid "Vendor supplied factory calibration data"
-msgstr "廠商提供的出廠校準資料"
-
-#: panels/color/cc-color-profile.c:197
-msgid "Full-screen display correction not possible with this profile"
-msgstr "這個描述檔無法使用全螢幕顯示校正"
-
-#: panels/color/cc-color-profile.c:219
-msgid "This profile may no longer be accurate"
-msgstr "這個描述檔可能不再準確"
 
 #: panels/color/gnome-color-panel.desktop.in.in:3
 msgid "Color"
@@ -1099,16 +695,11 @@ msgid ""
 "Calibrate the color of your devices, such as displays, cameras or printers"
 msgstr "校準您裝置的色彩，像是顯示器、攝影機或印表機"
 
-#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/color/gnome-color-panel.desktop.in.in:19
 msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
 msgstr ""
-"Color;ICC;Profile;Calibrate;Printer;Display;顏色;色彩描述檔;校準;印表機;顯示"
-"器;"
-
-#: panels/common/cc-common-language.c:300
-msgid "Other…"
-msgstr "其他…"
+"Color;ICC;Profile;Calibrate;Printer;Display;顏色;色彩描述檔;校準;校正;印表機;"
+"顯示器;色彩管理;攝影;設計;出版;多媒體;"
 
 #: panels/common/cc-language-chooser.ui:5
 msgid "Select Language"
@@ -1116,26 +707,21 @@ msgstr "選擇語言"
 
 #: panels/common/cc-language-chooser.ui:13
 msgid "_Select"
-msgstr "選取(_S)"
+msgstr "選擇(_S)"
 
 #: panels/common/cc-language-chooser.ui:58
 msgid "No languages found"
 msgstr "找不到語言"
 
 #: panels/common/cc-language-chooser.ui:69
-#: panels/keyboard/cc-input-chooser.c:173
 msgid "More…"
 msgstr "更多…"
 
-#: panels/common/cc-permission-infobar.c:109
-msgid "Unlock to Change Settings"
-msgstr "解除鎖定以變更設定"
-
-#: panels/common/cc-permission-infobar.ui:40
+#: panels/common/cc-permission-infobar.ui:42
 msgid "Some settings must be unlocked before they can be changed."
-msgstr "部份設定需要先解鎖才能變更。"
+msgstr "部分設定需先解鎖才能進行更動。"
 
-#: panels/common/cc-permission-infobar.ui:57
+#: panels/common/cc-permission-infobar.ui:59
 msgid "Unlock…"
 msgstr "解除鎖定…"
 
@@ -1147,9 +733,10 @@ msgstr "遞增小時"
 msgid "Increment Minute"
 msgstr "遞增分鐘"
 
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
 #: panels/common/cc-time-editor.ui:73
 msgid "Time"
-msgstr "時刻"
+msgstr "時間"
 
 #: panels/common/cc-time-editor.ui:94
 msgid "Decrement Hour"
@@ -1159,212 +746,71 @@ msgstr "遞減小時"
 msgid "Decrement Minute"
 msgstr "遞減分鐘"
 
-#: panels/common/cc-util.c:127
-#: panels/network/connection-editor/ce-page-details.c:162
-msgid "Today"
-msgstr "今日"
-
-#: panels/common/cc-util.c:131
-#: panels/network/connection-editor/ce-page-details.c:164
-msgid "Yesterday"
-msgstr "昨日"
-
-#. Translators: This is a date format string in the style of "Feb 24".
-#: panels/common/cc-util.c:138
-msgid "%b %e"
-msgstr "%b%e日"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013".
-#: panels/common/cc-util.c:143
-msgid "%b %e, %Y"
-msgstr "%Y年%b%e日"
-
-#: panels/common/cc-util.c:165
-#, c-format
-msgid "%d hour"
-msgid_plural "%d hours"
-msgstr[0] "%d 小時"
-
-#. Translators: Option for "Blank Screen" in "Power" panel
-#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:846
-#, c-format
-msgid "%d minute"
-msgid_plural "%d minutes"
-msgstr[0] "%d 分鐘"
-
-#: panels/common/cc-util.c:167
-#, c-format
-msgid "%d second"
-msgid_plural "%d seconds"
-msgstr[0] "%d 秒"
-
-#. 5 hours 2 minutes 12 seconds
-#: panels/common/cc-util.c:174
-#, c-format
-msgctxt "hours minutes seconds"
-msgid "%s %s %s"
-msgstr "%s %s %s"
-
-#. 5 hours 2 minutes
-#: panels/common/cc-util.c:179
-#, c-format
-msgctxt "hours minutes"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 5 hours
-#: panels/common/cc-util.c:184
-#, c-format
-msgctxt "hours"
-msgid "%s"
-msgstr "%s"
-
-#. 2 minutes 12 seconds
-#: panels/common/cc-util.c:192
-#, c-format
-msgctxt "minutes seconds"
-msgid "%s %s"
-msgstr "%s %s"
-
-#. 2 minutes
-#: panels/common/cc-util.c:197
-#, c-format
-msgctxt "minutes"
-msgid "%s"
-msgstr "%s"
-
-#. 0 seconds
-#: panels/common/cc-util.c:208
-msgid "0 seconds"
-msgstr "0 秒"
-
-#. translators: This is the default hotspot name, need to be less than 32-bytes
-#: panels/common/hostname-helper.c:177
-msgctxt "hotspot"
-msgid "Hotspot"
-msgstr "熱點"
-
-#: panels/datetime/cc-datetime-panel.c:175
-msgid "24-hour"
-msgstr "24小時"
-
-#: panels/datetime/cc-datetime-panel.c:177
-msgid "AM / PM"
-msgstr "AM / PM"
-
-#. Translators: This is the full date and time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:248
-msgid "%e %B %Y, %l:%M %p"
-msgstr "%Y年%b%e日，%p %l:%M"
-
-#. Translators: This is the full date and time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:253
-msgid "%e %B %Y, %R"
-msgstr "%Y年%b%e日，%R"
-
-#. Translators: "city, country"
-#: panels/datetime/cc-datetime-panel.c:423
-#, c-format
-msgctxt "timezone loc"
-msgid "%s, %s"
-msgstr "%s，%s"
-
-#. Update the timezone on the listbow row
-#. Translators: "timezone (details)"
-#: panels/datetime/cc-datetime-panel.c:450
-#, c-format
-msgctxt "timezone desc"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
-#. Translators: UTC here means the Coordinated Universal Time.
-#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
-#: panels/datetime/cc-datetime-panel.c:457
-msgid "UTC%:::z"
-msgstr "UTC%:::z"
-
-#. Translators: This is the time format used in 12-hour mode.
-#: panels/datetime/cc-datetime-panel.c:462
-msgid "%l:%M %p"
-msgstr "%p %l:%M"
-
-#. Translators: This is the time format used in 24-hour mode.
-#: panels/datetime/cc-datetime-panel.c:467
-msgid "%R"
-msgstr "%R"
-
-#. Update the text bubble in the timezone map
-#. Translators: "timezone (utc shift)"
-#: panels/datetime/cc-datetime-panel.c:472
-#, c-format
-msgctxt "timezone map"
-msgid "%s (%s)"
-msgstr "%s (%s)"
-
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
 #: panels/datetime/cc-datetime-panel.ui:15
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:3
 msgid "Date & Time"
-msgstr "日期與時刻"
+msgstr "日期與時間"
 
 #: panels/datetime/cc-datetime-panel.ui:50
 msgid "Year"
-msgstr "年"
+msgstr "年份"
 
 #: panels/datetime/cc-datetime-panel.ui:66
 msgid "Month"
-msgstr "月"
+msgstr "月份"
 
 #: panels/datetime/cc-datetime-panel.ui:71
 msgid "January"
-msgstr "一月"
+msgstr "1月"
 
 #: panels/datetime/cc-datetime-panel.ui:72
 msgid "February"
-msgstr "二月"
+msgstr "2月"
 
 #: panels/datetime/cc-datetime-panel.ui:73
 msgid "March"
-msgstr "三月"
+msgstr "3月"
 
 #: panels/datetime/cc-datetime-panel.ui:74
 msgid "April"
-msgstr "四月"
+msgstr "4月"
 
 #: panels/datetime/cc-datetime-panel.ui:75
 msgid "May"
-msgstr "五月"
+msgstr "5月"
 
 #: panels/datetime/cc-datetime-panel.ui:76
 msgid "June"
-msgstr "六月"
+msgstr "6月"
 
 #: panels/datetime/cc-datetime-panel.ui:77
 msgid "July"
-msgstr "七月"
+msgstr "7月"
 
 #: panels/datetime/cc-datetime-panel.ui:78
 msgid "August"
-msgstr "八月"
+msgstr "8月"
 
 #: panels/datetime/cc-datetime-panel.ui:79
 msgid "September"
-msgstr "九月"
+msgstr "9月"
 
 #: panels/datetime/cc-datetime-panel.ui:80
 msgid "October"
-msgstr "十月"
+msgstr "10月"
 
 #: panels/datetime/cc-datetime-panel.ui:81
 msgid "November"
-msgstr "十一月"
+msgstr "11月"
 
 #: panels/datetime/cc-datetime-panel.ui:82
 msgid "December"
-msgstr "十二月"
+msgstr "12月"
 
 #: panels/datetime/cc-datetime-panel.ui:92
 msgid "Day"
-msgstr "日"
+msgstr "日期"
 
 #: panels/datetime/cc-datetime-panel.ui:113
 msgid "Time Zone"
@@ -1374,50 +820,90 @@ msgstr "時區"
 msgid "Search for a city"
 msgstr "搜尋城市"
 
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
 #: panels/datetime/cc-datetime-panel.ui:164
 msgid "Automatic _Date &amp; Time"
-msgstr "自動調校日期與時刻(_D)"
+msgstr "自動調整日期與時間(_D)"
 
 #: panels/datetime/cc-datetime-panel.ui:165
 msgid "Requires internet access"
 msgstr "需要網際網路連線"
 
-#: panels/datetime/cc-datetime-panel.ui:177
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/datetime/cc-datetime-panel.ui:180
 msgid "Date &amp; _Time"
-msgstr "日期與時刻(_T)"
+msgstr "日期與時間(_T)"
 
-#: panels/datetime/cc-datetime-panel.ui:201
+#: panels/datetime/cc-datetime-panel.ui:204
 msgid "Automatic Time _Zone"
 msgstr "自動調整時區(_Z)"
 
-#: panels/datetime/cc-datetime-panel.ui:202
+#: panels/datetime/cc-datetime-panel.ui:205
 msgid "Requires location services enabled and internet access"
-msgstr "需要啟用定位服務及網際網路連線"
+msgstr "需啟用定位服務及網際網路連線"
 
-#: panels/datetime/cc-datetime-panel.ui:214
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+msgid "Enabled"
+msgstr "已啟用"
+
+#: panels/datetime/cc-datetime-panel.ui:220
 msgid "Time Z_one"
 msgstr "時區(_O)"
 
-#: panels/datetime/cc-datetime-panel.ui:239
-msgid "Time _Format"
-msgstr "時刻格式(_F)"
+#: panels/datetime/cc-datetime-panel.ui:243
+#, fuzzy
+msgid "Clock"
+msgstr "解除鎖定"
 
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr "時間格式(_F)"
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+#, fuzzy
+msgid "Date"
+msgstr "日期"
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "0 秒"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+msgid "Calendar"
+msgstr "行事曆"
+
+#: panels/datetime/cc-datetime-panel.ui:302
+#, fuzzy
+msgid "Week Numbers"
+msgstr "數字"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:4
 msgid "Change the date and time, including time zone"
-msgstr "改變時刻與日期，包含時區"
+msgstr "更改日期與時間及調整時區"
 
-#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/datetime/gnome-datetime-panel.desktop.in.in:15
 msgid "Clock;Timezone;Location;"
-msgstr "Clock;Timezone;Location;時鐘;時區;位置;定位;"
+msgstr "Clock;Timezone;Location;時鐘;時區;位置;定位;時間;時刻;時制;"
 
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
 #: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
 msgid "Change system time and date settings"
-msgstr "改變系統時刻與日期設定值"
+msgstr "更改系統的時間與日期設定值"
 
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
 #: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
 msgid "To change time or date settings, you need to authenticate."
-msgstr "要改變時刻或日期設定值，您需要通過核對。"
+msgstr "欲對日期或時間設定值進行更動需要核對身分。"
 
 #: panels/default-apps/cc-default-apps-panel.ui:23
 msgid "_Web"
@@ -1425,7 +911,7 @@ msgstr "網頁(_W)"
 
 #: panels/default-apps/cc-default-apps-panel.ui:33
 msgid "_Mail"
-msgstr "郵件(_M)"
+msgstr "電子郵件(_M)"
 
 #: panels/default-apps/cc-default-apps-panel.ui:47
 msgid "_Calendar"
@@ -1452,20 +938,9 @@ msgstr "預設應用程式"
 msgid "Configure Default Applications"
 msgstr "設定預設應用程式"
 
-#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
 msgid "default;application;preferred;media;"
 msgstr "default;application;preferred;media;預設;應用程式;偏好;首選;媒體;"
-
-#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
-#: panels/diagnostics/cc-diagnostics-panel.c:139
-#, c-format
-msgid ""
-"Sending reports of technical problems helps us improve %s. Reports are sent "
-"anonymously and are scrubbed of personal data. %s"
-msgstr ""
-"傳送技術問題的報告有助於我們改進 %s。報告是以匿名方式傳送，並且會消除個人資"
-"料。%s"
 
 #: panels/diagnostics/cc-diagnostics-panel.ui:8
 msgid "Problem Reporting"
@@ -1483,214 +958,175 @@ msgstr "診斷"
 msgid "Report your problems"
 msgstr "回報您遇到的問題"
 
-#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
-#: panels/location/gnome-location-panel.desktop.in.in:20
-#: panels/lock/gnome-lock-panel.desktop.in.in:20
-#: panels/usage/gnome-usage-panel.desktop.in.in:20
-msgid ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;"
-msgstr ""
-"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
-"network;identity;privacy;螢幕;鎖定;診斷;當掉;崩潰;私人;隱私;最近;暫存;索引;名"
-"稱;網路;身分;"
-
-#: panels/display/cc-display-panel.c:512
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:734 panels/power/cc-power-panel.c:741
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "On"
-msgstr "開啟"
-
-#: panels/display/cc-display-panel.c:514 panels/network/net-proxy.c:69
-#: panels/notifications/cc-notifications-panel.c:217
-#: panels/power/cc-power-panel.c:728 panels/power/cc-power-panel.c:739
-#: panels/universal-access/cc-ua-panel.c:336
-#: panels/universal-access/cc-ua-panel.c:468
-#: panels/universal-access/cc-ua-panel.c:478
-#: panels/universal-access/cc-ua-panel.c:490
-#: panels/universal-access/cc-ua-panel.c:526
-msgid "Off"
-msgstr "關閉"
-
-#: panels/display/cc-display-panel.c:945
-msgid "Apply Changes?"
-msgstr "要套用變更嗎？"
-
-#: panels/display/cc-display-panel.c:950
-msgid "Changes Cannot be Applied"
-msgstr "變更無法套用"
-
-#: panels/display/cc-display-panel.c:952
-msgid "This could be due to hardware limitations."
-msgstr "這可能是因為硬體限制。"
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;診斷;當機;"
 
 #: panels/display/cc-display-panel.ui:43
 #: panels/network/connection-editor/connection-editor.ui:21
 msgid "_Apply"
 msgstr "套用(_A)"
 
-#: panels/display/cc-display-panel.ui:97
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "返回"
+
+#: panels/display/cc-display-panel.ui:100
 msgid "Display Settings Disabled"
 msgstr "顯示器設定已停用"
 
-#: panels/display/cc-display-panel.ui:113
-msgid "Display Arrangement"
-msgstr "排列顯示器組合方式"
-
-#: panels/display/cc-display-panel.ui:124
+#: panels/display/cc-display-panel.ui:111
 msgid "Multiple Displays"
 msgstr "多重顯示器"
 
 #. 'Join' as in 'Join displays'
-#: panels/display/cc-display-panel.ui:133
+#: panels/display/cc-display-panel.ui:120
 msgid "Join"
-msgstr "聯結"
+msgstr "銜接顯示"
 
-#: panels/display/cc-display-panel.ui:140
+#: panels/display/cc-display-panel.ui:127
 msgid "Mirror"
-msgstr "相同"
+msgstr "鏡像顯示"
 
-#: panels/display/cc-display-panel.ui:153
+#: panels/display/cc-display-panel.ui:155
 msgid "Contains top bar and Activities"
 msgstr "包含頂端列及概覽"
 
-#: panels/display/cc-display-panel.ui:154
+#: panels/display/cc-display-panel.ui:156
 msgid "Primary Display"
-msgstr "主要顯示器"
+msgstr "主螢幕"
 
 #. This is the redshift functionality where we suppress blue light when the sun has gone down
-#: panels/display/cc-display-panel.ui:175
-#: panels/display/cc-display-panel.ui:223
-#: panels/display/cc-night-light-page.ui:77
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
 msgid "Night Light"
-msgstr "夜光"
+msgstr "夜光模式"
 
-#: panels/display/cc-display-settings.c:110
-msgctxt "Display rotation"
-msgid "Landscape"
-msgstr "橫向"
-
-#: panels/display/cc-display-settings.c:113
-msgctxt "Display rotation"
-msgid "Portrait Right"
-msgstr "直向右轉"
-
-#: panels/display/cc-display-settings.c:116
-msgctxt "Display rotation"
-msgid "Portrait Left"
-msgstr "直向左轉"
-
-#: panels/display/cc-display-settings.c:119
-msgctxt "Display rotation"
-msgid "Landscape (flipped)"
-msgstr "橫向（翻轉）"
-
-#: panels/display/cc-display-settings.c:177
-#, c-format
-msgid "%.2lf Hz"
-msgstr "%.2lf Hz"
-
-#: panels/display/cc-display-settings.ui:40
+#: panels/display/cc-display-settings.ui:43
 msgctxt "display setting"
 msgid "Orientation"
 msgstr "方向"
 
-#: panels/display/cc-display-settings.ui:47
+#: panels/display/cc-display-settings.ui:50
 msgctxt "display setting"
 msgid "Resolution"
 msgstr "解析度"
 
-#: panels/display/cc-display-settings.ui:54
+#: panels/display/cc-display-settings.ui:57
 msgid "Refresh Rate"
 msgstr "更新率"
 
-#: panels/display/cc-display-settings.ui:61
+#: panels/display/cc-display-settings.ui:64
 msgid "Adjust for TV"
-msgstr "調整為電視"
+msgstr "為電視進行調整"
 
-#: panels/display/cc-display-settings.ui:75
-#: panels/display/cc-display-settings.ui:90
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
 msgctxt "display setting"
 msgid "Scale"
 msgstr "縮放"
 
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "自然捲動"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "夜光模式無法使用"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr "可能是由於顯示卡的驅動程式不支援夜光模式，亦或是桌面正在遠端使用當中"
+
 #. Inhibit the redshift functionality until the next day starts
-#: panels/display/cc-night-light-page.ui:21
+#: panels/display/cc-night-light-page.ui:58
 msgid "Temporarily Disabled Until Tomorrow"
-msgstr "暫時停用直到明天"
+msgstr "暫時停用至明天"
 
 #. This cancels the redshift inhibit.
-#: panels/display/cc-night-light-page.ui:35
+#: panels/display/cc-night-light-page.ui:72
 msgid "Restart Filter"
-msgstr "重新啟動過濾器"
+msgstr "重啟夜光模式"
 
-#: panels/display/cc-night-light-page.ui:57
+#: panels/display/cc-night-light-page.ui:95
 msgid ""
 "Night light makes the screen color warmer. This can help to prevent eye "
 "strain and sleeplessness."
-msgstr "夜光讓螢幕色彩變得溫暖。這可以幫助防止眼睛疲勞與失眠。"
+msgstr "夜光模式會讓螢幕色彩變得溫暖，可幫助防止眼睛疲勞與失眠。"
 
-#: panels/display/cc-night-light-page.ui:91
+#: panels/display/cc-night-light-page.ui:132
 msgid "Schedule"
 msgstr "排程"
 
-#: panels/display/cc-night-light-page.ui:99
+#: panels/display/cc-night-light-page.ui:140
 msgid "Sunset to Sunrise"
-msgstr "日落到日出"
+msgstr "日落至日出"
 
-#: panels/display/cc-night-light-page.ui:100
+#: panels/display/cc-night-light-page.ui:141
 msgid "Manual Schedule"
 msgstr "手動排程"
 
-#: panels/display/cc-night-light-page.ui:110
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/display/cc-night-light-page.ui:154
 #: panels/region/cc-format-preview.ui:35
 msgid "Times"
-msgstr "時刻"
+msgstr "時間"
 
-#: panels/display/cc-night-light-page.ui:123
+#: panels/display/cc-night-light-page.ui:167
 msgid "From"
 msgstr "從"
 
-#: panels/display/cc-night-light-page.ui:148
-#: panels/display/cc-night-light-page.ui:235
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
 msgid "Hour"
 msgstr "時"
 
-#: panels/display/cc-night-light-page.ui:154
-#: panels/display/cc-night-light-page.ui:241
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
 msgid ":"
 msgstr ":"
 
-#: panels/display/cc-night-light-page.ui:171
-#: panels/display/cc-night-light-page.ui:258
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
 msgid "Minute"
 msgstr "分"
 
 #. This is the short form for the time period in the morning
-#: panels/display/cc-night-light-page.ui:181
-#: panels/display/cc-night-light-page.ui:268
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
 msgid "AM"
 msgstr "上午"
 
 #. This is the short form for the time period in the afternoon
-#: panels/display/cc-night-light-page.ui:193
-#: panels/display/cc-night-light-page.ui:280
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
 msgid "PM"
 msgstr "下午"
 
-#: panels/display/cc-night-light-page.ui:210
+#: panels/display/cc-night-light-page.ui:254
 msgid "To"
-msgstr "到"
+msgstr "至"
 
-#: panels/display/cc-night-light-page.ui:316
+#: panels/display/cc-night-light-page.ui:360
 msgid "Color Temperature"
-msgstr "色彩溫度"
+msgstr "色溫"
 
 #: panels/display/gnome-display-panel.desktop.in.in:3
 msgid "Displays"
@@ -1700,7 +1136,6 @@ msgstr "顯示器"
 msgid "Choose how to use connected monitors and projectors"
 msgstr "選擇如何使用連接的顯示器與投影機"
 
-#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/display/gnome-display-panel.desktop.in.in:19
 msgid ""
 "Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
@@ -1710,54 +1145,56 @@ msgstr ""
 "redshift;color;sunset;sunrise;面板;投影機;螢幕;解析度;重新整理;螢幕;夜晚;夜"
 "光;藍光;日出;日落;"
 
-#: panels/info-overview/cc-info-overview-panel.c:411
-#: panels/info-overview/cc-info-overview-panel.c:435
-#: panels/info-overview/cc-info-overview-panel.c:481
-#: panels/info-overview/cc-info-overview-panel.c:511
-#: panels/wwan/cc-wwan-details-dialog.c:100
-msgid "Unknown"
-msgstr "不明"
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"安全開機可防止惡意軟體在裝置啟動階段時悄悄載入。\n"
+"\n"
+"如需了解更多資訊，請聯絡您的硬體製造商或 IT 技術人員。"
 
-#. translators: This is the name of the OS, followed by the build ID, for
-#. * example:
-#. * "Fedora 25 (Workstation Edition); Build ID: xyz" or
-#. * "Ubuntu 16.04 LTS; Build ID: jki"
-#: panels/info-overview/cc-info-overview-panel.c:443
-#, c-format
-msgid "%s; Build ID: %s"
-msgstr "%s；組建 ID：%s"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr "安全性等級"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:458
-#, c-format
-msgid "64-bit"
-msgstr "64位元"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "等級 1"
 
-#. translators: This is the type of architecture for the OS
-#: panels/info-overview/cc-info-overview-panel.c:461
-#, c-format
-msgid "32-bit"
-msgstr "32位元"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "等級 2"
 
-#: panels/info-overview/cc-info-overview-panel.c:720
-msgid "X11"
-msgstr "X11"
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "等級 3"
 
-#: panels/info-overview/cc-info-overview-panel.c:724
-msgid "Wayland"
-msgstr "Wayland"
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "沒有活動"
 
-#: panels/info-overview/cc-info-overview-panel.c:726
-msgctxt "Windowing system (Wayland, X11, or Unknown)"
-msgid "Unknown"
-msgstr "不明"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "裝置安全"
 
-#: panels/info-overview/cc-info-overview-panel.ui:17
-msgid "System Logo"
-msgstr "系統標誌"
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "了解主機的安全性狀態"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;螢幕;鎖定;診斷;當掉;崩潰;私人;隱私;最近;暫存;索引;名"
+"稱;網路;身分;"
 
 #: panels/info-overview/cc-info-overview-panel.ui:32
-#: panels/sharing/cc-sharing-panel.ui:299
+#: panels/sharing/cc-sharing-panel.ui:304
 msgid "Device Name"
 msgstr "裝置名稱"
 
@@ -1775,7 +1212,7 @@ msgstr "處理器"
 
 #: panels/info-overview/cc-info-overview-panel.ui:74
 msgid "Graphics"
-msgstr "繪圖"
+msgstr "顯示卡"
 
 #: panels/info-overview/cc-info-overview-panel.ui:82
 msgid "Disk Capacity"
@@ -1790,37 +1227,51 @@ msgstr "正在計算…"
 msgid "OS Name"
 msgstr "作業系統名稱"
 
-#: panels/info-overview/cc-info-overview-panel.ui:106
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "作業系統組建 ID"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
 msgid "OS Type"
 msgstr "作業系統類型"
 
-#: panels/info-overview/cc-info-overview-panel.ui:114
+#: panels/info-overview/cc-info-overview-panel.ui:123
 msgid "GNOME Version"
 msgstr "GNOME 版本"
 
-#: panels/info-overview/cc-info-overview-panel.ui:123
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "正在載入…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
 msgid "Windowing System"
 msgstr "視窗系統"
 
-#: panels/info-overview/cc-info-overview-panel.ui:131
+#: panels/info-overview/cc-info-overview-panel.ui:141
 msgid "Virtualization"
 msgstr "虛擬化"
 
-#: panels/info-overview/cc-info-overview-panel.ui:139
+#: panels/info-overview/cc-info-overview-panel.ui:150
 msgid "Software Updates"
 msgstr "軟體更新"
 
-#: panels/info-overview/cc-info-overview-panel.ui:158
+#: panels/info-overview/cc-info-overview-panel.ui:174
 msgid "Rename Device"
 msgstr "重新命名裝置"
 
-#: panels/info-overview/cc-info-overview-panel.ui:174
+#: panels/info-overview/cc-info-overview-panel.ui:190
 msgid ""
 "The device name is used to identify this device when it is viewed over the "
 "network, or when pairing Bluetooth devices."
-msgstr "裝置名稱用來在網路上檢視裝置，或是配對藍牙裝置時識別裝置。"
+msgstr "在網路查看或藍牙配對時，裝置名稱能供他人辨識。"
 
-#: panels/info-overview/cc-info-overview-panel.ui:190
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "裝置名稱"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
 msgid "_Rename"
 msgstr "重新命名(_R)"
 
@@ -1832,11 +1283,6 @@ msgstr "關於"
 msgid "View information about your system"
 msgstr "檢視您系統的資訊"
 
-#. Translators: Search terms to find the About panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. "Preferred Applications" is the old name for the preference, so make
-#. sure that you use the same "translation" for those keywords
 #: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
 msgid ""
 "device;system;information;hostname;memory;processor;version;default;"
@@ -1849,31 +1295,31 @@ msgstr ""
 
 #: panels/keyboard/00-multimedia.xml.in:2
 msgid "Sound and Media"
-msgstr "聲音與媒體"
+msgstr "音訊與媒體"
 
 #: panels/keyboard/00-multimedia.xml.in:4
 msgid "Volume mute/unmute"
-msgstr "音量 靜音/取消靜音"
+msgstr "音量靜音/取消靜音"
 
 #: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
-msgstr "調低音量"
+msgstr "音量降低"
 
 #: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
-msgstr "調高音量"
+msgstr "音量提高"
 
 #: panels/keyboard/00-multimedia.xml.in:10
 msgid "Microphone mute/unmute"
-msgstr "麥克風 靜音/取消靜音"
+msgstr "麥克風靜音/取消靜音"
 
 #: panels/keyboard/00-multimedia.xml.in:12
 msgid "Launch media player"
-msgstr "執行媒體播放程式"
+msgstr "啟動媒體播放器"
 
 #: panels/keyboard/00-multimedia.xml.in:14
 msgid "Play (or play/pause)"
-msgstr "播放 (或播放/暫停)"
+msgstr "播放（或播放/暫停）"
 
 #: panels/keyboard/00-multimedia.xml.in:16
 msgid "Pause playback"
@@ -1893,7 +1339,7 @@ msgstr "下一首歌曲"
 
 #: panels/keyboard/00-multimedia.xml.in:24
 msgid "Eject"
-msgstr "退出"
+msgstr "退出光碟"
 
 #: panels/keyboard/01-input-sources.xml.in:4
 #: panels/universal-access/cc-ua-panel.ui:163
@@ -1902,31 +1348,37 @@ msgstr "輸入"
 
 #: panels/keyboard/01-input-sources.xml.in:8
 msgid "Switch to next input source"
-msgstr "切換到下一個輸入來源"
+msgstr "切換至下個輸入來源"
 
 #: panels/keyboard/01-input-sources.xml.in:13
 msgid "Switch to previous input source"
-msgstr "切換到上一個輸入來源"
+msgstr "切換至上個輸入來源"
 
 #: panels/keyboard/01-launchers.xml.in:2
 msgid "Launchers"
-msgstr "執行器"
+msgstr "啟動應用程式"
 
 #: panels/keyboard/01-launchers.xml.in:4
 msgid "Launch help browser"
-msgstr "執行說明文件瀏覽器"
+msgstr "求助文件瀏覽器"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "設定值"
 
 #: panels/keyboard/01-launchers.xml.in:8
 msgid "Launch calculator"
-msgstr "執行計算機"
+msgstr "計算機"
 
 #: panels/keyboard/01-launchers.xml.in:10
 msgid "Launch email client"
-msgstr "執行電子郵件客戶端"
+msgstr "電子郵件客戶端"
 
 #: panels/keyboard/01-launchers.xml.in:12
 msgid "Launch web browser"
-msgstr "執行網頁瀏覽器"
+msgstr "網頁瀏覽器"
 
 #: panels/keyboard/01-launchers.xml.in:14
 msgid "Home folder"
@@ -1937,7 +1389,7 @@ msgctxt "keybinding"
 msgid "Search"
 msgstr "搜尋"
 
-#: panels/keyboard/01-system.xml.in:2
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 msgid "System"
 msgstr "系統"
 
@@ -1947,7 +1399,7 @@ msgstr "登出"
 
 #: panels/keyboard/01-system.xml.in:6
 msgid "Lock screen"
-msgstr "鎖定畫面"
+msgstr "鎖定螢幕"
 
 #: panels/keyboard/50-accessibility.xml.in:2
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
@@ -1956,15 +1408,15 @@ msgstr "無障礙輔助"
 
 #: panels/keyboard/50-accessibility.xml.in:4
 msgid "Turn zoom on or off"
-msgstr "開啟或關閉放大鏡"
+msgstr "開啟或關閉縮放"
 
 #: panels/keyboard/50-accessibility.xml.in:6
 msgid "Zoom in"
-msgstr "拉近"
+msgstr "放大（需啟用縮放）"
 
 #: panels/keyboard/50-accessibility.xml.in:8
 msgid "Zoom out"
-msgstr "拉遠"
+msgstr "縮小（需啟用縮放）"
 
 #: panels/keyboard/50-accessibility.xml.in:10
 msgid "Turn screen reader on or off"
@@ -1984,143 +1436,43 @@ msgstr "將文字縮小"
 
 #: panels/keyboard/50-accessibility.xml.in:18
 msgid "High contrast on or off"
-msgstr "高對比開或關"
-
-#: panels/keyboard/cc-input-chooser.c:186
-msgid "No input sources found"
-msgstr "找不到輸入來源"
-
-#: panels/keyboard/cc-input-chooser.c:931
-msgctxt "Input Source"
-msgid "Other"
-msgstr "其他"
+msgstr "開啟或關閉高反差"
 
 #: panels/keyboard/cc-input-chooser.ui:5
 msgid "Add an Input Source"
 msgstr "加入輸入來源"
 
-#: panels/keyboard/cc-input-chooser.ui:81
+#: panels/keyboard/cc-input-chooser.ui:84
 msgid "Input methods can’t be used on the login screen"
-msgstr "輸入法無法在登入畫面中使用"
+msgstr "輸入法無法在登入畫面使用"
 
 #: panels/keyboard/cc-input-list-box.ui:24
 msgid "No input source selected"
-msgstr "尚未選擇輸入來源"
+msgstr "未選擇輸入來源"
 
-#: panels/keyboard/cc-input-row.ui:28 panels/search/cc-search-panel-row.ui:49
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "選項"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
 msgid "Move Up"
-msgstr "往上移"
+msgstr "上移"
 
-#: panels/keyboard/cc-input-row.ui:32 panels/search/cc-search-panel-row.ui:53
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
 msgid "Move Down"
-msgstr "往下移"
+msgstr "下移"
 
-#: panels/keyboard/cc-input-row.ui:38
+#: panels/keyboard/cc-input-row.ui:41
 msgid "Preferences"
 msgstr "偏好設定"
 
-#: panels/keyboard/cc-input-row.ui:45
+#: panels/keyboard/cc-input-row.ui:48
 msgid "View Keyboard Layout"
 msgstr "檢視鍵盤配置"
 
-#: panels/keyboard/cc-input-row.ui:51
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:29
+#: panels/keyboard/cc-input-row.ui:54
 msgid "Remove"
 msgstr "移除"
-
-#: panels/keyboard/cc-keyboard-manager.c:485
-#: panels/keyboard/cc-keyboard-manager.c:493
-#: panels/keyboard/cc-keyboard-manager.c:922
-msgid "Custom Shortcuts"
-msgstr "自訂快捷鍵"
-
-#: panels/keyboard/cc-keyboard-panel.c:64
-#: panels/keyboard/cc-keyboard-panel.ui:62
-msgid "Alternate Characters Key"
-msgstr "替代字元鍵"
-
-#: panels/keyboard/cc-keyboard-panel.c:65
-msgid ""
-"The alternate characters key can be used to enter additional characters. "
-"These are sometimes printed as a third-option on your keyboard."
-msgstr ""
-"可以用來輸入額外字元的代用字元。這些字元通常會以第三選項方式印在您的鍵盤上。"
-
-#: panels/keyboard/cc-keyboard-panel.c:67
-#: panels/keyboard/cc-keyboard-panel.c:85
-msgctxt "keyboard key"
-msgid "Left Alt"
-msgstr "左 Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:68
-#: panels/keyboard/cc-keyboard-panel.c:86
-msgctxt "keyboard key"
-msgid "Right Alt"
-msgstr "右 Alt"
-
-#: panels/keyboard/cc-keyboard-panel.c:69
-#: panels/keyboard/cc-keyboard-panel.c:87
-msgctxt "keyboard key"
-msgid "Left Super"
-msgstr "左 Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:70
-#: panels/keyboard/cc-keyboard-panel.c:88
-msgctxt "keyboard key"
-msgid "Right Super"
-msgstr "右 Super"
-
-#: panels/keyboard/cc-keyboard-panel.c:71
-#: panels/keyboard/cc-keyboard-panel.c:89
-msgctxt "keyboard key"
-msgid "Menu key"
-msgstr "選單鍵"
-
-#: panels/keyboard/cc-keyboard-panel.c:72
-#: panels/keyboard/cc-keyboard-panel.c:90
-msgctxt "keyboard key"
-msgid "Right Ctrl"
-msgstr "右 Ctrl"
-
-#: panels/keyboard/cc-keyboard-panel.c:80
-#: panels/keyboard/cc-keyboard-panel.ui:79
-msgid "Compose Key"
-msgstr "組合鍵"
-
-#: panels/keyboard/cc-keyboard-panel.c:81
-msgid ""
-"The compose key allows a wide variety of characters to be entered. To use "
-"it, press compose then a sequence of characters.  For example, compose key "
-"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
-"<b>'</b> will enter <b>á</b>."
-msgstr ""
-"組合鍵讓您可以輸入更多種字元。若要使用此功能，請先按組合鍵，再輸入一段字元順"
-"序。舉例，先按組合鍵，再按 <b>C</b> 和 <b>o</b>，可以輸入 <b>©</b>，而再按 "
-"<b>a</b> 和 <b>'</b> 則會輸入 <b>á</b>。"
-
-#: panels/keyboard/cc-keyboard-panel.c:91
-msgctxt "keyboard key"
-msgid "Caps Lock"
-msgstr "大寫鎖定"
-
-#: panels/keyboard/cc-keyboard-panel.c:92
-msgctxt "keyboard key"
-msgid "Scroll Lock"
-msgstr "捲動鎖定"
-
-#: panels/keyboard/cc-keyboard-panel.c:93
-msgctxt "keyboard key"
-msgid "Print Screen"
-msgstr "列印畫面"
-
-#: panels/keyboard/cc-keyboard-panel.c:217
-#, c-format
-msgid ""
-"Input sources can be switched using the %s keyboard shortcut.\n"
-"This can be changed in the keyboard shortcut settings."
-msgstr ""
-"輸入來源可以使用 %s 鍵盤快捷鍵切換。\n"
-"這可以在鍵盤快捷鍵設定值中修改。"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17
 msgid "Input Sources"
@@ -2136,153 +1488,122 @@ msgstr "輸入來源切換"
 
 #: panels/keyboard/cc-keyboard-panel.ui:31
 msgid "Use the _same source for all windows"
-msgstr "所有視窗皆使用相同的來源(_S)"
+msgstr "所有視窗皆使用相同的輸入來源(_S)"
 
 #: panels/keyboard/cc-keyboard-panel.ui:43
 msgid "Switch input sources _individually for each window"
 msgstr "每個視窗各自切換獨立的輸入來源(_D)"
 
-#: panels/keyboard/cc-keyboard-panel.ui:58
-msgid "Special Character Entry"
-msgstr "特殊字元輸入"
-
 #: panels/keyboard/cc-keyboard-panel.ui:59
-msgid "Methods for entering symbols and letter variants using the keyboard."
-msgstr "使用鍵盤輸入符號、字母變體的輸入法。"
+msgid "Special Character Entry"
+msgstr "輸入特殊字元"
 
-#: panels/keyboard/cc-keyboard-panel.ui:97
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "使用鍵盤輸入符號及字母變體的方法。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "替代字元鍵"
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "組合鍵"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
 msgid "Keyboard Shortcuts"
 msgstr "鍵盤快捷鍵"
 
-#: panels/keyboard/cc-keyboard-panel.ui:100
+#: panels/keyboard/cc-keyboard-panel.ui:101
 msgid "View and Customize Shortcuts"
 msgstr "檢視與自訂快捷鍵"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
-#, c-format
-msgid "%d modified"
-msgid_plural "%d modified"
-msgstr[0] "%d 已修改"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:460
-msgid "Reset All Shortcuts?"
-msgstr "重設所有的快捷鍵？"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
-msgid ""
-"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
-"undone."
-msgstr "重設快捷鍵可能會影響您自訂的快捷鍵。這個動作不能撤銷。"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:467
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
-#: panels/network/wireless-security/ws-file-chooser-button.c:94
-#: panels/printers/ppd-selection-dialog.ui:83
-#: panels/wwan/cc-wwan-device-page.c:189
-msgid "Cancel"
-msgstr "取消"
-
-#: panels/keyboard/cc-keyboard-shortcut-dialog.c:468
-msgid "Reset All"
-msgstr "全部重設"
-
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
 msgid "Reset All…"
-msgstr "全部重設…"
+msgstr "重設全部…"
 
 #: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
 msgid "Reset all shortcuts to their default keybindings"
-msgstr "將快捷鍵重設回它們預設的按鍵組合"
+msgstr "將快捷鍵重設為預設的按鍵組合"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:143
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "節"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "加入快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
 msgid "Add Custom Shortcuts"
 msgstr "加入自訂快捷鍵"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:151
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
 msgid "Set up custom shortcuts for launching apps, running scripts, and more."
-msgstr "設置自訂快捷鍵方便啟動程式、執行指令稿…等。"
+msgstr "設定自訂快捷鍵來啟動應用程式、執行命令稿等。"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:157
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
 msgid "Add Shortcut"
-msgstr "加入捷徑鍵"
+msgstr "加入快捷鍵"
 
-#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:189
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
 msgid "No keyboard shortcut found"
 msgstr "找不到鍵盤快捷鍵"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
-#, c-format
-msgid "%s is already being used for %s. If you replace it, %s will be disabled"
-msgstr "%s 已經被 %s 使用。如您替換，則 %s 會被停用"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "移除(_R)"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
-msgid "Enter the new shortcut"
-msgstr "輸入新的快捷鍵"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "取代(_P)"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Custom Shortcut"
-msgstr "設定自訂快捷鍵"
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr "設定(_S)"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
-msgid "Set Shortcut"
-msgstr "設定快捷鍵"
-
-#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
-#, c-format
-msgid "Enter new shortcut to change %s."
-msgstr "請輸入新的快捷鍵來更改 %s。"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.c:992
-msgid "Add Custom Shortcut"
-msgstr "加入自訂快捷鍵"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:39
-#: panels/wwan/cc-wwan-apn-dialog.ui:33
-msgid "Add"
-msgstr "加入"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:46
-msgid "Replace"
-msgstr "取代"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:52
-msgid "Set"
-msgstr "設定"
-
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
-msgstr "按下 Esc 取消或按 Backspace 停用鍵盤快捷鍵。"
+msgstr "按下 Esc 鍵取消或按 Backspace 鍵停用該鍵盤快捷鍵。"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:153
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
 #: panels/printers/pp-details-dialog.ui:39
 #: panels/user-accounts/cc-add-user-dialog.ui:68
-#: panels/user-accounts/cc-user-panel.ui:132
+#: panels/user-accounts/cc-user-panel.ui:137
 #: panels/wwan/cc-wwan-apn-dialog.ui:96
 msgid "Name"
 msgstr "名稱"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:163
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
 msgid "Command"
-msgstr "指令"
+msgstr "命令"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:173
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
 msgid "Shortcut"
 msgstr "快捷鍵"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:240
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
 msgid "Set Shortcut…"
 msgstr "設定快捷鍵…"
 
-#: panels/keyboard/cc-keyboard-shortcut-editor.ui:248
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
 msgid "None"
 msgstr "沒有"
 
 #: panels/keyboard/cc-keyboard-shortcut-row.ui:23
 msgid "Reset the shortcut to its default value"
-msgstr "將快捷鍵重設回預設值"
+msgstr "將快捷鍵重設為預設值"
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "使用相機"
 
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
 msgid "Keyboard"
@@ -2292,26 +1613,25 @@ msgstr "鍵盤"
 msgid ""
 "Change keyboard shortcuts and set your typing preferences, keyboard layouts "
 "and input sources"
-msgstr "變更鍵盤快捷鍵，並設定您的輸入偏好設定、鍵盤配置、輸入來源等"
+msgstr "更改鍵盤快捷鍵，並設定您的輸入偏好設定、鍵盤配置、輸入來源等"
 
-#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
 msgid ""
 "Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
-"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;捷徑"
-"鍵;快捷鍵;工作區;視窗;重新調整大小;縮放;拉遠;拉近;遠近;輸入;來源;輸入法;鎖定;"
-"上鎖;音量;"
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;快捷"
+"鍵;快捷鍵;工作區;視窗;重新調整大小;縮放;拉遠;拉近;遠近;對比;反差;輸入;來源;輸"
+"入法;鎖定;上鎖;音量;"
 
-#: panels/location/cc-location-panel.ui:20
+#: panels/location/cc-location-panel.ui:23
 msgid "Location Services Turned Off"
 msgstr "定位服務已關閉"
 
-#: panels/location/cc-location-panel.ui:21
+#: panels/location/cc-location-panel.ui:24
 msgid "No applications can obtain location information."
-msgstr "沒有應用程式可以取得定位資訊。"
+msgstr "沒有應用程式能取得位置資訊。"
 
-#: panels/location/cc-location-panel.ui:35
+#: panels/location/cc-location-panel.ui:38
 msgid ""
 "Location services allow applications to know your location. Using Wi-Fi and "
 "mobile broadband increases accuracy.\n"
@@ -2321,186 +1641,34 @@ msgid ""
 "\n"
 "Allow the applications below to determine your location."
 msgstr ""
-"定位服務允許應用程式知道您的地理位置。使用 Wi-Fi 和寬頻網路能提高準確度。\n"
+"定位服務可允許應用程式知道您的位置。使用 Wi-Fi 和行動寬頻能提高定位準確度。\n"
 "\n"
 "使用 Mozilla 定位服務：<a href='https://location.services.mozilla.com/"
 "privacy'>隱私權政策</a>\n"
 "\n"
-"允許下列應用程式判定您的地理位置。"
+"允許下列應用程式偵測您的位置。"
 
-#: panels/location/cc-location-panel.ui:53
+#: panels/location/cc-location-panel.ui:56
 msgid "No Applications Have Asked for Location Access"
-msgstr "沒有應用程式請求定位存取權"
+msgstr "沒有應用程式請求取用位置資訊"
 
 #: panels/location/gnome-location-panel.desktop.in.in:4
 msgid "Protect your location information"
-msgstr "保護您的定位資訊"
+msgstr "保護您的位置資訊"
 
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:62
-msgctxt "lock_screen"
-msgid "Screen Turns Off"
-msgstr "螢幕關閉"
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;定位;隱私權;衛星定位;位置;地理;"
 
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:65
-msgctxt "lock_screen"
-msgid "30 seconds"
-msgstr "30 秒"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:68
-msgctxt "lock_screen"
-msgid "1 minute"
-msgstr "1 分鐘"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:71
-msgctxt "lock_screen"
-msgid "2 minutes"
-msgstr "2 分鐘"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:74
-msgctxt "lock_screen"
-msgid "3 minutes"
-msgstr "3 分鐘"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:77
-msgctxt "lock_screen"
-msgid "5 minutes"
-msgstr "5 分鐘"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:80
-msgctxt "lock_screen"
-msgid "30 minutes"
-msgstr "30 分鐘"
-
-#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:83
-msgctxt "lock_screen"
-msgid "1 hour"
-msgstr "1 小時"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:126
-msgctxt "blank_screen"
-msgid "1 minute"
-msgstr "1 分鐘"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:129
-msgctxt "blank_screen"
-msgid "2 minutes"
-msgstr "2 分鐘"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:132
-msgctxt "blank_screen"
-msgid "3 minutes"
-msgstr "3 分鐘"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:135
-msgctxt "blank_screen"
-msgid "4 minutes"
-msgstr "4 分鐘"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:138
-msgctxt "blank_screen"
-msgid "5 minutes"
-msgstr "5 分鐘"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:141
-msgctxt "blank_screen"
-msgid "8 minutes"
-msgstr "8 分鐘"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:144
-msgctxt "blank_screen"
-msgid "10 minutes"
-msgstr "10 分鐘"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:147
-msgctxt "blank_screen"
-msgid "12 minutes"
-msgstr "12 分鐘"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:150
-msgctxt "blank_screen"
-msgid "15 minutes"
-msgstr "15 分鐘"
-
-#. Translators: Option for "Blank screen" in "Screen Lock" panel
-#: panels/lock/cc-lock-panel.c:153
-msgctxt "blank_screen"
-msgid "Never"
-msgstr "永不"
-
-#: panels/lock/cc-lock-panel.ui:8
-msgid ""
-"Automatically locking the screen prevents others from accessing the computer "
-"while you're away."
-msgstr "自動鎖定螢幕能防止其他人在您離開時取用您的電腦。"
-
-#: panels/lock/cc-lock-panel.ui:13
-msgid "Blank Screen Delay"
-msgstr "螢幕轉黑延遲"
-
-#: panels/lock/cc-lock-panel.ui:14
-msgid "Period of inactivity after which the screen will go blank."
-msgstr "不活躍多久後螢幕轉黑。"
-
-#: panels/lock/cc-lock-panel.ui:32
-msgid "Automatic Screen _Lock"
-msgstr "自動鎖定螢幕(_L)"
-
-#: panels/lock/cc-lock-panel.ui:46
-msgid "Automatic _Screen Lock Delay"
-msgstr "自動螢幕鎖定延遲(_S)"
-
-#: panels/lock/cc-lock-panel.ui:47
-msgid "Period after the screen blanks when the screen is automatically locked."
-msgstr "螢幕轉黑後，要多久才會自動鎖定螢幕。"
-
-#: panels/lock/cc-lock-panel.ui:65
-msgid "Show _Notifications on Lock Screen"
-msgstr "在鎖定螢幕顯示通知(_N)"
-
-#: panels/lock/cc-lock-panel.ui:80
-msgid "Forbid new _USB devices"
-msgstr "禁止新的 _USB 裝置"
-
-#: panels/lock/cc-lock-panel.ui:81
-msgid ""
-"Prevent new USB devices from interacting with the system when the screen is "
-"locked."
-msgstr "當螢幕鎖定時，防止新的 USB 裝置與系統互動。"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:3
-msgid "Screen Lock"
-msgstr "螢幕鎖定"
-
-#: panels/lock/gnome-lock-panel.desktop.in.in:4
-msgid "Lock your screen"
-msgstr "鎖定您的螢幕"
-
-#: panels/microphone/cc-microphone-panel.ui:20
+#: panels/microphone/cc-microphone-panel.ui:23
 msgid "Microphone Turned Off"
 msgstr "麥克風已關閉"
 
-#: panels/microphone/cc-microphone-panel.ui:21
+#: panels/microphone/cc-microphone-panel.ui:24
 msgid "No applications can record sound."
-msgstr "沒有能錄音的應用程式。"
+msgstr "沒有能錄製聲音的應用程式。"
 
-#: panels/microphone/cc-microphone-panel.ui:34
+#: panels/microphone/cc-microphone-panel.ui:37
 msgid ""
 "Use of the microphone allows applications to record and listen to audio. "
 "Disabling the microphone may cause some applications to not function "
@@ -2508,18 +1676,22 @@ msgid ""
 "\n"
 "Allow the applications below to use your microphone."
 msgstr ""
-"使用麥克風可允許應用程式錄音或聆聽聲音。停用麥克風可能導致部份應用程式無法正"
-"常運作。\n"
+"麥克風的使用可允許應用程式錄製或聆聽聲音。停用麥克風可能導致部分應用程式無法"
+"正常運作。\n"
 "\n"
 "允許下列應用程式使用您的麥克風。"
 
-#: panels/microphone/cc-microphone-panel.ui:51
+#: panels/microphone/cc-microphone-panel.ui:54
 msgid "No Applications Have Asked for Microphone Access"
-msgstr "沒有應用程式請求麥克風存取權"
+msgstr "沒有應用程式請求取用麥克風"
 
 #: panels/microphone/gnome-microphone-panel.desktop.in.in:4
 msgid "Protect your conversations"
 msgstr "保護您的對話"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "microphone;recording;application;privacy;麥克風;錄音;應用程式;隱私權;"
 
 #: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
 msgid "Test Your _Settings"
@@ -2532,89 +1704,154 @@ msgstr "一般"
 
 #: panels/mouse/cc-mouse-panel.ui:26
 msgid "Primary Button"
-msgstr "主要按鈕"
+msgstr "主要按鍵"
 
 #: panels/mouse/cc-mouse-panel.ui:27
 msgid "Sets the order of physical buttons on mice and touchpads."
-msgstr "設定滑鼠與觸控板上實體按鈕的順序。"
+msgstr "設定滑鼠與觸控板上實體按鍵所對應的命令。"
 
-#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:13
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
 msgid "Left"
 msgstr "左"
 
-#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:15
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
 msgid "Right"
 msgstr "右"
 
-#: panels/mouse/cc-mouse-panel.ui:62
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "搜尋位置"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
 msgid "Mouse"
 msgstr "滑鼠"
 
-#: panels/mouse/cc-mouse-panel.ui:65
+#: panels/mouse/cc-mouse-panel.ui:90
 msgid "Mouse Speed"
-msgstr "鼠標速度"
+msgstr "滑鼠速度"
 
-#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
-#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
-#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:108
-msgid "Natural Scrolling"
-msgstr "自然捲動"
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+#, fuzzy
+msgid "Scroll Direction"
+msgstr "向下捲動"
 
-#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:109
-msgid "Scrolling moves the content, not the view."
-msgstr "捲動會移動內容，而非檢視畫面。"
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:95 panels/mouse/cc-mouse-panel.ui:98
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+#, fuzzy
+msgid "Scrolling moves the view."
+msgstr "捲動的方向為內容移動方向，而非畫面移動的方向。"
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+#, fuzzy
+msgid "Scrolling moves the content."
+msgstr "捲動的方向為內容移動方向，而非畫面移動的方向。"
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+msgid "Mouse Acceleration"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+#, fuzzy
+msgid "Adaptive"
+msgstr "使用中"
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
 msgid "Touchpad"
 msgstr "觸控板"
 
-#: panels/mouse/cc-mouse-panel.ui:119
+#: panels/mouse/cc-mouse-panel.ui:269
 msgid "Touchpad Speed"
 msgstr "觸控板速度"
 
-#: panels/mouse/cc-mouse-panel.ui:136
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
 msgid "Tap to Click"
-msgstr "輕觸表示點擊"
+msgstr "輕觸以點擊"
 
-#: panels/mouse/cc-mouse-panel.ui:147
-msgid "Two-finger Scrolling"
-msgstr "兩指捲動"
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
 
-#: panels/mouse/cc-mouse-panel.ui:159
-msgid "Edge Scrolling"
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr "輕觸就能進行點擊操作"
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+#, fuzzy
+msgid "Disable While Typing"
+msgstr "打字時停用(_T)"
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "觸控板 (相對位置)"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+#, fuzzy
+msgid "Scrolling"
 msgstr "邊緣捲動"
 
-#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+#: panels/mouse/cc-mouse-panel.ui:491
+#, fuzzy
+msgid "Scroll Method"
+msgstr "向下捲動"
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+#, fuzzy
+msgid "Two-Finger"
+msgstr "雙面"
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
 msgid "Try clicking, double clicking, scrolling"
-msgstr "試著單擊、雙擊、捲動"
-
-#: panels/mouse/cc-mouse-test.c:136
-msgid "Five clicks, GEGL time!"
-msgstr "五次點擊，GEGL 時間！"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Double click, primary button"
-msgstr "雙擊，主要按鈕"
-
-#: panels/mouse/cc-mouse-test.c:141
-msgid "Single click, primary button"
-msgstr "單擊，主要按鈕"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Double click, middle button"
-msgstr "雙擊，中央按鈕"
-
-#: panels/mouse/cc-mouse-test.c:144
-msgid "Single click, middle button"
-msgstr "單擊，中央按鈕"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Double click, secondary button"
-msgstr "雙擊，次要按鈕"
-
-#: panels/mouse/cc-mouse-test.c:147
-msgid "Single click, secondary button"
-msgstr "單擊，次要按鈕"
+msgstr "試著按一下、按兩下、捲動"
 
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:3
 msgid "Mouse & Touchpad"
@@ -2623,14 +1860,13 @@ msgstr "滑鼠與觸控板"
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:4
 msgid ""
 "Change your mouse or touchpad sensitivity and select right or left-handed"
-msgstr "改變您的滑鼠或控制板靈敏度並選擇慣用右手或左手"
+msgstr "更改您的滑鼠或觸控板靈敏度，並選擇慣用右手或慣用左手"
 
-#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/mouse/gnome-mouse-panel.desktop.in.in:19
 msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
 msgstr ""
 "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;觸控板;指標;點擊;輕"
-"觸;雙擊;按鈕;軌跡球;捲動;"
+"觸;雙擊;按鈕;軌跡球;捲動;慣用手;滑鼠;速度;按鍵;"
 
 #: panels/multitasking/cc-multitasking-panel.ui:15
 msgid "_Hot Corner"
@@ -2638,40 +1874,40 @@ msgstr "熱角(_H)"
 
 #: panels/multitasking/cc-multitasking-panel.ui:16
 msgid "Touch the top-left corner to open the Activities Overview."
-msgstr "觸碰左上角可以開啟「活動概覽」。"
+msgstr "觸碰左上角可以開啟「概覽」。"
 
 #: panels/multitasking/cc-multitasking-panel.ui:42
 msgid "_Active Screen Edges"
-msgstr "啟動螢幕邊緣(_A)"
+msgstr "積極邊框(_A)"
 
 #: panels/multitasking/cc-multitasking-panel.ui:43
 msgid ""
 "Drag windows against the top, left, and right screen edges to resize them."
-msgstr "拖曳視窗到螢幕上緣、左緣、右緣可以重新調整視窗大小。"
+msgstr "將視窗拖動至螢幕上緣、左緣、右緣來調整視窗大小。"
 
 #: panels/multitasking/cc-multitasking-panel.ui:70
 msgid "Workspaces"
-msgstr "工作空間"
+msgstr "工作區"
 
 #: panels/multitasking/cc-multitasking-panel.ui:76
 msgid "_Dynamic workspaces"
-msgstr "動態工作空間(_D)"
+msgstr "動態工作區(_D)"
 
 #: panels/multitasking/cc-multitasking-panel.ui:77
 msgid "Automatically removes empty workspaces."
-msgstr "自動移除空的工作空間。"
+msgstr "自動移除空的工作區。"
 
 #: panels/multitasking/cc-multitasking-panel.ui:91
 msgid "_Fixed number of workspaces"
-msgstr "固定數目工作空間(_F)"
+msgstr "固定數目工作區(_F)"
 
 #: panels/multitasking/cc-multitasking-panel.ui:92
 msgid "Specify a number of permanent workspaces."
-msgstr "指定恆定數目的工作空間。"
+msgstr "指定常駐的工作區數目。"
 
 #: panels/multitasking/cc-multitasking-panel.ui:108
 msgid "_Number of Workspaces"
-msgstr "工作空間數目(_N)"
+msgstr "工作區數目(_N)"
 
 #: panels/multitasking/cc-multitasking-panel.ui:124
 msgid "Multi-Monitor"
@@ -2679,11 +1915,11 @@ msgstr "多重顯示器"
 
 #: panels/multitasking/cc-multitasking-panel.ui:130
 msgid "Workspaces on _primary display only"
-msgstr "工作空間只在主要顯示器上(_P)"
+msgstr "只在主要顯示器使用工作區(_P)"
 
 #: panels/multitasking/cc-multitasking-panel.ui:156
 msgid "Workspaces on all d_isplays"
-msgstr "工作空間在所有的顯示器上(_I)"
+msgstr "在所有顯示器上使用工作區(_I)"
 
 #: panels/multitasking/cc-multitasking-panel.ui:184
 msgid "Application Switching"
@@ -2691,11 +1927,11 @@ msgstr "應用程式切換"
 
 #: panels/multitasking/cc-multitasking-panel.ui:190
 msgid "Include applications from all _workspaces"
-msgstr "包含所有工作空間的應用程式(_W)"
+msgstr "包含所有工作區的應用程式(_W)"
 
 #: panels/multitasking/cc-multitasking-panel.ui:204
 msgid "Include applications from the _current workspace only"
-msgstr "僅包含目前工作空間的應用程式(_C)"
+msgstr "僅包含目前工作區的應用程式(_C)"
 
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
 msgid "Multitasking"
@@ -2705,94 +1941,49 @@ msgstr "多工作業"
 msgid "Manage preferences for productivity and multitasking"
 msgstr "管理生產力與多工作業的偏好設定"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
-msgid "Multitasking;Multitask;Productivity;Customize;Desktop;"
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
 msgstr ""
 "Multitasking;Multitask;Productivity;Customize;Desktop;多工作業;多工;生產力;自"
 "訂;桌面;"
-
-#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:300
-msgid "Oops, something has gone wrong. Please contact your software vendor."
-msgstr "噢，有問題發生。請聯繫您的軟體供應商。"
-
-#: panels/network/cc-network-panel.c:669
-msgid "NetworkManager needs to be running."
-msgstr "需要先執行 NetworkManager。"
 
 #: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
 msgid "Other Devices"
 msgstr "其他裝置"
 
-#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:53
-#: panels/network/connection-editor/net-connection-editor.c:580
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
 msgid "VPN"
 msgstr "VPN"
 
-#: panels/network/cc-network-panel.ui:70
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "加入新連線"
+
+#: panels/network/cc-network-panel.ui:62
 msgid "Not set up"
-msgstr "尚未設置"
+msgstr "尚未設定"
 
-#. TRANSLATORS: This happens when the connection name does not contain the SSID.
-#: panels/network/cc-wifi-connection-row.c:207
-#, c-format
-msgctxt "Wi-Fi Connection"
-msgid "%s (SSID: %s)"
-msgstr "%s (SSID: %s)"
-
-#: panels/network/cc-wifi-connection-row.c:263
-msgid "Insecure network (WEP)"
-msgstr "不安全網路 (WEP)"
-
-#: panels/network/cc-wifi-connection-row.c:267
-msgid "Secure network (WPA)"
-msgstr "安全網路 (WPA)"
-
-#: panels/network/cc-wifi-connection-row.c:271
-msgid "Secure network (WPA2)"
-msgstr "安全網路 (WPA2)"
-
-#: panels/network/cc-wifi-connection-row.c:275
-msgid "Secure network (WPA3)"
-msgstr "安全網路 (WPA3)"
-
-#: panels/network/cc-wifi-connection-row.c:279
-msgid "Secure network"
-msgstr "安全網路"
-
-#. TRANSLATORS: device status
-#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+#: panels/network/cc-wifi-connection-row.ui:41
 msgid "Connected"
 msgstr "已連線"
 
 #: panels/network/cc-wifi-connection-row.ui:62
-#: panels/network/net-device-ethernet.c:325
-#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:50
-#: panels/network/network-mobile.ui:321 panels/network/network-vpn.ui:21
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
 msgid "Options…"
 msgstr "選項…"
-
-#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
-#: panels/network/cc-wifi-hotspot-dialog.c:133
-#, c-format
-msgid ""
-"Turning on the hotspot will disconnect from %s, and it will not be possible "
-"to access the internet through Wi-Fi."
-msgstr "開啟熱點會斷開 %s 的連線，且會不能透過 Wi-Fi 連線網路。"
-
-#: panels/network/cc-wifi-hotspot-dialog.c:266
-msgid "Must have a minimum of 8 characters"
-msgstr "必須至少有 8 個字元"
 
 #: panels/network/cc-wifi-hotspot-dialog.c:271
 #, c-format
 msgid "Must have a maximum of %d character"
 msgid_plural "Must have a maximum of %d characters"
-msgstr[0] "必須至少有 %d 個字元"
+msgstr[0] "必須至少為 %d 個字元"
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:4
 msgid "Turn On Wi-Fi Hotspot?"
-msgstr "開啟 Wi-Fi 熱點？"
+msgstr "要開啟 Wi-Fi 熱點嗎？"
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:28
 msgid ""
@@ -2800,372 +1991,118 @@ msgid ""
 "Wi-Fi network that they can connect to. To do this, you must have an "
 "internet connection through a source other than Wi-Fi."
 msgstr ""
-"Wi-Fi 熱點透過建立其他人能連線的 Wi-Fi 網路，讓其他人能分享您的網路連線。要這"
-"麼做，您必須要有 Wi-Fi 之外的網路連線來源。"
+"Wi-Fi 熱點透過建立能讓其他人連接的 Wi-Fi 網路，與其他人共用您的網路連線。您需"
+"要有 Wi-Fi 之外的網路連線來源。"
 
 #: panels/network/cc-wifi-hotspot-dialog.ui:51
 msgid "Network Name"
 msgstr "網路名稱"
 
 #. Translators: This is a password needed for printing.
-#: panels/network/cc-wifi-hotspot-dialog.ui:74
-#: panels/printers/new-printer-dialog.ui:331
-#: panels/printers/pp-jobs-dialog.ui:52 panels/sharing/cc-sharing-panel.ui:376
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
 #: panels/user-accounts/cc-add-user-dialog.ui:145
 #: panels/user-accounts/cc-add-user-dialog.ui:181
-#: panels/user-accounts/cc-add-user-dialog.ui:362
-#: panels/wwan/cc-wwan-apn-dialog.ui:172
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
 msgid "Password"
 msgstr "密碼"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:86
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
 msgid "Generate Random Password"
 msgstr "產生隨機密碼"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:87
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
 msgid "Autogenerate Password"
 msgstr "自動產生密碼"
 
-#: panels/network/cc-wifi-hotspot-dialog.ui:129
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
 msgid "_Turn On"
 msgstr "開啟(_T)"
 
-#: panels/network/cc-wifi-panel.c:544
-#: panels/network/gnome-wifi-panel.desktop.in.in:3
-#: panels/network/network-wifi.ui:66
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: panels/network/cc-wifi-panel.c:879
-msgid "Stop hotspot and disconnect any users?"
-msgstr "停止熱點並中斷任何使用者的連線？"
-
-#: panels/network/cc-wifi-panel.c:882
-msgid "_Stop Hotspot"
-msgstr "停止熱點(_S)"
-
-#: panels/network/cc-wifi-panel.ui:72
+#: panels/network/cc-wifi-panel.ui:75
 msgid "Airplane Mode"
 msgstr "飛安模式"
 
-#: panels/network/cc-wifi-panel.ui:73
+#: panels/network/cc-wifi-panel.ui:76
 msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
 msgstr "停用 Wi-Fi、藍牙與行動寬頻"
 
-#: panels/network/cc-wifi-panel.ui:110
+#: panels/network/cc-wifi-panel.ui:113
 msgid "No Wi-Fi Adapter Found"
 msgstr "找不到 Wi-Fi 網卡"
 
-#: panels/network/cc-wifi-panel.ui:120
+#: panels/network/cc-wifi-panel.ui:123
 msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
 msgstr "請確認您的 Wi-Fi 網卡已插入並啟動"
 
-#: panels/network/cc-wifi-panel.ui:152 panels/wwan/cc-wwan-panel.ui:135
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
 msgid "Airplane Mode On"
 msgstr "開啟飛安模式"
 
-#: panels/network/cc-wifi-panel.ui:162
+#: panels/network/cc-wifi-panel.ui:165
 msgid "Turn off to use Wi-Fi"
 msgstr "關閉以使用 Wi-Fi"
 
-#: panels/network/cc-wifi-panel.ui:199
+#: panels/network/cc-wifi-panel.ui:202
 msgid "Wi-Fi Hotspot Active"
-msgstr "Wi-Fi 熱點作用中"
+msgstr "Wi-Fi 熱點已啟動"
 
-#: panels/network/cc-wifi-panel.ui:209
+#: panels/network/cc-wifi-panel.ui:212
 msgid "Mobile devices can scan the QR code to connect."
-msgstr "行動裝置可以掃描 QR 碼來連線。"
+msgstr "行動裝置可以掃描 QR 碼來連接。"
 
-#: panels/network/cc-wifi-panel.ui:217
+#: panels/network/cc-wifi-panel.ui:220
 msgid "Turn Off Hotspot…"
 msgstr "關閉熱點…"
 
-#: panels/network/cc-wifi-panel.ui:237
+#: panels/network/cc-wifi-panel.ui:240
 msgid "Visible Networks"
-msgstr "可見網路"
+msgstr "可見的網路"
 
-#: panels/network/cc-wifi-panel.ui:294
+#: panels/network/cc-wifi-panel.ui:297
 msgid "NetworkManager needs to be running"
-msgstr "需要先執行 NetworkManager"
+msgstr "需要執行 NetworkManager"
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "噢，發生問題。請聯繫您的軟體供應商。"
 
 #: panels/network/connection-editor/8021x-security-page.ui:16
 msgid "802.1x _Security"
-msgstr "802.1x 防護(_S)"
+msgstr "802.1x 安全加密(_S)"
 
-#: panels/network/connection-editor/ce-page-8021x-security.c:109
-#: panels/network/connection-editor/ce-page-security.c:419
-#: panels/network/connection-editor/details-page.ui:78
-msgid "Security"
-msgstr "安全性"
-
-#: panels/network/connection-editor/ce-page.c:234
-msgid "Preserve"
-msgstr "保留"
-
-#: panels/network/connection-editor/ce-page.c:235
-msgid "Permanent"
-msgstr "永久"
-
-#: panels/network/connection-editor/ce-page.c:236
-msgid "Random"
-msgstr "隨機"
-
-#: panels/network/connection-editor/ce-page.c:237
-msgid "Stable"
-msgstr "穩定"
-
-#: panels/network/connection-editor/ce-page.c:241
-msgid ""
-"The MAC address entered here will be used as hardware address for the "
-"network device this connection is activated on. This feature is known as MAC "
-"cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
-"這裡輸入的 MAC 位址會當作這個連線開在的網路裝置的硬體位址。這個功能又稱為 "
-"MAC 複製或欺騙。範例：00:11:22:33:44:55"
-
-#: panels/network/connection-editor/ce-page.c:399
-#, c-format
-msgid "Profile %d"
-msgstr "設定檔 %d"
-
-#. TRANSLATORS: this WEP WiFi security
-#: panels/network/connection-editor/ce-page-details.c:97
-#: panels/network/net-device-wifi.c:229
-msgid "WEP"
-msgstr "WEP"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:101
-#: panels/network/net-device-wifi.c:234
-msgid "WPA"
-msgstr "WPA"
-
-#. TRANSLATORS: this WPA3 WiFi security
-#: panels/network/connection-editor/ce-page-details.c:107
-msgid "WPA3"
-msgstr "WPA3"
-
-#. TRANSLATORS: this Enhanced Open WiFi security
-#: panels/network/connection-editor/ce-page-details.c:112
-#: panels/network/connection-editor/ce-page-security.c:274
-msgid "Enhanced Open"
-msgstr "Enhanced Open"
-
-#. TRANSLATORS: this WPA WiFi security
-#: panels/network/connection-editor/ce-page-details.c:119
-msgid "WPA2"
-msgstr "WPA2"
-
-#. TRANSLATORS: this Enterprise WiFi security
-#: panels/network/connection-editor/ce-page-details.c:125
-msgid "Enterprise"
-msgstr "企業版"
-
-#: panels/network/connection-editor/ce-page-details.c:130
-#: panels/network/net-device-wifi.c:219
-msgctxt "Wifi security"
-msgid "None"
-msgstr "沒有"
-
-#: panels/network/connection-editor/ce-page-details.c:151
-msgid "Never"
-msgstr "永不"
-
-#: panels/network/connection-editor/ce-page-details.c:166
+#: panels/network/connection-editor/ce-page-details.c:172
 #: panels/network/net-device-ethernet.c:105
 #, c-format
 msgid "%i day ago"
 msgid_plural "%i days ago"
 msgstr[0] "%i 天以前"
 
-#: panels/network/connection-editor/ce-page-details.c:293
-#, c-format
-msgid "%d Mb/s (%1.1f GHz)"
-msgstr "%d Mb/s (%1.1f GHz)"
-
-#. Translators: network device speed
-#: panels/network/connection-editor/ce-page-details.c:295
-#: panels/network/net-device-ethernet.c:217
-#, c-format
-msgid "%d Mb/s"
-msgstr "%d Mb/s"
-
-#: panels/network/connection-editor/ce-page-details.c:310
-msgid "2.4 GHz / 5 GHz"
-msgstr "2.4 GHz / 5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:312
-msgid "2.4 GHz"
-msgstr "2.4 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:314
-msgid "5 GHz"
-msgstr "5 GHz"
-
-#: panels/network/connection-editor/ce-page-details.c:334
-msgctxt "Signal strength"
-msgid "None"
-msgstr "沒有"
-
-#: panels/network/connection-editor/ce-page-details.c:336
-msgctxt "Signal strength"
-msgid "Weak"
-msgstr "太弱"
-
-#: panels/network/connection-editor/ce-page-details.c:338
-msgctxt "Signal strength"
-msgid "Ok"
-msgstr "確定"
-
-#: panels/network/connection-editor/ce-page-details.c:340
-msgctxt "Signal strength"
-msgid "Good"
-msgstr "良好"
-
-#: panels/network/connection-editor/ce-page-details.c:342
-msgctxt "Signal strength"
-msgid "Excellent"
-msgstr "很好"
-
-#: panels/network/connection-editor/ce-page-details.c:409
-#: panels/network/connection-editor/details-page.ui:94
-#: panels/network/net-device-ethernet.c:144
-#: panels/network/net-device-mobile.c:441
-msgid "IPv4 Address"
-msgstr "IPv4 位址"
-
-#: panels/network/connection-editor/ce-page-details.c:410
-#: panels/network/connection-editor/details-page.ui:110
-#: panels/network/net-device-ethernet.c:146
-#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:176
-msgid "IPv6 Address"
-msgstr "IPv6 位址"
-
-#: panels/network/connection-editor/ce-page-details.c:412
-#: panels/network/connection-editor/ce-page-details.c:413
-#: panels/network/net-device-ethernet.c:149
-#: panels/network/net-device-ethernet.c:151
-#: panels/network/net-device-mobile.c:445
-#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
-msgid "IP Address"
-msgstr "IP 位址"
-
-#: panels/network/connection-editor/ce-page-details.c:417
-#: panels/network/net-device-ethernet.c:166
-#: panels/network/net-device-mobile.c:450
-msgid "DNS4"
-msgstr "DNS4"
-
-#: panels/network/connection-editor/ce-page-details.c:418
-#: panels/network/net-device-ethernet.c:167
-#: panels/network/net-device-mobile.c:451
-msgid "DNS6"
-msgstr "DNS6"
-
-#: panels/network/connection-editor/ce-page-details.c:420
-#: panels/network/connection-editor/ce-page-details.c:421
-#: panels/network/connection-editor/details-page.ui:175
-#: panels/network/connection-editor/details-page.ui:192
-#: panels/network/connection-editor/ip4-page.ui:165
-#: panels/network/connection-editor/ip6-page.ui:175
-#: panels/network/net-device-ethernet.c:169
-#: panels/network/net-device-ethernet.c:171
-#: panels/network/net-device-mobile.c:453
-#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:203
-#: panels/network/network-mobile.ui:217
-msgid "DNS"
-msgstr "DNS"
-
-#: panels/network/connection-editor/ce-page-details.c:473
-msgid "Forget Connection"
-msgstr "忘記連線"
-
-#: panels/network/connection-editor/ce-page-details.c:475
-msgid "Remove Connection Profile"
-msgstr "移除連線個人檔案"
-
-#: panels/network/connection-editor/ce-page-details.c:477
-msgid "Remove VPN"
-msgstr "移除 VPN"
-
-#: panels/network/connection-editor/ce-page-details.c:495
-msgid "Details"
-msgstr "詳細資料"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:71
-msgid "automatic"
-msgstr "自動"
-
-#: panels/network/connection-editor/ce-page-ethernet.c:144
-#: panels/network/connection-editor/ce-page-vpn.c:148
-#: panels/network/connection-editor/ce-page-wifi.c:129
-msgid "Identity"
-msgstr "身分"
-
-#: panels/network/connection-editor/ce-page-ip4.c:245
-#: panels/network/connection-editor/ce-page-ip6.c:226
-msgid "Delete Address"
-msgstr "刪除位址"
-
-#: panels/network/connection-editor/ce-page-ip4.c:392
-#: panels/network/connection-editor/ce-page-ip6.c:361
-msgid "Delete Route"
-msgstr "刪除路由"
-
-#: panels/network/connection-editor/ce-page-ip4.c:742
-msgid "IPv4"
-msgstr "IPv4"
-
-#: panels/network/connection-editor/ce-page-ip6.c:712
-msgid "IPv6"
-msgstr "IPv6"
-
-#: panels/network/connection-editor/ce-page-security.c:263
-msgctxt "Wi-Fi/Ethernet security"
-msgid "None"
-msgstr "沒有"
-
-#: panels/network/connection-editor/ce-page-security.c:298
-msgid "WEP 40/128-bit Key (Hex or ASCII)"
-msgstr "WEP 40/128-位元金鑰 (Hex 或 ASCII)"
-
-#: panels/network/connection-editor/ce-page-security.c:308
-msgid "WEP 128-bit Passphrase"
-msgstr "WEP 128-位元密語"
-
-#: panels/network/connection-editor/ce-page-security.c:321
-#: panels/network/wireless-security/ws-dynamic-wep.ui:20
-#: panels/network/wireless-security/ws-wpa-eap.ui:25
-msgid "LEAP"
-msgstr "LEAP"
-
-#: panels/network/connection-editor/ce-page-security.c:334
-msgid "Dynamic WEP (802.1x)"
-msgstr "動態 WEP (802.1x)"
-
-#: panels/network/connection-editor/ce-page-security.c:348
-msgid "WPA & WPA2 Personal"
-msgstr "WPA 與 WPA2 個人版"
-
-#: panels/network/connection-editor/ce-page-security.c:362
-msgid "WPA & WPA2 Enterprise"
-msgstr "WPA 與 WPA2 企業版"
-
-#: panels/network/connection-editor/ce-page-security.c:376
-msgid "WPA3 Personal"
-msgstr "WPA3 個人版"
-
 #: panels/network/connection-editor/details-page.ui:14
 #: panels/wwan/cc-wwan-details-dialog.ui:73
 msgid "Signal Strength"
-msgstr "信號強度"
+msgstr "訊號強度"
 
 #: panels/network/connection-editor/details-page.ui:46
 msgid "Link speed"
 msgstr "連線速度"
 
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "安全性"
+
+#: panels/network/connection-editor/details-page.ui:94
+msgid "IPv4 Address"
+msgstr "IPv4 位址"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 位址"
+
 #: panels/network/connection-editor/details-page.ui:126
-#: panels/network/net-device-ethernet.c:154
 msgid "Hardware Address"
 msgstr "硬體位址"
 
@@ -3174,16 +2111,21 @@ msgid "Supported Frequencies"
 msgstr "支援的頻率"
 
 #: panels/network/connection-editor/details-page.ui:158
-#: panels/network/net-device-ethernet.c:158
-#: panels/network/net-device-ethernet.c:160
-#: panels/network/net-device-ethernet.c:162
-#: panels/network/network-mobile.ui:189
+#: panels/network/network-mobile.ui:191
 msgid "Default Route"
 msgstr "預設路由"
 
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
 #: panels/network/connection-editor/details-page.ui:208
 msgid "Last Used"
-msgstr "最後使用的"
+msgstr "最後使用時間"
 
 #: panels/network/connection-editor/details-page.ui:369
 msgid "Connect _automatically"
@@ -3193,14 +2135,14 @@ msgstr "自動連線(_A)"
 msgid "Make available to _other users"
 msgstr "允許其他使用者使用(_O)"
 
-#: panels/network/connection-editor/details-page.ui:412
+#: panels/network/connection-editor/details-page.ui:414
 msgid "_Metered connection: has data limits or can incur charges"
-msgstr "計量連線(_M)：有資料限制或可能會收取費用"
+msgstr "計量連線(_M)：有資料傳輸量上限，超過可能會產生額外費用"
 
-#: panels/network/connection-editor/details-page.ui:421
+#: panels/network/connection-editor/details-page.ui:423
 msgid ""
 "Software updates and other large downloads will not be started automatically."
-msgstr "軟體更新及其他大型下載不會自動開始。"
+msgstr "不會自動進行軟體更新及其他大型下載。"
 
 #: panels/network/connection-editor/ethernet-page.ui:21
 #: panels/network/connection-editor/vpn-page.ui:17
@@ -3240,7 +2182,7 @@ msgstr "只有本機連線"
 
 #: panels/network/connection-editor/ip4-page.ui:55
 #: panels/network/connection-editor/ip6-page.ui:65
-#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:98
+#: panels/network/network-proxy.ui:100
 msgid "Manual"
 msgstr "手動"
 
@@ -3260,33 +2202,32 @@ msgid "Addresses"
 msgstr "位址"
 
 #: panels/network/connection-editor/ip4-page.ui:112
-#: panels/network/connection-editor/ip4-page.ui:246
+#: panels/network/connection-editor/ip4-page.ui:250
 #: panels/network/connection-editor/ip6-page.ui:122
-#: panels/network/connection-editor/ip6-page.ui:255
-#: panels/printers/pp-details-dialog.ui:90
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
 msgid "Address"
-msgstr "地址"
+msgstr "位址"
 
 #: panels/network/connection-editor/ip4-page.ui:124
-#: panels/network/connection-editor/ip4-page.ui:258
+#: panels/network/connection-editor/ip4-page.ui:262
 msgid "Netmask"
-msgstr "網路遮罩"
+msgstr "子網路遮罩"
 
 #: panels/network/connection-editor/ip4-page.ui:136
-#: panels/network/connection-editor/ip4-page.ui:270
+#: panels/network/connection-editor/ip4-page.ui:274
 #: panels/network/connection-editor/ip6-page.ui:146
-#: panels/network/connection-editor/ip6-page.ui:279
+#: panels/network/connection-editor/ip6-page.ui:284
 msgid "Gateway"
-msgstr "通訊閘"
+msgstr "閘道"
 
 #: panels/network/connection-editor/ip4-page.ui:175
-#: panels/network/connection-editor/ip4-page.ui:223
+#: panels/network/connection-editor/ip4-page.ui:227
 #: panels/network/connection-editor/ip6-page.ui:36
 #: panels/network/connection-editor/ip6-page.ui:185
-#: panels/network/connection-editor/ip6-page.ui:232
-#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:91
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
 #: panels/network/wireless-security/eap-method-peap.ui:33
-#: panels/wacom/cc-wacom-page.c:621
 msgid "Automatic"
 msgstr "自動"
 
@@ -3295,31 +2236,36 @@ msgstr "自動"
 msgid "Automatic DNS"
 msgstr "自動 DNS"
 
-#: panels/network/connection-editor/ip4-page.ui:196
-#: panels/network/connection-editor/ip6-page.ui:205
-msgid "Separate IP addresses with commas"
-msgstr "請以逗號 (,) 分隔 IP 地址"
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS 伺服器位址"
 
-#: panels/network/connection-editor/ip4-page.ui:213
-#: panels/network/connection-editor/ip6-page.ui:222
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "請以逗號 (,) 分隔 IP 位址"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
 msgid "Routes"
 msgstr "路由"
 
-#: panels/network/connection-editor/ip4-page.ui:231
-#: panels/network/connection-editor/ip6-page.ui:240
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
 msgid "Automatic Routes"
 msgstr "自動路由"
 
 #. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
-#: panels/network/connection-editor/ip4-page.ui:281
-#: panels/network/connection-editor/ip6-page.ui:290
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
 msgid "Metric"
-msgstr "度量權值"
+msgstr "權值"
 
-#: panels/network/connection-editor/ip4-page.ui:304
-#: panels/network/connection-editor/ip6-page.ui:313
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
 msgid "Use this connection _only for resources on its network"
-msgstr "只在使用這個連線的網路資源時才使用此連線(_U)"
+msgstr "只在使用該連線的網路資源時才使用此連線(_O)"
 
 #: panels/network/connection-editor/ip6-page.ui:21
 msgid "IPv_6 Method"
@@ -3330,86 +2276,17 @@ msgid "Automatic, DHCP only"
 msgstr "自動，僅使用 DHCP"
 
 #: panels/network/connection-editor/ip6-page.ui:134
-#: panels/network/connection-editor/ip6-page.ui:267
+#: panels/network/connection-editor/ip6-page.ui:272
 msgid "Prefix"
 msgstr "前綴"
-
-#: panels/network/connection-editor/net-connection-editor.c:277
-msgid "Unable to open connection editor"
-msgstr "無法開啟連線編輯器"
-
-#: panels/network/connection-editor/net-connection-editor.c:293
-msgid "New Profile"
-msgstr "新增設定檔"
-
-#: panels/network/connection-editor/net-connection-editor.c:715
-msgid "Import from file…"
-msgstr "從檔案匯入…"
-
-#: panels/network/connection-editor/net-connection-editor.c:741
-msgid "Add VPN"
-msgstr "加入 VPN"
 
 #: panels/network/connection-editor/security-page.ui:16
 msgid "S_ecurity"
 msgstr "安全性(_E)"
 
-#: panels/network/connection-editor/vpn-helpers.c:186
-msgid "Cannot import VPN connection"
-msgstr "無法匯入 VPN 網路連線"
-
-#: panels/network/connection-editor/vpn-helpers.c:188
-#, c-format
-msgid ""
-"The file “%s” could not be read or does not contain recognized VPN "
-"connection information\n"
-"\n"
-"Error: %s."
-msgstr ""
-"檔案「%s」無法讀取，或未包含可辨識的 VPN 連線資訊\n"
-"\n"
-"錯誤：%s。"
-
-#: panels/network/connection-editor/vpn-helpers.c:218
-msgid "Select file to import"
-msgstr "選擇要匯入的檔案"
-
-#: panels/network/connection-editor/vpn-helpers.c:271
-#, c-format
-msgid "A file named “%s” already exists."
-msgstr "名為「%s」的檔案已經存在。"
-
-#: panels/network/connection-editor/vpn-helpers.c:273
-msgid "_Replace"
-msgstr "取代(_R)"
-
-#: panels/network/connection-editor/vpn-helpers.c:275
-#, c-format
-msgid "Do you want to replace %s with the VPN connection you are saving?"
-msgstr "您是否要以準備儲存的 VPN 連線取代 %s？"
-
-#: panels/network/connection-editor/vpn-helpers.c:310
-msgid "Cannot export VPN connection"
-msgstr "無法匯出 VPN 連線"
-
-#: panels/network/connection-editor/vpn-helpers.c:312
-#, c-format
-msgid ""
-"The VPN connection “%s” could not be exported to %s.\n"
-"\n"
-"Error: %s."
-msgstr ""
-"VPN 連線「%s」無法匯出至 %s。\n"
-"\n"
-"錯誤：%s。"
-
-#: panels/network/connection-editor/vpn-helpers.c:338
-msgid "Export VPN connection"
-msgstr "匯出 VPN 連線"
-
 #: panels/network/connection-editor/vpn-page.ui:34
 msgid "(Error: unable to load VPN connection editor)"
-msgstr "(錯誤：無法載入 VPN 連線編輯器)"
+msgstr "（錯誤：無法載入 VPN 連線編輯器）"
 
 #: panels/network/connection-editor/wifi-page.ui:16
 msgid "_SSID"
@@ -3419,103 +2296,49 @@ msgstr "_SSID"
 msgid "_BSSID"
 msgstr "_BSSID"
 
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "網路"
+
 #: panels/network/gnome-network-panel.desktop.in.in:4
 msgid "Control how you connect to the Internet"
 msgstr "控制您如何連線至網際網絡"
 
-#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:19
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
 msgstr ""
 "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;網路;區域網路;代理"
-"伺服器;寬頻;數據機;藍牙;區網;代理;藍芽;"
+"伺服器;寬頻;數據機;藍牙;區網;代理;藍牙;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
 msgstr "控制您如何連線至 Wi-Fi 網絡"
 
-#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:19
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
 msgstr ""
 "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;網路;無線網路;區域網"
 "路;寬頻;熱點;區網;"
 
-#: panels/network/net-device-ethernet.c:93
-msgid "never"
-msgstr "永不"
-
-#: panels/network/net-device-ethernet.c:101
-msgid "today"
-msgstr "今日"
-
-#: panels/network/net-device-ethernet.c:103
-msgid "yesterday"
-msgstr "昨日"
-
-#: panels/network/net-device-ethernet.c:177
-msgid "Last used"
-msgstr "最後使用的"
-
-#. Translators: This is used as the title of the connection
-#. * details window for ethernet, if there is only a single
-#. * profile. It is also used to display ethernet in the
-#. * device list.
-#.
-#: panels/network/net-device-ethernet.c:264
 #: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
 msgid "Wired"
-msgstr "有線"
-
-#: panels/network/net-device-mobile.c:208
-msgid "Add new connection"
-msgstr "加入新連線"
-
-#: panels/network/net-device-wifi.c:857
-msgid ""
-"Network details for the selected networks, including passwords and any "
-"custom configuration will be lost."
-msgstr "選取網路的詳細資料包含密碼及任何自訂的設定都會消失。"
-
-#: panels/network/net-device-wifi.c:861
-msgid "_Forget"
-msgstr "遺忘(_F)"
-
-#: panels/network/net-device-wifi.c:1041
-msgid "Known Wi-Fi Networks"
-msgstr "已知 Wi-Fi 網路"
-
-#. translators: This is the label for the "Forget wireless network" functionality
-#: panels/network/net-device-wifi.c:1073
-msgctxt "Wi-Fi Network"
-msgid "_Forget"
-msgstr "遺忘(_F)"
-
-#: panels/network/net-device-wifi.c:1216
-msgid "System policy prohibits use as a Hotspot"
-msgstr "系統原則禁止做為熱點"
-
-#: panels/network/net-device-wifi.c:1219
-msgid "Wireless device does not support Hotspot mode"
-msgstr "無線裝置不支援熱點模式"
-
-#. TRANSLATORS: this is when the use leaves the PAC textbox blank
-#: panels/network/net-proxy.c:112
-msgid ""
-"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
-msgstr "當沒有提供設定 URL 時會使用網頁代理伺服器自動發現。"
-
-#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
-#. * network, then anyone else on that network can tell your
-#. * machine that it should proxy all of your web traffic
-#. * through them.
-#: panels/network/net-proxy.c:120
-msgid "This is not recommended for untrusted public networks."
-msgstr "這不建議用於不信任的公用網路。"
+msgstr "有線網路"
 
 #: panels/network/network-bluetooth.ui:11
 msgid "Turn device off"
 msgstr "關閉裝置"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "使用中"
 
 #: panels/network/network-mobile.ui:27
 #: panels/wwan/cc-wwan-details-dialog.ui:237
@@ -3526,49 +2349,53 @@ msgstr "IMEI"
 msgid "Provider"
 msgstr "供應商"
 
-#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:80
+#: panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP 位址"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
 msgid "Network Proxy"
 msgstr "網路代理伺服器"
 
-#: panels/network/network-proxy.ui:139
+#: panels/network/network-proxy.ui:141
 msgid "_HTTP Proxy"
 msgstr "_HTTP 代理伺服器"
 
-#: panels/network/network-proxy.ui:156
+#: panels/network/network-proxy.ui:158
 msgid "H_TTPS Proxy"
 msgstr "H_TTPS 代理伺服器"
 
-#: panels/network/network-proxy.ui:173
+#: panels/network/network-proxy.ui:175
 msgid "_FTP Proxy"
 msgstr "_FTP 代理伺服器"
 
-#: panels/network/network-proxy.ui:190
+#: panels/network/network-proxy.ui:192
 msgid "_Socks Host"
 msgstr "Socks 主機(_S)"
 
-#: panels/network/network-proxy.ui:207
+#: panels/network/network-proxy.ui:209
 msgid "_Ignore Hosts"
 msgstr "忽略主機(_I)"
 
-#: panels/network/network-proxy.ui:244
+#: panels/network/network-proxy.ui:246
 msgid "HTTP proxy port"
-msgstr "HTTP 代理伺服器連接埠"
+msgstr "HTTP 代理伺服器通訊埠"
 
-#: panels/network/network-proxy.ui:307
+#: panels/network/network-proxy.ui:309
 msgid "HTTPS proxy port"
-msgstr "HTTPS 代理伺服器連接埠"
+msgstr "HTTPS 代理伺服器通訊埠"
 
-#: panels/network/network-proxy.ui:322
+#: panels/network/network-proxy.ui:324
 msgid "FTP proxy port"
-msgstr "FTP 代理伺服器連接埠"
+msgstr "FTP 代理伺服器通訊埠"
 
-#: panels/network/network-proxy.ui:337
+#: panels/network/network-proxy.ui:339
 msgid "Socks proxy port"
 msgstr "Socks 代理伺服器通訊埠"
 
-#: panels/network/network-proxy.ui:357
+#: panels/network/network-proxy.ui:359
 msgid "_Configuration URL"
-msgstr "設定網址(_C)"
+msgstr "設定 URL 位址(_C)"
 
 #: panels/network/network-vpn.ui:11
 msgid "Turn VPN connection off"
@@ -3591,302 +2418,24 @@ msgstr "密碼"
 
 #: panels/network/network-wifi.ui:90
 msgid "Turn Wi-Fi off"
-msgstr "關閉 Wi-Fi"
+msgstr "關閉 Wi-Fi 網路"
 
-#: panels/network/network-wifi.ui:121
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "更多選項…"
+
+# (Freddy)這項操作會調用 libnma 組件，其翻譯內容需要修正。
+#: panels/network/network-wifi.ui:119
 msgid "_Connect to Hidden Network…"
-msgstr "連接到隱藏的網路(_C)…"
+msgstr "連接隱藏的網路(_C)…"
 
-#: panels/network/network-wifi.ui:128
+#: panels/network/network-wifi.ui:131
 msgid "_Turn On Wi-Fi Hotspot…"
 msgstr "開啟 Wi-Fi 熱點(_T)…"
 
-#: panels/network/network-wifi.ui:135
+#: panels/network/network-wifi.ui:143
 msgid "_Known Wi-Fi Networks"
-msgstr "已知 Wi-Fi 網路(_K)"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:37
-msgid "Status unknown"
-msgstr "狀態不明"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:41
-msgid "Unmanaged"
-msgstr "未管理"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:45
-msgid "Unavailable"
-msgstr "無法使用"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:55
-msgid "Connecting"
-msgstr "連線中"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:59
-msgid "Authentication required"
-msgstr "需要核對"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:67
-msgid "Disconnecting"
-msgstr "斷線"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:71
-msgid "Connection failed"
-msgstr "連線失敗"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:75
-msgid "Status unknown (missing)"
-msgstr "狀態不詳（缺乏）"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:96
-msgid "Configuration failed"
-msgstr "設定失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:100
-msgid "IP configuration failed"
-msgstr "IP 設定失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:104
-msgid "IP configuration expired"
-msgstr "IP 設定過期"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:108
-msgid "Secrets were required, but not provided"
-msgstr "需要機密，但沒有提供"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:112
-msgid "802.1x supplicant disconnected"
-msgstr "802.1x 請求已斷線"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:116
-msgid "802.1x supplicant configuration failed"
-msgstr "802.1x 請求設定失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:120
-msgid "802.1x supplicant failed"
-msgstr "802.1x 請求已失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:124
-msgid "802.1x supplicant took too long to authenticate"
-msgstr "802.1x 請求花費太長時間核對身份"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:128
-msgid "PPP service failed to start"
-msgstr "無法啟動 PPP 服務"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:132
-msgid "PPP service disconnected"
-msgstr "PPP 服務已斷線"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:136
-msgid "PPP failed"
-msgstr "PPP 失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:140
-msgid "DHCP client failed to start"
-msgstr "DHCP 客戶端啟動失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:144
-msgid "DHCP client error"
-msgstr "DHCP 客戶端錯誤"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:148
-msgid "DHCP client failed"
-msgstr "DHCP 客戶端失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:152
-msgid "Shared connection service failed to start"
-msgstr "分享的連線服務啟動失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:156
-msgid "Shared connection service failed"
-msgstr "分享的連線服務失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:160
-msgid "AutoIP service failed to start"
-msgstr "無法啟動 AutoIP 服務"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:164
-msgid "AutoIP service error"
-msgstr "AutoIP 服務錯誤"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:168
-msgid "AutoIP service failed"
-msgstr "AutoIP 服務失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:172
-msgid "Line busy"
-msgstr "線路忙碌"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:176
-msgid "No dial tone"
-msgstr "沒有撥號音"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:180
-msgid "No carrier could be established"
-msgstr "無法建立載體"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:184
-msgid "Dialing request timed out"
-msgstr "撥號要求逾時"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:188
-msgid "Dialing attempt failed"
-msgstr "嘗試撥號失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:192
-msgid "Modem initialization failed"
-msgstr "數據機初始化失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:196
-msgid "Failed to select the specified APN"
-msgstr "無法選擇指定的 APN"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:200
-msgid "Not searching for networks"
-msgstr "不要搜尋網路"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:204
-msgid "Network registration denied"
-msgstr "網路登記被禁止"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:208
-msgid "Network registration timed out"
-msgstr "網路登記逾時"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:212
-msgid "Failed to register with the requested network"
-msgstr "無法向要求的網路登記"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:216
-msgid "PIN check failed"
-msgstr "PIN 檢查失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:220
-msgid "Firmware for the device may be missing"
-msgstr "可能缺少裝置的韌體"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:224
-msgid "Connection disappeared"
-msgstr "連線已消失"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:228
-msgid "Existing connection was assumed"
-msgstr "優先使用現有的連線"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:232
-msgid "Modem not found"
-msgstr "找不到數據機"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:236
-msgid "Bluetooth connection failed"
-msgstr "藍牙連線失敗"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:240
-msgid "SIM Card not inserted"
-msgstr "SIM 卡尚未插入"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:244
-msgid "SIM Pin required"
-msgstr "需要 SIM PIN 碼"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:248
-msgid "SIM Puk required"
-msgstr "需要 SIM PUK 碼"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
-msgid "SIM wrong"
-msgstr "SIM 錯誤"
-
-#. TRANSLATORS: device status reason
-#: panels/network/panel-common.c:256
-msgid "Connection dependency failed"
-msgstr "連線相依性解析失敗"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:327
-msgid "Firmware missing"
-msgstr "缺少韌體"
-
-#. TRANSLATORS: device status
-#: panels/network/panel-common.c:331
-msgid "Cable unplugged"
-msgstr "纜線已拔除"
-
-#: panels/network/wireless-security/eap-method.c:92
-msgid "undefined error in 802.1X security (wpa-eap)"
-msgstr "802.1X 安全加密的未定義錯誤 (wpa-eap)"
-
-#: panels/network/wireless-security/eap-method.c:196
-msgid "no file selected"
-msgstr "未選取檔案"
-
-#: panels/network/wireless-security/eap-method.c:224
-msgid "unspecified error validating eap-method file"
-msgstr "驗證 eap-method 檔案時未指定的錯誤"
-
-#: panels/network/wireless-security/eap-method.c:389
-msgid "DER, PEM, or PKCS#12 private keys (*.der, *.pem, *.p12, *.key)"
-msgstr "DER, PEM, 或 PKCS#12 私密金鑰 (*.der, *.pem, *.p12, *.key)"
-
-#: panels/network/wireless-security/eap-method.c:392
-msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
-msgstr "DER 或 PEM 憑證 (*.der, *.pem, *.crt, *.cer)"
-
-#: panels/network/wireless-security/eap-method-fast.c:88
-msgid "missing EAP-FAST PAC file"
-msgstr "缺少 EAP-FAST PAC 檔案"
-
-#: panels/network/wireless-security/eap-method-fast.c:353
-msgid "PAC files (*.pac)"
-msgstr "PAC 檔案 (*.pac)"
+msgstr "已知的 Wi-Fi 網路(_K)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:13
 #: panels/network/wireless-security/eap-method-peap.ui:21
@@ -3906,7 +2455,7 @@ msgstr "匿名"
 
 #: panels/network/wireless-security/eap-method-fast.ui:32
 msgid "Authenticated"
-msgstr "已核對"
+msgstr "已認證"
 
 #: panels/network/wireless-security/eap-method-fast.ui:35
 msgid "Both"
@@ -3930,19 +2479,11 @@ msgstr "選擇一個 PAC 檔案"
 #: panels/network/wireless-security/eap-method-peap.ui:131
 #: panels/network/wireless-security/eap-method-ttls.ui:122
 msgid "_Inner authentication"
-msgstr "內部核對(_I)"
+msgstr "內部身分核對(_I)"
 
 #: panels/network/wireless-security/eap-method-fast.ui:126
 msgid "Allow automatic PAC pro_visioning"
-msgstr "允許自動供應 PAC (_V)"
-
-#: panels/network/wireless-security/eap-method-leap.c:65
-msgid "missing EAP-LEAP username"
-msgstr "缺少 EAP-LEAP 使用者名稱"
-
-#: panels/network/wireless-security/eap-method-leap.c:80
-msgid "missing EAP-LEAP password"
-msgstr "缺少 EAP-LEAP 密碼"
+msgstr "允許自動 PAC 規範(_V)"
 
 #: panels/network/wireless-security/eap-method-leap.ui:11
 #: panels/network/wireless-security/eap-method-simple.ui:11
@@ -3956,7 +2497,7 @@ msgstr "使用者名稱(_U)"
 #: panels/network/wireless-security/ws-sae.ui:10
 #: panels/network/wireless-security/ws-wpa-psk.ui:10
 #: panels/sharing/cc-sharing-panel.ui:152
-#: panels/user-accounts/cc-user-panel.ui:175
+#: panels/user-accounts/cc-user-panel.ui:182
 msgid "_Password"
 msgstr "密碼(_P)"
 
@@ -3968,15 +2509,6 @@ msgstr "密碼(_P)"
 #: panels/network/wireless-security/ws-wpa-psk.ui:53
 msgid "Sho_w password"
 msgstr "顯示密碼(_W)"
-
-#: panels/network/wireless-security/eap-method-peap.c:88
-#, c-format
-msgid "invalid EAP-PEAP CA certificate: %s"
-msgstr "無效的 EAP-PEAP CA 憑證：%s"
-
-#: panels/network/wireless-security/eap-method-peap.c:97
-msgid "invalid EAP-PEAP CA certificate: no certificate specified"
-msgstr "無效的 EAP-PEAP CA 憑證：沒有指定憑證"
 
 #: panels/network/wireless-security/eap-method-peap.ui:17
 #: panels/network/wireless-security/eap-method-ttls.ui:33
@@ -3996,10 +2528,9 @@ msgstr "版本 1"
 #: panels/network/wireless-security/eap-method-tls.ui:54
 #: panels/network/wireless-security/eap-method-ttls.ui:89
 msgid "C_A certificate"
-msgstr "憑證(_A)"
+msgstr "C_A 憑證"
 
 #: panels/network/wireless-security/eap-method-peap.ui:82
-#: panels/network/wireless-security/eap-method-tls.c:524
 #: panels/network/wireless-security/eap-method-tls.ui:44
 #: panels/network/wireless-security/eap-method-tls.ui:66
 msgid "Choose a Certificate Authority certificate"
@@ -4015,62 +2546,6 @@ msgstr "不需要 CA 憑證(_R)"
 msgid "PEAP _version"
 msgstr "PEAP 版本(_V)"
 
-#: panels/network/wireless-security/eap-method-simple.c:78
-msgid "missing EAP username"
-msgstr "缺少 EAP 使用者名稱"
-
-#: panels/network/wireless-security/eap-method-simple.c:91
-msgid "missing EAP password"
-msgstr "缺少 EAP 密碼"
-
-#: panels/network/wireless-security/eap-method-tls.c:93
-msgid "missing EAP-TLS identity"
-msgstr "缺少 EAP-TLS 身分"
-
-#: panels/network/wireless-security/eap-method-tls.c:103
-#, c-format
-msgid "invalid EAP-TLS CA certificate: %s"
-msgstr "無效的 EAP-TLS CA 憑證：%s"
-
-#: panels/network/wireless-security/eap-method-tls.c:113
-msgid "invalid EAP-TLS CA certificate: no certificate specified"
-msgstr "無效的 EAP-TLS CA 憑證：沒有指定憑證"
-
-#: panels/network/wireless-security/eap-method-tls.c:130
-#, c-format
-msgid "invalid EAP-TLS private-key: %s"
-msgstr "無效的 EAP-TLS 私鑰：%s"
-
-#: panels/network/wireless-security/eap-method-tls.c:140
-#, c-format
-msgid "invalid EAP-TLS user-certificate: %s"
-msgstr "無效的 EAP-TLS 使用者憑證：%s"
-
-#: panels/network/wireless-security/eap-method-tls.c:279
-msgid "Unencrypted private keys are insecure"
-msgstr "未加密的私密金鑰不安全"
-
-#: panels/network/wireless-security/eap-method-tls.c:282
-msgid ""
-"The selected private key does not appear to be protected by a password. This "
-"could allow your security credentials to be compromised. Please select a "
-"password-protected private key.\n"
-"\n"
-"(You can password-protect your private key with openssl)"
-msgstr ""
-"所選的私密金鑰似乎沒有受密碼保護。 這可能導致您的安全憑證受到威脅。請選擇受密"
-"碼保護的私密金鑰。\n"
-"\n"
-"（您可以使用 openssl 來加密您的私密金鑰）"
-
-#: panels/network/wireless-security/eap-method-tls.c:517
-msgid "Choose your personal certificate"
-msgstr "選擇您的個人憑證"
-
-#: panels/network/wireless-security/eap-method-tls.c:531
-msgid "Choose your private key"
-msgstr "選擇您的私密金鑰"
-
 #: panels/network/wireless-security/eap-method-tls.ui:11
 msgid "I_dentity"
 msgstr "識別(_D)"
@@ -4081,20 +2556,11 @@ msgstr "使用者憑證(_U)"
 
 #: panels/network/wireless-security/eap-method-tls.ui:87
 msgid "Private _key"
-msgstr "私鑰(_K)"
+msgstr "私密金鑰(_K)"
 
 #: panels/network/wireless-security/eap-method-tls.ui:108
 msgid "_Private key password"
 msgstr "私密金鑰密碼(_P)"
-
-#: panels/network/wireless-security/eap-method-ttls.c:99
-#, c-format
-msgid "invalid EAP-TTLS CA certificate: %s"
-msgstr "無效的 EAP-TTLS CA 憑證：%s"
-
-#: panels/network/wireless-security/eap-method-ttls.c:107
-msgid "invalid EAP-TTLS CA certificate: no certificate specified"
-msgstr "無效的 EAP-TTLS CA 憑證：沒有指定憑證"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:13
 msgid "PAP"
@@ -4106,7 +2572,7 @@ msgstr "MSCHAP"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:25
 msgid "MSCHAPv2 (no EAP)"
-msgstr "MSCHAPv2 (無 EAP)"
+msgstr "MSCHAPv2（無 EAP）"
 
 #: panels/network/wireless-security/eap-method-ttls.ui:29
 msgid "CHAP"
@@ -4117,14 +2583,15 @@ msgstr "CHAP"
 msgid "_Domain"
 msgstr "網域(_O)"
 
-#: panels/network/wireless-security/wireless-security.c:71
-msgid "Unknown error validating 802.1X security"
-msgstr "驗證 802.1X 安全加密的未知錯誤"
-
 #: panels/network/wireless-security/ws-dynamic-wep.ui:15
 #: panels/network/wireless-security/ws-wpa-eap.ui:20
 msgid "TLS"
 msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
 
 #: panels/network/wireless-security/ws-dynamic-wep.ui:25
 #: panels/network/wireless-security/ws-wpa-eap.ui:30
@@ -4150,60 +2617,12 @@ msgstr "保護式 EAP (PEAP)"
 #: panels/network/wireless-security/ws-wep-key.ui:87
 #: panels/network/wireless-security/ws-wpa-eap.ui:57
 msgid "Au_thentication"
-msgstr "核對(_T)"
-
-#: panels/network/wireless-security/ws-file-chooser-button.c:49
-msgid "Select a file"
-msgstr "選取檔案"
-
-#: panels/network/wireless-security/ws-leap.c:66
-msgid "missing leap-username"
-msgstr "缺少 leap 使用者名稱"
-
-#: panels/network/wireless-security/ws-leap.c:81
-msgid "missing leap-password"
-msgstr "缺少 leap 密碼"
-
-#: panels/network/wireless-security/ws-sae.c:77
-msgid "Wi-Fi password is missing."
-msgstr "缺少 Wi-Fi 密碼。"
+msgstr "認證協定(_T)"
 
 #: panels/network/wireless-security/ws-sae.ui:33
 #: panels/network/wireless-security/ws-wpa-psk.ui:33
 msgid "_Type"
 msgstr "類型(_T)"
-
-#: panels/network/wireless-security/ws-wep-key.c:114
-msgid "missing wep-key"
-msgstr "缺少 wep-key"
-
-#: panels/network/wireless-security/ws-wep-key.c:123
-#, c-format
-msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
-msgstr "無效的 wep-key：長度為 %zu 的金鑰只能包含十六進位數字"
-
-#: panels/network/wireless-security/ws-wep-key.c:131
-#, c-format
-msgid ""
-"invalid wep-key: key with a length of %zu must contain only ascii characters"
-msgstr "無效的 wep-key：長度為 %zu 的金鑰只能包含 ascii 字元"
-
-#: panels/network/wireless-security/ws-wep-key.c:137
-#, c-format
-msgid ""
-"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
-"(ascii) or 10/26 (hex)"
-msgstr ""
-"無效的 wep-key：錯誤的金鑰長度 %zu。金鑰長度必須為 5/13 (ascii) 或 10/26 (十"
-"六進位)"
-
-#: panels/network/wireless-security/ws-wep-key.c:144
-msgid "invalid wep-key: passphrase must be non-empty"
-msgstr "無效的 wep-key︰密語必須為非空"
-
-#: panels/network/wireless-security/ws-wep-key.c:146
-msgid "invalid wep-key: passphrase must be shorter than 64 characters"
-msgstr "無效的 wep-key︰密語必須少於 64 個字元"
 
 #: panels/network/wireless-security/ws-wep-key.ui:11
 msgid "1 (Default)"
@@ -4215,7 +2634,7 @@ msgstr "開放系統"
 
 #: panels/network/wireless-security/ws-wep-key.ui:34
 msgid "Shared Key"
-msgstr "共享金鑰"
+msgstr "共享的金鑰"
 
 #: panels/network/wireless-security/ws-wep-key.ui:44
 msgid "_Key"
@@ -4229,28 +2648,17 @@ msgstr "顯示金鑰(_W)"
 msgid "WEP inde_x"
 msgstr "WEP 索引(_X)"
 
-#: panels/network/wireless-security/ws-wpa-psk.c:77
-#, c-format
-msgid ""
-"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
-"digits"
-msgstr "無效的 wpa-psk：無效的長度 %zu。必須為 [8,63] 位元組或 64 十六進位數字"
-
-#: panels/network/wireless-security/ws-wpa-psk.c:86
-msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
-msgstr "無效的 wpa-psk：不能將 64 位元組金鑰轉譯為十六進位"
-
 #. This is the per application switch for message tray usage.
 #: panels/notifications/cc-app-notifications-dialog.ui:15
 msgctxt "notifications"
 msgid "_Notifications"
-msgstr "通知(_N)"
+msgstr "啟用/停用通知(_N)"
 
 #. This is the setting to configure sounds associated with notifications.
 #: panels/notifications/cc-app-notifications-dialog.ui:29
 msgctxt "notifications"
 msgid "Sound _Alerts"
-msgstr "音效警示(_A)"
+msgstr "響鈴通知(_A)"
 
 #: panels/notifications/cc-app-notifications-dialog.ui:42
 msgctxt "notifications"
@@ -4261,23 +2669,23 @@ msgstr "彈出式通知(_P)"
 msgid ""
 "Notifications will continue to appear in the notification list when popups "
 "are disabled."
-msgstr "當彈出視窗被停用時，通知將繼續出現在通知列表中。"
+msgstr "彈出式通知停用時，通知依然會顯示在通知列表中。"
 
 #. Popups here refers to message tray notifications in the middle of the screen.
 #: panels/notifications/cc-app-notifications-dialog.ui:56
 msgctxt "notifications"
 msgid "Show Message _Content in Popups"
-msgstr "在彈出視窗中顯示訊息內容(_C)"
+msgstr "在彈出的通知中顯示訊息內容(_C)"
 
 #: panels/notifications/cc-app-notifications-dialog.ui:69
 msgctxt "notifications"
 msgid "_Lock Screen Notifications"
-msgstr "鎖定畫面通知(_L)"
+msgstr "螢幕鎖定畫面通知(_L)"
 
 #: panels/notifications/cc-app-notifications-dialog.ui:82
 msgctxt "notifications"
 msgid "Show Message C_ontent on Lock Screen"
-msgstr "在鎖定畫面中顯示訊息內容(_O)"
+msgstr "在螢幕鎖定畫面中顯示訊息內容(_O)"
 
 #: panels/notifications/cc-notifications-panel.ui:10
 msgid "_Do Not Disturb"
@@ -4285,62 +2693,39 @@ msgstr "不要打擾(_D)"
 
 #: panels/notifications/cc-notifications-panel.ui:17
 msgid "_Lock Screen Notifications"
-msgstr "鎖定畫面通知(_L)"
+msgstr "螢幕鎖定時顯示通知(_L)"
 
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:4
 msgid "Control which notifications are displayed and what they show"
-msgstr "控制要顯示哪種通知及要顯示什麼"
+msgstr "控制要顯示哪些通知及要顯示什麼"
 
-#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/notifications/gnome-notifications-panel.desktop.in.in:20
 msgid "Notifications;Banner;Message;Tray;Popup;"
-msgstr "Notifications;Banner;Message;Tray;Popup;通知;橫幅;訊息;匣;彈出;"
-
-#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
-#. * or rishi).
-#.
-#: panels/online-accounts/cc-online-accounts-panel.c:277
-#, c-format
-msgid "%s removed"
-msgstr "已移除 %s"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:406
-msgctxt "Online Account"
-msgid "Other"
-msgstr "其他"
-
-#: panels/online-accounts/cc-online-accounts-panel.c:803
-msgid "Error removing account"
-msgstr "移除帳號時發生錯誤"
+msgstr ""
+"Notifications;Banner;Message;Tray;Popup;通知;橫幅;訊息;匣;彈出;鎖定畫面;不要"
+"打擾;"
 
 #. Translators: This is the button which allows undoing the removal of the printer.
 #: panels/online-accounts/cc-online-accounts-panel.ui:23
-#: panels/printers/printers.ui:51
+#: panels/printers/printers.ui:47
 msgid "Undo"
-msgstr "復原"
+msgstr "還原"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:55
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "關閉通知"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
 msgid "Connect to your data in the cloud"
-msgstr "連接您雲端上的資料"
+msgstr "連接您在雲端伺服器上的資料"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:66
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
 msgid "No internet connection — connect to set up new online accounts"
-msgstr "沒有網際網路連線 — 請連線以設定新的線上帳號"
+msgstr "沒有網際網路連線 — 請連接網路以設定新的線上帳號"
 
-#: panels/online-accounts/cc-online-accounts-panel.ui:93
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
 msgid "Add an account"
 msgstr "加入帳號"
-
-#. translators: This is the title of the "Show Account" dialog. The
-#. * %s is the name of the provider. e.g., 'Google'.
-#: panels/online-accounts/gnome-control-center-goa-helper.c:428
-#, c-format
-msgid "%s Account"
-msgstr "%s 帳號"
-
-#: panels/online-accounts/gnome-control-center-goa-helper.c:431
-msgid "Remove Account"
-msgstr "移除帳號"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
 msgid "Online Accounts"
@@ -4348,12 +2733,8 @@ msgstr "線上帳號"
 
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
 msgid "Connect to your online accounts and decide what to use them for"
-msgstr "連接到您的線上帳號並決定要用它們來做什麼"
+msgstr "連接您的線上帳號並設定線上帳號的用途"
 
-#. Translators: Search terms to find the Online Accounts panel.
-#. Do NOT translate or localize the semicolons!
-#. The list MUST also end with a semicolon!
-#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
 #: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
 msgid ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
@@ -4362,10 +2743,6 @@ msgstr ""
 "Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
 "Kerberos;IMAP;SMTP;Pocket;ReadItLater;谷歌;臉書;推特;雅虎奇摩;網頁;線上;聊天;"
 "行事曆;郵件;連絡人;"
-
-#: panels/power/cc-battery-row.c:80
-msgid "Unknown time"
-msgstr "不明的時間"
 
 #: panels/power/cc-battery-row.c:83
 #, c-format
@@ -4379,13 +2756,6 @@ msgid "%i hour"
 msgid_plural "%i hours"
 msgstr[0] "%i 小時"
 
-#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
-#. * Swap order with "%2$s %2$i %1$s %1$i if needed
-#: panels/power/cc-battery-row.c:98
-#, c-format
-msgid "%i %s %i %s"
-msgstr "%i %s %i %s"
-
 #: panels/power/cc-battery-row.c:99
 msgid "hour"
 msgid_plural "hours"
@@ -4395,186 +2765,6 @@ msgstr[0] "小時"
 msgid "minute"
 msgid_plural "minutes"
 msgstr[0] "分鐘"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:117
-#, c-format
-msgid "%s until fully charged"
-msgstr "%s後完全充飽"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:124
-#, c-format
-msgid "Caution: %s remaining"
-msgstr "注意：剩下 %s"
-
-#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
-#: panels/power/cc-battery-row.c:129
-#, c-format
-msgid "%s remaining"
-msgstr "剩下 %s"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
-msgid "Fully charged"
-msgstr "已完全充飽"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
-msgid "Not charging"
-msgstr "未充電"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
-msgid "Empty"
-msgstr "沒電"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:155
-msgid "Charging"
-msgstr "充電"
-
-#. TRANSLATORS: primary battery
-#: panels/power/cc-battery-row.c:160
-msgid "Discharging"
-msgstr "放電中"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:191
-msgid "Wireless mouse"
-msgstr "無線滑鼠"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:194
-msgid "Wireless keyboard"
-msgstr "無線鍵盤"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:197
-msgid "Uninterruptible power supply"
-msgstr "不斷電系統"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:200
-msgid "Personal digital assistant"
-msgstr "個人數位助理"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:203
-msgid "Cellphone"
-msgstr "手機"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:206
-msgid "Media player"
-msgstr "媒體播放器"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:209
-msgid "Tablet"
-msgstr "繪圖板"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:212
-msgid "Computer"
-msgstr "電腦"
-
-#. TRANSLATORS: secondary battery
-#: panels/power/cc-battery-row.c:215
-msgid "Gaming input device"
-msgstr "遊戲輸入裝置"
-
-#. TRANSLATORS: secondary battery, misc
-#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
-#: panels/power/cc-power-panel.ui:58
-msgid "Battery"
-msgstr "電池"
-
-#: panels/power/cc-battery-row.c:266
-msgctxt "Battery name"
-msgid "Main"
-msgstr "主要"
-
-#: panels/power/cc-battery-row.c:268
-msgctxt "Battery name"
-msgid "Extra"
-msgstr "額外"
-
-#: panels/power/cc-power-panel.c:255
-msgid "Batteries"
-msgstr "電池"
-
-#: panels/power/cc-power-panel.c:511
-msgid "When _idle"
-msgstr "閒置時(_I)"
-
-#: panels/power/cc-power-panel.c:671
-msgid "Suspend"
-msgstr "暫停"
-
-#: panels/power/cc-power-panel.c:672
-msgid "Power Off"
-msgstr "關閉電源"
-
-#: panels/power/cc-power-panel.c:673
-msgid "Hibernate"
-msgstr "休眠"
-
-#: panels/power/cc-power-panel.c:674
-msgid "Nothing"
-msgstr "沒有"
-
-#: panels/power/cc-power-panel.c:730
-msgid "When on battery power"
-msgstr "使用電池電源時"
-
-#: panels/power/cc-power-panel.c:732
-msgid "When plugged in"
-msgstr "當插入電源線時"
-
-#: panels/power/cc-power-panel.c:853
-msgctxt "Idle time"
-msgid "Never"
-msgstr "永不"
-
-#: panels/power/cc-power-panel.c:937
-msgid "Automatic suspend"
-msgstr "自動暫停"
-
-#: panels/power/cc-power-panel.c:1030
-msgid ""
-"Performance mode temporarily disabled due to high operating temperature."
-msgstr "因為系統作業產生高溫，效能模式已暫時停用。"
-
-#: panels/power/cc-power-panel.c:1032
-msgid ""
-"Lap detected: performance mode temporarily unavailable. Move the device to a "
-"stable surface to restore."
-msgstr ""
-"偵測到大腿：效能模式已暫時無法使用。請將裝置移動到穩定的平面上來還原效能模"
-"式。"
-
-#: panels/power/cc-power-panel.c:1034
-msgid "Performance mode temporarily disabled."
-msgstr "效能模式已暫時停用。"
-
-#: panels/power/cc-power-panel.c:1076
-msgid ""
-"Low battery: power saver enabled. Previous mode will be restored when "
-"battery is sufficiently charged."
-msgstr "低電量：省電模式已啟用。當充電至足夠電量時會回到上個模式。"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1084
-#, c-format
-msgid "Power Saver mode activated by “%s”."
-msgstr "省電模式已由「%s」啟動。"
-
-#. translators: "%s" is an application name
-#: panels/power/cc-power-panel.c:1088
-#, c-format
-msgid "Performance mode activated by “%s”."
-msgstr "效能模式已由「%s」啟動。"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:12
@@ -4636,109 +2826,91 @@ msgctxt "automatic_suspend"
 msgid "2 hours"
 msgstr "2 小時"
 
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "電池"
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "裝置"
+
 #: panels/power/cc-power-panel.ui:93
 msgid "Power Mode"
 msgstr "電源模式"
 
 #: panels/power/cc-power-panel.ui:94
 msgid "Affects system performance and power usage."
-msgstr "會影響系統效能與電量使用。"
+msgstr "模式的選擇影響系統效能與耗電量。"
 
 #: panels/power/cc-power-panel.ui:123
 msgid "Power Saving Options"
-msgstr "電源節省選項"
+msgstr "節能選項"
 
 #: panels/power/cc-power-panel.ui:126
 msgid "Automatic Screen Brightness"
-msgstr "自動螢幕亮度"
+msgstr "自動調整螢幕亮度"
 
 #: panels/power/cc-power-panel.ui:127
 msgid "Screen brightness adjusts to the surrounding light."
 msgstr "根據周圍光線調整螢幕亮度。"
 
-#: panels/power/cc-power-panel.ui:138
+#: panels/power/cc-power-panel.ui:139
 msgid "Dim Screen"
 msgstr "調暗螢幕"
 
-#: panels/power/cc-power-panel.ui:139
+#: panels/power/cc-power-panel.ui:140
 msgid "Reduces the screen brightness when the computer is inactive."
-msgstr "電腦不活動時降低螢幕亮度。"
-
-#: panels/power/cc-power-panel.ui:150
-msgid "Screen _Blank"
-msgstr "螢幕轉黑(_B)"
+msgstr "電腦處於非活動狀態時降低螢幕亮度。"
 
 #: panels/power/cc-power-panel.ui:151
-msgid "Turns the screen off after a period of inactivity."
-msgstr "在一段時間不活動後關閉螢幕。"
+msgid "Screen _Blank"
+msgstr "轉黑螢幕(_B)"
 
-#: panels/power/cc-power-panel.ui:159
-msgid "Automatic Power Saver"
-msgstr "自動省電"
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "一段時間不活動後關閉螢幕。"
 
 #: panels/power/cc-power-panel.ui:160
-msgid "Enables power saver mode when battery is low."
-msgstr "電量低落時啟用自動省電模式。"
+msgid "Automatic Power Saver"
+msgstr "自動進入省電模式"
 
-#: panels/power/cc-power-panel.ui:173
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "低電量時啟用省電模式。"
+
+#: panels/power/cc-power-panel.ui:174
 msgid "_Automatic Suspend"
 msgstr "自動暫停(_A)"
 
-#: panels/power/cc-power-panel.ui:174
+#: panels/power/cc-power-panel.ui:175
 msgid "Pauses the computer after a period of inactivity."
-msgstr "在一段時間不活動後暫停電腦。"
+msgstr "一段時間不活動後將電腦暫停。"
 
-#: panels/power/cc-power-panel.ui:199
+#: panels/power/cc-power-panel.ui:200
 msgid "Po_wer Button Behavior"
 msgstr "電源鍵行為(_W)"
 
-#: panels/power/cc-power-panel.ui:207
+#: panels/power/cc-power-panel.ui:208
 msgid "Show Battery _Percentage"
-msgstr "顯示電池百分比(_P)"
+msgstr "顯示電量百分比(_P)"
 
-#: panels/power/cc-power-panel.ui:243
+#: panels/power/cc-power-panel.ui:244
 msgid "Automatic Suspend"
 msgstr "自動暫停"
 
-#: panels/power/cc-power-panel.ui:266
+#: panels/power/cc-power-panel.ui:267
 msgid "_Plugged In"
-msgstr "插入插頭(_P)"
+msgstr "使用交流電源(_P)"
 
-#: panels/power/cc-power-panel.ui:278
+#: panels/power/cc-power-panel.ui:279
 msgid "On _Battery Power"
 msgstr "使用電池電源(_B)"
 
-#: panels/power/cc-power-panel.ui:311 panels/power/cc-power-panel.ui:347
-#: panels/universal-access/cc-repeat-keys-dialog.ui:62
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
 msgid "Delay"
-msgstr "延遲"
-
-#: panels/power/cc-power-profile-row.c:132
-msgctxt "Power profile"
-msgid "Performance"
-msgstr "效能"
-
-#: panels/power/cc-power-profile-row.c:133
-msgid "High performance and power usage."
-msgstr "高效能與高度電量使用。"
-
-#: panels/power/cc-power-profile-row.c:136
-msgctxt "Power profile"
-msgid "Balanced"
-msgstr "平衡"
-
-#: panels/power/cc-power-profile-row.c:137
-msgid "Standard performance and power usage."
-msgstr "標準效能與電量使用。"
-
-#: panels/power/cc-power-profile-row.c:140
-msgctxt "Power profile"
-msgid "Power Saver"
-msgstr "省電"
-
-#: panels/power/cc-power-profile-row.c:141
-msgid "Reduced performance and power usage."
-msgstr "降低效能與電量使用。"
+msgstr "等候時間"
 
 #: panels/power/gnome-power-panel.desktop.in.in:3
 msgid "Power"
@@ -4746,37 +2918,15 @@ msgstr "電源"
 
 #: panels/power/gnome-power-panel.desktop.in.in:4
 msgid "View your battery status and change power saving settings"
-msgstr "檢視您的電池狀態並改變電源節省設定值"
+msgstr "檢視電量與更改節能設定"
 
-#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/power/gnome-power-panel.desktop.in.in:19
 msgid ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
 "Energy;"
 msgstr ""
 "Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
-"Energy;電源;睡眠;暫停;休眠;電池;亮度;轉黑;顯示器;閒置;能源;"
-
-#. Translators: %s is the printer name
-#: panels/printers/cc-printers-panel.c:676
-#, c-format
-msgid "Printer “%s” has been deleted"
-msgstr "「%s」印表機已刪除"
-
-#. Translators: Addition of the new printer failed.
-#: panels/printers/cc-printers-panel.c:928
-msgid "Failed to add new printer."
-msgstr "無法加入新的印表機。"
-
-#. Translators: The XML file containing user interface can not be loaded
-#: panels/printers/cc-printers-panel.c:1229
-#, c-format
-msgid "Could not load ui: %s"
-msgstr "無法載入 ui：%s"
-
-#: panels/printers/cc-printers-panel.c:1297
-msgid "Unlock to Add Printers and Change Settings"
-msgstr "請解除鎖定以加入印表機與變更設定"
+"Energy;電源;睡眠;暫停;休眠;電池;亮度;轉黑;顯示器;閒置;能源;關閉螢幕;交流電;"
 
 #: panels/printers/gnome-printers-panel.desktop.in.in:3
 msgid "Printers"
@@ -4786,7 +2936,6 @@ msgstr "印表機"
 msgid "Add printers, view printer jobs and decide how you want to print"
 msgstr "加入印表機、檢視印表機工作並決定您要如何列印"
 
-#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/printers/gnome-printers-panel.desktop.in.in:16
 msgid "Printer;Queue;Print;Paper;Ink;Toner;"
 msgstr "Printer;Queue;Print;Paper;Ink;Toner;印表機;佇列;列印;紙張;墨水;碳粉;"
@@ -4794,90 +2943,69 @@ msgstr "Printer;Queue;Print;Paper;Ink;Toner;印表機;佇列;列印;紙張;墨�
 #. Translators: This is the title presented at top of the dialog.
 #: panels/printers/new-printer-dialog.ui:28
 #: panels/printers/new-printer-dialog.ui:38
-#: panels/printers/pp-new-printer-dialog.c:255
-#: panels/printers/pp-new-printer-dialog.c:312
 msgid "Add Printer"
 msgstr "加入印表機"
 
 #. Translators: This button opens authentication dialog for selected server.
 #. Translators: This buttons submits the credentials for the selected server.
-#: panels/printers/new-printer-dialog.ui:100
-#: panels/printers/new-printer-dialog.ui:115
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
 #: panels/wwan/cc-wwan-device-page.ui:38
 msgid "_Unlock"
 msgstr "解除鎖定(_U)"
 
 #. Translators: No printers were detected
-#: panels/printers/new-printer-dialog.ui:194
+#: panels/printers/new-printer-dialog.ui:197
 msgid "No Printers Found"
 msgstr "找不到印表機"
 
 #. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
-#: panels/printers/new-printer-dialog.ui:244
+#: panels/printers/new-printer-dialog.ui:247
 msgid "Enter a network address or search for a printer"
 msgstr "輸入網路位址或搜尋印表機"
 
-#: panels/printers/new-printer-dialog.ui:286
+#: panels/printers/new-printer-dialog.ui:292
 msgid "Authentication Required"
-msgstr "要求核對"
+msgstr "需要核對身分"
 
-#: panels/printers/new-printer-dialog.ui:302
+#: panels/printers/new-printer-dialog.ui:308
 msgid "Enter username and password to view printers on Print Server."
 msgstr "輸入使用者名稱與密碼以檢視在印表機伺服器上的印表機。"
 
 #. Translators: This is a username on a print server.
-#: panels/printers/new-printer-dialog.ui:311
-#: panels/printers/pp-jobs-dialog.ui:41
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
 #: panels/user-accounts/cc-add-user-dialog.ui:94
-#: panels/user-accounts/cc-add-user-dialog.ui:342
-#: panels/wwan/cc-wwan-apn-dialog.ui:148
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
 msgid "Username"
 msgstr "使用者名稱"
 
-#. Translators: This is the title of the dialog. %s is the printer name.
-#: panels/printers/pp-details-dialog.c:74
-#: panels/printers/pp-details-dialog.c:365
-#, c-format
-msgid "%s Details"
-msgstr "%s 詳細資料"
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "印表機名稱不能包含空格、TAB 鍵、# 或 /"
 
-#: panels/printers/pp-details-dialog.c:101
-msgid "No suitable driver found"
-msgstr "找不到合適的驅動程式"
-
-#: panels/printers/pp-details-dialog.c:260
-msgid "Select PPD File"
-msgstr "選擇 PPD 檔案"
-
-#: panels/printers/pp-details-dialog.c:269
-msgid ""
-"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
-"PPD.GZ)"
-msgstr "PostScript 印表機描述檔 (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
-
-#: panels/printers/pp-details-dialog.ui:65 panels/printers/printer-entry.ui:215
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
 msgid "Location"
 msgstr "位置"
 
-#. Translators: Name of column showing printer drivers
-#: panels/printers/pp-details-dialog.ui:115
-#: panels/printers/pp-ppd-selection-dialog.c:236
+#: panels/printers/pp-details-dialog.ui:139
 msgid "Driver"
 msgstr "驅動程式"
 
-#: panels/printers/pp-details-dialog.ui:154
+#: panels/printers/pp-details-dialog.ui:178
 msgid "Searching for preferred drivers…"
 msgstr "正在搜尋偏好的驅動程式…"
 
-#: panels/printers/pp-details-dialog.ui:173
+#: panels/printers/pp-details-dialog.ui:197
 msgid "Search for Drivers"
-msgstr "正在搜尋驅動程式"
+msgstr "搜尋驅動程式"
 
-#: panels/printers/pp-details-dialog.ui:181
+#: panels/printers/pp-details-dialog.ui:205
 msgid "Select from Database…"
 msgstr "從資料庫選擇…"
 
-#: panels/printers/pp-details-dialog.ui:189
+#: panels/printers/pp-details-dialog.ui:213
 msgid "Install PPD File…"
 msgstr "安裝 PPD 檔案…"
 
@@ -4889,131 +3017,19 @@ msgstr "選擇印表機驅動程式"
 msgid "Loading drivers database…"
 msgstr "正在載入驅動程式資料庫…"
 
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr "取消"
+
 #: panels/printers/ppd-selection-dialog.ui:91
-#: panels/user-accounts/cc-avatar-chooser.c:98
 msgid "Select"
 msgstr "選取"
 
-#. Translators: The found device is a JetDirect printer
-#: panels/printers/pp-host.c:478
-msgid "JetDirect Printer"
-msgstr "JetDirect 印表機"
-
-#. Translators: The found device is a Line Printer Daemon printer
-#: panels/printers/pp-host.c:713
-msgid "LPD Printer"
-msgstr "LPD 印表機"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:64
-#: panels/printers/pp-ppd-option-widget.c:69
-msgid "One Sided"
-msgstr "單面"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:66
-#: panels/printers/pp-ppd-option-widget.c:71
-msgid "Long Edge (Standard)"
-msgstr "長邊 (標準)"
-
-#. Translators: this is an option of "Two Sided"
-#: panels/printers/pp-ipp-option-widget.c:68
-#: panels/printers/pp-ppd-option-widget.c:73
-msgid "Short Edge (Flip)"
-msgstr "短邊 (翻轉)"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:70
-msgid "Portrait"
-msgstr "直向"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:72
-msgid "Landscape"
-msgstr "橫向"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:74
-msgid "Reverse landscape"
-msgstr "橫向倒轉"
-
-#. Translators: this is an option of "Orientation"
-#: panels/printers/pp-ipp-option-widget.c:76
-msgid "Reverse portrait"
-msgstr "直向倒轉"
-
-#. Translators: Job's state (job is waiting to be printed)
-#: panels/printers/pp-job-row.c:134
-msgctxt "print job"
-msgid "Pending"
-msgstr "待處理"
-
-#. Translators: Job's state (job is held for printing)
-#: panels/printers/pp-job-row.c:140
-msgctxt "print job"
-msgid "Paused"
-msgstr "暫停"
-
-#. Translators: Job's state (job needs authentication to proceed further)
-#: panels/printers/pp-job-row.c:145
-msgctxt "print job"
-msgid "Authentication required"
-msgstr "需要核對"
-
-#. Translators: Job's state (job is currently printing)
-#: panels/printers/pp-job-row.c:150
-msgctxt "print job"
-msgid "Processing"
-msgstr "處理中"
-
-#. Translators: Job's state (job has been stopped)
-#: panels/printers/pp-job-row.c:154
-msgctxt "print job"
-msgid "Stopped"
-msgstr "已停止"
-
-#. Translators: Job's state (job has been canceled)
-#: panels/printers/pp-job-row.c:158
-msgctxt "print job"
-msgid "Canceled"
-msgstr "已取消"
-
-#. Translators: Job's state (job has aborted due to error)
-#: panels/printers/pp-job-row.c:162
-msgctxt "print job"
-msgid "Aborted"
-msgstr "已放棄"
-
-#. Translators: Job's state (job has completed successfully)
-#: panels/printers/pp-job-row.c:166
-msgctxt "print job"
-msgid "Completed"
-msgstr "已完成"
-
-#. Translators: Clicking this button prioritizes printing of this print job
-#: panels/printers/pp-job-row.c:176
-msgid "Move this job to the top of the queue"
-msgstr "將此工作移動至佇列頂端"
-
-#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
 #: panels/printers/pp-jobs-dialog.c:318
 #, c-format
 msgid "%u Job Requires Authentication"
 msgid_plural "%u Jobs Require Authentication"
-msgstr[0] "有 %u 份工作需要核對身份"
-
-#. Translators: This is the printer name for which we are showing the active jobs
-#: panels/printers/pp-jobs-dialog.c:456
-#, c-format
-msgctxt "Printer jobs dialog title"
-msgid "%s — Active Jobs"
-msgstr "%s — 進行中的工作"
-
-#. Translators: The printer needs authentication info to print.
-#: panels/printers/pp-jobs-dialog.c:460
-#, c-format
-msgid "Enter credentials to print from %s."
-msgstr "請輸入憑證以從 %s 列印。"
+msgstr[0] "有 %u 份工作需要核對身分"
 
 #. Translators: This is a windows domain used with SMB protocol.
 #: panels/printers/pp-jobs-dialog.ui:30
@@ -5022,339 +3038,35 @@ msgid "Domain"
 msgstr "網域"
 
 #. Translators: This button authenticates all print jobs and send them for printing.
-#: panels/printers/pp-jobs-dialog.ui:100
+#: panels/printers/pp-jobs-dialog.ui:103
 msgid "A_uthenticate"
-msgstr "核對(_U)"
+msgstr "認證(_U)"
 
 #. Translators: this action removes (purges) all the listed jobs from the list.
-#: panels/printers/pp-jobs-dialog.ui:128
+#: panels/printers/pp-jobs-dialog.ui:131
 msgid "Clear All"
 msgstr "全部清除"
 
 #. Translators: This button pop up authentication dialog for print jobs which need credentials.
-#: panels/printers/pp-jobs-dialog.ui:173
+#: panels/printers/pp-jobs-dialog.ui:177
 msgid "_Authenticate"
-msgstr "核對(_A)"
+msgstr "認證(_A)"
 
 #. Translators: this label describes the dialog empty state, with no jobs listed.
-#: panels/printers/pp-jobs-dialog.ui:214
+#: panels/printers/pp-jobs-dialog.ui:219
 msgid "No Active Printer Jobs"
-msgstr "沒有使用中的印表機工作"
+msgstr "沒有正在進行的印表機工作"
 
-#: panels/printers/pp-new-printer-dialog.c:270
-msgid "Unlock Print Server"
-msgstr "解鎖印表機伺服器"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:274
-#, c-format
-msgid "Unlock %s."
-msgstr "解除鎖定 %s。"
-
-#. Translators: Samba server needs authentication of the user to show list of its printers.
-#: panels/printers/pp-new-printer-dialog.c:278
-#, c-format
-msgid "Enter username and password to view printers on %s."
-msgstr "輸入使用者名稱與密碼以檢視在 %s 的印表機。"
-
-#: panels/printers/pp-new-printer-dialog.c:578
-msgid "Searching for Printers"
-msgstr "正在搜尋印表機"
-
-#. Translators: The found device is a printer connected via USB
-#: panels/printers/pp-new-printer-dialog.c:1366
-msgid "USB"
-msgstr "USB"
-
-#. Translators: The found device is a printer connected via serial port
-#: panels/printers/pp-new-printer-dialog.c:1371
-msgid "Serial Port"
-msgstr "序列埠"
-
-#. Translators: The found device is a printer connected via parallel port
-#: panels/printers/pp-new-printer-dialog.c:1378
-msgid "Parallel Port"
-msgstr "串列埠"
-
-#. Translators: Location of found network printer (e.g. Kitchen, Reception)
-#: panels/printers/pp-new-printer-dialog.c:1420
-#, c-format
-msgid "Location: %s"
-msgstr "位置：%s"
-
-#. Translators: Network address of found printer
-#: panels/printers/pp-new-printer-dialog.c:1425
-#, c-format
-msgid "Address: %s"
-msgstr "位址：%s"
-
-#. Translators: This item is a server which needs authentication to show its printers
-#: panels/printers/pp-new-printer-dialog.c:1452
-msgid "Server requires authentication"
-msgstr "伺服器需要核對身份"
-
-#: panels/printers/pp-options-dialog.c:87
-msgid "Two Sided"
-msgstr "雙面"
-
-#: panels/printers/pp-options-dialog.c:88
-msgid "Paper Type"
-msgstr "紙張類型"
-
-#: panels/printers/pp-options-dialog.c:89
-msgid "Paper Source"
-msgstr "紙張來源"
-
-#: panels/printers/pp-options-dialog.c:90
-msgid "Output Tray"
-msgstr "出紙匣"
-
-#: panels/printers/pp-options-dialog.c:91
-msgctxt "printing option"
-msgid "Resolution"
-msgstr "解析度"
-
-#: panels/printers/pp-options-dialog.c:92
-msgid "GhostScript pre-filtering"
-msgstr "GhostScript 前置過濾器"
-
-#. Translators: This option sets number of pages printed on one sheet
-#: panels/printers/pp-options-dialog.c:517
-msgid "Pages per side"
-msgstr "每張紙的頁數"
-
-#. Translators: This option sets whether to print on both sides of paper
-#: panels/printers/pp-options-dialog.c:529
-msgid "Two-sided"
-msgstr "雙面"
-
-#. Translators: This option sets orientation of print (portrait, landscape...)
-#: panels/printers/pp-options-dialog.c:541
-msgid "Orientation"
-msgstr "方向"
-
-#. Translators: "General" tab contains general printer options
-#: panels/printers/pp-options-dialog.c:638
-msgctxt "Printer Option Group"
-msgid "General"
-msgstr "一般"
-
-#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
-#: panels/printers/pp-options-dialog.c:641
-msgctxt "Printer Option Group"
-msgid "Page Setup"
-msgstr "頁面設定"
-
-#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
-#: panels/printers/pp-options-dialog.c:644
-msgctxt "Printer Option Group"
-msgid "Installable Options"
-msgstr "可安裝選項"
-
-#. Translators: "Job" tab contains settings for jobs
-#: panels/printers/pp-options-dialog.c:647
-msgctxt "Printer Option Group"
-msgid "Job"
-msgstr "工作"
-
-#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
-#: panels/printers/pp-options-dialog.c:650
-msgctxt "Printer Option Group"
-msgid "Image Quality"
-msgstr "影像品質"
-
-#. Translators: "Color" tab contains color settings (e.g. color printing)
-#: panels/printers/pp-options-dialog.c:653
-msgctxt "Printer Option Group"
-msgid "Color"
-msgstr "色彩"
-
-#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
-#: panels/printers/pp-options-dialog.c:656
-msgctxt "Printer Option Group"
-msgid "Finishing"
-msgstr "完成"
-
-#. Translators: "Advanced" tab contains all others settings
-#: panels/printers/pp-options-dialog.c:659
-msgctxt "Printer Option Group"
-msgid "Advanced"
-msgstr "進階"
-
-#. Translators: Name of job which makes printer to print test page
 #. Translators: This button triggers the printing of a test page.
-#: panels/printers/pp-options-dialog.c:844
 #: panels/printers/pp-options-dialog.ui:14
 msgid "Test Page"
 msgstr "測試頁"
 
-#. Translators: Name of job which makes printer to print test page
-#: panels/printers/pp-options-dialog.c:857
-msgid "Test page"
-msgstr "測試頁"
-
-#. Translators: this is an option of "Paper Source"
-#: panels/printers/pp-ppd-option-widget.c:75
-#: panels/printers/pp-ppd-option-widget.c:77
-#: panels/printers/pp-ppd-option-widget.c:85
-msgid "Auto Select"
-msgstr "自動選擇"
-
-#. Translators: this is an option of "Paper Source"
-#. Translators: this is an option of "Resolution"
-#: panels/printers/pp-ppd-option-widget.c:79
-#: panels/printers/pp-ppd-option-widget.c:81
-#: panels/printers/pp-ppd-option-widget.c:83
-#: panels/printers/pp-ppd-option-widget.c:87
-msgid "Printer Default"
-msgstr "印表機預設"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:89
-msgid "Embed GhostScript fonts only"
-msgstr "只有內嵌的 GhostScript 字型"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:91
-msgid "Convert to PS level 1"
-msgstr "轉換為 PS 等級 1"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:93
-msgid "Convert to PS level 2"
-msgstr "轉換為 PS 等級 2"
-
-#. Translators: this is an option of "GhostScript"
-#: panels/printers/pp-ppd-option-widget.c:95
-msgid "No pre-filtering"
-msgstr "無前置過濾器"
-
-#. Translators: Name of column showing printer manufacturers
-#: panels/printers/pp-ppd-selection-dialog.c:220
-#: panels/wwan/cc-wwan-details-dialog.ui:160
-msgid "Manufacturer"
-msgstr "製造商"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
-#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
-msgid "No Active Jobs"
-msgstr "沒有進行中的工作"
-
-#. Translators: This is the label of the button that opens the Jobs Dialog.
 #: panels/printers/pp-printer-entry.c:531
 #, c-format
 msgid "%u Job"
 msgid_plural "%u Jobs"
 msgstr[0] "%u 個工作"
-
-#. Translators: Name of job which makes printer to clean its heads
-#: panels/printers/pp-printer-entry.c:651
-msgid "Clean print heads"
-msgstr "清理列印噴頭"
-
-#. Translators: The printer is low on toner
-#: panels/printers/pp-printer-entry.c:719
-msgid "Low on toner"
-msgstr "碳粉不足"
-
-#. Translators: The printer has no toner left
-#: panels/printers/pp-printer-entry.c:721
-msgid "Out of toner"
-msgstr "碳粉用完"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:724
-msgid "Low on developer"
-msgstr "顯像劑不足"
-
-#. Translators: "Developer" is a chemical for photo development,
-#. * http://en.wikipedia.org/wiki/Photographic_developer
-#: panels/printers/pp-printer-entry.c:727
-msgid "Out of developer"
-msgstr "顯像劑用完"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:729
-msgid "Low on a marker supply"
-msgstr "墨水匣不足"
-
-#. Translators: "marker" is one color bin of the printer
-#: panels/printers/pp-printer-entry.c:731
-msgid "Out of a marker supply"
-msgstr "墨水匣用完"
-
-#. Translators: One or more covers on the printer are open
-#: panels/printers/pp-printer-entry.c:733
-msgid "Open cover"
-msgstr "外殼開啟"
-
-#. Translators: One or more doors on the printer are open
-#: panels/printers/pp-printer-entry.c:735
-msgid "Open door"
-msgstr "紙匣門開啟"
-
-#. Translators: At least one input tray is low on media
-#: panels/printers/pp-printer-entry.c:737
-msgid "Low on paper"
-msgstr "紙張不足"
-
-#. Translators: At least one input tray is empty
-#: panels/printers/pp-printer-entry.c:739
-msgid "Out of paper"
-msgstr "紙張用完"
-
-#. Translators: The printer is offline
-#: panels/printers/pp-printer-entry.c:741
-msgctxt "printer state"
-msgid "Offline"
-msgstr "離線"
-
-#. Translators: Someone has stopped the Printer
-#. Translators: Printer's state (no jobs can be processed)
-#: panels/printers/pp-printer-entry.c:743
-#: panels/printers/pp-printer-entry.c:886
-msgctxt "printer state"
-msgid "Stopped"
-msgstr "已停止"
-
-#. Translators: The printer marker supply waste receptacle is almost full
-#: panels/printers/pp-printer-entry.c:745
-msgid "Waste receptacle almost full"
-msgstr "廢墨收集器將滿"
-
-#. Translators: The printer marker supply waste receptacle is full
-#: panels/printers/pp-printer-entry.c:747
-msgid "Waste receptacle full"
-msgstr "廢墨收集器已滿"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:749
-msgid "The optical photo conductor is near end of life"
-msgstr "感光鼓接近使用壽命"
-
-#. Translators: Optical photo conductors are used in laser printers
-#: panels/printers/pp-printer-entry.c:751
-msgid "The optical photo conductor is no longer functioning"
-msgstr "感光鼓已無法使用"
-
-#. Translators: Printer's state (can start new job without waiting)
-#: panels/printers/pp-printer-entry.c:872
-msgctxt "printer state"
-msgid "Ready"
-msgstr "準備就緒"
-
-#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
-#: panels/printers/pp-printer-entry.c:877
-msgctxt "printer state"
-msgid "Does not accept jobs"
-msgstr "不接受工作"
-
-#. Translators: Printer's state (jobs are processing)
-#: panels/printers/pp-printer-entry.c:882
-msgctxt "printer state"
-msgid "Processing"
-msgstr "處理中"
 
 #: panels/printers/printer-entry.ui:18
 msgid "Printing Options"
@@ -5367,7 +3079,7 @@ msgstr "印表機詳細資料"
 #. Set this printer as default
 #: panels/printers/printer-entry.ui:40
 msgid "Use Printer by Default"
-msgstr "使用預設印表機"
+msgstr "作為預設印表機"
 
 #. Translators: This button executes command which cleans print heads of the printer.
 #: panels/printers/printer-entry.ui:52
@@ -5378,100 +3090,88 @@ msgstr "清理列印噴頭"
 msgid "Remove Printer"
 msgstr "移除印表機"
 
-#: panels/printers/printer-entry.ui:187
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "沒有進行中的工作"
+
+#: panels/printers/printer-entry.ui:183
 #: panels/wwan/cc-wwan-details-dialog.ui:184
 msgid "Model"
 msgstr "型號"
 
-#: panels/printers/printer-entry.ui:242
+#: panels/printers/printer-entry.ui:238
 msgid "Ink Level"
-msgstr "墨水等級"
+msgstr "墨水殘餘量"
 
 #. Translators: This is the message which follows the printer error.
-#: panels/printers/printer-entry.ui:304
+#: panels/printers/printer-entry.ui:300
 msgid "Please restart when the problem is resolved."
-msgstr "若問題解決後請重新啟動機器。"
+msgstr "問題解決後請重新啟動機器。"
 
 #. Translators: This is the button which restarts the printer.
-#: panels/printers/printer-entry.ui:310
+#: panels/printers/printer-entry.ui:306
 msgid "Restart"
 msgstr "重新啟動"
 
 #. Translators: This button adds new printer.
-#: panels/printers/printers.ui:10
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
 msgid "Add Printer…"
 msgstr "加入印表機…"
 
-#: panels/printers/printers.ui:168
+#: panels/printers/printers.ui:134
+#, fuzzy
+msgid "Additional Printer Settings…"
+msgstr "加入印表機…"
+
+#: panels/printers/printers.ui:173
 msgid "No printers"
 msgstr "沒有印表機"
 
-#. Translators: This button adds new printer.
-#: panels/printers/printers.ui:179
-msgid "Add a Printer…"
-msgstr "加入印表機…"
-
 #. Translators: The CUPS server is not running (we can not connect to it).
-#: panels/printers/printers.ui:204
+#: panels/printers/printers.ui:209
 msgid ""
 "Sorry! The system printing service\n"
 "    doesn’t seem to be available."
 msgstr ""
 "抱歉！系統列印服務\n"
-"    似乎無法使用。"
+"  似乎無法使用。"
 
-#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
 #: panels/region/cc-format-chooser.ui:4
 msgid "Formats"
 msgstr "格式"
-
-#: panels/region/cc-format-chooser.ui:37
-#: panels/wacom/cc-wacom-stylus-page.ui:136
-#: panels/wwan/cc-wwan-apn-dialog.ui:21
-msgid "Back"
-msgstr "上一頁"
 
 #: panels/region/cc-format-chooser.ui:76
 msgid "Search locales…"
 msgstr "搜尋語言地區…"
 
-#: panels/region/cc-format-chooser.ui:113
+#: panels/region/cc-format-chooser.ui:116
 msgid "Common Formats"
 msgstr "通常格式"
 
-#: panels/region/cc-format-chooser.ui:140
+#: panels/region/cc-format-chooser.ui:143
 msgid "All Formats"
 msgstr "所有格式"
 
-#: panels/region/cc-format-chooser.ui:188
+#: panels/region/cc-format-chooser.ui:191
 msgid "No Search Results"
 msgstr "沒有搜尋結果"
 
-#: panels/region/cc-format-chooser.ui:200
+#: panels/region/cc-format-chooser.ui:203
 msgid "Searches can be for countries or languages."
 msgstr "可以搜尋國家或語言。"
 
-#: panels/region/cc-format-chooser.ui:236
+#: panels/region/cc-format-chooser.ui:239
 msgid "Preview"
 msgstr "預覽"
-
-#: panels/region/cc-format-preview.c:135
-msgctxt "measurement format"
-msgid "Imperial"
-msgstr "英制"
-
-#: panels/region/cc-format-preview.c:137
-msgctxt "measurement format"
-msgid "Metric"
-msgstr "公制"
 
 #: panels/region/cc-format-preview.ui:17
 msgid "Dates"
 msgstr "日期"
 
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
 #: panels/region/cc-format-preview.ui:53
 msgid "Dates & Times"
-msgstr "日期與時刻"
+msgstr "日期與時間"
 
 #: panels/region/cc-format-preview.ui:71
 msgid "Numbers"
@@ -5487,32 +3187,36 @@ msgstr "紙張"
 
 #: panels/region/cc-region-panel.ui:19
 msgid "Language and format will be changed after next login"
-msgstr "語言與格式會在下次登入後變更"
+msgstr "語言與格式設定會在下次登入後修改"
 
 #: panels/region/cc-region-panel.ui:29
 msgid "Logout…"
-msgstr "登出…"
+msgstr "立即登出…"
 
 #: panels/region/cc-region-panel.ui:45
 msgid ""
-"The language setting is used for interface text and web pages. Formats is "
+"The language setting is used for interface text and web pages. Formats are "
 "used for numbers, dates, and currencies."
-msgstr "語言設定用於介面文字與網頁上。格式用於數字、日期、貨幣等。"
+msgstr "語言設定會用於介面中的文字與網頁，格式則用於數字、日期、貨幣等。"
 
-#: panels/region/cc-region-panel.ui:51
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
 msgid "Your Account"
 msgstr "您的帳號"
 
-#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
-#: panels/user-accounts/cc-user-panel.ui:299
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
 msgid "_Language"
 msgstr "語言(_L)"
 
-#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
 msgid "_Formats"
 msgstr "格式(_F)"
 
-#: panels/region/cc-region-panel.ui:90
+#: panels/region/cc-region-panel.ui:113
 msgid "Login Screen"
 msgstr "登入畫面"
 
@@ -5522,113 +3226,25 @@ msgstr "地區和語言"
 
 #: panels/region/gnome-region-panel.desktop.in.in:4
 msgid "Select your display language and formats"
-msgstr "選取您要顯示的語言與格式"
+msgstr "選擇您要顯示的語言與格式"
 
-#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/region/gnome-region-panel.desktop.in.in:19
 msgid "Language;Layout;Keyboard;Input;"
-msgstr "Language;Layout;Keyboard;Input;語言;配置;鍵盤;輸入;"
-
-#: panels/removable-media/cc-removable-media-panel.c:256
-msgid "Ask what to do"
-msgstr "詢問要做什麼"
-
-#: panels/removable-media/cc-removable-media-panel.c:260
-msgid "Do nothing"
-msgstr "不做任何事"
-
-#: panels/removable-media/cc-removable-media-panel.c:264
-msgid "Open folder"
-msgstr "開啟資料夾"
-
-#: panels/removable-media/cc-removable-media-panel.c:331
-msgid "Other Media"
-msgstr "其他媒體"
-
-#: panels/removable-media/cc-removable-media-panel.c:352
-msgid "Select an application for audio CDs"
-msgstr "選擇播放音樂 CD 的應用程式"
-
-#: panels/removable-media/cc-removable-media-panel.c:353
-msgid "Select an application for video DVDs"
-msgstr "選擇播放影片 DVD 的應用程式"
-
-#: panels/removable-media/cc-removable-media-panel.c:354
-msgid "Select an application to run when a music player is connected"
-msgstr "選擇當音樂播放器連接時要執行的應用程式"
-
-#: panels/removable-media/cc-removable-media-panel.c:355
-msgid "Select an application to run when a camera is connected"
-msgstr "選擇當攝影機連接時要執行的應用程式"
-
-#: panels/removable-media/cc-removable-media-panel.c:356
-msgid "Select an application for software CDs"
-msgstr "選擇軟體 CD 要用的應用程式"
-
-#. translators: these strings are duplicates of shared-mime-info
-#. * strings, just here to fix capitalization of the English originals.
-#. * If the shared-mime-info translation works for your language,
-#. * simply leave these untranslated.
-#.
-#: panels/removable-media/cc-removable-media-panel.c:368
-msgid "audio DVD"
-msgstr "音樂 DVD"
-
-#: panels/removable-media/cc-removable-media-panel.c:369
-msgid "blank Blu-ray disc"
-msgstr "空白 Blu-ray 碟片"
-
-#: panels/removable-media/cc-removable-media-panel.c:370
-msgid "blank CD disc"
-msgstr "空白 CD 碟片"
-
-#: panels/removable-media/cc-removable-media-panel.c:371
-msgid "blank DVD disc"
-msgstr "空白 DVD 碟片"
-
-#: panels/removable-media/cc-removable-media-panel.c:372
-msgid "blank HD DVD disc"
-msgstr "空白 HD DVD 碟片"
-
-#: panels/removable-media/cc-removable-media-panel.c:373
-msgid "Blu-ray video disc"
-msgstr "Blu-ray 影片碟片"
-
-#: panels/removable-media/cc-removable-media-panel.c:374
-msgid "e-book reader"
-msgstr "電子書閱讀器"
-
-#: panels/removable-media/cc-removable-media-panel.c:375
-msgid "HD DVD video disc"
-msgstr "HD DVD 影片碟片"
-
-#: panels/removable-media/cc-removable-media-panel.c:376
-msgid "Picture CD"
-msgstr "照片 CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:377
-msgid "Super Video CD"
-msgstr "SVCD"
-
-#: panels/removable-media/cc-removable-media-panel.c:378
-msgid "Video CD"
-msgstr "影片 CD"
-
-#: panels/removable-media/cc-removable-media-panel.c:379
-msgid "Windows software"
-msgstr "Windows 軟體"
+msgstr "Language;Layout;Keyboard;Input;語言;配置;鍵盤;輸入;格式;顯示;"
 
 #: panels/removable-media/cc-removable-media-panel.ui:32
 msgid "Select how media should be handled"
-msgstr "選擇要如何處理媒體"
+msgstr "選擇媒體與裝置接上時要執行的動作"
 
+# (Freddy)考量臺灣人普遍都講 CD VCD DVD 之類的東西，也都知道誰是視訊誰是音訊，故邏輯上是以括號來補充 CD VCD DVD。
 #: panels/removable-media/cc-removable-media-panel.ui:52
 msgid "CD _audio"
-msgstr "CD 音樂(_A)"
+msgstr "音訊 CD(_A)"
 
+# (Freddy)考量臺灣人普遍都講 CD VCD DVD 之類的東西，也都知道誰是視訊誰是音訊，故邏輯上是以括號來補充 CD VCD DVD。
 #: panels/removable-media/cc-removable-media-panel.ui:67
 msgid "_DVD video"
-msgstr "_DVD 影片"
+msgstr "視訊 _DVD"
 
 #: panels/removable-media/cc-removable-media-panel.ui:102
 msgid "_Music player"
@@ -5640,15 +3256,15 @@ msgstr "軟體(_S)"
 
 #: panels/removable-media/cc-removable-media-panel.ui:178
 msgid "_Other Media…"
-msgstr "其他(_O)…"
+msgstr "其他媒體(_O)…"
 
 #: panels/removable-media/cc-removable-media-panel.ui:195
 msgid "_Never prompt or start programs on media insertion"
-msgstr "插入媒體時永遠不提示或啟動程式(_N)"
+msgstr "接上媒體與裝置時不要提示或啟動程式(_N)"
 
 #: panels/removable-media/cc-removable-media-panel.ui:225
 msgid "Select how other media should be handled"
-msgstr "選擇要如何處理其他媒體"
+msgstr "選擇其他媒體接上時要執行的動作"
 
 #: panels/removable-media/cc-removable-media-panel.ui:259
 msgid "_Action:"
@@ -5660,13 +3276,12 @@ msgstr "類型(_T)："
 
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
 msgid "Removable Media"
-msgstr "可移除式媒體"
+msgstr "卸除式媒體"
 
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
 msgid "Configure Removable Media settings"
-msgstr "設定可移除式媒體設定值"
+msgstr "修改卸除式媒體的設定值"
 
-#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
 msgid ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
@@ -5674,15 +3289,76 @@ msgid ""
 msgstr ""
 "device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
 "removable;media;autorun;裝置;系統;預設;應用程式;偏好;首選;音訊;視訊;光碟;碟"
-"片;可移除;可移除式;媒體;自動執行;"
+"片;可移除;可移除式;媒體;自動執行;卸除式;"
 
-#: panels/search/cc-search-locations-dialog.c:674
-msgid "Select Location"
-msgstr "選擇位置"
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "螢幕鎖定"
 
-#: panels/search/cc-search-locations-dialog.c:678
-msgid "_OK"
-msgstr "確定(_O)"
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr "自動鎖定螢幕能防止他人在您離開時取用您的電腦。"
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "螢幕轉黑等候"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "多久沒活動後將螢幕轉黑。"
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "自動鎖定螢幕(_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "螢幕自動鎖定等候(_S)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "螢幕轉黑後要隔多久才將螢幕鎖定。"
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "在螢幕鎖定畫面顯示通知(_N)"
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "螢幕鎖定時顯示通知(_L)"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr "禁止新的 _USB 裝置"
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "當螢幕鎖定時，防止新的 USB 裝置與系統互動。"
+
+#: panels/screen/cc-screen-panel.ui:122
+msgid "Screen Privacy"
+msgstr "螢幕隱私"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr "限制螢幕的檢視角度"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "螢幕"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "螢幕設定"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;螢幕鎖定;鎖定畫面;隱私權;"
 
 #: panels/search/cc-search-locations-dialog.ui:8
 #: panels/search/cc-search-panel.ui:22
@@ -5699,21 +3375,17 @@ msgstr "系統應用程式會搜尋的資料夾，例如「檔案」、「照片
 msgid "Places"
 msgstr "位置"
 
-#: panels/search/cc-search-locations-dialog.ui:33
+#: panels/search/cc-search-locations-dialog.ui:35
 msgid "Bookmarks"
 msgstr "書籤"
 
-#: panels/search/cc-search-locations-dialog.ui:48
+#: panels/search/cc-search-locations-dialog.ui:52
 msgid "Others"
 msgstr "其他"
 
-#: panels/search/cc-search-locations-dialog.ui:55
+#: panels/search/cc-search-locations-dialog.ui:59
 msgid "Add Location"
 msgstr "加入位置"
-
-#: panels/search/cc-search-panel.c:165
-msgid "No applications found"
-msgstr "找不到應用程式"
 
 #: panels/search/cc-search-panel.ui:10
 msgid "Application Search"
@@ -5738,64 +3410,15 @@ msgstr "結果會根據列表順序顯示。"
 #: panels/search/gnome-search-panel.desktop.in.in:4
 msgid ""
 "Control which applications show search results in the Activities Overview"
-msgstr "控制在活動概覽中哪些應用程式會顯示在搜尋結果中"
+msgstr "控制在概覽中哪些應用程式會顯示在搜尋結果"
 
-#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/search/gnome-search-panel.desktop.in.in:19
 msgid "Search;Find;Index;Hide;Privacy;Results;"
 msgstr "Search;Find;Index;Hide;Privacy;Results;搜尋;尋找;索引;隱藏;隱私;結果;"
 
-#. Label
-#: panels/sharing/cc-sharing-networks.c:265
-msgid "No networks selected for sharing"
-msgstr "沒有選擇用來分享的網路"
-
 #: panels/sharing/cc-sharing-networks.ui:15
 msgid "Networks"
 msgstr "網路"
-
-#: panels/sharing/cc-sharing-panel.c:370
-msgctxt "service is enabled"
-msgid "On"
-msgstr "開啟"
-
-#: panels/sharing/cc-sharing-panel.c:372 panels/sharing/cc-sharing-panel.c:399
-msgctxt "service is disabled"
-msgid "Off"
-msgstr "關閉"
-
-#: panels/sharing/cc-sharing-panel.c:402
-msgctxt "service is enabled"
-msgid "Enabled"
-msgstr "已啟用"
-
-#: panels/sharing/cc-sharing-panel.c:405
-msgctxt "service is active"
-msgid "Active"
-msgstr "使用中"
-
-#: panels/sharing/cc-sharing-panel.c:523
-msgid "Choose a Folder"
-msgstr "選擇一個資料夾"
-
-#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
-#: panels/sharing/cc-sharing-panel.c:751
-#, c-format
-msgid ""
-"File Sharing allows you to share your Public folder with others on your "
-"current network using: %s"
-msgstr "檔案分享允許您使用下述方式與目前網路上的其他人分享您的公開資料夾：%s"
-
-#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
-#: panels/sharing/cc-sharing-panel.c:757
-#, c-format
-msgid ""
-"When remote login is enabled, remote users can connect using the Secure "
-"Shell command:\n"
-"%s"
-msgstr ""
-"啟用遠端登入後，遠端使用者可使用此 SSH 指令連線：\n"
-"%s"
 
 #: panels/sharing/cc-sharing-panel.ui:9
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:3
@@ -5835,55 +3458,62 @@ msgstr "需要密碼(_R)"
 msgid "Remote Login"
 msgstr "遠端登入"
 
-#: panels/sharing/cc-sharing-panel.ui:250
-#: panels/sharing/cc-sharing-panel.ui:267
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
 msgid "Remote Desktop"
 msgstr "遠端桌面"
 
-#: panels/sharing/cc-sharing-panel.ui:263
+#: panels/sharing/cc-sharing-panel.ui:266
 msgid ""
 "Remote desktop allows viewing and controlling your desktop from another "
 "computer."
-msgstr "遠端桌面允許從另一臺電腦檢視並遙控您的系統。"
+msgstr "遠端桌面允許另一臺電腦檢視與控制您的桌面。"
 
-#: panels/sharing/cc-sharing-panel.ui:268
+#: panels/sharing/cc-sharing-panel.ui:271
 msgid "Enable or disable remote desktop connections to this computer."
-msgstr "啟用或停用此電腦的遠端桌面連線。"
+msgstr "啟用或停用本電機的遠端桌面連線。"
 
-#: panels/sharing/cc-sharing-panel.ui:280
+#: panels/sharing/cc-sharing-panel.ui:284
 msgid "Remote Control"
-msgstr "遠端遙控"
+msgstr "遠端控制"
 
-#: panels/sharing/cc-sharing-panel.ui:281
+#: panels/sharing/cc-sharing-panel.ui:285
 msgid "Allows remote connections to control the screen."
-msgstr "允許遠端連線控制此螢幕。"
+msgstr "允許遠端的連線控制本機。"
 
-#: panels/sharing/cc-sharing-panel.ui:294
+#: panels/sharing/cc-sharing-panel.ui:299
 msgid "How to Connect"
-msgstr "連接方式"
+msgstr "如何連接"
 
-#: panels/sharing/cc-sharing-panel.ui:295
+#: panels/sharing/cc-sharing-panel.ui:300
 msgid ""
 "Connect to this computer using the device name or remote desktop address."
-msgstr "使用裝置名稱或遠端桌面位址來連接至此電腦。"
+msgstr "使用裝置名稱或遠端桌面位址進行連接。"
 
-#: panels/sharing/cc-sharing-panel.ui:323
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "複製"
+
+#: panels/sharing/cc-sharing-panel.ui:331
 msgid "Remote Desktop Address"
 msgstr "遠端桌面位址"
 
-#: panels/sharing/cc-sharing-panel.ui:350
+#: panels/sharing/cc-sharing-panel.ui:361
 msgid "Authentication"
-msgstr "身分核對"
+msgstr "核對身分"
 
-#: panels/sharing/cc-sharing-panel.ui:351
+#: panels/sharing/cc-sharing-panel.ui:362
 msgid "The user name and password are required to connect to this computer."
-msgstr "需要使用者名稱與密碼才能連接至此電腦。"
+msgstr "需要使用者名稱與密碼才能連接本電腦。"
 
-#: panels/sharing/cc-sharing-panel.ui:355
+#: panels/sharing/cc-sharing-panel.ui:366
 msgid "User Name"
 msgstr "使用者名稱"
 
-#: panels/sharing/cc-sharing-panel.ui:401
+#: panels/sharing/cc-sharing-panel.ui:405
 msgid "Verify Encryption"
 msgstr "核驗加密"
 
@@ -5894,8 +3524,8 @@ msgstr "加密指紋"
 #: panels/sharing/cc-sharing-panel.ui:435
 msgid ""
 "The encryption fingerprint can be seen in connecting clients and should be "
-"identical"
-msgstr "加密指紋可以在連接客戶端時查看，而且應該相同"
+"identical."
+msgstr "您可以在已連接的客戶端看見相同的加密指紋。"
 
 #: panels/sharing/cc-sharing-panel.ui:467
 msgid "Media Sharing"
@@ -5911,9 +3541,8 @@ msgstr "資料夾"
 
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:4
 msgid "Control what you want to share with others"
-msgstr "控制您想要與其他人分享什麼"
+msgstr "控制您想與他人分享什麼內容"
 
-#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sharing/gnome-sharing-panel.desktop.in.in:16
 msgid ""
 "share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
@@ -5929,40 +3558,39 @@ msgstr "啟用或停用遠端登入"
 
 #: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
 msgid "Authentication is required to enable or disable remote login"
-msgstr "啟用或停用遠端登入需要核對"
-
-#: panels/sound/cc-alert-chooser.c:150
-msgid "Custom"
-msgstr "自訂"
+msgstr "啟用或停用遠端登入需要認證"
 
 #: panels/sound/cc-alert-chooser.ui:12
-msgid "Bark"
-msgstr "汪汪"
+msgid "Click"
+msgstr "喀喀"
 
 #: panels/sound/cc-alert-chooser.ui:20
-msgid "Drip"
-msgstr "水滴聲"
+msgid "String"
+msgstr "噠噠"
 
 #: panels/sound/cc-alert-chooser.ui:28
-msgid "Glass"
-msgstr "敲玻璃"
+msgid "Swing"
+msgstr "霍霍"
 
 #: panels/sound/cc-alert-chooser.ui:36
-msgid "Sonar"
-msgstr "聲納"
+msgid "Hum"
+msgstr "嗡嗡"
 
-#: panels/sound/cc-fade-slider.ui:13
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "平衡"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "淡化"
+
+#: panels/sound/cc-fade-slider.ui:16
 msgid "Rear"
-msgstr "後"
+msgstr "後方"
 
-#: panels/sound/cc-fade-slider.ui:15
+#: panels/sound/cc-fade-slider.ui:18
 msgid "Front"
-msgstr "前"
-
-#: panels/sound/cc-output-test-dialog.c:134
-#, c-format
-msgid "Testing %s"
-msgstr "正在測試 %s"
+msgstr "前方"
 
 #: panels/sound/cc-output-test-dialog.ui:131
 msgid "Click a speaker to test"
@@ -5972,68 +3600,62 @@ msgstr "按一下喇叭以測試"
 msgid "System Volume"
 msgstr "系統音量"
 
-#: panels/sound/cc-sound-panel.ui:25
-msgid "Volume Levels"
-msgstr "音量等級"
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "主音量"
 
-#: panels/sound/cc-sound-panel.ui:35
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "個別音量"
+
+#: panels/sound/cc-sound-panel.ui:38
 msgid "Output"
 msgstr "輸出"
 
-#: panels/sound/cc-sound-panel.ui:56
+#: panels/sound/cc-sound-panel.ui:59
 msgid "Output Device"
 msgstr "輸出裝置"
 
-#: panels/sound/cc-sound-panel.ui:75
+#: panels/sound/cc-sound-panel.ui:81
 msgid "Test"
 msgstr "測試"
 
-#: panels/sound/cc-sound-panel.ui:104 panels/sound/cc-sound-panel.ui:263
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
 msgid "Configuration"
 msgstr "設定"
 
-#: panels/sound/cc-sound-panel.ui:135
-msgid "Balance"
-msgstr "平衡"
-
-#: panels/sound/cc-sound-panel.ui:161
-msgid "Fade"
-msgstr "淡化"
-
-#: panels/sound/cc-sound-panel.ui:187
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
 msgid "Subwoofer"
 msgstr "重低音"
 
-#: panels/sound/cc-sound-panel.ui:205
+#: panels/sound/cc-sound-panel.ui:214
 msgid "Input"
 msgstr "輸入"
 
-#: panels/sound/cc-sound-panel.ui:226
+#: panels/sound/cc-sound-panel.ui:235
 msgid "Input Device"
 msgstr "輸入裝置"
 
-#: panels/sound/cc-sound-panel.ui:294
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
 msgid "Volume"
 msgstr "音量"
 
-#: panels/sound/cc-sound-panel.ui:312
+#: panels/sound/cc-sound-panel.ui:327
 msgid "Alert Sound"
-msgstr "警示音效"
+msgstr "鈴響音效"
 
-#: panels/sound/cc-volume-slider.c:117
-msgctxt "volume"
-msgid "100%"
-msgstr "100%"
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "靜音"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:3
 msgid "Sound"
-msgstr "音效"
+msgstr "音訊與音效"
 
 #: panels/sound/gnome-sound-panel.desktop.in.in:4
 msgid "Change sound levels, inputs, outputs, and alert sounds"
-msgstr "改變音效的音量、輸入、輸出與警示音效"
+msgstr "更改電腦的音量、輸入與輸出裝置、鈴響音效"
 
-#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/sound/gnome-sound-panel.desktop.in.in:20
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
@@ -6041,166 +3663,58 @@ msgstr ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;;Output;Input;音"
 "效卡;麥克風;音量;淡化;平衡;藍牙;耳機;音效;輸出;輸入;"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.c:92
-#: panels/thunderbolt/cc-bolt-device-entry.c:123
-msgctxt "Thunderbolt Device Status"
-msgid "Disconnected"
-msgstr "斷線"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:95
-#: panels/thunderbolt/cc-bolt-device-entry.c:126
-msgctxt "Thunderbolt Device Status"
-msgid "Connecting"
-msgstr "連線中"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:98
-#: panels/thunderbolt/cc-bolt-device-entry.c:130
-#: panels/thunderbolt/cc-bolt-device-entry.c:142
-msgctxt "Thunderbolt Device Status"
-msgid "Connected"
-msgstr "已連線"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:101
-msgctxt "Thunderbolt Device Status"
-msgid "Authorization Error"
-msgstr "認證失敗"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:104
-#: panels/thunderbolt/cc-bolt-device-entry.c:136
-msgctxt "Thunderbolt Device Status"
-msgid "Authorizing"
-msgstr "正在認證"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:111
-msgctxt "Thunderbolt Device Status"
-msgid "Reduced Functionality"
-msgstr "功能較少"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:113
-msgctxt "Thunderbolt Device Status"
-msgid "Connected & Authorized"
-msgstr "已連線、認證"
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:119
-#: panels/thunderbolt/cc-bolt-device-entry.c:150
-msgctxt "Thunderbolt Device Status"
-msgid "Unknown"
-msgstr "未知"
-
-#. Translators: The time point the device was authorized.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:175
-msgid "Authorized at:"
-msgstr "認證於："
-
-#. Translators: The time point the device was connected.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:181
-msgid "Connected at:"
-msgstr "連線於："
-
-#. Translators: The time point the device was enrolled,
-#. * i.e. authorized and stored in the device database.
-#: panels/thunderbolt/cc-bolt-device-dialog.c:188
-msgid "Enrolled at:"
-msgstr "登錄於："
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:262
-msgid "Failed to authorize device: "
-msgstr "裝置授權失敗："
-
-#: panels/thunderbolt/cc-bolt-device-dialog.c:329
-msgid "Failed to forget device: "
-msgstr "遺忘裝置失敗："
-
 #: panels/thunderbolt/cc-bolt-device-dialog.c:485
 #, c-format
 msgid "Depends on %u other device"
 msgid_plural "Depends on %u other devices"
 msgstr[0] "基於其他 %u 個裝置"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:84
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "關閉通知"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "名稱："
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:112
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
 msgid "Status:"
 msgstr "狀態："
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:141
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
 msgid "UUID:"
 msgstr "UUID："
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:247
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
 msgid "Authorize and Connect"
-msgstr "認證並連線"
+msgstr "授權並連接"
 
-#: panels/thunderbolt/cc-bolt-device-dialog.ui:263
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
 msgid "Forget Device"
-msgstr "遺忘裝置"
+msgstr "將該裝置遺忘"
 
-#: panels/thunderbolt/cc-bolt-device-entry.c:133
-msgctxt "Thunderbolt Device Status"
-msgid "Error"
-msgstr "錯誤"
-
-#: panels/thunderbolt/cc-bolt-device-entry.c:144
-msgctxt "Thunderbolt Device Status"
-msgid "Authorized"
-msgstr "已認證"
-
-#: panels/thunderbolt/cc-bolt-panel.c:169
-msgid ""
-"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
-msgstr "Thunderbolt 子系統 (boltd) 尚未安裝或未正確設定。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:425
-#: panels/thunderbolt/cc-bolt-panel.ui:157
-msgid "Allow direct access to devices such as docks and external GPUs."
-msgstr "允許直接存取裝置，例如 Dock 或外部 GPU。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:426
-msgid "Only USB and Display Port devices can attach."
-msgstr "只有 USB 與顯示埠裝置可以連接。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:461
-msgid ""
-"Thunderbolt could not be detected.\n"
-"Either the system lacks Thunderbolt support, it has been disabled in the "
-"BIOS or is set to an unsupported security level in the BIOS."
-msgstr ""
-"無法偵測到 Thunderbolt。\n"
-"可能是系統缺乏 Thunderbolt 支援，它可能在 BIOS 被停用或設定至不支援的安全級"
-"別。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:505
-msgid "Thunderbolt support has been disabled in the BIOS."
-msgstr "Thunderbolt 支援在 BIOS 中被停用。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:509
-msgid "Thunderbolt security level could not be determined."
-msgstr "無法確定 Thunderbolt 安全性等級。"
-
-#: panels/thunderbolt/cc-bolt-panel.c:614
-#, c-format
-msgid "Error switching direct mode: %s"
-msgstr "切換直接模式時發生問題：%s"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "不支援 Thunderbolt"
 
 #: panels/thunderbolt/cc-bolt-panel.ui:103
-msgid "No Thunderbolt Support"
-msgstr "無 Thunderbolt 支援"
-
-#: panels/thunderbolt/cc-bolt-panel.ui:104
 msgid "Could not connect to the thunderbolt subsystem."
-msgstr "無法連接 thunderbolt 子系統。"
+msgstr "無法連接 Thunderbolt 子系統。"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:153
+#: panels/thunderbolt/cc-bolt-panel.ui:152
 msgid "Direct Access"
 msgstr "直接存取"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:225
-msgid "Pending Devices"
-msgstr "待處理裝置"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "允許直接存取裝置，例如擴充塢或外接顯示卡。"
 
-#: panels/thunderbolt/cc-bolt-panel.ui:319
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "待處理的裝置"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
 msgid "No devices attached"
 msgstr "沒有連接任何裝置"
 
@@ -6212,7 +3726,6 @@ msgstr "Thunderbolt"
 msgid "Manage Thunderbolt devices"
 msgstr "管理 Thunderbolt 裝置"
 
-#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
 msgid "Thunderbolt;privacy;"
 msgstr "Thunderbolt;privacy;隱私;"
@@ -6221,27 +3734,27 @@ msgstr "Thunderbolt;privacy;隱私;"
 msgid "Cursor Blinking"
 msgstr "游標閃爍"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:29
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
 msgid "Cursor blinks in text fields."
-msgstr "游標在文字欄位中閃爍。"
+msgstr "讓文字欄中的鍵盤游標閃爍。"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:62
-#: panels/universal-access/cc-repeat-keys-dialog.ui:117
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
 msgid "Speed"
 msgstr "速度"
 
-#: panels/universal-access/cc-cursor-blinking-dialog.ui:84
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
 msgid "Cursor blinking speed"
 msgstr "游標閃爍速度"
 
 #: panels/universal-access/cc-cursor-size-dialog.ui:5
 msgid "Cursor Size"
-msgstr "游標大小"
+msgstr "滑鼠指標大小"
 
 #: panels/universal-access/cc-cursor-size-dialog.ui:22
 msgid ""
 "Cursor size can be combined with zoom to make it easier to see the cursor."
-msgstr "游標大小可以與縮放搭配以輕鬆看出游標位置。"
+msgstr "滑鼠指標大小可與縮放搭配以輕鬆看出其位置。"
 
 #: panels/universal-access/cc-pointing-dialog.ui:5
 msgid "Click Assist"
@@ -6249,17 +3762,17 @@ msgstr "點擊助理"
 
 #: panels/universal-access/cc-pointing-dialog.ui:38
 msgid "_Simulated Secondary Click"
-msgstr "模擬次要點擊(_S)"
+msgstr "模擬次要按鍵點擊(_S)"
 
 #: panels/universal-access/cc-pointing-dialog.ui:49
 msgid "Trigger a secondary click by holding down the primary button"
-msgstr "按住主要鍵時觸發次要點擊"
+msgstr "按住主要按鍵不放時觸發次要按鍵點擊"
 
 #: panels/universal-access/cc-pointing-dialog.ui:66
 #: panels/universal-access/cc-typing-dialog.ui:123
 #: panels/universal-access/cc-typing-dialog.ui:230
 msgid "A_cceptance delay:"
-msgstr "接受時間延遲(_C)："
+msgstr "觸發時間(_C)："
 
 #: panels/universal-access/cc-pointing-dialog.ui:78
 msgctxt "secondary click"
@@ -6268,7 +3781,7 @@ msgstr "短"
 
 #: panels/universal-access/cc-pointing-dialog.ui:90
 msgid "Secondary click delay"
-msgstr "第二次點擊延遲"
+msgstr "次要按鍵點擊延遲"
 
 #: panels/universal-access/cc-pointing-dialog.ui:97
 msgctxt "secondary click delay"
@@ -6277,15 +3790,15 @@ msgstr "長"
 
 #: panels/universal-access/cc-pointing-dialog.ui:126
 msgid "_Hover Click"
-msgstr "停駐即點擊(_H)"
+msgstr "懸停點擊(_H)"
 
 #: panels/universal-access/cc-pointing-dialog.ui:137
 msgid "Trigger a click when the pointer hovers"
-msgstr "當停止游標移動時觸發點擊"
+msgstr "滑鼠指標懸停在定點時觸發點擊"
 
 #: panels/universal-access/cc-pointing-dialog.ui:154
 msgid "D_elay:"
-msgstr "延遲(_E)："
+msgstr "懸停時間(_E)："
 
 #: panels/universal-access/cc-pointing-dialog.ui:166
 msgctxt "dwell click delay"
@@ -6299,7 +3812,7 @@ msgstr "長"
 
 #: panels/universal-access/cc-pointing-dialog.ui:201
 msgid "Motion _threshold:"
-msgstr "移動速度(_M)："
+msgstr "移動範圍閾值(_T)："
 
 #: panels/universal-access/cc-pointing-dialog.ui:213
 msgctxt "dwell click threshold"
@@ -6315,45 +3828,45 @@ msgstr "大"
 msgid "Repeat Keys"
 msgstr "重複按鍵"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:29
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
 msgid "Key presses repeat when key is held down."
-msgstr "當按下某鍵不放時重複輸出該字元。"
+msgstr "按下某鍵不放時重複輸出字元。"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:85
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
 msgid "Repeat keys delay"
 msgstr "按鍵重複延遲"
 
-#: panels/universal-access/cc-repeat-keys-dialog.ui:141
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
 msgid "Repeat keys speed"
 msgstr "按鍵重複速度"
 
 #: panels/universal-access/cc-typing-dialog.ui:4
 msgid "Typing Assist"
-msgstr "打字助理"
+msgstr "輸入助理"
 
 #: panels/universal-access/cc-typing-dialog.ui:41
 msgid "_Sticky Keys"
-msgstr "黏性特殊鍵(_S)"
+msgstr "相黏按鍵(_S)"
 
 #: panels/universal-access/cc-typing-dialog.ui:51
 msgid "Treats a sequence of modifier keys as a key combination"
-msgstr "將連續按的特殊鍵視為按鍵組合"
+msgstr "將連續按下的特殊按鍵視作按鍵組合"
 
 #: panels/universal-access/cc-typing-dialog.ui:63
 msgid "_Disable if two keys are pressed together"
-msgstr "如果同時按下任何兩鍵則停用(_D)"
+msgstr "若兩個按鍵同時按下則停用(_D)"
 
 #: panels/universal-access/cc-typing-dialog.ui:71
 msgid "Beep when a _modifier key is pressed"
-msgstr "當按下特殊按鍵時發出聲響(_M)"
+msgstr "特殊鍵按下時發出聲響(_M)"
 
 #: panels/universal-access/cc-typing-dialog.ui:96
 msgid "S_low Keys"
-msgstr "重複按鍵(_L)"
+msgstr "遲緩按鍵(_L)"
 
 #: panels/universal-access/cc-typing-dialog.ui:106
 msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr "在按鍵被按下到它被接受之間置入延遲"
+msgstr "按鍵按下後需停留片刻再放開才會被傳送"
 
 #: panels/universal-access/cc-typing-dialog.ui:135
 msgctxt "slow keys delay"
@@ -6362,7 +3875,7 @@ msgstr "短"
 
 #: panels/universal-access/cc-typing-dialog.ui:147
 msgid "Slow keys typing delay"
-msgstr "降低按鍵輸入延遲"
+msgstr "遲緩按鍵觸發時間長度"
 
 #: panels/universal-access/cc-typing-dialog.ui:154
 msgctxt "slow keys delay"
@@ -6371,24 +3884,24 @@ msgstr "長"
 
 #: panels/universal-access/cc-typing-dialog.ui:166
 msgid "Beep when a key is pr_essed"
-msgstr "當按下按鍵時發出聲響(_E)"
+msgstr "按鍵按下時發出聲響(_E)"
 
 #: panels/universal-access/cc-typing-dialog.ui:173
 msgid "Beep when a key is _accepted"
-msgstr "當接受按鍵動作時發出聲響(_A)"
+msgstr "按鍵被接受時發出聲響(_A)"
 
 #: panels/universal-access/cc-typing-dialog.ui:180
 #: panels/universal-access/cc-typing-dialog.ui:273
 msgid "Beep when a key is _rejected"
-msgstr "當拒絕按鍵動作則發出聲響(_R)"
+msgstr "按鍵被拒絕時發出聲響(_R)"
 
 #: panels/universal-access/cc-typing-dialog.ui:203
 msgid "_Bounce Keys"
-msgstr "反彈鍵(_B)"
+msgstr "反彈按鍵(_B)"
 
 #: panels/universal-access/cc-typing-dialog.ui:213
 msgid "Ignores fast duplicate keypresses"
-msgstr "忽略快速重複按鍵"
+msgstr "忽略對按鍵快速重複按下的動作"
 
 #: panels/universal-access/cc-typing-dialog.ui:242
 msgctxt "bounce keys delay"
@@ -6397,57 +3910,24 @@ msgstr "短"
 
 #: panels/universal-access/cc-typing-dialog.ui:254
 msgid "Bounce keys typing delay"
-msgstr "反彈鍵輸入延遲"
+msgstr "反彈按鍵觸發時間長度"
 
 #: panels/universal-access/cc-typing-dialog.ui:261
 msgctxt "bounce keys delay"
 msgid "Long"
 msgstr "長"
 
-#: panels/universal-access/cc-typing-dialog.ui:326
+#: panels/universal-access/cc-typing-dialog.ui:335
 msgid "_Enable by Keyboard"
-msgstr "由鍵盤啟用(_E)"
+msgstr "透過鍵盤啟用(_E)"
 
-#: panels/universal-access/cc-typing-dialog.ui:336
+#: panels/universal-access/cc-typing-dialog.ui:345
 msgid "Turn accessibility features on and off using the keyboard"
-msgstr "以鍵盤開啟與關閉無障礙功能"
-
-#. translators: the labels will read:
-#. * Cursor Size: Default
-#: panels/universal-access/cc-ua-panel.c:356
-msgctxt "cursor size"
-msgid "Default"
-msgstr "預設值"
-
-#: panels/universal-access/cc-ua-panel.c:359
-msgctxt "cursor size"
-msgid "Medium"
-msgstr "中"
-
-#: panels/universal-access/cc-ua-panel.c:362
-msgctxt "cursor size"
-msgid "Large"
-msgstr "大"
-
-#: panels/universal-access/cc-ua-panel.c:365
-msgctxt "cursor size"
-msgid "Larger"
-msgstr "較大"
-
-#: panels/universal-access/cc-ua-panel.c:368
-msgctxt "cursor size"
-msgid "Largest"
-msgstr "最大"
-
-#: panels/universal-access/cc-ua-panel.c:372
-#, c-format
-msgid "%d pixel"
-msgid_plural "%d pixels"
-msgstr[0] "%d 像素"
+msgstr "使用鍵盤開啟與關閉無障礙功能"
 
 #: panels/universal-access/cc-ua-panel.ui:17
 msgid "_Always Show Accessibility Menu"
-msgstr "永遠顯示無障礙存取選單(_A)"
+msgstr "永遠顯示無障礙輔助選單(_A)"
 
 #: panels/universal-access/cc-ua-panel.ui:31
 msgid "Seeing"
@@ -6471,19 +3951,19 @@ msgstr "螢幕閱讀器(_R)"
 
 #: panels/universal-access/cc-ua-panel.ui:71
 msgid "The screen reader reads displayed text as you move the focus."
-msgstr "螢幕閱讀器能在您移動焦點時讀出顯示的文字。"
+msgstr "螢幕閱讀器能朗讀您所指向的文字。"
 
 #: panels/universal-access/cc-ua-panel.ui:83
 msgid "_Sound Keys"
-msgstr "聲音按鍵(_S)"
+msgstr "按鍵聲音(_S)"
 
 #: panels/universal-access/cc-ua-panel.ui:84
 msgid "Beep when Num Lock or Caps Lock are turned on or off."
-msgstr "當 Num Lock 或 Caps Lock 開啟時發出聲響。"
+msgstr "開啟或關閉 Num Lock 與 Caps Lock 時發出聲響提示。"
 
 #: panels/universal-access/cc-ua-panel.ui:96
 msgid "C_ursor Size"
-msgstr "游標大小(_U)"
+msgstr "滑鼠指標大小(_U)"
 
 #: panels/universal-access/cc-ua-panel.ui:116
 #: panels/universal-access/cc-zoom-options-dialog.ui:82
@@ -6497,7 +3977,7 @@ msgstr "聽覺"
 #: panels/universal-access/cc-ua-panel.ui:141
 #: panels/universal-access/cc-visual-alerts-dialog.ui:54
 msgid "_Visual Alerts"
-msgstr "視覺警示(_V)"
+msgstr "鈴響視覺化(_V)"
 
 #: panels/universal-access/cc-ua-panel.ui:166
 msgid "Screen _Keyboard"
@@ -6505,7 +3985,7 @@ msgstr "螢幕鍵盤(_K)"
 
 #: panels/universal-access/cc-ua-panel.ui:178
 msgid "R_epeat Keys"
-msgstr "重複鍵(_E)"
+msgstr "重複按鍵(_E)"
 
 #: panels/universal-access/cc-ua-panel.ui:198
 msgid "Cursor _Blinking"
@@ -6513,19 +3993,19 @@ msgstr "游標閃爍(_B)"
 
 #: panels/universal-access/cc-ua-panel.ui:218
 msgid "_Typing Assist (AccessX)"
-msgstr "打字助理 [AccessX](_T)"
+msgstr "輸入助理 (AccessX)(_T)"
 
 #: panels/universal-access/cc-ua-panel.ui:240
 msgid "Pointing &amp; Clicking"
-msgstr "指向與點選"
+msgstr "指向與點擊"
 
 #: panels/universal-access/cc-ua-panel.ui:243
 msgid "_Mouse Keys"
-msgstr "滑鼠按鍵(_M)"
+msgstr "滑鼠鍵(_M)"
 
 #: panels/universal-access/cc-ua-panel.ui:255
 msgid "_Locate Pointer"
-msgstr "定位印表機(_L)"
+msgstr "定位滑鼠指標(_L)"
 
 #: panels/universal-access/cc-ua-panel.ui:267
 msgid "_Click Assist"
@@ -6533,15 +4013,15 @@ msgstr "點擊助理(_C)"
 
 #: panels/universal-access/cc-ua-panel.ui:287
 msgid "_Double-Click Delay"
-msgstr "雙擊延遲(_D)"
+msgstr "點兩下的延遲時間(_D)"
 
 #: panels/universal-access/cc-ua-panel.ui:297
 msgid "Double-Click Delay"
-msgstr "雙擊延遲"
+msgstr "滑鼠按兩下的速度"
 
 #: panels/universal-access/cc-visual-alerts-dialog.ui:5
 msgid "Visual Alerts"
-msgstr "視覺警示"
+msgstr "鈴響視覺化"
 
 #: panels/universal-access/cc-visual-alerts-dialog.ui:14
 msgid "_Test flash"
@@ -6549,7 +4029,7 @@ msgstr "測試閃動(_T)"
 
 #: panels/universal-access/cc-visual-alerts-dialog.ui:38
 msgid "Use a visual indication when an alert sound occurs."
-msgstr "當警示音效發出時使用視覺化的指示。"
+msgstr "發出鈴響時使用視覺化指示。"
 
 #: panels/universal-access/cc-visual-alerts-dialog.ui:74
 msgid "Flash the entire _screen"
@@ -6557,36 +4037,11 @@ msgstr "閃動整個螢幕(_S)"
 
 #: panels/universal-access/cc-visual-alerts-dialog.ui:86
 msgid "Flash the entire _window"
-msgstr "閃動整個視窗(_W)"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:306
-msgctxt "Distance"
-msgid "Short"
-msgstr "短"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:307
-msgctxt "Distance"
-msgid "¼ Screen"
-msgstr "¼ 螢幕"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:308
-msgctxt "Distance"
-msgid "½ Screen"
-msgstr "½ 螢幕"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:309
-msgctxt "Distance"
-msgid "¾ Screen"
-msgstr "¾ 螢幕"
-
-#: panels/universal-access/cc-zoom-options-dialog.c:310
-msgctxt "Distance"
-msgid "Long"
-msgstr "長"
+msgstr "閃動目前視窗(_W)"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:40
 msgid "Full Screen"
-msgstr "全螢幕"
+msgstr "整個螢幕"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:45
 msgid "Top Half"
@@ -6598,19 +4053,19 @@ msgstr "下半部"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:55
 msgid "Left Half"
-msgstr "左半"
+msgstr "左半部"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:60
 msgid "Right Half"
-msgstr "右半"
+msgstr "右半部"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:68
 msgid "Zoom Options"
-msgstr "放大鏡選項"
+msgstr "縮放選項"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:119
 msgid "_Magnification:"
-msgstr "放大率(_M)："
+msgstr "縮放倍率(_M)："
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:146
 msgid "Magnifier Position:"
@@ -6618,27 +4073,27 @@ msgstr "放大鏡位置："
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:163
 msgid "_Follow mouse cursor"
-msgstr "跟隨滑鼠遊標(_F)"
+msgstr "跟隨滑鼠指標(_F)"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:174
 msgid "_Screen part:"
-msgstr "螢幕部分(_S)："
+msgstr "螢幕範圍(_S)："
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:208
 msgid "Magnifier _extends outside of screen"
-msgstr "放大鏡延伸到螢幕外(_E)"
+msgstr "放大鏡延伸至螢幕外(_E)"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:215
 msgid "_Keep magnifier cursor centered"
-msgstr "保持放大鏡游標置中(_K)"
+msgstr "放大鏡指標保持置中(_K)"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:223
 msgid "Magnifier cursor _pushes contents around"
-msgstr "放大鏡游標將內容推到周圍(_P)"
+msgstr "放大鏡指標移動至四周時推動內容(_P)"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:231
 msgid "Magnifier cursor moves with _contents"
-msgstr "放大鏡游標隨內容移動(_C)"
+msgstr "放大鏡指標隨內容移動(_C)"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:247
 msgid "Magnifier"
@@ -6650,7 +4105,7 @@ msgstr "十字準星(_C)："
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:284
 msgid "_Overlaps mouse cursor"
-msgstr "重疊滑鼠遊標(_O)"
+msgstr "與滑鼠指標重疊(_O)"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:306
 msgid "_Thickness:"
@@ -6704,12 +4159,12 @@ msgstr "色彩(_L)"
 #: panels/universal-access/cc-zoom-options-dialog.ui:538
 msgctxt "universal access, color"
 msgid "None"
-msgstr "沒有"
+msgstr "黑白"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:556
 msgctxt "universal access, color"
 msgid "Full"
-msgstr "完全"
+msgstr "彩色"
 
 #: panels/universal-access/cc-zoom-options-dialog.ui:588
 msgctxt "universal access, brightness"
@@ -6737,9 +4192,8 @@ msgstr "色彩效果"
 
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
 msgid "Make it easier to see, hear, type, point and click"
-msgstr "讓電腦更容易看、聽、輸入、指向與點按"
+msgstr "讓您的電腦更容易閱覽、聆聽、輸入、指向與點擊"
 
-#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
@@ -6754,114 +4208,6 @@ msgstr ""
 "大小;相黏;遲緩;反彈;滑鼠;雙擊;兩下;點按;延遲;助理;輔助;重複;閃動;游標;音效;"
 "大;高;速度;視覺;聽覺;音訊;音樂;輸入;動畫;"
 
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:55
-msgctxt "purge_files"
-msgid "1 hour"
-msgstr "1 小時"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:58
-msgctxt "purge_files"
-msgid "1 day"
-msgstr "1 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:61
-msgctxt "purge_files"
-msgid "2 days"
-msgstr "2 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:64
-msgctxt "purge_files"
-msgid "3 days"
-msgstr "3 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:67
-msgctxt "purge_files"
-msgid "4 days"
-msgstr "4 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:70
-msgctxt "purge_files"
-msgid "5 days"
-msgstr "5 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:73
-msgctxt "purge_files"
-msgid "6 days"
-msgstr "6 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:76
-msgctxt "purge_files"
-msgid "7 days"
-msgstr "7 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:79
-msgctxt "purge_files"
-msgid "14 days"
-msgstr "14 天"
-
-#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
-#: panels/usage/cc-usage-panel.c:82
-msgctxt "purge_files"
-msgid "30 days"
-msgstr "30 天"
-
-#: panels/usage/cc-usage-panel.c:180
-msgid "Empty all items from Trash?"
-msgstr "要清除垃圾桶中所有的項目？"
-
-#: panels/usage/cc-usage-panel.c:181
-msgid "All items in the Trash will be permanently deleted."
-msgstr "所有在垃圾桶中的項目會永遠刪除。"
-
-#: panels/usage/cc-usage-panel.c:182
-msgid "_Empty Trash"
-msgstr "清理垃圾桶(_E)"
-
-#: panels/usage/cc-usage-panel.c:218
-msgid "Delete all the temporary files?"
-msgstr "刪除所有暫存檔案？"
-
-#: panels/usage/cc-usage-panel.c:219
-msgid "All the temporary files will be permanently deleted."
-msgstr "所有的暫存檔案會永遠刪除。"
-
-#: panels/usage/cc-usage-panel.c:220
-msgid "_Purge Temporary Files"
-msgstr "清理暫存檔案(_P)"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:247
-msgctxt "retain_history"
-msgid "1 day"
-msgstr "1 天"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:250
-msgctxt "retain_history"
-msgid "7 days"
-msgstr "7 天"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:253
-msgctxt "retain_history"
-msgid "30 days"
-msgstr "30 天"
-
-#. Translators: Option for "File History Duration" in "File History" group
-#: panels/usage/cc-usage-panel.c:256
-msgctxt "retain_history"
-msgid "Forever"
-msgstr "永遠"
-
 #: panels/usage/cc-usage-panel.ui:9
 msgid "File History"
 msgstr "檔案歷史記錄"
@@ -6872,8 +4218,8 @@ msgid ""
 "shared between applications, and makes it easier to find files that you "
 "might want to use."
 msgstr ""
-"檔案歷史記錄會保留您用過檔案的記錄。這個資訊會與應用程式共用，且會讓尋找可能"
-"想用的檔案變簡單。"
+"檔案歷史記錄會紀錄下您所使用過的檔案。該資訊會與其他應用程式分享，方便您找尋"
+"可能會需要的檔案。"
 
 #: panels/usage/cc-usage-panel.ui:13
 msgid "File H_istory"
@@ -6895,19 +4241,21 @@ msgstr "垃圾桶與暫存檔"
 msgid ""
 "Trash and temporary files can sometimes include personal or sensitive "
 "information. Automatically deleting them can help to protect privacy."
-msgstr "垃圾及暫存檔有時候可能會有個人或敏感資料。自動刪除會協助保障隱私權。"
+msgstr ""
+"垃圾桶與暫存檔中的資料可能涉及個人資料或敏感資料。自動定期清理能保障您的隱"
+"私。"
 
 #: panels/usage/cc-usage-panel.ui:67
 msgid "Automatically Delete _Trash Content"
-msgstr "自動刪除垃圾桶的內容(_T)"
+msgstr "自動清理垃圾桶(_T)"
 
 #: panels/usage/cc-usage-panel.ui:79
 msgid "Automatically Delete Temporary _Files"
-msgstr "自動刪除暫存檔案(_F)"
+msgstr "自動清理暫存檔(_F)"
 
 #: panels/usage/cc-usage-panel.ui:91
 msgid "Automatically Delete _Period"
-msgstr "自動刪除週期(_P)"
+msgstr "自動清理週期(_P)"
 
 #: panels/usage/cc-usage-panel.ui:115
 msgid "_Empty Trash…"
@@ -6915,66 +4263,22 @@ msgstr "清理垃圾桶(_E)…"
 
 #: panels/usage/cc-usage-panel.ui:126
 msgid "_Delete Temporary Files…"
-msgstr "刪除暫存檔案(_D)…"
+msgstr "清理暫存檔(_D)…"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:3
 msgid "File History & Trash"
-msgstr "檔案歷程記錄與垃圾桶"
+msgstr "檔案歷史記錄與垃圾桶"
 
 #: panels/usage/gnome-usage-panel.desktop.in.in:4
 msgid "Don't leave traces"
-msgstr "不留下追蹤"
+msgstr "不留下可被追蹤的訊息"
 
-#: panels/user-accounts/cc-add-user-dialog.c:35
-msgid "Should match the web address of your login provider."
-msgstr "應符合您的登入提供者的網路位址。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:216
-msgid "Failed to add account"
-msgstr "無法加入到帳號"
-
-#: panels/user-accounts/cc-add-user-dialog.c:679
-#: panels/user-accounts/cc-password-dialog.c:260
-msgid "The passwords do not match."
-msgstr "密碼不相符。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:883
-#: panels/user-accounts/cc-add-user-dialog.c:922
-#: panels/user-accounts/cc-add-user-dialog.c:940
-msgid "Failed to register account"
-msgstr "無法註冊帳號"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1055
-msgid "No supported way to authenticate with this domain"
-msgstr "沒有支援這個網域核對的方式"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1119
-msgid "Failed to join domain"
-msgstr "無法加入網域"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1174
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
 msgid ""
-"That login name didn’t work.\n"
-"Please try again."
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
 msgstr ""
-"登入名稱沒有作用。\n"
-"請再試一次。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1181
-msgid ""
-"That login password didn’t work.\n"
-"Please try again."
-msgstr ""
-"登入密碼沒有作用。\n"
-"請再試一次。"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1189
-msgid "Failed to log into domain"
-msgstr "無法登入網域"
-
-#: panels/user-accounts/cc-add-user-dialog.c:1244
-msgid "Unable to find the domain. Maybe you misspelled it?"
-msgstr "找不到網域。也許您拼錯字？"
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"使用;最近;歷史;檔案;暫存檔;隱私權;垃圾桶;清除;保存;紀錄;追蹤;自動刪除;"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:15
 #: panels/user-accounts/data/join-dialog.ui:9
@@ -6990,45 +4294,41 @@ msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users. Parental controls cannot be applied to administrators."
 msgstr ""
-"管理員可以加入與移除其他使用者，並且可以改變所有使用者的設定值。家長控制無法"
-"適用於管理員。"
+"管理員可以加入與移除其他使用者，並能更改所有使用者的設定。家長控制不適用於管"
+"理員。"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:149
 msgid "User sets password on first login"
-msgstr "使用者第一次登入時要設定密碼"
+msgstr "使用者首次登入時要求設定密碼"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:161
 msgid "Set password now"
-msgstr "立刻設定密碼"
+msgstr "立即設定密碼"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:224
 msgid "Confirm"
-msgstr "確認"
+msgstr "確認密碼"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:278
 msgid "Enterprise Login"
 msgstr "企業登入"
 
 #: panels/user-accounts/cc-add-user-dialog.ui:279
-msgid "User accounts which are managed by a company or organisation."
-msgstr "受到由公司或組織管理的使用者帳號。"
+msgid "User accounts which are managed by a company or organization."
+msgstr "由公司或組織所管理的帳號。"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:385
+#: panels/user-accounts/cc-add-user-dialog.ui:388
 msgid "You are Offline"
 msgstr "您已離線"
 
-#: panels/user-accounts/cc-add-user-dialog.ui:386
+#: panels/user-accounts/cc-add-user-dialog.ui:389
 msgid ""
 "Enterprise login allows an existing centrally managed user account to be "
 "used on this device. You can also use this account to access company "
 "resources on the internet."
 msgstr ""
-"企業登入允許現有的集中管理式使用者帳號能用在這個裝置上。您也可以使用這個帳號"
-"來存取網際網路上的公司資源。"
-
-#: panels/user-accounts/cc-avatar-chooser.c:164
-msgid "Browse for more pictures"
-msgstr "瀏覽更多照片"
+"企業登入功能可以讓集中管理的帳號在此裝置上使用；您也能透過該帳號存取公司的網"
+"路資源。"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:32
 msgid "Select a File…"
@@ -7036,521 +4336,190 @@ msgstr "選擇檔案…"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:8
 msgid "Fingerprint Manager"
-msgstr "指紋管理員"
+msgstr "指紋管理器"
 
 #: panels/user-accounts/cc-fingerprint-dialog.ui:20
 msgid "Fingerprint"
 msgstr "指紋"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:88
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
 msgid "_No"
 msgstr "否(_N)"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:96
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
 msgid "_Yes"
 msgstr "是(_Y)"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:116
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
-msgstr "您是否要刪除您註冊的指紋？這將會停用指紋登入。"
+msgstr "確定要刪除先前所登錄的指紋嗎？刪除指紋會停用指紋登入。"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:172
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
 msgid "No fingerprint device"
 msgstr "沒有指紋裝置"
 
 #. Translators: This is the empty state page label which states that there are no devices ready.
-#: panels/user-accounts/cc-fingerprint-dialog.ui:187
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
 msgid "No Fingerprint device"
 msgstr "沒有指紋裝置"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:196
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
 msgid "Ensure the device is properly connected."
-msgstr "請確認裝置已適當連接。"
+msgstr "請確認裝置已確實連接。"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:204
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
 msgid "Fingerprint Device"
 msgstr "指紋裝置"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:213
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
 msgid "Choose the fingerprint device you want to configure"
-msgstr "請選擇您想要設定的指紋裝置"
+msgstr "請選擇欲設定的指紋裝置"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:243
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
 msgid "Fingerprint Login"
 msgstr "指紋登入"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:249
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
 msgid ""
 "Fingerprint login allows you to unlock and log into your computer with your "
 "finger"
-msgstr "指紋登入讓您可以用手指解鎖並登入電腦"
+msgstr "指紋登入能讓您透過手指來解鎖與登入電腦"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:276
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
 msgid "_Delete Fingerprints"
 msgstr "刪除指紋(_D)"
 
-#: panels/user-accounts/cc-fingerprint-dialog.ui:290
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
 msgid "Fingerprint Enroll"
-msgstr "指紋登錄"
+msgstr "登錄指紋"
 
-#: panels/user-accounts/cc-fingerprint-dialog.c:235
-msgid "the device needs to be claimed to perform this action"
-msgstr "需要索取裝置才能執行此動作"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:237
-msgid "the device is already claimed by another process"
-msgstr "該裝置已經被其他程序索取"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:239
-msgid "you do not have permission to perform the action"
-msgstr "您尚未取得執行該動作的授權"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:241
-msgid "no prints have been enrolled"
-msgstr "尚未有指紋登錄"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:250
-msgid "Failed to communicate with the device during enrollment"
-msgstr "在登錄期間無法與裝置溝通"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:254
-msgid "Failed to communicate with the fingerprint reader"
-msgstr "無法與指紋讀取器溝通"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:256
-msgid "Failed to communicate with the fingerprint daemon"
-msgstr "無法與指紋幕後程式溝通"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:539
-#, c-format
-msgid "Failed to list fingerprints: %s"
-msgstr "無法列出指紋：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:606
-#, c-format
-msgid "Failed to delete saved fingerprints: %s"
-msgstr "無法刪除儲存的指紋：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:637
-msgid "Left thumb"
-msgstr "左手姆指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:639
-msgid "Left middle finger"
-msgstr "左手中指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:641
-msgid "_Left index finger"
-msgstr "左手食指(_L)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:643
-msgid "Left ring finger"
-msgstr "左手無名指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:645
-msgid "Left little finger"
-msgstr "左手小指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:647
-msgid "Right thumb"
-msgstr "右手姆指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:649
-msgid "Right middle finger"
-msgstr "右手中指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:651
-msgid "_Right index finger"
-msgstr "右手食指(_R)"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:653
-msgid "Right ring finger"
-msgstr "右手無名指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:655
-msgid "Right little finger"
-msgstr "右手小指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:657
-msgid "Unknown Finger"
-msgstr "未知的手指"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:791
-msgctxt "Fingerprint enroll state"
-msgid "Complete"
-msgstr "完成"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:802
-msgid "Fingerprint device disconnected"
-msgstr "指紋裝置已中斷連接"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:808
-msgid "Fingerprint device storage is full"
-msgstr "指紋裝置儲存空間已滿"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:812
-msgid "Failed to enroll new fingerprint"
-msgstr "無法登錄新的指紋"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:843
-#, c-format
-msgid "Failed to start enrollment: %s"
-msgstr "無法啟動登錄：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:851
-msgctxt "Fingerprint enroll state"
-msgid "Failed to enroll new fingerprint"
-msgstr "無法登錄新的指紋"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:882
-#, c-format
-msgid "Failed to stop enrollment: %s"
-msgstr "無法停止登錄：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:928
-msgid ""
-"Repeatedly lift and place your finger on the reader to enroll your "
-"fingerprint"
-msgstr "請反複提起您的手指再重放到閱讀器上，以登錄您的指紋"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1047
-msgid "_Re-enroll this finger…"
-msgstr "重新登錄這隻手指(_R)…"
-
-#. TRANSLATORS: This is the label for the button to enroll a new finger
-#: panels/user-accounts/cc-fingerprint-dialog.c:1062
-msgid "Scan new fingerprint"
-msgstr "掃描新的指紋"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1100
-#, c-format
-msgid "Failed to release fingerprint device %s: %s"
-msgstr "無法釋放指紋裝置 %s：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1172
-msgctxt "Fingerprint enroll state"
-msgid "Problem Reading Device"
-msgstr "讀取裝置有問題"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1207
-#, c-format
-msgid "Failed to claim fingerprint device %s: %s"
-msgstr "無法索取指紋裝置 %s：%s"
-
-#: panels/user-accounts/cc-fingerprint-dialog.c:1358
-#, c-format
-msgid "Failed to get fingerprint devices: %s"
-msgstr "無法取得指紋裝置：%s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:71
-msgid "This Week"
-msgstr "本週"
-
-#: panels/user-accounts/cc-login-history-dialog.c:74
-msgid "Last Week"
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
 msgstr "上週"
 
-#. Translators: This is a date format string in the style of "Feb 18",
-#. shown as the first day of a week on login history dialog.
-#. Translators: This is a date format string in the style of "Feb 24",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:84
-#: panels/user-accounts/cc-login-history-dialog.c:88
-msgctxt "login history week label"
-msgid "%b %e"
-msgstr "%b%e日"
-
-#. Translators: This is a date format string in the style of "Feb 24, 2013",
-#. shown as the last day of a week on login history dialog.
-#: panels/user-accounts/cc-login-history-dialog.c:93
-msgctxt "login history week label"
-msgid "%b %e, %Y"
-msgstr "%Y年%b%e日"
-
-#. Translators: This indicates a week label on a login history.
-#. The first %s is the first day of a week, and the second %s the last day.
-#: panels/user-accounts/cc-login-history-dialog.c:98
-#, c-format
-msgctxt "login history week label"
-msgid "%s — %s"
-msgstr "%s — %s"
-
-#. Translators: This is a time format string in the style of "22:58".
-#. It indicates a login time which follows a date.
-#: panels/user-accounts/cc-login-history-dialog.c:179
-#: panels/user-accounts/cc-user-panel.c:712
-msgctxt "login date-time"
-msgid "%k:%M"
-msgstr "%k:%M"
-
-#. Translators: This indicates a login date-time.
-#. The first %s is a date, and the second %s a time.
-#: panels/user-accounts/cc-login-history-dialog.c:182
-#: panels/user-accounts/cc-user-panel.c:716
-#, c-format
-msgctxt "login date-time"
-msgid "%s, %s"
-msgstr "%s，%s"
-
-#: panels/user-accounts/cc-login-history-dialog.c:238
-msgid "Session Ended"
-msgstr "作業階段結束"
-
-#: panels/user-accounts/cc-login-history-dialog.c:244
-msgid "Session Started"
-msgstr "作業階段開始"
-
-#. Translators: This is the title of the "Account Activity" dialog.
-#. The %s is the user real name.
-#: panels/user-accounts/cc-login-history-dialog.c:339
-#, c-format
-msgid "%s — Account Activity"
-msgstr "%s — 帳號活動"
-
-#: panels/user-accounts/cc-password-dialog.c:133
-msgid "Please choose another password."
-msgstr "請選擇其他密碼。"
-
-#: panels/user-accounts/cc-password-dialog.c:142
-msgid "Please type your current password again."
-msgstr "請再次輸入您目前的密碼。"
-
-#: panels/user-accounts/cc-password-dialog.c:148
-msgid "Password could not be changed"
-msgstr "密碼無法變更"
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "下週"
 
 #: panels/user-accounts/cc-password-dialog.ui:4
 msgid "Change Password"
 msgstr "更改密碼"
 
-#: panels/user-accounts/cc-password-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:34
 msgid "Ch_ange"
-msgstr "改變(_A)"
+msgstr "更改(_A)"
 
-#: panels/user-accounts/cc-password-dialog.ui:51
+#: panels/user-accounts/cc-password-dialog.ui:53
 msgid "Current Password"
-msgstr "目前的密碼"
+msgstr "目前密碼"
 
-#: panels/user-accounts/cc-password-dialog.ui:76
+#: panels/user-accounts/cc-password-dialog.ui:68
 msgid "New Password"
 msgstr "新密碼"
 
-#: panels/user-accounts/cc-password-dialog.ui:121
+#: panels/user-accounts/cc-password-dialog.ui:99
 msgid "Confirm Password"
 msgstr "確認新密碼"
 
-#: panels/user-accounts/cc-password-dialog.ui:175
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "密碼不相符。"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
 msgid "Allow user to change their password on next login"
-msgstr "允許使用者在下次登入時改變他們的密碼"
+msgstr "允許使用者在下次登入時更改密碼"
 
-#: panels/user-accounts/cc-password-dialog.ui:186
+#: panels/user-accounts/cc-password-dialog.ui:165
 msgid "Set a password now"
-msgstr "立刻設定密碼"
-
-#: panels/user-accounts/cc-realm-manager.c:303
-msgid "Cannot automatically join this type of domain"
-msgstr "不能自動加入這個類型的網域"
-
-#: panels/user-accounts/cc-realm-manager.c:306
-msgid "No such domain or realm found"
-msgstr "找不到這個網域或領域名稱"
-
-#: panels/user-accounts/cc-realm-manager.c:712
-#: panels/user-accounts/cc-realm-manager.c:726
-#, c-format
-msgid "Cannot log in as %s at the %s domain"
-msgstr "不能以 %s 身分登入 %s 網域"
-
-#: panels/user-accounts/cc-realm-manager.c:718
-msgid "Invalid password, please try again"
-msgstr "密碼錯誤，請再試一次"
-
-#: panels/user-accounts/cc-realm-manager.c:731
-#, c-format
-msgid "Couldn’t connect to the %s domain: %s"
-msgstr "無法連接到 %s 網域：%s"
-
-#: panels/user-accounts/cc-user-panel.c:341
-msgid "Failed to delete user"
-msgstr "刪除使用者失敗"
-
-#: panels/user-accounts/cc-user-panel.c:398
-#: panels/user-accounts/cc-user-panel.c:453
-#: panels/user-accounts/cc-user-panel.c:499
-msgid "Failed to revoke remotely managed user"
-msgstr "註銷遠端管理的使用者失敗"
-
-#: panels/user-accounts/cc-user-panel.c:548
-msgid "You cannot delete your own account."
-msgstr "您不能刪除自己的帳號。"
-
-#: panels/user-accounts/cc-user-panel.c:557
-#, c-format
-msgid "%s is still logged in"
-msgstr "%s 仍在登入中"
-
-#: panels/user-accounts/cc-user-panel.c:561
-msgid ""
-"Deleting a user while they are logged in can leave the system in an "
-"inconsistent state."
-msgstr "在使用者登入期間刪除他會使系統處於不穩定的狀態。"
-
-#: panels/user-accounts/cc-user-panel.c:570
-#, c-format
-msgid "Do you want to keep %s’s files?"
-msgstr "您想要保留 %s 的檔案嗎？"
-
-#: panels/user-accounts/cc-user-panel.c:574
-msgid ""
-"It is possible to keep the home directory, mail spool and temporary files "
-"around when deleting a user account."
-msgstr ""
-"刪除使用者時，可以選擇保留家目錄、新進郵件 (mail spool) 與暫存檔案等資料。"
-
-#: panels/user-accounts/cc-user-panel.c:577
-msgid "_Delete Files"
-msgstr "刪除檔案(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:578
-msgid "_Keep Files"
-msgstr "保留檔案(_K)"
-
-#: panels/user-accounts/cc-user-panel.c:592
-#, c-format
-msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr "確定要註銷遠端管理的 %s 帳號？"
-
-#: panels/user-accounts/cc-user-panel.c:596
-msgid "_Delete"
-msgstr "刪除(_D)"
-
-#: panels/user-accounts/cc-user-panel.c:646
-msgctxt "Password mode"
-msgid "Account disabled"
-msgstr "帳號已停用"
-
-#: panels/user-accounts/cc-user-panel.c:654
-msgctxt "Password mode"
-msgid "To be set at next login"
-msgstr "在下次登入時設定"
-
-#: panels/user-accounts/cc-user-panel.c:657
-msgctxt "Password mode"
-msgid "None"
-msgstr "沒有"
-
-#: panels/user-accounts/cc-user-panel.c:700
-msgid "Logged in"
-msgstr "已登入"
-
-#. TRANSLATORS: Status of Parental Controls setup
-#: panels/user-accounts/cc-user-panel.c:787
-#: panels/user-accounts/cc-user-panel.c:876
-#: panels/wwan/cc-wwan-device-page.c:476
-msgid "Enabled"
-msgstr "已啟用"
-
-#: panels/user-accounts/cc-user-panel.c:1173
-msgid "Failed to contact the accounts service"
-msgstr "無法連接帳號服務"
-
-#: panels/user-accounts/cc-user-panel.c:1175
-msgid "Please make sure that the AccountService is installed and enabled."
-msgstr "請確定 AccountService 已經安裝並啟用。"
-
-#: panels/user-accounts/cc-user-panel.c:1197
-msgid "This panel must be unlocked to change this setting"
-msgstr "必須解除鎖定此面板才能變更設定"
-
-#: panels/user-accounts/cc-user-panel.c:1264
-msgid "Delete the selected user account"
-msgstr "刪除選取的使用者帳號"
-
-#: panels/user-accounts/cc-user-panel.c:1268
-#: panels/user-accounts/cc-user-panel.c:1377
-msgid ""
-"To delete the selected user account,\n"
-"click the * icon first"
-msgstr ""
-"要刪除選取的使用者帳號，\n"
-"請先點選 * 圖示"
-
-#: panels/user-accounts/cc-user-panel.c:1423
-msgid "Unlock to Add Users and Change Settings"
-msgstr "請解除鎖定以加入使用者與變更設定"
+msgstr "立即設定密碼"
 
 #: panels/user-accounts/cc-user-panel.ui:23
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
 msgstr "使用者"
 
-#: panels/user-accounts/cc-user-panel.ui:60
+#: panels/user-accounts/cc-user-panel.ui:63
 msgid "Your session needs to be restarted for changes to take effect"
-msgstr "您的作業階段需要重新啟動以讓變更生效"
+msgstr "您的作業階段需要重新啟動才能使更動生效"
 
-#: panels/user-accounts/cc-user-panel.ui:67
+#: panels/user-accounts/cc-user-panel.ui:70
 msgid "Restart Now"
-msgstr "立刻重新啟動"
+msgstr "立即重新啟動"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "關閉"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "編輯大頭貼"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "全名"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+msgid "Edit"
+msgstr "編輯"
 
 #. FIXME
-#: panels/user-accounts/cc-user-panel.ui:195
+#: panels/user-accounts/cc-user-panel.ui:202
 msgid "_Fingerprint Login"
 msgstr "指紋登入(_F)"
 
-#: panels/user-accounts/cc-user-panel.ui:218
+#: panels/user-accounts/cc-user-panel.ui:225
 msgid "A_utomatic Login"
 msgstr "自動登入(_U)"
 
-#: panels/user-accounts/cc-user-panel.ui:231
+#: panels/user-accounts/cc-user-panel.ui:238
 msgid "Account Activity"
 msgstr "帳號活動"
 
-#: panels/user-accounts/cc-user-panel.ui:259
+#: panels/user-accounts/cc-user-panel.ui:266
 msgid "_Administrator"
 msgstr "管理員(_A)"
 
-#: panels/user-accounts/cc-user-panel.ui:260
+#: panels/user-accounts/cc-user-panel.ui:267
 msgid ""
 "Administrators can add and remove other users, and can change settings for "
 "all users."
-msgstr "管理員可以加入與移除其他使用者，並且可以改變所有使用者的設定值。"
+msgstr "管理員可以加入與移除其他使用者，並可以更改所有使用者的設定值。"
 
-#: panels/user-accounts/cc-user-panel.ui:276
+#: panels/user-accounts/cc-user-panel.ui:283
 msgid "_Parental Controls"
 msgstr "家長控制(_P)"
 
-#: panels/user-accounts/cc-user-panel.ui:277
+#: panels/user-accounts/cc-user-panel.ui:284
 msgid "Open the Parental Controls application."
 msgstr "開啟家長控制應用程式。"
 
-#: panels/user-accounts/cc-user-panel.ui:328
+#: panels/user-accounts/cc-user-panel.ui:335
 msgid "Remove User…"
 msgstr "移除使用者…"
 
-#: panels/user-accounts/cc-user-panel.ui:340
+#: panels/user-accounts/cc-user-panel.ui:347
 msgid "Other Users"
 msgstr "其他使用者"
 
-#: panels/user-accounts/cc-user-panel.ui:353
+#: panels/user-accounts/cc-user-panel.ui:360
 msgid "Add User…"
 msgstr "加入使用者…"
 
 #. Translators: This is the empty state page label which states that there are no users to show in the panel.
-#: panels/user-accounts/cc-user-panel.ui:381
+#: panels/user-accounts/cc-user-panel.ui:388
 msgid "No Users Found"
 msgstr "找不到使用者"
 
-#: panels/user-accounts/cc-user-panel.ui:390
+#: panels/user-accounts/cc-user-panel.ui:397
 msgid "Unlock to add a user account."
-msgstr "解除使用者帳號的新增鎖定。"
+msgstr "解鎖以新增使用者帳號。"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
-msgstr "加入或移除使用者並改變您的密碼"
+msgstr "加入或移除使用者及更改您的密碼"
 
-#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
@@ -7576,9 +4545,8 @@ msgid ""
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here."
 msgstr ""
-"為了使用企業登入，這個電腦需要\n"
-"加入網域。請網路管理員在這裡\n"
-"輸入網域密碼。"
+"欲使用企業登入，需將該電腦登錄至網域中。\n"
+"請通知您的網路管理員於此輸入網域密碼。"
 
 #: panels/user-accounts/data/join-dialog.ui:112
 msgid "Administrator _Name"
@@ -7594,187 +4562,24 @@ msgstr "管理使用者帳號"
 
 #: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
-msgstr "改變使用者資料需要核對"
+msgstr "更改使用者資料需要核對身分"
 
-#: panels/user-accounts/pw-utils.c:94
-msgctxt "Password hint"
-msgid "The new password needs to be different from the old one."
-msgstr "新的密碼需要與舊密碼有所差異。"
-
-#: panels/user-accounts/pw-utils.c:96
-msgctxt "Password hint"
-msgid "Try changing some letters and numbers."
-msgstr "試著改變某些文字與數字。"
-
-#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
-msgctxt "Password hint"
-msgid "Try changing the password a bit more."
-msgstr "試著更常改變密碼。"
-
-#: panels/user-accounts/pw-utils.c:100
-msgctxt "Password hint"
-msgid "A password without your user name would be stronger."
-msgstr "不含您的使用者名稱的密碼強度會比較高。"
-
-#: panels/user-accounts/pw-utils.c:102
-msgctxt "Password hint"
-msgid "Try to avoid using your name in the password."
-msgstr "試著避免在密碼中使用您的姓名。"
-
-#: panels/user-accounts/pw-utils.c:104
-msgctxt "Password hint"
-msgid "Try to avoid some of the words included in the password."
-msgstr "試著避免在密碼中包含某些文字。"
-
-#: panels/user-accounts/pw-utils.c:108
-msgctxt "Password hint"
-msgid "Try to avoid common words."
-msgstr "試著避免常見的文字。"
-
-#: panels/user-accounts/pw-utils.c:110
-msgctxt "Password hint"
-msgid "Try to avoid reordering existing words."
-msgstr "試著避免重新排序現有的文字。"
-
-#: panels/user-accounts/pw-utils.c:112
-msgctxt "Password hint"
-msgid "Try to use more numbers."
-msgstr "試著使用更多數字。"
-
-#: panels/user-accounts/pw-utils.c:114
-msgctxt "Password hint"
-msgid "Try to use more uppercase letters."
-msgstr "試著使用更多大寫字母。"
-
-#: panels/user-accounts/pw-utils.c:116
-msgctxt "Password hint"
-msgid "Try to use more lowercase letters."
-msgstr "試著使用更多小寫字母。"
-
-#: panels/user-accounts/pw-utils.c:118
-msgctxt "Password hint"
-msgid "Try to use more special characters, like punctuation."
-msgstr "試著使用更多特殊字元，像是標點符號。"
-
-#: panels/user-accounts/pw-utils.c:120
-msgctxt "Password hint"
-msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr "試著使用混合字母、數字與標點符號。"
-
-#: panels/user-accounts/pw-utils.c:122
-msgctxt "Password hint"
-msgid "Try to avoid repeating the same character."
-msgstr "試著避免同樣字元。"
-
-#: panels/user-accounts/pw-utils.c:124
-msgctxt "Password hint"
-msgid ""
-"Try to avoid repeating the same type of character: you need to mix up "
-"letters, numbers and punctuation."
-msgstr "試著避免重複同樣類型的字元：您需要混合字母、數字與標點符號。"
-
-#: panels/user-accounts/pw-utils.c:126
-msgctxt "Password hint"
-msgid "Try to avoid sequences like 1234 or abcd."
-msgstr "試著避免像 1234 或 abcd 等順序。"
-
-#: panels/user-accounts/pw-utils.c:128
-msgctxt "Password hint"
-msgid ""
-"Password needs to be longer. Try to add more letters, numbers and "
-"punctuation."
-msgstr "密碼需要更長。試著加入更多字母、數字與標點符號。"
-
-#: panels/user-accounts/pw-utils.c:130
-msgctxt "Password hint"
-msgid "Mix uppercase and lowercase and try to use a number or two."
-msgstr "混合大寫與小寫字元並嘗試使用一到兩個數字。"
-
-#: panels/user-accounts/pw-utils.c:132
-msgctxt "Password hint"
-msgid ""
-"Adding more letters, numbers and punctuation will make the password stronger."
-msgstr "加入更多字母、數字與標點符號會讓密碼更強。"
-
-#: panels/user-accounts/run-passwd.c:413
-msgid "Authentication failed"
-msgstr "核對失敗"
-
-#: panels/user-accounts/run-passwd.c:492
-#, c-format
-msgid "The new password is too short"
-msgstr "新的密碼太短"
-
-#: panels/user-accounts/run-passwd.c:498
-#, c-format
-msgid "The new password is too simple"
-msgstr "新的密碼太簡單"
-
-#: panels/user-accounts/run-passwd.c:504
-#, c-format
-msgid "The old and new passwords are too similar"
-msgstr "舊密碼與新密碼太相似"
-
-#: panels/user-accounts/run-passwd.c:507
-#, c-format
-msgid "The new password has already been used recently."
-msgstr "新的密碼已在最近使用過。"
-
-#: panels/user-accounts/run-passwd.c:510
-#, c-format
-msgid "The new password must contain numeric or special characters"
-msgstr "新的密碼必須包含數字或特殊字元"
-
-#: panels/user-accounts/run-passwd.c:514
-#, c-format
-msgid "The old and new passwords are the same"
-msgstr "舊密碼與新密碼相同"
-
-#: panels/user-accounts/run-passwd.c:518
-#, c-format
-msgid "Your password has been changed since you initially authenticated!"
-msgstr "您的密碼在第一次通過身分核對後已經更改！"
-
-#: panels/user-accounts/run-passwd.c:522
-#, c-format
-msgid "The new password does not contain enough different characters"
-msgstr "新的密碼並未包含足夠的不同字元"
-
-#: panels/user-accounts/run-passwd.c:526
-#: panels/wwan/cc-wwan-errors-private.h:72
-#, c-format
-msgid "Unknown error"
-msgstr "不明的錯誤"
-
-#: panels/user-accounts/user-utils.c:144
-msgid ""
-"The username should usually only consist of lower case letters from a-z, "
-"digits and the following characters: - _"
-msgstr "使用者名稱通常只能有小寫英文字母 a 到 z、數字與下述字元：- _"
-
-#: panels/user-accounts/user-utils.c:148
-msgid "Sorry, that user name isn’t available. Please try another."
-msgstr "抱歉，使用者名稱無法使用。請嘗試另一個。"
-
-#: panels/user-accounts/user-utils.c:190
-msgid "The username is too long."
-msgstr "使用者名稱太長。"
-
-#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-page.ui:38
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
 msgid "Map Buttons"
-msgstr "對應按鈕"
+msgstr "按鍵功能"
 
 #: panels/wacom/button-mapping.ui:26
 msgid "Map buttons to functions"
-msgstr "功能對應按鈕"
+msgstr "指定按鍵的功能"
 
 #: panels/wacom/button-mapping.ui:51
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
 msgstr ""
-"若要編輯快捷鍵，請選擇「傳送按鍵」動作，按下鍵盤捷徑按鈕與新的按鍵組合，或以 "
-"Backspace 鍵來清除。"
+"要編輯快捷鍵，請選擇「傳送按鍵」，並按下欲傳送的鍵盤快捷鍵與新按鍵；或按 "
+"Backspace 來清除。"
 
 #: panels/wacom/button-mapping.ui:66
 msgid "_Close"
@@ -7784,53 +4589,16 @@ msgstr "關閉(_C)"
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
-msgstr "請點一下出現在螢幕上的目標標記來校準繪圖板。"
+msgstr "請點選螢幕上所出現的目標標記來校準繪圖板。"
 
 #: panels/wacom/calibrator/calibrator.ui:63
 msgid "Mis-click detected, restarting…"
-msgstr "偵測到誤點，重新開始…"
+msgstr "偵測到錯誤的點擊，正在重新開始…"
 
-#: panels/wacom/cc-wacom-button-row.c:244
-#, c-format
-msgid "Button %d"
-msgstr "按鈕 %d"
-
-#: panels/wacom/cc-wacom-button-row.h:34
-msgctxt "Wacom action-type"
-msgid "Application defined"
-msgstr "定義的程式"
-
-#: panels/wacom/cc-wacom-button-row.h:35
-msgctxt "Wacom action-type"
-msgid "Send Keystroke"
-msgstr "傳送按鍵"
-
-#: panels/wacom/cc-wacom-button-row.h:36
-msgctxt "Wacom action-type"
-msgid "Switch Monitor"
-msgstr "切換監視器"
-
-#: panels/wacom/cc-wacom-button-row.h:37
-msgctxt "Wacom action-type"
-msgid "Show On-Screen Help"
-msgstr "顯示螢幕求助"
-
-#: panels/wacom/cc-wacom-device.c:431
-msgid "Tablet mounted on laptop panel"
-msgstr "繪圖板裝載至筆電面板上"
-
-#: panels/wacom/cc-wacom-device.c:433
-msgid "Tablet mounted on external display"
-msgstr "繪圖板裝載至外接顯示器上"
-
-#: panels/wacom/cc-wacom-device.c:435
-msgid "External tablet device"
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
 msgstr "外接繪圖板裝置"
-
-#. All displays item
-#: panels/wacom/cc-wacom-page.c:608
-msgid "All Displays"
-msgstr "所有顯示器"
 
 #: panels/wacom/cc-wacom-page.ui:16
 msgid "Tablet Mode"
@@ -7838,30 +4606,30 @@ msgstr "繪圖板模式"
 
 #: panels/wacom/cc-wacom-page.ui:17
 msgid "Use absolute positioning for the pen"
-msgstr "繪圖筆使用絕對定位"
-
-#: panels/wacom/cc-wacom-page.ui:27
-msgid "Left Hand Orientation"
-msgstr "左手方向"
+msgstr "數位筆使用絕對定位"
 
 #: panels/wacom/cc-wacom-page.ui:28
-msgid "Tablet and Express Keys™ are rotated for left hand use"
-msgstr "繪圖板與 Express Keys™ 可旋轉給左手使用"
+msgid "Left Hand Orientation"
+msgstr "左手操作"
 
-#: panels/wacom/cc-wacom-page.ui:56
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "將繪圖板與 Express Keys™ 旋轉至對側以適用於左手"
+
+#: panels/wacom/cc-wacom-page.ui:58
 msgctxt "display setting"
 msgid "Map to Monitor"
-msgstr "對應至顯示器"
+msgstr "顯示器鏡射"
 
-#: panels/wacom/cc-wacom-page.ui:62
+#: panels/wacom/cc-wacom-page.ui:64
 msgid "Keep Aspect Ratio"
 msgstr "維持寬長比"
 
-#: panels/wacom/cc-wacom-page.ui:63
+#: panels/wacom/cc-wacom-page.ui:65
 msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
-msgstr "僅使用繪圖板表面的一部分來維持螢幕寬長比"
+msgstr "僅使用部分的繪圖板面積並以相同寬長比鏡射至顯示器"
 
-#: panels/wacom/cc-wacom-page.ui:73
+#: panels/wacom/cc-wacom-page.ui:76
 msgid "Calibrate"
 msgstr "校準"
 
@@ -7871,11 +4639,11 @@ msgstr "未偵測到繪圖板"
 
 #: panels/wacom/cc-wacom-panel.ui:57
 msgid "Please plug in or turn on your Wacom tablet."
-msgstr "請插入或開啟您的 Wacom 繪圖板。"
+msgstr "請將 Wacom 繪圖板接上或開啟。"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:16
 msgid "Tip Pressure Feel"
-msgstr "點選壓力感應"
+msgstr "筆尖壓力感應"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:21
 #: panels/wacom/cc-wacom-stylus-page.ui:82
@@ -7884,7 +4652,7 @@ msgstr "輕"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:35
 msgid "Stylus tip pressure"
-msgstr "觸控筆尖壓力"
+msgstr "數位筆壓力感應的輕重"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:41
 #: panels/wacom/cc-wacom-stylus-page.ui:102
@@ -7894,17 +4662,17 @@ msgstr "重"
 #: panels/wacom/cc-wacom-stylus-page.ui:54
 msgctxt "display setting"
 msgid "Button 1"
-msgstr "按鈕 1"
+msgstr "按鍵 1"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:62
 msgctxt "display setting"
 msgid "Button 2"
-msgstr "按鈕 2"
+msgstr "按鍵 2"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:70
 msgctxt "display setting"
 msgid "Button 3"
-msgstr "按鈕 3"
+msgstr "按鍵 3"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:77
 msgid "Eraser Pressure Feel"
@@ -7914,37 +4682,17 @@ msgstr "橡皮擦壓力感應"
 msgid "Eraser pressure"
 msgstr "橡皮擦壓力"
 
-#: panels/wacom/cc-wacom-stylus-page.ui:133
-msgid "Default"
-msgstr "預設值"
-
 #: panels/wacom/cc-wacom-stylus-page.ui:134
 msgid "Middle Mouse Button Click"
-msgstr "滑鼠中鍵點擊"
+msgstr "滑鼠中鍵"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:135
 msgid "Right Mouse Button Click"
-msgstr "滑鼠右鍵點擊"
+msgstr "滑鼠右鍵"
 
 #: panels/wacom/cc-wacom-stylus-page.ui:137
 msgid "Forward"
 msgstr "下一頁"
-
-#: panels/wacom/cc-wacom-tool.c:321
-msgid "Airbrush stylus with pressure, tilt, and integrated slider"
-msgstr "Airbrush 觸控筆搭配壓感、傾斜偵測與整合式滑鈕"
-
-#: panels/wacom/cc-wacom-tool.c:323
-msgid "Airbrush stylus with pressure, tilt, and rotation"
-msgstr "Airbrush 觸控筆搭配壓感、傾斜偵測與旋轉"
-
-#: panels/wacom/cc-wacom-tool.c:325
-msgid "Standard stylus with pressure and tilt"
-msgstr "標準觸控筆搭配壓感與傾斜偵測"
-
-#: panels/wacom/cc-wacom-tool.c:327
-msgid "Standard stylus with pressure"
-msgstr "標準觸控筆搭配壓感"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:3
 msgid "Wacom Tablet"
@@ -7952,57 +4700,98 @@ msgstr "Wacom 繪圖板"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr "設定繪圖板的按鈕對映與調整觸控筆的靈敏度"
+msgstr "設定繪圖板的按鍵對映與調整數位筆的壓力感應力度"
 
-#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:19
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
 msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;繪圖板;橡皮擦;滑鼠;"
 
-#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
-msgid "New shortcut…"
-msgstr "新增快捷鍵…"
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+msgid "Center New Windows"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:82
+#, fuzzy
+msgid "Resize with Secondary Click"
+msgstr "模擬次要按鍵點擊(_S)"
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "軟體 (Windows)"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "碳粉不足"
+
+#: panels/windows/cc-windows-panel.ui:96
+#, fuzzy
+msgid "Secondary-Click"
+msgstr "次要"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+#, fuzzy
+msgid "Windows"
+msgstr "軟體 (Windows)"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+#, fuzzy
+msgid "Manage preferences for windows and windows titlebar"
+msgstr "管理生產力與多工作業的偏好設定"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
 
 #: panels/wwan/cc-wwan-apn-dialog.ui:8
 msgid "Access Points"
 msgstr "存取點"
 
-#: panels/wwan/cc-wwan-apn-dialog.ui:122
-#| msgid "VPN"
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "加入"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "儲存(_S)"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
 msgid "APN"
 msgstr "APN"
-
-#: panels/wwan/cc-wwan-data.c:542
-msgid "Operation Cancelled"
-msgstr "操作已取消"
-
-#: panels/wwan/cc-wwan-data.c:545
-msgid "<b>Error:</b> Access denied changing settings"
-msgstr "<b>錯誤：</b>變更設定時拒絕存取"
-
-#: panels/wwan/cc-wwan-data.c:548
-msgid "<b>Error:</b> Mobile Equipment Error"
-msgstr "<b>錯誤：</b> 行動裝置錯誤"
-
-#: panels/wwan/cc-wwan-details-dialog.c:80
-msgid "Not Registered"
-msgstr "未註冊"
-
-#: panels/wwan/cc-wwan-details-dialog.c:84
-msgid "Registered"
-msgstr "已註冊"
-
-#: panels/wwan/cc-wwan-details-dialog.c:88
-msgid "Roaming"
-msgstr "漫遊中"
-
-#: panels/wwan/cc-wwan-details-dialog.c:92
-msgid "Searching"
-msgstr "搜尋中"
-
-#: panels/wwan/cc-wwan-details-dialog.c:96
-msgid "Denied"
-msgstr "拒絕服務"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:5
 msgid "Modem Details"
@@ -8026,146 +4815,35 @@ msgstr "網路狀態"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:122
 msgid "Own Number"
-msgstr "擁有號碼"
+msgstr "擁有者號碼"
 
 #: panels/wwan/cc-wwan-details-dialog.ui:151
 msgid "Device Details"
 msgstr "裝置詳細資料"
 
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "製造商"
+
 #: panels/wwan/cc-wwan-details-dialog.ui:210
 msgid "Firmware Version"
 msgstr "韌體版本"
-
-#: panels/wwan/cc-wwan-device.c:988
-msgid "2G Only"
-msgstr "僅 2G"
-
-#: panels/wwan/cc-wwan-device.c:991
-msgid "3G Only"
-msgstr "僅 3G"
-
-#: panels/wwan/cc-wwan-device.c:994
-msgid "4G Only"
-msgstr "僅 4G"
-
-#: panels/wwan/cc-wwan-device.c:1003
-msgid "2G, 3G, 4G (Preferred)"
-msgstr "2G、3G、4G (偏好)"
-
-#: panels/wwan/cc-wwan-device.c:1005
-msgid "2G, 3G (Preferred), 4G"
-msgstr "2G、3G (偏好)、4G"
-
-#: panels/wwan/cc-wwan-device.c:1007
-msgid "2G (Preferred), 3G, 4G"
-msgstr "2G (偏好)、3G、4G"
-
-#: panels/wwan/cc-wwan-device.c:1009
-msgid "2G, 3G, 4G"
-msgstr "2G、3G、4G"
-
-#: panels/wwan/cc-wwan-device.c:1015
-msgid "3G, 4G (Preferred)"
-msgstr "3G、4G (偏好)"
-
-#: panels/wwan/cc-wwan-device.c:1017
-msgid "3G (Preferred), 4G"
-msgstr "3G (偏好)、4G"
-
-#: panels/wwan/cc-wwan-device.c:1019
-msgid "3G, 4G"
-msgstr "3G、4G"
-
-#: panels/wwan/cc-wwan-device.c:1025
-msgid "2G, 4G (Preferred)"
-msgstr "2G、4G (偏好)"
-
-#: panels/wwan/cc-wwan-device.c:1027
-msgid "2G (Preferred), 4G"
-msgstr "2G (偏好)、4G"
-
-#: panels/wwan/cc-wwan-device.c:1029
-msgid "2G, 4G"
-msgstr "2G、4G"
-
-#: panels/wwan/cc-wwan-device.c:1035
-msgid "2G, 3G (Preferred)"
-msgstr "2G、3G (偏好)"
-
-#: panels/wwan/cc-wwan-device.c:1037
-msgid "2G (Preferred), 3G"
-msgstr "2G (偏好)、3G"
-
-#: panels/wwan/cc-wwan-device.c:1039
-msgid "2G, 3G"
-msgstr "2G、3G"
-
-#: panels/wwan/cc-wwan-device.c:1043
-msgctxt "Network mode"
-msgid "Unknown"
-msgstr "不明"
-
-#: panels/wwan/cc-wwan-device-page.c:187
-msgid "Unlock SIM card"
-msgstr "解鎖 SIM 卡"
-
-#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
-msgid "Unlock"
-msgstr "解鎖"
-
-#: panels/wwan/cc-wwan-device-page.c:193
-#, c-format
-msgid "Please provide PIN code for SIM %d"
-msgstr "請提供 SIM %d 的 PIN 碼"
-
-#: panels/wwan/cc-wwan-device-page.c:194
-msgid "Enter PIN to unlock your SIM card"
-msgstr "請輸入 PIN 碼解鎖您的 SIM 卡"
-
-#: panels/wwan/cc-wwan-device-page.c:198
-#, c-format
-msgid "Please provide PUK code for SIM %d"
-msgstr "請為 SIM %d 提供 PUK 碼"
-
-#: panels/wwan/cc-wwan-device-page.c:199
-msgid "Enter PUK to unlock your SIM card"
-msgstr "請輸入 PUK 碼來解鎖您的 SIM 卡"
 
 #: panels/wwan/cc-wwan-device-page.c:217
 #, c-format
 msgid "Wrong password entered. You have %1$u try left"
 msgid_plural "Wrong password entered. You have %1$u tries left"
-msgstr[0] "密碼輸入錯誤。您還有 %1$u 次嘗試"
+msgstr[0] "密碼輸入錯誤。您還有 %1$u 次嘗試機會"
 
 #: panels/wwan/cc-wwan-device-page.c:220
 #, c-format
 msgid "You have %u try left"
 msgid_plural "You have %u tries left"
-msgstr[0] "您還有 %u 次嘗試"
-
-#: panels/wwan/cc-wwan-device-page.c:225
-msgid "Wrong password entered."
-msgstr "密碼輸入錯誤。"
-
-#: panels/wwan/cc-wwan-device-page.c:270
-msgid "PUK code should be an 8 digit number"
-msgstr "PUK 碼應該有 8 個數字"
-
-#: panels/wwan/cc-wwan-device-page.c:294
-msgid "Enter New PIN"
-msgstr "輸入新的 PIN 碼"
-
-#: panels/wwan/cc-wwan-device-page.c:298
-msgid "PIN code should be a 4-8 digit number"
-msgstr "PIN 碼應該是 4-8 個數字"
-
-#: panels/wwan/cc-wwan-device-page.c:316
-msgid "Unlocking…"
-msgstr "解鎖中…"
+msgstr[0] "您還有 %u 次嘗試機會"
 
 #: panels/wwan/cc-wwan-device-page.ui:18
 msgid "No SIM"
-msgstr "沒有 SIM"
+msgstr "沒有 SIM 卡"
 
 #: panels/wwan/cc-wwan-device-page.ui:19
 msgid "Insert a SIM card to use this modem"
@@ -8181,7 +4859,7 @@ msgstr "行動數據(_M)"
 
 #: panels/wwan/cc-wwan-device-page.ui:78
 msgid "Access data using mobile network"
-msgstr "使用行動網路存取數據連線"
+msgstr "使用行動網路存取網路數據"
 
 #: panels/wwan/cc-wwan-device-page.ui:88
 msgid "_Data Roaming"
@@ -8209,179 +4887,79 @@ msgstr "存取點名稱(_A)"
 
 #: panels/wwan/cc-wwan-device-page.ui:155
 msgid "_SIM Lock"
-msgstr "_SIM 鎖定"
+msgstr "_SIM 卡鎖定"
 
 #: panels/wwan/cc-wwan-device-page.ui:156
 msgid "Lock SIM with PIN"
-msgstr "以 PIN 碼鎖定 SIM"
+msgstr "以 PIN 碼鎖定 SIM 卡"
 
 #: panels/wwan/cc-wwan-device-page.ui:165
 msgid "M_odem Details"
-msgstr "數據機細節(_O)"
-
-#: panels/wwan/cc-wwan-errors-private.h:40
-msgid "Phone failure"
-msgstr "手機失敗"
-
-#: panels/wwan/cc-wwan-errors-private.h:41
-msgid "No connection to phone"
-msgstr "無法與手機連線"
-
-#: panels/wwan/cc-wwan-errors-private.h:43
-msgid "Operation not allowed"
-msgstr "不允許操作"
-
-#: panels/wwan/cc-wwan-errors-private.h:44
-msgid "Operation not supported"
-msgstr "不支援操作"
-
-#: panels/wwan/cc-wwan-errors-private.h:48
-msgid "SIM not inserted"
-msgstr "SIM 卡尚未插入"
-
-#: panels/wwan/cc-wwan-errors-private.h:49
-msgid "SIM PIN required"
-msgstr "需要 SIM PIN 碼"
-
-#: panels/wwan/cc-wwan-errors-private.h:50
-msgid "SIM PUK required"
-msgstr "需要 SIM PUK 碼"
-
-#: panels/wwan/cc-wwan-errors-private.h:51
-msgid "SIM failure"
-msgstr "SIM 失敗"
-
-#: panels/wwan/cc-wwan-errors-private.h:52
-msgid "SIM busy"
-msgstr "SIM 忙碌"
-
-#: panels/wwan/cc-wwan-errors-private.h:54
-msgid "Incorrect password"
-msgstr "密碼不正確"
-
-#: panels/wwan/cc-wwan-errors-private.h:55
-msgid "SIM PIN2 required"
-msgstr "需要 SIM PIN2 碼"
-
-#: panels/wwan/cc-wwan-errors-private.h:56
-msgid "SIM PUK2 required"
-msgstr "需要 SIM PUK2 碼"
-
-#: panels/wwan/cc-wwan-errors-private.h:59
-msgid "Not found"
-msgstr "找不到"
-
-#: panels/wwan/cc-wwan-errors-private.h:61
-msgid "No network service"
-msgstr "沒有網路服務"
-
-#: panels/wwan/cc-wwan-errors-private.h:62
-msgid "Network timeout"
-msgstr "網路逾時"
-
-#: panels/wwan/cc-wwan-errors-private.h:75
-msgid "GPRS services not allowed"
-msgstr "未允許 GPRS 服務"
-
-#: panels/wwan/cc-wwan-errors-private.h:78
-msgid "Roaming not allowed in this location area"
-msgstr "此地理位置區域不允許漫遊"
-
-#: panels/wwan/cc-wwan-errors-private.h:82
-msgid "Unspecified GPRS error"
-msgstr "不明確的 GPRS 錯誤"
-
-#: panels/wwan/cc-wwan-errors-private.h:91
-msgid "Action Cancelled"
-msgstr "動作已取消"
-
-#: panels/wwan/cc-wwan-errors-private.h:94
-msgid "Access denied"
-msgstr "存取已拒絕"
-
-#: panels/wwan/cc-wwan-errors-private.h:103
-msgid "Unknown Error"
-msgstr "不明的錯誤"
+msgstr "數據機詳細資訊(_O)"
 
 #: panels/wwan/cc-wwan-mode-dialog.ui:5
 msgid "Network Mode"
 msgstr "網路模式"
 
-#: panels/wwan/cc-wwan-mode-dialog.ui:39
-#: panels/wwan/cc-wwan-network-dialog.ui:146
-#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
-msgid "_Set"
-msgstr "設定(_S)"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:41 panels/wwan/cc-wwan-panel.ui:41
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:90
-msgid "Close"
-msgstr "關閉"
-
-#: panels/wwan/cc-wwan-network-dialog.ui:69
+#: panels/wwan/cc-wwan-network-dialog.ui:38
 msgid "_Automatic"
 msgstr "自動(_A)"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:84
+#: panels/wwan/cc-wwan-network-dialog.ui:53
 msgid "Choose Network"
 msgstr "選擇網路"
 
-#: panels/wwan/cc-wwan-network-dialog.ui:99
+#: panels/wwan/cc-wwan-network-dialog.ui:68
 msgid "Refresh Network Providers"
-msgstr "重新整理網路供應商"
-
-#: panels/wwan/cc-wwan-panel.c:417 panels/wwan/cc-wwan-panel.c:448
-#, c-format
-msgid "SIM %d"
-msgstr "SIM %d"
+msgstr "重新整理網路提供者"
 
 #: panels/wwan/cc-wwan-panel.ui:10
 msgid "Enable Mobile Network"
 msgstr "啟用行動網路"
 
-#: panels/wwan/cc-wwan-panel.ui:94
+#: panels/wwan/cc-wwan-panel.ui:61
 msgid "No WWAN Adapter Found"
 msgstr "找不到 WWAN 網卡"
 
-#: panels/wwan/cc-wwan-panel.ui:104
+#: panels/wwan/cc-wwan-panel.ui:71
 msgid "Make sure you have a Wireless Wan/Cellular device"
-msgstr "請確認您有無線 WAN 或巢格網路行動裝置"
+msgstr "請確認您有無線 WAN 網路或蜂巢式網路裝置"
 
-#: panels/wwan/cc-wwan-panel.ui:145
+#: panels/wwan/cc-wwan-panel.ui:112
 msgid "Wireless Wan is disabled when airplane mode is on"
-msgstr "開啟飛安模式時會停用無線 WAN 網路"
+msgstr "飛安模式開啟時會停無線 WAN 網路"
 
-#: panels/wwan/cc-wwan-panel.ui:153
+#: panels/wwan/cc-wwan-panel.ui:120
 msgid "_Turn off Airplane Mode"
 msgstr "關閉飛安模式(_T)"
 
-#: panels/wwan/cc-wwan-panel.ui:184
+#: panels/wwan/cc-wwan-panel.ui:151
 msgid "Data Connection"
-msgstr "數據資料連線"
+msgstr "數據連線"
 
-#: panels/wwan/cc-wwan-panel.ui:185
+#: panels/wwan/cc-wwan-panel.ui:152
 msgid "SIM card used for internet"
 msgstr "用於網際網路的 SIM 卡"
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
 msgid "SIM Lock"
-msgstr "SIM 鎖定"
+msgstr "SIM 卡鎖定"
 
 #: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
 msgid "_Next"
 msgstr "下一步(_N)"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:122
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
 msgid "_Lock SIM with PIN"
-msgstr "以 PIN 碼鎖定 SIM(_L)"
+msgstr "以 PIN 碼鎖定 SIM 卡(_L)"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:138
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
 msgid "Change PIN"
-msgstr "變更 PIN 碼"
+msgstr "更改 PIN 碼"
 
-#: panels/wwan/cc-wwan-sim-lock-dialog.ui:231
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
 msgid "Enter current PIN to change SIM lock settings"
-msgstr "輸入目前的 PIN 碼並更改 SIM 鎖定設定"
+msgstr "輸入目前的 PIN 碼以更改 SIM 卡鎖定的設定值"
 
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:3
 msgid "Mobile Network"
@@ -8391,10 +4969,11 @@ msgstr "行動網路"
 msgid "Configure Telephony and mobile data connections"
 msgstr "設定電話撥打與行動數據連線"
 
-#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wwan/gnome-wwan-panel.desktop.in.in:16
 msgid "cellular;wwan;telephony;sim;mobile;"
-msgstr "cellular;wwan;telephony;sim;mobile;行動數據;巢格網路;撥打電話;攜帶;"
+msgstr ""
+"cellular;wwan;telephony;sim;mobile;行動數據;蜂巢式網路;撥打電話;攜帶;行動網"
+"路;"
 
 #: shell/appdata/org.gnome.Settings.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
@@ -8408,37 +4987,13 @@ msgstr "《設定》是設定系統的主要介面。"
 msgid "The GNOME Project"
 msgstr "GNOME 專案"
 
-#: shell/cc-application.c:59
-msgid "Display version number"
-msgstr "顯示版本號碼"
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "設定值類別"
 
-#: shell/cc-application.c:60
-msgid "Enable verbose mode"
-msgstr "啟用詳細模式"
-
-#: shell/cc-application.c:61
-msgid "Search for the string"
-msgstr "搜尋字串"
-
-#: shell/cc-application.c:62
-msgid "List possible panel names and exit"
-msgstr "列出可能的面板名稱並結束"
-
-#: shell/cc-application.c:63
-msgid "Panel to display"
-msgstr "要顯示的面板"
-
-#: shell/cc-application.c:63
-msgid "[PANEL] [ARGUMENT…]"
-msgstr "[面板] [引數…]"
-
-#: shell/cc-panel-list.ui:39 shell/cc-window.c:242
+#: shell/cc-panel-list.ui:42
 msgid "Privacy"
 msgstr "隱私"
-
-#: shell/cc-panel-loader.c:301
-msgid "Available panels:"
-msgstr "可用的面板："
 
 #: shell/cc-window.ui:30
 msgid "All Settings"
@@ -8473,7 +5028,7 @@ msgstr "一般"
 #: shell/help-overlay.ui:20
 msgctxt "shortcut window"
 msgid "Quit"
-msgstr "結束"
+msgstr "退出"
 
 #: shell/help-overlay.ui:27 shell/help-overlay.ui:57
 msgctxt "shortcut window"
@@ -8488,29 +5043,27 @@ msgstr "面板"
 #: shell/help-overlay.ui:41 shell/help-overlay.ui:49
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
-msgstr "回到上一個面板"
+msgstr "返回到上一個面板"
 
 #: shell/help-overlay.ui:62
 msgctxt "shortcut window"
 msgid "Cancel search"
 msgstr "取消搜尋"
 
-#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: shell/org.gnome.Settings.desktop.in.in:17
 msgid "Preferences;Settings;"
 msgstr "Preferences;Settings;偏好設定;設定值;"
 
 #: shell/org.gnome.Settings.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
-msgstr "最後開啟的設定面板的識別碼"
+msgstr "最後開啟的設定面板識別碼"
 
 #: shell/org.gnome.Settings.gschema.xml:6
 msgid ""
 "The identifier for the last Settings panel to be opened. Unrecognised values "
 "will be ignored and the first panel in the list selected."
 msgstr ""
-"最後開啟的設定面板的識別碼。無法識別的值將會被忽略，且改選擇列表中的第一個面"
-"板。"
+"最後開啟的設定面板識別碼；無法識別的值會被忽略並改選擇列表中第一個面板。"
 
 #: shell/org.gnome.Settings.gschema.xml:13
 msgid "Show warning when running a development build of Settings"
@@ -8531,25 +5084,3172 @@ msgid ""
 "application window."
 msgstr "含有應用程式視窗初始寬度、高度與最大化狀態的元組。"
 
-#. translators:
-#. * The number of sound outputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1915
 #, c-format
 msgid "%u Output"
 msgid_plural "%u Outputs"
 msgstr[0] "%u 輸出"
 
-#. translators:
-#. * The number of sound inputs on a particular device
 #: subprojects/gvc/gvc-mixer-control.c:1925
 #, c-format
 msgid "%u Input"
 msgid_plural "%u Inputs"
 msgstr[0] "%u 輸入"
 
-#: subprojects/gvc/gvc-mixer-control.c:2876
-msgid "System Sounds"
-msgstr "系統音效"
+#~ msgid "System Bus"
+#~ msgstr "系統匯流排"
+
+#~ msgid "Full access"
+#~ msgstr "可以完全取用"
+
+#~ msgid "Session Bus"
+#~ msgstr "作業階段匯流排"
+
+#~ msgid "Full access to /dev"
+#~ msgstr "可以完全取用 /dev"
+
+#~ msgid "Has network access"
+#~ msgstr "可以取用網路"
+
+#~ msgid "Home"
+#~ msgstr "家目錄"
+
+#~ msgid "Read-only"
+#~ msgstr "僅能讀取"
+
+#~ msgid "File System"
+#~ msgstr "檔案系統"
+
+#~ msgid "Can change settings"
+#~ msgstr "可以更改設定值"
+
+#, c-format
+#~ msgid ""
+#~ "%s has the following permissions built-in. These cannot be altered. If "
+#~ "you are concerned about these permissions, consider removing this "
+#~ "application."
+#~ msgstr ""
+#~ "《%s》內建下列權限並且無法更改。若您對這些權限設定有疑慮，請考慮移除應用程"
+#~ "式。"
+
+#, c-format
+#~ msgid "%u file and link type that is opened by the app"
+#~ msgid_plural "%u file and link types that are opened by the app"
+#~ msgstr[0] "有 %u 種類型的檔案與連結使用這個應用程式開啟"
+
+#, c-format
+#~ msgid "<b>%s</b> is used to open the following types of files and links."
+#~ msgstr "《%s》用於開啟下列的檔案與連結類型。"
+
+#, c-format
+#~ msgid "%s of disk space used."
+#~ msgstr "已使用 %s 的磁碟空間。"
+
+#~ msgid "Select a picture"
+#~ msgstr "選取圖片"
+
+#~ msgid "_Open"
+#~ msgstr "開啟(_O)"
+
+#~ msgid "multiple sizes"
+#~ msgstr "多重尺寸"
+
+#, c-format
+#~ msgid "%d × %d"
+#~ msgstr "%d × %d"
+
+#~ msgid "No Desktop Background"
+#~ msgstr "無桌面背景"
+
+#~ msgid "Current background"
+#~ msgstr "目前的背景"
+
+#~ msgid "Place your calibration device over the square and press “Start”"
+#~ msgstr "將您的校準裝置放在方塊上方，並按下「開始」"
+
+#~ msgid ""
+#~ "Move your calibration device to the calibrate position and press "
+#~ "“Continue”"
+#~ msgstr "將您的校準裝置移至校準位置，並按下「繼續」"
+
+#~ msgid ""
+#~ "Move your calibration device to the surface position and press “Continue”"
+#~ msgstr "將您的校準裝置移至表面位置，並按下「繼續」"
+
+#~ msgid "Shut the laptop lid"
+#~ msgstr "請闔上筆記型電腦"
+
+#~ msgid "An internal error occurred that could not be recovered."
+#~ msgstr "發生內部的錯誤，無法還原。"
+
+#~ msgid "Tools required for calibration are not installed."
+#~ msgstr "校準所需的工具尚未安裝。"
+
+#~ msgid "The profile could not be generated."
+#~ msgstr "無法產生描述檔。"
+
+#~ msgid "The target whitepoint was not obtainable."
+#~ msgstr "無法取得目標白點。"
+
+#~ msgid "Complete!"
+#~ msgstr "完成！"
+
+#~ msgid "Calibration failed!"
+#~ msgstr "校準失敗！"
+
+#~ msgid "You can remove the calibration device."
+#~ msgstr "您可以移除校準裝置。"
+
+#~ msgid "Do not disturb the calibration device while in progress"
+#~ msgstr "校準過程中請勿干擾校準裝置"
+
+#~ msgid "Laptop Screen"
+#~ msgstr "筆記型電腦螢幕"
+
+#~ msgid "Built-in Webcam"
+#~ msgstr "內建的網路攝影機"
+
+#, c-format
+#~ msgid "%s Monitor"
+#~ msgstr "%s 顯示器"
+
+#, c-format
+#~ msgid "%s Scanner"
+#~ msgstr "%s 掃描器"
+
+#, c-format
+#~ msgid "%s Camera"
+#~ msgstr "%s 照相機"
+
+#, c-format
+#~ msgid "%s Printer"
+#~ msgstr "%s 印表機"
+
+#, c-format
+#~ msgid "%s Webcam"
+#~ msgstr "%s 網路攝影機"
+
+#, c-format
+#~ msgid "Enable color management for %s"
+#~ msgstr "啟用 %s 的色彩管理"
+
+#, c-format
+#~ msgid "Show color profiles for %s"
+#~ msgstr "顯示 %s 的色彩描述檔"
+
+#~ msgid "Not calibrated"
+#~ msgstr "尚未校準"
+
+#~ msgid "Default: "
+#~ msgstr "預設值："
+
+#~ msgid "Colorspace: "
+#~ msgstr "色彩空間："
+
+#~ msgid "Test profile: "
+#~ msgstr "測試用描述檔："
+
+#~ msgid "Select ICC Profile File"
+#~ msgstr "選擇 ICC 色彩描述檔"
+
+#~ msgid "_Import"
+#~ msgstr "匯入(_I)"
+
+#~ msgid "Supported ICC profiles"
+#~ msgstr "支援的 ICC 色彩描述檔"
+
+#~ msgid "All files"
+#~ msgstr "所有檔案"
+
+#~ msgid "Save Profile"
+#~ msgstr "儲存描述檔"
+
+#~ msgid "Create a color profile for the selected device"
+#~ msgstr "為所選的裝置建立色彩描述檔"
+
+#~ msgid ""
+#~ "The measuring instrument is not detected. Please check it is turned on "
+#~ "and correctly connected."
+#~ msgstr "未偵測到測量儀器，請檢查是否已開啟並正確連接。"
+
+#~ msgid "The measuring instrument does not support printer profiling."
+#~ msgstr "測量儀器不支援印表機分析。"
+
+#~ msgid "The device type is not currently supported."
+#~ msgstr "目前不支援這個裝置類型。"
+
+#~ msgid "Standard Space"
+#~ msgstr "標準色彩空間"
+
+#~ msgid "Test Profile"
+#~ msgstr "測試用描述檔"
+
+#~ msgctxt "Automatically generated profile"
+#~ msgid "Automatic"
+#~ msgstr "自動"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Low Quality"
+#~ msgstr "低品質"
+
+#~ msgctxt "Profile quality"
+#~ msgid "Medium Quality"
+#~ msgstr "中品質"
+
+#~ msgctxt "Profile quality"
+#~ msgid "High Quality"
+#~ msgstr "高品質"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default RGB"
+#~ msgstr "預設 RGB"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default CMYK"
+#~ msgstr "預設 CMYK"
+
+#~ msgctxt "Colorspace fallback"
+#~ msgid "Default Gray"
+#~ msgstr "預設灰階"
+
+#~ msgid "Vendor supplied factory calibration data"
+#~ msgstr "廠商提供的出廠校準資料"
+
+#~ msgid "Full-screen display correction not possible with this profile"
+#~ msgstr "這個描述檔無法使用全螢幕顯示校準"
+
+#~ msgid "This profile may no longer be accurate"
+#~ msgstr "這個描述檔可能不再準確"
+
+#~ msgid "Other…"
+#~ msgstr "其他…"
+
+#~ msgid "Unlock to Change Settings"
+#~ msgstr "解鎖以更改設定"
+
+#~ msgid "Today"
+#~ msgstr "今天"
+
+#~ msgid "Yesterday"
+#~ msgstr "昨天"
+
+#~ msgid "%b %e"
+#~ msgstr "%-m月%-e日"
+
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y年%-m月%-e日"
+
+#, c-format
+#~ msgid "%d hour"
+#~ msgid_plural "%d hours"
+#~ msgstr[0] "%d 小時"
+
+#, c-format
+#~ msgid "%d minute"
+#~ msgid_plural "%d minutes"
+#~ msgstr[0] "%d 分鐘"
+
+#, c-format
+#~ msgid "%d second"
+#~ msgid_plural "%d seconds"
+#~ msgstr[0] "%d 秒"
+
+#, c-format
+#~ msgctxt "hours minutes seconds"
+#~ msgid "%s %s %s"
+#~ msgstr "%s %s %s"
+
+#, c-format
+#~ msgctxt "hours minutes"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "hours"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#, c-format
+#~ msgctxt "minutes seconds"
+#~ msgid "%s %s"
+#~ msgstr "%s %s"
+
+#, c-format
+#~ msgctxt "minutes"
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgctxt "hotspot"
+#~ msgid "Hotspot"
+#~ msgstr "熱點"
+
+#~ msgid "24-hour"
+#~ msgstr "24 小時制"
+
+#~ msgid "AM / PM"
+#~ msgstr "12 小時制"
+
+#~ msgid "%e %B %Y, %l:%M %p"
+#~ msgstr "%Y年%-m月%-e日，%p %I:%M"
+
+#~ msgid "%e %B %Y, %R"
+#~ msgstr "%Y年%-m月%-e日，%R"
+
+#, c-format
+#~ msgctxt "timezone loc"
+#~ msgid "%s, %s"
+#~ msgstr "%s，%s"
+
+#, c-format
+#~ msgctxt "timezone desc"
+#~ msgid "%s (%s)"
+#~ msgstr "%s（%s）"
+
+#~ msgid "UTC%:::z"
+#~ msgstr "UTC%:::z"
+
+#~ msgid "%l:%M %p"
+#~ msgstr "%p %I:%M"
+
+#~ msgid "%R"
+#~ msgstr "%R"
+
+#, c-format
+#~ msgctxt "timezone map"
+#~ msgid "%s (%s)"
+#~ msgstr "%s (%s)"
+
+#, c-format
+#~ msgid ""
+#~ "Sending reports of technical problems helps us improve %s. Reports are "
+#~ "sent anonymously and are scrubbed of personal data. %s"
+#~ msgstr ""
+#~ "傳送技術問題報告有助於我們改進 %s。報告會以匿名方式傳送，並會抹除個人資"
+#~ "料。%s"
+
+#~ msgid "On"
+#~ msgstr "開啟"
+
+#~ msgid "Off"
+#~ msgstr "關閉"
+
+#~ msgid "Apply Changes?"
+#~ msgstr "要套用更動嗎？"
+
+#~ msgid "Changes Cannot be Applied"
+#~ msgstr "無法套用更動"
+
+#~ msgid "This could be due to hardware limitations."
+#~ msgstr "可能是硬體限制所致。"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape"
+#~ msgstr "橫向"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Right"
+#~ msgstr "直向右轉"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Portrait Left"
+#~ msgstr "直向左轉"
+
+#~ msgctxt "Display rotation"
+#~ msgid "Landscape (flipped)"
+#~ msgstr "橫向（翻轉）"
+
+#, c-format
+#~ msgid "%.2lf Hz"
+#~ msgstr "%.2lf Hz"
+
+#~ msgid "Secure Boot is Active"
+#~ msgstr "安全開機作用中"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on and is functioning correctly."
+#~ msgstr ""
+#~ "安全開機可防止惡意軟體在裝置啟動階段時悄悄載入。該功能目前為開啟狀態並且運"
+#~ "作正常。"
+
+#~ msgid "Secure Boot Has Problems"
+#~ msgstr "安全開機存在問題"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned on, but will not work due to having an "
+#~ "invalid key."
+#~ msgstr ""
+#~ "安全開機可防止惡意軟體在裝置啟動階段時悄悄載入。該功能目前為開啟狀態但無法"
+#~ "正常運作，原因為金鑰無效。"
+
+#~ msgid ""
+#~ "Secure boot problems can often be resolved from your computer's UEFI "
+#~ "firmware settings (BIOS) and your hardware manufacturer may provide "
+#~ "information on how to do this."
+#~ msgstr ""
+#~ "安全開機問題大多能透過電腦中的 UEFI (BIOS) 韌體設定來解決，您的硬體製造商"
+#~ "可能會提供解決問題的指引。"
+
+#~ msgid "For help, contact your hardware manufacturer or IT support provider."
+#~ msgstr "如需協助，請聯絡您的硬體製造商或 IT 技術人員。"
+
+#~ msgid "Secure Boot is Turned Off"
+#~ msgstr "安全開機已關閉"
+
+#~ msgid ""
+#~ "Secure boot prevents malicious software from being loaded when the device "
+#~ "starts. It is currently turned off."
+#~ msgstr ""
+#~ "安全開機可防止惡意軟體在裝置啟動階段時悄悄載入。該功能目前為關閉狀態。"
+
+#~ msgid ""
+#~ "Secure boot can often be turned on from your computer's UEFI firmware "
+#~ "settings (BIOS). For help, contact your hardware manufacturer or IT "
+#~ "support provider."
+#~ msgstr ""
+#~ "安全開機大多能透過電腦中的 UEFI (BIOS) 韌體設定來開啟。如需協助，請聯絡您"
+#~ "的硬體製造商或 IT 技術人員。"
+
+#~ msgid "Passed"
+#~ msgstr "測試成功"
+
+#~ msgid "Failed"
+#~ msgstr "測試失敗"
+
+#, c-format
+#~ msgid "Device conforms to HSI level %d"
+#~ msgstr "裝置所符合的 HSI 等級為 %d"
+
+#~ msgid "Security Level 0"
+#~ msgstr "安全性等級 0"
+
+#~ msgid ""
+#~ "This device has no protection against hardware security issues. This "
+#~ "could be because of a hardware or firmware configuration issue. It is "
+#~ "recommended to contact your IT support provider."
+#~ msgstr ""
+#~ "本裝置針對硬體安全性相關的問題缺乏防護。可能是硬體或韌體組態所造成的問題，"
+#~ "建議您聯絡 IT 技術人員。"
+
+#~ msgid "Security Level 1"
+#~ msgstr "安全性等級 1"
+
+#~ msgid ""
+#~ "This device has minimal protection against hardware security issues. This "
+#~ "is the lowest device security level and only provides protection against "
+#~ "simple security threats."
+#~ msgstr ""
+#~ "本裝置針對硬體安全性相關的問題僅提供最小防護。這意味著裝置的安全性等級為最"
+#~ "低等級，只能針對簡單的安全威脅提供防護。"
+
+#~ msgid "Security Level 2"
+#~ msgstr "安全性等級 2"
+
+#~ msgid ""
+#~ "This device has basic protection against hardware security issues. This "
+#~ "provides protection against some common security threats."
+#~ msgstr ""
+#~ "本裝置針對硬體安全性相關的問題提供基本防護。這意味著裝置能針對常見的安全威"
+#~ "脅提供防護。"
+
+#~ msgid "Security Level 3"
+#~ msgstr "安全性等級 3"
+
+#~ msgid ""
+#~ "This device has extended protection against hardware security issues. "
+#~ "This is the highest device security level and provides protection against "
+#~ "advanced security threats."
+#~ msgstr ""
+#~ "本裝置針對硬體安全性相關的問題具備延伸防護。這意味著裝置的安全性等級為最高"
+#~ "等級，能針對高階的安全威脅提供防護。"
+
+#~ msgid "Security levels are not available for this device."
+#~ msgstr "該裝置不適用安全性等級。"
+
+#~ msgid "Contact your hardware manufacturer for help with security updates."
+#~ msgstr "請聯絡您的硬體製造商以取得安全更新相關的支援訊息。"
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings, or by a support technician."
+#~ msgstr "該問題也許能透過裝置的 UEFI 韌體設定，或是交由 IT 技術人員來解決。"
+
+#~ msgid ""
+#~ "It might be possible to resolve this issue in the device’s UEFI firmware "
+#~ "settings."
+#~ msgstr "該問題也許能透過裝置的 UEFI 韌體設定來解決。"
+
+#~ msgid "It might be possible for a support technician to resolve this issue."
+#~ msgstr "該問題也許能透過 IT 技術人員來解決。"
+
+#~ msgid "Protected against malicious software when the device starts."
+#~ msgstr "裝置的啟動階段有針對惡意軟體採取防護措施。"
+
+#~ msgid "Secure Boot has Problems"
+#~ msgstr "安全開機存在問題"
+
+#~ msgid "Some protection when the device is started."
+#~ msgstr "裝置的啟動階段僅有部分防護措施。"
+
+#~ msgid "Secure Boot is Off"
+#~ msgstr "安全開機已關閉"
+
+#~ msgid "No protection when the device is started."
+#~ msgstr "裝置的啟動階段沒有任何防護措施。"
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in UEFI firmware settings, "
+#~ "an operating system configuration change, or because of malicious "
+#~ "software on this system."
+#~ msgstr ""
+#~ "該問題可能是由下列原因所導致：UEFI 韌體設定不正確、作業系統設定不正確，或"
+#~ "是系統遭植入惡意軟體。"
+
+#~ msgid ""
+#~ "This issue could have been caused by a change in the UEFI firmware "
+#~ "settings, or because of malicious software on this system."
+#~ msgstr ""
+#~ "該問題可能是由下列原因所導致：UEFI 韌體設定不正確或是系統遭植入惡意軟體。"
+
+#~ msgid ""
+#~ "This issue could have been caused by an operating system configuration "
+#~ "change, or because of malicious software on this system."
+#~ msgstr ""
+#~ "該問題可能是由下列原因所導致：作業系統設定不正確或是系統遭植入惡意軟體。"
+
+#~ msgid "Exposed to serious security threats."
+#~ msgstr "正暴露於嚴重的安全威脅之中。"
+
+#~ msgid "Limited protection against simple security threats."
+#~ msgstr "能針對簡單的安全威脅提供有限防護。"
+
+#~ msgid "Protected against common security threats."
+#~ msgstr "能針對常見的安全威脅提供防護。"
+
+#~ msgid "Protected against a wide range of security threats."
+#~ msgstr "能針對廣泛的安全威脅提供保護。"
+
+#~ msgid "Comprehensive Protection"
+#~ msgstr "全面性防護"
+
+#~ msgid "Firmware Write Protection"
+#~ msgstr "韌體寫入保護"
+
+#~ msgid "Firmware Write Protection Lock"
+#~ msgstr "韌體寫入保護鎖"
+
+#~ msgid "Firmware BIOS Region"
+#~ msgstr "韌體 BIOS 領域"
+
+#~ msgid "Firmware BIOS Descriptor"
+#~ msgstr "韌體 BIOS 描述元"
+
+#~ msgid "Pre-boot DMA Protection"
+#~ msgstr "預先開機 DMA 保護"
+
+#~ msgid "Intel BootGuard"
+#~ msgstr "Intel BootGuard"
+
+#~ msgid "Intel BootGuard Verified Boot"
+#~ msgstr "Intel BootGuard 驗證開機"
+
+#~ msgid "Intel BootGuard ACM Protected"
+#~ msgstr "Intel BootGuard ACM 保護"
+
+#~ msgid "Intel BootGuard Error Policy"
+#~ msgstr "Intel BootGuard 錯誤政策"
+
+#~ msgid "Intel BootGuard Fuse"
+#~ msgstr "Intel BootGuard Fuse"
+
+#~ msgid "Intel CET Enabled"
+#~ msgstr "Intel CET 已啟用"
+
+#~ msgid "Intel CET Active"
+#~ msgstr "Intel CET 作用中"
+
+#~ msgid "Intel SMAP"
+#~ msgstr "Intel SMAP"
+
+#~ msgid "Encrypted RAM"
+#~ msgstr "記憶體已加密"
+
+#~ msgid "IOMMU Protection"
+#~ msgstr "IOMMU 保護"
+
+#~ msgid "Linux Kernel Lockdown"
+#~ msgstr "Linux 核心鎖定"
+
+#~ msgid "Linux Kernel Verification"
+#~ msgstr "Linux 核心驗證"
+
+#~ msgid "Linux Swap"
+#~ msgstr "Linux 交換空間"
+
+#~ msgid "Suspend To RAM"
+#~ msgstr "暫停狀態"
+
+#~ msgid "Suspend To Idle"
+#~ msgstr "休眠狀態"
+
+#~ msgid "UEFI Platform Key"
+#~ msgstr "UEFI 平臺金鑰"
+
+#~ msgid "UEFI Secure Boot"
+#~ msgstr "UEFI 安全開機"
+
+#~ msgid "TPM Platform Configuration"
+#~ msgstr "TPM 平臺組態"
+
+#~ msgid "TPM Reconstruction"
+#~ msgstr "TPM 重構"
+
+#~ msgid "TPM v2.0"
+#~ msgstr "TPM 信賴平臺模組 v2.0"
+
+#~ msgid "Intel Management Engine Manufacturing Mode"
+#~ msgstr "Intel 管理引擎製造模式"
+
+#~ msgid "Intel Management Engine Override"
+#~ msgstr "Intel 管理引擎凌駕"
+
+#~ msgid "Intel Management Engine Version"
+#~ msgstr "Intel 管理引擎版本"
+
+#~ msgid "Firmware Updates"
+#~ msgstr "韌體更新"
+
+#~ msgid "Firmware Attestation"
+#~ msgstr "韌體核實"
+
+#~ msgid "Firmware Updater Verification"
+#~ msgstr "韌體更新器驗證"
+
+#~ msgid "Platform Debugging"
+#~ msgstr "平臺除錯"
+
+#~ msgid "Processor Security Checks"
+#~ msgstr "處理器安全性檢查"
+
+#~ msgid "AMD Rollback Protection"
+#~ msgstr "AMD 降版保護"
+
+#~ msgid "AMD Firmware Replay Protection"
+#~ msgstr "AMD 韌體重放保護"
+
+#~ msgid "AMD Firmware Write Protection"
+#~ msgstr "AMD 韌體寫入保護"
+
+#~ msgid "Fused Platform"
+#~ msgstr "融合平臺"
+
+#~ msgid "Valid"
+#~ msgstr "有效"
+
+#~ msgid "Not Valid"
+#~ msgstr "無效"
+
+#~ msgid "Not Enabled"
+#~ msgstr "尚未啟用"
+
+#~ msgid "Locked"
+#~ msgstr "已鎖定"
+
+#~ msgid "Not Locked"
+#~ msgstr "未鎖定"
+
+#~ msgid "Encrypted"
+#~ msgstr "已加密"
+
+#~ msgid "Not Encrypted"
+#~ msgstr "未加密"
+
+#~ msgid "Tainted"
+#~ msgstr "遭到污染"
+
+#~ msgid "Not Tainted"
+#~ msgstr "未遭污染"
+
+#~ msgid "Found"
+#~ msgstr "可以使用"
+
+#~ msgid "Not Found"
+#~ msgstr "無法使用"
+
+#~ msgid "Supported"
+#~ msgstr "支援"
+
+#~ msgid "Not Supported"
+#~ msgstr "未支援"
+
+#~ msgid "Unknown"
+#~ msgstr "不明"
+
+#, c-format
+#~ msgid "64-bit"
+#~ msgstr "64 位元"
+
+#, c-format
+#~ msgid "32-bit"
+#~ msgstr "32 位元"
+
+#~ msgid "X11"
+#~ msgstr "X11"
+
+#~ msgid "Wayland"
+#~ msgstr "Wayland"
+
+#~ msgctxt "Windowing system (Wayland, X11, or Unknown)"
+#~ msgid "Unknown"
+#~ msgstr "不明"
+
+#~ msgid "Not Available"
+#~ msgstr "無法取得"
+
+#~ msgid "System Logo"
+#~ msgstr "系統標誌"
+
+#~ msgid "No input sources found"
+#~ msgstr "找不到輸入來源"
+
+#~ msgctxt "Input Source"
+#~ msgid "Other"
+#~ msgstr "其他"
+
+#~ msgid "Custom Shortcuts"
+#~ msgstr "自訂快捷鍵"
+
+#~ msgid ""
+#~ "The alternate characters key can be used to enter additional characters. "
+#~ "These are sometimes printed as a third-option on your keyboard."
+#~ msgstr ""
+#~ "替代字元鍵可用於輸入額外的代用字元，這些字元通常是以第三選項印在您的鍵盤"
+#~ "上。"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Alt"
+#~ msgstr "左側 Alt 鍵"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Alt"
+#~ msgstr "右側 Alt 鍵"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Left Super"
+#~ msgstr "左側超級鍵"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Super"
+#~ msgstr "右側超級鍵"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu key"
+#~ msgstr "選單鍵"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Right Ctrl"
+#~ msgstr "右側 Ctrl 鍵"
+
+#~ msgid ""
+#~ "The compose key allows a wide variety of characters to be entered. To use "
+#~ "it, press compose then a sequence of characters.  For example, compose "
+#~ "key followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> "
+#~ "followed by <b>'</b> will enter <b>á</b>."
+#~ msgstr ""
+#~ "組合鍵能讓您輸入各式各樣的字元。若要使用此功能，請先按一下組合鍵，再輸入一"
+#~ "段字元順序。\n"
+#~ "舉例：先按一下組合鍵，再按 <b>C</b> 與 <b>o</b>能輸入 <b>©</b>；按下 "
+#~ "<b>a</b> 與 <b>'</b> 則能輸入 <b>á</b>。"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Caps Lock"
+#~ msgstr "Caps Lock 鍵"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Scroll Lock"
+#~ msgstr "Scroll Lock 鍵"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Print Screen"
+#~ msgstr "Print Screen 鍵"
+
+#, c-format
+#~ msgid ""
+#~ "Input sources can be switched using the %s keyboard shortcut.\n"
+#~ "This can be changed in the keyboard shortcut settings."
+#~ msgstr ""
+#~ "輸入來源可透過鍵盤快捷鍵 %s 切換。\n"
+#~ "欲修改快捷鍵可至「鍵盤快捷鍵」設定中修改。"
+
+#, c-format
+#~ msgid "%d modified"
+#~ msgid_plural "%d modified"
+#~ msgstr[0] "已修改 %d 個"
+
+#~ msgid "Reset All Shortcuts?"
+#~ msgstr "要重設所有快捷鍵嗎？"
+
+#~ msgid ""
+#~ "Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+#~ "undone."
+#~ msgstr "重設快捷鍵可能會影響您自訂的快捷鍵，且該動作不能還原。"
+
+#~ msgid "Reset All"
+#~ msgstr "重設全部"
+
+#, c-format
+#~ msgid ""
+#~ "%s is already being used for %s. If you replace it, %s will be disabled"
+#~ msgstr "%s 已被「%s」使用。若要取代，則「%s」會被停用"
+
+#~ msgid "Enter the new shortcut"
+#~ msgstr "輸入新的快捷鍵"
+
+#~ msgid "Set Custom Shortcut"
+#~ msgstr "設定自訂快捷鍵"
+
+#~ msgid "Set Shortcut"
+#~ msgstr "設定快捷鍵"
+
+#, c-format
+#~ msgid "Enter new shortcut to change %s."
+#~ msgstr "請輸入新的按鍵組合來更改「%s」快捷鍵。"
+
+#~ msgid "Add Custom Shortcut"
+#~ msgstr "加入自訂快捷鍵"
+
+#~ msgid "Two-finger Scrolling"
+#~ msgstr "兩指捲動"
+
+#~ msgid "Five clicks, GEGL time!"
+#~ msgstr "連按五下，GEGL 時間！"
+
+#~ msgid "Double click, primary button"
+#~ msgstr "按兩下（主要按鍵）"
+
+#~ msgid "Single click, primary button"
+#~ msgstr "按一下（主要按鍵）"
+
+#~ msgid "Double click, middle button"
+#~ msgstr "按兩下（中央按鍵）"
+
+#~ msgid "Single click, middle button"
+#~ msgstr "按一下（中央按鍵）"
+
+#~ msgid "Double click, secondary button"
+#~ msgstr "按兩下（次要按鍵）"
+
+#~ msgid "Single click, secondary button"
+#~ msgstr "按一下（次要按鍵）"
+
+#~ msgid "NetworkManager needs to be running."
+#~ msgstr "需要執行 NetworkManager。"
+
+#, c-format
+#~ msgctxt "Wi-Fi Connection"
+#~ msgid "%s (SSID: %s)"
+#~ msgstr "%s (SSID: %s)"
+
+#~ msgid "Insecure network (WEP)"
+#~ msgstr "不安全網路 (WEP)"
+
+#~ msgid "Secure network (WPA)"
+#~ msgstr "安全網路 (WPA)"
+
+#~ msgid "Secure network (WPA2)"
+#~ msgstr "安全網路 (WPA2)"
+
+#~ msgid "Secure network (WPA3)"
+#~ msgstr "安全網路 (WPA3)"
+
+#~ msgid "Secure network"
+#~ msgstr "安全網路"
+
+#, c-format
+#~ msgid ""
+#~ "Turning on the hotspot will disconnect from %s, and it will not be "
+#~ "possible to access the internet through Wi-Fi."
+#~ msgstr "開啟熱點會中斷與「%s」的連接，並且無法透過 Wi-Fi 使用網路。"
+
+#~ msgid "Must have a minimum of 8 characters"
+#~ msgstr "必須至少為 8 個字元"
+
+#~ msgid "Stop hotspot and disconnect any users?"
+#~ msgstr "要停止 Wi-Fi 熱點並中斷任何使用者的連接嗎？"
+
+#~ msgid "_Stop Hotspot"
+#~ msgstr "停止熱點(_S)"
+
+#~ msgid "Preserve"
+#~ msgstr "保留"
+
+#~ msgid "Permanent"
+#~ msgstr "永久"
+
+#~ msgid "Random"
+#~ msgstr "隨機"
+
+#~ msgid "Stable"
+#~ msgstr "穩定"
+
+#~ msgid ""
+#~ "The MAC address entered here will be used as hardware address for the "
+#~ "network device this connection is activated on. This feature is known as "
+#~ "MAC cloning or spoofing. Example: 00:11:22:33:44:55"
+#~ msgstr ""
+#~ "這裡輸入的 MAC 位址，會當作這個連線啟動所在的網路裝置的硬體位址。這個功能"
+#~ "也稱為 MAC 複製或欺騙。範例：00:11:22:33:44:55"
+
+#, c-format
+#~ msgid "Profile %d"
+#~ msgstr "設定檔 %d"
+
+#~ msgid "WEP"
+#~ msgstr "WEP"
+
+#~ msgid "WPA"
+#~ msgstr "WPA"
+
+#~ msgid "WPA3"
+#~ msgstr "WPA3"
+
+#~ msgid "Enhanced Open"
+#~ msgstr "Enhanced Open"
+
+#~ msgid "WPA2"
+#~ msgstr "WPA2"
+
+#~ msgid "Enterprise"
+#~ msgstr "企業版"
+
+#~ msgctxt "Wifi security"
+#~ msgid "None"
+#~ msgstr "沒有加密"
+
+#~ msgid "Never"
+#~ msgstr "從不使用"
+
+#, c-format
+#~ msgid "%d Mb/s (%1.1f GHz)"
+#~ msgstr "%d Mb/s (%1.1f GHz)"
+
+#, c-format
+#~ msgid "%d Mb/s"
+#~ msgstr "%d Mb/s"
+
+#~ msgid "2.4 GHz / 5 GHz"
+#~ msgstr "2.4 GHz / 5 GHz"
+
+#~ msgid "2.4 GHz"
+#~ msgstr "2.4 GHz"
+
+#~ msgid "5 GHz"
+#~ msgstr "5 GHz"
+
+#~ msgctxt "Signal strength"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Weak"
+#~ msgstr "太弱"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Ok"
+#~ msgstr "還行"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Good"
+#~ msgstr "良好"
+
+#~ msgctxt "Signal strength"
+#~ msgid "Excellent"
+#~ msgstr "優秀"
+
+#~ msgid "DNS4"
+#~ msgstr "DNS4"
+
+#~ msgid "DNS6"
+#~ msgstr "DNS6"
+
+#~ msgid "Forget Connection"
+#~ msgstr "將該連接遺忘"
+
+#~ msgid "Remove Connection Profile"
+#~ msgstr "移除連線設定檔"
+
+#~ msgid "Remove VPN"
+#~ msgstr "移除 VPN"
+
+#~ msgid "Details"
+#~ msgstr "詳細資料"
+
+#~ msgid "automatic"
+#~ msgstr "自動"
+
+#~ msgid "Identity"
+#~ msgstr "身分"
+
+#~ msgid "Delete Address"
+#~ msgstr "刪除位址"
+
+#~ msgid "Delete Route"
+#~ msgstr "刪除路由"
+
+#~ msgid "IPv4"
+#~ msgstr "IPv4"
+
+#~ msgid "IPv6"
+#~ msgstr "IPv6"
+
+#~ msgctxt "Wi-Fi/Ethernet security"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "WEP 40/128-bit Key (Hex or ASCII)"
+#~ msgstr "WEP 40/128-位元金鑰 (Hex 或 ASCII)"
+
+#~ msgid "WEP 128-bit Passphrase"
+#~ msgstr "WEP 128-位元密語"
+
+#~ msgid "Dynamic WEP (802.1x)"
+#~ msgstr "動態 WEP (802.1x)"
+
+#~ msgid "WPA & WPA2 Personal"
+#~ msgstr "WPA 與 WPA2 個人版"
+
+#~ msgid "WPA & WPA2 Enterprise"
+#~ msgstr "WPA 與 WPA2 企業版"
+
+#~ msgid "WPA3 Personal"
+#~ msgstr "WPA3 個人版"
+
+#~ msgid "Unable to open connection editor"
+#~ msgstr "無法開啟連線編輯器"
+
+#~ msgid "New Profile"
+#~ msgstr "新增設定檔"
+
+#, c-format
+#~ msgid "Invalid setting %s: %s"
+#~ msgstr "無效的設定值「%s」：%s"
+
+#, c-format
+#~ msgid "Invalid setting %s"
+#~ msgstr "無效的設定值「%s」"
+
+#~ msgid "Import from file…"
+#~ msgstr "從檔案匯入…"
+
+#~ msgid "Add VPN"
+#~ msgstr "加入 VPN"
+
+#~ msgid "Cannot import VPN connection"
+#~ msgstr "無法匯入 VPN 網路連線"
+
+#, c-format
+#~ msgid ""
+#~ "The file “%s” could not be read or does not contain recognized VPN "
+#~ "connection information\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "檔案「%s」無法讀取，或未包含可辨識的 VPN 連線資訊\n"
+#~ "\n"
+#~ "錯誤：%s。"
+
+#~ msgid "Select file to import"
+#~ msgstr "選擇要匯入的檔案"
+
+#, c-format
+#~ msgid "A file named “%s” already exists."
+#~ msgstr "名為「%s」的檔案已存在。"
+
+#~ msgid "_Replace"
+#~ msgstr "取代(_R)"
+
+#, c-format
+#~ msgid "Do you want to replace %s with the VPN connection you are saving?"
+#~ msgstr "您是否要以正在儲存的 VPN 連線取代「%s」？"
+
+#~ msgid "Cannot export VPN connection"
+#~ msgstr "無法匯出 VPN 連線"
+
+#, c-format
+#~ msgid ""
+#~ "The VPN connection “%s” could not be exported to %s.\n"
+#~ "\n"
+#~ "Error: %s."
+#~ msgstr ""
+#~ "VPN 連線「%s」無法匯出至 %s。\n"
+#~ "\n"
+#~ "錯誤：%s。"
+
+#~ msgid "Export VPN connection"
+#~ msgstr "匯出 VPN 連線"
+
+#~ msgid "never"
+#~ msgstr "從未用過"
+
+#~ msgid "today"
+#~ msgstr "今天"
+
+#~ msgid "yesterday"
+#~ msgstr "昨天"
+
+#~ msgid "Last used"
+#~ msgstr "最後使用時間"
+
+#~ msgid "Add new connection"
+#~ msgstr "加入新連線"
+
+#~ msgid ""
+#~ "Network details for the selected networks, including passwords and any "
+#~ "custom configuration will be lost."
+#~ msgstr "所選網路的詳細資料，包含密碼及任何自訂設定都將遺失。"
+
+#~ msgid "_Forget"
+#~ msgstr "遺忘(_F)"
+
+#~ msgid "Known Wi-Fi Networks"
+#~ msgstr "已知的 Wi-Fi 網路"
+
+#~ msgctxt "Wi-Fi Network"
+#~ msgid "_Forget"
+#~ msgstr "遺忘(_F)"
+
+#~ msgid "System policy prohibits use as a Hotspot"
+#~ msgstr "系統政策不允許做為熱點"
+
+#~ msgid "Wireless device does not support Hotspot mode"
+#~ msgstr "無線裝置不支援熱點模式"
+
+#~ msgid ""
+#~ "Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+#~ msgstr "當沒有提供組態 URL 時會使用網頁代理伺服器自動探尋。"
+
+#~ msgid "This is not recommended for untrusted public networks."
+#~ msgstr "這不建議用於不信任的公用網路。"
+
+#~ msgid "Status unknown"
+#~ msgstr "狀態不明"
+
+#~ msgid "Unmanaged"
+#~ msgstr "不受管理"
+
+#~ msgid "Unavailable"
+#~ msgstr "無法使用"
+
+#~ msgid "Connecting"
+#~ msgstr "正在連接"
+
+#~ msgid "Authentication required"
+#~ msgstr "需要核對身分"
+
+#~ msgid "Disconnecting"
+#~ msgstr "連接中斷"
+
+#~ msgid "Connection failed"
+#~ msgstr "連接失敗"
+
+#~ msgid "Status unknown (missing)"
+#~ msgstr "狀態不明（缺乏）"
+
+#~ msgid "Configuration failed"
+#~ msgstr "設定失敗"
+
+#~ msgid "IP configuration failed"
+#~ msgstr "IP 設定失敗"
+
+#~ msgid "IP configuration expired"
+#~ msgstr "IP 設定過期"
+
+#~ msgid "Secrets were required, but not provided"
+#~ msgstr "需要密語，但沒有提供"
+
+#~ msgid "802.1x supplicant disconnected"
+#~ msgstr "802.1x 的請求連接中斷"
+
+#~ msgid "802.1x supplicant configuration failed"
+#~ msgstr "802.1x 的請求設定失敗"
+
+#~ msgid "802.1x supplicant failed"
+#~ msgstr "802.1x 的請求失敗"
+
+#~ msgid "802.1x supplicant took too long to authenticate"
+#~ msgstr "802.1x supplicant 花費太長時間核對"
+
+#~ msgid "PPP service failed to start"
+#~ msgstr "無法啟動 PPP 服務"
+
+#~ msgid "PPP service disconnected"
+#~ msgstr "PPP 服務連接中斷"
+
+#~ msgid "PPP failed"
+#~ msgstr "PPP 失敗"
+
+#~ msgid "DHCP client failed to start"
+#~ msgstr "DHCP 客戶端無法啟動"
+
+#~ msgid "DHCP client error"
+#~ msgstr "DHCP 客戶端錯誤"
+
+#~ msgid "DHCP client failed"
+#~ msgstr "DHCP 客戶端失敗"
+
+#~ msgid "Shared connection service failed to start"
+#~ msgstr "無法啟動分享的連線服務"
+
+#~ msgid "Shared connection service failed"
+#~ msgstr "分享的連線服務失敗"
+
+#~ msgid "AutoIP service failed to start"
+#~ msgstr "無法啟動 AutoIP 服務"
+
+#~ msgid "AutoIP service error"
+#~ msgstr "AutoIP 服務錯誤"
+
+#~ msgid "AutoIP service failed"
+#~ msgstr "AutoIP 服務失敗"
+
+#~ msgid "Line busy"
+#~ msgstr "線路忙碌"
+
+#~ msgid "No dial tone"
+#~ msgstr "沒有撥號音"
+
+#~ msgid "No carrier could be established"
+#~ msgstr "無法連接電信商"
+
+#~ msgid "Dialing request timed out"
+#~ msgstr "撥號要求逾時"
+
+#~ msgid "Dialing attempt failed"
+#~ msgstr "嘗試撥號失敗"
+
+#~ msgid "Modem initialization failed"
+#~ msgstr "數據機初始化失敗"
+
+#~ msgid "Failed to select the specified APN"
+#~ msgstr "無法選擇指定的 APN"
+
+#~ msgid "Not searching for networks"
+#~ msgstr "不要搜尋網路"
+
+#~ msgid "Network registration denied"
+#~ msgstr "網路註冊被禁止"
+
+#~ msgid "Network registration timed out"
+#~ msgstr "網路註冊逾時"
+
+#~ msgid "Failed to register with the requested network"
+#~ msgstr "無法向要求的網路註冊"
+
+#~ msgid "PIN check failed"
+#~ msgstr "PIN 碼檢查失敗"
+
+#~ msgid "Firmware for the device may be missing"
+#~ msgstr "可能由於缺少裝置韌體"
+
+#~ msgid "Connection disappeared"
+#~ msgstr "連接已消失"
+
+#~ msgid "Existing connection was assumed"
+#~ msgstr "優先使用現有的連線"
+
+#~ msgid "Modem not found"
+#~ msgstr "找不到數據機"
+
+#~ msgid "Bluetooth connection failed"
+#~ msgstr "藍牙連接失敗"
+
+#~ msgid "SIM Card not inserted"
+#~ msgstr "SIM 卡尚未插入"
+
+#~ msgid "SIM Pin required"
+#~ msgstr "需要 SIM 卡的 PIN 碼"
+
+#~ msgid "SIM Puk required"
+#~ msgstr "需要 SIM 卡的 PUK 碼"
+
+#~ msgid "SIM wrong"
+#~ msgstr "SIM 錯誤"
+
+#~ msgid "Connection dependency failed"
+#~ msgstr "連線相依性解析失敗"
+
+#~ msgid "Firmware missing"
+#~ msgstr "缺少韌體"
+
+#~ msgid "Cable unplugged"
+#~ msgstr "網路線已拔除"
+
+#~ msgid "undefined error in 802.1X security (wpa-eap)"
+#~ msgstr "802.1X 安全加密 (wpa-eap) 的未定義錯誤"
+
+#~ msgid "no file selected"
+#~ msgstr "未選擇檔案"
+
+#~ msgid "unspecified error validating eap-method file"
+#~ msgstr "eap-method 檔案驗證時發生未指定的錯誤"
+
+#~ msgid "DER, PEM, PKCS#12, or PGP private keys"
+#~ msgstr "DER、PEM、PKCS#12、或 PGP 私密金鑰"
+
+#~ msgid "DER or PEM certificates"
+#~ msgstr "DER 或 PEM 憑證"
+
+#~ msgid "missing EAP-FAST PAC file"
+#~ msgstr "缺少 EAP-FAST PAC 檔案"
+
+#~ msgid "PAC files (*.pac)"
+#~ msgstr "PAC 檔案 (*.pac)"
+
+#~ msgid "missing EAP-LEAP username"
+#~ msgstr "缺少 EAP-LEAP 使用者名稱"
+
+#~ msgid "missing EAP-LEAP password"
+#~ msgstr "缺少 EAP-LEAP 密碼"
+
+#, c-format
+#~ msgid "invalid EAP-PEAP CA certificate: %s"
+#~ msgstr "無效的 EAP-PEAP CA 憑證：%s"
+
+#~ msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+#~ msgstr "無效的 EAP-PEAP CA 憑證：沒有指定憑證"
+
+#~ msgid "missing EAP username"
+#~ msgstr "缺少 EAP 使用者名稱"
+
+#~ msgid "missing EAP password"
+#~ msgstr "缺少 EAP 密碼"
+
+#~ msgid "missing EAP-TLS identity"
+#~ msgstr "缺少 EAP-TLS 身分"
+
+#, c-format
+#~ msgid "invalid EAP-TLS CA certificate: %s"
+#~ msgstr "無效的 EAP-TLS CA 憑證：%s"
+
+#~ msgid "invalid EAP-TLS CA certificate: no certificate specified"
+#~ msgstr "無效的 EAP-TLS CA 憑證：沒有指定憑證"
+
+#, c-format
+#~ msgid "invalid EAP-TLS private-key: %s"
+#~ msgstr "無效的 EAP-TLS 私密金鑰：%s"
+
+#, c-format
+#~ msgid "invalid EAP-TLS user-certificate: %s"
+#~ msgstr "無效的 EAP-TLS 使用者憑證：%s"
+
+#~ msgid "Unencrypted private keys are insecure"
+#~ msgstr "未加密的私密金鑰不安全"
+
+#~ msgid ""
+#~ "The selected private key does not appear to be protected by a password. "
+#~ "This could allow your security credentials to be compromised. Please "
+#~ "select a password-protected private key.\n"
+#~ "\n"
+#~ "(You can password-protect your private key with openssl)"
+#~ msgstr ""
+#~ "選擇的私密金鑰似乎沒有受密碼保護， 這可能導致您的安全憑證受到威脅。請選擇"
+#~ "受密碼保護的私密金鑰。\n"
+#~ "\n"
+#~ "（您可以使用 openssl 來加密您的私密金鑰）"
+
+#~ msgid "Choose your personal certificate"
+#~ msgstr "選擇您的個人憑證"
+
+#~ msgid "Choose your private key"
+#~ msgstr "選擇您的私密金鑰"
+
+#, c-format
+#~ msgid "invalid EAP-TTLS CA certificate: %s"
+#~ msgstr "無效的 EAP-TTLS CA 憑證：%s"
+
+#~ msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+#~ msgstr "無效的 EAP-TTLS CA 憑證：沒有指定憑證"
+
+#~ msgid "Unknown error validating 802.1X security"
+#~ msgstr "驗證 802.1X 安全加密時遇到未知錯誤"
+
+#~ msgid "Select a file"
+#~ msgstr "選擇檔案"
+
+#~ msgid "missing leap-username"
+#~ msgstr "缺少 leap 使用者名稱"
+
+#~ msgid "missing leap-password"
+#~ msgstr "缺少 leap 密碼"
+
+#~ msgid "Wi-Fi password is missing."
+#~ msgstr "缺少 Wi-Fi 密碼。"
+
+#~ msgid "missing wep-key"
+#~ msgstr "缺少 wep-key"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only hex-digits"
+#~ msgstr "無效的 wep-key：長度為 %zu 的金鑰必須只能包含十六進位數字"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: key with a length of %zu must contain only ascii "
+#~ "characters"
+#~ msgstr "無效的 wep-key：長度為 %zu 的金鑰必須只能包含 ascii 字元"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wep-key: wrong key length %zu. A key must be either of length "
+#~ "5/13 (ascii) or 10/26 (hex)"
+#~ msgstr ""
+#~ "無效的 wep-key：錯誤的金鑰長度 %zu。金鑰長度必須為 5/13 (ascii) 或 10/26 "
+#~ "(十六進位)"
+
+#~ msgid "invalid wep-key: passphrase must be non-empty"
+#~ msgstr "無效的 wep-key︰密語必須不能留空"
+
+#~ msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+#~ msgstr "無效的 wep-key︰密語必須少於 64 個字元"
+
+#, c-format
+#~ msgid ""
+#~ "invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+#~ "digits"
+#~ msgstr ""
+#~ "無效的 wpa-psk：無效的長度 %zu。必須為 [8,63] 位元組或 64 十六進位數字"
+
+#~ msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+#~ msgstr "無效的 wpa-psk：不能將 64 位元組金鑰轉譯為十六進位"
+
+#~ msgctxt "Online Account"
+#~ msgid "Other"
+#~ msgstr "其他"
+
+#, c-format
+#~ msgid "%s removed"
+#~ msgstr "已移除 %s"
+
+#~ msgid "Error removing account"
+#~ msgstr "移除帳號時發生錯誤"
+
+#, c-format
+#~ msgid "%s Account"
+#~ msgstr "%s 帳號"
+
+#~ msgid "Remove Account"
+#~ msgstr "移除帳號"
+
+#~ msgid "Unknown time"
+#~ msgstr "不明時間"
+
+#, c-format
+#~ msgid "%i %s %i %s"
+#~ msgstr "%i %s %i %s"
+
+#, c-format
+#~ msgid "%s until fully charged"
+#~ msgstr "充飽仍需 %s"
+
+#, c-format
+#~ msgid "Caution: %s remaining"
+#~ msgstr "注意：只能再使用 %s"
+
+#, c-format
+#~ msgid "%s remaining"
+#~ msgstr "還能使用 %s"
+
+#~ msgid "Fully charged"
+#~ msgstr "已充飽"
+
+#~ msgid "Not charging"
+#~ msgstr "未充電"
+
+#~ msgid "Empty"
+#~ msgstr "沒有電池"
+
+#~ msgid "Charging"
+#~ msgstr "正在充電"
+
+#~ msgid "Discharging"
+#~ msgstr "未充電"
+
+#~ msgid "Wireless mouse"
+#~ msgstr "無線滑鼠"
+
+#~ msgid "Wireless keyboard"
+#~ msgstr "無線鍵盤"
+
+#~ msgid "Uninterruptible power supply"
+#~ msgstr "不斷電系統"
+
+#~ msgid "Personal digital assistant"
+#~ msgstr "個人數位助理 (PDA)"
+
+#~ msgid "Cellphone"
+#~ msgstr "手機"
+
+#~ msgid "Media player"
+#~ msgstr "媒體播放器"
+
+#~ msgid "Tablet"
+#~ msgstr "繪圖板"
+
+#~ msgid "Computer"
+#~ msgstr "電腦"
+
+#~ msgid "Gaming input device"
+#~ msgstr "遊戲輸入裝置"
+
+#~ msgctxt "Battery name"
+#~ msgid "Main"
+#~ msgstr "主要"
+
+#~ msgctxt "Battery name"
+#~ msgid "Extra"
+#~ msgstr "額外"
+
+#~ msgid "Batteries"
+#~ msgstr "電池"
+
+#~ msgid "When _idle"
+#~ msgstr "裝置閒置時(_I)"
+
+#~ msgid "Suspend"
+#~ msgstr "暫停"
+
+#~ msgid "Power Off"
+#~ msgstr "關閉電源"
+
+#~ msgid "Hibernate"
+#~ msgstr "休眠"
+
+#~ msgid "Nothing"
+#~ msgstr "沒有動作"
+
+#~ msgid "When on battery power"
+#~ msgstr "使用電池電源時"
+
+#~ msgid "When plugged in"
+#~ msgstr "使用交流電源時"
+
+#~ msgctxt "Idle time"
+#~ msgid "Never"
+#~ msgstr "永不"
+
+#~ msgid "Automatic suspend"
+#~ msgstr "自動暫停"
+
+#~ msgid ""
+#~ "Performance mode temporarily disabled due to high operating temperature."
+#~ msgstr "因為系統作業產生高溫，效能模式已暫時停用。"
+
+#~ msgid ""
+#~ "Lap detected: performance mode temporarily unavailable. Move the device "
+#~ "to a stable surface to restore."
+#~ msgstr ""
+#~ "偵測到大腿：效能模式暫無法使用。請將裝置移動至穩定的平面以重啟效能模式。"
+
+#~ msgid "Performance mode temporarily disabled."
+#~ msgstr "效能模式已暫時停用。"
+
+#~ msgid ""
+#~ "Low battery: power saver enabled. Previous mode will be restored when "
+#~ "battery is sufficiently charged."
+#~ msgstr ""
+#~ "低電量：已啟用省電模式。充至足夠電量後會還原為之前所使用的電源模式。"
+
+#, c-format
+#~ msgid "Power Saver mode activated by “%s”."
+#~ msgstr "「%s」已啟動省電模式。"
+
+#, c-format
+#~ msgid "Performance mode activated by “%s”."
+#~ msgstr "效能模式已由「%s」啟動。"
+
+#~ msgctxt "Power profile"
+#~ msgid "Performance"
+#~ msgstr "效能模式"
+
+#~ msgid "High performance and power usage."
+#~ msgstr "提高效能與耗電量。"
+
+#~ msgctxt "Power profile"
+#~ msgid "Balanced"
+#~ msgstr "平衡模式"
+
+#~ msgid "Standard performance and power usage."
+#~ msgstr "標準效能與耗電量。"
+
+#~ msgctxt "Power profile"
+#~ msgid "Power Saver"
+#~ msgstr "省電模式"
+
+#~ msgid "Reduced performance and power usage."
+#~ msgstr "降低效能與耗電量。"
+
+#, c-format
+#~ msgid "Printer “%s” has been deleted"
+#~ msgstr "「%s」印表機已刪除"
+
+#~ msgid "Failed to add new printer."
+#~ msgstr "無法加入新的印表機。"
+
+#, c-format
+#~ msgid "Could not load ui: %s"
+#~ msgstr "無法載入使用者介面：%s"
+
+#~ msgid "Unlock to Add Printers and Change Settings"
+#~ msgstr "解鎖以加入印表機與更改設定"
+
+#, c-format
+#~ msgid "%s Details"
+#~ msgstr "「%s」詳細資料"
+
+#~ msgid "No suitable driver found"
+#~ msgstr "找不到合適的驅動程式"
+
+#~ msgid "Select PPD File"
+#~ msgstr "選擇 PPD 檔案"
+
+#~ msgid ""
+#~ "PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+#~ "PPD.GZ)"
+#~ msgstr ""
+#~ "PostScript 印表機描述檔 (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#~ msgid "JetDirect Printer"
+#~ msgstr "JetDirect 印表機"
+
+#~ msgid "LPD Printer"
+#~ msgstr "LPD 印表機"
+
+#~ msgid "One Sided"
+#~ msgstr "單面"
+
+#~ msgid "Long Edge (Standard)"
+#~ msgstr "長邊 (標準)"
+
+#~ msgid "Short Edge (Flip)"
+#~ msgstr "短邊 (翻轉)"
+
+#~ msgid "Portrait"
+#~ msgstr "直向"
+
+#~ msgid "Landscape"
+#~ msgstr "橫向"
+
+#~ msgid "Reverse landscape"
+#~ msgstr "橫向倒轉"
+
+#~ msgid "Reverse portrait"
+#~ msgstr "直向倒轉"
+
+#~ msgid "Resume"
+#~ msgstr "繼續"
+
+#~ msgid "Pause"
+#~ msgstr "暫停"
+
+#~ msgctxt "print job"
+#~ msgid "Pending"
+#~ msgstr "待處理"
+
+#~ msgctxt "print job"
+#~ msgid "Paused"
+#~ msgstr "已暫停"
+
+#~ msgctxt "print job"
+#~ msgid "Authentication required"
+#~ msgstr "需要核對身分"
+
+#~ msgctxt "print job"
+#~ msgid "Processing"
+#~ msgstr "正在處理"
+
+#~ msgctxt "print job"
+#~ msgid "Stopped"
+#~ msgstr "已停止"
+
+#~ msgctxt "print job"
+#~ msgid "Canceled"
+#~ msgstr "已取消"
+
+#~ msgctxt "print job"
+#~ msgid "Aborted"
+#~ msgstr "已放棄"
+
+#~ msgctxt "print job"
+#~ msgid "Completed"
+#~ msgstr "已完成"
+
+#~ msgid "Move this job to the top of the queue"
+#~ msgstr "將此工作移動至佇列頂端"
+
+#, c-format
+#~ msgctxt "Printer jobs dialog title"
+#~ msgid "%s — Active Jobs"
+#~ msgstr "%s — 進行中的工作"
+
+#, c-format
+#~ msgid "Enter credentials to print from %s."
+#~ msgstr "請輸入憑證以從 %s 列印。"
+
+#~ msgid "Unlock Print Server"
+#~ msgstr "解鎖印表機伺服器"
+
+#, c-format
+#~ msgid "Unlock %s."
+#~ msgstr "解鎖 %s。"
+
+#, c-format
+#~ msgid "Enter username and password to view printers on %s."
+#~ msgstr "輸入使用者名稱與密碼以檢視位於 %s 的印表機。"
+
+#~ msgid "Searching for Printers"
+#~ msgstr "搜尋印表機"
+
+#~ msgid "USB"
+#~ msgstr "USB"
+
+#~ msgid "Serial Port"
+#~ msgstr "序列埠"
+
+#~ msgid "Parallel Port"
+#~ msgstr "串列埠"
+
+#, c-format
+#~ msgid "Location: %s"
+#~ msgstr "位置：%s"
+
+#, c-format
+#~ msgid "Address: %s"
+#~ msgstr "位址：%s"
+
+#~ msgid "Server requires authentication"
+#~ msgstr "伺服器要求認證"
+
+#~ msgid "Two Sided"
+#~ msgstr "雙面"
+
+#~ msgid "Paper Type"
+#~ msgstr "紙張類型"
+
+#~ msgid "Paper Source"
+#~ msgstr "紙張來源"
+
+#~ msgid "Output Tray"
+#~ msgstr "出紙匣"
+
+#~ msgctxt "printing option"
+#~ msgid "Resolution"
+#~ msgstr "解析度"
+
+#~ msgid "GhostScript pre-filtering"
+#~ msgstr "GhostScript 前置過濾器"
+
+#~ msgid "Pages per side"
+#~ msgstr "每面的頁數"
+
+#~ msgid "Orientation"
+#~ msgstr "方向"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "General"
+#~ msgstr "一般"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Page Setup"
+#~ msgstr "頁面設定"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Installable Options"
+#~ msgstr "可安裝選項"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Job"
+#~ msgstr "工作"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Image Quality"
+#~ msgstr "影像品質"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Color"
+#~ msgstr "色彩"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Finishing"
+#~ msgstr "完成"
+
+#~ msgctxt "Printer Option Group"
+#~ msgid "Advanced"
+#~ msgstr "進階"
+
+#~ msgid "Test page"
+#~ msgstr "測試頁"
+
+#~ msgid "Auto Select"
+#~ msgstr "自動選擇"
+
+#~ msgid "Printer Default"
+#~ msgstr "印表機預設值"
+
+#~ msgid "Embed GhostScript fonts only"
+#~ msgstr "僅嵌入 GhostScript 字型"
+
+#~ msgid "Convert to PS level 1"
+#~ msgstr "轉換為 PS 等級 1"
+
+#~ msgid "Convert to PS level 2"
+#~ msgstr "轉換為 PS 等級 2"
+
+#~ msgid "No pre-filtering"
+#~ msgstr "沒有前置過濾器"
+
+#~ msgid "Clean print heads"
+#~ msgstr "清理列印噴頭"
+
+#~ msgid "Out of toner"
+#~ msgstr "碳粉已用完"
+
+#~ msgid "Low on developer"
+#~ msgstr "顯像劑不足"
+
+#~ msgid "Out of developer"
+#~ msgstr "顯像劑已用完"
+
+#~ msgid "Low on a marker supply"
+#~ msgstr "墨水匣不足"
+
+#~ msgid "Out of a marker supply"
+#~ msgstr "墨水匣已用完"
+
+#~ msgid "Open cover"
+#~ msgstr "外殼開啟"
+
+#~ msgid "Open door"
+#~ msgstr "紙匣門開啟"
+
+#~ msgid "Low on paper"
+#~ msgstr "紙張不足"
+
+#~ msgid "Out of paper"
+#~ msgstr "紙張已用完"
+
+#~ msgctxt "printer state"
+#~ msgid "Offline"
+#~ msgstr "離線"
+
+#~ msgctxt "printer state"
+#~ msgid "Stopped"
+#~ msgstr "已停止"
+
+#~ msgid "Waste receptacle almost full"
+#~ msgstr "廢墨收集器將滿"
+
+#~ msgid "Waste receptacle full"
+#~ msgstr "廢墨收集器已滿"
+
+#~ msgid "The optical photo conductor is near end of life"
+#~ msgstr "感光鼓接近使用壽命"
+
+#~ msgid "The optical photo conductor is no longer functioning"
+#~ msgstr "感光鼓已無法使用"
+
+#~ msgctxt "printer state"
+#~ msgid "Ready"
+#~ msgstr "準備就緒"
+
+#~ msgctxt "printer state"
+#~ msgid "Does not accept jobs"
+#~ msgstr "不接受工作"
+
+#~ msgctxt "printer state"
+#~ msgid "Processing"
+#~ msgstr "正在處理"
+
+#~ msgctxt "measurement format"
+#~ msgid "Imperial"
+#~ msgstr "英制"
+
+#~ msgctxt "measurement format"
+#~ msgid "Metric"
+#~ msgstr "公制"
+
+#~ msgid "Ask what to do"
+#~ msgstr "詢問要做什麼"
+
+#~ msgid "Do nothing"
+#~ msgstr "不做任何動作"
+
+#~ msgid "Open folder"
+#~ msgstr "開啟資料夾"
+
+#~ msgid "Other Media"
+#~ msgstr "其他媒體"
+
+#~ msgid "Select an application for audio CDs"
+#~ msgstr "選擇播放 CD 音訊的應用程式"
+
+#~ msgid "Select an application for video DVDs"
+#~ msgstr "選擇播放 DVD 視訊的應用程式"
+
+#~ msgid "Select an application to run when a music player is connected"
+#~ msgstr "選擇音樂播放器連接時要執行的應用程式"
+
+#~ msgid "Select an application to run when a camera is connected"
+#~ msgstr "選擇相機連接時要執行的應用程式"
+
+#~ msgid "Select an application for software CDs"
+#~ msgstr "選擇軟體 CD 放入時要開啟的應用程式"
+
+#~ msgid "audio DVD"
+#~ msgstr "音訊 (DVD-Audio)"
+
+#~ msgid "blank Blu-ray disc"
+#~ msgstr "空白光碟 (Blu-ray)"
+
+#~ msgid "blank CD disc"
+#~ msgstr "空白光碟 (CD)"
+
+#~ msgid "blank DVD disc"
+#~ msgstr "空白光碟 (DVD)"
+
+#~ msgid "blank HD DVD disc"
+#~ msgstr "空白光碟 (HD DVD)"
+
+#~ msgid "Blu-ray video disc"
+#~ msgstr "視訊 (Blu-ray)"
+
+#~ msgid "e-book reader"
+#~ msgstr "電子書閱讀器"
+
+#~ msgid "HD DVD video disc"
+#~ msgstr "視訊 (HD DVD)"
+
+#~ msgid "Picture CD"
+#~ msgstr "影像 (KODAK Picture CD)"
+
+#~ msgid "Super Video CD"
+#~ msgstr "視訊 (SVCD)"
+
+# (Freddy)考量臺灣人普遍都講 CD VCD DVD 之類的東西，也都知道誰是視訊誰是音訊，故邏輯上是以括號來補充 CD VCD DVD。
+#~ msgid "Video CD"
+#~ msgstr "視訊 (VCD)"
+
+#~ msgctxt "lock_screen"
+#~ msgid "Screen Turns Off"
+#~ msgstr "關閉立即鎖定"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 seconds"
+#~ msgstr "30 秒"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 分鐘"
+
+#~ msgctxt "lock_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 分鐘"
+
+#~ msgctxt "lock_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 分鐘"
+
+#~ msgctxt "lock_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 分鐘"
+
+#~ msgctxt "lock_screen"
+#~ msgid "30 minutes"
+#~ msgstr "30 分鐘"
+
+#~ msgctxt "lock_screen"
+#~ msgid "1 hour"
+#~ msgstr "1 小時"
+
+#~ msgctxt "blank_screen"
+#~ msgid "1 minute"
+#~ msgstr "1 分鐘"
+
+#~ msgctxt "blank_screen"
+#~ msgid "2 minutes"
+#~ msgstr "2 分鐘"
+
+#~ msgctxt "blank_screen"
+#~ msgid "3 minutes"
+#~ msgstr "3 分鐘"
+
+#~ msgctxt "blank_screen"
+#~ msgid "4 minutes"
+#~ msgstr "4 分鐘"
+
+#~ msgctxt "blank_screen"
+#~ msgid "5 minutes"
+#~ msgstr "5 分鐘"
+
+#~ msgctxt "blank_screen"
+#~ msgid "8 minutes"
+#~ msgstr "8 分鐘"
+
+#~ msgctxt "blank_screen"
+#~ msgid "10 minutes"
+#~ msgstr "10 分鐘"
+
+#~ msgctxt "blank_screen"
+#~ msgid "12 minutes"
+#~ msgstr "12 分鐘"
+
+#~ msgctxt "blank_screen"
+#~ msgid "15 minutes"
+#~ msgstr "15 分鐘"
+
+#~ msgctxt "blank_screen"
+#~ msgid "Never"
+#~ msgstr "永不"
+
+#~ msgid "Select Location"
+#~ msgstr "選擇位置"
+
+#~ msgid "_OK"
+#~ msgstr "確定(_O)"
+
+#~ msgid "No applications found"
+#~ msgstr "找不到應用程式"
+
+#~ msgid "No networks selected for sharing"
+#~ msgstr "沒有選擇用於分享的網路"
+
+#~ msgctxt "service is enabled"
+#~ msgid "On"
+#~ msgstr "開啟"
+
+#~ msgctxt "service is disabled"
+#~ msgid "Off"
+#~ msgstr "關閉"
+
+#~ msgctxt "service is enabled"
+#~ msgid "Enabled"
+#~ msgstr "已啟用"
+
+#~ msgctxt "service is active"
+#~ msgid "Active"
+#~ msgstr "啟動中"
+
+#~ msgid "Choose a Folder"
+#~ msgstr "選擇資料夾"
+
+#~ msgid "Enable media sharing"
+#~ msgstr "啟用媒體分享"
+
+#, c-format
+#~ msgid ""
+#~ "File Sharing allows you to share your Public folder with others on your "
+#~ "current network using: %s"
+#~ msgstr "檔案分享允許您與目前網路上的其他人分享公開資料夾，使用：%s"
+
+#, c-format
+#~ msgid ""
+#~ "When remote login is enabled, remote users can connect using the Secure "
+#~ "Shell command:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "啟用遠端登入後，遠端使用者可使用此 SSH 命令來連接：\n"
+#~ "%s"
+
+#~ msgid "Enable personal media sharing"
+#~ msgstr "啟用個人媒體分享"
+
+#~ msgid "Device name copied"
+#~ msgstr "已複製裝置名稱"
+
+#~ msgid "Device address copied"
+#~ msgstr "已複製裝置位址"
+
+#~ msgid "Username copied"
+#~ msgstr "已複製使用者名稱"
+
+#~ msgid "Password copied"
+#~ msgstr "密碼已複製"
+
+#~ msgid "Custom"
+#~ msgstr "自訂"
+
+#, c-format
+#~ msgid "Testing %s"
+#~ msgstr "正在測試「%s」"
+
+#~ msgctxt "volume"
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Disconnected"
+#~ msgstr "連接中斷"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connecting"
+#~ msgstr "正在連接"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected"
+#~ msgstr "已連接"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorization Error"
+#~ msgstr "授權發生錯誤"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorizing"
+#~ msgstr "正在授權"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Reduced Functionality"
+#~ msgstr "功能受到限制"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Connected & Authorized"
+#~ msgstr "已連接與授權"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Unknown"
+#~ msgstr "不明"
+
+#~ msgid "Authorized at:"
+#~ msgstr "授權於："
+
+#~ msgid "Connected at:"
+#~ msgstr "連接於："
+
+#~ msgid "Enrolled at:"
+#~ msgstr "登錄於："
+
+#~ msgid "Failed to authorize device: "
+#~ msgstr "裝置授權失敗："
+
+#~ msgid "Failed to forget device: "
+#~ msgstr "無法將該裝置遺忘："
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Error"
+#~ msgstr "錯誤"
+
+#~ msgctxt "Thunderbolt Device Status"
+#~ msgid "Authorized"
+#~ msgstr "已授權"
+
+#~ msgid ""
+#~ "The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+#~ msgstr "Thunderbolt 子系統 (boltd) 尚未安裝或未正確設定。"
+
+#~ msgid "Only USB and Display Port devices can attach."
+#~ msgstr "只有 USB 與 DisplayPort 裝置可以連接。"
+
+#~ msgid ""
+#~ "Thunderbolt could not be detected.\n"
+#~ "Either the system lacks Thunderbolt support, it has been disabled in the "
+#~ "BIOS or is set to an unsupported security level in the BIOS."
+#~ msgstr ""
+#~ "未偵測到 Thunderbolt。\n"
+#~ "可能是系統不支援 Thunderbolt，也可能是在 BIOS 中被停用或設定至不支援的安全"
+#~ "性層級。"
+
+#~ msgid "Thunderbolt support has been disabled in the BIOS."
+#~ msgstr "Thunderbolt 的支援在 BIOS 中被停用。"
+
+#~ msgid "Thunderbolt security level could not be determined."
+#~ msgstr "無法確定 Thunderbolt 的安全性層級。"
+
+#, c-format
+#~ msgid "Error switching direct mode: %s"
+#~ msgstr "切換直接模式時發生問題：%s"
+
+#~ msgctxt "cursor size"
+#~ msgid "Default"
+#~ msgstr "預設值"
+
+#~ msgctxt "cursor size"
+#~ msgid "Medium"
+#~ msgstr "中"
+
+#~ msgctxt "cursor size"
+#~ msgid "Large"
+#~ msgstr "大"
+
+#~ msgctxt "cursor size"
+#~ msgid "Larger"
+#~ msgstr "較大"
+
+#~ msgctxt "cursor size"
+#~ msgid "Largest"
+#~ msgstr "最大"
+
+#, c-format
+#~ msgid "%d pixel"
+#~ msgid_plural "%d pixels"
+#~ msgstr[0] "%d 畫素"
+
+#~ msgctxt "Distance"
+#~ msgid "Short"
+#~ msgstr "短"
+
+#~ msgctxt "Distance"
+#~ msgid "¼ Screen"
+#~ msgstr "¼ 螢幕"
+
+#~ msgctxt "Distance"
+#~ msgid "½ Screen"
+#~ msgstr "½ 螢幕"
+
+#~ msgctxt "Distance"
+#~ msgid "¾ Screen"
+#~ msgstr "¾ 螢幕"
+
+#~ msgctxt "Distance"
+#~ msgid "Long"
+#~ msgstr "長"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 hour"
+#~ msgstr "1 小時"
+
+#~ msgctxt "purge_files"
+#~ msgid "1 day"
+#~ msgstr "1 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "2 days"
+#~ msgstr "2 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "3 days"
+#~ msgstr "3 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "4 days"
+#~ msgstr "4 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "5 days"
+#~ msgstr "5 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "6 days"
+#~ msgstr "6 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "7 days"
+#~ msgstr "7 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "14 days"
+#~ msgstr "14 天"
+
+#~ msgctxt "purge_files"
+#~ msgid "30 days"
+#~ msgstr "30 天"
+
+#~ msgid "Empty all items from Trash?"
+#~ msgstr "要清除垃圾桶中的所有項目嗎？"
+
+#~ msgid "All items in the Trash will be permanently deleted."
+#~ msgstr "所有垃圾桶中的項目將永久刪除。"
+
+#~ msgid "_Empty Trash"
+#~ msgstr "清空垃圾桶(_E)"
+
+#~ msgid "Delete all the temporary files?"
+#~ msgstr "要刪除所有的暫存檔嗎？"
+
+#~ msgid "All the temporary files will be permanently deleted."
+#~ msgstr "所有的暫存檔將永遠刪除。"
+
+#~ msgid "_Purge Temporary Files"
+#~ msgstr "清除暫存檔(_P)"
+
+#~ msgctxt "retain_history"
+#~ msgid "1 day"
+#~ msgstr "1 天"
+
+#~ msgctxt "retain_history"
+#~ msgid "7 days"
+#~ msgstr "7 天"
+
+#~ msgctxt "retain_history"
+#~ msgid "30 days"
+#~ msgstr "30 天"
+
+#~ msgctxt "retain_history"
+#~ msgid "Forever"
+#~ msgstr "永遠"
+
+#~ msgid "Should match the web address of your login provider."
+#~ msgstr "應符合登入提供者的網路位址。"
+
+#~ msgid "Failed to add account"
+#~ msgstr "無法加入帳號"
+
+#~ msgid "Failed to register account"
+#~ msgstr "無法註冊帳號"
+
+#~ msgid "No supported way to authenticate with this domain"
+#~ msgstr "不支援這個網域的認證方式"
+
+#~ msgid "Failed to join domain"
+#~ msgstr "無法加入網域"
+
+#~ msgid ""
+#~ "That login name didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "登入名稱不起作用。\n"
+#~ "請再試一次。"
+
+#~ msgid ""
+#~ "That login password didn’t work.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "登入密碼不起作用。\n"
+#~ "請再試一次。"
+
+#~ msgid "Failed to log into domain"
+#~ msgstr "無法登入網域"
+
+#~ msgid "Unable to find the domain. Maybe you misspelled it?"
+#~ msgstr "找不到網域，也許您拼錯字了？"
+
+#~ msgid "Browse for more pictures"
+#~ msgstr "瀏覽更多照片"
+
+#~ msgid "the device needs to be claimed to perform this action"
+#~ msgstr "須索取裝置才能執行此動作"
+
+#~ msgid "the device is already claimed by another process"
+#~ msgstr "該裝置已經被其他程序索取"
+
+#~ msgid "you do not have permission to perform the action"
+#~ msgstr "您未取得執行該動作的許可"
+
+#~ msgid "no prints have been enrolled"
+#~ msgstr "沒有已登錄的指紋"
+
+#~ msgid "Failed to communicate with the device during enrollment"
+#~ msgstr "無法與裝置通訊（登錄期間）"
+
+#~ msgid "Failed to communicate with the fingerprint reader"
+#~ msgstr "無法與指紋辨識器通訊"
+
+#~ msgid "Failed to communicate with the fingerprint daemon"
+#~ msgstr "無法與指紋辨識器常駐程式通訊"
+
+#, c-format
+#~ msgid "Failed to list fingerprints: %s"
+#~ msgstr "無法列出指紋：%s"
+
+#, c-format
+#~ msgid "Failed to delete saved fingerprints: %s"
+#~ msgstr "無法刪除已儲存的指紋：%s"
+
+#~ msgid "Left thumb"
+#~ msgstr "左手姆指"
+
+#~ msgid "Left middle finger"
+#~ msgstr "左手中指"
+
+#~ msgid "_Left index finger"
+#~ msgstr "左手食指(_L)"
+
+#~ msgid "Left ring finger"
+#~ msgstr "左手無名指"
+
+#~ msgid "Left little finger"
+#~ msgstr "左手小指"
+
+#~ msgid "Right thumb"
+#~ msgstr "右手姆指"
+
+#~ msgid "Right middle finger"
+#~ msgstr "右手中指"
+
+#~ msgid "_Right index finger"
+#~ msgstr "右手食指(_R)"
+
+#~ msgid "Right ring finger"
+#~ msgstr "右手無名指"
+
+#~ msgid "Right little finger"
+#~ msgstr "右手小指"
+
+#~ msgid "Unknown Finger"
+#~ msgstr "不明手指"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Complete"
+#~ msgstr "登錄完畢"
+
+#~ msgid "Fingerprint device disconnected"
+#~ msgstr "指紋裝置已中斷連接"
+
+#~ msgid "Fingerprint device storage is full"
+#~ msgstr "指紋裝置的儲存空間已滿"
+
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "無法登錄新指紋"
+
+#, c-format
+#~ msgid "Failed to start enrollment: %s"
+#~ msgstr "無法開始登錄程序：%s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Failed to enroll new fingerprint"
+#~ msgstr "無法登錄新指紋"
+
+#, c-format
+#~ msgid "Failed to stop enrollment: %s"
+#~ msgstr "無法停止登錄程序：%s"
+
+#~ msgid ""
+#~ "Repeatedly lift and place your finger on the reader to enroll your "
+#~ "fingerprint"
+#~ msgstr "請將您的手指置於指紋辨識器上反覆抬起與放下來登錄指紋"
+
+#~ msgid "_Re-enroll this finger…"
+#~ msgstr "重新登錄這隻手指(_R)…"
+
+#~ msgid "Scan new fingerprint"
+#~ msgstr "掃描新指紋"
+
+#, c-format
+#~ msgid "Failed to release fingerprint device %s: %s"
+#~ msgstr "無法釋放指紋裝置 %s：%s"
+
+#~ msgctxt "Fingerprint enroll state"
+#~ msgid "Problem Reading Device"
+#~ msgstr "讀取裝置存在問題"
+
+#, c-format
+#~ msgid "Failed to claim fingerprint device %s: %s"
+#~ msgstr "無法索取指紋裝置 %s：%s"
+
+#, c-format
+#~ msgid "Failed to get fingerprint devices: %s"
+#~ msgstr "無法取得指紋裝置：%s"
+
+#~ msgid "This Week"
+#~ msgstr "本週"
+
+#~ msgid "Last Week"
+#~ msgstr "上週"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e"
+#~ msgstr "%-m月%e日"
+
+#~ msgctxt "login history week label"
+#~ msgid "%b %e, %Y"
+#~ msgstr "%Y年-m月%e日"
+
+#, c-format
+#~ msgctxt "login history week label"
+#~ msgid "%s — %s"
+#~ msgstr "%s — %s"
+
+#~ msgctxt "login date-time"
+#~ msgid "%k:%M"
+#~ msgstr "%k:%M"
+
+#, c-format
+#~ msgctxt "login date-time"
+#~ msgid "%s, %s"
+#~ msgstr "%s，%s"
+
+#~ msgid "Session Ended"
+#~ msgstr "作業階段結束"
+
+#~ msgid "Session Started"
+#~ msgstr "作業階段開始"
+
+#, c-format
+#~ msgid "%s — Account Activity"
+#~ msgstr "%s — 帳號活動"
+
+#~ msgid "Please choose another password."
+#~ msgstr "請選擇其他密碼。"
+
+#~ msgid "Please type your current password again."
+#~ msgstr "請再次輸入目前的密碼。"
+
+#~ msgid "Password could not be changed"
+#~ msgstr "無法更改密碼"
+
+#~ msgid "Cannot automatically join this type of domain"
+#~ msgstr "不能自動加入這個類型的網域"
+
+#~ msgid "No such domain or realm found"
+#~ msgstr "找不到網域或領域名稱"
+
+#, c-format
+#~ msgid "Cannot log in as %s at the %s domain"
+#~ msgstr "不能以 %s 的身分登入 %s 網域"
+
+#~ msgid "Invalid password, please try again"
+#~ msgstr "密碼錯誤，請再試一次"
+
+#, c-format
+#~ msgid "Couldn’t connect to the %s domain: %s"
+#~ msgstr "無法連接 %s 網域：%s"
+
+#~ msgid "Failed to delete user"
+#~ msgstr "無法刪除使用者"
+
+#~ msgid "Failed to revoke remotely managed user"
+#~ msgstr "無法註銷遠端管理的使用者"
+
+#~ msgid "You cannot delete your own account."
+#~ msgstr "您不能刪除自己的帳號。"
+
+#, c-format
+#~ msgid "%s is still logged in"
+#~ msgstr "%s 仍在登入中"
+
+#~ msgid ""
+#~ "Deleting a user while they are logged in can leave the system in an "
+#~ "inconsistent state."
+#~ msgstr "在使用者登入期間刪除其帳號會使系統處於不穩定的狀態。"
+
+#, c-format
+#~ msgid "Do you want to keep %s’s files?"
+#~ msgstr "您要保留 %s 的檔案嗎？"
+
+#~ msgid ""
+#~ "It is possible to keep the home directory, mail spool and temporary files "
+#~ "around when deleting a user account."
+#~ msgstr "刪除使用者時，可以選擇是否要保留家目錄、電子郵件與暫存檔等資料。"
+
+#~ msgid "_Delete Files"
+#~ msgstr "刪除檔案(_D)"
+
+#~ msgid "_Keep Files"
+#~ msgstr "保留檔案(_K)"
+
+#, c-format
+#~ msgid "Are you sure you want to revoke remotely managed %s’s account?"
+#~ msgstr "確定要註銷遠端管理的 %s 帳號嗎？"
+
+#~ msgid "_Delete"
+#~ msgstr "刪除(_D)"
+
+#~ msgctxt "Password mode"
+#~ msgid "Account disabled"
+#~ msgstr "帳號已停用"
+
+#~ msgctxt "Password mode"
+#~ msgid "To be set at next login"
+#~ msgstr "下次登入時再設定"
+
+#~ msgctxt "Password mode"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "Logged in"
+#~ msgstr "已登入"
+
+#~ msgid "Failed to contact the accounts service"
+#~ msgstr "無法連接帳號服務"
+
+#~ msgid "Please make sure that the AccountService is installed and enabled."
+#~ msgstr "請確保已在系統上安裝並啟用《AccountService》。"
+
+#~ msgid "This panel must be unlocked to change this setting"
+#~ msgstr "需先解鎖此面板才能更改設定"
+
+#~ msgid "Delete the selected user account"
+#~ msgstr "刪除所選的使用者帳號"
+
+#~ msgid ""
+#~ "To delete the selected user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "要刪除所選的使用者帳號，\n"
+#~ "請先點選 * 圖示"
+
+#~ msgid "Unlock to Add Users and Change Settings"
+#~ msgstr "解鎖以加入使用者與更改設定"
+
+#~ msgctxt "Password hint"
+#~ msgid "The new password needs to be different from the old one."
+#~ msgstr "新密碼需與舊密碼有所差異。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing some letters and numbers."
+#~ msgstr "試著更動某些英文字母與數字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try changing the password a bit more."
+#~ msgstr "試著更大幅地更動密碼。"
+
+#~ msgctxt "Password hint"
+#~ msgid "A password without your user name would be stronger."
+#~ msgstr "不含使用者名稱的密碼強度會更高。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid using your name in the password."
+#~ msgstr "試著避免在密碼中使用您的姓名。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid some of the words included in the password."
+#~ msgstr "試著避免在密碼中包含某些單字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid common words."
+#~ msgstr "試著避免常用單字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid reordering existing words."
+#~ msgstr "試著避免重新排序已有的單字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more numbers."
+#~ msgstr "試著使用更多數字。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more uppercase letters."
+#~ msgstr "試著使用更多大寫英文字母。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more lowercase letters."
+#~ msgstr "試著使用更多小寫英文字母。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use more special characters, like punctuation."
+#~ msgstr "試著使用更多特殊字元，例如半形標點符號。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to use a mixture of letters, numbers and punctuation."
+#~ msgstr "試著混合使用英文字母、數字、半形標點符號等。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid repeating the same character."
+#~ msgstr "試著避免重複使用相同字元。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Try to avoid repeating the same type of character: you need to mix up "
+#~ "letters, numbers and punctuation."
+#~ msgstr ""
+#~ "試著避免重複使用相同類型的字元：需混合英文字母、數字、半形標點符號等。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to avoid sequences like 1234 or abcd."
+#~ msgstr "試著避免使用如 1234 或 abcd 之類的連續字元。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Password needs to be longer. Try to add more letters, numbers and "
+#~ "punctuation."
+#~ msgstr "密碼長度不足。試著加入更多英文字母、數字、半形標點符號等。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Mix uppercase and lowercase and try to use a number or two."
+#~ msgstr "混合英文大小寫字元並試著使用 1 至 2 個數字。"
+
+#~ msgctxt "Password hint"
+#~ msgid ""
+#~ "Adding more letters, numbers and punctuation will make the password "
+#~ "stronger."
+#~ msgstr "加入更多英文字母、數字、半形標點符號能使密碼強度更高。"
+
+#~ msgid "Authentication failed"
+#~ msgstr "身分核對失敗"
+
+#, c-format
+#~ msgid "The new password is too short"
+#~ msgstr "新密碼過短"
+
+#, c-format
+#~ msgid "The new password is too simple"
+#~ msgstr "新密碼過於簡單"
+
+#, c-format
+#~ msgid "The old and new passwords are too similar"
+#~ msgstr "舊密碼與新密碼過於相似"
+
+#, c-format
+#~ msgid "The new password has already been used recently."
+#~ msgstr "新密碼已在最近使用過。"
+
+#, c-format
+#~ msgid "The new password must contain numeric or special characters"
+#~ msgstr "新密碼須包含數字或特殊字元"
+
+#, c-format
+#~ msgid "The old and new passwords are the same"
+#~ msgstr "舊密碼與新密碼相同"
+
+#, c-format
+#~ msgid "Your password has been changed since you initially authenticated!"
+#~ msgstr "您的密碼在先前身分核對之後已更動！"
+
+# (Freddy)新密碼並未包含足夠的不同字元
+#, c-format
+#~ msgid "The new password does not contain enough different characters"
+#~ msgstr "新密碼與舊密碼間差異字元數不足"
+
+#, c-format
+#~ msgid "Unknown error"
+#~ msgstr "不明錯誤"
+
+#~ msgid ""
+#~ "The username should usually only consist of lower case letters from a-z, "
+#~ "digits and the following characters: - _"
+#~ msgstr "使用者名稱通常僅能包含小寫英文字母 a 至 z、數字與下述字元：- _"
+
+#~ msgid "Sorry, that user name isn’t available. Please try another."
+#~ msgstr "抱歉，該使用者名稱無法使用。請嘗試其他名稱。"
+
+#~ msgid "The username is too long."
+#~ msgstr "使用者名稱過長。"
+
+#, c-format
+#~ msgid "Button %d"
+#~ msgstr "按鍵 %d"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Application defined"
+#~ msgstr "指定的應用程式"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Send Keystroke"
+#~ msgstr "傳送按鍵"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Switch Monitor"
+#~ msgstr "切換顯示器"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "Show On-Screen Help"
+#~ msgstr "在螢幕上顯示按鍵功能"
+
+#~ msgid "Tablet mounted on laptop panel"
+#~ msgstr "繪圖板裝載至筆電面板上"
+
+#~ msgid "Tablet mounted on external display"
+#~ msgstr "繪圖板裝載至外接顯示器上"
+
+#~ msgid "External tablet device"
+#~ msgstr "外接繪圖板裝置"
+
+#~ msgid "All Displays"
+#~ msgstr "所有顯示器"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+#~ msgstr "Airbrush 數位筆搭載壓力感應、傾斜偵測與整合式滑鈕"
+
+#~ msgid "Airbrush stylus with pressure, tilt, and rotation"
+#~ msgstr "Airbrush 數位筆搭載壓力感應、傾斜偵測與旋轉"
+
+#~ msgid "Standard stylus with pressure and tilt"
+#~ msgstr "標準數位筆搭載壓力感應與傾斜偵測"
+
+#~ msgid "Standard stylus with pressure"
+#~ msgstr "標準數位筆搭載壓力感應"
+
+#~ msgid "New shortcut…"
+#~ msgstr "新增快捷鍵…"
+
+#~ msgid "Operation Cancelled"
+#~ msgstr "操作已取消"
+
+#~ msgid "<b>Error:</b> Access denied changing settings"
+#~ msgstr "<b>錯誤：</b>更改設定時存取遭拒"
+
+#~ msgid "<b>Error:</b> Mobile Equipment Error"
+#~ msgstr "<b>錯誤：</b> 行動裝置錯誤"
+
+#~ msgid "Not Registered"
+#~ msgstr "未註冊"
+
+#~ msgid "Registered"
+#~ msgstr "已註冊"
+
+#~ msgid "Roaming"
+#~ msgstr "漫遊中"
+
+#~ msgid "Searching"
+#~ msgstr "搜尋中"
+
+#~ msgid "Denied"
+#~ msgstr "拒絕服務"
+
+#~ msgid "2G Only"
+#~ msgstr "僅 2G"
+
+#~ msgid "3G Only"
+#~ msgstr "僅 3G"
+
+#~ msgid "4G Only"
+#~ msgstr "僅 4G"
+
+#~ msgid "5G Only"
+#~ msgstr "僅 5G"
+
+#~ msgid "2G, 3G, 4G, 5G (Preferred)"
+#~ msgstr "2G、3G、4G、5G（偏好）"
+
+#~ msgid "2G, 3G, 4G (Preferred), 5G"
+#~ msgstr "2G、3G、4G（偏好）、5G"
+
+#~ msgid "2G, 3G (Preferred), 4G, 5G"
+#~ msgstr "2G、3G（偏好）、4G、5G"
+
+#~ msgid "2G (Preferred), 3G, 4G, 5G"
+#~ msgstr "2G（偏好）、3G、4G、5G"
+
+#~ msgid "2G, 3G, 4G, 5G"
+#~ msgstr "2G、3G、4G、5G"
+
+#~ msgid "2G, 3G, 4G (Preferred)"
+#~ msgstr "2G、3G、4G（偏好）"
+
+#~ msgid "2G, 3G (Preferred), 4G"
+#~ msgstr "2G、3G (偏好)、4G"
+
+#~ msgid "2G (Preferred), 3G, 4G"
+#~ msgstr "2G（偏好）、3G、4G"
+
+#~ msgid "2G, 3G, 4G"
+#~ msgstr "2G、3G、4G"
+
+#~ msgid "3G, 4G, 5G (Preferred)"
+#~ msgstr "3G、4G、5G（偏好）"
+
+#~ msgid "3G, 4G (Preferred), 5G"
+#~ msgstr "3G、4G（偏好）、5G"
+
+#~ msgid "3G (Preferred), 4G, 5G"
+#~ msgstr "3G（偏好）、4G、5G"
+
+#~ msgid "3G, 4G, 5G"
+#~ msgstr "3G、4G、5G"
+
+#~ msgid "2G, 4G, 5G (Preferred)"
+#~ msgstr "2G、4G、5G（偏好）"
+
+#~ msgid "2G, 4G (Preferred), 5G"
+#~ msgstr "2G、4G（偏好）、5G"
+
+#~ msgid "2G (Preferred), 4G, 5G"
+#~ msgstr "2G（偏好）、4G、5G"
+
+#~ msgid "2G, 4G, 5G"
+#~ msgstr "2G、3G、5G"
+
+#~ msgid "2G, 3G, 5G (Preferred)"
+#~ msgstr "2G、3G、5G（偏好）"
+
+#~ msgid "2G, 3G (Preferred), 5G"
+#~ msgstr "2G、3G（偏好）、5G"
+
+#~ msgid "2G (Preferred), 3G, 5G"
+#~ msgstr "2G（偏好）、3G、5G"
+
+#~ msgid "2G, 3G, 5G"
+#~ msgstr "2G、3G、5G"
+
+#~ msgid "3G, 4G (Preferred)"
+#~ msgstr "3G、4G（偏好）"
+
+#~ msgid "3G (Preferred), 4G"
+#~ msgstr "3G（偏好）、4G"
+
+#~ msgid "3G, 4G"
+#~ msgstr "3G、4G"
+
+#~ msgid "2G, 4G (Preferred)"
+#~ msgstr "2G、4G（偏好）"
+
+#~ msgid "2G (Preferred), 4G"
+#~ msgstr "2G（偏好）、4G"
+
+#~ msgid "2G, 4G"
+#~ msgstr "2G、4G"
+
+#~ msgid "2G, 3G (Preferred)"
+#~ msgstr "2G、3G（偏好）"
+
+#~ msgid "2G (Preferred), 3G"
+#~ msgstr "2G（偏好）、3G"
+
+#~ msgid "2G, 3G"
+#~ msgstr "2G、3G"
+
+#~ msgid "2G, 5G (Preferred)"
+#~ msgstr "2G、5G（偏好）"
+
+#~ msgid "2G (Preferred), 5G"
+#~ msgstr "2G（偏好）、5G"
+
+#~ msgid "2G, 5G"
+#~ msgstr "2G、5G"
+
+#~ msgid "3G, 5G (Preferred)"
+#~ msgstr "3G、5G（偏好）"
+
+#~ msgid "3G (Preferred), 5G"
+#~ msgstr "3G（偏好）、5G"
+
+#~ msgid "3G, 5G"
+#~ msgstr "3G、5G"
+
+#~ msgid "4G, 5G (Preferred)"
+#~ msgstr "3G、5G（偏好）"
+
+#~ msgid "4G (Preferred), 5G"
+#~ msgstr "4G（偏好）、5G"
+
+#~ msgid "4G, 5G"
+#~ msgstr "4G、5G"
+
+#~ msgctxt "Network mode"
+#~ msgid "Unknown"
+#~ msgstr "不明"
+
+#~ msgid "Unlock SIM card"
+#~ msgstr "解鎖 SIM 卡"
+
+#, c-format
+#~ msgid "Please provide PIN code for SIM %d"
+#~ msgstr "請提供 SIM 卡 %d 的 PIN 碼"
+
+#~ msgid "Enter PIN to unlock your SIM card"
+#~ msgstr "請輸入 PIN 碼以解鎖您的 SIM 卡"
+
+#, c-format
+#~ msgid "Please provide PUK code for SIM %d"
+#~ msgstr "請提供 SIM 卡 %d 的 PUK 碼"
+
+#~ msgid "Enter PUK to unlock your SIM card"
+#~ msgstr "請輸入 PUK 碼以解鎖您的 SIM 卡"
+
+#~ msgid "Wrong password entered."
+#~ msgstr "密碼輸入錯誤。"
+
+#~ msgid "PUK code should be an 8 digit number"
+#~ msgstr "PUK 碼應有 8 位數字"
+
+#~ msgid "Enter New PIN"
+#~ msgstr "輸入新的 PIN 碼"
+
+#~ msgid "PIN code should be a 4-8 digit number"
+#~ msgstr "PIN 碼應為 4-8 位數字"
+
+#~ msgid "Unlocking…"
+#~ msgstr "正在解除鎖定…"
+
+#~ msgid "Phone failure"
+#~ msgstr "手機失敗"
+
+#~ msgid "No connection to phone"
+#~ msgstr "沒有連線連接至手機"
+
+#~ msgid "Operation not allowed"
+#~ msgstr "不允許的操作"
+
+#~ msgid "Operation not supported"
+#~ msgstr "不支援的操作"
+
+#~ msgid "SIM not inserted"
+#~ msgstr "SIM 卡尚未插入"
+
+#~ msgid "SIM PIN required"
+#~ msgstr "需要 SIM 卡的 PIN 碼"
+
+#~ msgid "SIM PUK required"
+#~ msgstr "需要 SIM 卡的 PUK 碼"
+
+#~ msgid "SIM failure"
+#~ msgstr "SIM 卡失敗"
+
+#~ msgid "SIM busy"
+#~ msgstr "SIM 卡忙碌"
+
+#~ msgid "Incorrect password"
+#~ msgstr "密碼不正確"
+
+#~ msgid "SIM PIN2 required"
+#~ msgstr "需要 SIM 卡的 PIN2 碼"
+
+#~ msgid "SIM PUK2 required"
+#~ msgstr "需要 SIM 卡的 PUK2 碼"
+
+#~ msgid "Not found"
+#~ msgstr "找不到"
+
+#~ msgid "No network service"
+#~ msgstr "沒有網路服務"
+
+#~ msgid "Network timeout"
+#~ msgstr "網路逾時"
+
+#~ msgid "GPRS services not allowed"
+#~ msgstr "未允許 GPRS 服務"
+
+#~ msgid "Roaming not allowed in this location area"
+#~ msgstr "此位置區域不允許漫遊"
+
+#~ msgid "Unspecified GPRS error"
+#~ msgstr "不明的 GPRS 錯誤"
+
+#~ msgid "No Error"
+#~ msgstr "沒有錯誤"
+
+#~ msgid "Action Cancelled"
+#~ msgstr "動作取消"
+
+#~ msgid "Access denied"
+#~ msgstr "存取遭拒"
+
+#~ msgid "Unknown Error"
+#~ msgstr "不明錯誤"
+
+#, c-format
+#~ msgid "SIM %d"
+#~ msgstr "SIM %d"
+
+#~ msgid "Display version number"
+#~ msgstr "顯示版本號碼"
+
+#~ msgid "Enable verbose mode"
+#~ msgstr "啟用詳細模式"
+
+#~ msgid "Search for the string"
+#~ msgstr "搜尋字串"
+
+#~ msgid "List possible panel names and exit"
+#~ msgstr "列出可能的面板名稱並結束"
+
+#~ msgid "Panel to display"
+#~ msgstr "要顯示的面板"
+
+#~ msgid "[PANEL] [ARGUMENT…]"
+#~ msgstr "[面板] [參數…]"
+
+#~ msgid "Available panels:"
+#~ msgstr "可用的面板："
+
+#~ msgid "System Sounds"
+#~ msgstr "系統音效"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "錯誤：無法確認 HSI 等級。"
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "錯誤：無法確認不正確的 HSI 等級。"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER 或 PEM 憑證 (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Drip"
+#~ msgstr "水滴聲"
+
+#~ msgid "Glass"
+#~ msgstr "敲玻璃聲"
+
+#~ msgid "Sonar"
+#~ msgstr "聲納"
+
+#~ msgid "No Protection"
+#~ msgstr "缺乏防護"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "最小防護"
+
+#~ msgid "Basic Protection"
+#~ msgstr "基本防護"
+
+#~ msgid "Extended Protection"
+#~ msgstr "延伸防護"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "最小的安全性防護"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "基本的安全性防護"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "延伸的安全性防護"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "安全開機非作用中"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI 寫入"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI 鎖定"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "核心污染"
+
+#, fuzzy
+#~ msgid "Suspend-to-ram"
+#~ msgstr "暫停（暫存至記憶體）"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "MEI 製造模式"
+
+#~ msgid "MEI version"
+#~ msgstr "MEI 版本"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "fwupd 擴充套件"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "IOMMU 裝置防護已啟用"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "IOMMU 裝置防護已停用"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "核心遭受污染"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "核心鎖定已停用"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "核心鎖定已啟用"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "安全開機已停用"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "安全開機已啟用"
+
+#~ msgid "Lock your screen"
+#~ msgstr "鎖定您的螢幕"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "排列顯示器的組合方式"
+
+#~ msgid "Light"
+#~ msgstr "明亮"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;螢幕;鎖定;診斷;隱私;最近使用;暫存;索引;名稱;網路;身分;"
+
+#~ msgid "Set"
+#~ msgstr "設定"
+
+#~ msgid "Bark"
+#~ msgstr "汪汪"
 
 #~ msgid "Web Links"
 #~ msgstr "網頁連結"
@@ -8679,17 +8379,11 @@ msgstr "系統音效"
 #~ msgid "Active Display"
 #~ msgstr "使用中顯示器"
 
-#~ msgid "Display Configuration"
-#~ msgstr "顯示器設定"
-
 #~ msgid "More Warm"
 #~ msgstr "變得更暖"
 
 #~ msgid "Less Warm"
 #~ msgstr "變得更冷"
-
-#~ msgid "Screenshots"
-#~ msgstr "螢幕擷圖"
 
 #~ msgid "Save a screenshot to $PICTURES"
 #~ msgstr "將螢幕擷圖儲存為 $PICTURES"
@@ -8840,17 +8534,11 @@ msgstr "系統音效"
 #~ "connecting to %s"
 #~ msgstr "螢幕分享允許遠端使用者連線到 %s 以檢視或控制您的螢幕"
 
-#~ msgid "Copy"
-#~ msgstr "複製"
-
 #~ msgid "_Screen Sharing"
 #~ msgstr "螢幕分享(_S)"
 
 #~ msgid "Some services are disabled because of no network access."
 #~ msgstr "由於沒有網路存取，某些服務已停用。"
-
-#~ msgid "Screen Sharing"
-#~ msgstr "螢幕分享"
 
 #~ msgid "_Password:"
 #~ msgstr "密碼(_P)："
@@ -8872,9 +8560,6 @@ msgstr "系統音效"
 
 #~ msgid "_Screen Reader"
 #~ msgstr "螢幕閱讀器(_S)"
-
-#~ msgid "_Full Name"
-#~ msgstr "全名(_F)"
 
 #~ msgid "Standard"
 #~ msgstr "標準"
@@ -8939,9 +8624,6 @@ msgstr "系統音效"
 
 #~ msgid "Tablet (absolute)"
 #~ msgstr "繪圖板 (絕對位置)"
-
-#~ msgid "Touchpad (relative)"
-#~ msgstr "觸控板 (相對位置)"
 
 #~ msgid "Tablet Preferences"
 #~ msgstr "繪圖板偏好設定"
@@ -9120,9 +8802,6 @@ msgstr "系統音效"
 
 #~ msgid "Access bluetooth hardware directly"
 #~ msgstr "直接存取藍牙硬體"
-
-#~ msgid "Use your camera"
-#~ msgstr "使用相機"
 
 #~ msgid "Print documents"
 #~ msgstr "列印文件"
@@ -9812,9 +9491,6 @@ msgstr "系統音效"
 #~ msgid "Co­lor"
 #~ msgstr "色彩"
 
-#~ msgid "Section"
-#~ msgstr "節"
-
 #~ msgid "Overview"
 #~ msgstr "概覽"
 
@@ -9873,9 +9549,6 @@ msgstr "系統音效"
 
 #~ msgid "Mirrored"
 #~ msgstr "相同顯示"
-
-#~ msgid "Secondary"
-#~ msgstr "次要"
 
 #~ msgid "Arrange Combined Displays"
 #~ msgstr "排列顯示器的組合方式"
@@ -10018,9 +9691,6 @@ msgstr "系統音效"
 #~ msgid "4"
 #~ msgstr "4"
 
-#~ msgid "Loading options…"
-#~ msgstr "正在載入選項…"
-
 #~ msgctxt "Password hint"
 #~ msgid "Try to add more letters, numbers and symbols."
 #~ msgstr "試著加入更多字母、數字和標點符號。"
@@ -10048,9 +9718,6 @@ msgstr "系統音效"
 #~ msgid "<small>Your account</small>"
 #~ msgstr "<small>您的帳號</small>"
 
-#~ msgid "Edit"
-#~ msgstr "編輯"
-
 #~ msgctxt "button"
 #~ msgid "Set Shortcut"
 #~ msgstr "設定捷徑鍵"
@@ -10068,9 +9735,6 @@ msgstr "系統音效"
 #~ msgid "Mail"
 #~ msgstr "郵件"
 
-#~ msgid "Calendar"
-#~ msgstr "行事曆"
-
 #~ msgid "Contacts"
 #~ msgstr "連絡人"
 
@@ -10085,9 +9749,6 @@ msgstr "系統音效"
 
 #~ msgid "This will not remove the account on the server."
 #~ msgstr "這不會移除伺服器上的帳號。"
-
-#~ msgid "_Remove"
-#~ msgstr "移除(_R)"
 
 #~ msgid "No online accounts configured"
 #~ msgstr "尚未設定線上帳號"
@@ -10131,9 +9792,6 @@ msgstr "系統音效"
 
 #~ msgid "label"
 #~ msgstr "標籤"
-
-#~ msgid "Setting new driver…"
-#~ msgstr "正在設定新的驅動程式…"
 
 #~ msgid "Print _Test Page"
 #~ msgstr "列印測試頁(_T)"
@@ -10211,17 +9869,11 @@ msgstr "系統音效"
 #~ msgid "Bottom Button #%d"
 #~ msgstr "底部按鈕 #%d"
 
-#~ msgid "No Action"
-#~ msgstr "沒有動作"
-
 #~ msgid "Left Mouse Button Click"
 #~ msgstr "滑鼠左鍵點擊"
 
 #~ msgid "Scroll Up"
 #~ msgstr "向上捲動"
-
-#~ msgid "Scroll Down"
-#~ msgstr "向下捲動"
 
 #~ msgid "Scroll Right"
 #~ msgstr "向右捲動"
@@ -10355,9 +10007,6 @@ msgstr "系統音效"
 #~ msgid "Other"
 #~ msgstr "其他"
 
-#~ msgid "Personal File Sharing"
-#~ msgstr "個人檔案分享"
-
 #~ msgid "_Verify"
 #~ msgstr "驗證(_V)"
 
@@ -10388,9 +10037,6 @@ msgstr "系統音效"
 
 #~ msgid "Job State"
 #~ msgstr "工作狀態"
-
-#~ msgid "Options"
-#~ msgstr "選項"
 
 #~ msgid "Password:"
 #~ msgstr "密碼："
@@ -10472,9 +10118,6 @@ msgstr "系統音效"
 #~ msgid "Fast"
 #~ msgstr "快速"
 
-#~ msgid "No printers available"
-#~ msgstr "沒有可用的印表機"
-
 #~ msgid "Add New Printer"
 #~ msgstr "加入新的印表機"
 
@@ -10537,9 +10180,6 @@ msgstr "系統音效"
 #~ msgid "China"
 #~ msgstr "中國"
 
-#~ msgid "Disable while _typing"
-#~ msgstr "打字時停用(_T)"
-
 #~ msgid "The system network services are not compatible with this version."
 #~ msgstr "系統網路服務與這個版本不相容。"
 
@@ -10577,9 +10217,6 @@ msgstr "系統音效"
 
 #~ msgid "Immediately"
 #~ msgstr "立即"
-
-#~ msgid "Flickr"
-#~ msgstr "Flickr"
 
 #~ msgid "Set Up New Device"
 #~ msgstr "設置新裝置"
@@ -10952,9 +10589,6 @@ msgstr "系統音效"
 #~ msgid "C_ontinue"
 #~ msgstr "繼續(_O)"
 
-#~ msgid "Previous Week"
-#~ msgstr "前一週"
-
 #~ msgid "Next Week"
 #~ msgstr "下一週"
 
@@ -11098,9 +10732,6 @@ msgstr "系統音效"
 #~ msgid "Chinese (simplified)"
 #~ msgstr "簡體中文"
 
-#~ msgid "Select a region"
-#~ msgstr "選擇地區"
-
 #~ msgid "Date and Time preferences panel"
 #~ msgstr "日期和時刻偏好設定面板"
 
@@ -11124,9 +10755,6 @@ msgstr "系統音效"
 
 #~ msgid "Manufacturers"
 #~ msgstr "製造商"
-
-#~ msgid "Privacy settings"
-#~ msgstr "隱私設定值"
 
 #~ msgid "Don't retain history"
 #~ msgstr "不要保留歷史紀錄"

--- a/po/zh_TW.po~
+++ b/po/zh_TW.po~
@@ -1,0 +1,12169 @@
+# Chinese (Taiwan) translation of gnome-control-center.
+# Copyright (C) 1999, 2001-07 Free Software Foundation, Inc.
+# GNOME 1.x:
+# GNOME 2.x:
+#
+# S.J. Luo <crystal@mickey.ee.nctu.edu.tw>, 1999.
+# Abel Cheung <abel@oaka.org>, 2001-2002.
+# Abel Cheung <abel@oaka.org>, 2001-2003, 2005.
+# Woodman Tuen <wmtuen@gmail.com>, 2004-07.
+# Chao-Hsiung Liao <j_h_liau@yahoo.com.tw>, 2010.
+# Wei-Lun Chao <chaoweilun@gmail.com>, 2010.
+# pan93412 <pan93412@gmail.com>, 2019.
+# Freddy Cheng <freddy4212@gmail.com>, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center 3.3.91\n"
+"Report-Msgid-Bugs-To: https://gitlab.gnome.org/GNOME/gnome-control-center/"
+"issues\n"
+"POT-Creation-Date: 2022-10-25 14:38+0000\n"
+"PO-Revision-Date: 2022-11-29 23:55+0800\n"
+"Last-Translator: Cheng-Chia Tseng <pswo10680@gmail.com>\n"
+"Language-Team: Chinese - Taiwan <chinese-l10n@googlegroups.com>\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: panels/applications/cc-applications-panel.c:822
+msgid "System Bus"
+msgstr "系統匯流排"
+
+#: panels/applications/cc-applications-panel.c:822
+#: panels/applications/cc-applications-panel.c:824
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:842
+msgid "Full access"
+msgstr "可以完全取用"
+
+#: panels/applications/cc-applications-panel.c:824
+msgid "Session Bus"
+msgstr "作業階段匯流排"
+
+#: panels/applications/cc-applications-panel.c:828
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr "裝置"
+
+#: panels/applications/cc-applications-panel.c:828
+msgid "Full access to /dev"
+msgstr "可以完全取用 /dev"
+
+#: panels/applications/cc-applications-panel.c:832
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+msgid "Network"
+msgstr "網路"
+
+#: panels/applications/cc-applications-panel.c:832
+msgid "Has network access"
+msgstr "可以取用網路"
+
+#: panels/applications/cc-applications-panel.c:837
+#: panels/applications/cc-applications-panel.c:839
+#: panels/search/cc-search-locations-dialog.c:384
+msgid "Home"
+msgstr "家目錄"
+
+#: panels/applications/cc-applications-panel.c:839
+#: panels/applications/cc-applications-panel.c:844
+msgid "Read-only"
+msgstr "僅能讀取"
+
+#: panels/applications/cc-applications-panel.c:842
+#: panels/applications/cc-applications-panel.c:844
+msgid "File System"
+msgstr "檔案系統"
+
+#: panels/applications/cc-applications-panel.c:848
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.c:246
+#: shell/cc-window.c:880 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
+msgid "Settings"
+msgstr "設定值"
+
+#: panels/applications/cc-applications-panel.c:848
+msgid "Can change settings"
+msgstr "可以更改設定值"
+
+#: panels/applications/cc-applications-panel.c:850
+#, c-format
+msgid ""
+"%s has the following permissions built-in. These cannot be altered. If you "
+"are concerned about these permissions, consider removing this application."
+msgstr ""
+"《%s》內建下列權限並且無法更改。若您對這些權限設定有疑慮，請考慮移除應用程"
+"式。"
+
+#: panels/applications/cc-applications-panel.c:1192
+#, c-format
+msgid "%u file and link type that is opened by the app"
+msgid_plural "%u file and link types that are opened by the app"
+msgstr[0] "有 %u 種類型的檔案與連結使用這個應用程式開啟"
+
+#: panels/applications/cc-applications-panel.c:1199
+#, c-format
+msgid "<b>%s</b> is used to open the following types of files and links."
+msgstr "《%s》用於開啟下列的檔案與連結類型。"
+
+#. Translators: '%s' is the formatted size, e.g. "26.2 MB"
+#: panels/applications/cc-applications-panel.c:1251
+#, c-format
+msgid "%s of disk space used."
+msgstr "已使用 %s 的磁碟空間。"
+
+#. List of applications.
+#: panels/applications/cc-applications-panel.c:1415
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
+msgid "Applications"
+msgstr "應用程式"
+
+#: panels/applications/cc-applications-panel.ui:31
+msgid "No applications"
+msgstr "沒有應用程式"
+
+#: panels/applications/cc-applications-panel.ui:34
+msgid "Install some…"
+msgstr "安裝一些…"
+
+#: panels/applications/cc-applications-panel.ui:84
+#: panels/network/wireless-security/ws-file-chooser-button.c:96
+msgid "Open"
+msgstr "開啟"
+
+#: panels/applications/cc-applications-panel.ui:94
+msgid "View Details"
+msgstr "檢視詳細資料"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "搜尋"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
+msgstr "接收系統搜尋請求與傳送搜尋結果。"
+
+#. This label is displayed in a treeview cell displaying
+#. * a disabled accelerator key combination.
+#.
+#. TRANSLATORS: Status of Parental Controls setup
+#. translators:
+#. * The device has been disabled
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/keyboard/cc-xkb-modifier-dialog.c:344
+#: panels/keyboard/keyboard-shortcuts.c:367 panels/network/network-proxy.ui:107
+#: panels/user-accounts/cc-user-panel.c:804
+#: panels/user-accounts/cc-user-panel.c:907
+#: panels/wwan/cc-wwan-device-page.c:478
+#: subprojects/gvc/gvc-mixer-control.c:1908
+msgid "Disabled"
+msgstr "已停用"
+
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+msgid "Notifications"
+msgstr "通知"
+
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr "顯示系統通知。"
+
+#: panels/applications/cc-applications-panel.ui:133
+msgid "Run in Background"
+msgstr "背景執行"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr "應用程式關閉時仍允許活動。"
+
+#: panels/applications/cc-applications-panel.ui:140
+msgid "Screenshots"
+msgstr "螢幕快照"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr "隨時擷取螢幕快照。"
+
+#: panels/applications/cc-applications-panel.ui:147
+msgid "Change Wallpaper"
+msgstr "更換桌布"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr "更換桌面背景。"
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+msgid "Sounds"
+msgstr "聲音"
+
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
+msgstr "發出聲音。"
+
+#: panels/applications/cc-applications-panel.ui:168
+msgid "Inhibit Shortcuts"
+msgstr "暫時停用快捷鍵"
+
+#: panels/applications/cc-applications-panel.ui:169
+msgid "Block standard keyboard shortcuts."
+msgstr "封鎖常規的系統快捷鍵。"
+
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
+msgstr "相機"
+
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr "透過相機拍攝相片。"
+
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr "麥克風"
+
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr "透過麥克風錄製聲音。"
+
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr "定位服務"
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr "存取裝置的位置資訊。"
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr "內建的權限"
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr "應用程式所要求的系統取用權"
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr "關聯的檔案與連結"
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr "儲存空間"
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr "找不到結果"
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr "嘗試不同的搜尋內容"
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr "關聯的檔案與連結"
+
+#: panels/applications/cc-applications-panel.ui:374
+msgid "File Types"
+msgstr "檔案類型"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr "連結類型"
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr "重設"
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr "應用程式的資料與快取所佔用的磁碟空間。"
+
+#: panels/applications/cc-applications-panel.ui:420
+msgid "Application"
+msgstr "應用程式"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr "資料"
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr "快取"
+
+#: panels/applications/cc-applications-panel.ui:438
+msgid "<b>Total</b>"
+msgstr "<b>總計</b>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr "清除快取…"
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr "控制各應用程式的權限與設定值"
+
+#. Translators: Search terms to find the Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+"application;flatpak;permission;setting;應用程式;權限;應用;設定;設置;安全;快"
+"取;關聯;連結;"
+
+#: panels/background/cc-background-chooser.c:312
+msgid "Select a picture"
+msgstr "選取圖片"
+
+#: panels/background/cc-background-chooser.c:315
+#: panels/color/cc-color-calibrate.ui:22 panels/color/cc-color-panel.c:284
+#: panels/color/cc-color-panel.c:844 panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/cc-wifi-panel.c:886
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/network/connection-editor/vpn-helpers.c:221
+#: panels/network/connection-editor/vpn-helpers.c:341
+#: panels/network/net-device-wifi.c:866
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/printers/pp-details-dialog.c:269
+#: panels/region/cc-format-chooser.ui:24
+#: panels/search/cc-search-locations-dialog.c:677
+#: panels/sharing/cc-sharing-panel.c:522 panels/usage/cc-usage-panel.c:139
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-avatar-chooser.c:96
+#: panels/user-accounts/cc-avatar-chooser.c:167
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/cc-user-panel.c:594
+#: panels/user-accounts/cc-user-panel.c:612
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr "取消(_C)"
+
+#: panels/background/cc-background-chooser.c:316
+#: panels/network/connection-editor/vpn-helpers.c:222
+#: panels/printers/pp-details-dialog.c:270
+#: panels/sharing/cc-sharing-panel.c:523
+#: panels/user-accounts/cc-avatar-chooser.c:168
+msgid "_Open"
+msgstr "開啟(_O)"
+
+#: panels/background/cc-background-item.c:169
+msgid "multiple sizes"
+msgstr "多重尺寸"
+
+#. translators: 100 × 100px
+#. * Note that this is not an "x", but U+00D7 MULTIPLICATION SIGN
+#: panels/background/cc-background-item.c:173
+#, c-format
+msgid "%d × %d"
+msgstr "%d × %d"
+
+#: panels/background/cc-background-item.c:325
+msgid "No Desktop Background"
+msgstr "無桌面背景"
+
+#: panels/background/cc-background-panel.c:227
+msgid "Current background"
+msgstr "目前的背景"
+
+#: panels/background/cc-background-panel.ui:9
+msgid "Style"
+msgstr "風格"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+msgid "Default"
+msgstr "預設"
+
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
+msgstr "深色"
+
+#: panels/background/cc-background-panel.ui:98
+msgid "Background"
+msgstr "背景"
+
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr "加入圖片…"
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr "外觀"
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr "更改背景影像或使用者介面色彩"
+
+#. Translators: Search terms to find the Appearance panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+"Background;Wallpaper;Screen;Desktop;Style;Light;Dark;背景;桌布;螢幕;風格;明"
+"亮;黑暗;亮色;暗色;深色;淺色;"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr "啟用"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr "找不到藍牙"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr "接上藍牙配接器以使用藍牙。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr "藍牙已關閉"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr "開啟以連接裝置和接收檔案傳輸。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr "飛安模式已開啟"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr "飛安模式開啟時會停用藍牙。"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr "關閉飛安模式"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr "硬體飛安模式已開啟"
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr "關閉飛安模式開關以啟用藍牙。"
+
+#. Translators: The found device is a printer connected via Bluetooth
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+#: panels/printers/pp-new-printer-dialog.c:1383
+msgid "Bluetooth"
+msgstr "藍牙"
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr "開啟或關閉藍牙與連接您的裝置"
+
+#. Translators: Search terms to find the Bluetooth panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr "share;sharing;bluetooth;obex;分享;藍牙;"
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr "相機已關閉"
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr "沒有應用程式能拍攝相片或錄製影片。"
+
+#: panels/camera/cc-camera-panel.ui:39
+msgid ""
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
+"相機的使用可允許應用程式拍攝相片或錄製影片。停用相機可能導致部分應用程式不能"
+"正常運作。\n"
+"\n"
+"允許下列應用程式使用您的相機。"
+
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr "沒有應用程式請求取用相機"
+
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr "保護您的照片"
+
+#. Translators: Search terms to find the Camera panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
+"camera;photos;video;webcam;lock;private;privacy;相機;照片;影片;網路攝影機;鎖"
+"定相機;隱私權;"
+
+#. TRANSLATORS: The user has to attach the sensor to the screen
+#: panels/color/cc-color-calibrate.c:347
+msgid "Place your calibration device over the square and press “Start”"
+msgstr "將您的校準裝置放在方塊上方，並按下「開始」"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:353
+msgid ""
+"Move your calibration device to the calibrate position and press “Continue”"
+msgstr "將您的校準裝置移至校準位置，並按下「繼續」"
+
+#. TRANSLATORS: Some calibration devices need the user to move a
+#. * dial or switch manually. We also show a picture showing them
+#. * what to do...
+#: panels/color/cc-color-calibrate.c:359
+msgid ""
+"Move your calibration device to the surface position and press “Continue”"
+msgstr "將您的校準裝置移至表面位置，並按下「繼續」"
+
+#. TRANSLATORS: on some hardware e.g. Lenovo W700 the sensor
+#. * is built into the palmrest and we need to fullscreen the
+#. * sample widget and shut the lid.
+#: panels/color/cc-color-calibrate.c:365
+msgid "Shut the laptop lid"
+msgstr "請闔上筆記型電腦"
+
+#. TRANSLATORS: We suck, the calibration failed and we have no
+#. * good idea why or any suggestions
+#: panels/color/cc-color-calibrate.c:396
+msgid "An internal error occurred that could not be recovered."
+msgstr "發生內部的錯誤，無法還原。"
+
+#. TRANSLATORS: Some required-at-runtime tools were not
+#. * installed, which should only affect insane distros
+#: panels/color/cc-color-calibrate.c:401
+msgid "Tools required for calibration are not installed."
+msgstr "校準所需的工具尚未安裝。"
+
+#. TRANSLATORS: The profile failed for some reason
+#: panels/color/cc-color-calibrate.c:407
+msgid "The profile could not be generated."
+msgstr "無法產生描述檔。"
+
+#. TRANSLATORS: The user specified a whitepoint that was
+#. * unobtainable with the hardware they've got -- see
+#. * https://en.wikipedia.org/wiki/White_point for details
+#: panels/color/cc-color-calibrate.c:413
+msgid "The target whitepoint was not obtainable."
+msgstr "無法取得目標白點。"
+
+#. TRANSLATORS: the display calibration process is finished
+#: panels/color/cc-color-calibrate.c:452
+msgid "Complete!"
+msgstr "完成！"
+
+#. TRANSLATORS: the display calibration failed, and we also show
+#. * the translated (or untranslated) error string after this
+#: panels/color/cc-color-calibrate.c:460
+msgid "Calibration failed!"
+msgstr "校準失敗！"
+
+#. TRANSLATORS: The user can now remove the sensor from the screen
+#: panels/color/cc-color-calibrate.c:467
+msgid "You can remove the calibration device."
+msgstr "您可以移除校準裝置。"
+
+#. TRANSLATORS: The user has to be careful not to knock the
+#. * display off the screen (although we do cope if this is
+#. * detected early enough)
+#: panels/color/cc-color-calibrate.c:535
+msgid "Do not disturb the calibration device while in progress"
+msgstr "校準過程中請勿干擾校準裝置"
+
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr "顯示器校準"
+
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr "開始(_S)"
+
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr "繼續(_R)"
+
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr "完成(_D)"
+
+#. TRANSLATORS: This refers to the TFT display on a laptop
+#: panels/color/cc-color-common.c:41
+msgid "Laptop Screen"
+msgstr "筆記型電腦螢幕"
+
+#. TRANSLATORS: This refers to the embedded webcam on a laptop
+#: panels/color/cc-color-common.c:50
+msgid "Built-in Webcam"
+msgstr "內建的網路攝影機"
+
+#. TRANSLATORS: an externally connected display, where %s is either the
+#. * model, vendor or ID, e.g. 'LP2480zx Monitor'
+#: panels/color/cc-color-common.c:65
+#, c-format
+msgid "%s Monitor"
+msgstr "%s 顯示器"
+
+#. TRANSLATORS: a flatbed scanner device, e.g. 'Epson Scanner'
+#: panels/color/cc-color-common.c:69
+#, c-format
+msgid "%s Scanner"
+msgstr "%s 掃描器"
+
+#. TRANSLATORS: a camera device, e.g. 'Nikon D60 Camera'
+#: panels/color/cc-color-common.c:73
+#, c-format
+msgid "%s Camera"
+msgstr "%s 照相機"
+
+#. TRANSLATORS: a printer device, e.g. 'Epson Photosmart Printer'
+#: panels/color/cc-color-common.c:77
+#, c-format
+msgid "%s Printer"
+msgstr "%s 印表機"
+
+#. TRANSLATORS: a webcam device, e.g. 'Philips HiDef Camera'
+#: panels/color/cc-color-common.c:81
+#, c-format
+msgid "%s Webcam"
+msgstr "%s 網路攝影機"
+
+#: panels/color/cc-color-device.c:87
+#, c-format
+msgid "Enable color management for %s"
+msgstr "啟用 %s 的色彩管理"
+
+#: panels/color/cc-color-device.c:92
+#, c-format
+msgid "Show color profiles for %s"
+msgstr "顯示 %s 的色彩描述檔"
+
+#. not calibrated
+#: panels/color/cc-color-device.c:292
+msgid "Not calibrated"
+msgstr "尚未校準"
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile has been auto-generated for this hardware
+#: panels/color/cc-color-panel.c:160
+msgid "Default: "
+msgstr "預設值："
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile his a standard space like AdobeRGB
+#: panels/color/cc-color-panel.c:168
+msgid "Colorspace: "
+msgstr "色彩空間："
+
+#. TRANSLATORS: this is a profile prefix to signify the
+#. * profile is a test profile
+#: panels/color/cc-color-panel.c:175
+msgid "Test profile: "
+msgstr "測試用描述檔："
+
+#. TRANSLATORS: an ICC profile is a file containing colorspace data
+#: panels/color/cc-color-panel.c:282
+msgid "Select ICC Profile File"
+msgstr "選擇 ICC 色彩描述檔"
+
+#: panels/color/cc-color-panel.c:285
+msgid "_Import"
+msgstr "匯入(_I)"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:296
+msgid "Supported ICC profiles"
+msgstr "支援的 ICC 色彩描述檔"
+
+#. TRANSLATORS: filter name on the file->open dialog
+#: panels/color/cc-color-panel.c:303
+#: panels/network/wireless-security/eap-method-fast.c:357
+msgid "All files"
+msgstr "所有檔案"
+
+#: panels/color/cc-color-panel.c:586
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "螢幕"
+
+#. TRANSLATORS: this is the dialog to save the ICC profile
+#: panels/color/cc-color-panel.c:841
+msgid "Save Profile"
+msgstr "儲存描述檔"
+
+#: panels/color/cc-color-panel.c:845
+#: panels/network/connection-editor/vpn-helpers.c:342
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "儲存(_S)"
+
+#. TRANSLATORS: this is when the button is sensitive
+#: panels/color/cc-color-panel.c:1146
+msgid "Create a color profile for the selected device"
+msgstr "為所選的裝置建立色彩描述檔"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1161 panels/color/cc-color-panel.c:1185
+msgid ""
+"The measuring instrument is not detected. Please check it is turned on and "
+"correctly connected."
+msgstr "未偵測到測量儀器，請檢查是否已開啟並正確連接。"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1195
+msgid "The measuring instrument does not support printer profiling."
+msgstr "測量儀器不支援印表機分析。"
+
+#. TRANSLATORS: this is when the button is insensitive
+#: panels/color/cc-color-panel.c:1206
+msgid "The device type is not currently supported."
+msgstr "目前不支援這個裝置類型。"
+
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
+msgid "Screen Calibration"
+msgstr "螢幕校準"
+
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr "校準品質"
+
+#: panels/color/cc-color-panel.ui:21
+msgid ""
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
+msgstr ""
+"校準能建立用於管理螢幕色彩的描述檔。校準所花費的時間愈長，描述檔的品質就愈"
+"好。"
+
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr "校準進行時無法使用您的電腦。"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr "品質"
+
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr "大約時間"
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr "校準裝置"
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr "選擇您要用於校準的偵測裝置。"
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr "顯示類型"
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr "選擇連接的顯示器類型。"
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr "描述檔白點"
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr "選擇一個顯示目標白點；大多數顯示器應校準至 D65 光源。"
+
+#: panels/color/cc-color-panel.ui:187
+msgid "Display Brightness"
+msgstr "顯示亮度"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+"請將顯示器的亮度設定為您常用的狀態，色彩管理會以這個亮度等級進行最正確的調"
+"整。"
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr "或者，您可以使用這個裝置的其他描述檔所適用的亮度等級。"
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr "描述檔名稱"
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr "您可以在不同電腦上使用色彩描述檔，或是為不同的亮度條件建立描述檔。"
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr "描述檔名稱："
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr "摘要"
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr "描述檔製作成功！"
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr "複製描述檔"
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr "需要可寫入的媒體"
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+"您可以找到如何在 <a href=\"linux\">GNU/Linux</a>、<a href=\"osx\">Apple "
+"macOS</a> 與 <a href=\"windows\">Microsoft Windows</a> 系統上使用描述檔的指"
+"引。"
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr "加入描述檔"
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr "偵測到問題，描述檔可能無法正常運作。<a href=\"\">顯示詳細資料。</a>"
+
+#: panels/color/cc-color-panel.ui:384
+msgid "_Import File…"
+msgstr "載入檔案(_I)…"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/network/connection-editor/net-connection-editor.c:503
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+msgid "_Add"
+msgstr "加入(_A)"
+
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr "每個裝置需要最新的色彩描述檔才能進行色彩管理。"
+
+#. translators: Text used in link to privacy policy
+#: panels/color/cc-color-panel.ui:434
+#: panels/diagnostics/cc-diagnostics-panel.c:137
+msgid "Learn more"
+msgstr "深入瞭解"
+
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr "深入瞭解色彩管理的相關資訊"
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr "所有使用者皆可用(_S)"
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr "將這個描述檔提供給電腦上的所有使用者"
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr "啟用(_E)"
+
+#: panels/color/cc-color-panel.ui:497
+msgid "_Add profile"
+msgstr "加入描述檔(_A)"
+
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr "校準(_C)…"
+
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr "校準裝置"
+
+#: panels/color/cc-color-panel.ui:511
+msgid "_Remove profile"
+msgstr "移除描述檔(_R)"
+
+#: panels/color/cc-color-panel.ui:517
+msgid "_View details"
+msgstr "檢視詳細資料(_V)"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr "無法偵測到任何能進行色彩管理的裝置"
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr "LCD"
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr "LED"
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr "CRT"
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr "投影機"
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr "電漿"
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr "LCD（CCFL 背光）"
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr "LCD（RGB LED 背光）"
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr "LCD（白色 LED 背光）"
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr "廣色域 LCD（CCFL 背光）"
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr "廣色域 LCD（RGB LED 背光）"
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr "高"
+
+#: panels/color/cc-color-panel.ui:631
+msgid "40 minutes"
+msgstr "40 分鐘"
+
+#: panels/color/cc-color-panel.ui:635
+msgctxt "Calibration quality"
+msgid "Medium"
+msgstr "中"
+
+#: panels/color/cc-color-panel.ui:636
+msgid "30 minutes"
+msgstr "30 分鐘"
+
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr "低"
+
+#: panels/color/cc-color-panel.ui:641
+msgid "15 minutes"
+msgstr "15 分鐘"
+
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr "顯示器原生設定"
+
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr "D50（列印與出版）"
+
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr "D55"
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr "D65（攝影與繪圖）"
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr "D75"
+
+#. TRANSLATORS: standard spaces are well known colorspaces like
+#. * sRGB, AdobeRGB and ProPhotoRGB
+#: panels/color/cc-color-profile.c:98
+msgid "Standard Space"
+msgstr "標準色彩空間"
+
+#. TRANSLATORS: test profiles do things like changing the screen
+#. * a different color, or swap the red and green channels
+#: panels/color/cc-color-profile.c:104
+msgid "Test Profile"
+msgstr "測試用描述檔"
+
+#. TRANSLATORS: automatic profiles are generated automatically
+#. * by the color management system based on manufacturing data,
+#. * for instance the default monitor profile is created from the
+#. * primaries specified in the monitor EDID
+#: panels/color/cc-color-profile.c:112
+msgctxt "Automatically generated profile"
+msgid "Automatic"
+msgstr "自動"
+
+#. TRANSLATORS: the profile quality - low quality profiles take
+#. * much less time to generate but may be a poor reflection of the
+#. * device capability
+#: panels/color/cc-color-profile.c:122
+msgctxt "Profile quality"
+msgid "Low Quality"
+msgstr "低品質"
+
+#. TRANSLATORS: the profile quality
+#: panels/color/cc-color-profile.c:127
+msgctxt "Profile quality"
+msgid "Medium Quality"
+msgstr "中品質"
+
+#. TRANSLATORS: the profile quality - high quality profiles take
+#. * a *long* time, and have the best calibration and
+#. * characterisation data.
+#: panels/color/cc-color-profile.c:134
+msgctxt "Profile quality"
+msgid "High Quality"
+msgstr "高品質"
+
+#. TRANSLATORS: this default RGB space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:151
+msgctxt "Colorspace fallback"
+msgid "Default RGB"
+msgstr "預設 RGB"
+
+#. TRANSLATORS: this default CMYK space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:158
+msgctxt "Colorspace fallback"
+msgid "Default CMYK"
+msgstr "預設 CMYK"
+
+#. TRANSLATORS: this default gray space is used for printers that
+#. * do not have additional printer profiles specified in the PPD
+#: panels/color/cc-color-profile.c:165
+msgctxt "Colorspace fallback"
+msgid "Default Gray"
+msgstr "預設灰階"
+
+#: panels/color/cc-color-profile.c:188
+msgid "Vendor supplied factory calibration data"
+msgstr "廠商提供的出廠校準資料"
+
+#: panels/color/cc-color-profile.c:197
+msgid "Full-screen display correction not possible with this profile"
+msgstr "這個描述檔無法使用全螢幕顯示校準"
+
+#: panels/color/cc-color-profile.c:219
+msgid "This profile may no longer be accurate"
+msgstr "這個描述檔可能不再準確"
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+msgid "Color"
+msgstr "色彩"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr "校準您裝置的色彩，像是顯示器、攝影機或印表機"
+
+#. Translators: Search terms to find the Color panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+"Color;ICC;Profile;Calibrate;Printer;Display;顏色;色彩描述檔;校準;校正;印表機;"
+"顯示器;色彩管理;攝影;設計;出版;多媒體;"
+
+#: panels/common/cc-common-language.c:300
+msgid "Other…"
+msgstr "其他…"
+
+#: panels/common/cc-language-chooser.ui:5
+msgid "Select Language"
+msgstr "選擇語言"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "選擇(_S)"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr "找不到語言"
+
+#: panels/common/cc-language-chooser.ui:69
+#: panels/keyboard/cc-input-chooser.c:173
+msgid "More…"
+msgstr "更多…"
+
+#: panels/common/cc-permission-infobar.c:109
+msgid "Unlock to Change Settings"
+msgstr "解鎖以更改設定"
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr "部分設定需先解鎖才能進行更動。"
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr "解除鎖定…"
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr "遞增小時"
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr "遞增分鐘"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/common/cc-time-editor.ui:73
+msgid "Time"
+msgstr "時間"
+
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr "遞減小時"
+
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr "遞減分鐘"
+
+#: panels/common/cc-util.c:127
+#: panels/network/connection-editor/ce-page-details.c:168
+msgid "Today"
+msgstr "今天"
+
+#: panels/common/cc-util.c:131
+#: panels/network/connection-editor/ce-page-details.c:170
+msgid "Yesterday"
+msgstr "昨天"
+
+#. Translators: This is a date format string in the style of "Feb 24".
+#: panels/common/cc-util.c:138
+msgid "%b %e"
+msgstr "%-m月%-e日"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013".
+#: panels/common/cc-util.c:143
+msgid "%b %e, %Y"
+msgstr "%Y年%-m月%-e日"
+
+#: panels/common/cc-util.c:165
+#, c-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d 小時"
+
+#. Translators: Option for "Blank Screen" in "Power" panel
+#: panels/common/cc-util.c:166 panels/power/cc-power-panel.c:849
+#, c-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d 分鐘"
+
+#: panels/common/cc-util.c:167
+#, c-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d 秒"
+
+#. 5 hours 2 minutes 12 seconds
+#: panels/common/cc-util.c:174
+#, c-format
+msgctxt "hours minutes seconds"
+msgid "%s %s %s"
+msgstr "%s %s %s"
+
+#. 5 hours 2 minutes
+#: panels/common/cc-util.c:179
+#, c-format
+msgctxt "hours minutes"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 5 hours
+#: panels/common/cc-util.c:184
+#, c-format
+msgctxt "hours"
+msgid "%s"
+msgstr "%s"
+
+#. 2 minutes 12 seconds
+#: panels/common/cc-util.c:192
+#, c-format
+msgctxt "minutes seconds"
+msgid "%s %s"
+msgstr "%s %s"
+
+#. 2 minutes
+#: panels/common/cc-util.c:197
+#, c-format
+msgctxt "minutes"
+msgid "%s"
+msgstr "%s"
+
+#. 0 seconds
+#: panels/common/cc-util.c:208
+msgid "0 seconds"
+msgstr "0 秒"
+
+#. translators: This is the default hotspot name, need to be less than 32-bytes
+#: panels/common/hostname-helper.c:177
+msgctxt "hotspot"
+msgid "Hotspot"
+msgstr "熱點"
+
+#: panels/datetime/cc-datetime-panel.c:175
+msgid "24-hour"
+msgstr "24 小時制"
+
+#: panels/datetime/cc-datetime-panel.c:177
+msgid "AM / PM"
+msgstr "12 小時制"
+
+#. Translators: This is the full date and time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:248
+msgid "%e %B %Y, %l:%M %p"
+msgstr "%Y年%-m月%-e日，%p %I:%M"
+
+#. Translators: This is the full date and time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:253
+msgid "%e %B %Y, %R"
+msgstr "%Y年%-m月%-e日，%R"
+
+#. Translators: "city, country"
+#: panels/datetime/cc-datetime-panel.c:423
+#, c-format
+msgctxt "timezone loc"
+msgid "%s, %s"
+msgstr "%s，%s"
+
+#. Update the timezone on the listbow row
+#. Translators: "timezone (details)"
+#: panels/datetime/cc-datetime-panel.c:450
+#, c-format
+msgctxt "timezone desc"
+msgid "%s (%s)"
+msgstr "%s（%s）"
+
+#. Translators: UTC here means the Coordinated Universal Time.
+#. * %:::z will be replaced by the offset from UTC e.g. UTC+02
+#: panels/datetime/cc-datetime-panel.c:457
+msgid "UTC%:::z"
+msgstr "UTC%:::z"
+
+#. Translators: This is the time format used in 12-hour mode.
+#: panels/datetime/cc-datetime-panel.c:462
+msgid "%l:%M %p"
+msgstr "%p %I:%M"
+
+#. Translators: This is the time format used in 24-hour mode.
+#: panels/datetime/cc-datetime-panel.c:467
+msgid "%R"
+msgstr "%R"
+
+#. Update the text bubble in the timezone map
+#. Translators: "timezone (utc shift)"
+#: panels/datetime/cc-datetime-panel.c:472
+#, c-format
+msgctxt "timezone map"
+msgid "%s (%s)"
+msgstr "%s (%s)"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr "日期與時間"
+
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr "年份"
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr "月份"
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr "1月"
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr "2月"
+
+#: panels/datetime/cc-datetime-panel.ui:73
+msgid "March"
+msgstr "3月"
+
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr "4月"
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr "5月"
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr "6月"
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr "7月"
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr "8月"
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr "9月"
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr "10月"
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr "11月"
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr "12月"
+
+#: panels/datetime/cc-datetime-panel.ui:92
+msgid "Day"
+msgstr "日期"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr "時區"
+
+#: panels/datetime/cc-datetime-panel.ui:130
+msgid "Search for a city"
+msgstr "搜尋城市"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr "自動調整日期與時間(_D)"
+
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr "需要網際網路連線"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr "日期與時間(_T)"
+
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr "自動調整時區(_Z)"
+
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr "需啟用定位服務及網際網路連線"
+
+#. TRANSLATORS: if the function is enabled through BIOS or OS settings.
+#. TRANSLATORS: Status of Parental Controls setup
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/firmware-security/cc-firmware-security-utils.c:247
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:43
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:96
+#: panels/user-accounts/cc-user-panel.c:802
+#: panels/user-accounts/cc-user-panel.c:904
+#: panels/wwan/cc-wwan-device-page.c:476
+msgid "Enabled"
+msgstr "已啟用"
+
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr "時區(_O)"
+
+#: panels/datetime/cc-datetime-panel.ui:245
+msgid "Time _Format"
+msgstr "時間格式(_F)"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr "更改日期與時間及調整時區"
+
+#. Translators: Search terms to find the Date and Time panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr "Clock;Timezone;Location;時鐘;時區;位置;定位;時間;時刻;時制;"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+msgid "Change system time and date settings"
+msgstr "更改系統的時間與日期設定值"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr "欲對日期或時間設定值進行更動需要核對身分。"
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr "網頁(_W)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+msgid "_Mail"
+msgstr "電子郵件(_M)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+msgid "_Calendar"
+msgstr "日曆(_C)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr "音樂(_U)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr "影片(_V)"
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr "相片(_P)"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+msgid "Default Applications"
+msgstr "預設應用程式"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+msgid "Configure Default Applications"
+msgstr "設定預設應用程式"
+
+#. Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr "default;application;preferred;media;預設;應用程式;偏好;首選;媒體;"
+
+#. translators: The first '%s' is the distributor's name, such as 'Fedora', the second '%s' is a link to the privacy policy
+#: panels/diagnostics/cc-diagnostics-panel.c:139
+#, c-format
+msgid ""
+"Sending reports of technical problems helps us improve %s. Reports are sent "
+"anonymously and are scrubbed of personal data. %s"
+msgstr ""
+"傳送技術問題報告有助於我們改進 %s。報告會以匿名方式傳送，並會抹除個人資料。%s"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr "問題回報"
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr "自動回報問題(_A)"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr "診斷"
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr "回報您遇到的問題"
+
+#. Translators: Search terms to find the Diagnostics panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr "diagnostics;crash;診斷;當機;"
+
+#: panels/display/cc-display-panel.c:492
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:737 panels/power/cc-power-panel.c:744
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "On"
+msgstr "開啟"
+
+#: panels/display/cc-display-panel.c:494 panels/network/net-proxy.c:69
+#: panels/notifications/cc-notifications-panel.c:217
+#: panels/power/cc-power-panel.c:731 panels/power/cc-power-panel.c:742
+#: panels/universal-access/cc-ua-panel.c:336
+#: panels/universal-access/cc-ua-panel.c:468
+#: panels/universal-access/cc-ua-panel.c:478
+#: panels/universal-access/cc-ua-panel.c:490
+#: panels/universal-access/cc-ua-panel.c:526
+msgid "Off"
+msgstr "關閉"
+
+#: panels/display/cc-display-panel.c:930
+msgid "Apply Changes?"
+msgstr "要套用更動嗎？"
+
+#: panels/display/cc-display-panel.c:935
+msgid "Changes Cannot be Applied"
+msgstr "無法套用更動"
+
+#: panels/display/cc-display-panel.c:937
+msgid "This could be due to hardware limitations."
+msgstr "可能是硬體限制所致。"
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+msgid "_Apply"
+msgstr "套用(_A)"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr "返回"
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr "顯示器設定已停用"
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr "多重顯示器"
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr "銜接顯示"
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr "鏡像顯示"
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr "包含頂端列及概覽"
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr "主螢幕"
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr "夜光模式"
+
+#: panels/display/cc-display-settings.c:110
+msgctxt "Display rotation"
+msgid "Landscape"
+msgstr "橫向"
+
+#: panels/display/cc-display-settings.c:113
+msgctxt "Display rotation"
+msgid "Portrait Right"
+msgstr "直向右轉"
+
+#: panels/display/cc-display-settings.c:116
+msgctxt "Display rotation"
+msgid "Portrait Left"
+msgstr "直向左轉"
+
+#: panels/display/cc-display-settings.c:119
+msgctxt "Display rotation"
+msgid "Landscape (flipped)"
+msgstr "橫向（翻轉）"
+
+#: panels/display/cc-display-settings.c:177
+#, c-format
+msgid "%.2lf Hz"
+msgstr "%.2lf Hz"
+
+#: panels/display/cc-display-settings.ui:43
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "方向"
+
+#: panels/display/cc-display-settings.ui:50
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "解析度"
+
+#: panels/display/cc-display-settings.ui:57
+msgid "Refresh Rate"
+msgstr "更新率"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr "為電視進行調整"
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+msgctxt "display setting"
+msgid "Scale"
+msgstr "縮放"
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr "夜光模式無法使用"
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr "可能是由於顯示卡的驅動程式不支援夜光模式，亦或是桌面正在遠端使用當中"
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr "暫時停用至明天"
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr "重啟夜光模式"
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr "夜光模式會讓螢幕色彩變得溫暖，可幫助防止眼睛疲勞與失眠。"
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr "排程"
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr "日落至日出"
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr "手動排程"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr "時間"
+
+#: panels/display/cc-night-light-page.ui:167
+msgid "From"
+msgstr "從"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr "時"
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ":"
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+msgid "Minute"
+msgstr "分"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr "上午"
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr "下午"
+
+#: panels/display/cc-night-light-page.ui:254
+msgid "To"
+msgstr "至"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr "色溫"
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr "顯示器"
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr "選擇如何使用連接的顯示器與投影機"
+
+#. Translators: Search terms to find the Displays panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;面板;投影機;螢幕;解析度;重新整理;螢幕;夜晚;夜"
+"光;藍光;日出;日落;"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:72
+#: panels/firmware-security/cc-firmware-security-panel.c:112
+msgid "Secure Boot is Active"
+msgstr "安全開機作用中"
+
+#. TRANSLATORS: this is the first section of the decription
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:77
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on and is functioning correctly."
+msgstr ""
+"安全開機可防止惡意軟體在裝置啟動階段時悄悄載入。該功能目前為開啟狀態並且運作"
+"正常。"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:83
+msgid "Secure Boot Has Problems"
+msgstr "安全開機存在問題"
+
+#. TRANSLATORS: this is the first section of the decription.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:87
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned on, but will not work due to having an "
+"invalid key."
+msgstr ""
+"安全開機可防止惡意軟體在裝置啟動階段時悄悄載入。該功能目前為開啟狀態但無法正"
+"常運作，原因為金鑰無效。"
+
+#. TRANSLATORS: this is the second section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:90
+msgid ""
+"Secure boot problems can often be resolved from your computer's UEFI "
+"firmware settings (BIOS) and your hardware manufacturer may provide "
+"information on how to do this."
+msgstr ""
+"安全開機問題大多能透過電腦中的 UEFI (BIOS) 韌體設定來解決，您的硬體製造商可能"
+"會提供解決問題的指引。"
+
+#. TRANSLATORS: this is the third section of description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:93
+msgid "For help, contact your hardware manufacturer or IT support provider."
+msgstr "如需協助，請聯絡您的硬體製造商或 IT 技術人員。"
+
+#. TRANSLATORS: secure boot refers to the system firmware security mode
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:99
+msgid "Secure Boot is Turned Off"
+msgstr "安全開機已關閉"
+
+#. TRANSLATORS: this is the first section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:103
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts. It is currently turned off."
+msgstr "安全開機可防止惡意軟體在裝置啟動階段時悄悄載入。該功能目前為關閉狀態。"
+
+#. TRANSLATORS: this is the second section of the description.
+#: panels/firmware-security/cc-firmware-security-boot-dialog.c:106
+msgid ""
+"Secure boot can often be turned on from your computer's UEFI firmware "
+"settings (BIOS). For help, contact your hardware manufacturer or IT support "
+"provider."
+msgstr ""
+"安全開機大多能透過電腦中的 UEFI (BIOS) 韌體設定來開啟。如需協助，請聯絡您的硬"
+"體製造商或 IT 技術人員。"
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+"安全開機可防止惡意軟體在裝置啟動階段時悄悄載入。\n"
+"\n"
+"如需了解更多資訊，請聯絡您的硬體製造商或 IT 技術人員。"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Passed"
+msgstr "測試成功"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:96
+#: panels/firmware-security/cc-firmware-security-dialog.c:98
+#: panels/firmware-security/cc-firmware-security-dialog.c:100
+msgid "Failed"
+msgstr "測試失敗"
+
+#. TRANSLATORS: HSI stands for Host Security ID and device refers to the computer as a whole
+#: panels/firmware-security/cc-firmware-security-dialog.c:137
+#, c-format
+msgid "Device conforms to HSI level %d"
+msgstr "裝置所符合的 HSI 等級為 %d"
+
+#. TRANSLATORS: in reference to firmware protection: 0/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:149
+#: panels/firmware-security/cc-firmware-security-panel.c:485
+msgid "Security Level 0"
+msgstr "安全性等級 0"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:150
+msgid ""
+"This device has no protection against hardware security issues. This could "
+"be because of a hardware or firmware configuration issue. It is recommended "
+"to contact your IT support provider."
+msgstr ""
+"本裝置針對硬體安全性相關的問題缺乏防護。可能是硬體或韌體組態所造成的問題，建"
+"議您聯絡 IT 技術人員。"
+
+#. TRANSLATORS: in reference to firmware protection: 1/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:158
+#: panels/firmware-security/cc-firmware-security-dialog.c:357
+#: panels/firmware-security/cc-firmware-security-panel.c:492
+msgid "Security Level 1"
+msgstr "安全性等級 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:159
+msgid ""
+"This device has minimal protection against hardware security issues. This is "
+"the lowest device security level and only provides protection against simple "
+"security threats."
+msgstr ""
+"本裝置針對硬體安全性相關的問題僅提供最小防護。這意味著裝置的安全性等級為最低"
+"等級，只能針對簡單的安全威脅提供防護。"
+
+#. TRANSLATORS: in reference to firmware protection: 2/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:167
+#: panels/firmware-security/cc-firmware-security-dialog.c:362
+#: panels/firmware-security/cc-firmware-security-panel.c:499
+msgid "Security Level 2"
+msgstr "安全性等級 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:168
+msgid ""
+"This device has basic protection against hardware security issues. This "
+"provides protection against some common security threats."
+msgstr ""
+"本裝置針對硬體安全性相關的問題提供基本防護。這意味著裝置能針對常見的安全威脅"
+"提供防護。"
+
+#. TRANSLATORS: in reference to firmware protection: 3/4 stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:176
+#: panels/firmware-security/cc-firmware-security-dialog.c:367
+#: panels/firmware-security/cc-firmware-security-panel.c:506
+msgid "Security Level 3"
+msgstr "安全性等級 3"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:177
+msgid ""
+"This device has extended protection against hardware security issues. This "
+"is the highest device security level and provides protection against "
+"advanced security threats."
+msgstr ""
+"本裝置針對硬體安全性相關的問題具備延伸防護。這意味著裝置的安全性等級為最高等"
+"級，能針對高階的安全威脅提供防護。"
+
+#. TRANSLATORS: in reference to firmware protection: ??? stars
+#: panels/firmware-security/cc-firmware-security-dialog.c:185
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+#: panels/firmware-security/cc-firmware-security-panel.c:521
+msgid "Security Level"
+msgstr "安全性等級"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:186
+#: panels/firmware-security/cc-firmware-security-panel.c:522
+msgid "Security levels are not available for this device."
+msgstr "該裝置不適用安全性等級。"
+
+#. TRANSLATORS: hardware manufacturer as in OEM
+#: panels/firmware-security/cc-firmware-security-dialog.c:201
+#: panels/firmware-security/cc-firmware-security-dialog.c:211
+#: panels/firmware-security/cc-firmware-security-dialog.c:218
+msgid "Contact your hardware manufacturer for help with security updates."
+msgstr "請聯絡您的硬體製造商以取得安全更新相關的支援訊息。"
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:203
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings, or by a support technician."
+msgstr "該問題也許能透過裝置的 UEFI 韌體設定，或是交由 IT 技術人員來解決。"
+
+#: panels/firmware-security/cc-firmware-security-dialog.c:212
+#: panels/firmware-security/cc-firmware-security-dialog.c:223
+msgid ""
+"It might be possible to resolve this issue in the device’s UEFI firmware "
+"settings."
+msgstr "該問題也許能透過裝置的 UEFI 韌體設定來解決。"
+
+#. TRANSLATORS: support technician as in someone with root
+#: panels/firmware-security/cc-firmware-security-dialog.c:229
+msgid "It might be possible for a support technician to resolve this issue."
+msgstr "該問題也許能透過 IT 技術人員來解決。"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr "等級 1"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr "等級 2"
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr "等級 3"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:113
+msgid "Protected against malicious software when the device starts."
+msgstr "裝置的啟動階段有針對惡意軟體採取防護措施。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:119
+msgid "Secure Boot has Problems"
+msgstr "安全開機存在問題"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:120
+msgid "Some protection when the device is started."
+msgstr "裝置的啟動階段僅有部分防護措施。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:125
+msgid "Secure Boot is Off"
+msgstr "安全開機已關閉"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:126
+msgid "No protection when the device is started."
+msgstr "裝置的啟動階段沒有任何防護措施。"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:145
+msgid ""
+"This issue could have been caused by a change in UEFI firmware settings, an "
+"operating system configuration change, or because of malicious software on "
+"this system."
+msgstr ""
+"該問題可能是由下列原因所導致：UEFI 韌體設定不正確、作業系統設定不正確，或是系"
+"統遭植入惡意軟體。"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:153
+msgid ""
+"This issue could have been caused by a change in the UEFI firmware settings, "
+"or because of malicious software on this system."
+msgstr ""
+"該問題可能是由下列原因所導致：UEFI 韌體設定不正確或是系統遭植入惡意軟體。"
+
+#. TRANSLATORS: this is to explain an event that has already happened
+#: panels/firmware-security/cc-firmware-security-panel.c:160
+msgid ""
+"This issue could have been caused by an operating system configuration "
+"change, or because of malicious software on this system."
+msgstr ""
+"該問題可能是由下列原因所導致：作業系統設定不正確或是系統遭植入惡意軟體。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:486
+msgid "Exposed to serious security threats."
+msgstr "正暴露於嚴重的安全威脅之中。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:493
+msgid "Limited protection against simple security threats."
+msgstr "能針對簡單的安全威脅提供有限防護。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:500
+msgid "Protected against common security threats."
+msgstr "能針對常見的安全威脅提供防護。"
+
+#: panels/firmware-security/cc-firmware-security-panel.c:507
+#: panels/firmware-security/cc-firmware-security-panel.c:515
+msgid "Protected against a wide range of security threats."
+msgstr "能針對廣泛的安全威脅提供保護。"
+
+#. TRANSLATORS: in reference to firmware protection: 4/4 stars
+#: panels/firmware-security/cc-firmware-security-panel.c:514
+msgid "Comprehensive Protection"
+msgstr "全面性防護"
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+msgid "No Events"
+msgstr "沒有活動"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:37
+msgid "Firmware Write Protection"
+msgstr "韌體寫入保護"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:42
+msgid "Firmware Write Protection Lock"
+msgstr "韌體寫入保護鎖"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:47
+msgid "Firmware BIOS Region"
+msgstr "韌體 BIOS 領域"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: panels/firmware-security/cc-firmware-security-utils.c:52
+msgid "Firmware BIOS Descriptor"
+msgstr "韌體 BIOS 描述元"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: panels/firmware-security/cc-firmware-security-utils.c:57
+msgid "Pre-boot DMA Protection"
+msgstr "預先開機 DMA 保護"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:62
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: panels/firmware-security/cc-firmware-security-utils.c:68
+msgid "Intel BootGuard Verified Boot"
+msgstr "Intel BootGuard 驗證開機"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: panels/firmware-security/cc-firmware-security-utils.c:74
+msgid "Intel BootGuard ACM Protected"
+msgstr "Intel BootGuard ACM 保護"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: panels/firmware-security/cc-firmware-security-utils.c:80
+msgid "Intel BootGuard Error Policy"
+msgstr "Intel BootGuard 錯誤政策"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: panels/firmware-security/cc-firmware-security-utils.c:85
+msgid "Intel BootGuard Fuse"
+msgstr "Intel BootGuard Fuse"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: panels/firmware-security/cc-firmware-security-utils.c:91
+msgid "Intel CET Enabled"
+msgstr "Intel CET 已啟用"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * active means being used by the OS
+#: panels/firmware-security/cc-firmware-security-utils.c:97
+msgid "Intel CET Active"
+msgstr "Intel CET 作用中"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: panels/firmware-security/cc-firmware-security-utils.c:102
+msgid "Intel SMAP"
+msgstr "Intel SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: panels/firmware-security/cc-firmware-security-utils.c:107
+msgid "Encrypted RAM"
+msgstr "記憶體已加密"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: panels/firmware-security/cc-firmware-security-utils.c:113
+msgid "IOMMU Protection"
+msgstr "IOMMU 保護"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: panels/firmware-security/cc-firmware-security-utils.c:118
+msgid "Linux Kernel Lockdown"
+msgstr "Linux 核心鎖定"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: panels/firmware-security/cc-firmware-security-utils.c:123
+msgid "Linux Kernel Verification"
+msgstr "Linux 核心驗證"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: panels/firmware-security/cc-firmware-security-utils.c:128
+msgid "Linux Swap"
+msgstr "Linux 交換空間"
+
+#. TRANSLATORS: Title: sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:133
+msgid "Suspend To RAM"
+msgstr "暫停狀態"
+
+#. TRANSLATORS: Title: a better sleep state
+#: panels/firmware-security/cc-firmware-security-utils.c:138
+msgid "Suspend To Idle"
+msgstr "休眠狀態"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: panels/firmware-security/cc-firmware-security-utils.c:143
+msgid "UEFI Platform Key"
+msgstr "UEFI 平臺金鑰"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: panels/firmware-security/cc-firmware-security-utils.c:148
+msgid "UEFI Secure Boot"
+msgstr "UEFI 安全開機"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: panels/firmware-security/cc-firmware-security-utils.c:153
+msgid "TPM Platform Configuration"
+msgstr "TPM 平臺組態"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: panels/firmware-security/cc-firmware-security-utils.c:158
+msgid "TPM Reconstruction"
+msgstr "TPM 重構"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: panels/firmware-security/cc-firmware-security-utils.c:163
+msgid "TPM v2.0"
+msgstr "TPM 信賴平臺模組 v2.0"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:168
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Intel 管理引擎製造模式"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: panels/firmware-security/cc-firmware-security-utils.c:175
+msgid "Intel Management Engine Override"
+msgstr "Intel 管理引擎凌駕"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: panels/firmware-security/cc-firmware-security-utils.c:180
+msgid "Intel Management Engine Version"
+msgstr "Intel 管理引擎版本"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: panels/firmware-security/cc-firmware-security-utils.c:185
+msgid "Firmware Updates"
+msgstr "韌體更新"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: panels/firmware-security/cc-firmware-security-utils.c:190
+msgid "Firmware Attestation"
+msgstr "韌體核實"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: panels/firmware-security/cc-firmware-security-utils.c:195
+msgid "Firmware Updater Verification"
+msgstr "韌體更新器驗證"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: panels/firmware-security/cc-firmware-security-utils.c:201
+msgid "Platform Debugging"
+msgstr "平臺除錯"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: panels/firmware-security/cc-firmware-security-utils.c:206
+msgid "Processor Security Checks"
+msgstr "處理器安全性檢查"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: panels/firmware-security/cc-firmware-security-utils.c:211
+msgid "AMD Rollback Protection"
+msgstr "AMD 降版保護"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: panels/firmware-security/cc-firmware-security-utils.c:216
+msgid "AMD Firmware Replay Protection"
+msgstr "AMD 韌體重放保護"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: panels/firmware-security/cc-firmware-security-utils.c:221
+msgid "AMD Firmware Write Protection"
+msgstr "AMD 韌體寫入保護"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: panels/firmware-security/cc-firmware-security-utils.c:226
+msgid "Fused Platform"
+msgstr "融合平臺"
+
+#. TRANSLATORS: if the stauts is valid. For example security check is valid and key is valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:237
+msgid "Valid"
+msgstr "有效"
+
+#. TRANSLATORS: if the status or key is not valid.
+#: panels/firmware-security/cc-firmware-security-utils.c:242
+msgid "Not Valid"
+msgstr "無效"
+
+#. TRANSLATORS: if the function is not enabled through BIOS or OS settings.
+#: panels/firmware-security/cc-firmware-security-utils.c:252
+msgid "Not Enabled"
+msgstr "尚未啟用"
+
+#. TRANSLATORS: the memory space or system mode is locked to prevent from malicious modification.
+#: panels/firmware-security/cc-firmware-security-utils.c:257
+msgid "Locked"
+msgstr "已鎖定"
+
+#. TRANSLATORS: the memory space or system mode is not locked.
+#: panels/firmware-security/cc-firmware-security-utils.c:262
+msgid "Not Locked"
+msgstr "未鎖定"
+
+#. TRANSLATORS: The data is encrypted to prevent from malicious reading.
+#: panels/firmware-security/cc-firmware-security-utils.c:267
+msgid "Encrypted"
+msgstr "已加密"
+
+#. TRANSLATORS: the data in memory is plane text.
+#: panels/firmware-security/cc-firmware-security-utils.c:272
+msgid "Not Encrypted"
+msgstr "未加密"
+
+#. TRANSLATORS: Linux kernel is tainted by third party kernel module.
+#: panels/firmware-security/cc-firmware-security-utils.c:277
+msgid "Tainted"
+msgstr "遭到污染"
+
+#. TRANSLATORS: All the loaded kernel module are licensed.
+#: panels/firmware-security/cc-firmware-security-utils.c:282
+msgid "Not Tainted"
+msgstr "未遭污染"
+
+#. TRANSLATORS: the feature can be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:287
+msgid "Found"
+msgstr "可以使用"
+
+#. TRANSLATORS: the feature can't be detected.
+#: panels/firmware-security/cc-firmware-security-utils.c:292
+msgid "Not Found"
+msgstr "無法使用"
+
+#. TRANSLATORS: the function is supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:297
+msgid "Supported"
+msgstr "支援"
+
+#. TRANSLATORS: the function isn't supported by hardware.
+#: panels/firmware-security/cc-firmware-security-utils.c:302
+msgid "Not Supported"
+msgstr "未支援"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr "裝置安全"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr "了解主機的安全性狀態"
+
+#. Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;螢幕;鎖定;診斷;當掉;崩潰;私人;隱私;最近;暫存;索引;名"
+"稱;網路;身分;"
+
+#: panels/info-overview/cc-info-overview-panel.c:297
+#: panels/info-overview/cc-info-overview-panel.c:317
+#: panels/info-overview/cc-info-overview-panel.c:358
+#: panels/info-overview/cc-info-overview-panel.c:388
+#: panels/wwan/cc-wwan-details-dialog.c:100
+msgid "Unknown"
+msgstr "不明"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:335
+#, c-format
+msgid "64-bit"
+msgstr "64 位元"
+
+#. translators: This is the type of architecture for the OS
+#: panels/info-overview/cc-info-overview-panel.c:338
+#, c-format
+msgid "32-bit"
+msgstr "32 位元"
+
+#: panels/info-overview/cc-info-overview-panel.c:597
+msgid "X11"
+msgstr "X11"
+
+#: panels/info-overview/cc-info-overview-panel.c:601
+msgid "Wayland"
+msgstr "Wayland"
+
+#: panels/info-overview/cc-info-overview-panel.c:603
+msgctxt "Windowing system (Wayland, X11, or Unknown)"
+msgid "Unknown"
+msgstr "不明"
+
+#. translators: this is the placeholder string when the GNOME Shell
+#. * version couldn't be loaded, eg. “GNOME Version: Not Available”
+#: panels/info-overview/cc-info-overview-panel.c:681
+msgid "Not Available"
+msgstr "無法取得"
+
+#: panels/info-overview/cc-info-overview-panel.ui:17
+msgid "System Logo"
+msgstr "系統標誌"
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr "裝置名稱"
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr "硬體型號"
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr "記憶體"
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr "處理器"
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr "顯示卡"
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr "磁碟空間"
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr "正在計算…"
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+msgid "OS Name"
+msgstr "作業系統名稱"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr "作業系統組建 ID"
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+msgid "OS Type"
+msgstr "作業系統類型"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+msgid "GNOME Version"
+msgstr "GNOME 版本"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr "正在載入…"
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+msgid "Windowing System"
+msgstr "視窗系統"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr "虛擬化"
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr "軟體更新"
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr "重新命名裝置"
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr "在網路查看或藍牙配對時，裝置名稱能供他人辨識。"
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+msgid "Device name"
+msgstr "裝置名稱"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+msgid "_Rename"
+msgstr "重新命名(_R)"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+msgid "About"
+msgstr "關於"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr "檢視您系統的資訊"
+
+#. Translators: Search terms to find the About panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. "Preferred Applications" is the old name for the preference, so make
+#. sure that you use the same "translation" for those keywords
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;裝"
+"置;系統;資訊;記憶體;處理器;版本;預設;應用程式;首選;音訊;視訊;碟片;可移除;媒"
+"體;自動執行;主機名;主機名稱;"
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr "音訊與媒體"
+
+#: panels/keyboard/00-multimedia.xml.in:4
+msgid "Volume mute/unmute"
+msgstr "音量靜音/取消靜音"
+
+#: panels/keyboard/00-multimedia.xml.in:6
+msgid "Volume down"
+msgstr "音量降低"
+
+#: panels/keyboard/00-multimedia.xml.in:8
+msgid "Volume up"
+msgstr "音量提高"
+
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr "麥克風靜音/取消靜音"
+
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr "啟動媒體播放器"
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "播放（或播放/暫停）"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr "暫停播放"
+
+#: panels/keyboard/00-multimedia.xml.in:18
+msgid "Stop playback"
+msgstr "停止播放"
+
+#: panels/keyboard/00-multimedia.xml.in:20
+msgid "Previous track"
+msgstr "上一首歌曲"
+
+#: panels/keyboard/00-multimedia.xml.in:22
+msgid "Next track"
+msgstr "下一首歌曲"
+
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "退出光碟"
+
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
+msgid "Typing"
+msgstr "輸入"
+
+#: panels/keyboard/01-input-sources.xml.in:8
+msgid "Switch to next input source"
+msgstr "切換至下個輸入來源"
+
+#: panels/keyboard/01-input-sources.xml.in:13
+msgid "Switch to previous input source"
+msgstr "切換至上個輸入來源"
+
+#: panels/keyboard/01-launchers.xml.in:2
+msgid "Launchers"
+msgstr "啟動應用程式"
+
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "求助文件瀏覽器"
+
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
+msgstr "計算機"
+
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
+msgstr "電子郵件客戶端"
+
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "網頁瀏覽器"
+
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "家目錄"
+
+#: panels/keyboard/01-launchers.xml.in:16
+msgctxt "keybinding"
+msgid "Search"
+msgstr "搜尋"
+
+#: panels/keyboard/01-system.xml.in:2
+msgid "System"
+msgstr "系統"
+
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "登出"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "鎖定螢幕"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+msgid "Accessibility"
+msgstr "無障礙輔助"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
+msgstr "開啟或關閉縮放"
+
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr "放大（需啟用縮放）"
+
+#: panels/keyboard/50-accessibility.xml.in:8
+msgid "Zoom out"
+msgstr "縮小（需啟用縮放）"
+
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr "開啟或關閉螢幕閱讀器"
+
+#: panels/keyboard/50-accessibility.xml.in:12
+msgid "Turn on-screen keyboard on or off"
+msgstr "開啟或關閉螢幕鍵盤"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr "將文字放大"
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr "將文字縮小"
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr "開啟或關閉高反差"
+
+#: panels/keyboard/cc-input-chooser.c:186
+msgid "No input sources found"
+msgstr "找不到輸入來源"
+
+#: panels/keyboard/cc-input-chooser.c:931
+msgctxt "Input Source"
+msgid "Other"
+msgstr "其他"
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr "加入輸入來源"
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr "輸入法無法在登入畫面使用"
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr "未選擇輸入來源"
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "選項"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr "上移"
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr "下移"
+
+#: panels/keyboard/cc-input-row.ui:41
+msgid "Preferences"
+msgstr "偏好設定"
+
+#: panels/keyboard/cc-input-row.ui:48
+msgid "View Keyboard Layout"
+msgstr "檢視鍵盤配置"
+
+#: panels/keyboard/cc-input-row.ui:54 panels/sharing/cc-sharing-networks.c:223
+#: panels/sharing/cc-sharing-panel.c:646
+msgid "Remove"
+msgstr "移除"
+
+#: panels/keyboard/cc-keyboard-manager.c:485
+#: panels/keyboard/cc-keyboard-manager.c:493
+#: panels/keyboard/cc-keyboard-manager.c:922
+msgid "Custom Shortcuts"
+msgstr "自訂快捷鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:64
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr "替代字元鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:65
+msgid ""
+"The alternate characters key can be used to enter additional characters. "
+"These are sometimes printed as a third-option on your keyboard."
+msgstr ""
+"替代字元鍵可用於輸入額外的代用字元，這些字元通常是以第三選項印在您的鍵盤上。"
+
+#: panels/keyboard/cc-keyboard-panel.c:67
+#: panels/keyboard/cc-keyboard-panel.c:85
+msgctxt "keyboard key"
+msgid "Left Alt"
+msgstr "左側 Alt 鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:68
+#: panels/keyboard/cc-keyboard-panel.c:86
+msgctxt "keyboard key"
+msgid "Right Alt"
+msgstr "右側 Alt 鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:69
+#: panels/keyboard/cc-keyboard-panel.c:87
+msgctxt "keyboard key"
+msgid "Left Super"
+msgstr "左側超級鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:70
+#: panels/keyboard/cc-keyboard-panel.c:88
+msgctxt "keyboard key"
+msgid "Right Super"
+msgstr "右側超級鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:71
+#: panels/keyboard/cc-keyboard-panel.c:89
+msgctxt "keyboard key"
+msgid "Menu key"
+msgstr "選單鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:72
+#: panels/keyboard/cc-keyboard-panel.c:90
+msgctxt "keyboard key"
+msgid "Right Ctrl"
+msgstr "右側 Ctrl 鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:80
+#: panels/keyboard/cc-keyboard-panel.ui:80
+msgid "Compose Key"
+msgstr "組合鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:81
+msgid ""
+"The compose key allows a wide variety of characters to be entered. To use "
+"it, press compose then a sequence of characters.  For example, compose key "
+"followed by <b>C</b> and <b>o</b> will enter <b>©</b>, <b>a</b> followed by "
+"<b>'</b> will enter <b>á</b>."
+msgstr ""
+"組合鍵能讓您輸入各式各樣的字元。若要使用此功能，請先按一下組合鍵，再輸入一段"
+"字元順序。\n"
+"舉例：先按一下組合鍵，再按 <b>C</b> 與 <b>o</b>能輸入 <b>©</b>；按下 <b>a</"
+"b> 與 <b>'</b> 則能輸入 <b>á</b>。"
+
+#: panels/keyboard/cc-keyboard-panel.c:91
+msgctxt "keyboard key"
+msgid "Caps Lock"
+msgstr "Caps Lock 鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:92
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock 鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:93
+msgctxt "keyboard key"
+msgid "Print Screen"
+msgstr "Print Screen 鍵"
+
+#: panels/keyboard/cc-keyboard-panel.c:217
+#, c-format
+msgid ""
+"Input sources can be switched using the %s keyboard shortcut.\n"
+"This can be changed in the keyboard shortcut settings."
+msgstr ""
+"輸入來源可透過鍵盤快捷鍵 %s 切換。\n"
+"欲修改快捷鍵可至「鍵盤快捷鍵」設定中修改。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr "輸入來源"
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr "包含鍵盤配置與輸入法。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr "輸入來源切換"
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr "所有視窗皆使用相同的輸入來源(_S)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr "每個視窗各自切換獨立的輸入來源(_D)"
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr "輸入特殊字元"
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr "使用鍵盤輸入符號及字母變體的方法。"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:319
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:334 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "鍵盤快捷鍵"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr "檢視與自訂快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:296
+#, c-format
+msgid "%d modified"
+msgid_plural "%d modified"
+msgstr[0] "已修改 %d 個"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:463
+msgid "Reset All Shortcuts?"
+msgstr "要重設所有快捷鍵嗎？"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:466
+msgid ""
+"Resetting the shortcuts may affect your custom shortcuts. This cannot be "
+"undone."
+msgstr "重設快捷鍵可能會影響您自訂的快捷鍵，且該動作不能還原。"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:470
+#: panels/network/wireless-security/ws-file-chooser-button.c:94
+#: panels/printers/ppd-selection-dialog.ui:83
+#: panels/wwan/cc-wwan-device-page.c:189
+msgid "Cancel"
+msgstr "取消"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.c:471
+msgid "Reset All"
+msgstr "重設全部"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr "重設全部…"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr "將快捷鍵重設為預設的按鍵組合"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+msgid "Section"
+msgstr "節"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+msgid "Shortcuts"
+msgstr "快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+msgid "Add a shortcut"
+msgstr "加入快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr "加入自訂快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr "設定自訂快捷鍵來啟動應用程式、執行命令稿等。"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+msgid "Add Shortcut"
+msgstr "加入快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+msgid "No keyboard shortcut found"
+msgstr "找不到鍵盤快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:392
+#, c-format
+msgid "%s is already being used for %s. If you replace it, %s will be disabled"
+msgstr "%s 已被「%s」使用。若要取代，則「%s」會被停用"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:536
+msgid "Enter the new shortcut"
+msgstr "輸入新的快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Custom Shortcut"
+msgstr "設定自訂快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:551
+msgid "Set Shortcut"
+msgstr "設定快捷鍵"
+
+#. TRANSLATORS: %s is replaced with a description of the keyboard shortcut
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:562
+#, c-format
+msgid "Enter new shortcut to change %s."
+msgstr "請輸入新的按鍵組合來更改「%s」快捷鍵。"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.c:977
+msgid "Add Custom Shortcut"
+msgstr "加入自訂快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "移除(_R)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr "取代(_P)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+#: panels/wwan/cc-wwan-sim-lock-dialog.c:229
+msgid "_Set"
+msgstr "設定(_S)"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr "按下 Esc 鍵取消或按 Backspace 鍵停用該鍵盤快捷鍵。"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+msgid "Name"
+msgstr "名稱"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+msgid "Command"
+msgstr "命令"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "快捷鍵"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+msgid "Set Shortcut…"
+msgstr "設定快捷鍵…"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+msgid "None"
+msgstr "沒有"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr "將快捷鍵重設為預設值"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "鍵盤"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
+msgid ""
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
+msgstr "更改鍵盤快捷鍵，並設定您的輸入偏好設定、鍵盤配置、輸入來源等"
+
+#. Translators: Search terms to find the Keyboard panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
+msgstr ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;快捷"
+"鍵;快捷鍵;工作區;視窗;重新調整大小;縮放;拉遠;拉近;遠近;對比;反差;輸入;來源;輸"
+"入法;鎖定;上鎖;音量;"
+
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr "定位服務已關閉"
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr "沒有應用程式能取得位置資訊。"
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+"定位服務可允許應用程式知道您的位置。使用 Wi-Fi 和行動寬頻能提高定位準確度。\n"
+"\n"
+"使用 Mozilla 定位服務：<a href='https://location.services.mozilla.com/"
+"privacy'>隱私權政策</a>\n"
+"\n"
+"允許下列應用程式偵測您的位置。"
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr "沒有應用程式請求取用位置資訊"
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+msgid "Protect your location information"
+msgstr "保護您的位置資訊"
+
+#. Translators: Search terms to find the Location panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr "location;gps;private;privacy;定位;隱私權;衛星定位;位置;地理;"
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr "麥克風已關閉"
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr "沒有能錄製聲音的應用程式。"
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+"麥克風的使用可允許應用程式錄製或聆聽聲音。停用麥克風可能導致部分應用程式無法"
+"正常運作。\n"
+"\n"
+"允許下列應用程式使用您的麥克風。"
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr "沒有應用程式請求取用麥克風"
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr "保護您的對話"
+
+#. Translators: Search terms to find the Microphone panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr "microphone;recording;application;privacy;麥克風;錄音;應用程式;隱私權;"
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+msgid "Test Your _Settings"
+msgstr "測試您的設定值(_S)"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "一般"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr "主要按鍵"
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr "設定滑鼠與觸控板上實體按鍵所對應的命令。"
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr "左"
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+msgid "Right"
+msgstr "右"
+
+#: panels/mouse/cc-mouse-panel.ui:62
+msgid "Mouse"
+msgstr "滑鼠"
+
+#: panels/mouse/cc-mouse-panel.ui:65
+msgid "Mouse Speed"
+msgstr "滑鼠速度"
+
+#. Translators: This switch reverses the scrolling direction for mices. The term used comes from OS X so use the same translation if possible.
+#. Translators: This switch reverses the scrolling direction for touchpads. The term used comes from OS X so use the same translation if possible.
+#: panels/mouse/cc-mouse-panel.ui:81 panels/mouse/cc-mouse-panel.ui:87
+#: panels/mouse/cc-mouse-panel.ui:114 panels/mouse/cc-mouse-panel.ui:120
+msgid "Natural Scrolling"
+msgstr "自然捲動"
+
+#: panels/mouse/cc-mouse-panel.ui:82 panels/mouse/cc-mouse-panel.ui:115
+msgid "Scrolling moves the content, not the view."
+msgstr "捲動的方向為內容移動方向，而非畫面移動的方向。"
+
+#: panels/mouse/cc-mouse-panel.ui:98 panels/mouse/cc-mouse-panel.ui:101
+#: panels/mouse/cc-mouse-panel.ui:106
+msgid "Touchpad"
+msgstr "觸控板"
+
+#: panels/mouse/cc-mouse-panel.ui:128
+msgid "Touchpad Speed"
+msgstr "觸控板速度"
+
+#: panels/mouse/cc-mouse-panel.ui:145
+msgid "Tap to Click"
+msgstr "輕觸以點擊"
+
+#: panels/mouse/cc-mouse-panel.ui:150
+msgid "Tap to click"
+msgstr "輕觸就能進行點擊操作"
+
+#: panels/mouse/cc-mouse-panel.ui:159 panels/mouse/cc-mouse-panel.ui:164
+msgid "Two-finger Scrolling"
+msgstr "兩指捲動"
+
+#: panels/mouse/cc-mouse-panel.ui:174 panels/mouse/cc-mouse-panel.ui:179
+msgid "Edge Scrolling"
+msgstr "邊緣捲動"
+
+#: panels/mouse/cc-mouse-test.c:131 panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr "試著按一下、按兩下、捲動"
+
+#: panels/mouse/cc-mouse-test.c:136
+msgid "Five clicks, GEGL time!"
+msgstr "連按五下，GEGL 時間！"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Double click, primary button"
+msgstr "按兩下（主要按鍵）"
+
+#: panels/mouse/cc-mouse-test.c:141
+msgid "Single click, primary button"
+msgstr "按一下（主要按鍵）"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Double click, middle button"
+msgstr "按兩下（中央按鍵）"
+
+#: panels/mouse/cc-mouse-test.c:144
+msgid "Single click, middle button"
+msgstr "按一下（中央按鍵）"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Double click, secondary button"
+msgstr "按兩下（次要按鍵）"
+
+#: panels/mouse/cc-mouse-test.c:147
+msgid "Single click, secondary button"
+msgstr "按一下（次要按鍵）"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr "滑鼠與觸控板"
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr "更改您的滑鼠或觸控板靈敏度，並選擇慣用右手或慣用左手"
+
+#. Translators: Search terms to find the Mouse and Touchpad panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+"Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;觸控板;指標;點擊;輕"
+"觸;雙擊;按鈕;軌跡球;捲動;慣用手;滑鼠;速度;按鍵;"
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr "熱角(_H)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr "觸碰左上角可以開啟「概覽」。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr "積極邊框(_A)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr "將視窗拖動至螢幕上緣、左緣、右緣來調整視窗大小。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr "工作區"
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr "動態工作區(_D)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr "自動移除空的工作區。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr "固定數目工作區(_F)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr "指定常駐的工作區數目。"
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr "工作區數目(_N)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr "多重顯示器"
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr "只在主要顯示器使用工作區(_P)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr "在所有顯示器上使用工作區(_I)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+msgid "Application Switching"
+msgstr "應用程式切換"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr "包含所有工作區的應用程式(_W)"
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr "僅包含目前工作區的應用程式(_C)"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr "多工作業"
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr "管理生產力與多工作業的偏好設定"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;多工作業;多工;生產力;自"
+"訂;桌面;"
+
+#: panels/network/cc-network-panel.c:662 panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr "噢，發生問題。請聯繫您的軟體供應商。"
+
+#: panels/network/cc-network-panel.c:669
+msgid "NetworkManager needs to be running."
+msgstr "需要執行 NetworkManager。"
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+msgid "Other Devices"
+msgstr "其他裝置"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+#: panels/network/connection-editor/net-connection-editor.c:586
+msgid "VPN"
+msgstr "VPN"
+
+#: panels/network/cc-network-panel.ui:42
+msgid "Add connection"
+msgstr "加入新連線"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr "尚未設定"
+
+#. TRANSLATORS: This happens when the connection name does not contain the SSID.
+#: panels/network/cc-wifi-connection-row.c:216
+#, c-format
+msgctxt "Wi-Fi Connection"
+msgid "%s (SSID: %s)"
+msgstr "%s (SSID: %s)"
+
+#: panels/network/cc-wifi-connection-row.c:275
+msgid "Insecure network (WEP)"
+msgstr "不安全網路 (WEP)"
+
+#: panels/network/cc-wifi-connection-row.c:279
+msgid "Secure network (WPA)"
+msgstr "安全網路 (WPA)"
+
+#: panels/network/cc-wifi-connection-row.c:283
+msgid "Secure network (WPA2)"
+msgstr "安全網路 (WPA2)"
+
+#: panels/network/cc-wifi-connection-row.c:287
+msgid "Secure network (WPA3)"
+msgstr "安全網路 (WPA3)"
+
+#: panels/network/cc-wifi-connection-row.c:291
+msgid "Secure network"
+msgstr "安全網路"
+
+#. TRANSLATORS: device status
+#: panels/network/cc-wifi-connection-row.ui:41 panels/network/panel-common.c:63
+msgid "Connected"
+msgstr "已連線"
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/net-device-ethernet.c:325
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+msgid "Options…"
+msgstr "選項…"
+
+#. TRANSLATORS: ‘%s’ is a Wi-Fi Network(SSID) name
+#: panels/network/cc-wifi-hotspot-dialog.c:133
+#, c-format
+msgid ""
+"Turning on the hotspot will disconnect from %s, and it will not be possible "
+"to access the internet through Wi-Fi."
+msgstr "開啟熱點會中斷與「%s」的連接，並且無法透過 Wi-Fi 使用網路。"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:266
+msgid "Must have a minimum of 8 characters"
+msgstr "必須至少為 8 個字元"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] "必須至少為 %d 個字元"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr "要開啟 Wi-Fi 熱點嗎？"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+"Wi-Fi 熱點透過建立能讓其他人連接的 Wi-Fi 網路，與其他人共用您的網路連線。您需"
+"要有 Wi-Fi 之外的網路連線來源。"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+msgid "Network Name"
+msgstr "網路名稱"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+msgid "Password"
+msgstr "密碼"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr "產生隨機密碼"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+msgid "Autogenerate Password"
+msgstr "自動產生密碼"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr "開啟(_T)"
+
+#: panels/network/cc-wifi-panel.c:549
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: panels/network/cc-wifi-panel.c:884
+msgid "Stop hotspot and disconnect any users?"
+msgstr "要停止 Wi-Fi 熱點並中斷任何使用者的連接嗎？"
+
+#: panels/network/cc-wifi-panel.c:887
+msgid "_Stop Hotspot"
+msgstr "停止熱點(_S)"
+
+#: panels/network/cc-wifi-panel.ui:75
+msgid "Airplane Mode"
+msgstr "飛安模式"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr "停用 Wi-Fi、藍牙與行動寬頻"
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr "找不到 Wi-Fi 網卡"
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr "請確認您的 Wi-Fi 網卡已插入並啟動"
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr "開啟飛安模式"
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr "關閉以使用 Wi-Fi"
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr "Wi-Fi 熱點已啟動"
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr "行動裝置可以掃描 QR 碼來連接。"
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr "關閉熱點…"
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr "可見的網路"
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr "需要執行 NetworkManager"
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr "802.1x 安全加密(_S)"
+
+#: panels/network/connection-editor/ce-page-8021x-security.c:109
+#: panels/network/connection-editor/ce-page-security.c:419
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr "安全性"
+
+#: panels/network/connection-editor/ce-page.c:234
+msgid "Preserve"
+msgstr "保留"
+
+#: panels/network/connection-editor/ce-page.c:235
+msgid "Permanent"
+msgstr "永久"
+
+#: panels/network/connection-editor/ce-page.c:236
+msgid "Random"
+msgstr "隨機"
+
+#: panels/network/connection-editor/ce-page.c:237
+msgid "Stable"
+msgstr "穩定"
+
+#: panels/network/connection-editor/ce-page.c:241
+msgid ""
+"The MAC address entered here will be used as hardware address for the "
+"network device this connection is activated on. This feature is known as MAC "
+"cloning or spoofing. Example: 00:11:22:33:44:55"
+msgstr ""
+"這裡輸入的 MAC 位址，會當作這個連線啟動所在的網路裝置的硬體位址。這個功能也稱"
+"為 MAC 複製或欺騙。範例：00:11:22:33:44:55"
+
+#: panels/network/connection-editor/ce-page.c:399
+#, c-format
+msgid "Profile %d"
+msgstr "設定檔 %d"
+
+#. TRANSLATORS: this WEP WiFi security
+#: panels/network/connection-editor/ce-page-details.c:98
+#: panels/network/net-device-wifi.c:229
+msgid "WEP"
+msgstr "WEP"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:102
+#: panels/network/net-device-wifi.c:234
+msgid "WPA"
+msgstr "WPA"
+
+#. TRANSLATORS: this WPA3 WiFi security
+#: panels/network/connection-editor/ce-page-details.c:108
+msgid "WPA3"
+msgstr "WPA3"
+
+#. TRANSLATORS: this Enhanced Open WiFi security
+#: panels/network/connection-editor/ce-page-details.c:113
+#: panels/network/connection-editor/ce-page-security.c:274
+msgid "Enhanced Open"
+msgstr "Enhanced Open"
+
+#. TRANSLATORS: this WPA WiFi security
+#: panels/network/connection-editor/ce-page-details.c:125
+msgid "WPA2"
+msgstr "WPA2"
+
+#. TRANSLATORS: this Enterprise WiFi security
+#: panels/network/connection-editor/ce-page-details.c:131
+msgid "Enterprise"
+msgstr "企業版"
+
+#: panels/network/connection-editor/ce-page-details.c:136
+#: panels/network/net-device-wifi.c:219
+msgctxt "Wifi security"
+msgid "None"
+msgstr "沒有加密"
+
+#: panels/network/connection-editor/ce-page-details.c:157
+msgid "Never"
+msgstr "從不使用"
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] "%i 天以前"
+
+#: panels/network/connection-editor/ce-page-details.c:297
+#, c-format
+msgid "%d Mb/s (%1.1f GHz)"
+msgstr "%d Mb/s (%1.1f GHz)"
+
+#. Translators: network device speed
+#: panels/network/connection-editor/ce-page-details.c:299
+#: panels/network/net-device-ethernet.c:217
+#, c-format
+msgid "%d Mb/s"
+msgstr "%d Mb/s"
+
+#: panels/network/connection-editor/ce-page-details.c:314
+msgid "2.4 GHz / 5 GHz"
+msgstr "2.4 GHz / 5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:316
+msgid "2.4 GHz"
+msgstr "2.4 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:318
+msgid "5 GHz"
+msgstr "5 GHz"
+
+#: panels/network/connection-editor/ce-page-details.c:338
+msgctxt "Signal strength"
+msgid "None"
+msgstr "沒有"
+
+#: panels/network/connection-editor/ce-page-details.c:340
+msgctxt "Signal strength"
+msgid "Weak"
+msgstr "太弱"
+
+#: panels/network/connection-editor/ce-page-details.c:342
+msgctxt "Signal strength"
+msgid "Ok"
+msgstr "還行"
+
+#: panels/network/connection-editor/ce-page-details.c:344
+msgctxt "Signal strength"
+msgid "Good"
+msgstr "良好"
+
+#: panels/network/connection-editor/ce-page-details.c:346
+msgctxt "Signal strength"
+msgid "Excellent"
+msgstr "優秀"
+
+#: panels/network/connection-editor/ce-page-details.c:413
+#: panels/network/connection-editor/details-page.ui:94
+#: panels/network/net-device-ethernet.c:144
+#: panels/network/net-device-mobile.c:441
+msgid "IPv4 Address"
+msgstr "IPv4 位址"
+
+#: panels/network/connection-editor/ce-page-details.c:414
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/net-device-ethernet.c:146
+#: panels/network/net-device-mobile.c:442 panels/network/network-mobile.ui:177
+msgid "IPv6 Address"
+msgstr "IPv6 位址"
+
+#: panels/network/connection-editor/ce-page-details.c:416
+#: panels/network/connection-editor/ce-page-details.c:417
+#: panels/network/net-device-ethernet.c:149
+#: panels/network/net-device-ethernet.c:151
+#: panels/network/net-device-mobile.c:445
+#: panels/network/net-device-mobile.c:446 panels/network/network-mobile.ui:163
+msgid "IP Address"
+msgstr "IP 位址"
+
+#: panels/network/connection-editor/ce-page-details.c:421
+#: panels/network/net-device-ethernet.c:166
+#: panels/network/net-device-mobile.c:450
+msgid "DNS4"
+msgstr "DNS4"
+
+#: panels/network/connection-editor/ce-page-details.c:422
+#: panels/network/net-device-ethernet.c:167
+#: panels/network/net-device-mobile.c:451
+msgid "DNS6"
+msgstr "DNS6"
+
+#: panels/network/connection-editor/ce-page-details.c:424
+#: panels/network/connection-editor/ce-page-details.c:425
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/net-device-ethernet.c:169
+#: panels/network/net-device-ethernet.c:171
+#: panels/network/net-device-mobile.c:453
+#: panels/network/net-device-mobile.c:454 panels/network/network-mobile.ui:206
+#: panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr "DNS"
+
+#: panels/network/connection-editor/ce-page-details.c:477
+msgid "Forget Connection"
+msgstr "將該連接遺忘"
+
+#: panels/network/connection-editor/ce-page-details.c:479
+msgid "Remove Connection Profile"
+msgstr "移除連線設定檔"
+
+#: panels/network/connection-editor/ce-page-details.c:481
+msgid "Remove VPN"
+msgstr "移除 VPN"
+
+#: panels/network/connection-editor/ce-page-details.c:499
+msgid "Details"
+msgstr "詳細資料"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:71
+msgid "automatic"
+msgstr "自動"
+
+#: panels/network/connection-editor/ce-page-ethernet.c:144
+#: panels/network/connection-editor/ce-page-vpn.c:148
+#: panels/network/connection-editor/ce-page-wifi.c:129
+msgid "Identity"
+msgstr "身分"
+
+#: panels/network/connection-editor/ce-page-ip4.c:261
+#: panels/network/connection-editor/ce-page-ip6.c:242
+msgid "Delete Address"
+msgstr "刪除位址"
+
+#: panels/network/connection-editor/ce-page-ip4.c:420
+#: panels/network/connection-editor/ce-page-ip6.c:389
+msgid "Delete Route"
+msgstr "刪除路由"
+
+#: panels/network/connection-editor/ce-page-ip4.c:770
+msgid "IPv4"
+msgstr "IPv4"
+
+#: panels/network/connection-editor/ce-page-ip6.c:740
+msgid "IPv6"
+msgstr "IPv6"
+
+#: panels/network/connection-editor/ce-page-security.c:263
+msgctxt "Wi-Fi/Ethernet security"
+msgid "None"
+msgstr "沒有"
+
+#: panels/network/connection-editor/ce-page-security.c:298
+msgid "WEP 40/128-bit Key (Hex or ASCII)"
+msgstr "WEP 40/128-位元金鑰 (Hex 或 ASCII)"
+
+#: panels/network/connection-editor/ce-page-security.c:308
+msgid "WEP 128-bit Passphrase"
+msgstr "WEP 128-位元密語"
+
+#: panels/network/connection-editor/ce-page-security.c:321
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr "LEAP"
+
+#: panels/network/connection-editor/ce-page-security.c:334
+msgid "Dynamic WEP (802.1x)"
+msgstr "動態 WEP (802.1x)"
+
+#: panels/network/connection-editor/ce-page-security.c:348
+msgid "WPA & WPA2 Personal"
+msgstr "WPA 與 WPA2 個人版"
+
+#: panels/network/connection-editor/ce-page-security.c:362
+msgid "WPA & WPA2 Enterprise"
+msgstr "WPA 與 WPA2 企業版"
+
+#: panels/network/connection-editor/ce-page-security.c:376
+msgid "WPA3 Personal"
+msgstr "WPA3 個人版"
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr "訊號強度"
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr "連線速度"
+
+#: panels/network/connection-editor/details-page.ui:126
+#: panels/network/net-device-ethernet.c:154
+msgid "Hardware Address"
+msgstr "硬體位址"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr "支援的頻率"
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/net-device-ethernet.c:158
+#: panels/network/net-device-ethernet.c:160
+#: panels/network/net-device-ethernet.c:162
+#: panels/network/network-mobile.ui:191
+msgid "Default Route"
+msgstr "預設路由"
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr "最後使用時間"
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr "自動連線(_A)"
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr "允許其他使用者使用(_O)"
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr "計量連線(_M)：有資料傳輸量上限，超過可能會產生額外費用"
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr "不會自動進行軟體更新及其他大型下載。"
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+msgid "_Name"
+msgstr "名稱(_N)"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+msgid "_MAC Address"
+msgstr "_MAC 位址"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr "M_TU"
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+msgid "_Cloned Address"
+msgstr "複製的 MA_C 位址"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr "位元組"
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr "IPv_4 方法"
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr "自動 (DHCP)"
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr "只有本機連線"
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/net-proxy.c:71 panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr "手動"
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+msgid "Disable"
+msgstr "停用"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr "分享給其他電腦"
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+msgid "Addresses"
+msgstr "位址"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+msgid "Address"
+msgstr "位址"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr "子網路遮罩"
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr "閘道"
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/net-proxy.c:73 panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+#: panels/wacom/cc-wacom-page.c:656
+msgid "Automatic"
+msgstr "自動"
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr "自動 DNS"
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr "DNS 伺服器位址"
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr "請以逗號 (,) 分隔 IP 位址"
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+msgid "Routes"
+msgstr "路由"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr "自動路由"
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr "權值"
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr "只在使用該連線的網路資源時才使用此連線(_O)"
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr "IPv_6 方法"
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr "自動，僅使用 DHCP"
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr "前綴"
+
+#: panels/network/connection-editor/net-connection-editor.c:277
+msgid "Unable to open connection editor"
+msgstr "無法開啟連線編輯器"
+
+#: panels/network/connection-editor/net-connection-editor.c:293
+msgid "New Profile"
+msgstr "新增設定檔"
+
+#: panels/network/connection-editor/net-connection-editor.c:360
+#, c-format
+msgid "Invalid setting %s: %s"
+msgstr "無效的設定值「%s」：%s"
+
+#: panels/network/connection-editor/net-connection-editor.c:363
+#, c-format
+msgid "Invalid setting %s"
+msgstr "無效的設定值「%s」"
+
+#: panels/network/connection-editor/net-connection-editor.c:721
+msgid "Import from file…"
+msgstr "從檔案匯入…"
+
+#: panels/network/connection-editor/net-connection-editor.c:747
+msgid "Add VPN"
+msgstr "加入 VPN"
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr "安全性(_E)"
+
+#: panels/network/connection-editor/vpn-helpers.c:186
+msgid "Cannot import VPN connection"
+msgstr "無法匯入 VPN 網路連線"
+
+#: panels/network/connection-editor/vpn-helpers.c:188
+#, c-format
+msgid ""
+"The file “%s” could not be read or does not contain recognized VPN "
+"connection information\n"
+"\n"
+"Error: %s."
+msgstr ""
+"檔案「%s」無法讀取，或未包含可辨識的 VPN 連線資訊\n"
+"\n"
+"錯誤：%s。"
+
+#: panels/network/connection-editor/vpn-helpers.c:218
+msgid "Select file to import"
+msgstr "選擇要匯入的檔案"
+
+#: panels/network/connection-editor/vpn-helpers.c:271
+#, c-format
+msgid "A file named “%s” already exists."
+msgstr "名為「%s」的檔案已存在。"
+
+#: panels/network/connection-editor/vpn-helpers.c:273
+msgid "_Replace"
+msgstr "取代(_R)"
+
+#: panels/network/connection-editor/vpn-helpers.c:275
+#, c-format
+msgid "Do you want to replace %s with the VPN connection you are saving?"
+msgstr "您是否要以正在儲存的 VPN 連線取代「%s」？"
+
+#: panels/network/connection-editor/vpn-helpers.c:310
+msgid "Cannot export VPN connection"
+msgstr "無法匯出 VPN 連線"
+
+#: panels/network/connection-editor/vpn-helpers.c:312
+#, c-format
+msgid ""
+"The VPN connection “%s” could not be exported to %s.\n"
+"\n"
+"Error: %s."
+msgstr ""
+"VPN 連線「%s」無法匯出至 %s。\n"
+"\n"
+"錯誤：%s。"
+
+#: panels/network/connection-editor/vpn-helpers.c:338
+msgid "Export VPN connection"
+msgstr "匯出 VPN 連線"
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr "（錯誤：無法載入 VPN 連線編輯器）"
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr "_SSID"
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr "_BSSID"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr "控制您如何連線至網際網絡"
+
+#. Translators: Search terms to find the Network panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+"Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;網路;區域網路;代理"
+"伺服器;寬頻;數據機;藍牙;區網;代理;藍牙;"
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr "控制您如何連線至 Wi-Fi 網絡"
+
+#. Translators: Search terms to find the Wi-Fi panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+"Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;網路;無線網路;區域網"
+"路;寬頻;熱點;區網;"
+
+#: panels/network/net-device-ethernet.c:93
+msgid "never"
+msgstr "從未用過"
+
+#: panels/network/net-device-ethernet.c:101
+msgid "today"
+msgstr "今天"
+
+#: panels/network/net-device-ethernet.c:103
+msgid "yesterday"
+msgstr "昨天"
+
+#: panels/network/net-device-ethernet.c:177
+msgid "Last used"
+msgstr "最後使用時間"
+
+#. Translators: This is used as the title of the connection
+#. * details window for ethernet, if there is only a single
+#. * profile. It is also used to display ethernet in the
+#. * device list.
+#.
+#: panels/network/net-device-ethernet.c:264
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr "有線網路"
+
+#: panels/network/net-device-mobile.c:208
+msgid "Add new connection"
+msgstr "加入新連線"
+
+#: panels/network/net-device-wifi.c:863
+msgid ""
+"Network details for the selected networks, including passwords and any "
+"custom configuration will be lost."
+msgstr "所選網路的詳細資料，包含密碼及任何自訂設定都將遺失。"
+
+#: panels/network/net-device-wifi.c:867
+msgid "_Forget"
+msgstr "遺忘(_F)"
+
+#: panels/network/net-device-wifi.c:1048
+msgid "Known Wi-Fi Networks"
+msgstr "已知的 Wi-Fi 網路"
+
+#. translators: This is the label for the "Forget wireless network" functionality
+#: panels/network/net-device-wifi.c:1067
+msgctxt "Wi-Fi Network"
+msgid "_Forget"
+msgstr "遺忘(_F)"
+
+#: panels/network/net-device-wifi.c:1221
+msgid "System policy prohibits use as a Hotspot"
+msgstr "系統政策不允許做為熱點"
+
+#: panels/network/net-device-wifi.c:1224
+msgid "Wireless device does not support Hotspot mode"
+msgstr "無線裝置不支援熱點模式"
+
+#. TRANSLATORS: this is when the use leaves the PAC textbox blank
+#: panels/network/net-proxy.c:112
+msgid ""
+"Web Proxy Autodiscovery is used when a Configuration URL is not provided."
+msgstr "當沒有提供組態 URL 時會使用網頁代理伺服器自動探尋。"
+
+#. TRANSLATORS: WPAD is bad: if you enable it on an untrusted
+#. * network, then anyone else on that network can tell your
+#. * machine that it should proxy all of your web traffic
+#. * through them.
+#: panels/network/net-proxy.c:120
+msgid "This is not recommended for untrusted public networks."
+msgstr "這不建議用於不信任的公用網路。"
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr "關閉裝置"
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+msgid "Active"
+msgstr "使用中"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr "IMEI"
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr "供應商"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "網路代理伺服器"
+
+#: panels/network/network-proxy.ui:141
+msgid "_HTTP Proxy"
+msgstr "_HTTP 代理伺服器"
+
+#: panels/network/network-proxy.ui:158
+msgid "H_TTPS Proxy"
+msgstr "H_TTPS 代理伺服器"
+
+#: panels/network/network-proxy.ui:175
+msgid "_FTP Proxy"
+msgstr "_FTP 代理伺服器"
+
+#: panels/network/network-proxy.ui:192
+msgid "_Socks Host"
+msgstr "Socks 主機(_S)"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr "忽略主機(_I)"
+
+#: panels/network/network-proxy.ui:246
+msgid "HTTP proxy port"
+msgstr "HTTP 代理伺服器通訊埠"
+
+#: panels/network/network-proxy.ui:309
+msgid "HTTPS proxy port"
+msgstr "HTTPS 代理伺服器通訊埠"
+
+#: panels/network/network-proxy.ui:324
+msgid "FTP proxy port"
+msgstr "FTP 代理伺服器通訊埠"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr "Socks 代理伺服器通訊埠"
+
+#: panels/network/network-proxy.ui:359
+msgid "_Configuration URL"
+msgstr "設定 URL 位址(_C)"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr "關閉 VPN 連線"
+
+#: panels/network/network-wifi.ui:34
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "網路名稱"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr "安全性類型"
+
+#: panels/network/network-wifi.ui:46
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "密碼"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr "關閉 Wi-Fi 網路"
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+msgid "More options…"
+msgstr "更多選項…"
+
+# (Freddy)這項操作會調用 libnma 組件，其翻譯內容需要修正。
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr "連接隱藏的網路(_C)…"
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr "開啟 Wi-Fi 熱點(_T)…"
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr "已知的 Wi-Fi 網路(_K)"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:37
+msgid "Status unknown"
+msgstr "狀態不明"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:41
+msgid "Unmanaged"
+msgstr "不受管理"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:45
+msgid "Unavailable"
+msgstr "無法使用"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:55
+msgid "Connecting"
+msgstr "正在連接"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:59
+msgid "Authentication required"
+msgstr "需要核對身分"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:67
+msgid "Disconnecting"
+msgstr "連接中斷"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:71
+msgid "Connection failed"
+msgstr "連接失敗"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:75
+msgid "Status unknown (missing)"
+msgstr "狀態不明（缺乏）"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:96
+msgid "Configuration failed"
+msgstr "設定失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:100
+msgid "IP configuration failed"
+msgstr "IP 設定失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:104
+msgid "IP configuration expired"
+msgstr "IP 設定過期"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:108
+msgid "Secrets were required, but not provided"
+msgstr "需要密語，但沒有提供"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:112
+msgid "802.1x supplicant disconnected"
+msgstr "802.1x 的請求連接中斷"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:116
+msgid "802.1x supplicant configuration failed"
+msgstr "802.1x 的請求設定失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:120
+msgid "802.1x supplicant failed"
+msgstr "802.1x 的請求失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:124
+msgid "802.1x supplicant took too long to authenticate"
+msgstr "802.1x supplicant 花費太長時間核對"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:128
+msgid "PPP service failed to start"
+msgstr "無法啟動 PPP 服務"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:132
+msgid "PPP service disconnected"
+msgstr "PPP 服務連接中斷"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:136
+msgid "PPP failed"
+msgstr "PPP 失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:140
+msgid "DHCP client failed to start"
+msgstr "DHCP 客戶端無法啟動"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:144
+msgid "DHCP client error"
+msgstr "DHCP 客戶端錯誤"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:148
+msgid "DHCP client failed"
+msgstr "DHCP 客戶端失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:152
+msgid "Shared connection service failed to start"
+msgstr "無法啟動分享的連線服務"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:156
+msgid "Shared connection service failed"
+msgstr "分享的連線服務失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:160
+msgid "AutoIP service failed to start"
+msgstr "無法啟動 AutoIP 服務"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:164
+msgid "AutoIP service error"
+msgstr "AutoIP 服務錯誤"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:168
+msgid "AutoIP service failed"
+msgstr "AutoIP 服務失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:172
+msgid "Line busy"
+msgstr "線路忙碌"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:176
+msgid "No dial tone"
+msgstr "沒有撥號音"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:180
+msgid "No carrier could be established"
+msgstr "無法連接電信商"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:184
+msgid "Dialing request timed out"
+msgstr "撥號要求逾時"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:188
+msgid "Dialing attempt failed"
+msgstr "嘗試撥號失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:192
+msgid "Modem initialization failed"
+msgstr "數據機初始化失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:196
+msgid "Failed to select the specified APN"
+msgstr "無法選擇指定的 APN"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:200
+msgid "Not searching for networks"
+msgstr "不要搜尋網路"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:204
+msgid "Network registration denied"
+msgstr "網路註冊被禁止"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:208
+msgid "Network registration timed out"
+msgstr "網路註冊逾時"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:212
+msgid "Failed to register with the requested network"
+msgstr "無法向要求的網路註冊"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:216
+msgid "PIN check failed"
+msgstr "PIN 碼檢查失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:220
+msgid "Firmware for the device may be missing"
+msgstr "可能由於缺少裝置韌體"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:224
+msgid "Connection disappeared"
+msgstr "連接已消失"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:228
+msgid "Existing connection was assumed"
+msgstr "優先使用現有的連線"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:232
+msgid "Modem not found"
+msgstr "找不到數據機"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:236
+msgid "Bluetooth connection failed"
+msgstr "藍牙連接失敗"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:240
+msgid "SIM Card not inserted"
+msgstr "SIM 卡尚未插入"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:244
+msgid "SIM Pin required"
+msgstr "需要 SIM 卡的 PIN 碼"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:248
+msgid "SIM Puk required"
+msgstr "需要 SIM 卡的 PUK 碼"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:252 panels/wwan/cc-wwan-errors-private.h:53
+msgid "SIM wrong"
+msgstr "SIM 錯誤"
+
+#. TRANSLATORS: device status reason
+#: panels/network/panel-common.c:256
+msgid "Connection dependency failed"
+msgstr "連線相依性解析失敗"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:327
+msgid "Firmware missing"
+msgstr "缺少韌體"
+
+#. TRANSLATORS: device status
+#: panels/network/panel-common.c:331
+msgid "Cable unplugged"
+msgstr "網路線已拔除"
+
+#: panels/network/wireless-security/eap-method.c:92
+msgid "undefined error in 802.1X security (wpa-eap)"
+msgstr "802.1X 安全加密 (wpa-eap) 的未定義錯誤"
+
+#: panels/network/wireless-security/eap-method.c:196
+msgid "no file selected"
+msgstr "未選擇檔案"
+
+#: panels/network/wireless-security/eap-method.c:224
+msgid "unspecified error validating eap-method file"
+msgstr "eap-method 檔案驗證時發生未指定的錯誤"
+
+#: panels/network/wireless-security/eap-method.c:394
+msgid "DER, PEM, PKCS#12, or PGP private keys"
+msgstr "DER、PEM、PKCS#12、或 PGP 私密金鑰"
+
+#: panels/network/wireless-security/eap-method.c:397
+msgid "DER or PEM certificates"
+msgstr "DER 或 PEM 憑證"
+
+#: panels/network/wireless-security/eap-method-fast.c:88
+msgid "missing EAP-FAST PAC file"
+msgstr "缺少 EAP-FAST PAC 檔案"
+
+#: panels/network/wireless-security/eap-method-fast.c:353
+msgid "PAC files (*.pac)"
+msgstr "PAC 檔案 (*.pac)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr "GTC"
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr "MSCHAPv2"
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr "匿名"
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr "已認證"
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr "兩者"
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr "匿名識別(_M)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr "PAC 檔案(_F)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr "選擇一個 PAC 檔案"
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+msgid "_Inner authentication"
+msgstr "內部身分核對(_I)"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr "允許自動 PAC 規範(_V)"
+
+#: panels/network/wireless-security/eap-method-leap.c:65
+msgid "missing EAP-LEAP username"
+msgstr "缺少 EAP-LEAP 使用者名稱"
+
+#: panels/network/wireless-security/eap-method-leap.c:80
+msgid "missing EAP-LEAP password"
+msgstr "缺少 EAP-LEAP 密碼"
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+msgid "_Username"
+msgstr "使用者名稱(_U)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+msgid "_Password"
+msgstr "密碼(_P)"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+msgid "Sho_w password"
+msgstr "顯示密碼(_W)"
+
+#: panels/network/wireless-security/eap-method-peap.c:88
+#, c-format
+msgid "invalid EAP-PEAP CA certificate: %s"
+msgstr "無效的 EAP-PEAP CA 憑證：%s"
+
+#: panels/network/wireless-security/eap-method-peap.c:97
+msgid "invalid EAP-PEAP CA certificate: no certificate specified"
+msgstr "無效的 EAP-PEAP CA 憑證：沒有指定憑證"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr "MD5"
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+msgid "Version 0"
+msgstr "版本 0"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+msgid "Version 1"
+msgstr "版本 1"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr "C_A 憑證"
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.c:524
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr "選擇憑證授權單位 (CA) 憑證"
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr "不需要 CA 憑證(_R)"
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr "PEAP 版本(_V)"
+
+#: panels/network/wireless-security/eap-method-simple.c:78
+msgid "missing EAP username"
+msgstr "缺少 EAP 使用者名稱"
+
+#: panels/network/wireless-security/eap-method-simple.c:91
+msgid "missing EAP password"
+msgstr "缺少 EAP 密碼"
+
+#: panels/network/wireless-security/eap-method-tls.c:93
+msgid "missing EAP-TLS identity"
+msgstr "缺少 EAP-TLS 身分"
+
+#: panels/network/wireless-security/eap-method-tls.c:103
+#, c-format
+msgid "invalid EAP-TLS CA certificate: %s"
+msgstr "無效的 EAP-TLS CA 憑證：%s"
+
+#: panels/network/wireless-security/eap-method-tls.c:113
+msgid "invalid EAP-TLS CA certificate: no certificate specified"
+msgstr "無效的 EAP-TLS CA 憑證：沒有指定憑證"
+
+#: panels/network/wireless-security/eap-method-tls.c:130
+#, c-format
+msgid "invalid EAP-TLS private-key: %s"
+msgstr "無效的 EAP-TLS 私密金鑰：%s"
+
+#: panels/network/wireless-security/eap-method-tls.c:140
+#, c-format
+msgid "invalid EAP-TLS user-certificate: %s"
+msgstr "無效的 EAP-TLS 使用者憑證：%s"
+
+#: panels/network/wireless-security/eap-method-tls.c:279
+msgid "Unencrypted private keys are insecure"
+msgstr "未加密的私密金鑰不安全"
+
+#: panels/network/wireless-security/eap-method-tls.c:282
+msgid ""
+"The selected private key does not appear to be protected by a password. This "
+"could allow your security credentials to be compromised. Please select a "
+"password-protected private key.\n"
+"\n"
+"(You can password-protect your private key with openssl)"
+msgstr ""
+"選擇的私密金鑰似乎沒有受密碼保護， 這可能導致您的安全憑證受到威脅。請選擇受密"
+"碼保護的私密金鑰。\n"
+"\n"
+"（您可以使用 openssl 來加密您的私密金鑰）"
+
+#: panels/network/wireless-security/eap-method-tls.c:517
+msgid "Choose your personal certificate"
+msgstr "選擇您的個人憑證"
+
+#: panels/network/wireless-security/eap-method-tls.c:531
+msgid "Choose your private key"
+msgstr "選擇您的私密金鑰"
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr "識別(_D)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr "使用者憑證(_U)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr "私密金鑰(_K)"
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+msgid "_Private key password"
+msgstr "私密金鑰密碼(_P)"
+
+#: panels/network/wireless-security/eap-method-ttls.c:99
+#, c-format
+msgid "invalid EAP-TTLS CA certificate: %s"
+msgstr "無效的 EAP-TTLS CA 憑證：%s"
+
+#: panels/network/wireless-security/eap-method-ttls.c:107
+msgid "invalid EAP-TTLS CA certificate: no certificate specified"
+msgstr "無效的 EAP-TTLS CA 憑證：沒有指定憑證"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr "PAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr "MSCHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr "MSCHAPv2（無 EAP）"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr "CHAP"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr "網域(_O)"
+
+#: panels/network/wireless-security/wireless-security.c:71
+msgid "Unknown error validating 802.1X security"
+msgstr "驗證 802.1X 安全加密時遇到未知錯誤"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr "TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr "PWD"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr "FAST"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr "穿隧式 TLS"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr "保護式 EAP (PEAP)"
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+msgid "Au_thentication"
+msgstr "認證協定(_T)"
+
+#: panels/network/wireless-security/ws-file-chooser-button.c:49
+msgid "Select a file"
+msgstr "選擇檔案"
+
+#: panels/network/wireless-security/ws-leap.c:66
+msgid "missing leap-username"
+msgstr "缺少 leap 使用者名稱"
+
+#: panels/network/wireless-security/ws-leap.c:81
+msgid "missing leap-password"
+msgstr "缺少 leap 密碼"
+
+#: panels/network/wireless-security/ws-sae.c:77
+msgid "Wi-Fi password is missing."
+msgstr "缺少 Wi-Fi 密碼。"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+msgid "_Type"
+msgstr "類型(_T)"
+
+#: panels/network/wireless-security/ws-wep-key.c:114
+msgid "missing wep-key"
+msgstr "缺少 wep-key"
+
+#: panels/network/wireless-security/ws-wep-key.c:123
+#, c-format
+msgid "invalid wep-key: key with a length of %zu must contain only hex-digits"
+msgstr "無效的 wep-key：長度為 %zu 的金鑰必須只能包含十六進位數字"
+
+#: panels/network/wireless-security/ws-wep-key.c:131
+#, c-format
+msgid ""
+"invalid wep-key: key with a length of %zu must contain only ascii characters"
+msgstr "無效的 wep-key：長度為 %zu 的金鑰必須只能包含 ascii 字元"
+
+#: panels/network/wireless-security/ws-wep-key.c:137
+#, c-format
+msgid ""
+"invalid wep-key: wrong key length %zu. A key must be either of length 5/13 "
+"(ascii) or 10/26 (hex)"
+msgstr ""
+"無效的 wep-key：錯誤的金鑰長度 %zu。金鑰長度必須為 5/13 (ascii) 或 10/26 (十"
+"六進位)"
+
+#: panels/network/wireless-security/ws-wep-key.c:144
+msgid "invalid wep-key: passphrase must be non-empty"
+msgstr "無效的 wep-key︰密語必須不能留空"
+
+#: panels/network/wireless-security/ws-wep-key.c:146
+msgid "invalid wep-key: passphrase must be shorter than 64 characters"
+msgstr "無效的 wep-key︰密語必須少於 64 個字元"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+msgid "1 (Default)"
+msgstr "1 (預設值)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+msgid "Open System"
+msgstr "開放系統"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr "共享的金鑰"
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr "金鑰(_K)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr "顯示金鑰(_W)"
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr "WEP 索引(_X)"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:77
+#, c-format
+msgid ""
+"invalid wpa-psk: invalid key-length %zu. Must be [8,63] bytes or 64 hex "
+"digits"
+msgstr "無效的 wpa-psk：無效的長度 %zu。必須為 [8,63] 位元組或 64 十六進位數字"
+
+#: panels/network/wireless-security/ws-wpa-psk.c:86
+msgid "invalid wpa-psk: cannot interpret key with 64 bytes as hex"
+msgstr "無效的 wpa-psk：不能將 64 位元組金鑰轉譯為十六進位"
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "啟用/停用通知(_N)"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "響鈴通知(_A)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr "彈出式通知(_P)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr "彈出式通知停用時，通知依然會顯示在通知列表中。"
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr "在彈出的通知中顯示訊息內容(_C)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "螢幕鎖定畫面通知(_L)"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr "在螢幕鎖定畫面中顯示訊息內容(_O)"
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr "不要打擾(_D)"
+
+#: panels/notifications/cc-notifications-panel.ui:17
+msgid "_Lock Screen Notifications"
+msgstr "螢幕鎖定時顯示通知(_L)"
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr "控制要顯示哪些通知及要顯示什麼"
+
+#. Translators: Search terms to find the Notifications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+"Notifications;Banner;Message;Tray;Popup;通知;橫幅;訊息;匣;彈出;鎖定畫面;不要"
+"打擾;"
+
+#: panels/online-accounts/cc-online-account-provider-row.c:95
+msgctxt "Online Account"
+msgid "Other"
+msgstr "其他"
+
+#. Translators: The %s is the username (eg., debarshi.ray@gmail.com
+#. * or rishi).
+#.
+#: panels/online-accounts/cc-online-accounts-panel.c:280
+#, c-format
+msgid "%s removed"
+msgstr "已移除 %s"
+
+#: panels/online-accounts/cc-online-accounts-panel.c:695
+msgid "Error removing account"
+msgstr "移除帳號時發生錯誤"
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr "還原"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+msgid "Close the notification"
+msgstr "關閉通知"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr "連接您在雲端伺服器上的資料"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr "沒有網際網路連線 — 請連接網路以設定新的線上帳號"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr "加入帳號"
+
+#. translators: This is the title of the "Show Account" dialog. The
+#. * %s is the name of the provider. e.g., 'Google'.
+#: panels/online-accounts/gnome-control-center-goa-helper.c:428
+#, c-format
+msgid "%s Account"
+msgstr "%s 帳號"
+
+#: panels/online-accounts/gnome-control-center-goa-helper.c:431
+msgid "Remove Account"
+msgstr "移除帳號"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr "線上帳號"
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr "連接您的線上帳號並設定線上帳號的用途"
+
+#. Translators: Search terms to find the Online Accounts panel.
+#. Do NOT translate or localize the semicolons!
+#. The list MUST also end with a semicolon!
+#. For ReadItLater and Pocket, see http://en.wikipedia.org/wiki/Pocket_(application)
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;谷歌;臉書;推特;雅虎奇摩;網頁;線上;聊天;"
+"行事曆;郵件;連絡人;"
+
+#: panels/power/cc-battery-row.c:80
+msgid "Unknown time"
+msgstr "不明時間"
+
+#: panels/power/cc-battery-row.c:83
+#, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "%i 分鐘"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] "%i 小時"
+
+#. TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+#. * Swap order with "%2$s %2$i %1$s %1$i if needed
+#: panels/power/cc-battery-row.c:98
+#, c-format
+msgid "%i %s %i %s"
+msgstr "%i %s %i %s"
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] "小時"
+
+#: panels/power/cc-battery-row.c:100
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "分鐘"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:117
+#, c-format
+msgid "%s until fully charged"
+msgstr "充飽仍需 %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:124
+#, c-format
+msgid "Caution: %s remaining"
+msgstr "注意：只能再使用 %s"
+
+#. TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes"
+#: panels/power/cc-battery-row.c:129
+#, c-format
+msgid "%s remaining"
+msgstr "還能使用 %s"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:134 panels/power/cc-battery-row.c:164
+msgid "Fully charged"
+msgstr "已充飽"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:138 panels/power/cc-battery-row.c:168
+msgid "Not charging"
+msgstr "未充電"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:142 panels/power/cc-battery-row.c:172
+msgid "Empty"
+msgstr "沒有電池"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:155
+msgid "Charging"
+msgstr "正在充電"
+
+#. TRANSLATORS: primary battery
+#: panels/power/cc-battery-row.c:160
+msgid "Discharging"
+msgstr "未充電"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:191
+msgid "Wireless mouse"
+msgstr "無線滑鼠"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:194
+msgid "Wireless keyboard"
+msgstr "無線鍵盤"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:197
+msgid "Uninterruptible power supply"
+msgstr "不斷電系統"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:200
+msgid "Personal digital assistant"
+msgstr "個人數位助理 (PDA)"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:203
+msgid "Cellphone"
+msgstr "手機"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:206
+msgid "Media player"
+msgstr "媒體播放器"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:209
+msgid "Tablet"
+msgstr "繪圖板"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:212
+msgid "Computer"
+msgstr "電腦"
+
+#. TRANSLATORS: secondary battery
+#: panels/power/cc-battery-row.c:215
+msgid "Gaming input device"
+msgstr "遊戲輸入裝置"
+
+#. TRANSLATORS: secondary battery, misc
+#: panels/power/cc-battery-row.c:218 panels/power/cc-power-panel.c:257
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr "電池"
+
+#: panels/power/cc-battery-row.c:266
+msgctxt "Battery name"
+msgid "Main"
+msgstr "主要"
+
+#: panels/power/cc-battery-row.c:268
+msgctxt "Battery name"
+msgid "Extra"
+msgstr "額外"
+
+#: panels/power/cc-power-panel.c:255
+msgid "Batteries"
+msgstr "電池"
+
+#: panels/power/cc-power-panel.c:514
+msgid "When _idle"
+msgstr "裝置閒置時(_I)"
+
+#: panels/power/cc-power-panel.c:674
+msgid "Suspend"
+msgstr "暫停"
+
+#: panels/power/cc-power-panel.c:675
+msgid "Power Off"
+msgstr "關閉電源"
+
+#: panels/power/cc-power-panel.c:676
+msgid "Hibernate"
+msgstr "休眠"
+
+#: panels/power/cc-power-panel.c:677
+msgid "Nothing"
+msgstr "沒有動作"
+
+#: panels/power/cc-power-panel.c:733
+msgid "When on battery power"
+msgstr "使用電池電源時"
+
+#: panels/power/cc-power-panel.c:735
+msgid "When plugged in"
+msgstr "使用交流電源時"
+
+#: panels/power/cc-power-panel.c:856
+msgctxt "Idle time"
+msgid "Never"
+msgstr "永不"
+
+#: panels/power/cc-power-panel.c:940
+msgid "Automatic suspend"
+msgstr "自動暫停"
+
+#: panels/power/cc-power-panel.c:1036
+msgid ""
+"Performance mode temporarily disabled due to high operating temperature."
+msgstr "因為系統作業產生高溫，效能模式已暫時停用。"
+
+#: panels/power/cc-power-panel.c:1038
+msgid ""
+"Lap detected: performance mode temporarily unavailable. Move the device to a "
+"stable surface to restore."
+msgstr ""
+"偵測到大腿：效能模式暫無法使用。請將裝置移動至穩定的平面以重啟效能模式。"
+
+#: panels/power/cc-power-panel.c:1040
+msgid "Performance mode temporarily disabled."
+msgstr "效能模式已暫時停用。"
+
+#: panels/power/cc-power-panel.c:1082
+msgid ""
+"Low battery: power saver enabled. Previous mode will be restored when "
+"battery is sufficiently charged."
+msgstr "低電量：已啟用省電模式。充至足夠電量後會還原為之前所使用的電源模式。"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1090
+#, c-format
+msgid "Power Saver mode activated by “%s”."
+msgstr "「%s」已啟動省電模式。"
+
+#. translators: "%s" is an application name
+#: panels/power/cc-power-panel.c:1094
+#, c-format
+msgid "Performance mode activated by “%s”."
+msgstr "效能模式已由「%s」啟動。"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "15 分鐘"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "20 分鐘"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "25 分鐘"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "30 分鐘"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "45 分鐘"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr "1 小時"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "80 分鐘"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "90 分鐘"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "100 分鐘"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr "2 小時"
+
+#: panels/power/cc-power-panel.ui:93
+msgid "Power Mode"
+msgstr "電源模式"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr "模式的選擇影響系統效能與耗電量。"
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr "節能選項"
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr "自動調整螢幕亮度"
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr "根據周圍光線調整螢幕亮度。"
+
+#: panels/power/cc-power-panel.ui:139
+msgid "Dim Screen"
+msgstr "調暗螢幕"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr "電腦處於非活動狀態時降低螢幕亮度。"
+
+#: panels/power/cc-power-panel.ui:151
+msgid "Screen _Blank"
+msgstr "轉黑螢幕(_B)"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr "一段時間不活動後關閉螢幕。"
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr "自動進入省電模式"
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr "低電量時啟用省電模式。"
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr "自動暫停(_A)"
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr "一段時間不活動後將電腦暫停。"
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr "電源鍵行為(_W)"
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr "顯示電量百分比(_P)"
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr "自動暫停"
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr "使用交流電源(_P)"
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr "使用電池電源(_B)"
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+msgid "Delay"
+msgstr "等候時間"
+
+#: panels/power/cc-power-profile-row.c:132
+msgctxt "Power profile"
+msgid "Performance"
+msgstr "效能模式"
+
+#: panels/power/cc-power-profile-row.c:133
+msgid "High performance and power usage."
+msgstr "提高效能與耗電量。"
+
+#: panels/power/cc-power-profile-row.c:136
+msgctxt "Power profile"
+msgid "Balanced"
+msgstr "平衡模式"
+
+#: panels/power/cc-power-profile-row.c:137
+msgid "Standard performance and power usage."
+msgstr "標準效能與耗電量。"
+
+#: panels/power/cc-power-profile-row.c:140
+msgctxt "Power profile"
+msgid "Power Saver"
+msgstr "省電模式"
+
+#: panels/power/cc-power-profile-row.c:141
+msgid "Reduced performance and power usage."
+msgstr "降低效能與耗電量。"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr "電源"
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr "檢視電量與更改節能設定"
+
+#. Translators: Search terms to find the Power panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;電源;睡眠;暫停;休眠;電池;亮度;轉黑;顯示器;閒置;能源;關閉螢幕;交流電;"
+
+#. Translators: %s is the printer name
+#: panels/printers/cc-printers-panel.c:685
+#, c-format
+msgid "Printer “%s” has been deleted"
+msgstr "「%s」印表機已刪除"
+
+#. Translators: Addition of the new printer failed.
+#: panels/printers/cc-printers-panel.c:942
+msgid "Failed to add new printer."
+msgstr "無法加入新的印表機。"
+
+#. Translators: The XML file containing user interface can not be loaded
+#: panels/printers/cc-printers-panel.c:1247
+#, c-format
+msgid "Could not load ui: %s"
+msgstr "無法載入使用者介面：%s"
+
+#: panels/printers/cc-printers-panel.c:1315
+msgid "Unlock to Add Printers and Change Settings"
+msgstr "解鎖以加入印表機與更改設定"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+msgid "Printers"
+msgstr "印表機"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr "加入印表機、檢視印表機工作並決定您要如何列印"
+
+#. Translators: Search terms to find the Printers panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr "Printer;Queue;Print;Paper;Ink;Toner;印表機;佇列;列印;紙張;墨水;碳粉;"
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+#: panels/printers/pp-new-printer-dialog.c:255
+#: panels/printers/pp-new-printer-dialog.c:312
+msgid "Add Printer"
+msgstr "加入印表機"
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr "解除鎖定(_U)"
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr "找不到印表機"
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr "輸入網路位址或搜尋印表機"
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr "需要核對身分"
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr "輸入使用者名稱與密碼以檢視在印表機伺服器上的印表機。"
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+msgid "Username"
+msgstr "使用者名稱"
+
+#. Translators: This is the title of the dialog. %s is the printer name.
+#: panels/printers/pp-details-dialog.c:76
+#: panels/printers/pp-details-dialog.c:372
+#, c-format
+msgid "%s Details"
+msgstr "「%s」詳細資料"
+
+#: panels/printers/pp-details-dialog.c:107
+msgid "No suitable driver found"
+msgstr "找不到合適的驅動程式"
+
+#: panels/printers/pp-details-dialog.c:266
+msgid "Select PPD File"
+msgstr "選擇 PPD 檔案"
+
+#: panels/printers/pp-details-dialog.c:275
+msgid ""
+"PostScript Printer Description files (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *."
+"PPD.GZ)"
+msgstr "PostScript 印表機描述檔 (*.ppd, *.PPD, *.ppd.gz, *.PPD.gz, *.PPD.GZ)"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr "印表機名稱不能包含空格、TAB 鍵、# 或 /"
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+msgid "Location"
+msgstr "位置"
+
+#. Translators: Name of column showing printer drivers
+#: panels/printers/pp-details-dialog.ui:139
+#: panels/printers/pp-ppd-selection-dialog.c:236
+msgid "Driver"
+msgstr "驅動程式"
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr "正在搜尋偏好的驅動程式…"
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr "搜尋驅動程式"
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr "從資料庫選擇…"
+
+#: panels/printers/pp-details-dialog.ui:213
+msgid "Install PPD File…"
+msgstr "安裝 PPD 檔案…"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr "選擇印表機驅動程式"
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr "正在載入驅動程式資料庫…"
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#: panels/user-accounts/cc-avatar-chooser.c:98
+msgid "Select"
+msgstr "選取"
+
+#. Translators: The found device is a JetDirect printer
+#: panels/printers/pp-host.c:478
+msgid "JetDirect Printer"
+msgstr "JetDirect 印表機"
+
+#. Translators: The found device is a Line Printer Daemon printer
+#: panels/printers/pp-host.c:713
+msgid "LPD Printer"
+msgstr "LPD 印表機"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:64
+#: panels/printers/pp-ppd-option-widget.c:69
+msgid "One Sided"
+msgstr "單面"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:66
+#: panels/printers/pp-ppd-option-widget.c:71
+msgid "Long Edge (Standard)"
+msgstr "長邊 (標準)"
+
+#. Translators: this is an option of "Two Sided"
+#: panels/printers/pp-ipp-option-widget.c:68
+#: panels/printers/pp-ppd-option-widget.c:73
+msgid "Short Edge (Flip)"
+msgstr "短邊 (翻轉)"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:70
+msgid "Portrait"
+msgstr "直向"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:72
+msgid "Landscape"
+msgstr "橫向"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:74
+msgid "Reverse landscape"
+msgstr "橫向倒轉"
+
+#. Translators: this is an option of "Orientation"
+#: panels/printers/pp-ipp-option-widget.c:76
+msgid "Reverse portrait"
+msgstr "直向倒轉"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Resume"
+msgstr "繼續"
+
+#: panels/printers/pp-job-row.c:55
+msgid "Pause"
+msgstr "暫停"
+
+#. Translators: Job's state (job is waiting to be printed)
+#: panels/printers/pp-job-row.c:144
+msgctxt "print job"
+msgid "Pending"
+msgstr "待處理"
+
+#. Translators: Job's state (job is held for printing)
+#: panels/printers/pp-job-row.c:150
+msgctxt "print job"
+msgid "Paused"
+msgstr "已暫停"
+
+#. Translators: Job's state (job needs authentication to proceed further)
+#: panels/printers/pp-job-row.c:155
+msgctxt "print job"
+msgid "Authentication required"
+msgstr "需要核對身分"
+
+#. Translators: Job's state (job is currently printing)
+#: panels/printers/pp-job-row.c:160
+msgctxt "print job"
+msgid "Processing"
+msgstr "正在處理"
+
+#. Translators: Job's state (job has been stopped)
+#: panels/printers/pp-job-row.c:164
+msgctxt "print job"
+msgid "Stopped"
+msgstr "已停止"
+
+#. Translators: Job's state (job has been canceled)
+#: panels/printers/pp-job-row.c:168
+msgctxt "print job"
+msgid "Canceled"
+msgstr "已取消"
+
+#. Translators: Job's state (job has aborted due to error)
+#: panels/printers/pp-job-row.c:172
+msgctxt "print job"
+msgid "Aborted"
+msgstr "已放棄"
+
+#. Translators: Job's state (job has completed successfully)
+#: panels/printers/pp-job-row.c:176
+msgctxt "print job"
+msgid "Completed"
+msgstr "已完成"
+
+#. Translators: Clicking this button prioritizes printing of this print job
+#: panels/printers/pp-job-row.c:186
+msgid "Move this job to the top of the queue"
+msgstr "將此工作移動至佇列頂端"
+
+#. Translators: This label shows how many jobs of this printer needs to be authenticated to be printed.
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] "有 %u 份工作需要核對身分"
+
+#. Translators: This is the printer name for which we are showing the active jobs
+#: panels/printers/pp-jobs-dialog.c:456
+#, c-format
+msgctxt "Printer jobs dialog title"
+msgid "%s — Active Jobs"
+msgstr "%s — 進行中的工作"
+
+#. Translators: The printer needs authentication info to print.
+#: panels/printers/pp-jobs-dialog.c:460
+#, c-format
+msgid "Enter credentials to print from %s."
+msgstr "請輸入憑證以從 %s 列印。"
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr "網域"
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr "認證(_U)"
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr "全部清除"
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr "認證(_A)"
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:221
+msgid "No Active Printer Jobs"
+msgstr "沒有正在進行的印表機工作"
+
+#: panels/printers/pp-new-printer-dialog.c:270
+msgid "Unlock Print Server"
+msgstr "解鎖印表機伺服器"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:274
+#, c-format
+msgid "Unlock %s."
+msgstr "解鎖 %s。"
+
+#. Translators: Samba server needs authentication of the user to show list of its printers.
+#: panels/printers/pp-new-printer-dialog.c:278
+#, c-format
+msgid "Enter username and password to view printers on %s."
+msgstr "輸入使用者名稱與密碼以檢視位於 %s 的印表機。"
+
+#: panels/printers/pp-new-printer-dialog.c:578
+msgid "Searching for Printers"
+msgstr "搜尋印表機"
+
+#. Translators: The found device is a printer connected via USB
+#: panels/printers/pp-new-printer-dialog.c:1366
+msgid "USB"
+msgstr "USB"
+
+#. Translators: The found device is a printer connected via serial port
+#: panels/printers/pp-new-printer-dialog.c:1371
+msgid "Serial Port"
+msgstr "序列埠"
+
+#. Translators: The found device is a printer connected via parallel port
+#: panels/printers/pp-new-printer-dialog.c:1378
+msgid "Parallel Port"
+msgstr "串列埠"
+
+#. Translators: Location of found network printer (e.g. Kitchen, Reception)
+#: panels/printers/pp-new-printer-dialog.c:1420
+#, c-format
+msgid "Location: %s"
+msgstr "位置：%s"
+
+#. Translators: Network address of found printer
+#: panels/printers/pp-new-printer-dialog.c:1425
+#, c-format
+msgid "Address: %s"
+msgstr "位址：%s"
+
+#. Translators: This item is a server which needs authentication to show its printers
+#: panels/printers/pp-new-printer-dialog.c:1452
+msgid "Server requires authentication"
+msgstr "伺服器要求認證"
+
+#: panels/printers/pp-options-dialog.c:87
+msgid "Two Sided"
+msgstr "雙面"
+
+#: panels/printers/pp-options-dialog.c:88
+msgid "Paper Type"
+msgstr "紙張類型"
+
+#: panels/printers/pp-options-dialog.c:89
+msgid "Paper Source"
+msgstr "紙張來源"
+
+#: panels/printers/pp-options-dialog.c:90
+msgid "Output Tray"
+msgstr "出紙匣"
+
+#: panels/printers/pp-options-dialog.c:91
+msgctxt "printing option"
+msgid "Resolution"
+msgstr "解析度"
+
+#: panels/printers/pp-options-dialog.c:92
+msgid "GhostScript pre-filtering"
+msgstr "GhostScript 前置過濾器"
+
+#. Translators: This option sets number of pages printed on one sheet
+#: panels/printers/pp-options-dialog.c:517
+msgid "Pages per side"
+msgstr "每面的頁數"
+
+#. Translators: This option sets whether to print on both sides of paper
+#: panels/printers/pp-options-dialog.c:529
+msgid "Two-sided"
+msgstr "雙面"
+
+#. Translators: This option sets orientation of print (portrait, landscape...)
+#: panels/printers/pp-options-dialog.c:541
+msgid "Orientation"
+msgstr "方向"
+
+#. Translators: "General" tab contains general printer options
+#: panels/printers/pp-options-dialog.c:638
+msgctxt "Printer Option Group"
+msgid "General"
+msgstr "一般"
+
+#. Translators: "Page Setup" tab contains settings related to pages (page size, paper source, etc.)
+#: panels/printers/pp-options-dialog.c:641
+msgctxt "Printer Option Group"
+msgid "Page Setup"
+msgstr "頁面設定"
+
+#. Translators: "Installable Options" tab contains settings of presence of installed options (amount of RAM, duplex unit, etc.)
+#: panels/printers/pp-options-dialog.c:644
+msgctxt "Printer Option Group"
+msgid "Installable Options"
+msgstr "可安裝選項"
+
+#. Translators: "Job" tab contains settings for jobs
+#: panels/printers/pp-options-dialog.c:647
+msgctxt "Printer Option Group"
+msgid "Job"
+msgstr "工作"
+
+#. Translators: "Image Quality" tab contains settings for quality of output print (e.g. resolution)
+#: panels/printers/pp-options-dialog.c:650
+msgctxt "Printer Option Group"
+msgid "Image Quality"
+msgstr "影像品質"
+
+#. Translators: "Color" tab contains color settings (e.g. color printing)
+#: panels/printers/pp-options-dialog.c:653
+msgctxt "Printer Option Group"
+msgid "Color"
+msgstr "色彩"
+
+#. Translators: "Finishing" tab contains finishing settings (e.g. booklet printing)
+#: panels/printers/pp-options-dialog.c:656
+msgctxt "Printer Option Group"
+msgid "Finishing"
+msgstr "完成"
+
+#. Translators: "Advanced" tab contains all others settings
+#: panels/printers/pp-options-dialog.c:659
+msgctxt "Printer Option Group"
+msgid "Advanced"
+msgstr "進階"
+
+#. Translators: Name of job which makes printer to print test page
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.c:844
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr "測試頁"
+
+#. Translators: Name of job which makes printer to print test page
+#: panels/printers/pp-options-dialog.c:857
+msgid "Test page"
+msgstr "測試頁"
+
+#. Translators: this is an option of "Paper Source"
+#: panels/printers/pp-ppd-option-widget.c:75
+#: panels/printers/pp-ppd-option-widget.c:77
+#: panels/printers/pp-ppd-option-widget.c:85
+msgid "Auto Select"
+msgstr "自動選擇"
+
+#. Translators: this is an option of "Paper Source"
+#. Translators: this is an option of "Resolution"
+#: panels/printers/pp-ppd-option-widget.c:79
+#: panels/printers/pp-ppd-option-widget.c:81
+#: panels/printers/pp-ppd-option-widget.c:83
+#: panels/printers/pp-ppd-option-widget.c:87
+msgid "Printer Default"
+msgstr "印表機預設值"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:89
+msgid "Embed GhostScript fonts only"
+msgstr "僅嵌入 GhostScript 字型"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:91
+msgid "Convert to PS level 1"
+msgstr "轉換為 PS 等級 1"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:93
+msgid "Convert to PS level 2"
+msgstr "轉換為 PS 等級 2"
+
+#. Translators: this is an option of "GhostScript"
+#: panels/printers/pp-ppd-option-widget.c:95
+msgid "No pre-filtering"
+msgstr "沒有前置過濾器"
+
+#. Translators: Name of column showing printer manufacturers
+#: panels/printers/pp-ppd-selection-dialog.c:220
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr "製造商"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:526 panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr "沒有進行中的工作"
+
+#. Translators: This is the label of the button that opens the Jobs Dialog.
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] "%u 個工作"
+
+#. Translators: Name of job which makes printer to clean its heads
+#: panels/printers/pp-printer-entry.c:651
+msgid "Clean print heads"
+msgstr "清理列印噴頭"
+
+#. Translators: The printer is low on toner
+#: panels/printers/pp-printer-entry.c:719
+msgid "Low on toner"
+msgstr "碳粉不足"
+
+#. Translators: The printer has no toner left
+#: panels/printers/pp-printer-entry.c:721
+msgid "Out of toner"
+msgstr "碳粉已用完"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:724
+msgid "Low on developer"
+msgstr "顯像劑不足"
+
+#. Translators: "Developer" is a chemical for photo development,
+#. * http://en.wikipedia.org/wiki/Photographic_developer
+#: panels/printers/pp-printer-entry.c:727
+msgid "Out of developer"
+msgstr "顯像劑已用完"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:729
+msgid "Low on a marker supply"
+msgstr "墨水匣不足"
+
+#. Translators: "marker" is one color bin of the printer
+#: panels/printers/pp-printer-entry.c:731
+msgid "Out of a marker supply"
+msgstr "墨水匣已用完"
+
+#. Translators: One or more covers on the printer are open
+#: panels/printers/pp-printer-entry.c:733
+msgid "Open cover"
+msgstr "外殼開啟"
+
+#. Translators: One or more doors on the printer are open
+#: panels/printers/pp-printer-entry.c:735
+msgid "Open door"
+msgstr "紙匣門開啟"
+
+#. Translators: At least one input tray is low on media
+#: panels/printers/pp-printer-entry.c:737
+msgid "Low on paper"
+msgstr "紙張不足"
+
+#. Translators: At least one input tray is empty
+#: panels/printers/pp-printer-entry.c:739
+msgid "Out of paper"
+msgstr "紙張已用完"
+
+#. Translators: The printer is offline
+#: panels/printers/pp-printer-entry.c:741
+msgctxt "printer state"
+msgid "Offline"
+msgstr "離線"
+
+#. Translators: Someone has stopped the Printer
+#. Translators: Printer's state (no jobs can be processed)
+#: panels/printers/pp-printer-entry.c:743
+#: panels/printers/pp-printer-entry.c:886
+msgctxt "printer state"
+msgid "Stopped"
+msgstr "已停止"
+
+#. Translators: The printer marker supply waste receptacle is almost full
+#: panels/printers/pp-printer-entry.c:745
+msgid "Waste receptacle almost full"
+msgstr "廢墨收集器將滿"
+
+#. Translators: The printer marker supply waste receptacle is full
+#: panels/printers/pp-printer-entry.c:747
+msgid "Waste receptacle full"
+msgstr "廢墨收集器已滿"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:749
+msgid "The optical photo conductor is near end of life"
+msgstr "感光鼓接近使用壽命"
+
+#. Translators: Optical photo conductors are used in laser printers
+#: panels/printers/pp-printer-entry.c:751
+msgid "The optical photo conductor is no longer functioning"
+msgstr "感光鼓已無法使用"
+
+#. Translators: Printer's state (can start new job without waiting)
+#: panels/printers/pp-printer-entry.c:872
+msgctxt "printer state"
+msgid "Ready"
+msgstr "準備就緒"
+
+#. Translators: Printer's state (printer is ready but doesn't accept new jobs)
+#: panels/printers/pp-printer-entry.c:877
+msgctxt "printer state"
+msgid "Does not accept jobs"
+msgstr "不接受工作"
+
+#. Translators: Printer's state (jobs are processing)
+#: panels/printers/pp-printer-entry.c:882
+msgctxt "printer state"
+msgid "Processing"
+msgstr "正在處理"
+
+#: panels/printers/printer-entry.ui:18
+msgid "Printing Options"
+msgstr "印表機選項"
+
+#: panels/printers/printer-entry.ui:29
+msgid "Printer Details"
+msgstr "印表機詳細資料"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+msgid "Use Printer by Default"
+msgstr "作為預設印表機"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr "清理列印噴頭"
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr "移除印表機"
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+msgid "Model"
+msgstr "型號"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr "墨水殘餘量"
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr "問題解決後請重新啟動機器。"
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr "重新啟動"
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:171
+msgid "Add Printer…"
+msgstr "加入印表機…"
+
+#: panels/printers/printers.ui:160
+msgid "No printers"
+msgstr "沒有印表機"
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:196
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+"抱歉！系統列印服務\n"
+"  似乎無法使用。"
+
+#: panels/region/cc-format-chooser.c:148 panels/region/cc-format-chooser.c:196
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr "格式"
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr "搜尋語言地區…"
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr "通常格式"
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr "所有格式"
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr "沒有搜尋結果"
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr "可以搜尋國家或語言。"
+
+#: panels/region/cc-format-chooser.ui:239
+msgid "Preview"
+msgstr "預覽"
+
+#: panels/region/cc-format-preview.c:137
+msgctxt "measurement format"
+msgid "Imperial"
+msgstr "英制"
+
+#: panels/region/cc-format-preview.c:139
+msgctxt "measurement format"
+msgid "Metric"
+msgstr "公制"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr "日期"
+
+# (Freddy)考量到其他作業系統時常混用「時間」與「時刻」，以及蠻多系統模組也都用「時間」而非「時刻」，嘗試做更改。
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr "日期與時間"
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr "數字"
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr "度量衡"
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr "紙張"
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr "語言與格式設定會在下次登入後修改"
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr "立即登出…"
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr "語言設定會用於介面中的文字與網頁，格式則用於數字、日期、貨幣等。"
+
+#: panels/region/cc-region-panel.ui:51
+msgid "Your Account"
+msgstr "您的帳號"
+
+#: panels/region/cc-region-panel.ui:56 panels/region/cc-region-panel.ui:95
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr "語言(_L)"
+
+#: panels/region/cc-region-panel.ui:72 panels/region/cc-region-panel.ui:111
+msgid "_Formats"
+msgstr "格式(_F)"
+
+#: panels/region/cc-region-panel.ui:90
+msgid "Login Screen"
+msgstr "登入畫面"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr "地區和語言"
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr "選擇您要顯示的語言與格式"
+
+#. Translators: Search terms to find the Region and Language panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr "Language;Layout;Keyboard;Input;語言;配置;鍵盤;輸入;格式;顯示;"
+
+#: panels/removable-media/cc-removable-media-panel.c:256
+msgid "Ask what to do"
+msgstr "詢問要做什麼"
+
+#: panels/removable-media/cc-removable-media-panel.c:260
+msgid "Do nothing"
+msgstr "不做任何動作"
+
+#: panels/removable-media/cc-removable-media-panel.c:264
+msgid "Open folder"
+msgstr "開啟資料夾"
+
+#: panels/removable-media/cc-removable-media-panel.c:331
+msgid "Other Media"
+msgstr "其他媒體"
+
+#: panels/removable-media/cc-removable-media-panel.c:352
+msgid "Select an application for audio CDs"
+msgstr "選擇播放 CD 音訊的應用程式"
+
+#: panels/removable-media/cc-removable-media-panel.c:353
+msgid "Select an application for video DVDs"
+msgstr "選擇播放 DVD 視訊的應用程式"
+
+#: panels/removable-media/cc-removable-media-panel.c:354
+msgid "Select an application to run when a music player is connected"
+msgstr "選擇音樂播放器連接時要執行的應用程式"
+
+#: panels/removable-media/cc-removable-media-panel.c:355
+msgid "Select an application to run when a camera is connected"
+msgstr "選擇相機連接時要執行的應用程式"
+
+#: panels/removable-media/cc-removable-media-panel.c:356
+msgid "Select an application for software CDs"
+msgstr "選擇軟體 CD 放入時要開啟的應用程式"
+
+#. translators: these strings are duplicates of shared-mime-info
+#. * strings, just here to fix capitalization of the English originals.
+#. * If the shared-mime-info translation works for your language,
+#. * simply leave these untranslated.
+#.
+#: panels/removable-media/cc-removable-media-panel.c:368
+msgid "audio DVD"
+msgstr "音訊 (DVD-Audio)"
+
+#: panels/removable-media/cc-removable-media-panel.c:369
+msgid "blank Blu-ray disc"
+msgstr "空白光碟 (Blu-ray)"
+
+#: panels/removable-media/cc-removable-media-panel.c:370
+msgid "blank CD disc"
+msgstr "空白光碟 (CD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:371
+msgid "blank DVD disc"
+msgstr "空白光碟 (DVD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:372
+msgid "blank HD DVD disc"
+msgstr "空白光碟 (HD DVD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:373
+msgid "Blu-ray video disc"
+msgstr "視訊 (Blu-ray)"
+
+#: panels/removable-media/cc-removable-media-panel.c:374
+msgid "e-book reader"
+msgstr "電子書閱讀器"
+
+#: panels/removable-media/cc-removable-media-panel.c:375
+msgid "HD DVD video disc"
+msgstr "視訊 (HD DVD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:376
+msgid "Picture CD"
+msgstr "影像 (KODAK Picture CD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:377
+msgid "Super Video CD"
+msgstr "視訊 (SVCD)"
+
+# (Freddy)考量臺灣人普遍都講 CD VCD DVD 之類的東西，也都知道誰是視訊誰是音訊，故邏輯上是以括號來補充 CD VCD DVD。
+#: panels/removable-media/cc-removable-media-panel.c:378
+msgid "Video CD"
+msgstr "視訊 (VCD)"
+
+#: panels/removable-media/cc-removable-media-panel.c:379
+msgid "Windows software"
+msgstr "軟體 (Windows)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr "選擇媒體與裝置接上時要執行的動作"
+
+# (Freddy)考量臺灣人普遍都講 CD VCD DVD 之類的東西，也都知道誰是視訊誰是音訊，故邏輯上是以括號來補充 CD VCD DVD。
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr "音訊 CD(_A)"
+
+# (Freddy)考量臺灣人普遍都講 CD VCD DVD 之類的東西，也都知道誰是視訊誰是音訊，故邏輯上是以括號來補充 CD VCD DVD。
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr "視訊 _DVD"
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr "音樂播放器(_M)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr "軟體(_S)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr "其他媒體(_O)…"
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr "接上媒體與裝置時不要提示或啟動程式(_N)"
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr "選擇其他媒體接上時要執行的動作"
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+msgid "_Action:"
+msgstr "動作(_A)："
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+msgid "_Type:"
+msgstr "類型(_T)："
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr "卸除式媒體"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr "修改卸除式媒體的設定值"
+
+#. Translators: Search terms to find the Removable Media panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;裝置;系統;預設;應用程式;偏好;首選;音訊;視訊;光碟;碟"
+"片;可移除;可移除式;媒體;自動執行;卸除式;"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:70
+msgctxt "lock_screen"
+msgid "Screen Turns Off"
+msgstr "關閉立即鎖定"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:73
+msgctxt "lock_screen"
+msgid "30 seconds"
+msgstr "30 秒"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:76
+msgctxt "lock_screen"
+msgid "1 minute"
+msgstr "1 分鐘"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:79
+msgctxt "lock_screen"
+msgid "2 minutes"
+msgstr "2 分鐘"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:82
+msgctxt "lock_screen"
+msgid "3 minutes"
+msgstr "3 分鐘"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:85
+msgctxt "lock_screen"
+msgid "5 minutes"
+msgstr "5 分鐘"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:88
+msgctxt "lock_screen"
+msgid "30 minutes"
+msgstr "30 分鐘"
+
+#. Translators: Option for "Lock screen after blank" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:91
+msgctxt "lock_screen"
+msgid "1 hour"
+msgstr "1 小時"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:134
+msgctxt "blank_screen"
+msgid "1 minute"
+msgstr "1 分鐘"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:137
+msgctxt "blank_screen"
+msgid "2 minutes"
+msgstr "2 分鐘"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:140
+msgctxt "blank_screen"
+msgid "3 minutes"
+msgstr "3 分鐘"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:143
+msgctxt "blank_screen"
+msgid "4 minutes"
+msgstr "4 分鐘"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:146
+msgctxt "blank_screen"
+msgid "5 minutes"
+msgstr "5 分鐘"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:149
+msgctxt "blank_screen"
+msgid "8 minutes"
+msgstr "8 分鐘"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:152
+msgctxt "blank_screen"
+msgid "10 minutes"
+msgstr "10 分鐘"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:155
+msgctxt "blank_screen"
+msgid "12 minutes"
+msgstr "12 分鐘"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:158
+msgctxt "blank_screen"
+msgid "15 minutes"
+msgstr "15 分鐘"
+
+#. Translators: Option for "Blank screen" in "Screen Lock" panel
+#: panels/screen/cc-screen-panel.c:161
+msgctxt "blank_screen"
+msgid "Never"
+msgstr "永不"
+
+#: panels/screen/cc-screen-panel.ui:8
+msgid "Screen Lock"
+msgstr "螢幕鎖定"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr "自動鎖定螢幕能防止他人在您離開時取用您的電腦。"
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr "螢幕轉黑等候"
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr "多久沒活動後將螢幕轉黑。"
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr "自動鎖定螢幕(_L)"
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr "螢幕自動鎖定等候(_S)"
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr "螢幕轉黑後要隔多久才將螢幕鎖定。"
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr "在螢幕鎖定畫面顯示通知(_N)"
+
+#: panels/screen/cc-screen-panel.ui:87
+msgid "Forbid new _USB devices"
+msgstr "禁止新的 _USB 裝置"
+
+#: panels/screen/cc-screen-panel.ui:88
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr "當螢幕鎖定時，防止新的 USB 裝置與系統互動。"
+
+#: panels/screen/cc-screen-panel.ui:108
+msgid "Screen Privacy"
+msgstr "螢幕隱私"
+
+#: panels/screen/cc-screen-panel.ui:113
+msgid "Restrict Viewing Angle"
+msgstr "限制螢幕的檢視角度"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+msgid "Screen Settings"
+msgstr "螢幕設定"
+
+#. Translators: Search terms to find the Screen panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr "screen;lock;private;privacy;螢幕鎖定;鎖定畫面;隱私權;"
+
+#: panels/search/cc-search-locations-dialog.c:674
+msgid "Select Location"
+msgstr "選擇位置"
+
+#: panels/search/cc-search-locations-dialog.c:678
+msgid "_OK"
+msgstr "確定(_O)"
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+msgid "Search Locations"
+msgstr "搜尋位置"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr "系統應用程式會搜尋的資料夾，例如「檔案」、「照片」或「影片」。"
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr "位置"
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr "書籤"
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "其他"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+msgid "Add Location"
+msgstr "加入位置"
+
+#: panels/search/cc-search-panel.c:165
+msgid "No applications found"
+msgstr "找不到應用程式"
+
+#: panels/search/cc-search-panel.ui:10
+msgid "Application Search"
+msgstr "應用程式搜尋"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr "包含應用程式提供的搜尋結果。"
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr "系統應用程式會搜尋的資料夾。"
+
+#: panels/search/cc-search-panel.ui:37
+msgid "Search Results"
+msgstr "搜尋結果"
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr "結果會根據列表順序顯示。"
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr "控制在概覽中哪些應用程式會顯示在搜尋結果"
+
+#. Translators: Search terms to find the Search panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr "Search;Find;Index;Hide;Privacy;Results;搜尋;尋找;索引;隱藏;隱私;結果;"
+
+#. Label
+#: panels/sharing/cc-sharing-networks.c:268
+msgid "No networks selected for sharing"
+msgstr "沒有選擇用於分享的網路"
+
+#: panels/sharing/cc-sharing-networks.ui:15
+msgid "Networks"
+msgstr "網路"
+
+#: panels/sharing/cc-sharing-panel.c:366
+msgctxt "service is enabled"
+msgid "On"
+msgstr "開啟"
+
+#: panels/sharing/cc-sharing-panel.c:368 panels/sharing/cc-sharing-panel.c:395
+msgctxt "service is disabled"
+msgid "Off"
+msgstr "關閉"
+
+#: panels/sharing/cc-sharing-panel.c:398
+msgctxt "service is enabled"
+msgid "Enabled"
+msgstr "已啟用"
+
+#: panels/sharing/cc-sharing-panel.c:401
+msgctxt "service is active"
+msgid "Active"
+msgstr "啟動中"
+
+#: panels/sharing/cc-sharing-panel.c:519
+msgid "Choose a Folder"
+msgstr "選擇資料夾"
+
+#: panels/sharing/cc-sharing-panel.c:672 panels/wwan/cc-wwan-apn-dialog.ui:33
+msgid "Add"
+msgstr "加入"
+
+#: panels/sharing/cc-sharing-panel.c:736
+msgid "Enable media sharing"
+msgstr "啟用媒體分享"
+
+#. TRANSLATORS: %s is replaced with a link to a dav://<hostname> URL
+#: panels/sharing/cc-sharing-panel.c:756
+#, c-format
+msgid ""
+"File Sharing allows you to share your Public folder with others on your "
+"current network using: %s"
+msgstr "檔案分享允許您與目前網路上的其他人分享公開資料夾，使用：%s"
+
+#. TRANSLATORS: %s is replaced with a link to a "ssh <hostname>" command to run
+#: panels/sharing/cc-sharing-panel.c:762
+#, c-format
+msgid ""
+"When remote login is enabled, remote users can connect using the Secure "
+"Shell command:\n"
+"%s"
+msgstr ""
+"啟用遠端登入後，遠端使用者可使用此 SSH 命令來連接：\n"
+"%s"
+
+#: panels/sharing/cc-sharing-panel.c:942
+msgid "Enable personal media sharing"
+msgstr "啟用個人媒體分享"
+
+#: panels/sharing/cc-sharing-panel.c:1308
+msgid "Device name copied"
+msgstr "已複製裝置名稱"
+
+#: panels/sharing/cc-sharing-panel.c:1319
+msgid "Device address copied"
+msgstr "已複製裝置位址"
+
+#: panels/sharing/cc-sharing-panel.c:1330
+msgid "Username copied"
+msgstr "已複製使用者名稱"
+
+#: panels/sharing/cc-sharing-panel.c:1341
+msgid "Password copied"
+msgstr "密碼已複製"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr "分享"
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr "電腦名稱(_C)"
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr "檔案分享(_F)"
+
+#: panels/sharing/cc-sharing-panel.ui:65
+msgid "Remote _Desktop"
+msgstr "遠端桌面(_D)"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr "媒體分享(_M)"
+
+#: panels/sharing/cc-sharing-panel.ui:79
+msgid "_Remote Login"
+msgstr "遠端登入(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr "檔案分享"
+
+#: panels/sharing/cc-sharing-panel.ui:138
+msgid "_Require Password"
+msgstr "需要密碼(_R)"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr "遠端登入"
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+msgid "Remote Desktop"
+msgstr "遠端桌面"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr "遠端桌面允許另一臺電腦檢視與控制您的桌面。"
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr "啟用或停用本電機的遠端桌面連線。"
+
+#: panels/sharing/cc-sharing-panel.ui:284
+msgid "Remote Control"
+msgstr "遠端控制"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr "允許遠端的連線控制本機。"
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr "如何連接"
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr "使用裝置名稱或遠端桌面位址進行連接。"
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+msgid "Copy"
+msgstr "複製"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr "遠端桌面位址"
+
+#: panels/sharing/cc-sharing-panel.ui:361
+msgid "Authentication"
+msgstr "核對身分"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr "需要使用者名稱與密碼才能連接本電腦。"
+
+#: panels/sharing/cc-sharing-panel.ui:366
+msgid "User Name"
+msgstr "使用者名稱"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr "核驗加密"
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr "加密指紋"
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr "您可以在已連接的客戶端看見相同的加密指紋。"
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr "媒體分享"
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr "透過網路分享音樂、相片與影片。"
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr "資料夾"
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr "控制您想與他人分享什麼內容"
+
+#. Translators: Search terms to find the Sharing panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;分享;主機;名稱;遠端;桌面;媒體;音效;影片;圖片;相片;伺服"
+"器;"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr "啟用或停用遠端登入"
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr "啟用或停用遠端登入需要認證"
+
+#: panels/sound/cc-alert-chooser.c:153
+msgid "Custom"
+msgstr "自訂"
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr "喀喀"
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr "噠噠"
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr "霍霍"
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr "嗡嗡"
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr "平衡"
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr "淡化"
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr "後方"
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr "前方"
+
+#: panels/sound/cc-output-test-dialog.c:134
+#, c-format
+msgid "Testing %s"
+msgstr "正在測試「%s」"
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr "按一下喇叭以測試"
+
+#: panels/sound/cc-sound-panel.ui:8
+msgid "System Volume"
+msgstr "系統音量"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr "主音量"
+
+#: panels/sound/cc-sound-panel.ui:28
+msgid "Volume Levels"
+msgstr "個別音量"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr "輸出"
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr "輸出裝置"
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr "測試"
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+msgid "Configuration"
+msgstr "設定"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr "重低音"
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr "輸入"
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr "輸入裝置"
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "音量"
+
+#: panels/sound/cc-sound-panel.ui:327
+msgid "Alert Sound"
+msgstr "鈴響音效"
+
+#: panels/sound/cc-volume-slider.c:116
+msgctxt "volume"
+msgid "100%"
+msgstr "100%"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr "靜音"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "音訊與音效"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr "更改電腦的音量、輸入與輸出裝置、鈴響音效"
+
+#. Translators: Search terms to find the Sound panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;;Output;Input;音"
+"效卡;麥克風;音量;淡化;平衡;藍牙;耳機;音效;輸出;輸入;"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:92
+#: panels/thunderbolt/cc-bolt-device-entry.c:123
+msgctxt "Thunderbolt Device Status"
+msgid "Disconnected"
+msgstr "連接中斷"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:95
+#: panels/thunderbolt/cc-bolt-device-entry.c:126
+msgctxt "Thunderbolt Device Status"
+msgid "Connecting"
+msgstr "正在連接"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:98
+#: panels/thunderbolt/cc-bolt-device-entry.c:130
+#: panels/thunderbolt/cc-bolt-device-entry.c:142
+msgctxt "Thunderbolt Device Status"
+msgid "Connected"
+msgstr "已連接"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:101
+msgctxt "Thunderbolt Device Status"
+msgid "Authorization Error"
+msgstr "授權發生錯誤"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:104
+#: panels/thunderbolt/cc-bolt-device-entry.c:136
+msgctxt "Thunderbolt Device Status"
+msgid "Authorizing"
+msgstr "正在授權"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:111
+msgctxt "Thunderbolt Device Status"
+msgid "Reduced Functionality"
+msgstr "功能受到限制"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:113
+msgctxt "Thunderbolt Device Status"
+msgid "Connected & Authorized"
+msgstr "已連接與授權"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:119
+#: panels/thunderbolt/cc-bolt-device-entry.c:150
+msgctxt "Thunderbolt Device Status"
+msgid "Unknown"
+msgstr "不明"
+
+#. Translators: The time point the device was authorized.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:175
+msgid "Authorized at:"
+msgstr "授權於："
+
+#. Translators: The time point the device was connected.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:181
+msgid "Connected at:"
+msgstr "連接於："
+
+#. Translators: The time point the device was enrolled,
+#. * i.e. authorized and stored in the device database.
+#: panels/thunderbolt/cc-bolt-device-dialog.c:188
+msgid "Enrolled at:"
+msgstr "登錄於："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:262
+msgid "Failed to authorize device: "
+msgstr "裝置授權失敗："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:329
+msgid "Failed to forget device: "
+msgstr "無法將該裝置遺忘："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] "基於其他 %u 個裝置"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr "關閉通知"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
+msgid "Name:"
+msgstr "名稱："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr "狀態："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr "UUID："
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr "授權並連接"
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr "將該裝置遺忘"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:133
+msgctxt "Thunderbolt Device Status"
+msgid "Error"
+msgstr "錯誤"
+
+#: panels/thunderbolt/cc-bolt-device-entry.c:144
+msgctxt "Thunderbolt Device Status"
+msgid "Authorized"
+msgstr "已授權"
+
+#: panels/thunderbolt/cc-bolt-panel.c:169
+msgid ""
+"The Thunderbolt subsystem (boltd) is not installed or not set up properly."
+msgstr "Thunderbolt 子系統 (boltd) 尚未安裝或未正確設定。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:425
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr "允許直接存取裝置，例如擴充塢或外接顯示卡。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:426
+msgid "Only USB and Display Port devices can attach."
+msgstr "只有 USB 與 DisplayPort 裝置可以連接。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:461
+msgid ""
+"Thunderbolt could not be detected.\n"
+"Either the system lacks Thunderbolt support, it has been disabled in the "
+"BIOS or is set to an unsupported security level in the BIOS."
+msgstr ""
+"未偵測到 Thunderbolt。\n"
+"可能是系統不支援 Thunderbolt，也可能是在 BIOS 中被停用或設定至不支援的安全性"
+"層級。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:505
+msgid "Thunderbolt support has been disabled in the BIOS."
+msgstr "Thunderbolt 的支援在 BIOS 中被停用。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:509
+msgid "Thunderbolt security level could not be determined."
+msgstr "無法確定 Thunderbolt 的安全性層級。"
+
+#: panels/thunderbolt/cc-bolt-panel.c:614
+#, c-format
+msgid "Error switching direct mode: %s"
+msgstr "切換直接模式時發生問題：%s"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr "不支援 Thunderbolt"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr "無法連接 Thunderbolt 子系統。"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr "直接存取"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr "待處理的裝置"
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr "沒有連接任何裝置"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr "Thunderbolt"
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr "管理 Thunderbolt 裝置"
+
+#. Translators: those are keywords for the thunderbolt control-center panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr "Thunderbolt;privacy;隱私;"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
+msgid "Cursor Blinking"
+msgstr "游標閃爍"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+msgid "Cursor blinks in text fields."
+msgstr "讓文字欄中的鍵盤游標閃爍。"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+msgid "Speed"
+msgstr "速度"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+msgid "Cursor blinking speed"
+msgstr "游標閃爍速度"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+msgid "Cursor Size"
+msgstr "滑鼠指標大小"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr "滑鼠指標大小可與縮放搭配以輕鬆看出其位置。"
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr "點擊助理"
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr "模擬次要按鍵點擊(_S)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr "按住主要按鍵不放時觸發次要按鍵點擊"
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr "觸發時間(_C)："
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+msgctxt "secondary click"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr "次要按鍵點擊延遲"
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr "長"
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr "懸停點擊(_H)"
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr "滑鼠指標懸停在定點時觸發點擊"
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+msgid "D_elay:"
+msgstr "懸停時間(_E)："
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr "長"
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+msgid "Motion _threshold:"
+msgstr "移動範圍閾值(_T)："
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "小"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "大"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+msgid "Repeat Keys"
+msgstr "重複按鍵"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+msgid "Key presses repeat when key is held down."
+msgstr "按下某鍵不放時重複輸出字元。"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr "按鍵重複延遲"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr "按鍵重複速度"
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr "輸入助理"
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+msgid "_Sticky Keys"
+msgstr "相黏按鍵(_S)"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr "將連續按下的特殊按鍵視作按鍵組合"
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+msgid "_Disable if two keys are pressed together"
+msgstr "若兩個按鍵同時按下則停用(_D)"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+msgid "Beep when a _modifier key is pressed"
+msgstr "特殊鍵按下時發出聲響(_M)"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+msgid "S_low Keys"
+msgstr "遲緩按鍵(_L)"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr "按鍵按下後需停留片刻再放開才會被傳送"
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr "遲緩按鍵觸發時間長度"
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr "長"
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+msgid "Beep when a key is pr_essed"
+msgstr "按鍵按下時發出聲響(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+msgid "Beep when a key is _accepted"
+msgstr "按鍵被接受時發出聲響(_A)"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+msgid "Beep when a key is _rejected"
+msgstr "按鍵被拒絕時發出聲響(_R)"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+msgid "_Bounce Keys"
+msgstr "反彈按鍵(_B)"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+msgid "Ignores fast duplicate keypresses"
+msgstr "忽略對按鍵快速重複按下的動作"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr "反彈按鍵觸發時間長度"
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr "長"
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr "透過鍵盤啟用(_E)"
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr "使用鍵盤開啟與關閉無障礙功能"
+
+#. translators: the labels will read:
+#. * Cursor Size: Default
+#: panels/universal-access/cc-ua-panel.c:356
+msgctxt "cursor size"
+msgid "Default"
+msgstr "預設值"
+
+#: panels/universal-access/cc-ua-panel.c:359
+msgctxt "cursor size"
+msgid "Medium"
+msgstr "中"
+
+#: panels/universal-access/cc-ua-panel.c:362
+msgctxt "cursor size"
+msgid "Large"
+msgstr "大"
+
+#: panels/universal-access/cc-ua-panel.c:365
+msgctxt "cursor size"
+msgid "Larger"
+msgstr "較大"
+
+#: panels/universal-access/cc-ua-panel.c:368
+msgctxt "cursor size"
+msgid "Largest"
+msgstr "最大"
+
+#: panels/universal-access/cc-ua-panel.c:372
+#, c-format
+msgid "%d pixel"
+msgid_plural "%d pixels"
+msgstr[0] "%d 畫素"
+
+#: panels/universal-access/cc-ua-panel.ui:17
+msgid "_Always Show Accessibility Menu"
+msgstr "永遠顯示無障礙輔助選單(_A)"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr "視覺"
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr "高反差(_H)"
+
+#: panels/universal-access/cc-ua-panel.ui:46
+msgid "_Large Text"
+msgstr "大型文字(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr "啟用動畫(_N)"
+
+#: panels/universal-access/cc-ua-panel.ui:70
+msgid "Screen _Reader"
+msgstr "螢幕閱讀器(_R)"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr "螢幕閱讀器能朗讀您所指向的文字。"
+
+#: panels/universal-access/cc-ua-panel.ui:83
+msgid "_Sound Keys"
+msgstr "按鍵聲音(_S)"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr "開啟或關閉 Num Lock 與 Caps Lock 時發出聲響提示。"
+
+#: panels/universal-access/cc-ua-panel.ui:96
+msgid "C_ursor Size"
+msgstr "滑鼠指標大小(_U)"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr "縮放(_Z)"
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr "聽覺"
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr "鈴響視覺化(_V)"
+
+#: panels/universal-access/cc-ua-panel.ui:166
+msgid "Screen _Keyboard"
+msgstr "螢幕鍵盤(_K)"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+msgid "R_epeat Keys"
+msgstr "重複按鍵(_E)"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+msgid "Cursor _Blinking"
+msgstr "游標閃爍(_B)"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr "輸入助理 (AccessX)(_T)"
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr "指向與點擊"
+
+#: panels/universal-access/cc-ua-panel.ui:243
+msgid "_Mouse Keys"
+msgstr "滑鼠鍵(_M)"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+msgid "_Locate Pointer"
+msgstr "定位滑鼠指標(_L)"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr "點擊助理(_C)"
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr "點兩下的延遲時間(_D)"
+
+#: panels/universal-access/cc-ua-panel.ui:297
+msgid "Double-Click Delay"
+msgstr "滑鼠按兩下的速度"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr "鈴響視覺化"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr "測試閃動(_T)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr "發出鈴響時使用視覺化指示。"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+msgid "Flash the entire _screen"
+msgstr "閃動整個螢幕(_S)"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+msgid "Flash the entire _window"
+msgstr "閃動目前視窗(_W)"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:306
+msgctxt "Distance"
+msgid "Short"
+msgstr "短"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:307
+msgctxt "Distance"
+msgid "¼ Screen"
+msgstr "¼ 螢幕"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:308
+msgctxt "Distance"
+msgid "½ Screen"
+msgstr "½ 螢幕"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:309
+msgctxt "Distance"
+msgid "¾ Screen"
+msgstr "¾ 螢幕"
+
+#: panels/universal-access/cc-zoom-options-dialog.c:310
+msgctxt "Distance"
+msgid "Long"
+msgstr "長"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+msgid "Full Screen"
+msgstr "整個螢幕"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr "上半部"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr "下半部"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr "左半部"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr "右半部"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+msgid "Zoom Options"
+msgstr "縮放選項"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+msgid "_Magnification:"
+msgstr "縮放倍率(_M)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+msgid "Magnifier Position:"
+msgstr "放大鏡位置："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr "跟隨滑鼠指標(_F)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+msgid "_Screen part:"
+msgstr "螢幕範圍(_S)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr "放大鏡延伸至螢幕外(_E)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr "放大鏡指標保持置中(_K)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr "放大鏡指標移動至四周時推動內容(_P)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr "放大鏡指標隨內容移動(_C)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+msgid "Magnifier"
+msgstr "放大鏡"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr "十字準星(_C)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr "與滑鼠指標重疊(_O)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr "厚度(_T)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr "薄"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr "厚"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr "長度(_L)："
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr "色彩(_L)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr "十字準星"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr "色彩效果："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr "黑底白字(_W)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+msgid "_Brightness:"
+msgstr "亮度(_B)："
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+msgid "_Contrast:"
+msgstr "對比(_C)："
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr "色彩(_L)"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+msgctxt "universal access, color"
+msgid "None"
+msgstr "黑白"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "彩色"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr "低"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr "高"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr "低"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr "高"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr "色彩效果"
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr "讓您的電腦更容易閱覽、聆聽、輸入、指向與點擊"
+
+#. Translators: Search terms to find the Accessibility panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;鍵盤;滑鼠;無障礙輔助存取;對比;螢幕;閱讀器;文字;字型;"
+"大小;相黏;遲緩;反彈;滑鼠;雙擊;兩下;點按;延遲;助理;輔助;重複;閃動;游標;音效;"
+"大;高;速度;視覺;聽覺;音訊;音樂;輸入;動畫;"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:55
+msgctxt "purge_files"
+msgid "1 hour"
+msgstr "1 小時"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:58
+msgctxt "purge_files"
+msgid "1 day"
+msgstr "1 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:61
+msgctxt "purge_files"
+msgid "2 days"
+msgstr "2 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:64
+msgctxt "purge_files"
+msgid "3 days"
+msgstr "3 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:67
+msgctxt "purge_files"
+msgid "4 days"
+msgstr "4 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:70
+msgctxt "purge_files"
+msgid "5 days"
+msgstr "5 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:73
+msgctxt "purge_files"
+msgid "6 days"
+msgstr "6 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:76
+msgctxt "purge_files"
+msgid "7 days"
+msgstr "7 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:79
+msgctxt "purge_files"
+msgid "14 days"
+msgstr "14 天"
+
+#. Translators: Option for "Automatically Delete Period" in "Trash & Temporary Files" group
+#: panels/usage/cc-usage-panel.c:82
+msgctxt "purge_files"
+msgid "30 days"
+msgstr "30 天"
+
+#: panels/usage/cc-usage-panel.c:180
+msgid "Empty all items from Trash?"
+msgstr "要清除垃圾桶中的所有項目嗎？"
+
+#: panels/usage/cc-usage-panel.c:181
+msgid "All items in the Trash will be permanently deleted."
+msgstr "所有垃圾桶中的項目將永久刪除。"
+
+#: panels/usage/cc-usage-panel.c:182
+msgid "_Empty Trash"
+msgstr "清空垃圾桶(_E)"
+
+#: panels/usage/cc-usage-panel.c:218
+msgid "Delete all the temporary files?"
+msgstr "要刪除所有的暫存檔嗎？"
+
+#: panels/usage/cc-usage-panel.c:219
+msgid "All the temporary files will be permanently deleted."
+msgstr "所有的暫存檔將永遠刪除。"
+
+#: panels/usage/cc-usage-panel.c:220
+msgid "_Purge Temporary Files"
+msgstr "清除暫存檔(_P)"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:247
+msgctxt "retain_history"
+msgid "1 day"
+msgstr "1 天"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:250
+msgctxt "retain_history"
+msgid "7 days"
+msgstr "7 天"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:253
+msgctxt "retain_history"
+msgid "30 days"
+msgstr "30 天"
+
+#. Translators: Option for "File History Duration" in "File History" group
+#: panels/usage/cc-usage-panel.c:256
+msgctxt "retain_history"
+msgid "Forever"
+msgstr "永遠"
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr "檔案歷史記錄"
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+"檔案歷史記錄會紀錄下您所使用過的檔案。該資訊會與其他應用程式分享，方便您找尋"
+"可能會需要的檔案。"
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr "檔案歷史記錄(_I)"
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr "檔案歷史記錄期間(_H)"
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr "清除歷史記錄(_C)…"
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr "垃圾桶與暫存檔"
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+"垃圾桶與暫存檔中的資料可能涉及個人資料或敏感資料。自動定期清理能保障您的隱"
+"私。"
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr "自動清理垃圾桶(_T)"
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr "自動清理暫存檔(_F)"
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr "自動清理週期(_P)"
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr "清理垃圾桶(_E)…"
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr "清理暫存檔(_D)…"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr "檔案歷史記錄與垃圾桶"
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr "不留下可被追蹤的訊息"
+
+#. Translators: Search terms to find the Usage panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+"使用;最近;歷史;檔案;暫存檔;隱私權;垃圾桶;清除;保存;紀錄;追蹤;自動刪除;"
+
+#: panels/user-accounts/cc-add-user-dialog.c:35
+msgid "Should match the web address of your login provider."
+msgstr "應符合登入提供者的網路位址。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:216
+msgid "Failed to add account"
+msgstr "無法加入帳號"
+
+#: panels/user-accounts/cc-add-user-dialog.c:679
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr "密碼不相符。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:883
+#: panels/user-accounts/cc-add-user-dialog.c:922
+#: panels/user-accounts/cc-add-user-dialog.c:940
+msgid "Failed to register account"
+msgstr "無法註冊帳號"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1055
+msgid "No supported way to authenticate with this domain"
+msgstr "不支援這個網域的認證方式"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1119
+msgid "Failed to join domain"
+msgstr "無法加入網域"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1174
+msgid ""
+"That login name didn’t work.\n"
+"Please try again."
+msgstr ""
+"登入名稱不起作用。\n"
+"請再試一次。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1181
+msgid ""
+"That login password didn’t work.\n"
+"Please try again."
+msgstr ""
+"登入密碼不起作用。\n"
+"請再試一次。"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1189
+msgid "Failed to log into domain"
+msgstr "無法登入網域"
+
+#: panels/user-accounts/cc-add-user-dialog.c:1244
+msgid "Unable to find the domain. Maybe you misspelled it?"
+msgstr "找不到網域，也許您拼錯字了？"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr "加入使用者"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr "管理員"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+"管理員可以加入與移除其他使用者，並能更改所有使用者的設定。家長控制不適用於管"
+"理員。"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr "使用者首次登入時要求設定密碼"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+msgid "Set password now"
+msgstr "立即設定密碼"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr "確認密碼"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr "企業登入"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr "由公司或組織所管理的帳號。"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr "您已離線"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+"企業登入功能可以讓集中管理的帳號在此裝置上使用；您也能透過該帳號存取公司的網"
+"路資源。"
+
+#: panels/user-accounts/cc-avatar-chooser.c:164
+msgid "Browse for more pictures"
+msgstr "瀏覽更多照片"
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+msgid "Select a File…"
+msgstr "選擇檔案…"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+msgid "Fingerprint Manager"
+msgstr "指紋管理器"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr "指紋"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+msgid "_No"
+msgstr "否(_N)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr "是(_Y)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr "確定要刪除先前所登錄的指紋嗎？刪除指紋會停用指紋登入。"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr "沒有指紋裝置"
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr "沒有指紋裝置"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr "請確認裝置已確實連接。"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr "指紋裝置"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr "請選擇欲設定的指紋裝置"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr "指紋登入"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr "指紋登入能讓您透過手指來解鎖與登入電腦"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr "刪除指紋(_D)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr "登錄指紋"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:235
+msgid "the device needs to be claimed to perform this action"
+msgstr "須索取裝置才能執行此動作"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:237
+msgid "the device is already claimed by another process"
+msgstr "該裝置已經被其他程序索取"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:239
+msgid "you do not have permission to perform the action"
+msgstr "您未取得執行該動作的許可"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:241
+msgid "no prints have been enrolled"
+msgstr "沒有已登錄的指紋"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:250
+msgid "Failed to communicate with the device during enrollment"
+msgstr "無法與裝置通訊（登錄期間）"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:254
+msgid "Failed to communicate with the fingerprint reader"
+msgstr "無法與指紋辨識器通訊"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:256
+msgid "Failed to communicate with the fingerprint daemon"
+msgstr "無法與指紋辨識器常駐程式通訊"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:513
+#, c-format
+msgid "Failed to list fingerprints: %s"
+msgstr "無法列出指紋：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:580
+#, c-format
+msgid "Failed to delete saved fingerprints: %s"
+msgstr "無法刪除已儲存的指紋：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:611
+msgid "Left thumb"
+msgstr "左手姆指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:613
+msgid "Left middle finger"
+msgstr "左手中指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:615
+msgid "_Left index finger"
+msgstr "左手食指(_L)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:617
+msgid "Left ring finger"
+msgstr "左手無名指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:619
+msgid "Left little finger"
+msgstr "左手小指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:621
+msgid "Right thumb"
+msgstr "右手姆指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:623
+msgid "Right middle finger"
+msgstr "右手中指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:625
+msgid "_Right index finger"
+msgstr "右手食指(_R)"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:627
+msgid "Right ring finger"
+msgstr "右手無名指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:629
+msgid "Right little finger"
+msgstr "右手小指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:631
+msgid "Unknown Finger"
+msgstr "不明手指"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:765
+msgctxt "Fingerprint enroll state"
+msgid "Complete"
+msgstr "登錄完畢"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:776
+msgid "Fingerprint device disconnected"
+msgstr "指紋裝置已中斷連接"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:782
+msgid "Fingerprint device storage is full"
+msgstr "指紋裝置的儲存空間已滿"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:786
+msgid "Failed to enroll new fingerprint"
+msgstr "無法登錄新指紋"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:817
+#, c-format
+msgid "Failed to start enrollment: %s"
+msgstr "無法開始登錄程序：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:825
+msgctxt "Fingerprint enroll state"
+msgid "Failed to enroll new fingerprint"
+msgstr "無法登錄新指紋"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:856
+#, c-format
+msgid "Failed to stop enrollment: %s"
+msgstr "無法停止登錄程序：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:902
+msgid ""
+"Repeatedly lift and place your finger on the reader to enroll your "
+"fingerprint"
+msgstr "請將您的手指置於指紋辨識器上反覆抬起與放下來登錄指紋"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1021
+msgid "_Re-enroll this finger…"
+msgstr "重新登錄這隻手指(_R)…"
+
+#. TRANSLATORS: This is the label for the button to enroll a new finger
+#: panels/user-accounts/cc-fingerprint-dialog.c:1036
+msgid "Scan new fingerprint"
+msgstr "掃描新指紋"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1074
+#, c-format
+msgid "Failed to release fingerprint device %s: %s"
+msgstr "無法釋放指紋裝置 %s：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1146
+msgctxt "Fingerprint enroll state"
+msgid "Problem Reading Device"
+msgstr "讀取裝置存在問題"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1181
+#, c-format
+msgid "Failed to claim fingerprint device %s: %s"
+msgstr "無法索取指紋裝置 %s：%s"
+
+#: panels/user-accounts/cc-fingerprint-dialog.c:1332
+#, c-format
+msgid "Failed to get fingerprint devices: %s"
+msgstr "無法取得指紋裝置：%s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:71
+msgid "This Week"
+msgstr "本週"
+
+#: panels/user-accounts/cc-login-history-dialog.c:74
+msgid "Last Week"
+msgstr "上週"
+
+#. Translators: This is a date format string in the style of "Feb 18",
+#. shown as the first day of a week on login history dialog.
+#. Translators: This is a date format string in the style of "Feb 24",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:84
+#: panels/user-accounts/cc-login-history-dialog.c:88
+msgctxt "login history week label"
+msgid "%b %e"
+msgstr "%-m月%e日"
+
+#. Translators: This is a date format string in the style of "Feb 24, 2013",
+#. shown as the last day of a week on login history dialog.
+#: panels/user-accounts/cc-login-history-dialog.c:93
+msgctxt "login history week label"
+msgid "%b %e, %Y"
+msgstr "%Y年-m月%e日"
+
+#. Translators: This indicates a week label on a login history.
+#. The first %s is the first day of a week, and the second %s the last day.
+#: panels/user-accounts/cc-login-history-dialog.c:98
+#, c-format
+msgctxt "login history week label"
+msgid "%s — %s"
+msgstr "%s — %s"
+
+#. Translators: This is a time format string in the style of "22:58".
+#. It indicates a login time which follows a date.
+#: panels/user-accounts/cc-login-history-dialog.c:179
+#: panels/user-accounts/cc-user-panel.c:727
+msgctxt "login date-time"
+msgid "%k:%M"
+msgstr "%k:%M"
+
+#. Translators: This indicates a login date-time.
+#. The first %s is a date, and the second %s a time.
+#: panels/user-accounts/cc-login-history-dialog.c:182
+#: panels/user-accounts/cc-user-panel.c:731
+#, c-format
+msgctxt "login date-time"
+msgid "%s, %s"
+msgstr "%s，%s"
+
+#: panels/user-accounts/cc-login-history-dialog.c:238
+msgid "Session Ended"
+msgstr "作業階段結束"
+
+#: panels/user-accounts/cc-login-history-dialog.c:244
+msgid "Session Started"
+msgstr "作業階段開始"
+
+#. Translators: This is the title of the "Account Activity" dialog.
+#. The %s is the user real name.
+#: panels/user-accounts/cc-login-history-dialog.c:339
+#, c-format
+msgid "%s — Account Activity"
+msgstr "%s — 帳號活動"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+msgid "Previous"
+msgstr "上週"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr "下週"
+
+#: panels/user-accounts/cc-password-dialog.c:127
+msgid "Please choose another password."
+msgstr "請選擇其他密碼。"
+
+#: panels/user-accounts/cc-password-dialog.c:136
+msgid "Please type your current password again."
+msgstr "請再次輸入目前的密碼。"
+
+#: panels/user-accounts/cc-password-dialog.c:142
+msgid "Password could not be changed"
+msgstr "無法更改密碼"
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+msgid "Change Password"
+msgstr "更改密碼"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+msgid "Ch_ange"
+msgstr "更改(_A)"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+msgid "Current Password"
+msgstr "目前密碼"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+msgid "New Password"
+msgstr "新密碼"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+msgid "Confirm Password"
+msgstr "確認新密碼"
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr "允許使用者在下次登入時更改密碼"
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+msgid "Set a password now"
+msgstr "立即設定密碼"
+
+#: panels/user-accounts/cc-realm-manager.c:303
+msgid "Cannot automatically join this type of domain"
+msgstr "不能自動加入這個類型的網域"
+
+#: panels/user-accounts/cc-realm-manager.c:306
+msgid "No such domain or realm found"
+msgstr "找不到網域或領域名稱"
+
+#: panels/user-accounts/cc-realm-manager.c:712
+#: panels/user-accounts/cc-realm-manager.c:726
+#, c-format
+msgid "Cannot log in as %s at the %s domain"
+msgstr "不能以 %s 的身分登入 %s 網域"
+
+#: panels/user-accounts/cc-realm-manager.c:718
+msgid "Invalid password, please try again"
+msgstr "密碼錯誤，請再試一次"
+
+#: panels/user-accounts/cc-realm-manager.c:731
+#, c-format
+msgid "Couldn’t connect to the %s domain: %s"
+msgstr "無法連接 %s 網域：%s"
+
+#: panels/user-accounts/cc-user-panel.c:356
+msgid "Failed to delete user"
+msgstr "無法刪除使用者"
+
+#: panels/user-accounts/cc-user-panel.c:413
+#: panels/user-accounts/cc-user-panel.c:468
+#: panels/user-accounts/cc-user-panel.c:514
+msgid "Failed to revoke remotely managed user"
+msgstr "無法註銷遠端管理的使用者"
+
+#: panels/user-accounts/cc-user-panel.c:563
+msgid "You cannot delete your own account."
+msgstr "您不能刪除自己的帳號。"
+
+#: panels/user-accounts/cc-user-panel.c:572
+#, c-format
+msgid "%s is still logged in"
+msgstr "%s 仍在登入中"
+
+#: panels/user-accounts/cc-user-panel.c:576
+msgid ""
+"Deleting a user while they are logged in can leave the system in an "
+"inconsistent state."
+msgstr "在使用者登入期間刪除其帳號會使系統處於不穩定的狀態。"
+
+#: panels/user-accounts/cc-user-panel.c:585
+#, c-format
+msgid "Do you want to keep %s’s files?"
+msgstr "您要保留 %s 的檔案嗎？"
+
+#: panels/user-accounts/cc-user-panel.c:589
+msgid ""
+"It is possible to keep the home directory, mail spool and temporary files "
+"around when deleting a user account."
+msgstr "刪除使用者時，可以選擇是否要保留家目錄、電子郵件與暫存檔等資料。"
+
+#: panels/user-accounts/cc-user-panel.c:592
+msgid "_Delete Files"
+msgstr "刪除檔案(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:593
+msgid "_Keep Files"
+msgstr "保留檔案(_K)"
+
+#: panels/user-accounts/cc-user-panel.c:607
+#, c-format
+msgid "Are you sure you want to revoke remotely managed %s’s account?"
+msgstr "確定要註銷遠端管理的 %s 帳號嗎？"
+
+#: panels/user-accounts/cc-user-panel.c:611
+msgid "_Delete"
+msgstr "刪除(_D)"
+
+#: panels/user-accounts/cc-user-panel.c:661
+msgctxt "Password mode"
+msgid "Account disabled"
+msgstr "帳號已停用"
+
+#: panels/user-accounts/cc-user-panel.c:669
+msgctxt "Password mode"
+msgid "To be set at next login"
+msgstr "下次登入時再設定"
+
+#: panels/user-accounts/cc-user-panel.c:672
+msgctxt "Password mode"
+msgid "None"
+msgstr "沒有"
+
+#: panels/user-accounts/cc-user-panel.c:715
+msgid "Logged in"
+msgstr "已登入"
+
+#: panels/user-accounts/cc-user-panel.c:1202
+msgid "Failed to contact the accounts service"
+msgstr "無法連接帳號服務"
+
+#: panels/user-accounts/cc-user-panel.c:1204
+msgid "Please make sure that the AccountService is installed and enabled."
+msgstr "請確保已在系統上安裝並啟用《AccountService》。"
+
+#: panels/user-accounts/cc-user-panel.c:1226
+msgid "This panel must be unlocked to change this setting"
+msgstr "需先解鎖此面板才能更改設定"
+
+#: panels/user-accounts/cc-user-panel.c:1293
+msgid "Delete the selected user account"
+msgstr "刪除所選的使用者帳號"
+
+#: panels/user-accounts/cc-user-panel.c:1297
+#: panels/user-accounts/cc-user-panel.c:1409
+msgid ""
+"To delete the selected user account,\n"
+"click the * icon first"
+msgstr ""
+"要刪除所選的使用者帳號，\n"
+"請先點選 * 圖示"
+
+#: panels/user-accounts/cc-user-panel.c:1455
+msgid "Unlock to Add Users and Change Settings"
+msgstr "解鎖以加入使用者與更改設定"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr "使用者"
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr "您的作業階段需要重新啟動才能使更動生效"
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr "立即重新啟動"
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr "關閉"
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr "編輯大頭貼"
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr "全名"
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#: panels/wwan/cc-wwan-apn-dialog.c:295
+msgid "Edit"
+msgstr "編輯"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr "指紋登入(_F)"
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr "自動登入(_U)"
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr "帳號活動"
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr "管理員(_A)"
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr "管理員可以加入與移除其他使用者，並可以更改所有使用者的設定值。"
+
+#: panels/user-accounts/cc-user-panel.ui:283
+msgid "_Parental Controls"
+msgstr "家長控制(_P)"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+msgid "Open the Parental Controls application."
+msgstr "開啟家長控制應用程式。"
+
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
+msgstr "移除使用者…"
+
+#: panels/user-accounts/cc-user-panel.ui:347
+msgid "Other Users"
+msgstr "其他使用者"
+
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
+msgstr "加入使用者…"
+
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr "找不到使用者"
+
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr "解鎖以新增使用者帳號。"
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr "加入或移除使用者及更改您的密碼"
+
+#. Translators: Search terms to find the Users panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
+msgid ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
+msgstr ""
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;登入;名稱;"
+"指紋;頭像;大頭貼;標誌;臉;密碼;家長控制;父母;大人;螢幕時間;程式限制;網路限制;"
+"用量;使用限制;孩子;小孩;孩童;兒童;"
+
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr "登錄(_E)"
+
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr "網域管理員登入"
+
+#: panels/user-accounts/data/join-dialog.ui:72
+msgid ""
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
+msgstr ""
+"欲使用企業登入，需將該電腦登錄至網域中。\n"
+"請通知您的網路管理員於此輸入網域密碼。"
+
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
+msgstr "管理員名稱(_N)"
+
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr "管理員密碼"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr "管理使用者帳號"
+
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr "更改使用者資料需要核對身分"
+
+#: panels/user-accounts/pw-utils.c:94
+msgctxt "Password hint"
+msgid "The new password needs to be different from the old one."
+msgstr "新密碼需與舊密碼有所差異。"
+
+#: panels/user-accounts/pw-utils.c:96
+msgctxt "Password hint"
+msgid "Try changing some letters and numbers."
+msgstr "試著更動某些英文字母與數字。"
+
+#: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
+msgctxt "Password hint"
+msgid "Try changing the password a bit more."
+msgstr "試著更大幅地更動密碼。"
+
+#: panels/user-accounts/pw-utils.c:100
+msgctxt "Password hint"
+msgid "A password without your user name would be stronger."
+msgstr "不含使用者名稱的密碼強度會更高。"
+
+#: panels/user-accounts/pw-utils.c:102
+msgctxt "Password hint"
+msgid "Try to avoid using your name in the password."
+msgstr "試著避免在密碼中使用您的姓名。"
+
+#: panels/user-accounts/pw-utils.c:104
+msgctxt "Password hint"
+msgid "Try to avoid some of the words included in the password."
+msgstr "試著避免在密碼中包含某些單字。"
+
+#: panels/user-accounts/pw-utils.c:108
+msgctxt "Password hint"
+msgid "Try to avoid common words."
+msgstr "試著避免常用單字。"
+
+#: panels/user-accounts/pw-utils.c:110
+msgctxt "Password hint"
+msgid "Try to avoid reordering existing words."
+msgstr "試著避免重新排序已有的單字。"
+
+#: panels/user-accounts/pw-utils.c:112
+msgctxt "Password hint"
+msgid "Try to use more numbers."
+msgstr "試著使用更多數字。"
+
+#: panels/user-accounts/pw-utils.c:114
+msgctxt "Password hint"
+msgid "Try to use more uppercase letters."
+msgstr "試著使用更多大寫英文字母。"
+
+#: panels/user-accounts/pw-utils.c:116
+msgctxt "Password hint"
+msgid "Try to use more lowercase letters."
+msgstr "試著使用更多小寫英文字母。"
+
+#: panels/user-accounts/pw-utils.c:118
+msgctxt "Password hint"
+msgid "Try to use more special characters, like punctuation."
+msgstr "試著使用更多特殊字元，例如半形標點符號。"
+
+#: panels/user-accounts/pw-utils.c:120
+msgctxt "Password hint"
+msgid "Try to use a mixture of letters, numbers and punctuation."
+msgstr "試著混合使用英文字母、數字、半形標點符號等。"
+
+#: panels/user-accounts/pw-utils.c:122
+msgctxt "Password hint"
+msgid "Try to avoid repeating the same character."
+msgstr "試著避免重複使用相同字元。"
+
+#: panels/user-accounts/pw-utils.c:124
+msgctxt "Password hint"
+msgid ""
+"Try to avoid repeating the same type of character: you need to mix up "
+"letters, numbers and punctuation."
+msgstr "試著避免重複使用相同類型的字元：需混合英文字母、數字、半形標點符號等。"
+
+#: panels/user-accounts/pw-utils.c:126
+msgctxt "Password hint"
+msgid "Try to avoid sequences like 1234 or abcd."
+msgstr "試著避免使用如 1234 或 abcd 之類的連續字元。"
+
+#: panels/user-accounts/pw-utils.c:128
+msgctxt "Password hint"
+msgid ""
+"Password needs to be longer. Try to add more letters, numbers and "
+"punctuation."
+msgstr "密碼長度不足。試著加入更多英文字母、數字、半形標點符號等。"
+
+#: panels/user-accounts/pw-utils.c:130
+msgctxt "Password hint"
+msgid "Mix uppercase and lowercase and try to use a number or two."
+msgstr "混合英文大小寫字元並試著使用 1 至 2 個數字。"
+
+#: panels/user-accounts/pw-utils.c:132
+msgctxt "Password hint"
+msgid ""
+"Adding more letters, numbers and punctuation will make the password stronger."
+msgstr "加入更多英文字母、數字、半形標點符號能使密碼強度更高。"
+
+#: panels/user-accounts/run-passwd.c:401
+msgid "Authentication failed"
+msgstr "身分核對失敗"
+
+#: panels/user-accounts/run-passwd.c:480
+#, c-format
+msgid "The new password is too short"
+msgstr "新密碼過短"
+
+#: panels/user-accounts/run-passwd.c:486
+#, c-format
+msgid "The new password is too simple"
+msgstr "新密碼過於簡單"
+
+#: panels/user-accounts/run-passwd.c:492
+#, c-format
+msgid "The old and new passwords are too similar"
+msgstr "舊密碼與新密碼過於相似"
+
+#: panels/user-accounts/run-passwd.c:495
+#, c-format
+msgid "The new password has already been used recently."
+msgstr "新密碼已在最近使用過。"
+
+#: panels/user-accounts/run-passwd.c:498
+#, c-format
+msgid "The new password must contain numeric or special characters"
+msgstr "新密碼須包含數字或特殊字元"
+
+#: panels/user-accounts/run-passwd.c:502
+#, c-format
+msgid "The old and new passwords are the same"
+msgstr "舊密碼與新密碼相同"
+
+#: panels/user-accounts/run-passwd.c:506
+#, c-format
+msgid "Your password has been changed since you initially authenticated!"
+msgstr "您的密碼在先前身分核對之後已更動！"
+
+# (Freddy)新密碼並未包含足夠的不同字元
+#: panels/user-accounts/run-passwd.c:510
+#, c-format
+msgid "The new password does not contain enough different characters"
+msgstr "新密碼與舊密碼間差異字元數不足"
+
+#: panels/user-accounts/run-passwd.c:514
+#: panels/wwan/cc-wwan-errors-private.h:72
+#, c-format
+msgid "Unknown error"
+msgstr "不明錯誤"
+
+#: panels/user-accounts/user-utils.c:144
+msgid ""
+"The username should usually only consist of lower case letters from a-z, "
+"digits and the following characters: - _"
+msgstr "使用者名稱通常僅能包含小寫英文字母 a 至 z、數字與下述字元：- _"
+
+#: panels/user-accounts/user-utils.c:148
+msgid "Sorry, that user name isn’t available. Please try another."
+msgstr "抱歉，該使用者名稱無法使用。請嘗試其他名稱。"
+
+#: panels/user-accounts/user-utils.c:190
+msgid "The username is too long."
+msgstr "使用者名稱過長。"
+
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+msgid "Map Buttons"
+msgstr "按鍵功能"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr "指定按鍵的功能"
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+"要編輯快捷鍵，請選擇「傳送按鍵」，並按下欲傳送的鍵盤快捷鍵與新按鍵；或按 "
+"Backspace 來清除。"
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr "關閉(_C)"
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr "請點選螢幕上所出現的目標標記來校準繪圖板。"
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr "偵測到錯誤的點擊，正在重新開始…"
+
+#: panels/wacom/cc-wacom-button-row.c:244
+#, c-format
+msgid "Button %d"
+msgstr "按鍵 %d"
+
+#: panels/wacom/cc-wacom-button-row.h:34
+msgctxt "Wacom action-type"
+msgid "Application defined"
+msgstr "指定的應用程式"
+
+#: panels/wacom/cc-wacom-button-row.h:35
+msgctxt "Wacom action-type"
+msgid "Send Keystroke"
+msgstr "傳送按鍵"
+
+#: panels/wacom/cc-wacom-button-row.h:36
+msgctxt "Wacom action-type"
+msgid "Switch Monitor"
+msgstr "切換顯示器"
+
+#: panels/wacom/cc-wacom-button-row.h:37
+msgctxt "Wacom action-type"
+msgid "Show On-Screen Help"
+msgstr "在螢幕上顯示按鍵功能"
+
+#: panels/wacom/cc-wacom-device.c:431
+msgid "Tablet mounted on laptop panel"
+msgstr "繪圖板裝載至筆電面板上"
+
+#: panels/wacom/cc-wacom-device.c:433
+msgid "Tablet mounted on external display"
+msgstr "繪圖板裝載至外接顯示器上"
+
+#: panels/wacom/cc-wacom-device.c:435
+msgid "External tablet device"
+msgstr "外接繪圖板裝置"
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr "外接繪圖板裝置"
+
+#. All displays item
+#: panels/wacom/cc-wacom-page.c:643
+msgid "All Displays"
+msgstr "所有顯示器"
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr "繪圖板模式"
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr "數位筆使用絕對定位"
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr "左手操作"
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr "將繪圖板與 Express Keys™ 旋轉至對側以適用於左手"
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr "顯示器鏡射"
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr "維持寬長比"
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr "僅使用部分的繪圖板面積並以相同寬長比鏡射至顯示器"
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr "校準"
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr "未偵測到繪圖板"
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr "請將 Wacom 繪圖板接上或開啟。"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr "筆尖壓力感應"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr "輕"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr "數位筆壓力感應的輕重"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr "重"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "按鍵 1"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "按鍵 2"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "按鍵 3"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr "橡皮擦壓力感應"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr "橡皮擦壓力"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr "滑鼠中鍵"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr "滑鼠右鍵"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr "下一頁"
+
+#: panels/wacom/cc-wacom-tool.c:321
+msgid "Airbrush stylus with pressure, tilt, and integrated slider"
+msgstr "Airbrush 數位筆搭載壓力感應、傾斜偵測與整合式滑鈕"
+
+#: panels/wacom/cc-wacom-tool.c:323
+msgid "Airbrush stylus with pressure, tilt, and rotation"
+msgstr "Airbrush 數位筆搭載壓力感應、傾斜偵測與旋轉"
+
+#: panels/wacom/cc-wacom-tool.c:325
+msgid "Standard stylus with pressure and tilt"
+msgstr "標準數位筆搭載壓力感應與傾斜偵測"
+
+#: panels/wacom/cc-wacom-tool.c:327
+msgid "Standard stylus with pressure"
+msgstr "標準數位筆搭載壓力感應"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr "Wacom 繪圖板"
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr "設定繪圖板的按鍵對映與調整數位筆的壓力感應力度"
+
+#. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr "Tablet;Wacom;Stylus;Eraser;Mouse;繪圖板;橡皮擦;滑鼠;"
+
+#: panels/wacom/gsd-wacom-key-shortcut-button.c:190
+msgid "New shortcut…"
+msgstr "新增快捷鍵…"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr "存取點"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr "APN"
+
+#: panels/wwan/cc-wwan-data.c:542
+msgid "Operation Cancelled"
+msgstr "操作已取消"
+
+#: panels/wwan/cc-wwan-data.c:545
+msgid "<b>Error:</b> Access denied changing settings"
+msgstr "<b>錯誤：</b>更改設定時存取遭拒"
+
+#: panels/wwan/cc-wwan-data.c:548
+msgid "<b>Error:</b> Mobile Equipment Error"
+msgstr "<b>錯誤：</b> 行動裝置錯誤"
+
+#: panels/wwan/cc-wwan-details-dialog.c:80
+msgid "Not Registered"
+msgstr "未註冊"
+
+#: panels/wwan/cc-wwan-details-dialog.c:84
+msgid "Registered"
+msgstr "已註冊"
+
+#: panels/wwan/cc-wwan-details-dialog.c:88
+msgid "Roaming"
+msgstr "漫遊中"
+
+#: panels/wwan/cc-wwan-details-dialog.c:92
+msgid "Searching"
+msgstr "搜尋中"
+
+#: panels/wwan/cc-wwan-details-dialog.c:96
+msgid "Denied"
+msgstr "拒絕服務"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+msgid "Modem Details"
+msgstr "數據機詳細資料"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr "數據機狀態"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr "電信商"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+msgid "Network Type"
+msgstr "網路類型"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr "網路狀態"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr "擁有者號碼"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+msgid "Device Details"
+msgstr "裝置詳細資料"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr "韌體版本"
+
+#: panels/wwan/cc-wwan-device.c:988
+msgid "2G Only"
+msgstr "僅 2G"
+
+#: panels/wwan/cc-wwan-device.c:991
+msgid "3G Only"
+msgstr "僅 3G"
+
+#: panels/wwan/cc-wwan-device.c:994
+msgid "4G Only"
+msgstr "僅 4G"
+
+#: panels/wwan/cc-wwan-device.c:997
+msgid "5G Only"
+msgstr "僅 5G"
+
+#: panels/wwan/cc-wwan-device.c:1007
+msgid "2G, 3G, 4G, 5G (Preferred)"
+msgstr "2G、3G、4G、5G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1009
+msgid "2G, 3G, 4G (Preferred), 5G"
+msgstr "2G、3G、4G（偏好）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1011
+msgid "2G, 3G (Preferred), 4G, 5G"
+msgstr "2G、3G（偏好）、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1013
+msgid "2G (Preferred), 3G, 4G, 5G"
+msgstr "2G（偏好）、3G、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1015
+msgid "2G, 3G, 4G, 5G"
+msgstr "2G、3G、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1022
+msgid "2G, 3G, 4G (Preferred)"
+msgstr "2G、3G、4G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1024
+msgid "2G, 3G (Preferred), 4G"
+msgstr "2G、3G (偏好)、4G"
+
+#: panels/wwan/cc-wwan-device.c:1026
+msgid "2G (Preferred), 3G, 4G"
+msgstr "2G（偏好）、3G、4G"
+
+#: panels/wwan/cc-wwan-device.c:1028
+msgid "2G, 3G, 4G"
+msgstr "2G、3G、4G"
+
+#: panels/wwan/cc-wwan-device.c:1035
+msgid "3G, 4G, 5G (Preferred)"
+msgstr "3G、4G、5G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1037
+msgid "3G, 4G (Preferred), 5G"
+msgstr "3G、4G（偏好）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1039
+msgid "3G (Preferred), 4G, 5G"
+msgstr "3G（偏好）、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1041
+msgid "3G, 4G, 5G"
+msgstr "3G、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1048
+msgid "2G, 4G, 5G (Preferred)"
+msgstr "2G、4G、5G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1050
+msgid "2G, 4G (Preferred), 5G"
+msgstr "2G、4G（偏好）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1052
+msgid "2G (Preferred), 4G, 5G"
+msgstr "2G（偏好）、4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1054
+msgid "2G, 4G, 5G"
+msgstr "2G、3G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1061
+msgid "2G, 3G, 5G (Preferred)"
+msgstr "2G、3G、5G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1063
+msgid "2G, 3G (Preferred), 5G"
+msgstr "2G、3G（偏好）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1065
+msgid "2G (Preferred), 3G, 5G"
+msgstr "2G（偏好）、3G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1067
+msgid "2G, 3G, 5G"
+msgstr "2G、3G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1073
+msgid "3G, 4G (Preferred)"
+msgstr "3G、4G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1075
+msgid "3G (Preferred), 4G"
+msgstr "3G（偏好）、4G"
+
+#: panels/wwan/cc-wwan-device.c:1077
+msgid "3G, 4G"
+msgstr "3G、4G"
+
+#: panels/wwan/cc-wwan-device.c:1083
+msgid "2G, 4G (Preferred)"
+msgstr "2G、4G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1085
+msgid "2G (Preferred), 4G"
+msgstr "2G（偏好）、4G"
+
+#: panels/wwan/cc-wwan-device.c:1087
+msgid "2G, 4G"
+msgstr "2G、4G"
+
+#: panels/wwan/cc-wwan-device.c:1093
+msgid "2G, 3G (Preferred)"
+msgstr "2G、3G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1095
+msgid "2G (Preferred), 3G"
+msgstr "2G（偏好）、3G"
+
+#: panels/wwan/cc-wwan-device.c:1097
+msgid "2G, 3G"
+msgstr "2G、3G"
+
+#: panels/wwan/cc-wwan-device.c:1103
+msgid "2G, 5G (Preferred)"
+msgstr "2G、5G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1105
+msgid "2G (Preferred), 5G"
+msgstr "2G（偏好）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1107
+msgid "2G, 5G"
+msgstr "2G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1113
+msgid "3G, 5G (Preferred)"
+msgstr "3G、5G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1115
+msgid "3G (Preferred), 5G"
+msgstr "3G（偏好）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1117
+msgid "3G, 5G"
+msgstr "3G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1123
+msgid "4G, 5G (Preferred)"
+msgstr "3G、5G（偏好）"
+
+#: panels/wwan/cc-wwan-device.c:1125
+msgid "4G (Preferred), 5G"
+msgstr "4G（偏好）、5G"
+
+#: panels/wwan/cc-wwan-device.c:1127
+msgid "4G, 5G"
+msgstr "4G、5G"
+
+#: panels/wwan/cc-wwan-device.c:1131
+msgctxt "Network mode"
+msgid "Unknown"
+msgstr "不明"
+
+#: panels/wwan/cc-wwan-device-page.c:187
+msgid "Unlock SIM card"
+msgstr "解鎖 SIM 卡"
+
+#: panels/wwan/cc-wwan-device-page.c:188 panels/wwan/cc-wwan-device-page.c:236
+msgid "Unlock"
+msgstr "解除鎖定"
+
+#: panels/wwan/cc-wwan-device-page.c:193
+#, c-format
+msgid "Please provide PIN code for SIM %d"
+msgstr "請提供 SIM 卡 %d 的 PIN 碼"
+
+#: panels/wwan/cc-wwan-device-page.c:194
+msgid "Enter PIN to unlock your SIM card"
+msgstr "請輸入 PIN 碼以解鎖您的 SIM 卡"
+
+#: panels/wwan/cc-wwan-device-page.c:198
+#, c-format
+msgid "Please provide PUK code for SIM %d"
+msgstr "請提供 SIM 卡 %d 的 PUK 碼"
+
+#: panels/wwan/cc-wwan-device-page.c:199
+msgid "Enter PUK to unlock your SIM card"
+msgstr "請輸入 PUK 碼以解鎖您的 SIM 卡"
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] "密碼輸入錯誤。您還有 %1$u 次嘗試機會"
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] "您還有 %u 次嘗試機會"
+
+#: panels/wwan/cc-wwan-device-page.c:225
+msgid "Wrong password entered."
+msgstr "密碼輸入錯誤。"
+
+#: panels/wwan/cc-wwan-device-page.c:270
+msgid "PUK code should be an 8 digit number"
+msgstr "PUK 碼應有 8 位數字"
+
+#: panels/wwan/cc-wwan-device-page.c:294
+msgid "Enter New PIN"
+msgstr "輸入新的 PIN 碼"
+
+#: panels/wwan/cc-wwan-device-page.c:298
+msgid "PIN code should be a 4-8 digit number"
+msgstr "PIN 碼應為 4-8 位數字"
+
+#: panels/wwan/cc-wwan-device-page.c:316
+msgid "Unlocking…"
+msgstr "正在解除鎖定…"
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr "沒有 SIM 卡"
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr "插入 SIM 卡以使用此數據機"
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr "SIM 卡已鎖定"
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+msgid "_Mobile Data"
+msgstr "行動數據(_M)"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr "使用行動網路存取網路數據"
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr "數據漫遊(_D)"
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr "漫遊時使用行動數據網路"
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+msgid "_Network Mode"
+msgstr "網路模式(_N)"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+msgid "N_etwork"
+msgstr "網路(_E)"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr "進階"
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr "存取點名稱(_A)"
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr "_SIM 卡鎖定"
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr "以 PIN 碼鎖定 SIM 卡"
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+msgid "M_odem Details"
+msgstr "數據機詳細資訊(_O)"
+
+#: panels/wwan/cc-wwan-errors-private.h:40
+msgid "Phone failure"
+msgstr "手機失敗"
+
+#: panels/wwan/cc-wwan-errors-private.h:41
+msgid "No connection to phone"
+msgstr "沒有連線連接至手機"
+
+#: panels/wwan/cc-wwan-errors-private.h:43
+msgid "Operation not allowed"
+msgstr "不允許的操作"
+
+#: panels/wwan/cc-wwan-errors-private.h:44
+msgid "Operation not supported"
+msgstr "不支援的操作"
+
+#: panels/wwan/cc-wwan-errors-private.h:48
+msgid "SIM not inserted"
+msgstr "SIM 卡尚未插入"
+
+#: panels/wwan/cc-wwan-errors-private.h:49
+msgid "SIM PIN required"
+msgstr "需要 SIM 卡的 PIN 碼"
+
+#: panels/wwan/cc-wwan-errors-private.h:50
+msgid "SIM PUK required"
+msgstr "需要 SIM 卡的 PUK 碼"
+
+#: panels/wwan/cc-wwan-errors-private.h:51
+msgid "SIM failure"
+msgstr "SIM 卡失敗"
+
+#: panels/wwan/cc-wwan-errors-private.h:52
+msgid "SIM busy"
+msgstr "SIM 卡忙碌"
+
+#: panels/wwan/cc-wwan-errors-private.h:54
+msgid "Incorrect password"
+msgstr "密碼不正確"
+
+#: panels/wwan/cc-wwan-errors-private.h:55
+msgid "SIM PIN2 required"
+msgstr "需要 SIM 卡的 PIN2 碼"
+
+#: panels/wwan/cc-wwan-errors-private.h:56
+msgid "SIM PUK2 required"
+msgstr "需要 SIM 卡的 PUK2 碼"
+
+#: panels/wwan/cc-wwan-errors-private.h:59
+msgid "Not found"
+msgstr "找不到"
+
+#: panels/wwan/cc-wwan-errors-private.h:61
+msgid "No network service"
+msgstr "沒有網路服務"
+
+#: panels/wwan/cc-wwan-errors-private.h:62
+msgid "Network timeout"
+msgstr "網路逾時"
+
+#: panels/wwan/cc-wwan-errors-private.h:75
+msgid "GPRS services not allowed"
+msgstr "未允許 GPRS 服務"
+
+#: panels/wwan/cc-wwan-errors-private.h:78
+msgid "Roaming not allowed in this location area"
+msgstr "此位置區域不允許漫遊"
+
+#: panels/wwan/cc-wwan-errors-private.h:82
+msgid "Unspecified GPRS error"
+msgstr "不明的 GPRS 錯誤"
+
+#: panels/wwan/cc-wwan-errors-private.h:91
+msgid "No Error"
+msgstr "沒有錯誤"
+
+#: panels/wwan/cc-wwan-errors-private.h:94
+msgid "Action Cancelled"
+msgstr "動作取消"
+
+#: panels/wwan/cc-wwan-errors-private.h:97
+msgid "Access denied"
+msgstr "存取遭拒"
+
+#: panels/wwan/cc-wwan-errors-private.h:106
+msgid "Unknown Error"
+msgstr "不明錯誤"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+msgid "Network Mode"
+msgstr "網路模式"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr "自動(_A)"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr "選擇網路"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr "重新整理網路提供者"
+
+#: panels/wwan/cc-wwan-panel.c:365 panels/wwan/cc-wwan-panel.c:396
+#, c-format
+msgid "SIM %d"
+msgstr "SIM %d"
+
+#: panels/wwan/cc-wwan-panel.ui:10
+msgid "Enable Mobile Network"
+msgstr "啟用行動網路"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr "找不到 WWAN 網卡"
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr "請確認您有無線 WAN 網路或蜂巢式網路裝置"
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr "飛安模式開啟時會停無線 WAN 網路"
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr "關閉飛安模式(_T)"
+
+#: panels/wwan/cc-wwan-panel.ui:151
+msgid "Data Connection"
+msgstr "數據連線"
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr "用於網際網路的 SIM 卡"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr "SIM 卡鎖定"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr "下一步(_N)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr "以 PIN 碼鎖定 SIM 卡(_L)"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+msgid "Change PIN"
+msgstr "更改 PIN 碼"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr "輸入目前的 PIN 碼以更改 SIM 卡鎖定的設定值"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr "行動網路"
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr "設定電話撥打與行動數據連線"
+
+#. Translators: Search terms to find the WWAN panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+"cellular;wwan;telephony;sim;mobile;行動數據;蜂巢式網路;撥打電話;攜帶;行動網"
+"路;"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr "設定 GNOME 桌面的工具程式"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr "《設定》是設定系統的主要介面。"
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr "GNOME 專案"
+
+#: shell/cc-application.c:59
+msgid "Display version number"
+msgstr "顯示版本號碼"
+
+#: shell/cc-application.c:60
+msgid "Enable verbose mode"
+msgstr "啟用詳細模式"
+
+#: shell/cc-application.c:61
+msgid "Search for the string"
+msgstr "搜尋字串"
+
+#: shell/cc-application.c:62
+msgid "List possible panel names and exit"
+msgstr "列出可能的面板名稱並結束"
+
+#: shell/cc-application.c:63
+msgid "Panel to display"
+msgstr "要顯示的面板"
+
+#: shell/cc-application.c:63
+msgid "[PANEL] [ARGUMENT…]"
+msgstr "[面板] [參數…]"
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr "設定值類別"
+
+#: shell/cc-panel-list.ui:42 shell/cc-window.c:242
+msgid "Privacy"
+msgstr "隱私"
+
+#: shell/cc-panel-loader.c:304
+msgid "Available panels:"
+msgstr "可用的面板："
+
+#: shell/cc-window.ui:30
+msgid "All Settings"
+msgstr "所有設定值"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr "主選單"
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr "警告：開發版本"
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+"這個版本的《設定值》應只作為開發目的使用。您可能會遇到不正常的系統行為、資料"
+"遺失，或其他預期之外的問題。 "
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr "求助"
+
+#: shell/help-overlay.ui:15
+msgctxt "shortcut window"
+msgid "General"
+msgstr "一般"
+
+#: shell/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "退出"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "搜尋"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr "面板"
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "返回到上一個面板"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr "取消搜尋"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: shell/org.gnome.Settings.desktop.in.in:17
+msgid "Preferences;Settings;"
+msgstr "Preferences;Settings;偏好設定;設定值;"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr "最後開啟的設定面板識別碼"
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+"最後開啟的設定面板識別碼；無法識別的值會被忽略並改選擇列表中第一個面板。"
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr "顯示警告，當執行設定的開發構建版本"
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr "當執行開發構建版本時，是否在設定中顯示警告。"
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr "視窗的初始狀態"
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr "含有應用程式視窗初始寬度、高度與最大化狀態的元組。"
+
+#. translators:
+#. * The number of sound outputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] "%u 輸出"
+
+#. translators:
+#. * The number of sound inputs on a particular device
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] "%u 輸入"
+
+#: subprojects/gvc/gvc-mixer-control.c:2876
+msgid "System Sounds"
+msgstr "系統音效"
+
+#~ msgid "Error: unable to determine HSI level."
+#~ msgstr "錯誤：無法確認 HSI 等級。"
+
+#~ msgid "Error: unable to determine Incorrect HSI level."
+#~ msgstr "錯誤：無法確認不正確的 HSI 等級。"
+
+#~ msgid "DER or PEM certificates (*.der, *.pem, *.crt, *.cer)"
+#~ msgstr "DER 或 PEM 憑證 (*.der, *.pem, *.crt, *.cer)"
+
+#~ msgid "Add a Printer…"
+#~ msgstr "加入印表機…"
+
+#~ msgid "Drip"
+#~ msgstr "水滴聲"
+
+#~ msgid "Glass"
+#~ msgstr "敲玻璃聲"
+
+#~ msgid "Sonar"
+#~ msgstr "聲納"
+
+#~ msgid "No Protection"
+#~ msgstr "缺乏防護"
+
+#~ msgid "Minimal Protection"
+#~ msgstr "最小防護"
+
+#~ msgid "Basic Protection"
+#~ msgstr "基本防護"
+
+#~ msgid "Extended Protection"
+#~ msgstr "延伸防護"
+
+#~ msgid "Minimal Security Protections"
+#~ msgstr "最小的安全性防護"
+
+#~ msgid "Basic Security Protections"
+#~ msgstr "基本的安全性防護"
+
+#~ msgid "Extended Security Protections"
+#~ msgstr "延伸的安全性防護"
+
+#~ msgid "Secure Boot is Inactive"
+#~ msgstr "安全開機非作用中"
+
+#~ msgid "SPI write"
+#~ msgstr "SPI 寫入"
+
+#~ msgid "SPI lock"
+#~ msgstr "SPI 鎖定"
+
+#~ msgid "Kernel tainted"
+#~ msgstr "核心污染"
+
+#, fuzzy
+#~ msgid "Suspend-to-ram"
+#~ msgstr "暫停（暫存至記憶體）"
+
+#~ msgid "MEI manufacturing mode"
+#~ msgstr "MEI 製造模式"
+
+#~ msgid "MEI version"
+#~ msgstr "MEI 版本"
+
+#~ msgid "fwupd plugins"
+#~ msgstr "fwupd 擴充套件"
+
+#~ msgid "IOMMU device protection enabled"
+#~ msgstr "IOMMU 裝置防護已啟用"
+
+#~ msgid "IOMMU device protection disabled"
+#~ msgstr "IOMMU 裝置防護已停用"
+
+#~ msgid "Kernel is tainted"
+#~ msgstr "核心遭受污染"
+
+#~ msgid "Kernel lockdown disabled"
+#~ msgstr "核心鎖定已停用"
+
+#~ msgid "Kernel lockdown enabled"
+#~ msgstr "核心鎖定已啟用"
+
+#~ msgid "Secure Boot disabled"
+#~ msgstr "安全開機已停用"
+
+#~ msgid "Secure Boot enabled"
+#~ msgstr "安全開機已啟用"
+
+#~ msgid "Lock your screen"
+#~ msgstr "鎖定您的螢幕"
+
+#~ msgid "Display Arrangement"
+#~ msgstr "排列顯示器的組合方式"
+
+#~ msgid "Light"
+#~ msgstr "明亮"
+
+#~ msgid ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;"
+#~ msgstr ""
+#~ "screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+#~ "network;identity;螢幕;鎖定;診斷;隱私;最近使用;暫存;索引;名稱;網路;身分;"
+
+#~ msgid "Set"
+#~ msgstr "設定"
+
+#~ msgid "Bark"
+#~ msgstr "汪汪"
+
+#~ msgid "Web Links"
+#~ msgstr "網頁連結"
+
+#~ msgid "Git Links"
+#~ msgstr "Git 連結"
+
+#, c-format
+#~ msgid "%s Links"
+#~ msgstr "%s 連結"
+
+#~ msgid "Unset"
+#~ msgstr "取消設定"
+
+#~ msgid "Links"
+#~ msgstr "連結"
+
+#~ msgid "Hypertext Files"
+#~ msgstr "超文字檔案"
+
+#~ msgid "Text Files"
+#~ msgstr "文字檔案"
+
+#~ msgid "Image Files"
+#~ msgstr "圖片檔案"
+
+#~ msgid "Font Files"
+#~ msgstr "字型檔案"
+
+#~ msgid "Archive Files"
+#~ msgstr "封存檔案"
+
+#~ msgid "Package Files"
+#~ msgstr "軟體包檔案"
+
+#~ msgid "Audio Files"
+#~ msgstr "音訊檔案"
+
+#~ msgid "Video Files"
+#~ msgstr "視訊檔案"
+
+#~ msgid "Permissions & Access"
+#~ msgstr "權限與存取權"
+
+#~ msgid ""
+#~ "Data and services that this app has asked for access to and permissions "
+#~ "that it requires."
+#~ msgstr "此應用程式要求存取的資料及服務，及應用程式請求的存取權。"
+
+#~ msgid "Cannot be changed"
+#~ msgstr "不能變更"
+
+#~ msgid ""
+#~ "Individual permissions for applications can be reviewed in the <a "
+#~ "href=\"privacy\">Privacy</a> Settings."
+#~ msgstr "應用程式的個別權限可以在<a href=\"privacy\">隱私</a>設定值中檢閱。"
+
+#~ msgid "Integration"
+#~ msgstr "整合"
+
+#~ msgid "Set Desktop Background"
+#~ msgstr "設定桌面背景"
+
+#~ msgid "Default Handlers"
+#~ msgstr "預設處理程式"
+
+#~ msgid "Types of files and links that this application opens."
+#~ msgstr "此應用程式開啟的檔案及連結類型。"
+
+#~ msgid "Usage"
+#~ msgstr "用量"
+
+#~ msgid "How much resources this application is using."
+#~ msgstr "應用程式正在使用多少資源。"
+
+#~ msgid "Open in Software"
+#~ msgstr "在《軟體》中開啟"
+
+#~ msgid "Activities"
+#~ msgstr "活動"
+
+#~ msgid "Allow the applications below to use your camera."
+#~ msgstr "允許下列應用程式使用相機。"
+
+#, c-format
+#~ msgid "Failed to upload file: %s"
+#~ msgstr "上傳檔案失敗：%s"
+
+#~ msgid "The profile has been uploaded to:"
+#~ msgstr "描述檔已經上傳到："
+
+#~ msgid "Write down this URL."
+#~ msgstr "寫下這個 URL。"
+
+#~ msgid "Restart this computer and boot your normal operating system."
+#~ msgstr "重新啟動這臺電腦並開機進入您一般的作業系統。"
+
+#~ msgid "Type the URL into your browser to download and install the profile."
+#~ msgstr "在您的瀏覽器中輸入 URL 以下載並安裝描述檔。"
+
+#~ msgid "Upload profile"
+#~ msgstr "上傳描述檔"
+
+#~ msgid "Requires Internet connection"
+#~ msgstr "需要網際網路連線"
+
+#~ msgid "_Copy"
+#~ msgstr "複製(_C)"
+
+#~ msgid "Select _All"
+#~ msgstr "全部選取(_A)"
+
+#~ msgid "Single Display"
+#~ msgstr "單一顯示器"
+
+#~ msgid "Join Displays"
+#~ msgstr "接合多臺顯示器"
+
+#~ msgid "Display Mode"
+#~ msgstr "顯示器模式"
+
+#~ msgid ""
+#~ "Drag displays to match your physical display setup. Select a display to "
+#~ "change its settings."
+#~ msgstr "請將顯示器拖曳到符合您實體顯示器的配置。請選取顯示器以變更其設定。"
+
+#~ msgid "Active Display"
+#~ msgstr "使用中顯示器"
+
+#~ msgid "More Warm"
+#~ msgstr "變得更暖"
+
+#~ msgid "Less Warm"
+#~ msgstr "變得更冷"
+
+#~ msgid "Save a screenshot to $PICTURES"
+#~ msgstr "將螢幕擷圖儲存為 $PICTURES"
+
+#~ msgid "Save a screenshot of a window to $PICTURES"
+#~ msgstr "將視窗的螢幕擷圖儲存為 $PICTURES"
+
+#~ msgid "Save a screenshot of an area to $PICTURES"
+#~ msgstr "將區域的螢幕擷圖儲存為 $PICTURES"
+
+#~ msgid "Copy a screenshot to clipboard"
+#~ msgstr "將螢幕截圖複製到剪貼簿"
+
+#~ msgid "Copy a screenshot of a window to clipboard"
+#~ msgstr "將視窗的螢幕截圖複製到剪貼簿"
+
+#~ msgid "Copy a screenshot of an area to clipboard"
+#~ msgstr "將區域的螢幕截圖複製到剪貼簿"
+
+#~ msgid "Record a short screencast"
+#~ msgstr "錄製短式螢幕廣播"
+
+#~ msgid "Move up"
+#~ msgstr "往上移"
+
+#~ msgid "Move down"
+#~ msgstr "往下移"
+
+#~ msgid "Keyboard Shortcut"
+#~ msgstr "鍵盤快捷鍵"
+
+#~ msgid "This can be changed in Customize Shortcuts"
+#~ msgstr "這可以在「自訂快捷鍵」中變更"
+
+#~ msgid "Hold down and type to enter different characters"
+#~ msgstr "按下並輸入以輸入不同字元"
+
+#~ msgid ""
+#~ "Location services allow applications to know your location. Using Wi-Fi "
+#~ "and mobile broadband increases accuracy."
+#~ msgstr ""
+#~ "位置服務允許應用程式知道您的所在位置。使用 Wi-Fi 與行動寬頻可以提高定位精"
+#~ "準度。"
+
+#~ msgid ""
+#~ "Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+#~ "com/privacy'>Privacy Policy</a>"
+#~ msgstr ""
+#~ "使用 Mozilla 位置服務：<a href='https://location.services.mozilla.com/"
+#~ "privacy'>隱私服務</a>"
+
+#~ msgid "Allow the applications below to determine your location."
+#~ msgstr "允許下列應用程式判斷位置。"
+
+#~ msgid "Allow the applications below to use your microphone."
+#~ msgstr "允許下列應用程式使用麥克風。"
+
+#~ msgid "Double-click timeout"
+#~ msgstr "雙擊分辨時間"
+
+#, c-format
+#~ msgid "%s VPN"
+#~ msgstr "%s VPN"
+
+#~ msgid "Suspend & Power Button"
+#~ msgstr "暫停與電源按鈕"
+
+#~ msgid "_Screen Brightness"
+#~ msgstr "螢幕亮度(_S)"
+
+#~ msgid "_Keyboard Brightness"
+#~ msgstr "鍵盤亮度(_K)"
+
+#~ msgid "Dim Screen When Inactive"
+#~ msgstr "當不活動後降低螢幕亮度"
+
+#~ msgid "_Blank Screen"
+#~ msgstr "螢幕轉黑(_B)"
+
+#~ msgid "_Wi-Fi"
+#~ msgstr "_Wi-Fi"
+
+#~ msgid "Wi-Fi can be turned off to save power."
+#~ msgstr "可以關閉 Wi-Fi 以省電。"
+
+#~ msgid ""
+#~ "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
+#~ msgstr "可以關閉行動數據 (3G、4G、LTE 等等) 以省電。"
+
+#~ msgid "_Bluetooth"
+#~ msgstr "藍牙(_B)"
+
+#~ msgid "Bluetooth can be turned off to save power."
+#~ msgstr "可以關閉藍牙以省電。"
+
+#~ msgid "Lap detected: performance mode unavailable"
+#~ msgstr "偵測到放置腿上：無法使用效能模式"
+
+#~ msgid "High hardware temperature: performance mode unavailable"
+#~ msgstr "硬體高溫：無法使用效能模式"
+
+#~ msgid "Balanced Power"
+#~ msgstr "平衡電能"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "Authenticate"
+#~ msgstr "核對"
+
+#~ msgid "Add…"
+#~ msgstr "加入…"
+
+#~ msgid ""
+#~ "Choose the format for numbers, dates and currencies. Changes take effect "
+#~ "on next login."
+#~ msgstr "選擇數字、日期及貨幣的格式。變更會在下次登入時生效。"
+
+#~ msgid "Language"
+#~ msgstr "語言"
+
+#~ msgid "The language used for text in windows and web pages."
+#~ msgstr "視窗與網頁內文所使用的語言。"
+
+#~ msgid "Restart the session for changes to take effect"
+#~ msgstr "須要重新啟動作業階段才能讓變更生效"
+
+#~ msgid "Restart…"
+#~ msgstr "重新啟動…"
+
+#~ msgid "Login settings are used by all users when logging into the system"
+#~ msgstr "登入設定值是所有的使用者在登入系統時會用到的"
+
+#~ msgid ""
+#~ "Select your display language, formats, keyboard layouts and input sources"
+#~ msgstr "選擇您的顯示語言、格式、鍵盤配置與輸入來源"
+
+#~ msgid ""
+#~ "Control which search results are shown in the Activities Overview. The "
+#~ "order of search results can also be changed by moving rows in the list."
+#~ msgstr ""
+#~ "控制是否在「活動概覽」顯示搜尋結果。亦可藉由移動清單中的行來變更搜尋結果順"
+#~ "序。"
+
+#, c-format
+#~ msgid ""
+#~ "Screen sharing allows remote users to view or control your screen by "
+#~ "connecting to %s"
+#~ msgstr "螢幕分享允許遠端使用者連線到 %s 以檢視或控制您的螢幕"
+
+#~ msgid "_Screen Sharing"
+#~ msgstr "螢幕分享(_S)"
+
+#~ msgid "Some services are disabled because of no network access."
+#~ msgstr "由於沒有網路存取，某些服務已停用。"
+
+#~ msgid "_Password:"
+#~ msgstr "密碼(_P)："
+
+#~ msgid "_Show Password"
+#~ msgstr "顯示密碼(_S)"
+
+#~ msgid "_New connections must ask for access"
+#~ msgstr "存取新的連線必須詢問(_N)"
+
+#~ msgid "_Require a password"
+#~ msgstr "需要密碼(_R)"
+
+#~ msgid "Sound Keys"
+#~ msgstr "聲音按鍵"
+
+#~ msgid "Screen Reader"
+#~ msgstr "螢幕閱讀器"
+
+#~ msgid "_Screen Reader"
+#~ msgstr "螢幕閱讀器(_S)"
+
+#~ msgid "Standard"
+#~ msgstr "標準"
+
+#~ msgid "Account _Type"
+#~ msgstr "帳號類型(_T)"
+
+#~ msgid "Allow user to set a password when they next _login"
+#~ msgstr "允許使用者在下次登入時設定密碼(_L)"
+
+#~ msgid "Set a password _now"
+#~ msgstr "立刻設定密碼(_N)"
+
+#~ msgid "You must be online in order to add enterprise users."
+#~ msgstr "請上線以加入企業登入使用者。"
+
+#~ msgid "Take a Picture…"
+#~ msgstr "照張相…"
+
+#~ msgid ""
+#~ "To make changes,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "要進行變更，\n"
+#~ "請先點選 * 圖示"
+
+#~ msgid "Create a user account"
+#~ msgstr "建立新的使用者帳號"
+
+#~ msgid "User Icon"
+#~ msgstr "使用者圖示"
+
+#~ msgid "Account Settings"
+#~ msgstr "帳號設定值"
+
+#~ msgid "Authentication & Login"
+#~ msgstr "身分核對與登入"
+
+#~ msgid "Login;Name;Fingerprint;Avatar;Logo;Face;Password;"
+#~ msgstr ""
+#~ "Login;Name;Fingerprint;Avatar;Logo;Face;Password;登入;姓名;指紋;大頭貼;標"
+#~ "誌;臉;密碼;"
+
+#~ msgid "This will be used to name your home folder and can’t be changed."
+#~ msgstr "這會成為您家目錄資料夾的名稱，並且不能被改變。"
+
+#~ msgid "Output:"
+#~ msgstr "輸出："
+
+#~ msgid "Keep aspect ratio (letterbox):"
+#~ msgstr "保持長寬比："
+
+#~ msgid "Map to single monitor"
+#~ msgstr "映射到單一螢幕"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d / %d"
+
+#~ msgid "Display Mapping"
+#~ msgstr "顯示對應"
+
+#~ msgid "Tablet (absolute)"
+#~ msgstr "繪圖板 (絕對位置)"
+
+#~ msgid "Touchpad (relative)"
+#~ msgstr "觸控板 (相對位置)"
+
+#~ msgid "Tablet Preferences"
+#~ msgstr "繪圖板偏好設定"
+
+#~ msgid "_Help"
+#~ msgstr "求助(_H)"
+
+#~ msgid "Bluetooth Settings"
+#~ msgstr "藍牙設定值"
+
+#~ msgid "Tracking Mode"
+#~ msgstr "追蹤模式"
+
+#~ msgid "Map Buttons…"
+#~ msgstr "對應按鈕…"
+
+#~ msgid "Adjust mouse settings"
+#~ msgstr "調整滑鼠設定值"
+
+#~ msgid "Adjust display resolution"
+#~ msgstr "調整顯示解析度"
+
+#~ msgid ""
+#~ "Please move your stylus to the proximity of the tablet to configure it"
+#~ msgstr "請讓您的觸控筆靠近繪圖板來設定"
+
+#~ msgid "Top Button"
+#~ msgstr "頂端按鈕"
+
+#~ msgid "Lower Button"
+#~ msgstr "較低的按鈕"
+
+#~ msgid "Lowest Button"
+#~ msgstr "最低的按鈕"
+
+#~ msgid "GNOME Settings"
+#~ msgstr "GNOME 設定"
+
+#~ msgid "Left Alt"
+#~ msgstr "左 Alt"
+
+#~ msgid "Right Alt"
+#~ msgstr "右 Alt"
+
+#~ msgid "Left Super"
+#~ msgstr "左 Super"
+
+#~ msgid "Right Super"
+#~ msgstr "右 Super"
+
+#~ msgid "Right Ctrl"
+#~ msgstr "右 Ctrl"
+
+#~ msgid "Alternative Characters Key"
+#~ msgstr "替代的字元鍵"
+
+#~ msgid "Modifiers-only switch to next source"
+#~ msgstr "只以修飾鍵切換至下個來源"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Menu Key"
+#~ msgstr "選單鍵"
+
+#~ msgctxt "Battery power"
+#~ msgid "Charging"
+#~ msgstr "充電"
+
+#~ msgctxt "Battery power"
+#~ msgid "Caution"
+#~ msgstr "注意"
+
+#~ msgctxt "Battery power"
+#~ msgid "Low"
+#~ msgstr "低"
+
+#~ msgctxt "Battery power"
+#~ msgid "Good"
+#~ msgstr "良好"
+
+#~ msgctxt "Battery power"
+#~ msgid "Fully charged"
+#~ msgstr "已完全充飽"
+
+#~ msgctxt "Battery power"
+#~ msgid "Empty"
+#~ msgstr "沒電"
+
+#~ msgid "Previous source"
+#~ msgstr "上一個來源"
+
+#~ msgid "Super+Shift+Space"
+#~ msgstr "Super+Shift+Space"
+
+#~ msgid "Next source"
+#~ msgstr "下一個來源"
+
+#~ msgid "Super+Space"
+#~ msgstr "Super+Space"
+
+#~ msgid "Left+Right Alt"
+#~ msgstr "左+右 Alt"
+
+#~ msgid "∶"
+#~ msgstr "∶"
+
+#~ msgid "Universal Access"
+#~ msgstr "無障礙功能"
+
+#~ msgid "Switch off to connect to a Wi-Fi network"
+#~ msgstr "關閉連線到 Wi-Fi 網路"
+
+#~ msgctxt "Wi-Fi passkey"
+#~ msgid "Password"
+#~ msgstr "密碼"
+
+#~ msgid "Enable Fingerprint Login"
+#~ msgstr "啟用指紋登入"
+
+#~ msgid "_Other finger:"
+#~ msgstr "其他手指(_O)："
+
+#~ msgid ""
+#~ "Your fingerprint was successfully saved. You should now be able to log in "
+#~ "using your fingerprint reader."
+#~ msgstr "您的指紋已成功儲存。現在應該可以使用您的指紋辨識器登入。"
+
+#~ msgid ""
+#~ "You are not allowed to access the device. Contact your system "
+#~ "administrator."
+#~ msgstr "您不被允許使用這個裝置。請連絡您的管理員。"
+
+#~ msgid "An internal error occurred."
+#~ msgstr "發生內部的錯誤。"
+
+#~ msgid "Delete registered fingerprints?"
+#~ msgstr "是否刪除已註冊的指紋？"
+
+#~ msgid "Done!"
+#~ msgstr "完成！"
+
+#~ msgid "Could not access “%s” device"
+#~ msgstr "無法存取「%s」裝置"
+
+#~ msgid "Could not start finger capture on “%s” device"
+#~ msgstr "無法啟動「%s」裝置的指紋捕捉功能"
+
+#~ msgid "Could not access any fingerprint readers"
+#~ msgstr "無法存取任何指紋辨識器"
+
+#~ msgid "Please contact your system administrator for help."
+#~ msgstr "請連絡您的管理員來幫忙。"
+
+#~ msgid ""
+#~ "To enable fingerprint login, you need to save one of your fingerprints, "
+#~ "using the “%s” device."
+#~ msgstr "若要啟用指紋登入，您需要使用「%s」裝置儲存您的指紋。"
+
+#~ msgid "Selecting finger"
+#~ msgstr "選擇手指"
+
+#~ msgid ""
+#~ "To create a user account,\n"
+#~ "click the * icon first"
+#~ msgstr ""
+#~ "要建立使用者帳號，\n"
+#~ "請先點選 * 圖示"
+
+#~ msgid "Add user accounts and change passwords"
+#~ msgstr "加入使用者帳戶並變更密碼"
+
+#~ msgid "Play and record sound"
+#~ msgstr "播放及錄音"
+
+#~ msgid "Detect network devices using mDNS/DNS-SD (Bonjour/zeroconf)"
+#~ msgstr "使用 mDNS/DNS-SD (Bonjour/zeroconf) 偵測網路裝置"
+
+#~ msgid "Access bluetooth hardware directly"
+#~ msgstr "直接存取藍牙硬體"
+
+#~ msgid "Use your camera"
+#~ msgstr "使用相機"
+
+#~ msgid "Print documents"
+#~ msgstr "列印文件"
+
+#~ msgid "Use any connected joystick"
+#~ msgstr "使用連結的搖桿"
+
+#~ msgid "Allow connecting to the Docker service"
+#~ msgstr "允許連線至 Docker 服務"
+
+#~ msgid "Configure network firewall"
+#~ msgstr "設定網路防火牆"
+
+#~ msgid "Setup and use privileged FUSE filesystems"
+#~ msgstr "設定並使用特權 FUSE 檔案系統"
+
+#~ msgid "Update firmware on this device"
+#~ msgstr "更新此裝置的韌體"
+
+#~ msgid "Access hardware information"
+#~ msgstr "存取硬體資訊"
+
+#~ msgid "Provide entropy to hardware random number generator"
+#~ msgstr "提供熵給硬體隨機數字產生器"
+
+#~ msgid "Use hardware-generated random numbers"
+#~ msgstr "使用硬體產生的隨機數"
+
+#~ msgid "Access files in your home folder"
+#~ msgstr "存取您家目錄的檔案"
+
+#~ msgid "Access libvirt service"
+#~ msgstr "存取 libvirt 服務"
+
+#~ msgid "Change system language and region settings"
+#~ msgstr "變更系統語言及地區設定"
+
+#~ msgid "Change location settings and providers"
+#~ msgstr "變更位置設定及提供者"
+
+#~ msgid "Read system and application logs"
+#~ msgstr "讀取系統及應用程式日誌"
+
+#~ msgid "access the media-hub service"
+#~ msgstr "存取媒體中心服務"
+
+#~ msgid "Use and configure modems"
+#~ msgstr "使用並設定數據機"
+
+#~ msgid "Read system mount information and disk quotas"
+#~ msgstr "讀取系統掛載資訊及磁碟配額"
+
+#~ msgid "Control music and video players"
+#~ msgstr "控制音樂及影片播放器"
+
+#~ msgid "Change low-level network settings"
+#~ msgstr "變更低階網路設定"
+
+#~ msgid ""
+#~ "Access the NetworkManager service to read and change network settings"
+#~ msgstr "存取 NetworkManager 服務以讀取及變更網路設定"
+
+#~ msgid "Read access to network settings"
+#~ msgstr "有權讀取網路設定"
+
+#~ msgid "Change network settings"
+#~ msgstr "變更網路設定"
+
+#~ msgid "Read network settings"
+#~ msgstr "讀取網路設定"
+
+#~ msgid ""
+#~ "Access the ofono service to read and change network settings for mobile "
+#~ "telephony"
+#~ msgstr "存取 ofono 服務以讀取及變更行動電話語音的網路設定"
+
+#~ msgid "Control Open vSwitch hardware"
+#~ msgstr "控制開放 vSwitch 硬體"
+
+#~ msgid "Read from CD/DVD"
+#~ msgstr "從 CD/DVD 讀取"
+
+#~ msgid "Read, add, change, or remove saved passwords"
+#~ msgstr "讀取、加入、變更或移除儲存的密碼"
+
+#~ msgid ""
+#~ "Access pppd and ppp devices for configuring Point-to-Point Protocol "
+#~ "connections"
+#~ msgstr "存取 pppd 及 ppp 裝置以設定端對端通訊協定的連線"
+
+#~ msgid "Pause or end any process on the system"
+#~ msgstr "暫停或結束系統處理程序"
+
+#~ msgid "Access USB hardware directly"
+#~ msgstr "直接存取 USB 硬體"
+
+#~ msgid "Read/write files on removable storage devices"
+#~ msgstr "讀取╱寫入可移除式儲存裝置"
+
+#~ msgid "Prevent screen sleep/lock"
+#~ msgstr "防止螢幕睡眠／鎖定"
+
+#~ msgid "Access serial port hardware"
+#~ msgstr "存取序列埠硬體"
+
+#~ msgid "Restart or power off the device"
+#~ msgstr "重新啟動或關機裝置"
+
+#~ msgid "Install, remove and configure software"
+#~ msgstr "安裝、移除及設定軟體"
+
+#~ msgid "Access Storage Framework service"
+#~ msgstr "存取儲存空間框架 (Storage Framework) 服務"
+
+#~ msgid "Read process and system information"
+#~ msgstr "讀取處理程序及系統資訊"
+
+#~ msgid "Monitor and control any running program"
+#~ msgstr "監控及控制執行程式"
+
+#~ msgid "Change the date and time"
+#~ msgstr "變更日期及時間"
+
+#~ msgid "Change time server settings"
+#~ msgstr "變更時間伺服器設定"
+
+#~ msgid "Change the time zone"
+#~ msgstr "變更時區"
+
+#~ msgid "Access the UDisks2 service for configuring disks and removable media"
+#~ msgstr "存取 UDisks2 服務以設定磁碟及可移除式媒體"
+
+#~ msgid "Read/change shared calendar events in Ubuntu Unity 8"
+#~ msgstr "讀取或變更 Ubuntu Unity 8 的共享行事曆事件"
+
+#~ msgid "Read/change shared contacts in Ubuntu Unity 8"
+#~ msgstr "讀取或變更 Ubuntu Unity 8 的共享聯絡人"
+
+#~ msgid "Access energy usage data"
+#~ msgstr "存取能量使用情況資料"
+
+#~ msgid "Read/write access to U2F devices exposed"
+#~ msgstr "有權讀取／寫入至公開的 U2F 裝置"
+
+#~ msgid "Set Background and Lock Screen"
+#~ msgstr "設定背景及鎖定螢幕"
+
+#~ msgid "Set Background"
+#~ msgstr "設定背景"
+
+#~ msgid "Set Lock Screen"
+#~ msgstr "設定鎖定螢幕"
+
+#~ msgid "Remove Background"
+#~ msgstr "移除背景"
+
+#~ msgid "Reports are sent anonymously and are scrubbed of personal data."
+#~ msgstr "報告是以匿名方式傳送，並且會消除個人資料。"
+
+#~ msgid ""
+#~ "Sending reports of technical problems help us improve this operating "
+#~ "system."
+#~ msgstr "傳送技術問題的報告有助於我們改進這個作業系統。"
+
+#~ msgid "Notification _Popups"
+#~ msgstr "彈出式通知(_P)"
+
+#~ msgid "Last Login"
+#~ msgstr "上次登入"
+
+#~ msgid "Version %s"
+#~ msgstr "版本 %s"
+
+#~ msgid "OS name"
+#~ msgstr "作業系統名稱"
+
+#~ msgid "OS type"
+#~ msgstr "作業系統類型"
+
+#~ msgid "Disk"
+#~ msgstr "磁碟"
+
+#~ msgid "Check for updates"
+#~ msgstr "檢查更新"
+
+#~ msgid "Network proxy"
+#~ msgstr "網路代理伺服器"
+
+#~ msgid "page 1"
+#~ msgstr "頁 1"
+
+#~ msgid "Inner _authentication"
+#~ msgstr "內部核對(_A)"
+
+#~ msgid "page 2"
+#~ msgstr "頁 2"
+
+#~| msgid "Restrict background data usage"
+#~ msgid "Restrict _background data usage"
+#~ msgstr "限制背景資料用量(_B)"
+
+#~ msgid "Appropriate for connections that have data charges or limits."
+#~ msgstr "適合數據需收費或有流量限制的連線使用。"
+
+#~ msgid "Twisted Pair (TP)"
+#~ msgstr "雙絞線 (TP)"
+
+#~ msgid "Attachment Unit Interface (AUI)"
+#~ msgstr "附加單位介面 (AUI)"
+
+#~ msgid "BNC"
+#~ msgstr "BNC"
+
+#~ msgid "Media Independent Interface (MII)"
+#~ msgstr "媒體獨立介面 (MII)"
+
+#~ msgid "10 Mb/s"
+#~ msgstr "10 Mb/s"
+
+#~ msgid "100 Mb/s"
+#~ msgstr "100 Mb/s"
+
+#~ msgid "1 Gb/s"
+#~ msgstr "1 Gb/s"
+
+#~ msgid "10 Gb/s"
+#~ msgstr "10 Gb/s"
+
+#~ msgid ""
+#~ "Switching on the wireless hotspot will disconnect you from <b>%s</b>."
+#~ msgstr "切換無線網路熱點會讓您從 <b>%s</b> 斷線。"
+
+#~ msgid ""
+#~ "It is not possible to access the Internet through your wireless while the "
+#~ "hotspot is active."
+#~ msgstr "當熱點在使用中時是沒有辦法透過您的無線網路存取網際網路的。"
+
+#~ msgid ""
+#~ "Wi-Fi hotspots are usually used to share an additional Internet "
+#~ "connection over Wi-Fi."
+#~ msgstr "Wi-Fi 熱點常用於透過 Wi-Fi 分享額外網際網路連線。"
+
+#~ msgid "Automatic _Connect"
+#~ msgstr "自動連線(_C)"
+
+#~ msgid "details"
+#~ msgstr "詳細資料"
+
+#~ msgid "Show P_assword"
+#~ msgstr "顯示密碼(_A)"
+
+#~ msgid "Make available to other users"
+#~ msgstr "允許其他使用者使用"
+
+#~ msgid "identity"
+#~ msgstr "身分"
+
+#~ msgid "IPv_4"
+#~ msgstr "IPv_4"
+
+#~ msgid "_Addresses"
+#~ msgstr "位址(_A)"
+
+#~ msgid "Automatic (DHCP) addresses only"
+#~ msgstr "只用自動 (DHCP) 位址"
+
+#~ msgid "Link-local only"
+#~ msgstr "只有本機連線"
+
+#~ msgid "_Ignore automatically obtained routes"
+#~ msgstr "忽略自動獲得的路由(_I)"
+
+#~ msgid "ipv4"
+#~ msgstr "ipv4"
+
+#~ msgid "IPv_6"
+#~ msgstr "IPv_6"
+
+#~ msgid "ipv6"
+#~ msgstr "ipv6"
+
+#~ msgid "_Cloned MAC Address"
+#~ msgstr "複製的 MA_C 位址"
+
+#~ msgid "_Reset"
+#~ msgstr "重設(_R)"
+
+#~ msgid ""
+#~ "Reset the settings for this connection to their defaults, but remember as "
+#~ "a preferred connection."
+#~ msgstr "重設這個網路的設定值為預設值，但將它記住為偏好的網路。"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect to it."
+#~ msgstr "移除這個網路的所有相關詳細資料並且不再嘗試自動連線。"
+
+#~ msgid "Hardware"
+#~ msgstr "硬體"
+
+#~ msgctxt "tab"
+#~ msgid "Reset"
+#~ msgstr "重設"
+
+#~ msgid "Connected Devices"
+#~ msgstr "已連線的裝置"
+
+#~ msgid "Ad-hoc"
+#~ msgstr "Ad-hoc"
+
+#~ msgid "Infrastructure"
+#~ msgstr "基礎架構"
+
+#~ msgid "In use"
+#~ msgstr "使用中"
+
+#~ msgctxt "Location services status"
+#~ msgid "On"
+#~ msgstr "開"
+
+#~ msgctxt "Location services status"
+#~ msgid "Off"
+#~ msgstr "關"
+
+#~| msgid "Off"
+#~ msgctxt "Camera status"
+#~ msgid "Off"
+#~ msgstr "關閉"
+
+#~| msgid "On"
+#~ msgctxt "Camera status"
+#~ msgid "On"
+#~ msgstr "開啟"
+
+#~| msgid "Off"
+#~ msgctxt "Microphone status"
+#~ msgid "Off"
+#~ msgstr "關閉"
+
+#~| msgid "On"
+#~ msgctxt "Microphone status"
+#~ msgid "On"
+#~ msgstr "開啟"
+
+#~ msgid "Usage & History"
+#~ msgstr "使用與歷史紀錄"
+
+#~ msgid "Privacy Policy"
+#~ msgstr "隱私權原則"
+
+#~ msgid ""
+#~ "Remembering your history makes things easier to find again. These items "
+#~ "are never shared over the network."
+#~ msgstr ""
+#~ "記住您的歷史紀錄會讓需要再次找到某樣東西時更簡單。這些項目永遠不會透過網路"
+#~ "分享出去。"
+
+#~ msgid "_Recently Used"
+#~ msgstr "最近使用(_R)"
+
+#~ msgid "Retain _History"
+#~ msgstr "保留歷史紀錄(_H)"
+
+#~ msgid "The Screen Lock protects your privacy when you are away."
+#~ msgstr "螢幕鎖可以在您離開時保護您的隱私。"
+
+#~ msgid "Lock screen _after blank for"
+#~ msgstr "螢幕轉黑後多久鎖定螢幕(_A)"
+
+#~| msgid "_Lock Screen Notifications"
+#~ msgid "Lock Screen _Notifications"
+#~ msgstr "鎖定畫面通知(_N)"
+
+#~ msgid ""
+#~ "Automatically purge the Trash and temporary files to help keep your "
+#~ "computer free of unnecessary sensitive information."
+#~ msgstr "自動清除垃圾桶和暫存檔案可以保護您的電腦減少不必要的敏感資訊。"
+
+#~ msgid "Purge _After"
+#~ msgstr "清除於(_A)"
+
+#~ msgid ""
+#~ "Sending us information about which software you use helps us provide you "
+#~ "with more accurate recommendations. It also helps us to improve our "
+#~ "software.\n"
+#~ "\n"
+#~ "All the information we collect is made anonymous, and we will never share "
+#~ "your data with third parties."
+#~ msgstr ""
+#~ "傳送您所使用軟體的資訊給我們能幫助我們提供您更準確的建議。它也能協助我們改"
+#~ "進我們的軟體。\n"
+#~ "\n"
+#~ "我們所收集的所有資訊都是匿名的，而且我們永遠不會將您的資料與任何第三方分"
+#~ "享。"
+
+#~ msgid "_Send software usage statistics"
+#~ msgstr "傳送軟體使用率統計(_S)"
+
+#~| msgid "%s Camera"
+#~ msgid "_Camera"
+#~ msgstr "相機(_C)"
+
+#~ msgid "_Microphone"
+#~ msgstr "麥克風(_M)"
+
+#~ msgid "_Location Services"
+#~ msgstr "位置服務(_L)"
+
+#~ msgid "Protect your personal information and control what others might see"
+#~ msgstr "保護您的個人資訊並控制其他人能看到什麼"
+
+#~ msgid "No regions found"
+#~ msgstr "找不到區域"
+
+#~ msgid "Flash the _window title"
+#~ msgstr "閃動視窗標題(_W)"
+
+#~ msgid "_Background"
+#~ msgstr "背景(_B)"
+
+#~ msgid "Changes throughout the day"
+#~ msgstr "整天的變更"
+
+#~ msgctxt "background, style"
+#~ msgid "Tile"
+#~ msgstr "鋪排"
+
+#~ msgctxt "background, style"
+#~ msgid "Zoom"
+#~ msgstr "縮放"
+
+#~ msgctxt "background, style"
+#~ msgid "Center"
+#~ msgstr "置中"
+
+#~ msgctxt "background, style"
+#~ msgid "Scale"
+#~ msgstr "縮放"
+
+#~ msgctxt "background, style"
+#~ msgid "Fill"
+#~ msgstr "填滿"
+
+#~ msgctxt "background, style"
+#~ msgid "Span"
+#~ msgstr "合併"
+
+#~ msgid "Colors"
+#~ msgstr "顏色"
+
+#~ msgid "Pictures"
+#~ msgstr "影像"
+
+#~ msgid "No Pictures Found"
+#~ msgstr "找不到影像"
+
+#~ msgid "You can add images to your %s folder and they will show up here"
+#~ msgstr "您可以將影像加入您的%s資料夾，它們會顯示在這裡"
+
+#~ msgid "bluetooth"
+#~ msgstr "bluetooth"
+
+#~ msgid "preferences-color"
+#~ msgstr "preferences-color"
+
+#~ msgid "preferences-system-time"
+#~ msgstr "preferences-system-time"
+
+#~ msgid "_Night Light"
+#~ msgstr "夜光(_N)"
+
+#~ msgid "Could not get screen information"
+#~ msgstr "無法取得螢幕資訊"
+
+#~ msgid "preferences-desktop-display"
+#~ msgstr "preferences-desktop-display"
+
+#~ msgid "starred"
+#~ msgstr "starred"
+
+#~ msgid "help-about"
+#~ msgstr "help-about"
+
+#~ msgid "media-removable"
+#~ msgstr "media-removable"
+
+#~ msgid "input-keyboard"
+#~ msgstr "input-keyboard"
+
+#~ msgid "input-mouse"
+#~ msgstr "input-mouse"
+
+#~ msgid "network-workgroup"
+#~ msgstr "network-workgroup"
+
+#~ msgid "network-wireless"
+#~ msgstr "network-wireless"
+
+#~ msgid "hardware"
+#~ msgstr "硬體"
+
+#~ msgid "goa-panel"
+#~ msgstr "goa-panel"
+
+#~ msgid "_Automatic suspend"
+#~ msgstr "自動暫停(_A)"
+
+#~ msgid "_When the Power Button is pressed"
+#~ msgstr "當按下電源按鈕(_W)"
+
+#~ msgid "gnome-power-manager"
+#~ msgstr "gnome-power-manager"
+
+#~ msgid "printer"
+#~ msgstr "printer"
+
+#~ msgid "preferences-system-privacy"
+#~ msgstr "preferences-system-privacy"
+
+#~ msgid "preferences-desktop-locale"
+#~ msgstr "preferences-desktop-locale"
+
+#~ msgid "Switch to previous source"
+#~ msgstr "切換至上個來源"
+
+#~ msgid "Switch to next source"
+#~ msgstr "切換至下個來源"
+
+#~ msgid "Alternative switch to next source"
+#~ msgstr "切換至下個來源的替代鍵"
+
+#~ msgid "English (United Kingdom)"
+#~ msgstr "英文 (英國)"
+
+#~ msgid "United Kingdom"
+#~ msgstr "英國"
+
+#~ msgid "_Options"
+#~ msgstr "選項(_O)"
+
+#~ msgid "Add input source"
+#~ msgstr "加入輸入來源"
+
+#~ msgid "Remove input source"
+#~ msgstr "移除輸入來源"
+
+#~ msgid "Move input source up"
+#~ msgstr "將輸入來源往上移"
+
+#~ msgid "Move input source down"
+#~ msgstr "將輸入來源往下移"
+
+#~ msgid "Show input source keyboard layout"
+#~ msgstr "顯示輸入來源鍵盤配置"
+
+#~ msgid "preferences-system-search"
+#~ msgstr "preferences-system-search"
+
+#~ msgid "preferences-system-sharing"
+#~ msgstr "preferences-system-sharing"
+
+#~ msgid "multimedia-volume-control"
+#~ msgstr "multimedia-volume-control"
+
+#~ msgctxt "balance"
+#~ msgid "Left"
+#~ msgstr "左"
+
+#~ msgctxt "balance"
+#~ msgid "Right"
+#~ msgstr "右"
+
+#~ msgctxt "balance"
+#~ msgid "Minimum"
+#~ msgstr "最小值"
+
+#~ msgctxt "balance"
+#~ msgid "Maximum"
+#~ msgstr "最大值"
+
+#~ msgid "_Subwoofer:"
+#~ msgstr "重低音(_S)："
+
+#~ msgid "_Profile:"
+#~ msgstr "設定檔(_P)："
+
+#~ msgid "_Test Speakers"
+#~ msgstr "測試喇叭(_T)"
+
+#~ msgid "Peak detect"
+#~ msgstr "峰值檢測"
+
+#~ msgid "Device"
+#~ msgstr "裝置"
+
+#~ msgid "Speaker Testing for %s"
+#~ msgstr "%s 的喇叭測試"
+
+#~ msgid "C_hoose a device for sound output:"
+#~ msgstr "選擇聲音輸出的裝置(_H)："
+
+#~ msgid "Settings for the selected device:"
+#~ msgstr "已選取裝置的設定值："
+
+#~ msgid "_Input volume:"
+#~ msgstr "輸入音量(_I)："
+
+#~ msgid "C_hoose a device for sound input:"
+#~ msgstr "選擇聲音輸入的裝置(_H)："
+
+#~ msgid "Sound Effects"
+#~ msgstr "聲音效果"
+
+#~ msgid "Built-in"
+#~ msgstr "內建"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "音效偏好設定"
+
+#~ msgid "Testing event sound"
+#~ msgstr "測試事件聲音"
+
+#~ msgid "From theme"
+#~ msgstr "從主題"
+
+#~ msgid "C_hoose an alert sound:"
+#~ msgstr "選擇警示音效(_H)："
+
+#~ msgid "Stop"
+#~ msgstr "停止"
+
+#~ msgid "thunderbolt"
+#~ msgstr "thunderbolt"
+
+#~ msgid "preferences-desktop-accessibility"
+#~ msgstr "preferences-desktop-accessibility"
+
+#~ msgid "system-users"
+#~ msgstr "system-users"
+
+#~ msgctxt "Account type"
+#~ msgid "Standard"
+#~ msgstr "標準"
+
+#~ msgctxt "Account type"
+#~ msgid "Administrator"
+#~ msgstr "管理員"
+
+#~ msgid "The username cannot start with a “-”."
+#~ msgstr "使用者名稱不能以「-」字元開頭。"
+
+#~ msgid "input-tablet"
+#~ msgstr "input-tablet"
+
+#~ msgid "page 3"
+#~ msgstr "頁 3"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME 控制中心"
+
+#~ msgid ""
+#~ "The control center is GNOME’s main interface for configuration of various "
+#~ "aspects of your desktop."
+#~ msgstr "控制中心是 GNOME 用來管理桌面各層面設定的主要介面。"
+
+#~ msgid "Quit"
+#~ msgstr "結束"
+
+#~ msgid "gnome-control-center"
+#~ msgstr "gnome-control-center"
+
+#~ msgid "_Verify New Password"
+#~ msgstr "驗證新密碼(_V)"
+
+#~ msgid "Passwords do not match."
+#~ msgstr "密碼不相符。"
+
+#~ msgid "Show the overview"
+#~ msgstr "顯示概覽"
+
+#~ msgid "Back­ground"
+#~ msgstr "背景"
+
+#~ msgid "Blue­tooth"
+#~ msgstr "藍牙"
+
+#~ msgid "Co­lor"
+#~ msgstr "色彩"
+
+#~ msgid "Overview"
+#~ msgstr "概覽"
+
+#~ msgid "Defa­ult Applications"
+#~ msgstr "預設應用程式"
+
+#~ msgid "Ab­out"
+#~ msgstr "關於"
+
+#~ msgid "De­tails"
+#~ msgstr "詳細資訊"
+
+#~ msgid "Remo­vable Media"
+#~ msgstr "可移除式媒體"
+
+#~ msgid "Net­work"
+#~ msgstr "網路"
+
+#~ msgid "No­ti­fi­ca­tions"
+#~ msgstr "通知"
+
+#~ msgid "Po­wer"
+#~ msgstr "電源"
+
+#~ msgid "Pri­va­cy"
+#~ msgstr "隱私權"
+
+#~ msgid "Sha­ring"
+#~ msgstr "分享"
+
+#~ msgid "Uni­ver­sal Access"
+#~ msgstr "無障礙功能"
+
+#~ msgid "Disable image"
+#~ msgstr "停用影像"
+
+#~ msgid "Browse for more pictures…"
+#~ msgstr "瀏覽更多照片…"
+
+#~ msgid "Used by %s"
+#~ msgstr "由 %s 使用"
+
+#~ msgid "Wa­com Tab­let"
+#~ msgstr "Wacom 繪圖板"
+
+#~ msgctxt "category"
+#~ msgid "Hardware"
+#~ msgstr "硬體"
+
+#~ msgctxt "category"
+#~ msgid "System"
+#~ msgstr "系統"
+
+#~ msgid "Lid Closed"
+#~ msgstr "上蓋已經關閉"
+
+#~ msgid "Mirrored"
+#~ msgstr "相同顯示"
+
+#~ msgid "Secondary"
+#~ msgstr "次要"
+
+#~ msgid "Arrange Combined Displays"
+#~ msgstr "排列顯示器的組合方式"
+
+#~ msgid "Drag displays to rearrange them"
+#~ msgstr "拖拉顯示器以重新排列"
+
+#~ msgid "%d Hz (NTSC)"
+#~ msgstr "%d Hz (NTSC)"
+
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Rotate counterclockwise by 90°"
+#~ msgstr "逆時針"
+
+#~ msgid "Rotate by 180°"
+#~ msgstr "旋轉 180°"
+
+#~ msgid "Rotate clockwise by 90°"
+#~ msgstr "順時針旋轉 90°"
+
+#~ msgid "Size"
+#~ msgstr "尺寸"
+
+#~ msgid "Show the top bar and Activities Overview on this display"
+#~ msgstr "在這個顯示器顯示頂端列與活動概覽"
+
+#~ msgid "Join this display with another to create an extra workspace"
+#~ msgstr "將本顯示器與另一個顯示器組合以建立額外的工作空間"
+
+#~ msgid "Presentation"
+#~ msgstr "展示"
+
+#~ msgid "Show slideshows and media only"
+#~ msgstr "只顯示投影片與媒體"
+
+#~ msgid "Show your existing view on both displays"
+#~ msgstr "兩臺顯示器上皆顯示您現在的檢視畫面"
+
+#~ msgid "Turn Off"
+#~ msgstr "關閉"
+
+#~ msgid "Don’t use this display"
+#~ msgstr "不使用這臺顯示器"
+
+#~ msgid "_Arrange Combined Displays"
+#~ msgstr "排列顯示器組合方式(_A)"
+
+#~ msgid "%s %d-bit (Build ID: %s)"
+#~ msgstr "%s %d 位元 (組建 ID：%s)"
+
+#~ msgid "%s %d-bit"
+#~ msgstr "%s %d 位元"
+
+#~ msgid "Base system"
+#~ msgstr "基礎系統"
+
+#~ msgid "Shortcut;Repeat;Blink;"
+#~ msgstr "Shortcut;Repeat;Blink;快捷鍵;重複;閃爍;"
+
+#~ msgid "Press Esc to cancel."
+#~ msgstr "按下 Esc 鍵取消。"
+
+#~ msgid "Server"
+#~ msgstr "伺服器"
+
+#~ msgid "Delete DNS Server"
+#~ msgstr "刪除 DNS 伺服器"
+
+#~ msgid "Make available to other _users"
+#~ msgstr "允許其他使用者使用(_U)"
+
+#~ msgid "Firewall _Zone"
+#~ msgstr "防火牆界域(_Z)"
+
+#~ msgctxt "Firewall zone"
+#~ msgid "Default"
+#~ msgstr "預設"
+
+#~ msgid "The zone defines the trust level of the connection"
+#~ msgstr "界域定義了連線的信任等級"
+
+#~ msgid ""
+#~ "Reset the settings for this network, including passwords, but remember it "
+#~ "as a preferred network"
+#~ msgstr "重設這個網路的設定值，包含密碼，但將它記住為偏好的網路"
+
+#~ msgid ""
+#~ "Remove all details relating to this network and do not try to "
+#~ "automatically connect"
+#~ msgstr "移除這個網路的相關詳細資料並且不再嘗試自動連線"
+
+#~ msgid ""
+#~ "If you have a connection to the Internet other than wireless, you can set "
+#~ "up a wireless hotspot to share the connection with others."
+#~ msgstr ""
+#~ "如果您有無線網路以外的方式連線到網際網路，您可以使用它來與其他人分享您的網"
+#~ "際網路連線。"
+
+#~ msgid "Proxy"
+#~ msgstr "代理伺服器"
+
+#~ msgid "_Add Profile…"
+#~ msgstr "加入設定檔(_A)…"
+
+#~ msgctxt "proxy method"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgctxt "proxy method"
+#~ msgid "Manual"
+#~ msgstr "手動"
+
+#~ msgctxt "proxy method"
+#~ msgid "Automatic"
+#~ msgstr "自動"
+
+#~ msgid "VPN Type"
+#~ msgstr "VPN 類型"
+
+#~ msgid "Group Name"
+#~ msgstr "群組名稱"
+
+#~ msgid "Group Password"
+#~ msgstr "群組密碼"
+
+#~ msgid "_Use as Hotspot…"
+#~ msgstr "做為熱點(_U)…"
+
+#~ msgid "_History"
+#~ msgstr "歷史紀錄(_H)"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more letters, numbers and symbols."
+#~ msgstr "試著加入更多字母、數字和標點符號。"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Weak"
+#~ msgstr "強度：很弱"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Low"
+#~ msgstr "強度：低度"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Medium"
+#~ msgstr "強度：中度"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: Good"
+#~ msgstr "強度：良好"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strength: High"
+#~ msgstr "強度：高度"
+
+#~ msgid "<small>Your account</small>"
+#~ msgstr "<small>您的帳號</small>"
+
+#~ msgctxt "button"
+#~ msgid "Set Shortcut"
+#~ msgstr "設定捷徑鍵"
+
+#~ msgctxt "notifications"
+#~ msgid "Notification _Banners"
+#~ msgstr "通知橫幅(_B)"
+
+#~ msgid "Notification _Banners"
+#~ msgstr "通知橫幅(_B)"
+
+#~ msgid "Add Account"
+#~ msgstr "加入帳號"
+
+#~ msgid "Mail"
+#~ msgstr "郵件"
+
+#~ msgid "Calendar"
+#~ msgstr "行事曆"
+
+#~ msgid "Contacts"
+#~ msgstr "連絡人"
+
+#~ msgid "Chat"
+#~ msgstr "聊天"
+
+#~ msgid "Error creating account"
+#~ msgstr "建立帳號時發生錯誤"
+
+#~ msgid "Are you sure you want to remove the account?"
+#~ msgstr "確定要刪除這個帳號？"
+
+#~ msgid "This will not remove the account on the server."
+#~ msgstr "這不會移除伺服器上的帳號。"
+
+#~ msgid "No online accounts configured"
+#~ msgstr "尚未設定線上帳號"
+
+#~ msgid "Add an online account"
+#~ msgstr "加入線上帳號"
+
+#~ msgid ""
+#~ "Adding an account allows your applications to access it for documents, "
+#~ "mail, contacts, calendar, chat and more."
+#~ msgstr ""
+#~ "加入一個帳號以允許您的應用程式存取它用於文件、郵件、連絡人、行事曆、聊天等"
+#~ "等。"
+
+#~ msgctxt "printer state"
+#~ msgid "Configuring"
+#~ msgstr "正在設定"
+
+#~ msgid "Toner Level"
+#~ msgstr "碳粉匣等級"
+
+#~ msgid "Supply Level"
+#~ msgstr "耗材等級"
+
+#~ msgctxt "printer state"
+#~ msgid "Installing"
+#~ msgstr "正在安裝"
+
+#~ msgid "%u active"
+#~ msgid_plural "%u active"
+#~ msgstr[0] "%u 使用中"
+
+#~ msgid "Supply"
+#~ msgstr "耗材"
+
+#~ msgid "Jobs"
+#~ msgstr "工作"
+
+#~ msgid "Show _Jobs"
+#~ msgstr "顯示工作(_J)"
+
+#~ msgid "label"
+#~ msgstr "標籤"
+
+#~ msgid "Print _Test Page"
+#~ msgstr "列印測試頁(_T)"
+
+#~ msgid "Other Accounts"
+#~ msgstr "其他帳號"
+
+#~ msgid "Add a New Printer"
+#~ msgstr "加入新的印表機"
+
+#~ msgid "No printers detected."
+#~ msgstr "未偵測到印表機。"
+
+#~ msgctxt "login history week label"
+#~ msgid "%s - %s"
+#~ msgstr "%s - %s"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Up"
+#~ msgstr "上"
+
+#~ msgctxt "Wacom tablet button"
+#~ msgid "Down"
+#~ msgstr "下"
+
+#~ msgctxt "Wacom action-type"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "Left Ring"
+#~ msgstr "左環"
+
+#~ msgid "Left Ring Mode #%d"
+#~ msgstr "左觸控環模式 #%d"
+
+#~ msgid "Right Ring Mode #%d"
+#~ msgstr "右觸控環模式 #%d"
+
+#~ msgid "Left Touchstrip"
+#~ msgstr "左觸控列"
+
+#~ msgid "Left Touchstrip Mode #%d"
+#~ msgstr "左觸控列模式 #%d"
+
+#~ msgid "Right Touchstrip"
+#~ msgstr "右觸控列"
+
+#~ msgid "Right Touchstrip Mode #%d"
+#~ msgstr "右觸控列模式 #%d"
+
+#~ msgid "Left Touchring Mode Switch"
+#~ msgstr "左觸控環模式切換"
+
+#~ msgid "Right Touchring Mode Switch"
+#~ msgstr "右觸控環模式切換"
+
+#~ msgid "Left Touchstrip Mode Switch"
+#~ msgstr "左觸控列模式切換"
+
+#~ msgid "Right Touchstrip Mode Switch"
+#~ msgstr "右觸控列模式切換"
+
+#~ msgid "Mode Switch #%d"
+#~ msgstr "模式切換 #%d"
+
+#~ msgid "Left Button #%d"
+#~ msgstr "左側按鈕 #%d"
+
+#~ msgid "Right Button #%d"
+#~ msgstr "右側按鈕 #%d"
+
+#~ msgid "Top Button #%d"
+#~ msgstr "頂端按鈕 #%d"
+
+#~ msgid "Bottom Button #%d"
+#~ msgstr "底部按鈕 #%d"
+
+#~ msgid "Left Mouse Button Click"
+#~ msgstr "滑鼠左鍵點擊"
+
+#~ msgid "Scroll Up"
+#~ msgstr "向上捲動"
+
+#~ msgid "Scroll Down"
+#~ msgstr "向下捲動"
+
+#~ msgid "Scroll Right"
+#~ msgstr "向右捲動"
+
+#~ msgid "Remove Shortcut"
+#~ msgstr "移除捷徑鍵"
+
+#~ msgid ""
+#~ "To edit a shortcut, click the row and hold down the new keys or press "
+#~ "Backspace to clear."
+#~ msgstr ""
+#~ "要編輯捷徑鍵，點選相應的列並按下新的按鍵組合，或以 Backspace 鍵來清除。"
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<行動設定不詳>"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" cannot be used because it will become impossible to "
+#~ "type using this key.\n"
+#~ "Please try with a key such as Control, Alt or Shift at the same time."
+#~ msgstr ""
+#~ "捷徑「%s」無法使用，原因是會無法按下此按鍵。\n"
+#~ "請試用其它的按鍵：如同時使用 Control，Alt  或 Shift。"
+
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for\n"
+#~ "\"%s\""
+#~ msgstr ""
+#~ "捷徑鍵「%s」己經使用於：\n"
+#~ "「%s」"
+
+#~ msgid ""
+#~ "If you reassign the shortcut to \"%s\", the \"%s\" shortcut will be "
+#~ "disabled."
+#~ msgstr "如果您重新指派捷徑鍵為「%s」，「%s」的捷徑鍵就會停用。"
+
+#~ msgid "_Reassign"
+#~ msgstr "重新指派(_R)"
+
+#~ msgid ""
+#~ "The \"%s\" shortcut has an associated \"%s\" shortcut. Do you want to "
+#~ "automatically set it to \"%s\"?"
+#~ msgstr "捷徑鍵「%s」已指派「%s」捷徑。您想要自動將它設定為「%s」嗎？"
+
+#~ msgid ""
+#~ "\"%s\" is currently associated with \"%s\", this shortcut will be "
+#~ "disabled if you move forward."
+#~ msgstr "「%s」目前指派為「%s」，如果您繼續這個捷徑鍵就會停用。"
+
+#~ msgid "_Assign"
+#~ msgstr "指派(_R)"
+
+#~ msgid "Error logging into the account"
+#~ msgstr "登入帳號時發生錯誤"
+
+#~ msgid "Credentials have expired."
+#~ msgstr "憑證已經過期。"
+
+#~ msgid "Sign in to enable this account."
+#~ msgstr "登入以啟用這個帳號。"
+
+#~ msgid "_Sign In"
+#~ msgstr "登入(_S)"
+
+#~ msgid "Login History"
+#~ msgstr "登入歷史紀錄"
+
+#~ msgid "Add User Account"
+#~ msgstr "加入使用者帳號"
+
+#~ msgid "Bond"
+#~ msgstr "繫結"
+
+#~ msgid "Team"
+#~ msgstr "團隊"
+
+#~ msgid "Bridge"
+#~ msgstr "橋接"
+
+#~ msgid "VLAN"
+#~ msgstr "VLAN"
+
+#~ msgid "Could not load VPN plugins"
+#~ msgstr "無法載入 VPN 外掛程式"
+
+#~ msgid "Add Network Connection"
+#~ msgstr "加入網路連線"
+
+#~ msgid "Bond slaves"
+#~ msgstr "繫結的連線"
+
+#~ msgid "(none)"
+#~ msgstr "(沒有)"
+
+#~ msgid "Bridge slaves"
+#~ msgstr "橋接的連線"
+
+#~ msgid "Team slaves"
+#~ msgstr "團隊從屬"
+
+#~ msgid "InfiniBand device does not support connected mode"
+#~ msgstr "InfiniBand 裝置不支援已連接模式"
+
+#~ msgid "No Certificate Authority certificate chosen"
+#~ msgstr "未選擇任何憑證授權單位(CA)憑證"
+
+#~ msgid ""
+#~ "Not using a Certificate Authority (CA) certificate can result in "
+#~ "connections to insecure, rogue Wi-Fi networks.  Would you like to choose "
+#~ "a Certificate Authority certificate?"
+#~ msgstr ""
+#~ "不使用憑證中心 (CA) 的憑證會造成連線不安全、流氓 Wi-Fi 網路。是否要選擇一"
+#~ "個憑證中心的憑證？"
+
+#~ msgid "Ignore"
+#~ msgstr "忽略"
+
+#~ msgid "Choose CA Certificate"
+#~ msgstr "選擇 CA 憑證"
+
+#~ msgid "As_k for this password every time"
+#~ msgstr "每次都詢問密碼(_K)"
+
+#~ msgid "Don't _warn me again"
+#~ msgstr "不要再警告我(_W)"
+
+#~ msgid "Yes"
+#~ msgstr "是"
+
+#~ msgctxt "Search Location"
+#~ msgid "Other"
+#~ msgstr "其他"
+
+#~ msgid "_Verify"
+#~ msgstr "驗證(_V)"
+
+#~ msgid "A user with the username '%s' already exists."
+#~ msgstr "以「%s」為名的使用者已經存在。"
+
+#~ msgid "Used to determine your geographical location"
+#~ msgstr "用來判斷您所在的地理位置"
+
+#~ msgid "Done"
+#~ msgstr "完成"
+
+#~ msgid "Time _Zone"
+#~ msgstr "時區(_Z)"
+
+#~ msgid "Resume Printing"
+#~ msgstr "繼續列印"
+
+#~ msgid "Pause Printing"
+#~ msgstr "暫停列印"
+
+#~ msgctxt "print job"
+#~ msgid "Held"
+#~ msgstr "已暫停"
+
+#~ msgid "Job Title"
+#~ msgstr "工作名稱"
+
+#~ msgid "Job State"
+#~ msgstr "工作狀態"
+
+#~ msgid "Password:"
+#~ msgstr "密碼："
+
+#, fuzzy
+#~| msgid "Repeat Keys"
+#~ msgid "_Repeat Keys"
+#~ msgstr "重複按鍵"
+
+#, fuzzy
+#~| msgid "Cursor Blinking"
+#~ msgid "_Cursor Blinking"
+#~ msgstr "游標閃爍"
+
+#~ msgid "Zoom"
+#~ msgstr "縮放"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Color"
+#~ msgstr "顏色"
+
+#~ msgid "_Delay:"
+#~ msgstr "延遲(_D)："
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Short"
+#~ msgstr "短"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgctxt "keyboard, delay"
+#~ msgid "Long"
+#~ msgstr "長"
+
+#~ msgctxt "keyboard, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgid "S_peed:"
+#~ msgstr "速度(_P)："
+
+#~ msgid "Test Your Settings"
+#~ msgstr "測試您的設定值"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgctxt "double click, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgctxt "mouse, left button as primary"
+#~ msgid "_Left"
+#~ msgstr "左(_L)"
+
+#~ msgctxt "mouse, right button as primary"
+#~ msgid "_Right"
+#~ msgstr "右(_R)"
+
+#~ msgid "_Pointer speed"
+#~ msgstr "指標速度(_P)"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgctxt "mouse pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgctxt "touchpad pointer, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgid "Add New Printer"
+#~ msgstr "加入新的印表機"
+
+#~ msgid "No Bluetooth adapters found"
+#~ msgstr "找不到藍牙接配器"
+
+#~ msgid "Bluetooth is disabled by hardware switch"
+#~ msgstr "藍牙已被硬體開關停用"
+
+#~ msgid "Wireless devices require extra power"
+#~ msgstr "無線裝置需要額外電源"
+
+#~ msgid "Mobile broadband (3G, 4G, WiMax, etc.) devices require extra power"
+#~ msgstr "行動寬頻 (3G、4G、WiMax 等) 裝置需要額外電源"
+
+#~ msgid ""
+#~ "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;"
+#~ "video;pictures;photos;movies;server;renderer;"
+#~ msgstr ""
+#~ "share;sharing;ssh;host;name;remote;desktop;bluetooth;obex;media;audio;"
+#~ "video;pictures;photos;movies;server;renderer;分享;主機;名稱;遠端;桌面;藍"
+#~ "牙;媒體;音樂;視訊;影像;相片;影片;伺服器;"
+
+#~ msgid "Bluetooth Sharing"
+#~ msgstr "藍牙分享"
+
+#~ msgid ""
+#~ "Bluetooth Sharing allows you to share files with other Bluetooth enabled "
+#~ "devices"
+#~ msgstr "藍牙分享允許您與其他具有藍牙的裝置分享檔案"
+
+#~ msgid "Only Receive From Trusted Devices"
+#~ msgstr "只接收信任的裝置"
+
+#~ msgid "Save Received Files to Downloads Folder"
+#~ msgstr "將接收的檔案儲存至下載資料夾"
+
+#~ msgid "When battery power is _critical"
+#~ msgstr "當電池的電量極低時(_C)"
+
+#~ msgid "Show help options"
+#~ msgstr "顯示說明的選項"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Run '%s --help' to see a full list of available command line options.\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "執行 「%s --help」以查看完整的命令列可用選項清單。\n"
+
+#~ msgid "Turns off wireless devices"
+#~ msgstr "關閉無線裝置"
+
+#~ msgid "United States"
+#~ msgstr "美國"
+
+#~ msgid "Spain"
+#~ msgstr "西班牙"
+
+#~ msgid "China"
+#~ msgstr "中國"
+
+#~ msgid "Disable while _typing"
+#~ msgstr "打字時停用(_T)"
+
+#~ msgid "The system network services are not compatible with this version."
+#~ msgstr "系統網路服務與這個版本不相容。"
+
+#~ msgctxt "notifications"
+#~ msgid "Show Popup Banners"
+#~ msgstr "顯示彈出式橫幅"
+
+#~ msgctxt "notifications"
+#~ msgid "View in Lock Screen"
+#~ msgstr "在鎖定畫面中顯示"
+
+#~ msgid "Show Pop Up Banners"
+#~ msgstr "顯示彈出式橫幅"
+
+#~ msgid "Enter address of a printer or a text to filter results"
+#~ msgstr "輸入網路印表機的位址或過濾器結果文字"
+
+#~ msgid "Sorry"
+#~ msgstr "抱歉"
+
+#~ msgid "Share Media On This Network"
+#~ msgstr "在這個網路分享媒體"
+
+#~ msgid "Shared Folders"
+#~ msgstr "分享資料夾"
+
+#~ msgid "column"
+#~ msgstr "欄"
+
+#~ msgid "Remove Folder"
+#~ msgstr "移除資料夾"
+
+#~ msgid "Share Public Folder On This Network"
+#~ msgstr "在這個網路分享公開資料夾"
+
+#~ msgid "Immediately"
+#~ msgstr "立即"
+
+#~ msgid "Set Up New Device"
+#~ msgstr "設置新裝置"
+
+#~ msgid "Paired"
+#~ msgstr "已配對"
+
+#~ msgid "Mouse & Touchpad Settings"
+#~ msgstr "滑鼠與觸控板設定值"
+
+#~ msgid "Keyboard Settings"
+#~ msgstr "鍵盤設定值"
+
+#~ msgid "Send Files…"
+#~ msgstr "傳送檔案…"
+
+#~ msgid "Visibility of “%s”"
+#~ msgstr "「%s」的顯示狀態"
+
+#~ msgid "Remove '%s' from the list of devices?"
+#~ msgstr "是否從裝置的清單中移除「%s」？"
+
+#~ msgid ""
+#~ "If you remove the device, you will have to set it up again before next "
+#~ "use."
+#~ msgstr "如果您刪除此裝置，下次使用時必須再次設定它。"
+
+#~ msgid "Install Updates"
+#~ msgstr "安裝更新"
+
+#~ msgid "System Up-To-Date"
+#~ msgstr "系統已是最新"
+
+#~ msgid "Search for network printers or filter result"
+#~ msgstr "搜尋網路印表機或過濾器結果"
+
+#~ msgid "_Default"
+#~ msgstr "預設值(_D)"
+
+#~ msgid "Share Public Folder"
+#~ msgstr "分享公用資料夾"
+
+#~ msgid "Only share with Trusted Devices"
+#~ msgstr "只與信任的裝置分享"
+
+#~ msgid "Approve All Connections"
+#~ msgstr "允許所有的連線"
+
+#~ msgid "Device type:"
+#~ msgstr "裝置類型："
+
+#~ msgid "Manufacturer:"
+#~ msgstr "製造商："
+
+#~ msgid "Model:"
+#~ msgstr "型號："
+
+#~ msgid ""
+#~ "Image files can be dragged on this window to auto-complete the above "
+#~ "fields."
+#~ msgstr "可以將影像檔案拖放到這個視窗自動完成上列欄位。"
+
+#~ msgid "Show your primary display on this screen also"
+#~ msgstr "也在這個螢幕顯示您的主要顯示"
+
+#~ msgid "Combine"
+#~ msgstr "組合"
+
+#~ msgid "Join with the primary display to create an extra space"
+#~ msgstr "結合主要顯示器以建立額外的工作區"
+
+#~ msgid "Don't use the display"
+#~ msgstr "不使用這個顯示器"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "滑鼠偏好設定"
+
+#~ msgid "Select the interface to use for the new service"
+#~ msgstr "選擇要用於新服務的介面"
+
+#~ msgid "C_reate…"
+#~ msgstr "建立(_R)…"
+
+#~ msgid "_Interface"
+#~ msgstr "介面(_I)"
+
+#~ msgctxt "Language"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "Changing photo for:"
+#~ msgstr "正在改變相片："
+
+#~ msgid ""
+#~ "Choose a picture that will be shown at the login screen for this account."
+#~ msgstr "選擇這個帳號要顯示在登入畫面的照片。"
+
+#~ msgid "Gallery"
+#~ msgstr "藝廊"
+
+#~ msgid "Take a photograph"
+#~ msgstr "照一張相片"
+
+#~ msgid "Browse"
+#~ msgstr "瀏覽"
+
+#~ msgid "Photograph"
+#~ msgstr "相片"
+
+#~ msgid "Switch between AM and PM."
+#~ msgstr "在上午與下午之間切換。"
+
+#~ msgid "Estimated battery capacity: %s"
+#~ msgstr "預估電池電力：%s"
+
+#~ msgid "_Region:"
+#~ msgstr "區域(_R)："
+
+#~ msgid "_City:"
+#~ msgstr "城市(_C)："
+
+#~ msgid "Set the time one hour ahead."
+#~ msgstr "將時刻延後一小時。"
+
+#~ msgid "Set the time one hour back."
+#~ msgstr "將時刻提早一小時。"
+
+#~ msgid "Set the time one minute ahead."
+#~ msgstr "將時刻延後一分鐘。"
+
+#~ msgid "Set the time one minute back."
+#~ msgstr "將時刻提早一分鐘。"
+
+#~ msgid "AM/PM"
+#~ msgstr "AM/PM"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Normal"
+#~ msgstr "正常"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "Clockwise"
+#~ msgstr "順時針"
+
+#~ msgctxt "display panel, rotation"
+#~ msgid "180 Degrees"
+#~ msgstr "180 度"
+
+#~ msgid ""
+#~ "Select a monitor to change its properties; drag it to rearrange its "
+#~ "placement."
+#~ msgstr "選擇一個螢幕以改變它的屬性；拖曳它則能重新排列它的位置。"
+
+#~ msgid "%a %R"
+#~ msgstr "%a %R"
+
+#~ msgid "Could not save the monitor configuration"
+#~ msgstr "無法儲存顯示器設定"
+
+#~ msgid "_Resolution"
+#~ msgstr "解析度(_R)"
+
+#~ msgid "R_otation"
+#~ msgstr "旋轉(_O)"
+
+#~ msgid "_Mirror displays"
+#~ msgstr "鏡射顯示器(_M)"
+
+#~ msgid "Note: may limit resolution options"
+#~ msgstr "注意：可能會限制解析度選項"
+
+#~ msgid "Hidden"
+#~ msgstr "隱藏"
+
+#~ msgid "Visible"
+#~ msgstr "顯示"
+
+#~ msgid "Name & Visibility"
+#~ msgstr "名稱與可見度"
+
+#~ msgid "Control how you appear on the screen and the network."
+#~ msgstr "控制您在螢幕及網路上如何顯示。"
+
+#~ msgid "Display _full name in top bar"
+#~ msgstr "在頂端列顯示全名(_F)"
+
+#~ msgid "Display full name in _lock screen"
+#~ msgstr "在鎖定畫面中顯示全名(_L)"
+
+#~ msgid "_Stealth Mode"
+#~ msgstr "隱密模式(_S)"
+
+#~ msgid "Show Status When _Inactive"
+#~ msgstr "當不活動後顯示狀態(_I)"
+
+#~ msgid "_Login Name"
+#~ msgstr "登入名稱(_L)"
+
+#~ msgid "Login _Password"
+#~ msgstr "登入密碼(_P)"
+
+#~ msgid "Passwords do not match"
+#~ msgstr "密碼不相符"
+
+#~ msgid ""
+#~ "Login not recognized.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "登入無法辨識。\n"
+#~ "請再試一次。"
+
+#~ msgid "Domain not found."
+#~ msgstr "找不到網域。"
+
+#~ msgctxt "Password hint"
+#~ msgid "Try to add more characters."
+#~ msgstr "試著加入更多字元。"
+
+#~ msgid "Switch Modes"
+#~ msgstr "切換模式"
+
+#~ msgid "Action"
+#~ msgstr "動作"
+
+#~ msgid "Export"
+#~ msgstr "匯出"
+
+#~ msgid "Left Shift"
+#~ msgstr "左 Shift"
+
+#~ msgid "Right Shift"
+#~ msgstr "右 Shift"
+
+#~ msgid "Left Alt+Shift"
+#~ msgstr "左 Alt+Shift"
+
+#~ msgid "Left Ctrl+Shift"
+#~ msgstr "左 Ctrl+Shift"
+
+#~ msgid "Right Ctrl+Shift"
+#~ msgstr "右 Ctrl+Shift"
+
+#~ msgid "Alt+Shift"
+#~ msgstr "Alt+Shift"
+
+#~ msgid "Ctrl+Shift"
+#~ msgstr "Ctrl+Shift"
+
+#~ msgid "Alt+Ctrl"
+#~ msgstr "Alt+Ctrl"
+
+#~ msgid "Shift+Caps"
+#~ msgstr "Shift+Caps"
+
+#~ msgid "Alt+Caps"
+#~ msgstr "Alt+Caps"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Slow"
+#~ msgstr "慢速"
+
+#~ msgctxt "mouse, speed"
+#~ msgid "Fast"
+#~ msgstr "快速"
+
+#~ msgid "C_ontent sticks to fingers"
+#~ msgstr "捲動時內容黏住手指(_O)"
+
+#~ msgid "_Options…"
+#~ msgstr "選項(_O)…"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "Normal"
+#~ msgstr "一般"
+
+#~ msgctxt "universal access, contrast"
+#~ msgid "High/Inverse"
+#~ msgstr "高/反差"
+
+#~ msgid "On screen keyboard"
+#~ msgstr "螢幕鍵盤"
+
+#~ msgid "OnBoard"
+#~ msgstr "OnBoard"
+
+#~ msgid "75%"
+#~ msgstr "75%"
+
+#~ msgid "100%"
+#~ msgstr "100%"
+
+#~ msgctxt "universal access, text size"
+#~ msgid "Normal"
+#~ msgstr "正常"
+
+#~ msgid "125%"
+#~ msgstr "125%"
+
+#~ msgid "150%"
+#~ msgstr "150%"
+
+#~ msgid "Beep on Caps and Num Lock"
+#~ msgstr "當 Caps 和 Num Lock 在使用時發出聲響"
+
+#~ msgid "Turn on or off:"
+#~ msgstr "開啟或關閉："
+
+#~ msgctxt "universal access, zoom"
+#~ msgid "Zoom"
+#~ msgstr "縮放"
+
+#~ msgid "Zoom in:"
+#~ msgstr "拉近："
+
+#~ msgid "Zoom out:"
+#~ msgstr "拉遠："
+
+#~ msgid "Closed Captioning"
+#~ msgstr "關閉說明"
+
+#~ msgid "Display a textual description of speech and sounds"
+#~ msgstr "顯示語音和音效的文字描述"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Short"
+#~ msgstr "短"
+
+#~ msgctxt "universal access, delay"
+#~ msgid "Long"
+#~ msgstr "長"
+
+#~ msgid "Beep when a key is"
+#~ msgstr "發出聲響條件為按鍵"
+
+#~ msgid "pressed"
+#~ msgstr "已按下"
+
+#~ msgid "accepted"
+#~ msgstr "已接受"
+
+#~ msgid "rejected"
+#~ msgstr "已拒絕"
+
+#~ msgid "Acc_eptance delay:"
+#~ msgstr "接受時間延遲(_E)："
+
+#~ msgid "Control the pointer using the keypad"
+#~ msgstr "使用鍵盤控制滑鼠指標"
+
+#~ msgid "Video Mouse"
+#~ msgstr "視訊滑鼠"
+
+#~ msgid "Control the pointer using the video camera."
+#~ msgstr "使用視訊攝影機控制指標"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Small"
+#~ msgstr "小"
+
+#~ msgctxt "universal access, threshold"
+#~ msgid "Large"
+#~ msgstr "大"
+
+#~ msgid "_Local Account"
+#~ msgstr "登入帳號(_L)"
+
+#~ msgid "Tip: Enterprise domain or realm name"
+#~ msgstr "提示：企業網域或領域名稱"
+
+#~ msgid "C_ontinue"
+#~ msgstr "繼續(_O)"
+
+#~ msgid "Next Week"
+#~ msgstr "下一週"
+
+#~ msgid "Next week"
+#~ msgstr "下一週"
+
+#~ msgid "Log in without a password"
+#~ msgstr "不使用密碼登入"
+
+#~ msgid "Disable this account"
+#~ msgstr "停用這個帳號"
+
+#~ msgid "Enable this account"
+#~ msgstr "啟用這個帳號"
+
+#~ msgid "_Action"
+#~ msgstr "動作(_A)"
+
+#~ msgid "_Show password"
+#~ msgstr "顯示密碼(_S)"
+
+#~ msgid "How to choose a strong password"
+#~ msgstr "如何選擇強度高的密碼"
+
+#~ msgctxt "Password strength"
+#~ msgid "Too short"
+#~ msgstr "太短"
+
+#~ msgctxt "Password strength"
+#~ msgid "Not good enough"
+#~ msgstr "不夠好"
+
+#~ msgctxt "Password strength"
+#~ msgid "Weak"
+#~ msgstr "太弱"
+
+#~ msgctxt "Password strength"
+#~ msgid "Fair"
+#~ msgstr "一般"
+
+#~ msgctxt "Password strength"
+#~ msgid "Good"
+#~ msgstr "良好"
+
+#~ msgctxt "Password strength"
+#~ msgid "Strong"
+#~ msgstr "強固"
+
+#~ msgid "_Generate a password"
+#~ msgstr "產生密碼(_G)"
+
+#~ msgid "You need to enter a new password"
+#~ msgstr "您需要輸入新的密碼"
+
+#~ msgid "The new password is not strong enough"
+#~ msgstr "新的密碼強度不夠"
+
+#~ msgid "You need to confirm the password"
+#~ msgstr "您需要確認密碼"
+
+#~ msgid "You need to enter your current password"
+#~ msgstr "您需要輸入您目前的密碼"
+
+#~ msgid "The current password is not correct"
+#~ msgstr "目前的密碼並不正確"
+
+#~ msgid "Right Alt+Shift"
+#~ msgstr "右 Alt+Shift"
+
+#~ msgid "Left+Right Shift"
+#~ msgstr "左+右 Shift"
+
+#~ msgid "Left+Right Ctrl"
+#~ msgstr "左+右 Ctrl"
+
+#~ msgid "Ctrl+Caps"
+#~ msgstr "Ctrl+Caps"
+
+#~ msgid "blablabla"
+#~ msgstr "…等等"
+
+#~ msgid ""
+#~ "Address\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "位址\n"
+#~ "部分\n"
+#~ "在\n"
+#~ "這裡"
+
+#~ msgid ""
+#~ "DNS\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "DNS\n"
+#~ "部分\n"
+#~ "在\n"
+#~ "這裡"
+
+#~ msgid ""
+#~ "Routes\n"
+#~ "section\n"
+#~ "goes\n"
+#~ "here"
+#~ msgstr ""
+#~ "路由\n"
+#~ "部分\n"
+#~ "在\n"
+#~ "這裡"
+
+#~ msgid "00:24:16:31:8G:7A"
+#~ msgstr "00:24:16:31:8G:7A"
+
+#~ msgctxt "Input source"
+#~ msgid "None"
+#~ msgstr "沒有"
+
+#~ msgid "Expired credentials. Please log in again."
+#~ msgstr "憑證已逾期。請重新登入。"
+
+#~ msgid "_Log In"
+#~ msgstr "登入(_L)"
+
+#~ msgctxt "Power"
+#~ msgid "Bluetooth"
+#~ msgstr "藍牙"
+
+#~ msgid "Color management settings"
+#~ msgstr "顏色管理設定值"
+
+#~ msgid "British English"
+#~ msgstr "英式英文"
+
+#~ msgid "Spanish"
+#~ msgstr "西班牙文"
+
+#~ msgid "Chinese (simplified)"
+#~ msgstr "簡體中文"
+
+#~ msgid "Date and Time preferences panel"
+#~ msgstr "日期和時刻偏好設定面板"
+
+#~ msgid "Layout Settings"
+#~ msgstr "配置設定值"
+
+#~ msgid "Set your mouse and touchpad preferences"
+#~ msgstr "設定您的滑鼠與觸控板偏好設定"
+
+#~ msgid "Carrier/link changed"
+#~ msgstr "載體/連結已變更"
+
+#~ msgid "Manage online accounts"
+#~ msgstr "管理線上帳號"
+
+#~ msgid "_Mark As Inactive After"
+#~ msgstr "標記為不活動於(_M)"
+
+#~ msgid "Power management settings"
+#~ msgstr "電源管理設定值"
+
+#~ msgid "Manufacturers"
+#~ msgstr "製造商"
+
+#~ msgid "Don't retain history"
+#~ msgstr "不要保留歷史紀錄"
+
+#~ msgid "Change your region and language settings"
+#~ msgstr "改變您的地區和語言設定值"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings."
+#~ msgstr "登入畫面、系統帳號和新使用者帳號使用系統的地區和語言設定值。"
+
+#~ msgid ""
+#~ "The login screen, system accounts and new user accounts use the system-"
+#~ "wide Region and Language settings. You may change the system settings to "
+#~ "match yours."
+#~ msgstr ""
+#~ "登入畫面、系統帳號和新使用者帳號使用系統的地區和語言設定值。您可以將系統設"
+#~ "定值改變以符合您的需求。"
+
+#~ msgid "Copy Settings"
+#~ msgstr "複製設定值"
+
+#~ msgid "Copy Settings…"
+#~ msgstr "複製設定值…"
+
+#~ msgid "Region and Language"
+#~ msgstr "地區和語言"
+
+#~ msgid "Add Language"
+#~ msgstr "加入語言"
+
+#~ msgid "Select a region (change will be applied the next time you log in)"
+#~ msgstr "選擇地區 (變更會在您下次登入時套用)"
+
+#~ msgid "Add Region"
+#~ msgstr "加入區域"
+
+#~ msgid "Remove Region"
+#~ msgstr "移除區域"
+
+#~ msgid "Currency"
+#~ msgstr "貨幣"
+
+#~ msgid "Examples"
+#~ msgstr "範例"
+
+#~ msgid "Ctrl+Alt+Space"
+#~ msgstr "Ctrl+Alt+Space"
+
+#~ msgid "Shortcut Settings"
+#~ msgstr "捷徑鍵設定值"
+
+#~ msgid "Input source:"
+#~ msgstr "輸入來源："
+
+#~ msgid "Format:"
+#~ msgstr "格式："
+
+#~ msgid "Your settings"
+#~ msgstr "您的設定值"
+
+#~ msgid "System settings"
+#~ msgstr "系統設定值"
+
+#~ msgid "Universal Access Preferences"
+#~ msgstr "無障礙偏好設定"
+
+#~ msgid "_Hint"
+#~ msgstr "提示(_H)"
+
+#~ msgid ""
+#~ "This hint may be displayed at the login screen.  It will be visible to "
+#~ "all users of this system.  Do <b>not</b> include the password here."
+#~ msgstr ""
+#~ "這個提示可能會顯示在登入畫面。它將會顯示給這個系統上的所有使用者。請<b>不"
+#~ "要</b>在這裡寫入密碼。"
+
+#~ msgid "Fair"
+#~ msgstr "一般"
+
+#~ msgid "Set your Wacom tablet preferences"
+#~ msgstr "設定您的 Wacom 繪圖板偏好設定"
+
+#~ msgid "Out of range"
+#~ msgstr "超過範圍"

--- a/po/zu.po
+++ b/po/zu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center HEAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"POT-Creation-Date: 2023-01-10 20:29+0530\n"
 "PO-Revision-Date: 2004-12-13 19:02+0200\n"
 "Last-Translator: Zuza Software Foundation <info@translate.org.za>\n"
 "Language-Team: Zulu <translate-discuss-zu@lists.sourceforge.net>\n"
@@ -18,3495 +18,7158 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../capplets/about-me/eel-alert-dialog.c:114
-msgid "Image/label border"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:115
-msgid "Width of border around the label and image in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:124
+#. List of applications.
+#: panels/applications/cc-applications-panel.ui:19
+#: panels/applications/gnome-applications-panel.desktop.in.in:3
+#: panels/notifications/cc-notifications-panel.ui:26
 #, fuzzy
-msgid "Alert Type"
-msgstr "Faka uhlobo lwehele"
-
-#: ../capplets/about-me/eel-alert-dialog.c:125
-#, fuzzy
-msgid "The type of alert"
-msgstr "Uhlobo lwesigijimi."
-
-#: ../capplets/about-me/eel-alert-dialog.c:133
-#, fuzzy
-msgid "Alert Buttons"
-msgstr "Amankinombho"
-
-#: ../capplets/about-me/eel-alert-dialog.c:134
-msgid "The buttons shown in the alert dialog"
-msgstr ""
-
-#: ../capplets/about-me/eel-alert-dialog.c:198
-#, fuzzy
-msgid "Show more _details"
-msgstr "_Imniningwane yendikima"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
-#: ../capplets/about-me/gnome-about-me.glade.h:14
-#, fuzzy
-msgid "About Me"
-msgstr "_Nge"
-
-#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
-#, fuzzy
-msgid "Set your personal information"
-msgstr "Uhlobo lolwazi MIME"
-
-#: ../capplets/about-me/gnome-about-me.c:554
-#, fuzzy
-msgid "Select Image"
-msgstr "_Khetha"
-
-#: ../capplets/about-me/gnome-about-me.c:556
-#, fuzzy
-msgid "No Image"
-msgstr "Izithombe"
-
-#: ../capplets/about-me/gnome-about-me.c:706
-msgid ""
-"There was an error while trying to get the addressbook information\n"
-"Evolution Data Server can't handle the protocol"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:727
-msgid "Unable to open address book"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:739
-msgid "Unknown login ID, the user database might be corrupted"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.c:770
-#: ../capplets/about-me/gnome-about-me.c:772
-#, fuzzy, c-format
-msgid "About %s"
-msgstr "_Nge"
-
-#: ../capplets/about-me/gnome-about-me-password.c:101
-#: ../capplets/about-me/gnome-about-me-password.c:479
-msgid "Old password is incorrect, please retype it"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:112
-msgid "System error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:113
-msgid "Could not run /usr/bin/passwd"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:114
-msgid "Unable to launch backend"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:116
-#: ../capplets/about-me/gnome-about-me-password.c:117
-msgid "Unexpected error has occurred"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:315
-msgid "Password is too short"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:318
-#: ../capplets/about-me/gnome-about-me-password.c:321
-msgid "Password is too simple"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:324
-msgid "Old and new passwords are too similar"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:328
-msgid "Old and new password are the same"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:406
-#, fuzzy
-msgid "Please type the passwords."
-msgstr "_Igama lokungena:"
-
-#: ../capplets/about-me/gnome-about-me-password.c:414
-msgid "Please type the password again, it is wrong."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me-password.c:417
-msgid "Click on Change Password to change the password."
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:1
-#: ../vfs-methods/themus/apply-font.glade.h:1
-msgid " "
-msgstr " "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:2
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
-#: ../capplets/font/font-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
-msgid "    "
-msgstr "    "
-
-#: ../capplets/about-me/gnome-about-me.glade.h:3
-#, fuzzy
-msgid "<b>Email</b>"
-msgstr "<i>Ncanel</i>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:4
-#, fuzzy
-msgid "<b>Home</b>"
-msgstr "<b>Ijubane</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:5
-#, fuzzy
-msgid "<b>Instant Messaging</b>"
-msgstr "<b>Ukutyelekana isiqwema</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:6
-#, fuzzy
-msgid "<b>Job</b>"
-msgstr "<b>Sekela</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:7
-msgid "<b>Please type the passwords.</b>"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:8
-#, fuzzy
-msgid "<b>Telephone</b>"
-msgstr "<b>Izihlushulelo zokugqoka</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:9
-#, fuzzy
-msgid "<b>Web</b>"
-msgstr "<b>Ijubane</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:10
-#, fuzzy
-msgid "<b>Work</b>"
-msgstr "<b>Sekela</b>"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:11
-msgid "A_IM/iChat:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:12
-#, fuzzy
-msgid "A_ddress:"
-msgstr "_Hlanganisa:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:13
-msgid "A_ssistant:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:15
-#, fuzzy
-msgid "Address"
-msgstr "_ipotshoziwe"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:16
-#, fuzzy
-msgid "C_ity:"
-msgstr "_Inhlobo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:17
-#, fuzzy
-msgid "C_ompany:"
-msgstr "Umy_alo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:18
-#, fuzzy
-msgid "Cale_ndar:"
-msgstr "Uhla_ngothi..."
-
-#: ../capplets/about-me/gnome-about-me.glade.h:19
-#, fuzzy
-msgid "Change Passwo_rd..."
-msgstr "Shintsha uhlelo"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:20
-#, fuzzy
-msgid "Change Password"
-msgstr "Shintsha uhlelo"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:21
-#, fuzzy
-msgid "Ci_ty:"
-msgstr "_Inhlobo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:22
-#, fuzzy
-msgid "Co_untry:"
-msgstr "Lawula"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:23
-#, fuzzy
-msgid "Contact"
-msgstr "_Iziqikili"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:24
-#, fuzzy
-msgid "Cou_ntry:"
-msgstr "Lawula"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:25
-msgid "Full Name"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:26
-#, fuzzy
-msgid "Hom_e:"
-msgstr "_Igama:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:27
-msgid "IC_Q:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:28
-msgid "M_SN:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:29
-#, fuzzy
-msgid "Old pa_ssword:"
-msgstr "_Igama lokungena:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:30
-msgid "P.O. _box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:31
-msgid "P._O. box:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:32
-#, fuzzy
-msgid "Personal Info"
-msgstr "_Isixhumi siqwema:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:33
-msgid "State/Pro_vince:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:34
-#, fuzzy
-msgid "User name:"
-msgstr "I_gamamsebemzi:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:35
-msgid "Web _log:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:36
-msgid "Wor_k:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:37
-msgid "Work _fax:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:38
-msgid "Zip/_Postal code:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:39
-#, fuzzy
-msgid "_Address:"
-msgstr "_Hlanganisa:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:40
-msgid "_Department:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:41
-msgid "_Groupwise:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:42
-#, fuzzy
-msgid "_Home page:"
-msgstr "_Igama lendikimba:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:43
-#, fuzzy
-msgid "_Home:"
-msgstr "_Igama:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:44
-msgid "_Jabber:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:45
-#, fuzzy
-msgid "_Manager:"
-msgstr "_Inkulisa"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:46
-#, fuzzy
-msgid "_Mobile:"
-msgstr "_Ihele"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:47
-#, fuzzy
-msgid "_New password:"
-msgstr "_Igama lokungena:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:48
-#, fuzzy
-msgid "_Profession:"
-msgstr "Umlandiso:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:49
-#, fuzzy
-msgid "_Retype new password:"
-msgstr "_Igama lokungena:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:50
-msgid "_State/Province:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:51
-#, fuzzy
-msgid "_Title:"
-msgstr "_Inhlobo:"
-
-#: ../capplets/about-me/gnome-about-me.glade.h:52
-msgid "_Work:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:53
-msgid "_Yahoo:"
-msgstr ""
-
-#: ../capplets/about-me/gnome-about-me.glade.h:54
-msgid "_Zip/Postal code:"
-msgstr ""
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
-msgid "<b>Applications</b>"
+msgid "Applications"
 msgstr "<b> Izithobo</b>"
 
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
-msgid "<b>Support</b>"
-msgstr "<b>Sekela</b>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
-msgid ""
-"<small><i><b>Note:</b> Changes to this setting will not take effect until "
-"you next log in.</i></small>"
-msgstr ""
-"<small><i><b>Qaphela:</b> Ushintsho kuloluhlelo angeke lwenzeke uze uphinde "
-"ungene futhi ngaphakathi.</i></small>"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
-msgid "Assistive Technology Preferences"
-msgstr "Usizo lwesayensi yemisebenzi ethile oluthandekayo"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
-msgid "Close and _Log Out"
-msgstr "Vala futhi _uphume"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
-msgid "Start these assistive technologies every time you log in:"
-msgstr "Qala lolusizo lwesayensi ethile ngazo zonke izikhathi uma ungena:"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
-msgid "_Enable assistive technologies"
-msgstr "_Nika amandla kusizo lwesayensi ethile"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
-msgid "_Magnifier"
-msgstr "_Inkulisa"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
-msgid "_On-screen keyboard"
-msgstr "_Ebusweni besiga-nyezi kwindawo yokushaya uma ubhala"
-
-#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
-msgid "_Screenreader"
-msgstr "_Isifundi ebusweni besiga-nyezi"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
-msgid "Assistive Technology Support"
-msgstr "Usizo lwesayensi yemisebenzi ethile oluthandekayo"
-
-#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
-msgid "Enable support for GNOME assistive technologies at login"
-msgstr ""
-"Nika amandla ngokusekela I GNOME uma ungena kusizo lwesayensi yemisebenzi "
-"ethile"
-
-#: ../capplets/accessibility/at-properties/main.c:60
-msgid ""
-"No Assistive Technology is available on your system.  The 'gok' package must "
-"be installed in order to get on-screen keyboard support, and the "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Usizo lobugciko alukho phakathi kohlelo lwakho. Umthwalo we-'gok' imelwe "
-"ukufakwa ukuze uthole inxaso yobuso besiga-nyezi kwindawo yokushaya uma "
-"ubhala, nomthwalo we 'gnopernicus' kumelwe ufakwe ukuze ufundwe ebusweni "
-"besiga-nyezi namakhono okukhulisa."
-
-#: ../capplets/accessibility/at-properties/main.c:62
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gok' package must be installed in order to get on-screen keyboard support."
-msgstr ""
-"Akusilo lonke usizo olutholakalayo lwesayensi ethile olufakiwe phakathi "
-"komshini wakho. Isithungu se 'gok' kumelwe sifakwe ukuze kutholwe ukusekelwa "
-"kwindawo yokusahya uma ubhala ebusweni besiga-nyezi."
-
-#: ../capplets/accessibility/at-properties/main.c:64
-msgid ""
-"Not all available assistive technologies are installed on your system.  The "
-"'gnopernicus' package must be installed for screenreading and magnifying "
-"capabilities."
-msgstr ""
-"Usizo lwesayensi yemisebenzi ethile oluthandekayo alufakiwe phakathi "
-"emshinini wakho. Isishuqulu se 'gnopernicus' kumelwe sifakwe ukuze kufundwe "
-"ebusweni besiga-nyezi nokukhulisa okukhoekayo."
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
-#, c-format
-msgid "There was an error launching the mouse preferences dialog: %s"
-msgstr ""
-"Kube khona iphutha elenzikile uma kungeniswa ingoso oluthandekayo lokushaya: "
-"%s"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
-#, c-format
-msgid "Unable to import AccessX settings from file '%s'"
-msgstr "Ihlulekile ukuthwebula izinhlelo zemvumeX phakathi kwehele '%s'"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
-msgid "Import Feature Settings File"
-msgstr "Ingqondo yokuhlela imininingwane yehele"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
-msgid "_Import"
-msgstr "_Ngenisa okuvela ngaphandle"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
-msgid "Keyboard"
-msgstr "Indawo yokushaya uma ubhala"
-
-#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
-msgid "Set your keyboard accessibility preferences"
-msgstr "Hlela indawo yakho yokubhala ngezimvume ezithandekayo"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
-msgid ""
-"This system does not seem to have the XKB extension.  The keyboard "
-"accessibility features will not operate without it."
-msgstr ""
-"Lomshini awutshengise njengonendawo yangaphandle ye XKB. Imininingwane "
-"yendawo yokushaya uma ubhala ngeke isebenze ngaphandle kwayo."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
-#: ../capplets/theme-switcher/theme-install.glade.h:1
-#: ../capplets/theme-switcher/theme-properties.glade.h:1
-msgid "*"
-msgstr "*"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
-msgid "<b>Enable Bo_unce Keys</b>"
-msgstr "<b>Nika amandla Qha_sha Izihluthulelo</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
-msgid "<b>Enable Slo_w Keys</b>"
-msgstr "<b>Nika amandla Kan_cane Izihluthulelo</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
-msgid "<b>Enable _Mouse Keys</b>"
-msgstr "<b>Nika amandla _Ingoso Izihluthulelo</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
-msgid "<b>Enable _Repeat Keys</b>"
-msgstr "<b>Nika amandla _Phinda Izihluthulelo</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
-msgid "<b>Enable _Sticky Keys</b>"
-msgstr "<b>Nika amandla _Namathelayo Izihluthulelo</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
-msgid "<b>Features</b>"
-msgstr "<b>Umumo</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
-msgid "<b>Toggle Keys</b>"
-msgstr "<b>Izihlushulelo zokugqoka</b>"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
-msgid "Basic"
-msgstr "Isisekelo"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
-msgid "Beep if key is re_jected"
-msgstr "Khala uma isihluthulelo sali_we"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
-msgid "Beep when _features turned on or off from keyboard"
-msgstr ""
-"Khala uma _umumo ucishiwe noma ukhanyisiwe kwindawo yokushaya uma ubhala"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
-msgid "Beep when _modifier is pressed"
-msgstr "Khala uma _isilungisi sipotshozwa"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
-msgid "Beep when an LED is turned on and two beeps when one is turned off."
-msgstr "Khala uma LED ikhanyisiwe futhi ikhale kabili uma enye icishiwe."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
-msgid "Beep when key is:"
-msgstr "Khala uma isihluthulelo siyi:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
-msgid "Del_ay:"
-msgstr "Chitha Isi_khathi:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
-msgid "Delay between keypress and pointer mo_vement:"
-msgstr ""
-"Chitha isikhathi phakathi kokupotshoza ikinombho nokuha_mba kwesikhombi:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
-msgid "Disa_ble if two keys pressed together"
-msgstr "Cis_ha uma amakinombho amabili epotshozwe kanye kanye"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
-msgid "E_nable Toggle Keys"
-msgstr "Nika ama_ndla amakinombho wokugqoka"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
-msgid "Filters"
-msgstr "Izisefo"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
-msgid "I_gnore duplicate keypresses within:"
-msgstr "Ungan_aki ukupotsozwa kabili kwangaphakathi:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
-msgid ""
-"Ignore all subsequent presses of the SAME key if they happen within a user "
-"selectable period of time."
-msgstr ""
-"Unganaki ukupotsozwa kaningi kwekinombho ngokufanayo umakwenzeka "
-"mgomsebenzisi okukhethwa isikhala sesikhathi."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
-msgid "Keyboard Accessibility Preferences (AccessX)"
-msgstr "Ukuthandeka nemvume yendawo yokushaya ethandekayo (AccessX)"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
-msgid "Ma_ximum pointer speed:"
-msgstr "Ukushesha okuphele_le kokukhomba:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
-msgid "Mouse Keys"
-msgstr "Amakinombho engoso"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
-msgid "Mouse _Preferences..."
-msgstr "_Okuthandekayo kwengoso..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
-msgid ""
-"Only accept keys after they have been pressed and held for a user adjustable "
-"amount of time."
-msgstr ""
-"Vumela amankinobho kuphela emuva kokupotshozwa abanjwa ukusebenziswa "
-"ngokuhlelwa kwesikhathi."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
-msgid ""
-"Perform multiple simultaneous key press operations by pressing modifier keys "
-"in sequence."
-msgstr ""
-"Yenza ngokupotshoza amankonombho amaningi ukusebenzisa amankinobho "
-"okulungisa ngokohlelo."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
-msgid "S_peed:"
-msgstr "I_jubane:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
-msgid "Time to acce_lerate to maximum speed:"
-msgstr "Isikhakthi sokukhu_phula ijubane eliphezulu:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
-msgid "Turn the numeric keypad into a mouse control pad."
-msgstr "Khanyisela inkinombho lokubala phakathi kweqweqwe lokulawula lwengoso."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
-msgid "_Disable if unused for:"
-msgstr "_Cisha uma ingasebenzisiwe:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
-msgid "_Enable keyboard accessibility features"
-msgstr "_Nika amandla umumo wemvume yendawo yokushaya"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
-msgid "_Import Feature Settings..."
-msgstr "_Ngenisa okuvela ngaphandle kwehlelo lomumo..."
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
-msgid "_Only accept keys held for:"
-msgstr "_Vuma kuphela amankinombho abanjelwe lokhu:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
-msgid "_Type to test settings:"
-msgstr "_Bhala ukuhlola uhelo:"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
-msgid "_accepted"
-msgstr "_yamukelekile"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
-msgid "_pressed"
-msgstr "_ipotshoziwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
-msgid "_rejected"
-msgstr "_yaliwe"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
-msgid "characters/second"
-msgstr "imibhalo/umzuzwana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
-msgid "milliseconds"
-msgstr "imizuzwana"
-
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
-msgid "pixels/second"
-msgstr "amachaphaza/umzuzu"
-
-#. set the timeout value  label with correct value of timeout
-#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
-#: ../capplets/mouse/gnome-mouse-properties.c:138
-#: ../capplets/mouse/gnome-mouse-properties.c:885
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
-#: ../capplets/windows/gnome-window-properties.glade.h:10
-msgid "seconds"
-msgstr "imizuzwana"
-
-#: ../capplets/background/background.desktop.in.in.h:1
-msgid "Change your Desktop Background settings"
-msgstr "Shintsha uhlelo lwesizinda sesiga-nyezi sakho"
-
-#: ../capplets/background/background.desktop.in.in.h:2
-msgid "Desktop Background"
-msgstr "Isizinda sesiganyezi"
-
-#: ../capplets/background/gnome-background-properties.glade.h:1
-msgid "<b>Desktop _Wallpaper</b>"
-msgstr "<b>_Iphepha elihlotsisiwe lwesizinda sesiga-nyezi</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:2
-msgid "<b>_Desktop Colors</b>"
-msgstr "<b>Imibala yobuso be _Siga-nyezi</b>"
-
-#: ../capplets/background/gnome-background-properties.glade.h:3
-msgid "Desktop Background Preferences"
-msgstr "Isizinda sesiga-nyezi esithandekayo"
-
-#: ../capplets/background/gnome-background-properties.glade.h:4
-msgid "Open a dialog to specify the color"
-msgstr ""
-
-#: ../capplets/background/gnome-background-properties.glade.h:5
-msgid "_Add Wallpaper"
-msgstr "_Faka iphepha elihlotshisiweyo"
-
-#: ../capplets/background/gnome-background-properties.glade.h:6
-msgid "_Style:"
-msgstr "_Inhlobo:"
-
-#: ../capplets/background/gnome-wp-capplet.c:74
-#: ../capplets/common/capplet-util.c:340
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
-#, c-format
-msgid "There was an error displaying help: %s"
-msgstr "Kube khona iphutha elibonisa usizo: %s"
-
-#: ../capplets/background/gnome-wp-capplet.c:1042
-#: ../capplets/background/gnome-wp-capplet.c:1060
-msgid "Centered"
-msgstr "Ngaphakathi"
-
-#: ../capplets/background/gnome-wp-capplet.c:1068
-#: ../capplets/background/gnome-wp-capplet.c:1085
-msgid "Fill Screen"
-msgstr "Gcwalisa ubuso besiga-nyezi"
-
-#: ../capplets/background/gnome-wp-capplet.c:1093
-#: ../capplets/background/gnome-wp-capplet.c:1110
-msgid "Scaled"
-msgstr "Ilinganisiwe"
-
-#: ../capplets/background/gnome-wp-capplet.c:1118
-#: ../capplets/background/gnome-wp-capplet.c:1135
-msgid "Tiled"
-msgstr "Ihlotshisiwe"
-
-#: ../capplets/background/gnome-wp-capplet.c:1159
-#: ../capplets/background/gnome-wp-capplet.c:1168
-msgid "Solid Color"
-msgstr "Umbala ongenelele"
-
-#: ../capplets/background/gnome-wp-capplet.c:1176
-#: ../capplets/background/gnome-wp-capplet.c:1185
-msgid "Horizontal Gradient"
-msgstr "Ubukhulu bokukhuphuka obuqondile buthe ndindilizi"
-
-#: ../capplets/background/gnome-wp-capplet.c:1193
-#: ../capplets/background/gnome-wp-capplet.c:1202
-msgid "Vertical Gradient"
-msgstr "Ubukhulu bokukhuphuka obuqondile buthe ndindilizi obumile"
-
-#. Create the file chooser dialog stuff here
-#: ../capplets/background/gnome-wp-capplet.c:1251
-msgid "Add Wallpaper"
-msgstr "Faka iphepha elihlotsisiwe"
-
-#: ../capplets/background/gnome-wp-info.c:57
-msgid "No Wallpaper"
-msgstr "Alikho iphepha elihlotshisiwe"
-
-#: ../capplets/background/gnome-wp-item.c:292
-#: ../capplets/background/gnome-wp-item.c:294
-msgid "pixel"
-msgid_plural "pixels"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../capplets/common/activate-settings-daemon.c:18
-msgid ""
-"Unable to start the settings manager 'gnome-settings-daemon'.\n"
-"Without the GNOME settings manager running, some preferences may not take "
-"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
-"settings manager may already be active and conflicting with the GNOME "
-"settings manager."
-msgstr ""
-"Ihlulekile ukuqala umphathi hlelo 'gnome-settings-daemon'.\n"
-"Ngaphandle kohlelo lomphathi weGNOME esebenza, ezinye ezithandekayo ngekhe "
-"zisebenze. Lokhu kungaveza inkinga nge bonobo, noma i-GNOME engekho "
-"(isibonelo KDE) umphathi wohlelo angahle sekaya sebenza abuye aphikisane "
-"nomphathi hlelo weGNOME."
-
-#: ../capplets/common/capplet-stock-icons.c:94
-#, c-format
-msgid "Unable to load capplet stock icon '%s'\n"
-msgstr "Ihlulekile ukufaka uphawu capplet stock '%s'\n"
-
-#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
-msgid "Just apply settings and quit"
-msgstr "Faka uhlelo uphume"
-
-#: ../capplets/common/capplet-util.c:243
-#: ../capplets/default-applications/gnome-default-applications-properties.c:765
-#: ../capplets/keyboard/gnome-keyboard-properties.c:225
-#: ../capplets/mouse/gnome-mouse-properties.c:1021
-#: ../capplets/sound/sound-properties-capplet.c:244
-msgid "Retrieve and store legacy settings"
-msgstr "Buyisa futhi ugcine uhlelo lobucebi"
-
-#: ../capplets/common/file-transfer-dialog.c:94
-#, c-format
-msgid "Copying file: %i of %i"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:122
-#, c-format
-msgid "Copying '%s'"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:193
-msgid "From URI"
-msgstr "Iphuma URI"
-
-#: ../capplets/common/file-transfer-dialog.c:194
-msgid "URI currently transferring from"
-msgstr "Okwamanje URI idlulisela okuphuma"
-
-#: ../capplets/common/file-transfer-dialog.c:201
-msgid "To URI"
-msgstr "Iya URI"
-
-#: ../capplets/common/file-transfer-dialog.c:202
-msgid "URI currently transferring to"
-msgstr "URI okwamanje edlulisela ku"
-
-#: ../capplets/common/file-transfer-dialog.c:209
-msgid "Fraction completed"
-msgstr "Isigamu sesibalo siqhediwe"
-
-#: ../capplets/common/file-transfer-dialog.c:210
-msgid "Fraction of transfer currently completed"
-msgstr "Ukudluliselwa kwesigamu sesibalo kuqediwe"
-
-#: ../capplets/common/file-transfer-dialog.c:217
-msgid "Current URI index"
-msgstr "Inkomba yamanje ye URI"
-
-#: ../capplets/common/file-transfer-dialog.c:218
-msgid "Current URI index - starts from 1"
-msgstr "Inkomba yamanje ye URI - iqala ku 1"
-
-#: ../capplets/common/file-transfer-dialog.c:225
-msgid "Total URIs"
-msgstr "URIs eziphelele"
-
-#: ../capplets/common/file-transfer-dialog.c:226
-msgid "Total number of URIs"
-msgstr "Inani eliphelele le URIs"
-
-#: ../capplets/common/file-transfer-dialog.c:327
-#: ../capplets/common/file-transfer-dialog.c:369
-msgid "Copying files"
-msgstr ""
-
-#: ../capplets/common/file-transfer-dialog.c:345
+#: panels/applications/cc-applications-panel.ui:31
 #, fuzzy
-msgid "From:"
-msgstr "Iphuma: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:349
-#, fuzzy
-msgid "To:"
-msgstr "Iya: %s"
-
-#: ../capplets/common/file-transfer-dialog.c:448
-msgid "Connecting..."
-msgstr "Isaxhumana..."
-
-#: ../capplets/common/gconf-property-editor.c:170
-msgid "Key"
-msgstr "Inkinombho"
-
-#: ../capplets/common/gconf-property-editor.c:171
-msgid "GConf key to which this property editor is attached"
-msgstr "Inkinombo Gconf lapho lesisakhi sokuhlela sinamatheliswe khona"
-
-#: ../capplets/common/gconf-property-editor.c:177
-msgid "Callback"
-msgstr "Bizela emuva"
-
-#: ../capplets/common/gconf-property-editor.c:178
-msgid "Issue this callback when the value associated with key gets changed"
-msgstr ""
-"Kipha lesisimemo sokubuyela emuva uma inani elithintekayo kumankinombho "
-"lishintshwa"
-
-#: ../capplets/common/gconf-property-editor.c:183
-msgid "Change set"
-msgstr "Shintsha uhlelo"
-
-#: ../capplets/common/gconf-property-editor.c:184
-msgid ""
-"GConf change set containing data to be forwarded to the gconf client on apply"
-msgstr ""
-"Gconf ishintsha uhlelo olukhungethe ulwazi olumelwe luthunyelwe "
-"kwikhasimende ye gconf ekuyingeniseni"
-
-#: ../capplets/common/gconf-property-editor.c:189
-msgid "Conversion to widget callback"
-msgstr "Ukuguqulwa kwewidget ebizela emuva"
-
-#: ../capplets/common/gconf-property-editor.c:190
-msgid ""
-"Callback to be issued when data are to be converted from GConf to the widget"
-msgstr ""
-"Isibizo sangemuva sizokhishwa uma imniningo imelwe ukushintshwa ukusuka ku "
-"Gconf ukuya kwiwidget"
-
-#: ../capplets/common/gconf-property-editor.c:195
-msgid "Conversion from widget callback"
-msgstr "Ukuguqulwa kwewidget ebizela emuva"
-
-#: ../capplets/common/gconf-property-editor.c:196
-msgid ""
-"Callback to be issued when data are to be converted to GConf from the widget"
-msgstr ""
-"Isibizo sangemuva sizokhishwa uma imniningo imelwe ukushintshwa ukusuka ku "
-"Gconf ukuya kwiwidget"
-
-#: ../capplets/common/gconf-property-editor.c:201
-msgid "UI Control"
-msgstr "Ukulawula UI"
-
-#: ../capplets/common/gconf-property-editor.c:202
-msgid "Object that controls the property (normally a widget)"
-msgstr "Into elawula leso sakha (okwejwayelekile yiwidget)"
-
-#: ../capplets/common/gconf-property-editor.c:217
-msgid "Property editor object data"
-msgstr "Umhleli wezakha into yemniningo"
-
-#: ../capplets/common/gconf-property-editor.c:218
-msgid "Custom data required by the specific property editor"
-msgstr "Imniningo yesiko icelwa yisakha esithize somhleli"
-
-#: ../capplets/common/gconf-property-editor.c:224
-msgid "Property editor data freeing callback"
-msgstr "Umhleli wesakha ukhulula imniningo yokushaya ngasemuva"
-
-#: ../capplets/common/gconf-property-editor.c:225
-msgid "Callback to be issued when property editor object data is to be freed"
-msgstr ""
-"Kuzo khishwa isibizo ngasemuva uma umhleli wesakha wento yomniningo ekhululwa"
-
-#: ../capplets/common/gconf-property-editor.c:1466
-#, c-format
-msgid ""
-"Couldn't find the file '%s'.\n"
-"\n"
-"Please make sure it exists and try again, or choose a different background "
-"picture."
-msgstr ""
-"Yehlulekile ukuthola ihele '%s'.\n"
-"\n"
-"Sicela uqiniseke ukuba yikhona uphinde uzame futhi, noma khetha isithombe "
-"esehlukile sesizinda sesiga-nyezi."
-
-#: ../capplets/common/gconf-property-editor.c:1474
-#, c-format
-msgid ""
-"I don't know how to open the file '%s'.\n"
-"Perhaps it's a kind of picture that is not yet supported.\n"
-"\n"
-"Please select a different picture instead."
-msgstr ""
-"Angikwazi ukuvula ihele '%s'.\n"
-"Mhlambe yinhlobo yesithombe esingakaxhaswa.\n"
-"\n"
-"Sicela ukhethe isithombe esihlukile kunalokho."
-
-#: ../capplets/common/gconf-property-editor.c:1593
-msgid "Please select an image."
-msgstr "Sicela ukhethe isithombe."
-
-#: ../capplets/common/gconf-property-editor.c:1598
-msgid "_Select"
-msgstr "_Khetha"
-
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
-msgid "Preferred Applications"
+msgid "No applications"
 msgstr "Izithobo ezithandekayo"
 
-#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
-msgid "Select your default applications"
-msgstr "Khetha izithobo zakho ezinephutha"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+#: panels/applications/cc-applications-panel.ui:34
 #, fuzzy
-msgid "Debian Sensible Browser"
-msgstr "Isiyaluzi solwembu esinephutha"
+msgid "Install some…"
+msgstr "_Faka indikimba..."
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
-msgid "Epiphany"
-msgstr "Epiphany"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
-msgid "Galeon"
-msgstr "Galeon"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
-msgid "Encompass"
-msgstr "Encompass"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+#: panels/applications/cc-applications-panel.ui:84
 #, fuzzy
-msgid "Firebird"
-msgstr "Firebird/FireFox"
+msgid "Open"
+msgstr "_Vula"
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
-msgid "Firefox"
+#: panels/applications/cc-applications-panel.ui:94
+#, fuzzy
+msgid "View Details"
+msgstr "Imniningwane yendikima"
+
+#: panels/applications/cc-applications-panel.ui:112
+#: panels/applications/cc-applications-panel.ui:119
+#: panels/keyboard/01-launchers.xml.in:16
+#: panels/keyboard/cc-input-chooser.ui:75
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:63
+#: panels/printers/new-printer-dialog.ui:252
+#: panels/region/cc-format-chooser.ui:82
+#: panels/search/gnome-search-panel.desktop.in.in:3 shell/cc-window.ui:41
+msgid "Search"
+msgstr "Hlola"
+
+#: panels/applications/cc-applications-panel.ui:113
+#: panels/applications/cc-applications-panel.ui:120
+msgid "Receive system searches and send results."
 msgstr ""
 
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
-#, fuzzy
-msgid "Mozilla"
-msgstr "Umyalezo we Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
-msgid "Netscape Communicator"
-msgstr "Umxhumanisi we Netscape"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
-msgid "Konqueror"
-msgstr "Konqueror"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
-msgid "W3M Text Browser"
-msgstr "W3M Isiyaluzi setekisi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
-msgid "Lynx Text Browser"
-msgstr "Lynx Isiyaluzi setekisi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
-msgid "Links Text Browser"
-msgstr "Links Isiyaluzi setekisi"
-
-#. The code in gnome-default-applications-properties.c makes sure
-#. * there is only one (the first entry in this list) Evolution entry
-#. * in the list shown to the user
-#.
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
-msgid "Evolution Mail Reader"
-msgstr "Umfundi miyalezo we-Evolution"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
-msgid "Balsa"
-msgstr "Balsa"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
-msgid "KMail"
-msgstr "Kmail"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
-msgid "Thunderbird"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
-msgid "Mozilla Mail"
-msgstr "Umyalezo we Mozilla"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
-msgid "Mutt"
-msgstr "Mutt"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
-#, fuzzy
-msgid "Debian Terminal Emulator"
-msgstr "Isixhumanisi esinephutha"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
-#, fuzzy
-msgid "GNOME Terminal"
-msgstr "Isixhumanisi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
-msgid "Standard XTerminal"
-msgstr "Isixhumi X esejwayekile"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
-msgid "NXterm"
-msgstr "Nxterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
-msgid "RXVT"
-msgstr "RXVT"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
-#, fuzzy
-msgid "aterm"
-msgstr "Nxterm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
-msgid "ETerm"
-msgstr "ETerm"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.c:123
-msgid "Please specify a name and a command for this editor."
-msgstr "Sicela uchaze igama nomyalo walombhali."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
-msgid "Add..."
-msgstr "Hlanganisa..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
-#, fuzzy
-msgid "C_ustom"
-msgstr "Isiko"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
-#, fuzzy
-msgid "C_ustom:"
-msgstr "Isiko"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
-msgid "Can open _URIs"
-msgstr ""
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
-#, fuzzy
-msgid "Can open multiple _files"
-msgstr "Lesisithobo singavula ohele _abaningi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
-msgid "Co_mmand:"
-msgstr "Umy_alo:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
-msgid "Custom Editor Properties"
-msgstr "Izakhi zomhleli zesiko"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
-msgid "Default Mail Reader"
-msgstr "Umfundi miyalezo onephutha"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
-msgid "Default Terminal"
-msgstr "Isixhumanisi esinephutha"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
-msgid "Default Text Editor"
-msgstr "Umhleli wetekisi onephutha"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
-msgid "Default Web Browser"
-msgstr "Isiyaluzi solwembu esinephutha"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
-msgid "Default Window Manager"
-msgstr "Umphathi wefasitela onephutha"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
-msgid "Delete"
-msgstr "Susa"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
-msgid "E_xec Flag:"
-msgstr "E_exc iflagi:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
-msgid "Edit..."
-msgstr "Hlela..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
-msgid "Mail Reader"
-msgstr "Umfundi milayezo"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
-#, fuzzy
-msgid "Run in a _terminal"
-msgstr "Hambisa phakathi koku_xhuma"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
-#, fuzzy
-msgid "Run in a t_erminal"
-msgstr "Hambisa phakathi koku_xhuma"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
-msgid ""
-"Select the window manager you want.  You will need to hit apply, wave the "
-"magic wand, and do a magic dance for it to work."
-msgstr ""
-"Khetha umphathi wefasitela omfunayo. Kumele ushaye usebenzisa, uthinte "
-"iwandi elizenzekelayo, ubuye wenze umdanso ukuze isebenze."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
-msgid "Terminal"
-msgstr "Isixhumanisi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
-msgid "Text Editor"
-msgstr "Uhele wetekisi"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
-msgid "Understands _Netscape Remote Control"
-msgstr "Yiqonda ukulawulwa ngongesi yi _Netscape"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
-msgid "Use this _editor to open text files in the file manager"
-msgstr "Sebenzisa lo_mhleli ukuvula ihele letekisi phakathi komphathi wehele"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
-msgid "Web Browser"
-msgstr "Isiyaluzi solwembu"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
-msgid "Window Manager"
-msgstr "Umphathi wefasitela"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
-#, fuzzy
-msgid "_Command:"
-msgstr "Umy_alo:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
-msgid "_Name:"
-msgstr "_Igama:"
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
-msgid "_Properties..."
-msgstr "_Izakhi..."
-
-#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
-#, fuzzy
-msgid "_Select:"
-msgstr "_Khetha"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:1
-msgid "Change screen resolution"
-msgstr "Shintsa isinqumo sobuso besiga-nyezi"
-
-#: ../capplets/display/display-properties.desktop.in.in.h:2
-msgid "Screen Resolution"
-msgstr "Isinqumo sobuso besiga-nyezi"
-
-#: ../capplets/display/main.c:345
-#, c-format
-msgid "%d Hz"
-msgstr "%d Hz"
-
-#: ../capplets/display/main.c:448
-msgid "_Resolution:"
-msgstr "_Isinqumo:"
-
-#: ../capplets/display/main.c:467
-msgid "Re_fresh rate:"
-msgstr "Ijubane eliphinde kabu_sha:"
-
-#: ../capplets/display/main.c:488
-msgid "Default Settings"
-msgstr "Izinhlelo ezinephutha"
-
-#: ../capplets/display/main.c:490
-#, c-format
-msgid "Screen %d Settings\n"
-msgstr "Ubuso besiga-nyezi %d Izinhlelo\n"
-
-#: ../capplets/display/main.c:516
-msgid "Screen Resolution Preferences"
-msgstr "Isinqumo esithandekayo sobuso besiga-nyezi"
-
-#: ../capplets/display/main.c:553
-#, c-format
-msgid "_Make default for this computer (%s) only"
-msgstr "_Yenza iphutha lwesiga-nyezi (%s) kuphela"
-
-#: ../capplets/display/main.c:571
-msgid "Options"
-msgstr "Ukhetho"
-
-#: ../capplets/display/main.c:592
-#, c-format
-msgid ""
-"Testing the new settings. If you don't respond in %d second the previous "
-"settings will be restored."
-msgid_plural ""
-"Testing the new settings. If you don't respond in %d seconds the previous "
-"settings will be restored."
-msgstr[0] ""
-"Ukuhlolwa kwezinhlelo ezintsha. Uma ungaphendule %d emzuzwaneni izinhlelo "
-"ezidlulile zizophindwa zibuyiswe."
-msgstr[1] ""
-"Ukuhlolwa kwezinhlelo ezintsha. Uma ungaphendule %d emizuzwaneni izinhlelo "
-"ezidlulile zizophindwa zibuyiswe."
-
-#: ../capplets/display/main.c:638
-msgid "Keep Resolution"
-msgstr "Gcina isinqumo"
-
-#: ../capplets/display/main.c:642
-msgid "Do you want to keep this resolution?"
-msgstr "Ufuna ukugcina lesisinqumo?"
-
-#: ../capplets/display/main.c:667
-msgid "Use _previous resolution"
-msgstr "Sebenzisa isinqumo _esidlulile"
-
-#: ../capplets/display/main.c:667
-msgid "_Keep resolution"
-msgstr "_Gcina isinqumo"
-
-#: ../capplets/display/main.c:818
-msgid ""
-"The X Server does not support the XRandR extension.  Runtime resolution "
-"changes to the display size are not available."
-msgstr ""
-"Isisebenzi X asixhasi XRandR yangaphandle. Isikhathi sokusebenza sesinqumo "
-"sishintsha isilinganiso somboniso azitholakali."
-
-#: ../capplets/display/main.c:826
-msgid ""
-"The version of the XRandR extension is incompatible with this program. "
-"Runtime changes to the display size are not available."
-msgstr ""
-"Ukulandisa kwe XRandR yangaphandle akusebenzi kuloluhlelo. Isikhathi "
-"sokusebenza sishintsha isilinganiso sokubonisa azitholakali."
-
-#: ../capplets/font/font-properties.desktop.in.in.h:1
-msgid "Font"
-msgstr "Isiqwema"
-
-#: ../capplets/font/font-properties.desktop.in.in.h:2
-msgid "Select fonts for the desktop"
-msgstr "Khetha isiqwema sesiga-nyezi"
-
-#: ../capplets/font/font-properties.glade.h:2
-msgid "<b>Font Rendering</b>"
-msgstr "<b>Ukutyelekana isiqwema</b>"
-
-#: ../capplets/font/font-properties.glade.h:3
-msgid "<b>Hinting</b>:"
-msgstr "<b>Isexwayiso</b>:"
-
-#: ../capplets/font/font-properties.glade.h:4
-msgid "<b>Smoothing</b>:"
-msgstr "<b>Bushelezi</b>:"
-
-#: ../capplets/font/font-properties.glade.h:5
-msgid "<b>Subpixel order</b>:"
-msgstr "<b>Umyalo wechashazana</b>:"
-
-#: ../capplets/font/font-properties.glade.h:6
-msgid "Best _shapes"
-msgstr "_Isimo esibalasele"
-
-#: ../capplets/font/font-properties.glade.h:7
-msgid "Best co_ntrast"
-msgstr "Ukukha_nya okubalasele"
-
-#: ../capplets/font/font-properties.glade.h:8
-msgid "D_etails..."
-msgstr "Im_niningwane..."
-
-#: ../capplets/font/font-properties.glade.h:9
-msgid "Font Preferences"
-msgstr "Isiqwema esithandekayo"
-
-#: ../capplets/font/font-properties.glade.h:10
-msgid "Font Rendering Details"
-msgstr "Imininingwane yokutyelekana isiqwema"
-
-#: ../capplets/font/font-properties.glade.h:11
-msgid "Go _to font folder"
-msgstr "Hamba _kwi sibaya sesiqwema"
-
-#: ../capplets/font/font-properties.glade.h:12
-msgid "Gra_yscale"
-msgstr "Isilinganiso esi_gray"
-
-#: ../capplets/font/font-properties.glade.h:13
-msgid "N_one"
-msgstr "L_utho"
-
-#: ../capplets/font/font-properties.glade.h:14
-msgid "R_esolution:"
-msgstr "I_siqumo:"
-
-#: ../capplets/font/font-properties.glade.h:15
-msgid "Sub_pixel (LCDs)"
-msgstr "Ama_chashazana (LCDs)"
-
-#: ../capplets/font/font-properties.glade.h:16
-msgid "Sub_pixel smoothing (LCDs)"
-msgstr "Ukushelela kwama_chashazana (LCDs)"
-
-#: ../capplets/font/font-properties.glade.h:17
-msgid "VB_GR"
-msgstr "VB_GR"
-
-#: ../capplets/font/font-properties.glade.h:18
-msgid "_Application font:"
-msgstr "Isiqwema _sesithobo:"
-
-#: ../capplets/font/font-properties.glade.h:19
-msgid "_BGR"
-msgstr "_BGR"
-
-#: ../capplets/font/font-properties.glade.h:20
-msgid "_Desktop font:"
-msgstr "_Isiqwema sesiga-nyezi:"
-
-#: ../capplets/font/font-properties.glade.h:21
-msgid "_Full"
-msgstr "_Igcwele"
-
-#: ../capplets/font/font-properties.glade.h:22
-msgid "_Medium"
-msgstr "_Iphakathi"
-
-#: ../capplets/font/font-properties.glade.h:23
-msgid "_Monochrome"
-msgstr "_Isiqalo esiphathele sodwa"
-
-#: ../capplets/font/font-properties.glade.h:24
-msgid "_None"
-msgstr "_Lutho"
-
-#: ../capplets/font/font-properties.glade.h:25
-msgid "_RGB"
-msgstr "_RGB"
-
-#: ../capplets/font/font-properties.glade.h:26
-msgid "_Slight"
-msgstr "_Cishe"
-
-#: ../capplets/font/font-properties.glade.h:27
-msgid "_Terminal font:"
-msgstr "_Isixhumi siqwema:"
-
-#: ../capplets/font/font-properties.glade.h:28
-msgid "_VRGB"
-msgstr "_VRGB"
-
-#: ../capplets/font/font-properties.glade.h:29
-msgid "_Window title font:"
-msgstr "_Isihloko sombhalo wefasitela:"
-
-#: ../capplets/font/font-properties.glade.h:30
-msgid "dots per inch"
-msgstr "amabala ngobude"
-
-#: ../capplets/font/main.c:488
-msgid "Font may be too large"
-msgstr "Iisqqwema singaba sikhulu kakhulu"
-
-#: ../capplets/font/main.c:492
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a size "
-"smaller than %d."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a size "
-"smaller than %d."
-msgstr[0] ""
-"Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kubelikhuni "
-"ukusebenzisa isiga-nyezi. Kuyakhuthazwa ukuba ukhethe isayizi encane kune %d."
-msgstr[1] ""
-"Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kubelikhuni "
-"ukusebenzisa isiga-nyezi. Kuyakhuthazwa ukuba ukhethe isayizi encane kune %d."
-
-#: ../capplets/font/main.c:505
-#, c-format
-msgid ""
-"The font selected is %d point large, and may make it difficult to "
-"effectively use the computer.  It is recommended that you select a smaller "
-"sized font."
-msgid_plural ""
-"The font selected is %d points large, and may make it difficult to "
-"effectively use the computer. It is recommended that you select a smaller "
-"sized font."
-msgstr[0] ""
-"Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kubelikhuni "
-"ukusebenzisa isiga-nyezi. Kuyakhuthazwa ukuba ukhethe isayizi encane."
-msgstr[1] ""
-"Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kebe likhuni "
-"ukusebenzisa isiga-nyezi. Kuya khuthazwa ukuba ukhethe isayizi encane."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:21
-msgid "New accelerator..."
-msgstr "Isigijimi esisha..."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:163
-#: ../capplets/keybindings/eggcellrendererkeys.c:164
-msgid "Accelerator key"
-msgstr "Inkinombho yesigijimi"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:173
-#: ../capplets/keybindings/eggcellrendererkeys.c:174
-msgid "Accelerator modifiers"
-msgstr "Izilungisi zesigijimi"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:182
-#: ../capplets/keybindings/eggcellrendererkeys.c:183
-msgid "Accelerator keycode"
-msgstr "Inkinombho lekhodi lesigijimi"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:193
-msgid "Accel Mode"
-msgstr "Uhlu Accel"
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:194
-msgid "The type of accelerator."
-msgstr "Uhlobo lwesigijimi."
-
-#: ../capplets/keybindings/eggcellrendererkeys.c:242
-#: ../capplets/keybindings/gnome-keybinding-properties.c:197
-#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+#: panels/applications/cc-applications-panel.ui:121
+#: panels/applications/cc-applications-panel.ui:163
+#: panels/applications/cc-applications-panel.ui:184
+#: panels/applications/cc-applications-panel.ui:198
+#: panels/applications/cc-applications-panel.ui:212
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:123
+#: panels/network/network-proxy.ui:107
 msgid "Disabled"
 msgstr "Ayinamandla"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:545
-msgid "<Unknown Action>"
-msgstr "<Isenzo esingaziwa>"
+#: panels/applications/cc-applications-panel.ui:126
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:3
+#, fuzzy
+msgid "Notifications"
+msgstr "_Indawo:"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:566
-msgid "Desktop"
-msgstr "Isiga-nyezi"
+#: panels/applications/cc-applications-panel.ui:127
+msgid "Show system notifications."
+msgstr ""
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:567
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
-msgid "Sound"
+#: panels/applications/cc-applications-panel.ui:133
+#, fuzzy
+msgid "Run in Background"
+msgstr "Sebenzisa _Isizinda"
+
+#: panels/applications/cc-applications-panel.ui:134
+msgid "Allow activity when the app is closed."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:140
+#, fuzzy
+msgid "Screenshots"
+msgstr "Ubuso besiga-nyezi"
+
+#: panels/applications/cc-applications-panel.ui:141
+msgid "Take pictures of the screen at any time."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:147
+#, fuzzy
+msgid "Change Wallpaper"
+msgstr "Alikho iphepha elihlotshisiwe"
+
+#: panels/applications/cc-applications-panel.ui:148
+msgid "Change the desktop wallpaper."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:154
+#: panels/applications/cc-applications-panel.ui:161
+#, fuzzy
+msgid "Sounds"
 msgstr "Umsindo"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:571
-msgid "Window Management"
-msgstr "Ukuphathwa kwefasitela"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:668
-#, c-format
-msgid ""
-"The shortcut \"%s\" is already used for:\n"
-" \"%s\"\n"
+#: panels/applications/cc-applications-panel.ui:155
+#: panels/applications/cc-applications-panel.ui:162
+msgid "Reproduce sounds."
 msgstr ""
-"Indlela emfishane \"%s\" sele yisebenziselwe uku:\n"
-" \"%s\"\n"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.c:700
-#, c-format
-msgid "Error setting new accelerator in configuration database: %s\n"
-msgstr "Iphutha lihlelela isigijimi esisha kumumo wokulonda: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:750
-#, c-format
-msgid "Error unsetting accelerator in configuration database: %s\n"
-msgstr "Iphutha alihleli isigijimi kumumo wokulonda: %s\n"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:857
-msgid "Action"
-msgstr "Isenzo"
-
-#: ../capplets/keybindings/gnome-keybinding-properties.c:881
-msgid "Shortcut"
+#: panels/applications/cc-applications-panel.ui:168
+#, fuzzy
+msgid "Inhibit Shortcuts"
 msgstr "Ukunqamula"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
-msgid "Keyboard Shortcuts"
+#: panels/applications/cc-applications-panel.ui:169
+#, fuzzy
+msgid "Block standard keyboard shortcuts."
 msgstr "Izinqamulo zendawo yokushaya uma ubhala"
 
-#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
-msgid ""
-"To edit a shortcut key, click on the corresponding row and type a new "
-"accelerator, or press backspace to clear."
+#: panels/applications/cc-applications-panel.ui:175
+#: panels/applications/cc-applications-panel.ui:182
+#: panels/camera/gnome-camera-panel.desktop.in.in:3
+msgid "Camera"
 msgstr ""
-"Ukuhlela inkinombho enqamulayo, potshoza emugqeni ongale ubhale isigijimi "
-"esisha, okanye potshoza inkinombho lokubuyisela isikhala emuva ukusula."
 
-#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
-msgid "Assign shortcut keys to commands"
-msgstr "Nikela iinkinombho kwimilayezo"
+#: panels/applications/cc-applications-panel.ui:176
+#: panels/applications/cc-applications-panel.ui:183
+msgid "Take pictures with the camera."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
-msgid "Unknown"
-msgstr "Ayaziwa"
+#: panels/applications/cc-applications-panel.ui:189
+#: panels/applications/cc-applications-panel.ui:196
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:3
+msgid "Microphone"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
-msgid "Layout"
-msgstr "Ukubonakala ngaphandle"
+#: panels/applications/cc-applications-panel.ui:190
+#: panels/applications/cc-applications-panel.ui:197
+msgid "Record audio with the microphone."
+msgstr ""
 
-#. The first radio in a group is to be "Default", meaning none of
-#. the below options are to be included in the selected list.
-#. This is a HIG-compliant alternative to allowing no
-#. selection in the group.
-#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#: panels/applications/cc-applications-panel.ui:203
+#: panels/applications/cc-applications-panel.ui:210
+#: panels/location/gnome-location-panel.desktop.in.in:3
+msgid "Location Services"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:204
+#: panels/applications/cc-applications-panel.ui:211
+msgid "Access device location data."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:222
+#: panels/applications/cc-applications-panel.ui:326
+msgid "Built-in Permissions"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:223
+msgid "System access that is required by the app"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:231
+msgid "File &amp; Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:239
+#: panels/applications/cc-applications-panel.ui:406
+msgid "Storage"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:301 shell/cc-panel-list.ui:108
+msgid "No results found"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:311
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:210
+#: shell/cc-panel-list.ui:117
+msgid "Try a different search"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:351
+msgid "File & Link Associations"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:374
+#, fuzzy
+msgid "File Types"
+msgstr "Faka uhlobo lwehele"
+
+#: panels/applications/cc-applications-panel.ui:380
+msgid "Link Types"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:390
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:131
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:234
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:25
+msgid "Reset"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:417
+msgid ""
+"How much disk space this application is occupying with app data and caches."
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:420
+#, fuzzy
+msgid "Application"
+msgstr "Isiqwema _sesithobo:"
+
+#: panels/applications/cc-applications-panel.ui:426
+msgid "Data"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:432
+msgid "Cache"
+msgstr ""
+
+#: panels/applications/cc-applications-panel.ui:438
+#, fuzzy
+msgid "<b>Total</b>"
+msgstr "<i>Ncanel</i>"
+
+#: panels/applications/cc-applications-panel.ui:448
+msgid "Clear Cache…"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:4
+msgid "Control various application permissions and settings"
+msgstr ""
+
+#: panels/applications/gnome-applications-panel.desktop.in.in:16
+msgid "application;flatpak;permission;setting;"
+msgstr ""
+
+#: panels/background/cc-background-panel.ui:9
+#, fuzzy
+msgid "Style"
+msgstr "Indlela:"
+
+#: panels/background/cc-background-panel.ui:49
+#: panels/mouse/cc-mouse-panel.ui:167 panels/mouse/cc-mouse-panel.ui:241
+#: panels/mouse/cc-mouse-panel.ui:331 panels/mouse/cc-mouse-panel.ui:349
+#: panels/mouse/cc-mouse-panel.ui:465 panels/mouse/cc-mouse-panel.ui:671
+#: panels/wacom/cc-wacom-stylus-page.ui:133
+#: panels/windows/cc-windows-panel.ui:12
 #, fuzzy
 msgid "Default"
 msgstr "Isikhombi esinephutha"
 
-#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
-msgid "Models"
-msgstr "Izifanekiso"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.c:106
-#, c-format
-msgid "There was an error launching the keyboard capplet : %s"
+#: panels/background/cc-background-panel.ui:79
+msgid "Dark"
 msgstr ""
-"Kube khona iphutha uma kungeniswa i-capplet yendawo yokushaya uma ubhala: %s"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:202
-msgid "_Accessibility"
-msgstr "_Ukutholakala"
+#: panels/background/cc-background-panel.ui:98
+#, fuzzy
+msgid "Background"
+msgstr "Sebenzisa _Isizinda"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:221
-#: ../capplets/keyboard/gnome-keyboard-properties.c:223
-#: ../capplets/sound/sound-properties-capplet.c:240
-#: ../capplets/sound/sound-properties-capplet.c:242
+#: panels/background/cc-background-panel.ui:104
+msgid "Add Picture…"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:3
+msgid "Appearance"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:4
+msgid "Change your background image or the UI colors"
+msgstr ""
+
+#: panels/background/gnome-background-panel.desktop.in.in:15
+msgid "Background;Wallpaper;Screen;Desktop;Style;Light;Dark;Appearance;"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:11 panels/camera/cc-camera-panel.ui:8
+#: panels/datetime/cc-datetime-panel.ui:172
+#: panels/diagnostics/cc-diagnostics-panel.ui:18
+#: panels/display/cc-night-light-page.ui:122
+#: panels/microphone/cc-microphone-panel.ui:9
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:15
+#: panels/universal-access/cc-repeat-keys-dialog.ui:15
+msgid "Enable"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:24
+msgid "No Bluetooth Found"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:25
+msgid "Plug in a dongle to use Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:31
+msgid "Bluetooth Turned Off"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:32
+msgid "Turn on to connect devices and receive file transfers."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:38
+msgid "Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:39
+msgid "Bluetooth is disabled when airplane mode is on."
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:42
+msgid "Turn Off Airplane Mode"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:56
+msgid "Hardware Airplane Mode is On"
+msgstr ""
+
+#: panels/bluetooth/cc-bluetooth-panel.ui:57
+msgid "Turn off the Airplane mode switch to enable Bluetooth."
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:3
+msgid "Bluetooth"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:4
+msgid "Turn Bluetooth on and off and connect your devices"
+msgstr ""
+
+#: panels/bluetooth/gnome-bluetooth-panel.desktop.in.in:19
+msgid "share;sharing;bluetooth;obex;"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:24
+msgid "Camera is Turned Off"
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:25
+msgid "No applications can capture photos or video."
+msgstr ""
+
+#: panels/camera/cc-camera-panel.ui:39
 msgid ""
-"Just apply settings and quit (compatibility only; now handled by daemon)"
-msgstr "Sebenzisa uhlelo uphe (ingacinwa kuphela; manje iphethwe yi-daemon)"
+"Use of the camera allows applications to capture photos and video. Disabling "
+"the camera may cause some applications to not function properly.\n"
+"\n"
+"Allow the applications below to use your camera."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.c:227
-msgid "Start the page with the typing break settings showing"
-msgstr "Qala ikhasi ngokubhala ngokunqamula ukhombisa izinhlelo"
+#: panels/camera/cc-camera-panel.ui:55
+msgid "No Applications Have Asked for Camera Access"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
-msgid "..."
-msgstr "..."
+#: panels/camera/gnome-camera-panel.desktop.in.in:4
+msgid "Protect your pictures"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
-msgid "<b>Cursor Blinking</b>"
-msgstr "<b>Isikhombi siyajampajampa</b>"
+#: panels/camera/gnome-camera-panel.desktop.in.in:20
+msgid "camera;photos;video;webcam;lock;private;privacy;"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
-msgid "<b>Repeat Keys</b>"
-msgstr "<b>Phinda amankinombho</b>"
+#: panels/color/cc-color-calibrate.ui:9
+msgid "Display Calibration"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
-msgid "<b>_Lock screen to enforce typing break</b>"
-msgstr "<b>_Vala ubusos ukufaka ngenkani umbhalo onqamulayo</b>"
+#: panels/color/cc-color-calibrate.ui:22
+#: panels/common/cc-language-chooser.ui:21
+#: panels/display/cc-display-panel.ui:31
+#: panels/info-overview/cc-info-overview-panel.ui:218
+#: panels/keyboard/cc-input-chooser.ui:11
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:23
+#: panels/network/cc-wifi-hotspot-dialog.ui:125
+#: panels/network/connection-editor/connection-editor.ui:14
+#: panels/printers/new-printer-dialog.ui:50
+#: panels/region/cc-format-chooser.ui:24
+#: panels/user-accounts/cc-add-user-dialog.ui:25
+#: panels/user-accounts/cc-fingerprint-dialog.ui:32
+#: panels/user-accounts/cc-password-dialog.ui:20
+#: panels/user-accounts/data/join-dialog.ui:17
+#: panels/wwan/cc-wwan-mode-dialog.ui:32
+#: panels/wwan/cc-wwan-network-dialog.ui:108
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:240
+msgid "_Cancel"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
-msgid "<small><i>Fast</i></small>"
-msgstr "<small><i>Shesha</i></small>"
+#. This starts the calibration process
+#: panels/color/cc-color-calibrate.ui:28
+msgid "_Start"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
-msgid "<small><i>Long</i></small>"
-msgstr "<small><i>Inde</i></small>"
+#. This resumes the calibration process
+#: panels/color/cc-color-calibrate.ui:34
+msgid "_Resume"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
-msgid "<small><i>Short</i></small>"
-msgstr "<small><i>Imfisha</i></small>"
+#. This button returns the user back to the color control panel
+#: panels/color/cc-color-calibrate.ui:40 panels/region/cc-format-chooser.ui:49
+#: panels/user-accounts/cc-fingerprint-dialog.ui:57
+msgid "_Done"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
-msgid "<small><i>Slow</i></small>"
-msgstr "<small><i>Nwabuza</i></small>"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
-msgid "A_vailable layouts:"
-msgstr "Umphandle o_tholakalayo:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
-msgid "All_ow postponing of breaks"
-msgstr "V_umela ukubuyiselwa emuva kwezinqamuli"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
-msgid "Check if breaks are allowed to be postponed"
-msgstr "Qaphela ukuba izinqamuli zivunyelwe ukuhlehliswa"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+#: panels/color/cc-color-panel.ui:4 panels/wacom/calibrator/calibrator.ui:40
 #, fuzzy
-msgid "Choose A Keyboard Model"
-msgstr "Khetha isifanekiso sendawo yokushaya uma ubhala"
+msgid "Screen Calibration"
+msgstr "Isinqumo sobuso besiga-nyezi"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
-#, fuzzy
-msgid "Choose A Layout"
-msgstr "Vala futhi _uphume"
+#: panels/color/cc-color-panel.ui:12
+msgid "Calibration Quality"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
-msgid "Cursor _blinks in text boxes and fields"
-msgstr "Isikhombi _sijampajampa phakathi kwebhokisi letekisi nemibhalo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
-msgid "Duration of the break when typing is disallowed"
-msgstr "Isikhathi sokunqamula uma ukubhala kungavumelekile"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
-msgid "Duration of work before forcing a break"
-msgstr "Isikhathi somsebenzi phambi kokufaka isinqamuli ngenkani"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
-msgid "Key presses _repeat when key is held down"
-msgstr "Inkinombho lipotshozwa _phinda uma lipotshozelwe phantsi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
-msgid "Keyboard Preferences"
-msgstr "Okuthandekayo endaweni yokushaya uma ubhala"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
-msgid "Keyboard _model:"
-msgstr "_Isifanekiso sendawo yokushaya uma ubhala:"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
-msgid "Layout Options"
-msgstr "Ukhetha umumo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
-msgid "Layouts"
-msgstr "Umumo"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+#: panels/color/cc-color-panel.ui:21
 msgid ""
-"Lock screen after a certain duration to help prevent repetitive keyboard use "
-"injuries"
-msgstr ""
-"Vala ubuso besiga-nyezi emuva kwesikhathi esithile ukusiza ukuvimba "
-"ukuziphinda ukusebenzisa izingozi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
-msgid "Microsoft Natural Keyboard"
-msgstr "Indawo yokushaya uma ubhala yendalo ye-Microsoft"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
-#, fuzzy
-msgid "Preview:"
-msgstr "_Buka futhi"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
-#, fuzzy
-msgid "Reset To De_faults"
-msgstr "Hlela kabusha emaphu_theni"
-
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
-msgid "Separate _group for each window"
+"Calibration will produce a profile that you can use to color manage your "
+"screen. The longer you spend on calibration, the better the quality of the "
+"color profile."
 msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
-msgid "Typing Break"
-msgstr "Ukunqamula ukubhala"
+#: panels/color/cc-color-panel.ui:28
+msgid ""
+"You will not be able to use your computer while calibration takes place."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
-msgid "_Accessibility..."
-msgstr "_Ukungenisela..."
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:40
+msgid "Quality"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#. This is the approximate time it takes to calibrate the display.
+#: panels/color/cc-color-panel.ui:51
+msgid "Approximate Time"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:82
+msgid "Calibration Device"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:90
+msgid "Select the sensor device you want to use for calibration."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:117
+msgid "Display Type"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:125
+msgid "Select the type of display that is connected."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:152
+msgid "Profile Whitepoint"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:160
+msgid ""
+"Select a display target white point. Most displays should be calibrated to a "
+"D65 illuminant."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:187
 #, fuzzy
-msgid "_Add..."
+msgid "Display Brightness"
+msgstr "Ukukhanya phezulu"
+
+#: panels/color/cc-color-panel.ui:195
+msgid ""
+"Please set the display to a brightness that is typical for you. Color "
+"management will be most accurate at this brightness level."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:202
+msgid ""
+"Alternatively, you can use the brightness level used with one of the other "
+"profiles for this device."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:214
+msgid "Profile Name"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:222
+msgid ""
+"You can use a color profile on different computers, or even create profiles "
+"for different lighting conditions."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:229
+msgid "Profile Name:"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:251
+msgid "Summary"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:259
+msgid "Profile successfully created!"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:290
+msgid "Copy profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:296
+msgid "Requires writable media"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:313
+msgid ""
+"You may find these instructions on how to use the profile on <a "
+"href=\"linux\">GNU/Linux</a>, <a href=\"osx\">Apple OS X</a> and <a "
+"href=\"windows\">Microsoft Windows</a> systems useful."
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:335
+msgid "Add Profile"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:373
+msgid ""
+"Problems detected. The profile may not work correctly. <a href=\"\">Show "
+"details.</a>"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:384
+#, fuzzy
+msgid "_Import File…"
+msgstr "_Ngenisa okuvela ngaphandle"
+
+#: panels/color/cc-color-panel.ui:390 panels/keyboard/cc-input-chooser.ui:18
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:41
+#: panels/printers/new-printer-dialog.ui:87
+#: panels/user-accounts/cc-add-user-dialog.ui:39
+#, fuzzy
+msgid "_Add"
 msgstr "Hlanganisa..."
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
-msgid "_Break interval lasts:"
-msgstr "_Umkhawulo wokugina wokunqamula:"
+#: panels/color/cc-color-panel.ui:424
+msgid "Each device needs an up to date color profile to be color managed."
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
-msgid "_Delay:"
-msgstr "_Bambezela:"
+#: panels/color/cc-color-panel.ui:434
+msgid "Learn more"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#: panels/color/cc-color-panel.ui:436
+msgid "Learn more about color management"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:473
+msgid "_Set for all users"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:475 panels/color/cc-color-panel.ui:483
+#: panels/color/cc-color-panel.ui:484
+msgid "Set this profile for all users on this computer"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:481
+msgid "_Enable"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:497
 #, fuzzy
-msgid "_Models:"
+msgid "_Add profile"
 msgstr "_Izifanekiso"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
-msgid "_Selected layouts:"
-msgstr "_Umumo okhethiwe:"
+#: panels/color/cc-color-panel.ui:503
+msgid "_Calibrate…"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
-msgid "_Speed:"
-msgstr "_Ijubane:"
+#: panels/color/cc-color-panel.ui:505
+msgid "Calibrate the device"
+msgstr ""
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
-msgid "_Work interval lasts:"
-msgstr "_Umsebenzi womkhawulo ekugcineni:"
+#: panels/color/cc-color-panel.ui:511
+#, fuzzy
+msgid "_Remove profile"
+msgstr "_Susa"
 
-#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
-msgid "minutes"
+#: panels/color/cc-color-panel.ui:517
+#, fuzzy
+msgid "_View details"
+msgstr "_Imniningwane"
+
+#: panels/color/cc-color-panel.ui:529
+msgid "Unable to detect any devices that can be color managed"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:568
+msgid "LCD"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:573
+msgid "LED"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:578
+msgid "CRT"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:583
+msgid "Projector"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:588
+msgid "Plasma"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:593
+msgid "LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:598
+msgid "LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:603
+msgid "LCD (white LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:608
+msgid "Wide gamut LCD (CCFL backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:613
+msgid "Wide gamut LCD (RGB LED backlight)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:630
+msgctxt "Calibration quality"
+msgid "High"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:631
+#, fuzzy
+msgid "40 minutes"
 msgstr "imizuzu"
 
-#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
-msgid "Set your keyboard preferences"
-msgstr "Hlela indawo zakho ozithandayo kwindawo yokushaya uma ubhala"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:559
-msgid "Unknown Cursor"
-msgstr "Isikhombisi esingaziwa"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:761
-msgid "Default Cursor"
-msgstr "Isikhombi esinephutha"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:762
-msgid "Default Cursor - Current"
-msgstr "Isikhombi esinephutha - Manje"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:763
-msgid "The default cursor that ships with X"
-msgstr "Isikhombi esinephutha esihambisana no-X"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:767
-msgid "White Cursor"
-msgstr "Isikhombi esimhlophe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:768
-msgid "White Cursor - Current"
-msgstr "Isikhombi esimhlophe - okwamanje"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:769
-msgid "The default cursor inverted"
-msgstr "Isikhombi esinephuthat sifakiwe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:773
-msgid "Large Cursor"
-msgstr "Isikhombi esikhulu"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:774
-msgid "Large Cursor - Current"
-msgstr "Isikhombi esikhulu - okwamanje"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:775
-msgid "Large version of normal cursor"
-msgstr "Umlandiso omkhulu wesikhombi esejwayelekile"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:779
-msgid "Large White Cursor - Current"
-msgstr "Isikhombi esimhlophe esikhulu - okwamanje"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:780
-msgid "Large White Cursor"
-msgstr "Isikhombi esimhlophe esikhulu"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:781
-msgid "Large version of white cursor"
-msgstr "Umlandisi omkhulu wesikhombi esimhlophe"
-
-#: ../capplets/mouse/gnome-mouse-properties.c:975
-msgid "Cursor Theme"
-msgstr "Indikimba yesikhombi"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
-msgid "<b>Double-Click Timeout </b>"
-msgstr "<b>Potshoza-kabili isikhathi siphelile </b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
-msgid "<b>Drag and Drop</b>"
-msgstr "<b>Dontsa futhi uphontse</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
-msgid "<b>Locate Pointer</b>"
-msgstr "<b>Beka isikhombisi endaweni</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
-msgid "<b>Mouse Orientation</b>"
-msgstr "<b>Ukuhanjiswa kwesingoso</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
-msgid "<b>Speed</b>"
-msgstr "<b>Ijubane</b>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
-msgid "<i>Fast</i>"
-msgstr "<i>Shesha</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
-msgid "<i>High</i>"
-msgstr "<i>Phezulu</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
-msgid "<i>Large</i>"
-msgstr "<i>Okukhulu</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
-msgid "<i>Low</i>"
-msgstr "<i>Okuphantsi</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
-msgid "<i>Slow</i>"
-msgstr "<i>Nwazayo</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
-msgid "<i>Small</i>"
-msgstr "<i>Ncanel</i>"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
-msgid "Buttons"
-msgstr "Amankinombho"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#: panels/color/cc-color-panel.ui:635
 #, fuzzy
-msgid "Cursor Size:"
-msgstr "Isayizi yesikhombi"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
-msgid "Cursors"
-msgstr "Izikhombi"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
-msgid "Highlight the _pointer when you press Ctrl"
-msgstr "Khanyisela _isikhombisi uma upotshoza Ctrl"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
-#, fuzzy
-msgid "Large"
-msgstr "_Okukhulu"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
-#, fuzzy
+msgctxt "Calibration quality"
 msgid "Medium"
 msgstr "_Iphakathi"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
-msgid "Motion"
-msgstr "Intshukumo"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
-msgid "Mouse Preferences"
-msgstr "Okuthandekayo kwesingoso"
-
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#: panels/color/cc-color-panel.ui:636
 #, fuzzy
-msgid "Small"
-msgstr "_Okuncane"
+msgid "30 minutes"
+msgstr "imizuzu"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
-msgid "_Acceleration:"
-msgstr "_Ukusheshisa:"
+#: panels/color/cc-color-panel.ui:640
+msgctxt "Calibration quality"
+msgid "Low"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
-msgid "_Left-handed mouse"
-msgstr "_Isingoso sesandla sasebunxele"
+#: panels/color/cc-color-panel.ui:641
+#, fuzzy
+msgid "15 minutes"
+msgstr "imizuzu"
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
-msgid "_Sensitivity:"
-msgstr "_Binyekile:"
+#: panels/color/cc-color-panel.ui:663
+msgid "Native to display"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
-msgid "_Threshold:"
-msgstr "_Umnyango:"
+#: panels/color/cc-color-panel.ui:667
+msgid "D50 (Printing and publishing)"
+msgstr ""
 
-#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
-msgid "_Timeout:"
+#: panels/color/cc-color-panel.ui:671
+msgid "D55"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:675
+msgid "D65 (Photography and graphics)"
+msgstr ""
+
+#: panels/color/cc-color-panel.ui:679
+msgid "D75"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:3
+#, fuzzy
+msgid "Color"
+msgstr "Umbala ongenelele"
+
+#: panels/color/gnome-color-panel.desktop.in.in:4
+msgid ""
+"Calibrate the color of your devices, such as displays, cameras or printers"
+msgstr ""
+
+#: panels/color/gnome-color-panel.desktop.in.in:19
+msgid "Color;ICC;Profile;Calibrate;Printer;Display;"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:5
+#, fuzzy
+msgid "Select Language"
+msgstr "_Khetha"
+
+#: panels/common/cc-language-chooser.ui:13
+msgid "_Select"
+msgstr "_Khetha"
+
+#: panels/common/cc-language-chooser.ui:58
+msgid "No languages found"
+msgstr ""
+
+#: panels/common/cc-language-chooser.ui:69
+msgid "More…"
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:42
+msgid "Some settings must be unlocked before they can be changed."
+msgstr ""
+
+#: panels/common/cc-permission-infobar.ui:59
+msgid "Unlock…"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:25
+msgid "Increment Hour"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:53
+msgid "Increment Minute"
+msgstr ""
+
+#: panels/common/cc-time-editor.ui:73
+#, fuzzy
+msgid "Time"
 msgstr "_Isikhathi siphelile:"
 
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
-msgid "Mouse"
-msgstr "Isingoso"
+#: panels/common/cc-time-editor.ui:94
+msgid "Decrement Hour"
+msgstr ""
 
-#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
-msgid "Set your mouse preferences"
-msgstr "Hlela okuthandekayo kwesingoso"
+#: panels/common/cc-time-editor.ui:122
+msgid "Decrement Minute"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
-msgid "Network Proxy"
-msgstr "Proxy yokuxhumana"
+#: panels/datetime/cc-datetime-panel.ui:15
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:3
+msgid "Date & Time"
+msgstr ""
 
-#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#: panels/datetime/cc-datetime-panel.ui:50
+msgid "Year"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:66
+msgid "Month"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:71
+msgid "January"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:72
+msgid "February"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:73
 #, fuzzy
-msgid "Set your network proxy preferences"
-msgstr "Okuthandekayo kwe-proxy yokuxhumana"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:1
-msgid "      "
-msgstr "      "
-
-#: ../capplets/network/gnome-network-preferences.glade.h:2
-#, fuzzy
-msgid "<b>D_irect internet connection</b>"
-msgstr "<b>_Ukuxhumana ngqo kolwembu</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:3
-msgid "<b>Ignore Host List</b>"
-msgstr ""
-
-#: ../capplets/network/gnome-network-preferences.glade.h:4
-msgid "<b>_Automatic proxy configuration</b>"
-msgstr "<b>_Umumo wozenzakalelayo we-proxy</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:5
-msgid "<b>_Manual proxy configuration</b>"
-msgstr "<b>_Ukulungisa umumo we-proxy ngesandla</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:6
-msgid "<b>_Use authentication</b>"
-msgstr "<b>_Sebenzisa izifungo</b>"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:7
-#, fuzzy
-msgid "Advanced Configuration"
-msgstr "Ukulungisa ngokuzenzekela _URL:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:8
-msgid "Autoconfiguration _URL:"
-msgstr "Ukulungisa ngokuzenzekela _URL:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:9
-msgid "HTTP Proxy Details"
-msgstr "Imniningwane emileyo ye-HTTP"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:10
-msgid "H_TTP proxy:"
-msgstr "H_TTP ezimele:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:11
-#, fuzzy
-msgid "Network Proxy Preferences"
-msgstr "Okuthandekayo kwe-proxy yokuxhumana"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:12
-msgid "Port:"
-msgstr "Itheku:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:13
-#, fuzzy
-msgid "Proxy Configuration"
-msgstr "Ukulingasa umumo wokuxhumana okuzimele"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:14
-msgid "S_ocks host:"
-msgstr "Umhathi weso_kisi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:15
-msgid "U_sername:"
-msgstr "I_gamamsebemzi:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:16
-msgid "_Details"
-msgstr "_Imniningwane"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:17
-msgid "_FTP proxy:"
-msgstr "_FTP ezimele:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:18
-msgid "_Password:"
-msgstr "_Igama lokungena:"
-
-#: ../capplets/network/gnome-network-preferences.glade.h:19
-msgid "_Secure HTTP proxy:"
-msgstr "_Vikela i-HTTP ezimele:"
-
-#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
-msgid "Enable sound and associate sounds with events"
-msgstr "Nika amandla umsindo futhi ujwayeze imisindo nemicimbi"
-
-#: ../capplets/sound/sound-properties-capplet.c:271
-#: ../capplets/sound/sound-properties.glade.h:6
-msgid "Sound Preferences"
-msgstr "Imisindo ethandekayo"
-
-#: ../capplets/sound/sound-properties.glade.h:1
-msgid "E_nable sound server startup"
-msgstr "Ni_ka amandla uphathi womsindo ukuqala"
-
-#: ../capplets/sound/sound-properties.glade.h:2
-msgid "Flash _entire screen"
-msgstr "Khanyisa _bonke ubuso"
-
-#: ../capplets/sound/sound-properties.glade.h:3
-msgid "Flash _window titlebar"
-msgstr "Khanyisa _ifasitela lohlu"
-
-#: ../capplets/sound/sound-properties.glade.h:4
-msgid "General"
-msgstr "Jikelele"
-
-#: ../capplets/sound/sound-properties.glade.h:5
-msgid "Sound Events"
-msgstr "Imicimbi yomsindo"
-
-#: ../capplets/sound/sound-properties.glade.h:7
-msgid "System Bell"
-msgstr "Insimbi yohlelo"
-
-#: ../capplets/sound/sound-properties.glade.h:8
-msgid "_Sound an audible bell"
-msgstr "_Khalisa insimbi ezakalayo"
-
-#: ../capplets/sound/sound-properties.glade.h:9
-msgid "_Sounds for events"
-msgstr "_Umsindo wemicimbi"
-
-#: ../capplets/sound/sound-properties.glade.h:10
-msgid "_Visual feedback:"
-msgstr "_Impendulo ebonakalayo:"
-
-#: ../capplets/theme-switcher/gnome-theme-details.c:347
-msgid ""
-"No themes could be found on your system.  This probably means that your "
-"\"Theme Preferences\" dialog was improperly installed, or you haven't "
-"installed the \"gnome-themes\" package."
-msgstr ""
-"Azikho indikima ezitholakele kuhlelo lwakho. Mhalbe lokhu kuchaza ukuthi "
-"\"Indikima ezithandekayo\" ibhokisana lifakwe kabi, noma mhlambe awukalifaki "
-"\"gnome-themes\" umthwalo."
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:227
-msgid "This theme is not in a supported format."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:244
-msgid "Failed to create temporary directory"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:264
-msgid ""
-"Can not install theme. \n"
-"The bzip2 utility is not installed."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:282
-#: ../capplets/theme-switcher/gnome-theme-installer.c:319
-#: ../capplets/theme-switcher/gnome-theme-installer.c:399
-#, fuzzy
-msgid "Installation Failed"
-msgstr "Ukufakwa kwendikima"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:302
-msgid ""
-"Can not install themes. \n"
-"The gzip utility is not installed."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:340
-#, c-format
-msgid ""
-"Icon Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:343
-#, c-format
-msgid "Gnome Theme %s correctly installed"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:346
-#, c-format
-msgid ""
-"Windows Border Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:349
-#, c-format
-msgid ""
-"Controls Theme %s correctly installed.\n"
-"You can select it in the theme details."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:357
-msgid "The theme is an engine. You need to compile the theme."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:374
-#, fuzzy
-msgid "The file format is invalid"
-msgstr "Ihele %s asiyilo ihele elifanele"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:468
-msgid "No theme file location specified to install"
-msgstr "Akukho ihele lendikima elinendawo elifakiwe"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:485
-msgid "The theme file location specified to install is invalid"
-msgstr "Indikima yehele echaziwe ukuthi ifakwe ayifanele"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:505
-#, c-format
-msgid ""
-"Insufficient permissions to install the theme in:\n"
-"%s"
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:526
-#, fuzzy
-msgid "The file format is invalid."
-msgstr "Ihele %s asiyilo ihele elifanele"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:553
-#, c-format
-msgid ""
-"%s is the path where the theme files will be installed. This can not be "
-"selected as the source location"
-msgstr ""
-"%s yindlela lapho indikima zohele zizofakwa khona. Lokhu ngeke kukhethwe "
-"ngenje ndawo eyimvelo"
-
-#: ../capplets/theme-switcher/gnome-theme-installer.c:607
-msgid ""
-"Cannot install theme.\n"
-"The tar program is not installed on your system."
-msgstr ""
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "Custom theme"
-msgstr "Indikima yesiko"
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:680
-msgid "You can save this theme by pressing the Save Theme button."
-msgstr "Ungahlenga lendikima ngokupotshoza inkinombho lokuhlenga eliyindikima."
-
-#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
-msgid ""
-"The default theme schemas could not be found on your system.  This means "
-"that you probably don't have metacity installed, or that your gconf is "
-"configured incorrectly."
-msgstr ""
-"Indikima eziyiphutha ezingamaqembu azitholakalanga phakathi kohlu. Lokhu "
-"kuchaza ukuthi awuna imetacity efakiwe, noma i-gconf yakho ifakwe kabi."
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:72
-msgid "Theme name must be present"
-msgstr "Igama lendikima kumele libe khona"
-
-#: ../capplets/theme-switcher/gnome-theme-save.c:104
-msgid "The theme already exists. Would you like to replace it?"
-msgstr "Indikima sele yikhona. Ingabe uthanda ukufaka enye kunale?"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
-msgid "Select themes for various parts of the desktop"
-msgstr "Khetha indikima zamalungu ahlukile esiga-nyezi"
-
-#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
-#: ../vfs-methods/themus/themus-properties-main.c:92
-msgid "Theme"
-msgstr "Indikima"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
-msgstr "<span size=\"larger\" weight=\"bold\">Faka indikima</span>"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:3
-msgid "Theme Installation"
-msgstr "Ukufakwa kwendikima"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:4
-msgid "_Install"
-msgstr "_Faka"
-
-#: ../capplets/theme-switcher/theme-install.glade.h:5
-msgid "_Location:"
-msgstr "_Indawo:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:2
-msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
-msgstr ""
-"<span size=\"larger\" weight=\"bold\">Hlenga indikima phakathi kwecwecwe</"
-"span>"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:3
-msgid "Apply _Background"
-msgstr "Sebenzisa _Isizinda"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:4
-msgid "Apply _Font"
-msgstr "Sebenzisa _Isiqwema"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:5
-msgid "Controls"
-msgstr "Abalawuli"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:6
-msgid "Icons"
-msgstr "Amaphawu"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:7
-msgid "New themes can also be installed by dragging them into the window."
-msgstr "Indikima ezinsha zinga fakwa ngokuzidontsela efasitileni."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:8
-msgid "Save Theme"
-msgstr "Hlenga indikima"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:9
-msgid "Select theme for the desktop"
-msgstr "Khetha indikima yesiga-nyezi"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:10
-msgid "Short _description:"
-msgstr "_Umlandiso omfishane:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:11
-msgid "Theme Details"
-msgstr "Imniningwane yendikima"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:12
-msgid "Theme Preferences"
-msgstr "Indikima ezithandekayo"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:13
-msgid "Theme _Details"
-msgstr "_Imniningwane yendikima"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:14
-msgid "This theme does not suggest any particular font or background."
-msgstr "Lendikima ayibonisi isiqwema esikhethekile noma isizinda."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:15
-msgid "This theme suggests a background:"
-msgstr "Lendikima ibonisa isizinda:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:16
-msgid "This theme suggests a font and a background:"
-msgstr "Lendikima ibonisa isiqwema nesizinda:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:17
-msgid "This theme suggests a font:"
-msgstr "Lendikima ibonisa isiqwqema:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:18
-msgid "Window Border"
-msgstr "Isiyaluzi Window"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:19
-msgid "_Go To Theme Folder"
-msgstr "_Hamba kwisibaya sendikimba"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:20
-msgid "_Install Theme..."
-msgstr "_Faka indikimba..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:21
-msgid "_Revert"
-msgstr "_Buyisela"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:22
-msgid "_Save Theme..."
-msgstr "_Hlenga indikimba..."
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:23
-msgid "_Theme name:"
-msgstr "_Igama lendikimba:"
-
-#: ../capplets/theme-switcher/theme-properties.glade.h:24
-msgid "theme selection tree"
-msgstr "isihlahla sokukhetha indikimba"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
-msgid "Customize the appearance of toolbars and menubars in applications"
-msgstr ""
-"Hlela ngokwesiko ukubonakala kwehlu lwamathuluzi nohlu phakathi kwezithobo"
-
-#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
-msgid "Menus & Toolbars"
-msgstr "Uhlu & amathuluzi"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
-msgid "<b>Behavior and Appearance</b>"
-msgstr "<b>Ukuziphatha nokubonakala</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
-msgid "<b>Preview</b>"
-msgstr "<b>Buka kuqala</b>"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
-msgid "C_ut"
-msgstr "S_ika"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
-msgid "Icons only"
-msgstr "Amaphawu wodwa"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
-msgid "Menu and Toolbar Preferences"
-msgstr "Uhlu namathuluzi athandekayo"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
-msgid "New File"
-msgstr "Ihele elisha"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
-msgid "Open File"
-msgstr "Vula ihele"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
-msgid "Save File"
-msgstr "Hlenga ihele"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
-msgid "Show _icons in menus"
-msgstr "Bonisa _amaphawu phakathi kohlu"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
-msgid "Text below icons"
-msgstr "Itekisi ngaphantsi kwamaphawu"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
-msgid "Text beside icons"
-msgstr "Itekisi eceleni namaphawu"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
-msgid "Text only"
-msgstr "Itekisi lodwa"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
-#, fuzzy
-msgid "Toolbar _button labels:"
-msgstr "Ilebhula _lekinombho lamathuluzi: "
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
-msgid "_Copy"
-msgstr "_Kopisha"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
-msgid "_Detachable toolbars"
-msgstr "_Amathulusi anganamatheli"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
-msgid "_Edit"
-msgstr "_Hlela"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
-msgid "_Editable menu accelerators"
-msgstr ""
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
-msgid "_File"
-msgstr "_Ihele"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
-msgid "_New"
-msgstr "_Okusha"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
-msgid "_Open"
-msgstr "_Vula"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
-msgid "_Paste"
-msgstr "_Namthelisa"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
-msgid "_Print"
-msgstr "_Bhala"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
-msgid "_Quit"
-msgstr "_Phuma"
-
-#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
-msgid "_Save"
-msgstr "_Hlenga"
-
-#: ../capplets/windows/gnome-window-properties.c:386
-#, c-format
-msgid ""
-"<b>Cannot start the preferences application for your window manager</b>\n"
-"\n"
-"%s"
-msgstr ""
-"<b>Ayikhoni ukuqala izithobo ezithandekayo zomphathi wefasitela wakho</b>\n"
-"\n"
-"%s"
-
-#: ../capplets/windows/gnome-window-properties.c:644
-msgid "Control"
-msgstr "Lawula"
-
-#: ../capplets/windows/gnome-window-properties.c:649
-msgid "Alt"
-msgstr "Alt"
-
-#: ../capplets/windows/gnome-window-properties.c:655
-msgid "Hyper"
-msgstr "Isiqalo esiphathelene nokweqisa"
-
-#: ../capplets/windows/gnome-window-properties.c:662
-msgid "Super (or \"Windows logo\")"
-msgstr "Phezulu (noma \"Windows yesihlokondaba\")"
-
-#: ../capplets/windows/gnome-window-properties.c:669
-msgid "Meta"
-msgstr "Meta"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:1
-msgid "<b>Movement Key</b>"
-msgstr "<b>Inkinombho lokuhamba</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:2
-msgid "<b>Titlebar Action</b>"
-msgstr "<b>Isenzo sesihloko sohlu</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:3
-msgid "<b>Window Selection</b>"
-msgstr "<b>Ukhetho Window</b>"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:4
-msgid "To _move a window, press-and-hold this key then grab the window:"
-msgstr ""
-"Uku_hambisa ifasitela, potshoza-ubuye-ubambe lenkinombho uphinde ubambe "
-"ifasitela:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:5
-msgid "Window Preferences"
-msgstr "Okuthadekayo kwe-Windows"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:6
-msgid "_Double-click titlebar to perform this action:"
-msgstr "_Potshoza-kabili uhlu lwesihloko ukwenza lesisenzo:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:7
-msgid "_Interval before raising:"
-msgstr "_Umkhathi phambi kokuphakama:"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:8
-msgid "_Raise selected windows after an interval"
-msgstr "_Phakamisa amafasitela akhethiwe emuva komkhawulo"
-
-#: ../capplets/windows/gnome-window-properties.glade.h:9
-msgid "_Select windows when the mouse moves over them"
-msgstr "_Khetha amafasitela uma isingoso sihamba phezu kwawo"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:1
-#, fuzzy
-msgid "Set your window properties"
-msgstr "Izakhi Windows"
-
-#: ../capplets/windows/window-properties.desktop.in.in.h:2
-msgid "Windows"
-msgstr "Windows"
-
-#: ../control-center/control-center-categories.c:257
-msgid "Others"
-msgstr "Abanye"
-
-#: ../control-center/control-center.c:42
-#, fuzzy
-msgid "Desktop Preferences"
-msgstr "Isizinda sesiga-nyezi esithandekayo"
-
-#: ../control-center/gnomecc.desktop.in.in.h:1
-msgid "GNOME Control Center"
-msgstr "GNOME umlawuli ophakathi"
-
-#: ../control-center/gnomecc.desktop.in.in.h:2
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
-msgid "The GNOME configuration tool"
-msgstr "Ithulusi lokumisa lwe-GNOME"
-
-#: ../gnome-settings-daemon/actions/acme.glade.h:1
-msgid "Volume"
-msgstr "Ivolumu"
-
-#: ../gnome-settings-daemon/factory.c:36
-msgid "Could not initialize Bonobo"
-msgstr "Ihlukile ukuqala u-Bonobo"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
-msgid "Slow Keys Alert"
-msgstr "Amankinombho angasheshi isexwayiso"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
-msgid ""
-"You just held down the Shift key for 8 seconds.  This is the shortcut for "
-"the Slow Keys feature, which affects the way your keyboard works."
-msgstr ""
-"Uqeda ukubambela phantsi inkinombho Shift imizuzwana 8. Le yindlela "
-"emfishane yemniningo engasheshi yamankinombho, leyo ethinta indlela indawo "
-"yokushaya uma ubhala esebenza ngayo."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
-msgid "Do you want to activate Slow Keys?"
-msgstr "Ingabe ufuna ukukhanyisa amankinombho angasheshi?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
-msgid "Do you want to deactivate Slow Keys?"
-msgstr "Ingabe ufuna ukucisha amankinombho angasheshi?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
-msgid "Sticky Keys Alert"
-msgstr "Ukwexwayiswa ngamankinombho angasheshi"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
-msgid ""
-"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
-"the Sticky Keys feature, which affects the way your keyboard works."
-msgstr ""
-"Uqeda ukupotshozela inkinombho Shift 5 emugqeni. Le yindlela emfishane "
-"yemniningo yamankinombho anamathelayo, lawo athinta indlela indawo yakho "
-"yokushaya uma ubhala esebenza ngayo."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
-msgid ""
-"You just pressed two keys at once, or pressed the Shift key 5 times in a "
-"row.  This turns off the Sticky Keys feature, which affects the way your "
-"keyboard works."
-msgstr ""
-"Uqeda ukupotsoza amankinombho amabili kanye, noma upotshoze inkinombho Shift "
-"izihlanhlo 5 emugqeni. Lokhu kucisha imniningwane yamankinombho "
-"anamathelayo, athintana nendlela indawo yakho yokushaya uma ubhala isebenza "
-"ngayo."
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
-msgid "Do you want to activate Sticky Keys?"
-msgstr "Ingabe ufuna ukukhanyisa amankinombho anamathelayo?"
-
-#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
-msgid "Do you want to deactivate Sticky Keys?"
-msgstr "Ingabe ufuna ukucisha amankinombho anmathelayo?"
-
-#: ../gnome-settings-daemon/gnome-settings-font.c:107
-#, c-format
-msgid ""
-"Cannot create the directory \"%s\".\n"
-"This is needed to allow changing cursors."
-msgstr ""
-"Ihlulekile ukudala indlela yamakheli \"%s\".\n"
-"Lokhu kuyadingeka ukuvumela izikhombi ezishintshayo."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
-#, c-format
-msgid "Key Binding (%s) has its action defined multiple times\n"
-msgstr "Ukuphetha inkinombho (%s) inesenzo sayo esichaziwe kaningi\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
-#, c-format
-msgid "Key Binding (%s) has its binding defined multiple times\n"
-msgstr "Ukuphetha inkinombho (%s) inokuphethao kwayo okuchaziwe kaningi\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
-#, c-format
-msgid "Key Binding (%s) is incomplete\n"
-msgstr "Ukuphetha inkinombho (%s) ayiphelele\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
-#, c-format
-msgid "Key Binding (%s) is invalid\n"
-msgstr "Ukuphetha inkinombho (%s) akufanele\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
-#, c-format
-msgid "It seems that another application already has access to key '%d'."
-msgstr "Ikhombisa sengathi esinye isithobo sinemvume vele kwinkinombho '%d'."
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
-#, c-format
-msgid "Key Binding (%s) is already in use\n"
-msgstr "Ukuphetha inkinombho (%s) iyasebenziswa\n"
-
-#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
-#, c-format
-msgid ""
-"Error while trying to run (%s)\n"
-"which is linked to the key (%s)"
-msgstr ""
-"Iphutha lenzekile uma usazama ukusebenza (%s)\n"
-"elixhunyanyiswe kwisihlushulelo (%s)"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
-#, fuzzy, c-format
-msgid ""
-"Error activating XKB configuration.\n"
-"It can happen under various circumstances:\n"
-"- a bug in libxklavier library\n"
-"- a bug in X server (xkbcomp, xmodmap utilities)\n"
-"- X server with incompatible libxkbfile implementation\n"
-"\n"
-"X server version data:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"If you report this situation as a bug, please include:\n"
-"- The result of <b>%s</b>\n"
-"- The result of <b>%s</b>"
-msgstr ""
-"Iphutha liyakhanyiswa uma kuhlelwa isimo XKB.\n"
-"Mhalmbe ngaphakathi kwesisekeli X senkinga.\n"
-"\n"
-"imniningwane yesisekeli somhumusho:\n"
-"%s\n"
-"%d\n"
-"%s\n"
-"Uma ubika loludaba njengephutha, sicela ufake:\n"
-"- Umphumela we <b>xprop -root | grep XKB</b>\n"
-"- Umphumela we <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/xkb</b>"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
-#, fuzzy
-msgid ""
-"You are using XFree 4.3.0.\n"
-"There are known problems with complex XKB configurations.\n"
-"Try using a simpler configuration or taking a fresher version of XFree "
-"software."
-msgstr ""
-"Usebenzisa Xfree 4.3.0 \n"
-"Kunezinkinga ezaziwayo ngokuhlangene XKB komumo wohlelo.\n"
-"Zama ukusebenzisa umumo olula noma thatha umhumusho wamanje wesoftware "
-"yeXFree."
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
-#, fuzzy
-msgid "Do _not show this warning again"
-msgstr "_Unga khombisi lomyalezo futhi"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
-msgid ""
-"The X system keyboard settings differ from your current GNOME keyboard "
-"settings.  Which set would you like to use?"
-msgstr ""
-"Uhlelo X lwendawo yokushaya uma ubhala uhlelo luhlukile kule yamanje ye-"
-"GNOME. Ingabe ufuna ukusebenzisa uhlelo oluphi?"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
-msgid "Use X settings"
-msgstr "Sebenzisa uhlelo X"
-
-#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
-msgid "Use GNOME settings"
-msgstr "Sebenzisa uhleo GNOME"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
-#, c-format
-msgid ""
-"Couldn't execute command: %s\n"
-"Verify that this command exists."
-msgstr ""
-"Ihlulekile ukubhala umyalo: %s\n"
-"Qiniseka ukuba lomyalo usukhona."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
-msgid ""
-"Couldn't put the machine to sleep.\n"
-"Verify that the machine is correctly configured."
-msgstr ""
-"Ihlulekile ukulalisa umashini.\n"
-"Bhekisisa ukuba umashini uhlelwe kahle."
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
-#, c-format
-msgid "Permissions on the file %s are broken\n"
-msgstr "Imvume phezu kwehele %s zinqamukile\n"
-
-#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
-msgid ""
-"Couldn't load the Glade file.\n"
-"Make sure that this daemon is properly installed."
-msgstr ""
-"Ihlulekile ukufaka ihele le-Glade.\n"
-"Qiniseka ukuba le-daemon ifakwe ngokufanele."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
-#, c-format
-msgid ""
-"There was an error starting up the screensaver:\n"
-"\n"
-"%s\n"
-"\n"
-"Screensaver functionality will not work in this session."
-msgstr ""
-"Kube khona iphutha makuqalwa isigcini sobuso besiga-nyezi:\n"
-"\n"
-"%s\n"
-"\n"
-"Ukusebenza kwesigcini sobuso besiga-nyezi ngekhe kusebenze kulesiqephu."
-
-#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
-msgid "_Do not show this message again"
-msgstr "_Unga khombisi lomyalezo futhi"
-
-#: ../gnome-settings-daemon/gnome-settings-sound.c:129
-#, c-format
-msgid "Couldn't load sound file %s as sample %s"
-msgstr "Ihlulekile ukufaka ihele lomsindo %s njenge sibonelo %s"
-
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
-#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
-msgid "Cannot determine user's home directory"
-msgstr "Ihlulekile ukuthola ikheli lomsebenzisi"
-
-#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
-#, c-format
-msgid "GConf key %s set to type %s but its expected type was %s\n"
-msgstr ""
-"Inkinombho GConf %s lihlelelwe ukubhala %s kepha ukubhala okulindelekile "
-"bekuyi %s\n"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
-#, fuzzy
-msgid "A_vailable files:"
-msgstr "Umphandle o_tholakalayo:"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
-#, fuzzy
-msgid "Do _not show this warning again."
-msgstr "_Unga khombisi lomyalezo futhi"
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
-msgid "Load modmap files"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
-msgid "Would you like to load the modmap file(s)?"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
-msgid "_Load"
-msgstr ""
-
-#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
-#, fuzzy
-msgid "_Loaded files:"
-msgstr "_Izifanekiso"
-
-#: ../gnome-settings-daemon/reaper.c:103
-msgid "Error creating signal pipe."
-msgstr "Iphutha lidala ithumbu lezimpawu."
-
-#: ../libbackground/applier.c:255
-msgid "Type"
-msgstr "Uhlobo"
-
-#: ../libbackground/applier.c:256
-msgid ""
-"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
-"for preview"
-msgstr ""
-"Uhlobo le bg_sebenzisa: BG_APPLIER_ROOT lempande yefasitela noma "
-"BG_APPLIER_PREVIEW ukubukwa kabusha"
-
-#: ../libbackground/applier.c:263
-msgid "Preview Width"
-msgstr "Bheka kabusha ububanzi"
-
-#: ../libbackground/applier.c:264
-msgid "Width if applier is a preview: Defaults to 64."
-msgstr "Dontsa kabanzi uma isisebenzisi siphinda: Amaphutha ku 64."
-
-#: ../libbackground/applier.c:271
-msgid "Preview Height"
-msgstr "Hlolisisa ubude"
-
-#: ../libbackground/applier.c:272
-msgid "Height if applier is a preview: Defaults to 48."
-msgstr "Ubude uma isesebenzisi siphinda: Amaphutha ku 48."
-
-#: ../libbackground/applier.c:279
-msgid "Screen"
-msgstr "Ubuso besiga-nyezi"
-
-#: ../libbackground/applier.c:280
-msgid "Screen on which BGApplier is to draw"
-msgstr "Ubuso besiga-nyezi lapho I-BGApllier izokhipha"
-
-#: ../libgswitchit/gswitchit_config.c:1035
-#, fuzzy, c-format
-msgid "There was an error loading an image: %s"
-msgstr "Kube khona iphutha elibonisa usizo: %s"
-
-#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
-msgid "The sound file for this event does not exist."
-msgstr "Ihele lomsindo lwalomcimbi alikho sanhlobo."
-
-#: ../libsounds/sound-view.c:149
-msgid ""
-"The sound file for this event does not exist.\n"
-"You may want to install the gnome-audio package\n"
-"for a set of default sounds."
-msgstr ""
-"Ihele lomsindo lwalomcimbi alikho sanhlobo.\n"
-"Ungafuna ukufaka isisakazi-gnome somthwalo\n"
-"kumahlelo emniningwane yomsindo enephutha."
-
-#: ../libsounds/sound-view.c:224
-#, c-format
-msgid "The file %s is not a valid wav file"
-msgstr "Ihele %s asiyilo ihele elifanele"
-
-#: ../libsounds/sound-view.c:289
-msgid "Event"
-msgstr "Umcimbi"
-
-#: ../libsounds/sound-view.c:298
-msgid "Sound File"
-msgstr "Ihele lomsindo"
-
-#: ../libsounds/sound-view.c:314
-msgid "_Sounds:"
-msgstr "_Umsindo:"
-
-#: ../libsounds/sound-view.c:328
-msgid "Sound _file:"
-msgstr "Ihele _lomsindo:"
-
-#: ../libsounds/sound-view.c:332
-msgid "Select Sound File"
-msgstr "Khetha ihele lomsindo"
-
-#: ../libsounds/sound-view.c:356
-msgid "_Play"
-msgstr "_Dlala"
-
-#: ../libsounds/sound-view.c:366
-msgid "_Remove"
-msgstr "_Susa"
-
-#: ../libwindow-settings/gnome-wm-manager.c:320
-#, c-format
-msgid "Window manager \"%s\" has not registered a configuration tool\n"
-msgstr "Umphathi wefasitela \"%s\" akabhalisile ithulusi lokulungisa umumo\n"
-
-#: ../libwindow-settings/metacity-window-manager.c:378
-msgid "Maximize"
-msgstr "Khulisa"
-
-#: ../libwindow-settings/metacity-window-manager.c:379
-msgid "Roll up"
-msgstr "Yaluzisela phezulu"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
-msgid ""
-"If true, the mime handlers for text/plain and text/* will be kept in sync"
-msgstr ""
-"Uma kuyiqiniso, abaphathi be-mime text/plain and text/* lizogcinwa phakathi "
-"kwe-sync"
-
-#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
-msgid "Sync text/plain and text/* handlers"
-msgstr "Sync text/plain and text/* abaphathi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
-msgid "Brightness down"
-msgstr "Ukukhanya phantsi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
-msgid "Brightness down's shortcut."
-msgstr "Ukunqamula kokukhanya okuphantsi."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
-msgid "Brightness up"
-msgstr "Ukukhanya phezulu"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
-msgid "Brightness up's shortcut."
-msgstr "Ukunqamula kokukhanya okuphezulu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
-msgid "E-mail"
-msgstr "Umyalezo-kagesi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
-msgid "E-mail's shortcut."
-msgstr "Ukunqamula komyalezo-kagesi."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
-msgid "Eject"
-msgstr "Khipa"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
-msgid "Eject's shortcut."
-msgstr "Ukunqamula kokukhipha."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
-msgid "Home folder"
-msgstr "Isibaya sasekhaya"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
-msgid "Home folder's shortcut."
-msgstr "Ukunqamula kwesibaya sasekhaya."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
-msgid "Launch help browser"
-msgstr "Ngenisa usizo lwesiyaluzi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
-msgid "Launch help browser's shortcut."
-msgstr "Ngenisa usizo lokunqamula isiyaluzi."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
-msgid "Launch web browser"
-msgstr "Ngenisa isiyaluzi solwembu"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
-msgid "Launch web browser's shortcut."
-msgstr "Ngenisa ukunqamula kwesiyaluzi solwembu."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
-msgid "Lock screen"
-msgstr "Vala ubuso besiga-nyezi"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
-msgid "Lock screen's shortcut."
-msgstr "Vala ukunqamula kobuso besi-nyezi."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
-msgid "Log out"
-msgstr "Phuma"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
-msgid "Log out's shortcut."
-msgstr "Phuma ngokunqamula."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
-msgid "Next track key's shortcut."
-msgstr "Okulandela kokunqamula kwenkinombho."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
-msgid "Pause"
-msgstr "Yima isikhashana"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
-msgid "Pause key's shortcut."
-msgstr "Inkinombho lokunqamula kokuma isikhashana."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
-msgid "Play (or play/pause)"
-msgstr "Dlala (noma dlala/misa isikhashana)"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
-msgid "Play (or play/pause) key's shortcut."
-msgstr "Dlala (noma dlala/misa isikhashana) inkinombho lokunqamula."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
-msgid "Previous track key's shortcut."
-msgstr "Ingoma edlulile inkinombho lokunqamula."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
-msgid "Search"
+msgid "March"
 msgstr "Hlola"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
-msgid "Search's shortcut."
+#: panels/datetime/cc-datetime-panel.ui:74
+msgid "April"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:75
+msgid "May"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:76
+msgid "June"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:77
+msgid "July"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:78
+msgid "August"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:79
+msgid "September"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:80
+msgid "October"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:81
+msgid "November"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:82
+msgid "December"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:92
+#, fuzzy
+msgid "Day"
+msgstr "Chitha Isi_khathi:"
+
+#: panels/datetime/cc-datetime-panel.ui:113
+msgid "Time Zone"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:130
+#, fuzzy
+msgid "Search for a city"
 msgstr "Ukuqamula uma uhlola."
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
-msgid "Skip to next track"
-msgstr "Dlulela engomeni elandelayo"
+#: panels/datetime/cc-datetime-panel.ui:164
+msgid "Automatic _Date &amp; Time"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
-msgid "Skip to previous track"
-msgstr "Buyela engomeni edlulile"
+#: panels/datetime/cc-datetime-panel.ui:165
+msgid "Requires internet access"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
-msgid "Sleep"
-msgstr "Cisha"
+#: panels/datetime/cc-datetime-panel.ui:180
+msgid "Date &amp; _Time"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
-msgid "Sleep's shortcut."
-msgstr "Ukunqamula uma ucisha."
+#: panels/datetime/cc-datetime-panel.ui:204
+msgid "Automatic Time _Zone"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
-msgid "Stop playback key"
-msgstr "Inkinombho lokunmisa ukudlala"
+#: panels/datetime/cc-datetime-panel.ui:205
+msgid "Requires location services enabled and internet access"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
-msgid "Stop playback key's shortcut."
-msgstr "Inkinombho lokumisa elinqamulayo."
+#: panels/datetime/cc-datetime-panel.ui:212
+#: panels/display/cc-display-settings.ui:23
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:44
+#: panels/location/cc-location-panel.ui:9 panels/screen/cc-screen-panel.ui:40
+#: panels/screen/cc-screen-panel.ui:76 panels/screen/cc-screen-panel.ui:110
+#, fuzzy
+msgid "Enabled"
+msgstr "Ayinamandla"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+#: panels/datetime/cc-datetime-panel.ui:220
+msgid "Time Z_one"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:243
+msgid "Clock"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:246
+msgid "Time _Format"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:261
+msgid "Week Day"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:273
+msgid "Date"
+msgstr ""
+
+#: panels/datetime/cc-datetime-panel.ui:285
+#, fuzzy
+msgid "Seconds"
+msgstr "imizuzwana"
+
+#: panels/datetime/cc-datetime-panel.ui:299
+#, fuzzy
+msgid "Calendar"
+msgstr "Uhla_ngothi..."
+
+#: panels/datetime/cc-datetime-panel.ui:302
+msgid "Week Numbers"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:4
+msgid "Change the date and time, including time zone"
+msgstr ""
+
+#: panels/datetime/gnome-datetime-panel.desktop.in.in:15
+msgid "Clock;Timezone;Location;"
+msgstr ""
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:11
+#, fuzzy
+msgid "Change system time and date settings"
+msgstr "Shintsha uhlelo lwesizinda sesiga-nyezi sakho"
+
+#: panels/datetime/org.gnome.controlcenter.datetime.policy.in:12
+msgid "To change time or date settings, you need to authenticate."
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:23
+msgid "_Web"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:33
+#, fuzzy
+msgid "_Mail"
+msgstr "Kmail"
+
+#: panels/default-apps/cc-default-apps-panel.ui:47
+#, fuzzy
+msgid "_Calendar"
+msgstr "Uhla_ngothi..."
+
+#: panels/default-apps/cc-default-apps-panel.ui:61
+msgid "M_usic"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:75
+msgid "_Video"
+msgstr ""
+
+#: panels/default-apps/cc-default-apps-panel.ui:134
+#: panels/removable-media/cc-removable-media-panel.ui:127
+msgid "_Photos"
+msgstr ""
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:3
+#, fuzzy
+msgid "Default Applications"
+msgstr "Izithobo ezithandekayo"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:4
+#, fuzzy
+msgid "Configure Default Applications"
+msgstr "Khetha izithobo zakho ezinephutha"
+
+#: panels/default-apps/gnome-default-apps-panel.desktop.in.in:19
+msgid "default;application;preferred;media;"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:8
+msgid "Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/cc-diagnostics-panel.ui:11
+msgid "_Automatic Problem Reporting"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:3
+msgid "Diagnostics"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:4
+msgid "Report your problems"
+msgstr ""
+
+#: panels/diagnostics/gnome-diagnostics-panel.desktop.in.in:20
+msgid "diagnostics;crash;"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:43
+#: panels/network/connection-editor/connection-editor.ui:21
+#, fuzzy
+msgid "_Apply"
+msgstr "_Sebenzisa isiqwema"
+
+#: panels/display/cc-display-panel.ui:78 panels/display/cc-display-panel.ui:221
+#: panels/display/cc-display-panel.ui:260 panels/network/cc-wifi-panel.ui:16
+#: panels/printers/new-printer-dialog.ui:64
+#: panels/region/cc-format-chooser.ui:37
+#: panels/user-accounts/cc-fingerprint-dialog.ui:44
+#: panels/user-accounts/cc-user-panel.ui:31
+#: panels/wacom/cc-wacom-stylus-page.ui:136
+#: panels/wwan/cc-wwan-apn-dialog.ui:21
+msgid "Back"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:100
+msgid "Display Settings Disabled"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:111
+msgid "Multiple Displays"
+msgstr ""
+
+#. 'Join' as in 'Join displays'
+#: panels/display/cc-display-panel.ui:120
+msgid "Join"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:127
+msgid "Mirror"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:155
+msgid "Contains top bar and Activities"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:156
+msgid "Primary Display"
+msgstr ""
+
+#. This is the redshift functionality where we suppress blue light when the sun has gone down
+#: panels/display/cc-display-panel.ui:177
+#: panels/display/cc-display-panel.ui:228
+#: panels/display/cc-night-light-page.ui:115
+msgid "Night Light"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:43
+#, fuzzy
+msgctxt "display setting"
+msgid "Orientation"
+msgstr "<b>Ukuhanjiswa kwesingoso</b>"
+
+#: panels/display/cc-display-settings.ui:50
+#, fuzzy
+msgctxt "display setting"
+msgid "Resolution"
+msgstr "_Isinqumo:"
+
+#: panels/display/cc-display-settings.ui:57
+#, fuzzy
+msgid "Refresh Rate"
+msgstr "Ijubane eliphinde kabu_sha:"
+
+#: panels/display/cc-display-settings.ui:64
+msgid "Adjust for TV"
+msgstr ""
+
+#: panels/display/cc-display-settings.ui:78
+#: panels/display/cc-display-settings.ui:93
+#, fuzzy
+msgctxt "display setting"
+msgid "Scale"
+msgstr "Ilinganisiwe"
+
+#: panels/display/cc-display-settings.ui:101
+#, fuzzy
+msgctxt "display setting"
+msgid "Fractional Scaling"
+msgstr "Isigamu sesibalo siqhediwe"
+
+#: panels/display/cc-display-settings.ui:102
+msgctxt "display setting"
+msgid "May increase power usage, lower speed, or reduce display sharpness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:22
+msgid "Night Light unavailable"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:33
+msgid ""
+"This could be the result of the graphics driver being used, or the desktop "
+"being used remotely"
+msgstr ""
+
+#. Inhibit the redshift functionality until the next day starts
+#: panels/display/cc-night-light-page.ui:58
+msgid "Temporarily Disabled Until Tomorrow"
+msgstr ""
+
+#. This cancels the redshift inhibit.
+#: panels/display/cc-night-light-page.ui:72
+msgid "Restart Filter"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:95
+msgid ""
+"Night light makes the screen color warmer. This can help to prevent eye "
+"strain and sleeplessness."
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:132
+msgid "Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:140
+msgid "Sunset to Sunrise"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:141
+msgid "Manual Schedule"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:154
+#: panels/region/cc-format-preview.ui:35
+msgid "Times"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:167
+#, fuzzy
+msgid "From"
+msgstr "Iphuma: %s"
+
+#: panels/display/cc-night-light-page.ui:192
+#: panels/display/cc-night-light-page.ui:279
+msgid "Hour"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:198
+#: panels/display/cc-night-light-page.ui:285
+msgid ":"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:215
+#: panels/display/cc-night-light-page.ui:302
+#, fuzzy
+msgid "Minute"
+msgstr "imizuzu"
+
+#. This is the short form for the time period in the morning
+#: panels/display/cc-night-light-page.ui:225
+#: panels/display/cc-night-light-page.ui:312
+msgid "AM"
+msgstr ""
+
+#. This is the short form for the time period in the afternoon
+#: panels/display/cc-night-light-page.ui:237
+#: panels/display/cc-night-light-page.ui:324
+msgid "PM"
+msgstr ""
+
+#: panels/display/cc-night-light-page.ui:254
+#, fuzzy
+msgid "To"
+msgstr "Iya: %s"
+
+#: panels/display/cc-night-light-page.ui:360
+msgid "Color Temperature"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:3
+msgid "Displays"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:4
+msgid "Choose how to use connected monitors and projectors"
+msgstr ""
+
+#: panels/display/gnome-display-panel.desktop.in.in:19
+msgid ""
+"Panel;Projector;xrandr;Screen;Resolution;Refresh;Monitor;Night;Light;Blue;"
+"redshift;color;sunset;sunrise;"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-boot-dialog.ui:53
+msgid ""
+"Secure boot prevents malicious software from being loaded when the device "
+"starts.\n"
+"\n"
+"For more information, contact the hardware manufacturer or IT support."
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:22
+msgid "Security Level"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:88
+msgid "Level 1"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:124
+msgid "Level 2"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-dialog.ui:160
+msgid "Level 3"
+msgstr ""
+
+#: panels/firmware-security/cc-firmware-security-panel.ui:150
+#, fuzzy
+msgid "No Events"
+msgstr "Imicimbi yomsindo"
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:3
+msgid "Device Security"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:4
+msgid "Host firmware security status"
+msgstr ""
+
+#: panels/firmware-security/gnome-firmware-security-panel.desktop.in.in:20
+msgid ""
+"screen;lock;diagnostics;crash;private;recent;temporary;tmp;index;name;"
+"network;identity;privacy;"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:32
+#: panels/sharing/cc-sharing-panel.ui:304
+msgid "Device Name"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:50
+msgid "Hardware Model"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:58
+msgid "Memory"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:66
+msgid "Processor"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:74
+msgid "Graphics"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:82
+msgid "Disk Capacity"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:83
+msgid "Calculating…"
+msgstr ""
+
+#. translators: this field contains the distro name and version
+#: panels/info-overview/cc-info-overview-panel.ui:98
+#, fuzzy
+msgid "OS Name"
+msgstr "Igama:"
+
+#. translators: this field contains the distro build ID
+#: panels/info-overview/cc-info-overview-panel.ui:107
+msgid "OS Build ID"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:115
+#, fuzzy
+msgid "OS Type"
+msgstr "Uhlobo"
+
+#: panels/info-overview/cc-info-overview-panel.ui:123
+#, fuzzy
+msgid "GNOME Version"
+msgstr "Isixhumanisi"
+
+#. translators: this is a placeholder while the GNOME version is being fetched
+#: panels/info-overview/cc-info-overview-panel.ui:125
+msgid "Loading…"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:133
+#, fuzzy
+msgid "Windowing System"
+msgstr "Windows"
+
+#: panels/info-overview/cc-info-overview-panel.ui:141
+msgid "Virtualization"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:150
+msgid "Software Updates"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:174
+msgid "Rename Device"
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:190
+msgid ""
+"The device name is used to identify this device when it is viewed over the "
+"network, or when pairing Bluetooth devices."
+msgstr ""
+
+#: panels/info-overview/cc-info-overview-panel.ui:196
+#, fuzzy
+msgid "Device name"
+msgstr "_Igama lendikimba:"
+
+#: panels/info-overview/cc-info-overview-panel.ui:210
+#, fuzzy
+msgid "_Rename"
+msgstr "I_gamamsebemzi:"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:3
+#, fuzzy
+msgid "About"
+msgstr "/_Nge"
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:4
+msgid "View information about your system"
+msgstr ""
+
+#: panels/info-overview/gnome-info-overview-panel.desktop.in.in:23
+msgid ""
+"device;system;information;hostname;memory;processor;version;default;"
+"application;preferred;cd;dvd;usb;audio;video;disc;removable;media;autorun;"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:2
+msgid "Sound and Media"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:4
+#, fuzzy
+msgid "Volume mute/unmute"
+msgstr "Ukucisha ivolumu okwesikhashana"
+
+#: panels/keyboard/00-multimedia.xml.in:6
 msgid "Volume down"
 msgstr "Ivolumu ephantsi"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
-msgid "Volume down's shortcut."
-msgstr "Ukunqamula kwevolumu ephantsi."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
-msgid "Volume mute"
-msgstr "Ukucisha ivolumu okwesikhashana"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
-msgid "Volume mute's shortcut"
-msgstr "Ukunqamula kokucisha ivolumu okwesikhashana"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
-msgid "Volume step"
-msgstr "Inyathelo lwevolumu"
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
-msgid "Volume step as percentage of volume."
-msgstr "Inyathelo lwevolumu njengamaphesenti."
-
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+#: panels/keyboard/00-multimedia.xml.in:8
 msgid "Volume up"
 msgstr "Ivolumu ephezulu"
 
-#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
-msgid "Volume up's shortcut."
-msgstr "Ukuqamula ivolumu ephezulu."
+#: panels/keyboard/00-multimedia.xml.in:10
+msgid "Microphone mute/unmute"
+msgstr ""
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+#: panels/keyboard/00-multimedia.xml.in:12
+msgid "Launch media player"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:14
+msgid "Play (or play/pause)"
+msgstr "Dlala (noma dlala/misa isikhashana)"
+
+#: panels/keyboard/00-multimedia.xml.in:16
+msgid "Pause playback"
+msgstr ""
+
+#: panels/keyboard/00-multimedia.xml.in:18
 #, fuzzy
-msgid "Display a dialog when there are errors running the screensaver"
-msgstr "Bonisa ibhokisi uma kukho amaphutha akhona XScreenSaver"
+msgid "Stop playback"
+msgstr "Inkinombho lokunmisa ukudlala"
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+#: panels/keyboard/00-multimedia.xml.in:20
 #, fuzzy
-msgid "Run screensaver at login"
-msgstr "Sebenzisa XSreenSaver uma ungena"
+msgid "Previous track"
+msgstr "Buyela engomeni edlulile"
 
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
-msgid "Show Startup Errors"
-msgstr "Khombisa amaphutha okungena"
-
-#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#: panels/keyboard/00-multimedia.xml.in:22
 #, fuzzy
-msgid "Start screensaver"
-msgstr "Qala XScreenSaver"
+msgid "Next track"
+msgstr "Dlulela engomeni elandelayo"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
-msgid ""
-"A collection of scripts to run whenever the keyboard state is reloaded. "
-"Useful for re-applying xmodmap based adjustments"
-msgstr ""
+#: panels/keyboard/00-multimedia.xml.in:24
+msgid "Eject"
+msgstr "Khipa"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
-msgid "A list of modmap files available in the $HOME directory."
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
-msgid "Default group, assigned on window creation"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
-msgid "Keep and manage separate group per window"
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+#: panels/keyboard/01-input-sources.xml.in:4
+#: panels/universal-access/cc-ua-panel.ui:163
 #, fuzzy
-msgid "Keyboard Update Handlers"
-msgstr "_Isifanekiso sendawo yokushaya uma ubhala:"
+msgid "Typing"
+msgstr "Ukunqamula ukubhala"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#: panels/keyboard/01-input-sources.xml.in:8
 #, fuzzy
-msgid "Keyboard layout"
-msgstr "Umphandle wendawo yokushaya uma ubhala XKB"
+msgid "Switch to next input source"
+msgstr "Dlulela engomeni elandelayo"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#: panels/keyboard/01-input-sources.xml.in:13
 #, fuzzy
-msgid "Keyboard model"
-msgstr "_Isifanekiso sendawo yokushaya uma ubhala:"
+msgid "Switch to previous input source"
+msgstr "Buyela engomeni edlulile"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+#: panels/keyboard/01-launchers.xml.in:2
 #, fuzzy
-msgid "Keyboard options"
-msgstr "Izinqamulo zendawo yokushaya uma ubhala"
+msgid "Launchers"
+msgstr "Ngenisa isiyaluzi solwembu"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+#: panels/keyboard/01-launchers.xml.in:4
+msgid "Launch help browser"
+msgstr "Ngenisa usizo lwesiyaluzi"
+
+#: panels/keyboard/01-launchers.xml.in:6
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:7 shell/cc-window.ui:22
+#: shell/org.gnome.Settings.desktop.in.in:3
 #, fuzzy
-msgid ""
-"Keyboard settings in gconf will be overridden from the system ASAP "
-"(deprecated)"
-msgstr ""
-"Uhlelo lwe-XKB phakathi kwe-gconf lizonyatheliswa emshinini masinya ASAP"
+msgid "Settings"
+msgstr "Izinhlelo ezinephutha"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
-msgid "Save/restore indicators together with layout groups"
+#: panels/keyboard/01-launchers.xml.in:8
+msgid "Launch calculator"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
-msgid "Show layout names instead of group names"
+#: panels/keyboard/01-launchers.xml.in:10
+msgid "Launch email client"
 msgstr ""
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
-msgid ""
-"Show layout names instead of group names (only for versions of XFree "
-"supporting multiple layouts)"
-msgstr ""
+#: panels/keyboard/01-launchers.xml.in:12
+msgid "Launch web browser"
+msgstr "Ngenisa isiyaluzi solwembu"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
-msgid "Suppress the \"X sysconfig changed\" warning message"
-msgstr ""
+#: panels/keyboard/01-launchers.xml.in:14
+msgid "Home folder"
+msgstr "Isibaya sasekhaya"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
-msgid ""
-"Very soon, keyboard settings in gconf will be overridden (from the system "
-"configuration) This key has been deprecated since GNOME 2.12, please unset "
-"the model, layouts and options keys to get the default system configuration."
-msgstr ""
-
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+#: panels/keyboard/01-launchers.xml.in:16
 #, fuzzy
-msgid "keyboard layout"
-msgstr "Umphandle wendawo yokushaya uma ubhala XKB"
+msgctxt "keybinding"
+msgid "Search"
+msgstr "Hlola"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+#: panels/keyboard/01-system.xml.in:2 panels/region/cc-region-panel.ui:51
 #, fuzzy
-msgid "keyboard model"
-msgstr "Isifanekiso sendawo yokushaya uma ubhala XKB"
+msgid "System"
+msgstr "Insimbi yohlelo"
 
-#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
-msgid "modmap file list"
+#: panels/keyboard/01-system.xml.in:4
+msgid "Log out"
+msgstr "Phuma"
+
+#: panels/keyboard/01-system.xml.in:6
+msgid "Lock screen"
+msgstr "Vala ubuso besiga-nyezi"
+
+#: panels/keyboard/50-accessibility.xml.in:2
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:3
+#, fuzzy
+msgid "Accessibility"
+msgstr "_Ukutholakala"
+
+#: panels/keyboard/50-accessibility.xml.in:4
+msgid "Turn zoom on or off"
 msgstr ""
 
-#: ../typing-break/drw-break-window.c:212
-msgid "_Postpone break"
-msgstr "_Buyisela ukunqamuka emuva"
+#: panels/keyboard/50-accessibility.xml.in:6
+msgid "Zoom in"
+msgstr ""
 
-#: ../typing-break/drw-break-window.c:259
-msgid "Take a break!"
-msgstr "Thatha ikhefu"
+#: panels/keyboard/50-accessibility.xml.in:8
+#, fuzzy
+msgid "Zoom out"
+msgstr "Phuma"
 
-#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
-#: ../typing-break/drwright.c:141
-msgid "/_Preferences"
+#: panels/keyboard/50-accessibility.xml.in:10
+msgid "Turn screen reader on or off"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:12
+#, fuzzy
+msgid "Turn on-screen keyboard on or off"
+msgstr "_Ebusweni besiga-nyezi kwindawo yokushaya uma ubhala"
+
+#: panels/keyboard/50-accessibility.xml.in:14
+msgid "Increase text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:16
+msgid "Decrease text size"
+msgstr ""
+
+#: panels/keyboard/50-accessibility.xml.in:18
+msgid "High contrast on or off"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:5
+msgid "Add an Input Source"
+msgstr ""
+
+#: panels/keyboard/cc-input-chooser.ui:84
+msgid "Input methods can’t be used on the login screen"
+msgstr ""
+
+#: panels/keyboard/cc-input-list-box.ui:24
+msgid "No input source selected"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:20
+msgid "Options"
+msgstr "Ukhetho"
+
+#: panels/keyboard/cc-input-row.ui:31 panels/search/cc-search-panel-row.ui:52
+msgid "Move Up"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:35 panels/search/cc-search-panel-row.ui:56
+msgid "Move Down"
+msgstr ""
+
+#: panels/keyboard/cc-input-row.ui:41
+#, fuzzy
+msgid "Preferences"
 msgstr "/_Okuthandayo"
 
-#: ../typing-break/drwright.c:142
-msgid "/_About"
-msgstr "/_Nge"
-
-#: ../typing-break/drwright.c:144
-msgid "/_Take a Break"
-msgstr "/_Thatha ikhefu"
-
-#: ../typing-break/drwright.c:495
-#, c-format
-msgid "%d minute until the next break"
-msgid_plural "%d minutes until the next break"
-msgstr[0] "%d umzuzu kude kufike elinye ikhefu"
-msgstr[1] "%d imizuzu kude kufike elinye ikhefu"
-
-#: ../typing-break/drwright.c:499
-msgid "Less than one minute until the next break"
-msgstr "Ngaphantsi komzuzu kude kufike enye ikhefu"
-
-#: ../typing-break/drwright.c:587
-#, c-format
-msgid ""
-"Unable to bring up the typing break properties dialog with the following "
-"error: %s"
-msgstr ""
-"Ihlulekile ukuletha umbhalo wokunqamula nezakha zebhokisi kulokhu "
-"okulandelayo nephutha: %s"
-
-#: ../typing-break/drwright.c:635
-msgid "About GNOME Typing Monitor"
-msgstr "Ngobuso besiga-nyezi bokubhala nge-GNOME"
-
-#: ../typing-break/drwright.c:659
-msgid "A computer break reminder."
-msgstr "Isinqamulo sesiga-nyezi esikhumbuzayo."
-
-#: ../typing-break/drwright.c:660
-msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
-msgstr "Ibhalwe ngu Richard Hult &It;richard@imendio.com&gt;"
-
-#: ../typing-break/drwright.c:661
-msgid "Eye candy added by Anders Carlsson"
-msgstr "Iso lonezelela ngo Anders Carlsson"
-
-#: ../typing-break/drwright.c:837
-msgid "Break reminder"
-msgstr "Isikhumbuzi ngokunqamuka"
-
-#: ../typing-break/main.c:93
-msgid "The typing monitor is already running."
-msgstr "Ubuso besiga-nyezi bokubhala sebuyasebenza."
-
-#: ../typing-break/main.c:106
+#: panels/keyboard/cc-input-row.ui:48
 #, fuzzy
+msgid "View Keyboard Layout"
+msgstr "Umphandle wendawo yokushaya uma ubhala XKB"
+
+#: panels/keyboard/cc-input-row.ui:54
+#, fuzzy
+msgid "Remove"
+msgstr "_Susa"
+
+#: panels/keyboard/cc-keyboard-panel.ui:17
+msgid "Input Sources"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:18
+msgid "Includes keyboard layouts and input methods."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:28
+msgid "Input Source Switching"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:31
+msgid "Use the _same source for all windows"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:43
+msgid "Switch input sources _individually for each window"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:59
+msgid "Special Character Entry"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:60
+msgid "Methods for entering symbols and letter variants using the keyboard."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:63
+msgid "Alternate Characters Key"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-panel.ui:80
+#, fuzzy
+msgid "Compose Key"
+msgstr "Amakinombho engoso"
+
+#: panels/keyboard/cc-keyboard-panel.ui:98 shell/cc-window.ui:160
+msgid "Keyboard Shortcuts"
+msgstr "Izinqamulo zendawo yokushaya uma ubhala"
+
+#: panels/keyboard/cc-keyboard-panel.ui:101
+msgid "View and Customize Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:35
+msgid "Reset All…"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:36
+msgid "Reset all shortcuts to their default keybindings"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:89
+#, fuzzy
+msgid "Section"
+msgstr "Isenzo"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:111
+#, fuzzy
+msgid "Shortcuts"
+msgstr "Ukunqamula"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:120
+#, fuzzy
+msgid "Add a shortcut"
+msgstr "Ukunqamula"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:155
+msgid "Add Custom Shortcuts"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:163
+msgid "Set up custom shortcuts for launching apps, running scripts, and more."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:169
+#, fuzzy
+msgid "Add Shortcut"
+msgstr "Ukunqamula"
+
+#: panels/keyboard/cc-keyboard-shortcut-dialog.ui:201
+#, fuzzy
+msgid "No keyboard shortcut found"
+msgstr "Izinqamulo zendawo yokushaya uma ubhala"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:30
+msgid "_Remove"
+msgstr "_Susa"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:49
+msgid "Re_place"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:56
+#: panels/wwan/cc-wwan-mode-dialog.ui:39
+#: panels/wwan/cc-wwan-network-dialog.ui:115
+msgid "_Set"
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:103
+msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
+msgstr ""
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:161
+#: panels/printers/pp-details-dialog.ui:39
+#: panels/user-accounts/cc-add-user-dialog.ui:68
+#: panels/user-accounts/cc-user-panel.ui:137
+#: panels/wwan/cc-wwan-apn-dialog.ui:96
+#, fuzzy
+msgid "Name"
+msgstr "Igama:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:172
+#, fuzzy
+msgid "Command"
+msgstr "Umy_alo:"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:183
+msgid "Shortcut"
+msgstr "Ukunqamula"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:253
+#, fuzzy
+msgid "Set Shortcut…"
+msgstr "Ukunqamula"
+
+#: panels/keyboard/cc-keyboard-shortcut-editor.ui:261
+#, fuzzy
+msgid "None"
+msgstr "_Lutho"
+
+#: panels/keyboard/cc-keyboard-shortcut-row.ui:23
+msgid "Reset the shortcut to its default value"
+msgstr ""
+
+#: panels/keyboard/cc-xkb-modifier-dialog.ui:39
+#, fuzzy
+msgid "Use layout default"
+msgstr "Hlela kabusha emaphu_theni"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:3
+msgid "Keyboard"
+msgstr "Indawo yokushaya uma ubhala"
+
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:4
 msgid ""
-"The typing monitor uses the notification area to display information. You "
-"don't seem to have a notification area on your panel. You can add it by "
-"right-clicking on your panel and choosing 'Add to panel', selecting "
-"'Notification area' and clicking 'Add'."
+"Change keyboard shortcuts and set your typing preferences, keyboard layouts "
+"and input sources"
 msgstr ""
-"Ubuso besiganyezi bokubhala busebenzisa indawo yokwaziswa ukubonisa ulwazi. "
-"Kubonakala sengathi awunayo indawo yokwazisa kwihlu lakho. Unga yifaka "
-"ngokupotshoza ngakwesokudla kwihlu lakho ubuye ukhethe 'Faka kuhlu -> "
-"Isisebenziswa -> Indawo yokwaziswa'."
 
-#: ../vfs-methods/fontilus/font-view.c:115
-msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#: panels/keyboard/gnome-keyboard-panel.desktop.in.in:19
+msgid ""
+"Shortcut;Workspace;Window;Resize;Zoom;Contrast;Input;Source;Lock;Volume;"
 msgstr ""
-"Impungushe esheshayo embala womhlabathi yenqa phezu kwenja evilaphayo. "
-"0123456789"
 
-#: ../vfs-methods/fontilus/font-view.c:276
+#: panels/location/cc-location-panel.ui:23
+msgid "Location Services Turned Off"
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:24
+msgid "No applications can obtain location information."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:38
+msgid ""
+"Location services allow applications to know your location. Using Wi-Fi and "
+"mobile broadband increases accuracy.\n"
+"\n"
+"Uses Mozilla Location Service: <a href='https://location.services.mozilla."
+"com/privacy'>Privacy Policy</a>\n"
+"\n"
+"Allow the applications below to determine your location."
+msgstr ""
+
+#: panels/location/cc-location-panel.ui:56
+msgid "No Applications Have Asked for Location Access"
+msgstr ""
+
+#: panels/location/gnome-location-panel.desktop.in.in:4
+#, fuzzy
+msgid "Protect your location information"
+msgstr "Uhlobo lolwazi MIME"
+
+#: panels/location/gnome-location-panel.desktop.in.in:20
+msgid "location;gps;private;privacy;"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:23
+msgid "Microphone Turned Off"
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:24
+msgid "No applications can record sound."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:37
+msgid ""
+"Use of the microphone allows applications to record and listen to audio. "
+"Disabling the microphone may cause some applications to not function "
+"properly.\n"
+"\n"
+"Allow the applications below to use your microphone."
+msgstr ""
+
+#: panels/microphone/cc-microphone-panel.ui:54
+msgid "No Applications Have Asked for Microphone Access"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:4
+msgid "Protect your conversations"
+msgstr ""
+
+#: panels/microphone/gnome-microphone-panel.desktop.in.in:20
+msgid "microphone;recording;application;privacy;"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:9 panels/wacom/cc-wacom-panel.ui:9
+#, fuzzy
+msgid "Test Your _Settings"
+msgstr "Izinhlelo ezinephutha"
+
+#: panels/mouse/cc-mouse-panel.ui:23
+#: panels/multitasking/cc-multitasking-panel.ui:9
+msgid "General"
+msgstr "Jikelele"
+
+#: panels/mouse/cc-mouse-panel.ui:26
+msgid "Primary Button"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:27
+msgid "Sets the order of physical buttons on mice and touchpads."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:41 panels/sound/cc-balance-slider.ui:16
+msgid "Left"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:48 panels/sound/cc-balance-slider.ui:18
+#, fuzzy
+msgid "Right"
+msgstr "_Cishe"
+
+#: panels/mouse/cc-mouse-panel.ui:60 panels/mouse/cc-mouse-panel.ui:66
+#, fuzzy
+msgid "Pointer Location"
+msgstr "_Indawo:"
+
+#: panels/mouse/cc-mouse-panel.ui:61
+msgid "Press the Ctrl key to highlight the pointer."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:87
+msgid "Mouse"
+msgstr "Isingoso"
+
+#: panels/mouse/cc-mouse-panel.ui:90
+#, fuzzy
+msgid "Mouse Speed"
+msgstr "Amakinombho engoso"
+
+#: panels/mouse/cc-mouse-panel.ui:113 panels/mouse/cc-mouse-panel.ui:617
+msgid "Scroll Direction"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:149 panels/mouse/cc-mouse-panel.ui:653
+msgid "Traditional"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:156 panels/mouse/cc-mouse-panel.ui:660
+msgid "Scrolling moves the view."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:202 panels/mouse/cc-mouse-panel.ui:706
+msgid "Natural"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:209 panels/mouse/cc-mouse-panel.ui:713
+msgid "Scrolling moves the content."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:220 panels/mouse/cc-mouse-panel.ui:403
+#: panels/mouse/cc-mouse-panel.ui:724
+msgid "Area"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:236 panels/mouse/cc-mouse-panel.ui:246
+#, fuzzy
+msgid "Mouse Acceleration"
+msgstr "_Ukusheshisa:"
+
+#: panels/mouse/cc-mouse-panel.ui:242 panels/mouse/cc-mouse-panel.ui:466
+msgid "Flat"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:243 panels/mouse/cc-mouse-panel.ui:467
+msgid "Adaptive"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:262 panels/mouse/cc-mouse-panel.ui:266
+msgid "Touchpad"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:269
+msgid "Touchpad Speed"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:294
+msgid "Click Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:338
+msgid "Click in hardware default."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:385
+msgid "Areas"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:392
+msgid "Click in marked areas."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:420
+msgid "Tap to Click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:421
+msgid "Quickly touch the touchpad to click."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:427
+msgid "Tap to click"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:445 panels/mouse/cc-mouse-panel.ui:451
+msgid "Disable While Typing"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:459 panels/mouse/cc-mouse-panel.ui:470
+#, fuzzy
+msgid "Touchpad Acceleration"
+msgstr "_Ukusheshisa:"
+
+#: panels/mouse/cc-mouse-panel.ui:478
+msgid "Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:491
+msgid "Scroll Method"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:527 panels/mouse/cc-mouse-panel.ui:545
+msgid "Two-Finger"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:534
+msgid "Drag two fingers on the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:578 panels/mouse/cc-mouse-panel.ui:596
+msgid "Edge"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui:585
+msgid "Drag one finger on the edge of the touchpad."
+msgstr ""
+
+#: panels/mouse/cc-mouse-test.ui:62
+msgid "Try clicking, double clicking, scrolling"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:3
+msgid "Mouse & Touchpad"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:4
+msgid ""
+"Change your mouse or touchpad sensitivity and select right or left-handed"
+msgstr ""
+
+#: panels/mouse/gnome-mouse-panel.desktop.in.in:19
+msgid "Trackpad;Pointer;Click;Tap;Double;Button;Trackball;Scroll;"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:15
+msgid "_Hot Corner"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:16
+msgid "Touch the top-left corner to open the Activities Overview."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:42
+msgid "_Active Screen Edges"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:43
+msgid ""
+"Drag windows against the top, left, and right screen edges to resize them."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:70
+msgid "Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:76
+msgid "_Dynamic workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:77
+msgid "Automatically removes empty workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:91
+msgid "_Fixed number of workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:92
+msgid "Specify a number of permanent workspaces."
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:108
+msgid "_Number of Workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:124
+msgid "Multi-Monitor"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:130
+msgid "Workspaces on _primary display only"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:156
+msgid "Workspaces on all d_isplays"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:184
+#, fuzzy
+msgid "Application Switching"
+msgstr "Isiqwema _sesithobo:"
+
+#: panels/multitasking/cc-multitasking-panel.ui:190
+msgid "Include applications from all _workspaces"
+msgstr ""
+
+#: panels/multitasking/cc-multitasking-panel.ui:204
+msgid "Include applications from the _current workspace only"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:3
+msgid "Multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:4
+msgid "Manage preferences for productivity and multitasking"
+msgstr ""
+
+#: panels/multitasking/gnome-multitasking-panel.desktop.in.in:15
+msgid ""
+"Multitasking;Multitask;Productivity;Customize;Desktop;Hot Corner;Workspaces;"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:21 panels/network/cc-network-panel.ui:26
+#, fuzzy
+msgid "Other Devices"
+msgstr "Abanye"
+
+#: panels/network/cc-network-panel.ui:37 panels/network/cc-network-panel.ui:71
+msgid "VPN"
+msgstr ""
+
+#: panels/network/cc-network-panel.ui:42
+#, fuzzy
+msgid "Add connection"
+msgstr "Isenzo"
+
+#: panels/network/cc-network-panel.ui:62
+msgid "Not set up"
+msgstr ""
+
+#: panels/network/cc-wifi-connection-row.ui:41
+#, fuzzy
+msgid "Connected"
+msgstr "Isaxhumana..."
+
+#: panels/network/cc-wifi-connection-row.ui:62
+#: panels/network/network-bluetooth.ui:22 panels/network/network-ethernet.ui:56
+#: panels/network/network-mobile.ui:329 panels/network/network-proxy.ui:62
+#: panels/network/network-vpn.ui:21
+#, fuzzy
+msgid "Options…"
+msgstr "Ukhetho"
+
+#: panels/network/cc-wifi-hotspot-dialog.c:271
+#, c-format
+msgid "Must have a maximum of %d character"
+msgid_plural "Must have a maximum of %d characters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:4
+msgid "Turn On Wi-Fi Hotspot?"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:28
+msgid ""
+"Wi-Fi hotspot allows others to share your internet connection, by creating a "
+"Wi-Fi network that they can connect to. To do this, you must have an "
+"internet connection through a source other than Wi-Fi."
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:51
+#, fuzzy
+msgid "Network Name"
+msgstr "Proxy yokuxhumana"
+
+#. Translators: This is a password needed for printing.
+#: panels/network/cc-wifi-hotspot-dialog.ui:75
+#: panels/printers/new-printer-dialog.ui:338
+#: panels/printers/pp-jobs-dialog.ui:54 panels/sharing/cc-sharing-panel.ui:384
+#: panels/user-accounts/cc-add-user-dialog.ui:145
+#: panels/user-accounts/cc-add-user-dialog.ui:181
+#: panels/user-accounts/cc-add-user-dialog.ui:364
+#: panels/wwan/cc-wwan-apn-dialog.ui:175
+#, fuzzy
+msgid "Password"
+msgstr "_Igama lokungena:"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:88
+msgid "Generate Random Password"
+msgstr ""
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:89
+#, fuzzy
+msgid "Autogenerate Password"
+msgstr "Shintsha uhlelo"
+
+#: panels/network/cc-wifi-hotspot-dialog.ui:131
+msgid "_Turn On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:75
+#, fuzzy
+msgid "Airplane Mode"
+msgstr "Uhlu Accel"
+
+#: panels/network/cc-wifi-panel.ui:76
+msgid "Disables Wi-Fi, Bluetooth and mobile broadband"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:113
+msgid "No Wi-Fi Adapter Found"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:123
+msgid "Make sure you have a Wi-Fi adapter plugged and turned on"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:155 panels/wwan/cc-wwan-panel.ui:102
+msgid "Airplane Mode On"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:165
+msgid "Turn off to use Wi-Fi"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:202
+msgid "Wi-Fi Hotspot Active"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:212
+msgid "Mobile devices can scan the QR code to connect."
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:220
+msgid "Turn Off Hotspot…"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:240
+msgid "Visible Networks"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:297
+msgid "NetworkManager needs to be running"
+msgstr ""
+
+#: panels/network/cc-wifi-panel.ui:303
+msgid "Oops, something has gone wrong. Please contact your software vendor."
+msgstr ""
+
+#: panels/network/connection-editor/8021x-security-page.ui:16
+msgid "802.1x _Security"
+msgstr ""
+
+#: panels/network/connection-editor/ce-page-details.c:172
+#: panels/network/net-device-ethernet.c:105
+#, c-format
+msgid "%i day ago"
+msgid_plural "%i days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/network/connection-editor/details-page.ui:14
+#: panels/wwan/cc-wwan-details-dialog.ui:73
+msgid "Signal Strength"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:46
+msgid "Link speed"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:78
+msgid "Security"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:94
+#, fuzzy
+msgid "IPv4 Address"
+msgstr "_ipotshoziwe"
+
+#: panels/network/connection-editor/details-page.ui:110
+#: panels/network/network-mobile.ui:177
+#, fuzzy
+msgid "IPv6 Address"
+msgstr "_ipotshoziwe"
+
+#: panels/network/connection-editor/details-page.ui:126
+#, fuzzy
+msgid "Hardware Address"
+msgstr "_ipotshoziwe"
+
+#: panels/network/connection-editor/details-page.ui:142
+msgid "Supported Frequencies"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:158
+#: panels/network/network-mobile.ui:191
+#, fuzzy
+msgid "Default Route"
+msgstr "Isikhombi esinephutha"
+
+#: panels/network/connection-editor/details-page.ui:175
+#: panels/network/connection-editor/details-page.ui:192
+#: panels/network/connection-editor/ip4-page.ui:165
+#: panels/network/connection-editor/ip6-page.ui:175
+#: panels/network/network-mobile.ui:206 panels/network/network-mobile.ui:221
+msgid "DNS"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:208
+msgid "Last Used"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:369
+msgid "Connect _automatically"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:383
+msgid "Make available to _other users"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:414
+msgid "_Metered connection: has data limits or can incur charges"
+msgstr ""
+
+#: panels/network/connection-editor/details-page.ui:423
+msgid ""
+"Software updates and other large downloads will not be started automatically."
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:21
+#: panels/network/connection-editor/vpn-page.ui:17
+#, fuzzy
+msgid "_Name"
+msgstr "_Igama:"
+
+#: panels/network/connection-editor/ethernet-page.ui:42
+#: panels/network/connection-editor/wifi-page.ui:51
+#, fuzzy
+msgid "_MAC Address"
+msgstr "_Hlanganisa:"
+
+#: panels/network/connection-editor/ethernet-page.ui:80
+msgid "M_TU"
+msgstr ""
+
+#: panels/network/connection-editor/ethernet-page.ui:93
+#: panels/network/connection-editor/wifi-page.ui:77
+#, fuzzy
+msgid "_Cloned Address"
+msgstr "_Hlanganisa:"
+
+#: panels/network/connection-editor/ethernet-page.ui:104
+msgid "bytes"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:21
+msgid "IPv_4 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:36
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:45
+#: panels/network/connection-editor/ip6-page.ui:55
+msgid "Link-Local Only"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:55
+#: panels/network/connection-editor/ip6-page.ui:65
+#: panels/network/network-proxy.ui:100
+msgid "Manual"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:65
+#: panels/network/connection-editor/ip6-page.ui:75
+#, fuzzy
+msgid "Disable"
+msgstr "Ayinamandla"
+
+#: panels/network/connection-editor/ip4-page.ui:75
+#: panels/network/connection-editor/ip6-page.ui:85
+msgid "Shared to other computers"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:98
+#: panels/network/connection-editor/ip6-page.ui:108
+#, fuzzy
+msgid "Addresses"
+msgstr "_ipotshoziwe"
+
+#: panels/network/connection-editor/ip4-page.ui:112
+#: panels/network/connection-editor/ip4-page.ui:250
+#: panels/network/connection-editor/ip6-page.ui:122
+#: panels/network/connection-editor/ip6-page.ui:260
+#: panels/printers/pp-details-dialog.ui:114
+#, fuzzy
+msgid "Address"
+msgstr "_ipotshoziwe"
+
+#: panels/network/connection-editor/ip4-page.ui:124
+#: panels/network/connection-editor/ip4-page.ui:262
+msgid "Netmask"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:136
+#: panels/network/connection-editor/ip4-page.ui:274
+#: panels/network/connection-editor/ip6-page.ui:146
+#: panels/network/connection-editor/ip6-page.ui:284
+msgid "Gateway"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:175
+#: panels/network/connection-editor/ip4-page.ui:227
+#: panels/network/connection-editor/ip6-page.ui:36
+#: panels/network/connection-editor/ip6-page.ui:185
+#: panels/network/connection-editor/ip6-page.ui:237
+#: panels/network/network-proxy.ui:93
+#: panels/network/wireless-security/eap-method-peap.ui:33
+msgid "Automatic"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:183
+#: panels/network/connection-editor/ip6-page.ui:193
+msgid "Automatic DNS"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:192
+#: panels/network/connection-editor/ip6-page.ui:202
+msgid "DNS server address(es)"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:200
+#: panels/network/connection-editor/ip6-page.ui:210
+msgid "Separate IP addresses with commas"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:217
+#: panels/network/connection-editor/ip6-page.ui:227
+#, fuzzy
+msgid "Routes"
+msgstr "imizuzu"
+
+#: panels/network/connection-editor/ip4-page.ui:235
+#: panels/network/connection-editor/ip6-page.ui:245
+msgid "Automatic Routes"
+msgstr ""
+
+#. Translators: Please see https://en.wikipedia.org/wiki/Metrics_(networking)
+#: panels/network/connection-editor/ip4-page.ui:285
+#: panels/network/connection-editor/ip6-page.ui:295
+msgid "Metric"
+msgstr ""
+
+#: panels/network/connection-editor/ip4-page.ui:308
+#: panels/network/connection-editor/ip6-page.ui:318
+msgid "Use this connection _only for resources on its network"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:21
+msgid "IPv_6 Method"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:45
+msgid "Automatic, DHCP only"
+msgstr ""
+
+#: panels/network/connection-editor/ip6-page.ui:134
+#: panels/network/connection-editor/ip6-page.ui:272
+msgid "Prefix"
+msgstr ""
+
+#: panels/network/connection-editor/security-page.ui:16
+msgid "S_ecurity"
+msgstr ""
+
+#: panels/network/connection-editor/vpn-page.ui:34
+msgid "(Error: unable to load VPN connection editor)"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:16
+msgid "_SSID"
+msgstr ""
+
+#: panels/network/connection-editor/wifi-page.ui:28
+msgid "_BSSID"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:3
+#: panels/network/network-mobile.ui:235 panels/wwan/cc-wwan-device-page.ui:61
+#: panels/wwan/cc-wwan-network-dialog.ui:5
+#, fuzzy
+msgid "Network"
+msgstr "Proxy yokuxhumana"
+
+#: panels/network/gnome-network-panel.desktop.in.in:4
+msgid "Control how you connect to the Internet"
+msgstr ""
+
+#: panels/network/gnome-network-panel.desktop.in.in:19
+msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:3
+#: panels/network/network-wifi.ui:66
+msgid "Wi-Fi"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:4
+msgid "Control how you connect to Wi-Fi networks"
+msgstr ""
+
+#: panels/network/gnome-wifi-panel.desktop.in.in:19
+msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:5 panels/network/network-ethernet.ui:5
+msgid "Wired"
+msgstr ""
+
+#: panels/network/network-bluetooth.ui:11
+msgid "Turn device off"
+msgstr ""
+
+#: panels/network/network-ethernet.ui:45 panels/network/network-mobile.ui:310
+#: panels/power/cc-power-profile-row.ui:21
+#, fuzzy
+msgid "Active"
+msgstr "Isenzo"
+
+#: panels/network/network-mobile.ui:27
+#: panels/wwan/cc-wwan-details-dialog.ui:237
+msgid "IMEI"
+msgstr ""
+
+#: panels/network/network-mobile.ui:41
+msgid "Provider"
+msgstr ""
+
+#: panels/network/network-mobile.ui:163
+#, fuzzy
+msgid "IP Address"
+msgstr "_ipotshoziwe"
+
+#: panels/network/network-proxy.ui:40 panels/network/network-proxy.ui:82
+msgid "Network Proxy"
+msgstr "Proxy yokuxhumana"
+
+#: panels/network/network-proxy.ui:141
+#, fuzzy
+msgid "_HTTP Proxy"
+msgstr "H_TTP ezimele:"
+
+#: panels/network/network-proxy.ui:158
+#, fuzzy
+msgid "H_TTPS Proxy"
+msgstr "H_TTP ezimele:"
+
+#: panels/network/network-proxy.ui:175
+#, fuzzy
+msgid "_FTP Proxy"
+msgstr "_FTP ezimele:"
+
+#: panels/network/network-proxy.ui:192
+#, fuzzy
+msgid "_Socks Host"
+msgstr "Umhathi weso_kisi:"
+
+#: panels/network/network-proxy.ui:209
+msgid "_Ignore Hosts"
+msgstr ""
+
+#: panels/network/network-proxy.ui:246
+#, fuzzy
+msgid "HTTP proxy port"
+msgstr "H_TTP ezimele:"
+
+#: panels/network/network-proxy.ui:309
+#, fuzzy
+msgid "HTTPS proxy port"
+msgstr "H_TTP ezimele:"
+
+#: panels/network/network-proxy.ui:324
+#, fuzzy
+msgid "FTP proxy port"
+msgstr "_FTP ezimele:"
+
+#: panels/network/network-proxy.ui:339
+msgid "Socks proxy port"
+msgstr ""
+
+#: panels/network/network-proxy.ui:359
+#, fuzzy
+msgid "_Configuration URL"
+msgstr "Ukulungisa ngokuzenzekela _URL:"
+
+#: panels/network/network-vpn.ui:11
+msgid "Turn VPN connection off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:34
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Network Name"
+msgstr "Proxy yokuxhumana"
+
+#: panels/network/network-wifi.ui:40
+msgctxt "Wi-Fi Hotspot"
+msgid "Security type"
+msgstr ""
+
+#: panels/network/network-wifi.ui:46
+#, fuzzy
+msgctxt "Wi-Fi Hotspot"
+msgid "Password"
+msgstr "_Igama lokungena:"
+
+#: panels/network/network-wifi.ui:90
+msgid "Turn Wi-Fi off"
+msgstr ""
+
+#: panels/network/network-wifi.ui:99 panels/search/cc-search-panel-row.ui:39
+#, fuzzy
+msgid "More options…"
+msgstr "Izinqamulo zendawo yokushaya uma ubhala"
+
+#: panels/network/network-wifi.ui:119
+msgid "_Connect to Hidden Network…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:131
+msgid "_Turn On Wi-Fi Hotspot…"
+msgstr ""
+
+#: panels/network/network-wifi.ui:143
+msgid "_Known Wi-Fi Networks"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:13
+#: panels/network/wireless-security/eap-method-peap.ui:21
+#: panels/network/wireless-security/eap-method-ttls.ui:37
+msgid "GTC"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:17
+#: panels/network/wireless-security/eap-method-peap.ui:13
+#: panels/network/wireless-security/eap-method-ttls.ui:21
+msgid "MSCHAPv2"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:29
+msgid "Anonymous"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:32
+msgid "Authenticated"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:35
+msgid "Both"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:46
+#: panels/network/wireless-security/eap-method-peap.ui:49
+#: panels/network/wireless-security/eap-method-ttls.ui:48
+msgid "Anony_mous identity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:67
+msgid "PAC _file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:79
+msgid "Choose a PAC file"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-fast.ui:99
+#: panels/network/wireless-security/eap-method-peap.ui:131
+#: panels/network/wireless-security/eap-method-ttls.ui:122
+#, fuzzy
+msgid "_Inner authentication"
+msgstr "<b>_Sebenzisa izifungo</b>"
+
+#: panels/network/wireless-security/eap-method-fast.ui:126
+msgid "Allow automatic PAC pro_visioning"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-leap.ui:11
+#: panels/network/wireless-security/eap-method-simple.ui:11
+#: panels/network/wireless-security/ws-leap.ui:11
+#, fuzzy
+msgid "_Username"
+msgstr "I_gamamsebemzi:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:23
+#: panels/network/wireless-security/eap-method-simple.ui:23
+#: panels/network/wireless-security/ws-leap.ui:23
+#: panels/network/wireless-security/ws-sae.ui:10
+#: panels/network/wireless-security/ws-wpa-psk.ui:10
+#: panels/sharing/cc-sharing-panel.ui:152
+#: panels/user-accounts/cc-user-panel.ui:182
+#, fuzzy
+msgid "_Password"
+msgstr "_Igama lokungena:"
+
+#: panels/network/wireless-security/eap-method-leap.ui:44
+#: panels/network/wireless-security/eap-method-simple.ui:61
+#: panels/network/wireless-security/eap-method-tls.ui:129
+#: panels/network/wireless-security/ws-leap.ui:44
+#: panels/network/wireless-security/ws-sae.ui:45
+#: panels/network/wireless-security/ws-wpa-psk.ui:53
+#, fuzzy
+msgid "Sho_w password"
+msgstr "_Igama lokungena:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:17
+#: panels/network/wireless-security/eap-method-ttls.ui:33
+#: panels/network/wireless-security/ws-wpa-eap.ui:15
+msgid "MD5"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:36
+#, fuzzy
+msgid "Version 0"
+msgstr "Umlandiso:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:39
+#, fuzzy
+msgid "Version 1"
+msgstr "Umlandiso:"
+
+#: panels/network/wireless-security/eap-method-peap.ui:70
+#: panels/network/wireless-security/eap-method-tls.ui:54
+#: panels/network/wireless-security/eap-method-ttls.ui:89
+msgid "C_A certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:82
+#: panels/network/wireless-security/eap-method-tls.ui:44
+#: panels/network/wireless-security/eap-method-tls.ui:66
+msgid "Choose a Certificate Authority certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:91
+#: panels/network/wireless-security/eap-method-tls.ui:75
+#: panels/network/wireless-security/eap-method-ttls.ui:110
+msgid "No CA certificate is _required"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-peap.ui:103
+msgid "PEAP _version"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:11
+msgid "I_dentity"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:32
+msgid "_User certificate"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:87
+msgid "Private _key"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-tls.ui:108
+#, fuzzy
+msgid "_Private key password"
+msgstr "_Igama lokungena:"
+
+#: panels/network/wireless-security/eap-method-ttls.ui:13
+msgid "PAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:17
+msgid "MSCHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:25
+msgid "MSCHAPv2 (no EAP)"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:29
+msgid "CHAP"
+msgstr ""
+
+#: panels/network/wireless-security/eap-method-ttls.ui:68
+#: panels/user-accounts/data/join-dialog.ui:90
+msgid "_Domain"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:15
+#: panels/network/wireless-security/ws-wpa-eap.ui:20
+msgid "TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:20
+#: panels/network/wireless-security/ws-wpa-eap.ui:25
+msgid "LEAP"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:25
+#: panels/network/wireless-security/ws-wpa-eap.ui:30
+msgid "PWD"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:30
+#: panels/network/wireless-security/ws-wpa-eap.ui:35
+msgid "FAST"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:35
+#: panels/network/wireless-security/ws-wpa-eap.ui:40
+msgid "Tunneled TLS"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:40
+#: panels/network/wireless-security/ws-wpa-eap.ui:45
+msgid "Protected EAP (PEAP)"
+msgstr ""
+
+#: panels/network/wireless-security/ws-dynamic-wep.ui:52
+#: panels/network/wireless-security/ws-wep-key.ui:87
+#: panels/network/wireless-security/ws-wpa-eap.ui:57
+#, fuzzy
+msgid "Au_thentication"
+msgstr "<b>_Sebenzisa izifungo</b>"
+
+#: panels/network/wireless-security/ws-sae.ui:33
+#: panels/network/wireless-security/ws-wpa-psk.ui:33
+#, fuzzy
+msgid "_Type"
+msgstr "Uhlobo"
+
+#: panels/network/wireless-security/ws-wep-key.ui:11
+#, fuzzy
+msgid "1 (Default)"
+msgstr "Isikhombi esinephutha"
+
+#: panels/network/wireless-security/ws-wep-key.ui:31
+#, fuzzy
+msgid "Open System"
+msgstr "Vula ihele"
+
+#: panels/network/wireless-security/ws-wep-key.ui:34
+msgid "Shared Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:44
+msgid "_Key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:75
+msgid "Sho_w key"
+msgstr ""
+
+#: panels/network/wireless-security/ws-wep-key.ui:115
+msgid "WEP inde_x"
+msgstr ""
+
+#. This is the per application switch for message tray usage.
+#: panels/notifications/cc-app-notifications-dialog.ui:15
+#, fuzzy
+msgctxt "notifications"
+msgid "_Notifications"
+msgstr "_Indawo:"
+
+#. This is the setting to configure sounds associated with notifications.
+#: panels/notifications/cc-app-notifications-dialog.ui:29
+#, fuzzy
+msgctxt "notifications"
+msgid "Sound _Alerts"
+msgstr "Ihele _lomsindo:"
+
+#: panels/notifications/cc-app-notifications-dialog.ui:42
+msgctxt "notifications"
+msgid "Notification _Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:43
+msgid ""
+"Notifications will continue to appear in the notification list when popups "
+"are disabled."
+msgstr ""
+
+#. Popups here refers to message tray notifications in the middle of the screen.
+#: panels/notifications/cc-app-notifications-dialog.ui:56
+msgctxt "notifications"
+msgid "Show Message _Content in Popups"
+msgstr ""
+
+#: panels/notifications/cc-app-notifications-dialog.ui:69
+#, fuzzy
+msgctxt "notifications"
+msgid "_Lock Screen Notifications"
+msgstr "Vala ukunqamula kobuso besi-nyezi."
+
+#: panels/notifications/cc-app-notifications-dialog.ui:82
+msgctxt "notifications"
+msgid "Show Message C_ontent on Lock Screen"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:10
+msgid "_Do Not Disturb"
+msgstr ""
+
+#: panels/notifications/cc-notifications-panel.ui:17
+#, fuzzy
+msgid "_Lock Screen Notifications"
+msgstr "Vala ukunqamula kobuso besi-nyezi."
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:4
+msgid "Control which notifications are displayed and what they show"
+msgstr ""
+
+#: panels/notifications/gnome-notifications-panel.desktop.in.in:20
+msgid "Notifications;Banner;Message;Tray;Popup;"
+msgstr ""
+
+#. Translators: This is the button which allows undoing the removal of the printer.
+#: panels/online-accounts/cc-online-accounts-panel.ui:23
+#: panels/printers/printers.ui:47
+msgid "Undo"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:31
+#, fuzzy
+msgid "Close the notification"
+msgstr "<b>_Sebenzisa izifungo</b>"
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:58
+msgid "Connect to your data in the cloud"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:69
+msgid "No internet connection — connect to set up new online accounts"
+msgstr ""
+
+#: panels/online-accounts/cc-online-accounts-panel.ui:96
+msgid "Add an account"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:3
+msgid "Online Accounts"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:4
+msgid "Connect to your online accounts and decide what to use them for"
+msgstr ""
+
+#: panels/online-accounts/gnome-online-accounts-panel.desktop.in.in:22
+msgid ""
+"Google;Facebook;Twitter;Yahoo;Web;Online;Chat;Calendar;Mail;Contact;ownCloud;"
+"Kerberos;IMAP;SMTP;Pocket;ReadItLater;"
+msgstr ""
+
+#: panels/power/cc-battery-row.c:83
+#, fuzzy, c-format
+msgid "%i minute"
+msgid_plural "%i minutes"
+msgstr[0] "imizuzu"
+msgstr[1] "imizuzu"
+
+#: panels/power/cc-battery-row.c:92
+#, c-format
+msgid "%i hour"
+msgid_plural "%i hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:99
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/power/cc-battery-row.c:100
+#, fuzzy
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] "imizuzu"
+msgstr[1] "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:12
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "15 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:16
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "20 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:20
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "25 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:24
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "30 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:28
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "45 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:32
+msgctxt "automatic_suspend"
+msgid "1 hour"
+msgstr ""
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:36
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "80 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:40
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "90 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:44
+#, fuzzy
+msgctxt "automatic_suspend"
+msgid "100 minutes"
+msgstr "imizuzu"
+
+#. Translators: Option for "Delay" in "Automatic suspend" dialog.
+#: panels/power/cc-power-panel.ui:48
+msgctxt "automatic_suspend"
+msgid "2 hours"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:58
+msgid "Battery"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:75 panels/thunderbolt/cc-bolt-panel.ui:265
+#: panels/thunderbolt/cc-bolt-panel.ui:309
+msgid "Devices"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:93
+#, fuzzy
+msgid "Power Mode"
+msgstr "Uhlu Accel"
+
+#: panels/power/cc-power-panel.ui:94
+msgid "Affects system performance and power usage."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:123
+msgid "Power Saving Options"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:126
+msgid "Automatic Screen Brightness"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:127
+msgid "Screen brightness adjusts to the surrounding light."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:139
+#, fuzzy
+msgid "Dim Screen"
+msgstr "Gcwalisa ubuso besiga-nyezi"
+
+#: panels/power/cc-power-panel.ui:140
+msgid "Reduces the screen brightness when the computer is inactive."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:151
+#, fuzzy
+msgid "Screen _Blank"
+msgstr "Ubuso besiga-nyezi"
+
+#: panels/power/cc-power-panel.ui:152
+msgid "Turns the screen off after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:160
+msgid "Automatic Power Saver"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:161
+msgid "Enables power saver mode when battery is low."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:174
+msgid "_Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:175
+msgid "Pauses the computer after a period of inactivity."
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:200
+msgid "Po_wer Button Behavior"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:208
+msgid "Show Battery _Percentage"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:244
+msgid "Automatic Suspend"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:267
+msgid "_Plugged In"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:279
+msgid "On _Battery Power"
+msgstr ""
+
+#: panels/power/cc-power-panel.ui:312 panels/power/cc-power-panel.ui:348
+#: panels/universal-access/cc-repeat-keys-dialog.ui:65
+#, fuzzy
+msgid "Delay"
+msgstr "_Bambezela:"
+
+#: panels/power/gnome-power-panel.desktop.in.in:3
+msgid "Power"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:4
+msgid "View your battery status and change power saving settings"
+msgstr ""
+
+#: panels/power/gnome-power-panel.desktop.in.in:19
+msgid ""
+"Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;"
+"Energy;"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:3
+#, fuzzy
+msgid "Printers"
+msgstr "_Bhala"
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:4
+msgid "Add printers, view printer jobs and decide how you want to print"
+msgstr ""
+
+#: panels/printers/gnome-printers-panel.desktop.in.in:16
+msgid "Printer;Queue;Print;Paper;Ink;Toner;"
+msgstr ""
+
+#. Translators: This is the title presented at top of the dialog.
+#: panels/printers/new-printer-dialog.ui:28
+#: panels/printers/new-printer-dialog.ui:38
+msgid "Add Printer"
+msgstr ""
+
+#. Translators: This button opens authentication dialog for selected server.
+#. Translators: This buttons submits the credentials for the selected server.
+#: panels/printers/new-printer-dialog.ui:103
+#: panels/printers/new-printer-dialog.ui:118
+#: panels/wwan/cc-wwan-device-page.ui:38
+msgid "_Unlock"
+msgstr ""
+
+#. Translators: No printers were detected
+#: panels/printers/new-printer-dialog.ui:197
+msgid "No Printers Found"
+msgstr ""
+
+#. Translators: The entered text should contain network address of a printer or a text which will filter found devices (their names and locations)
+#: panels/printers/new-printer-dialog.ui:247
+msgid "Enter a network address or search for a printer"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:292
+msgid "Authentication Required"
+msgstr ""
+
+#: panels/printers/new-printer-dialog.ui:308
+msgid "Enter username and password to view printers on Print Server."
+msgstr ""
+
+#. Translators: This is a username on a print server.
+#: panels/printers/new-printer-dialog.ui:317
+#: panels/printers/pp-jobs-dialog.ui:42
+#: panels/user-accounts/cc-add-user-dialog.ui:94
+#: panels/user-accounts/cc-add-user-dialog.ui:343
+#: panels/wwan/cc-wwan-apn-dialog.ui:150
+#, fuzzy
+msgid "Username"
+msgstr "I_gamamsebemzi:"
+
+#: panels/printers/pp-details-dialog.ui:69
+msgid "Printer names cannot contain SPACE, TAB, #, or /"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:89 panels/printers/printer-entry.ui:211
+#, fuzzy
+msgid "Location"
+msgstr "_Indawo:"
+
+#: panels/printers/pp-details-dialog.ui:139
+msgid "Driver"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:178
+msgid "Searching for preferred drivers…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:197
+msgid "Search for Drivers"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:205
+msgid "Select from Database…"
+msgstr ""
+
+#: panels/printers/pp-details-dialog.ui:213
+#, fuzzy
+msgid "Install PPD File…"
+msgstr "Ukufakwa kwendikima"
+
+#: panels/printers/ppd-selection-dialog.ui:8
+msgid "Select Printer Driver"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:75
+msgid "Loading drivers database…"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:83
+msgid "Cancel"
+msgstr ""
+
+#: panels/printers/ppd-selection-dialog.ui:91
+#, fuzzy
+msgid "Select"
+msgstr "_Khetha"
+
+#: panels/printers/pp-jobs-dialog.c:318
+#, c-format
+msgid "%u Job Requires Authentication"
+msgid_plural "%u Jobs Require Authentication"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: This is a windows domain used with SMB protocol.
+#: panels/printers/pp-jobs-dialog.ui:30
+#: panels/user-accounts/cc-add-user-dialog.ui:300
+msgid "Domain"
+msgstr ""
+
+#. Translators: This button authenticates all print jobs and send them for printing.
+#: panels/printers/pp-jobs-dialog.ui:103
+msgid "A_uthenticate"
+msgstr ""
+
+#. Translators: this action removes (purges) all the listed jobs from the list.
+#: panels/printers/pp-jobs-dialog.ui:131
+msgid "Clear All"
+msgstr ""
+
+#. Translators: This button pop up authentication dialog for print jobs which need credentials.
+#: panels/printers/pp-jobs-dialog.ui:177
+msgid "_Authenticate"
+msgstr ""
+
+#. Translators: this label describes the dialog empty state, with no jobs listed.
+#: panels/printers/pp-jobs-dialog.ui:219
+msgid "No Active Printer Jobs"
+msgstr ""
+
+#. Translators: This button triggers the printing of a test page.
+#: panels/printers/pp-options-dialog.ui:14
+msgid "Test Page"
+msgstr ""
+
+#: panels/printers/pp-printer-entry.c:531
+#, c-format
+msgid "%u Job"
+msgid_plural "%u Jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/printers/printer-entry.ui:18
+#, fuzzy
+msgid "Printing Options"
+msgstr "Ukhetho"
+
+#: panels/printers/printer-entry.ui:29
+#, fuzzy
+msgid "Printer Details"
+msgstr "Imininingwane yokutyelekana isiqwema"
+
+#. Set this printer as default
+#: panels/printers/printer-entry.ui:40
+#, fuzzy
+msgid "Use Printer by Default"
+msgstr "Hlela kabusha emaphu_theni"
+
+#. Translators: This button executes command which cleans print heads of the printer.
+#: panels/printers/printer-entry.ui:52
+msgid "Clean Print Heads"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:62
+msgid "Remove Printer"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:167
+msgid "No Active Jobs"
+msgstr ""
+
+#: panels/printers/printer-entry.ui:183
+#: panels/wwan/cc-wwan-details-dialog.ui:184
+#, fuzzy
+msgid "Model"
+msgstr "Izifanekiso"
+
+#: panels/printers/printer-entry.ui:238
+msgid "Ink Level"
+msgstr ""
+
+#. Translators: This is the message which follows the printer error.
+#: panels/printers/printer-entry.ui:300
+msgid "Please restart when the problem is resolved."
+msgstr ""
+
+#. Translators: This is the button which restarts the printer.
+#: panels/printers/printer-entry.ui:306
+msgid "Restart"
+msgstr ""
+
+#. Translators: This button adds new printer.
+#: panels/printers/printers.ui:10 panels/printers/printers.ui:184
+msgid "Add Printer…"
+msgstr ""
+
+#: panels/printers/printers.ui:134
+msgid "Additional Printer Settings…"
+msgstr ""
+
+#: panels/printers/printers.ui:173
+msgid "No printers"
+msgstr ""
+
+#. Translators: The CUPS server is not running (we can not connect to it).
+#: panels/printers/printers.ui:209
+msgid ""
+"Sorry! The system printing service\n"
+"    doesn’t seem to be available."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:4
+msgid "Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:76
+msgid "Search locales…"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:116
+msgid "Common Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:143
+msgid "All Formats"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:191
+msgid "No Search Results"
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:203
+msgid "Searches can be for countries or languages."
+msgstr ""
+
+#: panels/region/cc-format-chooser.ui:239
+#, fuzzy
+msgid "Preview"
+msgstr "_Buka futhi"
+
+#: panels/region/cc-format-preview.ui:17
+msgid "Dates"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:53
+msgid "Dates & Times"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:71
+msgid "Numbers"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:89
+msgid "Measurement"
+msgstr ""
+
+#: panels/region/cc-format-preview.ui:107
+msgid "Paper"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:19
+msgid "Language and format will be changed after next login"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:29
+msgid "Logout…"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:45
+msgid ""
+"The language setting is used for interface text and web pages. Formats are "
+"used for numbers, dates, and currencies."
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:56
+msgid "Manage Installed Languages"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:74
+msgid "Your Account"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:79 panels/region/cc-region-panel.ui:118
+#: panels/user-accounts/cc-user-panel.ui:306
+msgid "_Language"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:95 panels/region/cc-region-panel.ui:134
+msgid "_Formats"
+msgstr ""
+
+#: panels/region/cc-region-panel.ui:113
+#, fuzzy
+msgid "Login Screen"
+msgstr "Gcwalisa ubuso besiga-nyezi"
+
+#: panels/region/gnome-region-panel.desktop.in.in:3
+msgid "Region & Language"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:4
+msgid "Select your display language and formats"
+msgstr ""
+
+#: panels/region/gnome-region-panel.desktop.in.in:19
+msgid "Language;Layout;Keyboard;Input;"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:32
+msgid "Select how media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:52
+msgid "CD _audio"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:67
+msgid "_DVD video"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:102
+msgid "_Music player"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:152
+msgid "_Software"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:178
+msgid "_Other Media…"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:195
+msgid "_Never prompt or start programs on media insertion"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:225
+msgid "Select how other media should be handled"
+msgstr ""
+
+#: panels/removable-media/cc-removable-media-panel.ui:259
+#, fuzzy
+msgid "_Action:"
+msgstr "Isenzo"
+
+#: panels/removable-media/cc-removable-media-panel.ui:278
+#, fuzzy
+msgid "_Type:"
+msgstr "Uhlobo:"
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:3
+msgid "Removable Media"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:4
+msgid "Configure Removable Media settings"
+msgstr ""
+
+#: panels/removable-media/gnome-removable-media-panel.desktop.in.in:19
+msgid ""
+"device;system;default;application;preferred;cd;dvd;usb;audio;video;disc;"
+"removable;media;autorun;"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:8
+#, fuzzy
+msgid "Screen Lock"
+msgstr "Ubuso besiga-nyezi"
+
+#: panels/screen/cc-screen-panel.ui:9
+msgid ""
+"Automatically locking the screen prevents others from accessing the computer "
+"while you're away."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:14
+msgid "Blank Screen Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:15
+msgid "Period of inactivity after which the screen will go blank."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:33
+msgid "Automatic Screen _Lock"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:50
+msgid "Automatic _Screen Lock Delay"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:51
+msgid "Period after the screen blanks when the screen is automatically locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:69
+msgid "Show _Notifications on Lock Screen"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:86
+#, fuzzy
+msgid "Lock Screen on Suspend"
+msgstr "Vala ubuso besiga-nyezi"
+
+#: panels/screen/cc-screen-panel.ui:101
+msgid "Forbid new _USB devices"
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:102
+msgid ""
+"Prevent new USB devices from interacting with the system when the screen is "
+"locked."
+msgstr ""
+
+#: panels/screen/cc-screen-panel.ui:122
+#, fuzzy
+msgid "Screen Privacy"
+msgstr "Ubuso besiga-nyezi"
+
+#: panels/screen/cc-screen-panel.ui:127
+msgid "Restrict Viewing Angle"
+msgstr ""
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:3
+msgid "Screen"
+msgstr "Ubuso besiga-nyezi"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:4
+#, fuzzy
+msgid "Screen Settings"
+msgstr "Ubuso besiga-nyezi %d Izinhlelo\n"
+
+#: panels/screen/gnome-screen-panel.desktop.in.in:20
+msgid "screen;lock;private;privacy;"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:8
+#: panels/search/cc-search-panel.ui:22
+#, fuzzy
+msgid "Search Locations"
+msgstr "Izinqamulo zendawo yokushaya uma ubhala"
+
+#: panels/search/cc-search-locations-dialog.ui:13
+msgid ""
+"Folders which are searched by system applications, such as Files, Photos and "
+"Videos."
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:18
+msgid "Places"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:35
+msgid "Bookmarks"
+msgstr ""
+
+#: panels/search/cc-search-locations-dialog.ui:52
+msgid "Others"
+msgstr "Abanye"
+
+#: panels/search/cc-search-locations-dialog.ui:59
+#, fuzzy
+msgid "Add Location"
+msgstr "_Indawo:"
+
+#: panels/search/cc-search-panel.ui:10
+#, fuzzy
+msgid "Application Search"
+msgstr "Isiqwema _sesithobo:"
+
+#: panels/search/cc-search-panel.ui:11
+msgid "Include application-provided search results."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:23
+msgid "Folders which are searched by system applications."
+msgstr ""
+
+#: panels/search/cc-search-panel.ui:37
+#, fuzzy
+msgid "Search Results"
+msgstr "Ukuqamula uma uhlola."
+
+#: panels/search/cc-search-panel.ui:38
+msgid "Results are displayed according to the list order."
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:4
+msgid ""
+"Control which applications show search results in the Activities Overview"
+msgstr ""
+
+#: panels/search/gnome-search-panel.desktop.in.in:19
+msgid "Search;Find;Index;Hide;Privacy;Results;"
+msgstr ""
+
+#: panels/sharing/cc-sharing-networks.ui:15
+#, fuzzy
+msgid "Networks"
+msgstr "Proxy yokuxhumana"
+
+#: panels/sharing/cc-sharing-panel.ui:9
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:3
+msgid "Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:31
+msgid "_Computer Name"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:58
+msgid "_File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:65
+#, fuzzy
+msgid "Remote _Desktop"
+msgstr "Isiga-nyezi"
+
+#: panels/sharing/cc-sharing-panel.ui:72
+msgid "_Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:79
+#, fuzzy
+msgid "_Remote Login"
+msgstr "_Susa"
+
+#: panels/sharing/cc-sharing-panel.ui:92
+msgid "File Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:138
+#, fuzzy
+msgid "_Require Password"
+msgstr "_Igama lokungena:"
+
+#: panels/sharing/cc-sharing-panel.ui:195
+#: panels/sharing/cc-sharing-panel.ui:231
+msgid "Remote Login"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:251
+#: panels/sharing/cc-sharing-panel.ui:270
+#, fuzzy
+msgid "Remote Desktop"
+msgstr "Isiga-nyezi"
+
+#: panels/sharing/cc-sharing-panel.ui:266
+msgid ""
+"Remote desktop allows viewing and controlling your desktop from another "
+"computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:271
+msgid "Enable or disable remote desktop connections to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:284
+#, fuzzy
+msgid "Remote Control"
+msgstr "Ukulawula UI"
+
+#: panels/sharing/cc-sharing-panel.ui:285
+msgid "Allows remote connections to control the screen."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:299
+msgid "How to Connect"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:300
+msgid ""
+"Connect to this computer using the device name or remote desktop address."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:318
+#: panels/sharing/cc-sharing-panel.ui:345
+#: panels/sharing/cc-sharing-panel.ui:372
+#: panels/sharing/cc-sharing-panel.ui:390
+#, fuzzy
+msgid "Copy"
+msgstr "_Kopisha"
+
+#: panels/sharing/cc-sharing-panel.ui:331
+msgid "Remote Desktop Address"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:361
+#, fuzzy
+msgid "Authentication"
+msgstr "<b>_Sebenzisa izifungo</b>"
+
+#: panels/sharing/cc-sharing-panel.ui:362
+msgid "The user name and password are required to connect to this computer."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:366
+#, fuzzy
+msgid "User Name"
+msgstr "I_gamamsebemzi:"
+
+#: panels/sharing/cc-sharing-panel.ui:405
+msgid "Verify Encryption"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:434
+msgid "Encryption Fingerprint"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:435
+msgid ""
+"The encryption fingerprint can be seen in connecting clients and should be "
+"identical."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:467
+msgid "Media Sharing"
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:489
+msgid "Share music, photos and videos over the network."
+msgstr ""
+
+#: panels/sharing/cc-sharing-panel.ui:502
+msgid "Folders"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:4
+msgid "Control what you want to share with others"
+msgstr ""
+
+#: panels/sharing/gnome-sharing-panel.desktop.in.in:16
+msgid ""
+"share;sharing;ssh;host;name;remote;desktop;media;audio;video;pictures;photos;"
+"movies;server;renderer;"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:11
+msgid "Enable or disable remote login"
+msgstr ""
+
+#: panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in.in:12
+msgid "Authentication is required to enable or disable remote login"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:12
+msgid "Click"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:20
+msgid "String"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:28
+msgid "Swing"
+msgstr ""
+
+#: panels/sound/cc-alert-chooser.ui:36
+msgid "Hum"
+msgstr ""
+
+#: panels/sound/cc-balance-slider.ui:13 panels/sound/cc-sound-panel.ui:144
+msgid "Balance"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:13 panels/sound/cc-sound-panel.ui:170
+msgid "Fade"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:16
+msgid "Rear"
+msgstr ""
+
+#: panels/sound/cc-fade-slider.ui:18
+msgid "Front"
+msgstr ""
+
+#: panels/sound/cc-output-test-dialog.ui:131
+msgid "Click a speaker to test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:8
+#, fuzzy
+msgid "System Volume"
+msgstr "Insimbi yohlelo"
+
+#: panels/sound/cc-sound-panel.ui:12
+msgid "Master volume"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:28
+#, fuzzy
+msgid "Volume Levels"
+msgstr "Ukucisha ivolumu okwesikhashana"
+
+#: panels/sound/cc-sound-panel.ui:38
+msgid "Output"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:59
+msgid "Output Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:81
+msgid "Test"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:110 panels/sound/cc-sound-panel.ui:275
+#, fuzzy
+msgid "Configuration"
+msgstr "Ukulingasa umumo wokuxhumana okuzimele"
+
+#: panels/sound/cc-sound-panel.ui:196 panels/sound/cc-subwoofer-slider.ui:13
+msgid "Subwoofer"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:214
+msgid "Input"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:235
+msgid "Input Device"
+msgstr ""
+
+#: panels/sound/cc-sound-panel.ui:309 panels/sound/cc-volume-slider.ui:13
+msgid "Volume"
+msgstr "Ivolumu"
+
+#: panels/sound/cc-sound-panel.ui:327
+#, fuzzy
+msgid "Alert Sound"
+msgstr "Amankinombho"
+
+#: panels/sound/cc-volume-slider.ui:22
+msgid "Mute"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:3
+msgid "Sound"
+msgstr "Umsindo"
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:4
+msgid "Change sound levels, inputs, outputs, and alert sounds"
+msgstr ""
+
+#: panels/sound/gnome-sound-panel.desktop.in.in:20
+msgid ""
+"Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.c:485
+#, c-format
+msgid "Depends on %u other device"
+msgid_plural "Depends on %u other devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:43
+#: panels/thunderbolt/cc-bolt-panel.ui:41
+msgid "Close notification"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:87
 msgid "Name:"
 msgstr "Igama:"
 
-#: ../vfs-methods/fontilus/font-view.c:279
-msgid "Style:"
-msgstr "Indlela:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:115
+msgid "Status:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:289
-msgid "Type:"
-msgstr "Uhlobo:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:144
+msgid "UUID:"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:295
-msgid "Size:"
-msgstr "Isayizi:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:250
+msgid "Authorize and Connect"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:339
-#: ../vfs-methods/fontilus/font-view.c:352
-msgid "Version:"
-msgstr "Umlandiso:"
+#: panels/thunderbolt/cc-bolt-device-dialog.ui:266
+msgid "Forget Device"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:343
-#: ../vfs-methods/fontilus/font-view.c:354
-msgid "Copyright:"
-msgstr "Ilungelo lombhali:"
+#: panels/thunderbolt/cc-bolt-panel.ui:102
+msgid "No Thunderbolt Support"
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:347
-msgid "Description:"
-msgstr "Ukulanda:"
+#: panels/thunderbolt/cc-bolt-panel.ui:103
+msgid "Could not connect to the thunderbolt subsystem."
+msgstr ""
 
-#: ../vfs-methods/fontilus/font-view.c:408
-#, c-format
-msgid "usage: %s fontfile\n"
-msgstr "ukusebenziswa: %s iqwemahele\n"
+#: panels/thunderbolt/cc-bolt-panel.ui:152
+msgid "Direct Access"
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
-msgid "Set as Application Font"
-msgstr "Hlela njenge siqwema sesithobo"
+#: panels/thunderbolt/cc-bolt-panel.ui:156
+msgid "Allow direct access to devices such as docks and external GPUs."
+msgstr ""
 
-#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+#: panels/thunderbolt/cc-bolt-panel.ui:224
+msgid "Pending Devices"
+msgstr ""
+
+#: panels/thunderbolt/cc-bolt-panel.ui:318
+msgid "No devices attached"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:3
+msgid "Thunderbolt"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:4
+msgid "Manage Thunderbolt devices"
+msgstr ""
+
+#: panels/thunderbolt/gnome-thunderbolt-panel.desktop.in.in:19
+msgid "Thunderbolt;privacy;"
+msgstr ""
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:5
 #, fuzzy
-msgid "Sets the default application font"
+msgid "Cursor Blinking"
+msgstr "<b>Isikhombi siyajampajampa</b>"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:32
+#, fuzzy
+msgid "Cursor blinks in text fields."
+msgstr "Isikhombi _sijampajampa phakathi kwebhokisi letekisi nemibhalo"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:65
+#: panels/universal-access/cc-repeat-keys-dialog.ui:120
+#, fuzzy
+msgid "Speed"
+msgstr "_Ijubane:"
+
+#: panels/universal-access/cc-cursor-blinking-dialog.ui:87
+#, fuzzy
+msgid "Cursor blinking speed"
+msgstr "<b>Isikhombi siyajampajampa</b>"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:5
+#, fuzzy
+msgid "Cursor Size"
+msgstr "Isayizi yesikhombi"
+
+#: panels/universal-access/cc-cursor-size-dialog.ui:22
+msgid ""
+"Cursor size can be combined with zoom to make it easier to see the cursor."
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:5
+msgid "Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:38
+msgid "_Simulated Secondary Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:49
+msgid "Trigger a secondary click by holding down the primary button"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:66
+#: panels/universal-access/cc-typing-dialog.ui:123
+#: panels/universal-access/cc-typing-dialog.ui:230
+msgid "A_cceptance delay:"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:78
+#, fuzzy
+msgctxt "secondary click"
+msgid "Short"
+msgstr "Ukunqamula"
+
+#: panels/universal-access/cc-pointing-dialog.ui:90
+msgid "Secondary click delay"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:97
+msgctxt "secondary click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:126
+msgid "_Hover Click"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:137
+msgid "Trigger a click when the pointer hovers"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:154
+#, fuzzy
+msgid "D_elay:"
+msgstr "_Bambezela:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:166
+#, fuzzy
+msgctxt "dwell click delay"
+msgid "Short"
+msgstr "Ukunqamula"
+
+#: panels/universal-access/cc-pointing-dialog.ui:184
+msgctxt "dwell click delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-pointing-dialog.ui:201
+#, fuzzy
+msgid "Motion _threshold:"
+msgstr "_Umnyango:"
+
+#: panels/universal-access/cc-pointing-dialog.ui:213
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Small"
+msgstr "_Okuncane"
+
+#: panels/universal-access/cc-pointing-dialog.ui:231
+#, fuzzy
+msgctxt "dwell click threshold"
+msgid "Large"
+msgstr "_Okukhulu"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:5
+#, fuzzy
+msgid "Repeat Keys"
+msgstr "<b>Phinda amankinombho</b>"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:32
+#, fuzzy
+msgid "Key presses repeat when key is held down."
+msgstr "Inkinombho lipotshozwa _phinda uma lipotshozelwe phantsi"
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:88
+msgid "Repeat keys delay"
+msgstr ""
+
+#: panels/universal-access/cc-repeat-keys-dialog.ui:144
+msgid "Repeat keys speed"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:4
+msgid "Typing Assist"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:41
+#, fuzzy
+msgid "_Sticky Keys"
+msgstr "Ukwexwayiswa ngamankinombho angasheshi"
+
+#: panels/universal-access/cc-typing-dialog.ui:51
+msgid "Treats a sequence of modifier keys as a key combination"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:63
+#, fuzzy
+msgid "_Disable if two keys are pressed together"
+msgstr "Cis_ha uma amakinombho amabili epotshozwe kanye kanye"
+
+#: panels/universal-access/cc-typing-dialog.ui:71
+#, fuzzy
+msgid "Beep when a _modifier key is pressed"
+msgstr "Khala uma _isilungisi sipotshozwa"
+
+#: panels/universal-access/cc-typing-dialog.ui:96
+#, fuzzy
+msgid "S_low Keys"
+msgstr "Amankinombho angasheshi isexwayiso"
+
+#: panels/universal-access/cc-typing-dialog.ui:106
+msgid "Puts a delay between when a key is pressed and when it is accepted"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:135
+#, fuzzy
+msgctxt "slow keys delay"
+msgid "Short"
+msgstr "Ukunqamula"
+
+#: panels/universal-access/cc-typing-dialog.ui:147
+msgid "Slow keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:154
+msgctxt "slow keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:166
+#, fuzzy
+msgid "Beep when a key is pr_essed"
+msgstr "Khala uma _isilungisi sipotshozwa"
+
+#: panels/universal-access/cc-typing-dialog.ui:173
+#, fuzzy
+msgid "Beep when a key is _accepted"
+msgstr "Khala uma isihluthulelo siyi:"
+
+#: panels/universal-access/cc-typing-dialog.ui:180
+#: panels/universal-access/cc-typing-dialog.ui:273
+#, fuzzy
+msgid "Beep when a key is _rejected"
+msgstr "Khala uma isihluthulelo sali_we"
+
+#: panels/universal-access/cc-typing-dialog.ui:203
+#, fuzzy
+msgid "_Bounce Keys"
+msgstr "Amakinombho engoso"
+
+#: panels/universal-access/cc-typing-dialog.ui:213
+#, fuzzy
+msgid "Ignores fast duplicate keypresses"
+msgstr "Ungan_aki ukupotsozwa kabili kwangaphakathi:"
+
+#: panels/universal-access/cc-typing-dialog.ui:242
+#, fuzzy
+msgctxt "bounce keys delay"
+msgid "Short"
+msgstr "Ukunqamula"
+
+#: panels/universal-access/cc-typing-dialog.ui:254
+msgid "Bounce keys typing delay"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:261
+msgctxt "bounce keys delay"
+msgid "Long"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:335
+msgid "_Enable by Keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-typing-dialog.ui:345
+msgid "Turn accessibility features on and off using the keyboard"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:17
+#, fuzzy
+msgid "_Always Show Accessibility Menu"
+msgstr "_Ukutholakala"
+
+#: panels/universal-access/cc-ua-panel.ui:31
+msgid "Seeing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:34
+msgid "_High Contrast"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:46
+#, fuzzy
+msgid "_Large Text"
+msgstr "_Okukhulu"
+
+#: panels/universal-access/cc-ua-panel.ui:58
+msgid "Enable A_nimations"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:70
+#, fuzzy
+msgid "Screen _Reader"
+msgstr "_Isifundi ebusweni besiga-nyezi"
+
+#: panels/universal-access/cc-ua-panel.ui:71
+msgid "The screen reader reads displayed text as you move the focus."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:83
+#, fuzzy
+msgid "_Sound Keys"
+msgstr "_Umsindo:"
+
+#: panels/universal-access/cc-ua-panel.ui:84
+msgid "Beep when Num Lock or Caps Lock are turned on or off."
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:96
+#, fuzzy
+msgid "C_ursor Size"
+msgstr "Isayizi yesikhombi"
+
+#: panels/universal-access/cc-ua-panel.ui:116
+#: panels/universal-access/cc-zoom-options-dialog.ui:82
+msgid "_Zoom"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:138
+msgid "Hearing"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:141
+#: panels/universal-access/cc-visual-alerts-dialog.ui:54
+msgid "_Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:166
+#, fuzzy
+msgid "Screen _Keyboard"
+msgstr "_Ebusweni besiga-nyezi kwindawo yokushaya uma ubhala"
+
+#: panels/universal-access/cc-ua-panel.ui:178
+#, fuzzy
+msgid "R_epeat Keys"
+msgstr "<b>Phinda amankinombho</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:198
+#, fuzzy
+msgid "Cursor _Blinking"
+msgstr "<b>Isikhombi siyajampajampa</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:218
+msgid "_Typing Assist (AccessX)"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:240
+msgid "Pointing &amp; Clicking"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:243
+#, fuzzy
+msgid "_Mouse Keys"
+msgstr "Amakinombho engoso"
+
+#: panels/universal-access/cc-ua-panel.ui:255
+#, fuzzy
+msgid "_Locate Pointer"
+msgstr "<b>Beka isikhombisi endaweni</b>"
+
+#: panels/universal-access/cc-ua-panel.ui:267
+msgid "_Click Assist"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:287
+msgid "_Double-Click Delay"
+msgstr ""
+
+#: panels/universal-access/cc-ua-panel.ui:297
+#, fuzzy
+msgid "Double-Click Delay"
+msgstr "<b>Potshoza-kabili isikhathi siphelile </b>"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:5
+msgid "Visual Alerts"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:14
+msgid "_Test flash"
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:38
+msgid "Use a visual indication when an alert sound occurs."
+msgstr ""
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:74
+#, fuzzy
+msgid "Flash the entire _screen"
+msgstr "Khanyisa _bonke ubuso"
+
+#: panels/universal-access/cc-visual-alerts-dialog.ui:86
+#, fuzzy
+msgid "Flash the entire _window"
+msgstr "Khanyisa _bonke ubuso"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:40
+#, fuzzy
+msgid "Full Screen"
+msgstr "Gcwalisa ubuso besiga-nyezi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:45
+msgid "Top Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:50
+msgid "Bottom Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:55
+msgid "Left Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:60
+msgid "Right Half"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:68
+#, fuzzy
+msgid "Zoom Options"
+msgstr "Ukhetho"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:119
+#, fuzzy
+msgid "_Magnification:"
+msgstr "_Inkulisa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:146
+#, fuzzy
+msgid "Magnifier Position:"
+msgstr "_Inkulisa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:163
+msgid "_Follow mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:174
+#, fuzzy
+msgid "_Screen part:"
+msgstr "_Isifundi ebusweni besiga-nyezi"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:208
+msgid "Magnifier _extends outside of screen"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:215
+msgid "_Keep magnifier cursor centered"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:223
+msgid "Magnifier cursor _pushes contents around"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:231
+msgid "Magnifier cursor moves with _contents"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:247
+#, fuzzy
+msgid "Magnifier"
+msgstr "_Inkulisa"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:267
+msgid "_Crosshairs:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:284
+msgid "_Overlaps mouse cursor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:306
+msgid "_Thickness:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:330
+msgctxt "universal access, thickness"
+msgid "Thin"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:348
+msgctxt "universal access, thickness"
+msgid "Thick"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:361
+msgid "_Length:"
+msgstr ""
+
+#. The color of the accessibility crosshair
+#: panels/universal-access/cc-zoom-options-dialog.ui:395
+msgid "Co_lor:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:427
+msgid "Crosshairs"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:444
+msgid "Color Effects:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:466
+msgid "_White on black:"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:482
+#, fuzzy
+msgid "_Brightness:"
+msgstr "Ukukhanya phezulu"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:499
+#, fuzzy
+msgid "_Contrast:"
+msgstr "_Iziqikili"
+
+#. The contrast scale goes from Color to None (grayscale)
+#: panels/universal-access/cc-zoom-options-dialog.ui:515
+msgctxt "universal access, contrast"
+msgid "Co_lor"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:538
+#, fuzzy
+msgctxt "universal access, color"
+msgid "None"
+msgstr "_Lutho"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:556
+#, fuzzy
+msgctxt "universal access, color"
+msgid "Full"
+msgstr "_Igcwele"
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:588
+msgctxt "universal access, brightness"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:606
+msgctxt "universal access, brightness"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:626
+msgctxt "universal access, contrast"
+msgid "Low"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:644
+msgctxt "universal access, contrast"
+msgid "High"
+msgstr ""
+
+#: panels/universal-access/cc-zoom-options-dialog.ui:664
+msgid "Color Effects"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
+msgid "Make it easier to see, hear, type, point and click"
+msgstr ""
+
+#: panels/universal-access/gnome-universal-access-panel.desktop.in.in:19
+msgid ""
+"Keyboard;Mouse;a11y;Accessibility;Universal Access;Contrast;Cursor;Sound;"
+"Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;"
+"Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;"
+"audio;typing;animations;"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:9
+msgid "File History"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:10
+msgid ""
+"File history keeps a record of files that you have used. This information is "
+"shared between applications, and makes it easier to find files that you "
+"might want to use."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:13
+msgid "File H_istory"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:25
+msgid "File _History Duration"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:48
+msgid "_Clear History…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:63
+msgid "Trash &amp; Temporary Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:64
+msgid ""
+"Trash and temporary files can sometimes include personal or sensitive "
+"information. Automatically deleting them can help to protect privacy."
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:67
+msgid "Automatically Delete _Trash Content"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:79
+msgid "Automatically Delete Temporary _Files"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:91
+msgid "Automatically Delete _Period"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:115
+msgid "_Empty Trash…"
+msgstr ""
+
+#: panels/usage/cc-usage-panel.ui:126
+msgid "_Delete Temporary Files…"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:3
+msgid "File History & Trash"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:4
+msgid "Don't leave traces"
+msgstr ""
+
+#: panels/usage/gnome-usage-panel.desktop.in.in:20
+msgid ""
+"usage;recent;history;files;temporary;tmp;private;privacy;trash;purge;retain;"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:15
+#: panels/user-accounts/data/join-dialog.ui:9
+msgid "Add User"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:131
+msgid "Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:132
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users. Parental controls cannot be applied to administrators."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:149
+msgid "User sets password on first login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:161
+#, fuzzy
+msgid "Set password now"
+msgstr "_Igama lokungena:"
+
+#: panels/user-accounts/cc-add-user-dialog.ui:224
+msgid "Confirm"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:278
+msgid "Enterprise Login"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:279
+msgid "User accounts which are managed by a company or organization."
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:388
+msgid "You are Offline"
+msgstr ""
+
+#: panels/user-accounts/cc-add-user-dialog.ui:389
+msgid ""
+"Enterprise login allows an existing centrally managed user account to be "
+"used on this device. You can also use this account to access company "
+"resources on the internet."
+msgstr ""
+
+#: panels/user-accounts/cc-avatar-chooser.ui:32
+#, fuzzy
+msgid "Select a File…"
+msgstr "Khetha ihele lomsindo"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:8
+#, fuzzy
+msgid "Fingerprint Manager"
+msgstr "Umphathi wefasitela"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:20
+msgid "Fingerprint"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:85
+#, fuzzy
+msgid "_No"
+msgstr "_Lutho"
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:93
+msgid "_Yes"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:113
+msgid ""
+"Do you want to delete your registered fingerprints so fingerprint login is "
+"disabled?"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:169
+msgid "No fingerprint device"
+msgstr ""
+
+#. Translators: This is the empty state page label which states that there are no devices ready.
+#: panels/user-accounts/cc-fingerprint-dialog.ui:184
+msgid "No Fingerprint device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:193
+msgid "Ensure the device is properly connected."
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:201
+msgid "Fingerprint Device"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:210
+msgid "Choose the fingerprint device you want to configure"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:240
+msgid "Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:246
+msgid ""
+"Fingerprint login allows you to unlock and log into your computer with your "
+"finger"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:273
+msgid "_Delete Fingerprints"
+msgstr ""
+
+#: panels/user-accounts/cc-fingerprint-dialog.ui:287
+msgid "Fingerprint Enroll"
+msgstr ""
+
+#: panels/user-accounts/cc-login-history-dialog.ui:30
+#, fuzzy
+msgid "Previous"
+msgstr "_Buka futhi"
+
+#: panels/user-accounts/cc-login-history-dialog.ui:40
+msgid "Next"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:4
+#, fuzzy
+msgid "Change Password"
+msgstr "Shintsha uhlelo"
+
+#: panels/user-accounts/cc-password-dialog.ui:34
+#, fuzzy
+msgid "Ch_ange"
+msgstr "Shintsha uhlelo"
+
+#: panels/user-accounts/cc-password-dialog.ui:53
+#, fuzzy
+msgid "Current Password"
+msgstr "Shintsha uhlelo"
+
+#: panels/user-accounts/cc-password-dialog.ui:68
+#, fuzzy
+msgid "New Password"
+msgstr "_Igama lokungena:"
+
+#: panels/user-accounts/cc-password-dialog.ui:99
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Shintsha uhlelo"
+
+#: panels/user-accounts/cc-password-dialog.ui:114
+msgid "The passwords do not match."
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:153
+msgid "Allow user to change their password on next login"
+msgstr ""
+
+#: panels/user-accounts/cc-password-dialog.ui:165
+#, fuzzy
+msgid "Set a password now"
+msgstr "_Igama lokungena:"
+
+#: panels/user-accounts/cc-user-panel.ui:23
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
+msgid "Users"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:63
+msgid "Your session needs to be restarted for changes to take effect"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:70
+msgid "Restart Now"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:79
+msgid "Close"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:120
+msgid "Edit avatar"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:152
+msgid "Full name"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:171
+#, fuzzy
+msgid "Edit"
+msgstr "_Hlela"
+
+#. FIXME
+#: panels/user-accounts/cc-user-panel.ui:202
+msgid "_Fingerprint Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:225
+msgid "A_utomatic Login"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:238
+msgid "Account Activity"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:266
+msgid "_Administrator"
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:267
+msgid ""
+"Administrators can add and remove other users, and can change settings for "
+"all users."
+msgstr ""
+
+#: panels/user-accounts/cc-user-panel.ui:283
+#, fuzzy
+msgid "_Parental Controls"
+msgstr "Abalawuli"
+
+#: panels/user-accounts/cc-user-panel.ui:284
+#, fuzzy
+msgid "Open the Parental Controls application."
 msgstr "Khetha izithobo zakho ezinephutha"
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
-msgid "If set to true, then OpenType fonts will be thumbnailed."
-msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke OpenType amaqwema azogcizelelwa."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
-msgid "If set to true, then PCF fonts will be thumbnailed."
-msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke PCF amaqwema azogcizelelwa."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
-msgid "If set to true, then TrueType fonts will be thumbnailed."
-msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke TrueType amaqwema azogcizelelwa."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
-msgid "If set to true, then Type1 fonts will be thumbnailed."
-msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke Type1 amaqwema azogcizelelwa."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
-msgid ""
-"Set this key to the command used to create thumbnails for OpenType fonts."
+#: panels/user-accounts/cc-user-panel.ui:335
+msgid "Remove User…"
 msgstr ""
-"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
-"OpenType."
 
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
-msgid "Set this key to the command used to create thumbnails for PCF fonts."
-msgstr ""
-"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-PCF."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
-msgid ""
-"Set this key to the command used to create thumbnails for TrueType fonts."
-msgstr ""
-"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
-"TrueType."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
-msgid "Set this key to the command used to create thumbnails for Type1 fonts."
-msgstr ""
-"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
-"Type1."
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
-msgid "Thumbnail command for OpenType fonts"
-msgstr "Gcizelela umyalo wesiqwema se-OpenType"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
-msgid "Thumbnail command for PCF fonts"
-msgstr "Gcizelela umyalo wesiqwema se-PCF"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
-msgid "Thumbnail command for TrueType fonts"
-msgstr "Gcizelela umyalo wesiqwema se-TrueType"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
-msgid "Thumbnail command for Type1 fonts"
-msgstr "Gcizelela umyalo wesiqwema se-Type1"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
-msgid "Whether to thumbnail OpenType fonts"
-msgstr "Mhlambe ukugcizelela iziqwema ze-OpenType"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
-msgid "Whether to thumbnail PCF fonts"
-msgstr "Mhlambe ukugcizelela iziqwema ze-PCF"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
-msgid "Whether to thumbnail TrueType fonts"
-msgstr "Mhlambe ukugcizelela iziqwema ze-TrueType"
-
-#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
-msgid "Whether to thumbnail Type1 fonts"
-msgstr "Mhlambe ukugcizelela iziqwema ze-Type1"
-
-#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+#: panels/user-accounts/cc-user-panel.ui:347
 #, fuzzy
-msgid "GNOME Font Viewer"
-msgstr "GNOME umlawuli ophakathi"
+msgid "Other Users"
+msgstr "Abanye"
 
-#: ../vfs-methods/themus/apply-font.glade.h:2
-msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#: panels/user-accounts/cc-user-panel.ui:360
+msgid "Add User…"
 msgstr ""
-"<span weight=\"bold\" size=\"larger\">Sebenzisa isiqwema esisha?</span>"
 
-#: ../vfs-methods/themus/apply-font.glade.h:3
-msgid "Do _not apply font"
-msgstr "Unga_sebenzisi isiqwema"
+#. Translators: This is the empty state page label which states that there are no users to show in the panel.
+#: panels/user-accounts/cc-user-panel.ui:388
+msgid "No Users Found"
+msgstr ""
 
-#: ../vfs-methods/themus/apply-font.glade.h:4
+#: panels/user-accounts/cc-user-panel.ui:397
+msgid "Unlock to add a user account."
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
+msgid "Add or remove users and change your password"
+msgstr ""
+
+#: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:20
 msgid ""
-"The theme you have selected suggests a new font. A preview of the font is "
-"shown below."
+"Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental Controls;Screen "
+"Time;App Restrictions;Web Restrictions;Usage;Usage Limit;Kid;Child;"
 msgstr ""
-"Indikima oyikhethile ibonisa isiqwema esisha. Ukubukwa kabusha "
-"kwalesosiqwema sibonisiwe ngezantsi."
 
-#: ../vfs-methods/themus/apply-font.glade.h:5
-msgid "_Apply font"
-msgstr "_Sebenzisa isiqwema"
+#. Translators: This button enrolls the computer in the domain in order to use enterprise logins.
+#: panels/user-accounts/data/join-dialog.ui:30
+msgid "_Enroll"
+msgstr ""
 
-#: ../vfs-methods/themus/theme-method.c:520
-msgid "Themes"
-msgstr "Iindikima"
+#: panels/user-accounts/data/join-dialog.ui:59
+msgid "Domain Administrator Login"
+msgstr ""
 
-#: ../vfs-methods/themus/themus-properties-view.c:126
-msgid "Description"
-msgstr "Ukulanda"
-
-#: ../vfs-methods/themus/themus-properties-view.c:133
-msgid "Control theme"
-msgstr "Lawula indikima"
-
-#: ../vfs-methods/themus/themus-properties-view.c:139
-msgid "Window border theme"
-msgstr "Indikima ehlulayo yefasitela"
-
-#: ../vfs-methods/themus/themus-properties-view.c:145
-msgid "Icon theme"
-msgstr "Indikima yophawu"
-
-#. translators: you may want to include non-western chars here
-#: ../vfs-methods/themus/themus-theme-applier.c:78
-msgid "ABCDEFG"
-msgstr "ABCDEFG"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
-#, fuzzy
-msgid "Apply theme"
-msgstr "_Sebenzisa isiqwema"
-
-#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
-#, fuzzy
-msgid "Sets the default theme"
-msgstr "Hlela kabusha emaphu_theni"
-
-#: ../vfs-methods/themus/themus.schemas.in.h:1
-msgid "If set to true, then installed themes will be thumbnailed."
-msgstr "Uma ihlelelwe iqiniso, manje indikima ezifakiwe zizogcizelelwa."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:2
-msgid "If set to true, then themes will be thumbnailed."
-msgstr "Uma ihlelelwe iqiniso, manje indikima zizogcizelelwa."
-
-#: ../vfs-methods/themus/themus.schemas.in.h:3
+#: panels/user-accounts/data/join-dialog.ui:72
 msgid ""
-"Set this key to the command used to create thumbnails for installed themes."
+"In order to use enterprise logins, this computer needs to be\n"
+"enrolled in the domain. Please have your network administrator\n"
+"type their domain password here."
 msgstr ""
-"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo kwindikima "
-"ezifakiwe."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:4
-msgid "Set this key to the command used to create thumbnails for themes."
+#: panels/user-accounts/data/join-dialog.ui:112
+msgid "Administrator _Name"
 msgstr ""
-"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo kwindikima."
 
-#: ../vfs-methods/themus/themus.schemas.in.h:5
-msgid "Thumbnail command for installed themes"
-msgstr "Umyalo wokugcizelela wendikima ezifakiwe"
+#: panels/user-accounts/data/join-dialog.ui:135
+msgid "Administrator Password"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:6
-msgid "Thumbnail command for themes"
-msgstr "Umyalo wokugcizelela wendikima"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
+msgid "Manage user accounts"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:7
-msgid "Whether to thumbnail installed themes"
-msgstr "Ngabe uzogcizelela izihloko ngesithupha ezifakiwe"
+#: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
+msgid "Authentication is required to change user data"
+msgstr ""
 
-#: ../vfs-methods/themus/themus.schemas.in.h:8
-msgid "Whether to thumbnail themes"
-msgstr "Ngabe uzogcizelela izihloko ngesithupha"
+#: panels/wacom/button-mapping.ui:7 panels/wacom/cc-wacom-ekr-page.ui:19
+#: panels/wacom/cc-wacom-page.ui:40
+#, fuzzy
+msgid "Map Buttons"
+msgstr "Amankinombho"
+
+#: panels/wacom/button-mapping.ui:26
+msgid "Map buttons to functions"
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:51
+msgid ""
+"To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
+"shortcut button and hold down the new keys or press Backspace to clear."
+msgstr ""
+
+#: panels/wacom/button-mapping.ui:66
+msgid "_Close"
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:51
+msgid ""
+"Please tap the target markers as they appear on screen to calibrate the "
+"tablet."
+msgstr ""
+
+#: panels/wacom/calibrator/calibrator.ui:63
+msgid "Mis-click detected, restarting…"
+msgstr ""
+
+#. translators: this is a drawing tablet pad, i.e. a collection of buttons and knobs
+#: panels/wacom/cc-wacom-ekr-page.ui:9
+msgid "External pad device"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:16
+msgid "Tablet Mode"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:17
+msgid "Use absolute positioning for the pen"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:28
+msgid "Left Hand Orientation"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:29
+msgid "Tablet and Express Keys™ are rotated for left hand use"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:58
+msgctxt "display setting"
+msgid "Map to Monitor"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:64
+msgid "Keep Aspect Ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:65
+msgid "Only use a portion of the tablet surface to keep monitor aspect ratio"
+msgstr ""
+
+#: panels/wacom/cc-wacom-page.ui:76
+msgid "Calibrate"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:56
+msgid "No tablet detected"
+msgstr ""
+
+#: panels/wacom/cc-wacom-panel.ui:57
+msgid "Please plug in or turn on your Wacom tablet."
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:16
+msgid "Tip Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:21
+#: panels/wacom/cc-wacom-stylus-page.ui:82
+msgid "Soft"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:35
+msgid "Stylus tip pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:41
+#: panels/wacom/cc-wacom-stylus-page.ui:102
+msgid "Firm"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:54
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 1"
+msgstr "Amankinombho"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:62
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 2"
+msgstr "Amankinombho"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:70
+#, fuzzy
+msgctxt "display setting"
+msgid "Button 3"
+msgstr "Amankinombho"
+
+#: panels/wacom/cc-wacom-stylus-page.ui:77
+msgid "Eraser Pressure Feel"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:96
+msgid "Eraser pressure"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:134
+msgid "Middle Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:135
+msgid "Right Mouse Button Click"
+msgstr ""
+
+#: panels/wacom/cc-wacom-stylus-page.ui:137
+msgid "Forward"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:3
+msgid "Wacom Tablet"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:4
+msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
+msgstr ""
+
+#: panels/wacom/gnome-wacom-panel.desktop.in.in:19
+msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:8
+msgid "Layout"
+msgstr "Ukubonakala ngaphandle"
+
+#: panels/windows/cc-windows-panel.ui:13
+msgid "Shows only close button."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:37
+msgid "Extended"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:38
+msgid "Shows minimize, maximize and close buttons."
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:64
+msgid "Behaviour"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:67
+msgid "Attach Modal dialogs"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:68
+msgid ""
+"Modal dialogs will be attached to their parent windows, and cannot be moved"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:75
+#, fuzzy
+msgid "Center New Windows"
+msgstr "Ngaphakathi"
+
+#: panels/windows/cc-windows-panel.ui:82
+msgid "Resize with Secondary Click"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:89
+#, fuzzy
+msgid "Windows Focus"
+msgstr "Windows"
+
+#: panels/windows/cc-windows-panel.ui:94
+msgid "Click to Focus"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:95
+msgid "Focus on Hover"
+msgstr ""
+
+#: panels/windows/cc-windows-panel.ui:96
+msgid "Secondary-Click"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:3
+msgid "Windows"
+msgstr "Windows"
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:4
+msgid "Manage preferences for windows and windows titlebar"
+msgstr ""
+
+#: panels/windows/gnome-windows-panel.desktop.in.in:15
+msgid "Windows;Titlebar;Focus Mode;Center New Windows;Layout;Modal dialogs;"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:8
+msgid "Access Points"
+msgstr ""
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:33
+#, fuzzy
+msgid "Add"
+msgstr "Hlanganisa..."
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:43
+msgid "_Save"
+msgstr "_Hlenga"
+
+#: panels/wwan/cc-wwan-apn-dialog.ui:123
+msgid "APN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:5
+#, fuzzy
+msgid "Modem Details"
+msgstr "Imniningwane yendikima"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:16
+msgid "Modem Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:25
+msgid "Carrier"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:49
+#, fuzzy
+msgid "Network Type"
+msgstr "Proxy yokuxhumana"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:97
+msgid "Network Status"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:122
+msgid "Own Number"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:151
+#, fuzzy
+msgid "Device Details"
+msgstr "Imniningwane yendikima"
+
+#: panels/wwan/cc-wwan-details-dialog.ui:160
+msgid "Manufacturer"
+msgstr ""
+
+#: panels/wwan/cc-wwan-details-dialog.ui:210
+msgid "Firmware Version"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.c:217
+#, c-format
+msgid "Wrong password entered. You have %1$u try left"
+msgid_plural "Wrong password entered. You have %1$u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.c:220
+#, c-format
+msgid "You have %u try left"
+msgid_plural "You have %u tries left"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/wwan/cc-wwan-device-page.ui:18
+msgid "No SIM"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:19
+msgid "Insert a SIM card to use this modem"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:33
+msgid "SIM Locked"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:77
+#, fuzzy
+msgid "_Mobile Data"
+msgstr "_Ihele"
+
+#: panels/wwan/cc-wwan-device-page.ui:78
+msgid "Access data using mobile network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:88
+msgid "_Data Roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:89
+msgid "Use mobile data when roaming"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:115
+#, fuzzy
+msgid "_Network Mode"
+msgstr "Proxy yokuxhumana"
+
+#: panels/wwan/cc-wwan-device-page.ui:122
+#, fuzzy
+msgid "N_etwork"
+msgstr "Proxy yokuxhumana"
+
+#: panels/wwan/cc-wwan-device-page.ui:132
+msgid "Advanced"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:146
+msgid "_Access Point Names"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:155
+msgid "_SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:156
+msgid "Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-device-page.ui:165
+#, fuzzy
+msgid "M_odem Details"
+msgstr "Imniningwane yendikima"
+
+#: panels/wwan/cc-wwan-mode-dialog.ui:5
+#, fuzzy
+msgid "Network Mode"
+msgstr "Proxy yokuxhumana"
+
+#: panels/wwan/cc-wwan-network-dialog.ui:38
+msgid "_Automatic"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:53
+msgid "Choose Network"
+msgstr ""
+
+#: panels/wwan/cc-wwan-network-dialog.ui:68
+msgid "Refresh Network Providers"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:10
+#, fuzzy
+msgid "Enable Mobile Network"
+msgstr "Nika ama_ndla amakinombho wokugqoka"
+
+#: panels/wwan/cc-wwan-panel.ui:61
+msgid "No WWAN Adapter Found"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:71
+msgid "Make sure you have a Wireless Wan/Cellular device"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:112
+msgid "Wireless Wan is disabled when airplane mode is on"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:120
+msgid "_Turn off Airplane Mode"
+msgstr ""
+
+#: panels/wwan/cc-wwan-panel.ui:151
+#, fuzzy
+msgid "Data Connection"
+msgstr "Isaxhumana..."
+
+#: panels/wwan/cc-wwan-panel.ui:152
+msgid "SIM card used for internet"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:9
+msgid "SIM Lock"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:24
+msgid "_Next"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:91
+msgid "_Lock SIM with PIN"
+msgstr ""
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:107
+#, fuzzy
+msgid "Change PIN"
+msgstr "Shintsha uhlelo"
+
+#: panels/wwan/cc-wwan-sim-lock-dialog.ui:202
+msgid "Enter current PIN to change SIM lock settings"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:3
+msgid "Mobile Network"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:4
+msgid "Configure Telephony and mobile data connections"
+msgstr ""
+
+#: panels/wwan/gnome-wwan-panel.desktop.in.in:16
+msgid "cellular;wwan;telephony;sim;mobile;"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:8
+msgid "Utility to configure the GNOME desktop"
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:10
+msgid "Settings is the primary interface for configuring your system."
+msgstr ""
+
+#: shell/appdata/org.gnome.Settings.appdata.xml.in:34
+msgid "The GNOME Project"
+msgstr ""
+
+#: shell/cc-panel-list.ui:18
+msgid "Settings categories"
+msgstr ""
+
+#: shell/cc-panel-list.ui:42
+msgid "Privacy"
+msgstr ""
+
+#: shell/cc-window.ui:30
+#, fuzzy
+msgid "All Settings"
+msgstr "Izinhlelo ezinephutha"
+
+#: shell/cc-window.ui:54
+msgid "Primary Menu"
+msgstr ""
+
+#: shell/cc-window.ui:152
+msgid "Warning: Development Version"
+msgstr ""
+
+#: shell/cc-window.ui:153
+msgid ""
+"This version of Settings should only be used for development purposes. You "
+"may experience incorrect system behavior, data loss, and other unexpected "
+"issues. "
+msgstr ""
+
+#: shell/cc-window.ui:164
+msgid "Help"
+msgstr ""
+
+#: shell/help-overlay.ui:15
+#, fuzzy
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Jikelele"
+
+#: shell/help-overlay.ui:20
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "_Phuma"
+
+#: shell/help-overlay.ui:27 shell/help-overlay.ui:57
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Search"
+msgstr "Hlola"
+
+#: shell/help-overlay.ui:35
+msgctxt "shortcut window"
+msgid "Panels"
+msgstr ""
+
+#: shell/help-overlay.ui:41 shell/help-overlay.ui:49
+#, fuzzy
+msgctxt "shortcut window"
+msgid "Go back to previous panel"
+msgstr "Buyela engomeni edlulile"
+
+#: shell/help-overlay.ui:62
+msgctxt "shortcut window"
+msgid "Cancel search"
+msgstr ""
+
+#: shell/org.gnome.Settings.desktop.in.in:17
+#, fuzzy
+msgid "Preferences;Settings;"
+msgstr "/_Okuthandayo"
+
+#: shell/org.gnome.Settings.gschema.xml:5
+msgid "The identifier for the last Settings panel to be opened"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:6
+msgid ""
+"The identifier for the last Settings panel to be opened. Unrecognised values "
+"will be ignored and the first panel in the list selected."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:13
+msgid "Show warning when running a development build of Settings"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:14
+msgid ""
+"Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:20
+msgid "Initial state of the window"
+msgstr ""
+
+#: shell/org.gnome.Settings.gschema.xml:21
+msgid ""
+"A tuple containing the initial width, height and maximized state of the "
+"application window."
+msgstr ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1915
+#, c-format
+msgid "%u Output"
+msgid_plural "%u Outputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: subprojects/gvc/gvc-mixer-control.c:1925
+#, c-format
+msgid "%u Input"
+msgid_plural "%u Inputs"
+msgstr[0] ""
+msgstr[1] ""
+
+#, fuzzy
+#~ msgid "The type of alert"
+#~ msgstr "Uhlobo lwesigijimi."
+
+#, fuzzy
+#~ msgid "Show more _details"
+#~ msgstr "_Imniningwane yendikima"
+
+#, fuzzy
+#~ msgid "About Me"
+#~ msgstr "_Nge"
+
+#, fuzzy
+#~ msgid "No Image"
+#~ msgstr "Izithombe"
+
+#, fuzzy, c-format
+#~ msgid "About %s"
+#~ msgstr "_Nge"
+
+#, fuzzy
+#~ msgid "Please type the passwords."
+#~ msgstr "_Igama lokungena:"
+
+#~ msgid " "
+#~ msgstr " "
+
+#~ msgid "    "
+#~ msgstr "    "
+
+#, fuzzy
+#~ msgid "<b>Home</b>"
+#~ msgstr "<b>Ijubane</b>"
+
+#, fuzzy
+#~ msgid "<b>Instant Messaging</b>"
+#~ msgstr "<b>Ukutyelekana isiqwema</b>"
+
+#, fuzzy
+#~ msgid "<b>Job</b>"
+#~ msgstr "<b>Sekela</b>"
+
+#, fuzzy
+#~ msgid "<b>Telephone</b>"
+#~ msgstr "<b>Izihlushulelo zokugqoka</b>"
+
+#, fuzzy
+#~ msgid "<b>Web</b>"
+#~ msgstr "<b>Ijubane</b>"
+
+#, fuzzy
+#~ msgid "<b>Work</b>"
+#~ msgstr "<b>Sekela</b>"
+
+#, fuzzy
+#~ msgid "A_ddress:"
+#~ msgstr "_Hlanganisa:"
+
+#, fuzzy
+#~ msgid "C_ity:"
+#~ msgstr "_Inhlobo:"
+
+#, fuzzy
+#~ msgid "C_ompany:"
+#~ msgstr "Umy_alo:"
+
+#, fuzzy
+#~ msgid "Change Passwo_rd..."
+#~ msgstr "Shintsha uhlelo"
+
+#, fuzzy
+#~ msgid "Ci_ty:"
+#~ msgstr "_Inhlobo:"
+
+#, fuzzy
+#~ msgid "Co_untry:"
+#~ msgstr "Lawula"
+
+#, fuzzy
+#~ msgid "Cou_ntry:"
+#~ msgstr "Lawula"
+
+#, fuzzy
+#~ msgid "Hom_e:"
+#~ msgstr "_Igama:"
+
+#, fuzzy
+#~ msgid "Old pa_ssword:"
+#~ msgstr "_Igama lokungena:"
+
+#, fuzzy
+#~ msgid "Personal Info"
+#~ msgstr "_Isixhumi siqwema:"
+
+#, fuzzy
+#~ msgid "_Home page:"
+#~ msgstr "_Igama lendikimba:"
+
+#, fuzzy
+#~ msgid "_Home:"
+#~ msgstr "_Igama:"
+
+#, fuzzy
+#~ msgid "_Manager:"
+#~ msgstr "_Inkulisa"
+
+#, fuzzy
+#~ msgid "_Profession:"
+#~ msgstr "Umlandiso:"
+
+#, fuzzy
+#~ msgid "_Title:"
+#~ msgstr "_Inhlobo:"
+
+#~ msgid "<b>Support</b>"
+#~ msgstr "<b>Sekela</b>"
+
+#~ msgid ""
+#~ "<small><i><b>Note:</b> Changes to this setting will not take effect until "
+#~ "you next log in.</i></small>"
+#~ msgstr ""
+#~ "<small><i><b>Qaphela:</b> Ushintsho kuloluhlelo angeke lwenzeke uze "
+#~ "uphinde ungene futhi ngaphakathi.</i></small>"
+
+#~ msgid "Assistive Technology Preferences"
+#~ msgstr "Usizo lwesayensi yemisebenzi ethile oluthandekayo"
+
+#~ msgid "Close and _Log Out"
+#~ msgstr "Vala futhi _uphume"
+
+#~ msgid "Start these assistive technologies every time you log in:"
+#~ msgstr "Qala lolusizo lwesayensi ethile ngazo zonke izikhathi uma ungena:"
+
+#~ msgid "_Enable assistive technologies"
+#~ msgstr "_Nika amandla kusizo lwesayensi ethile"
+
+#~ msgid "Assistive Technology Support"
+#~ msgstr "Usizo lwesayensi yemisebenzi ethile oluthandekayo"
+
+#~ msgid "Enable support for GNOME assistive technologies at login"
+#~ msgstr ""
+#~ "Nika amandla ngokusekela I GNOME uma ungena kusizo lwesayensi yemisebenzi "
+#~ "ethile"
+
+#~ msgid ""
+#~ "No Assistive Technology is available on your system.  The 'gok' package "
+#~ "must be installed in order to get on-screen keyboard support, and the "
+#~ "'gnopernicus' package must be installed for screenreading and magnifying "
+#~ "capabilities."
+#~ msgstr ""
+#~ "Usizo lobugciko alukho phakathi kohlelo lwakho. Umthwalo we-'gok' imelwe "
+#~ "ukufakwa ukuze uthole inxaso yobuso besiga-nyezi kwindawo yokushaya uma "
+#~ "ubhala, nomthwalo we 'gnopernicus' kumelwe ufakwe ukuze ufundwe ebusweni "
+#~ "besiga-nyezi namakhono okukhulisa."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gok' package must be installed in order to get on-screen keyboard "
+#~ "support."
+#~ msgstr ""
+#~ "Akusilo lonke usizo olutholakalayo lwesayensi ethile olufakiwe phakathi "
+#~ "komshini wakho. Isithungu se 'gok' kumelwe sifakwe ukuze kutholwe "
+#~ "ukusekelwa kwindawo yokusahya uma ubhala ebusweni besiga-nyezi."
+
+#~ msgid ""
+#~ "Not all available assistive technologies are installed on your system.  "
+#~ "The 'gnopernicus' package must be installed for screenreading and "
+#~ "magnifying capabilities."
+#~ msgstr ""
+#~ "Usizo lwesayensi yemisebenzi ethile oluthandekayo alufakiwe phakathi "
+#~ "emshinini wakho. Isishuqulu se 'gnopernicus' kumelwe sifakwe ukuze "
+#~ "kufundwe ebusweni besiga-nyezi nokukhulisa okukhoekayo."
+
+#, c-format
+#~ msgid "There was an error launching the mouse preferences dialog: %s"
+#~ msgstr ""
+#~ "Kube khona iphutha elenzikile uma kungeniswa ingoso oluthandekayo "
+#~ "lokushaya: %s"
+
+#, c-format
+#~ msgid "Unable to import AccessX settings from file '%s'"
+#~ msgstr "Ihlulekile ukuthwebula izinhlelo zemvumeX phakathi kwehele '%s'"
+
+#~ msgid "Import Feature Settings File"
+#~ msgstr "Ingqondo yokuhlela imininingwane yehele"
+
+#~ msgid "Set your keyboard accessibility preferences"
+#~ msgstr "Hlela indawo yakho yokubhala ngezimvume ezithandekayo"
+
+#~ msgid ""
+#~ "This system does not seem to have the XKB extension.  The keyboard "
+#~ "accessibility features will not operate without it."
+#~ msgstr ""
+#~ "Lomshini awutshengise njengonendawo yangaphandle ye XKB. Imininingwane "
+#~ "yendawo yokushaya uma ubhala ngeke isebenze ngaphandle kwayo."
+
+#~ msgid "*"
+#~ msgstr "*"
+
+#~ msgid "<b>Enable Bo_unce Keys</b>"
+#~ msgstr "<b>Nika amandla Qha_sha Izihluthulelo</b>"
+
+#~ msgid "<b>Enable Slo_w Keys</b>"
+#~ msgstr "<b>Nika amandla Kan_cane Izihluthulelo</b>"
+
+#~ msgid "<b>Enable _Mouse Keys</b>"
+#~ msgstr "<b>Nika amandla _Ingoso Izihluthulelo</b>"
+
+#~ msgid "<b>Enable _Repeat Keys</b>"
+#~ msgstr "<b>Nika amandla _Phinda Izihluthulelo</b>"
+
+#~ msgid "<b>Enable _Sticky Keys</b>"
+#~ msgstr "<b>Nika amandla _Namathelayo Izihluthulelo</b>"
+
+#~ msgid "<b>Features</b>"
+#~ msgstr "<b>Umumo</b>"
+
+#~ msgid "<b>Toggle Keys</b>"
+#~ msgstr "<b>Izihlushulelo zokugqoka</b>"
+
+#~ msgid "Basic"
+#~ msgstr "Isisekelo"
+
+#~ msgid "Beep when _features turned on or off from keyboard"
+#~ msgstr ""
+#~ "Khala uma _umumo ucishiwe noma ukhanyisiwe kwindawo yokushaya uma ubhala"
+
+#~ msgid "Beep when an LED is turned on and two beeps when one is turned off."
+#~ msgstr "Khala uma LED ikhanyisiwe futhi ikhale kabili uma enye icishiwe."
+
+#~ msgid "Delay between keypress and pointer mo_vement:"
+#~ msgstr ""
+#~ "Chitha isikhathi phakathi kokupotshoza ikinombho nokuha_mba kwesikhombi:"
+
+#~ msgid "Filters"
+#~ msgstr "Izisefo"
+
+#~ msgid ""
+#~ "Ignore all subsequent presses of the SAME key if they happen within a "
+#~ "user selectable period of time."
+#~ msgstr ""
+#~ "Unganaki ukupotsozwa kaningi kwekinombho ngokufanayo umakwenzeka "
+#~ "mgomsebenzisi okukhethwa isikhala sesikhathi."
+
+#~ msgid "Keyboard Accessibility Preferences (AccessX)"
+#~ msgstr "Ukuthandeka nemvume yendawo yokushaya ethandekayo (AccessX)"
+
+#~ msgid "Ma_ximum pointer speed:"
+#~ msgstr "Ukushesha okuphele_le kokukhomba:"
+
+#~ msgid "Mouse _Preferences..."
+#~ msgstr "_Okuthandekayo kwengoso..."
+
+#~ msgid ""
+#~ "Only accept keys after they have been pressed and held for a user "
+#~ "adjustable amount of time."
+#~ msgstr ""
+#~ "Vumela amankinobho kuphela emuva kokupotshozwa abanjwa ukusebenziswa "
+#~ "ngokuhlelwa kwesikhathi."
+
+#~ msgid ""
+#~ "Perform multiple simultaneous key press operations by pressing modifier "
+#~ "keys in sequence."
+#~ msgstr ""
+#~ "Yenza ngokupotshoza amankonombho amaningi ukusebenzisa amankinobho "
+#~ "okulungisa ngokohlelo."
+
+#~ msgid "S_peed:"
+#~ msgstr "I_jubane:"
+
+#~ msgid "Time to acce_lerate to maximum speed:"
+#~ msgstr "Isikhakthi sokukhu_phula ijubane eliphezulu:"
+
+#~ msgid "Turn the numeric keypad into a mouse control pad."
+#~ msgstr ""
+#~ "Khanyisela inkinombho lokubala phakathi kweqweqwe lokulawula lwengoso."
+
+#~ msgid "_Disable if unused for:"
+#~ msgstr "_Cisha uma ingasebenzisiwe:"
+
+#~ msgid "_Enable keyboard accessibility features"
+#~ msgstr "_Nika amandla umumo wemvume yendawo yokushaya"
+
+#~ msgid "_Import Feature Settings..."
+#~ msgstr "_Ngenisa okuvela ngaphandle kwehlelo lomumo..."
+
+#~ msgid "_Only accept keys held for:"
+#~ msgstr "_Vuma kuphela amankinombho abanjelwe lokhu:"
+
+#~ msgid "_Type to test settings:"
+#~ msgstr "_Bhala ukuhlola uhelo:"
+
+#~ msgid "_accepted"
+#~ msgstr "_yamukelekile"
+
+#~ msgid "_pressed"
+#~ msgstr "_ipotshoziwe"
+
+#~ msgid "_rejected"
+#~ msgstr "_yaliwe"
+
+#~ msgid "characters/second"
+#~ msgstr "imibhalo/umzuzwana"
+
+#~ msgid "milliseconds"
+#~ msgstr "imizuzwana"
+
+#~ msgid "pixels/second"
+#~ msgstr "amachaphaza/umzuzu"
+
+#~ msgid "Desktop Background"
+#~ msgstr "Isizinda sesiganyezi"
+
+#~ msgid "<b>Desktop _Wallpaper</b>"
+#~ msgstr "<b>_Iphepha elihlotsisiwe lwesizinda sesiga-nyezi</b>"
+
+#~ msgid "<b>_Desktop Colors</b>"
+#~ msgstr "<b>Imibala yobuso be _Siga-nyezi</b>"
+
+#~ msgid "Desktop Background Preferences"
+#~ msgstr "Isizinda sesiga-nyezi esithandekayo"
+
+#~ msgid "_Add Wallpaper"
+#~ msgstr "_Faka iphepha elihlotshisiweyo"
+
+#~ msgid "_Style:"
+#~ msgstr "_Inhlobo:"
+
+#, c-format
+#~ msgid "There was an error displaying help: %s"
+#~ msgstr "Kube khona iphutha elibonisa usizo: %s"
+
+#~ msgid "Tiled"
+#~ msgstr "Ihlotshisiwe"
+
+#~ msgid "Horizontal Gradient"
+#~ msgstr "Ubukhulu bokukhuphuka obuqondile buthe ndindilizi"
+
+#~ msgid "Vertical Gradient"
+#~ msgstr "Ubukhulu bokukhuphuka obuqondile buthe ndindilizi obumile"
+
+#~ msgid "Add Wallpaper"
+#~ msgstr "Faka iphepha elihlotsisiwe"
+
+#~ msgid ""
+#~ "Unable to start the settings manager 'gnome-settings-daemon'.\n"
+#~ "Without the GNOME settings manager running, some preferences may not take "
+#~ "effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. "
+#~ "KDE) settings manager may already be active and conflicting with the "
+#~ "GNOME settings manager."
+#~ msgstr ""
+#~ "Ihlulekile ukuqala umphathi hlelo 'gnome-settings-daemon'.\n"
+#~ "Ngaphandle kohlelo lomphathi weGNOME esebenza, ezinye ezithandekayo "
+#~ "ngekhe zisebenze. Lokhu kungaveza inkinga nge bonobo, noma i-GNOME "
+#~ "engekho (isibonelo KDE) umphathi wohlelo angahle sekaya sebenza abuye "
+#~ "aphikisane nomphathi hlelo weGNOME."
+
+#, c-format
+#~ msgid "Unable to load capplet stock icon '%s'\n"
+#~ msgstr "Ihlulekile ukufaka uphawu capplet stock '%s'\n"
+
+#~ msgid "Just apply settings and quit"
+#~ msgstr "Faka uhlelo uphume"
+
+#~ msgid "Retrieve and store legacy settings"
+#~ msgstr "Buyisa futhi ugcine uhlelo lobucebi"
+
+#~ msgid "From URI"
+#~ msgstr "Iphuma URI"
+
+#~ msgid "URI currently transferring from"
+#~ msgstr "Okwamanje URI idlulisela okuphuma"
+
+#~ msgid "To URI"
+#~ msgstr "Iya URI"
+
+#~ msgid "URI currently transferring to"
+#~ msgstr "URI okwamanje edlulisela ku"
+
+#~ msgid "Fraction of transfer currently completed"
+#~ msgstr "Ukudluliselwa kwesigamu sesibalo kuqediwe"
+
+#~ msgid "Current URI index"
+#~ msgstr "Inkomba yamanje ye URI"
+
+#~ msgid "Current URI index - starts from 1"
+#~ msgstr "Inkomba yamanje ye URI - iqala ku 1"
+
+#~ msgid "Total URIs"
+#~ msgstr "URIs eziphelele"
+
+#~ msgid "Total number of URIs"
+#~ msgstr "Inani eliphelele le URIs"
+
+#~ msgid "Key"
+#~ msgstr "Inkinombho"
+
+#~ msgid "GConf key to which this property editor is attached"
+#~ msgstr "Inkinombo Gconf lapho lesisakhi sokuhlela sinamatheliswe khona"
+
+#~ msgid "Callback"
+#~ msgstr "Bizela emuva"
+
+#~ msgid "Issue this callback when the value associated with key gets changed"
+#~ msgstr ""
+#~ "Kipha lesisimemo sokubuyela emuva uma inani elithintekayo kumankinombho "
+#~ "lishintshwa"
+
+#~ msgid ""
+#~ "GConf change set containing data to be forwarded to the gconf client on "
+#~ "apply"
+#~ msgstr ""
+#~ "Gconf ishintsha uhlelo olukhungethe ulwazi olumelwe luthunyelwe "
+#~ "kwikhasimende ye gconf ekuyingeniseni"
+
+#~ msgid "Conversion to widget callback"
+#~ msgstr "Ukuguqulwa kwewidget ebizela emuva"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted from GConf to the "
+#~ "widget"
+#~ msgstr ""
+#~ "Isibizo sangemuva sizokhishwa uma imniningo imelwe ukushintshwa ukusuka "
+#~ "ku Gconf ukuya kwiwidget"
+
+#~ msgid "Conversion from widget callback"
+#~ msgstr "Ukuguqulwa kwewidget ebizela emuva"
+
+#~ msgid ""
+#~ "Callback to be issued when data are to be converted to GConf from the "
+#~ "widget"
+#~ msgstr ""
+#~ "Isibizo sangemuva sizokhishwa uma imniningo imelwe ukushintshwa ukusuka "
+#~ "ku Gconf ukuya kwiwidget"
+
+#~ msgid "Object that controls the property (normally a widget)"
+#~ msgstr "Into elawula leso sakha (okwejwayelekile yiwidget)"
+
+#~ msgid "Property editor object data"
+#~ msgstr "Umhleli wezakha into yemniningo"
+
+#~ msgid "Custom data required by the specific property editor"
+#~ msgstr "Imniningo yesiko icelwa yisakha esithize somhleli"
+
+#~ msgid "Property editor data freeing callback"
+#~ msgstr "Umhleli wesakha ukhulula imniningo yokushaya ngasemuva"
+
+#~ msgid ""
+#~ "Callback to be issued when property editor object data is to be freed"
+#~ msgstr ""
+#~ "Kuzo khishwa isibizo ngasemuva uma umhleli wesakha wento yomniningo "
+#~ "ekhululwa"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't find the file '%s'.\n"
+#~ "\n"
+#~ "Please make sure it exists and try again, or choose a different "
+#~ "background picture."
+#~ msgstr ""
+#~ "Yehlulekile ukuthola ihele '%s'.\n"
+#~ "\n"
+#~ "Sicela uqiniseke ukuba yikhona uphinde uzame futhi, noma khetha isithombe "
+#~ "esehlukile sesizinda sesiga-nyezi."
+
+#, c-format
+#~ msgid ""
+#~ "I don't know how to open the file '%s'.\n"
+#~ "Perhaps it's a kind of picture that is not yet supported.\n"
+#~ "\n"
+#~ "Please select a different picture instead."
+#~ msgstr ""
+#~ "Angikwazi ukuvula ihele '%s'.\n"
+#~ "Mhlambe yinhlobo yesithombe esingakaxhaswa.\n"
+#~ "\n"
+#~ "Sicela ukhethe isithombe esihlukile kunalokho."
+
+#~ msgid "Please select an image."
+#~ msgstr "Sicela ukhethe isithombe."
+
+#, fuzzy
+#~ msgid "Debian Sensible Browser"
+#~ msgstr "Isiyaluzi solwembu esinephutha"
+
+#~ msgid "Epiphany"
+#~ msgstr "Epiphany"
+
+#~ msgid "Galeon"
+#~ msgstr "Galeon"
+
+#~ msgid "Encompass"
+#~ msgstr "Encompass"
+
+#, fuzzy
+#~ msgid "Firebird"
+#~ msgstr "Firebird/FireFox"
+
+#, fuzzy
+#~ msgid "Mozilla"
+#~ msgstr "Umyalezo we Mozilla"
+
+#~ msgid "Netscape Communicator"
+#~ msgstr "Umxhumanisi we Netscape"
+
+#~ msgid "Konqueror"
+#~ msgstr "Konqueror"
+
+#~ msgid "W3M Text Browser"
+#~ msgstr "W3M Isiyaluzi setekisi"
+
+#~ msgid "Lynx Text Browser"
+#~ msgstr "Lynx Isiyaluzi setekisi"
+
+#~ msgid "Links Text Browser"
+#~ msgstr "Links Isiyaluzi setekisi"
+
+#~ msgid "Evolution Mail Reader"
+#~ msgstr "Umfundi miyalezo we-Evolution"
+
+#~ msgid "Balsa"
+#~ msgstr "Balsa"
+
+#~ msgid "Mozilla Mail"
+#~ msgstr "Umyalezo we Mozilla"
+
+#~ msgid "Mutt"
+#~ msgstr "Mutt"
+
+#, fuzzy
+#~ msgid "Debian Terminal Emulator"
+#~ msgstr "Isixhumanisi esinephutha"
+
+#~ msgid "Standard XTerminal"
+#~ msgstr "Isixhumi X esejwayekile"
+
+#~ msgid "NXterm"
+#~ msgstr "Nxterm"
+
+#~ msgid "RXVT"
+#~ msgstr "RXVT"
+
+#, fuzzy
+#~ msgid "aterm"
+#~ msgstr "Nxterm"
+
+#~ msgid "ETerm"
+#~ msgstr "ETerm"
+
+#~ msgid "Please specify a name and a command for this editor."
+#~ msgstr "Sicela uchaze igama nomyalo walombhali."
+
+#, fuzzy
+#~ msgid "C_ustom"
+#~ msgstr "Isiko"
+
+#, fuzzy
+#~ msgid "C_ustom:"
+#~ msgstr "Isiko"
+
+#, fuzzy
+#~ msgid "Can open multiple _files"
+#~ msgstr "Lesisithobo singavula ohele _abaningi"
+
+#~ msgid "Co_mmand:"
+#~ msgstr "Umy_alo:"
+
+#~ msgid "Custom Editor Properties"
+#~ msgstr "Izakhi zomhleli zesiko"
+
+#~ msgid "Default Mail Reader"
+#~ msgstr "Umfundi miyalezo onephutha"
+
+#~ msgid "Default Terminal"
+#~ msgstr "Isixhumanisi esinephutha"
+
+#~ msgid "Default Text Editor"
+#~ msgstr "Umhleli wetekisi onephutha"
+
+#~ msgid "Default Web Browser"
+#~ msgstr "Isiyaluzi solwembu esinephutha"
+
+#~ msgid "Default Window Manager"
+#~ msgstr "Umphathi wefasitela onephutha"
+
+#~ msgid "Delete"
+#~ msgstr "Susa"
+
+#~ msgid "E_xec Flag:"
+#~ msgstr "E_exc iflagi:"
+
+#~ msgid "Edit..."
+#~ msgstr "Hlela..."
+
+#~ msgid "Mail Reader"
+#~ msgstr "Umfundi milayezo"
+
+#, fuzzy
+#~ msgid "Run in a _terminal"
+#~ msgstr "Hambisa phakathi koku_xhuma"
+
+#, fuzzy
+#~ msgid "Run in a t_erminal"
+#~ msgstr "Hambisa phakathi koku_xhuma"
+
+#~ msgid ""
+#~ "Select the window manager you want.  You will need to hit apply, wave the "
+#~ "magic wand, and do a magic dance for it to work."
+#~ msgstr ""
+#~ "Khetha umphathi wefasitela omfunayo. Kumele ushaye usebenzisa, uthinte "
+#~ "iwandi elizenzekelayo, ubuye wenze umdanso ukuze isebenze."
+
+#~ msgid "Terminal"
+#~ msgstr "Isixhumanisi"
+
+#~ msgid "Text Editor"
+#~ msgstr "Uhele wetekisi"
+
+#~ msgid "Understands _Netscape Remote Control"
+#~ msgstr "Yiqonda ukulawulwa ngongesi yi _Netscape"
+
+#~ msgid "Use this _editor to open text files in the file manager"
+#~ msgstr ""
+#~ "Sebenzisa lo_mhleli ukuvula ihele letekisi phakathi komphathi wehele"
+
+#~ msgid "Web Browser"
+#~ msgstr "Isiyaluzi solwembu"
+
+#~ msgid "_Properties..."
+#~ msgstr "_Izakhi..."
+
+#, fuzzy
+#~ msgid "_Select:"
+#~ msgstr "_Khetha"
+
+#~ msgid "Change screen resolution"
+#~ msgstr "Shintsa isinqumo sobuso besiga-nyezi"
+
+#, c-format
+#~ msgid "%d Hz"
+#~ msgstr "%d Hz"
+
+#~ msgid "Screen Resolution Preferences"
+#~ msgstr "Isinqumo esithandekayo sobuso besiga-nyezi"
+
+#, c-format
+#~ msgid "_Make default for this computer (%s) only"
+#~ msgstr "_Yenza iphutha lwesiga-nyezi (%s) kuphela"
+
+#, c-format
+#~ msgid ""
+#~ "Testing the new settings. If you don't respond in %d second the previous "
+#~ "settings will be restored."
+#~ msgid_plural ""
+#~ "Testing the new settings. If you don't respond in %d seconds the previous "
+#~ "settings will be restored."
+#~ msgstr[0] ""
+#~ "Ukuhlolwa kwezinhlelo ezintsha. Uma ungaphendule %d emzuzwaneni izinhlelo "
+#~ "ezidlulile zizophindwa zibuyiswe."
+#~ msgstr[1] ""
+#~ "Ukuhlolwa kwezinhlelo ezintsha. Uma ungaphendule %d emizuzwaneni "
+#~ "izinhlelo ezidlulile zizophindwa zibuyiswe."
+
+#~ msgid "Keep Resolution"
+#~ msgstr "Gcina isinqumo"
+
+#~ msgid "Do you want to keep this resolution?"
+#~ msgstr "Ufuna ukugcina lesisinqumo?"
+
+#~ msgid "Use _previous resolution"
+#~ msgstr "Sebenzisa isinqumo _esidlulile"
+
+#~ msgid "_Keep resolution"
+#~ msgstr "_Gcina isinqumo"
+
+#~ msgid ""
+#~ "The X Server does not support the XRandR extension.  Runtime resolution "
+#~ "changes to the display size are not available."
+#~ msgstr ""
+#~ "Isisebenzi X asixhasi XRandR yangaphandle. Isikhathi sokusebenza "
+#~ "sesinqumo sishintsha isilinganiso somboniso azitholakali."
+
+#~ msgid ""
+#~ "The version of the XRandR extension is incompatible with this program. "
+#~ "Runtime changes to the display size are not available."
+#~ msgstr ""
+#~ "Ukulandisa kwe XRandR yangaphandle akusebenzi kuloluhlelo. Isikhathi "
+#~ "sokusebenza sishintsha isilinganiso sokubonisa azitholakali."
+
+#~ msgid "Font"
+#~ msgstr "Isiqwema"
+
+#~ msgid "Select fonts for the desktop"
+#~ msgstr "Khetha isiqwema sesiga-nyezi"
+
+#~ msgid "<b>Font Rendering</b>"
+#~ msgstr "<b>Ukutyelekana isiqwema</b>"
+
+#~ msgid "<b>Hinting</b>:"
+#~ msgstr "<b>Isexwayiso</b>:"
+
+#~ msgid "<b>Smoothing</b>:"
+#~ msgstr "<b>Bushelezi</b>:"
+
+#~ msgid "<b>Subpixel order</b>:"
+#~ msgstr "<b>Umyalo wechashazana</b>:"
+
+#~ msgid "Best _shapes"
+#~ msgstr "_Isimo esibalasele"
+
+#~ msgid "Best co_ntrast"
+#~ msgstr "Ukukha_nya okubalasele"
+
+#~ msgid "D_etails..."
+#~ msgstr "Im_niningwane..."
+
+#~ msgid "Font Preferences"
+#~ msgstr "Isiqwema esithandekayo"
+
+#~ msgid "Go _to font folder"
+#~ msgstr "Hamba _kwi sibaya sesiqwema"
+
+#~ msgid "Gra_yscale"
+#~ msgstr "Isilinganiso esi_gray"
+
+#~ msgid "N_one"
+#~ msgstr "L_utho"
+
+#~ msgid "R_esolution:"
+#~ msgstr "I_siqumo:"
+
+#~ msgid "Sub_pixel (LCDs)"
+#~ msgstr "Ama_chashazana (LCDs)"
+
+#~ msgid "Sub_pixel smoothing (LCDs)"
+#~ msgstr "Ukushelela kwama_chashazana (LCDs)"
+
+#~ msgid "VB_GR"
+#~ msgstr "VB_GR"
+
+#~ msgid "_BGR"
+#~ msgstr "_BGR"
+
+#~ msgid "_Desktop font:"
+#~ msgstr "_Isiqwema sesiga-nyezi:"
+
+#~ msgid "_Medium"
+#~ msgstr "_Iphakathi"
+
+#~ msgid "_Monochrome"
+#~ msgstr "_Isiqalo esiphathele sodwa"
+
+#~ msgid "_RGB"
+#~ msgstr "_RGB"
+
+#~ msgid "_Terminal font:"
+#~ msgstr "_Isixhumi siqwema:"
+
+#~ msgid "_VRGB"
+#~ msgstr "_VRGB"
+
+#~ msgid "_Window title font:"
+#~ msgstr "_Isihloko sombhalo wefasitela:"
+
+#~ msgid "dots per inch"
+#~ msgstr "amabala ngobude"
+
+#~ msgid "Font may be too large"
+#~ msgstr "Iisqqwema singaba sikhulu kakhulu"
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a size "
+#~ "smaller than %d."
+#~ msgstr[0] ""
+#~ "Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kubelikhuni "
+#~ "ukusebenzisa isiga-nyezi. Kuyakhuthazwa ukuba ukhethe isayizi encane kune "
+#~ "%d."
+#~ msgstr[1] ""
+#~ "Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kubelikhuni "
+#~ "ukusebenzisa isiga-nyezi. Kuyakhuthazwa ukuba ukhethe isayizi encane kune "
+#~ "%d."
+
+#, c-format
+#~ msgid ""
+#~ "The font selected is %d point large, and may make it difficult to "
+#~ "effectively use the computer.  It is recommended that you select a "
+#~ "smaller sized font."
+#~ msgid_plural ""
+#~ "The font selected is %d points large, and may make it difficult to "
+#~ "effectively use the computer. It is recommended that you select a smaller "
+#~ "sized font."
+#~ msgstr[0] ""
+#~ "Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kubelikhuni "
+#~ "ukusebenzisa isiga-nyezi. Kuyakhuthazwa ukuba ukhethe isayizi encane."
+#~ msgstr[1] ""
+#~ "Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kebe likhuni "
+#~ "ukusebenzisa isiga-nyezi. Kuya khuthazwa ukuba ukhethe isayizi encane."
+
+#~ msgid "New accelerator..."
+#~ msgstr "Isigijimi esisha..."
+
+#~ msgid "Accelerator key"
+#~ msgstr "Inkinombho yesigijimi"
+
+#~ msgid "Accelerator modifiers"
+#~ msgstr "Izilungisi zesigijimi"
+
+#~ msgid "Accelerator keycode"
+#~ msgstr "Inkinombho lekhodi lesigijimi"
+
+#~ msgid "The type of accelerator."
+#~ msgstr "Uhlobo lwesigijimi."
+
+#~ msgid "<Unknown Action>"
+#~ msgstr "<Isenzo esingaziwa>"
+
+#~ msgid "Window Management"
+#~ msgstr "Ukuphathwa kwefasitela"
+
+#, c-format
+#~ msgid ""
+#~ "The shortcut \"%s\" is already used for:\n"
+#~ " \"%s\"\n"
+#~ msgstr ""
+#~ "Indlela emfishane \"%s\" sele yisebenziselwe uku:\n"
+#~ " \"%s\"\n"
+
+#, c-format
+#~ msgid "Error setting new accelerator in configuration database: %s\n"
+#~ msgstr "Iphutha lihlelela isigijimi esisha kumumo wokulonda: %s\n"
+
+#, c-format
+#~ msgid "Error unsetting accelerator in configuration database: %s\n"
+#~ msgstr "Iphutha alihleli isigijimi kumumo wokulonda: %s\n"
+
+#~ msgid ""
+#~ "To edit a shortcut key, click on the corresponding row and type a new "
+#~ "accelerator, or press backspace to clear."
+#~ msgstr ""
+#~ "Ukuhlela inkinombho enqamulayo, potshoza emugqeni ongale ubhale isigijimi "
+#~ "esisha, okanye potshoza inkinombho lokubuyisela isikhala emuva ukusula."
+
+#~ msgid "Assign shortcut keys to commands"
+#~ msgstr "Nikela iinkinombho kwimilayezo"
+
+#~ msgid "Unknown"
+#~ msgstr "Ayaziwa"
+
+#, c-format
+#~ msgid "There was an error launching the keyboard capplet : %s"
+#~ msgstr ""
+#~ "Kube khona iphutha uma kungeniswa i-capplet yendawo yokushaya uma ubhala: "
+#~ "%s"
+
+#~ msgid ""
+#~ "Just apply settings and quit (compatibility only; now handled by daemon)"
+#~ msgstr "Sebenzisa uhlelo uphe (ingacinwa kuphela; manje iphethwe yi-daemon)"
+
+#~ msgid "Start the page with the typing break settings showing"
+#~ msgstr "Qala ikhasi ngokubhala ngokunqamula ukhombisa izinhlelo"
+
+#~ msgid "..."
+#~ msgstr "..."
+
+#~ msgid "<b>_Lock screen to enforce typing break</b>"
+#~ msgstr "<b>_Vala ubusos ukufaka ngenkani umbhalo onqamulayo</b>"
+
+#~ msgid "<small><i>Fast</i></small>"
+#~ msgstr "<small><i>Shesha</i></small>"
+
+#~ msgid "<small><i>Long</i></small>"
+#~ msgstr "<small><i>Inde</i></small>"
+
+#~ msgid "<small><i>Short</i></small>"
+#~ msgstr "<small><i>Imfisha</i></small>"
+
+#~ msgid "<small><i>Slow</i></small>"
+#~ msgstr "<small><i>Nwabuza</i></small>"
+
+#~ msgid "A_vailable layouts:"
+#~ msgstr "Umphandle o_tholakalayo:"
+
+#~ msgid "All_ow postponing of breaks"
+#~ msgstr "V_umela ukubuyiselwa emuva kwezinqamuli"
+
+#~ msgid "Check if breaks are allowed to be postponed"
+#~ msgstr "Qaphela ukuba izinqamuli zivunyelwe ukuhlehliswa"
+
+#, fuzzy
+#~ msgid "Choose A Keyboard Model"
+#~ msgstr "Khetha isifanekiso sendawo yokushaya uma ubhala"
+
+#, fuzzy
+#~ msgid "Choose A Layout"
+#~ msgstr "Vala futhi _uphume"
+
+#~ msgid "Duration of the break when typing is disallowed"
+#~ msgstr "Isikhathi sokunqamula uma ukubhala kungavumelekile"
+
+#~ msgid "Duration of work before forcing a break"
+#~ msgstr "Isikhathi somsebenzi phambi kokufaka isinqamuli ngenkani"
+
+#~ msgid "Keyboard Preferences"
+#~ msgstr "Okuthandekayo endaweni yokushaya uma ubhala"
+
+#~ msgid "Keyboard _model:"
+#~ msgstr "_Isifanekiso sendawo yokushaya uma ubhala:"
+
+#~ msgid "Layout Options"
+#~ msgstr "Ukhetha umumo"
+
+#~ msgid "Layouts"
+#~ msgstr "Umumo"
+
+#~ msgid ""
+#~ "Lock screen after a certain duration to help prevent repetitive keyboard "
+#~ "use injuries"
+#~ msgstr ""
+#~ "Vala ubuso besiga-nyezi emuva kwesikhathi esithile ukusiza ukuvimba "
+#~ "ukuziphinda ukusebenzisa izingozi"
+
+#~ msgid "Microsoft Natural Keyboard"
+#~ msgstr "Indawo yokushaya uma ubhala yendalo ye-Microsoft"
+
+#~ msgid "_Accessibility..."
+#~ msgstr "_Ukungenisela..."
+
+#~ msgid "_Break interval lasts:"
+#~ msgstr "_Umkhawulo wokugina wokunqamula:"
+
+#, fuzzy
+#~ msgid "_Models:"
+#~ msgstr "_Izifanekiso"
+
+#~ msgid "_Selected layouts:"
+#~ msgstr "_Umumo okhethiwe:"
+
+#~ msgid "_Work interval lasts:"
+#~ msgstr "_Umsebenzi womkhawulo ekugcineni:"
+
+#~ msgid "Set your keyboard preferences"
+#~ msgstr "Hlela indawo zakho ozithandayo kwindawo yokushaya uma ubhala"
+
+#~ msgid "Unknown Cursor"
+#~ msgstr "Isikhombisi esingaziwa"
+
+#~ msgid "Default Cursor"
+#~ msgstr "Isikhombi esinephutha"
+
+#~ msgid "Default Cursor - Current"
+#~ msgstr "Isikhombi esinephutha - Manje"
+
+#~ msgid "The default cursor that ships with X"
+#~ msgstr "Isikhombi esinephutha esihambisana no-X"
+
+#~ msgid "White Cursor"
+#~ msgstr "Isikhombi esimhlophe"
+
+#~ msgid "White Cursor - Current"
+#~ msgstr "Isikhombi esimhlophe - okwamanje"
+
+#~ msgid "The default cursor inverted"
+#~ msgstr "Isikhombi esinephuthat sifakiwe"
+
+#~ msgid "Large Cursor"
+#~ msgstr "Isikhombi esikhulu"
+
+#~ msgid "Large Cursor - Current"
+#~ msgstr "Isikhombi esikhulu - okwamanje"
+
+#~ msgid "Large version of normal cursor"
+#~ msgstr "Umlandiso omkhulu wesikhombi esejwayelekile"
+
+#~ msgid "Large White Cursor - Current"
+#~ msgstr "Isikhombi esimhlophe esikhulu - okwamanje"
+
+#~ msgid "Large White Cursor"
+#~ msgstr "Isikhombi esimhlophe esikhulu"
+
+#~ msgid "Large version of white cursor"
+#~ msgstr "Umlandisi omkhulu wesikhombi esimhlophe"
+
+#~ msgid "Cursor Theme"
+#~ msgstr "Indikimba yesikhombi"
+
+#~ msgid "<b>Drag and Drop</b>"
+#~ msgstr "<b>Dontsa futhi uphontse</b>"
+
+#~ msgid "<b>Speed</b>"
+#~ msgstr "<b>Ijubane</b>"
+
+#~ msgid "<i>Fast</i>"
+#~ msgstr "<i>Shesha</i>"
+
+#~ msgid "<i>High</i>"
+#~ msgstr "<i>Phezulu</i>"
+
+#~ msgid "<i>Large</i>"
+#~ msgstr "<i>Okukhulu</i>"
+
+#~ msgid "<i>Low</i>"
+#~ msgstr "<i>Okuphantsi</i>"
+
+#~ msgid "<i>Slow</i>"
+#~ msgstr "<i>Nwazayo</i>"
+
+#~ msgid "<i>Small</i>"
+#~ msgstr "<i>Ncanel</i>"
+
+#~ msgid "Cursors"
+#~ msgstr "Izikhombi"
+
+#~ msgid "Highlight the _pointer when you press Ctrl"
+#~ msgstr "Khanyisela _isikhombisi uma upotshoza Ctrl"
+
+#~ msgid "Motion"
+#~ msgstr "Intshukumo"
+
+#~ msgid "Mouse Preferences"
+#~ msgstr "Okuthandekayo kwesingoso"
+
+#~ msgid "_Left-handed mouse"
+#~ msgstr "_Isingoso sesandla sasebunxele"
+
+#~ msgid "_Sensitivity:"
+#~ msgstr "_Binyekile:"
+
+#~ msgid "Set your mouse preferences"
+#~ msgstr "Hlela okuthandekayo kwesingoso"
+
+#, fuzzy
+#~ msgid "Set your network proxy preferences"
+#~ msgstr "Okuthandekayo kwe-proxy yokuxhumana"
+
+#~ msgid "      "
+#~ msgstr "      "
+
+#, fuzzy
+#~ msgid "<b>D_irect internet connection</b>"
+#~ msgstr "<b>_Ukuxhumana ngqo kolwembu</b>"
+
+#~ msgid "<b>_Automatic proxy configuration</b>"
+#~ msgstr "<b>_Umumo wozenzakalelayo we-proxy</b>"
+
+#~ msgid "<b>_Manual proxy configuration</b>"
+#~ msgstr "<b>_Ukulungisa umumo we-proxy ngesandla</b>"
+
+#, fuzzy
+#~ msgid "Advanced Configuration"
+#~ msgstr "Ukulungisa ngokuzenzekela _URL:"
+
+#~ msgid "HTTP Proxy Details"
+#~ msgstr "Imniningwane emileyo ye-HTTP"
+
+#, fuzzy
+#~ msgid "Network Proxy Preferences"
+#~ msgstr "Okuthandekayo kwe-proxy yokuxhumana"
+
+#~ msgid "Port:"
+#~ msgstr "Itheku:"
+
+#~ msgid "_Secure HTTP proxy:"
+#~ msgstr "_Vikela i-HTTP ezimele:"
+
+#~ msgid "Enable sound and associate sounds with events"
+#~ msgstr "Nika amandla umsindo futhi ujwayeze imisindo nemicimbi"
+
+#~ msgid "Sound Preferences"
+#~ msgstr "Imisindo ethandekayo"
+
+#~ msgid "E_nable sound server startup"
+#~ msgstr "Ni_ka amandla uphathi womsindo ukuqala"
+
+#~ msgid "Flash _window titlebar"
+#~ msgstr "Khanyisa _ifasitela lohlu"
+
+#~ msgid "_Sound an audible bell"
+#~ msgstr "_Khalisa insimbi ezakalayo"
+
+#~ msgid "_Sounds for events"
+#~ msgstr "_Umsindo wemicimbi"
+
+#~ msgid "_Visual feedback:"
+#~ msgstr "_Impendulo ebonakalayo:"
+
+#~ msgid ""
+#~ "No themes could be found on your system.  This probably means that your "
+#~ "\"Theme Preferences\" dialog was improperly installed, or you haven't "
+#~ "installed the \"gnome-themes\" package."
+#~ msgstr ""
+#~ "Azikho indikima ezitholakele kuhlelo lwakho. Mhalbe lokhu kuchaza ukuthi "
+#~ "\"Indikima ezithandekayo\" ibhokisana lifakwe kabi, noma mhlambe "
+#~ "awukalifaki \"gnome-themes\" umthwalo."
+
+#, fuzzy
+#~ msgid "The file format is invalid"
+#~ msgstr "Ihele %s asiyilo ihele elifanele"
+
+#~ msgid "No theme file location specified to install"
+#~ msgstr "Akukho ihele lendikima elinendawo elifakiwe"
+
+#~ msgid "The theme file location specified to install is invalid"
+#~ msgstr "Indikima yehele echaziwe ukuthi ifakwe ayifanele"
+
+#, fuzzy
+#~ msgid "The file format is invalid."
+#~ msgstr "Ihele %s asiyilo ihele elifanele"
+
+#, c-format
+#~ msgid ""
+#~ "%s is the path where the theme files will be installed. This can not be "
+#~ "selected as the source location"
+#~ msgstr ""
+#~ "%s yindlela lapho indikima zohele zizofakwa khona. Lokhu ngeke kukhethwe "
+#~ "ngenje ndawo eyimvelo"
+
+#~ msgid "Custom theme"
+#~ msgstr "Indikima yesiko"
+
+#~ msgid "You can save this theme by pressing the Save Theme button."
+#~ msgstr ""
+#~ "Ungahlenga lendikima ngokupotshoza inkinombho lokuhlenga eliyindikima."
+
+#~ msgid ""
+#~ "The default theme schemas could not be found on your system.  This means "
+#~ "that you probably don't have metacity installed, or that your gconf is "
+#~ "configured incorrectly."
+#~ msgstr ""
+#~ "Indikima eziyiphutha ezingamaqembu azitholakalanga phakathi kohlu. Lokhu "
+#~ "kuchaza ukuthi awuna imetacity efakiwe, noma i-gconf yakho ifakwe kabi."
+
+#~ msgid "Theme name must be present"
+#~ msgstr "Igama lendikima kumele libe khona"
+
+#~ msgid "The theme already exists. Would you like to replace it?"
+#~ msgstr "Indikima sele yikhona. Ingabe uthanda ukufaka enye kunale?"
+
+#~ msgid "Select themes for various parts of the desktop"
+#~ msgstr "Khetha indikima zamalungu ahlukile esiga-nyezi"
+
+#~ msgid "Theme"
+#~ msgstr "Indikima"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+#~ msgstr "<span size=\"larger\" weight=\"bold\">Faka indikima</span>"
+
+#~ msgid "Theme Installation"
+#~ msgstr "Ukufakwa kwendikima"
+
+#~ msgid "_Install"
+#~ msgstr "_Faka"
+
+#~ msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+#~ msgstr ""
+#~ "<span size=\"larger\" weight=\"bold\">Hlenga indikima phakathi kwecwecwe</"
+#~ "span>"
+
+#~ msgid "Apply _Font"
+#~ msgstr "Sebenzisa _Isiqwema"
+
+#~ msgid "Icons"
+#~ msgstr "Amaphawu"
+
+#~ msgid "New themes can also be installed by dragging them into the window."
+#~ msgstr "Indikima ezinsha zinga fakwa ngokuzidontsela efasitileni."
+
+#~ msgid "Save Theme"
+#~ msgstr "Hlenga indikima"
+
+#~ msgid "Select theme for the desktop"
+#~ msgstr "Khetha indikima yesiga-nyezi"
+
+#~ msgid "Short _description:"
+#~ msgstr "_Umlandiso omfishane:"
+
+#~ msgid "Theme Preferences"
+#~ msgstr "Indikima ezithandekayo"
+
+#~ msgid "Theme _Details"
+#~ msgstr "_Imniningwane yendikima"
+
+#~ msgid "This theme does not suggest any particular font or background."
+#~ msgstr "Lendikima ayibonisi isiqwema esikhethekile noma isizinda."
+
+#~ msgid "This theme suggests a background:"
+#~ msgstr "Lendikima ibonisa isizinda:"
+
+#~ msgid "This theme suggests a font and a background:"
+#~ msgstr "Lendikima ibonisa isiqwema nesizinda:"
+
+#~ msgid "This theme suggests a font:"
+#~ msgstr "Lendikima ibonisa isiqwqema:"
+
+#~ msgid "Window Border"
+#~ msgstr "Isiyaluzi Window"
+
+#~ msgid "_Go To Theme Folder"
+#~ msgstr "_Hamba kwisibaya sendikimba"
+
+#~ msgid "_Revert"
+#~ msgstr "_Buyisela"
+
+#~ msgid "_Save Theme..."
+#~ msgstr "_Hlenga indikimba..."
+
+#~ msgid "theme selection tree"
+#~ msgstr "isihlahla sokukhetha indikimba"
+
+#~ msgid "Customize the appearance of toolbars and menubars in applications"
+#~ msgstr ""
+#~ "Hlela ngokwesiko ukubonakala kwehlu lwamathuluzi nohlu phakathi kwezithobo"
+
+#~ msgid "Menus & Toolbars"
+#~ msgstr "Uhlu & amathuluzi"
+
+#~ msgid "<b>Behavior and Appearance</b>"
+#~ msgstr "<b>Ukuziphatha nokubonakala</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Buka kuqala</b>"
+
+#~ msgid "C_ut"
+#~ msgstr "S_ika"
+
+#~ msgid "Icons only"
+#~ msgstr "Amaphawu wodwa"
+
+#~ msgid "Menu and Toolbar Preferences"
+#~ msgstr "Uhlu namathuluzi athandekayo"
+
+#~ msgid "New File"
+#~ msgstr "Ihele elisha"
+
+#~ msgid "Save File"
+#~ msgstr "Hlenga ihele"
+
+#~ msgid "Show _icons in menus"
+#~ msgstr "Bonisa _amaphawu phakathi kohlu"
+
+#~ msgid "Text below icons"
+#~ msgstr "Itekisi ngaphantsi kwamaphawu"
+
+#~ msgid "Text beside icons"
+#~ msgstr "Itekisi eceleni namaphawu"
+
+#~ msgid "Text only"
+#~ msgstr "Itekisi lodwa"
+
+#, fuzzy
+#~ msgid "Toolbar _button labels:"
+#~ msgstr "Ilebhula _lekinombho lamathuluzi: "
+
+#~ msgid "_Detachable toolbars"
+#~ msgstr "_Amathulusi anganamatheli"
+
+#~ msgid "_File"
+#~ msgstr "_Ihele"
+
+#~ msgid "_New"
+#~ msgstr "_Okusha"
+
+#~ msgid "_Paste"
+#~ msgstr "_Namthelisa"
+
+#, c-format
+#~ msgid ""
+#~ "<b>Cannot start the preferences application for your window manager</b>\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "<b>Ayikhoni ukuqala izithobo ezithandekayo zomphathi wefasitela wakho</"
+#~ "b>\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid "Control"
+#~ msgstr "Lawula"
+
+#~ msgid "Alt"
+#~ msgstr "Alt"
+
+#~ msgid "Hyper"
+#~ msgstr "Isiqalo esiphathelene nokweqisa"
+
+#~ msgid "Super (or \"Windows logo\")"
+#~ msgstr "Phezulu (noma \"Windows yesihlokondaba\")"
+
+#~ msgid "Meta"
+#~ msgstr "Meta"
+
+#~ msgid "<b>Movement Key</b>"
+#~ msgstr "<b>Inkinombho lokuhamba</b>"
+
+#~ msgid "<b>Titlebar Action</b>"
+#~ msgstr "<b>Isenzo sesihloko sohlu</b>"
+
+#~ msgid "<b>Window Selection</b>"
+#~ msgstr "<b>Ukhetho Window</b>"
+
+#~ msgid "To _move a window, press-and-hold this key then grab the window:"
+#~ msgstr ""
+#~ "Uku_hambisa ifasitela, potshoza-ubuye-ubambe lenkinombho uphinde ubambe "
+#~ "ifasitela:"
+
+#~ msgid "Window Preferences"
+#~ msgstr "Okuthadekayo kwe-Windows"
+
+#~ msgid "_Double-click titlebar to perform this action:"
+#~ msgstr "_Potshoza-kabili uhlu lwesihloko ukwenza lesisenzo:"
+
+#~ msgid "_Interval before raising:"
+#~ msgstr "_Umkhathi phambi kokuphakama:"
+
+#~ msgid "_Raise selected windows after an interval"
+#~ msgstr "_Phakamisa amafasitela akhethiwe emuva komkhawulo"
+
+#~ msgid "_Select windows when the mouse moves over them"
+#~ msgstr "_Khetha amafasitela uma isingoso sihamba phezu kwawo"
+
+#, fuzzy
+#~ msgid "Set your window properties"
+#~ msgstr "Izakhi Windows"
+
+#, fuzzy
+#~ msgid "Desktop Preferences"
+#~ msgstr "Isizinda sesiga-nyezi esithandekayo"
+
+#~ msgid "GNOME Control Center"
+#~ msgstr "GNOME umlawuli ophakathi"
+
+#~ msgid "The GNOME configuration tool"
+#~ msgstr "Ithulusi lokumisa lwe-GNOME"
+
+#~ msgid "Could not initialize Bonobo"
+#~ msgstr "Ihlukile ukuqala u-Bonobo"
+
+#~ msgid ""
+#~ "You just held down the Shift key for 8 seconds.  This is the shortcut for "
+#~ "the Slow Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Uqeda ukubambela phantsi inkinombho Shift imizuzwana 8. Le yindlela "
+#~ "emfishane yemniningo engasheshi yamankinombho, leyo ethinta indlela "
+#~ "indawo yokushaya uma ubhala esebenza ngayo."
+
+#~ msgid "Do you want to activate Slow Keys?"
+#~ msgstr "Ingabe ufuna ukukhanyisa amankinombho angasheshi?"
+
+#~ msgid "Do you want to deactivate Slow Keys?"
+#~ msgstr "Ingabe ufuna ukucisha amankinombho angasheshi?"
+
+#~ msgid ""
+#~ "You just pressed the Shift key 5 times in a row.  This is the shortcut "
+#~ "for the Sticky Keys feature, which affects the way your keyboard works."
+#~ msgstr ""
+#~ "Uqeda ukupotshozela inkinombho Shift 5 emugqeni. Le yindlela emfishane "
+#~ "yemniningo yamankinombho anamathelayo, lawo athinta indlela indawo yakho "
+#~ "yokushaya uma ubhala esebenza ngayo."
+
+#~ msgid ""
+#~ "You just pressed two keys at once, or pressed the Shift key 5 times in a "
+#~ "row.  This turns off the Sticky Keys feature, which affects the way your "
+#~ "keyboard works."
+#~ msgstr ""
+#~ "Uqeda ukupotsoza amankinombho amabili kanye, noma upotshoze inkinombho "
+#~ "Shift izihlanhlo 5 emugqeni. Lokhu kucisha imniningwane yamankinombho "
+#~ "anamathelayo, athintana nendlela indawo yakho yokushaya uma ubhala "
+#~ "isebenza ngayo."
+
+#~ msgid "Do you want to activate Sticky Keys?"
+#~ msgstr "Ingabe ufuna ukukhanyisa amankinombho anamathelayo?"
+
+#~ msgid "Do you want to deactivate Sticky Keys?"
+#~ msgstr "Ingabe ufuna ukucisha amankinombho anmathelayo?"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create the directory \"%s\".\n"
+#~ "This is needed to allow changing cursors."
+#~ msgstr ""
+#~ "Ihlulekile ukudala indlela yamakheli \"%s\".\n"
+#~ "Lokhu kuyadingeka ukuvumela izikhombi ezishintshayo."
+
+#, c-format
+#~ msgid "Key Binding (%s) has its action defined multiple times\n"
+#~ msgstr "Ukuphetha inkinombho (%s) inesenzo sayo esichaziwe kaningi\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) has its binding defined multiple times\n"
+#~ msgstr "Ukuphetha inkinombho (%s) inokuphethao kwayo okuchaziwe kaningi\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is incomplete\n"
+#~ msgstr "Ukuphetha inkinombho (%s) ayiphelele\n"
+
+#, c-format
+#~ msgid "Key Binding (%s) is invalid\n"
+#~ msgstr "Ukuphetha inkinombho (%s) akufanele\n"
+
+#, c-format
+#~ msgid "It seems that another application already has access to key '%d'."
+#~ msgstr ""
+#~ "Ikhombisa sengathi esinye isithobo sinemvume vele kwinkinombho '%d'."
+
+#, c-format
+#~ msgid "Key Binding (%s) is already in use\n"
+#~ msgstr "Ukuphetha inkinombho (%s) iyasebenziswa\n"
+
+#, c-format
+#~ msgid ""
+#~ "Error while trying to run (%s)\n"
+#~ "which is linked to the key (%s)"
+#~ msgstr ""
+#~ "Iphutha lenzekile uma usazama ukusebenza (%s)\n"
+#~ "elixhunyanyiswe kwisihlushulelo (%s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Error activating XKB configuration.\n"
+#~ "It can happen under various circumstances:\n"
+#~ "- a bug in libxklavier library\n"
+#~ "- a bug in X server (xkbcomp, xmodmap utilities)\n"
+#~ "- X server with incompatible libxkbfile implementation\n"
+#~ "\n"
+#~ "X server version data:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "If you report this situation as a bug, please include:\n"
+#~ "- The result of <b>%s</b>\n"
+#~ "- The result of <b>%s</b>"
+#~ msgstr ""
+#~ "Iphutha liyakhanyiswa uma kuhlelwa isimo XKB.\n"
+#~ "Mhalmbe ngaphakathi kwesisekeli X senkinga.\n"
+#~ "\n"
+#~ "imniningwane yesisekeli somhumusho:\n"
+#~ "%s\n"
+#~ "%d\n"
+#~ "%s\n"
+#~ "Uma ubika loludaba njengephutha, sicela ufake:\n"
+#~ "- Umphumela we <b>xprop -root | grep XKB</b>\n"
+#~ "- Umphumela we <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/xkb</"
+#~ "b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "You are using XFree 4.3.0.\n"
+#~ "There are known problems with complex XKB configurations.\n"
+#~ "Try using a simpler configuration or taking a fresher version of XFree "
+#~ "software."
+#~ msgstr ""
+#~ "Usebenzisa Xfree 4.3.0 \n"
+#~ "Kunezinkinga ezaziwayo ngokuhlangene XKB komumo wohlelo.\n"
+#~ "Zama ukusebenzisa umumo olula noma thatha umhumusho wamanje wesoftware "
+#~ "yeXFree."
+
+#, fuzzy
+#~ msgid "Do _not show this warning again"
+#~ msgstr "_Unga khombisi lomyalezo futhi"
+
+#~ msgid ""
+#~ "The X system keyboard settings differ from your current GNOME keyboard "
+#~ "settings.  Which set would you like to use?"
+#~ msgstr ""
+#~ "Uhlelo X lwendawo yokushaya uma ubhala uhlelo luhlukile kule yamanje ye-"
+#~ "GNOME. Ingabe ufuna ukusebenzisa uhlelo oluphi?"
+
+#~ msgid "Use X settings"
+#~ msgstr "Sebenzisa uhlelo X"
+
+#~ msgid "Use GNOME settings"
+#~ msgstr "Sebenzisa uhleo GNOME"
+
+#, c-format
+#~ msgid ""
+#~ "Couldn't execute command: %s\n"
+#~ "Verify that this command exists."
+#~ msgstr ""
+#~ "Ihlulekile ukubhala umyalo: %s\n"
+#~ "Qiniseka ukuba lomyalo usukhona."
+
+#~ msgid ""
+#~ "Couldn't put the machine to sleep.\n"
+#~ "Verify that the machine is correctly configured."
+#~ msgstr ""
+#~ "Ihlulekile ukulalisa umashini.\n"
+#~ "Bhekisisa ukuba umashini uhlelwe kahle."
+
+#, c-format
+#~ msgid "Permissions on the file %s are broken\n"
+#~ msgstr "Imvume phezu kwehele %s zinqamukile\n"
+
+#~ msgid ""
+#~ "Couldn't load the Glade file.\n"
+#~ "Make sure that this daemon is properly installed."
+#~ msgstr ""
+#~ "Ihlulekile ukufaka ihele le-Glade.\n"
+#~ "Qiniseka ukuba le-daemon ifakwe ngokufanele."
+
+#, c-format
+#~ msgid ""
+#~ "There was an error starting up the screensaver:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Screensaver functionality will not work in this session."
+#~ msgstr ""
+#~ "Kube khona iphutha makuqalwa isigcini sobuso besiga-nyezi:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Ukusebenza kwesigcini sobuso besiga-nyezi ngekhe kusebenze kulesiqephu."
+
+#~ msgid "_Do not show this message again"
+#~ msgstr "_Unga khombisi lomyalezo futhi"
+
+#, c-format
+#~ msgid "Couldn't load sound file %s as sample %s"
+#~ msgstr "Ihlulekile ukufaka ihele lomsindo %s njenge sibonelo %s"
+
+#~ msgid "Cannot determine user's home directory"
+#~ msgstr "Ihlulekile ukuthola ikheli lomsebenzisi"
+
+#, c-format
+#~ msgid "GConf key %s set to type %s but its expected type was %s\n"
+#~ msgstr ""
+#~ "Inkinombho GConf %s lihlelelwe ukubhala %s kepha ukubhala okulindelekile "
+#~ "bekuyi %s\n"
+
+#, fuzzy
+#~ msgid "A_vailable files:"
+#~ msgstr "Umphandle o_tholakalayo:"
+
+#, fuzzy
+#~ msgid "Do _not show this warning again."
+#~ msgstr "_Unga khombisi lomyalezo futhi"
+
+#~ msgid "Error creating signal pipe."
+#~ msgstr "Iphutha lidala ithumbu lezimpawu."
+
+#~ msgid ""
+#~ "Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+#~ "for preview"
+#~ msgstr ""
+#~ "Uhlobo le bg_sebenzisa: BG_APPLIER_ROOT lempande yefasitela noma "
+#~ "BG_APPLIER_PREVIEW ukubukwa kabusha"
+
+#~ msgid "Preview Width"
+#~ msgstr "Bheka kabusha ububanzi"
+
+#~ msgid "Width if applier is a preview: Defaults to 64."
+#~ msgstr "Dontsa kabanzi uma isisebenzisi siphinda: Amaphutha ku 64."
+
+#~ msgid "Preview Height"
+#~ msgstr "Hlolisisa ubude"
+
+#~ msgid "Height if applier is a preview: Defaults to 48."
+#~ msgstr "Ubude uma isesebenzisi siphinda: Amaphutha ku 48."
+
+#~ msgid "Screen on which BGApplier is to draw"
+#~ msgstr "Ubuso besiga-nyezi lapho I-BGApllier izokhipha"
+
+#, fuzzy, c-format
+#~ msgid "There was an error loading an image: %s"
+#~ msgstr "Kube khona iphutha elibonisa usizo: %s"
+
+#~ msgid "The sound file for this event does not exist."
+#~ msgstr "Ihele lomsindo lwalomcimbi alikho sanhlobo."
+
+#~ msgid ""
+#~ "The sound file for this event does not exist.\n"
+#~ "You may want to install the gnome-audio package\n"
+#~ "for a set of default sounds."
+#~ msgstr ""
+#~ "Ihele lomsindo lwalomcimbi alikho sanhlobo.\n"
+#~ "Ungafuna ukufaka isisakazi-gnome somthwalo\n"
+#~ "kumahlelo emniningwane yomsindo enephutha."
+
+#, c-format
+#~ msgid "The file %s is not a valid wav file"
+#~ msgstr "Ihele %s asiyilo ihele elifanele"
+
+#~ msgid "Event"
+#~ msgstr "Umcimbi"
+
+#~ msgid "Sound File"
+#~ msgstr "Ihele lomsindo"
+
+#~ msgid "_Play"
+#~ msgstr "_Dlala"
+
+#, c-format
+#~ msgid "Window manager \"%s\" has not registered a configuration tool\n"
+#~ msgstr ""
+#~ "Umphathi wefasitela \"%s\" akabhalisile ithulusi lokulungisa umumo\n"
+
+#~ msgid "Maximize"
+#~ msgstr "Khulisa"
+
+#~ msgid "Roll up"
+#~ msgstr "Yaluzisela phezulu"
+
+#~ msgid ""
+#~ "If true, the mime handlers for text/plain and text/* will be kept in sync"
+#~ msgstr ""
+#~ "Uma kuyiqiniso, abaphathi be-mime text/plain and text/* lizogcinwa "
+#~ "phakathi kwe-sync"
+
+#~ msgid "Sync text/plain and text/* handlers"
+#~ msgstr "Sync text/plain and text/* abaphathi"
+
+#~ msgid "Brightness down"
+#~ msgstr "Ukukhanya phantsi"
+
+#~ msgid "Brightness down's shortcut."
+#~ msgstr "Ukunqamula kokukhanya okuphantsi."
+
+#~ msgid "Brightness up's shortcut."
+#~ msgstr "Ukunqamula kokukhanya okuphezulu."
+
+#~ msgid "E-mail"
+#~ msgstr "Umyalezo-kagesi"
+
+#~ msgid "E-mail's shortcut."
+#~ msgstr "Ukunqamula komyalezo-kagesi."
+
+#~ msgid "Eject's shortcut."
+#~ msgstr "Ukunqamula kokukhipha."
+
+#~ msgid "Home folder's shortcut."
+#~ msgstr "Ukunqamula kwesibaya sasekhaya."
+
+#~ msgid "Launch help browser's shortcut."
+#~ msgstr "Ngenisa usizo lokunqamula isiyaluzi."
+
+#~ msgid "Launch web browser's shortcut."
+#~ msgstr "Ngenisa ukunqamula kwesiyaluzi solwembu."
+
+#~ msgid "Log out's shortcut."
+#~ msgstr "Phuma ngokunqamula."
+
+#~ msgid "Next track key's shortcut."
+#~ msgstr "Okulandela kokunqamula kwenkinombho."
+
+#~ msgid "Pause"
+#~ msgstr "Yima isikhashana"
+
+#~ msgid "Pause key's shortcut."
+#~ msgstr "Inkinombho lokunqamula kokuma isikhashana."
+
+#~ msgid "Play (or play/pause) key's shortcut."
+#~ msgstr "Dlala (noma dlala/misa isikhashana) inkinombho lokunqamula."
+
+#~ msgid "Previous track key's shortcut."
+#~ msgstr "Ingoma edlulile inkinombho lokunqamula."
+
+#~ msgid "Sleep"
+#~ msgstr "Cisha"
+
+#~ msgid "Sleep's shortcut."
+#~ msgstr "Ukunqamula uma ucisha."
+
+#~ msgid "Stop playback key's shortcut."
+#~ msgstr "Inkinombho lokumisa elinqamulayo."
+
+#~ msgid "Volume down's shortcut."
+#~ msgstr "Ukunqamula kwevolumu ephantsi."
+
+#~ msgid "Volume mute's shortcut"
+#~ msgstr "Ukunqamula kokucisha ivolumu okwesikhashana"
+
+#~ msgid "Volume step"
+#~ msgstr "Inyathelo lwevolumu"
+
+#~ msgid "Volume step as percentage of volume."
+#~ msgstr "Inyathelo lwevolumu njengamaphesenti."
+
+#~ msgid "Volume up's shortcut."
+#~ msgstr "Ukuqamula ivolumu ephezulu."
+
+#, fuzzy
+#~ msgid "Display a dialog when there are errors running the screensaver"
+#~ msgstr "Bonisa ibhokisi uma kukho amaphutha akhona XScreenSaver"
+
+#, fuzzy
+#~ msgid "Run screensaver at login"
+#~ msgstr "Sebenzisa XSreenSaver uma ungena"
+
+#~ msgid "Show Startup Errors"
+#~ msgstr "Khombisa amaphutha okungena"
+
+#, fuzzy
+#~ msgid "Start screensaver"
+#~ msgstr "Qala XScreenSaver"
+
+#, fuzzy
+#~ msgid "Keyboard Update Handlers"
+#~ msgstr "_Isifanekiso sendawo yokushaya uma ubhala:"
+
+#, fuzzy
+#~ msgid "Keyboard model"
+#~ msgstr "_Isifanekiso sendawo yokushaya uma ubhala:"
+
+#, fuzzy
+#~ msgid ""
+#~ "Keyboard settings in gconf will be overridden from the system ASAP "
+#~ "(deprecated)"
+#~ msgstr ""
+#~ "Uhlelo lwe-XKB phakathi kwe-gconf lizonyatheliswa emshinini masinya ASAP"
+
+#, fuzzy
+#~ msgid "keyboard layout"
+#~ msgstr "Umphandle wendawo yokushaya uma ubhala XKB"
+
+#, fuzzy
+#~ msgid "keyboard model"
+#~ msgstr "Isifanekiso sendawo yokushaya uma ubhala XKB"
+
+#~ msgid "_Postpone break"
+#~ msgstr "_Buyisela ukunqamuka emuva"
+
+#~ msgid "Take a break!"
+#~ msgstr "Thatha ikhefu"
+
+#~ msgid "/_Take a Break"
+#~ msgstr "/_Thatha ikhefu"
+
+#, c-format
+#~ msgid "%d minute until the next break"
+#~ msgid_plural "%d minutes until the next break"
+#~ msgstr[0] "%d umzuzu kude kufike elinye ikhefu"
+#~ msgstr[1] "%d imizuzu kude kufike elinye ikhefu"
+
+#~ msgid "Less than one minute until the next break"
+#~ msgstr "Ngaphantsi komzuzu kude kufike enye ikhefu"
+
+#, c-format
+#~ msgid ""
+#~ "Unable to bring up the typing break properties dialog with the following "
+#~ "error: %s"
+#~ msgstr ""
+#~ "Ihlulekile ukuletha umbhalo wokunqamula nezakha zebhokisi kulokhu "
+#~ "okulandelayo nephutha: %s"
+
+#~ msgid "About GNOME Typing Monitor"
+#~ msgstr "Ngobuso besiga-nyezi bokubhala nge-GNOME"
+
+#~ msgid "A computer break reminder."
+#~ msgstr "Isinqamulo sesiga-nyezi esikhumbuzayo."
+
+#~ msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+#~ msgstr "Ibhalwe ngu Richard Hult &It;richard@imendio.com&gt;"
+
+#~ msgid "Eye candy added by Anders Carlsson"
+#~ msgstr "Iso lonezelela ngo Anders Carlsson"
+
+#~ msgid "Break reminder"
+#~ msgstr "Isikhumbuzi ngokunqamuka"
+
+#~ msgid "The typing monitor is already running."
+#~ msgstr "Ubuso besiga-nyezi bokubhala sebuyasebenza."
+
+#, fuzzy
+#~ msgid ""
+#~ "The typing monitor uses the notification area to display information. You "
+#~ "don't seem to have a notification area on your panel. You can add it by "
+#~ "right-clicking on your panel and choosing 'Add to panel', selecting "
+#~ "'Notification area' and clicking 'Add'."
+#~ msgstr ""
+#~ "Ubuso besiganyezi bokubhala busebenzisa indawo yokwaziswa ukubonisa "
+#~ "ulwazi. Kubonakala sengathi awunayo indawo yokwazisa kwihlu lakho. Unga "
+#~ "yifaka ngokupotshoza ngakwesokudla kwihlu lakho ubuye ukhethe 'Faka kuhlu "
+#~ "-> Isisebenziswa -> Indawo yokwaziswa'."
+
+#~ msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+#~ msgstr ""
+#~ "Impungushe esheshayo embala womhlabathi yenqa phezu kwenja evilaphayo. "
+#~ "0123456789"
+
+#~ msgid "Size:"
+#~ msgstr "Isayizi:"
+
+#~ msgid "Copyright:"
+#~ msgstr "Ilungelo lombhali:"
+
+#~ msgid "Description:"
+#~ msgstr "Ukulanda:"
+
+#, c-format
+#~ msgid "usage: %s fontfile\n"
+#~ msgstr "ukusebenziswa: %s iqwemahele\n"
+
+#~ msgid "Set as Application Font"
+#~ msgstr "Hlela njenge siqwema sesithobo"
+
+#~ msgid "If set to true, then OpenType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Uma ihlelwe ukuba yiqiniso, ngakho ke OpenType amaqwema azogcizelelwa."
+
+#~ msgid "If set to true, then PCF fonts will be thumbnailed."
+#~ msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke PCF amaqwema azogcizelelwa."
+
+#~ msgid "If set to true, then TrueType fonts will be thumbnailed."
+#~ msgstr ""
+#~ "Uma ihlelwe ukuba yiqiniso, ngakho ke TrueType amaqwema azogcizelelwa."
+
+#~ msgid "If set to true, then Type1 fonts will be thumbnailed."
+#~ msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke Type1 amaqwema azogcizelelwa."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for OpenType fonts."
+#~ msgstr ""
+#~ "Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
+#~ "OpenType."
+
+#~ msgid "Set this key to the command used to create thumbnails for PCF fonts."
+#~ msgstr ""
+#~ "Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
+#~ "PCF."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for TrueType fonts."
+#~ msgstr ""
+#~ "Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
+#~ "TrueType."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for Type1 fonts."
+#~ msgstr ""
+#~ "Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
+#~ "Type1."
+
+#~ msgid "Thumbnail command for OpenType fonts"
+#~ msgstr "Gcizelela umyalo wesiqwema se-OpenType"
+
+#~ msgid "Thumbnail command for PCF fonts"
+#~ msgstr "Gcizelela umyalo wesiqwema se-PCF"
+
+#~ msgid "Thumbnail command for TrueType fonts"
+#~ msgstr "Gcizelela umyalo wesiqwema se-TrueType"
+
+#~ msgid "Thumbnail command for Type1 fonts"
+#~ msgstr "Gcizelela umyalo wesiqwema se-Type1"
+
+#~ msgid "Whether to thumbnail OpenType fonts"
+#~ msgstr "Mhlambe ukugcizelela iziqwema ze-OpenType"
+
+#~ msgid "Whether to thumbnail PCF fonts"
+#~ msgstr "Mhlambe ukugcizelela iziqwema ze-PCF"
+
+#~ msgid "Whether to thumbnail TrueType fonts"
+#~ msgstr "Mhlambe ukugcizelela iziqwema ze-TrueType"
+
+#~ msgid "Whether to thumbnail Type1 fonts"
+#~ msgstr "Mhlambe ukugcizelela iziqwema ze-Type1"
+
+#, fuzzy
+#~ msgid "GNOME Font Viewer"
+#~ msgstr "GNOME umlawuli ophakathi"
+
+#~ msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+#~ msgstr ""
+#~ "<span weight=\"bold\" size=\"larger\">Sebenzisa isiqwema esisha?</span>"
+
+#~ msgid "Do _not apply font"
+#~ msgstr "Unga_sebenzisi isiqwema"
+
+#~ msgid ""
+#~ "The theme you have selected suggests a new font. A preview of the font is "
+#~ "shown below."
+#~ msgstr ""
+#~ "Indikima oyikhethile ibonisa isiqwema esisha. Ukubukwa kabusha "
+#~ "kwalesosiqwema sibonisiwe ngezantsi."
+
+#~ msgid "Themes"
+#~ msgstr "Iindikima"
+
+#~ msgid "Description"
+#~ msgstr "Ukulanda"
+
+#~ msgid "Control theme"
+#~ msgstr "Lawula indikima"
+
+#~ msgid "Window border theme"
+#~ msgstr "Indikima ehlulayo yefasitela"
+
+#~ msgid "Icon theme"
+#~ msgstr "Indikima yophawu"
+
+#~ msgid "ABCDEFG"
+#~ msgstr "ABCDEFG"
+
+#, fuzzy
+#~ msgid "Apply theme"
+#~ msgstr "_Sebenzisa isiqwema"
+
+#, fuzzy
+#~ msgid "Sets the default theme"
+#~ msgstr "Hlela kabusha emaphu_theni"
+
+#~ msgid "If set to true, then installed themes will be thumbnailed."
+#~ msgstr "Uma ihlelelwe iqiniso, manje indikima ezifakiwe zizogcizelelwa."
+
+#~ msgid "If set to true, then themes will be thumbnailed."
+#~ msgstr "Uma ihlelelwe iqiniso, manje indikima zizogcizelelwa."
+
+#~ msgid ""
+#~ "Set this key to the command used to create thumbnails for installed "
+#~ "themes."
+#~ msgstr ""
+#~ "Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo kwindikima "
+#~ "ezifakiwe."
+
+#~ msgid "Set this key to the command used to create thumbnails for themes."
+#~ msgstr ""
+#~ "Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo kwindikima."
+
+#~ msgid "Thumbnail command for installed themes"
+#~ msgstr "Umyalo wokugcizelela wendikima ezifakiwe"
+
+#~ msgid "Thumbnail command for themes"
+#~ msgstr "Umyalo wokugcizelela wendikima"
+
+#~ msgid "Whether to thumbnail installed themes"
+#~ msgstr "Ngabe uzogcizelela izihloko ngesithupha ezifakiwe"
+
+#~ msgid "Whether to thumbnail themes"
+#~ msgstr "Ngabe uzogcizelela izihloko ngesithupha"

--- a/po/zu.po~
+++ b/po/zu.po~
@@ -1,0 +1,3512 @@
+# Zulu translation of gnome-control-center.
+# Copyright (C) 2004 Zuza Software Foundation (Translate.org.za)
+# This file is distributed under the same license as the gnome-control-center package.
+#
+# Zuza Software Foundation <info@translate.org.za>, 2004
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-control-center HEAD\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2005-09-17 22:10+0200\n"
+"PO-Revision-Date: 2004-12-13 19:02+0200\n"
+"Last-Translator: Zuza Software Foundation <info@translate.org.za>\n"
+"Language-Team: Zulu <translate-discuss-zu@lists.sourceforge.net>\n"
+"Language: zu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../capplets/about-me/eel-alert-dialog.c:114
+msgid "Image/label border"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:115
+msgid "Width of border around the label and image in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:124
+#, fuzzy
+msgid "Alert Type"
+msgstr "Faka uhlobo lwehele"
+
+#: ../capplets/about-me/eel-alert-dialog.c:125
+#, fuzzy
+msgid "The type of alert"
+msgstr "Uhlobo lwesigijimi."
+
+#: ../capplets/about-me/eel-alert-dialog.c:133
+#, fuzzy
+msgid "Alert Buttons"
+msgstr "Amankinombho"
+
+#: ../capplets/about-me/eel-alert-dialog.c:134
+msgid "The buttons shown in the alert dialog"
+msgstr ""
+
+#: ../capplets/about-me/eel-alert-dialog.c:198
+#, fuzzy
+msgid "Show more _details"
+msgstr "_Imniningwane yendikima"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:1
+#: ../capplets/about-me/gnome-about-me.glade.h:14
+#, fuzzy
+msgid "About Me"
+msgstr "_Nge"
+
+#: ../capplets/about-me/gnome-about-me.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your personal information"
+msgstr "Uhlobo lolwazi MIME"
+
+#: ../capplets/about-me/gnome-about-me.c:554
+#, fuzzy
+msgid "Select Image"
+msgstr "_Khetha"
+
+#: ../capplets/about-me/gnome-about-me.c:556
+#, fuzzy
+msgid "No Image"
+msgstr "Izithombe"
+
+#: ../capplets/about-me/gnome-about-me.c:706
+msgid ""
+"There was an error while trying to get the addressbook information\n"
+"Evolution Data Server can't handle the protocol"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:727
+msgid "Unable to open address book"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:739
+msgid "Unknown login ID, the user database might be corrupted"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.c:770
+#: ../capplets/about-me/gnome-about-me.c:772
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "_Nge"
+
+#: ../capplets/about-me/gnome-about-me-password.c:101
+#: ../capplets/about-me/gnome-about-me-password.c:479
+msgid "Old password is incorrect, please retype it"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:112
+msgid "System error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:113
+msgid "Could not run /usr/bin/passwd"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:114
+msgid "Unable to launch backend"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:116
+#: ../capplets/about-me/gnome-about-me-password.c:117
+msgid "Unexpected error has occurred"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:315
+msgid "Password is too short"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:318
+#: ../capplets/about-me/gnome-about-me-password.c:321
+msgid "Password is too simple"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:324
+msgid "Old and new passwords are too similar"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:328
+msgid "Old and new password are the same"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:406
+#, fuzzy
+msgid "Please type the passwords."
+msgstr "_Igama lokungena:"
+
+#: ../capplets/about-me/gnome-about-me-password.c:414
+msgid "Please type the password again, it is wrong."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me-password.c:417
+msgid "Click on Change Password to change the password."
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:1
+#: ../vfs-methods/themus/apply-font.glade.h:1
+msgid " "
+msgstr " "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:2
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:1
+#: ../capplets/font/font-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:1
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:1
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:1
+msgid "    "
+msgstr "    "
+
+#: ../capplets/about-me/gnome-about-me.glade.h:3
+#, fuzzy
+msgid "<b>Email</b>"
+msgstr "<i>Ncanel</i>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:4
+#, fuzzy
+msgid "<b>Home</b>"
+msgstr "<b>Ijubane</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:5
+#, fuzzy
+msgid "<b>Instant Messaging</b>"
+msgstr "<b>Ukutyelekana isiqwema</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:6
+#, fuzzy
+msgid "<b>Job</b>"
+msgstr "<b>Sekela</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:7
+msgid "<b>Please type the passwords.</b>"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:8
+#, fuzzy
+msgid "<b>Telephone</b>"
+msgstr "<b>Izihlushulelo zokugqoka</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:9
+#, fuzzy
+msgid "<b>Web</b>"
+msgstr "<b>Ijubane</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:10
+#, fuzzy
+msgid "<b>Work</b>"
+msgstr "<b>Sekela</b>"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:11
+msgid "A_IM/iChat:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:12
+#, fuzzy
+msgid "A_ddress:"
+msgstr "_Hlanganisa:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:13
+msgid "A_ssistant:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:15
+#, fuzzy
+msgid "Address"
+msgstr "_ipotshoziwe"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:16
+#, fuzzy
+msgid "C_ity:"
+msgstr "_Inhlobo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:17
+#, fuzzy
+msgid "C_ompany:"
+msgstr "Umy_alo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:18
+#, fuzzy
+msgid "Cale_ndar:"
+msgstr "Uhla_ngothi..."
+
+#: ../capplets/about-me/gnome-about-me.glade.h:19
+#, fuzzy
+msgid "Change Passwo_rd..."
+msgstr "Shintsha uhlelo"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:20
+#, fuzzy
+msgid "Change Password"
+msgstr "Shintsha uhlelo"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:21
+#, fuzzy
+msgid "Ci_ty:"
+msgstr "_Inhlobo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:22
+#, fuzzy
+msgid "Co_untry:"
+msgstr "Lawula"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:23
+#, fuzzy
+msgid "Contact"
+msgstr "_Iziqikili"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:24
+#, fuzzy
+msgid "Cou_ntry:"
+msgstr "Lawula"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:25
+msgid "Full Name"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:26
+#, fuzzy
+msgid "Hom_e:"
+msgstr "_Igama:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:27
+msgid "IC_Q:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:28
+msgid "M_SN:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:29
+#, fuzzy
+msgid "Old pa_ssword:"
+msgstr "_Igama lokungena:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:30
+msgid "P.O. _box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:31
+msgid "P._O. box:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:32
+#, fuzzy
+msgid "Personal Info"
+msgstr "_Isixhumi siqwema:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:33
+msgid "State/Pro_vince:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:34
+#, fuzzy
+msgid "User name:"
+msgstr "I_gamamsebemzi:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:35
+msgid "Web _log:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:36
+msgid "Wor_k:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:37
+msgid "Work _fax:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:38
+msgid "Zip/_Postal code:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:39
+#, fuzzy
+msgid "_Address:"
+msgstr "_Hlanganisa:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:40
+msgid "_Department:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:41
+msgid "_Groupwise:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:42
+#, fuzzy
+msgid "_Home page:"
+msgstr "_Igama lendikimba:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:43
+#, fuzzy
+msgid "_Home:"
+msgstr "_Igama:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:44
+msgid "_Jabber:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:45
+#, fuzzy
+msgid "_Manager:"
+msgstr "_Inkulisa"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:46
+#, fuzzy
+msgid "_Mobile:"
+msgstr "_Ihele"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:47
+#, fuzzy
+msgid "_New password:"
+msgstr "_Igama lokungena:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:48
+#, fuzzy
+msgid "_Profession:"
+msgstr "Umlandiso:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:49
+#, fuzzy
+msgid "_Retype new password:"
+msgstr "_Igama lokungena:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:50
+msgid "_State/Province:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:51
+#, fuzzy
+msgid "_Title:"
+msgstr "_Inhlobo:"
+
+#: ../capplets/about-me/gnome-about-me.glade.h:52
+msgid "_Work:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:53
+msgid "_Yahoo:"
+msgstr ""
+
+#: ../capplets/about-me/gnome-about-me.glade.h:54
+msgid "_Zip/Postal code:"
+msgstr ""
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:1
+msgid "<b>Applications</b>"
+msgstr "<b> Izithobo</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:2
+msgid "<b>Support</b>"
+msgstr "<b>Sekela</b>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:3
+msgid ""
+"<small><i><b>Note:</b> Changes to this setting will not take effect until "
+"you next log in.</i></small>"
+msgstr ""
+"<small><i><b>Qaphela:</b> Ushintsho kuloluhlelo angeke lwenzeke uze uphinde "
+"ungene futhi ngaphakathi.</i></small>"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:4
+msgid "Assistive Technology Preferences"
+msgstr "Usizo lwesayensi yemisebenzi ethile oluthandekayo"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:5
+msgid "Close and _Log Out"
+msgstr "Vala futhi _uphume"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:6
+msgid "Start these assistive technologies every time you log in:"
+msgstr "Qala lolusizo lwesayensi ethile ngazo zonke izikhathi uma ungena:"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:7
+msgid "_Enable assistive technologies"
+msgstr "_Nika amandla kusizo lwesayensi ethile"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:8
+msgid "_Magnifier"
+msgstr "_Inkulisa"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:9
+msgid "_On-screen keyboard"
+msgstr "_Ebusweni besiga-nyezi kwindawo yokushaya uma ubhala"
+
+#: ../capplets/accessibility/at-properties/at-enable-dialog.glade.h:10
+msgid "_Screenreader"
+msgstr "_Isifundi ebusweni besiga-nyezi"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:1
+msgid "Assistive Technology Support"
+msgstr "Usizo lwesayensi yemisebenzi ethile oluthandekayo"
+
+#: ../capplets/accessibility/at-properties/at-properties.desktop.in.in.h:2
+msgid "Enable support for GNOME assistive technologies at login"
+msgstr ""
+"Nika amandla ngokusekela I GNOME uma ungena kusizo lwesayensi yemisebenzi "
+"ethile"
+
+#: ../capplets/accessibility/at-properties/main.c:60
+msgid ""
+"No Assistive Technology is available on your system.  The 'gok' package must "
+"be installed in order to get on-screen keyboard support, and the "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Usizo lobugciko alukho phakathi kohlelo lwakho. Umthwalo we-'gok' imelwe "
+"ukufakwa ukuze uthole inxaso yobuso besiga-nyezi kwindawo yokushaya uma "
+"ubhala, nomthwalo we 'gnopernicus' kumelwe ufakwe ukuze ufundwe ebusweni "
+"besiga-nyezi namakhono okukhulisa."
+
+#: ../capplets/accessibility/at-properties/main.c:62
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gok' package must be installed in order to get on-screen keyboard support."
+msgstr ""
+"Akusilo lonke usizo olutholakalayo lwesayensi ethile olufakiwe phakathi "
+"komshini wakho. Isithungu se 'gok' kumelwe sifakwe ukuze kutholwe ukusekelwa "
+"kwindawo yokusahya uma ubhala ebusweni besiga-nyezi."
+
+#: ../capplets/accessibility/at-properties/main.c:64
+msgid ""
+"Not all available assistive technologies are installed on your system.  The "
+"'gnopernicus' package must be installed for screenreading and magnifying "
+"capabilities."
+msgstr ""
+"Usizo lwesayensi yemisebenzi ethile oluthandekayo alufakiwe phakathi "
+"emshinini wakho. Isishuqulu se 'gnopernicus' kumelwe sifakwe ukuze kufundwe "
+"ebusweni besiga-nyezi nokukhulisa okukhoekayo."
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:241
+#, c-format
+msgid "There was an error launching the mouse preferences dialog: %s"
+msgstr ""
+"Kube khona iphutha elenzikile uma kungeniswa ingoso oluthandekayo lokushaya: "
+"%s"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:337
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:398
+#, c-format
+msgid "Unable to import AccessX settings from file '%s'"
+msgstr "Ihlulekile ukuthwebula izinhlelo zemvumeX phakathi kwehele '%s'"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:435
+msgid "Import Feature Settings File"
+msgstr "Ingqondo yokuhlela imininingwane yehele"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.c:439
+msgid "_Import"
+msgstr "_Ngenisa okuvela ngaphandle"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:20
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:1
+msgid "Keyboard"
+msgstr "Indawo yokushaya uma ubhala"
+
+#: ../capplets/accessibility/keyboard/accessibility-keyboard.desktop.in.in.h:2
+msgid "Set your keyboard accessibility preferences"
+msgstr "Hlela indawo yakho yokubhala ngezimvume ezithandekayo"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.c:59
+msgid ""
+"This system does not seem to have the XKB extension.  The keyboard "
+"accessibility features will not operate without it."
+msgstr ""
+"Lomshini awutshengise njengonendawo yangaphandle ye XKB. Imininingwane "
+"yendawo yokushaya uma ubhala ngeke isebenze ngaphandle kwayo."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:2
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:1
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:2
+#: ../capplets/theme-switcher/theme-install.glade.h:1
+#: ../capplets/theme-switcher/theme-properties.glade.h:1
+msgid "*"
+msgstr "*"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:3
+msgid "<b>Enable Bo_unce Keys</b>"
+msgstr "<b>Nika amandla Qha_sha Izihluthulelo</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:4
+msgid "<b>Enable Slo_w Keys</b>"
+msgstr "<b>Nika amandla Kan_cane Izihluthulelo</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:5
+msgid "<b>Enable _Mouse Keys</b>"
+msgstr "<b>Nika amandla _Ingoso Izihluthulelo</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:6
+msgid "<b>Enable _Repeat Keys</b>"
+msgstr "<b>Nika amandla _Phinda Izihluthulelo</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:7
+msgid "<b>Enable _Sticky Keys</b>"
+msgstr "<b>Nika amandla _Namathelayo Izihluthulelo</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:8
+msgid "<b>Features</b>"
+msgstr "<b>Umumo</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:9
+msgid "<b>Toggle Keys</b>"
+msgstr "<b>Izihlushulelo zokugqoka</b>"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:10
+msgid "Basic"
+msgstr "Isisekelo"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:11
+msgid "Beep if key is re_jected"
+msgstr "Khala uma isihluthulelo sali_we"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:12
+msgid "Beep when _features turned on or off from keyboard"
+msgstr ""
+"Khala uma _umumo ucishiwe noma ukhanyisiwe kwindawo yokushaya uma ubhala"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:13
+msgid "Beep when _modifier is pressed"
+msgstr "Khala uma _isilungisi sipotshozwa"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:14
+msgid "Beep when an LED is turned on and two beeps when one is turned off."
+msgstr "Khala uma LED ikhanyisiwe futhi ikhale kabili uma enye icishiwe."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:15
+msgid "Beep when key is:"
+msgstr "Khala uma isihluthulelo siyi:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:16
+msgid "Del_ay:"
+msgstr "Chitha Isi_khathi:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:17
+msgid "Delay between keypress and pointer mo_vement:"
+msgstr ""
+"Chitha isikhathi phakathi kokupotshoza ikinombho nokuha_mba kwesikhombi:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:18
+msgid "Disa_ble if two keys pressed together"
+msgstr "Cis_ha uma amakinombho amabili epotshozwe kanye kanye"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:19
+msgid "E_nable Toggle Keys"
+msgstr "Nika ama_ndla amakinombho wokugqoka"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:20
+msgid "Filters"
+msgstr "Izisefo"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:21
+msgid "I_gnore duplicate keypresses within:"
+msgstr "Ungan_aki ukupotsozwa kabili kwangaphakathi:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:22
+msgid ""
+"Ignore all subsequent presses of the SAME key if they happen within a user "
+"selectable period of time."
+msgstr ""
+"Unganaki ukupotsozwa kaningi kwekinombho ngokufanayo umakwenzeka "
+"mgomsebenzisi okukhethwa isikhala sesikhathi."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:23
+msgid "Keyboard Accessibility Preferences (AccessX)"
+msgstr "Ukuthandeka nemvume yendawo yokushaya ethandekayo (AccessX)"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:24
+msgid "Ma_ximum pointer speed:"
+msgstr "Ukushesha okuphele_le kokukhomba:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:25
+msgid "Mouse Keys"
+msgstr "Amakinombho engoso"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:26
+msgid "Mouse _Preferences..."
+msgstr "_Okuthandekayo kwengoso..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:27
+msgid ""
+"Only accept keys after they have been pressed and held for a user adjustable "
+"amount of time."
+msgstr ""
+"Vumela amankinobho kuphela emuva kokupotshozwa abanjwa ukusebenziswa "
+"ngokuhlelwa kwesikhathi."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:28
+msgid ""
+"Perform multiple simultaneous key press operations by pressing modifier keys "
+"in sequence."
+msgstr ""
+"Yenza ngokupotshoza amankonombho amaningi ukusebenzisa amankinobho "
+"okulungisa ngokohlelo."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:29
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:29
+msgid "S_peed:"
+msgstr "I_jubane:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:30
+msgid "Time to acce_lerate to maximum speed:"
+msgstr "Isikhakthi sokukhu_phula ijubane eliphezulu:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:31
+msgid "Turn the numeric keypad into a mouse control pad."
+msgstr "Khanyisela inkinombho lokubala phakathi kweqweqwe lokulawula lwengoso."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:32
+msgid "_Disable if unused for:"
+msgstr "_Cisha uma ingasebenzisiwe:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:33
+msgid "_Enable keyboard accessibility features"
+msgstr "_Nika amandla umumo wemvume yendawo yokushaya"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:34
+msgid "_Import Feature Settings..."
+msgstr "_Ngenisa okuvela ngaphandle kwehlelo lomumo..."
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:35
+msgid "_Only accept keys held for:"
+msgstr "_Vuma kuphela amankinombho abanjelwe lokhu:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:36
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:39
+msgid "_Type to test settings:"
+msgstr "_Bhala ukuhlola uhelo:"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:37
+msgid "_accepted"
+msgstr "_yamukelekile"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:38
+msgid "_pressed"
+msgstr "_ipotshoziwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:39
+msgid "_rejected"
+msgstr "_yaliwe"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:40
+msgid "characters/second"
+msgstr "imibhalo/umzuzwana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:41
+msgid "milliseconds"
+msgstr "imizuzwana"
+
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:42
+msgid "pixels/second"
+msgstr "amachaphaza/umzuzu"
+
+#. set the timeout value  label with correct value of timeout
+#: ../capplets/accessibility/keyboard/gnome-accessibility-keyboard-properties.glade.h:43
+#: ../capplets/mouse/gnome-mouse-properties.c:138
+#: ../capplets/mouse/gnome-mouse-properties.c:885
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:27
+#: ../capplets/windows/gnome-window-properties.glade.h:10
+msgid "seconds"
+msgstr "imizuzwana"
+
+#: ../capplets/background/background.desktop.in.in.h:1
+msgid "Change your Desktop Background settings"
+msgstr "Shintsha uhlelo lwesizinda sesiga-nyezi sakho"
+
+#: ../capplets/background/background.desktop.in.in.h:2
+msgid "Desktop Background"
+msgstr "Isizinda sesiganyezi"
+
+#: ../capplets/background/gnome-background-properties.glade.h:1
+msgid "<b>Desktop _Wallpaper</b>"
+msgstr "<b>_Iphepha elihlotsisiwe lwesizinda sesiga-nyezi</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:2
+msgid "<b>_Desktop Colors</b>"
+msgstr "<b>Imibala yobuso be _Siga-nyezi</b>"
+
+#: ../capplets/background/gnome-background-properties.glade.h:3
+msgid "Desktop Background Preferences"
+msgstr "Isizinda sesiga-nyezi esithandekayo"
+
+#: ../capplets/background/gnome-background-properties.glade.h:4
+msgid "Open a dialog to specify the color"
+msgstr ""
+
+#: ../capplets/background/gnome-background-properties.glade.h:5
+msgid "_Add Wallpaper"
+msgstr "_Faka iphepha elihlotshisiweyo"
+
+#: ../capplets/background/gnome-background-properties.glade.h:6
+msgid "_Style:"
+msgstr "_Inhlobo:"
+
+#: ../capplets/background/gnome-wp-capplet.c:74
+#: ../capplets/common/capplet-util.c:340
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:333
+#, c-format
+msgid "There was an error displaying help: %s"
+msgstr "Kube khona iphutha elibonisa usizo: %s"
+
+#: ../capplets/background/gnome-wp-capplet.c:1042
+#: ../capplets/background/gnome-wp-capplet.c:1060
+msgid "Centered"
+msgstr "Ngaphakathi"
+
+#: ../capplets/background/gnome-wp-capplet.c:1068
+#: ../capplets/background/gnome-wp-capplet.c:1085
+msgid "Fill Screen"
+msgstr "Gcwalisa ubuso besiga-nyezi"
+
+#: ../capplets/background/gnome-wp-capplet.c:1093
+#: ../capplets/background/gnome-wp-capplet.c:1110
+msgid "Scaled"
+msgstr "Ilinganisiwe"
+
+#: ../capplets/background/gnome-wp-capplet.c:1118
+#: ../capplets/background/gnome-wp-capplet.c:1135
+msgid "Tiled"
+msgstr "Ihlotshisiwe"
+
+#: ../capplets/background/gnome-wp-capplet.c:1159
+#: ../capplets/background/gnome-wp-capplet.c:1168
+msgid "Solid Color"
+msgstr "Umbala ongenelele"
+
+#: ../capplets/background/gnome-wp-capplet.c:1176
+#: ../capplets/background/gnome-wp-capplet.c:1185
+msgid "Horizontal Gradient"
+msgstr "Ubukhulu bokukhuphuka obuqondile buthe ndindilizi"
+
+#: ../capplets/background/gnome-wp-capplet.c:1193
+#: ../capplets/background/gnome-wp-capplet.c:1202
+msgid "Vertical Gradient"
+msgstr "Ubukhulu bokukhuphuka obuqondile buthe ndindilizi obumile"
+
+#. Create the file chooser dialog stuff here
+#: ../capplets/background/gnome-wp-capplet.c:1251
+msgid "Add Wallpaper"
+msgstr "Faka iphepha elihlotsisiwe"
+
+#: ../capplets/background/gnome-wp-info.c:57
+msgid "No Wallpaper"
+msgstr "Alikho iphepha elihlotshisiwe"
+
+#: ../capplets/background/gnome-wp-item.c:292
+#: ../capplets/background/gnome-wp-item.c:294
+msgid "pixel"
+msgid_plural "pixels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../capplets/common/activate-settings-daemon.c:18
+msgid ""
+"Unable to start the settings manager 'gnome-settings-daemon'.\n"
+"Without the GNOME settings manager running, some preferences may not take "
+"effect. This could indicate a problem with Bonobo, or a non-GNOME (e.g. KDE) "
+"settings manager may already be active and conflicting with the GNOME "
+"settings manager."
+msgstr ""
+"Ihlulekile ukuqala umphathi hlelo 'gnome-settings-daemon'.\n"
+"Ngaphandle kohlelo lomphathi weGNOME esebenza, ezinye ezithandekayo ngekhe "
+"zisebenze. Lokhu kungaveza inkinga nge bonobo, noma i-GNOME engekho "
+"(isibonelo KDE) umphathi wohlelo angahle sekaya sebenza abuye aphikisane "
+"nomphathi hlelo weGNOME."
+
+#: ../capplets/common/capplet-stock-icons.c:94
+#, c-format
+msgid "Unable to load capplet stock icon '%s'\n"
+msgstr "Ihlulekile ukufaka uphawu capplet stock '%s'\n"
+
+#: ../capplets/common/capplet-util.c:239 ../capplets/common/capplet-util.c:241
+msgid "Just apply settings and quit"
+msgstr "Faka uhlelo uphume"
+
+#: ../capplets/common/capplet-util.c:243
+#: ../capplets/default-applications/gnome-default-applications-properties.c:765
+#: ../capplets/keyboard/gnome-keyboard-properties.c:225
+#: ../capplets/mouse/gnome-mouse-properties.c:1021
+#: ../capplets/sound/sound-properties-capplet.c:244
+msgid "Retrieve and store legacy settings"
+msgstr "Buyisa futhi ugcine uhlelo lobucebi"
+
+#: ../capplets/common/file-transfer-dialog.c:94
+#, c-format
+msgid "Copying file: %i of %i"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:122
+#, c-format
+msgid "Copying '%s'"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:193
+msgid "From URI"
+msgstr "Iphuma URI"
+
+#: ../capplets/common/file-transfer-dialog.c:194
+msgid "URI currently transferring from"
+msgstr "Okwamanje URI idlulisela okuphuma"
+
+#: ../capplets/common/file-transfer-dialog.c:201
+msgid "To URI"
+msgstr "Iya URI"
+
+#: ../capplets/common/file-transfer-dialog.c:202
+msgid "URI currently transferring to"
+msgstr "URI okwamanje edlulisela ku"
+
+#: ../capplets/common/file-transfer-dialog.c:209
+msgid "Fraction completed"
+msgstr "Isigamu sesibalo siqhediwe"
+
+#: ../capplets/common/file-transfer-dialog.c:210
+msgid "Fraction of transfer currently completed"
+msgstr "Ukudluliselwa kwesigamu sesibalo kuqediwe"
+
+#: ../capplets/common/file-transfer-dialog.c:217
+msgid "Current URI index"
+msgstr "Inkomba yamanje ye URI"
+
+#: ../capplets/common/file-transfer-dialog.c:218
+msgid "Current URI index - starts from 1"
+msgstr "Inkomba yamanje ye URI - iqala ku 1"
+
+#: ../capplets/common/file-transfer-dialog.c:225
+msgid "Total URIs"
+msgstr "URIs eziphelele"
+
+#: ../capplets/common/file-transfer-dialog.c:226
+msgid "Total number of URIs"
+msgstr "Inani eliphelele le URIs"
+
+#: ../capplets/common/file-transfer-dialog.c:327
+#: ../capplets/common/file-transfer-dialog.c:369
+msgid "Copying files"
+msgstr ""
+
+#: ../capplets/common/file-transfer-dialog.c:345
+#, fuzzy
+msgid "From:"
+msgstr "Iphuma: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:349
+#, fuzzy
+msgid "To:"
+msgstr "Iya: %s"
+
+#: ../capplets/common/file-transfer-dialog.c:448
+msgid "Connecting..."
+msgstr "Isaxhumana..."
+
+#: ../capplets/common/gconf-property-editor.c:170
+msgid "Key"
+msgstr "Inkinombho"
+
+#: ../capplets/common/gconf-property-editor.c:171
+msgid "GConf key to which this property editor is attached"
+msgstr "Inkinombo Gconf lapho lesisakhi sokuhlela sinamatheliswe khona"
+
+#: ../capplets/common/gconf-property-editor.c:177
+msgid "Callback"
+msgstr "Bizela emuva"
+
+#: ../capplets/common/gconf-property-editor.c:178
+msgid "Issue this callback when the value associated with key gets changed"
+msgstr ""
+"Kipha lesisimemo sokubuyela emuva uma inani elithintekayo kumankinombho "
+"lishintshwa"
+
+#: ../capplets/common/gconf-property-editor.c:183
+msgid "Change set"
+msgstr "Shintsha uhlelo"
+
+#: ../capplets/common/gconf-property-editor.c:184
+msgid ""
+"GConf change set containing data to be forwarded to the gconf client on apply"
+msgstr ""
+"Gconf ishintsha uhlelo olukhungethe ulwazi olumelwe luthunyelwe "
+"kwikhasimende ye gconf ekuyingeniseni"
+
+#: ../capplets/common/gconf-property-editor.c:189
+msgid "Conversion to widget callback"
+msgstr "Ukuguqulwa kwewidget ebizela emuva"
+
+#: ../capplets/common/gconf-property-editor.c:190
+msgid ""
+"Callback to be issued when data are to be converted from GConf to the widget"
+msgstr ""
+"Isibizo sangemuva sizokhishwa uma imniningo imelwe ukushintshwa ukusuka ku "
+"Gconf ukuya kwiwidget"
+
+#: ../capplets/common/gconf-property-editor.c:195
+msgid "Conversion from widget callback"
+msgstr "Ukuguqulwa kwewidget ebizela emuva"
+
+#: ../capplets/common/gconf-property-editor.c:196
+msgid ""
+"Callback to be issued when data are to be converted to GConf from the widget"
+msgstr ""
+"Isibizo sangemuva sizokhishwa uma imniningo imelwe ukushintshwa ukusuka ku "
+"Gconf ukuya kwiwidget"
+
+#: ../capplets/common/gconf-property-editor.c:201
+msgid "UI Control"
+msgstr "Ukulawula UI"
+
+#: ../capplets/common/gconf-property-editor.c:202
+msgid "Object that controls the property (normally a widget)"
+msgstr "Into elawula leso sakha (okwejwayelekile yiwidget)"
+
+#: ../capplets/common/gconf-property-editor.c:217
+msgid "Property editor object data"
+msgstr "Umhleli wezakha into yemniningo"
+
+#: ../capplets/common/gconf-property-editor.c:218
+msgid "Custom data required by the specific property editor"
+msgstr "Imniningo yesiko icelwa yisakha esithize somhleli"
+
+#: ../capplets/common/gconf-property-editor.c:224
+msgid "Property editor data freeing callback"
+msgstr "Umhleli wesakha ukhulula imniningo yokushaya ngasemuva"
+
+#: ../capplets/common/gconf-property-editor.c:225
+msgid "Callback to be issued when property editor object data is to be freed"
+msgstr ""
+"Kuzo khishwa isibizo ngasemuva uma umhleli wesakha wento yomniningo ekhululwa"
+
+#: ../capplets/common/gconf-property-editor.c:1466
+#, c-format
+msgid ""
+"Couldn't find the file '%s'.\n"
+"\n"
+"Please make sure it exists and try again, or choose a different background "
+"picture."
+msgstr ""
+"Yehlulekile ukuthola ihele '%s'.\n"
+"\n"
+"Sicela uqiniseke ukuba yikhona uphinde uzame futhi, noma khetha isithombe "
+"esehlukile sesizinda sesiga-nyezi."
+
+#: ../capplets/common/gconf-property-editor.c:1474
+#, c-format
+msgid ""
+"I don't know how to open the file '%s'.\n"
+"Perhaps it's a kind of picture that is not yet supported.\n"
+"\n"
+"Please select a different picture instead."
+msgstr ""
+"Angikwazi ukuvula ihele '%s'.\n"
+"Mhlambe yinhlobo yesithombe esingakaxhaswa.\n"
+"\n"
+"Sicela ukhethe isithombe esihlukile kunalokho."
+
+#: ../capplets/common/gconf-property-editor.c:1593
+msgid "Please select an image."
+msgstr "Sicela ukhethe isithombe."
+
+#: ../capplets/common/gconf-property-editor.c:1598
+msgid "_Select"
+msgstr "_Khetha"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:1
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:18
+msgid "Preferred Applications"
+msgstr "Izithobo ezithandekayo"
+
+#: ../capplets/default-applications/default-applications.desktop.in.in.h:2
+msgid "Select your default applications"
+msgstr "Khetha izithobo zakho ezinephutha"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:9
+#, fuzzy
+msgid "Debian Sensible Browser"
+msgstr "Isiyaluzi solwembu esinephutha"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:10
+msgid "Epiphany"
+msgstr "Epiphany"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:11
+msgid "Galeon"
+msgstr "Galeon"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:12
+msgid "Encompass"
+msgstr "Encompass"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:13
+#, fuzzy
+msgid "Firebird"
+msgstr "Firebird/FireFox"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:14
+msgid "Firefox"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:15
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:16
+#, fuzzy
+msgid "Mozilla"
+msgstr "Umyalezo we Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:17
+msgid "Netscape Communicator"
+msgstr "Umxhumanisi we Netscape"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:18
+msgid "Konqueror"
+msgstr "Konqueror"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:19
+msgid "W3M Text Browser"
+msgstr "W3M Isiyaluzi setekisi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:20
+msgid "Lynx Text Browser"
+msgstr "Lynx Isiyaluzi setekisi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:21
+msgid "Links Text Browser"
+msgstr "Links Isiyaluzi setekisi"
+
+#. The code in gnome-default-applications-properties.c makes sure
+#. * there is only one (the first entry in this list) Evolution entry
+#. * in the list shown to the user
+#.
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:36
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:37
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:38
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:39
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:40
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:41
+msgid "Evolution Mail Reader"
+msgstr "Umfundi miyalezo we-Evolution"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:42
+msgid "Balsa"
+msgstr "Balsa"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:43
+msgid "KMail"
+msgstr "Kmail"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:44
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:45
+msgid "Thunderbird"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:46
+msgid "Mozilla Mail"
+msgstr "Umyalezo we Mozilla"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:47
+msgid "Mutt"
+msgstr "Mutt"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:58
+#, fuzzy
+msgid "Debian Terminal Emulator"
+msgstr "Isixhumanisi esinephutha"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:59
+#, fuzzy
+msgid "GNOME Terminal"
+msgstr "Isixhumanisi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:60
+msgid "Standard XTerminal"
+msgstr "Isixhumi X esejwayekile"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:61
+msgid "NXterm"
+msgstr "Nxterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:62
+msgid "RXVT"
+msgstr "RXVT"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:63
+#, fuzzy
+msgid "aterm"
+msgstr "Nxterm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties-structs.c:64
+msgid "ETerm"
+msgstr "ETerm"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.c:123
+msgid "Please specify a name and a command for this editor."
+msgstr "Sicela uchaze igama nomyalo walombhali."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:2
+msgid "Add..."
+msgstr "Hlanganisa..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:3
+#, fuzzy
+msgid "C_ustom"
+msgstr "Isiko"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:4
+#, fuzzy
+msgid "C_ustom:"
+msgstr "Isiko"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:5
+msgid "Can open _URIs"
+msgstr ""
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:6
+#, fuzzy
+msgid "Can open multiple _files"
+msgstr "Lesisithobo singavula ohele _abaningi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:7
+msgid "Co_mmand:"
+msgstr "Umy_alo:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:8
+msgid "Custom Editor Properties"
+msgstr "Izakhi zomhleli zesiko"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:9
+msgid "Default Mail Reader"
+msgstr "Umfundi miyalezo onephutha"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:10
+msgid "Default Terminal"
+msgstr "Isixhumanisi esinephutha"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:11
+msgid "Default Text Editor"
+msgstr "Umhleli wetekisi onephutha"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:12
+msgid "Default Web Browser"
+msgstr "Isiyaluzi solwembu esinephutha"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:13
+msgid "Default Window Manager"
+msgstr "Umphathi wefasitela onephutha"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:14
+msgid "Delete"
+msgstr "Susa"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:15
+msgid "E_xec Flag:"
+msgstr "E_exc iflagi:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:16
+msgid "Edit..."
+msgstr "Hlela..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:17
+msgid "Mail Reader"
+msgstr "Umfundi milayezo"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:19
+#, fuzzy
+msgid "Run in a _terminal"
+msgstr "Hambisa phakathi koku_xhuma"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:20
+#, fuzzy
+msgid "Run in a t_erminal"
+msgstr "Hambisa phakathi koku_xhuma"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:21
+msgid ""
+"Select the window manager you want.  You will need to hit apply, wave the "
+"magic wand, and do a magic dance for it to work."
+msgstr ""
+"Khetha umphathi wefasitela omfunayo. Kumele ushaye usebenzisa, uthinte "
+"iwandi elizenzekelayo, ubuye wenze umdanso ukuze isebenze."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:22
+msgid "Terminal"
+msgstr "Isixhumanisi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:23
+msgid "Text Editor"
+msgstr "Uhele wetekisi"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:24
+msgid "Understands _Netscape Remote Control"
+msgstr "Yiqonda ukulawulwa ngongesi yi _Netscape"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:25
+msgid "Use this _editor to open text files in the file manager"
+msgstr "Sebenzisa lo_mhleli ukuvula ihele letekisi phakathi komphathi wehele"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:26
+msgid "Web Browser"
+msgstr "Isiyaluzi solwembu"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:27
+msgid "Window Manager"
+msgstr "Umphathi wefasitela"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:28
+#, fuzzy
+msgid "_Command:"
+msgstr "Umy_alo:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:29
+msgid "_Name:"
+msgstr "_Igama:"
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:30
+msgid "_Properties..."
+msgstr "_Izakhi..."
+
+#: ../capplets/default-applications/gnome-default-applications-properties.glade.h:31
+#, fuzzy
+msgid "_Select:"
+msgstr "_Khetha"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:1
+msgid "Change screen resolution"
+msgstr "Shintsa isinqumo sobuso besiga-nyezi"
+
+#: ../capplets/display/display-properties.desktop.in.in.h:2
+msgid "Screen Resolution"
+msgstr "Isinqumo sobuso besiga-nyezi"
+
+#: ../capplets/display/main.c:345
+#, c-format
+msgid "%d Hz"
+msgstr "%d Hz"
+
+#: ../capplets/display/main.c:448
+msgid "_Resolution:"
+msgstr "_Isinqumo:"
+
+#: ../capplets/display/main.c:467
+msgid "Re_fresh rate:"
+msgstr "Ijubane eliphinde kabu_sha:"
+
+#: ../capplets/display/main.c:488
+msgid "Default Settings"
+msgstr "Izinhlelo ezinephutha"
+
+#: ../capplets/display/main.c:490
+#, c-format
+msgid "Screen %d Settings\n"
+msgstr "Ubuso besiga-nyezi %d Izinhlelo\n"
+
+#: ../capplets/display/main.c:516
+msgid "Screen Resolution Preferences"
+msgstr "Isinqumo esithandekayo sobuso besiga-nyezi"
+
+#: ../capplets/display/main.c:553
+#, c-format
+msgid "_Make default for this computer (%s) only"
+msgstr "_Yenza iphutha lwesiga-nyezi (%s) kuphela"
+
+#: ../capplets/display/main.c:571
+msgid "Options"
+msgstr "Ukhetho"
+
+#: ../capplets/display/main.c:592
+#, c-format
+msgid ""
+"Testing the new settings. If you don't respond in %d second the previous "
+"settings will be restored."
+msgid_plural ""
+"Testing the new settings. If you don't respond in %d seconds the previous "
+"settings will be restored."
+msgstr[0] ""
+"Ukuhlolwa kwezinhlelo ezintsha. Uma ungaphendule %d emzuzwaneni izinhlelo "
+"ezidlulile zizophindwa zibuyiswe."
+msgstr[1] ""
+"Ukuhlolwa kwezinhlelo ezintsha. Uma ungaphendule %d emizuzwaneni izinhlelo "
+"ezidlulile zizophindwa zibuyiswe."
+
+#: ../capplets/display/main.c:638
+msgid "Keep Resolution"
+msgstr "Gcina isinqumo"
+
+#: ../capplets/display/main.c:642
+msgid "Do you want to keep this resolution?"
+msgstr "Ufuna ukugcina lesisinqumo?"
+
+#: ../capplets/display/main.c:667
+msgid "Use _previous resolution"
+msgstr "Sebenzisa isinqumo _esidlulile"
+
+#: ../capplets/display/main.c:667
+msgid "_Keep resolution"
+msgstr "_Gcina isinqumo"
+
+#: ../capplets/display/main.c:818
+msgid ""
+"The X Server does not support the XRandR extension.  Runtime resolution "
+"changes to the display size are not available."
+msgstr ""
+"Isisebenzi X asixhasi XRandR yangaphandle. Isikhathi sokusebenza sesinqumo "
+"sishintsha isilinganiso somboniso azitholakali."
+
+#: ../capplets/display/main.c:826
+msgid ""
+"The version of the XRandR extension is incompatible with this program. "
+"Runtime changes to the display size are not available."
+msgstr ""
+"Ukulandisa kwe XRandR yangaphandle akusebenzi kuloluhlelo. Isikhathi "
+"sokusebenza sishintsha isilinganiso sokubonisa azitholakali."
+
+#: ../capplets/font/font-properties.desktop.in.in.h:1
+msgid "Font"
+msgstr "Isiqwema"
+
+#: ../capplets/font/font-properties.desktop.in.in.h:2
+msgid "Select fonts for the desktop"
+msgstr "Khetha isiqwema sesiga-nyezi"
+
+#: ../capplets/font/font-properties.glade.h:2
+msgid "<b>Font Rendering</b>"
+msgstr "<b>Ukutyelekana isiqwema</b>"
+
+#: ../capplets/font/font-properties.glade.h:3
+msgid "<b>Hinting</b>:"
+msgstr "<b>Isexwayiso</b>:"
+
+#: ../capplets/font/font-properties.glade.h:4
+msgid "<b>Smoothing</b>:"
+msgstr "<b>Bushelezi</b>:"
+
+#: ../capplets/font/font-properties.glade.h:5
+msgid "<b>Subpixel order</b>:"
+msgstr "<b>Umyalo wechashazana</b>:"
+
+#: ../capplets/font/font-properties.glade.h:6
+msgid "Best _shapes"
+msgstr "_Isimo esibalasele"
+
+#: ../capplets/font/font-properties.glade.h:7
+msgid "Best co_ntrast"
+msgstr "Ukukha_nya okubalasele"
+
+#: ../capplets/font/font-properties.glade.h:8
+msgid "D_etails..."
+msgstr "Im_niningwane..."
+
+#: ../capplets/font/font-properties.glade.h:9
+msgid "Font Preferences"
+msgstr "Isiqwema esithandekayo"
+
+#: ../capplets/font/font-properties.glade.h:10
+msgid "Font Rendering Details"
+msgstr "Imininingwane yokutyelekana isiqwema"
+
+#: ../capplets/font/font-properties.glade.h:11
+msgid "Go _to font folder"
+msgstr "Hamba _kwi sibaya sesiqwema"
+
+#: ../capplets/font/font-properties.glade.h:12
+msgid "Gra_yscale"
+msgstr "Isilinganiso esi_gray"
+
+#: ../capplets/font/font-properties.glade.h:13
+msgid "N_one"
+msgstr "L_utho"
+
+#: ../capplets/font/font-properties.glade.h:14
+msgid "R_esolution:"
+msgstr "I_siqumo:"
+
+#: ../capplets/font/font-properties.glade.h:15
+msgid "Sub_pixel (LCDs)"
+msgstr "Ama_chashazana (LCDs)"
+
+#: ../capplets/font/font-properties.glade.h:16
+msgid "Sub_pixel smoothing (LCDs)"
+msgstr "Ukushelela kwama_chashazana (LCDs)"
+
+#: ../capplets/font/font-properties.glade.h:17
+msgid "VB_GR"
+msgstr "VB_GR"
+
+#: ../capplets/font/font-properties.glade.h:18
+msgid "_Application font:"
+msgstr "Isiqwema _sesithobo:"
+
+#: ../capplets/font/font-properties.glade.h:19
+msgid "_BGR"
+msgstr "_BGR"
+
+#: ../capplets/font/font-properties.glade.h:20
+msgid "_Desktop font:"
+msgstr "_Isiqwema sesiga-nyezi:"
+
+#: ../capplets/font/font-properties.glade.h:21
+msgid "_Full"
+msgstr "_Igcwele"
+
+#: ../capplets/font/font-properties.glade.h:22
+msgid "_Medium"
+msgstr "_Iphakathi"
+
+#: ../capplets/font/font-properties.glade.h:23
+msgid "_Monochrome"
+msgstr "_Isiqalo esiphathele sodwa"
+
+#: ../capplets/font/font-properties.glade.h:24
+msgid "_None"
+msgstr "_Lutho"
+
+#: ../capplets/font/font-properties.glade.h:25
+msgid "_RGB"
+msgstr "_RGB"
+
+#: ../capplets/font/font-properties.glade.h:26
+msgid "_Slight"
+msgstr "_Cishe"
+
+#: ../capplets/font/font-properties.glade.h:27
+msgid "_Terminal font:"
+msgstr "_Isixhumi siqwema:"
+
+#: ../capplets/font/font-properties.glade.h:28
+msgid "_VRGB"
+msgstr "_VRGB"
+
+#: ../capplets/font/font-properties.glade.h:29
+msgid "_Window title font:"
+msgstr "_Isihloko sombhalo wefasitela:"
+
+#: ../capplets/font/font-properties.glade.h:30
+msgid "dots per inch"
+msgstr "amabala ngobude"
+
+#: ../capplets/font/main.c:488
+msgid "Font may be too large"
+msgstr "Iisqqwema singaba sikhulu kakhulu"
+
+#: ../capplets/font/main.c:492
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a size "
+"smaller than %d."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a size "
+"smaller than %d."
+msgstr[0] ""
+"Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kubelikhuni "
+"ukusebenzisa isiga-nyezi. Kuyakhuthazwa ukuba ukhethe isayizi encane kune %d."
+msgstr[1] ""
+"Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kubelikhuni "
+"ukusebenzisa isiga-nyezi. Kuyakhuthazwa ukuba ukhethe isayizi encane kune %d."
+
+#: ../capplets/font/main.c:505
+#, c-format
+msgid ""
+"The font selected is %d point large, and may make it difficult to "
+"effectively use the computer.  It is recommended that you select a smaller "
+"sized font."
+msgid_plural ""
+"The font selected is %d points large, and may make it difficult to "
+"effectively use the computer. It is recommended that you select a smaller "
+"sized font."
+msgstr[0] ""
+"Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kubelikhuni "
+"ukusebenzisa isiga-nyezi. Kuyakhuthazwa ukuba ukhethe isayizi encane."
+msgstr[1] ""
+"Isiqwema esikhethiwe si %d sikhomba kakhulu, singenza kebe likhuni "
+"ukusebenzisa isiga-nyezi. Kuya khuthazwa ukuba ukhethe isayizi encane."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:21
+msgid "New accelerator..."
+msgstr "Isigijimi esisha..."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:163
+#: ../capplets/keybindings/eggcellrendererkeys.c:164
+msgid "Accelerator key"
+msgstr "Inkinombho yesigijimi"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:173
+#: ../capplets/keybindings/eggcellrendererkeys.c:174
+msgid "Accelerator modifiers"
+msgstr "Izilungisi zesigijimi"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:182
+#: ../capplets/keybindings/eggcellrendererkeys.c:183
+msgid "Accelerator keycode"
+msgstr "Inkinombho lekhodi lesigijimi"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:193
+msgid "Accel Mode"
+msgstr "Uhlu Accel"
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:194
+msgid "The type of accelerator."
+msgstr "Uhlobo lwesigijimi."
+
+#: ../capplets/keybindings/eggcellrendererkeys.c:242
+#: ../capplets/keybindings/gnome-keybinding-properties.c:197
+#: ../libbackground/applier.c:624 ../typing-break/drwright.c:477
+msgid "Disabled"
+msgstr "Ayinamandla"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:545
+msgid "<Unknown Action>"
+msgstr "<Isenzo esingaziwa>"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:566
+msgid "Desktop"
+msgstr "Isiga-nyezi"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:567
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:2
+msgid "Sound"
+msgstr "Umsindo"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:571
+msgid "Window Management"
+msgstr "Ukuphathwa kwefasitela"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:668
+#, c-format
+msgid ""
+"The shortcut \"%s\" is already used for:\n"
+" \"%s\"\n"
+msgstr ""
+"Indlela emfishane \"%s\" sele yisebenziselwe uku:\n"
+" \"%s\"\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:700
+#, c-format
+msgid "Error setting new accelerator in configuration database: %s\n"
+msgstr "Iphutha lihlelela isigijimi esisha kumumo wokulonda: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:750
+#, c-format
+msgid "Error unsetting accelerator in configuration database: %s\n"
+msgstr "Iphutha alihleli isigijimi kumumo wokulonda: %s\n"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:857
+msgid "Action"
+msgstr "Isenzo"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.c:881
+msgid "Shortcut"
+msgstr "Ukunqamula"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:1
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:2
+msgid "Keyboard Shortcuts"
+msgstr "Izinqamulo zendawo yokushaya uma ubhala"
+
+#: ../capplets/keybindings/gnome-keybinding-properties.glade.h:2
+msgid ""
+"To edit a shortcut key, click on the corresponding row and type a new "
+"accelerator, or press backspace to clear."
+msgstr ""
+"Ukuhlela inkinombho enqamulayo, potshoza emugqeni ongale ubhale isigijimi "
+"esisha, okanye potshoza inkinombho lokubuyisela isikhala emuva ukusula."
+
+#: ../capplets/keybindings/keybinding.desktop.in.in.h:1
+msgid "Assign shortcut keys to commands"
+msgstr "Nikela iinkinombho kwimilayezo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkb.c:84
+msgid "Unknown"
+msgstr "Ayaziwa"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:273
+msgid "Layout"
+msgstr "Ukubonakala ngaphandle"
+
+#. The first radio in a group is to be "Default", meaning none of
+#. the below options are to be included in the selected list.
+#. This is a HIG-compliant alternative to allowing no
+#. selection in the group.
+#: ../capplets/keyboard/gnome-keyboard-properties-xkblt.c:277
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbot.c:228
+#, fuzzy
+msgid "Default"
+msgstr "Isikhombi esinephutha"
+
+#: ../capplets/keyboard/gnome-keyboard-properties-xkbmc.c:75
+msgid "Models"
+msgstr "Izifanekiso"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:106
+#, c-format
+msgid "There was an error launching the keyboard capplet : %s"
+msgstr ""
+"Kube khona iphutha uma kungeniswa i-capplet yendawo yokushaya uma ubhala: %s"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:202
+msgid "_Accessibility"
+msgstr "_Ukutholakala"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:221
+#: ../capplets/keyboard/gnome-keyboard-properties.c:223
+#: ../capplets/sound/sound-properties-capplet.c:240
+#: ../capplets/sound/sound-properties-capplet.c:242
+msgid ""
+"Just apply settings and quit (compatibility only; now handled by daemon)"
+msgstr "Sebenzisa uhlelo uphe (ingacinwa kuphela; manje iphethwe yi-daemon)"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.c:227
+msgid "Start the page with the typing break settings showing"
+msgstr "Qala ikhasi ngokubhala ngokunqamula ukhombisa izinhlelo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:3
+msgid "..."
+msgstr "..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:4
+msgid "<b>Cursor Blinking</b>"
+msgstr "<b>Isikhombi siyajampajampa</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:5
+msgid "<b>Repeat Keys</b>"
+msgstr "<b>Phinda amankinombho</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:6
+msgid "<b>_Lock screen to enforce typing break</b>"
+msgstr "<b>_Vala ubusos ukufaka ngenkani umbhalo onqamulayo</b>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:7
+msgid "<small><i>Fast</i></small>"
+msgstr "<small><i>Shesha</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:8
+msgid "<small><i>Long</i></small>"
+msgstr "<small><i>Inde</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:9
+msgid "<small><i>Short</i></small>"
+msgstr "<small><i>Imfisha</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:10
+msgid "<small><i>Slow</i></small>"
+msgstr "<small><i>Nwabuza</i></small>"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:11
+msgid "A_vailable layouts:"
+msgstr "Umphandle o_tholakalayo:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:12
+msgid "All_ow postponing of breaks"
+msgstr "V_umela ukubuyiselwa emuva kwezinqamuli"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:13
+msgid "Check if breaks are allowed to be postponed"
+msgstr "Qaphela ukuba izinqamuli zivunyelwe ukuhlehliswa"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:14
+#, fuzzy
+msgid "Choose A Keyboard Model"
+msgstr "Khetha isifanekiso sendawo yokushaya uma ubhala"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:15
+#, fuzzy
+msgid "Choose A Layout"
+msgstr "Vala futhi _uphume"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:16
+msgid "Cursor _blinks in text boxes and fields"
+msgstr "Isikhombi _sijampajampa phakathi kwebhokisi letekisi nemibhalo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:17
+msgid "Duration of the break when typing is disallowed"
+msgstr "Isikhathi sokunqamula uma ukubhala kungavumelekile"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:18
+msgid "Duration of work before forcing a break"
+msgstr "Isikhathi somsebenzi phambi kokufaka isinqamuli ngenkani"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:19
+msgid "Key presses _repeat when key is held down"
+msgstr "Inkinombho lipotshozwa _phinda uma lipotshozelwe phantsi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:21
+msgid "Keyboard Preferences"
+msgstr "Okuthandekayo endaweni yokushaya uma ubhala"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:22
+msgid "Keyboard _model:"
+msgstr "_Isifanekiso sendawo yokushaya uma ubhala:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:23
+msgid "Layout Options"
+msgstr "Ukhetha umumo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:24
+msgid "Layouts"
+msgstr "Umumo"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:25
+msgid ""
+"Lock screen after a certain duration to help prevent repetitive keyboard use "
+"injuries"
+msgstr ""
+"Vala ubuso besiga-nyezi emuva kwesikhathi esithile ukusiza ukuvimba "
+"ukuziphinda ukusebenzisa izingozi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:26
+msgid "Microsoft Natural Keyboard"
+msgstr "Indawo yokushaya uma ubhala yendalo ye-Microsoft"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:27
+#, fuzzy
+msgid "Preview:"
+msgstr "_Buka futhi"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:28
+#, fuzzy
+msgid "Reset To De_faults"
+msgstr "Hlela kabusha emaphu_theni"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:30
+msgid "Separate _group for each window"
+msgstr ""
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:31
+msgid "Typing Break"
+msgstr "Ukunqamula ukubhala"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:32
+msgid "_Accessibility..."
+msgstr "_Ukungenisela..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:33
+#, fuzzy
+msgid "_Add..."
+msgstr "Hlanganisa..."
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:34
+msgid "_Break interval lasts:"
+msgstr "_Umkhawulo wokugina wokunqamula:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:35
+msgid "_Delay:"
+msgstr "_Bambezela:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:36
+#, fuzzy
+msgid "_Models:"
+msgstr "_Izifanekiso"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:37
+msgid "_Selected layouts:"
+msgstr "_Umumo okhethiwe:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:38
+msgid "_Speed:"
+msgstr "_Ijubane:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:40
+msgid "_Work interval lasts:"
+msgstr "_Umsebenzi womkhawulo ekugcineni:"
+
+#: ../capplets/keyboard/gnome-keyboard-properties.glade.h:41
+msgid "minutes"
+msgstr "imizuzu"
+
+#: ../capplets/keyboard/keyboard.desktop.in.in.h:2
+msgid "Set your keyboard preferences"
+msgstr "Hlela indawo zakho ozithandayo kwindawo yokushaya uma ubhala"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:559
+msgid "Unknown Cursor"
+msgstr "Isikhombisi esingaziwa"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:761
+msgid "Default Cursor"
+msgstr "Isikhombi esinephutha"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:762
+msgid "Default Cursor - Current"
+msgstr "Isikhombi esinephutha - Manje"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:763
+msgid "The default cursor that ships with X"
+msgstr "Isikhombi esinephutha esihambisana no-X"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:767
+msgid "White Cursor"
+msgstr "Isikhombi esimhlophe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:768
+msgid "White Cursor - Current"
+msgstr "Isikhombi esimhlophe - okwamanje"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:769
+msgid "The default cursor inverted"
+msgstr "Isikhombi esinephuthat sifakiwe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:773
+msgid "Large Cursor"
+msgstr "Isikhombi esikhulu"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:774
+msgid "Large Cursor - Current"
+msgstr "Isikhombi esikhulu - okwamanje"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:775
+msgid "Large version of normal cursor"
+msgstr "Umlandiso omkhulu wesikhombi esejwayelekile"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:779
+msgid "Large White Cursor - Current"
+msgstr "Isikhombi esimhlophe esikhulu - okwamanje"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:780
+msgid "Large White Cursor"
+msgstr "Isikhombi esimhlophe esikhulu"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:781
+msgid "Large version of white cursor"
+msgstr "Umlandisi omkhulu wesikhombi esimhlophe"
+
+#: ../capplets/mouse/gnome-mouse-properties.c:975
+msgid "Cursor Theme"
+msgstr "Indikimba yesikhombi"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:2
+msgid "<b>Double-Click Timeout </b>"
+msgstr "<b>Potshoza-kabili isikhathi siphelile </b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:3
+msgid "<b>Drag and Drop</b>"
+msgstr "<b>Dontsa futhi uphontse</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:4
+msgid "<b>Locate Pointer</b>"
+msgstr "<b>Beka isikhombisi endaweni</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:5
+msgid "<b>Mouse Orientation</b>"
+msgstr "<b>Ukuhanjiswa kwesingoso</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:6
+msgid "<b>Speed</b>"
+msgstr "<b>Ijubane</b>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:7
+msgid "<i>Fast</i>"
+msgstr "<i>Shesha</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:8
+msgid "<i>High</i>"
+msgstr "<i>Phezulu</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:9
+msgid "<i>Large</i>"
+msgstr "<i>Okukhulu</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:10
+msgid "<i>Low</i>"
+msgstr "<i>Okuphantsi</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:11
+msgid "<i>Slow</i>"
+msgstr "<i>Nwazayo</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:12
+msgid "<i>Small</i>"
+msgstr "<i>Ncanel</i>"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:13
+msgid "Buttons"
+msgstr "Amankinombho"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:14
+#, fuzzy
+msgid "Cursor Size:"
+msgstr "Isayizi yesikhombi"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:15
+msgid "Cursors"
+msgstr "Izikhombi"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:16
+msgid "Highlight the _pointer when you press Ctrl"
+msgstr "Khanyisela _isikhombisi uma upotshoza Ctrl"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:17
+#, fuzzy
+msgid "Large"
+msgstr "_Okukhulu"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:18
+#, fuzzy
+msgid "Medium"
+msgstr "_Iphakathi"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:19
+msgid "Motion"
+msgstr "Intshukumo"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:20
+msgid "Mouse Preferences"
+msgstr "Okuthandekayo kwesingoso"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:21
+#, fuzzy
+msgid "Small"
+msgstr "_Okuncane"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:22
+msgid "_Acceleration:"
+msgstr "_Ukusheshisa:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:23
+msgid "_Left-handed mouse"
+msgstr "_Isingoso sesandla sasebunxele"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:24
+msgid "_Sensitivity:"
+msgstr "_Binyekile:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:25
+msgid "_Threshold:"
+msgstr "_Umnyango:"
+
+#: ../capplets/mouse/gnome-mouse-properties.glade.h:26
+msgid "_Timeout:"
+msgstr "_Isikhathi siphelile:"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:1
+msgid "Mouse"
+msgstr "Isingoso"
+
+#: ../capplets/mouse/gnome-settings-mouse.desktop.in.in.h:2
+msgid "Set your mouse preferences"
+msgstr "Hlela okuthandekayo kwesingoso"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:1
+msgid "Network Proxy"
+msgstr "Proxy yokuxhumana"
+
+#: ../capplets/network/gnome-network-preferences.desktop.in.in.h:2
+#, fuzzy
+msgid "Set your network proxy preferences"
+msgstr "Okuthandekayo kwe-proxy yokuxhumana"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:1
+msgid "      "
+msgstr "      "
+
+#: ../capplets/network/gnome-network-preferences.glade.h:2
+#, fuzzy
+msgid "<b>D_irect internet connection</b>"
+msgstr "<b>_Ukuxhumana ngqo kolwembu</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:3
+msgid "<b>Ignore Host List</b>"
+msgstr ""
+
+#: ../capplets/network/gnome-network-preferences.glade.h:4
+msgid "<b>_Automatic proxy configuration</b>"
+msgstr "<b>_Umumo wozenzakalelayo we-proxy</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:5
+msgid "<b>_Manual proxy configuration</b>"
+msgstr "<b>_Ukulungisa umumo we-proxy ngesandla</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:6
+msgid "<b>_Use authentication</b>"
+msgstr "<b>_Sebenzisa izifungo</b>"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:7
+#, fuzzy
+msgid "Advanced Configuration"
+msgstr "Ukulungisa ngokuzenzekela _URL:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:8
+msgid "Autoconfiguration _URL:"
+msgstr "Ukulungisa ngokuzenzekela _URL:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:9
+msgid "HTTP Proxy Details"
+msgstr "Imniningwane emileyo ye-HTTP"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:10
+msgid "H_TTP proxy:"
+msgstr "H_TTP ezimele:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:11
+#, fuzzy
+msgid "Network Proxy Preferences"
+msgstr "Okuthandekayo kwe-proxy yokuxhumana"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:12
+msgid "Port:"
+msgstr "Itheku:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:13
+#, fuzzy
+msgid "Proxy Configuration"
+msgstr "Ukulingasa umumo wokuxhumana okuzimele"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:14
+msgid "S_ocks host:"
+msgstr "Umhathi weso_kisi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:15
+msgid "U_sername:"
+msgstr "I_gamamsebemzi:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:16
+msgid "_Details"
+msgstr "_Imniningwane"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:17
+msgid "_FTP proxy:"
+msgstr "_FTP ezimele:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:18
+msgid "_Password:"
+msgstr "_Igama lokungena:"
+
+#: ../capplets/network/gnome-network-preferences.glade.h:19
+msgid "_Secure HTTP proxy:"
+msgstr "_Vikela i-HTTP ezimele:"
+
+#: ../capplets/sound/gnome-settings-sound.desktop.in.in.h:1
+msgid "Enable sound and associate sounds with events"
+msgstr "Nika amandla umsindo futhi ujwayeze imisindo nemicimbi"
+
+#: ../capplets/sound/sound-properties-capplet.c:271
+#: ../capplets/sound/sound-properties.glade.h:6
+msgid "Sound Preferences"
+msgstr "Imisindo ethandekayo"
+
+#: ../capplets/sound/sound-properties.glade.h:1
+msgid "E_nable sound server startup"
+msgstr "Ni_ka amandla uphathi womsindo ukuqala"
+
+#: ../capplets/sound/sound-properties.glade.h:2
+msgid "Flash _entire screen"
+msgstr "Khanyisa _bonke ubuso"
+
+#: ../capplets/sound/sound-properties.glade.h:3
+msgid "Flash _window titlebar"
+msgstr "Khanyisa _ifasitela lohlu"
+
+#: ../capplets/sound/sound-properties.glade.h:4
+msgid "General"
+msgstr "Jikelele"
+
+#: ../capplets/sound/sound-properties.glade.h:5
+msgid "Sound Events"
+msgstr "Imicimbi yomsindo"
+
+#: ../capplets/sound/sound-properties.glade.h:7
+msgid "System Bell"
+msgstr "Insimbi yohlelo"
+
+#: ../capplets/sound/sound-properties.glade.h:8
+msgid "_Sound an audible bell"
+msgstr "_Khalisa insimbi ezakalayo"
+
+#: ../capplets/sound/sound-properties.glade.h:9
+msgid "_Sounds for events"
+msgstr "_Umsindo wemicimbi"
+
+#: ../capplets/sound/sound-properties.glade.h:10
+msgid "_Visual feedback:"
+msgstr "_Impendulo ebonakalayo:"
+
+#: ../capplets/theme-switcher/gnome-theme-details.c:347
+msgid ""
+"No themes could be found on your system.  This probably means that your "
+"\"Theme Preferences\" dialog was improperly installed, or you haven't "
+"installed the \"gnome-themes\" package."
+msgstr ""
+"Azikho indikima ezitholakele kuhlelo lwakho. Mhalbe lokhu kuchaza ukuthi "
+"\"Indikima ezithandekayo\" ibhokisana lifakwe kabi, noma mhlambe awukalifaki "
+"\"gnome-themes\" umthwalo."
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:227
+msgid "This theme is not in a supported format."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:244
+msgid "Failed to create temporary directory"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:264
+msgid ""
+"Can not install theme. \n"
+"The bzip2 utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:282
+#: ../capplets/theme-switcher/gnome-theme-installer.c:319
+#: ../capplets/theme-switcher/gnome-theme-installer.c:399
+#, fuzzy
+msgid "Installation Failed"
+msgstr "Ukufakwa kwendikima"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:302
+msgid ""
+"Can not install themes. \n"
+"The gzip utility is not installed."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:340
+#, c-format
+msgid ""
+"Icon Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:343
+#, c-format
+msgid "Gnome Theme %s correctly installed"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:346
+#, c-format
+msgid ""
+"Windows Border Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:349
+#, c-format
+msgid ""
+"Controls Theme %s correctly installed.\n"
+"You can select it in the theme details."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:357
+msgid "The theme is an engine. You need to compile the theme."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:374
+#, fuzzy
+msgid "The file format is invalid"
+msgstr "Ihele %s asiyilo ihele elifanele"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:468
+msgid "No theme file location specified to install"
+msgstr "Akukho ihele lendikima elinendawo elifakiwe"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:485
+msgid "The theme file location specified to install is invalid"
+msgstr "Indikima yehele echaziwe ukuthi ifakwe ayifanele"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:505
+#, c-format
+msgid ""
+"Insufficient permissions to install the theme in:\n"
+"%s"
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:526
+#, fuzzy
+msgid "The file format is invalid."
+msgstr "Ihele %s asiyilo ihele elifanele"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:553
+#, c-format
+msgid ""
+"%s is the path where the theme files will be installed. This can not be "
+"selected as the source location"
+msgstr ""
+"%s yindlela lapho indikima zohele zizofakwa khona. Lokhu ngeke kukhethwe "
+"ngenje ndawo eyimvelo"
+
+#: ../capplets/theme-switcher/gnome-theme-installer.c:607
+msgid ""
+"Cannot install theme.\n"
+"The tar program is not installed on your system."
+msgstr ""
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "Custom theme"
+msgstr "Indikima yesiko"
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:680
+msgid "You can save this theme by pressing the Save Theme button."
+msgstr "Ungahlenga lendikima ngokupotshoza inkinombho lokuhlenga eliyindikima."
+
+#: ../capplets/theme-switcher/gnome-theme-manager.c:1476
+msgid ""
+"The default theme schemas could not be found on your system.  This means "
+"that you probably don't have metacity installed, or that your gconf is "
+"configured incorrectly."
+msgstr ""
+"Indikima eziyiphutha ezingamaqembu azitholakalanga phakathi kohlu. Lokhu "
+"kuchaza ukuthi awuna imetacity efakiwe, noma i-gconf yakho ifakwe kabi."
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:72
+msgid "Theme name must be present"
+msgstr "Igama lendikima kumele libe khona"
+
+#: ../capplets/theme-switcher/gnome-theme-save.c:104
+msgid "The theme already exists. Would you like to replace it?"
+msgstr "Indikima sele yikhona. Ingabe uthanda ukufaka enye kunale?"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:1
+msgid "Select themes for various parts of the desktop"
+msgstr "Khetha indikima zamalungu ahlukile esiga-nyezi"
+
+#: ../capplets/theme-switcher/gtk-theme-selector.desktop.in.in.h:2
+#: ../vfs-methods/themus/themus-properties-main.c:92
+msgid "Theme"
+msgstr "Indikima"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Install a Theme</span>"
+msgstr "<span size=\"larger\" weight=\"bold\">Faka indikima</span>"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:3
+msgid "Theme Installation"
+msgstr "Ukufakwa kwendikima"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:4
+msgid "_Install"
+msgstr "_Faka"
+
+#: ../capplets/theme-switcher/theme-install.glade.h:5
+msgid "_Location:"
+msgstr "_Indawo:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:2
+msgid "<span size=\"larger\" weight=\"bold\">Save Theme to Disk</span>"
+msgstr ""
+"<span size=\"larger\" weight=\"bold\">Hlenga indikima phakathi kwecwecwe</"
+"span>"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:3
+msgid "Apply _Background"
+msgstr "Sebenzisa _Isizinda"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:4
+msgid "Apply _Font"
+msgstr "Sebenzisa _Isiqwema"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:5
+msgid "Controls"
+msgstr "Abalawuli"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:6
+msgid "Icons"
+msgstr "Amaphawu"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:7
+msgid "New themes can also be installed by dragging them into the window."
+msgstr "Indikima ezinsha zinga fakwa ngokuzidontsela efasitileni."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:8
+msgid "Save Theme"
+msgstr "Hlenga indikima"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:9
+msgid "Select theme for the desktop"
+msgstr "Khetha indikima yesiga-nyezi"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:10
+msgid "Short _description:"
+msgstr "_Umlandiso omfishane:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:11
+msgid "Theme Details"
+msgstr "Imniningwane yendikima"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:12
+msgid "Theme Preferences"
+msgstr "Indikima ezithandekayo"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:13
+msgid "Theme _Details"
+msgstr "_Imniningwane yendikima"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:14
+msgid "This theme does not suggest any particular font or background."
+msgstr "Lendikima ayibonisi isiqwema esikhethekile noma isizinda."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:15
+msgid "This theme suggests a background:"
+msgstr "Lendikima ibonisa isizinda:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:16
+msgid "This theme suggests a font and a background:"
+msgstr "Lendikima ibonisa isiqwema nesizinda:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:17
+msgid "This theme suggests a font:"
+msgstr "Lendikima ibonisa isiqwqema:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:18
+msgid "Window Border"
+msgstr "Isiyaluzi Window"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:19
+msgid "_Go To Theme Folder"
+msgstr "_Hamba kwisibaya sendikimba"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:20
+msgid "_Install Theme..."
+msgstr "_Faka indikimba..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:21
+msgid "_Revert"
+msgstr "_Buyisela"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:22
+msgid "_Save Theme..."
+msgstr "_Hlenga indikimba..."
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:23
+msgid "_Theme name:"
+msgstr "_Igama lendikimba:"
+
+#: ../capplets/theme-switcher/theme-properties.glade.h:24
+msgid "theme selection tree"
+msgstr "isihlahla sokukhetha indikimba"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:1
+msgid "Customize the appearance of toolbars and menubars in applications"
+msgstr ""
+"Hlela ngokwesiko ukubonakala kwehlu lwamathuluzi nohlu phakathi kwezithobo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.desktop.in.in.h:2
+msgid "Menus & Toolbars"
+msgstr "Uhlu & amathuluzi"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:2
+msgid "<b>Behavior and Appearance</b>"
+msgstr "<b>Ukuziphatha nokubonakala</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:3
+msgid "<b>Preview</b>"
+msgstr "<b>Buka kuqala</b>"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:4
+msgid "C_ut"
+msgstr "S_ika"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:5
+msgid "Icons only"
+msgstr "Amaphawu wodwa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:6
+msgid "Menu and Toolbar Preferences"
+msgstr "Uhlu namathuluzi athandekayo"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:7
+msgid "New File"
+msgstr "Ihele elisha"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:8
+msgid "Open File"
+msgstr "Vula ihele"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:9
+msgid "Save File"
+msgstr "Hlenga ihele"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:10
+msgid "Show _icons in menus"
+msgstr "Bonisa _amaphawu phakathi kohlu"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:11
+msgid "Text below icons"
+msgstr "Itekisi ngaphantsi kwamaphawu"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:12
+msgid "Text beside icons"
+msgstr "Itekisi eceleni namaphawu"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:13
+msgid "Text only"
+msgstr "Itekisi lodwa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:14
+#, fuzzy
+msgid "Toolbar _button labels:"
+msgstr "Ilebhula _lekinombho lamathuluzi: "
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:15
+msgid "_Copy"
+msgstr "_Kopisha"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:16
+msgid "_Detachable toolbars"
+msgstr "_Amathulusi anganamatheli"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:17
+msgid "_Edit"
+msgstr "_Hlela"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:18
+msgid "_Editable menu accelerators"
+msgstr ""
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:19
+msgid "_File"
+msgstr "_Ihele"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:20
+msgid "_New"
+msgstr "_Okusha"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:21
+msgid "_Open"
+msgstr "_Vula"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:22
+msgid "_Paste"
+msgstr "_Namthelisa"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:23
+msgid "_Print"
+msgstr "_Bhala"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:24
+msgid "_Quit"
+msgstr "_Phuma"
+
+#: ../capplets/ui-properties/gnome-ui-properties.glade.h:25
+msgid "_Save"
+msgstr "_Hlenga"
+
+#: ../capplets/windows/gnome-window-properties.c:386
+#, c-format
+msgid ""
+"<b>Cannot start the preferences application for your window manager</b>\n"
+"\n"
+"%s"
+msgstr ""
+"<b>Ayikhoni ukuqala izithobo ezithandekayo zomphathi wefasitela wakho</b>\n"
+"\n"
+"%s"
+
+#: ../capplets/windows/gnome-window-properties.c:644
+msgid "Control"
+msgstr "Lawula"
+
+#: ../capplets/windows/gnome-window-properties.c:649
+msgid "Alt"
+msgstr "Alt"
+
+#: ../capplets/windows/gnome-window-properties.c:655
+msgid "Hyper"
+msgstr "Isiqalo esiphathelene nokweqisa"
+
+#: ../capplets/windows/gnome-window-properties.c:662
+msgid "Super (or \"Windows logo\")"
+msgstr "Phezulu (noma \"Windows yesihlokondaba\")"
+
+#: ../capplets/windows/gnome-window-properties.c:669
+msgid "Meta"
+msgstr "Meta"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:1
+msgid "<b>Movement Key</b>"
+msgstr "<b>Inkinombho lokuhamba</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:2
+msgid "<b>Titlebar Action</b>"
+msgstr "<b>Isenzo sesihloko sohlu</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:3
+msgid "<b>Window Selection</b>"
+msgstr "<b>Ukhetho Window</b>"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:4
+msgid "To _move a window, press-and-hold this key then grab the window:"
+msgstr ""
+"Uku_hambisa ifasitela, potshoza-ubuye-ubambe lenkinombho uphinde ubambe "
+"ifasitela:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:5
+msgid "Window Preferences"
+msgstr "Okuthadekayo kwe-Windows"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:6
+msgid "_Double-click titlebar to perform this action:"
+msgstr "_Potshoza-kabili uhlu lwesihloko ukwenza lesisenzo:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:7
+msgid "_Interval before raising:"
+msgstr "_Umkhathi phambi kokuphakama:"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:8
+msgid "_Raise selected windows after an interval"
+msgstr "_Phakamisa amafasitela akhethiwe emuva komkhawulo"
+
+#: ../capplets/windows/gnome-window-properties.glade.h:9
+msgid "_Select windows when the mouse moves over them"
+msgstr "_Khetha amafasitela uma isingoso sihamba phezu kwawo"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:1
+#, fuzzy
+msgid "Set your window properties"
+msgstr "Izakhi Windows"
+
+#: ../capplets/windows/window-properties.desktop.in.in.h:2
+msgid "Windows"
+msgstr "Windows"
+
+#: ../control-center/control-center-categories.c:257
+msgid "Others"
+msgstr "Abanye"
+
+#: ../control-center/control-center.c:42
+#, fuzzy
+msgid "Desktop Preferences"
+msgstr "Isizinda sesiga-nyezi esithandekayo"
+
+#: ../control-center/gnomecc.desktop.in.in.h:1
+msgid "GNOME Control Center"
+msgstr "GNOME umlawuli ophakathi"
+
+#: ../control-center/gnomecc.desktop.in.in.h:2
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:2
+msgid "The GNOME configuration tool"
+msgstr "Ithulusi lokumisa lwe-GNOME"
+
+#: ../gnome-settings-daemon/actions/acme.glade.h:1
+msgid "Volume"
+msgstr "Ivolumu"
+
+#: ../gnome-settings-daemon/factory.c:36
+msgid "Could not initialize Bonobo"
+msgstr "Ihlukile ukuqala u-Bonobo"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:397
+msgid "Slow Keys Alert"
+msgstr "Amankinombho angasheshi isexwayiso"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:398
+msgid ""
+"You just held down the Shift key for 8 seconds.  This is the shortcut for "
+"the Slow Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Uqeda ukubambela phantsi inkinombho Shift imizuzwana 8. Le yindlela "
+"emfishane yemniningo engasheshi yamankinombho, leyo ethinta indlela indawo "
+"yokushaya uma ubhala esebenza ngayo."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:400
+msgid "Do you want to activate Slow Keys?"
+msgstr "Ingabe ufuna ukukhanyisa amankinombho angasheshi?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:401
+msgid "Do you want to deactivate Slow Keys?"
+msgstr "Ingabe ufuna ukucisha amankinombho angasheshi?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:410
+msgid "Sticky Keys Alert"
+msgstr "Ukwexwayiswa ngamankinombho angasheshi"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:411
+msgid ""
+"You just pressed the Shift key 5 times in a row.  This is the shortcut for "
+"the Sticky Keys feature, which affects the way your keyboard works."
+msgstr ""
+"Uqeda ukupotshozela inkinombho Shift 5 emugqeni. Le yindlela emfishane "
+"yemniningo yamankinombho anamathelayo, lawo athinta indlela indawo yakho "
+"yokushaya uma ubhala esebenza ngayo."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:413
+msgid ""
+"You just pressed two keys at once, or pressed the Shift key 5 times in a "
+"row.  This turns off the Sticky Keys feature, which affects the way your "
+"keyboard works."
+msgstr ""
+"Uqeda ukupotsoza amankinombho amabili kanye, noma upotshoze inkinombho Shift "
+"izihlanhlo 5 emugqeni. Lokhu kucisha imniningwane yamankinombho "
+"anamathelayo, athintana nendlela indawo yakho yokushaya uma ubhala isebenza "
+"ngayo."
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:415
+msgid "Do you want to activate Sticky Keys?"
+msgstr "Ingabe ufuna ukukhanyisa amankinombho anamathelayo?"
+
+#: ../gnome-settings-daemon/gnome-settings-accessibility-keyboard.c:416
+msgid "Do you want to deactivate Sticky Keys?"
+msgstr "Ingabe ufuna ukucisha amankinombho anmathelayo?"
+
+#: ../gnome-settings-daemon/gnome-settings-font.c:107
+#, c-format
+msgid ""
+"Cannot create the directory \"%s\".\n"
+"This is needed to allow changing cursors."
+msgstr ""
+"Ihlulekile ukudala indlela yamakheli \"%s\".\n"
+"Lokhu kuyadingeka ukuvumela izikhombi ezishintshayo."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:209
+#, c-format
+msgid "Key Binding (%s) has its action defined multiple times\n"
+msgstr "Ukuphetha inkinombho (%s) inesenzo sayo esichaziwe kaningi\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:222
+#, c-format
+msgid "Key Binding (%s) has its binding defined multiple times\n"
+msgstr "Ukuphetha inkinombho (%s) inokuphethao kwayo okuchaziwe kaningi\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:228
+#, c-format
+msgid "Key Binding (%s) is incomplete\n"
+msgstr "Ukuphetha inkinombho (%s) ayiphelele\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:256
+#, c-format
+msgid "Key Binding (%s) is invalid\n"
+msgstr "Ukuphetha inkinombho (%s) akufanele\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:292
+#, c-format
+msgid "It seems that another application already has access to key '%d'."
+msgstr "Ikhombisa sengathi esinye isithobo sinemvume vele kwinkinombho '%d'."
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:361
+#, c-format
+msgid "Key Binding (%s) is already in use\n"
+msgstr "Ukuphetha inkinombho (%s) iyasebenziswa\n"
+
+#: ../gnome-settings-daemon/gnome-settings-keybindings.c:436
+#, c-format
+msgid ""
+"Error while trying to run (%s)\n"
+"which is linked to the key (%s)"
+msgstr ""
+"Iphutha lenzekile uma usazama ukusebenza (%s)\n"
+"elixhunyanyiswe kwisihlushulelo (%s)"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:103
+#, fuzzy, c-format
+msgid ""
+"Error activating XKB configuration.\n"
+"It can happen under various circumstances:\n"
+"- a bug in libxklavier library\n"
+"- a bug in X server (xkbcomp, xmodmap utilities)\n"
+"- X server with incompatible libxkbfile implementation\n"
+"\n"
+"X server version data:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"If you report this situation as a bug, please include:\n"
+"- The result of <b>%s</b>\n"
+"- The result of <b>%s</b>"
+msgstr ""
+"Iphutha liyakhanyiswa uma kuhlelwa isimo XKB.\n"
+"Mhalmbe ngaphakathi kwesisekeli X senkinga.\n"
+"\n"
+"imniningwane yesisekeli somhumusho:\n"
+"%s\n"
+"%d\n"
+"%s\n"
+"Uma ubika loludaba njengephutha, sicela ufake:\n"
+"- Umphumela we <b>xprop -root | grep XKB</b>\n"
+"- Umphumela we <b>gconftool-2 -R /desktop/gnome/peripherals/keyboard/xkb</b>"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:117
+#, fuzzy
+msgid ""
+"You are using XFree 4.3.0.\n"
+"There are known problems with complex XKB configurations.\n"
+"Try using a simpler configuration or taking a fresher version of XFree "
+"software."
+msgstr ""
+"Usebenzisa Xfree 4.3.0 \n"
+"Kunezinkinga ezaziwayo ngokuhlangene XKB komumo wohlelo.\n"
+"Zama ukusebenzisa umumo olula noma thatha umhumusho wamanje wesoftware "
+"yeXFree."
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:227
+#, fuzzy
+msgid "Do _not show this warning again"
+msgstr "_Unga khombisi lomyalezo futhi"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:238
+msgid ""
+"The X system keyboard settings differ from your current GNOME keyboard "
+"settings.  Which set would you like to use?"
+msgstr ""
+"Uhlelo X lwendawo yokushaya uma ubhala uhlelo luhlukile kule yamanje ye-"
+"GNOME. Ingabe ufuna ukusebenzisa uhlelo oluphi?"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:251
+msgid "Use X settings"
+msgstr "Sebenzisa uhlelo X"
+
+#: ../gnome-settings-daemon/gnome-settings-keyboard-xkb.c:253
+msgid "Use GNOME settings"
+msgstr "Sebenzisa uhleo GNOME"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:129
+#, c-format
+msgid ""
+"Couldn't execute command: %s\n"
+"Verify that this command exists."
+msgstr ""
+"Ihlulekile ukubhala umyalo: %s\n"
+"Qiniseka ukuba lomyalo usukhona."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:145
+msgid ""
+"Couldn't put the machine to sleep.\n"
+"Verify that the machine is correctly configured."
+msgstr ""
+"Ihlulekile ukulalisa umashini.\n"
+"Bhekisisa ukuba umashini uhlelwe kahle."
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:155
+#, c-format
+msgid "Permissions on the file %s are broken\n"
+msgstr "Imvume phezu kwehele %s zinqamukile\n"
+
+#: ../gnome-settings-daemon/gnome-settings-multimedia-keys.c:200
+msgid ""
+"Couldn't load the Glade file.\n"
+"Make sure that this daemon is properly installed."
+msgstr ""
+"Ihlulekile ukufaka ihele le-Glade.\n"
+"Qiniseka ukuba le-daemon ifakwe ngokufanele."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:113
+#, c-format
+msgid ""
+"There was an error starting up the screensaver:\n"
+"\n"
+"%s\n"
+"\n"
+"Screensaver functionality will not work in this session."
+msgstr ""
+"Kube khona iphutha makuqalwa isigcini sobuso besiga-nyezi:\n"
+"\n"
+"%s\n"
+"\n"
+"Ukusebenza kwesigcini sobuso besiga-nyezi ngekhe kusebenze kulesiqephu."
+
+#: ../gnome-settings-daemon/gnome-settings-screensaver.c:123
+msgid "_Do not show this message again"
+msgstr "_Unga khombisi lomyalezo futhi"
+
+#: ../gnome-settings-daemon/gnome-settings-sound.c:129
+#, c-format
+msgid "Couldn't load sound file %s as sample %s"
+msgstr "Ihlulekile ukufaka ihele lomsindo %s njenge sibonelo %s"
+
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:214
+#: ../gnome-settings-daemon/gnome-settings-xrdb.c:262
+msgid "Cannot determine user's home directory"
+msgstr "Ihlulekile ukuthola ikheli lomsebenzisi"
+
+#: ../gnome-settings-daemon/gnome-settings-xsettings.c:215
+#, c-format
+msgid "GConf key %s set to type %s but its expected type was %s\n"
+msgstr ""
+"Inkinombho GConf %s lihlelelwe ukubhala %s kepha ukubhala okulindelekile "
+"bekuyi %s\n"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:1
+#, fuzzy
+msgid "A_vailable files:"
+msgstr "Umphandle o_tholakalayo:"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:2
+#, fuzzy
+msgid "Do _not show this warning again."
+msgstr "_Unga khombisi lomyalezo futhi"
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:3
+msgid "Load modmap files"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:4
+msgid "Would you like to load the modmap file(s)?"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:5
+msgid "_Load"
+msgstr ""
+
+#: ../gnome-settings-daemon/modmap-dialog.glade.h:6
+#, fuzzy
+msgid "_Loaded files:"
+msgstr "_Izifanekiso"
+
+#: ../gnome-settings-daemon/reaper.c:103
+msgid "Error creating signal pipe."
+msgstr "Iphutha lidala ithumbu lezimpawu."
+
+#: ../libbackground/applier.c:255
+msgid "Type"
+msgstr "Uhlobo"
+
+#: ../libbackground/applier.c:256
+msgid ""
+"Type of bg_applier: BG_APPLIER_ROOT for root window or BG_APPLIER_PREVIEW "
+"for preview"
+msgstr ""
+"Uhlobo le bg_sebenzisa: BG_APPLIER_ROOT lempande yefasitela noma "
+"BG_APPLIER_PREVIEW ukubukwa kabusha"
+
+#: ../libbackground/applier.c:263
+msgid "Preview Width"
+msgstr "Bheka kabusha ububanzi"
+
+#: ../libbackground/applier.c:264
+msgid "Width if applier is a preview: Defaults to 64."
+msgstr "Dontsa kabanzi uma isisebenzisi siphinda: Amaphutha ku 64."
+
+#: ../libbackground/applier.c:271
+msgid "Preview Height"
+msgstr "Hlolisisa ubude"
+
+#: ../libbackground/applier.c:272
+msgid "Height if applier is a preview: Defaults to 48."
+msgstr "Ubude uma isesebenzisi siphinda: Amaphutha ku 48."
+
+#: ../libbackground/applier.c:279
+msgid "Screen"
+msgstr "Ubuso besiga-nyezi"
+
+#: ../libbackground/applier.c:280
+msgid "Screen on which BGApplier is to draw"
+msgstr "Ubuso besiga-nyezi lapho I-BGApllier izokhipha"
+
+#: ../libgswitchit/gswitchit_config.c:1035
+#, fuzzy, c-format
+msgid "There was an error loading an image: %s"
+msgstr "Kube khona iphutha elibonisa usizo: %s"
+
+#: ../libsounds/sound-view.c:122 ../libsounds/sound-view.c:147
+msgid "The sound file for this event does not exist."
+msgstr "Ihele lomsindo lwalomcimbi alikho sanhlobo."
+
+#: ../libsounds/sound-view.c:149
+msgid ""
+"The sound file for this event does not exist.\n"
+"You may want to install the gnome-audio package\n"
+"for a set of default sounds."
+msgstr ""
+"Ihele lomsindo lwalomcimbi alikho sanhlobo.\n"
+"Ungafuna ukufaka isisakazi-gnome somthwalo\n"
+"kumahlelo emniningwane yomsindo enephutha."
+
+#: ../libsounds/sound-view.c:224
+#, c-format
+msgid "The file %s is not a valid wav file"
+msgstr "Ihele %s asiyilo ihele elifanele"
+
+#: ../libsounds/sound-view.c:289
+msgid "Event"
+msgstr "Umcimbi"
+
+#: ../libsounds/sound-view.c:298
+msgid "Sound File"
+msgstr "Ihele lomsindo"
+
+#: ../libsounds/sound-view.c:314
+msgid "_Sounds:"
+msgstr "_Umsindo:"
+
+#: ../libsounds/sound-view.c:328
+msgid "Sound _file:"
+msgstr "Ihele _lomsindo:"
+
+#: ../libsounds/sound-view.c:332
+msgid "Select Sound File"
+msgstr "Khetha ihele lomsindo"
+
+#: ../libsounds/sound-view.c:356
+msgid "_Play"
+msgstr "_Dlala"
+
+#: ../libsounds/sound-view.c:366
+msgid "_Remove"
+msgstr "_Susa"
+
+#: ../libwindow-settings/gnome-wm-manager.c:320
+#, c-format
+msgid "Window manager \"%s\" has not registered a configuration tool\n"
+msgstr "Umphathi wefasitela \"%s\" akabhalisile ithulusi lokulungisa umumo\n"
+
+#: ../libwindow-settings/metacity-window-manager.c:378
+msgid "Maximize"
+msgstr "Khulisa"
+
+#: ../libwindow-settings/metacity-window-manager.c:379
+msgid "Roll up"
+msgstr "Yaluzisela phezulu"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:1
+msgid ""
+"If true, the mime handlers for text/plain and text/* will be kept in sync"
+msgstr ""
+"Uma kuyiqiniso, abaphathi be-mime text/plain and text/* lizogcinwa phakathi "
+"kwe-sync"
+
+#: ../schemas/apps_gnome_settings_daemon_default_editor.schemas.in.h:2
+msgid "Sync text/plain and text/* handlers"
+msgstr "Sync text/plain and text/* abaphathi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:1
+msgid "Brightness down"
+msgstr "Ukukhanya phantsi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:2
+msgid "Brightness down's shortcut."
+msgstr "Ukunqamula kokukhanya okuphantsi."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:3
+msgid "Brightness up"
+msgstr "Ukukhanya phezulu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:4
+msgid "Brightness up's shortcut."
+msgstr "Ukunqamula kokukhanya okuphezulu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:5
+msgid "E-mail"
+msgstr "Umyalezo-kagesi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:6
+msgid "E-mail's shortcut."
+msgstr "Ukunqamula komyalezo-kagesi."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:7
+msgid "Eject"
+msgstr "Khipa"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:8
+msgid "Eject's shortcut."
+msgstr "Ukunqamula kokukhipha."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:9
+msgid "Home folder"
+msgstr "Isibaya sasekhaya"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:10
+msgid "Home folder's shortcut."
+msgstr "Ukunqamula kwesibaya sasekhaya."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:11
+msgid "Launch help browser"
+msgstr "Ngenisa usizo lwesiyaluzi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:12
+msgid "Launch help browser's shortcut."
+msgstr "Ngenisa usizo lokunqamula isiyaluzi."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:13
+msgid "Launch web browser"
+msgstr "Ngenisa isiyaluzi solwembu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:14
+msgid "Launch web browser's shortcut."
+msgstr "Ngenisa ukunqamula kwesiyaluzi solwembu."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:15
+msgid "Lock screen"
+msgstr "Vala ubuso besiga-nyezi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:16
+msgid "Lock screen's shortcut."
+msgstr "Vala ukunqamula kobuso besi-nyezi."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:17
+msgid "Log out"
+msgstr "Phuma"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:18
+msgid "Log out's shortcut."
+msgstr "Phuma ngokunqamula."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:19
+msgid "Next track key's shortcut."
+msgstr "Okulandela kokunqamula kwenkinombho."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:20
+msgid "Pause"
+msgstr "Yima isikhashana"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:21
+msgid "Pause key's shortcut."
+msgstr "Inkinombho lokunqamula kokuma isikhashana."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:22
+msgid "Play (or play/pause)"
+msgstr "Dlala (noma dlala/misa isikhashana)"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:23
+msgid "Play (or play/pause) key's shortcut."
+msgstr "Dlala (noma dlala/misa isikhashana) inkinombho lokunqamula."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:24
+msgid "Previous track key's shortcut."
+msgstr "Ingoma edlulile inkinombho lokunqamula."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:25
+msgid "Search"
+msgstr "Hlola"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:26
+msgid "Search's shortcut."
+msgstr "Ukuqamula uma uhlola."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:27
+msgid "Skip to next track"
+msgstr "Dlulela engomeni elandelayo"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:28
+msgid "Skip to previous track"
+msgstr "Buyela engomeni edlulile"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:29
+msgid "Sleep"
+msgstr "Cisha"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:30
+msgid "Sleep's shortcut."
+msgstr "Ukunqamula uma ucisha."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:31
+msgid "Stop playback key"
+msgstr "Inkinombho lokunmisa ukudlala"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:32
+msgid "Stop playback key's shortcut."
+msgstr "Inkinombho lokumisa elinqamulayo."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:33
+msgid "Volume down"
+msgstr "Ivolumu ephantsi"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:34
+msgid "Volume down's shortcut."
+msgstr "Ukunqamula kwevolumu ephantsi."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:35
+msgid "Volume mute"
+msgstr "Ukucisha ivolumu okwesikhashana"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:36
+msgid "Volume mute's shortcut"
+msgstr "Ukunqamula kokucisha ivolumu okwesikhashana"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:37
+msgid "Volume step"
+msgstr "Inyathelo lwevolumu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:38
+msgid "Volume step as percentage of volume."
+msgstr "Inyathelo lwevolumu njengamaphesenti."
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:39
+msgid "Volume up"
+msgstr "Ivolumu ephezulu"
+
+#: ../schemas/apps_gnome_settings_daemon_keybindings.schemas.in.h:40
+msgid "Volume up's shortcut."
+msgstr "Ukuqamula ivolumu ephezulu."
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:1
+#, fuzzy
+msgid "Display a dialog when there are errors running the screensaver"
+msgstr "Bonisa ibhokisi uma kukho amaphutha akhona XScreenSaver"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:2
+#, fuzzy
+msgid "Run screensaver at login"
+msgstr "Sebenzisa XSreenSaver uma ungena"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:3
+msgid "Show Startup Errors"
+msgstr "Khombisa amaphutha okungena"
+
+#: ../schemas/apps_gnome_settings_daemon_screensaver.schemas.in.h:4
+#, fuzzy
+msgid "Start screensaver"
+msgstr "Qala XScreenSaver"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:1
+msgid ""
+"A collection of scripts to run whenever the keyboard state is reloaded. "
+"Useful for re-applying xmodmap based adjustments"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:2
+msgid "A list of modmap files available in the $HOME directory."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:3
+msgid "Default group, assigned on window creation"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:4
+msgid "Keep and manage separate group per window"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:5
+#, fuzzy
+msgid "Keyboard Update Handlers"
+msgstr "_Isifanekiso sendawo yokushaya uma ubhala:"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:6
+#, fuzzy
+msgid "Keyboard layout"
+msgstr "Umphandle wendawo yokushaya uma ubhala XKB"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:7
+#, fuzzy
+msgid "Keyboard model"
+msgstr "_Isifanekiso sendawo yokushaya uma ubhala:"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:8
+#, fuzzy
+msgid "Keyboard options"
+msgstr "Izinqamulo zendawo yokushaya uma ubhala"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:9
+#, fuzzy
+msgid ""
+"Keyboard settings in gconf will be overridden from the system ASAP "
+"(deprecated)"
+msgstr ""
+"Uhlelo lwe-XKB phakathi kwe-gconf lizonyatheliswa emshinini masinya ASAP"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:10
+msgid "Save/restore indicators together with layout groups"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:11
+msgid "Show layout names instead of group names"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:12
+msgid ""
+"Show layout names instead of group names (only for versions of XFree "
+"supporting multiple layouts)"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:13
+msgid "Suppress the \"X sysconfig changed\" warning message"
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:14
+msgid ""
+"Very soon, keyboard settings in gconf will be overridden (from the system "
+"configuration) This key has been deprecated since GNOME 2.12, please unset "
+"the model, layouts and options keys to get the default system configuration."
+msgstr ""
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:15
+#, fuzzy
+msgid "keyboard layout"
+msgstr "Umphandle wendawo yokushaya uma ubhala XKB"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:16
+#, fuzzy
+msgid "keyboard model"
+msgstr "Isifanekiso sendawo yokushaya uma ubhala XKB"
+
+#: ../schemas/desktop_gnome_peripherals_keyboard_xkb.schemas.in.h:17
+msgid "modmap file list"
+msgstr ""
+
+#: ../typing-break/drw-break-window.c:212
+msgid "_Postpone break"
+msgstr "_Buyisela ukunqamuka emuva"
+
+#: ../typing-break/drw-break-window.c:259
+msgid "Take a break!"
+msgstr "Thatha ikhefu"
+
+#. { N_("/_Enabled"),      NULL, GIF_CB (popup_enabled_cb),     POPUP_ITEM_ENABLED, "<ToggleItem>", NULL },
+#: ../typing-break/drwright.c:141
+msgid "/_Preferences"
+msgstr "/_Okuthandayo"
+
+#: ../typing-break/drwright.c:142
+msgid "/_About"
+msgstr "/_Nge"
+
+#: ../typing-break/drwright.c:144
+msgid "/_Take a Break"
+msgstr "/_Thatha ikhefu"
+
+#: ../typing-break/drwright.c:495
+#, c-format
+msgid "%d minute until the next break"
+msgid_plural "%d minutes until the next break"
+msgstr[0] "%d umzuzu kude kufike elinye ikhefu"
+msgstr[1] "%d imizuzu kude kufike elinye ikhefu"
+
+#: ../typing-break/drwright.c:499
+msgid "Less than one minute until the next break"
+msgstr "Ngaphantsi komzuzu kude kufike enye ikhefu"
+
+#: ../typing-break/drwright.c:587
+#, c-format
+msgid ""
+"Unable to bring up the typing break properties dialog with the following "
+"error: %s"
+msgstr ""
+"Ihlulekile ukuletha umbhalo wokunqamula nezakha zebhokisi kulokhu "
+"okulandelayo nephutha: %s"
+
+#: ../typing-break/drwright.c:635
+msgid "About GNOME Typing Monitor"
+msgstr "Ngobuso besiga-nyezi bokubhala nge-GNOME"
+
+#: ../typing-break/drwright.c:659
+msgid "A computer break reminder."
+msgstr "Isinqamulo sesiga-nyezi esikhumbuzayo."
+
+#: ../typing-break/drwright.c:660
+msgid "Written by Richard Hult &lt;richard@imendio.com&gt;"
+msgstr "Ibhalwe ngu Richard Hult &It;richard@imendio.com&gt;"
+
+#: ../typing-break/drwright.c:661
+msgid "Eye candy added by Anders Carlsson"
+msgstr "Iso lonezelela ngo Anders Carlsson"
+
+#: ../typing-break/drwright.c:837
+msgid "Break reminder"
+msgstr "Isikhumbuzi ngokunqamuka"
+
+#: ../typing-break/main.c:93
+msgid "The typing monitor is already running."
+msgstr "Ubuso besiga-nyezi bokubhala sebuyasebenza."
+
+#: ../typing-break/main.c:106
+#, fuzzy
+msgid ""
+"The typing monitor uses the notification area to display information. You "
+"don't seem to have a notification area on your panel. You can add it by "
+"right-clicking on your panel and choosing 'Add to panel', selecting "
+"'Notification area' and clicking 'Add'."
+msgstr ""
+"Ubuso besiganyezi bokubhala busebenzisa indawo yokwaziswa ukubonisa ulwazi. "
+"Kubonakala sengathi awunayo indawo yokwazisa kwihlu lakho. Unga yifaka "
+"ngokupotshoza ngakwesokudla kwihlu lakho ubuye ukhethe 'Faka kuhlu -> "
+"Isisebenziswa -> Indawo yokwaziswa'."
+
+#: ../vfs-methods/fontilus/font-view.c:115
+msgid "The quick brown fox jumps over the lazy dog. 0123456789"
+msgstr ""
+"Impungushe esheshayo embala womhlabathi yenqa phezu kwenja evilaphayo. "
+"0123456789"
+
+#: ../vfs-methods/fontilus/font-view.c:276
+msgid "Name:"
+msgstr "Igama:"
+
+#: ../vfs-methods/fontilus/font-view.c:279
+msgid "Style:"
+msgstr "Indlela:"
+
+#: ../vfs-methods/fontilus/font-view.c:289
+msgid "Type:"
+msgstr "Uhlobo:"
+
+#: ../vfs-methods/fontilus/font-view.c:295
+msgid "Size:"
+msgstr "Isayizi:"
+
+#: ../vfs-methods/fontilus/font-view.c:339
+#: ../vfs-methods/fontilus/font-view.c:352
+msgid "Version:"
+msgstr "Umlandiso:"
+
+#: ../vfs-methods/fontilus/font-view.c:343
+#: ../vfs-methods/fontilus/font-view.c:354
+msgid "Copyright:"
+msgstr "Ilungelo lombhali:"
+
+#: ../vfs-methods/fontilus/font-view.c:347
+msgid "Description:"
+msgstr "Ukulanda:"
+
+#: ../vfs-methods/fontilus/font-view.c:408
+#, c-format
+msgid "usage: %s fontfile\n"
+msgstr "ukusebenziswa: %s iqwemahele\n"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:132
+msgid "Set as Application Font"
+msgstr "Hlela njenge siqwema sesithobo"
+
+#: ../vfs-methods/fontilus/fontilus-context-menu.c:133
+#, fuzzy
+msgid "Sets the default application font"
+msgstr "Khetha izithobo zakho ezinephutha"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:1
+msgid "If set to true, then OpenType fonts will be thumbnailed."
+msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke OpenType amaqwema azogcizelelwa."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:2
+msgid "If set to true, then PCF fonts will be thumbnailed."
+msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke PCF amaqwema azogcizelelwa."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:3
+msgid "If set to true, then TrueType fonts will be thumbnailed."
+msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke TrueType amaqwema azogcizelelwa."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:4
+msgid "If set to true, then Type1 fonts will be thumbnailed."
+msgstr "Uma ihlelwe ukuba yiqiniso, ngakho ke Type1 amaqwema azogcizelelwa."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:5
+msgid ""
+"Set this key to the command used to create thumbnails for OpenType fonts."
+msgstr ""
+"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
+"OpenType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:6
+msgid "Set this key to the command used to create thumbnails for PCF fonts."
+msgstr ""
+"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-PCF."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:7
+msgid ""
+"Set this key to the command used to create thumbnails for TrueType fonts."
+msgstr ""
+"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
+"TrueType."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:8
+msgid "Set this key to the command used to create thumbnails for Type1 fonts."
+msgstr ""
+"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo zesiqwema se-"
+"Type1."
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:9
+msgid "Thumbnail command for OpenType fonts"
+msgstr "Gcizelela umyalo wesiqwema se-OpenType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:10
+msgid "Thumbnail command for PCF fonts"
+msgstr "Gcizelela umyalo wesiqwema se-PCF"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:11
+msgid "Thumbnail command for TrueType fonts"
+msgstr "Gcizelela umyalo wesiqwema se-TrueType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:12
+msgid "Thumbnail command for Type1 fonts"
+msgstr "Gcizelela umyalo wesiqwema se-Type1"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:13
+msgid "Whether to thumbnail OpenType fonts"
+msgstr "Mhlambe ukugcizelela iziqwema ze-OpenType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:14
+msgid "Whether to thumbnail PCF fonts"
+msgstr "Mhlambe ukugcizelela iziqwema ze-PCF"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:15
+msgid "Whether to thumbnail TrueType fonts"
+msgstr "Mhlambe ukugcizelela iziqwema ze-TrueType"
+
+#: ../vfs-methods/fontilus/fontilus.schemas.in.h:16
+msgid "Whether to thumbnail Type1 fonts"
+msgstr "Mhlambe ukugcizelela iziqwema ze-Type1"
+
+#: ../vfs-methods/fontilus/gnome-font-viewer.desktop.in.in.h:1
+#, fuzzy
+msgid "GNOME Font Viewer"
+msgstr "GNOME umlawuli ophakathi"
+
+#: ../vfs-methods/themus/apply-font.glade.h:2
+msgid "<span weight=\"bold\" size=\"larger\">Apply new font?</span>"
+msgstr ""
+"<span weight=\"bold\" size=\"larger\">Sebenzisa isiqwema esisha?</span>"
+
+#: ../vfs-methods/themus/apply-font.glade.h:3
+msgid "Do _not apply font"
+msgstr "Unga_sebenzisi isiqwema"
+
+#: ../vfs-methods/themus/apply-font.glade.h:4
+msgid ""
+"The theme you have selected suggests a new font. A preview of the font is "
+"shown below."
+msgstr ""
+"Indikima oyikhethile ibonisa isiqwema esisha. Ukubukwa kabusha "
+"kwalesosiqwema sibonisiwe ngezantsi."
+
+#: ../vfs-methods/themus/apply-font.glade.h:5
+msgid "_Apply font"
+msgstr "_Sebenzisa isiqwema"
+
+#: ../vfs-methods/themus/theme-method.c:520
+msgid "Themes"
+msgstr "Iindikima"
+
+#: ../vfs-methods/themus/themus-properties-view.c:126
+msgid "Description"
+msgstr "Ukulanda"
+
+#: ../vfs-methods/themus/themus-properties-view.c:133
+msgid "Control theme"
+msgstr "Lawula indikima"
+
+#: ../vfs-methods/themus/themus-properties-view.c:139
+msgid "Window border theme"
+msgstr "Indikima ehlulayo yefasitela"
+
+#: ../vfs-methods/themus/themus-properties-view.c:145
+msgid "Icon theme"
+msgstr "Indikima yophawu"
+
+#. translators: you may want to include non-western chars here
+#: ../vfs-methods/themus/themus-theme-applier.c:78
+msgid "ABCDEFG"
+msgstr "ABCDEFG"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:1
+#, fuzzy
+msgid "Apply theme"
+msgstr "_Sebenzisa isiqwema"
+
+#: ../vfs-methods/themus/themus-theme-applier.desktop.in.in.h:2
+#, fuzzy
+msgid "Sets the default theme"
+msgstr "Hlela kabusha emaphu_theni"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:1
+msgid "If set to true, then installed themes will be thumbnailed."
+msgstr "Uma ihlelelwe iqiniso, manje indikima ezifakiwe zizogcizelelwa."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:2
+msgid "If set to true, then themes will be thumbnailed."
+msgstr "Uma ihlelelwe iqiniso, manje indikima zizogcizelelwa."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:3
+msgid ""
+"Set this key to the command used to create thumbnails for installed themes."
+msgstr ""
+"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo kwindikima "
+"ezifakiwe."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:4
+msgid "Set this key to the command used to create thumbnails for themes."
+msgstr ""
+"Hlela lenkinombho kumyalo osebenzisiwe ukudala izigcizelelo kwindikima."
+
+#: ../vfs-methods/themus/themus.schemas.in.h:5
+msgid "Thumbnail command for installed themes"
+msgstr "Umyalo wokugcizelela wendikima ezifakiwe"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:6
+msgid "Thumbnail command for themes"
+msgstr "Umyalo wokugcizelela wendikima"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:7
+msgid "Whether to thumbnail installed themes"
+msgstr "Ngabe uzogcizelela izihloko ngesithupha ezifakiwe"
+
+#: ../vfs-methods/themus/themus.schemas.in.h:8
+msgid "Whether to thumbnail themes"
+msgstr "Ngabe uzogcizelela izihloko ngesithupha"


### PR DESCRIPTION
## Changes

- Add our patched components to `POTFILES.in`.
- Imported recent translations from upstream.
- Created a POT file from PO using the command `xgettext --files-from=po/POTFILES.in -o po/gnome-control-center.po`.
- Updated each PO file manually using the command `msgmerge <locale>.po gnome-control-center.pot --update` _(Note: Locale is a placeholder here.)_
- Original translations from upstream are archived in backup po files (i.e `ta.po~`) which were generated by`msgmerge` automatically. (This will be helpful for reference of original translations in future as we use weblate). [It can be removed if not required]

Signed-off-by: K.B.Dharun Krishna <kbdharunkrishna@gmail.com>